### PR TITLE
added thread.h include (necessary since 227c847135c5d85cf0e9fe5770f5c47a0e5cba3b).

### DIFF
--- a/core/mutex.c
+++ b/core/mutex.c
@@ -27,6 +27,7 @@
 #include "tcb.h"
 #include "kernel.h"
 #include "sched.h"
+#include "thread.h"
 #include "irq.h"
 
 #include "debug.h"

--- a/core/sched.c
+++ b/core/sched.c
@@ -27,6 +27,7 @@
 #include <kernel_internal.h>
 #include <clist.h>
 #include <bitarithm.h>
+#include "thread.h"
 
 #if SCHEDSTATISTICS
 #include "hwtimer.h"


### PR DESCRIPTION
Eliminates some warnings.
