### PR TITLE
add native flash and term targets

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -11,13 +11,19 @@ export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
-FLASHER = lpc2k_pgm
-TERM = pyterm.py
 
 LINKFLAGS += -m32 -gc -ldl
 
+TERMPROG = $(BINDIR)/$(PROJECT).elf
+FLASHER = true
+
+
+ifneq (,$(findstring nativenet,$(USEMODULE)))
 ifeq ($(strip $(PORT)),)
-	export PORT = /dev/ttyUSB0
+	export PORT = tap0
+endif
+else
+	export PORT = 
 endif
 
 include $(RIOTBOARD)/$(BOARD)/Makefile.dep


### PR DESCRIPTION
flash does nothing
term starts the project with PORT misused for the tap interface
PORT is unset if nativenet is not used

Preliminarily implements https://github.com/RIOT-OS/RIOT/issues/314 - resolving it properly needs some accompanying changes in native I'd like to do later. Still, this makes native building blend with the other ports some more.
