### PR TITLE
Handle race conditions preventing MSP430 timers to be set correctly

### DIFF
--- a/cpu/msp430x16x/hwtimer_msp430.c
+++ b/cpu/msp430x16x/hwtimer_msp430.c
@@ -27,18 +27,15 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static uint32_t ticks = 0;
-
 extern void (*int_handler)(int);
 extern void timer_unset(short timer);
-extern uint16_t overflow_interrupt[HWTIMER_MAXTIMERS+1];
-extern uint16_t timer_round;
+extern volatile uint16_t overflow_interrupt[HWTIMER_MAXTIMERS+1];
+extern volatile uint16_t timer_round;
 
 void timerA_init(void)
 {
     volatile unsigned int *ccr;
     volatile unsigned int *ctl;
-    ticks = 0;                               /* Set tick counter value to 0 */
     timer_round = 0;                         /* Set to round 0 */
     TACTL = TASSEL_1 + TACLR;                /* Clear the timer counter, set ACLK */
     TACTL &= ~TAIFG;                         /* Clear the IFG */
@@ -58,10 +55,12 @@ void timerA_init(void)
 interrupt(TIMERA0_VECTOR) __attribute__((naked)) timer_isr_ccr0(void)
 {
     __enter_isr();
+
     if (overflow_interrupt[0] == timer_round) {
         timer_unset(0);
         int_handler(0);
     }
+
     __exit_isr();
 }
 
@@ -69,18 +68,34 @@ interrupt(TIMERA1_VECTOR) __attribute__((naked)) timer_isr(void)
 {
     __enter_isr();
 
-    short taiv = TAIV;
-    short timer = taiv / 2;
-    /* TAIV = 0x0A means overflow */
-    if (taiv == 0x0A) {
+    short taiv_reg = TAIV;
+    if (taiv_reg == 0x0A) {
+        /* TAIV = 0x0A means overflow */
         DEBUG("Overflow\n");
-        timer_round += 1;
+        timer_round++;
     }
-    /* check which CCR has been hit and if the overflow counter for this timer
-     * has been reached */
-    else if (overflow_interrupt[timer] == timer_round) {
-        timer_unset(timer);
-        int_handler(timer);
+    else {
+        short timer = taiv_reg >> 1;
+        /* check which CCR has been hit and if the overflow counter
+           for this timer has been reached (or exceeded);
+            there is indeed a race condition where an hwtimer
+            due to fire in the next round can be set after
+            the timer's counter has overflowed but *before*
+            timer_round incrementation has occured (when
+            interrupts are disabled for any reason), thus
+            effectively setting the timer one round in the past! */
+        int16_t round_delta = overflow_interrupt[timer] - timer_round;
+        /* in order to correctly handle timer_round overflow,
+           we must fire the timer when, for example,
+           timer_round == 0 and overflow_interrupt[timer] == 65535;
+           to that end, we compute the difference between the two
+           on a 16-bit signed integer: any difference >= +32768 will
+           thus overload to a negative number; we should then
+           correctly fire "overdue" timers whenever the case */
+        if (round_delta <= 0) {
+            timer_unset(timer);
+            int_handler(timer);
+        }
     }
 
     __exit_isr();


### PR DESCRIPTION
These occur:
- when the counter is incrementing during the setting of the comparator register (which is the actual implementation of the `hwtimer`)
- when setting a timer when the counter is overflowing and the overflow-handling interrupt hasn't incremented timer_counter yet (e.g. when you set the `hwtimer` from within an interrupt handler)
  Plus some minor fixes.
