### PR TITLE
doc: fix spelling in core/include

### DIFF
--- a/core/include/bitarithm.h
+++ b/core/include/bitarithm.h
@@ -22,7 +22,7 @@
 
 /**
  * @def SETBIT
- * @brief Sets a bitbitmask for a bitfield
+ * @brief Sets a bitmask for a bitfield
  *
  * @param[in] val   The bitfield
  * @param[in] bit   Specifies the bits to be set

--- a/core/include/io.h
+++ b/core/include/io.h
@@ -24,8 +24,8 @@
 /**
  * @brief   Firmware putstring implementation
  *
- * @param[in] data  charachters to be written
- * @param[in] count number of charachters to be written
+ * @param[in] data  characters to be written
+ * @param[in] count number of characters to be written
  */
 int fw_puts(char *data, int count);
 

--- a/core/include/kernel.h
+++ b/core/include/kernel.h
@@ -117,7 +117,7 @@
 extern volatile int lpm_prevent_sleep;
 
 /**
- * @brief Variable used to store system configurationi
+ * @brief Variable used to store system configuration
  *
  * @detail This contains e.g. the node ID, name, default channel and so on
  */

--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -96,7 +96,7 @@ int msg_send_to_self(msg_t *m);
 /**
  * @brief Send message from interrupt.
  *
- * Will be automatically chosen instead of ``msg_sennd()`` if called from an
+ * Will be automatically chosen instead of ``msg_send()`` if called from an
  * interrupt/ISR.
  *
  * @param[in] m             Pointer to preallocated ``msg_t`` structure, must
@@ -172,7 +172,7 @@ int msg_reply(msg_t *m, msg_t *reply);
  *
  * @param[in] array Pointer to preallocated array of ``msg_t`` structures, must
  *                  not be NULL.
- * @param[in] num   Number of ``msg_t`` structurs in array.
+ * @param[in] num   Number of ``msg_t`` structures in array.
  *                  **MUST BE POWER OF TWO!**
  *
  * @return 0, if successful

--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -44,13 +44,13 @@ typedef struct mutex_t {
 
 /**
  * @brief Static initializer for mutex_t.
- * @details This initializer is preferrable to mutex_init().
+ * @details This initializer is preferable to mutex_init().
  */
 #define MUTEX_INIT { 0, QUEUE_INIT }
 
 /**
  * @brief Initializes a mutex object.
- * @details For intialization of variables use MUTEX_INIT instead.
+ * @details For initialization of variables use MUTEX_INIT instead.
  *          Only use the function call for dynamically allocated mutexes.
  * @param[out] mutex    pre-allocated mutex structure, must not be NULL.
  */

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -72,7 +72,7 @@
  * @{
  *
  * @file        sched.h
- * @brief       Scheduler API definion
+ * @brief       Scheduler API definition
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */


### PR DESCRIPTION
Just a few things the spelling checker didn't like.
