### PR TITLE
shell: sensors: exit on failure

### DIFF
--- a/sys/shell/commands/sc_isl29020.c
+++ b/sys/shell/commands/sc_isl29020.c
@@ -56,6 +56,7 @@ void _get_isl29020_read_handler(int argc, char **argv)
 
     if (!isl29020_dev.address) {
         puts("Error: please call `isl29020_init` first!");
+        return;
     }
 
     val = isl29020_read(&isl29020_dev);

--- a/sys/shell/commands/sc_l3g4200d.c
+++ b/sys/shell/commands/sc_l3g4200d.c
@@ -57,6 +57,7 @@ void _get_l3g4200d_read_handler(int argc, char **argv)
 
     if (!l3g4200d_dev.addr) {
         puts("Error: please call `l3g4200d_init` first!");
+        return;
     }
 
     res = l3g4200d_read(&l3g4200d_dev, &data);

--- a/sys/shell/commands/sc_lps331ap.c
+++ b/sys/shell/commands/sc_lps331ap.c
@@ -54,6 +54,7 @@ void _get_lps331ap_read_handler(int argc, char **argv)
 
     if (!lps331ap_dev.address) {
         puts("Error: please call `lps331ap_init` first!");
+        return;
     }
 
     temp = lps331ap_read_temp(&lps331ap_dev);


### PR DESCRIPTION
Immediately leave the read command if sensor is not initialized.

Otherwise the board just hangs after the error message.
