### PR TITLE
nativenet: add missing include

### DIFF
--- a/cpu/native/include/nativenet.h
+++ b/cpu/native/include/nativenet.h
@@ -27,6 +27,7 @@
 
 #include <net/ethernet.h>
 
+#include "radio/types.h"
 #include "kernel_types.h"
 #include "netdev/base.h"
 


### PR DESCRIPTION
Radio types are used, but `radio/types.h` is only included indirectly
