### PR TITLE
make: allow setting RIOT_VERSION externally

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -55,6 +55,7 @@ buildtest:
 			RIOTCPU=$${RIOTCPU} \
 			BINDIRBASE=$${BINDIRBASE} \
 			RIOTNOLINK=$${RIOTNOLINK} \
+			RIOT_VERSION=$${RIOT_VERSION} \
 			$(MAKE) -j$(NPROC) 2>&1 >/dev/null) ; \
 		if [ "$${?}" = "0" ]; then \
 			$${ECHO} "$${GREEN}success$${RESET}"; \

--- a/Makefile.include
+++ b/Makefile.include
@@ -64,16 +64,18 @@ endif
 include $(RIOTBASE)/Makefile.cflags
 
 # make the RIOT version available to the program
-GIT_STRING := $(shell git describe --always --abbrev=4 --dirty=-`hostname`)
-ifneq (,$(GIT_STRING))
-  GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-  ifeq ($(strip $(GIT_BRANCH)),master)
-    RIOT_VERSION := $(GIT_STRING)
+ifeq ($(origin RIOT_VERSION), undefined)
+  GIT_STRING := $(shell git describe --always --abbrev=4 --dirty=-`hostname`)
+  ifneq (,$(GIT_STRING))
+    GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+    ifeq ($(strip $(GIT_BRANCH)),master)
+      RIOT_VERSION := $(GIT_STRING)
+    else
+      RIOT_VERSION := $(GIT_STRING)-$(GIT_BRANCH)
+    endif
   else
-    RIOT_VERSION := $(GIT_STRING)-$(GIT_BRANCH)
+    RIOT_VERSION := UNKNOWN
   endif
-else
-  RIOT_VERSION := UNKNOWN
 endif
 export CFLAGS += -DRIOT_VERSION='"$(RIOT_VERSION)"'
 


### PR DESCRIPTION
Allows for reasonable size comparisons between branches.

Also fix indentation
