### PR TITLE
transceiver: netapi adapter

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -112,6 +112,10 @@ ifneq (,$(filter netdev_802154,$(USEMODULE)))
 	USEMODULE += netdev_base
 endif
 
+ifneq (,$(filter pktbuf,$(USEMODULE)))
+	USEMODULE += pkt
+endif
+
 ifneq (,$(filter rgbled,$(USEMODULE)))
 	USEMODULE += color
 endif

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -108,6 +108,10 @@ ifneq (,$(filter ccn_lite,$(USEMODULE)))
 	USEMODULE += crypto
 endif
 
+ifneq (,$(filter netapi,$(USEMODULE)))
+	USEMODULE += pkt
+endif
+
 ifneq (,$(filter netdev_802154,$(USEMODULE)))
 	USEMODULE += netdev_base
 endif

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -108,6 +108,10 @@ ifneq (,$(filter ccn_lite,$(USEMODULE)))
 	USEMODULE += crypto
 endif
 
+ifneq (,$(filter nomac,$(USEMODULE)))
+	USEMODULE += pktbuf
+endif
+
 ifneq (,$(filter netapi,$(USEMODULE)))
 	USEMODULE += pkt
 endif

--- a/sys/include/transceiver.h
+++ b/sys/include/transceiver.h
@@ -172,6 +172,7 @@ extern "C" {
 #define TRANSCEIVER_MC1322X     (0x08)      /**< MC1322X transceivers */
 #define TRANSCEIVER_NATIVE      (0x10)      /**< NATIVE transceivers */
 #define TRANSCEIVER_AT86RF231   (0x20)      /**< AT86RF231 transceivers */
+#define TRANSCEIVER_NETAPI      (0x30)      /**< netapi compatible L* layers */
 /**
  * @}
  */
@@ -188,6 +189,10 @@ typedef uint64_t transceiver_eui64_t;
 
 /**
  * @brief Message types for transceiver interface
+ *
+ * @note    **ATTENTION:** Packages received from a netapi layer are neither
+ *          of type radio_packet_t nor ieee802154_packet_t as they normally are
+ *          (depending on the radio), but netapi_pkt_t!
  */
 enum transceiver_msg_type_t {
     /* Message types for driver <-> transceiver communication */

--- a/sys/net/crosslayer/netapi/netapi.c
+++ b/sys/net/crosslayer/netapi/netapi.c
@@ -58,20 +58,18 @@ int netapi_send_command(kernel_pid_t pid, netapi_cmd_t *cmd)
     return ack_result;
 }
 
-int netapi_send_packet(kernel_pid_t pid, netdev_hlist_t *upper_layer_hdrs,
-                       void *addr, size_t addr_len, void *data, size_t data_len)
+int netapi_send_packet(kernel_pid_t pid, void *dest, size_t dest_len,
+                       pkt_t *pkt)
 {
-    netapi_snd_pkt_t pkt;
+    netapi_pkt_t cmd;
 
-    pkt.type = NETAPI_CMD_SND;
+    cmd.type = NETAPI_CMD_SND;
 
-    pkt.ulh = upper_layer_hdrs;
-    pkt.dest = addr;
-    pkt.dest_len = addr_len;
-    pkt.data = data;
-    pkt.data_len = data_len;
+    cmd.dest = dest;
+    cmd.dest_len = dest_len;
+    cmd.pkt = pkt;
 
-    return netapi_send_command(pid, (netapi_cmd_t *)(&pkt));
+    return netapi_send_command(pid, (netapi_cmd_t *)(&cmd));
 }
 
 static unsigned int _get_set_option(kernel_pid_t pid, netapi_cmd_type_t type,
@@ -125,21 +123,19 @@ int netapi_unregister(kernel_pid_t pid, kernel_pid_t reg_pid)
 
 #ifdef MODULE_NETDEV_DUMMY
 int netapi_fire_receive_event(kernel_pid_t pid, void *src, size_t src_len,
-                              void *dest, size_t dest_len, void *data,
-                              size_t data_len)
+                              void *dest, size_t dest_len, pkt_t *pkt)
 {
-    netapi_rcv_pkt_t pkt;
+    netapi_pkt_t cmd;
 
-    pkt.type = NETAPI_CMD_FIRE_RCV;
+    cmd.type = NETAPI_CMD_FIRE_RCV;
 
-    pkt.src = src;
-    pkt.src_len = src_len;
-    pkt.dest = dest;
-    pkt.dest_len = dest_len;
-    pkt.data = data;
-    pkt.data_len = data_len;
+    cmd.src = src;
+    cmd.src_len = src_len;
+    cmd.dest = dest;
+    cmd.dest_len = dest_len;
+    cmd.pkt = pkt;
 
-    return netapi_send_command(pid, (netapi_cmd_t *)(&pkt));
+    return netapi_send_command(pid, (netapi_cmd_t *)(&cmd));
 }
 #endif
 /**

--- a/sys/net/include/pktbuf.h
+++ b/sys/net/include/pktbuf.h
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 
 #include "cpu-conf.h"
+#include "pkt.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -52,68 +53,98 @@ extern "C" {
  *
  * @see @ref pktbuf_hold()
  *
- * @param[in] size  The length of the packet you want to allocate
+ * @param[in] payload_len   The length of the packet you want to allocate.
  *
- * @return  Pointer to the start of the data in the packet buffer, on success.
+ * @return  Pointer to the packet in the packet buffer, on success.
  * @return  NULL, if no space is left in the packet buffer or size was 0.
  */
-void *pktbuf_alloc(size_t size);
+pkt_t *pktbuf_alloc(pktsize_t payload_len);
 
 /**
- * @brief   Reallocates new space in the packet buffer, without changing the
- *          content.
+ * @brief   Reallocates payload of packet in the packet buffer, without changing
+ *          the content.
  *
- * @details If enough memory is available behind it or *size* is smaller than
- *          the original size the packet will not be moved. Otherwise, it will
- *          be moved. If no space is available nothing happens.
+ * @details If enough memory is available behind it or @p size is smaller than
+ *          the original size the packet and payload will not be moved.
+ *          Otherwise, it will be moved. If no space is available nothing
+ *          happens. If @p pkt is not in the packet buffer it will be copied
+ *          into it with pkt_t::payload_len == size.
  *
- * @param[in] pkt   Old position of the packet in the packet buffer
- * @param[in] size  New amount of data you want to allocate
+ * @param[in] pkt           A packet.
+ * @param[in] payload_len   The new payload length for @p pkt.
  *
- * @return  Pointer to the (maybe new) position of the packet in the packet buffer,
- *          on success.
+ * @return  New position of @p pkt, on success.
  * @return  NULL, if no space is left in the packet buffer or size was 0.
- *          The packet will remain at *ptr*.
+ *          The payload will remain where it was.
  */
-void *pktbuf_realloc(const void *pkt, size_t size);
+pkt_t *pktbuf_realloc_payload(const pkt_t *pkt, pktsize_t payload_len);
 
 /**
- * @brief   Allocates and copies new packet data into the packet buffer.
+ * @brief   Allocates new packet in the packet buffer and copies data into it.
  *          This also marks the allocated data as processed for the current
  *          thread.
  *
  * @see @ref pktbuf_hold()
  *
- * @param[in] data  Data you want to copy into the new packet.
- * @param[in] size  The length of the packet you want to allocate
+ * @param[in] payload_data  Payload data you want to copy into the new packet.
+ * @param[in] payload_len   The length of the packet you want to allocate.
  *
- * @return  Pointer to the start of the data in the packet buffer, on success.
+ * @return  Pointer to the packet in the packet buffer, on success.
  * @return  NULL, if no space is left in the packet buffer.
  */
-void *pktbuf_insert(const void *data, size_t size);
+pkt_t *pktbuf_insert(const void *payload_data, pktsize_t payload_len);
 
 /**
- * @brief   Copies packet data into the packet buffer, safely.
+ * @brief   Copies packet payload or header data into the packet buffer, safely.
  *
  * @details Use this instead of memcpy, since it is thread-safe and checks if
- *          *pkt* is
+ *          @p data is
  *
  *          -# in the buffer at all
- *          -# its *size* is smaller or equal to the data allocated at *pkt*
+ *          -# its @p new_data is smaller or equal to the data allocated at
+ *             @p new_data
  *
- *          If the *pkt* is not in the buffer the data is just copied as
+ *          It also uses the thread-safe abilities of the packet buffer.
+ *
+ *          If the @p data is not in the buffer the data is just copied as
  *          memcpy would do.
  *
- * @param[in,out] pkt   The packet you want to set the data for.
- * @param[in] data      The data you want to copy into the packet.
- * @param[in] data_len  The length of the data you want to copy.
+ * @param[in,out] data      Some payload or header data pointer in the packet
+ *                          buffer.
+ * @param[in] new_data      The data you want to copy into the packet.
+ * @param[in] new_data_len  The length of the data you want to copy.
  *
- * @return  *data_len*, on success.
- * @return  -EFAULT, if *data* is NULL and DEVELHELP is defined.
- * @return  -EINVAL, if *pkt* is NULL and DEVELHELP is defined.
- * @return  -ENOBUFS, if *data_len* was greater than the packet size of *pkt*.
+ * @return  @p new_data_len, on success.
+ * @return  -EFAULT, if @p data is NULL and DEVELHELP is defined.
+ * @return  -EINVAL, if @p data is NULL and DEVELHELP is defined.
+ * @return  -EINVAL, if @p data is not a pointer to payload data in packet buffer.
+ * @return  -ENOMEM, if @p data_len was greater than the packet size of @p data.
  */
-int pktbuf_copy(void *pkt, const void *data, size_t data_len);
+int pktbuf_copy(void *data, const void *new_data, pktsize_t new_data_len);
+
+/**
+ * @brief   Adds a header to the packet and allocates it in packet buffer.
+ *
+ * @param[in] pkt           The packet to add the new header to
+ * @param[in] header_data   The data of the header
+ * @param[in] header_len    The length of the header
+ *
+ * @return  0, on success
+ * @return  -EFAULT, if @p header_data is NULL and DEVELHELP is defined.
+ * @return  -EINVAL, if @p pkt is NULL and DEVELHELP is defined.
+ * @return  -EINVAL, if @p pkt not a packet in packet buffer.
+ * @return  -ENOMEM, if no space is left in the packet buffer or @p header_len was 0.
+ */
+int pktbuf_add_header(pkt_t *pkt, void *header_data, pktsize_t header_len);
+
+/**
+ * @brief   Removes a header from the packet and releases it in the packet
+ *          buffer.
+ *
+ * @param[in] pkt           The packet to add the new header to
+ * @param[in] header        The header to remove.
+ */
+void pktbuf_remove_header(pkt_t *pkt, pkt_hlist_t *header);
 
 /**
  * @brief   Marks the data as being processed.
@@ -124,7 +155,7 @@ int pktbuf_copy(void *pkt, const void *data, size_t data_len);
  *
  * @param[in] pkt   The packet you want mark as being processed.
  */
-void pktbuf_hold(const void *pkt);
+void pktbuf_hold(const pkt_t *pkt);
 
 /**
  * @brief   Marks the data as not being processed.
@@ -136,7 +167,30 @@ void pktbuf_hold(const void *pkt);
  *          operation initializes it. If the counter is <=0 the reserved data
  *          block in the buffer will be made available again.
  */
-void pktbuf_release(const void *pkt);
+void pktbuf_release(const pkt_t *pkt);
+
+/**
+ * @brief   Checks if a given pointer is stored in the packet buffer
+ *
+ * @param[in] ptr   Pointer to be checked
+ *
+ * @return  1, if @p ptr is in packet buffer
+ * @return  0, otherwise
+ */
+int pktbuf_contains(const void *ptr);
+
+/**
+ * @brief   Checks if a given packet is stored in the packet buffer
+ *
+ * @param[in] pkt   Packet to be checked
+ *
+ * @return  1, if @p pkt is in packet buffer
+ * @return  0, otherwise
+ */
+static inline int pktbuf_contains_pkt(const pkt_t *pkt)
+{
+    return pktbuf_contains(pkt);
+}
 
 /**
  * @brief   Prints current packet buffer to stdout if DEVELHELP is defined.
@@ -154,14 +208,14 @@ void pktbuf_print(void);
  *
  * @return  Number of allocated bytes
  */
-size_t pktbuf_bytes_allocated(void);
+pktsize_t pktbuf_bytes_allocated(void);
 
 /**
  * @brief   Counts the number of allocated packets
  *
  * @return  Number of allocated packets
  */
-size_t pktbuf_packets_allocated(void);
+unsigned int pktbuf_packets_allocated(void);
 
 /**
  * @brief   Checks if packet buffer is empty
@@ -170,16 +224,6 @@ size_t pktbuf_packets_allocated(void);
  * @return  0, if packet buffer is not empty
  */
 int pktbuf_is_empty(void);
-
-/**
- * @brief   Checks if a given pointer is stored in the packet buffer
- *
- * @param[in] pkt   Pointer to be checked
- *
- * @return  1, if *pkt* is in packet buffer
- * @return  0, otherwise
- */
-int pktbuf_contains(const void *pkt);
 
 /**
  * @brief   Sets the whole packet buffer to 0

--- a/sys/transceiver/Makefile
+++ b/sys/transceiver/Makefile
@@ -1,13 +1,3 @@
-ifneq (,$(filter cc2420,$(USEMODULE)))
-	INCLUDES += -I$(RIOTBASE)/sys/net/include
-endif
-
-ifneq (,$(filter at86rf231,$(USEMODULE)))
-	INCLUDES += -I$(RIOTBASE)/sys/net/include
-endif
-
-ifneq (,$(filter mc1322x,$(USEMODULE)))
-	INCLUDES += -I$(RIOTBASE)/sys/net/include
-endif
+INCLUDES += -I$(RIOTBASE)/sys/net/include
 
 include $(RIOTBASE)/Makefile.base

--- a/tests/nativenet_netapi/Makefile
+++ b/tests/nativenet_netapi/Makefile
@@ -1,0 +1,23 @@
+APPLICATION = nativenet
+include ../Makefile.tests_common
+
+BOARD_WHITELIST := native
+
+USEMODULE += nativenet
+USEMODULE += transceiver
+USEMODULE += nomac
+
+INCLUDES += -I$(RIOTBASE)/sys/net/include
+CFLAGS += -DHAS_NETAPI_PID
+
+include $(RIOTBASE)/Makefile.include
+
+FORCE:
+	touch main.c
+
+sender: CFLAGS += -DSENDER
+sender: APPLICATION = nativenet_sender
+sender: FORCE all
+
+test:
+	./tests/01-tests.py

--- a/tests/nativenet_netapi/README.md
+++ b/tests/nativenet_netapi/README.md
@@ -1,0 +1,13 @@
+Tests transceiver module with nativenet through netapi
+=========================================================
+
+This test is equivalent to `tests/nativenet` in all but the fact that it uses
+the netapi transceiver adapter `TRANSCEIVER_NETAPI` instead of
+`TRANSCEIVER_NATIVENET`.
+
+To build the sender it *needs* to be build first. So to test this use
+
+```bash
+make clean sender
+make all test
+```

--- a/tests/nativenet_netapi/main.c
+++ b/tests/nativenet_netapi/main.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2013 INRIA
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief Nativenet test application
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+#include <time.h>
+
+#include "hwtimer.h"
+#include "board.h"
+#include "transceiver.h"
+#include "nativenet.h"
+#include "msg.h"
+#include "thread.h"
+#include "netdev/default.h"
+#include "nomac.h"
+
+#define SENDER_ADDR         (1)
+#define DEFAULT_RCV_ADDR    (2)
+
+#define PACKET_SIZE         (42)
+#define WAIT_TIME           (60)
+#define SECOND              (1000 * 1000)
+#define SENDING_DELAY       (10 * 1000)
+
+#define RCV_BUFFER_SIZE     (64)
+#define RADIO_STACK_SIZE    (KERNEL_CONF_STACKSIZE_DEFAULT)
+
+char radio_stack_buffer[RADIO_STACK_SIZE];
+char nomac_stack_buffer[RADIO_STACK_SIZE];
+msg_t msg_q[RCV_BUFFER_SIZE];
+uint8_t snd_buffer[NATIVE_MAX_DATA_LENGTH];
+uint8_t receiving = 1;
+unsigned int last_seq = 0, missed_cnt = 0;
+int first = -1;
+kernel_pid_t netapi_pid;
+
+void *radio(void *arg)
+{
+    (void) arg;
+
+    msg_t m;
+    radio_packet_t *p;
+    unsigned int tmp = 0, cur_seq = 0;
+
+    msg_init_queue(msg_q, RCV_BUFFER_SIZE);
+
+    puts("Start receiving");
+
+    while (receiving) {
+        msg_receive(&m);
+
+        if (m.type == PKT_PENDING) {
+            p = (radio_packet_t *) m.content.ptr;
+
+            if ((p->src == SENDER_ADDR) && (p->length == PACKET_SIZE)) {
+                puts("received");
+                cur_seq = (p->data[0] << 8) + p->data[1];
+
+                if (first < 0) {
+                    first = cur_seq;
+                }
+                else {
+                    tmp = cur_seq - last_seq;
+
+                    if (last_seq && (tmp > 1)) {
+                        missed_cnt += (tmp - 1);
+                    }
+                }
+
+                last_seq = cur_seq;
+            }
+            else {
+                printf("sender was %i\n", p->src);
+            }
+
+            p->processing--;
+        }
+        else if (m.type == ENOBUFFER) {
+            puts("Transceiver buffer full");
+        }
+        else {
+            puts("Unknown packet received");
+        }
+    }
+
+    return NULL;
+}
+
+void sender(void)
+{
+    unsigned int i = 0;
+    msg_t mesg;
+    transceiver_command_t tcmd;
+    radio_packet_t p;
+
+    mesg.type = SND_PKT;
+    mesg.content.ptr = (char *) &tcmd;
+
+    tcmd.transceivers = TRANSCEIVER_NETAPI;
+    tcmd.data = &p;
+
+    p.length = PACKET_SIZE;
+    p.dst = 0;
+
+    puts("Start sending packets");
+
+    while (1) {
+        /* filling uint8_t buffer with uint16_t sequence number */
+        snd_buffer[0] = (i & 0xFF00) >> 8;
+        snd_buffer[1] = i & 0x00FF;
+        p.data = snd_buffer;
+        i++;
+        msg_send(&mesg, transceiver_pid);
+        hwtimer_wait(HWTIMER_TICKS(SENDING_DELAY));
+    }
+}
+
+int main(void)
+{
+    int16_t a;
+    msg_t mesg;
+    transceiver_command_t tcmd;
+
+    netapi_pid = nomac_init(
+                     nomac_stack_buffer, sizeof(nomac_stack_buffer),
+                     PRIORITY_MAIN - 2, "nomac_native",
+                     (netdev_t *) &nativenet_default_dev);
+    printf("\n\tmain(): initializing transceiver\n");
+    transceiver_init(TRANSCEIVER_NETAPI);
+
+    printf("\n\tmain(): starting transceiver\n");
+    transceiver_start();
+
+#ifndef SENDER
+    printf("\n\tmain(): starting radio thread\n");
+    kernel_pid_t radio_pid = thread_create(
+                                 radio_stack_buffer, sizeof(radio_stack_buffer),
+                                 PRIORITY_MAIN - 2, CREATE_STACKTEST,
+                                 radio, NULL, "radio");
+    transceiver_register(TRANSCEIVER_NETAPI, radio_pid);
+#endif
+
+#ifdef SENDER
+    a = SENDER_ADDR;
+#elif defined ADDR
+    a = ADDR;
+#else
+    a = DEFAULT_RCV_ADDR;
+#endif
+    tcmd.transceivers = TRANSCEIVER_NETAPI;
+    tcmd.data = &a;
+    mesg.content.ptr = (char *) &tcmd;
+    mesg.type = SET_ADDRESS;
+
+    printf("[nativenet] trying to set address %" PRIi16 "\n", a);
+    msg_send_receive(&mesg, &mesg, transceiver_pid);
+
+#ifdef SENDER
+    hwtimer_wait(HWTIMER_TICKS(SECOND));
+    sender();
+#else
+    hwtimer_wait(HWTIMER_TICKS(WAIT_TIME * SECOND));
+    receiving = 0;
+    printf("Missed %u of %u packets after %u seconds\n", missed_cnt, (last_seq - first),  WAIT_TIME);
+#endif
+
+    return 0;
+}

--- a/tests/nativenet_netapi/tests/01-tests.py
+++ b/tests/nativenet_netapi/tests/01-tests.py
@@ -1,0 +1,44 @@
+#! /usr/bin/env python
+
+# Copyright (C) 2014 Martin Lenders <mlenders@inf.fu-berlin.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from pexpect import spawn
+
+if __name__ == "__main__":
+    try:
+        if len(sys.argv) > 1:
+            expected_received = int(sys.argv[1])
+        else:
+            expected_received = 5
+    except TypeError:
+        sys.stderr.write("Usage: "+str(sys.argv[0])+" [<expected 'received'>]\n")
+        sys.exit(1)
+
+    receiver = spawn("bin/native/nativenet.elf tap0")
+    sender = spawn("bin/native/nativenet_sender.elf tap1")
+
+
+    receiver.expect(r"main\(\): initializing transceiver")
+    receiver.expect(r"main\(\): starting transceiver")
+    receiver.expect(r"main\(\): starting radio thread")
+    receiver.expect("Start receiving")
+    receiver.expect(r"\[nativenet\] trying to set address \d+")
+
+    sender.expect(r"main\(\): initializing transceiver")
+    sender.expect(r"main\(\): starting transceiver")
+    sender.expect(r"\[nativenet\] trying to set address \d+")
+    sender.expect("Start sending packets")
+
+    while expected_received > 0:
+        receiver.expect("received")
+        expected_received -= 1
+
+    if not sender.terminate():
+        sender.terminate(force=True)
+    if not receiver.terminate():
+        receiver.terminate(force=True)

--- a/tests/unittests/tests-pktbuf/tests-pktbuf.c
+++ b/tests/unittests/tests-pktbuf/tests-pktbuf.c
@@ -53,120 +53,130 @@ static void test_pktbuf_alloc_memfull(void)
 
 static void test_pktbuf_alloc_success(void)
 {
-    void *data, *data_prev = NULL;
+    pkt_t *pkt, *pkt_prev = NULL;
 
     for (int i = 0; i < 9; i++) {
-        data = pktbuf_alloc((PKTBUF_SIZE / 10) + 4);
+        pkt = pktbuf_alloc((PKTBUF_SIZE / 10) + 4);
 
-        TEST_ASSERT(data_prev < data);
+        TEST_ASSERT_NOT_NULL(pkt);
 
-        data_prev = data;
+        if (pkt_prev != NULL) {
+            TEST_ASSERT(pkt_prev < pkt);
+            TEST_ASSERT(pkt_prev->payload_data < pkt->payload_data);
+        }
+
+        pkt_prev = pkt;
     }
 }
 
-static void test_pktbuf_realloc_0(void)
+static void test_pktbuf_realloc_payload_0(void)
 {
-    void *data = pktbuf_alloc(512);
+    pkt_t *pkt = pktbuf_alloc(512);
 
-    TEST_ASSERT_NULL(pktbuf_realloc(data, 0));
+    TEST_ASSERT_NULL(pktbuf_realloc_payload(pkt, 0));
 }
 
-static void test_pktbuf_realloc_memfull(void)
+static void test_pktbuf_realloc_payload_memfull(void)
 {
-    void *data = pktbuf_alloc(512);
+    pkt_t *pkt = pktbuf_alloc(512);
 
-    TEST_ASSERT_NULL(pktbuf_realloc(data, PKTBUF_SIZE + 1));
+    TEST_ASSERT_NULL(pktbuf_realloc_payload(pkt, PKTBUF_SIZE + 1));
 }
 
-static void test_pktbuf_realloc_memfull2(void)
+static void test_pktbuf_realloc_payload_memfull2(void)
 {
-    void *data = pktbuf_alloc(512);
+    pkt_t *pkt = pktbuf_alloc(512);
 
-    TEST_ASSERT_NOT_NULL(data);
+    TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(512));
-    TEST_ASSERT_NULL(pktbuf_realloc(data, PKTBUF_SIZE - 512));
+    TEST_ASSERT_NULL(pktbuf_realloc_payload(pkt, PKTBUF_SIZE - 512));
 }
 
-static void test_pktbuf_realloc_memfull3(void)
+static void test_pktbuf_realloc_payload_memfull3(void)
 {
-    void *data;
+    pkt_t *pkt;
 
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(25));
 
-    data = pktbuf_alloc(512);
+    pkt = pktbuf_alloc(512);
 
-    TEST_ASSERT_NOT_NULL(data);
+    TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(73));
 
-    TEST_ASSERT_NULL(pktbuf_realloc(data, PKTBUF_SIZE - 512));
+    TEST_ASSERT_NULL(pktbuf_realloc_payload(pkt, PKTBUF_SIZE - 512));
 }
 
-static void test_pktbuf_realloc_smaller(void)
+static void test_pktbuf_realloc_payload_smaller(void)
 {
-    void *data;
+    pkt_t *pkt;
 
-    data = pktbuf_alloc(512);
+    pkt = pktbuf_alloc(512);
 
-    TEST_ASSERT_NOT_NULL(data);
+    TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(25));
 
-    TEST_ASSERT(data == pktbuf_realloc(data, 128));
+    TEST_ASSERT(pkt == pktbuf_realloc_payload(pkt, 128));
 }
 
-static void test_pktbuf_realloc_memenough(void)
+static void test_pktbuf_realloc_payload_memenough(void)
 {
-    void *data;
+    pkt_t *pkt;
 
-    data = pktbuf_alloc(128);
+    pkt = pktbuf_alloc(128);
 
-    TEST_ASSERT_NOT_NULL(data);
+    TEST_ASSERT_NOT_NULL(pkt);
 
-    TEST_ASSERT(data == pktbuf_realloc(data, 200));
+    TEST_ASSERT(pkt == pktbuf_realloc_payload(pkt, 200));
 }
 
-static void test_pktbuf_realloc_memenough2(void)
+static void test_pktbuf_realloc_payload_memenough2(void)
 {
-    void *data, *data2;
+    pkt_t *pkt, *pkt2;
 
-    data = pktbuf_alloc(128);
+    pkt = pktbuf_alloc(128);
 
-    TEST_ASSERT_NOT_NULL(data);
+    TEST_ASSERT_NOT_NULL(pkt);
 
-    data2 = pktbuf_alloc(128);
+    pkt2 = pktbuf_alloc(128);
 
-    TEST_ASSERT_NOT_NULL(data);
+    TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(25));
 
-    pktbuf_release(data2);
+    pktbuf_release(pkt2);
 
-    TEST_ASSERT(data == pktbuf_realloc(data, 200));
+    TEST_ASSERT(pkt == pktbuf_realloc_payload(pkt, 200));
 }
 
-static void test_pktbuf_realloc_nomemenough(void)
+static void test_pktbuf_realloc_payload_nomemenough(void)
 {
-    void *data, *data2;
+    pkt_t *pkt, *pkt2;
 
-    data = pktbuf_alloc(128);
+    pkt = pktbuf_alloc(128);
 
-    TEST_ASSERT_NOT_NULL(data);
+    TEST_ASSERT_NOT_NULL(pkt);
 
-    data2 = pktbuf_alloc(128);
+    pkt2 = pktbuf_alloc(128);
 
-    TEST_ASSERT_NOT_NULL(data);
+    TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(25));
 
-    pktbuf_release(data2);
+    pktbuf_release(pkt2);
 
-    TEST_ASSERT(data != pktbuf_realloc(data, 512));
+    TEST_ASSERT(pkt != pktbuf_realloc_payload(pkt, 512));
 }
 
-static void test_pktbuf_realloc_unknown_ptr(void)
+static void test_pktbuf_realloc_payload_unknown_ptr(void)
 {
-    char *data = "abcd", *new_data = pktbuf_realloc(data, 5);
+    pkt_t pkt = { NULL, "abcd", 4, PKT_PROTO_UNKNOWN };
+    pkt_t *new_pkt = pktbuf_realloc_payload(&pkt, 5);
 
-    TEST_ASSERT_NOT_NULL(new_data);
-    TEST_ASSERT(data != new_data);
-    TEST_ASSERT_EQUAL_STRING(data, new_data);
+    TEST_ASSERT_NOT_NULL(new_pkt);
+    TEST_ASSERT_NOT_NULL(new_pkt->payload_data);
+    TEST_ASSERT(&pkt != new_pkt);
+    TEST_ASSERT(pkt.payload_data != new_pkt->payload_data);
+    TEST_ASSERT_EQUAL_STRING(pkt.payload_data, new_pkt->payload_data);
+    TEST_ASSERT_EQUAL_INT(4, pkt.payload_len);
+    TEST_ASSERT_EQUAL_INT(5, new_pkt->payload_len);
 }
 
 static void test_pktbuf_insert_size_0(void)
@@ -188,256 +198,401 @@ static void test_pktbuf_insert_memfull(void)
 
 static void test_pktbuf_insert_success(void)
 {
-    char *data, *data_prev = NULL;
+    pkt_t *pkt, *pkt_prev = NULL;
 
     for (int i = 0; i < 10; i++) {
-        data = (char *)pktbuf_insert("abc", 4);
+        pkt = pktbuf_insert("abc", 4);
 
-        TEST_ASSERT(data_prev < data);
-        TEST_ASSERT_EQUAL_STRING("abc", data);
+        TEST_ASSERT_NOT_NULL(pkt);
 
-        data_prev = data;
+        if (pkt_prev != NULL) {
+            TEST_ASSERT(pkt_prev < pkt);
+            TEST_ASSERT(pkt_prev->payload_data < pkt->payload_data);
+        }
+
+        TEST_ASSERT_EQUAL_STRING("abc", pkt->payload_data);
+        TEST_ASSERT_EQUAL_INT(4, pkt->payload_len);
+
+        pkt_prev = pkt;
     }
 }
 
 #ifdef DEVELHELP
+static void test_pktbuf_copy_einval(void)
+{
+    TEST_ASSERT_EQUAL_INT(-EINVAL, pktbuf_copy(NULL, "ab", 3));
+}
+
 static void test_pktbuf_copy_efault(void)
 {
-    char *data = (char *)pktbuf_insert("abcd", 5);
+    pkt_t *pkt = pktbuf_insert("abcd", 5);
 
-    TEST_ASSERT_NOT_NULL(data);
-    TEST_ASSERT_EQUAL_INT(-EFAULT, pktbuf_copy(data, NULL, 3));
-    TEST_ASSERT_EQUAL_STRING("abcd", data);
+    TEST_ASSERT_NOT_NULL(pkt);
+    TEST_ASSERT_EQUAL_INT(-EFAULT, pktbuf_copy(pkt->payload_data, NULL, 3));
+    TEST_ASSERT_EQUAL_STRING("abcd", pkt->payload_data);
+    TEST_ASSERT_EQUAL_INT(5, pkt->payload_len);
 }
 #endif
 
+static void test_pktbuf_copy_einval2(void)
+{
+    pkt_t *pkt = pktbuf_insert("abcd", 5);
+
+    TEST_ASSERT_NOT_NULL(pkt);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, pktbuf_copy(pkt->headers, "ab", 3));
+    TEST_ASSERT_EQUAL_STRING("abcd", pkt->payload_data);
+    TEST_ASSERT_EQUAL_INT(5, pkt->payload_len);
+}
+
 static void test_pktbuf_copy_data_len_too_long(void)
 {
-    char *data = (char *)pktbuf_insert("ab", 3);
+    pkt_t *pkt = pktbuf_insert("ab", 3);
 
-    TEST_ASSERT_NOT_NULL(data);
-    TEST_ASSERT_EQUAL_INT(-ENOMEM, pktbuf_copy(data, "cdef", 5));
-    TEST_ASSERT_EQUAL_STRING("ab", data);
+    TEST_ASSERT_NOT_NULL(pkt);
+    TEST_ASSERT_EQUAL_INT(-ENOMEM, pktbuf_copy(pkt->payload_data, "cdef", 5));
+    TEST_ASSERT_EQUAL_STRING("ab", pkt->payload_data);
+    TEST_ASSERT_EQUAL_INT(3, pkt->payload_len);
 }
 
 static void test_pktbuf_copy_data_len_too_long2(void)
 {
-    char *data = (char *)pktbuf_insert("abcd", 5);
+    pkt_t *pkt = pktbuf_insert("abcd", 5);
 
-    TEST_ASSERT_NOT_NULL(data);
-    TEST_ASSERT_EQUAL_INT(-ENOMEM, pktbuf_copy(data + 2, "efgh", 5));
-    TEST_ASSERT_EQUAL_STRING("abcd", data);
+    TEST_ASSERT_NOT_NULL(pkt);
+    TEST_ASSERT_EQUAL_INT(-ENOMEM, pktbuf_copy(((uint8_t *)(pkt->payload_data)) + 2, "efgh", 5));
+    TEST_ASSERT_EQUAL_STRING("abcd", pkt->payload_data);
+    TEST_ASSERT_EQUAL_INT(5, pkt->payload_len);
 }
 
 static void test_pktbuf_copy_data_len_0(void)
 {
-    char *data = (char *)pktbuf_insert("abcd", 5);
+    pkt_t *pkt = pktbuf_insert("abcd", 5);
 
-    TEST_ASSERT_NOT_NULL(data);
-    TEST_ASSERT_EQUAL_INT(0, pktbuf_copy(data, "ef", 0));
-    TEST_ASSERT_EQUAL_STRING("abcd", data);
+    TEST_ASSERT_NOT_NULL(pkt);
+    TEST_ASSERT_EQUAL_INT(0, pktbuf_copy(pkt->payload_data, "ef", 0));
+    TEST_ASSERT_EQUAL_STRING("abcd", pkt->payload_data);
+    TEST_ASSERT_EQUAL_INT(5, pkt->payload_len);
 }
 
 static void test_pktbuf_copy_success(void)
 {
-    char *data = (char *)pktbuf_insert("abcd", 5);
+    pkt_t *pkt = pktbuf_insert("abcd", 5);
 
-    TEST_ASSERT_NOT_NULL(data);
-    TEST_ASSERT_EQUAL_INT(3, pktbuf_copy(data, "ef", 3));
-    TEST_ASSERT_EQUAL_STRING("ef", data);
+    TEST_ASSERT_NOT_NULL(pkt);
+    TEST_ASSERT_EQUAL_INT(3, pktbuf_copy(pkt->payload_data, "ef", 3));
+    TEST_ASSERT_EQUAL_STRING("ef", pkt->payload_data);
+    TEST_ASSERT_EQUAL_INT(5, pkt->payload_len);
 }
 
 static void test_pktbuf_copy_success2(void)
 {
-    char *data = (char *)pktbuf_insert("abcdef", 7);
+    pkt_t *pkt = pktbuf_insert("abcdef", 7);
 
-    TEST_ASSERT_NOT_NULL(data);
-    TEST_ASSERT_EQUAL_INT(2, pktbuf_copy(data + 3, "gh", 2));
-    TEST_ASSERT_EQUAL_STRING("abcghf", data);
+    TEST_ASSERT_NOT_NULL(pkt);
+    TEST_ASSERT_EQUAL_INT(2, pktbuf_copy(((uint8_t *)(pkt->payload_data)) + 3, "gh", 2));
+    TEST_ASSERT_EQUAL_STRING("abcghf", pkt->payload_data);
+    TEST_ASSERT_EQUAL_INT(7, pkt->payload_len);
+}
+
+#ifdef DEVELHELP
+static void test_pktbuf_add_header_efault(void)
+{
+    pkt_t *pkt = pktbuf_insert("abcd", 5);
+
+    TEST_ASSERT_NOT_NULL(pkt);
+    TEST_ASSERT_EQUAL_INT(-EFAULT, pktbuf_add_header(pkt, NULL, 3));
+    TEST_ASSERT_EQUAL_STRING("abcd", pkt->payload_data);
+    TEST_ASSERT_EQUAL_INT(5, pkt->payload_len);
+    TEST_ASSERT_NULL(pkt->headers);
+}
+
+static void test_pktbuf_add_header_einval(void)
+{
+    TEST_ASSERT_EQUAL_INT(-EINVAL, pktbuf_add_header(NULL, "abcd", 3));
+}
+#endif
+
+static void test_pktbuf_add_header_einval2(void)
+{
+    pkt_t pkt = { NULL, "abcd", 5, PKT_PROTO_UNKNOWN };
+
+    TEST_ASSERT_EQUAL_INT(-EINVAL, pktbuf_add_header(&pkt, "ef", 3));
+    TEST_ASSERT_EQUAL_STRING("abcd", pkt.payload_data);
+    TEST_ASSERT_EQUAL_INT(5, pkt.payload_len);
+    TEST_ASSERT_NULL(pkt.headers);
+}
+
+static void test_pktbuf_add_header_header_len_too_long(void)
+{
+    pkt_t *pkt = pktbuf_insert("ab", 3);
+
+    TEST_ASSERT_NOT_NULL(pkt);
+    TEST_ASSERT_EQUAL_INT(-ENOMEM, pktbuf_add_header(pkt, "cdef", PKTBUF_SIZE + 1));
+    TEST_ASSERT_EQUAL_STRING("ab", pkt->payload_data);
+    TEST_ASSERT_EQUAL_INT(3, pkt->payload_len);
+}
+
+static void test_pktbuf_add_header_header_len_0(void)
+{
+    pkt_t *pkt = pktbuf_insert("abcd", 5);
+
+    TEST_ASSERT_NOT_NULL(pkt);
+    TEST_ASSERT_EQUAL_INT(-ENOMEM, pktbuf_add_header(pkt, "ef", 0));
+    TEST_ASSERT_EQUAL_STRING("abcd", pkt->payload_data);
+    TEST_ASSERT_EQUAL_INT(5, pkt->payload_len);
+    TEST_ASSERT_NULL(pkt->headers);
+}
+
+static void test_pktbuf_add_header_success(void)
+{
+    pkt_t *pkt = pktbuf_insert("abcd", 5);
+
+    TEST_ASSERT_NOT_NULL(pkt);
+    TEST_ASSERT_EQUAL_INT(0, pktbuf_add_header(pkt, "ef", 2));
+    TEST_ASSERT_EQUAL_STRING("abcd", pkt->payload_data);
+    TEST_ASSERT_EQUAL_INT(5, pkt->payload_len);
+    TEST_ASSERT_NOT_NULL(pkt->headers);
+    TEST_ASSERT_EQUAL_STRING("ef", pkt->headers->header_data);
+    TEST_ASSERT_EQUAL_INT(2, pkt->headers->header_len);
+    TEST_ASSERT_NULL(pkt->headers->next);
+}
+
+static void test_pktbuf_add_header_success2(void)
+{
+    pkt_t *pkt = pktbuf_insert("abcd", 5);
+
+    TEST_ASSERT_NOT_NULL(pkt);
+    TEST_ASSERT_EQUAL_INT(0, pktbuf_add_header(pkt, "ef", 2));
+    TEST_ASSERT_NOT_NULL(pkt->headers);
+    TEST_ASSERT_NULL(pkt->headers->next);
+    TEST_ASSERT_EQUAL_INT(0, pktbuf_add_header(pkt, "ghi", 3));
+    TEST_ASSERT_EQUAL_STRING("abcd", pkt->payload_data);
+    TEST_ASSERT_EQUAL_INT(5, pkt->payload_len);
+    TEST_ASSERT_NOT_NULL(pkt->headers);
+    TEST_ASSERT_EQUAL_STRING("ghi", pkt->headers->header_data);
+    TEST_ASSERT_EQUAL_INT(3, pkt->headers->header_len);
+    TEST_ASSERT_NOT_NULL(pkt->headers->next);
+    TEST_ASSERT_EQUAL_STRING("ef", pkt->headers->next->header_data);
+    TEST_ASSERT_EQUAL_INT(2, pkt->headers->next->header_len);
+    TEST_ASSERT_NULL(pkt->headers->next->next);
+}
+
+static void test_pktbuf_remove_header_success(void)
+{
+    pkt_t *pkt = pktbuf_insert("abcd", 5);
+
+    TEST_ASSERT_NOT_NULL(pkt);
+    TEST_ASSERT_EQUAL_INT(0, pktbuf_add_header(pkt, "ef", 3));
+    TEST_ASSERT_EQUAL_INT(0, pktbuf_add_header(pkt, "ghi", 4));
+    TEST_ASSERT_EQUAL_INT(0, pktbuf_add_header(pkt, "j", 2));
+    pktbuf_remove_header(pkt, pkt->headers->next);
+
+    TEST_ASSERT_EQUAL_STRING("abcd", pkt->payload_data);
+    TEST_ASSERT_EQUAL_INT(5, pkt->payload_len);
+    TEST_ASSERT_NOT_NULL(pkt->headers);
+    TEST_ASSERT_EQUAL_STRING("j", pkt->headers->header_data);
+    TEST_ASSERT_EQUAL_INT(2, pkt->headers->header_len);
+    TEST_ASSERT_NOT_NULL(pkt->headers->next);
+    TEST_ASSERT_EQUAL_STRING("ef", pkt->headers->next->header_data);
+    TEST_ASSERT_EQUAL_INT(3, pkt->headers->next->header_len);
+    TEST_ASSERT_NULL(pkt->headers->next->next);
+
+    pktbuf_remove_header(pkt, pkt->headers);
+
+    TEST_ASSERT_EQUAL_STRING("abcd", pkt->payload_data);
+    TEST_ASSERT_EQUAL_INT(5, pkt->payload_len);
+    TEST_ASSERT_NOT_NULL(pkt->headers);
+    TEST_ASSERT_EQUAL_STRING("ef", pkt->headers->header_data);
+    TEST_ASSERT_EQUAL_INT(3, pkt->headers->header_len);
+    TEST_ASSERT_NULL(pkt->headers->next);
+
+    pktbuf_remove_header(pkt, pkt->headers);
+
+    TEST_ASSERT_NULL(pkt->headers);
 }
 
 static void test_pktbuf_hold_ptr_null(void)
 {
-    char *data;
+    pkt_t *pkt;
 
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(25));
-    data = (char *)pktbuf_insert("abcd", 5);
-    TEST_ASSERT_NOT_NULL(data);
+    pkt = pktbuf_insert("abcd", 5);
+    TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(16));
 
     TEST_ASSERT_EQUAL_INT(3, pktbuf_packets_allocated());
 
     pktbuf_hold(NULL);
-    pktbuf_release(data);
+    pktbuf_release(pkt);
 
     TEST_ASSERT_EQUAL_INT(2, pktbuf_packets_allocated());
-    TEST_ASSERT_EQUAL_STRING("abcd", data);
+    TEST_ASSERT_EQUAL_STRING("abcd", pkt->payload_data);
 }
 
 static void test_pktbuf_hold_wrong_ptr(void)
 {
-    char *data, wrong;
+    pkt_t *pkt, wrong;
 
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(25));
-    data = (char *)pktbuf_insert("abcd", 5);
-    TEST_ASSERT_NOT_NULL(data);
+    pkt = pktbuf_insert("abcd", 5);
+    TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(16));
 
     TEST_ASSERT_EQUAL_INT(3, pktbuf_packets_allocated());
 
     pktbuf_hold(&wrong);
-    pktbuf_release(data);
+    pktbuf_release(pkt);
 
     TEST_ASSERT_EQUAL_INT(2, pktbuf_packets_allocated());
-    TEST_ASSERT_EQUAL_STRING("abcd", data);
+    TEST_ASSERT_EQUAL_STRING("abcd", pkt->payload_data);
 }
 
 static void test_pktbuf_hold_success(void)
 {
-    char *data;
+    pkt_t *pkt;
 
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(25));
-    data = (char *)pktbuf_insert("abcd", 5);
-    TEST_ASSERT_NOT_NULL(data);
+    pkt = pktbuf_insert("abcd", 5);
+    TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(16));
 
-    pktbuf_hold(data);
-    pktbuf_release(data);
+    pktbuf_hold(pkt);
+    pktbuf_release(pkt);
 
-    TEST_ASSERT_EQUAL_INT(3, pktbuf_copy(data, "ef", 3));
-    TEST_ASSERT_EQUAL_STRING("ef", data);
+    TEST_ASSERT_EQUAL_INT(3, pktbuf_copy(pkt->payload_data, "ef", 3));
+    TEST_ASSERT_EQUAL_STRING("ef", pkt->payload_data);
 }
 
 static void test_pktbuf_hold_success2(void)
 {
-    char *data;
+    pkt_t *pkt;
 
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(25));
-    data = (char *)pktbuf_insert("abcd", 5);
-    TEST_ASSERT_NOT_NULL(data);
+    pkt = pktbuf_insert("abcd", 5);
+    TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(16));
 
-    pktbuf_hold(data + 4);
-    pktbuf_release(data + 4);
+    pktbuf_hold(pkt + 4);
+    pktbuf_release(pkt + 4);
 
-    TEST_ASSERT_EQUAL_INT(3, pktbuf_copy(data, "ef", 3));
-    TEST_ASSERT_EQUAL_STRING("ef", data);
+    TEST_ASSERT_EQUAL_INT(3, pktbuf_copy(pkt->payload_data, "ef", 3));
+    TEST_ASSERT_EQUAL_STRING("ef", pkt->payload_data);
 }
 
 static void test_pktbuf_release_ptr_null(void)
 {
-    char *data;
+    pkt_t *pkt;
 
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(25));
-    data = (char *)pktbuf_insert("abcd", 5);
-    TEST_ASSERT_NOT_NULL(data);
+    pkt = pktbuf_insert("abcd", 5);
+    TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(16));
 
     pktbuf_release(NULL);
 
-    TEST_ASSERT_EQUAL_INT(3, pktbuf_copy(data, "ef", 3));
-    TEST_ASSERT_EQUAL_STRING("ef", data);
+    TEST_ASSERT_EQUAL_INT(3, pktbuf_copy(pkt->payload_data, "ef", 3));
+    TEST_ASSERT_EQUAL_STRING("ef", pkt->payload_data);
 }
 
 static void test_pktbuf_release_wrong_ptr(void)
 {
-    char *data, wrong;
+    pkt_t *pkt, wrong;
 
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(25));
-    data = (char *)pktbuf_insert("abcd", 5);
-    TEST_ASSERT_NOT_NULL(data);
+    pkt = pktbuf_insert("abcd", 5);
+    TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(16));
 
     pktbuf_release(&wrong);
 
-    TEST_ASSERT_EQUAL_INT(3, pktbuf_copy(data, "ef", 3));
-    TEST_ASSERT_EQUAL_STRING("ef", data);
+    TEST_ASSERT_EQUAL_INT(3, pktbuf_copy(pkt->payload_data, "ef", 3));
+    TEST_ASSERT_EQUAL_STRING("ef", pkt->payload_data);
 }
 
 static void test_pktbuf_release_success(void)
 {
-    char *data;
+    pkt_t *pkt;
 
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(25));
-    data = (char *)pktbuf_insert("abcd", 5);
-    TEST_ASSERT_NOT_NULL(data);
+    pkt = pktbuf_insert("abcd", 5);
+    TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_NOT_NULL(pktbuf_alloc(16));
 
     TEST_ASSERT_EQUAL_INT(3, pktbuf_packets_allocated());
 
-    pktbuf_hold(data);
-    pktbuf_hold(data);
-    pktbuf_release(data + 3);
-    pktbuf_release(data + 4);
-    pktbuf_release(data + 2);
+    pktbuf_hold(pkt);
+    pktbuf_hold(pkt);
+    pktbuf_release(pkt);
+    pktbuf_release(pkt);
+    pktbuf_release(pkt);
 
     TEST_ASSERT_EQUAL_INT(2, pktbuf_packets_allocated());
 }
 
 static void test_pktbuf_release_success2(void)
 {
-    char *data1, *data2, *data3;
+    pkt_t *pkt1, *pkt2, *pkt3;
 
-    data1 = (char *)pktbuf_insert("abcd", 5);
-    TEST_ASSERT_NOT_NULL(data1);
-    data2 = (char *)pktbuf_insert("ef", 3);
-    TEST_ASSERT_NOT_NULL(data2);
-    data3 = (char *)pktbuf_insert("ghijkl", 7);
-    TEST_ASSERT_NOT_NULL(data3);
+    pkt1 = pktbuf_insert("abcd", 5);
+    TEST_ASSERT_NOT_NULL(pkt1);
+    pkt2 = pktbuf_insert("ef", 3);
+    TEST_ASSERT_NOT_NULL(pkt2);
+    pkt3 = pktbuf_insert("ghijkl", 7);
+    TEST_ASSERT_NOT_NULL(pkt3);
 
     TEST_ASSERT_EQUAL_INT(3, pktbuf_packets_allocated());
 
-    pktbuf_release(data2);
+    pktbuf_release(pkt2);
 
     TEST_ASSERT_EQUAL_INT(2, pktbuf_packets_allocated());
-    TEST_ASSERT_EQUAL_INT(2, pktbuf_copy(data1, "m", 2));
-    TEST_ASSERT_EQUAL_STRING("m", data1);
-    TEST_ASSERT_EQUAL_INT(4, pktbuf_copy(data3, "nop", 4));
-    TEST_ASSERT_EQUAL_STRING("nop", data3);
+    TEST_ASSERT_EQUAL_INT(2, pktbuf_copy(pkt1->payload_data, "m", 2));
+    TEST_ASSERT_EQUAL_STRING("m", pkt1->payload_data);
+    TEST_ASSERT_EQUAL_INT(4, pktbuf_copy(pkt3->payload_data, "nop", 4));
+    TEST_ASSERT_EQUAL_STRING("nop", pkt3->payload_data);
 }
 
 static void test_pktbuf_release_success3(void)
 {
-    char *data1, *data2, *data3;
+    pkt_t *pkt1, *pkt2, *pkt3;
 
-    data1 = (char *)pktbuf_insert("abcd", 5);
-    TEST_ASSERT_NOT_NULL(data1);
-    data2 = (char *)pktbuf_insert("ef", 3);
-    TEST_ASSERT_NOT_NULL(data2);
-    data3 = (char *)pktbuf_insert("ghijkl", 7);
-    TEST_ASSERT_NOT_NULL(data3);
+    pkt1 = pktbuf_insert("abcd", 5);
+    TEST_ASSERT_NOT_NULL(pkt1);
+    pkt2 = pktbuf_insert("ef", 3);
+    TEST_ASSERT_NOT_NULL(pkt2);
+    pkt3 = pktbuf_insert("ghijkl", 7);
+    TEST_ASSERT_NOT_NULL(pkt3);
 
     TEST_ASSERT_EQUAL_INT(3, pktbuf_packets_allocated());
 
-    pktbuf_release(data1);
+    pktbuf_release(pkt1);
 
     TEST_ASSERT_EQUAL_INT(2, pktbuf_packets_allocated());
-    TEST_ASSERT_EQUAL_INT(2, pktbuf_copy(data2, "m", 2));
-    TEST_ASSERT_EQUAL_STRING("m", data2);
-    TEST_ASSERT_EQUAL_INT(4, pktbuf_copy(data3, "nop", 4));
-    TEST_ASSERT_EQUAL_STRING("nop", data3);
+    TEST_ASSERT_EQUAL_INT(2, pktbuf_copy(pkt2->payload_data, "m", 2));
+    TEST_ASSERT_EQUAL_STRING("m", pkt2->payload_data);
+    TEST_ASSERT_EQUAL_INT(4, pktbuf_copy(pkt3->payload_data, "nop", 4));
+    TEST_ASSERT_EQUAL_STRING("nop", pkt3->payload_data);
 }
 
 static void test_pktbuf_release_success4(void)
 {
-    char *data1, *data2, *data3;
+    pkt_t *pkt1, *pkt2, *pkt3;
 
-    data1 = (char *)pktbuf_insert("abcd", 5);
-    TEST_ASSERT_NOT_NULL(data1);
-    data2 = (char *)pktbuf_insert("ef", 3);
-    TEST_ASSERT_NOT_NULL(data2);
-    data3 = (char *)pktbuf_insert("ghijkl", 7);
-    TEST_ASSERT_NOT_NULL(data3);
+    pkt1 = pktbuf_insert("abcd", 5);
+    TEST_ASSERT_NOT_NULL(pkt1);
+    pkt2 = pktbuf_insert("ef", 3);
+    TEST_ASSERT_NOT_NULL(pkt2);
+    pkt3 = pktbuf_insert("ghijkl", 7);
+    TEST_ASSERT_NOT_NULL(pkt3);
 
     TEST_ASSERT_EQUAL_INT(3, pktbuf_packets_allocated());
 
-    pktbuf_release(data3);
+    pktbuf_release(pkt3);
 
     TEST_ASSERT_EQUAL_INT(2, pktbuf_packets_allocated());
-    TEST_ASSERT_EQUAL_INT(2, pktbuf_copy(data1, "m", 2));
-    TEST_ASSERT_EQUAL_STRING("m", data1);
-    TEST_ASSERT_EQUAL_INT(1, pktbuf_copy(data2, "", 1));
-    TEST_ASSERT_EQUAL_STRING("", data2);
+    TEST_ASSERT_EQUAL_INT(2, pktbuf_copy(pkt1->payload_data, "m", 2));
+    TEST_ASSERT_EQUAL_STRING("m", pkt1->payload_data);
+    TEST_ASSERT_EQUAL_INT(1, pktbuf_copy(pkt2->payload_data, "", 1));
+    TEST_ASSERT_EQUAL_STRING("", pkt2->payload_data);
 }
 
 static void test_pktbuf_insert_packed_struct(void)
@@ -446,8 +601,10 @@ static void test_pktbuf_insert_packed_struct(void)
                                   34, -4469, 149699748, -46590430597
                                 };
     test_pktbuf_struct_t *data_cpy;
+    pkt_t *pkt;
 
-    data_cpy = (test_pktbuf_struct_t *)pktbuf_insert(&data, sizeof(test_pktbuf_struct_t));
+    pkt = pktbuf_insert(&data, sizeof(test_pktbuf_struct_t));
+    data_cpy = (test_pktbuf_struct_t *)pkt->payload_data;
 
     TEST_ASSERT_EQUAL_INT(data.u8, data_cpy->u8);
     TEST_ASSERT_EQUAL_INT(data.u16, data_cpy->u16);
@@ -461,25 +618,25 @@ static void test_pktbuf_insert_packed_struct(void)
 
 static void test_pktbuf_alloc_off_by_one1(void)
 {
-    char *data1, *data2, *data3, *data4;
+    pkt_t *pkt1, *pkt2, *pkt3, *pkt4;
 
-    data1 = (char *)pktbuf_insert("1234567890a", 12);
-    TEST_ASSERT_NOT_NULL(data1);
-    data2 = (char *)pktbuf_alloc(44);
-    TEST_ASSERT_NOT_NULL(data2);
-    data4 = (char *)pktbuf_alloc(4);
-    TEST_ASSERT_NOT_NULL(data4);
+    pkt1 = pktbuf_insert("1234567890a", 12);
+    TEST_ASSERT_NOT_NULL(pkt1);
+    pkt2 = pktbuf_alloc(44);
+    TEST_ASSERT_NOT_NULL(pkt2);
+    pkt4 = pktbuf_alloc(4);
+    TEST_ASSERT_NOT_NULL(pkt4);
     TEST_ASSERT_EQUAL_INT(3, pktbuf_packets_allocated());
     TEST_ASSERT_EQUAL_INT(12 + 44 + 4, pktbuf_bytes_allocated());
 
-    pktbuf_release(data1);
+    pktbuf_release(pkt1);
 
     TEST_ASSERT_EQUAL_INT(2, pktbuf_packets_allocated());
     TEST_ASSERT_EQUAL_INT(44 + 4, pktbuf_bytes_allocated());
 
-    data3 = (char *)pktbuf_insert("bcdefghijklm", 13);
-    TEST_ASSERT_NOT_NULL(data3);
-    TEST_ASSERT(data1 != data3);
+    pkt3 = pktbuf_insert("bcdefghijklm", 13);
+    TEST_ASSERT_NOT_NULL(pkt3);
+    TEST_ASSERT(pkt1 != pkt3);
 
     TEST_ASSERT_EQUAL_INT(3, pktbuf_packets_allocated());
     TEST_ASSERT_EQUAL_INT(44 + 4 + 13, pktbuf_bytes_allocated());
@@ -491,27 +648,39 @@ Test *tests_pktbuf_tests(void)
         new_TestFixture(test_pktbuf_alloc_0),
         new_TestFixture(test_pktbuf_alloc_memfull),
         new_TestFixture(test_pktbuf_alloc_success),
-        new_TestFixture(test_pktbuf_realloc_0),
-        new_TestFixture(test_pktbuf_realloc_memfull),
-        new_TestFixture(test_pktbuf_realloc_memfull2),
-        new_TestFixture(test_pktbuf_realloc_memfull3),
-        new_TestFixture(test_pktbuf_realloc_smaller),
-        new_TestFixture(test_pktbuf_realloc_memenough),
-        new_TestFixture(test_pktbuf_realloc_memenough2),
-        new_TestFixture(test_pktbuf_realloc_nomemenough),
-        new_TestFixture(test_pktbuf_realloc_unknown_ptr),
+        new_TestFixture(test_pktbuf_realloc_payload_0),
+        new_TestFixture(test_pktbuf_realloc_payload_memfull),
+        new_TestFixture(test_pktbuf_realloc_payload_memfull2),
+        new_TestFixture(test_pktbuf_realloc_payload_memfull3),
+        new_TestFixture(test_pktbuf_realloc_payload_smaller),
+        new_TestFixture(test_pktbuf_realloc_payload_memenough),
+        new_TestFixture(test_pktbuf_realloc_payload_memenough2),
+        new_TestFixture(test_pktbuf_realloc_payload_nomemenough),
+        new_TestFixture(test_pktbuf_realloc_payload_unknown_ptr),
         new_TestFixture(test_pktbuf_insert_size_0),
         new_TestFixture(test_pktbuf_insert_data_NULL),
         new_TestFixture(test_pktbuf_insert_memfull),
         new_TestFixture(test_pktbuf_insert_success),
 #ifdef DEVELHELP
         new_TestFixture(test_pktbuf_copy_efault),
+        new_TestFixture(test_pktbuf_copy_einval),
 #endif
+        new_TestFixture(test_pktbuf_copy_einval2),
         new_TestFixture(test_pktbuf_copy_data_len_too_long),
         new_TestFixture(test_pktbuf_copy_data_len_too_long2),
         new_TestFixture(test_pktbuf_copy_data_len_0),
         new_TestFixture(test_pktbuf_copy_success),
         new_TestFixture(test_pktbuf_copy_success2),
+#ifdef DEVELHELP
+        new_TestFixture(test_pktbuf_add_header_efault),
+        new_TestFixture(test_pktbuf_add_header_einval),
+#endif
+        new_TestFixture(test_pktbuf_add_header_einval2),
+        new_TestFixture(test_pktbuf_add_header_header_len_too_long),
+        new_TestFixture(test_pktbuf_add_header_header_len_0),
+        new_TestFixture(test_pktbuf_add_header_success),
+        new_TestFixture(test_pktbuf_add_header_success2),
+        new_TestFixture(test_pktbuf_remove_header_success),
         new_TestFixture(test_pktbuf_hold_ptr_null),
         new_TestFixture(test_pktbuf_hold_wrong_ptr),
         new_TestFixture(test_pktbuf_hold_success),


### PR DESCRIPTION
Allows any netapi layer to be used as a device for the transceiver module (but only one at a time).

Depends on #1968 and transitively on #1448 