### PR TITLE
msp430: Fix variable usage in cc430-rtc.c

### DIFF
--- a/cpu/cc430/cc430-rtc.c
+++ b/cpu/cc430/cc430-rtc.c
@@ -197,7 +197,7 @@ interrupt(RTC_VECTOR) __attribute__((naked)) rtc_isr(void)
         }
 
         if (rtc_second_pid) {
-            msg_t m;
+            static msg_t m;
             m.type = RTC_SECOND;
             msg_send_int(&m, rtc_second_pid);
         }


### PR DESCRIPTION
Closes #967.
