### PR TITLE
native: set _native_pid correctly in daemon mode

### DIFF
--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -146,6 +146,9 @@ void daemonize(void)
         real_printf("RIOT pid: %d\n", _native_pid);
         exit(EXIT_SUCCESS);
     }
+    else {
+        _native_pid = real_getpid();
+    }
 }
 
 void usage_exit(void)


### PR DESCRIPTION
This fixes a bug that leads to all unix sockets being created as
`/tmp/riot.tty.0`.

This is cherry picked from #1214
