### PR TITLE
sixlowpan: Fix source address IPHC

### DIFF
--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -883,12 +883,12 @@ uint8_t lowpan_iphc_encoding(int if_id, const uint8_t *dest, int dest_len,
     net_if_eui64_t own_iid;
 
     if (net_if_get_src_address_mode(if_id) == NET_IF_TRANS_ADDR_M_SHORT) {
-        if (!net_if_get_eui64(&own_iid, if_id, 0)) {
+        if (!net_if_get_eui64(&own_iid, if_id, 1)) {
             return 1;
         }
     }
     else {
-        if (!net_if_get_eui64(&own_iid, if_id, 1)) {
+        if (!net_if_get_eui64(&own_iid, if_id, 0)) {
             return 1;
         }
 


### PR DESCRIPTION
In the earlier version the IID received for the IPHC was generated wrongly, leading to an unefficient header compression: from short address, when the EUI-64 was used, from EUI-64, when the short address was used. This PR fixes this mixup.
