### PR TITLE
valgrind target for native

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -14,17 +14,30 @@ export OBJCOPY = $(PREFIX)objcopy
 export DEBUGGER = gdb
 export TERMPROG = $(ELF)
 export FLASHER = true
+export VALGRIND ?= valgrind
 
 # flags:
 export CFLAGS += -std=gnu99 -Wall -Wextra -pedantic -m32
 export LINKFLAGS += -m32 -gc -ldl
 export ASFLAGS =
 export DEBUGGER_FLAGS = $(ELF)
+export VALGRIND_FLAGS ?= --track-origins=yes
+all-valgrind: export CFLAGS += -DHAVE_VALGRIND_VALGRIND_H -g
 
 ifneq (,$(findstring nativenet,$(USEMODULE)))
 	export PORT ?= tap0
 else
 	export PORT =
 endif
+
+all: # do not override first target
+
+all-valgrind: all
+
+valgrind:
+# use this if you want to attach gdb from valgrind:
+#	echo 0 > /proc/sys/kernel/yama/ptrace_scope
+#	VALGRIND_FLAGS += --db-attach=yes
+	$(VALGRIND) $(VALGRIND_FLAGS) $(ELF) $(PORT)
 
 include $(RIOTBOARD)/$(BOARD)/Makefile.dep


### PR DESCRIPTION
Adds a `valgrind` target that works like `debug`, only with valgrind instead of gdb.
Also adds an `all-valgrind` target that can be used instead of `all` to build with the proper flags for valgrind.
