### PR TITLE
buildtest: dont rely on boards/Makefile.base

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -101,7 +101,7 @@ debug:
 	$(DEBUGGER) $(DEBUGGER_FLAGS)
 
 buildtest:
-	@for BOARD in $$(sed -n -e 's/ifeq[^,]*,\([^)]*\))/\1/p' $(RIOTBOARD)/Makefile.base); do \
+	@for BOARD in $$(find $(RIOTBOARD) -mindepth 1 -maxdepth 1 -type d \! -name \*-common -printf '%f\n' ); do \
 		echo -n "Building for $${BOARD} .. "; \
 		env -i HOME=$${HOME} PATH=$${PATH} BOARD=$${BOARD} RIOTBASE=$${RIOTBASE} RIOTBOARD=$${RIOTBOARD} RIOTCPU=$${RIOTCPU} $(MAKE) -B clean all >/dev/null 2>&1 && echo "success" || echo "failed"  ; \
 	done


### PR DESCRIPTION
before:

```
Building for msba2 .. success
Building for msb-430 .. success
Building for msb-430h .. success
Building for wsn430-v1_3b .. success
Building for wsn430-v1_4 .. success
Building for chronos .. success
Building for native .. success
```

after:

```
$ make buildtest
Building for msba2 .. success
Building for wsn430-v1_3b .. success
Building for olimex_lpc2148 .. failed
Building for msb-430h .. success
Building for chronos .. success
Building for msb-430 .. success
Building for pttu .. failed
Building for native .. success
Building for telosb .. success
Building for redbee-econotag .. failed
Building for wsn430-v1_4 .. success
Building for avsextrem .. success
```
