### PR TITLE
make: cleanup Makefile.base

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -53,16 +53,16 @@ CXXFLAGS = $(filter-out $(CXXUWFLAGS), $(CFLAGS)) $(CXXEXFLAGS)
 
 # compile and generate dependency info
 
-$(BINDIR)$(MODULE)/%.o: %.c $(BINDIR)$(MODULE)/
+$(OBJC): $(BINDIR)$(MODULE)/%.o: %.c $(BINDIR)$(MODULE)/
 	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
-$(BINDIR)$(MODULE)/%.o: %.cpp $(BINDIR)$(MODULE)/
+$(OBJCXX): $(BINDIR)$(MODULE)/%.o: %.cpp $(BINDIR)$(MODULE)/
 	$(AD)$(CXX) $(CXXFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
-$(BINDIR)$(MODULE)/%.o: %.s $(BINDIR)$(MODULE)/
+$(ASMOBJ): $(BINDIR)$(MODULE)/%.o: %.s $(BINDIR)$(MODULE)/
 	$(AD)$(AS) $(ASFLAGS) -o $@ $(abspath $<)
 
-$(BINDIR)$(MODULE)/%.o: %.S $(BINDIR)$(MODULE)/
+$(ASSMOBJ): $(BINDIR)$(MODULE)/%.o: %.S $(BINDIR)$(MODULE)/
 	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
 # pull in dependency info for *existing* .o files


### PR DESCRIPTION
- `mkdir -p` was called for every object file.
- `-o $(BINDIR)$(MODULE)/$*.o $(abspath $*.c)` is harder on the eyes than `-o $@ $(abspath $<)`.
- Generate .a file index because we are supposed to.
- The use of `=` instead of `:=` meant that `$(wildcard *.c)` was executed multiple times.

This PR has a minor speedup (best of 3, `time make buildtest` for `examples/default`):

After:
real    0m11.107s
user    0m50.600s
sys     0m4.940s

Before:
real    0m11.896s
user    0m51.096s
sys     0m5.096s
