### PR TITLE
rpl: mute RPL

### DIFF
--- a/sys/net/routing/etx_beaconing.c
+++ b/sys/net/routing/etx_beaconing.c
@@ -143,7 +143,7 @@ void etx_init_beaconing(ipv6_addr_t *address)
 {
     own_address = address;
     //set code
-    puts("ETX BEACON INIT");
+    DEBUGF("ETX BEACON INIT");
     etx_send_buf[0] = ETX_PKT_OPTVAL;
 
     etx_beacon_pid = thread_create(etx_beacon_buf, ETX_BEACON_STACKSIZE,
@@ -159,7 +159,7 @@ void etx_init_beaconing(ipv6_addr_t *address)
                                   etx_clock, NULL, "etx_clock");
     //register at transceiver
     transceiver_register(TRANSCEIVER_CC1100, etx_radio_pid);
-    puts("...[DONE]");
+    DEBUG("...[DONE]\n");
 }
 
 static void *etx_beacon(void *arg)
@@ -357,8 +357,8 @@ void etx_handle_beacon(ipv6_addr_t *candidate_address)
         candidate = etx_add_candidate(candidate_address);
 
         if (candidate == NULL) {
-            puts("[ERROR] Candidate could not get added");
-            puts("Increase the constant ETX_MAX_CANDIDATE_NEIHGBORS");
+            DEBUGF("[ERROR] Candidate could not get added\n");
+            DEBUG("Increase the constant ETX_MAX_CANDIDATE_NEIHGBORS\n");
             return;
         }
     }
@@ -430,7 +430,7 @@ static void *etx_radio(void *arg)
             p->processing--;
         }
         else if (m.type == ENOBUFFER) {
-            puts("Transceiver buffer full");
+            DEBUGF("Transceiver buffer full\n");
         }
         else {
             //packet is not for me, whatever

--- a/sys/net/routing/rpl/of_mrhof.c
+++ b/sys/net/routing/rpl/of_mrhof.c
@@ -20,6 +20,9 @@
 
 #include "etx_beaconing.h"
 
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
 // Function Prototypes
 static uint16_t calc_rank(rpl_parent_t *, uint16_t);
 static rpl_parent_t *which_parent(rpl_parent_t *, rpl_parent_t *);
@@ -53,7 +56,7 @@ void reset(rpl_dodag_t *dodag)
 
 static uint16_t calc_path_cost(rpl_parent_t *parent)
 {
-    puts("calc_pathcost");
+    DEBUGF("calc_pathcost\n");
 
     /*
      * Calculates the path cost through the parent, for now, only for ETX
@@ -61,12 +64,12 @@ static uint16_t calc_path_cost(rpl_parent_t *parent)
     if (parent == NULL) {
         // Shouldn't ever happen since this function is supposed to be always
         // run with a parent. If it does happen, we can assume a root called it.
-        puts("[WARNING] calc_path_cost called without parent!");
+        DEBUGF("[WARNING] calc_path_cost called without parent!\n");
         return DEFAULT_MIN_HOP_RANK_INCREASE;
     }
 
     double etx_value = etx_get_metric(&(parent->addr));
-    printf("Metric for parent returned: %f", etx_value);
+    DEBUGF("Metric for parent returned: %f\n", etx_value);
 
     if (etx_value != 0) {
         /*
@@ -103,7 +106,7 @@ static uint16_t calc_path_cost(rpl_parent_t *parent)
 
 static uint16_t calc_rank(rpl_parent_t *parent, uint16_t base_rank)
 {
-    puts("calc_rank");
+    DEBUGF("calc_rank\n");
 
     /*
      * Return the rank for this node.
@@ -152,7 +155,7 @@ static uint16_t calc_rank(rpl_parent_t *parent, uint16_t base_rank)
 
 static rpl_parent_t *which_parent(rpl_parent_t *p1, rpl_parent_t *p2)
 {
-    puts("which_parent");
+    DEBUGF("which_parent\n");
     /*
      * Return the parent with the lowest path cost.
      * Before returning any of the two given parents, make sure that a switch is

--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -82,7 +82,7 @@ rpl_dodag_t *rpl_new_dodag(uint8_t instanceid, ipv6_addr_t *dodagid)
     inst = rpl_get_instance(instanceid);
 
     if (inst == NULL) {
-        printf("Error - No instance found for id %d. This should not happen\n",
+        DEBUGF("Error - No instance found for id %d. This should not happen\n",
                instanceid);
         return NULL;
     }
@@ -369,11 +369,11 @@ void rpl_join_dodag(rpl_dodag_t *dodag, ipv6_addr_t *parent, uint16_t parent_ran
 
 void rpl_global_repair(rpl_dodag_t *dodag, ipv6_addr_t *p_addr, uint16_t rank)
 {
-    puts("[INFO] Global repair started");
+    DEBUGF("[INFO] Global repair started\n");
     rpl_dodag_t *my_dodag = rpl_get_my_dodag();
 
     if (my_dodag == NULL) {
-        printf("[Error] - no global repair possible, if not part of a DODAG\n");
+        DEBUGF("[Error] - no global repair possible, if not part of a DODAG\n");
         return;
     }
 
@@ -383,7 +383,7 @@ void rpl_global_repair(rpl_dodag_t *dodag, ipv6_addr_t *p_addr, uint16_t rank)
     my_dodag->my_preferred_parent = rpl_new_parent(my_dodag, p_addr, rank);
 
     if (my_dodag->my_preferred_parent == NULL) {
-        printf("[Error] no more parent after global repair\n");
+        DEBUGF("[Error] no more parent after global repair\n");
         my_dodag->my_rank = INFINITE_RANK;
     }
     else {
@@ -395,17 +395,17 @@ void rpl_global_repair(rpl_dodag_t *dodag, ipv6_addr_t *p_addr, uint16_t rank)
         delay_dao();
     }
 
-    printf("Migrated to DODAG Version %d. My new Rank: %d\n", my_dodag->version,
+    DEBUGF("Migrated to DODAG Version %d. My new Rank: %d\n", my_dodag->version,
            my_dodag->my_rank);
 }
 
 void rpl_local_repair(void)
 {
-    puts("[INFO] Local Repair started");
+    DEBUGF("[INFO] Local Repair started\n");
     rpl_dodag_t *my_dodag = rpl_get_my_dodag();
 
     if (my_dodag == NULL) {
-        printf("[Error] - no local repair possible, if not part of a DODAG\n");
+        DEBUGF("[Error] - no local repair possible, if not part of a DODAG\n");
         return;
     }
 

--- a/sys/net/routing/rpl/trickle.c
+++ b/sys/net/routing/rpl/trickle.c
@@ -155,10 +155,10 @@ static void *trickle_interval_over(void *arg)
         DEBUG("TRICKLE new Interval %" PRIu32 "\n", I);
 
         if (I == 0) {
-            puts("[WARNING] Interval was 0");
+            DEBUGF("[WARNING] Interval was 0\n");
 
             if (Imax == 0) {
-                puts("[WARNING] Imax == 0");
+                DEBUGF("[WARNING] Imax == 0\n");
             }
 
             I = (Imin << Imax);
@@ -179,13 +179,13 @@ static void *trickle_interval_over(void *arg)
         vtimer_remove(&trickle_t_timer);
 
         if (vtimer_set_wakeup(&trickle_t_timer, t_time, timer_over_pid) != 0) {
-            puts("[ERROR] setting Wakeup");
+            DEBUGF("[ERROR] setting Wakeup\n");
         }
 
         vtimer_remove(&trickle_I_timer);
 
         if (vtimer_set_wakeup(&trickle_I_timer, I_time, interval_over_pid) != 0) {
-            puts("[ERROR] setting Wakeup");
+            DEBUGF("[ERROR] setting Wakeup\n");
         }
     }
 
@@ -263,7 +263,7 @@ static void *rt_timer_over(void *arg)
             /* Parent is NULL for root too */
             if (my_dodag->my_preferred_parent != NULL) {
                 if (my_dodag->my_preferred_parent->lifetime <= 1) {
-                    puts("parent lifetime timeout");
+                    DEBUGF("parent lifetime timeout\n");
                     rpl_parent_update(NULL);
                 }
                 else {


### PR DESCRIPTION
Removes all but one occurrence of printf and puts within routing (the
remaining puts is called from a debug function.

Possible solution for #641.

I'm not sure if muting all error messages is so smart. Maybe we shoud add a `WARN` and/or `ERR` macro for `DEVELHELP`?
