### PR TITLE
Initial import of low-level GPIO driver interface

### DIFF
--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -7,11 +7,11 @@
 
 /**
  * @ingroup     driver_periph
- * @brief       Low-level GPIO periphial driver
+ * @brief       Low-level GPIO peripheral driver
  * @{
  *
  * @file        gpio.h
- * @brief       Low-level GPIO periphial driver interface definitions
+ * @brief       Low-level GPIO peripheral driver interface definitions
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
@@ -23,7 +23,7 @@
 
 
 /**
- * @brief Definition of available GPIO devices. Each device is managin exactly one pin.
+ * @brief Definition of available GPIO devices. Each device is managing exactly one pin.
  */
 #ifdef GPIO_NUMOF
 typedef enum {
@@ -115,7 +115,7 @@ void gpio_init_in(gpio_t dev, gpio_pp_t pullup);
 /**
  * @brief Initialize a GPIO pin for external interrupt usage
  * 
- * The registerd callback function will be called in interrupt context everytime the defined flank(s)
+ * The registered callback function will be called in interrupt context every time the defined flank(s)
  * are detected.
  * 
  * The interrupt is activated automatically after the initialization.


### PR DESCRIPTION
Here is a proposed interface for a low-level GPIO driver interface.

For each platform the GPIO devices (one for each pin) are statically assigned to a specific pin in the 'periph_conf.h' file (which needs to be defined for each board). This can for example look like this:
GPIO_1 --> PA.2
GPIO_2 --> PB.14
GPIO_3 --> PD1 ... you get the picture.

This approach has the benefit, that pins used by applications are completely independent of the underlying platform, so code using this interface is hardware independent and portable. 

For now there are 15 GPIOs defined (if a platform has less pins defined, it can disable them by undefining the corresponding GPIO_x_EN in the boards 'periph_conf.h' file).
