### PR TITLE
include cc110x.h instead of deprecated interface.h

### DIFF
--- a/drivers/cc110x/cc1100-csmaca-mac.h
+++ b/drivers/cc110x/cc1100-csmaca-mac.h
@@ -28,7 +28,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 #ifndef CC1100_CSMACA_MAC_
 #define CC1100_CSMACA_MAC_
 
-#include "cc1100-interface.h"
 #include "cc1100-defaultSettings.h"
 
 //#define CSMACA_MAC_AGGRESSIVE_MODE		   		// MAC aggressive mode on/off switch

--- a/drivers/cc110x/cc1100.h
+++ b/drivers/cc110x/cc1100.h
@@ -34,7 +34,7 @@
 #define CC1100_H
 
 #include <stdbool.h>
-#include "cc1100-interface.h"
+#include "cc110x.h"
 
 /**
  * @name    Defines used as state values for state machine

--- a/drivers/cc110x/cc1100_phy.h
+++ b/drivers/cc110x/cc1100_phy.h
@@ -36,7 +36,7 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 #include <stdint.h>
 //#include "cc1100.h"
 #include "cc1100-internal.h"
-#include "cc1100-interface.h"
+#include "cc110x.h"
 
 #define MAX_DATA_LENGTH		(0x3A)	///< Maximum data length of layer 0 = 58 Bytes.
 

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -32,7 +32,7 @@
 #endif
 
 #ifdef MODULE_CC110X
-#include "cc1100-interface.h"
+#include "cc110x.h"
 #endif
 
 #ifdef MODULE_LTC4150

--- a/sys/include/transceiver.h
+++ b/sys/include/transceiver.h
@@ -14,7 +14,7 @@
  * NOTE: necessary to include here again due to
  * https://github.com/RIOT-OS/RIOT/issues/117 */
 #ifdef MODULE_CC110X
-#include "cc1100-interface.h"
+#include "cc110x.h"
 #endif
 
 #ifdef MODULE_CC110X_NG

--- a/sys/shell/commands/sc_transceiver.c
+++ b/sys/shell/commands/sc_transceiver.c
@@ -25,7 +25,7 @@
 #include "msg.h"
 
 #if   defined( MODULE_CC110X )
-#include "cc1100-interface.h"
+#include "cc110x.h"
 #define TEXT_SIZE           CC1100_MAX_DATA_LENGTH
 #define _TC_TYPE            TRANSCEIVER_CC1100
 

--- a/sys/transceiver/transceiver.c
+++ b/sys/transceiver/transceiver.c
@@ -31,7 +31,7 @@
 
 /* supported transceivers */
 #ifdef MODULE_CC110X
-#include "cc1100-interface.h"
+#include "cc110x.h"
 #endif
 
 #ifdef MODULE_CC110X_NG


### PR DESCRIPTION
Merging #482 broke some includes for the old cc110x driver.
