### PR TITLE
travis: squash check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ script:
     - make -C ./tests/unittests all test BOARD=qemu-i386 || exit
 
     - ./dist/tools/compile_test/compile_test.py
+    - ./dist/tools/pr_check/pr_check.sh riot/master
 
 notifications:
     email: false

--- a/dist/tools/pr_check/README.md
+++ b/dist/tools/pr_check/README.md
@@ -1,0 +1,18 @@
+# About
+
+This script checks if a Pull Request needs squashing or if it is waiting for
+another Pull Request.
+
+# Usage
+
+```bash
+./pr_check.sh [<master branch>]
+```
+
+The optional `<master branch>` parameter refers to the branch the pull request's
+branch branched from. The script will output all commits marked as squashable
+from `HEAD` to the merge-base with `<master branch>`. The default for
+`<master branch>` is `master`.
+
+A commit is marked as squashable if it contains the keywords SQUASH or FIX
+(case insensitive) within the first five characters of it's subject title.

--- a/dist/tools/pr_check/pr_check.sh
+++ b/dist/tools/pr_check/pr_check.sh
@@ -1,0 +1,67 @@
+#! /bin/bash
+#
+# Copyright (C) 2014 Martin Lenders <mlenders@inf.fu-berlin.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+EXIT_CODE=0
+GITHUB_API_HOST="https://api.github.com"
+GITHUB_REPO="RIOT-OS/RIOT"
+
+if which wget &> /dev/null; then
+    GET="wget -O -"
+elif which curl &> /dev/null; then
+    GET="curl"
+else
+    echo "Script needs wget or curl" >&2
+    exit 2
+fi
+
+LABELS_JSON=$(${GET} "${GITHUB_API_HOST}/repos/${GITHUB_REPO}/issues/${TRAVIS_PULL_REQUEST}/labels" 2> /dev/null)
+
+if tput colors &> /dev/null && [ $(tput colors) -ge 8 ]; then
+    CERROR="\e[1;31m"
+    CRESET="\e[0m"
+else
+    CERROR=
+    CRESET=
+fi
+
+check_gh_label() {
+    LABEL="${1}"
+
+    echo "${LABELS_JSON}" | grep -q "${LABEL}"
+    return $?
+}
+
+if [[ ${#} -eq 1 ]]; then
+    RIOT_MASTER="${1}"
+else
+    RIOT_MASTER="master"
+fi
+
+SQUASH_COMMITS="$(git log $(git merge-base HEAD "${RIOT_MASTER}")...HEAD --pretty=format:"\t%C(auto)%h %s%Creset" \
+                  -i --grep "^.\{0,2\}SQUASH" --grep "^.\{0,2\}FIX")"
+
+if [ -n "${SQUASH_COMMITS}" ]; then
+    echo -e "${CERROR}Pull request needs squashing:${CRESET}" 1>&2
+    echo -e "${SQUASH_COMMITS}"
+    EXIT_CODE=1
+fi
+
+if [ -n "$TRAVIS_PULL_REQUEST" ]; then
+    if check_gh_label "NEEDS SQUASHING"; then
+        echo -e "${CERROR}Pull request needs squashing according to its labels${CRESET}"
+        EXIT_CODE=1
+    fi
+
+    if check_gh_label "Waiting For Other PR"; then
+        echo -e "${CERROR}Pull request is waiting for another pull request according to its labels${CRESET}"
+        EXIT_CODE=1
+    fi
+fi
+
+exit ${EXIT_CODE}


### PR DESCRIPTION
This checks at the very end of the build if a pull request needs squashing, based on the fact if there are any commits that start with a "SQUASH" tag between `HEAD` and `RIOT/master`.
