### PR TITLE
native: removing externs from native tramp

### DIFF
--- a/cpu/native/tramp.S
+++ b/cpu/native/tramp.S
@@ -29,10 +29,6 @@ __native_sig_leave_tramp:
 
     ret
 #elif __arm__
-.extern _native_saved_eip
-.extern _native_isr_ctx
-.extern _native_cur_ctx
-.extern _native_in_isr
 
 .globl _native_sig_leave_tramp
 _native_sig_leave_tramp:
@@ -70,11 +66,6 @@ _native_sig_leave_tramp:
     ldmia   sp!, {pc}
 
 #else
-.extern $_native_saved_eip
-.extern $_native_isr_ctx
-.extern $_native_cur_ctx
-.extern $_native_in_isr
-
 .globl _native_sig_leave_tramp
 
 _native_sig_leave_tramp:


### PR DESCRIPTION
I have no idea what's that about, but it should fix #1235.
