### PR TITLE
vtimer: unify and enhance interface

### DIFF
--- a/drivers/cc110x/cc1100_phy.c
+++ b/drivers/cc110x/cc1100_phy.c
@@ -184,7 +184,7 @@ void cc1100_phy_init(void)
         cc1100_watch_dog_period = timex_set(CC1100_WATCHDOG_PERIOD, 0);
 
         if (timex_cmp(cc1100_watch_dog_period, timex_set(0, 0)) != 0) {
-            vtimer_set_msg(&cc1100_watch_dog, cc1100_watch_dog_period, cc1100_event_handler_pid, NULL);
+            vtimer_set_msg(&cc1100_watch_dog, cc1100_watch_dog_period, VTIMER_RELATIVE, cc1100_event_handler_pid, NULL);
         }
     }
 }
@@ -684,7 +684,7 @@ static void *cc1100_event_handler_function(void *arg)
 
         if (rx_buffer_size == 0) {
             if (timex_uint64(cc1100_watch_dog_period) != 0) {
-                vtimer_set_msg(&cc1100_watch_dog, cc1100_watch_dog_period,
+                vtimer_set_msg(&cc1100_watch_dog, cc1100_watch_dog_period, VTIMER_RELATIVE,
                                cc1100_event_handler_pid, NULL);
             }
 

--- a/sys/include/vtimer.h
+++ b/sys/include/vtimer.h
@@ -27,24 +27,41 @@
 
 #define MSG_TIMER 12345
 
+struct vtimer_t;
+
 /**
- * A vtimer object.
- *
- * This structure is used for declaring a vtimer. This should not be used by programmers, use the vtimer_set_*-functions instead.
- *
- * \hideinitializer
+ * @brief           Prototype of a vtimer callback function.
+ * @param[in]       The calling vtimer.
+ */
+typedef void (*vtimer_action_t)(struct vtimer_t *timer);
+
+/**
+ * @brief           A vtimer token.  The structure is used for setting a vtimer.
+ * @details         This should not be used by programmers directly, use the vtimer_set_*-functions instead.
+ * @note            The token remains the callers responsibility until the event fired.
+ *                  If you declare a vtimer token on the stack, then you need to call vtimer_remove(),
+ *                  if the event did not fire yet.
+ * @hideinitializer
  */
 typedef struct vtimer_t {
     priority_queue_node_t priority_queue_entry;
     timex_t absolute;
-    void (*action)(struct vtimer_t *timer);
+    vtimer_action_t action;
     void *arg;
     kernel_pid_t pid;
 } vtimer_t;
 
 /**
- * @brief   Current system time
- * @return  Time as timex_t since system boot
+ * @brief           Values to tell if a `timex_t timestamp` is a relative or absolute timestamp.
+ */
+typedef enum vtimer_absolute {
+    VTIMER_RELATIVE, /**< The timestamp is relative to the current wallclock time. */
+    VTIMER_ABSOLUTE, /**< The timestamp is an absolute value. Epoch is vtimer_now(). */
+} vtimer_absolute_t;
+
+/**
+ * @brief           The epoch of the vtimer.
+ * @param[out]      out   Time since system boot / vtimer initialization.
  */
 void vtimer_now(timex_t *out);
 
@@ -55,66 +72,111 @@ void vtimer_now(timex_t *out);
 void vtimer_gettimeofday(struct timeval *tp);
 
 /**
- * @brief   Returns the current time in broken down format
- * @details This function only fills the fields `tm_sec`, `tm_min` and `tm_hour`.
- *          Use tm_fill_derived_values() to fill the other fields.
- * @param[out]  localt      Pointer to structure to receive time
+ * @brief           Returns the current time in broken down format
+ * @details         This function only fills the fields `tm_sec`, `tm_min` and `tm_hour`.
+ *                  Use tm_fill_derived_values() to fill the other fields.
+ * @param[out]      localt   Pointer to structure to receive time
  */
 void vtimer_get_localtime(struct tm *localt);
 
 /**
- * @brief   Initializes the vtimer subsystem. To be called once at system initialization. Will be initialized by auto_init.
- *
- * @return  always 0
+ * @brief           Initializes the vtimer subsystem.
+ * @details         To be called once at system initialization. Will be initialized by auto_init.
+ * @return          always 0
  */
 int vtimer_init(void);
 
 /**
- * @brief   will cause the calling thread to be suspended from excecution until the number of microseconds has elapsed
- * @param[in]   us          number of microseconds
- * @return      0 on success, < 0 on error
+ * @brief           Let the current thread sleep for a given amount of microseconds.
+ * @note            You must not call this function in a ISR.
+ * @note            You must call this function with interrupts enabled.
+ * @param[in]       us   Number of microseconds to sleep.
+ * @returns         @arg `= 0`, if the sleeping was successful.
+ *                  @arg `> 0`, if the thread was woken up spuriously.
+ *                  @arg `< 0`, if the vtimer refused to handle this request.
  */
 int vtimer_usleep(uint32_t us);
 
 /**
- * @brief   will cause the calling thread to be suspended from excecution until the time specified by time has elapsed
- * @param[in]   time    timex_t with time to suspend execution
- * @return      0 on success, < 0 on error
+ * @brief           Let the current thread sleep until a given timestamp.
+ * @note            You must not call this function in a ISR.
+ *                  You must call this function with interrupts enabled.
+ * @param[in]       timestamp   Relative or absolute timestamp when to wake up.
+ * @param[in]       absolute    Whether the timestamp is a relative or an absolute value.
+ * @returns         @arg `= 0`, if the sleeping was successful.
+ *                  @arg `> 0`, if the thread was woken up spuriously.
+ *                  @arg `< 0`, if the vtimer refused to handle this request.
  */
-int vtimer_sleep(timex_t time);
+int vtimer_sleep(timex_t timestamp, vtimer_absolute_t absolute);
 
 /**
- * @brief   set a vtimer with msg event handler
- * @param[in]   t           pointer to preinitialised vtimer_t
- * @param[in]   interval    vtimer timex_t interval
- * @param[in]   pid         process id
- * @param[in]   ptr         message value
- * @return      0 on success, < 0 on error
+ * @brief           Schedule a vtimer callback.
+ * @note            The callback will happen inside the ISR.
+ * @details         This function should be strictly avoided in application code.
+ *                  This function is used by `vtimer_set_…()`, call use functions instead.
+ * @param[in,out]   t           vtimer token, keeping it remains the callers responsibility.
+ * @param[in]       timestamp   Relative or absolute timestamp when to send the message.
+ * @param[in]       absolute    Whether the timestamp is a relative or an absolute value.
+ * @param[in]       pid         New value for `t->pid`.
+ * @param[in]       ptr         New value for `t->arg`.
+ * @param[in]       callback    Function to call once the interval has elapsed.
+ * @returns         @arg `= 0`, if the timer was scheduled successfully.
+ *                  @arg `!= 0`, otherwise.
  */
-int vtimer_set_msg(vtimer_t *t, timex_t interval, kernel_pid_t pid, void *ptr);
+int __vtimer_set_callback(vtimer_t *t, timex_t timestamp, vtimer_absolute_t absolute,
+                          kernel_pid_t pid, void *ptr, vtimer_action_t callback);
 
 /**
- * @brief   set a vtimer with wakeup event
- * @param[in]   t           pointer to preinitialised vtimer_t
- * @param[in]   pid         process id
- * @return      0 on success, < 0 on error
+ * @brief           Send a message to a thread after a given timestamp.
+ * @details         You may call this function in an ISR and/or with interrupts disabled.
+ * @details         The target thread will receive a message with `msg.type = MSG_TIMER` and `msg.content.ptr = arg`.
+ * @param[in,out]   t           vtimer token, keeping it remains the callers responsibility.
+ * @param[in]       timestamp   Relative or absolute timestamp when to send the message.
+ * @param[in]       absolute    Whether the timestamp is a relative or an absolute value.
+ * @param[in]       pid         Target thread for the message.
+ * @param[in]       ptr         The value for `msg.content.ptr`.
+ * @returns         `0` on success, `!= 0` on error.
  */
-int vtimer_set_wakeup(vtimer_t *t, timex_t interval, kernel_pid_t pid);
+static inline int vtimer_set_msg(vtimer_t *t, timex_t timestamp, vtimer_absolute_t absolute, kernel_pid_t pid, void *ptr)
+{
+    extern void __vtimer_callback_msg(vtimer_t *timer);
+    return __vtimer_set_callback(t, timestamp, absolute, pid, ptr, __vtimer_callback_msg);
+}
 
 /**
- * @brief   remove a vtimer
- * @param[in]   t           pointer to preinitialised vtimer_t
- * @return      0 on success, < 0 on error
+ * @brief           Wake up a thread after a given timestamp.
+ * @details         You may call this function in an ISR and/or with interrupts disabled.
+ * @param[in,out]   t           vtimer token, keeping it remains the callers responsibility.
+ * @param[in]       timestamp   Relative or absolute timestamp when to send the message.
+ * @param[in]       absolute    Whether the timestamp is a relative or an absolute value.
+ * @param[in]       pid         Target thread to wake up, e.g. the current thread is `sched_active_pid`.
+ * @returns         `0` on success, `!= 0` on error.
  */
-int vtimer_remove(vtimer_t *t);
+static inline int vtimer_set_wakeup(vtimer_t *t, timex_t timestamp, vtimer_absolute_t absolute, kernel_pid_t pid, int *spurious)
+{
+    extern void __vtimer_callback_wakeup(vtimer_t *timer);
+    return __vtimer_set_callback(t, timestamp, absolute, pid, spurious, __vtimer_callback_wakeup);
+}
 
 /**
- * @brief   receive a message but return in case of timeout time is passed by without a new message
- * @param[out]   m           pointer to a msg_t which will be filled in case of no timeout
- * @param[in]    timeout     timex_t containing the relative time to fire the timeout
- * @return       < 0 on error, other value otherwise
+ * @brief           Unschedule a vtimer event.
+ * @param[in,out]   t   Pointer to the vtimer token that was previously supplied to e.g. vtimer_set_msg().
  */
-int vtimer_msg_receive_timeout(msg_t *m, timex_t timeout);
+void vtimer_remove(vtimer_t *t);
+
+/**
+ * @brief           Try to receive a message until a given timestamp.
+ * @note            You must not call this function in a ISR.
+ *                  You must call this function with interrupts enabled.
+ * @details         See msg_receive() for further information about messaging.
+ * @param[out]      The received message. The result is random if no message was received in time.
+ * @param[in]       timestamp   Relative or absolute timestamp when to send the message.
+ * @param[in]       absolute    Whether the timestamp is a relative or an absolute value.
+ * @return          @arg `= 0` if a message was received.
+ *                  @arg `> 0` on timeout.
+ *                  @arg `< 0` on error.
+ */
+int vtimer_msg_receive_timeout(msg_t *m, timex_t timestamp, vtimer_absolute_t absolute);
 
 #if ENABLE_DEBUG
 

--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -1645,7 +1645,7 @@ static void *lowpan_context_auto_remove(void *arg)
     int8_t to_remove_size;
 
     while (1) {
-        vtimer_sleep(minute);
+        vtimer_sleep(minute, VTIMER_RELATIVE);
         to_remove_size = 0;
         mutex_lock(&lowpan_context_mutex);
 

--- a/sys/net/routing/rpl/trickle.c
+++ b/sys/net/routing/rpl/trickle.c
@@ -73,8 +73,8 @@ void reset_trickletimer(void)
     timex_normalize(&I_time);
     vtimer_remove(&trickle_t_timer);
     vtimer_remove(&trickle_I_timer);
-    vtimer_set_wakeup(&trickle_t_timer, t_time, timer_over_pid);
-    vtimer_set_wakeup(&trickle_I_timer, I_time, interval_over_pid);
+    vtimer_set_wakeup(&trickle_t_timer, t_time, VTIMER_RELATIVE, timer_over_pid, NULL);
+    vtimer_set_wakeup(&trickle_I_timer, I_time, VTIMER_RELATIVE, interval_over_pid, NULL);
 
 }
 
@@ -116,8 +116,8 @@ void start_trickle(uint8_t DIOIntMin, uint8_t DIOIntDoubl,
     timex_normalize(&I_time);
     vtimer_remove(&trickle_t_timer);
     vtimer_remove(&trickle_I_timer);
-    vtimer_set_wakeup(&trickle_t_timer, t_time, timer_over_pid);
-    vtimer_set_wakeup(&trickle_I_timer, I_time, interval_over_pid);
+    vtimer_set_wakeup(&trickle_t_timer, t_time, VTIMER_RELATIVE, timer_over_pid, NULL);
+    vtimer_set_wakeup(&trickle_I_timer, I_time, VTIMER_RELATIVE, interval_over_pid, NULL);
 }
 
 void trickle_increment_counter(void)
@@ -178,13 +178,13 @@ static void *trickle_interval_over(void *arg)
 
         vtimer_remove(&trickle_t_timer);
 
-        if (vtimer_set_wakeup(&trickle_t_timer, t_time, timer_over_pid) != 0) {
+        if (vtimer_set_wakeup(&trickle_t_timer, t_time, VTIMER_RELATIVE, timer_over_pid, NULL) != 0) {
             puts("[ERROR] setting Wakeup");
         }
 
         vtimer_remove(&trickle_I_timer);
 
-        if (vtimer_set_wakeup(&trickle_I_timer, I_time, interval_over_pid) != 0) {
+        if (vtimer_set_wakeup(&trickle_I_timer, I_time, VTIMER_RELATIVE, interval_over_pid, NULL) != 0) {
             puts("[ERROR] setting Wakeup");
         }
     }
@@ -198,7 +198,7 @@ void delay_dao(void)
     dao_counter = 0;
     ack_received = false;
     vtimer_remove(&dao_timer);
-    vtimer_set_wakeup(&dao_timer, dao_time, dao_delay_over_pid);
+    vtimer_set_wakeup(&dao_timer, dao_time, VTIMER_RELATIVE, dao_delay_over_pid, NULL);
 }
 
 /* This function is used for regular update of the routes. The Timer can be overwritten, as the normal delay_dao function gets called */
@@ -208,7 +208,7 @@ void long_delay_dao(void)
     dao_counter = 0;
     ack_received = false;
     vtimer_remove(&dao_timer);
-    vtimer_set_wakeup(&dao_timer, dao_time, dao_delay_over_pid);
+    vtimer_set_wakeup(&dao_timer, dao_time, VTIMER_RELATIVE, dao_delay_over_pid, NULL);
 }
 
 static void *dao_delay_over(void *arg)
@@ -222,7 +222,7 @@ static void *dao_delay_over(void *arg)
             send_DAO(NULL, 0, true, 0);
             dao_time = timex_set(DEFAULT_WAIT_FOR_DAO_ACK, 0);
             vtimer_remove(&dao_timer);
-            vtimer_set_wakeup(&dao_timer, dao_time, dao_delay_over_pid);
+            vtimer_set_wakeup(&dao_timer, dao_time, VTIMER_RELATIVE, dao_delay_over_pid, NULL);
         }
         else if (ack_received == false) {
             long_delay_dao();

--- a/sys/net/transport_layer/destiny/tcp_timer.c
+++ b/sys/net/transport_layer/destiny/tcp_timer.c
@@ -144,16 +144,10 @@ void *tcp_general_timer(void *arg)
 {
     (void) arg;
 
-    vtimer_t tcp_vtimer;
-    timex_t interval = timex_set(0, TCP_TIMER_RESOLUTION);
-
     while (1) {
         inc_global_variables();
         check_sockets();
 
-        vtimer_set_wakeup(&tcp_vtimer, interval, thread_getpid());
-        thread_sleep();
-
-        vtimer_remove(&tcp_vtimer);
+        vtimer_usleep(TCP_TIMER_RESOLUTION);
     }
 }

--- a/sys/posix/unistd.c
+++ b/sys/posix/unistd.c
@@ -8,7 +8,7 @@
 
 /**
  * @{
- * @file    fd.c
+ * @file    unistd.c
  * @brief   Providing implementation for close for fds defined in fd.h.
  * @author  Martin Lenders <mlenders@inf.fu-berlin.de>
  * @author  Christian Mehlis <mehlis@inf.fu-berlin.de>
@@ -39,17 +39,52 @@ int close(int fildes)
 
 int usleep(useconds_t useconds)
 {
-    timex_t time = timex_set(0, useconds);
-    timex_normalize(&time);
-    vtimer_sleep(time);
-    return 0;
+    if (useconds == 0) {
+        return 0;
+    }
+
+    int result = vtimer_usleep((uint32_t) useconds);
+    if (result == 0) {
+        return 0;
+    }
+    else if (result > 0) {
+        /* The sleep was interrupted. The thread was woken up spuriously. */
+        errno = EINTR;
+        return -1;
+    }
+    else /* if (result < 0) */ {
+        /* The sleep could not be performed. vtimer_set() returned an error value. */
+        errno = EINVAL;
+        return -1;
+    }
 }
 
 unsigned int sleep(unsigned int seconds)
 {
-    timex_t time = timex_set(seconds, 0);
-    vtimer_sleep(time);
-    return 0;
+    if (seconds == 0) {
+        return 0;
+    }
+
+    timex_t now;
+    vtimer_now(&now);
+    timex_t timestamp = timex_set(seconds, 0);
+    timestamp = timex_add(now, timestamp);
+
+    int result = vtimer_sleep(timestamp, VTIMER_ABSOLUTE);
+    if (result == 0) {
+        return 0;
+    }
+    else if (result > 0) {
+        /* The sleep was interrupted. The thread was woken up spuriously. */
+        timex_t now_after;
+        vtimer_now(&now_after);
+        now_after = timex_sub(now_after, now);
+        return now_after.seconds;
+    }
+    else /* if (result < 0) */ {
+        /* The sleep could not be performed. vtimer_set() returned an error value. */
+        return seconds;
+    }
 }
 
 /**

--- a/tests/vtimer_msg/main.c
+++ b/tests/vtimer_msg/main.c
@@ -64,7 +64,7 @@ void *timer_thread(void *arg)
                tmsg->interval.microseconds,
                tmsg->msg);
 
-        if (vtimer_set_msg(&tmsg->timer, tmsg->interval, thread_getpid(), tmsg) != 0) {
+        if (vtimer_set_msg(&tmsg->timer, tmsg->interval, VTIMER_RELATIVE, thread_getpid(), tmsg) != 0) {
             puts("something went wrong");
         }
         else {
@@ -121,7 +121,7 @@ int main(void)
     timex_t sleep = timex_set(1, 0);
 
     while (1) {
-        vtimer_sleep(sleep);
+        vtimer_sleep(sleep, VTIMER_RELATIVE);
         msg_send(&m, pid2, 0);
     }
 }

--- a/tests/vtimer_msg_diff/main.c
+++ b/tests/vtimer_msg_diff/main.c
@@ -87,7 +87,7 @@ void *timer_thread(void *arg)
             printf("WARNING: timer difference %" PRId64 "us exceeds MAXDIFF(%d)!\n", diff, MAXDIFF);
         }
 
-        if (vtimer_set_msg(&tmsg->timer, tmsg->interval, thread_getpid(), tmsg) != 0) {
+        if (vtimer_set_msg(&tmsg->timer, tmsg->interval, thread_getpid(), VTIMER_RELATIVE, tmsg) != 0) {
             puts("something went wrong setting a timer");
         }
 


### PR DESCRIPTION
Currently the vtimer only accepts relative timestamps, even though it
uses absolute timestamps internally. This PR adds the parameter
`vtimer_absolute_t absolute` to every function, which is either
`VTIMER_RELATIVE` or `VTIMER_ABSOLUTE`.

~~A generic `vtimer_set_callback()` function is added, which all other
functions use.~~

`vtimer_sleep()` sleep uses `thread_sleep()` now instead of
`mutex_lock()` to allow spurious wake ups. A parameter `int *spurious`
is added, which is set to 0 if the wake up was not spurious.
