### PR TITLE
shell: remove clutter from shell's Makefile

### DIFF
--- a/sys/shell/Makefile
+++ b/sys/shell/Makefile
@@ -1,21 +1,3 @@
-SRC = shell.c
-OBJ = $(SRC:%.c=$(BINDIR)%.o)
-DEP = $(SRC:%.c=$(BINDIR)%.d)
+MODULE = shell
 
-MODULE =shell
-
-$(BINDIR)$(MODULE).a: $(OBJ)
-	$(AD)$(AR) rc $(BINDIR)$(MODULE).a $(OBJ)
-
-# pull in dependency info for *existing* .o files
--include $(OBJ:.o=.d)
-
-# compile and generate dependency info
-$(BINDIR)%.o: %.c
-	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -c $*.c -o $(BINDIR)$*.o
-	@$(CC) $(CFLAGS) $(INCLUDES) -MM $*.c > $(BINDIR)$*.d
-	@printf "$(BINDIR)"|cat - $(BINDIR)$*.d > /tmp/riot_out && mv /tmp/riot_out $(BINDIR)$*.d
-
-# remove compilation products
-clean::
-	@rm -f $(BINDIR)$(MODULE).a $(OBJ) $(DEP) $(ASMOBJ)
+include $(RIOTBASE)/Makefile.base

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -1,3 +1,5 @@
+MODULE = shell_commands
+
 SRC = shell_commands.c sc_sys.c
 
 ifneq (,$(filter config,$(USEMODULE)))
@@ -36,10 +38,5 @@ endif
 ifneq (,$(filter random,$(USEMODULE)))
 	SRC += sc_mersenne.c
 endif
-
-OBJ = $(SRC:%.c=$(BINDIR)%.o)
-DEP = $(SRC:%.c=$(BINDIR)%.d)
-
-MODULE =shell_commands
 
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
Remove clutter that was put into centralized Makefile.includes.
