### PR TITLE
test/hwtimer_spin: test slightly wider range

### DIFF
--- a/tests/hwtimer_spin/main.c
+++ b/tests/hwtimer_spin/main.c
@@ -14,6 +14,7 @@
  * @brief Hwtimer test application
  *
  * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
  * @}
  */
@@ -27,8 +28,16 @@ int main(void)
 {
     puts("This is just a functionality test for hwtimer_spin.");
 
-    for (unsigned long r = 10000; r > 0; r--) {
+    puts("\nYou should see the message \"success\" after while if this test was successful");
+    puts("If you do not see this message, something went wrong.\n");
+
+    for (unsigned long r = 100; r > 0; r--) {
+        /* test values <= SPIN_BARRIER */
         for (unsigned long i = HWTIMER_SPIN_BARRIER; i > 0; i--) {
+            hwtimer_wait(i);
+        }
+        /* test values that are slightly above the SPIN_BARRIER */
+        for (unsigned long i = (10 * HWTIMER_SPIN_BARRIER); i > HWTIMER_SPIN_BARRIER; i--) {
             hwtimer_wait(i);
         }
     }


### PR DESCRIPTION
test is now also testing for values slightly above SPIN_BARRIER. This way faulty behavior as in #2091 can be detected.
