### PR TITLE
dist/cppcheck: handle unhandled condition

### DIFF
--- a/dist/tools/cppcheck/check.sh
+++ b/dist/tools/cppcheck/check.sh
@@ -17,7 +17,9 @@ FILEREGEX='\.([sScHh]|cpp)$'
 if echo "${BRANCH}" | grep -q '^-'; then
     BRANCH=""
 else
-    shift 1
+    if [ -n "${BRANCH}" ]; then
+        shift 1
+    fi
 fi
 
 # If the --diff-filter option is given, consume this parameter.


### PR DESCRIPTION
When no arguments are given at all, the script would shift when there
is nothing to shift. This results in a failure on debian stable:

```
./dist/tools/cppcheck/check.sh: 20: shift: can't shift that many
```
