### PR TITLE
Restructuring RPL as setup for implementation of non-storing mode

### DIFF
--- a/examples/rpl_udp/Makefile
+++ b/examples/rpl_udp/Makefile
@@ -47,6 +47,7 @@ else ifeq ($(strip $(BOARD)),iot-lab_M3)
 endif
 USEMODULE += sixlowpan
 USEMODULE += rpl
+USEMODULE += routing
 USEMODULE += destiny
 
 export INCLUDES += -I$(RIOTBASE)/sys/net/include -I$(RIOTBASE)/sys/net/routing/rpl -I$(RIOTBASE)/drivers/cc110x

--- a/examples/rpl_udp/rpl.c
+++ b/examples/rpl_udp/rpl.c
@@ -81,7 +81,7 @@ void rpl_udp_init(int argc, char **argv)
             is_root = 1;
         }
         else {
-            ipv6_iface_set_routing_provider(rpl_get_next_hop);
+            ipv6_iface_set_routing_provider(get_next_hop);
         }
 
         int monitor_pid = thread_create(monitor_stack_buffer, MONITOR_STACK_SIZE, PRIORITY_MAIN - 2, CREATE_STACKTEST, rpl_udp_monitor, "monitor");
@@ -124,9 +124,9 @@ void rpl_udp_loop(int argc, char **argv)
     (void) argc;
     (void) argv;
 
-    rpl_routing_entry_t *rtable;
+    routing_entry_t *rtable;
 
-    rtable = rpl_get_routing_table();
+    rtable = get_forwarding_table();
     rpl_dodag_t *mydodag = rpl_get_my_dodag();
 
     if (mydodag == NULL) {
@@ -149,13 +149,13 @@ void rpl_udp_loop(int argc, char **argv)
     for (int i = 0; i < RPL_MAX_ROUTING_ENTRIES; i++) {
         if (rtable[i].used) {
             printf("%s\n", ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN,
-                                            (&rtable[i].address)));
+                                            (&rtable[i].destination)));
             puts("next hop");
             printf("%s\n", ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN,
                                             (&rtable[i].next_hop)));
             printf("entry %d lifetime %d\n", i, rtable[i].lifetime);
 
-            if (!rpl_equal_id(&rtable[i].address, &rtable[i].next_hop)) {
+            if (!rpl_equal_id(&rtable[i].destination, &rtable[i].next_hop)) {
                 puts("multi-hop");
             }
 
@@ -171,8 +171,8 @@ void rpl_udp_table(int argc, char **argv)
     (void) argc;
     (void) argv;
 
-    rpl_routing_entry_t *rtable;
-    rtable = rpl_get_routing_table();
+    routing_entry_t *rtable;
+    rtable = get_forwarding_table();
     printf("---------------------------\n");
     printf("OUTPUT\n");
     printf("---------------------------\n");
@@ -180,10 +180,10 @@ void rpl_udp_table(int argc, char **argv)
     for (int i = 0; i < RPL_MAX_ROUTING_ENTRIES; i++) {
         if (rtable[i].used) {
             printf("%s\n", ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN,
-                                            (&rtable[i].address)));
+                                            (&rtable[i].destination)));
             printf("entry %d lifetime %d\n", i, rtable[i].lifetime);
 
-            if (!rpl_equal_id(&rtable[i].address, &rtable[i].next_hop)) {
+            if (!rpl_equal_id(&rtable[i].destination, &rtable[i].next_hop)) {
                 puts("multi-hop");
             }
 

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -63,6 +63,9 @@ endif
 ifneq (,$(filter rpl,$(USEMODULE)))
     DIRS += net/routing/rpl
 endif
+ifneq (,$(filter routing,$(USEMODULE)))
+	DIRS += net/routing
+endif
 ifneq (,$(filter ieee802154,$(USEMODULE)))
     DIRS += net/link_layer/ieee802154
 endif
@@ -107,10 +110,10 @@ ifneq (,$(findstring quad_math,$(USEMODULE)))
 endif
 
 all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i ; done ;
 
 include $(RIOTBASE)/Makefile.base
 
 # remove compilation products
 clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean ; done ;

--- a/sys/net/include/etx_beaconing.h
+++ b/sys/net/include/etx_beaconing.h
@@ -1,3 +1,11 @@
+/*
+ * Header for the ETX-beaconing module
+ * etx_beaconing.h
+ *
+ *  Created on: Feb 26, 2013
+ *      Author: stephan
+ */
+
 #ifndef ETX_BEACONING_H_
 #define ETX_BEACONING_H_
 #include <stdint.h>
@@ -8,13 +16,13 @@
 #include "debug.h"
 
 #if ENABLE_DEBUG
-#define ETX_BEACON_STACKSIZE    (KERNEL_CONF_STACKSIZE_DEFAULT + KERNEL_CONF_STACKSIZE_PRINTF_FLOAT)
-#define ETX_RADIO_STACKSIZE     (KERNEL_CONF_STACKSIZE_DEFAULT + KERNEL_CONF_STACKSIZE_PRINTF_FLOAT)
-#define ETX_CLOCK_STACKSIZE     (KERNEL_CONF_STACKSIZE_DEFAULT)
+#define ETX_BEACON_STACKSIZE    (4500)
+#define ETX_RADIO_STACKSIZE     (4500)
+#define ETX_CLOCK_STACKSIZE      (500)
 #else
-#define ETX_BEACON_STACKSIZE    (KERNEL_CONF_STACKSIZE_MAIN)
-#define ETX_RADIO_STACKSIZE     (KERNEL_CONF_STACKSIZE_MAIN)
-#define ETX_CLOCK_STACKSIZE     (KERNEL_CONF_STACKSIZE_DEFAULT)
+#define ETX_BEACON_STACKSIZE    (2500) //TODO optimize, maybe 2000 is enough
+#define ETX_RADIO_STACKSIZE     (2500) //TODO optimize, maybe 2000 is enough
+#define ETX_CLOCK_STACKSIZE     (500) //TODO optimize, maybe  250 is enough
 #endif
 
 //[option|length|ipaddr.|packetcount] with up to 15 ipaddr|packetcount pairs

--- a/sys/net/include/forwarding_tables.h
+++ b/sys/net/include/forwarding_tables.h
@@ -1,0 +1,45 @@
+/**
+ * RPL dodag implementation
+ *
+ * Copyright (C) 2014  INRIA.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ *
+ * @ingroup rpl
+ * @{
+ * @file    forwarding_tables.h
+ * @brief   Header for forwarding tables
+ * @author  Fabian Brandt <fabianbr@zedat.fu-berlin.de>
+ * @}
+ */
+
+#include <string.h>
+#include "ipv6.h"
+
+#ifndef FORWARDING_TABLES_H_INCLUDED
+#define FORWARDING_TABLES_H_INCLUDED
+/* structs */ 
+
+typedef struct {
+    uint8_t used;
+    ipv6_addr_t destination;
+    ipv6_addr_t next_hop;
+    uint16_t lifetime;
+
+} routing_entry_t;
+
+/* functions and variables */
+
+/* Maximum routing entries is depending on routing algorithm */
+void forwarding_table_init(uint8_t max_entries);
+void add_forwarding_entry(ipv6_addr_t *next_hop, ipv6_addr_t *destination, uint16_t lifetime);
+void del_forwarding_entry(ipv6_addr_t *destination);
+ipv6_addr_t *get_next_hop(ipv6_addr_t *destination);
+routing_entry_t *find_forwarding_entry(ipv6_addr_t *destination);
+routing_entry_t *get_forwarding_table(void);
+void clear_forwarding_table();
+
+#endif
+

--- a/sys/net/routing/Makefile
+++ b/sys/net/routing/Makefile
@@ -1,0 +1,3 @@
+MODULE:=$(shell basename $(CURDIR))
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/routing/etx_beaconing.c
+++ b/sys/net/routing/etx_beaconing.c
@@ -160,7 +160,7 @@ void etx_init_beaconing(ipv6_addr_t *address)
 
 void etx_beacon(void)
 {
-    /*
+    /*sixlowpan_mac_send_ieee802154_frame
      * Sends a message every ETX_INTERVAL +/- a jitter-value (default is 10%) .
      * A correcting variable is needed to stay at a base interval of
      * ETX_INTERVAL between the wakeups. It takes the old jittervalue in account

--- a/sys/net/routing/forwarding_tables.c
+++ b/sys/net/routing/forwarding_tables.c
@@ -1,0 +1,109 @@
+/**
+ * RPL dodag implementation
+ *
+ * Copyright (C) 2014  INRIA.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ *
+ * @ingroup rpl
+ * @{
+ * @file    forwarding_tables.c
+ * @brief   Manages forwarding tables
+ * @author  Fabian Brandt <fabianbr@zedat.fu-berlin.de>
+ * @}
+ */
+
+#include "forwarding_tables.h"
+
+routing_entry_t *forwarding_table;
+uint8_t forwarding_max_entries;
+
+/* helper functions */
+
+void clear_forwarding_table() {
+    for (uint8_t i = 0; i < forwarding_max_entries; i++) {
+        memset(&forwarding_table[i], 0, sizeof(forwarding_table[i]));
+    }
+}
+
+bool equal_id(ipv6_addr_t *id1, ipv6_addr_t *id2)
+{
+    for (uint8_t i = 0; i < 4; i++) {
+        if (id1->uint32[i] != id2->uint32[i]) {
+            return false;
+        }
+    }
+
+    return true;
+
+}
+
+/* core functions */
+
+void forwarding_table_init(uint8_t max_entries) {
+
+    forwarding_max_entries = max_entries;
+	forwarding_table = malloc(sizeof(routing_entry_t)*forwarding_max_entries);
+    clear_forwarding_table();
+
+}
+
+void add_forwarding_entry(ipv6_addr_t *next_hop, ipv6_addr_t *destination, uint16_t lifetime) {
+
+    routing_entry_t *entry = find_forwarding_entry(destination);
+
+    if (entry != NULL) {
+        entry->lifetime = lifetime;
+        return;
+    }
+
+    for (uint8_t i = 0; i < forwarding_max_entries; i++) {
+        if (!forwarding_table[i].used) {
+            forwarding_table[i].destination = *destination;
+            forwarding_table[i].next_hop = *next_hop;
+            forwarding_table[i].lifetime = lifetime;
+            forwarding_table[i].used = 1;
+            break;
+        }
+    }
+}
+
+routing_entry_t *find_forwarding_entry(ipv6_addr_t *destination)
+{
+    for (uint8_t i = 0; i < forwarding_max_entries; i++) {
+        if (forwarding_table[i].used && equal_id(&forwarding_table[i].destination, destination)) {
+            return &forwarding_table[i];
+        }
+    }
+
+    return NULL;
+}
+
+routing_entry_t *get_forwarding_table(void)
+{
+    return forwarding_table;
+}
+
+void del_routing_entry(ipv6_addr_t *destination)
+{
+    for (uint8_t i = 0; i < forwarding_max_entries; i++) {
+        if (forwarding_table[i].used && equal_id(&forwarding_table[i].destination, destination)) {
+            memset(&forwarding_table[i], 0, sizeof(forwarding_table[i]));
+            return;
+        }
+    }
+}
+
+ipv6_addr_t *get_next_hop(ipv6_addr_t *dest)
+{
+    for (uint8_t i = 0; i < forwarding_max_entries; i++) {
+        if (forwarding_table[i].used && equal_id(&forwarding_table[i].destination, dest)) {
+            return &forwarding_table[i].next_hop;
+        }
+    }
+
+    return NULL;
+}
+

--- a/sys/net/routing/rpl/of0.h
+++ b/sys/net/routing/rpl/of0.h
@@ -1,3 +1,4 @@
 #include "rpl_structs.h"
+#include "rpl_config.h"
 
 rpl_of_t *rpl_get_of0(void);

--- a/sys/net/routing/rpl/of_mrhof.h
+++ b/sys/net/routing/rpl/of_mrhof.h
@@ -1,4 +1,5 @@
 #include "rpl_structs.h"
+#include "rpl_config.h"
 
 /*
  * Disallow links with greater than 4 expected

--- a/sys/net/routing/rpl/rpl.h
+++ b/sys/net/routing/rpl/rpl.h
@@ -27,7 +27,10 @@
 #include <mutex.h>
 #include <transceiver.h>
 #include "ipv6.h"
+#include "forwarding_tables.h"
 #include "rpl_dodag.h"
+#include "rpl_of_manager.h"
+
 
 #undef CC1100_RADIO_MODE
 #define CC1100_RADIO_MODE CC1100_MODE_WOR
@@ -36,7 +39,6 @@
 #define RPL_PROCESS_STACKSIZE KERNEL_CONF_STACKSIZE_DEFAULT
 
 uint8_t rpl_init(int if_id);
-void rpl_init_root(void);
 rpl_of_t *rpl_get_of_for_ocp(uint16_t ocp);
 
 void send_DIO(ipv6_addr_t *destination);
@@ -48,13 +50,8 @@ void recv_rpl_dio(void);
 void recv_rpl_dis(void);
 void recv_rpl_dao(void);
 void recv_rpl_dao_ack(void);
+void rpl_init_root(void);
 void rpl_send(ipv6_addr_t *destination, uint8_t *payload, uint16_t p_len, uint8_t next_header);
-ipv6_addr_t *rpl_get_next_hop(ipv6_addr_t *addr);
-void rpl_add_routing_entry(ipv6_addr_t *addr, ipv6_addr_t *next_hop, uint16_t lifetime);
-void rpl_del_routing_entry(ipv6_addr_t *addr);
-rpl_routing_entry_t *rpl_find_routing_entry(ipv6_addr_t *addr);
-void rpl_clear_routing_table(void);
-rpl_routing_entry_t *rpl_get_routing_table(void);
 
 /** @} */
 #endif /* __RPL_H */

--- a/sys/net/routing/rpl/rpl_config.h
+++ b/sys/net/routing/rpl/rpl_config.h
@@ -1,0 +1,120 @@
+/**
+ * RPL data structs
+ *
+ * Copyright (C) 2013  INRIA.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ *
+ * @ingroup rpl
+ * @{
+ * @file    rpl_config.h
+ * @brief   RPL Config
+ * @author  Eric Engel <eric.engel@fu-berlin.de>
+ * @}
+ */
+
+#ifndef RPL_CONFIG_H_INCLUDED
+#define RPL_CONFIG_H_INCLUDED
+
+/*  Default values */ 
+#define NO_DOWNWARD_ROUTES  0x00
+#define NON_STORING_MODE    0x01
+#define STORING_MODE_NO_MC  0x02
+#define STORING_MODE_MC     0x03
+
+/* ICMP type */
+#define RPL_SEQUENCE_WINDOW         16
+#define ICMP_CODE_DIS               0x00
+#define ICMP_CODE_DIO               0x01
+#define ICMP_CODE_DAO               0x02
+#define ICMP_CODE_DAO_ACK           0x03
+/* packet base lengths */
+#define DIO_BASE_LEN                24
+#define DIS_BASE_LEN                2
+#define DAO_BASE_LEN                4
+#define DAO_D_LEN                   24
+#define DAO_ACK_LEN                 4
+#define DAO_ACK_D_LEN               24
+#define RPL_OPT_LEN                 2
+#define RPL_OPT_DODAG_CONF_LEN      14
+#define RPL_OPT_PREFIX_INFO_LEN		30
+#define RPL_OPT_SOLICITED_INFO_LEN	19
+#define RPL_OPT_TARGET_LEN			18
+#define RPL_OPT_TRANSIT_LEN			4
+
+/* message options */
+#define RPL_OPT_PAD1                 0
+#define RPL_OPT_PADN                 1
+#define RPL_OPT_DAG_METRIC_CONTAINER 2
+#define RPL_OPT_ROUTE_INFO           3
+#define RPL_OPT_DODAG_CONF           4
+#define RPL_OPT_TARGET               5
+#define RPL_OPT_TRANSIT              6
+#define RPL_OPT_SOLICITED_INFO       7
+#define RPL_OPT_PREFIX_INFO          8
+#define RPL_OPT_TARGET_DESC          9
+
+/* Counters */
+#define RPL_COUNTER_MAX                 255
+#define RPL_COUNTER_LOWER_REGION        127
+#define RPL_COUNTER_SEQ_WINDOW          16
+#define RPL_COUNTER_INIT                RPL_COUNTER_MAX - RPL_COUNTER_SEQ_WINDOW + 1
+#define RPL_COUNTER_INCREMENT(counter)  (counter > RPL_COUNTER_LOWER_REGION ? (counter == RPL_COUNTER_MAX ? counter=0 : ++counter) : (counter == RPL_COUNTER_LOWER_REGION ? counter=0 : ++counter))
+#define RPL_COUNTER_IS_INIT(counter)    (counter > RPL_COUNTER_LOWER_REGION)
+#define RPL_COUNTER_GREATER_THAN_LOCAL(A,B) (((A<B) && (RPL_COUNTER_LOWER_REGION + 1 - B + A < RPL_COUNTER_SEQ_WINDOW)) || ((A > B) && (A-B < RPL_COUNTER_SEQ_WINDOW)))
+#define RPL_COUNTER_GREATER_THAN(A,B)   ((A>RPL_COUNTER_LOWER_REGION) ? ((B > RPL_COUNTER_LOWER_REGION ) ? RPL_COUNTER_GREATER_THAN_LOCAL(A,B) : 0): (( B>RPL_COUNTER_LOWER_REGION ) ? 1: RPL_COUNTER_GREATER_THAN_LOCAL(A,B)))
+
+/* Node Status */
+#define NORMAL_NODE  0
+#define ROOT_NODE    1
+#define LEAF_NODE    2
+
+/* Link Metric Type */
+#define METRIC_ETX 1
+
+/*  RPL Constants and Variables */
+
+#define RPL_DEFAULT_MOP STORING_MODE_NO_MC
+#define BASE_RANK 0
+#define INFINITE_RANK 0xFFFF
+#define RPL_DEFAULT_INSTANCE 0
+#define DEFAULT_PATH_CONTROL_SIZE 0
+#define DEFAULT_DIO_INTERVAL_MIN 11
+/* standard value: */
+/* #define DEFAULT_DIO_INTERVAL_MIN 3 */
+#define DEFAULT_DIO_INTERVAL_DOUBLINGS 7
+/* standard value: */
+/* #define DEFAULT_DIO_INTERVAL_DOUBLINGS 20 */
+#define DEFAULT_DIO_REDUNDANCY_CONSTANT 10
+#define DEFAULT_MIN_HOP_RANK_INCREASE 256
+#define ROOT_RANK DEFAULT_MIN_HOP_RANK_INCREASE
+/* DAO_DELAY is in seconds */
+#define DEFAULT_DAO_DELAY 3
+#define REGULAR_DAO_INTERVAL 300
+#define DAO_SEND_RETRIES 4
+#define DEFAULT_WAIT_FOR_DAO_ACK 15
+#define RPL_DODAG_ID_LEN 16
+
+/* others */
+
+#define NUMBER_IMPLEMENTED_OFS 2
+#define RPL_MAX_DODAGS 3
+#define RPL_MAX_INSTANCES 1
+#define RPL_MAX_PARENTS 5
+#define RPL_MAX_ROUTING_ENTRIES 128
+#define RPL_ROOT_RANK 256
+#define RPL_DEFAULT_LIFETIME 0xff
+#define RPL_LIFETIME_UNIT 2
+#define RPL_GROUNDED 1
+#define RPL_PRF_MASK 0x7
+#define RPL_MOP_SHIFT 3
+#define RPL_SHIFTED_MOP_MASK 0x7
+#define RPL_DIS_V_MASK 0x80
+#define RPL_DIS_I_MASK 0x40
+#define RPL_DIS_D_MASK 0x20
+#define RPL_GROUNDED_SHIFT 7
+#define RPL_DEFAULT_OCP 0
+
+ #endif

--- a/sys/net/routing/rpl/rpl_dodag.h
+++ b/sys/net/routing/rpl/rpl_dodag.h
@@ -18,6 +18,7 @@
 #include <string.h>
 #include "ipv6.h"
 #include "rpl_structs.h"
+#include "rpl_config.h"
 
 void rpl_instances_init(void);
 rpl_instance_t *rpl_new_instance(uint8_t instanceid);

--- a/sys/net/routing/rpl/rpl_nsm.c
+++ b/sys/net/routing/rpl/rpl_nsm.c
@@ -1,0 +1,26 @@
+/**
+ * RPL dodag implementation
+ *
+ * Copyright (C) 2013  INRIA.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ *
+ * @ingroup rpl
+ * @{
+ * @file    rpl_nsm.c
+ * @brief   RPL Non-Storing mode functions
+ * @author  Fabian Brandt <fabianbr@zedat.fu-berlin.de>
+ * @}
+ */
+
+#include "rpl_nsm.h"
+#include "rpl_routing_tables.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+void rpl_init_root_nsm(void) {
+
+}

--- a/sys/net/routing/rpl/rpl_nsm.h
+++ b/sys/net/routing/rpl/rpl_nsm.h
@@ -1,0 +1,21 @@
+/**
+ * RPL dodag implementation
+ *
+ * Copyright (C) 2013  INRIA.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ *
+ * @ingroup rpl
+ * @{
+ * @file    rpl_nsm.h
+ * @brief   RPL Non-Storing mode header
+ * @author  Fabian Brandt <fabianbr@zedat.fu-berlin.de>
+ * @}
+ */
+
+#include "rpl_structs.h"
+#include "rpl_config.h"
+
+void rpl_init_root_nsm(void);

--- a/sys/net/routing/rpl/rpl_of_manager.c
+++ b/sys/net/routing/rpl/rpl_of_manager.c
@@ -1,0 +1,56 @@
+/**
+ * RPL dodag implementation
+ *
+ * Copyright (C) 2014  INRIA.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ *
+ * @ingroup rpl
+ * @{
+ * @file    rpl_of_manager.c
+ * @brief   RPL Objective functions manager
+ * @author  Fabian Brandt <fabianbr@zedat.fu-berlin.de>
+ * @}
+ */
+
+
+#include "rpl_of_manager.h"
+#include "of0.h"
+#include "of_mrhof.h"
+#include "etx_beaconing.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+rpl_of_t *objective_functions[NUMBER_IMPLEMENTED_OFS];
+
+void init_of_manager(ipv6_addr_t *my_address) {
+
+ /* INSERT NEW OBJECTIVE FUNCTIONS HERE */
+    objective_functions[0] = rpl_get_of0();
+    objective_functions[1] = rpl_get_of_mrhof();
+
+	if (RPL_DEFAULT_OCP == 1) {
+        DEBUG("%s, %d: INIT ETX BEACONING\n", __FILE__, __LINE__);
+        etx_init_beaconing(my_address);
+    }
+}
+
+
+
+/* find implemented OF via objective code point */
+rpl_of_t *rpl_get_of_for_ocp(uint16_t ocp)
+{
+    for (uint16_t i = 0; i < NUMBER_IMPLEMENTED_OFS; i++) {
+        if (ocp == objective_functions[i]->ocp) {
+            return objective_functions[i];
+        }
+    }
+
+    return NULL;
+}
+
+
+

--- a/sys/net/routing/rpl/rpl_of_manager.h
+++ b/sys/net/routing/rpl/rpl_of_manager.h
@@ -1,0 +1,24 @@
+/**
+ * RPL dodag implementation
+ *
+ * Copyright (C) 2014  INRIA.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ *
+ * @ingroup rpl
+ * @{
+ * @file    rpl_of_manager.h
+ * @brief   RPL Objective functions manager header
+ * @author  Fabian Brandt <fabianbr@zedat.fu-berlin.de>
+ * @}
+ */
+
+ #include "rpl_structs.h"
+ #include "rpl_config.h"
+
+void init_of_manager(ipv6_addr_t *my_address);
+
+//Returns objective function with a given cope point
+rpl_of_t *rpl_get_of_for_ocp(uint16_t ocp);

--- a/sys/net/routing/rpl/rpl_routing_tables.c
+++ b/sys/net/routing/rpl/rpl_routing_tables.c
@@ -1,0 +1,20 @@
+/**
+ * RPL dodag implementation
+ *
+ * Copyright (C) 2014  INRIA.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ *
+ * @ingroup rpl
+ * @{
+ * @file    rpl_routing_tables.c
+ * @brief   Manages routing tables
+ * @author  Fabian Brandt <fabianbr@zedat.fu-berlin.de>
+ * @}
+ */
+
+ #include "rpl_routing_tables.h"
+
+ipv6_addr_t **routing_table_entries;

--- a/sys/net/routing/rpl/rpl_routing_tables.h
+++ b/sys/net/routing/rpl/rpl_routing_tables.h
@@ -1,0 +1,34 @@
+/**
+ * RPL dodag implementation
+ *
+ * Copyright (C) 2014  INRIA.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ *
+ * @ingroup rpl
+ * @{
+ * @file    rpl_routing_tables.h
+ * @brief   Manages routing tables
+ * @author  Fabian Brandt <fabianbr@zedat.fu-berlin.de>
+ * @}
+ */
+
+#include <string.h>
+#include "ipv6.h"
+#include "forwarding_tables.h"
+
+#ifndef ROUTING_TABLES_H_INCLUDED
+#define ROUTING_TABLES_H_INCLUDED
+
+// Init only when root of RPL-Dodag 
+void init_routing_tables(uint16_t max_routing_entries);
+void add_routing_entry(ipv6_addr_t *destination, ipv6_addr_t *parent_table);
+void del_routing_entry(ipv6_addr_t *destination);
+void calculate_routes();
+
+// Returns array of intermediate hosts for a given destination
+ipv6_addr_t *get_routing_info(ipv6_addr_t *destination);
+
+#endif

--- a/sys/net/routing/rpl/rpl_sm.c
+++ b/sys/net/routing/rpl/rpl_sm.c
@@ -1,0 +1,22 @@
+/**
+ * RPL dodag implementation
+ *
+ * Copyright (C) 2013  INRIA.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ *
+ * @ingroup rpl
+ * @{
+ * @file    rpl_sm.c
+ * @brief   RPL Storing mode functions
+ * @author  Fabian Brandt <fabianbr@zedat.fu-berlin.de>
+ * @}
+ */
+
+#include "rpl_sm.h"
+
+void rpl_init_root_sm(void) {
+	
+}

--- a/sys/net/routing/rpl/rpl_sm.h
+++ b/sys/net/routing/rpl/rpl_sm.h
@@ -1,0 +1,21 @@
+/**
+ * RPL dodag implementation
+ *
+ * Copyright (C) 2013  INRIA.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ *
+ * @ingroup rpl
+ * @{
+ * @file    rpl_sm.h
+ * @brief   RPL Storing mode header
+ * @author  Fabian Brandt <fabianbr@zedat.fu-berlin.de>
+ * @}
+ */
+
+#include "rpl_structs.h"
+#include "rpl_config.h"
+
+void rpl_init_root_sm(void);

--- a/sys/net/routing/rpl/rpl_structs.h
+++ b/sys/net/routing/rpl/rpl_structs.h
@@ -20,108 +20,6 @@
 
 #ifndef RPL_STRUCTS_H_INCLUDED
 #define RPL_STRUCTS_H_INCLUDED
-/* Modes of Operation */
-
-#define NO_DOWNWARD_ROUTES  0x00
-#define NON_STORING_MODE    0x01
-#define STORING_MODE_NO_MC  0x02
-#define STORING_MODE_MC     0x03
-
-/* ICMP type */
-#define RPL_SEQUENCE_WINDOW         16
-#define ICMP_CODE_DIS               0x00
-#define ICMP_CODE_DIO               0x01
-#define ICMP_CODE_DAO               0x02
-#define ICMP_CODE_DAO_ACK           0x03
-/* packet base lengths */
-#define DIO_BASE_LEN                24
-#define DIS_BASE_LEN                2
-#define DAO_BASE_LEN                4
-#define DAO_D_LEN                   24
-#define DAO_ACK_LEN                 4
-#define DAO_ACK_D_LEN               24
-#define RPL_OPT_LEN                 2
-#define RPL_OPT_DODAG_CONF_LEN      14
-#define RPL_OPT_PREFIX_INFO_LEN		30
-#define RPL_OPT_SOLICITED_INFO_LEN	19
-#define RPL_OPT_TARGET_LEN			18
-#define RPL_OPT_TRANSIT_LEN			4
-
-/* message options */
-#define RPL_OPT_PAD1                 0
-#define RPL_OPT_PADN                 1
-#define RPL_OPT_DAG_METRIC_CONTAINER 2
-#define RPL_OPT_ROUTE_INFO           3
-#define RPL_OPT_DODAG_CONF           4
-#define RPL_OPT_TARGET               5
-#define RPL_OPT_TRANSIT              6
-#define RPL_OPT_SOLICITED_INFO       7
-#define RPL_OPT_PREFIX_INFO          8
-#define RPL_OPT_TARGET_DESC          9
-
-/* Counters */
-#define RPL_COUNTER_MAX                 255
-#define RPL_COUNTER_LOWER_REGION        127
-#define RPL_COUNTER_SEQ_WINDOW          16
-#define RPL_COUNTER_INIT                RPL_COUNTER_MAX - RPL_COUNTER_SEQ_WINDOW + 1
-#define RPL_COUNTER_INCREMENT(counter)  (counter > RPL_COUNTER_LOWER_REGION ? (counter == RPL_COUNTER_MAX ? counter=0 : ++counter) : (counter == RPL_COUNTER_LOWER_REGION ? counter=0 : ++counter))
-#define RPL_COUNTER_IS_INIT(counter)    (counter > RPL_COUNTER_LOWER_REGION)
-#define RPL_COUNTER_GREATER_THAN_LOCAL(A,B) (((A<B) && (RPL_COUNTER_LOWER_REGION + 1 - B + A < RPL_COUNTER_SEQ_WINDOW)) || ((A > B) && (A-B < RPL_COUNTER_SEQ_WINDOW)))
-#define RPL_COUNTER_GREATER_THAN(A,B)   ((A>RPL_COUNTER_LOWER_REGION) ? ((B > RPL_COUNTER_LOWER_REGION ) ? RPL_COUNTER_GREATER_THAN_LOCAL(A,B) : 0): (( B>RPL_COUNTER_LOWER_REGION ) ? 1: RPL_COUNTER_GREATER_THAN_LOCAL(A,B)))
-
-/* Node Status */
-#define NORMAL_NODE  0
-#define ROOT_NODE    1
-#define LEAF_NODE    2
-
-/* Link Metric Type */
-#define METRIC_ETX 1
-
-/*  Default values */
-
-#define RPL_DEFAULT_MOP STORING_MODE_NO_MC
-
-/*  RPL Constants and Variables */
-
-#define BASE_RANK 0
-#define INFINITE_RANK 0xFFFF
-#define RPL_DEFAULT_INSTANCE 0
-#define DEFAULT_PATH_CONTROL_SIZE 0
-#define DEFAULT_DIO_INTERVAL_MIN 11
-/* standard value: */
-/* #define DEFAULT_DIO_INTERVAL_MIN 3 */
-#define DEFAULT_DIO_INTERVAL_DOUBLINGS 7
-/* standard value: */
-/* #define DEFAULT_DIO_INTERVAL_DOUBLINGS 20 */
-#define DEFAULT_DIO_REDUNDANCY_CONSTANT 10
-#define DEFAULT_MIN_HOP_RANK_INCREASE 256
-#define ROOT_RANK DEFAULT_MIN_HOP_RANK_INCREASE
-/* DAO_DELAY is in seconds */
-#define DEFAULT_DAO_DELAY 3
-#define REGULAR_DAO_INTERVAL 300
-#define DAO_SEND_RETRIES 4
-#define DEFAULT_WAIT_FOR_DAO_ACK 15
-#define RPL_DODAG_ID_LEN 16
-
-/* others */
-
-#define NUMBER_IMPLEMENTED_OFS 2
-#define RPL_MAX_DODAGS 3
-#define RPL_MAX_INSTANCES 1
-#define RPL_MAX_PARENTS 5
-#define RPL_MAX_ROUTING_ENTRIES 128
-#define RPL_ROOT_RANK 256
-#define RPL_DEFAULT_LIFETIME 0xff
-#define RPL_LIFETIME_UNIT 2
-#define RPL_GROUNDED 1
-#define RPL_PRF_MASK 0x7
-#define RPL_MOP_SHIFT 3
-#define RPL_SHIFTED_MOP_MASK 0x7
-#define RPL_DIS_V_MASK 0x80
-#define RPL_DIS_I_MASK 0x40
-#define RPL_DIS_D_MASK 0x20
-#define RPL_GROUNDED_SHIFT 7
-#define RPL_DEFAULT_OCP 0
 
 /* DIO Base Object (RFC 6550 Fig. 14) */
 struct __attribute__((packed)) rpl_dio_t {
@@ -272,13 +170,5 @@ typedef struct rpl_of_t {
     void (*init)(void);  //OF specific init function
     void (*process_dio)(void);  //DIO processing callback (acc. to OF0 spec, chpt 5)
 } rpl_of_t;
-
-typedef struct {
-    uint8_t used;
-    ipv6_addr_t address;
-    ipv6_addr_t next_hop;
-    uint16_t lifetime;
-
-} rpl_routing_entry_t;
 
 #endif

--- a/sys/net/routing/rpl/trickle.c
+++ b/sys/net/routing/rpl/trickle.c
@@ -225,13 +225,13 @@ void dao_ack_received()
 
 void rt_timer_over(void)
 {
-    rpl_routing_entry_t *rt;
+    routing_entry_t *rt;
 
     while (1) {
         rpl_dodag_t *my_dodag = rpl_get_my_dodag();
 
         if (my_dodag != NULL) {
-            rt = rpl_get_routing_table();
+            rt = get_forwarding_table();
 
             for (uint8_t i = 0; i < RPL_MAX_ROUTING_ENTRIES; i++) {
                 if (rt[i].used) {


### PR DESCRIPTION
Changes are mostly only concerning RPL - except a new module used for "routing", which includes core routing functions independent of the protocol in use. Makefile of example "rpl_udp" uses the new module. There are several files still empty - they build the setup for the non-storing mode. 
