### PR TITLE
transceiver: notify about dropped packets

### DIFF
--- a/sys/transceiver/transceiver.c
+++ b/sys/transceiver/transceiver.c
@@ -434,6 +434,7 @@ static void receive_packet(uint16_t type, uint8_t pos)
         /* inform upper layers of lost packet */
         m.type = ENOBUFFER;
         m.content.value = t;
+        DEBUGF("transceiver: buffer size exceeded, dropping packet\n");
     }
     /* copy packet and handle it */
     else {
@@ -504,6 +505,9 @@ static void receive_packet(uint16_t type, uint8_t pos)
 
             if (msg_send(&m, reg[i].pid, false) && (m.type != ENOBUFFER)) {
                 transceiver_buffer[transceiver_buffer_pos].processing++;
+            }
+            else {
+                DEBUGF("transceiver: failed to notify upper layer.\n");
             }
         }
 


### PR DESCRIPTION
Added debug output that warns about packets that are dropped
because the transceiver buffer was full or because the transceiver
failed to notify waiting upper layers.
