### PR TITLE
add way to declare parameter as unused

### DIFF
--- a/core/include/unused.h
+++ b/core/include/unused.h
@@ -1,0 +1,22 @@
+/**
+ * @file
+ * @author      Freie Universität Berlin, Computer Systems & Telematics
+ * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
+ */
+
+#ifndef UNUSED_H_
+#define UNUSED_H_
+
+#ifdef __GNUC__
+#  define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
+#else
+#  define UNUSED(x) UNUSED_ ## x
+#endif
+
+#ifdef __GNUC__
+#  define UNUSED_FUNCTION(x) __attribute__((__unused__)) UNUSED_ ## x
+#else
+#  define UNUSED_FUNCTION(x) UNUSED_ ## x
+#endif
+
+#endif /* UNUSED_H_ */

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -15,15 +15,16 @@
  */
 
 #include <stdio.h>
+
 #include "mutex.h"
 #include "atomic.h"
 #include "queue.h"
 #include "tcb.h"
 #include "kernel.h"
 #include "sched.h"
-#include <irq.h>
-
-#include <debug.h>
+#include "irq.h"
+#include "unused.h"
+#include "debug.h"
 
 int mutex_init(struct mutex_t *mutex)
 {
@@ -90,7 +91,7 @@ void mutex_wait(struct mutex_t *mutex)
     /* we were woken up by scheduler. waker removed us from queue. we have the mutex now. */
 }
 
-void mutex_unlock(struct mutex_t *mutex, int yield)
+void mutex_unlock(struct mutex_t *mutex, int UNUSED(yield))
 {
     DEBUG("%s: unlocking mutex. val: %u pid: %u\n", active_thread->name, mutex->val, thread_pid);
     int irqstate = disableIRQ();

--- a/core/oneway_malloc.c
+++ b/core/oneway_malloc.c
@@ -20,6 +20,8 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include "unused.h"
+
 #include <debug.h>
 
 extern void *sbrk(int incr);
@@ -46,7 +48,7 @@ void *_realloc(void *ptr, size_t size)
     return newptr;
 }
 
-void _free(void *ptr)
+void _free(void *UNUSED(ptr))
 {
     DEBUG("_free(): block at 0x%X lost.\n", (unsigned int)ptr);
 }

--- a/cpu/native/hwtimer_cpu.c
+++ b/cpu/native/hwtimer_cpu.c
@@ -38,6 +38,7 @@
 #include "cpu.h"
 #include "cpu-conf.h"
 
+#include "unused.h"
 #include "debug.h"
 
 #define HWTIMERMINOFFSET 1000
@@ -240,7 +241,7 @@ unsigned long hwtimer_arch_now(void)
     return native_hwtimer_now;
 }
 
-void hwtimer_arch_init(void (*handler)(int), uint32_t fcpu)
+void hwtimer_arch_init(void (*handler)(int), uint32_t UNUSED(fcpu))
 {
     DEBUG("hwtimer_arch_init()\n");
 

--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -24,6 +24,7 @@
 
 #include "irq.h"
 #include "cpu.h"
+#include "unused.h"
 
 #include "debug.h"
 
@@ -292,7 +293,7 @@ void native_irq_handler()
 /**
  * save signal, return to _native_sig_leave_tramp if possible
  */
-void native_isr_entry(int sig, siginfo_t *info, void *context)
+void native_isr_entry(int sig, siginfo_t *UNUSED(info), void *context)
 {
     DEBUG("\n\n\t\tnative_isr_entry\n\n");
 

--- a/cpu/native/rtc/posix-rtc.c
+++ b/cpu/native/rtc/posix-rtc.c
@@ -20,6 +20,7 @@
 
 #include <time.h>
 #include <err.h>
+#include "unused.h"
 
 #include "debug.h"
 
@@ -45,7 +46,7 @@ void rtc_disable(void)
     native_rtc_enabled = 0;
 }
 
-void rtc_set_localtime(struct tm *localt)
+void rtc_set_localtime(struct tm *UNUSED(localt))
 {
     DEBUG("rtc_set_localtime()\n");
     printf("setting time not supported.");

--- a/sys/shell/commands/sc_ltc4150.c
+++ b/sys/shell/commands/sc_ltc4150.c
@@ -16,14 +16,16 @@
  */
 
 #include <stdio.h>
+
+#include "unused.h"
 #include <ltc4150.h>
 
-void _get_current_handler(char *unused)
+void _get_current_handler(char *UNUSED(ptr))
 {
     printf("Power usage: %.4f mA (%.4f mA avg/ %.4f mAh total / %i usec)\n", ltc4150_get_current_mA(), ltc4150_get_avg_mA(), ltc4150_get_total_mAh(), ltc4150_get_interval());
 }
 
-void _reset_current_handler(char *unused)
+void _reset_current_handler(char *UNUSED(ptr))
 {
     ltc4150_start();
 }

--- a/sys/shell/commands/sc_ps.c
+++ b/sys/shell/commands/sc_ps.c
@@ -15,9 +15,11 @@
  * @}
  */
 
+#include "unused.h"
+
 #include "ps.h"
 
-void _ps_handler(char *unnused)
+void _ps_handler(char *UNUSED(ptr))
 {
     thread_print_all();
 }

--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -10,10 +10,12 @@
 #include <msg.h>
 #include <thread.h>
 #include <queue.h>
+#include "unused.h"
 
 #include <vtimer.h>
 
 #include <debug.h>
+
 
 
 #define VTIMER_THRESHOLD 20UL
@@ -77,7 +79,7 @@ static int update_shortterm(void)
     return 0;
 }
 
-void vtimer_tick(void *ptr)
+void vtimer_tick(void *UNUSED(ptr))
 {
     DEBUG("vtimer_tick().");
     seconds += SECONDS_PER_TICK;
@@ -109,7 +111,7 @@ static int set_shortterm(vtimer_t *timer)
     return 1;
 }
 
-void vtimer_callback(void *ptr)
+void vtimer_callback(void *UNUSED(ptr))
 {
     vtimer_t *timer;
     in_callback = true;


### PR DESCRIPTION
Riot lags some way to declare, that a function parameter
is unused. This commit adds a file called "unused.h",
which defines some nice macros.

http://stackoverflow.com/questions/3599160/unused-parameter-warnings-in-c-code

this commit fixes #62 (the discussion wasn't finally over in this issue)
