### PR TITLE
add thread_getname function

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -46,6 +46,12 @@ int thread_create(char *stack, int stacksize, char priority, int flags, void (*f
 unsigned int thread_getstatus(int pid);
 
 /**
+ * @brief   returns the name of a process.
+ * @return  NULL if pid is unknown
+ */
+const char *thread_getname(int pid);
+
+/**
  * @brief   Puts the current thread into sleep mode. Has to be woken up externally.
  */
 void thread_sleep(void);

--- a/core/thread.c
+++ b/core/thread.c
@@ -47,6 +47,15 @@ unsigned int thread_getstatus(int pid)
     return sched_threads[pid]->status;
 }
 
+const char *thread_getname(int pid)
+{
+    if (sched_threads[pid] == NULL) {
+        return NULL;
+    }
+
+    return sched_threads[pid]->name;
+}
+
 void thread_sleep()
 {
     if (inISR()) {


### PR DESCRIPTION
this adds a getter for a threads name, which was set on creation. now "userland code" can access this field.
