### PR TITLE
sixlowpan: optimize stack sizes

### DIFF
--- a/sys/net/network_layer/sixlowpan/ip.h
+++ b/sys/net/network_layer/sixlowpan/ip.h
@@ -41,7 +41,7 @@
 #define MULTIHOP_HOPLIMIT           (64)
 
 #define SIXLOWIP_MAX_REGISTERED     (4)
-#define IP_PROCESS_STACKSIZE        (KERNEL_CONF_STACKSIZE_MAIN)
+#define IP_PROCESS_STACKSIZE        (4096)
 
 /* extern variables */
 extern uint8_t ipv6_ext_hdr_len;

--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -53,8 +53,8 @@ char addr_str[IPV6_MAX_ADDR_STR_LEN];
 #endif
 #include "debug.h"
 
-#define CON_STACKSIZE                   (KERNEL_CONF_STACKSIZE_DEFAULT)
-#define LOWPAN_TRANSFER_BUF_STACKSIZE   (KERNEL_CONF_STACKSIZE_DEFAULT)
+#define CON_STACKSIZE                   (1536)
+#define LOWPAN_TRANSFER_BUF_STACKSIZE   (1536)
 
 #define SIXLOWPAN_MAX_REGISTERED        (4)
 

--- a/sys/net/network_layer/sixlowpan/mac.c
+++ b/sys/net/network_layer/sixlowpan/mac.c
@@ -42,7 +42,7 @@
 #endif
 #include "debug.h"
 
-#define RADIO_STACK_SIZE            (KERNEL_CONF_STACKSIZE_MAIN)
+#define RADIO_STACK_SIZE            (1536)
 #define RADIO_RCV_BUF_SIZE          (64)
 #define RADIO_SENDING_DELAY         (1000)
 


### PR DESCRIPTION
Based on observations in rpl_udp after letting it run for a while.
For safety rounded up to the next half-KiB.
