### PR TITLE
Makefile cleanup 2

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,26 +1,26 @@
 ####
-#### Sample Makefile for building apps with the RIOT OS
+#### Sample Makefile for building projects with the RIOT OS
 ####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../../RIOT 
-#### 
+#### The example file system layout is:
+#### ./project makefile
+#### ../../RIOT
+####
 
-# name of your project
+# Set the name of your project:
 export PROJECT = foobar
 
-# for easy switching of boards
+# If not BOARD is found in the environment, use this default:
 export BOARD ?= native
 
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
+# This has to be the absolute path to the RIOT base directory:
+export RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# uncomment these lines if you want to use platform support from external
-# repositories
-#export RIOTCPU =$(CURDIR)/../../RIOT/thirdparty_cpu
-#export RIOTBOARD =$(CURDIR)/../../RIOT/thirdparty_boards
+# Uncomment these lines if you want to use platform support from external
+# repositories:
+#export RIOTCPU ?= $(CURDIR)/../../RIOT/thirdparty_cpu
+#export RIOTBOARD ?= $(CURDIR)/../../RIOT/thirdparty_boards
 
-# uncomment this to enable scheduler statistics for ps
+# Uncomment this to enable scheduler statistics for ps:
 #CFLAGS += -DSCHEDSTATISTICS
 
 # If you want to use valgrind, you should recompile native with either
@@ -36,7 +36,10 @@ export RIOTBASE = $(CURDIR)/../../RIOT
 # development process:
 #CFLAGS += -DDEVELHELP
 
-## Modules to include. 
+# Change this to 0 show compiler invocation lines by default:
+export QUIET ?= 1
+
+## Modules to include:
 
 #USEMODULE += shell
 #USEMODULE += uart0
@@ -48,7 +51,5 @@ export RIOTBASE = $(CURDIR)/../../RIOT
 #USEMODULE += fat
 
 export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/
-
-export QUIET := 1
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
Based on https://github.com/RIOT-OS/RIOT/pull/481
- move over documentation/options from projects/default/Makefile
- partially resolves https://github.com/RIOT-OS/RIOT/issues/438
- resolves https://github.com/RIOT-OS/RIOT/issues/478

I'd squash before merging.
