### PR TITLE
rpl: fix offset for transit buf

### DIFF
--- a/sys/net/routing/rpl/rpl_storing/rpl_storing.c
+++ b/sys/net/routing/rpl/rpl_storing/rpl_storing.c
@@ -679,7 +679,7 @@ void rpl_recv_DAO_mode(void)
                     break;
                 }
 
-                len += rpl_opt_target_buf->length + 2;
+                len += rpl_opt_target_buf->length;
                 rpl_opt_transit_buf = get_rpl_opt_transit_buf(len);
 
                 if (rpl_opt_transit_buf->type != RPL_OPT_TRANSIT) {


### PR DESCRIPTION
As a result of PR #1404, entries will not be added to the routing table
when running in storing mode, although it is supposed to do so.
You can verify by running the **rpl_udp** example and calling _route_ on the dodag-root.

This PR fixes the wrong offset calculation.
