### PR TITLE
core/thread: remove thread_create_arg from header

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -80,14 +80,6 @@ int thread_create(char *stack,
                   void *(*function)(void *arg),
                   void *arg,
                   const char *name);
-
-int thread_create_arg(char *stack,
-                      int stacksize,
-                      char priority,
-                      int flags,
-                      void *(*function)(void *arg),
-                      void *arg,
-                      const char *name);
 /**
  * @brief Returns the status of a process
  *


### PR DESCRIPTION
It's just a leftover from #856
