### PR TITLE
cpu/cc2538: centralized all cpu specific includes

### DIFF
--- a/cpu/cc2538/cpu.c
+++ b/cpu/cc2538/cpu.c
@@ -18,7 +18,6 @@
  */
 
 #include "cpu.h"
-#include "sys-ctrl.h"
 
 #define BIT(n)          ( 1UL << (n) )
 

--- a/cpu/cc2538/include/cpu-conf.h
+++ b/cpu/cc2538/include/cpu-conf.h
@@ -20,6 +20,13 @@
 #define __CPU_CONF_H
 
 #include "cc2538.h"
+#include "cc2538-gpio.h"
+#include "cc2538-uart.h"
+#include "gptimer.h"
+#include "ioc.h"
+#include "soc-adc.h"
+#include "rfcore.h"
+#include "sys-ctrl.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/cc2538/include/hwtimer_cpu.h
+++ b/cpu/cc2538/include/hwtimer_cpu.h
@@ -19,8 +19,6 @@
 #ifndef __HWTIMER_CPU_H
 #define __HWTIMER_CPU_H
 
-#include "gptimer.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -29,7 +27,7 @@ extern "C" {
  * @name Hardware timer configuration
  * @{
  */
-#define HWTIMER_MAXTIMERS   NUM_CHANNELS_PER_GPTIMER /**< Number of hwtimers */
+#define HWTIMER_MAXTIMERS   2               /**< Number of hwtimers */
 #define HWTIMER_SPEED       1000000         /**< The hardware timer runs at 1MHz */
 #define HWTIMER_MAXTICKS    0xFFFFFFFF      /**< 32-bit timer */
 /** @} */

--- a/cpu/cc2538/periph/cpuid.c
+++ b/cpu/cc2538/periph/cpuid.c
@@ -23,7 +23,6 @@
 #include <string.h>
 
 #include "cpu.h"
-#include "cpu-conf.h"
 #include "periph/cpuid.h"
 
 #define BITS_PER_BYTE 8

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -23,9 +23,6 @@
 #include "cpu.h"
 #include "sched.h"
 #include "thread.h"
-
-#include "cc2538-gpio.h"
-#include "ioc.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
 

--- a/cpu/cc2538/periph/random.c
+++ b/cpu/cc2538/periph/random.c
@@ -21,9 +21,6 @@
 #include <stdint.h>
 
 #include "cpu.h"
-#include "rfcore.h"
-#include "soc-adc.h"
-
 #include "periph_conf.h"
 #include "periph/random.h"
 

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -25,9 +25,6 @@
 #include "cpu.h"
 #include "sched.h"
 #include "thread.h"
-
-#include "gptimer.h"
-
 #include "periph/timer.h"
 #include "periph_conf.h"
 

--- a/cpu/cc2538/periph/uart.c
+++ b/cpu/cc2538/periph/uart.c
@@ -24,12 +24,6 @@
 #include "cpu.h"
 #include "sched.h"
 #include "thread.h"
-
-#include "cc2538-gpio.h"
-#include "cc2538-uart.h"
-#include "ioc.h"
-#include "sys-ctrl.h"
-
 #include "periph/uart.h"
 #include "periph_conf.h"
 


### PR DESCRIPTION
- added all CPU specific includes to cpu-conf.h
- removed now not needed includes from cpu .c files
