### PR TITLE
cpu/sam3x8e C++ arduino due support fix

### DIFF
--- a/boards/arduino-due/Makefile.features
+++ b/boards/arduino-due/Makefile.features
@@ -1,1 +1,1 @@
-FEATURES_PROVIDED += periph_uart periph_gpio periph_spi periph_random
+FEATURES_PROVIDED += periph_uart periph_gpio periph_spi periph_random cpp

--- a/boards/arduino-due/Makefile.include
+++ b/boards/arduino-due/Makefile.include
@@ -4,12 +4,17 @@ export CPU = sam3x8e
 # define tools used for building the project
 export PREFIX = arm-none-eabi-
 export CC = $(PREFIX)gcc
+export CXX = $(PREFIX)g++
 export AR = $(PREFIX)ar
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
 export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm
+
+# unwanted (CXXUWFLAGS) and extra (CXXEXFLAGS) flags for c++
+export CXXUWFLAGS +=
+export CXXEXFLAGS +=
 
 #define the flash-tool and default port depending on the host operating system
 OS := $(shell uname)

--- a/cpu/sam3x8e/syscalls.c
+++ b/cpu/sam3x8e/syscalls.c
@@ -156,6 +156,7 @@ pid_t _getpid(void)
  *
  * @return      TODO
  */
+__attribute__ ((weak))
 int _kill_r(struct _reent *r, pid_t pid, int sig)
 {
     r->_errno = ESRCH;                      /* not implemented yet */
@@ -321,5 +322,20 @@ int _isatty_r(struct _reent *r, int fd)
 int _unlink_r(struct _reent *r, char* path)
 {
     r->_errno = ENODEV;                     /* not implemented yet */
+    return -1;
+}
+
+/**
+ * @brief Send a signal to a thread
+ *
+ * @param[in] pid the pid to send to
+ * @param[in] sig the signal to send
+ *
+ * @return TODO
+ */
+__attribute__ ((weak))
+int _kill(int pid, int sig)
+{
+    errno = ESRCH;                         /* not implemented yet */
     return -1;
 }


### PR DESCRIPTION
Using `g++` links to the newlib implementation of `_kill_r` which conflicts the RIOT own implementation in `syscalls.c`, so I removed RIOT `_kill_r` as it has no real implementation/purpose.
Additionally c++ requires to be provided with a `_kill()` function, so I added a stub for it (currently).
