### PR TITLE
destiny: using a bit field for tcp_header->data_offset is more convenient

### DIFF
--- a/sys/net/include/destiny/types.h
+++ b/sys/net/include/destiny/types.h
@@ -51,21 +51,22 @@ typedef struct __attribute__((packed)) {
  * @see <a href="http://tools.ietf.org/html/rfc793">RFC 793</a>
  */
 typedef struct __attribute__((packed)) {
-    uint16_t 	src_port;               ///< source port
-    uint16_t 	dst_port;               ///< destination port
-    uint32_t 	seq_nr;                 ///< sequence number
-    uint32_t 	ack_nr;                 ///< acknowledgement number
-    uint8_t 	dataOffset_reserved;    ///< 4 MSBs data offsets,
-                                       ///< 4 LSBs reserved (must be zero)
-    uint8_t 	reserved_flags;         ///< MSB reserved, rest flags
-    uint16_t 	window;                 ///< receiver window
+    uint16_t    src_port;               ///< source port
+    uint16_t    dst_port;               ///< destination port
+    uint32_t    seq_nr;                 ///< sequence number
+    uint32_t    ack_nr;                 ///< acknowledgement number
+    uint8_t     flag_ns         :1;     ///< ECN-nonce concealment protection (since RFC 3540).
+    uint8_t     reserved        :3;     ///< for future use - set to zero
+    uint8_t     data_offset     :4;
+    uint8_t     reserved_flags;         ///< TODO: break this down into another bitfield: flag_fin, flag_syn, etc
+    uint16_t    window;                 ///< receiver window
     /**
      * internet checksum
      *
      * @see <a href="http://tools.ietf.org/html/rfc1071">RFC 1071</a>
      */
-    uint16_t	checksum;
-    uint16_t	urg_pointer;            ///< urgent pointer
+    uint16_t    checksum;
+    uint16_t    urg_pointer;            ///< urgent pointer
 } tcp_hdr_t;
 
 /**

--- a/sys/net/transport_layer/destiny/tcp.c
+++ b/sys/net/transport_layer/destiny/tcp.c
@@ -48,7 +48,7 @@ void printTCPHeader(tcp_hdr_t *tcp_header)
     printf("\nBEGIN: TCP HEADER\n");
     printf("ack_nr: %" PRIu32 "\n", tcp_header->ack_nr);
     printf("checksum: %i\n", tcp_header->checksum);
-    printf("dataOffset_reserved: %i\n", tcp_header->dataOffset_reserved);
+    printf("data_offset: %i\n", tcp_header->data_offset);
     printf("dst_port: %i\n", tcp_header->dst_port);
     printf("reserved_flags: %i\n", tcp_header->reserved_flags);
     printf("seq_nr: %" PRIu32 "\n", tcp_header->seq_nr);
@@ -331,15 +331,14 @@ void tcp_packet_handler(void)
 #endif
         chksum = tcp_csum(ipv6_header, tcp_header);
 
-        payload = (uint8_t *)(m_recv_ip.content.ptr + IPV6_HDR_LEN +
-                              tcp_header->dataOffset_reserved * 4);
+        payload = (uint8_t *)(m_recv_ip.content.ptr + IPV6_HDR_LEN + tcp_header->data_offset * 4);
 
         if ((chksum == 0xffff) && (tcp_socket != NULL)) {
 #ifdef TCP_HC
             update_tcp_hc_context(true, tcp_socket, tcp_header);
 #endif
             /* Remove reserved bits from tcp flags field */
-            uint8_t tcp_flags = tcp_header->reserved_flags & REMOVE_RESERVED;
+            uint8_t tcp_flags = tcp_header->reserved_flags;
 
             switch (tcp_flags) {
                 case TCP_ACK: {

--- a/sys/net/transport_layer/destiny/tcp_hc.c
+++ b/sys/net/transport_layer/destiny/tcp_hc.c
@@ -90,7 +90,7 @@ uint16_t compress_tcp_packet(socket_internal_t *current_socket,
 
         /* Move tcp packet 3 bytes to add padding and Context ID */
         memmove(current_tcp_packet + 3, current_tcp_packet,
-                ((((tcp_hdr_t *)current_tcp_packet)->dataOffset_reserved) * 4) +
+                ((((tcp_hdr_t *)current_tcp_packet)->data_offset) * 4) +
                 payload_length);
 
         /* 1 padding byte with value 0x01 to introduce full header TCP_HC
@@ -102,7 +102,7 @@ uint16_t compress_tcp_packet(socket_internal_t *current_socket,
         memcpy(current_tcp_packet + 1, &current_context, 2);
 
         /* Return correct header length (+3) */
-        packet_size = ((((tcp_hdr_t *)(current_tcp_packet + 3))->dataOffset_reserved) * 4) + 3 +
+        packet_size = ((((tcp_hdr_t *)(current_tcp_packet + 3))->data_offset) * 4) + 3 +
                       payload_length;
 
         /* Update the tcp context fields */
@@ -616,7 +616,7 @@ socket_internal_t *decompress_tcp_packet(ipv6_hdr_t *temp_ipv6_header)
                &current_socket->socket_values.foreign_address.sin6_port, 2);
 
         /* Ordinary TCP header length */
-        full_tcp_header.dataOffset_reserved = TCP_HDR_LEN / 4;
+        full_tcp_header.data_offset = TCP_HDR_LEN / 4;
 
         /* Move payload to end of tcp header */
         memmove(((uint8_t *)temp_ipv6_header) + IPV6_HDR_LEN + TCP_HDR_LEN,


### PR DESCRIPTION
In the current implementation the data offset is coded into an uint8_t.
Of this uint8_t only 3 bits apply for the data offset.
The remaining bits represent reserved flags for future use.
However, a proper bit masking is forgotten in order
to obtain the data offset part of this uint8_t.

Therefore, defining this uint8_t as a bit field allows a more convenient
method of access.
