### PR TITLE
cpu/stm32f4: optimized GPIO driver implementation

### DIFF
--- a/cpu/stm32f4/periph/gpio.c
+++ b/cpu/stm32f4/periph/gpio.c
@@ -259,9 +259,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pullup, gpio_flank_t flank, gpio_cb_t cb
     RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;
 
     /* enable IRQ */
-    NVIC_SetPriority(gpio_irq_map[dev], GPIO_IRQ_PRIO);
-    NVIC_EnableIRQ(gpio_irq_map[dev]);
-
     switch (dev) {
 #if GPIO_0_EN
         case GPIO_0:
@@ -344,6 +341,8 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pullup, gpio_flank_t flank, gpio_cb_t cb
             break;
 #endif
     }
+    NVIC_SetPriority(gpio_irq_map[dev], GPIO_IRQ_PRIO);
+    NVIC_EnableIRQ(gpio_irq_map[dev]);
 
     /* set callback */
     gpio_config[dev].cb = cb;


### PR DESCRIPTION
And the same game for the STM32F4, results (for `tests/periph_gpio_int`):

before:

```
   text    data     bss     dec     hex
  13364     112   14216   27692    6c2c
```

and after:

```
   text    data     bss     dec     hex
  12484     112   14216   26812    68bc
```
