### PR TITLE
 core: msg_send_receive() corrupts the input 

### DIFF
--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -162,8 +162,6 @@ int msg_try_receive(msg_t *m);
  * This function sends a message to *target_pid* and then blocks until target
  * has sent a reply which is then stored in *reply*.
  *
- * @note    CAUTION! Use this function only when receiver is already waiting.
- *          If not use simple msg_send()
  * @param[in] m             Pointer to preallocated ``msg_t`` structure with
  *                          the message to send, must not be NULL.
  * @param[out] reply        Pointer to preallocated msg. Reply will be written

--- a/core/msg.c
+++ b/core/msg.c
@@ -203,10 +203,17 @@ int msg_send_receive(msg_t *m, msg_t *reply, kernel_pid_t target_pid)
     unsigned state = disableIRQ();
     tcb_t *me = (tcb_t*) sched_threads[sched_active_pid];
     sched_set_status(me, STATUS_REPLY_BLOCKED);
-    me->wait_data = (void*) reply;
+
+    /* _msg_send() corrupts the data pointed to by me->wait_data if the reeciver
+     * is not write blocked, and has no space in the message queue.*/
+    msg_t in_out = *m;
+    me->wait_data = &in_out;
 
     /* msg_send blocks until reply received */
-    return _msg_send(m, target_pid, true, state);
+    int result = _msg_send(&in_out, target_pid, true, state);
+
+    *reply = in_out;
+    return result;
 }
 
 int msg_reply(msg_t *m, msg_t *reply)

--- a/core/msg.c
+++ b/core/msg.c
@@ -146,8 +146,9 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block, unsigned sta
         *target_message = *m;
         sched_set_status(target, STATUS_PENDING);
 
+        uint16_t target_prio = target->priority;
         restoreIRQ(state);
-        thread_yield_higher();
+        sched_switch(target_prio);
     }
 
     return 1;


### PR DESCRIPTION
`tcb_t::wait_data` is used both to send data and receive data.

This leads to the corruption of the paramter `m` in `msg_send_receive()`
if the target thread is not receive blocked and has no (or a full)
message queue.

This PR fixes the problem by writing the input message into a variable
on the stack first.