### PR TITLE
Driver for  Freescale MPL3115A2 Pressure/Altitude Sensor

### DIFF
--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -28,3 +28,6 @@ endif
 ifneq (,$(filter nrf24l01p,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/drivers/nrf24l01p/include
 endif
+ifneq (,$(filter mpl3115a2,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/mpl3115a2/include
+endif

--- a/drivers/include/mpl3115a2.h
+++ b/drivers/include/mpl3115a2.h
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2014 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_mpl3115a2 MPL3115A2 Pressure Sensor
+ * @ingroup     drivers
+ * @brief       Driver for the Freescale MPL3115A2 pressure sensor.
+ *              The driver will initialize the sensor for 
+ *              pressure measurement. The conversion duration
+ *              depends on oversample ratio.
+ *              After initialization and set activ the sensor
+ *              will make measurements at periodic times.
+ *              The oversample ratio can be determined
+ *              by sensor initialization.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for the MPL3115A2 sensor driver.
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ */
+
+#ifndef MPL3115A2_H
+#define MPL3115A2_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "periph/i2c.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#ifndef MPL3115A2_I2C_ADDRESS
+#define MPL3115A2_I2C_ADDRESS           0x60 /**< Pressure Sensor Default Address */
+#endif
+
+#define MPL3115A2_OS_RATIO_1            0 /**< Oversample Ratio 1, conversion time 6 ms */
+#define MPL3115A2_OS_RATIO_2            1 /**< Oversample Ratio 2, conversion time 10 ms */
+#define MPL3115A2_OS_RATIO_4            2 /**< Oversample Ratio 4, conversion time 18 ms */
+#define MPL3115A2_OS_RATIO_8            3 /**< Oversample Ratio 8, conversion time 34 ms */
+#define MPL3115A2_OS_RATIO_16           4 /**< Oversample Ratio 16, conversion time 66 ms */
+#define MPL3115A2_OS_RATIO_32           5 /**< Oversample Ratio 32, conversion time 130 ms */
+#define MPL3115A2_OS_RATIO_64           6 /**< Oversample Ratio 64, conversion time 258 ms */
+#define MPL3115A2_OS_RATIO_128          7 /**< Oversample Ratio 128, conversion time 512 ms */
+#define MPL3115A2_OS_RATIO_DEFAULT      MPL3115A2_OS_RATIO_128 /**< Default Ratio for testing */
+
+#ifndef MPL3115A2_CONVERSION_TIME
+#define MPL3115A2_CONVERSION_TIME       512000 /**< Maximum Conversion Time in us */
+#endif
+
+
+/**
+ * @brief Device descriptor for MPL3115A2 sensors.
+ */
+typedef struct {
+    i2c_t i2c;              /**< I2C device, the sensor is connected to */
+    uint8_t addr;           /**< the sensor's slave address on the I2C bus */
+    bool initialized;       /**< sensor status, true if sensor is initialized */
+} mpl3115a2_t;
+
+/**
+ * @brief MPL3115A2 sensor test.
+ * This function looks for Device ID of the MPL3115A2 sensor.
+ *
+ * @param[in]  dev          device descriptor of sensor
+ *
+ * @return                  0 on success
+ * @return                  -1 on error
+ */
+int mpl3115a2_test(mpl3115a2_t *dev);
+
+/**
+ * @brief Initialize the MPL3115A2 sensor driver.
+ *
+ * @param[out] dev          device descriptor of sensor to initialize
+ * @param[in]  i2c          I2C bus the sensor is connected to
+ * @param[in]  address      sensor's I2C slave address
+ * @param[in]  os_ratio     oversample rate selection
+ *
+ * @return                  0 on success
+ * @return                  -1 if os_ratio parameter is wrong
+ * @return                  -2 if initialization of I2C bus failed
+ * @return                  -3 if sensor test failed
+ * @return                  -4 if sensor configuration failed
+ */
+int mpl3115a2_init(mpl3115a2_t *dev, i2c_t i2c, uint8_t address, uint8_t os_ratio);
+
+/**
+ * @brief Reset the MPL3115A2 sensor. After that, the sensor should be reinitialized.
+ *
+ * @param[out] dev          device descriptor of sensor
+ *
+ * @return                  0 on success
+ * @return                  -1 on error
+ */
+int mpl3115a2_reset(mpl3115a2_t *dev);
+
+/**
+ * @brief Set active mode, this enables periodic measurements.
+ *
+ * @param[out] dev          device descriptor of sensor
+ *
+ * @return                  0 on success
+ * @return                  -1 on error
+ */
+int mpl3115a2_set_active(mpl3115a2_t *dev);
+
+/**
+ * @brief Set standby mode.
+ *
+ * @param[in]  dev          device descriptor of sensor
+ *
+ * @return                  0 on success
+ * @return                  -1 on error
+ */
+int mpl3115a2_set_standby(mpl3115a2_t *dev);
+
+/**
+ * @brief Check for new set of measurement data.
+ *
+ * @param[in]  dev          device descriptor of sensor
+ *
+ * @return                  >0 if new data sample is ready
+ * @return                  0 measurement in progress
+ * @return                  -1 on error
+ */
+int mpl3115a2_is_ready(mpl3115a2_t *dev);
+
+/**
+ * @brief Read sensor's data in pressure mode.
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[out] pres         pressure in Pascals
+ * @param[out] status       sensor status register
+ *
+ * @return                  0 on success
+ * @return                  -1 on error
+ */
+int mpl3115a2_read_pressure(mpl3115a2_t *dev, uint32_t *pres, uint8_t *status);
+
+/**
+ * @brief Read sensor's temperature.
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[out] temp         temperature in \f$^\circ C \cdot 10\f$
+ *
+ * @return                  0 on success
+ * @return                  -1 on error
+ */
+int mpl3115a2_read_temp(mpl3115a2_t *dev, int16_t *temp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+/** @} */

--- a/drivers/mpl3115a2/Makefile
+++ b/drivers/mpl3115a2/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/mpl3115a2/include/mpl3115a2_reg.h
+++ b/drivers/mpl3115a2/include/mpl3115a2_reg.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2014 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     drivers_mpl3115a2
+ * @{
+ *
+ * @file
+ * @brief       Register definition for the MPL3115A2 sensor driver.
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ *
+ */
+
+#ifndef __MPL3115A2_REG_H__
+#define __MPL3115A2_REG_H__
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define MPL3115A2_STATUS            0x00 /**< Sensor Status Register */
+#define MPL3115A2_OUT_P_MSB         0x01 /**< Pressure Data Out MSB */
+#define MPL3115A2_OUT_P_CSB         0x02 /**< Pressure Data Out CSB */
+#define MPL3115A2_OUT_P_LSB         0x03 /**< Pressure Data Out LSB */
+#define MPL3115A2_OUT_T_MSB         0x04 /**< Temperature Data Out MSB */
+#define MPL3115A2_OUT_T_LSB         0x05 /**< Temperature Data Out LSB */
+#define MPL3115A2_DR_STATUS         0x06 /**< Sensor Status Register */
+#define MPL3115A2_OUT_P_DELTA MSB   0x07 /**< Pressure Data Out Delta MSB */
+#define MPL3115A2_OUT_P_DELTA_CSB   0x08 /**< Pressure Data Out Delta CSB */
+#define MPL3115A2_OUT_P_DELTA_LSB   0x09 /**< Pressure Data Out Delta LSB */
+#define MPL3115A2_OUT_T_DELTA_MSB   0x0A /**< Temperature Data Out Delta MSB */
+#define MPL3115A2_OUT_T_DELTA_LSB   0x0B /**< Temperature Data Out Delta LSB */
+#define MPL3115A2_WHO_AM_I          0x0C /**< Device Identification Register */
+#define MPL3115A2_F_STATUS          0x0D /**< FIFO Status Register */
+#define MPL3115A2_F_DATA            0x0E /**< FIFO 8-bit Data Access */
+#define MPL3115A2_F_SETUP           0x0F /**< FIFO Setup Register */
+#define MPL3115A2_TIME_DLY          0x10 /**< Time Delay Register */
+#define MPL3115A2_SYSMOD            0x11 /**< System Mode Register */
+#define MPL3115A2_INT_SOURCE        0x12 /**< Interrupt Source Register */
+#define MPL3115A2_PT_DATA_CFG       0x13 /**< PT Data Configuration Register */
+#define MPL3115A2_BAR_IN_MSB        0x14 /**< BAR Input in MSB */
+#define MPL3115A2_BAR_IN_LSB        0x15 /**< BAR Input in LSB */
+#define MPL3115A2_P_TGT_MSB         0x16 /**< Pressure Target MSB */
+#define MPL3115A2_P_TGT_LSB         0x17 /**< Pressure Target LSB */
+#define MPL3115A2_T_TGT             0x18 /**< Temperature Target */
+#define MPL3115A2_P_WND_MSB         0x19 /**< Pressure/Altitude Window MSB */
+#define MPL3115A2_P_WND_LSB         0x1A /**< Pressure/Altitude Window LSB */
+#define MPL3115A2_T_WND             0x1B /**< Temperature Window */
+#define MPL3115A2_P_MIN_MSB         0x1C /**< Minimum Pressure Data Out MSB */
+#define MPL3115A2_P_MIN_CSB         0x1D /**< Minimum Pressure Data Out CSB */
+#define MPL3115A2_P_MIN_LSB         0x1E /**< Minimum Pressure Data Out LSB */
+#define MPL3115A2_T_MIN_MSB         0x1F /**< Minimum Temperature Data Out MSB */
+#define MPL3115A2_T_MIN_LSB         0x20 /**< Minimum Temperature Data Out LSB */
+#define MPL3115A2_P_MAX_MSB         0x21 /**< Maximum Pressure Data Out MSB */
+#define MPL3115A2_P_MAX_CSB         0x22 /**< Maximum Pressure Data Out CSB */
+#define MPL3115A2_P_MAX_LSB         0x23 /**< Maximum Pressure Data Out LSB */
+#define MPL3115A2_T_MAX_MSB         0x24 /**< Maximum Temperature Data Out MSB */
+#define MPL3115A2_T_MAX_LSB         0x25 /**< Maximum Temperature Data Out LSB */
+#define MPL3115A2_CTRL_REG1         0x26 /**< Control Register 1 */
+#define MPL3115A2_CTRL_REG2         0x27 /**< Control Register 2 */
+#define MPL3115A2_CTRL_REG3         0x28 /**< Control Register 3 */
+#define MPL3115A2_CTRL_REG4         0x29 /**< Control Register 4 */
+#define MPL3115A2_CTRL_REG5         0x2A /**< Control Register 5 */
+#define MPL3115A2_OFF_P             0x2B /**< Pressure Data User Offset Register */
+#define MPL3115A2_OFF_T             0x2C /**< Temperature Data User Offset Register */
+#define MPL3115A2_OFF_H             0x2D /**< Altitude Data User Offset Register */
+
+#define MPL3115A2_STATUS_TDR            (1 << 1)
+#define MPL3115A2_STATUS_PDR            (1 << 2)
+#define MPL3115A2_STATUS_PTDR           (1 << 3)
+#define MPL3115A2_STATUS_TOW            (1 << 5)
+#define MPL3115A2_STATUS_POW            (1 << 6)
+#define MPL3115A2_STATUS_PTOW           (1 << 7)
+
+#define MPL3115A2_PT_DATA_CFG_TDEFE     (1 << 0)
+#define MPL3115A2_PT_DATA_CFG_PDEFE     (1 << 1)
+#define MPL3115A2_PT_DATA_CFG_DREM      (1 << 2)
+
+#define MPL3115A2_CTRL_REG1_SBYB        (1 << 0)
+#define MPL3115A2_CTRL_REG1_OST         (1 << 1)
+#define MPL3115A2_CTRL_REG1_RST         (1 << 2)
+#define MPL3115A2_CTRL_REG1_OS_SHIFT    3
+#define MPL3115A2_CTRL_REG1_OS_MASK     0x38
+#define MPL3115A2_CTRL_REG1_OS(x)       (((uint8_t)(((uint8_t)(x))<<MPL3115A2_CTRL_REG1_OS_SHIFT))\
+                                        &MPL3115A2_CTRL_REG1_OS_MASK)
+#define MPL3115A2_CTRL_REG1_RAW         (1 << 6)
+#define MPL3115A2_CTRL_REG1_ALT         (1 << 7)
+
+#define MPL3115A2_CTRL_REG2_ST_SHIFT    0
+#define MPL3115A2_CTRL_REG2_ST_MASK     0xF
+#define MPL3115A2_CTRL_REG2_ST(x)       (((uint8_t)(((uint8_t)(x))<<MPL3115A2_CTRL_REG2_ST_SHIFT))\
+                                        &MPL3115A2_CTRL_REG2_ST_MASK)
+#define MPL3115A2_CTRL_REG2_ALARM_SEL   (1 << 4)
+#define MPL3115A2_CTRL_REG2_LOAD_OPUT   (1 << 5)
+
+#define MPL3115A2_CTRL_REG3_PP_OD2      (1 << 0)
+#define MPL3115A2_CTRL_REG3_IPOL2       (1 << 1)
+#define MPL3115A2_CTRL_REG3_PP_OD1      (1 << 4)
+#define MPL3115A2_CTRL_REG3_IPOL1       (1 << 5)
+
+#define MPL3115A2_CTRL_REG4_INT_EN_TCHG (1 << 0)
+#define MPL3115A2_CTRL_REG4_INT_EN_PCHG (1 << 1)
+#define MPL3115A2_CTRL_REG4_INT_EN_TTH  (1 << 2)
+#define MPL3115A2_CTRL_REG4_INT_EN_PTH  (1 << 3)
+#define MPL3115A2_CTRL_REG4_INT_EN_TW   (1 << 4)
+#define MPL3115A2_CTRL_REG4_INT_EN_PW   (1 << 5)
+#define MPL3115A2_CTRL_REG4_INT_EN_FIFO (1 << 6)
+#define MPL3115A2_CTRL_REG4_INT_EN_DRDY (1 << 7)
+
+#define MPL3115A2_CTRL_REG5_INT_TCHG    (1 << 0)
+#define MPL3115A2_CTRL_REG5_INT_PCHG    (1 << 1)
+#define MPL3115A2_CTRL_REG5_INT_TTH     (1 << 2)
+#define MPL3115A2_CTRL_REG5_INT_PTH     (1 << 3)
+#define MPL3115A2_CTRL_REG5_INT_TW      (1 << 4)
+#define MPL3115A2_CTRL_REG5_INT_PW      (1 << 5)
+#define MPL3115A2_CTRL_REG5_INT_FIFO    (1 << 6)
+#define MPL3115A2_CTRL_REG5_INT_DRDY    (1 << 7)
+
+#define MPL3115A2_ID                    0xC4 /**< Device ID */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+/** @} */

--- a/drivers/mpl3115a2/mpl3115a2.c
+++ b/drivers/mpl3115a2/mpl3115a2.c
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2014 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     drivers_mpl3115a2
+ * @{
+ *
+ * @file
+ * @brief       Driver for the Freescale MPL3115A2 Sensor.
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "periph/i2c.h"
+#include "mpl3115a2.h"
+#include "mpl3115a2_reg.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#define I2C_SPEED                  I2C_SPEED_FAST
+
+int mpl3115a2_test(mpl3115a2_t *dev)
+{
+    char reg;
+
+    if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_WHO_AM_I, &reg, 1) != 1) {
+        return -1;
+    }
+
+    if (reg != MPL3115A2_ID) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int mpl3115a2_init(mpl3115a2_t *dev, i2c_t i2c, uint8_t address, uint8_t os_ratio)
+{
+    char reg;
+
+    /* write device descriptor */
+    dev->i2c = i2c;
+    dev->addr = address;
+    dev->initialized = false;
+
+    if (os_ratio > MPL3115A2_OS_RATIO_128) {
+        return -1;
+    }
+
+    /* initialize the I2C bus */
+    if (i2c_init_master(i2c, I2C_SPEED) < 0) {
+        return -2;
+    }
+
+    if (mpl3115a2_test(dev)) {
+        return -3;
+    }
+
+    reg = MPL3115A2_CTRL_REG1_OS(os_ratio);
+
+    if (i2c_write_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        return -4;
+    }
+
+    reg = MPL3115A2_PT_DATA_CFG_TDEFE
+          | MPL3115A2_PT_DATA_CFG_PDEFE
+          | MPL3115A2_PT_DATA_CFG_DREM;
+
+    if (i2c_write_regs(dev->i2c, dev->addr, MPL3115A2_PT_DATA_CFG, &reg, 1) != 1) {
+        return -4;
+    }
+
+    dev->initialized = true;
+
+    return 0;
+}
+
+int mpl3115a2_reset(mpl3115a2_t *dev)
+{
+    char reg;
+
+    dev->initialized = false;
+    reg = MPL3115A2_CTRL_REG1_RST;
+
+    if (i2c_write_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int mpl3115a2_set_active(mpl3115a2_t *dev)
+{
+    char reg;
+
+    if (dev->initialized == false) {
+        return -1;
+    }
+
+    if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        return -1;
+    }
+
+    reg |= MPL3115A2_CTRL_REG1_SBYB;
+
+    if (i2c_write_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int mpl3115a2_set_standby(mpl3115a2_t *dev)
+{
+    char reg;
+
+    if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        return -1;
+    }
+
+    reg &= ~MPL3115A2_CTRL_REG1_SBYB;
+
+    if (i2c_write_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int mpl3115a2_is_ready(mpl3115a2_t *dev)
+{
+    char reg;
+
+    if (dev->initialized == false) {
+        return -1;
+    }
+
+    if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_STATUS, &reg, 1) != 1) {
+        return -1;
+    }
+
+    return reg & MPL3115A2_STATUS_PTDR;
+}
+
+int mpl3115a2_read_pressure(mpl3115a2_t *dev, uint32_t *pres, uint8_t *status)
+{
+    char buf[4];
+
+    if (dev->initialized == false) {
+        return -1;
+    }
+
+    if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_STATUS, buf, 4) != 4) {
+        return -1;
+    }
+
+    *status = buf[0];
+
+    *pres = ((uint32_t)buf[1] << 16) | ((uint32_t)buf[2] << 8) | buf[3];
+    *pres = *pres / 64;
+
+    return 0;
+}
+
+int mpl3115a2_read_temp(mpl3115a2_t *dev, int16_t *temp)
+{
+    char buf[2];
+
+    if (dev->initialized == false) {
+        return -1;
+    }
+
+    if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_OUT_T_MSB, buf, 2) != 2) {
+        return -1;
+    }
+
+    *temp = ((int16_t)(((int16_t)buf[0] << 8) | buf[1]) * 10) / 256;
+
+    return 0;
+}

--- a/tests/driver_mpl3115a2/Makefile
+++ b/tests/driver_mpl3115a2/Makefile
@@ -1,0 +1,20 @@
+APPLICATION = driver_mpl3115a2
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_i2c
+
+USEMODULE += mpl3115a2
+USEMODULE += vtimer
+
+ifneq (,$(TEST_MPL3115A2_I2C))
+  CFLAGS += -DTEST_MPL3115A2_I2C=$(TEST_MPL3115A2_I2C)
+else
+  CFLAGS += -DTEST_MPL3115A2_I2C=I2C_0
+endif
+ifneq (,$(TEST_MPL3115A2_ADDR))
+  CFLAGS += -DTEST_MPL3115A2_ADDR=$(TEST_MPL3115A2_ADDR)
+else
+  CFLAGS += -DTEST_MPL3115A2_ADDR=0x60
+endif
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_mpl3115a2/README.md
+++ b/tests/driver_mpl3115a2/README.md
@@ -1,0 +1,9 @@
+# About
+This is a manual test application for the MPL3115A2 driver.
+
+# Usage
+This test application will initialize the MPL3115A2 sensor with the following parameters:
+ - oversample ratio 128
+
+After initialization, the sensor reads the pressure and temperature values every 1s
+and prints them to STDOUT.

--- a/tests/driver_mpl3115a2/main.c
+++ b/tests/driver_mpl3115a2/main.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the MPL3115A2 sensor driver.
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ *
+ * @}
+ */
+
+#ifndef TEST_MPL3115A2_I2C
+#error "TEST_MPL3115A2_I2C not defined"
+#endif
+#ifndef TEST_MPL3115A2_ADDR
+#error "TEST_MPL3115A2_ADDR not defined"
+#endif
+
+#include <stdio.h>
+
+#include "vtimer.h"
+#include "mpl3115a2.h"
+
+#define SLEEP       (1000 * 1000U)
+
+int main(void)
+{
+    mpl3115a2_t dev;
+    uint32_t pressure;
+    int16_t temp;
+    uint8_t status;
+
+    puts("MPL3115A2 pressure sensor driver test application\n");
+    printf("Initializing MPL3115A2 sensor at I2C_%i... ", TEST_MPL3115A2_I2C);
+    if (mpl3115a2_init(&dev, TEST_MPL3115A2_I2C, TEST_MPL3115A2_ADDR,
+                                                 MPL3115A2_OS_RATIO_DEFAULT) == 0) {
+        puts("[OK]\n");
+    }
+    else {
+        puts("[Failed]");
+        return -1;
+    }
+
+    if (mpl3115a2_set_active(&dev)) {
+        puts("Measurement start failed.");
+        return -1;
+    }
+
+    while (1) {
+        vtimer_usleep(SLEEP);
+        mpl3115a2_read_pressure(&dev, &pressure, &status);
+        printf("Pressure: %u Status: %#02x\n", (unsigned int)pressure, status);
+        mpl3115a2_read_temp(&dev, &temp);
+        printf("Temperature: %d\n", temp/10);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR add support for Freescale MPL3115A2 Pressure/Altitude Sensor.
This driver only implements pressure and temperature measurement functionality. 