### PR TITLE
aodvv2: fix calls to DEBUG()

### DIFF
--- a/sys/net/routing/aodvv2/aodv.c
+++ b/sys/net/routing/aodvv2/aodv.c
@@ -17,13 +17,12 @@
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>
  */
 
-#include "debug.h"
-
 #include "aodv.h"
 #include "aodvv2/aodvv2.h"
 #include "aodv_debug.h"
 
 #define ENABLE_DEBUG (0)
+#include "debug.h"
 
 #define UDP_BUFFER_SIZE     (128) /** with respect to IEEE 802.15.4's MTU */
 #define RCV_MSG_Q_SIZE      (32)  /* TODO: check if smaller values work, too */

--- a/sys/net/routing/aodvv2/reader.c
+++ b/sys/net/routing/aodvv2/reader.c
@@ -21,12 +21,11 @@
 #include "net_help.h"
 #endif
 
-#include "debug.h"
-
 #include "reader.h"
 #include "aodv_debug.h"
 
 #define ENABLE_DEBUG (0)
+#include "debug.h"
 
 #define VERBOSE_DEBUG (0)
 #if VERBOSE_DEBUG

--- a/sys/net/routing/aodvv2/routingtable.c
+++ b/sys/net/routing/aodvv2/routingtable.c
@@ -17,12 +17,11 @@
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>
  */
 
-#include "debug.h"
-
 #include "routingtable.h"
 #include "aodv_debug.h"
 
 #define ENABLE_DEBUG (0)
+#include "debug.h"
 
 /* helper functions */
 static void _reset_entry_if_stale(uint8_t i);

--- a/sys/net/routing/aodvv2/seqnum.c
+++ b/sys/net/routing/aodvv2/seqnum.c
@@ -17,11 +17,11 @@
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>
  */
 
-#include "debug.h"
 
 #include "seqnum.h"
 
 #define ENABLE_DEBUG (0)
+#include "debug.h"
 
 static aodvv2_seqnum_t seqnum;
 

--- a/sys/net/routing/aodvv2/utils.c
+++ b/sys/net/routing/aodvv2/utils.c
@@ -18,11 +18,11 @@
  */
 
 #include "utils.h"
-#include "debug.h"
 
 #include "aodv_debug.h"
 
 #define ENABLE_DEBUG (0)
+#include "debug.h"
 
 /* Some aodvv2 utilities (mostly tables) */
 static mutex_t clientt_mutex;

--- a/sys/net/routing/aodvv2/writer.c
+++ b/sys/net/routing/aodvv2/writer.c
@@ -22,11 +22,11 @@
 #endif
 
 #include "writer.h"
-#include "debug.h"
 
 #include "aodv_debug.h"
 
 #define ENABLE_DEBUG (0)
+#include "debug.h"
 
 static void _cb_addMessageHeader(struct rfc5444_writer *wr,
                                  struct rfc5444_writer_message *message);


### PR DESCRIPTION
``debug.h`` was included before ``ENABLE_DEBUG`` was set to 0 or 1. In consequence, setting ``ENABLE_DEBUG`` to 1 had no effect. This should be fixed now.