### PR TITLE
sys/net: changed first parameter of `destiny_socket_close()` to `kernel_pid_t`

### DIFF
--- a/sys/net/include/destiny/socket.h
+++ b/sys/net/include/destiny/socket.h
@@ -281,7 +281,7 @@ int32_t destiny_socket_sendto(int s, const void *buf, uint32_t len, int flags,
  *
  * @return 0 on success, -1 otherwise.
  */
-int destiny_socket_close(int s);
+int destiny_socket_close(kernel_pid_t s);
 
 /**
  * Assigns an IPv6 address *addr* to the socket *s*. Roughly identical to

--- a/sys/net/transport_layer/destiny/socket.c
+++ b/sys/net/transport_layer/destiny/socket.c
@@ -1036,7 +1036,7 @@ int32_t destiny_socket_sendto(int s, const void *buf, uint32_t len, int flags,
     }
 }
 
-int destiny_socket_close(int s)
+int destiny_socket_close(kernel_pid_t s)
 {
     socket_internal_t *current_socket = get_socket(s);
 


### PR DESCRIPTION
changed the `ID of the socket to close` to `kernel_pid_t` for `destiny_socket_close()`. 
This resolves warnings on conflicting function pointers passed to `fd_new()`
