### PR TITLE
sys: use typedef for `struct bloom_t`

### DIFF
--- a/sys/bloom/bloom.c
+++ b/sys/bloom/bloom.c
@@ -23,14 +23,14 @@
 #define GETBIT(a,n) (a[n/CHAR_BIT] &  (1<<(n%CHAR_BIT)))
 #define ROUND(size) ((size + CHAR_BIT - 1) / CHAR_BIT)
 
-struct bloom_t *bloom_new(size_t size, size_t num_hashes, ...)
+bloom_t *bloom_new(size_t size, size_t num_hashes, ...)
 {
-    struct bloom_t *bloom;
+    bloom_t *bloom;
     va_list hashes;
     size_t n;
 
     /* Allocate Bloom filter container */
-    if (!(bloom = malloc(sizeof(struct bloom_t)))) {
+    if (!(bloom = malloc(sizeof(bloom_t)))) {
         return NULL;
     }
 
@@ -66,14 +66,14 @@ struct bloom_t *bloom_new(size_t size, size_t num_hashes, ...)
     return bloom;
 }
 
-void bloom_del(struct bloom_t *bloom)
+void bloom_del(bloom_t *bloom)
 {
     free(bloom->a);
     free(bloom->hash);
     free(bloom);
 }
 
-void bloom_add(struct bloom_t *bloom, const uint8_t *buf, size_t len)
+void bloom_add(bloom_t *bloom, const uint8_t *buf, size_t len)
 {
     for (size_t n = 0; n < bloom->k; n++) {
         uint32_t hash = bloom->hash[n](buf, len);
@@ -81,7 +81,7 @@ void bloom_add(struct bloom_t *bloom, const uint8_t *buf, size_t len)
     }
 }
 
-bool bloom_check(struct bloom_t *bloom, const uint8_t *buf, size_t len)
+bool bloom_check(bloom_t *bloom, const uint8_t *buf, size_t len)
 {
     for (size_t n = 0; n < bloom->k; n++) {
         uint32_t hash = bloom->hash[n](buf, len);

--- a/sys/include/bloom.h
+++ b/sys/include/bloom.h
@@ -125,14 +125,14 @@
 typedef uint32_t (*hashfp_t)(const uint8_t *, int len);
 
 /**
- * struct bloom_t bloom filter object
+ * bloom_t bloom filter object
  */
-struct bloom_t {
+typedef struct {
     size_t m;
     size_t k;
     uint8_t *a;
     hashfp_t *hash;
-};
+} bloom_t;
 
 /**
  * bloom_new  Allocate and return a pointer to a new Bloom filter.
@@ -146,7 +146,7 @@ struct bloom_t {
  * @return An allocated bloom filter
  *
  */
-struct bloom_t *bloom_new(size_t size, size_t num_hashes, ...);
+bloom_t *bloom_new(size_t size, size_t num_hashes, ...);
 
 /**
  * bloom_del  Delete a Bloom filter.
@@ -155,7 +155,7 @@ struct bloom_t *bloom_new(size_t size, size_t num_hashes, ...);
  * @return nothing
  *
  */
-void bloom_del(struct bloom_t *bloom);
+void bloom_del(bloom_t *bloom);
 
 /**
  * bloom_add  Add a string to a Bloom filter.
@@ -168,7 +168,7 @@ void bloom_del(struct bloom_t *bloom);
  * @return       nothing
  *
  */
-void bloom_add(struct bloom_t *bloom, const uint8_t *buf, size_t len);
+void bloom_add(bloom_t *bloom, const uint8_t *buf, size_t len);
 
 /**
  * bloom_check  Determine if a string is in the Bloom filter.
@@ -205,7 +205,7 @@ void bloom_add(struct bloom_t *bloom, const uint8_t *buf, size_t len);
  * @return       true if string is may be in the filter
  *
  */
-bool bloom_check(struct bloom_t *bloom, const uint8_t *buf, size_t len);
+bool bloom_check(bloom_t *bloom, const uint8_t *buf, size_t len);
 
 /** @} */
 #endif /* _BLOOM_FILTER_H */

--- a/tests/bloom/main.c
+++ b/tests/bloom/main.c
@@ -28,7 +28,7 @@
 
 int main(void)
 {
-    struct bloom_t *bloom = bloom_new(1 << 7, 6, fnv_hash, sax_hash, sdbm_hash,
+    bloom_t *bloom = bloom_new(1 << 7, 6, fnv_hash, sax_hash, sdbm_hash,
                                       djb2_hash, kr_hash, dek_hash, rotating_hash, one_at_a_time_hash);
 
     printf("Testing Bloom filter.\n\n");

--- a/tests/bloom_bytes/main.c
+++ b/tests/bloom_bytes/main.c
@@ -50,7 +50,7 @@ int main(void)
 {
     hwtimer_init();
 
-    struct bloom_t *bloom = bloom_new(1 << 12, 8, fnv_hash, sax_hash, sdbm_hash,
+    bloom_t *bloom = bloom_new(1 << 12, 8, fnv_hash, sax_hash, sdbm_hash,
                                       djb2_hash, kr_hash, dek_hash, rotating_hash, one_at_a_time_hash);
 
     printf("Testing Bloom filter.\n\n");


### PR DESCRIPTION
`bloom_t` is defined as a struct.
`_t` can mislead the user to think of bloom_t
as a typedef (see our coding conventions) instead of a struct.
Thus, I modified `struct bloom_t` to be a _typedefed_ struct.

Another solution would be to rename bloom_t to sth. like bloom_s
everywhere and use `struct bloom_s` instead of `bloom_t`.
