### PR TITLE
scheduler: use proper inttype for runtime, use import instead of declaration, rename to runtime_ticks

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -90,7 +90,7 @@ typedef struct {
     unsigned int laststart; /*< Time stamp of the last time this thread was
                                 scheduled to run */
     unsigned int schedules; /*< How often the thread was scheduled to run */
-    unsigned long runtime;   /*< The total runtime of this thread */
+    unsigned long runtime_ticks;   /*< The total runtime of this thread in ticks */
 } schedstat;
 
 /**

--- a/core/sched.c
+++ b/core/sched.c
@@ -57,7 +57,7 @@ void sched_init()
         sched_threads[i] = NULL;
 #if SCHEDSTATISTICS
         pidlist[i].laststart = 0;
-        pidlist[i].runtime = 0;
+        pidlist[i].runtime_ticks = 0;
         pidlist[i].schedules = 0;
 #endif
     }
@@ -97,7 +97,7 @@ void sched_run()
     unsigned long time = hwtimer_now();
 
     if (my_active_thread && (pidlist[my_active_thread->pid].laststart)) {
-        pidlist[my_active_thread->pid].runtime += time - pidlist[my_active_thread->pid].laststart;
+        pidlist[my_active_thread->pid].runtime_ticks += time - pidlist[my_active_thread->pid].laststart;
     }
 
 #endif

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -54,16 +54,16 @@ void thread_print_all(void)
             const char *sname = state_names[statebit];                      // get state name
             const char *queued = queued_name + (state & BIT0);              // get queued flag
             int stacksz = p->stack_size;                                    // get max used stack
-            double runtime = 0 / 0.0;
+            double runtime_ticks = 0 / 0.0;
             int switches = -1;
 #if SCHEDSTATISTICS
-            runtime =  pidlist[i].runtime / (double) hwtimer_now() * 100;
+            runtime_ticks =  pidlist[i].runtime_ticks / (double) hwtimer_now() * 100;
             switches = pidlist[i].schedules;
 #endif
             overall_stacksz += stacksz;
             stacksz -= thread_measure_stack_usage(p->stack_start);
             printf("\t%3u | %-21s| %-8s %.1s | %3i | %5i (%5i) %p | %6.3f%% | ",
-                   p->pid, p->name, sname, queued, p->priority, p->stack_size, stacksz, p->stack_start, runtime);
+                   p->pid, p->name, sname, queued, p->priority, p->stack_size, stacksz, p->stack_start, runtime_ticks);
             printf(" %8u\n", switches);
         }
     }


### PR DESCRIPTION
define runtime long as hwtimer_now() uses long
import hwtimer.h instead of declaring hwtimer_now()
rename runtime to reflect the unit of measurement
