### PR TITLE
test:test_pthread_barrier fixed Wformat warning

### DIFF
--- a/tests/test_pthread_barrier/main.c
+++ b/tests/test_pthread_barrier/main.c
@@ -43,7 +43,7 @@ static void *run(void *id_)
         pthread_barrier_wait(&barrier);
 
         uint32_t timeout_us = genrand_uint32() % 2500000;
-        printf("Child %i sleeps for % 8i µs.\n", id, timeout_us);
+        printf("Child %i sleeps for %" PRIu32 " µs.\n", id, timeout_us);
         vtimer_usleep(timeout_us);
     }
 


### PR DESCRIPTION
changed 2nd `printf(...)` argument to get rid of `[-Wformat]` warning
