### PR TITLE
make/buildtest: print errors (alternative to #836)

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -174,7 +174,6 @@ buildtest:
 			RIOTBASE=$${RIOTBASE} \
 			RIOTBOARD=$${RIOTBOARD} \
 			RIOTCPU=$${RIOTCPU} \
-			CFLAGS="-w" \
 			$(MAKE) -B clean all 2>&1 >/dev/null) ; \
 		if [ "$${?}" = "0" ]; then \
 			$${ECHO} "$${GREEN}success$${RESET}"; \


### PR DESCRIPTION
Display all stderr output but suppress warnings.

implements https://github.com/RIOT-OS/RIOT/issues/835

This is an alternative to https://github.com/RIOT-OS/RIOT/pull/836
