### PR TITLE
cc110x: header cleanups

### DIFF
--- a/drivers/include/cc110x_legacy/cc110x-config.h
+++ b/drivers/include/cc110x_legacy/cc110x-config.h
@@ -71,30 +71,30 @@ typedef struct {
 
 /** CC1100 radio configuration */
 typedef struct {
-    cc110x_reg_t reg_cfg;       ///< CC1100 register configuration
-    uint8_t pa_power;           ///< Output power setting
+    cc110x_reg_t reg_cfg;       /**< CC1100 register configuration */
+    uint8_t pa_power;           /**< Output power setting */
 } cc110x_cfg_t;
 
 /**
  * @brief   Radio Control Flags
  */
 typedef struct {
-    uint32_t TOF;               ///< Time of flight of the last packet and last ACK
-    timex_t  TOA;               ///< Time of packet arriveal
-    uint32_t TCP;               ///< Time to compute packet
-    unsigned RPS        : 16;   ///< Raw packets sent to transmit last packet
-    unsigned RETC       : 8;    ///< Retransmission count of last send packet
-    unsigned _RSSI      : 8;    ///< The RSSI value of last received packet
-    unsigned RSSI_SEND  : 8;    ///< The RSSI value of the last send unicast packet of this node
-    unsigned _LQI       : 8;    ///< The LQI value of the last received packet
-    unsigned LL_ACK     : 1;    ///< Is set if Link-Level ACK is received, otherwise 0 (reset on new burst)
-    unsigned CAA        : 1;    ///< The status of the air (1 = air free, 0 = air not free)
-    unsigned CRC_STATE  : 1;    ///< The CRC status of last received packet (1 = OK, 0 = not OK)
-    unsigned SEQ        : 1;    ///< Sequence number (toggles between 0 and 1)
-    unsigned MAN_WOR    : 1;    ///< Manual WOR set (for randomized WOR times => no synch)
-    unsigned KT_RES_ERR : 1;    ///< A hwtimer resource error has occurred (no free timers available)
-    unsigned TX         : 1;    ///< State machine TX lock, only ACKs will be received
-    unsigned WOR_RST    : 1;    ///< Reset CC1100 real time clock (WOR) on next WOR strobe
+    uint32_t TOF;               /**< Time of flight of the last packet and last ACK */
+    timex_t  TOA;               /**< Time of packet arrival */
+    uint32_t TCP;               /**< Time to compute packet */
+    unsigned RPS        : 16;   /**< Raw packets sent to transmit last packet */
+    unsigned RETC       : 8;    /**< Retransmission count of last sent packet */
+    unsigned _RSSI      : 8;    /**< The RSSI value of last received packet */
+    unsigned RSSI_SEND  : 8;    /**< The RSSI value of the last sent unicast packet of this node */
+    unsigned _LQI       : 8;    /**< The LQI value of the last received packet */
+    unsigned LL_ACK     : 1;    /**< Is set if Link-Level ACK is received, otherwise 0 (reset on new burst) */
+    unsigned CAA        : 1;    /**< The status of the air (1 = air free, 0 = air not free) */
+    unsigned CRC_STATE  : 1;    /**< The CRC status of last received packet (1 = OK, 0 = not OK) */
+    unsigned SEQ        : 1;    /**< Sequence number (toggles between 0 and 1) */
+    unsigned MAN_WOR    : 1;    /**< Manual WOR set (for randomized WOR times => no synch) */
+    unsigned KT_RES_ERR : 1;    /**< A hwtimer resource error has occurred (no free timers available) */
+    unsigned TX         : 1;    /**< State machine TX lock, only ACKs will be received */
+    unsigned WOR_RST    : 1;    /**< Reset CC1100 real time clock (WOR) on next WOR strobe */
 } cc110x_flags;
 
 /**

--- a/drivers/include/cc110x_legacy/cc110x-defaultSettings.h
+++ b/drivers/include/cc110x_legacy/cc110x-defaultSettings.h
@@ -26,60 +26,60 @@
 extern "C" {
 #endif
 
-// returns hwtimer ticks per us
+/* returns hwtimer ticks per us */
 #define RTIMER_TICKS(us) HWTIMER_TICKS(us)
 
 #define TIMER_TICK_USEC_RES     (122)
 
-// Watchdog cycle time in seconds, set 0 to disable watchdog
+/* Watchdog cycle time in seconds, set 0 to disable watchdog */
 #define CC1100_WATCHDOG_PERIOD  (5)
 
-// Number of transmission retries for unicast packets (constant RX mode)
+/* Number of transmission retries for unicast packets (constant RX mode) */
 #define TRANSMISSION_RETRIES_CRX_UC     (5)
 
-// Number of transmission retries for unicast packets (WOR mode)
+/* Number of transmission retries for unicast packets (WOR mode) */
 #define TRANSMISSION_RETRIES_WOR_UC     (1)
 
-// Number of transmission retries for broadcast packets (constant RX mode)
+/* Number of transmission retries for broadcast packets (constant RX mode) */
 #define TRANSMISSION_RETRIES_CRX_BC     (0)
 
-// Number of transmission retries for broadcast packets (WOR mode)
+/* Number of transmission retries for broadcast packets (WOR mode) */
 #define TRANSMISSION_RETRIES_WOR_BC     (0)
 
-// Time before chip goes back to RX (= stays in PWD after incoming packet)
-#define WOR_TIMEOUT_1           (3200)  // ~ 32 milliseconds
+/* Time before chip goes back to RX (= stays in PWD after incoming packet) */
+#define WOR_TIMEOUT_1           (3200)  /* ~ 32 milliseconds */
 
-// Time before chip goes back to WOR (= stays in RX after elapsed WOR_TIMEOUT_1)
-#define WOR_TIMEOUT_2           (800)   // ~ 8 milliseconds
+/* Time before chip goes back to WOR (= stays in RX after elapsed WOR_TIMEOUT_1) */
+#define WOR_TIMEOUT_2           (800)   /* ~ 8 milliseconds */
 
-// XOSC startup + FS calibration (300 + 809 us  ~ 1.38 ms)
+/* XOSC startup + FS calibration (300 + 809 us  ~ 1.38 ms) */
 #define FS_CAL_TIME             RTIMER_TICKS(12 * TIMER_TICK_USEC_RES)
 
-// Manual FS calibration (721 us)
+/* Manual FS calibration (721 us) */
 #define MANUAL_FS_CAL_TIME      RTIMER_TICKS(7 * TIMER_TICK_USEC_RES)
 
-// Reset wait time (in reset procedure)
+/* Reset wait time (in reset procedure) */
 #define RESET_WAIT_TIME         RTIMER_TICKS(4 * TIMER_TICK_USEC_RES)
 
-// Time chip needs to go to RX
+/* Time chip needs to go to RX */
 #define IDLE_TO_RX_TIME         RTIMER_TICKS(1 * TIMER_TICK_USEC_RES)
 
-// Time chip needs to go to RX and CS signal is ready
+/* Time chip needs to go to RX and CS signal is ready */
 #define CS_READY_TIME           RTIMER_TICKS(3 * TIMER_TICK_USEC_RES)
 
-// Default RX interval for WOR in milliseconds
+/* Default RX interval for WOR in milliseconds */
 #define T_RX_INTERVAL           (542)
 
-// Time of packet interval in microseconds (at 400 kbps)
+/* Time of packet interval in microseconds (at 400 kbps) */
 #define T_PACKET_INTERVAL       (3800)
 
-// The size of the configuration array for CC1100 in bytes
+/* The size of the configuration array for CC1100 in bytes */
 #define CC1100_CONF_SIZE        (39)
 
-// The default channel number (0-24) for CC1100
+/* The default channel number (0-24) for CC1100 */
 #define CC1100_DEFAULT_CHANNR   (0)
 
-// Burst retry to TX switch time (measured ~ 230 us)
+/* Burst retry to TX switch time (measured ~ 230 us) */
 #define BURST_RETRY_TX_SWITCH_TIME  (23)
 
 #ifdef __cplusplus

--- a/drivers/include/cc110x_legacy/cc110x-interface.h
+++ b/drivers/include/cc110x_legacy/cc110x-interface.h
@@ -33,24 +33,25 @@
 extern "C" {
 #endif
 
-#define CC1100_MAX_DATA_LENGTH (58)
+#define CC1100_MAX_DATA_LENGTH      (58)
 
-#define CC1100_HEADER_LENGTH   (3)             ///< Header covers SRC, DST and FLAGS
+#define CC1100_HEADER_LENGTH         (3) /**< Header covers SRC, DST and FLAGS */
 
-#define CC1100_BROADCAST_ADDRESS (0x00) ///< CC1100 broadcast address
+#define CC1100_BROADCAST_ADDRESS  (0x00) /**< CC1100 broadcast address */
 
-#define MAX_UID                  (0xFF) ///< Maximum UID of a node is 255
-#define MIN_UID                  (0x01) ///< Minimum UID of a node is 1
+#define MAX_UID                   (0xFF) /**< Maximum UID of a node is 255 */
+#define MIN_UID                   (0x01) /**< Minimum UID of a node is 1 */
 
-#define MIN_CHANNR                  (0) ///< Minimum channel number
-#define MAX_CHANNR                 (24) ///< Maximum channel number
+#define MIN_CHANNR                   (0) /**< Minimum channel number */
+#define MAX_CHANNR                  (24) /**< Maximum channel number */
 
-#define MIN_OUTPUT_POWER            (0) ///< Minimum output power value
-#define MAX_OUTPUT_POWER           (11) ///< Maximum output power value
+#define MIN_OUTPUT_POWER             (0) /**< Minimum output power value */
+#define MAX_OUTPUT_POWER            (11) /**< Maximum output power value */
 
-#define PACKET_LENGTH               (0x3E)      ///< Packet length = 62 Bytes.
-#define CC1100_SYNC_WORD_TX_TIME   (90000)      // loop count (max. timeout ~ 15 ms) to wait for
-                                                // sync word to be transmitted (GDO2 from low to high)
+#define PACKET_LENGTH             (0x3E) /**< Packet length = 62 Bytes. */
+#define CC1100_SYNC_WORD_TX_TIME (90000) /**< loop count (max. timeout ~15 ms)
+                                          * to wait for sync word to be
+                                          * transmitted (GDO2 from low to high) */
 /**
  * @name    Defines used as state values for state machine
  * @{
@@ -66,7 +67,7 @@ extern "C" {
 
 /** @} */
 
-extern volatile cc110x_flags rflags;    ///< Radio flags
+extern volatile cc110x_flags rflags;    /**< Radio flags */
 extern char cc110x_conf[];
 
 /**
@@ -94,11 +95,11 @@ Notes:
  */
 typedef struct __attribute__((packed))
 {
-    uint8_t length;                         ///< Length of the packet (without length byte)
-    uint8_t address;                        ///< Destination address
-    uint8_t phy_src;                        ///< Source address (physical source)
-    uint8_t flags;                          ///< Flags
-    uint8_t data[CC1100_MAX_DATA_LENGTH];   ///< Data (high layer protocol)
+    uint8_t length;                         /**< Length of the packet (without length byte) */
+    uint8_t address;                        /**< Destination address */
+    uint8_t phy_src;                        /**< Source address (physical source) */
+    uint8_t flags;                          /**< Flags */
+    uint8_t data[CC1100_MAX_DATA_LENGTH];   /**< Data (high layer protocol) */
 }
 cc110x_packet_t;
 
@@ -109,16 +110,16 @@ typedef struct {
 } rx_buffer_t;
 
 enum radio_mode {
-    RADIO_MODE_GET  = -1,       ///< leave mode unchanged
-    RADIO_MODE_OFF  = 0,        ///< turn radio off
-    RADIO_MODE_ON   = 1         ///< turn radio on
+    RADIO_MODE_GET  = -1,       /**< leave mode unchanged */
+    RADIO_MODE_OFF  = 0,        /**< turn radio off */
+    RADIO_MODE_ON   = 1         /**< turn radio on */
 };
 
 extern rx_buffer_t cc110x_rx_buffer[];
 
-extern volatile uint8_t rx_buffer_next;     ///< Next packet in RX queue
+extern volatile uint8_t rx_buffer_next;     /**< Next packet in RX queue */
 
-extern volatile uint8_t radio_state;        ///< Radio state
+extern volatile uint8_t radio_state;        /**< Radio state */
 extern cc110x_statistic_t cc110x_statistic;
 
 void cc110x_init(kernel_pid_t transceiver_pid);

--- a/drivers/include/cc110x_legacy_csma/cc1100-interface.h
+++ b/drivers/include/cc110x_legacy_csma/cc1100-interface.h
@@ -31,24 +31,24 @@
 extern "C" {
 #endif
 
-#define CC1100_BROADCAST_ADDRESS (0x00) ///< CC1100 broadcast address
+#define CC1100_BROADCAST_ADDRESS (0x00) /**< CC1100 broadcast address */
 
-#define MAX_UID                  (0xFF) ///< Maximum UID of a node is 255
-#define MIN_UID                  (0x01) ///< Minimum UID of a node is 1
+#define MAX_UID                  (0xFF) /**< Maximum UID of a node is 255 */
+#define MIN_UID                  (0x01) /**< Minimum UID of a node is 1 */
 
-#define MIN_CHANNR                  (0) ///< Minimum channel number
-#define MAX_CHANNR                 (24) ///< Maximum channel number
+#define MIN_CHANNR                  (0) /**< Minimum channel number */
+#define MAX_CHANNR                 (24) /**< Maximum channel number */
 
-#define MIN_OUTPUT_POWER            (0) ///< Minimum output power value
-#define MAX_OUTPUT_POWER           (11) ///< Maximum output power value
+#define MIN_OUTPUT_POWER            (0) /**< Minimum output power value */
+#define MAX_OUTPUT_POWER           (11) /**< Maximum output power value */
 
-#define CC1100_MODE_WOR             (0) ///< Usable radio mode: Wake-On-Radio
-#define CC1100_MODE_CONSTANT_RX     (1) ///< Usable radio mode: Constant receive
+#define CC1100_MODE_WOR             (0) /**< Usable radio mode: Wake-On-Radio */
+#define CC1100_MODE_CONSTANT_RX     (1) /**< Usable radio mode: Constant receive */
 
 #define CC1100_MAX_DATA_LENGTH (58)
 
-// Define default radio mode to constant RX if no
-// application specific setting is available.
+/* Define default radio mode to constant RX if no application specific setting
+ * is available. */
 #ifndef CC1100_RADIO_MODE
 #ifdef MODULE_RPL
 #warning RPL currently works with CC1100_MODE_WOR


### PR DESCRIPTION
I stumbled across some empty `extern "C"` and C++ style comments in the cc110x headers. This PR removes the empty `extern "C"` and replaces the comments with C style comments (`/*  xxxx */`).