### PR TITLE
drivers/at86rf231: fix reading of rssi value

### DIFF
--- a/drivers/at86rf231/at86rf231_rx.c
+++ b/drivers/at86rf231/at86rf231_rx.c
@@ -53,7 +53,7 @@ void at86rf231_rx_handler(void)
     /* build package */
     at86rf231_rx_buffer[rx_buffer_next].lqi = lqi;
     /* RSSI has no meaning here, it should be read during packet reception. */
-    at86rf231_rx_buffer[rx_buffer_next].rssi = fcs_rssi & 0x0F;  // bit[4:0]
+    at86rf231_rx_buffer[rx_buffer_next].rssi = fcs_rssi & 0x1F;  /* bit[4:0] */
     /* bit7, boolean, 1 FCS valid, 0 FCS not valid */
     at86rf231_rx_buffer[rx_buffer_next].crc = (fcs_rssi >> 7) & 0x01;
 

--- a/drivers/include/at86rf231.h
+++ b/drivers/include/at86rf231.h
@@ -76,7 +76,7 @@ typedef struct __attribute__((packed))
     /** @{ */
     uint8_t length;             /**< the length of the frame of the frame including fcs*/
     ieee802154_frame_t frame;   /**< the ieee802154 frame */
-    int8_t rssi;                /**< the rssi value */
+    uint8_t rssi;               /**< the rssi value */
     uint8_t crc;                /**< 1 if crc was successfull, 0 otherwise */
     uint8_t lqi;                /**< the link quality indicator */
     /** @} */


### PR DESCRIPTION
Currently one bit of the rssi value gets dropped.