### PR TITLE
net: socket: fix for e93d030058684f98894aafb5c4048b2c6d9d479f

### DIFF
--- a/sys/net/transport_layer/socket_base/socket.c
+++ b/sys/net/transport_layer/socket_base/socket.c
@@ -179,7 +179,7 @@ void socket_base_print_internal_socket(socket_internal_t *current_socket_interna
     printf("\n--------------------------\n");
 }
 
-int socket_base_exists_socket(int socket)
+bool socket_base_exists_socket(int socket)
 {
     if (socket < 1) {
         return false;

--- a/sys/net/transport_layer/socket_base/socket.h
+++ b/sys/net/transport_layer/socket_base/socket.h
@@ -96,7 +96,7 @@ extern "C" {
 
 socket_internal_t *socket_base_get_socket(int s);
 uint16_t socket_base_get_free_source_port(uint8_t protocol);
-int socket_base_exists_socket(int socket);
+bool socket_base_exists_socket(int socket);
 int socket_base_socket(int domain, int type, int protocol);
 void socket_base_print_sockets(void);
 


### PR DESCRIPTION
The former fix for socket initialization was broken. This fixes the
"fix" by using the right exit condition for the loops.
