### PR TITLE
core: , sys: , cpu: , drivers: , examples: make headers cpp compatible

### DIFF
--- a/core/include/bitarithm.h
+++ b/core/include/bitarithm.h
@@ -21,6 +21,10 @@
 #ifndef BITARITHM_H_
 #define BITARITHM_H_
 
+#ifdef __cplusplus 
+extern "C" {
+#endif
+
 /**
  * @def SETBIT
  * @brief Sets a bitbitmask for a bitfield
@@ -114,6 +118,11 @@ unsigned bitarithm_lsb(register unsigned v);
  * Source: http://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious
  */
 unsigned bitarithm_bits_set(unsigned v);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* BITARITHM_H_ */
 /** @} */

--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -22,6 +22,11 @@
 #ifndef __DEBUG_H
 #define __DEBUG_H
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif 
+
 #include <stdio.h>
 #include "sched.h"
 
@@ -81,5 +86,10 @@
 #endif
 /** @} */
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __DEBUG_H */
 /** @} */
+

--- a/core/include/flags.h
+++ b/core/include/flags.h
@@ -19,6 +19,14 @@
 #ifndef _FLAGS_H
 #define _FLAGS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+
+
 /**
  * @name Optional flags for controlling a threads initial state.
  * @{
@@ -29,6 +37,10 @@
 #define CREATE_STACKTEST    (8)     /**< write markers into the thread's stack to measure stack
                                          usage (for debugging) */
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FLAGS_H */
 /** @} */

--- a/core/include/hwtimer.h
+++ b/core/include/hwtimer.h
@@ -34,6 +34,10 @@
 #ifndef __HWTIMER_H
 #define __HWTIMER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 #include "hwtimer_cpu.h"
 
@@ -135,6 +139,10 @@ void hwtimer_init_comp(uint32_t fcpu);
  * @param[in]   ticks        Number of kernel ticks to delay
  */
 void hwtimer_spin(unsigned long ticks);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __HWTIMER_H */

--- a/core/include/kernel.h
+++ b/core/include/kernel.h
@@ -23,6 +23,13 @@
 #ifndef KERNEL_H_
 #define KERNEL_H_
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
 #include <stdbool.h>
 
 #include "attributes.h"
@@ -142,6 +149,10 @@ int reboot(int mode);
  * @brief Reboot the system in the usual fashion
  */
 #define RB_AUTOBOOT 0
+
+#ifdef __cplusplus
+}
+#endif 
 
 #endif /* KERNEL_H_ */
 /** @} */

--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -33,6 +33,12 @@
 #ifndef __MSG_H_
 #define __MSG_H_
 
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+
+
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -179,6 +185,12 @@ int msg_reply(msg_t *m, msg_t *reply);
  * @return -1, on error
  */
 int msg_init_queue(msg_t *array, int num);
+
+
+
+#ifdef	__cplusplus
+}
+#endif
 
 #endif /* __MSG_H_ */
 /** @} */

--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -22,6 +22,10 @@
 #ifndef __MUTEX_H_
 #define __MUTEX_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "queue.h"
 
 /**
@@ -88,6 +92,10 @@ void mutex_unlock(struct mutex_t *mutex);
  * @param[in] mutex Mutex object to unlock, must not be NULL.
  */
 void mutex_unlock_and_sleep(struct mutex_t *mutex);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __MUTEX_H_ */
 /** @} */

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -22,6 +22,10 @@
 #ifndef _SCHEDULER_H
 #define _SCHEDULER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stddef.h>
 #include "bitarithm.h"
 #include "tcb.h"
@@ -121,6 +125,11 @@ extern schedstat sched_pidlist[MAXTHREADS];
  */
 void sched_register_cb(void (*callback)(uint32_t, uint32_t));
 
+#endif
+
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif // _SCHEDULER_H

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -23,6 +23,11 @@
 #define __THREAD_H
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 #include "kernel.h"
 #include "tcb.h"
 #include "arch/thread_arch.h"
@@ -141,6 +146,11 @@ int thread_getpid(void);
  * @return          the amount of unused space of the thread's stack
  */
 int thread_measure_stack_free(char *stack);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 /* @} */
 #endif /* __THREAD_H */

--- a/cpu/native/include/nativenet.h
+++ b/cpu/native/include/nativenet.h
@@ -25,6 +25,10 @@
 #ifndef NATIVENET_H
 #define NATIVENET_H
 
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
 #include <net/ethernet.h>
 
 #define RX_BUF_SIZE (10)
@@ -135,5 +139,10 @@ uint16_t nativenet_get_pan(void);
  * Enable transceiver rx mode
  */
 void nativenet_switch_to_rx(void);
+
+#ifdef __cplusplus
+}
+#endif
+
 /** @} */
 #endif /* NATIVENET_H */

--- a/drivers/include/ltc4150.h
+++ b/drivers/include/ltc4150.h
@@ -1,6 +1,11 @@
 #ifndef __LTC4150_H
 #define __LTC4150_H
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "ltc4150_arch.h"
 
 void ltc4150_init(void);
@@ -13,5 +18,11 @@ double ltc4150_get_total_Joule(void);
 double ltc4150_get_avg_mA(void);
 int ltc4150_get_interval(void);
 long ltc4150_get_intcount(void);
+
+
+
+#ifdef __cplusplus
+}				   /*Cpp def*/
+#endif
 
 #endif /* __LTC4150_H */

--- a/drivers/include/rtc.h
+++ b/drivers/include/rtc.h
@@ -22,6 +22,11 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 #ifndef RTC_H
 #define RTC_H
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define RTC_SECOND 10001U
 
 #include <time.h>
@@ -62,5 +67,8 @@ time_t rtc_time(struct timeval *time);
 
 extern int rtc_second_pid;
 
+#ifdef __cplusplus
+}
+#endif
 /** @} */
 #endif

--- a/examples/rpl_udp/demo.h
+++ b/examples/rpl_udp/demo.h
@@ -1,6 +1,12 @@
 #ifndef DEMO_H
 #define DEMO_H
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 #include "kernel.h"
 
 #define APP_VERSION "1.1"
@@ -51,4 +57,9 @@ void *rpl_udp_monitor(void *arg);
 extern radio_address_t id;
 extern ipv6_addr_t std_addr;
 extern char addr_str[IPV6_MAX_ADDR_STR_LEN];
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* DEMO_H */

--- a/sys/include/bloom.h
+++ b/sys/include/bloom.h
@@ -116,6 +116,10 @@
 #ifndef _BLOOM_FILTER_H
 #define _BLOOM_FILTER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -207,6 +211,10 @@ void bloom_add(struct bloom_t *bloom, const uint8_t *buf, size_t len);
  *
  */
 bool bloom_check(struct bloom_t *bloom, const uint8_t *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* _BLOOM_FILTER_H */

--- a/sys/include/board_uart0.h
+++ b/sys/include/board_uart0.h
@@ -12,6 +12,10 @@
 #ifndef __BOARD_UART0_H
 #define __BOARD_UART0_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif 
+
 #include "cpu-conf.h"   /* To give user access to UART0_BUFSIZE */
 
 extern int uart0_handler_pid;
@@ -22,6 +26,11 @@ void uart0_notify_thread(void);
 
 int uart0_readc(void);
 void uart0_putc(int c);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __BOARD_UART0_H */

--- a/sys/include/crypto/sha256.h
+++ b/sys/include/crypto/sha256.h
@@ -49,6 +49,10 @@
 #ifndef _SHA256_H_
 #define _SHA256_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <inttypes.h>
 
 #define SHA256_DIGEST_LENGTH 32
@@ -95,6 +99,11 @@ void sha256_final(unsigned char digest[32], sha256_context_t *ctx);
  *           if md == NULL, one static buffer is used
  */
 unsigned char *sha256(const unsigned char *d, size_t n, unsigned char *md);
+
+#ifdef __cplusplus
+}
+#endif
+
 
 /** @} */
 #endif /* _SHA256_H_ */

--- a/sys/include/hashes.h
+++ b/sys/include/hashes.h
@@ -23,6 +23,11 @@
 #ifndef __HASHES_H
 #define __HASHES_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 #include <stddef.h>
 #include <inttypes.h>
 
@@ -155,6 +160,10 @@ uint32_t rotating_hash(const uint8_t *buf, size_t len);
  * @return 32 bit sized hash
  */
 uint32_t one_at_a_time_hash(const uint8_t *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __HASHES_H */

--- a/sys/include/posix_io.h
+++ b/sys/include/posix_io.h
@@ -21,6 +21,12 @@
 #ifndef __READ_H
 #define __READ_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
 #define OPEN 0
 #define CLOSE 1
 #define READ 2
@@ -35,6 +41,12 @@ int posix_open(int pid, int flags);
 int posix_close(int pid);
 int posix_read(int pid, char *buffer, int bufsize);
 int posix_write(int pid, char *buffer, int bufsize);
+
+
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __READ_H */

--- a/sys/include/ps.h
+++ b/sys/include/ps.h
@@ -8,7 +8,18 @@
 #ifndef __PS_H
 #define __PS_H
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 void thread_print_all(void);
 void _ps_handler(int argc, char **argv);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PS_H */

--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -7,6 +7,10 @@
 
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef PRNG_FLOAT
 #  define PRNG_FLOAT (0)
 #endif
@@ -62,5 +66,9 @@ double genrand_real_exclusive(void);
  * @return a random number on [0,1) with 53-bit resolution
  */
 double genrand_res53(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* PRNG_FLOAT */

--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -15,6 +15,11 @@
 #ifndef __SHELL_H
 #define __SHELL_H
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 
 #include "attributes.h"
@@ -83,5 +88,9 @@ void shell_init(shell_t *shell,
  * @returns         This function does not return.
  */
 void shell_run(shell_t *shell) NORETURN;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SHELL_H */

--- a/sys/include/shell_commands.h
+++ b/sys/include/shell_commands.h
@@ -1,6 +1,12 @@
 #ifndef __SHELL_COMMANDS_H
 #define __SHELL_COMMANDS_H
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 #include "shell.h"
 
 #define DISK_GET_SECTOR_SIZE    "dget_ssize"
@@ -10,5 +16,9 @@
 #define DISK_READ_BYTES_CMD     "dread"
 
 extern const shell_command_t _shell_command_list[];
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SHELL_COMMANDS_H */

--- a/sys/include/tm.h
+++ b/sys/include/tm.h
@@ -1,4 +1,4 @@
-/**
++/**
  * @addtogroup  sys_timex
  * @{
  * @brief       Utility library for `struct tm`.
@@ -6,6 +6,10 @@
 
 #ifndef __SYS__TIMEX__TM__H
 #define __SYS__TIMEX__TM__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <time.h>
 #include <sys/time.h>
@@ -99,5 +103,10 @@ int tm_is_valid_date(int year, int mon, int mday) CONST;
  * @returns         0 iff the time is invalid.
  */
 int tm_is_valid_time(int hour, int min, int sec) CONST;
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/sys/include/transceiver.h
+++ b/sys/include/transceiver.h
@@ -11,6 +11,11 @@
 #ifndef TRANSCEIVER_H
 #define TRANSCEIVER_H
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "radio/types.h"
 
 /* supported transceivers *
@@ -237,6 +242,11 @@ uint8_t transceiver_register(transceiver_type_t transceivers, int pid);
  * @return              1 on success, 0 otherwise
  */
 uint8_t transceiver_unregister(transceiver_type_t transceivers, int pid);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TRANSCEIVER_H */
 /** @} */

--- a/sys/include/vtimer.h
+++ b/sys/include/vtimer.h
@@ -18,6 +18,10 @@
 #ifndef __VTIMER_H
 #define __VTIMER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <time.h>
 #include <sys/time.h>
 
@@ -132,6 +136,10 @@ void vtimer_print_short_queue(void);
  */
 void vtimer_print_long_queue(void);
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 /** @} */

--- a/sys/net/include/ccn_lite/ccnl-riot.h
+++ b/sys/net/include/ccn_lite/ccnl-riot.h
@@ -34,6 +34,10 @@
 #ifndef RIOT_CCN_COMPAT_H_
 #define RIOT_CCN_COMPAT_H_
 
+#ifdef __cplusplus
+extern "C"  {
+#endif
+
 #include <inttypes.h>
 
 #include "transceiver.h"
@@ -79,6 +83,11 @@ void ccnl_riot_relay_start(int max_cache_entries, int fib_threshold_prefix, int 
  * @param relay_pid the pid of the relay
  */
 void ccnl_riot_appserver_start(int relay_pid);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/sys/net/include/ccn_lite/util/ccnl-riot-client.h
+++ b/sys/net/include/ccn_lite/util/ccnl-riot-client.h
@@ -27,6 +27,12 @@
 #ifndef CCNL_RIOT_CLIENT_H
 #define CCNL_RIOT_CLIENT_H
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 /**
  * @brief  high level function to fetch a file (all chunks of a file)
  *
@@ -102,6 +108,11 @@ int ccnl_riot_client_new_face(unsigned int relay_pid, char *type, char *faceid,
  */
 int ccnl_riot_client_register_prefix(unsigned int relay_pid, char *prefix,
         char *faceid, unsigned char *reply_buf);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/sys/net/include/destiny.h
+++ b/sys/net/include/destiny.h
@@ -33,6 +33,12 @@
 #ifndef DESTINY_H
 #define DESTINY_H
 
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "destiny/in.h"
 #include "destiny/socket.h"
 #include "destiny/types.h"
@@ -43,5 +49,9 @@
  * @return 0 on success, other else.
  */
 int destiny_init_transport_layer(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* DESTINY_H */

--- a/sys/net/include/net_help.h
+++ b/sys/net/include/net_help.h
@@ -12,6 +12,10 @@
 #ifndef __NET_HELP_H
 #define __NET_HELP_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <string.h>
 #include <stdint.h>
 
@@ -41,6 +45,10 @@
 
 uint16_t csum(uint16_t sum, uint8_t *buf, uint16_t len);
 void printArrayRange(uint8_t *array, uint16_t len, char *str);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __NET_HELP_H */

--- a/sys/net/include/net_if.h
+++ b/sys/net/include/net_if.h
@@ -22,6 +22,11 @@
 #ifndef _NET_IF_H
 #define _NET_IF_H
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -497,6 +502,11 @@ int32_t net_if_get_pan_id(int if_id);
  * @return  the PAN ID on success, -1 on failure.
  */
 int32_t net_if_set_pan_id(int if_id, uint16_t pan_id);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/sys/posix/include/semaphore.h
+++ b/sys/posix/include/semaphore.h
@@ -1,6 +1,10 @@
 #ifndef _SEMAPHORE_H
 #define _SEMAPHORE_H	1
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <time.h>
 
 /** Value returned if `sem_open' failed.  */
@@ -97,5 +101,9 @@ int sem_post(sem_t *sem);
  * @param sval place whre value goes to
  */
 int sem_getvalue(sem_t *sem, int *sval);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif	/* semaphore.h */

--- a/sys/posix/pthread/include/pthread.h
+++ b/sys/posix/pthread/include/pthread.h
@@ -12,6 +12,10 @@
 #ifndef __SYS__POSIX__PTHREAD__H
 #define __SYS__POSIX__PTHREAD__H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <time.h>
 
 #include "kernel.h"
@@ -31,6 +35,10 @@
 #include "pthread_scheduling.h"
 #include "pthread_cancellation.h"
 #include "pthread_cond.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 


### PR DESCRIPTION
Hi, I extended the used headers inluded in `./RIOT/tests/*` and `./RIOT/examples/*` to be compatible with cpp compilers.
This addresses partly #944. 
