### PR TITLE
uart: use cpu dependent stack size

### DIFF
--- a/sys/uart0/uart0.c
+++ b/sys/uart0/uart0.c
@@ -36,7 +36,7 @@
 #endif
 
 /* increase when ENABLE_DEBUG in chardev_thread is set to 1! */
-#define UART0_STACKSIZE 	(MINIMUM_STACK_SIZE + 256)
+#define UART0_STACKSIZE 	(KERNEL_CONF_STACKSIZE_DEFAULT)
 
 ringbuffer_t uart0_ringbuffer;
 int uart0_handler_pid;


### PR DESCRIPTION
The old stack size was too small for some platforms.
