### PR TITLE
doc: add license headers to some .h files

### DIFF
--- a/boards/native/include/board_internal.h
+++ b/boards/native/include/board_internal.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2013, 2014 Ludwig Ortmann
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 #ifdef MODULE_UART0
 #include <sys/select.h>
 void _native_handle_uart0_input(void);

--- a/core/include/kernel_types.h
+++ b/core/include/kernel_types.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2014 Oliver Hahm
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 #ifndef KERNEL_TYPES_H
 #define KERNEL_TYPES_H
 

--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2013, 2014 Ludwig Ortmann
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 /**
  * Native CPU internal declarations
  */

--- a/sys/include/auto_init.h
+++ b/sys/include/auto_init.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (C) 2010 Freie Universität Berlin
+ * Copyright (C) 2010 Kaspar Schleiser
+ * Copyright (C) 2013 INRIA
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 
 /**
  * @defgroup    sys_autoinit Auto-init

--- a/sys/include/bloom.h
+++ b/sys/include/bloom.h
@@ -1,4 +1,12 @@
 /*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/*
  * bloom.c
  *
  * Bloom filters

--- a/sys/include/board_uart0.h
+++ b/sys/include/board_uart0.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2010 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 
 /**
  * @defgroup    sys_uart0 UART0

--- a/sys/include/chardev_thread.h
+++ b/sys/include/chardev_thread.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2010 Kaspar Schleiser
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 
 /**
  * @defgroup    sys_chardevthread Chardev Thread

--- a/sys/include/hash_string.h
+++ b/sys/include/hash_string.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2010 Kaspar Schleiser
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 #ifndef __HASH_STRING_H
 #define __HASH_STRING_H
 

--- a/sys/include/ping.h
+++ b/sys/include/ping.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2010 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 
 /**
  * @defgroup    sys_ping Ping

--- a/sys/include/ps.h
+++ b/sys/include/ps.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2010 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 
 /**
  * @defgroup    sys_ps PS

--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2013 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 
 /**
  * @defgroup    sys_random Random

--- a/sys/include/shell_commands.h
+++ b/sys/include/shell_commands.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2010 Kaspar Schleiser
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 #ifndef __SHELL_COMMANDS_H
 #define __SHELL_COMMANDS_H
 

--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2010 Kaspar Schleiser
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 
 /**
  * @defgroup    sys_timex Timex

--- a/sys/include/tm.h
+++ b/sys/include/tm.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2014 René Kijewski
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 /**
  * @addtogroup  sys_timex
  * @{

--- a/sys/include/transceiver.h
+++ b/sys/include/transceiver.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2010 - 2014 Oliver Hahm
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 /**
  * @defgroup    sys_transceiver Transceiver
  * @ingroup     sys


### PR DESCRIPTION
This covers:
- the last missing headers in `native` and `core`
- all in `sys/include`

~~@mehlis Did you really write that bloom header?~~ moved to https://github.com/RIOT-OS/RIOT/issues/1682
