### PR TITLE
ccnl: use default transceiver

### DIFF
--- a/examples/ccn-lite-client/Makefile
+++ b/examples/ccn-lite-client/Makefile
@@ -36,12 +36,7 @@ USEMODULE += posix
 USEMODULE += ps
 USEMODULE += random
 USEMODULE += transceiver
-ifeq ($(BOARD),msba2)
-	USEMODULE += cc110x_ng
-else ifeq ($(BOARD),native)
-	USEMODULE += nativenet
-endif
-
+USEMODULE += defaulttransceiver
 USEMODULE += rtc
 USEMODULE += crypto_sha256
 USEMODULE += ccn_lite

--- a/examples/ccn-lite-relay/Makefile
+++ b/examples/ccn-lite-relay/Makefile
@@ -33,12 +33,7 @@ USEMODULE += config
 USEMODULE += posix
 
 USEMODULE += transceiver
-ifeq ($(BOARD),msba2)
-	USEMODULE += cc110x_ng
-else ifeq ($(BOARD),native)
-	USEMODULE += nativenet
-endif
-
+USEMODULE += defaulttransceiver
 USEMODULE += rtc
 USEMODULE += crypto_sha256
 USEMODULE += ccn_lite

--- a/examples/ccn-lite-relay/main.c
+++ b/examples/ccn-lite-relay/main.c
@@ -44,7 +44,7 @@ void set_address_handler(uint16_t a)
     msg_t mesg;
     transceiver_command_t tcmd;
 
-    tcmd.transceivers = transceiver_ids;
+    tcmd.transceivers = TRANSCEIVER;
     tcmd.data = &a;
     mesg.content.ptr = (char *) &tcmd;
 

--- a/sys/net/ccn_lite/ccn-lite-relay.c
+++ b/sys/net/ccn_lite/ccn-lite-relay.c
@@ -105,11 +105,11 @@ int ccnl_open_riotmsgdev(void)
 int ccnl_open_riottransdev(void)
 {
 
-    transceiver_init(transceiver_ids);
+    transceiver_init(TRANSCEIVER);
     transceiver_start();
 
     /** register for transceiver events */
-    transceiver_register(transceiver_ids, thread_getpid());
+    transceiver_register(TRANSCEIVER, thread_getpid());
 
     return RIOT_TRANS_DEV; /* sock id */
 }

--- a/sys/net/ccn_lite/ccnl-riot-compat.c
+++ b/sys/net/ccn_lite/ccnl-riot-compat.c
@@ -46,7 +46,7 @@ int riot_send_transceiver(uint8_t *buf, uint16_t size, uint16_t to)
     p.dst = (to == RIOT_BROADCAST) ? 0 : to;
     p.data = buf;
 
-    tcmd.transceivers = transceiver_ids;
+    tcmd.transceivers = TRANSCEIVER;
     tcmd.data = &p;
 
     mesg.type = SND_PKT;

--- a/sys/net/include/ccn_lite/ccnl-riot.h
+++ b/sys/net/include/ccn_lite/ccnl-riot.h
@@ -38,13 +38,7 @@
 
 #include "transceiver.h"
 
-#ifdef MODULE_CC110X_NG
-#  include "cc110x_ng.h"
-#  define transceiver_ids (TRANSCEIVER_CC1100 | TRANSCEIVER_NONE)
-#else
-#  include "nativenet.h"
-#  define transceiver_ids (TRANSCEIVER_NATIVE | TRANSCEIVER_NONE)
-#endif
+#define TRANSCEIVER TRANSCEIVER_DEFAULT
 
 #define CCNL_RIOT_EVENT_NUMBER_OFFSET (1 << 8)
 typedef enum ccnl_riot_event {


### PR DESCRIPTION
this solves https://github.com/RIOT-OS/RIOT/issues/966

it makes CCN lite ready for different hardware platforms
