### PR TITLE
Fix .d file creation, separate module folders

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -1,13 +1,13 @@
 ASMSRC = $(wildcard *.s)
 ASSMSRC = $(wildcard *.S)
-ASMOBJ = $(ASMSRC:%.s=$(BINDIR)%.o)
-ASMOBJ += $(ASSMSRC:%.S=$(BINDIR)%.o)
+ASMOBJ = $(ASMSRC:%.s=$(BINDIR)$(MODULE)/%.o)
+ASMOBJ += $(ASSMSRC:%.S=$(BINDIR)$(MODULE)/%.o)
 
 ifeq ($(strip $(SRC)),)
 	SRC = $(wildcard *.c)
 endif
-OBJ = $(SRC:%.c=$(BINDIR)%.o)
-DEP = $(SRC:%.c=$(BINDIR)%.d)
+OBJ = $(SRC:%.c=$(BINDIR)$(MODULE)/%.o)
+DEP = $(SRC:%.c=$(BINDIR)$(MODULE)/%.d)
 
 GIT_STRING := $(shell git describe --abbrev=4 --dirty=-`hostname`)
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
@@ -26,22 +26,24 @@ export CFLAGS += -DVERSION=\"$(GIT_VERSION)\"
 $(BINDIR)$(MODULE).a: $(OBJ) $(ASMOBJ)
 	$(AD)$(AR) -rc $(BINDIR)$(MODULE).a $(OBJ) $(ASMOBJ)
 
-# pull in dependency info for *existing* .o files
--include $(OBJ:.o=.d)
-
 # compile and generate dependency info
-$(BINDIR)%.o: %.c
-	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -c $*.c -o $(BINDIR)$*.o
-	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -MM $*.c > $(BINDIR)$*.d
-	@printf "$(BINDIR)"|cat - $(BINDIR)$*.d > /tmp/riot_out && mv /tmp/riot_out $(BINDIR)$*.d
+$(BINDIR)$(MODULE)/%.o: %.c
+	@mkdir -p $(BINDIR)$(MODULE)
+	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -c $*.c -o $(BINDIR)$(MODULE)/$*.o
 
-$(BINDIR)%.o: %.s
-	$(AD)$(AS) $(ASFLAGS) $*.s -o $(BINDIR)$*.o
+$(DEP): $(BINDIR)$(MODULE)%.d: %.c
+	@mkdir -p $(BINDIR)$(MODULE)
+	@$(CC) $(CFLAGS) $(INCLUDES) -M -MF $(BINDIR)$(MODULE)/$*.d -MT $(BINDIR)$(MODULE)/$*.o $*.c
 
-$(BINDIR)%.o: %.S
-	$(AD)$(CC) -c $(CFLAGS) $*.S -o $(BINDIR)$*.o
+$(BINDIR)$(MODULE)/%.o: %.s
+	$(AD)$(AS) $(ASFLAGS) $*.s -o $(BINDIR)$(MODULE)/$*.o
+
+$(BINDIR)$(MODULE)/%.o: %.S
+	$(AD)$(CC) -c $(CFLAGS) $*.S -o $(BINDIR)$(MODULE)/$*.o
 
 # remove compilation products
 clean::
 	$(AD)rm -f $(BINDIR)$(MODULE).a $(OBJ) $(DEP) $(ASMOBJ)
-	
+
+.PHONY: $(DEP)
+-include $(DEP)

--- a/Makefile.include
+++ b/Makefile.include
@@ -84,13 +84,14 @@ OBJ = $(SRC:%.c=${BINDIR}${PROJECT}/%.o)
 $(BINDIR)$(PROJECT).a:  $(OBJ)
 	$(AD)$(AR) -rc $(BINDIR)$(PROJECT).a $(OBJ)
 
-# pull in dependency info for *existing* .o files
--include $(OBJ:.o=.d)
-
 $(BINDIR)$(PROJECT)/%.o: %.c $(PROJDEPS)
 	@echo; echo "Compiling.... $*.c"; echo
-	@test -d $(BINDIR)$(PROJECT) || mkdir -p $(BINDIR)$(PROJECT)
+	@mkdir -p $(BINDIR)$(PROJECT)
 	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -c $*.c -o $(BINDIR)$(PROJECT)/$*.o
+
+$(OBJ:.o=.d): $(BINDIR)$(PROJECT)/%.d: %.c $(PROJDEPS)
+	@mkdir -p $(BINDIR)$(PROJECT)
+	@$(CC) $(CFLAGS) $(INCLUDES) -M -MF $(BINDIR)$(PROJECT)/$*.d -MT $(BINDIR)$(PROJECT)/$*.o $*.c
 
 clean:
 	"$(MAKE)" -C $(RIOTBOARD)/$(BOARD) clean
@@ -115,3 +116,6 @@ buildtest:
 		echo -n "Building for $${BOARD} .. "; \
 		env -i HOME=$${HOME} PATH=$${PATH} BOARD=$${BOARD} RIOTBASE=$${RIOTBASE} RIOTBOARD=$${RIOTBOARD} RIOTCPU=$${RIOTCPU} $(MAKE) -B clean all >/dev/null 2>&1 && echo -e "\033[1;32msuccess\033[0m" || echo -e "\033[1;31mfailed\033[0m" ; \
 	done
+
+.PHONY: $(OBJ:.o=.d)
+-include $(OBJ:.o=.d)

--- a/Makefile.modules
+++ b/Makefile.modules
@@ -1,5 +1,4 @@
 export MAKEBASE =$(RIOTBASE)
-UNDEF += $(BINDIR)startup.o
 
 USEMODULE += cpu core sys
 INCLUDES += -I$(RIOTBASE)/core/include -I$(RIOTBASE)/drivers/include -I$(RIOTBASE)/sys/include

--- a/boards/chronos/Makefile.include
+++ b/boards/chronos/Makefile.include
@@ -14,7 +14,7 @@ export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
-export LINKFLAGS = -mmcu=$(MCU) -lgcc $(BINDIR)startup.o
+export LINKFLAGS = -mmcu=$(MCU) -lgcc
 export FLASHER = mspdebug
 export HEXFILE = $(BINDIR)$(PROJECT).hex
 export USEMODULE += msp430_common

--- a/boards/msb-430/Makefile
+++ b/boards/msb-430/Makefile
@@ -1,6 +1,6 @@
 MODULE =$(BOARD)_base
 
-DIRS = $(RIOTBOARD)/msb-430-common 
+DIRS = $(RIOTBOARD)/msb-430-common
 
 all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;

--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -13,7 +13,7 @@ export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
-export LINKFLAGS = -mmcu=$(MCU) -lgcc $(BINDIR)startup.o
+export LINKFLAGS = -mmcu=$(MCU) -lgcc
 export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm.py
 export FLASHER = goodfet.bsl
 ifeq ($(strip $(PORT)),)

--- a/boards/wsn430-common/Makefile.include
+++ b/boards/wsn430-common/Makefile.include
@@ -12,7 +12,7 @@ export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
-export LINKFLAGS = -mmcu=$(MCU) -lgcc $(BINDIR)startup.o
+export LINKFLAGS = -mmcu=$(MCU) -lgcc
 export FLASHER = mspdebug
 ifeq ($(strip $(PORT)),)
     export PORT = /dev/ttyUSB0

--- a/cpu/arm_common/Makefile.include
+++ b/cpu/arm_common/Makefile.include
@@ -1,4 +1,4 @@
 INCLUDES += -I$(MAKEBASE)/cpu/arm_common/include/
 
-export UNDEF += $(BINDIR)syscalls.o
+export UNDEF += $(BINDIR)arm_common/syscalls.o
 

--- a/cpu/lpc1768/Makefile.include
+++ b/cpu/lpc1768/Makefile.include
@@ -1,3 +1,3 @@
 INCLUDES += -I$(MAKEBASE)/cpu/lpc1768/include
 
-export UNDEF += $(BINDIR)syscalls.o
+export UNDEF += $(BINDIR)cpu/syscalls.o

--- a/cpu/lpc_common/Makefile.include
+++ b/cpu/lpc_common/Makefile.include
@@ -1,3 +1,3 @@
 INCLUDES += -I$(RIOTCPU)/lpc_common/include
 
-export UNDEF += $(BINDIR)lpc_syscalls.o
+export UNDEF += $(BINDIR)lpc_common/lpc_syscalls.o

--- a/cpu/mc1322x/Makefile.include
+++ b/cpu/mc1322x/Makefile.include
@@ -2,6 +2,6 @@ INCLUDES += -I$(MAKEBASE)/cpu/mc1322x/include
 
 include $(RIOTCPU)/arm_common/Makefile.include
 
-export UNDEF += $(BINDIR)mc1322x_syscalls.o
+export UNDEF += $(BINDIR)cpu/mc1322x_syscalls.o
 
 export USEMODULE += arm_common

--- a/cpu/msp430-common/Makefile.include
+++ b/cpu/msp430-common/Makefile.include
@@ -1,2 +1,3 @@
 INCLUDES += -I$(MAKEBASE)/cpu/msp430-common/include/
 
+export UNDEF += $(BINDIR)msp430_common/startup.o


### PR DESCRIPTION
Right now all .c file get compiled into the same folder: $(BINDIR).
The only exception are the user modules.
This is prone to naming clashes for different modules.
A prime example is the file "config.c" in the module config.

This diff separates the .o files per $(MODULE) subfolders in $(BINDIR),
e.g.:

```
...
├── lpc_common.a
├── msba2_base
│   ├── board_common_init.o
│   ├── board_config.o
│   ├── board_init.o
│   ├── lpc2387-timer3.o
│   ├── msba2-cc110x.o
│   ├── msba2-ltc4150.o
│   └── msba2-uart0.o
├── msba2_base.a
├── sys
│   └── chardev_thread.o
└── sys.a
```

Further this patch fixes the creation of .d files. The patch enables the
creation of fresh .d files instead of using stale ones.

The patch was tested by compiling hello-world for all boards and
comparing the file sizes with and without he changes. The resulting
binaries were only tested for native.
