### PR TITLE
msba2: Use --gc-sections when linking.

### DIFF
--- a/boards/msba2-common/Makefile.include
+++ b/boards/msba2-common/Makefile.include
@@ -7,7 +7,7 @@ export PREFIX = arm-none-eabi-
 export CC = $(PREFIX)gcc
 export CXX = $(PREFIX)g++
 export AR = $(PREFIX)ar
-export CFLAGS += -O2 -Wall -Wstrict-prototypes -mcpu=arm7tdmi-s -gdwarf-2
+export CFLAGS += -O2 -Wall -Wstrict-prototypes -mcpu=arm7tdmi-s -gdwarf-2 -fdata-sections -ffunction-sections
 export ASFLAGS = -gdwarf-2 -mcpu=arm7tdmi-s
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
@@ -15,7 +15,7 @@ export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
 FLASHER = lpc2k_pgm
 TERMPROG ?= $(RIOTBASE)/dist/tools/pyterm/pyterm
-LINKFLAGS += -gdwarf-2 -mcpu=arm7tdmi-s -static -lgcc -nostartfiles -T$(RIOTBASE)/cpu/$(CPU)/linkerscript.x
+LINKFLAGS += -gdwarf-2 -mcpu=arm7tdmi-s -static -lgcc -nostartfiles -T$(RIOTBASE)/cpu/$(CPU)/linkerscript.x -Wl,--gc-sections
 
 # unwanted (CXXUWFLAGS) and extra (CXXEXFLAGS) flags for c++
 export CXXUWFLAGS +=

--- a/cpu/lpc2387/linkerscript.x
+++ b/cpu/lpc2387/linkerscript.x
@@ -163,7 +163,7 @@ SECTIONS
 	{
 		. = ALIGN(4);					/* ensure data is aligned so relocation can use 4-byte operations */
 		_data = .;						/* create a global symbol marking the start of the .data section  */
-		*(.data)						/* all .data sections  */
+		*(.data .data.*)				/* all .data sections  */
 		*(.gnu.linkonce.d*)
         . = ALIGN(4);
         /* preinit data */

--- a/cpu/lpc2387/linkerscript.x
+++ b/cpu/lpc2387/linkerscript.x
@@ -30,60 +30,59 @@ SECTIONS
 {
 	.text :								/* collect all sections that should go into FLASH after startup  */
 	{
-		*(.vectors)						/* Exception Vectors and branch table >= 64 bytes */
+		KEEP(*(.vectors))				/* Exception Vectors and branch table >= 64 bytes */
 		. = ALIGN(64);
-	    *(.init)
-	    *(.init0)  						/* Start here after reset.  */
-	    *(.init1)
-	    *(.init2) 						/* Copy data loop  */
-	    *(.init3)
-	    *(.init4)  						/* Clear bss  */
-	    *(.init5)
-	    *(.init6)  						/* C++ constructors.  */
-	    *(.init7)
-	    *(.init8)
-	    *(.init9) 						/* Call main().  */
-
+		KEEP(*(.init))
+		KEEP(*(.init0))					/* Start here after reset.  */
+		KEEP(*(.init1))
+		KEEP(*(.init2))					/* Copy data loop  */
+		KEEP(*(.init3))
+		KEEP(*(.init4))					/* Clear bss  */
+		KEEP(*(.init5))
+		KEEP(*(.init6))					/* C++ constructors.  */
+		KEEP(*(.init7))
+		KEEP(*(.init8))
+		KEEP(*(.init9))					/* Call main().  */
 		*(.text)						/* all .text sections (code)  */
 		*(.text.*)
 		*(.gnu.linkonce.t.*)
 
 		. = ALIGN(4);
 		__commands_start = .;
-		*(.commands)					/* command table */
+		KEEP(*(.commands))				/* command table */
 		__commands_end = .;
 		. = ALIGN(4);
 		__cfgspec_start = .;
-		*(.cfgspec)						/* configuration spec table */
+		KEEP(*(.cfgspec))				/* configuration spec table */
 		__cfgspec_end = .;
 		. = ALIGN(4);
 
 		__ctors_start = .;
-        	PROVIDE (_os_ctor_start = .);
-        	*(.ctors);
-        	KEEP (*(.init_array))
-        	PROVIDE (_os_ctor_end = .);
+        	PROVIDE(_os_ctor_start = .);
+        	KEEP(*(.ctors));
+        	KEEP(*(.init_array))
+        	PROVIDE(_os_ctor_end = .);
 		__ctors_end = .;
-	        *(.dtors);
+	        KEEP(*(.dtors));
 	        LONG (0);
 
 
 		*(.rodata .rodata.*)			/* all .rodata sections (constants, strings, etc.)  */
 		*(.gnu.linkonce.r.*)
-		*(.glue_7)						/* all .glue_7 sections  (no idea what these are) */
-		*(.glue_7t)						/* all .glue_7t sections (no idea what these are) */
+		*(.glue_7)						/* all .glue_7 sections, see https://gcc.gnu.org/ml/gcc-help/2009-03/msg00306.html */
+		*(.glue_7t)						/* all .glue_7t sections */
 
-		*(.fini9)
-		*(.fini8)
-		*(.fini7)
-		*(.fini6)						/* C++ destructors.  */
-		*(.fini5)
-		*(.fini4)
-		*(.fini3)
-		*(.fini2)
-		*(.fini1)
-		*(.fini0)						/* Infinite loop after program termination.  */
-		*(.fini)
+		KEEP(*(.fini9))
+		KEEP(*(.fini8))
+		KEEP(*(.fini7))
+		KEEP(*(.fini6))						/* C++ destructors.  */
+		KEEP(*(.fini5))
+		KEEP(*(.fini4))
+		KEEP(*(.fini3))
+		KEEP(*(.fini2))
+		KEEP(*(.fini1))
+		KEEP(*(.fini0))						/* Infinite loop after program termination.  */
+		KEEP(*(.fini))
 
 		*(.gcc_except_table)
 


### PR DESCRIPTION
 - Add `-Wl,--gc-sections` to LDFLAGS
 - Add `-fdata-sections` and `-ffunction-sections` to CFLAGS
 - Update lpc2387 linker script to keep the isr vector and init
   sections when garbage collecting.
 - Keep .ctors and .dtors sections (similar to what binutils default
   linker script does when building for Linux targets)

I do not own any msba2 hardware or lpc2387 CPUs, please test.
Also affects #1927, msba2 does not seem to need `__attributes__((used))` for syscalls anymore when using LTO.