### PR TITLE
migrate native to current Makefile structure

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -38,6 +38,9 @@ ifeq ($(BOARD),msb-430h)
  INCLUDES += -I$(RIOTBOARD)/msb-430-common/include/
  INCLUDES += -I$(RIOTBOARD)/msb-430-common/drivers/include/
 endif
+ifeq ($(BOARD),native)
+ INCLUDES += -I$(RIOTBOARD)/native/include/
+endif
 
 $(BINDIR)$(MODULE).a: $(OBJ) $(ASMOBJ)
 	$(AR) -rc $(BINDIR)$(MODULE).a $(OBJ) $(ASMOBJ)

--- a/Makefile.include
+++ b/Makefile.include
@@ -18,7 +18,7 @@ all: $(PROJBINDIR)/$(PROJECT).a
 	@echo "Building project $(PROJECT) for $(BOARD) w/ MCU $(CPU)."
 	$(MAKE) -C $(RIOTBOARD)
 	$(MAKE) -C $(RIOTBASE)
-	$(LINK) $(LINKFLAGS) $(UNDEF) -o $(PROJBINDIR)/$(PROJECT).elf -Wl,--start-group $(BASELIBS) -lm -Wl,--end-group  -Wl,-Map=$(PROJBINDIR)/$(PROJECT).map
+	$(LINK) $(UNDEF) -o $(PROJBINDIR)/$(PROJECT).elf -Wl,--start-group $(BASELIBS) -lm -Wl,--end-group  -Wl,-Map=$(PROJBINDIR)/$(PROJECT).map $(LINKFLAGS) 
 	$(SIZE) $(PROJBINDIR)/$(PROJECT).elf
 	$(OBJCOPY) -O ihex $(PROJBINDIR)/$(PROJECT).elf $(PROJBINDIR)/$(PROJECT).hex
 

--- a/Makefile.modules
+++ b/Makefile.modules
@@ -13,6 +13,9 @@ ifeq ($(CPU),lpc214x)
   USEMODULE += arm_common
   UNDEF += $(BINDIR)syscalls.o
 endif
+ifeq ($(CPU),native)
+  export INCLUDES += -I$(RIOTBASE)/cpu/native/include
+endif
 ifeq ($(CPU),cc430)
 USEMODULE += cpu core lib sys
 else


### PR DESCRIPTION
Also reorders linker options because gcc needs -lrt later in the option list for it to work on some systems (at least in ubuntu 12.04). Please review this change for compliance with other options/targets needs and change if needed.
