### PR TITLE
vtimer: enable vtimer_gettimeofday as fallback

### DIFF
--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -41,6 +41,8 @@
 #define SECONDS_PER_TICK (4096U)
 #define MICROSECONDS_PER_TICK (4096UL * 1000000)
 
+void _gettimeofday(void)           __attribute__ ((weak, alias("vtimer_gettimeofday")));
+
 static void vtimer_callback(void *ptr);
 static void vtimer_callback_tick(vtimer_t *timer);
 static void vtimer_callback_msg(vtimer_t *timer);


### PR DESCRIPTION
This is a quick workaround for modules, like _libcoap_ requiring the (obsolescent) `_gettimeofday()` system call. By declaring `vtimer_gettimeofday()` as a "weak" alias for the _gettimeofday syscall, periph RTC implementations may implement it in a more energy efficient manner. I'm not gonna include any peripheral implementation in this PR, because the whole timer system may change soon anyway.
