### PR TITLE
fix memory leaks in sys/net/ccn_lite/util/ccn-lite-ctrl.c

### DIFF
--- a/sys/net/ccn_lite/util/ccn-lite-ctrl.c
+++ b/sys/net/ccn_lite/util/ccn-lite-ctrl.c
@@ -47,6 +47,7 @@ mkNewFaceRequest(unsigned char *out, char *macsrc, char *ip4src,
 
     unsigned char *faceinst = malloc(500);
     if (!faceinst) {
+        free(contentobj);
         puts("mkNewFaceRequest: malloc failed");
         return 0;
     }
@@ -123,7 +124,8 @@ mkPrefixregRequest(unsigned char *out, char reg, char *path, char *faceid)
     }
 
     unsigned char *fwdentry = malloc(500);
-    if (!contentobj) {
+    if (!fwdentry) {
+        free(contentobj);
         puts("mkNewFaceRequest: malloc failed");
         return 0;
     }


### PR DESCRIPTION
Via static analysis using cppcheck I found two memory leaks in sys/net/ccn_lite/util/ccn-lite-ctrl.c:
1. in mkNewFaceRequest(...) there is memory allocated for contentobj. In the next step the function tries to allocate memory for faceinst and returns in the case of failure without freeing the allocated memory for contentobj.
2.in mkPrefixregRequest(...) there is basically the same error with the additional twist that after trying to allocate memory for fwdentry there is an error handling routine that doesn't check for the failure of memory allocation for fwdentry but for contentobj which was checked before and can't have changed.

My commit fixes both issues by freeing the memory for contentobj in both cases if the second allocation of memory fails and in the case of the latter changes the check to use the right variable.
