### PR TITLE
[RFC] allow applications to register a function to provide routing information

### DIFF
--- a/sys/net/sixlowpan/include/sixlowpan/ip.h
+++ b/sys/net/sixlowpan/include/sixlowpan/ip.h
@@ -350,6 +350,20 @@ void ipv6_iface_get_best_src_addr(ipv6_addr_t *src,
 void ipv6_iface_print_addrs(void);
 
 /**
+ * @brief   Registers a function that decides how to route incomming
+ *          IP packets with a destination that is not this interface.
+ *          The default behaviour is to try forwarding such packets to
+ *          the neighborhood.
+ *          Register a function to change the default behaviour.
+ *          Such function shall return the next hop to reach the destination
+ *          of the IP packet, or NULL if no such next hop is known.
+ *          In this case, the packet will be discarded.
+ *
+ * @param   next_hop    function that returns the next hop to reach dest
+ */
+void ipv6_iface_set_routing_provider(ipv6_addr_t *(*next_hop)(ipv6_addr_t* dest));
+
+/**
  * @}
  */
 #endif /* SIXLOWPAN_IP_H */


### PR DESCRIPTION
Currently, RIOT does not offer a way to provide the IP stack with routing information.
This patch adds a very simple way to do so, a routing protocol implementation would register a function get_next_hop() and each time RIOT receives a packet that is not destined for the local interface, it asks the routing implementation what to do with it.
It will also be called for every sent IP packet, as the destination address is not necessarily the address of the next hop. 

The routing implementation might hold a lock to protect it's data structures when they are currently modified, so the registered function may block. Is this a problem? 
