### PR TITLE
doc: eliminate driver documentation warnings

### DIFF
--- a/drivers/cc110x_legacy_csma/cc1100-csmaca-mac.h
+++ b/drivers/cc110x_legacy_csma/cc1100-csmaca-mac.h
@@ -29,25 +29,32 @@ extern "C" {
 
 //#define CSMACA_MAC_AGGRESSIVE_MODE                // MAC aggressive mode on/off switch
 
-#define CARRIER_SENSE_TIMEOUT            (200000)   // Carrier Sense timeout ~ 2 seconds
-#define CARRIER_SENSE_TIMEOUT_MIN          (2000)   // Minimum Carrier Sense timeout ~ 20 milliseconds
-#define CS_TX_SWITCH_TIME                    (80)   // Carrier Sense to TX switch time (measured ~ 350 us)
+#define CARRIER_SENSE_TIMEOUT            (200000)   /**< Carrier Sense timeout ~ 2 seconds */
+#define CARRIER_SENSE_TIMEOUT_MIN          (2000)   /**< Minimum Carrier Sense timeout ~ 20 milliseconds */
+#define CS_TX_SWITCH_TIME                    (80)   /**< Carrier Sense to TX switch time (measured ~ 350 us) */
 
-/** All values are in ticks (x10 us) */
-#define PRIO_ALARM_DIFS                     (200)   // DIFS for ALARM packets, the default wait time
-#define PRIO_ALARM_SLOTTIME   (CS_TX_SWITCH_TIME)   // Time of one additional wait slot
-#define PRIO_ALARM_MIN_WINDOW_SIZE            (2)   // Minimum window size of backoff algorithm
-#define PRIO_ALARM_MAX_WINDOW_SIZE            (8)   // Maximum window size of backoff algorithm
+/**
+ * @name CSMA backoff and wait times
+ * @brief All values are in ticks (x10 us)
+ * @{
+ */
+#define PRIO_ALARM_DIFS                     (200)   /**< DIFS for ALARM packets, the default wait time */
+#define PRIO_ALARM_SLOTTIME   (CS_TX_SWITCH_TIME)   /**< Time of one additional wait slot */
+#define PRIO_ALARM_MIN_WINDOW_SIZE            (2)   /**< Minimum window size of backoff algorithm */
+#define PRIO_ALARM_MAX_WINDOW_SIZE            (8)   /**< Maximum window size of backoff algorithm */
 
-#define PRIO_WARN_DIFS                     (1000)   // DIFS for WARN packets, the default wait time
-#define PRIO_WARN_SLOTTIME    (CS_TX_SWITCH_TIME)   // Time of one additional wait slot
-#define PRIO_WARN_MIN_WINDOW_SIZE             (2)   // Minimum window size of backoff algorithm
-#define PRIO_WARN_MAX_WINDOW_SIZE            (16)   // Maximum window size of backoff algorithm
+#define PRIO_WARN_DIFS                     (1000)   /**< DIFS for WARN packets, the default wait time */
+#define PRIO_WARN_SLOTTIME    (CS_TX_SWITCH_TIME)   /**< Time of one additional wait slot */
+#define PRIO_WARN_MIN_WINDOW_SIZE             (2)   /**< Minimum window size of backoff algorithm */
+#define PRIO_WARN_MAX_WINDOW_SIZE            (16)   /**< Maximum window size of backoff algorithm */
 
-#define PRIO_DATA_DIFS                     (2500)   // DIFS for normal data packets, the default wait time
-#define PRIO_DATA_SLOTTIME    (CS_TX_SWITCH_TIME)   // Time of one additional wait slot
-#define PRIO_DATA_MIN_WINDOW_SIZE             (4)   // Minimum window size of backoff algorithm
-#define PRIO_DATA_MAX_WINDOW_SIZE            (32)   // Maximum window size of backoff algorithm
+#define PRIO_DATA_DIFS                     (2500)   /**< DIFS for normal data packets, the default wait time */
+#define PRIO_DATA_SLOTTIME    (CS_TX_SWITCH_TIME)   /**< Time of one additional wait slot */
+#define PRIO_DATA_MIN_WINDOW_SIZE             (4)   /**< Minimum window size of backoff algorithm */
+#define PRIO_DATA_MAX_WINDOW_SIZE            (32)   /**< Maximum window size of backoff algorithm */
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/drivers/cc110x_legacy_csma/cc1100.h
+++ b/drivers/cc110x_legacy_csma/cc1100.h
@@ -48,74 +48,74 @@ extern "C" {
 
 /** @} */
 
-/** CC1100 register configuration */
+/** @brief CC1100 register configuration */
 typedef struct cc1100_reg {
-    uint8_t IOCFG2;
-    uint8_t IOCFG1;
-    uint8_t IOCFG0;
-    uint8_t FIFOTHR;
-    uint8_t SYNC1;
-    uint8_t SYNC0;
-    uint8_t PKTLEN;
-    uint8_t PKTCTRL1;
-    uint8_t PKTCTRL0;
-    uint8_t ADDR;
-    uint8_t CHANNR;
-    uint8_t FSCTRL1;
-    uint8_t FSCTRL0;
-    uint8_t FREQ2;
-    uint8_t FREQ1;
-    uint8_t FREQ0;
-    uint8_t MDMCFG4;
-    uint8_t MDMCFG3;
-    uint8_t MDMCFG2;
-    uint8_t MDMCFG1;
-    uint8_t MDMCFG0;
-    uint8_t DEVIATN;
-    uint8_t MCSM2;
-    uint8_t MCSM1;
-    uint8_t MCSM0;
-    uint8_t FOCCFG;
-    uint8_t BSCFG;
-    uint8_t AGCCTRL2;
-    uint8_t AGCCTRL1;
-    uint8_t AGCCTRL0;
-    uint8_t WOREVT1;
-    uint8_t WOREVT0;
-    uint8_t WORCTRL;
-    uint8_t FREND1;
-    uint8_t FREND0;
-    uint8_t FSCAL3;
-    uint8_t FSCAL2;
-    uint8_t FSCAL1;
-    uint8_t FSCAL0;
+    uint8_t IOCFG2;      /**< GDO2 output pin configuration */
+    uint8_t IOCFG1;      /**< GDO1 output pin configuration */
+    uint8_t IOCFG0;      /**< GDO0 output pin configuration */
+    uint8_t FIFOTHR;     /**< RX FIFO and TX FIFO thresholds */
+    uint8_t SYNC1;       /**< Sync word, high byte */
+    uint8_t SYNC0;       /**< Sync word, low byte */
+    uint8_t PKTLEN;      /**< Packet length */
+    uint8_t PKTCTRL1;    /**< Packet automation control */
+    uint8_t PKTCTRL0;    /**< Packet automation control */
+    uint8_t ADDR;        /**< Device address */
+    uint8_t CHANNR;      /**< Channel number */
+    uint8_t FSCTRL1;     /**< Frequency synthesizer control */
+    uint8_t FSCTRL0;     /**< Frequency synthesizer control */
+    uint8_t FREQ2;       /**< Frequency control word, high byte */
+    uint8_t FREQ1;       /**< Frequency control word, middle byte */
+    uint8_t FREQ0;       /**< Frequency control word, low byte */
+    uint8_t MDMCFG4;     /**< Modem configuration */
+    uint8_t MDMCFG3;     /**< Modem configuration */
+    uint8_t MDMCFG2;     /**< Modem configuration */
+    uint8_t MDMCFG1;     /**< Modem configuration */
+    uint8_t MDMCFG0;     /**< Modem configuration */
+    uint8_t DEVIATN;     /**< Modem deviation setting */
+    uint8_t MCSM2;       /**< Main Radio Control State Machine configuration */
+    uint8_t MCSM1;       /**< Main Radio Control State Machine configuration */
+    uint8_t MCSM0;       /**< Main Radio Control State Machine configuration */
+    uint8_t FOCCFG;      /**< Frequency Offset Compensation configuration */
+    uint8_t BSCFG;       /**< Bit Synchronization configuration */
+    uint8_t AGCCTRL2;    /**< AGC control */
+    uint8_t AGCCTRL1;    /**< AGC control */
+    uint8_t AGCCTRL0;    /**< AGC control */
+    uint8_t WOREVT1;     /**< High byte Event 0 timeout */
+    uint8_t WOREVT0;     /**< Low byte Event 0 timeout */
+    uint8_t WORCTRL;     /**< Wake On Radio control */
+    uint8_t FREND1;      /**< Front end RX configuration */
+    uint8_t FREND0;      /**< Front end TX configuration */
+    uint8_t FSCAL3;      /**< Frequency synthesizer calibration */
+    uint8_t FSCAL2;      /**< Frequency synthesizer calibration */
+    uint8_t FSCAL1;      /**< Frequency synthesizer calibration */
+    uint8_t FSCAL0;      /**< Frequency synthesizer calibration */
 } cc1100_reg_t;
 
 /** CC1100 radio configuration */
 typedef struct cc1100_cfg_t {
-    cc1100_reg_t reg_cfg;       ///< CC1100 register configuration
-    uint8_t pa_power;           ///< Output power setting
+    cc1100_reg_t reg_cfg;       /**< CC1100 register configuration */
+    uint8_t pa_power;           /**< Output power setting */
 } cc1100_cfg_t;
 
 /**
  * @brief   Radio Control Flags
  */
 typedef struct cc1100_flags {
-    uint32_t TOF;               ///< Time of flight of the last packet and last ACK
-    uint32_t TCP;               ///< Time to compute packet
-    unsigned RPS        : 16;   ///< Raw packets sent to transmit last packet
-    unsigned RETC       : 8;    ///< Retransmission count of last send packet
-    unsigned RSSI       : 8;    ///< The RSSI value of last received packet
-    unsigned RSSI_SEND  : 8;    ///< The RSSI value of the last send unicast packet of this node
-    unsigned LQI        : 8;    ///< The LQI value of the last received packet
-    unsigned LL_ACK     : 1;    ///< Is set if Link-Level ACK is received, otherwise 0 (reset on new burst)
-    unsigned CAA        : 1;    ///< The status of the air (1 = air free, 0 = air not free)
-    unsigned CRC_STATE  : 1;    ///< The CRC status of last received packet (1 = OK, 0 = not OK)
-    unsigned SEQ        : 1;    ///< Sequence number (toggles between 0 and 1)
-    unsigned MAN_WOR    : 1;    ///< Manual WOR set (for randomized WOR times => no synch)
-    unsigned KT_RES_ERR : 1;    ///< A hwtimer resource error has occurred (no free timers available)
-    unsigned TX         : 1;    ///< State machine TX lock, only ACKs will be received
-    unsigned WOR_RST    : 1;    ///< Reset CC1100 real time clock (WOR) on next WOR strobe
+    uint32_t TOF;               /**< Time of flight of the last packet and last ACK */
+    uint32_t TCP;               /**< Time to compute packet */
+    unsigned RPS        : 16;   /**< Raw packets sent to transmit last packet */
+    unsigned RETC       : 8;    /**< Retransmission count of last send packet */
+    unsigned RSSI       : 8;    /**< The RSSI value of last received packet */
+    unsigned RSSI_SEND  : 8;    /**< The RSSI value of the last send unicast packet of this node */
+    unsigned LQI        : 8;    /**< The LQI value of the last received packet */
+    unsigned LL_ACK     : 1;    /**< Is set if Link-Level ACK is received, otherwise 0 (reset on new burst) */
+    unsigned CAA        : 1;    /**< The status of the air (1 = air free, 0 = air not free) */
+    unsigned CRC_STATE  : 1;    /**< The CRC status of last received packet (1 = OK, 0 = not OK) */
+    unsigned SEQ        : 1;    /**< Sequence number (toggles between 0 and 1) */
+    unsigned MAN_WOR    : 1;    /**< Manual WOR set (for randomized WOR times => no synch) */
+    unsigned KT_RES_ERR : 1;    /**< A hwtimer resource error has occurred (no free timers available) */
+    unsigned TX         : 1;    /**< State machine TX lock, only ACKs will be received */
+    unsigned WOR_RST    : 1;    /**< Reset CC1100 real time clock (WOR) on next WOR strobe */
 } cc1100_flags;
 
 /**
@@ -138,18 +138,18 @@ typedef struct cc1100_statistic {
 } cc1100_statistic_t;
 
 enum radio_mode {
-    RADIO_MODE_GET  = -1,       ///< leave mode unchanged
-    RADIO_MODE_OFF  = 0,        ///< turn radio off
-    RADIO_MODE_ON   = 1         ///< turn radio on
+    RADIO_MODE_GET  = -1,       /**< leave mode unchanged */
+    RADIO_MODE_OFF  = 0,        /**< turn radio off */
+    RADIO_MODE_ON   = 1         /**< turn radio on */
 };
 
 enum radio_result {
-    RADIO_PAYLOAD_TOO_LONG      = -1,   ///< payload too long
-    RADIO_WRONG_MODE            = -2,   ///< operation not supported in current mode
-    RADIO_ADDR_OUT_OF_RANGE     = -3,   ///< address out of range
-    RADIO_OP_FAILED             = -4,   ///< operation failed
-    RADIO_CS_TIMEOUT            = -5,   ///< Carrier Sense timeout: air was never free
-    RADIO_INVALID_PARAM         = -6    ///< Invalid parameters passed to radio
+    RADIO_PAYLOAD_TOO_LONG      = -1,   /**< payload too long */
+    RADIO_WRONG_MODE            = -2,   /**< operation not supported in current mode */
+    RADIO_ADDR_OUT_OF_RANGE     = -3,   /**< address out of range */
+    RADIO_OP_FAILED             = -4,   /**< operation failed */
+    RADIO_CS_TIMEOUT            = -5,   /**< Carrier Sense timeout: air was never free */
+    RADIO_INVALID_PARAM         = -6    /**< Invalid parameters passed to radio */
 };
 
 /* ------------------------------------------------------------------------- */

--- a/drivers/include/cc110x/cc110x-config.h
+++ b/drivers/include/cc110x/cc110x-config.h
@@ -31,45 +31,45 @@ extern "C" {
  * @brief   CC110x register configuration
  */
 typedef struct {
-    uint8_t _IOCFG2;
-    uint8_t _IOCFG1;
-    uint8_t _IOCFG0;
-    uint8_t _FIFOTHR;
-    uint8_t _SYNC1;
-    uint8_t _SYNC0;
-    uint8_t _PKTLEN;
-    uint8_t _PKTCTRL1;
-    uint8_t _PKTCTRL0;
-    uint8_t _ADDR;
-    uint8_t _CHANNR;
-    uint8_t _FSCTRL1;
-    uint8_t _FSCTRL0;
-    uint8_t _FREQ2;
-    uint8_t _FREQ1;
-    uint8_t _FREQ0;
-    uint8_t _MDMCFG4;
-    uint8_t _MDMCFG3;
-    uint8_t _MDMCFG2;
-    uint8_t _MDMCFG1;
-    uint8_t _MDMCFG0;
-    uint8_t _DEVIATN;
-    uint8_t _MCSM2;
-    uint8_t _MCSM1;
-    uint8_t _MCSM0;
-    uint8_t _FOCCFG;
-    uint8_t _BSCFG;
-    uint8_t _AGCCTRL2;
-    uint8_t _AGCCTRL1;
-    uint8_t _AGCCTRL0;
-    uint8_t _WOREVT1;
-    uint8_t _WOREVT0;
-    uint8_t _WORCTRL;
-    uint8_t _FREND1;
-    uint8_t _FREND0;
-    uint8_t _FSCAL3;
-    uint8_t _FSCAL2;
-    uint8_t _FSCAL1;
-    uint8_t _FSCAL0;
+    uint8_t _IOCFG2;      /**< GDO2 output pin configuration */
+    uint8_t _IOCFG1;      /**< GDO1 output pin configuration */
+    uint8_t _IOCFG0;      /**< GDO0 output pin configuration */
+    uint8_t _FIFOTHR;     /**< RX FIFO and TX FIFO thresholds */
+    uint8_t _SYNC1;       /**< Sync word, high byte */
+    uint8_t _SYNC0;       /**< Sync word, low byte */
+    uint8_t _PKTLEN;      /**< Packet length */
+    uint8_t _PKTCTRL1;    /**< Packet automation control */
+    uint8_t _PKTCTRL0;    /**< Packet automation control */
+    uint8_t _ADDR;        /**< Device address */
+    uint8_t _CHANNR;      /**< Channel number */
+    uint8_t _FSCTRL1;     /**< Frequency synthesizer control */
+    uint8_t _FSCTRL0;     /**< Frequency synthesizer control */
+    uint8_t _FREQ2;       /**< Frequency control word, high byte */
+    uint8_t _FREQ1;       /**< Frequency control word, middle byte */
+    uint8_t _FREQ0;       /**< Frequency control word, low byte */
+    uint8_t _MDMCFG4;     /**< Modem configuration */
+    uint8_t _MDMCFG3;     /**< Modem configuration */
+    uint8_t _MDMCFG2;     /**< Modem configuration */
+    uint8_t _MDMCFG1;     /**< Modem configuration */
+    uint8_t _MDMCFG0;     /**< Modem configuration */
+    uint8_t _DEVIATN;     /**< Modem deviation setting */
+    uint8_t _MCSM2;       /**< Main Radio Control State Machine configuration */
+    uint8_t _MCSM1;       /**< Main Radio Control State Machine configuration */
+    uint8_t _MCSM0;       /**< Main Radio Control State Machine configuration */
+    uint8_t _FOCCFG;      /**< Frequency Offset Compensation configuration */
+    uint8_t _BSCFG;       /**< Bit Synchronization configuration */
+    uint8_t _AGCCTRL2;    /**< AGC control */
+    uint8_t _AGCCTRL1;    /**< AGC control */
+    uint8_t _AGCCTRL0;    /**< AGC control */
+    uint8_t _WOREVT1;     /**< High byte Event 0 timeout */
+    uint8_t _WOREVT0;     /**< Low byte Event 0 timeout */
+    uint8_t _WORCTRL;     /**< Wake On Radio control */
+    uint8_t _FREND1;      /**< Front end RX configuration */
+    uint8_t _FREND0;      /**< Front end TX configuration */
+    uint8_t _FSCAL3;      /**< Frequency synthesizer calibration */
+    uint8_t _FSCAL2;      /**< Frequency synthesizer calibration */
+    uint8_t _FSCAL1;      /**< Frequency synthesizer calibration */
+    uint8_t _FSCAL0;      /**< Frequency synthesizer calibration */
 } cc110x_reg_t;
 
 /**

--- a/drivers/include/lm75a-temp-sensor.h
+++ b/drivers/include/lm75a-temp-sensor.h
@@ -64,7 +64,8 @@ enum OPERATION_MODES {
     LM75A_INTERRUPT_MODE
 };
 
-/** @name Common definitions for LMA75A
+/**
+ * @name Common definitions for LMA75A
  * @{
  */
 #define LM75A_BIT0                      0x0

--- a/drivers/include/lm75a-temp-sensor.h
+++ b/drivers/include/lm75a-temp-sensor.h
@@ -35,20 +35,28 @@
 extern "C" {
 #endif
 
-/* LM75A register addresses */
+/**
+ * @name LM75A register addresses
+ * @{
+ */
 #define LM75A_ADDR                      0x48
 #define LM75A_TEMPERATURE_REG           0x0
 #define LM75A_CONFIG_REG                0x1
 #define LM75A_THYST_REG                 0x2
 #define LM75A_OVER_TEMP_REG             0x3
+/** @} */
 
-/* Define the used I2C Interface */
+/**
+ * @brief Define the used I2C Interface
+ */
 //#define LM75A_I2C_INTERFACE I2C0                // P0.27 SDA0, P0.28 SCL0
 #define LM75A_I2C_INTERFACE             I2C1_0    // P0.0  SDA1, P0.1  SCL1
 //#define LM75A_I2C_INTERFACE I2C1_1              // P0.19 SDA1, P0.20 SCL1
 //#define LM75A_I2C_INTERFACE I2C2                // P0.10 SDA2, P0.11 SCL2
 
-/* LM75A operation modes */
+/**
+ * @brief LM75A operation modes
+ */
 enum OPERATION_MODES {
     LM75A_NORMAL_OPERATION_MODE,
     LM75A_SHUTDOWN_MODE,
@@ -56,7 +64,9 @@ enum OPERATION_MODES {
     LM75A_INTERRUPT_MODE
 };
 
-/*Common definitions for LMA75A  */
+/** @name Common definitions for LMA75A
+ * @{
+ */
 #define LM75A_BIT0                      0x0
 #define LM75A_BIT1                      0x1
 #define LM75A_BIT2                      0x2
@@ -75,34 +85,38 @@ enum OPERATION_MODES {
 #define LM75A_SIGN_BIT_MASK             (1<<LM75A_BIT10)
 #define LM75A_LSB_MASK                  0x1
 #define LM75A_EXTINT_MODE               0x1
+/** @} */
 
-/* LM75A configuration register */
+/**
+ * @name LM75A configuration register
+ * @{
+ */
 #define LM75A_ACTIVE_LOW                0
 #define LM75A_ACTIVE_HIGH               1
 #define LM75A_DEFAULT_CONFIG_VALUE      0
+/** @} */
 
-enum FAULT_QUEUE_VALUES {
-    LM75A_ONE_FAULT = 1,
-    LM75A_TWO_FAULT = 2,
-    LM75A_FOUR_FAULT = 4,
-    LM75A_SIX_FAULT = 6
-};
-
-/* LM75A default values */
+/**
+ * @brief LM75A default values
+ */
 enum DEFAULT_VALUES {
     LM75A_DEFAULT_TOS = 80,
     LM75A_DEFAULT_THYST = 75,
     LM75A_DEFAULT_OPERATION = LM75A_NORMAL_OPERATION_MODE,
     LM75A_DEFAULT_MODE = LM75A_COMPARATOR_MODE,
     LM75A_DEFAULT_POLARITY = LM75A_ACTIVE_LOW,
-    LM75A_DEFAULT_FAULT_NUM = LM75A_ONE_FAULT
+    LM75A_DEFAULT_FAULT_NUM = 1
 };
 
-/*define inter-threads messages */
+/**
+ * @name define inter-threads messages
+ * @{
+ */
 #define LM75A_EXIT_MSG                  0
 #define LM75A_SAMPLING_MSG              1
 #define LM75A_SLEEP_MSG                 2
 #define LM75A_WEAKUP_MSG                3
+/** @} */
 
 /**
  * @brief       Set the over-temperature shutdown threshold (TOS).


### PR DESCRIPTION
Another issue addressing #2137. Eliminating about 140 warnings in `drivers`.