### PR TITLE
ccnl: don't include transceiver and defaulttransceiver

### DIFF
--- a/examples/ccn-lite-client/Makefile
+++ b/examples/ccn-lite-client/Makefile
@@ -47,7 +47,6 @@ USEMODULE += shell_commands
 USEMODULE += posix
 USEMODULE += ps
 USEMODULE += random
-USEMODULE += transceiver
 USEMODULE += defaulttransceiver
 USEMODULE += rtc
 USEMODULE += crypto_sha256


### PR DESCRIPTION
This removes the duplicate include of the transceiver.
The transceiver module is a dependency of the
defaulttransceiver, so an explicite include is not needed
