### PR TITLE
Allow external modules to be added to a RIOT project

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -43,6 +43,7 @@ all: $(PROJBINDIR)/$(PROJECT).a
 	@echo "Building project $(PROJECT) for $(BOARD) w/ MCU $(MCU)."
 	$(MAKE) -C $(RIOTBOARD)
 	$(MAKE) -C $(RIOTBASE)
+	@for i in $(EXTERNAL_MODULES) ; do $(MAKE) -C $$i ; done ;
 ifeq ($(BUILDOSXNATIVE),1)	
 	@$(LINK) $(UNDEF) -o $(PROJBINDIR)/$(PROJECT).elf $(BASELIBS) $(LINKFLAGS) -Wl,-no_pie
 else
@@ -75,6 +76,7 @@ ${PROJBINDIR}/%.o: %.c
 clean:
 	$(MAKE) -C $(RIOTBOARD) clean
 	$(MAKE) -C $(RIOTBASE) clean
+	@for i in $(EXTERNAL_MODULES) ; do $(MAKE) -C $$i clean ; done ;
 	rm -f $(PROJBINDIR)/*
 
 flash: all


### PR DESCRIPTION
Some modules might not be not part of the riot tree (oonf_api, [riot-libs](https://github.com/benpicco/riot-libs)).
Add a way to include them into the Make process. 
