### PR TITLE
allow to register ICMPv6 echo reply handler

### DIFF
--- a/sys/net/include/sixlowpan/icmp.h
+++ b/sys/net/include/sixlowpan/icmp.h
@@ -166,6 +166,14 @@ void icmpv6_send_echo_reply(ipv6_addr_t *destaddr, uint16_t id,
                             uint16_t seq, char *data, size_t data_len);
 
 /**
+ * @brief Register a handler for ICMPv6 echo replys.
+ *
+ * @param[in] handle_reply  Function to handle a ICMPv6 echo reply.
+ */
+void icmpv6_register_echo_reply_handler(void (*handle_reply)(ipv6_hdr_t *ipv6_buf,
+                            icmpv6_echo_reply_hdr_t *echo_buf));
+
+/**
  * @brief Send ICMPv6 router solicitation.
  *
  * @param[in] sllao     Flag to include source link-layer address

--- a/sys/net/network_layer/sixlowpan/icmp.c
+++ b/sys/net/network_layer/sixlowpan/icmp.c
@@ -138,6 +138,7 @@ uint8_t icmpv6_opt_hdr_len = 0;
 uint8_t recvd_cids_len = 0;
 ndp_prefix_list_t *recvd_prefixes[OPT_PI_LIST_LEN];
 uint8_t recvd_pref_len = 0;
+void (*handle_echo_reply)(ipv6_hdr_t *ipv6_buf, icmpv6_echo_reply_hdr_t *echo_buf) = 0;
 
 void def_rtr_lst_add(ipv6_addr_t *ipaddr, uint32_t rtr_ltime);
 void def_rtr_lst_rem(ndp_default_router_list_t *entry);
@@ -417,6 +418,14 @@ void recv_echo_repl(void)
     }
 
 #endif
+
+    if (handle_echo_reply != NULL) {
+        handle_echo_reply(ipv6_buf, echo_buf);
+    }
+}
+
+void icmpv6_register_echo_reply_handler(void (*handle_reply)(ipv6_hdr_t *ipv6_buf, icmpv6_echo_reply_hdr_t *echo_buf)) {
+    handle_echo_reply = handle_reply;
 }
 
 void recv_rtr_sol(void)


### PR DESCRIPTION
Currently ICMPv6 echo messages are rather useless as it's impossible to determine whether a reply was received without debug output turned on.
This allows to register a function as an ICMPv6 echo reply handler that gets called whenever an echo reply has been received.
