### PR TITLE
pnet: Fix INADDR_ANY and INADDR_BROADCAST

### DIFF
--- a/sys/posix/pnet/include/netinet/in.h
+++ b/sys/posix/pnet/include/netinet/in.h
@@ -125,12 +125,12 @@ extern const struct sockaddr_in6 in6addr_loopback;
 /**
  * IPv4 local host address.
  */
-#define INADDR_ANY          {(in_addr_t)0x00000000}
+#define INADDR_ANY          ((in_addr_t)0x00000000)
 
 /**
  * IPv4 broadcast address.
  */
-#define INADDR_BROADCAST    {(in_addr_t)0xffffffff}
+#define INADDR_BROADCAST    ((in_addr_t)0xffffffff)
 
 /**
  * Multicast hop limit option name for getsockopt() or setsockopt()


### PR DESCRIPTION
INADDR_ANY and INADDR_BROADCAST should not be initializers.
