### PR TITLE
core:mutex: allow idle thread to use mutexes

### DIFF
--- a/core/mutex.c
+++ b/core/mutex.c
@@ -45,7 +45,7 @@ int mutex_init(struct mutex_t *mutex)
 int mutex_trylock(struct mutex_t *mutex)
 {
     DEBUG("%s: trylocking to get mutex. val: %u\n", active_thread->name, mutex->val);
-    return (atomic_set_return(&mutex->val, thread_pid) == 0);
+    return (atomic_set_return(&mutex->val, 1) == 0);
 }
 
 int prio(void)
@@ -72,7 +72,7 @@ void mutex_wait(struct mutex_t *mutex)
 
     if (mutex->val == 0) {
         /* somebody released the mutex. return. */
-        mutex->val = thread_pid;
+        mutex->val = 1;
         DEBUG("%s: mutex_wait early out. %u\n", active_thread->name, mutex->val);
         restoreIRQ(irqstate);
         return;


### PR DESCRIPTION
`mutex_t::val` is an integral value where 0 means unlocked, and any other value means locked.
`mutex_trylock` writes the current thread id into this member to denote that it is locked.
The problem is that the `idle` thread has the PID 0, and is therefore not able to sanely use this function.
The reason why the idle thread might need to use mutexes is because it changes the low-power state of the board, and I see reasons why it might be useful to use a mutex in this circumstance.
