### PR TITLE
sys/ps: don't use float for runtime calculations

### DIFF
--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -39,7 +39,6 @@ const char *state_names[] = {
  */
 void thread_print_all(void)
 {
-    extern unsigned long hwtimer_now(void);
     const char queued_name[] = {'_', 'Q'};
     int i;
     int overall_stacksz = 0;
@@ -55,10 +54,10 @@ void thread_print_all(void)
         tcb_t *p = (tcb_t *)sched_threads[i];
 
         if (p != NULL) {
-            int state = p->status;                                                 // copy state
-            const char *sname = state_names[state];                                // get state name
-            const char *queued = &queued_name[(int)(state >= STATUS_ON_RUNQUEUE)]; // get queued flag
-            int stacksz = p->stack_size;                                           // get stack size
+            int state = p->status;                                                 /* copy state */
+            const char *sname = state_names[state];                                /* get state name */
+            const char *queued = &queued_name[(int)(state >= STATUS_ON_RUNQUEUE)]; /* get queued flag */
+            int stacksz = p->stack_size;                                           /* get stack size */
 #if SCHEDSTATISTICS
             int runtime_ticks = sched_pidlist[i].runtime_ticks / (hwtimer_now()/1000UL + 1);
             int switches = sched_pidlist[i].schedules;


### PR DESCRIPTION
Not sure if I'd prefer `%` or `‰`.. - `‰` looks like it will break stuff ;-)

%:

```
> ps
    pid | name                 | state    Q | pri | stack ( used) location  | runtime | switches
      0 | idle                 | pending  Q |  31 |  8192 ( 1088) 0x8057254 |     99% |         1
      1 | main                 | running  Q |  15 | 16384 ( 2840) 0x8059254 |      0% |         8
      2 | uart0                | bl rx    _ |  14 |  8192 (  924) 0x805de0c |      0% |        10
      3 | radio                | bl rx    _ |  13 |  8192 (  896) 0x806abe0 |      0% |         1
      4 | Transceiver          | bl rx    _ |  12 | 16384 (  900) 0x806de64 |      0% |         1
        | SUM                  |            |     | 57344
```

‰:

```
> ps
    pid | name                 | state    Q | pri | stack ( used) location  | runtime | switches
      0 | idle                 | pending  Q |  31 |  8192 ( 1088) 0x8057254 |    999‰ |         1
      1 | main                 | running  Q |  15 | 16384 ( 2840) 0x8059254 |      0‰ |         8
      2 | uart0                | bl rx    _ |  14 |  8192 (  924) 0x805de0c |      0‰ |        10
      3 | radio                | bl rx    _ |  13 |  8192 (  896) 0x806abe0 |      0‰ |         1
      4 | Transceiver          | bl rx    _ |  12 | 16384 (  900) 0x806de64 |      0‰ |         1
        | SUM                  |            |     | 57344
```
