### PR TITLE
cpu: added `extern "C"` to headers

### DIFF
--- a/cpu/arm7_common/include/VIC.h
+++ b/cpu/arm7_common/include/VIC.h
@@ -9,7 +9,7 @@
 #define __ARM_COMMON_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**

--- a/cpu/arm7_common/include/arm7_common.h
+++ b/cpu/arm7_common/include/arm7_common.h
@@ -27,7 +27,7 @@
 #include "bitarithm.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**

--- a/cpu/arm7_common/include/hwtimer_cpu.h
+++ b/cpu/arm7_common/include/hwtimer_cpu.h
@@ -20,7 +20,7 @@
 #define HWTIMER_CPU_H_
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 #define HWTIMER_MAXTIMERS 4

--- a/cpu/arm7_common/include/iap.h
+++ b/cpu/arm7_common/include/iap.h
@@ -12,7 +12,7 @@
 #include <stdint.h>
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* IAP-Commands  */

--- a/cpu/atmega2560/include/cpu-conf.h
+++ b/cpu/atmega2560/include/cpu-conf.h
@@ -20,6 +20,9 @@
 #define __CPU_CONF_H
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @name Kernel configuration
@@ -47,6 +50,10 @@
 #define UART0_BUFSIZE                   (128)
 #endif
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CPU_CONF_H */
 /** @} */

--- a/cpu/atmega2560/include/hwtimer_cpu.h
+++ b/cpu/atmega2560/include/hwtimer_cpu.h
@@ -19,6 +19,10 @@
 #ifndef __HWTIMER_CPU_H
 #define __HWTIMER_CPU_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Hardware timer configuration
  * @{
@@ -27,6 +31,10 @@
 #define HWTIMER_SPEED       1000000     /**< the HW timer runs with 1MHz */
 #define HWTIMER_MAXTICKS    (0xFFFF)    /**< 16-bit timer */
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __HWTIMER_CPU_H */
 /** @} */

--- a/cpu/atmega_common/avr-libc-extra/time.h
+++ b/cpu/atmega_common/avr-libc-extra/time.h
@@ -101,12 +101,12 @@
 #ifndef TIME_H
 #define TIME_H
 
-#ifdef __cplusplus
-extern          "C" {
-#endif
-
 #include <inttypes.h>
 #include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
     /** \ingroup avr_time */
     /* @{ */

--- a/cpu/atmega_common/include/cpu.h
+++ b/cpu/atmega_common/include/cpu.h
@@ -33,6 +33,11 @@
  * TODO: remove once core was adjusted
  */
 #include "irq.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define eINT            enableIRQ
 #define dINT            disableIRQ
 
@@ -41,6 +46,9 @@
  */
 void cpu_init(void);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ATMEGA_COMMON_H */
 /** @} */

--- a/cpu/atmega_common/include/sys/time.h
+++ b/cpu/atmega_common/include/sys/time.h
@@ -9,7 +9,15 @@
 
 #include <sys/types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct timeval {
     time_t         tv_sec;
     suseconds_t    tv_usec;
 };
+
+#ifdef __cplusplus
+}
+#endif

--- a/cpu/atmega_common/include/sys/types.h
+++ b/cpu/atmega_common/include/sys/types.h
@@ -12,7 +12,15 @@
 #ifndef AVR_TYPES_H
 #define AVR_TYPES_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef int16_t suseconds_t;
 typedef signed int ssize_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ifndef AVR_TYPES_H */

--- a/cpu/cc430/include/cc430-adc.h
+++ b/cpu/cc430/include/cc430-adc.h
@@ -36,9 +36,17 @@
 #ifndef CC430_ADC_H
 #define CC430_ADC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern uint16_t adc12_single_conversion(uint16_t ref, uint16_t sht, uint16_t channel);
 
 extern uint16_t adc12_result;
 extern uint8_t  adc12_data_ready;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/cpu/cc430/include/cc430-rtc.h
+++ b/cpu/cc430/include/cc430-rtc.h
@@ -11,6 +11,10 @@
 #include "rtc.h"
 #include "time.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup     cc430
  */
@@ -52,5 +56,8 @@ void rtc_set_alarm(struct tm *localti, rtc_alarm_mask_t mask);
  */
 void rtc_remove_alarm(void);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/cpu/cortex-m0_common/include/core_cm0.h
+++ b/cpu/cortex-m0_common/include/core_cm0.h
@@ -123,9 +123,17 @@
   #endif
 #endif
 
+#ifdef __cplusplus
+}
+#endif
+
 #include <stdint.h>                      /* standard types definitions                      */
 #include <core_cmInstr.h>                /* Core Instruction Access                         */
 #include <core_cmFunc.h>                 /* Core Function Access                            */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #endif /* __CORE_CM0_H_GENERIC */
 

--- a/cpu/cortex-m0_common/include/core_cm0plus.h
+++ b/cpu/cortex-m0_common/include/core_cm0plus.h
@@ -107,9 +107,17 @@
   #endif
 #endif
 
+#ifdef __cplusplus
+}
+#endif
+
 #include <stdint.h>                      /* standard types definitions                      */
 #include <core_cmInstr.h>                /* Core Instruction Access                         */
 #include <core_cmFunc.h>                 /* Core Function Access                            */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #endif /* __CORE_CM0PLUS_H_GENERIC */
 

--- a/cpu/cortex-m0_common/include/core_cmFunc.h
+++ b/cpu/cortex-m0_common/include/core_cmFunc.h
@@ -23,6 +23,9 @@
 #ifndef __CORE_CMFUNC_H
 #define __CORE_CMFUNC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* ###########################  Core Function Access  ########################### */
 /** \ingroup  CMSIS_Core_FunctionInterface   
@@ -604,5 +607,8 @@ __attribute__( ( always_inline ) ) static __INLINE void __set_FPSCR(uint32_t fps
 
 /*@} end of CMSIS_Core_RegAccFunctions */
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CORE_CMFUNC_H */

--- a/cpu/cortex-m0_common/include/core_cmInstr.h
+++ b/cpu/cortex-m0_common/include/core_cmInstr.h
@@ -23,6 +23,9 @@
 #ifndef __CORE_CMINSTR_H
 #define __CORE_CMINSTR_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* ##########################  Core Instruction Access  ######################### */
 /** \defgroup CMSIS_Core_InstructionInterface CMSIS Core Instruction Interface
@@ -580,5 +583,9 @@ __attribute__( ( always_inline ) ) static __INLINE uint8_t __CLZ(uint32_t value)
 #endif
 
 /*@}*/ /* end of group CMSIS_Core_InstructionInterface */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CORE_CMINSTR_H */

--- a/cpu/cortex-m0_common/include/cpu.h
+++ b/cpu/cortex-m0_common/include/cpu.h
@@ -33,6 +33,11 @@
  * TODO: remove once core was adjusted
  */
 #include "irq.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define eINT            enableIRQ
 #define dINT            disableIRQ
 
@@ -40,6 +45,10 @@
  * @brief Initialization of the CPU
  */
 void cpu_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CPU_H */
 /** @} */

--- a/cpu/cortex-m3_common/include/core_cm3.h
+++ b/cpu/cortex-m3_common/include/core_cm3.h
@@ -117,9 +117,17 @@
     /* add preprocessor checks */
 #endif
 
+#ifdef __cplusplus
+}
+#endif
+
 #include <stdint.h>                      /*!< standard types definitions                      */
 #include "core_cmInstr.h"                /*!< Core Instruction Access                         */
 #include "core_cmFunc.h"                 /*!< Core Function Access                            */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #endif /* __CORE_CM3_H_GENERIC */
 

--- a/cpu/cortex-m3_common/include/core_cmFunc.h
+++ b/cpu/cortex-m3_common/include/core_cmFunc.h
@@ -23,6 +23,9 @@
 #ifndef __CORE_CMFUNC_H
 #define __CORE_CMFUNC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* ###########################  Core Function Access  ########################### */
 /** \ingroup  CMSIS_Core_FunctionInterface
@@ -604,5 +607,8 @@ __attribute__( ( always_inline ) ) static __INLINE void __set_FPSCR(uint32_t fps
 
 /*@} end of CMSIS_Core_RegAccFunctions */
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CORE_CMFUNC_H */

--- a/cpu/cortex-m3_common/include/core_cmInstr.h
+++ b/cpu/cortex-m3_common/include/core_cmInstr.h
@@ -23,6 +23,9 @@
 #ifndef __CORE_CMINSTR_H
 #define __CORE_CMINSTR_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* ##########################  Core Instruction Access  ######################### */
 /** \defgroup CMSIS_Core_InstructionInterface CMSIS Core Instruction Interface
@@ -580,5 +583,9 @@ __attribute__( ( always_inline ) ) static __INLINE uint8_t __CLZ(uint32_t value)
 #endif
 
 /*@}*/ /* end of group CMSIS_Core_InstructionInterface */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CORE_CMINSTR_H */

--- a/cpu/cortex-m3_common/include/cpu.h
+++ b/cpu/cortex-m3_common/include/cpu.h
@@ -30,6 +30,11 @@
  * TODO: remove once core was adjusted
  */
 #include "irq.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define eINT            enableIRQ
 #define dINT            disableIRQ
 
@@ -38,6 +43,9 @@
  */
 void cpu_init(void);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CORTEXM_COMMON_H */
 /** @} */

--- a/cpu/cortex-m4_common/include/core_cm4.h
+++ b/cpu/cortex-m4_common/include/core_cm4.h
@@ -165,10 +165,18 @@
   #endif
 #endif
 
+#ifdef __cplusplus
+}
+#endif
+
 #include <stdint.h>                      /* standard types definitions                      */
 #include <core_cmInstr.h>                /* Core Instruction Access                         */
 #include <core_cmFunc.h>                 /* Core Function Access                            */
 #include <core_cm4_simd.h>               /* Compiler specific SIMD Intrinsics               */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #endif /* __CORE_CM4_H_GENERIC */
 

--- a/cpu/cortex-m4_common/include/core_cmFunc.h
+++ b/cpu/cortex-m4_common/include/core_cmFunc.h
@@ -23,6 +23,9 @@
 #ifndef __CORE_CMFUNC_H
 #define __CORE_CMFUNC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* ###########################  Core Function Access  ########################### */
 /** \ingroup  CMSIS_Core_FunctionInterface   
@@ -604,5 +607,8 @@ __attribute__( ( always_inline ) ) static __INLINE void __set_FPSCR(uint32_t fps
 
 /*@} end of CMSIS_Core_RegAccFunctions */
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CORE_CMFUNC_H */

--- a/cpu/cortex-m4_common/include/core_cmInstr.h
+++ b/cpu/cortex-m4_common/include/core_cmInstr.h
@@ -23,6 +23,9 @@
 #ifndef __CORE_CMINSTR_H
 #define __CORE_CMINSTR_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* ##########################  Core Instruction Access  ######################### */
 /** \defgroup CMSIS_Core_InstructionInterface CMSIS Core Instruction Interface
@@ -580,5 +583,9 @@ __attribute__( ( always_inline ) ) static __INLINE uint8_t __CLZ(uint32_t value)
 #endif
 
 /*@}*/ /* end of group CMSIS_Core_InstructionInterface */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CORE_CMINSTR_H */

--- a/cpu/cortex-m4_common/include/cpu.h
+++ b/cpu/cortex-m4_common/include/cpu.h
@@ -32,6 +32,11 @@
  * TODO: remove once core was adjusted
  */
 #include "irq.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define eINT            enableIRQ
 #define dINT            disableIRQ
 
@@ -39,6 +44,10 @@
  * @brief Initialization of the CPU
  */
 void cpu_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CORTEXM_COMMON_H */
 /** @} */

--- a/cpu/lpc1768/include/LPC17xx.h
+++ b/cpu/lpc1768/include/LPC17xx.h
@@ -98,9 +98,15 @@ typedef enum IRQn
 #define __NVIC_PRIO_BITS          5         /*!< Number of Bits used for Priority Levels          */
 #define __Vendor_SysTickConfig    0         /*!< Set to 1 if different SysTick Config is used     */
 
+#ifdef __cplusplus
+}
+#endif
 
 #include "core_cm3.h"                       /* Cortex-M3 processor and core peripherals           */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /******************************************************************************/
 /*                Device Specific Peripheral registers structures             */

--- a/cpu/lpc2387/include/cpu-conf.h
+++ b/cpu/lpc2387/include/cpu-conf.h
@@ -10,6 +10,10 @@
 #ifndef CPUCONF_H_
 #define CPUCONF_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup     conf
  * @ingroup     lpc2387
@@ -66,6 +70,9 @@
 #define UART0_BUFSIZE                   (128)
 #endif
 
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* CPUCONF_H_ */

--- a/cpu/lpc2387/include/cpu.h
+++ b/cpu/lpc2387/include/cpu.h
@@ -20,10 +20,18 @@
 #include "lpc2387.h"
 #include "arm_cpu.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern uintptr_t __stack_start;     ///< end of user stack memory space
 
 void lpc2387_pclk_scale(uint32_t source, uint32_t target, uint32_t *pclksel, uint32_t *prescale);
 bool install_irq(int IntNumber, void (*HandlerAddr)(void), int Priority);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __CPU_H */

--- a/cpu/lpc2387/include/i2c.h
+++ b/cpu/lpc2387/include/i2c.h
@@ -34,6 +34,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define I2C_BUFSIZE             0x23
 #define MAX_TIMEOUT             0x00FFFFFF
 
@@ -325,5 +329,9 @@ void i2c_enable_pull_up_resistor(uint8_t i2c_interface);
  *                              open-drain pins without pull-up/down.
  */
 void i2c_disable_pull_up_resistor(uint8_t i2c_interface);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* end __I2C_H */

--- a/cpu/lpc2387/include/lpc2387-adc.h
+++ b/cpu/lpc2387/include/lpc2387-adc.h
@@ -29,6 +29,10 @@
 #include <stdint.h>
 #include "adc_legacy.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define ADC_NUM                  (6)
 #define ADC_OFFSET            (0x10)
 #define ADC_INDEX                (4)
@@ -41,6 +45,10 @@
  */
 void adc_init_1(void);
 void adc_init_2(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* LPC2387ADC_H_ */

--- a/cpu/lpc2387/include/lpc2387-rtc.h
+++ b/cpu/lpc2387/include/lpc2387-rtc.h
@@ -35,6 +35,10 @@
 #include "rtc.h"
 #include "lpc2387.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ------------------------------------------------------------------------- */
 /**
  * @name LPC2387 RTC Compile-Time Configuration
@@ -103,6 +107,10 @@ void rtc_set_alarm(struct tm *localt, enum rtc_alarm_mask mask);
  * @see ::rtc_alarm_mask
  */
 enum rtc_alarm_mask _rtc_get_alarm(struct tm *localt);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* end __RTC_H */

--- a/cpu/lpc2387/include/lpc2387.h
+++ b/cpu/lpc2387/include/lpc2387.h
@@ -14,6 +14,10 @@
 #include "lpc23xx.h"
 #include "bitarithm.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define F_CCO                   288000000
 #define CL_CPU_DIV              4                                   ///< CPU clock divider
 #define F_CPU                   (F_CCO / CL_CPU_DIV)                ///< CPU target speed in Hz
@@ -207,5 +211,9 @@
 #define TXCTCR         0x70
 /** @} */
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // __LPC2387_H

--- a/cpu/lpc2387/include/lpc23xx.h
+++ b/cpu/lpc2387/include/lpc23xx.h
@@ -15,6 +15,10 @@
 #ifndef __LPC23xx_H
 #define __LPC23xx_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Vectored Interrupt Controller (VIC) */
 #define VIC_BASE_ADDR   0xFFFFF000
 #define VICIRQStatus   (*(volatile unsigned long *)(VIC_BASE_ADDR + 0x000))
@@ -1126,5 +1130,8 @@ with the spec. update in USB Device Section. */
 #define MAC_POWERDOWN       (*(volatile unsigned long *)(MAC_BASE_ADDR + 0xFF4)) /* Power-down reg */
 #define MAC_MODULEID        (*(volatile unsigned long *)(MAC_BASE_ADDR + 0xFFC)) /* Module ID reg (RO) */
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // __LPC23xx_H

--- a/cpu/mc1322x/asm/include/asm.h
+++ b/cpu/mc1322x/asm/include/asm.h
@@ -12,6 +12,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define ASM_BASE_ADDRESS 0x80008000
 
 struct ASM_struct {
@@ -99,5 +103,9 @@ void asm_cbc_mac_finish(asm_data_t *data);
 void asm_ctr_cbc_mac_init(asm_keys_t *keys);
 void asm_ctr_cbc_mac_update(asm_data_t *data, asm_ctr_t *ctr);
 void asm_ctr_cbc_mac_finish(asm_data_t *data);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ASM_H */

--- a/cpu/mc1322x/include/cpu-conf.h
+++ b/cpu/mc1322x/include/cpu-conf.h
@@ -10,6 +10,10 @@
 #ifndef CPUCONF_H_
 #define CPUCONF_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup     conf
  * @ingroup     mc1322x
@@ -61,6 +65,10 @@
 
 #ifndef UART0_BUFSIZE
 #define UART0_BUFSIZE                   (64)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 /** @} */

--- a/cpu/mc1322x/include/cpu.h
+++ b/cpu/mc1322x/include/cpu.h
@@ -26,8 +26,16 @@
 #include "arm_cpu.h"
 #include "mc1322x.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern uintptr_t __stack_start;     ///< end of user stack memory space
 bool install_irq(int int_number, void *handler_addr, int priority);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* CPU_H */

--- a/cpu/mc1322x/include/gpio.h
+++ b/cpu/mc1322x/include/gpio.h
@@ -13,6 +13,10 @@
 // TODO: why do we need to include this for macro expansion?
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Structure-based GPIO access
    Example usage:
 
@@ -154,5 +158,9 @@ enum { _REP(0,0) };
 #undef _V
 
 static volatile struct GPIO_struct * const GPIO = (void *) (0x80000000);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/cpu/mc1322x/include/mc1322x.h
+++ b/cpu/mc1322x/include/mc1322x.h
@@ -12,6 +12,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*-----------------------------------------------------------------*/
 /* System Management */
 #define SW_RST_VAL       (0x87651234)
@@ -303,8 +307,6 @@ static volatile struct TMR_struct * const TMR3 = (void *) (TMR3_BASE);
 /* Interrupts */
 #define INTBASE        (0x80020000)
 
-#include <stdint.h>
-
 /* Structure-based ITC access */
 #define __INTERRUPT_union(x)              \
                 union {                   \
@@ -441,5 +443,9 @@ extern void ssi_isr(void) __attribute__((weak));
 extern void adc_isr(void) __attribute__((weak));
 
 extern void spi_isr(void) __attribute__((weak));
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* MC1322X_H */

--- a/cpu/mc1322x/maca/include/maca.h
+++ b/cpu/mc1322x/maca/include/maca.h
@@ -15,6 +15,10 @@
 
 #include "maca_packet.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*********************************************************/
 /* function definitions                                  */
 /*********************************************************/
@@ -530,5 +534,8 @@ static volatile struct MACA_struct * const MACA = (void *) (MACA_BASE_ADDRESS + 
 #define MACA_TMRDIS_SFTOFF_ABORT 1
 
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif // MACA_H_

--- a/cpu/mc1322x/maca/include/maca_packet.h
+++ b/cpu/mc1322x/maca/include/maca_packet.h
@@ -12,6 +12,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* does not include 2 byte FCS checksum */
 #ifndef MACA_MAX_PAYLOAD_SIZE
 #define MACA_MAX_PAYLOAD_SIZE 125
@@ -39,5 +43,9 @@ struct packet {
     uint8_t data[MACA_MAX_PAYLOAD_SIZE+2+1]; /* +2 for FCS; + 1 since maca returns the length as the first byte */
 };
 typedef struct packet maca_packet_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/cpu/msp430-common/include/cpu-conf.h
+++ b/cpu/msp430-common/include/cpu-conf.h
@@ -9,6 +9,10 @@
 #ifndef CPUCONF_H_
 #define CPUCONF_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Kernel configuration
  * @{
@@ -35,5 +39,9 @@
                                                    overall MTU dependent */
 #endif
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CPUCONF_H_ */

--- a/cpu/msp430-common/include/cpu.h
+++ b/cpu/msp430-common/include/cpu.h
@@ -31,6 +31,10 @@
 #include "msp430_types.h"
 #include "cpu-conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define WORDSIZE 16
 
 extern volatile int __inISR;
@@ -134,6 +138,10 @@ inline void dINT(void)
 int inISR(void);
 
 void msp430_cpu_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif // _CPU_H

--- a/cpu/msp430-common/include/hwtimer_cpu.h
+++ b/cpu/msp430-common/include/hwtimer_cpu.h
@@ -13,6 +13,10 @@
 
 #include "cpu.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef __MSP430_HAS_TA2__
 #define HWTIMER_MAXTIMERS 2
 #endif
@@ -31,5 +35,9 @@
 
 #define HWTIMER_SPEED  (F_RC_OSCILLATOR)
 #define HWTIMER_MAXTICKS (0xFFFFFFFF)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // __HWTIMER_CPU_H

--- a/cpu/msp430-common/include/msp430_types.h
+++ b/cpu/msp430-common/include/msp430_types.h
@@ -15,6 +15,10 @@
 /** defining signed type for size_t */
 #include "kernel_types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef EINVAL
 /**
  * @brief defines EINVAL if MSP430 toolchain is too old to provide it itself
@@ -46,5 +50,9 @@ struct timeval {
 
 /* TODO: remove once msp430 libc supports clockid_t */
 typedef int clockid_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* MSP430_TYPES_H */

--- a/cpu/msp430-common/include/sys/time.h
+++ b/cpu/msp430-common/include/sys/time.h
@@ -11,4 +11,12 @@
 
 #include "msp430_types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* TIME_H */

--- a/cpu/msp430-common/include/time.h
+++ b/cpu/msp430-common/include/time.h
@@ -9,6 +9,10 @@
 #ifndef MSPGCC_TIME_H
 #define MSPGCC_TIME_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct tm {
     int tm_sec;                   /* Seconds after the minute [0, 60] */
     int tm_min;                   /* Minutes after the hour [0, 59] */
@@ -20,5 +24,9 @@ struct tm {
     int tm_yday;                  /* Days since January 1st [0, 365] */
     int tm_isdst;                 /* Daylight saving time is in effect */
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/cpu/native/include/clang_compat.h
+++ b/cpu/native/include/clang_compat.h
@@ -10,11 +10,19 @@
 
 #ifndef __CLANG_COMPAT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #undef HTONS
 #undef HTONL
 #undef HTONLL
 #undef NTOHS
 #undef NTOHL
 #undef NTOHLL
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/cpu/native/include/cpu-conf.h
+++ b/cpu/native/include/cpu-conf.h
@@ -16,6 +16,10 @@
 #ifndef CPUCONF_H_
 #define CPUCONF_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* TODO: tighten stack sizes */
 #ifdef __MACH__ /* OSX */
 #define KERNEL_CONF_STACKSIZE_DEFAULT       (163840)
@@ -62,6 +66,10 @@
  */
 #ifndef CPUID_ID_LEN
 #define CPUID_ID_LEN                    (4)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* CPUCONF_H_ */

--- a/cpu/native/include/cpu.h
+++ b/cpu/native/include/cpu.h
@@ -20,9 +20,17 @@
 #ifndef _CPU_H
 #define _CPU_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* TODO: remove once these have been removed from RIOT: */
 void dINT(void);
 void eINT(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif //_CPU_H

--- a/cpu/native/include/hwtimer_cpu.h
+++ b/cpu/native/include/hwtimer_cpu.h
@@ -17,8 +17,16 @@
 #ifndef HWTIMER_CPU_H_
 #define HWTIMER_CPU_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define HWTIMER_MAXTIMERS 4
 #define HWTIMER_SPEED 1000000
 #define HWTIMER_MAXTICKS (0xFFFFFFFF)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* HWTIMER_CPU_H_ */

--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -47,6 +47,9 @@
 
 #include "kernel_types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * Prototype for native's internal callbacks
@@ -145,6 +148,10 @@ int register_interrupt(int sig, _native_callback_t handler);
 int unregister_interrupt(int sig);
 
 //#include <sys/param.h>
+
+#ifdef __cplusplus
+}
+#endif
 
 #include "kernel_internal.h"
 #include "sched.h"

--- a/cpu/native/include/nativenet.h
+++ b/cpu/native/include/nativenet.h
@@ -42,6 +42,11 @@
 
 #ifndef NATIVE_MAX_DATA_LENGTH
 #include "tap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef MODULE_SIXLOWPAN
 #define NATIVE_MAX_DATA_LENGTH (127)
 #else
@@ -155,5 +160,10 @@ uint16_t nativenet_get_pan(void);
  * Enable transceiver rx mode
  */
 void nativenet_switch_to_rx(void);
+
+#ifdef __cplusplus
+}
+#endif
+
 /** @} */
 #endif /* NATIVENET_H */

--- a/cpu/native/include/nativenet_internal.h
+++ b/cpu/native/include/nativenet_internal.h
@@ -19,6 +19,10 @@
 
 #include "tap.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define NNEV_PWRDWN     0x01
 #define NNEV_PWRUP      0x02
 #define NNEV_MONITOR    0x03
@@ -97,4 +101,9 @@ extern _nativenet_netdev_more_t _nativenet_default_dev_more;
 
 void _nativenet_handle_packet(radio_packet_t *packet);
 int8_t send_buf(radio_packet_t *packet);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* NATIVENET_INTERNAL_H */

--- a/cpu/native/include/tap.h
+++ b/cpu/native/include/tap.h
@@ -21,6 +21,10 @@
 #include "board.h"
 #include "radio/types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * create and/or open tap device "name"
  *
@@ -54,5 +58,9 @@ union eth_frame {
     } field;
     unsigned char buffer[ETHER_MAX_LEN];
 } __attribute__((packed));
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _TAP_H */

--- a/cpu/nrf51822/include/cpu-conf.h
+++ b/cpu/nrf51822/include/cpu-conf.h
@@ -22,6 +22,10 @@
 #include "nrf51.h"
 #include "nrf51_bitfields.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Kernel configuration
  * @{
@@ -50,6 +54,10 @@
  * @name Length in bytes for reading CPU_ID
  */
 #define CPUID_ID_LEN                    (8)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CPU_CONF_H */
 /** @} */

--- a/cpu/nrf51822/include/hwtimer_cpu.h
+++ b/cpu/nrf51822/include/hwtimer_cpu.h
@@ -19,6 +19,10 @@
 #ifndef __HWTIMER_CPU_H
 #define __HWTIMER_CPU_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Hardware timer configuration
  * @{
@@ -29,6 +33,9 @@
 #define HWTIMER_MAXTICKS    (0xFFFFFF)      /**< 24-bit timer -> see PAN note */
 /** @} */
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __HWTIMER_CPU_H */
 /** @} */

--- a/cpu/nrf51822/include/nrf51.h
+++ b/cpu/nrf51822/include/nrf51.h
@@ -116,8 +116,15 @@ typedef enum {
 #define __Vendor_SysTickConfig         0            /*!< Set to 1 if different SysTick Config is used                          */
 /** @} */ /* End of group Configuration_of_CMSIS */
 
+#ifdef __cplusplus
+}
+#endif
+
 #include <core_cm0.h>                               /*!< Cortex-M0 processor and core peripherals                              */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* ================================================================================ */
 /* ================       Device Specific Peripheral Section       ================ */

--- a/cpu/nrf51822/include/nrf51_bitfields.h
+++ b/cpu/nrf51822/include/nrf51_bitfields.h
@@ -34,6 +34,10 @@
 
 #include <core_cm0.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Peripheral: AAR */
 /* Description: Accelerated Address Resolver. */
 
@@ -6889,6 +6893,9 @@
 #define WDT_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
 #define WDT_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
 
+#ifdef __cplusplus
+}
+#endif
 
 /*lint --flb "Leave library region" */
 #endif

--- a/cpu/sam3x8e/include/component/component_adc.h
+++ b/cpu/sam3x8e/include/component/component_adc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_ADC_COMPONENT_
 #define _SAM3XA_ADC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Analog-to-digital Converter */
 /* ============================================================================= */
@@ -501,5 +505,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_ADC_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_can.h
+++ b/cpu/sam3x8e/include/component/component_can.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_CAN_COMPONENT_
 #define _SAM3XA_CAN_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Controller Area Network */
 /* ============================================================================= */
@@ -295,5 +299,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_CAN_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_chipid.h
+++ b/cpu/sam3x8e/include/component/component_chipid.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_CHIPID_COMPONENT_
 #define _SAM3XA_CHIPID_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Chip Identifier */
 /* ============================================================================= */
@@ -156,5 +160,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_CHIPID_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_dacc.h
+++ b/cpu/sam3x8e/include/component/component_dacc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_DACC_COMPONENT_
 #define _SAM3XA_DACC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Digital-to-Analog Converter Controller */
 /* ============================================================================= */
@@ -207,5 +211,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_DACC_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_dmac.h
+++ b/cpu/sam3x8e/include/component/component_dmac.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_DMAC_COMPONENT_
 #define _SAM3XA_DMAC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR DMA Controller */
 /* ============================================================================= */
@@ -364,5 +368,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_DMAC_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_efc.h
+++ b/cpu/sam3x8e/include/component/component_efc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_EFC_COMPONENT_
 #define _SAM3XA_EFC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Embedded Flash Controller */
 /* ============================================================================= */
@@ -73,5 +77,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_EFC_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_emac.h
+++ b/cpu/sam3x8e/include/component/component_emac.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_EMAC_COMPONENT_
 #define _SAM3XA_EMAC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Ethernet MAC 10/100 */
 /* ============================================================================= */
@@ -332,5 +336,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_EMAC_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_gpbr.h
+++ b/cpu/sam3x8e/include/component/component_gpbr.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_GPBR_COMPONENT_
 #define _SAM3XA_GPBR_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR General Purpose Backup Register */
 /* ============================================================================= */
@@ -50,5 +54,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_GPBR_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_hsmci.h
+++ b/cpu/sam3x8e/include/component/component_hsmci.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_HSMCI_COMPONENT_
 #define _SAM3XA_HSMCI_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR High Speed MultiMedia Card Interface */
 /* ============================================================================= */
@@ -338,5 +342,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_HSMCI_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_matrix.h
+++ b/cpu/sam3x8e/include/component/component_matrix.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_MATRIX_COMPONENT_
 #define _SAM3XA_MATRIX_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR AHB Bus Matrix */
 /* ============================================================================= */
@@ -282,5 +286,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_MATRIX_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_pdc.h
+++ b/cpu/sam3x8e/include/component/component_pdc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_PDC_COMPONENT_
 #define _SAM3XA_PDC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Peripheral DMA Controller */
 /* ============================================================================= */
@@ -95,5 +99,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_PDC_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_pio.h
+++ b/cpu/sam3x8e/include/component/component_pio.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_PIO_COMPONENT_
 #define _SAM3XA_PIO_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Parallel Input/Output Controller */
 /* ============================================================================= */
@@ -1432,5 +1436,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_PIO_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_pmc.h
+++ b/cpu/sam3x8e/include/component/component_pmc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_PMC_COMPONENT_
 #define _SAM3XA_PMC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Power Management Controller */
 /* ============================================================================= */
@@ -413,5 +417,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_PMC_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_pwm.h
+++ b/cpu/sam3x8e/include/component/component_pwm.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_PWM_COMPONENT_
 #define _SAM3XA_PWM_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Pulse Width Modulation Controller */
 /* ============================================================================= */
@@ -664,5 +668,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_PWM_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_rstc.h
+++ b/cpu/sam3x8e/include/component/component_rstc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_RSTC_COMPONENT_
 #define _SAM3XA_RSTC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Reset Controller */
 /* ============================================================================= */
@@ -70,5 +74,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_RSTC_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_rtc.h
+++ b/cpu/sam3x8e/include/component/component_rtc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_RTC_COMPONENT_
 #define _SAM3XA_RTC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Real-time Clock */
 /* ============================================================================= */
@@ -165,5 +169,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_RTC_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_rtt.h
+++ b/cpu/sam3x8e/include/component/component_rtt.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_RTT_COMPONENT_
 #define _SAM3XA_RTT_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Real-time Timer */
 /* ============================================================================= */
@@ -66,5 +70,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_RTT_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_sdramc.h
+++ b/cpu/sam3x8e/include/component/component_sdramc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_SDRAMC_COMPONENT_
 #define _SAM3XA_SDRAMC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR SDRAM Controller */
 /* ============================================================================= */
@@ -185,5 +189,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_SDRAMC_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_smc.h
+++ b/cpu/sam3x8e/include/component/component_smc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_SMC_COMPONENT_
 #define _SAM3XA_SMC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Static Memory Controller */
 /* ============================================================================= */
@@ -481,5 +485,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_SMC_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_spi.h
+++ b/cpu/sam3x8e/include/component/component_spi.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_SPI_COMPONENT_
 #define _SAM3XA_SPI_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Serial Peripheral Interface */
 /* ============================================================================= */
@@ -156,5 +160,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_SPI_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_ssc.h
+++ b/cpu/sam3x8e/include/component/component_ssc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_SSC_COMPONENT_
 #define _SAM3XA_SSC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Synchronous Serial Controller */
 /* ============================================================================= */
@@ -267,5 +271,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_SSC_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_supc.h
+++ b/cpu/sam3x8e/include/component/component_supc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_SUPC_COMPONENT_
 #define _SAM3XA_SUPC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Supply Controller */
 /* ============================================================================= */
@@ -309,5 +313,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_SUPC_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_tc.h
+++ b/cpu/sam3x8e/include/component/component_tc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_TC_COMPONENT_
 #define _SAM3XA_TC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Timer Counter */
 /* ============================================================================= */
@@ -300,5 +304,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_TC_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_trng.h
+++ b/cpu/sam3x8e/include/component/component_trng.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_TRNG_COMPONENT_
 #define _SAM3XA_TRNG_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR True Random Number Generator */
 /* ============================================================================= */
@@ -69,5 +73,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_TRNG_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_twi.h
+++ b/cpu/sam3x8e/include/component/component_twi.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_TWI_COMPONENT_
 #define _SAM3XA_TWI_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Two-wire Interface */
 /* ============================================================================= */
@@ -214,5 +218,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_TWI_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_uart.h
+++ b/cpu/sam3x8e/include/component/component_uart.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_UART_COMPONENT_
 #define _SAM3XA_UART_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Universal Asynchronous Receiver Transmitter */
 /* ============================================================================= */
@@ -182,5 +186,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_UART_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_uotghs.h
+++ b/cpu/sam3x8e/include/component/component_uotghs.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_UOTGHS_COMPONENT_
 #define _SAM3XA_UOTGHS_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR USB On-The-Go Interface */
 /* ============================================================================= */
@@ -935,5 +939,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_UOTGHS_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_usart.h
+++ b/cpu/sam3x8e/include/component/component_usart.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_USART_COMPONENT_
 #define _SAM3XA_USART_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Universal Synchronous Asynchronous Receiver Transmitter */
 /* ============================================================================= */
@@ -393,5 +397,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_USART_COMPONENT_ */

--- a/cpu/sam3x8e/include/component/component_wdt.h
+++ b/cpu/sam3x8e/include/component/component_wdt.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_WDT_COMPONENT_
 #define _SAM3XA_WDT_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ============================================================================= */
 /**  SOFTWARE API DEFINITION FOR Watchdog Timer */
 /* ============================================================================= */
@@ -69,5 +73,8 @@ typedef struct {
 
 /*@}*/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_WDT_COMPONENT_ */

--- a/cpu/sam3x8e/include/cpu-conf.h
+++ b/cpu/sam3x8e/include/cpu-conf.h
@@ -20,6 +20,9 @@
 
 #include "sam3x8e.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @name Kernel configuration
@@ -47,6 +50,9 @@
 #endif
 /** @} */
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CPU_CONF_H */
 /** @} */

--- a/cpu/sam3x8e/include/hwtimer_cpu.h
+++ b/cpu/sam3x8e/include/hwtimer_cpu.h
@@ -19,6 +19,10 @@
 #ifndef __HWTIMER_CPU_H
 #define __HWTIMER_CPU_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Hardware timer configuration
  * @{
@@ -28,6 +32,10 @@
 #define HWTIMER_MAXTICKS    (0xFFFFFFFF)    /**< 32-bit timer */
 /** @} */
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __HWTIMER_CPU_H */
 /** @} */

--- a/cpu/sam3x8e/include/instance/instance_adc.h
+++ b/cpu/sam3x8e/include/instance/instance_adc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_ADC_INSTANCE_
 #define _SAM3XA_ADC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for ADC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_ADC_CR               (0x400C0000U) /**< \brief (ADC) Control Register */
@@ -88,5 +92,9 @@
 #define REG_ADC_PTCR    (*(WoReg*)0x400C0120U) /**< \brief (ADC) Transfer Control Register */
 #define REG_ADC_PTSR    (*(RoReg*)0x400C0124U) /**< \brief (ADC) Transfer Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_ADC_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_can0.h
+++ b/cpu/sam3x8e/include/instance/instance_can0.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_CAN0_INSTANCE_
 #define _SAM3XA_CAN0_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for CAN0 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_CAN0_MR               (0x400B4000U) /**< \brief (CAN0) Mode Register */
@@ -188,5 +192,9 @@
 #define REG_CAN0_MDH7    (*(RwReg*)0x400B42F8U) /**< \brief (CAN0) Mailbox Data High Register (MB = 7) */
 #define REG_CAN0_MCR7    (*(WoReg*)0x400B42FCU) /**< \brief (CAN0) Mailbox Control Register (MB = 7) */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_CAN0_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_can1.h
+++ b/cpu/sam3x8e/include/instance/instance_can1.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_CAN1_INSTANCE_
 #define _SAM3XA_CAN1_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for CAN1 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_CAN1_MR               (0x400B8000U) /**< \brief (CAN1) Mode Register */
@@ -188,5 +192,9 @@
 #define REG_CAN1_MDH7    (*(RwReg*)0x400B82F8U) /**< \brief (CAN1) Mailbox Data High Register (MB = 7) */
 #define REG_CAN1_MCR7    (*(WoReg*)0x400B82FCU) /**< \brief (CAN1) Mailbox Control Register (MB = 7) */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_CAN1_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_chipid.h
+++ b/cpu/sam3x8e/include/instance/instance_chipid.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_CHIPID_INSTANCE_
 #define _SAM3XA_CHIPID_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for CHIPID peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_CHIPID_CIDR          (0x400E0940U) /**< \brief (CHIPID) Chip ID Register */
@@ -38,5 +42,9 @@
 #define REG_CHIPID_CIDR (*(RoReg*)0x400E0940U) /**< \brief (CHIPID) Chip ID Register */
 #define REG_CHIPID_EXID (*(RoReg*)0x400E0944U) /**< \brief (CHIPID) Chip ID Extension Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_CHIPID_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_dacc.h
+++ b/cpu/sam3x8e/include/instance/instance_dacc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_DACC_INSTANCE_
 #define _SAM3XA_DACC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for DACC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_DACC_CR            (0x400C8000U) /**< \brief (DACC) Control Register */
@@ -72,5 +76,9 @@
 #define REG_DACC_PTCR (*(WoReg*)0x400C8120U) /**< \brief (DACC) Transfer Control Register */
 #define REG_DACC_PTSR (*(RoReg*)0x400C8124U) /**< \brief (DACC) Transfer Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_DACC_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_dmac.h
+++ b/cpu/sam3x8e/include/instance/instance_dmac.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_DMAC_INSTANCE_
 #define _SAM3XA_DMAC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for DMAC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_DMAC_GCFG            (0x400C4000U) /**< \brief (DMAC) DMAC Global Configuration Register */
@@ -134,5 +138,9 @@
 #define REG_DMAC_WPMR   (*(RwReg*)0x400C41E4U) /**< \brief (DMAC) DMAC Write Protect Mode Register */
 #define REG_DMAC_WPSR   (*(RoReg*)0x400C41E8U) /**< \brief (DMAC) DMAC Write Protect Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_DMAC_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_efc0.h
+++ b/cpu/sam3x8e/include/instance/instance_efc0.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_EFC0_INSTANCE_
 #define _SAM3XA_EFC0_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for EFC0 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_EFC0_FMR           (0x400E0A00U) /**< \brief (EFC0) EEFC Flash Mode Register */
@@ -42,5 +46,9 @@
 #define REG_EFC0_FSR  (*(RoReg*)0x400E0A08U) /**< \brief (EFC0) EEFC Flash Status Register */
 #define REG_EFC0_FRR  (*(RoReg*)0x400E0A0CU) /**< \brief (EFC0) EEFC Flash Result Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_EFC0_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_efc1.h
+++ b/cpu/sam3x8e/include/instance/instance_efc1.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_EFC1_INSTANCE_
 #define _SAM3XA_EFC1_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for EFC1 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_EFC1_FMR           (0x400E0C00U) /**< \brief (EFC1) EEFC Flash Mode Register */
@@ -42,5 +46,9 @@
 #define REG_EFC1_FSR  (*(RoReg*)0x400E0C08U) /**< \brief (EFC1) EEFC Flash Status Register */
 #define REG_EFC1_FRR  (*(RoReg*)0x400E0C0CU) /**< \brief (EFC1) EEFC Flash Result Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_EFC1_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_emac.h
+++ b/cpu/sam3x8e/include/instance/instance_emac.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_EMAC_INSTANCE_
 #define _SAM3XA_EMAC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for EMAC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_EMAC_NCR            (0x400B0000U) /**< \brief (EMAC) Network Control Register */
@@ -124,5 +128,9 @@
 #define REG_EMAC_TID   (*(RwReg*)0x400B00B8U) /**< \brief (EMAC) Type ID Checking Register */
 #define REG_EMAC_USRIO (*(RwReg*)0x400B00C0U) /**< \brief (EMAC) User Input/Output Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_EMAC_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_gpbr.h
+++ b/cpu/sam3x8e/include/instance/instance_gpbr.h
@@ -30,11 +30,19 @@
 #ifndef _SAM3XA_GPBR_INSTANCE_
 #define _SAM3XA_GPBR_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for GPBR peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_GPBR_GPBR            (0x400E1A90U) /**< \brief (GPBR) General Purpose Backup Register */
 #else
 #define REG_GPBR_GPBR   (*(RwReg*)0x400E1A90U) /**< \brief (GPBR) General Purpose Backup Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_GPBR_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_hsmci.h
+++ b/cpu/sam3x8e/include/instance/instance_hsmci.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_HSMCI_INSTANCE_
 #define _SAM3XA_HSMCI_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for HSMCI peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_HSMCI_CR                 (0x40000000U) /**< \brief (HSMCI) Control Register */
@@ -74,5 +78,9 @@
 #define REG_HSMCI_WPSR      (*(RoReg*)0x400000E8U) /**< \brief (HSMCI) Write Protection Status Register */
 #define REG_HSMCI_FIFO      (*(RwReg*)0x40000200U) /**< \brief (HSMCI) FIFO Memory Aperture0 */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_HSMCI_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_matrix.h
+++ b/cpu/sam3x8e/include/instance/instance_matrix.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_MATRIX_INSTANCE_
 #define _SAM3XA_MATRIX_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for MATRIX peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_MATRIX_MCFG             (0x400E0400U) /**< \brief (MATRIX) Master Configuration Register */
@@ -64,5 +68,9 @@
 #define REG_MATRIX_WPMR    (*(RwReg*)0x400E05E4U) /**< \brief (MATRIX) Write Protect Mode Register */
 #define REG_MATRIX_WPSR    (*(RoReg*)0x400E05E8U) /**< \brief (MATRIX) Write Protect Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_MATRIX_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_pioa.h
+++ b/cpu/sam3x8e/include/instance/instance_pioa.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_PIOA_INSTANCE_
 #define _SAM3XA_PIOA_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for PIOA peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_PIOA_PER             (0x400E0E00U) /**< \brief (PIOA) PIO Enable Register */
@@ -120,5 +124,9 @@
 #define REG_PIOA_WPMR   (*(RwReg*)0x400E0EE4U) /**< \brief (PIOA) Write Protect Mode Register */
 #define REG_PIOA_WPSR   (*(RoReg*)0x400E0EE8U) /**< \brief (PIOA) Write Protect Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_PIOA_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_piob.h
+++ b/cpu/sam3x8e/include/instance/instance_piob.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_PIOB_INSTANCE_
 #define _SAM3XA_PIOB_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for PIOB peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_PIOB_PER             (0x400E1000U) /**< \brief (PIOB) PIO Enable Register */
@@ -120,5 +124,9 @@
 #define REG_PIOB_WPMR   (*(RwReg*)0x400E10E4U) /**< \brief (PIOB) Write Protect Mode Register */
 #define REG_PIOB_WPSR   (*(RoReg*)0x400E10E8U) /**< \brief (PIOB) Write Protect Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_PIOB_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_pioc.h
+++ b/cpu/sam3x8e/include/instance/instance_pioc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_PIOC_INSTANCE_
 #define _SAM3XA_PIOC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for PIOC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_PIOC_PER             (0x400E1200U) /**< \brief (PIOC) PIO Enable Register */
@@ -120,5 +124,9 @@
 #define REG_PIOC_WPMR   (*(RwReg*)0x400E12E4U) /**< \brief (PIOC) Write Protect Mode Register */
 #define REG_PIOC_WPSR   (*(RoReg*)0x400E12E8U) /**< \brief (PIOC) Write Protect Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_PIOC_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_piod.h
+++ b/cpu/sam3x8e/include/instance/instance_piod.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_PIOD_INSTANCE_
 #define _SAM3XA_PIOD_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for PIOD peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_PIOD_PER             (0x400E1400U) /**< \brief (PIOD) PIO Enable Register */
@@ -120,5 +124,9 @@
 #define REG_PIOD_WPMR   (*(RwReg*)0x400E14E4U) /**< \brief (PIOD) Write Protect Mode Register */
 #define REG_PIOD_WPSR   (*(RoReg*)0x400E14E8U) /**< \brief (PIOD) Write Protect Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_PIOD_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_pioe.h
+++ b/cpu/sam3x8e/include/instance/instance_pioe.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_PIOE_INSTANCE_
 #define _SAM3XA_PIOE_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for PIOE peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_PIOE_PER             (0x400E1600U) /**< \brief (PIOE) PIO Enable Register */
@@ -120,5 +124,9 @@
 #define REG_PIOE_WPMR   (*(RwReg*)0x400E16E4U) /**< \brief (PIOE) Write Protect Mode Register */
 #define REG_PIOE_WPSR   (*(RoReg*)0x400E16E8U) /**< \brief (PIOE) Write Protect Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_PIOE_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_piof.h
+++ b/cpu/sam3x8e/include/instance/instance_piof.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_PIOF_INSTANCE_
 #define _SAM3XA_PIOF_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for PIOF peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_PIOF_PER             (0x400E1800U) /**< \brief (PIOF) PIO Enable Register */
@@ -120,5 +124,9 @@
 #define REG_PIOF_WPMR   (*(RwReg*)0x400E18E4U) /**< \brief (PIOF) Write Protect Mode Register */
 #define REG_PIOF_WPSR   (*(RoReg*)0x400E18E8U) /**< \brief (PIOF) Write Protect Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_PIOF_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_pmc.h
+++ b/cpu/sam3x8e/include/instance/instance_pmc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_PMC_INSTANCE_
 #define _SAM3XA_PMC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for PMC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_PMC_SCER            (0x400E0600U) /**< \brief (PMC) System Clock Enable Register */
@@ -86,5 +90,9 @@
 #define REG_PMC_PCSR1  (*(RoReg*)0x400E0708U) /**< \brief (PMC) Peripheral Clock Status Register 1 */
 #define REG_PMC_PCR    (*(RwReg*)0x400E070CU) /**< \brief (PMC) Peripheral Control Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_PMC_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_pwm.h
+++ b/cpu/sam3x8e/include/instance/instance_pwm.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_PWM_INSTANCE_
 #define _SAM3XA_PWM_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for PWM peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_PWM_CLK               (0x40094000U) /**< \brief (PWM) PWM Clock Register */
@@ -302,5 +306,9 @@
 #define REG_PWM_DT7      (*(RwReg*)0x400942F8U) /**< \brief (PWM) PWM Channel Dead Time Register (ch_num = 7) */
 #define REG_PWM_DTUPD7   (*(WoReg*)0x400942FCU) /**< \brief (PWM) PWM Channel Dead Time Update Register (ch_num = 7) */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_PWM_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_rstc.h
+++ b/cpu/sam3x8e/include/instance/instance_rstc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_RSTC_INSTANCE_
 #define _SAM3XA_RSTC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for RSTC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_RSTC_CR          (0x400E1A00U) /**< \brief (RSTC) Control Register */
@@ -40,5 +44,9 @@
 #define REG_RSTC_SR (*(RoReg*)0x400E1A04U) /**< \brief (RSTC) Status Register */
 #define REG_RSTC_MR (*(RwReg*)0x400E1A08U) /**< \brief (RSTC) Mode Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_RSTC_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_rtc.h
+++ b/cpu/sam3x8e/include/instance/instance_rtc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_RTC_INSTANCE_
 #define _SAM3XA_RTC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for RTC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_RTC_CR              (0x400E1A60U) /**< \brief (RTC) Control Register */
@@ -60,5 +64,9 @@
 #define REG_RTC_VER    (*(RoReg*)0x400E1A8CU) /**< \brief (RTC) Valid Entry Register */
 #define REG_RTC_WPMR   (*(RwReg*)0x400E1B44U) /**< \brief (RTC) Write Protect Mode Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_RTC_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_rtt.h
+++ b/cpu/sam3x8e/include/instance/instance_rtt.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_RTT_INSTANCE_
 #define _SAM3XA_RTT_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for RTT peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_RTT_MR          (0x400E1A30U) /**< \brief (RTT) Mode Register */
@@ -42,5 +46,9 @@
 #define REG_RTT_VR (*(RoReg*)0x400E1A38U) /**< \brief (RTT) Value Register */
 #define REG_RTT_SR (*(RoReg*)0x400E1A3CU) /**< \brief (RTT) Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_RTT_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_sdramc.h
+++ b/cpu/sam3x8e/include/instance/instance_sdramc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_SDRAMC_INSTANCE_
 #define _SAM3XA_SDRAMC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for SDRAMC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_SDRAMC_MR            (0x400E0200U) /**< \brief (SDRAMC) SDRAMC Mode Register */
@@ -56,5 +60,9 @@
 #define REG_SDRAMC_CR1  (*(RwReg*)0x400E0228U) /**< \brief (SDRAMC) SDRAMC Configuration Register 1 */
 #define REG_SDRAMC_OCMS (*(RwReg*)0x400E022CU) /**< \brief (SDRAMC) SDRAMC OCMS Register 1 */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_SDRAMC_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_smc.h
+++ b/cpu/sam3x8e/include/instance/instance_smc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_SMC_INSTANCE_
 #define _SAM3XA_SMC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for SMC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_SMC_CFG               (0x400E0000U) /**< \brief (SMC) SMC NFC Configuration Register */
@@ -180,5 +184,9 @@
 #define REG_SMC_WPCR     (*(WoReg*)0x400E01E4U) /**< \brief (SMC) Write Protection Control Register */
 #define REG_SMC_WPSR     (*(RoReg*)0x400E01E8U) /**< \brief (SMC) Write Protection Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_SMC_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_spi0.h
+++ b/cpu/sam3x8e/include/instance/instance_spi0.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_SPI0_INSTANCE_
 #define _SAM3XA_SPI0_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for SPI0 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_SPI0_CR              (0x40008000U) /**< \brief (SPI0) Control Register */
@@ -56,5 +60,9 @@
 #define REG_SPI0_WPMR   (*(RwReg*)0x400080E4U) /**< \brief (SPI0) Write Protection Control Register */
 #define REG_SPI0_WPSR   (*(RoReg*)0x400080E8U) /**< \brief (SPI0) Write Protection Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_SPI0_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_spi1.h
+++ b/cpu/sam3x8e/include/instance/instance_spi1.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_SPI1_INSTANCE_
 #define _SAM3XA_SPI1_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for SPI1 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_SPI1_CR              (0x4000C000U) /**< \brief (SPI1) Control Register */
@@ -56,5 +60,9 @@
 #define REG_SPI1_WPMR   (*(RwReg*)0x4000C0E4U) /**< \brief (SPI1) Write Protection Control Register */
 #define REG_SPI1_WPSR   (*(RoReg*)0x4000C0E8U) /**< \brief (SPI1) Write Protection Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_SPI1_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_ssc.h
+++ b/cpu/sam3x8e/include/instance/instance_ssc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_SSC_INSTANCE_
 #define _SAM3XA_SSC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for SSC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_SSC_CR            (0x40004000U) /**< \brief (SSC) Control Register */
@@ -70,5 +74,9 @@
 #define REG_SSC_WPMR (*(RwReg*)0x400040E4U) /**< \brief (SSC) Write Protect Mode Register */
 #define REG_SSC_WPSR (*(RoReg*)0x400040E8U) /**< \brief (SSC) Write Protect Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_SSC_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_supc.h
+++ b/cpu/sam3x8e/include/instance/instance_supc.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_SUPC_INSTANCE_
 #define _SAM3XA_SUPC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for SUPC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_SUPC_CR            (0x400E1A10U) /**< \brief (SUPC) Supply Controller Control Register */
@@ -46,5 +50,9 @@
 #define REG_SUPC_WUIR (*(RwReg*)0x400E1A20U) /**< \brief (SUPC) Supply Controller Wake Up Inputs Register */
 #define REG_SUPC_SR   (*(RoReg*)0x400E1A24U) /**< \brief (SUPC) Supply Controller Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_SUPC_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_tc0.h
+++ b/cpu/sam3x8e/include/instance/instance_tc0.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_TC0_INSTANCE_
 #define _SAM3XA_TC0_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for TC0 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_TC0_CCR0           (0x40080000U) /**< \brief (TC0) Channel Control Register (channel = 0) */
@@ -116,5 +120,9 @@
 #define REG_TC0_FMR   (*(RwReg*)0x400800D8U) /**< \brief (TC0) Fault Mode Register */
 #define REG_TC0_WPMR  (*(RwReg*)0x400800E4U) /**< \brief (TC0) Write Protect Mode Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_TC0_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_tc1.h
+++ b/cpu/sam3x8e/include/instance/instance_tc1.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_TC1_INSTANCE_
 #define _SAM3XA_TC1_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for TC1 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_TC1_CCR0           (0x40084000U) /**< \brief (TC1) Channel Control Register (channel = 0) */
@@ -116,5 +120,9 @@
 #define REG_TC1_FMR   (*(RwReg*)0x400840D8U) /**< \brief (TC1) Fault Mode Register */
 #define REG_TC1_WPMR  (*(RwReg*)0x400840E4U) /**< \brief (TC1) Write Protect Mode Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_TC1_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_tc2.h
+++ b/cpu/sam3x8e/include/instance/instance_tc2.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_TC2_INSTANCE_
 #define _SAM3XA_TC2_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for TC2 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_TC2_CCR0           (0x40088000U) /**< \brief (TC2) Channel Control Register (channel = 0) */
@@ -116,5 +120,9 @@
 #define REG_TC2_FMR   (*(RwReg*)0x400880D8U) /**< \brief (TC2) Fault Mode Register */
 #define REG_TC2_WPMR  (*(RwReg*)0x400880E4U) /**< \brief (TC2) Write Protect Mode Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_TC2_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_trng.h
+++ b/cpu/sam3x8e/include/instance/instance_trng.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_TRNG_INSTANCE_
 #define _SAM3XA_TRNG_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for TRNG peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_TRNG_CR             (0x400BC000U) /**< \brief (TRNG) Control Register */
@@ -46,5 +50,9 @@
 #define REG_TRNG_ISR   (*(RoReg*)0x400BC01CU) /**< \brief (TRNG) Interrupt Status Register */
 #define REG_TRNG_ODATA (*(RoReg*)0x400BC050U) /**< \brief (TRNG) Output Data Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_TRNG_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_twi0.h
+++ b/cpu/sam3x8e/include/instance/instance_twi0.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_TWI0_INSTANCE_
 #define _SAM3XA_TWI0_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for TWI0 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_TWI0_CR            (0x4008C000U) /**< \brief (TWI0) Control Register */
@@ -76,5 +80,9 @@
 #define REG_TWI0_PTCR (*(WoReg*)0x4008C120U) /**< \brief (TWI0) Transfer Control Register */
 #define REG_TWI0_PTSR (*(RoReg*)0x4008C124U) /**< \brief (TWI0) Transfer Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_TWI0_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_twi1.h
+++ b/cpu/sam3x8e/include/instance/instance_twi1.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_TWI1_INSTANCE_
 #define _SAM3XA_TWI1_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for TWI1 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_TWI1_CR            (0x40090000U) /**< \brief (TWI1) Control Register */
@@ -76,5 +80,9 @@
 #define REG_TWI1_PTCR (*(WoReg*)0x40090120U) /**< \brief (TWI1) Transfer Control Register */
 #define REG_TWI1_PTSR (*(RoReg*)0x40090124U) /**< \brief (TWI1) Transfer Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_TWI1_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_uart.h
+++ b/cpu/sam3x8e/include/instance/instance_uart.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_UART_INSTANCE_
 #define _SAM3XA_UART_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for UART peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_UART_CR            (0x400E0800U) /**< \brief (UART) Control Register */
@@ -72,5 +76,9 @@
 #define REG_UART_PTCR (*(WoReg*)0x400E0920U) /**< \brief (UART) Transfer Control Register */
 #define REG_UART_PTSR (*(RoReg*)0x400E0924U) /**< \brief (UART) Transfer Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_UART_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_uotghs.h
+++ b/cpu/sam3x8e/include/instance/instance_uotghs.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_UOTGHS_INSTANCE_
 #define _SAM3XA_UOTGHS_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for UOTGHS peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_UOTGHS_DEVCTRL                 (0x400AC000U) /**< \brief (UOTGHS) Device General Control Register */
@@ -230,5 +234,9 @@
 #define REG_UOTGHS_SFR            (*(WoReg*)0x400AC80CU) /**< \brief (UOTGHS) General Status Set Register */
 #define REG_UOTGHS_FSM            (*(RoReg*)0x400AC82CU) /**< \brief (UOTGHS) General Finite State Machine Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_UOTGHS_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_usart0.h
+++ b/cpu/sam3x8e/include/instance/instance_usart0.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_USART0_INSTANCE_
 #define _SAM3XA_USART0_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for USART0 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_USART0_CR          (0x40098000U) /**< \brief (USART0) Control Register */
@@ -92,5 +96,9 @@
 #define REG_USART0_PTCR (*(WoReg*)0x40098120U) /**< \brief (USART0) Transfer Control Register */
 #define REG_USART0_PTSR (*(RoReg*)0x40098124U) /**< \brief (USART0) Transfer Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_USART0_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_usart1.h
+++ b/cpu/sam3x8e/include/instance/instance_usart1.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_USART1_INSTANCE_
 #define _SAM3XA_USART1_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for USART1 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_USART1_CR          (0x4009C000U) /**< \brief (USART1) Control Register */
@@ -92,5 +96,9 @@
 #define REG_USART1_PTCR (*(WoReg*)0x4009C120U) /**< \brief (USART1) Transfer Control Register */
 #define REG_USART1_PTSR (*(RoReg*)0x4009C124U) /**< \brief (USART1) Transfer Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_USART1_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_usart2.h
+++ b/cpu/sam3x8e/include/instance/instance_usart2.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_USART2_INSTANCE_
 #define _SAM3XA_USART2_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for USART2 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_USART2_CR          (0x400A0000U) /**< \brief (USART2) Control Register */
@@ -92,5 +96,9 @@
 #define REG_USART2_PTCR (*(WoReg*)0x400A0120U) /**< \brief (USART2) Transfer Control Register */
 #define REG_USART2_PTSR (*(RoReg*)0x400A0124U) /**< \brief (USART2) Transfer Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_USART2_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_usart3.h
+++ b/cpu/sam3x8e/include/instance/instance_usart3.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_USART3_INSTANCE_
 #define _SAM3XA_USART3_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for USART3 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_USART3_CR          (0x400A4000U) /**< \brief (USART3) Control Register */
@@ -92,5 +96,9 @@
 #define REG_USART3_PTCR (*(WoReg*)0x400A4120U) /**< \brief (USART3) Transfer Control Register */
 #define REG_USART3_PTSR (*(RoReg*)0x400A4124U) /**< \brief (USART3) Transfer Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_USART3_INSTANCE_ */

--- a/cpu/sam3x8e/include/instance/instance_wdt.h
+++ b/cpu/sam3x8e/include/instance/instance_wdt.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3XA_WDT_INSTANCE_
 #define _SAM3XA_WDT_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for WDT peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_WDT_CR          (0x400E1A50U) /**< \brief (WDT) Control Register */
@@ -40,5 +44,9 @@
 #define REG_WDT_MR (*(RwReg*)0x400E1A54U) /**< \brief (WDT) Mode Register */
 #define REG_WDT_SR (*(RoReg*)0x400E1A58U) /**< \brief (WDT) Status Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3XA_WDT_INSTANCE_ */

--- a/cpu/sam3x8e/include/pio/pio_sam3x8e.h
+++ b/cpu/sam3x8e/include/pio/pio_sam3x8e.h
@@ -30,6 +30,10 @@
 #ifndef _SAM3X8E_PIO_
 #define _SAM3X8E_PIO_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define PIO_PA0              (1u << 0)  /**< \brief Pin Controlled by PA0 */
 #define PIO_PA1              (1u << 1)  /**< \brief Pin Controlled by PA1 */
 #define PIO_PA2              (1u << 2)  /**< \brief Pin Controlled by PA2 */
@@ -548,5 +552,9 @@
 #define PIO_PD8_IDX          104
 #define PIO_PD9_IDX          105
 #define PIO_PD10_IDX         106
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAM3X8E_PIO_ */

--- a/cpu/sam3x8e/include/sam3x8e.h
+++ b/cpu/sam3x8e/include/sam3x8e.h
@@ -257,6 +257,10 @@ void WDT_Handler        ( void );
  * \brief CMSIS includes
  */
 
+#ifdef __cplusplus
+}
+#endif
+
 #include <core_cm3.h>
 #if !defined DONT_USE_CMSIS_INIT
 #include "system_sam3xa.h"
@@ -572,11 +576,6 @@ void WDT_Handler        ( void );
 #define CHIP_FREQ_FWS_1                 (34000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
 #define CHIP_FREQ_FWS_2                 (53000000UL) /**< \brief Maximum operating frequency when FWS is 2 */
 #define CHIP_FREQ_FWS_3                 (78000000UL) /**< \brief Maximum operating frequency when FWS is 3 */
-
-
-#ifdef __cplusplus
-}
-#endif
 
 /*@}*/
 

--- a/cpu/sam3x8e/include/system_sam3xa.h
+++ b/cpu/sam3x8e/include/system_sam3xa.h
@@ -42,13 +42,14 @@
 
 /* @cond 0 */
 /**INDENT-OFF**/
-#ifdef __cplusplus
-extern "C" {
-#endif
 /**INDENT-ON**/
 /* @endcond */
 
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 extern uint32_t SystemCoreClock;    /* System Clock Frequency (Core Clock) */
 

--- a/cpu/samd21/include/component/component_ac.h
+++ b/cpu/samd21/include/component/component_ac.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_AC_COMPONENT_
 #define _SAMR21_AC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR AC */
 /* ========================================================================== */
@@ -555,5 +559,9 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_AC_COMPONENT_ */

--- a/cpu/samd21/include/component/component_adc.h
+++ b/cpu/samd21/include/component/component_adc.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_ADC_COMPONENT_
 #define _SAMR21_ADC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR ADC */
 /* ========================================================================== */
@@ -695,5 +699,9 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_ADC_COMPONENT_ */

--- a/cpu/samd21/include/component/component_dac.h
+++ b/cpu/samd21/include/component/component_dac.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_DAC_COMPONENT_
 #define _SAMR21_DAC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR DAC */
 /* ========================================================================== */
@@ -282,5 +286,9 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_DAC_COMPONENT_ */

--- a/cpu/samd21/include/component/component_dmac.h
+++ b/cpu/samd21/include/component/component_dmac.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_DMAC_COMPONENT_
 #define _SAMR21_DMAC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR DMAC */
 /* ========================================================================== */
@@ -1029,5 +1033,9 @@ typedef struct {
 #define SECTION_DMAC_DESCRIPTOR
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_DMAC_COMPONENT_ */

--- a/cpu/samd21/include/component/component_dsu.h
+++ b/cpu/samd21/include/component/component_dsu.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_DSU_COMPONENT_
 #define _SAMR21_DSU_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR DSU */
 /* ========================================================================== */
@@ -547,5 +551,9 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_DSU_COMPONENT_ */

--- a/cpu/samd21/include/component/component_eic.h
+++ b/cpu/samd21/include/component/component_eic.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_EIC_COMPONENT_
 #define _SAMR21_EIC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR EIC */
 /* ========================================================================== */
@@ -677,5 +681,9 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_EIC_COMPONENT_ */

--- a/cpu/samd21/include/component/component_evsys.h
+++ b/cpu/samd21/include/component/component_evsys.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_EVSYS_COMPONENT_
 #define _SAMR21_EVSYS_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR EVSYS */
 /* ========================================================================== */
@@ -600,5 +604,9 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_EVSYS_COMPONENT_ */

--- a/cpu/samd21/include/component/component_gclk.h
+++ b/cpu/samd21/include/component/component_gclk.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_GCLK_COMPONENT_
 #define _SAMR21_GCLK_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR GCLK */
 /* ========================================================================== */
@@ -230,5 +234,9 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_GCLK_COMPONENT_ */

--- a/cpu/samd21/include/component/component_i2s.h
+++ b/cpu/samd21/include/component/component_i2s.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_I2S_COMPONENT_
 #define _SAMR21_I2S_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR I2S */
 /* ========================================================================== */
@@ -635,5 +639,9 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_I2S_COMPONENT_ */

--- a/cpu/samd21/include/component/component_mtb.h
+++ b/cpu/samd21/include/component/component_mtb.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_MTB_COMPONENT_
 #define _SAMR21_MTB_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR MTB */
 /* ========================================================================== */
@@ -392,5 +396,9 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_MTB_COMPONENT_ */

--- a/cpu/samd21/include/component/component_nvmctrl.h
+++ b/cpu/samd21/include/component/component_nvmctrl.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_NVMCTRL_COMPONENT_
 #define _SAMR21_NVMCTRL_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR NVMCTRL */
 /* ========================================================================== */
@@ -526,5 +530,9 @@ typedef struct {
 #define WDT_FUSES_WINDOW_1(value)   ((WDT_FUSES_WINDOW_1_Msk & ((value) << WDT_FUSES_WINDOW_1_Pos)))
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_NVMCTRL_COMPONENT_ */

--- a/cpu/samd21/include/component/component_pac.h
+++ b/cpu/samd21/include/component/component_pac.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_PAC_COMPONENT_
 #define _SAMR21_PAC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR PAC */
 /* ========================================================================== */
@@ -100,5 +104,9 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_PAC_COMPONENT_ */

--- a/cpu/samd21/include/component/component_pm.h
+++ b/cpu/samd21/include/component/component_pm.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_PM_COMPONENT_
 #define _SAMR21_PM_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR PM */
 /* ========================================================================== */
@@ -520,5 +524,9 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_PM_COMPONENT_ */

--- a/cpu/samd21/include/component/component_port.h
+++ b/cpu/samd21/include/component/component_port.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_PORT_COMPONENT_
 #define _SAMR21_PORT_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR PORT */
 /* ========================================================================== */
@@ -391,5 +395,9 @@ typedef struct {
 #define SECTION_PORT_IOBUS
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_PORT_COMPONENT_ */

--- a/cpu/samd21/include/component/component_rfctrl.h
+++ b/cpu/samd21/include/component/component_rfctrl.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_RFCTRL_COMPONENT_
 #define _SAMR21_RFCTRL_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR RFCTRL */
 /* ========================================================================== */
@@ -100,5 +104,9 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_RFCTRL_COMPONENT_ */

--- a/cpu/samd21/include/component/component_rtc.h
+++ b/cpu/samd21/include/component/component_rtc.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_RTC_COMPONENT_
 #define _SAMR21_RTC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR RTC */
 /* ========================================================================== */
@@ -1058,5 +1062,9 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_RTC_COMPONENT_ */

--- a/cpu/samd21/include/component/component_sercom.h
+++ b/cpu/samd21/include/component/component_sercom.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_SERCOM_COMPONENT_
 #define _SAMR21_SERCOM_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR SERCOM */
 /* ========================================================================== */
@@ -1504,5 +1508,9 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_SERCOM_COMPONENT_ */

--- a/cpu/samd21/include/component/component_sysctrl.h
+++ b/cpu/samd21/include/component/component_sysctrl.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_SYSCTRL_COMPONENT_
 #define _SAMR21_SYSCTRL_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR SYSCTRL */
 /* ========================================================================== */
@@ -944,5 +948,9 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_SYSCTRL_COMPONENT_ */

--- a/cpu/samd21/include/component/component_tc.h
+++ b/cpu/samd21/include/component/component_tc.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_TC_COMPONENT_
 #define _SAMR21_TC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR TC */
 /* ========================================================================== */
@@ -680,5 +684,9 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_TC_COMPONENT_ */

--- a/cpu/samd21/include/component/component_tcc.h
+++ b/cpu/samd21/include/component/component_tcc.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_TCC_COMPONENT_
 #define _SAMR21_TCC_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR TCC */
 /* ========================================================================== */
@@ -1604,5 +1608,9 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_TCC_COMPONENT_ */

--- a/cpu/samd21/include/component/component_usb.h
+++ b/cpu/samd21/include/component/component_usb.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_USB_COMPONENT_
 #define _SAMR21_USB_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR USB */
 /* ========================================================================== */
@@ -1763,5 +1767,9 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_USB_COMPONENT_ */

--- a/cpu/samd21/include/component/component_wdt.h
+++ b/cpu/samd21/include/component/component_wdt.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_WDT_COMPONENT_
 #define _SAMR21_WDT_COMPONENT_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========================================================================== */
 /**  SOFTWARE API DEFINITION FOR WDT */
 /* ========================================================================== */
@@ -299,5 +303,9 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /*@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_WDT_COMPONENT_ */

--- a/cpu/samd21/include/cpu-conf.h
+++ b/cpu/samd21/include/cpu-conf.h
@@ -20,6 +20,9 @@
 
 #include "samd21.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @name Kernel configuration
@@ -47,6 +50,9 @@
 #endif
 /** @} */
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CPU_CONF_H */
 /** @} */

--- a/cpu/samd21/include/hwtimer_cpu.h
+++ b/cpu/samd21/include/hwtimer_cpu.h
@@ -19,6 +19,10 @@
 #ifndef __HWTIMER_CPU_H
 #define __HWTIMER_CPU_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Hardware timer configuration
  * @{
@@ -28,6 +32,9 @@
 #define HWTIMER_MAXTICKS    (0xFFFF)        /**< 16-bit timer */
 /** @} */
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __HWTIMER_CPU_H */
 /** @} */

--- a/cpu/samd21/include/instance/instance_ac.h
+++ b/cpu/samd21/include/instance/instance_ac.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_AC_INSTANCE_
 #define _SAMR21_AC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for AC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_AC_CTRLA               (0x42004400U) /**< \brief (AC) Control A */
@@ -83,5 +87,9 @@
 #define AC_GCLK_ID_DIG              31
 #define AC_NUM_CMP                  AC_CMP_NUM
 #define AC_PAIRS                    1
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_AC_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_adc.h
+++ b/cpu/samd21/include/instance/instance_adc.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_ADC_INSTANCE_
 #define _SAMR21_ADC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for ADC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_ADC_CTRLA              (0x42004000U) /**< \brief (ADC) Control A */
@@ -95,5 +99,9 @@
 #define ADC_GCLK_ID                 30
 #define ADC_RESULT_BITS             16
 #define ADC_RESULT_MSB              (ADC_RESULT_BITS-1)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_ADC_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_dac.h
+++ b/cpu/samd21/include/instance/instance_dac.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_DAC_INSTANCE_
 #define _SAMR21_DAC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for DAC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_DAC_CTRLA              (0x42004800U) /**< \brief (DAC) Control A */
@@ -70,5 +74,9 @@
 /* ========== Instance parameters for DAC peripheral ========== */
 #define DAC_DMAC_ID_EMPTY           40
 #define DAC_GCLK_ID                 33
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_DAC_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_dmac.h
+++ b/cpu/samd21/include/instance/instance_dmac.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_DMAC_INSTANCE_
 #define _SAMR21_DMAC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for DMAC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_DMAC_CTRL              (0x41004800U) /**< \brief (DMAC) Control */
@@ -103,5 +107,9 @@
 #define DMAC_LVL_NUM                4
 #define DMAC_TRIG_BITS              len(bin(DMAC_TRIG_NUM - 1))-2
 #define DMAC_TRIG_NUM               45
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_DMAC_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_dsu.h
+++ b/cpu/samd21/include/instance/instance_dsu.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_DSU_INSTANCE_
 #define _SAMR21_DSU_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for DSU peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_DSU_CTRL               (0x41002000U) /**< \brief (DSU) Control */
@@ -95,5 +99,9 @@
 
 /* ========== Instance parameters for DSU peripheral ========== */
 #define DSU_CLK_HSB_ID              3
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_DSU_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_eic.h
+++ b/cpu/samd21/include/instance/instance_eic.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_EIC_INSTANCE_
 #define _SAMR21_EIC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for EIC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_EIC_CTRL               (0x40001800U) /**< \brief (EIC) Control */
@@ -74,5 +78,9 @@
 /* ========== Instance parameters for EIC peripheral ========== */
 #define EIC_CONFIG_NUM              ((EIC_EXTINT_NUM+7)/8)
 #define EIC_GCLK_ID                 5
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_EIC_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_evsys.h
+++ b/cpu/samd21/include/instance/instance_evsys.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_EVSYS_INSTANCE_
 #define _SAMR21_EVSYS_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for EVSYS peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_EVSYS_CTRL             (0x42000400U) /**< \brief (EVSYS) Control */
@@ -193,5 +197,9 @@
 #define EVSYS_ID_USER_AC_SOC_1      26
 #define EVSYS_ID_USER_DAC_START     27
 #define EVSYS_ID_USER_PTC_STCONV    28
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_EVSYS_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_gclk.h
+++ b/cpu/samd21/include/instance/instance_gclk.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_GCLK_INSTANCE_
 #define _SAMR21_GCLK_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for GCLK peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_GCLK_CTRL              (0x40000C00U) /**< \brief (GCLK) Control */
@@ -75,5 +79,9 @@
 #define GCLK_SOURCE_OSC32K          4
 #define GCLK_SOURCE_XOSC            0
 #define GCLK_SOURCE_XOSC32K         5
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_GCLK_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_i2s.h
+++ b/cpu/samd21/include/instance/instance_i2s.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_I2S_INSTANCE_
 #define _SAMR21_I2S_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for I2S peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_I2S_CTRLA              (0x42005000U) /**< \brief (I2S) Control A */
@@ -90,5 +94,9 @@
 #define I2S_GCLK_ID_SIZE            2
 #define I2S_MAX_SLOTS               8
 #define I2S_SER_NUM                 2
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_I2S_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_mtb.h
+++ b/cpu/samd21/include/instance/instance_mtb.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_MTB_INSTANCE_
 #define _SAMR21_MTB_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for MTB peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_MTB_POSITION           (0x41006000U) /**< \brief (MTB) MTB Position */
@@ -99,5 +103,8 @@
 #define REG_MTB_CID3               (*(RoReg  *)0x41006FFCU) /**< \brief (MTB) CoreSight */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_MTB_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_nvmctrl.h
+++ b/cpu/samd21/include/instance/instance_nvmctrl.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_NVMCTRL_INSTANCE_
 #define _SAMR21_NVMCTRL_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for NVMCTRL peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_NVMCTRL_CTRLA          (0x41004000U) /**< \brief (NVMCTRL) Control A */
@@ -88,5 +92,9 @@
 #define NVMCTRL_USER_PAGE_ADDRESS   (FLASH_ADDR + NVMCTRL_USER_PAGE_OFFSET)
 #define NVMCTRL_USER_PAGE_OFFSET    0x00800000
 #define NVMCTRL_USER_WORD_IMPLEMENTED_MASK 0xC01FFFFFFFFFFFFF
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_NVMCTRL_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_pac0.h
+++ b/cpu/samd21/include/instance/instance_pac0.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_PAC0_INSTANCE_
 #define _SAMR21_PAC0_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for PAC0 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_PAC0_WPCLR             (0x40000000U) /**< \brief (PAC0) Write Protection Clear */
@@ -55,5 +59,9 @@
 
 /* ========== Instance parameters for PAC0 peripheral ========== */
 #define PAC0_WPROT_DEFAULT_VAL      0x00000000
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_PAC0_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_pac1.h
+++ b/cpu/samd21/include/instance/instance_pac1.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_PAC1_INSTANCE_
 #define _SAMR21_PAC1_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for PAC1 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_PAC1_WPCLR             (0x41000000U) /**< \brief (PAC1) Write Protection Clear */
@@ -55,5 +59,9 @@
 
 /* ========== Instance parameters for PAC1 peripheral ========== */
 #define PAC1_WPROT_DEFAULT_VAL      0x00000000
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_PAC1_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_pac2.h
+++ b/cpu/samd21/include/instance/instance_pac2.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_PAC2_INSTANCE_
 #define _SAMR21_PAC2_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for PAC2 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_PAC2_WPCLR             (0x42000000U) /**< \brief (PAC2) Write Protection Clear */
@@ -55,5 +59,9 @@
 
 /* ========== Instance parameters for PAC2 peripheral ========== */
 #define PAC2_WPROT_DEFAULT_VAL      0x00800000
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_PAC2_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_pm.h
+++ b/cpu/samd21/include/instance/instance_pm.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_PM_INSTANCE_
 #define _SAMR21_PM_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for PM peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_PM_CTRL                (0x40000400U) /**< \brief (PM) Control */
@@ -83,5 +87,9 @@
 #define PM_CTRL_MCSEL_OSC8M         1
 #define PM_CTRL_MCSEL_XOSC          2
 #define PM_PM_CLK_APB_NUM           2
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_PM_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_port.h
+++ b/cpu/samd21/include/instance/instance_port.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_PORT_INSTANCE_
 #define _SAMR21_PORT_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for PORT peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_PORT_DIR0              (0x41004400U) /**< \brief (PORT) Data Direction 0 */
@@ -158,5 +162,9 @@
 #define PORT_SLEWLIM                0
 #define PORT_SLEWLIM_DEFAULT_VAL    { 0x00000000, 0x00000000, 0x00000000 }
 #define PORT_SLEWLIM_IMPLEMENTED    { 0x00000000, 0x00000000, 0x00000000 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_PORT_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_rfctrl.h
+++ b/cpu/samd21/include/instance/instance_rfctrl.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_RFCTRL_INSTANCE_
 #define _SAMR21_RFCTRL_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for RFCTRL peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_RFCTRL_FECFG           (0x42005400U) /**< \brief (RFCTRL) Front-end control bus configuration */
@@ -53,5 +57,9 @@
 
 /* ========== Instance parameters for RFCTRL peripheral ========== */
 #define RFCTRL_FBUSMSB              5
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_RFCTRL_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_rtc.h
+++ b/cpu/samd21/include/instance/instance_rtc.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_RTC_INSTANCE_
 #define _SAMR21_RTC_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for RTC peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_RTC_READREQ            (0x40001402U) /**< \brief (RTC) Read Request */
@@ -113,5 +117,9 @@
 #define RTC_NUM_OF_ALARMS           RTC_ALARM_NUM
 #define RTC_NUM_OF_COMP16           RTC_COMP16_NUM
 #define RTC_NUM_OF_COMP32           RTC_COMP32_NUM
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_RTC_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_sercom0.h
+++ b/cpu/samd21/include/instance/instance_sercom0.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_SERCOM0_INSTANCE_
 #define _SAMR21_SERCOM0_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for SERCOM0 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_SERCOM0_I2CM_CTRLA     (0x42000800U) /**< \brief (SERCOM0) I2CM Control A */
@@ -139,5 +143,9 @@
 #define SERCOM0_GCLK_ID_CORE        20
 #define SERCOM0_GCLK_ID_SLOW        19
 #define SERCOM0_INT_MSB             6
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_SERCOM0_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_sercom1.h
+++ b/cpu/samd21/include/instance/instance_sercom1.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_SERCOM1_INSTANCE_
 #define _SAMR21_SERCOM1_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for SERCOM1 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_SERCOM1_I2CM_CTRLA     (0x42000C00U) /**< \brief (SERCOM1) I2CM Control A */
@@ -139,5 +143,9 @@
 #define SERCOM1_GCLK_ID_CORE        21
 #define SERCOM1_GCLK_ID_SLOW        19
 #define SERCOM1_INT_MSB             6
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_SERCOM1_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_sercom2.h
+++ b/cpu/samd21/include/instance/instance_sercom2.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_SERCOM2_INSTANCE_
 #define _SAMR21_SERCOM2_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for SERCOM2 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_SERCOM2_I2CM_CTRLA     (0x42001000U) /**< \brief (SERCOM2) I2CM Control A */
@@ -139,5 +143,9 @@
 #define SERCOM2_GCLK_ID_CORE        22
 #define SERCOM2_GCLK_ID_SLOW        19
 #define SERCOM2_INT_MSB             6
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_SERCOM2_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_sercom3.h
+++ b/cpu/samd21/include/instance/instance_sercom3.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_SERCOM3_INSTANCE_
 #define _SAMR21_SERCOM3_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for SERCOM3 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_SERCOM3_I2CM_CTRLA     (0x42001400U) /**< \brief (SERCOM3) I2CM Control A */
@@ -139,5 +143,9 @@
 #define SERCOM3_GCLK_ID_CORE        23
 #define SERCOM3_GCLK_ID_SLOW        19
 #define SERCOM3_INT_MSB             6
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_SERCOM3_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_sercom4.h
+++ b/cpu/samd21/include/instance/instance_sercom4.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_SERCOM4_INSTANCE_
 #define _SAMR21_SERCOM4_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for SERCOM4 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_SERCOM4_I2CM_CTRLA     (0x42001800U) /**< \brief (SERCOM4) I2CM Control A */
@@ -139,5 +143,9 @@
 #define SERCOM4_GCLK_ID_CORE        24
 #define SERCOM4_GCLK_ID_SLOW        19
 #define SERCOM4_INT_MSB             6
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_SERCOM4_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_sercom5.h
+++ b/cpu/samd21/include/instance/instance_sercom5.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_SERCOM5_INSTANCE_
 #define _SAMR21_SERCOM5_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for SERCOM5 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_SERCOM5_I2CM_CTRLA     (0x42001C00U) /**< \brief (SERCOM5) I2CM Control A */
@@ -139,5 +143,9 @@
 #define SERCOM5_GCLK_ID_CORE        25
 #define SERCOM5_GCLK_ID_SLOW        19
 #define SERCOM5_INT_MSB             6
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_SERCOM5_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_sysctrl.h
+++ b/cpu/samd21/include/instance/instance_sysctrl.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_SYSCTRL_INSTANCE_
 #define _SAMR21_SYSCTRL_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for SYSCTRL peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_SYSCTRL_INTENCLR       (0x40000800U) /**< \brief (SYSCTRL) Interrupt Enable Clear */
@@ -116,5 +120,9 @@
 #define SYSCTRL_VREG_VERSION        0x201
 #define SYSCTRL_XOSC_VERSION        0x111
 #define SYSCTRL_XOSC32K_VERSION     0x111
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_SYSCTRL_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_tc3.h
+++ b/cpu/samd21/include/instance/instance_tc3.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_TC3_INSTANCE_
 #define _SAMR21_TC3_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for TC3 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_TC3_CTRLA              (0x42002C00U) /**< \brief (TC3) Control A */
@@ -107,5 +111,9 @@
 #define TC3_OW_NUM                  2
 #define TC3_PERIOD_EXT              0
 #define TC3_SHADOW_EXT              0
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_TC3_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_tc4.h
+++ b/cpu/samd21/include/instance/instance_tc4.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_TC4_INSTANCE_
 #define _SAMR21_TC4_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for TC4 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_TC4_CTRLA              (0x42003000U) /**< \brief (TC4) Control A */
@@ -107,5 +111,9 @@
 #define TC4_OW_NUM                  2
 #define TC4_PERIOD_EXT              0
 #define TC4_SHADOW_EXT              0
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_TC4_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_tc5.h
+++ b/cpu/samd21/include/instance/instance_tc5.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_TC5_INSTANCE_
 #define _SAMR21_TC5_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for TC5 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_TC5_CTRLA              (0x42003400U) /**< \brief (TC5) Control A */
@@ -107,5 +111,9 @@
 #define TC5_OW_NUM                  2
 #define TC5_PERIOD_EXT              0
 #define TC5_SHADOW_EXT              0
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_TC5_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_tc6.h
+++ b/cpu/samd21/include/instance/instance_tc6.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_TC6_INSTANCE_
 #define _SAMR21_TC6_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for TC6 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_TC6_CTRLA              (0x42003800U) /**< \brief (TC6) Control A */
@@ -107,5 +111,9 @@
 #define TC6_OW_NUM                  2
 #define TC6_PERIOD_EXT              0
 #define TC6_SHADOW_EXT              0
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_TC6_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_tc7.h
+++ b/cpu/samd21/include/instance/instance_tc7.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_TC7_INSTANCE_
 #define _SAMR21_TC7_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for TC7 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_TC7_CTRLA              (0x42003C00U) /**< \brief (TC7) Control A */
@@ -107,5 +111,9 @@
 #define TC7_OW_NUM                  2
 #define TC7_PERIOD_EXT              0
 #define TC7_SHADOW_EXT              0
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_TC7_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_tcc0.h
+++ b/cpu/samd21/include/instance/instance_tcc0.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_TCC0_INSTANCE_
 #define _SAMR21_TCC0_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for TCC0 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_TCC0_CTRLA             (0x42002000U) /**< \brief (TCC0) Control A */
@@ -127,5 +131,9 @@
 #define TCC0_PG                     1
 #define TCC0_SIZE                   24
 #define TCC0_SWAP                   1
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_TCC0_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_tcc1.h
+++ b/cpu/samd21/include/instance/instance_tcc1.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_TCC1_INSTANCE_
 #define _SAMR21_TCC1_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for TCC1 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_TCC1_CTRLA             (0x42002400U) /**< \brief (TCC1) Control A */
@@ -115,5 +119,9 @@
 #define TCC1_PG                     1
 #define TCC1_SIZE                   24
 #define TCC1_SWAP                   0
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_TCC1_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_tcc2.h
+++ b/cpu/samd21/include/instance/instance_tcc2.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_TCC2_INSTANCE_
 #define _SAMR21_TCC2_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for TCC2 peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_TCC2_CTRLA             (0x42002800U) /**< \brief (TCC2) Control A */
@@ -111,5 +115,9 @@
 #define TCC2_PG                     0
 #define TCC2_SIZE                   16
 #define TCC2_SWAP                   0
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_TCC2_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_usb.h
+++ b/cpu/samd21/include/instance/instance_usb.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_USB_INSTANCE_
 #define _SAMR21_USB_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for USB peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_USB_CTRLA              (0x41005000U) /**< \brief (USB) Control A */
@@ -338,5 +342,9 @@
 #define USB_EPT_NUM                 8
 #define USB_GCLK_ID                 6
 #define USB_PIPE_NUM                8
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_USB_INSTANCE_ */

--- a/cpu/samd21/include/instance/instance_wdt.h
+++ b/cpu/samd21/include/instance/instance_wdt.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21_WDT_INSTANCE_
 #define _SAMR21_WDT_INSTANCE_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ========== Register definition for WDT peripheral ========== */
 #if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 #define REG_WDT_CTRL               (0x40001000U) /**< \brief (WDT) Control */
@@ -67,5 +71,9 @@
 
 /* ========== Instance parameters for WDT peripheral ========== */
 #define WDT_GCLK_ID                 3
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21_WDT_INSTANCE_ */

--- a/cpu/samd21/include/pio/pio_samr21g18a.h
+++ b/cpu/samd21/include/pio/pio_samr21g18a.h
@@ -44,6 +44,10 @@
 #ifndef _SAMR21G18A_PIO_
 #define _SAMR21G18A_PIO_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
 #define PORT_PA00                  (1u <<  0) /**< \brief PORT Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
@@ -1005,5 +1009,9 @@
 #define MUX_PA15F_RFCTRL_FECTRL5           5
 #define PINMUX_PA15F_RFCTRL_FECTRL5  ((PIN_PA15F_RFCTRL_FECTRL5 << 16) | MUX_PA15F_RFCTRL_FECTRL5)
 #define PORT_PA15F_RFCTRL_FECTRL5  (1u << 15)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SAMR21G18A_PIO_ */

--- a/cpu/samd21/include/samd21.h
+++ b/cpu/samd21/include/samd21.h
@@ -55,12 +55,13 @@
 */
 /*@{*/
 
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+
 #ifdef __cplusplus
  extern "C" {
 #endif
 
-#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-#include <stdint.h>
 #ifndef __cplusplus
 typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
 typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
@@ -236,6 +237,10 @@ void I2S_Handler                 ( void );
 /**
  * \brief CMSIS includes
  */
+
+#ifdef __cplusplus
+}
+#endif
 
 #include <core_cm0plus.h>
 #if !defined DONT_USE_CMSIS_INIT
@@ -541,11 +546,6 @@ void I2S_Handler                 ( void );
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAMR21G18A */
 /* ************************************************************************** */
-
-
-#ifdef __cplusplus
-}
-#endif
 
 /*@}*/
 

--- a/cpu/stm32f0/include/cpu-conf.h
+++ b/cpu/stm32f0/include/cpu-conf.h
@@ -25,6 +25,9 @@
 #include "stm32f051x8.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @name Kernel configuration
@@ -54,6 +57,10 @@
 #define UART0_BUFSIZE                   (128)
 #endif
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CPU_CONF_H */
 /** @} */

--- a/cpu/stm32f0/include/hwtimer_cpu.h
+++ b/cpu/stm32f0/include/hwtimer_cpu.h
@@ -19,6 +19,10 @@
 #ifndef __HWTIMER_CPU_H
 #define __HWTIMER_CPU_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Hardware timer configuration
  * @{
@@ -27,6 +31,10 @@
 #define HWTIMER_SPEED       1000000         /**< the HW timer runs with 1MHz */
 #define HWTIMER_MAXTICKS    (0xFFFFFFFF)    /**< 32-bit timer */
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __HWTIMER_CPU_H */
 /** @} */

--- a/cpu/stm32f1/include/cpu-conf.h
+++ b/cpu/stm32f1/include/cpu-conf.h
@@ -25,6 +25,10 @@
 
 #include "stm32f10x.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Kernel configuration
  *
@@ -70,6 +74,10 @@ typedef enum {
 void cpu_clock_scale(uint32_t source, uint32_t target, uint32_t *prescale);
 
 #define TRANSCEIVER_BUFFER_SIZE (3)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CPU_CONF_H */
 /** @} */

--- a/cpu/stm32f1/include/hwtimer_cpu.h
+++ b/cpu/stm32f1/include/hwtimer_cpu.h
@@ -19,6 +19,10 @@
 #ifndef HWTIMER_CPU_H_
 #define HWTIMER_CPU_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Hardware timer configuration
  * @{
@@ -28,6 +32,10 @@
 #define HWTIMER_MAXTICKS    (0xFFFFFFFF)    /**< 32-bit timer */
 #define HWTIMER_WAIT_OVERHEAD (3)
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* HWTIMER_CPU_H_ */
 /** @} */

--- a/cpu/stm32f1/include/stm32f10x.h
+++ b/cpu/stm32f1/include/stm32f10x.h
@@ -477,8 +477,16 @@ typedef enum IRQn
   * @}
   */
 
+#ifdef __cplusplus
+}
+#endif
+
 #include "core_cm3.h"
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @addtogroup cpu_specific_Exported_types
   * @{
@@ -8294,8 +8302,16 @@ typedef struct
   * @}
   */
 
+#ifdef __cplusplus
+}
+#endif
+
 #ifdef USE_STDPERIPH_DRIVER
   #include "stm32f10x_conf.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 /** @addtogroup cpu_specific_Exported_macro

--- a/cpu/stm32f3/include/cpu-conf.h
+++ b/cpu/stm32f3/include/cpu-conf.h
@@ -51,5 +51,13 @@
 #endif
 /** @} */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __CPU_CONF_H */
 /** @} */

--- a/cpu/stm32f3/include/hwtimer_cpu.h
+++ b/cpu/stm32f3/include/hwtimer_cpu.h
@@ -19,6 +19,10 @@
 #ifndef __HWTIMER_CPU_H
 #define __HWTIMER_CPU_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Hardware timer configuration
  * @{
@@ -27,6 +31,10 @@
 #define HWTIMER_SPEED       1000000         /**< the HW timer runs with 1MHz */
 #define HWTIMER_MAXTICKS    (0xFFFFFFFF)    /**< 32-bit timer */
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __HWTIMER_CPU_H */
 /** @} */

--- a/cpu/stm32f4/include/cpu-conf.h
+++ b/cpu/stm32f4/include/cpu-conf.h
@@ -53,5 +53,13 @@
 #endif
 /** @} */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __CPU_CONF_H */
 /** @} */

--- a/cpu/stm32f4/include/hwtimer_cpu.h
+++ b/cpu/stm32f4/include/hwtimer_cpu.h
@@ -19,6 +19,10 @@
 #ifndef __HWTIMER_CPU_H
 #define __HWTIMER_CPU_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Hardware timer configuration
  * @{
@@ -27,6 +31,10 @@
 #define HWTIMER_SPEED       1000000         /**< the HW timer runs with 1MHz */
 #define HWTIMER_MAXTICKS    (0xFFFFFFFF)    /**< 32-bit timer */
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __HWTIMER_CPU_H */
 /** @} */

--- a/cpu/x86/include/cpu.h
+++ b/cpu/x86/include/cpu.h
@@ -39,6 +39,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static inline void __attribute__((always_inline)) dINT(void)
 {
     asm volatile ("cli");
@@ -115,6 +119,10 @@ void x86_init_board(void);
  * The regions are expected to contain memory that lies inside the elf sections.
  */
 bool x86_get_memory_region(uint64_t *start, uint64_t *len, unsigned long *cnt);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/hwtimer_cpu.h
+++ b/cpu/x86/include/hwtimer_cpu.h
@@ -29,6 +29,10 @@
 #ifndef CPU__X86__HWTIMER_CPU__H__
 #define CPU__X86__HWTIMER_CPU__H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   Number of configured hardware timers.
  *
@@ -52,6 +56,10 @@
  * Since 1 tick = 1 µs, this number will flow over after 4295 seconds (1h11m34s).
  */
 #define HWTIMER_MAXTICKS (0xFFFFFFFFu)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/ucontext.h
+++ b/cpu/x86/include/ucontext.h
@@ -31,6 +31,10 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   Common stacksize for a signal handler.
  *
@@ -160,6 +164,10 @@ void makecontext(ucontext_t *ucp, makecontext_fun_t func, int argc, ...);
  * Same restrictions apply.
  */
 int swapcontext(ucontext_t *oucp, const ucontext_t *ucp);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/x86_cmos.h
+++ b/cpu/x86/include/x86_cmos.h
@@ -32,6 +32,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CMOS_ADDRESS (0x70)
 #define CMOS_DATA    (0x71)
 
@@ -57,6 +61,10 @@ void x86_cmos_write(int reg, uint8_t value);
  * The implementor of the board specific code should know whether the BIOS contains a serial number.
  */
 void x86_cmos_serial(uint8_t (*serial)[CMOS_SERIAL_LEN]);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/x86_hwtimer.h
+++ b/cpu/x86/include/x86_hwtimer.h
@@ -29,6 +29,10 @@
 #ifndef CPU__X86__HWTIMER__H__
 #define CPU__X86__HWTIMER__H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   Do timestamping to enable the use of the hwtimer module.
  *
@@ -36,6 +40,10 @@
  * You must not call this function on your own accord.
  */
 void x86_init_hwtimer(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/x86_interrupts.h
+++ b/cpu/x86/include/x86_interrupts.h
@@ -33,6 +33,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   Initialize interrupts.
  *
@@ -151,6 +155,10 @@ static inline void __attribute__((always_inline)) x86_restore_flags(unsigned lon
  * @brief   Print saved general purposed registers.
  */
 void x86_print_registers(struct x86_pushad *orig_ctx, unsigned long error_code);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/x86_kernel_memory.h
+++ b/cpu/x86/include/x86_kernel_memory.h
@@ -28,6 +28,10 @@
 #ifndef KERNEL_MEMORY_H__
 #define KERNEL_MEMORY_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   First byte inside the elf segments.
  *
@@ -110,6 +114,10 @@ extern char _kernel_memory_end;
  * There should be a space between _kernel_memory_end and _heap_start, but it does not have to.
  */
 extern char _heap_start;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/x86_memory.h
+++ b/cpu/x86/include/x86_memory.h
@@ -31,6 +31,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   Maximum static size of the kernel.
  *
@@ -169,6 +173,10 @@ void x86_release_virtual_pages(uint32_t virtual_start, unsigned pages);
  *            0x0010 is the data segment, from 0x00000000 to 0xFFFFFFFF, non-executable, writable.
  */
 void x86_init_gdt(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/x86_pci.h
+++ b/cpu/x86/include/x86_pci.h
@@ -35,6 +35,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   Initialize the Peripheral Component Interconnect.
  *
@@ -409,6 +413,10 @@ void x86_pci_write16(unsigned bus, unsigned dev, unsigned fun, unsigned reg, uin
  * Bad things will happen if you supply any other value.
  */
 void x86_pci_set_irq(struct x86_known_pci_device *d, uint8_t irq_num);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/x86_pci_init.h
+++ b/cpu/x86/include/x86_pci_init.h
@@ -19,8 +19,16 @@
 #ifndef __X86__PCI_INIT__H
 #define __X86__PCI_INIT__H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* no PCI devices are implemented, yet */
 
 void x86_init_pci_devices(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/cpu/x86/include/x86_pci_strings.h
+++ b/cpu/x86/include/x86_pci_strings.h
@@ -28,6 +28,10 @@
 #ifndef CPU__X86__PCI_NAMES__H__
 #define CPU__X86__PCI_NAMES__H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief        Get a string representation of the device class.
  * @param[out]   baseclass_name   Name of the base class. Supply NULL if you do not care.
@@ -47,6 +51,10 @@ const char *x86_pci_subclass_to_string(unsigned baseclass, unsigned subclass, un
  * This function is not thread safe.
  */
 const char *x86_pci_device_id_to_string(unsigned vendor_id, unsigned device_id, const char **vendor_name);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/x86_pic.h
+++ b/cpu/x86/include/x86_pic.h
@@ -30,6 +30,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   Initialize the Programmable Interrupt Controller.
  *
@@ -162,6 +166,10 @@ void x86_pic_enable_irq(unsigned num);
  * This function should only be called by other subsystems like the PCI subsystem.
  */
 void x86_pic_disable_irq(unsigned num);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/x86_pit.h
+++ b/cpu/x86/include/x86_pit.h
@@ -37,6 +37,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define PIT_CHANNEL_0_PORT (0x40) /**< Channel 0 */
 #define PIT_CHANNEL_1_PORT (0x41) /**< Channel 1, DO NOT USE */
 #define PIT_CHANNEL_2_PORT (0x42) /**< Channel 2, do not use if you can help it */
@@ -108,6 +112,10 @@ void x86_pit_set2(unsigned channel, unsigned mode, uint16_t max);
  * Beware: the 1,193,163 different values for hz will only render 2,165 different values for max.
  */
 bool x86_pit_set(unsigned channel, unsigned mode, unsigned hz);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/x86_ports.h
+++ b/cpu/x86/include/x86_ports.h
@@ -29,6 +29,10 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief        Reads and returns a byte from PORT.
  * @param[in]    port   Port to read from.
@@ -182,5 +186,9 @@ static inline void  __attribute__((always_inline)) io_wait(void)
                  "1: jmp 2f\n"
                  "2:");
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/cpu/x86/include/x86_reboot.h
+++ b/cpu/x86/include/x86_reboot.h
@@ -30,6 +30,10 @@
 
 #include "kernel.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   Prototype for a x86 reboot function.
  *
@@ -83,6 +87,10 @@ bool x86_shutdown(void);
  * @brief   Function to call on x86_shutdown()
  */
 void x86_set_shutdown_fun(x86_shutdown_t fun);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/x86_registers.h
+++ b/cpu/x86/include/x86_registers.h
@@ -30,6 +30,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* see "Intel® Quark SoC X1000 Core Developer’s Manual", § 4.4.1.1 (p. 47) */
 #define CR0_PE (1u << 0)  /**< 1 = protected mode */
 #define CR0_MP (1u << 1)  /**< 1 = monitor coprocessor (FWAIT causes an interrupt) */
@@ -246,6 +250,10 @@ static inline uint64_t X86_CR_ATTR cpuid_caps(void)
     asm volatile ("cpuid" : "=d"(edx), "=c"(ecx) : "a"(1) : "ebx");
     return ((uint64_t) ecx << 32) | edx;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/x86_rtc.h
+++ b/cpu/x86/include/x86_rtc.h
@@ -36,6 +36,10 @@
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   A timestamp.
  *
@@ -205,6 +209,10 @@ void x86_rtc_set_periodic_callback(x86_rtc_callback_t cb);
  * because the hwtimer subsystem gets set up before the message system works.
  */
 void x86_rtc_set_update_callback(x86_rtc_callback_t cb);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/x86_threading.h
+++ b/cpu/x86/include/x86_threading.h
@@ -31,6 +31,10 @@
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   Initialize threading.
  *
@@ -43,6 +47,10 @@ void x86_init_threading(void);
  * @brief   The getter/setter for inISR() for the x86 port.
  */
 extern bool x86_in_isr;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/x86_uart.h
+++ b/cpu/x86/include/x86_uart.h
@@ -35,6 +35,10 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   Early initialization of the UART system, before there are interrupts.
  *
@@ -170,6 +174,10 @@ enum iir_t {
     IIR_FIFO_MAL     = 2 << 6, /* FIFO enabled, not working */
     IIR_FIFO_ENABLED = 3 << 6, /* FIFO enabled */
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/cpu/x86/include/x86_videoram.h
+++ b/cpu/x86/include/x86_videoram.h
@@ -28,6 +28,10 @@
 #ifndef CPU__X86__VIDEORAM_H__
 #define CPU__X86__VIDEORAM_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   Print out a single character on the graphical device.
  *
@@ -56,6 +60,10 @@ void videoram_puts(const char *s);
  * @brief   Print out a hexadecimal number on the graphical device, including "0x" at the start.
  */
 void videoram_put_hex(unsigned long v);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 


### PR DESCRIPTION
This PR adds `extern "C"` to the header files in ./RIOT/cpu/\* folders.
