### PR TITLE
boards: core: cpu: drivers: sys: added missing header guards

### DIFF
--- a/boards/native/include/board_internal.h
+++ b/boards/native/include/board_internal.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef BOARD_INTERNAL_H
+#define BOARD_INTERNAL_H
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -30,3 +33,5 @@ void board_init(void);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* BOARD_INTERNAL_H */

--- a/boards/x86-multiboot-common/include/multiboot.h
+++ b/boards/x86-multiboot-common/include/multiboot.h
@@ -23,6 +23,9 @@
  * @file
  */
 
+#ifndef MULTIBOOT_H
+#define MULTIBOOT_H
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -129,4 +132,5 @@ enum multiboot_info_flags {
 }
 #endif
 
+#endif /* MULTIBOOT_H */
 /** @} */

--- a/core/include/kernel_macros.h
+++ b/core/include/kernel_macros.h
@@ -16,6 +16,9 @@
  * @author      René Kijewski
  */
 
+#ifndef KENREL_MACROS_H
+#define KENREL_MACROS_H
+
 #include <stddef.h>
 
 #ifdef __cplusplus
@@ -58,6 +61,7 @@ extern "C" {
 }
 #endif
 
+#endif /* KENREL_MACROS_H */
 /**
  * @}
  */

--- a/cpu/atmega_common/include/sys/time.h
+++ b/cpu/atmega_common/include/sys/time.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef ATMEGA_TIME_H
+#define ATMEGA_TIME_H
 
 #include <sys/types.h>
 
@@ -21,3 +23,5 @@ struct timeval {
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* ATMEGA_TIME_H */

--- a/cpu/atmega_common/include/sys/types.h
+++ b/cpu/atmega_common/include/sys/types.h
@@ -6,11 +6,11 @@
  * directory for more details.
  */
 
+ #ifndef AVR_TYPES_H
+ #define AVR_TYPES_H
+
 #include <inttypes.h>
 #include <stddef.h>
-
-#ifndef AVR_TYPES_H
-#define AVR_TYPES_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/cc110x_legacy_csma/arch_cc1100.h
+++ b/drivers/cc110x_legacy_csma/arch_cc1100.h
@@ -17,6 +17,9 @@
  * @note        $Id: arch_cc1100.h 1775 2010-01-26 09:37:03Z hillebra $
  */
 
+#ifndef ARCH_CC1100_H
+#define ARCH_CC1100_H
+
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -37,3 +40,5 @@ void cc110x_after_send(void);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* ARCH_CC1100_H */

--- a/drivers/cc2420/include/cc2420_arch.h
+++ b/drivers/cc2420/include/cc2420_arch.h
@@ -16,6 +16,9 @@
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
  */
 
+#ifndef CC2420_ARCH_H
+#define CC2420_ARCH_H
+
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -125,3 +128,5 @@ void cc2420_after_send(void);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* CC2420_ARCH_H */

--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -13,6 +13,9 @@
  * @brief       Random number generator
  */
 
+#ifndef RANDOM_H
+#define RANDOM_H
+
 #include <inttypes.h>
 
 #ifdef __cplusplus
@@ -80,3 +83,5 @@ double genrand_res53(void);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* RANDOM_H */


### PR DESCRIPTION
This PR adds missing guards to headers across RIOT