### PR TITLE
Native hwtimer fix

### DIFF
--- a/cpu/native/hwtimer_cpu.c
+++ b/cpu/native/hwtimer_cpu.c
@@ -159,14 +159,9 @@ void schedule_timer(void)
 
     int retval = timeval_subtract(&result.it_value, &native_hwtimer[next_timer].it_value, &now);
     if (retval || (tv2ticks(&result.it_value) < HWTIMERMINOFFSET)) {
-        DEBUG("schedule_timer(): schduling interrupt for expired timer (%i).\n", next_timer);
-        /* the timeout has happened already, schedule an interrupt */
-        int sig = SIGALRM;
-        if (real_write(_sig_pipefd[1], &sig, sizeof(int)) == -1) {
-            err(EXIT_FAILURE, "schedule_timer(): real_write()");
-        }
-        _native_sigpend++;
-        return;
+        DEBUG("\033[31mschedule_timer(): timer is already due (%i), mitigating.\033[0m\n", next_timer);
+        result.it_value.tv_sec = 0;
+        result.it_value.tv_usec = 1;
     }
 
     if (setitimer(ITIMER_REAL, &result, NULL) == -1) {


### PR DESCRIPTION
With master, test_hwtimer shows the delays are relative to the previous timers, not relative to the point in time they were set (i.e. longer delays). This misbehavior changes with this PR.

The 'overdue mitigation' fix is visible in test_vtimer_msg. Without it, the output shows that the 5 second timeout is scheduled along with the 2 second timeout continuously:

```
now=6:606 -> every 2.0s: Hello World
timer_thread: set timer successfully
now=6:644 -> every 5.0s: This is a Test
timer_thread: set timer successfully
sec=6 min=0 hour=0
sec=7 min=0 hour=0
now=8:694 -> every 2.0s: Hello World
timer_thread: set timer successfully
now=8:731 -> every 5.0s: This is a Test
timer_thread: set timer successfully
sec=8 min=0 hour=0
sec=9 min=0 hour=0
```

This was due to a bad hack when handling an overdue timer.
The test output with this PR looks like one would expect:

```
sec=1 min=0 hour=0
now=2:431 -> every 2.0s: Hello World
timer_thread: set timer successfully
sec=2 min=0 hour=0
sec=3 min=0 hour=0
now=4:516 -> every 2.0s: Hello World
timer_thread: set timer successfully
sec=4 min=0 hour=0
now=5:480 -> every 5.0s: This is a Test
timer_thread: set timer successfully
sec=5 min=0 hour=0
now=6:600 -> every 2.0s: Hello World
timer_thread: set timer successfully
sec=6 min=0 hour=0
sec=7 min=0 hour=0
now=8:698 -> every 2.0s: Hello World
timer_thread: set timer successfully
sec=8 min=0 hour=0
sec=9 min=0 hour=0
now=10:557 -> every 5.0s: This is a Test
timer_thread: set timer successfully
now=10:626 -> every 2.0s: Hello World
timer_thread: set timer successfully
sec=10 min=0 hour=0
sec=11 min=0 hour=0
```
