### PR TITLE
make: comprehensive list of the boards' filesizes

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -31,7 +31,8 @@ CFLAGS += -DBOARD_$(BB) -DCPU_$(CPUDEF)
 
 export CFLAGS
 
-export BINDIR =$(CURDIR)/bin/$(BOARD)/
+export BINDIRBASE ?= $(CURDIR)/bin
+export BINDIR ?= $(abspath $(BINDIRBASE)/$(BOARD))/
 
 ifeq ($(QUIET),1)
 	AD=@
@@ -82,7 +83,7 @@ BASELIBS += $(BINDIR)$(BOARD)_base.a
 BASELIBS += $(BINDIR)${PROJECT}.a
 BASELIBS += $(USEPKG:%=${BINDIR}%.a)
 
-.PHONY: all clean flash doc term objsize buildsize buildsizes
+.PHONY: all clean flash doc term objsize buildsize buildsizes buildsizes-diff
 
 ## make script for your application. Build RIOT-base here!
 all: $(BINDIR)$(PROJECT).a
@@ -187,6 +188,7 @@ buildtest:
 			RIOTBASE=$${RIOTBASE} \
 			RIOTBOARD=$${RIOTBOARD} \
 			RIOTCPU=$${RIOTCPU} \
+			BINDIRBASE=$${BINDIRBASE} \
 			$(MAKE) -B clean all 2>&1 >/dev/null) ; \
 		if [ "$${?}" = "0" ]; then \
 			$${ECHO} "$${GREEN}success$${RESET}"; \
@@ -238,5 +240,49 @@ buildsizes:
 			RIOTBASE=$${RIOTBASE} \
 			RIOTBOARD=$${RIOTBOARD} \
 			RIOTCPU=$${RIOTCPU} \
+			BINDIRBASE=$${BINDIRBASE} \
 			$(MAKE) buildsize 2>/dev/null | tail -n-1 | cut -f-4)" "$${BOARD}"; \
+	done;
+
+buildsizes-diff: SHELL=bash
+buildsizes-diff:
+	@if [[ -z "$(BOARD_WHITELIST)" ]]; then \
+		BOARDS=$$(find $(RIOTBOARD) -mindepth 1 -maxdepth 1 -type d \! -name \*-common -printf '%f\n' ); \
+	else \
+		BOARDS="$(BOARD_WHITELIST)"; \
+	fi; \
+	for BOARD in $(BOARD_BLACKLIST); do \
+		BOARDS=$$(sed -e "s/ $${BOARD} / /" <<< " $${BOARDS} "); \
+	done; \
+	\
+	GREEN='\033[1;32m'; RED='\033[1;31m'; RESET='\033[0m'; \
+	\
+	echo -e "text\tdata\tbss\tdec\tBOARD/BINDIRBASE\n"; \
+	for BOARD in $$(tr ' ' '\n' <<< $${BOARDS} | sort); do \
+		for BINDIRBASE in $${OLDBIN} $${NEWBIN}; do \
+			env -i \
+				HOME=$${HOME} \
+				PATH=$${PATH} \
+				BOARD=$${BOARD} \
+				RIOTBASE=$${RIOTBASE} \
+				RIOTBOARD=$${RIOTBOARD} \
+				RIOTCPU=$${RIOTCPU} \
+				BINDIRBASE=$${BINDIRBASE} \
+				$(MAKE) buildsize 2>/dev/null | tail -n-1 | cut -f-4; \
+		done | \
+		while read -a OLD && read -a NEW; do \
+			for I in 0 1 2 3; do \
+				if [[ -n "$${NEW[I]}" && -n "$${OLD[I]}" ]]; then \
+					DIFF=$$(($${NEW[I]} - $${OLD[I]})); \
+					if [[ "$${DIFF}" -gt 0 ]]; then echo -ne "$${RED}"; fi; \
+					if [[ "$${DIFF}" -lt 0 ]]; then echo -ne "$${GREEN}"; fi; \
+				else \
+					DIFF="$${RED}ERR"; \
+				fi; \
+				echo -ne "$${DIFF}\t$${RESET}"; \
+			done; \
+			echo "$${BOARD}"; \
+			for I in 0 1 2 3; do echo -ne "$${OLD[I]-$${RED}ERR$${RESET}}\t"; done; echo -e "$${OLDBIN}"; \
+			for I in 0 1 2 3; do echo -ne "$${NEW[I]-$${RED}ERR$${RESET}}\t"; done; echo -e "$${NEWBIN}\n"; \
+		done; \
 	done;


### PR DESCRIPTION
Ever wondered if your change sucks for some board?

This PR adds a maketarget that prints a comprehensive list of the sizes for all boards:

```
tests/test_vtimer_msg$ make buildsizes
   text    data     bss     dec     hex board
  30590     564   68392   99546   184da native
  57340    1532   96769  155641   25ff9 avsextrem
  11812     160    1618   13590    3516 chronos
  43804    3577   28988   76369   12a51 mbed_lpc1768
  10914      80    1580   12574    311e msb-430
  10792      80    1580   12452    30a4 msb-430h
  57036    1532   96769  155337   25ec9 msba2
  57548    1532   96769  155849   260c9 pttu
  59988    1568   13216   74772   12414 redbee-econotag
  10856      76    1580   12512    30e0 telosb
  10942      80    1580   12602    313a wsn430-v1_3b
  10942      80    1580   12602    313a wsn430-v1_4
```

Use `make buildtest` beforehand.
