### PR TITLE
Do not assume 0x0 to be an unusable address

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -14,7 +14,7 @@ endif
 # if you want to publish the board into the sources as an uppercase #define
 BB = $(shell echo $(BOARD)|tr 'a-z' 'A-Z')
 CPUDEF = $(shell echo $(CPU)|tr 'a-z' 'A-Z')
-CFLAGS += -DBOARD=$(BB) -DCPU_$(CPUDEF)
+CFLAGS += -DBOARD=$(BB) -DCPU_$(CPUDEF) -fno-delete-null-pointer-checks
 export CFLAGS
 
 export BINDIR =$(CURDIR)/bin/$(BOARD)/


### PR DESCRIPTION
I just ran into the problem that GCC assumes that a pointer cannot be NULL, if you have accessed it previously, e.g.

```
unsigned *x = ...;
printf("%p is %u\n", (void *) x, *x);
if (!x) break;
else ...
```

The problem is that 0x0 is a perfectly fine address to read from without an MMU / paging.
So it is completely unreasonable that the `if (!x)` is dropped without any sort of warning. 
