### PR TITLE
iot-lab_M3: fix numof uart

### DIFF
--- a/boards/iot-lab_M3/include/periph_conf.h
+++ b/boards/iot-lab_M3/include/periph_conf.h
@@ -50,7 +50,7 @@
 /**
  * @brief UART configuration
  */
-#define UART_NUMOF          (2U)
+#define UART_NUMOF          (1U)
 #define UART_0_EN           1
 #define UART_1_EN           0
 #define UART_IRQ_PRIO       1


### PR DESCRIPTION
NUMOF is the sum of the activated elements: 1 + 0 = 1
