### PR TITLE
SAMR21/RTC: Error negative second fixed

### DIFF
--- a/cpu/samd21/periph/rtc.c
+++ b/cpu/samd21/periph/rtc.c
@@ -123,7 +123,7 @@ int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
                 | RTC_MODE2_ALARM_DAY(time->tm_mday)
                 | RTC_MODE2_ALARM_HOUR(time->tm_hour)
                 | RTC_MODE2_ALARM_MINUTE(time->tm_min)
-                | RTC_MODE2_ALARM_SECOND(time->tm_sec - 1);
+                | RTC_MODE2_ALARM_SECOND(time->tm_sec);
         rtcMode2->Mode2Alarm[0].MASK.reg = RTC_MODE2_MASK_SEL(6);
     }
     while (rtcMode2->STATUS.bit.SYNCBUSY);


### PR DESCRIPTION
It fixes #2259

I did the -1 because of this line (p224):
>The clock value is continuously compared with the 32-bit Alarm register (ALARM0). When an alarm match occurs, the Alarm 0 Interrupt flag in the Interrupt Flag Status and Clear registers (INTFLAG.ALARMn0) is set on the next 0-to-1 transition of CLK_RTC_CNT. 

Actually, the alarm ring at the right time so the -1 is not required.