### PR TITLE
ipc_pingpong: start receiving thread immediately

### DIFF
--- a/examples/ipc_pingpong/main.c
+++ b/examples/ipc_pingpong/main.c
@@ -45,7 +45,7 @@ int main(void)
     msg_t m;
 
     int pid = thread_create(second_thread_stack, sizeof(second_thread_stack),
-                            PRIORITY_MAIN - 1, CREATE_WOUT_YIELD | CREATE_STACKTEST,
+                            PRIORITY_MAIN - 1, CREATE_STACKTEST,
                             second_thread, "pong");
 
     m.content.value = 1;


### PR DESCRIPTION
Rationale: When using `msg_send_receive()` the receiving thread needs to
be already in receiving mode.
