### PR TITLE
make: strip white space from application name

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -22,6 +22,7 @@ else
 endif
 
 BOARD := $(strip $(BOARD))
+APPLICATION := $(strip $(APPLICATION))
 
 # provide common external programs for `Makefile.include`s
 


### PR DESCRIPTION
Trailing white spaces in the application Makefile will cause the build
system to fail otherwise.
