### PR TITLE
core: Add the ability to send a message to the current thread's message queue

### DIFF
--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin
+ * Copyright (C) 2014 Freie Universität Berlin
  *
  * This file subject to the terms and conditions of the GNU Lesser General
  * Public License. See the file LICENSE in the top level directory for more
@@ -26,6 +26,7 @@
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
  */
 
 #ifndef __MSG_H
@@ -75,6 +76,21 @@ typedef struct msg {
  */
 int msg_send(msg_t *m, unsigned int target_pid, bool block);
 
+
+/**
+ * @brief Send a message to the current thread.
+ * @details Will work only if the thread has a message queue.
+ *
+ * Will be automatically chosen instead of @c msg_send
+ * if @c target_pid == @c thread_pid.
+ * This function never blocks.
+ *
+ * @param  m pointer to message structure
+ *
+ * @return 1 if sending was successful
+ * @return 0 if the thread's message queue is full (or inexistent)
+ */
+int msg_send_to_self(msg_t *m);
 
 /**
  * @brief Send message from interrupt.

--- a/core/msg.c
+++ b/core/msg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin
+ * Copyright (C) 2014 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License. See the file LICENSE in the top level directory for more
@@ -16,6 +16,7 @@
  * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
  *
  * @}
  */
@@ -62,7 +63,7 @@ int msg_send(msg_t *m, unsigned int target_pid, bool block)
     m->sender_pid = thread_pid;
 
     if (m->sender_pid == target_pid) {
-        return -1;
+        return msg_send_to_self(m);
     }
 
     if (target == NULL) {
@@ -126,6 +127,16 @@ int msg_send(msg_t *m, unsigned int target_pid, bool block)
     thread_yield();
 
     return 1;
+}
+
+int msg_send_to_self(msg_t *m)
+{
+    unsigned int state = disableIRQ();
+
+    int res = queue_msg(active_thread, m);
+
+    restoreIRQ(state);
+    return res;
 }
 
 int msg_send_int(msg_t *m, unsigned int target_pid)


### PR DESCRIPTION
This possibility replaces the current behavior of msg_send() that is: to treat this situation as an error.

Being able to send messages inside the same thread is a elegant way to replace flags and other global variables: it especially helps building finite state machines.
