### PR TITLE
boards/z1: fix cc2420_txrx function in CC2420 driver HAL

### DIFF
--- a/boards/z1/driver_cc2420.c
+++ b/boards/z1/driver_cc2420.c
@@ -168,7 +168,7 @@ uint8_t cc2420_txrx(uint8_t data)
         if (count >= MAX_SPI_WAIT) {
             core_panic(0x2420, "cc2420_txrx(): couldn't send byte!");
         }
-    } while(!(UCB0STAT & UCBUSY));
+    } while (UCB0STAT & UCBUSY);
     /* Read the byte that CC2420 has (normally, during TX) returned */
     count = 0;
     do {
@@ -176,7 +176,7 @@ uint8_t cc2420_txrx(uint8_t data)
         if (count >= MAX_SPI_WAIT) {
             core_panic(0x2420, "cc2420_txrx(): couldn't receive byte!");
         }
-    } while(!(IFG2 & UCB0RXIFG));
+    } while (!(IFG2 & UCB0RXIFG));
     /* Return received byte */
     return UCB0RXBUF;
 }


### PR DESCRIPTION
When waiting for the SPI transmission (to CC2420) to be done,
we were wrongly waiting for UCBUSY bit to be set,
while one should actually wait for that bit to be cleared.
