### PR TITLE
change my email address

### DIFF
--- a/boards/msba2-common/drivers/msba2-ltc4150.c
+++ b/boards/msba2-common/drivers/msba2-ltc4150.c
@@ -37,7 +37,7 @@ and the mailinglist (subscription via web site)
  * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
  * @author		Heiko Will
  * @author		Michael Baar
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
 #include <stdio.h>

--- a/core/bitarithm.c
+++ b/core/bitarithm.c
@@ -10,7 +10,7 @@
  * \ingroup bitarithm
  * \{
  * \file
- * \author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * \author Kaspar Schleiser <kaspar@schleiser.de>
  * \author Martin Lenders <mlenders@inf.fu-berlin.de>
  * \}
  */

--- a/core/clist.c
+++ b/core/clist.c
@@ -10,7 +10,7 @@
  * @ingroup kernel
  * @{
  * @file
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @}
  */
 

--- a/core/hwtimer.c
+++ b/core/hwtimer.c
@@ -12,7 +12,7 @@
  * @file
  * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Oliver Hahm <oliver.hahm@fu-berlin.de>
  * @}
  */

--- a/core/include/atomic.h
+++ b/core/include/atomic.h
@@ -11,7 +11,7 @@
  * @{
  * @file
  * @author Freie Universität Berlin, Computer Systems & Telematics
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  */
 
 #ifndef _ATOMIC_H

--- a/core/include/bitarithm.h
+++ b/core/include/bitarithm.h
@@ -12,7 +12,7 @@
  * @{
  * @file
  * @author Freie Universität Berlin, Computer Systems & Telematics
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @author Martin Lenders <mlenders@inf.fu-berlin.de>
  */
 

--- a/core/include/clist.h
+++ b/core/include/clist.h
@@ -13,7 +13,7 @@
  * @{
  * @file
  * @author Freie Universität Berlin, Computer Systems & Telematics
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  */
 
 #ifndef __CLIST_H

--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -13,7 +13,7 @@
  * @{
  * @file
  * @author Freie Universität Berlin, Computer Systems & Telematics
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @}
  */
 

--- a/core/include/flags.h
+++ b/core/include/flags.h
@@ -10,7 +10,7 @@
  * @ingroup	kernel
  * @{
  * @file
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  */
 
 #ifndef _FLAGS_H

--- a/core/include/hwtimer_arch.h
+++ b/core/include/hwtimer_arch.h
@@ -13,7 +13,7 @@
  * @author Freie Universität Berlin, Computer Systems & Telematics
  * @author Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author Heiko Will <hwill@inf.fu-berlin.de>
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  */
 #ifndef HWTIMER_ARCH_H_
 #define HWTIMER_ARCH_H_

--- a/core/include/kernel.h
+++ b/core/include/kernel.h
@@ -11,7 +11,7 @@
  * @{
  * @file
  * @author Freie Universität Berlin, Computer Systems & Telematics
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  */
 
 #ifndef KERNEL_H_

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -10,7 +10,7 @@
  * @ingroup kernel
  * @{
  * @file
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @}
  */
 

--- a/core/msg.c
+++ b/core/msg.c
@@ -11,7 +11,7 @@
  * @{
  * @file
  * @author Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @author Oliver Hahm <oliver.hahm@inria.fr>
  * @}
  */

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -10,7 +10,7 @@
  * @ingroup kernel
  * @{
  * @file
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @}
  */
 

--- a/core/oneway_malloc.c
+++ b/core/oneway_malloc.c
@@ -12,7 +12,7 @@
  * @ingroup kernel
  * @{
  * @file
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @}
  */
 

--- a/core/queue.c
+++ b/core/queue.c
@@ -10,7 +10,7 @@
  * @ingroup kernel
  * @{
  * @file
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @}
  */
 

--- a/core/sched.c
+++ b/core/sched.c
@@ -12,7 +12,7 @@
  * @ingroup kernel
  * @{
  * @file
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @}
  */
 

--- a/core/thread.c
+++ b/core/thread.c
@@ -10,7 +10,7 @@
  * @ingroup kernel
  * @{
  * @file
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @}
  */
 

--- a/cpu/arm_common/arm_cpu.c
+++ b/cpu/arm_common/arm_cpu.c
@@ -11,7 +11,7 @@
  * @ingroup arch
  * @{
  * @file
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @author Heiko Will <heiko.will@fu-berlin.de>
  * @}
  */

--- a/drivers/ltc4150/ltc4150.c
+++ b/drivers/ltc4150/ltc4150.c
@@ -23,7 +23,7 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Heiko Will
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
 #include <hwtimer.h>

--- a/sys/lib/ringbuffer.c
+++ b/sys/lib/ringbuffer.c
@@ -11,7 +11,7 @@
  * @ingroup sys_lib
  * @{
  * @file   ringbuffer.c
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @}
  */
 

--- a/sys/lib/ringbuffer.h
+++ b/sys/lib/ringbuffer.h
@@ -11,7 +11,7 @@
  * @ingroup sys_lib
  * @{
  * @file   ringbuffer.h
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @}
  */
 


### PR DESCRIPTION
kaspar.schleiser@fu-berlin.de will be obsoleted soon. Replace it with
kaspar@schleiser.de, which will (hopefully) stay.
