### PR TITLE
tests: define random default GPIOs to pass Travis builds

### DIFF
--- a/tests/driver_l3g4200d/Makefile
+++ b/tests/driver_l3g4200d/Makefile
@@ -22,13 +22,13 @@ ifneq (,$(TEST_L3G4200D_INT))
   CFLAGS += -DTEST_L3G4200D_INT=$(TEST_L3G4200D_INT)
 else
   # set random default
-  CFLAGS += -DTEST_L3G4200D_INT=GPIO_8
+  CFLAGS += -DTEST_L3G4200D_INT=GPIO_0
 endif
 ifneq (,$(TEST_L3G4200D_DRDY))
   CFLAGS += -DTEST_L3G4200D_DRDY=$(TEST_L3G4200D_DRDY)
 else
   # set random default
-  CFLAGS += -DTEST_L3G4200D_DRDY=GPIO_9
+  CFLAGS += -DTEST_L3G4200D_DRDY=GPIO_1
 endif
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_lsm303dlhc/Makefile
+++ b/tests/driver_lsm303dlhc/Makefile
@@ -31,5 +31,17 @@ else
   # set random default
   CFLAGS += -DTEST_LSM303DLHC_ACC_ADDR=25
 endif
+ifneq (,$(TEST_LSM303DLHC_ACC_PIN))
+  CFLAGS += -DTEST_LSM303DLHC_ACC_PIN=$(TEST_LSM303DLHC_ACC_PIN)
+else
+  # set random default
+  CFLAGS += -DTEST_LSM303DLHC_ACC_PIN=GPIO_0
+endif
+ifneq (,$(TEST_LSM303DLHC_MAG_PIN))
+  CFLAGS += -DTEST_LSM303DLHC_MAG_PIN=$(TEST_LSM303DLHC_MAG_PIN)
+else
+  # set random default
+  CFLAGS += -DTEST_LSM303DLHC_MAG_PIN=GPIO_1
+endif
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_lsm303dlhc/main.c
+++ b/tests/driver_lsm303dlhc/main.c
@@ -27,6 +27,12 @@
 #ifndef TEST_LSM303DLHC_ACC_ADDR
 #error "TEST_LSM303DLHC_ACC_ADDR not defined"
 #endif
+#ifndef TEST_LSM303DLHC_ACC_PIN
+#error "TEST_LSM303DLHC_ACC_PIN not defined"
+#endif
+#ifndef TEST_LSM303DLHC_MAG_PIN
+#error "TEST_LSM303DLHC_MAG_PIN not defined"
+#endif
 
 #include <stdio.h>
 
@@ -38,8 +44,6 @@
 #define ACC_SCALE   LSM303DLHC_ACC_SCALE_2G
 #define MAG_S_RATE  LSM303DLHC_MAG_SAMPLE_RATE_75HZ
 #define MAG_GAIN    LSM303DLHC_MAG_GAIN_400_355_GAUSS
-#define ACC_PIN     GPIO_2
-#define MAG_PIN     GPIO_8
 
 int main(void)
 {
@@ -51,7 +55,7 @@ int main(void)
     puts("LSM303DLHC temperature test application\n");
     printf("Initializing LSM303DLHC sensor at I2C_%i... ", TEST_LSM303DLHC_I2C);
 
-    if (lsm303dlhc_init(&dev, TEST_LSM303DLHC_I2C, ACC_PIN, MAG_PIN,
+    if (lsm303dlhc_init(&dev, TEST_LSM303DLHC_I2C, TEST_LSM303DLHC_ACC_PIN, TEST_LSM303DLHC_MAG_PIN,
                         TEST_LSM303DLHC_ACC_ADDR, ACC_S_RATE, ACC_SCALE,
                         TEST_LSM303DLHC_MAG_ADDR, MAG_S_RATE, MAG_GAIN) == 0) {
         puts("[OK]\n");


### PR DESCRIPTION
These tests fail for boards providing periph_i2c (and periph_gpio) but default pins are not defined correctly.
