### PR TITLE
added board airfy beacon

### DIFF
--- a/boards/airfy-beacon/Makefile
+++ b/boards/airfy-beacon/Makefile
@@ -1,0 +1,4 @@
+# tell the Makefile.base which module to build
+MODULE = $(BOARD)_base
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/airfy-beacon/Makefile.features
+++ b/boards/airfy-beacon/Makefile.features
@@ -1,0 +1,1 @@
+FEATURES_PROVIDED = periph_gpio periph_random periph_rtt periph_cpuid

--- a/boards/airfy-beacon/Makefile.include
+++ b/boards/airfy-beacon/Makefile.include
@@ -1,0 +1,52 @@
+# define the cpu used by the airfy-beacon board
+export CPU = nrf51822
+export CPU_MODEL = nrf51822qfaa
+
+#define the default port depending on the host OS
+OS := $(shell uname)
+ifeq ($(OS),Linux)
+  PORT ?= /dev/ttyUSB0
+else ifeq ($(OS),Darwin)
+  PORT ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+else
+  $(info CAUTION: No flash tool for your host system found!)
+  # TODO: add support for windows as host platform
+endif
+export PORT
+
+# define tools used for building the project
+export PREFIX = arm-none-eabi-
+export CC = $(PREFIX)gcc
+export AR = $(PREFIX)ar
+export AS = $(PREFIX)as
+export LINK = $(PREFIX)gcc
+export SIZE = $(PREFIX)size
+export OBJCOPY = $(PREFIX)objcopy
+export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm
+export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
+export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
+export DEBUGSERVER = $(RIOTBOARD)/$(BOARD)/dist/debug-server.sh
+export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
+
+# define build specific options
+CPU_USAGE = -mcpu=cortex-m0
+FPU_USAGE =
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
+export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+# $(LINKERSCRIPT) is specified in cpu/Makefile.include
+export LINKFLAGS += -T$(LINKERSCRIPT)
+export OFLAGS = -O binary
+export HEXFILE = $(ELFFILE:.elf=.bin)
+export TERMFLAGS += -p "$(PORT)"
+export FFLAGS = $(HEXFILE)
+export DEBUGGER_FLAGS = $(ELFFILE)
+
+# use the nano-specs of the NewLib when available
+ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+export LINKFLAGS += -specs=nano.specs -lc -lnosys
+endif
+
+# export board specific includes to the global includes-listing
+export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include

--- a/boards/airfy-beacon/board.c
+++ b/boards/airfy-beacon/board.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2014 Christian Mehlis <mehlis@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     board_airfy-beacon
+ * @{
+ *
+ * @file        board.c
+ * @brief       Board specific implementations for the Airfy Beacon board
+ *
+ * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "cpu.h"
+
+void board_init(void)
+{
+    /* setup led(s) for debugging */
+    NRF_GPIO->PIN_CNF[LED_RED_PIN] = GPIO_PIN_CNF_DIR_Output;
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/airfy-beacon/dist/debug-server.sh
+++ b/boards/airfy-beacon/dist/debug-server.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+if [ -L "$0" ]; then
+    FILE=$(readlink "$0")
+else
+    FILE="$0"
+fi
+
+BIN_FOLDER=$(dirname "${FILE}")
+
+echo "##"
+echo "## Starting debug server"
+echo "##"
+openocd -f "${BIN_FOLDER}/openocd.cfg" \
+    -c "init" \
+    -c "targets" \
+    -c "reset halt" \

--- a/boards/airfy-beacon/dist/debug.sh
+++ b/boards/airfy-beacon/dist/debug.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+if [ ! -f "$1" ]; then
+    echo "ELF-file $1 does not exist"
+    exit 1
+fi
+
+if [ -L "$0" ]; then
+    FILE=$(readlink "$0")
+else
+    FILE="$0"
+fi
+
+BIN_FOLDER=$(dirname "${FILE}")
+
+echo "##"
+echo "## Debugging $1"
+echo "##"
+arm-none-eabi-gdb -tui -command="${BIN_FOLDER}/gdb.cfg" $1

--- a/boards/airfy-beacon/dist/flash.sh
+++ b/boards/airfy-beacon/dist/flash.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+if [ ! -f "$1" ]; then
+    echo "Binary file $1 does not exist"
+    exit 1
+fi
+
+if [ -L "$0" ]; then
+    FILE=$(readlink "$0")
+else
+    FILE="$0"
+fi
+
+BIN_FOLDER=$(dirname "${FILE}")
+
+echo "##"
+echo "## Flashing $1"
+echo "##"
+openocd -f "${BIN_FOLDER}/openocd.cfg" \
+    -c "init" \
+    -c "targets" \
+    -c "flash banks" \
+    -c "reset halt" \
+    -c "flash write_image erase $1 0" \
+    -c "verify_image $1" \
+    -c "reset run"\
+    -c "shutdown"

--- a/boards/airfy-beacon/dist/gdb.cfg
+++ b/boards/airfy-beacon/dist/gdb.cfg
@@ -1,0 +1,1 @@
+target extended-remote 127.0.0.1:3333

--- a/boards/airfy-beacon/dist/openocd.cfg
+++ b/boards/airfy-beacon/dist/openocd.cfg
@@ -1,0 +1,10 @@
+# nRF51822 Target
+source [find interface/stlink-v2.cfg]
+
+transport select hla_swd
+
+set WORKAREASIZE 0x4000
+source [find target/nrf51.cfg]
+
+# use hardware reset, connect under reset
+#reset_config srst_only srst_nogate

--- a/boards/airfy-beacon/dist/reset.sh
+++ b/boards/airfy-beacon/dist/reset.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+if [ -L "$0" ]; then
+    FILE=$(readlink "$0")
+else
+    FILE="$0"
+fi
+
+BIN_FOLDER=$(dirname "${FILE}")
+
+echo "##"
+echo "## Resetting $BOARD"
+echo "##"
+openocd -f "${BIN_FOLDER}/openocd.cfg" \
+    -c "init" \
+    -c "reset run" \
+    -c "shutdown"

--- a/boards/airfy-beacon/include/board.h
+++ b/boards/airfy-beacon/include/board.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2014 Christian Mehlis <mehlis@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    board_airfy-beacon Airfy Beacon
+ * @ingroup     boards
+ * @brief       Board specific files for the Arify Beacon board
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Arify Beacon board
+ *
+ * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
+ */
+
+#ifndef __BOARD_H
+#define __BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * @name Define the nominal CPU core clock in this board
+ */
+#define F_CPU               (16000000UL)
+
+/**
+ * @name Define the boards stdio
+ * @{
+ */
+#define STDIO               UART_0
+#define STDIO_BAUDRATE      (115200U)
+#define STDIO_RX_BUFSIZE    (64U)
+/** @} */
+
+/**
+ * @name Assign the hardware timer
+ */
+#define HW_TIMER            TIMER_0
+
+/**
+ * @name Macros for controlling the on-board LEDs.
+ * @{
+ */
+#define LED_RED_PIN         16
+
+#define LED_RED_ON          (NRF_GPIO->OUTSET = (1 << LED_RED_PIN))
+#define LED_RED_OFF         (NRF_GPIO->OUTCLR = (1 << LED_RED_PIN))
+#define LED_RED_TOGGLE      (NRF_GPIO->OUT ^= (1 << LED_RED_PIN))
+
+/* @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /** __BOARD_H */
+/** @} */

--- a/boards/airfy-beacon/include/periph_conf.h
+++ b/boards/airfy-beacon/include/periph_conf.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2014 Christian Mehlis <mehlis@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     board_airfy-beacon
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the Airfy Beacon board
+ *
+ * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
+ */
+
+#ifndef __PERIPH_CONF_H
+#define __PERIPH_CONF_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * @name Timer configuration
+ * @{
+ */
+#define TIMER_NUMOF         (1U)
+#define TIMER_0_EN          1
+#define TIMER_1_EN          0
+#define TIMER_2_EN          0
+#define TIMER_IRQ_PRIO      1
+
+/* Timer 0 configuration */
+#define TIMER_0_DEV         NRF_TIMER0
+#define TIMER_0_CHANNELS    3
+#define TIMER_0_MAX_VALUE   (0xffffff)
+#define TIMER_0_BITMODE     TIMER_BITMODE_BITMODE_24Bit     /* only possible value for TIMER0 */
+#define TIMER_0_ISR         isr_timer0
+#define TIMER_0_IRQ         TIMER0_IRQn
+
+/* Timer 1 configuration */
+#define TIMER_1_DEV         NRF_TIMER1
+#define TIMER_1_CHANNELS    3
+#define TIMER_1_MAX_VALUE   (0xffff)
+#define TIEMR_1_BITMODE     TIMER_BITMODE_BITMODE_16Bit
+#define TIMER_1_ISR         isr_timer1
+#define TIMER_1_IRQ         TIMER1_IRQn
+
+/* Timer 2 configuration */
+#define TIMER_2_DEV         NRF_TIMER2
+#define TIMER_2_CHANNELS    3
+#define TIMER_2_MAX_VALUE   (0xffff)
+#define TIMER_2_BITMODE     TIMER_BITMODE_BITMODE_16Bit
+#define TIMER_2_ISR         isr_timer2
+#define TIMER_2_IRQ         TIMER2_IRQn
+/** @} */
+
+/**
+ * @name UART configuration
+ * @{
+ */
+#define UART_NUMOF          (1U)
+#define UART_0_EN           1
+#define UART_IRQ_PRIO       1
+
+/* UART 0 device configuration */
+#define UART_DEV            NRF_UART0
+#define UART_PIN_RX         17
+#define UART_PIN_TX         18
+/** @} */
+
+/**
+ * @name Real time counter configuration
+ * @{
+ */
+#define RTT_NUMOF           (1U)
+#define RTT_IRQ_PRIO        1
+
+#define RTT_DEV             NRF_RTC0
+#define RTT_IRQ             RTC0_IRQn
+#define RTT_ISR             isr_rtc0
+#define RTT_MAX_VALUE       (0xffffff)
+#define RTT_FREQUENCY       (10)            /* in Hz */
+#define RTT_PRESCALER       (3275U)         /* run with 10 Hz */
+/** @} */
+
+/**
+ * @name Random Number Generator configuration
+ * @{
+ */
+#define RANDOM_NUMOF        (1U)
+/** @} */
+
+/**
+ * @name GPIO configuration
+ * @{
+ */
+#define GPIO_NUMOF          (16U)
+#define GPIO_0_EN           1
+#define GPIO_1_EN           1
+#define GPIO_2_EN           1
+#define GPIO_3_EN           1
+#define GPIO_4_EN           1
+#define GPIO_5_EN           1
+#define GPIO_6_EN           0 /* not usable */
+#define GPIO_7_EN           1
+#define GPIO_8_EN           1
+#define GPIO_9_EN           1
+#define GPIO_10_EN          1
+#define GPIO_11_EN          1
+#define GPIO_12_EN          1
+#define GPIO_13_EN          1
+#define GPIO_14_EN          1
+#define GPIO_15_EN          1
+#define GPIO_IRQ_PRIO       1
+
+/* GPIO pin configuration */
+#define GPIO_0_PIN          0
+#define GPIO_1_PIN          1
+#define GPIO_2_PIN          2
+#define GPIO_3_PIN          3
+#define GPIO_4_PIN          4
+#define GPIO_5_PIN          5
+#define GPIO_6_PIN          6 /* not usable */
+#define GPIO_7_PIN          7
+#define GPIO_8_PIN          8
+#define GPIO_9_PIN          9
+#define GPIO_10_PIN         10
+#define GPIO_11_PIN         11
+#define GPIO_12_PIN         12
+#define GPIO_13_PIN         13
+#define GPIO_14_PIN         14
+#define GPIO_15_PIN         15
+
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* __PERIPH_CONF_H */

--- a/examples/riot_and_cpp/Makefile
+++ b/examples/riot_and_cpp/Makefile
@@ -31,7 +31,7 @@ QUIET ?= 1
 BOARD_BLACKLIST := arduino-due avsextrem chronos mbed_lpc1768 msb-430h msba2 redbee-econotag \
                    telosb wsn430-v1_3b wsn430-v1_4 msb-430 pttu udoo qemu-i386 z1 stm32f0discovery \
                    stm32f3discovery stm32f4discovery pca10000 pca10005 iot-lab_M3 arduino-mega2560 \
-                   msbiot yunjia-nrf51822 samr21-xpro cc2538dk openmote spark-core
+                   msbiot yunjia-nrf51822 samr21-xpro cc2538dk openmote spark-core airfy-beacon
 
 # This example only works with native for now.
 # msb430-based boards: msp430-g++ is not provided in mspgcc.

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -2,7 +2,7 @@ APPLICATION = thread_cooperation
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_RAM := chronos msb-430 msb-430h mbed_lpc1768 redbee-econotag stm32f0discovery \
-                          pca10000 pca10005 yunjia-nrf51822 spark-core
+                          pca10000 pca10005 yunjia-nrf51822 spark-core airfy-beacon
 
 DISABLE_MODULE += auto_init
 


### PR DESCRIPTION
wiki page: https://github.com/RIOT-OS/RIOT/wiki/Board%3A-Airfy-Beacon

the following PRs increase the usability of the nrf51 platform in general:
- ~~for interrupt driven UART: https://github.com/RIOT-OS/RIOT/pull/1555~~
- for working timers: ~~https://github.com/RIOT-OS/RIOT/pull/1824~~ and https://github.com/RIOT-OS/RIOT/pull/1827
- for the radio: https://github.com/RIOT-OS/RIOT/pull/1537 (@hauke is working on a new implementation)

wishlist:
- proper _power modes_ are missing too (probably simple)
