### PR TITLE
make: migrate OS variable for COLOR_ECHO too

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -31,8 +31,6 @@ endif
         info-buildsizes-diff info-build info-boards-supported \
         info-features-missing info-boards-features-missing
 
-OS := $(shell uname)
-
 buildtest:
 	@ \
 	BUILDTESTOK=true; \

--- a/Makefile.include
+++ b/Makefile.include
@@ -21,6 +21,9 @@ COLOR_RED    :=
 COLOR_PURPLE :=
 COLOR_RESET  :=
 COLOR_ECHO   := /bin/echo
+
+OS := $(shell uname)
+
 ifeq (, ${JENKINS_URL})
   ifeq (0,  $(shell tput colors 2>&1 > /dev/null; echo $$?))
     COLOR_GREEN  := \033[1;32m


### PR DESCRIPTION
Was left behind in #1913 but is needed for color echo on OS X.
