### PR TITLE
Make: exterminate 'clean' buildtarget clutter

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -21,8 +21,6 @@ ifeq ($(strip $(GIT_VERSION)),)
 endif
 export CFLAGS += -DVERSION=\"$(GIT_VERSION)\"
 
-.PHONY: clean
-
 $(BINDIR)$(MODULE).a: $(OBJ) $(ASMOBJ)
 	$(AD)$(AR) -rc $(BINDIR)$(MODULE).a $(OBJ) $(ASMOBJ)
 
@@ -44,7 +42,3 @@ $(BINDIR)$(MODULE)/%.o: %.s
 $(BINDIR)$(MODULE)/%.o: %.S
 	@mkdir -p $(BINDIR)$(MODULE)
 	$(AD)$(CC) -c $(CFLAGS) $*.S -o $(BINDIR)$(MODULE)/$*.o
-
-# remove compilation products
-clean::
-	$(AD)rm -f $(BINDIR)$(MODULE).a $(OBJ) $(DEP) $(ASMOBJ)

--- a/Makefile.include
+++ b/Makefile.include
@@ -143,9 +143,7 @@ $(USEPKG:%=${BINDIR}%.a)::
 	"$(MAKE)" -C $(RIOTBASE)/pkg/$(patsubst ${BINDIR}%.a,%,$@)
 
 clean:
-	@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTBASE)/pkg/$$i clean || exit 1; done ;
-	"$(MAKE)" -C $(RIOTBOARD)/$(BOARD) clean
-	"$(MAKE)" -C $(RIOTBASE) clean
+	@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTBASE)/pkg/$$i clean || exit 1; done
 	rm -rf $(BINDIR)
 
 flash: all

--- a/Makefile.unsupported
+++ b/Makefile.unsupported
@@ -3,4 +3,5 @@
 all:
 	$(error Project $(PROJECT) currently not supported for $(BOARD))
 
-clean: all
+clean:
+	@true

--- a/boards/avsextrem/Makefile
+++ b/boards/avsextrem/Makefile
@@ -6,6 +6,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/chronos/Makefile
+++ b/boards/chronos/Makefile
@@ -7,6 +7,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/msb-430-common/Makefile
+++ b/boards/msb-430-common/Makefile
@@ -6,6 +6,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/msb-430/Makefile
+++ b/boards/msb-430/Makefile
@@ -6,6 +6,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/msb-430h/Makefile
+++ b/boards/msb-430h/Makefile
@@ -6,6 +6,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/msba2-common/Makefile
+++ b/boards/msba2-common/Makefile
@@ -6,6 +6,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/msba2/Makefile
+++ b/boards/msba2/Makefile
@@ -7,6 +7,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/native/Makefile
+++ b/boards/native/Makefile
@@ -12,6 +12,3 @@ $(BINDIR)$(MODULE)/%.o: %.c
 	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -c $*.c -o $(BINDIR)$(MODULE)/$*.o
 	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -MM $*.c |\
 		sed -e "1s|^|$(BINDIR)$(MODULE)/|" > $(BINDIR)$(MODULE)/$*.d
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/pttu/Makefile
+++ b/boards/pttu/Makefile
@@ -7,6 +7,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/redbee-econotag/Makefile
+++ b/boards/redbee-econotag/Makefile
@@ -6,6 +6,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/wsn430-common/Makefile
+++ b/boards/wsn430-common/Makefile
@@ -6,6 +6,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/wsn430-v1_3b/Makefile
+++ b/boards/wsn430-v1_3b/Makefile
@@ -6,6 +6,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/boards/wsn430-v1_4/Makefile
+++ b/boards/wsn430-v1_4/Makefile
@@ -6,6 +6,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/cpu/cc430/Makefile
+++ b/cpu/cc430/Makefile
@@ -6,6 +6,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/cpu/lpc1768/Makefile
+++ b/cpu/lpc1768/Makefile
@@ -11,9 +11,6 @@ all: $(BINDIR)$(MODULE).a
 
 include $(RIOTBASE)/Makefile.base
 
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;
-
 # This is needed for NXP Cortex M devices
 nxpsum:
 	$(CCLOCAL) nxpsum.c -std=c99 -o nxpsum

--- a/cpu/lpc2387/Makefile
+++ b/cpu/lpc2387/Makefile
@@ -20,6 +20,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/cpu/mc1322x/Makefile
+++ b/cpu/mc1322x/Makefile
@@ -12,6 +12,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/cpu/msp430-common/Makefile
+++ b/cpu/msp430-common/Makefile
@@ -1,11 +1,3 @@
 MODULE =msp430_common
 
-DIRS =
-
-all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
-
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/cpu/msp430x16x/Makefile
+++ b/cpu/msp430x16x/Makefile
@@ -8,6 +8,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/cpu/native/Makefile
+++ b/cpu/native/Makefile
@@ -18,6 +18,3 @@ $(BINDIR)$(MODULE)/%.o: %.c
 	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -c $*.c -o $(BINDIR)$(MODULE)/$*.o
 	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -MM $*.c |\
 		sed -e "1s|^|$(BINDIR)$(MODULE)/|" > $(BINDIR)$(MODULE)/$*.d
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -39,7 +39,3 @@ all:
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-# remove compilation products
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/drivers/at86rf231/Makefile
+++ b/drivers/at86rf231/Makefile
@@ -1,11 +1,3 @@
 MODULE =at86rf231
 
-DIRS =
-
-all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
-
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/drivers/cc110x_ng/Makefile
+++ b/drivers/cc110x_ng/Makefile
@@ -15,6 +15,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/drivers/cc2420/Makefile
+++ b/drivers/cc2420/Makefile
@@ -1,11 +1,3 @@
 MODULE =cc2420
 
-DIRS =
-
-all: $(BINDIR)$(MODULE).a
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
-
 include $(RIOTBASE)/Makefile.base
-
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -106,7 +106,3 @@ all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 
 include $(RIOTBASE)/Makefile.base
-
-# remove compilation products
-clean::
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;


### PR DESCRIPTION
Closes #993.

We do not need to descend into the modules to know what to do on
`make clean BOARD=blub`. We can just invoke `rm -rf bin/blub`.

This PR only keeps the descending into the USEPKGs, since they might
want to delete cached/downloaded/extracted data.
