### PR TITLE
Add quadword math library (as a PKG)

### DIFF
--- a/pkg/quad_math/.gitignore
+++ b/pkg/quad_math/.gitignore
@@ -1,0 +1,2 @@
+/quad_math
+/src

--- a/pkg/quad_math/Makefile
+++ b/pkg/quad_math/Makefile
@@ -1,0 +1,31 @@
+PKG_NAME=       quad_math
+PKG_URL=        anoncvs@anoncvs.ca.openbsd.org:/cvs
+PKG_VERSION=    -rOPENBSD_5_4
+PKG_SRC=        src/lib/libc/quad
+
+ifneq ($(RIOTBOARD),)
+include $(RIOTBOARD)/$(BOARD)/Makefile.include
+endif
+
+.PHONY: all clean distclean
+
+all: $(CURDIR)/$(PKG_NAME)/Makefile
+	"$(MAKE)" -C $(CURDIR)/$(PKG_NAME)
+
+$(CURDIR)/$(PKG_NAME)/Makefile: $(CURDIR)/$(PKG_NAME)/
+	cd $(CURDIR)/$(PKG_NAME) && patch -p0 -N -i ../patch.txt
+
+$(CURDIR)/$(PKG_NAME)/: $(CURDIR)/$(PKG_SRC)/
+	rm -rf $@
+	mkdir -p $@
+	cd $@ && cp -a $^/*.c $^/*.h .
+
+$(CURDIR)/$(PKG_SRC)/:
+	rm -rf $@
+	cvs -q -z9 -d $(PKG_URL) get $(PKG_VERSION) -P $(PKG_SRC)
+
+clean::
+	rm -rf $(CURDIR)/$(PKG_NAME)
+
+distclean:: clean
+	rm -rf $(CURDIR)/$(PKG_SRC)

--- a/pkg/quad_math/patch.txt
+++ b/pkg/quad_math/patch.txt
@@ -1,0 +1,73 @@
+diff -crBN quad.h quad.h
+*** quad.h
+--- quad.h
+***************
+*** 50,61 ****
+   */
+  
+  #include <sys/types.h>
+- #if !defined(_KERNEL) && !defined(_STANDALONE)
+  #include <limits.h>
+  #else
+! #include <sys/limits.h>
+  #endif
+  
+  /*
+   * Depending on the desired operation, we view a `long long' (aka quad_t) in
+   * one or more of the following formats.
+--- 50,75 ----
+   */
+  
+  #include <sys/types.h>
+  #include <limits.h>
++ 
++ #include <machine/endian.h>
++ typedef long long quad_t;
++ typedef unsigned long long u_quad_t;
++ 
++ #if BYTE_ORDER == LITTLE_ENDIAN
++ #	define _QUAD_LOWWORD (1)
++ #	define _QUAD_HIGHWORD (0)
++ #elif BYTE_ORDER == BIG_ENDIAN
++ #	define _QUAD_LOWWORD (0)
++ #	define _QUAD_HIGHWORD (1)
+  #else
+! #	error "BYTE_ORDER must be either LITTLE_ENDIAN or BIG_ENDIAN!"
+  #endif
+  
++ #define QUAD_MIN (LLONG_MIN)
++ #define QUAD_MAX (LLONG_MAX)
++ #define UQUAD_MAX (ULLONG_MAX)
++ 
+  /*
+   * Depending on the desired operation, we view a `long long' (aka quad_t) in
+   * one or more of the following formats.
+diff -crB qdivrem.c qdivrem.c
+*** qdivrem.c
+--- qdivrem.c
+***************
+*** 51,57 ****
+  typedef u_int digit;
+  #endif
+  
+! static void shl __P((digit *p, int len, int sh));
+  
+  /*
+   * __qdivrem(u, v, rem) returns u/v and, optionally, sets *rem to u%v.
+--- 51,57 ----
+  typedef u_int digit;
+  #endif
+  
+! static void shl(digit *p, int len, int sh);
+  
+  /*
+   * __qdivrem(u, v, rem) returns u/v and, optionally, sets *rem to u%v.
+diff -crBN Makefile Makefile
+*** Makefile
+--- Makefile
+***************
+*** 0 ****
+--- 1,3 ----
++ MODULE = quad_math
++ 
++ include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
GCC implicitly calls functions like __adddi3 to handle arithmetics on
long long. Newlib depends on these functions in its printf() but
expects them to be present.

Since every function is defined in its own compiling unit, only the
function that are actually used will wind up in the binary.

There is no need for doxygen comments; you are not supposed to call
these functions directly.

Copied from http://ftp3.usa.openbsd.org/pub/OpenBSD/src/lib/libc/quad/
which is curtesy of the OpenBSD project (3 clause BSD license).
