### PR TITLE
core: fix variable name for sched_pidlist

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -117,7 +117,7 @@ typedef struct {
 /**
  *  Thread statistics table
  */
-extern schedstat pidlist[MAXTHREADS];
+extern schedstat sched_pidlist[MAXTHREADS];
 
 /**
  *  @brief  Register a callback that will be called on every scheduler run


### PR DESCRIPTION
Something was overlooked in #1000.
