### PR TITLE
transceiver: DEBUG instead of DEBUGF

### DIFF
--- a/sys/transceiver/transceiver.c
+++ b/sys/transceiver/transceiver.c
@@ -437,7 +437,7 @@ static void receive_packet(uint16_t type, uint8_t pos)
         /* inform upper layers of lost packet */
         m.type = ENOBUFFER;
         m.content.value = t;
-        DEBUGF("transceiver: buffer size exceeded, dropping packet\n");
+        DEBUG("transceiver: buffer size exceeded, dropping packet\n");
     }
     /* copy packet and handle it */
     else {
@@ -523,7 +523,7 @@ static void receive_packet(uint16_t type, uint8_t pos)
                 transceiver_buffer[transceiver_buffer_pos].processing++;
             }
             else {
-                DEBUGF("transceiver: failed to notify upper layer.\n");
+                DEBUG("transceiver: failed to notify upper layer.\n");
             }
         }
 


### PR DESCRIPTION
Switch two calls to DEBUGF() to DEBUG() because they lead to compliling complcations and the additional output provided by DEBUG isn't really necessary here.