### PR TITLE
dist/tools/licenses: support BSD sed

### DIFF
--- a/dist/tools/licenses/check.sh
+++ b/dist/tools/licenses/check.sh
@@ -13,6 +13,9 @@ OUTPUT="${CHECKROOT}/out"
 UNKNOWN="${OUTPUT}/unknown"
 TMP="${CHECKROOT}/.tmp"
 
+# Needed for compatibility with BSD sed
+TAB_CHAR="$(printf '\t')"
+
 # prepare
 ROOT=$(git rev-parse --show-toplevel)
 LICENSES=$(ls "${LICENSEDIR}")
@@ -63,7 +66,7 @@ fi
 # categorize files
 for FILE in ${FILES}; do
     FAIL=1
-    head -100 "${ROOT}/${FILE}" | sed -e 's/[\/\*\t]/ /g' -e 's/$/ /' | tr -d '\r\n' | sed -e 's/  */ /g' > "${TMP}"
+    head -100 "${ROOT}/${FILE}" | sed -e 's/[\/\*'"${TAB_CHAR}"']/ /g' -e 's/$/ /' | tr -d '\r\n' | sed -e 's/  */ /g' > "${TMP}"
     for LICENSE in ${LICENSES}; do
         if pcregrep -q -f "${LICENSEDIR}/${LICENSE}" "${TMP}"; then
             echo "${FILE}" >> "${OUTPUT}/${LICENSE}"


### PR DESCRIPTION
This adds support for BSD sed for the license checker. It now works on at least FreeBSD 9 and OS X 10.10. I also tested it on CentOS 6 and Debian 7 (with pcregrep installed) to make sure there are no regressions introduced.
