### PR TITLE
tests: add pattern for short lgplv2.1 header

### DIFF
--- a/dist/tools/licenses/patterns/lgplv2.1-short
+++ b/dist/tools/licenses/patterns/lgplv2.1-short
@@ -1,0 +1,1 @@
+This file is subject to the terms and conditions of the GNU Lesser General Public License v2\.1\. See the file LICENSE in the top level directory for more details\.


### PR DESCRIPTION
Add the license checker pattern which is advertised in our [wiki](https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions).
