### PR TITLE
make: Fix BOARD and CPU macros

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -27,7 +27,7 @@ endif
 # if you want to publish the board into the sources as an uppercase #define
 BB = $(shell echo $(BOARD)|tr 'a-z' 'A-Z'|tr '-' '_')
 CPUDEF = $(shell echo $(CPU)|tr 'a-z' 'A-Z'|tr '-' '_')
-CFLAGS += -DBOARD=$(BB) -DCPU_$(CPUDEF)
+CFLAGS += -DBOARD_$(BB) -DCPU_$(CPUDEF)
 
 export CFLAGS
 


### PR DESCRIPTION
Minuses in macro names are problematic, since the CPP interpretes them as substraction operators.
