### PR TITLE
core: Fix msg_send_receive

### DIFF
--- a/core/msg.c
+++ b/core/msg.c
@@ -146,9 +146,8 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block, unsigned sta
         *target_message = *m;
         sched_set_status(target, STATUS_PENDING);
 
-        uint16_t target_prio = target->priority;
         restoreIRQ(state);
-        sched_switch(target_prio);
+        thread_yield_higher();
     }
 
     return 1;


### PR DESCRIPTION
Fixes #1935

It reverts `_msg_send()` to yielding if target is receive-blocked (as originally superseded in 677d690). This way, the context switch previously disabled in #1836 happens again and `msg_send_receive()` is usable again.
