### PR TITLE
fix libcoap checkout target

### DIFF
--- a/pkg/libcoap/Makefile
+++ b/pkg/libcoap/Makefile
@@ -21,7 +21,7 @@ patch: $(CURDIR)/$(PKG_NAME)/Makefile
 $(CURDIR)/$(PKG_NAME)/Makefile: $(CURDIR)/$(PKG_NAME)
 	cd $< && git apply ../patch.txt
 
-$(CURDIR)/$(PKG_NAME):
+$(CURDIR)/$(PKG_NAME)/:
 	git clone $(PKG_URL) $@ && \
 		cd $@ && git checkout $(PKG_VERSION)
 


### PR DESCRIPTION
Fixes the following error:

```
make[1]: Entering directory '/foo/RIOT/pkg/libcoap'
git clone http://git.code.sf.net/p/libcoap/code /foo/RIOT/pkg/libcoap/libcoap && \
    cd /foo/RIOT/pkg/libcoap/libcoap && git checkout 89acaa6775ca3a4aedea510557e6b9c0c01fa5db
fatal: destination path '/foo/RIOT/pkg/libcoap/libcoap' already exists and is not an empty directory.
Makefile:25: recipe for target '/foo/RIOT/pkg/libcoap/libcoap' failed
```

Test case:
run `make -B clean all` twice with https://github.com/authmillenon/projects/tree/libcoap
