### PR TITLE
sys/timex: suppress passedByValue warnings

### DIFF
--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -67,6 +67,7 @@ typedef struct {
  *
  * @return The sum of the two timestamps
  */
+/* cppcheck-suppress passedByValue */
 timex_t timex_add(const timex_t a, const timex_t b);
 
 /**
@@ -77,6 +78,7 @@ timex_t timex_add(const timex_t a, const timex_t b);
  *
  * @return The difference a - b
  */
+/* cppcheck-suppress passedByValue */
 timex_t timex_sub(const timex_t a, const timex_t b);
 
 /**
@@ -99,6 +101,7 @@ timex_t timex_set(uint32_t seconds, uint32_t microseconds);
  * @return 0 if equal
  * @return 1 if a is bigger
  */
+/* cppcheck-suppress passedByValue */
 int timex_cmp(const timex_t a, const timex_t b);
 
 /**
@@ -132,6 +135,7 @@ static inline int timex_isnormalized(timex_t *time)
  *
  * @return timex representation as uint64_t
  */
+/* cppcheck-suppress passedByValue */
 static inline uint64_t timex_uint64(const timex_t a)
 {
     return (uint64_t) a.seconds * SEC_IN_USEC + a.microseconds;


### PR DESCRIPTION
In #2155 the build failed like https://travis-ci.org/RIOT-OS/RIOT/builds/46896962 because the changeset included calls to this API. This should not happen.