### PR TITLE
TelosB added OFLAGS to Makefile.include

### DIFF
--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -23,3 +23,4 @@ export HEXFILE = bin/$(PROJECT).hex
 export FFLAGS = --telosb -c $(PORT) -r -e -I -p $(HEXFILE)
 
 export INCLUDES += -I $(RIOTCPU)/msp430-common/include/
+export OFLAGS = -O ihex


### PR DESCRIPTION
added OFLAGS to let objcopy produce an Intelhex file needed for TelosB
