### PR TITLE
driver/timer: adjusted doxygen for speed value

### DIFF
--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -59,13 +59,13 @@ typedef enum {
  * The timer will be started automatically after initialization with interrupts enabled.
  *
  * @param[in] dev           the timer to initialize
- * @param[in] ticks_per_us  the timers speed in ticks per us
+ * @param[in] us_per_tick   number of us passed for one timer tick
  * @param[in] callback      this callback is called in interrupt context, the emitting channel is
  *                          passed as argument
  *
  * @return                  returns 0 on success, -1 if speed not applicable of unknown device given
  */
-int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int));
+int timer_init(tim_t dev, unsigned int us_per_tick, void (*callback)(int));
 
 /**
  * @brief Set a given timer channel for the given timer device. The callback given during


### PR DESCRIPTION
The speed value was described differently then it was used... Now it should be correct.
