### PR TITLE
Do not zero out sched_threads needlessly

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -35,11 +35,6 @@
 #endif
 
 /**
- * @brief   Initializes thread table, active thread information, and runqueues
- */
-void sched_init(void);
-
-/**
  * @brief   Triggers the scheduler to schedule the next task
  */
 void sched_run(void);

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -70,8 +70,6 @@ void kernel_init(void)
     dINT();
     printf("kernel_init(): This is RIOT! (Version: %s)\n", VERSION);
 
-    sched_init();
-
     if (thread_create(idle_stack, sizeof(idle_stack), PRIORITY_IDLE, CREATE_WOUT_YIELD | CREATE_STACKTEST, idle_thread, idle_name) < 0) {
         printf("kernel_init(): error creating idle task.\n");
     }

--- a/core/sched.c
+++ b/core/sched.c
@@ -43,7 +43,7 @@ volatile unsigned int sched_context_switch_request;
 volatile tcb_t *sched_threads[MAXTHREADS];
 volatile tcb_t *active_thread;
 
-volatile int thread_pid;
+volatile int thread_pid = -1;
 volatile int last_pid = -1;
 
 clist_node_t *runqueues[SCHED_PRIO_LEVELS];
@@ -53,30 +53,6 @@ static uint32_t runqueue_bitcache = 0;
 static void (*sched_cb) (uint32_t timestamp, uint32_t value) = NULL;
 schedstat pidlist[MAXTHREADS];
 #endif
-
-void sched_init()
-{
-    printf("Scheduler...");
-    int i;
-
-    for (i = 0; i < MAXTHREADS; i++) {
-        sched_threads[i] = NULL;
-#if SCHEDSTATISTICS
-        pidlist[i].laststart = 0;
-        pidlist[i].runtime_ticks = 0;
-        pidlist[i].schedules = 0;
-#endif
-    }
-
-    active_thread = NULL;
-    thread_pid = -1;
-
-    for (i = 0; i < SCHED_PRIO_LEVELS; i++) {
-        runqueues[i] = NULL;
-    }
-
-    printf("[OK]\n");
-}
 
 void sched_run()
 {


### PR DESCRIPTION
The function sched_init() zeroes out sched_threads needlessly. All
static variables can be assumed to be initialized with zero, anyways.
The C standard mandates it, and all at other places in the code it is
assumed.

Currently, if your CPU or board spawns worker threads before calling
kernel_init(), they get deleted.
