### PR TITLE
fix buildtest with oonf_api

### DIFF
--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -25,6 +25,7 @@ $(CURDIR)/$(PKG_NAME)/Makefile: $(CURDIR)/$(PKG_NAME)
 	$(foreach patch,$(shell ls [0-9][0-9][0-9][0-9]*.patch),cd "$<" && git am "../$(patch)" || { git am --abort; exit 1; };)
 
 $(CURDIR)/$(PKG_NAME):
+	test -d oonf_api || \
 	git clone $(PKG_URL) $@ && \
 		cd $@ && git reset --hard $(PKG_VERSION)
 


### PR DESCRIPTION
Don't try to checkout `oonf_api` if it's already present.
