### PR TITLE
upgrade buildtest for CI

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -133,5 +133,9 @@ buildtest:
 			$${ECHO} "$${GREEN}success$${RESET}"; \
 		else \
 			$${ECHO} "$${RED}failed$${RESET}"; \
+			BUILDTESTFAILED=1; \
 		fi; \
 	done; \
+	if [ "$${BUILDTESTFAILED}" = "1" ]; then \
+		exit 1; \
+	fi


### PR DESCRIPTION
- colorize buildtest output only if supported
- make buildtest fail on error - closes #607
