### PR TITLE
native: add stack smashing protection

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -24,8 +24,11 @@ export VALGRIND ?= valgrind
 export CGANNOTATE ?= cg_annotate
 export GPROF ?= gprof
 
-# flags:
+# basic cflags:
 export CFLAGS += -Wall -Wextra -pedantic -m32
+ifneq (,$(filter -DDEVELHELP,$(CFLAGS)))
+export CFLAGS += -fstack-protector-all
+endif
 ifeq ($(shell uname -s),FreeBSD)
 ifeq ($(shell uname -m),amd64)
 export CFLAGS += -DCOMPAT_32BIT -L/usr/lib32 -B/usr/lib32


### PR DESCRIPTION
Compare http://multimedia.cx/eggs/heroic-defender-of-the-stack/ for a discussion of the problem and the fix.

TLDR:
Valgrind does not find certain kinds of errors (array out of bounds write into otherwise valid memory) that this compiler flag adds code to check for.
