### PR TITLE
destiny: fixed condition for error handling of send_tcp in destiny_socket_send

### DIFF
--- a/sys/net/transport_layer/destiny/socket.c
+++ b/sys/net/transport_layer/destiny/socket.c
@@ -796,7 +796,7 @@ int32_t destiny_socket_send(int s, const void *buf, uint32_t len, int flags)
             current_tcp_socket->tcp_control.send_wnd -= sent_bytes;
 
             if (send_tcp(current_int_tcp_socket, current_tcp_packet,
-                         temp_ipv6_header, 0, sent_bytes) != 1) {
+                         temp_ipv6_header, 0, sent_bytes) < 0) {
                 /* Error while sending tcp data */
                 current_tcp_socket->tcp_control.send_nxt -= sent_bytes;
                 current_tcp_socket->tcp_control.send_wnd += sent_bytes;


### PR DESCRIPTION
send_tcp returns either the length of the sent data,
or -1, if an error was detected.

The current implementation checks for != 1.
This results in executing the error case, although
there was semantically no error returned from send_tcp.
