### PR TITLE
converting tabs to spaces in drivers (#1439)

### DIFF
--- a/drivers/cc110x/arch_cc1100.h
+++ b/drivers/cc110x/arch_cc1100.h
@@ -14,13 +14,13 @@
 
 /**
  * @file
- * @ingroup		LPC2387
- * @brief		CC1100 LPC2387 dependend functions
+ * @ingroup     LPC2387
+ * @brief       CC1100 LPC2387 dependend functions
  *
- * @author		Heiko Will <hwill@inf.fu-berlin.de>
+ * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 1775 $
  *
- * @note    	$Id: arch_cc1100.h 1775 2010-01-26 09:37:03Z hillebra $
+ * @note        $Id: arch_cc1100.h 1775 2010-01-26 09:37:03Z hillebra $
  */
 
 #include <stdint.h>

--- a/drivers/cc110x/cc1100-csmaca-mac.c
+++ b/drivers/cc110x/cc1100-csmaca-mac.c
@@ -14,14 +14,14 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 
 /**
  * @file
- * @ingroup		dev_cc110x
- * @brief		ScatterWeb MSB-A2 mac-layer
+ * @ingroup     dev_cc110x
+ * @brief       ScatterWeb MSB-A2 mac-layer
  *
- * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
- * @author		Heiko Will <hwill@inf.fu-berlin.de>
+ * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
+ * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 2128 $
  *
- * @note    	$Id: cc1100-csmaca-mac.c 2128 2010-05-12 12:07:59Z hillebra $
+ * @note        $Id: cc1100-csmaca-mac.c 2128 2010-05-12 12:07:59Z hillebra $
  */
 
 #include <stdio.h>
@@ -139,16 +139,16 @@ int cc1100_send_csmaca(radio_address_t address, protocol_t protocol, int priorit
         min_window_size *= 4;
     }
 
-    uint16_t windowSize = min_window_size;		/* Start with window size of PRIO_XXX_MIN_WINDOW_SIZE */
-    uint16_t backoff = 0;						/* Backoff between 1 and windowSize */
-    uint32_t total;								/* Holds the total wait time before send try */
-    uint32_t cs_timeout;						/* Current carrier sense timeout value */
+    uint16_t windowSize = min_window_size;      /* Start with window size of PRIO_XXX_MIN_WINDOW_SIZE */
+    uint16_t backoff = 0;                       /* Backoff between 1 and windowSize */
+    uint32_t total;                             /* Holds the total wait time before send try */
+    uint32_t cs_timeout;                        /* Current carrier sense timeout value */
 
     if (protocol == 0) {
-        return RADIO_INVALID_PARAM;				/* Not allowed, protocol id must be greater zero */
+        return RADIO_INVALID_PARAM;             /* Not allowed, protocol id must be greater zero */
     }
 
-    cc1100_phy_mutex_lock();					/* Lock radio for exclusive access */
+    cc1100_phy_mutex_lock();                    /* Lock radio for exclusive access */
 
     /* Get carrier sense timeout based on overall error rate till now */
     send_csmaca_calls++;
@@ -164,7 +164,7 @@ int cc1100_send_csmaca(radio_address_t address, protocol_t protocol, int priorit
         cs_timeout = CARRIER_SENSE_TIMEOUT_MIN;
     }
 
-    cc1100_cs_init();							/* Initialize carrier sensing */
+    cc1100_cs_init();                           /* Initialize carrier sensing */
 
 window:
 
@@ -172,36 +172,36 @@ window:
         goto cycle;    /* If backoff was 0 */
     }
 
-    windowSize *= 2;						/* ...double the current window size */
+    windowSize *= 2;                        /* ...double the current window size */
 
     if (windowSize > max_window_size) {
-        windowSize = max_window_size;		/* This is the maximum size allowed */
+        windowSize = max_window_size;       /* This is the maximum size allowed */
     }
 
-    backoff = rand() % windowSize;			/* ...and choose new backoff */
+    backoff = rand() % windowSize;          /* ...and choose new backoff */
 
     backoff += (uint16_t) 1;
 cycle:
-    cs_timeout_flag = 0;					/* Carrier sense timeout flag */
-    cs_hwtimer_id = hwtimer_set(cs_timeout,	/* Set hwtimer to set CS timeout flag */
+    cs_timeout_flag = 0;                    /* Carrier sense timeout flag */
+    cs_hwtimer_id = hwtimer_set(cs_timeout, /* Set hwtimer to set CS timeout flag */
                                 cs_timeout_cb, NULL);
 
-    while (cc1100_cs_read()) {			/* Wait until air is free */
+    while (cc1100_cs_read()) {          /* Wait until air is free */
         if (cs_timeout_flag) {
             send_csmaca_calls_cs_timeout++;
 #ifndef CSMACA_MAC_AGGRESSIVE_MODE
             cc1100_phy_mutex_unlock();
-            cc1100_go_after_tx();			/* Go from RX to default mode */
-            return RADIO_CS_TIMEOUT;		/* Return immediately */
+            cc1100_go_after_tx();           /* Go from RX to default mode */
+            return RADIO_CS_TIMEOUT;        /* Return immediately */
 #endif
 #ifdef CSMACA_MAC_AGGRESSIVE_MODE
-            goto send;						/* Send anyway */
+            goto send;                      /* Send anyway */
 #endif
         }
     }
 
-    hwtimer_remove(cs_hwtimer_id);			/* Remove hwtimer */
-    cc1100_cs_write_cca(1);					/* Air is free now */
+    hwtimer_remove(cs_hwtimer_id);          /* Remove hwtimer */
+    cc1100_cs_write_cca(1);                 /* Air is free now */
     cc1100_cs_set_enabled(true);
 
     if (cc1100_cs_read()) {
@@ -213,18 +213,18 @@ cycle:
         backoff--;    /* Decrement backoff counter */
     }
 
-    total = slottime;						/* Calculate total wait time */
-    total *= (uint32_t)backoff;				/* Slot vector set */
-    total += difs;							/* ...and standard DIFS wait time */
-    cs_timeout_flag = 0;					/* Carrier sense timeout flag */
-    cs_hwtimer_id = hwtimer_set(total,		/* Set hwtimer to set CS timeout flag */
+    total = slottime;                       /* Calculate total wait time */
+    total *= (uint32_t)backoff;             /* Slot vector set */
+    total += difs;                          /* ...and standard DIFS wait time */
+    cs_timeout_flag = 0;                    /* Carrier sense timeout flag */
+    cs_hwtimer_id = hwtimer_set(total,      /* Set hwtimer to set CS timeout flag */
                                 cs_timeout_cb, NULL);
 
     while (!cs_timeout_flag
-          || !cc1100_cs_read_cca()) {	/* Wait until timeout is finished */
-        if (cc1100_cs_read_cca() == 0) {	/* Is the air still free? */
+          || !cc1100_cs_read_cca()) {   /* Wait until timeout is finished */
+        if (cc1100_cs_read_cca() == 0) {    /* Is the air still free? */
             hwtimer_remove(cs_hwtimer_id);
-            goto window;					/* No. Go back to new wait period. */
+            goto window;                    /* No. Go back to new wait period. */
         }
     }
 

--- a/drivers/cc110x/cc1100-csmaca-mac.h
+++ b/drivers/cc110x/cc1100-csmaca-mac.h
@@ -14,14 +14,14 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 
 /**
  * @file
- * @ingroup		dev_cc110x
- * @brief		ScatterWeb MSB-A2 mac-layer
+ * @ingroup     dev_cc110x
+ * @brief       ScatterWeb MSB-A2 mac-layer
  *
- * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
- * @author		Heiko Will <hwill@inf.fu-berlin.de>
+ * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
+ * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 1999 $
  *
- * @note    	$Id: cc1100-csmaca-mac.h 1999 2010-03-16 15:48:18Z hillebra $
+ * @note        $Id: cc1100-csmaca-mac.h 1999 2010-03-16 15:48:18Z hillebra $
  */
 
 #ifndef CC1100_CSMACA_MAC_
@@ -29,26 +29,26 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 
 #include "cc1100-defaultSettings.h"
 
-//#define CSMACA_MAC_AGGRESSIVE_MODE		   		// MAC aggressive mode on/off switch
+//#define CSMACA_MAC_AGGRESSIVE_MODE                // MAC aggressive mode on/off switch
 
-#define CARRIER_SENSE_TIMEOUT		  	 (200000)	// Carrier Sense timeout ~ 2 seconds
-#define CARRIER_SENSE_TIMEOUT_MIN		   (2000)	// Minimum Carrier Sense timeout ~ 20 milliseconds
-#define CS_TX_SWITCH_TIME				  	 (80)	// Carrier Sense to TX switch time (measured ~ 350 us)
+#define CARRIER_SENSE_TIMEOUT            (200000)   // Carrier Sense timeout ~ 2 seconds
+#define CARRIER_SENSE_TIMEOUT_MIN          (2000)   // Minimum Carrier Sense timeout ~ 20 milliseconds
+#define CS_TX_SWITCH_TIME                    (80)   // Carrier Sense to TX switch time (measured ~ 350 us)
 
 /** All values are in ticks (x10 us) */
-#define PRIO_ALARM_DIFS 				 	(200)	// DIFS for ALARM packets, the default wait time
-#define PRIO_ALARM_SLOTTIME	  (CS_TX_SWITCH_TIME)	// Time of one additional wait slot
-#define PRIO_ALARM_MIN_WINDOW_SIZE		   	  (2)	// Minimum window size of backoff algorithm
-#define PRIO_ALARM_MAX_WINDOW_SIZE		   	  (8)	// Maximum window size of backoff algorithm
+#define PRIO_ALARM_DIFS                     (200)   // DIFS for ALARM packets, the default wait time
+#define PRIO_ALARM_SLOTTIME   (CS_TX_SWITCH_TIME)   // Time of one additional wait slot
+#define PRIO_ALARM_MIN_WINDOW_SIZE            (2)   // Minimum window size of backoff algorithm
+#define PRIO_ALARM_MAX_WINDOW_SIZE            (8)   // Maximum window size of backoff algorithm
 
-#define PRIO_WARN_DIFS 					   (1000)	// DIFS for WARN packets, the default wait time
-#define PRIO_WARN_SLOTTIME 	  (CS_TX_SWITCH_TIME)	// Time of one additional wait slot
-#define PRIO_WARN_MIN_WINDOW_SIZE		   	  (2)	// Minimum window size of backoff algorithm
-#define PRIO_WARN_MAX_WINDOW_SIZE		  	 (16)	// Maximum window size of backoff algorithm
+#define PRIO_WARN_DIFS                     (1000)   // DIFS for WARN packets, the default wait time
+#define PRIO_WARN_SLOTTIME    (CS_TX_SWITCH_TIME)   // Time of one additional wait slot
+#define PRIO_WARN_MIN_WINDOW_SIZE             (2)   // Minimum window size of backoff algorithm
+#define PRIO_WARN_MAX_WINDOW_SIZE            (16)   // Maximum window size of backoff algorithm
 
-#define PRIO_DATA_DIFS 					   (2500)	// DIFS for normal data packets, the default wait time
-#define PRIO_DATA_SLOTTIME 	  (CS_TX_SWITCH_TIME)	// Time of one additional wait slot
-#define PRIO_DATA_MIN_WINDOW_SIZE		   	  (4)	// Minimum window size of backoff algorithm
-#define PRIO_DATA_MAX_WINDOW_SIZE		  	 (32)	// Maximum window size of backoff algorithm
+#define PRIO_DATA_DIFS                     (2500)   // DIFS for normal data packets, the default wait time
+#define PRIO_DATA_SLOTTIME    (CS_TX_SWITCH_TIME)   // Time of one additional wait slot
+#define PRIO_DATA_MIN_WINDOW_SIZE             (4)   // Minimum window size of backoff algorithm
+#define PRIO_DATA_MAX_WINDOW_SIZE            (32)   // Maximum window size of backoff algorithm
 
 #endif /*CC1100_CSMACA_MAC_*/

--- a/drivers/cc110x/cc1100-defaultSettings.c
+++ b/drivers/cc110x/cc1100-defaultSettings.c
@@ -13,19 +13,19 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 *******************************************************************************/
 
 /**
- * @ingroup		dev_cc110x
+ * @ingroup     dev_cc110x
  * @{
  */
 
 /**
  * @file
- * @brief		TI Chipcon CC110x default settings
+ * @brief       TI Chipcon CC110x default settings
  *
- * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
- * @author		Heiko Will <hwill@inf.fu-berlin.de>
+ * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
+ * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 2058 $
  *
- * @note		$Id: cc1100-defaultSettings.c 2058 2010-03-31 08:59:31Z hillebra $
+ * @note        $Id: cc1100-defaultSettings.c 2058 2010-03-31 08:59:31Z hillebra $
  */
 
 #include "cc1100-defaultSettings.h"
@@ -38,7 +38,7 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  * -----------------------------------------
  *              0 |      0 | 869.525
  *              1 |     10 | 871.61
- *              2 |     20 | 873.58			~ seems to be bad (hang-ups with this channel)
+ *              2 |     20 | 873.58         ~ seems to be bad (hang-ups with this channel)
  *              3 |     30 | 875.61
  *              4 |     40 | 877.58
  *              5 |     50 | 879.61
@@ -71,9 +71,9 @@ char cc1100_conf[] = {
     0x0F, /* FIFOTHR */
     0x9B, /* SYNC1 */
     0xAD, /* SYNC0 */
-    0x3D, /* PKTLEN 		(maximum value of packet length byte = 61) */
+    0x3D, /* PKTLEN         (maximum value of packet length byte = 61) */
     0x06, /* PKTCTRL1 */
-    0x45, /* PKTCTRL0 	(variable packet length) */
+    0x45, /* PKTCTRL0   (variable packet length) */
     0xFF, /* ADDR */
     CC1100_DEFAULT_CHANNR * 10, /* CHANNR */
     0x0B, /* FSCTRL1 */

--- a/drivers/cc110x/cc1100-defaultSettings.h
+++ b/drivers/cc110x/cc1100-defaultSettings.h
@@ -16,19 +16,19 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 #define CC1100_DEFAULTSETTINGS_H
 
 /**
- * @ingroup		dev_cc110x
+ * @ingroup     dev_cc110x
  * @{
  */
 
 /**
  * @file
- * @brief		TI Chipcon CC110x default settings
+ * @brief       TI Chipcon CC110x default settings
  *
- * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
- * @author		Heiko Will <hwill@inf.fu-berlin.de>
+ * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
+ * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 2139 $
  *
- * @note		$Id: cc1100-defaultSettings.h 2139 2010-05-26 08:04:04Z hillebra $
+ * @note        $Id: cc1100-defaultSettings.h 2139 2010-05-26 08:04:04Z hillebra $
  */
 
 #include "hwtimer.h"
@@ -36,61 +36,61 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 // returns hwtimer ticks per us
 #define RTIMER_TICKS(us) HWTIMER_TICKS(us)
 
-#define TIMER_TICK_USEC_RES 	(122)
+#define TIMER_TICK_USEC_RES     (122)
 
 // Default PA table index (output power)
-#define PATABLE 				(11)
+#define PATABLE                 (11)
 
 // Watchdog cycle time in seconds, set 0 to disable watchdog
-#define CC1100_WATCHDOG_PERIOD	(5)
+#define CC1100_WATCHDOG_PERIOD  (5)
 
 // Number of transmission retries for unicast packets (constant RX mode)
-#define TRANSMISSION_RETRIES_CRX_UC		(5)
+#define TRANSMISSION_RETRIES_CRX_UC     (5)
 
 // Number of transmission retries for unicast packets (WOR mode)
-#define TRANSMISSION_RETRIES_WOR_UC		(1)
+#define TRANSMISSION_RETRIES_WOR_UC     (1)
 
 // Number of transmission retries for broadcast packets (constant RX mode)
-#define TRANSMISSION_RETRIES_CRX_BC		(0)
+#define TRANSMISSION_RETRIES_CRX_BC     (0)
 
 // Number of transmission retries for broadcast packets (WOR mode)
-#define TRANSMISSION_RETRIES_WOR_BC		(0)
+#define TRANSMISSION_RETRIES_WOR_BC     (0)
 
 // Time before chip goes back to RX (= stays in PWD after incoming packet)
-#define WOR_TIMEOUT_1			(3200)	// ~ 32 milliseconds
+#define WOR_TIMEOUT_1           (3200)  // ~ 32 milliseconds
 
 // Time before chip goes back to WOR (= stays in RX after elapsed WOR_TIMEOUT_1)
-#define WOR_TIMEOUT_2			(800)	// ~ 8 milliseconds
+#define WOR_TIMEOUT_2           (800)   // ~ 8 milliseconds
 
 // XOSC startup + FS calibration (300 + 809 us  ~ 1.38 ms)
-#define FS_CAL_TIME				RTIMER_TICKS(12 * TIMER_TICK_USEC_RES)
+#define FS_CAL_TIME             RTIMER_TICKS(12 * TIMER_TICK_USEC_RES)
 
 // Manual FS calibration (721 us)
-#define MANUAL_FS_CAL_TIME 		RTIMER_TICKS(7 * TIMER_TICK_USEC_RES)
+#define MANUAL_FS_CAL_TIME      RTIMER_TICKS(7 * TIMER_TICK_USEC_RES)
 
 // Reset wait time (in reset procedure)
-#define RESET_WAIT_TIME			RTIMER_TICKS(4 * TIMER_TICK_USEC_RES)
+#define RESET_WAIT_TIME         RTIMER_TICKS(4 * TIMER_TICK_USEC_RES)
 
 // Time chip needs to go to RX
-#define IDLE_TO_RX_TIME			RTIMER_TICKS(1 * TIMER_TICK_USEC_RES)
+#define IDLE_TO_RX_TIME         RTIMER_TICKS(1 * TIMER_TICK_USEC_RES)
 
 // Time chip needs to go to RX and CS signal is ready
-#define CS_READY_TIME			RTIMER_TICKS(3 * TIMER_TICK_USEC_RES)
+#define CS_READY_TIME           RTIMER_TICKS(3 * TIMER_TICK_USEC_RES)
 
 // Default RX interval for WOR in milliseconds
-#define T_RX_INTERVAL			(542)
+#define T_RX_INTERVAL           (542)
 
 // Time of packet interval in microseconds (at 400 kbps)
-#define T_PACKET_INTERVAL		(3800)
+#define T_PACKET_INTERVAL       (3800)
 
 // The size of the configuration array for CC1100 in bytes
-#define CC1100_CONF_SIZE 		(39)
+#define CC1100_CONF_SIZE        (39)
 
 // The default channel number (0-24) for CC1100
-#define CC1100_DEFAULT_CHANNR	(0)
+#define CC1100_DEFAULT_CHANNR   (0)
 
 // Burst retry to TX switch time (measured ~ 230 us)
-#define BURST_RETRY_TX_SWITCH_TIME	(23)
+#define BURST_RETRY_TX_SWITCH_TIME  (23)
 
 /** @} */
 #endif

--- a/drivers/cc110x/cc1100-internal.h
+++ b/drivers/cc110x/cc1100-internal.h
@@ -16,33 +16,33 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 #define CC1100_INTERNAL_H
 
 /**
- * @ingroup		dev_cc110x
+ * @ingroup     dev_cc110x
  * @{
  */
 
 /**
  * @file
  * @internal
- * @brief		TI Chipcon CC110x internal hardware constants
+ * @brief       TI Chipcon CC110x internal hardware constants
  *
- * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
- * @author		Heiko Will <hwill@inf.fu-berlin.de>
+ * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
+ * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 1231 $
  *
- * @note		$Id: cc1100-internal.h 1231 2009-08-20 08:31:32Z baar $
+ * @note        $Id: cc1100-internal.h 1231 2009-08-20 08:31:32Z baar $
  */
 
-#define FIXED_PKTLEN		(0x00)		///< Fixed length packets, length configured in PKTLEN register.
-#define	VARIABLE_PKTLEN		(0x01)		///< Variable length packets, packet length configured by the first
-										///< byte after synch word.
+#define FIXED_PKTLEN        (0x00)      ///< Fixed length packets, length configured in PKTLEN register.
+#define VARIABLE_PKTLEN     (0x01)      ///< Variable length packets, packet length configured by the first
+                                        ///< byte after synch word.
 
 /**
- * @name	Bitmasks for reading out status register values
+ * @name    Bitmasks for reading out status register values
  * @{
  */
 
 /**
- * @brief	Bitmask (=10000000) for reading CRC_OK.
+ * @brief   Bitmask (=10000000) for reading CRC_OK.
  *
  * If CRC_OK == 1: CRC for received data OK (or CRC disabled).
  * If CRC_OK == 0: CRC error in received data.
@@ -53,42 +53,42 @@ and Telematics group (http://cst.mi.fu-berlin.de).
  *
  * The Link Quality Indicator estimates how easily a received signal can be demodulated.
  */
-#define LQI_EST				(0x7F)
-#define I_RSSI              (0x00)		///< Index 0 contains RSSI information (from optionally appended packet status bytes).
-#define I_LQI               (0x01)		///< Index 1 contains LQI & CRC_OK information (from optionally appended packet status bytes).
-#define MARC_STATE			(0x1F)		///< Bitmask (=00011111) for reading MARC_STATE in MARCSTATE status register.
-#define CS					(0x40)		///< Bitmask (=01000000) for reading CS (Carrier Sense) in PKTSTATUS status register.
-#define PQT_REACHED			(0x20)		///< Bitmask (=00100000) for reading PQT_REACHED (Preamble Quality reached) in PKTSTATUS status register.
-#define CCA					(0x10)		///< Bitmask (=00010000) for reading CCA (clear channel assessment) in PKTSTATUS status register.
-#define SFD					(0x08)		///< Bitmask (=00001000) for reading SFD (Sync word found) in PKTSTATUS status register.
-#define GDO2				(0x04)		///< Bitmask (=00000100) for reading GDO2 (current value on GDO2 pin) in PKTSTATUS status register.
-#define GDO1				(0x02)		///< Bitmask (=00000010) for reading GDO1 (current value on GDO1 pin) in PKTSTATUS status register.
-#define GDO0				(0x01)		///< Bitmask (=00000001) for reading GDO0 (current value on GDO0 pin) in PKTSTATUS status register.
-#define TXFIFO_UNDERFLOW	(0x80)		///< Bitmask (=10000000) for reading TXFIFO_UNDERFLOW in TXBYTES status register.
-#define BYTES_IN_TXFIFO		(0x7F)		///< Bitmask (=01111111) for reading NUM_TXBYTES in TXBYTES status register.
-#define RXFIFO_OVERFLOW		(0x80)		///< Bitmask (=10000000) for reading RXFIFO_OVERFLOW in RXBYTES status register.
-#define BYTES_IN_RXFIFO     (0x7F)		///< Bitmask (=01111111) for reading NUM_RXBYTES in RXBYTES status register.
+#define LQI_EST             (0x7F)
+#define I_RSSI              (0x00)      ///< Index 0 contains RSSI information (from optionally appended packet status bytes).
+#define I_LQI               (0x01)      ///< Index 1 contains LQI & CRC_OK information (from optionally appended packet status bytes).
+#define MARC_STATE          (0x1F)      ///< Bitmask (=00011111) for reading MARC_STATE in MARCSTATE status register.
+#define CS                  (0x40)      ///< Bitmask (=01000000) for reading CS (Carrier Sense) in PKTSTATUS status register.
+#define PQT_REACHED         (0x20)      ///< Bitmask (=00100000) for reading PQT_REACHED (Preamble Quality reached) in PKTSTATUS status register.
+#define CCA                 (0x10)      ///< Bitmask (=00010000) for reading CCA (clear channel assessment) in PKTSTATUS status register.
+#define SFD                 (0x08)      ///< Bitmask (=00001000) for reading SFD (Sync word found) in PKTSTATUS status register.
+#define GDO2                (0x04)      ///< Bitmask (=00000100) for reading GDO2 (current value on GDO2 pin) in PKTSTATUS status register.
+#define GDO1                (0x02)      ///< Bitmask (=00000010) for reading GDO1 (current value on GDO1 pin) in PKTSTATUS status register.
+#define GDO0                (0x01)      ///< Bitmask (=00000001) for reading GDO0 (current value on GDO0 pin) in PKTSTATUS status register.
+#define TXFIFO_UNDERFLOW    (0x80)      ///< Bitmask (=10000000) for reading TXFIFO_UNDERFLOW in TXBYTES status register.
+#define BYTES_IN_TXFIFO     (0x7F)      ///< Bitmask (=01111111) for reading NUM_TXBYTES in TXBYTES status register.
+#define RXFIFO_OVERFLOW     (0x80)      ///< Bitmask (=10000000) for reading RXFIFO_OVERFLOW in RXBYTES status register.
+#define BYTES_IN_RXFIFO     (0x7F)      ///< Bitmask (=01111111) for reading NUM_RXBYTES in RXBYTES status register.
 /** @} */
 
 /**
- * @name	Bitmasks for reading out configuration register values
+ * @name    Bitmasks for reading out configuration register values
  * @{
  */
-#define PKT_LENGTH_CONFIG	(0x03)		///< Bitmask (=00000011) for reading LENGTH_CONFIG in PKTCTRL0 configuration register.
+#define PKT_LENGTH_CONFIG   (0x03)      ///< Bitmask (=00000011) for reading LENGTH_CONFIG in PKTCTRL0 configuration register.
 /** @} */
 
 /**
- * @name	Definitions to support burst/single access
+ * @name    Definitions to support burst/single access
  * @{
  */
-#define CC1100_WRITE_BURST	(0x40) ///< Offset for burst write.
-#define CC1100_READ_SINGLE	(0x80) ///< Offset for read single byte.
-#define CC1100_READ_BURST	(0xC0) ///< Offset for read burst.
-#define CC1100_NOBYTE		(0x00) ///< No command (for reading).
+#define CC1100_WRITE_BURST  (0x40) ///< Offset for burst write.
+#define CC1100_READ_SINGLE  (0x80) ///< Offset for read single byte.
+#define CC1100_READ_BURST   (0xC0) ///< Offset for read burst.
+#define CC1100_NOBYTE       (0x00) ///< No command (for reading).
 /** @} */
 
 /**
- * @name	Configuration Registers (47x)
+ * @name    Configuration Registers (47x)
  * @{
  */
 #define CC1100_IOCFG2       (0x00)      ///< GDO2 output pin configuration
@@ -141,12 +141,12 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 /** @} */
 
 /**
- * @name	Strobe commands (14x)
+ * @name    Strobe commands (14x)
  * @{
  */
-#define CC1100_SRES         (0x30)		///< Reset chip.
+#define CC1100_SRES         (0x30)      ///< Reset chip.
 /**
- * @brief	Enable and calibrate frequency synthesizer (if MCSM0.FS_AUTOCAL=1).
+ * @brief   Enable and calibrate frequency synthesizer (if MCSM0.FS_AUTOCAL=1).
  *
  * If in RX/TX: Go to a wait state where only the synthesizer is running (for quick RX / TX turnaround).
  */
@@ -170,35 +170,35 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 /** @} */
 
 /**
- * @name	Status registers (12x)
+ * @name    Status registers (12x)
  * @{
  */
-#define CC1100_PARTNUM      (0x30)		///< Part number of CC1100.
-#define CC1100_VERSION      (0x31)		///< Current version number.
-#define CC1100_FREQEST      (0x32)		///< Frequency Offset Estimate.
-#define CC1100_LQI          (0x33)		///< Demodulator estimate for Link Quality.
-#define CC1100_RSSI         (0x34)		///< Received signal strength indication.
-#define CC1100_MARCSTATE    (0x35)		///< Control state machine state.
-#define CC1100_WORTIME1     (0x36)		///< High byte of WOR timer.
-#define CC1100_WORTIME0     (0x37)		///< Low byte of WOR timer.
-#define CC1100_PKTSTATUS    (0x38)		///< Current GDOx status and packet status.
-#define CC1100_VCO_VC_DAC   (0x39)		///< Current setting from PLL calibration module.
-#define CC1100_TXBYTES      (0x3A)		///< Underflow and number of bytes in the TX FIFO.
-#define CC1100_RXBYTES      (0x3B)		///< Overflow and number of bytes in the RX FIFO.
+#define CC1100_PARTNUM      (0x30)      ///< Part number of CC1100.
+#define CC1100_VERSION      (0x31)      ///< Current version number.
+#define CC1100_FREQEST      (0x32)      ///< Frequency Offset Estimate.
+#define CC1100_LQI          (0x33)      ///< Demodulator estimate for Link Quality.
+#define CC1100_RSSI         (0x34)      ///< Received signal strength indication.
+#define CC1100_MARCSTATE    (0x35)      ///< Control state machine state.
+#define CC1100_WORTIME1     (0x36)      ///< High byte of WOR timer.
+#define CC1100_WORTIME0     (0x37)      ///< Low byte of WOR timer.
+#define CC1100_PKTSTATUS    (0x38)      ///< Current GDOx status and packet status.
+#define CC1100_VCO_VC_DAC   (0x39)      ///< Current setting from PLL calibration module.
+#define CC1100_TXBYTES      (0x3A)      ///< Underflow and number of bytes in the TX FIFO.
+#define CC1100_RXBYTES      (0x3B)      ///< Overflow and number of bytes in the RX FIFO.
 /** @} */
 
 /**
- * @name	Multi byte registers
+ * @name    Multi byte registers
  * @{
  */
 /**
- * @brief	Register for eight user selected output power settings.
+ * @brief   Register for eight user selected output power settings.
  *
  * 3-bit FREND0.PA_POWER value selects the PATABLE entry to use.
  */
 #define CC1100_PATABLE      (0x3E)
-#define CC1100_TXFIFO       (0x3F)		///< TX FIFO: Write operations write to the TX FIFO (SB: +0x00; BURST: +0x40)
-#define CC1100_RXFIFO       (0x3F)		///< RX FIFO: Read operations read from the RX FIFO (SB: +0x80; BURST: +0xC0)
+#define CC1100_TXFIFO       (0x3F)      ///< TX FIFO: Write operations write to the TX FIFO (SB: +0x00; BURST: +0x40)
+#define CC1100_RXFIFO       (0x3F)      ///< RX FIFO: Read operations read from the RX FIFO (SB: +0x80; BURST: +0xC0)
 
 /** @} */
 

--- a/drivers/cc110x/cc1100_phy.h
+++ b/drivers/cc110x/cc1100_phy.h
@@ -13,20 +13,20 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 *******************************************************************************/
 
 /**
- * @ingroup		dev_cc110x
+ * @ingroup     dev_cc110x
  * @{
  */
 
 /**
  * @file
  * @internal
- * @brief		TI Chipcon CC110x physical radio driver
+ * @brief       TI Chipcon CC110x physical radio driver
  *
- * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
- * @author		Heiko Will <hwill@inf.fu-berlin.de>
+ * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
+ * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 1285 $
  *
- * @note		$Id: cc1100_phy.h 1285 2009-08-27 13:22:42Z hillebra $
+ * @note        $Id: cc1100_phy.h 1285 2009-08-27 13:22:42Z hillebra $
  */
 #ifndef CC1100_PHY_H_
 #define CC1100_PHY_H_
@@ -37,10 +37,10 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 #include "cc1100-internal.h"
 #include "cc110x.h"
 
-#define MAX_DATA_LENGTH		(0x3A)	///< Maximum data length of layer 0 = 58 Bytes.
+#define MAX_DATA_LENGTH     (0x3A)  ///< Maximum data length of layer 0 = 58 Bytes.
 
 /**
- * @brief	CC1100 layer 0 protocol
+ * @brief   CC1100 layer 0 protocol
  *
  * <pre>
 ---------------------------------------------------
@@ -51,36 +51,36 @@ and Telematics group (http://cst.mi.fu-berlin.de).
   1 byte   1 byte    1 byte   1 byte   <= 58 bytes
 
 Flags:
-		Bit | Meaning
-		--------------------
-		7:4	| -
-		3:1 | Protocol
-		  0 | Identification
+        Bit | Meaning
+        --------------------
+        7:4 | -
+        3:1 | Protocol
+          0 | Identification
 </pre>
 Notes:
 \li length & address are given by CC1100
 \li Identification is increased is used to scan duplicates. It must be increased
-	for each new packet and kept for packet retransmissions.
+    for each new packet and kept for packet retransmissions.
  */
 typedef struct __attribute__((packed)) cc1100_packet_layer0_t {
-    uint8_t length;					///< Length of the packet (without length byte)
-    uint8_t address;				///< Destination address
-    uint8_t phy_src;				///< Source address (physical source)
-    uint8_t flags;					///< Flags
-    uint8_t data[MAX_DATA_LENGTH];	///< Data (high layer protocol)
+    uint8_t length;                 ///< Length of the packet (without length byte)
+    uint8_t address;                ///< Destination address
+    uint8_t phy_src;                ///< Source address (physical source)
+    uint8_t flags;                  ///< Flags
+    uint8_t data[MAX_DATA_LENGTH];  ///< Data (high layer protocol)
 } cc1100_packet_layer0_t;
 
 typedef struct cc1100_wor_config_t {
-    uint16_t rx_interval;	///< RX polling interval in milliseconds
-    float	 rx_time_ms;	///< WOR_RX_TIME in milliseconds
-    uint8_t  rx_time_reg;	///< WOR_RX_TIME (CC1100 "MCSM2.RX_TIME" register value)
-    uint8_t  wor_evt_0;		///< CC1100 WOREVT0 register value
-    uint8_t  wor_evt_1;		///< CC1100 WOREVT1 register value
-    uint8_t  wor_ctrl;		///< CC1100 WORCTRL register value
+    uint16_t rx_interval;   ///< RX polling interval in milliseconds
+    float    rx_time_ms;    ///< WOR_RX_TIME in milliseconds
+    uint8_t  rx_time_reg;   ///< WOR_RX_TIME (CC1100 "MCSM2.RX_TIME" register value)
+    uint8_t  wor_evt_0;     ///< CC1100 WOREVT0 register value
+    uint8_t  wor_evt_1;     ///< CC1100 WOREVT1 register value
+    uint8_t  wor_ctrl;      ///< CC1100 WORCTRL register value
 } cc1100_wor_config_t;
 
 /*---------------------------------------------------------------------------*/
-//					CC1100 Wake-On-Radio configuration
+//                  CC1100 Wake-On-Radio configuration
 /*---------------------------------------------------------------------------*/
 
 extern uint16_t cc1100_burst_count;
@@ -89,11 +89,11 @@ extern uint8_t cc1100_retransmission_count_bc;
 extern cc1100_wor_config_t cc1100_wor_config;
 
 /*---------------------------------------------------------------------------*/
-//					CC1100 physical radio driver API
+//                  CC1100 physical radio driver API
 /*---------------------------------------------------------------------------*/
 
 /**
- * @brief	Initialize the physical radio layer.
+ * @brief   Initialize the physical radio layer.
  */
 void cc1100_phy_init(void);
 
@@ -114,22 +114,22 @@ void cc1100_phy_mutex_lock(void);
 void cc1100_phy_mutex_unlock(void);
 
 /**
- * @brief	Calculate and store Wake-On-Radio settings.
+ * @brief   Calculate and store Wake-On-Radio settings.
  *
  * Calculates WOR settings for a given RX interval in
  * milliseconds and stores the values in global configuration.
  * <p>
  * Does not change settings if not applicable.
  *
- * @param 	millis Desired RX interval in milliseconds [50..60000].
+ * @param   millis Desired RX interval in milliseconds [50..60000].
  *
- * @return 	The burst count (number of packets in a burst transfer)
- * 			or -1 if an error occurred (e.g. RX interval invalid).
+ * @return  The burst count (number of packets in a burst transfer)
+ *          or -1 if an error occurred (e.g. RX interval invalid).
  */
 int cc1100_phy_calc_wor_settings(uint16_t millis);
 
 /**
- * @brief	Handler function for incoming packets.
+ * @brief   Handler function for incoming packets.
  *
  * This handler function must be called in the receive
  * interrupt service routine.

--- a/drivers/cc110x/cc1100_spi.c
+++ b/drivers/cc110x/cc1100_spi.c
@@ -13,20 +13,20 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 *******************************************************************************/
 
 /**
- * @ingroup		dev_cc110x
+ * @ingroup     dev_cc110x
  * @{
  */
 
 /**
  * @file
  * @internal
- * @brief		TI Chipcon CC1100 SPI driver
+ * @brief       TI Chipcon CC1100 SPI driver
  *
- * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
- * @author		Heiko Will <hwill@inf.fu-berlin.de>
+ * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
+ * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 1775 $
  *
- * @note		$Id: cc1100_spi.c 1775 2010-01-26 09:37:03Z hillebra $
+ * @note        $Id: cc1100_spi.c 1775 2010-01-26 09:37:03Z hillebra $
  */
 
 #include <stdio.h>
@@ -38,7 +38,7 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 #include "cc1100-internal.h"
 
 /*---------------------------------------------------------------------------*/
-//					    CC1100 SPI access
+//                      CC1100 SPI access
 /*---------------------------------------------------------------------------*/
 
 uint8_t

--- a/drivers/cc110x/cc1100_spi.h
+++ b/drivers/cc110x/cc1100_spi.h
@@ -13,20 +13,20 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 *******************************************************************************/
 
 /**
- * @ingroup		dev_cc110x
+ * @ingroup     dev_cc110x
  * @{
  */
 
 /**
  * @file
  * @internal
- * @brief		TI Chipcon CC1100 SPI driver
+ * @brief       TI Chipcon CC1100 SPI driver
  *
- * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
- * @author		Heiko Will <hwill@inf.fu-berlin.de>
+ * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
+ * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @version     $Revision: 1775 $
  *
- * @note		$Id: cc1100_spi.h 1775 2010-01-26 09:37:03Z hillebra $
+ * @note        $Id: cc1100_spi.h 1775 2010-01-26 09:37:03Z hillebra $
  */
 
 #ifndef CC1100_SPI_H_

--- a/drivers/cc2420/include/cc2420_arch.h
+++ b/drivers/cc2420/include/cc2420_arch.h
@@ -14,10 +14,10 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 
 /**
  * @file
- * @ingroup		CC2420
- * @brief		CC2420 dependend functions
+ * @ingroup     CC2420
+ * @brief       CC2420 dependend functions
  *
- * @author		Heiko Will <hwill@inf.fu-berlin.de>
+ * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @author      Milan Babel <babel@inf.fu-berlin.de>
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
  */

--- a/drivers/include/at86rf231.h
+++ b/drivers/include/at86rf231.h
@@ -19,7 +19,7 @@
 typedef struct __attribute__((packed))
 {
     /* @{ */
-    uint8_t length;  			      /** < the length of the frame of the frame including fcs*/
+    uint8_t length;                   /** < the length of the frame of the frame including fcs*/
     ieee802154_frame_t frame;   /** < the ieee802154 frame */
     int8_t rssi;                /** < the rssi value */
     uint8_t crc;                /** < 1 if crc was successfull, 0 otherwise */

--- a/drivers/include/cc110x/cc1100-interface.h
+++ b/drivers/include/cc110x/cc1100-interface.h
@@ -13,18 +13,18 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 *******************************************************************************/
 
 /**
- * @ingroup		dev_cc110x
+ * @ingroup     dev_cc110x
  * @{
  */
 
 /**
  * @file
- * @brief		TI Chipcon CC110x public interface
+ * @brief       TI Chipcon CC110x public interface
  *
- * @author		Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
+ * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @version     $Revision: 2283 $
  *
- * @note		$Id: cc1100-interface.h 2283 2010-06-15 14:02:27Z hillebra $
+ * @note        $Id: cc1100-interface.h 2283 2010-06-15 14:02:27Z hillebra $
  */
 
 #ifndef CC1100INTERFACE_H_
@@ -33,19 +33,19 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 #include <stdint.h>
 #include "radio/radio.h"
 
-#define	CC1100_BROADCAST_ADDRESS (0x00)	///< CC1100 broadcast address
+#define CC1100_BROADCAST_ADDRESS (0x00) ///< CC1100 broadcast address
 
-#define MAX_UID					 (0xFF) ///< Maximum UID of a node is 255
-#define MIN_UID					 (0x01) ///< Minimum UID of a node is 1
+#define MAX_UID                  (0xFF) ///< Maximum UID of a node is 255
+#define MIN_UID                  (0x01) ///< Minimum UID of a node is 1
 
-#define MIN_CHANNR					(0)	///< Minimum channel number
-#define MAX_CHANNR				   (24)	///< Maximum channel number
+#define MIN_CHANNR                  (0) ///< Minimum channel number
+#define MAX_CHANNR                 (24) ///< Maximum channel number
 
-#define MIN_OUTPUT_POWER			(0)	///< Minimum output power value
-#define MAX_OUTPUT_POWER		   (11)	///< Maximum output power value
+#define MIN_OUTPUT_POWER            (0) ///< Minimum output power value
+#define MAX_OUTPUT_POWER           (11) ///< Maximum output power value
 
-#define CC1100_MODE_WOR				(0)	///< Usable radio mode: Wake-On-Radio
-#define CC1100_MODE_CONSTANT_RX		(1)	///< Usable radio mode: Constant receive
+#define CC1100_MODE_WOR             (0) ///< Usable radio mode: Wake-On-Radio
+#define CC1100_MODE_CONSTANT_RX     (1) ///< Usable radio mode: Constant receive
 
 #define CC1100_MAX_DATA_LENGTH (58)
 
@@ -62,21 +62,21 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 extern const radio_t radio_cc1100;
 
 /**
- * @brief	Initialize radio layer.
+ * @brief   Initialize radio layer.
  *
  * Initialize the radio layer, must be called before radio can be used.
  */
 void cc1100_init(void);
 
 /**
- * @brief	Get the radio mode.
+ * @brief   Get the radio mode.
  *
- * @return	Either CC1100_MODE_CONSTANT_RX or CC1100_MODE_WOR.
+ * @return  Either CC1100_MODE_CONSTANT_RX or CC1100_MODE_WOR.
  */
 uint8_t cc1100_get_mode(void);
 
 /**
- * @brief	Set the radio mode.
+ * @brief   Set the radio mode.
  *
  * Sets the radio mode with optional mode data. If the radio mode is WOR,
  * the optional mode data is the RX interval in milliseconds. Must be called
@@ -90,116 +90,116 @@ uint8_t cc1100_get_mode(void);
 bool cc1100_set_mode(uint8_t mode, uint16_t opt_mode_data);
 
 /**
- * @brief	Get the average transmission duration (till ACK received).
+ * @brief   Get the average transmission duration (till ACK received).
  *
- * @return	The average transmission duration of one packet in milliseconds.
+ * @return  The average transmission duration of one packet in milliseconds.
  */
 int cc1100_get_avg_transmission_duration(void);
 
 /**
- * @brief	Get the radio address.
+ * @brief   Get the radio address.
  *
- * @return	The current address of the radio.
+ * @return  The current address of the radio.
  */
 radio_address_t cc1100_get_address(void);
 
 /**
- * @brief	Set the radio address.
+ * @brief   Set the radio address.
  *
- * @param	address The new radio address.
+ * @param   address The new radio address.
  *
- * @return	true if address could be set; false otherwise.
+ * @return  true if address could be set; false otherwise.
  */
 bool cc1100_set_address(radio_address_t address);
 
 /**
- * @brief	Get the current channel number.
+ * @brief   Get the current channel number.
  *
- * @return	The current channel number used.
+ * @return  The current channel number used.
  */
 uint8_t cc1100_get_channel(void);
 
 /**
- * @brief	Set the channel to use.
+ * @brief   Set the channel to use.
  *
- * @param	channr The new channel number (between MIN_CHANNR and MAX_CHANNR) to use.
+ * @param   channr The new channel number (between MIN_CHANNR and MAX_CHANNR) to use.
  *
- * @return	true if channel could be set; false otherwise.
+ * @return  true if channel could be set; false otherwise.
  */
 bool cc1100_set_channel(uint8_t channr);
 
 /**
- * @brief	Set current output power in dBm.
+ * @brief   Set current output power in dBm.
  *
- * @param	pa_idx New output power setting, valid values
+ * @param   pa_idx New output power setting, valid values
  *          are from MIN_OUTPUT_POWER (lowest output power, -52 dBm)
  *          to MAX_OUTPUT_POWER (highest output power, +10 dBm).
  *
- * @return	true if output power could be set; false otherwise.
+ * @return  true if output power could be set; false otherwise.
  */
 bool cc1100_set_output_power(uint8_t pa_idx);
 
 /**
- * @brief	Set a packet monitor at this layer.
+ * @brief   Set a packet monitor at this layer.
  *
  * All incoming packets will be passed to this packet monitor before
  * packet gets processed by a specific handler. The work in the monitor
  * should take as less time as possible (no waiting or intense I/O).
  *
- * @param	monitor	The packet monitor or NULL if the current packet
+ * @param   monitor The packet monitor or NULL if the current packet
  *                  monitor should be removed.
  *
- * @return	true if this layer supports packet monitoring; false otherwise.
+ * @return  true if this layer supports packet monitoring; false otherwise.
  */
 bool cc1100_set_packet_monitor(packet_monitor_t monitor);
 
 /**
- * @brief	Set a packet handler for a given protocol.
+ * @brief   Set a packet handler for a given protocol.
  *
- * @param	protocol The protocol identifier (3-bit value > 0, 1 reserved for LL-ACK).
- * @param	handler The packet handler called if a packet of given protocol is received.
+ * @param   protocol The protocol identifier (3-bit value > 0, 1 reserved for LL-ACK).
+ * @param   handler The packet handler called if a packet of given protocol is received.
  *
- * @return	-1 if an error occurs (e.g. handler table full) else >= 0.
+ * @return  -1 if an error occurs (e.g. handler table full) else >= 0.
  */
 int cc1100_set_packet_handler(protocol_t protocol, packet_handler_t handler);
 
 /**
- * @brief	Send data to given destination address with acknowledgment.
+ * @brief   Send data to given destination address with acknowledgment.
  *
  * The maximum payload length are 58 bytes!
  *
- * @param	addr The destination address.
- * @param	protocol The protocol identifier of the transmitted data.
- * @param	priority Ignored (always highest).
- * @param	payload The data to be send.
- * @param	payload_len The length of the data in bytes.
+ * @param   addr The destination address.
+ * @param   protocol The protocol identifier of the transmitted data.
+ * @param   priority Ignored (always highest).
+ * @param   payload The data to be send.
+ * @param   payload_len The length of the data in bytes.
  *
- * @return	A negative value if operation failed; if operation succeeded (ACK received) the number of transmitted bytes.
+ * @return  A negative value if operation failed; if operation succeeded (ACK received) the number of transmitted bytes.
  */
 int cc1100_send(radio_address_t addr, protocol_t protocol, int priority, char *payload, int payload_len);
 
 /**
- * @brief	Send data to given destination address with acknowledgment and CSMA/CA.
+ * @brief   Send data to given destination address with acknowledgment and CSMA/CA.
  *
  * The maximum payload length are 58 bytes!
  *
- * @param	address The destination address.
- * @param	protocol The protocol identifier of the transmitted data.
- * @param	priority The MAC priority to send with. One of {PRIORITY_ALARM, PRIORITY_WARNING, PRIORITY_DATA}.
- * @param	payload The data to be send.
- * @param	payload_len The length of the data in bytes.
+ * @param   address The destination address.
+ * @param   protocol The protocol identifier of the transmitted data.
+ * @param   priority The MAC priority to send with. One of {PRIORITY_ALARM, PRIORITY_WARNING, PRIORITY_DATA}.
+ * @param   payload The data to be send.
+ * @param   payload_len The length of the data in bytes.
  *
- * @return	A negative value if operation failed; if operation succeeded (ACK received) else the number of transmitted bytes.
+ * @return  A negative value if operation failed; if operation succeeded (ACK received) else the number of transmitted bytes.
  */
 int cc1100_send_csmaca(radio_address_t address, protocol_t protocol, int priority, char *payload, int payload_len);
 
 /**
- * @brief	Print current radio configuration.
+ * @brief   Print current radio configuration.
  */
 void cc1100_print_config(void);
 
 /**
- * @brief	Print radio statistics.
+ * @brief   Print radio statistics.
  */
 void cc1100_print_statistic(void);
 

--- a/drivers/include/cc2420.h
+++ b/drivers/include/cc2420.h
@@ -39,17 +39,17 @@ FCS contain a hardware generated CRC sum with the polynom x^16+x^12+x^5+1
 When receiving a package FCS will be checked by hardware, the first FCS byte will be replaced by RSSI,
 followed by a CRC OK bit and the unsigned 7 bit correlation value.
 FCF:
-		Bit | Meaning
-		--------------------
-		0-2	| Frame Type
-		  3 | Security Enabled
-		  4 | Frame Pending
-		  5 | Acknowledge request
-		  6 | PAN ID Compression Field
-		7-9 | Reserved
-	  10-11 | Destination addressing mode
-	  12-13 | Reserved
-	  14-15 | Source addressing mode
+        Bit | Meaning
+        --------------------
+        0-2 | Frame Type
+          3 | Security Enabled
+          4 | Frame Pending
+          5 | Acknowledge request
+          6 | PAN ID Compression Field
+        7-9 | Reserved
+      10-11 | Destination addressing mode
+      12-13 | Reserved
+      14-15 | Source addressing mode
 
 For the cc2420 bit 0 is the most right bit and bit 15 is the most left bit.
 But the 2 FCF bytes have to be transmitted littel endian (byte 15 to 8 first than 7 to 0)
@@ -97,8 +97,8 @@ Frame type value:
  *  Structure to represent a cc2420 packet.
  */
 typedef struct __attribute__ ((packed)) {
-	/* @{ */
-    uint8_t length;  			/** < the length of the frame of the frame including fcs*/
+    /* @{ */
+    uint8_t length;             /** < the length of the frame of the frame including fcs*/
     ieee802154_frame_t frame;   /** < the ieee802154 frame */
     int8_t rssi;                /** < the rssi value */
     uint8_t lqi;                /** < the link quality indicator */

--- a/drivers/sht11/sht11.c
+++ b/drivers/sht11/sht11.c
@@ -13,19 +13,19 @@ and Telematics group (http://cst.mi.fu-berlin.de).
 *******************************************************************************/
 
 /**
- * @defgroup	sht11 SHT11
- * @ingroup		drivers
- * @brief		Driver for the Sensirion SHT11 humidity and temperature sensor
+ * @defgroup    sht11 SHT11
+ * @ingroup     drivers
+ * @brief       Driver for the Sensirion SHT11 humidity and temperature sensor
  * @{
  */
 
 /**
  * @file
- * @brief		SHT11 Device Driver
+ * @brief       SHT11 Device Driver
  *
  * @version     $Revision: 2396 $
  *
- * @note		$Id: sht11.c 2396 2010-07-06 15:12:35Z ziegert $
+ * @note        $Id: sht11.c 2396 2010-07-06 15:12:35Z ziegert $
  */
 
 #include <stdio.h>


### PR DESCRIPTION
This PR converts tabs to white spaces.
The statement I used for the conversion:
`find . -name "*.[ch]" -exec zsh -c 'expand -t 4 "$0" > /tmp/e && mv /tmp/e "$0"' {} \;`
Afterwards, I had a quick overview of the converted files to prevent odd indentation.
