### PR TITLE
cpu - sam3x8e: fixed vtimer, added timer_set_absolute

### DIFF
--- a/cpu/sam3x8e/hwtimer_arch.c
+++ b/cpu/sam3x8e/hwtimer_arch.c
@@ -53,7 +53,7 @@ void hwtimer_arch_set(unsigned long offset, short timer)
 
 void hwtimer_arch_set_absolute(unsigned long value, short timer)
 {
-    /* DEPRECATED?! - will not be implemented */
+    timer_set_absolute(HW_TIMER, timer, value);
 }
 
 void hwtimer_arch_unset(short timer)

--- a/cpu/sam3x8e/periph/timer.c
+++ b/cpu/sam3x8e/periph/timer.c
@@ -129,6 +129,11 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
 
 int timer_set(tim_t dev, int channel, unsigned int timeout)
 {
+    return timer_set_absolute(dev, channel, timer_read(dev) + timeout);
+}
+
+int timer_set_absolute(tim_t dev, int channel, unsigned int value)
+{
     Tc *tim;
 
     /* get timer base register address */
@@ -156,32 +161,33 @@ int timer_set(tim_t dev, int channel, unsigned int timeout)
     /* set timeout value */
     switch (channel) {
         case 0:
-            tim->TC_CHANNEL[0].TC_RA = tim->TC_CHANNEL[0].TC_CV + timeout;
+            tim->TC_CHANNEL[0].TC_RA = value;
             tim->TC_CHANNEL[0].TC_IER = TC_IER_CPAS;
             break;
         case 1:
-            tim->TC_CHANNEL[0].TC_RB = tim->TC_CHANNEL[0].TC_CV + timeout;
+            tim->TC_CHANNEL[0].TC_RB = value;
             tim->TC_CHANNEL[0].TC_IER = TC_IER_CPBS;
             break;
         case 2:
-            tim->TC_CHANNEL[0].TC_RC = tim->TC_CHANNEL[0].TC_CV + timeout;
+            tim->TC_CHANNEL[0].TC_RC = value;
             tim->TC_CHANNEL[0].TC_IER = TC_IER_CPCS;
             break;
         case 3:
-            tim->TC_CHANNEL[1].TC_RA = tim->TC_CHANNEL[1].TC_CV + timeout;
+            tim->TC_CHANNEL[1].TC_RA = value;
             tim->TC_CHANNEL[1].TC_IER = TC_IER_CPAS;
             break;
         case 4:
-            tim->TC_CHANNEL[1].TC_RB = tim->TC_CHANNEL[1].TC_CV + timeout;
+            tim->TC_CHANNEL[1].TC_RB = value;
             tim->TC_CHANNEL[1].TC_IER = TC_IER_CPBS;
             break;
         case 5:
-            tim->TC_CHANNEL[1].TC_RC = tim->TC_CHANNEL[1].TC_CV + timeout;
+            tim->TC_CHANNEL[1].TC_RC = value;
             tim->TC_CHANNEL[1].TC_IER = TC_IER_CPCS;
             break;
         default:
             return -1;
     }
+
     return 1;
 }
 


### PR DESCRIPTION
Added the missing implementation of `timer_set_absolute`, now the vtimer is working like a charm.
