### PR TITLE
added missing include to transceiver

### DIFF
--- a/sys/include/transceiver.h
+++ b/sys/include/transceiver.h
@@ -5,17 +5,33 @@
 
 /* Stack size for transceiver thread */
 #ifndef TRANSCEIVER_STACK_SIZE
-#if ENABLE_DEBUG
-#define TRANSCEIVER_STACK_SIZE      (KERNEL_CONF_STACKSIZE_PRINTF)
-#else
-#define TRANSCEIVER_STACK_SIZE      (512)
-#endif
+    #define TRANSCEIVER_STACK_SIZE      (512)
 #endif
 
+#define PAYLOAD_SIZE  (0)
+#ifdef MODULE_CC110X
+    #if (CC1100_MAX_DATA_LENGTH > PAYLOAD_SIZE)
+        #undef PAYLOAD_SIZE
+        #define PAYLOAD_SIZE (CC1100_MAX_DATA_LENGTH)
+    #endif
+#endif
+#ifdef MODULE_CC110X_NG
+    #if (CC1100_MAX_DATA_LENGTH > PAYLOAD_SIZE)
+        #undef PAYLOAD_SIZE
+        #define PAYLOAD_SIZE (CC1100_MAX_DATA_LENGTH)
+    #endif
+#endif
 #ifdef MODULE_CC2420
-#define PAYLOAD_SIZE  (118)
-#else
-#define PAYLOAD_SIZE  (58)
+    #if (CC2420_MAX_DATA_LENGTH > PAYLOAD_SIZE)
+        #undef PAYLOAD_SIZE
+        #define PAYLOAD_SIZE (CC2420_MAX_DATA_LENGTH)
+    #endif
+#endif
+#ifdef MODULE_MC1322X
+    #if (MC1322X_MAX_DATA_LENGTH > PAYLOAD_SIZE)
+        #undef PAYLOAD_SIZE
+        #define PAYLOAD_SIZE (MC1322X_MAX_DATA_LENGTH)
+    #endif
 #endif
 /* The maximum of threads to register */
 #define TRANSCEIVER_MAX_REGISTERED  (4)

--- a/sys/transceiver/transceiver.c
+++ b/sys/transceiver/transceiver.c
@@ -24,32 +24,21 @@
 #include <thread.h>
 #include <msg.h>
 
-#include <transceiver.h>
 #include <radio/types.h>
+
+#include "transceiver.h"
 
 /* supported transceivers */
 #ifdef MODULE_CC110X
 #include <cc1100-interface.h>
-#if (CC1100_MAX_DATA_LENGTH > PAYLOAD_SIZE)
-#undef PAYLOAD_SIZE
-#define PAYLOAD_SIZE (CC1100_MAX_DATA_LENGTH)
-#endif
 #endif
 
 #ifdef MODULE_CC110X_NG
 #include <cc110x_ng.h>
-#if (CC1100_MAX_DATA_LENGTH > PAYLOAD_SIZE)
-#undef PAYLOAD_SIZE
-#define PAYLOAD_SIZE (CC1100_MAX_DATA_LENGTH)
-#endif
 #endif
 
 #ifdef MODULE_CC2420
 #include <cc2420.h>
-#if (CC2420_MAX_DATA_LENGTH > PAYLOAD_SIZE)
-    #undef PAYLOAD_SIZE
-    #define PAYLOAD_SIZE (CC2420_MAX_DATA_LENGTH)
-#endif
 #endif
 
 #ifdef MODULE_MC1322X
@@ -59,6 +48,10 @@
 #endif
 
 #define ENABLE_DEBUG (0)
+#if ENABLE_DEBUG
+    #undef TRANSCEIVER_STACK_SIZE
+    #define TRANSCEIVER_STACK_SIZE      (KERNEL_CONF_STACKSIZE_PRINTF)
+#endif
 #include <debug.h>
 
 /*------------------------------------------------------------------------------------*/


### PR DESCRIPTION
There was a missing include in #98 and debugging was broken due to wrong order of preprocessor directives.
