### PR TITLE
make: improve failing RIOT_VERSION

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -74,7 +74,7 @@ ifeq ($(origin RIOT_VERSION), undefined)
       RIOT_VERSION := $(GIT_STRING)-$(GIT_BRANCH)
     endif
   else
-    RIOT_VERSION := UNKNOWN
+    RIOT_VERSION := UNKNOWN (builddir: $(RIOTBASE))
   endif
 endif
 export CFLAGS += -DRIOT_VERSION='"$(RIOT_VERSION)"'


### PR DESCRIPTION
- make RIOT_VERSION fail-safe (compare: https://github.com/RIOT-OS/RIOT/pull/1475#discussion_r15534849)
- add RIOTBASE to UNKNOWN RIOT_VERSION
