### PR TITLE
cpu/arm_common C++ msba2 support fix

### DIFF
--- a/boards/msba2-common/Makefile.include
+++ b/boards/msba2-common/Makefile.include
@@ -5,6 +5,7 @@ export CPU = lpc2387
 export PREFIX = arm-none-eabi-
 #export PREFIX = arm-elf-
 export CC = $(PREFIX)gcc
+export CXX = $(PREFIX)g++
 export AR = $(PREFIX)ar
 export CFLAGS += -O2 -Wall -Wstrict-prototypes -mcpu=arm7tdmi-s -gdwarf-2
 export ASFLAGS = -gdwarf-2 -mcpu=arm7tdmi-s
@@ -15,6 +16,10 @@ export OBJCOPY = $(PREFIX)objcopy
 FLASHER = lpc2k_pgm
 TERMPROG ?= $(RIOTBASE)/dist/tools/pyterm/pyterm
 LINKFLAGS += -gdwarf-2 -mcpu=arm7tdmi-s -static -lgcc -nostartfiles -T$(RIOTBASE)/cpu/$(CPU)/linkerscript.x
+
+# unwanted (CXXUWFLAGS) and extra (CXXEXFLAGS) flags for c++
+export CXXUWFLAGS +=
+export CXXEXFLAGS +=
 
 ifeq ($(strip $(PORT)),)
 	export PORT = /dev/ttyUSB0

--- a/boards/msba2/Makefile.features
+++ b/boards/msba2/Makefile.features
@@ -1,1 +1,1 @@
-FEATURES_PROVIDED += transceiver periph_pwm
+FEATURES_PROVIDED += transceiver periph_pwm cpp

--- a/cpu/arm7_common/syscalls.c
+++ b/cpu/arm7_common/syscalls.c
@@ -213,6 +213,7 @@ pid_t _getpid(void)
     return (pid_t) sched_active_pid;
 }
 /*---------------------------------------------------------------------------*/
+__attribute__ ((weak))
 int _kill_r(struct _reent *r, int pid, int sig)
 {
     (void) pid;
@@ -224,3 +225,18 @@ int _kill_r(struct _reent *r, int pid, int sig)
 
 void _init(void) {}
 void _fini(void) {}
+
+/**
+ * @brief Send a signal to a thread
+ *
+ * @param[in] pid the pid to send to
+ * @param[in] sig the signal to send
+ *
+ * @return TODO
+ */
+__attribute__ ((weak))
+int _kill(int pid, int sig)
+{
+    errno = ESRCH;                         /* not implemented yet */
+    return -1;
+}


### PR DESCRIPTION
Using `g++` links to the newlib implementation of `_kill_r` which conflicts the RIOT own implementation in `syscalls.c`, so I removed RIOT `_kill_r` as it has no real implementation/purpose.
Additionally c++ requires to be provided with a `_kill()` function, so I added a stub for it (currently).
