### PR TITLE
Cortex-M(3|4): `atomic_arch_set_return()` without `disableIRQ()`

### DIFF
--- a/cpu/cortex-m3_common/atomic_arch.c
+++ b/cpu/cortex-m3_common/atomic_arch.c
@@ -1,32 +1,37 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin
  *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
  */
 
 /**
  * @ingroup     cpu_cortex-m3
  * @{
  *
- * @file        atomic_arch.c
+ * @file
  * @brief       Implementation of the kernels atomic interface
  *
  * @author      Stefan Pfeiffer <stefan.pfeiffer@fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Joakim Gebart <joakim.gebart@eistec.se>
  *
  * @}
  */
 
 #include "arch/atomic_arch.h"
-#include "irq.h"
+#include "cpu.h"
 
 unsigned int atomic_arch_set_return(unsigned int *to_set, unsigned int value)
 {
-    disableIRQ();
-    unsigned int old = *to_set;
-    *to_set = value;
-    enableIRQ();
+    int status;
+    unsigned int old;
+    do {
+        /* Load exclusive */
+        old = __LDREXW((volatile uint32_t*)to_set);
+        /* Try to write the new value */
+        status = __STREXW(value, (volatile uint32_t*)to_set);
+    } while (status != 0); /* retry until load-store cycle was exclusive. */
     return old;
 }

--- a/cpu/cortex-m3_common/atomic_arch.c
+++ b/cpu/cortex-m3_common/atomic_arch.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     cpu_cortex-m3
+ * @ingroup     cpu_cortexm3_common
  * @{
  *
  * @file

--- a/cpu/cortex-m3_common/doc.txt
+++ b/cpu/cortex-m3_common/doc.txt
@@ -1,5 +1,0 @@
-/**
- * @defgroup    cpu_cortex-m3 Cortex-M3 common
- * @brief       ARM Cortex-M specific code
- * @ingroup     cpu
- */

--- a/cpu/cortex-m3_common/include/cpu.h
+++ b/cpu/cortex-m3_common/include/cpu.h
@@ -7,7 +7,9 @@
  */
 
 /**
- * @addtogroup  cpu_cortex-m3
+ * @defgroup    cpu_cortexm3_common ARM Cortex-M3 common
+ * @ingroup     cpu
+ * @brief       Common implementations and headers for Cortex-M3 family based micro-controllers
  * @{
  *
  * @file

--- a/cpu/cortex-m3_common/irq_arch.c
+++ b/cpu/cortex-m3_common/irq_arch.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     cpu_cortex-m3
+ * @ingroup     cpu_cortexm3_common
  * @{
  *
  * @file        irq_arch.c

--- a/cpu/cortex-m3_common/thread_arch.c
+++ b/cpu/cortex-m3_common/thread_arch.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     cpu_cortex-m3
+ * @ingroup     cpu_cortexm3_common
  * @{
  *
  * @file        thread_arch.c


### PR DESCRIPTION
This PR is an experimental branch for performing atomic operations without the need to disable interrupts.

Todo: 
 - [x] compare sizes before and after the change.
 - [ ] Test thoroughly on all cortex platforms