### PR TITLE
clang does not know fno-delete-null-pointer-checks

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -14,7 +14,19 @@ endif
 # if you want to publish the board into the sources as an uppercase #define
 BB = $(shell echo $(BOARD)|tr 'a-z' 'A-Z')
 CPUDEF = $(shell echo $(CPU)|tr 'a-z' 'A-Z')
-CFLAGS += -DBOARD=$(BB) -DCPU_$(CPUDEF) -fno-delete-null-pointer-checks
+CFLAGS += -DBOARD=$(BB) -DCPU_$(CPUDEF)
+
+# Add `-fno-delete-null-pointer-checks` flag iff the compiler supports it.
+# GCC removes moves tests whether `x == NULL`, if previously `x` or even `x->y` was accessed.
+# 0x0 might be a sane memory location for embedded systems, so the test must not be removed.
+# Right now clang does not use the *delete-null-pointer* optimization, and does not understand the parameter.
+# Related issues: #628, #664.
+ifeq ($(shell $(CC) -fno-delete-null-pointer-checks -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+ifeq ($(shell LANG=C $(CC) -fno-delete-null-pointer-checks -E - 2>&1 1>/dev/null </dev/null | grep warning: | grep -- -fno-delete-null-pointer-checks),)
+CFLAGS += -fno-delete-null-pointer-checks
+endif
+endif
+
 export CFLAGS
 
 export BINDIR =$(CURDIR)/bin/$(BOARD)/


### PR DESCRIPTION
as introduced in https://github.com/RIOT-OS/RIOT/pull/628 the parameter "-fno-delete-null-pointer-checks" is handed over to the compiler.

clang throws a warning and ignores it.

task: try to find a way to get the desired functionality in clang, and or try to find a way to get rid of this warning.
