### PR TITLE
Samr21: cpuid implementation

### DIFF
--- a/boards/samr21-xpro/Makefile.features
+++ b/boards/samr21-xpro/Makefile.features
@@ -1,1 +1,1 @@
-FEATURES_PROVIDED += transceiver periph_gpio periph_spi cpp periph_timer periph_uart periph_i2c cpp periph_rtc
+FEATURES_PROVIDED += transceiver periph_gpio periph_spi cpp periph_timer periph_uart periph_i2c cpp periph_rtc periph_cpuid

--- a/cpu/samd21/include/cpu-conf.h
+++ b/cpu/samd21/include/cpu-conf.h
@@ -55,5 +55,9 @@ extern "C" {
 }
 #endif
 
+/**
+ * @brief CPUID_ID_LEN length of cpuid in bytes
+ */
+#define CPUID_ID_LEN (16) /* 128 bits long, 16 bytes long */
 #endif /* __CPU_CONF_H */
 /** @} */

--- a/cpu/samd21/periph/cpuid.c
+++ b/cpu/samd21/periph/cpuid.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  driver_periph
+ * @{
+ *
+ * @file        cpuid.c
+ * @brief       Low-level CPUID driver implementation
+ *
+ * @author      Troels Hoffmeyer <troels.d.hoffmeyer@gmail.com>
+ */
+
+#include <string.h>
+
+#include "cpu-conf.h"
+#include "periph/cpuid.h"
+
+#define SAMD21_CPUID_WORD0 (*(volatile uint32_t *)0x0080A00C)
+#define SAMD21_CPUID_WORD1 (*(volatile uint32_t *)0x0080A040)
+#define SAMD21_CPUID_WORD2 (*(volatile uint32_t *)0x0080A044)
+#define SAMD21_CPUID_WORD3 (*(volatile uint32_t *)0x0080A048)
+
+
+void cpuid_get(void *id)
+{
+    uint32_t source_address[] = { SAMD21_CPUID_WORD0,
+                                  SAMD21_CPUID_WORD1,
+                                  SAMD21_CPUID_WORD2,
+                                  SAMD21_CPUID_WORD3};
+    memcpy(id, (void*) source_address, CPUID_ID_LEN);
+}


### PR DESCRIPTION
Reading the 128bit serial number in the samd21 by copying it from memory addresses that point to non-volatile memory.
The addresses come from section 8.3.3 in the datasheet.