### PR TITLE
Fix a nasty race condition in CCA determination on CC2420

### DIFF
--- a/boards/telosb/driver_cc2420.c
+++ b/boards/telosb/driver_cc2420.c
@@ -17,6 +17,7 @@
 
 #include "cc2420.h"
 #include "cc2420_arch.h"
+#include "cc2420_spi.h"
 
 #define ENABLE_DEBUG    (1)
 #include "debug.h"
@@ -106,14 +107,21 @@ uint8_t cc2420_get_sfd(void)
     return CC2420_SFD;
 }
 
+#define MAX_RSSI_WAIT 1000
+
 uint8_t cc2420_get_cca(void)
 {
     uint8_t status;
-    long c = 0;
+    long count = 0;
     do {
+        unsigned int sr = disableIRQ();
+        cc2420_spi_select();
         status = cc2420_txrx(NOBYTE);
-        if (c++ == 1000000) {
-            core_panic(0x2420, "cc2420_get_cca() alarm");
+        cc2420_spi_unselect();
+        restoreIRQ(sr);
+        count++;
+        if (count >= MAX_RSSI_WAIT) {
+            core_panic(0x2420, "cc2420_get_cca(): RSSI never valid!");
         }
     } while (!(status & CC2420_STATUS_RSSI_VALID));
     return CC2420_GIO1;

--- a/boards/z1/driver_cc2420.c
+++ b/boards/z1/driver_cc2420.c
@@ -32,6 +32,7 @@
 
 #include "cc2420.h"
 #include "cc2420_arch.h"
+#include "cc2420_spi.h"
 
 #define ENABLE_DEBUG    (1)
 #include "debug.h"
@@ -128,7 +129,11 @@ uint8_t cc2420_get_cca(void)
     uint8_t status;
     long count = 0;
     do {
+        unsigned int sr = disableIRQ();
+        cc2420_spi_select();
         status = cc2420_txrx(NOBYTE);
+        cc2420_spi_unselect();
+        restoreIRQ(sr);
         count++;
         if (count >= MAX_RSSI_WAIT) {
             core_panic(0x2420, "cc2420_get_cca(): RSSI never valid!");


### PR DESCRIPTION
We now ensure that CS signal is active, and interrupts are disabled, when querying CC2420 status byte for CCA.
Also do a little refactoring in the same cc2420_get_cca function (renamed c variable into count, and named the constant corresponding to RSSI "timeout"), so that all the driver_cc2420 C files have the same function.
