### PR TITLE
Remove undefined variables from Makefiles

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -18,8 +18,8 @@ $(BINDIR)$(MODULE).a: $(OBJ) $(ASMOBJ)
 
 # compile and generate dependency info
 $(BINDIR)%.o: %.c
-	@$(CC) $(CFLAGS) $(PROJECTINCLUDE) $(BOARDINCLUDE) $(INCLUDES) -c $*.c -o $(BINDIR)$*.o
-	@$(CC) $(CFLAGS) $(PROJECTINCLUDE) $(BOARDINCLUDE) $(INCLUDES) -MM $*.c > $(BINDIR)$*.d
+	@$(CC) $(CFLAGS) $(INCLUDES) -c $*.c -o $(BINDIR)$*.o
+	@$(CC) $(CFLAGS) $(INCLUDES) -MM $*.c > $(BINDIR)$*.d
 	@printf "$(BINDIR)"|cat - $(BINDIR)$*.d > /tmp/riot_out && mv /tmp/riot_out $(BINDIR)$*.d
 
 $(BINDIR)%.o: %.s

--- a/Makefile.include
+++ b/Makefile.include
@@ -70,7 +70,7 @@ ${PROJBINDIR}/$(PROJECT).a:  $(OBJ)
 
 ${PROJBINDIR}/%.o: %.c
 	@echo; echo "Compiling.... $*.c"; echo
-	$(CC) $(CFLAGS) $(BOARDINCLUDE) $(INCLUDES) -c $*.c -o bin/$*.o
+	$(CC) $(CFLAGS) $(INCLUDES) -c $*.c -o bin/$*.o
 
 clean:
 	$(MAKE) -C $(RIOTBOARD) clean

--- a/cpu/lpc214x/Makefile
+++ b/cpu/lpc214x/Makefile
@@ -19,8 +19,8 @@ endif
 
 # compile and generate dependency info
 ../bin/%.o: %.c
-	$(CC) $(CFLAGS) $(INCLUDES) $(BOARDINCLUDE) $(PROJECTINCLUDE) $(CPUINCLUDE) -c $*.c -o ../bin/$*.o
-	$(CC) $(CFLAGS) $(INCLUDES) $(BOARDINCLUDE) $(PROJECTINCLUDE) $(CPUINCLUDE) -MM $*.c > ../bin/$*.d
+	$(CC) $(CFLAGS) $(INCLUDES) $(CPUINCLUDE) -c $*.c -o ../bin/$*.o
+	$(CC) $(CFLAGS) $(INCLUDES) $(CPUINCLUDE) -MM $*.c > ../bin/$*.d
 	@printf "../bin/"|cat - ../bin/$*.d > /tmp/fw_out && mv /tmp/fw_out ../bin/$*.d
 
 # remove compilation products

--- a/sys/shell/Makefile
+++ b/sys/shell/Makefile
@@ -13,8 +13,8 @@ $(BINDIR)$(MODULE).a: $(OBJ)
 
 # compile and generate dependency info
 $(BINDIR)%.o: %.c
-	$(CC) $(CFLAGS) $(PROJECTINCLUDE) $(BOARDINCLUDE) $(INCLUDES) -c $*.c -o $(BINDIR)$*.o
-	$(CC) $(CFLAGS) $(PROJECTINCLUDE) $(BOARDINCLUDE) $(INCLUDES) -MM $*.c > $(BINDIR)$*.d
+	$(CC) $(CFLAGS) $(INCLUDES) -c $*.c -o $(BINDIR)$*.o
+	$(CC) $(CFLAGS) $(INCLUDES) -MM $*.c > $(BINDIR)$*.d
 	@printf "$(BINDIR)"|cat - $(BINDIR)$*.d > /tmp/riot_out && mv /tmp/riot_out $(BINDIR)$*.d
 
 # remove compilation products

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -38,8 +38,8 @@ $(BINDIR)$(MODULE).a: $(OBJ)
 
 # compile and generate dependency info
 $(BINDIR)%.o: %.c
-	$(CC) $(CFLAGS) $(PROJECTINCLUDE) $(BOARDINCLUDE) $(INCLUDES) -c $*.c -o $(BINDIR)$*.o
-	$(CC) $(CFLAGS) $(PROJECTINCLUDE) $(BOARDINCLUDE) $(INCLUDES) -MM $*.c > $(BINDIR)$*.d
+	$(CC) $(CFLAGS) $(INCLUDES) -c $*.c -o $(BINDIR)$*.o
+	$(CC) $(CFLAGS) $(INCLUDES) -MM $*.c > $(BINDIR)$*.d
 	@printf "$(BINDIR)"|cat - $(BINDIR)$*.d > /tmp/riot_out && mv /tmp/riot_out $(BINDIR)$*.d
 
 # remove compilation products


### PR DESCRIPTION
The following variables are included in various Makefiles but never
defined.

```
$(BOARDINCLUDE)
$(PROJECTINCLUDE)
$(CPUINCLUDE)
```
