### PR TITLE
Introduce board blacklists and board whitelists

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -12,6 +12,18 @@ ifeq ($(strip $(MCU)),)
 	MCU = $(CPU)
 endif
 
+ifeq (,$(filter buildtest,$(MAKECMDGOALS)))
+	ifneq (,$(BOARD_WHITELIST))
+		ifeq (,$(filter $(BOARD),$(BOARD_WHITELIST)))
+$(error This application only runs on following boards: $(BOARD_WHITELIST))
+		endif
+	endif
+
+	ifneq (,$(findstring $(BOARD),$(BOARD_BLACKLIST)))
+$(error This application does not run on following boards: $(BOARD_BLACKLIST))
+	endif
+endif
+
 # if you want to publish the board into the sources as an uppercase #define
 BB = $(shell echo $(BOARD)|tr 'a-z' 'A-Z')
 CPUDEF = $(shell echo $(CPU)|tr 'a-z' 'A-Z')
@@ -116,7 +128,18 @@ buildtest:
 		ECHO='echo'; \
 	fi; \
 	\
-	for BOARD in $$(find $(RIOTBOARD) -mindepth 1 -maxdepth 1 -type d \! -name \*-common -printf '%f\n' ); do \
+	if [ -z "$(BOARD_WHITELIST)" ]; then \
+		BOARDS=$$(find $(RIOTBOARD) -mindepth 1 -maxdepth 1 -type d \! -name \*-common -printf '%f\n' ); \
+	else \
+		BOARDS="$(BOARD_WHITELIST)"; \
+	fi; \
+	\
+	for BOARD in $(BOARD_BLACKLIST); do \
+		echo "Ignoring $${BOARD} (blacklisted)"; \
+		BOARDS=$$(echo \ $${BOARDS}\  | sed -e 's/ '$${BOARD}' / /'); \
+	done; \
+	\
+	for BOARD in $${BOARDS}; do \
 		$${ECHO} -n "Building for $${BOARD} .. "; \
 		env -i \
 			HOME=$${HOME} \


### PR DESCRIPTION
For some applications it does not make sense to be able to build on all boards (e.g. `test_cc110x_ng` in (https://github.com/RIOT-OS/projects/tree/master/test_cc110x_ng)[RIOT-OS/projects]) but it might be confusing if someone actually tries to compile it and the compiler overwhelms them with cryptic error messages.

This PR introduces two new variables into the Makefiles: `BOARD_BLACKLIST` and `BOARD_WHITELIST`.
If `BOARD_WHITELIST` is non-empty and `BOARD` is not in `BOARD_WHITELIST` make will halt with an error. If `BOARD` is in `BOARD_BLACKLIST` make will also halt with an error.
