### PR TITLE
core: debug: make stack size check more sensible

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -43,7 +43,7 @@
 #include "cpu-conf.h"
 #define DEBUG_PRINT(...) \
     do { \
-        if ((sched_active_thread == NULL) || (sched_active_thread->stack_size > KERNEL_CONF_STACKSIZE_PRINTF)) { \
+        if ((sched_active_thread == NULL) || (sched_active_thread->stack_size >= KERNEL_CONF_STACKSIZE_PRINTF)) { \
             printf(__VA_ARGS__); \
         } \
         else { \


### PR DESCRIPTION
When DEVELHELP is defined, DEBUG() used to bail out when the thread's stack size is smaller or equal KERNEL_CONF_STACKSIZE_PRINTF. Change that so that if stacksize is at least KERNEL_CONF_STACKSIZE_PRINTF, DEBUG() will do it's magic.
