### PR TITLE
posix: Disable debug output of pthreads

### DIFF
--- a/sys/posix/pthread/pthread.c
+++ b/sys/posix/pthread/pthread.c
@@ -32,7 +32,7 @@
 
 #include "pthread.h"
 
-#define ENABLE_DEBUG (1)
+#define ENABLE_DEBUG (0)
 
 #if ENABLE_DEBUG
 #   define PTHREAD_REAPER_STACKSIZE KERNEL_CONF_STACKSIZE_MAIN


### PR DESCRIPTION
`ENABLE_DEBUG` should be enabled during debugging, and disabled afterwards.
