### PR TITLE
cpu: use typed function pointer for thread_arch_init

### DIFF
--- a/core/include/arch/thread_arch.h
+++ b/core/include/arch/thread_arch.h
@@ -25,6 +25,7 @@
  extern "C" {
 #endif
 
+#include "kernel_internal.h"
 /**
  * @name Define the mapping between the architecture independent interfaces
  *       and the kernel internal interfaces
@@ -52,7 +53,7 @@
  *
  * @return                  pointer to the new top of the stack
  */
-char *thread_arch_stack_init(void *(*function)(void *arg), void *arg, void *stack_start, int stack_size);
+char *thread_arch_stack_init(thread_task_func_t task_func, void *arg, void *stack_start, int stack_size);
 
 /**
  * @brief Print the current stack to stdout

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -79,7 +79,7 @@ kernel_pid_t thread_create(char *stack,
                   int stacksize,
                   char priority,
                   int flags,
-                  void *(*function)(void *arg),
+                  thread_task_func_t task_func,
                   void *arg,
                   const char *name);
 

--- a/core/thread.c
+++ b/core/thread.c
@@ -105,7 +105,7 @@ uintptr_t thread_measure_stack_free(char *stack)
 }
 #endif
 
-kernel_pid_t thread_create(char *stack, int stacksize, char priority, int flags, void *(*function)(void *arg), void *arg, const char *name)
+kernel_pid_t thread_create(char *stack, int stacksize, char priority, int flags, thread_task_func_t function, void *arg, const char *name)
 {
     if (priority >= SCHED_PRIO_LEVELS) {
         return -EINVAL;

--- a/cpu/atmega_common/thread_arch.c
+++ b/cpu/atmega_common/thread_arch.c
@@ -67,8 +67,8 @@ static void __enter_thread_mode(void);
  * it inside of the programm counter of the MCU.
  * if task_func returns sched_task_exit gets popped into the PC
  */
-char *thread_arch_stack_init(void *(*task_func)(void *), void *arg, void *stack_start,
-                             int stack_size)
+char *thread_arch_stack_init(thread_task_func_t task_func, void *arg,
+                             void *stack_start, int stack_size)
 {
     uint16_t tmp_adress;
     uint8_t *stk;

--- a/cpu/cortex-m0_common/thread_arch.c
+++ b/cpu/cortex-m0_common/thread_arch.c
@@ -60,7 +60,7 @@ static void context_restore(void);
  * lowest address                                                                    highest address
  *
  */
-char *thread_arch_stack_init(void *(*task_func)(void *),
+char *thread_arch_stack_init(thread_task_func_t task_func,
                              void *arg,
                              void *stack_start,
                              int stack_size)

--- a/cpu/cortex-m3_common/thread_arch.c
+++ b/cpu/cortex-m3_common/thread_arch.c
@@ -54,7 +54,7 @@ static void context_restore(void) NORETURN;
  * --------------------------------------
  *
  */
-char *thread_arch_stack_init(void *(*task_func)(void *), void *arg, void *stack_start, int stack_size)
+char *thread_arch_stack_init(thread_task_func_t task_func, void *arg, void *stack_start, int stack_size)
 {
     uint32_t *stk;
     stk = (uint32_t *)((uintptr_t)stack_start + stack_size);

--- a/cpu/cortex-m4_common/thread_arch.c
+++ b/cpu/cortex-m4_common/thread_arch.c
@@ -57,7 +57,7 @@
  * --------------------------------------
  *
  */
-char *thread_arch_stack_init(void *(*task_func)(void *),
+char *thread_arch_stack_init(thread_task_func_t task_func,
                              void *arg,
                              void *stack_start,
                              int stack_size)


### PR DESCRIPTION
The function pointer typedef already exists, but haven't been used for thread_init().
