### PR TITLE
Objcopy flags

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -53,7 +53,7 @@ ifeq ($(BUILDOSXNATIVE),1)
 else
 	@$(LINK) $(UNDEF) -o $(PROJBINDIR)/$(PROJECT).elf -Wl,--start-group $(BASELIBS) -lm -Wl,--end-group  -Wl,-Map=$(PROJBINDIR)/$(PROJECT).map $(LINKFLAGS) 
 	@$(SIZE) $(PROJBINDIR)/$(PROJECT).elf
-	@$(OBJCOPY) -O ihex $(PROJBINDIR)/$(PROJECT).elf $(PROJBINDIR)/$(PROJECT).hex
+	@$(OBJCOPY) $(OFLAGS) $(PROJBINDIR)/$(PROJECT).elf $(PROJBINDIR)/$(PROJECT).hex
 endif
 
 ## your make rules


### PR DESCRIPTION
Some platform require different formats than Intel hexfiles.
