### PR TITLE
samr21: 32 hwtimer

### DIFF
--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -30,12 +30,12 @@ extern "C" {
 /**
  * Define the nominal CPU core clock in this board
  */
-#define F_CPU               (48000000UL)
+#define F_CPU               (8000000UL)
 
 /**
  * Assign the hardware timer
  */
-#define HW_TIMER            TIMER_0
+#define HW_TIMER            TIMER_1
 
 /**
  * @name Define UART device and baudrate for stdio

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -27,30 +27,23 @@ extern "C" {
  * @name Timer peripheral configuration
  * @{
  */
-#define TIMER_NUMOF         (3U)
-#define TIMER_0_EN          1
-#define TIMER_1_EN          1
-#define TIMER_2_EN          1
+#define TIMER_NUMOF        (2U)
+#define TIMER_0_EN         1
+#define TIMER_1_EN         1
 
 /* Timer 0 configuration */
-#define TIMER_0_DEV         TC3->COUNT16
-#define TIMER_0_CHANNELS    2
-#define TIMER_0_MAX_VALUE   (0xffff)
-#define TIMER_0_ISR         isr_tc3
+#define TIMER_0_DEV        TC3->COUNT16
+#define TIMER_0_CHANNELS   2
+#define TIMER_0_MAX_VALUE  (0xffff)
+#define TIMER_0_ISR        isr_tc3
 
 /* Timer 1 configuration */
-#define TIMER_1_DEV         TC4->COUNT16
-#define TIMER_1_CHANNELS    2
-#define TIMER_1_MAX_VALUE   (0xffff)
-#define TIMER_1_ISR         isr_tc4
+#define TIMER_1_DEV        TC4->COUNT32
+#define TIMER_1_CHANNELS   2
+#define TIMER_1_MAX_VALUE  (0xffffffff)
+#define TIMER_1_ISR        isr_tc4
 
-/* Timer 2 configuration */
-#define TIMER_2_DEV         TC5->COUNT16
-#define TIMER_2_CHANNELS    2
-#define TIMER_2_MAX_VALUE   (0xffff)
-#define TIMER_2_ISR         isr_tc5
 /** @} */
-
 
 /**
  * @name UART configuration

--- a/cpu/samd21/include/hwtimer_cpu.h
+++ b/cpu/samd21/include/hwtimer_cpu.h
@@ -27,9 +27,9 @@ extern "C" {
  * @name Hardware timer configuration
  * @{
  */
-#define HWTIMER_MAXTIMERS   2               /**< the CPU implementation supports 2 HW timers */
-#define HWTIMER_SPEED       (124999U)       /**< the HW timer runs with 125kHz */
-#define HWTIMER_MAXTICKS    (0xFFFF)        /**< 16-bit timer */
+#define HWTIMER_MAXTIMERS   2               /**< the CPU implementation supports 1 HW timer */
+#define HWTIMER_SPEED       (1000000U)      /**< the HW timer runs with 1MHz */
+#define HWTIMER_MAXTICKS    (0xFFFFFFFF)    /**< 32-bit timer */
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/samd21/periph/timer.c
+++ b/cpu/samd21/periph/timer.c
@@ -27,6 +27,8 @@
 #include "periph/timer.h"
 #include "periph_conf.h"
 
+#include "sched.h"
+#include "thread.h"
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
@@ -44,59 +46,60 @@ timer_conf_t config[TIMER_NUMOF];
 /**
  * @brief Setup the given timer
  */
-int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
+int timer_init(tim_t dev, unsigned int us_per_ticks, void (*callback)(int))
 {
-    TcCount16 *tim;
-
-    /* select the timer and enable the timer specific peripheral clocks */
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            tim = &TIMER_0_DEV;
-            PM->APBCMASK.reg |= PM_APBCMASK_TC3;
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            tim = &TIMER_1_DEV;
-            PM->APBCMASK.reg |= PM_APBCMASK_TC4;
-            break;
-#endif
-#if TIMER_2_EN
-        case TIMER_2:
-            tim = &TIMER_2_DEV;
-            PM->APBCMASK.reg = PM_APBCMASK_TC5;
-            break;
-#endif
-        case TIMER_UNDEFINED:
-        default:
-            return -1;
-    }
-
-    if (tim->CTRLA.bit.ENABLE) {
-        return 0;
-    }
-
     /* configure GCLK0 to feed TC3, TC4 and TC5 */;
     GCLK->CLKCTRL.reg = (uint16_t)((GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 | (TC3_GCLK_ID << GCLK_CLKCTRL_ID_Pos)));
     while (GCLK->STATUS.bit.SYNCBUSY);
     /* TC4 and TC5 share the same channel */
     GCLK->CLKCTRL.reg = (uint16_t)((GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 | (TC4_GCLK_ID << GCLK_CLKCTRL_ID_Pos)));
     while (GCLK->STATUS.bit.SYNCBUSY);
+    /* select the timer and enable the timer specific peripheral clocks */
+
+    switch (dev) {
+#if TIMER_0_EN
+    case TIMER_0:
+        if (TIMER_0_DEV.CTRLA.bit.ENABLE) {
+            return 0;
+        }
+        PM->APBCMASK.reg |= PM_APBCMASK_TC3;
+        /* reset timer */
+        TIMER_0_DEV.CTRLA.bit.SWRST = 1;
+        while (TIMER_0_DEV.CTRLA.bit.SWRST);
+        /* choosing 16 bit mode */
+        TIMER_0_DEV.CTRLA.bit.MODE = TC_CTRLA_MODE_COUNT16_Val;
+        /* sourced by 8MHz with Presc 64 results in 125kHz clk */
+        TIMER_0_DEV.CTRLA.bit.PRESCALER = TC_CTRLA_PRESCALER_DIV64_Val;
+        /* choose normal frequency operation */
+        TIMER_0_DEV.CTRLA.bit.WAVEGEN = TC_CTRLA_WAVEGEN_NFRQ_Val;
+        break;
+#endif
+#if TIMER_1_EN
+    case TIMER_1:
+        if (TIMER_1_DEV.CTRLA.bit.ENABLE) {
+            return 0;
+        }
+        PM->APBCMASK.reg |= PM_APBCMASK_TC4;
+        /* reset timer */
+        TIMER_1_DEV.CTRLA.bit.SWRST = 1;
+
+        while (TIMER_1_DEV.CTRLA.bit.SWRST);
+
+
+        TIMER_1_DEV.CTRLA.bit.MODE = TC_CTRLA_MODE_COUNT32_Val;
+        /* sourced by 8MHz with Presc 8 results in 1Mhz clk */
+        TIMER_1_DEV.CTRLA.bit.PRESCALER = TC_CTRLA_PRESCALER_DIV8_Val;
+        /* choose normal frequency operation */
+        TIMER_1_DEV.CTRLA.bit.WAVEGEN = TC_CTRLA_WAVEGEN_NFRQ_Val;
+        break;
+#endif
+    case TIMER_UNDEFINED:
+    default:
+        return -1;
+    }
 
     /* save callback */
     config[dev].cb = callback;
-
-    /* reset timer */
-    tim->CTRLA.bit.SWRST = 1;
-    while (tim->CTRLA.bit.SWRST);
-
-    /* choosing 16 bit mode */
-    tim->CTRLA.bit.MODE = TC_CTRLA_MODE_COUNT16_Val;
-    /* sourced by 8MHz with Presc 64 results in 125kHz clk */
-    tim->CTRLA.bit.PRESCALER = TC_CTRLA_PRESCALER_DIV64_Val;
-    /* choose normal frequency operation */
-    tim->CTRLA.bit.WAVEGEN = TC_CTRLA_WAVEGEN_NFRQ_Val;
 
     /* enable interrupts for given timer */
     timer_irq_enable(dev);
@@ -113,44 +116,51 @@ int timer_set(tim_t dev, int channel, unsigned int timeout)
 
 int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 {
-    TcCount16 *tim;
+    DEBUG("Setting timer %i channel %i to %i\n", dev, channel, value);
 
     /* get timer base register address */
     switch (dev) {
 #if TIMER_0_EN
-        case TIMER_0:
-            tim = &TIMER_0_DEV;
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            tim = &TIMER_1_DEV;
-            break;
-#endif
-#if TIMER_2_EN
-        case TIMER_2:
-            tim = &TIMER_2_DEV;
-            break;
-#endif
-        case TIMER_UNDEFINED:
-        default:
-            return -1;
-    }
-
-    DEBUG("Setting timer %i channel %i to %i\n", dev, channel, value);
-
-    /* set timeout value */
-    switch (channel) {
+    case TIMER_0:
+        /* set timeout value */
+        switch (channel) {
         case 0:
-            tim->CC[0].reg = value;
-            tim->INTENSET.bit.MC0 = 1;
+            TIMER_0_DEV.INTFLAG.bit.MC0 = 1;
+            TIMER_0_DEV.CC[0].reg = value;
+            TIMER_0_DEV.INTENSET.bit.MC0 = 1;
             break;
         case 1:
-            tim->CC[1].reg = value;
-            tim->INTENSET.bit.MC1 = 1;
+            TIMER_0_DEV.INTFLAG.bit.MC1 = 1;
+            TIMER_0_DEV.CC[1].reg = value;
+            TIMER_0_DEV.INTENSET.bit.MC1 = 1;
             break;
         default:
             return -1;
+        }
+        break;
+#endif
+#if TIMER_1_EN
+    case TIMER_1:
+        /* set timeout value */
+        switch (channel) {
+        case 0:
+            TIMER_1_DEV.INTFLAG.bit.MC0 = 1;
+            TIMER_1_DEV.CC[0].reg = value;
+            TIMER_1_DEV.INTENSET.bit.MC0 = 1;
+            break;
+        case 1:
+            TIMER_1_DEV.INTFLAG.bit.MC1 = 1;
+            TIMER_1_DEV.CC[1].reg = value;
+            TIMER_1_DEV.INTENSET.bit.MC1 = 1;
+            break;
+        default:
+            return -1;
+        }
+        break;
+#endif
+    case TIMER_UNDEFINED:
+    default:
+        return -1;
     }
 
     return 1;
@@ -158,40 +168,43 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 
 int timer_clear(tim_t dev, int channel)
 {
-    TcCount16 *tim;
-
     /* get timer base register address */
     switch (dev) {
 #if TIMER_0_EN
-        case TIMER_0:
-            tim = &TIMER_0_DEV;
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            tim = &TIMER_1_DEV;
-            break;
-#endif
-#if TIMER_2_EN
-        case TIMER_2:
-            tim = &TIMER_2_DEV;
-            break;
-#endif
-        case TIMER_UNDEFINED:
-        default:
-            return -1;
-    }
-
-    /* disable the channels interrupt */
-    switch (channel) {
+    case TIMER_0:
+        switch (channel) {
         case 0:
-            tim->INTENCLR.bit.MC0 = 1;
+            TIMER_0_DEV.INTFLAG.bit.MC0 = 1;
+            TIMER_0_DEV.INTENCLR.bit.MC0 = 1;
             break;
         case 1:
-            tim->INTENCLR.bit.MC1 = 1;
+            TIMER_0_DEV.INTFLAG.bit.MC1 = 1;
+            TIMER_0_DEV.INTENCLR.bit.MC1 = 1;
             break;
         default:
             return -1;
+        }
+        break;
+#endif
+#if TIMER_1_EN
+    case TIMER_1:
+        switch (channel) {
+        case 0:
+            TIMER_1_DEV.INTFLAG.bit.MC0 = 1;
+            TIMER_1_DEV.INTENCLR.bit.MC0 = 1;
+            break;
+        case 1:
+            TIMER_1_DEV.INTFLAG.bit.MC1 = 1;
+            TIMER_1_DEV.INTENCLR.bit.MC1 = 1;
+            break;
+        default:
+            return -1;
+        }
+        break;
+#endif
+    case TIMER_UNDEFINED:
+    default:
+        return -1;
     }
 
     return 1;
@@ -199,30 +212,28 @@ int timer_clear(tim_t dev, int channel)
 
 unsigned int timer_read(tim_t dev)
 {
-    TcCount16 *tim;
-
     switch (dev) {
 #if TIMER_0_EN
-        case TIMER_0:
-            tim = (&TIMER_0_DEV);
+    case TIMER_0:
+        /* request syncronisation */
+        TIMER_0_DEV.READREQ.reg = TC_READREQ_RREQ | TC_READREQ_ADDR(0x10);
+        while (TIMER_0_DEV.STATUS.bit.SYNCBUSY);
+        return TIMER_0_DEV.COUNT.reg;
+        break;
 #endif
 #if TIMER_1_EN
-        case TIMER_1:
-            tim = (&TIMER_1_DEV);
+    case TIMER_1:
+        /* request syncronisation */
+        TIMER_1_DEV.READREQ.reg = TC_READREQ_RREQ | TC_READREQ_ADDR(0x10);
+        while (TIMER_1_DEV.STATUS.bit.SYNCBUSY);
+        return TIMER_1_DEV.COUNT.reg;
+        break;
 #endif
-#if TIMER_2_EN
-        case TIMER_2:
-            tim = (&TIMER_0_DEV);
-#endif
-        default:
-            return 0;
+    default:
+        return 0;
     }
 
-    /* request syncronisation */
-    tim->READREQ.reg = TC_READREQ_RREQ | TC_READREQ_ADDR(0x10);
-    while (tim->STATUS.bit.SYNCBUSY);
 
-    return tim->COUNT.reg;
 }
 
 void timer_stop(tim_t dev)
@@ -236,11 +247,6 @@ void timer_stop(tim_t dev)
 #if TIMER_1_EN
         case TIMER_1:
             TIMER_1_DEV.CTRLA.bit.ENABLE = 0;
-            break;
-#endif
-#if TIMER_2_EN
-        case TIMER_2:
-            TIMER_2_DEV.CTRLA.bit.ENABLE = 0;
             break;
 #endif
         case TIMER_UNDEFINED:
@@ -261,11 +267,6 @@ void timer_start(tim_t dev)
             TIMER_1_DEV.CTRLA.bit.ENABLE = 1;
             break;
 #endif
-#if TIMER_2_EN
-        case TIMER_2:
-            TIMER_2_DEV.CTRLA.bit.ENABLE = 1;
-            break;
-#endif
         case TIMER_UNDEFINED:
             break;
     }
@@ -282,11 +283,6 @@ void timer_irq_enable(tim_t dev)
 #if TIMER_1_EN
         case TIMER_1:
             NVIC_EnableIRQ(TC4_IRQn);
-            break;
-#endif
-#if TIMER_2_EN
-        case TIMER_2:
-            NVIC_EnableIRQ(TC5_IRQn);
             break;
 #endif
         case TIMER_UNDEFINED:
@@ -307,11 +303,6 @@ void timer_irq_disable(tim_t dev)
             NVIC_DisableIRQ(TC4_IRQn);
             break;
 #endif
-#if TIMER_2_EN
-        case TIMER_2:
-            NVIC_DisableIRQ(TC5_IRQn);
-            break;
-#endif
         case TIMER_UNDEFINED:
             break;
     }
@@ -330,27 +321,31 @@ void timer_reset(tim_t dev)
             TIMER_1_DEV.CTRLA.bit.SWRST = 1;
             break;
 #endif
-#if TIMER_2_EN
-        case TIMER_2:
-            TIMER_2_DEV.CTRLA.bit.SWRST = 1;
-            break;
-#endif
         case TIMER_UNDEFINED:
             break;
     }
 }
 
-
 #if TIMER_0_EN
 void TIMER_0_ISR(void)
 {
     if (TIMER_0_DEV.INTFLAG.bit.MC0 && TIMER_0_DEV.INTENSET.bit.MC0) {
-        TIMER_0_DEV.INTFLAG.bit.MC0 = 1;
-        config[TIMER_0].cb(0);
+        if(config[TIMER_0].cb) {
+            TIMER_0_DEV.INTFLAG.bit.MC0 = 1;
+            TIMER_0_DEV.INTENCLR.reg = TC_INTENCLR_MC0;
+            config[TIMER_0].cb(0);            
+        }
     }
     else if (TIMER_0_DEV.INTFLAG.bit.MC1 && TIMER_0_DEV.INTENSET.bit.MC1) {
-        TIMER_0_DEV.INTFLAG.bit.MC1 = 1;
-        config[TIMER_0].cb(1);
+        if(config[TIMER_0].cb) {
+            TIMER_0_DEV.INTFLAG.bit.MC1 = 1;
+            TIMER_0_DEV.INTENCLR.reg = TC_INTENCLR_MC1;
+            config[TIMER_0].cb(1);
+        }
+    }
+
+    if (sched_context_switch_request) {
+        thread_yield();
     }
 }
 #endif /* TIMER_0_EN */
@@ -360,27 +355,23 @@ void TIMER_0_ISR(void)
 void TIMER_1_ISR(void)
 {
     if (TIMER_1_DEV.INTFLAG.bit.MC0 && TIMER_1_DEV.INTENSET.bit.MC0) {
-        TIMER_1_DEV.INTFLAG.bit.MC0 = 1;
-        config[TIMER_1].cb(0);
+        if (config[TIMER_1].cb) {
+            TIMER_1_DEV.INTFLAG.bit.MC0 = 1;
+            TIMER_1_DEV.INTENCLR.reg = TC_INTENCLR_MC0;
+            config[TIMER_1].cb(0);
+        }
     }
     else if (TIMER_1_DEV.INTFLAG.bit.MC1 && TIMER_1_DEV.INTENSET.bit.MC1) {
-        TIMER_1_DEV.INTFLAG.bit.MC1 = 1;
-        config[TIMER_1].cb(1);
+        if(config[TIMER_1].cb) {
+            TIMER_1_DEV.INTFLAG.bit.MC1 = 1;
+            TIMER_1_DEV.INTENCLR.reg = TC_INTENCLR_MC1;
+            config[TIMER_1].cb(1);
+        }
+
+    }
+
+    if (sched_context_switch_request) {
+        thread_yield();
     }
 }
 #endif /* TIMER_1_EN */
-
-
-#if TIMER_2_EN
-void TIMER_2_ISR(void)
-{
-    if (TIMER_2_DEV.INTFLAG.bit.MC0 && TIMER_2_DEV.INTENSET.bit.MC0) {
-        TIMER_2_DEV.INTFLAG.bit.MC0 = 1;
-        config[TIMER_2].cb(0);
-    }
-    else if (TIMER_2_DEV.INTFLAG.bit.MC1 && TIMER_2_DEV.INTENSET.bit.MC1) {
-        TIMER_2_DEV.INTFLAG.bit.MC1 = 1;
-        config[TIMER_2].cb(1);
-    }
-}
-#endif /* TIMER_2_EN */


### PR DESCRIPTION
The hwtimer did not work correctly on the samr21-xpro, I accidentally read that it has to use a 32 bit timer,
So I changed the timer peripheral to have 1 16-bit timer and 1 32-bit timer, and the hwtimer is now using the 32 bit timer.
