### PR TITLE
avsextrem: use cc110x_ng as default transceiver driver

### DIFF
--- a/boards/avsextrem/Makefile.include
+++ b/boards/avsextrem/Makefile.include
@@ -1,7 +1,7 @@
 export INCLUDES += -I$(RIOTBOARD)/avsextrem/include
 
 ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
-	USEMODULE += cc110x
+	USEMODULE += cc110x_ng
 	USEMODULE += transceiver
 endif
 


### PR DESCRIPTION
I don't really see why avsextrem should be the only platform which still uses cc110x as the default transceiver driver. Also: since avsextrem is very similar to msba2 it would make a lot of sense not to use two different transceiver drivers for those platforms (principle of least surprise and so on). 
