### PR TITLE
Make filenames in periph documentation unique

### DIFF
--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -10,7 +10,7 @@
  * @brief       Low-level ADC peripheral driver
  * @{
  *
- * @file        adc.h
+ * @file        periph/adc.h
  * @brief       Low-level ADC peripheral driver interface definitions
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -10,7 +10,7 @@
  * @brief       Low-level GPIO peripheral driver
  * @{
  *
- * @file        gpio.h
+ * @file        periph/gpio.h
  * @brief       Low-level GPIO peripheral driver interface definitions
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/drivers/include/periph/pwm.h
+++ b/drivers/include/periph/pwm.h
@@ -11,7 +11,7 @@
  * @brief       Low-level PWM peripheral driver
  * @{
  *
- * @file
+ * @file        periph/pwm.h
  * @brief       Low-level PWM peripheral driver interface definitions
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -10,7 +10,7 @@
  * @brief       Low-level timer peripheral driver
  * @{
  *
- * @file        timer.h
+ * @file        periph/timer.h
  * @brief       Low-level timer peripheral driver interface definitions
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -10,7 +10,7 @@
  * @brief       Low-level UART peripheral driver
  * @{
  *
- * @file        uart.h
+ * @file        periph/uart.h
  * @brief       Low-level UART peripheral driver interface definitions
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>


### PR DESCRIPTION
This makes the filenames in the documentation of low-lever peripheral
drivers unique, so doxygen stops complaining about duplicates.
