### PR TITLE
ipv6: fix IPv6 address matching algorithm

### DIFF
--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -301,6 +301,8 @@ uint8_t ipv6_get_addr_match(const ipv6_addr_t *src,
                     break;
                 }
             }
+
+            break;
         }
     }
 


### PR DESCRIPTION
Found this by actually testing the reworked version in #2003.
