### PR TITLE
cpu/stm32f0: fixed port clk en for GPIO driver

### DIFF
--- a/boards/stm32f0discovery/include/periph_conf.h
+++ b/boards/stm32f0discovery/include/periph_conf.h
@@ -212,73 +212,73 @@ extern "C" {
 /* GPIO channel 0 config */
 #define GPIO_0_PORT         GPIOA                   /* Used for user button 1 */
 #define GPIO_0_PIN          0
-#define GPIO_0_CLKEN()      (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define GPIO_0_CLK          17                      /* 0: PORT A, 1: B ... */
 #define GPIO_0_EXTI_CFG()   (SYSCFG->EXTICR[0] |= SYSCFG_EXTICR1_EXTI0_PA)
 #define GPIO_0_IRQ          EXTI0_1_IRQn
 /* GPIO channel 1 config */
 #define GPIO_1_PORT         GPIOA
 #define GPIO_1_PIN          1
-#define GPIO_1_CLKEN()      (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define GPIO_1_CLK          17
 #define GPIO_1_EXTI_CFG()   (SYSCFG->EXTICR[0] |= SYSCFG_EXTICR1_EXTI1_PA)
 #define GPIO_1_IRQ          EXTI0_1_IRQn
 /* GPIO channel 2 config */
 #define GPIO_2_PORT         GPIOF
 #define GPIO_2_PIN          4
-#define GPIO_2_CLKEN()      (RCC->AHBENR |= RCC_AHBENR_GPIOFEN)
+#define GPIO_2_CLK          22
 #define GPIO_2_EXTI_CFG()   (SYSCFG->EXTICR[1] |= SYSCFG_EXTICR2_EXTI4_PF)
 #define GPIO_2_IRQ          EXTI4_15_IRQn
 /* GPIO channel 3 config */
 #define GPIO_3_PORT         GPIOF
 #define GPIO_3_PIN          5
-#define GPIO_3_CLKEN()      (RCC->AHBENR |= RCC_AHBENR_GPIOFEN)
+#define GPIO_3_CLK          22
 #define GPIO_3_EXTI_CFG()   (SYSCFG->EXTICR[1] |= SYSCFG_EXTICR2_EXTI5_PF)
 #define GPIO_3_IRQ          EXTI4_15_IRQn
 /* GPIO channel 4 config */
 #define GPIO_4_PORT         GPIOF
 #define GPIO_4_PIN          6
-#define GPIO_4_CLKEN()      (RCC->AHBENR |= RCC_AHBENR_GPIOFEN)
+#define GPIO_4_CLK          22
 #define GPIO_4_EXTI_CFG()   (SYSCFG->EXTICR[1] |= SYSCFG_EXTICR2_EXTI6_PF)
 #define GPIO_4_IRQ          EXTI4_15_IRQn
 /* GPIO channel 5 config */
 #define GPIO_5_PORT         GPIOF
 #define GPIO_5_PIN          7
-#define GPIO_5_CLKEN()      (RCC->AHBENR |= RCC_AHBENR_GPIOFEN)
+#define GPIO_5_CLK          22
 #define GPIO_5_EXTI_CFG()   (SYSCFG->EXTICR[1] |= SYSCFG_EXTICR2_EXTI7_PF)
 #define GPIO_5_IRQ          EXTI4_15_IRQn
 /* GPIO channel 6 config */
 #define GPIO_6_PORT         GPIOC
 #define GPIO_6_PIN          10
-#define GPIO_6_CLKEN()      (RCC->AHBENR |= RCC_AHBENR_GPIOCEN)
+#define GPIO_6_CLK          19
 #define GPIO_6_EXTI_CFG()   (SYSCFG->EXTICR[2] |= SYSCFG_EXTICR3_EXTI10_PC)
 #define GPIO_6_IRQ          EXTI4_15_IRQn
 /* GPIO channel 7 config */
 #define GPIO_7_PORT         GPIOC
 #define GPIO_7_PIN          11
-#define GPIO_7_CLKEN()      (RCC->AHBENR |= RCC_AHBENR_GPIOCEN)
+#define GPIO_7_CLK          19
 #define GPIO_7_EXTI_CFG()   (SYSCFG->EXTICR[2] |= SYSCFG_EXTICR3_EXTI11_PC)
 #define GPIO_7_IRQ          EXTI4_15_IRQn
 /* GPIO channel 8 config */
 #define GPIO_8_PORT         GPIOC
 #define GPIO_8_PIN          12
-#define GPIO_8_CLKEN()      (RCC->AHBENR |= RCC_AHBENR_GPIOCEN)
+#define GPIO_8_CLK          19
 #define GPIO_8_EXTI_CFG()   (SYSCFG->EXTICR[3] |= SYSCFG_EXTICR4_EXTI12_PC)
 #define GPIO_8_IRQ          EXTI4_15_IRQn
 /* GPIO channel 9 config */
 #define GPIO_9_PORT         GPIOC
 #define GPIO_9_PIN          13
-#define GPIO_9_CLKEN()      (RCC->AHBENR |= RCC_AHBENR_GPIOCEN)
+#define GPIO_9_CLK          19
 #define GPIO_9_EXTI_CFG()   (SYSCFG->EXTICR[3] |= SYSCFG_EXTICR4_EXTI13_PC)
 #define GPIO_9_IRQ          EXTI4_15_IRQn
 /* GPIO channel 10 config */
 #define GPIO_10_PORT        GPIOC
 #define GPIO_10_PIN         14
-#define GPIO_10_CLKEN()     (RCC->AHBENR |= RCC_AHBENR_GPIOCEN)
+#define GPIO_10_CLK         19
 #define GPIO_10_EXTI_CFG()  (SYSCFG->EXTICR[3] |= SYSCFG_EXTICR4_EXTI14_PC)
 #define GPIO_10_IRQ         EXTI4_15_IRQn
 /* GPIO channel 11 config */
 #define GPIO_11_PORT        GPIOC
 #define GPIO_11_PIN         15
-#define GPIO_11_CLKEN()     (RCC->AHBENR |= RCC_AHBENR_GPIOCEN)
+#define GPIO_11_CLK         19
 #define GPIO_11_EXTI_CFG()  (SYSCFG->EXTICR[3] |= SYSCFG_EXTICR4_EXTI15_PC)
 #define GPIO_11_IRQ         EXTI4_15_IRQn
 /** @} */

--- a/cpu/stm32f0/periph/gpio.c
+++ b/cpu/stm32f0/periph/gpio.c
@@ -154,6 +154,46 @@ static const IRQn_Type gpio_irq_map[GPIO_NUMOF] = {
 #endif
 };
 
+/* static clock mapping */
+static const uint8_t gpio_clock_map[GPIO_NUMOF] = {
+#if GPIO_0_EN
+    [GPIO_0] = GPIO_0_CLK,
+#endif
+#if GPIO_1_EN
+    [GPIO_1] = GPIO_1_CLK,
+#endif
+#if GPIO_2_EN
+    [GPIO_2] = GPIO_2_CLK,
+#endif
+#if GPIO_3_EN
+    [GPIO_3] = GPIO_3_CLK,
+#endif
+#if GPIO_4_EN
+    [GPIO_4] = GPIO_4_CLK,
+#endif
+#if GPIO_5_EN
+    [GPIO_5] = GPIO_5_CLK,
+#endif
+#if GPIO_6_EN
+    [GPIO_6] = GPIO_6_CLK,
+#endif
+#if GPIO_7_EN
+    [GPIO_7] = GPIO_7_CLK,
+#endif
+#if GPIO_8_EN
+    [GPIO_8] = GPIO_8_CLK,
+#endif
+#if GPIO_9_EN
+    [GPIO_9] = GPIO_9_CLK,
+#endif
+#if GPIO_10_EN
+    [GPIO_10] = GPIO_10_CLK,
+#endif
+#if GPIO_11_EN
+    [GPIO_11] = GPIO_11_CLK,
+#endif
+};
+
 int gpio_init_out(gpio_t dev, gpio_pp_t pullup)
 {
     GPIO_TypeDef *port;
@@ -165,6 +205,8 @@ int gpio_init_out(gpio_t dev, gpio_pp_t pullup)
 
     port = gpio_port_map[dev];
     pin = gpio_pin_map[dev];
+
+    RCC->AHBENR |= (1 << gpio_clock_map[dev]);
 
     port->MODER &= ~(2 << (2 * pin));           /* set pin to output mode */
     port->MODER |= (1 << (2 * pin));
@@ -188,6 +230,8 @@ int gpio_init_in(gpio_t dev, gpio_pp_t pullup)
 
     port = gpio_port_map[dev];
     pin = gpio_pin_map[dev];
+
+    RCC->AHBENR |= (1 << gpio_clock_map[dev]);
 
     port->MODER &= ~(3 << (2 * pin));           /* configure pin as input */
     port->PUPDR &= ~(3 << (2 * pin));           /* configure push-pull resistors */


### PR DESCRIPTION
same then for the F4: the CLK enable for the GPIO ports got lost during optimization... Here they are again.