### PR TITLE
make / cortex m: replace hyphen in module name

### DIFF
--- a/Makefile.modules
+++ b/Makefile.modules
@@ -4,8 +4,7 @@ include $(RIOTBASE)/Makefile.defaultmodules
 USEMODULE += $(filter-out $(DISABLE_MODULE), $(DEFAULT_MODULE))
 
 INCLUDES += -I$(RIOTBASE)/core/include -I$(RIOTBASE)/drivers/include -I$(RIOTBASE)/sys/include
-ED = $(USEMODULE:%=-DMODULE_%)
-ED += $(USEPKG:%=-DMODULE_%)
+ED = $(patsubst %,-DMODULE_%,$(subst -,_,$(USEMODULE) $(USEPKG)))
 EXTDEFINES = $(shell echo $(sort $(ED))|tr 'a-z' 'A-Z')
 REALMODULES = $(filter-out $(PSEUDOMODULES), $(sort $(USEMODULE)))
 export BASELIBS += $(REALMODULES:%=$(BINDIR)%.a)


### PR DESCRIPTION
When you compile for UDOO, you are greeted by a multitude of this
warnings:

```
<command-line>:0:14: warning: ISO C99 requires whitespace after the macro name [enabled by default]
```

The reason for that is the argument `-DMODULE_CORTEX-M3_COMMON`.

This PR fixes this problem by replacing hyphens with underscores for the
`-D…` argument.
