### PR TITLE
cpu/cc2538: add the exception handling frame section "eh_frame" to the linker script.

### DIFF
--- a/cpu/cc2538/cc2538_linkerscript.ld
+++ b/cpu/cc2538/cc2538_linkerscript.ld
@@ -96,6 +96,13 @@ SECTIONS
     } > rom
     PROVIDE_HIDDEN (__exidx_end = .);
 
+    /* exception handling */
+    . = ALIGN(4);
+    .eh_frame :
+    {
+        KEEP (*(.eh_frame))
+    } > rom
+
     . = ALIGN(4);
     _etext = .;
 


### PR DESCRIPTION
Fixes linker errors on newer toolchains, for example:

```
ld: foo.elf section `.eh_frame' will not fit in region `cca'
ld: region `cca' overflowed by 40 bytes
```

I started seeing these errors following an upgrade to Ubuntu Utopic.
