### PR TITLE
Fixing unit test build process

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -44,7 +44,7 @@ else
 endif
 
 test: SHELL=bash
-test:
+test: all
 	@exec 5>&1 && \
 	LOG=$$("$(MAKE)" -s term | tee >(cat - >&5)) && \
 	grep 'OK ([1-9][0-9]* tests)' <<< $${LOG} > /dev/null


### PR DESCRIPTION
The unit tests failing currently on a clean master.

With the additional 'all' dependency it works fine.

To reproduce the error run:

``` bash
git checkout master
make -C ./tests/unittests clean test BOARD=native
```
