### PR TITLE
tests: fix netdev test

### DIFF
--- a/tests/netdev/main.c
+++ b/tests/netdev/main.c
@@ -630,10 +630,6 @@ static int check_protocol(void)
                     puts("Got protocol: IEEE 802.15.4");
                     return 1;
 
-                case NETDEV_PROTO_RADIO_802154:
-                    puts("Got protocol: radio-encapsulated IEEE 802.15.4");
-                    return 1;
-
                 case NETDEV_PROTO_6LOWPAN:
                     puts("Got protocol: 6LoWPAN");
                     return 1;


### PR DESCRIPTION
Quick-fix and follow-up to #1492 

In the review process of #1492 I removed `NETDEV_PROTO_RADIO_802154`. Since the test compile that part without implemented devices, it went under the radar
