### PR TITLE
sys: Hotfix for error introduced in #678

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -99,6 +99,7 @@ static void handle_input_line(shell_t *shell, char *line)
         handler = find_handler(shell->command_list, command);
 
         if (handler != NULL) {
+            line[strlen(command)] = ' ';
             handler(line);
         }
         else {


### PR DESCRIPTION
33239487 let the shell to only give the name of the command to be given to the shell handlers, but no arguments.
