### PR TITLE
net: destiny: renamed internal TCP enums

### DIFF
--- a/sys/net/transport_layer/destiny/socket.c
+++ b/sys/net/transport_layer/destiny/socket.c
@@ -553,9 +553,9 @@ int destiny_socket_connect(int socket, sockaddr6_t *addr, uint32_t addrlen)
     srand(addr->sin6_port);
 
     current_tcp_socket->tcp_control.rcv_irs	= 0;
-    mutex_lock(&global_sequence_clunter_mutex);
+    mutex_lock(&global_sequence_counter_mutex);
     current_tcp_socket->tcp_control.send_iss = global_sequence_counter;
-    mutex_unlock(&global_sequence_clunter_mutex);
+    mutex_unlock(&global_sequence_counter_mutex);
     current_tcp_socket->tcp_control.state = TCP_SYN_SENT;
 
 #ifdef TCP_HC
@@ -1367,10 +1367,10 @@ socket_internal_t *new_tcp_queued_socket(ipv6_hdr_t *ipv6_header,
 
     current_queued_socket->socket_values.tcp_control.rcv_irs =
         tcp_header->seq_nr;
-    mutex_lock(&global_sequence_clunter_mutex);
+    mutex_lock(&global_sequence_counter_mutex);
     current_queued_socket->socket_values.tcp_control.send_iss =
         global_sequence_counter;
-    mutex_unlock(&global_sequence_clunter_mutex);
+    mutex_unlock(&global_sequence_counter_mutex);
     current_queued_socket->socket_values.tcp_control.state = TCP_SYN_RCVD;
     set_tcp_cb(&current_queued_socket->socket_values.tcp_control,
                tcp_header->seq_nr + 1, DESTINY_SOCKET_STATIC_WINDOW,

--- a/sys/net/transport_layer/destiny/tcp.c
+++ b/sys/net/transport_layer/destiny/tcp.c
@@ -35,6 +35,14 @@
 
 #include "tcp.h"
 
+#ifdef TCP_HC
+mutex_t             global_context_counter_mutex;
+uint8_t             global_context_counter;
+#endif
+
+mutex_t             global_sequence_counter_mutex;
+uint32_t            global_sequence_counter;
+
 void printTCPHeader(tcp_hdr_t *tcp_header)
 {
     printf("\nBEGIN: TCP HEADER\n");

--- a/sys/net/transport_layer/destiny/tcp.h
+++ b/sys/net/transport_layer/destiny/tcp.h
@@ -62,19 +62,19 @@ enum tcp_codes {
 
 #define REMOVE_RESERVED         (0xFC)
 
-#define IS_TCP_ACK(a)           ((a & TCP_ACK)      == TCP_ACK) /* Test for ACK flag only, ignore URG und PSH flag */
-#define IS_TCP_RST(a)           ((a & TCP_RST)      == TCP_RST)
-#define IS_TCP_SYN(a)           ((a & TCP_SYN)      == TCP_SYN)
-#define IS_TCP_SYN_ACK(a)       ((a & TCP_SYN_ACK)  == TCP_SYN_ACK)
-#define IS_TCP_FIN(a)           ((a & TCP_FIN)      == TCP_FIN)
-#define IS_TCP_FIN_ACK(a)       ((a & TCP_FIN_ACK)  == TCP_FIN_ACK)
+#define IS_TCP_ACK(a)           (((a) & TCP_ACK)      == TCP_ACK) /* Test for ACK flag only, ignore URG und PSH flag */
+#define IS_TCP_RST(a)           (((a) & TCP_RST)      == TCP_RST)
+#define IS_TCP_SYN(a)           (((a) & TCP_SYN)      == TCP_SYN)
+#define IS_TCP_SYN_ACK(a)       (((a) & TCP_SYN_ACK)  == TCP_SYN_ACK)
+#define IS_TCP_FIN(a)           (((a) & TCP_FIN)      == TCP_FIN)
+#define IS_TCP_FIN_ACK(a)       (((a) & TCP_FIN_ACK)  == TCP_FIN_ACK)
 
-#define SET_TCP_ACK(a)          a = ((a & 0x00) | TCP_ACK)
-#define SET_TCP_RST(a)          a = ((a & 0x00) | TCP_RST)
-#define SET_TCP_SYN(a)          a = ((a & 0x00) | TCP_SYN)
-#define SET_TCP_SYN_ACK(a)      a = ((a & 0x00) | TCP_SYN_ACK)
-#define SET_TCP_FIN(a)          a = ((a & 0x00) | TCP_FIN)
-#define SET_TCP_FIN_ACK(a)      a = ((a & 0x00) | TCP_FIN_ACK)
+#define SET_TCP_ACK(a)          (a) = TCP_ACK
+#define SET_TCP_RST(a)          (a) = TCP_RST
+#define SET_TCP_SYN(a)          (a) = TCP_SYN
+#define SET_TCP_SYN_ACK(a)      (a) = TCP_SYN_ACK
+#define SET_TCP_FIN(a)          (a) = TCP_FIN
+#define SET_TCP_FIN_ACK(a)      (a) = TCP_FIN_ACK
 
 #define TCP_STACK_SIZE          (KERNEL_CONF_STACKSIZE_DEFAULT)
 
@@ -85,12 +85,12 @@ typedef struct __attribute__((packed)) tcp_mms_o_t {
 } tcp_mss_option_t;
 
 #ifdef TCP_HC
-mutex_t             global_context_counter_mutex;
-uint8_t             global_context_counter;
+extern mutex_t             global_context_counter_mutex;
+extern uint8_t             global_context_counter;
 #endif
 
-mutex_t             global_sequence_clunter_mutex;
-uint32_t            global_sequence_counter;
+extern mutex_t             global_sequence_counter_mutex;
+extern uint32_t            global_sequence_counter;
 
 void tcp_packet_handler(void);
 uint16_t tcp_csum(ipv6_hdr_t *ipv6_header, tcp_hdr_t *tcp_header);

--- a/sys/net/transport_layer/destiny/tcp_timer.c
+++ b/sys/net/transport_layer/destiny/tcp_timer.c
@@ -130,9 +130,9 @@ void check_sockets(void)
 
 void inc_global_variables(void)
 {
-    mutex_lock(&global_sequence_clunter_mutex);
+    mutex_lock(&global_sequence_counter_mutex);
     global_sequence_counter += rand();
-    mutex_unlock(&global_sequence_clunter_mutex);
+    mutex_unlock(&global_sequence_counter_mutex);
 #ifdef TCP_HC
     mutex_lock(&global_context_counter_mutex);
     global_context_counter += rand();


### PR DESCRIPTION
Rationale: LISTEN was used in MSP430-Lib for the USART.
