### PR TITLE
set proper start of the stack in thread_stack_init for arm_common

### DIFF
--- a/cpu/arm_common/arm_cpu.c
+++ b/cpu/arm_common/arm_cpu.c
@@ -45,7 +45,7 @@ char * thread_stack_init(void * task_func, void * stack_start, int stack_size)
     *stk = (unsigned int)sched_task_exit;       // LR
 
    stk--;
-   *stk = (unsigned int) stack_start - 4;   // SP
+   *stk = (unsigned int) stack_start + stack_size - 4;   // SP
 
    for (int i = 12; i>= 0 ; i--) {          // build base stack
        stk--;


### PR DESCRIPTION
7cef6c4 did not update all uses of stack_start, creating a bug where stk\* is actually set to the end of the stack instead of the beginning after initialization.
