### PR TITLE
examples/rpl_udp: changed type of variable `chan` to `uint32_t`

### DIFF
--- a/examples/rpl_udp/rpl.c
+++ b/examples/rpl_udp/rpl.c
@@ -44,7 +44,7 @@ void rpl_udp_init(int argc, char **argv)
 {
     transceiver_command_t tcmd;
     msg_t m;
-    uint8_t chan = RADIO_CHANNEL;
+    uint32_t chan = RADIO_CHANNEL;
 
     if (argc != 2) {
         printf("Usage: %s (r|n|h)\n", argv[0]);


### PR DESCRIPTION
Setting the channel for a transceiver results in writing the actual set channel value to the passed variable providing the desired value [1].
The `rpl_udp` example uses `uint8_t` for the provided variable which can result in overwriting the stack of other values.  

[1] https://github.com/RIOT-OS/RIOT/blob/master/sys/transceiver/transceiver.c#L319 