### PR TITLE
make: initialize debugger with TERMFLAGS

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -55,8 +55,19 @@ else
 export LINKFLAGS += -ldl
 endif
 
+# set the tap interface for term/valgrind
+ifneq (,$(filter nativenet,$(USEMODULE)))
+	export PORT ?= tap0
+else
+	export PORT =
+endif
+
+ifeq (,$(filter $(PORT),$(TERMFLAGS)))
+    export TERMFLAGS += $(PORT)
+endif
+
 export ASFLAGS =
-export DEBUGGER_FLAGS = $(ELF)
+export DEBUGGER_FLAGS = --args $(ELF) $(TERMFLAGS)
 term-valgrind: export VALGRIND_FLAGS ?= \
 	--track-origins=yes \
 	--fullpath-after=$(RIOTBASE)/ \
@@ -87,17 +98,6 @@ ifeq ($(CPU),native)
 ifeq ($(shell uname -s),Darwin)
 	BUILDOSXNATIVE = 1
 endif
-endif
-
-# set the tap interface for term/valgrind
-ifneq (,$(filter nativenet,$(USEMODULE)))
-	export PORT ?= tap0
-else
-	export PORT =
-endif
-
-ifeq (,$(filter $(PORT),$(TERMFLAGS)))
-    export TERMFLAGS += $(PORT)
 endif
 
 all: # do not override first target


### PR DESCRIPTION
With this e.g.

``` gdb
set args tap0
```

is not necessary any more.
