### PR TITLE
shell: refactor default shell command handling

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -45,8 +45,10 @@ static void(*find_handler(const shell_command_t *command_list, char *command))(c
 
     const shell_command_t *entry;
 
-    for (int i = 0; i < sizeof(command_lists)/sizeof(entry); i++) {
+    /* iterating over command_lists */
+    for (unsigned int i = 0; i < sizeof(command_lists)/sizeof(entry); i++) {
         if ((entry = command_lists[i])) {
+            /* iterating over commands in command_lists entry */
             while (entry->name != NULL) {
                 if (strcmp(entry->name, command) == 0) {
                     return entry->handler;
@@ -75,8 +77,10 @@ static void print_help(const shell_command_t *command_list)
 
     const shell_command_t *entry;
 
-    for (int i = 0; i < sizeof(command_lists)/sizeof(entry); i++) {
+    /* iterating over command_lists */
+    for (unsigned int i = 0; i < sizeof(command_lists)/sizeof(entry); i++) {
         if ((entry = command_lists[i])) {
+            /* iterating over commands in command_lists entry */
             while (entry->name != NULL) {
                 printf("%-20s %s\n", entry->name, entry->desc);
                 entry++;


### PR DESCRIPTION
before, we actually duplicated code for handling of shell commands
supplied to shell_init and those hardcoded by MODULE_SHELL_COMMANDS.

This patch refactors shell.c find_handler and print_help so there's
no duplicated code.
