### PR TITLE
minimize stacksize of the idle thread

### DIFF
--- a/cpu/lpc2387/include/cpu-conf.h
+++ b/cpu/lpc2387/include/cpu-conf.h
@@ -59,7 +59,7 @@ License. See the file LICENSE in the top level directory for more details.
 #define KERNEL_CONF_STACKSIZE_DEFAULT	(512)
 #endif
 
-#define KERNEL_CONF_STACKSIZE_IDLE		(512)
+#define KERNEL_CONF_STACKSIZE_IDLE		(160)
 /** @} */
 
 /**


### PR DESCRIPTION
with this patch activated:

```
2013-09-25 15:28:40,807 - INFO # > ps
2013-09-25 15:28:40,816 - INFO #    pid | name                 | state    Q | pri | stack ( used) location   | runtime | switches 
2013-09-25 15:28:40,824 - INFO #      0 | idle                 | pending  Q |  31 |   256 (  152) 0x40000010 |    nan% |       -1
```
