### PR TITLE
Revert "shell: remove useless copying of input string"

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -90,8 +90,10 @@ static void print_help(const shell_command_t *command_list)
 
 static void handle_input_line(shell_t *shell, char *line)
 {
+    char line_copy[shell->shell_buffer_size];
     char *saveptr;
-    char *command = strtok_r(line, " ", &saveptr);
+    strncpy(line_copy, line, sizeof(line_copy));
+    char *command = strtok_r(line_copy, " ", &saveptr);
 
     void (*handler)(char *) = NULL;
 


### PR DESCRIPTION
This reverts commit 33239487bf8f7f85a7d27ad5bd912079c503b4cd.

indeed, this commit breaks some shell handler which use strtok to tokenize the input string.
strtok returns always a nullptr.

DO NOT MERGE: https://github.com/RIOT-OS/RIOT/pull/707 will come with a clean solution
