### PR TITLE
udp: fix byte order in sockaddr6_t

### DIFF
--- a/sys/net/transport_layer/udp/udp.c
+++ b/sys/net/transport_layer/udp/udp.c
@@ -155,7 +155,7 @@ int32_t udp_recvfrom(int s, void *buf, uint32_t len, int flags, sockaddr6_t *fro
     memcpy(&from->sin6_addr, &ipv6_header->srcaddr, 16);
     from->sin6_family = AF_INET6;
     from->sin6_flowinfo = 0;
-    from->sin6_port = NTOHS(udp_header->src_port);
+    from->sin6_port = udp_header->src_port;
     *fromlen = sizeof(sockaddr6_t);
 
     msg_reply(&m_recv, &m_send);


### PR DESCRIPTION
udp_recvfrom wrote the sender port number in host byte order into the
provided sockaddr6_t. Because all send functions expect the port number
in network byte order this introduces a superfluous conversion step in
case one wants to reuse the address for replying.

closes #1406
was #1585
