### PR TITLE
drivers/at86rf231: fix LQI / frame reading

### DIFF
--- a/drivers/at86rf231/at86rf231_rx.c
+++ b/drivers/at86rf231/at86rf231_rx.c
@@ -43,10 +43,11 @@ void at86rf231_rx_handler(void)
 
     /* read psdu, read packet with length as first byte and lqi as last byte. */
     uint8_t *buf = buffer[rx_buffer_next];
-    at86rf231_read_fifo(buf, length + 2);
+    at86rf231_read_fifo(buf, length + 3);
 
     /* read lqi which is appended after the psdu */
     lqi = buf[length + 1];
+    uint8_t ed = buf[length + 2];
 
     /* read fcs and rssi, from a register */
     fcs_rssi = at86rf231_reg_read(AT86RF231_REG__PHY_RSSI);
@@ -54,7 +55,7 @@ void at86rf231_rx_handler(void)
     /* build package */
     at86rf231_rx_buffer[rx_buffer_next].lqi = lqi;
     /* RSSI has no meaning here, it should be read during packet reception. */
-    at86rf231_rx_buffer[rx_buffer_next].rssi = fcs_rssi & 0x1F;  /* bit[4:0] */
+    at86rf231_rx_buffer[rx_buffer_next].rssi = ed;
     /* bit7, boolean, 1 FCS valid, 0 FCS not valid */
     at86rf231_rx_buffer[rx_buffer_next].crc = (fcs_rssi >> 7) & 0x01;
 

--- a/drivers/at86rf231/at86rf231_rx.c
+++ b/drivers/at86rf231/at86rf231_rx.c
@@ -36,16 +36,17 @@ extern netdev_802154_raw_packet_cb_t at86rf231_raw_packet_cb;
 
 void at86rf231_rx_handler(void)
 {
-    uint8_t lqi, fcs_rssi;
-    /* read packet length */
-    at86rf231_read_fifo(&at86rf231_rx_buffer[rx_buffer_next].length, 1);
+    uint8_t lqi, fcs_rssi, length;
+    /* read packet length (PHR) */
+    at86rf231_read_fifo(&length, 1);
+    at86rf231_rx_buffer[rx_buffer_next].length = length;
 
     /* read psdu, read packet with length as first byte and lqi as last byte. */
     uint8_t *buf = buffer[rx_buffer_next];
-    at86rf231_read_fifo(buf, at86rf231_rx_buffer[rx_buffer_next].length);
+    at86rf231_read_fifo(buf, length + 2);
 
     /* read lqi which is appended after the psdu */
-    lqi = buf[at86rf231_rx_buffer[rx_buffer_next].length - 1];
+    lqi = buf[length + 1];
 
     /* read fcs and rssi, from a register */
     fcs_rssi = at86rf231_reg_read(AT86RF231_REG__PHY_RSSI);


### PR DESCRIPTION
According to the **AT86RF233** datasheet, a "frame" read operation starts with one byte `PHR` indicating the length of the `PSDU` and ends with up to three bytes `LQI`, `ED`, `RX_STATUS` (after the `PSDU`). Since we only care for `LQI`, read it and ignore the rest.

I'm a bit confused by the data sheet and the current implementation - is this different for the `AT86RF231`?

I'll fix the commit message etc. once this is cleared up.