### PR TITLE
drivers: added missing `extern "C"` guards in new files

### DIFF
--- a/drivers/cc110x/arch_cc1100.h
+++ b/drivers/cc110x/arch_cc1100.h
@@ -19,6 +19,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 uint8_t cc110x_txrx(uint8_t c);
 
 void cc110x_gdo0_enable(void);
@@ -29,3 +33,7 @@ void cc110x_init_interrupts(void);
 
 void cc110x_before_send(void);
 void cc110x_after_send(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/drivers/include/isl29020.h
+++ b/drivers/include/isl29020.h
@@ -24,6 +24,10 @@
 #include <stdint.h>
 #include "periph/i2c.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
  /**
   * @brief The sensors default I2C address
   */
@@ -100,6 +104,10 @@ int isl29020_enable(isl29020_t *dev);
  * @return              -1 on error
  */
 int isl29020_disable(isl29020_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ISL29020_H */
 /** @} */

--- a/drivers/isl29020/include/isl29020-internal.h
+++ b/drivers/isl29020/include/isl29020-internal.h
@@ -19,6 +19,10 @@
 #ifndef __ISL29020_INTERNAL_H
 #define __ISL29020_INTERNAL_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @name ISL29020 registers
  * @{
@@ -60,6 +64,10 @@
 #define ISL29020_RANGE_3        0x02
 #define ISL29020_RANGE_4        0x03
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ISL29020_INTERNAL_H */
 /** @} */


### PR DESCRIPTION
This PR adds extern "C" to the new header files in ./RIOT/drivers/\* folders.
