### PR TITLE
Allow IEEE 802.15.4 addressing types for transceiver

### DIFF
--- a/sys/net/include/ieee802154_frame.h
+++ b/sys/net/include/ieee802154_frame.h
@@ -62,6 +62,20 @@ typedef struct __attribute__((packed)) {
     uint8_t payload_len;
 } ieee802154_frame_t;
 
+/**
+ * Structure to represent an IEEE 802.15.4 packet for the transceiver.
+ */
+typedef struct __attribute__(( packed )) {
+    /* @{ */
+    uint8_t processing;         /** < internal processing state */
+    uint8_t length;             /** < the length of the frame of the frame including fcs*/
+    ieee802154_frame_t frame;   /** < the ieee802154 frame */
+    int8_t rssi;                /** < the rssi value */
+    uint8_t crc;                /** < 1 if crc was successfull, 0 otherwise */
+    uint8_t lqi;                /** < the link quality indicator */
+    /* @} */
+} ieee802154_packet_t;
+
 uint8_t ieee802154_frame_init(ieee802154_frame_t *frame, uint8_t *buf);
 uint8_t ieee802154_frame_get_hdr_len(ieee802154_frame_t *frame);
 uint8_t ieee802154_frame_read(uint8_t *buf, ieee802154_frame_t *frame, uint8_t len);

--- a/sys/transceiver/Makefile
+++ b/sys/transceiver/Makefile
@@ -1,3 +1,15 @@
 MODULE =transceiver
 
+ifneq (,$(filter cc2420,$(USEMODULE)))
+	INCLUDES += -I$(RIOTBASE)/sys/net/include
+endif
+
+ifneq (,$(filter at86rf231,$(USEMODULE)))
+	INCLUDES += -I$(RIOTBASE)/sys/net/include
+endif
+
+ifneq (,$(filter mc1322x,$(USEMODULE)))
+	INCLUDES += -I$(RIOTBASE)/sys/net/include
+endif
+
 include $(MAKEBASE)/Makefile.base


### PR DESCRIPTION
IEEE 802.15.4 has two addressing modes: 16-bit short and the device's
EUI-64. Currently RIOT supports only sending of packets with 16-bit
short addresses via the transceiver interface. This patch allows at
least for the radio chips that support IEEE 802.15.4 to let the
application/upper layer decide which addressing mode to use.

Upper layer implementation will be implemented in follow-up PR to #460 so for now ccn and sixlowpan will not work with this PR

Note: there are some coding convention fixes included in this PR.
