### PR TITLE
drivers: add `extern "C"` to header files

### DIFF
--- a/drivers/at86rf231/include/at86rf231_spi.h
+++ b/drivers/at86rf231/include/at86rf231_spi.h
@@ -24,6 +24,10 @@
 
 #include "board.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 uint8_t at86rf231_reg_read(uint8_t addr);
 void at86rf231_reg_write(uint8_t addr, uint8_t value);
 
@@ -31,6 +35,10 @@ void at86rf231_read_fifo(uint8_t *data, radio_packet_length_t length);
 void at86rf231_write_fifo(const uint8_t *data, radio_packet_length_t length);
 
 uint8_t at86rf231_get_status(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* AT86RF231_SPI_H_ */
 /** @} */

--- a/drivers/cc110x/cc1100-csmaca-mac.h
+++ b/drivers/cc110x/cc1100-csmaca-mac.h
@@ -23,6 +23,10 @@
 
 #include "cc1100-defaultSettings.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //#define CSMACA_MAC_AGGRESSIVE_MODE                // MAC aggressive mode on/off switch
 
 #define CARRIER_SENSE_TIMEOUT            (200000)   // Carrier Sense timeout ~ 2 seconds
@@ -44,5 +48,9 @@
 #define PRIO_DATA_SLOTTIME    (CS_TX_SWITCH_TIME)   // Time of one additional wait slot
 #define PRIO_DATA_MIN_WINDOW_SIZE             (4)   // Minimum window size of backoff algorithm
 #define PRIO_DATA_MAX_WINDOW_SIZE            (32)   // Maximum window size of backoff algorithm
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*CC1100_CSMACA_MAC_*/

--- a/drivers/cc110x/cc1100-defaultSettings.h
+++ b/drivers/cc110x/cc1100-defaultSettings.h
@@ -27,6 +27,10 @@
 
 #include "hwtimer.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // returns hwtimer ticks per us
 #define RTIMER_TICKS(us) HWTIMER_TICKS(us)
 
@@ -85,6 +89,10 @@
 
 // Burst retry to TX switch time (measured ~ 230 us)
 #define BURST_RETRY_TX_SWITCH_TIME  (23)
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif

--- a/drivers/cc110x/cc1100-internal.h
+++ b/drivers/cc110x/cc1100-internal.h
@@ -9,6 +9,10 @@
 #ifndef CC1100_INTERNAL_H
 #define CC1100_INTERNAL_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup     dev_cc110x
  * @{
@@ -194,6 +198,11 @@
 #define CC1100_TXFIFO       (0x3F)      ///< TX FIFO: Write operations write to the TX FIFO (SB: +0x00; BURST: +0x40)
 #define CC1100_RXFIFO       (0x3F)      ///< RX FIFO: Read operations read from the RX FIFO (SB: +0x80; BURST: +0xC0)
 
+
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/drivers/cc110x/cc1100.h
+++ b/drivers/cc110x/cc1100.h
@@ -29,6 +29,10 @@
 #include <stdbool.h>
 #include "cc110x.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name    Defines used as state values for state machine
  * @{
@@ -317,6 +321,10 @@ void cc1100_cs_write_cca(const int cca);
 void cc1100_reset_statistic(void);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif

--- a/drivers/cc110x/cc1100_phy.h
+++ b/drivers/cc110x/cc1100_phy.h
@@ -31,6 +31,10 @@
 #include "cc1100-internal.h"
 #include "cc110x.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MAX_DATA_LENGTH     (0x3A)  ///< Maximum data length of layer 0 = 58 Bytes.
 
 /**
@@ -132,5 +136,9 @@ int cc1100_phy_calc_wor_settings(uint16_t millis);
 void cc1100_phy_rx_handler(void);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CC1100_PHY_H_ */

--- a/drivers/cc110x/cc1100_spi.h
+++ b/drivers/cc110x/cc1100_spi.h
@@ -26,6 +26,10 @@
 #ifndef CC1100_SPI_H_
 #define CC1100_SPI_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int cc110x_get_gdo0(void);
 int cc110x_get_gdo1(void);
 int cc110x_get_gdo2(void);
@@ -41,6 +45,10 @@ void cc1100_spi_write_reg(uint8_t addr, uint8_t value);
 uint8_t cc1100_spi_read_reg(uint8_t addr);
 uint8_t cc1100_spi_read_status(uint8_t addr);
 uint8_t cc1100_spi_strobe(uint8_t c);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* CC1100_SPI_H_ */

--- a/drivers/cc110x_ng/cc110x-internal.h
+++ b/drivers/cc110x_ng/cc110x-internal.h
@@ -22,6 +22,9 @@
 #ifndef CC1100_INTERNAL_H
 #define CC1100_INTERNAL_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define FIXED_PKTLEN        (0x00)      ///< Fixed length packets, length configured in PKTLEN register.
 #define VARIABLE_PKTLEN     (0x01)      ///< Variable length packets, packet length configured by the first
@@ -191,6 +194,10 @@
 #define CC1100_TXFIFO       (0x3F)      ///< TX FIFO: Write operations write to the TX FIFO (SB: +0x00; BURST: +0x40)
 #define CC1100_RXFIFO       (0x3F)      ///< RX FIFO: Read operations read from the RX FIFO (SB: +0x80; BURST: +0xC0)
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif

--- a/drivers/cc2420/include/cc2420_arch.h
+++ b/drivers/cc2420/include/cc2420_arch.h
@@ -18,6 +18,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief SPI tx and rx function.
  *
@@ -117,3 +121,7 @@ void cc2420_before_send(void);
  *
  */
 void cc2420_after_send(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/drivers/cc2420/include/cc2420_settings.h
+++ b/drivers/cc2420/include/cc2420_settings.h
@@ -19,6 +19,10 @@
 #ifndef CC2420_SETTINGS_H
 #define CC2420_SETTINGS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name CC2420 access mode values.
  * @brief Values defining the command you want to give to the CC2420:
@@ -308,5 +312,9 @@
 #define CC2420_SYNC_WORD_TX_TIME 900000
 #define CC2420_RX_BUF_SIZE      3
 #define CC2420_WAIT_TIME        500
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/drivers/cc2420/include/cc2420_spi.h
+++ b/drivers/cc2420/include/cc2420_spi.h
@@ -21,6 +21,10 @@
 #include <stdio.h>
 #include "board.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Writes a byte to the cc2420 register.
  *
@@ -89,5 +93,9 @@ radio_packet_length_t cc2420_write_fifo(uint8_t* data, radio_packet_length_t dat
  * @return The number of bytes read.
  */
 radio_packet_length_t cc2420_read_fifo(uint8_t* data, radio_packet_length_t data_length);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/drivers/include/adc.h
+++ b/drivers/include/adc.h
@@ -12,6 +12,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   Initialize ADC.
  */
@@ -25,6 +29,10 @@ void adc_init(void);
  * @return  ADC value of selected channel.
  */
 uint16_t adc_read(uint8_t channel);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* ADC_H */

--- a/drivers/include/at86rf231.h
+++ b/drivers/include/at86rf231.h
@@ -32,6 +32,10 @@
 #include "at86rf231/at86rf231_settings.h"
 #include "periph/gpio.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define AT86RF231_MAX_PKT_LENGTH    127
 #define AT86RF231_MAX_DATA_LENGTH   118
 
@@ -95,6 +99,10 @@ enum {
 };
 
 extern at86rf231_packet_t at86rf231_rx_buffer[AT86RF231_RX_BUF_SIZE];
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* AT86RF231_H_ */
 /** @} */

--- a/drivers/include/at86rf231/at86rf231_settings.h
+++ b/drivers/include/at86rf231/at86rf231_settings.h
@@ -19,6 +19,10 @@
 #ifndef AT86AT86RF231_SETTINGS_H
 #define AT86AT86RF231_SETTINGS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define AT86RF231_RX_BUF_SIZE   3
 
 enum at86rf231_access {
@@ -222,5 +226,9 @@ enum {
     AT86RF231_TIMING__RESET = 100,
     AT86RF231_TIMING__RESET_TO_TRX_OFF = 37,
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/drivers/include/cc110x.h
+++ b/drivers/include/cc110x.h
@@ -3,4 +3,12 @@
 
 #include "cc110x/cc1100-interface.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* CC110X_H */

--- a/drivers/include/cc110x/cc1100-interface.h
+++ b/drivers/include/cc110x/cc1100-interface.h
@@ -27,6 +27,10 @@
 #include <stdint.h>
 #include "radio/radio.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CC1100_BROADCAST_ADDRESS (0x00) ///< CC1100 broadcast address
 
 #define MAX_UID                  (0xFF) ///< Maximum UID of a node is 255
@@ -198,5 +202,9 @@ void cc1100_print_config(void);
 void cc1100_print_statistic(void);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CC1100INTERFACE_H_ */

--- a/drivers/include/cc110x_ng.h
+++ b/drivers/include/cc110x_ng.h
@@ -8,4 +8,12 @@
 #include "cc110x_ng/cc110x-arch.h"
 #include "cc110x_ng/cc110x_spi.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* CC110X_NG_H */

--- a/drivers/include/cc110x_ng/cc110x-arch.h
+++ b/drivers/include/cc110x_ng/cc110x-arch.h
@@ -21,6 +21,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 uint8_t cc110x_txrx(uint8_t c);
 
 void cc110x_gdo0_enable(void);
@@ -31,6 +35,10 @@ void cc110x_init_interrupts(void);
 
 void cc110x_before_send(void);
 void cc110x_after_send(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __CC1100_ARCH_H */

--- a/drivers/include/cc110x_ng/cc110x-config.h
+++ b/drivers/include/cc110x_ng/cc110x-config.h
@@ -22,6 +22,10 @@
 #include <stdint.h>
 #include "timex.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** CC1100 register configuration */
 typedef struct {
     uint8_t _IOCFG2;
@@ -109,6 +113,10 @@ typedef struct cc110x_statistic {
     uint32_t    rx_buffer_max;
     uint32_t    watch_dog_resets;
 } cc110x_statistic_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __CC110X_CONFIG_H */

--- a/drivers/include/cc110x_ng/cc110x-defaultSettings.h
+++ b/drivers/include/cc110x_ng/cc110x-defaultSettings.h
@@ -22,6 +22,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // returns hwtimer ticks per us
 #define RTIMER_TICKS(us) HWTIMER_TICKS(us)
 
@@ -78,6 +82,9 @@
 // Burst retry to TX switch time (measured ~ 230 us)
 #define BURST_RETRY_TX_SWITCH_TIME  (23)
 
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __CC110X_DEFAULTSETTINGS_H */

--- a/drivers/include/cc110x_ng/cc110x-interface.h
+++ b/drivers/include/cc110x_ng/cc110x-interface.h
@@ -29,6 +29,10 @@
 #include "kernel_types.h"
 #include "transceiver.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CC1100_MAX_DATA_LENGTH (58)
 
 #define CC1100_HEADER_LENGTH   (3)             ///< Header covers SRC, DST and FLAGS
@@ -169,6 +173,10 @@ void cc110x_init_ignore(void);
  *
  */
 uint8_t cc110x_add_ignored(radio_address_t addr);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 /** @} */

--- a/drivers/include/cc110x_ng/cc110x-reg.h
+++ b/drivers/include/cc110x_ng/cc110x-reg.h
@@ -22,6 +22,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Write a set of bytes using burst mode (if available)
  *
@@ -87,6 +91,10 @@ uint8_t cc110x_read_status(uint8_t addr);
  * @return Command response
  */
 uint8_t cc110x_strobe(uint8_t c);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* __CC110X_REG_H */

--- a/drivers/include/cc110x_ng/cc110x_spi.h
+++ b/drivers/include/cc110x_ng/cc110x_spi.h
@@ -20,6 +20,10 @@
 #ifndef CC1100_SPI_H_
 #define CC1100_SPI_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int cc110x_get_gdo0(void);
 int cc110x_get_gdo1(void);
 int cc110x_get_gdo2(void);
@@ -28,6 +32,10 @@ void cc110x_spi_init(void);
 void cc110x_spi_cs(void);
 void cc110x_spi_select(void);
 void cc110x_spi_unselect(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* CC1100_SPI_H_ */

--- a/drivers/include/cc2420.h
+++ b/drivers/include/cc2420.h
@@ -86,6 +86,10 @@ Frame type value:
 
 #include "radio_driver.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CC2420_MAX_PKT_LENGTH 127
 #define CC2420_MAX_DATA_LENGTH (118)
 
@@ -396,5 +400,8 @@ static inline void do_set_tx_power(int pow) {
  */
 extern const ieee802154_radio_driver_t cc2420_radio_driver;
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/drivers/include/diskio.h
+++ b/drivers/include/diskio.h
@@ -21,6 +21,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define DN_MCI      0   /* Physical drive number for MCI */
 #define DN_NAND     1   /* Physical drive number for NAND flash */
 
@@ -116,6 +120,10 @@ DRESULT MCI_read(unsigned char *, unsigned long, unsigned char);
 DRESULT MCI_write(const unsigned char *, unsigned long, unsigned char);
 DRESULT MCI_ioctl(unsigned char, void *);
 void MCI_timerproc(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif

--- a/drivers/include/flashrom.h
+++ b/drivers/include/flashrom.h
@@ -16,6 +16,10 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Erase sector
  *
@@ -35,6 +39,10 @@ uint8_t             flashrom_erase(uint8_t *addr);
  * @return          1 on success, 0 otherwise
  */
 uint8_t             flashrom_write(uint8_t *dst, const uint8_t *src, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* FLASHROM_H */
 /** @} */

--- a/drivers/include/gpioint.h
+++ b/drivers/include/gpioint.h
@@ -27,6 +27,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * gpioint_flags:
  * Note: - We rely on the exact values for the edges.
@@ -59,6 +63,10 @@ typedef void(*fp_irqcb)(void);
 bool gpioint_set(int port, uint32_t bitmask, int flags, fp_irqcb callback);
 
 void gpioint_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* GPIOINT_H_ */

--- a/drivers/include/lm75a-temp-sensor.h
+++ b/drivers/include/lm75a-temp-sensor.h
@@ -31,6 +31,10 @@
 #include <math.h>
 #include "i2c.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* LM75A register addresses */
 #define LM75A_ADDR                      0x48
 #define LM75A_TEMPERATURE_REG           0x0
@@ -252,6 +256,10 @@ bool lm75A_external_interrupt_register(void *handler);
  *
  */
 void lm75A_set_in_alarm(bool b);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* LM75A_H_ */

--- a/drivers/include/ltc4150.h
+++ b/drivers/include/ltc4150.h
@@ -3,6 +3,10 @@
 
 #include "ltc4150_arch.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void ltc4150_init(void);
 void ltc4150_start(void);
 void ltc4150_stop(void);
@@ -13,5 +17,9 @@ double ltc4150_get_total_Joule(void);
 double ltc4150_get_avg_mA(void);
 int ltc4150_get_interval(void);
 long ltc4150_get_intcount(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __LTC4150_H */

--- a/drivers/include/ltc4150_arch.h
+++ b/drivers/include/ltc4150_arch.h
@@ -9,6 +9,10 @@
 #ifndef __LTC4150_ARCH_H
 #define __LTC4150_ARCH_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @defgroup    ltc4150 LTC4150
  * @ingroup     drivers
@@ -40,6 +44,10 @@ void ltc4150_arch_init(void);
  * implemented in driver
  */
 void ltc4150_interrupt(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** * @} */
 #endif /* __LTC4150_ARCH_H */

--- a/drivers/include/netdev/base.h
+++ b/drivers/include/netdev/base.h
@@ -25,6 +25,10 @@
 
 #include "clist.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Type for @ref msg_t if device fired an event.
  */
@@ -376,6 +380,10 @@ static inline void netdev_hlist_remove(netdev_hlist_t **list,
 {
     clist_remove((clist_node_t **)list, (clist_node_t *)node);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __NETDEV_BASE_H_ */
 /**

--- a/drivers/include/netdev/default.h
+++ b/drivers/include/netdev/default.h
@@ -29,11 +29,21 @@
  */
 
 #ifdef MODULE_NATIVENET
+
 #include "nativenet.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifndef NETDEV_DEFAULT
 #define NETDEV_DEFAULT   (&nativenet_default_dev)
 #endif /* NETDEV_DEFAULT */
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* MODULE_NATIVENET */
 
 #endif /* __NETDEV_DEFAULT_H_ */

--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -22,6 +22,10 @@
 
 #include "periph_conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* guard file in case no ADC device is defined */
 #if ADC_NUMOF
 
@@ -131,6 +135,10 @@ int adc_map(adc_t dev, int value, int min, int max);
 float adc_mapf(adc_t dev, int value, float min, float max);
 
 #endif /* ADC_NUMOF */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ADC_H */
 /** @} */

--- a/drivers/include/periph/cpuid.h
+++ b/drivers/include/periph/cpuid.h
@@ -21,6 +21,10 @@
 
 #include "cpu-conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @def CPUID_ID_LEN
  *
@@ -38,6 +42,10 @@
  */
 void cpuid_get(void *id);
 #endif /* CPUID_ID_LEN */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_CPUID_H_ */
 /**

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -22,6 +22,10 @@
 
 #include "periph_conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* guard file in case no GPIO devices are defined */
 #if GPIO_NUMOF
 
@@ -249,6 +253,10 @@ void gpio_toggle(gpio_t dev);
 void gpio_write(gpio_t dev, int value);
 
 #endif /* GPIO_NUMOF */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __GPIO_H */
 /** @} */

--- a/drivers/include/periph/pwm.h
+++ b/drivers/include/periph/pwm.h
@@ -22,6 +22,10 @@
 
 #include "periph_conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ignore file in case no PWM devices are defined */
 #if PWM_NUMOF
 
@@ -127,6 +131,10 @@ void pwm_poweron(pwm_t dev);
 void pwm_poweroff(pwm_t dev);
 
 #endif /* PWM_NUMOF */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PWM_H */
 /** @} */

--- a/drivers/include/periph/random.h
+++ b/drivers/include/periph/random.h
@@ -29,6 +29,10 @@
 
 #include "periph_conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* only include this file if a random number generator is defined */
 #if RANDOM_NUMOF
 
@@ -66,6 +70,10 @@ void random_poweron(void);
 void random_poweroff(void);
 
 #endif /* RANDOM_NUMOF */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __RANDOM_H */
 /** @} */

--- a/drivers/include/periph/rtc.h
+++ b/drivers/include/periph/rtc.h
@@ -23,6 +23,10 @@
 #include <time.h>
 #include "periph_conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* guard file in case no RTC device was specified */
 #if RTC_NUMOF
 
@@ -102,5 +106,10 @@ void rtc_poweron(void);
 void rtc_poweroff(void);
 
 #endif /* RTC_NUMOF */
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __RTC_H */
 /** @} */

--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -21,6 +21,10 @@
 
 #include "periph_conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* guard file in case no RTC device was specified */
 #if RTT_NUMOF
 
@@ -84,5 +88,10 @@ void rtt_poweron(void);
 void rtt_poweroff(void);
 
 #endif /* RTT_NUMOF */
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __RTT_H */
 /** @} */

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -26,6 +26,10 @@
 
 #include "periph_conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* add guard for the case that no SPI device is defined */
 #if SPI_NUMOF
 
@@ -200,6 +204,10 @@ void spi_poweron(spi_t dev);
 void spi_poweroff(spi_t dev);
 
 #endif /* SPI_NUMOF */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SPI_H */
 /** @} */

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -22,6 +22,9 @@
 
 #include "periph_conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Definition of available timers
@@ -142,6 +145,10 @@ void timer_irq_disable(tim_t dev);
  * @param[in] dev           the timer to reset
  */
 void timer_reset(tim_t dev);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __TIMER_H */
 /** @} */

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -24,6 +24,10 @@
 
 #include "periph_conf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* guard file in case no UART device was specified */
 #if UART_NUMOF
 
@@ -169,6 +173,10 @@ void uart_poweron(uart_t uart);
 void uart_poweroff(uart_t uart);
 
 #endif /* UART_NUMOF */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PERIPH_UART_H */
 /** @} */

--- a/drivers/include/pir.h
+++ b/drivers/include/pir.h
@@ -24,6 +24,10 @@
 #include "kernel_types.h"
 #include "periph/gpio.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief device descriptor for a PIR sensor
  */
@@ -83,6 +87,10 @@ pir_event_t pir_get_status(pir_t *dev);
  * @return              -2 if another thread is registered already
  */
 int pir_register_thread(pir_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PIR_H */
 /** @} */

--- a/drivers/include/radio_driver.h
+++ b/drivers/include/radio_driver.h
@@ -21,6 +21,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Callback function type for receiving incoming packets
@@ -345,6 +348,9 @@ typedef struct {
 
 } ieee802154_radio_driver_t;
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* IEEE802154_RADIO_DRIVER_API_ */
 

--- a/drivers/include/rgbled.h
+++ b/drivers/include/rgbled.h
@@ -24,6 +24,9 @@
 #include "color.h"
 #include "periph/pwm.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @name Descriptor struct for rgbleds
@@ -54,6 +57,10 @@ void rgbled_init(rgbled_t *led, pwm_t pwm, int channel_r, int channel_g, int cha
  * @param[in] color         Color to set the led to
  */
 void rgbled_set(rgbled_t *led, color_rgb_t *color);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __RGBLED_H */
 /** @} */

--- a/drivers/include/rtc.h
+++ b/drivers/include/rtc.h
@@ -22,6 +22,10 @@
 #include <sys/time.h>
 #include "kernel_types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Initializes the RTC for calendar mode
  */
@@ -56,6 +60,10 @@ void rtc_get_localtime(struct tm *localt);
 time_t rtc_time(struct timeval *time);
 
 extern kernel_pid_t rtc_second_pid;
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif

--- a/drivers/include/servo.h
+++ b/drivers/include/servo.h
@@ -23,6 +23,9 @@
 
 #include "periph/pwm.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @name Descriptor struct for a servo
@@ -81,6 +84,10 @@ int servo_init(servo_t *dev, pwm_t pwm, int pwm_channel, unsigned int min, unsig
  * @return                  -2 on invalid position
  */
 int servo_set(servo_t *dev, unsigned int pos);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SERVO_H */
 /** @} */

--- a/drivers/include/sht11.h
+++ b/drivers/include/sht11.h
@@ -23,6 +23,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define SHT11_NO_ACK        (0)
 #define SHT11_ACK           (1)
 //adr command  r/w
@@ -95,6 +99,10 @@ uint8_t sht11_write_status(uint8_t *p_value);
  * return   1 on success, 0 otherwise
  */
 uint8_t sht11_read_status(uint8_t *p_value, uint8_t *p_checksum);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /*SHT11_H_*/

--- a/drivers/include/srf02-ultrasonic-sensor.h
+++ b/drivers/include/srf02-ultrasonic-sensor.h
@@ -27,6 +27,10 @@
 #define SRF02_ULTRASONIC_SENSOR_I2C_H_
 #include "i2c.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* define the SRF02 registers*/
 #define SRF02_DEFAULT_ADDR                  112
 #define SRF02_COMMAND_REG                   0x0
@@ -93,6 +97,10 @@ uint32_t srf02_get_distance(uint8_t ranging_mode);
  *
  */
 void srf02_start_ranging(uint16_t ranging_mode);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* SRF02_ULTRASONIC_SENSOR_I2C_H_ */

--- a/drivers/include/srf08-ultrasonic-sensor.h
+++ b/drivers/include/srf08-ultrasonic-sensor.h
@@ -27,6 +27,10 @@
 #ifndef SRF08_ULTRASONIC_SENSOR_I2C_H_
 #define SRF08_ULTRASONIC_SENSOR_I2C_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* define the SRF02 registers*/
 #define SRF08_DEFAULT_ADDR              112
 #define SRF08_COMMAND_REG               0x0
@@ -127,6 +131,10 @@ uint8_t srf08_get_gain(void);
  *            otherwise the number of the detected targets is delivered.
  */
 int32_t srf08_get_distances(uint32_t *range_array, uint8_t ranging_mode);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 #endif /* SRF08_ULTRASONIC_SENSOR_I2C_H_ */


### PR DESCRIPTION
This PR adds extern "C" to the header files in ./RIOT/drivers/\* folders.
