### PR TITLE
make: make clean usable together with `-j`

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -106,6 +106,11 @@ USEMODULE_INCLUDES_ = $(shell echo $(USEMODULE_INCLUDES) | tr ' ' '\n' | awk '!a
 
 INCLUDES += $(USEMODULE_INCLUDES_:%=-I%)
 
+# The `clean` needs to be serialized before everything else.
+ifneq (, $(filter clean, $(MAKECMDGOALS)))
+    $(OBJ) $(BASELIBS) $(USEPKG:%=$(RIOTBASE)/pkg/%/Makefile.include): clean
+endif
+
 # include Makefile.includes for packages in $(USEPKG)
 $(RIOTBASE)/pkg/%/Makefile.include::
 	$(AD)"$(MAKE)" -C $(RIOTBASE)/pkg/$* Makefile.include


### PR DESCRIPTION
Not really needed, but it comes without any cost …
