### PR TITLE
Add basic travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: c
+
+before_install:
+    - sudo apt-get update
+
+    - sudo apt-get install emdebian-archive-keyring
+    - echo 'deb http://www.emdebian.org/debian wheezy main' | sudo tee /etc/apt/sources.list.d/emdebian.list > /dev/null
+
+    - echo 'deb http://us.archive.ubuntu.com/ubuntu trusty           main restricted universe multiverse' | sudo tee    /etc/apt/sources.list.d/trusty.list > /dev/null
+    - echo 'deb http://us.archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse' | sudo tee -a /etc/apt/sources.list.d/trusty.list > /dev/null
+    - echo 'deb http://us.archive.ubuntu.com/ubuntu trusty-security  main restricted universe multiverse' | sudo tee -a /etc/apt/sources.list.d/trusty.list > /dev/null
+    - echo 'deb http://us.archive.ubuntu.com/ubuntu trusty-updates   main restricted universe multiverse' | sudo tee -a /etc/apt/sources.list.d/trusty.list > /dev/null
+    - sudo apt-get update
+
+    - sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
+    - sudo apt-get update
+
+install:
+    - sudo apt-get install build-essential
+    - sudo apt-get install gcc-multilib
+    - sudo apt-get install gcc-arm-none-eabi
+    - sudo apt-get install gcc-msp430
+
+script:
+    - ./dist/tools/compile_test/compile_test.py
+
+notifications:
+    email: false


### PR DESCRIPTION
This PR adds the basic integration for [Travis CI](https://travis-ci.org/).

The config file `.travis.yml` tells the server to setup the basic build
system, and run `compile_test.py`. If not all  examples and tests could be
built, then the Travis CI integration adds a warning to "merge" button on
the bottom of the Github page.

Of course this integration makes little sense until #1049 is resolved,
because new bugs and old bugs cannot be told apart. Also (of course)
only because everything still builds, a PR still can intruduce a
multitude of runtime errors.

This integrations is meant to work additionally to our Jenkings. Users
can activate the test in their own RIOT forks to run the test before
opening a PR to master.
