### PR TITLE
shell: provide shell commands to poll lsm303dlhc sensor

### DIFF
--- a/boards/iot-lab_M3/include/board.h
+++ b/boards/iot-lab_M3/include/board.h
@@ -111,8 +111,8 @@ extern "C" {
  * @{
  */
 #define LSM303DLHC_I2C      I2C_0
-#define LSM303DLHC_ACC_ADDR (25)
-#define LSM303DLHC_MAG_ADDR (30)
+#define LSM303DLHC_ACC_ADDR (0x19)
+#define LSM303DLHC_MAG_ADDR (0x1e)
 #define LSM303DLHC_INT1     GPIO_5
 #define LSM303DLHC_INT2     GPIO_6
 #define LSM303DLHC_DRDY     GPIO_7

--- a/drivers/include/lsm303dlhc.h
+++ b/drivers/include/lsm303dlhc.h
@@ -51,6 +51,8 @@ typedef struct {
     i2c_t i2c;              /**< I2C device                  */
     uint8_t acc_address;    /**< accelerometer's I2C address */
     uint8_t mag_address;    /**< magnetometer's I2C address  */
+    gpio_t  acc_pin;        /**< accelerometer's data ready pin */
+    gpio_t  mag_pin;        /**< magnetometer's data ready pin  */
 } lsm303dlhc_t;
 
 /**

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -59,6 +59,7 @@ ifneq (,$(filter iot-lab_M3,$(BOARD)))
 	USEMODULE += isl29020
 	USEMODULE += lps331ap
 	USEMODULE += l3g4200d
+	USEMODULE += lsm303dlhc
 endif
 
 include $(RIOTBASE)/Makefile.include

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -52,5 +52,8 @@ endif
 ifneq (,$(filter l3g4200d,$(USEMODULE)))
 	SRC += sc_l3g4200d.c
 endif
+ifneq (,$(filter lsm303dlhc,$(USEMODULE)))
+	SRC += sc_lsm303dlhc.c
+endif
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/shell/commands/sc_lsm303dlhc.c
+++ b/sys/shell/commands/sc_lsm303dlhc.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup shell_commands
+ * @{
+ *
+ * @file
+ * @brief       provides shell commands to poll lsm303dlhc sensor
+ *
+ * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include "board.h"
+#include "lsm303dlhc.h"
+
+#ifdef MODULE_LSM303DLHC
+
+#define ACC_S_RATE  LSM303DLHC_ACC_SAMPLE_RATE_10HZ
+#define ACC_SCALE   LSM303DLHC_ACC_SCALE_2G
+#define MAG_S_RATE  LSM303DLHC_MAG_SAMPLE_RATE_75HZ
+#define MAG_GAIN    LSM303DLHC_MAG_GAIN_400_355_GAUSS
+
+static lsm303dlhc_t lsm303_dev;
+
+void _get_lsm303dlhc_init_handler(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    uint8_t error;
+
+    error = lsm303dlhc_init(&lsm303_dev, LSM303DLHC_I2C,
+                            LSM303DLHC_INT1, LSM303DLHC_DRDY,
+                            LSM303DLHC_ACC_ADDR, ACC_S_RATE, ACC_SCALE,
+                            LSM303DLHC_MAG_ADDR, MAG_S_RATE, MAG_GAIN);
+
+    if (error) {
+        puts("Error initializing lsm303dlhc sensor.");
+    }
+    else {
+        puts("Initialized lsm303dlhc sensor with default values");
+    }
+}
+
+void _get_lsm303dlhc_read_handler(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    uint8_t error;
+    lsm303dlhc_3d_data_t data;
+
+    if (!lsm303_dev.acc_address || !lsm303_dev.mag_address) {
+        puts("Error: please call `lsm303dlhc_init` first!");
+        return;
+    }
+
+    error = lsm303dlhc_read_acc(&lsm303_dev, &data);
+    if (error) {
+        puts("Error reading accelerometer data from lsm303dlhc.");
+        return;
+    }
+    else {
+        printf("lsm303dlhc: Accelerometer {%i, %i, %i} mg\n", data.x_axis, data.y_axis, data.z_axis);
+    }
+
+    error = lsm303dlhc_read_mag(&lsm303_dev, &data);
+    if (error) {
+        puts("Error reading magnetometer data from lsm303dlhc.");
+        return;
+    }
+    else {
+        printf("lsm303dlhc: Magnetometer {%i, %i, %i}/1100 gauss\n", data.x_axis, data.y_axis, data.z_axis);
+    }
+
+    error = lsm303dlhc_read_temp(&lsm303_dev, &(data.x_axis));
+    if (error) {
+        puts("Error reading temperature data from lsm303dlhc.");
+        return;
+    }
+    else {
+        printf("lsm303dlhc: Temperature %i\n", data.x_axis);
+    }
+}
+
+#endif /* MODULE_LSM303DLHC */

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -64,6 +64,11 @@ extern void _get_l3g4200d_init_handler(int argc, char **argv);
 extern void _get_l3g4200d_read_handler(int argc, char **argv);
 #endif
 
+#ifdef MODULE_LSM303DLHC
+extern void _get_lsm303dlhc_init_handler(int argc, char **argv);
+extern void _get_lsm303dlhc_read_handler(int argc, char **argv);
+#endif
+
 #ifdef MODULE_LTC4150
 extern void _get_current_handler(int argc, char **argv);
 extern void _reset_current_handler(int argc, char **argv);
@@ -171,6 +176,10 @@ const shell_command_t _shell_command_list[] = {
 #ifdef MODULE_L3G4200D
     {"l3g4200d_init", "Initializes the l3g4200d sensor driver.", _get_l3g4200d_init_handler},
     {"l3g4200d_read", "Prints data from the l3g4200d sensor.", _get_l3g4200d_read_handler},
+#endif
+#ifdef MODULE_LSM303DLHC
+    {"lsm303dlhc_init", "Initializes the lsm303dlhc sensor driver.", _get_lsm303dlhc_init_handler},
+    {"lsm303dlhc_read", "Prints data from the lsm303dlhc sensor.", _get_lsm303dlhc_read_handler},
 #endif
 #ifdef MODULE_LTC4150
     {"cur", "Prints current and average power consumption.", _get_current_handler},


### PR DESCRIPTION
Introduces shell commands `lsm303dlhc_init` and `lsm303dlhc_read` to interact with the lsm303dlhc driver.
