### PR TITLE
core/msp430: no <errno.h> in core

### DIFF
--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -21,7 +21,6 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <errno.h>
 #include "tcb.h"
 #include "kernel.h"
 #include "kernel_internal.h"

--- a/core/thread.c
+++ b/core/thread.c
@@ -18,7 +18,6 @@
  * @}
  */
 
-#include <errno.h>
 #include <stdio.h>
 
 #include "thread.h"
@@ -134,7 +133,7 @@ int thread_create(char *stack, int stacksize, char priority, int flags, void (*f
     tcb_t *cb = (tcb_t *) tcb_address;
 
     if (priority >= SCHED_PRIO_LEVELS) {
-        return -EINVAL;
+        return -1;
     }
 
     if (flags & CREATE_STACKTEST) {
@@ -175,7 +174,7 @@ int thread_create(char *stack, int stacksize, char priority, int flags, void (*f
             eINT();
         }
 
-        return -EOVERFLOW;
+        return -1;
     }
 
     cb->sp = thread_stack_init(function, stack, stacksize);


### PR DESCRIPTION
The gcc-msp430 as of Ubuntu stable (12.04) does have the file errno.h,
but some values are missing.

Since the documentation in thread.h does not say that there are multiple
error values, and no-one uses it, we can just omit errno.h and its
values.
