### PR TITLE
Implement AUTO_FREE flag for thread_create

### DIFF
--- a/core/include/tcb.h
+++ b/core/include/tcb.h
@@ -53,6 +53,7 @@ typedef struct tcb_t {
     const char *name;
     char *stack_start;
     int stack_size;
+    uint8_t auto_free;
 } tcb_t;
 
 /** @} */

--- a/core/sched.c
+++ b/core/sched.c
@@ -37,6 +37,8 @@ volatile int last_pid = -1;
 clist_node_t *runqueues[SCHED_PRIO_LEVELS];
 static uint32_t runqueue_bitcache = 0;
 
+static char *sched_free_stack;
+
 #if SCHEDSTATISTICS
 static void (*sched_cb) (uint32_t timestamp, uint32_t value) = NULL;
 schedstat pidlist[MAXTHREADS];
@@ -151,6 +153,12 @@ void sched_run()
 
     active_thread = (volatile tcb_t *) my_active_thread;
 
+    if (sched_free_stack) {
+        DEBUG("scheduler: freeing stack.\n");
+        free(sched_free_stack);
+        sched_free_stack = NULL;
+    }
+
     DEBUG("scheduler: done.\n");
 }
 
@@ -207,6 +215,10 @@ void sched_task_exit(void)
     num_tasks--;
 
     sched_set_status((tcb_t *)active_thread,  STATUS_STOPPED);
+
+    if (active_thread->auto_free) {
+        sched_free_stack = active_thread->stack_start;
+    }
 
     active_thread = NULL;
     cpu_switch_context_exit();

--- a/core/thread.c
+++ b/core/thread.c
@@ -187,6 +187,7 @@ int thread_create(char *stack, int stacksize, char priority, int flags, void (*f
     cb->sp = thread_stack_init(function, stack, stacksize);
     cb->stack_start = stack;
     cb->stack_size = total_stacksize;
+    cb->auto_free = !!(flags & AUTO_FREE);
 
     cb->priority = priority;
     cb->status = 0;


### PR DESCRIPTION
Currently the `AUTO_FREE` flag (defined in flags.h) is unused.

Implementing it will be helpful for dynamic thread creation (e.g. by pthreads).
