### PR TITLE
transceiver: fix check for existence

### DIFF
--- a/sys/transceiver/transceiver.c
+++ b/sys/transceiver/transceiver.c
@@ -154,7 +154,7 @@ void transceiver_init(transceiver_type_t t)
 {
     uint8_t i;
 
-    if (transceiver_pid >= 0) {
+    if (transceiver_pid != KERNEL_PID_UNDEF) {
         /* do not re-initialize an already running transceiver */
         return;
     }


### PR DESCRIPTION
The transceiver check if it is already running when initializing.
However, this check was done by comparing its pid for >= 0, which is not
sensible anymore since valid PIDs only start at 1.
