### PR TITLE
msp430: fix missing members in `struct tm`

### DIFF
--- a/cpu/msp430-common/include/time.h
+++ b/cpu/msp430-common/include/time.h
@@ -2,13 +2,15 @@
 #define MSPGCC_TIME_H
 
 struct tm {
-    int tm_sec;                   /* Seconds after the minute [0, 59] */
+    int tm_sec;                   /* Seconds after the minute [0, 60] */
     int tm_min;                   /* Minutes after the hour [0, 59] */
     int tm_hour;                  /* Hours since midnight [0, 23] */
     int tm_mday;                  /* Day of the month [1, 31] */
     int tm_mon;                   /* Months since January [0, 11] */
     int tm_year;                  /* Years since 1900 */
     int tm_wday;                  /* Days since Sunday [0, 6] */
+    int tm_yday;                  /* Days since January 1st [0, 365] */
+    int tm_isdst;                 /* Daylight saving time is in effect */
 };
 
 #endif


### PR DESCRIPTION
Closes #1150.
