### PR TITLE
all over the place: use sched_active_pid

### DIFF
--- a/boards/avsextrem/drivers/avsextrem-smb380.c
+++ b/boards/avsextrem/drivers/avsextrem-smb380.c
@@ -173,7 +173,7 @@ uint8_t SMB380_init_simple(uint16_t samplerate, uint8_t bandwidth, uint8_t
 {
     SSP0Init();
     interruptTicksSMB380 = 0;
-    simple_pid = sched_active_thread->pid;
+    simple_pid = sched_active_pid;
     gpioint_set(0, BIT1, GPIOINT_RISING_EDGE, &SMB380_simple_interrupthandler);
     SMB380_softReset();
     hwtimer_wait(HWTIMER_TICKS(100000));
@@ -305,7 +305,7 @@ uint8_t getRingReadPointerforCurrentThread(void)
 {
     uint8_t pointerNo = 0;
 
-    while ((PointerList[pointerNo] != sched_active_thread->pid) &&
+    while ((PointerList[pointerNo] != sched_active_pid) &&
            (pointerNo < SMB380_RING_BUFF_MAX_THREADS)) {
         pointerNo++;
     }
@@ -327,7 +327,7 @@ uint8_t initRingReadPointerforCurrentThread(void)
         return 0;
     }
     else {
-        PointerList[pointerNo] = sched_active_thread->pid;
+        PointerList[pointerNo] = sched_active_pid;
         readPointerPos[pointerNo] = settings.writePointerPos;
         return 1;
     }

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -138,7 +138,10 @@ int thread_wakeup(kernel_pid_t pid);
  *
  * @return          obviously you are not a golfer.
  */
-kernel_pid_t thread_getpid(void);
+static inline kernel_pid_t thread_getpid(void)
+{
+    return sched_active_pid;
+}
 
 #ifdef DEVELHELP
 /**

--- a/core/sched.c
+++ b/core/sched.c
@@ -173,7 +173,7 @@ NORETURN void sched_task_exit(void)
     DEBUG("sched_task_exit(): ending task %s...\n", sched_active_thread->name);
 
     dINT();
-    sched_threads[sched_active_thread->pid] = NULL;
+    sched_threads[sched_active_pid] = NULL;
     sched_num_threads--;
 
     sched_set_status((tcb_t *)sched_active_thread, STATUS_STOPPED);

--- a/core/thread.c
+++ b/core/thread.c
@@ -32,11 +32,6 @@
 #include "hwtimer.h"
 #include "sched.h"
 
-inline kernel_pid_t thread_getpid(void)
-{
-    return sched_active_thread->pid;
-}
-
 volatile tcb_t *thread_get(kernel_pid_t pid)
 {
     if ((pid != KERNEL_PID_UNDEF) && (0 <= pid) && (pid < MAXTHREADS)) {

--- a/cpu/arm_common/syscalls.c
+++ b/cpu/arm_common/syscalls.c
@@ -262,7 +262,7 @@ void _exit(int n)
 /*---------------------------------------------------------------------------*/
 pid_t _getpid(void)
 {
-    return (pid_t) sched_active_thread->pid;
+    return (pid_t) sched_active_pid;
 }
 /*---------------------------------------------------------------------------*/
 int _kill_r(struct _reent *r, int pid, int sig)

--- a/cpu/lpc1768/syscalls.c
+++ b/cpu/lpc1768/syscalls.c
@@ -221,7 +221,7 @@ void _exit(int n)
 /*---------------------------------------------------------------------------*/
 pid_t _getpid(void)
 {
-    return sched_active_thread->pid;
+    return sched_active_pid;
 }
 /*---------------------------------------------------------------------------*/
 int _kill_r(struct _reent *r, int pid, int sig)

--- a/cpu/nrf51822/syscalls.c
+++ b/cpu/nrf51822/syscalls.c
@@ -100,7 +100,7 @@ caddr_t _sbrk_r(struct _reent *r, size_t incr)
  */
 int _getpid(void)
 {
-    return sched_active_thread->pid;
+    return sched_active_pid;
 }
 
 /**

--- a/cpu/sam3x8e/syscalls.c
+++ b/cpu/sam3x8e/syscalls.c
@@ -100,7 +100,7 @@ caddr_t _sbrk_r(struct _reent *r, size_t incr)
  */
 pid_t _getpid(void)
 {
-    return (pid_t) sched_active_thread->pid;
+    return (pid_t) sched_active_pid;
 }
 
 /**

--- a/cpu/stm32f0/syscalls.c
+++ b/cpu/stm32f0/syscalls.c
@@ -100,7 +100,7 @@ caddr_t _sbrk_r(struct _reent *r, size_t incr)
  */
 int _getpid(void)
 {
-    return sched_active_thread->pid;
+    return sched_active_pid;
 }
 
 /**

--- a/cpu/stm32f3/syscalls.c
+++ b/cpu/stm32f3/syscalls.c
@@ -122,7 +122,7 @@ caddr_t _sbrk_r(struct _reent *r, size_t incr)
  */
 int _getpid(void)
 {
-    return sched_active_thread->pid;
+    return sched_active_pid;
 }
 
 /**

--- a/cpu/stm32f4/syscalls.c
+++ b/cpu/stm32f4/syscalls.c
@@ -99,7 +99,7 @@ caddr_t _sbrk_r(struct _reent *r, size_t incr)
  */
 int _getpid(void)
 {
-    return sched_active_thread->pid;
+    return sched_active_pid;
 }
 
 /**

--- a/drivers/cc110x/cc1100_phy.c
+++ b/drivers/cc110x/cc1100_phy.c
@@ -195,9 +195,9 @@ void cc1100_phy_init(void)
 
 void cc1100_phy_mutex_lock(void)
 {
-    if (sched_active_thread->pid != cc1100_mutex_pid) {
+    if (sched_active_pid != cc1100_mutex_pid) {
         mutex_lock(&cc1100_mutex);
-        cc1100_mutex_pid = sched_active_thread->pid;
+        cc1100_mutex_pid = sched_active_pid;
     }
 }
 

--- a/sys/posix/pthread/pthread_barrier.c
+++ b/sys/posix/pthread/pthread_barrier.c
@@ -56,7 +56,7 @@ int pthread_barrier_wait(pthread_barrier_t *barrier)
 
     mutex_lock(&barrier->mutex);
     DEBUG("%s: hit a synchronization barrier. pid=%" PRIkernel_pid"\n",
-          sched_active_thread->name, sched_active_thread->pid);
+          sched_active_thread->name, sched_active_pid);
 
     int switch_prio = -1;
 
@@ -64,7 +64,7 @@ int pthread_barrier_wait(pthread_barrier_t *barrier)
         /* need to wait for further threads */
 
         DEBUG("%s: waiting for %u threads. pid=%" PRIkernel_pid "\n",
-              sched_active_thread->name, barrier->count, sched_active_thread->pid);
+              sched_active_thread->name, barrier->count, sched_active_pid);
 
         pthread_barrier_waiting_node_t node;
         node.pid = sched_active_pid;
@@ -90,7 +90,7 @@ int pthread_barrier_wait(pthread_barrier_t *barrier)
         /* all threads have arrived, wake everybody up */
 
         DEBUG("%s: waking every other thread up. pid=%" PRIkernel_pid "\n",
-              sched_active_thread->name, sched_active_thread->pid);
+              sched_active_thread->name, sched_active_pid);
 
         int count = 1; /* Count number of woken up threads.
                         * The first thread is the current thread. */

--- a/sys/posix/pthread/pthread_cond.c
+++ b/sys/posix/pthread/pthread_cond.c
@@ -98,7 +98,7 @@ int pthread_cond_wait(struct pthread_cond_t *cond, struct mutex_t *mutex)
 {
     priority_queue_node_t n;
     n.priority = sched_active_thread->priority;
-    n.data = sched_active_thread->pid;
+    n.data = sched_active_pid;
     n.next = NULL;
 
     /* the signaling thread may not hold the mutex, the queue is not thread safe */
@@ -130,7 +130,7 @@ int pthread_cond_timedwait(struct pthread_cond_t *cond, struct mutex_t *mutex, c
     reltime = timex_sub(then, now);
 
     vtimer_t timer;
-    vtimer_set_wakeup(&timer, reltime, sched_active_thread->pid);
+    vtimer_set_wakeup(&timer, reltime, sched_active_pid);
     int result = pthread_cond_wait(cond, mutex);
     vtimer_remove(&timer);
 

--- a/sys/posix/pthread/pthread_rwlock.c
+++ b/sys/posix/pthread/pthread_rwlock.c
@@ -200,7 +200,7 @@ static int pthread_rwlock_timedlock(pthread_rwlock_t *rwlock,
         timex_t reltime = timex_sub(then, now);
 
         vtimer_t timer;
-        vtimer_set_wakeup(&timer, reltime, sched_active_thread->pid);
+        vtimer_set_wakeup(&timer, reltime, sched_active_pid);
         int result = pthread_rwlock_lock(rwlock, is_blocked, is_writer, incr_when_held, true);
         if (result != ETIMEDOUT) {
             vtimer_remove(&timer);


### PR DESCRIPTION
In many places we needlessly use `sched_active_thread->pid` whilst we
already have `sched_active_pid` with the same value, and one less
indirection.
