### PR TITLE
cpu: removed NAKED attribute from ISRs

### DIFF
--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -525,14 +525,10 @@ void gpio_write(gpio_t dev, int value)
 }
 
 /** @brief Interrupt service routine for Port A */
-__attribute__((naked))
 void isr_gpioa(void)
 {
     int mis, bit;
     gpio_state_t* state;
-
-    ISR_ENTER();
-    asm("push {r4-r5}");
 
     /* Latch and clear the interrupt status early on: */
     mis = GPIO_A->MIS;
@@ -551,20 +547,13 @@ void isr_gpioa(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-
-    asm("pop {r4-r5}");
-    ISR_EXIT();
 }
 
 /** @brief Interrupt service routine for Port B */
-__attribute__((naked))
 void isr_gpiob(void)
 {
     int mis, bit;
     gpio_state_t* state;
-
-    ISR_ENTER();
-    asm("push {r4-r5}");
 
     /* Latch and clear the interrupt status early on: */
     mis = GPIO_B->MIS;
@@ -583,20 +572,13 @@ void isr_gpiob(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-
-    asm("pop {r4-r5}");
-    ISR_EXIT();
 }
 
 /** @brief Interrupt service routine for Port C */
-__attribute__((naked))
 void isr_gpioc(void)
 {
     int mis, bit;
     gpio_state_t* state;
-
-    ISR_ENTER();
-    asm("push {r4-r5}");
 
     /* Latch and clear the interrupt status early on: */
     mis = GPIO_C->MIS;
@@ -615,20 +597,13 @@ void isr_gpioc(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-
-    asm("pop {r4-r5}");
-    ISR_EXIT();
 }
 
 /** @brief Interrupt service routine for Port D */
-__attribute__((naked))
 void isr_gpiod(void)
 {
     int mis, bit;
     gpio_state_t* state;
-
-    ISR_ENTER();
-    asm("push {r4-r5}");
 
     /* Latch and clear the interrupt status early on: */
     mis = GPIO_D->MIS;
@@ -647,9 +622,6 @@ void isr_gpiod(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-
-    asm("pop {r4-r5}");
-    ISR_EXIT();
 }
 
 #endif /* GPIO_NUMOF */

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -388,116 +388,89 @@ void timer_reset(tim_t dev)
 
 
 #if TIMER_0_EN
-__attribute__((naked))
 void TIMER_0_ISR_1(void)
 {
-    ISR_ENTER();
     if (config[0].cb != NULL) config[0].cb(0);
 
     if (sched_context_switch_request) {
         thread_yield();
     }
 
-    ISR_EXIT();
 }
 
-__attribute__((naked))
 void TIMER_0_ISR_2(void)
 {
-    ISR_ENTER();
     if (config[0].cb != NULL) config[0].cb(1);
 
     if (sched_context_switch_request) {
         thread_yield();
     }
 
-    ISR_EXIT();
 }
 #endif /* TIMER_0_EN */
 
-
 #if TIMER_1_EN
-__attribute__((naked))
 void TIMER_1_ISR_1(void)
 {
-    ISR_ENTER();
     if (config[1].cb != NULL) config[1].cb(0);
 
     if (sched_context_switch_request) {
         thread_yield();
     }
 
-    ISR_EXIT();
 }
 
-__attribute__((naked))
 void TIMER_1_ISR_2(void)
 {
-    ISR_ENTER();
     if (config[1].cb != NULL) config[1].cb(1);
 
     if (sched_context_switch_request) {
         thread_yield();
     }
 
-    ISR_EXIT();
 }
 #endif /* TIMER_1_EN */
 
-
 #if TIMER_2_EN
-__attribute__((naked))
 void TIMER_2_ISR_1(void)
 {
-    ISR_ENTER();
     if (config[2].cb != NULL) config[2].cb(0);
 
     if (sched_context_switch_request) {
         thread_yield();
     }
 
-    ISR_EXIT();
 }
 
-__attribute__((naked))
 void TIMER_2_ISR_2(void)
 {
-    ISR_ENTER();
     if (config[2].cb != NULL) config[2].cb(1);
 
     if (sched_context_switch_request) {
         thread_yield();
     }
 
-    ISR_EXIT();
 }
 #endif /* TIMER_2_EN */
 
-
 #if TIMER_3_EN
-__attribute__((naked))
 void TIMER_3_ISR_1(void)
 {
-    ISR_ENTER();
     if (config[3].cb != NULL) config[3].cb(0);
 
     if (sched_context_switch_request) {
         thread_yield();
     }
 
-    ISR_EXIT();
 }
 
-__attribute__((naked))
 void TIMER_3_ISR_2(void)
 {
-    ISR_ENTER();
     if (config[3].cb != NULL) config[3].cb(1);
 
     if (sched_context_switch_request) {
         thread_yield();
     }
 
-    ISR_EXIT();
 }
 #endif /* TIMER_3_EN */

--- a/cpu/cc2538/periph/uart.c
+++ b/cpu/cc2538/periph/uart.c
@@ -110,13 +110,9 @@ static void reset(cc2538_uart_t *u)
 /*---------------------------------------------------------------------------*/
 
 #if UART_0_EN
-__attribute__((naked))
 void UART_0_ISR(void)
 {
     uint_fast16_t mis;
-
-    ISR_ENTER();
-    asm("push {r4}");
 
     /* Store the current MIS and clear all flags early, except the RTM flag.
      * This will clear itself when we read out the entire FIFO contents */
@@ -136,20 +132,13 @@ void UART_0_ISR(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-
-    asm("pop {r4}");
-    ISR_EXIT();
 }
 #endif /* UART_0_EN */
 
 #if UART_1_EN
-__attribute__((naked))
 void UART_1_ISR(void)
 {
     uint_fast16_t mis;
-
-    ISR_ENTER();
-    asm("push {r4}");
 
     /* Store the current MIS and clear all flags early, except the RTM flag.
      * This will clear itself when we read out the entire FIFO contents */
@@ -169,9 +158,6 @@ void UART_1_ISR(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-
-    asm("pop {r4}");
-    ISR_EXIT();
 }
 #endif /* UART_1_EN */
 

--- a/cpu/cc2538/startup.c
+++ b/cpu/cc2538/startup.c
@@ -77,7 +77,6 @@ void reset_handler(void)
 /**
  * @brief Default handler is called in case no interrupt handler was defined
  */
-__attribute__((naked))
 void dummy_handler(void)
 {
     while (1) {
@@ -85,7 +84,6 @@ void dummy_handler(void)
     }
 }
 
-__attribute__((naked))
 void isr_nmi(void)
 {
     while (1) {
@@ -93,7 +91,6 @@ void isr_nmi(void)
     }
 }
 
-__attribute__((naked))
 void isr_mem_manage(void)
 {
     while (1) {
@@ -101,7 +98,6 @@ void isr_mem_manage(void)
     }
 }
 
-__attribute__((naked))
 void isr_debug_mon(void)
 {
     while (1) {
@@ -109,7 +105,6 @@ void isr_debug_mon(void)
     }
 }
 
-__attribute__((naked))
 void isr_hard_fault(void)
 {
     while (1) {
@@ -117,7 +112,6 @@ void isr_hard_fault(void)
     }
 }
 
-__attribute__((naked))
 void isr_bus_fault(void)
 {
     while (1) {
@@ -125,7 +119,6 @@ void isr_bus_fault(void)
     }
 }
 
-__attribute__((naked))
 void isr_usage_fault(void)
 {
     while (1) {

--- a/cpu/cortex-m0_common/include/cpu.h
+++ b/cpu/cortex-m0_common/include/cpu.h
@@ -37,16 +37,6 @@
 #define dINT            disableIRQ
 
 /**
- * @brief Macro has to be called in the beginning of each ISR
- */
-#define ISR_ENTER()         asm("push {LR}")
-
-/**
- * @brief Macro has to be called on each exit of an ISR
- */
-#define ISR_EXIT()          asm("pop {r0} \n bx r0")
-
-/**
  * @brief Initialization of the CPU
  */
 void cpu_init(void);

--- a/cpu/cortex-m3_common/include/cpu.h
+++ b/cpu/cortex-m3_common/include/cpu.h
@@ -34,16 +34,6 @@
 #define dINT            disableIRQ
 
 /**
- * @brief Macro has to be called in the beginning of each ISR
- */
-#define ISR_ENTER()     asm("push {LR}")
-
-/**
- * @brief Macro has to be called on each exit of an ISR
- */
-#define ISR_EXIT()      asm("pop {r0} \n bx r0")
-
-/**
  * @brief Initialization of the CPU
  */
 void cpu_init(void);

--- a/cpu/cortex-m4_common/include/cpu.h
+++ b/cpu/cortex-m4_common/include/cpu.h
@@ -36,16 +36,6 @@
 #define dINT            disableIRQ
 
 /**
- * @brief Macro has to be called in the beginning of each ISR
- */
-#define ISR_ENTER()         asm("push {LR}")
-
-/**
- * @brief Macro has to be called on each exit of an ISR
- */
-#define ISR_EXIT()          asm("pop {r0}"); asm("bx r0")
-
-/**
  * @brief Initialization of the CPU
  */
 void cpu_init(void);

--- a/cpu/nrf51822/periph/gpio.c
+++ b/cpu/nrf51822/periph/gpio.c
@@ -297,9 +297,8 @@ void gpio_write(gpio_t dev, int value)
     }
 }
 
-__attribute__((naked)) void isr_gpiote(void)
+void isr_gpiote(void)
 {
-    ISR_ENTER();
     if (NRF_GPIOTE->EVENTS_IN[0] == 1)
     {
         NRF_GPIOTE->EVENTS_IN[0] = 0;
@@ -308,7 +307,6 @@ __attribute__((naked)) void isr_gpiote(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 
 #endif /* GPIO_NUMOF */

--- a/cpu/nrf51822/periph/rtt.c
+++ b/cpu/nrf51822/periph/rtt.c
@@ -93,9 +93,8 @@ void rtt_poweroff(void)
     RTT_DEV->POWER = 0;
 }
 
-__attribute__((naked)) void RTT_ISR(void)
+void RTT_ISR(void)
 {
-    ISR_ENTER();
     if (RTT_DEV->EVENTS_COMPARE[0] ==1) {
         RTT_DEV->EVENTS_COMPARE[0] = 0;
         RTT_DEV->INTENCLR = RTC_INTENSET_COMPARE0_Msk;
@@ -104,7 +103,6 @@ __attribute__((naked)) void RTT_ISR(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 
 #endif /* RTT_NUMOF */

--- a/cpu/nrf51822/periph/timer.c
+++ b/cpu/nrf51822/periph/timer.c
@@ -349,9 +349,8 @@ void timer_reset(tim_t dev)
 }
 
 #if TIMER_0_EN
-__attribute__((naked)) void TIMER_0_ISR(void)
+void TIMER_0_ISR(void)
 {
-    ISR_ENTER();
     for(int i = 0; i < TIMER_0_CHANNELS; i++){
         if(TIMER_0_DEV->EVENTS_COMPARE[i] == 1){
             TIMER_0_DEV->EVENTS_COMPARE[i] = 0;
@@ -362,14 +361,12 @@ __attribute__((naked)) void TIMER_0_ISR(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 #endif
 
 #if TIMER_1_EN
-__attribute__((naked)) void TIMER_1_ISR(void)
+void TIMER_1_ISR(void)
 {
-    ISR_ENTER();
     for(int i = 0; i < TIMER_1_CHANNELS; i++){
         if(TIMER_1_DEV->EVENTS_COMPARE[i] == 1){
             TIMER_1_DEV->EVENTS_COMPARE[i] = 0;
@@ -380,14 +377,12 @@ __attribute__((naked)) void TIMER_1_ISR(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 #endif
 
 #if TIMER_2_EN
-__attribute__((naked)) void TIMER_2_ISR(void)
+void TIMER_2_ISR(void)
 {
-    ISR_ENTER();
     for(int i = 0; i < TIMER_2_CHANNELS; i++){
         if(TIMER_2_DEV->EVENTS_COMPARE[i] == 1){
             TIMER_2_DEV->EVENTS_COMPARE[i] = 0;
@@ -398,6 +393,5 @@ __attribute__((naked)) void TIMER_2_ISR(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 #endif

--- a/cpu/sam3x8e/periph/gpio.c
+++ b/cpu/sam3x8e/periph/gpio.c
@@ -785,9 +785,8 @@ void gpio_write(gpio_t dev, int value)
     }
 }
 
-__attribute__((naked)) void isr_pioa(void)
+void isr_pioa(void)
 {
-    ISR_ENTER();
     uint32_t status = PIOA->PIO_ISR;
 #ifdef GPIO_A0_MAP
     if (status & (1 << 0)) {
@@ -952,12 +951,10 @@ __attribute__((naked)) void isr_pioa(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 
-__attribute__((naked)) void isr_piob(void)
+void isr_piob(void)
 {
-    ISR_ENTER();
     uint32_t status = PIOB->PIO_ISR;
 #ifdef GPIO_B0_MAP
     if (status & (1 << 0)) {
@@ -1122,12 +1119,10 @@ __attribute__((naked)) void isr_piob(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 
-__attribute__((naked)) void isr_pioc(void)
+void isr_pioc(void)
 {
-    ISR_ENTER();
     uint32_t status = PIOC->PIO_ISR;
 #ifdef GPIO_C0_MAP
     if (status & (1 << 0)) {
@@ -1292,13 +1287,10 @@ __attribute__((naked)) void isr_pioc(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-
-    ISR_EXIT();
 }
 
-__attribute__((naked)) void isr_piod(void)
+void isr_piod(void)
 {
-    ISR_ENTER();
     uint32_t status = PIOD->PIO_ISR;
 #ifdef GPIO_D0_MAP
     if (status & (1 << 0)) {
@@ -1463,7 +1455,6 @@ __attribute__((naked)) void isr_piod(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 
 #endif /* GPIO_NUMOF */

--- a/cpu/sam3x8e/periph/spi.c
+++ b/cpu/sam3x8e/periph/spi.c
@@ -395,13 +395,13 @@ static inline void irq_handler_transfer(Spi *spi, spi_t dev)
     }
 }
 
-__attribute__((naked))
+#if SPI_0_EN
 void SPI_0_IRQ_HANDLER(void)
 {
     if (SPI_0_DEV->SPI_SR & SPI_SR_RDRF) {
-        ISR_ENTER();
         irq_handler_transfer(SPI_0_DEV, SPI_0);
-        ISR_EXIT();
     }
 }
+#endif
+
 #endif /* SPI_NUMOF */

--- a/cpu/sam3x8e/periph/timer.c
+++ b/cpu/sam3x8e/periph/timer.c
@@ -399,9 +399,8 @@ void timer_reset(tim_t dev)
 
 
 #if TIMER_0_EN
-__attribute__ ((naked)) void TIMER_0_ISR1(void)
+void TIMER_0_ISR1(void)
 {
-    ISR_ENTER();
     uint32_t status = TIMER_0_DEV->TC_CHANNEL[0].TC_SR;
     if (status & TC_SR_CPAS) {
         TIMER_0_DEV->TC_CHANNEL[0].TC_IDR = TC_IDR_CPAS;
@@ -418,12 +417,10 @@ __attribute__ ((naked)) void TIMER_0_ISR1(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 
-__attribute__ ((naked)) void TIMER_0_ISR2(void)
+void TIMER_0_ISR2(void)
 {
-    ISR_ENTER();
     uint32_t status = TIMER_0_DEV->TC_CHANNEL[1].TC_SR;
     if (status & TC_SR_CPAS) {
         TIMER_0_DEV->TC_CHANNEL[1].TC_IDR = TC_IDR_CPAS;
@@ -440,15 +437,13 @@ __attribute__ ((naked)) void TIMER_0_ISR2(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 #endif /* TIMER_0_EN */
 
 
 #if TIMER_1_EN
-__attribute__ ((naked)) void TIMER_1_ISR1(void)
+void TIMER_1_ISR1(void)
 {
-    ISR_ENTER();
     uint32_t status = TIMER_1_DEV->TC_CHANNEL[0].TC_SR;
     if (status & TC_SR_CPAS) {
         TIMER_1_DEV->TC_CHANNEL[0].TC_IDR = TC_IDR_CPAS;
@@ -465,12 +460,10 @@ __attribute__ ((naked)) void TIMER_1_ISR1(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 
-__attribute__ ((naked)) void TIMER_1_ISR2(void)
+void TIMER_1_ISR2(void)
 {
-    ISR_ENTER();
     uint32_t status = TIMER_1_DEV->TC_CHANNEL[1].TC_SR;
     if (status & TC_SR_CPAS) {
         TIMER_1_DEV->TC_CHANNEL[1].TC_IDR = TC_IDR_CPAS;
@@ -487,15 +480,13 @@ __attribute__ ((naked)) void TIMER_1_ISR2(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 #endif /* TIMER_1_EN */
 
 
 #if TIMER_2_EN
-__attribute__ ((naked)) void TIMER_2_ISR1(void)
+void TIMER_2_ISR1(void)
 {
-    ISR_ENTER();
     uint32_t status = TIMER_2_DEV->TC_CHANNEL[0].TC_SR;
     if (status & TC_SR_CPAS) {
         TIMER_2_DEV->TC_CHANNEL[0].TC_IDR = TC_IDR_CPAS;
@@ -512,12 +503,10 @@ __attribute__ ((naked)) void TIMER_2_ISR1(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 
-__attribute__ ((naked)) void TIMER_2_ISR2(void)
+void TIMER_2_ISR2(void)
 {
-    ISR_ENTER();
     uint32_t status = TIMER_2_DEV->TC_CHANNEL[1].TC_SR;
     if (status & TC_SR_CPAS) {
         TIMER_2_DEV->TC_CHANNEL[1].TC_IDR = TC_IDR_CPAS;
@@ -534,6 +523,5 @@ __attribute__ ((naked)) void TIMER_2_ISR2(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 #endif /* TIMER_2_EN */

--- a/cpu/samd21/periph/gpio.c
+++ b/cpu/samd21/periph/gpio.c
@@ -887,9 +887,8 @@ void gpio_write(gpio_t dev, int value)
     }
 }
 
-__attribute__((naked)) void isr_eic(void)
+void isr_eic(void)
 {
-    ISR_ENTER();
     uint16_t status = EIC->INTFLAG.reg;
     switch (status) {
         case EIC_INTFLAG_EXTINT0:
@@ -960,7 +959,6 @@ __attribute__((naked)) void isr_eic(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 
 #endif /* GPIO_NUMOF */

--- a/cpu/samd21/periph/timer.c
+++ b/cpu/samd21/periph/timer.c
@@ -342,54 +342,45 @@ void timer_reset(tim_t dev)
 
 
 #if TIMER_0_EN
-__attribute__ ((naked))
 void TIMER_0_ISR(void)
 {
-    ISR_ENTER();
-        if (TIMER_0_DEV.INTFLAG.bit.MC0 && TIMER_0_DEV.INTENSET.bit.MC0) {
-            TIMER_0_DEV.INTFLAG.bit.MC0 = 1;
-            config[TIMER_0].cb(0);
-        }
-        else if (TIMER_0_DEV.INTFLAG.bit.MC1 && TIMER_0_DEV.INTENSET.bit.MC1) {
-            TIMER_0_DEV.INTFLAG.bit.MC1 = 1;
-            config[TIMER_0].cb(1);
-        }
-    ISR_EXIT();
+    if (TIMER_0_DEV.INTFLAG.bit.MC0 && TIMER_0_DEV.INTENSET.bit.MC0) {
+        TIMER_0_DEV.INTFLAG.bit.MC0 = 1;
+        config[TIMER_0].cb(0);
+    }
+    else if (TIMER_0_DEV.INTFLAG.bit.MC1 && TIMER_0_DEV.INTENSET.bit.MC1) {
+        TIMER_0_DEV.INTFLAG.bit.MC1 = 1;
+        config[TIMER_0].cb(1);
+    }
 }
 #endif /* TIMER_0_EN */
 
 
 #if TIMER_1_EN
-__attribute__ ((naked))
 void TIMER_1_ISR(void)
 {
-    ISR_ENTER();
-        if (TIMER_1_DEV.INTFLAG.bit.MC0 && TIMER_1_DEV.INTENSET.bit.MC0) {
-            TIMER_1_DEV.INTFLAG.bit.MC0 = 1;
-            config[TIMER_1].cb(0);
-        }
-        else if (TIMER_1_DEV.INTFLAG.bit.MC1 && TIMER_1_DEV.INTENSET.bit.MC1) {
-            TIMER_1_DEV.INTFLAG.bit.MC1 = 1;
-            config[TIMER_1].cb(1);
-        }
-    ISR_EXIT();
+    if (TIMER_1_DEV.INTFLAG.bit.MC0 && TIMER_1_DEV.INTENSET.bit.MC0) {
+        TIMER_1_DEV.INTFLAG.bit.MC0 = 1;
+        config[TIMER_1].cb(0);
+    }
+    else if (TIMER_1_DEV.INTFLAG.bit.MC1 && TIMER_1_DEV.INTENSET.bit.MC1) {
+        TIMER_1_DEV.INTFLAG.bit.MC1 = 1;
+        config[TIMER_1].cb(1);
+    }
 }
 #endif /* TIMER_1_EN */
 
 
 #if TIMER_2_EN
-__attribute__ ((naked))
 void TIMER_2_ISR(void)
 {
-    ISR_ENTER();
-        if (TIMER_2_DEV.INTFLAG.bit.MC0 && TIMER_2_DEV.INTENSET.bit.MC0) {
-            TIMER_2_DEV.INTFLAG.bit.MC0 = 1;
-            config[TIMER_2].cb(0);
-        }
-        else if (TIMER_2_DEV.INTFLAG.bit.MC1 && TIMER_2_DEV.INTENSET.bit.MC1) {
-            TIMER_2_DEV.INTFLAG.bit.MC1 = 1;
-            config[TIMER_2].cb(1);
-        }
-    ISR_EXIT();
+    if (TIMER_2_DEV.INTFLAG.bit.MC0 && TIMER_2_DEV.INTENSET.bit.MC0) {
+        TIMER_2_DEV.INTFLAG.bit.MC0 = 1;
+        config[TIMER_2].cb(0);
+    }
+    else if (TIMER_2_DEV.INTFLAG.bit.MC1 && TIMER_2_DEV.INTENSET.bit.MC1) {
+        TIMER_2_DEV.INTFLAG.bit.MC1 = 1;
+        config[TIMER_2].cb(1);
+    }
 }
 #endif /* TIMER_2_EN */

--- a/cpu/samd21/periph/uart.c
+++ b/cpu/samd21/periph/uart.c
@@ -194,11 +194,9 @@ void uart_poweroff(uart_t uart)
 }
 
 #if UART_0_EN
-__attribute__((naked)) void UART_0_ISR(void)
+void UART_0_ISR(void)
 {
-    ISR_ENTER();
     irq_handler(UART_0, &UART_0_DEV);
-    ISR_EXIT();
 }
 #endif
 

--- a/cpu/stm32f0/periph/gpio.c
+++ b/cpu/stm32f0/periph/gpio.c
@@ -752,9 +752,8 @@ void gpio_write(gpio_t dev, int value)
     }
 }
 
-__attribute__((naked)) void isr_exti0_1(void)
+void isr_exti0_1(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR0) {
         EXTI->PR |= EXTI_PR_PR0;        /* clear status bit by writing a 1 to it */
         gpio_config[GPIO_IRQ_0].cb(gpio_config[GPIO_IRQ_0].arg);
@@ -766,12 +765,10 @@ __attribute__((naked)) void isr_exti0_1(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 
-__attribute__((naked)) void isr_exti2_3(void)
+void isr_exti2_3(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR2) {
         EXTI->PR |= EXTI_PR_PR2;        /* clear status bit by writing a 1 to it */
         gpio_config[GPIO_IRQ_2].cb(gpio_config[GPIO_IRQ_2].arg);
@@ -783,12 +780,10 @@ __attribute__((naked)) void isr_exti2_3(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 
-__attribute__((naked)) void isr_exti4_15(void)
+void isr_exti4_15(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR4) {
         EXTI->PR |= EXTI_PR_PR4;        /* clear status bit by writing a 1 to it */
         gpio_config[GPIO_IRQ_4].cb(gpio_config[GPIO_IRQ_4].arg);
@@ -840,7 +835,6 @@ __attribute__((naked)) void isr_exti4_15(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 
 #endif /* GPIO_NUMOF */

--- a/cpu/stm32f0/periph/timer.c
+++ b/cpu/stm32f0/periph/timer.c
@@ -288,20 +288,16 @@ void timer_reset(tim_t dev)
 }
 
 #if TIMER_0_EN
-__attribute__ ((naked)) void TIMER_0_ISR(void)
+void TIMER_0_ISR(void)
 {
-    ISR_ENTER();
     irq_handler(TIMER_0, TIMER_0_DEV);
-    ISR_EXIT();
 }
 #endif
 
 #if TIMER_1_EN
-__attribute__ ((naked)) void TIMER_1_ISR(void)
+void TIMER_1_ISR(void)
 {
-    ISR_ENTER();
     irq_handler(TIMER_1, TIMER_1_DEV);
-    ISR_EXIT();
 }
 #endif
 

--- a/cpu/stm32f0/periph/uart.c
+++ b/cpu/stm32f0/periph/uart.c
@@ -281,20 +281,16 @@ void uart_poweroff(uart_t uart)
 }
 
 #if UART_0_EN
-__attribute__((naked)) void UART_0_ISR(void)
+void UART_0_ISR(void)
 {
-    ISR_ENTER();
     irq_handler(UART_0, UART_0_DEV);
-    ISR_EXIT();
 }
 #endif
 
 #if UART_1_EN
-__attribute__((naked)) void UART_1_ISR(void)
+void UART_1_ISR(void)
 {
-    ISR_ENTER();
     irq_handler(UART_1, UART_1_DEV);
-    ISR_EXIT();
 }
 #endif
 

--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -1014,9 +1014,8 @@ void gpio_write(gpio_t dev, int value)
 }
 
 #ifdef GPIO_IRQ_0
-__attribute__((naked)) void isr_exti0(void)
+void isr_exti0(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR0) {
         EXTI->PR |= EXTI_PR_PR0;        /* clear status bit by writing a 1 to it */
         config[GPIO_IRQ_0].cb(config[GPIO_IRQ_0].arg);
@@ -1025,14 +1024,12 @@ __attribute__((naked)) void isr_exti0(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 #endif
 
 #ifdef GPIO_IRQ_1
-__attribute__((naked)) void isr_exti1(void)
+void isr_exti1(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR1) {
         EXTI->PR |= EXTI_PR_PR1;        /* clear status bit by writing a 1 to it */
         config[GPIO_IRQ_1].cb(config[GPIO_IRQ_1].arg);
@@ -1041,14 +1038,12 @@ __attribute__((naked)) void isr_exti1(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 #endif
 
 #ifdef GPIO_IRQ_2
-__attribute__((naked)) void isr_exti2(void)
+void isr_exti2(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR2) {
         EXTI->PR |= EXTI_PR_PR2;        /* clear status bit by writing a 1 to it */
         config[GPIO_IRQ_2].cb(config[GPIO_IRQ_2].arg);
@@ -1057,14 +1052,12 @@ __attribute__((naked)) void isr_exti2(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 #endif
 
 #ifdef GPIO_IRQ_3
-__attribute__((naked)) void isr_exti3(void)
+void isr_exti3(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR3) {
         EXTI->PR |= EXTI_PR_PR3;        /* clear status bit by writing a 1 to it */
         config[GPIO_IRQ_3].cb(config[GPIO_IRQ_3].arg);
@@ -1073,14 +1066,12 @@ __attribute__((naked)) void isr_exti3(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 #endif
 
 #ifdef GPIO_IRQ_4
-__attribute__((naked)) void isr_exti4(void)
+void isr_exti4(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR4) {
         EXTI->PR |= EXTI_PR_PR4;        /* clear status bit by writing a 1 to it */
         config[GPIO_IRQ_4].cb(config[GPIO_IRQ_4].arg);
@@ -1089,14 +1080,12 @@ __attribute__((naked)) void isr_exti4(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 #endif
 
 #if defined(GPIO_IRQ_5) || defined(GPIO_IRQ_6) || defined(GPIO_IRQ_7) || defined(GPIO_IRQ_8) || defined(GPIO_IRQ_9)
-__attribute__((naked)) void isr_exti9_5(void)
+void isr_exti9_5(void)
 {
-    ISR_ENTER();
 #ifdef GPIO_IRQ_5
     if (EXTI->PR & EXTI_PR_PR5) {
         EXTI->PR |= EXTI_PR_PR5;        /* clear status bit by writing a 1 to it */
@@ -1130,14 +1119,12 @@ __attribute__((naked)) void isr_exti9_5(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 #endif
 
 #if defined(GPIO_IRQ_10) || defined(GPIO_IRQ_11) || defined(GPIO_IRQ_12) || defined(GPIO_IRQ_13) || defined(GPIO_IRQ_14) || defined(GPIO_IRQ_15)
-__attribute__((naked)) void isr_exti15_10(void)
+void isr_exti15_10(void)
 {
-    ISR_ENTER();
 #ifdef GPIO_IRQ_10
     if (EXTI->PR & EXTI_PR_PR10) {
         EXTI->PR |= EXTI_PR_PR10;        /* clear status bit by writing a 1 to it */
@@ -1177,7 +1164,6 @@ __attribute__((naked)) void isr_exti15_10(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 #endif
 

--- a/cpu/stm32f1/periph/rtt.c
+++ b/cpu/stm32f1/periph/rtt.c
@@ -163,10 +163,8 @@ inline void _rtt_leave_config_mode(void)
     while (!(RTT_DEV->CRL & RTT_FLAG_RTOFF));
 }
 
-__attribute__((naked)) void RTT_ISR(void)
+void RTT_ISR(void)
 {
-    ISR_ENTER();
-
     if (RTT_DEV->CRL & RTC_CRL_ALRF) {
         RTT_DEV->CRL &= ~(RTC_CRL_ALRF);
         alarm_cb(alarm_arg);
@@ -174,7 +172,6 @@ __attribute__((naked)) void RTT_ISR(void)
     if (sched_context_switch_request) {
         thread_yield();
     }
-    ISR_EXIT();
 }
 
 #endif /* RTT_NUMOF */

--- a/cpu/stm32f1/periph/timer.c
+++ b/cpu/stm32f1/periph/timer.c
@@ -339,22 +339,18 @@ void timer_reset(tim_t dev)
 
 
 #if TIMER_0_EN
-__attribute__ ((naked)) void TIMER_0_ISR_0(void)
+void TIMER_0_ISR_0(void)
 {
-    ISR_ENTER();
     DEBUG("\nenter ISR\n");
     irq_handler(TIMER_0, TIMER_0_DEV_0, TIMER_0_DEV_1);
     DEBUG("leave ISR\n\n");
-    ISR_EXIT();
 }
 #endif
 
 #if TIMER_1_EN
-__attribute__ ((naked)) void TIMER_1_ISR_0(void)
+void TIMER_1_ISR_0(void)
 {
-    ISR_ENTER();
     irq_handler(TIMER_0, TIMER_1_DEV_0, TIMER_1_DEV_1);
-    ISR_EXIT();
 }
 #endif
 

--- a/cpu/stm32f1/periph/uart.c
+++ b/cpu/stm32f1/periph/uart.c
@@ -270,20 +270,16 @@ int uart_write_blocking(uart_t uart, char data)
 }
 
 #if UART_0_EN
-__attribute__((naked)) void UART_0_ISR(void)
+void UART_0_ISR(void)
 {
-    ISR_ENTER();
     irq_handler(UART_0, UART_0_DEV);
-    ISR_EXIT();
 }
 #endif
 
 #if UART_1_EN
-__attribute__((naked)) void UART_1_ISR(void)
+void UART_1_ISR(void)
 {
-    ISR_ENTER();
     irq_handler(UART_1, UART_1_DEV);
-    ISR_EXIT();
 }
 #endif
 

--- a/cpu/stm32f3/periph/gpio.c
+++ b/cpu/stm32f3/periph/gpio.c
@@ -767,59 +767,48 @@ static inline void irq_handler(gpio_t dev)
     }
 }
 
-__attribute__((naked)) void isr_exti0(void)
+void isr_exti0(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR0) {
         EXTI->PR |= EXTI_PR_PR0;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_0);
     }
-    ISR_EXIT();
 }
 
-__attribute__((naked)) void isr_exti1(void)
+void isr_exti1(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR1) {
         EXTI->PR |= EXTI_PR_PR1;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_1);
     }
-    ISR_EXIT();
 }
 
-__attribute__((naked)) void isr_exti2(void)
+void isr_exti2(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR2) {
         EXTI->PR |= EXTI_PR_PR2;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_2);
     }
-    ISR_EXIT();
 }
 
-__attribute__((naked)) void isr_exti3(void)
+void isr_exti3(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR3) {
         EXTI->PR |= EXTI_PR_PR3;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_3);
     }
-    ISR_EXIT();
 }
 
-__attribute__((naked)) void isr_exti4(void)
+void isr_exti4(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR4) {
         EXTI->PR |= EXTI_PR_PR4;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_4);
     }
-    ISR_EXIT();
 }
 
-__attribute__((naked)) void isr_exti9_5(void)
+void isr_exti9_5(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR5) {
         EXTI->PR |= EXTI_PR_PR5;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_5);
@@ -840,12 +829,10 @@ __attribute__((naked)) void isr_exti9_5(void)
         EXTI->PR |= EXTI_PR_PR9;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_9);
     }
-    ISR_EXIT();
 }
 
-__attribute__((naked)) void isr_exti15_10(void)
+void isr_exti15_10(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR10) {
         EXTI->PR |= EXTI_PR_PR10;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_10);
@@ -870,7 +857,6 @@ __attribute__((naked)) void isr_exti15_10(void)
         EXTI->PR |= EXTI_PR_PR15;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_15);
     }
-    ISR_EXIT();
 }
 
 #endif /* GPIO_NUMOF */

--- a/cpu/stm32f3/periph/timer.c
+++ b/cpu/stm32f3/periph/timer.c
@@ -242,11 +242,9 @@ void timer_reset(tim_t dev)
 }
 
 #if TIMER_0_EN
-__attribute__ ((naked)) void TIMER_0_ISR(void)
+void TIMER_0_ISR(void)
 {
-    ISR_ENTER();
     irq_handler(TIMER_0, TIMER_0_DEV);
-    ISR_EXIT();
 }
 #endif
 

--- a/cpu/stm32f3/periph/uart.c
+++ b/cpu/stm32f3/periph/uart.c
@@ -285,29 +285,23 @@ int uart_write_blocking(uart_t uart, char data)
 }
 
 #if UART_0_EN
-__attribute__((naked)) void UART_0_ISR(void)
+void UART_0_ISR(void)
 {
-    ISR_ENTER();
     irq_handler(UART_0, UART_0_DEV);
-    ISR_EXIT();
 }
 #endif
 
 #if UART_1_EN
-__attribute__((naked)) void UART_1_ISR(void)
+void UART_1_ISR(void)
 {
-    ISR_ENTER();
     irq_handler(UART_1, UART_1_DEV);
-    ISR_EXIT();
 }
 #endif
 
 #if UART_2_EN
-__attribute__((naked)) void UART_2_ISR(void)
+void UART_2_ISR(void)
 {
-    ISR_ENTER();
     irq_handler(UART_2, UART_2_DEV);
-    ISR_EXIT();
 }
 #endif
 

--- a/cpu/stm32f4/periph/gpio.c
+++ b/cpu/stm32f4/periph/gpio.c
@@ -956,65 +956,48 @@ static inline void irq_handler(gpio_t dev)
     }
 }
 
-__attribute__((naked))
 void isr_exti0(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR0) {
         EXTI->PR |= EXTI_PR_PR0;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_0);
     }
-    ISR_EXIT();
 }
 
-__attribute__((naked))
 void isr_exti1(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR1) {
         EXTI->PR |= EXTI_PR_PR1;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_1);
     }
-    ISR_EXIT();
 }
 
-__attribute__((naked))
 void isr_exti2(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR2) {
         EXTI->PR |= EXTI_PR_PR2;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_2);
     }
-    ISR_EXIT();
 }
 
-__attribute__((naked))
 void isr_exti3(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR3) {
         EXTI->PR |= EXTI_PR_PR3;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_3);
     }
-    ISR_EXIT();
 }
 
-__attribute__((naked))
 void isr_exti4(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR4) {
         EXTI->PR |= EXTI_PR_PR4;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_4);
     }
-    ISR_EXIT();
 }
 
-__attribute__((naked))
 void isr_exti9_5(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR5) {
         EXTI->PR |= EXTI_PR_PR5;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_5);
@@ -1035,13 +1018,10 @@ void isr_exti9_5(void)
         EXTI->PR |= EXTI_PR_PR9;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_9);
     }
-    ISR_EXIT();
 }
 
-__attribute__((naked))
 void isr_exti15_10(void)
 {
-    ISR_ENTER();
     if (EXTI->PR & EXTI_PR_PR10) {
         EXTI->PR |= EXTI_PR_PR10;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_10);
@@ -1066,7 +1046,6 @@ void isr_exti15_10(void)
         EXTI->PR |= EXTI_PR_PR15;        /* clear status bit by writing a 1 to it */
         irq_handler(GPIO_IRQ_15);
     }
-    ISR_EXIT();
 }
 
 #endif /* GPIO_NUMOF */

--- a/cpu/stm32f4/periph/spi.c
+++ b/cpu/stm32f4/periph/spi.c
@@ -436,29 +436,23 @@ static inline void irq_handler_transfer(SPI_TypeDef *spi, spi_t dev)
 }
 
 #if SPI_0_EN
-__attribute__((naked)) void SPI_0_IRQ_HANDLER(void)
+void SPI_0_IRQ_HANDLER(void)
 {
-    ISR_ENTER();
     irq_handler_transfer(SPI_0_DEV, SPI_0);
-    ISR_EXIT();
 }
 #endif
 
 #if SPI_1_EN
-__attribute__((naked)) void SPI_1_IRQ_HANDLER(void)
+void SPI_1_IRQ_HANDLER(void)
 {
-    ISR_ENTER();
     irq_handler_transfer(SPI_1_DEV, SPI_1);
-    ISR_EXIT();
 }
 #endif
 
 #if SPI_2_EN
-__attribute__((naked)) void SPI_2_IRQ_HANDLER(void)
+void SPI_2_IRQ_HANDLER(void)
 {
-    ISR_ENTER();
     irq_handler_transfer(SPI_2_DEV, SPI_2);
-    ISR_EXIT();
 }
 #endif
 

--- a/cpu/stm32f4/periph/timer.c
+++ b/cpu/stm32f4/periph/timer.c
@@ -293,18 +293,14 @@ void timer_reset(tim_t dev)
     }
 }
 
-__attribute__ ((naked)) void TIMER_0_ISR(void)
+void TIMER_0_ISR(void)
 {
-    ISR_ENTER();
     irq_handler(TIMER_0, TIMER_0_DEV);
-    ISR_EXIT();
 }
 
-__attribute__ ((naked)) void TIMER_1_ISR(void)
+void TIMER_1_ISR(void)
 {
-    ISR_ENTER();
     irq_handler(TIMER_1, TIMER_1_DEV);
-    ISR_EXIT();
 }
 
 static inline void irq_handler(tim_t timer, TIM_TypeDef *dev)

--- a/cpu/stm32f4/periph/uart.c
+++ b/cpu/stm32f4/periph/uart.c
@@ -329,29 +329,23 @@ void uart_poweroff(uart_t uart)
 }
 
 #if UART_0_EN
-__attribute__((naked)) void UART_0_ISR(void)
+void UART_0_ISR(void)
 {
-    ISR_ENTER();
     irq_handler(UART_0, UART_0_DEV);
-    ISR_EXIT();
 }
 #endif
 
 #if UART_1_EN
-__attribute__((naked)) void UART_1_ISR(void)
+void UART_1_ISR(void)
 {
-    ISR_ENTER();
     irq_handler(UART_1, UART_1_DEV);
-    ISR_EXIT();
 }
 #endif
 
 #if UART_2_EN
-__attribute__((naked)) void UART_2_ISR(void)
+void UART_2_ISR(void)
 {
-    ISR_ENTER();
     irq_handler(UART_2, UART_2_DEV);
-    ISR_EXIT();
 }
 #endif
 


### PR DESCRIPTION
After some thoughts and discussion in #1654 it seems that the current way of handling ISRs for Arm Cortex based platforms is far from optimal (to put it mildly...). I propose to simplify the ISR code by removing the `naked` attribute and the `ISR_ENTER()` and `ISR_EXIT()` macros. This comes with a penalty of 2 CPU cycles per ISR, but gives us far more robust code.

PLEASE TEST THOROUGHLY! 
