### PR TITLE
core/cpu/board: moved F_CPU define to board

### DIFF
--- a/boards/mbed_lpc1768/include/board.h
+++ b/boards/mbed_lpc1768/include/board.h
@@ -13,6 +13,9 @@
 #include <stdint.h>
 #include "bitarithm.h"
 
+#define F_CPU                   (96000000)
+
+
 #define PIN_LED1 (BIT18)
 #define PIN_LED2 (BIT20)
 #define PIN_LED3 (BIT21)

--- a/boards/native/include/board.h
+++ b/boards/native/include/board.h
@@ -25,6 +25,10 @@
 
 #include <stdint.h>
 
+/* TODO: choose better value? */
+#define F_CPU 1000000
+
+
 void _native_LED_GREEN_OFF(void);
 #define LED_GREEN_OFF (_native_LED_GREEN_OFF())
 void _native_LED_GREEN_ON(void);

--- a/boards/redbee-econotag/include/board.h
+++ b/boards/redbee-econotag/include/board.h
@@ -23,6 +23,8 @@
 
 #include <stdint.h>
 
+#define F_CPU   (24000000)              ///< CPU target speed in Hz
+
 #define CTUNE 		0xb
 #define IBIAS 		0x1f
 #define FTUNE		0x7

--- a/core/hwtimer.c
+++ b/core/hwtimer.c
@@ -29,6 +29,7 @@
 #include "lifo.h"
 #include "mutex.h"
 #include "irq.h"
+#include "board.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"

--- a/cpu/lpc1768/include/cpu-conf.h
+++ b/cpu/lpc1768/include/cpu-conf.h
@@ -5,8 +5,6 @@
  * @name Kernel configuration
  * @{
  */
-#define F_CPU                                             96000000
-
 #define KERNEL_CONF_STACKSIZE_PRINTF		(4096)
 #ifndef KERNEL_CONF_STACKSIZE_DEFAULT
 #define KERNEL_CONF_STACKSIZE_DEFAULT	1500

--- a/cpu/mc1322x/include/mc1322x.h
+++ b/cpu/mc1322x/include/mc1322x.h
@@ -203,8 +203,6 @@ static volatile struct CRM_struct * const CRM = (void*) (CRM_BASE);
 /*-----------------------------------------------------------------*/
 /* TIMERS */
 
-#define F_CPU   (24000000)				///< CPU target speed in Hz
-
 /* Timer registers are all 16-bit wide with 16-bit access only */
 #define TMR_OFFSET      (0x20)
 #define TMR_BASE        (0x80007000)

--- a/cpu/msp430-common/include/cpu.h
+++ b/cpu/msp430-common/include/cpu.h
@@ -36,10 +36,6 @@ See the file LICENSE in the top level directory for more details.
 
 #define WORDSIZE 16
 
-/* CPU speed, to be defined in board.h */
-//#define F_CPU               (2457600ul)
-//#define F_RC_OSCILLATOR     (32768) ///< Frequency of internal RC oscillator
-
 extern volatile int __inISR;
 extern char __isr_stack[MSP430_ISR_STACK_SIZE];
 

--- a/cpu/native/include/cpu.h
+++ b/cpu/native/include/cpu.h
@@ -22,11 +22,6 @@
 #ifndef _CPU_H
 #define _CPU_H
 
-#include "cpu-conf.h"
-
-/* TODO: choose better value? */
-#define F_CPU 1000000
-
 /* TODO: remove once these have been removed from RIOT: */
 void dINT(void);
 void eINT(void);


### PR DESCRIPTION
Building for wsn430-v1_3b .. success
Building for redbee-econotag .. success
Building for wsn430-v1_4 .. success
Building for pttu .. success
Building for telosb .. success
Building for mbed_lpc1768 .. success
Building for msb-430 .. success
Building for native .. success
Building for chronos .. success
Building for avsextrem .. success
Building for msb-430h .. success
Building for msba2 .. success
