### PR TITLE
use filter instead of findstring in Makefile

### DIFF
--- a/pkg/oonf_api/0002-port-tests-to-riot.patch
+++ b/pkg/oonf_api/0002-port-tests-to-riot.patch
@@ -59,12 +59,12 @@ index 0000000..c286ad3
 +
 +USEMODULE += net_help
 +USEMODULE += oonf_cunit
-+ifneq (,$(findstring regex,$(PROJECT)))
++ifneq (,$(filter regex,$(PROJECT)))
 +	USEMODULE += oonf_regex
 +endif
 +USEMODULE += oonf_common
 +
-+ifneq (,$(findstring daemonize,$(PROJECT)))
++ifneq (,$(filter daemonize,$(PROJECT)))
 +	error daemonize is not supported on RIOT
 +endif
 +


### PR DESCRIPTION
fixes issue #672

The git hash doesn't really matter here, patch still applies
