### PR TITLE
Thread-local memory

### DIFF
--- a/core/include/tcb.h
+++ b/core/include/tcb.h
@@ -39,7 +39,6 @@
 #define STATUS_SEND_BLOCKED     (0x0080)
 #define STATUS_REPLY_BLOCKED    (0x0100)
 #define STATUS_TIMER_WAITING    (0x0200)
-#define STATUS_LOCAL_MEMORY     (0x8000)        ///< flag is set if thread-local memory was reserved
 
 typedef struct tcb_t {
     char *sp;

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -54,7 +54,8 @@ int thread_create(char *stack, int stacksize, char priority, int flags, void (*f
 /**
  * @brief   Reserve a given amount of memory on the top of the stack as thread local memory
  *
- * Always reserve the full number size of bytes or none, do not try to fit as many bytes as possible into the stack
+ * CAUTION: The function will not check wether there is actually enough space on the stack 
+ * memory for the local memory. So it is up to the caller to make sure that stacksize >> localmemsize.
  *
  * @param   stack Lowest address of preallocated stack space
  * @param   stacksize
@@ -75,9 +76,14 @@ int thread_create_with_local_mem(char *stack, int stacksize, int localmemsize, c
 
 /**
  * @brief   Acces the threads local memory
+ * 
+ * CAUTION: This function should only be called when the thread identified pid was created
+ * using thread_create_with_local_mem(), otherwise an invalid pointer poiting to how-knows-what
+ * will be returned and something hard to debug will break!
  *
  * @param[in] pid       pid of the thread to access
- * @return pointer to the threads local memory, 0 on error
+ * @return pointer to the threads local memory, random invalid memory location if 
+ *         no local memory was defined
  */
 char *thread_get_local_mem(int pid);
 

--- a/core/thread.c
+++ b/core/thread.c
@@ -242,17 +242,10 @@ int thread_create(char *stack, int stacksize, char priority, int flags, void (*f
 int thread_create_with_local_mem(char *stack, int stacksize, int localmemsize, char priority, 
                                  int flags, void (*function) (void), const char *name)
 {
-    int pid = thread_create(stack, stacksize - localmemsize, priority, flags, function, name);
-    sched_threads[pid]->status |= STATUS_LOCAL_MEMORY;
-    return pid;
+    return thread_create(stack, stacksize - localmemsize, priority, flags, function, name);
 }
 
 char *thread_get_local_mem(int pid)
 {
-    if (sched_threads[pid]->status & STATUS_LOCAL_MEMORY) {
-        return sched_threads[pid]->stack_start + sched_threads[pid]->stack_size;
-    } else {
-        return NULL;
-    }
-    
+    return sched_threads[pid]->stack_start + sched_threads[pid]->stack_size;
 }


### PR DESCRIPTION
This PR is a proposal for an implementation to reserve a memory section of the stack memory for thread-local memory. This is especially useful for device drivers that run in their own thread, as there can be any amount of driver instances without the need of reserving memory inside the driver code in advance.

For example if you want to use multiple UARTs on a board, you can just create one thread for each device and each thread will use the same code. The usage could look like this:

``` c
// somewhere in the uart code
typdef struct {...} uart_state_t;           // struct containing the memory needed for the uart driver

// during initilization:
char mem1[STACKSIZE], mem2[STACKSIZE];
int uart1_pid = thread_create_with_local_mem(mem1, STACKSIZE, sizeof(uart_state_t), PRIO, 0, &uart_run, "UART 1");
int uart1_pid = thread_create_with_local_mem(mem2, STACKSIZE, sizeof(uart_state_t), PRIO, 0, &uart_run, "UART 2");

[...]

// for accessing the thread local memory inside the uart thread:
uart_state_t *my_state = (uart_state_t*) thread_get_local_mem(thread_getpid());
```

The advantages of this implementation over using malloc() are:
- it is independent from any clib implementation
- no dynamic memory allocation needed
- its platform independent

The only drawback is the use of sizeof(char*) bytes more in the tcb_t struct (e.g. 80byte when having 20 threads on a 32-bit machine...)

Does this work for you or does anyone have a better idea how to do this? I'm open for discussion!
