### PR TITLE
msg.c fixes

### DIFF
--- a/core/msg.c
+++ b/core/msg.c
@@ -151,6 +151,7 @@ int msg_send_receive(msg_t *m, msg_t *reply, unsigned int target_pid)
 
     /* msg_send blocks until reply received */
 
+    eINT();
     return msg_send(m, target_pid, true);
 }
 
@@ -162,6 +163,7 @@ int msg_reply(msg_t *m, msg_t *reply)
 
     if (!target) {
         DEBUG("msg_reply(): %s: Target \"%" PRIu16 "\" not existing...dropping msg!\n", active_thread->name, m->sender_pid);
+        restoreIRQ(state);
         return -1;
     }
 
@@ -223,6 +225,7 @@ static int _msg_receive(msg_t *m, int block)
 
     /* no message, fail */
     if ((!block) && (n == -1)) {
+        eINT();
         return -1;
     }
 
@@ -249,6 +252,7 @@ static int _msg_receive(msg_t *m, int block)
             /* sender copied message */
         }
 
+        eINT();
         return 1;
     }
     else {


### PR DESCRIPTION
This preliminary fixes the segfault from #272. The proper fix should probably be to find out how `sender_msg` can be 0 in the first place, when two UDP packets are received at the same time.

Another patch enables interrupts again when functions return that previously called `dINT()`, forgot to call `eINT()` in some code paths, so now there are much less

> interrupts are off, but I caught a signal.

messages.

Thirdly, it outputs a DEBUG message when messages can't be queued.
Most callers in RIOT don't check the return value, so at least output some hint what's going on with ENABLE_DEBUG set.
I guess the next step would be to go to all callers and print an actual `printf` warning, as it's not obvious to the user when a message was silently lost.
