### PR TITLE
cpu: adjusted IRQ stack sizes for Cortex CPUs

### DIFF
--- a/cpu/cc2538/cc2538_linkerscript.ld
+++ b/cpu/cc2538/cc2538_linkerscript.ld
@@ -31,8 +31,10 @@ OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
 OUTPUT_ARCH(arm)
 SEARCH_DIR(.)
 
-/* The stack size used by the application. NOTE: you need to adjust  */
-STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 2K ;
+/* Define the default stack size for interrupt mode. As no context is
+   saved on this stack and ISRs are supposed to be short, it can be fairly
+   small. 512 byte should be a save assumption here */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x200; /* 512 byte */
 
 /* Section Definitions */
 SECTIONS

--- a/cpu/sam3x8e/sam3x8e_linkerscript.ld
+++ b/cpu/sam3x8e/sam3x8e_linkerscript.ld
@@ -40,8 +40,10 @@ MEMORY
     ram (rwx)   : ORIGIN = 0x20070000, LENGTH = 0x00018000 /* sram, 96K */
 }
 
-/* The stack size used by the application. NOTE: you need to adjust  */
-STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x2000 ;
+/* Define the default stack size for interrupt mode. As no context is
+   saved on this stack and ISRs are supposed to be short, it can be fairly
+   small. 512 byte should be a save assumption here */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x200; /* 512 byte */
 
 /* Section Definitions */
 SECTIONS

--- a/cpu/samd21/samd21_linkerscript.ld
+++ b/cpu/samd21/samd21_linkerscript.ld
@@ -38,8 +38,10 @@ MEMORY
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 0x00008000  /* RAM, 32K    */
 }
 
-/* The stack size used by the application. NOTE: you need to adjust  */
-STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x2000 ;
+/* Define the default stack size for interrupt mode. As no context is
+   saved on this stack and ISRs are supposed to be short, it can be fairly
+   small. 512 byte should be a save assumption here */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x200; /* 512 byte */
 
 /* Section Definitions */
 SECTIONS

--- a/cpu/stm32f0/stm32f051r8_linkerscript.ld
+++ b/cpu/stm32f0/stm32f051r8_linkerscript.ld
@@ -38,8 +38,10 @@ MEMORY
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 8K
 }
 
-/* The stack size used by the application. NOTE: you need to adjust  */
-STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0xa00 ;
+/* Define the default stack size for interrupt mode. As no context is
+   saved on this stack and ISRs are supposed to be short, it can be fairly
+   small. 512 byte should be a save assumption here */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x200; /* 512 byte */
 
 /* Section Definitions */
 SECTIONS

--- a/cpu/stm32f1/stm32f103cb_linkerscript.ld
+++ b/cpu/stm32f1/stm32f103cb_linkerscript.ld
@@ -38,8 +38,10 @@ MEMORY
     ram (xrw)       : ORIGIN = 0x20000000, LENGTH = 20K
 }
 
-/* The stack size used by the application. NOTE: you need to adjust  */
-STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x200 ;
+/* Define the default stack size for interrupt mode. As no context is
+   saved on this stack and ISRs are supposed to be short, it can be fairly
+   small. 512 byte should be a save assumption here */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x200; /* 512 byte */
 
 /* Section Definitions */
 SECTIONS

--- a/cpu/stm32f1/stm32f103re_linkerscript.ld
+++ b/cpu/stm32f1/stm32f103re_linkerscript.ld
@@ -38,8 +38,10 @@ MEMORY
     ram (xrw)       : ORIGIN = 0x20000000, LENGTH = 64K
 }
 
-/* The stack size used by the application. NOTE: you need to adjust  */
-STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x200 ;
+/* Define the default stack size for interrupt mode. As no context is
+   saved on this stack and ISRs are supposed to be short, it can be fairly
+   small. 512 byte should be a save assumption here */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x200; /* 512 byte */
 
 /* Section Definitions */
 SECTIONS

--- a/cpu/stm32f3/stm32f303vc_linkerscript.ld
+++ b/cpu/stm32f3/stm32f303vc_linkerscript.ld
@@ -39,8 +39,10 @@ MEMORY
     ccmram (rwx): ORIGIN = 0x10000000, LENGTH = 8K
 }
 
-/* The stack size used by the application. NOTE: you need to adjust  */
-STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0xa00; /* 2.5K */
+/* Define the default stack size for interrupt mode. As no context is
+   saved on this stack and ISRs are supposed to be short, it can be fairly
+   small. 512 byte should be a save assumption here */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x200; /* 512 byte */
 
 /* Section Definitions */
 SECTIONS

--- a/cpu/stm32f4/stm32f407vg_linkerscript.ld
+++ b/cpu/stm32f4/stm32f407vg_linkerscript.ld
@@ -39,8 +39,10 @@ MEMORY
     ccmram (rwx): ORIGIN = 0x10000000, LENGTH = 64K
 }
 
-/* The stack size used by the application. NOTE: you need to adjust  */
-STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x2000 ;
+/* Define the default stack size for interrupt mode. As no context is
+   saved on this stack and ISRs are supposed to be short, it can be fairly
+   small. 512 byte should be a save assumption here */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x200; /* 512 byte */
 
 
 /* Section Definitions */

--- a/cpu/stm32f4/stm32f415rg_linkerscript.ld
+++ b/cpu/stm32f4/stm32f415rg_linkerscript.ld
@@ -39,8 +39,10 @@ MEMORY
     ccmram (rwx): ORIGIN = 0x10000000, LENGTH = 64K
 }
 
-/* The stack size used by the application. NOTE: you need to adjust  */
-STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x2000 ;
+/* Define the default stack size for interrupt mode. As no context is
+   saved on this stack and ISRs are supposed to be short, it can be fairly
+   small. 512 byte should be a save assumption here */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x200; /* 512 byte */
 
 
 /* Section Definitions */


### PR DESCRIPTION
By comparing the Cortex-based CPUs, I found that the exception stack sizes were defined quite differently. As the stack is only used on startup and when in interrupt context, it does not need to hold any context etc. So 512 byte should be quite sufficient, even in worst case scenarios. (And that is the value used on the iot-lab_M3, which we tested quite a bit...)
