### PR TITLE
net: sixlowpan: notify lowpan_transfer when IP packet is not routable

### DIFF
--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -421,6 +421,9 @@ void ipv6_process(void)
             }
 
             if ((dest == NULL) || ((--ipv6_buf->hoplimit) == 0)) {
+                DEBUG("!!! Packet not for me, routing handler is set, but I "\
+                      " have no idea where to send or the hop limit is exceeded.\n");
+                msg_reply(&m_recv_lowpan, &m_send_lowpan);
                 continue;
             }
 


### PR DESCRIPTION
The IP process silently discarded an unroutable packet without replying to the 6LoWPAN layer, causing that thread to starve.
