### PR TITLE
converting tabs to spaces in tests (#1439)

### DIFF
--- a/tests/unittests/embunit/embUnit/AssertImpl.c
+++ b/tests/unittests/embunit/embUnit/AssertImpl.c
@@ -38,63 +38,63 @@
 
 void assertImplementationInt(int expected,int actual, long line, const char *file)
 {
-	char buffer[32];	/*"exp -2147483647 was -2147483647"*/
-	char numbuf[12];	/*32bit int decimal maximum column is 11 (-2147483647~2147483647)*/
+    char buffer[32];    /*"exp -2147483647 was -2147483647"*/
+    char numbuf[12];    /*32bit int decimal maximum column is 11 (-2147483647~2147483647)*/
 
-	stdimpl_strcpy(buffer, "exp ");
+    stdimpl_strcpy(buffer, "exp ");
 
-	{	stdimpl_itoa(expected, numbuf, 10);
-		stdimpl_strncat(buffer, numbuf, 11);	}
+    {   stdimpl_itoa(expected, numbuf, 10);
+        stdimpl_strncat(buffer, numbuf, 11);    }
 
-	stdimpl_strcat(buffer, " was ");
+    stdimpl_strcat(buffer, " was ");
 
-	{	stdimpl_itoa(actual, numbuf, 10);
-		stdimpl_strncat(buffer, numbuf, 11);	}
+    {   stdimpl_itoa(actual, numbuf, 10);
+        stdimpl_strncat(buffer, numbuf, 11);    }
 
-	addFailure(buffer, line, file);
+    addFailure(buffer, line, file);
 }
 
 void assertImplementationCStr(const char *expected,const char *actual, long line, const char *file)
 {
-	char buffer[ASSERT_STRING_BUFFER_MAX];
-	#define exp_act_limit ((ASSERT_STRING_BUFFER_MAX-11-1)/2)/*	"exp'' was''" = 11 byte	*/
-	int el;
-	int al;
+    char buffer[ASSERT_STRING_BUFFER_MAX];
+    #define exp_act_limit ((ASSERT_STRING_BUFFER_MAX-11-1)/2)/* "exp'' was''" = 11 byte */
+    int el;
+    int al;
 
-	if (expected) {
-		el = stdimpl_strlen(expected);
-	} else {
-		el = 4;
-		expected = "null";
-	}
+    if (expected) {
+        el = stdimpl_strlen(expected);
+    } else {
+        el = 4;
+        expected = "null";
+    }
 
-	if (actual) {
-		al = stdimpl_strlen(actual);
-	} else {
-		al = 4;
-		actual = "null";
-	}
-	if (el > exp_act_limit) {
-		if (al > exp_act_limit) {
-			al = exp_act_limit;
-			el = exp_act_limit;
-		} else {
-			int w = exp_act_limit + (exp_act_limit - al);
-			if (el > w) {
-				el = w;
-			}
-		}
-	} else {
-		int w = exp_act_limit + (exp_act_limit - el);
-		if (al > w) {
-			al = w;
-		}
-	}
-	stdimpl_strcpy(buffer, "exp \"");
-	stdimpl_strncat(buffer, expected, el);
-	stdimpl_strcat(buffer, "\" was \"");
-	stdimpl_strncat(buffer, actual, al);
-	stdimpl_strcat(buffer, "\"");
+    if (actual) {
+        al = stdimpl_strlen(actual);
+    } else {
+        al = 4;
+        actual = "null";
+    }
+    if (el > exp_act_limit) {
+        if (al > exp_act_limit) {
+            al = exp_act_limit;
+            el = exp_act_limit;
+        } else {
+            int w = exp_act_limit + (exp_act_limit - al);
+            if (el > w) {
+                el = w;
+            }
+        }
+    } else {
+        int w = exp_act_limit + (exp_act_limit - el);
+        if (al > w) {
+            al = w;
+        }
+    }
+    stdimpl_strcpy(buffer, "exp \"");
+    stdimpl_strncat(buffer, expected, el);
+    stdimpl_strcat(buffer, "\" was \"");
+    stdimpl_strncat(buffer, actual, al);
+    stdimpl_strcat(buffer, "\"");
 
-	addFailure(buffer, line, file);
+    addFailure(buffer, line, file);
 }

--- a/tests/unittests/embunit/embUnit/AssertImpl.h
+++ b/tests/unittests/embunit/embUnit/AssertImpl.h
@@ -32,40 +32,40 @@
  *
  * $Id: AssertImpl.h,v 1.6 2003/09/16 11:09:53 arms22 Exp $
  */
-#ifndef	__ASSERTIMPL_H__
-#define	__ASSERTIMPL_H__
+#ifndef __ASSERTIMPL_H__
+#define __ASSERTIMPL_H__
 
-#ifdef	__cplusplus
+#ifdef  __cplusplus
 extern "C" {
 #endif
 
-void addFailure(const char *msg, long line, const char *file);	/*TestCase.c*/
+void addFailure(const char *msg, long line, const char *file);  /*TestCase.c*/
 
 void assertImplementationInt(int expected,int actual, long line, const char *file);
 void assertImplementationCStr(const char *expected,const char *actual, long line, const char *file);
 
 #define TEST_ASSERT_EQUAL_STRING(expected,actual)\
-	if (expected && actual && (stdimpl_strcmp(expected,actual)==0)) {} else {assertImplementationCStr(expected,actual,__LINE__,__FILE__);return;}
+    if (expected && actual && (stdimpl_strcmp(expected,actual)==0)) {} else {assertImplementationCStr(expected,actual,__LINE__,__FILE__);return;}
 
 #define TEST_ASSERT_EQUAL_INT(expected,actual)\
-	if (expected == actual) {} else {assertImplementationInt(expected,actual,__LINE__,__FILE__);return;}
+    if (expected == actual) {} else {assertImplementationInt(expected,actual,__LINE__,__FILE__);return;}
 
 #define TEST_ASSERT_NULL(pointer)\
-	TEST_ASSERT_MESSAGE(pointer == NULL,#pointer " was not null.")
+    TEST_ASSERT_MESSAGE(pointer == NULL,#pointer " was not null.")
 
 #define TEST_ASSERT_NOT_NULL(pointer)\
-	TEST_ASSERT_MESSAGE(pointer != NULL,#pointer " was null.")
+    TEST_ASSERT_MESSAGE(pointer != NULL,#pointer " was null.")
 
 #define TEST_ASSERT_MESSAGE(condition, message)\
-	if (condition) {} else {TEST_FAIL(message);}
+    if (condition) {} else {TEST_FAIL(message);}
 
 #define TEST_ASSERT(condition)\
-	if (condition) {} else {TEST_FAIL(#condition);}
+    if (condition) {} else {TEST_FAIL(#condition);}
 
 #define TEST_FAIL(message)\
-	if (0) {} else {addFailure(message,__LINE__,__FILE__);return;}
+    if (0) {} else {addFailure(message,__LINE__,__FILE__);return;}
 
-#ifdef	__cplusplus
+#ifdef  __cplusplus
 }
 #endif
 

--- a/tests/unittests/embunit/embUnit/HelperMacro.h
+++ b/tests/unittests/embunit/embUnit/HelperMacro.h
@@ -32,28 +32,28 @@
  *
  * $Id: HelperMacro.h,v 1.3 2004/02/10 16:19:29 arms22 Exp $
  */
-#ifndef	__HELPERMACRO_H__
-#define	__HELPERMACRO_H__
+#ifndef __HELPERMACRO_H__
+#define __HELPERMACRO_H__
 
 #define EMB_UNIT_TESTCASE(ca,sup,tdw,run) \
-	static const TestCase	ca = new_TestCase(#ca,sup,tdw,run)
+    static const TestCase   ca = new_TestCase(#ca,sup,tdw,run)
 
 #define EMB_UNIT_TESTSUITE(su,array) \
-	static const TestSuite	su = new_TestSuite(#su,(Test**)array,sizeof(array)/sizeof(array[0]))
+    static const TestSuite  su = new_TestSuite(#su,(Test**)array,sizeof(array)/sizeof(array[0]))
 
 #define EMB_UNIT_TESTREFS(tests) \
-	static Test* const tests[] =
+    static Test* const tests[] =
 
 #define EMB_UNIT_ADD_TESTREF(testref) \
-				(Test*)	testref
+                (Test*) testref
 
 #define EMB_UNIT_TESTCALLER(caller,sup,tdw,fixtures) \
-	static const TestCaller caller = new_TestCaller(#caller,sup,tdw,sizeof(fixtures)/sizeof(fixtures[0]),(TestFixture*)fixtures)
+    static const TestCaller caller = new_TestCaller(#caller,sup,tdw,sizeof(fixtures)/sizeof(fixtures[0]),(TestFixture*)fixtures)
 
 #define EMB_UNIT_TESTFIXTURES(fixtures) \
-	static const TestFixture	fixtures[] =
+    static const TestFixture    fixtures[] =
 
 #define EMB_UNIT_REPEATEDTEST(repeater,test,tmrp) \
-	static const RepeatedTest	repeater = new_RepeatedTest(test,tmrp)
+    static const RepeatedTest   repeater = new_RepeatedTest(test,tmrp)
 
 #endif/*__HELPERMACRO_H__*/

--- a/tests/unittests/embunit/embUnit/RepeatedTest.c
+++ b/tests/unittests/embunit/embUnit/RepeatedTest.c
@@ -37,25 +37,25 @@
 
 char* RepeatedTest_name(RepeatedTest* self)
 {
-	return Test_name(self->test);
+    return Test_name(self->test);
 }
 
 void RepeatedTest_run(RepeatedTest* self,TestResult* result)
 {
-	int i;
-	Test* test = self->test;
-	for (i=0; i<self->timesRepeat; i++) {
-		Test_run(test, result);
-	}
+    int i;
+    Test* test = self->test;
+    for (i=0; i<self->timesRepeat; i++) {
+        Test_run(test, result);
+    }
 }
 
 int RepeatedTest_countTestCases(RepeatedTest* self)
 {
-	return Test_countTestCases(self->test) * self->timesRepeat;
+    return Test_countTestCases(self->test) * self->timesRepeat;
 }
 
 const TestImplement RepeatedTestImplement = {
-	(TestNameFunction)			RepeatedTest_name,
-	(TestRunFunction)			RepeatedTest_run,
-	(TestCountTestCasesFunction)RepeatedTest_countTestCases,
+    (TestNameFunction)          RepeatedTest_name,
+    (TestRunFunction)           RepeatedTest_run,
+    (TestCountTestCasesFunction)RepeatedTest_countTestCases,
 };

--- a/tests/unittests/embunit/embUnit/RepeatedTest.h
+++ b/tests/unittests/embunit/embUnit/RepeatedTest.h
@@ -32,25 +32,25 @@
  *
  * $Id: RepeatedTest.h,v 1.7 2004/02/10 16:19:29 arms22 Exp $
  */
-#ifndef	__REPEATEDTEST_H__
-#define	__REPEATEDTEST_H__
+#ifndef __REPEATEDTEST_H__
+#define __REPEATEDTEST_H__
 
-typedef struct __RepeatedTest	RepeatedTest;
-typedef struct __RepeatedTest*	RepeatedTestRef;	/*downward compatible*/
+typedef struct __RepeatedTest   RepeatedTest;
+typedef struct __RepeatedTest*  RepeatedTestRef;    /*downward compatible*/
 
 struct __RepeatedTest {
-	TestImplement* isa;
-	Test* test;
-	int timesRepeat;
+    TestImplement* isa;
+    Test* test;
+    int timesRepeat;
 };
 
 extern const TestImplement RepeatedTestImplement;
 
-#define	new_RepeatedTest(test,tmrp)\
-	{\
-		(TestImplement*)&RepeatedTestImplement,\
-		(Test*)test,\
-		tmrp,\
-	}
+#define new_RepeatedTest(test,tmrp)\
+    {\
+        (TestImplement*)&RepeatedTestImplement,\
+        (Test*)test,\
+        tmrp,\
+    }
 
 #endif/*__REPEATEDTEST_H__*/

--- a/tests/unittests/embunit/embUnit/Test.h
+++ b/tests/unittests/embunit/embUnit/Test.h
@@ -32,34 +32,34 @@
  *
  * $Id: Test.h,v 1.4 2004/02/10 16:19:29 arms22 Exp $
  */
-#ifndef	__TEST_H__
-#define	__TEST_H__
+#ifndef __TEST_H__
+#define __TEST_H__
 
-typedef struct __TestResult		TestResult;
-typedef struct __TestResult*	TestResultRef;/*downward compatible*/
+typedef struct __TestResult     TestResult;
+typedef struct __TestResult*    TestResultRef;/*downward compatible*/
 
-typedef struct __TestImplement	TestImplement;
-typedef struct __TestImplement*	TestImplementRef;/*downward compatible*/
+typedef struct __TestImplement  TestImplement;
+typedef struct __TestImplement* TestImplementRef;/*downward compatible*/
 
 typedef char*(*TestNameFunction)(void*);
 typedef void(*TestRunFunction)(void*,TestResult*);
 typedef int(*TestCountTestCasesFunction)(void*);
 
 struct __TestImplement {
-	TestNameFunction name;
-	TestRunFunction run;
-	TestCountTestCasesFunction countTestCases;
+    TestNameFunction name;
+    TestRunFunction run;
+    TestCountTestCasesFunction countTestCases;
 };
 
-typedef struct __Test	Test;
-typedef struct __Test*	TestRef;/*downward compatible*/
+typedef struct __Test   Test;
+typedef struct __Test*  TestRef;/*downward compatible*/
 
 struct __Test {
-	TestImplement* isa;
+    TestImplement* isa;
 };
 
-#define Test_name(s)			((Test*)s)->isa->name(s)
-#define Test_run(s,r)			((Test*)s)->isa->run(s,r)
-#define Test_countTestCases(s)	((Test*)s)->isa->countTestCases(s)
+#define Test_name(s)            ((Test*)s)->isa->name(s)
+#define Test_run(s,r)           ((Test*)s)->isa->run(s,r)
+#define Test_countTestCases(s)  ((Test*)s)->isa->countTestCases(s)
 
 #endif/*__TEST_H__*/

--- a/tests/unittests/embunit/embUnit/TestCaller.c
+++ b/tests/unittests/embunit/embUnit/TestCaller.c
@@ -38,30 +38,30 @@
 
 char* TestCaller_name(TestCaller* self)
 {
-	return self->name;
+    return self->name;
 }
 
 void TestCaller_run(TestCaller* self,TestResult* result)
 {
-	TestCase cs = new_TestCase(0,0,0,0);
-	int i;
-	cs.setUp= self->setUp;
-	cs.tearDown	= self->tearDown;
-	for (i=0; i<self->numberOfFixtuers; i++) {
-		cs.name	= self->fixtuers[i].name;
-		cs.runTest	= self->fixtuers[i].test;
-		/*run test*/
-		Test_run(&cs,result);
-	}
+    TestCase cs = new_TestCase(0,0,0,0);
+    int i;
+    cs.setUp= self->setUp;
+    cs.tearDown = self->tearDown;
+    for (i=0; i<self->numberOfFixtuers; i++) {
+        cs.name = self->fixtuers[i].name;
+        cs.runTest  = self->fixtuers[i].test;
+        /*run test*/
+        Test_run(&cs,result);
+    }
 }
 
 int TestCaller_countTestCases(TestCaller* self)
 {
-	return self->numberOfFixtuers;
+    return self->numberOfFixtuers;
 }
 
 const TestImplement TestCallerImplement = {
-	(TestNameFunction)			TestCaller_name,
-	(TestRunFunction)			TestCaller_run,
-	(TestCountTestCasesFunction)TestCaller_countTestCases,
+    (TestNameFunction)          TestCaller_name,
+    (TestRunFunction)           TestCaller_run,
+    (TestCountTestCasesFunction)TestCaller_countTestCases,
 };

--- a/tests/unittests/embunit/embUnit/TestCaller.h
+++ b/tests/unittests/embunit/embUnit/TestCaller.h
@@ -32,41 +32,41 @@
  *
  * $Id: TestCaller.h,v 1.7 2004/02/10 16:19:29 arms22 Exp $
  */
-#ifndef	__TESTCALLER_H__
-#define	__TESTCALLER_H__
+#ifndef __TESTCALLER_H__
+#define __TESTCALLER_H__
 
-typedef struct __TestFixture	TestFixture;
-typedef struct __TestFixture*	TestFixtureRef;/*downward compatible*/
+typedef struct __TestFixture    TestFixture;
+typedef struct __TestFixture*   TestFixtureRef;/*downward compatible*/
 
 struct __TestFixture {
-	char *name;
-	void(*test)(void);
+    char *name;
+    void(*test)(void);
 };
 
 #define new_TestFixture(test) { #test, test }
 
-typedef struct __TestCaller		TestCaller;
-typedef struct __TestCaller*	TestCallerRef;/*downward compatible*/
+typedef struct __TestCaller     TestCaller;
+typedef struct __TestCaller*    TestCallerRef;/*downward compatible*/
 
 struct __TestCaller {
-	TestImplement* isa;
-	char *name;
-	void(*setUp)(void);
-	void(*tearDown)(void);
-	int numberOfFixtuers;
-	TestFixture	*fixtuers;
+    TestImplement* isa;
+    char *name;
+    void(*setUp)(void);
+    void(*tearDown)(void);
+    int numberOfFixtuers;
+    TestFixture *fixtuers;
 };
 
 extern const TestImplement TestCallerImplement;
 
 #define new_TestCaller(name,sup,tdw,numberOfFixtuers,fixtuers)\
-	{\
-		(TestImplement*)&TestCallerImplement,\
-		name,\
-		sup,\
-		tdw,\
-		numberOfFixtuers,\
-		fixtuers,\
-	}
+    {\
+        (TestImplement*)&TestCallerImplement,\
+        name,\
+        sup,\
+        tdw,\
+        numberOfFixtuers,\
+        fixtuers,\
+    }
 
 #endif/*__TESTCALLER_H__*/

--- a/tests/unittests/embunit/embUnit/TestCase.c
+++ b/tests/unittests/embunit/embUnit/TestCase.c
@@ -41,43 +41,43 @@ static TestCase* self_;
 
 char* TestCase_name(TestCase* self)
 {
-	return self->name;
+    return self->name;
 }
 
 void TestCase_run(TestCase* self,TestResult* result)
 {
-	TestResult_startTest(result, (Test*)self);
-	if (self->setUp) {
-		self->setUp();
-	}
-	if (self->runTest) {
-		TestResult* wr =result_;	/*push*/
-		TestCase* ws = self_;	/*push*/
-		result_ = result;
-		self_ = self;
-		self->runTest();
-		result_ = wr;	/*pop*/
-		self_ = ws;	/*pop*/
-	}
-	if (self->tearDown) {
-		self->tearDown();
-	}
-	TestResult_endTest(result, (Test*)self);
+    TestResult_startTest(result, (Test*)self);
+    if (self->setUp) {
+        self->setUp();
+    }
+    if (self->runTest) {
+        TestResult* wr =result_;    /*push*/
+        TestCase* ws = self_;   /*push*/
+        result_ = result;
+        self_ = self;
+        self->runTest();
+        result_ = wr;   /*pop*/
+        self_ = ws; /*pop*/
+    }
+    if (self->tearDown) {
+        self->tearDown();
+    }
+    TestResult_endTest(result, (Test*)self);
 }
 
 int TestCase_countTestCases(TestCase* self)
 {
     (void)self;
-	return 1;
+    return 1;
 }
 
 const TestImplement TestCaseImplement = {
-	(TestNameFunction)			TestCase_name,
-	(TestRunFunction)			TestCase_run,
-	(TestCountTestCasesFunction)TestCase_countTestCases,
+    (TestNameFunction)          TestCase_name,
+    (TestRunFunction)           TestCase_run,
+    (TestCountTestCasesFunction)TestCase_countTestCases,
 };
 
 void addFailure(const char *msg, long line, const char *file)
 {
-	TestResult_addFailure(result_, (Test*)self_, (char*)msg, line, (char*)file);
+    TestResult_addFailure(result_, (Test*)self_, (char*)msg, line, (char*)file);
 }

--- a/tests/unittests/embunit/embUnit/TestCase.h
+++ b/tests/unittests/embunit/embUnit/TestCase.h
@@ -32,29 +32,29 @@
  *
  * $Id: TestCase.h,v 1.7 2004/02/10 16:19:29 arms22 Exp $
  */
-#ifndef	__TESTCASE_H__
-#define	__TESTCASE_H__
+#ifndef __TESTCASE_H__
+#define __TESTCASE_H__
 
-typedef struct __TestCase	TestCase;
-typedef struct __TestCase*	TestCaseRef;/*compatible embUnit1.0*/
+typedef struct __TestCase   TestCase;
+typedef struct __TestCase*  TestCaseRef;/*compatible embUnit1.0*/
 
 struct __TestCase {
-	TestImplement* isa;
-	char *name;
-	void(*setUp)(void);
-	void(*tearDown)(void);
-	void(*runTest)(void);
+    TestImplement* isa;
+    char *name;
+    void(*setUp)(void);
+    void(*tearDown)(void);
+    void(*runTest)(void);
 };
 
 extern const TestImplement TestCaseImplement;
 
 #define new_TestCase(name,setUp,tearDown,runTest)\
-	{\
-		(TestImplement*)&TestCaseImplement,\
-		name,\
-		setUp,\
-		tearDown,\
-		runTest,\
-	}
+    {\
+        (TestImplement*)&TestCaseImplement,\
+        name,\
+        setUp,\
+        tearDown,\
+        runTest,\
+    }
 
 #endif/*__TESTCASE_H__*/

--- a/tests/unittests/embunit/embUnit/TestListener.h
+++ b/tests/unittests/embunit/embUnit/TestListener.h
@@ -32,31 +32,31 @@
  *
  * $Id: TestListener.h,v 1.4 2004/02/10 16:19:29 arms22 Exp $
  */
-#ifndef	__TESTLISTENER_H__
-#define	__TESTLISTENER_H__
+#ifndef __TESTLISTENER_H__
+#define __TESTLISTENER_H__
 
-typedef struct __TestListnerImplement	TestListnerImplement;
-typedef struct __TestListnerImplement*	TestListnerImplementRef;/*downward compatible*/
+typedef struct __TestListnerImplement   TestListnerImplement;
+typedef struct __TestListnerImplement*  TestListnerImplementRef;/*downward compatible*/
 
 typedef void(*TestListnerStartTestCallBack)(void*,void*);
 typedef void(*TestListnerEndTestCallBack)(void*,void*);
 typedef void(*TestListnerAddFailureCallBack)(void*,void*,const char*,int,const char*);
 
 struct __TestListnerImplement {
-	TestListnerStartTestCallBack startTest;
-	TestListnerEndTestCallBack endTest;
-	TestListnerAddFailureCallBack addFailure;
+    TestListnerStartTestCallBack startTest;
+    TestListnerEndTestCallBack endTest;
+    TestListnerAddFailureCallBack addFailure;
 };
 
-/*typedef struct __TestListner	TestListner;*/	/*->TestResult.h*/
-/*typedef struct __TestListner*	TestListnerRef;*/	/*->TestResult.h*/
+/*typedef struct __TestListner  TestListner;*/  /*->TestResult.h*/
+/*typedef struct __TestListner* TestListnerRef;*/   /*->TestResult.h*/
 
 struct __TestListner {
-	TestListnerImplement* isa;
+    TestListnerImplement* isa;
 };
 
-#define TestListner_startTest(s,t)			((TestListner*)s)->isa->startTest(s,t)
-#define TestListner_endTest(s,t)			((TestListner*)s)->isa->endTest(s,t)
-#define TestListner_addFailure(s,t,m,l,f)	((TestListner*)s)->isa->addFailure(s,t,m,l,f)
+#define TestListner_startTest(s,t)          ((TestListner*)s)->isa->startTest(s,t)
+#define TestListner_endTest(s,t)            ((TestListner*)s)->isa->endTest(s,t)
+#define TestListner_addFailure(s,t,m,l,f)   ((TestListner*)s)->isa->addFailure(s,t,m,l,f)
 
 #endif/*__TESTLISTENER_H__*/

--- a/tests/unittests/embunit/embUnit/TestResult.c
+++ b/tests/unittests/embunit/embUnit/TestResult.c
@@ -38,30 +38,30 @@
 
 void TestResult_init(TestResult* self,TestListner* listner)
 {
-	self->runCount = 0;
-	self->failureCount = 0;
-	self->listener = listner;
+    self->runCount = 0;
+    self->failureCount = 0;
+    self->listener = listner;
 }
 
 void TestResult_startTest(TestResult* self,Test* test)
 {
-	self->runCount++;
-	if (self->listener) {
-		TestListner_startTest(self->listener, test);
-	}
+    self->runCount++;
+    if (self->listener) {
+        TestListner_startTest(self->listener, test);
+    }
 }
 
 void TestResult_endTest(TestResult* self,Test* test)
 {
-	if (self->listener) {
-		TestListner_endTest(self->listener, test);
-	}
+    if (self->listener) {
+        TestListner_endTest(self->listener, test);
+    }
 }
 
 void TestResult_addFailure(TestResult* self,Test* test,const char* msg,int line,const char* file)
 {
-	self->failureCount++;
-	if (self->listener) {
-		TestListner_addFailure(self->listener, test, msg, line, file);
-	}
+    self->failureCount++;
+    if (self->listener) {
+        TestListner_addFailure(self->listener, test, msg, line, file);
+    }
 }

--- a/tests/unittests/embunit/embUnit/TestResult.h
+++ b/tests/unittests/embunit/embUnit/TestResult.h
@@ -32,38 +32,38 @@
  *
  * $Id: TestResult.h,v 1.7 2004/02/10 16:19:29 arms22 Exp $
  */
-#ifndef	__TESTRESULT_H__
-#define	__TESTRESULT_H__
+#ifndef __TESTRESULT_H__
+#define __TESTRESULT_H__
 
-#ifdef	__cplusplus
+#ifdef  __cplusplus
 extern "C" {
 #endif
 
-/*typedef struct __TestResult		TestResult;*//* -> Test.h*/
-/*typedef struct __TestResult*		TestResultRef;*//* -> Test.h*/
+/*typedef struct __TestResult       TestResult;*//* -> Test.h*/
+/*typedef struct __TestResult*      TestResultRef;*//* -> Test.h*/
 
-typedef struct __TestListner	TestListner;
-typedef struct __TestListner*	TestListnerRef;/*downward compatible*/
+typedef struct __TestListner    TestListner;
+typedef struct __TestListner*   TestListnerRef;/*downward compatible*/
 
 struct __TestResult {
-	unsigned short runCount;
-	unsigned short failureCount;
-	TestListner* listener;
+    unsigned short runCount;
+    unsigned short failureCount;
+    TestListner* listener;
 };
 
 #define new_TestResult(listener)\
-	{\
-		0,\
-		0,\
-		(TestListner*)listener,\
-	}
+    {\
+        0,\
+        0,\
+        (TestListner*)listener,\
+    }
 
 void TestResult_init(TestResult* self,TestListner* listner);
 void TestResult_startTest(TestResult* self,Test* test);
 void TestResult_endTest(TestResult* self,Test* test);
 void TestResult_addFailure(TestResult* self,Test* test,const char* msg,int line,const char* file);
 
-#ifdef	__cplusplus
+#ifdef  __cplusplus
 }
 #endif
 

--- a/tests/unittests/embunit/embUnit/TestRunner.c
+++ b/tests/unittests/embunit/embUnit/TestRunner.c
@@ -47,7 +47,7 @@ static void TestRunner_startTest(TestListner* self,Test* test)
 {
     (void)self;
     (void)test;
-	stdimpl_print(".");
+    stdimpl_print(".");
 }
 
 static void TestRunner_endTest(TestListner* self,Test* test)
@@ -59,63 +59,63 @@ static void TestRunner_endTest(TestListner* self,Test* test)
 static void TestRunner_addFailure(TestListner* self,Test* test,char* msg,int line,char* file)
 {
     (void)self;
-	stdimpl_print("\n");
-	stdimpl_print(Test_name(root_));
-	stdimpl_print(".");
-	stdimpl_print(Test_name(test));
-	{
-		char buf[16];
-		stdimpl_print(" (");
-		stdimpl_print(file);
-		stdimpl_print(" ");
-		stdimpl_itoa(line, buf, 10);
-		stdimpl_print(buf);
-		stdimpl_print(") ");
-	}
-	stdimpl_print(msg);
-	stdimpl_print("\n");
+    stdimpl_print("\n");
+    stdimpl_print(Test_name(root_));
+    stdimpl_print(".");
+    stdimpl_print(Test_name(test));
+    {
+        char buf[16];
+        stdimpl_print(" (");
+        stdimpl_print(file);
+        stdimpl_print(" ");
+        stdimpl_itoa(line, buf, 10);
+        stdimpl_print(buf);
+        stdimpl_print(") ");
+    }
+    stdimpl_print(msg);
+    stdimpl_print("\n");
 
-	TestRunnerHadErrors = 1;
+    TestRunnerHadErrors = 1;
 }
 
 static const TestListnerImplement TestRunnerImplement = {
-	(TestListnerStartTestCallBack)	TestRunner_startTest,
-	(TestListnerEndTestCallBack)	TestRunner_endTest,
-	(TestListnerAddFailureCallBack)	TestRunner_addFailure,
+    (TestListnerStartTestCallBack)  TestRunner_startTest,
+    (TestListnerEndTestCallBack)    TestRunner_endTest,
+    (TestListnerAddFailureCallBack) TestRunner_addFailure,
 };
 
 static const TestListner testrunner_ = {
-	(TestListnerImplement*)&TestRunnerImplement,
+    (TestListnerImplement*)&TestRunnerImplement,
 };
 
 void TestRunner_start(void)
 {
-	TestResult_init(&result_, (TestListner*)&testrunner_);
+    TestResult_init(&result_, (TestListner*)&testrunner_);
 }
 
 void TestRunner_runTest(Test* test)
 {
-	root_ = test;
-	Test_run(test, &result_);
+    root_ = test;
+    Test_run(test, &result_);
 }
 
 void TestRunner_end(void)
 {
-	char buf[16];
-	if (result_.failureCount) {
-		stdimpl_print("\nrun ");
-		stdimpl_itoa(result_.runCount, buf, 10);
-		stdimpl_print(buf);
-		stdimpl_print(" failures ");
-		stdimpl_itoa(result_.failureCount, buf, 10);
-		stdimpl_print(buf);
-		stdimpl_print("\n");
+    char buf[16];
+    if (result_.failureCount) {
+        stdimpl_print("\nrun ");
+        stdimpl_itoa(result_.runCount, buf, 10);
+        stdimpl_print(buf);
+        stdimpl_print(" failures ");
+        stdimpl_itoa(result_.failureCount, buf, 10);
+        stdimpl_print(buf);
+        stdimpl_print("\n");
 
-		TestRunnerHadErrors = 1;
-	} else {
-		stdimpl_print("\nOK (");
-		stdimpl_itoa(result_.runCount, buf, 10);
-		stdimpl_print(buf);
-		stdimpl_print(" tests)\n");
-	}
+        TestRunnerHadErrors = 1;
+    } else {
+        stdimpl_print("\nOK (");
+        stdimpl_itoa(result_.runCount, buf, 10);
+        stdimpl_print(buf);
+        stdimpl_print(" tests)\n");
+    }
 }

--- a/tests/unittests/embunit/embUnit/TestRunner.h
+++ b/tests/unittests/embunit/embUnit/TestRunner.h
@@ -32,10 +32,10 @@
  *
  * $Id: TestRunner.h,v 1.6 2004/02/10 16:19:29 arms22 Exp $
  */
-#ifndef	__TESTRUNNER_H__
-#define	__TESTRUNNER_H__
+#ifndef __TESTRUNNER_H__
+#define __TESTRUNNER_H__
 
-#ifdef	__cplusplus
+#ifdef  __cplusplus
 extern "C" {
 #endif
 
@@ -45,7 +45,7 @@ void TestRunner_end(void);
 
 extern int TestRunnerHadErrors;
 
-#ifdef	__cplusplus
+#ifdef  __cplusplus
 }
 #endif
 

--- a/tests/unittests/embunit/embUnit/TestSuite.c
+++ b/tests/unittests/embunit/embUnit/TestSuite.c
@@ -37,33 +37,33 @@
 
 char* TestSuite_name(TestSuite* self)
 {
-	return self->name;
+    return self->name;
 }
 
 void TestSuite_run(TestSuite* self,TestResult* result)
 {
-	if (self->tests) {
-		for (int i = 0; i < self->numberOfTests; i++) {
-			Test* test = self->tests[i];
-			Test_run(test, result);
-		}
-	}
+    if (self->tests) {
+        for (int i = 0; i < self->numberOfTests; i++) {
+            Test* test = self->tests[i];
+            Test_run(test, result);
+        }
+    }
 }
 
 int TestSuite_countTestCases(TestSuite* self)
 {
-	int count = 0;
-	if (self->tests) {
-		for (int i = 0; i < self->numberOfTests; i++) {
-			Test* test = self->tests[i];
-			count += Test_countTestCases(test);
-		}
-	}
-	return count;
+    int count = 0;
+    if (self->tests) {
+        for (int i = 0; i < self->numberOfTests; i++) {
+            Test* test = self->tests[i];
+            count += Test_countTestCases(test);
+        }
+    }
+    return count;
 }
 
 const TestImplement TestSuiteImplement = {
-	(TestNameFunction)			TestSuite_name,
-	(TestRunFunction)			TestSuite_run,
-	(TestCountTestCasesFunction)TestSuite_countTestCases,
+    (TestNameFunction)          TestSuite_name,
+    (TestRunFunction)           TestSuite_run,
+    (TestCountTestCasesFunction)TestSuite_countTestCases,
 };

--- a/tests/unittests/embunit/embUnit/TestSuite.h
+++ b/tests/unittests/embunit/embUnit/TestSuite.h
@@ -32,27 +32,27 @@
  *
  * $Id: TestSuite.h,v 1.7 2004/02/10 16:19:29 arms22 Exp $
  */
-#ifndef	__TESTSUITE_H__
-#define	__TESTSUITE_H__
+#ifndef __TESTSUITE_H__
+#define __TESTSUITE_H__
 
-typedef struct __TestSuite	TestSuite;
-typedef struct __TestSuite*	TestSuiteRef;/*downward compatible*/
+typedef struct __TestSuite  TestSuite;
+typedef struct __TestSuite* TestSuiteRef;/*downward compatible*/
 
 struct __TestSuite {
-	TestImplement* isa;
-	char *name;
-	int numberOfTests;
-	Test** tests;
+    TestImplement* isa;
+    char *name;
+    int numberOfTests;
+    Test** tests;
 };
 
 extern const TestImplement TestSuiteImplement;
 
 #define new_TestSuite(name,tests,numberOfTests)\
-	{\
-		(TestImplement*)&TestSuiteImplement,\
-		name,\
-		numberOfTests,\
-		tests,\
-	}
+    {\
+        (TestImplement*)&TestSuiteImplement,\
+        name,\
+        numberOfTests,\
+        tests,\
+    }
 
 #endif/*__TESTSUITE_H__*/

--- a/tests/unittests/embunit/embUnit/config.h
+++ b/tests/unittests/embunit/embUnit/config.h
@@ -35,14 +35,14 @@
 #ifndef __CONFIG_H__
 #define __CONFIG_H__
 
-/*	#define NO_STDIO_PRINTF*/
-	#ifdef	NO_STDIO_PRINTF
-		extern void stdimpl_print(const char *string);
-	#else
-		#include<stdio.h>
-		#define stdimpl_print(s) printf("%s", s);
-	#endif
+/*  #define NO_STDIO_PRINTF*/
+    #ifdef  NO_STDIO_PRINTF
+        extern void stdimpl_print(const char *string);
+    #else
+        #include<stdio.h>
+        #define stdimpl_print(s) printf("%s", s);
+    #endif
 
-	#define ASSERT_STRING_BUFFER_MAX	64
+    #define ASSERT_STRING_BUFFER_MAX    64
 
 #endif/*__CONFIG_H__*/

--- a/tests/unittests/embunit/embUnit/embUnit.h
+++ b/tests/unittests/embunit/embUnit/embUnit.h
@@ -32,8 +32,8 @@
  *
  * $Id: embUnit.h,v 1.4 2004/02/10 16:16:19 arms22 Exp $
  */
-#ifndef	__EMBUNIT_H__
-#define	__EMBUNIT_H__
+#ifndef __EMBUNIT_H__
+#define __EMBUNIT_H__
 
 #include <embUnit/Test.h>
 #include <embUnit/TestCase.h>

--- a/tests/unittests/embunit/embUnit/stdImpl.c
+++ b/tests/unittests/embunit/embUnit/stdImpl.c
@@ -36,106 +36,106 @@
 
 char* stdimpl_strcpy(char *dst, const char *src)
 {
-	char *start = dst;
-	char c;
-	do {
-		c = *src;
-		*dst = c;
-		src++;
-		dst++;
-	} while (c);
-	return start;
+    char *start = dst;
+    char c;
+    do {
+        c = *src;
+        *dst = c;
+        src++;
+        dst++;
+    } while (c);
+    return start;
 }
 
 char* stdimpl_strcat(char *dst, const char *src)
 {
-	char *start = dst;
-	char c;
-	do {
-		c = *dst;
-		dst++;
-	} while (c);
-	dst--;
-	do {
-		c = *src;
-		*dst = c;
-		src++;
-		dst++;
-	} while (c);
-	return start;
+    char *start = dst;
+    char c;
+    do {
+        c = *dst;
+        dst++;
+    } while (c);
+    dst--;
+    do {
+        c = *src;
+        *dst = c;
+        src++;
+        dst++;
+    } while (c);
+    return start;
 }
 
 char* stdimpl_strncat(char *dst, const char *src,unsigned int count)
 {
-	char *start = dst;
-	char c;
-	do {
-		c = *dst;
-		dst++;
-	} while (c);
-	dst--;
-	if (count) {
-		do {
-			c = *src;
-			*dst = c;
-			src++;
-			dst++;
-			count--;
-		} while (c && count);
-		*dst = '\0';
-	}
-	return start;
+    char *start = dst;
+    char c;
+    do {
+        c = *dst;
+        dst++;
+    } while (c);
+    dst--;
+    if (count) {
+        do {
+            c = *src;
+            *dst = c;
+            src++;
+            dst++;
+            count--;
+        } while (c && count);
+        *dst = '\0';
+    }
+    return start;
 }
 
 int stdimpl_strlen(const char *str)
 {
     const char *estr = str;
-	char c;
-	do {
-		c = *estr;
-		estr++;
-	} while (c);
+    char c;
+    do {
+        c = *estr;
+        estr++;
+    } while (c);
     return ((int)(estr - str - 1));
 }
 
 int stdimpl_strcmp(const char *s1, const char *s2)
 {
-	char c1,c2;
-	do {
-		c1 = *s1++;
-		c2 = *s2++;
-	} while ((c1) && (c2) && (c1==c2));
-	return c1 - c2;
+    char c1,c2;
+    do {
+        c1 = *s1++;
+        c2 = *s2++;
+    } while ((c1) && (c2) && (c1==c2));
+    return c1 - c2;
 }
 
 static char* _xtoa(unsigned long v,char *string, int r, int is_neg)
 {
-	char *start = string;
-	char buf[33],*p;
+    char *start = string;
+    char buf[33],*p;
 
-	p = buf;
+    p = buf;
 
-	do {
-		*p++ = "0123456789abcdef"[(v % r) & 0xf];
-	} while (v /= r);
+    do {
+        *p++ = "0123456789abcdef"[(v % r) & 0xf];
+    } while (v /= r);
 
-	if (is_neg) {
-		*p++ = '-';
-	}
+    if (is_neg) {
+        *p++ = '-';
+    }
 
-	do {
-		*string++ = *--p;
-	} while (buf != p);
+    do {
+        *string++ = *--p;
+    } while (buf != p);
 
-	*string = '\0';
+    *string = '\0';
 
-	return start;
+    return start;
 }
 
 char* stdimpl_itoa(int v,char *string,int r)
 {
     if ((r == 10) && (v < 0)) {
-		return _xtoa((unsigned long)(-v), string, r, 1);
-	}
-	return _xtoa((unsigned long)(v), string, r, 0);
+        return _xtoa((unsigned long)(-v), string, r, 1);
+    }
+    return _xtoa((unsigned long)(v), string, r, 0);
 }

--- a/tests/unittests/embunit/embUnit/stdImpl.h
+++ b/tests/unittests/embunit/embUnit/stdImpl.h
@@ -32,15 +32,15 @@
  *
  * $Id: stdImpl.h,v 1.4 2004/02/10 16:15:25 arms22 Exp $
  */
-#ifndef	__STDIMPL_H__
-#define	__STDIMPL_H__
+#ifndef __STDIMPL_H__
+#define __STDIMPL_H__
 
-#ifdef	__cplusplus
+#ifdef  __cplusplus
 extern "C" {
 #endif
 
 #ifndef NULL
-#define	NULL	0
+#define NULL    0
 #endif
 
 char* stdimpl_strcpy(char *s1, const char *s2);
@@ -50,7 +50,7 @@ int stdimpl_strlen(const char *str);
 int stdimpl_strcmp(const char *s1, const char *s2);
 char* stdimpl_itoa(int v,char *string,int r);
 
-#ifdef	__cplusplus
+#ifdef  __cplusplus
 }
 #endif
 

--- a/tests/unittests/embunit/textui/CompilerOutputter.c
+++ b/tests/unittests/embunit/textui/CompilerOutputter.c
@@ -64,7 +64,7 @@ static void CompilerOutputter_printFailure(OutputterRef self,TestRef test,char *
 {
     (void)self;
     (void)runCount;
-	fprintf(stdout,"%s %d: %s: %s\n", file, line, Test_name(test), msg);
+    fprintf(stdout,"%s %d: %s: %s\n", file, line, Test_name(test), msg);
 }
 
 static void CompilerOutputter_printStatistics(OutputterRef self,TestResultRef result)
@@ -74,19 +74,19 @@ static void CompilerOutputter_printStatistics(OutputterRef self,TestResultRef re
 }
 
 static const OutputterImplement CompilerOutputterImplement = {
-	(OutputterPrintHeaderFunction)		CompilerOutputter_printHeader,
-	(OutputterPrintStartTestFunction)	CompilerOutputter_printStartTest,
-	(OutputterPrintEndTestFunction)		CompilerOutputter_printEndTest,
-	(OutputterPrintSuccessfulFunction)	CompilerOutputter_printSuccessful,
-	(OutputterPrintFailureFunction)		CompilerOutputter_printFailure,
-	(OutputterPrintStatisticsFunction)	CompilerOutputter_printStatistics,
+    (OutputterPrintHeaderFunction)      CompilerOutputter_printHeader,
+    (OutputterPrintStartTestFunction)   CompilerOutputter_printStartTest,
+    (OutputterPrintEndTestFunction)     CompilerOutputter_printEndTest,
+    (OutputterPrintSuccessfulFunction)  CompilerOutputter_printSuccessful,
+    (OutputterPrintFailureFunction)     CompilerOutputter_printFailure,
+    (OutputterPrintStatisticsFunction)  CompilerOutputter_printStatistics,
 };
 
 static const Outputter CompilerOutputter = {
-	(OutputterImplementRef)&CompilerOutputterImplement,
+    (OutputterImplementRef)&CompilerOutputterImplement,
 };
 
 OutputterRef CompilerOutputter_outputter(void)
 {
-	return (OutputterRef)&CompilerOutputter;
+    return (OutputterRef)&CompilerOutputter;
 }

--- a/tests/unittests/embunit/textui/CompilerOutputter.h
+++ b/tests/unittests/embunit/textui/CompilerOutputter.h
@@ -32,8 +32,8 @@
  *
  * $Id: CompilerOutputter.h,v 1.2 2003/09/06 13:28:27 arms22 Exp $
  */
-#ifndef	__COMPILEROUTPUTTER_H__
-#define	__COMPILEROUTPUTTER_H__
+#ifndef __COMPILEROUTPUTTER_H__
+#define __COMPILEROUTPUTTER_H__
 
 #include "Outputter.h"
 

--- a/tests/unittests/embunit/textui/Outputter.h
+++ b/tests/unittests/embunit/textui/Outputter.h
@@ -32,13 +32,13 @@
  *
  * $Id: Outputter.h,v 1.2 2003/09/06 13:28:27 arms22 Exp $
  */
-#ifndef	__OUTPUTTER_H__
-#define	__OUTPUTTER_H__
+#ifndef __OUTPUTTER_H__
+#define __OUTPUTTER_H__
 
 #include <embUnit/embUnit.h>
 
-typedef struct __OutputterImplement		OutputterImplement;
-typedef struct __OutputterImplement*	OutputterImplementRef;
+typedef struct __OutputterImplement     OutputterImplement;
+typedef struct __OutputterImplement*    OutputterImplementRef;
 
 typedef void(*OutputterPrintHeaderFunction)(void*);
 typedef void(*OutputterPrintStartTestFunction)(void*,TestRef);
@@ -49,26 +49,26 @@ typedef void(*OutputterPrintStatisticsFunction)(void*,TestResultRef);
 
 
 struct __OutputterImplement {
-	OutputterPrintHeaderFunction		printHeader;
-	OutputterPrintStartTestFunction		printStartTest;
-	OutputterPrintEndTestFunction		printEndTest;
-	OutputterPrintSuccessfulFunction	printSuccessful;
-	OutputterPrintFailureFunction		printFailure;
-	OutputterPrintStatisticsFunction	printStatistics;
+    OutputterPrintHeaderFunction        printHeader;
+    OutputterPrintStartTestFunction     printStartTest;
+    OutputterPrintEndTestFunction       printEndTest;
+    OutputterPrintSuccessfulFunction    printSuccessful;
+    OutputterPrintFailureFunction       printFailure;
+    OutputterPrintStatisticsFunction    printStatistics;
 };
 
-typedef struct __Outputter	Outputter;
-typedef struct __Outputter*	OutputterRef;
+typedef struct __Outputter  Outputter;
+typedef struct __Outputter* OutputterRef;
 
 struct __Outputter {
-	OutputterImplementRef isa;
+    OutputterImplementRef isa;
 };
 
-#define Outputter_printHeader(o)			(o)->isa->printHeader(o)
-#define Outputter_printStartTest(o,t)		(o)->isa->printStartTest(o,t)
-#define Outputter_printEndTest(o,t)			(o)->isa->printEndTest(o,t)
-#define Outputter_printSuccessful(o,t,c)	(o)->isa->printSuccessful(o,t,c)
-#define Outputter_printFailure(o,t,m,l,f,c)	(o)->isa->printFailure(o,t,m,l,f,c)
-#define Outputter_printStatistics(o,r)		(o)->isa->printStatistics(o,r)
+#define Outputter_printHeader(o)            (o)->isa->printHeader(o)
+#define Outputter_printStartTest(o,t)       (o)->isa->printStartTest(o,t)
+#define Outputter_printEndTest(o,t)         (o)->isa->printEndTest(o,t)
+#define Outputter_printSuccessful(o,t,c)    (o)->isa->printSuccessful(o,t,c)
+#define Outputter_printFailure(o,t,m,l,f,c) (o)->isa->printFailure(o,t,m,l,f,c)
+#define Outputter_printStatistics(o,r)      (o)->isa->printStatistics(o,r)
 
 #endif/*__OUTPUTTER_H__*/

--- a/tests/unittests/embunit/textui/TextOutputter.c
+++ b/tests/unittests/embunit/textui/TextOutputter.c
@@ -43,7 +43,7 @@ static void TextOutputter_printHeader(OutputterRef self)
 static void TextOutputter_printStartTest(OutputterRef self,TestRef test)
 {
     (void)self;
-	fprintf(stdout,"- %s\n",Test_name(test));
+    fprintf(stdout,"- %s\n",Test_name(test));
 }
 
 static void TextOutputter_printEndTest(OutputterRef self,TestRef test)
@@ -55,39 +55,39 @@ static void TextOutputter_printEndTest(OutputterRef self,TestRef test)
 static void TextOutputter_printSuccessful(OutputterRef self,TestRef test,int runCount)
 {
     (void)self;
-	fprintf(stdout,"%d) OK %s\n", runCount, Test_name(test));
+    fprintf(stdout,"%d) OK %s\n", runCount, Test_name(test));
 }
 
 static void TextOutputter_printFailure(OutputterRef self,TestRef test,char *msg,int line,char *file,int runCount)
 {
     (void)self;
-	fprintf(stdout,"%d) NG %s (%s %d) %s\n", runCount, Test_name(test), file, line, msg);
+    fprintf(stdout,"%d) NG %s (%s %d) %s\n", runCount, Test_name(test), file, line, msg);
 }
 
 static void TextOutputter_printStatistics(OutputterRef self,TestResultRef result)
 {
     (void)self;
-	if (result->failureCount) {
-		fprintf(stdout,"\nrun %d failures %d\n",result->runCount,result->failureCount);
-	} else {
-		fprintf(stdout,"\nOK (%d tests)\n",result->runCount);
-	}
+    if (result->failureCount) {
+        fprintf(stdout,"\nrun %d failures %d\n",result->runCount,result->failureCount);
+    } else {
+        fprintf(stdout,"\nOK (%d tests)\n",result->runCount);
+    }
 }
 
 static const OutputterImplement TextOutputterImplement = {
-	(OutputterPrintHeaderFunction)		TextOutputter_printHeader,
-	(OutputterPrintStartTestFunction)	TextOutputter_printStartTest,
-	(OutputterPrintEndTestFunction)		TextOutputter_printEndTest,
-	(OutputterPrintSuccessfulFunction)	TextOutputter_printSuccessful,
-	(OutputterPrintFailureFunction)		TextOutputter_printFailure,
-	(OutputterPrintStatisticsFunction)	TextOutputter_printStatistics,
+    (OutputterPrintHeaderFunction)      TextOutputter_printHeader,
+    (OutputterPrintStartTestFunction)   TextOutputter_printStartTest,
+    (OutputterPrintEndTestFunction)     TextOutputter_printEndTest,
+    (OutputterPrintSuccessfulFunction)  TextOutputter_printSuccessful,
+    (OutputterPrintFailureFunction)     TextOutputter_printFailure,
+    (OutputterPrintStatisticsFunction)  TextOutputter_printStatistics,
 };
 
 static const Outputter TextOutputter = {
-	(OutputterImplementRef)&TextOutputterImplement,
+    (OutputterImplementRef)&TextOutputterImplement,
 };
 
 OutputterRef TextOutputter_outputter(void)
 {
-	return (OutputterRef)&TextOutputter;
+    return (OutputterRef)&TextOutputter;
 }

--- a/tests/unittests/embunit/textui/TextOutputter.h
+++ b/tests/unittests/embunit/textui/TextOutputter.h
@@ -32,8 +32,8 @@
  *
  * $Id: TextOutputter.h,v 1.2 2003/09/06 13:28:27 arms22 Exp $
  */
-#ifndef	__TEXTOUTPUTTER_H__
-#define	__TEXTOUTPUTTER_H__
+#ifndef __TEXTOUTPUTTER_H__
+#define __TEXTOUTPUTTER_H__
 
 #include "Outputter.h"
 

--- a/tests/unittests/embunit/textui/TextUIRunner.c
+++ b/tests/unittests/embunit/textui/TextUIRunner.c
@@ -35,7 +35,7 @@
 #include "TextOutputter.h"
 #include "TextUIRunner.h"
 
-/*	Private
+/*  Private
  */
 static TestResult result_;
 static OutputterRef outputterRef_ = 0;
@@ -45,63 +45,63 @@ static void TextUIRunner_startTest(TestListnerRef self,TestRef test)
 {
     (void)self;
     (void)test;
-	wasfailure_ = 0;
+    wasfailure_ = 0;
 }
 
 static void TextUIRunner_endTest(TestListnerRef self,TestRef test)
 {
     (void)self;
-	if (!wasfailure_)
-		Outputter_printSuccessful(outputterRef_,test,result_.runCount);
+    if (!wasfailure_)
+        Outputter_printSuccessful(outputterRef_,test,result_.runCount);
 }
 
 static void TextUIRunner_addFailure(TestListnerRef self,TestRef test,char *msg,int line,char *file)
 {
     (void)self;
-	wasfailure_ = 1;
-	Outputter_printFailure(outputterRef_,test,msg,line,file,result_.runCount);
+    wasfailure_ = 1;
+    Outputter_printFailure(outputterRef_,test,msg,line,file,result_.runCount);
 }
 
 static const TestListnerImplement TextUIRunnerImplement = {
-	(TestListnerStartTestCallBack)	TextUIRunner_startTest,
-	(TestListnerEndTestCallBack)	TextUIRunner_endTest,
-	(TestListnerAddFailureCallBack)	TextUIRunner_addFailure,
+    (TestListnerStartTestCallBack)  TextUIRunner_startTest,
+    (TestListnerEndTestCallBack)    TextUIRunner_endTest,
+    (TestListnerAddFailureCallBack) TextUIRunner_addFailure,
 };
 
 static const TestListner testuirunner_ = {
-	(TestListnerImplement*)&TextUIRunnerImplement,
+    (TestListnerImplement*)&TextUIRunnerImplement,
 };
 
-/*	Public
+/*  Public
  */
 void TextUIRunner_setOutputter(OutputterRef outputter)
 {
-	outputterRef_ = outputter;
+    outputterRef_ = outputter;
 }
 
 void TextUIRunner_startWithOutputter(OutputterRef outputter)
 {
-	TestResult_init(&result_, (TestListnerRef)&testuirunner_);
-	TextUIRunner_setOutputter(outputter);
-	Outputter_printHeader(outputter);
+    TestResult_init(&result_, (TestListnerRef)&testuirunner_);
+    TextUIRunner_setOutputter(outputter);
+    Outputter_printHeader(outputter);
 
 }
 
 void TextUIRunner_start(void)
 {
-	if (!outputterRef_)
-		outputterRef_ = TextOutputter_outputter();
-	TextUIRunner_startWithOutputter(outputterRef_);
+    if (!outputterRef_)
+        outputterRef_ = TextOutputter_outputter();
+    TextUIRunner_startWithOutputter(outputterRef_);
 }
 
 void TextUIRunner_runTest(TestRef test)
 {
-	Outputter_printStartTest(outputterRef_,test);
-	Test_run(test, &result_);
-	Outputter_printEndTest(outputterRef_,test);
+    Outputter_printStartTest(outputterRef_,test);
+    Test_run(test, &result_);
+    Outputter_printEndTest(outputterRef_,test);
 }
 
 void TextUIRunner_end(void)
 {
-	Outputter_printStatistics(outputterRef_,&result_);
+    Outputter_printStatistics(outputterRef_,&result_);
 }

--- a/tests/unittests/embunit/textui/TextUIRunner.h
+++ b/tests/unittests/embunit/textui/TextUIRunner.h
@@ -32,8 +32,8 @@
  *
  * $Id: TextUIRunner.h,v 1.3 2003/09/06 13:28:27 arms22 Exp $
  */
-#ifndef	__TEXTUIRUNNER_H__
-#define	__TEXTUIRUNNER_H__
+#ifndef __TEXTUIRUNNER_H__
+#define __TEXTUIRUNNER_H__
 
 #include "Outputter.h"
 

--- a/tests/unittests/embunit/textui/XMLOutputter.c
+++ b/tests/unittests/embunit/textui/XMLOutputter.c
@@ -40,76 +40,76 @@ static char *stylesheet_;
 static void XMLOutputter_printHeader(OutputterRef self)
 {
     (void)self;
-	fprintf(stdout,"<?xml version=\"1.0\" encoding='shift_jis' standalone='yes' ?>\n");
-	if (stylesheet_)
-	fprintf(stdout,"<?xml-stylesheet type=\"text/xsl\" href=\"%s\" ?>\n",stylesheet_);
-	fprintf(stdout,"<TestRun>\n");
+    fprintf(stdout,"<?xml version=\"1.0\" encoding='shift_jis' standalone='yes' ?>\n");
+    if (stylesheet_)
+    fprintf(stdout,"<?xml-stylesheet type=\"text/xsl\" href=\"%s\" ?>\n",stylesheet_);
+    fprintf(stdout,"<TestRun>\n");
 }
 
 static void XMLOutputter_printStartTest(OutputterRef self,TestRef test)
 {
     (void)self;
-	fprintf(stdout,"<%s>\n",Test_name(test));
+    fprintf(stdout,"<%s>\n",Test_name(test));
 }
 
 static void XMLOutputter_printEndTest(OutputterRef self,TestRef test)
 {
     (void)self;
-	fprintf(stdout,"</%s>\n",Test_name(test));
+    fprintf(stdout,"</%s>\n",Test_name(test));
 }
 
 static void XMLOutputter_printSuccessful(OutputterRef self,TestRef test,int runCount)
 {
     (void)self;
-	fprintf(stdout,"<Test id=\"%d\">\n",runCount);
-	fprintf(stdout,"<Name>%s</Name>\n",Test_name(test));
-	fprintf(stdout,"</Test>\n");
+    fprintf(stdout,"<Test id=\"%d\">\n",runCount);
+    fprintf(stdout,"<Name>%s</Name>\n",Test_name(test));
+    fprintf(stdout,"</Test>\n");
 }
 
 static void XMLOutputter_printFailure(OutputterRef self,TestRef test,char *msg,int line,char *file,int runCount)
 {
     (void)self;
-	fprintf(stdout,"<FailedTest id=\"%d\">\n",runCount);
-	fprintf(stdout,"<Name>%s</Name>\n",Test_name(test));
-	fprintf(stdout,"<Location>\n");
-	fprintf(stdout,"<File>%s</File>\n",file);
-	fprintf(stdout,"<Line>%d</Line>\n",line);
-	fprintf(stdout,"</Location>\n");
-	fprintf(stdout,"<Message>%s</Message>\n",msg);
-	fprintf(stdout,"</FailedTest>\n");
+    fprintf(stdout,"<FailedTest id=\"%d\">\n",runCount);
+    fprintf(stdout,"<Name>%s</Name>\n",Test_name(test));
+    fprintf(stdout,"<Location>\n");
+    fprintf(stdout,"<File>%s</File>\n",file);
+    fprintf(stdout,"<Line>%d</Line>\n",line);
+    fprintf(stdout,"</Location>\n");
+    fprintf(stdout,"<Message>%s</Message>\n",msg);
+    fprintf(stdout,"</FailedTest>\n");
 }
 
 static void XMLOutputter_printStatistics(OutputterRef self,TestResultRef result)
 {
     (void)self;
-	fprintf(stdout,"<Statistics>\n");
-	fprintf(stdout,"<Tests>%d</Tests>\n",result->runCount);
-	if (result->failureCount) {
-	fprintf(stdout,"<Failures>%d</Failures>\n",result->failureCount);
-	}
-	fprintf(stdout,"</Statistics>\n");
-	fprintf(stdout,"</TestRun>\n");
+    fprintf(stdout,"<Statistics>\n");
+    fprintf(stdout,"<Tests>%d</Tests>\n",result->runCount);
+    if (result->failureCount) {
+    fprintf(stdout,"<Failures>%d</Failures>\n",result->failureCount);
+    }
+    fprintf(stdout,"</Statistics>\n");
+    fprintf(stdout,"</TestRun>\n");
 }
 
 static const OutputterImplement XMLOutputterImplement = {
-	(OutputterPrintHeaderFunction)		XMLOutputter_printHeader,
-	(OutputterPrintStartTestFunction)	XMLOutputter_printStartTest,
-	(OutputterPrintEndTestFunction)		XMLOutputter_printEndTest,
-	(OutputterPrintSuccessfulFunction)	XMLOutputter_printSuccessful,
-	(OutputterPrintFailureFunction)		XMLOutputter_printFailure,
-	(OutputterPrintStatisticsFunction)	XMLOutputter_printStatistics,
+    (OutputterPrintHeaderFunction)      XMLOutputter_printHeader,
+    (OutputterPrintStartTestFunction)   XMLOutputter_printStartTest,
+    (OutputterPrintEndTestFunction)     XMLOutputter_printEndTest,
+    (OutputterPrintSuccessfulFunction)  XMLOutputter_printSuccessful,
+    (OutputterPrintFailureFunction)     XMLOutputter_printFailure,
+    (OutputterPrintStatisticsFunction)  XMLOutputter_printStatistics,
 };
 
 static const Outputter XMLOutputter = {
-	(OutputterImplementRef)&XMLOutputterImplement,
+    (OutputterImplementRef)&XMLOutputterImplement,
 };
 
 void XMLOutputter_setStyleSheet(char *style)
 {
-	stylesheet_ = style;
+    stylesheet_ = style;
 }
 
 OutputterRef XMLOutputter_outputter(void)
 {
-	return (OutputterRef)&XMLOutputter;
+    return (OutputterRef)&XMLOutputter;
 }

--- a/tests/unittests/embunit/textui/XMLOutputter.h
+++ b/tests/unittests/embunit/textui/XMLOutputter.h
@@ -32,8 +32,8 @@
  *
  * $Id: XMLOutputter.h,v 1.3 2003/09/06 13:28:27 arms22 Exp $
  */
-#ifndef	__XMLOUTPUTTER_H__
-#define	__XMLOUTPUTTER_H__
+#ifndef __XMLOUTPUTTER_H__
+#define __XMLOUTPUTTER_H__
 
 #include "Outputter.h"
 


### PR DESCRIPTION
This PR converts tabs to white spaces.
The statement I used for the conversion:
`find . -name "*.[ch]" -exec zsh -c 'expand -t 4 "$0" > /tmp/e && mv /tmp/e "$0"' {} \;`
Afterwards, I had a quick overview of the converted files to prevent odd indentation.
