### PR TITLE
spelling: fix autor to author

### DIFF
--- a/sys/bloom/bloom.c
+++ b/sys/bloom/bloom.c
@@ -8,9 +8,9 @@
  * details.
  *
  * @file
- * @autor Jason Linehan <patientulysses@gmail.com>
- * @autor Christian Mehlis <mehlis@inf.fu-berlin.de>
- * @autor Freie Universität Berlin, Computer Systems & Telematics
+ * @author Jason Linehan <patientulysses@gmail.com>
+ * @author Christian Mehlis <mehlis@inf.fu-berlin.de>
+ * @author Freie Universität Berlin, Computer Systems & Telematics
  *
  */
 

--- a/sys/hashes/hashes.c
+++ b/sys/hashes/hashes.c
@@ -10,7 +10,7 @@
 
 /**
  * @file
- * @autor       Jason Linehan <patientulysses@gmail.com>
+ * @author      Jason Linehan <patientulysses@gmail.com>
  * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
  */

--- a/sys/include/bloom.h
+++ b/sys/include/bloom.h
@@ -109,8 +109,8 @@
  * @file        bloom.h
  * @brief       Bloom filter API
  *
- * @autor Christian Mehlis <mehlis@inf.fu-berlin.de>
- * @autor Freie Universität Berlin, Computer Systems & Telematics
+ * @author Christian Mehlis <mehlis@inf.fu-berlin.de>
+ * @author Freie Universität Berlin, Computer Systems & Telematics
  */
 
 #ifndef _BLOOM_FILTER_H

--- a/sys/include/hashes.h
+++ b/sys/include/hashes.h
@@ -15,7 +15,7 @@
  * @file        hashes.h
  * @brief       Hash function API
  *
- * @autor       Jason Linehan <patientulysses@gmail.com>
+ * @author      Jason Linehan <patientulysses@gmail.com>
  * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
  */


### PR DESCRIPTION
found by: `$ git grep autor`
