### PR TITLE
unittests: do not use auto_init

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -24,6 +24,8 @@ else
     UNIT_TESTS := $(filter tests-%, $(MAKECMDGOALS))
 endif
 
+DISABLE_MODULE += auto_init
+
 # Pull in `Makefile.include`s from the test suites:
 -include $(UNIT_TESTS:%=$(RIOTBASE)/tests/unittests/%/Makefile.include)
 


### PR DESCRIPTION
Unittests should not use auto_init. In most use-cases it would be called multiple times in the test's setup-function anyways.
