### PR TITLE
Fix sixlowpan/icmp.h

### DIFF
--- a/sys/net/sixlowpan/include/sixlowpan/icmp.h
+++ b/sys/net/sixlowpan/include/sixlowpan/icmp.h
@@ -21,6 +21,7 @@
 #ifndef SIXLOWPAN_ICMP_H
 #define SIXLOWPAN_ICMP_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "sixlowpan/types.h"


### PR DESCRIPTION
size_t in function definition needs stddef.h include
