### PR TITLE
cpu/cc2538: Enable the CC2538's more compact alternate interrupt mapping.

### DIFF
--- a/cpu/cc2538/cpu.c
+++ b/cpu/cc2538/cpu.c
@@ -42,6 +42,9 @@ void cpu_init(void)
     /* configure the vector table location to internal flash */
     SCB->VTOR = FLASH_BASE;
 
+    /* Enable the CC2538's more compact alternate interrupt mapping */
+    SYS_CTRL->I_MAP = 1;
+
     /* initialize the clock system */
     cpu_clock_init();
 


### PR DESCRIPTION
RIOT has been using the alternate interrupt mapping in its vector table since 24ac5a7 but the MCU is still expecting the normal mapping, which causes hard faults whenever a higher-numbered interrupt is generated (e.g. sleep timer or radio). This PR tells the MCU to use the new alternate mapping.
