### PR TITLE
cc110x_ng: build cc110x_spi for avsextrem (bugfix)

### DIFF
--- a/drivers/cc110x_ng/Makefile
+++ b/drivers/cc110x_ng/Makefile
@@ -1,11 +1,6 @@
-ifneq (,$(filter msb-430h,$(BOARD)))
-	DIRS += spi
-endif
-ifneq (,$(filter msba2,$(BOARD)))
-	DIRS += spi
-endif
-ifneq (,$(filter wsn430-v1_3b,$(BOARD)))
-	DIRS += spi
+DIRS = spi
+ifneq (,$(filter chronos,$(BOARD)))
+	DIRS =
 endif
 
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
Building the cc110x_ng driver fails when setting BOARD=avsextrem. 
You can easily check this by adding the following line to examples/hello-world/Makefile:

```
USEMODULE += cc110x_ng
```

and then building hello-world for avsextrem:

```
BOARD=avsextrem make
```

This should fail with a message similar to this:

```
arm-none-eabi-gcc: error: /home/philipp/RIOT/examples/hello-world/bin/avsextrem/cc110x_spi.a: No such file or directory
```

This PR would fix this problem.

BTW: Why is cc110x and not cc110x_ng the default transceiver driver for avsextrem? I find this a little bit strange since the AVS-Extrem boards are nearly identical to the msba2 boards and yet they use different default transceiver drivers...
