### PR TITLE
lint: fix array indices being used before limit check

### DIFF
--- a/boards/avsextrem/drivers/avsextrem-smb380.c
+++ b/boards/avsextrem/drivers/avsextrem-smb380.c
@@ -305,8 +305,8 @@ uint8_t getRingReadPointerforCurrentThread(void)
 {
     uint8_t pointerNo = 0;
 
-    while ((PointerList[pointerNo] != sched_active_pid) &&
-           (pointerNo < SMB380_RING_BUFF_MAX_THREADS)) {
+    while ((pointerNo < SMB380_RING_BUFF_MAX_THREADS) &&
+           (PointerList[pointerNo] != sched_active_pid)) {
         pointerNo++;
     }
 
@@ -318,8 +318,8 @@ uint8_t initRingReadPointerforCurrentThread(void)
     //TODO: make it Threadsafe
     uint8_t pointerNo = 0;
 
-    while ((PointerList[pointerNo] > 0) &&
-           (pointerNo < SMB380_RING_BUFF_MAX_THREADS)) {
+    while ((pointerNo < SMB380_RING_BUFF_MAX_THREADS) &&
+           (PointerList[pointerNo] > 0)) {
         pointerNo++;
     }
 
@@ -564,8 +564,8 @@ void wakeUpRegisteredProcesses(void)
     //wake up waiting processes
     wakeupmessage.type = MSG_TYPE_SMB380_WAKEUP;
 
-    while ((PointerList[pointerNo] > 0) &&
-           (pointerNo < SMB380_RING_BUFF_MAX_THREADS)) {
+    while ((pointerNo < SMB380_RING_BUFF_MAX_THREADS) &&
+           (PointerList[pointerNo] > 0)) {
         msg_send(&wakeupmessage, PointerList[pointerNo], false);
         pointerNo++;
     }

--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -766,7 +766,7 @@ uint8_t sixlowpan_lowpan_register(kernel_pid_t pid)
 {
     uint8_t i;
 
-    for (i = 0; ((sixlowpan_reg[i] != pid) && (i < SIXLOWPAN_MAX_REGISTERED) &&
+    for (i = 0; (((i < SIXLOWPAN_MAX_REGISTERED) && sixlowpan_reg[i] != pid) &&
                  (sixlowpan_reg[i] != 0)); i++) {
         ;
     }


### PR DESCRIPTION
Clean up:
cppcheck found some occurrences where arrays were accessed at a given index while the check of the bounds was done afterwards.
This PR fixes this by switching access and check such that the check occurs before the access.
