### PR TITLE
converting tabs to spaces in core (#1439)

### DIFF
--- a/core/include/arch/hwtimer_arch.h
+++ b/core/include/arch/hwtimer_arch.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup	    core_arch
+ * @ingroup     core_arch
  * @{
  *
  * @file        hwtimer_arch.h


### PR DESCRIPTION
This PR converts tabs to white spaces.
The statement I used for the conversion:
`find . -name "*.[ch]" -exec zsh -c 'expand -t 4 "$0" > /tmp/e && mv /tmp/e "$0"' {} \;`
Afterwards, I had a quick overview of the converted files to prevent odd indentation.
