### PR TITLE
First apply board includes, then det. CC caps

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -29,17 +29,6 @@ BB = $(shell echo $(BOARD)|tr 'a-z' 'A-Z')
 CPUDEF = $(shell echo $(CPU)|tr 'a-z' 'A-Z')
 CFLAGS += -DBOARD=$(BB) -DCPU_$(CPUDEF)
 
-# Add `-fno-delete-null-pointer-checks` flag iff the compiler supports it.
-# GCC removes moves tests whether `x == NULL`, if previously `x` or even `x->y` was accessed.
-# 0x0 might be a sane memory location for embedded systems, so the test must not be removed.
-# Right now clang does not use the *delete-null-pointer* optimization, and does not understand the parameter.
-# Related issues: #628, #664.
-ifeq ($(shell $(CC) -fno-delete-null-pointer-checks -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
-ifeq ($(shell LANG=C $(CC) -fno-delete-null-pointer-checks -E - 2>&1 1>/dev/null </dev/null | grep warning: | grep -- -fno-delete-null-pointer-checks),)
-CFLAGS += -fno-delete-null-pointer-checks
-endif
-endif
-
 export CFLAGS
 
 export BINDIR =$(CURDIR)/bin/$(BOARD)/
@@ -69,6 +58,17 @@ else
 ifeq ($(shell $(CC) -std=c99 -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
 CFLAGS += -std=c99
 endif
+endif
+endif
+
+# Add `-fno-delete-null-pointer-checks` flag iff the compiler supports it.
+# GCC removes moves tests whether `x == NULL`, if previously `x` or even `x->y` was accessed.
+# 0x0 might be a sane memory location for embedded systems, so the test must not be removed.
+# Right now clang does not use the *delete-null-pointer* optimization, and does not understand the parameter.
+# Related issues: #628, #664.
+ifeq ($(shell $(CC) -fno-delete-null-pointer-checks -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+ifeq ($(shell LANG=C $(CC) -fno-delete-null-pointer-checks -E - 2>&1 1>/dev/null </dev/null | grep warning: | grep -- -fno-delete-null-pointer-checks),)
+CFLAGS += -fno-delete-null-pointer-checks
 endif
 endif
 


### PR DESCRIPTION
In #664 I added a test that determines if the supplied compiler
understands the `-fno-delete-null-pointer-checks` flag. The problem is
that the `$(CC)` supplied on command line or in the application's
Makefile is used, but not the one the `$(BOARD)`'s Makefile sets.

That problem was overlooked as all the boards use GCC, and GCC happens
to know the flag. But if some future board does not use GCC, then the
wrong order of the checks could pose a problem.
