### PR TITLE
 core: fix const-ness for msg operations

### DIFF
--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -77,7 +77,7 @@ typedef struct msg {
  *            (it is not waiting or it's message queue is full)
  * @return -1, on error (invalid PID)
  */
-int msg_send(msg_t *m, kernel_pid_t target_pid);
+int msg_send(const msg_t *m, kernel_pid_t target_pid);
 
 
 /**
@@ -96,7 +96,7 @@ int msg_send(msg_t *m, kernel_pid_t target_pid);
  * @return 0, if receiver is not waiting or has a full message queue
  * @return -1, on error (invalid PID)
  */
-int msg_try_send(msg_t *m, kernel_pid_t target_pid);
+int msg_try_send(const msg_t *m, kernel_pid_t target_pid);
 
 
 /**
@@ -112,7 +112,7 @@ int msg_try_send(msg_t *m, kernel_pid_t target_pid);
  * @return 1 if sending was successful
  * @return 0 if the thread's message queue is full (or inexistent)
  */
-int msg_send_to_self(msg_t *m);
+int msg_send_to_self(const msg_t *m);
 
 /**
  * Value of msg_t::sender_pid if the sender was an interrupt service routine.
@@ -137,7 +137,7 @@ int msg_send_to_self(msg_t *m);
  * @return 0, if receiver is not waiting and ``block == 0``
  * @return -1, on error (invalid PID)
  */
-int msg_send_int(msg_t *m, kernel_pid_t target_pid);
+int msg_send_int(const msg_t *m, kernel_pid_t target_pid);
 
 /**
  * @brief Test if the message was sent inside an ISR.
@@ -192,7 +192,7 @@ int msg_try_receive(msg_t *m);
  *
  * @return  1, if successful.
  */
-int msg_send_receive(msg_t *m, msg_t *reply, kernel_pid_t target_pid);
+int msg_send_receive(const msg_t *m, msg_t *reply, kernel_pid_t target_pid);
 
 /**
  * @brief Replies to a message.
@@ -200,13 +200,12 @@ int msg_send_receive(msg_t *m, msg_t *reply, kernel_pid_t target_pid);
  * Sender must have sent the message with msg_send_receive().
  *
  * @param[in] m         message to reply to, must not be NULL.
- * @param[out] reply    message that target will get as reply, must not be
- *                      NULL.
+ * @param[in] reply     message that target will get as reply, must not be NULL.
  *
  * @return 1, if successful
  * @return 0, on error
  */
-int msg_reply(msg_t *m, msg_t *reply);
+int msg_reply(const msg_t *m, const msg_t *reply);
 
 /**
  * @brief Initialize the current thread's message queue.

--- a/core/include/tcb.h
+++ b/core/include/tcb.h
@@ -68,7 +68,7 @@ typedef struct tcb_t {
 
     clist_node_t rq_entry;      /**< run queue entry                */
 
-    void *wait_data;            /**< holding messages               */
+    msg_t *wait_data;           /**< holding messages               */
     priority_queue_t msg_waiters;   /**< threads waiting on message     */
 
     cib_t msg_queue;            /**< message queue                  */

--- a/core/msg.c
+++ b/core/msg.c
@@ -238,22 +238,6 @@ int msg_reply(msg_t *m, msg_t *reply)
     return 1;
 }
 
-int msg_reply_int(msg_t *m, msg_t *reply)
-{
-    tcb_t *target = (tcb_t*) sched_threads[m->sender_pid];
-
-    if (target->status != STATUS_REPLY_BLOCKED) {
-        DEBUG("msg_reply_int(): %s: Target \"%s\" not waiting for reply.", sched_active_thread->name, target->name);
-        return -1;
-    }
-
-    msg_t *target_message = (msg_t*) target->wait_data;
-    *target_message = *reply;
-    sched_set_status(target, STATUS_PENDING);
-    sched_context_switch_request = 1;
-    return 1;
-}
-
 int msg_try_receive(msg_t *m)
 {
     return _msg_receive(m, 0);

--- a/core/msg.c
+++ b/core/msg.c
@@ -16,6 +16,7 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
+ * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  *
  * @}
  */
@@ -37,9 +38,16 @@
 #include "thread.h"
 
 static int _msg_receive(msg_t *m, int block);
-static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block, unsigned state);
+static int _msg_send(const msg_t *m, kernel_pid_t target_pid, bool block, unsigned state);
 
-static int queue_msg(tcb_t *target, const msg_t *m)
+static inline void _msg_copy_into(msg_t *dest, kernel_pid_t sender_pid, const msg_t *src)
+{
+    dest->sender_pid = sender_pid;
+    dest->type = src->type;
+    dest->content = src->content;
+}
+
+static int queue_msg(tcb_t *target, kernel_pid_t sender_pid, const msg_t *m)
 {
     int n = cib_put(&(target->msg_queue));
     if (n < 0) {
@@ -48,12 +56,11 @@ static int queue_msg(tcb_t *target, const msg_t *m)
     }
 
     DEBUG("queue_msg(): queuing message\n");
-    msg_t *dest = &target->msg_array[n];
-    *dest = *m;
+    _msg_copy_into(&target->msg_array[n], sender_pid, m);
     return 1;
 }
 
-int msg_send(msg_t *m, kernel_pid_t target_pid)
+int msg_send(const msg_t *m, kernel_pid_t target_pid)
 {
     if (inISR()) {
         return msg_send_int(m, target_pid);
@@ -64,7 +71,7 @@ int msg_send(msg_t *m, kernel_pid_t target_pid)
     return _msg_send(m, target_pid, true, disableIRQ());
 }
 
-int msg_try_send(msg_t *m, kernel_pid_t target_pid)
+int msg_try_send(const msg_t *m, kernel_pid_t target_pid)
 {
     if (inISR()) {
         return msg_send_int(m, target_pid);
@@ -75,7 +82,7 @@ int msg_try_send(msg_t *m, kernel_pid_t target_pid)
     return _msg_send(m, target_pid, false, disableIRQ());
 }
 
-static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block, unsigned state)
+static int _msg_send(const msg_t *m, kernel_pid_t target_pid, bool block, unsigned state)
 {
 #if DEVELHELP
     if (!pid_is_valid(target_pid)) {
@@ -84,8 +91,7 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block, unsigned sta
 #endif /* DEVELHELP */
 
     tcb_t *target = (tcb_t*) sched_threads[target_pid];
-
-    m->sender_pid = sched_active_pid;
+    tcb_t *me = (tcb_t*) sched_active_thread;
 
     if (target == NULL) {
         DEBUG("msg_send(): target thread does not exist\n");
@@ -93,57 +99,60 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block, unsigned sta
         return -1;
     }
 
-    DEBUG("msg_send() %s:%i: Sending from %" PRIkernel_pid " to %" PRIkernel_pid ". block=%i src->state=%i target->state=%i\n", __FILE__, __LINE__, sched_active_pid, target_pid, block, sched_active_thread->status, target->status);
+    DEBUG("msg_send() %s:%i: Sending from %" PRIkernel_pid " to %" PRIkernel_pid ". "
+          "block=%i src->state=%i target->state=%i\n", __FILE__, __LINE__,
+          sched_active_pid, target_pid, block, me->status, target->status);
 
     if (target->status != STATUS_RECEIVE_BLOCKED) {
-        DEBUG("msg_send() %s:%i: Target %" PRIkernel_pid " is not RECEIVE_BLOCKED.\n", __FILE__, __LINE__, target_pid);
-        if (queue_msg(target, m)) {
-            DEBUG("msg_send() %s:%i: Target %" PRIkernel_pid " has a msg_queue. Queueing message.\n", __FILE__, __LINE__, target_pid);
+        DEBUG("msg_send() %s:%i: Target %" PRIkernel_pid " is not RECEIVE_BLOCKED.\n",
+              __FILE__, __LINE__, target_pid);
+        if (queue_msg(target, sched_active_pid, m)) {
+            DEBUG("msg_send() %s:%i: Target %" PRIkernel_pid " has a msg_queue. "
+                  "Queueing message.\n", __FILE__, __LINE__, target_pid);
             restoreIRQ(state);
-            if (sched_active_thread->status == STATUS_REPLY_BLOCKED) {
+            if (me->status == STATUS_REPLY_BLOCKED) {
                 thread_yield_higher();
             }
             return 1;
         }
 
         if (!block) {
-            DEBUG("msg_send: %s: Receiver not waiting, block=%u\n", sched_active_thread->name, block);
+            DEBUG("msg_send: %s: Receiver not waiting, block=%u\n", me->name, block);
             restoreIRQ(state);
             return 0;
         }
 
-        DEBUG("msg_send: %s: send_blocked.\n", sched_active_thread->name);
+        DEBUG("msg_send: %s: send_blocked.\n", me->name);
         priority_queue_node_t n;
-        n.priority = sched_active_thread->priority;
-        n.data = (unsigned int) sched_active_thread;
+        n.priority = me->priority;
+        n.data = (unsigned int) me;
         n.next = NULL;
-        DEBUG("msg_send: %s: Adding node to msg_waiters:\n", sched_active_thread->name);
+        DEBUG("msg_send: %s: Adding node to msg_waiters:\n", me->name);
 
         priority_queue_add(&(target->msg_waiters), &n);
 
-        sched_active_thread->wait_data = m;
+        me->wait_data = (msg_t *) m; /* discard const-ness */
 
         int newstatus;
-
-        if (sched_active_thread->status == STATUS_REPLY_BLOCKED) {
+        if (me->status == STATUS_REPLY_BLOCKED) {
             newstatus = STATUS_REPLY_BLOCKED;
         }
         else {
             newstatus = STATUS_SEND_BLOCKED;
         }
 
-        sched_set_status((tcb_t*) sched_active_thread, newstatus);
+        sched_set_status(me, newstatus);
 
-        DEBUG("msg_send: %s: Back from send block.\n", sched_active_thread->name);
+        DEBUG("msg_send: %s: Back from send block.\n", me->name);
 
         restoreIRQ(state);
         thread_yield_higher();
     }
     else {
-        DEBUG("msg_send: %s: Direct msg copy from %" PRIkernel_pid " to %" PRIkernel_pid ".\n", sched_active_thread->name, thread_getpid(), target_pid);
+        DEBUG("msg_send: %s: Direct msg copy from %" PRIkernel_pid " to %" PRIkernel_pid ".\n",
+              me->name, thread_getpid(), target_pid);
         /* copy msg to target */
-        msg_t *target_message = target->wait_data;
-        *target_message = *m;
+        _msg_copy_into(target->wait_data, sched_active_pid, m);
         sched_set_status(target, STATUS_PENDING);
 
         restoreIRQ(state);
@@ -153,18 +162,17 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block, unsigned sta
     return 1;
 }
 
-int msg_send_to_self(msg_t *m)
+int msg_send_to_self(const msg_t *m)
 {
     unsigned state = disableIRQ();
 
-    m->sender_pid = sched_active_pid;
-    int res = queue_msg((tcb_t *) sched_active_thread, m);
+    int res = queue_msg((tcb_t *) sched_active_thread, sched_active_pid, m);
 
     restoreIRQ(state);
     return res;
 }
 
-int msg_send_int(msg_t *m, kernel_pid_t target_pid)
+int msg_send_int(const msg_t *m, kernel_pid_t target_pid)
 {
 #if DEVELHELP
     if (!pid_is_valid(target_pid)) {
@@ -179,14 +187,12 @@ int msg_send_int(msg_t *m, kernel_pid_t target_pid)
         return -1;
     }
 
-    m->sender_pid = KERNEL_PID_ISR;
     if (target->status == STATUS_RECEIVE_BLOCKED) {
-        DEBUG("msg_send_int: Direct msg copy from %" PRIkernel_pid " to %" PRIkernel_pid ".\n", thread_getpid(), target_pid);
-
+        DEBUG("msg_send_int: Direct msg copy from %" PRIkernel_pid " to %" PRIkernel_pid ".\n",
+              thread_getpid(), target_pid);
 
         /* copy msg to target */
-        msg_t *target_message = target->wait_data;
-        *target_message = *m;
+        _msg_copy_into(target->wait_data, KERNEL_PID_ISR, m);
         sched_set_status(target, STATUS_PENDING);
 
         sched_context_switch_request = 1;
@@ -194,29 +200,35 @@ int msg_send_int(msg_t *m, kernel_pid_t target_pid)
     }
     else {
         DEBUG("msg_send_int: Receiver not waiting.\n");
-        return (queue_msg(target, m));
+        return (queue_msg(target, KERNEL_PID_ISR, m));
     }
 }
 
-int msg_send_receive(msg_t *m, msg_t *reply, kernel_pid_t target_pid)
+int msg_send_receive(const msg_t *m, msg_t *reply, kernel_pid_t target_pid)
 {
     unsigned state = disableIRQ();
-    tcb_t *me = (tcb_t*) sched_threads[sched_active_pid];
-    sched_set_status(me, STATUS_REPLY_BLOCKED);
-    me->wait_data = reply;
 
+    tcb_t *me = (tcb_t*) sched_active_thread;
+    sched_set_status(me, STATUS_REPLY_BLOCKED);
+
+    msg_t in_out = *m;
+    me->wait_data = &in_out;
     /* msg_send blocks until reply received */
-    return _msg_send(m, target_pid, true, state);
+    int result = _msg_send(&in_out, target_pid, true, state);
+    *reply = in_out;
+
+    return result;
 }
 
-int msg_reply(msg_t *m, msg_t *reply)
+int msg_reply(const msg_t *m, const msg_t *reply)
 {
     unsigned state = disableIRQ();
 
     tcb_t *target = (tcb_t*) sched_threads[m->sender_pid];
 
     if (!target) {
-        DEBUG("msg_reply(): %s: Target \"%" PRIkernel_pid "\" not existing...dropping msg!\n", sched_active_thread->name, m->sender_pid);
+        DEBUG("msg_reply(): %s: Target \"%" PRIkernel_pid "\" not existing...dropping msg!\n",
+              sched_active_thread->name, m->sender_pid);
         return -1;
     }
 
@@ -228,8 +240,8 @@ int msg_reply(msg_t *m, msg_t *reply)
 
     DEBUG("msg_reply(): %s: Direct msg copy.\n", sched_active_thread->name);
     /* copy msg to target */
-    msg_t *target_message = target->wait_data;
-    *target_message = *reply;
+    _msg_copy_into(target->wait_data, sched_active_pid, reply);
+
     sched_set_status(target, STATUS_PENDING);
     uint16_t target_prio = target->priority;
     restoreIRQ(state);
@@ -253,13 +265,9 @@ static int _msg_receive(msg_t *m, int block)
     unsigned state = disableIRQ();
     DEBUG("_msg_receive: %s: _msg_receive.\n", sched_active_thread->name);
 
-    tcb_t *me = (tcb_t*) sched_threads[sched_active_pid];
+    tcb_t *me = (tcb_t*) sched_active_thread;
 
-    int queue_index = -1;
-
-    if (me->msg_array) {
-        queue_index = cib_get(&(me->msg_queue));
-    }
+    int queue_index = cib_get(&(me->msg_queue));
 
     /* no message, fail */
     if ((!block) && (queue_index == -1)) {
@@ -307,8 +315,7 @@ static int _msg_receive(msg_t *m, int block)
         }
 
         /* copy msg */
-        msg_t *sender_msg = sender->wait_data;
-        *m = *sender_msg;
+        _msg_copy_into(m, sender->pid, sender->wait_data);
 
         /* remove sender from queue */
         uint16_t sender_prio = PRIORITY_IDLE;

--- a/core/msg.c
+++ b/core/msg.c
@@ -121,7 +121,7 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block, unsigned sta
 
         priority_queue_add(&(target->msg_waiters), &n);
 
-        sched_active_thread->wait_data = (void*) m;
+        sched_active_thread->wait_data = m;
 
         int newstatus;
 
@@ -142,7 +142,7 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block, unsigned sta
     else {
         DEBUG("msg_send: %s: Direct msg copy from %" PRIkernel_pid " to %" PRIkernel_pid ".\n", sched_active_thread->name, thread_getpid(), target_pid);
         /* copy msg to target */
-        msg_t *target_message = (msg_t*) target->wait_data;
+        msg_t *target_message = target->wait_data;
         *target_message = *m;
         sched_set_status(target, STATUS_PENDING);
 
@@ -185,7 +185,7 @@ int msg_send_int(msg_t *m, kernel_pid_t target_pid)
 
 
         /* copy msg to target */
-        msg_t *target_message = (msg_t*) target->wait_data;
+        msg_t *target_message = target->wait_data;
         *target_message = *m;
         sched_set_status(target, STATUS_PENDING);
 
@@ -203,7 +203,7 @@ int msg_send_receive(msg_t *m, msg_t *reply, kernel_pid_t target_pid)
     unsigned state = disableIRQ();
     tcb_t *me = (tcb_t*) sched_threads[sched_active_pid];
     sched_set_status(me, STATUS_REPLY_BLOCKED);
-    me->wait_data = (void*) reply;
+    me->wait_data = reply;
 
     /* msg_send blocks until reply received */
     return _msg_send(m, target_pid, true, state);
@@ -228,7 +228,7 @@ int msg_reply(msg_t *m, msg_t *reply)
 
     DEBUG("msg_reply(): %s: Direct msg copy.\n", sched_active_thread->name);
     /* copy msg to target */
-    msg_t *target_message = (msg_t*) target->wait_data;
+    msg_t *target_message = target->wait_data;
     *target_message = *reply;
     sched_set_status(target, STATUS_PENDING);
     uint16_t target_prio = target->priority;
@@ -272,7 +272,7 @@ static int _msg_receive(msg_t *m, int block)
         *m = me->msg_array[queue_index];
     }
     else {
-        me->wait_data = (void *) m;
+        me->wait_data = m;
     }
 
     priority_queue_node_t *node = priority_queue_remove_head(&(me->msg_waiters));
@@ -307,7 +307,7 @@ static int _msg_receive(msg_t *m, int block)
         }
 
         /* copy msg */
-        msg_t *sender_msg = (msg_t*) sender->wait_data;
+        msg_t *sender_msg = sender->wait_data;
         *m = *sender_msg;
 
         /* remove sender from queue */


### PR DESCRIPTION
Either an msg parameter is meant for input of output.

A parameter for input (i.e. the message that you want to send) should
not be changed, or at least it should be changed in a deterministic way.

This PR makes `[in]` parameters `const`.