### PR TITLE
board/yunjia-nrf51822: adjusted openocd.cfg

### DIFF
--- a/boards/yunjia-nrf51822/dist/openocd.cfg
+++ b/boards/yunjia-nrf51822/dist/openocd.cfg
@@ -1,8 +1,10 @@
 # nRF51822 Target
 source [find interface/stlink-v2.cfg]
 
+transport select hla_swd
+
 set WORKAREASIZE 0x4000
-source [find target/nrf51_stlink.tcl]
+source [find target/nrf51.cfg]
 
 # use hardware reset, connect under reset
 #reset_config srst_only srst_nogate


### PR DESCRIPTION
The newest upstream of OpenOCD contains some changes, so the existing OpenOCD config did not work anymore. This should fix it.
