### PR TITLE
make: add objdump target + .PHONY missing targets from Makefile.include

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -131,7 +131,7 @@ BASELIBS += $(BINDIR)$(BOARD)_base.a
 BASELIBS += $(BINDIR)${APPLICATION}.a
 BASELIBS += $(USEPKG:%=${BINDIR}%.a)
 
-.PHONY: all clean flash doc term
+.PHONY: all clean flash term doc debug debug-server reset objdump
 
 ELFFILE ?= $(BINDIR)$(APPLICATION).elf
 HEXFILE ?= $(ELFFILE:.elf=.hex)


### PR DESCRIPTION
Add target `objdump` which runs the proper objdump for the respective board and pipes the result to less.
