### PR TITLE
cpu/cortex-mX_common: bugfix to arch_stack_init

### DIFF
--- a/cpu/cortex-m0_common/thread_arch.c
+++ b/cpu/cortex-m0_common/thread_arch.c
@@ -28,7 +28,6 @@
 #include "cpu.h"
 #include "kernel_internal.h"
 
-
 /**
  * @name noticeable marker marking the beginning of a stack segment
  *
@@ -67,7 +66,7 @@ char *thread_arch_stack_init(void *(*task_func)(void *),
                              int stack_size)
 {
     uint32_t *stk;
-    stk = (uint32_t *)((uint32_t *)stack_start + stack_size);
+    stk = (uint32_t *)((uint32_t)stack_start + stack_size);
 
     /* marker */
     stk--;

--- a/cpu/cortex-m3_common/thread_arch.c
+++ b/cpu/cortex-m3_common/thread_arch.c
@@ -57,7 +57,7 @@ static void context_restore(void) NORETURN;
 char *thread_arch_stack_init(void *(*task_func)(void *), void *arg, void *stack_start, int stack_size)
 {
     uint32_t *stk;
-    stk = (uint32_t *)((uint32_t *)stack_start + stack_size);
+    stk = (uint32_t *)((uint32_t)stack_start + stack_size);
 
     /* marker */
     stk--;

--- a/cpu/cortex-m4_common/thread_arch.c
+++ b/cpu/cortex-m4_common/thread_arch.c
@@ -63,7 +63,7 @@ char *thread_arch_stack_init(void *(*task_func)(void *),
                              int stack_size)
 {
     uint32_t *stk;
-    stk = (uint32_t *)((uint32_t*)stack_start + stack_size);
+    stk = (uint32_t *)((uint32_t)stack_start + stack_size);
 
     /* marker */
     stk--;


### PR DESCRIPTION
I think I found a quite serious bug introduced by me last week: The void pointer cast in the beginning of `thread_arch_stack_init()` computes (at least for `arm-none-eabi-gcc (GNU Tools for ARM Embedded Processors) 4.8.3 20131129 (release) [ARM/embedded-4_8-branch revision 205641]`) a wrong `stk` variable:

``` c
void *stack_start = 1000;  // decimal values for easier readablility
int stadk_size = 100; // in bytes, right?

uint32_t *stk = ((uint32_t *)stack_start + stack_size); // stk := 1400 -> wrong!
uint32_t *stk = ((uint32_t)stack_start + stack_size); // stk := 1100 -> correct
```

Does this make sense or do I have some wrinkled thoughts here?
