### PR TITLE
rpl: remove send mutex

### DIFF
--- a/sys/net/include/rpl.h
+++ b/sys/net/include/rpl.h
@@ -27,7 +27,6 @@
 #include <string.h>
 #include <stdint.h>
 #include <vtimer.h>
-#include <mutex.h>
 #include <transceiver.h>
 #include "ipv6.h"
 #include "rpl/rpl_dodag.h"
@@ -46,10 +45,6 @@ extern "C" {
 /* global variables */
 extern kernel_pid_t rpl_process_pid;
 extern uint8_t rpl_max_routing_entries;
-
-/* needed for sending RPL-messages */
-extern mutex_t rpl_send_mutex;
-
 extern msg_t rpl_msg_queue[RPL_PKT_RECV_BUF_SIZE];
 extern char rpl_process_buf[RPL_PROCESS_STACKSIZE];
 extern uint8_t rpl_buffer[BUFFER_SIZE - LL_HDR_LEN];
@@ -57,7 +52,7 @@ extern uint8_t rpl_buffer[BUFFER_SIZE - LL_HDR_LEN];
 /**
  * @brief Initialization of RPL.
  *
- * This function initializes all basic RPL resources such as mutex for send/receive,
+ * This function initializes all basic RPL resources such as
  * corresponding objective functions and sixlowpan (including own address). Calls
  * initialization for mode as specified by PL_DEFAULT_MOP in rpl_structs.h.
  *
@@ -83,7 +78,7 @@ void rpl_init_root(void);
  * @brief Sends a DIO-message to a given destination
  *
  * This function sends a DIO message to a given destination. Because nodes can act
- * differently in different modes, this function just sets the mutex and call the DIO
+ * differently in different modes, this function calls the DIO
  * sending function of the chosen mode.
  *
  * @param[in] destination       IPv6-address of the destination of the DIO. Should be a direct neighbor.
@@ -95,7 +90,7 @@ void rpl_send_DIO(ipv6_addr_t *destination);
  * @brief Sends a DAO-message to a given destination
  *
  * This function sends a DAO message to a given destination. Because nodes can act
- * differently in different modes, this function just sets the mutex and call the DAO
+ * differently in different modes, this function calls the DAO
  * sending function of the chosen mode.
  *
  * @param[in] destination       IPv6-address of the destination of the DAO. Should be the preferred parent.
@@ -110,7 +105,7 @@ void rpl_send_DAO(ipv6_addr_t *destination, uint8_t lifetime, bool default_lifet
  * @brief Sends a DIS-message to a given destination
  *
  * This function sends a DIS message to a given destination or multicast-address. Because nodes can act
- * differently in different modes, this function just sets the mutex and call the DIS
+ * differently in different modes, this function calls the DIS
  * sending function of the chosen mode.
  *
  * @param[in] destination       IPv6-address of the destination of the DIS. Should be a direct neighbor or multicast-address.
@@ -122,7 +117,7 @@ void rpl_send_DIS(ipv6_addr_t *destination);
  * @brief Sends a DAO acknowledgment-message to a given destination
  *
  * This function sends a DAO_ACK message to a given destination. Because nodes can act
- * differently in different modes, this function just sets the mutex and call the DAO_ACK
+ * differently in different modes, this function calls the DAO_ACK
  * sending function of the chosen mode.
  *
  * @param[in] destination       IPv6-address of the destination of the DAO_ACK. Should be a direct neighbor.
@@ -170,10 +165,7 @@ void rpl_recv_DAO_ACK(void);
  * @brief Initialization of RPl-root.
  *
  * This function initializes all RPL resources especially for root purposes.
- * corresponding objective functions and sixlowpan (including own address). It also register mutexes for
- * sending and receiving RPL-based messages. Both are necessary because of parallel access from different
- * layers/modules of RIOT. May change with future structure changes.
- *
+ * corresponding objective functions and sixlowpan (including own address).
  * @param arg ignored
  * @returns nothing
  */

--- a/sys/net/include/rpl/rpl_nonstoring.h
+++ b/sys/net/include/rpl/rpl_nonstoring.h
@@ -143,8 +143,7 @@ void rpl_recv_dao_ack_mode(void);
  *
  * This function sends any RPl related messages to a given destination. This implementation should be equal
  * for all modes and therefore should not be altered. Every mode related RPL-sending function calls this for
- * relaying it in lower layers to sixlowpan. Because send-functions are wrapped by a mutex in rpl.c, the same
- * mutex applies here.
+ * relaying it in lower layers to sixlowpan.
  *
  * @param[in] destination           IPv6-address of the destination of the message.
  * @param[in] payload               Payload of the message.

--- a/sys/net/include/rpl/rpl_storing.h
+++ b/sys/net/include/rpl/rpl_storing.h
@@ -144,8 +144,7 @@ void rpl_recv_dao_ack_mode(void);
  *
  * This function sends any RPl related messages to a given destination. This implementation should be equal
  * for all modes and therefore should not be altered. Every mode related RPL-sending function calls this for
- * relaying it in lower layers to sixlowpan. Because send-functions are wrapped by a mutex in rpl.c, the same
- * mutex applies here.
+ * relaying it in lower layers to sixlowpan.
  *
  * @param[in] destination           IPv6-address of the destination of the message.
  * @param[in] payload               Payload of the message.

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -23,7 +23,6 @@
 #include <string.h>
 #include "vtimer.h"
 #include "thread.h"
-#include "mutex.h"
 
 #include "msg.h"
 #include "rpl.h"
@@ -51,7 +50,6 @@ char addr_str[IPV6_MAX_ADDR_STR_LEN];
 
 /* global variables */
 kernel_pid_t rpl_process_pid = KERNEL_PID_UNDEF;
-mutex_t rpl_send_mutex = MUTEX_INIT;
 msg_t rpl_msg_queue[RPL_PKT_RECV_BUF_SIZE];
 char rpl_process_buf[RPL_PROCESS_STACKSIZE];
 uint8_t rpl_buffer[BUFFER_SIZE - LL_HDR_LEN];
@@ -291,9 +289,7 @@ void rpl_send_DIO(ipv6_addr_t *destination)
         DEBUGF("Send DIO to %s\n", ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN, destination));
     }
 
-    mutex_lock(&rpl_send_mutex);
     rpl_send_DIO_mode(destination);
-    mutex_unlock(&rpl_send_mutex);
 }
 
 void rpl_send_DAO(ipv6_addr_t *destination, uint8_t lifetime,
@@ -303,9 +299,7 @@ void rpl_send_DAO(ipv6_addr_t *destination, uint8_t lifetime,
         DEBUGF("Send DAO to %s\n", ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN, destination));
     }
 
-    mutex_lock(&rpl_send_mutex);
     rpl_send_DAO_mode(destination, lifetime, default_lifetime, start_index);
-    mutex_unlock(&rpl_send_mutex);
 }
 
 void rpl_send_DIS(ipv6_addr_t *destination)
@@ -314,9 +308,7 @@ void rpl_send_DIS(ipv6_addr_t *destination)
         DEBUGF("Send DIS to %s\n", ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN, destination));
     }
 
-    mutex_lock(&rpl_send_mutex);
     rpl_send_DIS_mode(destination);
-    mutex_unlock(&rpl_send_mutex);
 }
 
 void rpl_send_DAO_ACK(ipv6_addr_t *destination)
@@ -326,9 +318,7 @@ void rpl_send_DAO_ACK(ipv6_addr_t *destination)
                 ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN, destination));
     }
 
-    mutex_lock(&rpl_send_mutex);
     rpl_send_DAO_ACK_mode(destination);
-    mutex_unlock(&rpl_send_mutex);
 }
 
 void rpl_recv_DIO(void)


### PR DESCRIPTION
~~This PR is *based* on #2155.~~
Since RPL/Trickle is only using one thread ~~in #2155~~, the send mutex becomes
obsolete and can be removed safely.

~~**The diff seems quite large, because it also compares the changes made in #2155 with master.**~~