### PR TITLE
move global char array out of thread

### DIFF
--- a/tests/test_hwtimer/main.c
+++ b/tests/test_hwtimer/main.c
@@ -22,6 +22,11 @@
 
 #include "hwtimer.h"
 
+#define BASE_DELAY (1000UL * 1000UL)
+#define DELTA_DELAY (1000UL * 1000UL)
+#define MSGLEN 12 // == strlen("callback %2i")
+char msg[MSGLEN * ARCH_MAXTIMERS]; // == [callback  1\0callback  2\0...]
+
 void callback(void *ptr)
 {
     puts((char *) ptr);
@@ -36,10 +41,6 @@ int main(void)
 
     puts("Initializing hwtimer [OK].");
 
-#define BASE_DELAY (1000UL * 1000UL)
-#define DELTA_DELAY (1000UL * 1000UL)
-#define MSGLEN 12 // == strlen("callback %2i")
-    char msg[MSGLEN * ARCH_MAXTIMERS]; // == [callback  1\0callback  2\0...]
     unsigned long delay = BASE_DELAY + ((ARCH_MAXTIMERS - 1) * DELTA_DELAY);
 
     /* make the first timer first to fire so timers do not run out linearly */


### PR DESCRIPTION
The `char msg[]` is accessed from outside the main thread after it has exited, so it needs to outlive it.

Fixes #717
