### PR TITLE
 core: make sched_runqueues static 

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -152,11 +152,6 @@ extern volatile int sched_num_threads;
  */
 extern volatile kernel_pid_t sched_active_pid;
 
-/**
- * List of runqueues per priority level
- */
-extern clist_node_t *runqueues[SCHED_PRIO_LEVELS];
-
 #if SCHEDSTATISTICS
 /**
  *  Scheduler statistics

--- a/core/sched.c
+++ b/core/sched.c
@@ -45,7 +45,7 @@ volatile tcb_t *sched_active_thread;
 
 volatile kernel_pid_t sched_active_pid = KERNEL_PID_UNDEF;
 
-clist_node_t *sched_runqueues[SCHED_PRIO_LEVELS];
+static clist_node_t *sched_runqueues[SCHED_PRIO_LEVELS];
 static uint32_t runqueue_bitcache = 0;
 
 #if SCHEDSTATISTICS


### PR DESCRIPTION
~~'twas overlooked in #1000.~~

PR #1000 overlooked to rename `runqueues` into `sched_runqueues` in
`sched.h`. This shows that the variable is not used outside of
`sched.c`.

As the list should not be accessed outside of the scheduler, so it
can be `static`.
