### PR TITLE
initializes watchdog properly for MSB-A2

### DIFF
--- a/boards/msba2-common/board_common_init.c
+++ b/boards/msba2-common/board_common_init.c
@@ -51,6 +51,8 @@ and the mailinglist (subscription via web site)
 #define PCRTC         BIT9
 #define CL_CPU_DIV    4
 
+#define WD_INTERVAL    10      ///< number of seconds before WD triggers
+
 /*---------------------------------------------------------------------------*/
 /**
  * @brief   Enabling MAM and setting number of clocks used for Flash memory fetch
@@ -85,8 +87,17 @@ void init_clks2(void)
     while (!(PLLSTAT & BIT25));
 }
 
+void watchdog_init(void)
+{
+    WDCLKSEL = 0;                                   // clock source: RC oscillator
+    WDMOD &= ~WDTOF;                                // clear time-out flag
+    WDTC = (F_RC_OSCILLATOR / 4) * WD_INTERVAL;
+}
+
+
 void bl_init_clks(void)
 {
+    watchdog_init();
     PCONP = PCRTC;          // switch off everything except RTC
     init_clks1();
     init_clks2();

--- a/cpu/arm_common/arm_cpu.c
+++ b/cpu/arm_common/arm_cpu.c
@@ -89,17 +89,3 @@ void thread_print_stack(void)
 
     printf("STACK (%u)= %X \n", i, *s);
 }
-
-/* LPC specific */
-#ifdef WDTC
-__attribute__((naked,noreturn)) void arm_reset(void)
-{
-    dINT();
-    WDTC   = 0x00FFF;
-    WDMOD  = 0x03;
-    WDFEED = 0xAA;
-    WDFEED = 0x55;
-
-    while (1);
-}
-#endif

--- a/cpu/lpc_common/lpc_cpu.c
+++ b/cpu/lpc_common/lpc_cpu.c
@@ -15,7 +15,7 @@
 __attribute__((naked,noreturn)) void arm_reset(void)
 {
     disableIRQ();
-    WDTC = 0x00FFF;
+    WDTC = 0x0FFFF;
     WDMOD = 0x03;
     WDFEED= 0xAA;
     WDFEED= 0x55;


### PR DESCRIPTION
It the watchdog does not reset the WDMOD, BSL pin remains ignored.
