### PR TITLE
tests: print expected duration in hwtimer_wait

### DIFF
--- a/tests/hwtimer_wait/main.c
+++ b/tests/hwtimer_wait/main.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <math.h>
 
 #include "board_uart0.h"
 #include "posix_io.h"
@@ -30,13 +31,24 @@
 int main(void)
 {
     puts("This is a regression test for a race condition in hwtimer_wait.");
-    puts("When the race condition is hit, the timer will wait for a very very long time...");
+    puts("When the race condition is hit, the timer will wait for a very very long time.");
 
-    for (unsigned long r = 10000; r > 0; r--) {
-        for (unsigned long i = 256; i; i = i >> 1) {
+    int iterations = 10000;
+    int start_duration = 256;
+
+    long duration = iterations * (
+            /* geometric series */
+            (1 - pow(2,(log2(start_duration) + 1)))
+            / (1 - 2)
+            );
+    printf("The test should take about %li sec.\n", (HWTIMER_TICKS_TO_US(duration)/1000000));
+
+    for (unsigned long r = iterations; r > 0; r--) {
+        for (unsigned long i = start_duration; i; i = i >> 1) {
             hwtimer_wait(i);
         }
     }
     puts("success");
+
     return 0;
 }


### PR DESCRIPTION
EG:

```
$ time pseudoterm /dev/ttyUSB0
Using /dev/ttyUSB0 as serial device.
Port "/dev/ttyUSB0" opened at 115200 baud
Reset CPU (into user code)
RIOT MSP430 hardware initialization complete.

kernel_init(): This is RIOT! (Version: 2014.05-666-g2bdf-starfish-msp430-fix-thread-yield)
kernel_init(): jumping into first task...
This is a regression test for a race condition in hwtimer_wait.
When the race condition is hit, the timer will wait for a very very long time.
The test should take about 153 seconds.
success
SIGINT received, exiting...
pseudoterm /dev/ttyUSB0  0.00s user 0.00s system 0% cpu 2:43.83 total
```
