### PR TITLE
use CC1100_NOBYTE consistently (fixing #129)

### DIFF
--- a/drivers/cc110x/cc1100_spi.c
+++ b/drivers/cc110x/cc1100_spi.c
@@ -42,8 +42,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 //					    CC1100 SPI access
 /*---------------------------------------------------------------------------*/
 
-#define NOBYTE 0xFF
-
 uint8_t
 cc1100_spi_writeburst_reg(uint8_t addr, char *src, uint8_t count)
 {
@@ -71,7 +69,7 @@ cc1100_spi_readburst_reg(uint8_t addr, char *buffer, uint8_t count)
     cc110x_txrx(addr | CC1100_READ_BURST);
 
     while (i < count) {
-        buffer[i] = cc110x_txrx(NOBYTE);
+        buffer[i] = cc110x_txrx(CC1100_NOBYTE);
         i++;
     }
 
@@ -96,7 +94,7 @@ uint8_t cc1100_spi_read_reg(uint8_t addr)
     unsigned int cpsr = disableIRQ();
     cc110x_spi_select();
     cc110x_txrx(addr | CC1100_READ_SINGLE);
-    result = cc110x_txrx(NOBYTE);
+    result = cc110x_txrx(CC1100_NOBYTE);
     cc110x_spi_unselect();
     restoreIRQ(cpsr);
     return result;
@@ -108,7 +106,7 @@ uint8_t cc1100_spi_read_status(uint8_t addr)
     unsigned int cpsr = disableIRQ();
     cc110x_spi_select();
     cc110x_txrx(addr | CC1100_READ_BURST);
-    result = cc110x_txrx(NOBYTE);
+    result = cc110x_txrx(CC1100_NOBYTE);
     cc110x_spi_unselect();
     restoreIRQ(cpsr);
     return result;

--- a/drivers/cc110x_ng/include/cc110x-internal.h
+++ b/drivers/cc110x_ng/include/cc110x-internal.h
@@ -88,7 +88,7 @@
 #define CC1100_WRITE_BURST	(0x40) ///< Offset for burst write.
 #define CC1100_READ_SINGLE	(0x80) ///< Offset for read single byte.
 #define CC1100_READ_BURST	(0xC0) ///< Offset for read burst.
-#define CC1100_NOBYTE		(0x00) ///< No command (for reading).
+#define CC1100_NOBYTE		(0xFF) ///< No command (for reading).
 /** @} */
 
 /**

--- a/drivers/cc110x_ng/spi/cc110x_spi.c
+++ b/drivers/cc110x_ng/spi/cc110x_spi.c
@@ -44,8 +44,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 //					    CC1100 SPI access
 /*---------------------------------------------------------------------------*/
 
-#define NOBYTE 0xFF
-
 uint8_t cc110x_writeburst_reg(uint8_t addr, char *src, uint8_t count)
 {
     int i = 0;
@@ -71,7 +69,7 @@ void cc110x_readburst_reg(uint8_t addr, char *buffer, uint8_t count)
     cc110x_txrx(addr | CC1100_READ_BURST);
 
     while (i < count) {
-        buffer[i] = cc110x_txrx(NOBYTE);
+        buffer[i] = cc110x_txrx(CC1100_NOBYTE);
         i++;
     }
 
@@ -100,7 +98,7 @@ uint8_t cc110x_read_reg(uint8_t addr)
     unsigned int cpsr = disableIRQ();
     cc110x_spi_select();
     cc110x_txrx(addr | CC1100_READ_SINGLE);
-    result = cc110x_txrx(NOBYTE);
+    result = cc110x_txrx(CC1100_NOBYTE);
     cc110x_spi_unselect();
     restoreIRQ(cpsr);
     return result;
@@ -112,7 +110,7 @@ uint8_t cc110x_read_status(uint8_t addr)
     unsigned int cpsr = disableIRQ();
     cc110x_spi_select();
     cc110x_txrx(addr | CC1100_READ_BURST);
-    result = cc110x_txrx(NOBYTE);
+    result = cc110x_txrx(CC1100_NOBYTE);
     cc110x_spi_unselect();
     restoreIRQ(cpsr);
     return result;


### PR DESCRIPTION
From my understanding of the CC1100 data sheet it actually doesn't matter what is send here, but not changing the behavior of the driver seems the safest solution.
