### PR TITLE
x86: fix up `make term` for x86

### DIFF
--- a/boards/qemu-i386/dist/term.py
+++ b/boards/qemu-i386/dist/term.py
@@ -16,12 +16,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import atexit
 import os
 import readline
 import socket
 import signal
 import subprocess
 import sys
+import termios
 import threading
 
 from datetime import datetime
@@ -121,4 +123,7 @@ def main(QEMU, BINDIRBASE, HEXFILE, DEBUGGER=None):
 
 if __name__ == '__main__':
     print("Type 'exit' to exit.")
+
+    atexit.register(termios.tcsetattr, 0, termios.TCSAFLUSH, termios.tcgetattr(0))
+
     sys.exit(main(*sys.argv[1:]))


### PR DESCRIPTION
When qemu-i386 shuts down the instance on its own accord, like in the
hello-world example, then the terminal is broken afterwards.

This PR ensures that the terminal flags are restored on shutdown.
