### PR TITLE
core: change reboot signature.

### DIFF
--- a/core/include/kernel.h
+++ b/core/include/kernel.h
@@ -13,7 +13,7 @@
  * @file        kernel.h
  * @brief       Kernel compile time configuration
  *
- * A reboot() function is also provided (and used by core_panic() when needed).
+ * A int reboot(int mode) function is also provided (and used by core_panic() when needed).
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
@@ -89,9 +89,13 @@ extern config_t sysconfig;
  *
  * This function is used by core_panic() when the DEVELHELP macro is not defined.
  *
- * @return WARNING: this function NEVER returns!
+ * @param mode  The reboot mode (unused for now)
+ *
+ * @return This call never returns when successful. -1 is returned otherwise.
  */
-NORETURN void reboot(void);
+int reboot(int mode);
+
+#define RB_AUTOBOOT 0   /* << Reboot the system in the usual fashion */
 
 /** @} */
 #endif /* KERNEL_H_ */

--- a/core/include/kernel_internal.h
+++ b/core/include/kernel_internal.h
@@ -51,5 +51,15 @@ void sched_task_exit(void);
  */
 void thread_print_stack(void);
 
+/**
+ * @brief       Reboot the system
+ *
+ * @param mode  The argument is ignored and only used for conformity
+ *              with existing reboot implementations for now.
+ *
+ * @return      This call never returns when successful. -1 is returned otherwise.
+ */
+int reboot_arch(int mode);
+
 /** @} */
 #endif /* KERNEL_INTERNAL_H_ */

--- a/core/reboot.c
+++ b/core/reboot.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2014 Ludwig Ortmann
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     core_util
+ * @{
+ *
+ * @file        reboot.c
+ * @brief       Reboot function
+ *
+ * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de
+ *
+ * @}
+ */
+
+#include "kernel.h"
+#include "kernel_internal.h"
+
+int reboot(int mode)
+{
+    if (mode != RB_AUTOBOOT) {
+        return -1;
+    }
+
+    return reboot_arch(mode);
+}

--- a/cpu/arm_common/arm_cpu.c
+++ b/cpu/arm_common/arm_cpu.c
@@ -86,9 +86,13 @@ void thread_print_stack(void)
     printf("STACK (%u)= %X \n", i, *s);
 }
 
-NORETURN void reboot(void)
+int reboot_arch(int mode)
 {
+    (void) mode;
+
     while (1) {
         arm_reset();
     }
+
+    return -1;
 }

--- a/cpu/arm_common/crash.c
+++ b/cpu/arm_common/crash.c
@@ -58,6 +58,6 @@ NORETURN void core_panic(int crash_code, const char *message)
     }
 #else
     /* DEVELHELP not set => reboot system */
-    reboot();
+    (void) reboot(RB_AUTOBOOT);
 #endif
 }

--- a/cpu/lpc1768/cpu.c
+++ b/cpu/lpc1768/cpu.c
@@ -126,9 +126,13 @@ __attribute__((naked,noreturn)) void arm_reset(void)
      );
 }
 
-NORETURN void reboot(void)
+int reboot_arch(int mode)
 {
+    (void) mode;
+
     while (1) {
         arm_reset();
     }
+
+    return -1;
 }

--- a/cpu/lpc1768/crash.c
+++ b/cpu/lpc1768/crash.c
@@ -59,6 +59,6 @@ NORETURN void core_panic(int crash_code, const char *message)
     }
 #else
     /* DEVELHELP not set => reboot system */
-    reboot();
+    (void) reboot(RB_AUTOBOOT);
 #endif
 }

--- a/cpu/msp430-common/cpu.c
+++ b/cpu/msp430-common/cpu.c
@@ -90,11 +90,15 @@ int inISR()
 /******************************************************************************/
 
 /* System reboot */
-NORETURN void reboot(void)
+int reboot_arch(int mode)
 {
+    (void) mode;
+
     /* force an hardware reboot ("Power-Up Clear"), by writing
        an illegal value to the watchdog control register */
     while (1) {
         WDTCTL = 0x0000;
     }
+
+    return -1;
 }

--- a/cpu/msp430-common/crash.c
+++ b/cpu/msp430-common/crash.c
@@ -58,6 +58,6 @@ NORETURN void core_panic(int crash_code, const char *message)
     }
 #else
     /* DEVELHELP not set => reboot system */
-    reboot();
+    (void) reboot(RB_AUTOBOOT);
 #endif
 }

--- a/cpu/native/crash.c
+++ b/cpu/native/crash.c
@@ -55,7 +55,7 @@ NORETURN void core_panic(int crash_code, const char *message)
        just use the (developer-)friendly core-dump feature */
     kill(getpid(), SIGTRAP);
 #else
-    reboot();
+    (void) reboot(RB_AUTOBOOT);
 #endif
 
     /* proove the compiler that we won't return from this function

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -63,13 +63,19 @@ char __end_stack[SIGSTKSZ];
 fd_set _native_rfds;
 #endif
 
-NORETURN void reboot(void)
+int reboot_arch(int mode)
 {
+    (void) mode;
+
     printf("\n\n\t\t!! REBOOT !!\n\n");
+
     if (execve(_native_argv[0], _native_argv, NULL) == -1) {
         err(EXIT_FAILURE, "reboot: execve");
     }
+
     errx(EXIT_FAILURE, "reboot: this should not habe been reached");
+
+    return -1;
 }
 
 /**

--- a/sys/shell/commands/sc_sys.c
+++ b/sys/shell/commands/sc_sys.c
@@ -22,5 +22,5 @@ void _reboot_handler(int argc, char **argv)
     (void) argc;
     (void) argv;
 
-    reboot();
+    (void) reboot(RB_AUTOBOOT);
 }


### PR DESCRIPTION
A reboot function is already defined in <unistd.h> on BSD systems.
(See: http://www.openbsd.org/cgi-bin/man.cgi?query=reboot&sektion=2)
This patch not only allows native to build sensibly on these systems
but also streamlines RIOTs compatability with existing software.

Fixes: https://github.com/RIOT-OS/RIOT/issues/744
