### PR TITLE
unittests: Force execution of $(UNITTEST_LIBS) build target

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -32,7 +32,9 @@ UNITTEST_LIBS := $(UNIT_TESTS:%=$(BINDIR)%.a)
 all: $(UNITTEST_LIBS)
 $(UNIT_TESTS): all
 
-$(UNITTEST_LIBS): $(BINDIR)%.a:
+.FORCE:
+
+$(UNITTEST_LIBS): $(BINDIR)%.a: .FORCE
 	"$(MAKE)" -C $(CURDIR)/$*
 
 charEMPTY :=


### PR DESCRIPTION
Otherwise one always have to clean, when one write new tests.
