### PR TITLE
fix to use only transceiver_pid from transceiver.c (at86rf231)

### DIFF
--- a/drivers/at86rf231/at86rf231.c
+++ b/drivers/at86rf231/at86rf231.c
@@ -16,8 +16,6 @@ static uint8_t  radio_channel;
 static uint16_t radio_address;
 static uint64_t radio_address_long;
 
-int transceiver_pid;
-
 void at86rf231_init(int tpid)
 {
     transceiver_pid = tpid;

--- a/drivers/include/at86rf231.h
+++ b/drivers/include/at86rf231.h
@@ -30,6 +30,7 @@ typedef struct __attribute__((packed))
 }
 at86rf231_packet_t;
 
+extern int transceiver_pid;
 
 void at86rf231_init(int tpid);
 //void at86rf231_reset(void);


### PR DESCRIPTION
I cannot test this here, It does NOT compile
