### PR TITLE
drivers/at86rf231: handle channel out of range more conveniently

### DIFF
--- a/drivers/at86rf231/at86rf231.c
+++ b/drivers/at86rf231/at86rf231.c
@@ -173,14 +173,17 @@ uint16_t at86rf231_get_pan(void)
     return radio_pan;
 }
 
-uint8_t at86rf231_set_channel(uint8_t channel)
+int8_t at86rf231_set_channel(uint8_t channel)
 {
     uint8_t cca_state;
     radio_channel = channel;
 
     if (channel < RF86RF231_MIN_CHANNEL ||
         channel > RF86RF231_MAX_CHANNEL) {
-        radio_channel = RF86RF231_MAX_CHANNEL;
+#if DEVELHELP
+        puts("[at86rf231] channel out of range!");
+#endif
+        return -1;
     }
 
     cca_state = at86rf231_reg_read(AT86RF231_REG__PHY_CC_CCA) & ~AT86RF231_PHY_CC_CCA_MASK__CHANNEL;

--- a/drivers/include/at86rf231.h
+++ b/drivers/include/at86rf231.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 #ifndef AT86RF231_H_
 #define AT86RF231_H_
 
@@ -52,7 +60,7 @@ void at86rf231_rx_irq(void);
 
 int16_t at86rf231_send(at86rf231_packet_t *packet);
 
-uint8_t at86rf231_set_channel(uint8_t channel);
+int8_t at86rf231_set_channel(uint8_t channel);
 uint8_t at86rf231_get_channel(void);
 
 uint16_t at86rf231_set_pan(uint16_t pan);


### PR DESCRIPTION
Changes default behaviour from setting the highest possible channel to returning an error and print a `DEVELHELP` message when applicable. 
Fixes #1670 and change has to be mentioned in the [documentation](https://github.com/RIOT-OS/RIOT/wiki/Board%3A-IoT-LAB_M3#note-on-at86rf231-radio-driver).
