### PR TITLE
Move ringbuffer to core

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -48,7 +48,6 @@ ifneq (,$(filter sixlowpan,$(USEMODULE)))
 endif
 
 ifneq (,$(filter uart0,$(USEMODULE)))
-	USEMODULE += lib
 	USEMODULE += posix
 endif
 
@@ -100,10 +99,6 @@ endif
 
 ifneq (,$(filter rgbled,$(USEMODULE)))
 	USEMODULE += color
-endif
-
-ifneq (,$(filter pipe,$(USEMODULE)))
-	USEMODULE += lib
 endif
 
 ifneq (,$(filter libfixmath-unittests,$(USEMODULE)))

--- a/core/include/ringbuffer.h
+++ b/core/include/ringbuffer.h
@@ -8,7 +8,7 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  *
- * @ingroup sys_lib
+ * @ingroup  core_util
  * @{
  * @file   ringbuffer.h
  * @author Kaspar Schleiser <kaspar@schleiser.de>

--- a/core/ringbuffer.c
+++ b/core/ringbuffer.c
@@ -8,7 +8,7 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  *
- * @ingroup sys_lib
+ * @ingroup  core_util
  * @{
  * @file   ringbuffer.c
  * @author Kaspar Schleiser <kaspar@schleiser.de>

--- a/cpu/atmega2560/Makefile.include
+++ b/cpu/atmega2560/Makefile.include
@@ -21,8 +21,5 @@ export UNDEF += $(BINDIR)cpu/startup.o
 # export the peripheral drivers to be linked into the final binary
 export USEMODULE += periph
 
-# the uart implementation uses ringbuffer and therefore needs lib
-export USEMODULE += lib
-
 # CPU depends on the atmega common module, so include it
 include $(ATMEGA_COMMON)Makefile.include

--- a/cpu/cc2538/Makefile.include
+++ b/cpu/cc2538/Makefile.include
@@ -25,9 +25,6 @@ export UNDEF += $(BINDIR)cpu/startup.o
 # Export the peripheral drivers to be linked into the final binary:
 export USEMODULE += periph
 
-# this CPU implementation makes use of the ringbuffer, so include the lib module
-export USEMODULE += lib
-
 # CPU depends on the cortex-m common module, so include it:
 include $(CORTEX_COMMON)Makefile.include
 

--- a/cpu/nrf51822/Makefile.include
+++ b/cpu/nrf51822/Makefile.include
@@ -26,8 +26,5 @@ export UNDEF += $(BINDIR)cpu/startup.o
 # export the peripheral drivers to be linked into the final binary
 export USEMODULE += periph
 
-# the syscalls implementation makes use of the ringbuffer, so include the lib module
-export USEMODULE += lib
-
 # CPU depends on the cortex-m common module, so include it
 include $(CORTEX_COMMON)Makefile.include

--- a/cpu/sam3x8e/Makefile.include
+++ b/cpu/sam3x8e/Makefile.include
@@ -4,9 +4,6 @@ export CFLAGS += -DCOREIF_NG=1
 # export the peripheral drivers to be linked into the final binary
 export USEMODULE += periph
 
-# this CPU implementation makes use of the ringbuffer, so include the lib module
-export USEMODULE += lib
-
 # tell the build system that the CPU depends on the Cortex-M common files
 export USEMODULE += cortex-m3_common
 

--- a/cpu/samd21/Makefile.include
+++ b/cpu/samd21/Makefile.include
@@ -10,9 +10,6 @@ export USEMODULE += cortex-m0_common
 # define path to cortex-m common module, which is needed for this CPU
 export CORTEX_COMMON = $(RIOTCPU)/cortex-m0_common/
 
-# this CPU implementation makes use of the ringbuffer, so include the lib module
-export USEMODULE += lib
-
 # define the linker script to use for this CPU
 export LINKERSCRIPT ?= $(RIOTCPU)/$(CPU)/samd21_linkerscript.ld
 

--- a/cpu/stm32f0/Makefile.include
+++ b/cpu/stm32f0/Makefile.include
@@ -7,9 +7,6 @@ export USEMODULE += cortex-m0_common
 # define path to cortex-m common module, which is needed for this CPU
 export CORTEX_COMMON = $(RIOTCPU)/cortex-m0_common/
 
-# this CPU implementation makes use of the ringbuffer, so include the lib module
-export USEMODULE += lib
-
 # define the linker script to use for this CPU. The CPU_MODEL variable is defined in the
 # board's Makefile.include. This enables multiple STMF0 controllers with different memory to
 # use the same code-base.

--- a/cpu/stm32f1/Makefile.include
+++ b/cpu/stm32f1/Makefile.include
@@ -4,9 +4,6 @@ export CFLAGS += -DCOREIF_NG=1
 # tell the build system that the CPU depends on the Cortex-M common files
 export USEMODULE += cortex-m3_common
 
-# this CPU implementation makes use of the ringbuffer, so include the lib module
-export USEMODULE += lib
-
 # define path to cortex-m common module, which is needed for this CPU
 export CORTEXM_COMMON = $(RIOTCPU)/cortex-m3_common/
 

--- a/cpu/stm32f3/Makefile.include
+++ b/cpu/stm32f3/Makefile.include
@@ -4,9 +4,6 @@ export CFLAGS += -DCOREIF_NG=1
 # export the peripheral drivers to be linked into the final binary
 export USEMODULE += periph
 
-# this CPU implementation makes use of the ringbuffer, so include the lib module
-export USEMODULE += lib
-
 # tell the build system that the CPU depends on the Cortex-M common files
 export USEMODULE += cortex-m4_common
 

--- a/cpu/stm32f4/Makefile.include
+++ b/cpu/stm32f4/Makefile.include
@@ -4,9 +4,6 @@ export CFLAGS += -DCOREIF_NG=1
 # export the peripheral drivers to be linked into the final binary
 export USEMODULE += periph
 
-# this CPU implementation makes use of the ringbuffer, so include the lib module
-export USEMODULE += lib
-
 # tell the build system that the CPU depends on the Cortex-M common files
 export USEMODULE += cortex-m4_common
 

--- a/tests/periph_uart_int/Makefile
+++ b/tests/periph_uart_int/Makefile
@@ -5,7 +5,6 @@ BOARD_BLACKLIST := chronos mbed_lpc1768 msb-430 msb-430h native qemu-i386 redbee
                    wsn430-v1_3b wsn430-v1_4 z1
 # all listed boards: no periph_conf.h defined,
 
-USEMODULE += lib
 USEMODULE += vtimer
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/unittests/tests-lib/Makefile.include
+++ b/tests/unittests/tests-lib/Makefile.include
@@ -1,1 +1,0 @@
-USEMODULE += lib


### PR DESCRIPTION
Ringbuffer is needed by many platforms and also by my newmsg branch.

This PR moves it into it's own core module and adapts dependencies.
