### PR TITLE
remove hwtimer from test_irq

### DIFF
--- a/tests/test_irq/Makefile
+++ b/tests/test_irq/Makefile
@@ -6,7 +6,6 @@ ifeq (,$(filter native,$(BOARD)))
 else
 
 USEMODULE += auto_init
-USEMODULE += hwtimer
 USEMODULE += posix
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
cleans up after https://github.com/RIOT-OS/RIOT/pull/714
