### PR TITLE
cpu/cc2538: added extern C for rfcore.h

### DIFF
--- a/cpu/cc2538/include/rfcore.h
+++ b/cpu/cc2538/include/rfcore.h
@@ -26,6 +26,10 @@
 
 #include "cc2538.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief RF Core component registers
  */
@@ -216,6 +220,10 @@ enum {
     ISNACK         = 0xe8,                /**< Abort sending of acknowledge frame */
     ISCLEAR        = 0xff,                /**< Clear CSP program memory, reset program counter */
 };
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* CC2538_RFCORE_H */
 


### PR DESCRIPTION
Missed this one in #1803 :-)
