### PR TITLE
riot_and_cpp: do not link on build tests for stm32f0discovery

### DIFF
--- a/examples/riot_and_cpp/Makefile
+++ b/examples/riot_and_cpp/Makefile
@@ -4,6 +4,10 @@ APPLICATION = riot_and_cpp
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native
 
+# stm32f0discovery objects are too big with ARM Embedded Toolchain v4.9.3 20141119
+# (used currently by travis)
+BOARD_INSUFFICIENT_RAM=stm32f0discovery
+
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 


### PR DESCRIPTION
Fixes #2203
