### PR TITLE
use filter instead of findstring in BOARD_BLACKLIST checking

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -19,7 +19,7 @@ $(error This application only runs on following boards: $(BOARD_WHITELIST))
 		endif
 	endif
 
-	ifneq (,$(findstring $(BOARD),$(BOARD_BLACKLIST)))
+	ifneq (,$(filter $(BOARD),$(BOARD_BLACKLIST)))
 $(error This application does not run on following boards: $(BOARD_BLACKLIST))
 	endif
 endif


### PR DESCRIPTION
To test compare before and after behavior of:
`BOARD_BLACKLIST="msb-430h" make BOARD=msb-430`
