### PR TITLE
make: Remove `Makefile.unsupported`

### DIFF
--- a/Makefile.unsupported
+++ b/Makefile.unsupported
@@ -1,7 +1,0 @@
-.PHONY: all clean
-
-all:
-	$(error Project $(PROJECT) currently not supported for $(BOARD))
-
-clean:
-	@true

--- a/tests/test_nativenet/Makefile
+++ b/tests/test_nativenet/Makefile
@@ -1,11 +1,7 @@
-export PROJECT = test_nativenet
+PROJECT = test_nativenet
 include ../Makefile.tests_common
 
 BOARD_WHITELIST := native
-
-ifeq (,$(filter native,$(BOARD)))
-include $(RIOTBASE)/Makefile.unsupported
-else
 
 USEMODULE += nativenet
 USEMODULE += transceiver
@@ -18,5 +14,3 @@ FORCE:
 sender: CFLAGS += -DSENDER
 sender: PROJECT = test_nativenet_sender
 sender: FORCE all
-
-endif


### PR DESCRIPTION
This mechanism was replaced by #535. It was only used in one project.
