### PR TITLE
make: fix buildsizes* targets

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -93,8 +93,8 @@ buildsizes:
 	else \
 		BOARDS="$(BOARD_WHITELIST)"; \
 	fi; \
-	for BOARD in $(BOARD_BLACKLIST); do \
-		BOARDS=$$(sed -e "s/ $${BOARD} / /" <<< " $${BOARDS} "); \
+	for BOARD in $(BOARD_BLACKLIST) $(BOARD_INSUFFICIENT_RAM); do \
+		BOARDS=$$(echo \ $${BOARDS}\  | sed -e 's/ '$${BOARD}' / /'); \
 	done; \
 	\
 	echo -e "   text\t   data\t    bss\t    dec\tboard"; \
@@ -117,8 +117,8 @@ buildsizes-diff:
 	else \
 		BOARDS="$(BOARD_WHITELIST)"; \
 	fi; \
-	for BOARD in $(BOARD_BLACKLIST); do \
-		BOARDS=$$(sed -e "s/ $${BOARD} / /" <<< " $${BOARDS} "); \
+	for BOARD in $(BOARD_BLACKLIST) $(BOARD_INSUFFICIENT_RAM); do \
+		BOARDS=$$(echo \ $${BOARDS}\  | sed -e 's/ '$${BOARD}' / /'); \
 	done; \
 	\
 	GREEN='\033[1;32m'; RED='\033[1;31m'; RESET='\033[0m'; \


### PR DESCRIPTION
- also ignore BOARD_INSUFFICIENT_RAM boards
- unify/make work BOARD filter

Not sure why it failed I don't know the `<<<` construct .. I've got a `GNU bash, version 4.3.18(1)-release (x86_64-unknown-linux-gnu)`
