### PR TITLE
nativenet: change max packet size to 127

### DIFF
--- a/cpu/native/include/nativenet.h
+++ b/cpu/native/include/nativenet.h
@@ -33,7 +33,7 @@
 #ifndef NATIVE_MAX_DATA_LENGTH
 #include "tap.h"
 #ifdef MODULE_SIXLOWPAN
-#define NATIVE_MAX_DATA_LENGTH (255)
+#define NATIVE_MAX_DATA_LENGTH (127)
 #else
 #define NATIVE_MAX_DATA_LENGTH (TAP_MAX_DATA)
 #endif


### PR DESCRIPTION
Real IEEE 802.15.4 transceivers have a payload of 127. Hence, for
testing - particular 6lowpan - it would make sense to have the same
limitation in nativenet. Especially to test fragmentation this is
helpful.
