### PR TITLE
cpu/stm32f1: added missing spi function

### DIFF
--- a/cpu/stm32f1/periph/spi.c
+++ b/cpu/stm32f1/periph/spi.c
@@ -81,7 +81,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
 int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char))
 {
     /* TODO */
-    return 0;
+    return -1;
 }
 
 int spi_transfer_byte(spi_t dev, char out, char *in)
@@ -159,6 +159,11 @@ int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int 
 {
     spi_transfer_byte(dev, reg, NULL);
     return spi_transfer_bytes(dev, out, in, length);
+}
+
+void spi_transmission_begin(spi_t dev, char reset_val)
+{
+    /* slave mode not implemented, yet */
 }
 
 void spi_poweron(spi_t dev)


### PR DESCRIPTION
this fixes an issue with the `iot-lab_m3` and the newly merged `tests/periph_spi` application.
