### PR TITLE
drivers/cc110x: Allow packet sizes up to 255 bytes

### DIFF
--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -50,7 +50,7 @@ extern "C" {
 #define CC110X_GDO1         GPIO_2
 #define CC110X_GDO2         GPIO_12
 
-typedef uint8_t radio_packet_length_t;
+typedef uint16_t radio_packet_length_t;
 /** @} */
 
 /**

--- a/drivers/cc110x/cc110x-defaultsettings.c
+++ b/drivers/cc110x/cc110x-defaultsettings.c
@@ -92,11 +92,11 @@ uint8_t pa_table[] = {
 char cc110x_conf[] = {
     0x06, /* IOCFG2 */
     0x2E, /* IOCFG1 */
-    0x0E, /* IOCFG0 */
-    0x0F, /* FIFOTHR */
+    0x00, /* IOCFG0 */
+    0x00, /* FIFOTHR */
     0x9B, /* SYNC1 */
     0xAD, /* SYNC0 */
-    0x3D, /* PKTLEN (maximum value of packet length byte = 61) */
+    0xFF, /* PKTLEN (maximum value of packet length byte = 255) */
     0x06, /* PKTCTRL1 */
     0x45, /* PKTCTRL0 (variable packet length) */
     0xFF, /* ADDR */

--- a/drivers/cc110x/cc110x-internal.h
+++ b/drivers/cc110x/cc110x-internal.h
@@ -64,8 +64,8 @@ extern "C" {
 #define GDO0                (0x01)      ///< Bitmask (=00000001) for reading GDO0 (current value on GDO0 pin) in PKTSTATUS status register.
 #define TXFIFO_UNDERFLOW    (0x80)      ///< Bitmask (=10000000) for reading TXFIFO_UNDERFLOW in TXBYTES status register.
 #define BYTES_IN_TXFIFO     (0x7F)      ///< Bitmask (=01111111) for reading NUM_TXBYTES in TXBYTES status register.
-#define RXFIFO_OVERFLOW     (0xBF)      ///< Bitmask (=10000000) for reading RXFIFO_OVERFLOW in RXBYTES status register.
-#define BYTES_IN_RXFIFO     (0xFF)      ///< Bitmask (=01111111) for reading NUM_RXBYTES in RXBYTES status register.
+#define RXFIFO_OVERFLOW     (0x80)      ///< Bitmask (=10000000) for reading RXFIFO_OVERFLOW in RXBYTES status register.
+#define BYTES_IN_RXFIFO     (0x7F)      ///< Bitmask (=01111111) for reading NUM_RXBYTES in RXBYTES status register.
 /** @} */
 
 /**

--- a/drivers/cc110x/cc110x-netdev.c
+++ b/drivers/cc110x/cc110x-netdev.c
@@ -42,7 +42,7 @@ int _cc110x_send_data(netdev_t *dev, void *dest, size_t dest_len,
     if (dest_len > sizeof(uint8_t)) {
         return -EAFNOSUPPORT;
     }
-    if ((sizeof(tx_buffer) + CC1100_HEADER_LENGTH + 1) > PACKET_LENGTH) {
+    if ((sizeof(tx_buffer) + CC1100_HEADER_LENGTH) > PACKET_LENGTH) {
         return -EMSGSIZE;
     }
 

--- a/drivers/cc110x/cc110x-rxtx.c
+++ b/drivers/cc110x/cc110x-rxtx.c
@@ -18,20 +18,20 @@
  * @}
  */
 #include <stdio.h>
+#include <string.h>
+
+#include "periph/gpio.h"
+#include "irq.h"
+#include "msg.h"
+#include "kernel_types.h"
+#include "transceiver.h"
+#include "cpu-conf.h"
 
 #include "cc110x.h"
 #include "cc110x-internal.h"
 
-#include "periph/gpio.h"
-#include "irq.h"
-
-#include "kernel_types.h"
-#include "hwtimer.h"
-#include "msg.h"
-#include "transceiver.h"
-
-#include "cpu-conf.h"
-#include "cpu.h"
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
 
 #ifdef MODULE_NETDEV_BASE
 #include "netdev/base.h"
@@ -39,209 +39,255 @@
 netdev_rcv_data_cb_t cc110x_recv_cb = NULL;
 #endif
 
-/* Internal function prototypes */
-static uint8_t receive_packet_variable(uint8_t *rxBuffer, radio_packet_length_t length);
-static uint8_t receive_packet(uint8_t *rxBuffer, radio_packet_length_t length);
+/* Internal variables*/
+static cc110x_packet_t curr_packet;
+static uint16_t bytes_read = 0;
+static uint8_t bytes_rem = 0;
 
 /* Global variables */
 rx_buffer_t cc110x_rx_buffer[RX_BUF_SIZE];      /* RX buffer */
 volatile uint8_t rx_buffer_next;                /* Next packet in RX queue */
 
-void cc110x_rx_handler(void *args)
+
+/*------------------------------------------------------------------------------------*/
+/*                                 CC110X RX/TX API                                   */
+/*------------------------------------------------------------------------------------*/
+
+int cc110x_send(cc110x_packet_t *packet)
 {
-    uint8_t res = 0;
+    volatile uint32_t abort_count = 0;
+    uint16_t bytes_left, bytes_send;
+    char* packet_ptr = (char*) packet;
 
-    /* Possible packet received, RX -> IDLE (0.1 us) */
-    cc110x_statistic.packets_in++;
-
-    res = receive_packet((uint8_t *)&(cc110x_rx_buffer[rx_buffer_next].packet),
-            sizeof(cc110x_packet_t));
-
-    if (res) {
-        /* If we are sending a burst, don't accept packets.
-         * Only ACKs are processed (for stopping the burst).
-         * Same if state machine is in TX lock. */
-        if (radio_state == RADIO_SEND_BURST) {
-            cc110x_statistic.packets_in_while_tx++;
-            return;
-        }
-
-        cc110x_rx_buffer[rx_buffer_next].rssi = rflags._RSSI;
-        cc110x_rx_buffer[rx_buffer_next].lqi = rflags._LQI;
-        cc110x_strobe(CC1100_SFRX);     /* ...for flushing the RX FIFO */
-
-        /* Valid packet. After a wake-up, the radio should be in IDLE.
-         * So put CC110x to RX for WOR_TIMEOUT (have to manually put
-         * the radio back to sleep/WOR). */
-        cc110x_write_reg(CC1100_MCSM2, 0x07);   /* Configure RX_TIME (until end of packet) */
-        cc110x_strobe(CC1100_SRX);
-        hwtimer_wait(IDLE_TO_RX_TIME);
-        radio_state = RADIO_RX;
-
-#ifdef MODULE_TRANSCEIVER
-        /* notify transceiver thread if any */
-        if (transceiver_pid != KERNEL_PID_UNDEF) {
-            msg_t m;
-            m.type = (uint16_t) RCV_PKT_CC1100;
-            m.content.value = rx_buffer_next;
-            msg_send_int(&m, transceiver_pid);
-        }
-#endif
-
-#ifdef MODULE_NETDEV_BASE
-        if (cc110x_recv_cb != NULL) {
-            cc110x_packet_t p = cc110x_rx_buffer[rx_buffer_next].packet;
-            cc110x_recv_cb(&cc110x_dev, &p.phy_src, sizeof(uint8_t), &p.address,
-                    sizeof(uint8_t), p.data, p.length - CC1100_HEADER_LENGTH);
-        }
-#endif
-
-        /* shift to next buffer element */
-        if (++rx_buffer_next == RX_BUF_SIZE) {
-            rx_buffer_next = 0;
-        }
-
-        return;
-    }
-    else {
-        /* CRC false or RX buffer full -> clear RX FIFO in both cases */
-        cc110x_strobe(CC1100_SIDLE);    /* Switch to IDLE (should already be)... */
-        cc110x_strobe(CC1100_SFRX);     /* ...for flushing the RX FIFO */
-
-        /* If currently sending, exit here (don't go to RX/WOR) */
-        if (radio_state == RADIO_SEND_BURST) {
-            cc110x_statistic.packets_in_while_tx++;
-            return;
-        }
-
-        /* No valid packet, so go back to RX/WOR as soon as possible */
-        cc110x_switch_to_rx();
-    }
-}
-
-static uint8_t receive_packet_variable(uint8_t *rxBuffer, radio_packet_length_t length)
-{
-    uint8_t status[2];
-
-    /* Any bytes available in RX FIFO? */
-    if ((cc110x_read_status(CC1100_RXBYTES) & BYTES_IN_RXFIFO)) {
-        uint8_t packetLength = 0;
-
-        /* Read length byte (first byte in RX FIFO) */
-        packetLength = cc110x_read_reg(CC1100_RXFIFO);
-
-        /* Read data from RX FIFO and store in rxBuffer */
-        if (packetLength <= length) {
-	     uint8_t crc_ok = 0;
-
-            /* Put length byte at first position in RX Buffer */
-            rxBuffer[0] = packetLength;
-
-            /* Read the rest of the packet */
-            cc110x_readburst_reg(CC1100_RXFIFO, (char *) rxBuffer + 1, packetLength);
-
-            /* Read the 2 appended status bytes (status[0] = RSSI, status[1] = LQI) */
-            cc110x_readburst_reg(CC1100_RXFIFO, (char *)status, 2);
-
-            /* Store RSSI value of packet */
-            rflags._RSSI = status[I_RSSI];
-
-            /* MSB of LQI is the CRC_OK bit */
-            crc_ok = (status[I_LQI] & CRC_OK) >> 7;
-
-            if (!crc_ok) {
-                cc110x_statistic.packets_in_crc_fail++;
-            }
-
-            /* Bit 0-6 of LQI indicates the link quality (LQI) */
-            rflags._LQI = status[I_LQI] & LQI_EST;
-
-            return crc_ok;
-        }
-        /* too many bytes in FIFO */
-        else {
-            /* RX FIFO gets automatically flushed if return value is false */
-            return 0;
-        }
-    }
-    /* no bytes in RX FIFO */
-    else {
-        /* RX FIFO gets automatically flushed if return value is false */
-        return 0;
-    }
-}
-
-static uint8_t receive_packet(uint8_t *rxBuffer, radio_packet_length_t length)
-{
-    uint8_t pkt_len_cfg = cc110x_read_reg(CC1100_PKTCTRL0) & PKT_LENGTH_CONFIG;
-
-    if (pkt_len_cfg == VARIABLE_PKTLEN) {
-        return receive_packet_variable(rxBuffer, length);
-    }
-
-    /* Fixed packet length not supported. */
-    /* RX FIFO get automatically flushed if return value is false */
-    return 0;
-}
-
-int8_t cc110x_send(cc110x_packet_t *packet)
-{
-    volatile uint32_t abort_count;
-    uint8_t size;
+    /* Disable interrupts as they are only used for packet reception */
+    gpio_irq_disable(CC110X_GDO0);
+    gpio_irq_disable(CC110X_GDO2);
 
     radio_state = RADIO_SEND_BURST;
 
-    /*
-     * Number of bytes to send is:
-     * length of phy payload (packet->length)
-     * + size of length field (1 byte)
-     */
-    size = packet->length + 1;
+    /* Number of bytes to send is: packet->length + size of length field (1 byte) */
+    bytes_left = packet->length + 1;
 
-    /* The number of bytes to be transmitted must be smaller
-     * or equal to PACKET_LENGTH (62 bytes). So the receiver
-     * can put the whole packet in its RX-FIFO (with appended
-     * packet status bytes).*/
-    if (size > PACKET_LENGTH) {
-        return 0;
-    }
-
+    /* Set the configured address as source address */
     packet->phy_src = cc110x_get_address();
 
-    /* Disable RX interrupt */
-    gpio_irq_disable(CC110X_GDO2);
-
-    /* Put CC110x in IDLE mode to flush the FIFO */
+    /* Put CC110x in IDLE mode to flush the FIFO (to be sure it is empty) */
     cc110x_strobe(CC1100_SIDLE);
-    /* Flush TX FIFO to be sure it is empty */
     cc110x_strobe(CC1100_SFTX);
-    /* Write packet into TX FIFO */
-    cc110x_writeburst_reg(CC1100_TXFIFO, (char *) packet, size);
-    /* Switch to TX mode */
-    abort_count = 0;
-    unsigned int cpsr = disableIRQ();
-    cc110x_strobe(CC1100_STX);
 
-    /* Wait for GDO2 to be set -> sync word transmitted */
-    while (gpio_read(CC110X_GDO2) == 0) {
-        abort_count++;
+    if (bytes_left <= CC1100_FIFO_SIZE) {
+        /* We can put the whole packet into the TX FIFO */
+        cc110x_writeburst_reg(CC1100_TXFIFO, packet_ptr, bytes_left);
+        bytes_send = bytes_left;
 
-        if (abort_count > CC1100_SYNC_WORD_TX_TIME) {
-            /* Abort waiting. CC110x maybe in wrong mode */
-            break;
+        /* Start transmission */
+        unsigned int cpsr = disableIRQ();
+        cc110x_strobe(CC1100_STX);
+        /* Wait for sync word transmission */
+        while (!gpio_read(CC110X_GDO2)) {
+            abort_count++;
+            if (abort_count > CC1100_SYNC_WORD_TX_TIME) {
+                break;
+            }
         }
+        restoreIRQ(cpsr);
+    }
+    else {
+        /* Packet is too large, we need to fill the TX FIFO multiple times */
+        /* Push first 64 bytes of the packet */
+        cc110x_writeburst_reg(CC1100_TXFIFO, packet_ptr, CC1100_FIFO_SIZE);
+        bytes_send = CC1100_FIFO_SIZE;
+        bytes_left -= CC1100_FIFO_SIZE;
+
+        /* Start transmission */
+        unsigned int cpsr = disableIRQ();
+        cc110x_strobe(CC1100_STX);
+
+        /* Consecutively push remaining bytes to TX FIFO */
+        while (bytes_left > 0) {
+            /* Calculate free space in TX FIFO */
+            uint8_t free_space = CC1100_FIFO_SIZE -
+                    (cc110x_read_status(CC1100_TXBYTES) & BYTES_IN_TXFIFO);
+            if (free_space > 0) {
+                if (free_space > bytes_left) {
+                    free_space = bytes_left;
+                }
+                cc110x_writeburst_reg(CC1100_TXFIFO, packet_ptr + bytes_send, free_space);
+                bytes_send += free_space;
+                bytes_left -= free_space;
+            }
+        }
+
+        /* Wait for sync word transmission */
+        while (!gpio_read(CC110X_GDO2)) {
+            abort_count++;
+            if (abort_count > CC1100_SYNC_WORD_TX_TIME) {
+                /* Sync word was already send, we missed it */
+                break;
+            }
+        }
+        restoreIRQ(cpsr);
     }
 
-    restoreIRQ(cpsr);
+    if (cc110x_read_status(CC1100_TXBYTES) & TXFIFO_UNDERFLOW) {
+        DEBUG("[CC110X TX] TXFIFO UNDERFLOW ERROR");
+        /* Flush TX FIFO to be sure it is empty */
+        cc110x_strobe(CC1100_SFTX);
+    }
 
-    /* Wait for GDO2 to be cleared -> end of packet */
+    /* Wait for TXFIFO to be emptied completely */
+    while(cc110x_read_status(CC1100_TXBYTES) & BYTES_IN_TXFIFO);
+
+    /* Wait for GDO2 to be cleared -> packet has been sent */
     while (gpio_read(CC110X_GDO2) != 0);
-
-    gpio_irq_enable(CC110X_GDO2);
     cc110x_statistic.raw_packets_out++;
+
+    /* Re-enable packet reception interrupts */
+    gpio_irq_enable(CC110X_GDO0);
+    gpio_irq_enable(CC110X_GDO2);
 
     /* Go to RX mode after TX */
     cc110x_switch_to_rx();
 
-    return size;
+    return bytes_send;
+}
+
+void cc110x_rxfifo_of_handler(void)
+{
+    /* Disable interrupt (we only want it to trigger on reception start) */
+    gpio_irq_disable(CC110X_GDO0);
+
+    /* Read length byte from RX FIFO */
+    bytes_rem = cc110x_read_reg(CC1100_RXFIFO);
+    curr_packet.length = bytes_rem;
+    bytes_read = 1;
+
+    /* Read remaining bytes consecutively from RX FIFO */
+    while (bytes_rem > 0) {
+        uint8_t bytes_avail = (cc110x_read_status(CC1100_RXBYTES) & BYTES_IN_RXFIFO);
+        /* Don't empty the FIFO completely */
+        if (bytes_avail > 1) {
+            if (bytes_avail <= bytes_rem) {
+                cc110x_readburst_reg(CC1100_RXFIFO, ((char *)&curr_packet) + bytes_read,
+                        bytes_avail - 1);
+                bytes_rem -= (bytes_avail - 1);
+                bytes_read += (bytes_avail - 1);
+            }
+            else {
+                cc110x_readburst_reg(CC1100_RXFIFO, ((char *)&curr_packet) + bytes_read,
+                        bytes_rem);
+                bytes_read += bytes_rem;
+                bytes_rem = 0;
+            }
+        }
+    }
+}
+
+void cc110x_packet_end_handler(void)
+{
+    uint8_t status[2];
+
+    /* Check whether a RXFIFO OVERFLOW occured */
+    if (cc110x_read_status(CC1100_RXBYTES) & RXFIFO_OVERFLOW) {
+        DEBUG("[CC110X] TXFIFO Overflow: Packet drop\n");
+        /* Flush the RX FIFO to return to IDLE state */
+        cc110x_strobe(CC1100_SFRX);
+        bytes_read = 0;
+        bytes_rem = 0;
+        gpio_irq_enable(CC110X_GDO0);
+        /* Switch back to RX state */
+        cc110x_switch_to_rx();
+        return;
+    }
+
+    /* Any bytes available in RX FIFO? */
+    if ((cc110x_read_status(CC1100_RXBYTES) & BYTES_IN_RXFIFO)) {
+        /* Possible packet received */
+        cc110x_statistic.packets_in++;
+
+        /* Check whether the packet was read completely (if not, it was probably invalid) */
+        if ((bytes_read == 0) || (bytes_rem > 0)) {
+            DEBUG("[CC110X] RX Problem: Packet drop\n");
+            /* Switch to IDLE (should already be) for flushing the RX FIFO */
+            cc110x_strobe(CC1100_SIDLE);
+            cc110x_strobe(CC1100_SFRX);
+            bytes_read = 0;
+            bytes_rem = 0;
+            gpio_irq_enable(CC110X_GDO0);
+            /* Switch back to RX state */
+            cc110x_switch_to_rx();
+            return;
+        }
+
+        /* Read the 2 appended status bytes (status[0] = RSSI, status[1] = LQI) */
+        cc110x_readburst_reg(CC1100_RXFIFO, (char *)status, 2);
+
+        /* MSB of LQI is the CRC_OK bit */
+        if ((status[I_LQI] & CRC_OK) >> 7) {
+            cc110x_rx_buffer[rx_buffer_next].packet.length = curr_packet.length;
+            cc110x_rx_buffer[rx_buffer_next].packet.flags = curr_packet.flags;
+            cc110x_rx_buffer[rx_buffer_next].packet.phy_src = curr_packet.phy_src;
+            cc110x_rx_buffer[rx_buffer_next].packet.address = curr_packet.address;
+            memcpy(cc110x_rx_buffer[rx_buffer_next].packet.data,
+                    curr_packet.data, (curr_packet.length - CC1100_HEADER_LENGTH));
+
+            /* Store RSSI value of packet */
+            cc110x_rx_buffer[rx_buffer_next].rssi = status[I_RSSI];
+            /* Bit 0-6 of LQI indicates the link quality (LQI) */
+            cc110x_rx_buffer[rx_buffer_next].lqi = status[I_LQI] & LQI_EST;
+
+            /* Switch to IDLE (should already be) for flushing the RX FIFO */
+            cc110x_strobe(CC1100_SIDLE);
+            cc110x_strobe(CC1100_SFRX);
+
+            /* Re-enable RXFIFO threshold interrupt */
+            bytes_read = 0u;
+            bytes_rem = 0u;
+            gpio_irq_enable(CC110X_GDO0);
+
+            /* Go back to RX state, to be ready for new packets */
+            cc110x_write_reg(CC1100_MCSM2, 0x07);   /* Configure RX_TIME (until end of packet) */
+            cc110x_switch_to_rx();
+
+    #ifdef MODULE_TRANSCEIVER
+            /* notify transceiver thread if any */
+            if (transceiver_pid != KERNEL_PID_UNDEF) {
+                msg_t m;
+                m.type = (uint16_t) RCV_PKT_CC1100;
+                m.content.value = rx_buffer_next;
+                msg_send_int(&m, transceiver_pid);
+            }
+    #endif
+
+    #ifdef MODULE_NETDEV_BASE
+            if (cc110x_recv_cb != NULL) {
+                cc110x_packet_t p = cc110x_rx_buffer[rx_buffer_next].packet;
+                cc110x_recv_cb(&cc110x_dev, &p.phy_src, sizeof(uint8_t), &p.address,
+                        sizeof(uint8_t), p.data, p.length - CC1100_HEADER_LENGTH);
+            }
+    #endif
+
+            /* shift to next buffer element */
+            if (++rx_buffer_next == RX_BUF_SIZE) {
+                rx_buffer_next = 0;
+            }
+        }
+        else {
+            /* CRC false */
+            DEBUG("[CC110X] CRC Error: Packet drop\n");
+            cc110x_statistic.packets_in_crc_fail++;
+
+            /* Switch to IDLE (should already be) for flushing the RX FIFO */
+            cc110x_strobe(CC1100_SIDLE);
+            cc110x_strobe(CC1100_SFRX);
+
+            /* Re-enable RXFIFO threshold interrupt */
+            bytes_read = 0u;
+            bytes_rem = 0u;
+            gpio_irq_enable(CC110X_GDO0);
+
+            /* No valid packet, so go back to RX as soon as possible */
+            cc110x_switch_to_rx();
+        }
+    }
 }

--- a/drivers/include/cc110x/cc110x-interface.h
+++ b/drivers/include/cc110x/cc110x-interface.h
@@ -34,23 +34,23 @@
 extern "C" {
 #endif
 
-#define CC1100_MAX_DATA_LENGTH (58)
+#define CC1100_FIFO_SIZE            (64)        /**< Size of the CC110X RX/TX FIFO */
+#define CC1100_MAX_DATA_LENGTH      (252)       /**< Maximum length of pure payload data */
+#define CC1100_HEADER_LENGTH        (3)         ///< Header covers SRC, DST and FLAGS
 
-#define CC1100_HEADER_LENGTH   (3)              ///< Header covers SRC, DST and FLAGS
+#define CC1100_BROADCAST_ADDRESS    (0x00)      ///< CC1100 broadcast address
 
-#define CC1100_BROADCAST_ADDRESS (0x00)         ///< CC1100 broadcast address
-
-#define MAX_UID                  (0xFF)         ///< Maximum UID of a node is 255
-#define MIN_UID                  (0x01)         ///< Minimum UID of a node is 1
+#define MAX_UID                     (0xFF)      ///< Maximum UID of a node is 255
+#define MIN_UID                     (0x01)      ///< Minimum UID of a node is 1
 
 #define MIN_CHANNR                  (0)         ///< Minimum channel number
-#define MAX_CHANNR                 (24)         ///< Maximum channel number
+#define MAX_CHANNR                  (24)        ///< Maximum channel number
 
 #define MIN_OUTPUT_POWER            (0)         ///< Minimum output power value
-#define MAX_OUTPUT_POWER           (11)         ///< Maximum output power value
+#define MAX_OUTPUT_POWER            (11)        ///< Maximum output power value
 
-#define PACKET_LENGTH               (0x3E)      ///< Packet length = 62 Bytes.
-#define CC1100_SYNC_WORD_TX_TIME   (90000)      // loop count (max. timeout ~ 15 ms) to wait for
+#define PACKET_LENGTH               (0xFF)      ///< Packet length = 255 Bytes.
+#define CC1100_SYNC_WORD_TX_TIME    (90000)     // loop count (max. timeout ~ 15 ms) to wait for
                                                 // sync word to be transmitted (GDO2 from low to high)
 /**
  * @name    Defines used as state values for state machine
@@ -64,7 +64,6 @@ extern "C" {
 
 /** @} */
 
-extern volatile cc110x_flags rflags;            ///< Radio flags
 extern char cc110x_conf[];
 
 /**
@@ -125,7 +124,7 @@ void cc110x_init(kernel_pid_t transceiver_pid);
 
 int cc110x_initialize(netdev_t *dev);
 
-int8_t cc110x_send(cc110x_packet_t *pkt);
+int cc110x_send(cc110x_packet_t *pkt);
 
 uint8_t cc110x_get_buffer_pos(void);
 
@@ -146,11 +145,20 @@ void cc110x_set_monitor(uint8_t mode);
 void cc110x_print_config(void);
 
 /**
+ * @brief   GDO0 interrupt handler.
+ *
+ * Triggered if the fill count of the RXFIFO trespasses the configured
+ * threshold in the FIFOTHR register.
+ */
+void cc110x_rxfifo_of_handler(void);
+
+/**
  * @brief   GDO2 interrupt handler.
  *
- * @note    Wakes up MCU on packet reception.
+ * Triggered if a packet was received completely or if a RXFIFO Overflow
+ * occured.
  */
-void cc110x_rx_handler(void *args);
+void cc110x_packet_end_handler(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR extends the current cc110x driver implementation to allow packet sizes up to 255 bytes (maximum for Variable Packet Length Mode) ~~and adapts the netdev receive mechanism to handle packet reception not in the interrupt but in the event handling thread.~~ (UPDATE: Old netdev is deprecated, therefore no longer handled in this PR).

Both, the RX and the TX FIFO of the cc110x can only store 64 bytes. Therefore, for packet sizes > 64 bytes consecutively reading/pushing bytes is necessary.

For transmission of packets > 64 bytes the TX FIFO is filled with the first 64 bytes and afterwards the remaining bytes are consecutively pushed to the TX FIFO when space is available until all the bytes are transmitted (necessary because a TXFIFO underflow would result in a corrupted packet).

For reception of a packet, two interrupts are used. The first interrupt is triggered, when the RX FIFO is filled with more than 4 bytes (RX FIFO threshold, packets with less bytes are not valid). Subsequently, the available bytes in the RXFIFO are consecutively read until the whole packet is received. This is necessary to avoid a RX FIFO overflow. The second interrupt is triggered when the cc110x signals that the whole packet was received. This results in reading the remaining two status bytes in the RXFIFO. Afterwards the packet either gets dropped (CRC wrong) or gets processed further.

~~The PR is depending on #2163 (introduction of event handler pid member variable in netdev_t).~~(UPDATE: Old netdev is deprecated, this PR no longer relies on netdev changes).