### PR TITLE
Make: Add include paths automatically for USEMODULES

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -106,6 +106,16 @@ OBJ = $(SRC:%.c=${BINDIR}${PROJECT}/%.o)
 $(BINDIR)$(PROJECT).a: $(OBJ)
 	$(AD)$(AR) -rc $(BINDIR)$(PROJECT).a $(OBJ)
 
+# add extra include paths for packages in $(USEMODULE)
+export USEMODULE_INCLUDES =
+
+include $(RIOTBASE)/sys/Makefile.include
+include $(RIOTBASE)/drivers/Makefile.include
+
+USEMODULE_INCLUDES_ = $(shell echo $(USEMODULE_INCLUDES) | tr ' ' '\n' | awk '!a[$$0]++' | tr '\n' ' ')
+
+INCLUDES += $(USEMODULE_INCLUDES_:%=-I%)
+
 # include Makefile.includes for packages in $(USEPKG)
 $(RIOTBASE)/pkg/%/Makefile.include::
 	$(AD)"$(MAKE)" -C $(RIOTBASE)/pkg/$* Makefile.include

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -1,0 +1,12 @@
+ifneq (,$(filter cc2420,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/cc2420/include
+endif
+ifneq (,$(filter cc110x,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/cc110x/include
+endif
+ifneq (,$(filter cc110x_ng,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/cc110x_ng/include
+endif
+ifneq (,$(filter at86rf231,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/at86rf231/include
+endif

--- a/examples/ccn-lite-client/Makefile
+++ b/examples/ccn-lite-client/Makefile
@@ -48,6 +48,4 @@ USEMODULE += crypto_sha256
 USEMODULE += ccn_lite
 USEMODULE += ccn_lite_client
 
-export INCLUDES = -I$(RIOTBASE)/sys/net/include
-
 include $(RIOTBASE)/Makefile.include

--- a/examples/ccn-lite-relay/Makefile
+++ b/examples/ccn-lite-relay/Makefile
@@ -46,6 +46,4 @@ USEMODULE += rtc
 USEMODULE += crypto_sha256
 USEMODULE += ccn_lite
 
-export INCLUDES = -I$(RIOTBASE)/sys/net/include/
-
 include $(RIOTBASE)/Makefile.include

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -55,6 +55,4 @@ ifneq (,$(filter native,$(BOARD)))
 	USEMODULE += random
 endif
 
-export INCLUDES += -I${RIOTBASE}/core/include/ -I${RIOTBASE}/sys/include/ -I${RIOTBASE}/drivers/include/
-
 include $(RIOTBASE)/Makefile.include

--- a/examples/rpl_udp/Makefile
+++ b/examples/rpl_udp/Makefile
@@ -49,6 +49,4 @@ USEMODULE += sixlowpan
 USEMODULE += rpl
 USEMODULE += destiny
 
-export INCLUDES += -I$(RIOTBASE)/sys/net/include -I$(RIOTBASE)/sys/net/routing/rpl -I$(RIOTBASE)/drivers/cc110x
-
 include $(RIOTBASE)/Makefile.include

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -15,7 +15,6 @@ ifneq (,$(filter ps,$(USEMODULE)))
     DIRS += ps
 endif
 ifneq (,$(filter posix,$(USEMODULE)))
-	INCLUDES += -I$(RIOTBASE)/sys/posix/include
     DIRS += posix
 endif
 ifneq (,$(filter pnet,$(USEMODULE)))

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -1,0 +1,60 @@
+ifneq (,$(filter destiny,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include
+endif
+ifneq (,$(filter net_help,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/cc110x
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/cc110x_ng/include
+endif
+ifneq (,$(filter net_if,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include
+endif
+ifneq (,$(filter protocol_multiplex,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include
+endif
+ifneq (,$(filter sixlowpan,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include
+endif
+ifneq (,$(filter rpl,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/routing/rpl
+endif
+ifneq (,$(filter ieee802154,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include
+endif
+ifneq (,$(filter ccn_lite,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/ccn_lite
+endif
+ifneq (,$(filter ccn_lite_client,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include
+endif
+
+ifneq (,$(filter crypto_3des,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/include/crypto
+endif
+ifneq (,$(filter crypto_aes,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/include/crypto
+endif
+ifneq (,$(filter crypto_rc5,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/include/crypto
+endif
+ifneq (,$(filter crypto_sha256,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/include/crypto
+endif
+ifneq (,$(filter crypto_skipjack,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/include/crypto
+endif
+ifneq (,$(filter crypto_twofish,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/include/crypto
+endif
+
+ifneq (,$(filter posix,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/posix/include
+endif
+ifneq (,$(filter pnet,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/posix/pnet/include
+endif
+ifneq (,$(filter pthread,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/posix/pthread/include
+endif

--- a/sys/crypto/3des/Makefile
+++ b/sys/crypto/3des/Makefile
@@ -1,8 +1,3 @@
-SRC = 3des.c
-
-OBJ = $(SRC:%.c=$(BINDIR)%.o)
-DEP = $(SRC:%.c=$(BINDIR)%.d)
-
 MODULE = crypto_3des
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/crypto/aes/Makefile
+++ b/sys/crypto/aes/Makefile
@@ -1,8 +1,3 @@
-SRC = aes.c
-
-OBJ = $(SRC:%.c=$(BINDIR)%.o)
-DEP = $(SRC:%.c=$(BINDIR)%.d)
-
 MODULE = crypto_aes
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/crypto/rc5/Makefile
+++ b/sys/crypto/rc5/Makefile
@@ -1,8 +1,3 @@
-SRC = rc5.c
-
-OBJ = $(SRC:%.c=$(BINDIR)%.o)
-DEP = $(SRC:%.c=$(BINDIR)%.d)
-
 MODULE = crypto_rc5
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/crypto/sha256/Makefile
+++ b/sys/crypto/sha256/Makefile
@@ -1,8 +1,3 @@
-SRC = sha256.c
-
-OBJ = $(SRC:%.c=$(BINDIR)%.o)
-DEP = $(SRC:%.c=$(BINDIR)%.d)
-
 MODULE = crypto_sha256
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/crypto/skipjack/Makefile
+++ b/sys/crypto/skipjack/Makefile
@@ -1,8 +1,3 @@
-SRC = skipjack.c
-
-OBJ = $(SRC:%.c=$(BINDIR)%.o)
-DEP = $(SRC:%.c=$(BINDIR)%.d)
-
 MODULE = crypto_skipjack
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/crypto/twofish/Makefile
+++ b/sys/crypto/twofish/Makefile
@@ -1,8 +1,3 @@
-SRC = twofish.c
-
-OBJ = $(SRC:%.c=$(BINDIR)%.o)
-DEP = $(SRC:%.c=$(BINDIR)%.d)
-
 MODULE = crypto_twofish
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/crosslayer/net_help/Makefile
+++ b/sys/net/crosslayer/net_help/Makefile
@@ -1,5 +1,3 @@
 MODULE:=$(shell basename $(CURDIR))
 
-INCLUDES += -I$(RIOTBASE)/sys/net/include
-
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/link_layer/protocol-multiplex/Makefile
+++ b/sys/net/link_layer/protocol-multiplex/Makefile
@@ -1,5 +1,3 @@
-INCLUDES += -I$(RIOTBASE)/sys/net/include
-
-MODULE:=protocol_multiplex
+MODULE = protocol_multiplex
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/posix/pnet/Makefile
+++ b/sys/posix/pnet/Makefile
@@ -1,5 +1,3 @@
 MODULE =pnet
 
-CFLAGS += -isystem $(RIOTBASE)/sys/posix/pnet/include
-
 include $(RIOTBASE)/Makefile.base

--- a/sys/posix/pthread/Makefile
+++ b/sys/posix/pthread/Makefile
@@ -1,7 +1,3 @@
 MODULE = pthread
 
-CFLAGS += -isystem $(RIOTBASE)/sys/posix/pthread/include
-
-export INCLUDES += -I$(RIOTBASE)/sys/posix/pthread/include
-
 include $(RIOTBASE)/Makefile.base

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -14,7 +14,6 @@ ifneq (,$(filter cc110x,$(USEMODULE)))
 	endif
 endif
 ifneq (,$(filter net_if,$(USEMODULE)))
-	INCLUDES += -I$(RIOTBASE)/sys/net/include
 	SRC += sc_net_if.c
 endif
 ifneq (,$(filter mci,$(USEMODULE)))

--- a/tests/test_net_if/Makefile
+++ b/tests/test_net_if/Makefile
@@ -12,6 +12,4 @@ USEMODULE += auto_init
 USEMODULE += net_if
 USEMODULE += defaulttransceiver
 
-export INCLUDES += -I$(RIOTBASE)/sys/net/include
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/test_pnet/Makefile
+++ b/tests/test_pnet/Makefile
@@ -1,4 +1,4 @@
-export PROJECT =test_pnet
+export PROJECT = test_pnet
 include ../Makefile.tests_common
 
 USEMODULE += auto_init
@@ -6,14 +6,5 @@ USEMODULE += posix
 USEMODULE += pnet
 USEMODULE += vtimer
 USEMODULE += defaulttransceiver
-
-ifeq ($(BOARD),native)
-	CFLAGS += -isystem $(RIOTBASE)/sys/net/include \
-			  -isystem $(RIOTBASE)/sys/posix/pnet/include
-else
-	export INCLUDES += -I$(RIOTBASE)/sys/net/include \
-					   -I$(RIOTBASE)/sys/posix/pnet/include \
-					   -I$(RIOTBASE)/sys/posix/include
-endif
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/test_pthread/Makefile
+++ b/tests/test_pthread/Makefile
@@ -4,11 +4,4 @@ include ../Makefile.tests_common
 USEMODULE += posix
 USEMODULE += pthread
 
-ifeq ($(BOARD),native)
-	CFLAGS += -isystem $(RIOTBASE)/sys/posix/pthread/include
-else
-	export INCLUDES += -I$(RIOTBASE)/sys/posix/pthread/include \
-					   -I$(RIOTBASE)/sys/posix/include
-endif
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/test_pthread_cooperation/Makefile
+++ b/tests/test_pthread_cooperation/Makefile
@@ -4,11 +4,4 @@ include ../Makefile.tests_common
 USEMODULE += posix
 USEMODULE += pthread
 
-ifeq ($(BOARD),native)
-    CFLAGS += -isystem $(RIOTBASE)/sys/posix/pthread/include
-else
-    export INCLUDES = -I$(RIOTBASE)/sys/posix/pthread/include \
-                      -I$(RIOTBASE)/sys/posix/include
-endif
-
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
Application developers use `$(USEMODULES)` in their Makefiles to have
the relevant functionally automagically added to their apps. This even
does basic dependency tracking by means of `Makefile.dep`.

But an important thing is missing: the automatic adding of include
paths. This is inconvenient, error prone, and will hinder the RIOT core
developers in future to change folder structures.
