### PR TITLE
ccnl: don't include transceiver and defaulttransceiver

### DIFF
--- a/examples/ccn-lite-relay/Makefile
+++ b/examples/ccn-lite-relay/Makefile
@@ -44,7 +44,6 @@ BOARD_BLACKLIST := chronos mbed_lpc1768 msb-430 msb-430h redbee-econotag \
 USEMODULE += config
 USEMODULE += posix
 
-USEMODULE += transceiver
 USEMODULE += defaulttransceiver
 USEMODULE += rtc
 USEMODULE += crypto_sha256


### PR DESCRIPTION
This removes the duplicate include of the transceiver.
The transceiver module is a dependency of the
defaulttransceiver, so an explicite include is not needed

Follow up to #1053
