### PR TITLE
core: fixup for 685

### DIFF
--- a/core/include/crash.h
+++ b/core/include/crash.h
@@ -13,7 +13,7 @@
  * @file        crash.h
  * @brief       Crash handling header
  *
- * Define a panic() function that allows to stop/reboot the system
+ * Define a core_panic() function that allows to stop/reboot the system
  *  when an unrecoverable problem has occured.
  *
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
@@ -28,11 +28,11 @@
     A numeric code indicating the failure reason can be given
     as the ::crash_code parameter.
     Detailing the failure is possible using the ::message parameter.
-    This function should serve a similar purpose than the panic()
+    This function should serve a similar purpose as the panic()
     function of Unix/Linux kernels.
 
-    if DEVELHELP macro is defined, system will be halted;
-    system will be rebooted otherwise.
+    If the DEVELHELP macro is defined, the system will be halted;
+    the system will be rebooted otherwise.
 
     WARNING: this function NEVER returns! */
 NORETURN void core_panic(int crash_code, const char *message);

--- a/core/include/kernel.h
+++ b/core/include/kernel.h
@@ -13,7 +13,7 @@
  * @file        kernel.h
  * @brief       Kernel compile time configuration
  *
- * A reboot() function is also provided (and used by panic() when needed).
+ * A reboot() function is also provided (and used by core_panic() when needed).
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
@@ -87,7 +87,7 @@ extern config_t sysconfig;
 /**
  * @brief Immediately reboots the system.
  *
- * This function is used by panic() when the DEVELHELP macro is not defined.
+ * This function is used by core_panic() when the DEVELHELP macro is not defined.
  *
  * @return WARNING: this function NEVER returns!
  */

--- a/cpu/native/crash.c
+++ b/cpu/native/crash.c
@@ -41,12 +41,23 @@ NORETURN void core_panic(int crash_code, const char *message)
         /* try to print panic message to console (if possible) */
         puts("******** SYSTEM FAILURE ********\n");
         puts(message);
+#if DEVELHELP
         puts("******** RIOT HALTS HERE ********\n");
+#else
+        puts("******** RIOT WILL REBOOT ********\n");
+#endif
         puts("\n\n");
     }
+
+    dINT();
+#if DEVELHELP
     /* since we're atop an Unix-like platform,
        just use the (developer-)friendly core-dump feature */
     kill(getpid(), SIGTRAP);
+#else
+    reboot();
+#endif
+
     /* proove the compiler that we won't return from this function
        (even if we actually won't even get here...) */
     while (1) {


### PR DESCRIPTION
- use DEVELHELP for native as well
- fix function name in documentation
- improve documentation language/spelling
