### PR TITLE
destiny: Adjust TCP_STACK_SIZE

### DIFF
--- a/sys/net/transport_layer/destiny/tcp.h
+++ b/sys/net/transport_layer/destiny/tcp.h
@@ -80,7 +80,7 @@ enum tcp_codes {
 #define SET_TCP_FIN(a)          (a) = TCP_FIN
 #define SET_TCP_FIN_ACK(a)      (a) = TCP_FIN_ACK
 
-#define TCP_STACK_SIZE          (KERNEL_CONF_STACKSIZE_DEFAULT)
+#define TCP_STACK_SIZE          (KERNEL_CONF_STACKSIZE_MAIN)
 
 typedef struct __attribute__((packed)) tcp_mms_o_t {
     uint8_t     kind;


### PR DESCRIPTION
Currently, the TCP_STACK_SIZE is `KERNEL_CONF_STACKSIZE_DEFAULT`.
However, since printf statements are used in the tcp relevant code,
this stack size is too small (esp. for MSBA2).
