### PR TITLE
pkg/oonf_api: fix conflicting types on msba2

### DIFF
--- a/pkg/oonf_api/0004-fix-conflicting-types.patch
+++ b/pkg/oonf_api/0004-fix-conflicting-types.patch
@@ -1,0 +1,51 @@
+From 67f5a991886c09b652848a97017b4bb6cfcaa7e2 Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benpicco@zedat.fu-berlin.de>
+Date: Sun, 18 May 2014 22:48:40 +0200
+Subject: [PATCH] fix conflicting types
+
+---
+ src-api/rfc5444/rfc5444_reader.c | 10 +++++-----
+ src-api/rfc5444/rfc5444_reader.h |  2 +-
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src-api/rfc5444/rfc5444_reader.c b/src-api/rfc5444/rfc5444_reader.c
+index 290f558..1ad344a 100644
+--- a/src-api/rfc5444/rfc5444_reader.c
++++ b/src-api/rfc5444/rfc5444_reader.c
+@@ -62,15 +62,15 @@ static int _compare_tlvtypes(struct rfc5444_reader_tlvblock_entry *tlv,
+ static uint8_t _rfc5444_get_u8(uint8_t **ptr, uint8_t *end, enum rfc5444_result *result);
+ static uint16_t _rfc5444_get_u16(uint8_t **ptr, uint8_t *end, enum rfc5444_result *result);
+ static void _free_tlvblock(struct rfc5444_reader *parser, struct avl_tree *entries);
+-static int _parse_tlv(struct rfc5444_reader_tlvblock_entry *entry, uint8_t **ptr,
++static enum rfc5444_result _parse_tlv(struct rfc5444_reader_tlvblock_entry *entry, uint8_t **ptr,
+     uint8_t *eob, uint8_t addr_count);
+-static int _parse_tlvblock(struct rfc5444_reader *parser,
++static enum rfc5444_result _parse_tlvblock(struct rfc5444_reader *parser,
+     struct avl_tree *tlvblock, uint8_t **ptr, uint8_t *eob, uint8_t addr_count);
+-static int _schedule_tlvblock(struct rfc5444_reader_tlvblock_consumer *consumer,
++static enum rfc5444_result _schedule_tlvblock(struct rfc5444_reader_tlvblock_consumer *consumer,
+     struct rfc5444_reader_tlvblock_context *context, struct avl_tree *entries, uint8_t idx);
+-static int _parse_addrblock(struct rfc5444_reader_addrblock_entry *addr_entry,
++static enum rfc5444_result _parse_addrblock(struct rfc5444_reader_addrblock_entry *addr_entry,
+     struct rfc5444_reader_tlvblock_context *tlv_context, uint8_t **ptr, uint8_t *eob);
+-static int _handle_message(struct rfc5444_reader *parser,
++static enum rfc5444_result _handle_message(struct rfc5444_reader *parser,
+     struct rfc5444_reader_tlvblock_context *tlv_context, uint8_t **ptr, uint8_t *eob);
+ static struct rfc5444_reader_tlvblock_consumer *_add_consumer(
+     struct rfc5444_reader_tlvblock_consumer *, struct avl_tree *consumer_tree,
+diff --git a/src-api/rfc5444/rfc5444_reader.h b/src-api/rfc5444/rfc5444_reader.h
+index 6962741..c1ca7f6 100644
+--- a/src-api/rfc5444/rfc5444_reader.h
++++ b/src-api/rfc5444/rfc5444_reader.h
+@@ -309,7 +309,7 @@ EXPORT void rfc5444_reader_remove_packet_consumer(
+ EXPORT void rfc5444_reader_remove_message_consumer(
+     struct rfc5444_reader *, struct rfc5444_reader_tlvblock_consumer *);
+ 
+-EXPORT int rfc5444_reader_handle_packet(
++EXPORT enum rfc5444_result rfc5444_reader_handle_packet(
+     struct rfc5444_reader *parser, uint8_t *buffer, size_t length);
+ 
+ EXPORT uint8_t *rfc5444_reader_get_tlv_value(
+-- 
+1.9.1
+


### PR DESCRIPTION
oonf_api fails to compile for the msba2 target 

```
arm-none-eabi-gcc -DRIOT -DENABLE_NAME -DBOARD_MSBA2 -DINIT_ON_START -DENABLE_LEDS -DBOARD_MSBA2 -DCPU_LPC2387 -DMODULE_ARM_COMMON -DMODULE_AUTO_INIT -DMODULE_CC110X_NG -DMODULE_CC110X_SPI -DMODULE_CONFIG -DMODULE_CORE -DMODULE_CPU -DMODULE_DESTINY -DMODULE_GPIOINT -DMODULE_IEEE802154 -DMODULE_LIB -DMODULE_LPC_COMMON -DMODULE_NET_HELP -DMODULE_NET_IF -DMODULE_OLSR2 -DMODULE_OONF_API -DMODULE_OONF_COMMON -DMODULE_OONF_RFC5444 -DMODULE_POSIX -DMODULE_PROTOCOL_MULTIPLEX -DMODULE_PS -DMODULE_RANDOM -DMODULE_RTC -DMODULE_SHELL -DMODULE_SHELL_COMMANDS -DMODULE_SIXLOWPAN -DMODULE_SYS -DMODULE_TIMEX -DMODULE_TRANSCEIVER -DMODULE_UART0 -DMODULE_VTIMER -O2 -Wall -Wstrict-prototypes -mcpu=arm7tdmi-s -gdwarf-2 -std=gnu99 -fno-delete-null-pointer-checks -O2 -Wall -Wstrict-prototypes -mcpu=arm7tdmi-s -gdwarf-2 -DVERSION=\"v0.3.0-3-gf2be\" -I/home/ludwig/RIOT/core/include -I/home/ludwig/RIOT/drivers/include -I/home/ludwig/RIOT/sys/include -I/home/ludwig/RIOT/boards/msba2/include -I/home/ludwig/RIOT/boards/msba2-common/include -I/home/ludwig/RIOT/boards/msba2-common/drivers/include -I/home/ludwig/RIOT/cpu/lpc2387/include -I/home/ludwig/RIOT/cpu/arm_common/include/ -I/home/ludwig/RIOT/cpu/lpc_common/include -I/home/ludwig/RIOT/sys/net/include -I/home/ludwig/RIOT/drivers/cc110x -I/home/ludwig/RIOT/drivers/cc110x_ng/include -I/home/ludwig/RIOT/sys/posix/include -I /home/ludwig/RIOT/pkg/oonf_api/oonf_api/src-api -I/home/ludwig/RIOT/boards/msba2/include -I/home/ludwig/RIOT/boards/msba2-common/include -I/home/ludwig/RIOT/boards/msba2-common/drivers/include -I/home/ludwig/RIOT/sys/include -I/home/ludwig/RIOT/sys/net/include -I/home/ludwig/RIOT/sys/posix/include -I/home/ludwig/RIOT/sys/posix/pnet/include -c rfc5444_reader.c -o /home/ludwig/RIOT/examples/olsr2/bin/msba2/oonf_rfc5444/rfc5444_reader.o
rfc5444_reader.c:129:1: error: conflicting types for 'rfc5444_reader_handle_packet'
 rfc5444_reader_handle_packet(struct rfc5444_reader *parser, uint8_t *buffer, size_t length) {
 ^
In file included from rfc5444_reader.c:48:0:
/home/ludwig/RIOT/pkg/oonf_api/oonf_api/src-api/rfc5444/rfc5444_reader.h:312:12: note: previous declaration of 'rfc5444_reader_handle_packet' was here
 EXPORT int rfc5444_reader_handle_packet(
            ^
```

Always use the `enum rfc5444_result` type to fix that.
