### PR TITLE
posix: Fix `pthread_mutex_lock()` check in test_pthread_cooperation

### DIFF
--- a/tests/test_pthread_cooperation/main.c
+++ b/tests/test_pthread_cooperation/main.c
@@ -35,7 +35,7 @@ void *run(void *parameter)
 
     int err = pthread_mutex_lock(&mtx);
 
-    if (err != 1) {
+    if (err != 0) {
         printf("[!!!] pthread_mutex_lock failed with %d\n", err);
         return NULL;
     }


### PR DESCRIPTION
Fixes #844.
Fixup to #838.
