### PR TITLE
Move struct tm utility to examples

### DIFF
--- a/examples/struct_tm_utility/Makefile
+++ b/examples/struct_tm_utility/Makefile
@@ -1,4 +1,4 @@
-PROJECT = test_struct_tm_utility
+APPLICATION = struct_tm_utility
 include ../Makefile.tests_common
 
 DISABLE_MODULE += auto_init

--- a/examples/struct_tm_utility/main.c
+++ b/examples/struct_tm_utility/main.c
@@ -2,7 +2,7 @@
  * @ingroup  tests
  * @{
  * @file
- * @brief    Test the `struct tm` helpers in "tm.h" of the module "timex".
+ * @brief    Utility for the `struct tm` helpers in "tm.h" of the module "timex".
  * @author   René Kijewski <rene.kijewski@fu-berlin.de>
  * @}
  */


### PR DESCRIPTION
This PR moves the shell application `test_struct_tm_utility` to examples (and renames it to `struct_tm_utility`) and uses the new macros for the application.
