### PR TITLE
net: 6lowpan: added missing hdr position shift

### DIFF
--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -1435,6 +1435,7 @@ void lowpan_iphc_decoding(uint8_t *data, uint8_t length, net_if_eui64_t *s_addr,
 
                 default: {
                     memcpy(&(ipv6_buf->destaddr.uint8[0]), &ipv6_hdr_fields[hdr_pos], 16);
+                    hdr_pos += 16;
                     break;
                 }
             }


### PR DESCRIPTION
In IPHC decompression a header is copied into the IP header without shifting the position marker accordingly.
