### PR TITLE
actually use of msg_queue

### DIFF
--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -268,6 +268,8 @@ void ipv6_process(void)
     ipv6_addr_t myaddr;
     uint8_t i;
     uint16_t packet_length;
+    
+    msg_init_queue(msg_queue, IP_PKT_RECV_BUF_SIZE);
 
     ipv6_addr_init(&myaddr, 0xabcd, 0x0, 0x0, 0x0, 0x3612, 0x00ff, 0xfe00,
                    sixlowpan_mac_get_radio_address());


### PR DESCRIPTION
msg_queue is defined but never used, hook it up so that it actually queues IP packets instead of dropping them.
