### PR TITLE
core: introduce `msg_sent_by_int()`

### DIFF
--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -115,12 +115,21 @@ int msg_try_send(msg_t *m, kernel_pid_t target_pid);
 int msg_send_to_self(msg_t *m);
 
 /**
+ * Value of msg_t::sender_pid if the sender was an interrupt service routine.
+ */
+#define KERNEL_PID_ISR (KERNEL_PID_LAST + 1)
+
+/**
  * @brief Send message from interrupt.
  *
- * Will be automatically chosen instead of ``msg_send()`` if called from an
+ * Will be automatically chosen instead of msg_send() if called from an
  * interrupt/ISR.
  *
- * @param[in] m             Pointer to preallocated ``msg_t`` structure, must
+ * The value of ``m->sender_pid`` is set to @ref KERNEL_PID_ISR.
+ *
+ * @see msg_sent_by_int()
+ *
+ * @param[in] m             Pointer to preallocated @ref msg_t structure, must
  *                          not be NULL.
  * @param[in] target_pid    PID of target thread.
  *
@@ -130,6 +139,17 @@ int msg_send_to_self(msg_t *m);
  */
 int msg_send_int(msg_t *m, kernel_pid_t target_pid);
 
+/**
+ * @brief Test if the message was sent inside an ISR.
+ * @see msg_send_int()
+ * @param[in] m The message in question.
+ * @returns `== 0` if *not* sent by an ISR
+ * @returns `!= 0` if sent by an ISR
+ */
+static inline int msg_sent_by_int(const msg_t *m)
+{
+    return (m->sender_pid == KERNEL_PID_ISR);
+}
 
 /**
  * @brief Receive a message.

--- a/core/msg.c
+++ b/core/msg.c
@@ -179,7 +179,7 @@ int msg_send_int(msg_t *m, kernel_pid_t target_pid)
         return -1;
     }
 
-    m->sender_pid = target_pid;
+    m->sender_pid = KERNEL_PID_ISR;
     if (target->status == STATUS_RECEIVE_BLOCKED) {
         DEBUG("msg_send_int: Direct msg copy from %" PRIkernel_pid " to %" PRIkernel_pid ".\n", thread_getpid(), target_pid);
 

--- a/sys/chardev_thread.c
+++ b/sys/chardev_thread.c
@@ -18,10 +18,7 @@
 #include <stdio.h>
 #include <errno.h>
 
-#include "kernel.h"
 #include "irq.h"
-
-#include "thread.h"
 #include "msg.h"
 
 #include "ringbuffer.h"
@@ -45,8 +42,6 @@ void chardev_loop(ringbuffer_t *rb)
 {
     msg_t m;
 
-    kernel_pid_t pid = thread_getpid();
-
     kernel_pid_t reader_pid = KERNEL_PID_UNDEF;
     struct posix_iop_t *r = NULL;
 
@@ -55,7 +50,7 @@ void chardev_loop(ringbuffer_t *rb)
     while (1) {
         msg_receive(&m);
 
-        if (m.sender_pid != pid) {
+        if (!msg_sent_by_int(&m)) {
             DEBUG("Receiving message from another thread: ");
 
             switch(m.type) {


### PR DESCRIPTION
`msg_send_int()` sets `m->sender_pid = target_pid`. This was used to flag a message as having been sent by an ISR.

This PR introduces a static inline function 'msg_sent_by_int()' and a specific define for this purpose.
