### PR TITLE
make: couple include path and -I

### DIFF
--- a/boards/msb-430-common/Makefile.include
+++ b/boards/msb-430-common/Makefile.include
@@ -36,5 +36,5 @@ endif
 export FFLAGS += "prog $(HEXFILE)"
 
 export USEMODULE += msp430_common
-export INCLUDES += -I $(RIOTCPU)/msp430-common/include/ -I$(RIOTBOARD)/msb-430-common/include -I$(RIOTBOARD)/msb-430-common/drivers/include
+export INCLUDES += -I$(RIOTCPU)/msp430-common/include/ -I$(RIOTBOARD)/msb-430-common/include -I$(RIOTBOARD)/msb-430-common/drivers/include
 export OFLAGS = -O ihex

--- a/boards/redbee-econotag/Makefile.include
+++ b/boards/redbee-econotag/Makefile.include
@@ -28,4 +28,4 @@ export HEXFILE = $(BINDIR)/$(PROJECT).hex
 export FFLAGS = -t $(PORT) -f $(HEXFILE) -c 'bbmc -l redbee-econotag reset'
 export OFLAGS = -O binary --gap-fill=0xff
 
-export INCLUDES += -I $(RIOTCPU)/$(CPU)/include/
+export INCLUDES += -I$(RIOTCPU)/$(CPU)/include/

--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -22,5 +22,5 @@ endif
 export HEXFILE = $(BINDIR)$(PROJECT).hex
 export FFLAGS = --telosb -c $(PORT) -r -e -I -p $(HEXFILE)
 
-export INCLUDES += -I $(RIOTCPU)/msp430-common/include -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/drivers/cc2420/include -I$(RIOTBASE)/sys/net/include
+export INCLUDES += -I$(RIOTCPU)/msp430-common/include -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/drivers/cc2420/include -I$(RIOTBASE)/sys/net/include
 export OFLAGS = -O ihex

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -46,7 +46,7 @@ export QUIET ?= 1
 #USEMODULE += cc110x
 #USEMODULE += fat
 
-#export INCLUDES += -I application_include
+#export INCLUDES += -Iapplication_include
 
 # Specify custom dependencies for your application here ...
 # export PROJDEPS = proj_data.h

--- a/pkg/libcoap/Makefile.include
+++ b/pkg/libcoap/Makefile.include
@@ -1,4 +1,4 @@
-INCLUDES += -I $(RIOTBASE)/pkg/libcoap/libcoap \
-			-I $(RIOTBASE)/sys/posix/include \
-			-I $(RIOTBASE)/sys/posix/pnet/include \
-			-I $(RIOTBASE)/sys/net/include
+INCLUDES += -I$(RIOTBASE)/pkg/libcoap/libcoap \
+			-I$(RIOTBASE)/sys/posix/include \
+			-I$(RIOTBASE)/sys/posix/pnet/include \
+			-I$(RIOTBASE)/sys/net/include


### PR DESCRIPTION
This is necessary if includes have to be filtered, such as in native
to throw out RIOTs posix includes which interfere with system
includes.

This is part of a fix for https://github.com/RIOT-OS/RIOT/issues/793
