### PR TITLE
fix native stdlib.h include

### DIFF
--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -16,7 +16,7 @@
  * @author  Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
  */
 #include <stdio.h>
-#include <stdlib.h>
+
 #ifdef __MACH__
 #define _XOPEN_SOURCE
 #endif
@@ -36,6 +36,8 @@
 #define VALGRIND_STACK_REGISTER(...)
 #define VALGRIND_DEBUG(...)
 #endif
+
+#include <stdlib.h>
 
 #include "kernel_internal.h"
 #include "sched.h"


### PR DESCRIPTION
Fixes segfault in OSX introduced by 45ffdea
