### PR TITLE
native/posix: Don't include sys/types.h in semaphore.h

### DIFF
--- a/sys/include/semaphore.h
+++ b/sys/include/semaphore.h
@@ -1,7 +1,6 @@
 #ifndef _SEMAPHORE_H
 #define _SEMAPHORE_H	1
 
-#include <sys/types.h>
 #include <time.h>
 
 /** Value returned if `sem_open' failed.  */


### PR DESCRIPTION
`sys/types.h` contains the native definition for `pthread_*_t`. This
causes clashes if you want to use `semaphore` and `pthread` in the same
application.
