### PR TITLE
native: *long* overdue fixes

### DIFF
--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -6,3 +6,7 @@ ifeq ($(BUILDOSXNATIVE),1)
 endif
 
 export USEMODULE += periph
+
+ifeq ($(shell uname -s),Darwin)
+export CFLAGS += -D_XOPEN_SOURCE -D_DARWIN_C_SOURCE
+endif

--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -68,6 +68,7 @@ void native_interrupt_init(void);
 
 void native_irq_handler(void);
 extern void _native_sig_leave_tramp(void);
+extern void _native_sig_leave_handler(void);
 
 void _native_syscall_leave(void);
 void _native_syscall_enter(void);

--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -323,7 +323,7 @@ void native_isr_entry(int sig, siginfo_t *info, void *context)
     }
 
     native_isr_context.uc_stack.ss_sp = __isr_stack;
-    native_isr_context.uc_stack.ss_size = SIGSTKSZ;
+    native_isr_context.uc_stack.ss_size = sizeof(__isr_stack);
     native_isr_context.uc_stack.ss_flags = 0;
     makecontext(&native_isr_context, native_irq_handler, 0);
     _native_cur_ctx = (ucontext_t *)sched_active_thread->sp;
@@ -343,11 +343,11 @@ void native_isr_entry(int sig, siginfo_t *info, void *context)
 #elif defined(__FreeBSD__)
     _native_saved_eip = ((struct sigcontext *)context)->sc_eip;
     ((struct sigcontext *)context)->sc_eip = (unsigned int)&_native_sig_leave_tramp;
-#else
-#ifdef __arm__
+#else /* Linux */
+#if defined(__arm__)
     _native_saved_eip = ((ucontext_t *)context)->uc_mcontext.arm_pc;
     ((ucontext_t *)context)->uc_mcontext.arm_pc = (unsigned int)&_native_sig_leave_tramp;
-#else
+#else /* Linux/x86 */
     //printf("\n\033[31mEIP:\t%p\ngo switching\n\n\033[0m", (void*)((ucontext_t *)context)->uc_mcontext.gregs[REG_EIP]);
     _native_saved_eip = ((ucontext_t *)context)->uc_mcontext.gregs[REG_EIP];
     ((ucontext_t *)context)->uc_mcontext.gregs[REG_EIP] = (unsigned int)&_native_sig_leave_tramp;
@@ -509,13 +509,13 @@ void native_interrupt_init(void)
     }
 
     native_isr_context.uc_stack.ss_sp = __isr_stack;
-    native_isr_context.uc_stack.ss_size = SIGSTKSZ;
+    native_isr_context.uc_stack.ss_size = sizeof(__isr_stack);
     native_isr_context.uc_stack.ss_flags = 0;
     _native_isr_ctx = &native_isr_context;
 
     static stack_t sigstk;
     sigstk.ss_sp = sigalt_stk;
-    sigstk.ss_size = SIGSTKSZ;
+    sigstk.ss_size = sizeof(__isr_stack);
     sigstk.ss_flags = 0;
 
     if (sigaltstack(&sigstk, NULL) < 0) {

--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -45,7 +45,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-volatile int native_interrupts_enabled;
+volatile int native_interrupts_enabled = 0;
 volatile int _native_in_isr;
 volatile int _native_in_syscall;
 
@@ -466,7 +466,6 @@ void native_interrupt_init(void)
     VALGRIND_DEBUG("VALGRIND_STACK_REGISTER(%p, %p)\n",
                    (void *)__isr_stack, (void*)((int)__isr_stack + sizeof(__isr_stack)));
 
-    native_interrupts_enabled = 1;
     _native_sigpend = 0;
 
     for (int i = 0; i < 255; i++) {

--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -279,6 +279,7 @@ void native_irq_handler(void)
 void isr_set_sigmask(ucontext_t *ctx)
 {
     ctx->uc_sigmask = _native_sig_set_dint;
+    native_interrupts_enabled = 0;
 }
 
 /**

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -151,11 +151,11 @@ void cpu_switch_context_exit(void)
         irq_disable();
         _native_in_isr = 1;
         native_isr_context.uc_stack.ss_sp = __isr_stack;
-        native_isr_context.uc_stack.ss_size = SIGSTKSZ;
+        native_isr_context.uc_stack.ss_size = sizeof(__isr_stack);
         native_isr_context.uc_stack.ss_flags = 0;
         makecontext(&native_isr_context, isr_cpu_switch_context_exit, 0);
         if (setcontext(&native_isr_context) == -1) {
-            err(EXIT_FAILURE, "cpu_switch_context_exit: swapcontext");
+            err(EXIT_FAILURE, "cpu_switch_context_exit: setcontext");
         }
         errx(EXIT_FAILURE, "1 this should have never been reached!!");
     }
@@ -182,8 +182,8 @@ void isr_thread_yield(void)
 
 void thread_yield_higher(void)
 {
-    ucontext_t *ctx = (ucontext_t *)(sched_active_thread->sp);
     if (_native_in_isr == 0) {
+        ucontext_t *ctx = (ucontext_t *)(sched_active_thread->sp);
         _native_in_isr = 1;
         irq_disable();
         native_isr_context.uc_stack.ss_sp = __isr_stack;

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -185,6 +185,9 @@ void thread_yield_higher(void)
     if (_native_in_isr == 0) {
         ucontext_t *ctx = (ucontext_t *)(sched_active_thread->sp);
         _native_in_isr = 1;
+        if (!native_interrupts_enabled) {
+            warnx("thread_yield_higher: interrupts are disabled - this should not be");
+        }
         irq_disable();
         native_isr_context.uc_stack.ss_sp = __isr_stack;
         native_isr_context.uc_stack.ss_size = SIGSTKSZ;

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -32,6 +32,7 @@
 
 #include "kernel_init.h"
 #include "cpu.h"
+#include "irq.h"
 
 #include "board_internal.h"
 #include "native_internal.h"
@@ -334,5 +335,6 @@ __attribute__((constructor)) static void startup(int argc, char **argv)
     board_init();
 
     puts("RIOT native hardware initialization complete.\n");
+    irq_enable();
     kernel_init();
 }

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -120,16 +120,15 @@ void _native_syscall_leave(void)
        )
     {
         _native_in_isr = 1;
-        unsigned int mask = irq_disable();
         _native_cur_ctx = (ucontext_t *)sched_active_thread->sp;
         native_isr_context.uc_stack.ss_sp = __isr_stack;
         native_isr_context.uc_stack.ss_size = SIGSTKSZ;
         native_isr_context.uc_stack.ss_flags = 0;
+        native_interrupts_enabled = 0;
         makecontext(&native_isr_context, native_irq_handler, 0);
         if (swapcontext(_native_cur_ctx, &native_isr_context) == -1) {
             err(EXIT_FAILURE, "_native_syscall_leave: swapcontext");
         }
-        irq_restore(mask);
     }
 }
 

--- a/cpu/native/tramp.S
+++ b/cpu/native/tramp.S
@@ -28,6 +28,13 @@ __native_sig_leave_tramp:
     popfl
 
     ret
+
+.globl __native_sig_leave_handler
+__native_sig_leave_handler:
+    pushl __native_saved_eip
+    movl $0x0, __native_in_isr
+    ret
+
 #elif __arm__
 
 .globl _native_sig_leave_tramp
@@ -65,6 +72,26 @@ _native_sig_leave_tramp:
     ldmia   sp!, {r0-r12}
     ldmia   sp!, {pc}
 
+.globl _native_sig_leave_handler
+_native_sig_leave_handler:
+    stmdb sp!, {r0}
+    ldr r0, =_native_saved_eip
+    ldr r0, [r0]
+    stmdb sp!, {r0-r12}
+    stmdb sp!, {lr}
+    /* exchange r0 and _native_saved_eip */
+    ldr     r0, [sp,#56]
+    ldr     r1, [sp,#4 ]
+    str     r0, [sp,#4 ]
+    str     r1, [sp,#56]
+    /* _native_in_isr = 0 */
+    eor     r0, r0, r0
+    ldr     r1, =_native_in_isr
+    str     r0, [r1]
+    ldmia sp!, {lr}
+    ldmia sp!, {r0-r12}
+    ldmia sp!, {pc}
+
 #else
 .globl _native_sig_leave_tramp
 
@@ -84,5 +111,11 @@ _native_sig_leave_tramp:
     popal
     popfl
 
+    ret
+
+.globl _native_sig_leave_handler
+_native_sig_leave_handler:
+    pushl _native_saved_eip
+    movl $0x0, _native_in_isr
     ret
 #endif


### PR DESCRIPTION
Fixes for natives hwtimer and signal handling.

The hwtimer fixes made the signal handling fixes more pressing.

Some issues that should be fixed/closed by this:
- ~~https://github.com/RIOT-OS/RIOT/issues/499~~
- ~~https://github.com/RIOT-OS/RIOT/issues/715~~
- ~~https://github.com/RIOT-OS/RIOT/issues/1281~~
- ~~https://github.com/RIOT-OS/RIOT/issues/1905~~
