### PR TITLE
check for active_thread != NULL in syscalls.c before using it

### DIFF
--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -70,6 +70,7 @@ void _native_syscall_leave()
             && (_native_in_isr == 0)
             && (_native_in_syscall == 0)
             && (native_interrupts_enabled == 1)
+            && (active_thread != NULL)
        )
     {
         _native_in_isr = 1;


### PR DESCRIPTION
fixes #498
