### PR TITLE
rpl: added configurable RPL MOP on compile time

### DIFF
--- a/examples/rpl_udp/README.md
+++ b/examples/rpl_udp/README.md
@@ -3,26 +3,28 @@ First switch to this application directory:
 
 	cd RIOT/examples/rpl_udp
 
-#### Parameterizing the build
-The build system provides two specific parameters for the RPL module.
+The build system provides three specific parameters for the RPL module.
 These parameters are:
- * `RPL_MAX_ROUTING_ENTRIES` sets the desired maximum number of entries for the RPL routing table. _If this parameter is not provided, a [default](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/include/rpl/rpl_config.h#L139) value is used._
- * `RPL_NODE_IS_ROOT` indicating the build is specifically for a root node. This parameter is **only required** for using [`RPL_NON_STORING_MODE`](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/include/rpl/rpl_config.h#L31) MOP to initialize a RPL routing table. The parameter is ignored in all other cases. _For non-storing MOP a node does not require to provide a routing table._
+ * `RPL_MOP` sets the _mode of operation_ (MOP) of RPL. _The default value is used if this variable is not set._
+ * `RPL_MAX_ROUTING_ENTRIES` sets the desired maximum number of entries for the RPL routing table. _If this parameter is not provided, a default value is used._
+ * `RPL_NODE_IS_ROOT` indicating the build is specifically for a root node. This parameter is **only required** for using `RPL_MOP_NON_STORING_MODE` MOP to initialize a RPL routing table. The parameter is ignored in all other cases. _For non-storing MOP a node does not require to provide a routing table._
+
+These RPL build parameters and their according _default_ values are used in the [`rpl_config.h`](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/include/rpl/rpl_config.h).
 
 #### Compiling the executable
-**example for [`RPL_STORING_MODE_NO_MC`](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/include/rpl/rpl_config.h#L139):**
+**example for `RPL_MOP_STORING_MODE_MC`:**
 
-	make
+	make RPL_MOP=RPL_MOP_STORING_MODE_MC
 
 builds the project and creates `128` entries for the RPL routing table by default.
 
-	make RPL_MAX_ROUTING_ENTRIES=103
+	make RPL_MOP=RPL_MOP_STORING_MODE_MC RPL_MAX_ROUTING_ENTRIES=103
 
 builds the project and creates `103` entries for the RPL routing table **overwriting** the default value.
 
-**example for [`RPL_NON_STORING_MODE`](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/include/rpl/rpl_config.h#L133):**
+**example for `RPL_MOP_NON_STORING_MODE`:**
 
-	make RPL_MAX_ROUTING_ENTRIES=103 RPL_NODE_IS_ROOT=1
+	make RPL_MOP=RPL_MOP_NON_STORING_MODE RPL_MAX_ROUTING_ENTRIES=103 RPL_NODE_IS_ROOT=1
 
 builds the project and creates `103` entries for the RPL routing table for the root node.
 

--- a/sys/net/include/rpl.h
+++ b/sys/net/include/rpl.h
@@ -257,7 +257,7 @@ rpl_routing_entry_t *rpl_get_routing_table(void);
  * */
 uint8_t rpl_is_root(void);
 
-#if RPL_DEFAULT_MOP == RPL_NON_STORING_MODE
+#if RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE
 
 /**
  * @brief Adds one pair of child and its parent to the source routing table
@@ -303,7 +303,7 @@ int rpl_srh_sendto(const void *buf, uint16_t len, ipv6_addr_t *src, ipv6_addr_t 
  * */
 void rpl_remove_srh_header(ipv6_hdr_t *ipv6_header, const void *buf, uint8_t nextheader);
 
-#endif /* RPL_DEFAULT_MOP == RPL_NON_STORING_MODE */
+#endif /* RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE */
 
 #ifdef __cplusplus
 }

--- a/sys/net/include/rpl/rpl_config.h
+++ b/sys/net/include/rpl/rpl_config.h
@@ -27,10 +27,10 @@ extern "C" {
 #endif
 
 /*  Default values */
-#define RPL_NO_DOWNWARD_ROUTES  0x00
-#define RPL_NON_STORING_MODE    0x01
-#define RPL_STORING_MODE_NO_MC  0x02
-#define RPL_STORING_MODE_MC     0x03
+#define RPL_MOP_NO_DOWNWARD_ROUTES  0x00
+#define RPL_MOP_NON_STORING_MODE    0x01
+#define RPL_MOP_STORING_MODE_NO_MC  0x02
+#define RPL_MOP_STORING_MODE_MC     0x03
 
 #define RPL_SEQUENCE_WINDOW         16
 /* RPL Message type */
@@ -112,8 +112,9 @@ static inline bool RPL_COUNTER_GREATER_THAN(uint8_t A, uint8_t B)
 #define METRIC_ETX 1
 
 /*  RPL Constants and Variables */
-
-#define RPL_DEFAULT_MOP RPL_STORING_MODE_NO_MC
+#ifndef RPL_DEFAULT_MOP
+#   define RPL_DEFAULT_MOP RPL_MOP_STORING_MODE_NO_MC
+#endif
 #define BASE_RANK 0
 #define INFINITE_RANK 0xFFFF
 #define RPL_DEFAULT_INSTANCE 0
@@ -141,17 +142,17 @@ static inline bool RPL_COUNTER_GREATER_THAN(uint8_t A, uint8_t B)
 #define RPL_MAX_INSTANCES 1
 #define RPL_MAX_PARENTS 5
 #ifndef RPL_MAX_ROUTING_ENTRIES
-    #if (RPL_DEFAULT_MOP == RPL_NO_DOWNWARD_ROUTES)
+    #if (RPL_DEFAULT_MOP == RPL_MOP_NO_DOWNWARD_ROUTES)
     #    define RPL_MAX_ROUTING_ENTRIES (128)
-    #elif (RPL_DEFAULT_MOP == RPL_NON_STORING_MODE)
+    #elif (RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE)
         #ifdef RPL_NODE_IS_ROOT
         #    define RPL_MAX_ROUTING_ENTRIES (128)
         #else
         #    define RPL_MAX_ROUTING_ENTRIES (0)
         #endif
-    #elif (RPL_DEFAULT_MOP == RPL_STORING_MODE_NO_MC)
+    #elif (RPL_DEFAULT_MOP == RPL_MOP_STORING_MODE_NO_MC)
     #    define RPL_MAX_ROUTING_ENTRIES (128)
-    #else // RPL_DEFAULT_MOP == RPL_STORING_MODE_MC
+    #else // RPL_DEFAULT_MOP == RPL_MOP_STORING_MODE_MC
     #    define RPL_MAX_ROUTING_ENTRIES (128)
     #endif
 #endif

--- a/sys/net/routing/rpl/Makefile
+++ b/sys/net/routing/rpl/Makefile
@@ -1,7 +1,35 @@
-MODE = $(shell grep "RPL_DEFAULT_MOP RPL_NON_STORING_MODE" ../../include/rpl/rpl_config.h)
-ifneq (,$(MODE))
+# RPL_MOP values by IANA https://tools.ietf.org/html/rfc6550#page-129
+# RPL_MOP_NO_DOWNWARD_ROUTES  0x00
+# RPL_MOP_NON_STORING_MODE    0x01
+# RPL_MOP_STORING_MODE_NO_MC  0x02
+# RPL_MOP_STORING_MODE_MC     0x03
+
+# Set the RPL MOP iff it is matching a provided mode
+MODE :=
+
+ifeq (RPL_MOP_NO_DOWNWARD_ROUTES, $(RPL_MOP))
+	MODE := 0x00
+	DIRS += rpl_storing
+endif
+ifeq (RPL_MOP_NON_STORING_MODE, $(RPL_MOP))
+	MODE := 0x01
 	DIRS += rpl_nonstoring
+endif
+ifeq (RPL_MOP_STORING_MODE_NO_MC, $(RPL_MOP))
+	MODE := 0x02
+	DIRS += rpl_storing
+endif
+ifeq (RPL_MOP_STORING_MODE_MC, $(RPL_MOP))
+	MODE := 0x03
+	DIRS += rpl_storing
+endif
+
+# If a valid RPL_MOP was provided, use it for RPL
+ifneq (,$(MODE))
+	CFLAGS += -DRPL_DEFAULT_MOP=$(MODE)
 else
+	# If no (valid) RPL_MOP has been provided, use the following parameters
+	CFLAGS += -DRPL_DEFAULT_MOP=0x02
 	DIRS += rpl_storing
 endif
 
@@ -10,7 +38,7 @@ ifneq (,$(RPL_MAX_ROUTING_ENTRIES))
 	CFLAGS += -DRPL_MAX_ROUTING_ENTRIES=$(RPL_MAX_ROUTING_ENTRIES)
 endif
 
-# Define this node as root at compile time (required only for non-storing mode) 
+# Define this node as root at compile time (required only for non-storing mode)
 ifneq (,$(RPL_NODE_IS_ROOT))
 	CFLAGS += -DRPL_NODE_IS_ROOT
 endif

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -35,9 +35,9 @@
 #include "sixlowpan.h"
 #include "net_help.h"
 
-#if RPL_DEFAULT_MOP == RPL_STORING_MODE_NO_MC
+#if RPL_DEFAULT_MOP == RPL_MOP_STORING_MODE_NO_MC
 #include "rpl/rpl_storing.h"
-#elif RPL_DEFAULT_MOP == RPL_NON_STORING_MODE
+#elif RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE
 #include "rpl/rpl_nonstoring.h"
 #else
 #include "rpl/rpl_storing.h"
@@ -61,7 +61,7 @@ static vtimer_t rt_timer;
 static void _dao_handle_send(rpl_dodag_t *dodag);
 static void _rpl_update_routing_table(void);
 
-#if RPL_DEFAULT_MOP == RPL_NON_STORING_MODE
+#if RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE
 #if RPL_MAX_ROUTING_ENTRIES != 0
 static uint8_t srh_buffer[BUFFER_SIZE];
 #endif
@@ -100,7 +100,7 @@ uint8_t rpl_init(int if_id)
     ipv6_addr_set_link_local_prefix(&ll_address);
     ipv6_net_if_get_best_src_addr(&my_address, &ll_address);
     ipv6_register_rpl_handler(rpl_process_pid);
-#if (RPL_DEFAULT_MOP == RPL_NON_STORING_MODE)
+#if (RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE)
     ipv6_iface_set_srh_indicator(rpl_is_root);
 #endif
     ipv6_iface_set_routing_provider(rpl_get_next_hop);
@@ -118,7 +118,7 @@ uint8_t rpl_init(int if_id)
 
 void rpl_init_root(void)
 {
-#if (RPL_DEFAULT_MOP == RPL_NON_STORING_MODE)
+#if (RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE)
 #ifndef RPL_NODE_IS_ROOT
 puts("\n############################## ERROR ###############################");
 puts("This configuration has NO ROUTING TABLE available for the root node!");
@@ -137,7 +137,7 @@ uint8_t rpl_is_root(void)
     return rpl_is_root_mode();
 }
 
-#if RPL_DEFAULT_MOP == RPL_NON_STORING_MODE
+#if (RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE)
 void internal_srh_process(ipv6_srh_t *srh_header)
 {
     /* modify it accordingly - the number of entries is not depending on padding,
@@ -244,9 +244,9 @@ void *rpl_process(void *arg)
                 }
             }
 
-#if RPL_DEFAULT_MOP == RPL_NON_STORING_MODE
+#if RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE
             /* If the message is not RPL-type, it relates to non-storing mode */
-            else if (RPL_DEFAULT_MOP == RPL_NON_STORING_MODE) {
+            else if (RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE) {
 
                 if (ipv6_buf->nextheader == IPV6_PROTO_NUM_SRH) {
                     srh_header = ((ipv6_srh_t *)(m_recv.content.ptr + IPV6_HDR_LEN));
@@ -452,7 +452,7 @@ ipv6_addr_t *rpl_get_next_hop(ipv6_addr_t *addr)
                     ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN, &rpl_routing_table[i].address));
         }
 
-        if ((RPL_DEFAULT_MOP == RPL_NON_STORING_MODE) && rpl_is_root()) {
+        if ((RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE) && rpl_is_root()) {
             if (rpl_routing_table[i].used && rpl_equal_id(&rpl_routing_table[i].address, addr)) {
                 DEBUGF("found %d: %s\n", i,
                         ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN,
@@ -550,7 +550,7 @@ rpl_routing_entry_t *rpl_get_routing_table(void)
 #endif
 }
 
-#if RPL_DEFAULT_MOP == RPL_NON_STORING_MODE
+#if RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE
 /* everything from here on is non-storing mode related */
 
 #if RPL_MAX_ROUTING_ENTRIES != 0

--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -285,14 +285,14 @@ rpl_parent_t *rpl_find_preferred_parent(void)
     }
 
     if (!rpl_equal_id(&my_dodag->my_preferred_parent->addr, &best->addr)) {
-        if (my_dodag->mop != RPL_NO_DOWNWARD_ROUTES) {
+        if (my_dodag->mop != RPL_MOP_NO_DOWNWARD_ROUTES) {
             /* send DAO with ZERO_LIFETIME to old parent */
             rpl_send_DAO(&my_dodag->my_preferred_parent->addr, 0, false, 0);
         }
 
         my_dodag->my_preferred_parent = best;
 
-        if (my_dodag->mop != RPL_NO_DOWNWARD_ROUTES) {
+        if (my_dodag->mop != RPL_MOP_NO_DOWNWARD_ROUTES) {
             rpl_delay_dao(my_dodag);
         }
 

--- a/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
+++ b/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
@@ -676,7 +676,7 @@ void rpl_recv_DAO_mode(void)
                         &rpl_opt_target_buf->target));
                 DEBUGF("Transit: %s\n", ipv6_addr_to_str(addr_str_mode, IPV6_MAX_ADDR_STR_LEN,
                         &rpl_opt_transit_buf->parent));
-#if (RPL_DEFAULT_MOP == RPL_NON_STORING_MODE) && (RPL_MAX_ROUTING_ENTRIES != 0)
+#if (RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE) && (RPL_MAX_ROUTING_ENTRIES != 0)
                 rpl_add_srh_entry(&rpl_opt_target_buf->target, &rpl_opt_transit_buf->parent,
                         rpl_opt_transit_buf->path_lifetime * my_dodag->lifetime_unit);
 #endif
@@ -826,4 +826,3 @@ void rpl_send(ipv6_addr_t *destination, uint8_t *payload, uint16_t p_len, uint8_
 
     ipv6_send_packet(ipv6_send_buf, NULL);
 }
-


### PR DESCRIPTION
added configurable RPL MOP on compile time addressing #2194 
- e.g. `make RPL_MOP=RPL_MOP_NON_STORING_MODE`
- changed the MOP defines to have `RPL_MOP_*` prefix