### PR TITLE
Fix check of stack size in debug

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -39,7 +39,7 @@
 #include "cpu-conf.h"
 #define DEBUG_PRINT(...) \
     do { \
-        if ((sched_active_thread == NULL) || (sched_active_thread->stack_size > KERNEL_CONF_STACKSIZE_PRINTF)) { \
+        if ((sched_active_thread == NULL) || (sched_active_thread->stack_size >= KERNEL_CONF_STACKSIZE_PRINTF)) { \
             printf(__VA_ARGS__); \
         } \
         else { \


### PR DESCRIPTION
This behavior should be more intuitive. Otherwise Threads need to have KERNEL_CONF_STACKSIZE_PRINTF + 1 to run properly.
