### PR TITLE
cib.c: added @author fields

### DIFF
--- a/core/cib.c
+++ b/core/cib.c
@@ -13,6 +13,9 @@
  * @file        cib.c
  * @brief       Circular integer buffer implementation
  *
+ * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
  * @}
  */
 


### PR DESCRIPTION
authors found in:
https://github.com/RIOT-OS/RIOT/commits/master/core/cib.c
http://ukleos.org/projects/ukleos/repository/revisions/master/changes/core/cib.c
