### PR TITLE
cpu/stm32f1: spi_transfer_bytes proper counting.

### DIFF
--- a/cpu/stm32f1/periph/spi.c
+++ b/cpu/stm32f1/periph/spi.c
@@ -123,12 +123,11 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
 int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
 {
     int transfered = 0;
-    int ret = 0;
 
     if (out != NULL) {
         DEBUG("out*: %p out: %x length: %x\n", out, *out, length);
         while (length--) {
-            ret = spi_transfer_byte(dev, *(out)++, 0);
+            int ret = spi_transfer_byte(dev, *(out)++, 0);
             if (ret <  0) {
                 return ret;
             }
@@ -137,7 +136,7 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
     }
     if (in != NULL) {
         while (length--) {
-            ret = spi_transfer_byte(dev, 0, in++);
+            int ret = spi_transfer_byte(dev, 0, in++);
             if (ret <  0) {
                 return ret;
             }


### PR DESCRIPTION
The transferred bytes were being counted more than once because of a +=
when calling spi_transfer_byte().

This patch should also handle errors from spi_transfer_byte() better
since it is now possible to detect errors _after_ the first byte has
been successfully sent.

I do not have a board to test on so I would need someone else to verify that this is correct.
