### PR TITLE
cpu/stm32f4: added lost port clock eanble

### DIFF
--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -198,97 +198,97 @@ extern "C" {
 /* GPIO channel 0 config */
 #define GPIO_0_PORT         GPIOA                   /* User Button 2 */
 #define GPIO_0_PIN          0
-#define GPIO_0_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define GPIO_0_CLK          0                       /* 0: PORT A, 1: B ... */
 #define GPIO_0_EXTI_CFG()   (SYSCFG->EXTICR[0] |= SYSCFG_EXTICR1_EXTI0_PA)
 #define GPIO_0_IRQ          EXTI0_IRQn
 /* GPIO channel 1 config */
 #define GPIO_1_PORT         GPIOA
 #define GPIO_1_PIN          1
-#define GPIO_1_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define GPIO_1_CLK          0
 #define GPIO_1_EXTI_CFG()   (SYSCFG->EXTICR[0] |= SYSCFG_EXTICR1_EXTI1_PA)
 #define GPIO_1_IRQ          EXTI1_IRQn
 /* GPIO channel 2 config */
 #define GPIO_2_PORT         GPIOA                   /* CC1101 GDO1 */
 #define GPIO_2_PIN          6
-#define GPIO_2_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define GPIO_2_CLK          0
 #define GPIO_2_EXTI_CFG()   (SYSCFG->EXTICR[1] |= SYSCFG_EXTICR2_EXTI6_PA)
 #define GPIO_2_IRQ          EXTI9_5_IRQn
 /* GPIO channel 3 config */
 #define GPIO_3_PORT         GPIOA                   /* CC3000 SPI_IRQ */
 #define GPIO_3_PIN          10
-#define GPIO_3_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define GPIO_3_CLK          0
 #define GPIO_3_EXTI_CFG()   (SYSCFG->EXTICR[2] |= SYSCFG_EXTICR3_EXTI10_PA)
 #define GPIO_3_IRQ          EXTI15_10_IRQn
 /* GPIO channel 4 config */
 #define GPIO_4_PORT         GPIOB
 #define GPIO_4_PIN          0
-#define GPIO_4_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define GPIO_4_CLK          1
 #define GPIO_4_EXTI_CFG()   (SYSCFG->EXTICR[0] |= SYSCFG_EXTICR1_EXTI0_PB)
 #define GPIO_4_IRQ          EXTI0_IRQn
 /* GPIO channel 5 config */
 #define GPIO_5_PORT         GPIOB                   /* BEEPER Input */
 #define GPIO_5_PIN          9
-#define GPIO_5_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define GPIO_5_CLK          1
 #define GPIO_5_EXTI_CFG()   (SYSCFG->EXTICR[2] |= SYSCFG_EXTICR3_EXTI9_PB)
 #define GPIO_5_IRQ          EXTI9_5_IRQn
 /* GPIO channel 6 config */
 #define GPIO_6_PORT         GPIOB                   /* IMU-9150 INT */
 #define GPIO_6_PIN          11
-#define GPIO_6_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define GPIO_6_CLK          1
 #define GPIO_6_EXTI_CFG()   (SYSCFG->EXTICR[2] |= SYSCFG_EXTICR3_EXTI11_PB)
 #define GPIO_6_IRQ          EXTI15_10_IRQn
 /* GPIO channel 7 config */
 #define GPIO_7_PORT         GPIOB                   /* CC1101 CS */
 #define GPIO_7_PIN          12
-#define GPIO_7_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define GPIO_7_CLK          1
 #define GPIO_7_EXTI_CFG()   (SYSCFG->EXTICR[3] |= SYSCFG_EXTICR4_EXTI12_PB)
 #define GPIO_7_IRQ          EXTI15_10_IRQn
 /* GPIO channel 8 config */
 #define GPIO_8_PORT         GPIOB                   /* User Button 1 */
 #define GPIO_8_PIN          13
-#define GPIO_8_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define GPIO_8_CLK          1
 #define GPIO_8_EXTI_CFG()   (SYSCFG->EXTICR[3] |= SYSCFG_EXTICR4_EXTI13_PB)
 #define GPIO_8_IRQ          EXTI15_10_IRQn
 /* GPIO channel 9 config */
 #define GPIO_9_PORT         GPIOC                   /* TCA6416 Reset */
 #define GPIO_9_PIN          0
-#define GPIO_9_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOCEN)
+#define GPIO_9_CLK          2
 #define GPIO_9_EXTI_CFG()   (SYSCFG->EXTICR[0] |= SYSCFG_EXTICR1_EXTI0_PC)
 #define GPIO_9_IRQ          EXTI0_IRQn
 /* GPIO channel 10 config */
 #define GPIO_10_PORT        GPIOC                   /* CC3000 CS */
 #define GPIO_10_PIN         1
-#define GPIO_10_CLKEN()     (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOCEN)
+#define GPIO_10_CLK         2
 #define GPIO_10_EXTI_CFG()  (SYSCFG->EXTICR[0] |= SYSCFG_EXTICR1_EXTI1_PC)
 #define GPIO_10_IRQ         EXTI1_IRQn
 /* GPIO channel 11 config */
 #define GPIO_11_PORT        GPIOC                   /* CC1101 GDO 0 */
 #define GPIO_11_PIN         4
-#define GPIO_11_CLKEN()     (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOCEN)
+#define GPIO_11_CLK         2
 #define GPIO_11_EXTI_CFG()  (SYSCFG->EXTICR[1] |= SYSCFG_EXTICR2_EXTI4_PC)
 #define GPIO_11_IRQ         EXTI4_IRQn
 /* GPIO channel 12 config */
 #define GPIO_12_PORT        GPIOC                   /* CC1101 GDO 2 */
 #define GPIO_12_PIN         5
-#define GPIO_12_CLKEN()     (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOCEN)
+#define GPIO_12_CLK         2
 #define GPIO_12_EXTI_CFG()  (SYSCFG->EXTICR[1] |= SYSCFG_EXTICR2_EXTI5_PC)
 #define GPIO_12_IRQ         EXTI9_5_IRQn
 /* GPIO channel 13 config */
 #define GPIO_13_PORT        GPIOC                   /* TCA6416 INT */
 #define GPIO_13_PIN         8
-#define GPIO_13_CLKEN()     (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOCEN)
+#define GPIO_13_CLK         2
 #define GPIO_13_EXTI_CFG()  (SYSCFG->EXTICR[2] |= SYSCFG_EXTICR3_EXTI8_PC)
 #define GPIO_13_IRQ         EXTI9_5_IRQn
 /* GPIO channel 14 config */
 #define GPIO_14_PORT        GPIOC                   /* CC3000 VBAT_SW_EN */
 #define GPIO_14_PIN         13
-#define GPIO_14_CLKEN()     (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOCEN)
+#define GPIO_14_CLK         2
 #define GPIO_14_EXTI_CFG()  (SYSCFG->EXTICR[3] |= SYSCFG_EXTICR4_EXTI13_PC)
 #define GPIO_14_IRQ         EXTI15_10_IRQn
 /* GPIO channel 15 config */
 #define GPIO_15_PORT        GPIOD                   /* Micro SD Sockel CS */
 #define GPIO_15_PIN         2
-#define GPIO_15_CLKEN()     (RCC->AHB1ENR |= RCC_AHB1ENR_GPIODEN)
+#define GPIO_15_CLK         3
 #define GPIO_15_EXTI_CFG()  (SYSCFG->EXTICR[0] |= SYSCFG_EXTICR1_EXTI2_PD)
 #define GPIO_15_IRQ         EXTI2_IRQn
 /** @} */

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -162,7 +162,7 @@ extern "C" {
 #define DAC_0_CLKEN()        (RCC->APB1ENR |=  (RCC_APB1ENR_DACEN))
 #define DAC_0_CLKDIS()       (RCC->APB1ENR &= ~(RCC_APB1ENR_DACEN))
 #define DAC_0_PORT           GPIOA
-#define DAC_0_PORT_CLKEN()   (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)     
+#define DAC_0_PORT_CLKEN()   (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
 /* DAC 0 channel config */
 #define DAC_0_CH0_PIN        4
 #define DAC_0_CH1_PIN        5
@@ -332,75 +332,75 @@ extern "C" {
 /* GPIO channel 0 config */
 #define GPIO_0_PORT         GPIOA                   /* Used for user button 1 */
 #define GPIO_0_PIN          0
-#define GPIO_0_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define GPIO_0_CLK          0                       /* 0: PORT A, 1: B ... */
 #define GPIO_0_EXTI_CFG()   (SYSCFG->EXTICR[0] |= SYSCFG_EXTICR1_EXTI0_PA)
 #define GPIO_0_IRQ          EXTI0_IRQn
 /* GPIO channel 1 config */
 #define GPIO_1_PORT         GPIOE                   /* LIS302DL INT1 */
 #define GPIO_1_PIN          0
-#define GPIO_1_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOEEN)
+#define GPIO_1_CLK          4
 #define GPIO_1_EXTI_CFG()   (SYSCFG->EXTICR[0] |= SYSCFG_EXTICR1_EXTI0_PE)
 #define GPIO_1_IRQ          EXTI0_IRQn
 /* GPIO channel 2 config */
 #define GPIO_2_PORT         GPIOE                   /* LIS302DL INT2 */
 #define GPIO_2_PIN          1
-#define GPIO_2_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOEEN)
+#define GPIO_2_CLK          4
 #define GPIO_2_EXTI_CFG()   (SYSCFG->EXTICR[0] |= SYSCFG_EXTICR1_EXTI1_PE)
 #define GPIO_2_IRQ          EXTI1_IRQn
 /* GPIO channel 3 config */
 #define GPIO_3_PORT         GPIOE
 #define GPIO_3_PIN          2
-#define GPIO_3_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOEEN)
+#define GPIO_3_CLK          4
 #define GPIO_3_EXTI_CFG()   (SYSCFG->EXTICR[0] |= SYSCFG_EXTICR1_EXTI2_PE)
 #define GPIO_3_IRQ          EXTI2_IRQn
 /* GPIO channel 4 config */
 #define GPIO_4_PORT         GPIOE                   /* LIS302DL CS */
 #define GPIO_4_PIN          3
-#define GPIO_4_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOEEN)
+#define GPIO_4_CLK          4
 #define GPIO_4_EXTI_CFG()   (SYSCFG->EXTICR[0] |= SYSCFG_EXTICR1_EXTI3_PE)
 #define GPIO_4_IRQ          EXTI3_IRQn
 /* GPIO channel 5 config */
 #define GPIO_5_PORT         GPIOD                   /* CS43L22 RESET */
 #define GPIO_5_PIN          4
-#define GPIO_5_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIODEN)
+#define GPIO_5_CLK          3
 #define GPIO_5_EXTI_CFG()   (SYSCFG->EXTICR[1] |= SYSCFG_EXTICR2_EXTI4_PD)
 #define GPIO_5_IRQ          EXTI4_IRQn
 /* GPIO channel 6 config */
 #define GPIO_6_PORT         GPIOD                   /* LD8 */
 #define GPIO_6_PIN          5
-#define GPIO_6_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIODEN)
+#define GPIO_6_CLK          3
 #define GPIO_6_EXTI_CFG()   (SYSCFG->EXTICR[1] |= SYSCFG_EXTICR2_EXTI5_PD)
 #define GPIO_6_IRQ          EXTI9_5_IRQn
 /* GPIO channel 7 config */
 #define GPIO_7_PORT         GPIOD
 #define GPIO_7_PIN          6
-#define GPIO_7_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIODEN)
+#define GPIO_7_CLK          3
 #define GPIO_7_EXTI_CFG()   (SYSCFG->EXTICR[1] |= SYSCFG_EXTICR2_EXTI6_PD)
 #define GPIO_7_IRQ          EXTI9_5_IRQn
 /* GPIO channel 8 config */
 #define GPIO_8_PORT         GPIOD
 #define GPIO_8_PIN          7
-#define GPIO_8_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIODEN)
+#define GPIO_8_CLK          3
 #define GPIO_8_EXTI_CFG()   (SYSCFG->EXTICR[1] |= SYSCFG_EXTICR2_EXTI7_PD)
 #define GPIO_8_IRQ          EXTI9_5_IRQn
 /* GPIO channel 9 config */
 #define GPIO_9_PORT         GPIOA
 #define GPIO_9_PIN          8
-#define GPIO_9_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define GPIO_9_CLK          0
 #define GPIO_9_EXTI_CFG()   (SYSCFG->EXTICR[2] |= SYSCFG_EXTICR3_EXTI8_PA)
 #define GPIO_9_IRQ          EXTI9_5_IRQn
 /* GPIO channel 10 config */
 #define GPIO_10_PORT        GPIOA                   /* LD7 */
 #define GPIO_10_PIN         9
-#define GPIO_10_CLKEN()     (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
-#define GPIO_10_EXTI_CFG()   (SYSCFG->EXTICR[2] |= SYSCFG_EXTICR3_EXTI9_PA)
-#define GPIO_10_IRQ          EXTI9_5_IRQn
+#define GPIO_10_CLK         0
+#define GPIO_10_EXTI_CFG()  (SYSCFG->EXTICR[2] |= SYSCFG_EXTICR3_EXTI9_PA)
+#define GPIO_10_IRQ         EXTI9_5_IRQn
 /* GPIO channel 11 config */
 #define GPIO_11_PORT        GPIOD
 #define GPIO_11_PIN         10
-#define GPIO_11_CLKEN()     (RCC->AHB1ENR |= RCC_AHB1ENR_GPIODEN)
-#define GPIO_11_EXTI_CFG()   (SYSCFG->EXTICR[2] |= SYSCFG_EXTICR3_EXTI10_PD)
-#define GPIO_11_IRQ          EXTI15_10_IRQn
+#define GPIO_11_CLK         3
+#define GPIO_11_EXTI_CFG()  (SYSCFG->EXTICR[2] |= SYSCFG_EXTICR3_EXTI10_PD)
+#define GPIO_11_IRQ         EXTI15_10_IRQn
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/stm32f4/periph/gpio.c
+++ b/cpu/stm32f4/periph/gpio.c
@@ -196,6 +196,58 @@ static const IRQn_Type gpio_irq_map[GPIO_NUMOF] = {
 #endif
 };
 
+/* static clock mapping */
+static const uint8_t gpio_clock_map[GPIO_NUMOF] = {
+#if GPIO_0_EN
+    [GPIO_0] = GPIO_0_CLK,
+#endif
+#if GPIO_1_EN
+    [GPIO_1] = GPIO_1_CLK,
+#endif
+#if GPIO_2_EN
+    [GPIO_2] = GPIO_2_CLK,
+#endif
+#if GPIO_3_EN
+    [GPIO_3] = GPIO_3_CLK,
+#endif
+#if GPIO_4_EN
+    [GPIO_4] = GPIO_4_CLK,
+#endif
+#if GPIO_5_EN
+    [GPIO_5] = GPIO_5_CLK,
+#endif
+#if GPIO_6_EN
+    [GPIO_6] = GPIO_6_CLK,
+#endif
+#if GPIO_7_EN
+    [GPIO_7] = GPIO_7_CLK,
+#endif
+#if GPIO_8_EN
+    [GPIO_8] = GPIO_8_CLK,
+#endif
+#if GPIO_9_EN
+    [GPIO_9] = GPIO_9_CLK,
+#endif
+#if GPIO_10_EN
+    [GPIO_10] = GPIO_10_CLK,
+#endif
+#if GPIO_11_EN
+    [GPIO_11] = GPIO_11_CLK,
+#endif
+#if GPIO_12_EN
+    [GPIO_12] = GPIO_12_CLK,
+#endif
+#if GPIO_13_EN
+    [GPIO_13] = GPIO_13_CLK,
+#endif
+#if GPIO_14_EN
+    [GPIO_14] = GPIO_14_CLK,
+#endif
+#if GPIO_15_EN
+    [GPIO_15] = GPIO_15_CLK,
+#endif
+};
+
 /**
  * @brief Hold one callback function pointer for each gpio device
  */
@@ -212,6 +264,8 @@ int gpio_init_out(gpio_t dev, gpio_pp_t pullup)
 
     port = gpio_port_map[dev];
     pin = gpio_pin_map[dev];
+
+    RCC->AHB1ENR |= (1 << gpio_clock_map[dev]);
 
     port->MODER &= ~(2 << (2 * pin));           /* set pin to output mode */
     port->MODER |= (1 << (2 * pin));
@@ -235,6 +289,8 @@ int gpio_init_in(gpio_t dev, gpio_pp_t pullup)
 
     port = gpio_port_map[dev];
     pin = gpio_pin_map[dev];
+
+    RCC->AHB1ENR |= (1 << gpio_clock_map[dev]);
 
     port->MODER &= ~(3 << (2 * pin));           /* configure pin as input */
     port->PUPDR &= ~(3 << (2 * pin));           /* configure push-pull resistors */


### PR DESCRIPTION
Seems like I broke the GPIO driver implementation when optimizing it - the ports clock activation got lost... Should be fixed again with this PR.