### PR TITLE
core: msg: make messaging optional for threads (2)

### DIFF
--- a/core/include/flags.h
+++ b/core/include/flags.h
@@ -19,10 +19,11 @@
 #ifndef _FLAGS_H
 #define _FLAGS_H
 
-#define CREATE_SLEEPING     (1)
-#define AUTO_FREE           (2)
-#define CREATE_WOUT_YIELD   (4)
-#define CREATE_STACKTEST    (8)
+#define CREATE_SLEEPING     (1u << 0)
+#define AUTO_FREE           (1u << 1)
+#define CREATE_WOUT_YIELD   (1u << 2)
+#define CREATE_STACKTEST    (1u << 3)
+#define CREATE_NOMSG        (1u << 4)
 
 /** @} */
 #endif // _FLAGS_H

--- a/core/include/tcb.h
+++ b/core/include/tcb.h
@@ -44,27 +44,30 @@
 #define STATUS_RUNNING          7                      /**< currently running */
 #define STATUS_PENDING          8                      /**< waiting to be scheduled to run */
 
-
-
 typedef struct tcb_t {
     char *sp;
-    uint16_t status;
+    uint8_t status;
+    uint8_t flags;
 
     uint16_t pid;
     uint16_t priority;
 
     clist_node_t rq_entry;
 
+    const char *name;
+    char *stack_start;
+    int stack_size;
+} tcb_t;
+
+typedef struct msg_tcb_t {
+    tcb_t tcb;
+
     void *wait_data;
     queue_node_t msg_waiters;
 
     cib_t msg_queue;
     msg_t *msg_array;
-
-    const char *name;
-    char *stack_start;
-    int stack_size;
-} tcb_t;
+} msg_tcb_t;
 
 /** @} */
 #endif /* TCB_H_ */

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -80,7 +80,7 @@ void kernel_init(void)
 
     hwtimer_init();
 
-    if (thread_create(idle_stack, sizeof(idle_stack), PRIORITY_IDLE, CREATE_WOUT_YIELD | CREATE_STACKTEST, idle_thread, idle_name) < 0) {
+    if (thread_create(idle_stack, sizeof(idle_stack), PRIORITY_IDLE, CREATE_WOUT_YIELD | CREATE_STACKTEST | CREATE_NOMSG, idle_thread, idle_name) < 0) {
         printf("kernel_init(): error creating idle task.\n");
     }
 


### PR DESCRIPTION
That's my take on #703 from @kaspar030:

> This commit makes it possible to create threads with CREATE_NOMSG,
> disabling their messaging abilities.

The difference in my implementation is, that I don't use a pointer to
the message table, but make the thread control block as big as needed.

Incidentally I fixed the usage of `dINT()` and `eINT()` in msg.c,
because it would have been more complicated not to.
