### PR TITLE
make: Add target to show if boards that are supported by apps

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -24,6 +24,9 @@ BOARDS ?= $(shell find $(RIOTBOARD)/* -maxdepth 0 -type d \! -name *-common -pri
 BOARDS := $(filter $(if $(BOARD_WHITELIST), $(BOARD_WHITELIST), %), $(BOARDS))
 BOARDS := $(filter-out $(BOARD_BLACKLIST), $(BOARDS))
 
+.PHONY: buildtest info-objsize info-buildsize info-buildsizes \
+        info-buildsizes-diff info-build info-boards-supported
+
 buildtest:
 	@if [ -z "$${JENKINS_URL}" ] && tput colors 2>&1 > /dev/null; then \
 		GREEN='\033[1;32m'; RED='\033[1;31m'; PURPLE='\033[1;35m'; RESET='\033[0m'; \

--- a/Makefile.include
+++ b/Makefile.include
@@ -87,8 +87,7 @@ BASELIBS += $(BINDIR)$(BOARD)_base.a
 BASELIBS += $(BINDIR)${APPLICATION}.a
 BASELIBS += $(USEPKG:%=${BINDIR}%.a)
 
-.PHONY: all clean flash doc term info-objsize info-buildsize info-buildsizes \
-        info-buildsizes-diff info-build
+.PHONY: all clean flash doc term
 
 ELFFILE ?= $(BINDIR)$(APPLICATION).elf
 HEXFILE ?= $(ELFFILE:.elf=.hex)


### PR DESCRIPTION
This way it will be easier to check ahead, if a board is not supported by an application
