### PR TITLE
boards: added LED macro for pca1000 & yunjia-nrf

### DIFF
--- a/boards/pca10005/board.c
+++ b/boards/pca10005/board.c
@@ -15,22 +15,19 @@
  *
  * @author      Christian Kühling <kuehling@zedat.fu-berlin.de>
  * @author      Timo Ziegler <timo.ziegler@fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
  * @}
  */
 
-#include <stdio.h>
-#include <string.h>
 #include "board.h"
 #include "cpu.h"
-#include "nrf51.h"
-#include "periph/uart.h"
-#include "periph/gpio.h"
-
-extern void SystemInit(void);
 
 void board_init(void)
 {
+    /* setup led(s) for debugging */
+    NRF_GPIO->PIN_CNF[LED_RED_PIN] = GPIO_PIN_CNF_DIR_Output;
+
     /* initialize the CPU */
     cpu_init();
 }

--- a/boards/pca10005/include/board.h
+++ b/boards/pca10005/include/board.h
@@ -46,9 +46,11 @@
  * @name Macros for controlling the on-board LEDs.
  * @{
  */
-#define LED_RED_ON          /* not available */
-#define LED_RED_OFF         /* not available */
-#define LED_RED_TOGGLE      /* not available */
+#define LED_RED_PIN         1
+
+#define LED_RED_ON          (NRF_GPIO->OUTSET = (1 << LED_RED_PIN))
+#define LED_RED_OFF         (NRF_GPIO->OUTCLR = (1 << LED_RED_PIN))
+#define LED_RED_TOGGLE      (NRF_GPIO->OUT ^= (1 << LED_RED_PIN))
 #define LED_GREEN_ON        /* not available */
 #define LED_GREEN_OFF       /* not available */
 #define LED_GREEN_TOGGLE    /* not available */

--- a/boards/yunjia-nrf51822/board.c
+++ b/boards/yunjia-nrf51822/board.c
@@ -21,10 +21,11 @@
 #include "board.h"
 #include "cpu.h"
 
-#include "periph/uart.h"
-
 void board_init(void)
 {
+    /* setup led(s) for debugging */
+    NRF_GPIO->PIN_CNF[LED_RED_PIN] = GPIO_PIN_CNF_DIR_Output;
+
     /* initialize the CPU */
     cpu_init();
 }

--- a/boards/yunjia-nrf51822/include/board.h
+++ b/boards/yunjia-nrf51822/include/board.h
@@ -45,12 +45,17 @@
  * @name Macros for controlling the on-board LEDs.
  * @{
  */
-#define LED_RED_ON          /* not available */
-#define LED_RED_OFF         /* not available */
-#define LED_RED_TOGGLE      /* not available */
+#define LED_RED_PIN         8
+
+#define LED_RED_ON          (NRF_GPIO->OUTSET = (1 << LED_RED_PIN))
+#define LED_RED_OFF         (NRF_GPIO->OUTCLR = (1 << LED_RED_PIN))
+#define LED_RED_TOGGLE      (NRF_GPIO->OUT ^= (1 << LED_RED_PIN))
 #define LED_GREEN_ON        /* not available */
 #define LED_GREEN_OFF       /* not available */
 #define LED_GREEN_TOGGLE    /* not available */
+#define LED_BLUE_ON         /* not available */
+#define LED_BLUE_OFF        /* not available */
+#define LED_BLUE_TOGGLE     /* not available */
 /* @} */
 
 /**


### PR DESCRIPTION
To make debugging on these boards easier, I added the `LED_RED_x` macro, mapped to a more or less random pin on the boards (as both boards don't have integrated LEDs...).
