### PR TITLE
lint: limit maximum length of input via scanf

### DIFF
--- a/boards/msba2-common/tools/src/download.c
+++ b/boards/msba2-common/tools/src/download.c
@@ -348,7 +348,7 @@ static void download_main(int event)
             case SYNC_3:
                 switch (event) {
                     case BEGIN:
-                        if (sscanf(crystal, "%lf", &xtal) != 1) {
+                        if (sscanf(crystal, "%20lf", &xtal) != 1) {
                             printf("\r\n");
                             download_cancel("Crystal frequency is required for 3rd step of baud rate sync");
                             return;

--- a/boards/redbee-econotag/tools/ftditools/bbmc.c
+++ b/boards/redbee-econotag/tools/ftditools/bbmc.c
@@ -217,27 +217,27 @@ int main(int argc, char **argv)
                 /* process long opts */
             case 0:
                 if (strcmp(long_options[option_index].name, "interface") == 0) {
-                    sscanf(optarg, "%i", &interface);
+                    sscanf(optarg, "%11i", &interface);
                 }
 
                 if (strcmp(long_options[option_index].name, "dir") == 0) {
-                    sscanf(optarg, "%i", &dir);
+                    sscanf(optarg, "%11i", &dir);
                 }
 
                 if (strcmp(long_options[option_index].name, "reset_release") == 0) {
-                    sscanf(optarg, "%i", &reset_release);
+                    sscanf(optarg, "%11i", &reset_release);
                 }
 
                 if (strcmp(long_options[option_index].name, "reset_set") == 0) {
-                    sscanf(optarg, "%i", &reset_set);
+                    sscanf(optarg, "%11i", &reset_set);
                 }
 
                 if (strcmp(long_options[option_index].name, "vref2_normal") == 0) {
-                    sscanf(optarg, "%i", &vref2_normal);
+                    sscanf(optarg, "%11i", &vref2_normal);
                 }
 
                 if (strcmp(long_options[option_index].name, "vref2_erase") == 0) {
-                    sscanf(optarg, "%i", &vref2_erase);
+                    sscanf(optarg, "%11i", &vref2_erase);
                 }
 
                 break;
@@ -251,11 +251,11 @@ int main(int argc, char **argv)
                 break;
 
             case 'v':
-                sscanf(optarg, "%i", &vendid);
+                sscanf(optarg, "%11i", &vendid);
                 break;
 
             case 'p':
-                sscanf(optarg, "%i", &prodid);
+                sscanf(optarg, "%11i", &prodid);
                 break;
 
             default:
@@ -476,7 +476,7 @@ int print_and_prompt(struct ftdi_device_list *devlist)
             input[last] = '\0';
         }
 
-        sscanf(s, "%i", &sel);
+        sscanf(s, "%11i", &sel);
     }
 
     return sel;

--- a/dist/tools/linux-border_router/main.c
+++ b/dist/tools/linux-border_router/main.c
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
             return -1;
         }
 
-        sscanf(argv[8], "%f", &interval);
+        sscanf(argv[8], "%20f", &interval);
         sprintf(ping_addr, "abcd::%s/64", argv[4]);
 
         start_test(ping_addr, argv[5], argv[6], atoi(argv[7]), interval);

--- a/sys/shell/commands/sc_rtc.c
+++ b/sys/shell/commands/sc_rtc.c
@@ -35,7 +35,7 @@ static void _settime_handler(char **argv)
     do {
         short i1, i2, i3;
 
-        int res = sscanf(argv[1], "%hd-%hd-%hd", &i1, &i2, &i3);
+        int res = sscanf(argv[1], "%6hd-%6hd-%6hd", &i1, &i2, &i3);
         if (res != 3) {
             break;
         }
@@ -45,7 +45,7 @@ static void _settime_handler(char **argv)
         now.tm_mon = i2 - 1;
         now.tm_mday = i3;
 
-        res = sscanf(argv[2], "%hd:%hd:%hd", &i1, &i2, &i3);
+        res = sscanf(argv[2], "%6hd:%6hd:%6hd", &i1, &i2, &i3);
         if (res != 3) {
             break;
         }


### PR DESCRIPTION
This PR limits the maximum length of input via `scanf`-related functions to get rid of `cppcheck` warnings.
Rationale for the actual lengths is:
20 characters for `double` and `float` (double has about 15-17 decimal digits with full precision).
11 characters for `int` (10 digits for 32 Bit ints + for sign).
6 characters for `short` (5 digits + sign).
