### PR TITLE
sys: vtimer: simple vtimer version for gettimeofday

### DIFF
--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
+#include <sys/time.h>
 
 #include "irq.h"
 #include "queue.h"
@@ -400,3 +401,13 @@ void vtimer_print(vtimer_t *t)
 }
 
 #endif
+
+int _gettimeofday(struct timeval *tp, void *restrict tzp) {
+    timex_t now;
+    vtimer_now(&now);
+
+    tp->tv_sec = now.seconds;
+    tp->tv_usec = now.microseconds;
+
+    return 0;
+}


### PR DESCRIPTION
Probably this should be moved to a different location. Something like `sys/posix/rtc`?
