### PR TITLE
Travis: reverted forcing travis to install `gcc-arm-none-eabi=4-*`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
         sudo apt-get install \
             build-essential \
             gcc-multilib \
-            gcc-arm-none-eabi=4-* \
+            gcc-arm-none-eabi \
             gcc-msp430 \
             pcregrep \
             libpcre3 \


### PR DESCRIPTION
Travis: revert workaround for gcc-arm-none-eabi missing headers when fixed upstream
The stock installed `gcc-arm-none-eabi amd64 4.8.4.2014q3-0precise10` seems to ship all the required headers again.
