### PR TITLE
boards: Fix CC2420 RXFIFO overflow

### DIFF
--- a/boards/telosb/driver_cc2420.c
+++ b/boards/telosb/driver_cc2420.c
@@ -209,7 +209,7 @@ void cc2420_spi_init(void)
 }
 
 /*
- * CC1100 receive interrupt
+ * CC2420 receive interrupt
  */
 interrupt (PORT1_VECTOR) __attribute__ ((naked)) cc2420_isr(void)
 {

--- a/boards/wsn430-v1_4/driver_cc2420.c
+++ b/boards/wsn430-v1_4/driver_cc2420.c
@@ -18,6 +18,9 @@
 #include "cc2420.h"
 #include "cc2420_arch.h"
 
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
 #define CC2420_RESETn_PIN   0x80
 #define CC2420_VREGEN_PIN   0x01
 
@@ -199,24 +202,25 @@ void cc2420_spi_init(void)
 }
 
 /*
- * CC1100 receive interrupt
+ * CC2420 receive interrupt
  */
 interrupt (PORT1_VECTOR) __attribute__ ((naked)) cc2420_isr(void){
     __enter_isr();
      /* Check IFG */
     if ((P1IFG & CC2420_GDO2_PIN) != 0) {
-        puts("rx interrupt");
+        DEBUG("rx interrupt");
         P1IFG &= ~CC2420_GDO2_PIN;
         cc2420_rx_irq();
     }
     else if ((P1IFG & CC2420_GDO0_PIN) != 0) {
-        cc2420_rxoverflow_irq();
-        puts("[CC2420] rxfifo overflow");
-        //P1IE &= ~CC2420_GDO0_PIN;                // Disable interrupt for GDO0
-        P1IFG &= ~CC2420_GDO0_PIN;                // Clear IFG for GDO0
+        if (cc2420_get_gdo2()) {
+            cc2420_rxoverflow_irq();
+            DEBUG("[CC2420] rxfifo overflow");
+        }
+        P1IFG &= ~CC2420_GDO0_PIN;                /* Clear IFG for GDO0 */
     }
     else if ((P1IFG & CC2420_SFD_PIN) != 0) {
-        puts("sfd interrupt");
+        DEBUG("sfd interrupt");
         P1IFG &= ~CC2420_SFD_PIN;
         cc2420_switch_to_rx();
     }

--- a/boards/z1/driver_cc2420.c
+++ b/boards/z1/driver_cc2420.c
@@ -238,7 +238,7 @@ void cc2420_spi_init(void)
 }
 
 /*
- * CC2400 receive interrupt
+ * CC2420 receive interrupt
  */
 interrupt (PORT1_VECTOR) __attribute__ ((naked)) cc2420_isr(void)
 {


### PR DESCRIPTION
Attempts to implement CC2420 ISR to handle RXFIFO overflow compliant to datasheet.

Contains changes for:
- z1
- telosb
- wsn430-v1_4

fixes #315 
