### PR TITLE
move Makefile.dep include

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -32,6 +32,7 @@ BOARD := $(strip $(BOARD))
 include $(RIOTBASE)/Makefile.modules
 include $(RIOTBOARD)/$(BOARD)/Makefile.include
 include $(RIOTCPU)/$(CPU)/Makefile.include
+include $(RIOTBASE)/Makefile.dep
 
 # your binaries to link
 BASELIBS += $(BINDIR)$(BOARD)_base.a

--- a/Makefile.modules
+++ b/Makefile.modules
@@ -12,7 +12,4 @@ export BASELIBS = $(shell echo $(BL)|sed 's/[^ ]*hwtimer.a//')
 
 CFLAGS += $(EXTDEFINES)
 
-include $(RIOTBASE)/Makefile.dep
-
 export USEMODULE
-


### PR DESCRIPTION
boards modify USEMODULE which can lead to additional dependencies.
including Makefile.dep last enables it to resolve all dependencies.

side-remove a trailing newline
