### PR TITLE
enforce KERNEL_CONF_STACKSIZE_PRINTF in kernel.h

### DIFF
--- a/core/include/kernel.h
+++ b/core/include/kernel.h
@@ -55,6 +55,15 @@
 #endif
 
 /**
+ * @def KERNEL_CONF_STACKSIZE_PRINTF
+ * @ingroup conf
+ * @brief Size of the task's printf stack in bytes
+ */
+#ifndef KERNEL_CONF_STACKSIZE_PRINTF
+#error KERNEL_CONF_STACKSIZE_PRINTF must be defined per CPU
+#endif
+
+/**
  * @def KERNEL_CONF_STACKSIZE_MAIN
  * @ingroup conf
  * @brief Size of the main task's stack in bytes


### PR DESCRIPTION
fixes issue https://github.com/RIOT-OS/RIOT/issues/266 by checking for `KERNEL_CONF_STACKSIZE_PRINTF` and raising an error if not defined.
