### PR TITLE
x86: fix download script for OSX

### DIFF
--- a/boards/x86-multiboot-common/Makefile.include
+++ b/boards/x86-multiboot-common/Makefile.include
@@ -2,13 +2,23 @@ ifeq (, $(NEWLIB_BASE))
   NEWLIB_BASE := $(RIOTBASE)/toolchain/x86/i586-none-elf
 
   ifneq (0, $(shell test -e "$(NEWLIB_BASE)/lib/libc.a" && echo $$?))
-    NEWLIB_PRECOMPILED_NAME := i586-newlib_2.1.0_tlsf.txz
+    NEWLIB_PRECOMPILED_NAME := i586-newlib_2.1.0_tlsf.tar.bz2
     NEWLIB_PRECOMPILED := http://download.riot-os.org/$(NEWLIB_PRECOMPILED_NAME)
 
     $(warning "Precompiled newlib is missing in $(NEWLIB_BASE)")
     $(warning "Downloading from $(NEWLIB_PRECOMPILED)")
 
-    $(shell cd $(RIOTBASE) && wget -qO- "$(NEWLIB_PRECOMPILED)" | tar xJ)
+    ifeq (0, $(shell which wget 2>&1 > /dev/null ; echo $$?))
+      DOWNLOAD_TO_STDOUT := $(shell which wget) -qO-
+    else
+      ifeq (0, $(shell which curl 2>&1 > /dev/null ; echo $$?))
+        DOWNLOAD_TO_STDOUT := $(shell which curl) -s
+      else
+        $(error "Neither wget nor curl is installed!")
+      endif
+    endif
+
+    $(shell cd $(RIOTBASE) && $(DOWNLOAD_TO_STDOUT) "$(NEWLIB_PRECOMPILED)" | tar xj)
   endif
 endif
 

--- a/pkg/tlsf/Makefile
+++ b/pkg/tlsf/Makefile
@@ -3,6 +3,18 @@ PKG_VERSION = 3.0
 PKG_FILE = tlsf-$(PKG_VERSION).zip
 PKG_URL = http://tlsf.baisoku.org/$(PKG_FILE)
 
+ifeq (, $(DOWNLOAD_TO))
+  ifeq (0, $(shell which wget 2>&1 > /dev/null ; echo $$?))
+    DOWNLOAD_TO := $(shell which wget) -nv -c -O
+  else
+    ifeq (0, $(shell which curl 2>&1 > /dev/null ; echo $$?))
+      DOWNLOAD_TO := $(shell which curl) -s -o
+    else
+      $(error "Neither wget nor curl is installed.")
+    endif
+  endif
+endif
+
 ifeq (, $(UNZIP))
   ifeq (0, $(shell which unzip 2>&1 > /dev/null ; echo $$?))
     UNZIP := $(shell which unzip)
@@ -29,7 +41,7 @@ $(BINDIR)$(PKG_NAME)-src/Makefile: $(CURDIR)/$(PKG_FILE) $(CURDIR)/patch.txt
 	$(AD)cd $(@D) && patch --binary -p0 -N -i $(CURDIR)/patch.txt
 
 $(CURDIR)/$(PKG_FILE):
-	$(AD)wget -nv -c -O $@ $(PKG_URL)
+	$(AD)$(DOWNLOAD_TO) $@ $(PKG_URL)
 
 clean::
 	rm -rf $(BINDIR)$(PKG_NAME)-src/


### PR DESCRIPTION
Mac OSX does not have `wget`, but `curl`.
It does not understand `tar xJ`, but `tar xj`.
