### PR TITLE
change astylerc for astyle 2.0.4

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -1,5 +1,4 @@
---style=linux
---attach-namespaces
+--style=1tbs
 --indent=spaces=4
 --indent-switches
 --indent-labels


### PR DESCRIPTION
`brackets=attach` became `attach-namespaces` .. at least that is what I figure from the old and new syntax.
