### PR TITLE
boards: cpu: cleanup licenses to fix #392

### DIFF
--- a/boards/msba2-common/tools/src/boot_23xx.c
+++ b/boards/msba2-common/tools/src/boot_23xx.c
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2014 Paul Stoffregen <paul@pjrc.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
 /* automatically generated from boot_23xx.armasm */
 #include "boot_23xx.h"
 const unsigned int boot_23xx[] = {

--- a/boards/msba2-common/tools/src/boot_2xxx.c
+++ b/boards/msba2-common/tools/src/boot_2xxx.c
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2014 Paul Stoffregen <paul@pjrc.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
 /* automatically generated from boot_2xxx.armasm */
 #include "boot_2xxx.h"
 const unsigned int boot_2xxx[] = {

--- a/boards/msba2-common/tools/src/control_2xxx.c
+++ b/boards/msba2-common/tools/src/control_2xxx.c
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2014 Paul Stoffregen <paul@pjrc.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
 #include "control_2xxx.h"
 
 #include <stdio.h>

--- a/cpu/arm_common/atomic.s
+++ b/cpu/arm_common/atomic.s
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
 /* GCC ARM assembler */
 
   .text

--- a/cpu/arm_common/common.s
+++ b/cpu/arm_common/common.s
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
   /* GCC ARM assembler */
 
   .text

--- a/cpu/lpc2387/asmfunc.s
+++ b/cpu/lpc2387/asmfunc.s
@@ -1,3 +1,11 @@
+@
+@ Copyright (C) 2014 Freie Universität Berlin
+@
+@ This file is subject to the terms and conditions of the GNU Lesser General
+@ Public License. See the file LICENSE in the top level directory for more
+@ details.
+@
+
 @-----------------------------------------------------------@
 @ Fast Block Copy (declared in diskio.h)
 @-----------------------------------------------------------@

--- a/cpu/lpc2387/startup.s
+++ b/cpu/lpc2387/startup.s
@@ -1,6 +1,14 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
 /* ***************************************************************************************************************
 
-	crt.s						STARTUP  ASSEMBLY  CODE
+	startup.s						STARTUP  ASSEMBLY  CODE
 								-----------------------
 
 


### PR DESCRIPTION
Adds licenses to the following files:

``` bash
boards/msba2-common/tools/src/control_2xxx.c
cpu/arm_common/atomic.s
cpu/arm_common/common.s
cpu/lpc2387/asmfunc.s
cpu/lpc2387/startup.s
```

The remaining files with "unknown" license delivered by #1181 seem to be generated automatically.

``` bash
boards/msba2-common/tools/src/boot_23xx.c
boards/msba2-common/tools/src/boot_2xxx.c
```

Does anybody know about the original authors or is FU Berlin ok?
