### PR TITLE
pktqueue: adapt to pkt_t

### DIFF
--- a/sys/net/include/pktqueue.h
+++ b/sys/net/include/pktqueue.h
@@ -13,7 +13,7 @@
  * @{
  *
  * @file        pktqueue.h
- * @brief       Pointer-centric wrapper for @ref priority_queue_t
+ * @brief       `pkt_t`-centric wrapper for @ref priority_queue_t
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
@@ -24,6 +24,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "pkt.h"
 #include "priority_queue.h"
 
 #ifdef __cplusplus
@@ -38,7 +39,7 @@ extern "C" {
 typedef struct pktqueue_node_t {
     struct pktqueue_node_t *next;   /**< next node in queue */
     uint32_t priority;              /**< priority of the node */
-    void *data;                     /**< pointer to the data */
+    pkt_t *data;                    /**< pointer to the data */
 } pktqueue_node_t;
 
 /**

--- a/tests/unittests/tests-pktqueue/tests-pktqueue.c
+++ b/tests/unittests/tests-pktqueue/tests-pktqueue.c
@@ -15,6 +15,7 @@
 
 #include "embUnit.h"
 
+#include "pkt.h"
 #include "pktqueue.h"
 
 #include "tests-pktqueue.h"
@@ -48,14 +49,14 @@ static void test_pktqueue_remove_head_one(void)
     pktqueue_t *root = &q;
     pktqueue_node_t *elem = &(qe[1]), *res;
 
-    elem->data = (void *)62801;
+    elem->data = (pkt_t *)62801;
 
     pktqueue_add(root, elem);
 
     res = pktqueue_remove_head(root);
 
     TEST_ASSERT(res == elem);
-    TEST_ASSERT(((void *)62801) == res->data);
+    TEST_ASSERT(((pkt_t *)62801) == res->data);
 
     res = pktqueue_remove_head(root);
 
@@ -67,13 +68,13 @@ static void test_pktqueue_add_one(void)
     pktqueue_t *root = &q;
     pktqueue_node_t *elem = &(qe[1]);
 
-    elem->data = (void *)7317;
+    elem->data = (pkt_t *)7317;
     elem->priority = 713643658;
 
     pktqueue_add(root, elem);
 
     TEST_ASSERT(root->first == elem);
-    TEST_ASSERT(((void *)7317) == root->first->data);
+    TEST_ASSERT(((pkt_t *)7317) == root->first->data);
     TEST_ASSERT_EQUAL_INT(713643658, root->first->priority);
 
     TEST_ASSERT_NULL(root->first->next);
@@ -84,21 +85,21 @@ static void test_pktqueue_add_two_equal(void)
     pktqueue_t *root = &q;
     pktqueue_node_t *elem1 = &(qe[1]), *elem2 = &(qe[2]);
 
-    elem1->data = (void *)27088;
+    elem1->data = (pkt_t *)27088;
     elem1->priority = 14202;
 
-    elem2->data = (void *)4356;
+    elem2->data = (pkt_t *)4356;
     elem2->priority = 14202;
 
     pktqueue_add(root, elem1);
     pktqueue_add(root, elem2);
 
     TEST_ASSERT(root->first == elem1);
-    TEST_ASSERT(((void *)27088) == root->first->data);
+    TEST_ASSERT(((pkt_t *)27088) == root->first->data);
     TEST_ASSERT_EQUAL_INT(14202, root->first->priority);
 
     TEST_ASSERT(root->first->next == elem2);
-    TEST_ASSERT(((void *)4356) == root->first->next->data);
+    TEST_ASSERT(((pkt_t *)4356) == root->first->next->data);
     TEST_ASSERT_EQUAL_INT(14202, root->first->next->priority);
 
     TEST_ASSERT_NULL(root->first->next->next);
@@ -109,21 +110,21 @@ static void test_pktqueue_add_two_distinct(void)
     pktqueue_t *root = &q;
     pktqueue_node_t *elem1 = &(qe[1]), *elem2 = &(qe[2]);
 
-    elem1->data = (void *)46421;
+    elem1->data = (pkt_t *)46421;
     elem1->priority = 4567;
 
-    elem2->data = (void *)43088;
+    elem2->data = (pkt_t *)43088;
     elem2->priority = 1234;
 
     pktqueue_add(root, elem1);
     pktqueue_add(root, elem2);
 
     TEST_ASSERT(root->first == elem2);
-    TEST_ASSERT(((void *)43088) == root->first->data);
+    TEST_ASSERT(((pkt_t *)43088) == root->first->data);
     TEST_ASSERT_EQUAL_INT(1234, root->first->priority);
 
     TEST_ASSERT(root->first->next == elem1);
-    TEST_ASSERT(((void *)46421) == root->first->next->data);
+    TEST_ASSERT(((pkt_t *)46421) == root->first->next->data);
     TEST_ASSERT_EQUAL_INT(4567, root->first->next->priority);
 
     TEST_ASSERT_NULL(root->first->next->next);


### PR DESCRIPTION
Use `pkt_t` instead of `void` pointers to be consistent with new `pktbuf` API (#2285).

~~Depends on #2158.~~