### PR TITLE
make profiler a module

### DIFF
--- a/sys/Makefile
+++ b/sys/Makefile
@@ -94,6 +94,9 @@ endif
 ifneq (,$(findstring ccn_lite_client,$(USEMODULE)))
     DIRS += net/ccn_lite/util
 endif
+ifneq (,$(findstring profiling,$(USEMODULE)))
+    DIRS += profiling
+endif
 
 all: $(BINDIR)$(MODULE).a 
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;

--- a/sys/include/profiling.h
+++ b/sys/include/profiling.h
@@ -1,0 +1,7 @@
+#ifndef __PROFILING_H
+#define __PROFILING_H
+
+void profiling_init(void);
+void profiling_stats(void);
+
+#endif /* __PROFILING_H */

--- a/sys/profiling/Makefile
+++ b/sys/profiling/Makefile
@@ -1,0 +1,5 @@
+INCLUDES = -I../include -I$(RIOTBASE)/core/include -I$(RIOTBASE)/drivers/include
+MODULE = profiling
+
+include $(RIOTBASE)/Makefile.base
+

--- a/sys/profiling/profiling.c
+++ b/sys/profiling/profiling.c
@@ -1,7 +1,9 @@
 #include <stdio.h>
 #include <stdint.h>
-#include <cpu.h>
-#include <ltc4150.h>
+
+#include "cpu.h"
+#include "ltc4150.h"
+#include "hwtimer.h"
 
 #define MAX_TRACED_FUNCTIONS    (256)
 #define PROFILING_STACK_SIZE    (256)


### PR DESCRIPTION
I tried to make the profiler of the msba2 a general module...

missing parts: `hwtimer_now_ach()` is a function in native, we should consider to run the hwtimer in its own thread (perhaps its possible to tell the compiler that this function should not get profiled)

how to build: build your project with -CFLAGS="-finstrument-functions" use `void profiling_stats(void)` to print stats

what do you think?
