### PR TITLE
rpl_udp: remove destiny init call

### DIFF
--- a/examples/rpl_udp/rpl.c
+++ b/examples/rpl_udp/rpl.c
@@ -90,7 +90,6 @@ void init(char *str)
     msg_send_receive(&m, &m, transceiver_pid);
     printf("Channel set to %u\n", RADIO_CHANNEL);
 
-    destiny_init_transport_layer();
     puts("Destiny initialized");
     /* start transceiver watchdog */
 }


### PR DESCRIPTION
This handler is called by auto_init to initialize the destiny
module correctly.

Fix: 'examples/rpl_udp' is currently double initializing destiny.
See: https://github.com/RIOT-OS/RIOT/blob/master/sys/auto_init/auto_init.c#L114
