### PR TITLE
Introduced a cleaned-up cpu/core interface

### DIFF
--- a/core/include/arch/atomic_arch.h
+++ b/core/include/arch/atomic_arch.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     core_arch
+ * @{
+ *
+ * @file        atomic_arch.h
+ * @brief       Architecture dependent interface for an atomic set operation
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef __ATOMIC_ARCH_H
+#define __ATOMIC_ARCH_H
+
+/**
+ * @brief Define mappings between arch and internal interfaces
+ * 
+ * This mapping is done for compatibility of existing platforms, 
+ * new platforms should always use the *_arch_* interfaces.
+ * @{
+ */
+#ifdef COREIF_NG
+#define atomic_set_return       atomic_arch_set_return
+#endif
+/** @} */
+
+/**
+ * @brief Set a value atomically without interruption from interrupts etc.
+ *
+ * @param[out]  to_set      variable to set
+ * @param[in]   value       value to set to_set to
+ *
+ * @return                  the value that was set
+ */
+unsigned int atomic_arch_set_return(unsigned int *to_set, unsigned int value);
+
+
+#endif /* __ATOMIC_ARCH_H */
+/** @} */

--- a/core/include/arch/hwtimer_arch.h
+++ b/core/include/arch/hwtimer_arch.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup	    core_arch
+ * @{
+ * 
+ * @file        hwtimer_arch.h
+ * @brief       The kernel's hardware timer abstraction interface
+ *
+ * @author      Freie Universität Berlin, Computer Systems & Telematics
+ * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
+ * @author      Heiko Will <hwill@inf.fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef HWTIMER_ARCH_H_
+#define HWTIMER_ARCH_H_
+
+#include <stdint.h>
+
+/**
+ * @brief Initialize architecture dependent kernel timer support
+ * 
+ * @brief[in] handler   callback that is called when timer offset is reached
+ * @brief[in] fcpu      the core CPU-frequency for tick interval calculation
+ */
+void hwtimer_arch_init(void (*handler)(int), uint32_t fcpu);
+
+/**
+ * @brief Enable interrupts of hardware timers
+ */
+void hwtimer_arch_enable_interrupt(void);
+
+/**
+ * @brief Disable interrupts of hardware timers
+ */
+void hwtimer_arch_disable_interrupt(void);
+
+/**
+ * @brief Set a kernel timer to raise an interrupt after ::offset kernel timer
+ *              ticks from now
+ *
+ * @param[in] offset    number of ticks until the timer fires
+ * @param[in] timer     the channel to set
+ */
+void hwtimer_arch_set(unsigned long offset, short timer);
+
+/**
+ * @brief Unset the kernel timer with the given timer ID
+ * 
+ * @param[in] timer     the channel to unset
+ */
+void hwtimer_arch_unset(short timer);
+
+/**
+ * @brief Get the current tick count of the default hardware timer
+ * 
+ * @return              the current value of the hwtimer
+ */
+unsigned long hwtimer_arch_now(void);
+
+
+#endif /* HWTIMER_ARCH_H_ */
+/** @} */

--- a/core/include/arch/io_arch.h
+++ b/core/include/arch/io_arch.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     core_arch
+ * @{
+ *
+ * @file        io_arch.h
+ * @brief       Architecture dependent interface for the standard output
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef __IO_ARCH_H
+#define __IO_ARCH_H
+
+/**
+ * @brief Define mapping between kernel internal and arch interfaces
+ * 
+ * This mapping is done for compatibility of existing platforms, 
+ * new platforms should always use the *_arch_* interfaces.
+ * @{
+ */
+#ifdef COREIF_NG
+#define fw_puts         io_arch_puts
+#endif
+/** @} */
+
+/**
+ * @brief Write a number of characters to the std-out
+ *
+ * The stdout is on most platforms mapped to the UART0. This is however only a
+ * weak convention and must not be true for all platforms.
+ *
+ * @param[in] data      the data that is to be written
+ * @param[in] count     the number of bytes to write
+ * 
+ * @return              the number of bytes that were actually written
+ */
+int io_arch_puts(char *data, int count);
+
+
+#endif /* __IO_ARCH_H */
+/** @} */

--- a/core/include/arch/irq_arch.h
+++ b/core/include/arch/irq_arch.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     core_arch
+ * @{
+ *
+ * @file        irq_arch.h
+ * @brief       Interrupt handling interface for globally en- and disabling interrupts
+ *
+ * This file acts as a wrapper between the kernels interrupt interface and the architecture
+ * dependent implementation of the interfaces.
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef __IRQ_ARCH_H
+#define __IRQ_ARCH_H
+
+/**
+ * @name Define mapping between kernel internal and arch interfaces
+ * 
+ * This mapping is done for compatibility of existing platforms, 
+ * new platforms should always use the *_arch_* interfaces.
+ * @{
+ */
+#ifdef COREIF_NG
+#define enableIRQ       irq_arch_enable
+#define disableIRQ      irq_arch_disable
+#define restoreIRQ      irq_arch_restore
+#define inISR           irq_arch_in
+#endif
+/** @} */
+
+/**
+ * @brief Globally enable maskable interrupt sources
+ * 
+ * @return              the IRQ state after enabling interrupts
+ */
+unsigned int irq_arch_eneable(void);
+
+/**
+ * @brief Globally disable all maskable interrupt sources
+ *
+ * @return              the IRQ state before disabling interrupts
+ */
+unsigned int irq_arch_disable(void);
+
+
+/**
+ * @brief Restore a previously recorded IRQ state
+ *
+ * @param[in] state     the state to set the IRQ flags to
+ */
+void irq_arch_restore(unsigned int state);
+
+/**
+ * @brief See if the current context is inside an ISR
+ *
+ * @return              1 if currently in interrupt context, 0 otherwise
+ */
+int irq_arch_in(void);
+
+
+#endif /* __IRQ_ARCH_H */
+/** @} */

--- a/core/include/arch/lpm_arch.h
+++ b/core/include/arch/lpm_arch.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     core_arch
+ * @{
+ *
+ * @file        lpm_arch.h
+ * @brief       Architecture dependent interface for power mode management
+ *
+ * This file acts as a wrapper between the kernels power management interface and the architecture
+ * dependent implementation of power management.
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef __LPM_ARCH_H
+#define __LPM_ARCH_H
+
+/**
+ * @brief Define the mapping between the architecture independent interfaces
+          and the kernel internal interfaces
+ * 
+ * This mapping is done for compatibility of existing platforms, 
+ * new platforms should always use the *_arch_* interfaces.
+ * @{
+ */
+#ifdef COREIF_NG
+#define lpm_init            lpm_arch_init
+#define lpm_set             lpm_arch_set
+#define lpm_get             lpm_arch_get
+#define lpm_awake           lpm_arch_awake
+#define lpm_begin_awake     lpm_arch_begin_awake
+#define lpm_end_awake       lpm_arch_end_awake
+#endif
+/** @} */
+
+/**
+ * @name Available power modes
+ */
+enum lpm_mode {
+    LPM_ON,             /**< MCU is active */
+    LPM_IDLE,           /**< MCU is idle */
+    LPM_SLEEP,          /**< MCU in sleep mode */
+    LPM_POWERDOWN,      /**< MCU is powered down */
+    LPM_OFF,            /**< MCU is off */
+    LPM_UNKNOWN = -1    /**< status unknown/unavailable */
+};
+
+/**
+ * @brief Initialize the controller power management
+ */
+void lpm_arch_init(void);
+
+/**
+ * @brief Try to set the controller to a given power mode
+ *
+ * @param[in] target    the desired power mode
+ *
+ * @return              the power mode that was actually set
+ */
+enum lpm_mode lpm_arch_set(enum lpm_mode target);
+
+/**
+ * @brief Get the controller's current power mode
+ *
+ * @return              the power mode the controller is currently in
+ */
+enum lpm_mode lpm_arch_get(void);
+
+/**
+ * @brief Wakeup the controller from a low-power sleep mode
+ */
+void lpm_arch_awake(void);
+
+/**
+ * @brief This hook is called on the beginning of a wake-up phase
+ */
+void lpm_arch_begin_awake(void);
+
+/**
+ * @brief This hook is called on the end of a wake-up phase
+ */
+void lpm_arch_end_awake(void);
+
+
+#endif /* __LPM_ARCH_H */
+/** @} */

--- a/core/include/arch/reboot_arch.h
+++ b/core/include/arch/reboot_arch.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     core_arch
+ * @{
+ *
+ * @file        reboot_arch.h
+ * @brief       Architecture dependent interface rebooting
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ */
+
+#ifndef __REBOOT_ARCH_H
+#define __REBOOT_ARCH_H
+
+/**
+ * @brief Reboot the system
+ *
+ * @param[in] mode  the argument is ignored and only used for conformity
+ *                  with existing reboot implementations for now.
+ *
+ * @return          this call never returns when successful. -1 is returned otherwise.
+ */
+int reboot_arch(int mode);
+
+
+#endif /* __REBOOT_ARCH_H */
+/** @} */

--- a/core/include/arch/thread_arch.h
+++ b/core/include/arch/thread_arch.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     core_arch
+ * @{
+ *
+ * @file        thread_arch.h
+ * @brief       Architecture dependent kernel interface for handling and managing threads
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef __THREAD_ARCH_H
+#define __THREAD_ARCH_H
+
+
+/**
+ * @name Define the mapping between the architecture independent interfaces
+ *       and the kernel internal interfaces
+ * 
+ * This mapping is done for compatibility of existing platforms, 
+ * new platforms should always use the *_arch_* interfaces.
+ * @{
+ */
+#ifdef COREIF_NG
+#define thread_stack_init               thread_arch_stack_init
+#define thread_print_stack              thread_arch_print_stack
+#define cpu_switch_context_exit         thread_arch_start_threading
+#define thread_yield                    thread_arch_yield
+#endif
+/** @} */
+
+
+/**
+ * @brief Initialize a thread's stack
+ *
+ * @param[in] task_func     pointer to the thread's code
+ * @param[in] stack_start   pointer to the start address of the thread
+ * @param[in] stack_size    the maximum size of the stack
+ *
+ * @return                  pointer to the new top of the stack
+ */
+char *thread_arch_stack_init(void  (*task_func)(void), void *stack_start, int stack_size);
+
+/**
+ * @brief Print the current stack to stdout
+ */
+void thread_arch_stack_print(void);
+
+/**
+ * @brief Start threading by loading a threads initial information from the stack
+ */
+void thread_arch_start_threading(void);
+
+/**
+ * @brief Pause the current thread and schedule the next pending, if available
+ */
+void thread_arch_yield(void);
+
+
+#endif /* __THREAD_ARCH_H */
+/** @} */

--- a/core/include/atomic.h
+++ b/core/include/atomic.h
@@ -20,6 +20,8 @@
 #ifndef _ATOMIC_H
 #define _ATOMIC_H
 
+#include "arch/atomic_arch.h"
+
 /**
  * @brief Sets a new and returns the old value of a variable atomically
  *

--- a/core/include/irq.h
+++ b/core/include/irq.h
@@ -22,6 +22,7 @@
 #define IRQ_H_
 
 #include <stdbool.h>
+#include "arch/irq_arch.h"
 
 /**
  * @brief   This function sets the IRQ disable bit in the status register

--- a/core/include/kernel_internal.h
+++ b/core/include/kernel_internal.h
@@ -51,15 +51,5 @@ void sched_task_exit(void);
  */
 void thread_print_stack(void);
 
-/**
- * @brief       Reboot the system
- *
- * @param mode  The argument is ignored and only used for conformity
- *              with existing reboot implementations for now.
- *
- * @return      This call never returns when successful. -1 is returned otherwise.
- */
-int reboot_arch(int mode);
-
 /** @} */
 #endif /* KERNEL_INTERNAL_H_ */

--- a/core/include/lpm.h
+++ b/core/include/lpm.h
@@ -23,17 +23,7 @@
 #ifndef LPM_H_
 #define LPM_H_
 
-/**
- * @brief   Available power modes
- */
-enum lpm_mode {
-    LPM_ON,             ///< MCU is active
-    LPM_IDLE,           ///< MCU is idle
-    LPM_SLEEP,          ///< MCU in sleep mode
-    LPM_POWERDOWN,      ///< MCU is powered down
-    LPM_OFF,            ///< MCU is off
-    LPM_UNKNOWN = -1    ///< status unknown/unavailable
-};
+#include "arch/lpm_arch.h"
 
 /**
  * @brief   Initialization of power management (including clock setup)
@@ -60,6 +50,5 @@ void lpm_end_awake(void);
  */
 enum lpm_mode lpm_get(void);
 
-
-/** @} */
 #endif /* LPM_H_ */
+/** @} */

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -25,6 +25,7 @@
 
 #include "kernel.h"
 #include "tcb.h"
+#include "arch/thread_arch.h"
 
 #define STATUS_NOT_FOUND (-1)
 

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -28,6 +28,7 @@
 #include "sched.h"
 #include "thread.h"
 #include "irq.h"
+#include "thread.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"

--- a/core/reboot.c
+++ b/core/reboot.c
@@ -19,7 +19,7 @@
  */
 
 #include "kernel.h"
-#include "kernel_internal.h"
+#include "arch/reboot_arch.h"
 
 int reboot(int mode)
 {

--- a/core/sched.c
+++ b/core/sched.c
@@ -22,11 +22,13 @@
  */
 
 #include <stdint.h>
+ 
 #include "sched.h"
 #include "kernel.h"
 #include "kernel_internal.h"
 #include "clist.h"
 #include "bitarithm.h"
+#include "irq.h"
 #include "thread.h"
 #include "irq.h"
 


### PR DESCRIPTION
In attempt of a clean-up for the interface between the core and platform (cpu) specific code I introduced an interface-collection, that extracts all platform dependent interfaces from the core into a single location (folder).

The PR can not be merged yet -> i doesn't build because the cpu implementations are not yet adapted!

But the PR can maybe help to start a short discussion if the interfaces make sense and if we should further pursue this approach... 
