### PR TITLE
Travis: enable apt caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
 
+cache: apt
+
 env:
     - NPROC_MAX=8
 


### PR DESCRIPTION
This should speed up the installation process a bit.

Compare http://docs.travis-ci.com/user/caching/

Partial fix for https://github.com/RIOT-OS/RIOT/issues/1636
