### PR TITLE
unittests: separate test suites from main.c

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -32,5 +32,15 @@ $(UNIT_TESTS): all
 $(UNITTEST_LIBS): $(BINDIR)%.a:
 	"$(MAKE)" -C $(CURDIR)/$*
 
-CFLAGS += $(shell echo $(UNIT_TESTS:tests-%=-DTEST_%_ENABLED) | tr a-z A-Z)
+charEMPTY :=
+charSPACE := $(charEMPTY) $(charEMPTY)
+charCOMMA := ,
+
+ifeq (, $(UNIT_TESTS))
+    CFLAGS += -DNO_TEST_SUITES
+    $(warning There was no test suite specified!)
+else
+    CFLAGS += -DTEST_SUITES='$(subst $(charSPACE),$(charCOMMA),$(UNIT_TESTS:tests-%=%))'
+endif
+
 BASELIBS += $(UNITTEST_LIBS)

--- a/tests/unittests/main.c
+++ b/tests/unittests/main.c
@@ -7,8 +7,17 @@
  */
 
 #include "unittests.h"
+#include "map.h"
 
 #include "lpm.h"
+
+#define UNCURRY(FUN, ARGS) FUN(ARGS)
+#define RUN_TEST_SUITES(...) MAP(RUN_TEST_SUITE, __VA_ARGS__)
+#define RUN_TEST_SUITE(TEST_SUITE) \
+    do { \
+        extern void tests_##TEST_SUITE(void); \
+        tests_##TEST_SUITE(); \
+    } while (0);
 
 int main(void)
 {
@@ -17,13 +26,9 @@ int main(void)
 #endif
 
     TESTS_START();
-
-    /* put test TEST_RUN() calls here: */
-    /*     #ifdef TEST_xxx_ENABLED
-     *         tests_xxx();
-     *     #endif
-     */
-
+#ifndef NO_TEST_SUITES
+    UNCURRY(RUN_TEST_SUITES, TEST_SUITES)
+#endif
     TESTS_END();
 
 #if defined (BOARD_NATIVE) && !defined (OUTPUT)

--- a/tests/unittests/map.h
+++ b/tests/unittests/map.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2012 William Swanson
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the names of the authors or
+ * their institutions shall not be used in advertising or otherwise to
+ * promote the sale, use or other dealings in this Software without
+ * prior written authorization from the authors.
+ */
+
+#ifndef MAP_H_INCLUDED
+#define MAP_H_INCLUDED
+
+#define EVAL0(...) __VA_ARGS__
+#define EVAL1(...) EVAL0 (EVAL0 (EVAL0 (__VA_ARGS__)))
+#define EVAL2(...) EVAL1 (EVAL1 (EVAL1 (__VA_ARGS__)))
+#define EVAL3(...) EVAL2 (EVAL2 (EVAL2 (__VA_ARGS__)))
+#define EVAL4(...) EVAL3 (EVAL3 (EVAL3 (__VA_ARGS__)))
+#define EVAL(...)  EVAL4 (EVAL4 (EVAL4 (__VA_ARGS__)))
+
+#define MAP_END(...)
+#define MAP_OUT
+
+#define MAP_GET_END() 0, MAP_END
+#define MAP_NEXT0(test, next, ...) next MAP_OUT
+#define MAP_NEXT1(test, next) MAP_NEXT0 (test, next, 0)
+#define MAP_NEXT(test, next)  MAP_NEXT1 (MAP_GET_END test, next)
+
+#define MAP0(f, x, peek, ...) f(x) MAP_NEXT (peek, MAP1) (f, peek, __VA_ARGS__)
+#define MAP1(f, x, peek, ...) f(x) MAP_NEXT (peek, MAP0) (f, peek, __VA_ARGS__)
+#define MAP(f, ...) EVAL (MAP1 (f, __VA_ARGS__, (), 0))
+
+#endif


### PR DESCRIPTION
This change removes the need to patch the main.c if you add or remove a
test suite. A test suite in `tests/unittests/tests-XXX` needs to export
the function `void tests_XXX(void)`, which gets called by `main()`.

The `tests-XXX/Makefile` looks like your average module:

```
MODULE = tests-XXX
include $(RIOTBASE)/Makefile.base
```

~~(rebased on #1164)~~
