### PR TITLE
core: msg: don't wake up sender after receive if it's REPLY_BLOCKED

### DIFF
--- a/core/msg.c
+++ b/core/msg.c
@@ -78,6 +78,9 @@ int msg_send(msg_t *m, unsigned int target_pid, bool block)
         if (target->msg_array && queue_msg(target, m)) {
             DEBUG("msg_send() %s:%i: Target %i has a msg_queue. Queueing message.\n", __FILE__, __LINE__, target_pid);
             eINT();
+            if (active_thread->status == STATUS_REPLY_BLOCKED) {
+                thread_yield();
+            }
             return 1;
         }
 


### PR DESCRIPTION
solves issue #100

If the sender is reply-blocked, waking it up after its message has been
delivered is wrong. It needs to stay reply-blocked until the reply has
been delivered.

Someone cares to write a test case?
