### PR TITLE
drivers: added set_absolute to timer interface

### DIFF
--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -75,6 +75,17 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int));
 int timer_set(tim_t dev, int channel, unsigned int timeout);
 
 /**
+ * @brief Set an absolute timeout value for the given channel of the given timer device
+ *
+ * @param[in] dev           the timer device to set
+ * @param[in] channel       the channel to set
+ * @param[in] value         the absolute compare value when the callback will be triggered
+ *
+ * @return                  1 on success, -1 on error
+ */
+int timer_set_absolute(tim_t dev, int channel, unsigned int value);
+
+/**
  * @brief Clear the given channel of the given timer device
  *
  * @param[in] dev           the timer device to clear


### PR DESCRIPTION
added the so far missing `timer_set_absolute()` interface for easy mapping of `hwtimer_set_absolute()`, used by the vtimer.
