### PR TITLE
posix: Add pthread thread-local storage

### DIFF
--- a/sys/posix/pthread/include/pthread.h
+++ b/sys/posix/pthread/include/pthread.h
@@ -31,6 +31,7 @@
 #include "pthread_scheduling.h"
 #include "pthread_cancellation.h"
 #include "pthread_cond.h"
+#include "pthread_keys.h"
 
 #endif
 

--- a/sys/posix/pthread/include/pthread_keys.h
+++ b/sys/posix/pthread/include/pthread_keys.h
@@ -1,0 +1,97 @@
+/**
+ * Implementation of pthread thread local storage.
+ *
+ * Copyright (C) 2013 Freie Universität Berlin
+ *
+ * This file subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ *
+ * @ingroup posix
+ * @{
+ * @file
+ * @brief   Implementation of pthread thread local storage.
+ * @author  René Kijewski <kijewski@inf.fu-berlin.de>
+ */
+
+#ifndef __SYS__POSIX__PTHREAD_KEYS__H
+#define __SYS__POSIX__PTHREAD_KEYS__H
+
+#include "attributes.h"
+
+typedef struct pthread_key
+{
+    unsigned index;
+
+    void (*destructor)(void*);
+    struct pthread_key *next;
+} pthread_key_t[1];
+
+/**
+ * @brief Number of calls to pthread_key_create.
+ */
+extern int __pthread_key_count;
+
+/**
+ * Array of thread-local key values of the calling thread.
+ */
+void **__pthread_keys(void) PURE;
+
+/**
+ * @brief       Calls the dtors of the thread specific data.
+ * @param[in]   keys_   Keys to clean up.
+ *
+ * Called during pthread_exit().
+ */
+void __pthread_keys_exit(void *keys_);
+
+/**
+ * @brief        Creates a key for the thread specific key-value store.
+ * @param[out]   key   Key to allocate
+ * @returns      0, cannot fail
+ *
+ * This function does not implemented full functionallity described in the POSIX standard!
+ * The keys are not dynamic.
+ * All calls to pthread_key_create() must be done before the first call to pthread_create().
+ *
+ * A good place to call this function is auto_init() and main().
+ */
+int pthread_key_create(pthread_key_t *key, void (*destructor)(void*));
+
+/**
+ * @brief       This function fails.
+ * @param[in]   key   The key you want to get a failure for.
+ * @returns     -1, because this function fails
+ *
+ * Our pthread TLS implementation is not dynamic, see pthread_key_create().
+ * You cannot delete keys. Once you defined a key, you are stuck with it.
+ */
+int pthread_key_delete(const pthread_key_t key);
+
+/**
+ * @brief       Gets the value of a thread-local key
+ * @param[in]   KEY   The pthread_key_t key to return a value for
+ * @return      The value associated with KEY
+ *
+ * This function is implemented as a macro to enable compiler optimizations.
+ * __pthread_keys() is PURE, hence multiple calls to __pthread_keys() can be eliminated.
+ */
+#define pthread_getspecific(KEY) (__pthread_keys()[(KEY)[0].index])
+
+/**
+ * @brief       Sets the value of a thread-local key
+ * @param[in]   KEY     The pthread_key_t key to set its value for
+ * @param[in]   VALUE   Value to associate with KEY
+ * @return      0, cannot fail
+ *
+ * This function is implemented as a macro to enable compiler optimizations.
+ * __pthread_keys() is PURE, hence multiple calls to __pthread_keys() can be eliminated.
+ */
+#define pthread_setspecific(KEY, VALUE) \
+        ((__pthread_keys()[(KEY)[0].index] = (void *) (VALUE)), 0)
+
+#endif
+
+/**
+ * @}
+ */

--- a/tests/test_pthread_tls/Makefile
+++ b/tests/test_pthread_tls/Makefile
@@ -1,0 +1,6 @@
+PROJECT = test_pthread_tls
+include ../Makefile.tests_common
+
+USEMODULE += pthread
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/test_pthread_tls/main.c
+++ b/tests/test_pthread_tls/main.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief pthread TLS test application
+ *
+ * @author Christian Mehlis <mehlis@inf.fu-berlin.de>
+ * @author René Kijewski <rene.kijewski@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "pthread.h"
+
+#define NUM_CHILDREN 4
+
+static pthread_key_t id_key;
+
+static void cleanup(void *p)
+{
+    printf("Cleanup: %u\n", (int) (uintptr_t) p);
+}
+
+static void *run(void *parameter)
+{
+    pthread_setspecific(id_key, parameter);
+
+    printf("pthread: parameter = %u\n", (int) (uintptr_t) pthread_getspecific(id_key));
+
+    return pthread_getspecific(id_key);
+}
+
+int main(void)
+{
+    puts("Start.");
+
+    pthread_key_create(&id_key, cleanup);
+
+    pthread_t th_id[NUM_CHILDREN];
+    for (int i = 0; i < NUM_CHILDREN; ++i) {
+        pthread_create(&th_id[i], NULL, run, (void *) (intptr_t) i);
+    }
+    for (int i = 0; i < NUM_CHILDREN; ++i) {
+        void *res;
+        pthread_join(th_id[i], (void **) &res);
+        printf("Child %u returned with value %u\n", i, (int) (uintptr_t) res);
+    }
+
+    puts("Done.");
+    return 0;
+}


### PR DESCRIPTION
This PR is (re)based on #821.

This PR implements the [POSIX thread-local storage](http://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_key_create.html).
Though it's not anything as nice as C11's `_Thread_local`, it's something. [![Hosted by imgur.com](http://i.imgur.com/4sbAaQ8.gif)](http://knowyourmeme.com/memes/its-something)

This implementation of POSIX TLS is not dynamic as the standard wants it to be. All keys have to be defined before the first pthread is created with `pthread_create()`. I see this as a minor shortcoming. Otherwise we'd need malloc, maps and so on. The additional convenience would not be worth addition work at runtime.
