### PR TITLE
 core: refactor sched_run

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -100,8 +100,9 @@
 
 /**
  * @brief   Triggers the scheduler to schedule the next thread
+ * @returns 1 if sched_active_thread/sched_active_pid was changed, 0 otherwise.
  */
-void sched_run(void);
+int sched_run(void);
 
 /**
  * @brief   Set the status of the specified process


### PR DESCRIPTION
`sched_run()` was cluttered. Many individual changes were done without a proper refactoring.

Rebased on #1836.
