### PR TITLE
core: `queue_priority_add` should be fair

### DIFF
--- a/core/queue.c
+++ b/core/queue.c
@@ -69,7 +69,7 @@ void queue_priority_add(queue_node_t *root, queue_node_t *new_obj)
     queue_node_t *node = root;
 
     while (node->next != NULL) {
-        if (node->next->priority > new_obj->priority) {
+        if (node->next->priority >= new_obj->priority) {
             new_obj->next = node->next;
             node->next = new_obj;
             return;


### PR DESCRIPTION
`queue_priority_add` adds a thread to the top of its respective priority
class, i.e. it `queue_node_t` implements a FIFO queue for each priority
class. This is unfair. A thread in the same priority class could starve.

This patch add a new thread to the back of its respective priority
class, implementing a LIFO queue for each class.
