### PR TITLE
examples/riot_and_cpp: cleanup in Makefile

### DIFF
--- a/examples/riot_and_cpp/Makefile
+++ b/examples/riot_and_cpp/Makefile
@@ -30,23 +30,6 @@ QUIET ?= 1
 # Features required
 FEATURES_REQUIRED += cpp
 
-# This example only works with native for now.
-# msb430-based boards: msp430-g++ is not provided in mspgcc.
-# (People who want use c++ can build c++ compiler from source, or get binaries from Energia http://energia.nu/)
-# msba2: some changes should be applied to successfully compile c++. (_kill_r, _kill, __dso_handle)
-# stm32f0discovery: g++ does not support some used flags (e.g. -mthumb...)
-# stm32f3discovery: g++ does not support some used flags (e.g. -mthumb...)
-# stm32f4discovery: g++ does not support some used flags (e.g. -mthumb...)
-# pca10000:         g++ does not support some used flags (e.g. -mthumb...)
-# pca10005:         g++ does not support some used flags (e.g. -mthumb...)
-# yunjia-nrf51822:  g++ does not support some used flags (e.g. -mthumb...)
-# iot-lab_M3:       g++ does not support some used flags (e.g. -mthumb...)
-# arduino-mega2560: cstdio header missing from avr-libc
-# msbiot            g++ does not support some used flags (e.g. -mthumb...)
-# samr21-xpro       g++ does not support some used flags (e.g. -mthumb...)
-# cc2538dk:         g++ does not support some used flags (e.g. -mthumb...)
-# others: untested.
-
 # If you want to add some extra flags when compile c++ files, add these flags
 # to CXXEXFLAGS variable
 CXXEXFLAGS +=


### PR DESCRIPTION
just stumbled across this one. To my knowledge the removed comments are deprecated in favor of the `FEATURES_REQUIRED` field. Also most of the boards listed do support C++ by now.
