### PR TITLE
vtimer: fix crash on spurious hwtimer callback

### DIFF
--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -177,13 +177,18 @@ void vtimer_callback(void *ptr)
     /* get the vtimer that fired */
     vtimer_t *timer = (vtimer_t *)queue_remove_head(&shortterm_queue_root);
 
+    if (timer) {
 #if ENABLE_DEBUG
-    vtimer_print(timer);
+        vtimer_print(timer);
 #endif
-    DEBUG("vtimer_callback(): Shooting %" PRIu32 ".\n", timer->absolute.microseconds);
+        DEBUG("vtimer_callback(): Shooting %" PRIu32 ".\n", timer->absolute.microseconds);
 
-    /* shoot timer */
-    timer->action(timer);
+        /* shoot timer */
+        timer->action(timer);
+    }
+    else {
+        DEBUG("vtimer_callback(): spurious call.\n");
+    }
 
     in_callback = false;
     update_shortterm();


### PR DESCRIPTION
It seems that there are corner cases where a vtimer was removed, but
still there comes a hwtimer callback. This is a bug somewhere in the
vtimer or hwtimer. If there still was a vtimer set, then the next one
gets called before its time. If there was no other vtimer scheduled,
then `timer->action(timer)` crashes.

This PR simply fixes the crash, but does not attempt to find the more
fundamental bug.
