### PR TITLE
Revert "tests: don't build test/libfixmath on Travis CI"

### DIFF
--- a/tests/libfixmath/Makefile
+++ b/tests/libfixmath/Makefile
@@ -3,8 +3,4 @@ include ../Makefile.tests_common
 
 USEPKG += libfixmath
 
-ifeq ($(TRAVIS),true)
-  BOARD_WHITELIST := -
-endif
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/libfixmath_unittests/Makefile
+++ b/tests/libfixmath_unittests/Makefile
@@ -13,8 +13,4 @@ BOARD_INSUFFICIENT_RAM += redbee-econotag stm32f0discovery
 
 USEMODULE += libfixmath-unittests
 
-ifeq ($(TRAVIS),true)
-  BOARD_WHITELIST := -
-endif
-
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
This reverts commit f061d0214ebb788b3262b312a80323f5a1473d27.
Test if this test magically builds again Travis.

Closes https://github.com/RIOT-OS/RIOT/issues/1652
