### PR TITLE
Initial import of the stm32f3discovery board

### DIFF
--- a/boards/stm32f3discovery/Makefile
+++ b/boards/stm32f3discovery/Makefile
@@ -1,0 +1,17 @@
+
+# tell the Makefile.base which module to build
+MODULE = board
+
+# add a list of board specific subdirectories that should also be build
+DIRS = 
+
+.PHONY: all clean
+
+all: $(BINDIR)$(MODULE).a
+	@for i in $(DIRS) ; do $(MAKE) -C $$i ; done ;
+
+include $(RIOTBASE)/Makefile.base
+
+clean::
+	@for i in $(DIRS) ; do $(MAKE) -C $$i clean ; done ;
+

--- a/boards/stm32f3discovery/Makefile.include
+++ b/boards/stm32f3discovery/Makefile.include
@@ -1,0 +1,27 @@
+
+# define the cpu used by the stm32f3-discovery board
+export CPU = stm32f303vc
+
+# define tools used for building the project
+export PREFIX = arm-none-eabi-
+export CC = $(PREFIX)gcc
+export AR = $(PREFIX)ar
+export AS = $(PREFIX)as
+export LINK = $(PREFIX)gcc
+export SIZE = $(PREFIX)size
+export OBJCOPY = $(PREFIX)objcopy
+export FLASHER = st-flash
+export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm.py
+
+# define build specific options
+export FPU_USAGE = -mfloat-abi=hard -mfpu=fpv4-sp-d16
+export CFLAGS = -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes -mcpu=cortex-m4 $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+#export CFLAGS += -flto ffunction-sections -fdata-sections -fno-builtin  # addiontal compiler flags to optimize compiling for newlib-nano
+export ASFLAGS = -ggdb -g3 -mcpu=cortex-m4 $(FPU_USAGE) -mlittle-endian
+export FFLAGS = write bin/$(PROJECT).bin 0x8000000
+export LINKFLAGS = -g3 -ggdb -std=gnu99 -mcpu=cortex-m4 $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles -T$(RIOTBASE)/cpu/$(CPU)/$(CPU)_linkerscript.ld
+export LINKFLAGS += -specs=nano.specs -lc -lnosys                       # additional linker flags to enable newlib-nano
+
+
+# export board specific includes to the global includes-listing
+export INCLUDES += -I$(RIOTBOARD)/stm32f3discovery/include

--- a/boards/stm32f3discovery/include/board.h
+++ b/boards/stm32f3discovery/include/board.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    board_stm32f3discovery STM32F3Discovery
+ * @ingroup     boards
+ * @brief       Board definitons for the STM32F3Discovery board.
+ * @{
+ *
+ * @file        board.h
+ * @brief       Board specific definitions for the STM32F3Discovery evaluation board.
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef __BOARD_H
+#define __BOARD_H
+
+/**
+ * Define the nominal CPU core clock in this board
+ */
+#define F_CPU               (72000000U)
+
+/**
+ * @brief Configure the hardware timer
+ */
+#define ARCH_MAXTIMERS      (4U)
+#define HW_TIMER            TIMER_0
+
+/**
+ * @brief Assign the UART that should be used as standard IO
+ */
+#define STD_IO              UART_0
+#define STD_IO_BAUDRATE     (115200U)
+
+/**
+ * @brief Assign the board's LEDs
+ */
+#define LED_3               GPIO_8
+#define LED_4               GPIO_9
+#define LED_5               GPIO_10
+#define LED_6               GPIO_11
+#define LED_7               GPIO_12
+#define LED_8               GPIO_13
+#define LED_9               GPIO_14
+#define LED_10              GPIO_15
+// for compatability to other boards
+#define RED_LED             LED_3
+#define GREEN_LED           LED_10
+
+/**
+ * @brief Assign the board's user button
+ */
+#define USER_BUTTON         GPIO_7
+
+/**
+ * @brief Assign on board L3GD20 Gyroscope
+ */
+#define L3GD20_SPI          SPI_0
+#define L3GD20_INT1         GPIO_4
+#define L3GD20_INT2         GPIO_5
+#define L3GD20_CS           GPIO_3
+
+/**
+ * @brief Assign on board LSM303DLHC accelero- and magnetometer
+ */
+#define LSM303DLHC_I2C      I2C_0
+#define LSM303DLHC_DRDY     GPIO_0
+#define LSM303DLHC_INT1     GPIO_1
+#define LSM303DLHC_INT2     GPIO_2
+
+/**
+ * @brief Initialize a minimal board configuration by initializing the LEDs and UART_0.
+ */
+void board_init(void);
+
+
+#endif /** __BOARD_H */
+/** @} */


### PR DESCRIPTION
- import of board makefiles
- import of board.h
  --> board.c is still missing due to licensing problems

The board configuration in board.h is using the low-level periphial driver as proposed in PRs #611 to #616.

In this state the board is not complete yet, I have further commits pending and will append them once we solved the licensing issue with some ST-lib start-up code...
