### PR TITLE
tests/hwtimer: made hwtimer easier to understand

### DIFF
--- a/tests/hwtimer/main.c
+++ b/tests/hwtimer/main.c
@@ -16,6 +16,7 @@
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
  * @}
  */
@@ -25,10 +26,10 @@
 #include "hwtimer.h"
 #include "thread.h"
 
-#define BASE_DELAY (1000UL * 1000UL)
-#define DELTA_DELAY (10UL * 1000UL)
-#define MSGLEN 12 // == strlen("callback %2i")
-char msg[MSGLEN * HWTIMER_MAXTIMERS]; // == [callback  1\0callback  2\0...]
+#define DELAY           (1000UL * 1000UL)           /* 1 second delay */
+#define MSGLEN          (12U)                       /* == strlen("callback %2i") */
+
+static char msg[MSGLEN * HWTIMER_MAXTIMERS];        /* == [callback  1\0callback  2\0...] */
 
 void callback(void *ptr)
 {
@@ -37,42 +38,34 @@ void callback(void *ptr)
 
 int main(void)
 {
-    puts("hwtimer test application...");
-
-    puts("");
-    puts("  Timers should print \"callback x\" once when they run out.");
-    printf("  The order for x is 1, n-1, n-2, ..., 2 where n is the number of available hardware timers (%u on this platform).\n", HWTIMER_MAXTIMERS);
-    puts("  In 1 second, one timer should fire every second/100 until all timers have run out.");
-    puts("  Additionally the message \"hwtimer set.\" should be printed once 1 second from now.");
-    puts("");
-    puts("Setting timers:");
-    puts("");
-
-    unsigned long delay = BASE_DELAY + ((HWTIMER_MAXTIMERS - 1) * DELTA_DELAY);
-
-    /* make the first timer first to fire so timers do not run out linearly */
     char *msgn = msg;
-    snprintf(msgn, MSGLEN, "callback %2x", 1);
-    hwtimer_set(HWTIMER_TICKS(BASE_DELAY), callback, (void *) msgn);
-    printf("set %s\n", msgn);
 
-    /* set up to HWTIMER_MAXTIMERS-1 because hwtimer_wait below also
-     * needs a timer */
-    for (int i = 1; i < (HWTIMER_MAXTIMERS - 1); i++) {
+    puts("\nhwtimer test application...\n");
+
+    puts("This test will set all available channels of the hardware timer concurrently. Each");
+    puts("channel will time out 1 second after the previous one.\n");
+    puts("NOTE: this test assumes, that your hwtimer can cope with delays in the magnitude of");
+    puts("      some seconds.\n");
+    puts("On timeout, each channel will print \"callback xx\", you should see the following");
+    puts("sequence:");
+    puts("  callback  n");
+    puts("  callback  1");
+    puts("  callback  2");
+    puts("  ...");
+    puts("  callback  n-1");
+    printf("where n equals %i on your platform\n\n\n", HWTIMER_MAXTIMERS);
+
+    puts("Setting timers:");
+    for (int i = 1; i < HWTIMER_MAXTIMERS; i++) {
+        printf("  Timer %2i set\n", i);
+        snprintf(msgn, MSGLEN, "callback %2x", i);
+        hwtimer_set((i + 1) * DELAY, callback, (void*)msgn);
         msgn = msg + (i * MSGLEN);
-        delay -= DELTA_DELAY;
-        snprintf(msgn, MSGLEN, "callback %2x", i + 1);
-        hwtimer_set(HWTIMER_TICKS(delay), callback, (void *) msgn);
-        printf("set %s\n", msgn);
     }
 
-    puts("");
-    puts("All timers set.");
-    puts("");
+    printf("  Timer %2i set\n\n\n", HWTIMER_MAXTIMERS);
+    hwtimer_wait(HWTIMER_TICKS(DELAY));
+    printf("callback %2i\n", HWTIMER_MAXTIMERS);
 
-    hwtimer_wait(HWTIMER_TICKS(BASE_DELAY));
-
-    puts("hwtimer set.");
-    thread_sleep();
     return 0;
 }


### PR DESCRIPTION
I recently discovered that some boards don't work with the `tests/hwtimer` application anymore - but it turned out that the application had changed... By looking at the test I thought it might be a good idea to do a little clean-up... Voila!
