### PR TITLE
make: only depend on directories that don't exist

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -49,7 +49,7 @@ $(BINDIR)$(MODULE)/:
 $(BINDIR)$(MODULE).a $(OBJ): | $(BINDIR)$(MODULE)/
 
 $(BINDIR)$(MODULE).a: $(OBJ) | ${DIRS:%=ALL--%}
-   $(AD)$(AR) -rcs $@ $(OBJ)
+	$(AD)$(AR) -rcs $@ $?
 
 
 CXXFLAGS = $(filter-out $(CXXUWFLAGS), $(CFLAGS)) $(CXXEXFLAGS)


### PR DESCRIPTION
The timestamp of directories is updated when a file inside a directory
is changed.
Therefore, make decides a target needs to be rebuilt, whenever that
target depends on its parent directory, because the directory is
always newer than the file inside.
