### PR TITLE
README start page: improve developement procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,21 +64,8 @@ In the `examples` directory you can find some example applications. The `default
 For example, you can use it to the test the native networking by running two instances: `make term PORT=tap0` and `make term PORT=tap1`. Now configure two different addresses for both RIOT instances by typing `addr 1` and `addr 2` respectively and send a text message from one "node" to another by typing `txtsnd 2 hello` on the first "node".
 
 ## CONTRIBUTE
-1. Check if your code follows the [coding conventions](https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions). If the code does not comply these style rules, your code will not be merged.
 
-2. Create a new branch in your own fork for every new feature or fix. Then create the pull request from this branch, once you completed your task (feature or fix). Every commit in this branch will be added to the pull request.
-
-3. The master branch should always be in a working state. The RIOT maintainers will create release tags based on this branch, whenever a milestone is completed.
-
-4. New features and fixes will always be submitted as pull requests. A pull request will be merged if the RIOT maintainers acknowledge the request. Before it will get merged, the pull request has to stay open long enough to discuss possible issues, but no longer than 30 days. The more extensive the changes in the pull request, the more time should be given for discussion.
-
-5. Comments on a pull request should be added to the request itself, and *not* to the commit.
-
-6. Only RIOT maintainers have commit rights to the main RIOT repository. However, even they have to create pull requests to submit their changes. A RIOT contributor cannot acknowledge his own pull request. All current RIOT maintainers are listed in the wiki.
-
-7. Keep commits to the point, e.g., don't add whitespace/typo fixes to other code changes. If changes are layered, layer the patches.
-
-8. Describe the technical detail of the change(s) as specific as possible.
+To contribute something to RIOT, please refer to the [development procedures](https://github.com/RIOT-OS/RIOT/wiki/Development-procedures) and read all notes for best practice.
 
 ## MAILING LISTS
 * RIOT OS kernel developers list


### PR DESCRIPTION
Hi,
regarding our virtual  meeting yesterday, I tried to improve the RIOT start page and the wiki a bit to prevent overlaps between the work of multiple developers. Let me present the changes in a nutshell so we can discuss about it:

README:
- In section "CONTRIBUTE" there have been eight bullet points which equalled 11 bullet points in the "Developement procedures" wiki. I would vote for either put all points on the start page or just give a linkt to the "Developement procedures" site. I realised the second alternative.
- What du you think?

Developement procedures: 
- I added point 11. (wasn't shure where else it is appropriate) which tells to create a wiki page, open and link an issue and put this on the mailing list once when porting for new boards.
  https://github.com/RIOT-OS/RIOT/wiki/Development-procedures

wiki/Board:-Samr21-xpro:
- Under "Implementation Status" I linked the tracker
  https://github.com/RIOT-OS/RIOT/wiki/Board:-Samr21-xpro
