### PR TITLE
cpu - cortex-m3: moved crash.c to cortex-m3_common

### DIFF
--- a/cpu/cortex-m3_common/crash.c
+++ b/cpu/cortex-m3_common/crash.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup  core_util
+ * @ingroup     cortex-m3_common
  * @{
  *
  * @file        crash.c


### PR DESCRIPTION
moved `crash.c` for cortex-m3 from outdated `cortexm_common` to `cortex-m3_common` and fixed the doxygen group of the file.
