### PR TITLE
CCN_lite eliminate warning

### DIFF
--- a/sys/net/ccn_lite/ccnl-ext-frag.c
+++ b/sys/net/ccn_lite/ccnl-ext-frag.c
@@ -708,6 +708,8 @@ Bail:
 
 #else /* USE_FRAG */
 
+#define CCNL_NO_FRAG_DUMMY
+
 static int dummy __attribute__((unused));
 
 #endif


### PR DESCRIPTION
Compiling ccn_lite yields a warning:

```
RIOT/sys/net/ccn_lite/ccnl-ext-frag.c:711:0: warning: ISO C forbids an empty translation unit [-Wpedantic]
```

when `USE_FRAG` is not set (which is the case by default). This PR introduces a dummy define to convince the compiler that there's something in the unit.

If there's a better way to do so, let me know!

This PR also includes some very small formatting fixes in the same file.
