### PR TITLE
wsn430-v1_4b: don't always link cc2420

### DIFF
--- a/boards/wsn430-v1_4/Makefile
+++ b/boards/wsn430-v1_4/Makefile
@@ -2,6 +2,9 @@ MODULE = $(BOARD)_base
 
 DIRS = $(RIOTBOARD)/wsn430-common
 
+INCLUDES += -I$(RIOTBASE)/drivers/cc2420/include \
+			-I$(RIOTBASE)/sys/net/include
+
 all: $(BINDIR)$(MODULE).a
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
 

--- a/boards/wsn430-v1_4/Makefile.include
+++ b/boards/wsn430-v1_4/Makefile.include
@@ -1,13 +1,4 @@
 export INCLUDES += -I$(RIOTBOARD)/wsn430-v1_4/include -I$(RIOTBOARD)/wsn430-common/include
 
-ifeq (,$(filter cc2420,$(USEMODULE)))
-	USEMODULE += cc2420
-endif
-
-ifneq (,$(filter cc2420,$(USEMODULE)))
-	INCLUDES += -I$(RIOTBASE)/drivers/cc2420/include \
-				-I$(RIOTBASE)/sys/net/include
-endif
-
 include $(RIOTBOARD)/$(BOARD)/Makefile.dep
 include $(RIOTBOARD)/wsn430-common/Makefile.include


### PR DESCRIPTION
Resolves ~~#657~~ #671.

The board dependent part of the driver will still be built but no longer linked when not needed. 
