### PR TITLE
c++: tests/unittests: add extern C in header files

### DIFF
--- a/tests/unittests/embunit/embUnit/HelperMacro.h
+++ b/tests/unittests/embunit/embUnit/HelperMacro.h
@@ -35,6 +35,10 @@
 #ifndef __HELPERMACRO_H__
 #define __HELPERMACRO_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define EMB_UNIT_TESTCASE(ca,sup,tdw,run) \
     static const TestCase   ca = new_TestCase(#ca,sup,tdw,run)
 
@@ -55,5 +59,9 @@
 
 #define EMB_UNIT_REPEATEDTEST(repeater,test,tmrp) \
     static const RepeatedTest   repeater = new_RepeatedTest(test,tmrp)
+
+#ifdef  __cplusplus
+}
+#endif
 
 #endif/*__HELPERMACRO_H__*/

--- a/tests/unittests/embunit/embUnit/RepeatedTest.h
+++ b/tests/unittests/embunit/embUnit/RepeatedTest.h
@@ -35,6 +35,10 @@
 #ifndef __REPEATEDTEST_H__
 #define __REPEATEDTEST_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct __RepeatedTest   RepeatedTest;
 typedef struct __RepeatedTest*  RepeatedTestRef;    /*downward compatible*/
 
@@ -52,5 +56,9 @@ extern const TestImplement RepeatedTestImplement;
         (Test*)test,\
         tmrp,\
     }
+
+#ifdef  __cplusplus
+}
+#endif
 
 #endif/*__REPEATEDTEST_H__*/

--- a/tests/unittests/embunit/embUnit/Test.h
+++ b/tests/unittests/embunit/embUnit/Test.h
@@ -35,6 +35,10 @@
 #ifndef __TEST_H__
 #define __TEST_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct __TestResult     TestResult;
 typedef struct __TestResult*    TestResultRef;/*downward compatible*/
 
@@ -61,5 +65,9 @@ struct __Test {
 #define Test_name(s)            ((Test*)s)->isa->name(s)
 #define Test_run(s,r)           ((Test*)s)->isa->run(s,r)
 #define Test_countTestCases(s)  ((Test*)s)->isa->countTestCases(s)
+
+#ifdef  __cplusplus
+}
+#endif
 
 #endif/*__TEST_H__*/

--- a/tests/unittests/embunit/embUnit/TestCaller.h
+++ b/tests/unittests/embunit/embUnit/TestCaller.h
@@ -35,6 +35,10 @@
 #ifndef __TESTCALLER_H__
 #define __TESTCALLER_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct __TestFixture    TestFixture;
 typedef struct __TestFixture*   TestFixtureRef;/*downward compatible*/
 
@@ -68,5 +72,9 @@ extern const TestImplement TestCallerImplement;
         numberOfFixtuers,\
         fixtuers,\
     }
+
+#ifdef  __cplusplus
+}
+#endif
 
 #endif/*__TESTCALLER_H__*/

--- a/tests/unittests/embunit/embUnit/TestCase.h
+++ b/tests/unittests/embunit/embUnit/TestCase.h
@@ -35,6 +35,10 @@
 #ifndef __TESTCASE_H__
 #define __TESTCASE_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct __TestCase   TestCase;
 typedef struct __TestCase*  TestCaseRef;/*compatible embUnit1.0*/
 
@@ -56,5 +60,9 @@ extern const TestImplement TestCaseImplement;
         tearDown,\
         runTest,\
     }
+
+#ifdef  __cplusplus
+}
+#endif
 
 #endif/*__TESTCASE_H__*/

--- a/tests/unittests/embunit/embUnit/TestListener.h
+++ b/tests/unittests/embunit/embUnit/TestListener.h
@@ -35,6 +35,10 @@
 #ifndef __TESTLISTENER_H__
 #define __TESTLISTENER_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct __TestListnerImplement   TestListnerImplement;
 typedef struct __TestListnerImplement*  TestListnerImplementRef;/*downward compatible*/
 
@@ -58,5 +62,9 @@ struct __TestListner {
 #define TestListner_startTest(s,t)          ((TestListner*)s)->isa->startTest(s,t)
 #define TestListner_endTest(s,t)            ((TestListner*)s)->isa->endTest(s,t)
 #define TestListner_addFailure(s,t,m,l,f)   ((TestListner*)s)->isa->addFailure(s,t,m,l,f)
+
+#ifdef  __cplusplus
+}
+#endif
 
 #endif/*__TESTLISTENER_H__*/

--- a/tests/unittests/embunit/embUnit/TestSuite.h
+++ b/tests/unittests/embunit/embUnit/TestSuite.h
@@ -35,6 +35,10 @@
 #ifndef __TESTSUITE_H__
 #define __TESTSUITE_H__
 
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
 typedef struct __TestSuite  TestSuite;
 typedef struct __TestSuite* TestSuiteRef;/*downward compatible*/
 
@@ -54,5 +58,9 @@ extern const TestImplement TestSuiteImplement;
         numberOfTests,\
         tests,\
     }
+
+#ifdef  __cplusplus
+}
+#endif
 
 #endif/*__TESTSUITE_H__*/

--- a/tests/unittests/embunit/embUnit/config.h
+++ b/tests/unittests/embunit/embUnit/config.h
@@ -35,6 +35,10 @@
 #ifndef __CONFIG_H__
 #define __CONFIG_H__
 
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
 /*  #define NO_STDIO_PRINTF*/
     #ifdef  NO_STDIO_PRINTF
         extern void stdimpl_print(const char *string);
@@ -44,5 +48,9 @@
     #endif
 
     #define ASSERT_STRING_BUFFER_MAX    64
+
+#ifdef  __cplusplus
+}
+#endif
 
 #endif/*__CONFIG_H__*/

--- a/tests/unittests/embunit/embUnit/embUnit.h
+++ b/tests/unittests/embunit/embUnit/embUnit.h
@@ -47,4 +47,12 @@
 #include <embUnit/AssertImpl.h>
 #include <embUnit/HelperMacro.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif/*__EMBUNIT_H__*/

--- a/tests/unittests/embunit/textui/CompilerOutputter.h
+++ b/tests/unittests/embunit/textui/CompilerOutputter.h
@@ -37,6 +37,14 @@
 
 #include "Outputter.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 OutputterRef CompilerOutputter_outputter(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif/*__COMPILEROUTPUTTER_H__*/

--- a/tests/unittests/embunit/textui/Outputter.h
+++ b/tests/unittests/embunit/textui/Outputter.h
@@ -37,6 +37,10 @@
 
 #include <embUnit/embUnit.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct __OutputterImplement     OutputterImplement;
 typedef struct __OutputterImplement*    OutputterImplementRef;
 
@@ -70,5 +74,9 @@ struct __Outputter {
 #define Outputter_printSuccessful(o,t,c)    (o)->isa->printSuccessful(o,t,c)
 #define Outputter_printFailure(o,t,m,l,f,c) (o)->isa->printFailure(o,t,m,l,f,c)
 #define Outputter_printStatistics(o,r)      (o)->isa->printStatistics(o,r)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif/*__OUTPUTTER_H__*/

--- a/tests/unittests/embunit/textui/TextOutputter.h
+++ b/tests/unittests/embunit/textui/TextOutputter.h
@@ -37,6 +37,14 @@
 
 #include "Outputter.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 OutputterRef TextOutputter_outputter(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif/*__TEXTOUTPUTTER_H__*/

--- a/tests/unittests/embunit/textui/TextUIRunner.h
+++ b/tests/unittests/embunit/textui/TextUIRunner.h
@@ -39,10 +39,18 @@
 
 #include <embUnit/embUnit.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void TextUIRunner_setOutputter(OutputterRef outputter);
 void TextUIRunner_startWithOutputter(OutputterRef outputter);
 void TextUIRunner_start(void);
 void TextUIRunner_runTest(TestRef test);
 void TextUIRunner_end(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif/*__TEXTUIRUNNER_H__*/

--- a/tests/unittests/embunit/textui/XMLOutputter.h
+++ b/tests/unittests/embunit/textui/XMLOutputter.h
@@ -37,7 +37,15 @@
 
 #include "Outputter.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void XMLOutputter_setStyleSheet(char *style);
 OutputterRef XMLOutputter_outputter(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif/*__XMLOUTPUTTER_H__*/

--- a/tests/unittests/map.h
+++ b/tests/unittests/map.h
@@ -29,6 +29,10 @@
 #ifndef MAP_H_INCLUDED
 #define MAP_H_INCLUDED
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define EVAL0(...) __VA_ARGS__
 #define EVAL1(...) EVAL0 (EVAL0 (EVAL0 (__VA_ARGS__)))
 #define EVAL2(...) EVAL1 (EVAL1 (EVAL1 (__VA_ARGS__)))
@@ -47,5 +51,9 @@
 #define MAP0(f, x, peek, ...) f(x) MAP_NEXT (peek, MAP1) (f, peek, __VA_ARGS__)
 #define MAP1(f, x, peek, ...) f(x) MAP_NEXT (peek, MAP0) (f, peek, __VA_ARGS__)
 #define MAP(f, ...) EVAL (MAP1 (f, __VA_ARGS__, (), 0))
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/tests/unittests/tests-core/tests-core.h
+++ b/tests/unittests/tests-core/tests-core.h
@@ -20,6 +20,10 @@
 
 #include "../unittests.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   The entry point of this test suite.
  */
@@ -73,6 +77,10 @@ Test *tests_core_priority_queue_tests(void);
  * @return  embUnit tests if successful, NULL if not.
  */
 Test *tests_core_byteorder_tests(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __TESTS_CORE_H_ */
 /** @} */

--- a/tests/unittests/tests-lib/tests-lib.h
+++ b/tests/unittests/tests-lib/tests-lib.h
@@ -20,6 +20,10 @@
 
 #include "../unittests.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   The entry point of this test suite.
  */
@@ -31,6 +35,10 @@ void tests_lib(void);
  * @return  embUnit tests if successful, NULL if not.
  */
 Test *tests_lib_ringbuffer_tests(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __TESTS_CORE_H_ */
 /** @} */

--- a/tests/unittests/tests-pktbuf/tests-pktbuf.h
+++ b/tests/unittests/tests-pktbuf/tests-pktbuf.h
@@ -20,10 +20,18 @@
 
 #include "../unittests.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   The entry point of this test suite.
  */
 void tests_pktbuf(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __TESTS_PKTBUF_H_ */
 /** @} */

--- a/tests/unittests/tests-pktqueue/tests-pktqueue.h
+++ b/tests/unittests/tests-pktqueue/tests-pktqueue.h
@@ -20,10 +20,19 @@
 
 #include "../unittests.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   The entry point of this test suite.
  */
 void tests_pktqueue(void);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __TESTS_PKTQUEUE_H_ */
 /** @} */

--- a/tests/unittests/tests-timex/tests-timex.h
+++ b/tests/unittests/tests-timex/tests-timex.h
@@ -21,6 +21,10 @@
 
 #include "../unittests.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   The entry point of this test suite.
  */
@@ -32,6 +36,10 @@ void tests_timex(void);
  * @return  embUnit tests if successful, NULL if not.
  */
 Test *tests_timex_tests(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __TESTS_TIMEX_H_ */
 /** @} */

--- a/tests/unittests/unittests.h
+++ b/tests/unittests/unittests.h
@@ -19,6 +19,10 @@
 #ifndef __UNITTESTS__H
 #define __UNITTESTS__H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "embUnit/embUnit.h"
 
 #ifdef OUTPUT
@@ -46,6 +50,10 @@
 #   define TESTS_START()   TestRunner_start()
 #   define TESTS_RUN(t)    TestRunner_runTest(t)
 #   define TESTS_END()     TestRunner_end()
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif


### PR DESCRIPTION
This PR adds `extern "C"` for the header files in `./RIOT/test/unittests` folder.
`./RIOT/test` does not contain any header

~~I left out `./unittests/embUnit/embUnit.h` as it only collects all other headers form `embUnit`~~ (also encapsulated it to eventually satisfy #1789)
