### PR TITLE
posix:pthread c++11 changed pthread_self() to return thread IDs > 0

### DIFF
--- a/sys/posix/pthread/pthread.c
+++ b/sys/posix/pthread/pthread.c
@@ -241,7 +241,7 @@ int pthread_detach(pthread_t th)
 
 pthread_t pthread_self(void)
 {
-    pthread_t result = -1;
+    pthread_t result = 0;
     mutex_lock(&pthread_mutex);
     int pid = thread_pid; /* thread_pid is volatile */
     for (int i = 0; i < MAXTHREADS; i++) {


### PR DESCRIPTION
the changes move the returned `pthread_t` value of `pthread_self()` `+1` and reduces the given ID when accessing `pthread_sched_threads[]`.

This change is necessary for using `.join()` on a c++11 `std::thread`. 
If `pthread_self()` returns a 0 the `libstdc++` throws an exception, due to the 0 value equals `thread::id of a non-executing thread`
