### PR TITLE
Trickle: remove vtimers before (re)scheduling it

### DIFF
--- a/sys/net/rpl/trickle.c
+++ b/sys/net/rpl/trickle.c
@@ -166,10 +166,12 @@ void trickle_interval_over(void)
         I_time = timex_set(0, I * 1000);
         timex_normalize(&I_time);
 
+        vtimer_remove(&trickle_t_timer);
         if (vtimer_set_wakeup(&trickle_t_timer, t_time, timer_over_pid) != 0) {
             puts("[ERROR] setting Wakeup");
         }
 
+        vtimer_remove(&trickle_I_timer);
         if (vtimer_set_wakeup(&trickle_I_timer, I_time, interval_over_pid) != 0) {
             puts("[ERROR] setting Wakeup");
         }
@@ -205,6 +207,7 @@ void dao_delay_over(void)
             dao_counter++;
             send_DAO(NULL, 0, true, 0);
             dao_time = timex_set(DEFAULT_WAIT_FOR_DAO_ACK, 0);
+            vtimer_remove(&dao_timer);
             vtimer_set_wakeup(&dao_timer, dao_time, dao_delay_over_pid);
         }
         else if (ack_received == false) {


### PR DESCRIPTION
Otherwise it might cause an endless loop in `queue.c` due to multiple nodes of the same instance (e.g. `dao_timer`).

(Would look like:

```
$5 = (struct queue_node_t *) 0x809b1e0 <dao_timer>
(gdb) print node->next->next->next->next
$6 = (struct queue_node_t *) 0x8083dfc <con_buf+7644>
(gdb) print node->next->next->next->next->next
$7 = (struct queue_node_t *) 0x809b1e0 <dao_timer>
(gdb) print node->next->next->next->next->next->next
$8 = (struct queue_node_t *) 0x8083dfc <con_buf+7644>
(gdb) print node->next->next->next->next->next->next->next
$9 = (struct queue_node_t *) 0x809b1e0 <dao_timer>
(gdb) print node->next->next->next->next->next->next->next->next
$10 = (struct queue_node_t *) 0x8083dfc <con_buf+7644>
(gdb) print node->next->next->next->next->next->next->next->next->next
$11 = (struct queue_node_t *) 0x809b1e0 <dao_timer>
```

)
