### PR TITLE
fix priority comparison in sched_switch

### DIFF
--- a/core/sched.c
+++ b/core/sched.c
@@ -187,7 +187,7 @@ void sched_switch(uint16_t current_prio, uint16_t other_prio, int in_isr)
 {
     DEBUG("%s: %i %i %i\n", active_thread->name, (int)current_prio, (int)other_prio, in_isr);
 
-    if (current_prio <= other_prio) {
+    if (current_prio >= other_prio) {
         if (in_isr) {
             sched_context_switch_request = 1;
         }


### PR DESCRIPTION
fixes an old, but yet unknown bug in the mutex implementation
