### PR TITLE
Fix for missing include in the native cpu

### DIFF
--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -18,6 +18,7 @@
 
 // __USE_GNU for gregs[REG_EIP] access
 #define __USE_GNU
+#include <ucontext.h>
 #include <signal.h>
 #undef __USE_GNU
 


### PR DESCRIPTION
included missing ucontext.h inside of __USE_GNU, needed for defines such as REG_EIP
