### PR TITLE
make: don't ignore failures in for loops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ DIRS = $(RIOTCPU)/$(CPU) core drivers sys
 
 all:
 	mkdir -p $(BINDIR)
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 clean:
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;
 	-@if [ -d $(BINDIR) ] ; \
 	then rm -rf $(BINDIR) ; \
 	fi

--- a/Makefile.include
+++ b/Makefile.include
@@ -128,7 +128,7 @@ $(USEPKG:%=${BINDIR}%.a)::
 	"$(MAKE)" -C $(RIOTBASE)/pkg/$(patsubst ${BINDIR}%.a,%,$@)
 
 clean:
-	@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTBASE)/pkg/$$i clean ; done ;
+	@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTBASE)/pkg/$$i clean || exit 1; done ;
 	"$(MAKE)" -C $(RIOTBOARD)/$(BOARD) clean
 	"$(MAKE)" -C $(RIOTBASE) clean
 	rm -rf $(BINDIR)

--- a/boards/avsextrem/Makefile
+++ b/boards/avsextrem/Makefile
@@ -3,9 +3,9 @@ MODULE =$(BOARD)_base
 DIRS = drivers $(RIOTBOARD)/msba2-common
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/chronos/Makefile
+++ b/boards/chronos/Makefile
@@ -4,9 +4,9 @@ INCLUDES += -I$(RIOTBOARD)/$(BOARD)/drivers/include
 DIRS = drivers
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/msb-430-common/Makefile
+++ b/boards/msb-430-common/Makefile
@@ -3,9 +3,9 @@ MODULE =$(BOARD)_base
 DIRS = drivers
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/msb-430/Makefile
+++ b/boards/msb-430/Makefile
@@ -3,9 +3,9 @@ MODULE =$(BOARD)_base
 DIRS = $(RIOTBOARD)/msb-430-common
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/msb-430h/Makefile
+++ b/boards/msb-430h/Makefile
@@ -3,9 +3,9 @@ MODULE =$(BOARD)_base
 DIRS = $(RIOTBOARD)/msb-430-common
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/msba2-common/Makefile
+++ b/boards/msba2-common/Makefile
@@ -3,9 +3,9 @@ MODULE =$(BOARD)_base
 DIRS = drivers
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/msba2/Makefile
+++ b/boards/msba2/Makefile
@@ -4,9 +4,9 @@ INCLUDES += -I$(RIOTBASE)/drivers/cc110x
 DIRS = $(RIOTBOARD)/msba2-common
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/native/Makefile
+++ b/boards/native/Makefile
@@ -3,7 +3,7 @@ MODULE =$(BOARD)_base
 DIRS = drivers
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
@@ -14,4 +14,4 @@ $(BINDIR)%.o: %.c
 
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/native/drivers/Makefile
+++ b/boards/native/drivers/Makefile
@@ -1,7 +1,7 @@
 MODULE =$(BOARD)_base
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 

--- a/boards/pttu/Makefile
+++ b/boards/pttu/Makefile
@@ -4,9 +4,9 @@ INCLUDES += -I$(RIOTBASE)/drivers/cc110x
 DIRS = $(RIOTBOARD)/msba2-common
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/redbee-econotag/Makefile
+++ b/boards/redbee-econotag/Makefile
@@ -3,9 +3,9 @@ MODULE =$(BOARD)_base
 DIRS = drivers
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/wsn430-common/Makefile
+++ b/boards/wsn430-common/Makefile
@@ -3,9 +3,9 @@ MODULE =$(BOARD)_base
 DIRS = drivers
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/wsn430-v1_3b/Makefile
+++ b/boards/wsn430-v1_3b/Makefile
@@ -3,9 +3,9 @@ MODULE =$(BOARD)_base
 DIRS = $(RIOTBOARD)/wsn430-common
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/wsn430-v1_4/Makefile
+++ b/boards/wsn430-v1_4/Makefile
@@ -3,9 +3,9 @@ MODULE = $(BOARD)_base
 DIRS = $(RIOTBOARD)/wsn430-common
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/cpu/cc430/Makefile
+++ b/cpu/cc430/Makefile
@@ -3,9 +3,9 @@ MODULE = cpu
 DIRS = $(RIOTCPU)/msp430-common
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/cpu/lpc1768/Makefile
+++ b/cpu/lpc1768/Makefile
@@ -12,7 +12,7 @@ all: $(BINDIR)$(MODULE).a
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;
 
 # This is needed for NXP Cortex M devices
 nxpsum:

--- a/cpu/lpc2387/Makefile
+++ b/cpu/lpc2387/Makefile
@@ -17,9 +17,9 @@ ifneq (,$(filter i2c,$(USEMODULE)))
 endif
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/cpu/mc1322x/Makefile
+++ b/cpu/mc1322x/Makefile
@@ -9,9 +9,9 @@ ifneq (,$(filter mc1322x_asm,$(USEMODULE)))
 endif
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/cpu/msp430-common/Makefile
+++ b/cpu/msp430-common/Makefile
@@ -3,9 +3,9 @@ MODULE =msp430_common
 DIRS =
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/cpu/msp430x16x/Makefile
+++ b/cpu/msp430x16x/Makefile
@@ -5,9 +5,9 @@ include $(RIOTCPU)/$(CPU)/Makefile.include
 DIRS = $(RIOTCPU)/msp430-common/
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/cpu/native/Makefile
+++ b/cpu/native/Makefile
@@ -9,7 +9,7 @@ ifneq (,$(filter nativenet,$(USEMODULE)))
 endif
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
@@ -20,4 +20,4 @@ $(BINDIR)%.o: %.c
 
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -36,10 +36,10 @@ ifneq (,$(filter lm75a,$(USEMODULE)))
 endif
 
 all:
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 # remove compilation products
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/drivers/at86rf231/Makefile
+++ b/drivers/at86rf231/Makefile
@@ -3,9 +3,9 @@ MODULE =at86rf231
 DIRS =
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/drivers/cc110x_ng/Makefile
+++ b/drivers/cc110x_ng/Makefile
@@ -12,9 +12,9 @@ ifneq (,$(filter wsn430-v1_3b,$(BOARD)))
 endif
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/drivers/cc2420/Makefile
+++ b/drivers/cc2420/Makefile
@@ -3,9 +3,9 @@ MODULE =cc2420
 DIRS =
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/pkg/openwsn/Makefile.in
+++ b/pkg/openwsn/Makefile.in
@@ -2,8 +2,8 @@ DIRS =
 DIRS += openwsn
 
 all::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 # remove compilation products
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/pkg/openwsn/patch.txt
+++ b/pkg/openwsn/patch.txt
@@ -18663,7 +18663,7 @@ diff -crB openwsn/07-App/Makefile ../../../sys/net/openwsn/07-App/Makefile
 + DIRS += udpstorm
 + 
 + all: $(BINDIR)$(SUBMOD)
-+ 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
++ 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 + 
 + $(BINDIR)$(SUBMOD): $(OBJ)
 + 	$(AD)$(AR) rcs $(BINDIR)$(MODULE) $(OBJ)
@@ -18679,7 +18679,7 @@ diff -crB openwsn/07-App/Makefile ../../../sys/net/openwsn/07-App/Makefile
 + 	@printf "$(BINDIR)"|cat - $(BINDIR)$*.d > /tmp/riot_out && mv /tmp/riot_out $(BINDIR)$*.d
 + 
 + clean::
-+ 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
++ 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;
 diff -crB openwsn/07-App/heli/heli.c ../../../sys/net/openwsn/07-App/heli/heli.c
 *** openwsn/07-App/heli/heli.c	Thu Mar 21 21:36:59 2013
 --- ../../../sys/net/openwsn/07-App/heli/heli.c	Wed Jan 15 13:48:27 2014
@@ -27111,7 +27111,7 @@ diff -crB openwsn/Makefile ../../../sys/net/openwsn/Makefile
 + DIRS += 07-App
 + 
 + all: $(BINDIR)$(MODULE)
-+ 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
++ 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 + 
 + $(BINDIR)$(MODULE): $(OBJ)
 + 	$(AD)$(AR) rcs $(BINDIR)$(MODULE) $(OBJ)
@@ -27129,7 +27129,7 @@ diff -crB openwsn/Makefile ../../../sys/net/openwsn/Makefile
 + 
 + # remove compilation products
 + clean::
-+ 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
++ 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;
 diff -crB openwsn/board_info.h ../../../sys/net/openwsn/board_info.h
 *** openwsn/board_info.h	Thu Mar 21 21:36:59 2013
 --- ../../../sys/net/openwsn/board_info.h	Wed Jan 15 13:48:27 2014

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -107,10 +107,10 @@ ifneq (,$(findstring quad_math,$(USEMODULE)))
 endif
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 # remove compilation products
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;


### PR DESCRIPTION
Add `|| exit 1` to all constructs like `@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;`, so that compilation stops on the first error.
