### PR TITLE
rename msg_* to blip_*

### DIFF
--- a/boards/avsextrem/drivers/avsextrem-smb380.c
+++ b/boards/avsextrem/drivers/avsextrem-smb380.c
@@ -53,7 +53,7 @@ volatile int16_t *ringBuff_Z = NULL;
 volatile int16_t *ringBuff_T = NULL;
 uint16_t readPointerPos[SMB380_RING_BUFF_MAX_THREADS];
 kernel_pid_t PointerList[SMB380_RING_BUFF_MAX_THREADS];
-static msg_t wakeupmessage;
+static blip_t wakeupmessage;
 
 /*
  * pointer to a user-defined function which is called during a writepointer
@@ -158,7 +158,7 @@ static void SMB380_simple_interrupthandler(void)
     if (interruptTicksSMB380 >= sampleRateSMB380 - 1) {
         interruptTicksSMB380 = 0;
         wakeupmessage.type = MSG_TYPE_SMB380_WAKEUP;
-        msg_send(&wakeupmessage, simple_pid, 0);
+        blip_send(&wakeupmessage, simple_pid, 0);
     }
     else {
         interruptTicksSMB380++;
@@ -566,7 +566,7 @@ void wakeUpRegisteredProcesses(void)
 
     while ((PointerList[pointerNo] > 0) &&
            (pointerNo < SMB380_RING_BUFF_MAX_THREADS)) {
-        msg_send(&wakeupmessage, PointerList[pointerNo], false);
+        blip_send(&wakeupmessage, PointerList[pointerNo], false);
         pointerNo++;
     }
 }

--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -14,7 +14,7 @@
  * There are two ways to use the IPC Messaging system of RIOT. The default is
  * synchronous messaging. In this manner, messages are either dropped when the
  * receiver is not waiting and the message was sent non-blocking, or will be
- * delivered immediately when the receiver calls msg_receive(msg_t* m). To use
+ * delivered immediately when the receiver calls blip_receive(msg_t* m). To use
  * asynchronous messaging any thread can create its own queue by calling
  * msg_init_queue(msg_t* array, int num). Messages sent to a thread with a non
  * full message queue are never dropped * and the sending never blocks. Threads
@@ -52,18 +52,18 @@ typedef struct msg {
         char     *ptr;          /**< Pointer content field. */
         uint32_t value;         /**< Value content field. */
     } content;                  /**< Content of the message. */
-} msg_t;
+} blip_t;
 
 
 /**
  * @brief Send a message.
  *
- * This function sends a message to another thread. The ``msg_t`` structure has
+ * This function sends a message to another thread. The ``blip_t`` structure has
  * to be allocated (e.g. on the stack) before calling the function and can be
  * freed afterwards. If called from an interrupt, this function will never
  * block.
  *
- * @param[in] m             Pointer to preallocated ``msg_t`` structure, must
+ * @param[in] m             Pointer to preallocated ``blip_t`` structure, must
  *                          not be NULL.
  * @param[in] target_pid    PID of target thread
  * @param[in] block         If not 0 and receiver is not receive-blocked,
@@ -75,7 +75,7 @@ typedef struct msg {
  *         ``block == 0``
  * @return -1, on error (invalid PID)
  */
-int msg_send(msg_t *m, kernel_pid_t target_pid, bool block);
+int blip_send(blip_t *m, kernel_pid_t target_pid, bool block);
 
 
 /**
@@ -91,7 +91,7 @@ int msg_send(msg_t *m, kernel_pid_t target_pid, bool block);
  * @return 1 if sending was successful
  * @return 0 if the thread's message queue is full (or inexistent)
  */
-int msg_send_to_self(msg_t *m);
+int msg_send_to_self(blip_t *m);
 
 /**
  * @brief Send message from interrupt.
@@ -99,7 +99,7 @@ int msg_send_to_self(msg_t *m);
  * Will be automatically chosen instead of ``msg_send()`` if called from an
  * interrupt/ISR.
  *
- * @param[in] m             Pointer to preallocated ``msg_t`` structure, must
+ * @param[in] m             Pointer to preallocated ``blip_t`` structure, must
  *                          not be NULL.
  * @param[in] target_pid    PID of target thread.
  *
@@ -107,7 +107,7 @@ int msg_send_to_self(msg_t *m);
  * @return 0, if receiver is not waiting and ``block == 0``
  * @return -1, on error (invalid PID)
  */
-int msg_send_int(msg_t *m, kernel_pid_t target_pid);
+int blip_send_int(blip_t *m, kernel_pid_t target_pid);
 
 
 /**
@@ -115,25 +115,25 @@ int msg_send_int(msg_t *m, kernel_pid_t target_pid);
  *
  * This function blocks until a message was received.
  *
- * @param[out] m    Pointer to preallocated ``msg_t`` structure, must not be
+ * @param[out] m    Pointer to preallocated ``blip_t`` structure, must not be
  *                  NULL.
  *
  * @return  1, Function always succeeds or blocks forever.
  */
-int msg_receive(msg_t *m);
+int blip_receive(blip_t *m);
 
 /**
  * @brief Try to receive a message.
  *
  * This function does not block if no message can be received.
  *
- * @param[out] m    Pointer to preallocated ``msg_t`` structure, must not be
+ * @param[out] m    Pointer to preallocated ``blip_t`` structure, must not be
  *                  NULL.
  *
  * @return  1, if a message was received
  * @return  -1, otherwise.
  */
-int msg_try_receive(msg_t *m);
+int blip_try_receive(blip_t *m);
 
 /**
  * @brief Send a message, block until reply received.
@@ -142,8 +142,8 @@ int msg_try_receive(msg_t *m);
  * has sent a reply which is then stored in *reply*.
  *
  * @note    CAUTION! Use this function only when receiver is already waiting.
- *          If not use simple msg_send()
- * @param[in] m             Pointer to preallocated ``msg_t`` structure with
+ *          If not use simple blip_send()
+ * @param[in] m             Pointer to preallocated ``blip_t`` structure with
  *                          the message to send, must not be NULL.
  * @param[out] reply        Pointer to preallocated msg. Reply will be written
  *                          here, must not be NULL.
@@ -151,12 +151,12 @@ int msg_try_receive(msg_t *m);
  *
  * @return  1, if successful.
  */
-int msg_send_receive(msg_t *m, msg_t *reply, kernel_pid_t target_pid);
+int blip_send_receive(blip_t *m, blip_t *reply, kernel_pid_t target_pid);
 
 /**
  * @brief Replies to a message.
  *
- * Sender must have sent the message with msg_send_receive().
+ * Sender must have sent the message with blip_send_receive().
  *
  * @param[in] m         message to reply to, must not be NULL.
  * @param[out] reply    message that target will get as reply, must not be
@@ -165,20 +165,20 @@ int msg_send_receive(msg_t *m, msg_t *reply, kernel_pid_t target_pid);
  * @return 1, if successful
  * @return 0, on error
  */
-int msg_reply(msg_t *m, msg_t *reply);
+int blip_reply(blip_t *m, blip_t *reply);
 
 /**
  * @brief Initialize the current thread's message queue.
  *
- * @param[in] array Pointer to preallocated array of ``msg_t`` structures, must
+ * @param[in] array Pointer to preallocated array of ``blip_t`` structures, must
  *                  not be NULL.
- * @param[in] num   Number of ``msg_t`` structures in array.
+ * @param[in] num   Number of ``blip_t`` structures in array.
  *                  **MUST BE POWER OF TWO!**
  *
  * @return 0, if successful
  * @return -1, on error
  */
-int msg_init_queue(msg_t *array, int num);
+int msg_init_queue(blip_t *array, int num);
 
 #endif /* __MSG_H_ */
 /** @} */

--- a/core/include/tcb.h
+++ b/core/include/tcb.h
@@ -68,7 +68,7 @@ typedef struct tcb_t {
     priority_queue_t msg_waiters;   /**< threads waiting on message     */
 
     cib_t msg_queue;            /**< message queue                  */
-    msg_t *msg_array;           /**< memory holding messages        */
+    blip_t *msg_array;           /**< memory holding messages        */
 
     const char *name;           /**< thread's name                  */
     char *stack_start;          /**< thread's stack start address   */

--- a/core/msg.c
+++ b/core/msg.c
@@ -36,10 +36,10 @@
 #include "debug.h"
 #include "thread.h"
 
-static int _msg_receive(msg_t *m, int block);
+static int _msg_receive(blip_t *m, int block);
 
 
-static int queue_msg(tcb_t *target, msg_t *m)
+static int queue_msg(tcb_t *target, blip_t *m)
 {
     int n = cib_put(&(target->msg_queue));
 
@@ -51,10 +51,10 @@ static int queue_msg(tcb_t *target, msg_t *m)
     return 0;
 }
 
-int msg_send(msg_t *m, kernel_pid_t target_pid, bool block)
+int blip_send(blip_t *m, kernel_pid_t target_pid, bool block)
 {
     if (inISR()) {
-        return msg_send_int(m, target_pid);
+        return blip_send_int(m, target_pid);
     }
 
     if (sched_active_pid == target_pid) {
@@ -119,7 +119,7 @@ int msg_send(msg_t *m, kernel_pid_t target_pid, bool block)
     else {
         DEBUG("msg_send: %s: Direct msg copy from %" PRIkernel_pid " to %" PRIkernel_pid ".\n", sched_active_thread->name, thread_getpid(), target_pid);
         /* copy msg to target */
-        msg_t *target_message = (msg_t*) target->wait_data;
+        blip_t *target_message = (blip_t*) target->wait_data;
         *target_message = *m;
         sched_set_status(target, STATUS_PENDING);
     }
@@ -130,7 +130,7 @@ int msg_send(msg_t *m, kernel_pid_t target_pid, bool block)
     return 1;
 }
 
-int msg_send_to_self(msg_t *m)
+int msg_send_to_self(blip_t *m)
 {
     unsigned int state = disableIRQ();
 
@@ -141,7 +141,7 @@ int msg_send_to_self(msg_t *m)
     return res;
 }
 
-int msg_send_int(msg_t *m, kernel_pid_t target_pid)
+int blip_send_int(blip_t *m, kernel_pid_t target_pid)
 {
     tcb_t *target = (tcb_t *) sched_threads[target_pid];
 
@@ -156,7 +156,7 @@ int msg_send_int(msg_t *m, kernel_pid_t target_pid)
         m->sender_pid = target_pid;
 
         /* copy msg to target */
-        msg_t *target_message = (msg_t*) target->wait_data;
+        blip_t *target_message = (blip_t*) target->wait_data;
         *target_message = *m;
         sched_set_status(target, STATUS_PENDING);
 
@@ -169,7 +169,7 @@ int msg_send_int(msg_t *m, kernel_pid_t target_pid)
     }
 }
 
-int msg_send_receive(msg_t *m, msg_t *reply, kernel_pid_t target_pid)
+int blip_send_receive(blip_t *m, blip_t *reply, kernel_pid_t target_pid)
 {
     dINT();
     tcb_t *me = (tcb_t*) sched_threads[sched_active_pid];
@@ -178,10 +178,10 @@ int msg_send_receive(msg_t *m, msg_t *reply, kernel_pid_t target_pid)
 
     /* msg_send blocks until reply received */
 
-    return msg_send(m, target_pid, true);
+    return blip_send(m, target_pid, true);
 }
 
-int msg_reply(msg_t *m, msg_t *reply)
+int blip_reply(blip_t *m, blip_t *reply)
 {
     int state = disableIRQ();
 
@@ -200,7 +200,7 @@ int msg_reply(msg_t *m, msg_t *reply)
 
     DEBUG("msg_reply(): %s: Direct msg copy.\n", sched_active_thread->name);
     /* copy msg to target */
-    msg_t *target_message = (msg_t*) target->wait_data;
+    blip_t *target_message = (blip_t*) target->wait_data;
     *target_message = *reply;
     sched_set_status(target, STATUS_PENDING);
     restoreIRQ(state);
@@ -209,7 +209,7 @@ int msg_reply(msg_t *m, msg_t *reply)
     return 1;
 }
 
-int msg_reply_int(msg_t *m, msg_t *reply)
+int msg_reply_int(blip_t *m, blip_t *reply)
 {
     tcb_t *target = (tcb_t*) sched_threads[m->sender_pid];
 
@@ -218,24 +218,24 @@ int msg_reply_int(msg_t *m, msg_t *reply)
         return -1;
     }
 
-    msg_t *target_message = (msg_t*) target->wait_data;
+    blip_t *target_message = (blip_t*) target->wait_data;
     *target_message = *reply;
     sched_set_status(target, STATUS_PENDING);
     sched_context_switch_request = 1;
     return 1;
 }
 
-int msg_try_receive(msg_t *m)
+int blip_try_receive(blip_t *m)
 {
     return _msg_receive(m, 0);
 }
 
-int msg_receive(msg_t *m)
+int blip_receive(blip_t *m)
 {
     return _msg_receive(m, 1);
 }
 
-static int _msg_receive(msg_t *m, int block)
+static int _msg_receive(blip_t *m, int block)
 {
     dINT();
     DEBUG("_msg_receive: %s: _msg_receive.\n", sched_active_thread->name);
@@ -294,7 +294,7 @@ static int _msg_receive(msg_t *m, int block)
         }
 
         /* copy msg */
-        msg_t *sender_msg = (msg_t*) sender->wait_data;
+        blip_t *sender_msg = (blip_t*) sender->wait_data;
         *m = *sender_msg;
 
         /* remove sender from queue */
@@ -310,7 +310,7 @@ static int _msg_receive(msg_t *m, int block)
     DEBUG("This should have never been reached!\n");
 }
 
-int msg_init_queue(msg_t *array, int num)
+int msg_init_queue(blip_t *array, int num)
 {
     /* check if num is a power of two by comparing to its complement */
     if (num && (num & (num - 1)) == 0) {

--- a/cpu/cc430/cc430-rtc.c
+++ b/cpu/cc430/cc430-rtc.c
@@ -193,9 +193,9 @@ interrupt(RTC_VECTOR) __attribute__((naked)) rtc_isr(void)
         }
 
         if (rtc_second_pid != KERNEL_PID_UNDEF) {
-            static msg_t m;
+            static blip_t m;
             m.type = RTC_SECOND;
-            msg_send_int(&m, rtc_second_pid);
+            blip_send_int(&m, rtc_second_pid);
         }
     }
     /* RTC alarm */

--- a/cpu/native/net/interface.c
+++ b/cpu/native/net/interface.c
@@ -205,10 +205,10 @@ void _nativenet_handle_packet(radio_packet_t *packet)
     /* notify transceiver thread if any */
     if (_native_net_tpid != KERNEL_PID_UNDEF) {
         DEBUG("_nativenet_handle_packet: notifying transceiver thread!\n");
-        msg_t m;
+        blip_t m;
         m.type = (uint16_t) RCV_PKT_NATIVE;
         m.content.value = rx_buffer_next;
-        msg_send_int(&m, _native_net_tpid);
+        blip_send_int(&m, _native_net_tpid);
     }
     else {
         DEBUG("_nativenet_handle_packet: no one to notify =(\n");

--- a/cpu/x86/include/x86_pci.h
+++ b/cpu/x86/include/x86_pci.h
@@ -315,7 +315,7 @@ struct x86_known_pci_device;
  *
  * Because PCI is multiplexer, there might not be an IRQ for this device.
  * This callback is called out of the interrupt handler (inISR() == true).
- * Lengthy operations should be handled in a dedicated thread; use msg_send_int().
+ * Lengthy operations should be handled in a dedicated thread; use blip_send_int().
  * You must no enable interrupt inside the handler.
  */
 typedef void (*x86_pci_irq_handler_t)(struct x86_known_pci_device *d);

--- a/cpu/x86/include/x86_pic.h
+++ b/cpu/x86/include/x86_pic.h
@@ -118,7 +118,7 @@ void x86_init_pic(void);
  * @param   irq_num   IRQ line in question.
  *
  * This callback is called out of the interrupt handler (inISR() == true).
- * Lengthy operations should be handled in a dedicated thread; use msg_send_int().
+ * Lengthy operations should be handled in a dedicated thread; use blip_send_int().
  * You must no enable interrupt inside the handler.
  */
 typedef void (*x86_irq_handler_t)(uint8_t irq_num);

--- a/cpu/x86/x86_hwtimer.c
+++ b/cpu/x86/x86_hwtimer.c
@@ -210,11 +210,11 @@ static void *hwtimer_tick_handler(void *arg)
 {
     (void) arg;
 
-    msg_t msg_array[2];
+    blip_t msg_array[2];
     msg_init_queue(msg_array, sizeof (msg_array) / sizeof (*msg_array));
     while (1) {
-        msg_t m;
-        msg_receive(&m);
+        blip_t m;
+        blip_receive(&m);
 
         dINT();
         set_next_alarm(true);
@@ -269,8 +269,8 @@ static bool set_next_alarm(bool may_call)
             DEBUG("      callback(%u) (%lli µs prematurely), may_call=%u\n",
                   timer_i, us_future, may_call);
             if (!may_call) {
-                msg_t m;
-                msg_send_int(&m, hwtimer_pid);
+                blip_t m;
+                blip_send_int(&m, hwtimer_pid);
                 return true;
             }
             else {

--- a/cpu/x86/x86_rtc.c
+++ b/cpu/x86/x86_rtc.c
@@ -47,30 +47,30 @@ static kernel_pid_t alarm_pid = KERNEL_PID_UNDEF, periodic_pid = KERNEL_PID_UNDE
 static void alarm_callback_default(uint8_t reg_c)
 {
     if (alarm_pid != KERNEL_PID_UNDEF) {
-        msg_t m;
+        blip_t m;
         m.type = reg_c | (RTC_REG_B_INT_ALARM << 8);
         m.content.value = alarm_msg_content;
-        msg_send_int(&m, alarm_pid);
+        blip_send_int(&m, alarm_pid);
     }
 }
 
 static void periodic_callback_default(uint8_t reg_c)
 {
     if (periodic_pid != KERNEL_PID_UNDEF) {
-        msg_t m;
+        blip_t m;
         m.type = reg_c | (RTC_REG_B_INT_PERIODIC << 8);
         m.content.value = periodic_msg_content;
-        msg_send_int(&m, periodic_pid);
+        blip_send_int(&m, periodic_pid);
     }
 }
 
 static void update_callback_default(uint8_t reg_c)
 {
     if (update_pid != KERNEL_PID_UNDEF) {
-        msg_t m;
+        blip_t m;
         m.type = reg_c | (RTC_REG_B_INT_UPDATE << 8);
         m.content.value = update_msg_content;
-        msg_send_int(&m, update_pid);
+        blip_send_int(&m, update_pid);
     }
 }
 

--- a/drivers/at86rf231/at86rf231_rx.c
+++ b/drivers/at86rf231/at86rf231_rx.c
@@ -62,10 +62,10 @@ void at86rf231_rx_handler(void)
 
         /* notify transceiver thread if any */
         if (transceiver_pid != KERNEL_PID_UNDEF) {
-            msg_t m;
+            blip_t m;
             m.type = (uint16_t) RCV_PKT_AT86RF231;
             m.content.value = rx_buffer_next;
-            msg_send_int(&m, transceiver_pid);
+            blip_send_int(&m, transceiver_pid);
         }
     }
     else {

--- a/drivers/cc110x/cc1100_phy.c
+++ b/drivers/cc110x/cc1100_phy.c
@@ -618,7 +618,7 @@ static void *cc1100_event_handler_function(void *arg)
 {
     (void) arg;
 
-    msg_t m;
+    blip_t m;
 
     while (1) {
         if (timex_uint64(cc1100_watch_dog_period) != 0) {
@@ -682,7 +682,7 @@ static void *cc1100_event_handler_function(void *arg)
                                cc1100_event_handler_pid, NULL);
             }
 
-            msg_receive(&m);
+            blip_receive(&m);
         }
 
         eINT();
@@ -697,7 +697,7 @@ static void *cc1100_event_handler_function(void *arg)
 
 void cc1100_phy_rx_handler(void)
 {
-    msg_t m;
+    blip_t m;
     m.type = MSG_POLL;
     bool dup = false;
     bool res = false;
@@ -797,7 +797,7 @@ void cc1100_phy_rx_handler(void)
                  * Receiver process could already be running (triggered by previous message),
                  * so function would return 0 and assume the receiver is not waiting but indeed
                  * all is working fine.*/
-                msg_send_int(&m, cc1100_event_handler_pid);
+                blip_send_int(&m, cc1100_event_handler_pid);
                 cc1100_statistic.packets_in_up++;
             }
         }

--- a/drivers/cc110x_ng/cc110x-rx.c
+++ b/drivers/cc110x_ng/cc110x-rx.c
@@ -87,10 +87,10 @@ void cc110x_rx_handler(void)
 
         /* notify transceiver thread if any */
         if (transceiver_pid != KERNEL_PID_UNDEF) {
-            msg_t m;
+            blip_t m;
             m.type = (uint16_t) RCV_PKT_CC1100;
             m.content.value = rx_buffer_next;
-            msg_send_int(&m, transceiver_pid);
+            blip_send_int(&m, transceiver_pid);
         }
 
         /* shift to next buffer element */

--- a/drivers/cc2420/cc2420_rx.c
+++ b/drivers/cc2420/cc2420_rx.c
@@ -79,10 +79,10 @@ void cc2420_rx_handler(void)
 
         /* notify transceiver thread if any */
         if (transceiver_pid != KERNEL_PID_UNDEF) {
-            msg_t m;
+            blip_t m;
             m.type = (uint16_t) RCV_PKT_CC2420;
             m.content.value = rx_buffer_next;
-            msg_send_int(&m, transceiver_pid);
+            blip_send_int(&m, transceiver_pid);
         }
     }
 

--- a/examples/ccn-lite-client/main.c
+++ b/examples/ccn-lite-client/main.c
@@ -50,7 +50,7 @@ char appserver_stack[KERNEL_CONF_STACKSIZE_MAIN];
 static volatile kernel_pid_t _relay_pid = KERNEL_PID_UNDEF, _appserver_pid = KERNEL_PID_UNDEF;
 
 #define SHELL_MSG_BUFFER_SIZE (64)
-msg_t msg_buffer_shell[SHELL_MSG_BUFFER_SIZE];
+blip_t msg_buffer_shell[SHELL_MSG_BUFFER_SIZE];
 
 shell_t shell;
 
@@ -136,10 +136,10 @@ static void riot_ccn_relay_config(int argc, char **argv)
         return;
     }
 
-    msg_t m;
+    blip_t m;
     m.content.value = atoi(argv[1]);
     m.type = CCNL_RIOT_CONFIG_CACHE;
-    msg_send(&m, _relay_pid, 1);
+    blip_send(&m, _relay_pid, 1);
 }
 
 static void riot_ccn_transceiver_start(kernel_pid_t _relay_pid)
@@ -155,14 +155,14 @@ static void riot_ccn_transceiver_start(kernel_pid_t _relay_pid)
     }
 
     /* set channel to CCNL_CHAN */
-    msg_t mesg;
+    blip_t mesg;
     transceiver_command_t tcmd;
     int32_t c = CCNL_DEFAULT_CHANNEL;
     tcmd.transceivers = TRANSCEIVER;
     tcmd.data = &c;
     mesg.content.ptr = (char *) &tcmd;
     mesg.type = SET_CHANNEL;
-    msg_send_receive(&mesg, &mesg, transceiver_pid);
+    blip_send_receive(&mesg, &mesg, transceiver_pid);
     if (c == -1) {
         puts("[transceiver] Error setting/getting channel");
     }
@@ -193,10 +193,10 @@ static void riot_ccn_relay_stop(int argc, char **argv)
     (void) argc; /* the function takes no arguments */
     (void) argv;
 
-    msg_t m;
+    blip_t m;
     m.content.value = 0;
     m.type = CCNL_RIOT_HALT;
-    msg_send(&m, _relay_pid, 1);
+    blip_send(&m, _relay_pid, 1);
 
     /* mark relay as not running */
     _relay_pid = 0;
@@ -222,7 +222,7 @@ static void riot_ccn_pit_test(int argc, char **argv)
     //prefix[i] = 0; //segment to request
     prefix[i + 1] = 0;
 
-    msg_t m;
+    blip_t m;
     riot_ccnl_msg_t rmsg;
     char segment_string[16]; //max=999\0
     timex_t now;
@@ -241,7 +241,7 @@ static void riot_ccn_pit_test(int argc, char **argv)
         m.content.ptr = (char *) &rmsg;
         m.type = CCNL_RIOT_MSG;
 
-        msg_send(&m, _relay_pid, 1);
+        blip_send(&m, _relay_pid, 1);
 
         if ((segment % 50) == 0) {
             vtimer_now(&now);
@@ -287,10 +287,10 @@ static void riot_ccn_populate(int argc, char **argv)
     (void) argc; /* the function takes no arguments */
     (void) argv;
 
-    msg_t m;
+    blip_t m;
     m.content.value = 0;
     m.type = CCNL_RIOT_POPULATE;
-    msg_send(&m, _relay_pid, 1);
+    blip_send(&m, _relay_pid, 1);
 }
 
 static void riot_ccn_stat(int argc, char **argv)
@@ -298,10 +298,10 @@ static void riot_ccn_stat(int argc, char **argv)
     (void) argc; /* the function takes no arguments */
     (void) argv;
 
-    msg_t m;
+    blip_t m;
     m.content.value = 0;
     m.type = CCNL_RIOT_PRINT_STAT;
-    msg_send(&m, _relay_pid, 1);
+    blip_send(&m, _relay_pid, 1);
 }
 
 static const shell_command_t sc[] = {

--- a/examples/ccn-lite-relay/main.c
+++ b/examples/ccn-lite-relay/main.c
@@ -37,7 +37,7 @@ char t2_stack[KERNEL_CONF_STACKSIZE_MAIN];
 
 void set_address_handler(uint16_t a)
 {
-    msg_t mesg;
+    blip_t mesg;
     transceiver_command_t tcmd;
 
     tcmd.transceivers = TRANSCEIVER;
@@ -49,16 +49,16 @@ void set_address_handler(uint16_t a)
 
     printf("transceiver_pid=%" PRIkernel_pid"\n", transceiver_pid);
 
-    msg_send_receive(&mesg, &mesg, transceiver_pid);
+    blip_send_receive(&mesg, &mesg, transceiver_pid);
     printf("got address: %" PRIu16 "\n", a);
 }
 
 void populate_cache(void)
 {
-    msg_t m;
+    blip_t m;
     m.content.value = 0;
     m.type = CCNL_RIOT_POPULATE;
-    msg_send(&m, _relay_pid, 1);
+    blip_send(&m, _relay_pid, 1);
 }
 
 void *second_thread(void *arg)

--- a/examples/default/main.c
+++ b/examples/default/main.c
@@ -46,20 +46,20 @@
 #ifdef MODULE_TRANSCEIVER
 
 char radio_stack_buffer[RADIO_STACK_SIZE];
-msg_t msg_q[RCV_BUFFER_SIZE];
+blip_t msg_q[RCV_BUFFER_SIZE];
 
 void *radio(void *arg)
 {
     (void) arg;
 
-    msg_t m;
+    blip_t m;
     radio_packet_t *p;
     radio_packet_length_t i;
 
     msg_init_queue(msg_q, RCV_BUFFER_SIZE);
 
     while (1) {
-        msg_receive(&m);
+        blip_receive(&m);
 
         if (m.type == PKT_PENDING) {
             p = (radio_packet_t *) m.content.ptr;

--- a/examples/ipc_pingpong/main.c
+++ b/examples/ipc_pingpong/main.c
@@ -29,13 +29,13 @@ void *second_thread(void *arg)
     (void) arg;
 
     printf("2nd thread started, pid: %" PRIkernel_pid "\n", thread_getpid());
-    msg_t m;
+    blip_t m;
 
     while (1) {
-        msg_receive(&m);
+        blip_receive(&m);
         printf("2nd: Got msg from %" PRIkernel_pid "\n", m.sender_pid);
         m.content.value++;
-        msg_reply(&m, &m);
+        blip_reply(&m, &m);
     }
 
     return NULL;
@@ -48,7 +48,7 @@ int main(void)
     printf("Starting IPC Ping-pong example...\n");
     printf("1st thread started, pid: %" PRIkernel_pid "\n", thread_getpid());
 
-    msg_t m;
+    blip_t m;
 
     kernel_pid_t pid = thread_create(second_thread_stack, sizeof(second_thread_stack),
                             PRIORITY_MAIN - 1, CREATE_STACKTEST,
@@ -57,7 +57,7 @@ int main(void)
     m.content.value = 1;
 
     while (1) {
-        msg_send_receive(&m, &m, pid);
+        blip_send_receive(&m, &m, pid);
         printf("1st: Got msg with content %u\n", (unsigned int)m.content.value);
     }
 }

--- a/examples/rpl_udp/helper.c
+++ b/examples/rpl_udp/helper.c
@@ -37,7 +37,7 @@
 
 extern uint8_t ipv6_ext_hdr_len;
 
-msg_t msg_q[RCV_BUFFER_SIZE];
+blip_t msg_q[RCV_BUFFER_SIZE];
 
 void rpl_udp_set_id(int argc, char **argv)
 {
@@ -57,7 +57,7 @@ void *rpl_udp_monitor(void *arg)
 {
     (void) arg;
 
-    msg_t m;
+    blip_t m;
     radio_packet_t *p;
     ipv6_hdr_t *ipv6_buf;
     uint8_t icmp_type, icmp_code;
@@ -66,7 +66,7 @@ void *rpl_udp_monitor(void *arg)
     msg_init_queue(msg_q, RCV_BUFFER_SIZE);
 
     while (1) {
-        msg_receive(&m);
+        blip_receive(&m);
 
         if (m.type == PKT_PENDING) {
             p = (radio_packet_t *) m.content.ptr;
@@ -128,7 +128,7 @@ void rpl_udp_ignore(int argc, char **argv)
         return;
     }
 
-    msg_t mesg;
+    blip_t mesg;
     mesg.type = DBG_IGN;
     mesg.content.ptr = (char *) &tcmd;
 
@@ -138,7 +138,7 @@ void rpl_udp_ignore(int argc, char **argv)
     if (argc == 2) {
         a = atoi(argv[1]);
         printf("sending to transceiver (%" PRIkernel_pid "): %u\n", transceiver_pid, (*(uint8_t *)tcmd.data));
-        msg_send(&mesg, transceiver_pid, 1);
+        blip_send(&mesg, transceiver_pid, 1);
     }
     else {
         printf("Usage: %s <addr>\n", argv[0]);

--- a/examples/rpl_udp/rpl.c
+++ b/examples/rpl_udp/rpl.c
@@ -43,7 +43,7 @@ uint8_t is_root = 0;
 void rpl_udp_init(int argc, char **argv)
 {
     transceiver_command_t tcmd;
-    msg_t m;
+    blip_t m;
     uint8_t chan = RADIO_CHANNEL;
 
     if (argc != 2) {
@@ -119,7 +119,7 @@ void rpl_udp_init(int argc, char **argv)
     m.type = SET_CHANNEL;
     m.content.ptr = (void *) &tcmd;
 
-    msg_send_receive(&m, &m, transceiver_pid);
+    blip_send_receive(&m, &m, transceiver_pid);
     printf("Channel set to %u\n", RADIO_CHANNEL);
 
     puts("Destiny initialized");

--- a/sys/chardev_thread.c
+++ b/sys/chardev_thread.c
@@ -43,7 +43,7 @@ static int min(int a, int b)
 
 void chardev_loop(ringbuffer_t *rb)
 {
-    msg_t m;
+    blip_t m;
 
     kernel_pid_t pid = thread_getpid();
 
@@ -53,7 +53,7 @@ void chardev_loop(ringbuffer_t *rb)
     puts("UART0 thread started.");
 
     while (1) {
-        msg_receive(&m);
+        blip_receive(&m);
 
         if (m.sender_pid != pid) {
             DEBUG("Receiving message from another thread: ");
@@ -70,7 +70,7 @@ void chardev_loop(ringbuffer_t *rb)
                         m.content.value = -EBUSY;
                     }
 
-                    msg_reply(&m, &m);
+                    blip_reply(&m, &m);
                     break;
 
                 case READ:
@@ -78,7 +78,7 @@ void chardev_loop(ringbuffer_t *rb)
                     if (m.sender_pid != reader_pid) {
                         m.content.value = -EINVAL;
                         r = NULL;
-                        msg_reply(&m, &m);
+                        blip_reply(&m, &m);
                     }
                     else {
                         r = (struct posix_iop_t *)(void*)m.content.ptr;
@@ -98,13 +98,13 @@ void chardev_loop(ringbuffer_t *rb)
                         m.content.value = -EINVAL;
                     }
 
-                    msg_reply(&m, &m);
+                    blip_reply(&m, &m);
                     break;
 
                 default:
                     DEBUG("UNKNOWN\n");
                     m.content.value = -EINVAL;
-                    msg_reply(&m, &m);
+                    blip_reply(&m, &m);
             }
         }
 
@@ -120,7 +120,7 @@ void chardev_loop(ringbuffer_t *rb)
             m.type = OPEN;
             m.content.ptr = (char *)r;
 
-            msg_reply(&m, &m);
+            blip_reply(&m, &m);
 
             r = NULL;
             restoreIRQ(state);

--- a/sys/include/vtimer.h
+++ b/sys/include/vtimer.h
@@ -109,11 +109,11 @@ int vtimer_remove(vtimer_t *t);
 
 /**
  * @brief   receive a message but return in case of timeout time is passed by without a new message
- * @param[out]   m           pointer to a msg_t which will be filled in case of no timeout
+ * @param[out]   m           pointer to a blip_t which will be filled in case of no timeout
  * @param[in]    timeout     timex_t containing the relative time to fire the timeout
  * @return       < 0 on error, other value otherwise
  */
-int vtimer_msg_receive_timeout(msg_t *m, timex_t timeout);
+int vtimer_msg_receive_timeout(blip_t *m, timex_t timeout);
 
 #if ENABLE_DEBUG
 

--- a/sys/net/ccn_lite/ccn-lite-relay.c
+++ b/sys/net/ccn_lite/ccn-lite-relay.c
@@ -50,7 +50,7 @@
 #define RELAY_MSG_BUFFER_SIZE (64)
 
 /** message buffer */
-msg_t msg_buffer_relay[RELAY_MSG_BUFFER_SIZE];
+blip_t msg_buffer_relay[RELAY_MSG_BUFFER_SIZE];
 
 struct ccnl_relay_s *theRelay = NULL;
 
@@ -302,13 +302,13 @@ int ccnl_io_loop(struct ccnl_relay_s *ccnl)
         return -1;
     }
 
-    msg_t in;
+    blip_t in;
     radio_packet_t *p;
     riot_ccnl_msg_t *m;
 
     while (!ccnl->halt_flag) {
 
-        msg_receive(&in);
+        blip_receive(&in);
 
         mutex_lock(&ccnl->global_lock);
         switch (in.type) {

--- a/sys/net/ccn_lite/ccnl-ext-appserver.c
+++ b/sys/net/ccn_lite/ccnl-ext-appserver.c
@@ -35,7 +35,7 @@
 #define APPSERVER_MSG_BUFFER_SIZE (64)
 
 /** message buffer */
-msg_t msg_buffer_appserver[APPSERVER_MSG_BUFFER_SIZE];
+blip_t msg_buffer_appserver[APPSERVER_MSG_BUFFER_SIZE];
 
 kernel_pid_t relay_pid = KERNEL_PID_UNDEF;
 char prefix[] = "/riot/appserver/";
@@ -47,12 +47,12 @@ static int appserver_sent_content(uint8_t *buf, int len, kernel_pid_t from)
     rmsg.size = len;
     DEBUGMSG(1, "datalen=%d\n", rmsg.size);
 
-    msg_t m;
+    blip_t m;
     m.type = CCNL_RIOT_MSG;
     m.content.ptr = (char *) &rmsg;
     kernel_pid_t dest_pid = from;
     DEBUGMSG(1, "sending msg to pid=%" PRIkernel_pid "\n", dest_pid);
-    int ret = msg_send(&m, dest_pid, 1);
+    int ret = blip_send(&m, dest_pid, 1);
     DEBUGMSG(1, "msg_reply returned: %d\n", ret);
     return ret;
 }
@@ -122,12 +122,12 @@ static void riot_ccnl_appserver_ioloop(void)
         DEBUGMSG(1, "msg init queue failed...abording\n");
     }
 
-    msg_t in;
+    blip_t in;
     riot_ccnl_msg_t *m;
 
     while (1) {
         DEBUGMSG(1, "appserver: waiting for incomming msg\n");
-        msg_receive(&in);
+        blip_receive(&in);
 
         switch (in.type) {
             case (CCNL_RIOT_MSG):

--- a/sys/net/ccn_lite/ccnl-riot-compat.c
+++ b/sys/net/ccn_lite/ccnl-riot-compat.c
@@ -38,7 +38,7 @@ radio_packet_t p;
 #endif
 
 transceiver_command_t tcmd;
-msg_t mesg, rep;
+blip_t mesg, rep;
 
 char relay_helper_stack[KERNEL_CONF_STACKSIZE_MAIN];
 
@@ -69,7 +69,7 @@ int riot_send_transceiver(uint8_t *buf, uint16_t size, uint16_t to)
 
     mesg.type = SND_PKT;
     mesg.content.ptr = (char *) &tcmd;
-    msg_send_receive(&mesg, &rep, transceiver_pid);
+    blip_send_receive(&mesg, &rep, transceiver_pid);
 
     return size;
 }
@@ -91,21 +91,21 @@ int riot_send_msg(uint8_t *buf, uint16_t size, uint16_t to)
 
     memcpy(rmsg->payload, buf, size);
 
-    msg_t m;
+    blip_t m;
     m.type = CCNL_RIOT_MSG;
     m.content.ptr = (char *) rmsg;
     DEBUGMSG(1, "sending msg to pid=%" PRIkernel_pid "\n", to);
-    msg_send(&m, to, 1);
+    blip_send(&m, to, 1);
 
     return size;
 }
 
 void riot_send_nack(uint16_t to)
 {
-    msg_t m;
+    blip_t m;
     m.type = CCNL_RIOT_NACK;
     DEBUGMSG(1, "sending NACK msg to pid=%" PRIkernel_pid"\n", to);
-    msg_send(&m, to, 0);
+    blip_send(&m, to, 0);
 }
 
 void *ccnl_riot_relay_helper_start(void *);

--- a/sys/net/ccn_lite/util/ccnl-riot-client.c
+++ b/sys/net/ccn_lite/util/ccnl-riot-client.c
@@ -64,14 +64,14 @@ int ccnl_riot_client_get(kernel_pid_t relay_pid, char *name, char *reply_buf)
         rmsg.payload = interest_pkg;
         rmsg.size = interest_len;
 
-        msg_t m, rep;
+        blip_t m, rep;
         m.content.ptr = (char *) &rmsg;
         m.type = CCNL_RIOT_MSG;
-        msg_send(&m, relay_pid, 1);
+        blip_send(&m, relay_pid, 1);
 
         /* ######################################################################### */
 
-        msg_receive(&rep);
+        blip_receive(&rep);
         free(interest_pkg);
         if (rep.type == CCNL_RIOT_NACK) {
             /* network stack was not able to fetch this chunk */
@@ -127,15 +127,15 @@ int ccnl_riot_client_new_face(kernel_pid_t relay_pid, char *type, char *faceid,
     rmsg.payload = reply_buf;
     rmsg.size = len;
 
-    msg_t m, rep;
+    blip_t m, rep;
     m.content.ptr = (char *) &rmsg;
     m.type = CCNL_RIOT_MSG;
     DEBUGMSG(1, "  sending face req to relay\n");
-    msg_send(&m, relay_pid, 1);
+    blip_send(&m, relay_pid, 1);
 
     /* ######################################################################### */
 
-    msg_receive(&rep);
+    blip_receive(&rep);
     DEBUGMSG(1, "  received reply from relay\n");
     riot_ccnl_msg_t *rmsg_reply = (riot_ccnl_msg_t *) rep.content.ptr;
     memcpy(reply_buf, rmsg_reply->payload, rmsg_reply->size);
@@ -156,15 +156,15 @@ int ccnl_riot_client_register_prefix(kernel_pid_t relay_pid, char *prefix, char 
     rmsg.payload = reply_buf;
     rmsg.size = len;
 
-    msg_t m, rep;
+    blip_t m, rep;
     m.content.ptr = (char *) &rmsg;
     m.type = CCNL_RIOT_MSG;
     DEBUGMSG(1, "  sending prefix req to relay\n");
-    msg_send(&m, relay_pid, 1);
+    blip_send(&m, relay_pid, 1);
 
     /* ######################################################################### */
 
-    msg_receive(&rep);
+    blip_receive(&rep);
     DEBUGMSG(1, "  received reply from relay\n");
     riot_ccnl_msg_t *rmsg_reply = (riot_ccnl_msg_t *) rep.content.ptr;
     memcpy(reply_buf, rmsg_reply->payload, rmsg_reply->size);

--- a/sys/net/include/rpl.h
+++ b/sys/net/include/rpl.h
@@ -52,7 +52,7 @@ extern mutex_t rpl_recv_mutex;
 /* needed for sending RPL-messages */
 extern mutex_t rpl_send_mutex;
 
-extern msg_t rpl_msg_queue[RPL_PKT_RECV_BUF_SIZE];
+extern blip_t rpl_msg_queue[RPL_PKT_RECV_BUF_SIZE];
 extern char rpl_process_buf[RPL_PROCESS_STACKSIZE];
 extern uint8_t rpl_buffer[BUFFER_SIZE - LL_HDR_LEN];
 

--- a/sys/net/link_layer/net_if/net_if.c
+++ b/sys/net/link_layer/net_if/net_if.c
@@ -258,14 +258,14 @@ uint32_t net_if_transceiver_get_set_handler(int if_id, uint16_t op_type,
 {
     DEBUG("net_if_transceiver_get_set_handler: if_id = %d, op_type = %d, data = %p\n",
           if_id, op_type, data);
-    msg_t msg;
+    blip_t msg;
     transceiver_command_t tcmd;
 
     tcmd.transceivers = interfaces[if_id].transceivers;
     tcmd.data = (char *)data;
     msg.content.ptr = (char *)&tcmd;
     msg.type = op_type;
-    msg_send_receive(&msg, &msg, transceiver_pid);
+    blip_send_receive(&msg, &msg, transceiver_pid);
 
     return msg.content.value;
 }

--- a/sys/net/network_layer/sixlowpan/border/border.c
+++ b/sys/net/network_layer/sixlowpan/border/border.c
@@ -78,12 +78,12 @@ void serial_reader_f(void)
 {
     kernel_pid_t main_pid;
     int bytes;
-    msg_t m;
+    blip_t m;
     border_packet_t *uart_buf;
 
     posix_open(uart0_handler_pid, 0);
 
-    msg_receive(&m);
+    blip_receive(&m);
     main_pid = m.sender_pid;
 
     while (1) {
@@ -114,7 +114,7 @@ void serial_reader_f(void)
 
                 if (conf_packet->conftype == BORDER_CONF_SYN) {
                     m.content.ptr = (char *)conf_packet;
-                    msg_send(&m, main_pid, 1);
+                    blip_send(&m, main_pid, 1);
                     continue;
                 }
             }
@@ -170,11 +170,11 @@ int sixlowpan_lowpan_border_init(int if_id)
 
 void border_process_lowpan(void)
 {
-    msg_t m;
+    blip_t m;
     ipv6_hdr_t *ipv6_buf;
 
     while (1) {
-        msg_receive(&m);
+        blip_receive(&m);
         ipv6_buf = (ipv6_hdr_t *)m.content.ptr;
 
         if (ipv6_buf->nextheader == IPV6_PROTO_NUM_ICMPV6) {

--- a/sys/net/network_layer/sixlowpan/border/flowcontrol.c
+++ b/sys/net/network_layer/sixlowpan/border/flowcontrol.c
@@ -41,10 +41,10 @@ int16_t synack_seqnum = -1;
 ipv6_addr_t init_threeway_handshake(void)
 {
     border_syn_packet_t *syn;
-    msg_t m;
+    blip_t m;
     m.content.ptr = NULL;
-    msg_send(&m, border_get_serial_reader(), 1);
-    msg_receive(&m);
+    blip_send(&m, border_get_serial_reader(), 1);
+    blip_receive(&m);
 
     syn = (border_syn_packet_t *)m.content.ptr;
     border_conf_header_t *synack = (border_conf_header_t *)get_serial_out_buffer(0);
@@ -91,13 +91,13 @@ ipv6_addr_t flowcontrol_init(void)
 
 static void sending_slot(void)
 {
-    msg_t m;
+    blip_t m;
     uint8_t seq_num;
     struct send_slot *slot;
     border_packet_t *tmp;
 
     while (1) {
-        msg_receive(&m);
+        blip_receive(&m);
         seq_num = *((uint8_t *)m.content.ptr);
         slot = &(slwin_stat.send_win[seq_num % BORDER_SWS]);
         tmp = (border_packet_t *)slot->frame;

--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -361,7 +361,7 @@ static void *lowpan_transfer(void *arg)
 {
     (void) arg;
 
-    msg_t m_recv, m_send;
+    blip_t m_recv, m_send;
     ipv6_hdr_t *ipv6_buf;
     lowpan_reas_buf_t *current_buf;
     uint8_t gotosleep;
@@ -381,7 +381,7 @@ static void *lowpan_transfer(void *arg)
                 memcpy(ipv6_buf, (current_buf->packet) + 1, current_buf->packet_size - 1);
                 m_send.content.ptr = (char *)ipv6_buf;
                 packet_length = current_buf->packet_size - 1;
-                msg_send_receive(&m_send, &m_recv, ip_process_pid);
+                blip_send_receive(&m_send, &m_recv, ip_process_pid);
             }
             else if (((current_buf->packet[0] & 0xf0) == IPV6_VER) &&
                      (iphc_status == LOWPAN_IPHC_DISABLE)) {
@@ -389,7 +389,7 @@ static void *lowpan_transfer(void *arg)
                 memcpy(ipv6_buf, (current_buf->packet), current_buf->packet_size);
                 m_send.content.ptr = (char *)ipv6_buf;
                 packet_length = current_buf->packet_size;
-                msg_send_receive(&m_send, &m_recv, ip_process_pid);
+                blip_send_receive(&m_send, &m_recv, ip_process_pid);
             }
             else if (((current_buf->packet[0] & 0xe0) == SIXLOWPAN_IPHC1_DISPATCH) &&
                      (iphc_status == LOWPAN_IPHC_ENABLE)) {
@@ -402,7 +402,7 @@ static void *lowpan_transfer(void *arg)
 
                 ipv6_buf = ipv6_get_buf();
                 m_send.content.ptr = (char *) ipv6_buf;
-                msg_send_receive(&m_send, &m_recv, ip_process_pid);
+                blip_send_receive(&m_send, &m_recv, ip_process_pid);
             }
             else {
                 DEBUG("ERROR: packet with unknown dispatch 0x%02x received\n",
@@ -795,12 +795,12 @@ void lowpan_read(uint8_t *data, uint8_t length, net_if_eui64_t *s_addr,
 
     for (i = 0; i < SIXLOWPAN_MAX_REGISTERED; i++) {
         if (sixlowpan_reg[i]) {
-            msg_t m_send;
+            blip_t m_send;
             m_send.type = LOWPAN_FRAME_RECEIVED;;
             current_frame.length = length;
             current_frame.data = data;
             m_send.content.ptr = (char *) &current_frame;
-            msg_send(&m_send, sixlowpan_reg[i], 1);
+            blip_send(&m_send, sixlowpan_reg[i], 1);
         }
     }
 

--- a/sys/net/network_layer/sixlowpan/mac.c
+++ b/sys/net/network_layer/sixlowpan/mac.c
@@ -49,7 +49,7 @@
 #define DEFAULT_IEEE_802154_PAN_ID  (0x1234)
 
 char radio_stack_buffer[RADIO_STACK_SIZE];
-msg_t msg_q[RADIO_RCV_BUF_SIZE];
+blip_t msg_q[RADIO_RCV_BUF_SIZE];
 
 uint8_t lowpan_mac_buf[PAYLOAD_SIZE];
 static uint8_t macdsn;
@@ -67,7 +67,7 @@ static void *recv_ieee802154_frame(void *arg)
 {
     (void) arg;
 
-    msg_t m;
+    blip_t m;
 #if (defined(MODULE_AT86RF231) | \
      defined(MODULE_CC2420) | \
      defined(MODULE_MC1322X))
@@ -83,7 +83,7 @@ static void *recv_ieee802154_frame(void *arg)
     msg_init_queue(msg_q, RADIO_RCV_BUF_SIZE);
 
     while (1) {
-        msg_receive(&m);
+        blip_receive(&m);
 
         if (m.type == PKT_PENDING) {
 #if (defined(MODULE_AT86RF231) | \

--- a/sys/net/routing/etx_beaconing.c
+++ b/sys/net/routing/etx_beaconing.c
@@ -65,7 +65,7 @@ kernel_pid_t etx_radio_pid = KERNEL_PID_UNDEF;
 kernel_pid_t etx_clock_pid = KERNEL_PID_UNDEF;
 
 //Message queue for radio
-static msg_t msg_que[ETX_RCV_QUEUE_SIZE];
+static blip_t msg_que[ETX_RCV_QUEUE_SIZE];
 
 /*
  * The counter for the current 'round'. An ETX beacon is sent every ETX_INTERVAL
@@ -103,7 +103,7 @@ mutex_t etx_mutex = MUTEX_INIT;
 transceiver_command_t tcmd;
 
 //Message to send probes with
-msg_t mesg;
+blip_t mesg;
 
 static ipv6_addr_t *own_address;
 
@@ -392,7 +392,7 @@ static void *etx_radio(void *arg)
 {
     (void) arg;
 
-    msg_t m;
+    blip_t m;
     radio_packet_t *p;
 
     ieee802154_frame_t frame;
@@ -406,7 +406,7 @@ static void *etx_radio(void *arg)
     ipv6_net_if_get_best_src_addr(&candidate_addr, &ll_address);
 
     while (1) {
-        msg_receive(&m);
+        blip_receive(&m);
 
         if (m.type == PKT_PENDING) {
             p = (radio_packet_t *) m.content.ptr;

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -52,7 +52,7 @@ rpl_routing_entry_t rpl_routing_table[RPL_MAX_ROUTING_ENTRIES];
 kernel_pid_t rpl_process_pid = KERNEL_PID_UNDEF;
 mutex_t rpl_recv_mutex = MUTEX_INIT;
 mutex_t rpl_send_mutex = MUTEX_INIT;
-msg_t rpl_msg_queue[RPL_PKT_RECV_BUF_SIZE];
+blip_t rpl_msg_queue[RPL_PKT_RECV_BUF_SIZE];
 char rpl_process_buf[RPL_PROCESS_STACKSIZE];
 uint8_t rpl_buffer[BUFFER_SIZE - LL_HDR_LEN];
 
@@ -114,11 +114,11 @@ void *rpl_process(void *arg)
 {
     (void) arg;
 
-    msg_t m_recv;
+    blip_t m_recv;
     msg_init_queue(rpl_msg_queue, RPL_PKT_RECV_BUF_SIZE);
 
     while (1) {
-        msg_receive(&m_recv);
+        blip_receive(&m_recv);
         mutex_lock(&rpl_recv_mutex);
         uint8_t *code;
         code = ((uint8_t *)m_recv.content.ptr);

--- a/sys/net/transport_layer/destiny/msg_help.c
+++ b/sys/net/transport_layer/destiny/msg_help.c
@@ -23,7 +23,7 @@
 
 void block_continue_thread(void)
 {
-    //  msg_t recv_m;
+    //  blip_t recv_m;
     //  recv_m.type = TCP_NOT_DEFINED;
     //  while (recv_m.type != TCP_CONTINUE)
     //      {
@@ -31,27 +31,27 @@ void block_continue_thread(void)
     //      }
 }
 
-int net_msg_receive(msg_t *m)
+int net_msg_receive(blip_t *m)
 {
-    return msg_receive(m);
+    return blip_receive(m);
 }
 
-int net_msg_reply(msg_t *m, msg_t *reply, uint16_t message)
+int net_msg_reply(blip_t *m, blip_t *reply, uint16_t message)
 {
     reply->type = message;
-    return msg_reply(m, reply);
+    return blip_reply(m, reply);
 }
 
-int net_msg_send(msg_t *m, kernel_pid_t pid, bool block, uint16_t message)
+int net_msg_send(blip_t *m, kernel_pid_t pid, bool block, uint16_t message)
 {
     m->type = message;
-    return msg_send(m, pid, block);
+    return blip_send(m, pid, block);
 }
 
-int net_msg_send_recv(msg_t *m, msg_t *reply, kernel_pid_t pid, uint16_t message)
+int net_msg_send_recv(blip_t *m, blip_t *reply, kernel_pid_t pid, uint16_t message)
 {
     m->type = message;
-    return msg_send_receive(m, reply, pid);;
+    return blip_send_receive(m, reply, pid);;
 }
 
 /**

--- a/sys/net/transport_layer/destiny/msg_help.h
+++ b/sys/net/transport_layer/destiny/msg_help.h
@@ -35,10 +35,10 @@
 #define RETURNNOW                       4000
 
 void block_continue_thread(void);
-int net_msg_receive(msg_t *m);
-int net_msg_reply(msg_t *m, msg_t *reply, uint16_t message);
-int net_msg_send(msg_t *m, kernel_pid_t pid, bool block, uint16_t message);
-int net_msg_send_recv(msg_t *m, msg_t *reply, kernel_pid_t pid, uint16_t message);
+int net_msg_receive(blip_t *m);
+int net_msg_reply(blip_t *m, blip_t *reply, uint16_t message);
+int net_msg_send(blip_t *m, kernel_pid_t pid, bool block, uint16_t message);
+int net_msg_send_recv(blip_t *m, blip_t *reply, kernel_pid_t pid, uint16_t message);
 
 #endif /* MSG_HELP_H_ */
 /**

--- a/sys/net/transport_layer/destiny/tcp.c
+++ b/sys/net/transport_layer/destiny/tcp.c
@@ -86,7 +86,7 @@ uint8_t handle_payload(ipv6_hdr_t *ipv6_header, tcp_hdr_t *tcp_header,
 {
     (void) tcp_header;
 
-    msg_t m_send_tcp, m_recv_tcp;
+    blip_t m_send_tcp, m_recv_tcp;
     uint8_t tcp_payload_len = NTOHS(ipv6_header->length) - TCP_HDR_LEN;
     uint8_t acknowledged_bytes = 0;
 
@@ -121,18 +121,18 @@ uint8_t handle_payload(ipv6_hdr_t *ipv6_header, tcp_hdr_t *tcp_header,
 void handle_tcp_ack_packet(ipv6_hdr_t *ipv6_header, tcp_hdr_t *tcp_header,
                            socket_internal_t *tcp_socket)
 {
-    msg_t m_recv_tcp, m_send_tcp;
+    blip_t m_recv_tcp, m_send_tcp;
     kernel_pid_t target_pid = KERNEL_PID_UNDEF;
 
     if (tcp_socket->socket_values.tcp_control.state == TCP_LAST_ACK) {
         target_pid = tcp_socket->recv_pid;
         close_socket(tcp_socket);
-        msg_send(&m_send_tcp, target_pid, 0);
+        blip_send(&m_send_tcp, target_pid, 0);
         return;
     }
     else if (tcp_socket->socket_values.tcp_control.state == TCP_CLOSING) {
-        msg_send(&m_send_tcp, tcp_socket->recv_pid, 0);
-        msg_send(&m_send_tcp, tcp_socket->send_pid, 0);
+        blip_send(&m_send_tcp, tcp_socket->recv_pid, 0);
+        blip_send(&m_send_tcp, tcp_socket->send_pid, 0);
         return;
     }
     else if (get_waiting_connection_socket(tcp_socket->socket_id, ipv6_header,
@@ -165,7 +165,7 @@ void handle_tcp_rst_packet(ipv6_hdr_t *ipv6_header, tcp_hdr_t *tcp_header,
 void handle_tcp_syn_packet(ipv6_hdr_t *ipv6_header, tcp_hdr_t *tcp_header,
                            socket_internal_t *tcp_socket)
 {
-    msg_t m_send_tcp;
+    blip_t m_send_tcp;
 
     if (tcp_socket->socket_values.tcp_control.state == TCP_LISTEN) {
         socket_internal_t *new_socket = new_tcp_queued_socket(ipv6_header,
@@ -196,7 +196,7 @@ void handle_tcp_syn_ack_packet(ipv6_hdr_t *ipv6_header, tcp_hdr_t *tcp_header,
 {
     (void) ipv6_header;
 
-    msg_t m_send_tcp;
+    blip_t m_send_tcp;
 
     if (tcp_socket->socket_values.tcp_control.state == TCP_SYN_SENT) {
         m_send_tcp.content.ptr = (char *) tcp_header;
@@ -212,7 +212,7 @@ void handle_tcp_fin_packet(ipv6_hdr_t *ipv6_header, tcp_hdr_t *tcp_header,
 {
     (void) ipv6_header;
 
-    msg_t m_send;
+    blip_t m_send;
     socket_t *current_tcp_socket = &tcp_socket->socket_values;
     uint8_t send_buffer[BUFFER_SIZE];
     ipv6_hdr_t *temp_ipv6_header = ((ipv6_hdr_t *)(&send_buffer));
@@ -245,7 +245,7 @@ void handle_tcp_fin_ack_packet(ipv6_hdr_t *ipv6_header, tcp_hdr_t *tcp_header,
 {
     (void) ipv6_header;
 
-    msg_t m_send;
+    blip_t m_send;
     socket_t *current_tcp_socket = &tcp_socket->socket_values;
     uint8_t send_buffer[BUFFER_SIZE];
     ipv6_hdr_t *temp_ipv6_header = ((ipv6_hdr_t *)(&send_buffer));
@@ -263,8 +263,8 @@ void handle_tcp_fin_ack_packet(ipv6_hdr_t *ipv6_header, tcp_hdr_t *tcp_header,
 
     send_tcp(tcp_socket, current_tcp_packet, temp_ipv6_header, TCP_ACK, 0);
 
-    msg_send(&m_send, tcp_socket->send_pid, 0);
-    msg_send(&m_send, tcp_socket->recv_pid, 0);
+    blip_send(&m_send, tcp_socket->send_pid, 0);
+    blip_send(&m_send, tcp_socket->recv_pid, 0);
 }
 
 void handle_tcp_no_flags_packet(ipv6_hdr_t *ipv6_header, tcp_hdr_t *tcp_header,
@@ -310,7 +310,7 @@ void *tcp_packet_handler(void *arg)
 {
     (void) arg;
 
-    msg_t m_recv_ip, m_send_ip;
+    blip_t m_recv_ip, m_send_ip;
     ipv6_hdr_t *ipv6_header;
     tcp_hdr_t *tcp_header;
     uint8_t *payload;
@@ -318,7 +318,7 @@ void *tcp_packet_handler(void *arg)
     uint16_t chksum;
 
     while (1) {
-        msg_receive(&m_recv_ip);
+        blip_receive(&m_recv_ip);
 
         ipv6_header = ((ipv6_hdr_t *)m_recv_ip.content.ptr);
         tcp_header = ((tcp_hdr_t *)(m_recv_ip.content.ptr + IPV6_HDR_LEN));
@@ -407,6 +407,6 @@ void *tcp_packet_handler(void *arg)
                              &tcp_socket->socket_values);
         }
 
-        msg_reply(&m_recv_ip, &m_send_ip);
+        blip_reply(&m_recv_ip, &m_send_ip);
     }
 }

--- a/sys/net/transport_layer/destiny/tcp_timer.c
+++ b/sys/net/transport_layer/destiny/tcp_timer.c
@@ -32,7 +32,7 @@
 
 void handle_synchro_timeout(socket_internal_t *current_socket)
 {
-    msg_t send;
+    blip_t send;
 
     if (thread_getstatus(current_socket->recv_pid) == STATUS_RECEIVE_BLOCKED) {
         timex_t now;
@@ -62,7 +62,7 @@ void handle_synchro_timeout(socket_internal_t *current_socket)
 
 void handle_established(socket_internal_t *current_socket)
 {
-    msg_t send;
+    blip_t send;
     double current_timeout = current_socket->socket_values.tcp_control.rto;
 
     if (current_timeout < SECOND) {

--- a/sys/net/transport_layer/destiny/udp.c
+++ b/sys/net/transport_layer/destiny/udp.c
@@ -32,7 +32,7 @@
 
 #include "udp.h"
 
-msg_t udp_msg_queue[UDP_PKT_RECV_BUF_SIZE];
+blip_t udp_msg_queue[UDP_PKT_RECV_BUF_SIZE];
 
 uint16_t udp_csum(ipv6_hdr_t *ipv6_header, udp_hdr_t *udp_header)
 {
@@ -49,7 +49,7 @@ void *udp_packet_handler(void *arg)
 {
     (void) arg;
 
-    msg_t m_recv_ip, m_send_ip, m_recv_udp, m_send_udp;
+    blip_t m_recv_ip, m_send_ip, m_recv_udp, m_send_udp;
     ipv6_hdr_t *ipv6_header;
     udp_hdr_t *udp_header;
     socket_internal_t *udp_socket = NULL;
@@ -58,7 +58,7 @@ void *udp_packet_handler(void *arg)
     msg_init_queue(udp_msg_queue, UDP_PKT_RECV_BUF_SIZE);
 
     while (1) {
-        msg_receive(&m_recv_ip);
+        blip_receive(&m_recv_ip);
         ipv6_header = ((ipv6_hdr_t *)m_recv_ip.content.ptr);
         udp_header = ((udp_hdr_t *)(m_recv_ip.content.ptr + IPV6_HDR_LEN));
 
@@ -69,7 +69,7 @@ void *udp_packet_handler(void *arg)
 
             if (udp_socket != NULL) {
                 m_send_udp.content.ptr = (char *)ipv6_header;
-                msg_send_receive(&m_send_udp, &m_recv_udp, udp_socket->recv_pid);
+                blip_send_receive(&m_send_udp, &m_recv_udp, udp_socket->recv_pid);
             }
             else {
                 printf("Dropped UDP Message because no thread ID was found for delivery!\n");
@@ -79,6 +79,6 @@ void *udp_packet_handler(void *arg)
             printf("Wrong checksum (%x)!\n", chksum);
         }
 
-        msg_reply(&m_recv_ip, &m_send_ip);
+        blip_reply(&m_recv_ip, &m_send_ip);
     }
 }

--- a/sys/posix/posix_io.c
+++ b/sys/posix/posix_io.c
@@ -23,10 +23,10 @@
 
 static int _posix_fileop(kernel_pid_t pid, int op, int flags)
 {
-    msg_t m;
+    blip_t m;
     m.type = op;
     m.content.value = flags;
-    msg_send_receive(&m, &m, pid);
+    blip_send_receive(&m, &m, pid);
     return m.content.value;
 }
 
@@ -36,11 +36,11 @@ static int _posix_fileop_data(kernel_pid_t pid, int op, char *buffer, int nbytes
     r.nbytes = nbytes;
     r.buffer = buffer;
 
-    msg_t m;
+    blip_t m;
     m.type = op;
     m.content.ptr = (char *) &r;
 
-    msg_send_receive(&m, &m, pid);
+    blip_send_receive(&m, &m, pid);
 
     return r.nbytes;
 }

--- a/sys/posix/pthread/pthread.c
+++ b/sys/posix/pthread/pthread.c
@@ -103,8 +103,8 @@ static void *pthread_reaper(void *arg)
     (void) arg;
 
     while (1) {
-        msg_t m;
-        msg_receive(&m);
+        blip_t m;
+        blip_receive(&m);
         DEBUG("pthread_reaper(): free(%p)\n", m.content.ptr);
         free(m.content.ptr);
     }
@@ -198,9 +198,9 @@ void pthread_exit(void *retval)
 
         dINT();
         if (self->stack) {
-            msg_t m;
+            blip_t m;
             m.content.ptr = self->stack;
-            msg_send_int(&m, pthread_reaper_pid);
+            blip_send_int(&m, pthread_reaper_pid);
         }
     }
 

--- a/sys/shell/commands/sc_transceiver.c
+++ b/sys/shell/commands/sc_transceiver.c
@@ -64,7 +64,7 @@
 /* checked for type safety */
 void _transceiver_get_set_address_handler(int argc, char **argv)
 {
-    msg_t mesg;
+    blip_t mesg;
     transceiver_command_t tcmd;
     radio_address_t a;
 
@@ -86,7 +86,7 @@ void _transceiver_get_set_address_handler(int argc, char **argv)
         mesg.type = GET_ADDRESS;
     }
 
-    msg_send_receive(&mesg, &mesg, transceiver_pid);
+    blip_send_receive(&mesg, &mesg, transceiver_pid);
     printf("[transceiver] got address: %" PRIu16 "\n", a);
 }
 
@@ -143,7 +143,7 @@ uint64_t _str_to_eui64(const char *eui64_str)
 /* checked for type safety */
 void _transceiver_get_set_long_addr_handler(int argc, char **argv)
 {
-    msg_t mesg;
+    blip_t mesg;
     transceiver_command_t tcmd;
     transceiver_eui64_t a;
 
@@ -171,7 +171,7 @@ void _transceiver_get_set_long_addr_handler(int argc, char **argv)
         mesg.type = GET_LONG_ADDR;
     }
 
-    msg_send_receive(&mesg, &mesg, transceiver_pid);
+    blip_send_receive(&mesg, &mesg, transceiver_pid);
     printf("[transceiver] got EUI-64: %016"PRIx64"\n", a);
 }
 
@@ -179,7 +179,7 @@ void _transceiver_get_set_long_addr_handler(int argc, char **argv)
 /* checked for type safety */
 void _transceiver_get_set_channel_handler(int argc, char **argv)
 {
-    msg_t mesg;
+    blip_t mesg;
     transceiver_command_t tcmd;
     int32_t c;
 
@@ -201,7 +201,7 @@ void _transceiver_get_set_channel_handler(int argc, char **argv)
         mesg.type = GET_CHANNEL;
     }
 
-    msg_send_receive(&mesg, &mesg, transceiver_pid);
+    blip_send_receive(&mesg, &mesg, transceiver_pid);
     if (c == -1) {
         puts("[transceiver] Error setting/getting channel");
     }
@@ -247,7 +247,7 @@ void _transceiver_send_handler(int argc, char **argv)
     p.dst = atoi(argv[1]);
 #endif
 
-    msg_t mesg;
+    blip_t mesg;
     mesg.type = SND_PKT;
     mesg.content.ptr = (char *) &tcmd;
 
@@ -256,7 +256,7 @@ void _transceiver_send_handler(int argc, char **argv)
 #else
     printf("[transceiver] Sending packet of length %" PRIu16 " to %" PRIu16 ": %s\n", p.length, p.dst, (char*) p.data);
 #endif
-    msg_send_receive(&mesg, &mesg, transceiver_pid);
+    blip_send_receive(&mesg, &mesg, transceiver_pid);
     int8_t response = mesg.content.value;
     printf("[transceiver] Packet sent: %" PRIi8 "\n", response);
 }
@@ -280,11 +280,11 @@ void _transceiver_monitor_handler(int argc, char **argv)
     tcmd.transceivers = _TC_TYPE;
     tcmd.data = &m;
 
-    msg_t mesg;
+    blip_t mesg;
     mesg.content.ptr = (char *) &tcmd;
     mesg.type = SET_MONITOR;
 
-    msg_send(&mesg, transceiver_pid, 1);
+    blip_send(&mesg, transceiver_pid, 1);
 }
 
 /* checked for type safety */
@@ -301,7 +301,7 @@ void _transceiver_get_set_pan_handler(int argc, char **argv)
     tcmd.transceivers = _TC_TYPE;
     tcmd.data = &p;
 
-    msg_t mesg;
+    blip_t mesg;
     mesg.content.ptr = (char*) &tcmd;
     if (argc > 1) {
         p = atoi(argv[1]);
@@ -311,7 +311,7 @@ void _transceiver_get_set_pan_handler(int argc, char **argv)
     else {
         mesg.type = GET_PAN;
     }
-    msg_send_receive(&mesg, &mesg, transceiver_pid);
+    blip_send_receive(&mesg, &mesg, transceiver_pid);
     if (p == -1) {
         puts("[transceiver] Error setting/getting pan");
     }
@@ -350,13 +350,13 @@ void _transceiver_set_ignore_handler(int argc, char **argv)
     tcmd.transceivers = _TC_TYPE;
     tcmd.data = &a;
 
-    msg_t mesg;
+    blip_t mesg;
     mesg.content.ptr = (char*) &tcmd;
 
     a = atoi(argv[1]);
     printf("[transceiver] trying to add address %" PRIu16 " to the ignore list \n", a);
     mesg.type = DBG_IGN;
-    msg_send_receive(&mesg, &mesg, transceiver_pid);
+    blip_send_receive(&mesg, &mesg, transceiver_pid);
 
     int16_t response = a;
     if (response == -1) {

--- a/sys/transceiver/transceiver.c
+++ b/sys/transceiver/transceiver.c
@@ -84,7 +84,7 @@ radio_packet_t transceiver_buffer[TRANSCEIVER_BUFFER_SIZE];
 uint8_t data_buffer[TRANSCEIVER_BUFFER_SIZE * PAYLOAD_SIZE];
 
 /* message buffer */
-msg_t msg_buffer[TRANSCEIVER_MSG_BUFFER_SIZE];
+blip_t msg_buffer[TRANSCEIVER_MSG_BUFFER_SIZE];
 
 uint32_t response; ///< response bytes for messages to upper layer threads
 
@@ -281,14 +281,14 @@ static void *run(void *arg)
 {
     (void) arg;
 
-    msg_t m;
+    blip_t m;
     transceiver_command_t *cmd;
 
     msg_init_queue(msg_buffer, TRANSCEIVER_MSG_BUFFER_SIZE);
 
     while (1) {
         DEBUG("transceiver: Waiting for next message\n");
-        msg_receive(&m);
+        blip_receive(&m);
         /* only makes sense for messages for upper layers */
         cmd = (transceiver_command_t *) m.content.ptr;
         DEBUG("transceiver: Transceiver: Message received, type: %02X\n", m.type);
@@ -306,37 +306,37 @@ static void *run(void *arg)
             case SND_PKT:
                 response = send_packet(cmd->transceivers, cmd->data);
                 m.content.value = response;
-                msg_reply(&m, &m);
+                blip_reply(&m, &m);
                 break;
 
             case GET_CHANNEL:
                 *((int32_t *) cmd->data) = get_channel(cmd->transceivers);
-                msg_reply(&m, &m);
+                blip_reply(&m, &m);
                 break;
 
             case SET_CHANNEL:
                 *((int32_t *) cmd->data) = set_channel(cmd->transceivers, cmd->data);
-                msg_reply(&m, &m);
+                blip_reply(&m, &m);
                 break;
 
             case GET_ADDRESS:
                 *((radio_address_t *) cmd->data) = get_address(cmd->transceivers);
-                msg_reply(&m, &m);
+                blip_reply(&m, &m);
                 break;
 
             case SET_ADDRESS:
                 *((radio_address_t *) cmd->data) = set_address(cmd->transceivers, cmd->data);
-                msg_reply(&m, &m);
+                blip_reply(&m, &m);
                 break;
 
             case GET_LONG_ADDR:
                 *((transceiver_eui64_t *) cmd->data) = get_long_addr(cmd->transceivers);
-                msg_reply(&m, &m);
+                blip_reply(&m, &m);
                 break;
 
             case SET_LONG_ADDR:
                 *((transceiver_eui64_t *) cmd->data) = set_long_addr(cmd->transceivers, cmd->data);
-                msg_reply(&m, &m);
+                blip_reply(&m, &m);
                 break;
 
             case SET_MONITOR:
@@ -353,18 +353,18 @@ static void *run(void *arg)
 
             case GET_PAN:
                 *((int32_t *) cmd->data) = get_pan(cmd->transceivers);
-                msg_reply(&m, &m);
+                blip_reply(&m, &m);
                 break;
 
             case SET_PAN:
                 *((int32_t *) cmd->data) = set_pan(cmd->transceivers, cmd->data);
-                msg_reply(&m, &m);
+                blip_reply(&m, &m);
                 break;
 
 #ifdef DBG_IGNORE
             case DBG_IGN:
                 *((int16_t *) cmd->data) = ignore_add(cmd->transceivers, cmd->data);
-                msg_reply(&m, &m);
+                blip_reply(&m, &m);
                 break;
 #endif
 
@@ -390,7 +390,7 @@ static void receive_packet(uint16_t type, uint8_t pos)
     size_t i = 0;
     transceiver_type_t t;
     rx_buffer_pos = pos;
-    msg_t m;
+    blip_t m;
 
     DEBUG("Packet received\n");
 
@@ -504,7 +504,7 @@ static void receive_packet(uint16_t type, uint8_t pos)
             m.content.ptr = (char *) &(transceiver_buffer[transceiver_buffer_pos]);
             DEBUG("transceiver: Notify thread %" PRIkernel_pid "\n", reg[i].pid);
 
-            if (msg_send(&m, reg[i].pid, false) && (m.type != ENOBUFFER)) {
+            if (blip_send(&m, reg[i].pid, false) && (m.type != ENOBUFFER)) {
                 transceiver_buffer[transceiver_buffer_pos].processing++;
             }
         }

--- a/sys/uart0/uart0.c
+++ b/sys/uart0/uart0.c
@@ -69,9 +69,9 @@ void uart0_handle_incoming(int c)
 
 void uart0_notify_thread(void)
 {
-    msg_t m;
+    blip_t m;
     m.type = 0;
-    msg_send_int(&m, uart0_handler_pid);
+    blip_send_int(&m, uart0_handler_pid);
 }
 
 int uart0_readc(void)

--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -157,10 +157,10 @@ void vtimer_callback_tick(vtimer_t *timer)
 
 static void vtimer_callback_msg(vtimer_t *timer)
 {
-    msg_t msg;
+    blip_t msg;
     msg.type = MSG_TIMER;
     msg.content.value = (unsigned int) timer->arg;
-    msg_send_int(&msg, timer->pid);
+    blip_send_int(&msg, timer->pid);
 }
 
 static void vtimer_callback_wakeup(vtimer_t *timer)
@@ -394,14 +394,14 @@ int vtimer_set_msg(vtimer_t *t, timex_t interval, kernel_pid_t pid, void *ptr)
     return 0;
 }
 
-int vtimer_msg_receive_timeout(msg_t *m, timex_t timeout) {
-    msg_t timeout_message;
+int vtimer_msg_receive_timeout(blip_t *m, timex_t timeout) {
+    blip_t timeout_message;
     timeout_message.type = MSG_TIMER;
     timeout_message.content.ptr = (char *) &timeout_message;
 
     vtimer_t t;
     vtimer_set_msg(&t, timeout, sched_active_pid, &timeout_message);
-    msg_receive(m);
+    blip_receive(m);
     if (m->type == MSG_TIMER && m->content.ptr == (char *) &timeout_message) {
         /* we hit the timeout */
         return -1;

--- a/tests/ipc_pingpong/main.c
+++ b/tests/ipc_pingpong/main.c
@@ -38,9 +38,9 @@ static void *first_thread(void *arg)
 
     puts("1st starting.");
     for (unsigned i = 0; i < LIMIT; ++i) {
-        msg_t m;
+        blip_t m;
         m.content.value = i;
-        msg_send_receive(&m, &m, pids[1]);
+        blip_send_receive(&m, &m, pids[1]);
 
         DEBUG("%u: Got msg with content %i\n", i, m.content.value);
         if (m.content.value != i + 1) {
@@ -59,20 +59,20 @@ static void *second_thread(void *arg)
 
     puts("2nd starting.");
     while (1) {
-        msg_t m1;
-        msg_receive(&m1);
+        blip_t m1;
+        blip_receive(&m1);
         DEBUG("2nd: got msg from %" PRIkernel_pid ": %i\n", m1.sender_pid, m1.content.value);
 
-        msg_t m2;
+        blip_t m2;
         m2.content.value = m1.content.value + 1;
-        msg_send_receive(&m2, &m2, pids[2]);
+        blip_send_receive(&m2, &m2, pids[2]);
         if (m2.content.value != m1.content.value) {
             puts("ERROR. 2nd");
             return NULL;
         }
 
         ++m1.content.value;
-        msg_reply(&m1, &m1);
+        blip_reply(&m1, &m1);
         if (m1.content.value == LIMIT) {
             break;
         }
@@ -88,12 +88,12 @@ static void *third_thread(void *arg)
 
     puts("3rd starting.");
     while (1) {
-        msg_t m;
-        msg_receive(&m);
+        blip_t m;
+        blip_receive(&m);
         DEBUG("3rd: got msg from %" PRIkernel_pid ": %i\n", m.sender_pid, m.content.value);
 
         --m.content.value;
-        msg_reply(&m, &m);
+        blip_reply(&m, &m);
 
         if (m.content.value == LIMIT - 1) {
             break;

--- a/tests/nativenet/main.c
+++ b/tests/nativenet/main.c
@@ -42,7 +42,7 @@
 #define RADIO_STACK_SIZE    (KERNEL_CONF_STACKSIZE_DEFAULT)
 
 char radio_stack_buffer[RADIO_STACK_SIZE];
-msg_t msg_q[RCV_BUFFER_SIZE];
+blip_t msg_q[RCV_BUFFER_SIZE];
 uint8_t snd_buffer[NATIVE_MAX_DATA_LENGTH];
 uint8_t receiving = 1;
 unsigned int last_seq = 0, missed_cnt = 0;
@@ -52,7 +52,7 @@ void *radio(void *arg)
 {
     (void) arg;
 
-    msg_t m;
+    blip_t m;
     radio_packet_t *p;
     unsigned int tmp = 0, cur_seq = 0;
 
@@ -61,7 +61,7 @@ void *radio(void *arg)
     puts("Start receiving");
 
     while (receiving) {
-        msg_receive(&m);
+        blip_receive(&m);
 
         if (m.type == PKT_PENDING) {
             p = (radio_packet_t *) m.content.ptr;
@@ -103,7 +103,7 @@ void *radio(void *arg)
 void sender(void)
 {
     unsigned int i = 0;
-    msg_t mesg;
+    blip_t mesg;
     transceiver_command_t tcmd;
     radio_packet_t p;
 
@@ -124,7 +124,7 @@ void sender(void)
         snd_buffer[1] = i & 0x00FF;
         p.data = snd_buffer;
         i++;
-        msg_send(&mesg, transceiver_pid, 1);
+        blip_send(&mesg, transceiver_pid, 1);
         hwtimer_wait(HWTIMER_TICKS(SENDING_DELAY));
     }
 }
@@ -132,7 +132,7 @@ void sender(void)
 int main(void)
 {
     int16_t a;
-    msg_t mesg;
+    blip_t mesg;
     transceiver_command_t tcmd;
 
     printf("\n\tmain(): initializing transceiver\n");
@@ -163,7 +163,7 @@ int main(void)
     mesg.type = SET_ADDRESS;
 
     printf("[nativenet] trying to set address %" PRIi16 "\n", a);
-    msg_send_receive(&mesg, &mesg, transceiver_pid);
+    blip_send_receive(&mesg, &mesg, transceiver_pid);
 
 #ifdef SENDER
     hwtimer_wait(HWTIMER_TICKS(SECOND));

--- a/tests/periph_uart_int/main.c
+++ b/tests/periph_uart_int/main.c
@@ -57,11 +57,11 @@ static ringbuffer_t tx_buf;
 
 void rx(void *ptr, char data)
 {
-    msg_t msg;
+    blip_t msg;
 
     ringbuffer_add_one(&rx_buf, data);
     if (data == '\n') {
-        msg_send(&msg, main_pid, 1);
+        blip_send(&msg, main_pid, 1);
     }
 }
 
@@ -97,7 +97,7 @@ int main(void)
 {
     char buf[128];
     int res;
-    msg_t msg;
+    blip_t msg;
 
     main_pid = thread_getpid();
 
@@ -121,7 +121,7 @@ int main(void)
                   0, uart_thread, 0, "uart");
 
     while (1) {
-        msg_receive(&msg);
+        blip_receive(&msg);
 
         printf("RECEIVED INPUT: ");
         res = ringbuffer_get(&rx_buf, buf, rx_buf.avail);

--- a/tests/queue_fairness/main.c
+++ b/tests/queue_fairness/main.c
@@ -39,10 +39,10 @@ static void *child_fun(void *arg)
     printf("Start of %s.\n", sched_active_thread->name);
 
     for (int i = 0; i < NUM_ITERATIONS; ++i) {
-        msg_t m;
+        blip_t m;
         m.type = i + 1;
         m.content.ptr = (void *) sched_active_thread->name;
-        msg_send(&m, parent_pid, true);
+        blip_send(&m, parent_pid, true);
     }
 
     printf("End of %s.\n", sched_active_thread->name);
@@ -67,8 +67,8 @@ int main(void)
 
     int last_iteration = 0;
     for (int i = 0; i < NUM_ITERATIONS * NUM_CHILDREN; ++i) {
-        msg_t m;
-        msg_receive(&m);
+        blip_t m;
+        blip_receive(&m);
         int cur_iteration = (int) m.type;
         char *child = (char *) m.content.ptr;
 

--- a/tests/thread_cooperation/main.c
+++ b/tests/thread_cooperation/main.c
@@ -39,8 +39,8 @@ void *run(void *arg)
 
     kernel_pid_t me = thread_getpid();
     printf("I am alive (%d)\n", me);
-    msg_t m;
-    msg_receive(&m);
+    blip_t m;
+    blip_receive(&m);
     printf("Thread %d has arg %" PRIu32 "\n", me, m.content.value);
 
     mutex_lock(&mtx);
@@ -48,9 +48,9 @@ void *run(void *arg)
     storage *= m.content.value;
     mutex_unlock(&mtx);
 
-    msg_t final;
+    blip_t final;
     final.content.value = me;
-    int err = msg_send(&final, main_id, 1);
+    int err = blip_send(&final, main_id, 1);
 
     if (err < 0) {
         printf("[!!!] Failed to send message from %d to main\n", me);
@@ -65,7 +65,7 @@ int main(void)
 
     printf("Problem: %d\n", PROBLEM);
 
-    msg_t args[PROBLEM];
+    blip_t args[PROBLEM];
 
     for (int i = 0; i < PROBLEM; ++i) {
         printf("Creating thread with arg %d\n", (i + 1));
@@ -79,7 +79,7 @@ int main(void)
         else {
             args[i].content.value = i + 1;
 
-            int err = msg_send(&args[i], ths[i], 1);
+            int err = blip_send(&args[i], ths[i], 1);
             if (err < 0) {
                 printf("[!!!] Sending message to thread %d failed\n", ths[i]);
             }
@@ -87,8 +87,8 @@ int main(void)
     }
 
     for (int i = 0; i < PROBLEM; ++i) {
-        msg_t msg;
-        msg_receive(&msg);
+        blip_t msg;
+        blip_receive(&msg);
         printf("Reveiced message %d from thread %" PRIu32 "\n", i, msg.content.value);
     }
 

--- a/tests/thread_msg/main.c
+++ b/tests/thread_msg/main.c
@@ -36,13 +36,13 @@ void *thread1(void *arg)
     puts("THREAD 1 start\n");
 
     for (int i = 0; i < 3; ++i) {
-        msg_t msg, reply;
+        blip_t msg, reply;
 
-        msg_receive(&msg);
+        blip_receive(&msg);
         printf("T1 recv: %" PRIu32 "(i=%d)\n", msg.content.value, i);
 
         msg.content.value = i;
-        msg_send_receive(&msg, &reply, p2);
+        blip_send_receive(&msg, &reply, p2);
         printf("T1 got reply: %" PRIu32 " (i=%d)\n", reply.content.value, i);
     }
 
@@ -56,12 +56,12 @@ void *thread2(void *arg)
     puts("THREAD 2\n");
 
     for (int i = 0;; ++i) {
-        msg_t msg, reply;
+        blip_t msg, reply;
 
-        msg_receive(&msg);
+        blip_receive(&msg);
         printf("T2 got %" PRIu32 " (i=%d)\n", msg.content.value, i);
         reply.content.value = msg.content.value;
-        msg_reply(&msg, &reply);
+        blip_reply(&msg, &reply);
     }
 
     return NULL;
@@ -73,10 +73,10 @@ void *thread3(void *arg)
     puts("THREAD 3\n");
 
     for (int i = 0;; ++i) {
-        msg_t msg;
+        blip_t msg;
         msg.content.value = i;
         printf("T3 i=%d\n", i);
-        msg_send(&msg, p1, 1);
+        blip_send(&msg, p1, 1);
     }
     return NULL;
 }

--- a/tests/thread_msg_block_w_queue/main.c
+++ b/tests/thread_msg_block_w_queue/main.c
@@ -35,14 +35,14 @@ void *thread1(void *arg)
 
     printf("THREAD %" PRIkernel_pid " start\n", p1);
 
-    msg_t msg, reply;
-    memset(&msg, 1, sizeof(msg_t));
+    blip_t msg, reply;
+    memset(&msg, 1, sizeof(blip_t));
 
     /* step 1: send asynchonously */
-    msg_send(&msg, p_main, 0);
+    blip_send(&msg, p_main, 0);
 
     /* step 2: send message, turning its status into STATUS_REPLY_BLOCKED */
-    msg_send_receive(&msg, &reply, p_main);
+    blip_send_receive(&msg, &reply, p_main);
     printf("received: %" PRIkernel_pid ", %u \n", reply.sender_pid, reply.type);
     printf("pointer: %s\n", reply.content.ptr);
 
@@ -53,10 +53,10 @@ void *thread1(void *arg)
 
 int main(void)
 {
-    msg_t msg;
+    blip_t msg;
     p_main = sched_active_pid;
 
-    msg_t msg_q[1];
+    blip_t msg_q[1];
     msg_init_queue(msg_q, 1);
 
     p1 = thread_create(t1_stack, sizeof(t1_stack), PRIORITY_MAIN - 1,
@@ -64,7 +64,7 @@ int main(void)
                        thread1, NULL, "nr1");
 
     /* step 3: receive a msg */
-    msg_receive(&msg);
+    blip_receive(&msg);
 
     printf("MAIN THREAD %" PRIkernel_pid " ALIVE!\n", p_main);
     return 0;

--- a/tests/thread_msg_block_wo_queue/main.c
+++ b/tests/thread_msg_block_wo_queue/main.c
@@ -35,14 +35,14 @@ void *thread1(void *arg)
 
     printf("THREAD %u start\n", p1);
 
-    msg_t msg, reply;
-    memset(&msg, 1, sizeof(msg_t));
+    blip_t msg, reply;
+    memset(&msg, 1, sizeof(blip_t));
 
     /* step 1: send asynchonously */
-    msg_send(&msg, p_main, 0);
+    blip_send(&msg, p_main, 0);
 
     /* step 2: send message, turning its status into STATUS_REPLY_BLOCKED */
-    msg_send_receive(&msg, &reply, p_main);
+    blip_send_receive(&msg, &reply, p_main);
     printf("received: %" PRIkernel_pid ", %u \n", reply.sender_pid, reply.type);
     printf("pointer: %s\n", reply.content.ptr);
 
@@ -53,7 +53,7 @@ void *thread1(void *arg)
 
 int main(void)
 {
-    msg_t msg;
+    blip_t msg;
     p_main = sched_active_pid;
 
     p1 = thread_create(t1_stack, sizeof(t1_stack), PRIORITY_MAIN - 1,
@@ -61,7 +61,7 @@ int main(void)
                        thread1, NULL, "nr1");
 
     /* step 3: receive a msg */
-    msg_receive(&msg);
+    blip_receive(&msg);
 
     printf("MAIN THREAD %" PRIkernel_pid " ALIVE!\n", p_main);
     return 0;

--- a/tests/thread_msg_seq/main.c
+++ b/tests/thread_msg_seq/main.c
@@ -38,11 +38,11 @@ void *sub_thread(void *arg)
     kernel_pid_t pid = thread_getpid();
     printf("THREAD %s (pid:%" PRIkernel_pid ") start\n", thread_getname(pid), pid);
 
-    msg_t msg;
+    blip_t msg;
 
     msg.content.ptr = (char*)thread_getname(pid);
 
-    msg_send(&msg, 1, 1);
+    blip_send(&msg, 1, 1);
 
     printf("THREAD %s (pid:%" PRIkernel_pid ") end.\n", thread_getname(pid), pid);
 
@@ -52,7 +52,7 @@ void *sub_thread(void *arg)
 
 int main(void)
 {
-    msg_t msg;
+    blip_t msg;
 
     p1 = thread_create(t1_stack, sizeof(t1_stack), PRIORITY_MAIN - 1,
                        CREATE_WOUT_YIELD | CREATE_STACKTEST,
@@ -66,7 +66,7 @@ int main(void)
 
     puts("THREADS CREATED\n");
     for(int i = 0; i < 3; i++) {
-        msg_receive(&msg);
+        blip_receive(&msg);
         printf("Got msg from pid %" PRIkernel_pid ": \"%s\"\n", msg.sender_pid, msg.content.ptr);
     }
 

--- a/tests/vtimer_msg/main.c
+++ b/tests/vtimer_msg/main.c
@@ -49,12 +49,12 @@ void *timer_thread(void *arg)
     /* we need a queue if the second message arrives while the first is still processed */
     /* without a queue, the message would get lost */
     /* because of the way this timer works, there can be max 1 queued message */
-    msg_t msgq[1];
+    blip_t msgq[1];
     msg_init_queue(msgq, sizeof(msgq));
 
     while (1) {
-        msg_t m;
-        msg_receive(&m);
+        blip_t m;
+        blip_receive(&m);
         struct timer_msg *tmsg = (struct timer_msg *) m.content.ptr;
         vtimer_now(&now);
         printf("now=%" PRIu32 ":%" PRIu32 " -> every %" PRIu32 ".%" PRIu32 "s: %s\n",
@@ -80,8 +80,8 @@ void *timer_thread_local(void *arg)
     printf("This is thread %" PRIkernel_pid "\n", thread_getpid());
 
     while (1) {
-        msg_t m;
-        msg_receive(&m);
+        blip_t m;
+        blip_receive(&m);
 
         struct tm t;
         vtimer_get_localtime(&t);
@@ -91,7 +91,7 @@ void *timer_thread_local(void *arg)
 
 int main(void)
 {
-    msg_t m;
+    blip_t m;
     kernel_pid_t pid = thread_create(
                   timer_stack,
                   sizeof(timer_stack),
@@ -103,11 +103,11 @@ int main(void)
 
     puts("sending 1st msg");
     m.content.ptr = (char *) &msg_a;
-    msg_send(&m, pid, false);
+    blip_send(&m, pid, false);
 
     puts("sending 2nd msg");
     m.content.ptr = (char *) &msg_b;
-    msg_send(&m, pid, false);
+    blip_send(&m, pid, false);
 
     kernel_pid_t pid2 = thread_create(
                    timer_stack_local,
@@ -122,6 +122,6 @@ int main(void)
 
     while (1) {
         vtimer_sleep(sleep);
-        msg_send(&m, pid2, 0);
+        blip_send(&m, pid2, 0);
     }
 }

--- a/tests/vtimer_msg_diff/main.c
+++ b/tests/vtimer_msg_diff/main.c
@@ -56,12 +56,12 @@ void *timer_thread(void *arg)
     (void) arg;
     printf("This is thread %" PRIkernel_pid "\n", thread_getpid());
 
-    msg_t msgq[16];
+    blip_t msgq[16];
     msg_init_queue(msgq, sizeof(msgq));
 
     while (1) {
-        msg_t m;
-        msg_receive(&m);
+        blip_t m;
+        blip_receive(&m);
         struct timer_msg *tmsg = (struct timer_msg *) m.content.ptr;
 
         vtimer_now(&now);
@@ -102,7 +102,7 @@ void *timer_thread(void *arg)
 
 int main(void)
 {
-    msg_t m;
+    blip_t m;
     kernel_pid_t pid = thread_create(
                   timer_stack,
                   sizeof(timer_stack),
@@ -115,7 +115,7 @@ int main(void)
     for (unsigned i = 0; i < sizeof(timer_msgs)/sizeof(struct timer_msg); i++) {
         printf("Sending timer msg %u...\n", i);
         m.content.ptr = (char *) &timer_msgs[i];
-        msg_send(&m, pid, false);
+        blip_send(&m, pid, false);
     }
 
     return 0;


### PR DESCRIPTION
Messages are now blips.

Rename needed for upcoming new messaging API.

Changed using the following find/sed commands:

find . ( -name '_.c' -o -name '_.h' ) -exec sed -i 's/(\s)msg_t(\s)/\1blip_t\2/g' {} +
find . ( -name '_.c' -o -name '_.h' ) -exec sed -i 's/(\s)msg_send_receive(/\1blip_send_receive(/g' {} +
find . ( -name '_.c' -o -name '_.h' ) -exec sed -i 's/(\s)msg_send(/\1blip_send(/g' {} +
find . ( -name '_.c' -o -name '_.h' ) -exec sed -i 's/(\s)msg_receive(/\1blip_receive(/g' {} +
find . ( -name '_.c' -o -name '_.h' ) -exec sed -i 's/(\s)msg_reply(/\1blip_reply(/g' {} +
find . ( -name '_.c' -o -name '_.h' ) -exec sed -i 's/(msg_t /(blip_t /g' {} +
find . ( -name '_.c' -o -name '_.h' ) -exec sed -i 's/(\s)msg_send_int(/\1blip_send_int(/g' {} +
find . ( -name '_.c' -o -name '_.h' ) -exec sed -i 's/(\s)msg_try_receive(/\1blip_try_receive(/g' {} +
find . ( -name '_.c' -o -name '_.h' ) -exec sed -i 's/} msg_t;/} blip_t;/g' {} +
find . ( -name '_.c' -o -name '_.h' ) -exec sed -i 's/`msg_t`/`blip_t`/g' {} +
find . ( -name '_.c' -o -name '_.h' ) -exec sed -i 's/^msg_t /blip_t /g' {} +
find . ( -name '_.c' -o -name '_.h' ) -exec sed -i 's/(msg_t*)/(blip_t_)/g' {} +
find . ( -name '_.c' -o -name '_.h' ) -exec sed -i 's/(msg_send(/(blip_send(/g' {} +
find . ( -name '_.c' -o -name '*.h' ) -exec sed -i 's/(msg_t)/(blip_t)/g' {} +
