### PR TITLE
sys: add extern "C" to headers

### DIFF
--- a/sys/include/auto_init.h
+++ b/sys/include/auto_init.h
@@ -32,7 +32,15 @@
 #ifndef AUTO_INIT_H
 #define AUTO_INIT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void auto_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* AUTO_INIT_H */

--- a/sys/include/bloom.h
+++ b/sys/include/bloom.h
@@ -127,6 +127,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * hashfp_t  hash function to use in thee filter
  */
@@ -214,6 +218,10 @@ void bloom_add(bloom_t *bloom, const uint8_t *buf, size_t len);
  *
  */
 bool bloom_check(bloom_t *bloom, const uint8_t *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* _BLOOM_FILTER_H */

--- a/sys/include/board_uart0.h
+++ b/sys/include/board_uart0.h
@@ -23,6 +23,10 @@
 #include "kernel_types.h"
 #include "cpu-conf.h"   /* To give user access to UART0_BUFSIZE */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern kernel_pid_t uart0_handler_pid;
 
 void board_uart0_init(void);
@@ -31,6 +35,10 @@ void uart0_notify_thread(void);
 
 int uart0_readc(void);
 void uart0_putc(int c);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __BOARD_UART0_H */

--- a/sys/include/cbor.h
+++ b/sys/include/cbor.h
@@ -99,9 +99,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+
 #ifndef CBOR_NO_CTIME
 #include <time.h>
 #endif /* CBOR_NO_CTIME */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Struct containing CBOR-encoded data
@@ -362,6 +367,10 @@ bool cbor_at_break(const cbor_stream_t *s, size_t offset);
  * @return True in case @p offset marks the end of the stream
  */
 bool cbor_at_end(const cbor_stream_t *s, size_t offset);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/sys/include/chardev_thread.h
+++ b/sys/include/chardev_thread.h
@@ -18,7 +18,15 @@
 
 #include "ringbuffer.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void chardev_loop(ringbuffer_t *rb);
 void *chardev_thread_entry(void *rb_);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CHARDEV_THREAD_H */

--- a/sys/include/color.h
+++ b/sys/include/color.h
@@ -23,6 +23,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Data-structure describing a RGB color
  */
@@ -57,6 +61,10 @@ void color_rgb2hsv(color_rgb_t *rgb, color_hsv_t *hsv);
  * @param[out] rgb      Output color encoded in RGB space
  */
 void color_hsv2rgb(color_hsv_t *hsv, color_rgb_t *rgb);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __COLOR_H */
 /** @} */

--- a/sys/include/crypto/3des.h
+++ b/sys/include/crypto/3des.h
@@ -29,6 +29,10 @@
 #ifndef THREEDES_H_
 #define THREEDES_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define THREEDES_BLOCK_SIZE    8
 #define THREEDES_KEY_SIZE      PARSEC_KEYSIZE
 
@@ -147,6 +151,10 @@ uint8_t tripledes_get_preferred_block_size(void);
  *
  */
 extern block_cipher_interface_t tripledes_interface;
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* THREEDES_H_ */

--- a/sys/include/crypto/aes.h
+++ b/sys/include/crypto/aes.h
@@ -29,6 +29,9 @@
 #include <stdint.h>
 #include "crypto/ciphers.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef uint32_t u32;
 typedef uint16_t u16;
@@ -137,6 +140,10 @@ uint8_t aes_get_preferred_block_size(void);
   *
   */
 extern block_cipher_interface_t aes_inerface;
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* AES_H */

--- a/sys/include/crypto/cbcmode.h
+++ b/sys/include/crypto/cbcmode.h
@@ -31,6 +31,10 @@
 
 #include "crypto/ciphers.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MIN(a, b) ( ((a) < (b)) ? (a) : (b))
 
 #define DBG_CRYPTO      1
@@ -203,6 +207,10 @@ int block_cipher_mode_decrypt(CipherModeContext *context,
                               uint8_t *plain_blocks,
                               uint16_t num_bytes,
                               uint8_t *IV);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* CBCMODE_H_ */

--- a/sys/include/crypto/ciphers.h
+++ b/sys/include/crypto/ciphers.h
@@ -22,6 +22,10 @@
 #ifndef __CIPHERS_H_
 #define __CIPHERS_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Shared header file for all cipher algorithms */
 
 /* Set the algorithms that should be compiled in here. When these defines
@@ -118,6 +122,10 @@ typedef struct {
     uint8_t context[12];
 #endif
 } cipher_mac_context_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __CIPHERS_H_ */

--- a/sys/include/crypto/rc5.h
+++ b/sys/include/crypto/rc5.h
@@ -23,6 +23,9 @@
 #ifndef RC5_H_
 #define RC5_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define RC5_32_P        0xB7E15163L
 #define RC5_32_Q        0x9E3779B9L
@@ -136,6 +139,10 @@ uint8_t rc5_get_preferred_block_size(void);
  *
  */
 extern block_cipher_interface_t rc5_interface;
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* RC5_H_ */

--- a/sys/include/crypto/sha256.h
+++ b/sys/include/crypto/sha256.h
@@ -51,6 +51,10 @@
 
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define SHA256_DIGEST_LENGTH 32
 
 typedef struct {
@@ -95,6 +99,10 @@ void sha256_final(unsigned char digest[32], sha256_context_t *ctx);
  *           if md == NULL, one static buffer is used
  */
 unsigned char *sha256(const unsigned char *d, size_t n, unsigned char *md);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* _SHA256_H_ */

--- a/sys/include/crypto/skipjack.h
+++ b/sys/include/crypto/skipjack.h
@@ -23,6 +23,10 @@
 
 #include "crypto/ciphers.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define F(addr) /*CRYPTO_TABLE_ACCESS( &SJ_F[addr])*/ (SJ_F[addr])
 
 // G-Permutation: 4 round feistel structure
@@ -166,6 +170,10 @@ uint8_t skipjack_get_preferred_block_size(void);
  *
  */
 extern block_cipher_interface_t skipjack_interface;
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* SKIPJACK_H_ */

--- a/sys/include/crypto/twofish.h
+++ b/sys/include/crypto/twofish.h
@@ -28,6 +28,10 @@
 #ifndef TWOFISH_H_
 #define TWOFISH_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define TWOFISH_BLOCK_SIZE      16
 #define TWOFISH_KEY_SIZE        16   //only alternative is 32!
 
@@ -277,6 +281,10 @@ uint8_t twofish_get_preferred_block_size(void);
  *
  */
 extern block_cipher_interface_t twofish_interface;
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* TWOFISH_H_ */

--- a/sys/include/fd.h
+++ b/sys/include/fd.h
@@ -25,6 +25,10 @@
 #include "kernel_types.h"
 #include "cpu.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * File descriptor table.
  */
@@ -86,5 +90,9 @@ fd_t *fd_get(int fd);
  * @param[in] fd    A POSIX-like file descriptor.
  */
 void fd_destroy(int fd);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* FD_H */

--- a/sys/include/hash_string.h
+++ b/sys/include/hash_string.h
@@ -9,7 +9,15 @@
 #ifndef __HASH_STRING_H
 #define __HASH_STRING_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 unsigned long hash_string(unsigned char *str);
 int cmp_string(char *a, char *b);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __HASH_STRING_H */

--- a/sys/include/hashes.h
+++ b/sys/include/hashes.h
@@ -25,6 +25,10 @@
 #include <stddef.h>
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief djb2_hash
  *
@@ -154,6 +158,10 @@ uint32_t rotating_hash(const uint8_t *buf, size_t len);
  * @return 32 bit sized hash
  */
 uint32_t one_at_a_time_hash(const uint8_t *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __HASHES_H */

--- a/sys/include/ping.h
+++ b/sys/include/ping.h
@@ -15,6 +15,10 @@
 
 #include "radio/radio.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void init_payload(void);
 void ping_init(protocol_t protocol, uint8_t channr, radio_address_t addr);
 void ping(radio_address_t addr, uint8_t channr);
@@ -38,3 +42,7 @@ typedef struct pong {
 typedef struct ping_payload {
     char *payload;
 } ping_payload;
+
+#ifdef __cplusplus
+}
+#endif

--- a/sys/include/pipe.h
+++ b/sys/include/pipe.h
@@ -38,6 +38,10 @@
 #include "ringbuffer.h"
 #include "thread.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef PIPE_BUF
 #   define PIPE_BUF (128) /**< Size of a dynamically malloc'd pipe. */
 #endif
@@ -107,6 +111,10 @@ pipe_t *pipe_malloc(unsigned size);
  * @param     rp   Pipe to free.
  */
 void pipe_free(pipe_t *rp);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 /**

--- a/sys/include/posix_io.h
+++ b/sys/include/posix_io.h
@@ -22,6 +22,10 @@
 
 #include "kernel_types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define OPEN 0
 #define CLOSE 1
 #define READ 2
@@ -36,6 +40,10 @@ int posix_open(int pid, int flags);
 int posix_close(int pid);
 int posix_read(int pid, char *buffer, int bufsize);
 int posix_write(int pid, char *buffer, int bufsize);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __READ_H */

--- a/sys/include/ps.h
+++ b/sys/include/ps.h
@@ -16,7 +16,15 @@
 #ifndef __PS_H
 #define __PS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void thread_print_all(void);
 void _ps_handler(int argc, char **argv);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PS_H */

--- a/sys/include/radio/radio.h
+++ b/sys/include/radio/radio.h
@@ -37,6 +37,10 @@
 #include <stdbool.h>
 #include "radio/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define L1_PROTOCOL_CATCH_ALL             (0xff)    ///< Catch all protocol ID
 
 enum layer_1_protocols {
@@ -71,6 +75,10 @@ typedef struct {
     void (*print_stats)(void);
     void (*print_config)(void);
 } radio_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 

--- a/sys/include/radio/types.h
+++ b/sys/include/radio/types.h
@@ -30,6 +30,10 @@
 #include "board.h"
 #include "timex.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef uint8_t protocol_t;         ///< Packet protocol type
 typedef uint16_t radio_address_t;   ///< Radio layer address type
 
@@ -96,5 +100,9 @@ typedef void (*packet_handler_t)(void *payload, int payload_size, packet_info_t 
  * @param   packet_info     Cross-layer meta data
  */
 typedef void (*packet_monitor_t)(void *payload, int payload_size, protocol_t protocol, packet_info_t *packet_info);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COMMONTYPES_H_ */

--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -15,6 +15,10 @@
 
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef PRNG_FLOAT
 #  define PRNG_FLOAT (0)
 #endif
@@ -72,3 +76,7 @@ double genrand_real_exclusive(void);
 double genrand_res53(void);
 
 #endif /* PRNG_FLOAT */
+
+#ifdef __cplusplus
+}
+#endif

--- a/sys/include/ringbuffer.h
+++ b/sys/include/ringbuffer.h
@@ -19,6 +19,10 @@
 #ifndef __RINGBUFFER_H
 #define __RINGBUFFER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief     Ringbuffer.
  * @details   Non thread-safe FIFO ringbuffer implementation around a `char` array.
@@ -145,5 +149,9 @@ int ringbuffer_peek_one(const ringbuffer_t *restrict rb);
  * @returns         Same as ringbuffer_get()
  */
 unsigned ringbuffer_peek(const ringbuffer_t *restrict rb, char *buf, unsigned n);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __RINGBUFFER_H */

--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -19,6 +19,10 @@
 
 #include "attributes.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief           Protype of a shell callback handler.
  * @details         The functions supplied to shell_init() must use this signature.
@@ -83,5 +87,9 @@ void shell_init(shell_t *shell,
  * @returns         This function does not return.
  */
 void shell_run(shell_t *shell) NORETURN;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SHELL_H */

--- a/sys/include/shell_commands.h
+++ b/sys/include/shell_commands.h
@@ -11,6 +11,10 @@
 
 #include "shell.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define DISK_GET_SECTOR_SIZE    "dget_ssize"
 #define DISK_GET_SECTOR_COUNT   "dget_scount"
 #define DISK_GET_BLOCK_SIZE     "dget_bsize"
@@ -18,5 +22,9 @@
 #define DISK_READ_BYTES_CMD     "dread"
 
 extern const shell_command_t _shell_command_list[];
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SHELL_COMMANDS_H */

--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -25,6 +25,10 @@
 #include <stdio.h>
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // mspgcc bug : PRIxxx macros not defined before mid-2011 versions
 #ifndef PRIu32
 #define PRIu32 "lu"
@@ -163,6 +167,10 @@ static inline const char *timex_to_str(timex_t t, char *timestamp)
              t.seconds, t.microseconds);
     return timestamp;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __TIMEX_H */

--- a/sys/include/tm.h
+++ b/sys/include/tm.h
@@ -23,6 +23,10 @@
 
 #include "attributes.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define TM_WDAY_SUN (0) /**< Sunday in `struct tm::tm_wday`. */
 #define TM_WDAY_MON (1) /**< Monday in `struct tm::tm_wday`. */
 #define TM_WDAY_TUE (2) /**< Tuesday in `struct tm::tm_wday`. */
@@ -109,5 +113,9 @@ int tm_is_valid_date(int year, int mon, int mday) CONST;
  * @returns         0 iff the time is invalid.
  */
 int tm_is_valid_time(int hour, int min, int sec) CONST;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/sys/include/transceiver.h
+++ b/sys/include/transceiver.h
@@ -77,6 +77,10 @@
 #endif
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Stack size for transceiver thread */
 #ifndef TRANSCEIVER_STACK_SIZE
 #define TRANSCEIVER_STACK_SIZE      (KERNEL_CONF_STACKSIZE_DEFAULT)
@@ -246,6 +250,10 @@ uint8_t transceiver_register(transceiver_type_t transceivers, kernel_pid_t pid);
  * @return              1 on success, 0 otherwise
  */
 uint8_t transceiver_unregister(transceiver_type_t transceivers, kernel_pid_t pid);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TRANSCEIVER_H */
 /** @} */

--- a/sys/include/vtimer.h
+++ b/sys/include/vtimer.h
@@ -28,6 +28,10 @@
 #include "timex.h"
 #include "msg.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MSG_TIMER 12345
 
 /**
@@ -136,6 +140,10 @@ void vtimer_print_short_queue(void);
  */
 void vtimer_print_long_queue(void);
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 /** @} */

--- a/sys/net/ccn_lite/ccnl-core.h
+++ b/sys/net/ccn_lite/ccnl-core.h
@@ -54,6 +54,10 @@
 
 #include "ccnl.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // ----------------------------------------------------------------------
 
 typedef union {
@@ -289,6 +293,10 @@ void free_3ptr_list(void *a, void *b, void *c);
 void free_4ptr_list(void *a, void *b, void *c, void *d);
 void free_prefix(struct ccnl_prefix_s *p);
 void free_content(struct ccnl_content_s *c);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*CCNL_CORE_H__*/
 // eof

--- a/sys/net/ccn_lite/ccnl-ext.h
+++ b/sys/net/ccn_lite/ccnl-ext.h
@@ -26,6 +26,10 @@
 #ifndef CCNL_EXT_H__
 #define CCNL_EXT_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define compute_ccnx_digest(buf) sha256(buf->data, buf->datalen, NULL)
 
 #ifdef USE_FRAG
@@ -92,6 +96,10 @@ ccnl_prefix_clone_strip(struct ccnl_prefix_s *p, int strip);
 # define ccnl_sched_destroy(S)      do{}while(0)
 
 char *ccnl_prefix_to_path(struct ccnl_prefix_s *pr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CCNL_EXT_H__ */
 

--- a/sys/net/ccn_lite/ccnl-includes.h
+++ b/sys/net/ccn_lite/ccnl-includes.h
@@ -28,10 +28,18 @@
 
 #include "crypto/sha256.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define RIOT_MSG_DEV    (1)
 #define RIOT_TRANS_DEV  (2)
 
 #define RIOT_MSG_IDX (0)
 #define RIOT_TRANS_IDX (1)
+
+#ifdef __cplusplus
+}
+#endif
 
 // eof

--- a/sys/net/ccn_lite/ccnl-pdu.h
+++ b/sys/net/ccn_lite/ccnl-pdu.h
@@ -16,6 +16,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int dehead(unsigned char **buf, int *len, int *num, int *typ);
 int mkHeader(unsigned char *buf, unsigned int num, unsigned int tt);
 int mkBlob(unsigned char *out, unsigned int num, unsigned int tt, char *cp, int cnt);
@@ -26,3 +30,7 @@ int unmkBinaryInt(unsigned char **data, int *datalen, unsigned int *result,
                   unsigned char *width);
 int mkInterest(char **namecomp, unsigned int *nonce, unsigned char *out);
 int mkContent(char **namecomp, char *data, int datalen, unsigned char *out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/sys/net/ccn_lite/ccnl-platform.h
+++ b/sys/net/ccn_lite/ccnl-platform.h
@@ -20,6 +20,10 @@
 
 #include <sys/time.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // (ms) I moved the following struct def here because it is used by all
 // containers apart from the kernel (this way I don't need to redefine it
 // for omnet.
@@ -47,3 +51,7 @@ void
 ccnl_rem_timer(void *h);
 
 extern struct ccnl_timer_s *eventqueue;
+
+#ifdef __cplusplus
+}
+#endif

--- a/sys/net/ccn_lite/ccnl-riot-compat.h
+++ b/sys/net/ccn_lite/ccnl-riot-compat.h
@@ -18,6 +18,10 @@
 
 #include "ccn_lite/ccnl-riot.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define RIOT_CCN_EVENT_NUMBER_OFFSET (1 << 8)
 
 #define RIOT_BROADCAST (UINT16_MAX)
@@ -32,3 +36,7 @@ int riot_send_msg(uint8_t *buf, uint16_t size, uint16_t to);
 void riot_send_nack(uint16_t to);
 kernel_pid_t riot_start_helper_thread(void);
 char *riot_ccnl_event_to_string(int event);
+
+#ifdef __cplusplus
+}
+#endif

--- a/sys/net/ccn_lite/ccnl.h
+++ b/sys/net/ccn_lite/ccnl.h
@@ -21,6 +21,10 @@
  * 2011-03-30 created
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CCNL_MAX_INTERFACES             2 /* transceiver and msg interfaces */
 
 #define CCNL_INTEREST_TIMEOUT_SEC       0
@@ -138,5 +142,9 @@
 
 // function alias for RIOTs debug infrastructure
 #define DEBUGMSG(LVL, ...) DEBUG(__VA_ARGS__)
+
+#ifdef __cplusplus
+}
+#endif
 
 // eof

--- a/sys/net/ccn_lite/ccnx.h
+++ b/sys/net/ccn_lite/ccnx.h
@@ -20,6 +20,10 @@
  * 2011-03-13 created
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // ----------------------------------------------------------------------
 
 #define CCN_DEFAULT_MTU         PAYOAD_SIZE
@@ -68,5 +72,9 @@
 #define CCN_DTAG_MAXSUFFCOMP    84
 #define CCN_DTAG_SEQNO          256
 #define CCN_DTAG_CCNPDU         17702112
+
+#ifdef __cplusplus
+}
+#endif
 
 // eof

--- a/sys/net/ccn_lite/util/ccn-lite-ctrl.h
+++ b/sys/net/ccn_lite/util/ccn-lite-ctrl.h
@@ -16,7 +16,15 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int mkNewFaceRequest(unsigned char *out, char *macsrc, char *ip4src,
                      char *host, char *port, char *flags);
 
 int mkPrefixregRequest(unsigned char *out, char reg, char *path, char *faceid);
+
+#ifdef __cplusplus
+}
+#endif

--- a/sys/net/include/ccn_lite/ccnl-riot.h
+++ b/sys/net/include/ccn_lite/ccnl-riot.h
@@ -38,6 +38,10 @@
 
 #include "transceiver.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define TRANSCEIVER TRANSCEIVER_DEFAULT
 
 #define CCNL_DEFAULT_CHANNEL 6
@@ -81,6 +85,10 @@ void *ccnl_riot_relay_start(void *arg);
  * @param arg the pid of the relay
  */
 void *ccnl_riot_appserver_start(void *arg);
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/sys/net/include/ccn_lite/test_data/text.txt.ccnb.h
+++ b/sys/net/include/ccn_lite/test_data/text.txt.ccnb.h
@@ -16,6 +16,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define RIOT_CCNL_POPULATE (1)
 
 #if RIOT_CCNL_POPULATE
@@ -356,4 +360,8 @@ unsigned char text_txt_ccnb_9[] = {
 };
 unsigned int text_txt_ccnb_9_len = 118;
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/sys/net/include/ccn_lite/util/ccnl-riot-client.h
+++ b/sys/net/include/ccn_lite/util/ccnl-riot-client.h
@@ -27,6 +27,10 @@
 #ifndef CCNL_RIOT_CLIENT_H
 #define CCNL_RIOT_CLIENT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief  high level function to fetch a file (all chunks of a file)
  *
@@ -102,6 +106,10 @@ int ccnl_riot_client_new_face(kernel_pid_t relay_pid, char *type, char *faceid,
  */
 int ccnl_riot_client_register_prefix(kernel_pid_t relay_pid, char *prefix,
         char *faceid, unsigned char *reply_buf);
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/sys/net/include/etx_beaconing.h
+++ b/sys/net/include/etx_beaconing.h
@@ -11,6 +11,10 @@
 #include <stdint.h>
 #include "sixlowpan.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //[option|length|ipaddr.|packetcount] with up to 15 ipaddr|packetcount pairs
 // 1 Byte 1 Byte  1 Byte  1 Byte
 #define ETX_BUF_SIZE   (32)
@@ -98,5 +102,9 @@ void etx_update(etx_neighbor_t *neighbor);
 #define ETX_DATA_MAXLEN     (30)    //max length of the data
 #define ETX_PKT_HDR_LEN     (2)     //Option type + Length (1 Byte each)
 #define ETX_PKT_DATA        (2)     //Begin of Data Bytes
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ETX_BEACONING_H_ */

--- a/sys/net/include/ieee802154_frame.h
+++ b/sys/net/include/ieee802154_frame.h
@@ -25,6 +25,10 @@
 #include <stdio.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* maximum 802.15.4 header length */
 #define IEEE_802154_MAX_HDR_LEN         (23)
 /* ...and FCS*/
@@ -108,6 +112,10 @@ uint8_t ieee802154_frame_get_hdr_len(ieee802154_frame_t *frame);
 uint8_t ieee802154_frame_read(uint8_t *buf, ieee802154_frame_t *frame, uint8_t len);
 void ieee802154_frame_print_fcf_frame(ieee802154_frame_t *frame);
 uint16_t ieee802154_frame_get_fcs(const uint8_t *frame, uint8_t frame_len);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* IEEE802154_IEEE802154_FRAME */

--- a/sys/net/include/inet_ntop.h
+++ b/sys/net/include/inet_ntop.h
@@ -19,6 +19,10 @@
 #define INET_NTOP_H_
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef AF_INET
 #define AF_INET             2           ///< internetwork address family: UDP, TCP, etc.
 #endif
@@ -49,5 +53,9 @@
  */
 
 const char *inet_ntop(int af, const void *src, char *dst, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INET_NTOP_H_ */

--- a/sys/net/include/inet_pton.h
+++ b/sys/net/include/inet_pton.h
@@ -19,6 +19,10 @@
 #define INET_PTON_H_
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef AF_INET
 #define AF_INET             2           ///< internetwork address family: UDP, TCP, etc.
 #endif
@@ -53,5 +57,9 @@
  */
 
 int inet_pton(int af, const char *src, void *dst);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INET_PTON_H_ */

--- a/sys/net/include/ipv6.h
+++ b/sys/net/include/ipv6.h
@@ -28,6 +28,14 @@
 
 #include "../network_layer/sixlowpan/icmp.h"        /* TODO: remove if not needed anymore */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* IPV6_H */
 /**
  * @}

--- a/sys/net/include/net_help.h
+++ b/sys/net/include/net_help.h
@@ -29,6 +29,10 @@
 
 #include "byteorder.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define BITSET(var,pos) ((var) & (1<<(pos)))
 
 static inline uint16_t HTONS(uint16_t a)
@@ -65,6 +69,10 @@ static inline uint64_t NTOHLL(uint64_t a)
 
 uint16_t csum(uint16_t sum, uint8_t *buf, uint16_t len);
 void printArrayRange(uint8_t *array, uint16_t len, char *str);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __NET_HELP_H */

--- a/sys/net/include/net_if.h
+++ b/sys/net/include/net_if.h
@@ -27,6 +27,10 @@
 #include "mutex.h"
 #include "transceiver.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   type to specify types of upper layer addresses
  */
@@ -496,6 +500,10 @@ int32_t net_if_get_pan_id(int if_id);
  * @return  the PAN ID on success, -1 on failure.
  */
 int32_t net_if_set_pan_id(int if_id, uint16_t pan_id);
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/sys/net/include/pktbuf.h
+++ b/sys/net/include/pktbuf.h
@@ -31,6 +31,10 @@
 
 #include "cpu-conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef PKTBUF_SIZE
 /**
  * @brief Maximum size of the packet buffer.
@@ -181,6 +185,10 @@ int pktbuf_contains(const void *pkt);
  * @brief   Sets the whole packet buffer to 0
  */
 void pktbuf_reset(void);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* __PKTBUF_H_ */

--- a/sys/net/include/pktqueue.h
+++ b/sys/net/include/pktqueue.h
@@ -26,6 +26,10 @@
 
 #include "priority_queue.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   data type for packet queue nodes
  *
@@ -128,6 +132,10 @@ static inline void pktqueue_remove(pktqueue_t *queue, pktqueue_node_t *node)
 {
     priority_queue_remove((priority_queue_t *)queue, (priority_queue_node_t *) node);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PKTQUEUE_H_ */
 /**

--- a/sys/net/include/protocol-multiplex.h
+++ b/sys/net/include/protocol-multiplex.h
@@ -26,6 +26,10 @@
 
 #include "radio/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
     packet_handler_t    handler;
     protocol_t          protocol;
@@ -41,6 +45,10 @@ int pm_find_handler_index(const pm_table_t *table, protocol_t protocol, unsigned
 int pm_set_handler(const pm_table_t *table, protocol_t protocol, packet_handler_t handler);
 void pm_remove_handler(const pm_table_t *table, protocol_t protocol, packet_handler_t handler);
 int pm_invoke(const pm_table_t *table, protocol_t protocol, void *payload, int payload_size, packet_info_t *packet_info);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* PROTOCOLMULTIPLEX_H_ */

--- a/sys/net/include/rpl.h
+++ b/sys/net/include/rpl.h
@@ -35,6 +35,10 @@
 #include "ipv6.h"
 #include "rpl/rpl_dodag.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #undef CC1100_RADIO_MODE
 #define CC1100_RADIO_MODE CC1100_MODE_WOR
 
@@ -262,6 +266,10 @@ void rpl_clear_routing_table(void);
  *
  * */
 rpl_routing_entry_t *rpl_get_routing_table(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __RPL_H */

--- a/sys/net/include/rpl/rpl_config.h
+++ b/sys/net/include/rpl/rpl_config.h
@@ -18,6 +18,10 @@
 #ifndef RPL_CONFIG_H_INCLUDED
 #define RPL_CONFIG_H_INCLUDED
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*  Default values */
 #define RPL_NO_DOWNWARD_ROUTES  0x00
 #define RPL_NON_STORING_MODE    0x01
@@ -132,5 +136,9 @@ static inline bool RPL_COUNTER_GREATER_THAN(uint8_t A,uint8_t B)
 #define RPL_DIS_D_MASK 0x20
 #define RPL_GROUNDED_SHIFT 7
 #define RPL_DEFAULT_OCP 0
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/sys/net/include/rpl/rpl_dodag.h
+++ b/sys/net/include/rpl/rpl_dodag.h
@@ -20,6 +20,10 @@
 #include "rpl_structs.h"
 #include "rpl_config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void rpl_instances_init(void);
 rpl_instance_t *rpl_new_instance(uint8_t instanceid);
 rpl_instance_t *rpl_get_instance(uint8_t instanceid);
@@ -42,3 +46,7 @@ void rpl_parent_update(rpl_parent_t *parent);
 void rpl_global_repair(rpl_dodag_t *dodag, ipv6_addr_t *p_addr, uint16_t rank);
 void rpl_local_repair(void);
 uint16_t rpl_calc_rank(uint16_t abs_rank, uint16_t minhoprankincrease);
+
+#ifdef __cplusplus
+}
+#endif

--- a/sys/net/include/rpl/rpl_storing.h
+++ b/sys/net/include/rpl/rpl_storing.h
@@ -30,6 +30,10 @@
 #include "rpl_config.h"
 #include "rpl.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Initialization of RPL-root.
  *
@@ -140,6 +144,10 @@ void recv_rpl_dao_ack_mode(void);
  *
  */
 void rpl_send(ipv6_addr_t *destination, uint8_t *payload, uint16_t p_len, uint8_t next_header);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __RPL_SM_H */
 /** @} */

--- a/sys/net/include/rpl/rpl_structs.h
+++ b/sys/net/include/rpl/rpl_structs.h
@@ -20,6 +20,11 @@
 
 #ifndef RPL_STRUCTS_H_INCLUDED
 #define RPL_STRUCTS_H_INCLUDED
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Modes of Operation */
 
 /* DIO Base Object (RFC 6550 Fig. 14) */
@@ -178,5 +183,9 @@ typedef struct {
     uint16_t lifetime;
     uint8_t used;
 } rpl_routing_entry_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/sys/net/include/sixlowpan.h
+++ b/sys/net/include/sixlowpan.h
@@ -47,5 +47,13 @@
 #include "sixlowpan/lowpan.h"
 #include "sixlowpan/mac.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* SIXLOWPAN_H */
 /** @} */

--- a/sys/net/include/sixlowpan/error.h
+++ b/sys/net/include/sixlowpan/error.h
@@ -19,6 +19,10 @@
 #ifndef SIXLOWPAN_ERROR_H
 #define SIXLOWPAN_ERROR_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Functions return this if call was success. Only defined if not
  * already defined by other header.
@@ -94,6 +98,10 @@
  * not found.
  */
 #define SIXLOWERROR_CSUM        (141)
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* SIXLOWPAN_ERROR_H */

--- a/sys/net/include/sixlowpan/icmp.h
+++ b/sys/net/include/sixlowpan/icmp.h
@@ -30,6 +30,10 @@
 
 #include "sixlowpan/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief ICMPv6 packet type for parameter problem message.
  * @see <a href="http://tools.ietf.org/html/rfc4443#section-3.4">
@@ -246,5 +250,10 @@ void icmpv6_send_neighbor_adv(ipv6_addr_t *src, ipv6_addr_t *dst,
  * @return The internet checksum of the given ICMPv6 packet.
  */
 uint16_t icmpv6_csum(ipv6_hdr_t *ipv6_buf, icmpv6_hdr_t *icmpv6_buf);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* SIXLOWPAN_ICMP_H */
 /** @} */

--- a/sys/net/include/sixlowpan/ip.h
+++ b/sys/net/include/sixlowpan/ip.h
@@ -31,6 +31,10 @@
 #include "net_help.h"
 #include "sixlowpan/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   IPv6 maximum transmission unit.
  */
@@ -541,6 +545,10 @@ void ipv6_iface_set_routing_provider(ipv6_addr_t *(*next_hop)(ipv6_addr_t *dest)
  * @return The IPv6 upper-layer checksum.
  */
 uint16_t ipv6_csum(ipv6_hdr_t *ipv6_header, uint8_t *buf, uint16_t len, uint8_t proto);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SIXLOWPAN_IP_H */
 /** @} */

--- a/sys/net/include/sixlowpan/lowpan.h
+++ b/sys/net/include/sixlowpan/lowpan.h
@@ -31,6 +31,10 @@
 #include "net_if.h"
 #include "sixlowpan/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   6LoWPAN dispatch value for uncompressed IPv6 packets.
  * @see <a href="http://tools.ietf.org/html/rfc4944#section-5.1">
@@ -300,6 +304,10 @@ void sixlowpan_lowpan_print_reassembly_buffers(void);
  * @return  1 on success, 0 on failure.
  */
 int sixlowpan_lowpan_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SIXLOWPAN_LOWPAN_H */
 /** @} */

--- a/sys/net/include/sixlowpan/mac.h
+++ b/sys/net/include/sixlowpan/mac.h
@@ -28,6 +28,10 @@
 
 #include "sixlowpan/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   Maximum length of a IEEE 802.15.4 long address represented as string.
  */
@@ -57,6 +61,10 @@ int sixlowpan_mac_send_ieee802154_frame(int if_id, const void *dest,
  * @return  PID of the MAC receiver thread.
  */
 kernel_pid_t sixlowpan_mac_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* SIXLOWPAN_MAC_H */

--- a/sys/net/include/sixlowpan/ndp.h
+++ b/sys/net/include/sixlowpan/ndp.h
@@ -30,6 +30,10 @@
 #include "timex.h"
 #include "sixlowpan/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define NDP_6LOWPAN_CONTEXT_MAX         (16)
 
 #define NDP_OPT_SLLAO_TYPE                  (1)
@@ -226,6 +230,10 @@ ndp_prefix_info_t *ndp_prefix_info_match(int if_id, const ipv6_addr_t *prefix,
         uint8_t prefix_len);
 ndp_a6br_cache_t *ndp_a6br_cache_get_most_current(void);
 ndp_a6br_cache_t *ndp_a6br_cache_get_oldest(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* SIXLOWPAN_NDP_H */

--- a/sys/net/include/sixlowpan/types.h
+++ b/sys/net/include/sixlowpan/types.h
@@ -26,6 +26,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Data type to represent an EUI-64.
  */
@@ -393,6 +397,10 @@ typedef enum __attribute__((packed)) {
     NDP_ADDR_STATE_DEPRECATED,  ///< deprecated address, use discouraged.
     NDP_ADDR_STATE_ANY          ///< addresses of this state are always permitted.
 } ndp_addr_state_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* SIXLOWPAN_TYPES_H */

--- a/sys/net/include/socket_base.h
+++ b/sys/net/include/socket_base.h
@@ -37,4 +37,12 @@
 #include "socket_base/socket.h"
 #include "socket_base/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* SOCKET_BASE_H */

--- a/sys/net/include/socket_base/in.h
+++ b/sys/net/include/socket_base/in.h
@@ -29,6 +29,10 @@
 #ifndef SOCKET_BASE_IN_H
 #define SOCKET_BASE_IN_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Protocols (RFC 1700) TODO: may be deleted due to some double definition
  *                            in sys/net/sixlowpan/include/sixlowpan/ip.h
@@ -148,5 +152,9 @@
 #define IPPROTO_DONE            (257)             ///< last return value of *_input(), meaning "all job for this pkt is done".
 
 #define IN_LOOPBACKNET          (127)             ///< official!
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SOCKET_BASE_IN_H */

--- a/sys/net/include/socket_base/socket.h
+++ b/sys/net/include/socket_base/socket.h
@@ -28,6 +28,10 @@
 
 #include "socket_base/in.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef uint8_t sa_family_t;    ///< POSIX compatible type for address family.
 typedef uint32_t  socklen_t;    ///< POSIX compatible type for address length.
 
@@ -326,6 +330,10 @@ int socket_base_accept(int s, sockaddr6_t *addr, socklen_t *addrlen);
  * PIDs of the send and receive thread.
  */
 void socket_base_print_sockets(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/sys/net/include/socket_base/types.h
+++ b/sys/net/include/socket_base/types.h
@@ -18,6 +18,10 @@
 #define SOCKET_BASE_TYPES_H_
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * UDP packet header length
  */
@@ -68,6 +72,10 @@ typedef struct __attribute__((packed)) {
     uint16_t    checksum;
     uint16_t    urg_pointer;            ///< urgent pointer
 } tcp_hdr_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/sys/net/include/tcp.h
+++ b/sys/net/include/tcp.h
@@ -30,11 +30,19 @@
 #include "socket_base/socket.h"
 #include "socket_base/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Initializes tcp.
  *
  * @return 0 on success, other else.
  */
 int tcp_init_transport_layer(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TCP_H */

--- a/sys/net/include/udp.h
+++ b/sys/net/include/udp.h
@@ -30,11 +30,19 @@
 #include "socket_base/socket.h"
 #include "socket_base/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Initializes udp.
  *
  * @return 0 on success, other else.
  */
 int udp_init_transport_layer(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* UDP_H */

--- a/sys/net/network_layer/sixlowpan/border/border.h
+++ b/sys/net/network_layer/sixlowpan/border/border.h
@@ -29,6 +29,10 @@
 #include "ip.h"
 #include "semaphore.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern ipv6_addr_t *abr_addr;
 
 kernel_pid_t border_get_serial_reader(void);
@@ -37,5 +41,9 @@ uint8_t *get_serial_out_buffer(int offset);
 uint8_t *get_serial_in_buffer(int offset);
 
 void border_process_lowpan(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SIXLOWPAN_BORDER_H*/

--- a/sys/net/network_layer/sixlowpan/border/bordermultiplex.h
+++ b/sys/net/network_layer/sixlowpan/border/bordermultiplex.h
@@ -24,6 +24,10 @@
 
 #include "ip.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* packet types of uart-packets */
 #define BORDER_PACKET_RAW_TYPE    (0)
 #define BORDER_PACKET_CONF_TYPE   (2)
@@ -88,5 +92,9 @@ void multiplex_send_addr_over_uart(ipv6_addr_t *addr);
 
 int readpacket(uint8_t *packet_buf, size_t size);
 int writepacket(uint8_t *packet_buf, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SIXLOWPAN_BORDERMULTIPLEX_H*/

--- a/sys/net/network_layer/sixlowpan/border/flowcontrol.h
+++ b/sys/net/network_layer/sixlowpan/border/flowcontrol.h
@@ -28,6 +28,10 @@
 #include "border.h"
 #include "bordermultiplex.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* packet types for flowcontrol */
 #define BORDER_PACKET_ACK_TYPE    (1)
 
@@ -73,5 +77,9 @@ typedef struct __attribute__((packed)) {
 ipv6_addr_t flowcontrol_init(void);
 void flowcontrol_send_over_uart(border_packet_t *packet, int len);
 void flowcontrol_deliver_from_uart(border_packet_t *packet, int len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SIXLOWPAN_FLOWCONTROL_H*/

--- a/sys/net/network_layer/sixlowpan/icmp.h
+++ b/sys/net/network_layer/sixlowpan/icmp.h
@@ -32,6 +32,10 @@
 #include "lowpan.h"
 #include "ip.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum option_types_t {
     OPT_SLLAO = 1,
     OPT_TLLAO,
@@ -58,4 +62,9 @@ void nbr_cache_auto_rem(void);
 ndp_a6br_cache_t *abr_add_context(uint16_t version, ipv6_addr_t *abr_addr,
                                   uint8_t cid);
 void abr_remove_context(uint8_t cid);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* _SIXLOWPAN_ICMP_H*/

--- a/sys/net/network_layer/sixlowpan/ip.h
+++ b/sys/net/network_layer/sixlowpan/ip.h
@@ -33,6 +33,10 @@
 #include "sixlowpan/ip.h"
 #include "sixlowpan/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* IPv6 field values */
 #define IPV6_VER                    (0x60)
 /* size of global buffer */
@@ -98,5 +102,9 @@ ipv6_net_if_hit_t *ipv6_net_if_addr_prefix_eq(ipv6_net_if_hit_t *hit, ipv6_addr_
 ipv6_net_if_hit_t *ipv6_net_if_addr_match(ipv6_net_if_hit_t *hit, const ipv6_addr_t *addr);
 uint32_t get_remaining_time(timex_t *t);
 void set_remaining_time(timex_t *t, uint32_t time);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SIXLOWPAN_IP_H*/

--- a/sys/net/network_layer/sixlowpan/lowpan.h
+++ b/sys/net/network_layer/sixlowpan/lowpan.h
@@ -25,6 +25,10 @@
 
 #include "sixlowpan/lowpan.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define IEEE802154_TRANSCEIVER      (TRANSCEIVER_AT86RF231 | TRANSCEIVER_CC2420 | TRANSCEIVER_MC1322X)
 
 typedef struct {
@@ -47,5 +51,9 @@ lowpan_context_t *lowpan_context_update(uint8_t num,
                                         uint16_t lifetime);
 lowpan_context_t *lowpan_context_get(void);
 lowpan_context_t *lowpan_context_num_lookup(uint8_t num);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* _SIXLOWPAN_LOWPAN_H */

--- a/sys/net/network_layer/sixlowpan/serialnumber.h
+++ b/sys/net/network_layer/sixlowpan/serialnumber.h
@@ -14,6 +14,10 @@
 #define _SIXLOWPAN_SERIALNUMBER_H
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef enum serial_comp_res_t {
     LESS = 0,
     EQUAL = 1,
@@ -86,5 +90,9 @@ serial_comp_res_t serial_comp16(uint16_t s1, uint16_t s2);
  *          else UNDEF (see RFC1982 section 3.2).
  **/
 serial_comp_res_t serial_comp32(uint32_t s1, uint32_t s2);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SIXLOWPAN_SERIALNUMBER_H*/

--- a/sys/net/routing/rpl/of0.h
+++ b/sys/net/routing/rpl/of0.h
@@ -12,6 +12,14 @@
 #include "rpl/rpl_structs.h"
 #include "rpl/rpl_config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 rpl_of_t *rpl_get_of0(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* OF0_H */

--- a/sys/net/routing/rpl/of_mrhof.h
+++ b/sys/net/routing/rpl/of_mrhof.h
@@ -12,6 +12,10 @@
 #include "rpl/rpl_structs.h"
 #include "rpl/rpl_config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Disallow links with greater than 4 expected
  * transmission counts on the selected path.
@@ -45,5 +49,9 @@
 #define ETX_RANK_MULTIPLIER (0x80)
 
 rpl_of_t *rpl_get_of_mrhof(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* OF_MRHOF_H */

--- a/sys/net/routing/rpl/trickle.h
+++ b/sys/net/routing/rpl/trickle.h
@@ -18,6 +18,10 @@
 #include "vtimer.h"
 #include "thread.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define TRICKLE_TIMER_STACKSIZE (KERNEL_CONF_STACKSIZE_MAIN)
 #define TRICKLE_INTERVAL_STACKSIZE (KERNEL_CONF_STACKSIZE_MAIN)
 #define DAO_DELAY_STACKSIZE (KERNEL_CONF_STACKSIZE_MAIN)
@@ -29,3 +33,7 @@ void start_trickle(uint8_t DIOINtMin, uint8_t DIOIntDoubl, uint8_t DIORedundancy
 void trickle_increment_counter(void);
 void delay_dao(void);
 void dao_ack_received(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/sys/net/transport_layer/socket_base/msg_help.h
+++ b/sys/net/transport_layer/socket_base/msg_help.h
@@ -16,6 +16,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Function IDs
 #define FID_SIXLOWIP_TCP                0
 #define FID_SIXLOWIP_UDP                1
@@ -39,6 +43,10 @@ int socket_base_net_msg_receive(msg_t *m);
 int socket_base_net_msg_reply(msg_t *m, msg_t *reply, uint16_t message);
 int socket_base_net_msg_send(msg_t *m, kernel_pid_t pid, bool block, uint16_t message);
 int socket_base_net_msg_send_recv(msg_t *m, msg_t *reply, kernel_pid_t pid, uint16_t message);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* MSG_HELP_H_ */
 /**

--- a/sys/net/transport_layer/socket_base/socket.h
+++ b/sys/net/transport_layer/socket_base/socket.h
@@ -90,10 +90,18 @@ typedef struct {
 
 extern socket_internal_t socket_base_sockets[MAX_SOCKETS];
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 socket_internal_t *socket_base_get_socket(int s);
 uint16_t socket_base_get_free_source_port(uint8_t protocol);
 int socket_base_exists_socket(int socket);
 int socket_base_socket(int domain, int type, int protocol);
 void socket_base_print_sockets(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SOCKET_BASE_SOCKET */

--- a/sys/net/transport_layer/tcp/tcp.h
+++ b/sys/net/transport_layer/tcp/tcp.h
@@ -21,6 +21,10 @@
 #include "socket_base/types.h"
 #include "socket.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define TCP_EOO_OPTION          (0x00)        /* End of option list */
 #define TCP_NOP_OPTION          (0x01)        /* No operation */
 #define TCP_MSS_OPTION          (0x02)        /* Maximum segment size */
@@ -107,6 +111,10 @@ int tcp_listen(int s, int backlog);
 int32_t tcp_recv(int s, void *buf, uint32_t len, int flags);
 bool tcp_socket_compliancy(int s);
 int tcp_teardown(socket_internal_t *current_socket);
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/sys/net/transport_layer/tcp/tcp_hc.h
+++ b/sys/net/transport_layer/tcp/tcp_hc.h
@@ -20,6 +20,10 @@
 
 #include "tcp.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef TCP_HC
 
 #define FULL_HEADER                 1
@@ -30,6 +34,11 @@ void update_tcp_hc_context(bool incoming, socket_internal_t *current_socket, tcp
 uint16_t compress_tcp_packet(socket_internal_t *current_socket, uint8_t *current_tcp_packet, ipv6_hdr_t *temp_ipv6_header, uint8_t flags, uint8_t payload_length);
 socket_internal_t *decompress_tcp_packet(ipv6_hdr_t *temp_ipv6_header);
 #endif
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* TCP_HC_H_ */
 /**
  * @}

--- a/sys/net/transport_layer/tcp/tcp_timer.h
+++ b/sys/net/transport_layer/tcp/tcp_timer.h
@@ -15,6 +15,10 @@
 #ifndef TCP_TIMER_H_
 #define TCP_TIMER_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define TCP_TIMER_RESOLUTION        500*1000
 
 #define SECOND                      1000.0f*1000.0f
@@ -34,6 +38,10 @@
 #define TCP_CONTINUE                3
 
 void *tcp_general_timer(void *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TCP_TIMER_H_ */
 /**

--- a/sys/net/transport_layer/udp/udp.h
+++ b/sys/net/transport_layer/udp/udp.h
@@ -21,6 +21,10 @@
 #include "ipv6.h"
 #include "socket_base/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define UDP_STACK_SIZE                  KERNEL_CONF_STACKSIZE_MAIN
 #define UDP_PKT_RECV_BUF_SIZE           (64)
 
@@ -30,6 +34,10 @@ int32_t udp_sendto(int s, const void *buf, uint32_t len, int flags, sockaddr6_t 
 bool udp_socket_compliancy(int s);
 int32_t udp_recvfrom(int s, void *buf, uint32_t len, int flags, sockaddr6_t *from, uint32_t *fromlen);
 int32_t udp_sendto(int s, const void *buf, uint32_t len, int flags, sockaddr6_t *to, socklen_t tolen);
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/sys/oneway-malloc/include/malloc.h
+++ b/sys/oneway-malloc/include/malloc.h
@@ -28,6 +28,10 @@
 
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief       Allocation a block of memory.
  * @param[in]   size   Size of the block to allocate in bytes.
@@ -64,6 +68,10 @@ void *calloc(int size, size_t cnt);
  * @param[in]   ptr   The ignored argument.
  */
 void free(void *ptr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __MALLOC_H */
 

--- a/sys/posix/include/semaphore.h
+++ b/sys/posix/include/semaphore.h
@@ -3,10 +3,14 @@
 
 #include <time.h>
 
+#include "priority_queue.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** Value returned if `sem_open' failed.  */
 #define SEM_FAILED      ((sem_t *) 0)
-
-#include "priority_queue.h"
 
 typedef struct sem {
     volatile unsigned int value;
@@ -97,5 +101,9 @@ int sem_post(sem_t *sem);
  * @param sval place whre value goes to
  */
 int sem_getvalue(sem_t *sem, int *sval);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* semaphore.h */

--- a/sys/posix/include/strings.h
+++ b/sys/posix/include/strings.h
@@ -25,6 +25,10 @@
 #include <sys/types.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   Returns the position of the first (least significant) bit set in
  *          integer *i*, or 0 if no bits are set in i.
@@ -114,5 +118,9 @@ int strncasecmp(const char *s1, const char *s2, size_t n);
  *      </a>
  */
 #define strcasecmp_l(s1, s2, l) strncasecmp(s1, s2, -1)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* STRINGS_H */

--- a/sys/posix/include/unistd.h
+++ b/sys/posix/include/unistd.h
@@ -28,6 +28,10 @@
 #include "timex.h"
 #include "vtimer.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define STDIN_FILENO    0   ///< stdin file descriptor
 #define STDOUT_FILENO   1   ///< stdout file descriptor
 #define STDERR_FILENO   2   ///< stderr file descriptor
@@ -99,6 +103,10 @@ int usleep(useconds_t useconds);
  * @return          0 on success
  */
 unsigned int sleep(unsigned int seconds);
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/sys/posix/pnet/include/arpa/inet.h
+++ b/sys/posix/pnet/include/arpa/inet.h
@@ -29,6 +29,10 @@
 #include "inet_ntop.h"
 #include "inet_pton.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef uint16_t in_port_t;     ///< Internet port type
 typedef uint32_t in_addr_t;     ///< IPv4 address type
 
@@ -93,6 +97,10 @@ struct in_addr {
  *                      order.
  */
 #define ntohs(netshort)     NTOHS(netshort)
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/sys/posix/pnet/include/netinet/in.h
+++ b/sys/posix/pnet/include/netinet/in.h
@@ -29,6 +29,10 @@
 #include "ipv6.h"
 #include "socket_base/socket.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * IPv4 socket address type.
  */
@@ -150,6 +154,10 @@ extern const struct sockaddr_in6 in6addr_loopback;
  * @return  1 if *a* is an multicast address, 0 if not.
  */
 #define IN6_IS_ADDR_MULTICAST(a) (((const uint8_t *) (a))[0] == 0xff)
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/sys/posix/pnet/include/sys/socket.h
+++ b/sys/posix/pnet/include/sys/socket.h
@@ -38,6 +38,10 @@
 
 #include "socket_base/socket.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   Used to define the socket address.
  */
@@ -463,6 +467,10 @@ int setsockopt(int socket, int level, int option_name, const void *option_value,
  *          be returned and errno set to indicate the error.
  */
 int socket(int domain, int type, int protocol);
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}

--- a/sys/posix/pthread/include/pthread.h
+++ b/sys/posix/pthread/include/pthread.h
@@ -32,6 +32,14 @@
 #include "pthread_cancellation.h"
 #include "pthread_cond.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif
 
 /**

--- a/sys/posix/pthread/include/pthread_barrier.h
+++ b/sys/posix/pthread/include/pthread_barrier.h
@@ -11,6 +11,10 @@
 
 #include "mutex.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @def     PTHREAD_PROCESS_SHARED
  * @brief   Share the structure with child processes (default).
@@ -119,6 +123,10 @@ int pthread_barrierattr_getpshared(const pthread_barrierattr_t *attr, int *pshar
  * @returns   0, the invocation cannot fail
  */
 int pthread_barrierattr_setpshared(pthread_barrierattr_t *attr, int pshared);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/sys/posix/pthread/include/pthread_cancellation.h
+++ b/sys/posix/pthread/include/pthread_cancellation.h
@@ -10,6 +10,10 @@
 #ifndef __SYS__POSIX__PTHREAD_CANCELLCATION__H
 #define __SYS__POSIX__PTHREAD_CANCELLCATION__H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define PTHREAD_CANCEL_DISABLE 0
 #define PTHREAD_CANCEL_ENABLE  1
 
@@ -49,6 +53,10 @@ int pthread_cancel(pthread_t th);
  * @details      If pthread_cancel() called before, the current thread exits with with the code #PTHREAD_CANCELED.
  */
 void pthread_testcancel(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/sys/posix/pthread/include/pthread_cleanup.h
+++ b/sys/posix/pthread/include/pthread_cleanup.h
@@ -9,6 +9,10 @@
 #ifndef __SYS__POSIX__PTHREAD_CLEANUP__H
 #define __SYS__POSIX__PTHREAD_CLEANUP__H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   Internal structure for pthread_cleanup_push()
  */
@@ -78,6 +82,10 @@ void __pthread_cleanup_pop(__pthread_cleanup_datum_t *datum, int execute);
         } while (0); \
         __pthread_cleanup_pop(&____datum__, ____execute__); \
     } while (0)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/sys/posix/pthread/include/pthread_cond.h
+++ b/sys/posix/pthread/include/pthread_cond.h
@@ -24,6 +24,10 @@
 #   include "msp430_types.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @note condition attributes are currently NOT USED in RIOT condition variables
  */
@@ -131,6 +135,10 @@ int pthread_cond_signal(struct pthread_cond_t *cond);
  * @return returns 0 on success, an errorcode otherwise.
  */
 int pthread_cond_broadcast(struct pthread_cond_t *cond);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* _CONDITION_VARIABLE_H */

--- a/sys/posix/pthread/include/pthread_mutex.h
+++ b/sys/posix/pthread/include/pthread_mutex.h
@@ -14,6 +14,10 @@
 #include "kernel.h"
 #include "mutex.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief           Pthread mutexes are quite the same as RIOT mutexes.
  * @details         Recursive locking is not supported.
@@ -96,6 +100,10 @@ int pthread_mutex_getprioceiling(const pthread_mutex_t *mutex, int *prioceiling)
  * @return          Well ... you'll get a link time error, so nothing will be returned.
  */
 int pthread_mutex_setprioceiling(pthread_mutex_t *mutex, int prioceiling, int *old_ceiling);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/sys/posix/pthread/include/pthread_mutex_attr.h
+++ b/sys/posix/pthread/include/pthread_mutex_attr.h
@@ -11,6 +11,10 @@
 
 #include <errno.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @def             PTHREAD_MUTEX_NORMAL
  * @brief           A non-error correcting mutex (default).
@@ -198,6 +202,10 @@ int pthread_mutexattr_getrobust(const pthread_mutexattr_t *attr, int *robustness
  *                  `EINVAL` if `attr == NULL`.
  */
 int pthread_mutexattr_setrobust(pthread_mutexattr_t *attr, int robustness);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/sys/posix/pthread/include/pthread_once.h
+++ b/sys/posix/pthread/include/pthread_once.h
@@ -9,6 +9,10 @@
 #ifndef __SYS__POSIX__PTHREAD_ONCE__H
 #define __SYS__POSIX__PTHREAD_ONCE__H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief           Datatype to supply to pthread_once().
  */
@@ -31,6 +35,10 @@ typedef volatile int pthread_once_t;
  * @returns         0, this invocation cannot fail.
  */
 int pthread_once(pthread_once_t *once_control, void (*init_routine)(void));
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/sys/posix/pthread/include/pthread_rwlock.h
+++ b/sys/posix/pthread/include/pthread_rwlock.h
@@ -15,6 +15,10 @@
 #include <errno.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief     A fair reader writer lock.
  * @details   The implementation ensures that readers and writers of the same priority
@@ -160,6 +164,10 @@ bool __pthread_rwlock_blocked_readingly(const pthread_rwlock_t *rwlock);
  * @returns          `false` if locking for writing is possible without blocking.
  */
 bool __pthread_rwlock_blocked_writingly(const pthread_rwlock_t *rwlock);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/sys/posix/pthread/include/pthread_rwlock_attr.h
+++ b/sys/posix/pthread/include/pthread_rwlock_attr.h
@@ -11,6 +11,10 @@
 
 #include <errno.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief     Attributes for a new reader/writer lock.
  * @details   The options set in this struct will be ignored by pthread_rwlock_init().
@@ -63,6 +67,10 @@ int pthread_rwlockattr_getpshared(const pthread_rwlockattr_t *attr, int *pshared
  *                  `EINVAL` if `attr == NULL` or a wrong value for `pshared` was supplied.
  */
 int pthread_rwlockattr_setpshared(pthread_rwlockattr_t *attr, int pshared);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/sys/posix/pthread/include/pthread_scheduling.h
+++ b/sys/posix/pthread/include/pthread_scheduling.h
@@ -10,6 +10,10 @@
 #ifndef __SYS__POSIX__PTHREAD_SCHEDULING__H
 #define __SYS__POSIX__PTHREAD_SCHEDULING__H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief           Unimplemented.
  * @note            Due to the native of RIOT it is unlikely that this function will ever be implemented.
@@ -38,6 +42,10 @@ int pthread_getschedparam(pthread_t target_thread, int *policy, struct sched_par
  * @returns         The function is unimplemented. Using it will cause a link time error.
  */
 int pthread_setschedprio(pthread_t target_thread, int prio);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/sys/posix/pthread/include/pthread_spin.h
+++ b/sys/posix/pthread/include/pthread_spin.h
@@ -14,6 +14,10 @@
 
 #include <errno.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief           A spinlock.
  * @warning         Spinlocks should be avoided.
@@ -72,6 +76,10 @@ int pthread_spin_trylock(pthread_spinlock_t *lock);
  *                  `EINVAL` if `lock == NULL`.
  */
 int pthread_spin_unlock(pthread_spinlock_t *lock);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/sys/posix/pthread/include/pthread_threading.h
+++ b/sys/posix/pthread/include/pthread_threading.h
@@ -11,6 +11,10 @@
 
 #include "attributes.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief        Datatype to identify a POSIX thread.
  * @note         The pthread ids are one off to the index in the internal array.
@@ -90,6 +94,10 @@ static inline int pthread_equal(pthread_t thread1, pthread_t thread2)
 {
     return thread1 == thread2;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/sys/posix/pthread/include/pthread_threading_attr.h
+++ b/sys/posix/pthread/include/pthread_threading_attr.h
@@ -9,6 +9,10 @@
 #ifndef __SYS__POSIX__PTHREAD_THREADING_ATTR__H
 #define __SYS__POSIX__PTHREAD_THREADING_ATTR__H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief     An attribute set to supply to pthread_create()
  * @details   A zeroed out datum is default initiliazed.
@@ -188,6 +192,10 @@ int pthread_attr_getstacksize(const pthread_attr_t *attr, size_t *stacksize);
  * @return          0, this invocation cannot fail.
  */
 int pthread_attr_setstacksize(pthread_attr_t *attr, size_t stacksize);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/sys/quad_math/quad.h
+++ b/sys/quad_math/quad.h
@@ -53,6 +53,11 @@
 #include <limits.h>
 
 #include <machine/endian.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef char ___QUAD_ASSERT__LENGHTS[sizeof (long long) == 2*sizeof (int) ? +1 : -1];
 typedef char ___QUAD_ASSERT__2COMPLEMENT[-1234 == (~1234 + 1) ? +1 : -1];
 
@@ -138,3 +143,7 @@ int __ucmpdi2(u_quad_t, u_quad_t);
 u_quad_t __udivdi3(u_quad_t, u_quad_t );
 u_quad_t __umoddi3(u_quad_t, u_quad_t );
 quad_t __xordi3(quad_t, quad_t);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This PR adds extern "C" for the header files in `./RIOT/sys/*` folders.
