### PR TITLE
vtimer: renamed eINT to enableIRQ

### DIFF
--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -340,14 +340,13 @@ int vtimer_sleep(timex_t time)
 
 int vtimer_remove(vtimer_t *t)
 {
+    unsigned int irq_state = disableIRQ();
+
     queue_remove(&shortterm_queue_root, (queue_node_t *)t);
     queue_remove(&longterm_queue_root, (queue_node_t *)t);
-
     update_shortterm();
 
-    if (!inISR()) {
-        eINT();
-    }
+    restoreIRQ(irq_state);
 
     return 0;
 }


### PR DESCRIPTION
For some reason there was one single call to eINT() in vtimer.c, I changed it to enableIRQ() for now.

Correct me if I am wrong: but is the interrupt handling in vtimer_remove() correct? Shouldn't there be some kind of disableIRQ that goes with enable?
