### PR TITLE
cpu/stm32f0: optimized GPIO driver implementation

### DIFF
--- a/cpu/stm32f0/periph/gpio.c
+++ b/cpu/stm32f0/periph/gpio.c
@@ -34,97 +34,137 @@ typedef struct {
 
 static gpio_state_t gpio_config[GPIO_NUMOF];
 
+/* static port mappings */
+static GPIO_TypeDef *const gpio_port_map[GPIO_NUMOF] = {
+#if GPIO_0_EN
+    [GPIO_0] = GPIO_0_PORT,
+#endif
+#if GPIO_1_EN
+    [GPIO_1] = GPIO_1_PORT,
+#endif
+#if GPIO_2_EN
+    [GPIO_2] = GPIO_2_PORT,
+#endif
+#if GPIO_3_EN
+    [GPIO_3] = GPIO_3_PORT,
+#endif
+#if GPIO_4_EN
+    [GPIO_4] = GPIO_4_PORT,
+#endif
+#if GPIO_5_EN
+    [GPIO_5] = GPIO_5_PORT,
+#endif
+#if GPIO_6_EN
+    [GPIO_6] = GPIO_6_PORT,
+#endif
+#if GPIO_7_EN
+    [GPIO_7] = GPIO_7_PORT,
+#endif
+#if GPIO_8_EN
+    [GPIO_8] = GPIO_8_PORT,
+#endif
+#if GPIO_9_EN
+    [GPIO_9] = GPIO_9_PORT,
+#endif
+#if GPIO_10_EN
+    [GPIO_10] = GPIO_10_PORT,
+#endif
+#if GPIO_11_EN
+    [GPIO_11] = GPIO_11_PORT,
+#endif
+};
+
+/* static pin mappings */
+static const uint8_t gpio_pin_map[GPIO_NUMOF] = {
+#if GPIO_0_EN
+    [GPIO_0] = GPIO_0_PIN,
+#endif
+#if GPIO_1_EN
+    [GPIO_1] = GPIO_1_PIN,
+#endif
+#if GPIO_2_EN
+    [GPIO_2] = GPIO_2_PIN,
+#endif
+#if GPIO_3_EN
+    [GPIO_3] = GPIO_3_PIN,
+#endif
+#if GPIO_4_EN
+    [GPIO_4] = GPIO_4_PIN,
+#endif
+#if GPIO_5_EN
+    [GPIO_5] = GPIO_5_PIN,
+#endif
+#if GPIO_6_EN
+    [GPIO_6] = GPIO_6_PIN,
+#endif
+#if GPIO_7_EN
+    [GPIO_7] = GPIO_7_PIN,
+#endif
+#if GPIO_8_EN
+    [GPIO_8] = GPIO_8_PIN,
+#endif
+#if GPIO_9_EN
+    [GPIO_9] = GPIO_9_PIN,
+#endif
+#if GPIO_10_EN
+    [GPIO_10] = GPIO_10_PIN,
+#endif
+#if GPIO_11_EN
+    [GPIO_11] = GPIO_11_PIN,
+#endif
+};
+
+/* static irq mappings */
+static const IRQn_Type gpio_irq_map[GPIO_NUMOF] = {
+#if GPIO_0_EN
+    [GPIO_0] = GPIO_0_IRQ,
+#endif
+#if GPIO_1_EN
+    [GPIO_1] = GPIO_1_IRQ,
+#endif
+#if GPIO_2_EN
+    [GPIO_2] = GPIO_2_IRQ,
+#endif
+#if GPIO_3_EN
+    [GPIO_3] = GPIO_3_IRQ,
+#endif
+#if GPIO_4_EN
+    [GPIO_4] = GPIO_4_IRQ,
+#endif
+#if GPIO_5_EN
+    [GPIO_5] = GPIO_5_IRQ,
+#endif
+#if GPIO_6_EN
+    [GPIO_6] = GPIO_6_IRQ,
+#endif
+#if GPIO_7_EN
+    [GPIO_7] = GPIO_7_IRQ,
+#endif
+#if GPIO_8_EN
+    [GPIO_8] = GPIO_8_IRQ,
+#endif
+#if GPIO_9_EN
+    [GPIO_9] = GPIO_9_IRQ,
+#endif
+#if GPIO_10_EN
+    [GPIO_10] = GPIO_10_IRQ,
+#endif
+#if GPIO_11_EN
+    [GPIO_11] = GPIO_11_IRQ,
+#endif
+};
+
 int gpio_init_out(gpio_t dev, gpio_pp_t pullup)
 {
-    GPIO_TypeDef *port = 0;
-    uint32_t pin = 0;
+    GPIO_TypeDef *port;
+    uint8_t pin;
 
-    switch (dev) {
-#ifdef GPIO_0_EN
-        case GPIO_0:
-            GPIO_0_CLKEN();
-            port = GPIO_0_PORT;
-            pin = GPIO_0_PIN;
-            break;
-#endif
-#ifdef GPIO_1_EN
-        case GPIO_1:
-            GPIO_1_CLKEN();
-            port = GPIO_1_PORT;
-            pin = GPIO_1_PIN;
-            break;
-#endif
-#ifdef GPIO_2_EN
-        case GPIO_2:
-            GPIO_2_CLKEN();
-            port = GPIO_2_PORT;
-            pin = GPIO_2_PIN;
-            break;
-#endif
-#ifdef GPIO_3_EN
-        case GPIO_3:
-            GPIO_3_CLKEN();
-            port = GPIO_3_PORT;
-            pin = GPIO_3_PIN;
-            break;
-#endif
-#ifdef GPIO_4_EN
-        case GPIO_4:
-            GPIO_4_CLKEN();
-            port = GPIO_4_PORT;
-            pin = GPIO_4_PIN;
-            break;
-#endif
-#ifdef GPIO_5_EN
-        case GPIO_5:
-            GPIO_5_CLKEN();
-            port = GPIO_5_PORT;
-            pin = GPIO_5_PIN;
-            break;
-#endif
-#ifdef GPIO_6_EN
-        case GPIO_6:
-            GPIO_6_CLKEN();
-            port = GPIO_6_PORT;
-            pin = GPIO_6_PIN;
-            break;
-#endif
-#ifdef GPIO_7_EN
-        case GPIO_7:
-            GPIO_7_CLKEN();
-            port = GPIO_7_PORT;
-            pin = GPIO_7_PIN;
-            break;
-#endif
-#ifdef GPIO_8_EN
-        case GPIO_8:
-            GPIO_8_CLKEN();
-            port = GPIO_8_PORT;
-            pin = GPIO_8_PIN;
-            break;
-#endif
-#ifdef GPIO_9_EN
-        case GPIO_9:
-            GPIO_9_CLKEN();
-            port = GPIO_9_PORT;
-            pin = GPIO_9_PIN;
-            break;
-#endif
-#ifdef GPIO_10_EN
-        case GPIO_10:
-            GPIO_10_CLKEN();
-            port = GPIO_10_PORT;
-            pin = GPIO_10_PIN;
-            break;
-#endif
-#ifdef GPIO_11_EN
-        case GPIO_11:
-            GPIO_11_CLKEN();
-            port = GPIO_11_PORT;
-            pin = GPIO_11_PIN;
-            break;
-#endif
+    if (dev >= GPIO_NUMOF) {
+        return -1;
     }
+
+    port = gpio_port_map[dev];
+    pin = gpio_pin_map[dev];
 
     port->MODER &= ~(2 << (2 * pin));           /* set pin to output mode */
     port->MODER |= (1 << (2 * pin));
@@ -139,95 +179,15 @@ int gpio_init_out(gpio_t dev, gpio_pp_t pullup)
 
 int gpio_init_in(gpio_t dev, gpio_pp_t pullup)
 {
-    GPIO_TypeDef *port = 0;
-    uint32_t pin = 0;
+    GPIO_TypeDef *port;
+    uint8_t pin;
 
-    switch (dev) {
-#ifdef GPIO_0_EN
-        case GPIO_0:
-            GPIO_0_CLKEN();
-            port = GPIO_0_PORT;
-            pin = GPIO_0_PIN;
-            break;
-#endif
-#ifdef GPIO_1_EN
-        case GPIO_1:
-            GPIO_1_CLKEN();
-            port = GPIO_1_PORT;
-            pin = GPIO_1_PIN;
-            break;
-#endif
-#ifdef GPIO_2_EN
-        case GPIO_2:
-            GPIO_2_CLKEN();
-            port = GPIO_2_PORT;
-            pin = GPIO_2_PIN;
-            break;
-#endif
-#ifdef GPIO_3_EN
-        case GPIO_3:
-            GPIO_3_CLKEN();
-            port = GPIO_3_PORT;
-            pin = GPIO_3_PIN;
-            break;
-#endif
-#ifdef GPIO_4_EN
-        case GPIO_4:
-            GPIO_4_CLKEN();
-            port = GPIO_4_PORT;
-            pin = GPIO_4_PIN;
-            break;
-#endif
-#ifdef GPIO_5_EN
-        case GPIO_5:
-            GPIO_5_CLKEN();
-            port = GPIO_5_PORT;
-            pin = GPIO_5_PIN;
-            break;
-#endif
-#ifdef GPIO_6_EN
-        case GPIO_6:
-            GPIO_6_CLKEN();
-            port = GPIO_6_PORT;
-            pin = GPIO_6_PIN;
-            break;
-#endif
-#ifdef GPIO_7_EN
-        case GPIO_7:
-            GPIO_7_CLKEN();
-            port = GPIO_7_PORT;
-            pin = GPIO_7_PIN;
-            break;
-#endif
-#ifdef GPIO_8_EN
-        case GPIO_8:
-            GPIO_8_CLKEN();
-            port = GPIO_8_PORT;
-            pin = GPIO_8_PIN;
-            break;
-#endif
-#ifdef GPIO_9_EN
-        case GPIO_9:
-            GPIO_9_CLKEN();
-            port = GPIO_9_PORT;
-            pin = GPIO_9_PIN;
-            break;
-#endif
-#ifdef GPIO_10_EN
-        case GPIO_10:
-            GPIO_10_CLKEN();
-            port = GPIO_10_PORT;
-            pin = GPIO_10_PIN;
-            break;
-#endif
-#ifdef GPIO_11_EN
-        case GPIO_11:
-            GPIO_11_CLKEN();
-            port = GPIO_11_PORT;
-            pin = GPIO_11_PIN;
-            break;
-#endif
+    if (dev >= GPIO_NUMOF) {
+        return -1;
     }
+
+    port = gpio_port_map[dev];
+    pin = gpio_pin_map[dev];
 
     port->MODER &= ~(3 << (2 * pin));           /* configure pin as input */
     port->PUPDR &= ~(3 << (2 * pin));           /* configure push-pull resistors */
@@ -239,7 +199,13 @@ int gpio_init_in(gpio_t dev, gpio_pp_t pullup)
 int gpio_init_int(gpio_t dev, gpio_pp_t pullup, gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
     int res;
-    uint32_t pin = 0;
+    uint8_t pin;
+
+    if (dev >= GPIO_NUMOF) {
+        return -1;
+    }
+
+    pin = gpio_pin_map[dev];
 
     /* configure pin as input */
     res = gpio_init_in(dev, pullup);
@@ -259,101 +225,66 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pullup, gpio_flank_t flank, gpio_cb_t cb
     switch (dev) {
 #ifdef GPIO_0_EN
         case GPIO_0:
-            pin = GPIO_0_PIN;
             GPIO_0_EXTI_CFG();
-            NVIC_SetPriority(GPIO_0_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_0_IRQ);
             break;
 #endif
 #ifdef GPIO_1_EN
         case GPIO_1:
-            pin = GPIO_1_PIN;
             GPIO_1_EXTI_CFG();
-            NVIC_SetPriority(GPIO_1_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_1_IRQ);
             break;
 #endif
 #ifdef GPIO_2_EN
         case GPIO_2:
-            pin = GPIO_2_PIN;
             GPIO_2_EXTI_CFG();
-            NVIC_SetPriority(GPIO_2_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_2_IRQ);
             break;
 #endif
 #ifdef GPIO_3_EN
         case GPIO_3:
-            pin = GPIO_3_PIN;
             GPIO_3_EXTI_CFG();
-            NVIC_SetPriority(GPIO_3_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_3_IRQ);
             break;
 #endif
 #ifdef GPIO_4_EN
         case GPIO_4:
-            pin = GPIO_4_PIN;
             GPIO_4_EXTI_CFG();
-            NVIC_SetPriority(GPIO_4_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_4_IRQ);
             break;
 #endif
 #ifdef GPIO_5_EN
         case GPIO_5:
-            pin = GPIO_5_PIN;
             GPIO_5_EXTI_CFG();
-            NVIC_SetPriority(GPIO_5_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_5_IRQ);
             break;
 #endif
 #ifdef GPIO_6_EN
         case GPIO_6:
-            pin = GPIO_6_PIN;
             GPIO_6_EXTI_CFG();
-            NVIC_SetPriority(GPIO_6_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_6_IRQ);
             break;
 #endif
 #ifdef GPIO_7_EN
         case GPIO_7:
-            pin = GPIO_7_PIN;
             GPIO_7_EXTI_CFG();
-            NVIC_SetPriority(GPIO_7_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_7_IRQ);
             break;
 #endif
 #ifdef GPIO_8_EN
         case GPIO_8:
-            pin = GPIO_8_PIN;
             GPIO_8_EXTI_CFG();
-            NVIC_SetPriority(GPIO_8_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_8_IRQ);
             break;
 #endif
 #ifdef GPIO_9_EN
         case GPIO_9:
-            pin = GPIO_9_PIN;
             GPIO_9_EXTI_CFG();
-            NVIC_SetPriority(GPIO_9_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_9_IRQ);
             break;
 #endif
 #ifdef GPIO_10_EN
         case GPIO_10:
-            pin = GPIO_10_PIN;
             GPIO_10_EXTI_CFG();
-            NVIC_SetPriority(GPIO_10_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_10_IRQ);
             break;
 #endif
 #ifdef GPIO_11_EN
         case GPIO_11:
-            pin = GPIO_11_PIN;
             GPIO_11_EXTI_CFG();
-            NVIC_SetPriority(GPIO_11_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_11_IRQ);
             break;
 #endif
     }
+    NVIC_EnableIRQ(gpio_irq_map[dev]);
 
     /* set callback */
     gpio_config[dev].cb = cb;
@@ -385,215 +316,39 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pullup, gpio_flank_t flank, gpio_cb_t cb
 
 void gpio_irq_enable(gpio_t dev)
 {
-    switch (dev) {
-#ifdef GPIO_0_EN
-        case GPIO_0:
-            EXTI->IMR |= (1 << GPIO_0_PIN);
-            break;
-#endif
-#ifdef GPIO_1_EN
-        case GPIO_1:
-            EXTI->IMR |= (1 << GPIO_1_PIN);
-            break;
-#endif
-#ifdef GPIO_2_EN
-        case GPIO_2:
-            EXTI->IMR |= (1 << GPIO_2_PIN);
-            break;
-#endif
-#ifdef GPIO_3_EN
-        case GPIO_3:
-            EXTI->IMR |= (1 << GPIO_3_PIN);
-            break;
-#endif
-#ifdef GPIO_4_EN
-        case GPIO_4:
-            EXTI->IMR |= (1 << GPIO_4_PIN);
-            break;
-#endif
-#ifdef GPIO_5_EN
-        case GPIO_5:
-            EXTI->IMR |= (1 << GPIO_5_PIN);
-            break;
-#endif
-#ifdef GPIO_6_EN
-        case GPIO_6:
-            EXTI->IMR |= (1 << GPIO_6_PIN);
-            break;
-#endif
-#ifdef GPIO_7_EN
-        case GPIO_7:
-            EXTI->IMR |= (1 << GPIO_7_PIN);
-            break;
-#endif
-#ifdef GPIO_8_EN
-        case GPIO_8:
-            EXTI->IMR |= (1 << GPIO_8_PIN);
-            break;
-#endif
-#ifdef GPIO_9_EN
-        case GPIO_9:
-            EXTI->IMR |= (1 << GPIO_9_PIN);
-            break;
-#endif
-#ifdef GPIO_10_EN
-        case GPIO_10:
-            EXTI->IMR |= (1 << GPIO_10_PIN);
-            break;
-#endif
-#ifdef GPIO_11_EN
-        case GPIO_11:
-            EXTI->IMR |= (1 << GPIO_11_PIN);
-            break;
-#endif
+    uint8_t pin;
+
+    if (dev >= GPIO_NUMOF) {
+        return;
     }
+
+    pin = gpio_pin_map[dev];
+    EXTI->IMR |= (1 << pin);
 }
 
 void gpio_irq_disable(gpio_t dev)
 {
-    switch (dev) {
-#ifdef GPIO_0_EN
-        case GPIO_0:
-            EXTI->IMR &= ~(1 << GPIO_0_PIN);
-            break;
-#endif
-#ifdef GPIO_1_EN
-        case GPIO_1:
-            EXTI->IMR &= ~(1 << GPIO_1_PIN);
-            break;
-#endif
-#ifdef GPIO_2_EN
-        case GPIO_2:
-            EXTI->IMR &= ~(1 << GPIO_2_PIN);
-            break;
-#endif
-#ifdef GPIO_3_EN
-        case GPIO_3:
-            EXTI->IMR &= ~(1 << GPIO_3_PIN);
-            break;
-#endif
-#ifdef GPIO_4_EN
-        case GPIO_4:
-            EXTI->IMR &= ~(1 << GPIO_4_PIN);
-            break;
-#endif
-#ifdef GPIO_5_EN
-        case GPIO_5:
-            EXTI->IMR &= ~(1 << GPIO_5_PIN);
-            break;
-#endif
-#ifdef GPIO_6_EN
-        case GPIO_6:
-            EXTI->IMR &= ~(1 << GPIO_6_PIN);
-            break;
-#endif
-#ifdef GPIO_7_EN
-        case GPIO_7:
-            EXTI->IMR &= ~(1 << GPIO_7_PIN);
-            break;
-#endif
-#ifdef GPIO_8_EN
-        case GPIO_8:
-            EXTI->IMR &= ~(1 << GPIO_8_PIN);
-            break;
-#endif
-#ifdef GPIO_9_EN
-        case GPIO_9:
-            EXTI->IMR &= ~(1 << GPIO_9_PIN);
-            break;
-#endif
-#ifdef GPIO_10_EN
-        case GPIO_10:
-            EXTI->IMR &= ~(1 << GPIO_10_PIN);
-            break;
-#endif
-#ifdef GPIO_11_EN
-        case GPIO_11:
-            EXTI->IMR &= ~(1 << GPIO_11_PIN);
-            break;
-#endif
+    uint8_t pin;
+
+    if (dev >= GPIO_NUMOF) {
+        return;
     }
+
+    pin = gpio_pin_map[dev];
+    EXTI->IMR &= ~(1 << pin);
 }
 
 int gpio_read(gpio_t dev)
 {
-    GPIO_TypeDef *port = 0;
-    uint32_t pin = 0;
+    GPIO_TypeDef *port;
+    uint8_t pin;
 
-    switch (dev) {
-#ifdef GPIO_0_EN
-        case GPIO_0:
-            port = GPIO_0_PORT;
-            pin = GPIO_0_PIN;
-            break;
-#endif
-#ifdef GPIO_1_EN
-        case GPIO_1:
-            port = GPIO_1_PORT;
-            pin = GPIO_1_PIN;
-            break;
-#endif
-#ifdef GPIO_2_EN
-        case GPIO_2:
-            port = GPIO_2_PORT;
-            pin = GPIO_2_PIN;
-            break;
-#endif
-#ifdef GPIO_3_EN
-        case GPIO_3:
-            port = GPIO_3_PORT;
-            pin = GPIO_3_PIN;
-            break;
-#endif
-#ifdef GPIO_4_EN
-        case GPIO_4:
-            port = GPIO_4_PORT;
-            pin = GPIO_4_PIN;
-            break;
-#endif
-#ifdef GPIO_5_EN
-        case GPIO_5:
-            port = GPIO_5_PORT;
-            pin = GPIO_5_PIN;
-            break;
-#endif
-#ifdef GPIO_6_EN
-        case GPIO_6:
-            port = GPIO_6_PORT;
-            pin = GPIO_6_PIN;
-            break;
-#endif
-#ifdef GPIO_7_EN
-        case GPIO_7:
-            port = GPIO_7_PORT;
-            pin = GPIO_7_PIN;
-            break;
-#endif
-#ifdef GPIO_8_EN
-        case GPIO_8:
-            port = GPIO_8_PORT;
-            pin = GPIO_8_PIN;
-            break;
-#endif
-#ifdef GPIO_9_EN
-        case GPIO_9:
-            port = GPIO_9_PORT;
-            pin = GPIO_9_PIN;
-            break;
-#endif
-#ifdef GPIO_10_EN
-        case GPIO_10:
-            port = GPIO_10_PORT;
-            pin = GPIO_10_PIN;
-            break;
-#endif
-#ifdef GPIO_11_EN
-        case GPIO_11:
-            port = GPIO_11_PORT;
-            pin = GPIO_11_PIN;
-            break;
-#endif
+    if (dev >= GPIO_NUMOF) {
+        return -1;
     }
+
+    port = gpio_port_map[dev];
+    pin = gpio_pin_map[dev];
 
     if (port->MODER & (1 << (pin * 2))) {       /* if configured as output */
         return port->ODR & (1 << pin);          /* read output data register */
@@ -604,134 +359,32 @@ int gpio_read(gpio_t dev)
 
 void gpio_set(gpio_t dev)
 {
-    switch (dev) {
-#ifdef GPIO_0_EN
-        case GPIO_0:
-            GPIO_0_PORT->ODR |= (1 << GPIO_0_PIN);
-            break;
-#endif
-#ifdef GPIO_1_EN
-        case GPIO_1:
-            GPIO_1_PORT->ODR |= (1 << GPIO_1_PIN);
-            break;
-#endif
-#ifdef GPIO_2_EN
-        case GPIO_2:
-            GPIO_2_PORT->ODR |= (1 << GPIO_2_PIN);
-            break;
-#endif
-#ifdef GPIO_3_EN
-        case GPIO_3:
-            GPIO_3_PORT->ODR |= (1 << GPIO_3_PIN);
-            break;
-#endif
-#ifdef GPIO_4_EN
-        case GPIO_4:
-            GPIO_4_PORT->ODR |= (1 << GPIO_4_PIN);
-            break;
-#endif
-#ifdef GPIO_5_EN
-        case GPIO_5:
-            GPIO_5_PORT->ODR |= (1 << GPIO_5_PIN);
-            break;
-#endif
-#ifdef GPIO_6_EN
-        case GPIO_6:
-            GPIO_6_PORT->ODR |= (1 << GPIO_6_PIN);
-            break;
-#endif
-#ifdef GPIO_7_EN
-        case GPIO_7:
-            GPIO_7_PORT->ODR |= (1 << GPIO_7_PIN);
-            break;
-#endif
-#ifdef GPIO_8_EN
-        case GPIO_8:
-            GPIO_8_PORT->ODR |= (1 << GPIO_8_PIN);
-            break;
-#endif
-#ifdef GPIO_9_EN
-        case GPIO_9:
-            GPIO_9_PORT->ODR |= (1 << GPIO_9_PIN);
-            break;
-#endif
-#ifdef GPIO_10_EN
-        case GPIO_10:
-            GPIO_10_PORT->ODR |= (1 << GPIO_10_PIN);
-            break;
-#endif
-#ifdef GPIO_11_EN
-        case GPIO_11:
-            GPIO_11_PORT->ODR |= (1 << GPIO_11_PIN);
-            break;
-#endif
+    GPIO_TypeDef *port;
+    uint8_t pin;
+
+    if (dev >= GPIO_NUMOF) {
+        return;
     }
+
+    port = gpio_port_map[dev];
+    pin = gpio_pin_map[dev];
+
+    port->ODR |= (1 << pin);
 }
 
 void gpio_clear(gpio_t dev)
 {
-    switch (dev) {
-#ifdef GPIO_0_EN
-        case GPIO_0:
-            GPIO_0_PORT->ODR &= ~(1 << GPIO_0_PIN);
-            break;
-#endif
-#ifdef GPIO_1_EN
-        case GPIO_1:
-            GPIO_1_PORT->ODR &= ~(1 << GPIO_1_PIN);
-            break;
-#endif
-#ifdef GPIO_2_EN
-        case GPIO_2:
-            GPIO_2_PORT->ODR &= ~(1 << GPIO_2_PIN);
-            break;
-#endif
-#ifdef GPIO_3_EN
-        case GPIO_3:
-            GPIO_3_PORT->ODR &= ~(1 << GPIO_3_PIN);
-            break;
-#endif
-#ifdef GPIO_4_EN
-        case GPIO_4:
-            GPIO_4_PORT->ODR &= ~(1 << GPIO_4_PIN);
-            break;
-#endif
-#ifdef GPIO_5_EN
-        case GPIO_5:
-            GPIO_5_PORT->ODR &= ~(1 << GPIO_5_PIN);
-            break;
-#endif
-#ifdef GPIO_6_EN
-        case GPIO_6:
-            GPIO_6_PORT->ODR &= ~(1 << GPIO_6_PIN);
-            break;
-#endif
-#ifdef GPIO_7_EN
-        case GPIO_7:
-            GPIO_7_PORT->ODR &= ~(1 << GPIO_7_PIN);
-            break;
-#endif
-#ifdef GPIO_8_EN
-        case GPIO_8:
-            GPIO_8_PORT->ODR &= ~(1 << GPIO_8_PIN);
-            break;
-#endif
-#ifdef GPIO_9_EN
-        case GPIO_9:
-            GPIO_9_PORT->ODR &= ~(1 << GPIO_9_PIN);
-            break;
-#endif
-#ifdef GPIO_10_EN
-        case GPIO_10:
-            GPIO_10_PORT->ODR &= ~(1 << GPIO_10_PIN);
-            break;
-#endif
-#ifdef GPIO_11_EN
-        case GPIO_11:
-            GPIO_11_PORT->ODR &= ~(1 << GPIO_11_PIN);
-            break;
-#endif
+    GPIO_TypeDef *port;
+    uint8_t pin;
+
+    if (dev >= GPIO_NUMOF) {
+        return;
     }
+
+    port = gpio_port_map[dev];
+    pin = gpio_pin_map[dev];
+
+    port->ODR &= ~(1 << pin);
 }
 
 void gpio_toggle(gpio_t dev)


### PR DESCRIPTION
Tried a different concept for handling the GPIO-pin-and-port mapping (thx to @HexLuthor for the idea!).

The code is tested with `test/periph_gpio` and `tests/periph_gpio_int` and seems to work as before. The importent thing is the memory usage:

before applying this PR for `tests/periph_gpio`:

```
   text    data     bss     dec     hex 
  17440     112    4280   21832    5548
```

and after:

```
   text    data     bss     dec     hex 
  16428     112    4280   20820    5154
```

--> saves 1Kb of flash and makes the code a little less ugly...
