### PR TITLE
arm_common: no needless `_gettimeofday()` warning

### DIFF
--- a/cpu/arm_common/gettimeofday.c
+++ b/cpu/arm_common/gettimeofday.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2013 Oliver Hahm <oliver.hahm@inria.fr>
+ *
+ * This source code is licensed under the GNU Lesser General Public License,
+ * Version 2.  See the file LICENSE for more details.
+ *
+ * This file is part of RIOT.
+ *
+ */
+
+/**
+ * @file
+ * @ingroup     arm_common
+ * @brief       LPC2387 Newlib gettimeofday() system call glue
+ *
+ * @author      Freie Universität Berlin, Computer Systems & Telematics
+ * @author      Michael Baar <michael.baar@fu-berlin.de>
+ * @author      René Kijewski <rene.kijewski@fu-berlin.de>
+ */
+
+#include <sys/time.h>
+
+#if defined MODULE_RTC
+#   include "rtc.h"
+#elif defined MODULE_VTIMER
+#   include "vtimer.h"
+#endif
+
+/* Declared as external, without a definition. */
+/* This will cause a linktime error, if _gettimeofday() is referenced, */
+/* and neither rtc nor vtimer were linked in. */
+extern void __gettimeofday_syscall_is_not_implemented_without_vtimer_or_rtc_module(void);
+
+int _gettimeofday(struct timeval *tp, void *restrict tzp)
+{
+    (void) tzp;
+
+#if defined MODULE_RTC
+    rtc_time(tp);
+#elif defined MODULE_VTIMER
+    vtimer_gettimeofday(tp);
+#else
+    __gettimeofday_syscall_is_not_implemented_without_vtimer_or_rtc_module();
+#endif
+
+    return 0;
+}

--- a/cpu/arm_common/syscalls.c
+++ b/cpu/arm_common/syscalls.c
@@ -276,18 +276,6 @@ int _kill_r(struct _reent *r, int pid, int sig)
     r->_errno = ESRCH;      // no such process
     return -1;
 }
-/*---------------------------------------------------------------------------*/
-int _gettimeofday(struct timeval *tp, void *restrict tzp) {
-    (void) tzp;
-#if defined MODULE_RTC
-    rtc_time(tp);
-#elif defined MODULE_VTIMER
-    vtimer_gettimeofday(tp);
-#else
-#warning gettimeofday syscall is not implemented without vtimer or rtc module
-#endif
-    return 0;
-}
 
 void _init(void) {}
 void _fini(void) {}


### PR DESCRIPTION
The `arm_common` syscalls implement `_gettimeofday()` for the benefit of
newlib. The syscall call only work if the `rtc` module or the `vtimer`
modules is transcluded. If neither module is used, a warning is printed
by means of `#warning`.

This warning is useless if the user does not invoke `gettimeofday()`.
Further this warning prevents the use of `-Werror`.

This PR puts the function in its own file, that will only be linked if
it was used. And if the function was used, then a link time error occur
if neither `rtc` nor `vtimer` was transcluded.
