### PR TITLE
Add capability to Makefiles to use PROJBINDIR

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -67,16 +67,16 @@ SRC = $(wildcard *.c)
 # string array of all names replaced .c with .o 
 OBJ = $(SRC:%.c=${PROJBINDIR}/%.o)
 
-${PROJBINDIR}/$(PROJECT).a:  $(OBJ)
-	$(AR) -rc bin/$(PROJECT).a $(OBJ)
+$(PROJBINDIR)/$(PROJECT).a:  $(OBJ)
+	$(AR) -rc $(PROJBINDIR)/$(PROJECT).a $(OBJ)
 
 # pull in dependency info for *existing* .o files
 -include $(OBJ:.o=.d)
 
-${PROJBINDIR}/%.o: %.c $(PROJDEPS)
+$(PROJBINDIR)/%.o: %.c $(PROJDEPS)
 	@echo; echo "Compiling.... $*.c"; echo
 	@test -d $(PROJBINDIR) || mkdir -p $(PROJBINDIR)
-	$(CC) $(CFLAGS) $(INCLUDES) -c $*.c -o bin/$*.o
+	$(CC) $(CFLAGS) $(INCLUDES) -c $*.c -o $(PROJBINDIR)/$*.o
 
 clean:
 	$(MAKE) -C $(RIOTBOARD) clean


### PR DESCRIPTION
Fixes bug in build-system that does not allow you to use other
PROJBINDIR than $(CURDIR)/bin
