### PR TITLE
doc: added documentation of configuring the right debug stack size for uart0 module

### DIFF
--- a/sys/chardev_thread.c
+++ b/sys/chardev_thread.c
@@ -27,6 +27,7 @@
 #include "ringbuffer.h"
 #include "posix_io.h"
 
+/* increase stack size in uart0 when setting this to 1 */
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 

--- a/sys/uart0/uart0.c
+++ b/sys/uart0/uart0.c
@@ -35,6 +35,7 @@
 #define UART0_BUFSIZE       (128)
 #endif
 
+/* increase when ENABLE_DEBUG in chardev_thread is set to 1! */
 #define UART0_STACKSIZE 	(MINIMUM_STACK_SIZE + 256)
 
 ringbuffer_t uart0_ringbuffer;


### PR DESCRIPTION
Just a simple documentation update that might save someone else some time when debugging...
