### PR TITLE
Make: Automatically remove dups in `$(USEMODULE)`

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1,37 +1,21 @@
 ifneq (,$(filter libcoap,$(USEPKG)))
-	ifeq (,$(filter pnet,$(USEMODULE)))
-		USEMODULE += pnet
-	endif
+	USEMODULE += pnet
 endif
 
 ifneq (,$(filter pnet,$(USEMODULE)))
-	ifeq (,$(filter posix,$(USEMODULE)))
-		USEMODULE += posix
-	endif
-	ifeq (,$(filter destiny,$(USEMODULE)))
-		USEMODULE += destiny
-	endif
-	ifeq (,$(filter net_help,$(USEMODULE)))
-		USEMODULE += net_help
-	endif
+	USEMODULE += posix
+	USEMODULE += destiny
+	USEMODULE += net_help
 endif
 
 ifneq (,$(filter destiny,$(USEMODULE)))
-    ifeq (,$(filter sixlowpan,$(USEMODULE)))
-        USEMODULE += sixlowpan
-    endif
-    ifeq (,$(filter net_help,$(USEMODULE)))
-        USEMODULE += net_help
-    endif
-    ifeq (,$(filter vtimer,$(USEMODULE)))
-        USEMODULE += vtimer
-    endif
+    USEMODULE += sixlowpan
+    USEMODULE += net_help
+    USEMODULE += vtimer
 endif
 
 ifneq (,$(filter sixlowborder,$(USEMODULE)))
-    ifeq (,$(filter sixlowpan,$(USEMODULE)))
-        USEMODULE += sixlowpan
-    endif
+    USEMODULE += sixlowpan
 endif
 
 ifneq (,$(filter rpl,$(USEMODULE)))
@@ -43,94 +27,52 @@ ifneq (,$(filter routing,$(USEMODULE)))
 endif
 
 ifneq (,$(filter sixlowpan,$(USEMODULE)))
-    ifeq (,$(filter ieee802154,$(USEMODULE)))
-        USEMODULE += ieee802154
-    endif
-    ifeq (,$(filter net_help,$(USEMODULE)))
-        USEMODULE += net_help
-    endif
-    ifeq (,$(filter net_if,$(USEMODULE)))
-        USEMODULE += net_if
-    endif
-    ifeq (,$(filter posix, $(USEMODULE)))
-        USEMODULE += posix
-    endif
-    ifeq (,$(filter vtimer, $(USEMODULE)))
-        USEMODULE += vtimer
-    endif
+    USEMODULE += ieee802154
+    USEMODULE += net_help
+    USEMODULE += net_if
+    USEMODULE += posix
+    USEMODULE += vtimer
 endif
 
 ifneq (,$(filter posix,$(USEMODULE)))
-	ifeq (,$(filter uart0,$(USEMODULE)))
-		USEMODULE += uart0
-	endif
-	ifeq (,$(filter timex,$(USEMODULE)))
-		USEMODULE += timex
-	endif
-	ifeq (,$(filter vtimer,$(USEMODULE)))
-		USEMODULE += vtimer
-	endif
+	USEMODULE += uart0
+	USEMODULE += timex
+	USEMODULE += vtimer
 endif
 
 ifneq (,$(filter uart0,$(USEMODULE)))
-	ifeq (,$(filter lib,$(USEMODULE)))
-		USEMODULE += lib
-	endif
-	ifeq (,$(filter posix,$(USEMODULE)))
-		USEMODULE += posix
-	endif
+	USEMODULE += lib
+	USEMODULE += posix
 endif
 
 ifneq (,$(filter cc110x%,$(USEMODULE)))
-	ifeq (,$(filter protocol_multiplex,$(USEMODULE)))
-		USEMODULE += protocol_multiplex
-	endif
-	ifeq (,$(filter vtimer,$(USEMODULE)))
-		USEMODULE += vtimer
-	endif
+	USEMODULE += protocol_multiplex
+	USEMODULE += vtimer
 endif
 
 ifneq (,$(filter cc110x_ng,$(USEMODULE)))
-	ifeq (,$(filter transceiver,$(USEMODULE)))
-		USEMODULE += transceiver
-	endif
+	USEMODULE += transceiver
 endif
 
 ifneq (,$(filter cc2420,$(USEMODULE)))
-	ifeq (,$(filter transceiver,$(USEMODULE)))
-		USEMODULE += transceiver
-	endif
-	ifeq (,$(filter ieee802154,$(USEMODULE)))
-		USEMODULE += ieee802154
-	endif
+	USEMODULE += transceiver
+	USEMODULE += ieee802154
 endif
 
 ifneq (,$(filter at86rf231,$(USEMODULE)))
-	ifeq (,$(filter transceiver,$(USEMODULE)))
-		USEMODULE += transceiver
-	endif
-	ifeq (,$(filter ieee802154,$(USEMODULE)))
-		USEMODULE += ieee802154
-	endif
-	ifeq (,$(filter vtimer,$(USEMODULE)))
-		USEMODULE += vtimer
-	endif
+	USEMODULE += transceiver
+	USEMODULE += ieee802154
+	USEMODULE += vtimer
 endif
 
 ifneq (,$(filter vtimer,$(USEMODULE)))
-	ifeq (,$(filter timex,$(USEMODULE)))
-		USEMODULE += timex
-	endif
+	USEMODULE += timex
 endif
 
 ifneq (,$(filter net_if,$(USEMODULE)))
-	ifeq (,$(filter transceiver,$(USEMODULE)))
-		USEMODULE += transceiver
-	endif
+	USEMODULE += transceiver
 endif
 
 ifneq (,$(filter shell_commands,$(USEMODULE)))
-	ifneq (,$(filter net_if,$(USEMODULE)))
-		USEMODULE += net_help
-	endif
+	USEMODULE += net_help
 endif

--- a/Makefile.modules
+++ b/Makefile.modules
@@ -6,9 +6,9 @@ USEMODULE += $(filter-out $(DISABLE_MODULE), $(DEFAULT_MODULE))
 INCLUDES += -I$(RIOTBASE)/core/include -I$(RIOTBASE)/drivers/include -I$(RIOTBASE)/sys/include
 ED = $(USEMODULE:%=-DMODULE_%)
 ED += $(USEPKG:%=-DMODULE_%)
-EXTDEFINES = $(shell echo $(ED)|tr 'a-z' 'A-Z')
-REALMODULES = $(filter-out $(PSEUDOMODULES), $(USEMODULE))
-export BASELIBS = $(REALMODULES:%= $(BINDIR)%.a)
+EXTDEFINES = $(shell echo $(sort $(ED))|tr 'a-z' 'A-Z')
+REALMODULES = $(filter-out $(PSEUDOMODULES), $(sort $(USEMODULE)))
+export BASELIBS = $(REALMODULES:%=$(BINDIR)%.a)
 
 CFLAGS += $(EXTDEFINES)
 

--- a/boards/avsextrem/Makefile.include
+++ b/boards/avsextrem/Makefile.include
@@ -1,12 +1,8 @@
 export INCLUDES += -I$(RIOTBOARD)/avsextrem/include
 
 ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
-	ifeq (,$(filter cc110x,$(USEMODULE)))
-		USEMODULE += cc110x
-	endif
-	ifeq (,$(filter transceiver,$(USEMODULE)))
-		USEMODULE += transceiver
-	endif
+	USEMODULE += cc110x
+	USEMODULE += transceiver
 endif
 
 ifneq (,$(filter cc110x,$(USEMODULE)))

--- a/boards/chronos/Makefile.dep
+++ b/boards/chronos/Makefile.dep
@@ -1,8 +1,4 @@
 ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
-	ifeq (,$(filter cc110x_ng,$(USEMODULE)))
-		USEMODULE += cc110x_ng
-	endif
-	ifeq (,$(filter transceiver,$(USEMODULE)))
-		USEMODULE += transceiver
-	endif
+	USEMODULE += cc110x_ng
+	USEMODULE += transceiver
 endif

--- a/boards/msb-430h/Makefile.dep
+++ b/boards/msb-430h/Makefile.dep
@@ -1,14 +1,8 @@
 ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
-	ifeq (,$(filter cc110x_ng,$(USEMODULE)))
-		USEMODULE += cc110x_ng
-	endif
-	ifeq (,$(filter transceiver,$(USEMODULE)))
-		USEMODULE += transceiver
-	endif
+	USEMODULE += cc110x_ng
+	USEMODULE += transceiver
 endif
 
 ifneq (,$(filter cc110x_ng,$(USEMODULE)))
-	ifeq (,$(filter cc110x_spi,$(USEMODULE)))
-		USEMODULE += cc110x_spi
-	endif
+	USEMODULE += cc110x_spi
 endif

--- a/boards/msba2-common/Makefile.dep
+++ b/boards/msba2-common/Makefile.dep
@@ -1,20 +1,12 @@
 ifneq (,$(filter cc110x,$(USEMODULE)))
-	ifeq (,$(filter gpioint,$(USEMODULE)))
-		USEMODULE += gpioint
-	endif
+	USEMODULE += gpioint
 endif
 
 ifneq (,$(filter cc110x_ng,$(USEMODULE)))
-	ifeq (,$(filter cc110x_spi,$(USEMODULE)))
-		USEMODULE += cc110x_spi
-	endif
-	ifeq (,$(filter gpioint,$(USEMODULE)))
-		USEMODULE += gpioint
-	endif
+	USEMODULE += cc110x_spi
+	USEMODULE += gpioint
 endif
 
 ifneq (,$(filter ltc4150,$(USEMODULE)))
-	ifeq (,$(filter gpioint,$(USEMODULE)))
-		USEMODULE += gpioint
-	endif
+	USEMODULE += gpioint
 endif

--- a/boards/msba2/Makefile.include
+++ b/boards/msba2/Makefile.include
@@ -1,12 +1,8 @@
 export INCLUDES += -I$(RIOTBOARD)/msba2/include
 
 ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
-	ifeq (,$(filter cc110x_ng,$(USEMODULE)))
-		USEMODULE += cc110x_ng
-	endif
-	ifeq (,$(filter transceiver,$(USEMODULE)))
-		USEMODULE += transceiver
-	endif
+	USEMODULE += cc110x_ng
+	USEMODULE += transceiver
 endif
 
 include $(RIOTBOARD)/msba2-common/Makefile.include

--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -1,8 +1,4 @@
 ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
-	ifeq (,$(filter nativenet,$(USEMODULE)))
-		USEMODULE += nativenet
-	endif
-	ifeq (,$(filter transceiver,$(USEMODULE)))
-		USEMODULE += transceiver
-	endif
+	USEMODULE += nativenet
+	USEMODULE += transceiver
 endif

--- a/boards/pttu/Makefile.include
+++ b/boards/pttu/Makefile.include
@@ -2,12 +2,8 @@ export INCLUDES += -I$(RIOTBOARD)/pttu/include
 
 # Enable this after fixing https://github.com/RIOT-OS/RIOT/issues/659
 #ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
-#	ifeq (,$(filter cc110x,$(USEMODULE)))
-#		USEMODULE += cc110x
-#	endif
-#	ifeq (,$(filter transceiver,$(USEMODULE)))
-#		USEMODULE += transceiver
-#	endif
+#	USEMODULE += cc110x
+#	USEMODULE += transceiver
 #endif
 
 include $(RIOTBOARD)/msba2-common/Makefile.include

--- a/boards/redbee-econotag/Makefile.include
+++ b/boards/redbee-econotag/Makefile.include
@@ -33,12 +33,8 @@ export INCLUDES += -I$(RIOTCPU)/$(CPU)/maca/include
 export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/drivers/include
 
 ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
-	ifeq (,$(filter mc1322x,$(USEMODULE)))
-		USEMODULE += mc1322x
-	endif
-	ifeq (,$(filter transceiver,$(USEMODULE)))
-		USEMODULE += transceiver
-	endif
+	USEMODULE += mc1322x
+	USEMODULE += transceiver
 endif
 
 export UNDEF += $(BINDIR)cpu/startup.o

--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -26,12 +26,8 @@ export INCLUDES += -I$(RIOTCPU)/msp430-common/include -I$(RIOTBOARD)/$(BOARD)/in
 export OFLAGS = -O ihex
 
 ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
-	ifeq (,$(filter cc2240,$(USEMODULE)))
-		USEMODULE += cc2420
-	endif
-	ifeq (,$(filter transceiver,$(USEMODULE)))
-		USEMODULE += transceiver
-	endif
+	USEMODULE += cc2420
+	USEMODULE += transceiver
 endif
 
 export UNDEF += $(BINDIR)msp430_common/startup.o

--- a/boards/wsn430-v1_3b/Makefile.dep
+++ b/boards/wsn430-v1_3b/Makefile.dep
@@ -1,16 +1,10 @@
 ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
-	ifeq (,$(filter cc110x_ng,$(USEMODULE)))
-       USEMODULE += cc110x_ng
-   endif
-	ifeq (,$(filter transceiver,$(USEMODULE)))
-       USEMODULE += transceiver
-   endif
+    USEMODULE += cc110x_ng
+    USEMODULE += transceiver
 endif
 
 ifneq (,$(filter cc110x_ng,$(USEMODULE)))
-    ifeq (,$(filter cc110x_spi,$(USEMODULE)))
-        USEMODULE += cc110x_spi
-    endif
+    USEMODULE += cc110x_spi
 endif
 
 USEMODULE += msp430_common

--- a/boards/wsn430-v1_4/Makefile.dep
+++ b/boards/wsn430-v1_4/Makefile.dep
@@ -1,10 +1,6 @@
 USEMODULE += msp430_common
 
 ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
-	ifeq (,$(filter cc2420,$(USEMODULE)))
-		USEMODULE += cc2420
-	endif
-	ifeq (,$(filter transceiver,$(USEMODULE)))
-		USEMODULE += transceiver
-	endif
+	USEMODULE += cc2420
+	USEMODULE += transceiver
 endif


### PR DESCRIPTION
`Makefile.dep` is huge for no proper reason.
Remove the duplicates in one place to make the file more readable.
