### PR TITLE
safeguard intrinsics.h include in lpm_cpu.c

### DIFF
--- a/cpu/msp430-common/lpm_cpu.c
+++ b/cpu/msp430-common/lpm_cpu.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
-#include <intrinsics.h>   // MSP430-gcc compiler instrinsics
+#if (__GNUC__ >= 4) && (__GNUC_MINOR__ > 5)
+    #include <intrinsics.h>   // MSP430-gcc compiler instrinsics
+#endif
 
 #include "board.h"
 #include <msp430.h>


### PR DESCRIPTION
`intrinsics.h` is not provided by msp430-gcc < 4.6. Definitions of `intrinsics.h` are provided by `msp430xyyyy.h` files in 4.5. 
