### PR TITLE
Do not mandate input language

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -46,6 +46,19 @@ include $(RIOTBOARD)/$(BOARD)/Makefile.include
 include $(RIOTCPU)/$(CPU)/Makefile.include
 include $(RIOTBASE)/Makefile.dep
 
+# Test if the input language was specified externally.
+# Otherwise test if the compiler unterstands the "-std=gnu99" flag, and use it if so.
+# Otherwise test if the compiler unterstands the "-std=c99" flag, and use it if so.
+ifeq ($(filter -std=%,$(CFLAGS)),)
+ifeq ($(shell $(CC) -std=gnu99 -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+CFLAGS += -std=gnu99
+else
+ifeq ($(shell $(CC) -std=c99 -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+CFLAGS += -std=c99
+endif
+endif
+endif
+
 # your binaries to link
 BASELIBS += $(BINDIR)$(BOARD)_base.a
 BASELIBS += $(BINDIR)${PROJECT}.a

--- a/boards/chronos/Makefile.include
+++ b/boards/chronos/Makefile.include
@@ -8,7 +8,7 @@ export MCU = cc430f6137
 export PREFIX = msp430-
 export CC = $(PREFIX)gcc
 export AR = $(PREFIX)ar
-export CFLAGS += -std=gnu99 -Wstrict-prototypes -gdwarf-2 -Os -Wall -mmcu=$(MCU) -D CC430
+export CFLAGS += -Wstrict-prototypes -gdwarf-2 -Os -Wall -mmcu=$(MCU) -D CC430
 export ASFLAGS += -mmcu=$(MCU) --defsym $(MCU)=1 --gdwarf-2
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -5,7 +5,7 @@ export CPU = lpc1768
 export PREFIX = arm-none-eabi-
 export CC = $(PREFIX)gcc
 export AR = $(PREFIX)ar
-export CFLAGS += -DUSE_STDPERIPH_DRIVER -ggdb -g3 -std=gnu99 -O0 -Wall -Wstrict-prototypes -mcpu=cortex-m3 $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -DUSE_STDPERIPH_DRIVER -ggdb -g3 -O0 -Wall -Wstrict-prototypes -mcpu=cortex-m3 $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
 export ASFLAGS = -ggdb -g3 -mcpu=cortex-m3 $(FPU_USAGE) -mlittle-endian
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc

--- a/boards/msb-430-common/Makefile.include
+++ b/boards/msb-430-common/Makefile.include
@@ -6,7 +6,7 @@ export MCU = msp430f1612
 export PREFIX = msp430-
 export CC = $(PREFIX)gcc
 export AR = $(PREFIX)ar
-export CFLAGS += -std=gnu99 -Wstrict-prototypes -gdwarf-2 -Os -Wall -mmcu=$(MCU)
+export CFLAGS += -Wstrict-prototypes -gdwarf-2 -Os -Wall -mmcu=$(MCU)
 export ASFLAGS += -mmcu=$(MCU) --defsym $(MCU)=1 --gdwarf-2
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc

--- a/boards/msba2-common/Makefile.include
+++ b/boards/msba2-common/Makefile.include
@@ -6,7 +6,7 @@ export PREFIX = arm-none-eabi-
 #export PREFIX = arm-elf-
 export CC = $(PREFIX)gcc
 export AR = $(PREFIX)ar
-export CFLAGS += -std=gnu99 -O2 -Wall -Wstrict-prototypes -mcpu=arm7tdmi-s -gdwarf-2
+export CFLAGS += -O2 -Wall -Wstrict-prototypes -mcpu=arm7tdmi-s -gdwarf-2
 export ASFLAGS = -gdwarf-2 -mcpu=arm7tdmi-s
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -17,7 +17,7 @@ export FLASHER = true
 export VALGRIND ?= valgrind
 
 # flags:
-export CFLAGS += -std=gnu99 -Wall -Wextra -pedantic -m32
+export CFLAGS += -Wall -Wextra -pedantic -m32
 export LINKFLAGS += -m32 -gc -ldl
 export ASFLAGS =
 export DEBUGGER_FLAGS = $(ELF)

--- a/boards/redbee-econotag/Makefile.include
+++ b/boards/redbee-econotag/Makefile.include
@@ -5,7 +5,7 @@ export CPU = mc1322x
 export PREFIX = arm-none-eabi-
 export CC = $(PREFIX)gcc
 export AR = $(PREFIX)ar
-export CFLAGS += -std=gnu99 -march=armv4t -mtune=arm7tdmi-s -mlong-calls \
+export CFLAGS += -march=armv4t -mtune=arm7tdmi-s -mlong-calls \
 		-msoft-float -mthumb-interwork -fno-strict-aliasing -fno-common \
 		-ffixed-r8 -ffunction-sections -ffreestanding -fno-builtin \
 		-nodefaultlibs -Wcast-align -Wall -Wstrict-prototypes -Wextra \

--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -7,7 +7,7 @@ export MCU = msp430f1611
 export PREFIX = msp430-
 export CC = $(PREFIX)gcc
 export AR = $(PREFIX)ar
-export CFLAGS += -std=gnu99 -Wstrict-prototypes -gdwarf-2 -Os -Wall -mmcu=$(MCU)
+export CFLAGS += -Wstrict-prototypes -gdwarf-2 -Os -Wall -mmcu=$(MCU)
 export ASFLAGS += -mmcu=$(MCU) --defsym $(MCU)=1 --gdwarf-2
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc

--- a/boards/wsn430-common/Makefile.include
+++ b/boards/wsn430-common/Makefile.include
@@ -6,7 +6,7 @@ export MCU = msp430f1611
 export PREFIX = msp430-
 export CC = $(PREFIX)gcc
 export AR = $(PREFIX)ar
-export CFLAGS += -std=gnu99 -Wstrict-prototypes -gdwarf-2 -Os -Wall -mmcu=$(MCU)
+export CFLAGS += -Wstrict-prototypes -gdwarf-2 -Os -Wall -mmcu=$(MCU)
 export ASFLAGS += -mmcu=$(MCU) --defsym $(MCU)=1 --gdwarf-2
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc


### PR DESCRIPTION
An application might want to use C11 features. The user would assume
that setting `CFLAGS=-std=gnu11` in the Makefile would work. It does not
since the board's Makefile.include shadows the `-std` flag.

This patch removes the `-std=gnu99` from the various Makefile.includes,
and sets the flag in the common Makefile.include of RIOT instead.
If an `-std` flag was provided by an earlier Makefile (the application,
the board, or the CPU [whilst only the former one should]), then no
additional flag is set. It is first tested if the supplied compiler
understands `-std=gnu99`, then `-std=c99`.
