### PR TITLE
destiny: memcpying with the wrong length

### DIFF
--- a/sys/net/transport_layer/destiny/socket.c
+++ b/sys/net/transport_layer/destiny/socket.c
@@ -260,7 +260,9 @@ int bind_tcp_socket(int s, sockaddr6_t *name, int namelen, uint8_t pid)
 {
     int i;
 
-    if (!exists_socket(s)) {
+    socket_internal_t *sock = get_socket(s);
+
+    if (!sock) {
         return -1;
     }
 
@@ -271,9 +273,9 @@ int bind_tcp_socket(int s, sockaddr6_t *name, int namelen, uint8_t pid)
         }
     }
 
-    memcpy(&get_socket(s)->socket_values.local_address, name, namelen);
-    get_socket(s)->recv_pid = pid;
-    get_socket(s)->socket_values.tcp_control.rto = TCP_INITIAL_ACK_TIMEOUT;
+    sock->socket_values.local_address = *name;
+    sock->socket_values.tcp_control.rto = TCP_INITIAL_ACK_TIMEOUT;
+    sock->recv_pid = pid;
     return 0;
 }
 


### PR DESCRIPTION
when calling posix bind, the user will probably pass a
struct sockaddr_in6 and its corresponding sizeof() return value.
However, in further steps this struct is cast to a sockaddr6_t.
This cast by itself is not dangerous, since the former struct
encapsulates the sockaddr6_t plus an additional field.
But in later steps, memcpy is used with the former sizeof() value,
which was passed to the posix bind call.

Due to different sizes of struct sockaddr_in6 and sockaddr6_t,
the port value of the foreign address field gets overwritten.
But TCP expects the foreign address to be completely zero
in order to handle further connections with this socket.
