### PR TITLE
tests: limit concurrency level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: c
 
+env:
+    - NPROC_MAX=8
+
 before_install:
     - sudo apt-get install emdebian-archive-keyring
     - echo 'deb http://www.emdebian.org/debian wheezy main' | sudo tee /etc/apt/sources.list.d/emdebian.list > /dev/null
@@ -27,6 +30,7 @@ install:
     - git log -1 --pretty=format:%H riot/master
 
 script:
+    - make -s -C ./examples/default info-concurrency
     - git rebase riot/master || git rebase --abort
 
     - ./dist/tools/compile_test/compile_test.py

--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -1,4 +1,4 @@
-ifneq (, $(filter buildtest, $(MAKECMDGOALS)))
+ifneq (, $(filter buildtest info-concurrency, $(MAKECMDGOALS)))
   ifeq (, $(strip $(NPROC)))
     # Linux (utility program)
     NPROC := $(shell nproc 2>/dev/null)
@@ -17,6 +17,13 @@ ifneq (, $(filter buildtest, $(MAKECMDGOALS)))
     endif
 
     NPROC := $(shell echo $$(($(NPROC) + 1)))
+
+    ifneq (, $(NPROC_MAX))
+      NPROC := $(shell if [ ${NPROC} -gt $(NPROC_MAX) ]; then echo $(NPROC_MAX); else echo ${NPROC}; fi)
+    endif
+    ifneq (, $(NPROC_MIN))
+      NPROC := $(shell if [ ${NPROC} -lt $(NPROC_MIN) ]; then echo $(NPROC_MIN); else echo ${NPROC}; fi)
+    endif
   endif
 endif
 
@@ -190,3 +197,6 @@ info-build:
 
 info-boards-supported:
 	@echo "$(BOARDS)"
+
+info-concurrency:
+	@echo "$(NPROC)"


### PR DESCRIPTION
Some Travis CI machines have 32 CPUs. This sets our concurrency level to 33.
Travis CI kills our buildtest for obvious reasons.

This PR limits the concurrency level to 8 on Travis CI.
