### PR TITLE
make calloc "usable" early on

### DIFF
--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -105,6 +105,12 @@ void free(void *ptr)
 
 void *calloc(size_t nmemb, size_t size)
 {
+    /* XXX: This is a dirty hack to enable old dlsym versions to run.
+     * Throw it out when Ubuntu 12.04 support runs out (in 2017-04)! */
+    if (!real_calloc) {
+        return NULL;
+    }
+
     void *r;
     _native_syscall_enter();
     r = real_calloc(nmemb, size);


### PR DESCRIPTION
closes #741

Old versions of the gnu libc uses calloc to allocate dymanic memory
when some error occurs in dlsym.
This results in a segfault as natives calloc wrapper has not been
initialized yet.
As this is a circular dependency and the libc can cope with this, we
just return NULL from the calloc wrapper and hope for the best.

Recent libc versions use a static buffer instead.
