### PR TITLE
core: imply current_prio in `sched_switch()`

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -55,13 +55,12 @@ void sched_set_status(tcb_t *process, unsigned int status);
 
 /**
  * @brief   Compare thread priorities and yield() (or set
- *          sched_context_switch_request if in_isr) when other_prio is higher
- *          (has a lower value) than current_prio
+ *          sched_context_switch_request if inISR()) when other_prio is higher
+ *          (has a lower value) than the current thread's priority
  *
- * @param[in]   current_prio    The priority of the current thread
  * @param[in]   other_prio      The priority of the target thread
  */
-void sched_switch(uint16_t current_prio, uint16_t other_prio);
+void sched_switch(uint16_t other_prio);
 
 /**
  * @brief   Call context switching at thread exit

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -107,7 +107,7 @@ void mutex_unlock(struct mutex_t *mutex)
             DEBUG("%s: waking up waiter.\n", process->name);
             sched_set_status(process, STATUS_PENDING);
 
-            sched_switch(sched_active_thread->priority, process->priority);
+            sched_switch(process->priority);
         }
         else {
             mutex->val = 0;

--- a/core/sched.c
+++ b/core/sched.c
@@ -173,11 +173,12 @@ void sched_set_status(tcb_t *process, unsigned int status)
     process->status = status;
 }
 
-void sched_switch(uint16_t current_prio, uint16_t other_prio)
+void sched_switch(uint16_t other_prio)
 {
     int in_isr = inISR();
+    uint16_t current_prio = sched_active_thread->priority;
 
-    DEBUG("%s: %i %i %i\n", sched_active_thread->name, (int)current_prio, (int)other_prio, in_isr);
+    DEBUG("%s: %" PRIu16 " %" PRIu16 " %i\n", sched_active_thread->name, current_prio, other_prio, in_isr);
 
     if (current_prio >= other_prio) {
         if (in_isr) {

--- a/core/thread.c
+++ b/core/thread.c
@@ -86,7 +86,7 @@ int thread_wakeup(int pid)
         sched_set_status(other_thread, STATUS_RUNNING);
 
         restoreIRQ(old_state);
-        sched_switch(sched_active_thread->priority, other_thread->priority);
+        sched_switch(other_thread->priority);
 
         return 1;
     }

--- a/sys/posix/pthread/pthread.c
+++ b/sys/posix/pthread/pthread.c
@@ -158,7 +158,7 @@ int pthread_create(pthread_t *newthread, const pthread_attr_t *attr, void *(*sta
         return -1;
     }
 
-    sched_switch(sched_active_thread->priority, PRIORITY_MAIN);
+    sched_switch(PRIORITY_MAIN);
 
     return 0;
 }

--- a/sys/posix/pthread/pthread_cond.c
+++ b/sys/posix/pthread/pthread_cond.c
@@ -157,7 +157,7 @@ int pthread_cond_signal(struct pthread_cond_t *cond)
     restoreIRQ(old_state);
 
     if (other_prio >= 0) {
-        sched_switch(sched_active_thread->priority, other_prio);
+        sched_switch(other_prio);
     }
 
     return 0;
@@ -191,7 +191,7 @@ int pthread_cond_broadcast(struct pthread_cond_t *cond)
     restoreIRQ(old_state);
 
     if (other_prio >= 0) {
-        sched_switch(sched_active_thread->priority, other_prio);
+        sched_switch(other_prio);
     }
 
     return 0;

--- a/sys/posix/pthread/pthread_rwlock.c
+++ b/sys/posix/pthread/pthread_rwlock.c
@@ -315,6 +315,6 @@ int pthread_rwlock_unlock(pthread_rwlock_t *rwlock)
     mutex_unlock(&rwlock->mutex);
 
     /* yield if a woken up thread had a higher priority */
-    sched_switch(sched_active_thread->priority, prio);
+    sched_switch(prio);
     return 0;
 }

--- a/sys/posix/semaphore.c
+++ b/sys/posix/semaphore.c
@@ -149,7 +149,7 @@ int sem_post(sem_t *sem)
         tcb_t *next_process = (tcb_t*) next->data;
         DEBUG("%s: waking up %s\n", sched_active_thread->name, next_process->name);
         sched_set_status(next_process, STATUS_PENDING);
-        sched_switch(sched_active_thread->priority, next_process->priority);
+        sched_switch(next_process->priority);
     }
 
     restoreIRQ(old_state);


### PR DESCRIPTION
There is no need to supply the current priority to `sched_switch()`,
when this function can easily tell the value of
`active_thread->priority` itself.
