### PR TITLE
fix in ieee 802.15.4 frame

### DIFF
--- a/sys/net/link_layer/ieee802154/ieee802154_frame.c
+++ b/sys/net/link_layer/ieee802154/ieee802154_frame.c
@@ -186,9 +186,11 @@ uint8_t ieee802154_frame_read(uint8_t *buf, ieee802154_frame_t *frame,
 
     index++;
 
-    frame->dest_pan_id = (((uint16_t)buf[index]) << 8) | buf[index + 1];
-
-    index += 2;
+    if(frame->fcf.dest_addr_m != 0)
+    {
+        frame->dest_pan_id = (((uint16_t)buf[index]) << 8) | buf[index + 1];
+        index += 2;
+    }
 
     switch (frame->fcf.dest_addr_m) {
         case (0): {
@@ -220,8 +222,11 @@ uint8_t ieee802154_frame_read(uint8_t *buf, ieee802154_frame_t *frame,
     }
 
     if (!(frame->fcf.panid_comp == 1)) {
-        frame->src_pan_id = (((uint16_t)buf[index]) << 8) | buf[index + 1];
-        index += 2;
+        if(frame->fcf.src_addr_m != 0)
+        {
+            frame->src_pan_id = (((uint16_t)buf[index]) << 8) | buf[index + 1];
+            index += 2;
+        }
     }
 
     switch (frame->fcf.src_addr_m) {


### PR DESCRIPTION
According to the standard, if address mode is 0; the header will not include pan identifier. This is for both source and destination.
