### PR TITLE
unittests: use subfolders for different tests

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -16,6 +16,21 @@ else ifeq ($(OUTPUT),COMPILER)
 	USEMODULE += embunit_textui
 endif
 
-.PHONY : all clean core
+ifeq (, $(filter tests-%, $(MAKECMDGOALS)))
+    UNIT_TESTS := $(shell find -mindepth 1 -maxdepth 1 -type d -name 'tests-*' -printf '%f ')
+else
+    UNIT_TESTS := $(filter tests-%, $(MAKECMDGOALS))
+endif
 
 include $(RIOTBASE)/Makefile.include
+
+UNITTEST_LIBS := $(UNIT_TESTS:%=$(BINDIR)%.a)
+
+all: $(UNITTEST_LIBS)
+$(UNIT_TESTS): all
+
+$(UNITTEST_LIBS): $(BINDIR)%.a:
+	"$(MAKE)" -C $(CURDIR)/$*
+
+CFLAGS += $(shell echo $(UNIT_TESTS:tests-%=-DTEST_%_ENABLED) | tr a-z A-Z)
+BASELIBS += $(UNITTEST_LIBS)

--- a/tests/unittests/main.c
+++ b/tests/unittests/main.c
@@ -6,47 +6,9 @@
  * details.
  */
 
-#include "embUnit/embUnit.h"
+#include "unittests.h"
 
 #include "lpm.h"
-
-#ifdef OUTPUT
-#define OUTPUT_XML      (1)
-#define OUTPUT_TEXT     (2)
-#define OUTPUT_COMPILER (4)
-
-#if (OUTPUT==OUTPUT_XML)
-#include "textui/XMLOutputter.h"
-
-#define OUTPUTTER   (XMLOutputter_outputter())
-#endif
-
-#if (OUTPUT==OUTPUT_TEXT)
-#include "textui/TextOutputter.h"
-
-#define OUTPUTTER   (TextOutputter_outputter())
-#endif
-
-#if (OUTPUT==OUTPUT_COMPILER)
-#include "textui/CompilerOutputter.h"
-
-#define OUTPUTTER   (CompilerOutputter_outputter())
-#endif
-
-#include "textui/TextUIRunner.h"
-
-#define TESTS_START()   TextUIRunner_start()
-#define TESTS_RUN(t)    TextUIRunner_runTest(t)
-#define TESTS_END()     TextUIRunner_end()
-
-#else
-
-#define TESTS_START()   TestRunner_start()
-#define TESTS_RUN(t)    TestRunner_runTest(t)
-#define TESTS_END()     TestRunner_end()
-
-#endif
-
 
 int main(void)
 {
@@ -55,10 +17,15 @@ int main(void)
 #endif
 
     TESTS_START();
-    /* put test TEST_RUN() calls here */
+
+    /* put test TEST_RUN() calls here: */
+    /*     #ifdef TEST_xxx_ENABLED
+     *         tests_xxx();
+     *     #endif
+     */
+
     TESTS_END();
 
     lpm_set(LPM_POWERDOWN);
-
     return 0;
 }

--- a/tests/unittests/unittests.h
+++ b/tests/unittests/unittests.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2014 Martin Lenders
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file        unittests.h
+ * @brief       Common header file for unittests
+ *
+ * @author      Freie Universität Berlin, Computer Systems & Telematics
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#ifndef __UNITTESTS__H
+#define __UNITTESTS__H
+
+#include "embUnit/embUnit.h"
+
+#ifdef OUTPUT
+#   define OUTPUT_XML      (1)
+#   define OUTPUT_TEXT     (2)
+#   define OUTPUT_COMPILER (4)
+
+#   if (OUTPUT==OUTPUT_XML)
+#       include "textui/XMLOutputter.h"
+#       define OUTPUTTER   (XMLOutputter_outputter())
+#   elif (OUTPUT==OUTPUT_TEXT)
+#       include "textui/TextOutputter.h"
+#       define OUTPUTTER   (TextOutputter_outputter())
+#   elif (OUTPUT==OUTPUT_COMPILER)
+#       include "textui/CompilerOutputter.h"
+#       define OUTPUTTER   (CompilerOutputter_outputter())
+#   endif
+
+#   include "textui/TextUIRunner.h"
+
+#   define TESTS_START()   TextUIRunner_start()
+#   define TESTS_RUN(t)    TextUIRunner_runTest(t)
+#   define TESTS_END()     TextUIRunner_end()
+#else
+#   define TESTS_START()   TestRunner_start()
+#   define TESTS_RUN(t)    TestRunner_runTest(t)
+#   define TESTS_END()     TestRunner_end()
+#endif
+
+#endif


### PR DESCRIPTION
Unittests for e.g. different libraries can be put into
`tests/unittests/tests-XXX`, where `XXX` is your test suite.

If `unittests` is made with `make all` (or any explicit argument), then
all test suites get built. If you use `make tests-XXX tests-YYY …` then
only the test suites `XXX` and `YYY` get built.
