### PR TITLE
make: easify {sys,drivers}/Makefile

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -3,7 +3,7 @@ ifeq (, $(__RIOTBUILD_FLAG))
 endif
 
 unexport DIRS
-DIRS := $(abspath ${DIRS})
+DIRS := $(sort $(abspath ${DIRS}))
 
 MODULE ?= $(shell basename $(CURDIR))
 

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -1,65 +1,10 @@
-ifneq (,$(filter powermon,$(USEMODULE)))
-    DIRS += powermon
-endif
-ifneq (,$(filter cc2420,$(USEMODULE)))
-    DIRS += cc2420
-endif
-ifneq (,$(filter sht11,$(USEMODULE)))
-    DIRS += sht11
-endif
-ifneq (,$(filter ltc4150,$(USEMODULE)))
-    DIRS += ltc4150
-endif
-ifneq (,$(filter cc110x_legacy_csma,$(USEMODULE)))
-    DIRS += cc110x_legacy_csma
-endif
-ifneq (,$(filter cc110x_legacy,$(USEMODULE)))
-    DIRS += cc110x_legacy
-endif
-ifneq (,$(filter at86rf231,$(USEMODULE)))
-    DIRS += at86rf231
-endif
-ifneq (,$(filter gps_ublox,$(USEMODULE)))
-    DIRS += gps_ublox
-endif
-ifneq (,$(filter srf02,$(USEMODULE)))
-    DIRS += srf02
-endif
-ifneq (,$(filter srf08,$(USEMODULE)))
-    DIRS += srf08
-endif
-ifneq (,$(filter lm75a,$(USEMODULE)))
-    DIRS += lm75a
-endif
-ifneq (,$(filter rgbled,$(USEMODULE)))
-    DIRS += rgbled
-endif
-ifneq (,$(filter servo,$(USEMODULE)))
-    DIRS += servo
-endif
-ifneq (,$(filter pir,$(USEMODULE)))
-    DIRS += pir
-endif
 ifneq (,$(filter netdev_base,$(USEMODULE)))
     DIRS += netdev/base
-endif
-ifneq (,$(filter isl29020,$(USEMODULE)))
-    DIRS += isl29020
-endif
-ifneq (,$(filter mq3,$(USEMODULE)))
-    DIRS += mq3
-endif
-ifneq (,$(filter lps331ap,$(USEMODULE)))
-    DIRS += lps331ap
-endif
-ifneq (,$(filter l3g4200d,$(USEMODULE)))
-    DIRS += l3g4200d
 endif
 ifneq (,$(filter netdev_802154,$(USEMODULE)))
     DIRS += netdev/802154
 endif
-ifneq (,$(filter lsm303dlhc,$(USEMODULE)))
-    DIRS += lsm303dlhc
-endif
+
+DIRS += $(dir $(wildcard $(addsuffix /Makefile, ${USEMODULE})))
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -1,29 +1,5 @@
-ifneq (,$(filter auto_init,$(USEMODULE)))
-    DIRS += auto_init
-endif
-ifneq (,$(filter cbor,$(USEMODULE)))
-    DIRS += cbor
-endif
-ifneq (,$(filter config,$(USEMODULE)))
-    DIRS += config
-endif
-ifneq (,$(filter lib,$(USEMODULE)))
-    DIRS += lib
-endif
-ifneq (,$(filter od,$(USEMODULE)))
-    DIRS += od
-endif
-ifneq (,$(filter ping,$(USEMODULE)))
-    DIRS += ping
-endif
 ifneq (,$(filter pktbuf,$(USEMODULE)))
     DIRS += net/crosslayer/pktbuf
-endif
-ifneq (,$(filter ps,$(USEMODULE)))
-    DIRS += ps
-endif
-ifneq (,$(filter posix,$(USEMODULE)))
-    DIRS += posix
 endif
 ifneq (,$(filter pnet,$(USEMODULE)))
     DIRS += posix/pnet
@@ -31,23 +7,8 @@ endif
 ifneq (,$(filter pthread,$(USEMODULE)))
     DIRS += posix/pthread
 endif
-ifneq (,$(filter shell,$(USEMODULE)))
-    DIRS += shell
-endif
 ifneq (,$(filter shell_commands,$(USEMODULE)))
     DIRS += shell/commands
-endif
-ifneq (,$(filter timex,$(USEMODULE)))
-    DIRS += timex
-endif
-ifneq (,$(filter transceiver,$(USEMODULE)))
-    DIRS += transceiver
-endif
-ifneq (,$(filter uart0,$(USEMODULE)))
-    DIRS += uart0
-endif
-ifneq (,$(filter vtimer,$(USEMODULE)))
-    DIRS += vtimer
 endif
 ifneq (,$(filter net_if,$(USEMODULE)))
     DIRS += net/link_layer/net_if
@@ -86,35 +47,16 @@ endif
 ifneq (,$(filter ieee802154,$(USEMODULE)))
     DIRS += net/link_layer/ieee802154
 endif
-ifneq (,$(filter bloom,$(USEMODULE)))
-    DIRS += bloom
-endif
-ifneq (,$(filter crypto,$(USEMODULE)))
-    DIRS += crypto
-endif
-ifneq (,$(filter random,$(USEMODULE)))
-    DIRS += random
-endif
-ifneq (,$(filter hashes,$(USEMODULE)))
-    DIRS += hashes
-endif
 ifneq (,$(filter ccn_lite,$(USEMODULE)))
     DIRS += net/ccn_lite
 endif
 ifneq (,$(filter ccn_lite_client,$(USEMODULE)))
     DIRS += net/ccn_lite/util
 endif
-ifneq (,$(filter quad_math,$(USEMODULE)))
-    DIRS += quad_math
-endif
 ifneq (,$(filter oneway_malloc,$(USEMODULE)))
     DIRS += oneway-malloc
 endif
-ifneq (,$(filter color,$(USEMODULE)))
-    DIRS += color
-endif
-ifneq (,$(filter pipe,$(USEMODULE)))
-    DIRS += pipe
-endif
+
+DIRS += $(dir $(wildcard $(addsuffix /Makefile, ${USEMODULE})))
 
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
Currently you need to add every new sys and driver module into the
respective Makefile. This requires rebasing if another module was merged
in the meantime.

This PR allows you to omit the entry to {sys,drivers}/Makefile, if the
subfolder has the same name as the module name, which should be sensible
in most cases.
