### PR TITLE
cpu: removing tabs from asm files (#1439)

### DIFF
--- a/cpu/arm_common/common.s
+++ b/cpu/arm_common/common.s
@@ -129,7 +129,7 @@ task_return:
 *
 *----------------------------------------------------------------------------*/
 arm_irq_handler:
-    sub 	lr, lr, #4
+    sub     lr, lr, #4
 
     /* save interrupted tasks PC onto stack */
     stmfd  sp!, {lr}
@@ -151,7 +151,7 @@ arm_irq_handler:
     add    lr,pc,#4
 .else
     /* mc1322x seems to lack a VIC, distinction of IRQ has to be done in SW */
-	ldr    r0, =isr           /* mc1322x */
+    ldr    r0, =isr           /* mc1322x */
 .endif
 
     mov     pc, r0

--- a/cpu/lpc2387/asmfunc.s
+++ b/cpu/lpc2387/asmfunc.s
@@ -13,91 +13,91 @@
 .global Copy_un2al
 .arm
 Copy_un2al:
-	STMFD	SP!, {R4-R8}
-	ANDS	IP, R1, #3
-	BEQ	lb_align
+    STMFD   SP!, {R4-R8}
+    ANDS    IP, R1, #3
+    BEQ lb_align
 
-	BIC	R1, #3
-	MOV	IP, IP, LSL #3
-	RSB	R8, IP, #32
-	LDMIA	R1!, {R7}
-lb_l1:	MOV	R3, R7
-	LDMIA	R1!, {R4-R7}
-	MOV	R3, R3, LSR IP
-	ORR	R3, R3, R4, LSL R8
-	MOV	R4, R4, LSR IP
-	ORR	R4, R4, R5, LSL R8
-	MOV	R5, R5, LSR IP
-	ORR	R5, R5, R6, LSL R8
-	MOV	R6, R6, LSR IP
-	ORR	R6, R6, R7, LSL R8
-	SUBS	R2, R2, #16
-	STMIA	R0!, {R3-R6}
-	BNE	lb_l1
-	LDMFD	SP!, {R4-R8}
-	BX	LR
+    BIC R1, #3
+    MOV IP, IP, LSL #3
+    RSB R8, IP, #32
+    LDMIA   R1!, {R7}
+lb_l1:  MOV R3, R7
+    LDMIA   R1!, {R4-R7}
+    MOV R3, R3, LSR IP
+    ORR R3, R3, R4, LSL R8
+    MOV R4, R4, LSR IP
+    ORR R4, R4, R5, LSL R8
+    MOV R5, R5, LSR IP
+    ORR R5, R5, R6, LSL R8
+    MOV R6, R6, LSR IP
+    ORR R6, R6, R7, LSL R8
+    SUBS    R2, R2, #16
+    STMIA   R0!, {R3-R6}
+    BNE lb_l1
+    LDMFD   SP!, {R4-R8}
+    BX  LR
 
 lb_align:
-	LDMIA	R1!, {R3-R6}
-	SUBS	R2, R2, #16
-	STMIA	R0!, {R3-R6}
-	BNE	lb_align
-	LDMFD	SP!, {R4-R8}
-	BX	LR
+    LDMIA   R1!, {R3-R6}
+    SUBS    R2, R2, #16
+    STMIA   R0!, {R3-R6}
+    BNE lb_align
+    LDMFD   SP!, {R4-R8}
+    BX  LR
 
 
 .global Copy_al2un
 .arm
 Copy_al2un:
-	STMFD	SP!, {R4-R8}
-	ANDS	IP, R0, #3
-	BEQ	sb_align
+    STMFD   SP!, {R4-R8}
+    ANDS    IP, R0, #3
+    BEQ sb_align
 
-	MOV	IP, IP, LSL #3
-	RSB	R8, IP, #32
+    MOV IP, IP, LSL #3
+    RSB R8, IP, #32
 
-	LDMIA	R1!, {R4-R7}
-sb_p1:	STRB	R4, [R0], #1
-	MOV	R4, R4, LSR #8
-	TST	R0, #3
-	BNE	sb_p1
-	ORR	R4, R4, R5, LSL IP
-	MOV	R5, R5, LSR R8
-	ORR	R5, R5, R6, LSL IP
-	MOV	R6, R6, LSR R8
-	ORR	R6, R6, R7, LSL IP
-	SUBS	R2, R2, #16
-	STMIA	R0!, {R4-R6}
+    LDMIA   R1!, {R4-R7}
+sb_p1:  STRB    R4, [R0], #1
+    MOV R4, R4, LSR #8
+    TST R0, #3
+    BNE sb_p1
+    ORR R4, R4, R5, LSL IP
+    MOV R5, R5, LSR R8
+    ORR R5, R5, R6, LSL IP
+    MOV R6, R6, LSR R8
+    ORR R6, R6, R7, LSL IP
+    SUBS    R2, R2, #16
+    STMIA   R0!, {R4-R6}
 
-sb_l1:	MOV	R3, R7
-	LDMIA	R1!, {R4-R7}
-	MOV	R3, R3, LSR R8
-	ORR	R3, R3, R4, LSL IP
-	MOV	R4, R4, LSR R8
-	ORR	R4, R4, R5, LSL IP
-	MOV	R5, R5, LSR R8
-	ORR	R5, R5, R6, LSL IP
-	MOV	R6, R6, LSR R8
-	ORR	R6, R6, R7, LSL IP
-	SUBS	R2, R2, #16
-	STMIA	R0!, {R3-R6}
-	BNE	sb_l1
+sb_l1:  MOV R3, R7
+    LDMIA   R1!, {R4-R7}
+    MOV R3, R3, LSR R8
+    ORR R3, R3, R4, LSL IP
+    MOV R4, R4, LSR R8
+    ORR R4, R4, R5, LSL IP
+    MOV R5, R5, LSR R8
+    ORR R5, R5, R6, LSL IP
+    MOV R6, R6, LSR R8
+    ORR R6, R6, R7, LSL IP
+    SUBS    R2, R2, #16
+    STMIA   R0!, {R3-R6}
+    BNE sb_l1
 
-	MOV	R7, R7, LSR R8
-sb_p2:	SUBS	IP, IP, #8
-	STRB	R7, [R0], #1
-	MOV	R7, R7, LSR #8
-	BNE	sb_p2
+    MOV R7, R7, LSR R8
+sb_p2:  SUBS    IP, IP, #8
+    STRB    R7, [R0], #1
+    MOV R7, R7, LSR #8
+    BNE sb_p2
 
-	LDMFD	SP!, {R4-R8}
-	BX	LR
+    LDMFD   SP!, {R4-R8}
+    BX  LR
 
 sb_align:
-	LDMIA	R1!, {R3-R6}
-	SUBS	R2, #16
-	STMIA	R0!, {R3-R6}
-	BNE	sb_align
-	LDMFD	SP!, {R4-R8}
-	BX	LR
+    LDMIA   R1!, {R3-R6}
+    SUBS    R2, #16
+    STMIA   R0!, {R3-R6}
+    BNE sb_align
+    LDMFD   SP!, {R4-R8}
+    BX  LR
 
 .end

--- a/cpu/lpc2387/startup.s
+++ b/cpu/lpc2387/startup.s
@@ -8,11 +8,11 @@
 
 /* ***************************************************************************************************************
 
-	startup.s						STARTUP  ASSEMBLY  CODE
-								-----------------------
+    startup.s                       STARTUP  ASSEMBLY  CODE
+                                    -----------------------
 
 
-	Module includes the interrupt vectors and start-up code.
+    Module includes the interrupt vectors and start-up code.
 
   *************************************************************************************************************** */
 
@@ -29,16 +29,16 @@
 .extern __start_svc_start
 
 /* Standard definitions of Mode bits and Interrupt (I & F) flags in PSRs (program status registers) */
-.set  MODE_USR, 0x10            		/* Normal User Mode 										*/
-.set  MODE_FIQ, 0x11            		/* FIQ Processing Fast Interrupts Mode 						*/
-.set  MODE_IRQ, 0x12            		/* IRQ Processing Standard Interrupts Mode 					*/
-.set  MODE_SVC, 0x13            		/* Supervisor Processing Software Interrupts Mode 			*/
-.set  MODE_ABT, 0x17            		/* Abort Processing memory Faults Mode 						*/
-.set  MODE_UND, 0x1B            		/* Undefined Processing Undefined Instructions Mode 		*/
-.set  MODE_SYS, 0x1F            		/* System Running Priviledged Operating System Tasks  Mode	*/
+.set  MODE_USR, 0x10                    /* Normal User Mode                                         */
+.set  MODE_FIQ, 0x11                    /* FIQ Processing Fast Interrupts Mode                      */
+.set  MODE_IRQ, 0x12                    /* IRQ Processing Standard Interrupts Mode                  */
+.set  MODE_SVC, 0x13                    /* Supervisor Processing Software Interrupts Mode           */
+.set  MODE_ABT, 0x17                    /* Abort Processing memory Faults Mode                      */
+.set  MODE_UND, 0x1B                    /* Undefined Processing Undefined Instructions Mode         */
+.set  MODE_SYS, 0x1F                    /* System Running Priviledged Operating System Tasks  Mode  */
 
-.set  I_BIT, 0x80               		/* when I bit is set, IRQ is disabled (program status registers) */
-.set  F_BIT, 0x40               		/* when F bit is set, FIQ is disabled (program status registers) */
+.set  I_BIT, 0x80                       /* when I bit is set, IRQ is disabled (program status registers) */
+.set  F_BIT, 0x40                       /* when F bit is set, FIQ is disabled (program status registers) */
 
 .text
 .arm
@@ -47,24 +47,24 @@
 It is 64 bytes and can be mapped (see documentation 1.4.2). */
 .section .vectors
 /* Exception Vectors */
-      			ldr     PC, Reset_Addr		/* Reset */
-                ldr     PC, Undef_Addr		/* Undefined Instruction */
-                ldr     PC, SWI_Addr		/* Software Interrupt */
-                ldr     PC, PAbt_Addr		/* Prefetch Abort */
-                ldr     PC, DAbt_Addr		/* Data Abort */
-                nop							/* Reserved Vector (holds Philips ISP checksum) */
+                ldr     PC, Reset_Addr      /* Reset */
+                ldr     PC, Undef_Addr      /* Undefined Instruction */
+                ldr     PC, SWI_Addr        /* Software Interrupt */
+                ldr     PC, PAbt_Addr       /* Prefetch Abort */
+                ldr     PC, DAbt_Addr       /* Data Abort */
+                nop                         /* Reserved Vector (holds Philips ISP checksum) */
                 /* see page 71 of "Insiders Guide to the Philips ARM7-Based Microcontrollers" by Trevor Martin  */
-/*                ldr     PC, [PC,#-0x0120]  	/* Interrupt Request Interrupt (load from VIC) */
-                ldr     PC, IRQ_Addr    	/* Interrupt Request Interrupt (load from VIC) */
-                ldr		r0, =__fiq_handler	/* Fast Interrupt Request Interrupt */
-                ldr		pc, [r0]			/* jump to handler in pointer at __fiq_handler */
+/*                ldr     PC, [PC,#-0x0120]     /* Interrupt Request Interrupt (load from VIC) */
+                ldr     PC, IRQ_Addr        /* Interrupt Request Interrupt (load from VIC) */
+                ldr     r0, =__fiq_handler  /* Fast Interrupt Request Interrupt */
+                ldr     pc, [r0]            /* jump to handler in pointer at __fiq_handler */
 
 /* Exception vector handlers branching table */
-Reset_Addr:     .word   Reset_Handler		/* defined in this module below  */
-Undef_Addr:     .word   UNDEF_Routine		/* defined in main.c  */
-SWI_Addr:       .word   ctx_switch			/* defined in main.c  */
-PAbt_Addr:      .word   PABT_Routine		/* defined in main.c  */
-DAbt_Addr:      .word   DABT_Routine		/* defined in main.c  */
+Reset_Addr:     .word   Reset_Handler       /* defined in this module below  */
+Undef_Addr:     .word   UNDEF_Routine       /* defined in main.c  */
+SWI_Addr:       .word   ctx_switch          /* defined in main.c  */
+PAbt_Addr:      .word   PABT_Routine        /* defined in main.c  */
+DAbt_Addr:      .word   DABT_Routine        /* defined in main.c  */
 IRQ_Addr:       .word   arm_irq_handler      /* defined in main.c  */
 
 /* Begin of boot code */
@@ -76,29 +76,29 @@ IRQ_Addr:       .word   arm_irq_handler      /* defined in main.c  */
 .func   _startup
 
 _startup:
-				ldr    pc, =Reset_Handler
+                ldr    pc, =Reset_Handler
 
 /*.func Reset_Handler */
 Reset_Handler:
 
 .section .init0
-				/* Setup a stack for each mode - note that this only sets up a usable stack
-				for User mode.   Also each mode is setup with interrupts initially disabled. */
-    			ldr   r0, = __stack_end
-    			msr   CPSR_c, #MODE_UND|I_BIT|F_BIT 	/* Undefined Instruction Mode  */
-    			ldr   sp, =__stack_und_start
-    			msr   CPSR_c, #MODE_ABT|I_BIT|F_BIT 	/* Abort Mode */
-    			ldr   sp, =__stack_abt_start
-    			msr   CPSR_c, #MODE_FIQ|I_BIT|F_BIT 	/* FIQ Mode */
-    			ldr   sp, =__stack_fiq_start
-    			msr   CPSR_c, #MODE_IRQ|I_BIT|F_BIT 	/* IRQ Mode */
-    			ldr   sp, =__stack_irq_start
-    			msr   CPSR_c, #MODE_SVC|I_BIT|F_BIT 	/* Supervisor Mode */
-    			ldr   sp, =__stack_svc_start
-    			msr   CPSR_c, #MODE_SYS|I_BIT|F_BIT 	/* User Mode */
-    			ldr   sp, =__stack_usr_start
+                /* Setup a stack for each mode - note that this only sets up a usable stack
+                for User mode.   Also each mode is setup with interrupts initially disabled. */
+                ldr   r0, = __stack_end
+                msr   CPSR_c, #MODE_UND|I_BIT|F_BIT     /* Undefined Instruction Mode  */
+                ldr   sp, =__stack_und_start
+                msr   CPSR_c, #MODE_ABT|I_BIT|F_BIT     /* Abort Mode */
+                ldr   sp, =__stack_abt_start
+                msr   CPSR_c, #MODE_FIQ|I_BIT|F_BIT     /* FIQ Mode */
+                ldr   sp, =__stack_fiq_start
+                msr   CPSR_c, #MODE_IRQ|I_BIT|F_BIT     /* IRQ Mode */
+                ldr   sp, =__stack_irq_start
+                msr   CPSR_c, #MODE_SVC|I_BIT|F_BIT     /* Supervisor Mode */
+                ldr   sp, =__stack_svc_start
+                msr   CPSR_c, #MODE_SYS|I_BIT|F_BIT     /* User Mode */
+                ldr   sp, =__stack_usr_start
 
-.section .init2							/* copy .data section (Copy from ROM to RAM) */
+.section .init2                         /* copy .data section (Copy from ROM to RAM) */
 .extern _etext
 .extern _data
 .extern _edata
@@ -106,30 +106,30 @@ Reset_Handler:
                 ldr     R1, =_etext
                 ldr     R2, =_data
                 ldr     R3, =_edata
-LoopRel:   		cmp     R2, R3
+LoopRel:        cmp     R2, R3
                 ldrlo   R0, [R1], #4
                 strlo   R0, [R2], #4
                 blo     LoopRel
 */
-.section .init4							/* Clear .bss section (Zero init)  */
+.section .init4                         /* Clear .bss section (Zero init)  */
 .extern __bss_start
 .extern __bss_end
 /*
                 mov     R0, #0
                 ldr     R1, =__bss_start
                 ldr     R2, =__bss_end
-LoopZI:			cmp     R1, R2
+LoopZI:         cmp     R1, R2
                 strlo   R0, [R1], #4
                 blo     LoopZI
 */
-				/* Enter the C code  */
+                /* Enter the C code  */
 .section .init9
                 bl  bootloader
                 b   kernel_init
 
                 /* Infinite Loop */
 .section .fini0
-__main_exit:    B       __main_exit
+__main_exit:    B   __main_exit
 
 
 .endfunc


### PR DESCRIPTION
`find . -name "*.[sS]" -exec grep -l $'\t' {} \;` and `ack --asm -l "\t"`
revealed three more files with tabs.
