### PR TITLE
sys:posix:pthread added missing `pthread_cond.h` to `pthread.h`

### DIFF
--- a/sys/posix/pthread/include/pthread.h
+++ b/sys/posix/pthread/include/pthread.h
@@ -23,5 +23,6 @@
 #include "pthread_once.h"
 #include "pthread_scheduling.h"
 #include "pthread_cancellation.h"
+#include "pthread_cond.h"
 
 #endif	/* pthread.h */

--- a/tests/test_pthread_condition_variable/main.c
+++ b/tests/test_pthread_condition_variable/main.c
@@ -19,9 +19,8 @@
  */
 
 #include <stdio.h>
-#include "pthread_cond.h"
+#include "pthread.h"
 #include "thread.h"
-#include "mutex.h"
 
 static mutex_t mutex;
 static struct pthread_cond_t cv;


### PR DESCRIPTION
Added missing `pthread_cond.h` to `pthread.h`
and adjusted `test_pthread_condition_variable\main.c` includes reflecting the above change.
