### PR TITLE
Revert "pointer handling in lowpan notifier was wrong"

### DIFF
--- a/sys/net/sixlowpan/lowpan.c
+++ b/sys/net/sixlowpan/lowpan.c
@@ -745,7 +745,7 @@ void lowpan_read(uint8_t *data, uint8_t length, ieee_802154_long_t *s_laddr,
             m_send.type = LOWPAN_FRAME_RECEIVED;;
             current_frame.length = length;
             current_frame.data = data;
-            m_send.content.ptr = (char *) current_frame;
+            m_send.content.ptr = (char *) &current_frame;
             msg_send(&m_send, sixlowpan_reg[i], 1);
         }
     }


### PR DESCRIPTION
This reverts commit 5ccf65316455a7590f4bd18f7af54d7444b906fc. `current_frame` is not a pointer. Hence, the "fix" was wrong.
