### PR TITLE
Travis: auto rebase on master before running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,13 @@ install:
     - git config --global user.email "travis@example.com"
     - git config --global user.name "Travis CI"
 
+    - git remote add riot https://github.com/RIOT-OS/RIOT.git
+    - git fetch riot master
+    - git log -1 --pretty=format:%H riot/master
+
 script:
+    - git rebase riot/master || git rebase --abort
+
     - ./dist/tools/compile_test/compile_test.py
     - make -C ./tests/unittests test BOARD=native
     - make -C ./tests/unittests test BOARD=qemu-i386


### PR DESCRIPTION
It can happen that two PRs don't interfere with each other in the sense
that they hurt automatic rebasing, but still do not work together. The
prime example is PR1 changes the API of some function that PR2 uses. If
PR1 is merged, and PR2 is not rebased before merging, the error might
get unnoticed before the next build. Travis CI would have have told both
PR1 and PR2 are fine, but will complain (rather unnoticedly) that our
master does not compile.

This PR automatically rebases the PR on top of the current master,
before running the tests. If the automatic rebase fails, then this is
fine, because you will need to manually rebase again before merging,
anyway. The manual rebase, i.e. new push, will trigger Travis CI.

So, the main idea of this PR is that to can hit the "Restart Build"
button in Travis CI before hitting the merge button in Github.
