### PR TITLE
core: SCHED_PRIO_LEVELS==16 for every board

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -91,9 +91,7 @@
  * @def SCHED_PRIO_LEVELS
  * @brief The number of thread priority levels
  */
-#if ARCH_32_BIT
-#define SCHED_PRIO_LEVELS 32
-#else
+#ifndef SCHED_PRIO_LEVELS
 #define SCHED_PRIO_LEVELS 16
 #endif
 


### PR DESCRIPTION
Closes #1399.

> Using a different value for SCHED_PRIO_LEVELS for 16 and 32 bit
> platforms hurts portability, one thing that we heavily advertise about
> RIOT. if you want to write a portable application, then you have to
> assume the lower value.

This PR defaults `SCHED_PRIO_LEVELS` to 16 for every board.
