### PR TITLE
sys: doc: pipe.h spams the manual

### DIFF
--- a/sys/include/pipe.h
+++ b/sys/include/pipe.h
@@ -17,7 +17,8 @@
  */
 
 /**
- * @addtogroup  sys
+ * @defgroup    sys_pipe Pipe IPC
+ * @ingroup     sys
  * @{
  * @file
  *

--- a/sys/pipe/pipe.c
+++ b/sys/pipe/pipe.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @ingroup     sys
+ * @ingroup     sys_pipe
  * @{
  * @file
  * @brief       Implementation for statically allocated pipes.

--- a/sys/pipe/pipe_dynamic.c
+++ b/sys/pipe/pipe_dynamic.c
@@ -17,7 +17,7 @@
  */
 
 /**
- * @ingroup     sys
+ * @ingroup     sys_pipe
  * @{
  * @file
  * @brief       Implementation for dynamically allocated pipes.


### PR DESCRIPTION
This PR adds a new group for the pipe module, so the .h file does not
spam the manual in Modules/System.
