### PR TITLE
pttu transceiver preparation

### DIFF
--- a/boards/pttu/Makefile.include
+++ b/boards/pttu/Makefile.include
@@ -1,3 +1,7 @@
 export INCLUDES += -I$(RIOTBOARD)/pttu/include
 
+ifneq (,$(findstring cc110x,$(USEMODULE)))
+	INCLUDES += -I$(RIOTBASE)/sys/net/include
+endif
+
 include $(RIOTBOARD)/msba2-common/Makefile.include


### PR DESCRIPTION
Does not actually enable the transceiver, see https://github.com/RIOT-OS/RIOT/issues/659.
