### PR TITLE
net: sixlowpan: removing possible invalid check

### DIFF
--- a/sys/net/network_layer/sixlowpan/icmp.c
+++ b/sys/net/network_layer/sixlowpan/icmp.c
@@ -1522,10 +1522,6 @@ int ndp_addr_is_on_link(ipv6_addr_t *dest_addr)
     ndp_neighbor_cache_t *nce;
     int if_id = -1;
 
-    if (ipv6_addr_is_link_local(dest_addr)) {
-        return 1;
-    }
-
     if ((nce = ndp_neighbor_cache_search(dest_addr))) {
         return 1;
     }


### PR DESCRIPTION
Checking for a link local address to determine if a node is on-link is probably not a valid assumption in most wireless networks. However, the real purpose of this function needs to be thoroughly documented. Currently it is only used to determine if a packet needs routing where this condition is useless - at least if there's no mesh under routing.
