### PR TITLE
drivers/periph/spi: added means to make SPI thread-safe

### DIFF
--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -123,6 +123,28 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data));
 int spi_conf_pins(spi_t dev);
 
 /**
+ * @brief Get mutually exclusive access to the given SPI bus
+ *
+ * In case the SPI device is busy, this function will block until the bus is free again.
+ *
+ * @param[in] dev       SPI device to access
+ *
+ * @return              0 on success
+ * @return              -1 on error
+ */
+int spi_acquire(spi_t dev);
+
+/**
+ * @brief Release the given SPI device to be used by others
+ *
+ * @param[in] dev       SPI device to release
+ *
+ * @return              0 on success
+ * @return              -1 on error
+ */
+int spi_release(spi_t dev);
+
+/**
  * @brief Transfer one byte on the given SPI bus
  *
  * @param[in] dev       SPI device to use


### PR DESCRIPTION
extended the SPI driver's API with locking/unlocking functions and implemented them exemplary for the `stm32f4`.

These functions are needed for applications that share a SPI bus for more then one slave device, e.g. 2 sensors, while their drivers run in separate threads.

Usage:
```c
...
spi_aquire(SPI_x);
gpio_set(CS_PIN);
spi_transfer(SPI_X, ...);
gpio_clear(CS_PIN);
spi_release(SPI_X);
...
```

The price to pay:
```
for 1 configured SPI interface:    84 byte ROM and  8 byte RAM
for 2 configured SPI interfaces:  112 byte ROM and 16 byte RAM
(compiling the tests/periph_spi application)
```