### PR TITLE
doxygen: add predefines for periph headers

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -1970,7 +1970,19 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = __attribute__(x)=
+PREDEFINED             = __attribute__(x)= \
+                         ADC_NUMOF \
+                         CPUID_ID_LEN \
+                         GPIO_NUMOF \
+                         I2C_NUMOF \
+                         PWM_NUMOF \
+                         RANDOM_NUMOF \
+                         RTC_NUMOF \
+                         RTT_NUMOF \
+                         GPIO_NUMOF \
+                         SPI_NUMOF \
+                         UART_NUMOF
+
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
Fixes #1762
