### PR TITLE
sys/crypo: fix function declarations

### DIFF
--- a/sys/crypto/3des.c
+++ b/sys/crypto/3des.c
@@ -350,7 +350,7 @@ int tripledes_decrypt(cipher_context_t *context, uint8_t *crypt, uint8_t *plain)
     return 1;
 }
 
-uint8_t tripledes_get_preferred_block_size()
+uint8_t tripledes_get_preferred_block_size(void)
 {
     return THREEDES_BLOCK_SIZE;
 }

--- a/sys/crypto/aes.c
+++ b/sys/crypto/aes.c
@@ -1457,7 +1457,7 @@ int aes_decrypt(cipher_context_t *context, uint8_t *cipherBlock,
     return 1;
 }
 
-uint8_t aes_get_preferred_block_size()
+uint8_t aes_get_preferred_block_size(void)
 {
     return AES_BLOCK_SIZE;
 }

--- a/sys/crypto/rc5.c
+++ b/sys/crypto/rc5.c
@@ -186,7 +186,7 @@ int rc5_setup_key(cipher_context_t *context, uint8_t *key, uint8_t keysize)
  *         cipher operates with multiple block sizes, this will pick one
  *         particular size (deterministically).
  */
-uint8_t rc5_get_preferred_block_size()
+uint8_t rc5_get_preferred_block_size(void)
 {
     return BLOCK_SIZE;
 }

--- a/sys/crypto/skipjack.c
+++ b/sys/crypto/skipjack.c
@@ -345,7 +345,7 @@ int skipjack_setup_key(cipher_context_t *context, uint8_t *key, uint8_t keysize)
 }
 
 
-uint8_t skipjack_get_preferred_block_size()
+uint8_t skipjack_get_preferred_block_size(void)
 {
     return BLOCK_SIZE;
 }

--- a/sys/crypto/twofish.c
+++ b/sys/crypto/twofish.c
@@ -753,7 +753,7 @@ int twofish_decrypt(cipher_context_t *context, uint8_t *in, uint8_t *out)
     return 1;
 }
 
-uint8_t twofish_get_preferred_block_size()
+uint8_t twofish_get_preferred_block_size(void)
 {
     return TWOFISH_BLOCK_SIZE;
 }


### PR DESCRIPTION
In #1119 old-style function declarations are exterminated and forbidden.
I missed the functions in `sys/crypto` because they weren't used
throughout the tests/examples before #1124.
