### PR TITLE
core: msg: make messaging optional for threads

### DIFF
--- a/core/include/flags.h
+++ b/core/include/flags.h
@@ -23,6 +23,7 @@
 #define AUTO_FREE           (2)
 #define CREATE_WOUT_YIELD   (4)
 #define CREATE_STACKTEST    (8)
+#define CREATE_NOMSG        (16)
 
 /** @} */
 #endif // _FLAGS_H

--- a/core/include/tcb.h
+++ b/core/include/tcb.h
@@ -43,6 +43,13 @@
 #define STATUS_REPLY_BLOCKED    (0x0100)                      /**< waiting for a message response */
 #define STATUS_TIMER_WAITING    (0x0200)                      /**< waiting for a timer to fire
                                                                 *  (deprecated) */
+typedef struct msg_tcb_t {
+    void *wait_data;
+    queue_node_t msg_waiters;
+
+    cib_t msg_queue;
+    msg_t *msg_array;
+} msg_tcb_t;
 
 typedef struct tcb_t {
     char *sp;
@@ -53,11 +60,7 @@ typedef struct tcb_t {
 
     clist_node_t rq_entry;
 
-    void *wait_data;
-    queue_node_t msg_waiters;
-
-    cib_t msg_queue;
-    msg_t *msg_array;
+    msg_tcb_t *msg_tcb;
 
     const char *name;
     char *stack_start;


### PR DESCRIPTION
This commit makes it possible to create threads with CREATE_NOMSG, disabling their messaging abilities.

Slims tcb from 68 to 40 bytes in my native compile.

Only half of the tests use messaging, so there might be a use for this. Idle thread is also a candidate.
Can't see a performance impact on native, this adds some checks and indirection though.
