### PR TITLE
core: hwtimer: use disable/restoreIRQ

### DIFF
--- a/core/hwtimer.c
+++ b/core/hwtimer.c
@@ -148,15 +148,17 @@ static int _hwtimer_set(unsigned long offset, void (*callback)(void*), void *ptr
 {
     DEBUG("_hwtimer_set: offset=%lu callback=%p ptr=%p absolute=%d\n", offset, callback, ptr, absolute);
 
+    unsigned state;
+
     if (!inISR()) {
-        dINT();
+        state = disableIRQ();
     }
 
     int n = lifo_get(lifo);
 
     if (n == -1) {
         if (!inISR()) {
-            eINT();
+            restoreIRQ(state);
         }
 
         puts("No hwtimer left.");
@@ -178,7 +180,7 @@ static int _hwtimer_set(unsigned long offset, void (*callback)(void*), void *ptr
     lpm_prevent_sleep++;
 
     if (!inISR()) {
-        eINT();
+        restoreIRQ(state);
     }
 
     return n;


### PR DESCRIPTION
hwtimer still uses dINT/eINT(). This PR makes it use disableIRQ/restoreIRQ instead.
