### PR TITLE
core: moved `#include`s outside the `extern "C"` guards

### DIFF
--- a/core/include/arch/thread_arch.h
+++ b/core/include/arch/thread_arch.h
@@ -19,11 +19,11 @@
 #ifndef __THREAD_ARCH_H
 #define __THREAD_ARCH_H
 
+#include "attributes.h"
+
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-#include "attributes.h"
 
 /**
  * @name Define the mapping between the architecture independent interfaces

--- a/core/include/atomic.h
+++ b/core/include/atomic.h
@@ -19,11 +19,11 @@
 #ifndef _ATOMIC_H
 #define _ATOMIC_H
 
+#include "arch/atomic_arch.h"
+
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-#include "arch/atomic_arch.h"
 
 /**
  * @brief Sets a new and returns the old value of a variable atomically

--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -21,6 +21,9 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* ******************************* INTERFACE ******************************* */
 
@@ -309,6 +312,10 @@ uint64_t byteorder_ntohll(network_uint64_t v)
 {
     return _byteorder_swap(v.u64, ll);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* BYTEORDER_H_ */
 /** @} */

--- a/core/include/clist.h
+++ b/core/include/clist.h
@@ -19,11 +19,11 @@
 #ifndef __CLIST_H
 #define __CLIST_H
 
+#include "kernel_macros.h"
+
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-#include "kernel_macros.h"
 
 /**
  * @def         clist_get_container(NODE, TYPE, MEMBER)

--- a/core/include/config.h
+++ b/core/include/config.h
@@ -19,11 +19,11 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-#include <stdint.h>
 
 #define CONFIG_KEY      (0x1701)    /**< key to identify configuration             */
 #define CONFIG_NAME_LEN (10)        /**< length of name for configuration in bytes */

--- a/core/include/crash.h
+++ b/core/include/crash.h
@@ -22,11 +22,11 @@
 #ifndef __CRASH_H
 #define __CRASH_H
 
+#include "kernel.h"
+
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-#include "kernel.h"
 
 /**
  * @brief Handle an unrecoverable error by halting or rebooting the system

--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -21,12 +21,12 @@
 #ifndef __DEBUG_H
 #define __DEBUG_H
 
+#include <stdio.h>
+#include "sched.h"
+
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-#include <stdio.h>
-#include "sched.h"
 
 /**
  * @name Print debug information if the calling thread stack is large enough

--- a/core/include/hwtimer.h
+++ b/core/include/hwtimer.h
@@ -33,13 +33,13 @@
 #ifndef __HWTIMER_H
 #define __HWTIMER_H
 
-#ifdef __cplusplus
- extern "C" {
-#endif
-
 #include <stdint.h>
 #include "hwtimer_cpu.h"
 #include "board.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
 
 /**
  * @brief   Number of kernel timer ticks per second

--- a/core/include/irq.h
+++ b/core/include/irq.h
@@ -21,12 +21,12 @@
 #ifndef IRQ_H_
 #define IRQ_H_
 
+#include <stdbool.h>
+#include "arch/irq_arch.h"
+
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-#include <stdbool.h>
-#include "arch/irq_arch.h"
 
 /**
  * @brief   This function sets the IRQ disable bit in the status register

--- a/core/include/kernel.h
+++ b/core/include/kernel.h
@@ -22,10 +22,6 @@
 #ifndef KERNEL_H_
 #define KERNEL_H_
 
-#ifdef __cplusplus
- extern "C" {
-#endif
-
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -36,6 +32,10 @@
 #include "flags.h"
 #include "sched.h"
 #include "cpu-conf.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
 
 /**
  * @def KERNEL_CONF_STACKSIZE_DEFAULT

--- a/core/include/kernel_internal.h
+++ b/core/include/kernel_internal.h
@@ -19,11 +19,11 @@
 #ifndef KERNEL_INTERNAL_H_
 #define KERNEL_INTERNAL_H_
 
+#include "attributes.h"
+
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-#include "attributes.h"
 
 /**
  * @brief   Initializes scheduler and creates main and idle task

--- a/core/include/kernel_macros.h
+++ b/core/include/kernel_macros.h
@@ -18,6 +18,10 @@
 
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @def         container_of(PTR, TYPE, MEMBER)
  * @brief       Returns the container of a pointer to a member.
@@ -48,6 +52,10 @@
 #else
 #   define container_of(PTR, TYPE, MEMBER) \
         ((TYPE *) ((char *) (PTR) - offsetof(TYPE, MEMBER)))
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 /**

--- a/core/include/kernel_types.h
+++ b/core/include/kernel_types.h
@@ -6,7 +6,6 @@
  * directory for more details.
  */
 
-
 /**
  * @addtogroup  core_util
  * @{
@@ -21,10 +20,6 @@
 
 #ifndef KERNEL_TYPES_H
 #define KERNEL_TYPES_H
-
-#ifdef __cplusplus
- extern "C" {
-#endif
 
 #include <stdint.h>
 #include <inttypes.h>
@@ -45,6 +40,10 @@
 #   if defined (MODULE_MSP430_COMMON) || defined (MODULE_ATMEGA_COMMON)
         typedef signed ssize_t;
 #   endif
+#endif
+
+#ifdef __cplusplus
+ extern "C" {
 #endif
 
 /**

--- a/core/include/lpm.h
+++ b/core/include/lpm.h
@@ -23,11 +23,11 @@
 #ifndef LPM_H_
 #define LPM_H_
 
+#include "arch/lpm_arch.h"
+
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-#include "arch/lpm_arch.h"
 
 /**
  * @brief   Initialization of power management (including clock setup)

--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -32,13 +32,13 @@
 #ifndef __MSG_H_
 #define __MSG_H_
 
-#ifdef __cplusplus
- extern "C" {
-#endif
-
 #include <stdint.h>
 #include <stdbool.h>
 #include "kernel_types.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
 
 /**
  * @brief Describes a message object which can be sent between threads.

--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -21,11 +21,11 @@
 #ifndef __MUTEX_H_
 #define __MUTEX_H_
 
+#include "priority_queue.h"
+
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-#include "priority_queue.h"
 
 /**
  * @brief Mutex structure. Must never be modified by the user.

--- a/core/include/priority_queue.h
+++ b/core/include/priority_queue.h
@@ -19,12 +19,12 @@
 #ifndef __QUEUE_H
 #define __QUEUE_H
 
+#include <stddef.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-#include <stddef.h>
-#include <stdint.h>
 
 /**
  * data type for priority queue nodes

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -80,15 +80,15 @@
 #ifndef _SCHEDULER_H
 #define _SCHEDULER_H
 
-#ifdef __cplusplus
- extern "C" {
-#endif
-
 #include <stddef.h>
 #include "bitarithm.h"
 #include "tcb.h"
 #include "attributes.h"
 #include "kernel_types.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
 
 /**
  * @def SCHED_PRIO_LEVELS

--- a/core/include/tcb.h
+++ b/core/include/tcb.h
@@ -20,15 +20,15 @@
 #ifndef TCB_H_
 #define TCB_H_
 
-#ifdef __cplusplus
- extern "C" {
-#endif
-
 #include <stdint.h>
 #include "priority_queue.h"
 #include "clist.h"
 #include "cib.h"
 #include "msg.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
 
 /**
  * @brief Thread status list

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -21,13 +21,13 @@
 #ifndef __THREAD_H
 #define __THREAD_H
 
-#ifdef __cplusplus
- extern "C" {
-#endif
-
 #include "kernel.h"
 #include "tcb.h"
 #include "arch/thread_arch.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
 
 #define STATUS_NOT_FOUND (-1)
 


### PR DESCRIPTION
moved `#include`s outside the `extern "C"` guards
