### PR TITLE
rpl_udp: add non-routing hosts to example

### DIFF
--- a/examples/rpl_udp/rpl.c
+++ b/examples/rpl_udp/rpl.c
@@ -47,15 +47,18 @@ void rpl_udp_init(int argc, char **argv)
     uint8_t chan = RADIO_CHANNEL;
 
     if (argc != 2) {
-        printf("Usage: %s (r|n)\n", argv[0]);
+        printf("Usage: %s (r|n|h)\n", argv[0]);
         printf("\tr\tinitialize as root\n");
         printf("\tn\tinitialize as node router\n");
+        printf("\th\tinitialize as non-routing node (host-mode)\n");
         return;
     }
 
     char command = argv[1][0];
-    if ((command == 'n') || (command == 'r')) {
-        printf("INFO: Initialize as %s on address %d\n", ((command == 'n') ? "node" : "root"), id);
+    if ((command == 'n') || (command == 'r') || (command == 'h')) {
+        printf("INFO: Initialize as %srouting %s on address %d\n",
+               ((command == 'h') ? "non-" : ""),
+               (((command == 'n') || (command == 'h')) ? "node" : "root"), id);
 
         if (!id || (id > 255)) {
             printf("ERROR: address not a valid 8 bit integer\n");
@@ -65,22 +68,28 @@ void rpl_udp_init(int argc, char **argv)
         DEBUGF("Setting HW address to %u\n", id);
         net_if_set_hardware_address(0, id);
 
-        DEBUGF("Initializing RPL for interface 0\n");
-        uint8_t state = rpl_init(0);
+        if (command != 'h') {
+            DEBUGF("Initializing RPL for interface 0\n");
+            uint8_t state = rpl_init(0);
 
-        if (state != SIXLOWERROR_SUCCESS) {
-            printf("Error initializing RPL\n");
+            if (state != SIXLOWERROR_SUCCESS) {
+                printf("Error initializing RPL\n");
+            }
+            else {
+                puts("6LoWPAN and RPL initialized.");
+            }
+
+            if (command == 'r') {
+                rpl_init_root();
+                ipv6_iface_set_routing_provider(rpl_get_next_hop);
+                is_root = 1;
+            }
+            else {
+                ipv6_iface_set_routing_provider(rpl_get_next_hop);
+            }
         }
         else {
-            puts("6LoWPAN and RPL initialized.");
-        }
-
-        if (command == 'r') {
-            rpl_init_root();
-            is_root = 1;
-        }
-        else {
-            ipv6_iface_set_routing_provider(rpl_get_next_hop);
+            puts("6LoWPAN initialized.");
         }
 
         DEBUGF("Start monitor\n");
@@ -109,7 +118,9 @@ void rpl_udp_init(int argc, char **argv)
     ipv6_addr_set_by_eui64(&tmp, 0, &tmp);
     ipv6_net_if_add_addr(0, &tmp, NDP_ADDR_STATE_PREFERRED, 0, 0, 0);
 
-    ipv6_init_as_router();
+    if (command != 'h') {
+        ipv6_init_as_router();
+    }
 
     /* set channel to 10 */
     tcmd.transceivers = TRANSCEIVER;


### PR DESCRIPTION
Adds `h` parameter to `init` command which let the node initialize 6LoWPAN+IPv6 but not RPL.
