### PR TITLE
Use rm -rf instead of rmdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all:
 clean:
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
 	-@if [ -d $(BINDIR) ] ; \
-	then rmdir $(BINDIR) ; \
+	then rm -rf $(BINDIR) ; \
 	fi 
 
 doc:


### PR DESCRIPTION
This way make clean runs more... cleanly
- I had a lot of warnings that bin/ is not empty. This way they are avoided.
