### PR TITLE
boards, sys: purge feuerware_radios

### DIFF
--- a/boards/avsextrem/include/board.h
+++ b/boards/avsextrem/include/board.h
@@ -40,14 +40,6 @@
 #define LED_RED_ON (FIO3CLR = LED_RED_PIN)
 #define LED_RED_TOGGLE (FIO3PIN ^= LED_RED_PIN)
 
-
-
-#ifdef MODULE_CC110X
-#define FEUERWARE_CONF_NUM_RADIOS         1
-#else
-#define FEUERWARE_CONF_NUM_RADIOS         0
-#endif
-
 // if FAT is enabled this board supports files
 #define FEUERWARE_CONF_CORE_SUPPORTS_FILES    defined(MODULE_FAT)
 

--- a/sys/include/radio/radio.h
+++ b/sys/include/radio/radio.h
@@ -37,10 +37,6 @@
 #include <stdbool.h>
 #include "radio/types.h"
 
-#ifndef FEUERWARE_CONF_NUM_RADIOS
-#define FEUERWARE_CONF_NUM_RADIOS 1
-#endif
-
 #define L1_PROTOCOL_CATCH_ALL             (0xff)    ///< Catch all protocol ID
 
 enum layer_1_protocols {
@@ -75,8 +71,6 @@ typedef struct {
     void (*print_stats)(void);
     void (*print_config)(void);
 } radio_t;
-
-extern const struct radio *feuerware_radios[FEUERWARE_CONF_NUM_RADIOS];
 
 /** @} */
 


### PR DESCRIPTION
- `feuerware_radios` is unused, remove from `radio.h` header
- `FEUERWARE_CONF_NUM_RADIOS` is superfluous without it, remove all occurrences
