### PR TITLE
timex: new api proposal (pointers)

### DIFF
--- a/drivers/cc110x_legacy_csma/cc1100-csmaca-mac.c
+++ b/drivers/cc110x_legacy_csma/cc1100-csmaca-mac.c
@@ -93,10 +93,11 @@ int cc1100_send_csmaca(radio_address_t address, protocol_t protocol, int priorit
     else if (collision_state == COLLISION_STATE_MEASURE) {
         timex_t now;
         vtimer_now(&now);
-        timex_t timespan;
+        timex_t timespan, one_sec;
         timex_sub(&now, &collision_measurement_start, &timespan);
 
-        if (timex_cmp(timespan, timex_set(1, 0)) > 0) {
+        one_sec = timex_set(1, 0);
+        if (timex_cmp(&timespan, &one_sec) > 0) {
             collisions_per_sec = (collision_count * 1000000) / (double) timex_uint64(timespan);
 
             if (collisions_per_sec > 0.5 && collisions_per_sec <= 2.2) {
@@ -119,10 +120,11 @@ int cc1100_send_csmaca(radio_address_t address, protocol_t protocol, int priorit
     else if (collision_state == COLLISION_STATE_KEEP) {
         timex_t now;
         vtimer_now(&now);
-        timex_t timespan;
+        timex_t timespan, five_sec;
         timex_sub(&now, &collision_measurement_start, &timespan);
 
-        if (timex_cmp(timespan, timex_set(5, 0)) > 0) {
+        five_sec = timex_set(5, 0);
+        if (timex_cmp(&timespan, &five_sec) > 0) {
             collision_state = COLLISION_STATE_INITIAL;
         }
     }

--- a/drivers/cc110x_legacy_csma/cc1100-csmaca-mac.c
+++ b/drivers/cc110x_legacy_csma/cc1100-csmaca-mac.c
@@ -93,7 +93,8 @@ int cc1100_send_csmaca(radio_address_t address, protocol_t protocol, int priorit
     else if (collision_state == COLLISION_STATE_MEASURE) {
         timex_t now;
         vtimer_now(&now);
-        timex_t timespan = timex_sub(now, collision_measurement_start);
+        timex_t timespan;
+        timex_sub(&now, &collision_measurement_start, &timespan);
 
         if (timex_cmp(timespan, timex_set(1, 0)) > 0) {
             collisions_per_sec = (collision_count * 1000000) / (double) timex_uint64(timespan);
@@ -118,7 +119,8 @@ int cc1100_send_csmaca(radio_address_t address, protocol_t protocol, int priorit
     else if (collision_state == COLLISION_STATE_KEEP) {
         timex_t now;
         vtimer_now(&now);
-        timex_t timespan = timex_sub(now, collision_measurement_start);
+        timex_t timespan;
+        timex_sub(&now, &collision_measurement_start, &timespan);
 
         if (timex_cmp(timespan, timex_set(5, 0)) > 0) {
             collision_state = COLLISION_STATE_INITIAL;

--- a/drivers/cc110x_legacy_csma/cc1100_phy.c
+++ b/drivers/cc110x_legacy_csma/cc1100_phy.c
@@ -177,7 +177,8 @@ void cc1100_phy_init(void)
     if (radio_mode == CC1100_MODE_CONSTANT_RX) {
         cc1100_watch_dog_period = timex_set(CC1100_WATCHDOG_PERIOD, 0);
 
-        if (timex_cmp(cc1100_watch_dog_period, timex_set(0, 0)) != 0) {
+        timex_t zero = timex_set(0, 0);
+        if (timex_cmp(&cc1100_watch_dog_period, &zero) != 0) {
             vtimer_set_msg(&cc1100_watch_dog, cc1100_watch_dog_period, cc1100_event_handler_pid, MSG_TIMER, NULL);
         }
     }

--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -85,11 +85,11 @@ void timex_add(const timex_t *a, const timex_t *b, timex_t *r);
  *
  * @param[in] a     The minuend
  * @param[in] b     The subtrahend
+ * @param[out] r    Difference of minuend and subtrahend
  *
- * @return The difference a - b
  */
 /* cppcheck-suppress passedByValue */
-timex_t timex_sub(const timex_t a, const timex_t b);
+void timex_sub(const timex_t *a, const timex_t *b, timex_t *r);
 
 /**
  * @brief Initializes a timex timestamp

--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -112,7 +112,7 @@ timex_t timex_set(uint32_t seconds, uint32_t microseconds);
  * @return 1 if a is bigger
  */
 /* cppcheck-suppress passedByValue */
-int timex_cmp(const timex_t a, const timex_t b);
+int timex_cmp(const timex_t *a, const timex_t *b);
 
 /**
  * @brief Corrects timex structure so that microseconds < 1000000

--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -77,7 +77,6 @@ typedef struct {
  * @param[out] r    Sum of first and second addend
  *
  */
-/* cppcheck-suppress passedByValue */
 void timex_add(const timex_t *a, const timex_t *b, timex_t *r);
 
 /**
@@ -88,7 +87,6 @@ void timex_add(const timex_t *a, const timex_t *b, timex_t *r);
  * @param[out] r    Difference of minuend and subtrahend
  *
  */
-/* cppcheck-suppress passedByValue */
 void timex_sub(const timex_t *a, const timex_t *b, timex_t *r);
 
 /**
@@ -111,7 +109,6 @@ timex_t timex_set(uint32_t seconds, uint32_t microseconds);
  * @return 0 if equal
  * @return 1 if a is bigger
  */
-/* cppcheck-suppress passedByValue */
 int timex_cmp(const timex_t *a, const timex_t *b);
 
 /**

--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -74,11 +74,11 @@ typedef struct {
  *
  * @param[in] a     First summand
  * @param[in] b     Second summand
+ * @param[out] r    Sum of first and second addend
  *
- * @return The sum of the two timestamps
  */
 /* cppcheck-suppress passedByValue */
-timex_t timex_add(const timex_t a, const timex_t b);
+void timex_add(const timex_t *a, const timex_t *b, timex_t *r);
 
 /**
  * @brief Subtracts two timestamps

--- a/sys/net/link_layer/ping/ping.c
+++ b/sys/net/link_layer/ping/ping.c
@@ -193,10 +193,10 @@ static void calc_rtt(void)
 
     l2_ping_stats.last_rtt = rtt;
     l2_ping_stats.avg_rtt = timex_from_uint64(timex_uint64(rtt_sum) / l2_ping_stats.pong_count);
-    if (timex_cmp(rtt, l2_ping_stats.max_rtt) > 0) {
+    if (timex_cmp(&rtt, &l2_ping_stats.max_rtt) > 0) {
         l2_ping_stats.max_rtt = rtt;
     }
-    if (timex_cmp(rtt, l2_ping_stats.min_rtt) < 0) {
+    if (timex_cmp(&rtt, &l2_ping_stats.min_rtt) < 0) {
         l2_ping_stats.min_rtt = rtt;
     }
 }

--- a/sys/net/link_layer/ping/ping.c
+++ b/sys/net/link_layer/ping/ping.c
@@ -187,7 +187,8 @@ static void *l2_pkt_handler(void *unused)
 static void calc_rtt(void)
 {
     timex_t rtt = timex_sub(end, start);
-    rtt_sum = timex_add(rtt_sum, rtt);
+    timex_t rtt_sum;
+    timex_add(&rtt_sum, &rtt, &rtt_sum);
 
     l2_ping_stats.last_rtt = rtt;
     l2_ping_stats.avg_rtt = timex_from_uint64(timex_uint64(rtt_sum) / l2_ping_stats.pong_count);

--- a/sys/net/link_layer/ping/ping.c
+++ b/sys/net/link_layer/ping/ping.c
@@ -186,7 +186,8 @@ static void *l2_pkt_handler(void *unused)
 
 static void calc_rtt(void)
 {
-    timex_t rtt = timex_sub(end, start);
+    timex_t rtt;
+    timex_sub(&end, &start, &rtt);
     timex_t rtt_sum;
     timex_add(&rtt_sum, &rtt, &rtt_sum);
 

--- a/sys/net/network_layer/sixlowpan/icmp.c
+++ b/sys/net/network_layer/sixlowpan/icmp.c
@@ -1735,7 +1735,7 @@ void def_rtr_lst_add(ipv6_addr_t *ipaddr, uint32_t rtr_ltime)
         timex_t now;
         vtimer_now(&now);
 
-        def_rtr_lst[def_rtr_count].inval_time = timex_add(now, rltime);
+        timex_add(&now, &rltime, &def_rtr_lst[def_rtr_count].inval_time);
 
         def_rtr_count++;
     }

--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -826,7 +826,10 @@ uint32_t get_remaining_time(timex_t *t)
     timex_t now;
     vtimer_now(&now);
 
-    return (timex_sub(*t, now).seconds);
+    timex_t rem;
+    timex_sub(t, &now, &rem);
+
+    return rem.seconds;
 }
 
 void set_remaining_time(timex_t *t, uint32_t time)

--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -629,8 +629,8 @@ int ipv6_net_if_add_addr(int if_id, const ipv6_addr_t *addr,
         }
 
         addr_entry->ndp_state = state;
-        addr_entry->valid_lifetime = timex_add(now, valtime);
-        addr_entry->preferred_lifetime = timex_add(now, preftime);
+        timex_add(&now, &valtime, &addr_entry->valid_lifetime);
+        timex_add(&now, &preftime, &addr_entry->preferred_lifetime);
         addr_entry->is_anycast = is_anycast;
 
         ipv6_net_if_addr_buffer_count++;
@@ -835,7 +835,7 @@ void set_remaining_time(timex_t *t, uint32_t time)
 
     timex_t now;
     vtimer_now(&now);
-    *t = timex_add(now, tmp);
+    timex_add(&now, &tmp, t);
 }
 
 int ipv6_init_as_router(void)

--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -709,7 +709,7 @@ void check_timeout(void)
             if (smallest_time == NULL) {
                 smallest_time = temp_buf;
             }
-            else if (timex_cmp(temp_buf->timestamp, smallest_time->timestamp) < 0) {
+            else if (timex_cmp(&temp_buf->timestamp, &smallest_time->timestamp) < 0) {
                 smallest_time = temp_buf;
             }
 

--- a/sys/net/routing/aodvv2/routingtable.c
+++ b/sys/net/routing/aodvv2/routingtable.c
@@ -222,7 +222,7 @@ void routingtable_fill_routing_entry_t_rreq(struct aodvv2_packet_data *packet_da
     rt_entry->seqnum = packet_data->origNode.seqnum;
     rt_entry->nextHopAddr = packet_data->sender;
     rt_entry->lastUsed = packet_data->timestamp;
-    rt_entry->expirationTime = timex_add(packet_data->timestamp, validity_t);
+    timex_add(&packet_data->timestamp, &validity_t, &rt_entry->expirationTime);
     rt_entry->metricType = packet_data->metricType;
     rt_entry->metric = packet_data->origNode.metric;
     rt_entry->state = ROUTE_STATE_ACTIVE;
@@ -235,7 +235,7 @@ void routingtable_fill_routing_entry_t_rrep(struct aodvv2_packet_data *packet_da
     rt_entry->seqnum = packet_data->targNode.seqnum;
     rt_entry->nextHopAddr = packet_data->sender;
     rt_entry->lastUsed = packet_data->timestamp;
-    rt_entry->expirationTime = timex_add(packet_data->timestamp, validity_t);
+    timex_add(&packet_data->timestamp, &validity_t, &rt_entry->expirationTime);
     rt_entry->metricType = packet_data->metricType;
     rt_entry->metric = packet_data->targNode.metric;
     rt_entry->state = ROUTE_STATE_ACTIVE;

--- a/sys/net/routing/aodvv2/routingtable.c
+++ b/sys/net/routing/aodvv2/routingtable.c
@@ -141,7 +141,7 @@ static void _reset_entry_if_stale(uint8_t i)
     vtimer_now(&now);
     timex_t lastUsed, expirationTime, diff, sum;
 
-    if (timex_cmp(routing_table[i].expirationTime, null_time) == 0) {
+    if (timex_cmp(&routing_table[i].expirationTime, &null_time) == 0) {
         return;
     }
 
@@ -153,13 +153,13 @@ static void _reset_entry_if_stale(uint8_t i)
      * during every ACTIVE_INTERVAL. When a route is no longer Active, it becomes an Idle route. */
 
     /* if the node is younger than the active interval, don't bother */
-    if (timex_cmp(now, active_interval) < 0) {
+    if (timex_cmp(&now, &active_interval) < 0) {
         return;
     }
 
     timex_sub(&now, &active_interval, &diff);
     if ((state == ROUTE_STATE_ACTIVE) &&
-        (timex_cmp(diff, lastUsed) == 1)) {
+        (timex_cmp(&diff, &lastUsed) == 1)) {
         DEBUG("\t[routing] route towards %s Idle\n",
               netaddr_to_string(&nbuf, &routing_table[i].addr));
         routing_table[i].state = ROUTE_STATE_IDLE;
@@ -169,13 +169,13 @@ static void _reset_entry_if_stale(uint8_t i)
     /* After an Idle route remains Idle for MAX_IDLETIME, it becomes an Invalid route. */
 
     /* if the node is younger than the expiration time, don't bother */
-    if (timex_cmp(now, expirationTime) < 0) {
+    if (timex_cmp(&now, &expirationTime) < 0) {
         return;
     }
 
     /* If Current_Time > Route.ExpirationTime, set Route.State := Invalid. */
     if ((state == ROUTE_STATE_IDLE) &&
-        (timex_cmp(now, expirationTime) > 0)) {
+        (timex_cmp(&now, &expirationTime) > 0)) {
         DEBUG("\t[routing] route towards %s became Invalid\n",
               netaddr_to_string(&nbuf, &routing_table[i].addr));
         routing_table[i].state = ROUTE_STATE_INVALID;
@@ -186,7 +186,7 @@ static void _reset_entry_if_stale(uint8_t i)
      * and if (Route.Timed == FALSE), set Route.State := Invalid. */
     timex_sub(&now, &lastUsed, &diff);
     timex_add(&active_interval, &max_idletime, &sum);
-    if ((timex_cmp(diff, sum) > 0) &&
+    if ((timex_cmp(&diff, &sum) > 0) &&
         (state != ROUTE_STATE_TIMED)) {
         routing_table[i].state = ROUTE_STATE_INVALID;
     }
@@ -194,7 +194,7 @@ static void _reset_entry_if_stale(uint8_t i)
     /* After that time, old sequence number information is considered no longer
      * valid and the Invalid route MUST BE expunged */
     timex_sub(&now, &lastUsed, &diff);
-    if (timex_cmp(diff, max_seqnum_lifetime) >= 0) {
+    if (timex_cmp(&diff, &max_seqnum_lifetime) >= 0) {
         DEBUG("\t[routing] Expunged routing table entry for %s at %i\n",
               netaddr_to_string(&nbuf, &routing_table[i].addr), i);
         memset(&routing_table[i], 0, sizeof(routing_table[i]));

--- a/sys/net/routing/aodvv2/utils.c
+++ b/sys/net/routing/aodvv2/utils.c
@@ -219,7 +219,8 @@ static void _reset_entry_if_stale(uint8_t i)
     if (timex_cmp(rreq_table[i].timestamp, null_time) == 0) {
         return;
     }
-    timex_t expiration_time = timex_add(rreq_table[i].timestamp, _max_idletime);
+    timex_t expiration_time;
+    timex_add(&rreq_table[i].timestamp, &_max_idletime, &expiration_time);
     if (timex_cmp(expiration_time, now) < 0) {
         /* timestamp+expiration time is in the past: this entry is stale */
         DEBUG("\treset rreq table entry %s\n",

--- a/sys/net/routing/aodvv2/utils.c
+++ b/sys/net/routing/aodvv2/utils.c
@@ -216,12 +216,12 @@ static void _reset_entry_if_stale(uint8_t i)
 {
     vtimer_now(&now);
 
-    if (timex_cmp(rreq_table[i].timestamp, null_time) == 0) {
+    if (timex_cmp(&rreq_table[i].timestamp, &null_time) == 0) {
         return;
     }
     timex_t expiration_time;
     timex_add(&rreq_table[i].timestamp, &_max_idletime, &expiration_time);
-    if (timex_cmp(expiration_time, now) < 0) {
+    if (timex_cmp(&expiration_time, &now) < 0) {
         /* timestamp+expiration time is in the past: this entry is stale */
         DEBUG("\treset rreq table entry %s\n",
               netaddr_to_string(&nbuf, &rreq_table[i].origNode));

--- a/sys/posix/pthread/pthread_cond.c
+++ b/sys/posix/pthread/pthread_cond.c
@@ -127,7 +127,7 @@ int pthread_cond_timedwait(struct pthread_cond_t *cond, struct mutex_t *mutex, c
     vtimer_now(&now);
     then.seconds = abstime->tv_sec;
     then.microseconds = abstime->tv_nsec / 1000u;
-    reltime = timex_sub(then, now);
+    timex_sub(&then, &now, &reltime);
 
     vtimer_t timer;
     vtimer_set_wakeup(&timer, reltime, sched_active_pid);

--- a/sys/posix/pthread/pthread_rwlock.c
+++ b/sys/posix/pthread/pthread_rwlock.c
@@ -193,7 +193,7 @@ static int pthread_rwlock_timedlock(pthread_rwlock_t *rwlock,
 
     vtimer_now(&now);
 
-    if (timex_cmp(then, now) <= 0) {
+    if (timex_cmp(&then, &now) <= 0) {
         return ETIMEDOUT;
     }
     else {

--- a/sys/posix/pthread/pthread_rwlock.c
+++ b/sys/posix/pthread/pthread_rwlock.c
@@ -197,7 +197,8 @@ static int pthread_rwlock_timedlock(pthread_rwlock_t *rwlock,
         return ETIMEDOUT;
     }
     else {
-        timex_t reltime = timex_sub(then, now);
+        timex_t reltime;
+        timex_sub(&then, &now, &reltime);
 
         vtimer_t timer;
         vtimer_set_wakeup(&timer, reltime, sched_active_pid);

--- a/sys/shell/commands/sc_l2_ping.c
+++ b/sys/shell/commands/sc_l2_ping.c
@@ -70,7 +70,7 @@ int _l2_ping_req_handler(int argc, char **argv)
     l2_ping((radio_address_t) atoi(argv[1]), count, L2_PING_DEFAULT_INTERVAL,
             l2_payload, payload_strlen, 0);
     vtimer_now(&end);
-    period = timex_sub(end, start);
+    timex_sub(&end, &start, &period);
 
     printf("  --- ping statistics for host %" PRIu16 " ---\n", l2_ping_stats.dst);
     printf("  %" PRIu16 " packets transmitted, %" PRIu16 " received, %" PRIu16 "%% packet loss, time %" PRIu32 ".%06" PRIu32 "s\n",
@@ -126,7 +126,7 @@ int _l2_ping_probe_handler(int argc, char **argv)
     l2_ping((radio_address_t) atoi(argv[1]), count, L2_PING_DEFAULT_INTERVAL,
             l2_payload, payload_strlen, 1);
     vtimer_now(&end);
-    period = timex_sub(end, start);
+    timex_sub(&end, &start, &period);
 
     printf("  --- ping statistics for host %" PRIu16 " ---\n", l2_ping_stats.dst);
     printf("  %" PRIu16 " packets transmitted in %" PRIu32 ".%06" PRIu32 "s\n", l2_ping_stats.ping_count,

--- a/sys/timex/timex.c
+++ b/sys/timex/timex.c
@@ -60,7 +60,7 @@ timex_t timex_set(uint32_t seconds, uint32_t microseconds)
     return result;
 }
 
-timex_t timex_sub(const timex_t a, const timex_t b)
+void timex_sub(const timex_t *a, const timex_t *b, timex_t *r)
 {
 #if ENABLE_DEBUG
     if (!timex_isnormalized(&a) || !timex_isnormalized(&b)) {
@@ -68,18 +68,16 @@ timex_t timex_sub(const timex_t a, const timex_t b)
     }
 #endif
 
-    timex_t result;
-
-    if (a.microseconds >= b.microseconds) {
-        result.seconds = a.seconds - b.seconds;
-        result.microseconds = a.microseconds - b.microseconds;
+    if (a->microseconds >= b->microseconds) {
+        r->seconds = a->seconds - b->seconds;
+        r->microseconds = a->microseconds - b->microseconds;
     }
     else {
-        result.seconds = a.seconds - b.seconds - 1;
-        result.microseconds = a.microseconds + SEC_IN_USEC - b.microseconds;
+        r->seconds = a->seconds - b->seconds - 1;
+        r->microseconds = a->microseconds + SEC_IN_USEC - b->microseconds;
     }
 
-    return result;
+    return;
 }
 
 int timex_cmp(const timex_t a, const timex_t b)

--- a/sys/timex/timex.c
+++ b/sys/timex/timex.c
@@ -26,7 +26,7 @@
 
 #include "timex.h"
 
-timex_t timex_add(const timex_t a, const timex_t b)
+void timex_add(const timex_t *a, const timex_t *b, timex_t *r)
 {
 #if ENABLE_DEBUG
     if (!timex_isnormalized(&a) || !timex_isnormalized(&b)) {
@@ -34,16 +34,15 @@ timex_t timex_add(const timex_t a, const timex_t b)
     }
 #endif
 
-    timex_t result;
-    result.seconds = a.seconds + b.seconds;
-    result.microseconds = a.microseconds + b.microseconds;
+    r->seconds = a->seconds + b->seconds;
+    r->microseconds = a->microseconds + b->microseconds;
 
-    if (result.microseconds > SEC_IN_USEC) {
-        result.microseconds -= SEC_IN_USEC;
-        result.seconds++;
+    if (r->microseconds > SEC_IN_USEC) {
+        r->microseconds -= SEC_IN_USEC;
+        r->seconds++;
     }
 
-    return result;
+    return;
 }
 
 timex_t timex_set(uint32_t seconds, uint32_t microseconds)

--- a/sys/timex/timex.c
+++ b/sys/timex/timex.c
@@ -80,7 +80,7 @@ void timex_sub(const timex_t *a, const timex_t *b, timex_t *r)
     return;
 }
 
-int timex_cmp(const timex_t a, const timex_t b)
+int timex_cmp(const timex_t *a, const timex_t *b)
 {
 #if ENABLE_DEBUG
     if (!timex_isnormalized(&a) || !timex_isnormalized(&b)) {
@@ -88,16 +88,16 @@ int timex_cmp(const timex_t a, const timex_t b)
     }
 #endif
 
-    if (a.seconds < b.seconds) {
+    if (a->seconds < b->seconds) {
         return -1;
     }
 
-    if (a.seconds == b.seconds) {
-        if (a.microseconds < b.microseconds) {
+    if (a->seconds == b->seconds) {
+        if (a->microseconds < b->microseconds) {
             return -1;
         }
 
-        if (a.microseconds == b.microseconds) {
+        if (a->microseconds == b->microseconds) {
             return 0;
         }
     }

--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -261,7 +261,7 @@ static int vtimer_set(vtimer_t *timer)
 
     timex_t now;
     vtimer_now(&now);
-    timer->absolute = timex_add(now, timer->absolute);
+    timex_add(&now, &timer->absolute, &timer->absolute);
     normalize_to_tick(&(timer->absolute));
 
     DEBUG("vtimer_set(): Absolute: %" PRIu32 " %" PRIu32 "\n", timer->absolute.seconds, timer->absolute.microseconds);

--- a/tests/unittests/tests-timex/tests-timex.c
+++ b/tests/unittests/tests-timex/tests-timex.c
@@ -33,11 +33,17 @@ static void test_timex_add(void)
 
 static void test_timex_sub(void)
 {
-    timex_t time;
-    time = timex_sub(timex_set(100, 100), timex_set(40, 10));
-    TEST_ASSERT_EQUAL_INT(0, timex_cmp(time, timex_set(60, 90)));
-    time = timex_sub(timex_set(100, 100), timex_set(40, 200));
-    TEST_ASSERT_EQUAL_INT(0, timex_cmp(time, timex_set(59, 999900)));
+    timex_t time, a, b;
+    a = timex_set(100, 100);
+    b = timex_set(40, 10);
+    timex_sub(&a, &b, &time);
+    a = timex_set(60,90);
+    TEST_ASSERT_EQUAL_INT(0, timex_cmp(time, a));
+    a = timex_set(100, 100);
+    b = timex_set(40, 200);
+    timex_sub(&a, &b, &time);
+    a = timex_set(59,999900);
+    TEST_ASSERT_EQUAL_INT(0, timex_cmp(time, a));
 }
 
 static void test_timex_from_uint64(void)

--- a/tests/unittests/tests-timex/tests-timex.c
+++ b/tests/unittests/tests-timex/tests-timex.c
@@ -23,12 +23,14 @@ static void test_timex_add(void)
     timex_t time;
     timex_t a = timex_set(100, 100);
     timex_t b = timex_set(40, 10);
+    timex_t c = timex_set(140, 110);
     timex_add(&a, &b, &time);
-    TEST_ASSERT_EQUAL_INT(0, timex_cmp(time, timex_set(140, 110)));
+    TEST_ASSERT_EQUAL_INT(0, timex_cmp(&time, &c));
     a = timex_set(100, 700000);
     b = timex_set(40, 800000);
+    c = timex_set(141, 500000);
     timex_add(&a, &b, &time);
-    TEST_ASSERT_EQUAL_INT(0, timex_cmp(time, timex_set(141, 500000)));
+    TEST_ASSERT_EQUAL_INT(0, timex_cmp(&time, &c));
 }
 
 static void test_timex_sub(void)
@@ -38,12 +40,12 @@ static void test_timex_sub(void)
     b = timex_set(40, 10);
     timex_sub(&a, &b, &time);
     a = timex_set(60,90);
-    TEST_ASSERT_EQUAL_INT(0, timex_cmp(time, a));
+    TEST_ASSERT_EQUAL_INT(0, timex_cmp(&time, &a));
     a = timex_set(100, 100);
     b = timex_set(40, 200);
     timex_sub(&a, &b, &time);
     a = timex_set(59,999900);
-    TEST_ASSERT_EQUAL_INT(0, timex_cmp(time, a));
+    TEST_ASSERT_EQUAL_INT(0, timex_cmp(&time, &a));
 }
 
 static void test_timex_from_uint64(void)

--- a/tests/unittests/tests-timex/tests-timex.c
+++ b/tests/unittests/tests-timex/tests-timex.c
@@ -21,9 +21,13 @@ static void test_timex_set(void)
 static void test_timex_add(void)
 {
     timex_t time;
-    time = timex_add(timex_set(100, 100), timex_set(40, 10));
+    timex_t a = timex_set(100, 100);
+    timex_t b = timex_set(40, 10);
+    timex_add(&a, &b, &time);
     TEST_ASSERT_EQUAL_INT(0, timex_cmp(time, timex_set(140, 110)));
-    time = timex_add(timex_set(100, 700000), timex_set(40, 800000));
+    a = timex_set(100, 700000);
+    b = timex_set(40, 800000);
+    timex_add(&a, &b, &time);
     TEST_ASSERT_EQUAL_INT(0, timex_cmp(time, timex_set(141, 500000)));
 }
 


### PR DESCRIPTION
Based on #2298 and the comparison made by @Kijewski [here](https://github.com/RIOT-OS/RIOT/issues/2298#issuecomment-69816288), I decided to give it a try and changed the functions `timex_add`, `timex_sub` and `timex_cmp` to receive pointers as input and a further pointer for output.

Let the numbers speak (in bytes) (compiled from the rpl_udp example):

|board|master|refactored|Diff|
|:--------:|:----------:|:--------------:|:-----:|
|IoT-Lab_M3|120292|120204|88|
|MSBA2|222717|222541|176|
|samr21-xpro|181040|180776|264|

IMHO: the cut in rom size is noticeable, but you definitely pay with code comfortableness, as you cannot use the functions on-the-fly anymore like in: `timex_add(timex_set(20,20), timex_set(10,10))`. This would become:
```
timex_t first = timex_set(20,20), second = timex_set(10,10), result;
timex_add(&first, &second, &result);
```

Closes  #2298