### PR TITLE
Travis: cache downloads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: c
 
-cache: apt
+cache:
+    apt: true
+    directories:
+        - toolchain
+        - pkg/libfixmath/checkout
+        - pkg/tlsf/tlsf-3.0.zip
 
 env:
     - NPROC_MAX=8


### PR DESCRIPTION
I am not sure if this works.

It should reduce the impact when downloads.riot-os.org or another host is down.
