### PR TITLE
introduce msg API to send messages with accompanying buffer

### DIFF
--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -31,9 +31,14 @@
 /**
  * @brief Describes a message object which can be sent between threads.
  *
- * User can set type and one of content.ptr and content.value. (content is a union)
- * The meaning of type and the content fields is totally up to the user,
+ * User can set size field to 0 and use type and one of content.ptr and
+ * content.value for transmittine data. (Warning: content is a union)
+ * In this case the meaning of type and the content fields is totally up to the user,
  * the corresponding fields are never read by the kernel.
+ *
+ * It's also possible to have the kernel copy over an arbitrarily sized buffer.
+ * In this case, set content.ptr to the buffer's address and size to the amount
+ * of data that should be copied.
  *
  */
 typedef struct msg {
@@ -43,8 +48,10 @@ typedef struct msg {
         char     *ptr;          ///< pointer content field
         uint32_t value;         ///< value content field
     } content;
-} msg_t;
 
+    int32_t      size;          ///< size of buffer pointed to by content.ptr.
+                                ///< only used when sending extra data along.
+} msg_t;
 
 /**
  * @brief Send a message.
@@ -62,6 +69,7 @@ typedef struct msg {
  * @return 1 if sending was successful (message delivered directly or to a queue)
  * @return 0 if receiver is not waiting or has a full message queue and block == false
  * @return -1 on error (invalid PID)
+ * @return -2 if m->size larger than receiver's buffer
  */
 int msg_send(msg_t *m, unsigned int target_pid, bool block);
 
@@ -76,6 +84,7 @@ int msg_send(msg_t *m, unsigned int target_pid, bool block);
  *
  * @return 1 if sending was successful
  * @return 0 if receiver is not waiting and block == false
+ * @return -2 if m->size larger than receiver's buffer
  */
 int msg_send_int(msg_t *m, unsigned int target_pid);
 


### PR DESCRIPTION
This implementation doesn't break old-style API, e.g., code not using "big msgs" doesn't need changes.

Use case: This is useful when sending messages over network links where there's no shared memory space.

Usage:
Sender:
1. set content.ptr to the buffers pointer,
2. set new field "size" to the size of the buffer you want to copy

Receiver:
1. allocate buffer
2. see sender. ;)

Semantics:
If sender sends old-school message, it gets delivered as usual.
If sender sends a big message to a receiver that either has no buffer space or it's space is too small, msg_send returns "-2", receiver stays unaffected.
If sender sends a big message and the receiver as enough space, the extra data will be copied.

In order to use this, the sender _must_ check the return code of msg_send.

This does not work yet when the receiver has a message queue.
