### PR TITLE
cpu/stm32f1: fixes for the cpuid driver

### DIFF
--- a/boards/iot-lab_M3/Makefile.features
+++ b/boards/iot-lab_M3/Makefile.features
@@ -1,1 +1,1 @@
-FEATURES_PROVIDED += transceiver periph_gpio periph_uart periph_spi periph_i2c periph_rtt
+FEATURES_PROVIDED += transceiver periph_gpio periph_uart periph_spi periph_i2c periph_rtt periph_cpuid

--- a/cpu/stm32f1/include/cpu-conf.h
+++ b/cpu/stm32f1/include/cpu-conf.h
@@ -54,7 +54,7 @@
 /**
  * @name Length for reading CPU_ID
  */
-#define CPU_ID_LEN                      (12)
+#define CPUID_ID_LEN                    (12)
 
 /**
  * @name Definition of different panic modes

--- a/cpu/stm32f1/periph/cpuid.c
+++ b/cpu/stm32f1/periph/cpuid.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @file        cpuid.c
- * @brief       Implementation
+ * @brief       Low-level CPUID driver implementation
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  */
@@ -23,7 +23,7 @@
 
 void cpuid_get(void *id)
 {
-    memcpy(id, (void *)(0x1ffff7e8), CPU_ID_LEN);
+    memcpy(id, (void *)(0x1ffff7e8), CPUID_ID_LEN);
 }
 
 /** @} */


### PR DESCRIPTION
Fixes to the stm32f1 cpuid driver.
