### PR TITLE
make: add target to list available targets

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -140,7 +140,7 @@ BASELIBS += $(BINDIR)$(BOARD)_base.a
 BASELIBS += $(BINDIR)${APPLICATION}.a
 BASELIBS += $(USEPKG:%=${BINDIR}%.a)
 
-.PHONY: all clean flash term doc debug debug-server reset objdump
+.PHONY: all clean flash term doc debug debug-server reset objdump help
 
 ELFFILE ?= $(BINDIR)$(APPLICATION).elf
 HEXFILE ?= $(ELFFILE:.elf=.hex)
@@ -302,3 +302,6 @@ else # RIOT_VERSION
 	$(MAKE) RIOTBASE=$(<D) $(filter-out clean, ${MAKECMDGOALS})
 
 endif
+
+help:
+	@$(MAKE) -qp | sed -ne 's/\(^[a-z][a-z_-]*\):.*/\1/p' | sort | uniq


### PR DESCRIPTION
There are a plenty of helpful targets in RIOT's build system but I doubt that most people will ever find them. Maybe this helps a little bit.