### PR TITLE
make: term depends on flash

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -175,7 +175,7 @@ distclean:
 flash: all
 	$(FLASHER) $(FFLAGS)
 
-term:
+term: $(filter flash, $(MAKECMDGOALS))
 	$(TERMPROG) $(TERMFLAGS)
 
 doc:


### PR DESCRIPTION
If you provide both `flash` and `term` as Make goals, then `term` needs to wait for flash.
