### PR TITLE
make: Fix TERMFLAGS

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -193,7 +193,7 @@ flash: all
 	$(FLASHER) $(FFLAGS)
 
 term:
-	$(TERMPROG) $(TERMFLAGS) $(PORT)
+	$(TERMPROG) $(TERMFLAGS)
 
 doc:
 	make -BC $(RIOTBASE) doc

--- a/boards/arduino-due/Makefile.include
+++ b/boards/arduino-due/Makefile.include
@@ -36,7 +36,7 @@ export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endi
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS += -O binary
 export FFLAGS += -R -e -w -v -b bin/$(BOARD)/$(APPLICATION).hex
-export TERMFLAGS += -p
+export TERMFLAGS += -p "$(PORT)"
 
 # use the nano-specs of the NewLib when available
 ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)

--- a/boards/msb-430-common/Makefile.include
+++ b/boards/msb-430-common/Makefile.include
@@ -26,7 +26,7 @@ export DEBUGSERVER = $(FLASHER)
 export DEBUGSERVER_FLAGS = $(MSPDEBUGFLAGS) gdb
 export DEBUGGER = $(PREFIX)gdb
 export DEBUGGER_FLAGS = --tui --ex="target remote localhost:2000" --ex "monitor reset halt" --ex load -ex "monitor reset halt"  $(ELFFILE)
-export TERMFLAGS += -p
+export TERMFLAGS += -p "$(PORT)"
 
 export FFLAGS = $(MSPDEBUGFLAGS) "prog $(HEXFILE)"
 

--- a/boards/msba2-common/Makefile.include
+++ b/boards/msba2-common/Makefile.include
@@ -20,7 +20,7 @@ ifeq ($(strip $(PORT)),)
 	export PORT = /dev/ttyUSB0
 endif
 export FFLAGS = $(PORT) $(HEXFILE)
-export TERMFLAGS += -p
+export TERMFLAGS += -p "$(PORT)"
 include $(RIOTBOARD)/msba2-common/Makefile.dep
 
 export INCLUDES += -I$(RIOTBOARD)/msba2-common/include -I$(RIOTBOARD)/msba2-common/drivers/include

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -84,6 +84,10 @@ else
 	export PORT =
 endif
 
+ifeq (,$(filter $(PORT),$(TERMFLAGS)))
+    export TERMFLAGS += $(PORT)
+endif
+
 all: # do not override first target
 
 all-debug: all

--- a/boards/pca10000/Makefile.include
+++ b/boards/pca10000/Makefile.include
@@ -39,7 +39,7 @@ export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endi
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary
 export HEXFILE = $(ELFFILE:.elf=.bin)
-export TERMFLAGS = -p
+export TERMFLAGS += -p "$(PORT)"
 export FFLAGS = $(BINDIR) $(HEXFILE)
 export DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
 export RESET_FLAGS = $(BINDIR)

--- a/boards/pca10005/Makefile.include
+++ b/boards/pca10005/Makefile.include
@@ -36,7 +36,7 @@ export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endi
 # $(LINKERSCRIPT) is specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary
-export TERMFLAGS = -p
+export TERMFLAGS += -p "$(PORT)"
 
 # use the nano-specs of the NewLib when available
 ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)

--- a/boards/redbee-econotag/Makefile.include
+++ b/boards/redbee-econotag/Makefile.include
@@ -26,7 +26,7 @@ ifeq ($(strip $(PORT)),)
 endif
 export FFLAGS = -t $(PORT) -f $(HEXFILE) -c 'bbmc -l redbee-econotag reset'
 export OFLAGS = -O binary --gap-fill=0xff
-export TERMFLAGS += -p
+export TERMFLAGS += -p "$(PORT)"
 
 export INCLUDES += -I$(RIOTCPU)/$(CPU)/include/ -I$(RIOTBOARD)/$(BOARD)/include/
 export INCLUDES += -I$(RIOTCPU)/$(CPU)/maca/include

--- a/boards/stm32f0discovery/Makefile.include
+++ b/boards/stm32f0discovery/Makefile.include
@@ -39,7 +39,7 @@ export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary
 export FFLAGS = write bin/$(BOARD)/$(APPLICATION).hex 0x08000000
 export DEBUGGER_FLAGS = $(RIOTBOARD)/$(BOARD)/dist/gdb.conf bin/$(BOARD)/$(APPLICATION).elf
-export TERMFLAGS += -p
+export TERMFLAGS += -p "$(PORT)"
 
 # use the nano-specs of the NewLib when available
 ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)

--- a/boards/stm32f3discovery/Makefile.include
+++ b/boards/stm32f3discovery/Makefile.include
@@ -38,7 +38,7 @@ export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary
 export FFLAGS = write bin/$(BOARD)/$(APPLICATION).hex 0x8000000
 export DEBUGGER_FLAGS = $(RIOTBOARD)/$(BOARD)/dist/gdb.conf $(BINDIR)/$(APPLICATION).elf
-export TERMFLAGS = -p
+export TERMFLAGS += -p "$(PORT)"
 
 # use newLib nano-specs if available
 ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)

--- a/boards/stm32f4discovery/Makefile.include
+++ b/boards/stm32f4discovery/Makefile.include
@@ -38,7 +38,7 @@ export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary
 export FFLAGS = write bin/$(BOARD)/$(APPLICATION).hex 0x8000000
 export DEBUGGER_FLAGS = $(RIOTBOARD)/$(BOARD)/dist/gdb.conf $(BINDIR)/$(APPLICATION).elf
-export TERMFLAGS += -p
+export TERMFLAGS += -p "$(PORT)"
 
 # use newLib nano-specs if available
 ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)

--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -20,7 +20,7 @@ ifeq ($(strip $(PORT)),)
     export PORT = /dev/ttyUSB0
 endif
 export FFLAGS = --telosb -c $(PORT) -r -e -I -p $(HEXFILE)
-export TERMFLAGS += -p
+export TERMFLAGS += -p "$(PORT)"
 
 export INCLUDES += -I$(RIOTCPU)/msp430-common/include -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/drivers/cc2420/include -I$(RIOTBASE)/sys/net/include
 export OFLAGS = -O ihex

--- a/boards/udoo/Makefile.include
+++ b/boards/udoo/Makefile.include
@@ -36,7 +36,7 @@ export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endi
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS += -O binary
 export FFLAGS += -R -e -w -v -b bin/$(BOARD)/$(APPLICATION).hex
-export TERMFLAGS += -p
+export TERMFLAGS += -p "$(PORT)"
 
 # use the nano-specs of the NewLib when available
 ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)

--- a/boards/z1/Makefile.include
+++ b/boards/z1/Makefile.include
@@ -21,7 +21,7 @@ ifeq ($(strip $(PORT)),)
 endif
 export FFLAGS = --z1 -I -c $(PORT) -r -e -p $(HEXFILE)
 export OFLAGS = -O ihex
-export TERMFLAGS += -p
+export TERMFLAGS += -p "$(PORT)"
 
 export INCLUDES += -I $(RIOTCPU)/msp430-common/include -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/drivers/cc2420/include -I$(RIOTBASE)/sys/net/include
 


### PR DESCRIPTION
Sometimes boards/*/Makefile.include (e. g. in case of the msba2) gets included
twice somehow, leading the TERMFLAG to be set twice and faulty. This
fixes that.
