### PR TITLE
core,sys: fix storage types for irq API usage

### DIFF
--- a/core/hwtimer.c
+++ b/core/hwtimer.c
@@ -201,7 +201,7 @@ int hwtimer_remove(int n)
 {
     DEBUG("hwtimer_remove n=%d\n", n);
 
-    int state = disableIRQ();
+    unsigned state = disableIRQ();
     hwtimer_arch_unset(n);
 
     lifo_insert(lifo, n);

--- a/core/msg.c
+++ b/core/msg.c
@@ -151,7 +151,7 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block)
 
 int msg_send_to_self(msg_t *m)
 {
-    unsigned int state = disableIRQ();
+    unsigned state = disableIRQ();
 
     m->sender_pid = sched_active_pid;
     int res = queue_msg((tcb_t *) sched_active_thread, m);
@@ -208,7 +208,7 @@ int msg_send_receive(msg_t *m, msg_t *reply, kernel_pid_t target_pid)
 
 int msg_reply(msg_t *m, msg_t *reply)
 {
-    int state = disableIRQ();
+    unsigned state = disableIRQ();
 
     tcb_t *target = (tcb_t*) sched_threads[m->sender_pid];
 

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -53,7 +53,7 @@ void mutex_lock(struct mutex_t *mutex)
 
 static void mutex_wait(struct mutex_t *mutex)
 {
-    int irqstate = disableIRQ();
+    unsigned irqstate = disableIRQ();
     DEBUG("%s: Mutex in use. %u\n", sched_active_thread->name, mutex->val);
 
     if (mutex->val == 0) {
@@ -85,7 +85,7 @@ static void mutex_wait(struct mutex_t *mutex)
 void mutex_unlock(struct mutex_t *mutex)
 {
     DEBUG("%s: unlocking mutex. val: %u pid: %" PRIkernel_pid "\n", sched_active_thread->name, mutex->val, sched_active_pid);
-    int irqstate = disableIRQ();
+    unsigned irqstate = disableIRQ();
 
     if (mutex->val != 0) {
         priority_queue_node_t *next = priority_queue_remove_head(&(mutex->queue));
@@ -107,7 +107,7 @@ void mutex_unlock(struct mutex_t *mutex)
 void mutex_unlock_and_sleep(struct mutex_t *mutex)
 {
     DEBUG("%s: unlocking mutex. val: %u pid: %" PRIkernel_pid ", and taking a nap\n", sched_active_thread->name, mutex->val, sched_active_pid);
-    int irqstate = disableIRQ();
+    unsigned irqstate = disableIRQ();
 
     if (mutex->val != 0) {
         priority_queue_node_t *next = priority_queue_remove_head(&(mutex->queue));

--- a/core/thread.c
+++ b/core/thread.c
@@ -68,7 +68,7 @@ int thread_wakeup(kernel_pid_t pid)
 {
     DEBUG("thread_wakeup: Trying to wakeup PID %" PRIkernel_pid "...\n", pid);
 
-    int old_state = disableIRQ();
+    unsigned old_state = disableIRQ();
 
     tcb_t *other_thread = (tcb_t *) sched_threads[pid];
     if (other_thread && other_thread->status == STATUS_SLEEPING) {

--- a/sys/chardev_thread.c
+++ b/sys/chardev_thread.c
@@ -110,7 +110,7 @@ void chardev_loop(ringbuffer_t *rb)
 
         if (rb->avail && (r != NULL)) {
             DEBUG("Data is available\n");
-            int state = disableIRQ();
+            unsigned state = disableIRQ();
             int nbytes = min(r->nbytes, rb->avail);
             DEBUG("uart0_thread [%i]: sending %i bytes received from %" PRIkernel_pid " to pid %" PRIkernel_pid "\n", pid, nbytes, m.sender_pid, reader_pid);
             ringbuffer_get(rb, r->buffer, nbytes);

--- a/sys/posix/semaphore.c
+++ b/sys/posix/semaphore.c
@@ -96,7 +96,7 @@ static void sem_thread_blocked(sem_t *sem)
 
 int sem_wait(sem_t *sem)
 {
-    int old_state = disableIRQ();
+    unsigned old_state = disableIRQ();
     while (1) {
         unsigned value = sem->value;
         if (value == 0) {
@@ -121,7 +121,7 @@ int sem_timedwait(sem_t *sem, const struct timespec *abstime)
 
 int sem_trywait(sem_t *sem)
 {
-    int old_state = disableIRQ();
+    unsigned old_state = disableIRQ();
     int result;
 
     unsigned value = sem->value;
@@ -139,7 +139,7 @@ int sem_trywait(sem_t *sem)
 
 int sem_post(sem_t *sem)
 {
-    int old_state = disableIRQ();
+    unsigned old_state = disableIRQ();
     ++sem->value;
 
     priority_queue_node_t *next = priority_queue_remove_head(&sem->queue);

--- a/sys/transceiver/transceiver.c
+++ b/sys/transceiver/transceiver.c
@@ -237,7 +237,7 @@ kernel_pid_t transceiver_start(void)
 uint8_t transceiver_register(transceiver_type_t t, kernel_pid_t pid)
 {
     int result = 0;
-    int state = disableIRQ();
+    unsigned state = disableIRQ();
     for (size_t i = 0; i < TRANSCEIVER_MAX_REGISTERED; i++) {
         if ((reg[i].pid == pid) || (reg[i].transceivers == TRANSCEIVER_NONE)) {
             reg[i].transceivers |= t;
@@ -256,7 +256,7 @@ uint8_t transceiver_register(transceiver_type_t t, kernel_pid_t pid)
 uint8_t transceiver_unregister(transceiver_type_t t, kernel_pid_t pid)
 {
     int result = 0;
-    int state = disableIRQ();
+    unsigned state = disableIRQ();
     for (size_t i = 0; i < TRANSCEIVER_MAX_REGISTERED; ++i) {
         if (reg[i].pid == pid) {
             reg[i].transceivers &= ~t;

--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -307,7 +307,7 @@ void vtimer_get_localtime(struct tm *localt)
 int vtimer_init(void)
 {
     DEBUG("vtimer_init().\n");
-    int state = disableIRQ();
+    unsigned state = disableIRQ();
     seconds = 0;
 
     longterm_tick_start = 0;
@@ -372,7 +372,7 @@ int vtimer_sleep(timex_t time)
 
 int vtimer_remove(vtimer_t *t)
 {
-    unsigned int irq_state = disableIRQ();
+    unsigned irq_state = disableIRQ();
 
     priority_queue_remove(&shortterm_priority_queue_root, timer_get_node(t));
     priority_queue_remove(&longterm_priority_queue_root, timer_get_node(t));


### PR DESCRIPTION
- should not have any effect as long as `unsigned` and `int` are compatible
- also fix ~~one~~ two cosmetic `unsigned int` -> `unsigned` for consistency
