### PR TITLE
Make: Use subfolders in bin dir

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -1,13 +1,13 @@
 ASMSRC = $(wildcard *.s)
 ASSMSRC = $(wildcard *.S)
-ASMOBJ = $(ASMSRC:%.s=$(BINDIR)%.o)
-ASMOBJ += $(ASSMSRC:%.S=$(BINDIR)%.o)
+ASMOBJ = $(ASMSRC:%.s=$(BINDIR)$(MODULE)/%.o)
+ASMOBJ += $(ASSMSRC:%.S=$(BINDIR)$(MODULE)/%.o)
 
 ifeq ($(strip $(SRC)),)
 	SRC = $(wildcard *.c)
 endif
-OBJ = $(SRC:%.c=$(BINDIR)%.o)
-DEP = $(SRC:%.c=$(BINDIR)%.d)
+OBJ = $(SRC:%.c=$(BINDIR)$(MODULE)/%.o)
+DEP = $(SRC:%.c=$(BINDIR)$(MODULE)/%.d)
 
 GIT_STRING := $(shell git describe --abbrev=4 --dirty=-`hostname`)
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
@@ -31,16 +31,19 @@ $(BINDIR)$(MODULE).a: $(OBJ) $(ASMOBJ)
 
 # compile and generate dependency info,
 # prepend path to dependency info file
-$(BINDIR)%.o: %.c
-	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -c $*.c -o $(BINDIR)$*.o
+$(BINDIR)$(MODULE)/%.o: %.c
+	@mkdir -p $(BINDIR)$(MODULE)
+	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -c $*.c -o $(BINDIR)$(MODULE)/$*.o
 	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -MM $*.c |\
-		sed -e "1s|^|$(BINDIR)|" > $(BINDIR)$*.d
+		sed -e "1s|^|$(BINDIR)$(MODULE)/|" > $(BINDIR)$(MODULE)/$*.d
 
-$(BINDIR)%.o: %.s
-	$(AD)$(AS) $(ASFLAGS) $*.s -o $(BINDIR)$*.o
+$(BINDIR)$(MODULE)/%.o: %.s
+	@mkdir -p $(BINDIR)$(MODULE)
+	$(AD)$(AS) $(ASFLAGS) $*.s -o $(BINDIR)$(MODULE)/$*.o
 
-$(BINDIR)%.o: %.S
-	$(AD)$(CC) -c $(CFLAGS) $*.S -o $(BINDIR)$*.o
+$(BINDIR)$(MODULE)/%.o: %.S
+	@mkdir -p $(BINDIR)$(MODULE)
+	$(AD)$(CC) -c $(CFLAGS) $*.S -o $(BINDIR)$(MODULE)/$*.o
 
 # remove compilation products
 clean::

--- a/Makefile.modules
+++ b/Makefile.modules
@@ -1,5 +1,3 @@
-UNDEF += $(BINDIR)startup.o
-
 include $(RIOTBASE)/Makefile.pseudomodules
 include $(RIOTBASE)/Makefile.defaultmodules
 

--- a/boards/chronos/Makefile.include
+++ b/boards/chronos/Makefile.include
@@ -14,11 +14,13 @@ export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
-export LINKFLAGS = -mmcu=$(MCU) -lgcc $(BINDIR)startup.o
+export LINKFLAGS = -mmcu=$(MCU) -lgcc $(BINDIR)msp430_common/startup.o
 export FLASHER = mspdebug
 export HEXFILE = $(BINDIR)$(PROJECT).hex
 export USEMODULE += msp430_common
 export FFLAGS = rf2500 "prog $(HEXFILE)"
 export OFLAGS = -O ihex
+
+export UNDEF += $(BINDIR)msp430_common/startup.o
 
 include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -25,3 +25,5 @@ export DEBUGGER_FLAGS = $(ELFFILE)
 
 export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/ -I$(RIOTCPU)/$(CPU)/include
 export OFLAGS = -O binary
+
+export UNDEF += $(BINDIR)cpu/startup.o

--- a/boards/msb-430-common/Makefile.include
+++ b/boards/msb-430-common/Makefile.include
@@ -29,3 +29,5 @@ export FFLAGS += "prog $(HEXFILE)"
 export USEMODULE += msp430_common
 export INCLUDES += -I$(RIOTCPU)/msp430-common/include/ -I$(RIOTBOARD)/msb-430-common/include -I$(RIOTBOARD)/msb-430-common/drivers/include
 export OFLAGS = -O ihex
+
+export UNDEF += $(BINDIR)msp430_common/startup.o

--- a/boards/msba2-common/Makefile.include
+++ b/boards/msba2-common/Makefile.include
@@ -26,3 +26,5 @@ include $(RIOTBOARD)/msba2-common/Makefile.dep
 export INCLUDES += -I$(RIOTBOARD)/msba2-common/include -I$(RIOTBOARD)/msba2-common/drivers/include
 
 export OFLAGS = -O ihex
+
+export UNDEF += $(BINDIR)cpu/startup.o

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -88,3 +88,5 @@ eval-gprof:
 
 eval-cachegrind:
 	$(CGANNOTATE) $(shell ls -rt cachegrind.out* | tail -1)
+
+export UNDEF += $(BINDIR)cpu/startup.o

--- a/boards/redbee-econotag/Makefile.include
+++ b/boards/redbee-econotag/Makefile.include
@@ -28,7 +28,7 @@ export HEXFILE = $(BINDIR)/$(PROJECT).hex
 export FFLAGS = -t $(PORT) -f $(HEXFILE) -c 'bbmc -l redbee-econotag reset'
 export OFLAGS = -O binary --gap-fill=0xff
 
-export INCLUDES += -I$(RIOTCPU)/$(CPU)/include/ -I$(RIOTBOARD)/$(BOARD)/include
+export INCLUDES += -I$(RIOTCPU)/$(CPU)/include/ -I$(RIOTBOARD)/$(BOARD)/include/
 
 # un-comment once https://github.com/RIOT-OS/RIOT/issues/676 is fixed
 #ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
@@ -39,3 +39,5 @@ export INCLUDES += -I$(RIOTCPU)/$(CPU)/include/ -I$(RIOTBOARD)/$(BOARD)/include
 #		USEMODULE += transceiver
 #	endif
 #endif
+
+export UNDEF += $(BINDIR)cpu/startup.o

--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -13,7 +13,7 @@ export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
-export LINKFLAGS = -mmcu=$(MCU) -lgcc $(BINDIR)startup.o
+export LINKFLAGS = -mmcu=$(MCU) -lgcc $(BINDIR)msp430_common/startup.o
 export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm.py
 export FLASHER = goodfet.bsl
 ifeq ($(strip $(PORT)),)
@@ -33,3 +33,5 @@ ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
 		USEMODULE += transceiver
 	endif
 endif
+
+export UNDEF += $(BINDIR)msp430_common/startup.o

--- a/boards/wsn430-common/Makefile.include
+++ b/boards/wsn430-common/Makefile.include
@@ -12,7 +12,7 @@ export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
-export LINKFLAGS = -mmcu=$(MCU) -lgcc $(BINDIR)startup.o
+export LINKFLAGS = -mmcu=$(MCU) -lgcc $(BINDIR)msp430_common/startup.o
 export FLASHER = mspdebug
 ifeq ($(strip $(PORT)),)
     export PORT = /dev/ttyUSB0
@@ -22,3 +22,5 @@ export FFLAGS = -d $(PORT) -j uif "prog $(HEXFILE)"
 
 export INCLUDES += -I$(RIOTBOARD)/wsn430-common/include
 export OFLAGS = -O ihex
+
+export UNDEF += $(BINDIR)msp430_common/startup.o

--- a/cpu/arm_common/Makefile.include
+++ b/cpu/arm_common/Makefile.include
@@ -1,3 +1,3 @@
 INCLUDES += -I$(RIOTBASE)/cpu/arm_common/include/
 
-export UNDEF += $(BINDIR)syscalls.o
+export UNDEF += $(BINDIR)arm_common/syscalls.o

--- a/cpu/lpc1768/Makefile.include
+++ b/cpu/lpc1768/Makefile.include
@@ -1,3 +1,3 @@
 INCLUDES += -I$(RIOTBASE)/cpu/lpc1768/include
 
-export UNDEF += $(BINDIR)syscalls.o
+export UNDEF += $(BINDIR)cpu/syscalls.o

--- a/cpu/lpc_common/Makefile.include
+++ b/cpu/lpc_common/Makefile.include
@@ -1,3 +1,3 @@
 INCLUDES += -I$(RIOTCPU)/lpc_common/include
 
-export UNDEF += $(BINDIR)lpc_syscalls.o
+export UNDEF += $(BINDIR)lpc_common/lpc_syscalls.o

--- a/cpu/mc1322x/Makefile.include
+++ b/cpu/mc1322x/Makefile.include
@@ -2,6 +2,6 @@ INCLUDES += -I$(RIOTBASE)/cpu/mc1322x/include
 
 include $(RIOTCPU)/arm_common/Makefile.include
 
-export UNDEF += $(BINDIR)mc1322x_syscalls.o
+export UNDEF += $(BINDIR)cpu/mc1322x_syscalls.o
 
 export USEMODULE += arm_common


### PR DESCRIPTION
Creating all object files in one directory is bound to produce name
clashes. RIOT developers may take care to use unique file names, but
external packages surely don't.

With this change all the objects of a module (e.g. `shell`) will be
created in `bin/$(BOARD)/$(MODULE)`.

I compared the final linker command before and after the change. The
`.o` files (e.g. `startup.o`, `syscall.o` ...) are included in the same
order. Neglecting the changed path name where the `.o` files reside, the
linker command stays exactly the same.

A major problem could be third party boards, because the location of the
`startup.o` needs to the specified now in
`boards/$(BOARD)/Makefile.include`, e.g.

``` Makefile
export UNDEF += $(BINDIR)msp430_common/startup.o
```
