### PR TITLE
increase rt_timer_over stacksize

### DIFF
--- a/sys/net/rpl/trickle.h
+++ b/sys/net/rpl/trickle.h
@@ -21,7 +21,7 @@
 #define TRICKLE_TIMER_STACKSIZE 3072
 #define TRICKLE_INTERVAL_STACKSIZE 3072
 #define DAO_DELAY_STACKSIZE 3072
-#define RT_STACKSIZE 512
+#define RT_STACKSIZE 3072
 
 void reset_trickletimer(void);
 void init_trickle(void);


### PR DESCRIPTION
quick'n'dirty fix for segfault in native
on native rt_timer_over now uses 1416 of 3072 (instead of 512) bytes of stack
