### PR TITLE
destiny: change byte order of ipv6_header->length

### DIFF
--- a/sys/net/transport_layer/destiny/socket.c
+++ b/sys/net/transport_layer/destiny/socket.c
@@ -126,7 +126,7 @@ void print_tcp_status(int in_or_out, ipv6_hdr_t *ipv6_header,
     printf("IPv6 Dest: %s\n",
            ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN,
                             &ipv6_header->destaddr));
-    printf("TCP Length: %x\n", ipv6_header->length - TCP_HDR_LEN);
+    printf("TCP Length: %x\n", NTOHS(ipv6_header->length) - TCP_HDR_LEN);
     printf("Source Port: %x, Dest. Port: %x\n",
            NTOHS(tcp_header->src_port), NTOHS(tcp_header->dst_port));
     printf("Source Port: %u, Dest. Port: %u\n",
@@ -478,7 +478,7 @@ int send_tcp(socket_internal_t *current_socket, tcp_hdr_t *current_tcp_packet,
            &current_tcp_socket->foreign_address.sin6_addr, 16);
     memcpy(&(temp_ipv6_header->srcaddr),
            &current_tcp_socket->local_address.sin6_addr, 16);
-    temp_ipv6_header->length = header_length * 4 + payload_length;
+    temp_ipv6_header->length = HTONS(header_length * 4 + payload_length);
 
     current_tcp_packet->checksum = ~tcp_csum(temp_ipv6_header, current_tcp_packet);
 

--- a/sys/net/transport_layer/destiny/tcp.c
+++ b/sys/net/transport_layer/destiny/tcp.c
@@ -73,7 +73,7 @@ void printArrayRange_tcp(uint8_t *udp_header, uint16_t len)
 uint16_t tcp_csum(ipv6_hdr_t *ipv6_header, tcp_hdr_t *tcp_header)
 {
     uint16_t sum;
-    uint16_t len = ipv6_header->length;
+    uint16_t len = NTOHS(ipv6_header->length);
 
     sum = len + IPPROTO_TCP;
     sum = csum(sum, (uint8_t *)&ipv6_header->srcaddr, 2 * sizeof(ipv6_addr_t));
@@ -87,7 +87,7 @@ uint8_t handle_payload(ipv6_hdr_t *ipv6_header, tcp_hdr_t *tcp_header,
     (void) tcp_header;
 
     msg_t m_send_tcp, m_recv_tcp;
-    uint8_t tcp_payload_len = ipv6_header->length - TCP_HDR_LEN;
+    uint8_t tcp_payload_len = NTOHS(ipv6_header->length) - TCP_HDR_LEN;
     uint8_t acknowledged_bytes = 0;
 
     if (tcp_payload_len > tcp_socket->socket_values.tcp_control.rcv_wnd) {
@@ -270,7 +270,7 @@ void handle_tcp_fin_ack_packet(ipv6_hdr_t *ipv6_header, tcp_hdr_t *tcp_header,
 void handle_tcp_no_flags_packet(ipv6_hdr_t *ipv6_header, tcp_hdr_t *tcp_header,
                                 socket_internal_t *tcp_socket, uint8_t *payload)
 {
-    uint8_t tcp_payload_len = ipv6_header->length - TCP_HDR_LEN, read_bytes = 0;
+    uint8_t tcp_payload_len = NTOHS(ipv6_header->length) - TCP_HDR_LEN, read_bytes = 0;
     socket_t *current_tcp_socket = &tcp_socket->socket_values;
     uint8_t send_buffer[BUFFER_SIZE];
     ipv6_hdr_t *temp_ipv6_header = ((ipv6_hdr_t *)(&send_buffer));
@@ -394,7 +394,7 @@ void tcp_packet_handler(void)
             printf("Wrong checksum (%x) or no corresponding socket found!\n",
                    chksum);
             printArrayRange(((uint8_t *)ipv6_header), IPV6_HDR_LEN +
-                            ipv6_header->length, "Incoming");
+                            NTOHS(ipv6_header->length), "Incoming");
             print_tcp_status(INC_PACKET, ipv6_header, tcp_header,
                              &tcp_socket->socket_values);
         }


### PR DESCRIPTION
When accessing the length field of an ipv6_header a byte order switch (host -> network) is necessary.
Otherwise, it breaks calculations or the checksum and other tcp related computations.
Furthermore, when writing to ipv6_header->length it is important to switch this
from host byte order to network byte order.
