### PR TITLE
boards: add `extern "C"` to header files

### DIFF
--- a/boards/arduino-due/include/board.h
+++ b/boards/arduino-due/include/board.h
@@ -23,6 +23,10 @@
 
 #include "cpu.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Define the nominal CPU core clock in this board
  */
@@ -70,6 +74,10 @@
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /** __BOARD_H */
 /** @} */

--- a/boards/arduino-due/include/periph_conf.h
+++ b/boards/arduino-due/include/periph_conf.h
@@ -20,6 +20,10 @@
 #ifndef __PERIPH_CONF_H
 #define __PERIPH_CONF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Timer peripheral configuration
  * @{
@@ -221,6 +225,10 @@
 #define GPIO_15_IRQ         PIOB_IRQn
 #define GPIO_B14_MAP        15
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_CONF_H */
 /** @} */

--- a/boards/arduino-mega2560/include/board.h
+++ b/boards/arduino-mega2560/include/board.h
@@ -23,6 +23,10 @@
 
 #include "cpu.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Define the nominal CPU core clock in this board
  */
@@ -75,6 +79,9 @@
  */
 void board_init(void);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /** __BOARD_H */
 /** @} */

--- a/boards/arduino-mega2560/include/periph_conf.h
+++ b/boards/arduino-mega2560/include/periph_conf.h
@@ -19,6 +19,9 @@
 #ifndef __PERIPH_CONF_H
 #define __PERIPH_CONF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @name        Timer peripheral configuration
@@ -278,5 +281,9 @@
 #define GPIO_13_EN          0
 #define GPIO_14_EN          0
 #define GPIO_15_EN          0
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_CONF_H */

--- a/boards/avsextrem/include/board.h
+++ b/boards/avsextrem/include/board.h
@@ -27,6 +27,10 @@
 #include "bitarithm.h"
 #include "msba2_common.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define LED_RED_PIN (BIT25)
 #define LED_GREEN_PIN (BIT26)
 
@@ -48,6 +52,10 @@
 void init_clks1(void);
 
 typedef uint8_t radio_packet_length_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* BOARDCONF_H_ */

--- a/boards/avsextrem/include/periph_conf.h
+++ b/boards/avsextrem/include/periph_conf.h
@@ -21,6 +21,10 @@
 
 #include "lpc2387.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief PWM device and pinout configuration
  */
@@ -41,6 +45,9 @@
 #define PWM_0_CH2_PIN       (4)
 #define PWM_0_FUNC          (1)
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_CONF_H */
 /** @} */

--- a/boards/avsextrem/include/smb380-board.h
+++ b/boards/avsextrem/include/smb380-board.h
@@ -26,6 +26,10 @@
 #include <stdint.h>
 #include "bitarithm.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define SMB380_DEBUG_MESSAGE "SMB380 Driver Error: "
 
 #define MSG_TYPE_SMB380_WAKEUP          814
@@ -250,5 +254,8 @@ void SMB380_writeOffsetTemp(uint16_t *offset, uint8_t EEPROM);
 void SMB380_ShowMemory(void);
 void SMB380_Selftest_1(void);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif   /* SMB380_H_ */

--- a/boards/avsextrem/include/ssp0-board.h
+++ b/boards/avsextrem/include/ssp0-board.h
@@ -24,6 +24,10 @@
 
 #include "stdint.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define DMA_ENABLED     0
 
 /*
@@ -113,5 +117,9 @@ unsigned short SMB380_ssp_read(void);
 unsigned short nrf24l01_ssp_read_write(const uint8_t data);
 unsigned short acam_trx(const uint8_t data);
 void SSP0Handler(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* __SSP_H__ */

--- a/boards/chronos/drivers/include/battery.h
+++ b/boards/chronos/drivers/include/battery.h
@@ -9,6 +9,14 @@
 #ifndef BATTERY_H
 #define BATTERY_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 uint32_t battery_get_voltage(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* BATTERY_H */

--- a/boards/chronos/drivers/include/buzzer.h
+++ b/boards/chronos/drivers/include/buzzer.h
@@ -9,6 +9,14 @@
 #ifndef BUZZER_H
 #define BUZZER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void buzzer_beep(uint8_t pitch, uint16_t duration);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* BUZZER_H */

--- a/boards/chronos/drivers/include/display.h
+++ b/boards/chronos/drivers/include/display.h
@@ -38,6 +38,10 @@
 #ifndef __DISPLAY_H
 #define __DISPLAY_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CLOCK_24HR              (0)
 #define CLOCK_AM_PM             (1)
 #define CLOCK_DISPLAY_SELECT    (2)
@@ -454,5 +458,9 @@ uint8_t switch_seg(uint8_t line, uint8_t index1, uint8_t index2);
  * @return      none
  * ************************************************************************************************/
 void display_all_off(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __DISPLAY_ */

--- a/boards/chronos/drivers/include/display_putchar.h
+++ b/boards/chronos/drivers/include/display_putchar.h
@@ -9,6 +9,14 @@
 #ifndef __DISPLAY_PUTCHAR_H
 #define __DISPLAY_PUTCHAR_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void init_display_putchar(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __DISPLAY_PUTCHAR_H */

--- a/boards/chronos/include/board.h
+++ b/boards/chronos/include/board.h
@@ -23,6 +23,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // for correct inclusion of <msp430.h>
 #ifndef __CC430F6137__
 #define __CC430F6137__
@@ -35,5 +39,9 @@
 #define MSP430_HAS_EXTERNAL_CRYSTAL 1
 
 typedef uint8_t radio_packet_length_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // _MSB_BOARD_H

--- a/boards/chronos/include/buttons.h
+++ b/boards/chronos/include/buttons.h
@@ -9,11 +9,19 @@
 #ifndef BUTTONS_H
 #define BUTTONS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Button ports
 #define BUTTON_STAR_PIN         (BIT2)
 #define BUTTON_NUM_PIN          (BIT1)
 #define BUTTON_UP_PIN           (BIT4)
 #define BUTTON_DOWN_PIN         (BIT0)
 #define BUTTON_BACKLIGHT_PIN    (BIT3)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/boards/iot-lab_M3/include/board.h
+++ b/boards/iot-lab_M3/include/board.h
@@ -29,6 +29,10 @@
 #include "cpu.h"
 #include "periph_conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Define the nominal CPU core clock in this board
  */
@@ -115,6 +119,10 @@ typedef uint8_t radio_packet_length_t;
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* BOARD_H_ */
 /** @} */

--- a/boards/iot-lab_M3/include/periph_conf.h
+++ b/boards/iot-lab_M3/include/periph_conf.h
@@ -20,6 +20,10 @@
 #ifndef __PERIPH_CONF_H
 #define __PERIPH_CONF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Clock system configuration
  * @{
@@ -304,6 +308,10 @@
 #define I2C_0_SDA_PIN       7
 #define I2C_0_SDA_CLKEN()   (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_CONF_H */
 /** @} */

--- a/boards/mbed_lpc1768/include/board.h
+++ b/boards/mbed_lpc1768/include/board.h
@@ -22,6 +22,10 @@
 #include <stdint.h>
 #include "bitarithm.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define F_CPU                   (96000000)
 
 
@@ -42,6 +46,10 @@ typedef uint8_t radio_packet_length_t;
  * @param[in] t The waiting cycles
  */
 void loop_delay(uint32_t t);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __BOARD_H */

--- a/boards/msb-430-common/drivers/include/sht11-board.h
+++ b/boards/msb-430-common/drivers/include/sht11-board.h
@@ -24,6 +24,10 @@
 #include <msp430x16x.h>
 #include "bitarithm.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* SCK  = P3B5
  * DATA = P3B4
  */
@@ -36,6 +40,10 @@
 #define SHT11_DATA_IN   P3DIR &= ~(BIT5);      /**< serial I/O as input */
 #define SHT11_DATA_OUT  P3DIR |= BIT5;      /**< serial I/O as output */
 #define SHT11_INIT      P3DIR |= BIT5;      /* FIO1DIR |= BIT25; PINSEL3 &= ~(BIT14|BIT15 | BIT16|BIT17); */
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* SHT11BOARD_H_ */

--- a/boards/msb-430-common/include/board-conf.h
+++ b/boards/msb-430-common/include/board-conf.h
@@ -23,6 +23,14 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define INFOMEM     (0x1000)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* BOARD-CONF_H */

--- a/boards/msb-430/include/board.h
+++ b/boards/msb-430/include/board.h
@@ -28,6 +28,10 @@
 
 #include "board-conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // for correct inclusion of <msp430.h>
 #ifndef __MSP430F1612__
 #define __MSP430F1612__
@@ -50,6 +54,10 @@
 #define LED_RED_ON          LEDS_PxOUT &=~LEDS_CONF_RED
 #define LED_RED_OFF         LEDS_PxOUT |= LEDS_CONF_RED
 #define LED_RED_TOGGLE      LEDS_PxOUT ^= LEDS_CONF_RED
+
+#ifdef __cplusplus
+}
+#endif
 
 #include "board-conf.h"
 

--- a/boards/msb-430h/include/board.h
+++ b/boards/msb-430h/include/board.h
@@ -21,6 +21,10 @@
 #ifndef _MSB_BOARD_H
 #define _MSB_BOARD_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // for correct inclusion of <msp430.h>
 #ifndef __MSP430F1612__
 #define __MSP430F1612__
@@ -43,6 +47,10 @@
 #define LED_RED_ON          LEDS_PxOUT &=~LEDS_CONF_RED
 #define LED_RED_OFF         LEDS_PxOUT |= LEDS_CONF_RED
 #define LED_RED_TOGGLE      LEDS_PxOUT ^= LEDS_CONF_RED
+
+#ifdef __cplusplus
+}
+#endif
 
 #include "board-conf.h"
 

--- a/boards/msba2-common/drivers/include/sht11-board.h
+++ b/boards/msba2-common/drivers/include/sht11-board.h
@@ -27,6 +27,10 @@
 #include "lpc23xx.h"
 #include "board.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define SHT11_SCK_LOW   FIO1CLR = BIT25;    // serial clock line low
 #define SHT11_SCK_HIGH  FIO1SET = BIT25;    // serial clock line high
 #define SHT11_DATA      ((FIO1PIN & BIT26) != 0)                // read serial I/O
@@ -35,6 +39,10 @@
 #define SHT11_DATA_IN   (FIO1DIR &= ~BIT26)                     // serial I/O as input
 #define SHT11_DATA_OUT  (FIO1DIR |= BIT26)                      // serial I/O as output
 #define SHT11_INIT      FIO1DIR |= BIT25; PINSEL3 &= ~(BIT14|BIT15 | BIT16|BIT17);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* SHT11BOARD_H_ */

--- a/boards/msba2-common/drivers/include/uart0.h
+++ b/boards/msba2-common/drivers/include/uart0.h
@@ -9,6 +9,14 @@
 #ifndef __UART0_H
 #define __UART0_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern kernel_pid_t uart0_handler_pid;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __UART0_H */

--- a/boards/msba2-common/include/msba2_common.h
+++ b/boards/msba2-common/include/msba2_common.h
@@ -24,6 +24,10 @@
 #include <stdint.h>
 #include "lpc2387.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define VICIntEnClear VICIntEnClr
 
 static inline void pllfeed(void)
@@ -31,6 +35,10 @@ static inline void pllfeed(void)
     PLLFEED = 0xAA;
     PLLFEED = 0x55;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif // __MSBA2_COMMON_H

--- a/boards/msba2/include/board.h
+++ b/boards/msba2/include/board.h
@@ -24,6 +24,10 @@
 #include "msba2_common.h"
 #include "bitarithm.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define LED_RED_PIN (BIT25)
 #define LED_GREEN_PIN (BIT26)
 
@@ -38,5 +42,9 @@
 void init_clks1(void);
 
 typedef uint8_t radio_packet_length_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __BOARD_H */

--- a/boards/msba2/include/periph_conf.h
+++ b/boards/msba2/include/periph_conf.h
@@ -21,6 +21,10 @@
 
 #include "lpc2387.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief PWM device and pinout configuration
  */
@@ -42,6 +46,9 @@
 #define PWM_0_CH2_PIN       (4)
 #define PWM_0_FUNC          (1)
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_CONF_H */
 /** @} */

--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -24,6 +24,10 @@
 #include "cpu.h"
 #include "periph_conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Define the nominal CPU core clock in this board
  */
@@ -72,6 +76,10 @@
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /** __BOARD_H */
 /** @} */

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -19,6 +19,10 @@
 #ifndef __PERIPH_CONF_H
 #define __PERIPH_CONF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Clock system configuration
  * @{
@@ -259,6 +263,10 @@
 #define GPIO_15_EXTI_CFG()  (SYSCFG->EXTICR[0] |= SYSCFG_EXTICR1_EXTI2_PD)
 #define GPIO_15_IRQ         EXTI2_IRQn
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_CONF_H */
 /** @} */

--- a/boards/native/include/board.h
+++ b/boards/native/include/board.h
@@ -26,6 +26,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define F_CPU 1000000
 
 void _native_LED_GREEN_OFF(void);
@@ -42,6 +46,10 @@ void _native_LED_RED_TOGGLE(void);
 #define LED_RED_TOGGLE (_native_LED_RED_TOGGLE())
 
 typedef uint16_t radio_packet_length_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* BOARD_H */

--- a/boards/native/include/board_internal.h
+++ b/boards/native/include/board_internal.h
@@ -6,6 +6,10 @@
  * directory for more details.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef MODULE_UART0
 #include <sys/select.h>
 void _native_handle_uart0_input(void);
@@ -17,8 +21,12 @@ void _native_handle_uart0_input(void);
  */
 void _native_init_uart0(char *stdiotype, char *ioparam, int replay);
 int _native_set_uart_fds(void);
-#endif
+#endif /* MODULE_UART0 */
 
 extern int _native_null_out_file;
 extern int _native_null_in_pipe[2];
 void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/boards/pca10000/include/board.h
+++ b/boards/pca10000/include/board.h
@@ -24,6 +24,9 @@
 
 #include "cpu.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * Define the nominal CPU core clock in this board
@@ -73,6 +76,10 @@
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /** __BOARD_H */
 /** @} */

--- a/boards/pca10000/include/periph_conf.h
+++ b/boards/pca10000/include/periph_conf.h
@@ -21,6 +21,10 @@
 #ifndef __PERIPH_CONF_H
 #define __PERIPH_CONF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Timer configuration
  * @{
@@ -135,5 +139,9 @@
 #define GPIO_14_PIN         14
 #define GPIO_15_PIN         15
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_CONF_H */

--- a/boards/pca10005/include/board.h
+++ b/boards/pca10005/include/board.h
@@ -24,6 +24,10 @@
 
 #include "cpu.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Define the nominal CPU core clock in this board
  */
@@ -64,6 +68,10 @@
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /** __BOARD_H */
 /** @} */

--- a/boards/pca10005/include/periph_conf.h
+++ b/boards/pca10005/include/periph_conf.h
@@ -21,6 +21,10 @@
 #ifndef __PERIPH_CONF_H
 #define __PERIPH_CONF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Timer configuration
  * @{
@@ -132,5 +136,9 @@
 #define GPIO_14_PIN         14
 #define GPIO_15_PIN         15
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_CONF_H */

--- a/boards/pttu/include/board.h
+++ b/boards/pttu/include/board.h
@@ -18,6 +18,10 @@
 #include "lpc2387.h"
 #include "cpu-conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define VICIntEnClear VICIntEnClr
 
 void init_clks1(void);
@@ -25,6 +29,10 @@ void init_clks2(void);
 void bl_init_clks(void);
 
 typedef uint8_t radio_packet_length_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif // __BOARD_H

--- a/boards/pttu/include/periph_conf.h
+++ b/boards/pttu/include/periph_conf.h
@@ -21,6 +21,10 @@
 
 #include "lpc2387.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief PWM device and pinout configuration
  */
@@ -41,6 +45,9 @@
 #define PWM_0_CH2_PIN       (4)
 #define PWM_0_FUNC          (1)
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_CONF_H */
 /** @} */

--- a/boards/qemu-i386/include/board.h
+++ b/boards/qemu-i386/include/board.h
@@ -29,12 +29,20 @@
 #ifndef __RIOT__BOARDS__QEMU_I386__BOARD__H
 #define __RIOT__BOARDS__QEMU_I386__BOARD__H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define UART_PORT (COM1_PORT) /* IO port to use for UART */
 #define UART_IRQ (COM1_IRQ)   /* IRQ line to use for UART */
 
 #define LED_RED_ON          /* not available */
 #define LED_RED_OFF         /* not available */
 #define LED_RED_TOGGLE      /* not available */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/boards/qemu-i386/include/cpu-conf.h
+++ b/boards/qemu-i386/include/cpu-conf.h
@@ -28,6 +28,10 @@
 #ifndef __RIOT__BOARDS__QEMU_I386__CPU_CONF__H
 #define __RIOT__BOARDS__QEMU_I386__CPU_CONF__H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* FIXME: This file is just a filler. The numbers are entirely random ... */
 
 #define KERNEL_CONF_STACKSIZE_DEFAULT      (8192)
@@ -40,6 +44,10 @@
 #define UART0_BUFSIZE                      (16)
 
 #define F_CPU (1000000) /* This value is unused in x86 */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/boards/redbee-econotag/drivers/include/nvm.h
+++ b/boards/redbee-econotag/drivers/include/nvm.h
@@ -13,6 +13,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef enum
 {
         g_nvm_type_no_nvm_c = 0,
@@ -54,5 +58,9 @@ extern nvm_err_t (*nvm_write)(nvm_interface_t nvm_interface, nvm_type_t nvm_type
 /* bit 0 is the first sector, bit 31 is the last */
 extern nvm_err_t (*nvm_erase)(nvm_interface_t nvm_interface, nvm_type_t nvm_type ,uint32_t sector_bitfield);
 extern void(*nvm_setsvar)(uint32_t zero_for_awesome);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //NVM_H

--- a/boards/redbee-econotag/drivers/include/uart.h
+++ b/boards/redbee-econotag/drivers/include/uart.h
@@ -13,6 +13,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*-----------------------------------------------------------------*/
 /* UART */
 #define UART1_BASE      (0x80005000)
@@ -101,5 +105,9 @@ uint8_t uart1_getc(void);
 
 void uart2_putc(uint8_t c);
 uint8_t uart2_getc(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/boards/redbee-econotag/include/board.h
+++ b/boards/redbee-econotag/include/board.h
@@ -23,6 +23,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define F_CPU   (24000000)              ///< CPU target speed in Hz
 
 #define CTUNE       0xb
@@ -30,5 +34,9 @@
 #define FTUNE       0x7
 
 typedef uint8_t radio_packet_length_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -23,6 +23,10 @@
 
 #include "cpu.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Define the nominal CPU core clock in this board
  */
@@ -74,6 +78,10 @@
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /** __BOARD_H */
 /** @} */

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -19,6 +19,10 @@
 #ifndef __PERIPH_CONF_H
 #define __PERIPH_CONF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Timer peripheral configuration
  * @{
@@ -115,6 +119,10 @@
 #define GPIO_3_PIN          PIN_PA19
 #define GPIO_3_EXTINT       3
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_CONF_H */
 /** @} */

--- a/boards/stm32f0discovery/include/board.h
+++ b/boards/stm32f0discovery/include/board.h
@@ -23,6 +23,9 @@
 
 #include "cpu.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @name The nominal CPU core clock in this board
@@ -74,6 +77,10 @@
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /** __BOARD_H */
 /** @} */

--- a/boards/stm32f0discovery/include/periph_conf.h
+++ b/boards/stm32f0discovery/include/periph_conf.h
@@ -19,6 +19,10 @@
 #ifndef __PERIPH_CONF_H
 #define __PERIPH_CONF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Clock system configuration
  * @{
@@ -278,5 +282,9 @@
 #define GPIO_11_EXTI_CFG()  (SYSCFG->EXTICR[3] |= SYSCFG_EXTICR4_EXTI15_PC)
 #define GPIO_11_IRQ         EXTI4_15_IRQn
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_CONF_H */

--- a/boards/stm32f3discovery/include/board.h
+++ b/boards/stm32f3discovery/include/board.h
@@ -23,6 +23,10 @@
 
 #include "cpu.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Define the nominal CPU core clock in this board
  */
@@ -98,6 +102,10 @@
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /** __BOARD_H */
 /** @} */

--- a/boards/stm32f3discovery/include/periph_conf.h
+++ b/boards/stm32f3discovery/include/periph_conf.h
@@ -19,6 +19,10 @@
 #ifndef __PERIPH_CONF_H
 #define __PERIPH_CONF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Clock system configuration
  * @{
@@ -225,5 +229,9 @@
 #define GPIO_11_EXTI_CFG2() (SYSCFG->EXTICR[0] |= SYSCFG_EXTICR1_EXTI0_PA)
 #define GPIO_11_IRQ          EXTI0_IRQn
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_CONF_H */

--- a/boards/stm32f4discovery/include/board.h
+++ b/boards/stm32f4discovery/include/board.h
@@ -24,6 +24,10 @@
 #include "cpu.h"
 #include "periph_conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Define the nominal CPU core clock in this board
  */
@@ -84,6 +88,10 @@
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /** __BOARD_H */
 /** @} */

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -20,6 +20,10 @@
 #ifndef __PERIPH_CONF_H
 #define __PERIPH_CONF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Clock system configuration
  * @{
@@ -385,6 +389,10 @@
 #define GPIO_11_EXTI_CFG()   (SYSCFG->EXTICR[2] |= SYSCFG_EXTICR3_EXTI10_PD)
 #define GPIO_11_IRQ          EXTI15_10_IRQn
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_CONF_H */
 /** @} */

--- a/boards/telosb/include/board-conf.h
+++ b/boards/telosb/include/board-conf.h
@@ -8,6 +8,14 @@
 #ifndef BOARD_CONF_H
 #define BOARD_CONF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define INFOMEM     (0x1000)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* BOARD-CONF_H */

--- a/boards/telosb/include/board.h
+++ b/boards/telosb/include/board.h
@@ -25,6 +25,10 @@
 #ifndef _TELOSB_BOARD_H
 #define _TELOSB_BOARD_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // for correct inclusion of <msp430.h>
 #ifndef __MSP430F1611__
 #define __MSP430F1611__
@@ -55,6 +59,10 @@
 #define LED_BLUE_ON         LEDS_PxOUT &=~LEDS_CONF_BLUE
 #define LED_BLUE_OFF        LEDS_PxOUT |= LEDS_CONF_BLUE
 #define LED_BLUE_TOGGLE     LEDS_PxOUT ^= LEDS_CONF_BLUE
+
+#ifdef __cplusplus
+}
+#endif
 
 #include <stdint.h>
 

--- a/boards/udoo/include/board.h
+++ b/boards/udoo/include/board.h
@@ -24,6 +24,9 @@
 #include "cpu.h"
 #include "cpu-conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * Define the nominal CPU core clock in this board
@@ -74,6 +77,9 @@
  */
 void board_init(void);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /** __BOARD_H */
 /** @} */

--- a/boards/udoo/include/periph_conf.h
+++ b/boards/udoo/include/periph_conf.h
@@ -19,6 +19,10 @@
 #ifndef __PERIPH_CONF_H
 #define __PERIPH_CONF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Timer peripheral configuration
  * @{
@@ -211,6 +215,10 @@
 #define GPIO_15_IRQ         PIOB_IRQn
 #define GPIO_B14_MAP        15
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_CONF_H */
 /** @} */

--- a/boards/wsn430-common/include/board-conf.h
+++ b/boards/wsn430-common/include/board-conf.h
@@ -20,7 +20,15 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define INFOMEM     (0x1000)
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* BOARD-CONF_H */

--- a/boards/wsn430-v1_3b/include/board.h
+++ b/boards/wsn430-v1_3b/include/board.h
@@ -27,6 +27,10 @@
 
 #include "board-conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // for correct inclusion of <msp430.h>
 #ifndef __MSP430F1611__
 #define __MSP430F1611__
@@ -57,6 +61,10 @@
 #define LED_BLUE_ON         LEDS_PxOUT &=~LEDS_CONF_BLUE
 #define LED_BLUE_OFF        LEDS_PxOUT |= LEDS_CONF_BLUE
 #define LED_BLUE_TOGGLE     LEDS_PxOUT ^= LEDS_CONF_BLUE
+
+#ifdef __cplusplus
+}
+#endif
 
 #include <msp430x16x.h>
 

--- a/boards/wsn430-v1_4/include/board.h
+++ b/boards/wsn430-v1_4/include/board.h
@@ -27,6 +27,10 @@
 
 #include "board-conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // for correct inclusion of <msp430.h>
 #ifndef __MSP430F1611__
 #define __MSP430F1611__
@@ -57,6 +61,10 @@
 #define LED_BLUE_ON         LEDS_PxOUT &=~LEDS_CONF_BLUE
 #define LED_BLUE_OFF        LEDS_PxOUT |= LEDS_CONF_BLUE
 #define LED_BLUE_TOGGLE     LEDS_PxOUT ^= LEDS_CONF_BLUE
+
+#ifdef __cplusplus
+}
+#endif
 
 #include <msp430x16x.h>
 

--- a/boards/x86-multiboot-common/include/multiboot.h
+++ b/boards/x86-multiboot-common/include/multiboot.h
@@ -23,6 +23,10 @@
  * @file
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MULTIBOOT_HEADER_MAGIC 0x1BADB002 /**< The magic number for the Multiboot header. */
 #define MULTIBOOT_HEADER_FLAGS 0x00010003 /**< The flags for the Multiboot header. */
 #define MULTIBOOT_HEADER_CHECKSUM (-(MULTIBOOT_HEADER_MAGIC + MULTIBOOT_HEADER_FLAGS)) /**< The checksum for the Multiboot header.  */
@@ -120,5 +124,9 @@ enum multiboot_info_flags {
     MULTIBOOT_INFO_FLAGS_SYMS2   = 0x20,
     MULTIBOOT_INFO_FLAGS_MMAP    = 0x40,
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */

--- a/boards/yunjia-nrf51822/include/board.h
+++ b/boards/yunjia-nrf51822/include/board.h
@@ -23,6 +23,10 @@
 
 #include "cpu.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Define the nominal CPU core clock in this board
  */
@@ -63,6 +67,10 @@
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /** __BOARD_H */
 /** @} */

--- a/boards/yunjia-nrf51822/include/periph_conf.h
+++ b/boards/yunjia-nrf51822/include/periph_conf.h
@@ -19,6 +19,10 @@
 #ifndef __PERIPH_CONF_H
 #define __PERIPH_CONF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name Timer configuration
  * @{
@@ -114,5 +118,9 @@
 #define GPIO_6_PIN          13
 #define GPIO_7_PIN          14
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_CONF_H */

--- a/boards/z1/include/board-conf.h
+++ b/boards/z1/include/board-conf.h
@@ -23,7 +23,15 @@
  *
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define INFOMEM     (0x1000)
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* BOARD-CONF_H */

--- a/boards/z1/include/board.h
+++ b/boards/z1/include/board.h
@@ -32,6 +32,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef __MSP430F2617__
 #define __MSP430F2617__
 #endif
@@ -73,6 +77,10 @@
 #define USER_BTN_RELEASED  ((USER_BTN_PxIN & USER_BTN_MASK) != 0)
 
 typedef uint8_t radio_packet_length_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif // _Z1_BOARD_H


### PR DESCRIPTION
This PR adds `extern "C"` to the header files in ./RIOT/boards/\* folders.
