### PR TITLE
unittests: fix modulewise unittests/fix OUTPUT macro

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -26,7 +26,7 @@ include $(RIOTBASE)/Makefile.include
 
 UNITTEST_LIBS := $(UNIT_TESTS:%=$(BINDIR)%.a)
 
-all: $(UNITTEST_LIBS)
+$(BINDIR)$(PROJECT).elf: $(BINDIR)$(PROJECT).a $(UNITTEST_LIBS)
 $(UNIT_TESTS): all
 
 $(UNITTEST_LIBS): $(BINDIR)%.a:


### PR DESCRIPTION
The setup before worked if you just targeted `all`, but

``` bash
make clear tests-core
```

or even e.g.

``` base
make OUTPUT=XML clear all
```

are not working.
