### PR TITLE
make: del no-delete-null-pointer-checks for clang++

### DIFF
--- a/Makefile.cflags
+++ b/Makefile.cflags
@@ -2,13 +2,13 @@
 # Otherwise test if the compiler unterstands the "-std=gnu99" flag, and use it if so.
 # Otherwise test if the compiler unterstands the "-std=c99" flag, and use it if so.
 ifeq ($(filter -std=%,$(CFLAGS)),)
-ifeq ($(shell $(CC) -std=gnu99 -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
-CFLAGS += -std=gnu99
-else
-ifeq ($(shell $(CC) -std=c99 -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
-CFLAGS += -std=c99
-endif
-endif
+  ifeq ($(shell $(CC) -std=gnu99 -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+    CFLAGS += -std=gnu99
+  else
+    ifeq ($(shell $(CC) -std=c99 -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+      CFLAGS += -std=c99
+    endif
+  endif
 endif
 
 # Add `-fno-delete-null-pointer-checks` flag iff the compiler supports it.
@@ -17,18 +17,27 @@ endif
 # Right now clang does not use the *delete-null-pointer* optimization, and does not understand the parameter.
 # Related issues: #628, #664.
 ifeq ($(shell $(CC) -fno-delete-null-pointer-checks -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
-ifeq ($(shell LANG=C $(CC) -fno-delete-null-pointer-checks -E - 2>&1 1>/dev/null </dev/null | grep warning: | grep -- -fno-delete-null-pointer-checks),)
-CFLAGS += -fno-delete-null-pointer-checks
-endif
+  ifeq ($(shell LANG=C $(CC) -fno-delete-null-pointer-checks -E - 2>&1 1>/dev/null </dev/null | grep warning: | grep -- -fno-delete-null-pointer-checks),)
+    CFLAGS += -fno-delete-null-pointer-checks
+
+    ifneq ($(shell $(CXX) -fno-delete-null-pointer-checks -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+      CXXUWFLAGS += -fno-delete-null-pointer-checks
+    else
+      ifneq ($(shell LANG=C $(CXX) -fno-delete-null-pointer-checks -E - 2>&1 1>/dev/null </dev/null | grep warning: | grep -- -fno-delete-null-pointer-checks),)
+        CXXUWFLAGS += -fno-delete-null-pointer-checks
+      endif
+    endif
+  endif
 endif
 
 # Fast-out on old style function definitions.
 # They cause unreadable error compiler errors on missing semicolons.
 # Worse yet they hide errors by accepting wildcard argument types.
 ifeq ($(shell $(CC) -Wstrict-prototypes -Werror=strict-prototypes -Wold-style-definition -Werror=old-style-definition -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
-# duplicated parameters don't hurt
-CFLAGS += -Wstrict-prototypes -Werror=strict-prototypes -Wold-style-definition -Werror=old-style-definition
+  # duplicated parameters don't hurt
+  CFLAGS += -Wstrict-prototypes -Werror=strict-prototypes -Wold-style-definition -Werror=old-style-definition
+  CXXUWFLAGS += -Wstrict-prototypes -Wold-style-definition
 endif
 
 # Unwanted flags for c++
-CXXUWFLAGS += -std=gnu99 -std=c99 -Wstrict-prototypes -Wold-style-definition
+CXXUWFLAGS += -std=%


### PR DESCRIPTION
This PR enables the use of clang++ to compile C++ projects by adding
`CXXUWFLAGS += -fno-delete-null-pointer-checks`, if `${CC}` understands
`-fno-delete-null-pointer-checks` but `${CXX}` does not.
