### PR TITLE
destiny: wireshark compliant tcp flags

### DIFF
--- a/sys/net/transport_layer/destiny/tcp.h
+++ b/sys/net/transport_layer/destiny/tcp.h
@@ -27,13 +27,17 @@
 #define TCP_TS_OPTION           (0x08)        /* Timestamp */
 
 enum tcp_flags {
-    TCP_ACK                    = 0x08,
-    TCP_URG_PSH                = 0x14,
-    TCP_RST                    = 0x20,
-    TCP_SYN                    = 0x40,
-    TCP_SYN_ACK                = 0x48,
-    TCP_FIN                    = 0x80,
-    TCP_FIN_ACK                = 0x88
+    TCP_FIN                    = (1 << 0),
+    TCP_SYN                    = (1 << 1),
+    TCP_RST                    = (1 << 2),
+    TCP_PSH                    = (1 << 3),
+    TCP_ACK                    = (1 << 4),
+    TCP_URG                    = (1 << 5),
+    TCP_ECE                    = (1 << 6),
+    TCP_CWR                    = (1 << 7),
+    TCP_SYN_ACK                = (TCP_SYN | TCP_ACK),
+    TCP_URG_PSH                = (TCP_URG | TCP_PSH),
+    TCP_FIN_ACK                = (TCP_FIN | TCP_ACK)
 };
 
 enum tcp_states {


### PR DESCRIPTION
This enum is also used to set the tcp flags within a tcp header.
With the current values in this enum, wireshark is not able to
recognize the tcp segments as their actual tcp type,
and thus odd messages in wireshark appear.
