### PR TITLE
native/osx makefile cleanup

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -37,23 +37,6 @@ include $(RIOTCPU)/$(CPU)/Makefile.include
 BASELIBS += $(BINDIR)$(BOARD)_base.a
 BASELIBS += $(BINDIR)${PROJECT}.a
 
-# clumsy way to enable building native on osx:
-BUILDOSXNATIVE = 0
-ifeq ($(CPU),native)
-ifeq ($(shell uname -s),Darwin)
-	BUILDOSXNATIVE = 1
-endif
-endif
-
-# backward compatability with glibc <= 2.17 for native
-ifeq ($(CPU),native)
-ifeq ($(shell uname -s),Linux)
-ifeq ($(shell ldd --version |  awk '/^ldd/{if ($$NF < 2.17) {print "yes"} else {print "no"} }'),yes)
-	LINKFLAGS += -lrt
-endif
-endif
-endif
-
 .PHONY: all clean flash doc term
 
 ## make script for your project. Build RIOT-base here!
@@ -63,12 +46,12 @@ all: $(BINDIR)$(PROJECT).a
 	"$(MAKE)" -C $(RIOTBASE)
 	@for i in $(EXTERNAL_MODULES) ; do "$(MAKE)" -C $$i ; done ;
 ifeq ($(BUILDOSXNATIVE),1)	
-	$(LINK) $(UNDEF) -o $(BINDIR)$(PROJECT).elf $(BASELIBS) $(LINKFLAGS) -Wl,-no_pie
+	$(AD)$(LINK) $(UNDEF) -o $(BINDIR)$(PROJECT).elf $(BASELIBS) $(LINKFLAGS) -Wl,-no_pie
 else
 	$(AD)$(LINK) $(UNDEF) -o $(BINDIR)$(PROJECT).elf -Wl,--start-group $(BASELIBS) -lm -Wl,--end-group  -Wl,-Map=$(BINDIR)$(PROJECT).map $(LINKFLAGS)
+endif
 	$(AD)$(SIZE) $(BINDIR)$(PROJECT).elf
 	$(AD)$(OBJCOPY) $(OFLAGS) $(BINDIR)$(PROJECT).elf $(BINDIR)$(PROJECT).hex
-endif
 
 ## your make rules
 ## Only basic example - modify it for larger projects!!

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -9,7 +9,7 @@ export AR = $(PREFIX)ar
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
-export OBJCOPY = $(PREFIX)objcopy
+export OBJCOPY = true
 
 export DEBUGGER = gdb
 export TERMPROG = $(ELF)
@@ -24,6 +24,24 @@ export DEBUGGER_FLAGS = $(ELF)
 export VALGRIND_FLAGS ?= --track-origins=yes
 all-valgrind: export CFLAGS += -DHAVE_VALGRIND_VALGRIND_H -g
 
+# backward compatability with glibc <= 2.17 for native
+ifeq ($(CPU),native)
+ifeq ($(shell uname -s),Linux)
+ifeq ($(shell ldd --version |  awk '/^ldd/{if ($$NF < 2.17) {print "yes"} else {print "no"} }'),yes)
+	LINKFLAGS += -lrt
+endif
+endif
+endif
+
+# clumsy way to enable building native on osx:
+BUILDOSXNATIVE = 0
+ifeq ($(CPU),native)
+ifeq ($(shell uname -s),Darwin)
+	BUILDOSXNATIVE = 1
+endif
+endif
+
+# set the tap interface for term/valgrind
 ifneq (,$(findstring nativenet,$(USEMODULE)))
 	export PORT ?= tap0
 else


### PR DESCRIPTION
- add missing $(AD) to osx $(LINK) invocation
- move osx build determination to native makefile
- move old libc test to native makefile
- set objcopy to "true" - it is superfluous for native no matter what the system is
- add some documentation to natives makefile
