### PR TITLE
doc: fix all occurences of FU as author

### DIFF
--- a/boards/avsextrem/board_init.c
+++ b/boards/avsextrem/board_init.c
@@ -12,7 +12,6 @@
  * @file
  * @brief       avsextrem board initialization
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Heiko Will
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Michael Baar

--- a/boards/avsextrem/drivers/avsextrem-cc1100.c
+++ b/boards/avsextrem/drivers/avsextrem-cc1100.c
@@ -13,7 +13,6 @@
  * @ingroup	LPC2387
  * @brief	CC1100 LPC2387 dependend functions
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>

--- a/boards/avsextrem/drivers/avsextrem-smb380.c
+++ b/boards/avsextrem/drivers/avsextrem-smb380.c
@@ -14,7 +14,6 @@
  * @brief       SMB380 acceleration sensor driver for the LPC2387 on the
  *              AVSEXTREM board.
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Marco Ziegert <ziegert@inf.fu-berlin.de>
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  * @version     $Revision: 3854 $

--- a/boards/avsextrem/drivers/avsextrem-ssp0.c
+++ b/boards/avsextrem/drivers/avsextrem-ssp0.c
@@ -12,7 +12,6 @@
  * @internal
  * @brief       Implements the SPI0 interface for the LPC2387
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Marco Ziegert <ziegert@inf.fu-berlin.de>
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  * @version     $Revision: 3854 $

--- a/boards/avsextrem/include/board.h
+++ b/boards/avsextrem/include/board.h
@@ -16,7 +16,6 @@
  * @file        board.h
  * @brief       Boards specific drivers and configuration for the Avsextrem board
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Heiko Will
  * @author      Zakaria Kasmi
  */

--- a/boards/avsextrem/include/configure.h
+++ b/boards/avsextrem/include/configure.h
@@ -11,7 +11,6 @@
  * @file
  * @brief       definitions for the avsextrem board configuration
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      baar
  * @author      Zakaria Kasmi
  * @version     $Revision: 1127 $

--- a/boards/avsextrem/include/smb380-board.h
+++ b/boards/avsextrem/include/smb380-board.h
@@ -12,7 +12,6 @@
  * @internal
  * @brief   SMB380 acceleration sensor definitions for the LPC2387
  *
- * @author  Freie Universität Berlin, Computer Systems & Telematics
  * @author  Marco Ziegert <ziegert@inf.fu-berlin.de>
  * @author  Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  * @version $Revision: 3854 $

--- a/boards/avsextrem/include/ssp0-board.h
+++ b/boards/avsextrem/include/ssp0-board.h
@@ -12,7 +12,6 @@
  * @internal
  * @brief       SPI interface definitions for the LPC2387
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Marco Ziegert <ziegert@inf.fu-berlin.de>
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  * @version     $Revision: 3854 $

--- a/boards/msba2-common/board_common_init.c
+++ b/boards/msba2-common/board_common_init.c
@@ -15,7 +15,6 @@
  * @file
  * @brief       MSB-A2 board initialization
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
  * @author      Heiko Will
  * @author      Kaspar Schleiser
  * @author      Michael Baar <baar@inf.fu-berlin.de>

--- a/boards/msba2-common/drivers/msba2-ltc4150.c
+++ b/boards/msba2-common/drivers/msba2-ltc4150.c
@@ -16,7 +16,6 @@
  * @file
  * @brief		LTC4150 MSB-A2 specific implemetation
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
  * @author		Heiko Will
  * @author		Michael Baar
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/boards/msba2-common/drivers/msba2-uart0.c
+++ b/boards/msba2-common/drivers/msba2-uart0.c
@@ -9,8 +9,8 @@
 /*
  * debug_uart.c: provides initial serial debug output
  *
- * Copyright (C) 2008, 2009  Kaspar Schleiser <kaspar@schleiser.de>
- *                           Heiko Will <hwill@inf.fu-berlin.de>
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
+ * @author Heiko Will <hwill@inf.fu-berlin.de>
  */
 #include <stdlib.h>
 #include <string.h>
@@ -25,7 +25,6 @@
  * @file
  * @ingroup     lpc2387
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
  * @version     $Revision$
  *
  * @note    $Id$

--- a/boards/msba2-common/include/msba2_common.h
+++ b/boards/msba2-common/include/msba2_common.h
@@ -7,7 +7,6 @@
  * @files       msba2-common.h
  * @brief       MSB-A2 Common Board Definitions
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 #ifndef __MSBA2_COMMON_H

--- a/boards/msba2/board_init.c
+++ b/boards/msba2/board_init.c
@@ -15,7 +15,6 @@
  * @file
  * @brief       MSB-A2 board initialization
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
  * @author      Heiko Will
  * @author      Kaspar Schleiser
  * @author      Michael Baar <baar@inf.fu-berlin.de>

--- a/boards/msba2/msba2-cc110x.c
+++ b/boards/msba2/msba2-cc110x.c
@@ -11,7 +11,6 @@
  * @ingroup		LPC2387
  * @brief		CC1100 LPC2387 dependend functions
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
  * @author		Heiko Will <hwill@inf.fu-berlin.de>
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @version     $Revision: 1781 $

--- a/boards/pttu/include/board.h
+++ b/boards/pttu/include/board.h
@@ -7,7 +7,6 @@
  * @file        board.h
  * @brief       Basic definitions for the PTTU board
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 

--- a/boards/wsn430-v1_3b/include/board.h
+++ b/boards/wsn430-v1_3b/include/board.h
@@ -19,7 +19,6 @@
  * @file        board.h
  * @brief       Basic definitions for the Senslab WSN430 v1.3b board
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
  * @author      Milan Babel <babel@inf.fu-berlin.de>
  */
 

--- a/boards/wsn430-v1_4/include/board.h
+++ b/boards/wsn430-v1_4/include/board.h
@@ -19,7 +19,6 @@
  * @file        board.h
  * @brief       Basic definitions for the Senslab WSN430 v1.4 board
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
  * @author      Milan Babel <babel@inf.fu-berlin.de>
  */
 

--- a/core/cib.c
+++ b/core/cib.c
@@ -13,7 +13,6 @@
  * @file        cib.c
  * @brief       Circular integer buffer implementation
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  * @}

--- a/core/include/atomic.h
+++ b/core/include/atomic.h
@@ -13,7 +13,6 @@
  * @file        atomic.h
  * @brief       Atomic getter and setter functions
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 

--- a/core/include/attributes.h
+++ b/core/include/attributes.h
@@ -13,7 +13,6 @@
  * @file        attributes.h
  * @brief       Compiler attributes/pragmas configuration
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  */
 

--- a/core/include/bitarithm.h
+++ b/core/include/bitarithm.h
@@ -13,7 +13,6 @@
  * @file        bitarithm.h
  * @brief       Helper functions for bit arithmetic
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Martin Lenders <mlenders@inf.fu-berlin.de>
  */

--- a/core/include/clist.h
+++ b/core/include/clist.h
@@ -13,7 +13,6 @@
  * @file        clist.h
  * @brief       Circular linked list
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 

--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -15,7 +15,6 @@
  *
  * #define ENABLE_DEBUG, include this and then use DEBUG as printf you can toggle.
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 

--- a/core/include/hwtimer.h
+++ b/core/include/hwtimer.h
@@ -25,7 +25,6 @@
  * @file        hwtimer.h
  * @brief       HW-timer abstraction
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Heiko Will
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Michael Baar

--- a/core/include/kernel.h
+++ b/core/include/kernel.h
@@ -16,7 +16,6 @@
  *              A reboot() function is also provided
  *              (and used by core_panic() when needed).
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 

--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -25,7 +25,6 @@
  * @file        msg.h
  * @brief       Messaging API for inter process communication
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
  */

--- a/core/include/queue.h
+++ b/core/include/queue.h
@@ -13,7 +13,6 @@
  * @file        queue.h
  * @brief       A simple queue implementation
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -15,7 +15,6 @@
  * @file        sched.h
  * @brief       Scheduler API definion
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 

--- a/core/include/tcb.h
+++ b/core/include/tcb.h
@@ -13,7 +13,6 @@
  * @file        tcb.h
  * @brief       Thread context block definition
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Heiko Will
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -15,7 +15,6 @@
  * @file        thread.h
  * @brief       Threading API
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 

--- a/core/msg.c
+++ b/core/msg.c
@@ -13,7 +13,6 @@
  * @file
  * @brief       Kernel messaging implementation
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>

--- a/core/queue.c
+++ b/core/queue.c
@@ -13,7 +13,6 @@
  * @file        queue.c
  * @brief       A simple queue implementation
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @}
  */

--- a/core/sched.c
+++ b/core/sched.c
@@ -13,7 +13,6 @@
  * @file        sched.c
  * @brief       Scheduler implementation
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  * @}

--- a/cpu/arm_common/bootloader.c
+++ b/cpu/arm_common/bootloader.c
@@ -21,7 +21,6 @@
  * @internal
  * @brief       ARM bootloader
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @author      Michael Baar <michael.baar@fu-berlin.de>
  * @version     $Revision$

--- a/cpu/arm_common/gettimeofday.c
+++ b/cpu/arm_common/gettimeofday.c
@@ -13,7 +13,6 @@
  * @ingroup     arm_common
  * @brief       LPC2387 Newlib gettimeofday() system call glue
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Michael Baar <michael.baar@fu-berlin.de>
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  */

--- a/cpu/arm_common/syscalls.c
+++ b/cpu/arm_common/syscalls.c
@@ -14,7 +14,6 @@
  * @ingroup     arm_common
  * @brief       LPC2387 NewLib system calls implementation
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Michael Baar <michael.baar@fu-berlin.de>
  *
  */

--- a/cpu/lpc2387/gpioint/lpc2387-gpioint.c
+++ b/cpu/lpc2387/gpioint/lpc2387-gpioint.c
@@ -19,7 +19,6 @@ See the file LICENSE in the top level directory for more details.
  * @file
  * @brief       LPC2387 GPIO Interrupt Multiplexer implementation
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Michael Baar <michael.baar@fu-berlin.de>
  * @version     $Revision: 1508 $
  *

--- a/cpu/lpc2387/i2c/i2c.c
+++ b/cpu/lpc2387/i2c/i2c.c
@@ -17,7 +17,6 @@
  *              user does not declare a handler, an appropriate interrupt is
  *              automatically registered for the specific i2c interface.
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  * @author      Marco Ziegert <ziegert@inf.fu-berlin.de>
  * @author      Benjamin Aschenbrenner

--- a/cpu/lpc2387/include/cpu-conf.h
+++ b/cpu/lpc2387/include/cpu-conf.h
@@ -24,7 +24,6 @@ See the file LICENSE in the top level directory for more details.
  * @file
  * @brief		LPC2387 CPUconfiguration
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		baar
  * @version     $Revision$
  *

--- a/cpu/lpc2387/include/i2c.h
+++ b/cpu/lpc2387/include/i2c.h
@@ -19,7 +19,6 @@
  *              does not declare a handler, an appropriate interrupt is
  *              automatically registered for the specific i2c-interface.
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  * @author      Marco Ziegert <ziegert@inf.fu-berlin.de>
  * @author      Benjamin Aschenbrenner

--- a/cpu/lpc2387/include/lpc2387-adc.h
+++ b/cpu/lpc2387/include/lpc2387-adc.h
@@ -24,7 +24,6 @@ See the file LICENSE in the top level directory for more details.
  * @file
  * @brief		LPC2387 ADC
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @version     $Revision: 3249 $
  *

--- a/cpu/lpc2387/lpc2387-adc.c
+++ b/cpu/lpc2387/lpc2387-adc.c
@@ -15,7 +15,6 @@ See the file LICENSE in the top level directory for more details.
  * @ingroup		lpc2387_adc
  * @brief		LPC2387 ADC
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @version     $Revision: 3250 $
  *

--- a/cpu/lpc2387/lpc2387-lpm.c
+++ b/cpu/lpc2387/lpc2387-lpm.c
@@ -21,7 +21,6 @@ See the file LICENSE in the top level directory for more details.
  * @brief		LPC2387 Low-Power management
  * @ingroup		lpc2387
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author 		Heiko Will
  * @version     $Revision$
  *

--- a/cpu/lpc2387/rtc/lpc2387-rtc.c
+++ b/cpu/lpc2387/rtc/lpc2387-rtc.c
@@ -15,7 +15,6 @@ See the file LICENSE in the top level directory for more details.
  * @ingroup		lpc2387_rtc
  * @brief		LPC2387 Real-Time-Clock
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Michael Baar <michael.baar@fu-berlin.de>
  * @version     $Revision: 2005 $
  *

--- a/cpu/lpc_common/hwtimer_cpu.c
+++ b/cpu/lpc_common/hwtimer_cpu.c
@@ -11,7 +11,6 @@
  * @internal
  * @brief       ARM kernel timer CPU dependent functions implementation
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>

--- a/dist/tools/linux-border_router/flowcontrol.h
+++ b/dist/tools/linux-border_router/flowcontrol.h
@@ -8,7 +8,6 @@
 
 /**
  * @file    flowcontrol.h
- * @author  Freie Universität Berlin, Computer Systems & Telemetics
  * @author  Martin Lenders <mlenders@inf.fu-berlin.de>
  * @brief   Public declarations for the flow control jobs via the
  *          serial interface for the 6LoWPAN Border Router driver.

--- a/dist/tools/linux-border_router/multiplex.h
+++ b/dist/tools/linux-border_router/multiplex.h
@@ -8,7 +8,6 @@
 
 /**
  * @file    multiplex.h
- * @author  Freie Universität Berlin, Computer Systems & Telemetics
  * @author  Martin Lenders <mlenders@inf.fu-berlin.de>
  * @brief   Public declarations for the multiplexing jobs via the
  *          serial interface for the 6LoWPAN Border Router driver.

--- a/dist/tools/linux-border_router/serialnumber.h
+++ b/dist/tools/linux-border_router/serialnumber.h
@@ -8,7 +8,6 @@
 
 /**
  * @file    serialnumber.h
- * @author  Freie Universität Berlin, Computer Systems & Telemetics
  * @author  Martin Lenders <mlenders@inf.fu-berlin.de>
  * @brief   Serial number arithmetics after RFC 1982, section 3
  */

--- a/dist/tools/linux-border_router/sixlowdriver.h
+++ b/dist/tools/linux-border_router/sixlowdriver.h
@@ -8,7 +8,6 @@
 
 /**
  * @file    sixlowdriver.h
- * @author  Freie Universität Berlin, Computer Systems & Telemetics
  * @author  Martin Lenders <mlenders@inf.fu-berlin.de>
  * @brief   Public declarations for the 6LoWPAN Border Router driver.
  */

--- a/dist/tools/linux-border_router/testing.h
+++ b/dist/tools/linux-border_router/testing.h
@@ -16,7 +16,6 @@
  *          wants to measure by calling testing_start() to start the
  *          measuring and testing_stop() to end it.
  *
- * @author  Freie Universität Berlin, Computer Systems & Telemetics
  * @author  Martin Lenders <mlenders@inf.fu-berlin.de>
  */
 

--- a/drivers/cc110x/arch_cc1100.h
+++ b/drivers/cc110x/arch_cc1100.h
@@ -17,7 +17,6 @@
  * @ingroup		LPC2387
  * @brief		CC1100 LPC2387 dependend functions
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 1775 $
  *

--- a/drivers/cc110x/cc1100-csmaca-mac.c
+++ b/drivers/cc110x/cc1100-csmaca-mac.c
@@ -17,7 +17,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @ingroup		dev_cc110x
  * @brief		ScatterWeb MSB-A2 mac-layer
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author		Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 2128 $

--- a/drivers/cc110x/cc1100-csmaca-mac.h
+++ b/drivers/cc110x/cc1100-csmaca-mac.h
@@ -17,7 +17,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @ingroup		dev_cc110x
  * @brief		ScatterWeb MSB-A2 mac-layer
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author		Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 1999 $

--- a/drivers/cc110x/cc1100-defaultSettings.c
+++ b/drivers/cc110x/cc1100-defaultSettings.c
@@ -21,7 +21,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @file
  * @brief		TI Chipcon CC110x default settings
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author		Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 2058 $

--- a/drivers/cc110x/cc1100-defaultSettings.h
+++ b/drivers/cc110x/cc1100-defaultSettings.h
@@ -24,7 +24,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @file
  * @brief		TI Chipcon CC110x default settings
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author		Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 2139 $

--- a/drivers/cc110x/cc1100-internal.h
+++ b/drivers/cc110x/cc1100-internal.h
@@ -25,7 +25,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @internal
  * @brief		TI Chipcon CC110x internal hardware constants
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author		Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 1231 $

--- a/drivers/cc110x/cc1100.c
+++ b/drivers/cc110x/cc1100.c
@@ -19,7 +19,6 @@
  * @internal
  * @brief		TI Chipcon CC110x Radio driver
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author		Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 2283 $

--- a/drivers/cc110x/cc1100.h
+++ b/drivers/cc110x/cc1100.h
@@ -25,7 +25,6 @@
  * @file
  * @brief       TI Chipcon CC110x radio driver
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author      Heiko Will <hwill@inf.fu-berlin.de>
  */

--- a/drivers/cc110x/cc1100_phy.c
+++ b/drivers/cc110x/cc1100_phy.c
@@ -22,7 +22,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @internal
  * @brief		TI Chipcon CC110x physical radio driver
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author		Heiko Will <hwill@inf.fu-berlin.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>

--- a/drivers/cc110x/cc1100_phy.h
+++ b/drivers/cc110x/cc1100_phy.h
@@ -22,7 +22,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @internal
  * @brief		TI Chipcon CC110x physical radio driver
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author		Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 1285 $

--- a/drivers/cc110x/cc1100_spi.c
+++ b/drivers/cc110x/cc1100_spi.c
@@ -22,7 +22,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @internal
  * @brief		TI Chipcon CC1100 SPI driver
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author		Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 1775 $

--- a/drivers/cc110x/cc1100_spi.h
+++ b/drivers/cc110x/cc1100_spi.h
@@ -22,7 +22,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @internal
  * @brief		TI Chipcon CC1100 SPI driver
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author		Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 1775 $

--- a/drivers/cc110x_ng/cc110x-defaultSettings.c
+++ b/drivers/cc110x_ng/cc110x-defaultSettings.c
@@ -13,7 +13,6 @@
  * @file
  * @brief   TI Chipcon CC110x default settings
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      INRIA
  * @author    Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author    Heiko Will <hwill@inf.fu-berlin.de>

--- a/drivers/cc110x_ng/cc110x-internal.h
+++ b/drivers/cc110x_ng/cc110x-internal.h
@@ -14,7 +14,6 @@
  * @file        cc110x-internal.h
  * @brief       Driver internal constants for 110x chip configuration
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>

--- a/drivers/cc110x_ng/spi/cc110x_spi.c
+++ b/drivers/cc110x_ng/spi/cc110x_spi.c
@@ -19,7 +19,6 @@
  * @file        cc110x_spi.c
  * @brief       TI Chipcon CC1100 SPI driver
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @}

--- a/drivers/cc2420/include/cc2420_arch.h
+++ b/drivers/cc2420/include/cc2420_arch.h
@@ -17,7 +17,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @ingroup		CC2420
  * @brief		CC2420 dependend functions
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Heiko Will <hwill@inf.fu-berlin.de>
  * @author      Milan Babel <babel@inf.fu-berlin.de>
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>

--- a/drivers/include/cc110x/cc1100-interface.h
+++ b/drivers/include/cc110x/cc1100-interface.h
@@ -21,7 +21,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @file
  * @brief		TI Chipcon CC110x public interface
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @version     $Revision: 2283 $
  *

--- a/drivers/include/cc110x_ng/cc110x-arch.h
+++ b/drivers/include/cc110x_ng/cc110x-arch.h
@@ -19,7 +19,6 @@
  * @file        cc110x-arch.h
  * @brief       CC1100 architecture dependent functions
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Heiko Will <hwill@inf.fu-berlin.de>
  */
 

--- a/drivers/include/cc110x_ng/cc110x-defaultSettings.h
+++ b/drivers/include/cc110x_ng/cc110x-defaultSettings.h
@@ -22,7 +22,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @file
  * @brief       TI Chipcon CC110x default settings
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author      Heiko Will <hwill@inf.fu-berlin.de>
  */

--- a/drivers/include/cc110x_ng/cc110x_spi.h
+++ b/drivers/include/cc110x_ng/cc110x_spi.h
@@ -19,7 +19,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @file
  * @brief       TI Chipcon CC1100 SPI driver
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author      Heiko Will <hwill@inf.fu-berlin.de>
  */

--- a/drivers/include/gpioint.h
+++ b/drivers/include/gpioint.h
@@ -27,7 +27,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @file
  * @brief       GPIO IRQ Multiplexer interface
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Michael Baar <michael.baar@fu-berlin.de>
  */
 

--- a/drivers/include/lm75a-temp-sensor.h
+++ b/drivers/include/lm75a-temp-sensor.h
@@ -20,7 +20,6 @@
  *
  * The connection between the LM75A and the MCU is based on the I2C-interface.
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  */
 

--- a/drivers/include/ltc4150_arch.h
+++ b/drivers/include/ltc4150_arch.h
@@ -24,7 +24,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @file        ltc4150_arch.h
  * @brief       LTC4150 Coulomb Counter
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Heiko Will
  */
 

--- a/drivers/include/srf02-ultrasonic-sensor.h
+++ b/drivers/include/srf02-ultrasonic-sensor.h
@@ -19,7 +19,6 @@
  *
  * The connection between the SRF02 and the MCU is based on the i2c interface.
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  */
 

--- a/drivers/include/srf08-ultrasonic-sensor.h
+++ b/drivers/include/srf08-ultrasonic-sensor.h
@@ -20,7 +20,6 @@
  *
  * The communication between the MCU and SRF08 is via the i2c interface.
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  */
 

--- a/drivers/lm75a/lm75a-temp-sensor.c
+++ b/drivers/lm75a/lm75a-temp-sensor.c
@@ -16,7 +16,6 @@
  *              The communication between the LM75A and the MCU is
  *              based on the i2c interface.
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  * @version     $Revision: 3855 $
  *

--- a/drivers/ltc4150/ltc4150.c
+++ b/drivers/ltc4150/ltc4150.c
@@ -21,7 +21,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @file
  * @brief       LTC4150 Coulomb Counter
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Heiko Will
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */

--- a/drivers/sht11/sht11.c
+++ b/drivers/sht11/sht11.c
@@ -23,7 +23,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @file
  * @brief		SHT11 Device Driver
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @version     $Revision: 2396 $
  *
  * @note		$Id: sht11.c 2396 2010-07-06 15:12:35Z ziegert $

--- a/drivers/srf02/srf02-ultrasonic-sensor.c
+++ b/drivers/srf02/srf02-ultrasonic-sensor.c
@@ -14,7 +14,6 @@
  *              The connection between the MCU and the SRF08 is based on the
  *              i2c-interface.
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  * @version     $Revision: 3856 $
  *

--- a/drivers/srf08/srf08-ultrasonic-sensor.c
+++ b/drivers/srf08/srf08-ultrasonic-sensor.c
@@ -13,7 +13,6 @@
  * @internal
  * @brief       Driver for the SRF08 ultrasonic ranger using the i2c interface.
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  * @version     $Revision: 3857 $
  *

--- a/sys/bloom/bloom.c
+++ b/sys/bloom/bloom.c
@@ -10,7 +10,6 @@
  * @file
  * @author Jason Linehan <patientulysses@gmail.com>
  * @author Christian Mehlis <mehlis@inf.fu-berlin.de>
- * @author Freie Universität Berlin, Computer Systems & Telematics
  *
  */
 

--- a/sys/crypto/rc5.c
+++ b/sys/crypto/rc5.c
@@ -12,7 +12,6 @@
  * @file        rc5.c
  * @brief       implementation of the RC5 cipher-algorithm
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Nicolai Schmittberger <nicolai.schmittberger@fu-berlin.de>
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  * @author      Naveen Sastry

--- a/sys/hashes/hashes.c
+++ b/sys/hashes/hashes.c
@@ -11,7 +11,6 @@
 /**
  * @file
  * @author      Jason Linehan <patientulysses@gmail.com>
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
  */
 

--- a/sys/include/bloom.h
+++ b/sys/include/bloom.h
@@ -110,7 +110,6 @@
  * @brief       Bloom filter API
  *
  * @author Christian Mehlis <mehlis@inf.fu-berlin.de>
- * @author Freie Universität Berlin, Computer Systems & Telematics
  */
 
 #ifndef _BLOOM_FILTER_H

--- a/sys/include/fd.h
+++ b/sys/include/fd.h
@@ -15,7 +15,6 @@
  * @file    fd.h
  * @brief   Unifies diverse identifiers of RIOT to POSIX like file descriptors.
  *
- * @author  Freie Universität Berlin
  * @author  Martin Lenders <mlenders@inf.fu-berlin.de>
  * @author  Christian Mehlis <mehlis@inf.fu-berlin.de>
  */

--- a/sys/include/hashes.h
+++ b/sys/include/hashes.h
@@ -16,7 +16,6 @@
  * @brief       Hash function API
  *
  * @author      Jason Linehan <patientulysses@gmail.com>
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
  */
 

--- a/sys/include/posix_io.h
+++ b/sys/include/posix_io.h
@@ -12,7 +12,6 @@
  * @file        posix_io.h
  * @brief       POSIX-like IO
  *
- * @author      Freie Universität Berlin
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Stephan Zeisberg <zeisberg@mi.fu-berlin.de>
  * @author      Oliver Hahm <oleg@hobbykeller.org>

--- a/sys/include/radio/radio.h
+++ b/sys/include/radio/radio.h
@@ -26,7 +26,6 @@
  * @file
  * @brief
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		baar
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @version     $Revision: 1961 $

--- a/sys/include/radio/types.h
+++ b/sys/include/radio/types.h
@@ -17,7 +17,6 @@
  * @file
  * @brief		Common network stack types (of all layers).
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  * @version     $Revision: 2061 $

--- a/sys/net/include/net_if.h
+++ b/sys/net/include/net_if.h
@@ -16,7 +16,6 @@
  *
  * @file        net_if.h
  * @brief       Types and functions for network interfaces
- * @author      Freie Universität Berlin
  * @author      Martin Lenders <mlenders@inf.fu-berlin.de>
  */
 #ifndef _NET_IF_H

--- a/sys/net/include/protocol-multiplex.h
+++ b/sys/net/include/protocol-multiplex.h
@@ -21,7 +21,6 @@
  * @file
  * @brief       Protocol handler multiplexing
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @author      Michael Baar <baar@inf.fu-berlin.de>

--- a/sys/net/link_layer/protocol-multiplex/protocol-multiplex.c
+++ b/sys/net/link_layer/protocol-multiplex/protocol-multiplex.c
@@ -22,7 +22,6 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * @internal
  * @brief		Protocol handler multiplexing
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author		Heiko Will <hwill@inf.fu-berlin.de>
  * @author		Michael Baar <baar@inf.fu-berlin.de>

--- a/sys/posix/include/strings.h
+++ b/sys/posix/include/strings.h
@@ -17,7 +17,6 @@
  *              The Open Group Base Specifications Issue 7, <strings.h>
  *          </a>
  *
- * @author  Freie Universität Berlin
  * @author  Martin Lenders <mlenders@inf.fu-berlin.de>
  */
 #ifndef STRINGS_H

--- a/sys/posix/include/unistd.h
+++ b/sys/posix/include/unistd.h
@@ -18,7 +18,6 @@
  *              The Open Group Base Specifications Issue 7, <unistd.h>
  *          </a>
  *
- * @author  Freie Universität Berlin
  * @author  Martin Lenders <mlenders@inf.fu-berlin.de>
  */
 #ifndef _UNISTD_H

--- a/sys/posix/pnet/include/arpa/inet.h
+++ b/sys/posix/pnet/include/arpa/inet.h
@@ -18,7 +18,6 @@
  *              The Open Group Base Specifications Issue 7, <arpa/inet.h>
  *          </a>
  *
- * @author  Freie Universität Berlin
  * @author  Martin Lenders <mlenders@inf.fu-berlin.de>
  */
 #ifndef ARPA_INET_H

--- a/sys/posix/pnet/include/netinet/in.h
+++ b/sys/posix/pnet/include/netinet/in.h
@@ -18,7 +18,6 @@
  *              The Open Group Base Specifications Issue 7, <netinet/in.h>
  *          </a>
  *
- * @author  Freie Universität Berlin
  * @author  Martin Lenders <mlenders@inf.fu-berlin.de>
  */
 #ifndef _NETINET_IN_H

--- a/sys/posix/pnet/include/sys/socket.h
+++ b/sys/posix/pnet/include/sys/socket.h
@@ -18,7 +18,6 @@
  *              The Open Group Base Specifications Issue 7, <sys/socket.h>
  *          </a>
  *
- * @author  Freie Universität Berlin
  * @author  Martin Lenders <mlenders@inf.fu-berlin.de>
  */
 #ifndef _SYS_SOCKET_H

--- a/sys/shell/commands/sc_heap.c
+++ b/sys/shell/commands/sc_heap.c
@@ -12,7 +12,6 @@
  * @internal
  * @brief   Show the heap state for the LPC2387 on the command shell.
  *
- * @author  Freie Universität Berlin, Computer Systems & Telematics
  * @author  Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  *
  * @note    $Id: sc_heap.c 3855 2013-09-05 12:40:11 kasmi $

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -22,7 +22,6 @@
  *              name of a handler, the handler will be called with the whole
  *              command line as parameter.
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  */

--- a/tests/unittests/tests-core/tests-core.h
+++ b/tests/unittests/tests-core/tests-core.h
@@ -13,7 +13,6 @@
  * @file        tests-core.h
  * @brief       Unittests for the ``core`` module
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 #ifndef __TESTS_CORE_H_

--- a/tests/unittests/tests-lib/tests-lib.h
+++ b/tests/unittests/tests-lib/tests-lib.h
@@ -13,7 +13,6 @@
  * @file        tests-lib.h
  * @brief       Unittests for the ``lib`` sysmodule
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  */
 #ifndef __TESTS_CORE_H_

--- a/tests/unittests/unittests.h
+++ b/tests/unittests/unittests.h
@@ -13,7 +13,6 @@
  * @file        unittests.h
  * @brief       Common header file for unittests
  *
- * @author      Freie Universität Berlin, Computer Systems & Telematics
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 


### PR DESCRIPTION
Note: Some headers ended up without an author, I replaced the author with the original committer in that case.
Edit: I undid that and kept FU as author where no other author is mentioned.
Reason: Kaspar only imported those files and I am unable to lookup the original authors right now.
