### PR TITLE
Add a missing constant in 'radio_tx_status_t' enum

### DIFF
--- a/drivers/include/radio_driver.h
+++ b/drivers/include/radio_driver.h
@@ -76,6 +76,9 @@ typedef enum {
         before @c transmit() ) */
     RADIO_TX_UNDERFLOW,
 
+    /** Transmission cannot start because radio medium is already busy */
+    RADIO_TX_MEDIUM_BUSY,
+
     /** Transmission failed because of collision on radio medium */
     RADIO_TX_COLLISION,
 


### PR DESCRIPTION
The new constant indicates that radio medium is busy, thus preventing a transmission to occur.
