### PR TITLE
cpu/stm32f1: guard isr_exti9_5 and isr_exti15_10 if no GPIO_IRQ is enabled

### DIFF
--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -1097,6 +1097,7 @@ __attribute__((naked)) void isr_exti4(void)
 }
 #endif
 
+#if (GPIO_IRQ_5 || GPIO_IRQ_6 || GPIO_IRQ_7 || GPIO_IRQ_8 || GPIO_IRQ_9)
 __attribute__((naked)) void isr_exti9_5(void)
 {
     ISR_ENTER();
@@ -1135,7 +1136,9 @@ __attribute__((naked)) void isr_exti9_5(void)
     }
     ISR_EXIT();
 }
+#endif
 
+#if (GPIO_IRQ_10 || GPIO_IRQ_11 || GPIO_IRQ_12 || GPIO_IRQ_13 || GPIO_IRQ_14 || GPIO_IRQ_15)
 __attribute__((naked)) void isr_exti15_10(void)
 {
     ISR_ENTER();
@@ -1180,5 +1183,6 @@ __attribute__((naked)) void isr_exti15_10(void)
     }
     ISR_EXIT();
 }
+#endif
 
 #endif


### PR DESCRIPTION
This PR adds guards around isr_exti9_5, isr_exti15_10 if there are no GPIO_IRQs for these handlers are enabled. Thus, these handlers can be free to use in user's code.
