### PR TITLE
pyterm: explicitly specify the python version

### DIFF
--- a/dist/tools/pyterm/pyterm.py
+++ b/dist/tools/pyterm/pyterm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 # -*- coding: utf-8 -*-
 
 try:


### PR DESCRIPTION
My python points to python3.4.1 and this leads to
the following error message when flashing:

```
Welcome to pyterm!
Type 'exit' to exit.
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.4/threading.py", line 920, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.4/threading.py", line 868, in run
    self._target(*self._args, **self._kwargs)
  File "$RIOT/dist/tools/pyterm/pyterm.py", line 138, in reader
    output += c
TypeError: Can't convert 'bytes' object to str implicitly
```

specifying python2 in the she-bang line may be a safer approach and
ensures to always use python2.*
