### PR TITLE
cc2538: reimplement the hwtimer module using the MCU's Sleep Timer

### DIFF
--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -76,6 +76,14 @@ extern "C" {
 
 
 /**
+ * @name Hardware Timer peripheral configuration
+ * @{
+ */
+#define HWTIMER_IRQ_PRIO    1
+/** @} */
+
+
+/**
  * @name UART configuration
  * @{
  */

--- a/boards/openmote/include/periph_conf.h
+++ b/boards/openmote/include/periph_conf.h
@@ -78,6 +78,15 @@
 #define TIMER_3_ISR_2       isr_timer3_chan1
 /** @} */
 
+
+/**
+ * @name Hardware Timer peripheral configuration
+ * @{
+ */
+#define HWTIMER_IRQ_PRIO    1
+/** @} */
+
+
 /**
  * @name UART configuration
  * @{

--- a/cpu/cc2538/hwtimer_arch.c
+++ b/cpu/cc2538/hwtimer_arch.c
@@ -13,60 +13,105 @@
  * @file        hwtimer_arch.c
  * @brief       Implementation of the kernels hwtimer interface
  *
- * The hardware timer implementation uses the Cortex build-in system timer as back-end.
+ * The hardware timer implementation uses the CC2538 Sleep Timer as a back-end.
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Ian Martin <ian@locicontrols.com>
  *
  * @}
  */
 
 #include "arch/hwtimer_arch.h"
-#include "board.h"
-#include "periph/timer.h"
+#include "hwtimer.h"
 #include "hwtimer_cpu.h"
+#include "periph_conf.h"
 
+#include "sched.h"
+#include "thread.h"
 
-void irq_handler(int channel);
+#define sleep_timer_ready() ( SMWDTHROSC_STLOAD & 1 )
+
 void (*timeout_handler)(int);
 
+static inline void sleep_timer_load_compare_value(uint32_t value) {
+    /* Wait until the compare registers are ready to be loaded: */
+    while (!sleep_timer_ready());
+
+    /* Load the three most-significant bytes: */
+    SMWDTHROSC_ST3 = value >> 24;
+    SMWDTHROSC_ST2 = value >> 16;
+    SMWDTHROSC_ST1 = value >>  8;
+
+    /* Load the least-significant byte, which also latches the other bytes: */
+    SMWDTHROSC_ST0 = value;
+}
 
 void hwtimer_arch_init(void (*handler)(int), uint32_t fcpu)
 {
     timeout_handler = handler;
-    timer_init(HW_TIMER, HWTIMER_SPEED / 1000000, &irq_handler);
+    NVIC_SetPriority(SM_TIMER_ALT_IRQn, HWTIMER_IRQ_PRIO);
 }
 
 void hwtimer_arch_enable_interrupt(void)
 {
-    timer_irq_enable(HW_TIMER);
+    NVIC_EnableIRQ(SM_TIMER_ALT_IRQn);
 }
 
 void hwtimer_arch_disable_interrupt(void)
 {
-    timer_irq_disable(HW_TIMER);
-}
-
-void hwtimer_arch_set(unsigned long offset, short timer)
-{
-    timer_set(HW_TIMER, timer, offset);
-}
-
-void hwtimer_arch_set_absolute(unsigned long value, short timer)
-{
-    timer_set_absolute(HW_TIMER, timer, value);
-}
-
-void hwtimer_arch_unset(short timer)
-{
-    timer_clear(HW_TIMER, timer);
+    NVIC_DisableIRQ(SM_TIMER_ALT_IRQn);
 }
 
 unsigned long hwtimer_arch_now(void)
 {
-    return timer_read(HW_TIMER);
+    /* Read the least-significant byte, which also latches the other bytes: */
+    unsigned long now = SMWDTHROSC_ST0;
+
+    /* Read the remaining more-significant bytes: */
+    now |= SMWDTHROSC_ST1 <<  8;
+    now |= SMWDTHROSC_ST2 << 16;
+    now |= SMWDTHROSC_ST3 << 24;
+
+    return now;
 }
 
-void irq_handler(int channel)
+void hwtimer_arch_set_absolute(unsigned long value, short timer)
 {
-    timeout_handler((short)(channel));
+    unsigned long offset;
+
+    offset = value - hwtimer_arch_now();
+
+    if (offset < HWTIMER_SPIN_BARRIER) {
+        hwtimer_spin(offset);
+        timeout_handler(timer);
+    }
+    else {
+        sleep_timer_load_compare_value(value);
+        NVIC_EnableIRQ(SM_TIMER_ALT_IRQn);
+    }
+}
+
+void hwtimer_arch_set(unsigned long offset, short timer)
+{
+    if (offset < HWTIMER_SPIN_BARRIER) {
+        hwtimer_spin(offset);
+        timeout_handler(timer);
+    }
+    else {
+        sleep_timer_load_compare_value(hwtimer_arch_now() + offset);
+        NVIC_EnableIRQ(SM_TIMER_ALT_IRQn);
+    }
+}
+
+void hwtimer_arch_unset(short timer)
+{
+    NVIC_DisableIRQ(SM_TIMER_ALT_IRQn);
+}
+
+void isr_sleepmode(void) {
+    timeout_handler(0);
+
+    if (sched_context_switch_request) {
+        thread_yield();
+    }
 }

--- a/cpu/cc2538/include/hwtimer_cpu.h
+++ b/cpu/cc2538/include/hwtimer_cpu.h
@@ -27,9 +27,26 @@ extern "C" {
  * @name Hardware timer configuration
  * @{
  */
-#define HWTIMER_MAXTIMERS   2               /**< Number of hwtimers */
-#define HWTIMER_SPEED       1000000         /**< The hardware timer runs at 1MHz */
-#define HWTIMER_MAXTICKS    0xFFFFFFFF      /**< 32-bit timer */
+
+#define OSC32K_CAL_RATIO    977                               /**< CC2538 low-frequency clock calibration ratio = round(32000000 / 32768) */
+
+#define HWTIMER_MAXTIMERS   1                                 /**< Number of hwtimers */
+
+#if SYS_CTRL_OSC32K_USE_XTAL
+    #define HWTIMER_SPEED   XOSC32K_FREQ                      /**< The hardware timer runs at 32.768 kHz */
+#else
+    #define HWTIMER_SPEED   (XOSC32M_FREQ / OSC32K_CAL_RATIO) /**< The hardware timer runs at ~32.753 kHz */
+#endif
+
+#define HWTIMER_MAXTICKS    0xffffffff                        /**< 32-bit timer */
+
+/*
+ * When setting a new compare value, the value must be
+ * at least 5 more than the current sleep timer value.
+ * Otherwise, the timer compare event may be lost.
+ */
+#define HWTIMER_SPIN_BARRIER 5
+
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
The main benefit is that the Sleep Timer continues to work in low-power modes PM1 and PM2 whereas the GPTimer units are no longer clocked. Tested ok.