### PR TITLE
make: create dependencies as side effect

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -37,15 +37,13 @@ $(BINDIR)$(MODULE).a: $(OBJ) $(ASMOBJ)
 	$(AD)$(AR) -rc $(BINDIR)$(MODULE).a $(OBJ) $(ASMOBJ)
 
 # pull in dependency info for *existing* .o files
--include $(OBJ:.o=.d)
+# deleted header files will be silently ignored
+-include $(OBJ:.o=.d) $(ASMOBJ:.o=.d)
 
-# compile and generate dependency info,
-# prepend path to dependency info file
+# compile and generate dependency info
 $(BINDIR)$(MODULE)/%.o: %.c
 	@mkdir -p $(BINDIR)$(MODULE)
-	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -c $*.c -o $(BINDIR)$(MODULE)/$*.o
-	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -MM $*.c |\
-		sed -e "1s|^|$(BINDIR)$(MODULE)/|" > $(BINDIR)$(MODULE)/$*.d
+	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -MD -MP -c -o $(BINDIR)$(MODULE)/$*.o $*.c
 
 $(BINDIR)$(MODULE)/%.o: %.s
 	@mkdir -p $(BINDIR)$(MODULE)
@@ -53,4 +51,4 @@ $(BINDIR)$(MODULE)/%.o: %.s
 
 $(BINDIR)$(MODULE)/%.o: %.S
 	@mkdir -p $(BINDIR)$(MODULE)
-	$(AD)$(CC) -c $(CFLAGS) $*.S -o $(BINDIR)$(MODULE)/$*.o
+	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -MD -MP -c -o $(BINDIR)$(MODULE)/$*.o $*.S

--- a/boards/native/Makefile
+++ b/boards/native/Makefile
@@ -6,6 +6,4 @@ include $(RIOTBASE)/Makefile.base
 
 $(BINDIR)$(MODULE)/%.o: %.c
 	@mkdir -p $(BINDIR)$(MODULE)
-	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -c $*.c -o $(BINDIR)$(MODULE)/$*.o
-	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -MM $*.c |\
-		sed -e "1s|^|$(BINDIR)$(MODULE)/|" > $(BINDIR)$(MODULE)/$*.d
+	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -MD -MP -c -o $(BINDIR)$(MODULE)/$*.o $*.c

--- a/boards/native/drivers/Makefile
+++ b/boards/native/drivers/Makefile
@@ -4,6 +4,4 @@ include $(RIOTBASE)/Makefile.base
 
 $(BINDIR)$(MODULE)/%.o: %.c
 	@mkdir -p $(BINDIR)$(MODULE)
-	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -c $*.c -o $(BINDIR)$(MODULE)/$*.o
-	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -MM $*.c |\
-		sed -e "1s|^|$(BINDIR)$(MODULE)/|" > $(BINDIR)$(MODULE)/$*.d
+	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -MD -MP -c -o $(BINDIR)$(MODULE)/$*.o $*.c

--- a/cpu/native/Makefile
+++ b/cpu/native/Makefile
@@ -11,6 +11,4 @@ include $(RIOTBASE)/Makefile.base
 
 $(BINDIR)$(MODULE)/%.o: %.c
 	@mkdir -p $(BINDIR)$(MODULE)
-	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -c $*.c -o $(BINDIR)$(MODULE)/$*.o
-	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -MM $*.c |\
-		sed -e "1s|^|$(BINDIR)$(MODULE)/|" > $(BINDIR)$(MODULE)/$*.d
+	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -MD -MP -c -o $(BINDIR)$(MODULE)/$*.o $*.c

--- a/cpu/native/net/Makefile
+++ b/cpu/native/net/Makefile
@@ -4,6 +4,4 @@ include $(RIOTBASE)/Makefile.base
 
 $(BINDIR)$(MODULE)/%.o: %.c
 	@mkdir -p $(BINDIR)$(MODULE)
-	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -c $*.c -o $(BINDIR)$(MODULE)/$*.o
-	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -MM $*.c |\
-		sed -e "1s|^|$(BINDIR)$(MODULE)/|" > $(BINDIR)$(MODULE)/$*.d
+	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -MD -MP -c -o $(BINDIR)$(MODULE)/$*.o $*.c

--- a/cpu/native/rtc/Makefile
+++ b/cpu/native/rtc/Makefile
@@ -2,6 +2,4 @@ include $(RIOTBASE)/Makefile.base
 
 $(BINDIR)$(MODULE)/%.o: %.c
 	@mkdir -p $(BINDIR)$(MODULE)
-	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -c $*.c -o $(BINDIR)$(MODULE)/$*.o
-	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -MM $*.c |\
-		sed -e "1s|^|$(BINDIR)$(MODULE)/|" > $(BINDIR)$(MODULE)/$*.d
+	$(AD)$(CC) $(CFLAGS) $(NATIVEINCLUDES) -MD -MP -c -o $(BINDIR)$(MODULE)/$*.o $*.c


### PR DESCRIPTION
No need to do magic with `sed`, no need to parse all files twice, no
need to use `clean` if you renamed a header.
