### PR TITLE
adjusted default stack sizes for msp430

### DIFF
--- a/cpu/msp430-common/include/cpu-conf.h
+++ b/cpu/msp430-common/include/cpu-conf.h
@@ -17,13 +17,13 @@ License. See the file LICENSE in the top level directory for more details.
  * @name Kernel configuration
  * @{
  */
-#define KERNEL_CONF_STACKSIZE_PRINTF    (512)
+#define KERNEL_CONF_STACKSIZE_PRINTF    (256)
 
 #ifndef KERNEL_CONF_STACKSIZE_DEFAULT
-#define KERNEL_CONF_STACKSIZE_DEFAULT	(KERNEL_CONF_STACKSIZE_PRINTF)
+#define KERNEL_CONF_STACKSIZE_DEFAULT	(256)
 #endif
 
-#define KERNEL_CONF_STACKSIZE_IDLE 64
+#define KERNEL_CONF_STACKSIZE_IDLE 96
 #define MSP430_ISR_STACK_SIZE 256
 
 #define RX_BUF_SIZE (3)


### PR DESCRIPTION
- stack size for idle thread was too small
- main stack gets initialized with KERNEL_CONF_STACKSIZE_DEFAULT +
  KERNEL_CONF_STACKSIZE_PRINTF, leading to a huge main thread stack
