### PR TITLE
shell: fix indentation

### DIFF
--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -43,7 +43,7 @@ void thread_print_all(void)
     int i;
     int overall_stacksz = 0;
 
-    printf("\tpid | %-21s| %-9sQ | pri | stack ( used) location  | runtime | switches \n", "name", "state");
+    printf("\tpid | %-21s| %-9sQ | pri | stack ( used) location   | runtime | switches \n", "name", "state");
 
     for (i = 0; i < MAXTHREADS; i++) {
         tcb_t *p = (tcb_t *)sched_threads[i];


### PR DESCRIPTION
before:

```
2014-02-23 18:16:56,878 - INFO # > ps
2014-02-23 18:16:56,887 - INFO #    pid | name                 | state    Q | pri | stack ( used) location  | runtime | switches 
2014-02-23 18:16:56,896 - INFO #      0 | idle                 | pending  Q |  31 |   160 (  148) 0x40000010 |    nan% |  4294967295
2014-02-23 18:16:56,907 - INFO #      1 | main                 | running  Q |  15 |  2560 ( 1048) 0x400000b0 |    nan% |  4294967295
2014-02-23 18:16:56,913 - INFO #      2 | uart0                | bl rx    _ |  14 |   324 (  296) 0x40000c88 |    nan% |  4294967295
2014-02-23 18:16:56,922 - INFO #      3 | relay                | bl rx    _ |  13 |  2048 ( 1376) 0x400030e8 |    nan% |  4294967295
2014-02-23 18:16:56,931 - INFO #      4 | Transceiver          | bl rx    _ |  12 |   512 (  308) 0x40003a50 |    nan% |  4294967295
2014-02-23 18:16:56,940 - INFO #      5 | appserver            | bl rx    _ |  14 |  2048 (  744) 0x400026dc |    nan% |  4294967295
2014-02-23 18:16:56,945 - INFO #        | SUM                  |            |     |  7652
```

after:

```
2014-02-23 18:20:29,959 - INFO # > ps
2014-02-23 18:20:29,967 - INFO #    pid | name                 | state    Q | pri | stack ( used) location   | runtime | switches 
2014-02-23 18:20:29,976 - INFO #      0 | idle                 | pending  Q |  31 |   160 (  148) 0x40000010 |    nan% |  4294967295
2014-02-23 18:20:29,985 - INFO #      1 | main                 | running  Q |  15 |  2560 (  864) 0x400000b0 |    nan% |  4294967295
2014-02-23 18:20:29,999 - INFO #      2 | uart0                | bl rx    _ |  14 |   324 (  296) 0x40000c88 |    nan% |  4294967295
2014-02-23 18:20:30,000 - INFO #        | SUM                  |            |     |  3044
```
