### PR TITLE
cpu/nrf51822: fixed issue with disabled RAM

### DIFF
--- a/cpu/nrf51822/startup.c
+++ b/cpu/nrf51822/startup.c
@@ -20,6 +20,7 @@
 
 #include <stdint.h>
 #include "board.h"
+#include "cpu.h"
 
 /**
  * memory markers as defined in the linker script
@@ -56,6 +57,11 @@ void reset_handler(void)
 {
     uint32_t *dst;
     uint32_t *src = &_etext;
+
+    /* make sure all RAM blocks are turned on
+     * -> see NRF51822 Product Anomaly Notice (PAN) #16 for more details
+     */
+    NRF_POWER->RAMON = 0xf;
 
     /* load data section from flash to ram */
     for (dst = &_srelocate; dst < &_erelocate; ) {


### PR DESCRIPTION
- on certain devices the second RAM bank might be disabled after
  reset, this fix makes sure its enabled
