### PR TITLE
shell:ps: SCHEDSTATISTICS cols only if needed

### DIFF
--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -44,7 +44,12 @@ void thread_print_all(void)
     int i;
     int overall_stacksz = 0;
 
-    printf("\tpid | %-21s| %-9sQ | pri | stack ( used) location  | runtime | switches \n", "name", "state");
+    printf("\tpid | %-21s| %-9sQ | pri | stack ( used) location"
+#if SCHEDSTATISTICS
+           "  | runtime | switches"
+#endif
+           "\n"
+           , "name", "state");
 
     for (i = 0; i < MAXTHREADS; i++) {
         tcb_t *p = (tcb_t *)sched_threads[i];
@@ -54,17 +59,22 @@ void thread_print_all(void)
             const char *sname = state_names[state];                                // get state name
             const char *queued = &queued_name[(int)(state >= STATUS_ON_RUNQUEUE)]; // get queued flag
             int stacksz = p->stack_size;                                           // get stack size
-            double runtime_ticks = 0 / 0.0;
-            int switches = -1;
 #if SCHEDSTATISTICS
-            runtime_ticks =  pidlist[i].runtime_ticks / (double) hwtimer_now() * 100;
-            switches = pidlist[i].schedules;
+            double runtime_ticks =  pidlist[i].runtime_ticks / (double) hwtimer_now() * 100;
+            int switches = pidlist[i].schedules;
 #endif
             overall_stacksz += stacksz;
             stacksz -= thread_measure_stack_free(p->stack_start);
-            printf("\t%3u | %-21s| %-8s %.1s | %3i | %5i (%5i) %p | %6.3f%% | ",
-                   p->pid, p->name, sname, queued, p->priority, p->stack_size, stacksz, p->stack_start, runtime_ticks);
-            printf(" %8u\n", switches);
+            printf("\t%3u | %-21s| %-8s %.1s | %3i | %5i (%5i) %p"
+#if SCHEDSTATISTICS
+                   " | %6.3f%% |  %8u"
+#endif
+                   "\n",
+                   p->pid, p->name, sname, queued, p->priority, p->stack_size, stacksz, p->stack_start
+#if SCHEDSTATISTICS
+                   , runtime_ticks, switches
+#endif
+                  );
         }
     }
 


### PR DESCRIPTION
This PR hides the columns "runtime" and "switches" from the output of "ps" if the application was not compiled with `SCHEDSTATISTICS` support.
