### PR TITLE
macros are not handled by the preprocessor in ASM

### DIFF
--- a/cpu/arm_common/common.s
+++ b/cpu/arm_common/common.s
@@ -136,15 +136,15 @@ arm_irq_handler:
     MRS R1, CPSR 
     MSR SPSR, R1 
 
-#if CPU != mc1322x
+.if CPU != mc1322x
     /* jump into vic interrupt */
     mov    r0, #0xffffff00    /* lpc23xx */
     ldr    r0, [r0]
     add    lr,pc,#4
-#else
+.else
     /* mc1322x seems to lack a VIC, distinction of IRQ has to be done in SW */
 	ldr    r0, =isr           /* mc1322x */
-#endif
+.endif
 
     mov     pc, r0
     


### PR DESCRIPTION
https://github.com/RIOT-OS/RIOT/commit/6d2ed2966871a9ca6d8e7ba6b9c8a66a4249b2ff introduced some broken ASM code
