### PR TITLE
native: remove some warnings about undef functions

### DIFF
--- a/boards/native/drivers/native-uart0.c
+++ b/boards/native/drivers/native-uart0.c
@@ -156,7 +156,7 @@ int init_unix_socket(void)
     else {
         snprintf(sa.sun_path, sizeof(sa.sun_path), "/tmp/riot.tty.%d", _native_pid);
     }
-    unlink(sa.sun_path); /* remove stale socket */
+    real_unlink(sa.sun_path); /* remove stale socket */
     if (bind(s, (struct sockaddr *)&sa, SUN_LEN(&sa)) == -1) {
         err(EXIT_FAILURE, "init_unix_socket: bind");
     }
@@ -183,11 +183,11 @@ void handle_uart_in(void)
         /* end of file / socket closed */
         if (_native_uart_conn != 0) {
             if (_native_null_out_file != -1) {
-                if (dup2(_native_null_out_file, STDOUT_FILENO) == -1) {
+                if (real_dup2(_native_null_out_file, STDOUT_FILENO) == -1) {
                     err(EXIT_FAILURE, "handle_uart_in: dup2(STDOUT_FILENO)");
                 }
             }
-            if (dup2(_native_null_in_pipe[0], STDIN_FILENO) == -1) {
+            if (real_dup2(_native_null_in_pipe[0], STDIN_FILENO) == -1) {
                 err(EXIT_FAILURE, "handle_uart_in: dup2(STDIN_FILENO)");
             }
             _native_uart_conn = 0;
@@ -221,10 +221,10 @@ void handle_uart_sock(void)
         warnx("handle_uart_sock: successfully accepted socket");
     }
 
-    if (dup2(s, STDOUT_FILENO) == -1) {
+    if (real_dup2(s, STDOUT_FILENO) == -1) {
         err(EXIT_FAILURE, "handle_uart_sock: dup2()");
     }
-    if (dup2(s, STDIN_FILENO) == -1) {
+    if (real_dup2(s, STDIN_FILENO) == -1) {
         err(EXIT_FAILURE, "handle_uart_sock: dup2()");
     }
     _native_syscall_leave();

--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -61,6 +61,10 @@ extern void* (*real_realloc)(void *ptr, size_t size);
 extern int (*real_getpid)(void);
 extern int (*real_pipe)(int[2]);
 extern int (*real_close)(int);
+extern int (*real_fork)(void);
+extern int (*real_dup2)(int, int);
+extern int (*real_unlink)(const char *);
+extern int (*real_execve)(const char *, char *const[], char *const[]);
 
 /**
  * data structures

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -69,7 +69,7 @@ int reboot_arch(int mode)
 
     printf("\n\n\t\t!! REBOOT !!\n\n");
 
-    if (execve(_native_argv[0], _native_argv, NULL) == -1) {
+    if (real_execve(_native_argv[0], _native_argv, NULL) == -1) {
         err(EXIT_FAILURE, "reboot: execve");
     }
 

--- a/cpu/native/net/tap.c
+++ b/cpu/native/net/tap.c
@@ -153,7 +153,7 @@ void sigio_child()
 {
     pid_t parent = _native_pid;
 
-    if ((sigio_child_pid = fork()) == -1) {
+    if ((sigio_child_pid = real_fork()) == -1) {
         err(EXIT_FAILURE, "sigio_child: fork");
     }
 

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -56,6 +56,10 @@ void* (*real_calloc)(size_t nmemb, size_t size);
 void* (*real_realloc)(void *ptr, size_t size);
 int (*real_pipe)(int[2]);
 int (*real_close)(int);
+int (*real_fork)(void);
+int (*real_dup2)(int, int);
+int (*real_unlink)(const char *);
+int (*real_execve)(const char *, char *const[], char *const[]);
 
 void _native_syscall_enter(void)
 {


### PR DESCRIPTION
This PR implements `real_X` for `X in (fork, dup2, unlink, execve)`.
These function caused warnings while making the default example.
