### PR TITLE
rpl: wrong length of DIO options

### DIFF
--- a/sys/net/include/rpl/rpl_config.h
+++ b/sys/net/include/rpl/rpl_config.h
@@ -57,7 +57,8 @@ enum RPL_MSG_CODE {
 #define RPL_OPT_LEN                             2
 #define RPL_OPT_DODAG_CONF_LEN                  14
 #define RPL_OPT_DODAG_CONF_LEN_WITH_OPT_LEN     (RPL_OPT_DODAG_CONF_LEN + RPL_OPT_LEN)
-#define RPL_OPT_PREFIX_INFO_LEN                 32
+#define RPL_OPT_PREFIX_INFO_LEN                 30
+#define RPL_OPT_PREFIX_INFO_LEN_WITH_OPT_LEN    (RPL_OPT_PREFIX_INFO_LEN + RPL_OPT_LEN)
 #define RPL_OPT_SOLICITED_INFO_LEN              21
 #define RPL_OPT_TARGET_LEN                      20
 #define RPL_OPT_TRANSIT_LEN                     22

--- a/sys/net/include/rpl/rpl_config.h
+++ b/sys/net/include/rpl/rpl_config.h
@@ -48,18 +48,19 @@ enum RPL_MSG_CODE {
 };
 
 /* packet base lengths */
-#define DIO_BASE_LEN                24
-#define DIS_BASE_LEN                2
-#define DAO_BASE_LEN                4
-#define DAO_D_LEN                   24
-#define DAO_ACK_LEN                 4
-#define DAO_ACK_D_LEN               24
-#define RPL_OPT_LEN                 2
-#define RPL_OPT_DODAG_CONF_LEN      16
-#define RPL_OPT_PREFIX_INFO_LEN     32
-#define RPL_OPT_SOLICITED_INFO_LEN  21
-#define RPL_OPT_TARGET_LEN          20
-#define RPL_OPT_TRANSIT_LEN         22
+#define DIO_BASE_LEN                            24
+#define DIS_BASE_LEN                            2
+#define DAO_BASE_LEN                            4
+#define DAO_D_LEN                               24
+#define DAO_ACK_LEN                             4
+#define DAO_ACK_D_LEN                           24
+#define RPL_OPT_LEN                             2
+#define RPL_OPT_DODAG_CONF_LEN                  14
+#define RPL_OPT_DODAG_CONF_LEN_WITH_OPT_LEN     (RPL_OPT_DODAG_CONF_LEN + RPL_OPT_LEN)
+#define RPL_OPT_PREFIX_INFO_LEN                 32
+#define RPL_OPT_SOLICITED_INFO_LEN              21
+#define RPL_OPT_TARGET_LEN                      20
+#define RPL_OPT_TRANSIT_LEN                     22
 
 /* message options */
 #define RPL_OPT_PAD1                 0

--- a/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
+++ b/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
@@ -263,7 +263,7 @@ void rpl_send_DIO_mode(ipv6_addr_t *destination)
     /* DODAG configuration option */
     rpl_send_opt_dodag_conf_buf = get_rpl_send_opt_dodag_conf_buf(DIO_BASE_LEN);
     rpl_send_opt_dodag_conf_buf->type = RPL_OPT_DODAG_CONF;
-    rpl_send_opt_dodag_conf_buf->length = (RPL_OPT_DODAG_CONF_LEN - RPL_OPT_LEN);
+    rpl_send_opt_dodag_conf_buf->length = RPL_OPT_DODAG_CONF_LEN;
     rpl_send_opt_dodag_conf_buf->flags_a_pcs = 0;
     rpl_send_opt_dodag_conf_buf->DIOIntDoubl = mydodag->dio_interval_doubling;
     rpl_send_opt_dodag_conf_buf->DIOIntMin = mydodag->dio_min;
@@ -276,7 +276,7 @@ void rpl_send_DIO_mode(ipv6_addr_t *destination)
     rpl_send_opt_dodag_conf_buf->default_lifetime = mydodag->default_lifetime;
     rpl_send_opt_dodag_conf_buf->lifetime_unit = mydodag->lifetime_unit;
 
-    opt_hdr_len += RPL_OPT_DODAG_CONF_LEN;
+    opt_hdr_len += RPL_OPT_DODAG_CONF_LEN_WITH_OPT_LEN;
 
 
     uint16_t plen = ICMPV6_HDR_LEN + DIO_BASE_LEN + opt_hdr_len;
@@ -468,7 +468,7 @@ void rpl_recv_DIO_mode(void)
             case (RPL_OPT_DODAG_CONF): {
                 has_dodag_conf_opt = 1;
 
-                if (rpl_opt_buf->length != (RPL_OPT_DODAG_CONF_LEN - RPL_OPT_LEN)) {
+                if (rpl_opt_buf->length != RPL_OPT_DODAG_CONF_LEN) {
                     DEBUGF("DODAG configuration is malformed.\n");
                     /* error malformed */
                     return;
@@ -483,7 +483,7 @@ void rpl_recv_DIO_mode(void)
                 dio_dodag.default_lifetime = rpl_opt_dodag_conf_buf->default_lifetime;
                 dio_dodag.lifetime_unit = rpl_opt_dodag_conf_buf->lifetime_unit;
                 dio_dodag.of = (struct rpl_of_t *) rpl_get_of_for_ocp(rpl_opt_dodag_conf_buf->ocp);
-                len += RPL_OPT_DODAG_CONF_LEN;
+                len += RPL_OPT_DODAG_CONF_LEN_WITH_OPT_LEN;
                 break;
             }
 

--- a/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
+++ b/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
@@ -488,12 +488,12 @@ void rpl_recv_DIO_mode(void)
             }
 
             case (RPL_OPT_PREFIX_INFO): {
-                if (rpl_opt_buf->length != (RPL_OPT_PREFIX_INFO_LEN - RPL_OPT_LEN)) {
+                if (rpl_opt_buf->length != RPL_OPT_PREFIX_INFO_LEN) {
                     /* error malformed */
                     return;
                 }
 
-                len += RPL_OPT_PREFIX_INFO_LEN;
+                len += RPL_OPT_PREFIX_INFO_LEN_WITH_OPT_LEN;
                 break;
             }
 

--- a/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
+++ b/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
@@ -263,7 +263,7 @@ void rpl_send_DIO_mode(ipv6_addr_t *destination)
     /* DODAG configuration option */
     rpl_send_opt_dodag_conf_buf = get_rpl_send_opt_dodag_conf_buf(DIO_BASE_LEN);
     rpl_send_opt_dodag_conf_buf->type = RPL_OPT_DODAG_CONF;
-    rpl_send_opt_dodag_conf_buf->length = RPL_OPT_DODAG_CONF_LEN;
+    rpl_send_opt_dodag_conf_buf->length = (RPL_OPT_DODAG_CONF_LEN - RPL_OPT_LEN);
     rpl_send_opt_dodag_conf_buf->flags_a_pcs = 0;
     rpl_send_opt_dodag_conf_buf->DIOIntDoubl = mydodag->dio_interval_doubling;
     rpl_send_opt_dodag_conf_buf->DIOIntMin = mydodag->dio_min;
@@ -468,7 +468,7 @@ void rpl_recv_DIO_mode(void)
             case (RPL_OPT_DODAG_CONF): {
                 has_dodag_conf_opt = 1;
 
-                if (rpl_opt_buf->length != RPL_OPT_DODAG_CONF_LEN) {
+                if (rpl_opt_buf->length != (RPL_OPT_DODAG_CONF_LEN - RPL_OPT_LEN)) {
                     DEBUGF("DODAG configuration is malformed.\n");
                     /* error malformed */
                     return;
@@ -488,7 +488,7 @@ void rpl_recv_DIO_mode(void)
             }
 
             case (RPL_OPT_PREFIX_INFO): {
-                if (rpl_opt_buf->length != RPL_OPT_PREFIX_INFO_LEN) {
+                if (rpl_opt_buf->length != (RPL_OPT_PREFIX_INFO_LEN - RPL_OPT_LEN)) {
                     /* error malformed */
                     return;
                 }

--- a/sys/net/routing/rpl/rpl_storing/rpl_storing.c
+++ b/sys/net/routing/rpl/rpl_storing/rpl_storing.c
@@ -262,7 +262,7 @@ void rpl_send_DIO_mode(ipv6_addr_t *destination)
     /* DODAG configuration option */
     rpl_send_opt_dodag_conf_buf = get_rpl_send_opt_dodag_conf_buf(DIO_BASE_LEN);
     rpl_send_opt_dodag_conf_buf->type = RPL_OPT_DODAG_CONF;
-    rpl_send_opt_dodag_conf_buf->length = RPL_OPT_DODAG_CONF_LEN;
+    rpl_send_opt_dodag_conf_buf->length = (RPL_OPT_DODAG_CONF_LEN - RPL_OPT_LEN);
     rpl_send_opt_dodag_conf_buf->flags_a_pcs = 0;
     rpl_send_opt_dodag_conf_buf->DIOIntDoubl = mydodag->dio_interval_doubling;
     rpl_send_opt_dodag_conf_buf->DIOIntMin = mydodag->dio_min;
@@ -499,7 +499,7 @@ void rpl_recv_DIO_mode(void)
             case (RPL_OPT_DODAG_CONF): {
                 has_dodag_conf_opt = 1;
 
-                if (rpl_opt_buf->length != RPL_OPT_DODAG_CONF_LEN) {
+                if (rpl_opt_buf->length != (RPL_OPT_DODAG_CONF_LEN - RPL_OPT_LEN)) {
                     DEBUGF("DODAG configuration is malformed.\n");
                     /* error malformed */
                     return;
@@ -519,7 +519,7 @@ void rpl_recv_DIO_mode(void)
             }
 
             case (RPL_OPT_PREFIX_INFO): {
-                if (rpl_opt_buf->length != RPL_OPT_PREFIX_INFO_LEN) {
+                if (rpl_opt_buf->length != (RPL_OPT_PREFIX_INFO_LEN - RPL_OPT_LEN)) {
                     /* error malformed */
                     return;
                 }

--- a/sys/net/routing/rpl/rpl_storing/rpl_storing.c
+++ b/sys/net/routing/rpl/rpl_storing/rpl_storing.c
@@ -262,7 +262,7 @@ void rpl_send_DIO_mode(ipv6_addr_t *destination)
     /* DODAG configuration option */
     rpl_send_opt_dodag_conf_buf = get_rpl_send_opt_dodag_conf_buf(DIO_BASE_LEN);
     rpl_send_opt_dodag_conf_buf->type = RPL_OPT_DODAG_CONF;
-    rpl_send_opt_dodag_conf_buf->length = (RPL_OPT_DODAG_CONF_LEN - RPL_OPT_LEN);
+    rpl_send_opt_dodag_conf_buf->length = RPL_OPT_DODAG_CONF_LEN;
     rpl_send_opt_dodag_conf_buf->flags_a_pcs = 0;
     rpl_send_opt_dodag_conf_buf->DIOIntDoubl = mydodag->dio_interval_doubling;
     rpl_send_opt_dodag_conf_buf->DIOIntMin = mydodag->dio_min;
@@ -274,7 +274,7 @@ void rpl_send_DIO_mode(ipv6_addr_t *destination)
     rpl_send_opt_dodag_conf_buf->default_lifetime = mydodag->default_lifetime;
     rpl_send_opt_dodag_conf_buf->lifetime_unit = mydodag->lifetime_unit;
 
-    opt_hdr_len += RPL_OPT_DODAG_CONF_LEN;
+    opt_hdr_len += RPL_OPT_DODAG_CONF_LEN_WITH_OPT_LEN;
 
     uint16_t plen = ICMPV6_HDR_LEN + DIO_BASE_LEN + opt_hdr_len;
     rpl_send(destination, (uint8_t *)icmp_send_buf, plen, IPV6_PROTO_NUM_ICMPV6);
@@ -499,7 +499,7 @@ void rpl_recv_DIO_mode(void)
             case (RPL_OPT_DODAG_CONF): {
                 has_dodag_conf_opt = 1;
 
-                if (rpl_opt_buf->length != (RPL_OPT_DODAG_CONF_LEN - RPL_OPT_LEN)) {
+                if (rpl_opt_buf->length != RPL_OPT_DODAG_CONF_LEN) {
                     DEBUGF("DODAG configuration is malformed.\n");
                     /* error malformed */
                     return;
@@ -514,7 +514,7 @@ void rpl_recv_DIO_mode(void)
                 dio_dodag.default_lifetime = rpl_opt_dodag_conf_buf->default_lifetime;
                 dio_dodag.lifetime_unit = rpl_opt_dodag_conf_buf->lifetime_unit;
                 dio_dodag.of = (struct rpl_of_t *) rpl_get_of_for_ocp(rpl_opt_dodag_conf_buf->ocp);
-                len += RPL_OPT_DODAG_CONF_LEN;
+                len += RPL_OPT_DODAG_CONF_LEN_WITH_OPT_LEN;
                 break;
             }
 

--- a/sys/net/routing/rpl/rpl_storing/rpl_storing.c
+++ b/sys/net/routing/rpl/rpl_storing/rpl_storing.c
@@ -519,12 +519,12 @@ void rpl_recv_DIO_mode(void)
             }
 
             case (RPL_OPT_PREFIX_INFO): {
-                if (rpl_opt_buf->length != (RPL_OPT_PREFIX_INFO_LEN - RPL_OPT_LEN)) {
+                if (rpl_opt_buf->length != RPL_OPT_PREFIX_INFO_LEN) {
                     /* error malformed */
                     return;
                 }
 
-                len += RPL_OPT_PREFIX_INFO_LEN;
+                len += RPL_OPT_PREFIX_INFO_LEN_WITH_OPT_LEN;
                 break;
             }
 


### PR DESCRIPTION
Currently, the DIO options `dodag conf` and `prefix info` are off by two
bytes in their `length` field. The RFC states, that the length field
should not include the option `type` field and the `length` field (two bytes).

For Prefix Info Option: Option Length: 30 (RFC 6550, P.61)
For Dodag Conf  Option: Option Length: 14 (RFC 6550, P.52)

Wireshark complains about DIOs as malformed packets, otherwise.
Can be reproduced by running the rpl_udp example and logging the DIOs
via wireshark.