### PR TITLE
Make proper use of tcb_t::status bits

### DIFF
--- a/core/include/tcb.h
+++ b/core/include/tcb.h
@@ -27,22 +27,34 @@
 #include "cib.h"
 #include "msg.h"
 
-/* uneven means has to be on runqueue */
-#define STATUS_NOT_FOUND        (0x0000)                      /**< invalid status, may be used as
-                                                                *  return value to signal an error
-                                                                */
-#define STATUS_ON_RUNQUEUE      (0x0001)                      /**< scheduled to run */
-#define STATUS_RUNNING          (0x0002 + STATUS_ON_RUNQUEUE) /**< currently running */
-#define STATUS_PENDING          (0x0004 + STATUS_ON_RUNQUEUE) /**< waiting to be scheduled to run */
-#define STATUS_STOPPED          (0x0008)                      /**< has terminated */
-#define STATUS_SLEEPING         (0x0010)                      /**< sleeping */
-#define STATUS_MUTEX_BLOCKED    (0x0020)                      /**< waiting for a locked mutex */
-#define STATUS_RECEIVE_BLOCKED  (0x0040)                      /**< waiting for a message */
-#define STATUS_SEND_BLOCKED     (0x0080)                      /**< waiting for message to be
-                                                                *  delivered */
-#define STATUS_REPLY_BLOCKED    (0x0100)                      /**< waiting for a message response */
-#define STATUS_TIMER_WAITING    (0x0200)                      /**< waiting for a timer to fire
-                                                                *  (deprecated) */
+/** The runlevels have a running number, starting at 0, but they are shifted 1 bit
+ *  as they also code whether the thread is on the run queue. */
+#define STATUS_RUNLEVEL_SHIFT   (1)
+/** invalid status, may be used as return value to signal an error */
+#define STATUS_NOT_FOUND        (0x0000)
+/** scheduled to run */
+#define STATUS_ON_RUNQUEUE      (0x0001)
+/** currently running */
+#define STATUS_RUNNING         ((0x0000 << STATUS_RUNLEVEL_SHIFT) | STATUS_ON_RUNQUEUE)
+/** waiting to be scheduled to run */
+#define STATUS_PENDING         ((0x0001 << STATUS_RUNLEVEL_SHIFT) | STATUS_ON_RUNQUEUE)
+/** has terminated */
+#define STATUS_STOPPED          (0x0002 << STATUS_RUNLEVEL_SHIFT)
+/** sleeping */
+#define STATUS_SLEEPING         (0x0003 << STATUS_RUNLEVEL_SHIFT)
+/** waiting for a locked mutex */
+#define STATUS_MUTEX_BLOCKED    (0x0004 << STATUS_RUNLEVEL_SHIFT)
+/** waiting for a message */
+#define STATUS_RECEIVE_BLOCKED  (0x0005 << STATUS_RUNLEVEL_SHIFT)
+/** waiting for message to be delivered */
+#define STATUS_SEND_BLOCKED     (0x0006 << STATUS_RUNLEVEL_SHIFT)
+/** waiting for a message response */
+#define STATUS_REPLY_BLOCKED    (0x0007 << STATUS_RUNLEVEL_SHIFT)
+/**< waiting for a timer to fire (deprecated) */
+#define STATUS_TIMER_WAITING    (0x0008 << STATUS_RUNLEVEL_SHIFT)
+/** The bits that determine the runlevel. Use thread_runlevel() to read and
+ *  thread_runlevel_set() to write. */
+#define STATUS_RUNLEVEL_MASK   ((0x0010 << STATUS_RUNLEVEL_SHIFT) - 1)
 
 typedef struct tcb_t {
     char *sp;
@@ -63,6 +75,22 @@ typedef struct tcb_t {
     char *stack_start;
     int stack_size;
 } tcb_t;
+
+/**
+ * @brief   returns the runlevel of a process.
+ */
+static inline unsigned thread_runlevel(const struct tcb_t *tcb)
+{
+    return tcb->status & STATUS_RUNLEVEL_MASK;
+}
+
+/**
+ * @brief   sets the runlevel of a process.
+ */
+static inline void thread_runlevel_set(struct tcb_t *tcb, unsigned new_runlevel)
+{
+    tcb->status = (tcb->status & ~STATUS_RUNLEVEL_MASK) | new_runlevel;
+}
 
 /** @} */
 #endif /* TCB_H_ */

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -50,12 +50,6 @@
 int thread_create(char *stack, int stacksize, char priority, int flags, void (*function) (void), const char *name);
 
 /**
- * @brief   returns the status of a process.
- * @return  STATUS_NOT_FOUND if pid is unknown
- */
-unsigned int thread_getstatus(int pid);
-
-/**
  * @brief   returns the name of a process.
  * @return  NULL if pid is unknown
  */

--- a/core/sched.c
+++ b/core/sched.c
@@ -61,8 +61,8 @@ void sched_run()
     tcb_t *my_active_thread = (tcb_t *)active_thread;
 
     if (my_active_thread) {
-        if (my_active_thread->status == STATUS_RUNNING) {
-            my_active_thread->status = STATUS_PENDING;
+        if (thread_runlevel(my_active_thread) == STATUS_RUNNING) {
+            thread_runlevel_set(my_active_thread, STATUS_PENDING);
         }
 
 #ifdef SCHED_TEST_STACK
@@ -127,8 +127,8 @@ void sched_run()
 
     if (my_active_thread != active_thread) {
         if (active_thread != NULL) {  /* TODO: necessary? */
-            if (active_thread->status ==  STATUS_RUNNING) {
-                active_thread->status =  STATUS_PENDING ;
+            if (thread_runlevel((tcb_t *) active_thread) ==  STATUS_RUNNING) {
+                thread_runlevel_set((tcb_t *) active_thread, STATUS_PENDING);
             }
         }
 
@@ -167,7 +167,7 @@ void sched_set_status(tcb_t *process, unsigned int status)
         }
     }
 
-    process->status = status;
+    thread_runlevel_set(process, status);
 }
 
 void sched_switch(uint16_t current_prio, uint16_t other_prio, int in_isr)

--- a/core/thread.c
+++ b/core/thread.c
@@ -42,15 +42,6 @@ int thread_getlastpid()
     return last_pid;
 }
 
-unsigned int thread_getstatus(int pid)
-{
-    if (sched_threads[pid] == NULL) {
-        return STATUS_NOT_FOUND;
-    }
-
-    return sched_threads[pid]->status;
-}
-
 const char *thread_getname(int pid)
 {
     if (sched_threads[pid] == NULL) {
@@ -82,7 +73,7 @@ int thread_wakeup(int pid)
         dINT();
     }
 
-    int result = sched_threads[pid]->status;
+    int result = thread_runlevel((tcb_t *) sched_threads[pid]);
 
     if (result == STATUS_SLEEPING) {
         DEBUG("thread_wakeup: Thread is sleeping.\n");
@@ -194,7 +185,7 @@ int thread_create(char *stack, int stacksize, char priority, int flags, void (*f
     cb->stack_size = total_stacksize;
 
     cb->priority = priority;
-    cb->status = 0;
+    cb->status = STATUS_NOT_FOUND;
 
     cb->rq_entry.data = (unsigned int) cb;
     cb->rq_entry.next = NULL;

--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -614,7 +614,7 @@ void handle_packet_fragment(uint8_t *data, uint8_t datagram_offset,
         if (current_buf->current_packet_size == current_buf->packet_size) {
             add_fifo_packet(current_buf);
 
-            if (thread_getstatus(transfer_pid) == STATUS_SLEEPING) {
+            if (thread_runlevel(transfer_pid) == STATUS_SLEEPING) {
                 thread_wakeup(transfer_pid);
             }
         }
@@ -795,7 +795,7 @@ void lowpan_read(uint8_t *data, uint8_t length, ieee_802154_long_t *s_laddr,
         else {
             DEBUG("ERROR: no memory left in packet buffer!\n");
         }
-        if (thread_getstatus(transfer_pid) == STATUS_SLEEPING) {
+        if (thread_runlevel(transfer_pid) == STATUS_SLEEPING) {
             thread_wakeup(transfer_pid);
         }
     }

--- a/sys/net/transport_layer/destiny/tcp.c
+++ b/sys/net/transport_layer/destiny/tcp.c
@@ -103,7 +103,7 @@ uint8_t handle_payload(ipv6_hdr_t *ipv6_header, tcp_hdr_t *tcp_header,
         mutex_unlock(&tcp_socket->tcp_buffer_mutex);
     }
 
-    if (thread_getstatus(tcp_socket->recv_pid) == STATUS_RECEIVE_BLOCKED) {
+    if (thread_runlevel(tcp_socket->recv_pid) == STATUS_RECEIVE_BLOCKED) {
         net_msg_send_recv(&m_send_tcp, &m_recv_tcp, tcp_socket->recv_pid, UNDEFINED);
     }
 

--- a/sys/net/transport_layer/destiny/tcp_timer.c
+++ b/sys/net/transport_layer/destiny/tcp_timer.c
@@ -34,7 +34,7 @@ void handle_synchro_timeout(socket_internal_t *current_socket)
 {
     msg_t send;
 
-    if (thread_getstatus(current_socket->recv_pid) == STATUS_RECEIVE_BLOCKED) {
+    if (thread_runlevel(current_socket->recv_pid) == STATUS_RECEIVE_BLOCKED) {
         timex_t now;
         vtimer_now(&now);
 
@@ -73,7 +73,7 @@ void handle_established(socket_internal_t *current_socket)
 
     if ((current_socket->socket_values.tcp_control.send_nxt >
          current_socket->socket_values.tcp_control.send_una) &&
-        (thread_getstatus(current_socket->send_pid) == STATUS_RECEIVE_BLOCKED)) {
+        (thread_runlevel(current_socket) == STATUS_RECEIVE_BLOCKED)) {
         for (i = 0; i < current_socket->socket_values.tcp_control.no_of_retries;
              i++) {
             current_timeout *= 2;


### PR DESCRIPTION
The run level of a thread is coded in its tcb_t::status. The values of
status are currently aligned like a bitmask. Nevertheless the run levels
are (of course) mutual exclusive: A thread cannot be sleeping and
running at the same time.

This change fixes this waste of bits. The run level is now coded in a
consecutive sequence. With LSB remaining a marker whether the thread is
on the run queue, there are five bits coding the run level of a thread.
Seven more run levels can be invented before the (new) run level mask
has to be incresed.

This edit changes quite a lot core code (`msg.c`, `sched.c`, `thread.c`)
as well as rather unrelated codes (`sixlowpan`, `destiny`, and `ps`).

Two new functions are introduced (`thread_runlevel()` and
`thread_runlevel_get()`), and one function is removed
`thread_getstatus()`. The rationale for the latter one is the lack of a
proper justification for this helper function. The new functions are
`static inline`, as they are trivial.
