### PR TITLE
travis: force specific compiler branch to install the c++ headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ before_install:
 install:
     - sudo apt-get install build-essential
     - sudo apt-get install gcc-multilib
-    - sudo apt-get install gcc-arm-none-eabi
+#TODO: remove the `=4-*` if the stock gcc-arm-none-eabi ships the missing c++ headers (cf. #1656)
+    - sudo apt-get install gcc-arm-none-eabi=4-*
     - sudo apt-get install gcc-msp430
     - sudo apt-get install pcregrep libpcre3
     - sudo apt-get install qemu-system-x86 python3


### PR DESCRIPTION
The stock `gcc-arm-none-eabi` installed by travis does not ship c++ headers, which
is a known [bug](https://bugs.launchpad.net/gcc-arm-embedded/+bug/1309060).
This PR is ment as a workaround until the stock `gcc-arm-none-eabi` installs the c++ headers.
