### PR TITLE
sys:posix:fd: replaced designated initializer with direct assignments

### DIFF
--- a/sys/posix/fd.c
+++ b/sys/posix/fd.c
@@ -42,8 +42,8 @@ int fd_init(void)
     fd_t fd;
     fd.__active = 1;
     fd.fd = uart0_handler_pid;
-    fd.read = (ssize_t ( *)(int, void *, size_t))posix_read;
-    fd.write = (ssize_t ( *)(int, const void *, size_t))posix_write;
+    fd.read = (ssize_t (*)(int, void *, size_t))posix_read;
+    fd.write = (ssize_t (*)(int, const void *, size_t))posix_write;
     fd.close = posix_close;
 
     memcpy(&fd_table[STDIN_FILENO], &fd, sizeof(fd_t));


### PR DESCRIPTION
As the warning/error states c++ have no support to direct assign designated initializers.
I'm afraid, there is no way around this.
