### PR TITLE
tests: let license checker check headers, too

### DIFF
--- a/dist/tools/licenses/check.sh
+++ b/dist/tools/licenses/check.sh
@@ -22,9 +22,9 @@ done
 
 # select files to check
 if [ -z "${BRANCH}" ]; then
-    FILES="$(git ls-tree -r --full-tree --name-only HEAD | grep -E '\.[sSc]$')"
+    FILES="$(git ls-tree -r --full-tree --name-only HEAD | grep -E '\.[sSch]$')"
 else
-    FILES="$(git diff --diff-filter=ACMR --name-only ${BRANCH} | grep -E '\.[sSc]$')"
+    FILES="$(git diff --diff-filter=ACMR --name-only ${BRANCH} | grep -E '\.[sSch]$')"
 fi
 
 # categorize files


### PR DESCRIPTION
```
./dist/tools/licenses/check.sh  | wc -l
287
```

Need to decide whether the headers should have licenses at all (at least for the ones we wrote ourselves).
