### PR TITLE
Introduction of an of-manager for RPL.

### DIFF
--- a/sys/net/include/rpl.h
+++ b/sys/net/include/rpl.h
@@ -34,6 +34,7 @@
 #include <transceiver.h>
 #include "ipv6.h"
 #include "rpl/rpl_dodag.h"
+#include "rpl/rpl_of_manager.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,7 +47,6 @@ extern "C" {
 #define RPL_PROCESS_STACKSIZE KERNEL_CONF_STACKSIZE_DEFAULT
 
 /* global variables */
-extern rpl_of_t *rpl_objective_functions[NUMBER_IMPLEMENTED_OFS];
 extern rpl_routing_entry_t rpl_routing_table[RPL_MAX_ROUTING_ENTRIES];
 extern kernel_pid_t rpl_process_pid;
 
@@ -74,18 +74,6 @@ extern uint8_t rpl_buffer[BUFFER_SIZE - LL_HDR_LEN];
  *
  */
 uint8_t rpl_init(int if_id);
-
-/**
- * @brief Get entry point for default objective function.
- *
- * This function is obsolete in rpl.h and will be moved shortly.
- *
- * @param[in] ocp               Objective code point for desired objective function
- *
- * @return Implementation of objective function
- *
- * */
-rpl_of_t *rpl_get_of_for_ocp(uint16_t ocp);
 
 /**
  * @brief Initialization of RPL-root.

--- a/sys/net/include/rpl/rpl_of_manager.h
+++ b/sys/net/include/rpl/rpl_of_manager.h
@@ -1,0 +1,46 @@
+/*
+* RPL dodag implementation
+*
+* Copyright (C) 2014 Freie Universität Berlin
+*
+* This file is subject to the terms and conditions of the GNU Lesser
+* General Public License v2.1. See the file LICENSE in the top level
+* directory for more details.
+*
+* @ingroup rpl
+* @{
+* @file    rpl_of_manager.h
+* @brief   RPL Objective functions manager header
+* @author  Fabian Brandt <fabianbr@zedat.fu-berlin.de>
+* @}
+*/
+
+#ifndef __RPL_OFM_H
+#define __RPL_OFM_H
+
+#include "rpl_structs.h"
+#include "rpl_config.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialization of Manager and of-functions.
+ * @param[in]   my_address Own address for initialization of beaconing
+*/
+void rpl_of_manager_init(ipv6_addr_t *my_address);
+
+/**
+ * @brief Returns objective function with a given cope point
+ * @param[in]   ocp Objective code point of objective function
+ * @return      Pointer of corresponding objective function implementation
+*/
+rpl_of_t *rpl_get_of_for_ocp(uint16_t ocp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __RPL_OFM_H */
+/** @} */

--- a/sys/net/routing/rpl/rpl_of_manager.c
+++ b/sys/net/routing/rpl/rpl_of_manager.c
@@ -1,0 +1,60 @@
+/*
+* RPL dodag implementation
+*
+* Copyright (C) 2014 Freie Universität Berlin
+*
+* This file is subject to the terms and conditions of the GNU Lesser
+* General Public License v2.1. See the file LICENSE in the top level
+* directory for more details.
+*/
+
+/**
+ *
+ * @ingroup rpl
+ * @{
+ * @file    rpl_of_manager.c
+ * @brief   RPL Objective functions manager
+ * @author  Fabian Brandt <fabianbr@zedat.fu-berlin.de>
+ * @}
+ */
+
+
+
+#include "rpl/rpl_of_manager.h"
+#include "of0.h"
+#include "of_mrhof.h"
+#include "etx_beaconing.h"
+#include "rpl/rpl_config.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+rpl_of_t *objective_functions[NUMBER_IMPLEMENTED_OFS];
+
+void rpl_of_manager_init(ipv6_addr_t *my_address)
+{
+    /* insert new objective functions here */
+    objective_functions[0] = rpl_get_of0();
+    objective_functions[1] = rpl_get_of_mrhof();
+
+    if (RPL_DEFAULT_OCP == 1) {
+        DEBUG("%s, %d: INIT ETX BEACONING\n", __FILE__, __LINE__);
+        etx_init_beaconing(my_address);
+    }
+}
+
+/* find implemented OF via objective code point */
+rpl_of_t *rpl_get_of_for_ocp(uint16_t ocp)
+{
+    for (uint16_t i = 0; i < NUMBER_IMPLEMENTED_OFS; i++) {
+        if (objective_functions[i] == NULL) {
+            /* fallback if something goes wrong */
+            return rpl_get_of0();
+        }
+        else if (ocp == objective_functions[i]->ocp) {
+            return objective_functions[i];
+        }
+    }
+
+    return NULL;
+}


### PR DESCRIPTION
The of-manager should gather all available of´s and initialize the preferred one, based on `RPL_DEFAULT_OCP` in rpl_config.h.
