### PR TITLE
drivers: fix spi of cc110x_ng issue for avsextrem

### DIFF
--- a/drivers/cc110x_ng/Makefile
+++ b/drivers/cc110x_ng/Makefile
@@ -7,6 +7,9 @@ endif
 ifneq (,$(filter msba2,$(BOARD)))
 	DIRS += spi
 endif
+ifneq (,$(filter avsextrem,$(BOARD)))
+	DIRS += spi
+endif
 ifneq (,$(filter wsn430-v1_3b,$(BOARD)))
 	DIRS += spi
 endif


### PR DESCRIPTION
the avsextrem seems to have been forgotten here..
