### PR TITLE
core: added NAKED attribute to sched_task_exit()

### DIFF
--- a/core/include/attributes.h
+++ b/core/include/attributes.h
@@ -32,6 +32,17 @@
 #endif
 
 /**
+ * @def NAKED
+ * @brief The *NAKED* keyword tells the compiler not to save any registers before
+ *        executing the function.
+ */
+#ifdef __GNUC__
+#define NAKED  __attribute__((naked))
+#else
+#define NAKED
+#endif
+
+/**
  * @def CONST
  * @brief A function declared as *CONST* is #PURE and also not allowed to
  *        examine global memory. I.e. a *CONST* function cannot even

--- a/core/sched.c
+++ b/core/sched.c
@@ -190,7 +190,7 @@ void sched_switch(uint16_t other_prio)
     }
 }
 
-NORETURN void sched_task_exit(void)
+NORETURN NAKED void sched_task_exit(void)
 {
     DEBUG("sched_task_exit(): ending task %s...\n", sched_active_thread->name);
 


### PR DESCRIPTION
This PR
1) adds `__attribute((naked))` to the `attributes.h` file
2) labels `sched_task_exit()` as naked to surpress compiler warnings for the `arm-none-eabi` toolchain.
