### PR TITLE
Samr21: ADC implementation

### DIFF
--- a/boards/samr21-xpro/Makefile.features
+++ b/boards/samr21-xpro/Makefile.features
@@ -1,1 +1,1 @@
-FEATURES_PROVIDED += periph_gpio cpp
+FEATURES_PROVIDED += periph_gpio cpp periph_adc

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -120,6 +120,119 @@ extern "C" {
 #define GPIO_3_EXTINT       3
 /** @} */
 
+/**
+ * @ ADC Configuration
+ * @{
+ */
+#define ADC_NUMOF			(1U)
+#define ADC_0_EN			1
+#define ADC_MAX_CHANNELS	8
+
+/* ADC 0 device configuration */
+#define ADC_0_DEV 			ADC
+#define ADC_0_IRQ			ADC_IRQn 	
+#define ADC_0_CHANNELS      8
+
+/* ADC 0 Default values */
+#define ADC_0_CLK_SOURCE	0 //GCLK_GENERATOR_0
+#define ADC_0_PRESCALER		ADC_CTRLB_PRESCALER_DIV4
+#define ADC_0_WINDOW_MODE	ADC_WINCTRL_WINMODE_DISABLE
+#define ADC_0_CORRECTION_EN 0 // disabled
+#define ADC_0_GAIN_CORRECTION	ADC_GAINCORR_RESETVALUE
+#define ADC_0_OFFSET_CORRECTION	ADC_OFFSETCORR_RESETVALUE
+#define ADC_0_SAMPLE_LENGTH	0
+#define ADC_0_PIN_SCAN_OFFSET_START	0 // disabled
+#define	ADC_0_PIN_SCAN_INPUT_TO_SCAN	0 // disabled 	
+#define ADC_0_LEFT_ADJUST	0 // disabled
+#define ADC_0_DIFFERENTIAL_MODE	0 // disabled
+#define ADC_0_FREE_RUNNING	0 // disabled
+#define ADC_0_EVENT_ACTION	0 // disabled 	
+#define ADC_0_RUN_IN_STANDBY	0 // disabled
+
+/* ADC 0 Module Status flags */
+#define ADC_0_STATUS_RESULT_READY	(1UL << 0)
+#define ADC_0_STATUS_WINDOW			(1UL << 1)
+#define ADC_0_STATUS_OVERRUN		(1UL << 2) 	
+
+/* ADC 0 Positive Input Pins */
+#define ADC_0_POS_INPUT		ADC_INPUTCTRL_MUXPOS_PIN6
+
+/* ADC 0 Negative Input Pins */ 	
+#define ADC_0_NEG_INPUT		ADC_INPUTCTRL_MUXNEG_GND
+
+/* ADC 0 Gain Factor */
+#define ADC_0_GAIN_FACTOR_1X	ADC_INPUTCTRL_GAIN_1X
+#define ADC_0_GAIN_FACTOR_2X	ADC_INPUTCTRL_GAIN_2X
+#define ADC_0_GAIN_FACTOR_4X	ADC_INPUTCTRL_GAIN_4X
+#define ADC_0_GAIN_FACTOR_8X	ADC_INPUTCTRL_GAIN_8X
+#define ADC_0_GAIN_FACTOR_16X	ADC_INPUTCTRL_GAIN_16X
+#define ADC_0_GAIN_FACTOR_DEFAULT	ADC_0_GAIN_FACTOR_1X
+
+/* ADC 0 Resolutions */
+//#define ADC_0_RES_6BIT // NOT POSSIBLE! 	
+#define ADC_0_RES_8BIT	ADC_CTRLB_RESSEL_8BIT
+#define ADC_0_RES_10BIT ADC_CTRLB_RESSEL_10BIT
+#define ADC_0_RES_12BIT	ADC_CTRLB_RESSEL_12BIT
+//#define ADC_0_RES_14BIT // NOT POSSIBLE!
+#define ADC_0_RES_16BIT	ADC_CTRLB_RESSEL_16BIT 
+
+/* ADC 0 Voltage reference */
+#define ADC_0_REF_INT_1V	ADC_REFCTRL_REFSEL_INT1V
+#define ADC_0_REF_EXT_B		ADC_REFCTRL_REFSEL_AREFB
+#define ADC_0_REF_COM_EN	0 // default
+#define ADC_0_REF_DEFAULT	ADC_0_REF_INT_1V // Use this to define the value used
+
+/* ADC 0 ACCUMULATE */
+#define ADC_0_ACCUM_DISABLE	ADC_AVGCTRL_SAMPLENUM_1
+#define ADC_0_ACCUM_2		ADC_AVGCTRL_SAMPLENUM_2
+#define ADC_0_ACCUM_4		ADC_AVGCTRL_SAMPLENUM_4
+#define ADC_0_ACCUM_8		ADC_AVGCTRL_SAMPLENUM_8
+#define ADC_0_ACCUM_16		ADC_AVGCTRL_SAMPLENUM_16
+#define ADC_0_ACCUM_32		ADC_AVGCTRL_SAMPLENUM_32
+#define ADC_0_ACCUM_64		ADC_AVGCTRL_SAMPLENUM_64
+#define ADC_0_ACCUM_128		ADC_AVGCTRL_SAMPLENUM_128
+#define ADC_0_ACCUM_256		ADC_AVGCTRL_SAMPLENUM_256
+#define ADC_0_ACCUM_512		ADC_AVGCTRL_SAMPLENUM_512
+#define ADC_0_ACCUM_1024	ADC_AVGCTRL_SAMPLENUM_1024
+#define ADC_0_ACCUM_DEFAULT	ADC_0_ACCUM_1024 // ADC_0_ACCUM_DISABLE // Use this to define the value used
+
+/* ADC 0 DEVIDE RESULT */
+#define ADC_0_DIV_RES_DISABLE	0
+#define ADC_0_DIV_RES_2			1
+#define ADC_0_DIV_RES_4			2
+#define ADC_0_DIV_RES_8			3
+#define ADC_0_DIV_RES_16		4
+#define ADC_0_DIV_RES_32		5
+#define ADC_0_DIV_RES_64		6
+#define ADC_0_DIV_RES_128		7
+#define ADC_0_DIV_RES_DEFAULT	ADC_0_DIV_RES_DISABLE // Use this to define the value used
+	
+/* ADC 0 channel 0 pin config */
+#define ADC_0_CH0           PORT_PB08B_ADC_AIN2//10
+#define ADC_0_CH0_PIN       PIN_PB08B_ADC_AIN2//0
+/* ADC 0 channel 1 pin config */
+#define ADC_0_CH1           PORT_PB09B_ADC_AIN3//11
+#define ADC_0_CH1_PIN       PIN_PB09B_ADC_AIN3//1
+/* ADC 0 channel 2 pin config */
+#define ADC_0_CH2       	PORT_PA04B_ADC_AIN4//12
+#define ADC_0_CH2_PIN      	PIN_PA04B_ADC_AIN4//2
+/* ADC 0 channel 3 pin config */
+#define ADC_0_CH3           PORT_PA05B_ADC_AIN5//13
+#define ADC_0_CH3_PIN       PIN_PA05B_ADC_AIN5//3
+/* ADC 0 channel 4 pin config */
+#define ADC_0_CH4           PORT_PA06B_ADC_AIN6//14
+#define ADC_0_CH4_PIN       PIN_PA06B_ADC_AIN6//4
+/* ADC 0 channel 5 pin config */
+#define ADC_0_CH5           PORT_PA07B_ADC_AIN7//15
+#define ADC_0_CH5_PIN       PIN_PA07B_ADC_AIN7//5
+/* ADC 0 channel 6 pin config */
+#define ADC_0_CH6           PORT_PB00B_ADC_AIN8//14
+#define ADC_0_CH6_PIN       PIN_PB00B_ADC_AIN8//4
+/* ADC 0 channel 7 pin config */
+#define ADC_0_CH7           PORT_PB02B_ADC_AIN10//15
+#define ADC_0_CH7_PIN       PIN_PB02B_ADC_AIN10//5
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -126,116 +126,94 @@ extern "C" {
  * @ ADC Configuration
  * @{
  */
-#define ADC_NUMOF				(1U)
-#define ADC_0_EN				1
-#define ADC_MAX_CHANNELS		8
+#define ADC_NUMOF                          (1U)
+#define ADC_0_EN                           1
+#define ADC_MAX_CHANNELS                   8
 
 /* ADC 0 device configuration */
-#define ADC_0_DEV 				ADC
-#define	ADC_0_PORT 				(PORT->Group[0])
-#define ADC_0_IRQ				ADC_IRQn 	
-#define ADC_0_CHANNELS      	8
+#define ADC_0_DEV                          ADC
+#define    ADC_0_PORT                      (PORT->Group[0])
+#define ADC_0_IRQ                          ADC_IRQn     
+#define ADC_0_CHANNELS                     8
 /* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE		0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER			ADC_CTRLB_PRESCALER_DIV4
-#define ADC_0_WINDOW_MODE		ADC_WINCTRL_WINMODE_DISABLE
+#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
+#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV4
+#define ADC_0_WINDOW_MODE                  ADC_WINCTRL_WINMODE_DISABLE
+#define ADC_0_WINDOW_LOWER                 0
+#define ADC_0_WINDOW_HIGHER                0     
 
-#define ADC_0_CORRECTION_EN 	0 /* disabled */
-#define ADC_0_GAIN_CORRECTION	ADC_GAINCORR_RESETVALUE
-#define ADC_0_OFFSET_CORRECTION	ADC_OFFSETCORR_RESETVALUE
-#define ADC_0_SAMPLE_LENGTH		0
-#define ADC_0_PIN_SCAN_OFFSET_START	0 /* disabled */
-#define	ADC_0_PIN_SCAN_INPUT_TO_SCAN	0 /* disabled */	
-#define ADC_0_LEFT_ADJUST		0 /* disabled */
-#define ADC_0_DIFFERENTIAL_MODE	0 /* disabled */
-#define ADC_0_FREE_RUNNING		0 /* disabled */
-#define ADC_0_EVENT_ACTION		0 /* disabled */	
-#define ADC_0_RUN_IN_STANDBY	0 /* disabled */
+#define ADC_0_CORRECTION_EN                0 /* disabled */
+#define ADC_0_GAIN_CORRECTION              ADC_GAINCORR_RESETVALUE
+#define ADC_0_OFFSET_CORRECTION            ADC_OFFSETCORR_RESETVALUE
+#define ADC_0_SAMPLE_LENGTH                0
+#define ADC_0_PIN_SCAN_OFFSET_START        0 /* disabled */
+#define    ADC_0_PIN_SCAN_INPUT_TO_SCAN    0 /* disabled */    
+#define ADC_0_LEFT_ADJUST                  0 /* disabled */
+#define ADC_0_DIFFERENTIAL_MODE            0 /* disabled */
+#define ADC_0_FREE_RUNNING                 0 /* disabled */
+#define ADC_0_EVENT_ACTION                 0 /* disabled */    
+#define ADC_0_RUN_IN_STANDBY               0 /* disabled */
 
 /* ADC 0 Module Status flags */
-#define ADC_0_STATUS_RESULT_READY	(1UL << 0)
-#define ADC_0_STATUS_WINDOW			(1UL << 1)
-#define ADC_0_STATUS_OVERRUN		(1UL << 2) 	
+#define ADC_0_STATUS_RESULT_READY          (1UL << 0)
+#define ADC_0_STATUS_WINDOW                (1UL << 1)
+#define ADC_0_STATUS_OVERRUN               (1UL << 2)     
 
-/* ADC 0 Positive Input Pin PA06 */
-#define ADC_0_POS_INPUT			ADC_INPUTCTRL_MUXPOS_PIN6
 
-/* ADC 0 Negative Input Pin GND */ 	
-#define ADC_0_NEG_INPUT			ADC_INPUTCTRL_MUXNEG_GND
+/* ADC 0 Positive Input Pins */
+#define ADC_0_POS_INPUT                    ADC_INPUTCTRL_MUXPOS_PIN6
+
+/* ADC 0 Negative Input Pins */     
+#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
 
 /* ADC 0 Gain Factor */
-#define ADC_0_GAIN_FACTOR_1X	ADC_INPUTCTRL_GAIN_1X
-#define ADC_0_GAIN_FACTOR_2X	ADC_INPUTCTRL_GAIN_2X
-#define ADC_0_GAIN_FACTOR_4X	ADC_INPUTCTRL_GAIN_4X
-#define ADC_0_GAIN_FACTOR_8X	ADC_INPUTCTRL_GAIN_8X
-#define ADC_0_GAIN_FACTOR_16X	ADC_INPUTCTRL_GAIN_16X
+#define ADC_0_GAIN_FACTOR_1X               ADC_INPUTCTRL_GAIN_1X
+#define ADC_0_GAIN_FACTOR_2X               ADC_INPUTCTRL_GAIN_2X
+#define ADC_0_GAIN_FACTOR_4X               ADC_INPUTCTRL_GAIN_4X
+#define ADC_0_GAIN_FACTOR_8X               ADC_INPUTCTRL_GAIN_8X
+#define ADC_0_GAIN_FACTOR_16X              ADC_INPUTCTRL_GAIN_16X
 /* Use this to define the value used */
-#define ADC_0_GAIN_FACTOR_DEFAULT	ADC_0_GAIN_FACTOR_1X
+#define ADC_0_GAIN_FACTOR_DEFAULT          ADC_0_GAIN_FACTOR_1X
 
-/* ADC 0 Resolutions */	
-#define ADC_0_RES_8BIT			ADC_CTRLB_RESSEL_8BIT
-#define ADC_0_RES_10BIT 		ADC_CTRLB_RESSEL_10BIT
-#define ADC_0_RES_12BIT			ADC_CTRLB_RESSEL_12BIT
-#define ADC_0_RES_16BIT			ADC_CTRLB_RESSEL_16BIT 
+/* ADC 0 Resolutions */    
+#define ADC_0_RES_8BIT                     ADC_CTRLB_RESSEL_8BIT
+#define ADC_0_RES_10BIT                    ADC_CTRLB_RESSEL_10BIT
+#define ADC_0_RES_12BIT                    ADC_CTRLB_RESSEL_12BIT
+#define ADC_0_RES_16BIT                    ADC_CTRLB_RESSEL_16BIT 
 
 /* ADC 0 Voltage reference */
-#define ADC_0_REF_INT_1V		ADC_REFCTRL_REFSEL_INT1V
-#define ADC_0_REF_EXT_B			ADC_REFCTRL_REFSEL_AREFB
-#define ADC_0_REF_COM_EN		0
+#define ADC_0_REF_INT_1V                   ADC_REFCTRL_REFSEL_INT1V
+#define ADC_0_REF_EXT_B                    ADC_REFCTRL_REFSEL_AREFB
+#define ADC_0_REF_COM_EN                   0
 /* Use this to define the value used */ 
-#define ADC_0_REF_DEFAULT		ADC_0_REF_INT_1V
+#define ADC_0_REF_DEFAULT                  ADC_0_REF_INT_1V
 
 /* ADC 0 ACCUMULATE */
-#define ADC_0_ACCUM_DISABLE		ADC_AVGCTRL_SAMPLENUM_1
-#define ADC_0_ACCUM_2			ADC_AVGCTRL_SAMPLENUM_2
-#define ADC_0_ACCUM_4			ADC_AVGCTRL_SAMPLENUM_4
-#define ADC_0_ACCUM_8			ADC_AVGCTRL_SAMPLENUM_8
-#define ADC_0_ACCUM_16			ADC_AVGCTRL_SAMPLENUM_16
-#define ADC_0_ACCUM_32			ADC_AVGCTRL_SAMPLENUM_32
-#define ADC_0_ACCUM_64			ADC_AVGCTRL_SAMPLENUM_64
-#define ADC_0_ACCUM_128			ADC_AVGCTRL_SAMPLENUM_128
-#define ADC_0_ACCUM_256			ADC_AVGCTRL_SAMPLENUM_256
-#define ADC_0_ACCUM_512			ADC_AVGCTRL_SAMPLENUM_512
-#define ADC_0_ACCUM_1024		ADC_AVGCTRL_SAMPLENUM_1024
+#define ADC_0_ACCUM_DISABLE                ADC_AVGCTRL_SAMPLENUM_1
+#define ADC_0_ACCUM_2                      ADC_AVGCTRL_SAMPLENUM_2
+#define ADC_0_ACCUM_4                      ADC_AVGCTRL_SAMPLENUM_4
+#define ADC_0_ACCUM_8                      ADC_AVGCTRL_SAMPLENUM_8
+#define ADC_0_ACCUM_16                     ADC_AVGCTRL_SAMPLENUM_16
+#define ADC_0_ACCUM_32                     ADC_AVGCTRL_SAMPLENUM_32
+#define ADC_0_ACCUM_64                     ADC_AVGCTRL_SAMPLENUM_64
+#define ADC_0_ACCUM_128                    ADC_AVGCTRL_SAMPLENUM_128
+#define ADC_0_ACCUM_256                    ADC_AVGCTRL_SAMPLENUM_256
+#define ADC_0_ACCUM_512                    ADC_AVGCTRL_SAMPLENUM_512
+#define ADC_0_ACCUM_1024                   ADC_AVGCTRL_SAMPLENUM_1024
 /* Use this to define the value used */
-#define ADC_0_ACCUM_DEFAULT		ADC_AVGCTRL_SAMPLENUM_32 
+#define ADC_0_ACCUM_DEFAULT                ADC_0_ACCUM_DISABLE 
 
 /* ADC 0 DEVIDE RESULT */
-#define ADC_0_DIV_RES_DISABLE	0
-#define ADC_0_DIV_RES_2			1
-#define ADC_0_DIV_RES_4			2
-#define ADC_0_DIV_RES_8			3
-#define ADC_0_DIV_RES_16		4
-#define ADC_0_DIV_RES_32		5
-#define ADC_0_DIV_RES_64		6
-#define ADC_0_DIV_RES_128		7
+#define ADC_0_DIV_RES_DISABLE              0
+#define ADC_0_DIV_RES_2                    1
+#define ADC_0_DIV_RES_4                    2
+#define ADC_0_DIV_RES_8                    3
+#define ADC_0_DIV_RES_16                   4
+#define ADC_0_DIV_RES_32                   5
+#define ADC_0_DIV_RES_64                   6
+#define ADC_0_DIV_RES_128                  7
 /* Use this to define the value used */
-#define ADC_0_DIV_RES_DEFAULT	ADC_0_DIV_RES_DISABLE 
-
-/* ADC 0 channel 0 pin config - NOT implemented yet */
-#define ADC_0_CH0           	PORT_PB08B_ADC_AIN2
-#define ADC_0_CH0_PIN       	PIN_PB08B_ADC_AIN2
-/* ADC 0 channel 1 pin config */
-#define ADC_0_CH1           	PORT_PB09B_ADC_AIN3
-#define ADC_0_CH1_PIN       	PIN_PB09B_ADC_AIN3
-/* ADC 0 channel 2 pin config */
-#define ADC_0_CH2       		PORT_PA04B_ADC_AIN4
-#define ADC_0_CH2_PIN      		PIN_PA04B_ADC_AIN4
-/* ADC 0 channel 3 pin config */
-#define ADC_0_CH3           	PORT_PA05B_ADC_AIN5
-#define ADC_0_CH3_PIN       	PIN_PA05B_ADC_AIN5
-/* ADC 0 channel 4 pin config */
-#define ADC_0_CH4           	PORT_PA06B_ADC_AIN6
-#define ADC_0_CH4_PIN       	PIN_PA06B_ADC_AIN6
-/* ADC 0 channel 5 pin config */
-#define ADC_0_CH5           	PORT_PA07B_ADC_AIN7
-#define ADC_0_CH5_PIN       	PIN_PA07B_ADC_AIN7
-/* ADC 0 channel 6 pin config */
-#define ADC_0_CH6           	PORT_PB00B_ADC_AIN8
-#define ADC_0_CH6_PIN       	PIN_PB00B_ADC_AIN8
-/* ADC 0 channel 7 pin config */
-#define ADC_0_CH7           	PORT_PB02B_ADC_AIN10
-#define ADC_0_CH7_PIN       	PIN_PB02B_ADC_AIN10
+#define ADC_0_DIV_RES_DEFAULT             ADC_0_DIV_RES_DISABLE 
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -132,7 +132,7 @@ extern "C" {
 
 /* ADC 0 device configuration */
 #define ADC_0_DEV                          ADC
-#define    ADC_0_PORT                      (PORT->Group[0])
+#define ADC_0_PORT                         (PORT->Group[0])
 #define ADC_0_IRQ                          ADC_IRQn     
 #define ADC_0_CHANNELS                     8
 /* ADC 0 Default values */
@@ -147,7 +147,7 @@ extern "C" {
 #define ADC_0_OFFSET_CORRECTION            ADC_OFFSETCORR_RESETVALUE
 #define ADC_0_SAMPLE_LENGTH                0
 #define ADC_0_PIN_SCAN_OFFSET_START        0 /* disabled */
-#define    ADC_0_PIN_SCAN_INPUT_TO_SCAN    0 /* disabled */    
+#define ADC_0_PIN_SCAN_INPUT_TO_SCAN       0 /* disabled */    
 #define ADC_0_LEFT_ADJUST                  0 /* disabled */
 #define ADC_0_DIFFERENTIAL_MODE            0 /* disabled */
 #define ADC_0_FREE_RUNNING                 0 /* disabled */
@@ -157,8 +157,7 @@ extern "C" {
 /* ADC 0 Module Status flags */
 #define ADC_0_STATUS_RESULT_READY          (1UL << 0)
 #define ADC_0_STATUS_WINDOW                (1UL << 1)
-#define ADC_0_STATUS_OVERRUN               (1UL << 2)     
-
+#define ADC_0_STATUS_OVERRUN               (1UL << 2)
 
 /* ADC 0 Positive Input Pins */
 #define ADC_0_POS_INPUT                    ADC_INPUTCTRL_MUXPOS_PIN6

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -126,42 +126,42 @@ extern "C" {
  * @ ADC Configuration
  * @{
  */
-#define ADC_NUMOF		(1U)
-#define ADC_0_EN		1
-#define ADC_MAX_CHANNELS	8
+#define ADC_NUMOF				(1U)
+#define ADC_0_EN				1
+#define ADC_MAX_CHANNELS		8
 
 /* ADC 0 device configuration */
-#define ADC_0_DEV 			ADC
-#define	ADC_0_PORT			(PORT->Group[0])
-#define ADC_0_IRQ			ADC_IRQn 	
+#define ADC_0_DEV 				ADC
+#define	ADC_0_PORT 				(PORT->Group[0])
+#define ADC_0_IRQ				ADC_IRQn 	
 #define ADC_0_CHANNELS      	8
 /* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE	0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER		ADC_CTRLB_PRESCALER_DIV4
-#define ADC_0_WINDOW_MODE	ADC_WINCTRL_WINMODE_DISABLE
+#define ADC_0_CLK_SOURCE		0 /* GCLK_GENERATOR_0 */
+#define ADC_0_PRESCALER			ADC_CTRLB_PRESCALER_DIV4
+#define ADC_0_WINDOW_MODE		ADC_WINCTRL_WINMODE_DISABLE
 
-#define ADC_0_CORRECTION_EN 0 /* disabled */
+#define ADC_0_CORRECTION_EN 	0 /* disabled */
 #define ADC_0_GAIN_CORRECTION	ADC_GAINCORR_RESETVALUE
 #define ADC_0_OFFSET_CORRECTION	ADC_OFFSETCORR_RESETVALUE
-#define ADC_0_SAMPLE_LENGTH	0
+#define ADC_0_SAMPLE_LENGTH		0
 #define ADC_0_PIN_SCAN_OFFSET_START	0 /* disabled */
 #define	ADC_0_PIN_SCAN_INPUT_TO_SCAN	0 /* disabled */	
-#define ADC_0_LEFT_ADJUST	0 /* disabled */
+#define ADC_0_LEFT_ADJUST		0 /* disabled */
 #define ADC_0_DIFFERENTIAL_MODE	0 /* disabled */
-#define ADC_0_FREE_RUNNING	0 /* disabled */
-#define ADC_0_EVENT_ACTION	0 /* disabled */	
+#define ADC_0_FREE_RUNNING		0 /* disabled */
+#define ADC_0_EVENT_ACTION		0 /* disabled */	
 #define ADC_0_RUN_IN_STANDBY	0 /* disabled */
 
 /* ADC 0 Module Status flags */
 #define ADC_0_STATUS_RESULT_READY	(1UL << 0)
-#define ADC_0_STATUS_WINDOW		(1UL << 1)
+#define ADC_0_STATUS_WINDOW			(1UL << 1)
 #define ADC_0_STATUS_OVERRUN		(1UL << 2) 	
 
-/* ADC 0 Positive Input Pins */
-#define ADC_0_POS_INPUT		ADC_INPUTCTRL_MUXPOS_PIN6
+/* ADC 0 Positive Input Pin PA06 */
+#define ADC_0_POS_INPUT			ADC_INPUTCTRL_MUXPOS_PIN6
 
-/* ADC 0 Negative Input Pins */ 	
-#define ADC_0_NEG_INPUT		ADC_INPUTCTRL_MUXNEG_GND
+/* ADC 0 Negative Input Pin GND */ 	
+#define ADC_0_NEG_INPUT			ADC_INPUTCTRL_MUXNEG_GND
 
 /* ADC 0 Gain Factor */
 #define ADC_0_GAIN_FACTOR_1X	ADC_INPUTCTRL_GAIN_1X
@@ -169,36 +169,36 @@ extern "C" {
 #define ADC_0_GAIN_FACTOR_4X	ADC_INPUTCTRL_GAIN_4X
 #define ADC_0_GAIN_FACTOR_8X	ADC_INPUTCTRL_GAIN_8X
 #define ADC_0_GAIN_FACTOR_16X	ADC_INPUTCTRL_GAIN_16X
- 	/* Use this to define the value used */
+/* Use this to define the value used */
 #define ADC_0_GAIN_FACTOR_DEFAULT	ADC_0_GAIN_FACTOR_1X
 
 /* ADC 0 Resolutions */	
-#define ADC_0_RES_8BIT	ADC_CTRLB_RESSEL_8BIT
-#define ADC_0_RES_10BIT ADC_CTRLB_RESSEL_10BIT
-#define ADC_0_RES_12BIT	ADC_CTRLB_RESSEL_12BIT
-#define ADC_0_RES_16BIT	ADC_CTRLB_RESSEL_16BIT 
+#define ADC_0_RES_8BIT			ADC_CTRLB_RESSEL_8BIT
+#define ADC_0_RES_10BIT 		ADC_CTRLB_RESSEL_10BIT
+#define ADC_0_RES_12BIT			ADC_CTRLB_RESSEL_12BIT
+#define ADC_0_RES_16BIT			ADC_CTRLB_RESSEL_16BIT 
 
 /* ADC 0 Voltage reference */
-#define ADC_0_REF_INT_1V	ADC_REFCTRL_REFSEL_INT1V
-#define ADC_0_REF_EXT_B		ADC_REFCTRL_REFSEL_AREFB
-#define ADC_0_REF_COM_EN	0
+#define ADC_0_REF_INT_1V		ADC_REFCTRL_REFSEL_INT1V
+#define ADC_0_REF_EXT_B			ADC_REFCTRL_REFSEL_AREFB
+#define ADC_0_REF_COM_EN		0
 /* Use this to define the value used */ 
-#define ADC_0_REF_DEFAULT	ADC_0_REF_EXT_B
+#define ADC_0_REF_DEFAULT		ADC_0_REF_INT_1V
 
 /* ADC 0 ACCUMULATE */
-#define ADC_0_ACCUM_DISABLE	ADC_AVGCTRL_SAMPLENUM_1
-#define ADC_0_ACCUM_2		ADC_AVGCTRL_SAMPLENUM_2
-#define ADC_0_ACCUM_4		ADC_AVGCTRL_SAMPLENUM_4
-#define ADC_0_ACCUM_8		ADC_AVGCTRL_SAMPLENUM_8
-#define ADC_0_ACCUM_16		ADC_AVGCTRL_SAMPLENUM_16
-#define ADC_0_ACCUM_32		ADC_AVGCTRL_SAMPLENUM_32
-#define ADC_0_ACCUM_64		ADC_AVGCTRL_SAMPLENUM_64
-#define ADC_0_ACCUM_128		ADC_AVGCTRL_SAMPLENUM_128
-#define ADC_0_ACCUM_256		ADC_AVGCTRL_SAMPLENUM_256
-#define ADC_0_ACCUM_512		ADC_AVGCTRL_SAMPLENUM_512
-#define ADC_0_ACCUM_1024	ADC_AVGCTRL_SAMPLENUM_1024
+#define ADC_0_ACCUM_DISABLE		ADC_AVGCTRL_SAMPLENUM_1
+#define ADC_0_ACCUM_2			ADC_AVGCTRL_SAMPLENUM_2
+#define ADC_0_ACCUM_4			ADC_AVGCTRL_SAMPLENUM_4
+#define ADC_0_ACCUM_8			ADC_AVGCTRL_SAMPLENUM_8
+#define ADC_0_ACCUM_16			ADC_AVGCTRL_SAMPLENUM_16
+#define ADC_0_ACCUM_32			ADC_AVGCTRL_SAMPLENUM_32
+#define ADC_0_ACCUM_64			ADC_AVGCTRL_SAMPLENUM_64
+#define ADC_0_ACCUM_128			ADC_AVGCTRL_SAMPLENUM_128
+#define ADC_0_ACCUM_256			ADC_AVGCTRL_SAMPLENUM_256
+#define ADC_0_ACCUM_512			ADC_AVGCTRL_SAMPLENUM_512
+#define ADC_0_ACCUM_1024		ADC_AVGCTRL_SAMPLENUM_1024
 /* Use this to define the value used */
-#define ADC_0_ACCUM_DEFAULT	ADC_AVGCTRL_SAMPLENUM_32 
+#define ADC_0_ACCUM_DEFAULT		ADC_AVGCTRL_SAMPLENUM_32 
 
 /* ADC 0 DEVIDE RESULT */
 #define ADC_0_DIV_RES_DISABLE	0
@@ -213,29 +213,29 @@ extern "C" {
 #define ADC_0_DIV_RES_DEFAULT	ADC_0_DIV_RES_DISABLE 
 
 /* ADC 0 channel 0 pin config - NOT implemented yet */
-#define ADC_0_CH0           PORT_PB08B_ADC_AIN2//10
-#define ADC_0_CH0_PIN       PIN_PB08B_ADC_AIN2//0
+#define ADC_0_CH0           	PORT_PB08B_ADC_AIN2
+#define ADC_0_CH0_PIN       	PIN_PB08B_ADC_AIN2
 /* ADC 0 channel 1 pin config */
-#define ADC_0_CH1           PORT_PB09B_ADC_AIN3//11
-#define ADC_0_CH1_PIN       PIN_PB09B_ADC_AIN3//1
+#define ADC_0_CH1           	PORT_PB09B_ADC_AIN3
+#define ADC_0_CH1_PIN       	PIN_PB09B_ADC_AIN3
 /* ADC 0 channel 2 pin config */
-#define ADC_0_CH2       	PORT_PA04B_ADC_AIN4//12
-#define ADC_0_CH2_PIN      	PIN_PA04B_ADC_AIN4//2
+#define ADC_0_CH2       		PORT_PA04B_ADC_AIN4
+#define ADC_0_CH2_PIN      		PIN_PA04B_ADC_AIN4
 /* ADC 0 channel 3 pin config */
-#define ADC_0_CH3           PORT_PA05B_ADC_AIN5//13
-#define ADC_0_CH3_PIN       PIN_PA05B_ADC_AIN5//3
+#define ADC_0_CH3           	PORT_PA05B_ADC_AIN5
+#define ADC_0_CH3_PIN       	PIN_PA05B_ADC_AIN5
 /* ADC 0 channel 4 pin config */
-#define ADC_0_CH4           PORT_PA06B_ADC_AIN6//14
-#define ADC_0_CH4_PIN       PIN_PA06B_ADC_AIN6//4
+#define ADC_0_CH4           	PORT_PA06B_ADC_AIN6
+#define ADC_0_CH4_PIN       	PIN_PA06B_ADC_AIN6
 /* ADC 0 channel 5 pin config */
-#define ADC_0_CH5           PORT_PA07B_ADC_AIN7//15
-#define ADC_0_CH5_PIN       PIN_PA07B_ADC_AIN7//5
+#define ADC_0_CH5           	PORT_PA07B_ADC_AIN7
+#define ADC_0_CH5_PIN       	PIN_PA07B_ADC_AIN7
 /* ADC 0 channel 6 pin config */
-#define ADC_0_CH6           PORT_PB00B_ADC_AIN8//14
-#define ADC_0_CH6_PIN       PIN_PB00B_ADC_AIN8//4
+#define ADC_0_CH6           	PORT_PB00B_ADC_AIN8
+#define ADC_0_CH6_PIN       	PIN_PB00B_ADC_AIN8
 /* ADC 0 channel 7 pin config */
-#define ADC_0_CH7           PORT_PB02B_ADC_AIN10//15
-#define ADC_0_CH7_PIN       PIN_PB02B_ADC_AIN10//5
+#define ADC_0_CH7           	PORT_PB02B_ADC_AIN10
+#define ADC_0_CH7_PIN       	PIN_PB02B_ADC_AIN10
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -120,38 +120,41 @@ extern "C" {
 #define GPIO_3_EXTINT       3
 /** @} */
 
+/** @} */
+
 /**
  * @ ADC Configuration
  * @{
  */
-#define ADC_NUMOF			(1U)
-#define ADC_0_EN			1
+#define ADC_NUMOF		(1U)
+#define ADC_0_EN		1
 #define ADC_MAX_CHANNELS	8
 
 /* ADC 0 device configuration */
 #define ADC_0_DEV 			ADC
+#define	ADC_0_PORT			(PORT->Group[0])
 #define ADC_0_IRQ			ADC_IRQn 	
-#define ADC_0_CHANNELS      8
-
+#define ADC_0_CHANNELS      	8
 /* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE	0 //GCLK_GENERATOR_0
+#define ADC_0_CLK_SOURCE	0 /* GCLK_GENERATOR_0 */
 #define ADC_0_PRESCALER		ADC_CTRLB_PRESCALER_DIV4
 #define ADC_0_WINDOW_MODE	ADC_WINCTRL_WINMODE_DISABLE
-#define ADC_0_CORRECTION_EN 0 // disabled
+
+#define ADC_0_CORRECTION_EN 0 /* disabled */
 #define ADC_0_GAIN_CORRECTION	ADC_GAINCORR_RESETVALUE
 #define ADC_0_OFFSET_CORRECTION	ADC_OFFSETCORR_RESETVALUE
 #define ADC_0_SAMPLE_LENGTH	0
-#define ADC_0_PIN_SCAN_OFFSET_START	0 // disabled
-#define	ADC_0_PIN_SCAN_INPUT_TO_SCAN	0 // disabled 	
-#define ADC_0_LEFT_ADJUST	0 // disabled
-#define ADC_0_DIFFERENTIAL_MODE	0 // disabled
-#define ADC_0_FREE_RUNNING	0 // disabled
-#define ADC_0_EVENT_ACTION	0 // disabled 	
-#define ADC_0_RUN_IN_STANDBY	0 // disabled
+#define ADC_0_PIN_SCAN_OFFSET_START	0 /* disabled */
+#define	ADC_0_PIN_SCAN_INPUT_TO_SCAN	0 /* disabled */	
+#define ADC_0_LEFT_ADJUST	0 /* disabled */
+#define ADC_0_DIFFERENTIAL_MODE	0 /* disabled */
+#define ADC_0_FREE_RUNNING	0 /* disabled */
+#define ADC_0_EVENT_ACTION	0 /* disabled */	
+#define ADC_0_RUN_IN_STANDBY	0 /* disabled */
 
 /* ADC 0 Module Status flags */
 #define ADC_0_STATUS_RESULT_READY	(1UL << 0)
-#define ADC_0_STATUS_WINDOW			(1UL << 1)
+#define ADC_0_STATUS_WINDOW		(1UL << 1)
 #define ADC_0_STATUS_OVERRUN		(1UL << 2) 	
 
 /* ADC 0 Positive Input Pins */
@@ -166,21 +169,21 @@ extern "C" {
 #define ADC_0_GAIN_FACTOR_4X	ADC_INPUTCTRL_GAIN_4X
 #define ADC_0_GAIN_FACTOR_8X	ADC_INPUTCTRL_GAIN_8X
 #define ADC_0_GAIN_FACTOR_16X	ADC_INPUTCTRL_GAIN_16X
+ 	/* Use this to define the value used */
 #define ADC_0_GAIN_FACTOR_DEFAULT	ADC_0_GAIN_FACTOR_1X
 
-/* ADC 0 Resolutions */
-//#define ADC_0_RES_6BIT // NOT POSSIBLE! 	
+/* ADC 0 Resolutions */	
 #define ADC_0_RES_8BIT	ADC_CTRLB_RESSEL_8BIT
 #define ADC_0_RES_10BIT ADC_CTRLB_RESSEL_10BIT
 #define ADC_0_RES_12BIT	ADC_CTRLB_RESSEL_12BIT
-//#define ADC_0_RES_14BIT // NOT POSSIBLE!
 #define ADC_0_RES_16BIT	ADC_CTRLB_RESSEL_16BIT 
 
 /* ADC 0 Voltage reference */
 #define ADC_0_REF_INT_1V	ADC_REFCTRL_REFSEL_INT1V
 #define ADC_0_REF_EXT_B		ADC_REFCTRL_REFSEL_AREFB
-#define ADC_0_REF_COM_EN	0 // default
-#define ADC_0_REF_DEFAULT	ADC_0_REF_INT_1V // Use this to define the value used
+#define ADC_0_REF_COM_EN	0
+/* Use this to define the value used */ 
+#define ADC_0_REF_DEFAULT	ADC_0_REF_EXT_B
 
 /* ADC 0 ACCUMULATE */
 #define ADC_0_ACCUM_DISABLE	ADC_AVGCTRL_SAMPLENUM_1
@@ -194,7 +197,8 @@ extern "C" {
 #define ADC_0_ACCUM_256		ADC_AVGCTRL_SAMPLENUM_256
 #define ADC_0_ACCUM_512		ADC_AVGCTRL_SAMPLENUM_512
 #define ADC_0_ACCUM_1024	ADC_AVGCTRL_SAMPLENUM_1024
-#define ADC_0_ACCUM_DEFAULT	ADC_0_ACCUM_1024 // ADC_0_ACCUM_DISABLE // Use this to define the value used
+/* Use this to define the value used */
+#define ADC_0_ACCUM_DEFAULT	ADC_AVGCTRL_SAMPLENUM_32 
 
 /* ADC 0 DEVIDE RESULT */
 #define ADC_0_DIV_RES_DISABLE	0
@@ -205,9 +209,10 @@ extern "C" {
 #define ADC_0_DIV_RES_32		5
 #define ADC_0_DIV_RES_64		6
 #define ADC_0_DIV_RES_128		7
-#define ADC_0_DIV_RES_DEFAULT	ADC_0_DIV_RES_DISABLE // Use this to define the value used
-	
-/* ADC 0 channel 0 pin config */
+/* Use this to define the value used */
+#define ADC_0_DIV_RES_DEFAULT	ADC_0_DIV_RES_DISABLE 
+
+/* ADC 0 channel 0 pin config - NOT implemented yet */
 #define ADC_0_CH0           PORT_PB08B_ADC_AIN2//10
 #define ADC_0_CH0_PIN       PIN_PB08B_ADC_AIN2//0
 /* ADC 0 channel 1 pin config */

--- a/cpu/samd21/periph/adc.c
+++ b/cpu/samd21/periph/adc.c
@@ -184,18 +184,10 @@ int adc_configure_with_resolution(Adc* adc, uint32_t precision)
     if(adc->CTRLA.reg & ADC_CTRLA_ENABLE)
         return -1;
     
-    /* Cache the new config to reduce sync requirements */
-    uint32_t new_config = (ADC_GCLK_ID << GCLK_CLKCTRL_ID_Pos);
-    /* Select the desired generic clock generator */
-    new_config |= ADC_0_CLK_SOURCE << GCLK_CLKCTRL_GEN_Pos;
-    /* Setup generic clock channel for adc */                             
-    GCLK->CLKCTRL.reg |= (ADC_GCLK_ID << GCLK_CLKCTRL_GEN_Pos);
-    /* Write the new configuration */
-    GCLK->CLKCTRL.reg = new_config;
-    /*Choose generic clock channel */
-    *((uint8_t*)&GCLK->CLKCTRL.reg) = ADC_GCLK_ID;
-    /* Enable generic clock */
-    GCLK->CLKCTRL.reg |= GCLK_CLKCTRL_CLKEN;
+    /* GCLK Setup*/
+    GCLK->CLKCTRL.reg = (uint32_t)((GCLK_CLKCTRL_CLKEN
+                          | GCLK_CLKCTRL_GEN_GCLK0 
+                          | (ADC_GCLK_ID << GCLK_CLKCTRL_ID_Pos)));
 
      /* Pin Muxing */
     ADC_0_PORT.PINCFG[ ADC_0_POS_INPUT ].bit.PMUXEN = 1;

--- a/cpu/samd21/periph/adc.c
+++ b/cpu/samd21/periph/adc.c
@@ -22,7 +22,7 @@
 #include "cpu.h"
 #include "periph/adc.h"
 #include "periph_conf.h"
-#define ENABLE_DEBUG    (1)
+#define ENABLE_DEBUG    (0)
 #include "debug.h"
 
 /* guard in case that no ADC device is defined */

--- a/cpu/samd21/periph/adc.c
+++ b/cpu/samd21/periph/adc.c
@@ -222,8 +222,19 @@ int adc_configure_with_resolution(Adc* adc, uint32_t precision)
         resolution = ADC_0_RES_12BIT;
         break;
     case ADC_0_RES_16BIT:
-        divideResult = (ADC_0_DIV_RES_DISABLE | ADC_0_DIV_RES_DEFAULT);
-        accumulate = (ADC_0_ACCUM_256 | ADC_0_ACCUM_DEFAULT);
+        divideResult = ADC_0_DIV_RES_DISABLE;
+        switch(ADC_0_ACCUM_DEFAULT)
+        {
+            case ADC_0_ACCUM_512:
+                accumulate = ADC_0_ACCUM_512;
+                break;
+            case ADC_0_ACCUM_1024:
+                accumulate = ADC_0_ACCUM_1024;
+                break;
+            default:
+                accumulate = ADC_0_ACCUM_256;
+                break;
+        }        
         resolution = ADC_0_RES_16BIT;
         break;
     default:

--- a/cpu/samd21/periph/adc.c
+++ b/cpu/samd21/periph/adc.c
@@ -1,0 +1,321 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_samr21
+ * @{
+ *
+ * @file
+ * @brief       ADC driver implementation
+ *
+ * @author      Rane Balslev (SAMR21) <ranebalslev@gmail.com> 
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include "cpu.h"
+#include "periph/adc.h"
+#include "periph_conf.h"
+#define ENABLE_DEBUG    (1)
+#include "debug.h"
+
+/* guard in case that no ADC device is defined */
+#if ADC_NUMOF
+
+/* Prototypes */
+bool adc_syncing(Adc*);
+void adc_clear_status(Adc*, uint32_t);
+bool adc_get_status(Adc*);
+void adc_configure_with_resolution(Adc*, int);
+
+/**
+ * @brief Initialization of a given ADC device
+ *
+ * The ADC will be initialized in synchronous, blocking mode, so no callbacks for finished
+ * conversions are required as conversions are presumed to be very fast (somewhere in the
+ * range of some us).
+ *
+ * @param[in] dev           the device to initialize
+ * @param[in] precision     the precision to use for conversion
+ *
+ * @return                  0 on success
+ * @return                  -1 on precision not available
+ */
+int adc_init(adc_t dev, adc_precision_t precision)
+{
+    adc_poweron(dev);
+    Adc *adc = 0;
+    switch (dev) {
+    #if ADC_0_EN
+        case ADC_0:
+            adc = ADC_0_DEV;
+
+            switch (precision) 
+            {
+                case ADC_RES_6BIT: // Not possible!
+                    return -1;
+                    break;
+                case ADC_RES_8BIT:
+                    adc_configure_with_resolution(adc, ADC_0_RES_8BIT); 
+                    break;
+                case ADC_RES_10BIT:
+                    adc_configure_with_resolution(adc, ADC_0_RES_10BIT); 
+                    break;
+                case ADC_RES_12BIT:
+                    adc_configure_with_resolution(adc, ADC_0_RES_12BIT); 
+                    break;
+                case ADC_RES_14BIT: // Not possible!
+                    return -1;
+                    break;
+                case ADC_RES_16BIT:
+                    adc_configure_with_resolution(adc, ADC_0_RES_16BIT);            
+                    break;
+                default:
+                    return -1;
+            }
+            while(adc_syncing(adc));
+            /* Enable bandgap if internal ref 1 volt */
+            if(ADC_0_REF_DEFAULT == ADC_0_REF_INT_1V)
+            {
+                SYSCTRL->VREF.reg |= SYSCTRL_VREF_BGOUTEN;                    
+            }
+            /* Enable */
+            adc->CTRLA.reg |= ADC_CTRLA_ENABLE;
+        break;
+    #endif
+        default:
+            return -1;
+    }
+    return 0;
+}
+
+/**
+ * @brief Start a new conversion by using the given channel.
+ *
+ * If a conversion on any channel on the given ADC core is in progress, it is aborted.
+ *
+ * @param[in] dev           the ADC device to use for the conversion
+ * @param[in] channel       the channel to convert from
+ *
+ * @return                  the converted value
+ * @return                  -1 on invalid channel
+ */
+int adc_sample(adc_t dev, int channel)
+{
+    uint16_t result;
+    Adc *adc = 0;
+    switch (dev)
+    {
+    #if ADC_0_EN
+        case ADC_0:
+            adc = ADC_0_DEV;
+            /* Starts the ADC conversion */
+            while(adc_syncing(adc));
+            adc->SWTRIG.reg |= ADC_SWTRIG_START;
+        break;
+    #endif
+    }
+    while(adc_syncing(adc));
+    result = adc->RESULT.reg;
+    //CLEAR RESET FLAG
+    adc_clear_status(adc, ADC_0_STATUS_RESULT_READY);
+    while(!adc_get_status(adc)){} /* MUST NOT BLOCK */
+    return result;
+}
+
+/**
+ * @brief Enable the power for the given ADC device
+ *
+ * @param[in] dev           the ADC device to power up
+ */
+void adc_poweron(adc_t dev) 
+{
+    switch (dev) 
+    {
+    #if ADC_0_EN
+        case ADC_0:
+            /* Setup generic clock mask for adc */
+            PM->APBCMASK.reg |= PM_APBCMASK_ADC;
+            /* Setup generic clock channel for adc */ 
+            //system_gclk_chan_disable(ADC_GCLK_ID); //TODO:                            
+            GCLK->CLKCTRL.reg |= (ADC_GCLK_ID << GCLK_CLKCTRL_GEN_Pos);
+            /* Enable generic clock channel */
+            // Need a "mutex" ???  TODO:  
+            // Select requested generator channel
+            *((uint8_t*)&GCLK->CLKCTRL.reg) |= ADC_GCLK_ID;
+            // enable generic clock
+            GCLK->CLKCTRL.reg |= GCLK_CLKCTRL_CLKEN;
+            //release mutex TODO:
+            break;
+    #endif
+        default:
+            break;    
+    }
+}
+
+/**
+ * @brief Disable the power for the given ADC device
+ *
+ * @param[in] dev           the ADC device to power down
+ */
+void adc_poweroff(adc_t dev)
+{
+    Adc *adc = 0;
+    
+    switch (dev) 
+    {
+    #if ADC_0_EN
+        case ADC_0:
+            adc = ADC_0_DEV;
+            while(adc_syncing(adc));
+            /* Disable */
+            adc->CTRLA.reg &= ~ADC_CTRLA_ENABLE;
+            break;
+    #endif
+        default:
+            break;
+    }
+}
+
+/**
+ * @brief Helper function to map a converted value to the given integer range.
+ *
+ * This function is useful for converting sampled ADC values into their physical representation.
+ *
+ * The min value is asserted to be smaller than the max value.
+ *
+ * @param[in] dev           the ADC device to read the precision value from (as input interval)
+ * @param[in] value         the value to map
+ * @param[in] min           the lower bound of the target interval
+ * @param[in] max           the upper bound of the target interval
+ *
+ * @return                  the mapped value
+ */
+int adc_map(adc_t dev, int value, int min, int max)
+{
+    DEBUG("adc_map Not implemented!\n");
+    return 0;
+}
+
+/**
+ * @brief Helper function to map a converted value to the given float range
+ *
+ * @see adc_map
+ *
+ * @param[in] dev           the ADC device to read the precision value from (as input interval)
+ * @param[in] value         the value to map
+ * @param[in] min           the lower bound of the target interval
+ * @param[in] max           the upper bound of the target interval
+ *
+ * @return                  the mapped value
+ */
+float adc_mapf(adc_t dev, int value, float min, float max)
+{
+    DEBUG("adc_mapf Not implemented!\n");
+    return 0.0;
+}
+
+/* ADC syncing */
+bool adc_syncing(Adc* adc)
+{
+    if(adc->STATUS.reg & ADC_STATUS_SYNCBUSY)
+        return true;
+    return false;
+}
+
+/* Configure ADC with defined Resolution */
+void adc_configure_with_resolution(Adc* adc, int precision)
+{
+    adc->CTRLA.reg = (ADC_0_RUN_IN_STANDBY << ADC_CTRLA_RUNSTDBY_Pos); // Set RUN_IN_STANDBY register to default
+    adc->REFCTRL.reg = (ADC_0_REF_COM_EN << ADC_REFCTRL_REFCOMP_Pos) | ADC_0_REF_DEFAULT; // Set Reference config register to default
+    adc->AVGCTRL.reg = ADC_AVGCTRL_ADJRES(ADC_0_DIV_RES_DEFAULT) | ADC_0_ACCUM_DEFAULT; // Set the accumaltion and devide results register
+    adc->SAMPCTRL.reg = (ADC_0_SAMPLE_LENGTH << ADC_SAMPCTRL_SAMPLEN_Pos); // Set Sample length register with default value
+    while(adc_syncing(adc)) {/*wait for the ADC to become ready!*/ } 
+
+    /* Configure CTRLB Register*/  // <---- HERE IS THE RESOLUTION SET!
+    adc->CTRLB.reg = 
+        ADC_0_PRESCALER | 
+        /*ADC_0_RES_16BIT*/
+        precision | 
+        (ADC_0_CORRECTION_EN << ADC_CTRLB_CORREN_Pos) | 
+        (ADC_0_FREE_RUNNING << ADC_CTRLB_FREERUN_Pos) | 
+        (ADC_0_LEFT_ADJUST << ADC_CTRLB_LEFTADJ_Pos) |
+        (ADC_0_DIFFERENTIAL_MODE << ADC_CTRLB_DIFFMODE_Pos);        
+    while(adc_syncing(adc)) {/*wait for the ADC to become ready!*/ }
+
+    /* Configure Window Mode Register */
+    adc->WINCTRL.reg = ADC_0_WINDOW_MODE;
+    while(adc_syncing(adc)) {/*wait for the ADC to become ready!*/ }
+
+    //Perhaps lower&upper window must be set, even though it's disabled???
+
+    /* Configure PIN SCAN MODE & positive & Negative Input Pins */
+    adc->INPUTCTRL.reg = 
+        ADC_0_GAIN_FACTOR_DEFAULT |
+        (ADC_0_PIN_SCAN_OFFSET_START << ADC_INPUTCTRL_INPUTOFFSET_Pos) |
+        (ADC_0_PIN_SCAN_INPUT_TO_SCAN << ADC_INPUTCTRL_INPUTSCAN_Pos) |
+        ADC_0_NEG_INPUT |
+        ADC_0_POS_INPUT;
+
+    /* Configure event action */
+    adc->EVCTRL.reg = ADC_0_EVENT_ACTION;
+
+    /* Disable all interrupts */
+    adc->INTENCLR.reg =
+        (1 << ADC_INTENCLR_SYNCRDY_Pos) | (1 << ADC_INTENCLR_WINMON_Pos) |
+        (1 << ADC_INTENCLR_OVERRUN_Pos) | (1 << ADC_INTENCLR_RESRDY_Pos);     
+
+    /* Load the fixed device calibration constants*/
+    adc->CALIB.reg =
+        ADC_CALIB_BIAS_CAL(
+            (*(uint32_t*)ADC_FUSES_BIASCAL_ADDR >> ADC_FUSES_BIASCAL_Pos)
+        ) |
+        ADC_CALIB_LINEARITY_CAL(
+            (*(uint64_t*)ADC_FUSES_LINEARITY_0_ADDR >> ADC_FUSES_LINEARITY_0_Pos)
+        );
+}
+
+/* Clear interrupt status flags */
+void adc_clear_status(Adc* adc, uint32_t status_flag)
+{
+    uint32_t interrupt_flags = 0;
+
+    if(status_flag & ADC_0_STATUS_RESULT_READY)
+        interrupt_flags |= ADC_INTFLAG_RESRDY;
+    if(status_flag & ADC_0_STATUS_WINDOW)
+        interrupt_flags |= ADC_INTFLAG_WINMON;
+    if(status_flag & ADC_0_STATUS_OVERRUN)
+        interrupt_flags |= ADC_INTFLAG_OVERRUN; 
+
+    /* Clear interrupt flag*/
+    adc->INTFLAG.reg = interrupt_flags;
+}
+
+/* Get ADC status */
+bool adc_get_status(Adc* adc)
+{
+    uint32_t interrupt_flags = adc->INTFLAG.reg;
+    uint32_t status_flags = 0;
+
+    if(interrupt_flags & ADC_INTFLAG_RESRDY)
+        status_flags |= ADC_0_STATUS_RESULT_READY;
+    if(interrupt_flags & ADC_INTFLAG_WINMON)
+        status_flags |= ADC_0_STATUS_WINDOW;
+    if(interrupt_flags & ADC_INTFLAG_OVERRUN)
+    {
+        status_flags |= ADC_0_STATUS_OVERRUN;
+        //adc_clear_status(adc, ADC_0_STATUS_OVERRUN); // TODO:
+    }
+    if(status_flags > 0)
+        return false;
+    else
+        return true;
+}
+
+#endif /* ADC_NUMOF */

--- a/cpu/samd21/periph/adc.c
+++ b/cpu/samd21/periph/adc.c
@@ -31,36 +31,41 @@
 /* Prototypes */
 bool adc_syncing(Adc*);
 void adc_clear_status(Adc*, uint32_t);
-bool adc_get_status(Adc*);
-void adc_configure_with_resolution(Adc*, int);
+uint32_t adc_get_status(Adc*);
+int adc_configure_with_resolution(Adc*, uint32_t);
 
 int adc_init(adc_t dev, adc_precision_t precision)
 {
     adc_poweron(dev);
     Adc *adc = 0;
+    int init = 0;
     switch (dev) {
     #if ADC_0_EN
         case ADC_0:
             adc = ADC_0_DEV;
-
+            while(adc_syncing(adc));
+            /*Disable adc before init*/
+            adc->CTRLA.reg &= ~ADC_CTRLA_ENABLE;
             switch (precision) 
             {
                 case ADC_RES_8BIT:
-                    adc_configure_with_resolution(adc, ADC_0_RES_8BIT); 
+                    init = adc_configure_with_resolution(adc, ADC_0_RES_8BIT); 
                     break;
                 case ADC_RES_10BIT:
-                    adc_configure_with_resolution(adc, ADC_0_RES_10BIT); 
+                    init = adc_configure_with_resolution(adc, ADC_0_RES_10BIT); 
                     break;
                 case ADC_RES_12BIT:
-                    adc_configure_with_resolution(adc, ADC_0_RES_12BIT); 
+                    init = adc_configure_with_resolution(adc, ADC_0_RES_12BIT); 
                     break;
                 case ADC_RES_16BIT:
-                    adc_configure_with_resolution(adc, ADC_0_RES_16BIT);            
+                    init = adc_configure_with_resolution(adc, ADC_0_RES_16BIT);            
                     break;
                 default:
                     return -1;
             }
             while(adc_syncing(adc));
+            if(init == -1)
+                return -1;
             /* Enable bandgap if internal ref 1 volt */
             if(ADC_0_REF_DEFAULT == ADC_0_REF_INT_1V)
             {
@@ -78,7 +83,7 @@ int adc_init(adc_t dev, adc_precision_t precision)
 
 int adc_sample(adc_t dev, int channel)
 {
-    uint16_t result;
+    int result = 0;
     Adc *adc = 0;
     switch (dev)
     {
@@ -91,13 +96,24 @@ int adc_sample(adc_t dev, int channel)
         break;
     #endif
         default:
+            DEBUG("case default\n");
             return -1;
+    }
+    /* MUST NOT BLOCK */
+    while(!(adc_get_status(adc) & ADC_0_STATUS_RESULT_READY))
+    {
+        DEBUG("STATUS NOT READY\n");
     }
     while(adc_syncing(adc));
     result = adc->RESULT.reg;
     /*CLEAR RESET FLAG */
     adc_clear_status(adc, ADC_0_STATUS_RESULT_READY);
-    while(!adc_get_status(adc)){} /* MUST NOT BLOCK */
+    if (adc_get_status(adc) & ADC_0_STATUS_OVERRUN) 
+    {
+        adc_clear_status(adc, ADC_0_STATUS_OVERRUN);
+        DEBUG("OVERRUN\n");
+        return -1;
+    }
     return result;
 }
 
@@ -111,7 +127,7 @@ void adc_poweron(adc_t dev)
             PM->APBCMASK.reg |= PM_APBCMASK_ADC;
             /* Setup generic clock channel for adc */                             
             GCLK->CLKCTRL.reg |= (ADC_GCLK_ID << GCLK_CLKCTRL_GEN_Pos);
-            /* Enable generic clock channel */
+             /*Enable generic clock channel */
             *((uint8_t*)&GCLK->CLKCTRL.reg) |= ADC_GCLK_ID;
             /* enable generic clock */
             GCLK->CLKCTRL.reg |= GCLK_CLKCTRL_CLKEN;
@@ -155,23 +171,72 @@ float adc_mapf(adc_t dev, int value, float min, float max)
 
 bool adc_syncing(Adc* adc)
 {
-    if(adc->STATUS.reg & ADC_STATUS_SYNCBUSY)
+    if(adc->STATUS.reg & ADC_STATUS_SYNCBUSY){
         return true;
+    }
     return false;
 }
 
 /* Configure ADC with defined Resolution */
-void adc_configure_with_resolution(Adc* adc, int precision)
+int adc_configure_with_resolution(Adc* adc, uint32_t precision)
 {
+    uint8_t  divideResult = ADC_0_DIV_RES_DEFAULT;
+    uint32_t resolution = ADC_0_RES_16BIT;
+    uint32_t accumulate = ADC_0_ACCUM_DEFAULT;
+    if(adc->CTRLA.reg & ADC_CTRLA_SWRST)
+        return -1;
+    if(adc->CTRLA.reg & ADC_CTRLA_ENABLE)
+        return -1;
+
+     /* Pin Muxing */
+    ADC_0_PORT.PINCFG[ ADC_0_POS_INPUT ].bit.PMUXEN = 1;
+    ADC_0_PORT.PMUX[ ADC_0_POS_INPUT / 2].bit.PMUXE = 1;
+
+    /* ADC_0_POS_INPUT Input */
+    ADC_0_PORT.DIRCLR.reg = (1 << ADC_0_POS_INPUT);
+    ADC_0_PORT.PINCFG[ADC_0_POS_INPUT].bit.INEN = true;
+    ADC_0_PORT.PINCFG[ADC_0_POS_INPUT].bit.PULLEN = false; 
+
+    if(ADC_0_NEG_INPUT != ADC_INPUTCTRL_MUXNEG_GND)
+    {
+        ADC_0_PORT.DIRCLR.reg = (1 << ADC_0_NEG_INPUT);
+        ADC_0_PORT.PINCFG[ADC_0_NEG_INPUT].bit.INEN = true;
+        ADC_0_PORT.PINCFG[ADC_0_NEG_INPUT].bit.PULLEN = false;
+    } 
+
     /* Set RUN_IN_STANDBY */
     adc->CTRLA.reg = (ADC_0_RUN_IN_STANDBY << ADC_CTRLA_RUNSTDBY_Pos);
+
     /* Set Voltage Reference */
     adc->REFCTRL.reg = (ADC_0_REF_COM_EN << ADC_REFCTRL_REFCOMP_Pos) | ADC_0_REF_DEFAULT;
+
+    switch (precision)
+    {
+    case ADC_0_RES_8BIT:
+        resolution = ADC_0_RES_8BIT;
+        break;
+    case ADC_0_RES_10BIT:
+        resolution = ADC_0_RES_10BIT;
+        break;
+    case ADC_0_RES_12BIT:
+        resolution = ADC_0_RES_12BIT;
+        break;
+    case ADC_0_RES_16BIT:
+        divideResult = (ADC_0_DIV_RES_DISABLE | ADC_0_DIV_RES_DEFAULT);
+        accumulate = (ADC_0_ACCUM_256 | ADC_0_ACCUM_DEFAULT);
+        resolution = ADC_0_RES_16BIT;
+        break;
+    default:
+        DEBUG("Invalid precision");        
+        return -1;
+    }
+
     /* Set the accumlation and devide result */
-    adc->AVGCTRL.reg = ADC_AVGCTRL_ADJRES(ADC_0_DIV_RES_DEFAULT) | ADC_0_ACCUM_DEFAULT;
+    adc->AVGCTRL.reg = ADC_AVGCTRL_ADJRES(divideResult) | accumulate;
+
     /* Set Sample length */
     adc->SAMPCTRL.reg = (ADC_0_SAMPLE_LENGTH << ADC_SAMPCTRL_SAMPLEN_Pos);
-    while(adc_syncing(adc));    
+    while(adc_syncing(adc));
     /* If external vref. Pin setup */
     if(ADC_0_REF_DEFAULT == ADC_0_REF_EXT_B)
     {
@@ -183,7 +248,7 @@ void adc_configure_with_resolution(Adc* adc, int precision)
     /* Configure CTRLB Register HERE IS THE RESOLUTION SET!*/
     adc->CTRLB.reg = 
         ADC_0_PRESCALER |
-        precision | 
+        resolution | 
         (ADC_0_CORRECTION_EN << ADC_CTRLB_CORREN_Pos) | 
         (ADC_0_FREE_RUNNING << ADC_CTRLB_FREERUN_Pos) | 
         (ADC_0_LEFT_ADJUST << ADC_CTRLB_LEFTADJ_Pos) |
@@ -191,7 +256,14 @@ void adc_configure_with_resolution(Adc* adc, int precision)
     while(adc_syncing(adc));
     /* Configure Window Mode Register */
     adc->WINCTRL.reg = ADC_0_WINDOW_MODE;
-    while(adc_syncing(adc)); 
+    while(adc_syncing(adc));
+
+    /* Configure lower threshold */
+    adc->WINLT.reg = ADC_0_WINDOW_LOWER << ADC_WINLT_WINLT_Pos;
+    while(adc_syncing(adc));
+    /* Configure lower threshold */
+    adc->WINUT.reg = ADC_0_WINDOW_HIGHER << ADC_WINUT_WINUT_Pos;
+
     /* Configure PIN SCAN MODE & positive & Negative Input Pins */
     adc->INPUTCTRL.reg = 
         ADC_0_GAIN_FACTOR_DEFAULT |
@@ -199,20 +271,44 @@ void adc_configure_with_resolution(Adc* adc, int precision)
         (ADC_0_PIN_SCAN_INPUT_TO_SCAN << ADC_INPUTCTRL_INPUTSCAN_Pos) |
         ADC_0_NEG_INPUT |
         ADC_0_POS_INPUT;
+    
     /* Configure event action */
     adc->EVCTRL.reg = ADC_0_EVENT_ACTION;
+    
+    if (ADC_0_CORRECTION_EN)
+    {
+        if (ADC_0_GAIN_CORRECTION > ADC_GAINCORR_GAINCORR_Msk) 
+        {
+            DEBUG("Invalid gain correction\n");
+            return -1;
+        } 
+        else 
+        {
+            /* Set gain correction value */
+            adc->GAINCORR.reg = (ADC_0_GAIN_CORRECTION << ADC_GAINCORR_GAINCORR_Pos);
+        }
+        if (ADC_0_OFFSET_CORRECTION > 2047 || ADC_0_OFFSET_CORRECTION < -2048) 
+        {
+            DEBUG("Invalid offset correction\n");
+            return -1;
+        } 
+        else 
+        {
+            /* Set offset correction value */
+            adc->OFFSETCORR.reg = (ADC_0_OFFSET_CORRECTION << ADC_OFFSETCORR_OFFSETCORR_Pos);
+        }
+    }
+
     /* Disable all interrupts */
     adc->INTENCLR.reg =
         (1 << ADC_INTENCLR_SYNCRDY_Pos) | (1 << ADC_INTENCLR_WINMON_Pos) |
         (1 << ADC_INTENCLR_OVERRUN_Pos) | (1 << ADC_INTENCLR_RESRDY_Pos);
+    
     /* Load the fixed device calibration constants*/
-    adc->CALIB.reg =
-        ADC_CALIB_BIAS_CAL(
-            (*(uint32_t*)ADC_FUSES_BIASCAL_ADDR >> ADC_FUSES_BIASCAL_Pos)
-        ) |
-        ADC_CALIB_LINEARITY_CAL(
-            (*(uint64_t*)ADC_FUSES_LINEARITY_0_ADDR >> ADC_FUSES_LINEARITY_0_Pos)
-        );
+    adc->CALIB.reg = ADC_CALIB_BIAS_CAL((*(uint32_t*)ADC_FUSES_BIASCAL_ADDR >> ADC_FUSES_BIASCAL_Pos))
+                    |
+                    ADC_CALIB_LINEARITY_CAL((*(uint64_t*)ADC_FUSES_LINEARITY_0_ADDR >> ADC_FUSES_LINEARITY_0_Pos));
+    return 1;
 }
 
 /* Clear interrupt status flags */
@@ -231,7 +327,7 @@ void adc_clear_status(Adc* adc, uint32_t status_flag)
 }
 
 /* Get ADC status */
-bool adc_get_status(Adc* adc)
+uint32_t adc_get_status(Adc* adc)
 {
     uint32_t interrupt_flags = adc->INTFLAG.reg;
     uint32_t status_flags = 0;
@@ -241,14 +337,8 @@ bool adc_get_status(Adc* adc)
     if(interrupt_flags & ADC_INTFLAG_WINMON)
         status_flags |= ADC_0_STATUS_WINDOW;
     if(interrupt_flags & ADC_INTFLAG_OVERRUN)
-    {
         status_flags |= ADC_0_STATUS_OVERRUN;
-        //adc_clear_status(adc, ADC_0_STATUS_OVERRUN); // TODO:
-    }
-    if(status_flags > 0)
-        return false;
-    else
-        return true;
+    return status_flags;
 }
 
 #endif /* ADC_NUMOF */


### PR DESCRIPTION
New and refactored ADC driver.

As of now we don't have a defined config file for the ADC. This board have got a pretty neat ADC with many features. Most of these features can be switched on/off in the /periph_conf.h file.
e.g. Theres a DEFAULT value defined in the file for most of these non bool featues. fx.
#define ADC_0_GAIN_FACTOR_DEFAULT	ADC_0_GAIN_FACTOR_1X

TODOs:
adc_map
adc_mapf