### PR TITLE
ccnl: remove type warning

### DIFF
--- a/sys/net/ccn_lite/ccnl-riot-compat.c
+++ b/sys/net/ccn_lite/ccnl-riot-compat.c
@@ -90,7 +90,7 @@ void riot_send_nack(uint16_t to)
     msg_send(&m, to, 0);
 }
 
-char *riot_ccnl_event_to_string(ccnl_riot_event_t event)
+char *riot_ccnl_event_to_string(int event)
 {
     switch (event) {
         case PKT_PENDING:

--- a/sys/net/ccn_lite/ccnl-riot-compat.h
+++ b/sys/net/ccn_lite/ccnl-riot-compat.h
@@ -30,4 +30,4 @@ typedef struct riot_ccnl_msg {
 int riot_send_transceiver(uint8_t *buf, uint16_t size, uint16_t to);
 int riot_send_msg(uint8_t *buf, uint16_t size, uint16_t to);
 void riot_send_nack(uint16_t to);
-char *riot_ccnl_event_to_string(ccnl_riot_event_t event);
+char *riot_ccnl_event_to_string(int event);

--- a/sys/net/include/ccn_lite/ccnl-riot.h
+++ b/sys/net/include/ccn_lite/ccnl-riot.h
@@ -41,16 +41,13 @@
 #define TRANSCEIVER TRANSCEIVER_DEFAULT
 
 #define CCNL_RIOT_EVENT_NUMBER_OFFSET (1 << 8)
-typedef enum ccnl_riot_event {
-    CCNL_RIOT_MSG = CCNL_RIOT_EVENT_NUMBER_OFFSET + 1,
-    CCNL_RIOT_HALT,
-    CCNL_RIOT_POPULATE,
-    CCNL_RIOT_PRINT_STAT,
-    CCNL_RIOT_TIMEOUT,
-    CCNL_RIOT_NACK,
-
-    CCNL_RIOT_RESERVED
-} ccnl_riot_event_t;
+#define CCNL_RIOT_MSG                 (CCNL_RIOT_EVENT_NUMBER_OFFSET + 0)
+#define CCNL_RIOT_HALT                (CCNL_RIOT_EVENT_NUMBER_OFFSET + 1)
+#define CCNL_RIOT_POPULATE            (CCNL_RIOT_EVENT_NUMBER_OFFSET + 2)
+#define CCNL_RIOT_PRINT_STAT          (CCNL_RIOT_EVENT_NUMBER_OFFSET + 3)
+#define CCNL_RIOT_TIMEOUT             (CCNL_RIOT_EVENT_NUMBER_OFFSET + 4)
+#define CCNL_RIOT_NACK                (CCNL_RIOT_EVENT_NUMBER_OFFSET + 5)
+#define CCNL_RIOT_RESERVED            (CCNL_RIOT_EVENT_NUMBER_OFFSET + 6)
 
 #define CCNL_HEADER_SIZE (40)
 
@@ -64,8 +61,6 @@ typedef enum ccnl_riot_event {
 #else
 #  define CCNL_RIOT_CHUNK_SIZE (PAYLOAD_SIZE - CCNL_HEADER_SIZE)
 #endif
-
-
 
 /**
  * @brief starts the ccnl relay


### PR DESCRIPTION
Removes the warning about `PKT_PENDING` and `ENOBUFFER` not being in `ccnl_riot_event_t`.
