### PR TITLE
x86: increase timeout in qemu's term

### DIFF
--- a/boards/qemu-i386/dist/term.py
+++ b/boards/qemu-i386/dist/term.py
@@ -70,7 +70,7 @@ def main(QEMU, BINDIRBASE, HEXFILE, DEBUGGER=None):
     result = 1
     try:
         sock = socket.socket()
-        sock.settimeout(5)
+        sock.settimeout(60)
         sock.bind(('', 0))
         sock.listen(1)
         host, port = sock.getsockname()


### PR DESCRIPTION
Currently `boards/qemu-i386/dist/term.py` expects QEMU to connect in
less than 5 seconds, which is plenty on any user machine. Travis CI,
which we use without paying a cent, sometimes fails to start QEMU in
this is timeframe, though.

This PR increases the timeout to one minute.
