### PR TITLE
doc: periph/random: long+note from file to module

### DIFF
--- a/drivers/include/periph/random.h
+++ b/drivers/include/periph/random.h
@@ -9,18 +9,18 @@
 /**
  * @defgroup    driver_periph_random Random
  * @ingroup     driver_periph
- * @{
- *
- * @file
  * @brief       (Pseudo) random number generator low-level driver interface
  *
- * NOTE: The quality of the random data read from this interface is highly
+ * The quality of the random data read from this interface is highly
  * dependent on hardware dependent implementation. Most platforms utilize a
  * hardware (Pseudo) Random Number Generator. The quality of the generated
  * random data can be however very different.
  *
  * @note REFER TO YOUR PLATFORMS IMPLEMENTATION ABOUT INFORMATION ABOUT THE
  *       QUALITY OF RANDOMNES!
+ *
+ * @{
+ * @file
  *
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
  */


### PR DESCRIPTION
If inside the `@file` section, the documentation does only show up in the file's and not in the module's doxygen page.
