### PR TITLE
rpl: remove faulty comment

### DIFF
--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -35,7 +35,6 @@
 #include "sixlowpan.h"
 #include "net_help.h"
 
-/* You can only run Storing Mode by now. Other unsupported modes lead to default (Storing Mode) */
 #if RPL_DEFAULT_MOP == RPL_STORING_MODE_NO_MC
 #include "rpl/rpl_storing.h"
 #elif RPL_DEFAULT_MOP == RPL_NON_STORING_MODE


### PR DESCRIPTION
Can be misleading since we also support non-storing mode now.