### PR TITLE
board/iot-lab_M3: fixed default terminal device

### DIFF
--- a/boards/iot-lab_M3/Makefile.include
+++ b/boards/iot-lab_M3/Makefile.include
@@ -2,8 +2,17 @@
 export CPU = stm32f1
 export CPU_MODEL = stm32f103re
 
-# set the default port
-export PORT ?= /dev/ttyUSB0
+# set default port depending on operating system
+OS := $(shell uname)
+ifeq ($(OS),Linux)
+  PORT ?= /dev/ttyUSB1
+else ifeq ($(OS),Darwin)
+  PORT ?= $(shell ls -1 /dev/tty.usbmodem* | head -n 1)
+else
+  $(info CAUTION: No PORT was defined for your host platform!)
+  # TODO: add support for windows as host platform
+endif
+export PORT
 
 # define tools used for building the project
 export PREFIX = arm-none-eabi-


### PR DESCRIPTION
I found `/dev/ttyUSB1` to be the default PORT on two different Linux machines.

@thomaseichinger Can you verify the PORT for OSX?
