### PR TITLE
Fix thread_yield() on MSP430 platforms

### DIFF
--- a/cpu/msp430-common/cpu.c
+++ b/cpu/msp430-common/cpu.c
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2013, Freie Universitaet Berlin (FUB). All rights reserved.
-
+ * Copyright (C) 2014, Freie Universitaet Berlin (FUB) & INRIA.
+ * All rights reserved.
+ *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
@@ -17,13 +18,17 @@ volatile int __inISR = 0;
 
 char __isr_stack[MSP430_ISR_STACK_SIZE];
 
-/* we must prevent the compiler to generate a prologue or an epilogue
-   for thread_yield(), since we rely on RETI instruction at the end
-   of its execution, in inlined __restore_context() sub-function */
+/*
+ * we must prevent the compiler to generate a prologue or an epilogue
+ * for thread_yield(), since we rely on the RETI instruction at the end
+ * of its execution, in the inlined __restore_context() sub-function
+ */
 __attribute__((naked)) void thread_yield(void)
 {
-    /* disable IRQ, remembering if they are
-       to be reactivated after context switch */
+    /*
+     * disable IRQ, remembering if they are
+     * to be reactivated after context switch
+     */
     unsigned int irqen = disableIRQ();
 
     __save_context();

--- a/cpu/msp430-common/include/cpu.h
+++ b/cpu/msp430-common/include/cpu.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2013, Freie Universitaet Berlin (FUB). All rights reserved.
+ * Copyright (C) 2014, Freie Universitaet Berlin (FUB) & INRIA.
+ * All rights reserved.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -103,10 +104,12 @@ inline void __restore_context(unsigned int irqen)
 {
     __restore_context_isr();
 
-    /* we want to enable if appropriate IRQs *just after*
-       quitting the interrupt handler; to that end,
-       we change the GIE bit in the value to be restored
-       in R2 (a.k.a. SR) by the next RETI instruction */
+    /*
+     * we want to enable appropriate IRQs *just after*
+     * quitting the interrupt handler; to that end,
+     * we change the GIE bit in the value to be restored
+     * in R2 (a.k.a. SR) by the next RETI instruction
+     */
     if (irqen) {
         __asm__("bis.w #8, 0(r1)");
     } else {


### PR DESCRIPTION
Avoid race conditions that can cause crash on MSP430 platforms, when interruptions prevent thread context switching from being correctlty done.

It fixes the biggest cause of failure for the hwtimer_wait test on MSP430 (see issue #426), the other cause being fixed by #1619.
