### PR TITLE
doc: tailor CMSIS doxygen for license checker

### DIFF
--- a/cpu/cortex-m0_common/include/core_cmFunc.h
+++ b/cpu/cortex-m0_common/include/core_cmFunc.h
@@ -12,7 +12,6 @@
  * processor based microcontrollers.  This file can be freely distributed 
  * within development tools that are supporting such ARM based processors. 
  *
- * @par
  * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
  * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.

--- a/cpu/cortex-m0_common/include/core_cmInstr.h
+++ b/cpu/cortex-m0_common/include/core_cmInstr.h
@@ -12,7 +12,6 @@
  * processor based microcontrollers.  This file can be freely distributed 
  * within development tools that are supporting such ARM based processors. 
  *
- * @par
  * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
  * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.

--- a/cpu/cortex-m3_common/include/core_cm3.h
+++ b/cpu/cortex-m3_common/include/core_cm3.h
@@ -12,7 +12,6 @@
  * processor based microcontrollers.  This file can be freely distributed
  * within development tools that are supporting such ARM based processors.
  *
- * @par
  * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
  * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.

--- a/cpu/cortex-m3_common/include/core_cmFunc.h
+++ b/cpu/cortex-m3_common/include/core_cmFunc.h
@@ -12,7 +12,6 @@
  * processor based microcontrollers.  This file can be freely distributed
  * within development tools that are supporting such ARM based processors.
  *
- * @par
  * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
  * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.

--- a/cpu/cortex-m3_common/include/core_cmInstr.h
+++ b/cpu/cortex-m3_common/include/core_cmInstr.h
@@ -12,7 +12,6 @@
  * processor based microcontrollers.  This file can be freely distributed
  * within development tools that are supporting such ARM based processors.
  *
- * @par
  * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
  * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.

--- a/cpu/cortex-m4_common/include/core_cmFunc.h
+++ b/cpu/cortex-m4_common/include/core_cmFunc.h
@@ -12,7 +12,6 @@
  * processor based microcontrollers.  This file can be freely distributed 
  * within development tools that are supporting such ARM based processors. 
  *
- * @par
  * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
  * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.

--- a/cpu/cortex-m4_common/include/core_cmInstr.h
+++ b/cpu/cortex-m4_common/include/core_cmInstr.h
@@ -12,7 +12,6 @@
  * processor based microcontrollers.  This file can be freely distributed 
  * within development tools that are supporting such ARM based processors. 
  *
- * @par
  * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
  * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.

--- a/cpu/lpc1768/include/LPC17xx.h
+++ b/cpu/lpc1768/include/LPC17xx.h
@@ -14,7 +14,6 @@
  * processor based microcontrollers.  This file can be freely distributed
  * within development tools that are supporting such ARM based processors.
  *
- * @par
  * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
  * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.

--- a/cpu/lpc1768/include/core_cm3.h
+++ b/cpu/lpc1768/include/core_cm3.h
@@ -14,7 +14,6 @@
  * processor based microcontrollers.  This file can be freely distributed
  * within development tools that are supporting such ARM based processors.
  *
- * @par
  * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
  * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.

--- a/cpu/lpc1768/include/core_cmFunc.h
+++ b/cpu/lpc1768/include/core_cmFunc.h
@@ -12,7 +12,6 @@
  * processor based microcontrollers.  This file can be freely distributed
  * within development tools that are supporting such ARM based processors.
  *
- * @par
  * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
  * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.

--- a/cpu/lpc1768/include/core_cmInstr.h
+++ b/cpu/lpc1768/include/core_cmInstr.h
@@ -12,7 +12,6 @@
  * processor based microcontrollers.  This file can be freely distributed
  * within development tools that are supporting such ARM based processors.
  *
- * @par
  * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
  * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.


### PR DESCRIPTION
Remove '@par' within the license header to allow the existing regular
expression to match it.
