### PR TITLE
core:mutex removed unnecessary includes

### DIFF
--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -23,7 +23,6 @@
 #define _MUTEX_H
 
 #include "queue.h"
-#include "tcb.h"
 
 /**
  * @brief Mutex structure. Should never be modified by the user.

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -22,6 +22,7 @@
 #include <inttypes.h>
 
 #include "mutex.h"
+#include "tcb.h"
 #include "atomic.h"
 #include "kernel.h"
 #include "sched.h"


### PR DESCRIPTION
the removed entries from `mutex.c` are already included by `mutex.h`
