### PR TITLE
cpu: atmega: doxygen: blacklist upstream headers

### DIFF
--- a/cpu/atmega_common/avr-libc-extra/errno.h
+++ b/cpu/atmega_common/avr-libc-extra/errno.h
@@ -28,6 +28,8 @@
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE. */
 
+/* \cond DOXYGEN_BLACKLIST */
+
 /* $Id$ */
 
 #ifndef __ERRNO_H_
@@ -144,4 +146,5 @@ extern int errno;
 #define EINVAL 22 /* Invalid argument */
 #define EOVERFLOW 75 /* Value too large for defined data type */
 
+/* \endcond */
 #endif

--- a/cpu/atmega_common/avr-libc-extra/time.h
+++ b/cpu/atmega_common/avr-libc-extra/time.h
@@ -26,6 +26,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+/* \cond DOXYGEN_BLACKLIST */
+
 /* $Id$ */
 
 /** \file */
@@ -521,6 +523,9 @@ extern          "C" {
     };
 
     /* @} */
+
+/* /endcond */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR is a fix for #1641 
I use `\cond ... \endcond` to guard against including the doxygen stuff from avr-libc.
This way the headers only show up inside the file list.
