### PR TITLE
vtimer: fix callback usage

### DIFF
--- a/sys/include/vtimer.h
+++ b/sys/include/vtimer.h
@@ -37,7 +37,7 @@
 typedef struct vtimer_t {
     queue_node_t queue_entry;
     timex_t absolute;
-    void(*action)(void *);
+    void (*action)(struct vtimer_t *timer);
     void *arg;
     unsigned int pid;
 } vtimer_t;

--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -41,15 +41,14 @@
 #define SECONDS_PER_TICK (4096U)
 #define MICROSECONDS_PER_TICK (4096UL * 1000000)
 
-void vtimer_callback(void *ptr);
-void vtimer_tick(void *ptr);
+static void vtimer_callback(void *ptr);
+static void vtimer_callback_tick(vtimer_t *timer);
+static void vtimer_callback_msg(vtimer_t *timer);
+static void vtimer_callback_wakeup(vtimer_t *timer);
+
 static int vtimer_set(vtimer_t *timer);
 static int set_longterm(vtimer_t *timer);
 static int set_shortterm(vtimer_t *timer);
-
-#if ENABLE_DEBUG
-void vtimer_print(vtimer_t *t);
-#endif
 
 static queue_node_t longterm_queue_root;
 static queue_node_t shortterm_queue_root;
@@ -99,7 +98,7 @@ static int update_shortterm(void)
     uint32_t now = HWTIMER_TICKS_TO_US(hwtimer_now());
 
     /* make sure the longterm_tick_timer does not get truncated */
-    if (((vtimer_t*)shortterm_queue_root.next)->action != vtimer_tick) {
+    if (((vtimer_t *) shortterm_queue_root.next)->action != vtimer_callback_tick) {
         /* the next vtimer to schedule is the long term tick */
         /* it has a shortterm offset of longterm_tick_start */
         next += longterm_tick_start;
@@ -116,10 +115,11 @@ static int update_shortterm(void)
     return 0;
 }
 
-void vtimer_tick(void *ptr)
+void vtimer_callback_tick(vtimer_t *timer)
 {
-    (void) ptr;
-    DEBUG("vtimer_tick().\n");
+    (void) timer;
+
+    DEBUG("vtimer_callback_tick().\n");
     seconds += SECONDS_PER_TICK;
 
     longterm_tick_start = longterm_tick_timer.absolute.microseconds;
@@ -139,6 +139,25 @@ void vtimer_tick(void *ptr)
     }
 }
 
+static void vtimer_callback_msg(vtimer_t *timer)
+{
+    msg_t msg;
+    msg.type = MSG_TIMER;
+    msg.content.value = (unsigned int) timer->arg;
+    msg_send_int(&msg, timer->pid);
+}
+
+static void vtimer_callback_wakeup(vtimer_t *timer)
+{
+    thread_wakeup(timer->pid);
+}
+
+static void vtimer_callback_unlock(vtimer_t *timer)
+{
+    mutex_t *mutex = (mutex_t *) timer->arg;
+    mutex_unlock(mutex);
+}
+
 static int set_shortterm(vtimer_t *timer)
 {
     DEBUG("set_shortterm(): Absolute: %" PRIu32 " %" PRIu32 "\n", timer->absolute.seconds, timer->absolute.microseconds);
@@ -150,14 +169,13 @@ static int set_shortterm(vtimer_t *timer)
 void vtimer_callback(void *ptr)
 {
     DEBUG("vtimer_callback ptr=%p\n", ptr);
-
     (void) ptr;
-    vtimer_t *timer;
+
     in_callback = true;
     hwtimer_id = -1;
 
     /* get the vtimer that fired */
-    timer = (vtimer_t *)queue_remove_head(&shortterm_queue_root);
+    vtimer_t *timer = (vtimer_t *)queue_remove_head(&shortterm_queue_root);
 
 #if ENABLE_DEBUG
     vtimer_print(timer);
@@ -165,25 +183,7 @@ void vtimer_callback(void *ptr)
     DEBUG("vtimer_callback(): Shooting %" PRIu32 ".\n", timer->absolute.microseconds);
 
     /* shoot timer */
-    if (timer->action == (void (*)(void *)) msg_send_int) {
-        msg_t msg;
-        msg.type = MSG_TIMER;
-        msg.content.value = (unsigned int) timer->arg;
-        msg_send_int(&msg, timer->pid);
-    }
-    else if (timer->action == (void (*)(void *)) thread_wakeup){
-        timer->action(timer->arg);
-    }
-    else if (timer->action == vtimer_tick) {
-        vtimer_tick(NULL);
-    }
-    else if (timer->action == (void (*)(void *)) mutex_unlock) {
-        mutex_t *mutex = (mutex_t *) timer->arg;
-        timer->action(mutex);
-    }
-    else {
-        DEBUG("Timer was poisoned.\n");
-    }
+    timer->action(timer);
 
     in_callback = false;
     update_shortterm();
@@ -231,8 +231,7 @@ static int vtimer_set(vtimer_t *timer)
         }
     }
 
-    int state = disableIRQ();
-
+    unsigned state = disableIRQ();
     if (timer->absolute.seconds != seconds) {
         /* we're long-term */
         DEBUG("vtimer_set(): setting long_term\n");
@@ -242,7 +241,6 @@ static int vtimer_set(vtimer_t *timer)
         DEBUG("vtimer_set(): setting short_term\n");
 
         if (set_shortterm(timer)) {
-
             /* delay update of next shortterm timer if we
             * are called from within vtimer_callback. */
 
@@ -251,8 +249,6 @@ static int vtimer_set(vtimer_t *timer)
             }
         }
     }
-
-
     restoreIRQ(state);
 
     return result;
@@ -295,7 +291,7 @@ int vtimer_init(void)
 
     longterm_tick_start = 0;
 
-    longterm_tick_timer.action = vtimer_tick;
+    longterm_tick_timer.action = vtimer_callback_tick;
     longterm_tick_timer.arg = NULL;
 
     longterm_tick_timer.absolute.seconds = 0;
@@ -312,13 +308,11 @@ int vtimer_init(void)
 
 int vtimer_set_wakeup(vtimer_t *t, timex_t interval, int pid)
 {
-    int ret;
-    t->action = (void(*)(void *)) thread_wakeup;
-    t->arg = (void *) pid;
+    t->action = vtimer_callback_wakeup;
+    t->arg = NULL;
     t->absolute = interval;
-    t->pid = 0;
-    ret = vtimer_set(t);
-    return ret;
+    t->pid = pid;
+    return vtimer_set(t);
 }
 
 int vtimer_usleep(uint32_t usecs)
@@ -335,8 +329,8 @@ int vtimer_sleep(timex_t time)
     mutex_init(&mutex);
     mutex_lock(&mutex);
 
-    t.action = (void(*)(void *)) mutex_unlock;
-    t.arg = (void *) &mutex;
+    t.action = vtimer_callback_unlock;
+    t.arg = &mutex;
     t.absolute = time;
 
     ret = vtimer_set(&t);
@@ -360,7 +354,7 @@ int vtimer_remove(vtimer_t *t)
 
 int vtimer_set_msg(vtimer_t *t, timex_t interval, unsigned int pid, void *ptr)
 {
-    t->action = (void(*)(void *)) msg_send_int;
+    t->action = vtimer_callback_msg;
     t->arg = ptr;
     t->absolute = interval;
     t->pid = pid;


### PR DESCRIPTION
Right now the vtimer callback uses unnecessary type casts, which make understanding it difficult.
Functions like `vtimer_callback()` and `vtimer_tick()` were exposed though they are internal use only.

This PR fixes both.
