### PR TITLE
unittests: make: Fix unittests for branch changes

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -19,7 +19,7 @@ else ifeq ($(OUTPUT),COMPILER)
 endif
 
 ifeq (, $(filter tests-%, $(MAKECMDGOALS)))
-    UNIT_TESTS := $(shell find -mindepth 1 -maxdepth 1 -type d -name 'tests-*' -printf '%f ')
+    UNIT_TESTS := $(foreach d,$(wildcard tests-*/Makefile),$(shell dirname $(d)))
 else
     UNIT_TESTS := $(filter tests-%, $(MAKECMDGOALS))
 endif


### PR DESCRIPTION
Changing between branches in git typically leaves directories empty and
does not remove them. If you have different unittests in different
branches this leads to an error in building them, since the current
configuration expects a Makefile in all `tests-*` directory. This change
configures Make to search for a Makefile in `tests-*` rather than just
assuming that there is one.
