### PR TITLE
update Kaspar's email address

### DIFF
--- a/boards/avsextrem/board_init.c
+++ b/boards/avsextrem/board_init.c
@@ -14,7 +14,7 @@
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Heiko Will
- * @author      Kaspar Schleise
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Michael Baar
  * @author      Zakaria Kasmi
  * @author      Marco Ziegert

--- a/core/bitarithm.c
+++ b/core/bitarithm.c
@@ -13,7 +13,7 @@
  * @file        bitarithm.c
  * @brief       Bit arithmetic helper functions implementation
  *
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Martin Lenders <mlenders@inf.fu-berlin.de>
  *
  * @}

--- a/core/clist.c
+++ b/core/clist.c
@@ -13,7 +13,7 @@
  * @file        clist.c
  * @brief       Circular linked list implementation
  *
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  * @}
  */

--- a/core/include/atomic.h
+++ b/core/include/atomic.h
@@ -14,7 +14,7 @@
  * @brief       Atomic function declarations
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
 #ifndef _ATOMIC_H

--- a/core/include/bitarithm.h
+++ b/core/include/bitarithm.h
@@ -14,7 +14,7 @@
  * @brief       Helper functions for bit arithmetic
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Martin Lenders <mlenders@inf.fu-berlin.de>
  */
 

--- a/core/include/clist.h
+++ b/core/include/clist.h
@@ -14,7 +14,7 @@
  * @brief       Circular linkes list
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
 #ifndef __CLIST_H

--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -16,7 +16,7 @@
  * #define ENABLE_DEBUG, include this and then use DEBUG as printf you can toggle.
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
  
 #ifndef __DEBUG_H

--- a/core/include/flags.h
+++ b/core/include/flags.h
@@ -13,7 +13,7 @@
  * @file        flags.h
  * @brief       Misc flag definitions
  *
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
 #ifndef _FLAGS_H

--- a/core/include/hwtimer_arch.h
+++ b/core/include/hwtimer_arch.h
@@ -16,7 +16,7 @@
  * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author      Heiko Will <hwill@inf.fu-berlin.de>
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
  
 #ifndef HWTIMER_ARCH_H_

--- a/core/include/kernel.h
+++ b/core/include/kernel.h
@@ -14,7 +14,7 @@
  * @brief       Kernel compile time configuration
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
 #ifndef KERNEL_H_

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -13,7 +13,7 @@
  * @file        kernel_init.c
  * @brief       Platform-independent kernel initilization
  *
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  * @}
  */

--- a/core/msg.c
+++ b/core/msg.c
@@ -14,7 +14,7 @@
  * @brief       Kernel messaging implementation
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  *
  * @}

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -13,7 +13,7 @@
  * @file        mutex.c
  * @brief       Kernel mutex implementation
  *
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  * @}
  */

--- a/core/oneway_malloc.c
+++ b/core/oneway_malloc.c
@@ -19,7 +19,7 @@
  * 
  * Simple malloc implementation for plattforms without malloc in libc.
  * 
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  * @}
  */

--- a/core/queue.c
+++ b/core/queue.c
@@ -14,7 +14,7 @@
  * @brief       A simple queue implementation
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @}
  */
 

--- a/core/sched.c
+++ b/core/sched.c
@@ -14,7 +14,7 @@
  * @brief       Scheduler implementation
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  * @}
  *

--- a/core/thread.c
+++ b/core/thread.c
@@ -13,7 +13,7 @@
  * @file        thread.c
  * @brief       Threading implementation
  *
- * @author      Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  * @}
  */

--- a/cpu/lpc1768/cpu.c
+++ b/cpu/lpc1768/cpu.c
@@ -8,7 +8,7 @@
  * details.
  *
  * @file   cpu.c
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @author Oliver Hahm <oliver.hahm@inria.fr>
  */
 

--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -10,7 +10,7 @@
  * @ingroup vtimer
  * @{
  * @file
- * @author Kaspar Schleiser <kaspar.schleiser@fu-berlin.de> (author)
+ * @author Kaspar Schleiser <kaspar@schleiser.de> (author)
  * @author Oliver Hahm <oliver.hahm@inria.fr> (modifications)
  * @author Ludwig Ortmann <ludwig.ortmann@fu-berlin.de> (cleaning up the mess)
  * @}


### PR DESCRIPTION
kaspar.schleiser@fu-berlin.de is obsolete.
(2nd try, first try was overwritten by some overzealous documenter)
