### PR TITLE
test:test_vtimer fixed initializer and Wformat warnings

### DIFF
--- a/tests/test_vtimer_msg/main.c
+++ b/tests/test_vtimer_msg/main.c
@@ -37,8 +37,8 @@ struct timer_msg {
 
 timex_t now;
 
-struct timer_msg msg_a = { .timer = {0}, .interval = { .seconds = 2, .microseconds = 0}, .msg = "Hello World" };
-struct timer_msg msg_b = { .timer = {0}, .interval = { .seconds = 5, .microseconds = 0}, .msg = "This is a Test" };
+struct timer_msg msg_a = { .interval = { .seconds = 2, .microseconds = 0}, .msg = "Hello World" };
+struct timer_msg msg_b = { .interval = { .seconds = 5, .microseconds = 0}, .msg = "This is a Test" };
 
 void timer_thread(void)
 {
@@ -55,7 +55,7 @@ void timer_thread(void)
         msg_receive(&m);
         struct timer_msg *tmsg = (struct timer_msg *) m.content.ptr;
         vtimer_now(&now);
-        printf("now=%" PRIu32 ":%" PRIu32 " -> every %u.%us: %s\n",
+        printf("now=%" PRIu32 ":%" PRIu32 " -> every %" PRIu32 ".%" PRIu32 "s: %s\n",
                now.seconds,
                now.microseconds,
                tmsg->interval.seconds,


### PR DESCRIPTION
expanded the initializers to explicitly initialize every field to fix `[-Wmissing-braces]` and `[-Wmissing-field-initializers]` warnings.

changed `%u` to `PRIu32` to fix `[-Wformat]` warnings.
