### PR TITLE
native: fixup #1145: function declaration

### DIFF
--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -314,7 +314,7 @@ void errx(int eval, const char *fmt, ...)
     verrx(eval, fmt, argp);
 }
 
-int getpid()
+int getpid(void)
 {
     warnx("not implemented");
     return -1;


### PR DESCRIPTION
Clashes with #1119. Compare #1170. Please speedy-merge.
