### PR TITLE
vtimer: Add `vtimer_set_wakeup2()`

### DIFF
--- a/sys/include/vtimer.h
+++ b/sys/include/vtimer.h
@@ -100,6 +100,15 @@ int vtimer_set_msg(vtimer_t *t, timex_t interval, unsigned int pid, void *ptr);
 int vtimer_set_wakeup(vtimer_t *t, timex_t interval, int pid);
 
 /**
+ * @brief   set a vtimer with wakeup event
+ * @param[in]   t           pointer to preinitialised vtimer_t
+ * @param[in]   pid         process id
+ * @param[out]  activated_by_vtimer   1 if the vtimer woke up this thread, unchanged otherwise
+ * @return      0 on success, < 0 on error
+ */
+int vtimer_set_wakeup2(vtimer_t *t, timex_t interval, int pid, int *activated_by_vtimer);
+
+/**
  * @brief   remove a vtimer
  * @param[in]   t           pointer to preinitialised vtimer_t
  * @return      0 on success, < 0 on error

--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -172,14 +172,15 @@ void vtimer_callback(void *ptr)
         msg_send_int(&msg, timer->pid);
     }
     else if (timer->action == (void (*)(void *)) thread_wakeup){
-        timer->action(timer->arg);
+        *(int *) timer->arg = 1;
+        thread_wakeup(timer->pid);
     }
     else if (timer->action == vtimer_tick) {
         vtimer_tick(NULL);
     }
     else if (timer->action == (void (*)(void *)) mutex_unlock) {
         mutex_t *mutex = (mutex_t *) timer->arg;
-        timer->action(mutex);
+        mutex_unlock(mutex);
     }
     else {
         DEBUG("Timer was poisoned.\n");
@@ -242,7 +243,6 @@ static int vtimer_set(vtimer_t *timer)
         DEBUG("vtimer_set(): setting short_term\n");
 
         if (set_shortterm(timer)) {
-
             /* delay update of next shortterm timer if we
             * are called from within vtimer_callback. */
 
@@ -251,7 +251,6 @@ static int vtimer_set(vtimer_t *timer)
             }
         }
     }
-
 
     restoreIRQ(state);
 
@@ -311,11 +310,17 @@ int vtimer_init()
 
 int vtimer_set_wakeup(vtimer_t *t, timex_t interval, int pid)
 {
+    int activated_by_vtimer;
+    return vtimer_set_wakeup2(t, interval, pid, &activated_by_vtimer);
+}
+
+int vtimer_set_wakeup2(vtimer_t *t, timex_t interval, int pid, int *activated_by_vtimer)
+{
     int ret;
     t->action = (void(*)(void *)) thread_wakeup;
-    t->arg = (void *) pid;
+    t->arg = activated_by_vtimer;
     t->absolute = interval;
-    t->pid = 0;
+    t->pid = pid;
     ret = vtimer_set(t);
     return ret;
 }


### PR DESCRIPTION
`vtimer_set_wakeup()` wakes up the calling thread after N ticks. But if
you want to use this function to implement a timeout, then you are out
of luck. There is no way to differentiate between a wakeup through
`vtimer_set_wakeup()` or another thread using `thread_wakeup()`.

This patch introduces `vtimer_set_wakeup2()` which takes an addition
paramter `activated_by_vtimer` which gets set to 1 before wakte up the
thread. As long as the time is not up, the value is left unchanged.

This also allows "misusing" the function in a busy loop which tests if
the content was changed.
