### PR TITLE
core: priority_queue: simplify inheritance

### DIFF
--- a/core/include/priority_queue.h
+++ b/core/include/priority_queue.h
@@ -27,8 +27,8 @@
  */
 typedef struct priority_queue_node_t {
     struct priority_queue_node_t *next; /**< next queue node */
-    unsigned int data;                  /**< queue node data */
     uint32_t priority;                  /**< queue node priority */
+    unsigned int data;                  /**< queue node data */
 } priority_queue_node_t;
 
 /**


### PR DESCRIPTION
If `data` is last, it can get as big as someone who wants to extend the priority queue likes to.
