### PR TITLE
converting tabs to spaces in dist (#1439)

### DIFF
--- a/dist/tools/linux-border_router/control_2xxx.c
+++ b/dist/tools/linux-border_router/control_2xxx.c
@@ -17,23 +17,23 @@
 void hard_reset_to_bootloader(void)
 {
     printf("Reset CPU (into bootloader)\r\n");
-    set_rts(1);		/* RTS (ttl level) connects to P0.14 */
-    set_dtr(1);		/* DTR (ttl level) connects to RST */
-    send_break_signal();	/* or break detect circuit to RST */
+    set_rts(1);     /* RTS (ttl level) connects to P0.14 */
+    set_dtr(1);     /* DTR (ttl level) connects to RST */
+    send_break_signal();    /* or break detect circuit to RST */
     usleep(75000);
-    set_dtr(0);		/* allow the CPU to run */
+    set_dtr(0);     /* allow the CPU to run */
     set_baud(baud_rate);
-    set_rts(1);		/* set RTS again (as it has been reset by set_baudrate) */
+    set_rts(1);     /* set RTS again (as it has been reset by set_baudrate) */
     usleep(40000);
 }
 
 void hard_reset_to_user_code(void)
 {
     printf("Reset CPU (into user code)\r\n");
-    set_rts(0);		/* RTS (ttl level) connects to P0.14 */
-    set_dtr(1);		/* DTR (ttl level) connects to RST */
-    send_break_signal();	/* or break detect circuit to RST */
+    set_rts(0);     /* RTS (ttl level) connects to P0.14 */
+    set_dtr(1);     /* DTR (ttl level) connects to RST */
+    send_break_signal();    /* or break detect circuit to RST */
     usleep(75000);
-    set_dtr(0);		/* allow the CPU to run */
+    set_dtr(0);     /* allow the CPU to run */
     usleep(40000);
 }

--- a/dist/tools/linux-border_router/serial.c
+++ b/dist/tools/linux-border_router/serial.c
@@ -189,7 +189,7 @@ static void report_open_error(const char *filename, int err)
     }
 
     /* printf("%s is owned by: user %s, group %s\r\n",
-    	filename, file_uname, file_gname); */
+        filename, file_uname, file_gname); */
 
     perm = info.st_mode;
 


### PR DESCRIPTION
This PR converts tabs to white spaces.
The statement I used for the conversion:
`find . -name "*.[ch]" -exec zsh -c 'expand -t 4 "$0" > /tmp/e && mv /tmp/e "$0"' {} \;`
Afterwards, I had a quick overview of the converted files to prevent odd indentation.
