### PR TITLE
pyterm: don't crash on invalid characters

### DIFF
--- a/dist/tools/pyterm/pyterm.py
+++ b/dist/tools/pyterm/pyterm.py
@@ -130,7 +130,7 @@ class SerCmd(cmd.Cmd):
 def reader(ser, logger):
     output = ""
     while (1):
-        c = ser.read(1).decode("utf-8")
+        c = ser.read(1).decode("utf-8", errors='replace')
         if c == '\n' or c == '\r':
             logger.info(output)
             output = ""


### PR DESCRIPTION
If invalid characters were read, then pyterm crashed.

This PR lets pyterm print the character `�` for invalid UTF-8 sequences.
