### PR TITLE
make: print error if make was executed in the root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+ifeq (, $(__RIOTBUILD_FLAG))
+  all: welcome
+	@echo ""
+	@exit 1
+else
+  all:
+	mkdir -p $(BINDIR)
+	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
+endif
+
 DIRS = $(RIOTCPU)/$(CPU) core drivers sys
 
 ifneq (,$(filter embunit,$(USEMODULE)))
@@ -8,12 +18,7 @@ ifneq (,$(filter embunit_textui,$(USEMODULE)))
 	DIRS += tests/unittests/embunit/textui
 endif
 
-
-.PHONY: all clean doc
-
-all:
-	mkdir -p $(BINDIR)
-	@for i in $(DIRS) ; do "$(MAKE)" -C $$i || exit 1; done ;
+.PHONY: all clean doc docclean welcome
 
 clean:
 	@for i in $(DIRS) ; do "$(MAKE)" -C $$i clean || exit 1; done ;
@@ -26,3 +31,14 @@ doc:
 
 docclean:
 	"$(MAKE)" -BC doc/doxygen clean
+
+welcome:
+	@echo "Welcome to RIOT - The friendly OS for IoT!"
+	@echo ""
+	@echo "You executed 'make' from the base directory."
+	@echo "You should run 'make' in your application's directory instead."
+	@echo ""
+	@echo "Please see our Quick Start Guide at:"
+	@echo "    https://github.com/RIOT-OS/RIOT/wiki/Quick-Start-Guide"
+	@echo "Or ask questions on our mailing list:"
+	@echo "    users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)"

--- a/Makefile.base
+++ b/Makefile.base
@@ -1,3 +1,7 @@
+ifeq (, $(__RIOTBUILD_FLAG))
+    $(error You cannot build a module on its own. Use "make" in your application's directory instead.)
+endif
+
 ASMSRC = $(wildcard *.s)
 ASSMSRC = $(wildcard *.S)
 ASMOBJ = $(ASMSRC:%.s=$(BINDIR)$(MODULE)/%.o)

--- a/Makefile.include
+++ b/Makefile.include
@@ -1,3 +1,6 @@
+# Provide a shallow sanity check. You cannot call `make` in the root directory.
+export __RIOTBUILD_FLAG := RIOT
+
 # set undefined variables
 RIOTBASE ?= $(shell dirname "$(lastword $(MAKEFILE_LIST))")
 export RIOTBASE := $(abspath $(RIOTBASE))


### PR DESCRIPTION
Fixes #1104, alternative to #1178.
