### PR TITLE
Fix payload offset

### DIFF
--- a/sys/net/ieee802154/ieee802154_frame.c
+++ b/sys/net/ieee802154/ieee802154_frame.c
@@ -230,7 +230,7 @@ uint8_t ieee802154_frame_read(uint8_t *buf, ieee802154_frame_t *frame,
 
     frame->payload = (buf + index);
     hdrlen = index;
-    frame->payload_len = (len - hdrlen);
+    frame->payload_len = (len - hdrlen - IEEE_802154_FCS_LEN);
 
     return hdrlen;
 }

--- a/sys/net/sixlowpan/mac.c
+++ b/sys/net/sixlowpan/mac.c
@@ -143,7 +143,7 @@ void recv_ieee802154_frame(void)
 
             p = (radio_packet_t *) m.content.ptr;
             hdrlen = ieee802154_frame_read(p->data, &frame, p->length);
-            length = p->length - hdrlen;
+            length = p->length - hdrlen - IEEE_802154_FCS_LEN;
 
             /* deliver packet to network(6lowpan)-layer */
             lowpan_read(frame.payload, length, (ieee_802154_long_t *)&frame.src_addr,


### PR DESCRIPTION
This (should) fix the calculation of the payload offset in fragmented ieee_802154 frames.
