### PR TITLE
Add unittests to travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
 
 script:
     - ./dist/tools/compile_test/compile_test.py
+    - make -C ./tests/unittests term
 
 notifications:
     email: false


### PR DESCRIPTION
Though there are no unittests in master yet, this PR allows PRs that do contain unittests to be tested accordingly (also this PR serves as a kind reminder to finally merge #961 ;))
