### PR TITLE
core: and cpu: Added NORETURN to functions that should not return

### DIFF
--- a/core/include/kernel_internal.h
+++ b/core/include/kernel_internal.h
@@ -20,6 +20,8 @@
 #ifndef KERNEL_INTERNAL_H_
 #define KERNEL_INTERNAL_H_
 
+#include "attributes.h"
+
 /**
  * @brief   Initializes scheduler and creates main and idle task
  */
@@ -44,7 +46,7 @@ char *thread_stack_init(void  (*task_func)(void), void *stack_start, int stack_s
 /**
  * @brief  Removes thread from scheduler and set status to #STATUS_STOPPED
  */
-void sched_task_exit(void);
+NORETURN void sched_task_exit(void);
 
 /**
  * @brief   Prints human readable, ps-like thread information for debugging purposes

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -25,6 +25,7 @@
 #include <stddef.h>
 #include "bitarithm.h"
 #include "tcb.h"
+#include "attributes.h"
 
 #define MAXTHREADS 32 /**< the maximum number of threads to be scheduled */
 
@@ -65,7 +66,7 @@ void sched_switch(uint16_t current_prio, uint16_t other_prio);
 /**
  * @brief   Call context switching at thread exit
  */
-void cpu_switch_context_exit(void);
+NORETURN void cpu_switch_context_exit(void);
 
 /**
  * Flag indicating whether a context switch is necessary after handling an

--- a/core/sched.c
+++ b/core/sched.c
@@ -187,7 +187,7 @@ void sched_switch(uint16_t current_prio, uint16_t other_prio)
     }
 }
 
-void sched_task_exit(void)
+NORETURN void sched_task_exit(void)
 {
     DEBUG("sched_task_exit(): ending task %s...\n", active_thread->name);
 

--- a/cpu/msp430-common/cpu.c
+++ b/cpu/msp430-common/cpu.c
@@ -32,12 +32,14 @@ void thread_yield()
     __restore_context();
 }
 
-void cpu_switch_context_exit(void)
+NORETURN void cpu_switch_context_exit(void)
 {
     active_thread = sched_threads[0];
     sched_run();
 
     __restore_context();
+
+    UNREACHABLE();
 }
 
 /**


### PR DESCRIPTION
regarding #1078 this PR adds `__attribute__((noreturn))` in form of the `NORETURN` define to
`sched_task_exit()` and `cpu_switch_context_exit()`

This fixes the warning on  returning from a `noreturn` function ~~(currently only tested on native)~~
