### PR TITLE
tests: remove need for pow,log2 in hwtimer_wait

### DIFF
--- a/tests/hwtimer_wait/main.c
+++ b/tests/hwtimer_wait/main.c
@@ -34,12 +34,18 @@ int main(void)
     puts("When the race condition is hit, the timer will wait for a very very long time.");
 
     int iterations = 10000;
+    /* `#define I_CHANGED_START_DURATION 1` or update the constant if
+     * you change start_duration */
     int start_duration = 256;
 
     long duration = iterations * (
             /* geometric series */
+#if I_CHANGED_START_DURATION
             (1 - pow(2,(log2(start_duration) + 1)))
             / (1 - 2)
+#else
+            511.0
+#endif
             );
     printf("The test should take about %li sec.\n", (HWTIMER_TICKS_TO_US(duration)/1000000));
 


### PR DESCRIPTION
Default to precalculated value for geometric series, so pow and log2 are not needed.

The problem is that for `arduino-mega2560` the math functions were undefined.
Apart from that it does not really make sense to calculate this principally static value.
