### PR TITLE
Travis: use different emdebian mirror for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 
 before_install:
     - sudo apt-get install emdebian-archive-keyring
-    - echo 'deb http://www.emdebian.org/debian wheezy main' | sudo tee /etc/apt/sources.list.d/emdebian.list > /dev/null
+    - echo 'deb http://emdebian.bytesatwork.ch/mirror/toolchains/ wheezy main' | sudo tee /etc/apt/sources.list.d/emdebian.list > /dev/null
 
     - echo 'deb http://us.archive.ubuntu.com/ubuntu trusty           main restricted universe multiverse' | sudo tee    /etc/apt/sources.list.d/trusty.list > /dev/null
     - echo 'deb http://us.archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse' | sudo tee -a /etc/apt/sources.list.d/trusty.list > /dev/null


### PR DESCRIPTION
Workaround for https://github.com/RIOT-OS/RIOT/issues/2051
Mirror chosen from http://www.emdebian.org/grip/#mirrors
