### PR TITLE
core: always build and initialize hwtimer

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -44,9 +44,6 @@ ifneq (,$(filter cc110x_ng,$(USEMODULE)))
 	ifeq (,$(filter transceiver,$(USEMODULE)))
 		USEMODULE += transceiver
 	endif
-	ifeq (,$(filter hwtimer,$(USEMODULE)))
-		USEMODULE += hwtimer
-	endif
 endif
 
 ifneq (,$(filter cc2420,$(USEMODULE)))
@@ -101,9 +98,6 @@ ifneq (,$(filter sixlowpan,$(USEMODULE)))
 endif
 
 ifneq (,$(filter vtimer,$(USEMODULE)))
-	ifeq (,$(filter hwtimer,$(USEMODULE)))
-		USEMODULE += hwtimer
-	endif
 	ifeq (,$(filter timex,$(USEMODULE)))
 		USEMODULE += timex
 	endif

--- a/Makefile.modules
+++ b/Makefile.modules
@@ -6,10 +6,7 @@ INCLUDES += -I$(RIOTBASE)/core/include -I$(RIOTBASE)/drivers/include -I$(RIOTBAS
 ED = $(USEMODULE:%=-DMODULE_%)
 ED += $(USEPKG:%=-DMODULE_%)
 EXTDEFINES = $(shell echo $(ED)|tr 'a-z' 'A-Z')
-BL=$(USEMODULE:%= $(BINDIR)%.a)
-
-# exclude hwtimer, because it is part of the kernel but the define is needed for auto_init
-export BASELIBS = $(shell echo $(BL)|sed 's/[^ ]*hwtimer.a//')
+export BASELIBS = $(USEMODULE:%= $(BINDIR)%.a)
 
 CFLAGS += $(EXTDEFINES)
 

--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -1,5 +1,0 @@
-ifneq (,$(filter ltc4150,$(USEMODULE)))
-	ifeq (,$(filter hwtimer,$(USEMODULE)))
-		USEMODULE += hwtimer
-	endif
-endif

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -58,5 +58,3 @@ valgrind:
 #	echo 0 > /proc/sys/kernel/yama/ptrace_scope
 #	VALGRIND_FLAGS += --db-attach=yes
 	$(VALGRIND) $(VALGRIND_FLAGS) $(ELF) $(PORT)
-
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -30,6 +30,7 @@
 #include "cpu.h"
 #include "lpm.h"
 #include "thread.h"
+#include "hwtimer.h"
 
 #ifdef MODULE_AUTO_INIT
 #include <auto_init.h>
@@ -69,6 +70,8 @@ void kernel_init(void)
 {
     dINT();
     printf("kernel_init(): This is RIOT! (Version: %s)\n", VERSION);
+
+    hwtimer_init();
 
     if (thread_create(idle_stack, sizeof(idle_stack), PRIORITY_IDLE, CREATE_WOUT_YIELD | CREATE_STACKTEST, idle_thread, idle_name) < 0) {
         printf("kernel_init(): error creating idle task.\n");

--- a/examples/ccn-lite-client/Makefile
+++ b/examples/ccn-lite-client/Makefile
@@ -35,7 +35,6 @@ USEMODULE += shell_commands
 USEMODULE += posix
 USEMODULE += ps
 USEMODULE += auto_init
-USEMODULE += hwtimer
 USEMODULE += random
 USEMODULE += transceiver
 ifeq ($(BOARD),msba2)

--- a/examples/ccn-lite-relay/Makefile
+++ b/examples/ccn-lite-relay/Makefile
@@ -32,7 +32,6 @@ export QUIET ?= 1
 USEMODULE += config
 USEMODULE += posix
 USEMODULE += auto_init
-USEMODULE += hwtimer
 
 USEMODULE += auto_init
 

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -19,10 +19,6 @@
 
 #include "auto_init.h"
 
-#ifdef MODULE_HWTIMER
-#include "hwtimer.h"
-#endif
-
 #ifdef MODULE_SHT11
 #include "sht11.h"
 #endif
@@ -66,10 +62,6 @@ extern int main(void);
 
 void auto_init(void)
 {
-#ifdef MODULE_HWTIMER
-    DEBUG("Auto init hwtimer module.\n");
-    hwtimer_init();
-#endif
 #ifdef MODULE_VTIMER
     DEBUG("Auto init vtimer module.\n");
     vtimer_init();

--- a/tests/test_hwtimer_spin/Makefile
+++ b/tests/test_hwtimer_spin/Makefile
@@ -1,8 +1,4 @@
 export PROJECT = test_hwtimer_spin
 include ../Makefile.tests_common
 
-# modules to include
-USEMODULE += auto_init
-USEMODULE += hwtimer
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/test_nativenet/Makefile
+++ b/tests/test_nativenet/Makefile
@@ -6,7 +6,6 @@ include $(RIOTBASE)/Makefile.unsupported
 else
 
 USEMODULE += auto_init
-USEMODULE += hwtimer
 USEMODULE += nativenet
 USEMODULE += transceiver
 


### PR DESCRIPTION
Eliminates special treatment of the hwtimer module and makes it a
mandatory part of the kernel.
