### PR TITLE
core/sched fixup and optimize

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -94,11 +94,6 @@ extern volatile int sched_num_threads;
 extern volatile int sched_active_pid;
 
 /**
- *  Process ID of the thread that was active before the current one
- */
-extern volatile int last_pid;
-
-/**
  * List of runqueues per priority level
  */
 extern clist_node_t *runqueues[SCHED_PRIO_LEVELS];

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -132,13 +132,6 @@ int thread_wakeup(int pid);
 int thread_getpid(void);
 
 /**
- * @brief Returns the process ID of the thread running before the current one
- *
- * @return          obviously you are not a golfer.
- */
-int thread_getlastpid(void);
-
-/**
  * @brief Measures the stack usage of a stack
  *
  * Only works if the thread was created with the flag CREATE_STACKTEST.

--- a/core/sched.c
+++ b/core/sched.c
@@ -45,7 +45,6 @@ volatile tcb_t *sched_threads[MAXTHREADS];
 volatile tcb_t *sched_active_thread;
 
 volatile int sched_active_pid = -1;
-volatile int thread_last_pid = -1;
 
 clist_node_t *sched_runqueues[SCHED_PRIO_LEVELS];
 static uint32_t runqueue_bitcache = 0;
@@ -104,11 +103,6 @@ void sched_run(void)
     }
 #endif
 
-#ifdef MODULE_NSS
-    if (sched_active_thread && (my_next_pid != thread_last_pid)) {
-        thread_last_pid = sched_active_pid;
-    }
-#endif
     sched_active_pid = my_next_pid;
 
     DEBUG("scheduler: next task: %s\n", my_active_thread->name);

--- a/core/thread.c
+++ b/core/thread.c
@@ -37,12 +37,6 @@ inline int thread_getpid(void)
     return sched_active_thread->pid;
 }
 
-int thread_getlastpid(void)
-{
-    extern int thread_last_pid;
-    return thread_last_pid;
-}
-
 int thread_getstatus(int pid)
 {
     if (sched_threads[pid] == NULL) {


### PR DESCRIPTION
- fix some misuse of variables (mixing `tcb_t` and `pid_t`)
- fix condition logic (`X && Y != Y` -> `X && (Y != Y)`)
- refactor `SCHEDSTATISTICS` to make it faster/more readable
- remove obsolete/done TODOs
- remove stray spaces
- remove `last_pid`/`thread_getlastpid`
