### PR TITLE
tests: enable cppcheck for PR in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
     - sudo apt-get install qemu-system-x86 python3
     - sudo apt-get install g++-multilib
     - sudo apt-get install gcc-avr binutils-avr avr-libc
+    - sudo apt-get install cppcheck
     - git config --global user.email "travis@example.com"
     - git config --global user.name "Travis CI"
 
@@ -39,6 +40,10 @@ script:
     - make -C ./tests/unittests test BOARD=native
     - make -C ./tests/unittests test BOARD=qemu-i386
     - ./dist/tools/licenses/check.sh master
+# TODO:
+#   Remove the --error-exitcode=0` when all warnings of cppcheck have been
+#   taken care of in master.
+    - ./dist/tools/cppcheck/check.sh master --error-exitcode=0
 
 notifications:
     email: false


### PR DESCRIPTION
This lets cppcheck run on the files of the current PR and fail if there are errors.

If, for example, the PR would touch `cpu/cortex-m3_common/thread_arch.c`, then Travis' log would contain:

```
cpu/cortex-m3_common/thread_arch.c(62): portability (arithOperationsOnVoidPointer): 'stack_start' is of type 'void *'. When using void pointers in calculations, the behaviour is undefined.
```

To suppress this false positive, a comment can be added:

``` diff
index f4001cc..3c1c46e 100644
--- a/cpu/cortex-m3_common/thread_arch.c
+++ b/cpu/cortex-m3_common/thread_arch.c
@@ -57,6 +57,8 @@ static void context_restore(void) NORETURN;
 char *thread_arch_stack_init(void *(*task_func)(void *), void *arg, void *stack_start, int stack_size)
 {
     uint32_t *stk;
+    /* cppcheck-suppress arithOperationsOnVoidPointer */
     stk = (uint32_t *)(stack_start + stack_size);

     /* marker */
```
