### PR TITLE
fix signal handler context switch

### DIFF
--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -337,9 +337,11 @@ void native_isr_entry(int sig, siginfo_t *info, void *context)
     if (_native_in_syscall == 0) {
         DEBUG("\n\n\t\treturn to _native_sig_leave_tramp\n\n");
 #ifdef __MACH__
+        _native_in_isr = 1;
         _native_saved_eip = ((ucontext_t *)context)->uc_mcontext->__ss.__eip;
         ((ucontext_t *)context)->uc_mcontext->__ss.__eip = (unsigned int)&_native_sig_leave_tramp;
 #elif BSD
+        _native_in_isr = 1;
         _native_saved_eip = ((struct sigcontext *)context)->sc_eip;
         ((struct sigcontext *)context)->sc_eip = (unsigned int)&_native_sig_leave_tramp;
 #else
@@ -347,11 +349,11 @@ void native_isr_entry(int sig, siginfo_t *info, void *context)
                 ((void*)(((ucontext_t *)context)->uc_mcontext.gregs[REG_EIP]))
                 > ((void*)process_heap_address)
            ) {
-            DEBUG("\nEIP:\t%p\nHEAP:\t%p\nnot switching\n\n", (void*)((ucontext_t *)context)->uc_mcontext.gregs[REG_EIP], (void*)process_heap_address);
+            DEBUG("\n\033[36mEIP:\t%p\nHEAP:\t%p\nnot switching\n\n\033[0m", (void*)((ucontext_t *)context)->uc_mcontext.gregs[REG_EIP], (void*)process_heap_address);
         }
         else {
             _native_in_isr = 1;
-            warnx("\nEIP:\t%p\nHEAP:\t%p\ngo switching\n\n", (void*)((ucontext_t *)context)->uc_mcontext.gregs[REG_EIP], (void*)process_heap_address);
+            DEBUG("\n\033[31mEIP:\t%p\nHEAP:\t%p\ngo switching\n\n\033[0m", (void*)((ucontext_t *)context)->uc_mcontext.gregs[REG_EIP], (void*)process_heap_address);
             _native_saved_eip = ((ucontext_t *)context)->uc_mcontext.gregs[REG_EIP];
             ((ucontext_t *)context)->uc_mcontext.gregs[REG_EIP] = (unsigned int)&_native_sig_leave_tramp;
         }

--- a/cpu/native/tramp.S
+++ b/cpu/native/tramp.S
@@ -3,22 +3,17 @@
 #ifdef __MACH__
 .globl __native_sig_leave_tramp
 __native_sig_leave_tramp:
-    pushl %eax
     pushf
-    pushl %ebp
-    pushl %esp
+    pusha
 
-    movl  %esp, %ebp
-    subl  $24, %esp
-    movl  $__native_isr_ctx, 4(%esp)
-    movl  $__native_cur_ctx, (%esp)
+    pushl __native_isr_ctx
+    pushl __native_cur_ctx
     call _swapcontext
+    addl $8, %esp
 
-    addl  $24, %esp
-    popl %esp
-    popl %ebp
-    popf 
-    popl %eax
+    movl $0x0, __native_in_isr
+    popa
+    popf
 
     jmp *__native_saved_eip
 #else
@@ -30,23 +25,17 @@ __native_sig_leave_tramp:
 .globl _native_sig_leave_tramp
 
 _native_sig_leave_tramp:
-    pushl %eax
     pushf
-    pushl %ebp
-    pushl %esp
+    pusha
 
-    movl  %esp, %ebp
-    subl  $24, %esp
-    movl  $_native_isr_ctx, 4(%esp)
-    movl  $_native_cur_ctx, (%esp)
+    pushl _native_isr_ctx
+    pushl _native_cur_ctx
     call swapcontext
+    addl $8, %esp
 
-    addl  $24, %esp
-    popl %esp
-    popl %ebp
-    popf 
-    popl %eax
-    movl $0x0, _native_in_isr;
+    movl $0x0, _native_in_isr
+    popa
+    popf
 
     jmp *_native_saved_eip
 #endif


### PR DESCRIPTION
This is a somewhat embarrassing commit as it turns out the assembler code never worked in RIOT. The test program I used to write that code didn't have pointers, so swapcontext got pointers to pointers in RIOT instead...
In any case I simplified the code while I was at it.

Due to this patch the forced debug output is not needed anymore.
Also, the state update for the BSDs only became relevant now ;-)

A side effect of this patch is that valgrind now starts whining a lot once the trampoline code was executed once (at least in the default-native project). I'm still trying to figure out how to fix this. In any case this only allows for more successful executions as the respective execution would have led to a segfault before.

Note:
It turns out RIOT does not need asynchronous context switches all that much, as only execution paths without these can have worked in native up to now. That is, context switches needed to happen in a blocking call.
