### PR TITLE
stm32f1: implement 32bit hwtimer by cascading two timers

### DIFF
--- a/boards/iot-lab_M3/include/periph_conf.h
+++ b/boards/iot-lab_M3/include/periph_conf.h
@@ -47,24 +47,32 @@
 #define TIMER_1_EN          1
 
 /* Timer 0 configuration */
-#define TIMER_0_DEV         TIM2
+#define TIMER_0_DEV_0       TIM2
+#define TIMER_0_DEV_1       TIM3
 #define TIMER_0_CHANNELS    4
-#define TIMER_0_PRESCALER   (36000U)
+#define TIMER_0_PRESCALER   (72U)
 #define TIMER_0_MAX_VALUE   (0xffff)
-#define TIMER_0_CLKEN()     (RCC->APB1ENR |= RCC_APB1ENR_TIM2EN)
-#define TIMER_0_ISR         isr_tim2
-#define TIMER_0_IRQ_CHAN    TIM2_IRQn
+#define TIMER_0_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM2EN | RCC_APB1ENR_TIM3EN))
+#define TIMER_0_ISR_0       isr_tim2
+#define TIMER_0_ISR_1       isr_tim3
+#define TIMER_0_IRQ_CHAN_0  TIM2_IRQn
+#define TIMER_0_IRQ_CHAN_1  TIM3_IRQn
 #define TIMER_0_IRQ_PRIO    1
+#define TIMER_0_TRIG_SEL    TIM_SMCR_TS_0
 
 /* Timer 1 configuration */
-#define TIMER_1_DEV         TIM3
-#define TIMER_1_CHANNELS    2
+#define TIMER_1_DEV_0       TIM4
+#define TIMER_1_DEV_1       TIM5
+#define TIMER_1_CHANNELS    4
 #define TIMER_1_PRESCALER   (36000U)
 #define TIMER_1_MAX_VALUE   (0xffff)
-#define TIMER_1_CLKEN()     (RCC->APB1ENR |= RCC_APB1ENR_TIM3EN)
-#define TIMER_1_ISR         isr_tim3
-#define TIMER_1_IRQ_CHAN    TIM3_IRQn
+#define TIMER_1_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM4EN | RCC_APB1ENR_TIM5EN))
+#define TIMER_1_ISR_0       isr_tim4
+#define TIMER_1_ISR_1       isr_tim5
+#define TIMER_1_IRQ_CHAN_0  TIM4_IRQn
+#define TIMER_1_IRQ_CHAN_1  TIM5_IRQn
 #define TIMER_1_IRQ_PRIO    1
+#define TIMER_1_TRIG_SEL    TIM_SMCR_TS_1
 /** @} */
 
 /**

--- a/cpu/stm32f1/include/hwtimer_cpu.h
+++ b/cpu/stm32f1/include/hwtimer_cpu.h
@@ -23,9 +23,9 @@
  * @name Hardware timer configuration
  * @{
  */
-#define HWTIMER_MAXTIMERS   (4)             /**< the CPU implementation supports 3 HW timers */
-#define HWTIMER_SPEED       (2000U)         /**< the HW timer runs with 2KHz */
-#define HWTIMER_MAXTICKS    (0xFFFF)        /**< 16-bit timer */
+#define HWTIMER_MAXTIMERS   (4)             /**< the CPU implementation supports 4 HW timers */
+#define HWTIMER_SPEED       (1000000U)      /**< the HW timer runs with 1MHz */
+#define HWTIMER_MAXTICKS    (0xFFFFFFFF)    /**< 32-bit timer */
 /** @} */
 
 #endif /* HWTIMER_CPU_H_ */


### PR DESCRIPTION
Provide 32bit timers for the stm32f1 hwtimer implementation by cascading 2 hardware timers. Also changed to clock them by 1MHz.
