### PR TITLE
Native cleanup

### DIFF
--- a/cpu/native/include/cpu.h
+++ b/cpu/native/include/cpu.h
@@ -64,10 +64,10 @@ void thread_yield(void);
 
 extern void _native_sig_leave_tramp(void);
 extern ucontext_t *_native_cur_ctx, *_native_isr_ctx;
-extern unsigned int _native_saved_eip;
-extern int _native_in_isr;
-extern int _native_in_syscall;
-extern int _native_sigpend;
+extern volatile unsigned int _native_saved_eip;
+extern volatile int _native_in_isr;
+extern volatile int _native_in_syscall;
+extern volatile int _native_sigpend;
 #ifdef MODULE_UART0
 #include <sys/select.h>
 extern fd_set _native_rfds;

--- a/cpu/native/include/nativenet_internal.h
+++ b/cpu/native/include/nativenet_internal.h
@@ -38,7 +38,6 @@ struct rx_buffer_s {
 };
 
 extern struct rx_buffer_s _nativenet_rx_buffer[];
-extern volatile uint8_t rx_buffer_next;
 
 void _nativenet_handle_packet(radio_packet_t *packet);
 #endif /* NATIVENET_INTERNAL_H */

--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -16,6 +16,7 @@
 #include <err.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdlib.h>
 
 // __USE_GNU for gregs[REG_EIP] access under Linux
 #define __USE_GNU
@@ -25,21 +26,21 @@
 #include "irq.h"
 #include "cpu.h"
 
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static int native_interrupts_enabled;
+volatile int native_interrupts_enabled;
 
-int _native_sigpend;
-int _native_in_isr;
-int _native_in_syscall;
-static ucontext_t native_isr_context;
+volatile int _native_sigpend;
+volatile int _native_in_isr;
+volatile int _native_in_syscall;
+ucontext_t native_isr_context;
 static sigset_t native_sig_set;
 static char __isr_stack[SIGSTKSZ];
 extern volatile tcb_t *active_thread;
 
-unsigned int _native_saved_eip;
+volatile unsigned int _native_saved_eip;
 ucontext_t *_native_cur_ctx, *_native_isr_ctx;
-int _native_in_isr;
 
 static int pipefd[2];
 
@@ -261,7 +262,7 @@ int _native_popsig(void)
     i = 0;
 
     _native_in_syscall = 1;
-    while ((nleft > 0) && ((nread = read(pipefd[0], &sig + i, nleft))  != -1)) {
+    while ((nleft > 0) && ((nread = read(pipefd[0], ((uint8_t*)&sig) + i, nleft))  != -1)) {
         i += nread;
         nleft -= nread;
     }

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -34,7 +34,7 @@
 
 extern volatile tcb_t *active_thread;
 static ucontext_t end_context;
-static char __isr_stack[SIGSTKSZ];
+static char __end_stack[SIGSTKSZ];
 
 #ifdef MODULE_UART0
 fd_set _native_rfds;
@@ -135,11 +135,11 @@ void native_cpu_init()
         err(1, "end_context(): getcontext()");
     }
 
-    end_context.uc_stack.ss_sp = __isr_stack;
+    end_context.uc_stack.ss_sp = __end_stack;
     end_context.uc_stack.ss_size = SIGSTKSZ;
     end_context.uc_stack.ss_flags = 0;
     makecontext(&end_context, sched_task_exit, 0);
 
-    puts("RIOT native cpu initialized.");
+    DEBUG("RIOT native cpu initialized.");
 }
 /** @} */

--- a/cpu/native/net/interface.c
+++ b/cpu/native/net/interface.c
@@ -39,7 +39,7 @@ struct nativenet_callback_s {
 static struct nativenet_callback_s _nativenet_callbacks[255];
 
 struct rx_buffer_s _nativenet_rx_buffer[RX_BUF_SIZE];
-volatile uint8_t rx_buffer_next;
+static volatile uint8_t rx_buffer_next;
 
 uint8_t _native_net_chan;
 uint16_t _native_net_pan;
@@ -108,7 +108,7 @@ radio_address_t nativenet_get_address()
 uint8_t nativenet_send(radio_packet_t *packet)
 {
     packet->src = _native_net_addr;
-    DEBUG("nativenet_send:  Sending packet of length %"PRIu16" from %"PRIu16" to %"PRIu16": %s\n", packet->length, packet->src, packet->dst, (char*) packet->data);
+    DEBUG("nativenet_send:  Sending packet of length %"PRIu16" from %"PRIu16" to %"PRIu16"\n", packet->length, packet->src, packet->dst);
 
     if (send_buf(packet) == -1) {
         warnx("nativenet_send: error sending packet");
@@ -183,6 +183,7 @@ void _nativenet_handle_packet(radio_packet_t *packet)
     }
 
     /* copy packet to rx buffer */
+    DEBUG("\n\t\trx_buffer_next: %i\n\n", rx_buffer_next);
     memcpy(&_nativenet_rx_buffer[rx_buffer_next].data, packet->data, packet->length);
     memcpy(&_nativenet_rx_buffer[rx_buffer_next].packet, packet, sizeof(radio_packet_t));
     _nativenet_rx_buffer[rx_buffer_next].packet.data = (uint8_t *) &_nativenet_rx_buffer[rx_buffer_next].data;

--- a/cpu/native/net/tap.c
+++ b/cpu/native/net/tap.c
@@ -80,7 +80,7 @@ void _native_handle_tap_input(void)
                 p.rssi = 0;
                 p.lqi = 0;
                 p.data = frame.field.payload.data;
-                DEBUG("_native_handle_tap_input: received packet of length %"PRIu16" for %"PRIu16" from %"PRIu16": %s\n", p.length, p.dst, p.src, (char*) p.data);
+                DEBUG("_native_handle_tap_input: received packet of length %"PRIu16" for %"PRIu16" from %"PRIu16"\n", p.length, p.dst, p.src);
                 _nativenet_handle_packet(&p);
             }
         }
@@ -103,7 +103,7 @@ int _native_marshall_ethernet(uint8_t *framebuf, radio_packet_t *packet)
     unsigned char addr[ETHER_ADDR_LEN];
 
     f = (union eth_frame*)framebuf;
-    addr[0] = addr[1] = addr[2] = addr[3] = addr[4] = addr[5] = (char)0xFF;
+    addr[0] = addr[1] = addr[2] = addr[3] = addr[4] = addr[5] = 0xFF;
 
     memcpy(f->field.header.ether_dhost, addr, ETHER_ADDR_LEN);
     memcpy(f->field.header.ether_shost, _native_tap_mac, ETHER_ADDR_LEN);
@@ -134,7 +134,9 @@ int send_buf(radio_packet_t *packet)
     uint8_t buf[TAP_BUFFER_LENGTH];
     int nsent, to_send;
 
-    DEBUG("send_buf:  Sending packet of length %"PRIu16" from %"PRIu16" to %"PRIu16": %s\n", packet->length, packet->src, packet->dst, (char*) packet->data);
+    memset(buf, 0, sizeof(buf));
+
+    DEBUG("send_buf:  Sending packet of length %"PRIu16" from %"PRIu16" to %"PRIu16"\n", packet->length, packet->src, packet->dst);
     to_send = _native_marshall_ethernet(buf, packet);
 
     DEBUG("send_buf: trying to send %d bytes\n", to_send);
@@ -220,7 +222,7 @@ int tap_init(char *name)
     }
 #endif /* OSX */
 
-    puts("RIOT native tap initialized.");
+    DEBUG("RIOT native tap initialized.\n");
     return _native_tap_fd;
 }
 /** @} */

--- a/cpu/native/rtc/posix-rtc.c
+++ b/cpu/native/rtc/posix-rtc.c
@@ -23,7 +23,7 @@
 
 #include "debug.h"
 
-#include <rtc.h>
+#include "rtc.h"
 
 static int native_rtc_enabled;
 


### PR DESCRIPTION
make some variables volatile
remove rx_buffer_next from header
more DEBUG output
fix warnings
coding conventions
change puts to DEBUG
rename end context/stack
