### PR TITLE
net: Introduction of global protocol handler registry -> netreg (WIP)

### DIFF
--- a/sys/include/pkt.h
+++ b/sys/include/pkt.h
@@ -27,51 +27,11 @@
 #include <inttypes.h>
 
 #include "clist.h"
+#include "netmod.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @brief   Definition of protocol families to determine the type of the packet
- *          or which protocols a network device (see @ref netdev) or protocol
- *          layer (see @ref netapi) can handle
- *
- * @note    XXX: The concrete definition of the values is necessary to work
- *          with super-flexible devices as e.g. @ref native_net. It was also
- *          decided not to use ethertype since protocols not supplied by it
- *          might be supported
- */
-typedef enum {
-    PKT_PROTO_UNKNOWN       = 0x0000,   /**< Type was not specified */
-
-    /**
-     * @brief   Radio frame protocol
-     *
-     * @details Sends frames as defined by radio_packet_t.
-     */
-    PKT_PROTO_RADIO         = 0x0001,
-
-    PKT_PROTO_ETHERNET      = 0x0002,   /**< Ethernet */
-    PKT_PROTO_802154_BEACON = 0x0003,   /**< IEEE 802.15.4 beacon frame */
-    PKT_PROTO_802154_DATA   = 0x0004,   /**< IEEE 802.15.4 data frame */
-    PKT_PROTO_802154_ACK    = 0x0005,   /**< IEEE 802.15.4 acknowledgment frame */
-    PKT_PROTO_802154_MACCMD = 0x0006,   /**< IEEE 802.15.4 MAC command frame */
-    PKT_PROTO_BTLE          = 0x0007,   /**< Bluetooth Low-Energy */
-
-    /**
-     * @brief   CC110x frame format protocol
-     *
-     * @details Sends frames as defined by cc110x_packet_t.
-     */
-    PKT_PROTO_CC110X        = 0x0008,
-    PKT_PROTO_6LOWPAN       = 0x0009,   /**< 6LoWPAN. */
-    PKT_PROTO_IPV4          = 0x000a,   /**< IPv4. */
-    PKT_PROTO_IPV6          = 0x000b,   /**< IPv6. */
-    PKT_PROTO_UDP           = 0x000c,   /**< UDP. */
-    PKT_PROTO_TCP           = 0x000d,   /**< TCP. */
-    PKT_PROTO_CCNL          = 0x000e,   /**< CCN lite. */
-} pkt_proto_t;
 
 /**
  * @brief   Type to define payload size of a packet
@@ -101,7 +61,7 @@ typedef struct __attribute__((packed)) pkt_hlist_t {    /* packed to be aligned
     struct pkt_hlist_t *next;   /**< next element in list. */
     void *header_data;          /**< the data of the header */
     pktsize_t header_len;       /**< the length of the header in byte. */
-    pkt_proto_t header_proto;   /**< protocol of the header. */
+    netmod_t header_proto;      /**< protocol of the header. */
 } pkt_hlist_t;
 
 /**
@@ -115,7 +75,7 @@ typedef struct __attribute__((packed)) {    /* packed to be aligned correctly
     pkt_hlist_t *headers;       /**< network protocol headers of the packet. */
     void *payload_data;              /**< payload of the packet. */
     pktsize_t payload_len;      /**< length of pkt_t::payload. */
-    pkt_proto_t payload_proto;  /**< protocol of pkt_t::payload, if any */
+    netmod_t payload_proto;  /**< protocol of pkt_t::payload, if any */
 } pkt_t;
 
 /**

--- a/sys/net/crosslayer/netapi/netapi.c
+++ b/sys/net/crosslayer/netapi/netapi.c
@@ -100,29 +100,6 @@ int netapi_set_option(kernel_pid_t pid, netapi_conf_type_t param,
     return _get_set_option(pid, NETAPI_CMD_SET, param, data, data_len);
 }
 
-static int _netapi_register_cmd(kernel_pid_t pid, netapi_cmd_type_t cmd,
-                                kernel_pid_t reg_pid, netapi_reg_demux_ctx_t demux_ctx)
-{
-    netapi_reg_t reg;
-
-    reg.type = cmd;
-    reg.reg_pid = reg_pid;
-    reg.demux_ctx = demux_ctx;
-
-    return netapi_send_command(pid, (netapi_cmd_t *)(&reg));
-}
-
-int netapi_register(kernel_pid_t pid, kernel_pid_t reg_pid,
-                    netapi_reg_demux_ctx_t demux_ctx)
-{
-    return _netapi_register_cmd(pid, NETAPI_CMD_REG, reg_pid, demux_ctx);
-}
-
-int netapi_unregister(kernel_pid_t pid, kernel_pid_t reg_pid)
-{
-    return _netapi_register_cmd(pid, NETAPI_CMD_UNREG, reg_pid, 0);
-}
-
 #ifdef MODULE_NETDEV_DUMMY
 int netapi_fire_receive_event(kernel_pid_t pid, void *src, size_t src_len,
                               void *dest, size_t dest_len, void *data,

--- a/sys/net/crosslayer/netreg/Makefile
+++ b/sys/net/crosslayer/netreg/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/crosslayer/netreg/netreg.c
+++ b/sys/net/crosslayer/netreg/netreg.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_netreg
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the global network module registry
+ *
+ * The register is implemented as a table of lists. Each table row consists of
+ * a list header of entries for a given module. As module IDs are assigned
+ * continuously and are used as array indices, the lookup is done with a
+ * complexity of O(1).
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "netreg.h"
+
+
+
+/**
+ * @brief   Compute the needed size for the registry
+ *
+ * The size is computed to fit one pointer and 2 netreg_entry_t for each network
+ * module.
+ */
+#ifndef NETREG_REGISTRY_SIZE
+#define NETREG_REGISTRY_SIZE        (5 * sizeof(void*) * NETMOD_NUMOF)
+#endif
+
+/**
+ * @brief   Allocate memory for the registry
+ */
+static char *buffer[NETREG_REGISTRY_SIZE];
+
+/**
+ * @brief   Head for the list of free entries
+ */
+static netreg_entry_t *next_free;
+
+/**
+ * @brief   Array holding the list heads
+ */
+static netreg_entry_t *modules = (netreg_entry_t *)buffer;
+
+
+void netreg_init(void)
+{
+    netreg_entry_t *last = (netreg_entry_t *)&buffer[NETMOD_NUMOF * sizeof(netreg_entry_t *)];
+
+    /* set list head */
+    next_free = last;
+
+    /* null out initial list heads */
+    for (int i = 0; i < NETMOD_NUMOF; i++) {
+        modules[i] = NULL;
+    }
+
+    /* add the rest of the buffer to the list of free entries */
+    for (int i = ((NETMOD_NUMOF + 1) * sizeof(netreg_entry_t *);
+         i < (sizeof(buffer) - sizeof(netreg_entry_t);
+         i += sizeof(netreg_entry_t)) {
+         = (netreg_entry_t *)buffer[i];
+        last.next = (netreg_entry_t *)&buffer[i];
+        last = last->next;
+    }
+    last.next = NULL;
+}
+
+int netreg_register(netmod_t mdoule, kernel_pid_t pid)
+{
+    netreg_entry_t *newone, *tmp;
+
+    /* check if space is available and reserve space*/
+    if (next_free == NULL) {
+        return -1;
+    }
+    else {
+        newone = next_free;
+        newone->next = NULL;
+        next_free = next_free->next;
+    }
+
+    /* add to correct list */
+    do {
+        tmp = modules[module];
+    } while (tmp->next != NULL);
+    tmp->next = newone;
+
+    return 0;
+}
+
+int netreg_unregister(netmod_t module, kernel_pid_t pid)
+{
+    netreg_entry_t *tmp = modules[module];
+
+    /* see if the first entry is a hit */
+    if (tmp != NULL && tmp->module_pid == pid) {
+        modules[module] == tmp->next;
+        return 0;
+    }
+
+    while (tmp->next != NULL) {
+        if (tmp->next->module_pid == pid) {
+            tmp->next = tmp->next->next;
+            return 0;
+        }
+        tmp = tmp->next;
+    }
+
+    /* if we end up here, the PID was not found in the list */
+    return -1;
+}
+
+kernel_pid_t netreg_lookup(netreg_entry_t *entry, netmod_t module)
+{
+    /* are there entries for the given module? */
+    entry = modules[module];
+    if (entry != NULL) {
+        return entry->module_pid;
+    }
+    else {
+        return KERNEL_PID_UNDEF;
+    }
+}
+
+kernel_pid_t netreg_getnext(netreg_entry_t *entry)
+{
+    entry = entry->next;
+    if (entry != NULL) {
+        return entry->module_pid;
+    }
+    else {
+        return KERNEL_PID_UNDEF;
+    }
+}

--- a/sys/net/include/netapi.h
+++ b/sys/net/include/netapi.h
@@ -150,12 +150,6 @@ typedef enum {
      * @brief   Set or get default address length.
      */
     NETAPI_CONF_SRC_LEN = NETDEV_OPT_SRC_LEN,
-
-    /** @brief  Get (for setting always use NETAPI_CMD_REG and NETAPI_CMD_UNREG)
-     *          all PIDs of currently registered threads as array of
-     *          @ref kernel_pid_t.
-     */
-    NETAPI_CONF_REGISTRY = NETDEV_OPT_LAST,
 } netapi_conf_type_t;
 
 /**

--- a/sys/net/include/netmod.h
+++ b/sys/net/include/netmod.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_netmod Global network module list
+ * @ingroup     net
+ * @brief       Global list of available network module
+ * @{
+ *
+ * @file
+ * @brief       List of all available network modules
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef __NETMOD_H_
+#define __NETMOD_H_
+
+/**
+ * @brief   Make sure the number of network interfaces is defined
+ *
+ * TODO: Clarify where this value will be defined...
+ */
+#ifndef NET_CONF_NUMOF_INTERFACES /* or whatever name it will be */
+#error "netreg: The number of network interfaces is not defined!"
+#endif
+
+
+typedef enum {
+    /* virtually put the network interfaces on the first positions of this enum */
+    NETMOD_IF_NUMOF = (NET_CONF_NUMOF_INTERFACES - 1),
+
+#if MODULE_UDP
+    NETMOD_UDP,
+#endif
+#if MODULE_TCP
+    NETMOD_TCP,
+#endif
+
+#if MODULE_IPV6
+    NETMOD_IPV6,
+#endif
+#if MODULE_IPV4
+    NETMOD_IPV4
+#endif
+#if MODULE_6LOWPAN
+    NETMOD_6LOWPAN
+#endif
+
+#if MDULE_IEEE802154
+    NETMOD_IEEE802154
+#endif
+
+    /* ... you get the idea ... */
+
+    NETMOD_NUMOF        /**< shortcut for referencing the number of active protocols */
+} netmod_t;
+
+#endif /* __NETMOD_H_ */
+/** @} */

--- a/sys/net/include/netmod.h
+++ b/sys/net/include/netmod.h
@@ -21,20 +21,8 @@
 #ifndef __NETMOD_H_
 #define __NETMOD_H_
 
-/**
- * @brief   Make sure the number of network interfaces is defined
- *
- * TODO: Clarify where this value will be defined...
- */
-#ifndef NET_CONF_NUMOF_INTERFACES /* or whatever name it will be */
-#error "netreg: The number of network interfaces is not defined!"
-#endif
-
 
 typedef enum {
-    /* virtually put the network interfaces on the first positions of this enum */
-    NETMOD_IF_NUMOF = (NET_CONF_NUMOF_INTERFACES - 1),
-
 #if MODULE_UDP
     NETMOD_UDP,
 #endif

--- a/sys/net/include/netreg.h
+++ b/sys/net/include/netreg.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_netreg Network module registry
+ * @ingroup     net
+ * @brief       Global registry for lookup of network protocol handlers and
+ *              network interfaces
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for the global network module registry
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef __NETREG_H_
+#define __NETREG_H_
+
+#include <stdint.h>
+
+#include "kernel.h"
+#include "netmod.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Structure for holding one element int the registry
+ */
+typedef struct {
+    netreg_entry_t *next;           /**< point to the next entry */
+    kernel_pid_t module_pid;        /**< the PID of the referenced module */
+} netreg_entry_t;
+
+/**
+ * @brief   Initialize the registry
+ *
+ * No return value, as this can not fail.
+ */
+void netreg_init(void);
+
+/**
+ * @brief   Register a network module
+ *
+ * @param[in] module        global protocol or interface number
+ * @param[in] pid           the PID of the module
+ *
+ * @return                  something useful...
+ */
+int netreg_register(netmod_t module, kernel_pid_t pid);
+
+/**
+ * @brief Unregister a module from a list
+ *
+ * @param[in] module        module to unregister from
+ * @param[in] pid           the callers PID
+ *
+ * @return                  something even more useful...
+ */
+int netreg_unregister(netmod_t module, kernel_pid_t pid);
+
+/**
+ * @brief   Lookup a list of PIDs for a given protocol/interface
+ *
+ * @param[out] entry        head of the list of entries
+ * @param[in]  module       module id to look up
+ *
+ * @return                  the first PID registered for the requested module
+ */
+kernel_pid_t netreg_lookup(netreg_entry_t *entry, netmod_t module);
+
+/**
+ * @brief   Get the next PID in the given list
+ *
+ * @param[in|out] entry     pointer to the previous entry, will be advanced
+ *
+ * @return                  the next PID in the list
+ * @return                  KERNEL_PID_UNDEF if end of list is reached
+ */
+kernel_pid_t netreg_getnext(netreg_entry_t *entry);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __NETREG_H_ */
+/** @} */

--- a/sys/net/include/netreg.h
+++ b/sys/net/include/netreg.h
@@ -36,7 +36,7 @@ extern "C" {
  */
 typedef struct {
     netreg_entry_t *next;           /**< point to the next entry */
-    kernel_pid_t module_pid;        /**< the PID of the referenced module */
+    kernel_pid_t pid;        /**< the PID of the referenced module */
 } netreg_entry_t;
 
 /**
@@ -67,14 +67,43 @@ int netreg_register(netmod_t module, kernel_pid_t pid);
 int netreg_unregister(netmod_t module, kernel_pid_t pid);
 
 /**
+ * @brief   Register an interface with the given interface id (PID)
+ *
+ * @param pid [description]
+ * @return [description]
+ */
+int netreg_add_interface(kernel_pid_t pid);
+
+/**
+ * @brief   Remove the interface with the given interface id (PID)
+ *
+ * @param[in] pid           interface id
+ *
+ * @return                  0 on success
+ * @return                  -1 if device was not registered
+ */
+int netreg_remove_interface(kernel_pid_t pid);
+
+/**
  * @brief   Lookup a list of PIDs for a given protocol/interface
  *
  * @param[out] entry        head of the list of entries
  * @param[in]  module       module id to look up
  *
  * @return                  the first PID registered for the requested module
+ * @return                  KERNEL_PID_UNDEF if list for module is empty
  */
 kernel_pid_t netreg_lookup(netreg_entry_t *entry, netmod_t module);
+
+/**
+ * @brief   Get the first element from the list of registered network interfaces
+ *
+ * @param[in|out] entry     pointer to the current element in the list
+ *
+ * @return                  the PID of the first network interface
+ * @return                  KERNEL_PID_UNDEF if no device is registered
+ */
+kernel_pid_t netreg_get_interfaces(netreg_entry_t *entry);
 
 /**
  * @brief   Get the next PID in the given list

--- a/sys/net/include/nomac.h
+++ b/sys/net/include/nomac.h
@@ -32,42 +32,11 @@
 extern "C" {
 #endif
 
-#ifndef NOMAC_REGISTRY_SIZE
-/**
- * @brief   The size of NOMAC's registry of receiving threads.
- */
-#define NOMAC_REGISTRY_SIZE (1)
-#endif
-
 /**
  * @brief   Recommended stack size for a NOMAC thread
  * TODO: determine real minimal size based on thread_print_all() output
  */
 #define NOMAC_CONTROL_STACKSIZE    (KERNEL_CONF_STACKSIZE_DEFAULT)
-
-/**
- * @brief   Basic configuration types
- *
- * @extends netapi_conf_type_t
- */
-typedef enum {
-    NOMAC_PROTO = NETAPI_CONF_PROTO,            /**< Set or get protocol */
-    NOMAC_CHANNEL = NETAPI_CONF_CARRIER,        /**< Set or get channel */
-    NOMAC_ADDRESS = NETAPI_CONF_ADDRESS,        /**< Set or get address */
-    NOMAC_NID = NETAPI_CONF_SUBNETS,            /**< Set or get network id
-                                                 *   (e.g. PAN ID in 802.15.4)*/
-    NOMAC_MAX_PACKET_SIZE = NETAPI_CONF_MAX_PACKET_SIZE,    /**< Set or get maximum
-                                                             *   packet size */
-    NOMAC_SRC_LEN = NETAPI_CONF_SRC_LEN,        /**< Set or get default source length */
-    NOMAC_REGISTRY = NETAPI_CONF_REGISTRY,      /**< get registered threads */
-    NOMAC_ADDRESS2 = NETDEV_OPT_ADDRESS_LONG,   /**< Set or get alternative address
-                                                 *   format (e.g EUI-64 in 802.15.4) */
-} nomac_conf_type_t;
-
-/**
- * @brief   Initializes the module
- */
-void nomac_init_module(void);
 
 /**
  * @brief   Initialize new NOMAC layer.


### PR DESCRIPTION
This PR is opened for discussion and to demonstrate the concept of a global protocol handler/module registry that takes care or keeping lists of PID's.

This code is not compiling (I havn't even tried) and please don't spend much thought on the doxygen... I just want to get feedback on the overall concept.

The main things shown are:
- API and implementation of a global module registry, called `netreg`
- Introduction of a global list of used protocols, called `netmod`
- Simplified `netapi` by throwing out everything related to (un-)registering
- Adjusted `pkt_t` to make use of `netmod`
- Simplified `nomac` by making use of `netreg` (and integrating some thoughts about netdev -> compare to #2297)

Let me know what you think or where I have more explaining to do!

