### PR TITLE
byteorder: silence warnings in clang

### DIFF
--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -210,7 +210,7 @@ static inline uint64_t byteorder_swapll(uint64_t v);
 /* **************************** IMPLEMENTATION ***************************** */
 
 
-uint16_t byteorder_swaps(uint16_t v)
+static inline uint16_t byteorder_swaps(uint16_t v)
 {
 #ifndef MODULE_MSP430_COMMON
     return __builtin_bswap16(v);
@@ -223,47 +223,47 @@ uint16_t byteorder_swaps(uint16_t v)
 #endif
 }
 
-uint32_t byteorder_swapl(uint32_t v)
+static inline uint32_t byteorder_swapl(uint32_t v)
 {
     return __builtin_bswap32(v);
 }
 
-uint64_t byteorder_swapll(uint64_t v)
+static inline uint64_t byteorder_swapll(uint64_t v)
 {
     return __builtin_bswap64(v);
 }
 
-be_uint16_t byteorder_ltobs(le_uint16_t v)
+static inline be_uint16_t byteorder_ltobs(le_uint16_t v)
 {
     be_uint16_t result = { .u16 =  byteorder_swaps(v.u16) };
     return result;
 }
 
-be_uint32_t byteorder_ltobl(le_uint32_t v)
+static inline be_uint32_t byteorder_ltobl(le_uint32_t v)
 {
     be_uint32_t result = { .u32 =  byteorder_swapl(v.u32) };
     return result;
 }
 
-be_uint64_t byteorder_ltobll(le_uint64_t v)
+static inline be_uint64_t byteorder_ltobll(le_uint64_t v)
 {
     be_uint64_t result = { .u64 =  byteorder_swapll(v.u64) };
     return result;
 }
 
-le_uint16_t byteorder_btols(be_uint16_t v)
+static inline le_uint16_t byteorder_btols(be_uint16_t v)
 {
     le_uint16_t result = { .u16 =  byteorder_swaps(v.u16) };
     return result;
 }
 
-le_uint32_t byteorder_btoll(be_uint32_t v)
+static inline le_uint32_t byteorder_btoll(be_uint32_t v)
 {
     le_uint32_t result = { .u32 =  byteorder_swapl(v.u32) };
     return result;
 }
 
-le_uint64_t byteorder_btolll(be_uint64_t v)
+static inline le_uint64_t byteorder_btolll(be_uint64_t v)
 {
     le_uint64_t result = { .u64 =  byteorder_swapll(v.u64) };
     return result;
@@ -277,35 +277,35 @@ le_uint64_t byteorder_btolll(be_uint64_t v)
 #   error "Byte order is neither little nor big!"
 #endif
 
-network_uint16_t byteorder_htons(uint16_t v)
+static inline network_uint16_t byteorder_htons(uint16_t v)
 {
     network_uint16_t result = { .u16 = _byteorder_swap(v, s) };
     return result;
 }
 
-network_uint32_t byteorder_htonl(uint32_t v)
+static inline network_uint32_t byteorder_htonl(uint32_t v)
 {
     network_uint32_t result = { .u32 = _byteorder_swap(v, l) };
     return result;
 }
 
-network_uint64_t byteorder_htonll(uint64_t v)
+static inline network_uint64_t byteorder_htonll(uint64_t v)
 {
     network_uint64_t result = { .u64 = _byteorder_swap(v, ll) };
     return result;
 }
 
-uint16_t byteorder_ntohs(network_uint16_t v)
+static inline uint16_t byteorder_ntohs(network_uint16_t v)
 {
     return _byteorder_swap(v.u16, s);
 }
 
-uint32_t byteorder_ntohl(network_uint32_t v)
+static inline uint32_t byteorder_ntohl(network_uint32_t v)
 {
     return _byteorder_swap(v.u32, l);
 }
 
-uint64_t byteorder_ntohll(network_uint64_t v)
+static inline uint64_t byteorder_ntohll(network_uint64_t v)
 {
     return _byteorder_swap(v.u64, ll);
 }


### PR DESCRIPTION
Compare

```
$ git checkout master && CC=clang make -C examples/rpl_udp/ clean all

[…]le_uint32_t byteorder_btoll(be_uint32_t v)
            ^
/home/martine/Repositories/RIOT-OS/RIOT/core/include/byteorder.h:266:13: warning: unused function 'byteorder_btolll'
      [-Wunused-function]
le_uint64_t byteorder_btolll(be_uint64_t v)
            ^
6 warnings generated.
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/net/routing
In file included from /home/martine/Repositories/RIOT-OS/RIOT/sys/net/routing/etx_beaconing.c:28:
In file included from /home/martine/Repositories/RIOT-OS/RIOT/sys/net/include/sixlowpan/ip.h:31:
In file included from /home/martine/Repositories/RIOT-OS/RIOT/sys/net/include/net_help.h:30:
/home/martine/Repositories/RIOT-OS/RIOT/core/include/byteorder.h:236:13: warning: unused function 'byteorder_ltobs'
      [-Wunused-function]
be_uint16_t byteorder_ltobs(le_uint16_t v)
            ^
/home/martine/Repositories/RIOT-OS/RIOT/core/include/byteorder.h:242:13: warning: unused function 'byteorder_ltobl'
      [-Wunused-function]
be_uint32_t byteorder_ltobl(le_uint32_t v)
            ^
/home/martine/Repositories/RIOT-OS/RIOT/core/include/byteorder.h:248:13: warning: unused function 'byteorder_ltobll'
      [-Wunused-function]
be_uint64_t byteorder_ltobll(le_uint64_t v)
            ^
/home/martine/Repositories/RIOT-OS/RIOT/core/include/byteorder.h:254:13: warning: unused function 'byteorder_btols'
      [-Wunused-function]
le_uint16_t byteorder_btols(be_uint16_t v)
            ^
/home/martine/Repositories/RIOT-OS/RIOT/core/include/byteorder.h:260:13: warning: unused function 'byteorder_btoll'
      [-Wunused-function]
le_uint32_t byteorder_btoll(be_uint32_t v)
            ^
/home/martine/Repositories/RIOT-OS/RIOT/core/include/byteorder.h:266:13: warning: unused function 'byteorder_btolll'
      [-Wunused-function]
le_uint64_t byteorder_btolll(be_uint64_t v)
            ^
6 warnings generated.
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/net/link_layer/ieee802154
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/hashes
   text    data     bss     dec     hex filename
 186873     644  291396  478913   74ec1 /home/martine/Repositories/RIOT-OS/RIOT/examples/rpl_udp/bin/native/rpl_udp.elf
make: Leaving directory `/home/martine/Repositories/RIOT-OS/RIOT/examples/rpl_udp'
```

to

```
$ git checkout byteorder-silence && CC=clang make -C examples/rpl_udp/ clean all

Previous HEAD position was fd2ec50... Merge pull request #1848 from locicontrols/cc2538-nvic-prio-bits
Switched to branch 'byteorder-silence'
make: Entering directory `/home/martine/Repositories/RIOT-OS/RIOT/examples/rpl_udp'
Building application rpl_udp for native w/ MCU native.
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/cpu/native
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/cpu/native/periph
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/cpu/native/drivers
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/cpu/native/net
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/boards/native
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/boards/native/drivers
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/core
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/drivers
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/auto_init
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/lib
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/ps
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/posix
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/shell
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/shell/commands
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/timex
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/transceiver
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/uart0
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/vtimer
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/net/link_layer/net_if
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/net/transport_layer/socket_base
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/net/transport_layer/udp
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/net/crosslayer/net_help
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/net/network_layer/sixlowpan
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/net/routing/rpl
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/net/routing
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/net/link_layer/ieee802154
"make" -C /home/martine/Repositories/RIOT-OS/RIOT/sys/hashes
   text    data     bss     dec     hex filename
 186889     644  291396  478929   74ed1 /home/martine/Repositories/RIOT-OS/RIOT/examples/rpl_udp/bin/native/rpl_udp.elf
make: Leaving directory `/home/martine/Repositories/RIOT-OS/RIOT/examples/rpl_udp'
```
