### PR TITLE
cpu/stm32f4 C++ stm32f4discovery support fix

### DIFF
--- a/boards/stm32f4discovery/Makefile.features
+++ b/boards/stm32f4discovery/Makefile.features
@@ -1,1 +1,1 @@
-FEATURES_PROVIDED += periph_gpio periph_spi periph_pwm periph_random periph_adc
+FEATURES_PROVIDED += periph_gpio periph_spi periph_pwm periph_random periph_adc cpp

--- a/boards/stm32f4discovery/Makefile.include
+++ b/boards/stm32f4discovery/Makefile.include
@@ -17,6 +17,7 @@ export PORT
 # define tools used for building the project
 export PREFIX = arm-none-eabi-
 export CC = $(PREFIX)gcc
+export CXX = $(PREFIX)g++
 export AR = $(PREFIX)ar
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
@@ -39,6 +40,10 @@ export OFLAGS = -O binary
 export FFLAGS = write bin/$(BOARD)/$(APPLICATION).hex 0x8000000
 export DEBUGGER_FLAGS = $(RIOTBOARD)/$(BOARD)/dist/gdb.conf $(BINDIR)/$(APPLICATION).elf
 export TERMFLAGS += -p "$(PORT)"
+
+# unwanted (CXXUWFLAGS) and extra (CXXEXFLAGS) flags for c++
+export CXXUWFLAGS +=
+export CXXEXFLAGS +=
 
 # use newLib nano-specs if available
 ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)

--- a/cpu/stm32f4/syscalls.c
+++ b/cpu/stm32f4/syscalls.c
@@ -156,6 +156,7 @@ int _getpid(void)
  *
  * @return      TODO
  */
+__attribute__ ((weak))
 int _kill_r(struct _reent *r, int pid, int sig)
 {
     r->_errno = ESRCH;                      /* not implemented yet */
@@ -319,5 +320,20 @@ int _isatty_r(struct _reent *r, int fd)
 int _unlink_r(struct _reent *r, char* path)
 {
     r->_errno = ENODEV;                     /* not implemented yet */
+    return -1;
+}
+
+/**
+ * @brief Send a signal to a thread
+ *
+ * @param[in] pid the pid to send to
+ * @param[in] sig the signal to send
+ *
+ * @return TODO
+ */
+__attribute__ ((weak))
+int _kill(int pid, int sig)
+{
+    errno = ESRCH;                         /* not implemented yet */
     return -1;
 }


### PR DESCRIPTION
Using the [promoted](https://github.com/RIOT-OS/RIOT/wiki/Board%3A-STM32F4discovery#supported-toolchains) gnu toolchain provides newlib with a `_kill_r()` implementation conflicting with the RIOT one, 
so I removed `_kill_r()` from RIOT.
The shipped newlib requires to provide a `_kill()` function when using `g++`, so I added a stub for it.
