### PR TITLE
core/debug: fix printf barrier comparison

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -38,7 +38,7 @@
 #include "cpu-conf.h"
 #define DEBUG_PRINT(...) \
     do { \
-        if ((sched_active_thread == NULL) || (sched_active_thread->stack_size > KERNEL_CONF_STACKSIZE_PRINTF)) { \
+        if ((sched_active_thread == NULL) || (sched_active_thread->stack_size >= KERNEL_CONF_STACKSIZE_PRINTF)) { \
             printf(__VA_ARGS__); \
         } \
         else { \


### PR DESCRIPTION
Currently, if a thread has a stack size of KERNEL_CONF_STACKSIZE_PRINTF, it can not debug.
Is this appropriate?
