### PR TITLE
add name to sysconfig

### DIFF
--- a/core/include/config.h
+++ b/core/include/config.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 
 #define CONFIG_KEY      (0x1701)
+#define CONFIG_NAME_LEN (10)
 
 extern char configmem[];
 
@@ -30,6 +31,7 @@ typedef struct {
     uint16_t id;                ///< unique node identifier
     uint8_t radio_address;      ///< address for radio communication
     uint8_t radio_channel;      ///< current frequency
+    char name[CONFIG_NAME_LEN]; ///< name of the node
 } config_t;
 
 /* @brief:  Element to store in flashrom */

--- a/sys/config/config.c
+++ b/sys/config/config.c
@@ -22,4 +22,5 @@ config_t sysconfig  = {
     0,      ///< default ID
     0,      ///< default radio address
     0,      ///< default radio channel
+    "foobar", ///< default name
 };


### PR DESCRIPTION
there is still quite some space left on the persistent flash config area, make it possible to give nodes a name (e.g. hostname of the meshrouter) for nicer debugging
