### PR TITLE
make: rename VERSION into RIOT_VERSION

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -65,16 +65,17 @@ include $(RIOTBASE)/Makefile.cflags
 
 # make the RIOT version available to the program
 GIT_STRING := $(shell git describe --always --abbrev=4 --dirty=-`hostname`)
-GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-ifeq ($(strip $(GIT_BRANCH)),master)
-	GIT_VERSION = $(GIT_STRING)
+ifneq (,$(GIT_STRING))
+  GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+  ifeq ($(strip $(GIT_BRANCH)),master)
+    RIOT_VERSION := $(GIT_STRING)
+  else
+    RIOT_VERSION := $(GIT_STRING)-$(GIT_BRANCH)
+  endif
 else
-	GIT_VERSION = $(shell echo $(GIT_STRING) $(GIT_BRANCH) | sed 's/ /-/')
+  RIOT_VERSION := UNKNOWN
 endif
-ifeq ($(strip $(GIT_VERSION)),)
-	GIT_VERSION := "UNKNOWN"
-endif
-export CFLAGS += -DVERSION=\"$(GIT_VERSION)\"
+export CFLAGS += -DRIOT_VERSION='"$(RIOT_VERSION)"'
 
 # the binaries to link
 BASELIBS += $(BINDIR)$(BOARD)_base.a

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -85,7 +85,7 @@ static char idle_stack[KERNEL_CONF_STACKSIZE_IDLE];
 void kernel_init(void)
 {
     dINT();
-    printf("kernel_init(): This is RIOT! (Version: %s)\n", VERSION);
+    printf("kernel_init(): This is RIOT! (Version: %s)\n", RIOT_VERSION);
 
     hwtimer_init();
 


### PR DESCRIPTION
Building MSP boards gives an error, because `VERSION` is somewhere
defined in their toolchain as an integer.

This PR renames `VERSION` into `RIOT_VERSION`, because that's what it
is.
