### PR TITLE
native: create tap interfaces ad-hoc

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -78,6 +78,7 @@ endif
 endif
 
 # set the tap interface for term/valgrind
+ifneq (,$(findstring term, $(MAKECMDGOALS)))
 ifneq (,$(filter nativenet,$(USEMODULE)))
 export PORT = $(shell ../../cpu/native/tools/tapdep.sh)
 ifeq (,$(PORT))
@@ -85,6 +86,7 @@ $(error automatic tap setup failed)
 endif
 else
 export PORT =
+endif
 endif
 
 all: # do not override first target

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -79,9 +79,12 @@ endif
 
 # set the tap interface for term/valgrind
 ifneq (,$(filter nativenet,$(USEMODULE)))
-	export PORT ?= tap0
+export PORT = $(shell ../../cpu/native/tools/tapdep.sh)
+ifeq (,$(PORT))
+$(error automatic tap setup failed)
+endif
 else
-	export PORT =
+export PORT =
 endif
 
 all: # do not override first target

--- a/cpu/native/tools/tapdep.sh
+++ b/cpu/native/tools/tapdep.sh
@@ -1,31 +1,12 @@
 #!/bin/sh
 
-DEFBRIDGE="tapbr0"
-DEFTAPBASE="tap"
-
-# make sure this is not called as root
-if [ ${EUID} -eq 0 -o "$(ps -p ${PPID} -o comm=)" = "sudo" -o "$(ps -p ${PPID} -o comm=)" = "su" ]; then
-    echo "Error: ${0} must not be run as root"
-    exit 1
-fi
-if [ -z "${USER}" ]; then
-    echo 'need to export $USER'
-    exit 1
-fi
-
-# set defaults
-if [ -z "${BRIDGE}" ]; then
-    BRIDGE="${DEFBRIDGE}"
-fi
-if [ -z "${TAPBASE}" ]; then
-    TAPBASE="${DEFTAPBASE}"
-fi
-
-OS=$(uname -s)
-
-###
+######################################################################
 # Linux functions
-##
+######################################################################
+
+Linux_default_bridge () {
+    echo tapbr0
+}
 
 Linux_bridge_exists () {
     if [ -e /sys/class/net/${BRIDGE} ]; then
@@ -71,9 +52,40 @@ Linux_port_exists () {
     fi
 }
 
-###
+######################################################################
 # OSX functions
+######################################################################
+
+Darwin_default_bridge () {
+    echo bridge1234
+}
+
 ##
+# THE SCRIPT
+##
+
+OS=$(uname -s)
+
+DEFBRIDGE=$(${OS}_default_bridge)
+DEFTAPBASE="tap"
+
+# make sure this is not called as root
+if [ ${EUID} -eq 0 -o "$(ps -p ${PPID} -o comm=)" = "sudo" -o "$(ps -p ${PPID} -o comm=)" = "su" ]; then
+    echo "Error: ${0} must not be run as root"
+    exit 1
+fi
+if [ -z "${USER}" ]; then
+    echo 'need to export $USER'
+    exit 1
+fi
+
+# set defaults
+if [ -z "${BRIDGE}" ]; then
+    BRIDGE="${DEFBRIDGE}"
+fi
+if [ -z "${TAPBASE}" ]; then
+    TAPBASE="${DEFTAPBASE}"
+fi
 
 if ! ${OS}_bridge_exists; then
     ${OS}_bridge_create

--- a/cpu/native/tools/tapdep.sh
+++ b/cpu/native/tools/tapdep.sh
@@ -3,7 +3,7 @@
 DEFBRIDGE="tapbr0"
 DEFTAPBASE="tap"
 
-if [ "$(ps -p ${PPID} -o comm=)" = "sudo" -o "$(ps -p ${PPID} -o comm=)" = "su" ]; then
+if [ ${EUID} -eq 0 -o "$(ps -p ${PPID} -o comm=)" = "sudo" -o "$(ps -p ${PPID} -o comm=)" = "su" ]; then
     echo "Error: ${0} must not be run as root"
     exit 1
 fi

--- a/cpu/native/tools/tapdep.sh
+++ b/cpu/native/tools/tapdep.sh
@@ -4,7 +4,7 @@
 # Linux functions
 ######################################################################
 
-Linux_default_bridge () {
+Linux_bridge_default () {
     echo tapbr0
 }
 
@@ -22,7 +22,7 @@ Linux_bridge_create () {
     sudo ip link set ${BRIDGE} up || exit 1
 }
 
-Linux_define_port () {
+Linux_port_define () {
     # try to find an existing unused interface ..
     for IF in $(ls /sys/class/net/${BRIDGE}/brif/); do
         if [ "$(cat /sys/class/net/${BRIDGE}/brif/${IF}/state)" = 0 ]; then
@@ -37,7 +37,7 @@ Linux_define_port () {
     fi
 }
 
-Linux_create_port () {
+Linux_port_create () {
     sudo ip tuntap add dev ${PORT} mode tap user ${USER} || exit 1
     sudo -s sh -c "echo 1 > /proc/sys/net/ipv6/conf/${PORT}/disable_ipv6" || exit 1
     sudo brctl addif ${BRIDGE} ${PORT} || exit 1
@@ -58,6 +58,20 @@ Linux_port_exists () {
 
 Darwin_default_bridge () {
     echo bridge1234
+}
+
+Darwin_bridge_create () {
+    sudo ifconfig ${BRIDGE} create || exit 1
+    echo "upping ${BRIDGE}"
+    sudo ifconfig ${BRIDGE} up || exit 1
+}
+
+Darwin_port_create () {
+    sudo chown ${USER} /dev/${PORT} || exit 1
+    echo "start RIOT instance for ${PORT} now and hit enter"
+    read
+    sudo ifconfig ${BRIDGE} addm ${PORT} || exit 1
+    sudo ifconfig ${PORT} up
 }
 
 ##
@@ -92,11 +106,11 @@ if ! ${OS}_bridge_exists; then
 fi
 
 if [ -z "${PORT}" ]; then
-    ${OS}_define_port
+    ${OS}_port_define
 fi
 
 if ! ${OS}_port_exists; then
-    ${OS}_create_port
+    ${OS}_port_create
 fi
 
 echo ${PORT}

--- a/cpu/native/tools/tapdep.sh
+++ b/cpu/native/tools/tapdep.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+DEFBRIDGE="tapbr0"
+DEFTAPBASE="tap"
+
+if [ "$(ps -p ${PPID} -o comm=)" = "sudo" -o "$(ps -p ${PPID} -o comm=)" = "su" ]; then
+    echo "Error: ${0} must not be run as root"
+    exit 1
+fi
+if [ -z "${USER}" ]; then
+    echo 'need to export $USER'
+    exit 1
+fi
+
+if [ -z "${BRIDGE}" ]; then
+    BRIDGE="${DEFBRIDGE}"
+fi
+if [ -z "${TAPBASE}" ]; then
+    TAPBASE="${DEFTAPBASE}"
+fi
+
+if [ ! -e /sys/class/net/${BRIDGE} ]; then
+    # ${BRIDGE} does not exist yet, create it ...
+    sudo brctl addbr ${BRIDGE} || exit 1
+    sudo -s sh -c "echo 1  > /proc/sys/net/ipv6/conf/${BRIDGE}/disable_ipv6" || exit 1
+    sudo ip link set ${BRIDGE} up || exit 1
+fi
+
+if [ -z "${PORT}" ]; then
+
+    # try to find an existing unused interface ..
+    for IF in $(ls /sys/class/net/${BRIDGE}/brif/); do
+        if [ "$(cat /sys/class/net/${BRIDGE}/brif/${IF}/state)" = 0 ]; then
+            PORT=${IF}
+            break
+        fi
+    done
+
+    # .. or create a new one
+    if [ -z "${PORT}" ]; then
+        COUNT=$(ls /sys/class/net/${BRIDGE}/brif/ | sort -n | wc -l)
+        PORT=${TAPBASE}${COUNT}
+    fi
+
+fi
+
+if [ ! -e /sys/class/net/${BRIDGE}/brif/${PORT} ]; then
+    # ${PORT} does not exist, create it
+    sudo ip tuntap add dev ${PORT} mode tap user ${USER} || exit 1
+    sudo -s sh -c "echo 1 > /proc/sys/net/ipv6/conf/${PORT}/disable_ipv6" || exit 1
+    sudo brctl addif ${BRIDGE} ${PORT} || exit 1
+    sudo ip link set ${PORT} up || exit 1
+fi
+
+echo ${PORT}


### PR DESCRIPTION
PR currently only works in Linux, I will add support for other systems once the concept is ACK'd.

Usage: ignore `tapsetup.sh`, just use `make term` and get as many tap interfaces as you need.

TODO:
- [x] don't create unless term target is given
- [ ] integrate support for OSX/FreeBSD
- [ ] update documentation