### PR TITLE
use CREATE_WOUT_YIELD on uart0 thread creation

### DIFF
--- a/sys/uart0/uart0.c
+++ b/sys/uart0/uart0.c
@@ -25,7 +25,14 @@ static void uart0_loop(void)
 void board_uart0_init(void)
 {
     ringbuffer_init(&uart0_ringbuffer, buffer, UART0_BUFSIZE);
-    int pid = thread_create(uart0_thread_stack, sizeof(uart0_thread_stack), PRIORITY_MAIN - 1, CREATE_STACKTEST|CREATE_WOUT_YIELD, uart0_loop, "uart0");
+    int pid = thread_create(
+            uart0_thread_stack,
+            sizeof(uart0_thread_stack),
+            PRIORITY_MAIN - 1,
+            CREATE_STACKTEST|CREATE_WOUT_YIELD,
+            uart0_loop,
+            "uart0"
+            );
     uart0_handler_pid = pid;
     puts("uart0_init() [OK]");
 }


### PR DESCRIPTION
This should remove a race condition in the case that some uart event
occurs after the uart0 thread has started and before control has
returned to the calling thread, as uart0_handler_pid would not have
been set yet.
