### PR TITLE
renamed the cpp header file to `*.hpp`

### DIFF
--- a/examples/riot_and_cpp/cpp_class.cpp
+++ b/examples/riot_and_cpp/cpp_class.cpp
@@ -20,7 +20,7 @@
  * @}
  */
 
-#include "cpp_class.h"
+#include "cpp_class.hpp"
 
 cpp_class::cpp_class()
 {

--- a/examples/riot_and_cpp/cpp_class.hpp
+++ b/examples/riot_and_cpp/cpp_class.hpp
@@ -13,7 +13,7 @@
  * @ingroup     examples
  * @{
  *
- * @file        cpp_class.h
+ * @file        cpp_class.hpp
  * @brief       simple c++ object declaration with public and private functions
  *
  * @author      Martin Landsmann <martin.landsmann@haw-hamburg.de>

--- a/examples/riot_and_cpp/main.cpp
+++ b/examples/riot_and_cpp/main.cpp
@@ -32,7 +32,7 @@ extern "C" {
 
 #include <cstdio>
 #include <vector>
-#include "cpp_class.h"
+#include "cpp_class.hpp"
 
 using namespace std;
 


### PR DESCRIPTION
If we eventually have a `extern "C"` check for all `*.h` files (#1789) we need to explicitly have distinct names for c++ headers to avoid false positives.
