### PR TITLE
core: remove thread_getpid

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -135,17 +135,6 @@ void thread_yield(void);
  */
 int thread_wakeup(kernel_pid_t pid);
 
-
-/**
- * @brief Returns the process ID of the currently running thread
- *
- * @return          obviously you are not a golfer.
- */
-static inline kernel_pid_t thread_getpid(void)
-{
-    return sched_active_pid;
-}
-
 #ifdef DEVELHELP
 /**
  * @brief Measures the stack usage of a stack

--- a/core/msg.c
+++ b/core/msg.c
@@ -123,7 +123,7 @@ int msg_send(msg_t *m, kernel_pid_t target_pid, bool block)
         DEBUG("msg_send: %s: Back from send block.\n", sched_active_thread->name);
     }
     else {
-        DEBUG("msg_send: %s: Direct msg copy from %" PRIkernel_pid " to %" PRIkernel_pid ".\n", sched_active_thread->name, thread_getpid(), target_pid);
+        DEBUG("msg_send: %s: Direct msg copy from %" PRIkernel_pid " to %" PRIkernel_pid ".\n", sched_active_thread->name, sched_active_pid, target_pid);
         /* copy msg to target */
         msg_t *target_message = (msg_t*) target->wait_data;
         *target_message = *m;
@@ -163,7 +163,7 @@ int msg_send_int(msg_t *m, kernel_pid_t target_pid)
     }
 
     if (target->status == STATUS_RECEIVE_BLOCKED) {
-        DEBUG("msg_send_int: Direct msg copy from %" PRIkernel_pid " to %" PRIkernel_pid ".\n", thread_getpid(), target_pid);
+        DEBUG("msg_send_int: Direct msg copy from %" PRIkernel_pid " to %" PRIkernel_pid ".\n", sched_active_pid, target_pid);
 
         m->sender_pid = target_pid;
 

--- a/cpu/atmega_common/thread_arch.c
+++ b/cpu/atmega_common/thread_arch.c
@@ -182,7 +182,7 @@ void thread_arch_stack_print(void)
     uint8_t *sp = (uint8_t *)sched_active_thread->sp;
     uint16_t size = 0;
 
-    printf("Printing current stack of thread %" PRIkernel_pid "\n", thread_getpid());
+    printf("Printing current stack of thread %" PRIkernel_pid "\n", sched_active_pid);
     printf("\taddress:\tdata:\n");
 
     do {

--- a/cpu/cortex-m0_common/thread_arch.c
+++ b/cpu/cortex-m0_common/thread_arch.c
@@ -122,7 +122,7 @@ void thread_arch_stack_print(void)
     int count = 0;
     uint32_t *sp = (uint32_t *)sched_active_thread->sp;
 
-    printf("printing the current stack of thread %" PRIkernel_pid "\n", thread_getpid());
+    printf("printing the current stack of thread %" PRIkernel_pid "\n", sched_active_pid);
     printf("  address:      data:\n");
 
     do {

--- a/cpu/cortex-m3_common/thread_arch.c
+++ b/cpu/cortex-m3_common/thread_arch.c
@@ -107,7 +107,7 @@ void thread_arch_stack_print(void)
     int count = 0;
     uint32_t *sp = (uint32_t *)sched_active_thread->sp;
 
-    printf("printing the current stack of thread %" PRIkernel_pid "\n", thread_getpid());
+    printf("printing the current stack of thread %" PRIkernel_pid "\n", sched_active_pid);
     printf("  address:      data:\n");
 
     do {

--- a/cpu/cortex-m4_common/thread_arch.c
+++ b/cpu/cortex-m4_common/thread_arch.c
@@ -127,7 +127,7 @@ void thread_arch_stack_print(void)
     int count = 0;
     uint32_t *sp = (uint32_t *)sched_active_thread->sp;
 
-    printf("printing the current stack of thread %" PRIkernel_pid "\n", thread_getpid());
+    printf("printing the current stack of thread %" PRIkernel_pid "\n", sched_active_pid);
     printf("  address:      data:\n");
 
     do {

--- a/drivers/pir/pir.c
+++ b/drivers/pir/pir.c
@@ -52,7 +52,7 @@ pir_event_t pir_get_status(pir_t *dev)
 int pir_register_thread(pir_t *dev)
 {
     if (dev->msg_thread_pid != KERNEL_PID_UNDEF) {
-        if (dev->msg_thread_pid != thread_getpid()) {
+        if (dev->msg_thread_pid != sched_active_pid) {
             DEBUG("pir_register_thread: already registered to another thread\n");
             return -2;
         }
@@ -65,7 +65,7 @@ int pir_register_thread(pir_t *dev)
         }
         DEBUG("\tsuccess\n");
     }
-    dev->msg_thread_pid = thread_getpid();
+    dev->msg_thread_pid = sched_active_pid;
 
     return 0;
 }

--- a/examples/ccn-lite-relay/main.c
+++ b/examples/ccn-lite-relay/main.c
@@ -73,7 +73,7 @@ int main(void)
 {
     printf("CCN!\n");
 
-    _relay_pid = thread_getpid();
+    _relay_pid = sched_active_pid;
 
     thread_create(t2_stack, sizeof(t2_stack), PRIORITY_MAIN + 1,
                   CREATE_STACKTEST, second_thread, NULL, "helper thread");

--- a/examples/ipc_pingpong/main.c
+++ b/examples/ipc_pingpong/main.c
@@ -28,7 +28,7 @@ void *second_thread(void *arg)
 {
     (void) arg;
 
-    printf("2nd thread started, pid: %" PRIkernel_pid "\n", thread_getpid());
+    printf("2nd thread started, pid: %" PRIkernel_pid "\n", sched_active_pid);
     msg_t m;
 
     while (1) {
@@ -46,7 +46,7 @@ char second_thread_stack[KERNEL_CONF_STACKSIZE_MAIN];
 int main(void)
 {
     printf("Starting IPC Ping-pong example...\n");
-    printf("1st thread started, pid: %" PRIkernel_pid "\n", thread_getpid());
+    printf("1st thread started, pid: %" PRIkernel_pid "\n", sched_active_pid);
 
     msg_t m;
 

--- a/examples/riot_and_cpp/main.cpp
+++ b/examples/riot_and_cpp/main.cpp
@@ -51,7 +51,7 @@ int main()
     /* create thread A */
     thread_create(threadA_stack, sizeof(threadA_stack), 0, CREATE_WOUT_YIELD, threadA_func, NULL, "thread A");
 
-    printf("******** Hello, you're in thread %s ********\n", thread_getname(thread_getpid()));
+    printf("******** Hello, you're in thread %s ********\n", thread_getname(sched_active_pid));
     printf("We'll test C++ class and methods here!\n");
 
     cpp_class cpp_obj;
@@ -86,7 +86,7 @@ void *threadA_func(void *)
     int day = 13, month = 6, year = 2014;
     int ret_day;
 
-    printf("\n******** Hello, now you're in %s ********\n", thread_getname(thread_getpid()));
+    printf("\n******** Hello, now you're in %s ********\n", thread_getname(sched_active_pid));
     printf("We'll test some C functions here!\n");
 
     printf("\n-= hello function =-\n");

--- a/sys/chardev_thread.c
+++ b/sys/chardev_thread.c
@@ -45,7 +45,7 @@ void chardev_loop(ringbuffer_t *rb)
 {
     msg_t m;
 
-    kernel_pid_t pid = thread_getpid();
+    kernel_pid_t pid = sched_active_pid;
 
     kernel_pid_t reader_pid = KERNEL_PID_UNDEF;
     struct posix_iop_t *r = NULL;

--- a/sys/net/ccn_lite/ccnl-ext-appserver.c
+++ b/sys/net/ccn_lite/ccnl-ext-appserver.c
@@ -151,7 +151,7 @@ static void riot_ccnl_appserver_ioloop(void)
 static void riot_ccnl_appserver_register(void)
 {
     char faceid[10];
-    snprintf(faceid, sizeof(faceid), "%" PRIkernel_pid, thread_getpid());
+    snprintf(faceid, sizeof(faceid), "%" PRIkernel_pid, sched_active_pid);
     char *type = "newMSGface";
 
     unsigned char *mgnt_pkg = malloc(256);

--- a/sys/net/transport_layer/socket_base/socket.c
+++ b/sys/net/transport_layer/socket_base/socket.c
@@ -371,7 +371,7 @@ int socket_base_bind(int s, sockaddr6_t *addr, int addrlen)
                         if ((current_socket->protocol == 0) ||
                             (current_socket->protocol == IPPROTO_TCP)) {
                             return tcp_bind_socket(s, addr, addrlen,
-                                                   thread_getpid());
+                                                   sched_active_pid);
                         }
                         else {
                             return -1;
@@ -383,7 +383,7 @@ int socket_base_bind(int s, sockaddr6_t *addr, int addrlen)
                         if ((current_socket->protocol == 0) ||
                             (current_socket->protocol == IPPROTO_UDP)) {
                             return udp_bind_socket(s, addr, addrlen,
-                                                   thread_getpid());
+                                                   sched_active_pid);
                         }
                         else {
                             return -1;

--- a/sys/net/transport_layer/tcp/tcp.c
+++ b/sys/net/transport_layer/tcp/tcp.c
@@ -845,7 +845,7 @@ int handle_new_tcp_connection(socket_internal_t *current_queued_int_socket,
     ipv6_hdr_t *temp_ipv6_header = ((ipv6_hdr_t *)(&send_buffer));
     tcp_hdr_t *syn_ack_packet = ((tcp_hdr_t *)(&send_buffer[IPV6_HDR_LEN]));
 
-    current_queued_int_socket->recv_pid = thread_getpid();
+    current_queued_int_socket->recv_pid = sched_active_pid;
 #ifdef TCP_HC
     current_queued_int_socket->socket_values.tcp_control.tcp_context.hc_type =
         FULL_HEADER;
@@ -950,7 +950,7 @@ int32_t tcp_send(int s, const void *buf, uint32_t len, int flags)
     }
 
     /* Add thread PID */
-    current_int_tcp_socket->send_pid = thread_getpid();
+    current_int_tcp_socket->send_pid = sched_active_pid;
 
     recv_msg.type = UNDEFINED;
 
@@ -1108,7 +1108,7 @@ int tcp_accept(int s, sockaddr6_t *addr, uint32_t *addrlen)
 
         if (current_queued_socket != NULL) {
             return handle_new_tcp_connection(current_queued_socket,
-                                             server_socket, thread_getpid());
+                                             server_socket, sched_active_pid);
         }
         else {
             /* No waiting connections, waiting for message from TCP Layer */
@@ -1122,7 +1122,7 @@ int tcp_accept(int s, sockaddr6_t *addr, uint32_t *addrlen)
             current_queued_socket = get_waiting_connection_socket(s, NULL, NULL);
 
             return handle_new_tcp_connection(current_queued_socket,
-                                             server_socket, thread_getpid());
+                                             server_socket, sched_active_pid);
         }
     }
     else {
@@ -1152,7 +1152,7 @@ int tcp_connect(int socket, sockaddr6_t *addr, uint32_t addrlen)
 
     current_tcp_socket = &current_int_tcp_socket->socket_values;
 
-    current_int_tcp_socket->recv_pid = thread_getpid();
+    current_int_tcp_socket->recv_pid = sched_active_pid;
 
     /* Local address information */
     ipv6_net_if_get_best_src_addr(&src_addr, &addr->sin6_addr);
@@ -1339,7 +1339,7 @@ int32_t tcp_recv(int s, void *buf, uint32_t len, int flags)
     current_int_tcp_socket = socket_base_get_socket(s);
 
     /* Setting Thread PID */
-    current_int_tcp_socket->recv_pid = thread_getpid();
+    current_int_tcp_socket->recv_pid = sched_active_pid;
 
     if (current_int_tcp_socket->tcp_input_buffer_end > 0) {
         return read_from_socket(current_int_tcp_socket, buf, len);
@@ -1393,7 +1393,7 @@ int tcp_teardown(socket_internal_t *current_socket)
         return 0;
     }
 
-    current_socket->send_pid = thread_getpid();
+    current_socket->send_pid = sched_active_pid;
 
     /* Refresh local TCP socket information */
     current_socket->socket_values.tcp_control.state = TCP_FIN_WAIT_1;

--- a/sys/net/transport_layer/tcp/tcp_timer.c
+++ b/sys/net/transport_layer/tcp/tcp_timer.c
@@ -148,7 +148,7 @@ void *tcp_general_timer(void *arg)
         inc_global_variables();
         check_sockets();
 
-        vtimer_set_wakeup(&tcp_vtimer, interval, thread_getpid());
+        vtimer_set_wakeup(&tcp_vtimer, interval, sched_active_pid);
         thread_sleep();
 
         vtimer_remove(&tcp_vtimer);

--- a/sys/net/transport_layer/udp/udp.c
+++ b/sys/net/transport_layer/udp/udp.c
@@ -142,7 +142,7 @@ int32_t udp_recvfrom(int s, void *buf, uint32_t len, int flags, sockaddr6_t *fro
     ipv6_hdr_t *ipv6_header;
     udp_hdr_t *udp_header;
     uint8_t *payload;
-    socket_base_get_socket(s)->recv_pid = thread_getpid();
+    socket_base_get_socket(s)->recv_pid = sched_active_pid;
 
     msg_receive(&m_recv);
 

--- a/tests/mutex_unlock_and_sleep/main.c
+++ b/tests/mutex_unlock_and_sleep/main.c
@@ -44,7 +44,7 @@ int main(void)
     indicator = 0;
     count = 0;
 
-    main_pid = thread_getpid();
+    main_pid = sched_active_pid;
 
     kernel_pid_t second_pid = thread_create(stack,
                   sizeof(stack),

--- a/tests/periph_uart_int/main.c
+++ b/tests/periph_uart_int/main.c
@@ -93,7 +93,7 @@ void *uart_thread(void *arg)
 
 int main(void)
 {
-    main_pid = thread_getpid();
+    main_pid = sched_active_pid;
 
     puts("\nTesting interrupt driven mode of UART driver\n");
 

--- a/tests/posix_semaphore/main.c
+++ b/tests/posix_semaphore/main.c
@@ -123,7 +123,7 @@ static void *priority_sema_thread(void *arg)
 {
     (void) arg;
     sem_wait(&s);
-    printf("Thread '%s' woke up.\n", thread_getname(thread_getpid()));
+    printf("Thread '%s' woke up.\n", thread_getname(sched_active_pid));
     return NULL;
 }
 

--- a/tests/thread_cooperation/main.c
+++ b/tests/thread_cooperation/main.c
@@ -37,7 +37,7 @@ void *run(void *arg)
 {
     (void) arg;
 
-    kernel_pid_t me = thread_getpid();
+    kernel_pid_t me = sched_active_pid;
     printf("I am alive (%d)\n", me);
     msg_t m;
     msg_receive(&m);
@@ -61,7 +61,7 @@ void *run(void *arg)
 
 int main(void)
 {
-    main_id = thread_getpid();
+    main_id = sched_active_pid;
 
     printf("Problem: %d\n", PROBLEM);
 

--- a/tests/thread_msg_seq/main.c
+++ b/tests/thread_msg_seq/main.c
@@ -35,7 +35,7 @@ void *sub_thread(void *arg)
 {
     (void) arg;
 
-    kernel_pid_t pid = thread_getpid();
+    kernel_pid_t pid = sched_active_pid;
     printf("THREAD %s (pid:%" PRIkernel_pid ") start\n", thread_getname(pid), pid);
 
     msg_t msg;

--- a/tests/vtimer_msg/main.c
+++ b/tests/vtimer_msg/main.c
@@ -44,7 +44,7 @@ void *timer_thread(void *arg)
 {
     (void) arg;
 
-    printf("This is thread %" PRIkernel_pid "\n", thread_getpid());
+    printf("This is thread %" PRIkernel_pid "\n", sched_active_pid);
 
     /* we need a queue if the second message arrives while the first is still processed */
     /* without a queue, the message would get lost */
@@ -64,7 +64,7 @@ void *timer_thread(void *arg)
                tmsg->interval.microseconds,
                tmsg->msg);
 
-        if (vtimer_set_msg(&tmsg->timer, tmsg->interval, thread_getpid(), tmsg) != 0) {
+        if (vtimer_set_msg(&tmsg->timer, tmsg->interval, sched_active_pid, tmsg) != 0) {
             puts("something went wrong");
         }
         else {
@@ -77,7 +77,7 @@ void *timer_thread_local(void *arg)
 {
     (void) arg;
 
-    printf("This is thread %" PRIkernel_pid "\n", thread_getpid());
+    printf("This is thread %" PRIkernel_pid "\n", sched_active_pid);
 
     while (1) {
         msg_t m;

--- a/tests/vtimer_msg_diff/main.c
+++ b/tests/vtimer_msg_diff/main.c
@@ -54,7 +54,7 @@ struct timer_msg timer_msgs[] = { { .interval = { .seconds = 0, .microseconds = 
 void *timer_thread(void *arg)
 {
     (void) arg;
-    printf("This is thread %" PRIkernel_pid "\n", thread_getpid());
+    printf("This is thread %" PRIkernel_pid "\n", sched_active_pid);
 
     msg_t msgq[16];
     msg_init_queue(msgq, sizeof(msgq));
@@ -87,7 +87,7 @@ void *timer_thread(void *arg)
             printf("WARNING: timer difference %" PRId64 "us exceeds MAXDIFF(%d)!\n", diff, MAXDIFF);
         }
 
-        if (vtimer_set_msg(&tmsg->timer, tmsg->interval, thread_getpid(), tmsg) != 0) {
+        if (vtimer_set_msg(&tmsg->timer, tmsg->interval, sched_active_pid, tmsg) != 0) {
             puts("something went wrong setting a timer");
         }
 


### PR DESCRIPTION
The inline function thread_getpid is not needed, since sched_active_pid
is a public variable anyway.
