### PR TITLE
unittests: exit(1) on error

### DIFF
--- a/tests/unittests/embunit/embUnit/TestRunner.c
+++ b/tests/unittests/embunit/embUnit/TestRunner.c
@@ -41,6 +41,7 @@
 
 static TestResult result_;
 static Test* root_;
+int TestRunnerHadErrors;
 
 static void TestRunner_startTest(TestListner* self,Test* test)
 {
@@ -73,6 +74,8 @@ static void TestRunner_addFailure(TestListner* self,Test* test,char* msg,int lin
 	}
 	stdimpl_print(msg);
 	stdimpl_print("\n");
+
+	TestRunnerHadErrors = 1;
 }
 
 static const TestListnerImplement TestRunnerImplement = {
@@ -107,6 +110,8 @@ void TestRunner_end(void)
 		stdimpl_itoa(result_.failureCount, buf, 10);
 		stdimpl_print(buf);
 		stdimpl_print("\n");
+
+		TestRunnerHadErrors = 1;
 	} else {
 		stdimpl_print("\nOK (");
 		stdimpl_itoa(result_.runCount, buf, 10);

--- a/tests/unittests/embunit/embUnit/TestRunner.h
+++ b/tests/unittests/embunit/embUnit/TestRunner.h
@@ -43,6 +43,8 @@ void TestRunner_start(void);
 void TestRunner_runTest(Test* test);
 void TestRunner_end(void);
 
+extern int TestRunnerHadErrors;
+
 #ifdef	__cplusplus
 }
 #endif

--- a/tests/unittests/main.c
+++ b/tests/unittests/main.c
@@ -58,6 +58,11 @@ int main(void)
     /* put test TEST_RUN() calls here */
     TESTS_END();
 
+#if defined (BOARD_NATIVE) && !defined (OUTPUT)
+    void _exit(int);
+    _exit(TestRunnerHadErrors);
+#endif
+
     lpm_set(LPM_POWERDOWN);
 
     return 0;


### PR DESCRIPTION
Since #1130 the unittests are executed by Travis CI, the unittests should return an error code if not all tests passed.
