### PR TITLE
make: introduce source file blacklisting

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -22,49 +22,62 @@ ${DIRS:%=ALL--%}:
 ${DIRS:%=CLEAN--%}:
 	"$(MAKE)" -C ${@:CLEAN--%=%} clean
 
-ASMSRC = $(wildcard *.s)
-ASSMSRC = $(wildcard *.S)
-ASMOBJ = $(ASMSRC:%.s=$(BINDIR)$(MODULE)/%.o)
-ASMOBJ += $(ASSMSRC:%.S=$(BINDIR)$(MODULE)/%.o)
-
+# Collect sources to compiled if not specified.
 ifeq ($(strip $(SRC)),)
-	SRC = $(wildcard *.c)
+    SRC = $(wildcard *.c)
 endif
-
 ifeq ($(strip $(SRCXX)),)
-	SRCXX = $(wildcard *.cpp)
+    SRCXX := $(wildcard *.cpp)
+endif
+ifeq ($(strip $(ASMSRC)),)
+    ASMSRC := $(wildcard *.s)
+endif
+ifeq ($(strip $(ASSMSRC)),)
+    ASSMSRC := $(wildcard *.S)
 endif
 
-OBJC = $(SRC:%.c=$(BINDIR)$(MODULE)/%.o)
-OBJCXX = $(SRCXX:%.cpp=$(BINDIR)$(MODULE)/%.o)
+# Filter out unwanted / conditional source files.
+ifneq ($(strip $(SRC_BLACKLIST)),)
+    SRC     := $(filter-out $(SRC_BLACKLIST), $(SRC))
+    SRCXX   := $(filter-out $(SRC_BLACKLIST), $(SRCXX))
+    ASMSRC  := $(filter-out $(SRC_BLACKLIST), $(ASMSRC))
+    ASSMSRC := $(filter-out $(SRC_BLACKLIST), $(ASSMSRC))
+endif
+ifneq ($(strip $(SRC_WHITELIST)),)
+    SRC     := $(filter $(SRC_WHITELIST), $(SRC))
+    SRCXX   := $(filter $(SRC_WHITELIST), $(SRCXX))
+    ASMSRC  := $(filter $(SRC_WHITELIST), $(ASMSRC))
+    ASSMSRC := $(filter $(SRC_WHITELIST), $(ASSMSRC))
+endif
 
-OBJ = $(OBJC)
-OBJ += $(OBJCXX)
+# Compile into output directory.
+OBJC    := $(SRC:%.c=$(BINDIR)$(MODULE)/%.o)
+OBJCXX  := $(SRCXX:%.cpp=$(BINDIR)$(MODULE)/%.o)
+ASMOBJ  := $(ASMSRC:%.s=$(BINDIR)$(MODULE)/%.o)
+ASSMOBJ := $(ASSMSRC:%.S=$(BINDIR)$(MODULE)/%.o)
+OBJ     := $(OBJC) $(OBJCXX) $(ASMOBJ) $(ASSMOBJ)
 
-DEP = $(SRC:%.c=$(BINDIR)$(MODULE)/%.d)
-DEP += $(SRCXX:%.cpp=$(BINDIR)$(MODULE)/%.d)
-
-$(BINDIR)$(MODULE).a: $(OBJ) $(ASMOBJ) ${DIRS:%=ALL--%}
+$(BINDIR)$(MODULE).a: $(OBJ) ${DIRS:%=ALL--%}
 	@mkdir -p $(BINDIR)$(MODULE)
 	$(AD)$(AR) -rc $(BINDIR)$(MODULE).a $(OBJ) $(ASMOBJ)
 
-# pull in dependency info for *existing* .o files
-# deleted header files will be silently ignored
+# Pull in dependency info for *existing* .o files.
+# Deleted header files will be silently ignored.
 -include $(OBJ:.o=.d)
 
-# compile and generate dependency info
-$(BINDIR)$(MODULE)/%.o: %.c
+# Compile and generate dependency info.
+$(OBJC): $(BINDIR)$(MODULE)/%.o: %.c
 	@mkdir -p $(BINDIR)$(MODULE)
 	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -MD -MP -c -o $(BINDIR)$(MODULE)/$*.o $(abspath $*.c)
 
-$(BINDIR)$(MODULE)/%.o: %.cpp
+$(OBJCXX): $(BINDIR)$(MODULE)/%.o: %.cpp
 	@mkdir -p $(BINDIR)$(MODULE)
 	$(AD)$(CXX) $(filter-out $(CXXUWFLAGS), $(CFLAGS)) $(CXXEXFLAGS) $(INCLUDES) -MD -MP -c -o $(BINDIR)$(MODULE)/$*.o $(abspath $*.cpp)
 
-$(BINDIR)$(MODULE)/%.o: %.s
+$(ASMOBJ): $(BINDIR)$(MODULE)/%.o: %.s
 	@mkdir -p $(BINDIR)$(MODULE)
 	$(AD)$(AS) $(ASFLAGS) $*.s -o $(BINDIR)$(MODULE)/$*.o
 
-$(BINDIR)$(MODULE)/%.o: %.S
+$(ASSMOBJ): $(BINDIR)$(MODULE)/%.o: %.S
 	@mkdir -p $(BINDIR)$(MODULE)
 	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -MD -MP -c -o $(BINDIR)$(MODULE)/$*.o $(abspath $*.S)


### PR DESCRIPTION
**UNTESTED, WIP**

Right now RIOT compiles in every source file it finds in the module
directory, unless the files were specified in `SRC` / `SRCXX`.

This PR adds the variables `SRC_BLACKLIST` and `SRC_WHITELIST`, which
might come in handy if your have conditional or mutual exclusive source
files as in #1350.
