### PR TITLE
rpl: addr_str not renamed to addr_str_mode

### DIFF
--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -119,7 +119,7 @@ uint8_t rpl_init(int if_id)
 
     /* initialize objective function manager */
     rpl_of_manager_init(&my_address);
-	rpl_init_mode(&my_address);
+    rpl_init_mode(&my_address);
     return SIXLOWERROR_SUCCESS;
 }
 

--- a/sys/net/routing/rpl/rpl_storing/rpl_storing.c
+++ b/sys/net/routing/rpl/rpl_storing/rpl_storing.c
@@ -693,8 +693,8 @@ void rpl_recv_DAO_mode(void)
                 /* route lifetime seconds = (DAO lifetime) * (Unit Lifetime) */
 
                 DEBUG("Adding routing information: Target: %s, Source: %s, Lifetime: %u\n",
-                      ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN, &rpl_opt_target_buf->target),
-                      ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN, &ipv6_buf->srcaddr),
+                      ipv6_addr_to_str(addr_str_mode, IPV6_MAX_ADDR_STR_LEN, &rpl_opt_target_buf->target),
+                      ipv6_addr_to_str(addr_str_mode, IPV6_MAX_ADDR_STR_LEN, &ipv6_buf->srcaddr),
                       (rpl_opt_transit_buf->path_lifetime * my_dodag->lifetime_unit));
                 rpl_add_routing_entry(&rpl_opt_target_buf->target, &ipv6_buf->srcaddr,
                         rpl_opt_transit_buf->path_lifetime * my_dodag->lifetime_unit);
@@ -851,7 +851,7 @@ void rpl_send(ipv6_addr_t *destination, uint8_t *payload, uint16_t p_len, uint8_
 
         if (next_hop == NULL) {
             if (i_am_root) {
-                DEBUGF("[Error] destination unknown: %s\n", ipv6_addr_to_str(addr_str,
+                DEBUGF("[Error] destination unknown: %s\n", ipv6_addr_to_str(addr_str_mode,
                         IPV6_MAX_ADDR_STR_LEN, &ipv6_send_buf->destaddr));
                 return;
             }


### PR DESCRIPTION
In PR #1404 addr_str was renamed to addr_str_mode,
but at some places it was still referenced as addr_str.
When enabling debug messages _for the file rpl_storing.c_, the compiler complains.
