### PR TITLE
drivers/at86rf231: add transceiver/pid includes

### DIFF
--- a/drivers/at86rf231/at86rf231.c
+++ b/drivers/at86rf231/at86rf231.c
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#include "kernel_types.h"
+#include "transceiver.h"
+
 #include "at86rf231.h"
 #include "at86rf231_arch.h"
 #include "at86rf231_spi.h"

--- a/drivers/include/at86rf231.h
+++ b/drivers/include/at86rf231.h
@@ -4,6 +4,8 @@
 #include <stdio.h>
 #include <stdint.h>
 
+#include "kernel_types.h"
+
 #include "board.h"
 #include "radio/types.h"
 
@@ -28,8 +30,6 @@ typedef struct __attribute__((packed))
     /* @} */
 }
 at86rf231_packet_t;
-
-extern kernel_pid_t transceiver_pid;
 
 void at86rf231_init(kernel_pid_t tpid);
 //void at86rf231_reset(void);


### PR DESCRIPTION
- fixes compilation error
- (followup/fixup) refactor `transceiver_pid`
