### PR TITLE
include sc_heap only when building for LPC boards

### DIFF
--- a/sys/shell/commands/sc_heap.c
+++ b/sys/shell/commands/sc_heap.c
@@ -18,6 +18,8 @@
  * @note    $Id: sc_heap.c 3855 2013-09-05 12:40:11 kasmi $
  */
 
+#ifdef MODULE_LPC_COMMON
+
 extern void heap_stats(void);
 
 void _heap_handler(char *unused)
@@ -25,4 +27,6 @@ void _heap_handler(char *unused)
     (void) unused;
     heap_stats();
 }
+
+#endif
 

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -94,7 +94,9 @@ extern void _read_bytes(char *bytes);
 
 const shell_command_t _shell_command_list[] = {
     {"id", "Gets or sets the node's id.", _id_handler},
+#ifdef MODULE_LPC_COMMON
     {"heap", "Shows the heap state for the LPC2387 on the command shell.", _heap_handler},
+#endif
 #ifdef MODULE_PS
     {"ps", "Prints information about running threads.", _ps_handler},
 #endif


### PR DESCRIPTION
fixes from #191
