### PR TITLE
wireshark: fix dissector plugin and expand documentation

### DIFF
--- a/dist/tools/wireshark_dissector/README.md
+++ b/dist/tools/wireshark_dissector/README.md
@@ -1,5 +1,5 @@
-# RIOT native wireshark dissector
-This allows wireshark to parse packets send over TAP by RIOT's native.
+# RIOT nativenet wireshark dissector
+This allows wireshark to parse packets sent over TAP by RIOT's native port.
 
 ## Installation
 Just copy the script ``riot.lua`` to ``$HOME/.wireshark/plugins`` and restart
@@ -13,6 +13,9 @@ Ensure that dumpcat is available for you as non-superusers:
 sudo dpkg-reconfigure wireshark-common
 sudo usermod -a -G wireshark $USER
 ```
+
+### Fedora (and possibly others)
+The 'wireshark-devel' package must be installed to run the plugin.
 
 ## Configuration
 Depending on what you want to send over the native TAP you might want to change

--- a/dist/tools/wireshark_dissector/riot.lua
+++ b/dist/tools/wireshark_dissector/riot.lua
@@ -42,7 +42,10 @@ do
         riot_tree:add(f_length, buf(0, 2))
         riot_tree:add(f_dst, buf(2, 2))
         riot_tree:add(f_src, buf(4, 2))
-        riot_tree:add(f_pad, buf(packet_len + 6))
+
+        -- to show the padding for small packets uncomment the
+        -- following line and append "f_pad" to p_riot.fields above.
+        -- riot_tree:add(f_pad, buf(packet_len + 6))
 
         next_dis:call(buf(6, packet_len):tvb(), pkt, root)
 


### PR DESCRIPTION
The wireshark dissector plugin currently fails with a "Lua Error" when
trying to parse nativenet packets. This patch restores working behaviour
by commenting the offending line introduced in 1258675, which intention
was to account for padding in small packets. It further adds a comment
on how to edit the plugin for the case padding information is required.

The README.md now contains a usage note for configuration on fedora
which might also be helpful for users of other distributions.
