### PR TITLE
[RFC] add oonf_api to pkg

### DIFF
--- a/pkg/oonf_api/0001-add-RIOT-support.patch
+++ b/pkg/oonf_api/0001-add-RIOT-support.patch
@@ -1,0 +1,480 @@
+From 012da8d41806ae98adab8cb4e88e52c2e675ab4f Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benpicco@zedat.fu-berlin.de>
+Date: Wed, 5 Feb 2014 20:01:41 +0100
+Subject: [PATCH 1/3] add RIOT support
+
+---
+ Makefile                             | 29 ++++++++++++++
+ external/regex/Makefile              |  4 ++
+ src-api/common/Makefile              |  3 ++
+ src-api/common/autobuf.c             |  6 +++
+ src-api/common/common_types.h        |  5 +++
+ src-api/common/daemonize.c           |  2 +-
+ src-api/common/netaddr.c             | 74 +++++++++++++++++++++---------------
+ src-api/common/netaddr.h             | 22 +++++++----
+ src-api/rfc5444/Makefile             |  3 ++
+ src-api/rfc5444/rfc5444_api_config.h | 51 +++++++++++++++++++++++++
+ src-api/rfc5444/rfc5444_print.c      |  5 +++
+ 11 files changed, 165 insertions(+), 39 deletions(-)
+ create mode 100644 Makefile
+ create mode 100644 external/regex/Makefile
+ create mode 100644 src-api/common/Makefile
+ create mode 100644 src-api/rfc5444/Makefile
+ create mode 100644 src-api/rfc5444/rfc5444_api_config.h
+
+diff --git a/Makefile b/Makefile
+new file mode 100644
+index 0000000..cf66baa
+--- /dev/null
++++ b/Makefile
+@@ -0,0 +1,29 @@
++#
++# to use oonf_api in your RIOT project,
++# add the following to your Makefile:
++#
++#	export OONFBASE   = /path/to/this/directory
++#	EXTERNAL_MODULES += $(OONFBASE)
++#
++# this provides the following modules:
++#	oonf_common	-	avl tree, list, netaddr, regex, string functions
++#	oonf_rfc5444	-	packetBB implementation, requires oonf_common
++
++ifneq (,$(filter oonf_common,$(USEMODULE)))
++	DIRS += src-api/common
++endif
++ifneq (,$(filter oonf_rfc5444,$(USEMODULE)))
++	DIRS += src-api/rfc5444
++endif
++ifneq (,$(filter oonf_cunit,$(USEMODULE)))
++	DIRS += tests/cunit
++endif
++ifneq (,$(filter oonf_regex,$(USEMODULE)))
++	DIRS += external/regex
++endif
++
++all:
++	mkdir -p $(BINDIR)
++	@for i in $(DIRS) ; do $(MAKE) -C $$i ; done ;
++
++clean:
+diff --git a/external/regex/Makefile b/external/regex/Makefile
+new file mode 100644
+index 0000000..3bc1ce1
+--- /dev/null
++++ b/external/regex/Makefile
+@@ -0,0 +1,4 @@
++MODULE:=oonf_$(shell basename $(CURDIR))
++INCLUDES += $(CURDIR)/..
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/src-api/common/Makefile b/src-api/common/Makefile
+new file mode 100644
+index 0000000..5e0046d
+--- /dev/null
++++ b/src-api/common/Makefile
+@@ -0,0 +1,3 @@
++MODULE:=oonf_$(shell basename $(CURDIR))
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/src-api/common/autobuf.c b/src-api/common/autobuf.c
+index 77c519b..e09c0c9 100644
+--- a/src-api/common/autobuf.c
++++ b/src-api/common/autobuf.c
+@@ -51,6 +51,12 @@
+ #include <winsock2.h>
+ #endif
+ 
++#ifdef RIOT
++int getpagesize(void) {
++	return 512;
++}
++#endif
++
+ #include "common/autobuf.h"
+ 
+ /**
+diff --git a/src-api/common/common_types.h b/src-api/common/common_types.h
+index c90cf46..54ce281 100644
+--- a/src-api/common/common_types.h
++++ b/src-api/common/common_types.h
+@@ -77,6 +77,11 @@
+   #define PRINTF_SIZE_T_HEX_SPECIFIER "Ix"
+   #define PRINTF_SSIZE_T_SPECIFIER    "Id"
+   #define PRINTF_PTRDIFF_T_SPECIFIER  "Id"
++#elif defined(RIOT)
++  #define PRINTF_SIZE_T_SPECIFIER      "d"
++  #define PRINTF_SIZE_T_HEX_SPECIFIER  "x"
++  #define PRINTF_SSIZE_T_SPECIFIER     "d"
++  #define PRINTF_PTRDIFF_T_SPECIFIER   "d"
+ #elif defined(__GNUC__)
+   #define PRINTF_SIZE_T_SPECIFIER     "zu"
+   #define PRINTF_SIZE_T_HEX_SPECIFIER "zx"
+diff --git a/src-api/common/daemonize.c b/src-api/common/daemonize.c
+index 103c88f..6ea603d 100644
+--- a/src-api/common/daemonize.c
++++ b/src-api/common/daemonize.c
+@@ -48,7 +48,7 @@
+ #include "common/common_types.h"
+ #include "common/daemonize.h"
+ 
+-#ifndef WIN32
++#if (!defined(_WIN32)) && (!defined(RIOT))
+ /**
+  * Prepare the start of a daemon. Fork into background,
+  * but keep stdin/out/err open and a pipe connected to
+diff --git a/src-api/common/netaddr.c b/src-api/common/netaddr.c
+index dedab2c..fdc3e82 100644
+--- a/src-api/common/netaddr.c
++++ b/src-api/common/netaddr.c
+@@ -43,7 +43,14 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#ifndef RIOT
+ #include <net/if.h>
++#else
++#include "net_help.h"
++#include "inet_ntop.h"
++#include "inet_pton.h"
++#define DONT_HAVE_SIN6_SCOPE_ID
++#endif
+ 
+ #include "common/common_types.h"
+ #include "common/string.h"
+@@ -175,12 +182,12 @@ netaddr_to_binary(void *dst, const struct netaddr *src, size_t len) {
+ int
+ netaddr_from_socket(struct netaddr *dst, const union netaddr_socket *src) {
+   memset(dst->_addr, 0, sizeof(dst->_addr));
+-  if (src->std.sa_family == AF_INET) {
++  if (src->std.sin6_family == AF_INET) {
+     /* ipv4 */
+-    memcpy(dst->_addr, &src->v4.sin_addr, 4);
++    memcpy(dst->_addr, &src->v4.sin6_addr, 4);
+     dst->_prefix_len = 32;
+   }
+-  else if (src->std.sa_family == AF_INET6){
++  else if (src->std.sin6_family == AF_INET6){
+     /* ipv6 */
+     memcpy(dst->_addr, &src->v6.sin6_addr, 16);
+     dst->_prefix_len = 128;
+@@ -190,7 +197,7 @@ netaddr_from_socket(struct netaddr *dst, const union netaddr_socket *src) {
+     dst->_type = AF_UNSPEC;
+     return -1;
+   }
+-  dst->_type = (uint8_t)src->std.sa_family;
++  dst->_type = (uint8_t)src->std.sin6_family;
+   return 0;
+ }
+ 
+@@ -204,12 +211,12 @@ netaddr_from_socket(struct netaddr *dst, const union netaddr_socket *src) {
+ int
+ netaddr_to_socket(union netaddr_socket *dst, const struct netaddr *src) {
+   /* copy address type */
+-  dst->std.sa_family = src->_type;
++  dst->std.sin6_family = src->_type;
+ 
+   switch (src->_type) {
+     case AF_INET:
+       /* ipv4 */
+-      memcpy(&dst->v4.sin_addr, src->_addr, 4);
++      memcpy(&dst->v4.sin6_addr, src->_addr, 4);
+       break;
+     case AF_INET6:
+       /* ipv6 */
+@@ -221,7 +228,7 @@ netaddr_to_socket(union netaddr_socket *dst, const struct netaddr *src) {
+   }
+ 
+   /* copy address type */
+-  dst->std.sa_family= src->_type;
++  dst->std.sin6_family= src->_type;
+   return 0;
+ }
+ 
+@@ -319,14 +326,16 @@ netaddr_socket_init(union netaddr_socket *combined, const struct netaddr *addr,
+   switch (addr->_type) {
+     case AF_INET:
+       /* ipv4 */
+-      memcpy(&combined->v4.sin_addr, addr->_addr, 4);
+-      combined->v4.sin_port = htons(port);
++      memcpy(&combined->v4.sin6_addr, addr->_addr, 4);
++      combined->v4.sin6_port = HTONS(port);
+       break;
+     case AF_INET6:
+       /* ipv6 */
+       memcpy(&combined->v6.sin6_addr, addr->_addr, 16);
+-      combined->v6.sin6_port = htons(port);
++      combined->v6.sin6_port = HTONS(port);
++#ifndef DONT_HAVE_SIN6_SCOPE_ID      
+       combined->v6.sin6_scope_id = if_index;
++#endif
+       break;
+     default:
+       /* unknown address type */
+@@ -334,7 +343,7 @@ netaddr_socket_init(union netaddr_socket *combined, const struct netaddr *addr,
+   }
+ 
+   /* copy address type */
+-  combined->std.sa_family = addr->_type;
++  combined->std.sin6_family = addr->_type;
+   return 0;
+ }
+ 
+@@ -344,11 +353,11 @@ netaddr_socket_init(union netaddr_socket *combined, const struct netaddr *addr,
+  */
+ uint16_t
+ netaddr_socket_get_port(const union netaddr_socket *sock) {
+-  switch (sock->std.sa_family) {
++  switch (sock->std.sin6_family) {
+     case AF_INET:
+-      return ntohs(sock->v4.sin_port);
++      return NTOHS(sock->v4.sin6_port);
+     case AF_INET6:
+-      return ntohs(sock->v6.sin6_port);
++      return NTOHS(sock->v6.sin6_port);
+     default:
+       return 0;
+   }
+@@ -555,28 +564,31 @@ const char *
+ netaddr_socket_to_string(struct netaddr_str *dst, const union netaddr_socket *src) {
+   struct netaddr_str buf;
+ 
+-  if (src->std.sa_family == AF_INET) {
++  if (src->std.sin6_family == AF_INET) {
+     snprintf(dst->buf, sizeof(*dst), "%s:%d",
+-        inet_ntop(AF_INET, &src->v4.sin_addr, buf.buf, sizeof(buf)),
+-        ntohs(src->v4.sin_port));
++        inet_ntop(AF_INET, &src->v4.sin6_addr, buf.buf, sizeof(buf)),
++        NTOHS(src->v4.sin6_port));
+   }
+-  else if (src->std.sa_family == AF_INET6) {
++  else if (src->std.sin6_family == AF_INET6) {
++#ifndef DONT_HAVE_SIN6_SCOPE_ID
+     if (src->v6.sin6_scope_id) {
+       char scope_buf[IF_NAMESIZE];
+ 
+       snprintf(dst->buf, sizeof(*dst), "[%s]:%d%%%s",
+           inet_ntop(AF_INET6, &src->v6.sin6_addr, buf.buf, sizeof(buf)),
+-          ntohs(src->v6.sin6_port),
++          NTOHS(src->v6.sin6_port),
+           if_indextoname(src->v6.sin6_scope_id, scope_buf));
+     }
+-    else {
++    else
++#endif
++    {
+       snprintf(dst->buf, sizeof(*dst), "[%s]:%d",
+           inet_ntop(AF_INET6, &src->v6.sin6_addr, buf.buf, sizeof(buf)),
+-          ntohs(src->v6.sin6_port));
++          NTOHS(src->v6.sin6_port));
+     }
+   }
+   else {
+-    snprintf(dst->buf, sizeof(*dst), "\"Unknown socket type: %d\"", src->std.sa_family);
++    snprintf(dst->buf, sizeof(*dst), "\"Unknown socket type: %d\"", src->std.sin6_family);
+   }
+ 
+   return dst->buf;
+@@ -622,13 +634,13 @@ int
+ netaddr_cmp_to_socket(const struct netaddr *a1, const union netaddr_socket *a2) {
+   int result = 0;
+ 
+-  result = (int)a1->_type - (int)a2->std.sa_family;
++  result = (int)a1->_type - (int)a2->std.sin6_family;
+   if (result) {
+     return result;
+   }
+ 
+   if (a1->_type == AF_INET) {
+-    result = memcmp(a1->_addr, &a2->v4.sin_addr, 4);
++    result = memcmp(a1->_addr, &a2->v4.sin6_addr, 4);
+   }
+   else if (a1->_type == AF_INET6) {
+     /* ipv6 */
+@@ -741,20 +753,20 @@ const char *
+ inet_ntop(int af, const void *src, char *dst, socklen_t cnt)
+ {
+   if (af == AF_INET) {
+-    struct sockaddr_in in;
++    sockaddr6_t in;
+     memset(&in, 0, sizeof(in));
+     in.sin_family = AF_INET;
+-    memcpy(&in.sin_addr, src, sizeof(struct in_addr));
+-    getnameinfo((struct sockaddr *)&in, sizeof(struct sockaddr_in),
++    memcpy(&in.sin6_addr, src, sizeof(struct in_addr));
++    getnameinfo((sockaddr6_t *)&in, sizeof(sockaddr6_t),
+         dst, cnt, NULL, 0, NI_NUMERICHOST);
+     return dst;
+   }
+   else if (af == AF_INET6) {
+-    struct sockaddr_in6 in;
++    sockaddr6_t in;
+     memset(&in, 0, sizeof(in));
+     in.sin6_family = AF_INET6;
+     memcpy(&in.sin6_addr, src, sizeof(struct in_addr6));
+-    getnameinfo((struct sockaddr *)&in, sizeof(struct sockaddr_in6),
++    getnameinfo((sockaddr6_t *)&in, sizeof(sockaddr6_t),
+         dst, cnt, NULL, 0, NI_NUMERICHOST);
+     return dst;
+   }
+@@ -795,7 +807,7 @@ inet_pton(int af, const char *src, void *dst)
+ 
+   sock = (union netaddr_socket *)res->ai_addr;
+   if (af == AF_INET) {
+-    memcpy(dst, &sock->v4.sin_addr, 4);
++    memcpy(dst, &sock->v4.sin6_addr, 4);
+   }
+   else {
+     memcpy(dst, &sock->v6.sin6_addr, 16);
+@@ -928,7 +940,7 @@ _subnetmask_to_prefixlen(const char *src) {
+   }
+ 
+   /* transform into host byte order */
+-  v4 = ntohl(v4);
++  v4 = NTOHL(v4);
+ 
+   shift = 0xffffffff;
+   for (len = 31; len >= 0; len--) {
+diff --git a/src-api/common/netaddr.h b/src-api/common/netaddr.h
+index 78fd5b4..cfba7a9 100644
+--- a/src-api/common/netaddr.h
++++ b/src-api/common/netaddr.h
+@@ -43,18 +43,26 @@
+ #define NETADDR_H_
+ 
+ 
+-#ifndef _WIN32
++#if (!defined(_WIN32)) && (!defined(RIOT))
+ #include <arpa/inet.h>
+ #include <netinet/if_ether.h>
+ #include <netinet/ip.h>
+ #include <net/if.h>
+-#else
++#endif
++
++#ifdef _WIN32
+ #include <winsock2.h>
+ #include <ws2tcpip.h>
+ 
+ #define IF_NAMESIZE 16
+ #endif
+ 
++#ifdef RIOT
++#include "destiny/socket.h"
++#define INET_ADDRSTRLEN		(16)
++#define INET6_ADDRSTRLEN	(48)
++#endif
++
+ #include <assert.h>
+ #include <string.h>
+ 
+@@ -97,10 +105,10 @@ struct netaddr {
+  * to all variants without casting and compiler warnings.
+  */
+ union netaddr_socket {
+-  struct sockaddr_in v4;
+-  struct sockaddr_in6 v6;
+-  struct sockaddr std;
+-  struct sockaddr_storage storage;
++  sockaddr6_t v4;
++  sockaddr6_t v6;
++  sockaddr6_t std;
++  sockaddr6_t storage;
+ };
+ 
+ /**
+@@ -337,7 +345,7 @@ netaddr_set_prefix_length(struct netaddr *n, uint8_t prefix_len) {
+  */
+ static INLINE sa_family_t
+ netaddr_socket_get_addressfamily(const union netaddr_socket *s) {
+-  return s->std.sa_family;
++  return s->std.sin6_family;
+ }
+ 
+ #endif /* NETADDR_H_ */
+diff --git a/src-api/rfc5444/Makefile b/src-api/rfc5444/Makefile
+new file mode 100644
+index 0000000..5e0046d
+--- /dev/null
++++ b/src-api/rfc5444/Makefile
+@@ -0,0 +1,3 @@
++MODULE:=oonf_$(shell basename $(CURDIR))
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/src-api/rfc5444/rfc5444_api_config.h b/src-api/rfc5444/rfc5444_api_config.h
+new file mode 100644
+index 0000000..9bf6622
+--- /dev/null
++++ b/src-api/rfc5444/rfc5444_api_config.h
+@@ -0,0 +1,51 @@
++
++/*
++ * The olsr.org Optimized Link-State Routing daemon(olsrd)
++ * Copyright (c) 2004-2012, the olsr.org team - see HISTORY file
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *
++ * * Redistributions of source code must retain the above copyright
++ *   notice, this list of conditions and the following disclaimer.
++ * * Redistributions in binary form must reproduce the above copyright
++ *   notice, this list of conditions and the following disclaimer in
++ *   the documentation and/or other materials provided with the
++ *   distribution.
++ * * Neither the name of olsr.org, olsrd nor the names of its
++ *   contributors may be used to endorse or promote products derived
++ *   from this software without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
++ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
++ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
++ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
++ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
++ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
++ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
++ * POSSIBILITY OF SUCH DAMAGE.
++ *
++ * Visit http://www.olsr.org for more information.
++ *
++ * If you find this software useful feel free to make a donation
++ * to the project. For more information see the website or contact
++ * the copyright holders.
++ *
++ */
++
++#ifndef RFC5444_API_CONFIG_H_
++#define RFC5444_API_CONFIG_H_
++
++#define DISALLOW_CONSUMER_CONTEXT_DROP false
++#define WRITER_STATE_MACHINE true
++#define DEBUG_CLEANUP true
++#define DO_ADDR_COMPRESSION true
++#define CLEAR_ADDRESS_POSTFIX false
++
++#endif /* RFC5444_API_CONFIG_H_ */
+diff --git a/src-api/rfc5444/rfc5444_print.c b/src-api/rfc5444/rfc5444_print.c
+index 4b3e04d..6b52f72 100644
+--- a/src-api/rfc5444/rfc5444_print.c
++++ b/src-api/rfc5444/rfc5444_print.c
+@@ -41,8 +41,13 @@
+ #include <assert.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef RIOT
++#include "destiny/socket.h"
++#include "inet_ntop.h"
++#else
+ #include <sys/socket.h>
+ #include <arpa/inet.h>
++#endif
+ 
+ #include "common/netaddr.h"
+ #include "rfc5444/rfc5444_reader.h"
+-- 
+1.8.3.2
+

--- a/pkg/oonf_api/0002-port-tests-to-riot.patch
+++ b/pkg/oonf_api/0002-port-tests-to-riot.patch
@@ -1,0 +1,206 @@
+From 2c8298434b94506140893c540c49760ad7eb636f Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benpicco@zedat.fu-berlin.de>
+Date: Tue, 23 Jul 2013 21:08:31 +0200
+Subject: [PATCH 2/3] port tests to riot
+
+---
+ tests/common/.Makefile.template                 | 45 +++++++++++++++++++++++++
+ tests/common/bin/.gitignore                     |  0
+ tests/common/generate_makefiles.sh              |  8 +++++
+ tests/common/test_common_avl.c                  | 10 +++---
+ tests/cunit/Makefile                            |  3 ++
+ tests/rfc5444/.Makefile.template                | 39 +++++++++++++++++++++
+ tests/rfc5444/bin/.gitignore                    |  0
+ tests/rfc5444/generate_makefiles.sh             |  8 +++++
+ tests/rfc5444/test_rfc5444_reader_dropcontext.c |  2 +-
+ 9 files changed, 109 insertions(+), 6 deletions(-)
+ create mode 100644 tests/common/.Makefile.template
+ create mode 100644 tests/common/bin/.gitignore
+ create mode 100755 tests/common/generate_makefiles.sh
+ create mode 100644 tests/cunit/Makefile
+ create mode 100644 tests/rfc5444/.Makefile.template
+ create mode 100644 tests/rfc5444/bin/.gitignore
+ create mode 100755 tests/rfc5444/generate_makefiles.sh
+
+diff --git a/tests/common/.Makefile.template b/tests/common/.Makefile.template
+new file mode 100644
+index 0000000..c286ad3
+--- /dev/null
++++ b/tests/common/.Makefile.template
+@@ -0,0 +1,45 @@
++####
++#### Sample Makefile for building apps with the RIOT OS
++####
++#### The Sample Filesystem Layout is:
++#### /this makefile
++#### ../../RIOT 
++#### ../../boards   for board definitions (if you have one or more)
++#### 
++
++# name of your project
++export PROJECT = %TESTNAME%
++
++# for easy switching of boards
++ifeq ($(strip $(BOARD)),)
++	export BOARD = native
++endif
++
++# this has to be the absolute path of the RIOT-base dir
++export RIOTBASE =$(CURDIR)/../../../../../..
++
++export CFLAGS = -DRIOT -DOONF_LOG_INFO -DOONF_LOG_DEBUG_INFO
++
++## Modules to include. 
++
++USEMODULE += auto_init
++USEMODULE += config
++USEMODULE += uart0
++USEMODULE += posix
++
++USEMODULE += net_help
++USEMODULE += oonf_cunit
++ifneq (,$(findstring regex,$(PROJECT)))
++	USEMODULE += oonf_regex
++endif
++USEMODULE += oonf_common
++
++ifneq (,$(findstring daemonize,$(PROJECT)))
++	error daemonize is not supported on RIOT
++endif
++
++USEPKG += oonf_api
++
++export INCLUDES += -I$(CURDIR)/../.. -I$(RIOTBASE)/sys/net/include
++
++include $(RIOTBASE)/Makefile.include
+diff --git a/tests/common/bin/.gitignore b/tests/common/bin/.gitignore
+new file mode 100644
+index 0000000..e69de29
+diff --git a/tests/common/generate_makefiles.sh b/tests/common/generate_makefiles.sh
+new file mode 100755
+index 0000000..8bf9faa
+--- /dev/null
++++ b/tests/common/generate_makefiles.sh
+@@ -0,0 +1,8 @@
++#!/bin/bash
++
++for file in *.c; do
++	test=$(basename $file .c)
++	mkdir -p $test
++	sed s/%TESTNAME%/$test/ .Makefile.template > $test/Makefile
++	cp $test\.c $test
++done
+diff --git a/tests/common/test_common_avl.c b/tests/common/test_common_avl.c
+index b5ee8c0..e4e5b26 100644
+--- a/tests/common/test_common_avl.c
++++ b/tests/common/test_common_avl.c
+@@ -816,17 +816,17 @@ static void random_delete(uint32_t *array, int count) {
+ 
+ /* insert/remove 1000's random numbers into tree and check if everything is okay */
+ static void test_random_insert(void) {
+-  uint32_t array[1000];
++  uint32_t array[100];
+   struct tree_element *e, *ptr;
+ 
+   srand(0);
+   START_TEST();
+   avl_init(&head, avl_comp_uint32, true);
+ 
+-  random_insert(array, 1000);
+-  random_delete(array, 500);
+-  random_insert(array, 400);
+-  random_delete(array, 600);
++  random_insert(array, 100);
++  random_delete(array, 50);
++  random_insert(array, 40);
++  random_delete(array, 60);
+ 
+   avl_remove_all_elements(&head, e, node, ptr) {
+     free(e);
+diff --git a/tests/cunit/Makefile b/tests/cunit/Makefile
+new file mode 100644
+index 0000000..5e0046d
+--- /dev/null
++++ b/tests/cunit/Makefile
+@@ -0,0 +1,3 @@
++MODULE:=oonf_$(shell basename $(CURDIR))
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/tests/rfc5444/.Makefile.template b/tests/rfc5444/.Makefile.template
+new file mode 100644
+index 0000000..8a0452d
+--- /dev/null
++++ b/tests/rfc5444/.Makefile.template
+@@ -0,0 +1,39 @@
++####
++#### Sample Makefile for building apps with the RIOT OS
++####
++#### The Sample Filesystem Layout is:
++#### /this makefile
++#### ../../RIOT 
++#### ../../boards   for board definitions (if you have one or more)
++#### 
++
++# name of your project
++export PROJECT = %TESTNAME%
++
++# for easy switching of boards
++ifeq ($(strip $(BOARD)),)
++	export BOARD = native
++endif
++
++# this has to be the absolute path of the RIOT-base dir
++export RIOTBASE =$(CURDIR)/../../../../../..
++
++export CFLAGS = -DRIOT -DOONF_LOG_INFO -DOONF_LOG_DEBUG_INFO
++
++## Modules to include. 
++
++USEMODULE += auto_init
++USEMODULE += config
++USEMODULE += uart0
++USEMODULE += posix
++
++USEMODULE += net_help
++USEMODULE += oonf_cunit
++USEMODULE += oonf_common
++USEMODULE += oonf_rfc5444
++
++USEPKG += oonf_api
++
++export INCLUDES += -I$(CURDIR)/../.. -I$(RIOTBASE)/sys/net/include
++
++include $(RIOTBASE)/Makefile.include
+diff --git a/tests/rfc5444/bin/.gitignore b/tests/rfc5444/bin/.gitignore
+new file mode 100644
+index 0000000..e69de29
+diff --git a/tests/rfc5444/generate_makefiles.sh b/tests/rfc5444/generate_makefiles.sh
+new file mode 100755
+index 0000000..8bf9faa
+--- /dev/null
++++ b/tests/rfc5444/generate_makefiles.sh
+@@ -0,0 +1,8 @@
++#!/bin/bash
++
++for file in *.c; do
++	test=$(basename $file .c)
++	mkdir -p $test
++	sed s/%TESTNAME%/$test/ .Makefile.template > $test/Makefile
++	cp $test\.c $test
++done
+diff --git a/tests/rfc5444/test_rfc5444_reader_dropcontext.c b/tests/rfc5444/test_rfc5444_reader_dropcontext.c
+index df203fd..29daff6 100644
+--- a/tests/rfc5444/test_rfc5444_reader_dropcontext.c
++++ b/tests/rfc5444/test_rfc5444_reader_dropcontext.c
+@@ -38,7 +38,7 @@
+  * the copyright holders.
+  *
+  */
+-#include <arpa/inet.h>
++
+ #include <assert.h>
+ #include <stdio.h>
+ 
+-- 
+1.8.3.2
+

--- a/pkg/oonf_api/0003-port-example-to-riot.patch
+++ b/pkg/oonf_api/0003-port-example-to-riot.patch
@@ -1,0 +1,90 @@
+From 329910e5c6942a70aa258907c887c6fa162266a4 Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benpicco@zedat.fu-berlin.de>
+Date: Tue, 1 Oct 2013 17:39:03 +0200
+Subject: [PATCH 3/3] port example to riot
+
+---
+ examples/rfc5444_reader_writer/Makefile | 37 +++++++++++++++++++++++++++++++++
+ examples/rfc5444_reader_writer/reader.c |  5 +++++
+ examples/rfc5444_reader_writer/writer.c |  5 +++++
+ 3 files changed, 47 insertions(+)
+ create mode 100644 examples/rfc5444_reader_writer/Makefile
+
+diff --git a/examples/rfc5444_reader_writer/Makefile b/examples/rfc5444_reader_writer/Makefile
+new file mode 100644
+index 0000000..42f9a55
+--- /dev/null
++++ b/examples/rfc5444_reader_writer/Makefile
+@@ -0,0 +1,37 @@
++####
++#### Sample Makefile for building apps with the RIOT OS
++####
++#### The Sample Filesystem Layout is:
++#### /this makefile
++#### ../../RIOT 
++#### 
++
++# name of your project
++export PROJECT := $(shell basename $(CURDIR))
++
++# for easy switching of boards
++ifeq ($(strip $(BOARD)),)
++	export BOARD = native
++endif
++
++# this has to be the absolute path of the RIOT-base dir
++export RIOTBASE =$(CURDIR)/../../../../..
++
++export CFLAGS = -DRIOT -DOONF_LOG_INFO -DOONF_LOG_DEBUG_INFO
++
++## Modules to include. 
++
++USEMODULE += auto_init
++USEMODULE += config
++USEMODULE += uart0
++USEMODULE += posix
++
++USEMODULE += net_help
++USEMODULE += oonf_common
++USEMODULE += oonf_rfc5444
++
++USEPKG += oonf_api
++
++INCLUDES += -I$(RIOTBASE)/sys/net/include -I$(CURDIR)/..
++
++include $(RIOTBASE)/Makefile.include
+diff --git a/examples/rfc5444_reader_writer/reader.c b/examples/rfc5444_reader_writer/reader.c
+index 9cca869..c786d19 100644
+--- a/examples/rfc5444_reader_writer/reader.c
++++ b/examples/rfc5444_reader_writer/reader.c
+@@ -42,6 +42,11 @@
+ #include <string.h>
+ #include <stdio.h>
+ 
++#ifdef RIOT
++#include "net_help.h"
++#define ntohl(val)	NTOHL(val)
++#endif
++
+ #include "common/common_types.h"
+ #include "common/netaddr.h"
+ #include "rfc5444/rfc5444_reader.h"
+diff --git a/examples/rfc5444_reader_writer/writer.c b/examples/rfc5444_reader_writer/writer.c
+index 59bb741..d05c48c 100644
+--- a/examples/rfc5444_reader_writer/writer.c
++++ b/examples/rfc5444_reader_writer/writer.c
+@@ -42,6 +42,11 @@
+ #include <string.h>
+ #include <stdio.h>
+ 
++#ifdef RIOT
++#include "net_help.h"
++#define htonl(val)	HTONL(val)
++#endif
++
+ #include "common/common_types.h"
+ #include "common/netaddr.h"
+ #include "rfc5444/rfc5444_writer.h"
+-- 
+1.8.3.2
+

--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -1,0 +1,46 @@
+PKG_NAME=oonf_api
+PKG_URL=git://olsr.org/oonf_api.git
+PKG_VERSION=v0.3.0
+
+ifneq ($(RIOTBOARD),)
+include $(RIOTBOARD)/$(BOARD)/Makefile.include
+endif
+
+ifneq ($(RIOTBASE),)
+INCLUDES += -I$(RIOTBASE)/sys/include -I$(RIOTBASE)/sys/net/include \
+			-I$(RIOTBASE)/sys/posix/include -I$(RIOTBASE)/sys/posix/pnet/include
+endif
+
+MODULE:=$(shell basename $(CURDIR))
+
+.PHONY: all clean patch reset
+
+all: patch
+	make -C $(CURDIR)/$(PKG_NAME)
+	make $(BINDIR)$(MODULE).a
+
+patch: $(CURDIR)/$(PKG_NAME)/Makefile
+	# Dependancy might be changed accordingly though we think the Makefile
+	# will be the first thing you want to change
+	#
+	# Here might not happen anything besides dependancy checks
+
+$(CURDIR)/$(PKG_NAME)/Makefile: $(CURDIR)/$(PKG_NAME)
+	# Here you apply your patch.
+	$(foreach patch,$(shell ls [0-9][0-9][0-9][0-9]*.patch),cd "$<" && git am "../$(patch)";)
+
+$(CURDIR)/$(PKG_NAME)/:
+	git clone $(PKG_URL) $@ && \
+		cd $@ && git checkout $(PKG_VERSION)
+
+clean::
+	# Reset package to checkout state.
+	cd $(CURDIR)/$(PKG_NAME) || true && \
+		git clean -x -f && \
+		git reset --hard $(PKG_VERSION)
+
+distclean::
+	rm -rf $(CURDIR)/$(PKG_NAME)
+
+$(BINDIR)$(MODULE).a: $(BINDIR)oonf_*.a
+	mkdir -p $(BINDIR)$(MODULE); cd $(BINDIR)$(MODULE); for var in $?; do ar -x $$var; done; ar -r -c -s $(BINDIR)$(MODULE).a *.o

--- a/pkg/oonf_api/Makefile.include
+++ b/pkg/oonf_api/Makefile.include
@@ -1,0 +1,1 @@
+INCLUDES += -I $(RIOTBASE)/pkg/oonf_api/oonf_api/src-api


### PR DESCRIPTION
This adds OLSRs oonf_api as a RIOT package. oonf_api provides a rfc5444 reader/writer as well as utilities such as an avl tree, a flexible buffer, a double linked list as well as address abstraction (IPv4/Ipv6/MAC  - not very necessary on RIOT) and string functions.
The package provides three modules, oonf_common,  oonf_rfc5444 (depends on oonf_common) and cunit for unit tests.
This package pulls in the whole of oonf_api from git, but the majority of the code (OS abstraction, config framework, telnet and webserver, …) is neither required nor functional on RIOT, so it's ignored by the build system.
The only folders of interest are: 

| dir | use |
| --- | --- |
| src-api/common | library functions |
| src-api/rfc5444 | rfc5444 reader/writer |
| tests/cunit | cunit test framework |
| tests/common | unit tests for common (run `generate_makefiles.sh`) |
| tests/rfc5444 | unit tests for rfc5444 (run `generate_makefiles.sh`) |
| examples/rfc5444_reader_writer | example application |

Usage is a bit cumbersome because of the include paths, as seen in https://github.com/benpicco/tiny_olsr2/blob/master/Makefile 

```
EXTERNAL_MODULES +=$(RIOTBASE)/pkg/oonf_api
USEMODULE += oonf_common
USEMODULE += oonf_rfc5444
INCLUDES += -I$(RIOTBASE)/pkg/oonf_api/oonf_api/src-api
```

Also, build order is important, modules that depend on this won't find includes unless the pkg is build, aka checked out and patched.

I'm welcome for suggestions on how to improve this.
