### PR TITLE
allow HWTIMER_SPEED > 1000000

### DIFF
--- a/core/include/hwtimer.h
+++ b/core/include/hwtimer.h
@@ -82,14 +82,22 @@ per second for the current architecture."
  * @param[in]   us number of microseconds
  * @return      kernel timer ticks
  */
-#define HWTIMER_TICKS(us) ((us) / (1000000L / HWTIMER_SPEED))
+#if HWTIMER_SPEED > 1000000L
+#define HWTIMER_TICKS(us)        ((us) * (HWTIMER_SPEED / 1000000L))
+#else
+#define HWTIMER_TICKS(us)        ((us) / (1000000L / HWTIMER_SPEED))
+#endif
 
 /**
  * @brief       Convert ticks to microseconds
  * @param[in]   ticks   number of ticks
  * @return      microseconds
  */
-#define HWTIMER_TICKS_TO_US(ticks) ((ticks) * (1000000L/HWTIMER_SPEED))
+#if HWTIMER_SPEED > 1000000L
+#define HWTIMER_TICKS_TO_US(ticks)        ((ticks) / (HWTIMER_SPEED / 1000000L))
+#else
+#define HWTIMER_TICKS_TO_US(ticks)        ((ticks) * (1000000L / HWTIMER_SPEED))
+#endif
 
 /**
  * @brief   Maximum hwtimer tick count (before overflow)
@@ -103,7 +111,11 @@ number of ticks countable on the current architecture."
 /**
  * @brief   microseconds before hwtimer overflow
  */
-#define HWTIMER_OVERFLOW_MICROS() (1000000L / HWTIMER_SPEED * HWTIMER_MAXTICKS)
+#if HWTIMER_SPEED > 1000000L
+#define HWTIMER_OVERFLOW_MICROS()        (HWTIMER_MAXTICKS / HWTIMER_SPEED * 1000000L)
+#else
+#define HWTIMER_OVERFLOW_MICROS()        (1000000L / HWTIMER_SPEED * HWTIMER_MAXTICKS)
+#endif
 
 typedef uint32_t timer_tick_t; /**< data type for hwtimer ticks */
 


### PR DESCRIPTION
If HWTIMER_SPEED is greater than 1000000, division will result in 0 in `HWTIMER_TICKS`, `HWTIMER_TICKS_TO_US`

The proper solution would probably be using floating point defines to begin with, or at least casting to float for the division, but is this guaranteed to be evaluated by the compiler? 
