### PR TITLE
cpu:arm_common: Easy cpp mixing msba2 support fix

### DIFF
--- a/cpu/arm_common/syscalls.c
+++ b/cpu/arm_common/syscalls.c
@@ -268,15 +268,6 @@ int _getpid(void)
     return active_thread->pid;
 }
 /*---------------------------------------------------------------------------*/
-int _kill_r(struct _reent *r, int pid, int sig)
-{
-    (void) pid;
-    (void) sig;
-    /* not implemented */
-    r->_errno = ESRCH;      // no such process
-    return -1;
-}
-/*---------------------------------------------------------------------------*/
 int _gettimeofday(struct timeval *tp, void *restrict tzp) {
     (void) tzp;
 #if defined MODULE_RTC


### PR DESCRIPTION
This PR depends on #412 to work properly and enables to compile c++ code for msba2.
Added an empty stub for `_kill()` and removed the `_kill_r()` function already implemented in newlib `./newlib/newlib/libc/reent/signalr.c`.
