### PR TITLE
fixed debug output for ps and vtimer

### DIFF
--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -62,8 +62,9 @@ void thread_print_all(void)
 #endif
             overall_stacksz += stacksz;
             stacksz -= thread_measure_stack_usage(p->stack_start);
-            printf("\t%3u | %-21s| %-8s %.1s | %3i | %5i (%5i) %p | %6.3f%% | %8i\n",
-                   p->pid, p->name, sname, queued, p->priority, p->stack_size, stacksz, p->stack_start, runtime, switches);
+            printf("\t%3u | %-21s| %-8s %.1s | %3i | %5i (%5i) %p | %6.3f%% | ",
+                   p->pid, p->name, sname, queued, p->priority, p->stack_size, stacksz, p->stack_start, runtime);
+            printf(" %8u\n", switches);
         }
     }
 

--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -135,7 +135,7 @@ void vtimer_callback(void *ptr)
         timer->action(timer->arg);
     }
     else {
-        DEBUG("Timer was poisoned.");
+        DEBUG("Timer was poisoned.\n");
     }
 
     in_callback = false;


### PR DESCRIPTION
Floating point does not work properly on my msp430-gcc, hence I've split the ps-printf-line to get at least information about the thread switching.
