### PR TITLE
shell: prepare a rudimentary IEEE 802.15.4 packet

### DIFF
--- a/boards/redbee-econotag/Makefile.include
+++ b/boards/redbee-econotag/Makefile.include
@@ -30,6 +30,7 @@ export OFLAGS = -O binary --gap-fill=0xff
 export INCLUDES += -I$(RIOTCPU)/$(CPU)/include/ -I$(RIOTBOARD)/$(BOARD)/include/
 export INCLUDES += -I$(RIOTCPU)/$(CPU)/maca/include
 export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/drivers/include
+export INCLUDES += -I$(RIOTBASE)/sys/net/include
 
 ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
 	USEMODULE += mc1322x


### PR DESCRIPTION
The transceiver module expects an `ieee802154_packet_t` instead of a
`radio_packet_t` if the device supports the IEEE 802.15.4 packet format.
This commit fixes the corresponding transceiver shell command for
`txtsnd` to set destination address (short address mode), payload, and
length accordingly.
