### PR TITLE
doc: make peripheral interfaces modules

### DIFF
--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -7,6 +7,7 @@
  */
 
 /**
+ * @defgroup    driver_periph_adc ADC
  * @ingroup     driver_periph
  * @brief       Low-level ADC peripheral driver
  * @{

--- a/drivers/include/periph/cpuid.h
+++ b/drivers/include/periph/cpuid.h
@@ -7,10 +7,11 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @defgroup    driver_periph_cpuid CPUID
+ * @ingroup     driver_periph
  * @{
  *
- * @file        periph/cpuid.h
+ * @file
  * @brief       Provides access the CPU's serial number
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -7,11 +7,12 @@
  */
 
 /**
+ * @defgroup    driver_periph_gpio GPIO
  * @ingroup     driver_periph
  * @brief       Low-level GPIO peripheral driver
  * @{
  *
- * @file        periph/gpio.h
+ * @file
  * @brief       Low-level GPIO peripheral driver interface definitions
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -7,6 +7,7 @@
  */
 
 /**
+ * @defgroup    driver_periph_i2c I2C
  * @ingroup     driver_periph
  * @brief       Low-level I2C peripheral driver
  * @{

--- a/drivers/include/periph/pwm.h
+++ b/drivers/include/periph/pwm.h
@@ -7,11 +7,12 @@
  */
 
 /**
+ * @defgroup    driver_periph_pwm PWM
  * @ingroup     driver_periph
  * @brief       Low-level PWM peripheral driver
  * @{
  *
- * @file        periph/pwm.h
+ * @file
  * @brief       Low-level PWM peripheral driver interface definitions
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/drivers/include/periph/random.h
+++ b/drivers/include/periph/random.h
@@ -7,6 +7,7 @@
  */
 
 /**
+ * @defgroup    driver_periph_random Random
  * @ingroup     driver_periph
  * @{
  *

--- a/drivers/include/periph/rtc.h
+++ b/drivers/include/periph/rtc.h
@@ -7,11 +7,12 @@
  */
 
 /**
+ * @defgroup    driver_periph_rtc RTC
  * @ingroup     driver_periph
  * @brief       Low-level RTC (Real Time Clock) peripheral driver
  * @{
  *
- * @file        rtc.h
+ * @file
  * @brief       Low-level RTC peripheral driver interface definitions
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -5,11 +5,13 @@
  * Public License v2.1. See the file LICENSE in the top level directory for more
  * details.
  */
+
 /**
+ * @defgroup    driver_periph_rtt RTT
  * @ingroup     driver_periph
  * @{
  *
- * @file        rtt.h
+ * @file
  * @brief       Low-level RTT (Real Time Timer) peripheral driver interface
  *              definitions
  *

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -7,6 +7,7 @@
  */
 
 /**
+ * @defgroup    driver_periph_spi SPI
  * @ingroup     driver_periph
  * @brief       Low-level SPI peripheral driver
  * @{

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -7,11 +7,12 @@
  */
 
 /**
+ * @defgroup    driver_periph_timer Timer
  * @ingroup     driver_periph
  * @brief       Low-level timer peripheral driver
  * @{
  *
- * @file        periph/timer.h
+ * @file
  * @brief       Low-level timer peripheral driver interface definitions
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -7,11 +7,12 @@
  */
 
 /**
+ * @defgroup    driver_periph_uart UART
  * @ingroup     driver_periph
  * @brief       Low-level UART peripheral driver
  * @{
  *
- * @file        periph/uart.h
+ * @file
  * @brief       Low-level UART peripheral driver interface definitions
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>


### PR DESCRIPTION
- make peripheral interfaces modules
  - this way, e.g. `GPIO` shows up as a submodule of `Peripheral drivers`
- remove `@file` parameters
  - documentation renders much cleaner (I have no idea about the semantic/syntax, but it helps ;)
