### PR TITLE
msp430: fix writing more than one byte to flash

### DIFF
--- a/cpu/msp430x16x/flashrom.c
+++ b/cpu/msp430x16x/flashrom.c
@@ -54,7 +54,7 @@ void flashrom_write(uint8_t *dst, uint8_t *src, size_t size)
 
     for (i = size; i > 0; i--) {
         FCTL1 = FWKEY | WRT;
-        *dst = *src;                /* program Flash word */
+        *(dst++) = *(src++);                /* program Flash word */
 
         while (!(FCTL3 & WAIT)) {
             nop();


### PR DESCRIPTION
The function flashrom_write for the msp430 would only write the first byte to flash. This Patches corrects this bug.
