### PR TITLE
WIP/RFC: Add support for the Texas Instruments Tiva TM4C123GLX ARM Cortex-M4F MCU

### DIFF
--- a/boards/ek-tm4c123gxl/Makefile
+++ b/boards/ek-tm4c123gxl/Makefile
@@ -1,0 +1,7 @@
+# tell the Makefile.base which module to build
+MODULE = $(BOARD)_base
+
+PART=TM4C123GH6PM
+CFLAGS +=-DTARGET_IS_BLIZZARD_RB1 -DPART_${PART}
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/ek-tm4c123gxl/Makefile.include
+++ b/boards/ek-tm4c123gxl/Makefile.include
@@ -1,0 +1,50 @@
+# define the cpu used by the ek-tm4c123gxl launchpad
+export CPU = tm4c123
+export CPU_MODEL = tm4c123gh6pm
+
+#define the default port depending on the host OS
+OS := $(shell uname)
+ifeq ($(OS),Linux)
+  PORT ?= /dev/ttyACM0
+else ifeq ($(OS),Darwin)
+  PORT ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+else
+  $(info CAUTION: No flash tool for your host system found!)
+  # TODO: add support for windows as host platform
+endif
+export PORT
+
+# define tools used for building the project
+export PREFIX = arm-none-eabi-
+export CC = $(PREFIX)gcc
+export AR = $(PREFIX)ar
+export AS = $(PREFIX)as
+export LINK = $(PREFIX)gcc
+export SIZE = $(PREFIX)size
+export OBJCOPY = $(PREFIX)objcopy
+export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm
+export FLASHER = lm4flash
+export DEBUGGER = $(PREFIX)gdb
+export DEBUGSERVER = openocd
+
+# define build specific options
+CPU_USAGE = -mcpu=cortex-m4
+FPU_USAGE = -mfloat-abi=hard -mfpu=fpv4-sp-d16
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
+export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles -Wl,--gc-sections
+export LINKFLAGS += -T$(LINKERSCRIPT)
+export OFLAGS = -O binary
+export FFLAGS = bin/$(BOARD)/$(APPLICATION).hex
+export DEBUGGER_FLAGS = -x $(RIOTBOARD)/$(BOARD)/dist/gdb.conf $(BINDIR)/$(APPLICATION).elf
+export TERMFLAGS += -p "$(PORT)"
+export DEBUGSERVER_FLAGS = --file $(RIOTBOARD)/$(BOARD)/dist/LM4F120XL.cfg
+
+# use newLib nano-specs if available
+ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+export LINKFLAGS += -specs=nano.specs -lc -lnosys
+endif
+
+# export board specific includes to the global includes-listing
+export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include

--- a/boards/ek-tm4c123gxl/board.c
+++ b/boards/ek-tm4c123gxl/board.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2014 volatiles UG (haftungsbeschränkt)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     board_ek-tm4c123gxl
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the EK-TM4C123GXL Launchpad evaluation board
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@volatiles.de>
+ *
+ * @}
+ */
+
+#include "board.h"
+
+#include "driverlib/rom.h"
+#include "driverlib/sysctl.h"
+#include "driverlib/gpio.h"
+#include "driverlib/pin_map.h"
+
+void board_init(void)
+{
+    cpu_init();
+
+    /* Enable the GPIO port that is used for the on-board LED */
+    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOF);
+
+    /* Enable the GPIO pins for the LED (PF1, PF2 & PF3) */
+    ROM_GPIOPinTypeGPIOOutput(GPIOF_BASE, GPIO_PIN_1 | GPIO_PIN_2 | GPIO_PIN_3);
+
+    /* Enable the GPIO Peripheral used by the UART */
+    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOA);
+
+    /* Configure GPIO Pins for UART mode */
+    ROM_GPIOPinConfigure(GPIO_PA0_U0RX);
+    ROM_GPIOPinConfigure(GPIO_PA1_U0TX);
+    ROM_GPIOPinTypeUART(GPIOA_BASE, GPIO_PIN_0 | GPIO_PIN_1);
+}

--- a/boards/ek-tm4c123gxl/dist/LM4F120XL.cfg
+++ b/boards/ek-tm4c123gxl/dist/LM4F120XL.cfg
@@ -1,0 +1,13 @@
+#
+# TI Stellaris Launchpad ek-lm4f120xl Evaluation Kits
+#
+# http://www.ti.com/tool/ek-lm4f120xl
+#
+#
+# NOTE: using the bundled ICDI interface is optional!
+# This interface is not ftdi based as previous board were
+#
+source [find interface/ti-icdi.cfg]
+set WORKAREASIZE 0x4000
+set CHIPNAME lm4f120h5qr
+source [find target/stellaris_icdi.cfg]

--- a/boards/ek-tm4c123gxl/dist/gdb.conf
+++ b/boards/ek-tm4c123gxl/dist/gdb.conf
@@ -1,0 +1,3 @@
+target remote localhost:3333
+monitor reset halt
+load

--- a/boards/ek-tm4c123gxl/include/board.h
+++ b/boards/ek-tm4c123gxl/include/board.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2014 volatiles UG (haftungsbeschränkt)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    board_ek-tm4c123gxl
+ * @ingroup     boards
+ * @brief       Board specific files for the EK-TM4C123GXL Launchpad evaluation board
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the EK-TM4C123GXL Launchpad evaluation board
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@volatiles.de>
+ */
+
+#ifndef __BOARD_H
+#define __BOARD_H
+
+#include "cpu.h"
+
+/**
+ * Define the nominal CPU core clock in this board
+ */
+#define F_CPU               (80000000UL)
+
+/**
+ * @name Assign the hardware timer
+ */
+#define HW_TIMER            TIMER_0
+
+/**
+ * @name Define the UART used for stdio
+ */
+#define STDIO               UART_0
+#define STDIO_BAUDRATE      (115200U)
+
+#define _RED_LED            (*((volatile unsigned int *)(GPIOF_BASE + ((0x2 << 2)))))
+#define _BLUE_LED           (*((volatile unsigned int *)(GPIOF_BASE + ((0x4 << 2)))))
+#define _GREEN_LED          (*((volatile unsigned int *)(GPIOF_BASE + ((0x8 << 2)))))
+
+#define RED_LED_ON          (_RED_LED = 0x2)
+#define RED_LED_OFF         (_RED_LED = 0x0)
+#define RED_LED_TOGGLE      (_RED_LED^= 0x2)
+
+#define BLUE_LED_ON         (_BLUE_LED = 0x4)
+#define BLUE_LED_OFF        (_BLUE_LED = 0x0)
+#define BLUE_LED_TOGGLE     (_BLUE_LED^= 0x4)
+
+#define GREEN_LED_ON        (_GREEN_LED = 0x8)
+#define GREEN_LED_OFF       (_GREEN_LED = 0x0)
+#define GREEN_LED_TOGGLE    (_GREEN_LED^= 0x8)
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#endif /** __BOARD_H */
+/** @} */

--- a/boards/ek-tm4c123gxl/include/periph_conf.h
+++ b/boards/ek-tm4c123gxl/include/periph_conf.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2014 volatiles UG (haftungsbeschränkt)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     board_ek-tm4c123gxl
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the EK-TM4C123GXL Launchpad evaluation board
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@volatiles.de>
+ */
+
+#ifndef __PERIPH_CONF_H
+#define __PERIPH_CONF_H
+
+#define UART_IRQ_PRIO       1
+#define UART_NUMOF          (2U)
+#define UART_0_EN           1
+#define UART_0_ISR          isr_uart0
+
+#define UART_1_EN           0
+#define UART_1_ISR          isr_uart1
+
+#define UART_0_IRQ_CHAN     UART0_IRQn
+#define UART_1_IRQ_CHAN     UART1_IRQn
+
+#define UART_0_DEV          UART0
+#define UART_1_DEV          UART1
+
+#define TIMER_NUMOF         6
+
+#define TIMER_0_EN          1
+#define TIMER_1_EN          1
+#define TIMER_2_EN          1
+#define TIMER_3_EN          1
+#define TIMER_4_EN          1
+#define TIMER_5_EN          1
+
+#define TIMER_0_DEV         TIMER0
+#define TIMER_1_DEV         TIMER1
+#define TIMER_2_DEV         TIMER2
+#define TIMER_3_DEV         TIMER3
+#define TIMER_4_DEV         TIMER4
+#define TIMER_5_DEV         TIMER5
+
+#define TIMER_0_ISR         isr_tim0a
+#define TIMER_1_ISR         isr_tim1a
+#define TIMER_2_ISR         isr_tim2a
+#define TIMER_3_ISR         isr_tim3a
+#define TIMER_4_ISR         isr_tim4a
+#define TIMER_5_ISR         isr_tim5a
+
+#endif /* __PERIPH_CONF_H */

--- a/cpu/tm4c123/Makefile
+++ b/cpu/tm4c123/Makefile
@@ -1,0 +1,10 @@
+# define the module that is build
+MODULE = cpu
+
+# add a list of subdirectories, that should also be build
+DIRS = periph $(CORTEX_M4_COMMON)
+
+PART=TM4C123GH6PM
+CFLAGS +=-DTARGET_IS_BLIZZARD_RB1 -DPART_${PART}
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/tm4c123/Makefile.include
+++ b/cpu/tm4c123/Makefile.include
@@ -1,0 +1,28 @@
+# this CPU implementation is using the explicit core/CPU interface
+export CFLAGS += -DCOREIF_NG=1
+
+# export the peripheral drivers to be linked into the final binary
+export USEMODULE += periph
+
+# tell the build system that the CPU depends on the Cortex-M common files
+export USEMODULE += cortex-m4_common
+
+# define path to cortex-m common module, which is needed for this CPU
+export CORTEX_M4_COMMON = $(RIOTCPU)/cortex-m4_common/
+
+# CPU depends on the cortex-m common module, so include it
+include $(CORTEX_M4_COMMON)Makefile.include
+
+# define the linker script to use for this CPU
+export LINKERSCRIPT = $(RIOTCPU)/$(CPU)/$(CPU_MODEL)_linkerscript.ld
+
+#export the CPU model
+MODEL = $(shell echo $(CPU_MODEL)|tr 'a-z' 'A-Z')
+export CFLAGS += -DCPU_MODEL_$(MODEL) -DTARGET_IS_BLIZZARD_RB1
+
+# include CPU specific includes
+export INCLUDES += -I$(RIOTCPU)/$(CPU)/include
+
+# add the CPU specific system calls implementations for the linker
+export UNDEF += $(BINDIR)cpu/syscalls.o
+export UNDEF += $(BINDIR)cpu/startup.o

--- a/cpu/tm4c123/cpu.c
+++ b/cpu/tm4c123/cpu.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2014 volatiles UG (haftungsbeschränkt)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_tm4c123
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the CPU initialization
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@volatiles.de>
+ * @}
+ */
+
+#include <stdint.h>
+#include "cpu.h"
+
+#include "driverlib/rom.h"
+#include "driverlib/sysctl.h"
+
+/**
+ * @brief Initialize the CPU, set IRQ priorities
+ */
+void cpu_init(void)
+{
+    /* Set the clocking to run directly from the crystal, 80MHz */
+    ROM_SysCtlClockSet(SYSCTL_SYSDIV_2_5 | SYSCTL_USE_PLL | SYSCTL_XTAL_16MHZ | SYSCTL_OSC_MAIN);
+
+    /* set pendSV interrupt to lowest possible priority */
+    NVIC_SetPriority(PendSV_IRQn, 0xff);
+
+    /* Enable the FPU */
+    ROM_FPUEnable();
+}

--- a/cpu/tm4c123/hwtimer_arch.c
+++ b/cpu/tm4c123/hwtimer_arch.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014 volatiles UG (haftungsbeschränkt)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_tm4c123
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the kernels hwtimer interface
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Benjamin Valentin <benjamin.valentin@volatiles.de>
+ *
+ * @}
+ */
+
+#include "arch/hwtimer_arch.h"
+#include "hwtimer_cpu.h"
+#include "board.h"
+#include "periph/timer.h"
+#include "thread.h"
+
+static inline tim_t get_timer(short timer) {
+    switch (timer) {
+        case 0:
+        return TIMER_0;
+        case 1:
+        return TIMER_1;
+        case 2:
+        return TIMER_2;
+        case 3:
+        return TIMER_3;
+        case 4:
+        return TIMER_4;
+        case 5:
+        return TIMER_5;
+        default:
+        return TIMER_UNDEFINED;
+    }
+}
+/**
+ * @brief Callback function that is given to the low-level timer
+ *
+ * @param[in] channel   the channel of the low-level timer that was triggered
+ */
+void irq_handler(int channel);
+
+/**
+ * @brief Hold a reference to the hwtimer callback
+ */
+void (*timeout_handler)(int);
+
+void hwtimer_arch_init(void (*handler)(int), uint32_t fcpu)
+{
+    unsigned int ticks_per_us = 1;
+    timeout_handler = handler;
+
+    for (int i = 0; i < HWTIMER_MAXTIMERS; ++i)
+        timer_init(get_timer(i), ticks_per_us, &irq_handler);
+}
+
+void hwtimer_arch_enable_interrupt(void)
+{
+	// This function is never useds
+}
+
+void hwtimer_arch_disable_interrupt(void)
+{
+	// This function is never useds
+}
+
+void hwtimer_arch_set(unsigned long offset, short timer)
+{
+    timer_set(get_timer(timer), 0, offset);
+}
+
+void hwtimer_arch_set_absolute(unsigned long value, short timer)
+{
+    timer_set_absolute(get_timer(timer), 0, value);
+}
+
+void hwtimer_arch_unset(short timer)
+{
+    timer_clear(get_timer(timer), 0);
+}
+
+unsigned long hwtimer_arch_now(void)
+{
+    return timer_read(TIMER_3);
+}
+
+void irq_handler(int channel)
+{
+    timeout_handler((short)(channel));
+}

--- a/cpu/tm4c123/hwtimer_arch.c
+++ b/cpu/tm4c123/hwtimer_arch.c
@@ -92,7 +92,7 @@ void hwtimer_arch_unset(short timer)
 
 unsigned long hwtimer_arch_now(void)
 {
-    return timer_read(TIMER_3);
+    return timer_read(TIMER_0);
 }
 
 void irq_handler(int channel)

--- a/cpu/tm4c123/include/cpu-conf.h
+++ b/cpu/tm4c123/include/cpu-conf.h
@@ -29,13 +29,14 @@
  * TODO: measure and adjust for the Cortex-M4f
  * @{
  */
-#define KERNEL_CONF_STACKSIZE_PRINTF    (2500)
+#define KERNEL_CONF_STACKSIZE_PRINTF_FLOAT  (4096)
+#define KERNEL_CONF_STACKSIZE_PRINTF        (2048)
 
 #ifndef KERNEL_CONF_STACKSIZE_DEFAULT
-#define KERNEL_CONF_STACKSIZE_DEFAULT   (2500)
+#define KERNEL_CONF_STACKSIZE_DEFAULT   (256)
 #endif
 
-#define KERNEL_CONF_STACKSIZE_IDLE      (512)
+#define KERNEL_CONF_STACKSIZE_IDLE      (256)
 /** @} */
 
 /**

--- a/cpu/tm4c123/include/cpu-conf.h
+++ b/cpu/tm4c123/include/cpu-conf.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup        cpu_tm4c123 TM4C123
+ * @ingroup         cpu
+ * @brief           CPU specific implementations for the TM4C123
+ * @{
+ *
+ * @file
+ * @brief           Implementation specific CPU configuration options
+ *
+ * @author          Hauke Petersen <hauke.peterse@fu-berlin.de>
+ */
+
+#ifndef __CPU_CONF_H
+#define __CPU_CONF_H
+
+#include "tm4c123gh6pm.h"
+
+/**
+ * @name Kernel configuration
+ *
+ * TODO: measure and adjust for the Cortex-M4f
+ * @{
+ */
+#define KERNEL_CONF_STACKSIZE_PRINTF    (2500)
+
+#ifndef KERNEL_CONF_STACKSIZE_DEFAULT
+#define KERNEL_CONF_STACKSIZE_DEFAULT   (2500)
+#endif
+
+#define KERNEL_CONF_STACKSIZE_IDLE      (512)
+/** @} */
+
+/**
+ * @name UART0 buffer size definition for compatibility reasons
+ *
+ * TODO: remove once the remodeling of the uart0 driver is done
+ * @{
+ */
+#ifndef UART0_BUFSIZE
+#define UART0_BUFSIZE                   (128)
+#endif
+/** @} */
+
+#endif /* __CPU_CONF_H */
+/** @} */

--- a/cpu/tm4c123/include/driverlib/gpio.h
+++ b/cpu/tm4c123/include/driverlib/gpio.h
@@ -1,0 +1,145 @@
+//*****************************************************************************
+//
+// gpio.h - Defines and Macros for GPIO API.
+//
+// Copyright (c) 2005-2013 Texas Instruments Incorporated.  All rights reserved.
+// Software License Agreement
+// 
+//   Redistribution and use in source and binary forms, with or without
+//   modification, are permitted provided that the following conditions
+//   are met:
+// 
+//   Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+// 
+//   Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the  
+//   distribution.
+// 
+//   Neither the name of Texas Instruments Incorporated nor the names of
+//   its contributors may be used to endorse or promote products derived
+//   from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// This is part of revision 2.0.1.11577 of the Tiva Peripheral Driver Library.
+//
+//*****************************************************************************
+
+#ifndef __DRIVERLIB_GPIO_H__
+#define __DRIVERLIB_GPIO_H__
+
+//*****************************************************************************
+//
+// If building with a C++ compiler, make all of the definitions in this header
+// have a C binding.
+//
+//*****************************************************************************
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+//*****************************************************************************
+//
+// The following values define the bit field for the ui8Pins argument to
+// several of the APIs.
+//
+//*****************************************************************************
+#define GPIO_PIN_0              0x00000001  // GPIO pin 0
+#define GPIO_PIN_1              0x00000002  // GPIO pin 1
+#define GPIO_PIN_2              0x00000004  // GPIO pin 2
+#define GPIO_PIN_3              0x00000008  // GPIO pin 3
+#define GPIO_PIN_4              0x00000010  // GPIO pin 4
+#define GPIO_PIN_5              0x00000020  // GPIO pin 5
+#define GPIO_PIN_6              0x00000040  // GPIO pin 6
+#define GPIO_PIN_7              0x00000080  // GPIO pin 7
+
+//*****************************************************************************
+//
+// Values that can be passed to GPIODirModeSet as the ui32PinIO parameter, and
+// returned from GPIODirModeGet.
+//
+//*****************************************************************************
+#define GPIO_DIR_MODE_IN        0x00000000  // Pin is a GPIO input
+#define GPIO_DIR_MODE_OUT       0x00000001  // Pin is a GPIO output
+#define GPIO_DIR_MODE_HW        0x00000002  // Pin is a peripheral function
+
+//*****************************************************************************
+//
+// Values that can be passed to GPIOIntTypeSet as the ui32IntType parameter,
+// and returned from GPIOIntTypeGet.
+//
+//*****************************************************************************
+#define GPIO_FALLING_EDGE       0x00000000  // Interrupt on falling edge
+#define GPIO_RISING_EDGE        0x00000004  // Interrupt on rising edge
+#define GPIO_BOTH_EDGES         0x00000001  // Interrupt on both edges
+#define GPIO_LOW_LEVEL          0x00000002  // Interrupt on low level
+#define GPIO_HIGH_LEVEL         0x00000006  // Interrupt on high level
+#define GPIO_DISCRETE_INT       0x00010000  // Interrupt for individual pins
+
+//*****************************************************************************
+//
+// Values that can be passed to GPIOPadConfigSet as the ui32Strength parameter,
+// and returned by GPIOPadConfigGet in the *pui32Strength parameter.
+//
+//*****************************************************************************
+#define GPIO_STRENGTH_2MA       0x00000001  // 2mA drive strength
+#define GPIO_STRENGTH_4MA       0x00000002  // 4mA drive strength
+#define GPIO_STRENGTH_6MA       0x00000065  // 6mA drive strength
+#define GPIO_STRENGTH_8MA       0x00000004  // 8mA drive strength
+#define GPIO_STRENGTH_8MA_SC    0x0000000C  // 8mA drive with slew rate control
+#define GPIO_STRENGTH_10MA      0x00000075  // 10mA drive strength
+#define GPIO_STRENGTH_12MA      0x00000077  // 12mA drive strength
+
+//*****************************************************************************
+//
+// Values that can be passed to GPIOPadConfigSet as the ui32PadType parameter,
+// and returned by GPIOPadConfigGet in the *pui32PadType parameter.
+//
+//*****************************************************************************
+#define GPIO_PIN_TYPE_STD       0x00000008  // Push-pull
+#define GPIO_PIN_TYPE_STD_WPU   0x0000000A  // Push-pull with weak pull-up
+#define GPIO_PIN_TYPE_STD_WPD   0x0000000C  // Push-pull with weak pull-down
+#define GPIO_PIN_TYPE_OD        0x00000009  // Open-drain
+#define GPIO_PIN_TYPE_ANALOG    0x00000000  // Analog comparator
+#define GPIO_PIN_TYPE_WAKE_HIGH 0x00000208  // Hibernate wake, high
+#define GPIO_PIN_TYPE_WAKE_LOW  0x00000108  // Hibernate wake, low
+
+//*****************************************************************************
+//
+// Values that can be passed to GPIOIntEnable() and GPIOIntDisable() functions
+// in the ui32IntFlags parameter.
+//
+//*****************************************************************************
+#define GPIO_INT_PIN_0          0x00000001
+#define GPIO_INT_PIN_1          0x00000002
+#define GPIO_INT_PIN_2          0x00000004
+#define GPIO_INT_PIN_3          0x00000008
+#define GPIO_INT_PIN_4          0x00000010
+#define GPIO_INT_PIN_5          0x00000020
+#define GPIO_INT_PIN_6          0x00000040
+#define GPIO_INT_PIN_7          0x00000080
+#define GPIO_INT_DMA            0x00000100
+
+//*****************************************************************************
+//
+// Mark the end of the C bindings section for C++ compilers.
+//
+//*****************************************************************************
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __DRIVERLIB_GPIO_H__

--- a/cpu/tm4c123/include/driverlib/pin_map.h
+++ b/cpu/tm4c123/include/driverlib/pin_map.h
@@ -1,0 +1,17294 @@
+//*****************************************************************************
+//
+// pin_map.h - Mapping of peripherals to pins for all parts.
+//
+// Copyright (c) 2007-2013 Texas Instruments Incorporated.  All rights reserved.
+// Software License Agreement
+// 
+//   Redistribution and use in source and binary forms, with or without
+//   modification, are permitted provided that the following conditions
+//   are met:
+// 
+//   Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+// 
+//   Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the  
+//   distribution.
+// 
+//   Neither the name of Texas Instruments Incorporated nor the names of
+//   its contributors may be used to endorse or promote products derived
+//   from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// This is part of revision 2.0.1.11577 of the Tiva Peripheral Driver Library.
+//
+//*****************************************************************************
+
+#ifndef __DRIVERLIB_PIN_MAP_H__
+#define __DRIVERLIB_PIN_MAP_H__
+
+//*****************************************************************************
+//
+// TM4C1230C3PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1230C3PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#endif // PART_TM4C1230C3PM
+
+//*****************************************************************************
+//
+// TM4C1230D5PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1230D5PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#endif // PART_TM4C1230D5PM
+
+//*****************************************************************************
+//
+// TM4C1230E6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1230E6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#endif // PART_TM4C1230E6PM
+
+//*****************************************************************************
+//
+// TM4C1230H6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1230H6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#endif // PART_TM4C1230H6PM
+
+//*****************************************************************************
+//
+// TM4C1231C3PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1231C3PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#endif // PART_TM4C1231C3PM
+
+//*****************************************************************************
+//
+// TM4C1231D5PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1231D5PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#endif // PART_TM4C1231D5PM
+
+//*****************************************************************************
+//
+// TM4C1231D5PZ Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1231D5PZ
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE7_U1RI           0x00041C01
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_T2CCP1         0x00051407
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+
+#define GPIO_PK2_SSI3RX         0x00090802
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+
+#endif // PART_TM4C1231D5PZ
+
+//*****************************************************************************
+//
+// TM4C1231E6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1231E6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#endif // PART_TM4C1231E6PM
+
+//*****************************************************************************
+//
+// TM4C1231E6PZ Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1231E6PZ
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE7_U1RI           0x00041C01
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_T2CCP1         0x00051407
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+
+#define GPIO_PK2_SSI3RX         0x00090802
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+
+#endif // PART_TM4C1231E6PZ
+
+//*****************************************************************************
+//
+// TM4C1231H6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1231H6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#endif // PART_TM4C1231H6PM
+
+//*****************************************************************************
+//
+// TM4C1231H6PZ Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1231H6PZ
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE7_U1RI           0x00041C01
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_T2CCP1         0x00051407
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+
+#define GPIO_PK2_SSI3RX         0x00090802
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+
+#endif // PART_TM4C1231H6PZ
+
+//*****************************************************************************
+//
+// TM4C1232C3PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1232C3PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#endif // PART_TM4C1232C3PM
+
+//*****************************************************************************
+//
+// TM4C1232D5PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1232D5PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#endif // PART_TM4C1232D5PM
+
+//*****************************************************************************
+//
+// TM4C1232E6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1232E6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#endif // PART_TM4C1232E6PM
+
+//*****************************************************************************
+//
+// TM4C1232H6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1232H6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#endif // PART_TM4C1232H6PM
+
+//*****************************************************************************
+//
+// TM4C1233C3PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1233C3PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#endif // PART_TM4C1233C3PM
+
+//*****************************************************************************
+//
+// TM4C1233D5PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1233D5PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#endif // PART_TM4C1233D5PM
+
+//*****************************************************************************
+//
+// TM4C1233D5PZ Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1233D5PZ
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE7_U1RI           0x00041C01
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_T2CCP1         0x00051407
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+
+#define GPIO_PK2_SSI3RX         0x00090802
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+
+#endif // PART_TM4C1233D5PZ
+
+//*****************************************************************************
+//
+// TM4C1233E6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1233E6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#endif // PART_TM4C1233E6PM
+
+//*****************************************************************************
+//
+// TM4C1233E6PZ Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1233E6PZ
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE7_U1RI           0x00041C01
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_T2CCP1         0x00051407
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+
+#define GPIO_PK2_SSI3RX         0x00090802
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+
+#endif // PART_TM4C1233E6PZ
+
+//*****************************************************************************
+//
+// TM4C1233H6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1233H6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#endif // PART_TM4C1233H6PM
+
+//*****************************************************************************
+//
+// TM4C1233H6PZ Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1233H6PZ
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE7_U1RI           0x00041C01
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_T2CCP1         0x00051407
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+
+#define GPIO_PK2_SSI3RX         0x00090802
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+
+#endif // PART_TM4C1233H6PZ
+
+//*****************************************************************************
+//
+// TM4C1236D5PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1236D5PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+#define GPIO_PG4_USB0EPEN       0x00061008
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+#define GPIO_PG5_USB0PFLT       0x00061408
+
+#endif // PART_TM4C1236D5PM
+
+//*****************************************************************************
+//
+// TM4C1236E6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1236E6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+#define GPIO_PG4_USB0EPEN       0x00061008
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+#define GPIO_PG5_USB0PFLT       0x00061408
+
+#endif // PART_TM4C1236E6PM
+
+//*****************************************************************************
+//
+// TM4C1236H6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1236H6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+#define GPIO_PG4_USB0EPEN       0x00061008
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+#define GPIO_PG5_USB0PFLT       0x00061408
+
+#endif // PART_TM4C1236H6PM
+
+//*****************************************************************************
+//
+// TM4C1237D5PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1237D5PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+
+#endif // PART_TM4C1237D5PM
+
+//*****************************************************************************
+//
+// TM4C1237D5PZ Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1237D5PZ
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE7_U1RI           0x00041C01
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_T2CCP1         0x00051407
+#define GPIO_PF5_USB0PFLT       0x00051408
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+#define GPIO_PG4_USB0EPEN       0x00061008
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+#define GPIO_PG5_USB0PFLT       0x00061408
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+
+#define GPIO_PK2_SSI3RX         0x00090802
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+
+#endif // PART_TM4C1237D5PZ
+
+//*****************************************************************************
+//
+// TM4C1237E6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1237E6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+
+#endif // PART_TM4C1237E6PM
+
+//*****************************************************************************
+//
+// TM4C1237E6PZ Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1237E6PZ
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE7_U1RI           0x00041C01
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_T2CCP1         0x00051407
+#define GPIO_PF5_USB0PFLT       0x00051408
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+#define GPIO_PG4_USB0EPEN       0x00061008
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+#define GPIO_PG5_USB0PFLT       0x00061408
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+
+#define GPIO_PK2_SSI3RX         0x00090802
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+
+#endif // PART_TM4C1237E6PZ
+
+//*****************************************************************************
+//
+// TM4C1237H6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1237H6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+
+#endif // PART_TM4C1237H6PM
+
+//*****************************************************************************
+//
+// TM4C1237H6PZ Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1237H6PZ
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE7_U1RI           0x00041C01
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_T2CCP1         0x00051407
+#define GPIO_PF5_USB0PFLT       0x00051408
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+#define GPIO_PG4_USB0EPEN       0x00061008
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+#define GPIO_PG5_USB0PFLT       0x00061408
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+
+#define GPIO_PK2_SSI3RX         0x00090802
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+
+#endif // PART_TM4C1237H6PZ
+
+//*****************************************************************************
+//
+// TM4C123AE6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C123AE6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_CAN1RX         0x00000008
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_CAN1TX         0x00000408
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+#define GPIO_PA6_M1PWM2         0x00001805
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+#define GPIO_PA7_M1PWM3         0x00001C05
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_M0PWM2         0x00011004
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_M0PWM3         0x00011404
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_M0PWM0         0x00011804
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_M0PWM1         0x00011C04
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_M0PWM6         0x00021004
+#define GPIO_PC4_IDX1           0x00021006
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_M0PWM7         0x00021404
+#define GPIO_PC5_PHA1           0x00021406
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_PHB1           0x00021806
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_M0PWM6         0x00030004
+#define GPIO_PD0_M1PWM0         0x00030005
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_M0PWM7         0x00030404
+#define GPIO_PD1_M1PWM1         0x00030405
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_M0FAULT0       0x00030804
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_IDX0           0x00030C06
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_M0FAULT0       0x00031804
+#define GPIO_PD6_PHA0           0x00031806
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_M0FAULT1       0x00031C04
+#define GPIO_PD7_PHB0           0x00031C06
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_M0PWM4         0x00041004
+#define GPIO_PE4_M1PWM2         0x00041005
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_M0PWM5         0x00041404
+#define GPIO_PE5_M1PWM3         0x00041405
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_M1PWM4         0x00050005
+#define GPIO_PF0_PHA0           0x00050006
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_M1PWM5         0x00050405
+#define GPIO_PF1_PHB0           0x00050406
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_M0FAULT0       0x00050804
+#define GPIO_PF2_M1PWM6         0x00050805
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_M0FAULT1       0x00050C04
+#define GPIO_PF3_M1PWM7         0x00050C05
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_M0FAULT2       0x00051004
+#define GPIO_PF4_M1FAULT0       0x00051005
+#define GPIO_PF4_IDX0           0x00051006
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_M1FAULT1       0x00060005
+#define GPIO_PG0_PHA1           0x00060006
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_M1FAULT2       0x00060405
+#define GPIO_PG1_PHB1           0x00060406
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_M0FAULT1       0x00060804
+#define GPIO_PG2_M1PWM0         0x00060805
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_M0FAULT2       0x00060C04
+#define GPIO_PG3_M1PWM1         0x00060C05
+#define GPIO_PG3_PHA1           0x00060C06
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_M0PWM4         0x00061004
+#define GPIO_PG4_M1PWM2         0x00061005
+#define GPIO_PG4_PHB1           0x00061006
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_M0PWM5         0x00061404
+#define GPIO_PG5_M1PWM3         0x00061405
+#define GPIO_PG5_IDX1           0x00061406
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#endif // PART_TM4C123AE6PM
+
+//*****************************************************************************
+//
+// TM4C123AH6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C123AH6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_CAN1RX         0x00000008
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_CAN1TX         0x00000408
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+#define GPIO_PA6_M1PWM2         0x00001805
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+#define GPIO_PA7_M1PWM3         0x00001C05
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_M0PWM2         0x00011004
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_M0PWM3         0x00011404
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_M0PWM0         0x00011804
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_M0PWM1         0x00011C04
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_M0PWM6         0x00021004
+#define GPIO_PC4_IDX1           0x00021006
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_M0PWM7         0x00021404
+#define GPIO_PC5_PHA1           0x00021406
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_PHB1           0x00021806
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_M0PWM6         0x00030004
+#define GPIO_PD0_M1PWM0         0x00030005
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_M0PWM7         0x00030404
+#define GPIO_PD1_M1PWM1         0x00030405
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_M0FAULT0       0x00030804
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_IDX0           0x00030C06
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_M0FAULT0       0x00031804
+#define GPIO_PD6_PHA0           0x00031806
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_M0FAULT1       0x00031C04
+#define GPIO_PD7_PHB0           0x00031C06
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_M0PWM4         0x00041004
+#define GPIO_PE4_M1PWM2         0x00041005
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_M0PWM5         0x00041404
+#define GPIO_PE5_M1PWM3         0x00041405
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_M1PWM4         0x00050005
+#define GPIO_PF0_PHA0           0x00050006
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_M1PWM5         0x00050405
+#define GPIO_PF1_PHB0           0x00050406
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_M0FAULT0       0x00050804
+#define GPIO_PF2_M1PWM6         0x00050805
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_M0FAULT1       0x00050C04
+#define GPIO_PF3_M1PWM7         0x00050C05
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_M0FAULT2       0x00051004
+#define GPIO_PF4_M1FAULT0       0x00051005
+#define GPIO_PF4_IDX0           0x00051006
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_M1FAULT1       0x00060005
+#define GPIO_PG0_PHA1           0x00060006
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_M1FAULT2       0x00060405
+#define GPIO_PG1_PHB1           0x00060406
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_M0FAULT1       0x00060804
+#define GPIO_PG2_M1PWM0         0x00060805
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_M0FAULT2       0x00060C04
+#define GPIO_PG3_M1PWM1         0x00060C05
+#define GPIO_PG3_PHA1           0x00060C06
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_M0PWM4         0x00061004
+#define GPIO_PG4_M1PWM2         0x00061005
+#define GPIO_PG4_PHB1           0x00061006
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_M0PWM5         0x00061404
+#define GPIO_PG5_M1PWM3         0x00061405
+#define GPIO_PG5_IDX1           0x00061406
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#endif // PART_TM4C123AH6PM
+
+//*****************************************************************************
+//
+// TM4C123BE6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C123BE6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_CAN1RX         0x00000008
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_CAN1TX         0x00000408
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+#define GPIO_PA6_M1PWM2         0x00001805
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+#define GPIO_PA7_M1PWM3         0x00001C05
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_M0PWM2         0x00011004
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_M0PWM3         0x00011404
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_M0PWM0         0x00011804
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_M0PWM1         0x00011C04
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_M0PWM6         0x00021004
+#define GPIO_PC4_IDX1           0x00021006
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_M0PWM7         0x00021404
+#define GPIO_PC5_PHA1           0x00021406
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_PHB1           0x00021806
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_M0PWM6         0x00030004
+#define GPIO_PD0_M1PWM0         0x00030005
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_M0PWM7         0x00030404
+#define GPIO_PD1_M1PWM1         0x00030405
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_M0FAULT0       0x00030804
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_IDX0           0x00030C06
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_M0FAULT0       0x00031804
+#define GPIO_PD6_PHA0           0x00031806
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_PHB0           0x00031C06
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_M0PWM4         0x00041004
+#define GPIO_PE4_M1PWM2         0x00041005
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_M0PWM5         0x00041404
+#define GPIO_PE5_M1PWM3         0x00041405
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_M1PWM4         0x00050005
+#define GPIO_PF0_PHA0           0x00050006
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_M1PWM5         0x00050405
+#define GPIO_PF1_PHB0           0x00050406
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_M0FAULT0       0x00050804
+#define GPIO_PF2_M1PWM6         0x00050805
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_M1PWM7         0x00050C05
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_M1FAULT0       0x00051005
+#define GPIO_PF4_IDX0           0x00051006
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#endif // PART_TM4C123BE6PM
+
+//*****************************************************************************
+//
+// TM4C123BE6PZ Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C123BE6PZ
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_CAN1RX         0x00000008
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_CAN1TX         0x00000408
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+#define GPIO_PA6_M1PWM2         0x00001805
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+#define GPIO_PA7_M1PWM3         0x00001C05
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_M0PWM2         0x00011004
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_M0PWM3         0x00011404
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_M0PWM6         0x00021004
+#define GPIO_PC4_IDX1           0x00021006
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_M0PWM7         0x00021404
+#define GPIO_PC5_PHA1           0x00021406
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_PHB1           0x00021806
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_M0PWM6         0x00030004
+#define GPIO_PD0_M1PWM0         0x00030005
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_M0PWM7         0x00030404
+#define GPIO_PD1_M1PWM1         0x00030405
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_M0FAULT0       0x00030804
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_IDX0           0x00030C06
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_M0FAULT0       0x00031804
+#define GPIO_PD6_PHA0           0x00031806
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_M0FAULT1       0x00031C04
+#define GPIO_PD7_PHB0           0x00031C06
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_M0PWM4         0x00041004
+#define GPIO_PE4_M1PWM2         0x00041005
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_M0PWM5         0x00041404
+#define GPIO_PE5_M1PWM3         0x00041405
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE6_CAN1RX         0x00041808
+
+#define GPIO_PE7_U1RI           0x00041C01
+#define GPIO_PE7_CAN1TX         0x00041C08
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_M1PWM4         0x00050005
+#define GPIO_PF0_PHA0           0x00050006
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_M1PWM5         0x00050405
+#define GPIO_PF1_PHB0           0x00050406
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_M0FAULT0       0x00050804
+#define GPIO_PF2_M1PWM6         0x00050805
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_M0FAULT1       0x00050C04
+#define GPIO_PF3_M1PWM7         0x00050C05
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_M0FAULT2       0x00051004
+#define GPIO_PF4_M1FAULT0       0x00051005
+#define GPIO_PF4_IDX0           0x00051006
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_M0FAULT3       0x00051404
+#define GPIO_PF5_T2CCP1         0x00051407
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_M1FAULT0       0x00051C05
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_M1FAULT1       0x00060005
+#define GPIO_PG0_PHA1           0x00060006
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_M1FAULT2       0x00060405
+#define GPIO_PG1_PHB1           0x00060406
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_M0FAULT1       0x00060804
+#define GPIO_PG2_M1PWM0         0x00060805
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_M0FAULT2       0x00060C04
+#define GPIO_PG3_M1PWM1         0x00060C05
+#define GPIO_PG3_PHA1           0x00060C06
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_M0PWM4         0x00061004
+#define GPIO_PG4_M1PWM2         0x00061005
+#define GPIO_PG4_PHB1           0x00061006
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_M0PWM5         0x00061404
+#define GPIO_PG5_M1PWM3         0x00061405
+#define GPIO_PG5_IDX1           0x00061406
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_M0PWM6         0x00061804
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_M0PWM7         0x00061C04
+#define GPIO_PG7_IDX1           0x00061C05
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_M0PWM0         0x00070004
+#define GPIO_PH0_M0FAULT0       0x00070006
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_M0PWM1         0x00070404
+#define GPIO_PH1_IDX0           0x00070405
+#define GPIO_PH1_M0FAULT1       0x00070406
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_M0PWM2         0x00070804
+#define GPIO_PH2_M0FAULT2       0x00070806
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_M0PWM3         0x00070C04
+#define GPIO_PH3_M0FAULT3       0x00070C06
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_M0PWM4         0x00071004
+#define GPIO_PH4_PHA0           0x00071005
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_M0PWM5         0x00071404
+#define GPIO_PH5_PHB0           0x00071405
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_M0PWM6         0x00071804
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_M0PWM7         0x00071C04
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_IDX0           0x00080805
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+#define GPIO_PK0_M1FAULT0       0x00090006
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+#define GPIO_PK1_M1FAULT1       0x00090406
+
+#define GPIO_PK2_SSI3RX         0x00090802
+#define GPIO_PK2_M1FAULT2       0x00090806
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+#define GPIO_PK3_M1FAULT3       0x00090C06
+
+#endif // PART_TM4C123BE6PZ
+
+//*****************************************************************************
+//
+// TM4C123BH6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C123BH6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_CAN1RX         0x00000008
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_CAN1TX         0x00000408
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+#define GPIO_PA6_M1PWM2         0x00001805
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+#define GPIO_PA7_M1PWM3         0x00001C05
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_M0PWM2         0x00011004
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_M0PWM3         0x00011404
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_M0PWM0         0x00011804
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_M0PWM1         0x00011C04
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_M0PWM6         0x00021004
+#define GPIO_PC4_IDX1           0x00021006
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_M0PWM7         0x00021404
+#define GPIO_PC5_PHA1           0x00021406
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_PHB1           0x00021806
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_M0PWM6         0x00030004
+#define GPIO_PD0_M1PWM0         0x00030005
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_M0PWM7         0x00030404
+#define GPIO_PD1_M1PWM1         0x00030405
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_M0FAULT0       0x00030804
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_IDX0           0x00030C06
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_M0FAULT0       0x00031804
+#define GPIO_PD6_PHA0           0x00031806
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_PHB0           0x00031C06
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_M0PWM4         0x00041004
+#define GPIO_PE4_M1PWM2         0x00041005
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_M0PWM5         0x00041404
+#define GPIO_PE5_M1PWM3         0x00041405
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_M1PWM4         0x00050005
+#define GPIO_PF0_PHA0           0x00050006
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_M1PWM5         0x00050405
+#define GPIO_PF1_PHB0           0x00050406
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_M0FAULT0       0x00050804
+#define GPIO_PF2_M1PWM6         0x00050805
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_M1PWM7         0x00050C05
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_M1FAULT0       0x00051005
+#define GPIO_PF4_IDX0           0x00051006
+#define GPIO_PF4_T2CCP0         0x00051007
+
+#endif // PART_TM4C123BH6PM
+
+//*****************************************************************************
+//
+// TM4C123BH6PZ Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C123BH6PZ
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_CAN1RX         0x00000008
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_CAN1TX         0x00000408
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+#define GPIO_PA6_M1PWM2         0x00001805
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+#define GPIO_PA7_M1PWM3         0x00001C05
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_M0PWM2         0x00011004
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_M0PWM3         0x00011404
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_M0PWM6         0x00021004
+#define GPIO_PC4_IDX1           0x00021006
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_M0PWM7         0x00021404
+#define GPIO_PC5_PHA1           0x00021406
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_PHB1           0x00021806
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_M0PWM6         0x00030004
+#define GPIO_PD0_M1PWM0         0x00030005
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_M0PWM7         0x00030404
+#define GPIO_PD1_M1PWM1         0x00030405
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_M0FAULT0       0x00030804
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_IDX0           0x00030C06
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_M0FAULT0       0x00031804
+#define GPIO_PD6_PHA0           0x00031806
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_M0FAULT1       0x00031C04
+#define GPIO_PD7_PHB0           0x00031C06
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_M0PWM4         0x00041004
+#define GPIO_PE4_M1PWM2         0x00041005
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_M0PWM5         0x00041404
+#define GPIO_PE5_M1PWM3         0x00041405
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE6_CAN1RX         0x00041808
+
+#define GPIO_PE7_U1RI           0x00041C01
+#define GPIO_PE7_CAN1TX         0x00041C08
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_M1PWM4         0x00050005
+#define GPIO_PF0_PHA0           0x00050006
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_M1PWM5         0x00050405
+#define GPIO_PF1_PHB0           0x00050406
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_M0FAULT0       0x00050804
+#define GPIO_PF2_M1PWM6         0x00050805
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_M0FAULT1       0x00050C04
+#define GPIO_PF3_M1PWM7         0x00050C05
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_M0FAULT2       0x00051004
+#define GPIO_PF4_M1FAULT0       0x00051005
+#define GPIO_PF4_IDX0           0x00051006
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_M0FAULT3       0x00051404
+#define GPIO_PF5_T2CCP1         0x00051407
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_M1FAULT0       0x00051C05
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_M1FAULT1       0x00060005
+#define GPIO_PG0_PHA1           0x00060006
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_M1FAULT2       0x00060405
+#define GPIO_PG1_PHB1           0x00060406
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_M0FAULT1       0x00060804
+#define GPIO_PG2_M1PWM0         0x00060805
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_M0FAULT2       0x00060C04
+#define GPIO_PG3_M1PWM1         0x00060C05
+#define GPIO_PG3_PHA1           0x00060C06
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_M0PWM4         0x00061004
+#define GPIO_PG4_M1PWM2         0x00061005
+#define GPIO_PG4_PHB1           0x00061006
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_M0PWM5         0x00061404
+#define GPIO_PG5_M1PWM3         0x00061405
+#define GPIO_PG5_IDX1           0x00061406
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_M0PWM6         0x00061804
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_M0PWM7         0x00061C04
+#define GPIO_PG7_IDX1           0x00061C05
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_M0PWM0         0x00070004
+#define GPIO_PH0_M0FAULT0       0x00070006
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_M0PWM1         0x00070404
+#define GPIO_PH1_IDX0           0x00070405
+#define GPIO_PH1_M0FAULT1       0x00070406
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_M0PWM2         0x00070804
+#define GPIO_PH2_M0FAULT2       0x00070806
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_M0PWM3         0x00070C04
+#define GPIO_PH3_M0FAULT3       0x00070C06
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_M0PWM4         0x00071004
+#define GPIO_PH4_PHA0           0x00071005
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_M0PWM5         0x00071404
+#define GPIO_PH5_PHB0           0x00071405
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_M0PWM6         0x00071804
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_M0PWM7         0x00071C04
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_IDX0           0x00080805
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+#define GPIO_PK0_M1FAULT0       0x00090006
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+#define GPIO_PK1_M1FAULT1       0x00090406
+
+#define GPIO_PK2_SSI3RX         0x00090802
+#define GPIO_PK2_M1FAULT2       0x00090806
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+#define GPIO_PK3_M1FAULT3       0x00090C06
+
+#endif // PART_TM4C123BH6PZ
+
+//*****************************************************************************
+//
+// TM4C123FE6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C123FE6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_CAN1RX         0x00000008
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_CAN1TX         0x00000408
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+#define GPIO_PA6_M1PWM2         0x00001805
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+#define GPIO_PA7_M1PWM3         0x00001C05
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_M0PWM2         0x00011004
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_M0PWM3         0x00011404
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_M0PWM0         0x00011804
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_M0PWM1         0x00011C04
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_M0PWM6         0x00021004
+#define GPIO_PC4_IDX1           0x00021006
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_M0PWM7         0x00021404
+#define GPIO_PC5_PHA1           0x00021406
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_PHB1           0x00021806
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_M0PWM6         0x00030004
+#define GPIO_PD0_M1PWM0         0x00030005
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_M0PWM7         0x00030404
+#define GPIO_PD1_M1PWM1         0x00030405
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_M0FAULT0       0x00030804
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_IDX0           0x00030C06
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_M0FAULT0       0x00031804
+#define GPIO_PD6_PHA0           0x00031806
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_M0FAULT1       0x00031C04
+#define GPIO_PD7_PHB0           0x00031C06
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_M0PWM4         0x00041004
+#define GPIO_PE4_M1PWM2         0x00041005
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_M0PWM5         0x00041404
+#define GPIO_PE5_M1PWM3         0x00041405
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_M1PWM4         0x00050005
+#define GPIO_PF0_PHA0           0x00050006
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_M1PWM5         0x00050405
+#define GPIO_PF1_PHB0           0x00050406
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_M0FAULT0       0x00050804
+#define GPIO_PF2_M1PWM6         0x00050805
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_M0FAULT1       0x00050C04
+#define GPIO_PF3_M1PWM7         0x00050C05
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_M0FAULT2       0x00051004
+#define GPIO_PF4_M1FAULT0       0x00051005
+#define GPIO_PF4_IDX0           0x00051006
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_M1FAULT1       0x00060005
+#define GPIO_PG0_PHA1           0x00060006
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_M1FAULT2       0x00060405
+#define GPIO_PG1_PHB1           0x00060406
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_M0FAULT1       0x00060804
+#define GPIO_PG2_M1PWM0         0x00060805
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_M0FAULT2       0x00060C04
+#define GPIO_PG3_M1PWM1         0x00060C05
+#define GPIO_PG3_PHA1           0x00060C06
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_M0PWM4         0x00061004
+#define GPIO_PG4_M1PWM2         0x00061005
+#define GPIO_PG4_PHB1           0x00061006
+#define GPIO_PG4_WT0CCP0        0x00061007
+#define GPIO_PG4_USB0EPEN       0x00061008
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_M0PWM5         0x00061404
+#define GPIO_PG5_M1PWM3         0x00061405
+#define GPIO_PG5_IDX1           0x00061406
+#define GPIO_PG5_WT0CCP1        0x00061407
+#define GPIO_PG5_USB0PFLT       0x00061408
+
+#endif // PART_TM4C123FE6PM
+
+//*****************************************************************************
+//
+// TM4C123FH6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C123FH6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_CAN1RX         0x00000008
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_CAN1TX         0x00000408
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+#define GPIO_PA6_M1PWM2         0x00001805
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+#define GPIO_PA7_M1PWM3         0x00001C05
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_M0PWM2         0x00011004
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_M0PWM3         0x00011404
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_M0PWM0         0x00011804
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_M0PWM1         0x00011C04
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_M0PWM6         0x00021004
+#define GPIO_PC4_IDX1           0x00021006
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_M0PWM7         0x00021404
+#define GPIO_PC5_PHA1           0x00021406
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_PHB1           0x00021806
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_M0PWM6         0x00030004
+#define GPIO_PD0_M1PWM0         0x00030005
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_M0PWM7         0x00030404
+#define GPIO_PD1_M1PWM1         0x00030405
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_M0FAULT0       0x00030804
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_IDX0           0x00030C06
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_M0FAULT0       0x00031804
+#define GPIO_PD6_PHA0           0x00031806
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_M0FAULT1       0x00031C04
+#define GPIO_PD7_PHB0           0x00031C06
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_M0PWM4         0x00041004
+#define GPIO_PE4_M1PWM2         0x00041005
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_M0PWM5         0x00041404
+#define GPIO_PE5_M1PWM3         0x00041405
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_M1PWM4         0x00050005
+#define GPIO_PF0_PHA0           0x00050006
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_M1PWM5         0x00050405
+#define GPIO_PF1_PHB0           0x00050406
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_M0FAULT0       0x00050804
+#define GPIO_PF2_M1PWM6         0x00050805
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_M0FAULT1       0x00050C04
+#define GPIO_PF3_M1PWM7         0x00050C05
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_M0FAULT2       0x00051004
+#define GPIO_PF4_M1FAULT0       0x00051005
+#define GPIO_PF4_IDX0           0x00051006
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_M1FAULT1       0x00060005
+#define GPIO_PG0_PHA1           0x00060006
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_M1FAULT2       0x00060405
+#define GPIO_PG1_PHB1           0x00060406
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_M0FAULT1       0x00060804
+#define GPIO_PG2_M1PWM0         0x00060805
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_M0FAULT2       0x00060C04
+#define GPIO_PG3_M1PWM1         0x00060C05
+#define GPIO_PG3_PHA1           0x00060C06
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_M0PWM4         0x00061004
+#define GPIO_PG4_M1PWM2         0x00061005
+#define GPIO_PG4_PHB1           0x00061006
+#define GPIO_PG4_WT0CCP0        0x00061007
+#define GPIO_PG4_USB0EPEN       0x00061008
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_M0PWM5         0x00061404
+#define GPIO_PG5_M1PWM3         0x00061405
+#define GPIO_PG5_IDX1           0x00061406
+#define GPIO_PG5_WT0CCP1        0x00061407
+#define GPIO_PG5_USB0PFLT       0x00061408
+
+#endif // PART_TM4C123FH6PM
+
+//*****************************************************************************
+//
+// TM4C123GE6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C123GE6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_CAN1RX         0x00000008
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_CAN1TX         0x00000408
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+#define GPIO_PA6_M1PWM2         0x00001805
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+#define GPIO_PA7_M1PWM3         0x00001C05
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_M0PWM2         0x00011004
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_M0PWM3         0x00011404
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_M0PWM0         0x00011804
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_M0PWM1         0x00011C04
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_M0PWM6         0x00021004
+#define GPIO_PC4_IDX1           0x00021006
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_M0PWM7         0x00021404
+#define GPIO_PC5_PHA1           0x00021406
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_PHB1           0x00021806
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_M0PWM6         0x00030004
+#define GPIO_PD0_M1PWM0         0x00030005
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_M0PWM7         0x00030404
+#define GPIO_PD1_M1PWM1         0x00030405
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_M0FAULT0       0x00030804
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_IDX0           0x00030C06
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_M0FAULT0       0x00031804
+#define GPIO_PD6_PHA0           0x00031806
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_PHB0           0x00031C06
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_M0PWM4         0x00041004
+#define GPIO_PE4_M1PWM2         0x00041005
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_M0PWM5         0x00041404
+#define GPIO_PE5_M1PWM3         0x00041405
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_M1PWM4         0x00050005
+#define GPIO_PF0_PHA0           0x00050006
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_M1PWM5         0x00050405
+#define GPIO_PF1_PHB0           0x00050406
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_M0FAULT0       0x00050804
+#define GPIO_PF2_M1PWM6         0x00050805
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_M1PWM7         0x00050C05
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_M1FAULT0       0x00051005
+#define GPIO_PF4_IDX0           0x00051006
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+
+#endif // PART_TM4C123GE6PM
+
+//*****************************************************************************
+//
+// TM4C123GE6PZ Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C123GE6PZ
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_CAN1RX         0x00000008
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_CAN1TX         0x00000408
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+#define GPIO_PA6_M1PWM2         0x00001805
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+#define GPIO_PA7_M1PWM3         0x00001C05
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_M0PWM2         0x00011004
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_M0PWM3         0x00011404
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_M0PWM6         0x00021004
+#define GPIO_PC4_IDX1           0x00021006
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_M0PWM7         0x00021404
+#define GPIO_PC5_PHA1           0x00021406
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_PHB1           0x00021806
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_M0PWM6         0x00030004
+#define GPIO_PD0_M1PWM0         0x00030005
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_M0PWM7         0x00030404
+#define GPIO_PD1_M1PWM1         0x00030405
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_M0FAULT0       0x00030804
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_IDX0           0x00030C06
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_M0FAULT0       0x00031804
+#define GPIO_PD6_PHA0           0x00031806
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_M0FAULT1       0x00031C04
+#define GPIO_PD7_PHB0           0x00031C06
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_M0PWM4         0x00041004
+#define GPIO_PE4_M1PWM2         0x00041005
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_M0PWM5         0x00041404
+#define GPIO_PE5_M1PWM3         0x00041405
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE6_CAN1RX         0x00041808
+
+#define GPIO_PE7_U1RI           0x00041C01
+#define GPIO_PE7_CAN1TX         0x00041C08
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_M1PWM4         0x00050005
+#define GPIO_PF0_PHA0           0x00050006
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_M1PWM5         0x00050405
+#define GPIO_PF1_PHB0           0x00050406
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_M0FAULT0       0x00050804
+#define GPIO_PF2_M1PWM6         0x00050805
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_M0FAULT1       0x00050C04
+#define GPIO_PF3_M1PWM7         0x00050C05
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_M0FAULT2       0x00051004
+#define GPIO_PF4_M1FAULT0       0x00051005
+#define GPIO_PF4_IDX0           0x00051006
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_M0FAULT3       0x00051404
+#define GPIO_PF5_T2CCP1         0x00051407
+#define GPIO_PF5_USB0PFLT       0x00051408
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_M1FAULT0       0x00051C05
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_M1FAULT1       0x00060005
+#define GPIO_PG0_PHA1           0x00060006
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_M1FAULT2       0x00060405
+#define GPIO_PG1_PHB1           0x00060406
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_M0FAULT1       0x00060804
+#define GPIO_PG2_M1PWM0         0x00060805
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_M0FAULT2       0x00060C04
+#define GPIO_PG3_M1PWM1         0x00060C05
+#define GPIO_PG3_PHA1           0x00060C06
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_M0PWM4         0x00061004
+#define GPIO_PG4_M1PWM2         0x00061005
+#define GPIO_PG4_PHB1           0x00061006
+#define GPIO_PG4_WT0CCP0        0x00061007
+#define GPIO_PG4_USB0EPEN       0x00061008
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_M0PWM5         0x00061404
+#define GPIO_PG5_M1PWM3         0x00061405
+#define GPIO_PG5_IDX1           0x00061406
+#define GPIO_PG5_WT0CCP1        0x00061407
+#define GPIO_PG5_USB0PFLT       0x00061408
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_M0PWM6         0x00061804
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_M0PWM7         0x00061C04
+#define GPIO_PG7_IDX1           0x00061C05
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_M0PWM0         0x00070004
+#define GPIO_PH0_M0FAULT0       0x00070006
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_M0PWM1         0x00070404
+#define GPIO_PH1_IDX0           0x00070405
+#define GPIO_PH1_M0FAULT1       0x00070406
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_M0PWM2         0x00070804
+#define GPIO_PH2_M0FAULT2       0x00070806
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_M0PWM3         0x00070C04
+#define GPIO_PH3_M0FAULT3       0x00070C06
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_M0PWM4         0x00071004
+#define GPIO_PH4_PHA0           0x00071005
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_M0PWM5         0x00071404
+#define GPIO_PH5_PHB0           0x00071405
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_M0PWM6         0x00071804
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_M0PWM7         0x00071C04
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_IDX0           0x00080805
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+#define GPIO_PK0_M1FAULT0       0x00090006
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+#define GPIO_PK1_M1FAULT1       0x00090406
+
+#define GPIO_PK2_SSI3RX         0x00090802
+#define GPIO_PK2_M1FAULT2       0x00090806
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+#define GPIO_PK3_M1FAULT3       0x00090C06
+
+#endif // PART_TM4C123GE6PZ
+
+//*****************************************************************************
+//
+// TM4C123GH6PM Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C123GH6PM
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_CAN1RX         0x00000008
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_CAN1TX         0x00000408
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+#define GPIO_PA6_M1PWM2         0x00001805
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+#define GPIO_PA7_M1PWM3         0x00001C05
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_M0PWM2         0x00011004
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_M0PWM3         0x00011404
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_M0PWM0         0x00011804
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_M0PWM1         0x00011C04
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_M0PWM6         0x00021004
+#define GPIO_PC4_IDX1           0x00021006
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_M0PWM7         0x00021404
+#define GPIO_PC5_PHA1           0x00021406
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_PHB1           0x00021806
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_M0PWM6         0x00030004
+#define GPIO_PD0_M1PWM0         0x00030005
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_M0PWM7         0x00030404
+#define GPIO_PD1_M1PWM1         0x00030405
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_M0FAULT0       0x00030804
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_IDX0           0x00030C06
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_M0FAULT0       0x00031804
+#define GPIO_PD6_PHA0           0x00031806
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_PHB0           0x00031C06
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_M0PWM4         0x00041004
+#define GPIO_PE4_M1PWM2         0x00041005
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_M0PWM5         0x00041404
+#define GPIO_PE5_M1PWM3         0x00041405
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_M1PWM4         0x00050005
+#define GPIO_PF0_PHA0           0x00050006
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_M1PWM5         0x00050405
+#define GPIO_PF1_PHB0           0x00050406
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_M0FAULT0       0x00050804
+#define GPIO_PF2_M1PWM6         0x00050805
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_M1PWM7         0x00050C05
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_M1FAULT0       0x00051005
+#define GPIO_PF4_IDX0           0x00051006
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+
+#endif // PART_TM4C123GH6PM
+
+//*****************************************************************************
+//
+// TM4C123GH6PZ Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C123GH6PZ
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_CAN1RX         0x00000008
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_CAN1TX         0x00000408
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+#define GPIO_PA6_M1PWM2         0x00001805
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+#define GPIO_PA7_M1PWM3         0x00001C05
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_M0PWM2         0x00011004
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_M0PWM3         0x00011404
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_M0PWM6         0x00021004
+#define GPIO_PC4_IDX1           0x00021006
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_M0PWM7         0x00021404
+#define GPIO_PC5_PHA1           0x00021406
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_PHB1           0x00021806
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_M0PWM6         0x00030004
+#define GPIO_PD0_M1PWM0         0x00030005
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_M0PWM7         0x00030404
+#define GPIO_PD1_M1PWM1         0x00030405
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_M0FAULT0       0x00030804
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_IDX0           0x00030C06
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_M0FAULT0       0x00031804
+#define GPIO_PD6_PHA0           0x00031806
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_M0FAULT1       0x00031C04
+#define GPIO_PD7_PHB0           0x00031C06
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_M0PWM4         0x00041004
+#define GPIO_PE4_M1PWM2         0x00041005
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_M0PWM5         0x00041404
+#define GPIO_PE5_M1PWM3         0x00041405
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE6_CAN1RX         0x00041808
+
+#define GPIO_PE7_U1RI           0x00041C01
+#define GPIO_PE7_CAN1TX         0x00041C08
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_M1PWM4         0x00050005
+#define GPIO_PF0_PHA0           0x00050006
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_M1PWM5         0x00050405
+#define GPIO_PF1_PHB0           0x00050406
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_M0FAULT0       0x00050804
+#define GPIO_PF2_M1PWM6         0x00050805
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_M0FAULT1       0x00050C04
+#define GPIO_PF3_M1PWM7         0x00050C05
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_M0FAULT2       0x00051004
+#define GPIO_PF4_M1FAULT0       0x00051005
+#define GPIO_PF4_IDX0           0x00051006
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_M0FAULT3       0x00051404
+#define GPIO_PF5_T2CCP1         0x00051407
+#define GPIO_PF5_USB0PFLT       0x00051408
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_M1FAULT0       0x00051C05
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_M1FAULT1       0x00060005
+#define GPIO_PG0_PHA1           0x00060006
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_M1FAULT2       0x00060405
+#define GPIO_PG1_PHB1           0x00060406
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_M0FAULT1       0x00060804
+#define GPIO_PG2_M1PWM0         0x00060805
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_M0FAULT2       0x00060C04
+#define GPIO_PG3_M1PWM1         0x00060C05
+#define GPIO_PG3_PHA1           0x00060C06
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_M0PWM4         0x00061004
+#define GPIO_PG4_M1PWM2         0x00061005
+#define GPIO_PG4_PHB1           0x00061006
+#define GPIO_PG4_WT0CCP0        0x00061007
+#define GPIO_PG4_USB0EPEN       0x00061008
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_M0PWM5         0x00061404
+#define GPIO_PG5_M1PWM3         0x00061405
+#define GPIO_PG5_IDX1           0x00061406
+#define GPIO_PG5_WT0CCP1        0x00061407
+#define GPIO_PG5_USB0PFLT       0x00061408
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_M0PWM6         0x00061804
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_M0PWM7         0x00061C04
+#define GPIO_PG7_IDX1           0x00061C05
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_M0PWM0         0x00070004
+#define GPIO_PH0_M0FAULT0       0x00070006
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_M0PWM1         0x00070404
+#define GPIO_PH1_IDX0           0x00070405
+#define GPIO_PH1_M0FAULT1       0x00070406
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_M0PWM2         0x00070804
+#define GPIO_PH2_M0FAULT2       0x00070806
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_M0PWM3         0x00070C04
+#define GPIO_PH3_M0FAULT3       0x00070C06
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_M0PWM4         0x00071004
+#define GPIO_PH4_PHA0           0x00071005
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_M0PWM5         0x00071404
+#define GPIO_PH5_PHB0           0x00071405
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_M0PWM6         0x00071804
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_M0PWM7         0x00071C04
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_IDX0           0x00080805
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+#define GPIO_PK0_M1FAULT0       0x00090006
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+#define GPIO_PK1_M1FAULT1       0x00090406
+
+#define GPIO_PK2_SSI3RX         0x00090802
+#define GPIO_PK2_M1FAULT2       0x00090806
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+#define GPIO_PK3_M1FAULT3       0x00090C06
+
+#endif // PART_TM4C123GH6PZ
+
+//*****************************************************************************
+//
+// TM4C1231H6PGE Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1231H6PGE
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE7_U1RI           0x00041C01
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_T2CCP1         0x00051407
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PJ3_U5TX           0x00080C01
+#define GPIO_PJ3_T2CCP1         0x00080C07
+
+#define GPIO_PJ4_U6RX           0x00081001
+#define GPIO_PJ4_T3CCP0         0x00081007
+
+#define GPIO_PJ5_U6TX           0x00081401
+#define GPIO_PJ5_T3CCP1         0x00081407
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+
+#define GPIO_PK2_SSI3RX         0x00090802
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+
+#define GPIO_PK4_U7RX           0x00091001
+#define GPIO_PK4_RTCCLK         0x00091007
+#define GPIO_PK4_C0O            0x00091008
+
+#define GPIO_PK5_U7TX           0x00091401
+#define GPIO_PK5_C1O            0x00091408
+
+#define GPIO_PK6_WT1CCP0        0x00091807
+#define GPIO_PK6_C2O            0x00091808
+
+#define GPIO_PK7_WT1CCP1        0x00091C07
+
+#define GPIO_PL0_T0CCP0         0x000A0007
+#define GPIO_PL0_WT0CCP0        0x000A0008
+
+#define GPIO_PL1_T0CCP1         0x000A0407
+#define GPIO_PL1_WT0CCP1        0x000A0408
+
+#define GPIO_PL2_T1CCP0         0x000A0807
+#define GPIO_PL2_WT1CCP0        0x000A0808
+
+#define GPIO_PL3_T1CCP1         0x000A0C07
+#define GPIO_PL3_WT1CCP1        0x000A0C08
+
+#define GPIO_PL4_T2CCP0         0x000A1007
+#define GPIO_PL4_WT2CCP0        0x000A1008
+
+#define GPIO_PL5_T2CCP1         0x000A1407
+#define GPIO_PL5_WT2CCP1        0x000A1408
+
+#define GPIO_PL6_T3CCP0         0x000A1807
+#define GPIO_PL6_WT3CCP0        0x000A1808
+
+#define GPIO_PL7_T3CCP1         0x000A1C07
+#define GPIO_PL7_WT3CCP1        0x000A1C08
+
+#define GPIO_PM0_T4CCP0         0x000B0007
+#define GPIO_PM0_WT4CCP0        0x000B0008
+
+#define GPIO_PM1_T4CCP1         0x000B0407
+#define GPIO_PM1_WT4CCP1        0x000B0408
+
+#define GPIO_PM2_T5CCP0         0x000B0807
+#define GPIO_PM2_WT5CCP0        0x000B0808
+
+#define GPIO_PM3_T5CCP1         0x000B0C07
+#define GPIO_PM3_WT5CCP1        0x000B0C08
+
+#define GPIO_PM6_WT0CCP0        0x000B1807
+
+#define GPIO_PM7_WT0CCP1        0x000B1C07
+
+#define GPIO_PN0_CAN0RX         0x000C0001
+
+#define GPIO_PN1_CAN0TX         0x000C0401
+
+#define GPIO_PN2_WT2CCP0        0x000C0807
+
+#define GPIO_PN3_WT2CCP1        0x000C0C07
+
+#define GPIO_PN4_WT3CCP0        0x000C1007
+
+#define GPIO_PN5_WT3CCP1        0x000C1407
+
+#define GPIO_PN6_WT4CCP0        0x000C1807
+
+#define GPIO_PN7_WT4CCP1        0x000C1C07
+
+#define GPIO_PP0_T4CCP0         0x000D0007
+
+#define GPIO_PP1_T4CCP1         0x000D0407
+
+#define GPIO_PP2_T5CCP0         0x000D0807
+
+#endif // PART_TM4C1231H6PGE
+
+//*****************************************************************************
+//
+// TM4C1233H6PGE Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1233H6PGE
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE7_U1RI           0x00041C01
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_T2CCP1         0x00051407
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PJ3_U5TX           0x00080C01
+#define GPIO_PJ3_T2CCP1         0x00080C07
+
+#define GPIO_PJ4_U6RX           0x00081001
+#define GPIO_PJ4_T3CCP0         0x00081007
+
+#define GPIO_PJ5_U6TX           0x00081401
+#define GPIO_PJ5_T3CCP1         0x00081407
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+
+#define GPIO_PK2_SSI3RX         0x00090802
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+
+#define GPIO_PK4_U7RX           0x00091001
+#define GPIO_PK4_RTCCLK         0x00091007
+#define GPIO_PK4_C0O            0x00091008
+
+#define GPIO_PK5_U7TX           0x00091401
+#define GPIO_PK5_C1O            0x00091408
+
+#define GPIO_PK6_WT1CCP0        0x00091807
+#define GPIO_PK6_C2O            0x00091808
+
+#define GPIO_PK7_WT1CCP1        0x00091C07
+
+#define GPIO_PL0_T0CCP0         0x000A0007
+#define GPIO_PL0_WT0CCP0        0x000A0008
+
+#define GPIO_PL1_T0CCP1         0x000A0407
+#define GPIO_PL1_WT0CCP1        0x000A0408
+
+#define GPIO_PL2_T1CCP0         0x000A0807
+#define GPIO_PL2_WT1CCP0        0x000A0808
+
+#define GPIO_PL3_T1CCP1         0x000A0C07
+#define GPIO_PL3_WT1CCP1        0x000A0C08
+
+#define GPIO_PL4_T2CCP0         0x000A1007
+#define GPIO_PL4_WT2CCP0        0x000A1008
+
+#define GPIO_PL5_T2CCP1         0x000A1407
+#define GPIO_PL5_WT2CCP1        0x000A1408
+
+#define GPIO_PL6_T3CCP0         0x000A1807
+#define GPIO_PL6_WT3CCP0        0x000A1808
+
+#define GPIO_PL7_T3CCP1         0x000A1C07
+#define GPIO_PL7_WT3CCP1        0x000A1C08
+
+#define GPIO_PM0_T4CCP0         0x000B0007
+#define GPIO_PM0_WT4CCP0        0x000B0008
+
+#define GPIO_PM1_T4CCP1         0x000B0407
+#define GPIO_PM1_WT4CCP1        0x000B0408
+
+#define GPIO_PM2_T5CCP0         0x000B0807
+#define GPIO_PM2_WT5CCP0        0x000B0808
+
+#define GPIO_PM3_T5CCP1         0x000B0C07
+#define GPIO_PM3_WT5CCP1        0x000B0C08
+
+#define GPIO_PM6_WT0CCP0        0x000B1807
+
+#define GPIO_PM7_WT0CCP1        0x000B1C07
+
+#define GPIO_PN0_CAN0RX         0x000C0001
+
+#define GPIO_PN1_CAN0TX         0x000C0401
+
+#define GPIO_PN2_WT2CCP0        0x000C0807
+
+#define GPIO_PN3_WT2CCP1        0x000C0C07
+
+#define GPIO_PN4_WT3CCP0        0x000C1007
+
+#define GPIO_PN5_WT3CCP1        0x000C1407
+
+#define GPIO_PN6_WT4CCP0        0x000C1807
+
+#define GPIO_PN7_WT4CCP1        0x000C1C07
+
+#define GPIO_PP0_T4CCP0         0x000D0007
+
+#define GPIO_PP1_T4CCP1         0x000D0407
+
+#define GPIO_PP2_T5CCP0         0x000D0807
+
+#endif // PART_TM4C1233H6PGE
+
+//*****************************************************************************
+//
+// TM4C1237H6PGE Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1237H6PGE
+
+#define GPIO_PA0_U0RX           0x00000001
+
+#define GPIO_PA1_U0TX           0x00000401
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE7_U1RI           0x00041C01
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_T2CCP1         0x00051407
+#define GPIO_PF5_USB0PFLT       0x00051408
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_WT0CCP0        0x00061007
+#define GPIO_PG4_USB0EPEN       0x00061008
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_WT0CCP1        0x00061407
+#define GPIO_PG5_USB0PFLT       0x00061408
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PJ3_U5TX           0x00080C01
+#define GPIO_PJ3_T2CCP1         0x00080C07
+
+#define GPIO_PJ4_U6RX           0x00081001
+#define GPIO_PJ4_T3CCP0         0x00081007
+
+#define GPIO_PJ5_U6TX           0x00081401
+#define GPIO_PJ5_T3CCP1         0x00081407
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+
+#define GPIO_PK2_SSI3RX         0x00090802
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+
+#define GPIO_PK4_U7RX           0x00091001
+#define GPIO_PK4_RTCCLK         0x00091007
+#define GPIO_PK4_C0O            0x00091008
+
+#define GPIO_PK5_U7TX           0x00091401
+#define GPIO_PK5_C1O            0x00091408
+
+#define GPIO_PK6_WT1CCP0        0x00091807
+#define GPIO_PK6_C2O            0x00091808
+
+#define GPIO_PK7_WT1CCP1        0x00091C07
+
+#define GPIO_PL0_T0CCP0         0x000A0007
+#define GPIO_PL0_WT0CCP0        0x000A0008
+
+#define GPIO_PL1_T0CCP1         0x000A0407
+#define GPIO_PL1_WT0CCP1        0x000A0408
+
+#define GPIO_PL2_T1CCP0         0x000A0807
+#define GPIO_PL2_WT1CCP0        0x000A0808
+
+#define GPIO_PL3_T1CCP1         0x000A0C07
+#define GPIO_PL3_WT1CCP1        0x000A0C08
+
+#define GPIO_PL4_T2CCP0         0x000A1007
+#define GPIO_PL4_WT2CCP0        0x000A1008
+
+#define GPIO_PL5_T2CCP1         0x000A1407
+#define GPIO_PL5_WT2CCP1        0x000A1408
+
+#define GPIO_PL6_T3CCP0         0x000A1807
+#define GPIO_PL6_WT3CCP0        0x000A1808
+
+#define GPIO_PL7_T3CCP1         0x000A1C07
+#define GPIO_PL7_WT3CCP1        0x000A1C08
+
+#define GPIO_PM0_T4CCP0         0x000B0007
+#define GPIO_PM0_WT4CCP0        0x000B0008
+
+#define GPIO_PM1_T4CCP1         0x000B0407
+#define GPIO_PM1_WT4CCP1        0x000B0408
+
+#define GPIO_PM2_T5CCP0         0x000B0807
+#define GPIO_PM2_WT5CCP0        0x000B0808
+
+#define GPIO_PM3_T5CCP1         0x000B0C07
+#define GPIO_PM3_WT5CCP1        0x000B0C08
+
+#define GPIO_PM6_WT0CCP0        0x000B1807
+
+#define GPIO_PM7_WT0CCP1        0x000B1C07
+
+#define GPIO_PN0_CAN0RX         0x000C0001
+
+#define GPIO_PN1_CAN0TX         0x000C0401
+
+#define GPIO_PN2_WT2CCP0        0x000C0807
+
+#define GPIO_PN3_WT2CCP1        0x000C0C07
+
+#define GPIO_PN4_WT3CCP0        0x000C1007
+
+#define GPIO_PN5_WT3CCP1        0x000C1407
+
+#define GPIO_PN6_WT4CCP0        0x000C1807
+
+#define GPIO_PN7_WT4CCP1        0x000C1C07
+
+#define GPIO_PP0_T4CCP0         0x000D0007
+
+#define GPIO_PP1_T4CCP1         0x000D0407
+
+#define GPIO_PP2_T5CCP0         0x000D0807
+
+#endif // PART_TM4C1237H6PGE
+
+//*****************************************************************************
+//
+// TM4C123BH6PGE Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C123BH6PGE
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_CAN1RX         0x00000008
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_CAN1TX         0x00000408
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+#define GPIO_PA6_M1PWM2         0x00001805
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+#define GPIO_PA7_M1PWM3         0x00001C05
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_M0PWM2         0x00011004
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_M0PWM3         0x00011404
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_M0PWM6         0x00021004
+#define GPIO_PC4_IDX1           0x00021006
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_M0PWM7         0x00021404
+#define GPIO_PC5_PHA1           0x00021406
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_PHB1           0x00021806
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_M0PWM6         0x00030004
+#define GPIO_PD0_M1PWM0         0x00030005
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_M0PWM7         0x00030404
+#define GPIO_PD1_M1PWM1         0x00030405
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_M0FAULT0       0x00030804
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_IDX0           0x00030C06
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_M0FAULT0       0x00031804
+#define GPIO_PD6_PHA0           0x00031806
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_M0FAULT1       0x00031C04
+#define GPIO_PD7_PHB0           0x00031C06
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_M0PWM4         0x00041004
+#define GPIO_PE4_M1PWM2         0x00041005
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_M0PWM5         0x00041404
+#define GPIO_PE5_M1PWM3         0x00041405
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE6_CAN1RX         0x00041808
+
+#define GPIO_PE7_U1RI           0x00041C01
+#define GPIO_PE7_CAN1TX         0x00041C08
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_M1PWM4         0x00050005
+#define GPIO_PF0_PHA0           0x00050006
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_M1PWM5         0x00050405
+#define GPIO_PF1_PHB0           0x00050406
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_M0FAULT0       0x00050804
+#define GPIO_PF2_M1PWM6         0x00050805
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_M0FAULT1       0x00050C04
+#define GPIO_PF3_M1PWM7         0x00050C05
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_M0FAULT2       0x00051004
+#define GPIO_PF4_M1FAULT0       0x00051005
+#define GPIO_PF4_IDX0           0x00051006
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_M0FAULT3       0x00051404
+#define GPIO_PF5_T2CCP1         0x00051407
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_M1FAULT0       0x00051C05
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_M1FAULT1       0x00060005
+#define GPIO_PG0_PHA1           0x00060006
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_M1FAULT2       0x00060405
+#define GPIO_PG1_PHB1           0x00060406
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_M0FAULT1       0x00060804
+#define GPIO_PG2_M1PWM0         0x00060805
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_M0FAULT2       0x00060C04
+#define GPIO_PG3_M1PWM1         0x00060C05
+#define GPIO_PG3_PHA1           0x00060C06
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_M0PWM4         0x00061004
+#define GPIO_PG4_M1PWM2         0x00061005
+#define GPIO_PG4_PHB1           0x00061006
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_M0PWM5         0x00061404
+#define GPIO_PG5_M1PWM3         0x00061405
+#define GPIO_PG5_IDX1           0x00061406
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_M0PWM6         0x00061804
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_M0PWM7         0x00061C04
+#define GPIO_PG7_IDX1           0x00061C05
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_M0PWM0         0x00070004
+#define GPIO_PH0_M0FAULT0       0x00070006
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_M0PWM1         0x00070404
+#define GPIO_PH1_IDX0           0x00070405
+#define GPIO_PH1_M0FAULT1       0x00070406
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_M0PWM2         0x00070804
+#define GPIO_PH2_M0FAULT2       0x00070806
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_M0PWM3         0x00070C04
+#define GPIO_PH3_M0FAULT3       0x00070C06
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_M0PWM4         0x00071004
+#define GPIO_PH4_PHA0           0x00071005
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_M0PWM5         0x00071404
+#define GPIO_PH5_PHB0           0x00071405
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_M0PWM6         0x00071804
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_M0PWM7         0x00071C04
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_IDX0           0x00080805
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PJ3_U5TX           0x00080C01
+#define GPIO_PJ3_T2CCP1         0x00080C07
+
+#define GPIO_PJ4_U6RX           0x00081001
+#define GPIO_PJ4_T3CCP0         0x00081007
+
+#define GPIO_PJ5_U6TX           0x00081401
+#define GPIO_PJ5_T3CCP1         0x00081407
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+#define GPIO_PK0_M1FAULT0       0x00090006
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+#define GPIO_PK1_M1FAULT1       0x00090406
+
+#define GPIO_PK2_SSI3RX         0x00090802
+#define GPIO_PK2_M1FAULT2       0x00090806
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+#define GPIO_PK3_M1FAULT3       0x00090C06
+
+#define GPIO_PK4_U7RX           0x00091001
+#define GPIO_PK4_M0FAULT0       0x00091006
+#define GPIO_PK4_RTCCLK         0x00091007
+#define GPIO_PK4_C0O            0x00091008
+
+#define GPIO_PK5_U7TX           0x00091401
+#define GPIO_PK5_M0FAULT1       0x00091406
+#define GPIO_PK5_C1O            0x00091408
+
+#define GPIO_PK6_M0FAULT2       0x00091806
+#define GPIO_PK6_WT1CCP0        0x00091807
+#define GPIO_PK6_C2O            0x00091808
+
+#define GPIO_PK7_M0FAULT3       0x00091C06
+#define GPIO_PK7_WT1CCP1        0x00091C07
+
+#define GPIO_PL0_T0CCP0         0x000A0007
+#define GPIO_PL0_WT0CCP0        0x000A0008
+
+#define GPIO_PL1_T0CCP1         0x000A0407
+#define GPIO_PL1_WT0CCP1        0x000A0408
+
+#define GPIO_PL2_T1CCP0         0x000A0807
+#define GPIO_PL2_WT1CCP0        0x000A0808
+
+#define GPIO_PL3_T1CCP1         0x000A0C07
+#define GPIO_PL3_WT1CCP1        0x000A0C08
+
+#define GPIO_PL4_T2CCP0         0x000A1007
+#define GPIO_PL4_WT2CCP0        0x000A1008
+
+#define GPIO_PL5_T2CCP1         0x000A1407
+#define GPIO_PL5_WT2CCP1        0x000A1408
+
+#define GPIO_PL6_T3CCP0         0x000A1807
+#define GPIO_PL6_WT3CCP0        0x000A1808
+
+#define GPIO_PL7_T3CCP1         0x000A1C07
+#define GPIO_PL7_WT3CCP1        0x000A1C08
+
+#define GPIO_PM0_T4CCP0         0x000B0007
+#define GPIO_PM0_WT4CCP0        0x000B0008
+
+#define GPIO_PM1_T4CCP1         0x000B0407
+#define GPIO_PM1_WT4CCP1        0x000B0408
+
+#define GPIO_PM2_T5CCP0         0x000B0807
+#define GPIO_PM2_WT5CCP0        0x000B0808
+
+#define GPIO_PM3_T5CCP1         0x000B0C07
+#define GPIO_PM3_WT5CCP1        0x000B0C08
+
+#define GPIO_PM6_M0PWM4         0x000B1802
+#define GPIO_PM6_WT0CCP0        0x000B1807
+
+#define GPIO_PM7_M0PWM5         0x000B1C02
+#define GPIO_PM7_WT0CCP1        0x000B1C07
+
+#define GPIO_PN0_CAN0RX         0x000C0001
+
+#define GPIO_PN1_CAN0TX         0x000C0401
+
+#define GPIO_PN2_M0PWM6         0x000C0802
+#define GPIO_PN2_WT2CCP0        0x000C0807
+
+#define GPIO_PN3_M0PWM7         0x000C0C02
+#define GPIO_PN3_WT2CCP1        0x000C0C07
+
+#define GPIO_PN4_M1PWM4         0x000C1002
+#define GPIO_PN4_WT3CCP0        0x000C1007
+
+#define GPIO_PN5_M1PWM5         0x000C1402
+#define GPIO_PN5_WT3CCP1        0x000C1407
+
+#define GPIO_PN6_M1PWM6         0x000C1802
+#define GPIO_PN6_WT4CCP0        0x000C1807
+
+#define GPIO_PN7_M1PWM7         0x000C1C02
+#define GPIO_PN7_WT4CCP1        0x000C1C07
+
+#define GPIO_PP0_M0PWM0         0x000D0001
+#define GPIO_PP0_T4CCP0         0x000D0007
+
+#define GPIO_PP1_M0PWM1         0x000D0401
+#define GPIO_PP1_T4CCP1         0x000D0407
+
+#define GPIO_PP2_M0PWM2         0x000D0801
+#define GPIO_PP2_T5CCP0         0x000D0807
+
+#endif // PART_TM4C123BH6PGE
+
+//*****************************************************************************
+//
+// TM4C123BH6ZRB Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C123BH6ZRB
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_CAN1RX         0x00000008
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_CAN1TX         0x00000408
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+#define GPIO_PA6_M1PWM2         0x00001805
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+#define GPIO_PA7_M1PWM3         0x00001C05
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_M0PWM2         0x00011004
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_M0PWM3         0x00011404
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_M0PWM0         0x00011804
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_M0PWM1         0x00011C04
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_M0PWM6         0x00021004
+#define GPIO_PC4_IDX1           0x00021006
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_M0PWM7         0x00021404
+#define GPIO_PC5_PHA1           0x00021406
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_PHB1           0x00021806
+#define GPIO_PC6_WT1CCP0        0x00021807
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_M0PWM6         0x00030004
+#define GPIO_PD0_M1PWM0         0x00030005
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_M0PWM7         0x00030404
+#define GPIO_PD1_M1PWM1         0x00030405
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_M0FAULT0       0x00030804
+#define GPIO_PD2_WT3CCP0        0x00030807
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_IDX0           0x00030C06
+#define GPIO_PD3_WT3CCP1        0x00030C07
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_M0FAULT0       0x00031804
+#define GPIO_PD6_PHA0           0x00031806
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_M0FAULT1       0x00031C04
+#define GPIO_PD7_PHB0           0x00031C06
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_M0PWM4         0x00041004
+#define GPIO_PE4_M1PWM2         0x00041005
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_M0PWM5         0x00041404
+#define GPIO_PE5_M1PWM3         0x00041405
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE6_CAN1RX         0x00041808
+
+#define GPIO_PE7_U1RI           0x00041C01
+#define GPIO_PE7_CAN1TX         0x00041C08
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_M1PWM4         0x00050005
+#define GPIO_PF0_PHA0           0x00050006
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_M1PWM5         0x00050405
+#define GPIO_PF1_PHB0           0x00050406
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_M0FAULT0       0x00050804
+#define GPIO_PF2_M1PWM6         0x00050805
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_M0FAULT1       0x00050C04
+#define GPIO_PF3_M1PWM7         0x00050C05
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_M0FAULT2       0x00051004
+#define GPIO_PF4_M1FAULT0       0x00051005
+#define GPIO_PF4_IDX0           0x00051006
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_M0FAULT3       0x00051404
+#define GPIO_PF5_T2CCP1         0x00051407
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_M1FAULT0       0x00051C05
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_M1FAULT1       0x00060005
+#define GPIO_PG0_PHA1           0x00060006
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_M1FAULT2       0x00060405
+#define GPIO_PG1_PHB1           0x00060406
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_M0FAULT1       0x00060804
+#define GPIO_PG2_M1PWM0         0x00060805
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_M0FAULT2       0x00060C04
+#define GPIO_PG3_M1PWM1         0x00060C05
+#define GPIO_PG3_PHA1           0x00060C06
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_M0PWM4         0x00061004
+#define GPIO_PG4_M1PWM2         0x00061005
+#define GPIO_PG4_PHB1           0x00061006
+#define GPIO_PG4_WT0CCP0        0x00061007
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_M0PWM5         0x00061404
+#define GPIO_PG5_M1PWM3         0x00061405
+#define GPIO_PG5_IDX1           0x00061406
+#define GPIO_PG5_WT0CCP1        0x00061407
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_M0PWM6         0x00061804
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_M0PWM7         0x00061C04
+#define GPIO_PG7_IDX1           0x00061C05
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_M0PWM0         0x00070004
+#define GPIO_PH0_M0FAULT0       0x00070006
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_M0PWM1         0x00070404
+#define GPIO_PH1_IDX0           0x00070405
+#define GPIO_PH1_M0FAULT1       0x00070406
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_M0PWM2         0x00070804
+#define GPIO_PH2_M0FAULT2       0x00070806
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_M0PWM3         0x00070C04
+#define GPIO_PH3_M0FAULT3       0x00070C06
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_M0PWM4         0x00071004
+#define GPIO_PH4_PHA0           0x00071005
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_M0PWM5         0x00071404
+#define GPIO_PH5_PHB0           0x00071405
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_M0PWM6         0x00071804
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_M0PWM7         0x00071C04
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_IDX0           0x00080805
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PJ3_U5TX           0x00080C01
+#define GPIO_PJ3_T2CCP1         0x00080C07
+
+#define GPIO_PJ4_U6RX           0x00081001
+#define GPIO_PJ4_T3CCP0         0x00081007
+
+#define GPIO_PJ5_U6TX           0x00081401
+#define GPIO_PJ5_T3CCP1         0x00081407
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+#define GPIO_PK0_M1FAULT0       0x00090006
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+#define GPIO_PK1_M1FAULT1       0x00090406
+
+#define GPIO_PK2_SSI3RX         0x00090802
+#define GPIO_PK2_M1FAULT2       0x00090806
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+#define GPIO_PK3_M1FAULT3       0x00090C06
+
+#define GPIO_PK4_U7RX           0x00091001
+#define GPIO_PK4_M0FAULT0       0x00091006
+#define GPIO_PK4_RTCCLK         0x00091007
+#define GPIO_PK4_C0O            0x00091008
+
+#define GPIO_PK5_U7TX           0x00091401
+#define GPIO_PK5_M0FAULT1       0x00091406
+#define GPIO_PK5_C1O            0x00091408
+
+#define GPIO_PK6_M0FAULT2       0x00091806
+#define GPIO_PK6_WT1CCP0        0x00091807
+#define GPIO_PK6_C2O            0x00091808
+
+#define GPIO_PK7_M0FAULT3       0x00091C06
+#define GPIO_PK7_WT1CCP1        0x00091C07
+
+#define GPIO_PL0_T0CCP0         0x000A0007
+#define GPIO_PL0_WT0CCP0        0x000A0008
+
+#define GPIO_PL1_T0CCP1         0x000A0407
+#define GPIO_PL1_WT0CCP1        0x000A0408
+
+#define GPIO_PL2_T1CCP0         0x000A0807
+#define GPIO_PL2_WT1CCP0        0x000A0808
+
+#define GPIO_PL3_T1CCP1         0x000A0C07
+#define GPIO_PL3_WT1CCP1        0x000A0C08
+
+#define GPIO_PL4_T2CCP0         0x000A1007
+#define GPIO_PL4_WT2CCP0        0x000A1008
+
+#define GPIO_PL5_T2CCP1         0x000A1407
+#define GPIO_PL5_WT2CCP1        0x000A1408
+
+#define GPIO_PL6_T3CCP0         0x000A1807
+#define GPIO_PL6_WT3CCP0        0x000A1808
+
+#define GPIO_PL7_T3CCP1         0x000A1C07
+#define GPIO_PL7_WT3CCP1        0x000A1C08
+
+#define GPIO_PM0_T4CCP0         0x000B0007
+#define GPIO_PM0_WT4CCP0        0x000B0008
+
+#define GPIO_PM1_T4CCP1         0x000B0407
+#define GPIO_PM1_WT4CCP1        0x000B0408
+
+#define GPIO_PM2_T5CCP0         0x000B0807
+#define GPIO_PM2_WT5CCP0        0x000B0808
+
+#define GPIO_PM3_T5CCP1         0x000B0C07
+#define GPIO_PM3_WT5CCP1        0x000B0C08
+
+#define GPIO_PM6_M0PWM4         0x000B1802
+#define GPIO_PM6_WT0CCP0        0x000B1807
+
+#define GPIO_PM7_M0PWM5         0x000B1C02
+#define GPIO_PM7_WT0CCP1        0x000B1C07
+
+#define GPIO_PN0_CAN0RX         0x000C0001
+
+#define GPIO_PN1_CAN0TX         0x000C0401
+
+#define GPIO_PN2_M0PWM6         0x000C0802
+#define GPIO_PN2_WT2CCP0        0x000C0807
+
+#define GPIO_PN3_M0PWM7         0x000C0C02
+#define GPIO_PN3_WT2CCP1        0x000C0C07
+
+#define GPIO_PN4_M1PWM4         0x000C1002
+#define GPIO_PN4_WT3CCP0        0x000C1007
+
+#define GPIO_PN5_M1PWM5         0x000C1402
+#define GPIO_PN5_WT3CCP1        0x000C1407
+
+#define GPIO_PN6_M1PWM6         0x000C1802
+#define GPIO_PN6_WT4CCP0        0x000C1807
+
+#define GPIO_PN7_M1PWM7         0x000C1C02
+#define GPIO_PN7_WT4CCP1        0x000C1C07
+
+#define GPIO_PP0_M0PWM0         0x000D0001
+#define GPIO_PP0_T4CCP0         0x000D0007
+
+#define GPIO_PP1_M0PWM1         0x000D0401
+#define GPIO_PP1_T4CCP1         0x000D0407
+
+#define GPIO_PP2_M0PWM2         0x000D0801
+#define GPIO_PP2_T5CCP0         0x000D0807
+
+#define GPIO_PP3_M0PWM3         0x000D0C01
+#define GPIO_PP3_T5CCP1         0x000D0C07
+
+#define GPIO_PP4_M0PWM4         0x000D1001
+#define GPIO_PP4_WT0CCP0        0x000D1007
+
+#define GPIO_PP5_M0PWM5         0x000D1401
+#define GPIO_PP5_WT0CCP1        0x000D1407
+
+#define GPIO_PP6_M0PWM6         0x000D1801
+#define GPIO_PP6_WT1CCP0        0x000D1807
+
+#define GPIO_PP7_M0PWM7         0x000D1C01
+#define GPIO_PP7_WT1CCP1        0x000D1C07
+
+#define GPIO_PQ0_M1PWM0         0x000E0001
+#define GPIO_PQ0_WT2CCP0        0x000E0007
+
+#define GPIO_PQ1_M1PWM1         0x000E0401
+#define GPIO_PQ1_WT2CCP1        0x000E0407
+
+#define GPIO_PQ2_M1PWM2         0x000E0801
+#define GPIO_PQ2_WT3CCP0        0x000E0807
+
+#define GPIO_PQ3_M1PWM3         0x000E0C01
+#define GPIO_PQ3_WT3CCP1        0x000E0C07
+
+#define GPIO_PQ4_M1PWM4         0x000E1001
+#define GPIO_PQ4_WT4CCP0        0x000E1007
+
+#define GPIO_PQ5_M1PWM5         0x000E1401
+#define GPIO_PQ5_WT4CCP1        0x000E1407
+
+#define GPIO_PQ6_M1PWM6         0x000E1801
+#define GPIO_PQ6_WT5CCP0        0x000E1807
+
+#define GPIO_PQ7_M1PWM7         0x000E1C01
+#define GPIO_PQ7_WT5CCP1        0x000E1C07
+
+#endif // PART_TM4C123BH6ZRB
+
+//*****************************************************************************
+//
+// TM4C123GH6PGE Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C123GH6PGE
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_CAN1RX         0x00000008
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_CAN1TX         0x00000408
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+#define GPIO_PA6_M1PWM2         0x00001805
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+#define GPIO_PA7_M1PWM3         0x00001C05
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_M0PWM2         0x00011004
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_M0PWM3         0x00011404
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_M0PWM6         0x00021004
+#define GPIO_PC4_IDX1           0x00021006
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_M0PWM7         0x00021404
+#define GPIO_PC5_PHA1           0x00021406
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_PHB1           0x00021806
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_M0PWM6         0x00030004
+#define GPIO_PD0_M1PWM0         0x00030005
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_M0PWM7         0x00030404
+#define GPIO_PD1_M1PWM1         0x00030405
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_M0FAULT0       0x00030804
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_IDX0           0x00030C06
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_M0FAULT0       0x00031804
+#define GPIO_PD6_PHA0           0x00031806
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_M0FAULT1       0x00031C04
+#define GPIO_PD7_PHB0           0x00031C06
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_M0PWM4         0x00041004
+#define GPIO_PE4_M1PWM2         0x00041005
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_M0PWM5         0x00041404
+#define GPIO_PE5_M1PWM3         0x00041405
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE6_CAN1RX         0x00041808
+
+#define GPIO_PE7_U1RI           0x00041C01
+#define GPIO_PE7_CAN1TX         0x00041C08
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_M1PWM4         0x00050005
+#define GPIO_PF0_PHA0           0x00050006
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_M1PWM5         0x00050405
+#define GPIO_PF1_PHB0           0x00050406
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_M0FAULT0       0x00050804
+#define GPIO_PF2_M1PWM6         0x00050805
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_M0FAULT1       0x00050C04
+#define GPIO_PF3_M1PWM7         0x00050C05
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_M0FAULT2       0x00051004
+#define GPIO_PF4_M1FAULT0       0x00051005
+#define GPIO_PF4_IDX0           0x00051006
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_M0FAULT3       0x00051404
+#define GPIO_PF5_T2CCP1         0x00051407
+#define GPIO_PF5_USB0PFLT       0x00051408
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_M1FAULT0       0x00051C05
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_M1FAULT1       0x00060005
+#define GPIO_PG0_PHA1           0x00060006
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_M1FAULT2       0x00060405
+#define GPIO_PG1_PHB1           0x00060406
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_M0FAULT1       0x00060804
+#define GPIO_PG2_M1PWM0         0x00060805
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_M0FAULT2       0x00060C04
+#define GPIO_PG3_M1PWM1         0x00060C05
+#define GPIO_PG3_PHA1           0x00060C06
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_M0PWM4         0x00061004
+#define GPIO_PG4_M1PWM2         0x00061005
+#define GPIO_PG4_PHB1           0x00061006
+#define GPIO_PG4_WT0CCP0        0x00061007
+#define GPIO_PG4_USB0EPEN       0x00061008
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_M0PWM5         0x00061404
+#define GPIO_PG5_M1PWM3         0x00061405
+#define GPIO_PG5_IDX1           0x00061406
+#define GPIO_PG5_WT0CCP1        0x00061407
+#define GPIO_PG5_USB0PFLT       0x00061408
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_M0PWM6         0x00061804
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_M0PWM7         0x00061C04
+#define GPIO_PG7_IDX1           0x00061C05
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_M0PWM0         0x00070004
+#define GPIO_PH0_M0FAULT0       0x00070006
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_M0PWM1         0x00070404
+#define GPIO_PH1_IDX0           0x00070405
+#define GPIO_PH1_M0FAULT1       0x00070406
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_M0PWM2         0x00070804
+#define GPIO_PH2_M0FAULT2       0x00070806
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_M0PWM3         0x00070C04
+#define GPIO_PH3_M0FAULT3       0x00070C06
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_M0PWM4         0x00071004
+#define GPIO_PH4_PHA0           0x00071005
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_M0PWM5         0x00071404
+#define GPIO_PH5_PHB0           0x00071405
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_M0PWM6         0x00071804
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_M0PWM7         0x00071C04
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_IDX0           0x00080805
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PJ3_U5TX           0x00080C01
+#define GPIO_PJ3_T2CCP1         0x00080C07
+
+#define GPIO_PJ4_U6RX           0x00081001
+#define GPIO_PJ4_T3CCP0         0x00081007
+
+#define GPIO_PJ5_U6TX           0x00081401
+#define GPIO_PJ5_T3CCP1         0x00081407
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+#define GPIO_PK0_M1FAULT0       0x00090006
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+#define GPIO_PK1_M1FAULT1       0x00090406
+
+#define GPIO_PK2_SSI3RX         0x00090802
+#define GPIO_PK2_M1FAULT2       0x00090806
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+#define GPIO_PK3_M1FAULT3       0x00090C06
+
+#define GPIO_PK4_U7RX           0x00091001
+#define GPIO_PK4_M0FAULT0       0x00091006
+#define GPIO_PK4_RTCCLK         0x00091007
+#define GPIO_PK4_C0O            0x00091008
+
+#define GPIO_PK5_U7TX           0x00091401
+#define GPIO_PK5_M0FAULT1       0x00091406
+#define GPIO_PK5_C1O            0x00091408
+
+#define GPIO_PK6_M0FAULT2       0x00091806
+#define GPIO_PK6_WT1CCP0        0x00091807
+#define GPIO_PK6_C2O            0x00091808
+
+#define GPIO_PK7_M0FAULT3       0x00091C06
+#define GPIO_PK7_WT1CCP1        0x00091C07
+
+#define GPIO_PL0_T0CCP0         0x000A0007
+#define GPIO_PL0_WT0CCP0        0x000A0008
+
+#define GPIO_PL1_T0CCP1         0x000A0407
+#define GPIO_PL1_WT0CCP1        0x000A0408
+
+#define GPIO_PL2_T1CCP0         0x000A0807
+#define GPIO_PL2_WT1CCP0        0x000A0808
+
+#define GPIO_PL3_T1CCP1         0x000A0C07
+#define GPIO_PL3_WT1CCP1        0x000A0C08
+
+#define GPIO_PL4_T2CCP0         0x000A1007
+#define GPIO_PL4_WT2CCP0        0x000A1008
+
+#define GPIO_PL5_T2CCP1         0x000A1407
+#define GPIO_PL5_WT2CCP1        0x000A1408
+
+#define GPIO_PL6_T3CCP0         0x000A1807
+#define GPIO_PL6_WT3CCP0        0x000A1808
+
+#define GPIO_PL7_T3CCP1         0x000A1C07
+#define GPIO_PL7_WT3CCP1        0x000A1C08
+
+#define GPIO_PM0_T4CCP0         0x000B0007
+#define GPIO_PM0_WT4CCP0        0x000B0008
+
+#define GPIO_PM1_T4CCP1         0x000B0407
+#define GPIO_PM1_WT4CCP1        0x000B0408
+
+#define GPIO_PM2_T5CCP0         0x000B0807
+#define GPIO_PM2_WT5CCP0        0x000B0808
+
+#define GPIO_PM3_T5CCP1         0x000B0C07
+#define GPIO_PM3_WT5CCP1        0x000B0C08
+
+#define GPIO_PM6_M0PWM4         0x000B1802
+#define GPIO_PM6_WT0CCP0        0x000B1807
+
+#define GPIO_PM7_M0PWM5         0x000B1C02
+#define GPIO_PM7_WT0CCP1        0x000B1C07
+
+#define GPIO_PN0_CAN0RX         0x000C0001
+
+#define GPIO_PN1_CAN0TX         0x000C0401
+
+#define GPIO_PN2_M0PWM6         0x000C0802
+#define GPIO_PN2_WT2CCP0        0x000C0807
+
+#define GPIO_PN3_M0PWM7         0x000C0C02
+#define GPIO_PN3_WT2CCP1        0x000C0C07
+
+#define GPIO_PN4_M1PWM4         0x000C1002
+#define GPIO_PN4_WT3CCP0        0x000C1007
+
+#define GPIO_PN5_M1PWM5         0x000C1402
+#define GPIO_PN5_WT3CCP1        0x000C1407
+
+#define GPIO_PN6_M1PWM6         0x000C1802
+#define GPIO_PN6_WT4CCP0        0x000C1807
+
+#define GPIO_PN7_M1PWM7         0x000C1C02
+#define GPIO_PN7_WT4CCP1        0x000C1C07
+
+#define GPIO_PP0_M0PWM0         0x000D0001
+#define GPIO_PP0_T4CCP0         0x000D0007
+
+#define GPIO_PP1_M0PWM1         0x000D0401
+#define GPIO_PP1_T4CCP1         0x000D0407
+
+#define GPIO_PP2_M0PWM2         0x000D0801
+#define GPIO_PP2_T5CCP0         0x000D0807
+
+#endif // PART_TM4C123GH6PGE
+
+//*****************************************************************************
+//
+// TM4C123GH6ZRB Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C123GH6ZRB
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_CAN1RX         0x00000008
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_CAN1TX         0x00000408
+
+#define GPIO_PA2_SSI0CLK        0x00000802
+
+#define GPIO_PA3_SSI0FSS        0x00000C02
+
+#define GPIO_PA4_SSI0RX         0x00001002
+
+#define GPIO_PA5_SSI0TX         0x00001402
+
+#define GPIO_PA6_I2C1SCL        0x00001803
+#define GPIO_PA6_M1PWM2         0x00001805
+
+#define GPIO_PA7_I2C1SDA        0x00001C03
+#define GPIO_PA7_M1PWM3         0x00001C05
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_T2CCP0         0x00010007
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_T2CCP1         0x00010407
+
+#define GPIO_PB2_I2C0SCL        0x00010803
+#define GPIO_PB2_T3CCP0         0x00010807
+
+#define GPIO_PB3_I2C0SDA        0x00010C03
+#define GPIO_PB3_T3CCP1         0x00010C07
+
+#define GPIO_PB4_SSI2CLK        0x00011002
+#define GPIO_PB4_M0PWM2         0x00011004
+#define GPIO_PB4_T1CCP0         0x00011007
+#define GPIO_PB4_CAN0RX         0x00011008
+
+#define GPIO_PB5_SSI2FSS        0x00011402
+#define GPIO_PB5_M0PWM3         0x00011404
+#define GPIO_PB5_T1CCP1         0x00011407
+#define GPIO_PB5_CAN0TX         0x00011408
+
+#define GPIO_PB6_SSI2RX         0x00011802
+#define GPIO_PB6_I2C5SCL        0x00011803
+#define GPIO_PB6_M0PWM0         0x00011804
+#define GPIO_PB6_T0CCP0         0x00011807
+
+#define GPIO_PB7_SSI2TX         0x00011C02
+#define GPIO_PB7_I2C5SDA        0x00011C03
+#define GPIO_PB7_M0PWM1         0x00011C04
+#define GPIO_PB7_T0CCP1         0x00011C07
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_T4CCP0         0x00020007
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_T4CCP1         0x00020407
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_T5CCP0         0x00020807
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_T5CCP1         0x00020C07
+
+#define GPIO_PC4_U4RX           0x00021001
+#define GPIO_PC4_U1RX           0x00021002
+#define GPIO_PC4_M0PWM6         0x00021004
+#define GPIO_PC4_IDX1           0x00021006
+#define GPIO_PC4_WT0CCP0        0x00021007
+#define GPIO_PC4_U1RTS          0x00021008
+
+#define GPIO_PC5_U4TX           0x00021401
+#define GPIO_PC5_U1TX           0x00021402
+#define GPIO_PC5_M0PWM7         0x00021404
+#define GPIO_PC5_PHA1           0x00021406
+#define GPIO_PC5_WT0CCP1        0x00021407
+#define GPIO_PC5_U1CTS          0x00021408
+
+#define GPIO_PC6_U3RX           0x00021801
+#define GPIO_PC6_PHB1           0x00021806
+#define GPIO_PC6_WT1CCP0        0x00021807
+#define GPIO_PC6_USB0EPEN       0x00021808
+
+#define GPIO_PC7_U3TX           0x00021C01
+#define GPIO_PC7_WT1CCP1        0x00021C07
+#define GPIO_PC7_USB0PFLT       0x00021C08
+
+#define GPIO_PD0_SSI3CLK        0x00030001
+#define GPIO_PD0_SSI1CLK        0x00030002
+#define GPIO_PD0_I2C3SCL        0x00030003
+#define GPIO_PD0_M0PWM6         0x00030004
+#define GPIO_PD0_M1PWM0         0x00030005
+#define GPIO_PD0_WT2CCP0        0x00030007
+
+#define GPIO_PD1_SSI3FSS        0x00030401
+#define GPIO_PD1_SSI1FSS        0x00030402
+#define GPIO_PD1_I2C3SDA        0x00030403
+#define GPIO_PD1_M0PWM7         0x00030404
+#define GPIO_PD1_M1PWM1         0x00030405
+#define GPIO_PD1_WT2CCP1        0x00030407
+
+#define GPIO_PD2_SSI3RX         0x00030801
+#define GPIO_PD2_SSI1RX         0x00030802
+#define GPIO_PD2_M0FAULT0       0x00030804
+#define GPIO_PD2_WT3CCP0        0x00030807
+#define GPIO_PD2_USB0EPEN       0x00030808
+
+#define GPIO_PD3_SSI3TX         0x00030C01
+#define GPIO_PD3_SSI1TX         0x00030C02
+#define GPIO_PD3_IDX0           0x00030C06
+#define GPIO_PD3_WT3CCP1        0x00030C07
+#define GPIO_PD3_USB0PFLT       0x00030C08
+
+#define GPIO_PD4_U6RX           0x00031001
+#define GPIO_PD4_WT4CCP0        0x00031007
+
+#define GPIO_PD5_U6TX           0x00031401
+#define GPIO_PD5_WT4CCP1        0x00031407
+
+#define GPIO_PD6_U2RX           0x00031801
+#define GPIO_PD6_M0FAULT0       0x00031804
+#define GPIO_PD6_PHA0           0x00031806
+#define GPIO_PD6_WT5CCP0        0x00031807
+
+#define GPIO_PD7_U2TX           0x00031C01
+#define GPIO_PD7_M0FAULT1       0x00031C04
+#define GPIO_PD7_PHB0           0x00031C06
+#define GPIO_PD7_WT5CCP1        0x00031C07
+#define GPIO_PD7_NMI            0x00031C08
+
+#define GPIO_PE0_U7RX           0x00040001
+
+#define GPIO_PE1_U7TX           0x00040401
+
+#define GPIO_PE4_U5RX           0x00041001
+#define GPIO_PE4_I2C2SCL        0x00041003
+#define GPIO_PE4_M0PWM4         0x00041004
+#define GPIO_PE4_M1PWM2         0x00041005
+#define GPIO_PE4_CAN0RX         0x00041008
+
+#define GPIO_PE5_U5TX           0x00041401
+#define GPIO_PE5_I2C2SDA        0x00041403
+#define GPIO_PE5_M0PWM5         0x00041404
+#define GPIO_PE5_M1PWM3         0x00041405
+#define GPIO_PE5_CAN0TX         0x00041408
+
+#define GPIO_PE6_CAN1RX         0x00041808
+
+#define GPIO_PE7_U1RI           0x00041C01
+#define GPIO_PE7_CAN1TX         0x00041C08
+
+#define GPIO_PF0_U1RTS          0x00050001
+#define GPIO_PF0_SSI1RX         0x00050002
+#define GPIO_PF0_CAN0RX         0x00050003
+#define GPIO_PF0_M1PWM4         0x00050005
+#define GPIO_PF0_PHA0           0x00050006
+#define GPIO_PF0_T0CCP0         0x00050007
+#define GPIO_PF0_NMI            0x00050008
+#define GPIO_PF0_C0O            0x00050009
+#define GPIO_PF0_TRD2           0x0005000E
+
+#define GPIO_PF1_U1CTS          0x00050401
+#define GPIO_PF1_SSI1TX         0x00050402
+#define GPIO_PF1_M1PWM5         0x00050405
+#define GPIO_PF1_PHB0           0x00050406
+#define GPIO_PF1_T0CCP1         0x00050407
+#define GPIO_PF1_C1O            0x00050409
+#define GPIO_PF1_TRD1           0x0005040E
+
+#define GPIO_PF2_U1DCD          0x00050801
+#define GPIO_PF2_SSI1CLK        0x00050802
+#define GPIO_PF2_M0FAULT0       0x00050804
+#define GPIO_PF2_M1PWM6         0x00050805
+#define GPIO_PF2_T1CCP0         0x00050807
+#define GPIO_PF2_C2O            0x00050809
+#define GPIO_PF2_TRD0           0x0005080E
+
+#define GPIO_PF3_U1DSR          0x00050C01
+#define GPIO_PF3_SSI1FSS        0x00050C02
+#define GPIO_PF3_CAN0TX         0x00050C03
+#define GPIO_PF3_M0FAULT1       0x00050C04
+#define GPIO_PF3_M1PWM7         0x00050C05
+#define GPIO_PF3_T1CCP1         0x00050C07
+#define GPIO_PF3_TRCLK          0x00050C0E
+
+#define GPIO_PF4_U1DTR          0x00051001
+#define GPIO_PF4_M0FAULT2       0x00051004
+#define GPIO_PF4_M1FAULT0       0x00051005
+#define GPIO_PF4_IDX0           0x00051006
+#define GPIO_PF4_T2CCP0         0x00051007
+#define GPIO_PF4_USB0EPEN       0x00051008
+#define GPIO_PF4_TRD3           0x0005100E
+
+#define GPIO_PF5_M0FAULT3       0x00051404
+#define GPIO_PF5_T2CCP1         0x00051407
+#define GPIO_PF5_USB0PFLT       0x00051408
+
+#define GPIO_PF6_I2C2SCL        0x00051803
+#define GPIO_PF6_T3CCP0         0x00051807
+
+#define GPIO_PF7_I2C2SDA        0x00051C03
+#define GPIO_PF7_M1FAULT0       0x00051C05
+#define GPIO_PF7_T3CCP1         0x00051C07
+
+#define GPIO_PG0_I2C3SCL        0x00060003
+#define GPIO_PG0_M1FAULT1       0x00060005
+#define GPIO_PG0_PHA1           0x00060006
+#define GPIO_PG0_T4CCP0         0x00060007
+
+#define GPIO_PG1_I2C3SDA        0x00060403
+#define GPIO_PG1_M1FAULT2       0x00060405
+#define GPIO_PG1_PHB1           0x00060406
+#define GPIO_PG1_T4CCP1         0x00060407
+
+#define GPIO_PG2_I2C4SCL        0x00060803
+#define GPIO_PG2_M0FAULT1       0x00060804
+#define GPIO_PG2_M1PWM0         0x00060805
+#define GPIO_PG2_T5CCP0         0x00060807
+
+#define GPIO_PG3_I2C4SDA        0x00060C03
+#define GPIO_PG3_M0FAULT2       0x00060C04
+#define GPIO_PG3_M1PWM1         0x00060C05
+#define GPIO_PG3_PHA1           0x00060C06
+#define GPIO_PG3_T5CCP1         0x00060C07
+
+#define GPIO_PG4_U2RX           0x00061001
+#define GPIO_PG4_I2C1SCL        0x00061003
+#define GPIO_PG4_M0PWM4         0x00061004
+#define GPIO_PG4_M1PWM2         0x00061005
+#define GPIO_PG4_PHB1           0x00061006
+#define GPIO_PG4_WT0CCP0        0x00061007
+#define GPIO_PG4_USB0EPEN       0x00061008
+
+#define GPIO_PG5_U2TX           0x00061401
+#define GPIO_PG5_I2C1SDA        0x00061403
+#define GPIO_PG5_M0PWM5         0x00061404
+#define GPIO_PG5_M1PWM3         0x00061405
+#define GPIO_PG5_IDX1           0x00061406
+#define GPIO_PG5_WT0CCP1        0x00061407
+#define GPIO_PG5_USB0PFLT       0x00061408
+
+#define GPIO_PG6_I2C5SCL        0x00061803
+#define GPIO_PG6_M0PWM6         0x00061804
+#define GPIO_PG6_WT1CCP0        0x00061807
+
+#define GPIO_PG7_I2C5SDA        0x00061C03
+#define GPIO_PG7_M0PWM7         0x00061C04
+#define GPIO_PG7_IDX1           0x00061C05
+#define GPIO_PG7_WT1CCP1        0x00061C07
+
+#define GPIO_PH0_SSI3CLK        0x00070002
+#define GPIO_PH0_M0PWM0         0x00070004
+#define GPIO_PH0_M0FAULT0       0x00070006
+#define GPIO_PH0_WT2CCP0        0x00070007
+
+#define GPIO_PH1_SSI3FSS        0x00070402
+#define GPIO_PH1_M0PWM1         0x00070404
+#define GPIO_PH1_IDX0           0x00070405
+#define GPIO_PH1_M0FAULT1       0x00070406
+#define GPIO_PH1_WT2CCP1        0x00070407
+
+#define GPIO_PH2_SSI3RX         0x00070802
+#define GPIO_PH2_M0PWM2         0x00070804
+#define GPIO_PH2_M0FAULT2       0x00070806
+#define GPIO_PH2_WT5CCP0        0x00070807
+
+#define GPIO_PH3_SSI3TX         0x00070C02
+#define GPIO_PH3_M0PWM3         0x00070C04
+#define GPIO_PH3_M0FAULT3       0x00070C06
+#define GPIO_PH3_WT5CCP1        0x00070C07
+
+#define GPIO_PH4_SSI2CLK        0x00071002
+#define GPIO_PH4_M0PWM4         0x00071004
+#define GPIO_PH4_PHA0           0x00071005
+#define GPIO_PH4_WT3CCP0        0x00071007
+
+#define GPIO_PH5_SSI2FSS        0x00071402
+#define GPIO_PH5_M0PWM5         0x00071404
+#define GPIO_PH5_PHB0           0x00071405
+#define GPIO_PH5_WT3CCP1        0x00071407
+
+#define GPIO_PH6_SSI2RX         0x00071802
+#define GPIO_PH6_M0PWM6         0x00071804
+#define GPIO_PH6_WT4CCP0        0x00071807
+
+#define GPIO_PH7_SSI2TX         0x00071C02
+#define GPIO_PH7_M0PWM7         0x00071C04
+#define GPIO_PH7_WT4CCP1        0x00071C07
+
+#define GPIO_PJ0_U4RX           0x00080001
+#define GPIO_PJ0_T1CCP0         0x00080007
+
+#define GPIO_PJ1_U4TX           0x00080401
+#define GPIO_PJ1_T1CCP1         0x00080407
+
+#define GPIO_PJ2_U5RX           0x00080801
+#define GPIO_PJ2_IDX0           0x00080805
+#define GPIO_PJ2_T2CCP0         0x00080807
+
+#define GPIO_PJ3_U5TX           0x00080C01
+#define GPIO_PJ3_T2CCP1         0x00080C07
+
+#define GPIO_PJ4_U6RX           0x00081001
+#define GPIO_PJ4_T3CCP0         0x00081007
+
+#define GPIO_PJ5_U6TX           0x00081401
+#define GPIO_PJ5_T3CCP1         0x00081407
+
+#define GPIO_PK0_SSI3CLK        0x00090002
+#define GPIO_PK0_M1FAULT0       0x00090006
+
+#define GPIO_PK1_SSI3FSS        0x00090402
+#define GPIO_PK1_M1FAULT1       0x00090406
+
+#define GPIO_PK2_SSI3RX         0x00090802
+#define GPIO_PK2_M1FAULT2       0x00090806
+
+#define GPIO_PK3_SSI3TX         0x00090C02
+#define GPIO_PK3_M1FAULT3       0x00090C06
+
+#define GPIO_PK4_U7RX           0x00091001
+#define GPIO_PK4_M0FAULT0       0x00091006
+#define GPIO_PK4_RTCCLK         0x00091007
+#define GPIO_PK4_C0O            0x00091008
+
+#define GPIO_PK5_U7TX           0x00091401
+#define GPIO_PK5_M0FAULT1       0x00091406
+#define GPIO_PK5_C1O            0x00091408
+
+#define GPIO_PK6_M0FAULT2       0x00091806
+#define GPIO_PK6_WT1CCP0        0x00091807
+#define GPIO_PK6_C2O            0x00091808
+
+#define GPIO_PK7_M0FAULT3       0x00091C06
+#define GPIO_PK7_WT1CCP1        0x00091C07
+
+#define GPIO_PL0_T0CCP0         0x000A0007
+#define GPIO_PL0_WT0CCP0        0x000A0008
+
+#define GPIO_PL1_T0CCP1         0x000A0407
+#define GPIO_PL1_WT0CCP1        0x000A0408
+
+#define GPIO_PL2_T1CCP0         0x000A0807
+#define GPIO_PL2_WT1CCP0        0x000A0808
+
+#define GPIO_PL3_T1CCP1         0x000A0C07
+#define GPIO_PL3_WT1CCP1        0x000A0C08
+
+#define GPIO_PL4_T2CCP0         0x000A1007
+#define GPIO_PL4_WT2CCP0        0x000A1008
+
+#define GPIO_PL5_T2CCP1         0x000A1407
+#define GPIO_PL5_WT2CCP1        0x000A1408
+
+#define GPIO_PL6_T3CCP0         0x000A1807
+#define GPIO_PL6_WT3CCP0        0x000A1808
+
+#define GPIO_PL7_T3CCP1         0x000A1C07
+#define GPIO_PL7_WT3CCP1        0x000A1C08
+
+#define GPIO_PM0_T4CCP0         0x000B0007
+#define GPIO_PM0_WT4CCP0        0x000B0008
+
+#define GPIO_PM1_T4CCP1         0x000B0407
+#define GPIO_PM1_WT4CCP1        0x000B0408
+
+#define GPIO_PM2_T5CCP0         0x000B0807
+#define GPIO_PM2_WT5CCP0        0x000B0808
+
+#define GPIO_PM3_T5CCP1         0x000B0C07
+#define GPIO_PM3_WT5CCP1        0x000B0C08
+
+#define GPIO_PM6_M0PWM4         0x000B1802
+#define GPIO_PM6_WT0CCP0        0x000B1807
+
+#define GPIO_PM7_M0PWM5         0x000B1C02
+#define GPIO_PM7_WT0CCP1        0x000B1C07
+
+#define GPIO_PN0_CAN0RX         0x000C0001
+
+#define GPIO_PN1_CAN0TX         0x000C0401
+
+#define GPIO_PN2_M0PWM6         0x000C0802
+#define GPIO_PN2_WT2CCP0        0x000C0807
+
+#define GPIO_PN3_M0PWM7         0x000C0C02
+#define GPIO_PN3_WT2CCP1        0x000C0C07
+
+#define GPIO_PN4_M1PWM4         0x000C1002
+#define GPIO_PN4_WT3CCP0        0x000C1007
+
+#define GPIO_PN5_M1PWM5         0x000C1402
+#define GPIO_PN5_WT3CCP1        0x000C1407
+
+#define GPIO_PN6_M1PWM6         0x000C1802
+#define GPIO_PN6_WT4CCP0        0x000C1807
+
+#define GPIO_PN7_M1PWM7         0x000C1C02
+#define GPIO_PN7_WT4CCP1        0x000C1C07
+
+#define GPIO_PP0_M0PWM0         0x000D0001
+#define GPIO_PP0_T4CCP0         0x000D0007
+
+#define GPIO_PP1_M0PWM1         0x000D0401
+#define GPIO_PP1_T4CCP1         0x000D0407
+
+#define GPIO_PP2_M0PWM2         0x000D0801
+#define GPIO_PP2_T5CCP0         0x000D0807
+
+#define GPIO_PP3_M0PWM3         0x000D0C01
+#define GPIO_PP3_T5CCP1         0x000D0C07
+
+#define GPIO_PP4_M0PWM4         0x000D1001
+#define GPIO_PP4_WT0CCP0        0x000D1007
+
+#define GPIO_PP5_M0PWM5         0x000D1401
+#define GPIO_PP5_WT0CCP1        0x000D1407
+
+#define GPIO_PP6_M0PWM6         0x000D1801
+#define GPIO_PP6_WT1CCP0        0x000D1807
+
+#define GPIO_PP7_M0PWM7         0x000D1C01
+#define GPIO_PP7_WT1CCP1        0x000D1C07
+
+#define GPIO_PQ0_M1PWM0         0x000E0001
+#define GPIO_PQ0_WT2CCP0        0x000E0007
+
+#define GPIO_PQ1_M1PWM1         0x000E0401
+#define GPIO_PQ1_WT2CCP1        0x000E0407
+
+#define GPIO_PQ2_M1PWM2         0x000E0801
+#define GPIO_PQ2_WT3CCP0        0x000E0807
+
+#define GPIO_PQ3_M1PWM3         0x000E0C01
+#define GPIO_PQ3_WT3CCP1        0x000E0C07
+
+#define GPIO_PQ4_M1PWM4         0x000E1001
+#define GPIO_PQ4_WT4CCP0        0x000E1007
+
+#define GPIO_PQ5_M1PWM5         0x000E1401
+#define GPIO_PQ5_WT4CCP1        0x000E1407
+
+#define GPIO_PQ6_M1PWM6         0x000E1801
+#define GPIO_PQ6_WT5CCP0        0x000E1807
+
+#define GPIO_PQ7_M1PWM7         0x000E1C01
+#define GPIO_PQ7_WT5CCP1        0x000E1C07
+
+#endif // PART_TM4C123GH6ZRB
+
+//*****************************************************************************
+//
+// TM4C1290NCPDT Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1290NCPDT
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_I2C9SCL        0x00000002
+#define GPIO_PA0_T0CCP0         0x00000003
+#define GPIO_PA0_CAN0RX         0x00000007
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_I2C9SDA        0x00000402
+#define GPIO_PA1_T0CCP1         0x00000403
+#define GPIO_PA1_CAN0TX         0x00000407
+
+#define GPIO_PA2_U4RX           0x00000801
+#define GPIO_PA2_I2C8SCL        0x00000802
+#define GPIO_PA2_T1CCP0         0x00000803
+#define GPIO_PA2_SSI0CLK        0x0000080F
+
+#define GPIO_PA3_U4TX           0x00000C01
+#define GPIO_PA3_I2C8SDA        0x00000C02
+#define GPIO_PA3_T1CCP1         0x00000C03
+#define GPIO_PA3_SSI0FSS        0x00000C0F
+
+#define GPIO_PA4_U3RX           0x00001001
+#define GPIO_PA4_T2CCP0         0x00001003
+#define GPIO_PA4_I2C7SCL        0x00001002
+#define GPIO_PA4_SSI0XDAT0      0x0000100F
+
+#define GPIO_PA5_U3TX           0x00001401
+#define GPIO_PA5_T2CCP1         0x00001403
+#define GPIO_PA5_I2C7SDA        0x00001402
+#define GPIO_PA5_SSI0XDAT1      0x0000140F
+
+#define GPIO_PA6_U2RX           0x00001801
+#define GPIO_PA6_I2C6SCL        0x00001802
+#define GPIO_PA6_T3CCP0         0x00001803
+#define GPIO_PA6_USB0EPEN       0x00001805
+#define GPIO_PA6_SSI0XDAT2      0x0000180D
+#define GPIO_PA6_EPI0S8         0x0000180F
+
+#define GPIO_PA7_U2TX           0x00001C01
+#define GPIO_PA7_I2C6SDA        0x00001C02
+#define GPIO_PA7_T3CCP1         0x00001C03
+#define GPIO_PA7_USB0PFLT       0x00001C05
+#define GPIO_PA7_USB0EPEN       0x00001C0B
+#define GPIO_PA7_SSI0XDAT3      0x00001C0D
+#define GPIO_PA7_EPI0S9         0x00001C0F
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_I2C5SCL        0x00010002
+#define GPIO_PB0_CAN1RX         0x00010007
+#define GPIO_PB0_T4CCP0         0x00010003
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_I2C5SDA        0x00010402
+#define GPIO_PB1_CAN1TX         0x00010407
+#define GPIO_PB1_T4CCP1         0x00010403
+
+#define GPIO_PB2_T5CCP0         0x00010803
+#define GPIO_PB2_I2C0SCL        0x00010802
+#define GPIO_PB2_USB0STP        0x0001080E
+#define GPIO_PB2_EPI0S27        0x0001080F
+
+#define GPIO_PB3_I2C0SDA        0x00010C02
+#define GPIO_PB3_T5CCP1         0x00010C03
+#define GPIO_PB3_USB0CLK        0x00010C0E
+#define GPIO_PB3_EPI0S28        0x00010C0F
+
+#define GPIO_PB4_U0CTS          0x00011001
+#define GPIO_PB4_I2C5SCL        0x00011002
+#define GPIO_PB4_SSI1FSS        0x0001100F
+
+#define GPIO_PB5_U0RTS          0x00011401
+#define GPIO_PB5_I2C5SDA        0x00011402
+#define GPIO_PB5_SSI1CLK        0x0001140F
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+
+#define GPIO_PC2_TDI            0x00020801
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+
+#define GPIO_PC4_U7RX           0x00021001
+#define GPIO_PC4_EPI0S7         0x0002100F
+
+#define GPIO_PC5_U7TX           0x00021401
+#define GPIO_PC5_RTCCLK         0x00021407
+#define GPIO_PC5_EPI0S6         0x0002140F
+
+#define GPIO_PC6_U5RX           0x00021801
+#define GPIO_PC6_EPI0S5         0x0002180F
+
+#define GPIO_PC7_U5TX           0x00021C01
+#define GPIO_PC7_EPI0S4         0x00021C0F
+
+#define GPIO_PD0_I2C7SCL        0x00030002
+#define GPIO_PD0_T0CCP0         0x00030003
+#define GPIO_PD0_C0O            0x00030005
+#define GPIO_PD0_SSI2XDAT1      0x0003000F
+
+#define GPIO_PD1_I2C7SDA        0x00030402
+#define GPIO_PD1_T0CCP1         0x00030403
+#define GPIO_PD1_C1O            0x00030405
+#define GPIO_PD1_SSI2XDAT0      0x0003040F
+
+#define GPIO_PD2_I2C8SCL        0x00030802
+#define GPIO_PD2_T1CCP0         0x00030803
+#define GPIO_PD2_C2O            0x00030805
+#define GPIO_PD2_SSI2FSS        0x0003080F
+
+#define GPIO_PD3_I2C8SDA        0x00030C02
+#define GPIO_PD3_T1CCP1         0x00030C03
+#define GPIO_PD3_SSI2CLK        0x00030C0F
+
+#define GPIO_PD4_U2RX           0x00031001
+#define GPIO_PD4_T3CCP0         0x00031003
+#define GPIO_PD4_SSI1XDAT2      0x0003100F
+
+#define GPIO_PD5_U2TX           0x00031401
+#define GPIO_PD5_T3CCP1         0x00031403
+#define GPIO_PD5_SSI1XDAT3      0x0003140F
+
+#define GPIO_PD6_U2RTS          0x00031801
+#define GPIO_PD6_T4CCP0         0x00031803
+#define GPIO_PD6_USB0EPEN       0x00031805
+#define GPIO_PD6_SSI2XDAT3      0x0003180F
+
+#define GPIO_PD7_U2CTS          0x00031C01
+#define GPIO_PD7_T4CCP1         0x00031C03
+#define GPIO_PD7_USB0PFLT       0x00031C05
+#define GPIO_PD7_NMI            0x00031C08
+#define GPIO_PD7_SSI2XDAT2      0x00031C0F
+
+#define GPIO_PE0_U1RTS          0x00040001
+
+#define GPIO_PE1_U1DSR          0x00040401
+
+#define GPIO_PE2_U1DCD          0x00040801
+
+#define GPIO_PE3_U1DTR          0x00040C01
+
+#define GPIO_PE4_U1RI           0x00041001
+#define GPIO_PE4_SSI1XDAT0      0x0004100F
+
+#define GPIO_PE5_SSI1XDAT1      0x0004140F
+
+#define GPIO_PF0_M0PWM0         0x00050006
+#define GPIO_PF0_SSI3XDAT1      0x0005000E
+#define GPIO_PF0_TRD2           0x0005000F
+
+#define GPIO_PF1_M0PWM1         0x00050406
+#define GPIO_PF1_SSI3XDAT0      0x0005040E
+#define GPIO_PF1_TRD1           0x0005040F
+
+#define GPIO_PF2_M0PWM2         0x00050806
+#define GPIO_PF2_SSI3FSS        0x0005080E
+#define GPIO_PF2_TRD0           0x0005080F
+
+#define GPIO_PF3_M0PWM3         0x00050C06
+#define GPIO_PF3_SSI3CLK        0x00050C0E
+#define GPIO_PF3_TRCLK          0x00050C0F
+
+#define GPIO_PF4_M0FAULT0       0x00051006
+#define GPIO_PF4_SSI3XDAT2      0x0005100E
+#define GPIO_PF4_TRD3           0x0005100F
+
+#define GPIO_PG0_I2C1SCL        0x00060002
+#define GPIO_PG0_M0PWM4         0x00060006
+#define GPIO_PG0_EPI0S11        0x0006000F
+
+#define GPIO_PG1_I2C1SDA        0x00060402
+#define GPIO_PG1_M0PWM5         0x00060406
+#define GPIO_PG1_EPI0S10        0x0006040F
+
+#define GPIO_PG2_I2C2SCL        0x00060802
+#define GPIO_PG2_SSI2XDAT3      0x0006080F
+
+#define GPIO_PG3_I2C2SDA        0x00060C02
+#define GPIO_PG3_SSI2XDAT2      0x00060C0F
+
+#define GPIO_PG4_U0CTS          0x00061001
+#define GPIO_PG4_I2C3SCL        0x00061002
+#define GPIO_PG4_SSI2XDAT1      0x0006100F
+
+#define GPIO_PG5_U0RTS          0x00061401
+#define GPIO_PG5_I2C3SDA        0x00061402
+#define GPIO_PG5_SSI2XDAT0      0x0006140F
+
+#define GPIO_PG6_I2C4SCL        0x00061802
+#define GPIO_PG6_SSI2FSS        0x0006180F
+
+#define GPIO_PG7_I2C4SDA        0x00061C02
+#define GPIO_PG7_SSI2CLK        0x00061C0F
+
+#define GPIO_PH0_U0RTS          0x00070001
+#define GPIO_PH0_EPI0S0         0x0007000F
+
+#define GPIO_PH1_U0CTS          0x00070401
+#define GPIO_PH1_EPI0S1         0x0007040F
+
+#define GPIO_PH2_U0DCD          0x00070801
+#define GPIO_PH2_EPI0S2         0x0007080F
+
+#define GPIO_PH3_U0DSR          0x00070C01
+#define GPIO_PH3_EPI0S3         0x00070C0F
+
+#define GPIO_PJ0_U3RX           0x00080001
+
+#define GPIO_PJ1_U3TX           0x00080401
+
+#define GPIO_PK0_U4RX           0x00090001
+#define GPIO_PK0_EPI0S0         0x0009000F
+
+#define GPIO_PK1_U4TX           0x00090401
+#define GPIO_PK1_EPI0S1         0x0009040F
+
+#define GPIO_PK2_U4RTS          0x00090801
+#define GPIO_PK2_EPI0S2         0x0009080F
+
+#define GPIO_PK3_U4CTS          0x00090C01
+#define GPIO_PK3_EPI0S3         0x00090C0F
+
+#define GPIO_PK4_I2C3SCL        0x00091002
+#define GPIO_PK4_M0PWM6         0x00091006
+#define GPIO_PK4_EPI0S32        0x0009100F
+
+#define GPIO_PK5_I2C3SDA        0x00091402
+#define GPIO_PK5_M0PWM7         0x00091406
+#define GPIO_PK5_EPI0S31        0x0009140F
+
+#define GPIO_PK6_I2C4SCL        0x00091802
+#define GPIO_PK6_M0FAULT1       0x00091806
+#define GPIO_PK6_EPI0S25        0x0009180F
+
+#define GPIO_PK7_U0RI           0x00091C01
+#define GPIO_PK7_I2C4SDA        0x00091C02
+#define GPIO_PK7_RTCCLK         0x00091C05
+#define GPIO_PK7_M0FAULT2       0x00091C06
+#define GPIO_PK7_EPI0S24        0x00091C0F
+
+#define GPIO_PL0_I2C2SDA        0x000A0002
+#define GPIO_PL0_M0FAULT3       0x000A0006
+#define GPIO_PL0_USB0D0         0x000A000E
+#define GPIO_PL0_EPI0S16        0x000A000F
+
+#define GPIO_PL1_I2C2SCL        0x000A0402
+#define GPIO_PL1_PHA0           0x000A0406
+#define GPIO_PL1_USB0D1         0x000A040E
+#define GPIO_PL1_EPI0S17        0x000A040F
+
+#define GPIO_PL2_C0O            0x000A0805
+#define GPIO_PL2_PHB0           0x000A0806
+#define GPIO_PL2_USB0D2         0x000A080E
+#define GPIO_PL2_EPI0S18        0x000A080F
+
+#define GPIO_PL3_C1O            0x000A0C05
+#define GPIO_PL3_IDX0           0x000A0C06
+#define GPIO_PL3_USB0D3         0x000A0C0E
+#define GPIO_PL3_EPI0S19        0x000A0C0F
+
+#define GPIO_PL4_T0CCP0         0x000A1003
+#define GPIO_PL4_USB0D4         0x000A100E
+#define GPIO_PL4_EPI0S26        0x000A100F
+
+#define GPIO_PL5_T0CCP1         0x000A1403
+#define GPIO_PL5_EPI0S33        0x000A140F
+#define GPIO_PL5_USB0D5         0x000A140E
+
+#define GPIO_PL6_T1CCP0         0x000A1803
+
+#define GPIO_PL7_T1CCP1         0x000A1C03
+
+#define GPIO_PM0_T2CCP0         0x000B0003
+#define GPIO_PM0_EPI0S15        0x000B000F
+
+#define GPIO_PM1_T2CCP1         0x000B0403
+#define GPIO_PM1_EPI0S14        0x000B040F
+
+#define GPIO_PM2_T3CCP0         0x000B0803
+#define GPIO_PM2_EPI0S13        0x000B080F
+
+#define GPIO_PM3_T3CCP1         0x000B0C03
+#define GPIO_PM3_EPI0S12        0x000B0C0F
+
+#define GPIO_PM4_U0CTS          0x000B1001
+#define GPIO_PM4_T4CCP0         0x000B1003
+
+#define GPIO_PM5_U0DCD          0x000B1401
+#define GPIO_PM5_T4CCP1         0x000B1403
+
+#define GPIO_PM6_U0DSR          0x000B1801
+#define GPIO_PM6_T5CCP0         0x000B1803
+
+#define GPIO_PM7_U0RI           0x000B1C01
+#define GPIO_PM7_T5CCP1         0x000B1C03
+
+#define GPIO_PN0_U1RTS          0x000C0001
+
+#define GPIO_PN1_U1CTS          0x000C0401
+
+#define GPIO_PN2_U1DCD          0x000C0801
+#define GPIO_PN2_U2RTS          0x000C0802
+#define GPIO_PN2_EPI0S29        0x000C080F
+
+#define GPIO_PN3_U1DSR          0x000C0C01
+#define GPIO_PN3_U2CTS          0x000C0C02
+#define GPIO_PN3_EPI0S30        0x000C0C0F
+
+#define GPIO_PN4_U1DTR          0x000C1001
+#define GPIO_PN4_U3RTS          0x000C1002
+#define GPIO_PN4_I2C2SDA        0x000C1003
+#define GPIO_PN4_EPI0S34        0x000C100F
+
+#define GPIO_PN5_U1RI           0x000C1401
+#define GPIO_PN5_U3CTS          0x000C1402
+#define GPIO_PN5_I2C2SCL        0x000C1403
+#define GPIO_PN5_EPI0S35        0x000C140F
+
+#define GPIO_PP0_U6RX           0x000D0001
+#define GPIO_PP0_SSI3XDAT2      0x000D000F
+
+#define GPIO_PP1_U6TX           0x000D0401
+#define GPIO_PP1_SSI3XDAT3      0x000D040F
+
+#define GPIO_PP2_U0DTR          0x000D0801
+#define GPIO_PP2_USB0NXT        0x000D080E
+#define GPIO_PP2_EPI0S29        0x000D080F
+
+#define GPIO_PP3_U1CTS          0x000D0C01
+#define GPIO_PP3_U0DCD          0x000D0C02
+#define GPIO_PP3_RTCCLK         0x000D0C07
+#define GPIO_PP3_USB0DIR        0x000D0C0E
+#define GPIO_PP3_EPI0S30        0x000D0C0F
+
+#define GPIO_PP4_U3RTS          0x000D1001
+#define GPIO_PP4_U0DSR          0x000D1002
+#define GPIO_PP4_USB0D7         0x000D100E
+
+#define GPIO_PP5_U3CTS          0x000D1401
+#define GPIO_PP5_I2C2SCL        0x000D1402
+#define GPIO_PP5_USB0D6         0x000D140E
+
+#define GPIO_PQ0_SSI3CLK        0x000E000E
+#define GPIO_PQ0_EPI0S20        0x000E000F
+
+#define GPIO_PQ1_SSI3FSS        0x000E040E
+#define GPIO_PQ1_EPI0S21        0x000E040F
+
+#define GPIO_PQ2_SSI3XDAT0      0x000E080E
+#define GPIO_PQ2_EPI0S22        0x000E080F
+
+#define GPIO_PQ3_SSI3XDAT1      0x000E0C0E
+#define GPIO_PQ3_EPI0S23        0x000E0C0F
+
+#define GPIO_PQ4_U1RX           0x000E1001
+#define GPIO_PQ4_DIVSCLK        0x000E1007
+
+#define GPIO_PQ5_U1TX           0x000E1401
+
+#define GPIO_PQ6_U1DTR          0x000E1801
+
+#endif // PART_TM4C1290NCPDT
+
+//*****************************************************************************
+//
+// TM4C1290NCZAD Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1290NCZAD
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_I2C9SCL        0x00000002
+#define GPIO_PA0_T0CCP0         0x00000003
+#define GPIO_PA0_CAN0RX         0x00000007
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_I2C9SDA        0x00000402
+#define GPIO_PA1_T0CCP1         0x00000403
+#define GPIO_PA1_CAN0TX         0x00000407
+
+#define GPIO_PA2_U4RX           0x00000801
+#define GPIO_PA2_I2C8SCL        0x00000802
+#define GPIO_PA2_T1CCP0         0x00000803
+#define GPIO_PA2_SSI0CLK        0x0000080F
+
+#define GPIO_PA3_U4TX           0x00000C01
+#define GPIO_PA3_I2C8SDA        0x00000C02
+#define GPIO_PA3_T1CCP1         0x00000C03
+#define GPIO_PA3_SSI0FSS        0x00000C0F
+
+#define GPIO_PA4_U3RX           0x00001001
+#define GPIO_PA4_T2CCP0         0x00001003
+#define GPIO_PA4_I2C7SCL        0x00001002
+#define GPIO_PA4_SSI0XDAT0      0x0000100F
+
+#define GPIO_PA5_U3TX           0x00001401
+#define GPIO_PA5_T2CCP1         0x00001403
+#define GPIO_PA5_I2C7SDA        0x00001402
+#define GPIO_PA5_SSI0XDAT1      0x0000140F
+
+#define GPIO_PA6_U2RX           0x00001801
+#define GPIO_PA6_I2C6SCL        0x00001802
+#define GPIO_PA6_T3CCP0         0x00001803
+#define GPIO_PA6_USB0EPEN       0x00001805
+#define GPIO_PA6_SSI0XDAT2      0x0000180D
+#define GPIO_PA6_EPI0S8         0x0000180F
+
+#define GPIO_PA7_U2TX           0x00001C01
+#define GPIO_PA7_I2C6SDA        0x00001C02
+#define GPIO_PA7_T3CCP1         0x00001C03
+#define GPIO_PA7_USB0PFLT       0x00001C05
+#define GPIO_PA7_USB0EPEN       0x00001C0B
+#define GPIO_PA7_SSI0XDAT3      0x00001C0D
+#define GPIO_PA7_EPI0S9         0x00001C0F
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_I2C5SCL        0x00010002
+#define GPIO_PB0_CAN1RX         0x00010007
+#define GPIO_PB0_T4CCP0         0x00010003
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_I2C5SDA        0x00010402
+#define GPIO_PB1_CAN1TX         0x00010407
+#define GPIO_PB1_T4CCP1         0x00010403
+
+#define GPIO_PB2_T5CCP0         0x00010803
+#define GPIO_PB2_I2C0SCL        0x00010802
+#define GPIO_PB2_USB0STP        0x0001080E
+#define GPIO_PB2_EPI0S27        0x0001080F
+
+#define GPIO_PB3_I2C0SDA        0x00010C02
+#define GPIO_PB3_T5CCP1         0x00010C03
+#define GPIO_PB3_USB0CLK        0x00010C0E
+#define GPIO_PB3_EPI0S28        0x00010C0F
+
+#define GPIO_PB4_U0CTS          0x00011001
+#define GPIO_PB4_I2C5SCL        0x00011002
+#define GPIO_PB4_SSI1FSS        0x0001100F
+
+#define GPIO_PB5_U0RTS          0x00011401
+#define GPIO_PB5_I2C5SDA        0x00011402
+#define GPIO_PB5_SSI1CLK        0x0001140F
+
+#define GPIO_PB6_I2C6SCL        0x00011802
+#define GPIO_PB6_T6CCP0         0x00011803
+#define GPIO_PB6_PS2CLK3        0x00011804
+
+#define GPIO_PB7_I2C6SDA        0x00011C02
+#define GPIO_PB7_T6CCP1         0x00011C03
+#define GPIO_PB7_PS2DAT3        0x00011C04
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+
+#define GPIO_PC2_TDI            0x00020801
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+
+#define GPIO_PC4_U7RX           0x00021001
+#define GPIO_PC4_T7CCP0         0x00021003
+#define GPIO_PC4_EPI0S7         0x0002100F
+
+#define GPIO_PC5_U7TX           0x00021401
+#define GPIO_PC5_T7CCP1         0x00021403
+#define GPIO_PC5_RTCCLK         0x00021407
+#define GPIO_PC5_EPI0S6         0x0002140F
+
+#define GPIO_PC6_U5RX           0x00021801
+#define GPIO_PC6_EPI0S5         0x0002180F
+
+#define GPIO_PC7_U5TX           0x00021C01
+#define GPIO_PC7_EPI0S4         0x00021C0F
+
+#define GPIO_PD0_I2C7SCL        0x00030002
+#define GPIO_PD0_T0CCP0         0x00030003
+#define GPIO_PD0_C0O            0x00030005
+#define GPIO_PD0_SSI2XDAT1      0x0003000F
+
+#define GPIO_PD1_I2C7SDA        0x00030402
+#define GPIO_PD1_T0CCP1         0x00030403
+#define GPIO_PD1_C1O            0x00030405
+#define GPIO_PD1_SSI2XDAT0      0x0003040F
+
+#define GPIO_PD2_I2C8SCL        0x00030802
+#define GPIO_PD2_T1CCP0         0x00030803
+#define GPIO_PD2_C2O            0x00030805
+#define GPIO_PD2_SSI2FSS        0x0003080F
+
+#define GPIO_PD3_I2C8SDA        0x00030C02
+#define GPIO_PD3_T1CCP1         0x00030C03
+#define GPIO_PD3_SSI2CLK        0x00030C0F
+
+#define GPIO_PD4_U2RX           0x00031001
+#define GPIO_PD4_T3CCP0         0x00031003
+#define GPIO_PD4_SSI1XDAT2      0x0003100F
+
+#define GPIO_PD5_U2TX           0x00031401
+#define GPIO_PD5_T3CCP1         0x00031403
+#define GPIO_PD5_SSI1XDAT3      0x0003140F
+
+#define GPIO_PD6_U2RTS          0x00031801
+#define GPIO_PD6_T4CCP0         0x00031803
+#define GPIO_PD6_USB0EPEN       0x00031805
+#define GPIO_PD6_SSI2XDAT3      0x0003180F
+
+#define GPIO_PD7_U2CTS          0x00031C01
+#define GPIO_PD7_T4CCP1         0x00031C03
+#define GPIO_PD7_USB0PFLT       0x00031C05
+#define GPIO_PD7_NMI            0x00031C08
+#define GPIO_PD7_SSI2XDAT2      0x00031C0F
+
+#define GPIO_PE0_U1RTS          0x00040001
+
+#define GPIO_PE1_U1DSR          0x00040401
+
+#define GPIO_PE2_U1DCD          0x00040801
+
+#define GPIO_PE3_U1DTR          0x00040C01
+
+#define GPIO_PE4_U1RI           0x00041001
+#define GPIO_PE4_SSI1XDAT0      0x0004100F
+
+#define GPIO_PE5_SSI1XDAT1      0x0004140F
+
+#define GPIO_PE6_U0CTS          0x00041801
+#define GPIO_PE6_I2C9SCL        0x00041802
+
+#define GPIO_PE7_U0RTS          0x00041C01
+#define GPIO_PE7_I2C9SDA        0x00041C02
+#define GPIO_PE7_NMI            0x00041C08
+
+#define GPIO_PF0_M0PWM0         0x00050006
+#define GPIO_PF0_SSI3XDAT1      0x0005000E
+#define GPIO_PF0_TRD2           0x0005000F
+
+#define GPIO_PF1_M0PWM1         0x00050406
+#define GPIO_PF1_SSI3XDAT0      0x0005040E
+#define GPIO_PF1_TRD1           0x0005040F
+
+#define GPIO_PF2_M0PWM2         0x00050806
+#define GPIO_PF2_SSI3FSS        0x0005080E
+#define GPIO_PF2_TRD0           0x0005080F
+
+#define GPIO_PF3_M0PWM3         0x00050C06
+#define GPIO_PF3_SSI3CLK        0x00050C0E
+#define GPIO_PF3_TRCLK          0x00050C0F
+
+#define GPIO_PF4_M0FAULT0       0x00051006
+#define GPIO_PF4_SSI3XDAT2      0x0005100E
+#define GPIO_PF4_TRD3           0x0005100F
+
+#define GPIO_PF5_SSI3XDAT3      0x0005140E
+
+#define GPIO_PG0_I2C1SCL        0x00060002
+#define GPIO_PG0_M0PWM4         0x00060006
+#define GPIO_PG0_EPI0S11        0x0006000F
+
+#define GPIO_PG1_I2C1SDA        0x00060402
+#define GPIO_PG1_M0PWM5         0x00060406
+#define GPIO_PG1_EPI0S10        0x0006040F
+
+#define GPIO_PG2_I2C2SCL        0x00060802
+#define GPIO_PG2_SSI2XDAT3      0x0006080F
+
+#define GPIO_PG3_I2C2SDA        0x00060C02
+#define GPIO_PG3_SSI2XDAT2      0x00060C0F
+
+#define GPIO_PG4_U0CTS          0x00061001
+#define GPIO_PG4_I2C3SCL        0x00061002
+#define GPIO_PG4_SSI2XDAT1      0x0006100F
+
+#define GPIO_PG5_U0RTS          0x00061401
+#define GPIO_PG5_I2C3SDA        0x00061402
+#define GPIO_PG5_SSI2XDAT0      0x0006140F
+
+#define GPIO_PG6_I2C4SCL        0x00061802
+#define GPIO_PG6_SSI2FSS        0x0006180F
+
+#define GPIO_PG7_I2C4SDA        0x00061C02
+#define GPIO_PG7_SSI2CLK        0x00061C0F
+
+#define GPIO_PH0_U0RTS          0x00070001
+#define GPIO_PH0_EPI0S0         0x0007000F
+
+#define GPIO_PH1_U0CTS          0x00070401
+#define GPIO_PH1_EPI0S1         0x0007040F
+
+#define GPIO_PH2_U0DCD          0x00070801
+#define GPIO_PH2_EPI0S2         0x0007080F
+
+#define GPIO_PH3_U0DSR          0x00070C01
+#define GPIO_PH3_EPI0S3         0x00070C0F
+
+#define GPIO_PH4_U0DTR          0x00071001
+
+#define GPIO_PH5_U0RI           0x00071401
+
+#define GPIO_PH6_U5RX           0x00071801
+#define GPIO_PH6_U7RX           0x00071802
+
+#define GPIO_PH7_U5TX           0x00071C01
+#define GPIO_PH7_U7TX           0x00071C02
+
+#define GPIO_PJ0_U3RX           0x00080001
+
+#define GPIO_PJ1_U3TX           0x00080401
+
+#define GPIO_PJ2_U2RTS          0x00080801
+
+#define GPIO_PJ3_U2CTS          0x00080C01
+
+#define GPIO_PJ4_U3RTS          0x00081001
+
+#define GPIO_PJ5_U3CTS          0x00081401
+
+#define GPIO_PJ6_U4RTS          0x00081801
+
+#define GPIO_PJ7_U4CTS          0x00081C01
+
+#define GPIO_PK0_U4RX           0x00090001
+#define GPIO_PK0_EPI0S0         0x0009000F
+
+#define GPIO_PK1_U4TX           0x00090401
+#define GPIO_PK1_EPI0S1         0x0009040F
+
+#define GPIO_PK2_U4RTS          0x00090801
+#define GPIO_PK2_EPI0S2         0x0009080F
+
+#define GPIO_PK3_U4CTS          0x00090C01
+#define GPIO_PK3_EPI0S3         0x00090C0F
+
+#define GPIO_PK4_I2C3SCL        0x00091002
+#define GPIO_PK4_M0PWM6         0x00091006
+#define GPIO_PK4_EPI0S32        0x0009100F
+
+#define GPIO_PK5_I2C3SDA        0x00091402
+#define GPIO_PK5_M0PWM7         0x00091406
+#define GPIO_PK5_EPI0S31        0x0009140F
+
+#define GPIO_PK6_I2C4SCL        0x00091802
+#define GPIO_PK6_M0FAULT1       0x00091806
+#define GPIO_PK6_EPI0S25        0x0009180F
+
+#define GPIO_PK7_U0RI           0x00091C01
+#define GPIO_PK7_I2C4SDA        0x00091C02
+#define GPIO_PK7_RTCCLK         0x00091C05
+#define GPIO_PK7_M0FAULT2       0x00091C06
+#define GPIO_PK7_EPI0S24        0x00091C0F
+
+#define GPIO_PL0_I2C2SDA        0x000A0002
+#define GPIO_PL0_M0FAULT3       0x000A0006
+#define GPIO_PL0_USB0D0         0x000A000E
+#define GPIO_PL0_EPI0S16        0x000A000F
+
+#define GPIO_PL1_I2C2SCL        0x000A0402
+#define GPIO_PL1_PHA0           0x000A0406
+#define GPIO_PL1_USB0D1         0x000A040E
+#define GPIO_PL1_EPI0S17        0x000A040F
+
+#define GPIO_PL2_C0O            0x000A0805
+#define GPIO_PL2_PHB0           0x000A0806
+#define GPIO_PL2_USB0D2         0x000A080E
+#define GPIO_PL2_EPI0S18        0x000A080F
+
+#define GPIO_PL3_C1O            0x000A0C05
+#define GPIO_PL3_IDX0           0x000A0C06
+#define GPIO_PL3_USB0D3         0x000A0C0E
+#define GPIO_PL3_EPI0S19        0x000A0C0F
+
+#define GPIO_PL4_T0CCP0         0x000A1003
+#define GPIO_PL4_USB0D4         0x000A100E
+#define GPIO_PL4_EPI0S26        0x000A100F
+
+#define GPIO_PL5_T0CCP1         0x000A1403
+#define GPIO_PL5_EPI0S33        0x000A140F
+#define GPIO_PL5_USB0D5         0x000A140E
+
+#define GPIO_PL6_T1CCP0         0x000A1803
+
+#define GPIO_PL7_T1CCP1         0x000A1C03
+
+#define GPIO_PM0_T2CCP0         0x000B0003
+#define GPIO_PM0_EPI0S15        0x000B000F
+
+#define GPIO_PM1_T2CCP1         0x000B0403
+#define GPIO_PM1_EPI0S14        0x000B040F
+
+#define GPIO_PM2_T3CCP0         0x000B0803
+#define GPIO_PM2_EPI0S13        0x000B080F
+
+#define GPIO_PM3_T3CCP1         0x000B0C03
+#define GPIO_PM3_EPI0S12        0x000B0C0F
+
+#define GPIO_PM4_U0CTS          0x000B1001
+#define GPIO_PM4_T4CCP0         0x000B1003
+
+#define GPIO_PM5_U0DCD          0x000B1401
+#define GPIO_PM5_T4CCP1         0x000B1403
+
+#define GPIO_PM6_U0DSR          0x000B1801
+#define GPIO_PM6_T5CCP0         0x000B1803
+
+#define GPIO_PM7_U0RI           0x000B1C01
+#define GPIO_PM7_T5CCP1         0x000B1C03
+
+#define GPIO_PN0_U1RTS          0x000C0001
+
+#define GPIO_PN1_U1CTS          0x000C0401
+
+#define GPIO_PN2_U1DCD          0x000C0801
+#define GPIO_PN2_U2RTS          0x000C0802
+#define GPIO_PN2_EPI0S29        0x000C080F
+
+#define GPIO_PN3_U1DSR          0x000C0C01
+#define GPIO_PN3_U2CTS          0x000C0C02
+#define GPIO_PN3_EPI0S30        0x000C0C0F
+
+#define GPIO_PN4_U1DTR          0x000C1001
+#define GPIO_PN4_U3RTS          0x000C1002
+#define GPIO_PN4_I2C2SDA        0x000C1003
+#define GPIO_PN4_EPI0S34        0x000C100F
+
+#define GPIO_PN5_U1RI           0x000C1401
+#define GPIO_PN5_U3CTS          0x000C1402
+#define GPIO_PN5_I2C2SCL        0x000C1403
+#define GPIO_PN5_EPI0S35        0x000C140F
+
+#define GPIO_PN6_U4RTS          0x000C1802
+
+#define GPIO_PN7_U1RTS          0x000C1C01
+#define GPIO_PN7_U4CTS          0x000C1C02
+
+#define GPIO_PP0_U6RX           0x000D0001
+#define GPIO_PP0_T6CCP0         0x000D0005
+#define GPIO_PP0_SSI3XDAT2      0x000D000F
+
+#define GPIO_PP1_U6TX           0x000D0401
+#define GPIO_PP1_T6CCP1         0x000D0405
+#define GPIO_PP1_SSI3XDAT3      0x000D040F
+
+#define GPIO_PP2_U0DTR          0x000D0801
+#define GPIO_PP2_USB0NXT        0x000D080E
+#define GPIO_PP2_EPI0S29        0x000D080F
+
+#define GPIO_PP3_U1CTS          0x000D0C01
+#define GPIO_PP3_U0DCD          0x000D0C02
+#define GPIO_PP3_RTCCLK         0x000D0C07
+#define GPIO_PP3_USB0DIR        0x000D0C0E
+#define GPIO_PP3_EPI0S30        0x000D0C0F
+
+#define GPIO_PP4_U3RTS          0x000D1001
+#define GPIO_PP4_U0DSR          0x000D1002
+#define GPIO_PP4_USB0D7         0x000D100E
+
+#define GPIO_PP5_U3CTS          0x000D1401
+#define GPIO_PP5_I2C2SCL        0x000D1402
+#define GPIO_PP5_USB0D6         0x000D140E
+
+#define GPIO_PP6_U1DCD          0x000D1801
+#define GPIO_PP6_I2C2SDA        0x000D1802
+
+#define GPIO_PQ0_T6CCP0         0x000E0003
+#define GPIO_PQ0_SSI3CLK        0x000E000E
+#define GPIO_PQ0_EPI0S20        0x000E000F
+
+#define GPIO_PQ1_T6CCP1         0x000E0403
+#define GPIO_PQ1_SSI3FSS        0x000E040E
+#define GPIO_PQ1_EPI0S21        0x000E040F
+
+#define GPIO_PQ2_T7CCP0         0x000E0803
+#define GPIO_PQ2_SSI3XDAT0      0x000E080E
+#define GPIO_PQ2_EPI0S22        0x000E080F
+
+#define GPIO_PQ3_T7CCP1         0x000E0C03
+#define GPIO_PQ3_SSI3XDAT1      0x000E0C0E
+#define GPIO_PQ3_EPI0S23        0x000E0C0F
+
+#define GPIO_PQ4_U1RX           0x000E1001
+#define GPIO_PQ4_DIVSCLK        0x000E1007
+
+#define GPIO_PQ5_U1TX           0x000E1401
+
+#define GPIO_PQ6_U1DTR          0x000E1801
+
+#define GPIO_PQ7_U1RI           0x000E1C01
+
+#define GPIO_PR0_U4TX           0x000F0001
+#define GPIO_PR0_I2C1SCL        0x000F0002
+#define GPIO_PR0_M0PWM0         0x000F0006
+
+#define GPIO_PR1_U4RX           0x000F0401
+#define GPIO_PR1_I2C1SDA        0x000F0402
+#define GPIO_PR1_M0PWM1         0x000F0406
+
+#define GPIO_PR2_I2C2SCL        0x000F0802
+#define GPIO_PR2_M0PWM2         0x000F0806
+
+#define GPIO_PR3_I2C2SDA        0x000F0C02
+#define GPIO_PR3_M0PWM3         0x000F0C06
+
+#define GPIO_PR4_I2C3SCL        0x000F1002
+#define GPIO_PR4_T0CCP0         0x000F1003
+#define GPIO_PR4_M0PWM4         0x000F1006
+
+#define GPIO_PR5_U1RX           0x000F1401
+#define GPIO_PR5_I2C3SDA        0x000F1402
+#define GPIO_PR5_T0CCP1         0x000F1403
+#define GPIO_PR5_M0PWM5         0x000F1406
+
+#define GPIO_PR6_U1TX           0x000F1801
+#define GPIO_PR6_I2C4SCL        0x000F1802
+#define GPIO_PR6_T1CCP0         0x000F1803
+#define GPIO_PR6_M0PWM6         0x000F1806
+
+#define GPIO_PR7_I2C4SDA        0x000F1C02
+#define GPIO_PR7_T1CCP1         0x000F1C03
+#define GPIO_PR7_M0PWM7         0x000F1C06
+
+#define GPIO_PS0_T2CCP0         0x00100003
+#define GPIO_PS0_M0FAULT0       0x00100006
+
+#define GPIO_PS1_T2CCP1         0x00100403
+#define GPIO_PS1_M0FAULT1       0x00100406
+
+#define GPIO_PS2_U1DSR          0x00100801
+#define GPIO_PS2_T3CCP0         0x00100803
+#define GPIO_PS2_M0FAULT2       0x00100806
+
+#define GPIO_PS3_T3CCP1         0x00100C03
+#define GPIO_PS3_M0FAULT3       0x00100C06
+
+#define GPIO_PS4_T4CCP0         0x00101003
+#define GPIO_PS4_PHA0           0x00101006
+
+#define GPIO_PS5_T4CCP1         0x00101403
+#define GPIO_PS5_PHB0           0x00101406
+
+#define GPIO_PS6_T5CCP0         0x00101803
+#define GPIO_PS6_IDX0           0x00101806
+
+#define GPIO_PS7_T5CCP1         0x00101C03
+
+#define GPIO_PT0_T6CCP0         0x00110003
+#define GPIO_PT0_CAN0RX         0x00110007
+
+#define GPIO_PT1_T6CCP1         0x00110403
+#define GPIO_PT1_CAN0TX         0x00110407
+
+#define GPIO_PT2_T7CCP0         0x00110803
+#define GPIO_PT2_CAN1RX         0x00110807
+
+#define GPIO_PT3_T7CCP1         0x00110C03
+#define GPIO_PT3_CAN1TX         0x00110C07
+
+#endif // PART_TM4C1290NCZAD
+
+//*****************************************************************************
+//
+// TM4C1292NCPDT Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1292NCPDT
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_I2C9SCL        0x00000002
+#define GPIO_PA0_T0CCP0         0x00000003
+#define GPIO_PA0_CAN0RX         0x00000007
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_I2C9SDA        0x00000402
+#define GPIO_PA1_T0CCP1         0x00000403
+#define GPIO_PA1_CAN0TX         0x00000407
+
+#define GPIO_PA2_U4RX           0x00000801
+#define GPIO_PA2_I2C8SCL        0x00000802
+#define GPIO_PA2_T1CCP0         0x00000803
+#define GPIO_PA2_SSI0CLK        0x0000080F
+
+#define GPIO_PA3_U4TX           0x00000C01
+#define GPIO_PA3_I2C8SDA        0x00000C02
+#define GPIO_PA3_T1CCP1         0x00000C03
+#define GPIO_PA3_SSI0FSS        0x00000C0F
+
+#define GPIO_PA4_U3RX           0x00001001
+#define GPIO_PA4_T2CCP0         0x00001003
+#define GPIO_PA4_I2C7SCL        0x00001002
+#define GPIO_PA4_SSI0XDAT0      0x0000100F
+
+#define GPIO_PA5_U3TX           0x00001401
+#define GPIO_PA5_T2CCP1         0x00001403
+#define GPIO_PA5_I2C7SDA        0x00001402
+#define GPIO_PA5_SSI0XDAT1      0x0000140F
+
+#define GPIO_PA6_U2RX           0x00001801
+#define GPIO_PA6_I2C6SCL        0x00001802
+#define GPIO_PA6_T3CCP0         0x00001803
+#define GPIO_PA6_USB0EPEN       0x00001805
+#define GPIO_PA6_SSI0XDAT2      0x0000180D
+#define GPIO_PA6_EN0RXCK        0x0000180E
+#define GPIO_PA6_EPI0S8         0x0000180F
+
+#define GPIO_PA7_U2TX           0x00001C01
+#define GPIO_PA7_I2C6SDA        0x00001C02
+#define GPIO_PA7_T3CCP1         0x00001C03
+#define GPIO_PA7_USB0PFLT       0x00001C05
+#define GPIO_PA7_USB0EPEN       0x00001C0B
+#define GPIO_PA7_SSI0XDAT3      0x00001C0D
+#define GPIO_PA7_EPI0S9         0x00001C0F
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_I2C5SCL        0x00010002
+#define GPIO_PB0_CAN1RX         0x00010007
+#define GPIO_PB0_T4CCP0         0x00010003
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_I2C5SDA        0x00010402
+#define GPIO_PB1_CAN1TX         0x00010407
+#define GPIO_PB1_T4CCP1         0x00010403
+
+#define GPIO_PB2_T5CCP0         0x00010803
+#define GPIO_PB2_I2C0SCL        0x00010802
+#define GPIO_PB2_EN0MDC         0x00010805
+#define GPIO_PB2_USB0STP        0x0001080E
+#define GPIO_PB2_EPI0S27        0x0001080F
+
+#define GPIO_PB3_I2C0SDA        0x00010C02
+#define GPIO_PB3_T5CCP1         0x00010C03
+#define GPIO_PB3_EN0MDIO        0x00010C05
+#define GPIO_PB3_USB0CLK        0x00010C0E
+#define GPIO_PB3_EPI0S28        0x00010C0F
+
+#define GPIO_PB4_U0CTS          0x00011001
+#define GPIO_PB4_I2C5SCL        0x00011002
+#define GPIO_PB4_SSI1FSS        0x0001100F
+
+#define GPIO_PB5_U0RTS          0x00011401
+#define GPIO_PB5_I2C5SDA        0x00011402
+#define GPIO_PB5_SSI1CLK        0x0001140F
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+
+#define GPIO_PC2_TDI            0x00020801
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+
+#define GPIO_PC4_U7RX           0x00021001
+#define GPIO_PC4_EPI0S7         0x0002100F
+
+#define GPIO_PC5_U7TX           0x00021401
+#define GPIO_PC5_RTCCLK         0x00021407
+#define GPIO_PC5_EPI0S6         0x0002140F
+
+#define GPIO_PC6_U5RX           0x00021801
+#define GPIO_PC6_EPI0S5         0x0002180F
+
+#define GPIO_PC7_U5TX           0x00021C01
+#define GPIO_PC7_EPI0S4         0x00021C0F
+
+#define GPIO_PD0_I2C7SCL        0x00030002
+#define GPIO_PD0_T0CCP0         0x00030003
+#define GPIO_PD0_C0O            0x00030005
+#define GPIO_PD0_SSI2XDAT1      0x0003000F
+
+#define GPIO_PD1_I2C7SDA        0x00030402
+#define GPIO_PD1_T0CCP1         0x00030403
+#define GPIO_PD1_C1O            0x00030405
+#define GPIO_PD1_SSI2XDAT0      0x0003040F
+
+#define GPIO_PD2_I2C8SCL        0x00030802
+#define GPIO_PD2_T1CCP0         0x00030803
+#define GPIO_PD2_C2O            0x00030805
+#define GPIO_PD2_SSI2FSS        0x0003080F
+
+#define GPIO_PD3_I2C8SDA        0x00030C02
+#define GPIO_PD3_T1CCP1         0x00030C03
+#define GPIO_PD3_SSI2CLK        0x00030C0F
+
+#define GPIO_PD4_U2RX           0x00031001
+#define GPIO_PD4_T3CCP0         0x00031003
+#define GPIO_PD4_SSI1XDAT2      0x0003100F
+
+#define GPIO_PD5_U2TX           0x00031401
+#define GPIO_PD5_T3CCP1         0x00031403
+#define GPIO_PD5_SSI1XDAT3      0x0003140F
+
+#define GPIO_PD6_U2RTS          0x00031801
+#define GPIO_PD6_T4CCP0         0x00031803
+#define GPIO_PD6_USB0EPEN       0x00031805
+#define GPIO_PD6_SSI2XDAT3      0x0003180F
+
+#define GPIO_PD7_U2CTS          0x00031C01
+#define GPIO_PD7_T4CCP1         0x00031C03
+#define GPIO_PD7_USB0PFLT       0x00031C05
+#define GPIO_PD7_NMI            0x00031C08
+#define GPIO_PD7_SSI2XDAT2      0x00031C0F
+
+#define GPIO_PE0_U1RTS          0x00040001
+
+#define GPIO_PE1_U1DSR          0x00040401
+
+#define GPIO_PE2_U1DCD          0x00040801
+
+#define GPIO_PE3_U1DTR          0x00040C01
+
+#define GPIO_PE4_U1RI           0x00041001
+#define GPIO_PE4_SSI1XDAT0      0x0004100F
+
+#define GPIO_PE5_SSI1XDAT1      0x0004140F
+
+#define GPIO_PF0_M0PWM0         0x00050006
+#define GPIO_PF0_SSI3XDAT1      0x0005000E
+#define GPIO_PF0_TRD2           0x0005000F
+
+#define GPIO_PF1_M0PWM1         0x00050406
+#define GPIO_PF1_SSI3XDAT0      0x0005040E
+#define GPIO_PF1_TRD1           0x0005040F
+
+#define GPIO_PF2_EN0MDC         0x00050805
+#define GPIO_PF2_M0PWM2         0x00050806
+#define GPIO_PF2_SSI3FSS        0x0005080E
+#define GPIO_PF2_TRD0           0x0005080F
+
+#define GPIO_PF3_EN0MDIO        0x00050C05
+#define GPIO_PF3_M0PWM3         0x00050C06
+#define GPIO_PF3_SSI3CLK        0x00050C0E
+#define GPIO_PF3_TRCLK          0x00050C0F
+
+#define GPIO_PF4_M0FAULT0       0x00051006
+#define GPIO_PF4_SSI3XDAT2      0x0005100E
+#define GPIO_PF4_TRD3           0x0005100F
+
+#define GPIO_PG0_I2C1SCL        0x00060002
+#define GPIO_PG0_M0PWM4         0x00060006
+#define GPIO_PG0_EPI0S11        0x0006000F
+
+#define GPIO_PG1_I2C1SDA        0x00060402
+#define GPIO_PG1_M0PWM5         0x00060406
+#define GPIO_PG1_EPI0S10        0x0006040F
+
+#define GPIO_PG2_I2C2SCL        0x00060802
+#define GPIO_PG2_EN0TXCK        0x0006080E
+#define GPIO_PG2_SSI2XDAT3      0x0006080F
+
+#define GPIO_PG3_I2C2SDA        0x00060C02
+#define GPIO_PG3_EN0TXEN        0x00060C0E
+#define GPIO_PG3_SSI2XDAT2      0x00060C0F
+
+#define GPIO_PG4_U0CTS          0x00061001
+#define GPIO_PG4_I2C3SCL        0x00061002
+#define GPIO_PG4_EN0TXD0        0x0006100E
+#define GPIO_PG4_SSI2XDAT1      0x0006100F
+
+#define GPIO_PG5_U0RTS          0x00061401
+#define GPIO_PG5_I2C3SDA        0x00061402
+#define GPIO_PG5_EN0TXD1        0x0006140E
+#define GPIO_PG5_SSI2XDAT0      0x0006140F
+
+#define GPIO_PG6_I2C4SCL        0x00061802
+#define GPIO_PG6_EN0RXER        0x0006180E
+#define GPIO_PG6_SSI2FSS        0x0006180F
+
+#define GPIO_PG7_I2C4SDA        0x00061C02
+#define GPIO_PG7_EN0RXDV        0x00061C0E
+#define GPIO_PG7_SSI2CLK        0x00061C0F
+
+#define GPIO_PH0_U0RTS          0x00070001
+#define GPIO_PH0_EPI0S0         0x0007000F
+
+#define GPIO_PH1_U0CTS          0x00070401
+#define GPIO_PH1_EPI0S1         0x0007040F
+
+#define GPIO_PH2_U0DCD          0x00070801
+#define GPIO_PH2_EPI0S2         0x0007080F
+
+#define GPIO_PH3_U0DSR          0x00070C01
+#define GPIO_PH3_EPI0S3         0x00070C0F
+
+#define GPIO_PJ0_U3RX           0x00080001
+
+#define GPIO_PJ1_U3TX           0x00080401
+
+#define GPIO_PK0_U4RX           0x00090001
+#define GPIO_PK0_EPI0S0         0x0009000F
+
+#define GPIO_PK1_U4TX           0x00090401
+#define GPIO_PK1_EPI0S1         0x0009040F
+
+#define GPIO_PK2_U4RTS          0x00090801
+#define GPIO_PK2_EPI0S2         0x0009080F
+
+#define GPIO_PK3_U4CTS          0x00090C01
+#define GPIO_PK3_EPI0S3         0x00090C0F
+
+#define GPIO_PK4_I2C3SCL        0x00091002
+#define GPIO_PK4_M0PWM6         0x00091006
+#define GPIO_PK4_EN0INTRN       0x00091007
+#define GPIO_PK4_EN0RXD3        0x0009100E
+#define GPIO_PK4_EPI0S32        0x0009100F
+
+#define GPIO_PK5_I2C3SDA        0x00091402
+#define GPIO_PK5_M0PWM7         0x00091406
+#define GPIO_PK5_EN0RXD2        0x0009140E
+#define GPIO_PK5_EPI0S31        0x0009140F
+
+#define GPIO_PK6_I2C4SCL        0x00091802
+#define GPIO_PK6_M0FAULT1       0x00091806
+#define GPIO_PK6_EN0TXD2        0x0009180E
+#define GPIO_PK6_EPI0S25        0x0009180F
+
+#define GPIO_PK7_U0RI           0x00091C01
+#define GPIO_PK7_I2C4SDA        0x00091C02
+#define GPIO_PK7_RTCCLK         0x00091C05
+#define GPIO_PK7_M0FAULT2       0x00091C06
+#define GPIO_PK7_EN0TXD3        0x00091C0E
+#define GPIO_PK7_EPI0S24        0x00091C0F
+
+#define GPIO_PL0_I2C2SDA        0x000A0002
+#define GPIO_PL0_M0FAULT3       0x000A0006
+#define GPIO_PL0_USB0D0         0x000A000E
+#define GPIO_PL0_EPI0S16        0x000A000F
+
+#define GPIO_PL1_I2C2SCL        0x000A0402
+#define GPIO_PL1_PHA0           0x000A0406
+#define GPIO_PL1_USB0D1         0x000A040E
+#define GPIO_PL1_EPI0S17        0x000A040F
+
+#define GPIO_PL2_C0O            0x000A0805
+#define GPIO_PL2_PHB0           0x000A0806
+#define GPIO_PL2_USB0D2         0x000A080E
+#define GPIO_PL2_EPI0S18        0x000A080F
+
+#define GPIO_PL3_C1O            0x000A0C05
+#define GPIO_PL3_IDX0           0x000A0C06
+#define GPIO_PL3_USB0D3         0x000A0C0E
+#define GPIO_PL3_EPI0S19        0x000A0C0F
+
+#define GPIO_PL4_T0CCP0         0x000A1003
+#define GPIO_PL4_USB0D4         0x000A100E
+#define GPIO_PL4_EPI0S26        0x000A100F
+
+#define GPIO_PL5_T0CCP1         0x000A1403
+#define GPIO_PL5_EPI0S33        0x000A140F
+#define GPIO_PL5_USB0D5         0x000A140E
+
+#define GPIO_PL6_T1CCP0         0x000A1803
+
+#define GPIO_PL7_T1CCP1         0x000A1C03
+
+#define GPIO_PM0_T2CCP0         0x000B0003
+#define GPIO_PM0_EPI0S15        0x000B000F
+
+#define GPIO_PM1_T2CCP1         0x000B0403
+#define GPIO_PM1_EPI0S14        0x000B040F
+
+#define GPIO_PM2_T3CCP0         0x000B0803
+#define GPIO_PM2_EPI0S13        0x000B080F
+
+#define GPIO_PM3_T3CCP1         0x000B0C03
+#define GPIO_PM3_EPI0S12        0x000B0C0F
+
+#define GPIO_PM4_U0CTS          0x000B1001
+#define GPIO_PM4_T4CCP0         0x000B1003
+#define GPIO_PM4_EN0RREF_CLK    0x000B100E
+
+#define GPIO_PM5_U0DCD          0x000B1401
+#define GPIO_PM5_T4CCP1         0x000B1403
+
+#define GPIO_PM6_U0DSR          0x000B1801
+#define GPIO_PM6_T5CCP0         0x000B1803
+#define GPIO_PM6_EN0CRS         0x000B180E
+
+#define GPIO_PM7_U0RI           0x000B1C01
+#define GPIO_PM7_T5CCP1         0x000B1C03
+#define GPIO_PM7_EN0COL         0x000B1C0E
+
+#define GPIO_PN0_U1RTS          0x000C0001
+
+#define GPIO_PN1_U1CTS          0x000C0401
+
+#define GPIO_PN2_U1DCD          0x000C0801
+#define GPIO_PN2_U2RTS          0x000C0802
+#define GPIO_PN2_EPI0S29        0x000C080F
+
+#define GPIO_PN3_U1DSR          0x000C0C01
+#define GPIO_PN3_U2CTS          0x000C0C02
+#define GPIO_PN3_EPI0S30        0x000C0C0F
+
+#define GPIO_PN4_U1DTR          0x000C1001
+#define GPIO_PN4_U3RTS          0x000C1002
+#define GPIO_PN4_I2C2SDA        0x000C1003
+#define GPIO_PN4_EPI0S34        0x000C100F
+
+#define GPIO_PN5_U1RI           0x000C1401
+#define GPIO_PN5_U3CTS          0x000C1402
+#define GPIO_PN5_I2C2SCL        0x000C1403
+#define GPIO_PN5_EPI0S35        0x000C140F
+
+#define GPIO_PP0_U6RX           0x000D0001
+#define GPIO_PP0_EN0INTRN       0x000D0007
+#define GPIO_PP0_SSI3XDAT2      0x000D000F
+
+#define GPIO_PP1_U6TX           0x000D0401
+#define GPIO_PP1_SSI3XDAT3      0x000D040F
+
+#define GPIO_PP2_U0DTR          0x000D0801
+#define GPIO_PP2_USB0NXT        0x000D080E
+#define GPIO_PP2_EPI0S29        0x000D080F
+
+#define GPIO_PP3_U1CTS          0x000D0C01
+#define GPIO_PP3_U0DCD          0x000D0C02
+#define GPIO_PP3_RTCCLK         0x000D0C07
+#define GPIO_PP3_USB0DIR        0x000D0C0E
+#define GPIO_PP3_EPI0S30        0x000D0C0F
+
+#define GPIO_PP4_U3RTS          0x000D1001
+#define GPIO_PP4_U0DSR          0x000D1002
+#define GPIO_PP4_USB0D7         0x000D100E
+
+#define GPIO_PP5_U3CTS          0x000D1401
+#define GPIO_PP5_I2C2SCL        0x000D1402
+#define GPIO_PP5_USB0D6         0x000D140E
+
+#define GPIO_PQ0_SSI3CLK        0x000E000E
+#define GPIO_PQ0_EPI0S20        0x000E000F
+
+#define GPIO_PQ1_SSI3FSS        0x000E040E
+#define GPIO_PQ1_EPI0S21        0x000E040F
+
+#define GPIO_PQ2_SSI3XDAT0      0x000E080E
+#define GPIO_PQ2_EPI0S22        0x000E080F
+
+#define GPIO_PQ3_SSI3XDAT1      0x000E0C0E
+#define GPIO_PQ3_EPI0S23        0x000E0C0F
+
+#define GPIO_PQ4_U1RX           0x000E1001
+#define GPIO_PQ4_DIVSCLK        0x000E1007
+
+#define GPIO_PQ5_U1TX           0x000E1401
+#define GPIO_PQ5_EN0RXD0        0x000E140E
+
+#define GPIO_PQ6_U1DTR          0x000E1801
+#define GPIO_PQ6_EN0RXD1        0x000E180E
+
+#endif // PART_TM4C1292NCPDT
+
+//*****************************************************************************
+//
+// TM4C1292NCZAD Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1292NCZAD
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_I2C9SCL        0x00000002
+#define GPIO_PA0_T0CCP0         0x00000003
+#define GPIO_PA0_CAN0RX         0x00000007
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_I2C9SDA        0x00000402
+#define GPIO_PA1_T0CCP1         0x00000403
+#define GPIO_PA1_CAN0TX         0x00000407
+
+#define GPIO_PA2_U4RX           0x00000801
+#define GPIO_PA2_I2C8SCL        0x00000802
+#define GPIO_PA2_T1CCP0         0x00000803
+#define GPIO_PA2_SSI0CLK        0x0000080F
+
+#define GPIO_PA3_U4TX           0x00000C01
+#define GPIO_PA3_I2C8SDA        0x00000C02
+#define GPIO_PA3_T1CCP1         0x00000C03
+#define GPIO_PA3_SSI0FSS        0x00000C0F
+
+#define GPIO_PA4_U3RX           0x00001001
+#define GPIO_PA4_T2CCP0         0x00001003
+#define GPIO_PA4_I2C7SCL        0x00001002
+#define GPIO_PA4_SSI0XDAT0      0x0000100F
+
+#define GPIO_PA5_U3TX           0x00001401
+#define GPIO_PA5_T2CCP1         0x00001403
+#define GPIO_PA5_I2C7SDA        0x00001402
+#define GPIO_PA5_SSI0XDAT1      0x0000140F
+
+#define GPIO_PA6_U2RX           0x00001801
+#define GPIO_PA6_I2C6SCL        0x00001802
+#define GPIO_PA6_T3CCP0         0x00001803
+#define GPIO_PA6_USB0EPEN       0x00001805
+#define GPIO_PA6_SSI0XDAT2      0x0000180D
+#define GPIO_PA6_EN0RXCK        0x0000180E
+#define GPIO_PA6_EPI0S8         0x0000180F
+
+#define GPIO_PA7_U2TX           0x00001C01
+#define GPIO_PA7_I2C6SDA        0x00001C02
+#define GPIO_PA7_T3CCP1         0x00001C03
+#define GPIO_PA7_USB0PFLT       0x00001C05
+#define GPIO_PA7_USB0EPEN       0x00001C0B
+#define GPIO_PA7_SSI0XDAT3      0x00001C0D
+#define GPIO_PA7_EPI0S9         0x00001C0F
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_I2C5SCL        0x00010002
+#define GPIO_PB0_CAN1RX         0x00010007
+#define GPIO_PB0_T4CCP0         0x00010003
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_I2C5SDA        0x00010402
+#define GPIO_PB1_CAN1TX         0x00010407
+#define GPIO_PB1_T4CCP1         0x00010403
+
+#define GPIO_PB2_T5CCP0         0x00010803
+#define GPIO_PB2_I2C0SCL        0x00010802
+#define GPIO_PB2_EN0MDC         0x00010805
+#define GPIO_PB2_USB0STP        0x0001080E
+#define GPIO_PB2_EPI0S27        0x0001080F
+
+#define GPIO_PB3_I2C0SDA        0x00010C02
+#define GPIO_PB3_T5CCP1         0x00010C03
+#define GPIO_PB3_EN0MDIO        0x00010C05
+#define GPIO_PB3_USB0CLK        0x00010C0E
+#define GPIO_PB3_EPI0S28        0x00010C0F
+
+#define GPIO_PB4_U0CTS          0x00011001
+#define GPIO_PB4_I2C5SCL        0x00011002
+#define GPIO_PB4_SSI1FSS        0x0001100F
+
+#define GPIO_PB5_U0RTS          0x00011401
+#define GPIO_PB5_I2C5SDA        0x00011402
+#define GPIO_PB5_SSI1CLK        0x0001140F
+
+#define GPIO_PB6_I2C6SCL        0x00011802
+#define GPIO_PB6_T6CCP0         0x00011803
+#define GPIO_PB6_PS2CLK3        0x00011804
+
+#define GPIO_PB7_I2C6SDA        0x00011C02
+#define GPIO_PB7_T6CCP1         0x00011C03
+#define GPIO_PB7_PS2DAT3        0x00011C04
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+
+#define GPIO_PC2_TDI            0x00020801
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+
+#define GPIO_PC4_U7RX           0x00021001
+#define GPIO_PC4_T7CCP0         0x00021003
+#define GPIO_PC4_EPI0S7         0x0002100F
+
+#define GPIO_PC5_U7TX           0x00021401
+#define GPIO_PC5_T7CCP1         0x00021403
+#define GPIO_PC5_RTCCLK         0x00021407
+#define GPIO_PC5_EPI0S6         0x0002140F
+
+#define GPIO_PC6_U5RX           0x00021801
+#define GPIO_PC6_EPI0S5         0x0002180F
+
+#define GPIO_PC7_U5TX           0x00021C01
+#define GPIO_PC7_EPI0S4         0x00021C0F
+
+#define GPIO_PD0_I2C7SCL        0x00030002
+#define GPIO_PD0_T0CCP0         0x00030003
+#define GPIO_PD0_C0O            0x00030005
+#define GPIO_PD0_SSI2XDAT1      0x0003000F
+
+#define GPIO_PD1_I2C7SDA        0x00030402
+#define GPIO_PD1_T0CCP1         0x00030403
+#define GPIO_PD1_C1O            0x00030405
+#define GPIO_PD1_SSI2XDAT0      0x0003040F
+
+#define GPIO_PD2_I2C8SCL        0x00030802
+#define GPIO_PD2_T1CCP0         0x00030803
+#define GPIO_PD2_C2O            0x00030805
+#define GPIO_PD2_SSI2FSS        0x0003080F
+
+#define GPIO_PD3_I2C8SDA        0x00030C02
+#define GPIO_PD3_T1CCP1         0x00030C03
+#define GPIO_PD3_SSI2CLK        0x00030C0F
+
+#define GPIO_PD4_U2RX           0x00031001
+#define GPIO_PD4_T3CCP0         0x00031003
+#define GPIO_PD4_SSI1XDAT2      0x0003100F
+
+#define GPIO_PD5_U2TX           0x00031401
+#define GPIO_PD5_T3CCP1         0x00031403
+#define GPIO_PD5_SSI1XDAT3      0x0003140F
+
+#define GPIO_PD6_U2RTS          0x00031801
+#define GPIO_PD6_T4CCP0         0x00031803
+#define GPIO_PD6_USB0EPEN       0x00031805
+#define GPIO_PD6_SSI2XDAT3      0x0003180F
+
+#define GPIO_PD7_U2CTS          0x00031C01
+#define GPIO_PD7_T4CCP1         0x00031C03
+#define GPIO_PD7_USB0PFLT       0x00031C05
+#define GPIO_PD7_NMI            0x00031C08
+#define GPIO_PD7_SSI2XDAT2      0x00031C0F
+
+#define GPIO_PE0_U1RTS          0x00040001
+
+#define GPIO_PE1_U1DSR          0x00040401
+
+#define GPIO_PE2_U1DCD          0x00040801
+
+#define GPIO_PE3_U1DTR          0x00040C01
+
+#define GPIO_PE4_U1RI           0x00041001
+#define GPIO_PE4_SSI1XDAT0      0x0004100F
+
+#define GPIO_PE5_SSI1XDAT1      0x0004140F
+
+#define GPIO_PE6_U0CTS          0x00041801
+#define GPIO_PE6_I2C9SCL        0x00041802
+
+#define GPIO_PE7_U0RTS          0x00041C01
+#define GPIO_PE7_I2C9SDA        0x00041C02
+#define GPIO_PE7_NMI            0x00041C08
+
+#define GPIO_PF0_M0PWM0         0x00050006
+#define GPIO_PF0_SSI3XDAT1      0x0005000E
+#define GPIO_PF0_TRD2           0x0005000F
+
+#define GPIO_PF1_M0PWM1         0x00050406
+#define GPIO_PF1_SSI3XDAT0      0x0005040E
+#define GPIO_PF1_TRD1           0x0005040F
+
+#define GPIO_PF2_EN0MDC         0x00050805
+#define GPIO_PF2_M0PWM2         0x00050806
+#define GPIO_PF2_SSI3FSS        0x0005080E
+#define GPIO_PF2_TRD0           0x0005080F
+
+#define GPIO_PF3_EN0MDIO        0x00050C05
+#define GPIO_PF3_M0PWM3         0x00050C06
+#define GPIO_PF3_SSI3CLK        0x00050C0E
+#define GPIO_PF3_TRCLK          0x00050C0F
+
+#define GPIO_PF4_M0FAULT0       0x00051006
+#define GPIO_PF4_SSI3XDAT2      0x0005100E
+#define GPIO_PF4_TRD3           0x0005100F
+
+#define GPIO_PF5_SSI3XDAT3      0x0005140E
+
+#define GPIO_PG0_I2C1SCL        0x00060002
+#define GPIO_PG0_M0PWM4         0x00060006
+#define GPIO_PG0_EPI0S11        0x0006000F
+
+#define GPIO_PG1_I2C1SDA        0x00060402
+#define GPIO_PG1_M0PWM5         0x00060406
+#define GPIO_PG1_EPI0S10        0x0006040F
+
+#define GPIO_PG2_I2C2SCL        0x00060802
+#define GPIO_PG2_EN0TXCK        0x0006080E
+#define GPIO_PG2_SSI2XDAT3      0x0006080F
+
+#define GPIO_PG3_I2C2SDA        0x00060C02
+#define GPIO_PG3_EN0TXEN        0x00060C0E
+#define GPIO_PG3_SSI2XDAT2      0x00060C0F
+
+#define GPIO_PG4_U0CTS          0x00061001
+#define GPIO_PG4_I2C3SCL        0x00061002
+#define GPIO_PG4_EN0TXD0        0x0006100E
+#define GPIO_PG4_SSI2XDAT1      0x0006100F
+
+#define GPIO_PG5_U0RTS          0x00061401
+#define GPIO_PG5_I2C3SDA        0x00061402
+#define GPIO_PG5_EN0TXD1        0x0006140E
+#define GPIO_PG5_SSI2XDAT0      0x0006140F
+
+#define GPIO_PG6_I2C4SCL        0x00061802
+#define GPIO_PG6_EN0RXER        0x0006180E
+#define GPIO_PG6_SSI2FSS        0x0006180F
+
+#define GPIO_PG7_I2C4SDA        0x00061C02
+#define GPIO_PG7_EN0RXDV        0x00061C0E
+#define GPIO_PG7_SSI2CLK        0x00061C0F
+
+#define GPIO_PH0_U0RTS          0x00070001
+#define GPIO_PH0_EPI0S0         0x0007000F
+
+#define GPIO_PH1_U0CTS          0x00070401
+#define GPIO_PH1_EPI0S1         0x0007040F
+
+#define GPIO_PH2_U0DCD          0x00070801
+#define GPIO_PH2_EPI0S2         0x0007080F
+
+#define GPIO_PH3_U0DSR          0x00070C01
+#define GPIO_PH3_EPI0S3         0x00070C0F
+
+#define GPIO_PH4_U0DTR          0x00071001
+
+#define GPIO_PH5_U0RI           0x00071401
+
+#define GPIO_PH6_U5RX           0x00071801
+#define GPIO_PH6_U7RX           0x00071802
+
+#define GPIO_PH7_U5TX           0x00071C01
+#define GPIO_PH7_U7TX           0x00071C02
+
+#define GPIO_PJ0_U3RX           0x00080001
+
+#define GPIO_PJ1_U3TX           0x00080401
+
+#define GPIO_PJ2_U2RTS          0x00080801
+
+#define GPIO_PJ3_U2CTS          0x00080C01
+
+#define GPIO_PJ4_U3RTS          0x00081001
+
+#define GPIO_PJ5_U3CTS          0x00081401
+
+#define GPIO_PJ6_U4RTS          0x00081801
+
+#define GPIO_PJ7_U4CTS          0x00081C01
+
+#define GPIO_PK0_U4RX           0x00090001
+#define GPIO_PK0_EPI0S0         0x0009000F
+
+#define GPIO_PK1_U4TX           0x00090401
+#define GPIO_PK1_EPI0S1         0x0009040F
+
+#define GPIO_PK2_U4RTS          0x00090801
+#define GPIO_PK2_EPI0S2         0x0009080F
+
+#define GPIO_PK3_U4CTS          0x00090C01
+#define GPIO_PK3_EPI0S3         0x00090C0F
+
+#define GPIO_PK4_I2C3SCL        0x00091002
+#define GPIO_PK4_M0PWM6         0x00091006
+#define GPIO_PK4_EN0INTRN       0x00091007
+#define GPIO_PK4_EN0RXD3        0x0009100E
+#define GPIO_PK4_EPI0S32        0x0009100F
+
+#define GPIO_PK5_I2C3SDA        0x00091402
+#define GPIO_PK5_M0PWM7         0x00091406
+#define GPIO_PK5_EN0RXD2        0x0009140E
+#define GPIO_PK5_EPI0S31        0x0009140F
+
+#define GPIO_PK6_I2C4SCL        0x00091802
+#define GPIO_PK6_M0FAULT1       0x00091806
+#define GPIO_PK6_EN0TXD2        0x0009180E
+#define GPIO_PK6_EPI0S25        0x0009180F
+
+#define GPIO_PK7_U0RI           0x00091C01
+#define GPIO_PK7_I2C4SDA        0x00091C02
+#define GPIO_PK7_RTCCLK         0x00091C05
+#define GPIO_PK7_M0FAULT2       0x00091C06
+#define GPIO_PK7_EN0TXD3        0x00091C0E
+#define GPIO_PK7_EPI0S24        0x00091C0F
+
+#define GPIO_PL0_I2C2SDA        0x000A0002
+#define GPIO_PL0_M0FAULT3       0x000A0006
+#define GPIO_PL0_USB0D0         0x000A000E
+#define GPIO_PL0_EPI0S16        0x000A000F
+
+#define GPIO_PL1_I2C2SCL        0x000A0402
+#define GPIO_PL1_PHA0           0x000A0406
+#define GPIO_PL1_USB0D1         0x000A040E
+#define GPIO_PL1_EPI0S17        0x000A040F
+
+#define GPIO_PL2_C0O            0x000A0805
+#define GPIO_PL2_PHB0           0x000A0806
+#define GPIO_PL2_USB0D2         0x000A080E
+#define GPIO_PL2_EPI0S18        0x000A080F
+
+#define GPIO_PL3_C1O            0x000A0C05
+#define GPIO_PL3_IDX0           0x000A0C06
+#define GPIO_PL3_USB0D3         0x000A0C0E
+#define GPIO_PL3_EPI0S19        0x000A0C0F
+
+#define GPIO_PL4_T0CCP0         0x000A1003
+#define GPIO_PL4_USB0D4         0x000A100E
+#define GPIO_PL4_EPI0S26        0x000A100F
+
+#define GPIO_PL5_T0CCP1         0x000A1403
+#define GPIO_PL5_EPI0S33        0x000A140F
+#define GPIO_PL5_USB0D5         0x000A140E
+
+#define GPIO_PL6_T1CCP0         0x000A1803
+
+#define GPIO_PL7_T1CCP1         0x000A1C03
+
+#define GPIO_PM0_T2CCP0         0x000B0003
+#define GPIO_PM0_EPI0S15        0x000B000F
+
+#define GPIO_PM1_T2CCP1         0x000B0403
+#define GPIO_PM1_EPI0S14        0x000B040F
+
+#define GPIO_PM2_T3CCP0         0x000B0803
+#define GPIO_PM2_EPI0S13        0x000B080F
+
+#define GPIO_PM3_T3CCP1         0x000B0C03
+#define GPIO_PM3_EPI0S12        0x000B0C0F
+
+#define GPIO_PM4_U0CTS          0x000B1001
+#define GPIO_PM4_T4CCP0         0x000B1003
+#define GPIO_PM4_EN0RREF_CLK    0x000B100E
+
+#define GPIO_PM5_U0DCD          0x000B1401
+#define GPIO_PM5_T4CCP1         0x000B1403
+
+#define GPIO_PM6_U0DSR          0x000B1801
+#define GPIO_PM6_T5CCP0         0x000B1803
+#define GPIO_PM6_EN0CRS         0x000B180E
+
+#define GPIO_PM7_U0RI           0x000B1C01
+#define GPIO_PM7_T5CCP1         0x000B1C03
+#define GPIO_PM7_EN0COL         0x000B1C0E
+
+#define GPIO_PN0_U1RTS          0x000C0001
+
+#define GPIO_PN1_U1CTS          0x000C0401
+
+#define GPIO_PN2_U1DCD          0x000C0801
+#define GPIO_PN2_U2RTS          0x000C0802
+#define GPIO_PN2_EPI0S29        0x000C080F
+
+#define GPIO_PN3_U1DSR          0x000C0C01
+#define GPIO_PN3_U2CTS          0x000C0C02
+#define GPIO_PN3_EPI0S30        0x000C0C0F
+
+#define GPIO_PN4_U1DTR          0x000C1001
+#define GPIO_PN4_U3RTS          0x000C1002
+#define GPIO_PN4_I2C2SDA        0x000C1003
+#define GPIO_PN4_EPI0S34        0x000C100F
+
+#define GPIO_PN5_U1RI           0x000C1401
+#define GPIO_PN5_U3CTS          0x000C1402
+#define GPIO_PN5_I2C2SCL        0x000C1403
+#define GPIO_PN5_EPI0S35        0x000C140F
+
+#define GPIO_PN6_U4RTS          0x000C1802
+#define GPIO_PN6_EN0TXER        0x000C180E
+
+#define GPIO_PN7_U1RTS          0x000C1C01
+#define GPIO_PN7_U4CTS          0x000C1C02
+
+#define GPIO_PP0_U6RX           0x000D0001
+#define GPIO_PP0_T6CCP0         0x000D0005
+#define GPIO_PP0_EN0INTRN       0x000D0007
+#define GPIO_PP0_SSI3XDAT2      0x000D000F
+
+#define GPIO_PP1_U6TX           0x000D0401
+#define GPIO_PP1_T6CCP1         0x000D0405
+#define GPIO_PP1_SSI3XDAT3      0x000D040F
+
+#define GPIO_PP2_U0DTR          0x000D0801
+#define GPIO_PP2_USB0NXT        0x000D080E
+#define GPIO_PP2_EPI0S29        0x000D080F
+
+#define GPIO_PP3_U1CTS          0x000D0C01
+#define GPIO_PP3_U0DCD          0x000D0C02
+#define GPIO_PP3_RTCCLK         0x000D0C07
+#define GPIO_PP3_USB0DIR        0x000D0C0E
+#define GPIO_PP3_EPI0S30        0x000D0C0F
+
+#define GPIO_PP4_U3RTS          0x000D1001
+#define GPIO_PP4_U0DSR          0x000D1002
+#define GPIO_PP4_USB0D7         0x000D100E
+
+#define GPIO_PP5_U3CTS          0x000D1401
+#define GPIO_PP5_I2C2SCL        0x000D1402
+#define GPIO_PP5_USB0D6         0x000D140E
+
+#define GPIO_PP6_U1DCD          0x000D1801
+#define GPIO_PP6_I2C2SDA        0x000D1802
+
+#define GPIO_PQ0_T6CCP0         0x000E0003
+#define GPIO_PQ0_SSI3CLK        0x000E000E
+#define GPIO_PQ0_EPI0S20        0x000E000F
+
+#define GPIO_PQ1_T6CCP1         0x000E0403
+#define GPIO_PQ1_SSI3FSS        0x000E040E
+#define GPIO_PQ1_EPI0S21        0x000E040F
+
+#define GPIO_PQ2_T7CCP0         0x000E0803
+#define GPIO_PQ2_SSI3XDAT0      0x000E080E
+#define GPIO_PQ2_EPI0S22        0x000E080F
+
+#define GPIO_PQ3_T7CCP1         0x000E0C03
+#define GPIO_PQ3_SSI3XDAT1      0x000E0C0E
+#define GPIO_PQ3_EPI0S23        0x000E0C0F
+
+#define GPIO_PQ4_U1RX           0x000E1001
+#define GPIO_PQ4_DIVSCLK        0x000E1007
+
+#define GPIO_PQ5_U1TX           0x000E1401
+#define GPIO_PQ5_EN0RXD0        0x000E140E
+
+#define GPIO_PQ6_U1DTR          0x000E1801
+#define GPIO_PQ6_EN0RXD1        0x000E180E
+
+#define GPIO_PQ7_U1RI           0x000E1C01
+
+#define GPIO_PR0_U4TX           0x000F0001
+#define GPIO_PR0_I2C1SCL        0x000F0002
+#define GPIO_PR0_M0PWM0         0x000F0006
+
+#define GPIO_PR1_U4RX           0x000F0401
+#define GPIO_PR1_I2C1SDA        0x000F0402
+#define GPIO_PR1_M0PWM1         0x000F0406
+
+#define GPIO_PR2_I2C2SCL        0x000F0802
+#define GPIO_PR2_M0PWM2         0x000F0806
+
+#define GPIO_PR3_I2C2SDA        0x000F0C02
+#define GPIO_PR3_M0PWM3         0x000F0C06
+
+#define GPIO_PR4_I2C3SCL        0x000F1002
+#define GPIO_PR4_T0CCP0         0x000F1003
+#define GPIO_PR4_M0PWM4         0x000F1006
+
+#define GPIO_PR5_U1RX           0x000F1401
+#define GPIO_PR5_I2C3SDA        0x000F1402
+#define GPIO_PR5_T0CCP1         0x000F1403
+#define GPIO_PR5_M0PWM5         0x000F1406
+
+#define GPIO_PR6_U1TX           0x000F1801
+#define GPIO_PR6_I2C4SCL        0x000F1802
+#define GPIO_PR6_T1CCP0         0x000F1803
+#define GPIO_PR6_M0PWM6         0x000F1806
+
+#define GPIO_PR7_I2C4SDA        0x000F1C02
+#define GPIO_PR7_T1CCP1         0x000F1C03
+#define GPIO_PR7_M0PWM7         0x000F1C06
+#define GPIO_PR7_EN0TXEN        0x000F1C0E
+
+#define GPIO_PS0_T2CCP0         0x00100003
+#define GPIO_PS0_M0FAULT0       0x00100006
+
+#define GPIO_PS1_T2CCP1         0x00100403
+#define GPIO_PS1_M0FAULT1       0x00100406
+
+#define GPIO_PS2_U1DSR          0x00100801
+#define GPIO_PS2_T3CCP0         0x00100803
+#define GPIO_PS2_M0FAULT2       0x00100806
+
+#define GPIO_PS3_T3CCP1         0x00100C03
+#define GPIO_PS3_M0FAULT3       0x00100C06
+
+#define GPIO_PS4_T4CCP0         0x00101003
+#define GPIO_PS4_PHA0           0x00101006
+#define GPIO_PS4_EN0TXD0        0x0010100E
+
+#define GPIO_PS5_T4CCP1         0x00101403
+#define GPIO_PS5_PHB0           0x00101406
+#define GPIO_PS5_EN0TXD1        0x0010140E
+
+#define GPIO_PS6_T5CCP0         0x00101803
+#define GPIO_PS6_IDX0           0x00101806
+#define GPIO_PS6_EN0RXER        0x0010180E
+
+#define GPIO_PS7_T5CCP1         0x00101C03
+#define GPIO_PS7_EN0RXDV        0x00101C0E
+
+#define GPIO_PT0_T6CCP0         0x00110003
+#define GPIO_PT0_CAN0RX         0x00110007
+#define GPIO_PT0_EN0RXD0        0x0011000E
+
+#define GPIO_PT1_T6CCP1         0x00110403
+#define GPIO_PT1_CAN0TX         0x00110407
+#define GPIO_PT1_EN0RXD1        0x0011040E
+
+#define GPIO_PT2_T7CCP0         0x00110803
+#define GPIO_PT2_CAN1RX         0x00110807
+
+#define GPIO_PT3_T7CCP1         0x00110C03
+#define GPIO_PT3_CAN1TX         0x00110C07
+
+#endif // PART_TM4C1292NCZAD
+
+//*****************************************************************************
+//
+// TM4C1294NCPDT Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1294NCPDT
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_I2C9SCL        0x00000002
+#define GPIO_PA0_T0CCP0         0x00000003
+#define GPIO_PA0_CAN0RX         0x00000007
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_I2C9SDA        0x00000402
+#define GPIO_PA1_T0CCP1         0x00000403
+#define GPIO_PA1_CAN0TX         0x00000407
+
+#define GPIO_PA2_U4RX           0x00000801
+#define GPIO_PA2_I2C8SCL        0x00000802
+#define GPIO_PA2_T1CCP0         0x00000803
+#define GPIO_PA2_SSI0CLK        0x0000080F
+
+#define GPIO_PA3_U4TX           0x00000C01
+#define GPIO_PA3_I2C8SDA        0x00000C02
+#define GPIO_PA3_T1CCP1         0x00000C03
+#define GPIO_PA3_SSI0FSS        0x00000C0F
+
+#define GPIO_PA4_U3RX           0x00001001
+#define GPIO_PA4_T2CCP0         0x00001003
+#define GPIO_PA4_I2C7SCL        0x00001002
+#define GPIO_PA4_SSI0XDAT0      0x0000100F
+
+#define GPIO_PA5_U3TX           0x00001401
+#define GPIO_PA5_T2CCP1         0x00001403
+#define GPIO_PA5_I2C7SDA        0x00001402
+#define GPIO_PA5_SSI0XDAT1      0x0000140F
+
+#define GPIO_PA6_U2RX           0x00001801
+#define GPIO_PA6_I2C6SCL        0x00001802
+#define GPIO_PA6_T3CCP0         0x00001803
+#define GPIO_PA6_USB0EPEN       0x00001805
+#define GPIO_PA6_SSI0XDAT2      0x0000180D
+#define GPIO_PA6_EPI0S8         0x0000180F
+
+#define GPIO_PA7_U2TX           0x00001C01
+#define GPIO_PA7_I2C6SDA        0x00001C02
+#define GPIO_PA7_T3CCP1         0x00001C03
+#define GPIO_PA7_USB0PFLT       0x00001C05
+#define GPIO_PA7_USB0EPEN       0x00001C0B
+#define GPIO_PA7_SSI0XDAT3      0x00001C0D
+#define GPIO_PA7_EPI0S9         0x00001C0F
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_I2C5SCL        0x00010002
+#define GPIO_PB0_CAN1RX         0x00010007
+#define GPIO_PB0_T4CCP0         0x00010003
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_I2C5SDA        0x00010402
+#define GPIO_PB1_CAN1TX         0x00010407
+#define GPIO_PB1_T4CCP1         0x00010403
+
+#define GPIO_PB2_T5CCP0         0x00010803
+#define GPIO_PB2_I2C0SCL        0x00010802
+#define GPIO_PB2_USB0STP        0x0001080E
+#define GPIO_PB2_EPI0S27        0x0001080F
+
+#define GPIO_PB3_I2C0SDA        0x00010C02
+#define GPIO_PB3_T5CCP1         0x00010C03
+#define GPIO_PB3_USB0CLK        0x00010C0E
+#define GPIO_PB3_EPI0S28        0x00010C0F
+
+#define GPIO_PB4_U0CTS          0x00011001
+#define GPIO_PB4_I2C5SCL        0x00011002
+#define GPIO_PB4_SSI1FSS        0x0001100F
+
+#define GPIO_PB5_U0RTS          0x00011401
+#define GPIO_PB5_I2C5SDA        0x00011402
+#define GPIO_PB5_SSI1CLK        0x0001140F
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+
+#define GPIO_PC2_TDI            0x00020801
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+
+#define GPIO_PC4_U7RX           0x00021001
+#define GPIO_PC4_EPI0S7         0x0002100F
+
+#define GPIO_PC5_U7TX           0x00021401
+#define GPIO_PC5_RTCCLK         0x00021407
+#define GPIO_PC5_EPI0S6         0x0002140F
+
+#define GPIO_PC6_U5RX           0x00021801
+#define GPIO_PC6_EPI0S5         0x0002180F
+
+#define GPIO_PC7_U5TX           0x00021C01
+#define GPIO_PC7_EPI0S4         0x00021C0F
+
+#define GPIO_PD0_I2C7SCL        0x00030002
+#define GPIO_PD0_T0CCP0         0x00030003
+#define GPIO_PD0_C0O            0x00030005
+#define GPIO_PD0_SSI2XDAT1      0x0003000F
+
+#define GPIO_PD1_I2C7SDA        0x00030402
+#define GPIO_PD1_T0CCP1         0x00030403
+#define GPIO_PD1_C1O            0x00030405
+#define GPIO_PD1_SSI2XDAT0      0x0003040F
+
+#define GPIO_PD2_I2C8SCL        0x00030802
+#define GPIO_PD2_T1CCP0         0x00030803
+#define GPIO_PD2_C2O            0x00030805
+#define GPIO_PD2_SSI2FSS        0x0003080F
+
+#define GPIO_PD3_I2C8SDA        0x00030C02
+#define GPIO_PD3_T1CCP1         0x00030C03
+#define GPIO_PD3_SSI2CLK        0x00030C0F
+
+#define GPIO_PD4_U2RX           0x00031001
+#define GPIO_PD4_T3CCP0         0x00031003
+#define GPIO_PD4_SSI1XDAT2      0x0003100F
+
+#define GPIO_PD5_U2TX           0x00031401
+#define GPIO_PD5_T3CCP1         0x00031403
+#define GPIO_PD5_SSI1XDAT3      0x0003140F
+
+#define GPIO_PD6_U2RTS          0x00031801
+#define GPIO_PD6_T4CCP0         0x00031803
+#define GPIO_PD6_USB0EPEN       0x00031805
+#define GPIO_PD6_SSI2XDAT3      0x0003180F
+
+#define GPIO_PD7_U2CTS          0x00031C01
+#define GPIO_PD7_T4CCP1         0x00031C03
+#define GPIO_PD7_USB0PFLT       0x00031C05
+#define GPIO_PD7_NMI            0x00031C08
+#define GPIO_PD7_SSI2XDAT2      0x00031C0F
+
+#define GPIO_PE0_U1RTS          0x00040001
+
+#define GPIO_PE1_U1DSR          0x00040401
+
+#define GPIO_PE2_U1DCD          0x00040801
+
+#define GPIO_PE3_U1DTR          0x00040C01
+
+#define GPIO_PE4_U1RI           0x00041001
+#define GPIO_PE4_SSI1XDAT0      0x0004100F
+
+#define GPIO_PE5_SSI1XDAT1      0x0004140F
+
+#define GPIO_PF0_EN0LED0        0x00050005
+#define GPIO_PF0_M0PWM0         0x00050006
+#define GPIO_PF0_SSI3XDAT1      0x0005000E
+#define GPIO_PF0_TRD2           0x0005000F
+
+#define GPIO_PF1_EN0LED2        0x00050405
+#define GPIO_PF1_M0PWM1         0x00050406
+#define GPIO_PF1_SSI3XDAT0      0x0005040E
+#define GPIO_PF1_TRD1           0x0005040F
+
+#define GPIO_PF2_M0PWM2         0x00050806
+#define GPIO_PF2_SSI3FSS        0x0005080E
+#define GPIO_PF2_TRD0           0x0005080F
+
+#define GPIO_PF3_M0PWM3         0x00050C06
+#define GPIO_PF3_SSI3CLK        0x00050C0E
+#define GPIO_PF3_TRCLK          0x00050C0F
+
+#define GPIO_PF4_EN0LED1        0x00051005
+#define GPIO_PF4_M0FAULT0       0x00051006
+#define GPIO_PF4_SSI3XDAT2      0x0005100E
+#define GPIO_PF4_TRD3           0x0005100F
+
+#define GPIO_PG0_I2C1SCL        0x00060002
+#define GPIO_PG0_EN0PPS         0x00060005
+#define GPIO_PG0_M0PWM4         0x00060006
+#define GPIO_PG0_EPI0S11        0x0006000F
+
+#define GPIO_PG1_I2C1SDA        0x00060402
+#define GPIO_PG1_M0PWM5         0x00060406
+#define GPIO_PG1_EPI0S10        0x0006040F
+
+#define GPIO_PH0_U0RTS          0x00070001
+#define GPIO_PH0_EPI0S0         0x0007000F
+
+#define GPIO_PH1_U0CTS          0x00070401
+#define GPIO_PH1_EPI0S1         0x0007040F
+
+#define GPIO_PH2_U0DCD          0x00070801
+#define GPIO_PH2_EPI0S2         0x0007080F
+
+#define GPIO_PH3_U0DSR          0x00070C01
+#define GPIO_PH3_EPI0S3         0x00070C0F
+
+#define GPIO_PJ0_U3RX           0x00080001
+#define GPIO_PJ0_EN0PPS         0x00080005
+
+#define GPIO_PJ1_U3TX           0x00080401
+
+#define GPIO_PK0_U4RX           0x00090001
+#define GPIO_PK0_EPI0S0         0x0009000F
+
+#define GPIO_PK1_U4TX           0x00090401
+#define GPIO_PK1_EPI0S1         0x0009040F
+
+#define GPIO_PK2_U4RTS          0x00090801
+#define GPIO_PK2_EPI0S2         0x0009080F
+
+#define GPIO_PK3_U4CTS          0x00090C01
+#define GPIO_PK3_EPI0S3         0x00090C0F
+
+#define GPIO_PK4_I2C3SCL        0x00091002
+#define GPIO_PK4_EN0LED0        0x00091005
+#define GPIO_PK4_M0PWM6         0x00091006
+#define GPIO_PK4_EPI0S32        0x0009100F
+
+#define GPIO_PK5_I2C3SDA        0x00091402
+#define GPIO_PK5_EN0LED2        0x00091405
+#define GPIO_PK5_M0PWM7         0x00091406
+#define GPIO_PK5_EPI0S31        0x0009140F
+
+#define GPIO_PK6_I2C4SCL        0x00091802
+#define GPIO_PK6_EN0LED1        0x00091805
+#define GPIO_PK6_M0FAULT1       0x00091806
+#define GPIO_PK6_EPI0S25        0x0009180F
+
+#define GPIO_PK7_U0RI           0x00091C01
+#define GPIO_PK7_I2C4SDA        0x00091C02
+#define GPIO_PK7_RTCCLK         0x00091C05
+#define GPIO_PK7_M0FAULT2       0x00091C06
+#define GPIO_PK7_EPI0S24        0x00091C0F
+
+#define GPIO_PL0_I2C2SDA        0x000A0002
+#define GPIO_PL0_M0FAULT3       0x000A0006
+#define GPIO_PL0_USB0D0         0x000A000E
+#define GPIO_PL0_EPI0S16        0x000A000F
+
+#define GPIO_PL1_I2C2SCL        0x000A0402
+#define GPIO_PL1_PHA0           0x000A0406
+#define GPIO_PL1_USB0D1         0x000A040E
+#define GPIO_PL1_EPI0S17        0x000A040F
+
+#define GPIO_PL2_C0O            0x000A0805
+#define GPIO_PL2_PHB0           0x000A0806
+#define GPIO_PL2_USB0D2         0x000A080E
+#define GPIO_PL2_EPI0S18        0x000A080F
+
+#define GPIO_PL3_C1O            0x000A0C05
+#define GPIO_PL3_IDX0           0x000A0C06
+#define GPIO_PL3_USB0D3         0x000A0C0E
+#define GPIO_PL3_EPI0S19        0x000A0C0F
+
+#define GPIO_PL4_T0CCP0         0x000A1003
+#define GPIO_PL4_USB0D4         0x000A100E
+#define GPIO_PL4_EPI0S26        0x000A100F
+
+#define GPIO_PL5_T0CCP1         0x000A1403
+#define GPIO_PL5_EPI0S33        0x000A140F
+#define GPIO_PL5_USB0D5         0x000A140E
+
+#define GPIO_PL6_T1CCP0         0x000A1803
+
+#define GPIO_PL7_T1CCP1         0x000A1C03
+
+#define GPIO_PM0_T2CCP0         0x000B0003
+#define GPIO_PM0_EPI0S15        0x000B000F
+
+#define GPIO_PM1_T2CCP1         0x000B0403
+#define GPIO_PM1_EPI0S14        0x000B040F
+
+#define GPIO_PM2_T3CCP0         0x000B0803
+#define GPIO_PM2_EPI0S13        0x000B080F
+
+#define GPIO_PM3_T3CCP1         0x000B0C03
+#define GPIO_PM3_EPI0S12        0x000B0C0F
+
+#define GPIO_PM4_U0CTS          0x000B1001
+#define GPIO_PM4_T4CCP0         0x000B1003
+
+#define GPIO_PM5_U0DCD          0x000B1401
+#define GPIO_PM5_T4CCP1         0x000B1403
+
+#define GPIO_PM6_U0DSR          0x000B1801
+#define GPIO_PM6_T5CCP0         0x000B1803
+
+#define GPIO_PM7_U0RI           0x000B1C01
+#define GPIO_PM7_T5CCP1         0x000B1C03
+
+#define GPIO_PN0_U1RTS          0x000C0001
+
+#define GPIO_PN1_U1CTS          0x000C0401
+
+#define GPIO_PN2_U1DCD          0x000C0801
+#define GPIO_PN2_U2RTS          0x000C0802
+#define GPIO_PN2_EPI0S29        0x000C080F
+
+#define GPIO_PN3_U1DSR          0x000C0C01
+#define GPIO_PN3_U2CTS          0x000C0C02
+#define GPIO_PN3_EPI0S30        0x000C0C0F
+
+#define GPIO_PN4_U1DTR          0x000C1001
+#define GPIO_PN4_U3RTS          0x000C1002
+#define GPIO_PN4_I2C2SDA        0x000C1003
+#define GPIO_PN4_EPI0S34        0x000C100F
+
+#define GPIO_PN5_U1RI           0x000C1401
+#define GPIO_PN5_U3CTS          0x000C1402
+#define GPIO_PN5_I2C2SCL        0x000C1403
+#define GPIO_PN5_EPI0S35        0x000C140F
+
+#define GPIO_PP0_U6RX           0x000D0001
+#define GPIO_PP0_SSI3XDAT2      0x000D000F
+
+#define GPIO_PP1_U6TX           0x000D0401
+#define GPIO_PP1_SSI3XDAT3      0x000D040F
+
+#define GPIO_PP2_U0DTR          0x000D0801
+#define GPIO_PP2_USB0NXT        0x000D080E
+#define GPIO_PP2_EPI0S29        0x000D080F
+
+#define GPIO_PP3_U1CTS          0x000D0C01
+#define GPIO_PP3_U0DCD          0x000D0C02
+#define GPIO_PP3_RTCCLK         0x000D0C07
+#define GPIO_PP3_USB0DIR        0x000D0C0E
+#define GPIO_PP3_EPI0S30        0x000D0C0F
+
+#define GPIO_PP4_U3RTS          0x000D1001
+#define GPIO_PP4_U0DSR          0x000D1002
+#define GPIO_PP4_USB0D7         0x000D100E
+
+#define GPIO_PP5_U3CTS          0x000D1401
+#define GPIO_PP5_I2C2SCL        0x000D1402
+#define GPIO_PP5_USB0D6         0x000D140E
+
+#define GPIO_PQ0_SSI3CLK        0x000E000E
+#define GPIO_PQ0_EPI0S20        0x000E000F
+
+#define GPIO_PQ1_SSI3FSS        0x000E040E
+#define GPIO_PQ1_EPI0S21        0x000E040F
+
+#define GPIO_PQ2_SSI3XDAT0      0x000E080E
+#define GPIO_PQ2_EPI0S22        0x000E080F
+
+#define GPIO_PQ3_SSI3XDAT1      0x000E0C0E
+#define GPIO_PQ3_EPI0S23        0x000E0C0F
+
+#define GPIO_PQ4_U1RX           0x000E1001
+#define GPIO_PQ4_DIVSCLK        0x000E1007
+
+#endif // PART_TM4C1294NCPDT
+
+//*****************************************************************************
+//
+// TM4C1294NCZAD Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C1294NCZAD
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_I2C9SCL        0x00000002
+#define GPIO_PA0_T0CCP0         0x00000003
+#define GPIO_PA0_CAN0RX         0x00000007
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_I2C9SDA        0x00000402
+#define GPIO_PA1_T0CCP1         0x00000403
+#define GPIO_PA1_CAN0TX         0x00000407
+
+#define GPIO_PA2_U4RX           0x00000801
+#define GPIO_PA2_I2C8SCL        0x00000802
+#define GPIO_PA2_T1CCP0         0x00000803
+#define GPIO_PA2_SSI0CLK        0x0000080F
+
+#define GPIO_PA3_U4TX           0x00000C01
+#define GPIO_PA3_I2C8SDA        0x00000C02
+#define GPIO_PA3_T1CCP1         0x00000C03
+#define GPIO_PA3_SSI0FSS        0x00000C0F
+
+#define GPIO_PA4_U3RX           0x00001001
+#define GPIO_PA4_T2CCP0         0x00001003
+#define GPIO_PA4_I2C7SCL        0x00001002
+#define GPIO_PA4_SSI0XDAT0      0x0000100F
+
+#define GPIO_PA5_U3TX           0x00001401
+#define GPIO_PA5_T2CCP1         0x00001403
+#define GPIO_PA5_I2C7SDA        0x00001402
+#define GPIO_PA5_SSI0XDAT1      0x0000140F
+
+#define GPIO_PA6_U2RX           0x00001801
+#define GPIO_PA6_I2C6SCL        0x00001802
+#define GPIO_PA6_T3CCP0         0x00001803
+#define GPIO_PA6_USB0EPEN       0x00001805
+#define GPIO_PA6_SSI0XDAT2      0x0000180D
+#define GPIO_PA6_EPI0S8         0x0000180F
+
+#define GPIO_PA7_U2TX           0x00001C01
+#define GPIO_PA7_I2C6SDA        0x00001C02
+#define GPIO_PA7_T3CCP1         0x00001C03
+#define GPIO_PA7_USB0PFLT       0x00001C05
+#define GPIO_PA7_USB0EPEN       0x00001C0B
+#define GPIO_PA7_SSI0XDAT3      0x00001C0D
+#define GPIO_PA7_EPI0S9         0x00001C0F
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_I2C5SCL        0x00010002
+#define GPIO_PB0_CAN1RX         0x00010007
+#define GPIO_PB0_T4CCP0         0x00010003
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_I2C5SDA        0x00010402
+#define GPIO_PB1_CAN1TX         0x00010407
+#define GPIO_PB1_T4CCP1         0x00010403
+
+#define GPIO_PB2_T5CCP0         0x00010803
+#define GPIO_PB2_I2C0SCL        0x00010802
+#define GPIO_PB2_USB0STP        0x0001080E
+#define GPIO_PB2_EPI0S27        0x0001080F
+
+#define GPIO_PB3_I2C0SDA        0x00010C02
+#define GPIO_PB3_T5CCP1         0x00010C03
+#define GPIO_PB3_USB0CLK        0x00010C0E
+#define GPIO_PB3_EPI0S28        0x00010C0F
+
+#define GPIO_PB4_U0CTS          0x00011001
+#define GPIO_PB4_I2C5SCL        0x00011002
+#define GPIO_PB4_SSI1FSS        0x0001100F
+
+#define GPIO_PB5_U0RTS          0x00011401
+#define GPIO_PB5_I2C5SDA        0x00011402
+#define GPIO_PB5_SSI1CLK        0x0001140F
+
+#define GPIO_PB6_I2C6SCL        0x00011802
+#define GPIO_PB6_T6CCP0         0x00011803
+#define GPIO_PB6_PS2CLK3        0x00011804
+
+#define GPIO_PB7_I2C6SDA        0x00011C02
+#define GPIO_PB7_T6CCP1         0x00011C03
+#define GPIO_PB7_PS2DAT3        0x00011C04
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+
+#define GPIO_PC2_TDI            0x00020801
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+
+#define GPIO_PC4_U7RX           0x00021001
+#define GPIO_PC4_T7CCP0         0x00021003
+#define GPIO_PC4_EPI0S7         0x0002100F
+
+#define GPIO_PC5_U7TX           0x00021401
+#define GPIO_PC5_T7CCP1         0x00021403
+#define GPIO_PC5_RTCCLK         0x00021407
+#define GPIO_PC5_EPI0S6         0x0002140F
+
+#define GPIO_PC6_U5RX           0x00021801
+#define GPIO_PC6_EPI0S5         0x0002180F
+
+#define GPIO_PC7_U5TX           0x00021C01
+#define GPIO_PC7_EPI0S4         0x00021C0F
+
+#define GPIO_PD0_I2C7SCL        0x00030002
+#define GPIO_PD0_T0CCP0         0x00030003
+#define GPIO_PD0_C0O            0x00030005
+#define GPIO_PD0_SSI2XDAT1      0x0003000F
+
+#define GPIO_PD1_I2C7SDA        0x00030402
+#define GPIO_PD1_T0CCP1         0x00030403
+#define GPIO_PD1_C1O            0x00030405
+#define GPIO_PD1_SSI2XDAT0      0x0003040F
+
+#define GPIO_PD2_I2C8SCL        0x00030802
+#define GPIO_PD2_T1CCP0         0x00030803
+#define GPIO_PD2_C2O            0x00030805
+#define GPIO_PD2_SSI2FSS        0x0003080F
+
+#define GPIO_PD3_I2C8SDA        0x00030C02
+#define GPIO_PD3_T1CCP1         0x00030C03
+#define GPIO_PD3_SSI2CLK        0x00030C0F
+
+#define GPIO_PD4_U2RX           0x00031001
+#define GPIO_PD4_T3CCP0         0x00031003
+#define GPIO_PD4_SSI1XDAT2      0x0003100F
+
+#define GPIO_PD5_U2TX           0x00031401
+#define GPIO_PD5_T3CCP1         0x00031403
+#define GPIO_PD5_SSI1XDAT3      0x0003140F
+
+#define GPIO_PD6_U2RTS          0x00031801
+#define GPIO_PD6_T4CCP0         0x00031803
+#define GPIO_PD6_USB0EPEN       0x00031805
+#define GPIO_PD6_SSI2XDAT3      0x0003180F
+
+#define GPIO_PD7_U2CTS          0x00031C01
+#define GPIO_PD7_T4CCP1         0x00031C03
+#define GPIO_PD7_USB0PFLT       0x00031C05
+#define GPIO_PD7_NMI            0x00031C08
+#define GPIO_PD7_SSI2XDAT2      0x00031C0F
+
+#define GPIO_PE0_U1RTS          0x00040001
+
+#define GPIO_PE1_U1DSR          0x00040401
+
+#define GPIO_PE2_U1DCD          0x00040801
+
+#define GPIO_PE3_U1DTR          0x00040C01
+
+#define GPIO_PE4_U1RI           0x00041001
+#define GPIO_PE4_SSI1XDAT0      0x0004100F
+
+#define GPIO_PE5_SSI1XDAT1      0x0004140F
+
+#define GPIO_PE6_U0CTS          0x00041801
+#define GPIO_PE6_I2C9SCL        0x00041802
+
+#define GPIO_PE7_U0RTS          0x00041C01
+#define GPIO_PE7_I2C9SDA        0x00041C02
+#define GPIO_PE7_NMI            0x00041C08
+
+#define GPIO_PF0_EN0LED0        0x00050005
+#define GPIO_PF0_M0PWM0         0x00050006
+#define GPIO_PF0_SSI3XDAT1      0x0005000E
+#define GPIO_PF0_TRD2           0x0005000F
+
+#define GPIO_PF1_EN0LED2        0x00050405
+#define GPIO_PF1_M0PWM1         0x00050406
+#define GPIO_PF1_SSI3XDAT0      0x0005040E
+#define GPIO_PF1_TRD1           0x0005040F
+
+#define GPIO_PF2_M0PWM2         0x00050806
+#define GPIO_PF2_SSI3FSS        0x0005080E
+#define GPIO_PF2_TRD0           0x0005080F
+
+#define GPIO_PF3_M0PWM3         0x00050C06
+#define GPIO_PF3_SSI3CLK        0x00050C0E
+#define GPIO_PF3_TRCLK          0x00050C0F
+
+#define GPIO_PF4_EN0LED1        0x00051005
+#define GPIO_PF4_M0FAULT0       0x00051006
+#define GPIO_PF4_SSI3XDAT2      0x0005100E
+#define GPIO_PF4_TRD3           0x0005100F
+
+#define GPIO_PF5_SSI3XDAT3      0x0005140E
+
+#define GPIO_PG0_I2C1SCL        0x00060002
+#define GPIO_PG0_EN0PPS         0x00060005
+#define GPIO_PG0_M0PWM4         0x00060006
+#define GPIO_PG0_EPI0S11        0x0006000F
+
+#define GPIO_PG1_I2C1SDA        0x00060402
+#define GPIO_PG1_M0PWM5         0x00060406
+#define GPIO_PG1_EPI0S10        0x0006040F
+
+#define GPIO_PG2_I2C2SCL        0x00060802
+#define GPIO_PG2_SSI2XDAT3      0x0006080F
+
+#define GPIO_PG3_I2C2SDA        0x00060C02
+#define GPIO_PG3_SSI2XDAT2      0x00060C0F
+
+#define GPIO_PG4_U0CTS          0x00061001
+#define GPIO_PG4_I2C3SCL        0x00061002
+#define GPIO_PG4_SSI2XDAT1      0x0006100F
+
+#define GPIO_PG5_U0RTS          0x00061401
+#define GPIO_PG5_I2C3SDA        0x00061402
+#define GPIO_PG5_SSI2XDAT0      0x0006140F
+
+#define GPIO_PG6_I2C4SCL        0x00061802
+#define GPIO_PG6_SSI2FSS        0x0006180F
+
+#define GPIO_PG7_I2C4SDA        0x00061C02
+#define GPIO_PG7_SSI2CLK        0x00061C0F
+
+#define GPIO_PH0_U0RTS          0x00070001
+#define GPIO_PH0_EPI0S0         0x0007000F
+
+#define GPIO_PH1_U0CTS          0x00070401
+#define GPIO_PH1_EPI0S1         0x0007040F
+
+#define GPIO_PH2_U0DCD          0x00070801
+#define GPIO_PH2_EPI0S2         0x0007080F
+
+#define GPIO_PH3_U0DSR          0x00070C01
+#define GPIO_PH3_EPI0S3         0x00070C0F
+
+#define GPIO_PH4_U0DTR          0x00071001
+
+#define GPIO_PH5_U0RI           0x00071401
+#define GPIO_PH5_EN0PPS         0x00071405
+
+#define GPIO_PH6_U5RX           0x00071801
+#define GPIO_PH6_U7RX           0x00071802
+
+#define GPIO_PH7_U5TX           0x00071C01
+#define GPIO_PH7_U7TX           0x00071C02
+
+#define GPIO_PJ0_U3RX           0x00080001
+#define GPIO_PJ0_EN0PPS         0x00080005
+
+#define GPIO_PJ1_U3TX           0x00080401
+
+#define GPIO_PJ2_U2RTS          0x00080801
+
+#define GPIO_PJ3_U2CTS          0x00080C01
+
+#define GPIO_PJ4_U3RTS          0x00081001
+
+#define GPIO_PJ5_U3CTS          0x00081401
+
+#define GPIO_PJ6_U4RTS          0x00081801
+
+#define GPIO_PJ7_U4CTS          0x00081C01
+
+#define GPIO_PK0_U4RX           0x00090001
+#define GPIO_PK0_EPI0S0         0x0009000F
+
+#define GPIO_PK1_U4TX           0x00090401
+#define GPIO_PK1_EPI0S1         0x0009040F
+
+#define GPIO_PK2_U4RTS          0x00090801
+#define GPIO_PK2_EPI0S2         0x0009080F
+
+#define GPIO_PK3_U4CTS          0x00090C01
+#define GPIO_PK3_EPI0S3         0x00090C0F
+
+#define GPIO_PK4_I2C3SCL        0x00091002
+#define GPIO_PK4_EN0LED0        0x00091005
+#define GPIO_PK4_M0PWM6         0x00091006
+#define GPIO_PK4_EPI0S32        0x0009100F
+
+#define GPIO_PK5_I2C3SDA        0x00091402
+#define GPIO_PK5_EN0LED2        0x00091405
+#define GPIO_PK5_M0PWM7         0x00091406
+#define GPIO_PK5_EPI0S31        0x0009140F
+
+#define GPIO_PK6_I2C4SCL        0x00091802
+#define GPIO_PK6_EN0LED1        0x00091805
+#define GPIO_PK6_M0FAULT1       0x00091806
+#define GPIO_PK6_EPI0S25        0x0009180F
+
+#define GPIO_PK7_U0RI           0x00091C01
+#define GPIO_PK7_I2C4SDA        0x00091C02
+#define GPIO_PK7_RTCCLK         0x00091C05
+#define GPIO_PK7_M0FAULT2       0x00091C06
+#define GPIO_PK7_EPI0S24        0x00091C0F
+
+#define GPIO_PL0_I2C2SDA        0x000A0002
+#define GPIO_PL0_M0FAULT3       0x000A0006
+#define GPIO_PL0_USB0D0         0x000A000E
+#define GPIO_PL0_EPI0S16        0x000A000F
+
+#define GPIO_PL1_I2C2SCL        0x000A0402
+#define GPIO_PL1_PHA0           0x000A0406
+#define GPIO_PL1_USB0D1         0x000A040E
+#define GPIO_PL1_EPI0S17        0x000A040F
+
+#define GPIO_PL2_C0O            0x000A0805
+#define GPIO_PL2_PHB0           0x000A0806
+#define GPIO_PL2_USB0D2         0x000A080E
+#define GPIO_PL2_EPI0S18        0x000A080F
+
+#define GPIO_PL3_C1O            0x000A0C05
+#define GPIO_PL3_IDX0           0x000A0C06
+#define GPIO_PL3_USB0D3         0x000A0C0E
+#define GPIO_PL3_EPI0S19        0x000A0C0F
+
+#define GPIO_PL4_T0CCP0         0x000A1003
+#define GPIO_PL4_USB0D4         0x000A100E
+#define GPIO_PL4_EPI0S26        0x000A100F
+
+#define GPIO_PL5_T0CCP1         0x000A1403
+#define GPIO_PL5_EPI0S33        0x000A140F
+#define GPIO_PL5_USB0D5         0x000A140E
+
+#define GPIO_PL6_T1CCP0         0x000A1803
+
+#define GPIO_PL7_T1CCP1         0x000A1C03
+
+#define GPIO_PM0_T2CCP0         0x000B0003
+#define GPIO_PM0_EPI0S15        0x000B000F
+
+#define GPIO_PM1_T2CCP1         0x000B0403
+#define GPIO_PM1_EPI0S14        0x000B040F
+
+#define GPIO_PM2_T3CCP0         0x000B0803
+#define GPIO_PM2_EPI0S13        0x000B080F
+
+#define GPIO_PM3_T3CCP1         0x000B0C03
+#define GPIO_PM3_EPI0S12        0x000B0C0F
+
+#define GPIO_PM4_U0CTS          0x000B1001
+#define GPIO_PM4_T4CCP0         0x000B1003
+
+#define GPIO_PM5_U0DCD          0x000B1401
+#define GPIO_PM5_T4CCP1         0x000B1403
+
+#define GPIO_PM6_U0DSR          0x000B1801
+#define GPIO_PM6_T5CCP0         0x000B1803
+
+#define GPIO_PM7_U0RI           0x000B1C01
+#define GPIO_PM7_T5CCP1         0x000B1C03
+
+#define GPIO_PN0_U1RTS          0x000C0001
+
+#define GPIO_PN1_U1CTS          0x000C0401
+
+#define GPIO_PN2_U1DCD          0x000C0801
+#define GPIO_PN2_U2RTS          0x000C0802
+#define GPIO_PN2_EPI0S29        0x000C080F
+
+#define GPIO_PN3_U1DSR          0x000C0C01
+#define GPIO_PN3_U2CTS          0x000C0C02
+#define GPIO_PN3_EPI0S30        0x000C0C0F
+
+#define GPIO_PN4_U1DTR          0x000C1001
+#define GPIO_PN4_U3RTS          0x000C1002
+#define GPIO_PN4_I2C2SDA        0x000C1003
+#define GPIO_PN4_EPI0S34        0x000C100F
+
+#define GPIO_PN5_U1RI           0x000C1401
+#define GPIO_PN5_U3CTS          0x000C1402
+#define GPIO_PN5_I2C2SCL        0x000C1403
+#define GPIO_PN5_EPI0S35        0x000C140F
+
+#define GPIO_PN6_U4RTS          0x000C1802
+
+#define GPIO_PN7_U1RTS          0x000C1C01
+#define GPIO_PN7_U4CTS          0x000C1C02
+
+#define GPIO_PP0_U6RX           0x000D0001
+#define GPIO_PP0_T6CCP0         0x000D0005
+#define GPIO_PP0_SSI3XDAT2      0x000D000F
+
+#define GPIO_PP1_U6TX           0x000D0401
+#define GPIO_PP1_T6CCP1         0x000D0405
+#define GPIO_PP1_SSI3XDAT3      0x000D040F
+
+#define GPIO_PP2_U0DTR          0x000D0801
+#define GPIO_PP2_USB0NXT        0x000D080E
+#define GPIO_PP2_EPI0S29        0x000D080F
+
+#define GPIO_PP3_U1CTS          0x000D0C01
+#define GPIO_PP3_U0DCD          0x000D0C02
+#define GPIO_PP3_RTCCLK         0x000D0C07
+#define GPIO_PP3_USB0DIR        0x000D0C0E
+#define GPIO_PP3_EPI0S30        0x000D0C0F
+
+#define GPIO_PP4_U3RTS          0x000D1001
+#define GPIO_PP4_U0DSR          0x000D1002
+#define GPIO_PP4_USB0D7         0x000D100E
+
+#define GPIO_PP5_U3CTS          0x000D1401
+#define GPIO_PP5_I2C2SCL        0x000D1402
+#define GPIO_PP5_USB0D6         0x000D140E
+
+#define GPIO_PP6_U1DCD          0x000D1801
+#define GPIO_PP6_I2C2SDA        0x000D1802
+
+#define GPIO_PQ0_T6CCP0         0x000E0003
+#define GPIO_PQ0_SSI3CLK        0x000E000E
+#define GPIO_PQ0_EPI0S20        0x000E000F
+
+#define GPIO_PQ1_T6CCP1         0x000E0403
+#define GPIO_PQ1_SSI3FSS        0x000E040E
+#define GPIO_PQ1_EPI0S21        0x000E040F
+
+#define GPIO_PQ2_T7CCP0         0x000E0803
+#define GPIO_PQ2_SSI3XDAT0      0x000E080E
+#define GPIO_PQ2_EPI0S22        0x000E080F
+
+#define GPIO_PQ3_T7CCP1         0x000E0C03
+#define GPIO_PQ3_SSI3XDAT1      0x000E0C0E
+#define GPIO_PQ3_EPI0S23        0x000E0C0F
+
+#define GPIO_PQ4_U1RX           0x000E1001
+#define GPIO_PQ4_DIVSCLK        0x000E1007
+
+#define GPIO_PQ5_U1TX           0x000E1401
+
+#define GPIO_PQ6_U1DTR          0x000E1801
+
+#define GPIO_PQ7_U1RI           0x000E1C01
+
+#define GPIO_PR0_U4TX           0x000F0001
+#define GPIO_PR0_I2C1SCL        0x000F0002
+#define GPIO_PR0_M0PWM0         0x000F0006
+
+#define GPIO_PR1_U4RX           0x000F0401
+#define GPIO_PR1_I2C1SDA        0x000F0402
+#define GPIO_PR1_M0PWM1         0x000F0406
+
+#define GPIO_PR2_I2C2SCL        0x000F0802
+#define GPIO_PR2_M0PWM2         0x000F0806
+
+#define GPIO_PR3_I2C2SDA        0x000F0C02
+#define GPIO_PR3_M0PWM3         0x000F0C06
+
+#define GPIO_PR4_I2C3SCL        0x000F1002
+#define GPIO_PR4_T0CCP0         0x000F1003
+#define GPIO_PR4_M0PWM4         0x000F1006
+
+#define GPIO_PR5_U1RX           0x000F1401
+#define GPIO_PR5_I2C3SDA        0x000F1402
+#define GPIO_PR5_T0CCP1         0x000F1403
+#define GPIO_PR5_M0PWM5         0x000F1406
+
+#define GPIO_PR6_U1TX           0x000F1801
+#define GPIO_PR6_I2C4SCL        0x000F1802
+#define GPIO_PR6_T1CCP0         0x000F1803
+#define GPIO_PR6_M0PWM6         0x000F1806
+
+#define GPIO_PR7_I2C4SDA        0x000F1C02
+#define GPIO_PR7_T1CCP1         0x000F1C03
+#define GPIO_PR7_M0PWM7         0x000F1C06
+
+#define GPIO_PS0_T2CCP0         0x00100003
+#define GPIO_PS0_M0FAULT0       0x00100006
+
+#define GPIO_PS1_T2CCP1         0x00100403
+#define GPIO_PS1_M0FAULT1       0x00100406
+
+#define GPIO_PS2_U1DSR          0x00100801
+#define GPIO_PS2_T3CCP0         0x00100803
+#define GPIO_PS2_M0FAULT2       0x00100806
+
+#define GPIO_PS3_T3CCP1         0x00100C03
+#define GPIO_PS3_M0FAULT3       0x00100C06
+
+#define GPIO_PS4_T4CCP0         0x00101003
+#define GPIO_PS4_PHA0           0x00101006
+
+#define GPIO_PS5_T4CCP1         0x00101403
+#define GPIO_PS5_PHB0           0x00101406
+
+#define GPIO_PS6_T5CCP0         0x00101803
+#define GPIO_PS6_IDX0           0x00101806
+
+#define GPIO_PS7_T5CCP1         0x00101C03
+
+#define GPIO_PT0_T6CCP0         0x00110003
+#define GPIO_PT0_CAN0RX         0x00110007
+
+#define GPIO_PT1_T6CCP1         0x00110403
+#define GPIO_PT1_CAN0TX         0x00110407
+
+#define GPIO_PT2_T7CCP0         0x00110803
+#define GPIO_PT2_CAN1RX         0x00110807
+
+#define GPIO_PT3_T7CCP1         0x00110C03
+#define GPIO_PT3_CAN1TX         0x00110C07
+
+#endif // PART_TM4C1294NCZAD
+
+//*****************************************************************************
+//
+// TM4C129CNCPDT Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C129CNCPDT
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_I2C9SCL        0x00000002
+#define GPIO_PA0_T0CCP0         0x00000003
+#define GPIO_PA0_CAN0RX         0x00000007
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_I2C9SDA        0x00000402
+#define GPIO_PA1_T0CCP1         0x00000403
+#define GPIO_PA1_CAN0TX         0x00000407
+
+#define GPIO_PA2_U4RX           0x00000801
+#define GPIO_PA2_I2C8SCL        0x00000802
+#define GPIO_PA2_T1CCP0         0x00000803
+#define GPIO_PA2_SSI0CLK        0x0000080F
+
+#define GPIO_PA3_U4TX           0x00000C01
+#define GPIO_PA3_I2C8SDA        0x00000C02
+#define GPIO_PA3_T1CCP1         0x00000C03
+#define GPIO_PA3_SSI0FSS        0x00000C0F
+
+#define GPIO_PA4_U3RX           0x00001001
+#define GPIO_PA4_T2CCP0         0x00001003
+#define GPIO_PA4_I2C7SCL        0x00001002
+#define GPIO_PA4_SSI0XDAT0      0x0000100F
+
+#define GPIO_PA5_U3TX           0x00001401
+#define GPIO_PA5_T2CCP1         0x00001403
+#define GPIO_PA5_I2C7SDA        0x00001402
+#define GPIO_PA5_SSI0XDAT1      0x0000140F
+
+#define GPIO_PA6_U2RX           0x00001801
+#define GPIO_PA6_I2C6SCL        0x00001802
+#define GPIO_PA6_T3CCP0         0x00001803
+#define GPIO_PA6_USB0EPEN       0x00001805
+#define GPIO_PA6_SSI0XDAT2      0x0000180D
+#define GPIO_PA6_EPI0S8         0x0000180F
+
+#define GPIO_PA7_U2TX           0x00001C01
+#define GPIO_PA7_I2C6SDA        0x00001C02
+#define GPIO_PA7_T3CCP1         0x00001C03
+#define GPIO_PA7_USB0PFLT       0x00001C05
+#define GPIO_PA7_USB0EPEN       0x00001C0B
+#define GPIO_PA7_SSI0XDAT3      0x00001C0D
+#define GPIO_PA7_EPI0S9         0x00001C0F
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_I2C5SCL        0x00010002
+#define GPIO_PB0_CAN1RX         0x00010007
+#define GPIO_PB0_T4CCP0         0x00010003
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_I2C5SDA        0x00010402
+#define GPIO_PB1_CAN1TX         0x00010407
+#define GPIO_PB1_T4CCP1         0x00010403
+
+#define GPIO_PB2_T5CCP0         0x00010803
+#define GPIO_PB2_I2C0SCL        0x00010802
+#define GPIO_PB2_USB0STP        0x0001080E
+#define GPIO_PB2_EPI0S27        0x0001080F
+
+#define GPIO_PB3_I2C0SDA        0x00010C02
+#define GPIO_PB3_T5CCP1         0x00010C03
+#define GPIO_PB3_USB0CLK        0x00010C0E
+#define GPIO_PB3_EPI0S28        0x00010C0F
+
+#define GPIO_PB4_U0CTS          0x00011001
+#define GPIO_PB4_I2C5SCL        0x00011002
+#define GPIO_PB4_SSI1FSS        0x0001100F
+
+#define GPIO_PB5_U0RTS          0x00011401
+#define GPIO_PB5_I2C5SDA        0x00011402
+#define GPIO_PB5_SSI1CLK        0x0001140F
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+
+#define GPIO_PC2_TDI            0x00020801
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+
+#define GPIO_PC4_U7RX           0x00021001
+#define GPIO_PC4_EPI0S7         0x0002100F
+
+#define GPIO_PC5_U7TX           0x00021401
+#define GPIO_PC5_RTCCLK         0x00021407
+#define GPIO_PC5_EPI0S6         0x0002140F
+
+#define GPIO_PC6_U5RX           0x00021801
+#define GPIO_PC6_EPI0S5         0x0002180F
+
+#define GPIO_PC7_U5TX           0x00021C01
+#define GPIO_PC7_EPI0S4         0x00021C0F
+
+#define GPIO_PD0_I2C7SCL        0x00030002
+#define GPIO_PD0_T0CCP0         0x00030003
+#define GPIO_PD0_C0O            0x00030005
+#define GPIO_PD0_SSI2XDAT1      0x0003000F
+
+#define GPIO_PD1_I2C7SDA        0x00030402
+#define GPIO_PD1_T0CCP1         0x00030403
+#define GPIO_PD1_C1O            0x00030405
+#define GPIO_PD1_SSI2XDAT0      0x0003040F
+
+#define GPIO_PD2_I2C8SCL        0x00030802
+#define GPIO_PD2_T1CCP0         0x00030803
+#define GPIO_PD2_C2O            0x00030805
+#define GPIO_PD2_SSI2FSS        0x0003080F
+
+#define GPIO_PD3_I2C8SDA        0x00030C02
+#define GPIO_PD3_T1CCP1         0x00030C03
+#define GPIO_PD3_SSI2CLK        0x00030C0F
+
+#define GPIO_PD4_U2RX           0x00031001
+#define GPIO_PD4_T3CCP0         0x00031003
+#define GPIO_PD4_SSI1XDAT2      0x0003100F
+
+#define GPIO_PD5_U2TX           0x00031401
+#define GPIO_PD5_T3CCP1         0x00031403
+#define GPIO_PD5_SSI1XDAT3      0x0003140F
+
+#define GPIO_PD6_U2RTS          0x00031801
+#define GPIO_PD6_T4CCP0         0x00031803
+#define GPIO_PD6_USB0EPEN       0x00031805
+#define GPIO_PD6_SSI2XDAT3      0x0003180F
+
+#define GPIO_PD7_U2CTS          0x00031C01
+#define GPIO_PD7_T4CCP1         0x00031C03
+#define GPIO_PD7_USB0PFLT       0x00031C05
+#define GPIO_PD7_NMI            0x00031C08
+#define GPIO_PD7_SSI2XDAT2      0x00031C0F
+
+#define GPIO_PE0_U1RTS          0x00040001
+
+#define GPIO_PE1_U1DSR          0x00040401
+
+#define GPIO_PE2_U1DCD          0x00040801
+
+#define GPIO_PE3_U1DTR          0x00040C01
+
+#define GPIO_PE4_U1RI           0x00041001
+#define GPIO_PE4_SSI1XDAT0      0x0004100F
+
+#define GPIO_PE5_SSI1XDAT1      0x0004140F
+
+#define GPIO_PF0_M0PWM0         0x00050006
+#define GPIO_PF0_SSI3XDAT1      0x0005000E
+#define GPIO_PF0_TRD2           0x0005000F
+
+#define GPIO_PF1_M0PWM1         0x00050406
+#define GPIO_PF1_SSI3XDAT0      0x0005040E
+#define GPIO_PF1_TRD1           0x0005040F
+
+#define GPIO_PF2_M0PWM2         0x00050806
+#define GPIO_PF2_SSI3FSS        0x0005080E
+#define GPIO_PF2_TRD0           0x0005080F
+
+#define GPIO_PF3_M0PWM3         0x00050C06
+#define GPIO_PF3_SSI3CLK        0x00050C0E
+#define GPIO_PF3_TRCLK          0x00050C0F
+
+#define GPIO_PF4_M0FAULT0       0x00051006
+#define GPIO_PF4_SSI3XDAT2      0x0005100E
+#define GPIO_PF4_TRD3           0x0005100F
+
+#define GPIO_PG0_I2C1SCL        0x00060002
+#define GPIO_PG0_M0PWM4         0x00060006
+#define GPIO_PG0_EPI0S11        0x0006000F
+
+#define GPIO_PG1_I2C1SDA        0x00060402
+#define GPIO_PG1_M0PWM5         0x00060406
+#define GPIO_PG1_EPI0S10        0x0006040F
+
+#define GPIO_PG2_I2C2SCL        0x00060802
+#define GPIO_PG2_SSI2XDAT3      0x0006080F
+
+#define GPIO_PG3_I2C2SDA        0x00060C02
+#define GPIO_PG3_SSI2XDAT2      0x00060C0F
+
+#define GPIO_PG4_U0CTS          0x00061001
+#define GPIO_PG4_I2C3SCL        0x00061002
+#define GPIO_PG4_SSI2XDAT1      0x0006100F
+
+#define GPIO_PG5_U0RTS          0x00061401
+#define GPIO_PG5_I2C3SDA        0x00061402
+#define GPIO_PG5_SSI2XDAT0      0x0006140F
+
+#define GPIO_PG6_I2C4SCL        0x00061802
+#define GPIO_PG6_SSI2FSS        0x0006180F
+
+#define GPIO_PG7_I2C4SDA        0x00061C02
+#define GPIO_PG7_SSI2CLK        0x00061C0F
+
+#define GPIO_PH0_U0RTS          0x00070001
+#define GPIO_PH0_EPI0S0         0x0007000F
+
+#define GPIO_PH1_U0CTS          0x00070401
+#define GPIO_PH1_EPI0S1         0x0007040F
+
+#define GPIO_PH2_U0DCD          0x00070801
+#define GPIO_PH2_EPI0S2         0x0007080F
+
+#define GPIO_PH3_U0DSR          0x00070C01
+#define GPIO_PH3_EPI0S3         0x00070C0F
+
+#define GPIO_PJ0_U3RX           0x00080001
+
+#define GPIO_PJ1_U3TX           0x00080401
+
+#define GPIO_PK0_U4RX           0x00090001
+#define GPIO_PK0_EPI0S0         0x0009000F
+
+#define GPIO_PK1_U4TX           0x00090401
+#define GPIO_PK1_EPI0S1         0x0009040F
+
+#define GPIO_PK2_U4RTS          0x00090801
+#define GPIO_PK2_EPI0S2         0x0009080F
+
+#define GPIO_PK3_U4CTS          0x00090C01
+#define GPIO_PK3_EPI0S3         0x00090C0F
+
+#define GPIO_PK4_I2C3SCL        0x00091002
+#define GPIO_PK4_M0PWM6         0x00091006
+#define GPIO_PK4_EPI0S32        0x0009100F
+
+#define GPIO_PK5_I2C3SDA        0x00091402
+#define GPIO_PK5_M0PWM7         0x00091406
+#define GPIO_PK5_EPI0S31        0x0009140F
+
+#define GPIO_PK6_I2C4SCL        0x00091802
+#define GPIO_PK6_M0FAULT1       0x00091806
+#define GPIO_PK6_EPI0S25        0x0009180F
+
+#define GPIO_PK7_U0RI           0x00091C01
+#define GPIO_PK7_I2C4SDA        0x00091C02
+#define GPIO_PK7_RTCCLK         0x00091C05
+#define GPIO_PK7_M0FAULT2       0x00091C06
+#define GPIO_PK7_EPI0S24        0x00091C0F
+
+#define GPIO_PL0_I2C2SDA        0x000A0002
+#define GPIO_PL0_M0FAULT3       0x000A0006
+#define GPIO_PL0_USB0D0         0x000A000E
+#define GPIO_PL0_EPI0S16        0x000A000F
+
+#define GPIO_PL1_I2C2SCL        0x000A0402
+#define GPIO_PL1_PHA0           0x000A0406
+#define GPIO_PL1_USB0D1         0x000A040E
+#define GPIO_PL1_EPI0S17        0x000A040F
+
+#define GPIO_PL2_C0O            0x000A0805
+#define GPIO_PL2_PHB0           0x000A0806
+#define GPIO_PL2_USB0D2         0x000A080E
+#define GPIO_PL2_EPI0S18        0x000A080F
+
+#define GPIO_PL3_C1O            0x000A0C05
+#define GPIO_PL3_IDX0           0x000A0C06
+#define GPIO_PL3_USB0D3         0x000A0C0E
+#define GPIO_PL3_EPI0S19        0x000A0C0F
+
+#define GPIO_PL4_T0CCP0         0x000A1003
+#define GPIO_PL4_USB0D4         0x000A100E
+#define GPIO_PL4_EPI0S26        0x000A100F
+
+#define GPIO_PL5_T0CCP1         0x000A1403
+#define GPIO_PL5_EPI0S33        0x000A140F
+#define GPIO_PL5_USB0D5         0x000A140E
+
+#define GPIO_PL6_T1CCP0         0x000A1803
+
+#define GPIO_PL7_T1CCP1         0x000A1C03
+
+#define GPIO_PM0_T2CCP0         0x000B0003
+#define GPIO_PM0_EPI0S15        0x000B000F
+
+#define GPIO_PM1_T2CCP1         0x000B0403
+#define GPIO_PM1_EPI0S14        0x000B040F
+
+#define GPIO_PM2_T3CCP0         0x000B0803
+#define GPIO_PM2_EPI0S13        0x000B080F
+
+#define GPIO_PM3_T3CCP1         0x000B0C03
+#define GPIO_PM3_EPI0S12        0x000B0C0F
+
+#define GPIO_PM4_U0CTS          0x000B1001
+#define GPIO_PM4_T4CCP0         0x000B1003
+
+#define GPIO_PM5_U0DCD          0x000B1401
+#define GPIO_PM5_T4CCP1         0x000B1403
+
+#define GPIO_PM6_U0DSR          0x000B1801
+#define GPIO_PM6_T5CCP0         0x000B1803
+
+#define GPIO_PM7_U0RI           0x000B1C01
+#define GPIO_PM7_T5CCP1         0x000B1C03
+
+#define GPIO_PN0_U1RTS          0x000C0001
+
+#define GPIO_PN1_U1CTS          0x000C0401
+
+#define GPIO_PN2_U1DCD          0x000C0801
+#define GPIO_PN2_U2RTS          0x000C0802
+#define GPIO_PN2_EPI0S29        0x000C080F
+
+#define GPIO_PN3_U1DSR          0x000C0C01
+#define GPIO_PN3_U2CTS          0x000C0C02
+#define GPIO_PN3_EPI0S30        0x000C0C0F
+
+#define GPIO_PN4_U1DTR          0x000C1001
+#define GPIO_PN4_U3RTS          0x000C1002
+#define GPIO_PN4_I2C2SDA        0x000C1003
+#define GPIO_PN4_EPI0S34        0x000C100F
+
+#define GPIO_PN5_U1RI           0x000C1401
+#define GPIO_PN5_U3CTS          0x000C1402
+#define GPIO_PN5_I2C2SCL        0x000C1403
+#define GPIO_PN5_EPI0S35        0x000C140F
+
+#define GPIO_PP0_U6RX           0x000D0001
+#define GPIO_PP0_SSI3XDAT2      0x000D000F
+
+#define GPIO_PP1_U6TX           0x000D0401
+#define GPIO_PP1_SSI3XDAT3      0x000D040F
+
+#define GPIO_PP2_U0DTR          0x000D0801
+#define GPIO_PP2_USB0NXT        0x000D080E
+#define GPIO_PP2_EPI0S29        0x000D080F
+
+#define GPIO_PP3_U1CTS          0x000D0C01
+#define GPIO_PP3_U0DCD          0x000D0C02
+#define GPIO_PP3_RTCCLK         0x000D0C07
+#define GPIO_PP3_USB0DIR        0x000D0C0E
+#define GPIO_PP3_EPI0S30        0x000D0C0F
+
+#define GPIO_PP4_U3RTS          0x000D1001
+#define GPIO_PP4_U0DSR          0x000D1002
+#define GPIO_PP4_USB0D7         0x000D100E
+
+#define GPIO_PP5_U3CTS          0x000D1401
+#define GPIO_PP5_I2C2SCL        0x000D1402
+#define GPIO_PP5_USB0D6         0x000D140E
+
+#define GPIO_PQ0_SSI3CLK        0x000E000E
+#define GPIO_PQ0_EPI0S20        0x000E000F
+
+#define GPIO_PQ1_SSI3FSS        0x000E040E
+#define GPIO_PQ1_EPI0S21        0x000E040F
+
+#define GPIO_PQ2_SSI3XDAT0      0x000E080E
+#define GPIO_PQ2_EPI0S22        0x000E080F
+
+#define GPIO_PQ3_SSI3XDAT1      0x000E0C0E
+#define GPIO_PQ3_EPI0S23        0x000E0C0F
+
+#define GPIO_PQ4_U1RX           0x000E1001
+#define GPIO_PQ4_DIVSCLK        0x000E1007
+
+#define GPIO_PQ5_U1TX           0x000E1401
+
+#define GPIO_PQ6_U1DTR          0x000E1801
+
+#endif // PART_TM4C129CNCPDT
+
+//*****************************************************************************
+//
+// TM4C129CNCZAD Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C129CNCZAD
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_I2C9SCL        0x00000002
+#define GPIO_PA0_T0CCP0         0x00000003
+#define GPIO_PA0_CAN0RX         0x00000007
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_I2C9SDA        0x00000402
+#define GPIO_PA1_T0CCP1         0x00000403
+#define GPIO_PA1_CAN0TX         0x00000407
+
+#define GPIO_PA2_U4RX           0x00000801
+#define GPIO_PA2_I2C8SCL        0x00000802
+#define GPIO_PA2_T1CCP0         0x00000803
+#define GPIO_PA2_SSI0CLK        0x0000080F
+
+#define GPIO_PA3_U4TX           0x00000C01
+#define GPIO_PA3_I2C8SDA        0x00000C02
+#define GPIO_PA3_T1CCP1         0x00000C03
+#define GPIO_PA3_SSI0FSS        0x00000C0F
+
+#define GPIO_PA4_U3RX           0x00001001
+#define GPIO_PA4_T2CCP0         0x00001003
+#define GPIO_PA4_I2C7SCL        0x00001002
+#define GPIO_PA4_SSI0XDAT0      0x0000100F
+
+#define GPIO_PA5_U3TX           0x00001401
+#define GPIO_PA5_T2CCP1         0x00001403
+#define GPIO_PA5_I2C7SDA        0x00001402
+#define GPIO_PA5_SSI0XDAT1      0x0000140F
+
+#define GPIO_PA6_U2RX           0x00001801
+#define GPIO_PA6_I2C6SCL        0x00001802
+#define GPIO_PA6_T3CCP0         0x00001803
+#define GPIO_PA6_USB0EPEN       0x00001805
+#define GPIO_PA6_SSI0XDAT2      0x0000180D
+#define GPIO_PA6_EPI0S8         0x0000180F
+
+#define GPIO_PA7_U2TX           0x00001C01
+#define GPIO_PA7_I2C6SDA        0x00001C02
+#define GPIO_PA7_T3CCP1         0x00001C03
+#define GPIO_PA7_USB0PFLT       0x00001C05
+#define GPIO_PA7_USB0EPEN       0x00001C0B
+#define GPIO_PA7_SSI0XDAT3      0x00001C0D
+#define GPIO_PA7_EPI0S9         0x00001C0F
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_I2C5SCL        0x00010002
+#define GPIO_PB0_CAN1RX         0x00010007
+#define GPIO_PB0_T4CCP0         0x00010003
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_I2C5SDA        0x00010402
+#define GPIO_PB1_CAN1TX         0x00010407
+#define GPIO_PB1_T4CCP1         0x00010403
+
+#define GPIO_PB2_T5CCP0         0x00010803
+#define GPIO_PB2_I2C0SCL        0x00010802
+#define GPIO_PB2_USB0STP        0x0001080E
+#define GPIO_PB2_EPI0S27        0x0001080F
+
+#define GPIO_PB3_I2C0SDA        0x00010C02
+#define GPIO_PB3_T5CCP1         0x00010C03
+#define GPIO_PB3_USB0CLK        0x00010C0E
+#define GPIO_PB3_EPI0S28        0x00010C0F
+
+#define GPIO_PB4_U0CTS          0x00011001
+#define GPIO_PB4_I2C5SCL        0x00011002
+#define GPIO_PB4_SSI1FSS        0x0001100F
+
+#define GPIO_PB5_U0RTS          0x00011401
+#define GPIO_PB5_I2C5SDA        0x00011402
+#define GPIO_PB5_SSI1CLK        0x0001140F
+
+#define GPIO_PB6_I2C6SCL        0x00011802
+#define GPIO_PB6_T6CCP0         0x00011803
+#define GPIO_PB6_PS2CLK3        0x00011804
+
+#define GPIO_PB7_I2C6SDA        0x00011C02
+#define GPIO_PB7_T6CCP1         0x00011C03
+#define GPIO_PB7_PS2DAT3        0x00011C04
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+
+#define GPIO_PC2_TDI            0x00020801
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+
+#define GPIO_PC4_U7RX           0x00021001
+#define GPIO_PC4_T7CCP0         0x00021003
+#define GPIO_PC4_EPI0S7         0x0002100F
+
+#define GPIO_PC5_U7TX           0x00021401
+#define GPIO_PC5_T7CCP1         0x00021403
+#define GPIO_PC5_RTCCLK         0x00021407
+#define GPIO_PC5_EPI0S6         0x0002140F
+
+#define GPIO_PC6_U5RX           0x00021801
+#define GPIO_PC6_EPI0S5         0x0002180F
+
+#define GPIO_PC7_U5TX           0x00021C01
+#define GPIO_PC7_EPI0S4         0x00021C0F
+
+#define GPIO_PD0_I2C7SCL        0x00030002
+#define GPIO_PD0_T0CCP0         0x00030003
+#define GPIO_PD0_C0O            0x00030005
+#define GPIO_PD0_SSI2XDAT1      0x0003000F
+
+#define GPIO_PD1_I2C7SDA        0x00030402
+#define GPIO_PD1_T0CCP1         0x00030403
+#define GPIO_PD1_C1O            0x00030405
+#define GPIO_PD1_SSI2XDAT0      0x0003040F
+
+#define GPIO_PD2_I2C8SCL        0x00030802
+#define GPIO_PD2_T1CCP0         0x00030803
+#define GPIO_PD2_C2O            0x00030805
+#define GPIO_PD2_SSI2FSS        0x0003080F
+
+#define GPIO_PD3_I2C8SDA        0x00030C02
+#define GPIO_PD3_T1CCP1         0x00030C03
+#define GPIO_PD3_SSI2CLK        0x00030C0F
+
+#define GPIO_PD4_U2RX           0x00031001
+#define GPIO_PD4_T3CCP0         0x00031003
+#define GPIO_PD4_SSI1XDAT2      0x0003100F
+
+#define GPIO_PD5_U2TX           0x00031401
+#define GPIO_PD5_T3CCP1         0x00031403
+#define GPIO_PD5_SSI1XDAT3      0x0003140F
+
+#define GPIO_PD6_U2RTS          0x00031801
+#define GPIO_PD6_T4CCP0         0x00031803
+#define GPIO_PD6_USB0EPEN       0x00031805
+#define GPIO_PD6_SSI2XDAT3      0x0003180F
+
+#define GPIO_PD7_U2CTS          0x00031C01
+#define GPIO_PD7_T4CCP1         0x00031C03
+#define GPIO_PD7_USB0PFLT       0x00031C05
+#define GPIO_PD7_NMI            0x00031C08
+#define GPIO_PD7_SSI2XDAT2      0x00031C0F
+
+#define GPIO_PE0_U1RTS          0x00040001
+
+#define GPIO_PE1_U1DSR          0x00040401
+
+#define GPIO_PE2_U1DCD          0x00040801
+
+#define GPIO_PE3_U1DTR          0x00040C01
+
+#define GPIO_PE4_U1RI           0x00041001
+#define GPIO_PE4_SSI1XDAT0      0x0004100F
+
+#define GPIO_PE5_SSI1XDAT1      0x0004140F
+
+#define GPIO_PE6_U0CTS          0x00041801
+#define GPIO_PE6_I2C9SCL        0x00041802
+
+#define GPIO_PE7_U0RTS          0x00041C01
+#define GPIO_PE7_I2C9SDA        0x00041C02
+#define GPIO_PE7_NMI            0x00041C08
+
+#define GPIO_PF0_M0PWM0         0x00050006
+#define GPIO_PF0_SSI3XDAT1      0x0005000E
+#define GPIO_PF0_TRD2           0x0005000F
+
+#define GPIO_PF1_M0PWM1         0x00050406
+#define GPIO_PF1_SSI3XDAT0      0x0005040E
+#define GPIO_PF1_TRD1           0x0005040F
+
+#define GPIO_PF2_M0PWM2         0x00050806
+#define GPIO_PF2_SSI3FSS        0x0005080E
+#define GPIO_PF2_TRD0           0x0005080F
+
+#define GPIO_PF3_M0PWM3         0x00050C06
+#define GPIO_PF3_SSI3CLK        0x00050C0E
+#define GPIO_PF3_TRCLK          0x00050C0F
+
+#define GPIO_PF4_M0FAULT0       0x00051006
+#define GPIO_PF4_SSI3XDAT2      0x0005100E
+#define GPIO_PF4_TRD3           0x0005100F
+
+#define GPIO_PF5_SSI3XDAT3      0x0005140E
+
+#define GPIO_PG0_I2C1SCL        0x00060002
+#define GPIO_PG0_M0PWM4         0x00060006
+#define GPIO_PG0_EPI0S11        0x0006000F
+
+#define GPIO_PG1_I2C1SDA        0x00060402
+#define GPIO_PG1_M0PWM5         0x00060406
+#define GPIO_PG1_EPI0S10        0x0006040F
+
+#define GPIO_PG2_I2C2SCL        0x00060802
+#define GPIO_PG2_SSI2XDAT3      0x0006080F
+
+#define GPIO_PG3_I2C2SDA        0x00060C02
+#define GPIO_PG3_SSI2XDAT2      0x00060C0F
+
+#define GPIO_PG4_U0CTS          0x00061001
+#define GPIO_PG4_I2C3SCL        0x00061002
+#define GPIO_PG4_SSI2XDAT1      0x0006100F
+
+#define GPIO_PG5_U0RTS          0x00061401
+#define GPIO_PG5_I2C3SDA        0x00061402
+#define GPIO_PG5_SSI2XDAT0      0x0006140F
+
+#define GPIO_PG6_I2C4SCL        0x00061802
+#define GPIO_PG6_SSI2FSS        0x0006180F
+
+#define GPIO_PG7_I2C4SDA        0x00061C02
+#define GPIO_PG7_SSI2CLK        0x00061C0F
+
+#define GPIO_PH0_U0RTS          0x00070001
+#define GPIO_PH0_EPI0S0         0x0007000F
+
+#define GPIO_PH1_U0CTS          0x00070401
+#define GPIO_PH1_EPI0S1         0x0007040F
+
+#define GPIO_PH2_U0DCD          0x00070801
+#define GPIO_PH2_EPI0S2         0x0007080F
+
+#define GPIO_PH3_U0DSR          0x00070C01
+#define GPIO_PH3_EPI0S3         0x00070C0F
+
+#define GPIO_PH4_U0DTR          0x00071001
+
+#define GPIO_PH5_U0RI           0x00071401
+
+#define GPIO_PH6_U5RX           0x00071801
+#define GPIO_PH6_U7RX           0x00071802
+
+#define GPIO_PH7_U5TX           0x00071C01
+#define GPIO_PH7_U7TX           0x00071C02
+
+#define GPIO_PJ0_U3RX           0x00080001
+
+#define GPIO_PJ1_U3TX           0x00080401
+
+#define GPIO_PJ2_U2RTS          0x00080801
+
+#define GPIO_PJ3_U2CTS          0x00080C01
+
+#define GPIO_PJ4_U3RTS          0x00081001
+
+#define GPIO_PJ5_U3CTS          0x00081401
+
+#define GPIO_PJ6_U4RTS          0x00081801
+
+#define GPIO_PJ7_U4CTS          0x00081C01
+
+#define GPIO_PK0_U4RX           0x00090001
+#define GPIO_PK0_EPI0S0         0x0009000F
+
+#define GPIO_PK1_U4TX           0x00090401
+#define GPIO_PK1_EPI0S1         0x0009040F
+
+#define GPIO_PK2_U4RTS          0x00090801
+#define GPIO_PK2_EPI0S2         0x0009080F
+
+#define GPIO_PK3_U4CTS          0x00090C01
+#define GPIO_PK3_EPI0S3         0x00090C0F
+
+#define GPIO_PK4_I2C3SCL        0x00091002
+#define GPIO_PK4_M0PWM6         0x00091006
+#define GPIO_PK4_EPI0S32        0x0009100F
+
+#define GPIO_PK5_I2C3SDA        0x00091402
+#define GPIO_PK5_M0PWM7         0x00091406
+#define GPIO_PK5_EPI0S31        0x0009140F
+
+#define GPIO_PK6_I2C4SCL        0x00091802
+#define GPIO_PK6_M0FAULT1       0x00091806
+#define GPIO_PK6_EPI0S25        0x0009180F
+
+#define GPIO_PK7_U0RI           0x00091C01
+#define GPIO_PK7_I2C4SDA        0x00091C02
+#define GPIO_PK7_RTCCLK         0x00091C05
+#define GPIO_PK7_M0FAULT2       0x00091C06
+#define GPIO_PK7_EPI0S24        0x00091C0F
+
+#define GPIO_PL0_I2C2SDA        0x000A0002
+#define GPIO_PL0_M0FAULT3       0x000A0006
+#define GPIO_PL0_USB0D0         0x000A000E
+#define GPIO_PL0_EPI0S16        0x000A000F
+
+#define GPIO_PL1_I2C2SCL        0x000A0402
+#define GPIO_PL1_PHA0           0x000A0406
+#define GPIO_PL1_USB0D1         0x000A040E
+#define GPIO_PL1_EPI0S17        0x000A040F
+
+#define GPIO_PL2_C0O            0x000A0805
+#define GPIO_PL2_PHB0           0x000A0806
+#define GPIO_PL2_USB0D2         0x000A080E
+#define GPIO_PL2_EPI0S18        0x000A080F
+
+#define GPIO_PL3_C1O            0x000A0C05
+#define GPIO_PL3_IDX0           0x000A0C06
+#define GPIO_PL3_USB0D3         0x000A0C0E
+#define GPIO_PL3_EPI0S19        0x000A0C0F
+
+#define GPIO_PL4_T0CCP0         0x000A1003
+#define GPIO_PL4_USB0D4         0x000A100E
+#define GPIO_PL4_EPI0S26        0x000A100F
+
+#define GPIO_PL5_T0CCP1         0x000A1403
+#define GPIO_PL5_EPI0S33        0x000A140F
+#define GPIO_PL5_USB0D5         0x000A140E
+
+#define GPIO_PL6_T1CCP0         0x000A1803
+
+#define GPIO_PL7_T1CCP1         0x000A1C03
+
+#define GPIO_PM0_T2CCP0         0x000B0003
+#define GPIO_PM0_EPI0S15        0x000B000F
+
+#define GPIO_PM1_T2CCP1         0x000B0403
+#define GPIO_PM1_EPI0S14        0x000B040F
+
+#define GPIO_PM2_T3CCP0         0x000B0803
+#define GPIO_PM2_EPI0S13        0x000B080F
+
+#define GPIO_PM3_T3CCP1         0x000B0C03
+#define GPIO_PM3_EPI0S12        0x000B0C0F
+
+#define GPIO_PM4_U0CTS          0x000B1001
+#define GPIO_PM4_T4CCP0         0x000B1003
+
+#define GPIO_PM5_U0DCD          0x000B1401
+#define GPIO_PM5_T4CCP1         0x000B1403
+
+#define GPIO_PM6_U0DSR          0x000B1801
+#define GPIO_PM6_T5CCP0         0x000B1803
+
+#define GPIO_PM7_U0RI           0x000B1C01
+#define GPIO_PM7_T5CCP1         0x000B1C03
+
+#define GPIO_PN0_U1RTS          0x000C0001
+
+#define GPIO_PN1_U1CTS          0x000C0401
+
+#define GPIO_PN2_U1DCD          0x000C0801
+#define GPIO_PN2_U2RTS          0x000C0802
+#define GPIO_PN2_EPI0S29        0x000C080F
+
+#define GPIO_PN3_U1DSR          0x000C0C01
+#define GPIO_PN3_U2CTS          0x000C0C02
+#define GPIO_PN3_EPI0S30        0x000C0C0F
+
+#define GPIO_PN4_U1DTR          0x000C1001
+#define GPIO_PN4_U3RTS          0x000C1002
+#define GPIO_PN4_I2C2SDA        0x000C1003
+#define GPIO_PN4_EPI0S34        0x000C100F
+
+#define GPIO_PN5_U1RI           0x000C1401
+#define GPIO_PN5_U3CTS          0x000C1402
+#define GPIO_PN5_I2C2SCL        0x000C1403
+#define GPIO_PN5_EPI0S35        0x000C140F
+
+#define GPIO_PN6_U4RTS          0x000C1802
+
+#define GPIO_PN7_U1RTS          0x000C1C01
+#define GPIO_PN7_U4CTS          0x000C1C02
+
+#define GPIO_PP0_U6RX           0x000D0001
+#define GPIO_PP0_T6CCP0         0x000D0005
+#define GPIO_PP0_SSI3XDAT2      0x000D000F
+
+#define GPIO_PP1_U6TX           0x000D0401
+#define GPIO_PP1_T6CCP1         0x000D0405
+#define GPIO_PP1_SSI3XDAT3      0x000D040F
+
+#define GPIO_PP2_U0DTR          0x000D0801
+#define GPIO_PP2_USB0NXT        0x000D080E
+#define GPIO_PP2_EPI0S29        0x000D080F
+
+#define GPIO_PP3_U1CTS          0x000D0C01
+#define GPIO_PP3_U0DCD          0x000D0C02
+#define GPIO_PP3_RTCCLK         0x000D0C07
+#define GPIO_PP3_USB0DIR        0x000D0C0E
+#define GPIO_PP3_EPI0S30        0x000D0C0F
+
+#define GPIO_PP4_U3RTS          0x000D1001
+#define GPIO_PP4_U0DSR          0x000D1002
+#define GPIO_PP4_USB0D7         0x000D100E
+
+#define GPIO_PP5_U3CTS          0x000D1401
+#define GPIO_PP5_I2C2SCL        0x000D1402
+#define GPIO_PP5_USB0D6         0x000D140E
+
+#define GPIO_PP6_U1DCD          0x000D1801
+#define GPIO_PP6_I2C2SDA        0x000D1802
+
+#define GPIO_PQ0_T6CCP0         0x000E0003
+#define GPIO_PQ0_SSI3CLK        0x000E000E
+#define GPIO_PQ0_EPI0S20        0x000E000F
+
+#define GPIO_PQ1_T6CCP1         0x000E0403
+#define GPIO_PQ1_SSI3FSS        0x000E040E
+#define GPIO_PQ1_EPI0S21        0x000E040F
+
+#define GPIO_PQ2_T7CCP0         0x000E0803
+#define GPIO_PQ2_SSI3XDAT0      0x000E080E
+#define GPIO_PQ2_EPI0S22        0x000E080F
+
+#define GPIO_PQ3_T7CCP1         0x000E0C03
+#define GPIO_PQ3_SSI3XDAT1      0x000E0C0E
+#define GPIO_PQ3_EPI0S23        0x000E0C0F
+
+#define GPIO_PQ4_U1RX           0x000E1001
+#define GPIO_PQ4_DIVSCLK        0x000E1007
+
+#define GPIO_PQ5_U1TX           0x000E1401
+
+#define GPIO_PQ6_U1DTR          0x000E1801
+
+#define GPIO_PQ7_U1RI           0x000E1C01
+
+#define GPIO_PR0_U4TX           0x000F0001
+#define GPIO_PR0_I2C1SCL        0x000F0002
+#define GPIO_PR0_M0PWM0         0x000F0006
+
+#define GPIO_PR1_U4RX           0x000F0401
+#define GPIO_PR1_I2C1SDA        0x000F0402
+#define GPIO_PR1_M0PWM1         0x000F0406
+
+#define GPIO_PR2_I2C2SCL        0x000F0802
+#define GPIO_PR2_M0PWM2         0x000F0806
+
+#define GPIO_PR3_I2C2SDA        0x000F0C02
+#define GPIO_PR3_M0PWM3         0x000F0C06
+
+#define GPIO_PR4_I2C3SCL        0x000F1002
+#define GPIO_PR4_T0CCP0         0x000F1003
+#define GPIO_PR4_M0PWM4         0x000F1006
+
+#define GPIO_PR5_U1RX           0x000F1401
+#define GPIO_PR5_I2C3SDA        0x000F1402
+#define GPIO_PR5_T0CCP1         0x000F1403
+#define GPIO_PR5_M0PWM5         0x000F1406
+
+#define GPIO_PR6_U1TX           0x000F1801
+#define GPIO_PR6_I2C4SCL        0x000F1802
+#define GPIO_PR6_T1CCP0         0x000F1803
+#define GPIO_PR6_M0PWM6         0x000F1806
+
+#define GPIO_PR7_I2C4SDA        0x000F1C02
+#define GPIO_PR7_T1CCP1         0x000F1C03
+#define GPIO_PR7_M0PWM7         0x000F1C06
+
+#define GPIO_PS0_T2CCP0         0x00100003
+#define GPIO_PS0_M0FAULT0       0x00100006
+
+#define GPIO_PS1_T2CCP1         0x00100403
+#define GPIO_PS1_M0FAULT1       0x00100406
+
+#define GPIO_PS2_U1DSR          0x00100801
+#define GPIO_PS2_T3CCP0         0x00100803
+#define GPIO_PS2_M0FAULT2       0x00100806
+
+#define GPIO_PS3_T3CCP1         0x00100C03
+#define GPIO_PS3_M0FAULT3       0x00100C06
+
+#define GPIO_PS4_T4CCP0         0x00101003
+#define GPIO_PS4_PHA0           0x00101006
+
+#define GPIO_PS5_T4CCP1         0x00101403
+#define GPIO_PS5_PHB0           0x00101406
+
+#define GPIO_PS6_T5CCP0         0x00101803
+#define GPIO_PS6_IDX0           0x00101806
+
+#define GPIO_PS7_T5CCP1         0x00101C03
+
+#define GPIO_PT0_T6CCP0         0x00110003
+#define GPIO_PT0_CAN0RX         0x00110007
+
+#define GPIO_PT1_T6CCP1         0x00110403
+#define GPIO_PT1_CAN0TX         0x00110407
+
+#define GPIO_PT2_T7CCP0         0x00110803
+#define GPIO_PT2_CAN1RX         0x00110807
+
+#define GPIO_PT3_T7CCP1         0x00110C03
+#define GPIO_PT3_CAN1TX         0x00110C07
+
+#endif // PART_TM4C129CNCZAD
+
+//*****************************************************************************
+//
+// TM4C129DNCPDT Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C129DNCPDT
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_I2C9SCL        0x00000002
+#define GPIO_PA0_T0CCP0         0x00000003
+#define GPIO_PA0_CAN0RX         0x00000007
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_I2C9SDA        0x00000402
+#define GPIO_PA1_T0CCP1         0x00000403
+#define GPIO_PA1_CAN0TX         0x00000407
+
+#define GPIO_PA2_U4RX           0x00000801
+#define GPIO_PA2_I2C8SCL        0x00000802
+#define GPIO_PA2_T1CCP0         0x00000803
+#define GPIO_PA2_SSI0CLK        0x0000080F
+
+#define GPIO_PA3_U4TX           0x00000C01
+#define GPIO_PA3_I2C8SDA        0x00000C02
+#define GPIO_PA3_T1CCP1         0x00000C03
+#define GPIO_PA3_SSI0FSS        0x00000C0F
+
+#define GPIO_PA4_U3RX           0x00001001
+#define GPIO_PA4_T2CCP0         0x00001003
+#define GPIO_PA4_I2C7SCL        0x00001002
+#define GPIO_PA4_SSI0XDAT0      0x0000100F
+
+#define GPIO_PA5_U3TX           0x00001401
+#define GPIO_PA5_T2CCP1         0x00001403
+#define GPIO_PA5_I2C7SDA        0x00001402
+#define GPIO_PA5_SSI0XDAT1      0x0000140F
+
+#define GPIO_PA6_U2RX           0x00001801
+#define GPIO_PA6_I2C6SCL        0x00001802
+#define GPIO_PA6_T3CCP0         0x00001803
+#define GPIO_PA6_USB0EPEN       0x00001805
+#define GPIO_PA6_SSI0XDAT2      0x0000180D
+#define GPIO_PA6_EN0RXCK        0x0000180E
+#define GPIO_PA6_EPI0S8         0x0000180F
+
+#define GPIO_PA7_U2TX           0x00001C01
+#define GPIO_PA7_I2C6SDA        0x00001C02
+#define GPIO_PA7_T3CCP1         0x00001C03
+#define GPIO_PA7_USB0PFLT       0x00001C05
+#define GPIO_PA7_USB0EPEN       0x00001C0B
+#define GPIO_PA7_SSI0XDAT3      0x00001C0D
+#define GPIO_PA7_EPI0S9         0x00001C0F
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_I2C5SCL        0x00010002
+#define GPIO_PB0_CAN1RX         0x00010007
+#define GPIO_PB0_T4CCP0         0x00010003
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_I2C5SDA        0x00010402
+#define GPIO_PB1_CAN1TX         0x00010407
+#define GPIO_PB1_T4CCP1         0x00010403
+
+#define GPIO_PB2_T5CCP0         0x00010803
+#define GPIO_PB2_I2C0SCL        0x00010802
+#define GPIO_PB2_EN0MDC         0x00010805
+#define GPIO_PB2_USB0STP        0x0001080E
+#define GPIO_PB2_EPI0S27        0x0001080F
+
+#define GPIO_PB3_I2C0SDA        0x00010C02
+#define GPIO_PB3_T5CCP1         0x00010C03
+#define GPIO_PB3_EN0MDIO        0x00010C05
+#define GPIO_PB3_USB0CLK        0x00010C0E
+#define GPIO_PB3_EPI0S28        0x00010C0F
+
+#define GPIO_PB4_U0CTS          0x00011001
+#define GPIO_PB4_I2C5SCL        0x00011002
+#define GPIO_PB4_SSI1FSS        0x0001100F
+
+#define GPIO_PB5_U0RTS          0x00011401
+#define GPIO_PB5_I2C5SDA        0x00011402
+#define GPIO_PB5_SSI1CLK        0x0001140F
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+
+#define GPIO_PC2_TDI            0x00020801
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+
+#define GPIO_PC4_U7RX           0x00021001
+#define GPIO_PC4_EPI0S7         0x0002100F
+
+#define GPIO_PC5_U7TX           0x00021401
+#define GPIO_PC5_RTCCLK         0x00021407
+#define GPIO_PC5_EPI0S6         0x0002140F
+
+#define GPIO_PC6_U5RX           0x00021801
+#define GPIO_PC6_EPI0S5         0x0002180F
+
+#define GPIO_PC7_U5TX           0x00021C01
+#define GPIO_PC7_EPI0S4         0x00021C0F
+
+#define GPIO_PD0_I2C7SCL        0x00030002
+#define GPIO_PD0_T0CCP0         0x00030003
+#define GPIO_PD0_C0O            0x00030005
+#define GPIO_PD0_SSI2XDAT1      0x0003000F
+
+#define GPIO_PD1_I2C7SDA        0x00030402
+#define GPIO_PD1_T0CCP1         0x00030403
+#define GPIO_PD1_C1O            0x00030405
+#define GPIO_PD1_SSI2XDAT0      0x0003040F
+
+#define GPIO_PD2_I2C8SCL        0x00030802
+#define GPIO_PD2_T1CCP0         0x00030803
+#define GPIO_PD2_C2O            0x00030805
+#define GPIO_PD2_SSI2FSS        0x0003080F
+
+#define GPIO_PD3_I2C8SDA        0x00030C02
+#define GPIO_PD3_T1CCP1         0x00030C03
+#define GPIO_PD3_SSI2CLK        0x00030C0F
+
+#define GPIO_PD4_U2RX           0x00031001
+#define GPIO_PD4_T3CCP0         0x00031003
+#define GPIO_PD4_SSI1XDAT2      0x0003100F
+
+#define GPIO_PD5_U2TX           0x00031401
+#define GPIO_PD5_T3CCP1         0x00031403
+#define GPIO_PD5_SSI1XDAT3      0x0003140F
+
+#define GPIO_PD6_U2RTS          0x00031801
+#define GPIO_PD6_T4CCP0         0x00031803
+#define GPIO_PD6_USB0EPEN       0x00031805
+#define GPIO_PD6_SSI2XDAT3      0x0003180F
+
+#define GPIO_PD7_U2CTS          0x00031C01
+#define GPIO_PD7_T4CCP1         0x00031C03
+#define GPIO_PD7_USB0PFLT       0x00031C05
+#define GPIO_PD7_NMI            0x00031C08
+#define GPIO_PD7_SSI2XDAT2      0x00031C0F
+
+#define GPIO_PE0_U1RTS          0x00040001
+
+#define GPIO_PE1_U1DSR          0x00040401
+
+#define GPIO_PE2_U1DCD          0x00040801
+
+#define GPIO_PE3_U1DTR          0x00040C01
+
+#define GPIO_PE4_U1RI           0x00041001
+#define GPIO_PE4_SSI1XDAT0      0x0004100F
+
+#define GPIO_PE5_SSI1XDAT1      0x0004140F
+
+#define GPIO_PF0_M0PWM0         0x00050006
+#define GPIO_PF0_SSI3XDAT1      0x0005000E
+#define GPIO_PF0_TRD2           0x0005000F
+
+#define GPIO_PF1_M0PWM1         0x00050406
+#define GPIO_PF1_SSI3XDAT0      0x0005040E
+#define GPIO_PF1_TRD1           0x0005040F
+
+#define GPIO_PF2_EN0MDC         0x00050805
+#define GPIO_PF2_M0PWM2         0x00050806
+#define GPIO_PF2_SSI3FSS        0x0005080E
+#define GPIO_PF2_TRD0           0x0005080F
+
+#define GPIO_PF3_EN0MDIO        0x00050C05
+#define GPIO_PF3_M0PWM3         0x00050C06
+#define GPIO_PF3_SSI3CLK        0x00050C0E
+#define GPIO_PF3_TRCLK          0x00050C0F
+
+#define GPIO_PF4_M0FAULT0       0x00051006
+#define GPIO_PF4_SSI3XDAT2      0x0005100E
+#define GPIO_PF4_TRD3           0x0005100F
+
+#define GPIO_PG0_I2C1SCL        0x00060002
+#define GPIO_PG0_M0PWM4         0x00060006
+#define GPIO_PG0_EPI0S11        0x0006000F
+
+#define GPIO_PG1_I2C1SDA        0x00060402
+#define GPIO_PG1_M0PWM5         0x00060406
+#define GPIO_PG1_EPI0S10        0x0006040F
+
+#define GPIO_PG2_I2C2SCL        0x00060802
+#define GPIO_PG2_EN0TXCK        0x0006080E
+#define GPIO_PG2_SSI2XDAT3      0x0006080F
+
+#define GPIO_PG3_I2C2SDA        0x00060C02
+#define GPIO_PG3_EN0TXEN        0x00060C0E
+#define GPIO_PG3_SSI2XDAT2      0x00060C0F
+
+#define GPIO_PG4_U0CTS          0x00061001
+#define GPIO_PG4_I2C3SCL        0x00061002
+#define GPIO_PG4_EN0TXD0        0x0006100E
+#define GPIO_PG4_SSI2XDAT1      0x0006100F
+
+#define GPIO_PG5_U0RTS          0x00061401
+#define GPIO_PG5_I2C3SDA        0x00061402
+#define GPIO_PG5_EN0TXD1        0x0006140E
+#define GPIO_PG5_SSI2XDAT0      0x0006140F
+
+#define GPIO_PG6_I2C4SCL        0x00061802
+#define GPIO_PG6_EN0RXER        0x0006180E
+#define GPIO_PG6_SSI2FSS        0x0006180F
+
+#define GPIO_PG7_I2C4SDA        0x00061C02
+#define GPIO_PG7_EN0RXDV        0x00061C0E
+#define GPIO_PG7_SSI2CLK        0x00061C0F
+
+#define GPIO_PH0_U0RTS          0x00070001
+#define GPIO_PH0_EPI0S0         0x0007000F
+
+#define GPIO_PH1_U0CTS          0x00070401
+#define GPIO_PH1_EPI0S1         0x0007040F
+
+#define GPIO_PH2_U0DCD          0x00070801
+#define GPIO_PH2_EPI0S2         0x0007080F
+
+#define GPIO_PH3_U0DSR          0x00070C01
+#define GPIO_PH3_EPI0S3         0x00070C0F
+
+#define GPIO_PJ0_U3RX           0x00080001
+
+#define GPIO_PJ1_U3TX           0x00080401
+
+#define GPIO_PK0_U4RX           0x00090001
+#define GPIO_PK0_EPI0S0         0x0009000F
+
+#define GPIO_PK1_U4TX           0x00090401
+#define GPIO_PK1_EPI0S1         0x0009040F
+
+#define GPIO_PK2_U4RTS          0x00090801
+#define GPIO_PK2_EPI0S2         0x0009080F
+
+#define GPIO_PK3_U4CTS          0x00090C01
+#define GPIO_PK3_EPI0S3         0x00090C0F
+
+#define GPIO_PK4_I2C3SCL        0x00091002
+#define GPIO_PK4_M0PWM6         0x00091006
+#define GPIO_PK4_EN0INTRN       0x00091007
+#define GPIO_PK4_EN0RXD3        0x0009100E
+#define GPIO_PK4_EPI0S32        0x0009100F
+
+#define GPIO_PK5_I2C3SDA        0x00091402
+#define GPIO_PK5_M0PWM7         0x00091406
+#define GPIO_PK5_EN0RXD2        0x0009140E
+#define GPIO_PK5_EPI0S31        0x0009140F
+
+#define GPIO_PK6_I2C4SCL        0x00091802
+#define GPIO_PK6_M0FAULT1       0x00091806
+#define GPIO_PK6_EN0TXD2        0x0009180E
+#define GPIO_PK6_EPI0S25        0x0009180F
+
+#define GPIO_PK7_U0RI           0x00091C01
+#define GPIO_PK7_I2C4SDA        0x00091C02
+#define GPIO_PK7_RTCCLK         0x00091C05
+#define GPIO_PK7_M0FAULT2       0x00091C06
+#define GPIO_PK7_EN0TXD3        0x00091C0E
+#define GPIO_PK7_EPI0S24        0x00091C0F
+
+#define GPIO_PL0_I2C2SDA        0x000A0002
+#define GPIO_PL0_M0FAULT3       0x000A0006
+#define GPIO_PL0_USB0D0         0x000A000E
+#define GPIO_PL0_EPI0S16        0x000A000F
+
+#define GPIO_PL1_I2C2SCL        0x000A0402
+#define GPIO_PL1_PHA0           0x000A0406
+#define GPIO_PL1_USB0D1         0x000A040E
+#define GPIO_PL1_EPI0S17        0x000A040F
+
+#define GPIO_PL2_C0O            0x000A0805
+#define GPIO_PL2_PHB0           0x000A0806
+#define GPIO_PL2_USB0D2         0x000A080E
+#define GPIO_PL2_EPI0S18        0x000A080F
+
+#define GPIO_PL3_C1O            0x000A0C05
+#define GPIO_PL3_IDX0           0x000A0C06
+#define GPIO_PL3_USB0D3         0x000A0C0E
+#define GPIO_PL3_EPI0S19        0x000A0C0F
+
+#define GPIO_PL4_T0CCP0         0x000A1003
+#define GPIO_PL4_USB0D4         0x000A100E
+#define GPIO_PL4_EPI0S26        0x000A100F
+
+#define GPIO_PL5_T0CCP1         0x000A1403
+#define GPIO_PL5_EPI0S33        0x000A140F
+#define GPIO_PL5_USB0D5         0x000A140E
+
+#define GPIO_PL6_T1CCP0         0x000A1803
+
+#define GPIO_PL7_T1CCP1         0x000A1C03
+
+#define GPIO_PM0_T2CCP0         0x000B0003
+#define GPIO_PM0_EPI0S15        0x000B000F
+
+#define GPIO_PM1_T2CCP1         0x000B0403
+#define GPIO_PM1_EPI0S14        0x000B040F
+
+#define GPIO_PM2_T3CCP0         0x000B0803
+#define GPIO_PM2_EPI0S13        0x000B080F
+
+#define GPIO_PM3_T3CCP1         0x000B0C03
+#define GPIO_PM3_EPI0S12        0x000B0C0F
+
+#define GPIO_PM4_U0CTS          0x000B1001
+#define GPIO_PM4_T4CCP0         0x000B1003
+#define GPIO_PM4_EN0RREF_CLK    0x000B100E
+
+#define GPIO_PM5_U0DCD          0x000B1401
+#define GPIO_PM5_T4CCP1         0x000B1403
+
+#define GPIO_PM6_U0DSR          0x000B1801
+#define GPIO_PM6_T5CCP0         0x000B1803
+#define GPIO_PM6_EN0CRS         0x000B180E
+
+#define GPIO_PM7_U0RI           0x000B1C01
+#define GPIO_PM7_T5CCP1         0x000B1C03
+#define GPIO_PM7_EN0COL         0x000B1C0E
+
+#define GPIO_PN0_U1RTS          0x000C0001
+
+#define GPIO_PN1_U1CTS          0x000C0401
+
+#define GPIO_PN2_U1DCD          0x000C0801
+#define GPIO_PN2_U2RTS          0x000C0802
+#define GPIO_PN2_EPI0S29        0x000C080F
+
+#define GPIO_PN3_U1DSR          0x000C0C01
+#define GPIO_PN3_U2CTS          0x000C0C02
+#define GPIO_PN3_EPI0S30        0x000C0C0F
+
+#define GPIO_PN4_U1DTR          0x000C1001
+#define GPIO_PN4_U3RTS          0x000C1002
+#define GPIO_PN4_I2C2SDA        0x000C1003
+#define GPIO_PN4_EPI0S34        0x000C100F
+
+#define GPIO_PN5_U1RI           0x000C1401
+#define GPIO_PN5_U3CTS          0x000C1402
+#define GPIO_PN5_I2C2SCL        0x000C1403
+#define GPIO_PN5_EPI0S35        0x000C140F
+
+#define GPIO_PP0_U6RX           0x000D0001
+#define GPIO_PP0_EN0INTRN       0x000D0007
+#define GPIO_PP0_SSI3XDAT2      0x000D000F
+
+#define GPIO_PP1_U6TX           0x000D0401
+#define GPIO_PP1_SSI3XDAT3      0x000D040F
+
+#define GPIO_PP2_U0DTR          0x000D0801
+#define GPIO_PP2_USB0NXT        0x000D080E
+#define GPIO_PP2_EPI0S29        0x000D080F
+
+#define GPIO_PP3_U1CTS          0x000D0C01
+#define GPIO_PP3_U0DCD          0x000D0C02
+#define GPIO_PP3_RTCCLK         0x000D0C07
+#define GPIO_PP3_USB0DIR        0x000D0C0E
+#define GPIO_PP3_EPI0S30        0x000D0C0F
+
+#define GPIO_PP4_U3RTS          0x000D1001
+#define GPIO_PP4_U0DSR          0x000D1002
+#define GPIO_PP4_USB0D7         0x000D100E
+
+#define GPIO_PP5_U3CTS          0x000D1401
+#define GPIO_PP5_I2C2SCL        0x000D1402
+#define GPIO_PP5_USB0D6         0x000D140E
+
+#define GPIO_PQ0_SSI3CLK        0x000E000E
+#define GPIO_PQ0_EPI0S20        0x000E000F
+
+#define GPIO_PQ1_SSI3FSS        0x000E040E
+#define GPIO_PQ1_EPI0S21        0x000E040F
+
+#define GPIO_PQ2_SSI3XDAT0      0x000E080E
+#define GPIO_PQ2_EPI0S22        0x000E080F
+
+#define GPIO_PQ3_SSI3XDAT1      0x000E0C0E
+#define GPIO_PQ3_EPI0S23        0x000E0C0F
+
+#define GPIO_PQ4_U1RX           0x000E1001
+#define GPIO_PQ4_DIVSCLK        0x000E1007
+
+#define GPIO_PQ5_U1TX           0x000E1401
+#define GPIO_PQ5_EN0RXD0        0x000E140E
+
+#define GPIO_PQ6_U1DTR          0x000E1801
+#define GPIO_PQ6_EN0RXD1        0x000E180E
+
+#endif // PART_TM4C129DNCPDT
+
+//*****************************************************************************
+//
+// TM4C129DNCZAD Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C129DNCZAD
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_I2C9SCL        0x00000002
+#define GPIO_PA0_T0CCP0         0x00000003
+#define GPIO_PA0_CAN0RX         0x00000007
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_I2C9SDA        0x00000402
+#define GPIO_PA1_T0CCP1         0x00000403
+#define GPIO_PA1_CAN0TX         0x00000407
+
+#define GPIO_PA2_U4RX           0x00000801
+#define GPIO_PA2_I2C8SCL        0x00000802
+#define GPIO_PA2_T1CCP0         0x00000803
+#define GPIO_PA2_SSI0CLK        0x0000080F
+
+#define GPIO_PA3_U4TX           0x00000C01
+#define GPIO_PA3_I2C8SDA        0x00000C02
+#define GPIO_PA3_T1CCP1         0x00000C03
+#define GPIO_PA3_SSI0FSS        0x00000C0F
+
+#define GPIO_PA4_U3RX           0x00001001
+#define GPIO_PA4_T2CCP0         0x00001003
+#define GPIO_PA4_I2C7SCL        0x00001002
+#define GPIO_PA4_SSI0XDAT0      0x0000100F
+
+#define GPIO_PA5_U3TX           0x00001401
+#define GPIO_PA5_T2CCP1         0x00001403
+#define GPIO_PA5_I2C7SDA        0x00001402
+#define GPIO_PA5_SSI0XDAT1      0x0000140F
+
+#define GPIO_PA6_U2RX           0x00001801
+#define GPIO_PA6_I2C6SCL        0x00001802
+#define GPIO_PA6_T3CCP0         0x00001803
+#define GPIO_PA6_USB0EPEN       0x00001805
+#define GPIO_PA6_SSI0XDAT2      0x0000180D
+#define GPIO_PA6_EN0RXCK        0x0000180E
+#define GPIO_PA6_EPI0S8         0x0000180F
+
+#define GPIO_PA7_U2TX           0x00001C01
+#define GPIO_PA7_I2C6SDA        0x00001C02
+#define GPIO_PA7_T3CCP1         0x00001C03
+#define GPIO_PA7_USB0PFLT       0x00001C05
+#define GPIO_PA7_USB0EPEN       0x00001C0B
+#define GPIO_PA7_SSI0XDAT3      0x00001C0D
+#define GPIO_PA7_EPI0S9         0x00001C0F
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_I2C5SCL        0x00010002
+#define GPIO_PB0_CAN1RX         0x00010007
+#define GPIO_PB0_T4CCP0         0x00010003
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_I2C5SDA        0x00010402
+#define GPIO_PB1_CAN1TX         0x00010407
+#define GPIO_PB1_T4CCP1         0x00010403
+
+#define GPIO_PB2_T5CCP0         0x00010803
+#define GPIO_PB2_I2C0SCL        0x00010802
+#define GPIO_PB2_EN0MDC         0x00010805
+#define GPIO_PB2_USB0STP        0x0001080E
+#define GPIO_PB2_EPI0S27        0x0001080F
+
+#define GPIO_PB3_I2C0SDA        0x00010C02
+#define GPIO_PB3_T5CCP1         0x00010C03
+#define GPIO_PB3_EN0MDIO        0x00010C05
+#define GPIO_PB3_USB0CLK        0x00010C0E
+#define GPIO_PB3_EPI0S28        0x00010C0F
+
+#define GPIO_PB4_U0CTS          0x00011001
+#define GPIO_PB4_I2C5SCL        0x00011002
+#define GPIO_PB4_SSI1FSS        0x0001100F
+
+#define GPIO_PB5_U0RTS          0x00011401
+#define GPIO_PB5_I2C5SDA        0x00011402
+#define GPIO_PB5_SSI1CLK        0x0001140F
+
+#define GPIO_PB6_I2C6SCL        0x00011802
+#define GPIO_PB6_T6CCP0         0x00011803
+#define GPIO_PB6_PS2CLK3        0x00011804
+
+#define GPIO_PB7_I2C6SDA        0x00011C02
+#define GPIO_PB7_T6CCP1         0x00011C03
+#define GPIO_PB7_PS2DAT3        0x00011C04
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+
+#define GPIO_PC2_TDI            0x00020801
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+
+#define GPIO_PC4_U7RX           0x00021001
+#define GPIO_PC4_T7CCP0         0x00021003
+#define GPIO_PC4_EPI0S7         0x0002100F
+
+#define GPIO_PC5_U7TX           0x00021401
+#define GPIO_PC5_T7CCP1         0x00021403
+#define GPIO_PC5_RTCCLK         0x00021407
+#define GPIO_PC5_EPI0S6         0x0002140F
+
+#define GPIO_PC6_U5RX           0x00021801
+#define GPIO_PC6_EPI0S5         0x0002180F
+
+#define GPIO_PC7_U5TX           0x00021C01
+#define GPIO_PC7_EPI0S4         0x00021C0F
+
+#define GPIO_PD0_I2C7SCL        0x00030002
+#define GPIO_PD0_T0CCP0         0x00030003
+#define GPIO_PD0_C0O            0x00030005
+#define GPIO_PD0_SSI2XDAT1      0x0003000F
+
+#define GPIO_PD1_I2C7SDA        0x00030402
+#define GPIO_PD1_T0CCP1         0x00030403
+#define GPIO_PD1_C1O            0x00030405
+#define GPIO_PD1_SSI2XDAT0      0x0003040F
+
+#define GPIO_PD2_I2C8SCL        0x00030802
+#define GPIO_PD2_T1CCP0         0x00030803
+#define GPIO_PD2_C2O            0x00030805
+#define GPIO_PD2_SSI2FSS        0x0003080F
+
+#define GPIO_PD3_I2C8SDA        0x00030C02
+#define GPIO_PD3_T1CCP1         0x00030C03
+#define GPIO_PD3_SSI2CLK        0x00030C0F
+
+#define GPIO_PD4_U2RX           0x00031001
+#define GPIO_PD4_T3CCP0         0x00031003
+#define GPIO_PD4_SSI1XDAT2      0x0003100F
+
+#define GPIO_PD5_U2TX           0x00031401
+#define GPIO_PD5_T3CCP1         0x00031403
+#define GPIO_PD5_SSI1XDAT3      0x0003140F
+
+#define GPIO_PD6_U2RTS          0x00031801
+#define GPIO_PD6_T4CCP0         0x00031803
+#define GPIO_PD6_USB0EPEN       0x00031805
+#define GPIO_PD6_SSI2XDAT3      0x0003180F
+
+#define GPIO_PD7_U2CTS          0x00031C01
+#define GPIO_PD7_T4CCP1         0x00031C03
+#define GPIO_PD7_USB0PFLT       0x00031C05
+#define GPIO_PD7_NMI            0x00031C08
+#define GPIO_PD7_SSI2XDAT2      0x00031C0F
+
+#define GPIO_PE0_U1RTS          0x00040001
+
+#define GPIO_PE1_U1DSR          0x00040401
+
+#define GPIO_PE2_U1DCD          0x00040801
+
+#define GPIO_PE3_U1DTR          0x00040C01
+
+#define GPIO_PE4_U1RI           0x00041001
+#define GPIO_PE4_SSI1XDAT0      0x0004100F
+
+#define GPIO_PE5_SSI1XDAT1      0x0004140F
+
+#define GPIO_PE6_U0CTS          0x00041801
+#define GPIO_PE6_I2C9SCL        0x00041802
+
+#define GPIO_PE7_U0RTS          0x00041C01
+#define GPIO_PE7_I2C9SDA        0x00041C02
+#define GPIO_PE7_NMI            0x00041C08
+
+#define GPIO_PF0_M0PWM0         0x00050006
+#define GPIO_PF0_SSI3XDAT1      0x0005000E
+#define GPIO_PF0_TRD2           0x0005000F
+
+#define GPIO_PF1_M0PWM1         0x00050406
+#define GPIO_PF1_SSI3XDAT0      0x0005040E
+#define GPIO_PF1_TRD1           0x0005040F
+
+#define GPIO_PF2_EN0MDC         0x00050805
+#define GPIO_PF2_M0PWM2         0x00050806
+#define GPIO_PF2_SSI3FSS        0x0005080E
+#define GPIO_PF2_TRD0           0x0005080F
+
+#define GPIO_PF3_EN0MDIO        0x00050C05
+#define GPIO_PF3_M0PWM3         0x00050C06
+#define GPIO_PF3_SSI3CLK        0x00050C0E
+#define GPIO_PF3_TRCLK          0x00050C0F
+
+#define GPIO_PF4_M0FAULT0       0x00051006
+#define GPIO_PF4_SSI3XDAT2      0x0005100E
+#define GPIO_PF4_TRD3           0x0005100F
+
+#define GPIO_PF5_SSI3XDAT3      0x0005140E
+
+#define GPIO_PG0_I2C1SCL        0x00060002
+#define GPIO_PG0_M0PWM4         0x00060006
+#define GPIO_PG0_EPI0S11        0x0006000F
+
+#define GPIO_PG1_I2C1SDA        0x00060402
+#define GPIO_PG1_M0PWM5         0x00060406
+#define GPIO_PG1_EPI0S10        0x0006040F
+
+#define GPIO_PG2_I2C2SCL        0x00060802
+#define GPIO_PG2_EN0TXCK        0x0006080E
+#define GPIO_PG2_SSI2XDAT3      0x0006080F
+
+#define GPIO_PG3_I2C2SDA        0x00060C02
+#define GPIO_PG3_EN0TXEN        0x00060C0E
+#define GPIO_PG3_SSI2XDAT2      0x00060C0F
+
+#define GPIO_PG4_U0CTS          0x00061001
+#define GPIO_PG4_I2C3SCL        0x00061002
+#define GPIO_PG4_EN0TXD0        0x0006100E
+#define GPIO_PG4_SSI2XDAT1      0x0006100F
+
+#define GPIO_PG5_U0RTS          0x00061401
+#define GPIO_PG5_I2C3SDA        0x00061402
+#define GPIO_PG5_EN0TXD1        0x0006140E
+#define GPIO_PG5_SSI2XDAT0      0x0006140F
+
+#define GPIO_PG6_I2C4SCL        0x00061802
+#define GPIO_PG6_EN0RXER        0x0006180E
+#define GPIO_PG6_SSI2FSS        0x0006180F
+
+#define GPIO_PG7_I2C4SDA        0x00061C02
+#define GPIO_PG7_EN0RXDV        0x00061C0E
+#define GPIO_PG7_SSI2CLK        0x00061C0F
+
+#define GPIO_PH0_U0RTS          0x00070001
+#define GPIO_PH0_EPI0S0         0x0007000F
+
+#define GPIO_PH1_U0CTS          0x00070401
+#define GPIO_PH1_EPI0S1         0x0007040F
+
+#define GPIO_PH2_U0DCD          0x00070801
+#define GPIO_PH2_EPI0S2         0x0007080F
+
+#define GPIO_PH3_U0DSR          0x00070C01
+#define GPIO_PH3_EPI0S3         0x00070C0F
+
+#define GPIO_PH4_U0DTR          0x00071001
+
+#define GPIO_PH5_U0RI           0x00071401
+
+#define GPIO_PH6_U5RX           0x00071801
+#define GPIO_PH6_U7RX           0x00071802
+
+#define GPIO_PH7_U5TX           0x00071C01
+#define GPIO_PH7_U7TX           0x00071C02
+
+#define GPIO_PJ0_U3RX           0x00080001
+
+#define GPIO_PJ1_U3TX           0x00080401
+
+#define GPIO_PJ2_U2RTS          0x00080801
+
+#define GPIO_PJ3_U2CTS          0x00080C01
+
+#define GPIO_PJ4_U3RTS          0x00081001
+
+#define GPIO_PJ5_U3CTS          0x00081401
+
+#define GPIO_PJ6_U4RTS          0x00081801
+
+#define GPIO_PJ7_U4CTS          0x00081C01
+
+#define GPIO_PK0_U4RX           0x00090001
+#define GPIO_PK0_EPI0S0         0x0009000F
+
+#define GPIO_PK1_U4TX           0x00090401
+#define GPIO_PK1_EPI0S1         0x0009040F
+
+#define GPIO_PK2_U4RTS          0x00090801
+#define GPIO_PK2_EPI0S2         0x0009080F
+
+#define GPIO_PK3_U4CTS          0x00090C01
+#define GPIO_PK3_EPI0S3         0x00090C0F
+
+#define GPIO_PK4_I2C3SCL        0x00091002
+#define GPIO_PK4_M0PWM6         0x00091006
+#define GPIO_PK4_EN0INTRN       0x00091007
+#define GPIO_PK4_EN0RXD3        0x0009100E
+#define GPIO_PK4_EPI0S32        0x0009100F
+
+#define GPIO_PK5_I2C3SDA        0x00091402
+#define GPIO_PK5_M0PWM7         0x00091406
+#define GPIO_PK5_EN0RXD2        0x0009140E
+#define GPIO_PK5_EPI0S31        0x0009140F
+
+#define GPIO_PK6_I2C4SCL        0x00091802
+#define GPIO_PK6_M0FAULT1       0x00091806
+#define GPIO_PK6_EN0TXD2        0x0009180E
+#define GPIO_PK6_EPI0S25        0x0009180F
+
+#define GPIO_PK7_U0RI           0x00091C01
+#define GPIO_PK7_I2C4SDA        0x00091C02
+#define GPIO_PK7_RTCCLK         0x00091C05
+#define GPIO_PK7_M0FAULT2       0x00091C06
+#define GPIO_PK7_EN0TXD3        0x00091C0E
+#define GPIO_PK7_EPI0S24        0x00091C0F
+
+#define GPIO_PL0_I2C2SDA        0x000A0002
+#define GPIO_PL0_M0FAULT3       0x000A0006
+#define GPIO_PL0_USB0D0         0x000A000E
+#define GPIO_PL0_EPI0S16        0x000A000F
+
+#define GPIO_PL1_I2C2SCL        0x000A0402
+#define GPIO_PL1_PHA0           0x000A0406
+#define GPIO_PL1_USB0D1         0x000A040E
+#define GPIO_PL1_EPI0S17        0x000A040F
+
+#define GPIO_PL2_C0O            0x000A0805
+#define GPIO_PL2_PHB0           0x000A0806
+#define GPIO_PL2_USB0D2         0x000A080E
+#define GPIO_PL2_EPI0S18        0x000A080F
+
+#define GPIO_PL3_C1O            0x000A0C05
+#define GPIO_PL3_IDX0           0x000A0C06
+#define GPIO_PL3_USB0D3         0x000A0C0E
+#define GPIO_PL3_EPI0S19        0x000A0C0F
+
+#define GPIO_PL4_T0CCP0         0x000A1003
+#define GPIO_PL4_USB0D4         0x000A100E
+#define GPIO_PL4_EPI0S26        0x000A100F
+
+#define GPIO_PL5_T0CCP1         0x000A1403
+#define GPIO_PL5_EPI0S33        0x000A140F
+#define GPIO_PL5_USB0D5         0x000A140E
+
+#define GPIO_PL6_T1CCP0         0x000A1803
+
+#define GPIO_PL7_T1CCP1         0x000A1C03
+
+#define GPIO_PM0_T2CCP0         0x000B0003
+#define GPIO_PM0_EPI0S15        0x000B000F
+
+#define GPIO_PM1_T2CCP1         0x000B0403
+#define GPIO_PM1_EPI0S14        0x000B040F
+
+#define GPIO_PM2_T3CCP0         0x000B0803
+#define GPIO_PM2_EPI0S13        0x000B080F
+
+#define GPIO_PM3_T3CCP1         0x000B0C03
+#define GPIO_PM3_EPI0S12        0x000B0C0F
+
+#define GPIO_PM4_U0CTS          0x000B1001
+#define GPIO_PM4_T4CCP0         0x000B1003
+#define GPIO_PM4_EN0RREF_CLK    0x000B100E
+
+#define GPIO_PM5_U0DCD          0x000B1401
+#define GPIO_PM5_T4CCP1         0x000B1403
+
+#define GPIO_PM6_U0DSR          0x000B1801
+#define GPIO_PM6_T5CCP0         0x000B1803
+#define GPIO_PM6_EN0CRS         0x000B180E
+
+#define GPIO_PM7_U0RI           0x000B1C01
+#define GPIO_PM7_T5CCP1         0x000B1C03
+#define GPIO_PM7_EN0COL         0x000B1C0E
+
+#define GPIO_PN0_U1RTS          0x000C0001
+
+#define GPIO_PN1_U1CTS          0x000C0401
+
+#define GPIO_PN2_U1DCD          0x000C0801
+#define GPIO_PN2_U2RTS          0x000C0802
+#define GPIO_PN2_EPI0S29        0x000C080F
+
+#define GPIO_PN3_U1DSR          0x000C0C01
+#define GPIO_PN3_U2CTS          0x000C0C02
+#define GPIO_PN3_EPI0S30        0x000C0C0F
+
+#define GPIO_PN4_U1DTR          0x000C1001
+#define GPIO_PN4_U3RTS          0x000C1002
+#define GPIO_PN4_I2C2SDA        0x000C1003
+#define GPIO_PN4_EPI0S34        0x000C100F
+
+#define GPIO_PN5_U1RI           0x000C1401
+#define GPIO_PN5_U3CTS          0x000C1402
+#define GPIO_PN5_I2C2SCL        0x000C1403
+#define GPIO_PN5_EPI0S35        0x000C140F
+
+#define GPIO_PN6_U4RTS          0x000C1802
+#define GPIO_PN6_EN0TXER        0x000C180E
+
+#define GPIO_PN7_U1RTS          0x000C1C01
+#define GPIO_PN7_U4CTS          0x000C1C02
+
+#define GPIO_PP0_U6RX           0x000D0001
+#define GPIO_PP0_T6CCP0         0x000D0005
+#define GPIO_PP0_EN0INTRN       0x000D0007
+#define GPIO_PP0_SSI3XDAT2      0x000D000F
+
+#define GPIO_PP1_U6TX           0x000D0401
+#define GPIO_PP1_T6CCP1         0x000D0405
+#define GPIO_PP1_SSI3XDAT3      0x000D040F
+
+#define GPIO_PP2_U0DTR          0x000D0801
+#define GPIO_PP2_USB0NXT        0x000D080E
+#define GPIO_PP2_EPI0S29        0x000D080F
+
+#define GPIO_PP3_U1CTS          0x000D0C01
+#define GPIO_PP3_U0DCD          0x000D0C02
+#define GPIO_PP3_RTCCLK         0x000D0C07
+#define GPIO_PP3_USB0DIR        0x000D0C0E
+#define GPIO_PP3_EPI0S30        0x000D0C0F
+
+#define GPIO_PP4_U3RTS          0x000D1001
+#define GPIO_PP4_U0DSR          0x000D1002
+#define GPIO_PP4_USB0D7         0x000D100E
+
+#define GPIO_PP5_U3CTS          0x000D1401
+#define GPIO_PP5_I2C2SCL        0x000D1402
+#define GPIO_PP5_USB0D6         0x000D140E
+
+#define GPIO_PP6_U1DCD          0x000D1801
+#define GPIO_PP6_I2C2SDA        0x000D1802
+
+#define GPIO_PQ0_T6CCP0         0x000E0003
+#define GPIO_PQ0_SSI3CLK        0x000E000E
+#define GPIO_PQ0_EPI0S20        0x000E000F
+
+#define GPIO_PQ1_T6CCP1         0x000E0403
+#define GPIO_PQ1_SSI3FSS        0x000E040E
+#define GPIO_PQ1_EPI0S21        0x000E040F
+
+#define GPIO_PQ2_T7CCP0         0x000E0803
+#define GPIO_PQ2_SSI3XDAT0      0x000E080E
+#define GPIO_PQ2_EPI0S22        0x000E080F
+
+#define GPIO_PQ3_T7CCP1         0x000E0C03
+#define GPIO_PQ3_SSI3XDAT1      0x000E0C0E
+#define GPIO_PQ3_EPI0S23        0x000E0C0F
+
+#define GPIO_PQ4_U1RX           0x000E1001
+#define GPIO_PQ4_DIVSCLK        0x000E1007
+
+#define GPIO_PQ5_U1TX           0x000E1401
+#define GPIO_PQ5_EN0RXD0        0x000E140E
+
+#define GPIO_PQ6_U1DTR          0x000E1801
+#define GPIO_PQ6_EN0RXD1        0x000E180E
+
+#define GPIO_PQ7_U1RI           0x000E1C01
+
+#define GPIO_PR0_U4TX           0x000F0001
+#define GPIO_PR0_I2C1SCL        0x000F0002
+#define GPIO_PR0_M0PWM0         0x000F0006
+
+#define GPIO_PR1_U4RX           0x000F0401
+#define GPIO_PR1_I2C1SDA        0x000F0402
+#define GPIO_PR1_M0PWM1         0x000F0406
+
+#define GPIO_PR2_I2C2SCL        0x000F0802
+#define GPIO_PR2_M0PWM2         0x000F0806
+
+#define GPIO_PR3_I2C2SDA        0x000F0C02
+#define GPIO_PR3_M0PWM3         0x000F0C06
+
+#define GPIO_PR4_I2C3SCL        0x000F1002
+#define GPIO_PR4_T0CCP0         0x000F1003
+#define GPIO_PR4_M0PWM4         0x000F1006
+
+#define GPIO_PR5_U1RX           0x000F1401
+#define GPIO_PR5_I2C3SDA        0x000F1402
+#define GPIO_PR5_T0CCP1         0x000F1403
+#define GPIO_PR5_M0PWM5         0x000F1406
+
+#define GPIO_PR6_U1TX           0x000F1801
+#define GPIO_PR6_I2C4SCL        0x000F1802
+#define GPIO_PR6_T1CCP0         0x000F1803
+#define GPIO_PR6_M0PWM6         0x000F1806
+
+#define GPIO_PR7_I2C4SDA        0x000F1C02
+#define GPIO_PR7_T1CCP1         0x000F1C03
+#define GPIO_PR7_M0PWM7         0x000F1C06
+#define GPIO_PR7_EN0TXEN        0x000F1C0E
+
+#define GPIO_PS0_T2CCP0         0x00100003
+#define GPIO_PS0_M0FAULT0       0x00100006
+
+#define GPIO_PS1_T2CCP1         0x00100403
+#define GPIO_PS1_M0FAULT1       0x00100406
+
+#define GPIO_PS2_U1DSR          0x00100801
+#define GPIO_PS2_T3CCP0         0x00100803
+#define GPIO_PS2_M0FAULT2       0x00100806
+
+#define GPIO_PS3_T3CCP1         0x00100C03
+#define GPIO_PS3_M0FAULT3       0x00100C06
+
+#define GPIO_PS4_T4CCP0         0x00101003
+#define GPIO_PS4_PHA0           0x00101006
+#define GPIO_PS4_EN0TXD0        0x0010100E
+
+#define GPIO_PS5_T4CCP1         0x00101403
+#define GPIO_PS5_PHB0           0x00101406
+#define GPIO_PS5_EN0TXD1        0x0010140E
+
+#define GPIO_PS6_T5CCP0         0x00101803
+#define GPIO_PS6_IDX0           0x00101806
+#define GPIO_PS6_EN0RXER        0x0010180E
+
+#define GPIO_PS7_T5CCP1         0x00101C03
+#define GPIO_PS7_EN0RXDV        0x00101C0E
+
+#define GPIO_PT0_T6CCP0         0x00110003
+#define GPIO_PT0_CAN0RX         0x00110007
+#define GPIO_PT0_EN0RXD0        0x0011000E
+
+#define GPIO_PT1_T6CCP1         0x00110403
+#define GPIO_PT1_CAN0TX         0x00110407
+#define GPIO_PT1_EN0RXD1        0x0011040E
+
+#define GPIO_PT2_T7CCP0         0x00110803
+#define GPIO_PT2_CAN1RX         0x00110807
+
+#define GPIO_PT3_T7CCP1         0x00110C03
+#define GPIO_PT3_CAN1TX         0x00110C07
+
+#endif // PART_TM4C129DNCZAD
+
+//*****************************************************************************
+//
+// TM4C129ENCPDT Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C129ENCPDT
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_I2C9SCL        0x00000002
+#define GPIO_PA0_T0CCP0         0x00000003
+#define GPIO_PA0_CAN0RX         0x00000007
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_I2C9SDA        0x00000402
+#define GPIO_PA1_T0CCP1         0x00000403
+#define GPIO_PA1_CAN0TX         0x00000407
+
+#define GPIO_PA2_U4RX           0x00000801
+#define GPIO_PA2_I2C8SCL        0x00000802
+#define GPIO_PA2_T1CCP0         0x00000803
+#define GPIO_PA2_SSI0CLK        0x0000080F
+
+#define GPIO_PA3_U4TX           0x00000C01
+#define GPIO_PA3_I2C8SDA        0x00000C02
+#define GPIO_PA3_T1CCP1         0x00000C03
+#define GPIO_PA3_SSI0FSS        0x00000C0F
+
+#define GPIO_PA4_U3RX           0x00001001
+#define GPIO_PA4_T2CCP0         0x00001003
+#define GPIO_PA4_I2C7SCL        0x00001002
+#define GPIO_PA4_SSI0XDAT0      0x0000100F
+
+#define GPIO_PA5_U3TX           0x00001401
+#define GPIO_PA5_T2CCP1         0x00001403
+#define GPIO_PA5_I2C7SDA        0x00001402
+#define GPIO_PA5_SSI0XDAT1      0x0000140F
+
+#define GPIO_PA6_U2RX           0x00001801
+#define GPIO_PA6_I2C6SCL        0x00001802
+#define GPIO_PA6_T3CCP0         0x00001803
+#define GPIO_PA6_USB0EPEN       0x00001805
+#define GPIO_PA6_SSI0XDAT2      0x0000180D
+#define GPIO_PA6_EPI0S8         0x0000180F
+
+#define GPIO_PA7_U2TX           0x00001C01
+#define GPIO_PA7_I2C6SDA        0x00001C02
+#define GPIO_PA7_T3CCP1         0x00001C03
+#define GPIO_PA7_USB0PFLT       0x00001C05
+#define GPIO_PA7_USB0EPEN       0x00001C0B
+#define GPIO_PA7_SSI0XDAT3      0x00001C0D
+#define GPIO_PA7_EPI0S9         0x00001C0F
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_I2C5SCL        0x00010002
+#define GPIO_PB0_CAN1RX         0x00010007
+#define GPIO_PB0_T4CCP0         0x00010003
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_I2C5SDA        0x00010402
+#define GPIO_PB1_CAN1TX         0x00010407
+#define GPIO_PB1_T4CCP1         0x00010403
+
+#define GPIO_PB2_T5CCP0         0x00010803
+#define GPIO_PB2_I2C0SCL        0x00010802
+#define GPIO_PB2_USB0STP        0x0001080E
+#define GPIO_PB2_EPI0S27        0x0001080F
+
+#define GPIO_PB3_I2C0SDA        0x00010C02
+#define GPIO_PB3_T5CCP1         0x00010C03
+#define GPIO_PB3_USB0CLK        0x00010C0E
+#define GPIO_PB3_EPI0S28        0x00010C0F
+
+#define GPIO_PB4_U0CTS          0x00011001
+#define GPIO_PB4_I2C5SCL        0x00011002
+#define GPIO_PB4_SSI1FSS        0x0001100F
+
+#define GPIO_PB5_U0RTS          0x00011401
+#define GPIO_PB5_I2C5SDA        0x00011402
+#define GPIO_PB5_SSI1CLK        0x0001140F
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+
+#define GPIO_PC2_TDI            0x00020801
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+
+#define GPIO_PC4_U7RX           0x00021001
+#define GPIO_PC4_EPI0S7         0x0002100F
+
+#define GPIO_PC5_U7TX           0x00021401
+#define GPIO_PC5_RTCCLK         0x00021407
+#define GPIO_PC5_EPI0S6         0x0002140F
+
+#define GPIO_PC6_U5RX           0x00021801
+#define GPIO_PC6_EPI0S5         0x0002180F
+
+#define GPIO_PC7_U5TX           0x00021C01
+#define GPIO_PC7_EPI0S4         0x00021C0F
+
+#define GPIO_PD0_I2C7SCL        0x00030002
+#define GPIO_PD0_T0CCP0         0x00030003
+#define GPIO_PD0_C0O            0x00030005
+#define GPIO_PD0_SSI2XDAT1      0x0003000F
+
+#define GPIO_PD1_I2C7SDA        0x00030402
+#define GPIO_PD1_T0CCP1         0x00030403
+#define GPIO_PD1_C1O            0x00030405
+#define GPIO_PD1_SSI2XDAT0      0x0003040F
+
+#define GPIO_PD2_I2C8SCL        0x00030802
+#define GPIO_PD2_T1CCP0         0x00030803
+#define GPIO_PD2_C2O            0x00030805
+#define GPIO_PD2_SSI2FSS        0x0003080F
+
+#define GPIO_PD3_I2C8SDA        0x00030C02
+#define GPIO_PD3_T1CCP1         0x00030C03
+#define GPIO_PD3_SSI2CLK        0x00030C0F
+
+#define GPIO_PD4_U2RX           0x00031001
+#define GPIO_PD4_T3CCP0         0x00031003
+#define GPIO_PD4_SSI1XDAT2      0x0003100F
+
+#define GPIO_PD5_U2TX           0x00031401
+#define GPIO_PD5_T3CCP1         0x00031403
+#define GPIO_PD5_SSI1XDAT3      0x0003140F
+
+#define GPIO_PD6_U2RTS          0x00031801
+#define GPIO_PD6_T4CCP0         0x00031803
+#define GPIO_PD6_USB0EPEN       0x00031805
+#define GPIO_PD6_SSI2XDAT3      0x0003180F
+
+#define GPIO_PD7_U2CTS          0x00031C01
+#define GPIO_PD7_T4CCP1         0x00031C03
+#define GPIO_PD7_USB0PFLT       0x00031C05
+#define GPIO_PD7_NMI            0x00031C08
+#define GPIO_PD7_SSI2XDAT2      0x00031C0F
+
+#define GPIO_PE0_U1RTS          0x00040001
+
+#define GPIO_PE1_U1DSR          0x00040401
+
+#define GPIO_PE2_U1DCD          0x00040801
+
+#define GPIO_PE3_U1DTR          0x00040C01
+
+#define GPIO_PE4_U1RI           0x00041001
+#define GPIO_PE4_SSI1XDAT0      0x0004100F
+
+#define GPIO_PE5_SSI1XDAT1      0x0004140F
+
+#define GPIO_PF0_EN0LED0        0x00050005
+#define GPIO_PF0_M0PWM0         0x00050006
+#define GPIO_PF0_SSI3XDAT1      0x0005000E
+#define GPIO_PF0_TRD2           0x0005000F
+
+#define GPIO_PF1_EN0LED2        0x00050405
+#define GPIO_PF1_M0PWM1         0x00050406
+#define GPIO_PF1_SSI3XDAT0      0x0005040E
+#define GPIO_PF1_TRD1           0x0005040F
+
+#define GPIO_PF2_M0PWM2         0x00050806
+#define GPIO_PF2_SSI3FSS        0x0005080E
+#define GPIO_PF2_TRD0           0x0005080F
+
+#define GPIO_PF3_M0PWM3         0x00050C06
+#define GPIO_PF3_SSI3CLK        0x00050C0E
+#define GPIO_PF3_TRCLK          0x00050C0F
+
+#define GPIO_PF4_EN0LED1        0x00051005
+#define GPIO_PF4_M0FAULT0       0x00051006
+#define GPIO_PF4_SSI3XDAT2      0x0005100E
+#define GPIO_PF4_TRD3           0x0005100F
+
+#define GPIO_PG0_I2C1SCL        0x00060002
+#define GPIO_PG0_EN0PPS         0x00060005
+#define GPIO_PG0_M0PWM4         0x00060006
+#define GPIO_PG0_EPI0S11        0x0006000F
+
+#define GPIO_PG1_I2C1SDA        0x00060402
+#define GPIO_PG1_M0PWM5         0x00060406
+#define GPIO_PG1_EPI0S10        0x0006040F
+
+#define GPIO_PH0_U0RTS          0x00070001
+#define GPIO_PH0_EPI0S0         0x0007000F
+
+#define GPIO_PH1_U0CTS          0x00070401
+#define GPIO_PH1_EPI0S1         0x0007040F
+
+#define GPIO_PH2_U0DCD          0x00070801
+#define GPIO_PH2_EPI0S2         0x0007080F
+
+#define GPIO_PH3_U0DSR          0x00070C01
+#define GPIO_PH3_EPI0S3         0x00070C0F
+
+#define GPIO_PJ0_U3RX           0x00080001
+#define GPIO_PJ0_EN0PPS         0x00080005
+
+#define GPIO_PJ1_U3TX           0x00080401
+
+#define GPIO_PK0_U4RX           0x00090001
+#define GPIO_PK0_EPI0S0         0x0009000F
+
+#define GPIO_PK1_U4TX           0x00090401
+#define GPIO_PK1_EPI0S1         0x0009040F
+
+#define GPIO_PK2_U4RTS          0x00090801
+#define GPIO_PK2_EPI0S2         0x0009080F
+
+#define GPIO_PK3_U4CTS          0x00090C01
+#define GPIO_PK3_EPI0S3         0x00090C0F
+
+#define GPIO_PK4_I2C3SCL        0x00091002
+#define GPIO_PK4_EN0LED0        0x00091005
+#define GPIO_PK4_M0PWM6         0x00091006
+#define GPIO_PK4_EPI0S32        0x0009100F
+
+#define GPIO_PK5_I2C3SDA        0x00091402
+#define GPIO_PK5_EN0LED2        0x00091405
+#define GPIO_PK5_M0PWM7         0x00091406
+#define GPIO_PK5_EPI0S31        0x0009140F
+
+#define GPIO_PK6_I2C4SCL        0x00091802
+#define GPIO_PK6_EN0LED1        0x00091805
+#define GPIO_PK6_M0FAULT1       0x00091806
+#define GPIO_PK6_EPI0S25        0x0009180F
+
+#define GPIO_PK7_U0RI           0x00091C01
+#define GPIO_PK7_I2C4SDA        0x00091C02
+#define GPIO_PK7_RTCCLK         0x00091C05
+#define GPIO_PK7_M0FAULT2       0x00091C06
+#define GPIO_PK7_EPI0S24        0x00091C0F
+
+#define GPIO_PL0_I2C2SDA        0x000A0002
+#define GPIO_PL0_M0FAULT3       0x000A0006
+#define GPIO_PL0_USB0D0         0x000A000E
+#define GPIO_PL0_EPI0S16        0x000A000F
+
+#define GPIO_PL1_I2C2SCL        0x000A0402
+#define GPIO_PL1_PHA0           0x000A0406
+#define GPIO_PL1_USB0D1         0x000A040E
+#define GPIO_PL1_EPI0S17        0x000A040F
+
+#define GPIO_PL2_C0O            0x000A0805
+#define GPIO_PL2_PHB0           0x000A0806
+#define GPIO_PL2_USB0D2         0x000A080E
+#define GPIO_PL2_EPI0S18        0x000A080F
+
+#define GPIO_PL3_C1O            0x000A0C05
+#define GPIO_PL3_IDX0           0x000A0C06
+#define GPIO_PL3_USB0D3         0x000A0C0E
+#define GPIO_PL3_EPI0S19        0x000A0C0F
+
+#define GPIO_PL4_T0CCP0         0x000A1003
+#define GPIO_PL4_USB0D4         0x000A100E
+#define GPIO_PL4_EPI0S26        0x000A100F
+
+#define GPIO_PL5_T0CCP1         0x000A1403
+#define GPIO_PL5_EPI0S33        0x000A140F
+#define GPIO_PL5_USB0D5         0x000A140E
+
+#define GPIO_PL6_T1CCP0         0x000A1803
+
+#define GPIO_PL7_T1CCP1         0x000A1C03
+
+#define GPIO_PM0_T2CCP0         0x000B0003
+#define GPIO_PM0_EPI0S15        0x000B000F
+
+#define GPIO_PM1_T2CCP1         0x000B0403
+#define GPIO_PM1_EPI0S14        0x000B040F
+
+#define GPIO_PM2_T3CCP0         0x000B0803
+#define GPIO_PM2_EPI0S13        0x000B080F
+
+#define GPIO_PM3_T3CCP1         0x000B0C03
+#define GPIO_PM3_EPI0S12        0x000B0C0F
+
+#define GPIO_PM4_U0CTS          0x000B1001
+#define GPIO_PM4_T4CCP0         0x000B1003
+
+#define GPIO_PM5_U0DCD          0x000B1401
+#define GPIO_PM5_T4CCP1         0x000B1403
+
+#define GPIO_PM6_U0DSR          0x000B1801
+#define GPIO_PM6_T5CCP0         0x000B1803
+
+#define GPIO_PM7_U0RI           0x000B1C01
+#define GPIO_PM7_T5CCP1         0x000B1C03
+
+#define GPIO_PN0_U1RTS          0x000C0001
+
+#define GPIO_PN1_U1CTS          0x000C0401
+
+#define GPIO_PN2_U1DCD          0x000C0801
+#define GPIO_PN2_U2RTS          0x000C0802
+#define GPIO_PN2_EPI0S29        0x000C080F
+
+#define GPIO_PN3_U1DSR          0x000C0C01
+#define GPIO_PN3_U2CTS          0x000C0C02
+#define GPIO_PN3_EPI0S30        0x000C0C0F
+
+#define GPIO_PN4_U1DTR          0x000C1001
+#define GPIO_PN4_U3RTS          0x000C1002
+#define GPIO_PN4_I2C2SDA        0x000C1003
+#define GPIO_PN4_EPI0S34        0x000C100F
+
+#define GPIO_PN5_U1RI           0x000C1401
+#define GPIO_PN5_U3CTS          0x000C1402
+#define GPIO_PN5_I2C2SCL        0x000C1403
+#define GPIO_PN5_EPI0S35        0x000C140F
+
+#define GPIO_PP0_U6RX           0x000D0001
+#define GPIO_PP0_SSI3XDAT2      0x000D000F
+
+#define GPIO_PP1_U6TX           0x000D0401
+#define GPIO_PP1_SSI3XDAT3      0x000D040F
+
+#define GPIO_PP2_U0DTR          0x000D0801
+#define GPIO_PP2_USB0NXT        0x000D080E
+#define GPIO_PP2_EPI0S29        0x000D080F
+
+#define GPIO_PP3_U1CTS          0x000D0C01
+#define GPIO_PP3_U0DCD          0x000D0C02
+#define GPIO_PP3_RTCCLK         0x000D0C07
+#define GPIO_PP3_USB0DIR        0x000D0C0E
+#define GPIO_PP3_EPI0S30        0x000D0C0F
+
+#define GPIO_PP4_U3RTS          0x000D1001
+#define GPIO_PP4_U0DSR          0x000D1002
+#define GPIO_PP4_USB0D7         0x000D100E
+
+#define GPIO_PP5_U3CTS          0x000D1401
+#define GPIO_PP5_I2C2SCL        0x000D1402
+#define GPIO_PP5_USB0D6         0x000D140E
+
+#define GPIO_PQ0_SSI3CLK        0x000E000E
+#define GPIO_PQ0_EPI0S20        0x000E000F
+
+#define GPIO_PQ1_SSI3FSS        0x000E040E
+#define GPIO_PQ1_EPI0S21        0x000E040F
+
+#define GPIO_PQ2_SSI3XDAT0      0x000E080E
+#define GPIO_PQ2_EPI0S22        0x000E080F
+
+#define GPIO_PQ3_SSI3XDAT1      0x000E0C0E
+#define GPIO_PQ3_EPI0S23        0x000E0C0F
+
+#define GPIO_PQ4_U1RX           0x000E1001
+#define GPIO_PQ4_DIVSCLK        0x000E1007
+
+#endif // PART_TM4C129ENCPDT
+
+//*****************************************************************************
+//
+// TM4C129ENCZAD Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C129ENCZAD
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_I2C9SCL        0x00000002
+#define GPIO_PA0_T0CCP0         0x00000003
+#define GPIO_PA0_CAN0RX         0x00000007
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_I2C9SDA        0x00000402
+#define GPIO_PA1_T0CCP1         0x00000403
+#define GPIO_PA1_CAN0TX         0x00000407
+
+#define GPIO_PA2_U4RX           0x00000801
+#define GPIO_PA2_I2C8SCL        0x00000802
+#define GPIO_PA2_T1CCP0         0x00000803
+#define GPIO_PA2_SSI0CLK        0x0000080F
+
+#define GPIO_PA3_U4TX           0x00000C01
+#define GPIO_PA3_I2C8SDA        0x00000C02
+#define GPIO_PA3_T1CCP1         0x00000C03
+#define GPIO_PA3_SSI0FSS        0x00000C0F
+
+#define GPIO_PA4_U3RX           0x00001001
+#define GPIO_PA4_T2CCP0         0x00001003
+#define GPIO_PA4_I2C7SCL        0x00001002
+#define GPIO_PA4_SSI0XDAT0      0x0000100F
+
+#define GPIO_PA5_U3TX           0x00001401
+#define GPIO_PA5_T2CCP1         0x00001403
+#define GPIO_PA5_I2C7SDA        0x00001402
+#define GPIO_PA5_SSI0XDAT1      0x0000140F
+
+#define GPIO_PA6_U2RX           0x00001801
+#define GPIO_PA6_I2C6SCL        0x00001802
+#define GPIO_PA6_T3CCP0         0x00001803
+#define GPIO_PA6_USB0EPEN       0x00001805
+#define GPIO_PA6_SSI0XDAT2      0x0000180D
+#define GPIO_PA6_EPI0S8         0x0000180F
+
+#define GPIO_PA7_U2TX           0x00001C01
+#define GPIO_PA7_I2C6SDA        0x00001C02
+#define GPIO_PA7_T3CCP1         0x00001C03
+#define GPIO_PA7_USB0PFLT       0x00001C05
+#define GPIO_PA7_USB0EPEN       0x00001C0B
+#define GPIO_PA7_SSI0XDAT3      0x00001C0D
+#define GPIO_PA7_EPI0S9         0x00001C0F
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_I2C5SCL        0x00010002
+#define GPIO_PB0_CAN1RX         0x00010007
+#define GPIO_PB0_T4CCP0         0x00010003
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_I2C5SDA        0x00010402
+#define GPIO_PB1_CAN1TX         0x00010407
+#define GPIO_PB1_T4CCP1         0x00010403
+
+#define GPIO_PB2_T5CCP0         0x00010803
+#define GPIO_PB2_I2C0SCL        0x00010802
+#define GPIO_PB2_USB0STP        0x0001080E
+#define GPIO_PB2_EPI0S27        0x0001080F
+
+#define GPIO_PB3_I2C0SDA        0x00010C02
+#define GPIO_PB3_T5CCP1         0x00010C03
+#define GPIO_PB3_USB0CLK        0x00010C0E
+#define GPIO_PB3_EPI0S28        0x00010C0F
+
+#define GPIO_PB4_U0CTS          0x00011001
+#define GPIO_PB4_I2C5SCL        0x00011002
+#define GPIO_PB4_SSI1FSS        0x0001100F
+
+#define GPIO_PB5_U0RTS          0x00011401
+#define GPIO_PB5_I2C5SDA        0x00011402
+#define GPIO_PB5_SSI1CLK        0x0001140F
+
+#define GPIO_PB6_I2C6SCL        0x00011802
+#define GPIO_PB6_T6CCP0         0x00011803
+#define GPIO_PB6_PS2CLK3        0x00011804
+
+#define GPIO_PB7_I2C6SDA        0x00011C02
+#define GPIO_PB7_T6CCP1         0x00011C03
+#define GPIO_PB7_PS2DAT3        0x00011C04
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+
+#define GPIO_PC2_TDI            0x00020801
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+
+#define GPIO_PC4_U7RX           0x00021001
+#define GPIO_PC4_T7CCP0         0x00021003
+#define GPIO_PC4_EPI0S7         0x0002100F
+
+#define GPIO_PC5_U7TX           0x00021401
+#define GPIO_PC5_T7CCP1         0x00021403
+#define GPIO_PC5_RTCCLK         0x00021407
+#define GPIO_PC5_EPI0S6         0x0002140F
+
+#define GPIO_PC6_U5RX           0x00021801
+#define GPIO_PC6_EPI0S5         0x0002180F
+
+#define GPIO_PC7_U5TX           0x00021C01
+#define GPIO_PC7_EPI0S4         0x00021C0F
+
+#define GPIO_PD0_I2C7SCL        0x00030002
+#define GPIO_PD0_T0CCP0         0x00030003
+#define GPIO_PD0_C0O            0x00030005
+#define GPIO_PD0_SSI2XDAT1      0x0003000F
+
+#define GPIO_PD1_I2C7SDA        0x00030402
+#define GPIO_PD1_T0CCP1         0x00030403
+#define GPIO_PD1_C1O            0x00030405
+#define GPIO_PD1_SSI2XDAT0      0x0003040F
+
+#define GPIO_PD2_I2C8SCL        0x00030802
+#define GPIO_PD2_T1CCP0         0x00030803
+#define GPIO_PD2_C2O            0x00030805
+#define GPIO_PD2_SSI2FSS        0x0003080F
+
+#define GPIO_PD3_I2C8SDA        0x00030C02
+#define GPIO_PD3_T1CCP1         0x00030C03
+#define GPIO_PD3_SSI2CLK        0x00030C0F
+
+#define GPIO_PD4_U2RX           0x00031001
+#define GPIO_PD4_T3CCP0         0x00031003
+#define GPIO_PD4_SSI1XDAT2      0x0003100F
+
+#define GPIO_PD5_U2TX           0x00031401
+#define GPIO_PD5_T3CCP1         0x00031403
+#define GPIO_PD5_SSI1XDAT3      0x0003140F
+
+#define GPIO_PD6_U2RTS          0x00031801
+#define GPIO_PD6_T4CCP0         0x00031803
+#define GPIO_PD6_USB0EPEN       0x00031805
+#define GPIO_PD6_SSI2XDAT3      0x0003180F
+
+#define GPIO_PD7_U2CTS          0x00031C01
+#define GPIO_PD7_T4CCP1         0x00031C03
+#define GPIO_PD7_USB0PFLT       0x00031C05
+#define GPIO_PD7_NMI            0x00031C08
+#define GPIO_PD7_SSI2XDAT2      0x00031C0F
+
+#define GPIO_PE0_U1RTS          0x00040001
+
+#define GPIO_PE1_U1DSR          0x00040401
+
+#define GPIO_PE2_U1DCD          0x00040801
+
+#define GPIO_PE3_U1DTR          0x00040C01
+
+#define GPIO_PE4_U1RI           0x00041001
+#define GPIO_PE4_SSI1XDAT0      0x0004100F
+
+#define GPIO_PE5_SSI1XDAT1      0x0004140F
+
+#define GPIO_PE6_U0CTS          0x00041801
+#define GPIO_PE6_I2C9SCL        0x00041802
+
+#define GPIO_PE7_U0RTS          0x00041C01
+#define GPIO_PE7_I2C9SDA        0x00041C02
+#define GPIO_PE7_NMI            0x00041C08
+
+#define GPIO_PF0_EN0LED0        0x00050005
+#define GPIO_PF0_M0PWM0         0x00050006
+#define GPIO_PF0_SSI3XDAT1      0x0005000E
+#define GPIO_PF0_TRD2           0x0005000F
+
+#define GPIO_PF1_EN0LED2        0x00050405
+#define GPIO_PF1_M0PWM1         0x00050406
+#define GPIO_PF1_SSI3XDAT0      0x0005040E
+#define GPIO_PF1_TRD1           0x0005040F
+
+#define GPIO_PF2_M0PWM2         0x00050806
+#define GPIO_PF2_SSI3FSS        0x0005080E
+#define GPIO_PF2_TRD0           0x0005080F
+
+#define GPIO_PF3_M0PWM3         0x00050C06
+#define GPIO_PF3_SSI3CLK        0x00050C0E
+#define GPIO_PF3_TRCLK          0x00050C0F
+
+#define GPIO_PF4_EN0LED1        0x00051005
+#define GPIO_PF4_M0FAULT0       0x00051006
+#define GPIO_PF4_SSI3XDAT2      0x0005100E
+#define GPIO_PF4_TRD3           0x0005100F
+
+#define GPIO_PF5_SSI3XDAT3      0x0005140E
+
+#define GPIO_PG0_I2C1SCL        0x00060002
+#define GPIO_PG0_EN0PPS         0x00060005
+#define GPIO_PG0_M0PWM4         0x00060006
+#define GPIO_PG0_EPI0S11        0x0006000F
+
+#define GPIO_PG1_I2C1SDA        0x00060402
+#define GPIO_PG1_M0PWM5         0x00060406
+#define GPIO_PG1_EPI0S10        0x0006040F
+
+#define GPIO_PG2_I2C2SCL        0x00060802
+#define GPIO_PG2_SSI2XDAT3      0x0006080F
+
+#define GPIO_PG3_I2C2SDA        0x00060C02
+#define GPIO_PG3_SSI2XDAT2      0x00060C0F
+
+#define GPIO_PG4_U0CTS          0x00061001
+#define GPIO_PG4_I2C3SCL        0x00061002
+#define GPIO_PG4_SSI2XDAT1      0x0006100F
+
+#define GPIO_PG5_U0RTS          0x00061401
+#define GPIO_PG5_I2C3SDA        0x00061402
+#define GPIO_PG5_SSI2XDAT0      0x0006140F
+
+#define GPIO_PG6_I2C4SCL        0x00061802
+#define GPIO_PG6_SSI2FSS        0x0006180F
+
+#define GPIO_PG7_I2C4SDA        0x00061C02
+#define GPIO_PG7_SSI2CLK        0x00061C0F
+
+#define GPIO_PH0_U0RTS          0x00070001
+#define GPIO_PH0_EPI0S0         0x0007000F
+
+#define GPIO_PH1_U0CTS          0x00070401
+#define GPIO_PH1_EPI0S1         0x0007040F
+
+#define GPIO_PH2_U0DCD          0x00070801
+#define GPIO_PH2_EPI0S2         0x0007080F
+
+#define GPIO_PH3_U0DSR          0x00070C01
+#define GPIO_PH3_EPI0S3         0x00070C0F
+
+#define GPIO_PH4_U0DTR          0x00071001
+
+#define GPIO_PH5_U0RI           0x00071401
+#define GPIO_PH5_EN0PPS         0x00071405
+
+#define GPIO_PH6_U5RX           0x00071801
+#define GPIO_PH6_U7RX           0x00071802
+
+#define GPIO_PH7_U5TX           0x00071C01
+#define GPIO_PH7_U7TX           0x00071C02
+
+#define GPIO_PJ0_U3RX           0x00080001
+#define GPIO_PJ0_EN0PPS         0x00080005
+
+#define GPIO_PJ1_U3TX           0x00080401
+
+#define GPIO_PJ2_U2RTS          0x00080801
+
+#define GPIO_PJ3_U2CTS          0x00080C01
+
+#define GPIO_PJ4_U3RTS          0x00081001
+
+#define GPIO_PJ5_U3CTS          0x00081401
+
+#define GPIO_PJ6_U4RTS          0x00081801
+
+#define GPIO_PJ7_U4CTS          0x00081C01
+
+#define GPIO_PK0_U4RX           0x00090001
+#define GPIO_PK0_EPI0S0         0x0009000F
+
+#define GPIO_PK1_U4TX           0x00090401
+#define GPIO_PK1_EPI0S1         0x0009040F
+
+#define GPIO_PK2_U4RTS          0x00090801
+#define GPIO_PK2_EPI0S2         0x0009080F
+
+#define GPIO_PK3_U4CTS          0x00090C01
+#define GPIO_PK3_EPI0S3         0x00090C0F
+
+#define GPIO_PK4_I2C3SCL        0x00091002
+#define GPIO_PK4_EN0LED0        0x00091005
+#define GPIO_PK4_M0PWM6         0x00091006
+#define GPIO_PK4_EPI0S32        0x0009100F
+
+#define GPIO_PK5_I2C3SDA        0x00091402
+#define GPIO_PK5_EN0LED2        0x00091405
+#define GPIO_PK5_M0PWM7         0x00091406
+#define GPIO_PK5_EPI0S31        0x0009140F
+
+#define GPIO_PK6_I2C4SCL        0x00091802
+#define GPIO_PK6_EN0LED1        0x00091805
+#define GPIO_PK6_M0FAULT1       0x00091806
+#define GPIO_PK6_EPI0S25        0x0009180F
+
+#define GPIO_PK7_U0RI           0x00091C01
+#define GPIO_PK7_I2C4SDA        0x00091C02
+#define GPIO_PK7_RTCCLK         0x00091C05
+#define GPIO_PK7_M0FAULT2       0x00091C06
+#define GPIO_PK7_EPI0S24        0x00091C0F
+
+#define GPIO_PL0_I2C2SDA        0x000A0002
+#define GPIO_PL0_M0FAULT3       0x000A0006
+#define GPIO_PL0_USB0D0         0x000A000E
+#define GPIO_PL0_EPI0S16        0x000A000F
+
+#define GPIO_PL1_I2C2SCL        0x000A0402
+#define GPIO_PL1_PHA0           0x000A0406
+#define GPIO_PL1_USB0D1         0x000A040E
+#define GPIO_PL1_EPI0S17        0x000A040F
+
+#define GPIO_PL2_C0O            0x000A0805
+#define GPIO_PL2_PHB0           0x000A0806
+#define GPIO_PL2_USB0D2         0x000A080E
+#define GPIO_PL2_EPI0S18        0x000A080F
+
+#define GPIO_PL3_C1O            0x000A0C05
+#define GPIO_PL3_IDX0           0x000A0C06
+#define GPIO_PL3_USB0D3         0x000A0C0E
+#define GPIO_PL3_EPI0S19        0x000A0C0F
+
+#define GPIO_PL4_T0CCP0         0x000A1003
+#define GPIO_PL4_USB0D4         0x000A100E
+#define GPIO_PL4_EPI0S26        0x000A100F
+
+#define GPIO_PL5_T0CCP1         0x000A1403
+#define GPIO_PL5_EPI0S33        0x000A140F
+#define GPIO_PL5_USB0D5         0x000A140E
+
+#define GPIO_PL6_T1CCP0         0x000A1803
+
+#define GPIO_PL7_T1CCP1         0x000A1C03
+
+#define GPIO_PM0_T2CCP0         0x000B0003
+#define GPIO_PM0_EPI0S15        0x000B000F
+
+#define GPIO_PM1_T2CCP1         0x000B0403
+#define GPIO_PM1_EPI0S14        0x000B040F
+
+#define GPIO_PM2_T3CCP0         0x000B0803
+#define GPIO_PM2_EPI0S13        0x000B080F
+
+#define GPIO_PM3_T3CCP1         0x000B0C03
+#define GPIO_PM3_EPI0S12        0x000B0C0F
+
+#define GPIO_PM4_U0CTS          0x000B1001
+#define GPIO_PM4_T4CCP0         0x000B1003
+
+#define GPIO_PM5_U0DCD          0x000B1401
+#define GPIO_PM5_T4CCP1         0x000B1403
+
+#define GPIO_PM6_U0DSR          0x000B1801
+#define GPIO_PM6_T5CCP0         0x000B1803
+
+#define GPIO_PM7_U0RI           0x000B1C01
+#define GPIO_PM7_T5CCP1         0x000B1C03
+
+#define GPIO_PN0_U1RTS          0x000C0001
+
+#define GPIO_PN1_U1CTS          0x000C0401
+
+#define GPIO_PN2_U1DCD          0x000C0801
+#define GPIO_PN2_U2RTS          0x000C0802
+#define GPIO_PN2_EPI0S29        0x000C080F
+
+#define GPIO_PN3_U1DSR          0x000C0C01
+#define GPIO_PN3_U2CTS          0x000C0C02
+#define GPIO_PN3_EPI0S30        0x000C0C0F
+
+#define GPIO_PN4_U1DTR          0x000C1001
+#define GPIO_PN4_U3RTS          0x000C1002
+#define GPIO_PN4_I2C2SDA        0x000C1003
+#define GPIO_PN4_EPI0S34        0x000C100F
+
+#define GPIO_PN5_U1RI           0x000C1401
+#define GPIO_PN5_U3CTS          0x000C1402
+#define GPIO_PN5_I2C2SCL        0x000C1403
+#define GPIO_PN5_EPI0S35        0x000C140F
+
+#define GPIO_PN6_U4RTS          0x000C1802
+
+#define GPIO_PN7_U1RTS          0x000C1C01
+#define GPIO_PN7_U4CTS          0x000C1C02
+
+#define GPIO_PP0_U6RX           0x000D0001
+#define GPIO_PP0_T6CCP0         0x000D0005
+#define GPIO_PP0_SSI3XDAT2      0x000D000F
+
+#define GPIO_PP1_U6TX           0x000D0401
+#define GPIO_PP1_T6CCP1         0x000D0405
+#define GPIO_PP1_SSI3XDAT3      0x000D040F
+
+#define GPIO_PP2_U0DTR          0x000D0801
+#define GPIO_PP2_USB0NXT        0x000D080E
+#define GPIO_PP2_EPI0S29        0x000D080F
+
+#define GPIO_PP3_U1CTS          0x000D0C01
+#define GPIO_PP3_U0DCD          0x000D0C02
+#define GPIO_PP3_RTCCLK         0x000D0C07
+#define GPIO_PP3_USB0DIR        0x000D0C0E
+#define GPIO_PP3_EPI0S30        0x000D0C0F
+
+#define GPIO_PP4_U3RTS          0x000D1001
+#define GPIO_PP4_U0DSR          0x000D1002
+#define GPIO_PP4_USB0D7         0x000D100E
+
+#define GPIO_PP5_U3CTS          0x000D1401
+#define GPIO_PP5_I2C2SCL        0x000D1402
+#define GPIO_PP5_USB0D6         0x000D140E
+
+#define GPIO_PP6_U1DCD          0x000D1801
+#define GPIO_PP6_I2C2SDA        0x000D1802
+
+#define GPIO_PQ0_T6CCP0         0x000E0003
+#define GPIO_PQ0_SSI3CLK        0x000E000E
+#define GPIO_PQ0_EPI0S20        0x000E000F
+
+#define GPIO_PQ1_T6CCP1         0x000E0403
+#define GPIO_PQ1_SSI3FSS        0x000E040E
+#define GPIO_PQ1_EPI0S21        0x000E040F
+
+#define GPIO_PQ2_T7CCP0         0x000E0803
+#define GPIO_PQ2_SSI3XDAT0      0x000E080E
+#define GPIO_PQ2_EPI0S22        0x000E080F
+
+#define GPIO_PQ3_T7CCP1         0x000E0C03
+#define GPIO_PQ3_SSI3XDAT1      0x000E0C0E
+#define GPIO_PQ3_EPI0S23        0x000E0C0F
+
+#define GPIO_PQ4_U1RX           0x000E1001
+#define GPIO_PQ4_DIVSCLK        0x000E1007
+
+#define GPIO_PQ5_U1TX           0x000E1401
+
+#define GPIO_PQ6_U1DTR          0x000E1801
+
+#define GPIO_PQ7_U1RI           0x000E1C01
+
+#define GPIO_PR0_U4TX           0x000F0001
+#define GPIO_PR0_I2C1SCL        0x000F0002
+#define GPIO_PR0_M0PWM0         0x000F0006
+
+#define GPIO_PR1_U4RX           0x000F0401
+#define GPIO_PR1_I2C1SDA        0x000F0402
+#define GPIO_PR1_M0PWM1         0x000F0406
+
+#define GPIO_PR2_I2C2SCL        0x000F0802
+#define GPIO_PR2_M0PWM2         0x000F0806
+
+#define GPIO_PR3_I2C2SDA        0x000F0C02
+#define GPIO_PR3_M0PWM3         0x000F0C06
+
+#define GPIO_PR4_I2C3SCL        0x000F1002
+#define GPIO_PR4_T0CCP0         0x000F1003
+#define GPIO_PR4_M0PWM4         0x000F1006
+
+#define GPIO_PR5_U1RX           0x000F1401
+#define GPIO_PR5_I2C3SDA        0x000F1402
+#define GPIO_PR5_T0CCP1         0x000F1403
+#define GPIO_PR5_M0PWM5         0x000F1406
+
+#define GPIO_PR6_U1TX           0x000F1801
+#define GPIO_PR6_I2C4SCL        0x000F1802
+#define GPIO_PR6_T1CCP0         0x000F1803
+#define GPIO_PR6_M0PWM6         0x000F1806
+
+#define GPIO_PR7_I2C4SDA        0x000F1C02
+#define GPIO_PR7_T1CCP1         0x000F1C03
+#define GPIO_PR7_M0PWM7         0x000F1C06
+
+#define GPIO_PS0_T2CCP0         0x00100003
+#define GPIO_PS0_M0FAULT0       0x00100006
+
+#define GPIO_PS1_T2CCP1         0x00100403
+#define GPIO_PS1_M0FAULT1       0x00100406
+
+#define GPIO_PS2_U1DSR          0x00100801
+#define GPIO_PS2_T3CCP0         0x00100803
+#define GPIO_PS2_M0FAULT2       0x00100806
+
+#define GPIO_PS3_T3CCP1         0x00100C03
+#define GPIO_PS3_M0FAULT3       0x00100C06
+
+#define GPIO_PS4_T4CCP0         0x00101003
+#define GPIO_PS4_PHA0           0x00101006
+
+#define GPIO_PS5_T4CCP1         0x00101403
+#define GPIO_PS5_PHB0           0x00101406
+
+#define GPIO_PS6_T5CCP0         0x00101803
+#define GPIO_PS6_IDX0           0x00101806
+
+#define GPIO_PS7_T5CCP1         0x00101C03
+
+#define GPIO_PT0_T6CCP0         0x00110003
+#define GPIO_PT0_CAN0RX         0x00110007
+
+#define GPIO_PT1_T6CCP1         0x00110403
+#define GPIO_PT1_CAN0TX         0x00110407
+
+#define GPIO_PT2_T7CCP0         0x00110803
+#define GPIO_PT2_CAN1RX         0x00110807
+
+#define GPIO_PT3_T7CCP1         0x00110C03
+#define GPIO_PT3_CAN1TX         0x00110C07
+
+#endif // PART_TM4C129ENCZAD
+
+//*****************************************************************************
+//
+// TM4C129XNCZAD Port/Pin Mapping Definitions
+//
+//*****************************************************************************
+#ifdef PART_TM4C129XNCZAD
+
+#define GPIO_PA0_U0RX           0x00000001
+#define GPIO_PA0_I2C9SCL        0x00000002
+#define GPIO_PA0_T0CCP0         0x00000003
+#define GPIO_PA0_FAN1PWM5       0x00000004
+#define GPIO_PA0_KBCOUT08       0x00000005
+#define GPIO_PA0_CAN0RX         0x00000007
+
+#define GPIO_PA1_U0TX           0x00000401
+#define GPIO_PA1_I2C9SDA        0x00000402
+#define GPIO_PA1_T0CCP1         0x00000403
+#define GPIO_PA1_FAN1TACH5      0x00000404
+#define GPIO_PA1_KBCOUT09       0x00000405
+#define GPIO_PA1_CAN0TX         0x00000407
+
+#define GPIO_PA2_U4RX           0x00000801
+#define GPIO_PA2_I2C8SCL        0x00000802
+#define GPIO_PA2_T1CCP0         0x00000803
+#define GPIO_PA2_SSI0CLK        0x0000080F
+
+#define GPIO_PA3_U4TX           0x00000C01
+#define GPIO_PA3_I2C8SDA        0x00000C02
+#define GPIO_PA3_T1CCP1         0x00000C03
+#define GPIO_PA3_SSI0FSS        0x00000C0F
+
+#define GPIO_PA4_U3RX           0x00001001
+#define GPIO_PA4_T2CCP0         0x00001003
+#define GPIO_PA4_I2C7SCL        0x00001002
+#define GPIO_PA4_SSI0XDAT0      0x0000100F
+
+#define GPIO_PA5_U3TX           0x00001401
+#define GPIO_PA5_T2CCP1         0x00001403
+#define GPIO_PA5_I2C7SDA        0x00001402
+#define GPIO_PA5_SSI0XDAT1      0x0000140F
+
+#define GPIO_PA6_U2RX           0x00001801
+#define GPIO_PA6_I2C6SCL        0x00001802
+#define GPIO_PA6_T3CCP0         0x00001803
+#define GPIO_PA6_PS2CLK0        0x00001804
+#define GPIO_PA6_USB0EPEN       0x00001805
+#define GPIO_PA6_SSI0XDAT2      0x0000180D
+#define GPIO_PA6_EN0RXCK        0x0000180E
+#define GPIO_PA6_EPI0S8         0x0000180F
+
+#define GPIO_PA7_U2TX           0x00001C01
+#define GPIO_PA7_I2C6SDA        0x00001C02
+#define GPIO_PA7_T3CCP1         0x00001C03
+#define GPIO_PA7_PS2DAT0        0x00001C04
+#define GPIO_PA7_USB0PFLT       0x00001C05
+#define GPIO_PA7_USB0EPEN       0x00001C0B
+#define GPIO_PA7_SSI0XDAT3      0x00001C0D
+#define GPIO_PA7_EPI0S9         0x00001C0F
+
+#define GPIO_PB0_U1RX           0x00010001
+#define GPIO_PB0_I2C5SCL        0x00010002
+#define GPIO_PB0_PS2CLK1        0x00010004
+#define GPIO_PB0_LPC0COMYRX     0x00010005
+#define GPIO_PB0_CAN1RX         0x00010007
+#define GPIO_PB0_T4CCP0         0x00010003
+
+#define GPIO_PB1_U1TX           0x00010401
+#define GPIO_PB1_I2C5SDA        0x00010402
+#define GPIO_PB1_PS2DAT1        0x00010404
+#define GPIO_PB1_LPC0COMYTX     0x00010405
+#define GPIO_PB1_CAN1TX         0x00010407
+#define GPIO_PB1_T4CCP1         0x00010403
+
+#define GPIO_PB2_T5CCP0         0x00010803
+#define GPIO_PB2_I2C0SCL        0x00010802
+#define GPIO_PB2_PS2CLK2        0x00010804
+#define GPIO_PB2_EN0MDC         0x00010805
+#define GPIO_PB2_LPC0A20        0x0001080D
+#define GPIO_PB2_USB0STP        0x0001080E
+#define GPIO_PB2_EPI0S27        0x0001080F
+
+#define GPIO_PB3_I2C0SDA        0x00010C02
+#define GPIO_PB3_T5CCP1         0x00010C03
+#define GPIO_PB3_PS2DAT2        0x00010C04
+#define GPIO_PB3_EN0MDIO        0x00010C05
+#define GPIO_PB3_LPC0RESET_N    0x00010C0D
+#define GPIO_PB3_USB0CLK        0x00010C0E
+#define GPIO_PB3_EPI0S28        0x00010C0F
+
+#define GPIO_PB4_U0CTS          0x00011001
+#define GPIO_PB4_I2C5SCL        0x00011002
+#define GPIO_PB4_SSI1FSS        0x0001100F
+
+#define GPIO_PB5_U0RTS          0x00011401
+#define GPIO_PB5_I2C5SDA        0x00011402
+#define GPIO_PB5_SSI1CLK        0x0001140F
+
+#define GPIO_PB6_I2C6SCL        0x00011802
+#define GPIO_PB6_T6CCP0         0x00011803
+#define GPIO_PB6_PS2CLK3        0x00011804
+
+#define GPIO_PB7_I2C6SDA        0x00011C02
+#define GPIO_PB7_T6CCP1         0x00011C03
+#define GPIO_PB7_PS2DAT3        0x00011C04
+
+#define GPIO_PC0_TCK            0x00020001
+#define GPIO_PC0_SWCLK          0x00020001
+#define GPIO_PC0_HLED0          0x00020004
+#define GPIO_PC0_KBCOUT00       0x00020005
+
+#define GPIO_PC1_TMS            0x00020401
+#define GPIO_PC1_SWDIO          0x00020401
+#define GPIO_PC1_HLED1          0x00020404
+#define GPIO_PC1_KBCOUT01       0x00020405
+
+#define GPIO_PC2_TDI            0x00020801
+#define GPIO_PC2_HLED2          0x00020804
+#define GPIO_PC2_KBCOUT02       0x00020805
+
+#define GPIO_PC3_SWO            0x00020C01
+#define GPIO_PC3_TDO            0x00020C01
+#define GPIO_PC3_KBCOUT03       0x00020C05
+#define GPIO_PC3_HLED3          0x00020C04
+
+#define GPIO_PC4_U7RX           0x00021001
+#define GPIO_PC4_T7CCP0         0x00021003
+#define GPIO_PC4_FAN0PWM0       0x00021004
+#define GPIO_PC4_EPI0S7         0x0002100F
+
+#define GPIO_PC5_U7TX           0x00021401
+#define GPIO_PC5_T7CCP1         0x00021403
+#define GPIO_PC5_FAN0TACH0      0x00021404
+#define GPIO_PC5_RTCCLK         0x00021407
+#define GPIO_PC5_EPI0S6         0x0002140F
+
+#define GPIO_PC6_U5RX           0x00021801
+#define GPIO_PC6_FAN0PWM1       0x00021804
+#define GPIO_PC6_EPI0S5         0x0002180F
+
+#define GPIO_PC7_U5TX           0x00021C01
+#define GPIO_PC7_FAN0TACH1      0x00021C04
+#define GPIO_PC7_EPI0S4         0x00021C0F
+
+#define GPIO_PD0_I2C7SCL        0x00030002
+#define GPIO_PD0_T0CCP0         0x00030003
+#define GPIO_PD0_FAN0PWM4       0x00030004
+#define GPIO_PD0_C0O            0x00030005
+#define GPIO_PD0_SSI2XDAT1      0x0003000F
+
+#define GPIO_PD1_I2C7SDA        0x00030402
+#define GPIO_PD1_T0CCP1         0x00030403
+#define GPIO_PD1_FAN0TACH4      0x00030404
+#define GPIO_PD1_C1O            0x00030405
+#define GPIO_PD1_SSI2XDAT0      0x0003040F
+
+#define GPIO_PD2_I2C8SCL        0x00030802
+#define GPIO_PD2_T1CCP0         0x00030803
+#define GPIO_PD2_C2O            0x00030805
+#define GPIO_PD2_SSI2FSS        0x0003080F
+
+#define GPIO_PD3_I2C8SDA        0x00030C02
+#define GPIO_PD3_T1CCP1         0x00030C03
+#define GPIO_PD3_SSI2CLK        0x00030C0F
+
+#define GPIO_PD4_U2RX           0x00031001
+#define GPIO_PD4_T3CCP0         0x00031003
+#define GPIO_PD4_KBCOUT19       0x00031004
+#define GPIO_PD4_SSI1XDAT2      0x0003100F
+
+#define GPIO_PD5_U2TX           0x00031401
+#define GPIO_PD5_T3CCP1         0x00031403
+#define GPIO_PD5_KBCOUT18       0x00031404
+#define GPIO_PD5_SSI1XDAT3      0x0003140F
+
+#define GPIO_PD6_U2RTS          0x00031801
+#define GPIO_PD6_T4CCP0         0x00031803
+#define GPIO_PD6_USB0EPEN       0x00031805
+#define GPIO_PD6_SSI2XDAT3      0x0003180F
+
+#define GPIO_PD7_U2CTS          0x00031C01
+#define GPIO_PD7_T4CCP1         0x00031C03
+#define GPIO_PD7_USB0PFLT       0x00031C05
+#define GPIO_PD7_NMI            0x00031C08
+#define GPIO_PD7_SSI2XDAT2      0x00031C0F
+
+#define GPIO_PE0_U1RTS          0x00040001
+
+#define GPIO_PE1_U1DSR          0x00040401
+
+#define GPIO_PE2_U1DCD          0x00040801
+
+#define GPIO_PE3_U1DTR          0x00040C01
+
+#define GPIO_PE4_U1RI           0x00041001
+#define GPIO_PE4_FAN0TACH7      0x00041004
+#define GPIO_PE4_SSI1XDAT0      0x0004100F
+
+#define GPIO_PE5_FAN0PWM7       0x00041404
+#define GPIO_PE5_SSI1XDAT1      0x0004140F
+
+#define GPIO_PE6_U0CTS          0x00041801
+#define GPIO_PE6_I2C9SCL        0x00041802
+#define GPIO_PE6_HLED2          0x00041804
+
+#define GPIO_PE7_U0RTS          0x00041C01
+#define GPIO_PE7_I2C9SDA        0x00041C02
+#define GPIO_PE7_HLED3          0x00041C04
+#define GPIO_PE7_NMI            0x00041C08
+
+#define GPIO_PF0_KBCOUT00       0x00050003
+#define GPIO_PF0_FAN0PWM2       0x00050004
+#define GPIO_PF0_EN0LED0        0x00050005
+#define GPIO_PF0_M0PWM0         0x00050006
+#define GPIO_PF0_KBCOUT07       0x00050007
+#define GPIO_PF0_SSI3XDAT1      0x0005000E
+#define GPIO_PF0_TRD2           0x0005000F
+
+#define GPIO_PF1_KBCOUT01       0x00050403
+#define GPIO_PF1_FAN0TACH2      0x00050404
+#define GPIO_PF1_EN0LED2        0x00050405
+#define GPIO_PF1_M0PWM1         0x00050406
+#define GPIO_PF1_KBCOUT06       0x00050407
+#define GPIO_PF1_SSI3XDAT0      0x0005040E
+#define GPIO_PF1_TRD1           0x0005040F
+
+#define GPIO_PF2_KBCOUT02       0x00050803
+#define GPIO_PF2_FAN0PWM3       0x00050804
+#define GPIO_PF2_EN0MDC         0x00050805
+#define GPIO_PF2_M0PWM2         0x00050806
+#define GPIO_PF2_KBCOUT05       0x00050807
+#define GPIO_PF2_SSI3FSS        0x0005080E
+#define GPIO_PF2_TRD0           0x0005080F
+
+#define GPIO_PF3_KBCOUT03       0x00050C03
+#define GPIO_PF3_FAN0TACH3      0x00050C04
+#define GPIO_PF3_EN0MDIO        0x00050C05
+#define GPIO_PF3_M0PWM3         0x00050C06
+#define GPIO_PF3_KBCOUT04       0x00050C07
+#define GPIO_PF3_SSI3CLK        0x00050C0E
+#define GPIO_PF3_TRCLK          0x00050C0F
+
+#define GPIO_PF4_KBCOUT16       0x00051003
+#define GPIO_PF4_FAN0PWM4       0x00051004
+#define GPIO_PF4_EN0LED1        0x00051005
+#define GPIO_PF4_M0FAULT0       0x00051006
+#define GPIO_PF4_SSI3XDAT2      0x0005100E
+#define GPIO_PF4_TRD3           0x0005100F
+
+#define GPIO_PF5_KBCOUT17       0x00051403
+#define GPIO_PF5_FAN0TACH4      0x00051404
+#define GPIO_PF5_SSI3XDAT3      0x0005140E
+
+#define GPIO_PF6_FAN0PWM5       0x00051804
+#define GPIO_PF6_LCDMCLK        0x0005180F
+
+#define GPIO_PF7_FAN0TACH5      0x00051C04
+#define GPIO_PF7_LCDDATA02      0x00051C0F
+
+#define GPIO_PG0_I2C1SCL        0x00060002
+#define GPIO_PG0_FAN1PWM0       0x00060003
+#define GPIO_PG0_FAN0PWM6       0x00060004
+#define GPIO_PG0_EN0PPS         0x00060005
+#define GPIO_PG0_M0PWM4         0x00060006
+#define GPIO_PG0_EPI0S11        0x0006000F
+
+#define GPIO_PG1_I2C1SDA        0x00060402
+#define GPIO_PG1_KBRST_N        0x00060403
+#define GPIO_PG1_FAN0TACH6      0x00060404
+#define GPIO_PG1_FAN1TACH0      0x00060405
+#define GPIO_PG1_M0PWM5         0x00060406
+#define GPIO_PG1_EPI0S10        0x0006040F
+
+#define GPIO_PG2_I2C2SCL        0x00060802
+#define GPIO_PG2_KBCOUT00       0x00060803
+#define GPIO_PG2_FAN0PWM7       0x00060804
+#define GPIO_PG2_FAN1PWM1       0x00060805
+#define GPIO_PG2_EN0TXCK        0x0006080E
+#define GPIO_PG2_SSI2XDAT3      0x0006080F
+
+#define GPIO_PG3_I2C2SDA        0x00060C02
+#define GPIO_PG3_KBCOUT01       0x00060C03
+#define GPIO_PG3_FAN0TACH7      0x00060C04
+#define GPIO_PG3_FAN1TACH1      0x00060C05
+#define GPIO_PG3_EN0TXEN        0x00060C0E
+#define GPIO_PG3_SSI2XDAT2      0x00060C0F
+
+#define GPIO_PG4_U0CTS          0x00061001
+#define GPIO_PG4_I2C3SCL        0x00061002
+#define GPIO_PG4_OWIRE          0x00061005
+#define GPIO_PG4_EN0TXD0        0x0006100E
+#define GPIO_PG4_SSI2XDAT1      0x0006100F
+
+#define GPIO_PG5_U0RTS          0x00061401
+#define GPIO_PG5_I2C3SDA        0x00061402
+#define GPIO_PG5_KBRST_N        0x00061404
+#define GPIO_PG5_OWALT          0x00061405
+#define GPIO_PG5_EN0TXD1        0x0006140E
+#define GPIO_PG5_SSI2XDAT0      0x0006140F
+
+#define GPIO_PG6_I2C4SCL        0x00061802
+#define GPIO_PG6_KBCOUT00       0x00061804
+#define GPIO_PG6_EN0RXER        0x0006180E
+#define GPIO_PG6_SSI2FSS        0x0006180F
+
+#define GPIO_PG7_I2C4SDA        0x00061C02
+#define GPIO_PG7_KBCOUT01       0x00061C04
+#define GPIO_PG7_EN0RXDV        0x00061C0E
+#define GPIO_PG7_SSI2CLK        0x00061C0F
+
+#define GPIO_PH0_U0RTS          0x00070001
+#define GPIO_PH0_LPC0COMXRTS    0x00070002
+#define GPIO_PH0_KBCIN04        0x00070004
+#define GPIO_PH0_FAN1PWM3       0x00070005
+#define GPIO_PH0_EPI0S0         0x0007000F
+
+#define GPIO_PH1_U0CTS          0x00070401
+#define GPIO_PH1_LPC0COMXCTS    0x00070402
+#define GPIO_PH1_KBCIN05        0x00070404
+#define GPIO_PH1_FAN1TACH3      0x00070405
+#define GPIO_PH1_EPI0S1         0x0007040F
+
+#define GPIO_PH2_U0DCD          0x00070801
+#define GPIO_PH2_LPC0COMXDCD    0x00070802
+#define GPIO_PH2_KBCIN06        0x00070804
+#define GPIO_PH2_FAN0PWM4       0x00070805
+#define GPIO_PH2_EPI0S2         0x0007080F
+
+#define GPIO_PH3_U0DSR          0x00070C01
+#define GPIO_PH3_LPC0COMXDSR    0x00070C02
+#define GPIO_PH3_KBCIN07        0x00070C04
+#define GPIO_PH3_FAN0TACH4      0x00070C05
+#define GPIO_PH3_EPI0S3         0x00070C0F
+
+#define GPIO_PH4_U0DTR          0x00071001
+#define GPIO_PH4_LPC0COMXDTR    0x00071002
+#define GPIO_PH4_LPC0COMXRTS    0x00071003
+#define GPIO_PH4_PS2CLK0        0x00071004
+
+#define GPIO_PH5_U0RI           0x00071401
+#define GPIO_PH5_LPC0COMXRI     0x00071402
+#define GPIO_PH5_LPC0COMXCTS    0x00071403
+#define GPIO_PH5_PS2DAT0        0x00071404
+#define GPIO_PH5_EN0PPS         0x00071405
+
+#define GPIO_PH6_U5RX           0x00071801
+#define GPIO_PH6_U7RX           0x00071802
+#define GPIO_PH6_LPC0COMXDCD    0x00071803
+#define GPIO_PH6_FAN1PWM0       0x00071804
+#define GPIO_PH6_KBCIN04        0x00071805
+
+#define GPIO_PH7_U5TX           0x00071C01
+#define GPIO_PH7_U7TX           0x00071C02
+#define GPIO_PH7_LPC0COMXDSR    0x00071C03
+#define GPIO_PH7_FAN1TACH0      0x00071C04
+#define GPIO_PH7_KBCIN05        0x00071C05
+
+#define GPIO_PJ0_U3RX           0x00080001
+#define GPIO_PJ0_EN0PPS         0x00080005
+
+#define GPIO_PJ1_U3TX           0x00080401
+
+#define GPIO_PJ2_U2RTS          0x00080801
+#define GPIO_PJ2_KBCOUT02       0x00080804
+#define GPIO_PJ2_FAN1PWM1       0x00080805
+#define GPIO_PJ2_LCDDATA14      0x0008080F
+
+#define GPIO_PJ3_U2CTS          0x00080C01
+#define GPIO_PJ3_KBCOUT03       0x00080C04
+#define GPIO_PJ3_FAN1TACH1      0x00080C05
+#define GPIO_PJ3_LCDDATA15      0x00080C0F
+
+#define GPIO_PJ4_U3RTS          0x00081001
+#define GPIO_PJ4_KBCOUT04       0x00081004
+#define GPIO_PJ4_FAN1PWM5       0x00081005
+#define GPIO_PJ4_LCDDATA16      0x0008100F
+
+#define GPIO_PJ5_U3CTS          0x00081401
+#define GPIO_PJ5_KBCOUT05       0x00081404
+#define GPIO_PJ5_FAN1TACH5      0x00081405
+#define GPIO_PJ5_LCDDATA17      0x0008140F
+
+#define GPIO_PJ6_U4RTS          0x00081801
+#define GPIO_PJ6_KBCOUT06       0x00081804
+#define GPIO_PJ6_LCDAC          0x0008180F
+
+#define GPIO_PJ7_U4CTS          0x00081C01
+#define GPIO_PJ7_KBCOUT07       0x00081C04
+
+#define GPIO_PK0_U4RX           0x00090001
+#define GPIO_PK0_KBCIN06        0x00090003
+#define GPIO_PK0_FAN1PWM6       0x00090004
+#define GPIO_PK0_EPI0S0         0x0009000F
+
+#define GPIO_PK1_U4TX           0x00090401
+#define GPIO_PK1_KBCIN07        0x00090403
+#define GPIO_PK1_FAN1TACH6      0x00090404
+#define GPIO_PK1_EPI0S1         0x0009040F
+
+#define GPIO_PK2_U4RTS          0x00090801
+#define GPIO_PK2_KBCOUT05       0x00090803
+#define GPIO_PK2_FAN1PWM7       0x00090804
+#define GPIO_PK2_EPI0S2         0x0009080F
+
+#define GPIO_PK3_U4CTS          0x00090C01
+#define GPIO_PK3_KBCOUT06       0x00090C03
+#define GPIO_PK3_FAN1TACH7      0x00090C04
+#define GPIO_PK3_EPI0S3         0x00090C0F
+
+#define GPIO_PK4_I2C3SCL        0x00091002
+#define GPIO_PK4_KBCIN00        0x00091004
+#define GPIO_PK4_EN0LED0        0x00091005
+#define GPIO_PK4_M0PWM6         0x00091006
+#define GPIO_PK4_EN0INTRN       0x00091007
+#define GPIO_PK4_EN0RXD3        0x0009100E
+#define GPIO_PK4_EPI0S32        0x0009100F
+
+#define GPIO_PK5_I2C3SDA        0x00091402
+#define GPIO_PK5_KBCIN01        0x00091404
+#define GPIO_PK5_EN0LED2        0x00091405
+#define GPIO_PK5_M0PWM7         0x00091406
+#define GPIO_PK5_EN0RXD2        0x0009140E
+#define GPIO_PK5_EPI0S31        0x0009140F
+
+#define GPIO_PK6_I2C4SCL        0x00091802
+#define GPIO_PK6_KBCIN02        0x00091804
+#define GPIO_PK6_EN0LED1        0x00091805
+#define GPIO_PK6_M0FAULT1       0x00091806
+#define GPIO_PK6_EN0TXD2        0x0009180E
+#define GPIO_PK6_EPI0S25        0x0009180F
+
+#define GPIO_PK7_U0RI           0x00091C01
+#define GPIO_PK7_I2C4SDA        0x00091C02
+#define GPIO_PK7_KBCIN03        0x00091C04
+#define GPIO_PK7_RTCCLK         0x00091C05
+#define GPIO_PK7_M0FAULT2       0x00091C06
+#define GPIO_PK7_EN0TXD3        0x00091C0E
+#define GPIO_PK7_EPI0S24        0x00091C0F
+
+#define GPIO_PL0_I2C2SDA        0x000A0002
+#define GPIO_PL0_M0FAULT3       0x000A0006
+#define GPIO_PL0_LPC0FRAME_N    0x000A000D
+#define GPIO_PL0_USB0D0         0x000A000E
+#define GPIO_PL0_EPI0S16        0x000A000F
+
+#define GPIO_PL1_I2C2SCL        0x000A0402
+#define GPIO_PL1_PHA0           0x000A0406
+#define GPIO_PL1_LPC0CLK        0x000A040D
+#define GPIO_PL1_USB0D1         0x000A040E
+#define GPIO_PL1_EPI0S17        0x000A040F
+
+#define GPIO_PL2_C0O            0x000A0805
+#define GPIO_PL2_PHB0           0x000A0806
+#define GPIO_PL2_LPC0CLKRUN_N   0x000A080D
+#define GPIO_PL2_USB0D2         0x000A080E
+#define GPIO_PL2_EPI0S18        0x000A080F
+
+#define GPIO_PL3_C1O            0x000A0C05
+#define GPIO_PL3_IDX0           0x000A0C06
+#define GPIO_PL3_LPC0SERIRQ     0x000A0C0D
+#define GPIO_PL3_USB0D3         0x000A0C0E
+#define GPIO_PL3_EPI0S19        0x000A0C0F
+
+#define GPIO_PL4_T0CCP0         0x000A1003
+#define GPIO_PL4_LPC0SCI_N      0x000A100D
+#define GPIO_PL4_USB0D4         0x000A100E
+#define GPIO_PL4_EPI0S26        0x000A100F
+
+#define GPIO_PL5_T0CCP1         0x000A1403
+#define GPIO_PL5_EPI0S33        0x000A140F
+#define GPIO_PL5_LPC0PD_N       0x000A140D
+#define GPIO_PL5_USB0D5         0x000A140E
+
+#define GPIO_PL6_T1CCP0         0x000A1803
+#define GPIO_PL6_FAN1PWM4       0x000A1804
+
+#define GPIO_PL7_T1CCP1         0x000A1C03
+#define GPIO_PL7_FAN1TACH4      0x000A1C04
+
+#define GPIO_PM0_T2CCP0         0x000B0003
+#define GPIO_PM0_FAN0PWM5       0x000B0005
+#define GPIO_PM0_LPC0AD3        0x000B000D
+#define GPIO_PM0_EPI0S15        0x000B000F
+
+#define GPIO_PM1_T2CCP1         0x000B0403
+#define GPIO_PM1_FAN0TACH5      0x000B0405
+#define GPIO_PM1_LPC0AD2        0x000B040D
+#define GPIO_PM1_EPI0S14        0x000B040F
+
+#define GPIO_PM2_T3CCP0         0x000B0803
+#define GPIO_PM2_FAN1PWM4       0x000B0805
+#define GPIO_PM2_LPC0AD1        0x000B080D
+#define GPIO_PM2_EPI0S13        0x000B080F
+
+#define GPIO_PM3_T3CCP1         0x000B0C03
+#define GPIO_PM3_FAN1TACH4      0x000B0C05
+#define GPIO_PM3_LPC0AD0        0x000B0C0D
+#define GPIO_PM3_EPI0S12        0x000B0C0F
+
+#define GPIO_PM4_U0CTS          0x000B1001
+#define GPIO_PM4_T4CCP0         0x000B1003
+#define GPIO_PM4_KBCIN04        0x000B1004
+#define GPIO_PM4_EN0RREF_CLK    0x000B100E
+
+#define GPIO_PM5_U0DCD          0x000B1401
+#define GPIO_PM5_T4CCP1         0x000B1403
+#define GPIO_PM5_KBCIN05        0x000B1404
+
+#define GPIO_PM6_U0DSR          0x000B1801
+#define GPIO_PM6_LPC0COMXRTS    0x000B1802
+#define GPIO_PM6_KBCIN06        0x000B1804
+#define GPIO_PM6_T5CCP0         0x000B1803
+#define GPIO_PM6_EN0CRS         0x000B180E
+
+#define GPIO_PM7_U0RI           0x000B1C01
+#define GPIO_PM7_LPC0COMXCTS    0x000B1C02
+#define GPIO_PM7_KBCIN07        0x000B1C04
+#define GPIO_PM7_T5CCP1         0x000B1C03
+#define GPIO_PM7_EN0COL         0x000B1C0E
+
+#define GPIO_PN0_U1RTS          0x000C0001
+#define GPIO_PN0_LPC0COMYRTS    0x000C0002
+#define GPIO_PN0_KBCOUT11       0x000C0003
+#define GPIO_PN0_PS2CLK1        0x000C0004
+#define GPIO_PN0_FAN0PWM5       0x000C0005
+
+#define GPIO_PN1_U1CTS          0x000C0401
+#define GPIO_PN1_LPC0COMYCTS    0x000C0402
+#define GPIO_PN1_KBCOUT12       0x000C0403
+#define GPIO_PN1_PS2DAT1        0x000C0404
+#define GPIO_PN1_FAN0TACH5      0x000C0405
+
+#define GPIO_PN2_U1DCD          0x000C0801
+#define GPIO_PN2_U2RTS          0x000C0802
+#define GPIO_PN2_LPC0COMXDTR    0x000C0803
+#define GPIO_PN2_FAN1PWM4       0x000C0805
+#define GPIO_PN2_EPI0S29        0x000C080F
+
+#define GPIO_PN3_U1DSR          0x000C0C01
+#define GPIO_PN3_U2CTS          0x000C0C02
+#define GPIO_PN3_LPC0COMXRI     0x000C0C03
+#define GPIO_PN3_KBCOUT17       0x000C0C04
+#define GPIO_PN3_FAN1TACH4      0x000C0C05
+#define GPIO_PN3_EPI0S30        0x000C0C0F
+
+#define GPIO_PN4_U1DTR          0x000C1001
+#define GPIO_PN4_U3RTS          0x000C1002
+#define GPIO_PN4_I2C2SDA        0x000C1003
+#define GPIO_PN4_KBCOUT14       0x000C1004
+#define GPIO_PN4_EPI0S34        0x000C100F
+
+#define GPIO_PN5_U1RI           0x000C1401
+#define GPIO_PN5_U3CTS          0x000C1402
+#define GPIO_PN5_I2C2SCL        0x000C1403
+#define GPIO_PN5_KBCOUT15       0x000C1404
+#define GPIO_PN5_EPI0S35        0x000C140F
+
+#define GPIO_PN6_U4RTS          0x000C1802
+#define GPIO_PN6_KBCOUT07       0x000C1803
+#define GPIO_PN6_FAN1PWM3       0x000C1804
+#define GPIO_PN6_PS2CLK2        0x000C1805
+#define GPIO_PN6_EN0TXER        0x000C180E
+#define GPIO_PN6_LCDDATA13      0x000C180F
+
+#define GPIO_PN7_U1RTS          0x000C1C01
+#define GPIO_PN7_U4CTS          0x000C1C02
+#define GPIO_PN7_FAN1TACH3      0x000C1C04
+#define GPIO_PN7_PS2DAT2        0x000C1C05
+#define GPIO_PN7_LCDDATA12      0x000C1C0F
+
+#define GPIO_PP0_U6RX           0x000D0001
+#define GPIO_PP0_KBCOUT18       0x000D0003
+#define GPIO_PP0_HLED0          0x000D0004
+#define GPIO_PP0_T6CCP0         0x000D0005
+#define GPIO_PP0_EN0INTRN       0x000D0007
+#define GPIO_PP0_SSI3XDAT2      0x000D000F
+
+#define GPIO_PP1_U6TX           0x000D0401
+#define GPIO_PP1_KBCOUT19       0x000D0403
+#define GPIO_PP1_HLED1          0x000D0404
+#define GPIO_PP1_T6CCP1         0x000D0405
+#define GPIO_PP1_SSI3XDAT3      0x000D040F
+
+#define GPIO_PP2_U0DTR          0x000D0801
+#define GPIO_PP2_FAN1PWM2       0x000D0804
+#define GPIO_PP2_USB0NXT        0x000D080E
+#define GPIO_PP2_EPI0S29        0x000D080F
+
+#define GPIO_PP3_U1CTS          0x000D0C01
+#define GPIO_PP3_U0DCD          0x000D0C02
+#define GPIO_PP3_KBCOUT08       0x000D0C03
+#define GPIO_PP3_FAN1TACH2      0x000D0C04
+#define GPIO_PP3_RTCCLK         0x000D0C07
+#define GPIO_PP3_USB0DIR        0x000D0C0E
+#define GPIO_PP3_EPI0S30        0x000D0C0F
+
+#define GPIO_PP4_U3RTS          0x000D1001
+#define GPIO_PP4_U0DSR          0x000D1002
+#define GPIO_PP4_KBCOUT09       0x000D1003
+#define GPIO_PP4_OWIRE          0x000D1004
+#define GPIO_PP4_USB0D7         0x000D100E
+
+#define GPIO_PP5_U3CTS          0x000D1401
+#define GPIO_PP5_I2C2SCL        0x000D1402
+#define GPIO_PP5_KBCOUT10       0x000D1403
+#define GPIO_PP5_OWALT          0x000D1404
+#define GPIO_PP5_USB0D6         0x000D140E
+
+#define GPIO_PP6_U1DCD          0x000D1801
+#define GPIO_PP6_I2C2SDA        0x000D1802
+#define GPIO_PP6_KBCOUT11       0x000D1803
+
+#define GPIO_PP7_KBCOUT12       0x000D1C03
+
+#define GPIO_PQ0_T6CCP0         0x000E0003
+#define GPIO_PQ0_KBCOUT04       0x000E0004
+#define GPIO_PQ0_KBCOUT00       0x000E0005
+#define GPIO_PQ0_FAN1PWM1       0x000E0006
+#define GPIO_PQ0_SSI3CLK        0x000E000E
+#define GPIO_PQ0_EPI0S20        0x000E000F
+
+#define GPIO_PQ1_T6CCP1         0x000E0403
+#define GPIO_PQ1_KBCOUT05       0x000E0404
+#define GPIO_PQ1_KBCOUT01       0x000E0405
+#define GPIO_PQ1_FAN1TACH1      0x000E0406
+#define GPIO_PQ1_SSI3FSS        0x000E040E
+#define GPIO_PQ1_EPI0S21        0x000E040F
+
+#define GPIO_PQ2_T7CCP0         0x000E0803
+#define GPIO_PQ2_KBCOUT06       0x000E0804
+#define GPIO_PQ2_KBCOUT02       0x000E0805
+#define GPIO_PQ2_SSI3XDAT0      0x000E080E
+#define GPIO_PQ2_EPI0S22        0x000E080F
+
+#define GPIO_PQ3_T7CCP1         0x000E0C03
+#define GPIO_PQ3_KBCOUT07       0x000E0C04
+#define GPIO_PQ3_KBCOUT03       0x000E0C05
+#define GPIO_PQ3_SSI3XDAT1      0x000E0C0E
+#define GPIO_PQ3_EPI0S23        0x000E0C0F
+
+#define GPIO_PQ4_U1RX           0x000E1001
+#define GPIO_PQ4_KBCOUT13       0x000E1003
+#define GPIO_PQ4_FAN1PWM0       0x000E1004
+#define GPIO_PQ4_LPC0COMYRX     0x000E1005
+#define GPIO_PQ4_DIVSCLK        0x000E1007
+
+#define GPIO_PQ5_U1TX           0x000E1401
+#define GPIO_PQ5_KBCOUT14       0x000E1403
+#define GPIO_PQ5_FAN1TACH0      0x000E1404
+#define GPIO_PQ5_LPC0COMYTX     0x000E1405
+#define GPIO_PQ5_EN0RXD0        0x000E140E
+
+#define GPIO_PQ6_U1DTR          0x000E1801
+#define GPIO_PQ6_KBCOUT15       0x000E1803
+#define GPIO_PQ6_FAN1PWM1       0x000E1804
+#define GPIO_PQ6_EN0RXD1        0x000E180E
+
+#define GPIO_PQ7_U1RI           0x000E1C01
+#define GPIO_PQ7_FAN1TACH1      0x000E1C04
+
+#define GPIO_PR0_U4TX           0x000F0001
+#define GPIO_PR0_I2C1SCL        0x000F0002
+#define GPIO_PR0_KBCOUT08       0x000F0004
+#define GPIO_PR0_M0PWM0         0x000F0006
+#define GPIO_PR0_LCDCP          0x000F000F
+
+#define GPIO_PR1_U4RX           0x000F0401
+#define GPIO_PR1_I2C1SDA        0x000F0402
+#define GPIO_PR1_KBCOUT09       0x000F0404
+#define GPIO_PR1_M0PWM1         0x000F0406
+#define GPIO_PR1_LCDFP          0x000F040F
+
+#define GPIO_PR2_I2C2SCL        0x000F0802
+#define GPIO_PR2_KBCOUT10       0x000F0804
+#define GPIO_PR2_M0PWM2         0x000F0806
+#define GPIO_PR2_LCDLP          0x000F080F
+
+#define GPIO_PR3_I2C2SDA        0x000F0C02
+#define GPIO_PR3_KBCOUT11       0x000F0C04
+#define GPIO_PR3_M0PWM3         0x000F0C06
+#define GPIO_PR3_LCDDATA03      0x000F0C0F
+
+#define GPIO_PR4_I2C3SCL        0x000F1002
+#define GPIO_PR4_T0CCP0         0x000F1003
+#define GPIO_PR4_KBCOUT12       0x000F1004
+#define GPIO_PR4_M0PWM4         0x000F1006
+#define GPIO_PR4_LCDDATA00      0x000F100F
+
+#define GPIO_PR5_U1RX           0x000F1401
+#define GPIO_PR5_I2C3SDA        0x000F1402
+#define GPIO_PR5_T0CCP1         0x000F1403
+#define GPIO_PR5_KBCOUT13       0x000F1404
+#define GPIO_PR5_LPC0COMYRX     0x000F1405
+#define GPIO_PR5_M0PWM5         0x000F1406
+#define GPIO_PR5_LCDDATA01      0x000F140F
+
+#define GPIO_PR6_U1TX           0x000F1801
+#define GPIO_PR6_I2C4SCL        0x000F1802
+#define GPIO_PR6_T1CCP0         0x000F1803
+#define GPIO_PR6_KBCOUT14       0x000F1804
+#define GPIO_PR6_LPC0COMYTX     0x000F1805
+#define GPIO_PR6_M0PWM6         0x000F1806
+#define GPIO_PR6_LCDDATA04      0x000F180F
+
+#define GPIO_PR7_I2C4SDA        0x000F1C02
+#define GPIO_PR7_T1CCP1         0x000F1C03
+#define GPIO_PR7_KBCOUT15       0x000F1C04
+#define GPIO_PR7_M0PWM7         0x000F1C06
+#define GPIO_PR7_EN0TXEN        0x000F1C0E
+#define GPIO_PR7_LCDDATA05      0x000F1C0F
+
+#define GPIO_PS0_T2CCP0         0x00100003
+#define GPIO_PS0_KBCOUT16       0x00100004
+#define GPIO_PS0_M0FAULT0       0x00100006
+#define GPIO_PS0_LPC0A20        0x0010000D
+#define GPIO_PS0_LCDDATA20      0x0010000F
+
+#define GPIO_PS1_T2CCP1         0x00100403
+#define GPIO_PS1_KBCOUT17       0x00100404
+#define GPIO_PS1_M0FAULT1       0x00100406
+#define GPIO_PS1_LPC0RESET_N    0x0010040D
+#define GPIO_PS1_LCDDATA21      0x0010040F
+
+#define GPIO_PS2_U1DSR          0x00100801
+#define GPIO_PS2_T3CCP0         0x00100803
+#define GPIO_PS2_KBCOUT18       0x00100804
+#define GPIO_PS2_M0FAULT2       0x00100806
+#define GPIO_PS2_LCDDATA22      0x0010080F
+
+#define GPIO_PS3_T3CCP1         0x00100C03
+#define GPIO_PS3_KBCOUT19       0x00100C04
+#define GPIO_PS3_M0FAULT3       0x00100C06
+#define GPIO_PS3_LCDDATA23      0x00100C0F
+
+#define GPIO_PS4_T4CCP0         0x00101003
+#define GPIO_PS4_KBCIN07        0x00101004
+#define GPIO_PS4_PHA0           0x00101006
+#define GPIO_PS4_EN0TXD0        0x0010100E
+#define GPIO_PS4_LCDDATA06      0x0010100F
+
+#define GPIO_PS5_T4CCP1         0x00101403
+#define GPIO_PS5_KBCIN06        0x00101404
+#define GPIO_PS5_PHB0           0x00101406
+#define GPIO_PS5_EN0TXD1        0x0010140E
+#define GPIO_PS5_LCDDATA07      0x0010140F
+
+#define GPIO_PS6_T5CCP0         0x00101803
+#define GPIO_PS6_KBCIN05        0x00101804
+#define GPIO_PS6_IDX0           0x00101806
+#define GPIO_PS6_EN0RXER        0x0010180E
+#define GPIO_PS6_LCDDATA08      0x0010180F
+
+#define GPIO_PS7_T5CCP1         0x00101C03
+#define GPIO_PS7_KBCIN04        0x00101C04
+#define GPIO_PS7_EN0RXDV        0x00101C0E
+#define GPIO_PS7_LCDDATA09      0x00101C0F
+
+#define GPIO_PT0_T6CCP0         0x00110003
+#define GPIO_PT0_KBCIN03        0x00110004
+#define GPIO_PT0_CAN0RX         0x00110007
+#define GPIO_PT0_EN0RXD0        0x0011000E
+#define GPIO_PT0_LCDDATA10      0x0011000F
+
+#define GPIO_PT1_T6CCP1         0x00110403
+#define GPIO_PT1_KBCIN02        0x00110404
+#define GPIO_PT1_CAN0TX         0x00110407
+#define GPIO_PT1_EN0RXD1        0x0011040E
+#define GPIO_PT1_LCDDATA11      0x0011040F
+
+#define GPIO_PT2_T7CCP0         0x00110803
+#define GPIO_PT2_KBCIN01        0x00110804
+#define GPIO_PT2_CAN1RX         0x00110807
+#define GPIO_PT2_LCDDATA18      0x0011080F
+
+#define GPIO_PT3_T7CCP1         0x00110C03
+#define GPIO_PT3_KBCIN00        0x00110C04
+#define GPIO_PT3_CAN1TX         0x00110C07
+#define GPIO_PT3_LCDDATA19      0x00110C0F
+
+#endif // PART_TM4C129XNCZAD
+
+#endif // __DRIVERLIB_PIN_MAP_H__

--- a/cpu/tm4c123/include/driverlib/rom.h
+++ b/cpu/tm4c123/include/driverlib/rom.h
@@ -1,0 +1,7125 @@
+//*****************************************************************************
+//
+// rom.h - Macros to facilitate calling functions in the ROM.
+//
+// Copyright (c) 2007-2013 Texas Instruments Incorporated.  All rights reserved.
+// Software License Agreement
+// 
+//   Redistribution and use in source and binary forms, with or without
+//   modification, are permitted provided that the following conditions
+//   are met:
+// 
+//   Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+// 
+//   Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the  
+//   distribution.
+// 
+//   Neither the name of Texas Instruments Incorporated nor the names of
+//   its contributors may be used to endorse or promote products derived
+//   from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// This is part of revision 2.0.1.11577 of the Tiva Peripheral Driver Library.
+//
+//*****************************************************************************
+
+#ifndef __DRIVERLIB_ROM_H__
+#define __DRIVERLIB_ROM_H__
+
+//*****************************************************************************
+//
+// Pointers to the main API tables.
+//
+//*****************************************************************************
+#define ROM_APITABLE            ((uint32_t *)0x01000010)
+#define ROM_VERSION             (ROM_APITABLE[0])
+#define ROM_UARTTABLE           ((uint32_t *)(ROM_APITABLE[1]))
+#define ROM_SSITABLE            ((uint32_t *)(ROM_APITABLE[2]))
+#define ROM_I2CTABLE            ((uint32_t *)(ROM_APITABLE[3]))
+#define ROM_GPIOTABLE           ((uint32_t *)(ROM_APITABLE[4]))
+#define ROM_ADCTABLE            ((uint32_t *)(ROM_APITABLE[5]))
+#define ROM_COMPARATORTABLE     ((uint32_t *)(ROM_APITABLE[6]))
+#define ROM_FLASHTABLE          ((uint32_t *)(ROM_APITABLE[7]))
+#define ROM_PWMTABLE            ((uint32_t *)(ROM_APITABLE[8]))
+#define ROM_QEITABLE            ((uint32_t *)(ROM_APITABLE[9]))
+#define ROM_SYSTICKTABLE        ((uint32_t *)(ROM_APITABLE[10]))
+#define ROM_TIMERTABLE          ((uint32_t *)(ROM_APITABLE[11]))
+#define ROM_WATCHDOGTABLE       ((uint32_t *)(ROM_APITABLE[12]))
+#define ROM_SYSCTLTABLE         ((uint32_t *)(ROM_APITABLE[13]))
+#define ROM_INTERRUPTTABLE      ((uint32_t *)(ROM_APITABLE[14]))
+#define ROM_USBTABLE            ((uint32_t *)(ROM_APITABLE[16]))
+#define ROM_UDMATABLE           ((uint32_t *)(ROM_APITABLE[17]))
+#define ROM_CANTABLE            ((uint32_t *)(ROM_APITABLE[18]))
+#define ROM_HIBERNATETABLE      ((uint32_t *)(ROM_APITABLE[19]))
+#define ROM_MPUTABLE            ((uint32_t *)(ROM_APITABLE[20]))
+#define ROM_SOFTWARETABLE       ((uint32_t *)(ROM_APITABLE[21]))
+#define ROM_EPITABLE            ((uint32_t *)(ROM_APITABLE[23]))
+#define ROM_EEPROMTABLE         ((uint32_t *)(ROM_APITABLE[24]))
+#define ROM_FANTABLE            ((uint32_t *)(ROM_APITABLE[25]))
+#define ROM_FPUTABLE            ((uint32_t *)(ROM_APITABLE[26]))
+#define ROM_LPCTABLE            ((uint32_t *)(ROM_APITABLE[27]))
+#define ROM_PECITABLE           ((uint32_t *)(ROM_APITABLE[28]))
+#define ROM_SMBUSTABLE          ((uint32_t *)(ROM_APITABLE[29]))
+#define ROM_SYSEXCTABLE         ((uint32_t *)(ROM_APITABLE[30]))
+#define ROM_CIRTABLE            ((uint32_t *)(ROM_APITABLE[31]))
+#define ROM_KBSCANTABLE         ((uint32_t *)(ROM_APITABLE[32]))
+#define ROM_LEDSEQTABLE         ((uint32_t *)(ROM_APITABLE[33]))
+#define ROM_ONEWIRETABLE        ((uint32_t *)(ROM_APITABLE[34]))
+#define ROM_PS2TABLE            ((uint32_t *)(ROM_APITABLE[36]))
+#define ROM_SPIFLASHTABLE       ((uint32_t *)(ROM_APITABLE[38]))
+#define ROM_LPCBTABLE           ((uint32_t *)(ROM_APITABLE[40]))
+#define ROM_LCDTABLE            ((uint32_t *)(ROM_APITABLE[41]))
+#define ROM_EMACTABLE           ((uint32_t *)(ROM_APITABLE[42]))
+#define ROM_AESTABLE            ((uint32_t *)(ROM_APITABLE[43]))
+#define ROM_CRCTABLE            ((uint32_t *)(ROM_APITABLE[44]))
+#define ROM_DESTABLE            ((uint32_t *)(ROM_APITABLE[45]))
+#define ROM_SHAMD5TABLE         ((uint32_t *)(ROM_APITABLE[46]))
+#define ROM_PORT80TABLE         ((uint32_t *)(ROM_APITABLE[47]))
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the ADC API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCSequenceDataGet                                                \
+        ((int32_t (*)(uint32_t ui32Base,                                      \
+                      uint32_t ui32SequenceNum,                               \
+                      uint32_t *pui32Buffer))ROM_ADCTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCIntDisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32SequenceNum))ROM_ADCTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCIntEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32SequenceNum))ROM_ADCTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCIntStatus                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32SequenceNum,                              \
+                       bool bMasked))ROM_ADCTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCIntClear                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32SequenceNum))ROM_ADCTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCSequenceEnable                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32SequenceNum))ROM_ADCTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCSequenceDisable                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32SequenceNum))ROM_ADCTABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCSequenceConfigure                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32SequenceNum,                                  \
+                   uint32_t ui32Trigger,                                      \
+                   uint32_t ui32Priority))ROM_ADCTABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCSequenceStepConfigure                                          \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32SequenceNum,                                  \
+                   uint32_t ui32Step,                                         \
+                   uint32_t ui32Config))ROM_ADCTABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCSequenceOverflow                                               \
+        ((int32_t (*)(uint32_t ui32Base,                                      \
+                      uint32_t ui32SequenceNum))ROM_ADCTABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCSequenceOverflowClear                                          \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32SequenceNum))ROM_ADCTABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCSequenceUnderflow                                              \
+        ((int32_t (*)(uint32_t ui32Base,                                      \
+                      uint32_t ui32SequenceNum))ROM_ADCTABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCSequenceUnderflowClear                                         \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32SequenceNum))ROM_ADCTABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCProcessorTrigger                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32SequenceNum))ROM_ADCTABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCHardwareOversampleConfigure                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Factor))ROM_ADCTABLE[14])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCComparatorConfigure                                            \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Comp,                                         \
+                   uint32_t ui32Config))ROM_ADCTABLE[15])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCComparatorRegionSet                                            \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Comp,                                         \
+                   uint32_t ui32LowRef,                                       \
+                   uint32_t ui32HighRef))ROM_ADCTABLE[16])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCComparatorReset                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Comp,                                         \
+                   bool bTrigger,                                             \
+                   bool bInterrupt))ROM_ADCTABLE[17])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCComparatorIntDisable                                           \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32SequenceNum))ROM_ADCTABLE[18])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCComparatorIntEnable                                            \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32SequenceNum))ROM_ADCTABLE[19])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCComparatorIntStatus                                            \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_ADCTABLE[20])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCComparatorIntClear                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Status))ROM_ADCTABLE[21])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCReferenceSet                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Ref))ROM_ADCTABLE[22])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCReferenceGet                                                   \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_ADCTABLE[23])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCPhaseDelaySet                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Phase))ROM_ADCTABLE[24])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCPhaseDelayGet                                                  \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_ADCTABLE[25])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCIntClearEx                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_ADCTABLE[28])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCIntDisableEx                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_ADCTABLE[29])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCIntEnableEx                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_ADCTABLE[30])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCIntStatusEx                                                    \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_ADCTABLE[31])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCSequenceDMAEnable                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32SequenceNum))ROM_ADCTABLE[32])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCSequenceDMADisable                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32SequenceNum))ROM_ADCTABLE[33])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ADCBusy                                                           \
+        ((bool (*)(uint32_t ui32Base))ROM_ADCTABLE[34])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the AES API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESIntStatus                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_AESTABLE[0])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESAuthLengthSet                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Length))ROM_AESTABLE[1])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESConfigSet                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_AESTABLE[2])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESDataAuth                                                       \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Src,                                        \
+                   uint32_t ui32Length,                                       \
+                   uint32_t *pui32Tag))ROM_AESTABLE[3])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESDataProcess                                                    \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Src,                                        \
+                   uint32_t *pui32Dest,                                       \
+                   uint32_t ui32Length))ROM_AESTABLE[4])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESDataProcessAuth                                                \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Src,                                        \
+                   uint32_t *pui32Dest,                                       \
+                   uint32_t ui32Length,                                       \
+                   uint32_t *pui32AuthSrc,                                    \
+                   uint32_t ui32AuthLength,                                   \
+                   uint32_t *pui32Tag))ROM_AESTABLE[5])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESDataRead                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Dest))ROM_AESTABLE[6])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESDataReadNonBlocking                                            \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Dest))ROM_AESTABLE[7])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESDataWrite                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Src))ROM_AESTABLE[8])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESDataWriteNonBlocking                                           \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Src))ROM_AESTABLE[9])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESDMADisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Flags))ROM_AESTABLE[10])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESDMAEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Flags))ROM_AESTABLE[11])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESIntClear                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_AESTABLE[12])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESIntDisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_AESTABLE[13])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESIntEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_AESTABLE[14])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESIVSet                                                          \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32IVdata))ROM_AESTABLE[15])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESKey1Set                                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Key,                                        \
+                   uint32_t ui32Keysize))ROM_AESTABLE[16])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESKey2Set                                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Key,                                        \
+                   uint32_t ui32Keysize))ROM_AESTABLE[17])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESKey3Set                                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Key))ROM_AESTABLE[18])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESLengthSet                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint64_t ui64Length))ROM_AESTABLE[19])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESReset                                                          \
+        ((void (*)(uint32_t ui32Base))ROM_AESTABLE[20])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_AESTagRead                                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32TagData))ROM_AESTABLE[21])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the CAN API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANIntClear                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntClr))ROM_CANTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANInit                                                           \
+        ((void (*)(uint32_t ui32Base))ROM_CANTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANEnable                                                         \
+        ((void (*)(uint32_t ui32Base))ROM_CANTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANDisable                                                        \
+        ((void (*)(uint32_t ui32Base))ROM_CANTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANBitTimingSet                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   tCANBitClkParms *psClkParms))ROM_CANTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANBitTimingGet                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   tCANBitClkParms *psClkParms))ROM_CANTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANMessageSet                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32ObjID,                                        \
+                   tCANMsgObject *psMsgObject,                                \
+                   tMsgObjType eMsgType))ROM_CANTABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANMessageGet                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32ObjID,                                        \
+                   tCANMsgObject *psMsgObject,                                \
+                   bool bClrPendingInt))ROM_CANTABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANStatusGet                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       tCANStsReg eStatusReg))ROM_CANTABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANMessageClear                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32ObjID))ROM_CANTABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANIntEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_CANTABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANIntDisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_CANTABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANIntStatus                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       tCANIntStsReg eIntStsReg))ROM_CANTABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANRetryGet                                                       \
+        ((bool (*)(uint32_t ui32Base))ROM_CANTABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANRetrySet                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   bool bAutoRetry))ROM_CANTABLE[14])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANErrCntrGet                                                     \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32RxCount,                                    \
+                   uint32_t *pui32TxCount))ROM_CANTABLE[15])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CANBitRateSet                                                     \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32SourceClock,                              \
+                       uint32_t ui32BitRate))ROM_CANTABLE[16])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the CIR API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CIRIntStatus                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_CIRTABLE[0])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CIRConfigGet                                                      \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_CIRTABLE[1])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CIRConfigSet                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_CIRTABLE[2])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CIRIntClear                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_CIRTABLE[3])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CIRIntDisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_CIRTABLE[4])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CIRIntEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_CIRTABLE[5])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CIRRxCountGet                                                     \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t *pui32Output,                                 \
+                       uint32_t *pui32Silence))ROM_CIRTABLE[6])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CIRRxDisable                                                      \
+        ((void (*)(uint32_t ui32Base))ROM_CIRTABLE[7])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CIRRxEnable                                                       \
+        ((void (*)(uint32_t ui32Base))ROM_CIRTABLE[8])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CIRRxMinMaxSet                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8Min10uS,                                        \
+                   uint8_t ui8MaxOutput50uS,                                  \
+                   uint8_t ui8MaxSilence50uS,                                 \
+                   bool bMaxSilenceIsError))ROM_CIRTABLE[9])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CIRRxStatusGet                                                    \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_CIRTABLE[10])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CIRRxWaitForOutput                                                \
+        ((void (*)(uint32_t ui32Base))ROM_CIRTABLE[11])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CIRTxDisable                                                      \
+        ((void (*)(uint32_t ui32Base))ROM_CIRTABLE[12])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CIRTxEnable                                                       \
+        ((void (*)(uint32_t ui32Base))ROM_CIRTABLE[13])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CIRTxCountSet                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Output,                                       \
+                   uint32_t ui32Silence))ROM_CIRTABLE[14])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CIRTxStatusGet                                                    \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_CIRTABLE[15])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the Comparator API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ComparatorIntClear                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Comp))ROM_COMPARATORTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ComparatorConfigure                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Comp,                                         \
+                   uint32_t ui32Config))ROM_COMPARATORTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ComparatorRefSet                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Ref))ROM_COMPARATORTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ComparatorValueGet                                                \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Comp))ROM_COMPARATORTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ComparatorIntEnable                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Comp))ROM_COMPARATORTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ComparatorIntDisable                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Comp))ROM_COMPARATORTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_ComparatorIntStatus                                               \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Comp,                                         \
+                   bool bMasked))ROM_COMPARATORTABLE[6])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the CRC API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CRCConfigSet                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32CRCConfig))ROM_CRCTABLE[0])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CRCDataProcess                                                    \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t *pui32DataIn,                                 \
+                       uint32_t ui32DataLength,                               \
+                       bool bPPResult))ROM_CRCTABLE[1])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CRCDataWrite                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Data))ROM_CRCTABLE[2])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CRCResultRead                                                     \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bPPResult))ROM_CRCTABLE[3])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_CRCSeedSet                                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Seed))ROM_CRCTABLE[4])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the DES API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_DESIntStatus                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_DESTABLE[0])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_DESConfigSet                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_DESTABLE[1])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_DESDataRead                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Dest))ROM_DESTABLE[2])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_DESDataReadNonBlocking                                            \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Dest))ROM_DESTABLE[3])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_DESDataProcess                                                    \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Src,                                        \
+                   uint32_t *pui32Dest,                                       \
+                   uint32_t ui32Length))ROM_DESTABLE[4])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_DESDataWrite                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Src))ROM_DESTABLE[5])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_DESDataWriteNonBlocking                                           \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Src))ROM_DESTABLE[6])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_DESDMADisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Flags))ROM_DESTABLE[7])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_DESDMAEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Flags))ROM_DESTABLE[8])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_DESIntClear                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_DESTABLE[9])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_DESIntDisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_DESTABLE[10])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_DESIntEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_DESTABLE[11])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_DESIVSet                                                          \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32IVdata))ROM_DESTABLE[12])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_DESKeySet                                                         \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Key))ROM_DESTABLE[13])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_DESLengthSet                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Length))ROM_DESTABLE[14])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_DESReset                                                          \
+        ((void (*)(uint32_t ui32Base))ROM_DESTABLE[15])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the EEPROM API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMRead                                                        \
+        ((void (*)(uint32_t *pui32Data,                                       \
+                   uint32_t ui32Address,                                      \
+                   uint32_t ui32Count))ROM_EEPROMTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMBlockCountGet                                               \
+        ((uint32_t (*)(void))ROM_EEPROMTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMBlockHide                                                   \
+        ((void (*)(uint32_t ui32Block))ROM_EEPROMTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMBlockLock                                                   \
+        ((uint32_t (*)(uint32_t ui32Block))ROM_EEPROMTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMBlockPasswordSet                                            \
+        ((uint32_t (*)(uint32_t ui32Block,                                    \
+                       uint32_t *pui32Password,                               \
+                       uint32_t ui32Count))ROM_EEPROMTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMBlockProtectGet                                             \
+        ((uint32_t (*)(uint32_t ui32Block))ROM_EEPROMTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMBlockProtectSet                                             \
+        ((uint32_t (*)(uint32_t ui32Block,                                    \
+                       uint32_t ui32Protect))ROM_EEPROMTABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMBlockUnlock                                                 \
+        ((uint32_t (*)(uint32_t ui32Block,                                    \
+                       uint32_t *pui32Password,                               \
+                       uint32_t ui32Count))ROM_EEPROMTABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMIntClear                                                    \
+        ((void (*)(uint32_t ui32IntFlags))ROM_EEPROMTABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMIntDisable                                                  \
+        ((void (*)(uint32_t ui32IntFlags))ROM_EEPROMTABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMIntEnable                                                   \
+        ((void (*)(uint32_t ui32IntFlags))ROM_EEPROMTABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMIntStatus                                                   \
+        ((uint32_t (*)(bool bMasked))ROM_EEPROMTABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_EEPROMMassErase                                                   \
+        ((uint32_t (*)(void))ROM_EEPROMTABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMProgram                                                     \
+        ((uint32_t (*)(uint32_t *pui32Data,                                   \
+                       uint32_t ui32Address,                                  \
+                       uint32_t ui32Count))ROM_EEPROMTABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMProgramNonBlocking                                          \
+        ((uint32_t (*)(uint32_t ui32Data,                                     \
+                       uint32_t ui32Address))ROM_EEPROMTABLE[14])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMSizeGet                                                     \
+        ((uint32_t (*)(void))ROM_EEPROMTABLE[15])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMStatusGet                                                   \
+        ((uint32_t (*)(void))ROM_EEPROMTABLE[16])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EEPROMInit                                                        \
+        ((uint32_t (*)(void))ROM_EEPROMTABLE[17])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the EPI API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIIntStatus                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_EPITABLE[0])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIModeSet                                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Mode))ROM_EPITABLE[1])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIDividerSet                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Divider))ROM_EPITABLE[2])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIConfigSDRAMSet                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config,                                       \
+                   uint32_t ui32Refresh))ROM_EPITABLE[3])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIConfigGPModeSet                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config,                                       \
+                   uint32_t ui32FrameCount,                                   \
+                   uint32_t ui32MaxWait))ROM_EPITABLE[4])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIConfigHB8Set                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config,                                       \
+                   uint32_t ui32MaxWait))ROM_EPITABLE[5])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIConfigHB16Set                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config,                                       \
+                   uint32_t ui32MaxWait))ROM_EPITABLE[6])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIAddressMapSet                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Map))ROM_EPITABLE[7])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPINonBlockingReadConfigure                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint32_t ui32DataSize,                                     \
+                   uint32_t ui32Address))ROM_EPITABLE[8])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPINonBlockingReadStart                                           \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint32_t ui32Count))ROM_EPITABLE[9])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPINonBlockingReadStop                                            \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel))ROM_EPITABLE[10])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPINonBlockingReadCount                                           \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Channel))ROM_EPITABLE[11])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPINonBlockingReadAvail                                           \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_EPITABLE[12])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPINonBlockingReadGet32                                           \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Count,                                    \
+                       uint32_t *pui32Buf))ROM_EPITABLE[13])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPINonBlockingReadGet16                                           \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Count,                                    \
+                       uint16_t *pui16Buf))ROM_EPITABLE[14])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPINonBlockingReadGet8                                            \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Count,                                    \
+                       uint8_t *pui8Buf))ROM_EPITABLE[15])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIFIFOConfig                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_EPITABLE[16])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIWriteFIFOCountGet                                              \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_EPITABLE[17])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIIntEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_EPITABLE[18])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIIntDisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_EPITABLE[19])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIIntErrorStatus                                                 \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_EPITABLE[20])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIIntErrorClear                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32ErrFlags))ROM_EPITABLE[21])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIDividerCSSet                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32CS,                                           \
+                   uint32_t ui32Divider))ROM_EPITABLE[22])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIDMATxCount                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Count))ROM_EPITABLE[23])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIConfigHB8CSSet                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32CS,                                           \
+                   uint32_t ui32Config))ROM_EPITABLE[24])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIConfigHB16CSSet                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32CS,                                           \
+                   uint32_t ui32Config))ROM_EPITABLE[25])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIConfigHB8TimingSet                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32CS,                                           \
+                   uint32_t ui32Config))ROM_EPITABLE[26])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIConfigHB16TimingSet                                            \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32CS,                                           \
+                   uint32_t ui32Config))ROM_EPITABLE[27])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIPSRAMConfigRegSet                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32CS,                                           \
+                   uint32_t ui32CR))ROM_EPITABLE[28])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIPSRAMConfigRegRead                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32CS))ROM_EPITABLE[29])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIPSRAMConfigRegGetNonBlocking                                   \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32CS,                                           \
+                   uint32_t *pui32CR))ROM_EPITABLE[30])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EPIPSRAMConfigRegGet                                              \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32CS))ROM_EPITABLE[31])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the EMAC API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACIntStatus                                                     \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_EMACTABLE[0])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACAddrGet                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Index,                                        \
+                   uint8_t *pui8MACAddr))ROM_EMACTABLE[1])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACAddrSet                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Index,                                        \
+                   const uint8_t *pui8MACAddr))ROM_EMACTABLE[2])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACConfigGet                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Config,                                     \
+                   uint32_t *pui32Mode,                                       \
+                   uint32_t *pui32RxMaxFrameSize))ROM_EMACTABLE[3])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACConfigSet                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config,                                       \
+                   uint32_t ui32ModeFlags,                                    \
+                   uint32_t ui32RxMaxFrameSize))ROM_EMACTABLE[4])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACDMAStateGet                                                   \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_EMACTABLE[5])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACFrameFilterGet                                                \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_EMACTABLE[6])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACFrameFilterSet                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32FilterOpts))ROM_EMACTABLE[7])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACInit                                                          \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32SysClk,                                       \
+                   uint32_t ui32BusConfig,                                    \
+                   uint32_t ui32RxBurst,                                      \
+                   uint32_t ui32TxBurst,                                      \
+                   uint32_t ui32DescSkipSize))ROM_EMACTABLE[8])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACIntClear                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_EMACTABLE[9])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACIntDisable                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_EMACTABLE[10])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACIntEnable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_EMACTABLE[11])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACPHYConfigSet                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_EMACTABLE[12])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACPHYPowerOff                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8PhyAddr))ROM_EMACTABLE[13])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACPHYPowerOn                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8PhyAddr))ROM_EMACTABLE[14])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACPHYRead                                                       \
+        ((uint16_t (*)(uint32_t ui32Base,                                     \
+                        uint8_t ui8PhyAddr,                                   \
+                       uint8_t ui8RegAddr))ROM_EMACTABLE[15])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACPHYWrite                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8PhyAddr,                                        \
+                   uint8_t ui8RegAddr,                                        \
+                   uint16_t ui16Data))ROM_EMACTABLE[16])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACReset                                                         \
+        ((void (*)(uint32_t ui32Base))ROM_EMACTABLE[17])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACRxDisable                                                     \
+        ((void (*)(uint32_t ui32Base))ROM_EMACTABLE[18])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACRxDMACurrentBufferGet                                         \
+        ((uint8_t * (*)(uint32_t ui32Base))ROM_EMACTABLE[19])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACRxDMACurrentDescriptorGet                                     \
+        ((tEMACDMADescriptor * (*)(uint32_t ui32Base))ROM_EMACTABLE[20])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACRxDMADescriptorListGet                                        \
+        ((tEMACDMADescriptor * (*)(uint32_t ui32Base))ROM_EMACTABLE[21])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACRxDMADescriptorListSet                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   tEMACDMADescriptor *pDescriptor))ROM_EMACTABLE[22])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACRxDMAPollDemand                                               \
+        ((void (*)(uint32_t ui32Base))ROM_EMACTABLE[23])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACRxEnable                                                      \
+        ((void (*)(uint32_t ui32Base))ROM_EMACTABLE[24])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACRxWatchdogTimerSet                                            \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8Timeout))ROM_EMACTABLE[25])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACStatusGet                                                     \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_EMACTABLE[26])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACTxDisable                                                     \
+        ((void (*)(uint32_t ui32Base))ROM_EMACTABLE[27])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACTxDMACurrentBufferGet                                         \
+        ((uint8_t * (*)(uint32_t ui32Base))ROM_EMACTABLE[28])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACTxDMACurrentDescriptorGet                                     \
+        ((tEMACDMADescriptor * (*)(uint32_t ui32Base))ROM_EMACTABLE[29])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACTxDMADescriptorListGet                                        \
+        ((tEMACDMADescriptor * (*)(uint32_t ui32Base))ROM_EMACTABLE[30])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACTxDMADescriptorListSet                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   tEMACDMADescriptor *pDescriptor))ROM_EMACTABLE[31])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACTxDMAPollDemand                                               \
+        ((void (*)(uint32_t ui32Base))ROM_EMACTABLE[32])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACTxEnable                                                      \
+        ((void (*)(uint32_t ui32Base))ROM_EMACTABLE[33])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACTxFlush                                                       \
+        ((void (*)(uint32_t ui32Base))ROM_EMACTABLE[34])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_EMACHashFilterSet                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32HashHi,                                       \
+                   uint32_t ui32HashLo))ROM_EMACTABLE[39])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the Fan API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FanIntClear                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Flags))ROM_FANTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FanChannelConfigAuto                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint32_t ui32Config))ROM_FANTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FanChannelConfigManual                                            \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint32_t ui32Config))ROM_FANTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FanChannelDisable                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel))ROM_FANTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FanChannelDutyGet                                                 \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Channel))ROM_FANTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FanChannelDutySet                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint32_t ui32Duty))ROM_FANTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FanChannelEnable                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel))ROM_FANTABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FanChannelRPMGet                                                  \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Channel))ROM_FANTABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FanChannelRPMSet                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint32_t ui32RPM))ROM_FANTABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FanChannelStatus                                                  \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Channel))ROM_FANTABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FanChannelsGet                                                    \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_FANTABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FanIntDisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Flags))ROM_FANTABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FanIntEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Flags))ROM_FANTABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FanIntStatus                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_FANTABLE[13])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FanFractionalRPMDisable                                           \
+        ((void (*)(uint32_t ui32Base))ROM_FANTABLE[14])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FanFractionalRPMEnable                                            \
+        ((void (*)(uint32_t ui32Base))ROM_FANTABLE[15])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the Flash API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FlashProgram                                                      \
+        ((int32_t (*)(uint32_t *pui32Data,                                    \
+                      uint32_t ui32Address,                                   \
+                      uint32_t ui32Count))ROM_FLASHTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FlashErase                                                        \
+        ((int32_t (*)(uint32_t ui32Address))ROM_FLASHTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FlashProtectGet                                                   \
+        ((tFlashProtection (*)(uint32_t ui32Address))ROM_FLASHTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FlashProtectSet                                                   \
+        ((int32_t (*)(uint32_t ui32Address,                                   \
+                      tFlashProtection eProtect))ROM_FLASHTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FlashProtectSave                                                  \
+        ((int32_t (*)(void))ROM_FLASHTABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FlashUserGet                                                      \
+        ((int32_t (*)(uint32_t *pui32User0,                                   \
+                      uint32_t *pui32User1))ROM_FLASHTABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FlashUserSet                                                      \
+        ((int32_t (*)(uint32_t ui32User0,                                     \
+                      uint32_t ui32User1))ROM_FLASHTABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FlashUserSave                                                     \
+        ((int32_t (*)(void))ROM_FLASHTABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FlashIntEnable                                                    \
+        ((void (*)(uint32_t ui32IntFlags))ROM_FLASHTABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FlashIntDisable                                                   \
+        ((void (*)(uint32_t ui32IntFlags))ROM_FLASHTABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FlashIntStatus                                                    \
+        ((uint32_t (*)(bool bMasked))ROM_FLASHTABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FlashIntClear                                                     \
+        ((void (*)(uint32_t ui32IntFlags))ROM_FLASHTABLE[13])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the FPU API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FPUEnable                                                         \
+        ((void (*)(void))ROM_FPUTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FPUDisable                                                        \
+        ((void (*)(void))ROM_FPUTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FPUFlushToZeroModeSet                                             \
+        ((void (*)(uint32_t ui32Mode))ROM_FPUTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FPUHalfPrecisionModeSet                                           \
+        ((void (*)(uint32_t ui32Mode))ROM_FPUTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FPULazyStackingEnable                                             \
+        ((void (*)(void))ROM_FPUTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FPUNaNModeSet                                                     \
+        ((void (*)(uint32_t ui32Mode))ROM_FPUTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FPURoundingModeSet                                                \
+        ((void (*)(uint32_t ui32Mode))ROM_FPUTABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FPUStackingDisable                                                \
+        ((void (*)(void))ROM_FPUTABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_FPUStackingEnable                                                 \
+        ((void (*)(void))ROM_FPUTABLE[8])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the GPIO API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinWrite                                                      \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins,                                           \
+                   uint8_t ui8Val))ROM_GPIOTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIODirModeSet                                                    \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins,                                           \
+                   uint32_t ui32PinIO))ROM_GPIOTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIODirModeGet                                                    \
+        ((uint32_t (*)(uint32_t ui32Port,                                     \
+                       uint8_t ui8Pin))ROM_GPIOTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOIntTypeSet                                                    \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins,                                           \
+                   uint32_t ui32IntType))ROM_GPIOTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOIntTypeGet                                                    \
+        ((uint32_t (*)(uint32_t ui32Port,                                     \
+                       uint8_t ui8Pin))ROM_GPIOTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPadConfigSet                                                  \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins,                                           \
+                   uint32_t ui32Strength,                                     \
+                   uint32_t ui32PadType))ROM_GPIOTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPadConfigGet                                                  \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pin,                                            \
+                   uint32_t *pui32Strength,                                   \
+                   uint32_t *pui32PadType))ROM_GPIOTABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinRead                                                       \
+        ((int32_t (*)(uint32_t ui32Port,                                      \
+                      uint8_t ui8Pins))ROM_GPIOTABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeCAN                                                    \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeComparator                                             \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeGPIOInput                                              \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[14])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeGPIOOutput                                             \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[15])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeI2C                                                    \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[16])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypePWM                                                    \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[17])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeQEI                                                    \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[18])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeSSI                                                    \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[19])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeTimer                                                  \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[20])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeUART                                                   \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[21])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeGPIOOutputOD                                           \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[22])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeADC                                                    \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[23])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeUSBDigital                                             \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[24])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinConfigure                                                  \
+        ((void (*)(uint32_t ui32PinConfig))ROM_GPIOTABLE[26])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeUSBAnalog                                              \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[28])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeEPI                                                    \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[29])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIODMATriggerEnable                                              \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[31])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIODMATriggerDisable                                             \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[32])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOADCTriggerEnable                                              \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[33])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOADCTriggerDisable                                             \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[34])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeFan                                                    \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[35])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeLPC                                                    \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[36])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_GPIOPinTypePECIRx                                                 \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[37])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_GPIOPinTypePECITx                                                 \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[38])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeI2CSCL                                                 \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[39])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeCIR                                                    \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[40])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeKBRow                                                  \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[41])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeKBColumn                                               \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[42])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeLEDSeq                                                 \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[43])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeOneWire                                                \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[44])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypePS2                                                    \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[46])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeWakeHigh                                               \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[48])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeWakeLow                                                \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[49])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypePECIAnalog                                             \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[50])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOIntClear                                                      \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint32_t ui32IntFlags))ROM_GPIOTABLE[51])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOIntDisable                                                    \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint32_t ui32IntFlags))ROM_GPIOTABLE[52])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOIntEnable                                                     \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint32_t ui32IntFlags))ROM_GPIOTABLE[53])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOIntStatus                                                     \
+        ((uint32_t (*)(uint32_t ui32Port,                                     \
+                       bool bMasked))ROM_GPIOTABLE[54])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinWakeStatus                                                 \
+        ((uint32_t (*)(uint32_t ui32Port))ROM_GPIOTABLE[55])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_GPIOPinTypeLCD                                                    \
+        ((void (*)(uint32_t ui32Port,                                         \
+                   uint8_t ui8Pins))ROM_GPIOTABLE[56])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the Hibernate API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateIntClear                                                 \
+        ((void (*)(uint32_t ui32IntFlags))ROM_HIBERNATETABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateEnableExpClk                                             \
+        ((void (*)(uint32_t ui32HibClk))ROM_HIBERNATETABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateDisable                                                  \
+        ((void (*)(void))ROM_HIBERNATETABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateRTCEnable                                                \
+        ((void (*)(void))ROM_HIBERNATETABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateRTCDisable                                               \
+        ((void (*)(void))ROM_HIBERNATETABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateWakeSet                                                  \
+        ((void (*)(uint32_t ui32WakeFlags))ROM_HIBERNATETABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateWakeGet                                                  \
+        ((uint32_t (*)(void))ROM_HIBERNATETABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateLowBatSet                                                \
+        ((void (*)(uint32_t ui32LowBatFlags))ROM_HIBERNATETABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateLowBatGet                                                \
+        ((uint32_t (*)(void))ROM_HIBERNATETABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateRTCSet                                                   \
+        ((void (*)(uint32_t ui32RTCValue))ROM_HIBERNATETABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateRTCGet                                                   \
+        ((uint32_t (*)(void))ROM_HIBERNATETABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateRTCTrimSet                                               \
+        ((void (*)(uint32_t ui32Trim))ROM_HIBERNATETABLE[16])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateRTCTrimGet                                               \
+        ((uint32_t (*)(void))ROM_HIBERNATETABLE[17])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateDataSet                                                  \
+        ((void (*)(uint32_t *pui32Data,                                       \
+                   uint32_t ui32Count))ROM_HIBERNATETABLE[18])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateDataGet                                                  \
+        ((void (*)(uint32_t *pui32Data,                                       \
+                   uint32_t ui32Count))ROM_HIBERNATETABLE[19])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateRequest                                                  \
+        ((void (*)(void))ROM_HIBERNATETABLE[20])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateIntEnable                                                \
+        ((void (*)(uint32_t ui32IntFlags))ROM_HIBERNATETABLE[21])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateIntDisable                                               \
+        ((void (*)(uint32_t ui32IntFlags))ROM_HIBERNATETABLE[22])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateIntStatus                                                \
+        ((uint32_t (*)(bool bMasked))ROM_HIBERNATETABLE[23])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateIsActive                                                 \
+        ((uint32_t (*)(void))ROM_HIBERNATETABLE[24])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateRTCSSGet                                                 \
+        ((uint32_t (*)(void))ROM_HIBERNATETABLE[27])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateClockConfig                                              \
+        ((void (*)(uint32_t ui32Config))ROM_HIBERNATETABLE[28])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateBatCheckStart                                            \
+        ((void (*)(void))ROM_HIBERNATETABLE[29])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateBatCheckDone                                             \
+        ((uint32_t (*)(void))ROM_HIBERNATETABLE[30])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateGPIORetentionEnable                                      \
+        ((void (*)(void))ROM_HIBERNATETABLE[31])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateGPIORetentionDisable                                     \
+        ((void (*)(void))ROM_HIBERNATETABLE[32])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateGPIORetentionGet                                         \
+        ((bool (*)(void))ROM_HIBERNATETABLE[33])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateCounterMode                                              \
+        ((void (*)(uint32_t ui32Config))ROM_HIBERNATETABLE[34])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateCalendarSet                                              \
+        ((void (*)(struct tm *psTime))ROM_HIBERNATETABLE[35])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateCalendarGet                                              \
+        ((int (*)(struct tm *psTime))ROM_HIBERNATETABLE[36])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateCalendarMatchSet                                         \
+        ((void (*)(uint32_t ui32Index,                                        \
+                   struct tm *psTime))ROM_HIBERNATETABLE[37])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateCalendarMatchGet                                         \
+        ((void (*)(uint32_t ui32Index,                                        \
+                   struct tm *psTime))ROM_HIBERNATETABLE[38])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateTamperDisable                                            \
+        ((void (*)(void))ROM_HIBERNATETABLE[39])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateTamperEnable                                             \
+        ((void (*)(void))ROM_HIBERNATETABLE[40])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateTamperEventsClear                                        \
+        ((void (*)(void))ROM_HIBERNATETABLE[41])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateTamperEventsConfig                                       \
+        ((void (*)(uint32_t ui32Config))ROM_HIBERNATETABLE[42])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateTamperEventsGet                                          \
+        ((bool (*)(uint32_t ui32Index,                                        \
+                   uint32_t *pui32RTC,                                        \
+                   uint32_t *pui32Event))ROM_HIBERNATETABLE[43])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateTamperExtOscValid                                        \
+        ((bool (*)(void))ROM_HIBERNATETABLE[44])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateTamperExtOscRecover                                      \
+        ((void (*)(void))ROM_HIBERNATETABLE[45])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateTamperIODisable                                          \
+        ((void (*)(uint32_t ui32Input))ROM_HIBERNATETABLE[46])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateTamperIOEnable                                           \
+        ((void (*)(uint32_t ui32Input,                                        \
+                   uint32_t ui32Config))ROM_HIBERNATETABLE[47])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateTamperStatusGet                                          \
+        ((uint32_t (*)(void))ROM_HIBERNATETABLE[48])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_HibernateRTCSSMatchGet                                            \
+        ((uint32_t (*)(uint32_t ui32Match))ROM_HIBERNATETABLE[51])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the I2C API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterDataPut                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8Data))ROM_I2CTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterInitExpClk                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32I2CClk,                                       \
+                   bool bFast))ROM_I2CTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterEnable                                                   \
+        ((void (*)(uint32_t ui32Base))ROM_I2CTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterDisable                                                  \
+        ((void (*)(uint32_t ui32Base))ROM_I2CTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterIntEnable                                                \
+        ((void (*)(uint32_t ui32Base))ROM_I2CTABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterIntDisable                                               \
+        ((void (*)(uint32_t ui32Base))ROM_I2CTABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterIntStatus                                                \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   bool bMasked))ROM_I2CTABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterIntClear                                                 \
+        ((void (*)(uint32_t ui32Base))ROM_I2CTABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterSlaveAddrSet                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8SlaveAddr,                                      \
+                   bool bReceive))ROM_I2CTABLE[15])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterBusy                                                     \
+        ((bool (*)(uint32_t ui32Base))ROM_I2CTABLE[16])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterBusBusy                                                  \
+        ((bool (*)(uint32_t ui32Base))ROM_I2CTABLE[17])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterControl                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Cmd))ROM_I2CTABLE[18])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterErr                                                      \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_I2CTABLE[19])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterDataGet                                                  \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_I2CTABLE[20])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UpdateI2C                                                         \
+        ((void (*)(void))ROM_I2CTABLE[24])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterIntEnableEx                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_I2CTABLE[29])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterIntDisableEx                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_I2CTABLE[30])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterIntStatusEx                                              \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_I2CTABLE[31])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterIntClearEx                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_I2CTABLE[32])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterTimeoutSet                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Value))ROM_I2CTABLE[33])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterLineStateGet                                             \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_I2CTABLE[38])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CTxFIFOConfigSet                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_I2CTABLE[39])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CTxFIFOFlush                                                    \
+        ((void (*)(uint32_t ui32Base))ROM_I2CTABLE[40])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CRxFIFOConfigSet                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_I2CTABLE[41])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CRxFIFOFlush                                                    \
+        ((void (*)(uint32_t ui32Base))ROM_I2CTABLE[42])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CFIFOStatus                                                     \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_I2CTABLE[43])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CFIFODataPut                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8Data))ROM_I2CTABLE[44])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CFIFODataPutNonBlocking                                         \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint8_t ui8Data))ROM_I2CTABLE[45])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CFIFODataGet                                                    \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_I2CTABLE[46])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CFIFODataGetNonBlocking                                         \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint8_t *pui8Data))ROM_I2CTABLE[47])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterBurstLengthSet                                           \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8Length))ROM_I2CTABLE[48])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterBurstCountGet                                            \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_I2CTABLE[49])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_I2CMasterGlitchFilterConfigSet                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_I2CTABLE[54])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the Interrupt API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_IntEnable                                                         \
+        ((void (*)(uint32_t ui32Interrupt))ROM_INTERRUPTTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_IntMasterEnable                                                   \
+        ((bool (*)(void))ROM_INTERRUPTTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_IntMasterDisable                                                  \
+        ((bool (*)(void))ROM_INTERRUPTTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_IntDisable                                                        \
+        ((void (*)(uint32_t ui32Interrupt))ROM_INTERRUPTTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_IntPriorityGroupingSet                                            \
+        ((void (*)(uint32_t ui32Bits))ROM_INTERRUPTTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_IntPriorityGroupingGet                                            \
+        ((uint32_t (*)(void))ROM_INTERRUPTTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_IntPrioritySet                                                    \
+        ((void (*)(uint32_t ui32Interrupt,                                    \
+                   uint8_t ui8Priority))ROM_INTERRUPTTABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_IntPriorityGet                                                    \
+        ((int32_t (*)(uint32_t ui32Interrupt))ROM_INTERRUPTTABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_IntPendSet                                                        \
+        ((void (*)(uint32_t ui32Interrupt))ROM_INTERRUPTTABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_IntPendClear                                                      \
+        ((void (*)(uint32_t ui32Interrupt))ROM_INTERRUPTTABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_IntPriorityMaskSet                                                \
+        ((void (*)(uint32_t ui32PriorityMask))ROM_INTERRUPTTABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_IntPriorityMaskGet                                                \
+        ((uint32_t (*)(void))ROM_INTERRUPTTABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_IntIsEnabled                                                      \
+        ((uint32_t (*)(uint32_t ui32Interrupt))ROM_INTERRUPTTABLE[12])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the KBScan API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_KBScanIntStatus                                                   \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_KBSCANTABLE[0])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_KBScanConfigGet                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t *pui8ScanRows,                                     \
+                   uint8_t *pui8ScanCols,                                     \
+                   uint16_t *pui16ScanRowDelayuS,                             \
+                   uint16_t *pui16ScanRatemS,                                 \
+                   uint32_t *pui32Flags))ROM_KBSCANTABLE[1])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_KBScanConfigSet                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8ScanRows,                                       \
+                   uint8_t ui8ScanCols,                                       \
+                   uint16_t ui16ScanRowDelayuS,                               \
+                   uint16_t ui16ScanRatemS,                                   \
+                   uint32_t ui32Flags))ROM_KBSCANTABLE[2])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_KBScanDisable                                                     \
+        ((void (*)(uint32_t ui32Base))ROM_KBSCANTABLE[3])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_KBScanEnable                                                      \
+        ((void (*)(uint32_t ui32Base))ROM_KBSCANTABLE[4])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_KBScanIntClear                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_KBSCANTABLE[5])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_KBScanIntDisable                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_KBSCANTABLE[6])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_KBScanIntEnable                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_KBSCANTABLE[7])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_KBScanStatusGet                                                   \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t *pui32RowChange,                              \
+                       uint8_t *pui32Cols))ROM_KBSCANTABLE[8])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_KBScanTrigger                                                     \
+        ((void (*)(uint32_t ui32Base))ROM_KBSCANTABLE[9])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the LCD API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDIntStatus                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_LCDTABLE[0])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDClockReset                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Clocks))ROM_LCDTABLE[1])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDDMAConfigSet                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_LCDTABLE[2])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDIDDCommandWrite                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32CS,                                           \
+                   uint16_t ui16Cmd))ROM_LCDTABLE[3])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDIDDConfigSet                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_LCDTABLE[4])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDIDDDataRead                                                    \
+        ((uint16_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32CS))ROM_LCDTABLE[5])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDIDDDataWrite                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32CS,                                           \
+                   uint16_t ui16Data))ROM_LCDTABLE[6])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDIDDDMADisable                                                  \
+        ((void (*)(uint32_t ui32Base))ROM_LCDTABLE[7])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDIDDDMAWrite                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32CS,                                           \
+                   const uint32_t *pui32Data,                                 \
+                   uint32_t ui32Count))ROM_LCDTABLE[8])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDIDDIndexedRead                                                 \
+        ((uint16_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32CS,                                       \
+                       uint16_t ui16Addr))ROM_LCDTABLE[9])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDIDDIndexedWrite                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32CS,                                           \
+                   uint16_t ui16Addr,                                         \
+                   uint16_t ui16Data))ROM_LCDTABLE[10])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDIDDStatusRead                                                  \
+        ((uint16_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32CS))ROM_LCDTABLE[11])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDIDDTimingSet                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32CS,                                           \
+                   const tLCDIDDTiming *pTiming))ROM_LCDTABLE[12])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDIntClear                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_LCDTABLE[13])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDIntDisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_LCDTABLE[14])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDIntEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_LCDTABLE[15])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDModeSet                                                        \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint8_t ui8Mode,                                       \
+                       uint32_t ui32PixClk,                                   \
+                       uint32_t ui32SysClk))ROM_LCDTABLE[16])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDRasterACBiasIntCountSet                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8Count))ROM_LCDTABLE[17])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDRasterConfigSet                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config,                                       \
+                   uint8_t ui8PalLoadDelay))ROM_LCDTABLE[18])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDRasterDisable                                                  \
+        ((void (*)(uint32_t ui32Base))ROM_LCDTABLE[19])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDRasterEnable                                                   \
+        ((void (*)(uint32_t ui32Base))ROM_LCDTABLE[20])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDRasterFrameBufferSet                                           \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8Buffer,                                         \
+                   uint32_t *pui32Addr,                                       \
+                   uint32_t ui32NumBytes))ROM_LCDTABLE[21])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDRasterPaletteSet                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Type,                                         \
+                   uint32_t *pui32PalAddr,                                    \
+                   const uint32_t *pui32SrcColors,                            \
+                   uint32_t ui32Start,                                        \
+                   uint32_t ui32Count))ROM_LCDTABLE[22])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDRasterSubPanelConfigSet                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Flags,                                        \
+                   uint32_t ui32BottomLines,                                  \
+                   uint32_t ui32DefaultPixel))ROM_LCDTABLE[23])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDRasterSubPanelDisable                                          \
+        ((void (*)(uint32_t ui32Base))ROM_LCDTABLE[24])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDRasterSubPanelEnable                                           \
+        ((void (*)(uint32_t ui32Base))ROM_LCDTABLE[25])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LCDRasterTimingSet                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   const tLCDRasterTiming *pTiming))ROM_LCDTABLE[26])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the LEDSeq API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LEDSeqIntStatus                                                   \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_LEDSEQTABLE[0])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LEDSeqConfigGet                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8Sequencer,                                      \
+                   uint8_t *pui8StepIndex,                                    \
+                   uint8_t *pui8NumSteps,                                     \
+                   uint32_t *pui32Flags))ROM_LEDSEQTABLE[1])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LEDSeqConfigSet                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8Sequencer,                                      \
+                   uint8_t ui8StepIndex,                                      \
+                   uint8_t ui8NumSteps,                                       \
+                   uint32_t ui32Flags))ROM_LEDSEQTABLE[2])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LEDSeqDisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8Sequence))ROM_LEDSEQTABLE[3])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LEDSeqEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8Sequence))ROM_LEDSEQTABLE[4])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LEDSeqIntClear                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_LEDSEQTABLE[5])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LEDSeqIntDisable                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_LEDSEQTABLE[6])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LEDSeqIntEnable                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_LEDSEQTABLE[7])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LEDSeqSequenceGet                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8StartIndex,                                     \
+                   uint32_t *pui32Steps,                                      \
+                   uint8_t ui8NumSteps))ROM_LEDSEQTABLE[8])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LEDSeqSequenceSet                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8StartIndex,                                     \
+                   uint32_t *pui32Steps,                                      \
+                   uint8_t ui8NumSteps))ROM_LEDSEQTABLE[9])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the LPC API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCIntClear                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_LPCTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCByteRead                                                       \
+        ((uint8_t (*)(uint32_t ui32Base,                                      \
+                      uint32_t ui32Offset))ROM_LPCTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCByteWrite                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Offset,                                       \
+                   uint8_t ui8Data))ROM_LPCTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCChannelConfigCOMxSet                                           \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint32_t ui32Config,                                       \
+                   uint32_t ui32Address,                                      \
+                   uint32_t ui32Offset,                                       \
+                   uint32_t ui32COMxMode))ROM_LPCTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCChannelConfigGet                                               \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Channel,                                  \
+                       uint32_t *pui32Address,                                \
+                       uint32_t *pui32Offset,                                 \
+                       uint32_t *pui32COMxMode))ROM_LPCTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCChannelConfigEPSet                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint32_t ui32Config,                                       \
+                   uint32_t ui32Address,                                      \
+                   uint32_t ui32Offset))ROM_LPCTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCChannelConfigMBSet                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint32_t ui32Config,                                       \
+                   uint32_t ui32Address,                                      \
+                   uint32_t ui32Offset))ROM_LPCTABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCChannelDMAConfigGet                                            \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_LPCTABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCChannelDMAConfigSet                                            \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config,                                       \
+                   uint32_t ui32Mask))ROM_LPCTABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCChannelDisable                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel))ROM_LPCTABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCChannelEnable                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel))ROM_LPCTABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCChannelStatusClear                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint32_t ui32Status))ROM_LPCTABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCChannelStatusGet                                               \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Channel))ROM_LPCTABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCChannelStatusSet                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint32_t ui32Status))ROM_LPCTABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCCOMxIntClear                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_LPCTABLE[14])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCCOMxIntDisable                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_LPCTABLE[15])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCCOMxIntEnable                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_LPCTABLE[16])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCCOMxIntStatus                                                  \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_LPCTABLE[17])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCConfigGet                                                      \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_LPCTABLE[18])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCConfigSet                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_LPCTABLE[19])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCHalfWordRead                                                   \
+        ((uint16_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Offset))ROM_LPCTABLE[20])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCHalfWordWrite                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Offset,                                       \
+                   uint16_t ui16Data))ROM_LPCTABLE[21])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCIRQClear                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IRQ))ROM_LPCTABLE[22])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCIRQConfig                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   bool bIRQPulse,                                            \
+                   bool bIRQOnChange))ROM_LPCTABLE[23])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCIRQGet                                                         \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_LPCTABLE[24])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCIRQSend                                                        \
+        ((void (*)(uint32_t ui32Base))ROM_LPCTABLE[25])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCIRQSet                                                         \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IRQ))ROM_LPCTABLE[26])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCIntDisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_LPCTABLE[27])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCIntEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_LPCTABLE[28])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCIntStatus                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_LPCTABLE[29])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCSCIAssert                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Count))ROM_LPCTABLE[30])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCStatusGet                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t *pui32Count,                                  \
+                       uint32_t *pui32PoolSize))ROM_LPCTABLE[31])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCWordRead                                                       \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Offset))ROM_LPCTABLE[32])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCWordWrite                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Offset,                                       \
+                   uint32_t ui32Data))ROM_LPCTABLE[33])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCChannelPoolAddressGet                                          \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Channel))ROM_LPCTABLE[34])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCStatusBlockAddressGet                                          \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_LPCTABLE[35])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_LPCStatusBlockAddressSet                                          \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Address,                                      \
+                   bool bEnabled))ROM_LPCTABLE[36])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the LPCB API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBIntClear                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint64_t ui64IntFlags))ROM_LPCBTABLE[0])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBByteRead                                                      \
+        ((uint8_t (*)(uint32_t ui32Base,                                      \
+                      uint32_t ui32Offset))ROM_LPCBTABLE[1])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBByteWrite                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Offset,                                       \
+                   uint8_t ui8Data))ROM_LPCBTABLE[2])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBChannelConfigCOMxSet                                          \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Address,                                      \
+                   uint32_t ui32COMxMode))ROM_LPCBTABLE[3])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBChannelConfigGet                                              \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Channel,                                  \
+                       uint32_t *pui32Address,                                \
+                       uint32_t *pui32Offset,                                 \
+                       uint32_t *pui32COMxMode))ROM_LPCBTABLE[4])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBChannelConfigEPSet                                            \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint32_t ui32Config,                                       \
+                   uint32_t ui32Address,                                      \
+                   uint32_t ui32Offset))ROM_LPCBTABLE[5])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBChannelConfigMBSet                                            \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint32_t ui32Config,                                       \
+                   uint32_t ui32Address,                                      \
+                   uint32_t ui32Offset))ROM_LPCBTABLE[6])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBChannelDMAConfigGet                                           \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_LPCBTABLE[7])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBChannelDMAConfigSet                                           \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config,                                       \
+                   uint32_t ui32Mask))ROM_LPCBTABLE[8])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBChannelDisable                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel))ROM_LPCBTABLE[9])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBChannelEnable                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel))ROM_LPCBTABLE[10])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBChannelStatusClear                                            \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint64_t ui64Status))ROM_LPCBTABLE[11])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBChannelStatusGet                                              \
+        ((uint64_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Channel))ROM_LPCBTABLE[12])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBChannelStatusSet                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint64_t ui64Status))ROM_LPCBTABLE[13])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBConfigGet                                                     \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_LPCBTABLE[14])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBConfigSet                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_LPCBTABLE[15])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBHalfWordRead                                                  \
+        ((uint16_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Offset))ROM_LPCBTABLE[16])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBHalfWordWrite                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Offset,                                       \
+                   uint16_t ui16Data))ROM_LPCBTABLE[17])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBIRQClear                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IRQ))ROM_LPCBTABLE[18])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBIRQConfig                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   bool bIRQOnChange))ROM_LPCBTABLE[19])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBIRQGet                                                        \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_LPCBTABLE[20])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBIRQSend                                                       \
+        ((void (*)(uint32_t ui32Base))ROM_LPCBTABLE[21])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBIRQSet                                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IRQ))ROM_LPCBTABLE[22])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBIntDisable                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint64_t ui64IntFlags))ROM_LPCBTABLE[23])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBIntEnable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint64_t ui64IntFlags))ROM_LPCBTABLE[24])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBIntStatus                                                     \
+        ((uint64_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_LPCBTABLE[25])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBSCIAssert                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Count))ROM_LPCBTABLE[26])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBStatusGet                                                     \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t *pui32Count,                                  \
+                       uint32_t *pui32PoolSize))ROM_LPCBTABLE[27])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBWordRead                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Offset))ROM_LPCBTABLE[28])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBWordWrite                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Offset,                                       \
+                   uint32_t ui32Data))ROM_LPCBTABLE[29])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBChannelPoolAddressGet                                         \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Channel))ROM_LPCBTABLE[30])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBStatusBlockAddressGet                                         \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_LPCBTABLE[31])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBStatusBlockAddressSet                                         \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Address,                                      \
+                   bool bEnabled))ROM_LPCBTABLE[32])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBChannelConfigCOMSet                                           \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32COM,                                          \
+                   uint32_t ui32Address,                                      \
+                   uint32_t ui32COMMode))ROM_LPCBTABLE[38])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBChannelConfigCOMGet                                           \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32COM,                                          \
+                   uint32_t *pui32Address,                                    \
+                   uint32_t *pui32COMMode))ROM_LPCBTABLE[39])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBCOMIntEnable                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32COM,                                          \
+                   uint32_t ui32Flags))ROM_LPCBTABLE[40])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBCOMIntDisable                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32COM,                                          \
+                   uint32_t ui32Flags))ROM_LPCBTABLE[41])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBCOMCTSSet                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32COM,                                          \
+                   bool bValue))ROM_LPCBTABLE[42])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBCOMDSRSet                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32COM,                                          \
+                   bool bValue))ROM_LPCBTABLE[43])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBCOMStatusGet                                                  \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32COM))ROM_LPCBTABLE[44])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBCOMInterceptRXFIFOWrite                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32COM,                                          \
+                   uint8_t ui8Data))ROM_LPCBTABLE[45])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBCOMInterceptTXFIFORead                                        \
+        ((uint8_t (*)(uint32_t ui32Base,                                      \
+                      uint32_t ui32COM))ROM_LPCBTABLE[46])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBChannelStallClear                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel))ROM_LPCBTABLE[47])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_LPCBRTCAddressSet                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Address))ROM_LPCBTABLE[51])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the MPU API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_MPUEnable                                                         \
+        ((void (*)(uint32_t ui32MPUConfig))ROM_MPUTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_MPUDisable                                                        \
+        ((void (*)(void))ROM_MPUTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_MPURegionCountGet                                                 \
+        ((uint32_t (*)(void))ROM_MPUTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_MPURegionEnable                                                   \
+        ((void (*)(uint32_t ui32Region))ROM_MPUTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_MPURegionDisable                                                  \
+        ((void (*)(uint32_t ui32Region))ROM_MPUTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_MPURegionSet                                                      \
+        ((void (*)(uint32_t ui32Region,                                       \
+                   uint32_t ui32Addr,                                         \
+                   uint32_t ui32Flags))ROM_MPUTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_MPURegionGet                                                      \
+        ((void (*)(uint32_t ui32Region,                                       \
+                   uint32_t *pui32Addr,                                       \
+                   uint32_t *pui32Flags))ROM_MPUTABLE[6])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the OneWire API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_OneWireIntStatus                                                  \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_ONEWIRETABLE[0])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_OneWireBusReset                                                   \
+        ((void (*)(uint32_t ui32Base))ROM_ONEWIRETABLE[1])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_OneWireBusStatus                                                  \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_ONEWIRETABLE[2])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_OneWireDataGet                                                    \
+        ((void (*)(uint32_t u3i2Base,                                         \
+                   uint32_t *pui32Data))ROM_ONEWIRETABLE[3])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_OneWireDataGetNonBlocking                                         \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Data))ROM_ONEWIRETABLE[4])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_OneWireInit                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32InitFlags))ROM_ONEWIRETABLE[5])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_OneWireIntClear                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_ONEWIRETABLE[6])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_OneWireIntDisable                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_ONEWIRETABLE[7])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_OneWireIntEnable                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_ONEWIRETABLE[8])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_OneWireTransaction                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32OpFlags,                                      \
+                   uint32_t ui32Data,                                         \
+                   uint32_t ui32BitCnt))ROM_ONEWIRETABLE[9])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_OneWireDMADisable                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32DMAFlags))ROM_ONEWIRETABLE[10])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_OneWireDMAEnable                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32DMAFlags))ROM_ONEWIRETABLE[11])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the PECI API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIIntClear                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_PECITABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIAdvCmdSend                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8Cmd,                                            \
+                   uint8_t ui8HidRe,                                          \
+                   uint8_t ui8Domain,                                         \
+                   uint8_t ui8Proi8Add,                                       \
+                   uint32_t ui32Arg,                                          \
+                   uint8_t ui8Size,                                           \
+                   uint32_t ui32Data0,                                        \
+                   uint32_t ui32Data1))ROM_PECITABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIAdvCmdSendNonBlocking                                         \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint8_t ui8Cmd,                                        \
+                       uint8_t ui8HidRe,                                      \
+                       uint8_t ui8Domain,                                     \
+                       uint8_t ui8Proi8Add,                                   \
+                       uint32_t ui32Arg,                                      \
+                       uint8_t ui8Size,                                       \
+                       uint32_t ui32Data0,                                    \
+                       uint32_t ui32Data1))ROM_PECITABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIAdvCmdStatusGet                                               \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t *pui32Data0,                                  \
+                       uint32_t *pui32Data1))ROM_PECITABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIConfigGet                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32PECIClk,                                      \
+                   uint32_t *pui32Baud,                                       \
+                   uint32_t *pui32Poll,                                       \
+                   uint32_t *pui32Offset,                                     \
+                   uint32_t *pui32Retry))ROM_PECITABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIConfigSet                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32PECIClk,                                      \
+                   uint32_t ui32Baud,                                         \
+                   uint32_t ui32Poll,                                         \
+                   uint32_t ui32Offset,                                       \
+                   uint32_t ui32Retry))ROM_PECITABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIDomainMaxReadClear                                            \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Domain))ROM_PECITABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIDomainValueClear                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Domain))ROM_PECITABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIDomainConfigGet                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Domain,                                       \
+                   uint32_t *pui32High,                                       \
+                   uint32_t *pui32Low))ROM_PECITABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIDomainConfigSet                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Domain,                                       \
+                   uint32_t ui32High,                                         \
+                   uint32_t ui32Low))ROM_PECITABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIDomainDisable                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Domain))ROM_PECITABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIDomainEnable                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Domain))ROM_PECITABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIDomainMaxReadGet                                              \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Domain))ROM_PECITABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIDomainValueGet                                                \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Domain))ROM_PECITABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIIntDisable                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_PECITABLE[14])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIIntEnable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags,                                     \
+                   uint32_t ui32IntMode))ROM_PECITABLE[15])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIIntStatus                                                     \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_PECITABLE[16])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIBypassEnable                                                  \
+        ((void (*)(uint32_t ui32Base))ROM_PECITABLE[17])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIBypassDisable                                                 \
+        ((void (*)(uint32_t ui32Base))ROM_PECITABLE[18])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIDomainAverageConfigSet                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Domain,                                       \
+                   uint32_t ui32Config))ROM_PECITABLE[19])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIDomainAverageGet                                              \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Domain))ROM_PECITABLE[20])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIDomainAverageConfigGet                                        \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Domain))ROM_PECITABLE[21])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PECIBaudGet                                                       \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32PECIClk))ROM_PECITABLE[22])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the Port80 API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_Port80DataWrite                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint16_t ui16Data))ROM_PORT80TABLE[0])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_Port80Config                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_PORT80TABLE[1])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the PS2 API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PS2IntStatus                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Bus,                                      \
+                       bool bMasked))ROM_PS2TABLE[0])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PS2CommandWrite                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Bus,                                          \
+                   uint8_t ui8Command,                                        \
+                   bool bExpectAck,                                           \
+                   uint8_t ui8RxCount))ROM_PS2TABLE[1])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PS2ConfigGet                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Bus))ROM_PS2TABLE[2])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PS2ConfigSet                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Bus,                                          \
+                   uint32_t ui32Flags))ROM_PS2TABLE[3])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PS2DataRead                                                       \
+        ((uint8_t (*)(uint32_t ui32Base,                                      \
+                      uint32_t ui32Bus,                                       \
+                      bool bMoreExpected,                                     \
+                      uint32_t *pui32Type))ROM_PS2TABLE[4])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PS2Disable                                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Bus))ROM_PS2TABLE[5])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PS2Enable                                                         \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Bus))ROM_PS2TABLE[6])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PS2InhibitClear                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Bus))ROM_PS2TABLE[7])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PS2InhibitSet                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Bus))ROM_PS2TABLE[8])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PS2IntClear                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Bus,                                          \
+                   uint32_t ui32IntFlags))ROM_PS2TABLE[9])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PS2IntDisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Bus,                                          \
+                   uint32_t ui32IntFlags))ROM_PS2TABLE[10])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PS2IntEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Bus,                                          \
+                   uint32_t ui32IntFlags))ROM_PS2TABLE[11])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PS2StatusGet                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Bus,                                      \
+                       uint32_t *pui32Type))ROM_PS2TABLE[12])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the PWM API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMPulseWidthSet                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32PWMOut,                                       \
+                   uint32_t ui32Width))ROM_PWMTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMGenConfigure                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Gen,                                          \
+                   uint32_t ui32Config))ROM_PWMTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMGenPeriodSet                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Gen,                                          \
+                   uint32_t ui32Period))ROM_PWMTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMGenPeriodGet                                                   \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Gen))ROM_PWMTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMGenEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Gen))ROM_PWMTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMGenDisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Gen))ROM_PWMTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMPulseWidthGet                                                  \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32PWMOut))ROM_PWMTABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMDeadBandEnable                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Gen,                                          \
+                   uint16_t ui16Rise,                                         \
+                   uint16_t ui16Fall))ROM_PWMTABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMDeadBandDisable                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Gen))ROM_PWMTABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMSyncUpdate                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32GenBits))ROM_PWMTABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMSyncTimeBase                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32GenBits))ROM_PWMTABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMOutputState                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32PWMOutBits,                                   \
+                   bool bEnable))ROM_PWMTABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMOutputInvert                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32PWMOutBits,                                   \
+                   bool bInvert))ROM_PWMTABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMOutputFault                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32PWMOutBits,                                   \
+                   bool bFaultSuppress))ROM_PWMTABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMGenIntTrigEnable                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Gen,                                          \
+                   uint32_t ui32IntTrig))ROM_PWMTABLE[14])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMGenIntTrigDisable                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Gen,                                          \
+                   uint32_t ui32IntTrig))ROM_PWMTABLE[15])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMGenIntStatus                                                   \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Gen,                                      \
+                       bool bMasked))ROM_PWMTABLE[16])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMGenIntClear                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Gen,                                          \
+                   uint32_t ui32Ints))ROM_PWMTABLE[17])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMIntEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32GenFault))ROM_PWMTABLE[18])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMIntDisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32GenFault))ROM_PWMTABLE[19])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMFaultIntClear                                                  \
+        ((void (*)(uint32_t ui32Base))ROM_PWMTABLE[20])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMIntStatus                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_PWMTABLE[21])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMOutputFaultLevel                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32PWMOutBits,                                   \
+                   bool bDriveHigh))ROM_PWMTABLE[22])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMFaultIntClearExt                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32FaultInts))ROM_PWMTABLE[23])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMGenFaultConfigure                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Gen,                                          \
+                   uint32_t ui32MinFaultPeriod,                               \
+                   uint32_t ui32FaultSenses))ROM_PWMTABLE[24])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMGenFaultTriggerSet                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Gen,                                          \
+                   uint32_t ui32Group,                                        \
+                   uint32_t ui32FaultTriggers))ROM_PWMTABLE[25])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMGenFaultTriggerGet                                             \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Gen,                                      \
+                       uint32_t ui32Group))ROM_PWMTABLE[26])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMGenFaultStatus                                                 \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Gen,                                      \
+                       uint32_t ui32Group))ROM_PWMTABLE[27])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMGenFaultClear                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Gen,                                          \
+                   uint32_t ui32Group,                                        \
+                   uint32_t ui32FaultTriggers))ROM_PWMTABLE[28])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMClockSet                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_PWMTABLE[29])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMClockGet                                                       \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_PWMTABLE[30])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_PWMOutputUpdateMode                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32PWMOutBits,                                   \
+                   uint32_t ui32Mode))ROM_PWMTABLE[31])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the QEI API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_QEIPositionGet                                                    \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_QEITABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_QEIEnable                                                         \
+        ((void (*)(uint32_t ui32Base))ROM_QEITABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_QEIDisable                                                        \
+        ((void (*)(uint32_t ui32Base))ROM_QEITABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_QEIConfigure                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config,                                       \
+                   uint32_t ui32MaxPosition))ROM_QEITABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_QEIPositionSet                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Position))ROM_QEITABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_QEIDirectionGet                                                   \
+        ((int32_t (*)(uint32_t ui32Base))ROM_QEITABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_QEIErrorGet                                                       \
+        ((bool (*)(uint32_t ui32Base))ROM_QEITABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_QEIVelocityEnable                                                 \
+        ((void (*)(uint32_t ui32Base))ROM_QEITABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_QEIVelocityDisable                                                \
+        ((void (*)(uint32_t ui32Base))ROM_QEITABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_QEIVelocityConfigure                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32PreDiv,                                       \
+                   uint32_t ui32Period))ROM_QEITABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_QEIVelocityGet                                                    \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_QEITABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_QEIIntEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_QEITABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_QEIIntDisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_QEITABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_QEIIntStatus                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_QEITABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_QEIIntClear                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_QEITABLE[14])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the SHAMD5 API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5IntStatus                                                   \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_SHAMD5TABLE[0])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5ConfigSet                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Mode))ROM_SHAMD5TABLE[1])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5DataProcess                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32DataSrc,                                    \
+                   uint32_t ui32DataLength,                                   \
+                   uint32_t *pui32HashResult))ROM_SHAMD5TABLE[2])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5DataWrite                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Src))ROM_SHAMD5TABLE[3])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5DataWriteNonBlocking                                        \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Src))ROM_SHAMD5TABLE[4])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5DMADisable                                                  \
+        ((void (*)(uint32_t ui32Base))ROM_SHAMD5TABLE[5])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5DMAEnable                                                   \
+        ((void (*)(uint32_t ui32Base))ROM_SHAMD5TABLE[6])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5HashLengthSet                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Length))ROM_SHAMD5TABLE[7])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5HMACKeySet                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Src))ROM_SHAMD5TABLE[8])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5HMACPPKeyGenerate                                           \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Key,                                        \
+                   uint32_t *pui32PPKey))ROM_SHAMD5TABLE[9])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5HMACPPKeySet                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Src))ROM_SHAMD5TABLE[10])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5HMACProcess                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32DataSrc,                                    \
+                   uint32_t ui32DataLength,                                   \
+                   uint32_t *pui32HashResult))ROM_SHAMD5TABLE[11])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5IntClear                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_SHAMD5TABLE[12])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5IntDisable                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_SHAMD5TABLE[13])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5IntEnable                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_SHAMD5TABLE[14])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5Reset                                                       \
+        ((void (*)(uint32_t ui32Base))ROM_SHAMD5TABLE[15])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SHAMD5ResultRead                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Dest))ROM_SHAMD5TABLE[16])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the SMBus API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterIntProcess                                             \
+        ((tSMBusStatus (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusARPDisable                                                   \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusARPEnable                                                    \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusARPUDIDPacketDecode                                          \
+        ((void (*)(tSMBusUDID *pUDID,                                         \
+                   uint8_t *pui8Address,                                      \
+                   uint8_t *pui8Data))ROM_SMBUSTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusARPUDIDPacketEncode                                          \
+        ((void (*)(tSMBusUDID *pUDID,                                         \
+                   uint8_t ui8Address,                                        \
+                   uint8_t *pui8Data))ROM_SMBUSTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterARPAssignAddress                                       \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t *pui8Data))ROM_SMBUSTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterARPGetUDIDDir                                          \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t ui8TargetAddress,                          \
+                           uint8_t *pui8Data))ROM_SMBUSTABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterARPGetUDIDGen                                          \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t *pui8Data))ROM_SMBUSTABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterARPNotifyMaster                                        \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t *pui8Data))ROM_SMBUSTABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterARPPrepareToARP                                        \
+        ((tSMBusStatus (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterARPResetDeviceDir                                      \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t ui8TargetAddress))ROM_SMBUSTABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterARPResetDeviceGen                                      \
+        ((tSMBusStatus (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterBlockProcessCall                                       \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t ui8TargetAddress,                          \
+                           uint8_t ui8Command,                                \
+                           uint8_t *pui8TxData,                               \
+                           uint8_t ui8TxSize,                                 \
+                           uint8_t *pui8RxData))ROM_SMBUSTABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterBlockRead                                              \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t ui8TargetAddress,                          \
+                           uint8_t ui8Command,                                \
+                           uint8_t *pui8Data))ROM_SMBUSTABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterBlockWrite                                             \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t ui8TargetAddress,                          \
+                           uint8_t ui8Command,                                \
+                           uint8_t *pui8Data,                                 \
+                           uint8_t ui8Size))ROM_SMBUSTABLE[14])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterByteReceive                                            \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t ui8TargetAddress,                          \
+                           uint8_t *pui8Data))ROM_SMBUSTABLE[15])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterByteSend                                               \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t ui8TargetAddress,                          \
+                           uint8_t ui8Data))ROM_SMBUSTABLE[16])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterByteWordRead                                           \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t ui8TargetAddress,                          \
+                           uint8_t ui8Command,                                \
+                           uint8_t *pui8Data,                                 \
+                           uint8_t ui8Size))ROM_SMBUSTABLE[17])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterByteWordWrite                                          \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t ui8TargetAddress,                          \
+                           uint8_t ui8Command,                                \
+                           uint8_t *pui8Data,                                 \
+                           uint8_t ui8Size))ROM_SMBUSTABLE[18])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterHostNotify                                             \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t ui8OwnSlaveAddress,                        \
+                           uint8_t *pui8Data))ROM_SMBUSTABLE[19])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterI2CRead                                                \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t ui8TargetAddress,                          \
+                           uint8_t *pui8Data,                                 \
+                           uint8_t ui8Size))ROM_SMBUSTABLE[20])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterI2CWrite                                               \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t ui8TargetAddress,                          \
+                           uint8_t *pui8Data,                                 \
+                           uint8_t ui8Size))ROM_SMBUSTABLE[21])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterI2CWriteRead                                           \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t ui8TargetAddress,                          \
+                           uint8_t *pui8TxData,                               \
+                           uint8_t ui8TxSize,                                 \
+                           uint8_t *pui8RxData,                               \
+                           uint8_t ui8RxSize))ROM_SMBUSTABLE[22])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterInit                                                   \
+        ((void (*)(tSMBus *psSMBus,                                           \
+                   uint32_t ui32I2CBase,                                      \
+                   uint32_t ui32SMBusClock))ROM_SMBUSTABLE[23])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterIntEnable                                              \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[24])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterProcessCall                                            \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t ui8TargetAddress,                          \
+                           uint8_t ui8Command,                                \
+                           uint8_t *pui8TxData,                               \
+                           uint8_t *pui8RxData))ROM_SMBUSTABLE[25])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusMasterQuickCommand                                           \
+        ((tSMBusStatus (*)(tSMBus *psSMBus,                                   \
+                           uint8_t ui8TargetAddress,                          \
+                           bool bData))ROM_SMBUSTABLE[26])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusPECDisable                                                   \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[27])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusPECEnable                                                    \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[28])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusRxPacketSizeGet                                              \
+        ((uint8_t (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[29])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveACKSend                                                 \
+        ((void (*)(tSMBus *psSMBus,                                           \
+                   bool bACK))ROM_SMBUSTABLE[30])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveAddressSet                                              \
+        ((void (*)(tSMBus *psSMBus,                                           \
+                   uint8_t ui8AddressNum,                                     \
+                   uint8_t ui8SlaveAddress))ROM_SMBUSTABLE[31])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveARPFlagARGet                                            \
+        ((bool (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[32])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveARPFlagARSet                                            \
+        ((void (*)(tSMBus *psSMBus,                                           \
+                   bool bValue))ROM_SMBUSTABLE[33])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveARPFlagAVGet                                            \
+        ((bool (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[34])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveARPFlagAVSet                                            \
+        ((void (*)(tSMBus *psSMBus,                                           \
+                   bool bValue))ROM_SMBUSTABLE[35])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveBlockTransferDisable                                    \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[36])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveBlockTransferEnable                                     \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[37])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveCommandGet                                              \
+        ((uint8_t (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[38])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveI2CDisable                                              \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[39])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveI2CEnable                                               \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[40])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveInit                                                    \
+        ((void (*)(tSMBus *psSMBus,                                           \
+                   uint32_t ui32I2CBase))ROM_SMBUSTABLE[41])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveIntAddressGet                                           \
+        ((tSMBusStatus (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[42])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveIntEnable                                               \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[43])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveIntProcess                                              \
+        ((tSMBusStatus (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[44])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveManualACKDisable                                        \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[45])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveManualACKEnable                                         \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[46])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveManualACKStatusGet                                      \
+        ((bool (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[47])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveProcessCallDisable                                      \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[48])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveProcessCallEnable                                       \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[49])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveRxBufferSet                                             \
+        ((void (*)(tSMBus *psSMBus,                                           \
+                   uint8_t *pui8Data,                                         \
+                   uint8_t ui8Size))ROM_SMBUSTABLE[50])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveTransferInit                                            \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[51])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveTxBufferSet                                             \
+        ((void (*)(tSMBus *psSMBus,                                           \
+                   uint8_t *pui8Data,                                         \
+                   uint8_t ui8Size))ROM_SMBUSTABLE[52])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveUDIDSet                                                 \
+        ((void (*)(tSMBus *psSMBus,                                           \
+                   tSMBusUDID *pUDID))ROM_SMBUSTABLE[53])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusStatusGet                                                    \
+        ((tSMBusStatus (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[54])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusSlaveDataSend                                                \
+        ((tSMBusStatus (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[55])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusFIFOEnable                                                   \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[56])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusFIFODisable                                                  \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[57])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusDMAEnable                                                    \
+        ((void (*)(tSMBus *psSMBus,                                           \
+                   uint8_t ui8TxChannel,                                      \
+                   uint8_t ui8RxChannel))ROM_SMBUSTABLE[58])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SMBusDMADisable                                                   \
+        ((void (*)(tSMBus *psSMBus))ROM_SMBUSTABLE[59])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the SPIFlash API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashIntHandler                                                \
+        ((uint32_t (*)(tSPIFlashState *pState))ROM_SPIFLASHTABLE[0])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashInit                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Clock,                                        \
+                   uint32_t ui32BitRate))ROM_SPIFLASHTABLE[1])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashWriteStatus                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8Status))ROM_SPIFLASHTABLE[2])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashPageProgram                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Addr,                                         \
+                   const uint8_t *pui8Data,                                   \
+                   uint32_t ui32Count))ROM_SPIFLASHTABLE[3])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashPageProgramNonBlocking                                    \
+        ((void (*)(tSPIFlashState *pState,                                    \
+                   uint32_t ui32Base,                                         \
+                   uint32_t ui32Addr,                                         \
+                   const uint8_t *pui8Data,                                   \
+                   uint32_t ui32Count,                                        \
+                   bool bUseDMA,                                              \
+                   uint32_t ui32TxChannel))ROM_SPIFLASHTABLE[4])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashRead                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Addr,                                         \
+                   uint8_t *pui8Data,                                         \
+                   uint32_t ui32Count))ROM_SPIFLASHTABLE[5])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashReadNonBlocking                                           \
+        ((void (*)(tSPIFlashState *pState,                                    \
+                   uint32_t ui32Base,                                         \
+                   uint32_t ui32Addr,                                         \
+                   uint8_t *pui8Data,                                         \
+                   uint32_t ui32Count,                                        \
+                   bool bUseDMA,                                              \
+                   uint32_t ui32TxChannel,                                    \
+                   uint32_t ui32RxChannel))ROM_SPIFLASHTABLE[6])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashWriteDisable                                              \
+        ((void (*)(uint32_t ui32Base))ROM_SPIFLASHTABLE[7])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashReadStatus                                                \
+        ((uint8_t (*)(uint32_t ui32Base))ROM_SPIFLASHTABLE[8])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashWriteEnable                                               \
+        ((void (*)(uint32_t ui32Base))ROM_SPIFLASHTABLE[9])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashFastRead                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Addr,                                         \
+                   uint8_t *pui8Data,                                         \
+                   uint32_t ui32Count))ROM_SPIFLASHTABLE[10])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashFastReadNonBlocking                                       \
+        ((void (*)(tSPIFlashState *pState,                                    \
+                   uint32_t ui32Base,                                         \
+                   uint32_t ui32Addr,                                         \
+                   uint8_t *pui8Data,                                         \
+                   uint32_t ui32Count,                                        \
+                   bool bUseDMA,                                              \
+                   uint32_t ui32TxChannel,                                    \
+                   uint32_t ui32RxChannel))ROM_SPIFLASHTABLE[11])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashSectorErase                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Addr))ROM_SPIFLASHTABLE[12])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashDualRead                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Addr,                                         \
+                   uint8_t *pui8Data,                                         \
+                   uint32_t ui32Count))ROM_SPIFLASHTABLE[13])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashDualReadNonBlocking                                       \
+        ((void (*)(tSPIFlashState *pState,                                    \
+                   uint32_t ui32Base,                                         \
+                   uint32_t ui32Addr,                                         \
+                   uint8_t *pui8Data,                                         \
+                   uint32_t ui32Count,                                        \
+                   bool bUseDMA,                                              \
+                   uint32_t ui32TxChannel,                                    \
+                   uint32_t ui32RxChannel))ROM_SPIFLASHTABLE[14])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashBlockErase32                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Addr))ROM_SPIFLASHTABLE[15])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashQuadRead                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Addr,                                         \
+                   uint8_t *pui8Data,                                         \
+                   uint32_t ui32Count))ROM_SPIFLASHTABLE[16])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashQuadReadNonBlocking                                       \
+        ((void (*)(tSPIFlashState *pState,                                    \
+                   uint32_t ui32Base,                                         \
+                   uint32_t ui32Addr,                                         \
+                   uint8_t *pui8Data,                                         \
+                   uint32_t ui32Count,                                        \
+                   bool bUseDMA,                                              \
+                   uint32_t ui32TxChannel,                                    \
+                   uint32_t ui32RxChannel))ROM_SPIFLASHTABLE[17])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashReadID                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t *pui8ManufacturerID,                               \
+                   uint16_t *pui16DeviceID))ROM_SPIFLASHTABLE[18])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashChipErase                                                 \
+        ((void (*)(uint32_t ui32Base))ROM_SPIFLASHTABLE[19])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SPIFlashBlockErase64                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Addr))ROM_SPIFLASHTABLE[20])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the SSI API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIDataPut                                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Data))ROM_SSITABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIConfigSetExpClk                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32SSIClk,                                       \
+                   uint32_t ui32Protocol,                                     \
+                   uint32_t ui32Mode,                                         \
+                   uint32_t ui32BitRate,                                      \
+                   uint32_t ui32DataWidth))ROM_SSITABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIEnable                                                         \
+        ((void (*)(uint32_t ui32Base))ROM_SSITABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIDisable                                                        \
+        ((void (*)(uint32_t ui32Base))ROM_SSITABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIIntEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_SSITABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIIntDisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_SSITABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIIntStatus                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_SSITABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIIntClear                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_SSITABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIDataPutNonBlocking                                             \
+        ((int32_t (*)(uint32_t ui32Base,                                      \
+                      uint32_t ui32Data))ROM_SSITABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIDataGet                                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32Data))ROM_SSITABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIDataGetNonBlocking                                             \
+        ((int32_t (*)(uint32_t ui32Base,                                      \
+                      uint32_t *pui32Data))ROM_SSITABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UpdateSSI                                                         \
+        ((void (*)(void))ROM_SSITABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIDMAEnable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32DMAFlags))ROM_SSITABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIDMADisable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32DMAFlags))ROM_SSITABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIBusy                                                           \
+        ((bool (*)(uint32_t ui32Base))ROM_SSITABLE[14])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIClockSourceGet                                                 \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_SSITABLE[15])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIClockSourceSet                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Source))ROM_SSITABLE[16])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIAdvModeSet                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Mode))ROM_SSITABLE[17])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIAdvDataPutFrameEnd                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Data))ROM_SSITABLE[18])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIAdvDataPutFrameEndNonBlocking                                  \
+        ((int32_t (*)(uint32_t ui32Base,                                      \
+                      uint32_t ui32Data))ROM_SSITABLE[19])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIAdvFrameHoldEnable                                             \
+        ((void (*)(uint32_t ui32Base))ROM_SSITABLE[20])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SSIAdvFrameHoldDisable                                            \
+        ((void (*)(uint32_t ui32Base))ROM_SSITABLE[21])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the SysCtl API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlSleep                                                       \
+        ((void (*)(void))ROM_SYSCTLTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlSRAMSizeGet                                                 \
+        ((uint32_t (*)(void))ROM_SYSCTLTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlFlashSizeGet                                                \
+        ((uint32_t (*)(void))ROM_SYSCTLTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlPeripheralPresent                                           \
+        ((bool (*)(uint32_t ui32Peripheral))ROM_SYSCTLTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlPeripheralReset                                             \
+        ((void (*)(uint32_t ui32Peripheral))ROM_SYSCTLTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlPeripheralEnable                                            \
+        ((void (*)(uint32_t ui32Peripheral))ROM_SYSCTLTABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlPeripheralDisable                                           \
+        ((void (*)(uint32_t ui32Peripheral))ROM_SYSCTLTABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlPeripheralSleepEnable                                       \
+        ((void (*)(uint32_t ui32Peripheral))ROM_SYSCTLTABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlPeripheralSleepDisable                                      \
+        ((void (*)(uint32_t ui32Peripheral))ROM_SYSCTLTABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlPeripheralDeepSleepEnable                                   \
+        ((void (*)(uint32_t ui32Peripheral))ROM_SYSCTLTABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlPeripheralDeepSleepDisable                                  \
+        ((void (*)(uint32_t ui32Peripheral))ROM_SYSCTLTABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlPeripheralClockGating                                       \
+        ((void (*)(bool bEnable))ROM_SYSCTLTABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlIntEnable                                                   \
+        ((void (*)(uint32_t ui32Ints))ROM_SYSCTLTABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlIntDisable                                                  \
+        ((void (*)(uint32_t ui32Ints))ROM_SYSCTLTABLE[14])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlIntClear                                                    \
+        ((void (*)(uint32_t ui32Ints))ROM_SYSCTLTABLE[15])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlIntStatus                                                   \
+        ((uint32_t (*)(bool bMasked))ROM_SYSCTLTABLE[16])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlReset                                                       \
+        ((void (*)(void))ROM_SYSCTLTABLE[19])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlDeepSleep                                                   \
+        ((void (*)(void))ROM_SYSCTLTABLE[20])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlResetCauseGet                                               \
+        ((uint32_t (*)(void))ROM_SYSCTLTABLE[21])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlResetCauseClear                                             \
+        ((void (*)(uint32_t ui32Causes))ROM_SYSCTLTABLE[22])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_SysCtlClockSet                                                    \
+        ((void (*)(uint32_t ui32Config))ROM_SYSCTLTABLE[23])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_SysCtlClockGet                                                    \
+        ((uint32_t (*)(void))ROM_SYSCTLTABLE[24])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_SysCtlPWMClockSet                                                 \
+        ((void (*)(uint32_t ui32Config))ROM_SYSCTLTABLE[25])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_SysCtlPWMClockGet                                                 \
+        ((uint32_t (*)(void))ROM_SYSCTLTABLE[26])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_SysCtlADCSpeedSet                                                 \
+        ((void (*)(uint32_t ui32Speed))ROM_SYSCTLTABLE[27])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_SysCtlADCSpeedGet                                                 \
+        ((uint32_t (*)(void))ROM_SYSCTLTABLE[28])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_SysCtlUSBPLLEnable                                                \
+        ((void (*)(void))ROM_SYSCTLTABLE[31])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_SysCtlUSBPLLDisable                                               \
+        ((void (*)(void))ROM_SYSCTLTABLE[32])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlDelay                                                       \
+        ((void (*)(uint32_t ui32Count))ROM_SYSCTLTABLE[34])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlPeripheralReady                                             \
+        ((bool (*)(uint32_t ui32Peripheral))ROM_SYSCTLTABLE[35])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlPeripheralPowerOn                                           \
+        ((void (*)(uint32_t ui32Peripheral))ROM_SYSCTLTABLE[36])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlPeripheralPowerOff                                          \
+        ((void (*)(uint32_t ui32Peripheral))ROM_SYSCTLTABLE[37])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlMOSCConfigSet                                               \
+        ((void (*)(uint32_t ui32Config))ROM_SYSCTLTABLE[44])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlPIOSCCalibrate                                              \
+        ((uint32_t (*)(uint32_t ui32Type))ROM_SYSCTLTABLE[45])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_SysCtlDeepSleepClockSet                                           \
+        ((void (*)(uint32_t ui32Config))ROM_SYSCTLTABLE[46])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlDeepSleepClockConfigSet                                     \
+        ((void (*)(uint32_t ui32Div,                                          \
+                   uint32_t ui32Config))ROM_SYSCTLTABLE[47])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlClockFreqSet                                                \
+        ((uint32_t (*)(uint32_t ui32Config,                                   \
+                       uint32_t ui32SysClock))ROM_SYSCTLTABLE[48])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlLPCLowPowerConfigSet                                        \
+        ((void (*)(uint32_t ui32Config))ROM_SYSCTLTABLE[49])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlLPCLowPowerStatusGet                                        \
+        ((uint32_t (*)(void))ROM_SYSCTLTABLE[50])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlResetBehaviorSet                                            \
+        ((void (*)(uint32_t ui32Behavior))ROM_SYSCTLTABLE[51])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlResetBehaviorGet                                            \
+        ((uint32_t (*)(void))ROM_SYSCTLTABLE[52])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlFlashSectorSizeGet                                          \
+        ((uint32_t (*)(void))ROM_SYSCTLTABLE[54])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlVoltageEventConfig                                          \
+        ((void (*)(uint32_t ui32Config))ROM_SYSCTLTABLE[55])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlVoltageEventStatus                                          \
+        ((uint32_t (*)(void))ROM_SYSCTLTABLE[56])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlVoltageEventClear                                           \
+        ((void (*)(uint32_t ui32Status))ROM_SYSCTLTABLE[57])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlNMIStatus                                                   \
+        ((uint32_t (*)(void))ROM_SYSCTLTABLE[58])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlNMIClear                                                    \
+        ((void (*)(uint32_t ui32Status))ROM_SYSCTLTABLE[59])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlClockOutConfig                                              \
+        ((void (*)(uint32_t ui32Config,                                       \
+                   uint32_t ui32Div))ROM_SYSCTLTABLE[60])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlAltClkConfig                                                \
+        ((void (*)(uint32_t ui32Config))ROM_SYSCTLTABLE[61])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlLDOConfigSet                                                \
+        ((void (*)(uint32_t ui32Config))ROM_SYSCTLTABLE[62])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysCtlBrownOutConfigSet                                           \
+        ((void (*)(uint32_t ui32Config,                                       \
+                   uint32_t ui32Delay))ROM_SYSCTLTABLE[63])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the SysExc API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysExcIntStatus                                                   \
+        ((uint32_t (*)(bool bMasked))ROM_SYSEXCTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysExcIntClear                                                    \
+        ((void (*)(uint32_t ui32IntFlags))ROM_SYSEXCTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysExcIntDisable                                                  \
+        ((void (*)(uint32_t ui32IntFlags))ROM_SYSEXCTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysExcIntEnable                                                   \
+        ((void (*)(uint32_t ui32IntFlags))ROM_SYSEXCTABLE[3])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the SysTick API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysTickValueGet                                                   \
+        ((uint32_t (*)(void))ROM_SYSTICKTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysTickEnable                                                     \
+        ((void (*)(void))ROM_SYSTICKTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysTickDisable                                                    \
+        ((void (*)(void))ROM_SYSTICKTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysTickIntEnable                                                  \
+        ((void (*)(void))ROM_SYSTICKTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysTickIntDisable                                                 \
+        ((void (*)(void))ROM_SYSTICKTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysTickPeriodSet                                                  \
+        ((void (*)(uint32_t ui32Period))ROM_SYSTICKTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_SysTickPeriodGet                                                  \
+        ((uint32_t (*)(void))ROM_SYSTICKTABLE[6])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the Timer API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerIntClear                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_TIMERTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerEnable                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Timer))ROM_TIMERTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerDisable                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Timer))ROM_TIMERTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerConfigure                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_TIMERTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerControlLevel                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Timer,                                        \
+                   bool bInvert))ROM_TIMERTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1)
+#define ROM_TimerControlTrigger                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Timer,                                        \
+                   bool bEnable))ROM_TIMERTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerControlEvent                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Timer,                                        \
+                   uint32_t ui32Event))ROM_TIMERTABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerControlStall                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Timer,                                        \
+                   bool bStall))ROM_TIMERTABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerRTCEnable                                                    \
+        ((void (*)(uint32_t ui32Base))ROM_TIMERTABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerRTCDisable                                                   \
+        ((void (*)(uint32_t ui32Base))ROM_TIMERTABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerPrescaleSet                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Timer,                                        \
+                   uint32_t ui32Value))ROM_TIMERTABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerPrescaleGet                                                  \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Timer))ROM_TIMERTABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerPrescaleMatchSet                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Timer,                                        \
+                   uint32_t ui32Value))ROM_TIMERTABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerPrescaleMatchGet                                             \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Timer))ROM_TIMERTABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerLoadSet                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Timer,                                        \
+                   uint32_t ui32Value))ROM_TIMERTABLE[14])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerLoadGet                                                      \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Timer))ROM_TIMERTABLE[15])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerValueGet                                                     \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Timer))ROM_TIMERTABLE[16])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerMatchSet                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Timer,                                        \
+                   uint32_t ui32Value))ROM_TIMERTABLE[17])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerMatchGet                                                     \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Timer))ROM_TIMERTABLE[18])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerIntEnable                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_TIMERTABLE[19])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerIntDisable                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_TIMERTABLE[20])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerIntStatus                                                    \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_TIMERTABLE[21])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerControlWaitOnTrigger                                         \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Timer,                                        \
+                   bool bWait))ROM_TIMERTABLE[22])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerLoadSet64                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint64_t ui64Value))ROM_TIMERTABLE[23])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerLoadGet64                                                    \
+        ((uint64_t (*)(uint32_t ui32Base))ROM_TIMERTABLE[24])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerValueGet64                                                   \
+        ((uint64_t (*)(uint32_t ui32Base))ROM_TIMERTABLE[25])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerMatchSet64                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint64_t ui64Value))ROM_TIMERTABLE[26])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerMatchGet64                                                   \
+        ((uint64_t (*)(uint32_t ui32Base))ROM_TIMERTABLE[27])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerClockSourceGet                                               \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_TIMERTABLE[28])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerClockSourceSet                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Source))ROM_TIMERTABLE[29])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerADCEventGet                                                  \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_TIMERTABLE[30])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerADCEventSet                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32ADCEvent))ROM_TIMERTABLE[31])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerDMAEventGet                                                  \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_TIMERTABLE[32])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerDMAEventSet                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32DMAEvent))ROM_TIMERTABLE[33])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_TimerSynchronize                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Timers))ROM_TIMERTABLE[34])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the UART API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTCharPut                                                       \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   unsigned char ucData))ROM_UARTTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTParityModeSet                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Parity))ROM_UARTTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTParityModeGet                                                 \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_UARTTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTFIFOLevelSet                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32TxLevel,                                      \
+                   uint32_t ui32RxLevel))ROM_UARTTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTFIFOLevelGet                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t *pui32TxLevel,                                    \
+                   uint32_t *pui32RxLevel))ROM_UARTTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTConfigSetExpClk                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32UARTClk,                                      \
+                   uint32_t ui32Baud,                                         \
+                   uint32_t ui32Config))ROM_UARTTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTConfigGetExpClk                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32UARTClk,                                      \
+                   uint32_t *pui32Baud,                                       \
+                   uint32_t *pui32Config))ROM_UARTTABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTEnable                                                        \
+        ((void (*)(uint32_t ui32Base))ROM_UARTTABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTDisable                                                       \
+        ((void (*)(uint32_t ui32Base))ROM_UARTTABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTEnableSIR                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   bool bLowPower))ROM_UARTTABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTDisableSIR                                                    \
+        ((void (*)(uint32_t ui32Base))ROM_UARTTABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTCharsAvail                                                    \
+        ((bool (*)(uint32_t ui32Base))ROM_UARTTABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTSpaceAvail                                                    \
+        ((bool (*)(uint32_t ui32Base))ROM_UARTTABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTCharGetNonBlocking                                            \
+        ((int32_t (*)(uint32_t ui32Base))ROM_UARTTABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTCharGet                                                       \
+        ((int32_t (*)(uint32_t ui32Base))ROM_UARTTABLE[14])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTCharPutNonBlocking                                            \
+        ((bool (*)(uint32_t ui32Base,                                         \
+                   unsigned char ucData))ROM_UARTTABLE[15])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTBreakCtl                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   bool bBreakState))ROM_UARTTABLE[16])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTIntEnable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_UARTTABLE[17])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTIntDisable                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_UARTTABLE[18])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTIntStatus                                                     \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_UARTTABLE[19])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTIntClear                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_UARTTABLE[20])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UpdateUART                                                        \
+        ((void (*)(void))ROM_UARTTABLE[21])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTDMAEnable                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32DMAFlags))ROM_UARTTABLE[22])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTDMADisable                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32DMAFlags))ROM_UARTTABLE[23])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTFIFOEnable                                                    \
+        ((void (*)(uint32_t ui32Base))ROM_UARTTABLE[24])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTFIFODisable                                                   \
+        ((void (*)(uint32_t ui32Base))ROM_UARTTABLE[25])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTBusy                                                          \
+        ((bool (*)(uint32_t ui32Base))ROM_UARTTABLE[26])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTTxIntModeSet                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Mode))ROM_UARTTABLE[27])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTTxIntModeGet                                                  \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_UARTTABLE[28])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTRxErrorGet                                                    \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_UARTTABLE[29])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTRxErrorClear                                                  \
+        ((void (*)(uint32_t ui32Base))ROM_UARTTABLE[30])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTClockSourceSet                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Source))ROM_UARTTABLE[31])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTClockSourceGet                                                \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_UARTTABLE[32])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UART9BitEnable                                                    \
+        ((void (*)(uint32_t ui32Base))ROM_UARTTABLE[33])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UART9BitDisable                                                   \
+        ((void (*)(uint32_t ui32Base))ROM_UARTTABLE[34])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UART9BitAddrSet                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8Addr,                                           \
+                   uint8_t ui8Mask))ROM_UARTTABLE[35])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UART9BitAddrSend                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8Addr))ROM_UARTTABLE[36])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTSmartCardDisable                                              \
+        ((void (*)(uint32_t ui32Base))ROM_UARTTABLE[37])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTSmartCardEnable                                               \
+        ((void (*)(uint32_t ui32Base))ROM_UARTTABLE[38])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTModemControlClear                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Control))ROM_UARTTABLE[39])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTModemControlGet                                               \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_UARTTABLE[40])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTModemControlSet                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Control))ROM_UARTTABLE[41])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTModemStatusGet                                                \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_UARTTABLE[42])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTFlowControlGet                                                \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_UARTTABLE[43])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UARTFlowControlSet                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Mode))ROM_UARTTABLE[44])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the uDMA API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAChannelTransferSet                                            \
+        ((void (*)(uint32_t ui32ChannelStructIndex,                           \
+                   uint32_t ui32Mode,                                         \
+                   void *pvSrcAddr,                                           \
+                   void *pvDstAddr,                                           \
+                   uint32_t ui32TransferSize))ROM_UDMATABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAEnable                                                        \
+        ((void (*)(void))ROM_UDMATABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMADisable                                                       \
+        ((void (*)(void))ROM_UDMATABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAErrorStatusGet                                                \
+        ((uint32_t (*)(void))ROM_UDMATABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAErrorStatusClear                                              \
+        ((void (*)(void))ROM_UDMATABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAChannelEnable                                                 \
+        ((void (*)(uint32_t ui32ChannelNum))ROM_UDMATABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAChannelDisable                                                \
+        ((void (*)(uint32_t ui32ChannelNum))ROM_UDMATABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAChannelIsEnabled                                              \
+        ((bool (*)(uint32_t ui32ChannelNum))ROM_UDMATABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAControlBaseSet                                                \
+        ((void (*)(void *pControlTable))ROM_UDMATABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAControlBaseGet                                                \
+        ((void * (*)(void))ROM_UDMATABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAChannelRequest                                                \
+        ((void (*)(uint32_t ui32ChannelNum))ROM_UDMATABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAChannelAttributeEnable                                        \
+        ((void (*)(uint32_t ui32ChannelNum,                                   \
+                   uint32_t ui32Attr))ROM_UDMATABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAChannelAttributeDisable                                       \
+        ((void (*)(uint32_t ui32ChannelNum,                                   \
+                   uint32_t ui32Attr))ROM_UDMATABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAChannelAttributeGet                                           \
+        ((uint32_t (*)(uint32_t ui32ChannelNum))ROM_UDMATABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAChannelControlSet                                             \
+        ((void (*)(uint32_t ui32ChannelStructIndex,                           \
+                   uint32_t ui32Control))ROM_UDMATABLE[14])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAChannelSizeGet                                                \
+        ((uint32_t (*)(uint32_t ui32ChannelStructIndex))ROM_UDMATABLE[15])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAChannelModeGet                                                \
+        ((uint32_t (*)(uint32_t ui32ChannelStructIndex))ROM_UDMATABLE[16])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAChannelSelectSecondary                                        \
+        ((void (*)(uint32_t ui32SecPeriphs))ROM_UDMATABLE[17])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAChannelSelectDefault                                          \
+        ((void (*)(uint32_t ui32DefPeriphs))ROM_UDMATABLE[18])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAIntStatus                                                     \
+        ((uint32_t (*)(void))ROM_UDMATABLE[19])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAIntClear                                                      \
+        ((void (*)(uint32_t ui32ChanMask))ROM_UDMATABLE[20])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAControlAlternateBaseGet                                       \
+        ((void * (*)(void))ROM_UDMATABLE[21])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAChannelScatterGatherSet                                       \
+        ((void (*)(uint32_t ui32ChannelNum,                                   \
+                   uint32_t ui32TaskCount,                                    \
+                   void *pvTaskList,                                          \
+                   uint32_t ui32IsPeriphSG))ROM_UDMATABLE[22])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_uDMAChannelAssign                                                 \
+        ((void (*)(uint32_t ui32Mapping))ROM_UDMATABLE[23])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the USB API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDevAddrGet                                                     \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_USBTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDevAddrSet                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Address))ROM_USBTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDevConnect                                                     \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDevDisconnect                                                  \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDevEndpointConfigSet                                           \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32MaxPacketSize,                                \
+                   uint32_t ui32Flags))ROM_USBTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDevEndpointDataAck                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   bool bIsLastPacket))ROM_USBTABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDevEndpointStall                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32Flags))ROM_USBTABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDevEndpointStallClear                                          \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32Flags))ROM_USBTABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDevEndpointStatusClear                                         \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32Flags))ROM_USBTABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBEndpointDataGet                                                \
+        ((int32_t (*)(uint32_t ui32Base,                                      \
+                      uint32_t ui32Endpoint,                                  \
+                      uint8_t *pui8Data,                                      \
+                      uint32_t *pui32Size))ROM_USBTABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBEndpointDataPut                                                \
+        ((int32_t (*)(uint32_t ui32Base,                                      \
+                      uint32_t ui32Endpoint,                                  \
+                      uint8_t *pui8Data,                                      \
+                      uint32_t ui32Size))ROM_USBTABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBEndpointDataSend                                               \
+        ((int32_t (*)(uint32_t ui32Base,                                      \
+                      uint32_t ui32Endpoint,                                  \
+                      uint32_t ui32TransType))ROM_USBTABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBEndpointDataToggleClear                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32Flags))ROM_USBTABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBEndpointStatus                                                 \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Endpoint))ROM_USBTABLE[14])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBFIFOAddrGet                                                    \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Endpoint))ROM_USBTABLE[15])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBFIFOConfigGet                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t *pui32FIFOAddress,                                \
+                   uint32_t *pui32FIFOSize,                                   \
+                   uint32_t ui32Flags))ROM_USBTABLE[16])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBFIFOConfigSet                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32FIFOAddress,                                  \
+                   uint32_t ui32FIFOSize,                                     \
+                   uint32_t ui32Flags))ROM_USBTABLE[17])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBFIFOFlush                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32Flags))ROM_USBTABLE[18])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBFrameNumberGet                                                 \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_USBTABLE[19])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostAddrGet                                                    \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Endpoint,                                 \
+                       uint32_t ui32Flags))ROM_USBTABLE[20])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostAddrSet                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32Addr,                                         \
+                   uint32_t ui32Flags))ROM_USBTABLE[21])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostEndpointConfig                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32MaxPacketSize,                                \
+                   uint32_t ui32NAKPollInterval,                              \
+                   uint32_t ui32TargetEndpoint,                               \
+                   uint32_t ui32Flags))ROM_USBTABLE[22])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostEndpointDataAck                                            \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint))ROM_USBTABLE[23])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostEndpointDataToggle                                         \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   bool bDataToggle,                                          \
+                   uint32_t ui32Flags))ROM_USBTABLE[24])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostEndpointStatusClear                                        \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32Flags))ROM_USBTABLE[25])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostHubAddrGet                                                 \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Endpoint,                                 \
+                       uint32_t ui32Flags))ROM_USBTABLE[26])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostHubAddrSet                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32Addr,                                         \
+                   uint32_t ui32Flags))ROM_USBTABLE[27])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostPwrDisable                                                 \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[28])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostPwrEnable                                                  \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[29])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostPwrConfig                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Flags))ROM_USBTABLE[30])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostPwrFaultDisable                                            \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[31])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostPwrFaultEnable                                             \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[32])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostRequestIN                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint))ROM_USBTABLE[33])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostRequestStatus                                              \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[34])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostReset                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   bool bStart))ROM_USBTABLE[35])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostResume                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   bool bStart))ROM_USBTABLE[36])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostSpeedGet                                                   \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_USBTABLE[37])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostSuspend                                                    \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[38])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDevEndpointConfigGet                                           \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t *pui32MaxPacketSize,                              \
+                   uint32_t *pui32Flags))ROM_USBTABLE[41])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBEndpointDMAEnable                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32Flags))ROM_USBTABLE[42])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBEndpointDMADisable                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32Flags))ROM_USBTABLE[43])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBEndpointDataAvail                                              \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Endpoint))ROM_USBTABLE[44])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBModeGet                                                        \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_USBTABLE[46])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBEndpointDMAChannel                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32Channel))ROM_USBTABLE[47])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBIntDisableControl                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_USBTABLE[48])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBIntEnableControl                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_USBTABLE[49])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBIntStatusControl                                               \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_USBTABLE[50])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBIntDisableEndpoint                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_USBTABLE[51])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBIntEnableEndpoint                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32IntFlags))ROM_USBTABLE[52])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBIntStatusEndpoint                                              \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_USBTABLE[53])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostMode                                                       \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[54])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDevMode                                                        \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[55])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBPHYPowerOff                                                    \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[56])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBPHYPowerOn                                                     \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[57])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_UpdateUSB                                                         \
+        ((void (*)(uint8_t *pui8DescriptorInfo))ROM_USBTABLE[58])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBOTGMode                                                        \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[59])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostRequestINClear                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint))ROM_USBTABLE[60])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBNumEndpointsGet                                                \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_USBTABLE[61])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBClockDisable                                                   \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[62])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBClockEnable                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Div,                                          \
+                   uint32_t ui32Flags))ROM_USBTABLE[63])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBControllerVersion                                              \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_USBTABLE[64])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDevLPMConfig                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_USBTABLE[65])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDevLPMDisable                                                  \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[66])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDevLPMEnable                                                   \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[67])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDevLPMRemoteWake                                               \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[68])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDevSpeedGet                                                    \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_USBTABLE[69])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDMAChannelAddressGet                                           \
+        ((void * (*)(uint32_t ui32Base,                                       \
+                     uint32_t ui32Channel))ROM_USBTABLE[70])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDMAChannelAddressSet                                           \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   void *pvAddress))ROM_USBTABLE[71])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDMAChannelConfigSet                                            \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32Config))ROM_USBTABLE[72])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDMAChannelDisable                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel))ROM_USBTABLE[73])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDMAChannelEnable                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel))ROM_USBTABLE[74])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDMAChannelIntDisable                                           \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel))ROM_USBTABLE[75])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDMAChannelIntEnable                                            \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel))ROM_USBTABLE[76])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDMAChannelCountGet                                             \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Channel))ROM_USBTABLE[77])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDMAChannelCountSet                                             \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Count,                                        \
+                   uint32_t ui32Channel))ROM_USBTABLE[78])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDMAChannelIntStatus                                            \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_USBTABLE[79])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDMAChannelStatus                                               \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       uint32_t ui32Channel))ROM_USBTABLE[80])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBDMAChannelStatusClear                                          \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Channel,                                      \
+                   uint32_t ui32Status))ROM_USBTABLE[81])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHighSpeed                                                      \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   bool bEnable))ROM_USBTABLE[82])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostEndpointPing                                               \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   bool bEnable))ROM_USBTABLE[83])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostEndpointSpeed                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32Flags))ROM_USBTABLE[84])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostLPMConfig                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32ResumeTime,                                   \
+                   uint32_t ui32Config))ROM_USBTABLE[85])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostLPMResume                                                  \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[86])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBHostLPMSend                                                    \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Address,                                      \
+                   uint32_t uiEndpoint))ROM_USBTABLE[87])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBLPMIntDisable                                                  \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Ints))ROM_USBTABLE[88])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBLPMIntEnable                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Ints))ROM_USBTABLE[89])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBLPMIntStatus                                                   \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_USBTABLE[90])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBLPMLinkStateGet                                                \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_USBTABLE[91])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBEndpointPacketCountSet                                         \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Endpoint,                                     \
+                   uint32_t ui32Count))ROM_USBTABLE[92])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBULPIConfig                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Config))ROM_USBTABLE[93])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBULPIDisable                                                    \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[94])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBULPIEnable                                                     \
+        ((void (*)(uint32_t ui32Base))ROM_USBTABLE[95])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBULPIRegRead                                                    \
+        ((uint8_t (*)(uint32_t ui32Base,                                      \
+                      uint8_t ui8Reg))ROM_USBTABLE[96])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBULPIRegWrite                                                   \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint8_t ui8Reg,                                            \
+                   uint8_t ui8Data))ROM_USBTABLE[97])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBOTGSessionRequest                                              \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   bool bStart))ROM_USBTABLE[98])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_USBModeConfig                                                     \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Mode))ROM_USBTABLE[103])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the Watchdog API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_WatchdogIntClear                                                  \
+        ((void (*)(uint32_t ui32Base))ROM_WATCHDOGTABLE[0])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_WatchdogRunning                                                   \
+        ((bool (*)(uint32_t ui32Base))ROM_WATCHDOGTABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_WatchdogEnable                                                    \
+        ((void (*)(uint32_t ui32Base))ROM_WATCHDOGTABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_WatchdogResetEnable                                               \
+        ((void (*)(uint32_t ui32Base))ROM_WATCHDOGTABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_WatchdogResetDisable                                              \
+        ((void (*)(uint32_t ui32Base))ROM_WATCHDOGTABLE[4])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_WatchdogLock                                                      \
+        ((void (*)(uint32_t ui32Base))ROM_WATCHDOGTABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_WatchdogUnlock                                                    \
+        ((void (*)(uint32_t ui32Base))ROM_WATCHDOGTABLE[6])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_WatchdogLockState                                                 \
+        ((bool (*)(uint32_t ui32Base))ROM_WATCHDOGTABLE[7])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_WatchdogReloadSet                                                 \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32LoadVal))ROM_WATCHDOGTABLE[8])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_WatchdogReloadGet                                                 \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_WATCHDOGTABLE[9])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_WatchdogValueGet                                                  \
+        ((uint32_t (*)(uint32_t ui32Base))ROM_WATCHDOGTABLE[10])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_WatchdogIntEnable                                                 \
+        ((void (*)(uint32_t ui32Base))ROM_WATCHDOGTABLE[11])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_WatchdogIntStatus                                                 \
+        ((uint32_t (*)(uint32_t ui32Base,                                     \
+                       bool bMasked))ROM_WATCHDOGTABLE[12])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_WatchdogStallEnable                                               \
+        ((void (*)(uint32_t ui32Base))ROM_WATCHDOGTABLE[13])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_WatchdogStallDisable                                              \
+        ((void (*)(uint32_t ui32Base))ROM_WATCHDOGTABLE[14])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_WatchdogIntTypeSet                                                \
+        ((void (*)(uint32_t ui32Base,                                         \
+                   uint32_t ui32Type))ROM_WATCHDOGTABLE[15])
+#endif
+
+//*****************************************************************************
+//
+// Macros for calling ROM functions in the Software API.
+//
+//*****************************************************************************
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_Crc16Array                                                        \
+        ((uint16_t (*)(uint32_t ui32WordLen,                                  \
+                       const uint32_t *pui32Data))ROM_SOFTWARETABLE[1])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_Crc16Array3                                                       \
+        ((void (*)(uint32_t ui32WordLen,                                      \
+                   const uint32_t *pui32Data,                                 \
+                   uint16_t *pui16Crc3))ROM_SOFTWARETABLE[2])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_Crc16                                                             \
+        ((uint16_t (*)(uint16_t ui16Crc,                                      \
+                       const uint8_t *pui8Data,                               \
+                       uint32_t ui32Count))ROM_SOFTWARETABLE[3])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_Crc8CCITT                                                         \
+        ((uint8_t (*)(uint8_t ui8Crc,                                         \
+                      const uint8_t *pui8Data,                                \
+                      uint32_t ui32Count))ROM_SOFTWARETABLE[4])
+#endif
+#if defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_Crc32                                                             \
+        ((uint32_t (*)(uint32_t ui32Crc,                                      \
+                       const uint8_t *pui8Data,                               \
+                       uint32_t ui32Count))ROM_SOFTWARETABLE[5])
+#endif
+#if defined(TARGET_IS_BLIZZARD_RA1) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RA3) ||                                        \
+    defined(TARGET_IS_BLIZZARD_RB1) ||                                        \
+    defined(TARGET_IS_SNOWFLAKE_RA0)
+#define ROM_pvAESTable                                                        \
+        ((void *)&(ROM_SOFTWARETABLE[7]))
+#endif
+
+#endif // __DRIVERLIB_ROM_H__

--- a/cpu/tm4c123/include/driverlib/sysctl.h
+++ b/cpu/tm4c123/include/driverlib/sysctl.h
@@ -1,0 +1,618 @@
+//*****************************************************************************
+//
+// sysctl.h - Prototypes for the system control driver.
+//
+// Copyright (c) 2005-2013 Texas Instruments Incorporated.  All rights reserved.
+// Software License Agreement
+// 
+//   Redistribution and use in source and binary forms, with or without
+//   modification, are permitted provided that the following conditions
+//   are met:
+// 
+//   Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+// 
+//   Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the  
+//   distribution.
+// 
+//   Neither the name of Texas Instruments Incorporated nor the names of
+//   its contributors may be used to endorse or promote products derived
+//   from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// This is part of revision 2.0.1.11577 of the Tiva Peripheral Driver Library.
+//
+//*****************************************************************************
+
+#ifndef __DRIVERLIB_SYSCTL_H__
+#define __DRIVERLIB_SYSCTL_H__
+
+//*****************************************************************************
+//
+// If building with a C++ compiler, make all of the definitions in this header
+// have a C binding.
+//
+//*****************************************************************************
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+//*****************************************************************************
+//
+// The following are values that can be passed to the
+// SysCtlPeripheralPresent(), SysCtlPeripheralEnable(),
+// SysCtlPeripheralDisable(), and SysCtlPeripheralReset() APIs as the
+// ui32Peripheral parameter.  The peripherals in the fourth group (upper nibble
+// is 3) can only be used with the SysCtlPeripheralPresent() API.
+//
+//*****************************************************************************
+#define SYSCTL_PERIPH_ADC0      0xf0003800  // ADC 0
+#define SYSCTL_PERIPH_ADC1      0xf0003801  // ADC 1
+#define SYSCTL_PERIPH_CAN0      0xf0003400  // CAN 0
+#define SYSCTL_PERIPH_CAN1      0xf0003401  // CAN 1
+#define SYSCTL_PERIPH_CAN2      0xf0003402  // CAN 2
+#define SYSCTL_PERIPH_COMP0     0xf0003c00  // Analog comparator 0
+#define SYSCTL_PERIPH_COMP1     0xf0003c01  // Analog comparator 1
+#define SYSCTL_PERIPH_COMP2     0xf0003c02  // Analog comparator 2
+#define SYSCTL_PERIPH_EMAC0     0xf0009c00  // Ethernet MAC0
+#define SYSCTL_PERIPH_EPHY0     0xf0003000  // Ethernet PHY0
+#define SYSCTL_PERIPH_EPI0      0xf0001000  // EPI0
+#define SYSCTL_PERIPH_GPIOA     0xf0000800  // GPIO A
+#define SYSCTL_PERIPH_GPIOB     0xf0000801  // GPIO B
+#define SYSCTL_PERIPH_GPIOC     0xf0000802  // GPIO C
+#define SYSCTL_PERIPH_GPIOD     0xf0000803  // GPIO D
+#define SYSCTL_PERIPH_GPIOE     0xf0000804  // GPIO E
+#define SYSCTL_PERIPH_GPIOF     0xf0000805  // GPIO F
+#define SYSCTL_PERIPH_GPIOG     0xf0000806  // GPIO G
+#define SYSCTL_PERIPH_GPIOH     0xf0000807  // GPIO H
+#define SYSCTL_PERIPH_GPIOJ     0xf0000808  // GPIO J
+#define SYSCTL_PERIPH_HIBERNATE 0xf0001400  // Hibernation module
+#define SYSCTL_PERIPH_CCM0      0xf0007400  // CCM 0
+#define SYSCTL_PERIPH_EEPROM0   0xf0005800  // EEPROM 0
+#define SYSCTL_PERIPH_FAN0      0xf0005400  // FAN 0
+#define SYSCTL_PERIPH_FAN1      0xf0005401  // FAN 1
+#define SYSCTL_PERIPH_GPIOK     0xf0000809  // GPIO K
+#define SYSCTL_PERIPH_GPIOL     0xf000080a  // GPIO L
+#define SYSCTL_PERIPH_GPIOM     0xf000080b  // GPIO M
+#define SYSCTL_PERIPH_GPION     0xf000080c  // GPIO N
+#define SYSCTL_PERIPH_GPIOP     0xf000080d  // GPIO P
+#define SYSCTL_PERIPH_GPIOQ     0xf000080e  // GPIO Q
+#define SYSCTL_PERIPH_GPIOR     0xf000080f  // GPIO R
+#define SYSCTL_PERIPH_GPIOS     0xf0000810  // GPIO S
+#define SYSCTL_PERIPH_GPIOT     0xf0000811  // GPIO T
+#define SYSCTL_PERIPH_I2C0      0xf0002000  // I2C 0
+#define SYSCTL_PERIPH_I2C1      0xf0002001  // I2C 1
+#define SYSCTL_PERIPH_I2C2      0xf0002002  // I2C 2
+#define SYSCTL_PERIPH_I2C3      0xf0002003  // I2C 3
+#define SYSCTL_PERIPH_I2C4      0xf0002004  // I2C 4
+#define SYSCTL_PERIPH_I2C5      0xf0002005  // I2C 5
+#define SYSCTL_PERIPH_I2C6      0xf0002006  // I2C 6
+#define SYSCTL_PERIPH_I2C7      0xf0002007  // I2C 7
+#define SYSCTL_PERIPH_I2C8      0xf0002008  // I2C 8
+#define SYSCTL_PERIPH_I2C9      0xf0002009  // I2C 9
+#define SYSCTL_PERIPH_LCD0      0xf0009000  // LCD 0
+#define SYSCTL_PERIPH_PWM0      0xf0004000  // PWM 0
+#define SYSCTL_PERIPH_PWM1      0xf0004001  // PWM 1
+#define SYSCTL_PERIPH_QEI0      0xf0004400  // QEI 0
+#define SYSCTL_PERIPH_QEI1      0xf0004401  // QEI 1
+#define SYSCTL_PERIPH_SSI0      0xf0001c00  // SSI 0
+#define SYSCTL_PERIPH_SSI1      0xf0001c01  // SSI 1
+#define SYSCTL_PERIPH_SSI2      0xf0001c02  // SSI 2
+#define SYSCTL_PERIPH_SSI3      0xf0001c03  // SSI 3
+#define SYSCTL_PERIPH_TIMER0    0xf0000400  // Timer 0
+#define SYSCTL_PERIPH_TIMER1    0xf0000401  // Timer 1
+#define SYSCTL_PERIPH_TIMER2    0xf0000402  // Timer 2
+#define SYSCTL_PERIPH_TIMER3    0xf0000403  // Timer 3
+#define SYSCTL_PERIPH_TIMER4    0xf0000404  // Timer 4
+#define SYSCTL_PERIPH_TIMER5    0xf0000405  // Timer 5
+#define SYSCTL_PERIPH_TIMER6    0xf0000406  // Timer 6
+#define SYSCTL_PERIPH_TIMER7    0xf0000407  // Timer 7
+#define SYSCTL_PERIPH_UART0     0xf0001800  // UART 0
+#define SYSCTL_PERIPH_UART1     0xf0001801  // UART 1
+#define SYSCTL_PERIPH_UART2     0xf0001802  // UART 2
+#define SYSCTL_PERIPH_UART3     0xf0001803  // UART 3
+#define SYSCTL_PERIPH_UART4     0xf0001804  // UART 4
+#define SYSCTL_PERIPH_UART5     0xf0001805  // UART 5
+#define SYSCTL_PERIPH_UART6     0xf0001806  // UART 6
+#define SYSCTL_PERIPH_UART7     0xf0001807  // UART 7
+#define SYSCTL_PERIPH_UDMA      0xf0000c00  // uDMA
+#define SYSCTL_PERIPH_USB0      0xf0002800  // USB 0
+#define SYSCTL_PERIPH_WDOG0     0xf0000000  // Watchdog 0
+#define SYSCTL_PERIPH_WDOG1     0xf0000001  // Watchdog 1
+#define SYSCTL_PERIPH_WTIMER0   0xf0005c00  // Wide Timer 0
+#define SYSCTL_PERIPH_WTIMER1   0xf0005c01  // Wide Timer 1
+#define SYSCTL_PERIPH_WTIMER2   0xf0005c02  // Wide Timer 2
+#define SYSCTL_PERIPH_WTIMER3   0xf0005c03  // Wide Timer 3
+#define SYSCTL_PERIPH_WTIMER4   0xf0005c04  // Wide Timer 4
+#define SYSCTL_PERIPH_WTIMER5   0xf0005c05  // Wide Timer 5
+
+//*****************************************************************************
+//
+// The following are values that can be passed to the SysCtlLDOSleepSet() and
+// SysCtlLDODeepSleepSet() APIs as the ui32Voltage value, or returned by the
+// SysCtlLDOSleepGet() and SysCtlLDODeepSleepGet() APIs.
+//
+//*****************************************************************************
+#define SYSCTL_LDO_0_90V        0x80000012  // LDO output of 0.90V
+#define SYSCTL_LDO_0_95V        0x80000013  // LDO output of 0.95V
+#define SYSCTL_LDO_1_00V        0x80000014  // LDO output of 1.00V
+#define SYSCTL_LDO_1_05V        0x80000015  // LDO output of 1.05V
+#define SYSCTL_LDO_1_10V        0x80000016  // LDO output of 1.10V
+#define SYSCTL_LDO_1_15V        0x80000017  // LDO output of 1.15V
+#define SYSCTL_LDO_1_20V        0x80000018  // LDO output of 1.20V
+
+//*****************************************************************************
+//
+// The following are values that can be passed to the SysCtlIntEnable(),
+// SysCtlIntDisable(), and SysCtlIntClear() APIs, or returned in the bit mask
+// by the SysCtlIntStatus() API.
+//
+//*****************************************************************************
+#define SYSCTL_INT_MOSC_PUP     0x00000100  // MOSC power-up interrupt
+#define SYSCTL_INT_USBPLL_LOCK  0x00000080  // USB PLL lock interrupt
+#define SYSCTL_INT_PLL_LOCK     0x00000040  // PLL lock interrupt
+#define SYSCTL_INT_CUR_LIMIT    0x00000020  // Current limit interrupt
+#define SYSCTL_INT_IOSC_FAIL    0x00000010  // Internal oscillator failure int
+#define SYSCTL_INT_MOSC_FAIL    0x00000008  // Main oscillator failure int
+#define SYSCTL_INT_POR          0x00000004  // Power on reset interrupt
+#define SYSCTL_INT_BOR          0x00000002  // Brown out interrupt
+#define SYSCTL_INT_PLL_FAIL     0x00000001  // PLL failure interrupt
+
+//*****************************************************************************
+//
+// The following are values that can be passed to the SysCtlResetCauseClear()
+// API or returned by the SysCtlResetCauseGet() API.
+//
+//*****************************************************************************
+#define SYSCTL_CAUSE_HSRVREQ    0x00001000  // Hardware System Service Request
+#define SYSCTL_CAUSE_HIB        0x00000040  // Hibernate reset
+#define SYSCTL_CAUSE_LDO        0x00000020  // LDO power not OK reset
+#define SYSCTL_CAUSE_WDOG1      0x00000020  // Watchdog 1 reset
+#define SYSCTL_CAUSE_SW         0x00000010  // Software reset
+#define SYSCTL_CAUSE_WDOG0      0x00000008  // Watchdog 0 reset
+#define SYSCTL_CAUSE_WDOG       0x00000008  // Watchdog reset
+#define SYSCTL_CAUSE_BOR        0x00000004  // Brown-out reset
+#define SYSCTL_CAUSE_POR        0x00000002  // Power on reset
+#define SYSCTL_CAUSE_EXT        0x00000001  // External reset
+
+//*****************************************************************************
+//
+// The following are values that can be passed to the SysCtlBrownOutConfigSet()
+// API as the ui32Config parameter.
+//
+//*****************************************************************************
+#define SYSCTL_BOR_RESET        0x00000002  // Reset instead of interrupting
+#define SYSCTL_BOR_RESAMPLE     0x00000001  // Resample BOR before asserting
+
+//*****************************************************************************
+//
+// The following are values that can be passed to the SysCtlPWMClockSet() API
+// as the ui32Config parameter, and can be returned by the SysCtlPWMClockGet()
+// API.
+//
+//*****************************************************************************
+#define SYSCTL_PWMDIV_1         0x00000000  // PWM clock is processor clock /1
+#define SYSCTL_PWMDIV_2         0x00100000  // PWM clock is processor clock /2
+#define SYSCTL_PWMDIV_4         0x00120000  // PWM clock is processor clock /4
+#define SYSCTL_PWMDIV_8         0x00140000  // PWM clock is processor clock /8
+#define SYSCTL_PWMDIV_16        0x00160000  // PWM clock is processor clock /16
+#define SYSCTL_PWMDIV_32        0x00180000  // PWM clock is processor clock /32
+#define SYSCTL_PWMDIV_64        0x001A0000  // PWM clock is processor clock /64
+
+//*****************************************************************************
+//
+// The following are values that can be passed to the SysCtlADCSpeedSet() API
+// as the ui32Speed parameter, and can be returned by the SysCtlADCSpeedGet()
+// API.
+//
+//*****************************************************************************
+#define SYSCTL_ADCSPEED_1MSPS   0x00000F00  // 1,000,000 samples per second
+#define SYSCTL_ADCSPEED_500KSPS 0x00000A00  // 500,000 samples per second
+#define SYSCTL_ADCSPEED_250KSPS 0x00000500  // 250,000 samples per second
+#define SYSCTL_ADCSPEED_125KSPS 0x00000000  // 125,000 samples per second
+
+//*****************************************************************************
+//
+// The following are values that can be passed to the SysCtlClockSet() API as
+// the ui32Config parameter.
+//
+//*****************************************************************************
+#define SYSCTL_SYSDIV_1         0x07800000  // Processor clock is osc/pll /1
+#define SYSCTL_SYSDIV_2         0x00C00000  // Processor clock is osc/pll /2
+#define SYSCTL_SYSDIV_3         0x01400000  // Processor clock is osc/pll /3
+#define SYSCTL_SYSDIV_4         0x01C00000  // Processor clock is osc/pll /4
+#define SYSCTL_SYSDIV_5         0x02400000  // Processor clock is osc/pll /5
+#define SYSCTL_SYSDIV_6         0x02C00000  // Processor clock is osc/pll /6
+#define SYSCTL_SYSDIV_7         0x03400000  // Processor clock is osc/pll /7
+#define SYSCTL_SYSDIV_8         0x03C00000  // Processor clock is osc/pll /8
+#define SYSCTL_SYSDIV_9         0x04400000  // Processor clock is osc/pll /9
+#define SYSCTL_SYSDIV_10        0x04C00000  // Processor clock is osc/pll /10
+#define SYSCTL_SYSDIV_11        0x05400000  // Processor clock is osc/pll /11
+#define SYSCTL_SYSDIV_12        0x05C00000  // Processor clock is osc/pll /12
+#define SYSCTL_SYSDIV_13        0x06400000  // Processor clock is osc/pll /13
+#define SYSCTL_SYSDIV_14        0x06C00000  // Processor clock is osc/pll /14
+#define SYSCTL_SYSDIV_15        0x07400000  // Processor clock is osc/pll /15
+#define SYSCTL_SYSDIV_16        0x07C00000  // Processor clock is osc/pll /16
+#define SYSCTL_SYSDIV_17        0x88400000  // Processor clock is osc/pll /17
+#define SYSCTL_SYSDIV_18        0x88C00000  // Processor clock is osc/pll /18
+#define SYSCTL_SYSDIV_19        0x89400000  // Processor clock is osc/pll /19
+#define SYSCTL_SYSDIV_20        0x89C00000  // Processor clock is osc/pll /20
+#define SYSCTL_SYSDIV_21        0x8A400000  // Processor clock is osc/pll /21
+#define SYSCTL_SYSDIV_22        0x8AC00000  // Processor clock is osc/pll /22
+#define SYSCTL_SYSDIV_23        0x8B400000  // Processor clock is osc/pll /23
+#define SYSCTL_SYSDIV_24        0x8BC00000  // Processor clock is osc/pll /24
+#define SYSCTL_SYSDIV_25        0x8C400000  // Processor clock is osc/pll /25
+#define SYSCTL_SYSDIV_26        0x8CC00000  // Processor clock is osc/pll /26
+#define SYSCTL_SYSDIV_27        0x8D400000  // Processor clock is osc/pll /27
+#define SYSCTL_SYSDIV_28        0x8DC00000  // Processor clock is osc/pll /28
+#define SYSCTL_SYSDIV_29        0x8E400000  // Processor clock is osc/pll /29
+#define SYSCTL_SYSDIV_30        0x8EC00000  // Processor clock is osc/pll /30
+#define SYSCTL_SYSDIV_31        0x8F400000  // Processor clock is osc/pll /31
+#define SYSCTL_SYSDIV_32        0x8FC00000  // Processor clock is osc/pll /32
+#define SYSCTL_SYSDIV_33        0x90400000  // Processor clock is osc/pll /33
+#define SYSCTL_SYSDIV_34        0x90C00000  // Processor clock is osc/pll /34
+#define SYSCTL_SYSDIV_35        0x91400000  // Processor clock is osc/pll /35
+#define SYSCTL_SYSDIV_36        0x91C00000  // Processor clock is osc/pll /36
+#define SYSCTL_SYSDIV_37        0x92400000  // Processor clock is osc/pll /37
+#define SYSCTL_SYSDIV_38        0x92C00000  // Processor clock is osc/pll /38
+#define SYSCTL_SYSDIV_39        0x93400000  // Processor clock is osc/pll /39
+#define SYSCTL_SYSDIV_40        0x93C00000  // Processor clock is osc/pll /40
+#define SYSCTL_SYSDIV_41        0x94400000  // Processor clock is osc/pll /41
+#define SYSCTL_SYSDIV_42        0x94C00000  // Processor clock is osc/pll /42
+#define SYSCTL_SYSDIV_43        0x95400000  // Processor clock is osc/pll /43
+#define SYSCTL_SYSDIV_44        0x95C00000  // Processor clock is osc/pll /44
+#define SYSCTL_SYSDIV_45        0x96400000  // Processor clock is osc/pll /45
+#define SYSCTL_SYSDIV_46        0x96C00000  // Processor clock is osc/pll /46
+#define SYSCTL_SYSDIV_47        0x97400000  // Processor clock is osc/pll /47
+#define SYSCTL_SYSDIV_48        0x97C00000  // Processor clock is osc/pll /48
+#define SYSCTL_SYSDIV_49        0x98400000  // Processor clock is osc/pll /49
+#define SYSCTL_SYSDIV_50        0x98C00000  // Processor clock is osc/pll /50
+#define SYSCTL_SYSDIV_51        0x99400000  // Processor clock is osc/pll /51
+#define SYSCTL_SYSDIV_52        0x99C00000  // Processor clock is osc/pll /52
+#define SYSCTL_SYSDIV_53        0x9A400000  // Processor clock is osc/pll /53
+#define SYSCTL_SYSDIV_54        0x9AC00000  // Processor clock is osc/pll /54
+#define SYSCTL_SYSDIV_55        0x9B400000  // Processor clock is osc/pll /55
+#define SYSCTL_SYSDIV_56        0x9BC00000  // Processor clock is osc/pll /56
+#define SYSCTL_SYSDIV_57        0x9C400000  // Processor clock is osc/pll /57
+#define SYSCTL_SYSDIV_58        0x9CC00000  // Processor clock is osc/pll /58
+#define SYSCTL_SYSDIV_59        0x9D400000  // Processor clock is osc/pll /59
+#define SYSCTL_SYSDIV_60        0x9DC00000  // Processor clock is osc/pll /60
+#define SYSCTL_SYSDIV_61        0x9E400000  // Processor clock is osc/pll /61
+#define SYSCTL_SYSDIV_62        0x9EC00000  // Processor clock is osc/pll /62
+#define SYSCTL_SYSDIV_63        0x9F400000  // Processor clock is osc/pll /63
+#define SYSCTL_SYSDIV_64        0x9FC00000  // Processor clock is osc/pll /64
+#define SYSCTL_SYSDIV_2_5       0xC1000000  // Processor clock is pll / 2.5
+#define SYSCTL_SYSDIV_3_5       0xC1800000  // Processor clock is pll / 3.5
+#define SYSCTL_SYSDIV_4_5       0xC2000000  // Processor clock is pll / 4.5
+#define SYSCTL_SYSDIV_5_5       0xC2800000  // Processor clock is pll / 5.5
+#define SYSCTL_SYSDIV_6_5       0xC3000000  // Processor clock is pll / 6.5
+#define SYSCTL_SYSDIV_7_5       0xC3800000  // Processor clock is pll / 7.5
+#define SYSCTL_SYSDIV_8_5       0xC4000000  // Processor clock is pll / 8.5
+#define SYSCTL_SYSDIV_9_5       0xC4800000  // Processor clock is pll / 9.5
+#define SYSCTL_SYSDIV_10_5      0xC5000000  // Processor clock is pll / 10.5
+#define SYSCTL_SYSDIV_11_5      0xC5800000  // Processor clock is pll / 11.5
+#define SYSCTL_SYSDIV_12_5      0xC6000000  // Processor clock is pll / 12.5
+#define SYSCTL_SYSDIV_13_5      0xC6800000  // Processor clock is pll / 13.5
+#define SYSCTL_SYSDIV_14_5      0xC7000000  // Processor clock is pll / 14.5
+#define SYSCTL_SYSDIV_15_5      0xC7800000  // Processor clock is pll / 15.5
+#define SYSCTL_SYSDIV_16_5      0xC8000000  // Processor clock is pll / 16.5
+#define SYSCTL_SYSDIV_17_5      0xC8800000  // Processor clock is pll / 17.5
+#define SYSCTL_SYSDIV_18_5      0xC9000000  // Processor clock is pll / 18.5
+#define SYSCTL_SYSDIV_19_5      0xC9800000  // Processor clock is pll / 19.5
+#define SYSCTL_SYSDIV_20_5      0xCA000000  // Processor clock is pll / 20.5
+#define SYSCTL_SYSDIV_21_5      0xCA800000  // Processor clock is pll / 21.5
+#define SYSCTL_SYSDIV_22_5      0xCB000000  // Processor clock is pll / 22.5
+#define SYSCTL_SYSDIV_23_5      0xCB800000  // Processor clock is pll / 23.5
+#define SYSCTL_SYSDIV_24_5      0xCC000000  // Processor clock is pll / 24.5
+#define SYSCTL_SYSDIV_25_5      0xCC800000  // Processor clock is pll / 25.5
+#define SYSCTL_SYSDIV_26_5      0xCD000000  // Processor clock is pll / 26.5
+#define SYSCTL_SYSDIV_27_5      0xCD800000  // Processor clock is pll / 27.5
+#define SYSCTL_SYSDIV_28_5      0xCE000000  // Processor clock is pll / 28.5
+#define SYSCTL_SYSDIV_29_5      0xCE800000  // Processor clock is pll / 29.5
+#define SYSCTL_SYSDIV_30_5      0xCF000000  // Processor clock is pll / 30.5
+#define SYSCTL_SYSDIV_31_5      0xCF800000  // Processor clock is pll / 31.5
+#define SYSCTL_SYSDIV_32_5      0xD0000000  // Processor clock is pll / 32.5
+#define SYSCTL_SYSDIV_33_5      0xD0800000  // Processor clock is pll / 33.5
+#define SYSCTL_SYSDIV_34_5      0xD1000000  // Processor clock is pll / 34.5
+#define SYSCTL_SYSDIV_35_5      0xD1800000  // Processor clock is pll / 35.5
+#define SYSCTL_SYSDIV_36_5      0xD2000000  // Processor clock is pll / 36.5
+#define SYSCTL_SYSDIV_37_5      0xD2800000  // Processor clock is pll / 37.5
+#define SYSCTL_SYSDIV_38_5      0xD3000000  // Processor clock is pll / 38.5
+#define SYSCTL_SYSDIV_39_5      0xD3800000  // Processor clock is pll / 39.5
+#define SYSCTL_SYSDIV_40_5      0xD4000000  // Processor clock is pll / 40.5
+#define SYSCTL_SYSDIV_41_5      0xD4800000  // Processor clock is pll / 41.5
+#define SYSCTL_SYSDIV_42_5      0xD5000000  // Processor clock is pll / 42.5
+#define SYSCTL_SYSDIV_43_5      0xD5800000  // Processor clock is pll / 43.5
+#define SYSCTL_SYSDIV_44_5      0xD6000000  // Processor clock is pll / 44.5
+#define SYSCTL_SYSDIV_45_5      0xD6800000  // Processor clock is pll / 45.5
+#define SYSCTL_SYSDIV_46_5      0xD7000000  // Processor clock is pll / 46.5
+#define SYSCTL_SYSDIV_47_5      0xD7800000  // Processor clock is pll / 47.5
+#define SYSCTL_SYSDIV_48_5      0xD8000000  // Processor clock is pll / 48.5
+#define SYSCTL_SYSDIV_49_5      0xD8800000  // Processor clock is pll / 49.5
+#define SYSCTL_SYSDIV_50_5      0xD9000000  // Processor clock is pll / 50.5
+#define SYSCTL_SYSDIV_51_5      0xD9800000  // Processor clock is pll / 51.5
+#define SYSCTL_SYSDIV_52_5      0xDA000000  // Processor clock is pll / 52.5
+#define SYSCTL_SYSDIV_53_5      0xDA800000  // Processor clock is pll / 53.5
+#define SYSCTL_SYSDIV_54_5      0xDB000000  // Processor clock is pll / 54.5
+#define SYSCTL_SYSDIV_55_5      0xDB800000  // Processor clock is pll / 55.5
+#define SYSCTL_SYSDIV_56_5      0xDC000000  // Processor clock is pll / 56.5
+#define SYSCTL_SYSDIV_57_5      0xDC800000  // Processor clock is pll / 57.5
+#define SYSCTL_SYSDIV_58_5      0xDD000000  // Processor clock is pll / 58.5
+#define SYSCTL_SYSDIV_59_5      0xDD800000  // Processor clock is pll / 59.5
+#define SYSCTL_SYSDIV_60_5      0xDE000000  // Processor clock is pll / 60.5
+#define SYSCTL_SYSDIV_61_5      0xDE800000  // Processor clock is pll / 61.5
+#define SYSCTL_SYSDIV_62_5      0xDF000000  // Processor clock is pll / 62.5
+#define SYSCTL_SYSDIV_63_5      0xDF800000  // Processor clock is pll / 63.5
+#define SYSCTL_CFG_VCO_480      0xF1000000  // VCO is 480 MHz
+#define SYSCTL_CFG_VCO_320      0xF0000000  // VCO is 320 MHz
+#define SYSCTL_USE_PLL          0x00000000  // System clock is the PLL clock
+#define SYSCTL_USE_OSC          0x00003800  // System clock is the osc clock
+#define SYSCTL_XTAL_1MHZ        0x00000000  // External crystal is 1MHz
+#define SYSCTL_XTAL_1_84MHZ     0x00000040  // External crystal is 1.8432MHz
+#define SYSCTL_XTAL_2MHZ        0x00000080  // External crystal is 2MHz
+#define SYSCTL_XTAL_2_45MHZ     0x000000C0  // External crystal is 2.4576MHz
+#define SYSCTL_XTAL_3_57MHZ     0x00000100  // External crystal is 3.579545MHz
+#define SYSCTL_XTAL_3_68MHZ     0x00000140  // External crystal is 3.6864MHz
+#define SYSCTL_XTAL_4MHZ        0x00000180  // External crystal is 4MHz
+#define SYSCTL_XTAL_4_09MHZ     0x000001C0  // External crystal is 4.096MHz
+#define SYSCTL_XTAL_4_91MHZ     0x00000200  // External crystal is 4.9152MHz
+#define SYSCTL_XTAL_5MHZ        0x00000240  // External crystal is 5MHz
+#define SYSCTL_XTAL_5_12MHZ     0x00000280  // External crystal is 5.12MHz
+#define SYSCTL_XTAL_6MHZ        0x000002C0  // External crystal is 6MHz
+#define SYSCTL_XTAL_6_14MHZ     0x00000300  // External crystal is 6.144MHz
+#define SYSCTL_XTAL_7_37MHZ     0x00000340  // External crystal is 7.3728MHz
+#define SYSCTL_XTAL_8MHZ        0x00000380  // External crystal is 8MHz
+#define SYSCTL_XTAL_8_19MHZ     0x000003C0  // External crystal is 8.192MHz
+#define SYSCTL_XTAL_10MHZ       0x00000400  // External crystal is 10 MHz
+#define SYSCTL_XTAL_12MHZ       0x00000440  // External crystal is 12 MHz
+#define SYSCTL_XTAL_12_2MHZ     0x00000480  // External crystal is 12.288 MHz
+#define SYSCTL_XTAL_13_5MHZ     0x000004C0  // External crystal is 13.56 MHz
+#define SYSCTL_XTAL_14_3MHZ     0x00000500  // External crystal is 14.31818 MHz
+#define SYSCTL_XTAL_16MHZ       0x00000540  // External crystal is 16 MHz
+#define SYSCTL_XTAL_16_3MHZ     0x00000580  // External crystal is 16.384 MHz
+#define SYSCTL_XTAL_18MHZ       0x000005C0  // External crystal is 18.0 MHz
+#define SYSCTL_XTAL_20MHZ       0x00000600  // External crystal is 20.0 MHz
+#define SYSCTL_XTAL_24MHZ       0x00000640  // External crystal is 24.0 MHz
+#define SYSCTL_XTAL_25MHZ       0x00000680  // External crystal is 25.0 MHz
+#define SYSCTL_OSC_MAIN         0x00000000  // Osc source is main osc
+#define SYSCTL_OSC_INT          0x00000010  // Osc source is int. osc
+#define SYSCTL_OSC_INT4         0x00000020  // Osc source is int. osc /4
+#define SYSCTL_OSC_INT30        0x00000030  // Osc source is int. 30 KHz
+#define SYSCTL_OSC_EXT4_19      0x80000028  // Osc source is ext. 4.19 MHz
+#define SYSCTL_OSC_EXT32        0x80000038  // Osc source is ext. 32 KHz
+#define SYSCTL_INT_OSC_DIS      0x00000002  // Disable internal oscillator
+#define SYSCTL_MAIN_OSC_DIS     0x00000001  // Disable main oscillator
+
+//*****************************************************************************
+//
+// The following are values that can be passed to the SysCtlDeepSleepClockSet()
+// API as the ui32Config parameter.
+//
+//*****************************************************************************
+#define SYSCTL_DSLP_DIV_1       0x00000000  // Deep-sleep clock is osc /1
+#define SYSCTL_DSLP_DIV_2       0x00800000  // Deep-sleep clock is osc /2
+#define SYSCTL_DSLP_DIV_3       0x01000000  // Deep-sleep clock is osc /3
+#define SYSCTL_DSLP_DIV_4       0x01800000  // Deep-sleep clock is osc /4
+#define SYSCTL_DSLP_DIV_5       0x02000000  // Deep-sleep clock is osc /5
+#define SYSCTL_DSLP_DIV_6       0x02800000  // Deep-sleep clock is osc /6
+#define SYSCTL_DSLP_DIV_7       0x03000000  // Deep-sleep clock is osc /7
+#define SYSCTL_DSLP_DIV_8       0x03800000  // Deep-sleep clock is osc /8
+#define SYSCTL_DSLP_DIV_9       0x04000000  // Deep-sleep clock is osc /9
+#define SYSCTL_DSLP_DIV_10      0x04800000  // Deep-sleep clock is osc /10
+#define SYSCTL_DSLP_DIV_11      0x05000000  // Deep-sleep clock is osc /11
+#define SYSCTL_DSLP_DIV_12      0x05800000  // Deep-sleep clock is osc /12
+#define SYSCTL_DSLP_DIV_13      0x06000000  // Deep-sleep clock is osc /13
+#define SYSCTL_DSLP_DIV_14      0x06800000  // Deep-sleep clock is osc /14
+#define SYSCTL_DSLP_DIV_15      0x07000000  // Deep-sleep clock is osc /15
+#define SYSCTL_DSLP_DIV_16      0x07800000  // Deep-sleep clock is osc /16
+#define SYSCTL_DSLP_DIV_17      0x08000000  // Deep-sleep clock is osc /17
+#define SYSCTL_DSLP_DIV_18      0x08800000  // Deep-sleep clock is osc /18
+#define SYSCTL_DSLP_DIV_19      0x09000000  // Deep-sleep clock is osc /19
+#define SYSCTL_DSLP_DIV_20      0x09800000  // Deep-sleep clock is osc /20
+#define SYSCTL_DSLP_DIV_21      0x0A000000  // Deep-sleep clock is osc /21
+#define SYSCTL_DSLP_DIV_22      0x0A800000  // Deep-sleep clock is osc /22
+#define SYSCTL_DSLP_DIV_23      0x0B000000  // Deep-sleep clock is osc /23
+#define SYSCTL_DSLP_DIV_24      0x0B800000  // Deep-sleep clock is osc /24
+#define SYSCTL_DSLP_DIV_25      0x0C000000  // Deep-sleep clock is osc /25
+#define SYSCTL_DSLP_DIV_26      0x0C800000  // Deep-sleep clock is osc /26
+#define SYSCTL_DSLP_DIV_27      0x0D000000  // Deep-sleep clock is osc /27
+#define SYSCTL_DSLP_DIV_28      0x0D800000  // Deep-sleep clock is osc /28
+#define SYSCTL_DSLP_DIV_29      0x0E000000  // Deep-sleep clock is osc /29
+#define SYSCTL_DSLP_DIV_30      0x0E800000  // Deep-sleep clock is osc /30
+#define SYSCTL_DSLP_DIV_31      0x0F000000  // Deep-sleep clock is osc /31
+#define SYSCTL_DSLP_DIV_32      0x0F800000  // Deep-sleep clock is osc /32
+#define SYSCTL_DSLP_DIV_33      0x10000000  // Deep-sleep clock is osc /33
+#define SYSCTL_DSLP_DIV_34      0x10800000  // Deep-sleep clock is osc /34
+#define SYSCTL_DSLP_DIV_35      0x11000000  // Deep-sleep clock is osc /35
+#define SYSCTL_DSLP_DIV_36      0x11800000  // Deep-sleep clock is osc /36
+#define SYSCTL_DSLP_DIV_37      0x12000000  // Deep-sleep clock is osc /37
+#define SYSCTL_DSLP_DIV_38      0x12800000  // Deep-sleep clock is osc /38
+#define SYSCTL_DSLP_DIV_39      0x13000000  // Deep-sleep clock is osc /39
+#define SYSCTL_DSLP_DIV_40      0x13800000  // Deep-sleep clock is osc /40
+#define SYSCTL_DSLP_DIV_41      0x14000000  // Deep-sleep clock is osc /41
+#define SYSCTL_DSLP_DIV_42      0x14800000  // Deep-sleep clock is osc /42
+#define SYSCTL_DSLP_DIV_43      0x15000000  // Deep-sleep clock is osc /43
+#define SYSCTL_DSLP_DIV_44      0x15800000  // Deep-sleep clock is osc /44
+#define SYSCTL_DSLP_DIV_45      0x16000000  // Deep-sleep clock is osc /45
+#define SYSCTL_DSLP_DIV_46      0x16800000  // Deep-sleep clock is osc /46
+#define SYSCTL_DSLP_DIV_47      0x17000000  // Deep-sleep clock is osc /47
+#define SYSCTL_DSLP_DIV_48      0x17800000  // Deep-sleep clock is osc /48
+#define SYSCTL_DSLP_DIV_49      0x18000000  // Deep-sleep clock is osc /49
+#define SYSCTL_DSLP_DIV_50      0x18800000  // Deep-sleep clock is osc /50
+#define SYSCTL_DSLP_DIV_51      0x19000000  // Deep-sleep clock is osc /51
+#define SYSCTL_DSLP_DIV_52      0x19800000  // Deep-sleep clock is osc /52
+#define SYSCTL_DSLP_DIV_53      0x1A000000  // Deep-sleep clock is osc /53
+#define SYSCTL_DSLP_DIV_54      0x1A800000  // Deep-sleep clock is osc /54
+#define SYSCTL_DSLP_DIV_55      0x1B000000  // Deep-sleep clock is osc /55
+#define SYSCTL_DSLP_DIV_56      0x1B800000  // Deep-sleep clock is osc /56
+#define SYSCTL_DSLP_DIV_57      0x1C000000  // Deep-sleep clock is osc /57
+#define SYSCTL_DSLP_DIV_58      0x1C800000  // Deep-sleep clock is osc /58
+#define SYSCTL_DSLP_DIV_59      0x1D000000  // Deep-sleep clock is osc /59
+#define SYSCTL_DSLP_DIV_60      0x1D800000  // Deep-sleep clock is osc /60
+#define SYSCTL_DSLP_DIV_61      0x1E000000  // Deep-sleep clock is osc /61
+#define SYSCTL_DSLP_DIV_62      0x1E800000  // Deep-sleep clock is osc /62
+#define SYSCTL_DSLP_DIV_63      0x1F000000  // Deep-sleep clock is osc /63
+#define SYSCTL_DSLP_DIV_64      0x1F800000  // Deep-sleep clock is osc /64
+#define SYSCTL_DSLP_OSC_MAIN    0x00000000  // Osc source is main osc
+#define SYSCTL_DSLP_OSC_INT     0x00000010  // Osc source is int. osc
+#define SYSCTL_DSLP_OSC_INT30   0x00000030  // Osc source is int. 30 KHz
+#define SYSCTL_DSLP_OSC_EXT32   0x00000070  // Osc source is ext. 32 KHz
+#define SYSCTL_DSLP_PIOSC_PD    0x00000002  // Power down PIOSC in deep-sleep
+#define SYSCTL_DSLP_MOSC_PD     0x40000000  // Power down MOSC in deep-sleep
+
+//*****************************************************************************
+//
+// The following are values that can be passed to the SysCtlPIOSCCalibrate()
+// API as the ui32Type parameter.
+//
+//*****************************************************************************
+#define SYSCTL_PIOSC_CAL_AUTO   0x00000200  // Automatic calibration
+#define SYSCTL_PIOSC_CAL_FACT   0x00000100  // Factory calibration
+#define SYSCTL_PIOSC_CAL_USER   0x80000100  // User-supplied calibration
+
+//*****************************************************************************
+//
+// The following are values that can be passed to the SysCtlMOSCConfigSet() API
+// as the ui32Config parameter.
+//
+//*****************************************************************************
+#define SYSCTL_MOSC_VALIDATE    0x00000001  // Enable MOSC validation
+#define SYSCTL_MOSC_INTERRUPT   0x00000002  // Generate interrupt on MOSC fail
+#define SYSCTL_MOSC_NO_XTAL     0x00000004  // No crystal is attached to MOSC
+#define SYSCTL_MOSC_PWR_DIS     0x00000008  // Power down the MOSC.
+#define SYSCTL_MOSC_LOWFREQ     0x00000000  // MOSC is less than 10MHz
+#define SYSCTL_MOSC_HIGHFREQ    0x00000010  // MOSC is greater than 10MHz
+#define SYSCTL_MOSC_SESRC       0x00000020  // Singled ended oscillator source.
+
+//*****************************************************************************
+//
+// Defines for the SysCtlResetBehaviorSet() and SysCtlResetBehaviorGet() APIs.
+//
+//*****************************************************************************
+#define SYSCTL_ONRST_WDOG0_POR  0x00000030
+#define SYSCTL_ONRST_WDOG0_SYS  0x00000020
+#define SYSCTL_ONRST_WDOG1_POR  0x000000C0
+#define SYSCTL_ONRST_WDOG1_SYS  0x00000080
+#define SYSCTL_ONRST_BOR_POR    0x0000000C
+#define SYSCTL_ONRST_BOR_SYS    0x00000008
+#define SYSCTL_ONRST_EXT_POR    0x00000003
+#define SYSCTL_ONRST_EXT_SYS    0x00000002
+
+//*****************************************************************************
+//
+// The valid settings for the ui32Config parameter of the
+// SysCtlLPCLowPowerConfigSet() function.
+//
+//*****************************************************************************
+#define SYSCTL_LPCLPWR_SRAM_OFF                                               \
+                                0x00000000
+#define SYSCTL_LPCLPWR_SRAM_RETENTION                                         \
+                                0x00000001
+#define SYSCTL_LPCLPWR_SRAM_ON  0x00000003
+
+//*****************************************************************************
+//
+// The return values from the SysCtlLPCLowPowerStatusGet() function.
+//
+//*****************************************************************************
+#define SYSCTL_LPCLPWRS_PD_OFF  0x00000000
+#define SYSCTL_LPCLPWRS_SRAM_OFF                                              \
+                                0x00000033
+#define SYSCTL_LPCLPWRS_SRAM_RETENTION                                        \
+                                0x00000037
+#define SYSCTL_LPCLPWRS_SRAM_ON 0x0000003F
+
+//*****************************************************************************
+//
+// Values used with the SysCtlVoltageEventConfig() API.
+//
+//*****************************************************************************
+#define SYSCTL_VEVENT_VDDCBO_NONE                                             \
+                                0x00000000
+#define SYSCTL_VEVENT_VDDCBO_INT                                              \
+                                0x00001000
+#define SYSCTL_VEVENT_VDDCBO_NMI                                              \
+                                0x00002000
+#define SYSCTL_VEVENT_VDDCBO_RST                                              \
+                                0x00003000
+#define SYSCTL_VEVENT_VDDABO_NONE                                             \
+                                0x00000000
+#define SYSCTL_VEVENT_VDDABO_INT                                              \
+                                0x00000100
+#define SYSCTL_VEVENT_VDDABO_NMI                                              \
+                                0x00000200
+#define SYSCTL_VEVENT_VDDABO_RST                                              \
+                                0x00000300
+#define SYSCTL_VEVENT_VDDBO_NONE                                              \
+                                0x00000000
+#define SYSCTL_VEVENT_VDDBO_INT 0x00000001
+#define SYSCTL_VEVENT_VDDBO_NMI 0x00000002
+#define SYSCTL_VEVENT_VDDBO_RST 0x00000003
+
+//*****************************************************************************
+//
+// Values used with the SysCtlVoltageEventStatus() and
+// SysCtlVoltageEventClear() APIs.
+//
+//*****************************************************************************
+#define SYSCTL_VESTAT_VDDBOR    0x00000040
+#define SYSCTL_VESTAT_VDDABOR   0x00000010
+#define SYSCTL_VESTAT_VDDCBOR   0x00000001
+
+//*****************************************************************************
+//
+// Values used with the SysCtlNMIStatus() API.
+//
+//*****************************************************************************
+#define SYSCTL_NMI_MOSCFAIL     0x00010000
+#define SYSCTL_NMI_TAMPER       0x00000200
+#define SYSCTL_NMI_WDT1         0x00000020
+#define SYSCTL_NMI_WDT0         0x00000008
+#define SYSCTL_NMI_POWER        0x00000004
+#define SYSCTL_NMI_EXTERNAL     0x00000001
+
+//*****************************************************************************
+//
+// The defines for the SysCtlClockOutConfig() API.
+//
+//*****************************************************************************
+#define SYSCTL_CLKOUT_EN        0x80000000
+#define SYSCTL_CLKOUT_DIS       0x00000000
+#define SYSCTL_CLKOUT_SYSCLK    0x00000000
+#define SYSCTL_CLKOUT_PIOSC     0x00010000
+#define SYSCTL_CLKOUT_MOSC      0x00020000
+
+//*****************************************************************************
+//
+// The following defines are used with the SysCtlAltClkConfig() function.
+//
+//*****************************************************************************
+#define SYSCTL_ALTCLK_PIOSC     0x00000000
+#define SYSCTL_ALTCLK_PIOSC48   0x00000001
+#define SYSCTL_ALTCLK_LFIOSC    0x00000002
+#define SYSCTL_ALTCLK_HIB       0x00000004
+
+//*****************************************************************************
+//
+// Mark the end of the C bindings section for C++ compilers.
+//
+//*****************************************************************************
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __DRIVERLIB_SYSCTL_H__

--- a/cpu/tm4c123/include/driverlib/timer.h
+++ b/cpu/tm4c123/include/driverlib/timer.h
@@ -1,0 +1,236 @@
+//*****************************************************************************
+//
+// timer.h - Prototypes for the timer module
+//
+// Copyright (c) 2005-2013 Texas Instruments Incorporated.  All rights reserved.
+// Software License Agreement
+// 
+//   Redistribution and use in source and binary forms, with or without
+//   modification, are permitted provided that the following conditions
+//   are met:
+// 
+//   Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+// 
+//   Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the  
+//   distribution.
+// 
+//   Neither the name of Texas Instruments Incorporated nor the names of
+//   its contributors may be used to endorse or promote products derived
+//   from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// This is part of revision 2.0.1.11577 of the Tiva Peripheral Driver Library.
+//
+//*****************************************************************************
+
+#ifndef __DRIVERLIB_TIMER_H__
+#define __DRIVERLIB_TIMER_H__
+
+//*****************************************************************************
+//
+// If building with a C++ compiler, make all of the definitions in this header
+// have a C binding.
+//
+//*****************************************************************************
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+//*****************************************************************************
+//
+// Values that can be passed to TimerConfigure as the ui32Config parameter.
+//
+//*****************************************************************************
+#define TIMER_CFG_ONE_SHOT       0x00000021  // Full-width one-shot timer
+#define TIMER_CFG_ONE_SHOT_UP    0x00000031  // Full-width one-shot up-count
+                                            // timer
+#define TIMER_CFG_PERIODIC       0x00000022  // Full-width periodic timer
+#define TIMER_CFG_PERIODIC_UP    0x00000032  // Full-width periodic up-count
+                                            // timer
+#define TIMER_CFG_RTC            0x01000000  // Full-width RTC timer
+#define TIMER_CFG_SPLIT_PAIR     0x04000000  // Two half-width timers
+#define TIMER_CFG_A_ONE_SHOT     0x00000021  // Timer A one-shot timer
+#define TIMER_CFG_A_ONE_SHOT_UP  0x00000031  // Timer A one-shot up-count timer
+#define TIMER_CFG_A_PERIODIC     0x00000022  // Timer A periodic timer
+#define TIMER_CFG_A_PERIODIC_UP  0x00000032  // Timer A periodic up-count timer
+#define TIMER_CFG_A_CAP_COUNT    0x00000003  // Timer A event counter
+#define TIMER_CFG_A_CAP_COUNT_UP 0x00000013  // Timer A event up-counter
+#define TIMER_CFG_A_CAP_TIME     0x00000007  // Timer A event timer
+#define TIMER_CFG_A_CAP_TIME_UP  0x00000017  // Timer A event up-count timer
+#define TIMER_CFG_A_PWM          0x0000000A  // Timer A PWM output
+#define TIMER_CFG_B_ONE_SHOT     0x00002100  // Timer B one-shot timer
+#define TIMER_CFG_B_ONE_SHOT_UP  0x00003100  // Timer B one-shot up-count timer
+#define TIMER_CFG_B_PERIODIC     0x00002200  // Timer B periodic timer
+#define TIMER_CFG_B_PERIODIC_UP  0x00003200  // Timer B periodic up-count timer
+#define TIMER_CFG_B_CAP_COUNT    0x00000300  // Timer B event counter
+#define TIMER_CFG_B_CAP_COUNT_UP 0x00001300  // Timer B event up-counter
+#define TIMER_CFG_B_CAP_TIME     0x00000700  // Timer B event timer
+#define TIMER_CFG_B_CAP_TIME_UP  0x00001700  // Timer B event up-count timer
+#define TIMER_CFG_B_PWM          0x00000A00  // Timer B PWM output
+#define TIMER_CFG_A_ACT_TOINTD   0x00010000  // Timer A compare action disable
+                                             // time-out interrupt.
+#define TIMER_CFG_A_ACT_NONE     0x00000000  // Timer A compare action none.
+#define TIMER_CFG_A_ACT_TOGGLE   0x00020000  // Timer A compare action toggle.
+#define TIMER_CFG_A_ACT_CLRTO    0x00040000  // Timer A compare action CCP
+                                             // clear on time-out.
+#define TIMER_CFG_A_ACT_SETTO    0x00060000  // Timer A compare action CCP set
+                                             // on time-out.
+#define TIMER_CFG_A_ACT_SETTOGTO 0x00080000  // Timer A compare action set CCP
+                                             // toggle on time-out.
+#define TIMER_CFG_A_ACT_CLRTOGTO 0x000A0000  // Timer A compare action clear
+                                             // CCP toggle on time-out.
+#define TIMER_CFG_A_ACT_SETCLRTO 0x000C0000  // Timer A compare action set CCP
+                                             // clear on time-out.
+#define TIMER_CFG_A_ACT_CLRSETTO 0x000E0000  // Timer A compare action clear
+                                             // CCP set on time-out.
+#define TIMER_CFG_B_ACT_TOINTD   0x00100000  // Timer B compare action disable
+                                             // time-out interrupt.
+#define TIMER_CFG_B_ACT_NONE     0x00000000  // Timer A compare action none.
+#define TIMER_CFG_B_ACT_TOGGLE   0x00200000  // Timer A compare action toggle.
+#define TIMER_CFG_B_ACT_CLRTO    0x00400000  // Timer A compare action CCP
+                                             // clear on time-out.
+#define TIMER_CFG_B_ACT_SETTO    0x00600000  // Timer A compare action CCP set
+                                             // on time-out.
+#define TIMER_CFG_B_ACT_SETTOGTO 0x00800000  // Timer A compare action set CCP
+                                             // toggle on time-out.
+#define TIMER_CFG_B_ACT_CLRTOGTO 0x00A00000  // Timer A compare action clear
+                                             // CCP toggle on time-out.
+#define TIMER_CFG_B_ACT_SETCLRTO 0x00C00000  // Timer A compare action set CCP
+                                             // clear on time-out.
+#define TIMER_CFG_B_ACT_CLRSETTO 0x0000E000  // Timer A compare action clear
+                                             // CCP set on time-out.
+
+//*****************************************************************************
+//
+// Values that can be passed to TimerIntEnable, TimerIntDisable, and
+// TimerIntClear as the ui32IntFlags parameter, and returned from
+// TimerIntStatus.
+//
+//*****************************************************************************
+#define TIMER_TIMB_DMA          0x00002000 // TimerB DMA Complete Interrupt.
+#define TIMER_TIMB_MATCH        0x00000800  // TimerB match interrupt
+#define TIMER_CAPB_EVENT        0x00000400  // CaptureB event interrupt
+#define TIMER_CAPB_MATCH        0x00000200  // CaptureB match interrupt
+#define TIMER_TIMB_TIMEOUT      0x00000100  // TimerB time out interrupt
+#define TIMER_TIMA_DMA          0x00000020 // TimerA DMA Complete Interrupt.
+#define TIMER_TIMA_MATCH        0x00000010  // TimerA match interrupt
+#define TIMER_RTC_MATCH         0x00000008  // RTC interrupt mask
+#define TIMER_CAPA_EVENT        0x00000004  // CaptureA event interrupt
+#define TIMER_CAPA_MATCH        0x00000002  // CaptureA match interrupt
+#define TIMER_TIMA_TIMEOUT      0x00000001  // TimerA time out interrupt
+
+//*****************************************************************************
+//
+// Values that can be passed to TimerControlEvent as the ui32Event parameter.
+//
+//*****************************************************************************
+#define TIMER_EVENT_POS_EDGE    0x00000000  // Count positive edges
+#define TIMER_EVENT_NEG_EDGE    0x00000404  // Count negative edges
+#define TIMER_EVENT_BOTH_EDGES  0x00000C0C  // Count both edges
+
+//*****************************************************************************
+//
+// Values that can be passed to most of the timer APIs as the ui32Timer
+// parameter.
+//
+//*****************************************************************************
+#define TIMER_A                 0x000000ff  // Timer A
+#define TIMER_B                 0x0000ff00  // Timer B
+#define TIMER_BOTH              0x0000ffff  // Timer Both
+
+//*****************************************************************************
+//
+// Values that can be passed to TimerSynchronize as the ui32Timers parameter.
+//
+//*****************************************************************************
+#define TIMER_0A_SYNC           0x00000001  // Synchronize Timer 0A
+#define TIMER_0B_SYNC           0x00000002  // Synchronize Timer 0B
+#define TIMER_1A_SYNC           0x00000004  // Synchronize Timer 1A
+#define TIMER_1B_SYNC           0x00000008  // Synchronize Timer 1B
+#define TIMER_2A_SYNC           0x00000010  // Synchronize Timer 2A
+#define TIMER_2B_SYNC           0x00000020  // Synchronize Timer 2B
+#define TIMER_3A_SYNC           0x00000040  // Synchronize Timer 3A
+#define TIMER_3B_SYNC           0x00000080  // Synchronize Timer 3B
+#define TIMER_4A_SYNC           0x00000100  // Synchronize Timer 4A
+#define TIMER_4B_SYNC           0x00000200  // Synchronize Timer 4B
+#define TIMER_5A_SYNC           0x00000400  // Synchronize Timer 5A
+#define TIMER_5B_SYNC           0x00000800  // Synchronize Timer 5B
+#define WTIMER_0A_SYNC          0x00001000  // Synchronize Wide Timer 0A
+#define WTIMER_0B_SYNC          0x00002000  // Synchronize Wide Timer 0B
+#define WTIMER_1A_SYNC          0x00004000  // Synchronize Wide Timer 1A
+#define WTIMER_1B_SYNC          0x00008000  // Synchronize Wide Timer 1B
+#define WTIMER_2A_SYNC          0x00010000  // Synchronize Wide Timer 2A
+#define WTIMER_2B_SYNC          0x00020000  // Synchronize Wide Timer 2B
+#define WTIMER_3A_SYNC          0x00040000  // Synchronize Wide Timer 3A
+#define WTIMER_3B_SYNC          0x00080000  // Synchronize Wide Timer 3B
+#define WTIMER_4A_SYNC          0x00100000  // Synchronize Wide Timer 4A
+#define WTIMER_4B_SYNC          0x00200000  // Synchronize Wide Timer 4B
+#define WTIMER_5A_SYNC          0x00400000  // Synchronize Wide Timer 5A
+#define WTIMER_5B_SYNC          0x00800000  // Synchronize Wide Timer 5B
+
+//*****************************************************************************
+//
+// Values that can be passed to TimerClockSourceSet() or returned from
+// TimerClockSourceGet().
+//
+//*****************************************************************************
+#define TIMER_CLOCK_SYSTEM      0x00000000
+#define TIMER_CLOCK_PIOSC       0x00000001
+
+//*****************************************************************************
+//
+// Values that can be passed to TimerDMAEventSet() or returned from
+// TimerDMAEventGet().
+//
+//*****************************************************************************
+#define TIMER_DMA_MODEMATCH_B   0x00000800
+#define TIMER_DMA_CAPEVENT_B    0x00000400
+#define TIMER_DMA_CAPMATCH_B    0x00000200
+#define TIMER_DMA_TIMEOUT_B     0x00000100
+#define TIMER_DMA_MODEMATCH_A   0x00000010
+#define TIMER_DMA_RTC_A         0x00000008
+#define TIMER_DMA_CAPEVENT_A    0x00000004
+#define TIMER_DMA_CAPMATCH_A    0x00000002
+#define TIMER_DMA_TIMEOUT_A     0x00000001
+
+//*****************************************************************************
+//
+// Values that can be passed to TimerADCEventSet() or returned from
+// TimerADCEventGet().
+//
+//*****************************************************************************
+#define TIMER_ADC_MODEMATCH_B   0x00000800
+#define TIMER_ADC_CAPEVENT_B    0x00000400
+#define TIMER_ADC_CAPMATCH_B    0x00000200
+#define TIMER_ADC_TIMEOUT_B     0x00000100
+#define TIMER_ADC_MODEMATCH_A   0x00000010
+#define TIMER_ADC_RTC_A         0x00000008
+#define TIMER_ADC_CAPEVENT_A    0x00000004
+#define TIMER_ADC_CAPMATCH_A    0x00000002
+#define TIMER_ADC_TIMEOUT_A     0x00000001
+
+//*****************************************************************************
+//
+// Mark the end of the C bindings section for C++ compilers.
+//
+//*****************************************************************************
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __DRIVERLIB_TIMER_H__

--- a/cpu/tm4c123/include/driverlib/uart.h
+++ b/cpu/tm4c123/include/driverlib/uart.h
@@ -1,0 +1,198 @@
+//*****************************************************************************
+//
+// uart.h - Defines and Macros for the UART.
+//
+// Copyright (c) 2005-2013 Texas Instruments Incorporated.  All rights reserved.
+// Software License Agreement
+// 
+//   Redistribution and use in source and binary forms, with or without
+//   modification, are permitted provided that the following conditions
+//   are met:
+// 
+//   Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+// 
+//   Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the  
+//   distribution.
+// 
+//   Neither the name of Texas Instruments Incorporated nor the names of
+//   its contributors may be used to endorse or promote products derived
+//   from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// This is part of revision 2.0.1.11577 of the Tiva Peripheral Driver Library.
+//
+//*****************************************************************************
+
+#ifndef __DRIVERLIB_UART_H__
+#define __DRIVERLIB_UART_H__
+
+//*****************************************************************************
+//
+// If building with a C++ compiler, make all of the definitions in this header
+// have a C binding.
+//
+//*****************************************************************************
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+//*****************************************************************************
+//
+// Values that can be passed to UARTIntEnable, UARTIntDisable, and UARTIntClear
+// as the ui32IntFlags parameter, and returned from UARTIntStatus.
+//
+//*****************************************************************************
+#define UART_INT_DMATX          0x20000     // DMA TX interrupt
+#define UART_INT_DMARX          0x10000     // DMA RX interrupt
+#define UART_INT_9BIT           0x1000      // 9-bit address match interrupt
+#define UART_INT_OE             0x400       // Overrun Error Interrupt Mask
+#define UART_INT_BE             0x200       // Break Error Interrupt Mask
+#define UART_INT_PE             0x100       // Parity Error Interrupt Mask
+#define UART_INT_FE             0x080       // Framing Error Interrupt Mask
+#define UART_INT_RT             0x040       // Receive Timeout Interrupt Mask
+#define UART_INT_TX             0x020       // Transmit Interrupt Mask
+#define UART_INT_RX             0x010       // Receive Interrupt Mask
+#define UART_INT_DSR            0x008       // DSR Modem Interrupt Mask
+#define UART_INT_DCD            0x004       // DCD Modem Interrupt Mask
+#define UART_INT_CTS            0x002       // CTS Modem Interrupt Mask
+#define UART_INT_RI             0x001       // RI Modem Interrupt Mask
+
+//*****************************************************************************
+//
+// Values that can be passed to UARTConfigSetExpClk as the ui32Config parameter
+// and returned by UARTConfigGetExpClk in the pui32Config parameter.
+// Additionally, the UART_CONFIG_PAR_* subset can be passed to
+// UARTParityModeSet as the ui32Parity parameter, and are returned by
+// UARTParityModeGet.
+//
+//*****************************************************************************
+#define UART_CONFIG_WLEN_MASK   0x00000060  // Mask for extracting word length
+#define UART_CONFIG_WLEN_8      0x00000060  // 8 bit data
+#define UART_CONFIG_WLEN_7      0x00000040  // 7 bit data
+#define UART_CONFIG_WLEN_6      0x00000020  // 6 bit data
+#define UART_CONFIG_WLEN_5      0x00000000  // 5 bit data
+#define UART_CONFIG_STOP_MASK   0x00000008  // Mask for extracting stop bits
+#define UART_CONFIG_STOP_ONE    0x00000000  // One stop bit
+#define UART_CONFIG_STOP_TWO    0x00000008  // Two stop bits
+#define UART_CONFIG_PAR_MASK    0x00000086  // Mask for extracting parity
+#define UART_CONFIG_PAR_NONE    0x00000000  // No parity
+#define UART_CONFIG_PAR_EVEN    0x00000006  // Even parity
+#define UART_CONFIG_PAR_ODD     0x00000002  // Odd parity
+#define UART_CONFIG_PAR_ONE     0x00000082  // Parity bit is one
+#define UART_CONFIG_PAR_ZERO    0x00000086  // Parity bit is zero
+
+//*****************************************************************************
+//
+// Values that can be passed to UARTFIFOLevelSet as the ui32TxLevel parameter
+// and returned by UARTFIFOLevelGet in the pui32TxLevel.
+//
+//*****************************************************************************
+#define UART_FIFO_TX1_8         0x00000000  // Transmit interrupt at 1/8 Full
+#define UART_FIFO_TX2_8         0x00000001  // Transmit interrupt at 1/4 Full
+#define UART_FIFO_TX4_8         0x00000002  // Transmit interrupt at 1/2 Full
+#define UART_FIFO_TX6_8         0x00000003  // Transmit interrupt at 3/4 Full
+#define UART_FIFO_TX7_8         0x00000004  // Transmit interrupt at 7/8 Full
+
+//*****************************************************************************
+//
+// Values that can be passed to UARTFIFOLevelSet as the ui32RxLevel parameter
+// and returned by UARTFIFOLevelGet in the pui32RxLevel.
+//
+//*****************************************************************************
+#define UART_FIFO_RX1_8         0x00000000  // Receive interrupt at 1/8 Full
+#define UART_FIFO_RX2_8         0x00000008  // Receive interrupt at 1/4 Full
+#define UART_FIFO_RX4_8         0x00000010  // Receive interrupt at 1/2 Full
+#define UART_FIFO_RX6_8         0x00000018  // Receive interrupt at 3/4 Full
+#define UART_FIFO_RX7_8         0x00000020  // Receive interrupt at 7/8 Full
+
+//*****************************************************************************
+//
+// Values that can be passed to UARTDMAEnable() and UARTDMADisable().
+//
+//*****************************************************************************
+#define UART_DMA_ERR_RXSTOP     0x00000004  // Stop DMA receive if UART error
+#define UART_DMA_TX             0x00000002  // Enable DMA for transmit
+#define UART_DMA_RX             0x00000001  // Enable DMA for receive
+
+//*****************************************************************************
+//
+// Values returned from UARTRxErrorGet().
+//
+//*****************************************************************************
+#define UART_RXERROR_OVERRUN    0x00000008
+#define UART_RXERROR_BREAK      0x00000004
+#define UART_RXERROR_PARITY     0x00000002
+#define UART_RXERROR_FRAMING    0x00000001
+
+//*****************************************************************************
+//
+// Values that can be passed to UARTHandshakeOutputsSet() or returned from
+// UARTHandshakeOutputGet().
+//
+//*****************************************************************************
+#define UART_OUTPUT_RTS         0x00000800
+#define UART_OUTPUT_DTR         0x00000400
+
+//*****************************************************************************
+//
+// Values that can be returned from UARTHandshakeInputsGet().
+//
+//*****************************************************************************
+#define UART_INPUT_RI           0x00000100
+#define UART_INPUT_DCD          0x00000004
+#define UART_INPUT_DSR          0x00000002
+#define UART_INPUT_CTS          0x00000001
+
+//*****************************************************************************
+//
+// Values that can be passed to UARTFlowControl() or returned from
+// UARTFlowControlGet().
+//
+//*****************************************************************************
+#define UART_FLOWCONTROL_TX     0x00008000
+#define UART_FLOWCONTROL_RX     0x00004000
+#define UART_FLOWCONTROL_NONE   0x00000000
+
+//*****************************************************************************
+//
+// Values that can be passed to UARTTxIntModeSet() or returned from
+// UARTTxIntModeGet().
+//
+//*****************************************************************************
+#define UART_TXINT_MODE_FIFO    0x00000000
+#define UART_TXINT_MODE_EOT     0x00000010
+
+//*****************************************************************************
+//
+// Values that can be passed to UARTClockSourceSet() or returned from
+// UARTClockSourceGet().
+//
+//*****************************************************************************
+#define UART_CLOCK_SYSTEM       0x00000000
+#define UART_CLOCK_PIOSC        0x00000005
+
+//*****************************************************************************
+//
+// Mark the end of the C bindings section for C++ compilers.
+//
+//*****************************************************************************
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __DRIVERLIB_UART_H__

--- a/cpu/tm4c123/include/hwtimer_cpu.h
+++ b/cpu/tm4c123/include/hwtimer_cpu.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup         cpu_tm4c123
+ * @{
+ *
+ * @file
+ * @brief           CPU specific hwtimer configuration options
+ *
+ * @author          Hauke Petersen <hauke.peterse@fu-berlin.de>
+ */
+
+#ifndef __HWTIMER_CPU_H
+#define __HWTIMER_CPU_H
+
+/**
+ * @name Hardware timer configuration
+ * @{
+ */
+#define HWTIMER_MAXTIMERS   (5)                 /**< the CPU implementation supports 6 HW timers */
+#define HWTIMER_SPEED       (80000000UL)        /**< the HW timer runs with 80 MHz */
+#define HWTIMER_MAXTICKS    (0xFFFFFFFF)        /**< 32-bit timer */
+/** @} */
+
+#endif /* __HWTIMER_CPU_H */
+/** @} */

--- a/cpu/tm4c123/include/hwtimer_cpu.h
+++ b/cpu/tm4c123/include/hwtimer_cpu.h
@@ -23,8 +23,11 @@
  * @name Hardware timer configuration
  * @{
  */
+
+#define TIMER_0_PRESCALER   (1 << 10)
+
 #define HWTIMER_MAXTIMERS   (5)                 /**< the CPU implementation supports 6 HW timers */
-#define HWTIMER_SPEED       (80000000UL)        /**< the HW timer runs with 80 MHz */
+#define HWTIMER_SPEED       (80000000UL / TIMER_0_PRESCALER) /**< the HW timer runs with 80 MHz */
 #define HWTIMER_MAXTICKS    (0xFFFFFFFF)        /**< 32-bit timer */
 /** @} */
 

--- a/cpu/tm4c123/include/tm4c123gh6pm.h
+++ b/cpu/tm4c123/include/tm4c123gh6pm.h
@@ -1,0 +1,1678 @@
+
+/****************************************************************************************************//**
+ * @file     TM4C123GH6PM.h
+ *
+ * @brief    CMSIS Cortex-M4 Peripheral Access Layer Header File for
+ *           TM4C123GH6PM from Texas Instruments.
+ *
+ * @version  V12591
+ * @date     19. February 2014
+ *
+ * @note     Generated with SVDConv V2.79v 
+ *           from CMSIS SVD File 'TM4C123GH6PM.svd.xml' Version 12591,
+ *
+ * @par      
+ *           Software License Agreement
+ *           
+ *           Texas Instruments (TI) is supplying this software for use solely and
+ *           exclusively on TI's microcontroller products. The software is owned by
+ *           TI and/or its suppliers, and is protected under applicable copyright
+ *           laws. You may not combine this software with "viral" open-source
+ *           software in order to form a larger program.
+ *           
+ *           THIS SOFTWARE IS PROVIDED "AS IS" AND WITH ALL FAULTS.
+ *           NO WARRANTIES, WHETHER EXPRESS, IMPLIED OR STATUTORY, INCLUDING, BUT
+ *           NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *           A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE. TI SHALL NOT, UNDER ANY
+ *           CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR CONSEQUENTIAL
+ *           DAMAGES, FOR ANY REASON WHATSOEVER.
+ *           
+ *           
+ *
+ *******************************************************************************************************/
+
+
+
+/** @addtogroup Texas Instruments
+  * @{
+  */
+
+/** @addtogroup TM4C123GH6PM
+  * @{
+  */
+
+#ifndef TM4C123GH6PM_H
+#define TM4C123GH6PM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* -------------------------  Interrupt Number Definition  ------------------------ */
+
+typedef enum {
+/* -------------------  Cortex-M4 Processor Exceptions Numbers  ------------------- */
+  Reset_IRQn                    = -15,              /*!<   1  Reset Vector, invoked on Power up and warm reset                 */
+  NonMaskableInt_IRQn           = -14,              /*!<   2  Non maskable Interrupt, cannot be stopped or preempted           */
+  HardFault_IRQn                = -13,              /*!<   3  Hard Fault, all classes of Fault                                 */
+  MemoryManagement_IRQn         = -12,              /*!<   4  Memory Management, MPU mismatch, including Access Violation
+                                                         and No Match                                                          */
+  BusFault_IRQn                 = -11,              /*!<   5  Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory
+                                                         related Fault                                                         */
+  UsageFault_IRQn               = -10,              /*!<   6  Usage Fault, i.e. Undef Instruction, Illegal State Transition    */
+  SVCall_IRQn                   =  -5,              /*!<  11  System Service Call via SVC instruction                          */
+  DebugMonitor_IRQn             =  -4,              /*!<  12  Debug Monitor                                                    */
+  PendSV_IRQn                   =  -2,              /*!<  14  Pendable request for system service                              */
+  SysTick_IRQn                  =  -1,              /*!<  15  System Tick Timer                                                */
+/* -------------------  TM4C123GH6PM Specific Interrupt Numbers  ------------------ */
+  GPIOA_IRQn                    =   0,              /*!<   0  GPIOA                                                            */
+  GPIOB_IRQn                    =   1,              /*!<   1  GPIOB                                                            */
+  GPIOC_IRQn                    =   2,              /*!<   2  GPIOC                                                            */
+  GPIOD_IRQn                    =   3,              /*!<   3  GPIOD                                                            */
+  GPIOE_IRQn                    =   4,              /*!<   4  GPIOE                                                            */
+  UART0_IRQn                    =   5,              /*!<   5  UART0                                                            */
+  UART1_IRQn                    =   6,              /*!<   6  UART1                                                            */
+  SSI0_IRQn                     =   7,              /*!<   7  SSI0                                                             */
+  I2C0_IRQn                     =   8,              /*!<   8  I2C0                                                             */
+  PWM0_FAULT_IRQn               =   9,              /*!<   9  PWM0_FAULT                                                       */
+  PWM0_0_IRQn                   =  10,              /*!<  10  PWM0_0                                                           */
+  PWM0_1_IRQn                   =  11,              /*!<  11  PWM0_1                                                           */
+  PWM0_2_IRQn                   =  12,              /*!<  12  PWM0_2                                                           */
+  QEI0_IRQn                     =  13,              /*!<  13  QEI0                                                             */
+  ADC0SS0_IRQn                  =  14,              /*!<  14  ADC0SS0                                                          */
+  ADC0SS1_IRQn                  =  15,              /*!<  15  ADC0SS1                                                          */
+  ADC0SS2_IRQn                  =  16,              /*!<  16  ADC0SS2                                                          */
+  ADC0SS3_IRQn                  =  17,              /*!<  17  ADC0SS3                                                          */
+  WATCHDOG0_IRQn                =  18,              /*!<  18  WATCHDOG0                                                        */
+  TIMER0A_IRQn                  =  19,              /*!<  19  TIMER0A                                                          */
+  TIMER0B_IRQn                  =  20,              /*!<  20  TIMER0B                                                          */
+  TIMER1A_IRQn                  =  21,              /*!<  21  TIMER1A                                                          */
+  TIMER1B_IRQn                  =  22,              /*!<  22  TIMER1B                                                          */
+  TIMER2A_IRQn                  =  23,              /*!<  23  TIMER2A                                                          */
+  TIMER2B_IRQn                  =  24,              /*!<  24  TIMER2B                                                          */
+  COMP0_IRQn                    =  25,              /*!<  25  COMP0                                                            */
+  COMP1_IRQn                    =  26,              /*!<  26  COMP1                                                            */
+  SYSCTL_IRQn                   =  28,              /*!<  28  SYSCTL                                                           */
+  FLASH_CTRL_IRQn               =  29,              /*!<  29  FLASH_CTRL                                                       */
+  GPIOF_IRQn                    =  30,              /*!<  30  GPIOF                                                            */
+  UART2_IRQn                    =  33,              /*!<  33  UART2                                                            */
+  SSI1_IRQn                     =  34,              /*!<  34  SSI1                                                             */
+  TIMER3A_IRQn                  =  35,              /*!<  35  TIMER3A                                                          */
+  TIMER3B_IRQn                  =  36,              /*!<  36  TIMER3B                                                          */
+  I2C1_IRQn                     =  37,              /*!<  37  I2C1                                                             */
+  QEI1_IRQn                     =  38,              /*!<  38  QEI1                                                             */
+  CAN0_IRQn                     =  39,              /*!<  39  CAN0                                                             */
+  CAN1_IRQn                     =  40,              /*!<  40  CAN1                                                             */
+  HIB_IRQn                      =  43,              /*!<  43  HIB                                                              */
+  USB0_IRQn                     =  44,              /*!<  44  USB0                                                             */
+  PWM0_3_IRQn                   =  45,              /*!<  45  PWM0_3                                                           */
+  UDMA_IRQn                     =  46,              /*!<  46  UDMA                                                             */
+  UDMAERR_IRQn                  =  47,              /*!<  47  UDMAERR                                                          */
+  ADC1SS0_IRQn                  =  48,              /*!<  48  ADC1SS0                                                          */
+  ADC1SS1_IRQn                  =  49,              /*!<  49  ADC1SS1                                                          */
+  ADC1SS2_IRQn                  =  50,              /*!<  50  ADC1SS2                                                          */
+  ADC1SS3_IRQn                  =  51,              /*!<  51  ADC1SS3                                                          */
+  SSI2_IRQn                     =  57,              /*!<  57  SSI2                                                             */
+  SSI3_IRQn                     =  58,              /*!<  58  SSI3                                                             */
+  UART3_IRQn                    =  59,              /*!<  59  UART3                                                            */
+  UART4_IRQn                    =  60,              /*!<  60  UART4                                                            */
+  UART5_IRQn                    =  61,              /*!<  61  UART5                                                            */
+  UART6_IRQn                    =  62,              /*!<  62  UART6                                                            */
+  UART7_IRQn                    =  63,              /*!<  63  UART7                                                            */
+  I2C2_IRQn                     =  68,              /*!<  68  I2C2                                                             */
+  I2C3_IRQn                     =  69,              /*!<  69  I2C3                                                             */
+  TIMER4A_IRQn                  =  70,              /*!<  70  TIMER4A                                                          */
+  TIMER4B_IRQn                  =  71,              /*!<  71  TIMER4B                                                          */
+  TIMER5A_IRQn                  =  92,              /*!<  92  TIMER5A                                                          */
+  TIMER5B_IRQn                  =  93,              /*!<  93  TIMER5B                                                          */
+  WTIMER0A_IRQn                 =  94,              /*!<  94  WTIMER0A                                                         */
+  WTIMER0B_IRQn                 =  95,              /*!<  95  WTIMER0B                                                         */
+  WTIMER1A_IRQn                 =  96,              /*!<  96  WTIMER1A                                                         */
+  WTIMER1B_IRQn                 =  97,              /*!<  97  WTIMER1B                                                         */
+  WTIMER2A_IRQn                 =  98,              /*!<  98  WTIMER2A                                                         */
+  WTIMER2B_IRQn                 =  99,              /*!<  99  WTIMER2B                                                         */
+  WTIMER3A_IRQn                 = 100,              /*!< 100  WTIMER3A                                                         */
+  WTIMER3B_IRQn                 = 101,              /*!< 101  WTIMER3B                                                         */
+  WTIMER4A_IRQn                 = 102,              /*!< 102  WTIMER4A                                                         */
+  WTIMER4B_IRQn                 = 103,              /*!< 103  WTIMER4B                                                         */
+  WTIMER5A_IRQn                 = 104,              /*!< 104  WTIMER5A                                                         */
+  WTIMER5B_IRQn                 = 105,              /*!< 105  WTIMER5B                                                         */
+  SYSEXC_IRQn                   = 106,              /*!< 106  SYSEXC                                                           */
+  PWM1_0_IRQn                   = 134,              /*!< 134  PWM1_0                                                           */
+  PWM1_1_IRQn                   = 135,              /*!< 135  PWM1_1                                                           */
+  PWM1_2_IRQn                   = 136,              /*!< 136  PWM1_2                                                           */
+  PWM1_3_IRQn                   = 137,              /*!< 137  PWM1_3                                                           */
+  PWM1_FAULT_IRQn               = 138               /*!< 138  PWM1_FAULT                                                       */
+} IRQn_Type;
+
+
+/** @addtogroup Configuration_of_CMSIS
+  * @{
+  */
+
+
+/* ================================================================================ */
+/* ================      Processor and Core Peripheral Section     ================ */
+/* ================================================================================ */
+
+/* ----------------Configuration of the Cortex-M4 Processor and Core Peripherals---------------- */
+#define __CM4_REV                 0x0102            /*!< Cortex-M4 Core Revision                                               */
+#define __MPU_PRESENT                  1            /*!< MPU present or not                                                    */
+#define __NVIC_PRIO_BITS               3            /*!< Number of Bits used for Priority Levels                               */
+#define __Vendor_SysTickConfig         0            /*!< Set to 1 if different SysTick Config is used                          */
+#define __FPU_PRESENT                  1            /*!< FPU present or not                                                    */
+/** @} */ /* End of group Configuration_of_CMSIS */
+
+#include "core_cm4.h"                               /*!< Cortex-M4 processor and core peripherals                              */
+
+
+/* ================================================================================ */
+/* ================       Device Specific Peripheral Section       ================ */
+/* ================================================================================ */
+
+
+/** @addtogroup Device_Peripheral_Registers
+  * @{
+  */
+
+
+/* -------------------  Start of section using anonymous unions  ------------------ */
+#if defined(__CC_ARM)
+  #pragma push
+  #pragma anon_unions
+#elif defined(__ICCARM__)
+  #pragma language=extended
+#elif defined(__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined(__TMS470__)
+/* anonymous unions are enabled by default */
+#elif defined(__TASKING__)
+  #pragma warning 586
+#else
+  #warning Not supported compiler type
+#endif
+
+
+
+/* ================================================================================ */
+/* ================                    WATCHDOG0                   ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for WATCHDOG0 peripheral (WATCHDOG0)
+  */
+
+typedef struct {                                    /*!< WATCHDOG0 Structure                                                   */
+  __IO uint32_t  LOAD;                              /*!< Watchdog Load                                                         */
+  __IO uint32_t  VALUE;                             /*!< Watchdog Value                                                        */
+  __IO uint32_t  CTL;                               /*!< Watchdog Control                                                      */
+  __O  uint32_t  ICR;                               /*!< Watchdog Interrupt Clear                                              */
+  __IO uint32_t  RIS;                               /*!< Watchdog Raw Interrupt Status                                         */
+  __IO uint32_t  MIS;                               /*!< Watchdog Masked Interrupt Status                                      */
+  __I  uint32_t  RESERVED0[256];
+  __IO uint32_t  TEST;                              /*!< Watchdog Test                                                         */
+  __I  uint32_t  RESERVED1[505];
+  __IO uint32_t  LOCK;                              /*!< Watchdog Lock                                                         */
+} WATCHDOG0_Type;
+
+
+/* ================================================================================ */
+/* ================                      GPIOA                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for GPIOA peripheral (GPIOA)
+  */
+
+typedef struct {                                    /*!< GPIOA Structure                                                       */
+  __I  uint32_t  RESERVED0[255];
+  __IO uint32_t  DATA;                              /*!< GPIO Data                                                             */
+  __IO uint32_t  DIR;                               /*!< GPIO Direction                                                        */
+  __IO uint32_t  IS;                                /*!< GPIO Interrupt Sense                                                  */
+  __IO uint32_t  IBE;                               /*!< GPIO Interrupt Both Edges                                             */
+  __IO uint32_t  IEV;                               /*!< GPIO Interrupt Event                                                  */
+  __IO uint32_t  IM;                                /*!< GPIO Interrupt Mask                                                   */
+  __IO uint32_t  RIS;                               /*!< GPIO Raw Interrupt Status                                             */
+  __IO uint32_t  MIS;                               /*!< GPIO Masked Interrupt Status                                          */
+  __O  uint32_t  ICR;                               /*!< GPIO Interrupt Clear                                                  */
+  __IO uint32_t  AFSEL;                             /*!< GPIO Alternate Function Select                                        */
+  __I  uint32_t  RESERVED1[55];
+  __IO uint32_t  DR2R;                              /*!< GPIO 2-mA Drive Select                                                */
+  __IO uint32_t  DR4R;                              /*!< GPIO 4-mA Drive Select                                                */
+  __IO uint32_t  DR8R;                              /*!< GPIO 8-mA Drive Select                                                */
+  __IO uint32_t  ODR;                               /*!< GPIO Open Drain Select                                                */
+  __IO uint32_t  PUR;                               /*!< GPIO Pull-Up Select                                                   */
+  __IO uint32_t  PDR;                               /*!< GPIO Pull-Down Select                                                 */
+  __IO uint32_t  SLR;                               /*!< GPIO Slew Rate Control Select                                         */
+  __IO uint32_t  DEN;                               /*!< GPIO Digital Enable                                                   */
+  __IO uint32_t  LOCK;                              /*!< GPIO Lock                                                             */
+  __I  uint32_t  CR;                                /*!< GPIO Commit                                                           */
+  __IO uint32_t  AMSEL;                             /*!< GPIO Analog Mode Select                                               */
+  __IO uint32_t  PCTL;                              /*!< GPIO Port Control                                                     */
+  __IO uint32_t  ADCCTL;                            /*!< GPIO ADC Control                                                      */
+  __IO uint32_t  DMACTL;                            /*!< GPIO DMA Control                                                      */
+} GPIOA_Type;
+
+
+/* ================================================================================ */
+/* ================                      SSI0                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for SSI0 peripheral (SSI0)
+  */
+
+typedef struct {                                    /*!< SSI0 Structure                                                        */
+  __IO uint32_t  CR0;                               /*!< SSI Control 0                                                         */
+  __IO uint32_t  CR1;                               /*!< SSI Control 1                                                         */
+  __IO uint32_t  DR;                                /*!< SSI Data                                                              */
+  __IO uint32_t  SR;                                /*!< SSI Status                                                            */
+  __IO uint32_t  CPSR;                              /*!< SSI Clock Prescale                                                    */
+  __IO uint32_t  IM;                                /*!< SSI Interrupt Mask                                                    */
+  __IO uint32_t  RIS;                               /*!< SSI Raw Interrupt Status                                              */
+  __IO uint32_t  MIS;                               /*!< SSI Masked Interrupt Status                                           */
+  __O  uint32_t  ICR;                               /*!< SSI Interrupt Clear                                                   */
+  __IO uint32_t  DMACTL;                            /*!< SSI DMA Control                                                       */
+  __I  uint32_t  RESERVED0[1000];
+  __IO uint32_t  CC;                                /*!< SSI Clock Configuration                                               */
+} SSI0_Type;
+
+
+/* ================================================================================ */
+/* ================                      UART0                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for UART0 peripheral (UART0)
+  */
+
+typedef struct {                                    /*!< UART0 Structure                                                       */
+  __IO uint32_t  DR;                                /*!< UART Data                                                             */
+  
+  union {
+    __IO uint32_t  ECR_UART_ALT;                    /*!< UART Receive Status/Error Clear                                       */
+    __IO uint32_t  RSR;                             /*!< UART Receive Status/Error Clear                                       */
+  };
+  __I  uint32_t  RESERVED0[4];
+  __IO uint32_t  FR;                                /*!< UART Flag                                                             */
+  __I  uint32_t  RESERVED1;
+  __IO uint32_t  ILPR;                              /*!< UART IrDA Low-Power Register                                          */
+  __IO uint32_t  IBRD;                              /*!< UART Integer Baud-Rate Divisor                                        */
+  __IO uint32_t  FBRD;                              /*!< UART Fractional Baud-Rate Divisor                                     */
+  __IO uint32_t  LCRH;                              /*!< UART Line Control                                                     */
+  __IO uint32_t  CTL;                               /*!< UART Control                                                          */
+  __IO uint32_t  IFLS;                              /*!< UART Interrupt FIFO Level Select                                      */
+  __IO uint32_t  IM;                                /*!< UART Interrupt Mask                                                   */
+  __IO uint32_t  RIS;                               /*!< UART Raw Interrupt Status                                             */
+  __IO uint32_t  MIS;                               /*!< UART Masked Interrupt Status                                          */
+  __O  uint32_t  ICR;                               /*!< UART Interrupt Clear                                                  */
+  __IO uint32_t  DMACTL;                            /*!< UART DMA Control                                                      */
+  __I  uint32_t  RESERVED2[22];
+  __IO uint32_t  _9BITADDR;                         /*!< UART 9-Bit Self Address                                               */
+  __IO uint32_t  _9BITAMASK;                        /*!< UART 9-Bit Self Address Mask                                          */
+  __I  uint32_t  RESERVED3[965];
+  __IO uint32_t  PP;                                /*!< UART Peripheral Properties                                            */
+  __I  uint32_t  RESERVED4;
+  __IO uint32_t  CC;                                /*!< UART Clock Configuration                                              */
+} UART0_Type;
+
+
+/* ================================================================================ */
+/* ================                      I2C0                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for I2C0 peripheral (I2C0)
+  */
+
+typedef struct {                                    /*!< I2C0 Structure                                                        */
+  __IO uint32_t  MSA;                               /*!< I2C Master Slave Address                                              */
+  
+  union {
+    __IO uint32_t  MCS_I2C0_ALT;                    /*!< I2C Master Control/Status                                             */
+    __IO uint32_t  MCS;                             /*!< I2C Master Control/Status                                             */
+  };
+  __IO uint32_t  MDR;                               /*!< I2C Master Data                                                       */
+  __IO uint32_t  MTPR;                              /*!< I2C Master Timer Period                                               */
+  __IO uint32_t  MIMR;                              /*!< I2C Master Interrupt Mask                                             */
+  __IO uint32_t  MRIS;                              /*!< I2C Master Raw Interrupt Status                                       */
+  __IO uint32_t  MMIS;                              /*!< I2C Master Masked Interrupt Status                                    */
+  __O  uint32_t  MICR;                              /*!< I2C Master Interrupt Clear                                            */
+  __IO uint32_t  MCR;                               /*!< I2C Master Configuration                                              */
+  __IO uint32_t  MCLKOCNT;                          /*!< I2C Master Clock Low Timeout Count                                    */
+  __I  uint32_t  RESERVED0;
+  __IO uint32_t  MBMON;                             /*!< I2C Master Bus Monitor                                                */
+  __I  uint32_t  RESERVED1[2];
+  __IO uint32_t  MCR2;                              /*!< I2C Master Configuration 2                                            */
+  __I  uint32_t  RESERVED2[497];
+  __IO uint32_t  SOAR;                              /*!< I2C Slave Own Address                                                 */
+  
+  union {
+    __IO uint32_t  SCSR_I2C0_ALT;                   /*!< I2C Slave Control/Status                                              */
+    __IO uint32_t  SCSR;                            /*!< I2C Slave Control/Status                                              */
+  };
+  __IO uint32_t  SDR;                               /*!< I2C Slave Data                                                        */
+  __IO uint32_t  SIMR;                              /*!< I2C Slave Interrupt Mask                                              */
+  __IO uint32_t  SRIS;                              /*!< I2C Slave Raw Interrupt Status                                        */
+  __IO uint32_t  SMIS;                              /*!< I2C Slave Masked Interrupt Status                                     */
+  __O  uint32_t  SICR;                              /*!< I2C Slave Interrupt Clear                                             */
+  __IO uint32_t  SOAR2;                             /*!< I2C Slave Own Address 2                                               */
+  __IO uint32_t  SACKCTL;                           /*!< I2C Slave ACK Control                                                 */
+  __I  uint32_t  RESERVED3[487];
+  __IO uint32_t  PP;                                /*!< I2C Peripheral Properties                                             */
+  __IO uint32_t  PC;                                /*!< I2C Peripheral Configuration                                          */
+} I2C0_Type;
+
+
+/* ================================================================================ */
+/* ================                      PWM0                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for PWM0 peripheral (PWM0)
+  */
+
+typedef struct {                                    /*!< PWM0 Structure                                                        */
+  __IO uint32_t  CTL;                               /*!< PWM Master Control                                                    */
+  __IO uint32_t  SYNC;                              /*!< PWM Time Base Sync                                                    */
+  __IO uint32_t  ENABLE;                            /*!< PWM Output Enable                                                     */
+  __IO uint32_t  INVERT;                            /*!< PWM Output Inversion                                                  */
+  __IO uint32_t  FAULT;                             /*!< PWM Output Fault                                                      */
+  __IO uint32_t  INTEN;                             /*!< PWM Interrupt Enable                                                  */
+  __IO uint32_t  RIS;                               /*!< PWM Raw Interrupt Status                                              */
+  __IO uint32_t  ISC;                               /*!< PWM Interrupt Status and Clear                                        */
+  __IO uint32_t  STATUS;                            /*!< PWM Status                                                            */
+  __IO uint32_t  FAULTVAL;                          /*!< PWM Fault Condition Value                                             */
+  __IO uint32_t  ENUPD;                             /*!< PWM Enable Update                                                     */
+  __I  uint32_t  RESERVED0[5];
+  __IO uint32_t  _0_CTL;                            /*!< PWM0 Control                                                          */
+  __IO uint32_t  _0_INTEN;                          /*!< PWM0 Interrupt and Trigger Enable                                     */
+  __IO uint32_t  _0_RIS;                            /*!< PWM0 Raw Interrupt Status                                             */
+  __IO uint32_t  _0_ISC;                            /*!< PWM0 Interrupt Status and Clear                                       */
+  __IO uint32_t  _0_LOAD;                           /*!< PWM0 Load                                                             */
+  __IO uint32_t  _0_COUNT;                          /*!< PWM0 Counter                                                          */
+  __IO uint32_t  _0_CMPA;                           /*!< PWM0 Compare A                                                        */
+  __IO uint32_t  _0_CMPB;                           /*!< PWM0 Compare B                                                        */
+  __IO uint32_t  _0_GENA;                           /*!< PWM0 Generator A Control                                              */
+  __IO uint32_t  _0_GENB;                           /*!< PWM0 Generator B Control                                              */
+  __IO uint32_t  _0_DBCTL;                          /*!< PWM0 Dead-Band Control                                                */
+  __IO uint32_t  _0_DBRISE;                         /*!< PWM0 Dead-Band Rising-Edge Delay                                      */
+  __IO uint32_t  _0_DBFALL;                         /*!< PWM0 Dead-Band Falling-Edge-Delay                                     */
+  __IO uint32_t  _0_FLTSRC0;                        /*!< PWM0 Fault Source 0                                                   */
+  __IO uint32_t  _0_FLTSRC1;                        /*!< PWM0 Fault Source 1                                                   */
+  __IO uint32_t  _0_MINFLTPER;                      /*!< PWM0 Minimum Fault Period                                             */
+  __IO uint32_t  _1_CTL;                            /*!< PWM1 Control                                                          */
+  __IO uint32_t  _1_INTEN;                          /*!< PWM1 Interrupt and Trigger Enable                                     */
+  __IO uint32_t  _1_RIS;                            /*!< PWM1 Raw Interrupt Status                                             */
+  __IO uint32_t  _1_ISC;                            /*!< PWM1 Interrupt Status and Clear                                       */
+  __IO uint32_t  _1_LOAD;                           /*!< PWM1 Load                                                             */
+  __IO uint32_t  _1_COUNT;                          /*!< PWM1 Counter                                                          */
+  __IO uint32_t  _1_CMPA;                           /*!< PWM1 Compare A                                                        */
+  __IO uint32_t  _1_CMPB;                           /*!< PWM1 Compare B                                                        */
+  __IO uint32_t  _1_GENA;                           /*!< PWM1 Generator A Control                                              */
+  __IO uint32_t  _1_GENB;                           /*!< PWM1 Generator B Control                                              */
+  __IO uint32_t  _1_DBCTL;                          /*!< PWM1 Dead-Band Control                                                */
+  __IO uint32_t  _1_DBRISE;                         /*!< PWM1 Dead-Band Rising-Edge Delay                                      */
+  __IO uint32_t  _1_DBFALL;                         /*!< PWM1 Dead-Band Falling-Edge-Delay                                     */
+  __IO uint32_t  _1_FLTSRC0;                        /*!< PWM1 Fault Source 0                                                   */
+  __IO uint32_t  _1_FLTSRC1;                        /*!< PWM1 Fault Source 1                                                   */
+  __IO uint32_t  _1_MINFLTPER;                      /*!< PWM1 Minimum Fault Period                                             */
+  __IO uint32_t  _2_CTL;                            /*!< PWM2 Control                                                          */
+  __IO uint32_t  _2_INTEN;                          /*!< PWM2 Interrupt and Trigger Enable                                     */
+  __IO uint32_t  _2_RIS;                            /*!< PWM2 Raw Interrupt Status                                             */
+  __IO uint32_t  _2_ISC;                            /*!< PWM2 Interrupt Status and Clear                                       */
+  __IO uint32_t  _2_LOAD;                           /*!< PWM2 Load                                                             */
+  __IO uint32_t  _2_COUNT;                          /*!< PWM2 Counter                                                          */
+  __IO uint32_t  _2_CMPA;                           /*!< PWM2 Compare A                                                        */
+  __IO uint32_t  _2_CMPB;                           /*!< PWM2 Compare B                                                        */
+  __IO uint32_t  _2_GENA;                           /*!< PWM2 Generator A Control                                              */
+  __IO uint32_t  _2_GENB;                           /*!< PWM2 Generator B Control                                              */
+  __IO uint32_t  _2_DBCTL;                          /*!< PWM2 Dead-Band Control                                                */
+  __IO uint32_t  _2_DBRISE;                         /*!< PWM2 Dead-Band Rising-Edge Delay                                      */
+  __IO uint32_t  _2_DBFALL;                         /*!< PWM2 Dead-Band Falling-Edge-Delay                                     */
+  __IO uint32_t  _2_FLTSRC0;                        /*!< PWM2 Fault Source 0                                                   */
+  __IO uint32_t  _2_FLTSRC1;                        /*!< PWM2 Fault Source 1                                                   */
+  __IO uint32_t  _2_MINFLTPER;                      /*!< PWM2 Minimum Fault Period                                             */
+  __IO uint32_t  _3_CTL;                            /*!< PWM3 Control                                                          */
+  __IO uint32_t  _3_INTEN;                          /*!< PWM3 Interrupt and Trigger Enable                                     */
+  __IO uint32_t  _3_RIS;                            /*!< PWM3 Raw Interrupt Status                                             */
+  __IO uint32_t  _3_ISC;                            /*!< PWM3 Interrupt Status and Clear                                       */
+  __IO uint32_t  _3_LOAD;                           /*!< PWM3 Load                                                             */
+  __IO uint32_t  _3_COUNT;                          /*!< PWM3 Counter                                                          */
+  __IO uint32_t  _3_CMPA;                           /*!< PWM3 Compare A                                                        */
+  __IO uint32_t  _3_CMPB;                           /*!< PWM3 Compare B                                                        */
+  __IO uint32_t  _3_GENA;                           /*!< PWM3 Generator A Control                                              */
+  __IO uint32_t  _3_GENB;                           /*!< PWM3 Generator B Control                                              */
+  __IO uint32_t  _3_DBCTL;                          /*!< PWM3 Dead-Band Control                                                */
+  __IO uint32_t  _3_DBRISE;                         /*!< PWM3 Dead-Band Rising-Edge Delay                                      */
+  __IO uint32_t  _3_DBFALL;                         /*!< PWM3 Dead-Band Falling-Edge-Delay                                     */
+  __IO uint32_t  _3_FLTSRC0;                        /*!< PWM3 Fault Source 0                                                   */
+  __IO uint32_t  _3_FLTSRC1;                        /*!< PWM3 Fault Source 1                                                   */
+  __IO uint32_t  _3_MINFLTPER;                      /*!< PWM3 Minimum Fault Period                                             */
+  __I  uint32_t  RESERVED1[432];
+  __IO uint32_t  _0_FLTSEN;                         /*!< PWM0 Fault Pin Logic Sense                                            */
+  __I  uint32_t  _0_FLTSTAT0;                       /*!< PWM0 Fault Status 0                                                   */
+  __I  uint32_t  _0_FLTSTAT1;                       /*!< PWM0 Fault Status 1                                                   */
+  __I  uint32_t  RESERVED2[29];
+  __IO uint32_t  _1_FLTSEN;                         /*!< PWM1 Fault Pin Logic Sense                                            */
+  __I  uint32_t  _1_FLTSTAT0;                       /*!< PWM1 Fault Status 0                                                   */
+  __I  uint32_t  _1_FLTSTAT1;                       /*!< PWM1 Fault Status 1                                                   */
+  __I  uint32_t  RESERVED3[30];
+  __I  uint32_t  _2_FLTSTAT0;                       /*!< PWM2 Fault Status 0                                                   */
+  __I  uint32_t  _2_FLTSTAT1;                       /*!< PWM2 Fault Status 1                                                   */
+  __I  uint32_t  RESERVED4[30];
+  __I  uint32_t  _3_FLTSTAT0;                       /*!< PWM3 Fault Status 0                                                   */
+  __I  uint32_t  _3_FLTSTAT1;                       /*!< PWM3 Fault Status 1                                                   */
+  __I  uint32_t  RESERVED5[397];
+  __IO uint32_t  PP;                                /*!< PWM Peripheral Properties                                             */
+} PWM0_Type;
+
+
+/* ================================================================================ */
+/* ================                      QEI0                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for QEI0 peripheral (QEI0)
+  */
+
+typedef struct {                                    /*!< QEI0 Structure                                                        */
+  __IO uint32_t  CTL;                               /*!< QEI Control                                                           */
+  __IO uint32_t  STAT;                              /*!< QEI Status                                                            */
+  __IO uint32_t  POS;                               /*!< QEI Position                                                          */
+  __IO uint32_t  MAXPOS;                            /*!< QEI Maximum Position                                                  */
+  __IO uint32_t  LOAD;                              /*!< QEI Timer Load                                                        */
+  __IO uint32_t  TIME;                              /*!< QEI Timer                                                             */
+  __IO uint32_t  COUNT;                             /*!< QEI Velocity Counter                                                  */
+  __IO uint32_t  SPEED;                             /*!< QEI Velocity                                                          */
+  __IO uint32_t  INTEN;                             /*!< QEI Interrupt Enable                                                  */
+  __IO uint32_t  RIS;                               /*!< QEI Raw Interrupt Status                                              */
+  __IO uint32_t  ISC;                               /*!< QEI Interrupt Status and Clear                                        */
+} QEI0_Type;
+
+
+/* ================================================================================ */
+/* ================                     TIMER0                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for TIMER0 peripheral (TIMER0)
+  */
+
+typedef struct {                                    /*!< TIMER0 Structure                                                      */
+  __IO uint32_t  CFG;                               /*!< GPTM Configuration                                                    */
+  __IO uint32_t  TAMR;                              /*!< GPTM Timer A Mode                                                     */
+  __IO uint32_t  TBMR;                              /*!< GPTM Timer B Mode                                                     */
+  __IO uint32_t  CTL;                               /*!< GPTM Control                                                          */
+  __IO uint32_t  SYNC;                              /*!< GPTM Synchronize                                                      */
+  __I  uint32_t  RESERVED0;
+  __IO uint32_t  IMR;                               /*!< GPTM Interrupt Mask                                                   */
+  __IO uint32_t  RIS;                               /*!< GPTM Raw Interrupt Status                                             */
+  __IO uint32_t  MIS;                               /*!< GPTM Masked Interrupt Status                                          */
+  __O  uint32_t  ICR;                               /*!< GPTM Interrupt Clear                                                  */
+  __IO uint32_t  TAILR;                             /*!< GPTM Timer A Interval Load                                            */
+  __IO uint32_t  TBILR;                             /*!< GPTM Timer B Interval Load                                            */
+  __IO uint32_t  TAMATCHR;                          /*!< GPTM Timer A Match                                                    */
+  __IO uint32_t  TBMATCHR;                          /*!< GPTM Timer B Match                                                    */
+  __IO uint32_t  TAPR;                              /*!< GPTM Timer A Prescale                                                 */
+  __IO uint32_t  TBPR;                              /*!< GPTM Timer B Prescale                                                 */
+  __IO uint32_t  TAPMR;                             /*!< GPTM TimerA Prescale Match                                            */
+  __IO uint32_t  TBPMR;                             /*!< GPTM TimerB Prescale Match                                            */
+  __IO uint32_t  TAR;                               /*!< GPTM Timer A                                                          */
+  __IO uint32_t  TBR;                               /*!< GPTM Timer B                                                          */
+  __IO uint32_t  TAV;                               /*!< GPTM Timer A Value                                                    */
+  __IO uint32_t  TBV;                               /*!< GPTM Timer B Value                                                    */
+  __IO uint32_t  RTCPD;                             /*!< GPTM RTC Predivide                                                    */
+  __IO uint32_t  TAPS;                              /*!< GPTM Timer A Prescale Snapshot                                        */
+  __IO uint32_t  TBPS;                              /*!< GPTM Timer B Prescale Snapshot                                        */
+  __IO uint32_t  TAPV;                              /*!< GPTM Timer A Prescale Value                                           */
+  __IO uint32_t  TBPV;                              /*!< GPTM Timer B Prescale Value                                           */
+  __I  uint32_t  RESERVED1[981];
+  __IO uint32_t  PP;                                /*!< GPTM Peripheral Properties                                            */
+} TIMER0_Type;
+
+
+/* ================================================================================ */
+/* ================                     WTIMER0                    ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for WTIMER0 peripheral (WTIMER0)
+  */
+
+typedef struct {                                    /*!< WTIMER0 Structure                                                     */
+  __IO uint32_t  CFG;                               /*!< GPTM Configuration                                                    */
+  __IO uint32_t  TAMR;                              /*!< GPTM Timer A Mode                                                     */
+  __IO uint32_t  TBMR;                              /*!< GPTM Timer B Mode                                                     */
+  __IO uint32_t  CTL;                               /*!< GPTM Control                                                          */
+  __IO uint32_t  SYNC;                              /*!< GPTM Synchronize                                                      */
+  __I  uint32_t  RESERVED0;
+  __IO uint32_t  IMR;                               /*!< GPTM Interrupt Mask                                                   */
+  __IO uint32_t  RIS;                               /*!< GPTM Raw Interrupt Status                                             */
+  __IO uint32_t  MIS;                               /*!< GPTM Masked Interrupt Status                                          */
+  __O  uint32_t  ICR;                               /*!< GPTM Interrupt Clear                                                  */
+  __IO uint32_t  TAILR;                             /*!< GPTM Timer A Interval Load                                            */
+  __IO uint32_t  TBILR;                             /*!< GPTM Timer B Interval Load                                            */
+  __IO uint32_t  TAMATCHR;                          /*!< GPTM Timer A Match                                                    */
+  __IO uint32_t  TBMATCHR;                          /*!< GPTM Timer B Match                                                    */
+  __IO uint32_t  TAPR;                              /*!< GPTM Timer A Prescale                                                 */
+  __IO uint32_t  TBPR;                              /*!< GPTM Timer B Prescale                                                 */
+  __IO uint32_t  TAPMR;                             /*!< GPTM TimerA Prescale Match                                            */
+  __IO uint32_t  TBPMR;                             /*!< GPTM TimerB Prescale Match                                            */
+  __IO uint32_t  TAR;                               /*!< GPTM Timer A                                                          */
+  __IO uint32_t  TBR;                               /*!< GPTM Timer B                                                          */
+  __IO uint32_t  TAV;                               /*!< GPTM Timer A Value                                                    */
+  __IO uint32_t  TBV;                               /*!< GPTM Timer B Value                                                    */
+  __IO uint32_t  RTCPD;                             /*!< GPTM RTC Predivide                                                    */
+  __IO uint32_t  TAPS;                              /*!< GPTM Timer A Prescale Snapshot                                        */
+  __IO uint32_t  TBPS;                              /*!< GPTM Timer B Prescale Snapshot                                        */
+  __IO uint32_t  TAPV;                              /*!< GPTM Timer A Prescale Value                                           */
+  __IO uint32_t  TBPV;                              /*!< GPTM Timer B Prescale Value                                           */
+  __I  uint32_t  RESERVED1[981];
+  __IO uint32_t  PP;                                /*!< GPTM Peripheral Properties                                            */
+} WTIMER0_Type;
+
+
+/* ================================================================================ */
+/* ================                      ADC0                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for ADC0 peripheral (ADC0)
+  */
+
+typedef struct {                                    /*!< ADC0 Structure                                                        */
+  __IO uint32_t  ACTSS;                             /*!< ADC Active Sample Sequencer                                           */
+  __IO uint32_t  RIS;                               /*!< ADC Raw Interrupt Status                                              */
+  __IO uint32_t  IM;                                /*!< ADC Interrupt Mask                                                    */
+  __IO uint32_t  ISC;                               /*!< ADC Interrupt Status and Clear                                        */
+  __IO uint32_t  OSTAT;                             /*!< ADC Overflow Status                                                   */
+  __IO uint32_t  EMUX;                              /*!< ADC Event Multiplexer Select                                          */
+  __IO uint32_t  USTAT;                             /*!< ADC Underflow Status                                                  */
+  __IO uint32_t  TSSEL;                             /*!< ADC Trigger Source Select                                             */
+  __IO uint32_t  SSPRI;                             /*!< ADC Sample Sequencer Priority                                         */
+  __IO uint32_t  SPC;                               /*!< ADC Sample Phase Control                                              */
+  __IO uint32_t  PSSI;                              /*!< ADC Processor Sample Sequence Initiate                                */
+  __I  uint32_t  RESERVED0;
+  __IO uint32_t  SAC;                               /*!< ADC Sample Averaging Control                                          */
+  __IO uint32_t  DCISC;                             /*!< ADC Digital Comparator Interrupt Status and Clear                     */
+  __IO uint32_t  CTL;                               /*!< ADC Control                                                           */
+  __I  uint32_t  RESERVED1;
+  __IO uint32_t  SSMUX0;                            /*!< ADC Sample Sequence Input Multiplexer Select 0                        */
+  __IO uint32_t  SSCTL0;                            /*!< ADC Sample Sequence Control 0                                         */
+  __IO uint32_t  SSFIFO0;                           /*!< ADC Sample Sequence Result FIFO 0                                     */
+  __IO uint32_t  SSFSTAT0;                          /*!< ADC Sample Sequence FIFO 0 Status                                     */
+  __IO uint32_t  SSOP0;                             /*!< ADC Sample Sequence 0 Operation                                       */
+  __IO uint32_t  SSDC0;                             /*!< ADC Sample Sequence 0 Digital Comparator Select                       */
+  __I  uint32_t  RESERVED2[2];
+  __IO uint32_t  SSMUX1;                            /*!< ADC Sample Sequence Input Multiplexer Select 1                        */
+  __IO uint32_t  SSCTL1;                            /*!< ADC Sample Sequence Control 1                                         */
+  __IO uint32_t  SSFIFO1;                           /*!< ADC Sample Sequence Result FIFO 1                                     */
+  __IO uint32_t  SSFSTAT1;                          /*!< ADC Sample Sequence FIFO 1 Status                                     */
+  __IO uint32_t  SSOP1;                             /*!< ADC Sample Sequence 1 Operation                                       */
+  __IO uint32_t  SSDC1;                             /*!< ADC Sample Sequence 1 Digital Comparator Select                       */
+  __I  uint32_t  RESERVED3[2];
+  __IO uint32_t  SSMUX2;                            /*!< ADC Sample Sequence Input Multiplexer Select 2                        */
+  __IO uint32_t  SSCTL2;                            /*!< ADC Sample Sequence Control 2                                         */
+  __IO uint32_t  SSFIFO2;                           /*!< ADC Sample Sequence Result FIFO 2                                     */
+  __IO uint32_t  SSFSTAT2;                          /*!< ADC Sample Sequence FIFO 2 Status                                     */
+  __IO uint32_t  SSOP2;                             /*!< ADC Sample Sequence 2 Operation                                       */
+  __IO uint32_t  SSDC2;                             /*!< ADC Sample Sequence 2 Digital Comparator Select                       */
+  __I  uint32_t  RESERVED4[2];
+  __IO uint32_t  SSMUX3;                            /*!< ADC Sample Sequence Input Multiplexer Select 3                        */
+  __IO uint32_t  SSCTL3;                            /*!< ADC Sample Sequence Control 3                                         */
+  __IO uint32_t  SSFIFO3;                           /*!< ADC Sample Sequence Result FIFO 3                                     */
+  __IO uint32_t  SSFSTAT3;                          /*!< ADC Sample Sequence FIFO 3 Status                                     */
+  __IO uint32_t  SSOP3;                             /*!< ADC Sample Sequence 3 Operation                                       */
+  __IO uint32_t  SSDC3;                             /*!< ADC Sample Sequence 3 Digital Comparator Select                       */
+  __I  uint32_t  RESERVED5[786];
+  __O  uint32_t  DCRIC;                             /*!< ADC Digital Comparator Reset Initial Conditions                       */
+  __I  uint32_t  RESERVED6[63];
+  __IO uint32_t  DCCTL0;                            /*!< ADC Digital Comparator Control 0                                      */
+  __IO uint32_t  DCCTL1;                            /*!< ADC Digital Comparator Control 1                                      */
+  __IO uint32_t  DCCTL2;                            /*!< ADC Digital Comparator Control 2                                      */
+  __IO uint32_t  DCCTL3;                            /*!< ADC Digital Comparator Control 3                                      */
+  __IO uint32_t  DCCTL4;                            /*!< ADC Digital Comparator Control 4                                      */
+  __IO uint32_t  DCCTL5;                            /*!< ADC Digital Comparator Control 5                                      */
+  __IO uint32_t  DCCTL6;                            /*!< ADC Digital Comparator Control 6                                      */
+  __IO uint32_t  DCCTL7;                            /*!< ADC Digital Comparator Control 7                                      */
+  __I  uint32_t  RESERVED7[8];
+  __IO uint32_t  DCCMP0;                            /*!< ADC Digital Comparator Range 0                                        */
+  __IO uint32_t  DCCMP1;                            /*!< ADC Digital Comparator Range 1                                        */
+  __IO uint32_t  DCCMP2;                            /*!< ADC Digital Comparator Range 2                                        */
+  __IO uint32_t  DCCMP3;                            /*!< ADC Digital Comparator Range 3                                        */
+  __IO uint32_t  DCCMP4;                            /*!< ADC Digital Comparator Range 4                                        */
+  __IO uint32_t  DCCMP5;                            /*!< ADC Digital Comparator Range 5                                        */
+  __IO uint32_t  DCCMP6;                            /*!< ADC Digital Comparator Range 6                                        */
+  __IO uint32_t  DCCMP7;                            /*!< ADC Digital Comparator Range 7                                        */
+  __I  uint32_t  RESERVED8[88];
+  __IO uint32_t  PP;                                /*!< ADC Peripheral Properties                                             */
+  __IO uint32_t  PC;                                /*!< ADC Peripheral Configuration                                          */
+  __IO uint32_t  CC;                                /*!< ADC Clock Configuration                                               */
+} ADC0_Type;
+
+
+/* ================================================================================ */
+/* ================                      COMP                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for COMP peripheral (COMP)
+  */
+
+typedef struct {                                    /*!< COMP Structure                                                        */
+  __IO uint32_t  ACMIS;                             /*!< Analog Comparator Masked Interrupt Status                             */
+  __IO uint32_t  ACRIS;                             /*!< Analog Comparator Raw Interrupt Status                                */
+  __IO uint32_t  ACINTEN;                           /*!< Analog Comparator Interrupt Enable                                    */
+  __I  uint32_t  RESERVED0;
+  __IO uint32_t  ACREFCTL;                          /*!< Analog Comparator Reference Voltage Control                           */
+  __I  uint32_t  RESERVED1[3];
+  __IO uint32_t  ACSTAT0;                           /*!< Analog Comparator Status 0                                            */
+  __IO uint32_t  ACCTL0;                            /*!< Analog Comparator Control 0                                           */
+  __I  uint32_t  RESERVED2[6];
+  __IO uint32_t  ACSTAT1;                           /*!< Analog Comparator Status 1                                            */
+  __IO uint32_t  ACCTL1;                            /*!< Analog Comparator Control 1                                           */
+  __I  uint32_t  RESERVED3[990];
+  __IO uint32_t  PP;                                /*!< Analog Comparator Peripheral Properties                               */
+} COMP_Type;
+
+
+/* ================================================================================ */
+/* ================                      CAN0                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for CAN0 peripheral (CAN0)
+  */
+
+typedef struct {                                    /*!< CAN0 Structure                                                        */
+  __IO uint32_t  CTL;                               /*!< CAN Control                                                           */
+  __IO uint32_t  STS;                               /*!< CAN Status                                                            */
+  __IO uint32_t  ERR;                               /*!< CAN Error Counter                                                     */
+  __IO uint32_t  BIT;                               /*!< CAN Bit Timing                                                        */
+  __IO uint32_t  INT;                               /*!< CAN Interrupt                                                         */
+  __IO uint32_t  TST;                               /*!< CAN Test                                                              */
+  __IO uint32_t  BRPE;                              /*!< CAN Baud Rate Prescaler Extension                                     */
+  __I  uint32_t  RESERVED0;
+  __IO uint32_t  IF1CRQ;                            /*!< CAN IF1 Command Request                                               */
+  
+  union {
+    __IO uint32_t  IF1CMSK_CAN0_ALT;                /*!< CAN IF1 Command Mask                                                  */
+    __IO uint32_t  IF1CMSK;                         /*!< CAN IF1 Command Mask                                                  */
+  };
+  __IO uint32_t  IF1MSK1;                           /*!< CAN IF1 Mask 1                                                        */
+  __IO uint32_t  IF1MSK2;                           /*!< CAN IF1 Mask 2                                                        */
+  __IO uint32_t  IF1ARB1;                           /*!< CAN IF1 Arbitration 1                                                 */
+  __IO uint32_t  IF1ARB2;                           /*!< CAN IF1 Arbitration 2                                                 */
+  __IO uint32_t  IF1MCTL;                           /*!< CAN IF1 Message Control                                               */
+  __IO uint32_t  IF1DA1;                            /*!< CAN IF1 Data A1                                                       */
+  __IO uint32_t  IF1DA2;                            /*!< CAN IF1 Data A2                                                       */
+  __IO uint32_t  IF1DB1;                            /*!< CAN IF1 Data B1                                                       */
+  __IO uint32_t  IF1DB2;                            /*!< CAN IF1 Data B2                                                       */
+  __I  uint32_t  RESERVED1[13];
+  __IO uint32_t  IF2CRQ;                            /*!< CAN IF2 Command Request                                               */
+  
+  union {
+    __IO uint32_t  IF2CMSK_CAN0_ALT;                /*!< CAN IF2 Command Mask                                                  */
+    __IO uint32_t  IF2CMSK;                         /*!< CAN IF2 Command Mask                                                  */
+  };
+  __IO uint32_t  IF2MSK1;                           /*!< CAN IF2 Mask 1                                                        */
+  __IO uint32_t  IF2MSK2;                           /*!< CAN IF2 Mask 2                                                        */
+  __IO uint32_t  IF2ARB1;                           /*!< CAN IF2 Arbitration 1                                                 */
+  __IO uint32_t  IF2ARB2;                           /*!< CAN IF2 Arbitration 2                                                 */
+  __IO uint32_t  IF2MCTL;                           /*!< CAN IF2 Message Control                                               */
+  __IO uint32_t  IF2DA1;                            /*!< CAN IF2 Data A1                                                       */
+  __IO uint32_t  IF2DA2;                            /*!< CAN IF2 Data A2                                                       */
+  __IO uint32_t  IF2DB1;                            /*!< CAN IF2 Data B1                                                       */
+  __IO uint32_t  IF2DB2;                            /*!< CAN IF2 Data B2                                                       */
+  __I  uint32_t  RESERVED2[21];
+  __IO uint32_t  TXRQ1;                             /*!< CAN Transmission Request 1                                            */
+  __IO uint32_t  TXRQ2;                             /*!< CAN Transmission Request 2                                            */
+  __I  uint32_t  RESERVED3[6];
+  __IO uint32_t  NWDA1;                             /*!< CAN New Data 1                                                        */
+  __IO uint32_t  NWDA2;                             /*!< CAN New Data 2                                                        */
+  __I  uint32_t  RESERVED4[6];
+  __IO uint32_t  MSG1INT;                           /*!< CAN Message 1 Interrupt Pending                                       */
+  __IO uint32_t  MSG2INT;                           /*!< CAN Message 2 Interrupt Pending                                       */
+  __I  uint32_t  RESERVED5[6];
+  __IO uint32_t  MSG1VAL;                           /*!< CAN Message 1 Valid                                                   */
+  __IO uint32_t  MSG2VAL;                           /*!< CAN Message 2 Valid                                                   */
+} CAN0_Type;
+
+
+/* ================================================================================ */
+/* ================                      USB0                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for USB0 peripheral (USB0)
+  */
+
+typedef struct {                                    /*!< USB0 Structure                                                        */
+  __IO uint8_t   FADDR;                             /*!< USB Device Functional Address                                         */
+  __IO uint8_t   POWER;                             /*!< USB Power                                                             */
+  __IO uint16_t  TXIS;                              /*!< USB Transmit Interrupt Status                                         */
+  __IO uint16_t  RXIS;                              /*!< USB Receive Interrupt Status                                          */
+  __IO uint16_t  TXIE;                              /*!< USB Transmit Interrupt Enable                                         */
+  __IO uint16_t  RXIE;                              /*!< USB Receive Interrupt Enable                                          */
+  
+  union {
+    __IO uint8_t   IS_USB0_ALT;                     /*!< USB General Interrupt Status                                          */
+    __IO uint8_t   IS;                              /*!< USB General Interrupt Status                                          */
+  };
+  
+  union {
+    __IO uint8_t   IE_USB0_ALT;                     /*!< USB Interrupt Enable                                                  */
+    __IO uint8_t   IE;                              /*!< USB Interrupt Enable                                                  */
+  };
+  __IO uint16_t  FRAME;                             /*!< USB Frame Value                                                       */
+  __IO uint8_t   EPIDX;                             /*!< USB Endpoint Index                                                    */
+  __IO uint8_t   TEST;                              /*!< USB Test Mode                                                         */
+  __I  uint32_t  RESERVED0[4];
+  __IO uint32_t  FIFO0;                             /*!< USB FIFO Endpoint 0                                                   */
+  __IO uint32_t  FIFO1;                             /*!< USB FIFO Endpoint 1                                                   */
+  __IO uint32_t  FIFO2;                             /*!< USB FIFO Endpoint 2                                                   */
+  __IO uint32_t  FIFO3;                             /*!< USB FIFO Endpoint 3                                                   */
+  __IO uint32_t  FIFO4;                             /*!< USB FIFO Endpoint 4                                                   */
+  __IO uint32_t  FIFO5;                             /*!< USB FIFO Endpoint 5                                                   */
+  __IO uint32_t  FIFO6;                             /*!< USB FIFO Endpoint 6                                                   */
+  __IO uint32_t  FIFO7;                             /*!< USB FIFO Endpoint 7                                                   */
+  __I  uint32_t  RESERVED1[8];
+  __IO uint8_t   DEVCTL;                            /*!< USB Device Control                                                    */
+  __I  uint8_t   RESERVED2[1];
+  __IO uint8_t   TXFIFOSZ;                          /*!< USB Transmit Dynamic FIFO Sizing                                      */
+  __IO uint8_t   RXFIFOSZ;                          /*!< USB Receive Dynamic FIFO Sizing                                       */
+  __IO uint16_t  TXFIFOADD;                         /*!< USB Transmit FIFO Start Address                                       */
+  __IO uint16_t  RXFIFOADD;                         /*!< USB Receive FIFO Start Address                                        */
+  __I  uint32_t  RESERVED3[4];
+  __I  uint16_t  RESERVED4;
+  __IO uint8_t   CONTIM;                            /*!< USB Connect Timing                                                    */
+  __IO uint8_t   VPLEN;                             /*!< USB OTG VBUS Pulse Timing                                             */
+  __I  uint8_t   RESERVED5[1];
+  __IO uint8_t   FSEOF;                             /*!< USB Full-Speed Last Transaction to End of Frame Timing                */
+  __IO uint8_t   LSEOF;                             /*!< USB Low-Speed Last Transaction to End of Frame Timing                 */
+  __I  uint8_t   RESERVED6[1];
+  __IO uint8_t   TXFUNCADDR0;                       /*!< USB Transmit Functional Address Endpoint 0                            */
+  __I  uint8_t   RESERVED7[1];
+  __IO uint8_t   TXHUBADDR0;                        /*!< USB Transmit Hub Address Endpoint 0                                   */
+  __IO uint8_t   TXHUBPORT0;                        /*!< USB Transmit Hub Port Endpoint 0                                      */
+  __I  uint32_t  RESERVED8;
+  __IO uint8_t   TXFUNCADDR1;                       /*!< USB Transmit Functional Address Endpoint 1                            */
+  __I  uint8_t   RESERVED9[1];
+  __IO uint8_t   TXHUBADDR1;                        /*!< USB Transmit Hub Address Endpoint 1                                   */
+  __IO uint8_t   TXHUBPORT1;                        /*!< USB Transmit Hub Port Endpoint 1                                      */
+  __IO uint8_t   RXFUNCADDR1;                       /*!< USB Receive Functional Address Endpoint 1                             */
+  __I  uint8_t   RESERVED10[1];
+  __IO uint8_t   RXHUBADDR1;                        /*!< USB Receive Hub Address Endpoint 1                                    */
+  __IO uint8_t   RXHUBPORT1;                        /*!< USB Receive Hub Port Endpoint 1                                       */
+  __IO uint8_t   TXFUNCADDR2;                       /*!< USB Transmit Functional Address Endpoint 2                            */
+  __I  uint8_t   RESERVED11[1];
+  __IO uint8_t   TXHUBADDR2;                        /*!< USB Transmit Hub Address Endpoint 2                                   */
+  __IO uint8_t   TXHUBPORT2;                        /*!< USB Transmit Hub Port Endpoint 2                                      */
+  __IO uint8_t   RXFUNCADDR2;                       /*!< USB Receive Functional Address Endpoint 2                             */
+  __I  uint8_t   RESERVED12[1];
+  __IO uint8_t   RXHUBADDR2;                        /*!< USB Receive Hub Address Endpoint 2                                    */
+  __IO uint8_t   RXHUBPORT2;                        /*!< USB Receive Hub Port Endpoint 2                                       */
+  __IO uint8_t   TXFUNCADDR3;                       /*!< USB Transmit Functional Address Endpoint 3                            */
+  __I  uint8_t   RESERVED13[1];
+  __IO uint8_t   TXHUBADDR3;                        /*!< USB Transmit Hub Address Endpoint 3                                   */
+  __IO uint8_t   TXHUBPORT3;                        /*!< USB Transmit Hub Port Endpoint 3                                      */
+  __IO uint8_t   RXFUNCADDR3;                       /*!< USB Receive Functional Address Endpoint 3                             */
+  __I  uint8_t   RESERVED14[1];
+  __IO uint8_t   RXHUBADDR3;                        /*!< USB Receive Hub Address Endpoint 3                                    */
+  __IO uint8_t   RXHUBPORT3;                        /*!< USB Receive Hub Port Endpoint 3                                       */
+  __IO uint8_t   TXFUNCADDR4;                       /*!< USB Transmit Functional Address Endpoint 4                            */
+  __I  uint8_t   RESERVED15[1];
+  __IO uint8_t   TXHUBADDR4;                        /*!< USB Transmit Hub Address Endpoint 4                                   */
+  __IO uint8_t   TXHUBPORT4;                        /*!< USB Transmit Hub Port Endpoint 4                                      */
+  __IO uint8_t   RXFUNCADDR4;                       /*!< USB Receive Functional Address Endpoint 4                             */
+  __I  uint8_t   RESERVED16[1];
+  __IO uint8_t   RXHUBADDR4;                        /*!< USB Receive Hub Address Endpoint 4                                    */
+  __IO uint8_t   RXHUBPORT4;                        /*!< USB Receive Hub Port Endpoint 4                                       */
+  __IO uint8_t   TXFUNCADDR5;                       /*!< USB Transmit Functional Address Endpoint 5                            */
+  __I  uint8_t   RESERVED17[1];
+  __IO uint8_t   TXHUBADDR5;                        /*!< USB Transmit Hub Address Endpoint 5                                   */
+  __IO uint8_t   TXHUBPORT5;                        /*!< USB Transmit Hub Port Endpoint 5                                      */
+  __IO uint8_t   RXFUNCADDR5;                       /*!< USB Receive Functional Address Endpoint 5                             */
+  __I  uint8_t   RESERVED18[1];
+  __IO uint8_t   RXHUBADDR5;                        /*!< USB Receive Hub Address Endpoint 5                                    */
+  __IO uint8_t   RXHUBPORT5;                        /*!< USB Receive Hub Port Endpoint 5                                       */
+  __IO uint8_t   TXFUNCADDR6;                       /*!< USB Transmit Functional Address Endpoint 6                            */
+  __I  uint8_t   RESERVED19[1];
+  __IO uint8_t   TXHUBADDR6;                        /*!< USB Transmit Hub Address Endpoint 6                                   */
+  __IO uint8_t   TXHUBPORT6;                        /*!< USB Transmit Hub Port Endpoint 6                                      */
+  __IO uint8_t   RXFUNCADDR6;                       /*!< USB Receive Functional Address Endpoint 6                             */
+  __I  uint8_t   RESERVED20[1];
+  __IO uint8_t   RXHUBADDR6;                        /*!< USB Receive Hub Address Endpoint 6                                    */
+  __IO uint8_t   RXHUBPORT6;                        /*!< USB Receive Hub Port Endpoint 6                                       */
+  __IO uint8_t   TXFUNCADDR7;                       /*!< USB Transmit Functional Address Endpoint 7                            */
+  __I  uint8_t   RESERVED21[1];
+  __IO uint8_t   TXHUBADDR7;                        /*!< USB Transmit Hub Address Endpoint 7                                   */
+  __IO uint8_t   TXHUBPORT7;                        /*!< USB Transmit Hub Port Endpoint 7                                      */
+  __IO uint8_t   RXFUNCADDR7;                       /*!< USB Receive Functional Address Endpoint 7                             */
+  __I  uint8_t   RESERVED22[1];
+  __IO uint8_t   RXHUBADDR7;                        /*!< USB Receive Hub Address Endpoint 7                                    */
+  __IO uint8_t   RXHUBPORT7;                        /*!< USB Receive Hub Port Endpoint 7                                       */
+  __I  uint32_t  RESERVED23[16];
+  __I  uint16_t  RESERVED24;
+  
+  union {
+    __O  uint8_t   CSRL0_USB0_ALT;                  /*!< USB Control and Status Endpoint 0 Low                                 */
+    __O  uint8_t   CSRL0;                           /*!< USB Control and Status Endpoint 0 Low                                 */
+  };
+  __O  uint8_t   CSRH0;                             /*!< USB Control and Status Endpoint 0 High                                */
+  __I  uint16_t  RESERVED25[3];
+  __IO uint8_t   COUNT0;                            /*!< USB Receive Byte Count Endpoint 0                                     */
+  __I  uint8_t   RESERVED26[1];
+  __IO uint8_t   TYPE0;                             /*!< USB Type Endpoint 0                                                   */
+  __IO uint8_t   NAKLMT;                            /*!< USB NAK Limit                                                         */
+  __I  uint32_t  RESERVED27;
+  __IO uint16_t  TXMAXP1;                           /*!< USB Maximum Transmit Data Endpoint 1                                  */
+  
+  union {
+    __IO uint8_t   TXCSRL1_USB0_ALT;                /*!< USB Transmit Control and Status Endpoint 1 Low                        */
+    __IO uint8_t   TXCSRL1;                         /*!< USB Transmit Control and Status Endpoint 1 Low                        */
+  };
+  __IO uint8_t   TXCSRH1;                           /*!< USB Transmit Control and Status Endpoint 1 High                       */
+  __IO uint16_t  RXMAXP1;                           /*!< USB Maximum Receive Data Endpoint 1                                   */
+  
+  union {
+    __IO uint8_t   RXCSRL1_USB0_ALT;                /*!< USB Receive Control and Status Endpoint 1 Low                         */
+    __IO uint8_t   RXCSRL1;                         /*!< USB Receive Control and Status Endpoint 1 Low                         */
+  };
+  
+  union {
+    __IO uint8_t   RXCSRH1_USB0_ALT;                /*!< USB Receive Control and Status Endpoint 1 High                        */
+    __IO uint8_t   RXCSRH1;                         /*!< USB Receive Control and Status Endpoint 1 High                        */
+  };
+  __IO uint16_t  RXCOUNT1;                          /*!< USB Receive Byte Count Endpoint 1                                     */
+  __IO uint8_t   TXTYPE1;                           /*!< USB Host Transmit Configure Type Endpoint 1                           */
+  
+  union {
+    __IO uint8_t   TXINTERVAL1_USB0_ALT;            /*!< USB Host Transmit Interval Endpoint 1                                 */
+    __IO uint8_t   TXINTERVAL1;                     /*!< USB Host Transmit Interval Endpoint 1                                 */
+  };
+  __IO uint8_t   RXTYPE1;                           /*!< USB Host Configure Receive Type Endpoint 1                            */
+  
+  union {
+    __IO uint8_t   RXINTERVAL1_USB0_ALT;            /*!< USB Host Receive Polling Interval Endpoint 1                          */
+    __IO uint8_t   RXINTERVAL1;                     /*!< USB Host Receive Polling Interval Endpoint 1                          */
+  };
+  __I  uint16_t  RESERVED28;
+  __IO uint16_t  TXMAXP2;                           /*!< USB Maximum Transmit Data Endpoint 2                                  */
+  
+  union {
+    __IO uint8_t   TXCSRL2_USB0_ALT;                /*!< USB Transmit Control and Status Endpoint 2 Low                        */
+    __IO uint8_t   TXCSRL2;                         /*!< USB Transmit Control and Status Endpoint 2 Low                        */
+  };
+  __IO uint8_t   TXCSRH2;                           /*!< USB Transmit Control and Status Endpoint 2 High                       */
+  __IO uint16_t  RXMAXP2;                           /*!< USB Maximum Receive Data Endpoint 2                                   */
+  
+  union {
+    __IO uint8_t   RXCSRL2_USB0_ALT;                /*!< USB Receive Control and Status Endpoint 2 Low                         */
+    __IO uint8_t   RXCSRL2;                         /*!< USB Receive Control and Status Endpoint 2 Low                         */
+  };
+  
+  union {
+    __IO uint8_t   RXCSRH2_USB0_ALT;                /*!< USB Receive Control and Status Endpoint 2 High                        */
+    __IO uint8_t   RXCSRH2;                         /*!< USB Receive Control and Status Endpoint 2 High                        */
+  };
+  __IO uint16_t  RXCOUNT2;                          /*!< USB Receive Byte Count Endpoint 2                                     */
+  __IO uint8_t   TXTYPE2;                           /*!< USB Host Transmit Configure Type Endpoint 2                           */
+  
+  union {
+    __IO uint8_t   TXINTERVAL2_USB0_ALT;            /*!< USB Host Transmit Interval Endpoint 2                                 */
+    __IO uint8_t   TXINTERVAL2;                     /*!< USB Host Transmit Interval Endpoint 2                                 */
+  };
+  __IO uint8_t   RXTYPE2;                           /*!< USB Host Configure Receive Type Endpoint 2                            */
+  
+  union {
+    __IO uint8_t   RXINTERVAL2_USB0_ALT;            /*!< USB Host Receive Polling Interval Endpoint 2                          */
+    __IO uint8_t   RXINTERVAL2;                     /*!< USB Host Receive Polling Interval Endpoint 2                          */
+  };
+  __I  uint16_t  RESERVED29;
+  __IO uint16_t  TXMAXP3;                           /*!< USB Maximum Transmit Data Endpoint 3                                  */
+  
+  union {
+    __IO uint8_t   TXCSRL3_USB0_ALT;                /*!< USB Transmit Control and Status Endpoint 3 Low                        */
+    __IO uint8_t   TXCSRL3;                         /*!< USB Transmit Control and Status Endpoint 3 Low                        */
+  };
+  __IO uint8_t   TXCSRH3;                           /*!< USB Transmit Control and Status Endpoint 3 High                       */
+  __IO uint16_t  RXMAXP3;                           /*!< USB Maximum Receive Data Endpoint 3                                   */
+  
+  union {
+    __IO uint8_t   RXCSRL3_USB0_ALT;                /*!< USB Receive Control and Status Endpoint 3 Low                         */
+    __IO uint8_t   RXCSRL3;                         /*!< USB Receive Control and Status Endpoint 3 Low                         */
+  };
+  
+  union {
+    __IO uint8_t   RXCSRH3_USB0_ALT;                /*!< USB Receive Control and Status Endpoint 3 High                        */
+    __IO uint8_t   RXCSRH3;                         /*!< USB Receive Control and Status Endpoint 3 High                        */
+  };
+  __IO uint16_t  RXCOUNT3;                          /*!< USB Receive Byte Count Endpoint 3                                     */
+  __IO uint8_t   TXTYPE3;                           /*!< USB Host Transmit Configure Type Endpoint 3                           */
+  
+  union {
+    __IO uint8_t   TXINTERVAL3_USB0_ALT;            /*!< USB Host Transmit Interval Endpoint 3                                 */
+    __IO uint8_t   TXINTERVAL3;                     /*!< USB Host Transmit Interval Endpoint 3                                 */
+  };
+  __IO uint8_t   RXTYPE3;                           /*!< USB Host Configure Receive Type Endpoint 3                            */
+  
+  union {
+    __IO uint8_t   RXINTERVAL3_USB0_ALT;            /*!< USB Host Receive Polling Interval Endpoint 3                          */
+    __IO uint8_t   RXINTERVAL3;                     /*!< USB Host Receive Polling Interval Endpoint 3                          */
+  };
+  __I  uint16_t  RESERVED30;
+  __IO uint16_t  TXMAXP4;                           /*!< USB Maximum Transmit Data Endpoint 4                                  */
+  
+  union {
+    __IO uint8_t   TXCSRL4_USB0_ALT;                /*!< USB Transmit Control and Status Endpoint 4 Low                        */
+    __IO uint8_t   TXCSRL4;                         /*!< USB Transmit Control and Status Endpoint 4 Low                        */
+  };
+  __IO uint8_t   TXCSRH4;                           /*!< USB Transmit Control and Status Endpoint 4 High                       */
+  __IO uint16_t  RXMAXP4;                           /*!< USB Maximum Receive Data Endpoint 4                                   */
+  
+  union {
+    __IO uint8_t   RXCSRL4_USB0_ALT;                /*!< USB Receive Control and Status Endpoint 4 Low                         */
+    __IO uint8_t   RXCSRL4;                         /*!< USB Receive Control and Status Endpoint 4 Low                         */
+  };
+  
+  union {
+    __IO uint8_t   RXCSRH4_USB0_ALT;                /*!< USB Receive Control and Status Endpoint 4 High                        */
+    __IO uint8_t   RXCSRH4;                         /*!< USB Receive Control and Status Endpoint 4 High                        */
+  };
+  __IO uint16_t  RXCOUNT4;                          /*!< USB Receive Byte Count Endpoint 4                                     */
+  __IO uint8_t   TXTYPE4;                           /*!< USB Host Transmit Configure Type Endpoint 4                           */
+  
+  union {
+    __IO uint8_t   TXINTERVAL4_USB0_ALT;            /*!< USB Host Transmit Interval Endpoint 4                                 */
+    __IO uint8_t   TXINTERVAL4;                     /*!< USB Host Transmit Interval Endpoint 4                                 */
+  };
+  __IO uint8_t   RXTYPE4;                           /*!< USB Host Configure Receive Type Endpoint 4                            */
+  
+  union {
+    __IO uint8_t   RXINTERVAL4_USB0_ALT;            /*!< USB Host Receive Polling Interval Endpoint 4                          */
+    __IO uint8_t   RXINTERVAL4;                     /*!< USB Host Receive Polling Interval Endpoint 4                          */
+  };
+  __I  uint16_t  RESERVED31;
+  __IO uint16_t  TXMAXP5;                           /*!< USB Maximum Transmit Data Endpoint 5                                  */
+  
+  union {
+    __IO uint8_t   TXCSRL5_USB0_ALT;                /*!< USB Transmit Control and Status Endpoint 5 Low                        */
+    __IO uint8_t   TXCSRL5;                         /*!< USB Transmit Control and Status Endpoint 5 Low                        */
+  };
+  __IO uint8_t   TXCSRH5;                           /*!< USB Transmit Control and Status Endpoint 5 High                       */
+  __IO uint16_t  RXMAXP5;                           /*!< USB Maximum Receive Data Endpoint 5                                   */
+  
+  union {
+    __IO uint8_t   RXCSRL5_USB0_ALT;                /*!< USB Receive Control and Status Endpoint 5 Low                         */
+    __IO uint8_t   RXCSRL5;                         /*!< USB Receive Control and Status Endpoint 5 Low                         */
+  };
+  
+  union {
+    __IO uint8_t   RXCSRH5_USB0_ALT;                /*!< USB Receive Control and Status Endpoint 5 High                        */
+    __IO uint8_t   RXCSRH5;                         /*!< USB Receive Control and Status Endpoint 5 High                        */
+  };
+  __IO uint16_t  RXCOUNT5;                          /*!< USB Receive Byte Count Endpoint 5                                     */
+  __IO uint8_t   TXTYPE5;                           /*!< USB Host Transmit Configure Type Endpoint 5                           */
+  
+  union {
+    __IO uint8_t   TXINTERVAL5_USB0_ALT;            /*!< USB Host Transmit Interval Endpoint 5                                 */
+    __IO uint8_t   TXINTERVAL5;                     /*!< USB Host Transmit Interval Endpoint 5                                 */
+  };
+  __IO uint8_t   RXTYPE5;                           /*!< USB Host Configure Receive Type Endpoint 5                            */
+  
+  union {
+    __IO uint8_t   RXINTERVAL5_USB0_ALT;            /*!< USB Host Receive Polling Interval Endpoint 5                          */
+    __IO uint8_t   RXINTERVAL5;                     /*!< USB Host Receive Polling Interval Endpoint 5                          */
+  };
+  __I  uint16_t  RESERVED32;
+  __IO uint16_t  TXMAXP6;                           /*!< USB Maximum Transmit Data Endpoint 6                                  */
+  
+  union {
+    __IO uint8_t   TXCSRL6_USB0_ALT;                /*!< USB Transmit Control and Status Endpoint 6 Low                        */
+    __IO uint8_t   TXCSRL6;                         /*!< USB Transmit Control and Status Endpoint 6 Low                        */
+  };
+  __IO uint8_t   TXCSRH6;                           /*!< USB Transmit Control and Status Endpoint 6 High                       */
+  __IO uint16_t  RXMAXP6;                           /*!< USB Maximum Receive Data Endpoint 6                                   */
+  
+  union {
+    __IO uint8_t   RXCSRL6_USB0_ALT;                /*!< USB Receive Control and Status Endpoint 6 Low                         */
+    __IO uint8_t   RXCSRL6;                         /*!< USB Receive Control and Status Endpoint 6 Low                         */
+  };
+  
+  union {
+    __IO uint8_t   RXCSRH6_USB0_ALT;                /*!< USB Receive Control and Status Endpoint 6 High                        */
+    __IO uint8_t   RXCSRH6;                         /*!< USB Receive Control and Status Endpoint 6 High                        */
+  };
+  __IO uint16_t  RXCOUNT6;                          /*!< USB Receive Byte Count Endpoint 6                                     */
+  __IO uint8_t   TXTYPE6;                           /*!< USB Host Transmit Configure Type Endpoint 6                           */
+  
+  union {
+    __IO uint8_t   TXINTERVAL6_USB0_ALT;            /*!< USB Host Transmit Interval Endpoint 6                                 */
+    __IO uint8_t   TXINTERVAL6;                     /*!< USB Host Transmit Interval Endpoint 6                                 */
+  };
+  __IO uint8_t   RXTYPE6;                           /*!< USB Host Configure Receive Type Endpoint 6                            */
+  
+  union {
+    __IO uint8_t   RXINTERVAL6_USB0_ALT;            /*!< USB Host Receive Polling Interval Endpoint 6                          */
+    __IO uint8_t   RXINTERVAL6;                     /*!< USB Host Receive Polling Interval Endpoint 6                          */
+  };
+  __I  uint16_t  RESERVED33;
+  __IO uint16_t  TXMAXP7;                           /*!< USB Maximum Transmit Data Endpoint 7                                  */
+  
+  union {
+    __IO uint8_t   TXCSRL7_USB0_ALT;                /*!< USB Transmit Control and Status Endpoint 7 Low                        */
+    __IO uint8_t   TXCSRL7;                         /*!< USB Transmit Control and Status Endpoint 7 Low                        */
+  };
+  __IO uint8_t   TXCSRH7;                           /*!< USB Transmit Control and Status Endpoint 7 High                       */
+  __IO uint16_t  RXMAXP7;                           /*!< USB Maximum Receive Data Endpoint 7                                   */
+  
+  union {
+    __IO uint8_t   RXCSRL7_USB0_ALT;                /*!< USB Receive Control and Status Endpoint 7 Low                         */
+    __IO uint8_t   RXCSRL7;                         /*!< USB Receive Control and Status Endpoint 7 Low                         */
+  };
+  
+  union {
+    __IO uint8_t   RXCSRH7_USB0_ALT;                /*!< USB Receive Control and Status Endpoint 7 High                        */
+    __IO uint8_t   RXCSRH7;                         /*!< USB Receive Control and Status Endpoint 7 High                        */
+  };
+  __IO uint16_t  RXCOUNT7;                          /*!< USB Receive Byte Count Endpoint 7                                     */
+  __IO uint8_t   TXTYPE7;                           /*!< USB Host Transmit Configure Type Endpoint 7                           */
+  
+  union {
+    __IO uint8_t   TXINTERVAL7_USB0_ALT;            /*!< USB Host Transmit Interval Endpoint 7                                 */
+    __IO uint8_t   TXINTERVAL7;                     /*!< USB Host Transmit Interval Endpoint 7                                 */
+  };
+  __IO uint8_t   RXTYPE7;                           /*!< USB Host Configure Receive Type Endpoint 7                            */
+  
+  union {
+    __IO uint8_t   RXINTERVAL7_USB0_ALT;            /*!< USB Host Receive Polling Interval Endpoint 7                          */
+    __IO uint8_t   RXINTERVAL7;                     /*!< USB Host Receive Polling Interval Endpoint 7                          */
+  };
+  __I  uint16_t  RESERVED34[195];
+  __IO uint16_t  RQPKTCOUNT1;                       /*!< USB Request Packet Count in Block Transfer Endpoint 1                 */
+  __I  uint16_t  RESERVED35;
+  __IO uint16_t  RQPKTCOUNT2;                       /*!< USB Request Packet Count in Block Transfer Endpoint 2                 */
+  __I  uint16_t  RESERVED36;
+  __IO uint16_t  RQPKTCOUNT3;                       /*!< USB Request Packet Count in Block Transfer Endpoint 3                 */
+  __I  uint16_t  RESERVED37;
+  __IO uint16_t  RQPKTCOUNT4;                       /*!< USB Request Packet Count in Block Transfer Endpoint 4                 */
+  __I  uint16_t  RESERVED38;
+  __IO uint16_t  RQPKTCOUNT5;                       /*!< USB Request Packet Count in Block Transfer Endpoint 5                 */
+  __I  uint16_t  RESERVED39;
+  __IO uint16_t  RQPKTCOUNT6;                       /*!< USB Request Packet Count in Block Transfer Endpoint 6                 */
+  __I  uint16_t  RESERVED40;
+  __IO uint16_t  RQPKTCOUNT7;                       /*!< USB Request Packet Count in Block Transfer Endpoint 7                 */
+  __I  uint16_t  RESERVED41[17];
+  __IO uint16_t  RXDPKTBUFDIS;                      /*!< USB Receive Double Packet Buffer Disable                              */
+  __IO uint16_t  TXDPKTBUFDIS;                      /*!< USB Transmit Double Packet Buffer Disable                             */
+  __I  uint32_t  RESERVED42[47];
+  __IO uint32_t  EPC;                               /*!< USB External Power Control                                            */
+  __IO uint32_t  EPCRIS;                            /*!< USB External Power Control Raw Interrupt Status                       */
+  __IO uint32_t  EPCIM;                             /*!< USB External Power Control Interrupt Mask                             */
+  __IO uint32_t  EPCISC;                            /*!< USB External Power Control Interrupt Status and Clear                 */
+  __IO uint32_t  DRRIS;                             /*!< USB Device RESUME Raw Interrupt Status                                */
+  __IO uint32_t  DRIM;                              /*!< USB Device RESUME Interrupt Mask                                      */
+  __O  uint32_t  DRISC;                             /*!< USB Device RESUME Interrupt Status and Clear                          */
+  __IO uint32_t  GPCS;                              /*!< USB General-Purpose Control and Status                                */
+  __I  uint32_t  RESERVED43[4];
+  __IO uint32_t  VDC;                               /*!< USB VBUS Droop Control                                                */
+  __IO uint32_t  VDCRIS;                            /*!< USB VBUS Droop Control Raw Interrupt Status                           */
+  __IO uint32_t  VDCIM;                             /*!< USB VBUS Droop Control Interrupt Mask                                 */
+  __IO uint32_t  VDCISC;                            /*!< USB VBUS Droop Control Interrupt Status and Clear                     */
+  __I  uint32_t  RESERVED44;
+  __IO uint32_t  IDVRIS;                            /*!< USB ID Valid Detect Raw Interrupt Status                              */
+  __IO uint32_t  IDVIM;                             /*!< USB ID Valid Detect Interrupt Mask                                    */
+  __IO uint32_t  IDVISC;                            /*!< USB ID Valid Detect Interrupt Status and Clear                        */
+  __IO uint32_t  DMASEL;                            /*!< USB DMA Select                                                        */
+  __I  uint32_t  RESERVED45[731];
+  __IO uint32_t  PP;                                /*!< USB Peripheral Properties                                             */
+} USB0_Type;
+
+
+/* ================================================================================ */
+/* ================                     EEPROM                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for EEPROM peripheral (EEPROM)
+  */
+
+typedef struct {                                    /*!< EEPROM Structure                                                      */
+  __IO uint32_t  EESIZE;                            /*!< EEPROM Size Information                                               */
+  __IO uint32_t  EEBLOCK;                           /*!< EEPROM Current Block                                                  */
+  __IO uint32_t  EEOFFSET;                          /*!< EEPROM Current Offset                                                 */
+  __I  uint32_t  RESERVED0;
+  __IO uint32_t  EERDWR;                            /*!< EEPROM Read-Write                                                     */
+  __IO uint32_t  EERDWRINC;                         /*!< EEPROM Read-Write with Increment                                      */
+  __IO uint32_t  EEDONE;                            /*!< EEPROM Done Status                                                    */
+  __IO uint32_t  EESUPP;                            /*!< EEPROM Support Control and Status                                     */
+  __IO uint32_t  EEUNLOCK;                          /*!< EEPROM Unlock                                                         */
+  __I  uint32_t  RESERVED1[3];
+  __IO uint32_t  EEPROT;                            /*!< EEPROM Protection                                                     */
+  __IO uint32_t  EEPASS0;                           /*!< EEPROM Password                                                       */
+  __IO uint32_t  EEPASS1;                           /*!< EEPROM Password                                                       */
+  __IO uint32_t  EEPASS2;                           /*!< EEPROM Password                                                       */
+  __IO uint32_t  EEINT;                             /*!< EEPROM Interrupt                                                      */
+  __I  uint32_t  RESERVED2[3];
+  __IO uint32_t  EEHIDE;                            /*!< EEPROM Block Hide                                                     */
+  __I  uint32_t  RESERVED3[11];
+  __IO uint32_t  EEDBGME;                           /*!< EEPROM Debug Mass Erase                                               */
+  __I  uint32_t  RESERVED4[975];
+  __IO uint32_t  PP;                                /*!< EEPROM Peripheral Properties                                          */
+} EEPROM_Type;
+
+
+/* ================================================================================ */
+/* ================                     SYSEXC                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for SYSEXC peripheral (SYSEXC)
+  */
+
+typedef struct {                                    /*!< SYSEXC Structure                                                      */
+  __IO uint32_t  RIS;                               /*!< System Exception Raw Interrupt Status                                 */
+  __IO uint32_t  IM;                                /*!< System Exception Interrupt Mask                                       */
+  __IO uint32_t  MIS;                               /*!< System Exception Masked Interrupt Status                              */
+  __O  uint32_t  IC;                                /*!< System Exception Interrupt Clear                                      */
+} SYSEXC_Type;
+
+
+/* ================================================================================ */
+/* ================                       HIB                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for HIB peripheral (HIB)
+  */
+
+typedef struct {                                    /*!< HIB Structure                                                         */
+  __IO uint32_t  RTCC;                              /*!< Hibernation RTC Counter                                               */
+  __IO uint32_t  RTCM0;                             /*!< Hibernation RTC Match 0                                               */
+  __I  uint32_t  RESERVED0;
+  __IO uint32_t  RTCLD;                             /*!< Hibernation RTC Load                                                  */
+  __IO uint32_t  CTL;                               /*!< Hibernation Control                                                   */
+  __IO uint32_t  IM;                                /*!< Hibernation Interrupt Mask                                            */
+  __IO uint32_t  RIS;                               /*!< Hibernation Raw Interrupt Status                                      */
+  __IO uint32_t  MIS;                               /*!< Hibernation Masked Interrupt Status                                   */
+  __IO uint32_t  IC;                                /*!< Hibernation Interrupt Clear                                           */
+  __IO uint32_t  RTCT;                              /*!< Hibernation RTC Trim                                                  */
+  __IO uint32_t  RTCSS;                             /*!< Hibernation RTC Sub Seconds                                           */
+  __I  uint32_t  RESERVED1;
+  __IO uint32_t  DATA;                              /*!< Hibernation Data                                                      */
+} HIB_Type;
+
+
+/* ================================================================================ */
+/* ================                   FLASH_CTRL                   ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for FLASH_CTRL peripheral (FLASH_CTRL)
+  */
+
+typedef struct {                                    /*!< FLASH_CTRL Structure                                                  */
+  __IO uint32_t  FMA;                               /*!< Flash Memory Address                                                  */
+  __IO uint32_t  FMD;                               /*!< Flash Memory Data                                                     */
+  __IO uint32_t  FMC;                               /*!< Flash Memory Control                                                  */
+  __IO uint32_t  FCRIS;                             /*!< Flash Controller Raw Interrupt Status                                 */
+  __IO uint32_t  FCIM;                              /*!< Flash Controller Interrupt Mask                                       */
+  __IO uint32_t  FCMISC;                            /*!< Flash Controller Masked Interrupt Status and Clear                    */
+  __I  uint32_t  RESERVED0[2];
+  __IO uint32_t  FMC2;                              /*!< Flash Memory Control 2                                                */
+  __I  uint32_t  RESERVED1[3];
+  __IO uint32_t  FWBVAL;                            /*!< Flash Write Buffer Valid                                              */
+  __I  uint32_t  RESERVED2[51];
+  __IO uint32_t  FWBN;                              /*!< Flash Write Buffer n                                                  */
+  __I  uint32_t  RESERVED3[943];
+  __IO uint32_t  FSIZE;                             /*!< Flash Size                                                            */
+  __IO uint32_t  SSIZE;                             /*!< SRAM Size                                                             */
+  __I  uint32_t  RESERVED4;
+  
+  union {
+    __IO uint32_t  ROMSWMAP_FLASH_CTRL_ALT;         /*!< ROM Software Map                                                      */
+    __IO uint32_t  ROMSWMAP;                        /*!< ROM Software Map                                                      */
+  };
+  __I  uint32_t  RESERVED5[72];
+  __IO uint32_t  RMCTL;                             /*!< ROM Control                                                           */
+  __I  uint32_t  RESERVED6[55];
+  __IO uint32_t  BOOTCFG;                           /*!< Boot Configuration                                                    */
+  __I  uint32_t  RESERVED7[3];
+  __IO uint32_t  USERREG0;                          /*!< User Register 0                                                       */
+  __IO uint32_t  USERREG1;                          /*!< User Register 1                                                       */
+  __IO uint32_t  USERREG2;                          /*!< User Register 2                                                       */
+  __IO uint32_t  USERREG3;                          /*!< User Register 3                                                       */
+  __I  uint32_t  RESERVED8[4];
+  __IO uint32_t  FMPRE0;                            /*!< Flash Memory Protection Read Enable 0                                 */
+  __IO uint32_t  FMPRE1;                            /*!< Flash Memory Protection Read Enable 1                                 */
+  __IO uint32_t  FMPRE2;                            /*!< Flash Memory Protection Read Enable 2                                 */
+  __IO uint32_t  FMPRE3;                            /*!< Flash Memory Protection Read Enable 3                                 */
+  __I  uint32_t  RESERVED9[124];
+  __IO uint32_t  FMPPE0;                            /*!< Flash Memory Protection Program Enable 0                              */
+  __IO uint32_t  FMPPE1;                            /*!< Flash Memory Protection Program Enable 1                              */
+  __IO uint32_t  FMPPE2;                            /*!< Flash Memory Protection Program Enable 2                              */
+  __IO uint32_t  FMPPE3;                            /*!< Flash Memory Protection Program Enable 3                              */
+} FLASH_CTRL_Type;
+
+
+/* ================================================================================ */
+/* ================                     SYSCTL                     ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for SYSCTL peripheral (SYSCTL)
+  */
+
+typedef struct {                                    /*!< SYSCTL Structure                                                      */
+  __IO uint32_t  DID0;                              /*!< Device Identification 0                                               */
+  __IO uint32_t  DID1;                              /*!< Device Identification 1                                               */
+  __IO uint32_t  DC0;                               /*!< Device Capabilities 0                                                 */
+  __I  uint32_t  RESERVED0;
+  __IO uint32_t  DC1;                               /*!< Device Capabilities 1                                                 */
+  __IO uint32_t  DC2;                               /*!< Device Capabilities 2                                                 */
+  __IO uint32_t  DC3;                               /*!< Device Capabilities 3                                                 */
+  __IO uint32_t  DC4;                               /*!< Device Capabilities 4                                                 */
+  __IO uint32_t  DC5;                               /*!< Device Capabilities 5                                                 */
+  __IO uint32_t  DC6;                               /*!< Device Capabilities 6                                                 */
+  __IO uint32_t  DC7;                               /*!< Device Capabilities 7                                                 */
+  __IO uint32_t  DC8;                               /*!< Device Capabilities 8                                                 */
+  __IO uint32_t  PBORCTL;                           /*!< Brown-Out Reset Control                                               */
+  __I  uint32_t  RESERVED1[3];
+  __IO uint32_t  SRCR0;                             /*!< Software Reset Control 0                                              */
+  __IO uint32_t  SRCR1;                             /*!< Software Reset Control 1                                              */
+  __IO uint32_t  SRCR2;                             /*!< Software Reset Control 2                                              */
+  __I  uint32_t  RESERVED2;
+  __IO uint32_t  RIS;                               /*!< Raw Interrupt Status                                                  */
+  __IO uint32_t  IMC;                               /*!< Interrupt Mask Control                                                */
+  __IO uint32_t  MISC;                              /*!< Masked Interrupt Status and Clear                                     */
+  __IO uint32_t  RESC;                              /*!< Reset Cause                                                           */
+  __IO uint32_t  RCC;                               /*!< Run-Mode Clock Configuration                                          */
+  __I  uint32_t  RESERVED3[2];
+  __IO uint32_t  GPIOHBCTL;                         /*!< GPIO High-Performance Bus Control                                     */
+  __IO uint32_t  RCC2;                              /*!< Run-Mode Clock Configuration 2                                        */
+  __I  uint32_t  RESERVED4[2];
+  __IO uint32_t  MOSCCTL;                           /*!< Main Oscillator Control                                               */
+  __I  uint32_t  RESERVED5[32];
+  __IO uint32_t  RCGC0;                             /*!< Run Mode Clock Gating Control Register 0                              */
+  __IO uint32_t  RCGC1;                             /*!< Run Mode Clock Gating Control Register 1                              */
+  __IO uint32_t  RCGC2;                             /*!< Run Mode Clock Gating Control Register 2                              */
+  __I  uint32_t  RESERVED6;
+  __IO uint32_t  SCGC0;                             /*!< Sleep Mode Clock Gating Control Register 0                            */
+  __IO uint32_t  SCGC1;                             /*!< Sleep Mode Clock Gating Control Register 1                            */
+  __IO uint32_t  SCGC2;                             /*!< Sleep Mode Clock Gating Control Register 2                            */
+  __I  uint32_t  RESERVED7;
+  __IO uint32_t  DCGC0;                             /*!< Deep Sleep Mode Clock Gating Control Register 0                       */
+  __IO uint32_t  DCGC1;                             /*!< Deep-Sleep Mode Clock Gating Control Register 1                       */
+  __IO uint32_t  DCGC2;                             /*!< Deep Sleep Mode Clock Gating Control Register 2                       */
+  __I  uint32_t  RESERVED8[6];
+  __IO uint32_t  DSLPCLKCFG;                        /*!< Deep Sleep Clock Configuration                                        */
+  __I  uint32_t  RESERVED9;
+  __IO uint32_t  SYSPROP;                           /*!< System Properties                                                     */
+  __IO uint32_t  PIOSCCAL;                          /*!< Precision Internal Oscillator Calibration                             */
+  __IO uint32_t  PIOSCSTAT;                         /*!< Precision Internal Oscillator Statistics                              */
+  __I  uint32_t  RESERVED10[2];
+  __IO uint32_t  PLLFREQ0;                          /*!< PLL Frequency 0                                                       */
+  __IO uint32_t  PLLFREQ1;                          /*!< PLL Frequency 1                                                       */
+  __IO uint32_t  PLLSTAT;                           /*!< PLL Status                                                            */
+  __I  uint32_t  RESERVED11[7];
+  __IO uint32_t  SLPPWRCFG;                         /*!< Sleep Power Configuration                                             */
+  __IO uint32_t  DSLPPWRCFG;                        /*!< Deep-Sleep Power Configuration                                        */
+  __IO uint32_t  DC9;                               /*!< Device Capabilities 9                                                 */
+  __I  uint32_t  RESERVED12[3];
+  __IO uint32_t  NVMSTAT;                           /*!< Non-Volatile Memory Information                                       */
+  __I  uint32_t  RESERVED13[4];
+  __IO uint32_t  LDOSPCTL;                          /*!< LDO Sleep Power Control                                               */
+  __I  uint32_t  RESERVED14;
+  __IO uint32_t  LDODPCTL;                          /*!< LDO Deep-Sleep Power Control                                          */
+  __I  uint32_t  RESERVED15[80];
+  __IO uint32_t  PPWD;                              /*!< Watchdog Timer Peripheral Present                                     */
+  __IO uint32_t  PPTIMER;                           /*!< 16/32-Bit General-Purpose Timer Peripheral Present                    */
+  __IO uint32_t  PPGPIO;                            /*!< General-Purpose Input/Output Peripheral Present                       */
+  __IO uint32_t  PPDMA;                             /*!< Micro Direct Memory Access Peripheral Present                         */
+  __I  uint32_t  RESERVED16;
+  __IO uint32_t  PPHIB;                             /*!< Hibernation Peripheral Present                                        */
+  __IO uint32_t  PPUART;                            /*!< Universal Asynchronous Receiver/Transmitter Peripheral Present        */
+  __IO uint32_t  PPSSI;                             /*!< Synchronous Serial Interface Peripheral Present                       */
+  __IO uint32_t  PPI2C;                             /*!< Inter-Integrated Circuit Peripheral Present                           */
+  __I  uint32_t  RESERVED17;
+  __IO uint32_t  PPUSB;                             /*!< Universal Serial Bus Peripheral Present                               */
+  __I  uint32_t  RESERVED18[2];
+  __IO uint32_t  PPCAN;                             /*!< Controller Area Network Peripheral Present                            */
+  __IO uint32_t  PPADC;                             /*!< Analog-to-Digital Converter Peripheral Present                        */
+  __IO uint32_t  PPACMP;                            /*!< Analog Comparator Peripheral Present                                  */
+  __IO uint32_t  PPPWM;                             /*!< Pulse Width Modulator Peripheral Present                              */
+  __IO uint32_t  PPQEI;                             /*!< Quadrature Encoder Interface Peripheral Present                       */
+  __I  uint32_t  RESERVED19[4];
+  __IO uint32_t  PPEEPROM;                          /*!< EEPROM Peripheral Present                                             */
+  __IO uint32_t  PPWTIMER;                          /*!< 32/64-Bit Wide General-Purpose Timer Peripheral Present               */
+  __I  uint32_t  RESERVED20[104];
+  __IO uint32_t  SRWD;                              /*!< Watchdog Timer Software Reset                                         */
+  __IO uint32_t  SRTIMER;                           /*!< 16/32-Bit General-Purpose Timer Software Reset                        */
+  __IO uint32_t  SRGPIO;                            /*!< General-Purpose Input/Output Software Reset                           */
+  __IO uint32_t  SRDMA;                             /*!< Micro Direct Memory Access Software Reset                             */
+  __I  uint32_t  RESERVED21;
+  __IO uint32_t  SRHIB;                             /*!< Hibernation Software Reset                                            */
+  __IO uint32_t  SRUART;                            /*!< Universal Asynchronous Receiver/Transmitter Software Reset            */
+  __IO uint32_t  SRSSI;                             /*!< Synchronous Serial Interface Software Reset                           */
+  __IO uint32_t  SRI2C;                             /*!< Inter-Integrated Circuit Software Reset                               */
+  __I  uint32_t  RESERVED22;
+  __IO uint32_t  SRUSB;                             /*!< Universal Serial Bus Software Reset                                   */
+  __I  uint32_t  RESERVED23[2];
+  __IO uint32_t  SRCAN;                             /*!< Controller Area Network Software Reset                                */
+  __IO uint32_t  SRADC;                             /*!< Analog-to-Digital Converter Software Reset                            */
+  __IO uint32_t  SRACMP;                            /*!< Analog Comparator Software Reset                                      */
+  __IO uint32_t  SRPWM;                             /*!< Pulse Width Modulator Software Reset                                  */
+  __IO uint32_t  SRQEI;                             /*!< Quadrature Encoder Interface Software Reset                           */
+  __I  uint32_t  RESERVED24[4];
+  __IO uint32_t  SREEPROM;                          /*!< EEPROM Software Reset                                                 */
+  __IO uint32_t  SRWTIMER;                          /*!< 32/64-Bit Wide General-Purpose Timer Software Reset                   */
+  __I  uint32_t  RESERVED25[40];
+  __IO uint32_t  RCGCWD;                            /*!< Watchdog Timer Run Mode Clock Gating Control                          */
+  __IO uint32_t  RCGCTIMER;                         /*!< 16/32-Bit General-Purpose Timer Run Mode Clock Gating Control         */
+  __IO uint32_t  RCGCGPIO;                          /*!< General-Purpose Input/Output Run Mode Clock Gating Control            */
+  __IO uint32_t  RCGCDMA;                           /*!< Micro Direct Memory Access Run Mode Clock Gating Control              */
+  __I  uint32_t  RESERVED26;
+  __IO uint32_t  RCGCHIB;                           /*!< Hibernation Run Mode Clock Gating Control                             */
+  __IO uint32_t  RCGCUART;                          /*!< Universal Asynchronous Receiver/Transmitter Run Mode Clock Gating
+                                                         Control                                                               */
+  __IO uint32_t  RCGCSSI;                           /*!< Synchronous Serial Interface Run Mode Clock Gating Control            */
+  __IO uint32_t  RCGCI2C;                           /*!< Inter-Integrated Circuit Run Mode Clock Gating Control                */
+  __I  uint32_t  RESERVED27;
+  __IO uint32_t  RCGCUSB;                           /*!< Universal Serial Bus Run Mode Clock Gating Control                    */
+  __I  uint32_t  RESERVED28[2];
+  __IO uint32_t  RCGCCAN;                           /*!< Controller Area Network Run Mode Clock Gating Control                 */
+  __IO uint32_t  RCGCADC;                           /*!< Analog-to-Digital Converter Run Mode Clock Gating Control             */
+  __IO uint32_t  RCGCACMP;                          /*!< Analog Comparator Run Mode Clock Gating Control                       */
+  __IO uint32_t  RCGCPWM;                           /*!< Pulse Width Modulator Run Mode Clock Gating Control                   */
+  __IO uint32_t  RCGCQEI;                           /*!< Quadrature Encoder Interface Run Mode Clock Gating Control            */
+  __I  uint32_t  RESERVED29[4];
+  __IO uint32_t  RCGCEEPROM;                        /*!< EEPROM Run Mode Clock Gating Control                                  */
+  __IO uint32_t  RCGCWTIMER;                        /*!< 32/64-Bit Wide General-Purpose Timer Run Mode Clock Gating Control    */
+  __I  uint32_t  RESERVED30[40];
+  __IO uint32_t  SCGCWD;                            /*!< Watchdog Timer Sleep Mode Clock Gating Control                        */
+  __IO uint32_t  SCGCTIMER;                         /*!< 16/32-Bit General-Purpose Timer Sleep Mode Clock Gating Control       */
+  __IO uint32_t  SCGCGPIO;                          /*!< General-Purpose Input/Output Sleep Mode Clock Gating Control          */
+  __IO uint32_t  SCGCDMA;                           /*!< Micro Direct Memory Access Sleep Mode Clock Gating Control            */
+  __I  uint32_t  RESERVED31;
+  __IO uint32_t  SCGCHIB;                           /*!< Hibernation Sleep Mode Clock Gating Control                           */
+  __IO uint32_t  SCGCUART;                          /*!< Universal Asynchronous Receiver/Transmitter Sleep Mode Clock
+                                                         Gating Control                                                        */
+  __IO uint32_t  SCGCSSI;                           /*!< Synchronous Serial Interface Sleep Mode Clock Gating Control          */
+  __IO uint32_t  SCGCI2C;                           /*!< Inter-Integrated Circuit Sleep Mode Clock Gating Control              */
+  __I  uint32_t  RESERVED32;
+  __IO uint32_t  SCGCUSB;                           /*!< Universal Serial Bus Sleep Mode Clock Gating Control                  */
+  __I  uint32_t  RESERVED33[2];
+  __IO uint32_t  SCGCCAN;                           /*!< Controller Area Network Sleep Mode Clock Gating Control               */
+  __IO uint32_t  SCGCADC;                           /*!< Analog-to-Digital Converter Sleep Mode Clock Gating Control           */
+  __IO uint32_t  SCGCACMP;                          /*!< Analog Comparator Sleep Mode Clock Gating Control                     */
+  __IO uint32_t  SCGCPWM;                           /*!< Pulse Width Modulator Sleep Mode Clock Gating Control                 */
+  __IO uint32_t  SCGCQEI;                           /*!< Quadrature Encoder Interface Sleep Mode Clock Gating Control          */
+  __I  uint32_t  RESERVED34[4];
+  __IO uint32_t  SCGCEEPROM;                        /*!< EEPROM Sleep Mode Clock Gating Control                                */
+  __IO uint32_t  SCGCWTIMER;                        /*!< 32/64-Bit Wide General-Purpose Timer Sleep Mode Clock Gating
+                                                         Control                                                               */
+  __I  uint32_t  RESERVED35[40];
+  __IO uint32_t  DCGCWD;                            /*!< Watchdog Timer Deep-Sleep Mode Clock Gating Control                   */
+  __IO uint32_t  DCGCTIMER;                         /*!< 16/32-Bit General-Purpose Timer Deep-Sleep Mode Clock Gating
+                                                         Control                                                               */
+  __IO uint32_t  DCGCGPIO;                          /*!< General-Purpose Input/Output Deep-Sleep Mode Clock Gating Control     */
+  __IO uint32_t  DCGCDMA;                           /*!< Micro Direct Memory Access Deep-Sleep Mode Clock Gating Control       */
+  __I  uint32_t  RESERVED36;
+  __IO uint32_t  DCGCHIB;                           /*!< Hibernation Deep-Sleep Mode Clock Gating Control                      */
+  __IO uint32_t  DCGCUART;                          /*!< Universal Asynchronous Receiver/Transmitter Deep-Sleep Mode
+                                                         Clock Gating Control                                                  */
+  __IO uint32_t  DCGCSSI;                           /*!< Synchronous Serial Interface Deep-Sleep Mode Clock Gating Control     */
+  __IO uint32_t  DCGCI2C;                           /*!< Inter-Integrated Circuit Deep-Sleep Mode Clock Gating Control         */
+  __I  uint32_t  RESERVED37;
+  __IO uint32_t  DCGCUSB;                           /*!< Universal Serial Bus Deep-Sleep Mode Clock Gating Control             */
+  __I  uint32_t  RESERVED38[2];
+  __IO uint32_t  DCGCCAN;                           /*!< Controller Area Network Deep-Sleep Mode Clock Gating Control          */
+  __IO uint32_t  DCGCADC;                           /*!< Analog-to-Digital Converter Deep-Sleep Mode Clock Gating Control      */
+  __IO uint32_t  DCGCACMP;                          /*!< Analog Comparator Deep-Sleep Mode Clock Gating Control                */
+  __IO uint32_t  DCGCPWM;                           /*!< Pulse Width Modulator Deep-Sleep Mode Clock Gating Control            */
+  __IO uint32_t  DCGCQEI;                           /*!< Quadrature Encoder Interface Deep-Sleep Mode Clock Gating Control     */
+  __I  uint32_t  RESERVED39[4];
+  __IO uint32_t  DCGCEEPROM;                        /*!< EEPROM Deep-Sleep Mode Clock Gating Control                           */
+  __IO uint32_t  DCGCWTIMER;                        /*!< 32/64-Bit Wide General-Purpose Timer Deep-Sleep Mode Clock Gating
+                                                         Control                                                               */
+  __I  uint32_t  RESERVED40[104];
+  __IO uint32_t  PRWD;                              /*!< Watchdog Timer Peripheral Ready                                       */
+  __IO uint32_t  PRTIMER;                           /*!< 16/32-Bit General-Purpose Timer Peripheral Ready                      */
+  __IO uint32_t  PRGPIO;                            /*!< General-Purpose Input/Output Peripheral Ready                         */
+  __IO uint32_t  PRDMA;                             /*!< Micro Direct Memory Access Peripheral Ready                           */
+  __I  uint32_t  RESERVED41;
+  __IO uint32_t  PRHIB;                             /*!< Hibernation Peripheral Ready                                          */
+  __IO uint32_t  PRUART;                            /*!< Universal Asynchronous Receiver/Transmitter Peripheral Ready          */
+  __IO uint32_t  PRSSI;                             /*!< Synchronous Serial Interface Peripheral Ready                         */
+  __IO uint32_t  PRI2C;                             /*!< Inter-Integrated Circuit Peripheral Ready                             */
+  __I  uint32_t  RESERVED42;
+  __IO uint32_t  PRUSB;                             /*!< Universal Serial Bus Peripheral Ready                                 */
+  __I  uint32_t  RESERVED43[2];
+  __IO uint32_t  PRCAN;                             /*!< Controller Area Network Peripheral Ready                              */
+  __IO uint32_t  PRADC;                             /*!< Analog-to-Digital Converter Peripheral Ready                          */
+  __IO uint32_t  PRACMP;                            /*!< Analog Comparator Peripheral Ready                                    */
+  __IO uint32_t  PRPWM;                             /*!< Pulse Width Modulator Peripheral Ready                                */
+  __IO uint32_t  PRQEI;                             /*!< Quadrature Encoder Interface Peripheral Ready                         */
+  __I  uint32_t  RESERVED44[4];
+  __IO uint32_t  PREEPROM;                          /*!< EEPROM Peripheral Ready                                               */
+  __IO uint32_t  PRWTIMER;                          /*!< 32/64-Bit Wide General-Purpose Timer Peripheral Ready                 */
+} SYSCTL_Type;
+
+
+/* ================================================================================ */
+/* ================                      UDMA                      ================ */
+/* ================================================================================ */
+
+
+/**
+  * @brief Register map for UDMA peripheral (UDMA)
+  */
+
+typedef struct {                                    /*!< UDMA Structure                                                        */
+  __IO uint32_t  STAT;                              /*!< DMA Status                                                            */
+  __O  uint32_t  CFG;                               /*!< DMA Configuration                                                     */
+  __IO uint32_t  CTLBASE;                           /*!< DMA Channel Control Base Pointer                                      */
+  __IO uint32_t  ALTBASE;                           /*!< DMA Alternate Channel Control Base Pointer                            */
+  __IO uint32_t  WAITSTAT;                          /*!< DMA Channel Wait-on-Request Status                                    */
+  __O  uint32_t  SWREQ;                             /*!< DMA Channel Software Request                                          */
+  __IO uint32_t  USEBURSTSET;                       /*!< DMA Channel Useburst Set                                              */
+  __O  uint32_t  USEBURSTCLR;                       /*!< DMA Channel Useburst Clear                                            */
+  __IO uint32_t  REQMASKSET;                        /*!< DMA Channel Request Mask Set                                          */
+  __O  uint32_t  REQMASKCLR;                        /*!< DMA Channel Request Mask Clear                                        */
+  __IO uint32_t  ENASET;                            /*!< DMA Channel Enable Set                                                */
+  __O  uint32_t  ENACLR;                            /*!< DMA Channel Enable Clear                                              */
+  __IO uint32_t  ALTSET;                            /*!< DMA Channel Primary Alternate Set                                     */
+  __O  uint32_t  ALTCLR;                            /*!< DMA Channel Primary Alternate Clear                                   */
+  __IO uint32_t  PRIOSET;                           /*!< DMA Channel Priority Set                                              */
+  __O  uint32_t  PRIOCLR;                           /*!< DMA Channel Priority Clear                                            */
+  __I  uint32_t  RESERVED0[3];
+  __IO uint32_t  ERRCLR;                            /*!< DMA Bus Error Clear                                                   */
+  __I  uint32_t  RESERVED1[300];
+  __IO uint32_t  CHASGN;                            /*!< DMA Channel Assignment                                                */
+  __IO uint32_t  CHIS;                              /*!< DMA Channel Interrupt Status                                          */
+  __I  uint32_t  RESERVED2[2];
+  __IO uint32_t  CHMAP0;                            /*!< DMA Channel Map Select 0                                              */
+  __IO uint32_t  CHMAP1;                            /*!< DMA Channel Map Select 1                                              */
+  __IO uint32_t  CHMAP2;                            /*!< DMA Channel Map Select 2                                              */
+  __IO uint32_t  CHMAP3;                            /*!< DMA Channel Map Select 3                                              */
+} UDMA_Type;
+
+
+/* --------------------  End of section using anonymous unions  ------------------- */
+#if defined(__CC_ARM)
+  #pragma pop
+#elif defined(__ICCARM__)
+  /* leave anonymous unions enabled */
+#elif defined(__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined(__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined(__TASKING__)
+  #pragma warning restore
+#else
+  #warning Not supported compiler type
+#endif
+
+
+
+
+/* ================================================================================ */
+/* ================              Peripheral memory map             ================ */
+/* ================================================================================ */
+
+#define WATCHDOG0_BASE                  0x40000000UL
+#define WATCHDOG1_BASE                  0x40001000UL
+#define GPIOA_BASE                      0x40004000UL
+#define GPIOB_BASE                      0x40005000UL
+#define GPIOC_BASE                      0x40006000UL
+#define GPIOD_BASE                      0x40007000UL
+#define SSI0_BASE                       0x40008000UL
+#define SSI1_BASE                       0x40009000UL
+#define SSI2_BASE                       0x4000A000UL
+#define SSI3_BASE                       0x4000B000UL
+#define UART0_BASE                      0x4000C000UL
+#define UART1_BASE                      0x4000D000UL
+#define UART2_BASE                      0x4000E000UL
+#define UART3_BASE                      0x4000F000UL
+#define UART4_BASE                      0x40010000UL
+#define UART5_BASE                      0x40011000UL
+#define UART6_BASE                      0x40012000UL
+#define UART7_BASE                      0x40013000UL
+#define I2C0_BASE                       0x40020000UL
+#define I2C1_BASE                       0x40021000UL
+#define I2C2_BASE                       0x40022000UL
+#define I2C3_BASE                       0x40023000UL
+#define GPIOE_BASE                      0x40024000UL
+#define GPIOF_BASE                      0x40025000UL
+#define PWM0_BASE                       0x40028000UL
+#define PWM1_BASE                       0x40029000UL
+#define QEI0_BASE                       0x4002C000UL
+#define QEI1_BASE                       0x4002D000UL
+#define TIMER0_BASE                     0x40030000UL
+#define TIMER1_BASE                     0x40031000UL
+#define TIMER2_BASE                     0x40032000UL
+#define TIMER3_BASE                     0x40033000UL
+#define TIMER4_BASE                     0x40034000UL
+#define TIMER5_BASE                     0x40035000UL
+#define WTIMER0_BASE                    0x40036000UL
+#define WTIMER1_BASE                    0x40037000UL
+#define ADC0_BASE                       0x40038000UL
+#define ADC1_BASE                       0x40039000UL
+#define COMP_BASE                       0x4003C000UL
+#define CAN0_BASE                       0x40040000UL
+#define CAN1_BASE                       0x40041000UL
+#define WTIMER2_BASE                    0x4004C000UL
+#define WTIMER3_BASE                    0x4004D000UL
+#define WTIMER4_BASE                    0x4004E000UL
+#define WTIMER5_BASE                    0x4004F000UL
+#define USB0_BASE                       0x40050000UL
+#define GPIOA_AHB_BASE                  0x40058000UL
+#define GPIOB_AHB_BASE                  0x40059000UL
+#define GPIOC_AHB_BASE                  0x4005A000UL
+#define GPIOD_AHB_BASE                  0x4005B000UL
+#define GPIOE_AHB_BASE                  0x4005C000UL
+#define GPIOF_AHB_BASE                  0x4005D000UL
+#define EEPROM_BASE                     0x400AF000UL
+#define SYSEXC_BASE                     0x400F9000UL
+#define HIB_BASE                        0x400FC000UL
+#define FLASH_CTRL_BASE                 0x400FD000UL
+#define SYSCTL_BASE                     0x400FE000UL
+#define UDMA_BASE                       0x400FF000UL
+
+
+/* ================================================================================ */
+/* ================             Peripheral declaration             ================ */
+/* ================================================================================ */
+
+#define WATCHDOG0                       ((WATCHDOG0_Type          *) WATCHDOG0_BASE)
+#define WATCHDOG1                       ((WATCHDOG0_Type          *) WATCHDOG1_BASE)
+#define GPIOA                           ((GPIOA_Type              *) GPIOA_BASE)
+#define GPIOB                           ((GPIOA_Type              *) GPIOB_BASE)
+#define GPIOC                           ((GPIOA_Type              *) GPIOC_BASE)
+#define GPIOD                           ((GPIOA_Type              *) GPIOD_BASE)
+#define SSI0                            ((SSI0_Type               *) SSI0_BASE)
+#define SSI1                            ((SSI0_Type               *) SSI1_BASE)
+#define SSI2                            ((SSI0_Type               *) SSI2_BASE)
+#define SSI3                            ((SSI0_Type               *) SSI3_BASE)
+#define UART0                           ((UART0_Type              *) UART0_BASE)
+#define UART1                           ((UART0_Type              *) UART1_BASE)
+#define UART2                           ((UART0_Type              *) UART2_BASE)
+#define UART3                           ((UART0_Type              *) UART3_BASE)
+#define UART4                           ((UART0_Type              *) UART4_BASE)
+#define UART5                           ((UART0_Type              *) UART5_BASE)
+#define UART6                           ((UART0_Type              *) UART6_BASE)
+#define UART7                           ((UART0_Type              *) UART7_BASE)
+#define I2C0                            ((I2C0_Type               *) I2C0_BASE)
+#define I2C1                            ((I2C0_Type               *) I2C1_BASE)
+#define I2C2                            ((I2C0_Type               *) I2C2_BASE)
+#define I2C3                            ((I2C0_Type               *) I2C3_BASE)
+#define GPIOE                           ((GPIOA_Type              *) GPIOE_BASE)
+#define GPIOF                           ((GPIOA_Type              *) GPIOF_BASE)
+#define PWM0                            ((PWM0_Type               *) PWM0_BASE)
+#define PWM1                            ((PWM0_Type               *) PWM1_BASE)
+#define QEI0                            ((QEI0_Type               *) QEI0_BASE)
+#define QEI1                            ((QEI0_Type               *) QEI1_BASE)
+#define TIMER0                          ((TIMER0_Type             *) TIMER0_BASE)
+#define TIMER1                          ((TIMER0_Type             *) TIMER1_BASE)
+#define TIMER2                          ((TIMER0_Type             *) TIMER2_BASE)
+#define TIMER3                          ((TIMER0_Type             *) TIMER3_BASE)
+#define TIMER4                          ((TIMER0_Type             *) TIMER4_BASE)
+#define TIMER5                          ((TIMER0_Type             *) TIMER5_BASE)
+#define WTIMER0                         ((WTIMER0_Type            *) WTIMER0_BASE)
+#define WTIMER1                         ((TIMER0_Type             *) WTIMER1_BASE)
+#define ADC0                            ((ADC0_Type               *) ADC0_BASE)
+#define ADC1                            ((ADC0_Type               *) ADC1_BASE)
+#define COMP                            ((COMP_Type               *) COMP_BASE)
+#define CAN0                            ((CAN0_Type               *) CAN0_BASE)
+#define CAN1                            ((CAN0_Type               *) CAN1_BASE)
+#define WTIMER2                         ((TIMER0_Type             *) WTIMER2_BASE)
+#define WTIMER3                         ((TIMER0_Type             *) WTIMER3_BASE)
+#define WTIMER4                         ((TIMER0_Type             *) WTIMER4_BASE)
+#define WTIMER5                         ((TIMER0_Type             *) WTIMER5_BASE)
+#define USB0                            ((USB0_Type               *) USB0_BASE)
+#define GPIOA_AHB                       ((GPIOA_Type              *) GPIOA_AHB_BASE)
+#define GPIOB_AHB                       ((GPIOA_Type              *) GPIOB_AHB_BASE)
+#define GPIOC_AHB                       ((GPIOA_Type              *) GPIOC_AHB_BASE)
+#define GPIOD_AHB                       ((GPIOA_Type              *) GPIOD_AHB_BASE)
+#define GPIOE_AHB                       ((GPIOA_Type              *) GPIOE_AHB_BASE)
+#define GPIOF_AHB                       ((GPIOA_Type              *) GPIOF_AHB_BASE)
+#define EEPROM                          ((EEPROM_Type             *) EEPROM_BASE)
+#define SYSEXC                          ((SYSEXC_Type             *) SYSEXC_BASE)
+#define HIB                             ((HIB_Type                *) HIB_BASE)
+#define FLASH_CTRL                      ((FLASH_CTRL_Type         *) FLASH_CTRL_BASE)
+#define SYSCTL                          ((SYSCTL_Type             *) SYSCTL_BASE)
+#define UDMA                            ((UDMA_Type               *) UDMA_BASE)
+
+
+/** @} */ /* End of group Device_Peripheral_Registers */
+/** @} */ /* End of group TM4C123GH6PM */
+/** @} */ /* End of group Texas Instruments */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  /* TM4C123GH6PM_H */
+

--- a/cpu/tm4c123/lpm_arch.c
+++ b/cpu/tm4c123/lpm_arch.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_tm4c123
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the kernels power management interface
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "arch/lpm_arch.h"
+
+void lpm_arch_init(void)
+{
+    /* TODO */
+}
+
+enum lpm_mode lpm_arch_set(enum lpm_mode target)
+{
+    /* TODO */
+    return 0;
+}
+
+enum lpm_mode lpm_arch_get(void)
+{
+    /* TODO */
+    return 0;
+}
+
+void lpm_arch_awake(void)
+{
+    /* TODO */
+}
+
+void lpm_arch_begin_awake(void)
+{
+    /* TODO */
+}
+
+void lpm_arch_end_awake(void)
+{
+    /* TODO */
+}

--- a/cpu/tm4c123/periph/Makefile
+++ b/cpu/tm4c123/periph/Makefile
@@ -1,0 +1,3 @@
+MODULE = periph
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/tm4c123/periph/timer.c
+++ b/cpu/tm4c123/periph/timer.c
@@ -1,0 +1,355 @@
+/*
+ * Copyright (C) 2014 volatiles UG (haftungsbeschränkt)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_tm4c123
+ * @{
+ *
+ * @file
+ * @brief       Low-level timer driver implementation, uses full-with (32 bit) timers
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@volatiles.de>
+ *
+ * @}
+ */
+
+#include <stdlib.h>
+
+#include "board.h"
+#include "sched.h"
+#include "thread.h"
+#include "periph_conf.h"
+#include "periph/timer.h"
+#include "hwtimer_cpu.h"
+
+#include "board.h"
+
+#include "driverlib/timer.h"
+#include "driverlib/rom.h"
+#include "driverlib/sysctl.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+/** Unified IRQ handler for all timers */
+static inline void irq_handler(tim_t timer, TIMER0_Type *dev);
+
+/** Type for timer state */
+typedef struct {
+    void (*cb)(int);
+} timer_conf_t;
+
+/** Timer state memory */
+timer_conf_t config[TIMER_NUMOF];
+
+static inline int get_timer_base(tim_t dev) {
+    switch(dev) {
+#if TIMER_0_EN
+        case TIMER_0:
+        return TIMER0_BASE;
+#endif
+#if TIMER_1_EN
+        case TIMER_1:
+        return TIMER1_BASE;
+#endif
+#if TIMER_2_EN
+        case TIMER_2:
+        return TIMER2_BASE;
+#endif
+#if TIMER_3_EN
+        case TIMER_3:
+        return TIMER3_BASE;
+#endif
+#if TIMER_4_EN
+        case TIMER_4:
+        return TIMER4_BASE;
+#endif
+#if TIMER_5_EN
+        case TIMER_5:
+        return TIMER5_BASE;
+#endif
+        default:
+        return -1;
+    }
+}
+
+static inline int get_timer_num(tim_t dev) {
+    switch(dev) {
+#if TIMER_0_EN
+        case TIMER_0:
+        return 0;
+#endif
+#if TIMER_1_EN
+        case TIMER_1:
+        return 1;
+#endif
+#if TIMER_2_EN
+        case TIMER_2:
+        return 2;
+#endif
+#if TIMER_3_EN
+        case TIMER_3:
+        return 3;
+#endif
+#if TIMER_4_EN
+        case TIMER_4:
+        return 4;
+#endif
+#if TIMER_5_EN
+        case TIMER_5:
+        return 5;
+#endif
+        default:
+        return -1;
+    }
+}
+
+static inline IRQn_Type get_timer_irq(tim_t dev) {
+    switch(dev) {
+#if TIMER_0_EN
+        case TIMER_0:
+        return TIMER0A_IRQn;
+#endif
+#if TIMER_1_EN
+        case TIMER_1:
+        return TIMER1A_IRQn;
+#endif
+#if TIMER_2_EN
+        case TIMER_2:
+        return TIMER2A_IRQn;
+#endif
+#if TIMER_3_EN
+        case TIMER_3:
+        return TIMER3A_IRQn;
+#endif
+#if TIMER_4_EN
+        case TIMER_4:
+        return TIMER4A_IRQn;
+#endif
+#if TIMER_5_EN
+        case TIMER_5:
+        return TIMER5A_IRQn;
+#endif
+        default:
+        return -1;
+    }
+}
+
+/**
+ * @brief Initialize the given timer
+ *
+ * Each timer device is running with the given speed. Each can contain one or more channels
+ * as defined in periph_conf.h. The timer is configured in up-counting mode and will count
+ * until TIMER_x_MAX_VALUE as defined in used board's periph_conf.h until overflowing.
+ *
+ * The timer will be started automatically after initialization with interrupts enabled.
+ *
+ * @param[in] dev           the timer to initialize
+ * @param[in] ticks_per_us  the timers speed in ticks per us
+ * @param[in] callback      this callback is called in interrupt context, the emitting channel is
+ *                          passed as argument
+ *
+ * @return                  returns 0 on success, -1 if speed not applicable of unknown device given
+ */
+int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int)) {
+    DEBUG("timer_init(%d)\n", dev);
+    DEBUG("Running at %d Hz\n", ROM_SysCtlClockGet());
+
+    config[get_timer_num(dev)].cb = callback;
+
+    uint32_t timer = get_timer_base(dev);
+
+    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_TIMER0 + get_timer_num(dev));
+    ROM_TimerConfigure(timer, TIMER_CFG_PERIODIC_UP);
+    ROM_TimerLoadSet(timer, TIMER_A, HWTIMER_MAXTICKS);
+
+    NVIC_EnableIRQ(get_timer_irq(dev));
+
+    // enable timeout interrupt, just because
+    ROM_TimerIntDisable(get_timer_base(dev), TIMER_TIMA_TIMEOUT);
+
+    timer_start(dev);
+
+    return 0;
+}
+
+/**
+ * @brief Set a given timer channel for the given timer device. The callback given during
+ * initialization is called when timeout ticks have passed after calling this function
+ *
+ * @param[in] dev           the timer device to set
+ * @param[in] channel       the channel to set
+ * @param[in] timeout       timeout in ticks after that the registered callback is executed
+ *
+ * @return                  1 on success, -1 on error
+ */
+int timer_set(tim_t dev, int channel, unsigned int timeout) {
+    DEBUG("timer_set(%d, %d)\n", dev, timeout);
+
+    return timer_set_absolute(dev, channel, timeout + timer_read(dev));
+}
+
+/**
+ * @brief Set an absolute timeout value for the given channel of the given timer device
+ *
+ * @param[in] dev           the timer device to set
+ * @param[in] channel       the channel to set
+ * @param[in] value         the absolute compare value when the callback will be triggered
+ *
+ * @return                  1 on success, -1 on error
+ */
+int timer_set_absolute(tim_t dev, int channel, unsigned int value) {
+    DEBUG("timer_set_absolute(%d, %u)\n", dev, value);
+
+    ROM_TimerMatchSet(get_timer_base(dev), TIMER_A, value);
+
+    timer_irq_enable(dev);
+
+    return 1;
+}
+
+/**
+ * @brief Clear the given channel of the given timer device
+ *
+ * @param[in] dev           the timer device to clear
+ * @param[in] channel       the channel on the given device to clear
+ *
+ * @return                  1 on success, -1 on error
+ */
+int timer_clear(tim_t dev, int channel) {
+    DEBUG("TODO: timer_clear(%d, %d)\n", dev, channel);
+
+    // since we don't have channels in 32bit mode, just disable the interrupt
+
+    // timer_irq_disable(dev);
+
+    return 1;
+}
+
+/**
+ * @brief Read the current value of the given timer device
+ *
+ * @param[in] dev           the timer to read the current value from
+ *
+ * @return                  the timers current value
+ */
+unsigned int timer_read(tim_t dev) {
+    uint32_t value = ROM_TimerValueGet(get_timer_base(dev), TIMER_A);
+
+    DEBUG("timer_read(%d) = %u\n", dev, value);
+    return value;
+}
+
+/**
+ * @brief Start the given timer. This function is only needed if the timer was stopped manually before
+ *
+ * @param[in] dev           the timer device to stop
+ */
+void timer_start(tim_t dev) {
+    DEBUG("%s(%d)\n", __FUNCTION__, dev);
+    ROM_TimerEnable(get_timer_base(dev), TIMER_A);
+}
+
+/**
+ * @brief Stop the given timer - this will effect all of the timer's channels
+ *
+ * @param[in] dev           the timer to stop
+ */
+void timer_stop(tim_t dev) {
+    DEBUG("%s(%d)\n", __FUNCTION__, dev);
+    ROM_TimerDisable(get_timer_base(dev), TIMER_A);
+}
+
+/**
+ * @brief Enable the interrupts for the given timer
+ *
+ * @param[in] dev           timer to enable interrupts for
+ */
+void timer_irq_enable(tim_t dev) {
+    DEBUG("%s(%d)\n", __FUNCTION__, dev);
+    ROM_TimerIntEnable(get_timer_base(dev), TIMER_TIMA_MATCH);
+}
+
+/**
+ * @brief Disable interrupts for the given timer
+ *
+ * @param[in] dev           the timer to disable interrupts for
+ */
+void timer_irq_disable(tim_t dev) {
+    DEBUG("%s(%d)\n", __FUNCTION__, dev);
+    ROM_TimerIntDisable(get_timer_base(dev), TIMER_TIMA_MATCH);
+}
+
+/**
+ * @brief Reset the up-counting value to zero for the given timer
+ *
+ * Note that this function effects all currently set channels and it can lead to non-deterministic timeouts
+ * if any channel is active when this function is called.
+ *
+ * @param[in] dev           the timer to reset
+ */
+void timer_reset(tim_t dev) {
+    DEBUG("%s(%d)\n", __FUNCTION__, dev);
+    ((TIMER0_Type *) get_timer_base(dev))->TAV = 0;
+}
+
+#if TIMER_0_EN
+void TIMER_0_ISR(void)
+{
+    irq_handler(TIMER_0, TIMER_0_DEV);
+}
+#endif
+#if TIMER_1_EN
+__attribute__ ((naked)) void TIMER_1_ISR(void)
+{
+    irq_handler(TIMER_1, TIMER_1_DEV);
+}
+#endif
+#if TIMER_2_EN
+__attribute__ ((naked)) void TIMER_2_ISR(void)
+{
+    irq_handler(TIMER_2, TIMER_2_DEV);
+}
+#endif
+#if TIMER_3_EN
+__attribute__ ((naked)) void TIMER_3_ISR(void)
+{
+    irq_handler(TIMER_3, TIMER_3_DEV);
+}
+#endif
+#if TIMER_4_EN
+__attribute__ ((naked)) void TIMER_4_ISR(void)
+{
+    irq_handler(TIMER_4, TIMER_4_DEV);
+}
+#endif
+#if TIMER_5_EN
+__attribute__ ((naked)) void TIMER_5_ISR(void)
+{
+    irq_handler(TIMER_5, TIMER_5_DEV);
+}
+#endif
+
+static inline void irq_handler(tim_t timer, TIMER0_Type *dev)
+{
+    if (ROM_TimerIntStatus((uint32_t) dev, 0) & TIMER_TIMA_TIMEOUT) {
+        BLUE_LED_TOGGLE;
+        ROM_TimerIntClear ((uint32_t) dev, TIMER_TIMA_TIMEOUT);
+    }
+
+    if (ROM_TimerIntStatus((uint32_t) dev, 0) & TIMER_TIMA_MATCH) {
+        ROM_TimerIntClear ((uint32_t) dev, TIMER_TIMA_MATCH);
+        timer_irq_disable(timer);
+
+        config[timer].cb(get_timer_num(timer));
+    }
+
+    if (sched_context_switch_request) {
+        thread_yield();
+    }
+}

--- a/cpu/tm4c123/periph/uart.c
+++ b/cpu/tm4c123/periph/uart.c
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014 volatiles UG (haftungsbeschränkt)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_tm4c123
+ * @{
+ *
+ * @file
+ * @brief       Low-level UART driver implementation
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Fabian Nack <nack@inf.fu-berlin.de>
+ * @author      Benjamin Valentin <benjamin.valentin@volatiles.de>
+ *
+ * @}
+ */
+
+#include "thread.h"
+#include "sched.h"
+#include "periph_conf.h"
+#include "periph/uart.h"
+
+#include "board.h"
+
+#include "driverlib/rom.h"
+#include "driverlib/sysctl.h"
+#include "driverlib/uart.h"
+
+/* guard file in case no UART device was specified */
+#if UART_NUMOF
+
+static inline int get_uart_base(uart_t uart) {
+    switch(uart) {
+#if UART_0_EN
+        case UART_0:
+        return UART0_BASE;
+#endif
+#if UART_1_EN
+        case UART_1:
+        return UART1_BASE;
+#endif
+        default:
+        return -1;
+    }
+}
+
+static inline int get_uart_num(uart_t uart) {
+    switch(uart) {
+#if UART_0_EN
+        case UART_0:
+        return 0;
+#endif
+#if UART_1_EN
+        case UART_1:
+        return 1;
+#endif
+        default:
+        return -1;
+    }
+}
+
+static inline int get_uart_irq(uart_t uart) {
+    switch(uart) {
+#if UART_0_EN
+        case UART_0:
+        return UART_0_IRQ_CHAN;
+#endif
+#if UART_1_EN
+        case UART_1:
+        return UART_1_IRQ_CHAN;
+#endif
+        default:
+        return -1;
+    }
+}
+
+/**
+ * @brief Each UART device has to store two callbacks.
+ */
+typedef struct {
+    uart_rx_cb_t rx_cb;
+    uart_tx_cb_t tx_cb;
+    void *arg;
+} uart_conf_t;
+
+/**
+ * @brief Unified interrupt handler for all UART devices
+ *
+ * @param uartnum       the number of the UART that triggered the ISR
+ * @param uart          the UART device that triggered the ISR
+ */
+static inline void irq_handler(uint8_t uartnum, void* uart);
+
+/**
+ * @brief Allocate memory to store the callback functions.
+ */
+static uart_conf_t uart_config[UART_NUMOF];
+
+int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, uart_tx_cb_t tx_cb, void *arg)
+{
+    /* do basic initialization */
+    int res = uart_init_blocking(uart, baudrate);
+    if (res < 0) {
+        return res;
+    }
+
+    /* remember callback addresses */
+    uart_config[uart].rx_cb = rx_cb;
+    uart_config[uart].tx_cb = tx_cb;
+    uart_config[uart].arg = arg;
+
+    /* enable receive interrupt */
+    // TODO
+    NVIC_SetPriority(get_uart_irq(uart), UART_IRQ_PRIO);
+    NVIC_EnableIRQ(get_uart_irq(uart));
+    //  UART_0_DEV->CR1 |= USART_CR1_RXNEIE;
+
+    return 0;
+}
+
+int uart_init_blocking(uart_t uart, uint32_t baudrate)
+{
+    /* Enable UART */
+    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_UART0 + get_uart_num(uart));
+
+    /* Use the internal 16MHz oscillator as the UART clock source */
+    ROM_UARTClockSourceSet(get_uart_base(uart), UART_CLOCK_PIOSC);
+
+    /* Configure the UART for 115200, n, 8, 1 */
+    ROM_UARTConfigSetExpClk(get_uart_base(uart), 16000000, baudrate,
+                            (UART_CONFIG_PAR_NONE | UART_CONFIG_STOP_ONE |
+                             UART_CONFIG_WLEN_8));
+
+    /* Enable the UART operation */
+    ROM_UARTEnable(get_uart_base(uart));
+
+    return 0;
+}
+
+void uart_tx_begin(uart_t uart)
+{
+    // TODO
+}
+
+int uart_write(uart_t uart, char data)
+{
+    ROM_UARTCharPutNonBlocking(get_uart_base(uart), data);
+
+    return 0;
+}
+
+int uart_read_blocking(uart_t uart, char *data)
+{
+    *data = ROM_UARTCharGet(get_uart_base(uart));
+
+    return 1;
+}
+
+int uart_write_blocking(uart_t uart, char data)
+{
+    ROM_UARTCharPut(get_uart_base(uart), data);
+
+    return 1;
+}
+
+void uart_poweron(uart_t uart)
+{
+    // TODO
+}
+
+void uart_poweroff(uart_t uart)
+{
+    // TODO
+}
+
+#if UART_0_EN
+__attribute__((naked)) void UART_0_ISR(void)
+{
+    irq_handler(UART_0, NULL);
+}
+#endif
+
+#if UART_1_EN
+__attribute__((naked)) void UART_1_ISR(void)
+{
+    irq_handler(UART_1, NULL);
+}
+#endif
+
+static inline void irq_handler(uint8_t uartnum, void *dev)
+{
+	// TOOD
+/*
+    if (dev->SR & USART_SR_RXNE) {
+        char data = (char)dev->DR;
+        uart_config[uartnum].rx_cb(uart_config[uartnum].arg, data);
+    }
+    else if (dev->SR & USART_SR_TXE) {
+        if (uart_config[uartnum].tx_cb(uart_config[uartnum].arg) == 0) {
+            dev->CR1 &= ~(USART_CR1_TXEIE);
+        }
+    }
+*/
+    if (sched_context_switch_request) {
+        thread_yield();
+    }
+}
+
+#endif /* UART_NUMOF */

--- a/cpu/tm4c123/reboot_arch.c
+++ b/cpu/tm4c123/reboot_arch.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_tm4c123
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the kernels reboot interface
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "arch/reboot_arch.h"
+#include "cpu.h"
+
+
+int reboot_arch(int mode)
+{
+    printf("Going into reboot, mode %i\n", mode);
+
+    NVIC_SystemReset();
+
+    return 0;
+}

--- a/cpu/tm4c123/startup.c
+++ b/cpu/tm4c123/startup.c
@@ -96,10 +96,9 @@ void dummy_handler(void)
 void isr_hard_fault(void)
 {
 	while(1){
-		GREEN_LED_ON;
 		RED_LED_ON;
 		ROM_SysCtlDelay(1000000);
-		GREEN_LED_OFF;
+		RED_LED_OFF;
 		ROM_SysCtlDelay(1000000);
 	}
 }

--- a/cpu/tm4c123/startup.c
+++ b/cpu/tm4c123/startup.c
@@ -1,0 +1,306 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014 volatiles UG (haftungsbeschränkt)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_tm4c123
+ * @{
+ *
+ * @file
+ * @brief       Startup code and interrupt vector definition
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Benjamin Valentin <benjamin.valentin@volatiles.de>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+
+#include "board.h" // for debuging
+#include "driverlib/rom.h"
+
+/**
+ * memory markers as defined in the linker script
+ */
+extern uint32_t _sfixed;
+extern uint32_t _efixed;
+extern uint32_t _etext;
+extern uint32_t _srelocate;
+extern uint32_t _erelocate;
+extern uint32_t _szero;
+extern uint32_t _ezero;
+extern uint32_t _sstack;
+extern uint32_t _estack;
+
+/**
+ * @brief functions for initializing the board, std-lib and kernel
+ */
+extern void board_init(void);
+extern void kernel_init(void);
+extern void __libc_init_array(void);
+
+/**
+ * @brief This function is the entry point after a system reset
+ *
+ * After a system reset, the following steps are necessary and carried out:
+ * 1. load data section from flash to ram
+ * 2. overwrite uninitialized data section (BSS) with zeros
+ * 3. initialize the newlib
+ * 4. initialize the board (sync clock, setup std-IO)
+ * 5. initialize and start RIOTs kernel
+ */
+void reset_handler(void)
+{
+    uint32_t *dst;
+    uint32_t *src = &_etext;
+
+    /* load data section from flash to ram */
+    for (dst = &_srelocate; dst < &_erelocate; ) {
+        *(dst++) = *(src++);
+    }
+
+    /* default bss section to zero */
+    for (dst = &_szero; dst < &_ezero; ) {
+        *(dst++) = 0;
+    }
+
+    /* initialize the board and startup the kernel */
+    board_init();
+    /* initialize std-c library (this should be done after board_init) */
+
+    __libc_init_array();
+    /* startup the kernel */
+
+    kernel_init();
+}
+
+/**
+ * @brief Default handler is called in case no interrupt handler was defined
+ */
+void dummy_handler(void)
+{
+	while(1){
+		GREEN_LED_ON;
+		ROM_SysCtlDelay(5000000);
+		GREEN_LED_OFF;
+		ROM_SysCtlDelay(5000000);
+	}
+}
+
+void isr_hard_fault(void)
+{
+	while(1){
+		GREEN_LED_ON;
+		RED_LED_ON;
+		ROM_SysCtlDelay(1000000);
+		GREEN_LED_OFF;
+		ROM_SysCtlDelay(1000000);
+	}
+}
+
+/* Cortex-M specific interrupt vectors */
+void isr_nmi(void)                   __attribute__ ((weak, alias("dummy_handler")));
+void isr_mem_manage(void)            __attribute__ ((weak, alias("dummy_handler")));
+void isr_bus_fault(void)             __attribute__ ((weak, alias("dummy_handler")));
+void isr_usage_fault(void)           __attribute__ ((weak, alias("dummy_handler")));
+void isr_svc(void)                   __attribute__ ((weak, alias("dummy_handler")));
+void isr_debug_mon(void)             __attribute__ ((weak, alias("dummy_handler")));
+void isr_pendsv(void)                __attribute__ ((weak, alias("dummy_handler")));
+void isr_systick(void)               __attribute__ ((weak, alias("dummy_handler")));
+
+/* TM4C123 specific interrupt vector */
+void isr_uart0(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_uart1(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_tim0a(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_tim0b(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_tim1a(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_tim1b(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_tim2a(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_tim2b(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_tim3a(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_tim3b(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_tim4a(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_tim4b(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_tim5a(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_tim5b(void)                 __attribute__ ((weak, alias("dummy_handler")));
+
+void isr_wtim0a(void)                __attribute__ ((weak, alias("dummy_handler")));
+void isr_wtim0b(void)                __attribute__ ((weak, alias("dummy_handler")));
+void isr_wtim1a(void)                __attribute__ ((weak, alias("dummy_handler")));
+void isr_wtim1b(void)                __attribute__ ((weak, alias("dummy_handler")));
+void isr_wtim2a(void)                __attribute__ ((weak, alias("dummy_handler")));
+void isr_wtim2b(void)                __attribute__ ((weak, alias("dummy_handler")));
+void isr_wtim3a(void)                __attribute__ ((weak, alias("dummy_handler")));
+void isr_wtim3b(void)                __attribute__ ((weak, alias("dummy_handler")));
+void isr_wtim4a(void)                __attribute__ ((weak, alias("dummy_handler")));
+void isr_wtim4b(void)                __attribute__ ((weak, alias("dummy_handler")));
+void isr_wtim5a(void)                __attribute__ ((weak, alias("dummy_handler")));
+void isr_wtim5b(void)                __attribute__ ((weak, alias("dummy_handler")));
+
+/* interrupt vector table */
+__attribute__ ((section(".vectors")))
+const void *interrupt_vector[] = {
+    /* Stack pointer */
+    (void*) (&_estack),                 /* pointer to the top of the empty stack */
+    /* Cortex-M4 handlers */
+    (void*) reset_handler,              /* entry point of the program */
+    (void*) isr_nmi,                    /* non maskable interrupt handler */
+    (void*) isr_hard_fault,             /* if you end up here its not good */
+    (void*) isr_mem_manage,             /* memory controller interrupt */
+    (void*) isr_bus_fault,              /* also not good to end up here */
+    (void*) isr_usage_fault,            /* autsch */
+    (void*) (0UL),                      /* Reserved */
+    (void*) (0UL),                      /* Reserved */
+    (void*) (0UL),                      /* Reserved */
+    (void*) (0UL),                      /* Reserved */
+    (void*) isr_svc,                    /* system call interrupt */
+    (void*) isr_debug_mon,              /* debug interrupt */
+    (void*) (0UL),                      /* Reserved */
+    (void*) isr_pendsv,                 /* pendSV interrupt, used for task switching in RIOT */
+    (void*) isr_systick,                /* SysTick interrupt, not used in RIOT */
+    /* tiva specific peripheral handlers */
+    dummy_handler,                      // GPIO Port A
+    dummy_handler,                      // GPIO Port B
+    dummy_handler,                      // GPIO Port C
+    dummy_handler,                      // GPIO Port D
+    dummy_handler,                      // GPIO Port E
+    isr_uart0,                          // UART0 Rx and Tx
+    isr_uart1,                          // UART1 Rx and Tx
+    dummy_handler,                      // SSI0 Rx and Tx
+    dummy_handler,                      // I2C0 Master and Slave
+    dummy_handler,                      // PWM Fault
+    dummy_handler,                      // PWM Generator 0
+    dummy_handler,                      // PWM Generator 1
+    dummy_handler,                      // PWM Generator 2
+    dummy_handler,                      // Quadrature Encoder 0
+    dummy_handler,                      // ADC Sequence 0
+    dummy_handler,                      // ADC Sequence 1
+    dummy_handler,                      // ADC Sequence 2
+    dummy_handler,                      // ADC Sequence 3
+    dummy_handler,                      // Watchdog timer
+    isr_tim0a,                          // Timer 0 subtimer A
+    isr_tim0b,                          // Timer 0 subtimer B
+    isr_tim1a,                          // Timer 1 subtimer A
+    isr_tim1b,                          // Timer 1 subtimer B
+    isr_tim2a,                          // Timer 2 subtimer A
+    isr_tim2b,                          // Timer 2 subtimer B
+    dummy_handler,                      // Analog Comparator 0
+    dummy_handler,                      // Analog Comparator 1
+    dummy_handler,                      // Analog Comparator 2
+    dummy_handler,                      // System Control (PLL, OSC, BO)
+    dummy_handler,                      // FLASH Control
+    dummy_handler,                      // GPIO Port F
+    dummy_handler,                      // GPIO Port G
+    dummy_handler,                      // GPIO Port H
+    dummy_handler,                      // UART2 Rx and Tx
+    dummy_handler,                      // SSI1 Rx and Tx
+    isr_tim3a,                          // Timer 3 subtimer A
+    isr_tim3b,                          // Timer 3 subtimer B
+    dummy_handler,                      // I2C1 Master and Slave
+    dummy_handler,                      // Quadrature Encoder 1
+    dummy_handler,                      // CAN0
+    dummy_handler,                      // CAN1
+    dummy_handler,                      // CAN2
+    0,                                  // Reserved
+    dummy_handler,                      // Hibernate
+    dummy_handler,                      // USB0
+    dummy_handler,                      // PWM Generator 3
+    dummy_handler,                      // uDMA Software Transfer
+    dummy_handler,                      // uDMA Error
+    dummy_handler,                      // ADC1 Sequence 0
+    dummy_handler,                      // ADC1 Sequence 1
+    dummy_handler,                      // ADC1 Sequence 2
+    dummy_handler,                      // ADC1 Sequence 3
+    0,                                  // Reserved
+    0,                                  // Reserved
+    dummy_handler,                      // GPIO Port J
+    dummy_handler,                      // GPIO Port K
+    dummy_handler,                      // GPIO Port L
+    dummy_handler,                      // SSI2 Rx and Tx
+    dummy_handler,                      // SSI3 Rx and Tx
+    dummy_handler,                      // UART3 Rx and Tx
+    dummy_handler,                      // UART4 Rx and Tx
+    dummy_handler,                      // UART5 Rx and Tx
+    dummy_handler,                      // UART6 Rx and Tx
+    dummy_handler,                      // UART7 Rx and Tx
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    dummy_handler,                      // I2C2 Master and Slave
+    dummy_handler,                      // I2C3 Master and Slave
+    isr_tim4a,                          // Timer 4 subtimer A
+    isr_tim4b,                          // Timer 4 subtimer B
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    0,                                  // Reserved
+    isr_tim5a,                          // Timer 5 subtimer A
+    isr_tim5b,                          // Timer 5 subtimer B
+    isr_wtim0a,                         // Wide Timer 0 subtimer A
+    isr_wtim0b,                         // Wide Timer 0 subtimer B
+    isr_wtim1a,                         // Wide Timer 1 subtimer A
+    isr_wtim1b,                         // Wide Timer 1 subtimer B
+    isr_wtim2a,                         // Wide Timer 2 subtimer A
+    isr_wtim2b,                         // Wide Timer 2 subtimer B
+    isr_wtim3a,                         // Wide Timer 3 subtimer A
+    isr_wtim3b,                         // Wide Timer 3 subtimer B
+    isr_wtim4a,                         // Wide Timer 4 subtimer A
+    isr_wtim4b,                         // Wide Timer 4 subtimer B
+    isr_wtim5a,                         // Wide Timer 5 subtimer A
+    isr_wtim5b,                         // Wide Timer 5 subtimer B
+    dummy_handler,                      // FPU
+    0,                                  // Reserved
+    0,                                  // Reserved
+    dummy_handler,                      // I2C4 Master and Slave
+    dummy_handler,                      // I2C5 Master and Slave
+    dummy_handler,                      // GPIO Port M
+    dummy_handler,                      // GPIO Port N
+    dummy_handler,                      // Quadrature Encoder 2
+    0,                                  // Reserved
+    0,                                  // Reserved
+    dummy_handler,                      // GPIO Port P (Summary or P0)
+    dummy_handler,                      // GPIO Port P1
+    dummy_handler,                      // GPIO Port P2
+    dummy_handler,                      // GPIO Port P3
+    dummy_handler,                      // GPIO Port P4
+    dummy_handler,                      // GPIO Port P5
+    dummy_handler,                      // GPIO Port P6
+    dummy_handler,                      // GPIO Port P7
+    dummy_handler,                      // GPIO Port Q (Summary or Q0)
+    dummy_handler,                      // GPIO Port Q1
+    dummy_handler,                      // GPIO Port Q2
+    dummy_handler,                      // GPIO Port Q3
+    dummy_handler,                      // GPIO Port Q4
+    dummy_handler,                      // GPIO Port Q5
+    dummy_handler,                      // GPIO Port Q6
+    dummy_handler,                      // GPIO Port Q7
+    dummy_handler,                      // GPIO Port R
+    dummy_handler,                      // GPIO Port S
+    dummy_handler,                      // PWM 1 Generator 0
+    dummy_handler,                      // PWM 1 Generator 1
+    dummy_handler,                      // PWM 1 Generator 2
+    dummy_handler,                      // PWM 1 Generator 3
+    dummy_handler                       // PWM 1 Fault
+};

--- a/cpu/tm4c123/syscalls.c
+++ b/cpu/tm4c123/syscalls.c
@@ -1,0 +1,279 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_tm4c123
+ * @{
+ *
+ * @file
+ * @brief       NewLib system call implementations
+ *              based on STM32F4
+ *
+ * @author      Michael Baar <michael.baar@fu-berlin.de>
+ * @author      Stefan Pfeiffer <pfeiffer@inf.fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Benjamin Valentin <benjamin.valentin@volatiles.de>
+ *
+ * @}
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/unistd.h>
+#include <stdint.h>
+
+#include "board.h"
+#include "thread.h"
+#include "kernel.h"
+#include "irq.h"
+#include "periph/uart.h"
+
+/**
+ * manage the heap
+ */
+extern char _sheap;                 /* start of the heap */
+extern char _eheap;                 /* end of the heap */
+caddr_t heap_top = (caddr_t)&_sheap + 4;
+
+/**
+ * @brief Initialize NewLib, called by __libc_init_array() from the startup script
+ */
+void _init(void)
+{
+    uart_init_blocking(STDIO, STDIO_BAUDRATE);
+}
+
+/**
+ * @brief Free resources on NewLib de-initialization, not used for RIOT
+ */
+void _fini(void)
+{
+    /* nothing to do here */
+}
+
+/**
+ * @brief Exit a program without cleaning up files
+ *
+ * If your system doesn't provide this, it is best to avoid linking with subroutines that
+ * require it (exit, system).
+ *
+ * @param n     the exit code, 0 for all OK, >0 for not OK
+ */
+void _exit(int n)
+{
+    printf("#! exit %i: resetting\n", n);
+    NVIC_SystemReset();
+    while(1);
+}
+
+/**
+ * @brief Allocate memory from the heap.
+ *
+ * The current heap implementation is very rudimentary, it is only able to allocate
+ * memory. But it does not
+ * - have any means to free memory again
+ *
+ * @return [description]
+ */
+caddr_t _sbrk_r(struct _reent *r, ptrdiff_t incr)
+{
+    unsigned int state = disableIRQ();
+    caddr_t res = heap_top;
+
+    if (((incr > 0) && ((heap_top + incr > &_eheap) || (heap_top + incr < res))) ||
+        ((incr < 0) && ((heap_top + incr < &_sheap) || (heap_top + incr > res)))) {
+        r->_errno = ENOMEM;
+        res = (void *) -1;
+    } else {
+        heap_top += incr;
+    }
+
+    restoreIRQ(state);
+    return res;
+}
+
+/**
+ * @brief Get the process-ID of the current thread
+ *
+ * @return      the process ID of the current thread
+ */
+int _getpid(void)
+{
+    return sched_active_pid;
+}
+
+/**
+ * @brief Send a signal to a given thread
+ *
+ * @param r     TODO
+ * @param pid   TODO
+ * @param sig   TODO
+ *
+ * @return      TODO
+ */
+int _kill_r(struct _reent *r, int pid, int sig)
+{
+    r->_errno = ESRCH;                      /* not implemented yet */
+    return -1;
+}
+
+/**
+ * @brief Open a file
+ *
+ * @param r     TODO
+ * @param name  TODO
+ * @param mode  TODO
+ *
+ * @return      TODO
+ */
+int _open_r(struct _reent *r, const char *name, int mode)
+{
+    r->_errno = ENODEV;                     /* not implemented yet */
+    return -1;
+}
+
+/**
+ * @brief Read from a file
+ *
+ * All input is read from UART_0. The function will block until a byte is actually read.
+ *
+ * Note: the read function does not buffer - data will be lost if the function is not
+ * called fast enough.
+ *
+ * TODO: implement more sophisticated read call.
+ *
+ * @param r     TODO
+ * @param fd    TODO
+ * @param buffer TODO
+ * @param int   TODO
+ *
+ * @return      TODO
+ */
+int _read_r(struct _reent *r, int fd, void *buffer, unsigned int count)
+{
+    char c;
+    char *buff = (char*)buffer;
+    uart_read_blocking(STDIO, &c);
+    buff[0] = c;
+    return 1;
+}
+
+/**
+ * @brief Write characters to a file
+ *
+ * All output is currently directed to UART_0, independent of the given file descriptor.
+ * The write call will further block until the byte is actually written to the UART.
+ *
+ * TODO: implement more sophisticated write call.
+ *
+ * @param r     TODO
+ * @param fd    TODO
+ * @param data  TODO
+ * @param int   TODO
+ *
+ * @return      TODO
+ */
+int _write_r(struct _reent *r, int fd, const void *data, unsigned int count)
+{
+    char *c = (char*)data;
+    for (int i = 0; i < count; i++) {
+        uart_write_blocking(STDIO, c[i]);
+    }
+    return count;
+}
+
+/**
+ * @brief Close a file
+ *
+ * @param r     TODO
+ * @param fd    TODO
+ *
+ * @return      TODO
+ */
+int _close_r(struct _reent *r, int fd)
+{
+    r->_errno = ENODEV;                     /* not implemented yet */
+    return -1;
+}
+
+/**
+ * @brief Set position in a file
+ *
+ * @param r     TODO
+ * @param fd    TODO
+ * @param pos   TODO
+ * @param dir   TODO
+ *
+ * @return      TODO
+ */
+_off_t _lseek_r(struct _reent *r, int fd, _off_t pos, int dir)
+{
+    r->_errno = ENODEV;                     /* not implemented yet */
+    return -1;
+}
+
+/**
+ * @brief Status of an open file
+ *
+ * @param r     TODO
+ * @param fd    TODO
+ * @param stat  TODO
+ *
+ * @return      TODO
+ */
+int _fstat_r(struct _reent *r, int fd, struct stat * st)
+{
+    r->_errno = ENODEV;                     /* not implemented yet */
+    return -1;
+}
+
+/**
+ * @brief Status of a file (by name)
+ *
+ * @param r     TODO
+ * @param name  TODO
+ * @param stat  TODO
+ *
+ * @return      TODO
+ */
+int _stat_r(struct _reent *r, char *name, struct stat *st)
+{
+    r->_errno = ENODEV;                     /* not implemented yet */
+    return -1;
+}
+
+/**
+ * @brief Query whether output stream is a terminal
+ *
+ * @param r     TODO
+ * @param fd    TODO
+ *
+ * @return      TODO
+ */
+int _isatty_r(struct _reent *r, int fd)
+{
+    r->_errno = 0;
+    return -1;
+}
+
+/**
+ * @brief  Remove a file's directory entry
+ *
+ * @param r     TODO
+ * @param path  TODO
+ *
+ * @return      TODO
+ */
+int _unlink_r(struct _reent *r, char* path)
+{
+    r->_errno = ENODEV;                     /* not implemented yet */
+    return -1;
+}

--- a/cpu/tm4c123/tm4c123gh6pm_linkerscript.ld
+++ b/cpu/tm4c123/tm4c123gh6pm_linkerscript.ld
@@ -1,0 +1,144 @@
+/* ----------------------------------------------------------------------------
+ *         SAM Software Package License
+ * ----------------------------------------------------------------------------
+ * Copyright (c) 2012, Atmel Corporation
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following condition is met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the disclaimer below.
+ *
+ * Atmel's name may not be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * DISCLAIMER: THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ----------------------------------------------------------------------------
+ */
+
+OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+SEARCH_DIR(.)
+
+/* Memory Spaces Definitions */
+MEMORY
+{
+    rom (rx)    : ORIGIN = 0x00000000, LENGTH = 0x40000		/* 256K flash */
+    ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 0x8000		/* 32K ram */
+}
+
+/* The stack size used by the application. NOTE: you need to adjust  */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0xa00 ;
+
+/* Section Definitions */
+SECTIONS
+{
+    .text :
+    {
+        . = ALIGN(4);
+        _sfixed = .;
+        KEEP(*(.vectors .vectors.*))
+        *(.text .text.* .gnu.linkonce.t.*)
+        *(.glue_7t) *(.glue_7)
+        *(.rodata .rodata* .gnu.linkonce.r.*)
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+
+        /* Support C constructors, and C destructors in both user code
+           and the C library. This also provides support for C++ code. */
+        . = ALIGN(4);
+        KEEP(*(.init))
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP (*(.preinit_array))
+        __preinit_array_end = .;
+
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        __init_array_end = .;
+
+        . = ALIGN(0x4);
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+
+        . = ALIGN(4);
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        __fini_array_start = .;
+        KEEP (*(.fini_array))
+        KEEP (*(SORT(.fini_array.*)))
+        __fini_array_end = .;
+
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+
+        . = ALIGN(4);
+        _efixed = .;            /* End of text section */
+    } > rom
+
+    /* .ARM.exidx is sorted, so has to go in its own output section.  */
+    PROVIDE_HIDDEN (__exidx_start = .);
+    .ARM.exidx :
+    {
+      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > rom
+    PROVIDE_HIDDEN (__exidx_end = .);
+
+    . = ALIGN(4);
+    _etext = .;
+
+    .relocate : AT (_etext)
+    {
+        . = ALIGN(4);
+        _srelocate = .;
+        *(.ramfunc .ramfunc.*);
+        *(.data .data.*);
+        . = ALIGN(4);
+        _erelocate = .;
+    } > ram
+
+    /* .bss section which is used for uninitialized data */
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        _sbss = . ;
+        _szero = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = . ;
+        _ezero = .;
+    } > ram
+
+    /* stack section */
+    .stack (NOLOAD):
+    {
+        . = ALIGN(8);
+        _sstack = .;
+        . = . + STACK_SIZE;
+        . = ALIGN(8);
+        _estack = .;
+    } > ram
+
+    /* heap section */
+    . = ALIGN(4);
+    _sheap = . ;
+    _eheap = ORIGIN(ram) + LENGTH(ram);
+}

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -31,7 +31,7 @@ extern "C" {
  * @brief Definition of available timers
  *
  * Each timer is based on a hardware timer, which can further have 1 or more channels.
- * To this point 4 timers are possible, might need to be expanded for some cases.
+ * To this point 6 timers are possible, might need to be expanded for some cases.
  */
 typedef enum {
 #if TIMER_0_EN
@@ -45,6 +45,12 @@ typedef enum {
 #endif
 #if TIMER_3_EN
     TIMER_3,                /**< 4th timer */
+#endif
+#if TIMER_4_EN
+    TIMER_4,                /**< 5th timer */
+#endif
+#if TIMER_5_EN
+    TIMER_5,                /**< 6th timer */
 #endif
     TIMER_UNDEFINED         /**< fall-back if no timer is defined */
 } tim_t; /* named tim instead of timer to avoid conflicts with vendor libraries */

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -2,7 +2,7 @@ APPLICATION = thread_cooperation
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_RAM := chronos msb-430 msb-430h mbed_lpc1768 redbee-econotag stm32f0discovery \
-                          pca10000 pca10005 yunjia-nrf51822 spark-core airfy-beacon
+                          pca10000 pca10005 yunjia-nrf51822 spark-core airfy-beacon ek-tm4c123gxl
 
 DISABLE_MODULE += auto_init
 


### PR DESCRIPTION
This adds basic support for the TI TM4C123GH6PM MCU and the TM4C123GLX Launchpad development board based on it.

[TM4C123GH6PM](http://www.ti.com/product/tm4c123gh6pm) is a Cortex-M4F based chip with 32kiB Ram, running at up to 80 MHz.
As a special feature it provides 'ROM Functions', similar to BIOS calls, that are always present on the chip and that can be called using a memory table.

There are 6 32 bit general purpose timers and 6 64 bit general purpose timers.
Timers can be 'split' into two half-with timers (16/32bit). Prescaler is only available in half-with mode when counting down, when counting up it will extend the range by 8 bit.

There is also a currently unused 24 bit SysTick timer (also with no prescaling, only variable interrupt periods within the 24bit range)

I used stm32f4 as a template for this port.

working so far:
 - UART (tx only)
 - timers (32bit timers in full width mode are exported through hwtimer, no prescaler), tests/vtimer_msg crashes after ~53s

Depends on #1709 to run properly