### PR TITLE
newlib doesn't support the z modifier

### DIFF
--- a/sys/net/transport_layer/destiny/destiny.c
+++ b/sys/net/transport_layer/destiny/destiny.c
@@ -36,8 +36,8 @@ char tcp_timer_stack[TCP_TIMER_STACKSIZE];
 
 int destiny_init_transport_layer(void)
 {
-    printf("Initializing transport layer packages. Size of socket_type: %zu\n",
-           sizeof(socket_internal_t));
+    printf("Initializing transport layer packages. Size of socket_type: %u\n",
+           (unsigned int) sizeof(socket_internal_t));
     /* SOCKETS */
     memset(sockets, 0, MAX_SOCKETS * sizeof(socket_internal_t));
 


### PR DESCRIPTION
on msba2 this will otherwise print

```
Initializing transport layer packages. Size of socket_type: zu
```
