### PR TITLE
Fixes when a packet is not for me, but an interface is defined.

### DIFF
--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -378,7 +378,7 @@ void *ipv6_process(void *arg)
         int addr_match = is_our_address(&ipv6_buf->destaddr);
 
         /* no address configured for this node so far, exit early */
-        if (addr_match < 1) {
+        if (addr_match < 0) {
             msg_reply(&m_recv_lowpan, &m_send_lowpan);
             continue;
         }


### PR DESCRIPTION
It´s just wrong logic as it is now - likely self-explainable. It should only ignore handling the packet, if no interface is defined, which means, the int variable is less than zero.
