### PR TITLE
oneway-malloc: fix prototype for calloc

### DIFF
--- a/sys/oneway-malloc/include/malloc.h
+++ b/sys/oneway-malloc/include/malloc.h
@@ -59,7 +59,7 @@ void *realloc(void *ptr, size_t size);
  * @param[in]   cnt    The other factor of the number of bytes to allocated.
  * @returns     The new memory block. `NULL` if the "heap" is exhausted.
  */
-void *calloc(int size, size_t cnt);
+void *calloc(size_t size, size_t cnt);
 
 /**
  * @brief       This is a no-op.

--- a/sys/oneway-malloc/oneway-malloc.c
+++ b/sys/oneway-malloc/oneway-malloc.c
@@ -60,7 +60,7 @@ void __attribute__((weak)) *realloc(void *ptr, size_t size)
     }
 }
 
-void __attribute__((weak)) *calloc(int size, size_t cnt)
+void __attribute__((weak)) *calloc(size_t size, size_t cnt)
 {
     void *mem = malloc(size * cnt);
     if (mem) {


### PR DESCRIPTION
The prototype differs from stdlib.h
