### PR TITLE
make: remove downloader "axel"

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -25,32 +25,25 @@ BOARD := $(strip $(BOARD))
 
 # provide common external programs for `Makefile.include`s
 
-ifeq (,$(AXEL))
-  ifeq (0,$(shell which axel 2>&1 > /dev/null ; echo $$?))
-    AXEL := $(shell which axel)
+ifeq (,$(and $(DOWNLOAD_TO_STDOUT),$(DOWNLOAD_TO_FILE)))
+  ifeq (,$(WGET))
+    ifeq (0,$(shell which wget 2>&1 > /dev/null ; echo $$?))
+      WGET := $(shell which wget)
+    endif
   endif
-endif
-ifeq (,$(WGET))
-  ifeq (0,$(shell which wget 2>&1 > /dev/null ; echo $$?))
-    WGET := $(shell which wget)
+  ifeq (,$(CURL))
+    ifeq (0,$(shell which curl 2>&1 > /dev/null ; echo $$?))
+      CURL := $(shell which curl)
+    endif
   endif
-endif
-ifeq (,$(CURL))
-  ifeq (0,$(shell which curl 2>&1 > /dev/null ; echo $$?))
-    CURL := $(shell which curl)
+  ifeq (,$(WGET)$(CURL))
+    $(error Neither wget nor curl is installed!)
   endif
-endif
-ifeq (,$(WGET)$(CURL))
-  $(error Neither wget nor curl is installed!)
-endif
 
-ifeq (,$(DOWNLOAD_TO_STDOUT))
-  DOWNLOAD_TO_STDOUT := $(if $(CURL),$(CURL) -s,$(WGET) -q -O-)
-endif
-ifeq (,$(DOWNLOAD_TO_FILE))
-  ifneq (,$(AXEL))
-    DOWNLOAD_TO_FILE := $(AXEL) -n 4 -q -a -o
-  else
+  ifeq (,$(DOWNLOAD_TO_STDOUT))
+    DOWNLOAD_TO_STDOUT := $(if $(CURL),$(CURL) -s,$(WGET) -q -O-)
+  endif
+  ifeq (,$(DOWNLOAD_TO_FILE))
     DOWNLOAD_TO_FILE := $(if $(WGET),$(WGET) -nv -c -O,$(CURL) -s -o)
   endif
 endif


### PR DESCRIPTION
~~Brakes~~ Breaks for `make -B`. If the file already exists, then `axel` fails
because it does not find the status file for the download.
