### PR TITLE
make: removed shell_commands dependency

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -73,10 +73,6 @@ ifneq (,$(filter net_if,$(USEMODULE)))
 	USEMODULE += transceiver
 endif
 
-ifneq (,$(filter shell_commands,$(USEMODULE)))
-	USEMODULE += net_help
-endif
-
 ifneq (,$(filter ccn_lite,$(USEMODULE)))
 	USEMODULE += crypto
 endif


### PR DESCRIPTION
I just stumbled on this - can somebody explain this dependency to me?
