### PR TITLE
boards: fixup for pyterm renaming

### DIFF
--- a/boards/pca10000/Makefile.include
+++ b/boards/pca10000/Makefile.include
@@ -22,7 +22,7 @@ export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
-export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm.py
+export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm
 export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh $(BINDIR) $(RIOTBASE) $(APPLICATION) $(BOARD)
 export HEXFILE = $(ELFFILE:.elf=.bin)
 
@@ -36,6 +36,7 @@ export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endi
 # $(LINKERSCRIPT) is specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary
+export TERMFLAGS = -p
 
 # use the nano-specs of the NewLib when available
 ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)

--- a/boards/pca10005/Makefile.include
+++ b/boards/pca10005/Makefile.include
@@ -22,7 +22,7 @@ export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
-export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm.py
+export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm
 export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh $(BINDIR) $(RIOTBASE) $(APPLICATION) $(BOARD)
 export HEXFILE = $(ELFFILE:.elf=.bin)
 
@@ -36,6 +36,7 @@ export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endi
 # $(LINKERSCRIPT) is specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary
+export TERMFLAGS = -p
 
 # use the nano-specs of the NewLib when available
 ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)

--- a/boards/stm32f3discovery/Makefile.include
+++ b/boards/stm32f3discovery/Makefile.include
@@ -22,7 +22,7 @@ export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
-export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm.py
+export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm
 export FLASHER = st-flash
 export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
 
@@ -37,6 +37,7 @@ export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary
 export FFLAGS = write bin/$(BOARD)/$(APPLICATION).hex 0x8000000
 export DEBUGGER_FLAGS = $(RIOTBOARD)/$(BOARD)/dist/gdb.conf $(BINDIR)/$(APPLICATION).elf
+export TERMFLAGS = -p
 
 # use newLib nano-specs if available
 ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)


### PR DESCRIPTION
`pyterm.py` was renamed to `pyterm` and needs a parameter now.
