### PR TITLE
netdev: Add protocol field to netdev_hlist_t struct + cppcheck suppressions

### DIFF
--- a/drivers/include/netdev/base.h
+++ b/drivers/include/netdev/base.h
@@ -145,6 +145,7 @@ typedef enum {
 typedef struct __attribute__((packed)) netdev_hlist_t {
     struct netdev_hlist_t *next;    /**< next element in list */
     struct netdev_hlist_t *prev;    /**< previous element in list */
+    netdev_proto_t protocol;        /**< protocol of the header */
     void *header;                   /**< the header stored in here */
     size_t header_len;              /**< the length of the header in byte */
 } netdev_hlist_t;

--- a/tests/netdev/main.c
+++ b/tests/netdev/main.c
@@ -756,8 +756,8 @@ static int check_state(void)
 static int send_packet(void)
 {
     netdev_hlist_t *hlist = NULL;
-    netdev_hlist_t header1 = {NULL, NULL, "header 1,", 9};
-    netdev_hlist_t header2 = {NULL, NULL, "header 2,", 9};
+    netdev_hlist_t header1 = {NULL, NULL, NETDEV_PROTO_UNKNOWN, "header 1,", 9};
+    netdev_hlist_t header2 = {NULL, NULL, NETDEV_PROTO_UNKNOWN, "header 2,", 9};
     char payload[] = "payload";
 
     netdev_hlist_add(&hlist, &header2);

--- a/tests/unittests/tests-netdev_dummy/tests-netdev_dummy.c
+++ b/tests/unittests/tests-netdev_dummy/tests-netdev_dummy.c
@@ -158,7 +158,7 @@ static void test_netdev_dummy_send_data_no_ulhs(void)
 #if UNITTESTS_NETDEV_DUMMY_MAX_PACKET > 4
 static void test_netdev_dummy_send_data_with_ulhs(void)
 {
-    netdev_hlist_t hlist_node = {NULL, NULL, TEST_STRING8, 4};
+    netdev_hlist_t hlist_node = {NULL, NULL, NETDEV_PROTO_UNKNOWN, TEST_STRING8, 4};
     netdev_hlist_t *hlist = NULL;
     char dest[] = TEST_STRING64;
     size_t dest_len = UNITTESTS_NETDEV_DUMMY_MAX_ADDR_LEN;


### PR DESCRIPTION
Just realized I need to identify headers for IPv6's next header field…
- found some issues for cppcheck
