### PR TITLE
renamed SUCCESS constant in sixlowerror

### DIFF
--- a/sys/net/rpl/rpl.c
+++ b/sys/net/rpl/rpl.c
@@ -207,7 +207,7 @@ uint8_t rpl_init(transceiver_type_t trans, uint16_t rpl_address)
         etx_init_beaconing(&my_address);
     }
 
-    return SUCCESS;
+    return SIXLOWERROR_SUCCESS;
 }
 
 void rpl_init_root(void)

--- a/sys/net/sixlowpan/border.c
+++ b/sys/net/sixlowpan/border.c
@@ -158,7 +158,7 @@ uint8_t sixlowpan_lowpan_border_init(transceiver_type_t trans,
 
     ipv6_init_iface_as_router();
 
-    return SUCCESS;
+    return SIXLOWERROR_SUCCESS;
 }
 
 void border_process_lowpan(void)

--- a/sys/net/sixlowpan/icmp.c
+++ b/sys/net/sixlowpan/icmp.c
@@ -1581,6 +1581,6 @@ int8_t plist_add(ipv6_addr_t *addr, uint8_t size, uint32_t val_ltime,
         plist[prefix_count].pref_ltime = HTONL(pref_ltime);
         memcpy(&(plist[prefix_count].addr.uint8[0]), &(addr->uint8[0]), 16);
 
-        return SUCCESS;
+        return SIXLOWERROR_SUCCESS;
     }
 }

--- a/sys/net/sixlowpan/include/sixlowpan/error.h
+++ b/sys/net/sixlowpan/include/sixlowpan/error.h
@@ -18,13 +18,11 @@
 #ifndef SIXLOWPAN_ERROR_H
 #define SIXLOWPAN_ERROR_H
 
-#ifndef SUCCESS
 /**
  * Functions return this if call was success. Only defined if not
  * already defined by other header.
  */
-#define SUCCESS                 (0)
-#endif
+#define SIXLOWERROR_SUCCESS                 (0)
 
 /**
  * Error code that signals that array is full.

--- a/sys/net/sixlowpan/include/sixlowpan/lowpan.h
+++ b/sys/net/sixlowpan/include/sixlowpan/lowpan.h
@@ -201,7 +201,7 @@ void sixlowpan_lowpan_adhoc_init(transceiver_type_t trans,
  * @param[in] trans    transceiver to use with 6LoWPAN.
  * @param[in] border_router_addr    Address of this border router.
  *
- * @return  SUCCESS on success, otherwise SIXLOWERROR_ADDRESS if
+ * @return  SIXLOWERROR_SUCCESS on success, otherwise SIXLOWERROR_ADDRESS if
  *          address was not generated from IEEE 802.15.4 16-bit short
  *          address.
  */


### PR DESCRIPTION
SUCCESS is used in thirdparty libraries (e.g. in STM32 CMSIS) in a contrary way.
