### PR TITLE
vtimer: set custom msg_t.type with vtimer_set_msg

### DIFF
--- a/drivers/cc110x_legacy_csma/cc1100_phy.c
+++ b/drivers/cc110x_legacy_csma/cc1100_phy.c
@@ -178,7 +178,7 @@ void cc1100_phy_init(void)
         cc1100_watch_dog_period = timex_set(CC1100_WATCHDOG_PERIOD, 0);
 
         if (timex_cmp(cc1100_watch_dog_period, timex_set(0, 0)) != 0) {
-            vtimer_set_msg(&cc1100_watch_dog, cc1100_watch_dog_period, cc1100_event_handler_pid, NULL);
+            vtimer_set_msg(&cc1100_watch_dog, cc1100_watch_dog_period, cc1100_event_handler_pid, MSG_TIMER, NULL);
         }
     }
 }
@@ -677,7 +677,7 @@ static void *cc1100_event_handler_function(void *arg)
         if (rx_buffer_size == 0) {
             if (timex_uint64(cc1100_watch_dog_period) != 0) {
                 vtimer_set_msg(&cc1100_watch_dog, cc1100_watch_dog_period,
-                               cc1100_event_handler_pid, NULL);
+                               cc1100_event_handler_pid, MSG_TIMER, NULL);
             }
 
             msg_receive(&m);

--- a/sys/include/vtimer.h
+++ b/sys/include/vtimer.h
@@ -52,6 +52,8 @@ typedef struct vtimer_t {
     timex_t absolute;
     /** the action to perform when timer fires */
     void (*action)(struct vtimer_t *timer);
+    /** value for msg_t.type */
+    uint16_t type;
     /** optional argument for vtimer_t::action */
     void *arg;
     /** optional process id for vtimer_t::action to act on */
@@ -102,10 +104,11 @@ int vtimer_sleep(timex_t time);
  * @param[in]   t           pointer to preinitialised vtimer_t
  * @param[in]   interval    vtimer timex_t interval
  * @param[in]   pid         process id
+ * @param[in]   type        value for the msg_t type
  * @param[in]   ptr         message value
  * @return      0 on success, < 0 on error
  */
-int vtimer_set_msg(vtimer_t *t, timex_t interval, kernel_pid_t pid, void *ptr);
+int vtimer_set_msg(vtimer_t *t, timex_t interval, kernel_pid_t pid, uint16_t type, void *ptr);
 
 /**
  * @brief   set a vtimer with wakeup event

--- a/sys/net/network_layer/sixlowpan/border/flowcontrol.c
+++ b/sys/net/network_layer/sixlowpan/border/flowcontrol.c
@@ -114,7 +114,7 @@ static int set_timeout(vtimer_t *timeout, timex_t val, void *args)
     vtimer_remove(timeout);
 
     timex_normalize(&val);
-    return vtimer_set_msg(timeout, val, sending_slot_pid, args);
+    return vtimer_set_msg(timeout, val, sending_slot_pid, MSG_TIMER, args);
 }
 
 static int in_window(uint8_t seq_num, uint8_t min, uint8_t max)

--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -158,7 +158,7 @@ void vtimer_callback_tick(vtimer_t *timer)
 static void vtimer_callback_msg(vtimer_t *timer)
 {
     msg_t msg;
-    msg.type = MSG_TIMER;
+    msg.type = timer->type;
     msg.content.value = (unsigned int) timer->arg;
     msg_send_int(&msg, timer->pid);
 }
@@ -383,9 +383,10 @@ int vtimer_remove(vtimer_t *t)
     return 0;
 }
 
-int vtimer_set_msg(vtimer_t *t, timex_t interval, kernel_pid_t pid, void *ptr)
+int vtimer_set_msg(vtimer_t *t, timex_t interval, kernel_pid_t pid, uint16_t type, void *ptr)
 {
     t->action = vtimer_callback_msg;
+    t->type = type;
     t->arg = ptr;
     t->absolute = interval;
     t->pid = pid;
@@ -399,7 +400,7 @@ int vtimer_msg_receive_timeout(msg_t *m, timex_t timeout) {
     timeout_message.content.ptr = (char *) &timeout_message;
 
     vtimer_t t;
-    vtimer_set_msg(&t, timeout, sched_active_pid, &timeout_message);
+    vtimer_set_msg(&t, timeout, sched_active_pid, MSG_TIMER, &timeout_message);
     msg_receive(m);
     if (m->type == MSG_TIMER && m->content.ptr == (char *) &timeout_message) {
         /* we hit the timeout */

--- a/tests/vtimer_msg/main.c
+++ b/tests/vtimer_msg/main.c
@@ -64,7 +64,7 @@ void *timer_thread(void *arg)
                tmsg->interval.microseconds,
                tmsg->msg);
 
-        if (vtimer_set_msg(&tmsg->timer, tmsg->interval, thread_getpid(), tmsg) != 0) {
+        if (vtimer_set_msg(&tmsg->timer, tmsg->interval, thread_getpid(), MSG_TIMER, tmsg) != 0) {
             puts("something went wrong");
         }
         else {

--- a/tests/vtimer_msg_diff/main.c
+++ b/tests/vtimer_msg_diff/main.c
@@ -87,7 +87,7 @@ void *timer_thread(void *arg)
             printf("WARNING: timer difference %" PRId64 "us exceeds MAXDIFF(%d)!\n", diff, MAXDIFF);
         }
 
-        if (vtimer_set_msg(&tmsg->timer, tmsg->interval, thread_getpid(), tmsg) != 0) {
+        if (vtimer_set_msg(&tmsg->timer, tmsg->interval, thread_getpid(), MSG_TIMER, tmsg) != 0) {
             puts("something went wrong setting a timer");
         }
 


### PR DESCRIPTION
Currently, when using vtimer_set_msg the corresponding msg_t is filled
with the MSG_TIMER ("12345") type.
This approach makes it difficult to differentiate between incoming
messages via vtimer_set_msg.

In this PR I introduce another parameter for the vtimer_set_msg
function to specify a custom msg_t type.
~~If 0 is specified, the implementation will return to the MSG_TIMER type
as before.~~
