### PR TITLE
travis: Purge locales before install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
     - echo 'deb http://us.archive.ubuntu.com/ubuntu trusty-updates   main restricted universe multiverse' | sudo tee -a /etc/apt/sources.list.d/trusty.list > /dev/null
     - sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
     - sudo apt-get update
+    - sudo locale-gen --purge en_US.UTF-8
 
 install:
     - >


### PR DESCRIPTION
For every travis build there is a locale-gen called for a bunch of
(english) locales we really don't need. This cuts it down to en_US and
hopefully will decrease build time.
