### PR TITLE
boards/cc2538dk: allow the application's makefile to override UPDATE_CCA

### DIFF
--- a/boards/cc2538dk/include/board.h
+++ b/boards/cc2538dk/include/board.h
@@ -81,7 +81,11 @@ extern "C" {
  * @name Flash Customer Configuration Area (CCA) parameters
  * @{
  */
+
+#ifndef UPDATE_CCA
 #define UPDATE_CCA                1
+#endif
+
 #define CCA_BACKDOOR_ENABLE       1
 #define CCA_BACKDOOR_PORT_A_PIN   3 /**< Select button */
 #define CCA_BACKDOOR_ACTIVE_LEVEL 0 /**< Active low */


### PR DESCRIPTION
For example: CFLAGS += -DUPDATE_CCA=0

This produces a much smaller bin file and avoids overwriting the entire flash memory in case parts of it are used for data storage. Plus it's more of an application-specific parameter for the CC2538 than a board-specific parameter.
