### PR TITLE
boards/iot-lab_M3: change to openocd's new ftdi interface

### DIFF
--- a/boards/iot-lab_M3/dist/iot-lab_M3_jtag.cfg
+++ b/boards/iot-lab_M3/dist/iot-lab_M3_jtag.cfg
@@ -1,13 +1,7 @@
-jtag_khz 1000
+interface ftdi
+ftdi_device_desc "FITECO M3"
+ftdi_vid_pid 0x0403 0x6010
 
-# comstick ftdi device
-interface ft2232
-ft2232_layout "usbjtag"
-ft2232_device_desc "FITECO M3"
-ft2232_vid_pid 0x0403 0x6010
-
-jtag_nsrst_delay 100
-jtag_ntrst_delay 100
-
-# use combined on interfaces or targets that can't set TRST/SRST separately
-reset_config trst_and_srst
+ftdi_layout_init 0x0c08 0x0c2b
+ftdi_layout_signal nTRST -data 0x0800
+ftdi_layout_signal nSRST -data 0x0400


### PR DESCRIPTION
Openocd communication was done over a deprecated interface definition,
namely ft2232. Using the new ftdi interface speeds up flashing and
doesn't throw warnings anymore.
