### PR TITLE
tests: don't build test/libfixmath on Travis CI

### DIFF
--- a/tests/libfixmath/Makefile
+++ b/tests/libfixmath/Makefile
@@ -3,4 +3,8 @@ include ../Makefile.tests_common
 
 USEPKG += libfixmath
 
+ifeq ($(TRAVIS),true)
+  BOARD_WHITELIST := -
+endif
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/libfixmath_unittests/Makefile
+++ b/tests/libfixmath_unittests/Makefile
@@ -13,4 +13,8 @@ BOARD_INSUFFICIENT_RAM += redbee-econotag stm32f0discovery
 
 USEMODULE += libfixmath-unittests
 
+ifeq ($(TRAVIS),true)
+  BOARD_WHITELIST := -
+endif
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
Very often the build unexplainably hangs.
