### PR TITLE
pnet: accept should return a new generated file descriptor

### DIFF
--- a/sys/posix/pnet/sys_socket.c
+++ b/sys/posix/pnet/sys_socket.c
@@ -61,7 +61,8 @@ int accept(int socket, struct sockaddr *restrict address,
         return -1;
     }
 
-    return res;
+    return fd_new(res, flagless_recv, flagless_send,
+                  destiny_socket_close);
 }
 
 int bind(int socket, const struct sockaddr *address, socklen_t address_len)


### PR DESCRIPTION
From man page:
On success, these system calls return a nonnegative integer that is a
descriptor for the accepted socket. On error, -1 is returned, and errno
is set appropriately.
