### PR TITLE
fix wrong error handling introduced in 945aef

### DIFF
--- a/cpu/native/rtc/posix-rtc.c
+++ b/cpu/native/rtc/posix-rtc.c
@@ -73,12 +73,10 @@ time_t rtc_time(struct timeval *time)
 {
     if (native_rtc_enabled == 1) {
         _native_in_syscall++;
-        if (gettimeofday(time, 0) == 0) {
-            errx(1, "rtc_time: gettimeofday: error");
+        if (gettimeofday(time, NULL) == -1) {
+            err(1, "rtc_time: gettimeofday");
         }
         _native_in_syscall--;
     }
     return time->tv_sec;
 }
-
-


### PR DESCRIPTION
spotted by @benpicco in https://github.com/RIOT-OS/RIOT/commit/945aefad4fd707173be646d3c79a568381e85e0d#commitcomment-4430328
