### PR TITLE
cpu: added enableIRQ implementation to cpu/lpc1768

### DIFF
--- a/cpu/lpc1768/cpu.c
+++ b/cpu/lpc1768/cpu.c
@@ -33,6 +33,13 @@ unsigned int disableIRQ(void)
     return uiPriMask;
 }
 
+unsigned enableIRQ(void)
+{
+    unsigned int uiPriMask = __get_PRIMASK();
+    __enable_irq();
+    return uiPriMask;
+}
+
 void restoreIRQ(unsigned oldPRIMASK)
 {
     //PRIMASK lesen setzen


### PR DESCRIPTION
added missing function to the lpc1768 implementation, otherwise the port will break with PR #922
