### PR TITLE
rpl: wrong length for DAO options

### DIFF
--- a/sys/net/include/rpl/rpl_config.h
+++ b/sys/net/include/rpl/rpl_config.h
@@ -60,8 +60,10 @@ enum RPL_MSG_CODE {
 #define RPL_OPT_PREFIX_INFO_LEN                 30
 #define RPL_OPT_PREFIX_INFO_LEN_WITH_OPT_LEN    (RPL_OPT_PREFIX_INFO_LEN + RPL_OPT_LEN)
 #define RPL_OPT_SOLICITED_INFO_LEN              21
-#define RPL_OPT_TARGET_LEN                      20
-#define RPL_OPT_TRANSIT_LEN                     22
+#define RPL_OPT_TARGET_LEN                      18
+#define RPL_OPT_TARGET_LEN_WITH_OPT_LEN         (RPL_OPT_TARGET_LEN + RPL_OPT_LEN)
+#define RPL_OPT_TRANSIT_LEN                     20
+#define RPL_OPT_TRANSIT_LEN_WITH_OPT_LEN        (RPL_OPT_TRANSIT_LEN + RPL_OPT_LEN)
 
 /* message options */
 #define RPL_OPT_PAD1                 0

--- a/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
+++ b/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
@@ -331,7 +331,7 @@ void rpl_send_DAO_mode(ipv6_addr_t *destination, uint8_t lifetime, bool default_
     memcpy(&rpl_send_opt_target_buf->target, &my_address, sizeof(ipv6_addr_t));
 
     /* 18+2=20 bytes for one target-option */
-    opt_len += RPL_OPT_TARGET_LEN;
+    opt_len += RPL_OPT_TARGET_LEN_WITH_OPT_LEN;
 
     /* add parent */
     rpl_send_opt_transit_buf = get_rpl_send_opt_transit_buf(DAO_BASE_LEN + opt_len);
@@ -349,7 +349,7 @@ void rpl_send_DAO_mode(ipv6_addr_t *destination, uint8_t lifetime, bool default_
            ipv6_addr_to_str(addr_str_mode, IPV6_MAX_ADDR_STR_LEN, destination));
 
     /* 4+2=6 byte for one transit-option */
-    opt_len += RPL_OPT_TRANSIT_LEN;
+    opt_len += RPL_OPT_TRANSIT_LEN_WITH_OPT_LEN;
 
     uint16_t plen = ICMPV6_HDR_LEN + DAO_BASE_LEN + opt_len;
     rpl_send(destination, (uint8_t *)icmp_send_buf, plen, IPV6_PROTO_NUM_ICMPV6);
@@ -644,12 +644,12 @@ void rpl_recv_DAO_mode(void)
             }
 
             case (RPL_OPT_PADN): {
-                len += rpl_opt_buf->length;
+                len += (rpl_opt_buf->length + RPL_OPT_LEN);
                 break;
             }
 
             case (RPL_OPT_DAG_METRIC_CONTAINER): {
-                len += rpl_opt_buf->length;
+                len += (rpl_opt_buf->length + RPL_OPT_LEN);
                 break;
             }
 
@@ -661,7 +661,7 @@ void rpl_recv_DAO_mode(void)
                     break;
                 }
 
-                len += rpl_opt_target_buf->length;
+                len += (rpl_opt_target_buf->length + RPL_OPT_LEN);
                 rpl_opt_transit_buf = get_rpl_opt_transit_buf(len);
 
                 if (rpl_opt_transit_buf->type != RPL_OPT_TRANSIT) {
@@ -670,7 +670,7 @@ void rpl_recv_DAO_mode(void)
                     break;
                 }
 
-                len += rpl_opt_transit_buf->length;
+                len += (rpl_opt_transit_buf->length + RPL_OPT_LEN);
                 /* route lifetime seconds = (DAO lifetime) * (Unit Lifetime) */
                 DEBUGF("Target: %s\n", ipv6_addr_to_str(addr_str_mode, IPV6_MAX_ADDR_STR_LEN,
                         &rpl_opt_target_buf->target));
@@ -685,12 +685,12 @@ void rpl_recv_DAO_mode(void)
             }
 
             case (RPL_OPT_TRANSIT): {
-                len += rpl_opt_buf->length;
+                len += (rpl_opt_buf->length + RPL_OPT_LEN);
                 break;
             }
 
             case (RPL_OPT_TARGET_DESC): {
-                len += rpl_opt_buf->length;
+                len += (rpl_opt_buf->length + RPL_OPT_LEN);
                 break;
             }
 

--- a/sys/net/routing/rpl/rpl_storing/rpl_storing.c
+++ b/sys/net/routing/rpl/rpl_storing/rpl_storing.c
@@ -330,15 +330,15 @@ void rpl_send_DAO_mode(ipv6_addr_t *destination, uint8_t lifetime, bool default_
             rpl_send_opt_target_buf->prefix_length = RPL_DODAG_ID_LEN;
             memcpy(&rpl_send_opt_target_buf->target, &rpl_get_routing_table()[i].address,
                     sizeof(ipv6_addr_t));
-            opt_len += RPL_OPT_TARGET_LEN;
+            opt_len += RPL_OPT_TARGET_LEN_WITH_OPT_LEN;
             rpl_send_opt_transit_buf = get_rpl_send_opt_transit_buf(DAO_BASE_LEN + opt_len);
             rpl_send_opt_transit_buf->type = RPL_OPT_TRANSIT;
-            rpl_send_opt_transit_buf->length = RPL_OPT_TRANSIT_LEN;
+            rpl_send_opt_transit_buf->length = (RPL_OPT_TRANSIT_LEN - sizeof(ipv6_addr_t));
             rpl_send_opt_transit_buf->e_flags = 0x00;
             rpl_send_opt_transit_buf->path_control = 0x00; /* not used */
             rpl_send_opt_transit_buf->path_sequence = 0x00; /* not used */
             rpl_send_opt_transit_buf->path_lifetime = lifetime;
-            opt_len += RPL_OPT_TRANSIT_LEN;
+            opt_len += (RPL_OPT_TRANSIT_LEN_WITH_OPT_LEN - sizeof(ipv6_addr_t));
             rpl_send_opt_target_buf = get_rpl_send_opt_target_buf(DAO_BASE_LEN + opt_len);
             entries++;
         }
@@ -357,16 +357,16 @@ void rpl_send_DAO_mode(ipv6_addr_t *destination, uint8_t lifetime, bool default_
     rpl_send_opt_target_buf->flags = 0x00;
     rpl_send_opt_target_buf->prefix_length = RPL_DODAG_ID_LEN;
     memcpy(&rpl_send_opt_target_buf->target, &my_address, sizeof(ipv6_addr_t));
-    opt_len += RPL_OPT_TARGET_LEN;
+    opt_len += RPL_OPT_TARGET_LEN_WITH_OPT_LEN;
 
     rpl_send_opt_transit_buf = get_rpl_send_opt_transit_buf(DAO_BASE_LEN + opt_len);
     rpl_send_opt_transit_buf->type = RPL_OPT_TRANSIT;
-    rpl_send_opt_transit_buf->length = RPL_OPT_TRANSIT_LEN;
+    rpl_send_opt_transit_buf->length = (RPL_OPT_TRANSIT_LEN - sizeof(ipv6_addr_t));
     rpl_send_opt_transit_buf->e_flags = 0x00;
     rpl_send_opt_transit_buf->path_control = 0x00;
     rpl_send_opt_transit_buf->path_sequence = 0x00;
     rpl_send_opt_transit_buf->path_lifetime = lifetime;
-    opt_len += RPL_OPT_TRANSIT_LEN;
+    opt_len += (RPL_OPT_TRANSIT_LEN_WITH_OPT_LEN - sizeof(ipv6_addr_t));
 
     uint16_t plen = ICMPV6_HDR_LEN + DAO_BASE_LEN + opt_len;
     rpl_send(destination, (uint8_t *)icmp_send_buf, plen, IPV6_PROTO_NUM_ICMPV6);
@@ -664,12 +664,12 @@ void rpl_recv_DAO_mode(void)
             }
 
             case (RPL_OPT_PADN): {
-                len += rpl_opt_buf->length;
+                len += (rpl_opt_buf->length + RPL_OPT_LEN);
                 break;
             }
 
             case (RPL_OPT_DAG_METRIC_CONTAINER): {
-                len += rpl_opt_buf->length;
+                len += (rpl_opt_buf->length + RPL_OPT_LEN);
                 break;
             }
 
@@ -681,7 +681,7 @@ void rpl_recv_DAO_mode(void)
                     break;
                 }
 
-                len += rpl_opt_target_buf->length;
+                len += (rpl_opt_target_buf->length + RPL_OPT_LEN);
                 rpl_opt_transit_buf = get_rpl_opt_transit_buf(len);
 
                 if (rpl_opt_transit_buf->type != RPL_OPT_TRANSIT) {
@@ -690,7 +690,7 @@ void rpl_recv_DAO_mode(void)
                     break;
                 }
 
-                len += rpl_opt_transit_buf->length;
+                len += (rpl_opt_transit_buf->length + RPL_OPT_LEN);
                 /* route lifetime seconds = (DAO lifetime) * (Unit Lifetime) */
 
 #if RPL_MAX_ROUTING_ENTRIES != 0
@@ -706,12 +706,12 @@ void rpl_recv_DAO_mode(void)
             }
 
             case (RPL_OPT_TRANSIT): {
-                len += rpl_opt_buf->length;
+                len += (rpl_opt_buf->length + RPL_OPT_LEN);
                 break;
             }
 
             case (RPL_OPT_TARGET_DESC): {
-                len += rpl_opt_buf->length;
+                len += (rpl_opt_buf->length + RPL_OPT_LEN);
                 break;
             }
 


### PR DESCRIPTION
similar to #2216
According to RFC 6550, option `length` fields should not contain the two
bytes derived from the `length` field itself and the option `type` field.

Furthermore, the current implementation adds the parent's address (16
bytes) to transit options `length`, although this field is not used in
storing mode.
I subtracted the parennt's address length from the transit options
length for the storing mode.

Here again, can be reproduced by running the rpl_udp example and logging
DAOs via wireshark.