### PR TITLE
fix to use only transceiver_pid from transceiver.c (cc2420)

### DIFF
--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -17,8 +17,6 @@
 
 /* Radio driver API */
 
-int transceiver_pid;
-
 void cc2420_init(int tpid)
 {
     uint16_t reg;

--- a/drivers/include/cc2420.h
+++ b/drivers/include/cc2420.h
@@ -102,6 +102,8 @@ typedef struct __attribute__ ((packed)) {
     /* @} */
 } cc2420_packet_t;
 
+extern int transceiver_pid;
+
 /**
  * @brief Init the cc2420.
  *


### PR DESCRIPTION
I cannot test this right now, cause I have no msp430-gcc ready
