### PR TITLE
travis: disable qemu unittests temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,10 @@ script:
     - ./dist/tools/cppcheck/check.sh master --diff-filter=AC || exit
 
     - make -C ./tests/unittests all test BOARD=native || exit
-    - make -C ./tests/unittests all test BOARD=qemu-i386 || exit
+# TODO:
+#   Reenable once https://github.com/RIOT-OS/RIOT/issues/2300 is
+#   resolved:
+#   - make -C ./tests/unittests all test BOARD=qemu-i386 || exit
 
     - ./dist/tools/compile_test/compile_test.py
     - ./dist/tools/pr_check/pr_check.sh riot/master


### PR DESCRIPTION
Just a workaround for #2300 to quickly re-enable our CI.