### PR TITLE
drivers: fix includes in rtc.h for MSP430

### DIFF
--- a/drivers/include/rtc.h
+++ b/drivers/include/rtc.h
@@ -25,11 +25,7 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 #define RTC_SECOND 10001U
 
 #include <time.h>
-
-/* TODO: remove once msp430 libc supports struct timeval */
-#ifndef MSP430
 #include <sys/time.h>
-#endif
 
 /**
  * @brief Initializes the RTC for calendar mode


### PR DESCRIPTION
The comment and the actual guard in `rtc.h` did not match.
If (as in "implication") the MCU is an MSP, then `sys/time.h` must be
included, to have `time_t`, `struct timeval`, …

Including the header file in any case should be safe, so I dropped the
guard altogether.
