### PR TITLE
Automatic management of returning ACKs for TXed packets

### DIFF
--- a/drivers/cc2420/cc2420_rx.c
+++ b/drivers/cc2420/cc2420_rx.c
@@ -31,6 +31,11 @@ volatile uint8_t rx_buffer_next;  /* index of next free cell in RX buffer */
 static receive_802154_packet_callback_t recv_func = NULL;
 
 
+receive_802154_packet_callback_t cc2420_get_recv_callback(void)
+{
+    return recv_func;
+}
+
 void cc2420_set_recv_callback(receive_802154_packet_callback_t recv_cb)
 {
     recv_func = recv_cb;


### PR DESCRIPTION
Everything is in the title: using <code>send</code> now allows correct detection of returning ACK packets when the <code>wants_ack</code> is set to true.

Follow-up to #1633 (from my new personal repository).