### PR TITLE
make: remove local definitions for ELFFILE and HEXFILE (was: "mbed_lpc1768: fix ELF and HEX paths")

### DIFF
--- a/boards/chronos/Makefile.include
+++ b/boards/chronos/Makefile.include
@@ -16,7 +16,6 @@ export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
 export LINKFLAGS = -mmcu=$(MCU) -lgcc $(BINDIR)msp430_common/startup.o
 export FLASHER = mspdebug
-export HEXFILE = $(BINDIR)$(APPLICATION).hex
 export USEMODULE += msp430_common
 export FFLAGS = rf2500 "prog $(HEXFILE)"
 export OFLAGS = -O ihex

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -17,10 +17,8 @@ LINKFLAGS = -mcpu=cortex-m3 -mthumb -Wl,--gc-sections,--cref -lc -lgcc -lnosys -
 ifeq ($(strip $(PORT)),)
 	export PORT = /dev/ttyUSB0
 endif
-export HEXFILE = $(BINDIR)$(APPLICATION).hex
 export FFLAGS = $(HEXFILE)
 
-export ELFFILE = bin/$(APPLICATION).elf
 export DEBUGGER_FLAGS = $(ELFFILE)
 
 export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/ -I$(RIOTCPU)/$(CPU)/include

--- a/boards/msb-430-common/Makefile.include
+++ b/boards/msb-430-common/Makefile.include
@@ -14,7 +14,6 @@ export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
 export LINKFLAGS = -mmcu=$(MCU) -lgcc
 TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm.py
-export HEXFILE = $(BINDIR)$(APPLICATION).hex
 
 export FLASHER ?= mspdebug
 export PORT ?= /dev/ttyUSB0

--- a/boards/msba2-common/Makefile.include
+++ b/boards/msba2-common/Makefile.include
@@ -19,7 +19,6 @@ LINKFLAGS = -gdwarf-2 -mcpu=arm7tdmi-s -static -lgcc -nostartfiles -T$(RIOTBASE)
 ifeq ($(strip $(PORT)),)
 	export PORT = /dev/ttyUSB0
 endif
-export HEXFILE = $(BINDIR)$(APPLICATION).hex
 export FFLAGS = $(PORT) $(HEXFILE)
 include $(RIOTBOARD)/msba2-common/Makefile.dep
 

--- a/boards/redbee-econotag/Makefile.include
+++ b/boards/redbee-econotag/Makefile.include
@@ -24,7 +24,6 @@ LINKFLAGS = -mcpu=arm7tdmi-s -static -lgcc -nostartfiles -T$(RIOTBASE)/cpu/$(CPU
 ifeq ($(strip $(PORT)),)
 	export PORT = /dev/ttyUSB0
 endif
-export HEXFILE = $(BINDIR)/$(APPLICATION).hex
 export FFLAGS = -t $(PORT) -f $(HEXFILE) -c 'bbmc -l redbee-econotag reset'
 export OFLAGS = -O binary --gap-fill=0xff
 

--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -19,7 +19,6 @@ export FLASHER = goodfet.bsl
 ifeq ($(strip $(PORT)),)
     export PORT = /dev/ttyUSB0
 endif
-export HEXFILE = $(BINDIR)$(APPLICATION).hex
 export FFLAGS = --telosb -c $(PORT) -r -e -I -p $(HEXFILE)
 
 export INCLUDES += -I$(RIOTCPU)/msp430-common/include -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/drivers/cc2420/include -I$(RIOTBASE)/sys/net/include

--- a/boards/wsn430-common/Makefile.include
+++ b/boards/wsn430-common/Makefile.include
@@ -17,7 +17,6 @@ export FLASHER = mspdebug
 ifeq ($(strip $(PORT)),)
     export PORT = /dev/ttyUSB0
 endif
-export HEXFILE = $(BINDIR)$(APPLICATION).hex
 export FFLAGS = -d $(PORT) -j uif "prog $(HEXFILE)"
 
 export INCLUDES += -I$(RIOTBOARD)/wsn430-common/include

--- a/boards/z1/Makefile.include
+++ b/boards/z1/Makefile.include
@@ -19,7 +19,6 @@ export FLASHER = goodfet.bsl
 ifeq ($(strip $(PORT)),)
     export PORT = /dev/ttyUSB0
 endif
-export HEXFILE = $(BINDIR)$(APPLICATION).hex
 export FFLAGS = --z1 -I -c $(PORT) -r -e -p $(HEXFILE)
 export OFLAGS = -O ihex
 


### PR DESCRIPTION
E.g. `make buildsize` fails.
