### PR TITLE
lint: _sbrk_r: change parameter type from size_t to ptrdiff_t

### DIFF
--- a/cpu/lpc1768/syscalls.c
+++ b/cpu/lpc1768/syscalls.c
@@ -73,7 +73,7 @@ void __assert(const char *file, int line, const char *failedexpr)
     __assert_func(file, line, "?", failedexpr);
 }
 /*-----------------------------------------------------------------------------------*/
-caddr_t _sbrk_r(struct _reent *r, size_t incr)
+caddr_t _sbrk_r(struct _reent *r, ptrdiff_t incr)
 {
     if(incr < 0)
     {

--- a/cpu/lpc_common/lpc_syscalls.c
+++ b/cpu/lpc_common/lpc_syscalls.c
@@ -44,7 +44,7 @@ void heap_stats(void)
 }
 
 /*-----------------------------------------------------------------------------------*/
-caddr_t _sbrk_r(struct _reent *r, size_t incr)
+caddr_t _sbrk_r(struct _reent *r, ptrdiff_t incr)
 {
     uint32_t cpsr = disableIRQ();
 

--- a/cpu/mc1322x/mc1322x_syscalls.c
+++ b/cpu/mc1322x/mc1322x_syscalls.c
@@ -24,7 +24,7 @@ static const caddr_t heap_max = (caddr_t)&__heap_end;
 static const caddr_t heap_start = (caddr_t)&__heap_start;
 
 /*-----------------------------------------------------------------------------------*/
-caddr_t _sbrk_r(struct _reent *r, size_t incr)
+caddr_t _sbrk_r(struct _reent *r, ptrdiff_t incr)
 {
     uint32_t cpsr = disableIRQ();
 

--- a/cpu/nrf51822/syscalls.c
+++ b/cpu/nrf51822/syscalls.c
@@ -84,7 +84,7 @@ void _exit(int n)
  *
  * @return [description]
  */
-caddr_t _sbrk_r(struct _reent *r, size_t incr)
+caddr_t _sbrk_r(struct _reent *r, ptrdiff_t incr)
 {
     unsigned int state = disableIRQ();
     caddr_t res = heap_top;

--- a/cpu/sam3x8e/syscalls.c
+++ b/cpu/sam3x8e/syscalls.c
@@ -84,7 +84,7 @@ void _exit(int n)
  *
  * @return [description]
  */
-caddr_t _sbrk_r(struct _reent *r, size_t incr)
+caddr_t _sbrk_r(struct _reent *r, ptrdiff_t incr)
 {
     unsigned int state = disableIRQ();
     caddr_t res = heap_top;

--- a/cpu/stm32f0/syscalls.c
+++ b/cpu/stm32f0/syscalls.c
@@ -84,7 +84,7 @@ void _exit(int n)
  *
  * @return [description]
  */
-caddr_t _sbrk_r(struct _reent *r, size_t incr)
+caddr_t _sbrk_r(struct _reent *r, ptrdiff_t incr)
 {
     unsigned int state = disableIRQ();
     caddr_t res = heap_top;

--- a/cpu/stm32f1/syscalls.c
+++ b/cpu/stm32f1/syscalls.c
@@ -87,7 +87,7 @@ void _exit(int n)
  *
  * @return [description]
  */
-caddr_t _sbrk_r(struct _reent *r, size_t incr)
+caddr_t _sbrk_r(struct _reent *r, ptrdiff_t incr)
 {
     unsigned int state = disableIRQ();
     caddr_t res = heap_top;

--- a/cpu/stm32f3/syscalls.c
+++ b/cpu/stm32f3/syscalls.c
@@ -106,7 +106,7 @@ void _exit(int n)
  *
  * @return [description]
  */
-caddr_t _sbrk_r(struct _reent *r, size_t incr)
+caddr_t _sbrk_r(struct _reent *r, ptrdiff_t incr)
 {
     unsigned int state = disableIRQ();
     caddr_t res = heap_top;

--- a/cpu/stm32f4/syscalls.c
+++ b/cpu/stm32f4/syscalls.c
@@ -83,7 +83,7 @@ void _exit(int n)
  *
  * @return [description]
  */
-caddr_t _sbrk_r(struct _reent *r, size_t incr)
+caddr_t _sbrk_r(struct _reent *r, ptrdiff_t incr)
 {
     unsigned int state = disableIRQ();
     caddr_t res = heap_top;


### PR DESCRIPTION
`incr` is of type `size_t` which is essentially a `unsigned int` type (according to ISO 1999 C it's an unsigned integer of at least 16 Bit). Since unsigned integers can't be smaller than zero the check is unnecessary (and will hopefully gets optimized away by the compiler anyways).
~~This PR removes the unnecessary check to silence `cppcheck`.~~
This PR changes the type of `incr` to `ptrdiff_t` (as suggested by @Kijewski ).
Added: changed this for `_sbrk_r` implementations for other platforms too.
