### PR TITLE
boards: fix license headers to LGPL

### DIFF
--- a/boards/msb-430h/driver_cc110x.c
+++ b/boards/msb-430h/driver_cc110x.c
@@ -1,21 +1,10 @@
-/* Copyright (C) 2005, 2006, 2007, 2008 by Thomas Hillebrandt and Heiko Will
-
-This file is part of the Micro-mesh SensorWeb Firmware.
-
-Micro-Mesh is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3, or (at your option)
-any later version.
-
-Micro-Mesh is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with Micro-Mesh; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+/*
+ * Copyright (C) 2005, 2006, 2007, 2008 by Thomas Hillebrandt and Heiko Will
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
 
 #include <stdio.h>
 

--- a/boards/msba2-common/board_common_init.c
+++ b/boards/msba2-common/board_common_init.c
@@ -1,28 +1,10 @@
-/******************************************************************************
-Copyright 2008-2009, Freie Universitaet Berlin (FUB). All rights reserved.
-
-These sources were developed at the Freie Universitaet Berlin, Computer Systems
-and Telematics group (http://cst.mi.fu-berlin.de).
--------------------------------------------------------------------------------
-This file is part of RIOT.
-
-RIOT is free software: you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free Software
-Foundation, either version 3 of the License, or (at your option) any later
-version.
-
-RIOT is distributed in the hope that it will be useful, but WITHOUT
-ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with
-RIOT.  If not, see http://www.gnu.org/licenses/ .
---------------------------------------------------------------------------------
-For further information and questions please use the web site
-    http://scatterweb.mi.fu-berlin.de
-and the mailinglist (subscription via web site)
-    scatterweb@lists.spline.inf.fu-berlin.de
-*******************************************************************************/
+/*
+ * Copyright (C) 2008-2009, Freie Universitaet Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
 
 /**
  * @ingroup msba2

--- a/boards/msba2-common/drivers/msba2-ltc4150.c
+++ b/boards/msba2-common/drivers/msba2-ltc4150.c
@@ -1,28 +1,10 @@
-/******************************************************************************
-Copyright 2008-2009, Freie Universitaet Berlin (FUB). All rights reserved.
-
-These sources were developed at the Freie Universitaet Berlin, Computer Systems
-and Telematics group (http://cst.mi.fu-berlin.de).
--------------------------------------------------------------------------------
-This file is part of RIOT.
-
-This program is free software: you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free Software
-Foundation, either version 3 of the License, or (at your option) any later
-version.
-
-RIOT is distributed in the hope that it will be useful, but WITHOUT
-ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with
-this program.  If not, see http://www.gnu.org/licenses/ .
---------------------------------------------------------------------------------
-For further information and questions please use the web site
-	http://scatterweb.mi.fu-berlin.de
-and the mailinglist (subscription via web site)
-	scatterweb@lists.spline.inf.fu-berlin.de
-*******************************************************************************/
+/*
+ * Copyright (C) 2008-2009, Freie Universitaet Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
 
 /**
  * @ingroup		msba2

--- a/boards/msba2-common/drivers/msba2-uart0.c
+++ b/boards/msba2-common/drivers/msba2-uart0.c
@@ -1,28 +1,10 @@
-/******************************************************************************
-Copyright 2008-2009, Freie Universitaet Berlin (FUB). All rights reserved.
-
-These sources were developed at the Freie Universitaet Berlin, Computer Systems
-and Telematics group (http://cst.mi.fu-berlin.de).
--------------------------------------------------------------------------------
-This file is part of RIOT.
-
-This program is free software: you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free Software
-Foundation, either version 3 of the License, or (at your option) any later
-version.
-
-RIOT is distributed in the hope that it will be useful, but WITHOUT
-ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with
-this program.  If not, see http://www.gnu.org/licenses/ .
---------------------------------------------------------------------------------
-For further information and questions please use the web site
-    http://scatterweb.mi.fu-berlin.de
-and the mailinglist (subscription via web site)
-    scatterweb@lists.spline.inf.fu-berlin.de
-*******************************************************************************/
+/*
+ * Copyright (C) 2008-2009, Freie Universitaet Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
 
 /*
  * debug_uart.c: provides initial serial debug output

--- a/boards/msba2/msba2-cc110x.c
+++ b/boards/msba2/msba2-cc110x.c
@@ -1,28 +1,10 @@
-/******************************************************************************
-Copyright 2008, Freie Universitaet Berlin (FUB). All rights reserved.
-
-These sources were developed at the Freie Universitaet Berlin, Computer Systems
-and Telematics group (http://cst.mi.fu-berlin.de).
--------------------------------------------------------------------------------
-This file is part of RIOT.
-
-This program is free software: you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free Software
-Foundation, either version 3 of the License, or (at your option) any later
-version.
-
-RIOT is distributed in the hope that it will be useful, but WITHOUT
-ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with
-this program.  If not, see http://www.gnu.org/licenses/ .
---------------------------------------------------------------------------------
-For further information and questions please use the web site
-	http://scatterweb.mi.fu-berlin.de
-and the mailinglist (subscription via web site)
-	scatterweb@lists.spline.inf.fu-berlin.de
-*******************************************************************************/
+/*
+ * Copyright (C) 2008, Freie Universitaet Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
 
 /**
  * @file

--- a/boards/wsn430-common/wsn430-uart0.c
+++ b/boards/wsn430-common/wsn430-uart0.c
@@ -1,10 +1,11 @@
-  /*
-   * uart0.c - Implementation of the uart.
-   * Copyright (C) 2013 Milan Babel <babel@inf.fu-berlin.de>
-   *
-   * This source code is licensed under the GNU General Public License,
-   * Version 3.  See the file LICENSE for more details.
-   */
+/*
+ * uart0.c - Implementation of the uart.
+ * Copyright (C) 2013 Milan Babel <babel@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
 
 #include <stdio.h>
 #include "board.h"


### PR DESCRIPTION
harmonises license headers in msb-430, msba2-common,
msba2 and wsn430-common in terms of license and formating

fixes #1160
