### PR TITLE
pyterm: make pin toggling optional

### DIFF
--- a/boards/msba2-common/Makefile.include
+++ b/boards/msba2-common/Makefile.include
@@ -20,7 +20,7 @@ ifeq ($(strip $(PORT)),)
 	export PORT = /dev/ttyUSB0
 endif
 export FFLAGS = $(PORT) $(HEXFILE)
-export TERMFLAGS += -p "$(PORT)"
+export TERMFLAGS += -tg -p "$(PORT)"
 include $(RIOTBOARD)/msba2-common/Makefile.dep
 
 export INCLUDES += -I$(RIOTBOARD)/msba2-common/include -I$(RIOTBOARD)/msba2-common/drivers/include

--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -74,7 +74,7 @@ class SerCmd(cmd.Cmd):
     port.
     """
 
-    def __init__(self, port=None, baudrate=None, tcp_serial=None,
+    def __init__(self, port=None, baudrate=None, toggle=None, tcp_serial=None,
                  confdir=None, conffile=None, host=None, run_name=None, 
                  log_dir_name=None):
         """Constructor.
@@ -94,6 +94,7 @@ class SerCmd(cmd.Cmd):
         cmd.Cmd.__init__(self)
         self.port = port
         self.baudrate = baudrate
+        self.toggle = toggle
         self.tcp_serial = tcp_serial
         self.configdir = confdir
         self.configfile = conffile
@@ -551,8 +552,9 @@ class SerCmd(cmd.Cmd):
     def serial_connect(self):
         self.ser = serial.Serial(port=self.port, dsrdtr=0, rtscts=0)
         self.ser.baudrate = self.baudrate
-        self.ser.setDTR(0)
-        self.ser.setRTS(0)
+        if self.toggle:
+            self.ser.setDTR(0)
+            self.ser.setRTS(0)
 
     def reader(self):
         """Serial or TCP reader.
@@ -655,6 +657,10 @@ if __name__ == "__main__":
             help="Specifies baudrate for the serial port, default is %s"
                  % defaultbaud,
             default=defaultbaud)
+    parser.add_argument("-tg", "--toggle",
+            action="store_true",
+            help="toggles the DTR and RTS pin of the serial line when "
+                 "connecting, default is not toggling the pins")
     parser.add_argument('-d', '--directory',
             help="Specify the Pyterm directory, default is %s"
                  % defaultdir,
@@ -678,7 +684,7 @@ if __name__ == "__main__":
                  default=defaultdir)
     args = parser.parse_args()
 
-    myshell = SerCmd(args.port, args.baudrate, args.tcp_serial,
+    myshell = SerCmd(args.port, args.baudrate, args.toggle, args.tcp_serial,
                      args.directory, args.config, args.host, args.run_name,
                      args.log_dir_name)
     myshell.prompt = ''


### PR DESCRIPTION
For the MSB-A2 the DTR and RTS pins have to be pulled down over the
serial interface in the beginning. (This is required because the Linux
usbserial driver pulls them up when initializing the device which set
the node into reset mode.) Since this is not necessary on most other
platforms and might even cause problems, it's better to make this an
optional behavior of pyterm.
