### PR TITLE
rpl: wrong dodag assignment to parent

### DIFF
--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -329,13 +329,6 @@ void rpl_join_dodag(rpl_dodag_t *dodag, ipv6_addr_t *parent, uint16_t parent_ran
         return;
     }
 
-    preferred_parent = rpl_new_parent(dodag, parent, parent_rank);
-
-    if (preferred_parent == NULL) {
-        rpl_del_dodag(my_dodag);
-        return;
-    }
-
     my_dodag->instance->joined = 1;
     my_dodag->of = dodag->of;
     my_dodag->mop = dodag->mop;
@@ -351,6 +344,14 @@ void rpl_join_dodag(rpl_dodag_t *dodag, ipv6_addr_t *parent, uint16_t parent_ran
     my_dodag->version = dodag->version;
     my_dodag->grounded = dodag->grounded;
     my_dodag->joined = 1;
+
+    preferred_parent = rpl_new_parent(my_dodag, parent, parent_rank);
+
+    if (preferred_parent == NULL) {
+        rpl_del_dodag(my_dodag);
+        return;
+    }
+
     my_dodag->my_preferred_parent = preferred_parent;
     my_dodag->node_status = (uint8_t) NORMAL_NODE;
     my_dodag->my_rank = dodag->of->calc_rank(preferred_parent, dodag->my_rank);


### PR DESCRIPTION
`dodag` is the representation of the incoming DIO and thus is temporary.
Assigning this to the parent would lead to failure when reading/writing
to/from the parent's dodag attribute later.
`my_dodag`on the other hand is the local persistent representation of
the DIO's dodag and therefore the right choice.

I also had to move the code a little further down, because the parent uses the dodag's lifetime values to compute it's own lifetime. 