### PR TITLE
unittests: Simplify module-wise rebuild

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -34,7 +34,14 @@ BASELIBS += $(UNIT_TESTS:%=$(BINDIR)%.a)
 
 include $(RIOTBASE)/Makefile.include
 
-$(UNIT_TESTS): all
+.PHONY: FORCE $(UNIT_TESTS)
+
+FORCE:
+	touch $(CURDIR)/main.c
+
+all: FORCE
+
+$(UNIT_TESTS): FORCE all
 
 charCOMMA := ,
 


### PR DESCRIPTION
With this no `make clean` is necessary in-between module-wise rebuilds.
