### PR TITLE
fix redbee-econotag Makefile

### DIFF
--- a/boards/redbee-econotag/Makefile
+++ b/boards/redbee-econotag/Makefile
@@ -29,8 +29,8 @@ $(BINDIR)%.o: %.c
 
 # remove compilation products
 clean:
-	${MAKE} -C drivers clean
-	rm -f $(OBJ) $(DEP)
+	"$(MAKE)" -C drivers clean
+	rm -f $(BINDIR)$(ARCH) $(OBJ) $(DEP)
 	@if [ -d $(BINDIR) ] ; \
 	then rmdir $(BINDIR) ; \
 	fi

--- a/boards/redbee-econotag/Makefile.include
+++ b/boards/redbee-econotag/Makefile.include
@@ -27,3 +27,5 @@ endif
 export HEXFILE = bin/$(PROJECT).hex
 export FFLAGS = -t $(PORT) -f $(HEXFILE) -c 'bbmc -l redbee-econotag reset'
 export OFLAGS = -O binary --gap-fill=0xff
+
+export INCLUDES += -I $(RIOTCPU)/$(CPU)/include/


### PR DESCRIPTION
Had to do some fixes in the redbee-econotag Makefile to work again with new structure.
