### PR TITLE
Allow the application's makefile to specify a custom linker script

### DIFF
--- a/cpu/cc2538/Makefile.include
+++ b/cpu/cc2538/Makefile.include
@@ -8,7 +8,7 @@ export USEMODULE += cortex-m3_common
 export CORTEX_COMMON = $(RIOTCPU)/cortex-m3_common/
 
 # Define the linker script to use for this CPU:
-export LINKERSCRIPT = $(RIOTCPU)/$(CPU)/$(CPU_MODEL)_linkerscript.ld
+export LINKERSCRIPT ?= $(RIOTCPU)/$(CPU)/$(CPU_MODEL)_linkerscript.ld
 
 # Export the CPU model:
 MODEL = $(shell echo $(CPU_MODEL) | tr 'a-z' 'A-Z')

--- a/cpu/nrf51822/Makefile.include
+++ b/cpu/nrf51822/Makefile.include
@@ -10,7 +10,7 @@ export CORTEX_COMMON = $(RIOTCPU)/cortex-m0_common/
 # define the linker script to use for this CPU. The CPU_MODEL variable is defined in the
 # board's Makefile.include. This enables multiple NRF51822 controllers with different memory to
 # use the same code-base.
-export LINKERSCRIPT = $(RIOTCPU)/$(CPU)/$(CPU_MODEL)_linkerscript.ld
+export LINKERSCRIPT ?= $(RIOTCPU)/$(CPU)/$(CPU_MODEL)_linkerscript.ld
 
 #export the CPU model
 MODEL = $(shell echo $(CPU_MODEL)|tr 'a-z' 'A-Z')

--- a/cpu/sam3x8e/Makefile.include
+++ b/cpu/sam3x8e/Makefile.include
@@ -9,7 +9,7 @@ export USEMODULE += cortex-m3_common
 export CORTEX_COMMON = $(RIOTCPU)/cortex-m3_common/
 
 # define the linker script to use for this CPU
-export LINKERSCRIPT = $(RIOTCPU)/$(CPU)/sam3x8e_linkerscript.ld
+export LINKERSCRIPT ?= $(RIOTCPU)/$(CPU)/sam3x8e_linkerscript.ld
 
 # include CPU specific includes
 export INCLUDES += -I$(RIOTCPU)/$(CPU)/include

--- a/cpu/samd21/Makefile.include
+++ b/cpu/samd21/Makefile.include
@@ -14,7 +14,7 @@ export CORTEX_COMMON = $(RIOTCPU)/cortex-m0_common/
 export USEMODULE += lib
 
 # define the linker script to use for this CPU
-export LINKERSCRIPT = $(RIOTCPU)/$(CPU)/samd21_linkerscript.ld
+export LINKERSCRIPT ?= $(RIOTCPU)/$(CPU)/samd21_linkerscript.ld
 
 # include CPU specific includes
 export INCLUDES += -I$(RIOTCPU)/$(CPU)/include

--- a/cpu/stm32f0/Makefile.include
+++ b/cpu/stm32f0/Makefile.include
@@ -13,7 +13,7 @@ export USEMODULE += lib
 # define the linker script to use for this CPU. The CPU_MODEL variable is defined in the
 # board's Makefile.include. This enables multiple STMF0 controllers with different memory to
 # use the same code-base.
-export LINKERSCRIPT = $(RIOTCPU)/$(CPU)/$(CPU_MODEL)_linkerscript.ld
+export LINKERSCRIPT ?= $(RIOTCPU)/$(CPU)/$(CPU_MODEL)_linkerscript.ld
 
 #export the CPU model
 MODEL = $(shell echo $(CPU_MODEL)|tr 'a-z' 'A-Z')

--- a/cpu/stm32f1/Makefile.include
+++ b/cpu/stm32f1/Makefile.include
@@ -11,7 +11,7 @@ export USEMODULE += lib
 export CORTEXM_COMMON = $(RIOTCPU)/cortex-m3_common/
 
 # define the linker script to use for this CPU
-export LINKERSCRIPT = $(RIOTCPU)/$(CPU)/$(CPU_MODEL)_linkerscript.ld
+export LINKERSCRIPT ?= $(RIOTCPU)/$(CPU)/$(CPU_MODEL)_linkerscript.ld
 
 # include CPU specific includes
 export INCLUDES += -I$(RIOTCPU)/$(CPU)/include/components

--- a/cpu/stm32f3/Makefile.include
+++ b/cpu/stm32f3/Makefile.include
@@ -17,7 +17,7 @@ export CORTEX_M4_COMMON = $(RIOTCPU)/cortex-m4_common/
 include $(CORTEX_M4_COMMON)Makefile.include
 
 # define the linker script to use for this CPU
-export LINKERSCRIPT = $(RIOTCPU)/$(CPU)/$(CPU_MODEL)_linkerscript.ld
+export LINKERSCRIPT ?= $(RIOTCPU)/$(CPU)/$(CPU_MODEL)_linkerscript.ld
 
 #export the CPU model
 MODEL = $(shell echo $(CPU_MODEL)|tr 'a-z' 'A-Z')

--- a/cpu/stm32f4/Makefile.include
+++ b/cpu/stm32f4/Makefile.include
@@ -17,7 +17,7 @@ export CORTEX_M4_COMMON = $(RIOTCPU)/cortex-m4_common/
 include $(CORTEX_M4_COMMON)Makefile.include
 
 # define the linker script to use for this CPU
-export LINKERSCRIPT = $(RIOTCPU)/$(CPU)/$(CPU_MODEL)_linkerscript.ld
+export LINKERSCRIPT ?= $(RIOTCPU)/$(CPU)/$(CPU_MODEL)_linkerscript.ld
 
 #export the CPU model
 MODEL = $(shell echo $(CPU_MODEL)|tr 'a-z' 'A-Z')


### PR DESCRIPTION
For example: LINKERSCRIPT = custom-linkerscript.ld
Tested ok on boards/cc2538dk.
