### PR TITLE
sys:net:routing:rpl allow setting the number of routing entries on comile time

### DIFF
--- a/sys/net/include/rpl/rpl_config.h
+++ b/sys/net/include/rpl/rpl_config.h
@@ -127,8 +127,21 @@ static inline bool RPL_COUNTER_GREATER_THAN(uint8_t A, uint8_t B)
 #define RPL_MAX_DODAGS 3
 #define RPL_MAX_INSTANCES 1
 #define RPL_MAX_PARENTS 5
-#define RPL_MAX_ROUTING_ENTRIES_STORING 128
-#define RPL_MAX_ROUTING_ENTRIES_NON_STORING 128
+#ifndef RPL_MAX_ROUTING_ENTRIES
+    #if (RPL_DEFAULT_MOP == RPL_NO_DOWNWARD_ROUTES)
+    #    define RPL_MAX_ROUTING_ENTRIES (128)
+    #elif (RPL_DEFAULT_MOP == RPL_NON_STORING_MODE)
+        #ifdef RPL_NODE_IS_ROOT
+        #    define RPL_MAX_ROUTING_ENTRIES (128)
+        #else
+        #    define RPL_MAX_ROUTING_ENTRIES (0)
+        #endif
+    #elif (RPL_DEFAULT_MOP == RPL_STORING_MODE_NO_MC)
+    #    define RPL_MAX_ROUTING_ENTRIES (128)
+    #else // RPL_DEFAULT_MOP == RPL_STORING_MODE_MC
+    #    define RPL_MAX_ROUTING_ENTRIES (128)
+    #endif
+#endif
 #define RPL_MAX_SRH_PATH_LENGTH 10;
 #define RPL_SRH_ENTRIES 15
 #define RPL_ROOT_RANK 256

--- a/sys/net/routing/rpl/Makefile
+++ b/sys/net/routing/rpl/Makefile
@@ -4,4 +4,15 @@ ifneq (,$(MODE))
 else
 	DIRS += rpl_storing
 endif
+
+# Set the maximum number of routing entries to 128 if no number is provided
+ifneq (,$(RPL_MAX_ROUTING_ENTRIES))
+	CFLAGS += -DRPL_MAX_ROUTING_ENTRIES=$(RPL_MAX_ROUTING_ENTRIES)
+endif
+
+# Define this node as root at compile time (required only for non-storing mode) 
+ifneq (,$(RPL_NODE_IS_ROOT))
+	CFLAGS += -DRPL_NODE_IS_ROOT
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -65,10 +65,9 @@ uint8_t srh_send_buffer[BUFFER_SIZE];
 ipv6_addr_t *down_next_hop;
 ipv6_srh_t *srh_header;
 msg_t srh_m_send, srh_m_recv;
-rpl_routing_entry_t rpl_routing_table[RPL_MAX_ROUTING_ENTRIES_NON_STORING];
-#else
-rpl_routing_entry_t rpl_routing_table[RPL_MAX_ROUTING_ENTRIES_STORING];
 #endif
+
+rpl_routing_entry_t rpl_routing_table[RPL_MAX_ROUTING_ENTRIES];
 
 uint8_t rpl_max_routing_entries;
 ipv6_addr_t my_address;
@@ -82,16 +81,8 @@ uint8_t rpl_init(int if_id)
     rpl_instances_init();
 
     /* initialize routing table */
+    rpl_max_routing_entries = RPL_MAX_ROUTING_ENTRIES;
     rpl_clear_routing_table();
-
-    if (RPL_DEFAULT_MOP == RPL_STORING_MODE_NO_MC) {
-        rpl_max_routing_entries = RPL_MAX_ROUTING_ENTRIES_STORING;
-        rpl_clear_routing_table();
-    }
-    else {
-        rpl_max_routing_entries = RPL_MAX_ROUTING_ENTRIES_NON_STORING;
-        rpl_clear_routing_table();
-    }
 
     if (rpl_routing_table == NULL) {
         DEBUGF("Routing table init failed!\n");
@@ -124,6 +115,17 @@ uint8_t rpl_init(int if_id)
 
 void rpl_init_root(void)
 {
+#if (RPL_DEFAULT_MOP == RPL_NON_STORING_MODE)
+#ifndef RPL_NODE_IS_ROOT
+puts("\n############################## ERROR ###############################");
+puts("This configuration has NO ROUTING TABLE available for the root node!");
+puts("The root will NOT be INITIALIZED.");
+puts("Please build the binary for root in non-storing MOP with:");
+puts("\t\t'make RPL_NODE_IS_ROOT=1'");
+puts("############################## ERROR ###############################\n");
+return;
+#endif
+#endif
     rpl_init_root_mode();
 }
 


### PR DESCRIPTION
This PR allows to configure the maximum used entries for the routing table during compile time, e.g.:
`make RPL_MAX_ROUTING_ENTRIES=99`
If no maximum number is provided `128` is assumed as default.
This PR closes #2082
