### PR TITLE
make: optionally build with gcc's link time optimization

### DIFF
--- a/Makefile.cflags
+++ b/Makefile.cflags
@@ -41,3 +41,9 @@ endif
 
 # Unwanted flags for c++
 CXXUWFLAGS += -std=%
+
+ifeq ($(LTO),yes)
+  LTOFLAGS = -flto -ffat-lto-objects
+  CFLAGS += ${LTOFLAGS}
+  LINKFLAGS += ${LTOFLAGS}
+endif

--- a/cpu/stm32f1/startup.c
+++ b/cpu/stm32f1/startup.c
@@ -188,7 +188,7 @@ void isr_dma2_ch4_5(void)     __attribute__ ((weak, alias("dummy_handler")));
 
 
 /* interrupt vector table */
-__attribute__ ((section(".vectors")))
+__attribute__ ((section(".vectors"))) __attribute__((used))
 const void *interrupt_vector[] = {
     /* Stack pointer */
     (void*) (&_estack),             /* pointer to the top of the empty stack */


### PR DESCRIPTION
This commit enables building using link time optimization when
specifying "LTO=yes" in the application's Makefile (or compile with LTO=yes make ...).

Size comparisions:

|             | native w/o lto | native w lto | msba2 w/o lto | msba2 w lto |
|-------------|----------------|--------------|---------------|-------------|
| hello_world | 29814          | 24817        | 48332         | 43948       |
| default     |   71171        | 59282        | 118448        | 107108      |

Tested only with native and msba2.
On msba2, the syscalls needed __attribute__(used), causing default to use 16byte more in .text when not using LTO.