### PR TITLE
auto_init: remove destiny init

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -55,10 +55,6 @@
 #include "rtc.h"
 #endif
 
-#ifdef MODULE_DESTINY
-#include "destiny.h"
-#endif
-
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -108,10 +104,6 @@ void auto_init(void)
 #ifdef MODULE_PROFILING
     extern void profiling_init(void);
     profiling_init();
-#endif
-#ifdef MODULE_DESTINY
-    DEBUG("Auto init transport layer [destiny] module.\n");
-    destiny_init_transport_layer();
 #endif
 
     main();


### PR DESCRIPTION
This handler does not fulfill its purpose to initialize the destiny
module correctly. E.g. 'examples/rpl_udp' needs to initialize some
modules in the beginning and then initialize destiny.

Fix: 'examples/rpl_udp' is currently _double_ initializing destiny.
See: https://github.com/RIOT-OS/RIOT/blob/master/examples/rpl_udp/rpl.c#L93
