### PR TITLE
pyterm: fix exit behavior if twisted is not available

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -248,8 +248,12 @@ class SerCmd(cmd.Cmd):
         # save history file
         readline.write_history_file()
         # shut down twisted if running
-        if reactor.running:
-            reactor.callFromThread(reactor.stop)
+        try:
+            if reactor.running:
+                reactor.callFromThread(reactor.stop)
+        except NameError:
+            pass
+
         if self.tcp_serial:
             self.ser.close()
         return True


### PR DESCRIPTION
Right now the following error will occur on exiting pyterm when twisted is not available (and reactor therefore cannot be imported):

```
2014-08-16 00:46:45,378 - INFO # Exiting Pyterm
Traceback (most recent call last):
  File "/home/n8fear/src/RIOT/dist/tools/pyterm/pyterm", line 669, in <module>
    myshell.cmdloop("Welcome to pyterm!\nType '/exit' to exit.")
  File "/usr/lib64/python3.3/cmd.py", line 138, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib64/python3.3/cmd.py", line 217, in onecmd
    return func(arg)
  File "/home/n8fear/src/RIOT/dist/tools/pyterm/pyterm", line 251, in do_PYTERM_exit
    if reactor.running:
NameError: global name 'reactor' is not defined
make: *** [term] Error 1
```

While the import is guarded in a try...except block, the call to reactor on exit isn't. This pull request fixes that.
There are other instances of calls to reactor in the code that I didn't manage to hit so far. It may be needed to add similar fixes to these instances as well.
