### PR TITLE
sys/posix: changed parameters for `fd` from `kernel_pid_t` to `int`

### DIFF
--- a/sys/include/fd.h
+++ b/sys/include/fd.h
@@ -33,7 +33,7 @@ typedef struct {
     int __active;
 
     /** the internal filedescriptor */
-    kernel_pid_t fd;
+    int fd;
 
     /**
      * Read *n* into *buf* from *fd*.  Return the
@@ -45,7 +45,7 @@ typedef struct {
     ssize_t (*write)(int fd, const void *buf, size_t n);
 
     /** Close the file descriptor *fd*. */
-    int (*close)(kernel_pid_t fd);
+    int (*close)(int fd);
 } fd_t;
 
 /**
@@ -67,7 +67,7 @@ int fd_init(void);
  */
 int fd_new(int internal_fd, ssize_t (*internal_read)(int, void *, size_t),
            ssize_t (*internal_write)(int, const void *, size_t),
-           int (*internal_close)(kernel_pid_t));
+           int (*internal_close)(int));
 
 /**
  * @brief   Gets the file descriptor table entry associated with file

--- a/sys/include/posix_io.h
+++ b/sys/include/posix_io.h
@@ -32,10 +32,10 @@ struct posix_iop_t {
     char *buffer;
 };
 
-int posix_open(kernel_pid_t pid, int flags);
-int posix_close(kernel_pid_t pid);
-int posix_read(kernel_pid_t pid, char *buffer, int bufsize);
-int posix_write(kernel_pid_t pid, char *buffer, int bufsize);
+int posix_open(int pid, int flags);
+int posix_close(int pid);
+int posix_read(int pid, char *buffer, int bufsize);
+int posix_write(int pid, char *buffer, int bufsize);
 
 /** @} */
 #endif /* __READ_H */

--- a/sys/posix/fd.c
+++ b/sys/posix/fd.c
@@ -41,7 +41,7 @@ int fd_init(void)
     posix_open(uart0_handler_pid, 0);
     fd_t fd = {
         .__active = 1,
-        .fd = uart0_handler_pid,
+        .fd = (int)uart0_handler_pid,
         .read = (ssize_t ( *)(int, void *, size_t))posix_read,
         .write = (ssize_t ( *)(int, const void *, size_t))posix_write,
         .close = posix_close
@@ -67,7 +67,7 @@ static int fd_get_next_free(void)
 
 int fd_new(int internal_fd, ssize_t (*internal_read)(int, void *, size_t),
            ssize_t (*internal_write)(int, const void *, size_t),
-           int (*internal_close)(kernel_pid_t))
+           int (*internal_close)(int))
 {
     int fd = fd_get_next_free();
 

--- a/sys/posix/posix_io.c
+++ b/sys/posix/posix_io.c
@@ -45,22 +45,22 @@ static int _posix_fileop_data(kernel_pid_t pid, int op, char *buffer, int nbytes
     return r.nbytes;
 }
 
-int posix_open(kernel_pid_t pid, int flags)
+int posix_open(int pid, int flags)
 {
-    return _posix_fileop(pid, OPEN, flags);
+    return _posix_fileop((kernel_pid_t) pid, OPEN, flags);
 }
 
-int posix_close(kernel_pid_t pid)
+int posix_close(int pid)
 {
-    return _posix_fileop(pid, CLOSE, 0);
+    return _posix_fileop((kernel_pid_t) pid, CLOSE, 0);
 }
 
-int posix_read(kernel_pid_t pid, char *buffer, int bufsize)
+int posix_read(int pid, char *buffer, int bufsize)
 {
-    return _posix_fileop_data(pid, READ, buffer, bufsize);
+    return _posix_fileop_data((kernel_pid_t) pid, READ, buffer, bufsize);
 }
 
-int posix_write(kernel_pid_t pid, char *buffer, int bufsize)
+int posix_write(int pid, char *buffer, int bufsize)
 {
-    return _posix_fileop_data(pid, WRITE, buffer, bufsize);
+    return _posix_fileop_data((kernel_pid_t) pid, WRITE, buffer, bufsize);
 }


### PR DESCRIPTION
Using `kernel_pid_t` for the `fd` makes the opartions `posix_[open|close|read|write]` incomatible with non-RIOT implementations, e.g. using [`posix_close(fd)`](http://pubs.opengroup.org/onlinepubs/009695399/functions/close.html).
Following the POSIX standard, the `fd` must be an `int` to be portable and non specific to a system.
