### PR TITLE
fix: vtimer_now should return seconds and microseconds

### DIFF
--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -242,8 +242,10 @@ static int vtimer_set(vtimer_t *timer)
 
 void vtimer_now(timex_t *out)
 {
-    timex_t t = timex_set(seconds, hwtimer_now() - longterm_tick_start);
-    memcpy(out, &t, sizeof(timex_t));
+    uint32_t us = HWTIMER_TICKS_TO_US(hwtimer_now() - longterm_tick_start);
+
+    out->seconds = seconds + us / (1000 * 1000);
+    out->microseconds = us % (1000 * 1000);
 }
 
 int vtimer_init()


### PR DESCRIPTION
this is a follow up to https://github.com/RIOT-OS/RIOT/pull/457

merge after https://github.com/RIOT-OS/RIOT/pull/457
