### PR TITLE
native: workaround for missing __builtin_bswap16

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -95,6 +95,11 @@ all-gprof: export LINKFLAGS += -pg
 
 export INCLUDES += $(NATIVEINCLUDES)
 
+# workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52624
+ifneq ($(shell gcc --version | head -1 | grep -E ' (4.6|4.7)'),)
+	export CFLAGS += -DHAVE_NO_BUILTIN_BSWAP16
+endif
+
 # backward compatability with glibc <= 2.17 for native
 ifeq ($(CPU),native)
 ifeq ($(shell uname -s),Linux)

--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -275,6 +275,12 @@ static inline uint64_t NTOHLL(uint64_t v);
 
 /* **************************** IMPLEMENTATION ***************************** */
 
+#ifdef HAVE_NO_BUILTIN_BSWAP16
+static inline unsigned short __builtin_bswap16(unsigned short a)
+{
+    return (a<<8)|(a>>8);
+}
+#endif
 
 static inline uint16_t byteorder_swaps(uint16_t v)
 {


### PR DESCRIPTION
Implements a workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52624
This is present in current versions of ubuntu 12.04 and debian 7.7 (stable).
