### PR TITLE
shell: don't use malloc on each line

### DIFF
--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -2,7 +2,7 @@
  * Copyright 2009, Freie Universitaet Berlin (FUB). All rights reserved.
  *
  * These sources were developed at the Freie Universitaet Berlin, Computer Systems
-and Telematics group (http://cst.mi.fu-berlin.de).
+ * and Telematics group (http://cst.mi.fu-berlin.de).
  * ----------------------------------------------------------------------------
  * This file is part of RIOT.
  *
@@ -19,8 +19,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @defgroup shell Simple Shell Interpreter
  * @ingroup feuerware
  */
-
-//#include "hashtable.h"
 
 typedef struct shell_command_t {
     char *name;

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -26,7 +26,6 @@
  * @author		Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-//#include <sys/unistd.h>
 #include <string.h>
 #include <stdio.h>
 #include <shell.h>


### PR DESCRIPTION
strdup uses malloc, which may not be present in a useful fashion (oneway_malloc) for short life cycles of buffers
