### PR TITLE
[RFC] allow applications to register a function to provide routing information

### DIFF
--- a/cpu/native/rtc/posix-rtc.c
+++ b/cpu/native/rtc/posix-rtc.c
@@ -73,12 +73,10 @@ time_t rtc_time(struct timeval *time)
 {
     if (native_rtc_enabled == 1) {
         _native_in_syscall++;
-        if (gettimeofday(time, 0) == 0) {
-            errx(1, "rtc_time: gettimeofday: error");
+        if (gettimeofday(time, NULL) == -1) {
+            err(1, "rtc_time: gettimeofday");
         }
         _native_in_syscall--;
     }
     return time->tv_sec;
 }
-
-


### PR DESCRIPTION
Currently, RIOT does not offer a way to provide the IP stack with routing information.
This patch adds a very simple way to do so, a routing protocol implementation would register a function get_next_hop() and each time RIOT receives a packet that is not destined for the local interface, it asks the routing implementation what to do with it.

The routing implementation might hold a lock to protect it's data structures when they are currently modified, so the registered function may block. Is this a problem? 
