### PR TITLE
Fix `pthread_self()` confusion

### DIFF
--- a/sys/posix/pthread/pthread.c
+++ b/sys/posix/pthread/pthread.c
@@ -51,9 +51,10 @@ enum pthread_thread_status {
 };
 
 typedef struct pthread_thread {
+    int thread_pid;
+
     enum pthread_thread_status status;
     int joining_thread;
-    int thread_pid;
     void *returnval;
     bool should_cancel;
 
@@ -159,6 +160,7 @@ int pthread_create(pthread_t *newthread, const pthread_attr_t *attr, void *(*sta
 void pthread_exit(void *retval)
 {
     pthread_thread_t *self = pthread_sched_threads[pthread_self()];
+    self->thread_pid = -1;
     DEBUG("pthread_exit(%p), self == %p\n", retval, (void *) self);
     if (self->status != PTS_DETACHED) {
         self->returnval = retval;


### PR DESCRIPTION
This fixes #755.

The pthread ID cannot be reused as soon as the thread ends, because
another thread needs to join it first. `pthread_self()` uses the native
(i.e. RIOT's) thread ID to distinguish itself. A native thread ID can be
reused as soon as the thread ends, since the core knows no join
operation.

In order to not confuse itself with an earlier zombie thread (i.e a dead
non-detached thread, that was not joined, yet), we need to invalidate
the associated native thread ID.

This approach is sane since a dead thread won't call `pthread_self()`
anymore.
