### PR TITLE
test:test_irq initialized `j` with 0

### DIFF
--- a/tests/test_irq/main.c
+++ b/tests/test_irq/main.c
@@ -28,7 +28,7 @@ volatile int busy, i, k;
 
 void busy_thread(void)
 {
-    int j;
+    int j = 0;
     puts("busy_thread starting");
 
     i = 0;


### PR DESCRIPTION
initialized `j` with 0 to get rid of `warning: 'j' may be used uninitialized in this function [-Wmaybe-uninitialized]`
