### PR TITLE
setup git committer info in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ install:
     - sudo apt-get install pcregrep libpcre3
     - sudo apt-get install qemu-system-x86 python3
     - sudo apt-get install g++-multilib
+    - git config --global user.email "travis@example.com"
+    - git config --global user.name "Travis CI"
 
 script:
     - ./dist/tools/compile_test/compile_test.py


### PR DESCRIPTION
pkg/ Makefiles based on `Makefile.git` fail in Travis when attempting to apply patches with `git am` because no committer info is set.
This patch adds a dummy Travis username and mail in the 'install' step to satisfy git.

[Travis log](https://travis-ci.org/RIOT-OS/RIOT/builds/29360429#L1056) of the problematic behavior 
