### PR TITLE
rpl: remove routing table dependent code

### DIFF
--- a/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
+++ b/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
@@ -676,7 +676,7 @@ void rpl_recv_DAO_mode(void)
                         &rpl_opt_target_buf->target));
                 DEBUGF("Transit: %s\n", ipv6_addr_to_str(addr_str_mode, IPV6_MAX_ADDR_STR_LEN,
                         &rpl_opt_transit_buf->parent));
-#if RPL_DEFAULT_MOP == RPL_NON_STORING_MODE
+#if (RPL_DEFAULT_MOP == RPL_NON_STORING_MODE) && (RPL_MAX_ROUTING_ENTRIES != 0)
                 rpl_add_srh_entry(&rpl_opt_target_buf->target, &rpl_opt_transit_buf->parent,
                         rpl_opt_transit_buf->path_lifetime * my_dodag->lifetime_unit);
 #endif

--- a/sys/net/routing/rpl/rpl_storing/rpl_storing.c
+++ b/sys/net/routing/rpl/rpl_storing/rpl_storing.c
@@ -691,12 +691,14 @@ void rpl_recv_DAO_mode(void)
                 len += rpl_opt_transit_buf->length;
                 /* route lifetime seconds = (DAO lifetime) * (Unit Lifetime) */
 
+#if RPL_MAX_ROUTING_ENTRIES != 0
                 DEBUG("Adding routing information: Target: %s, Source: %s, Lifetime: %u\n",
                       ipv6_addr_to_str(addr_str_mode, IPV6_MAX_ADDR_STR_LEN, &rpl_opt_target_buf->target),
                       ipv6_addr_to_str(addr_str_mode, IPV6_MAX_ADDR_STR_LEN, &ipv6_buf->srcaddr),
                       (rpl_opt_transit_buf->path_lifetime * my_dodag->lifetime_unit));
                 rpl_add_routing_entry(&rpl_opt_target_buf->target, &ipv6_buf->srcaddr,
                         rpl_opt_transit_buf->path_lifetime * my_dodag->lifetime_unit);
+#endif
                 increment_seq = 1;
                 break;
             }

--- a/sys/net/routing/rpl/trickle.c
+++ b/sys/net/routing/rpl/trickle.c
@@ -246,12 +246,15 @@ static void *rt_timer_over(void *arg)
 {
     (void) arg;
 
+#if RPL_MAX_ROUTING_ENTRIES != 0
     rpl_routing_entry_t *rt;
+#endif
 
     while (1) {
         rpl_dodag_t *my_dodag = rpl_get_my_dodag();
 
         if (my_dodag != NULL) {
+#if RPL_MAX_ROUTING_ENTRIES != 0
             rt = rpl_get_routing_table();
 
             for (uint8_t i = 0; i < rpl_max_routing_entries; i++) {
@@ -264,7 +267,7 @@ static void *rt_timer_over(void *arg)
                     }
                 }
             }
-
+#endif
             /* Parent is NULL for root too */
             if (my_dodag->my_preferred_parent != NULL) {
                 if (my_dodag->my_preferred_parent->lifetime <= 1) {

--- a/sys/shell/commands/sc_rpl.c
+++ b/sys/shell/commands/sc_rpl.c
@@ -20,13 +20,15 @@
 
 #include "rpl.h"
 
+#if RPL_MAX_ROUTING_ENTRIES != 0
 static char addr_str[IPV6_MAX_ADDR_STR_LEN];
-
+#endif
 void _rpl_route_handler(int argc, char **argv)
 {
     (void) argc;
     (void) argv;
 
+#if RPL_MAX_ROUTING_ENTRIES != 0
     rpl_routing_entry_t *rtable;
     rtable = rpl_get_routing_table();
     unsigned c = 0;
@@ -48,6 +50,8 @@ void _rpl_route_handler(int argc, char **argv)
     }
     puts("--------------------------------------------------------------------");
     printf(" %u routing table entries\n", c);
-
+#else
+    puts("No routing table available");
+#endif
     puts("$");
 }


### PR DESCRIPTION
This PR removes code depending on a routing table with an entry
size > 0. Currently, all those functions and symbols are compiled into the binary,
even when there is no effective space in the routing table (as it is the
case for normal nodes in non-storing mode).