### PR TITLE
c++: core: add extern C in header files

### DIFF
--- a/core/include/arch/atomic_arch.h
+++ b/core/include/arch/atomic_arch.h
@@ -19,6 +19,10 @@
 #ifndef __ATOMIC_ARCH_H
 #define __ATOMIC_ARCH_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 /**
  * @brief Define mappings between arch and internal interfaces
  *
@@ -41,6 +45,9 @@
  */
 unsigned int atomic_arch_set_return(unsigned int *to_set, unsigned int value);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ATOMIC_ARCH_H */
 /** @} */

--- a/core/include/arch/hwtimer_arch.h
+++ b/core/include/arch/hwtimer_arch.h
@@ -22,6 +22,10 @@
 #ifndef HWTIMER_ARCH_H_
 #define HWTIMER_ARCH_H_
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include <stdint.h>
 
 /**
@@ -73,6 +77,9 @@ void hwtimer_arch_unset(short timer);
  */
 unsigned long hwtimer_arch_now(void);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* HWTIMER_ARCH_H_ */
 /** @} */

--- a/core/include/arch/io_arch.h
+++ b/core/include/arch/io_arch.h
@@ -19,6 +19,10 @@
 #ifndef __IO_ARCH_H
 #define __IO_ARCH_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 /**
  * @brief Define mapping between kernel internal and arch interfaces
  *
@@ -44,6 +48,9 @@
  */
 int io_arch_puts(char *data, int count);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __IO_ARCH_H */
 /** @} */

--- a/core/include/arch/irq_arch.h
+++ b/core/include/arch/irq_arch.h
@@ -22,6 +22,10 @@
 #ifndef __IRQ_ARCH_H
 #define __IRQ_ARCH_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 /**
  * @name Define mapping between kernel internal and arch interfaces
  *
@@ -66,6 +70,9 @@ void irq_arch_restore(unsigned int state);
  */
 int irq_arch_in(void);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __IRQ_ARCH_H */
 /** @} */

--- a/core/include/arch/lpm_arch.h
+++ b/core/include/arch/lpm_arch.h
@@ -22,6 +22,10 @@
 #ifndef __LPM_ARCH_H
 #define __LPM_ARCH_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 /**
  * @brief Define the mapping between the architecture independent interfaces
           and the kernel internal interfaces
@@ -88,6 +92,9 @@ void lpm_arch_begin_awake(void);
  */
 void lpm_arch_end_awake(void);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __LPM_ARCH_H */
 /** @} */

--- a/core/include/arch/reboot_arch.h
+++ b/core/include/arch/reboot_arch.h
@@ -20,6 +20,10 @@
 #ifndef __REBOOT_ARCH_H
 #define __REBOOT_ARCH_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 /**
  * @brief Reboot the system
  *
@@ -30,6 +34,9 @@
  */
 int reboot_arch(int mode);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __REBOOT_ARCH_H */
 /** @} */

--- a/core/include/arch/thread_arch.h
+++ b/core/include/arch/thread_arch.h
@@ -19,6 +19,10 @@
 #ifndef __THREAD_ARCH_H
 #define __THREAD_ARCH_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include "attributes.h"
 
 /**
@@ -65,6 +69,9 @@ void thread_arch_start_threading(void) NORETURN;
  */
 void thread_arch_yield(void);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __THREAD_ARCH_H */
 /** @} */

--- a/core/include/atomic.h
+++ b/core/include/atomic.h
@@ -19,6 +19,10 @@
 #ifndef _ATOMIC_H
 #define _ATOMIC_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include "arch/atomic_arch.h"
 
 /**
@@ -30,6 +34,10 @@
  * @return The old value of *val*
  */
 unsigned int atomic_set_return(unsigned int *val, unsigned int set);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ATOMIC_H */
 /** @} */

--- a/core/include/attributes.h
+++ b/core/include/attributes.h
@@ -19,6 +19,10 @@
 #ifndef ATTRIBUTES_H_
 #define ATTRIBUTES_H_
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 /**
  * @def NORETURN
  * @brief The *NORETURN* keyword tells the compiler to assume that the function
@@ -66,6 +70,10 @@
 #define UNREACHABLE() __builtin_unreachable()
 #else
 #define UNREACHABLE() do { /* nothing */ } while (1)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ATTRIBUTES_H_ */

--- a/core/include/bitarithm.h
+++ b/core/include/bitarithm.h
@@ -20,6 +20,10 @@
 #ifndef BITARITHM_H_
 #define BITARITHM_H_
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 /**
  * @def SETBIT
  * @brief Sets a bitmask for a bitfield
@@ -113,6 +117,10 @@ unsigned bitarithm_lsb(register unsigned v);
  * Source: http://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious
  */
 unsigned bitarithm_bits_set(unsigned v);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* BITARITHM_H_ */
 /** @} */

--- a/core/include/cib.h
+++ b/core/include/cib.h
@@ -21,6 +21,10 @@
 #ifndef __CIB_H
 #define __CIB_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 /**
  * @brief circular integer buffer structure
  */
@@ -67,6 +71,10 @@ int cib_put(cib_t *cib);
  * @return positive number for #cib_get < #cib_put
  */
 int cib_avail(cib_t *cib);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CIB_H */
 /** @} */

--- a/core/include/clist.h
+++ b/core/include/clist.h
@@ -19,6 +19,10 @@
 #ifndef __CLIST_H
 #define __CLIST_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include "kernel_macros.h"
 
 /**
@@ -83,6 +87,10 @@ static inline void clist_advance(clist_node_t **list)
  * @param[in]       clist       The list to get printed out.
  */
 void clist_print(clist_node_t *clist);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* __CLIST_H */

--- a/core/include/config.h
+++ b/core/include/config.h
@@ -19,6 +19,10 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include <stdint.h>
 
 #define CONFIG_KEY      (0x1701)    /**< key to identify configuration             */
@@ -65,6 +69,10 @@ uint8_t config_save(void);
  * @note If no configuration is present within flashrom a new configuration will be created
  */
 void config_load(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CONFIG_H */
 /** @} */

--- a/core/include/crash.h
+++ b/core/include/crash.h
@@ -22,6 +22,10 @@
 #ifndef __CRASH_H
 #define __CRASH_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include "kernel.h"
 
 /**
@@ -45,6 +49,10 @@
  * @return                  this function never returns
  * */
 NORETURN void core_panic(int crash_code, const char *message);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CRASH_H */
 /** @} */

--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -21,6 +21,10 @@
 #ifndef __DEBUG_H
 #define __DEBUG_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include <stdio.h>
 #include "sched.h"
 
@@ -79,6 +83,10 @@
 #define DEBUGF(...)
 #endif
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __DEBUG_H */
 /** @} */

--- a/core/include/flags.h
+++ b/core/include/flags.h
@@ -19,6 +19,10 @@
 #ifndef _FLAGS_H
 #define _FLAGS_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 /**
  * @name Optional flags for controlling a threads initial state.
  * @{
@@ -29,6 +33,10 @@
 #define CREATE_STACKTEST    (8)     /**< write markers into the thread's stack to measure stack
                                          usage (for debugging) */
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FLAGS_H */
 /** @} */

--- a/core/include/hwtimer.h
+++ b/core/include/hwtimer.h
@@ -33,6 +33,10 @@
 #ifndef __HWTIMER_H
 #define __HWTIMER_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include <stdint.h>
 #include "hwtimer_cpu.h"
 #include "board.h"
@@ -171,6 +175,10 @@ void hwtimer_init_comp(uint32_t fcpu);
  * @param[in]   ticks        Number of kernel ticks to delay
  */
 void hwtimer_spin(unsigned long ticks);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __HWTIMER_H */

--- a/core/include/io.h
+++ b/core/include/io.h
@@ -21,6 +21,10 @@
 #ifndef IO_H
 #define IO_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 /**
  * @brief   Firmware putstring implementation
  *
@@ -28,6 +32,10 @@
  * @param[in] count number of characters to be written
  */
 int fw_puts(char *data, int count);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* IO_H */

--- a/core/include/irq.h
+++ b/core/include/irq.h
@@ -21,6 +21,10 @@
 #ifndef IRQ_H_
 #define IRQ_H_
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include <stdbool.h>
 #include "arch/irq_arch.h"
 
@@ -68,6 +72,10 @@ void restoreIRQ(unsigned state);
  * @return  true, if in interrupt service routine, false if not
  */
 int inISR(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* IRQ_H_ */
 /** @} */

--- a/core/include/kernel.h
+++ b/core/include/kernel.h
@@ -22,6 +22,10 @@
 #ifndef KERNEL_H_
 #define KERNEL_H_
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -135,6 +139,10 @@ int reboot(int mode);
  * @brief Reboot the system in the usual fashion
  */
 #define RB_AUTOBOOT 0
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* KERNEL_H_ */
 /** @} */

--- a/core/include/kernel_internal.h
+++ b/core/include/kernel_internal.h
@@ -19,6 +19,10 @@
 #ifndef KERNEL_INTERNAL_H_
 #define KERNEL_INTERNAL_H_
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include "attributes.h"
 
 /**
@@ -54,6 +58,10 @@ NORETURN void sched_task_exit(void);
  * @brief   Prints human readable, ps-like thread information for debugging purposes
  */
 void thread_print_stack(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* KERNEL_INTERNAL_H_ */
 /** @} */

--- a/core/include/kernel_types.h
+++ b/core/include/kernel_types.h
@@ -9,6 +9,10 @@
 #ifndef KERNEL_TYPES_H
 #define KERNEL_TYPES_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include <stdint.h>
 #include <inttypes.h>
 #include <limits.h>
@@ -62,5 +66,9 @@
  * Unique process identifier
  */
 typedef int16_t kernel_pid_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* KERNEL_TYPES_H */

--- a/core/include/lifo.h
+++ b/core/include/lifo.h
@@ -23,6 +23,10 @@
 #ifndef __LIFO_H_
 #define __LIFO_H_
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 /**
  * @brief   Check if the given lifo is empty.
  *
@@ -61,6 +65,10 @@ void lifo_insert(int *array, int i);
  * @return          the least recently inserted element, otherwise.
  */
 int lifo_get(int *array);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __LIFO_H_ */
 /** @} */

--- a/core/include/lpm.h
+++ b/core/include/lpm.h
@@ -23,6 +23,10 @@
 #ifndef LPM_H_
 #define LPM_H_
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include "arch/lpm_arch.h"
 
 /**
@@ -59,6 +63,10 @@ void lpm_end_awake(void);
  * @return  Current power mode
  */
 enum lpm_mode lpm_get(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __LPM_H_ */
 /** @} */

--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -32,6 +32,10 @@
 #ifndef __MSG_H_
 #define __MSG_H_
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include <stdint.h>
 #include <stdbool.h>
 #include "kernel_types.h"
@@ -179,6 +183,10 @@ int msg_reply(msg_t *m, msg_t *reply);
  * @return -1, on error
  */
 int msg_init_queue(msg_t *array, int num);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __MSG_H_ */
 /** @} */

--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -21,6 +21,10 @@
 #ifndef __MUTEX_H_
 #define __MUTEX_H_
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include "priority_queue.h"
 
 /**
@@ -91,6 +95,10 @@ void mutex_unlock(mutex_t *mutex);
  * @param[in] mutex Mutex object to unlock, must not be NULL.
  */
 void mutex_unlock_and_sleep(mutex_t *mutex);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __MUTEX_H_ */
 /** @} */

--- a/core/include/priority_queue.h
+++ b/core/include/priority_queue.h
@@ -19,6 +19,10 @@
 #ifndef __QUEUE_H
 #define __QUEUE_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -108,6 +112,10 @@ void priority_queue_remove(priority_queue_t *root, priority_queue_node_t *node);
 #if ENABLE_DEBUG
 void priority_queue_print(priority_queue_t *root);
 void priority_queue_print_node(priority_queue_t *root);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 /** @} */

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -80,6 +80,10 @@
 #ifndef _SCHEDULER_H
 #define _SCHEDULER_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include <stddef.h>
 #include "bitarithm.h"
 #include "tcb.h"
@@ -176,6 +180,10 @@ extern schedstat sched_pidlist[KERNEL_PID_LAST + 1];
  */
 void sched_register_cb(void (*callback)(uint32_t, uint32_t));
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif // _SCHEDULER_H

--- a/core/include/tcb.h
+++ b/core/include/tcb.h
@@ -20,6 +20,10 @@
 #ifndef TCB_H_
 #define TCB_H_
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
 #include <stdint.h>
 #include "priority_queue.h"
 #include "clist.h"
@@ -77,6 +81,10 @@ typedef struct tcb_t {
     int stack_size;             /**< thread's stack size            */
 #endif
 } tcb_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TCB_H_ */
 /** @} */

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -21,6 +21,9 @@
 #ifndef __THREAD_H
 #define __THREAD_H
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
 
 #include "kernel.h"
 #include "tcb.h"
@@ -154,6 +157,10 @@ static inline kernel_pid_t thread_getpid(void)
  * @return          the amount of unused space of the thread's stack
  */
 int thread_measure_stack_free(char *stack);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 /* @} */


### PR DESCRIPTION
This PR adds extern "C" for the header files in core folder. Currently, we have header file in: 
- [x] core,
- [x] drivers, 
- [x] boards,
- [x] cpus,
- [x] sys,
- [x] examples,
- [x] tests 

around 530 files. :D 
By splitting to multiple PRs for each folders I think adding extern C in these headers can be doable. ;-)
