### PR TITLE
test/driver_nrf24l01p: changed default GPIOs

### DIFF
--- a/tests/driver_nrf24l01p_lowlevel/Makefile
+++ b/tests/driver_nrf24l01p_lowlevel/Makefile
@@ -10,9 +10,9 @@ USEMODULE += nrf24l01p
 FEATURES_REQUIRED = periph_spi
 
 SPI_PORT ?= SPI_0
-CE_PIN   ?= GPIO_8
-CS_PIN   ?= GPIO_7
-IRQ_PIN  ?= GPIO_6
+CE_PIN   ?= GPIO_0
+CS_PIN   ?= GPIO_1
+IRQ_PIN  ?= GPIO_2
 
 include $(RIOTBASE)/Makefile.include
 


### PR DESCRIPTION
not all boards have GPIO_x > GPIO_7, so the new values are
safer to use.
