### PR TITLE
x86: disable `--gc-sections` for Travis' sake

### DIFF
--- a/boards/x86-multiboot-common/Makefile.include
+++ b/boards/x86-multiboot-common/Makefile.include
@@ -65,8 +65,3 @@ all:
 
 all-debug: export CFLAGS += -ggdb3 -O0
 all-debug: all
-
-ifeq (, $(filter all-debug, $(MAKECMDGOALS)))
-  CFLAGS += -Os -ffunction-sections -fdata-sections
-  LINKFLAGS += -Wl,--gc-sections
-endif


### PR DESCRIPTION
I could not reproduce the problem at home, but on Travis CI after
merging #1415 tests/unittest failed to execute for qemu-i386.

There is a crash early in the initialization, caused by a #PF. The
execution hangs afterwards (`cli; 0: hlt; jmp 0b`), and Travis kills
the execution after 10 minutes.
