### PR TITLE
cpu/samd21 C++ samr21-xpro support fix

### DIFF
--- a/boards/samr21-xpro/Makefile.features
+++ b/boards/samr21-xpro/Makefile.features
@@ -1,1 +1,1 @@
-FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_gpio cpp

--- a/boards/samr21-xpro/Makefile.include
+++ b/boards/samr21-xpro/Makefile.include
@@ -8,6 +8,7 @@ export PORT ?= /dev/ttyACM0
 # define tools used for building the project
 export PREFIX = arm-none-eabi-
 export CC = $(PREFIX)gcc
+export CXX = $(PREFIX)g++
 export AR = $(PREFIX)ar
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
@@ -29,6 +30,10 @@ export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS += -O binary
 export FFLAGS += $(HEXFILE)
 export TERMFLAGS += "$(PORT)"
+
+# unwanted (CXXUWFLAGS) and extra (CXXEXFLAGS) flags for c++
+export CXXUWFLAGS +=
+export CXXEXFLAGS +=
 
 # use the nano-specs of the NewLib when available
 ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)

--- a/cpu/samd21/syscalls.c
+++ b/cpu/samd21/syscalls.c
@@ -150,6 +150,7 @@ pid_t _getpid(void)
  *
  * @return      TODO
  */
+__attribute__ ((weak))
 int _kill_r(struct _reent *r, pid_t pid, int sig)
 {
     r->_errno = ESRCH;                      /* not implemented yet */
@@ -315,5 +316,20 @@ int _isatty_r(struct _reent *r, int fd)
 int _unlink_r(struct _reent *r, char* path)
 {
     r->_errno = ENODEV;                     /* not implemented yet */
+    return -1;
+}
+
+/**
+ * @brief Send a signal to a thread
+ *
+ * @param[in] pid the pid to send to
+ * @param[in] sig the signal to send
+ *
+ * @return TODO
+ */
+__attribute__ ((weak))
+int _kill(int pid, int sig)
+{
+    errno = ESRCH;                         /* not implemented yet */
     return -1;
 }


### PR DESCRIPTION
Using the [promoted](https://github.com/RIOT-OS/RIOT/wiki/Board%3A-Samr21-xpro#supported-toolchains) gnu toolchain provides newlib with a `_kill_r()` implementation conflicting with the RIOT one,  so I removed `_kill_r()` from RIOT.
The shipped newlib requires to provide a `_kill()` function when using `g++`, so I added a stub for it.
