### PR TITLE
native/make: add missing target

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -66,6 +66,8 @@ endif
 
 all: # do not override first target
 
+all-debug: all
+
 all-gprof: all
 
 all-valgrind: all


### PR DESCRIPTION
fixup for https://github.com/RIOT-OS/RIOT/pull/789
