### PR TITLE
destiny: deleting packed attribute from socket_internal_t

### DIFF
--- a/sys/net/transport_layer/destiny/socket.h
+++ b/sys/net/transport_layer/destiny/socket.h
@@ -59,7 +59,7 @@ typedef struct __attribute__((packed)) {
     sockaddr6_t			foreign_address;
 } socket_t;
 
-typedef struct __attribute__((packed)) {
+typedef struct {
     uint8_t				socket_id;
     uint8_t				recv_pid;
     uint8_t				send_pid;


### PR DESCRIPTION
While testing the tcp implementation on MSBA2 I noticed that
the value of `tcp_input_buffer_end` gets changed whenever acquiring or
releasing the mutex of the struct on the server side.

After deleting the packed attribute of the struct this problem was
resolved and the value stayed the same after acquiring and releasing.

This problem could maybe arise from badly placed cache lines due to
missing padding... I am not sure.

Anyway, I guess using the packed attribute is useless here and makes it
more error-prone.
