### PR TITLE
cpu/stm32f4: Fix SPI baud rate control settings

### DIFF
--- a/boards/msbiot/Makefile.features
+++ b/boards/msbiot/Makefile.features
@@ -1,3 +1,3 @@
 FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart periph_gpio
+FEATURES_PROVIDED += periph_uart periph_gpio periph_spi
 FEATURES_PROVIDED += transceiver

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -137,6 +137,7 @@ extern "C" {
 #define SPI_0_DEV             SPI1
 #define SPI_0_CLKEN()         (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
 #define SPI_0_CLKDIS()        (RCC->APB2ENR &= ~RCC_APB2ENR_SPI1EN)
+#define SPI_0_BUS_DIV         1   /* 1 -> SPI runs with half CPU clock, 0 -> quarter CPU clock */
 #define SPI_0_IRQ             SPI1_IRQn
 #define SPI_0_IRQ_HANDLER     isr_spi1
 /* SPI 0 pin configuration */

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -227,6 +227,7 @@ extern "C" {
 #define SPI_0_DEV               SPI1
 #define SPI_0_CLKEN()           (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
 #define SPI_0_CLKDIS()          (RCC->APB2ENR &= ~RCC_APB2ENR_SPI1EN)
+#define SPI_0_BUS_DIV           1   /* 1 -> SPI runs with half CPU clock, 0 -> quarter CPU clock */
 #define SPI_0_IRQ               SPI1_IRQn
 #define SPI_0_IRQ_HANDLER       isr_spi1
 /* SPI 0 pin configuration */
@@ -247,6 +248,7 @@ extern "C" {
 #define SPI_1_DEV               SPI2
 #define SPI_1_CLKEN()           (RCC->APB1ENR |= RCC_APB1ENR_SPI2EN)
 #define SPI_1_CLKDIS()          (RCC->APB1ENR &= ~RCC_APB1ENR_SPI2EN)
+#define SPI_1_BUS_DIV           0   /* 1 -> SPI runs with half CPU clock, 0 -> quarter CPU clock */
 #define SPI_1_IRQ               SPI2_IRQn
 #define SPI_1_IRQ_HANDLER       isr_spi2
 /* SPI 1 pin configuration */

--- a/cpu/stm32f4/periph/spi.c
+++ b/cpu/stm32f4/periph/spi.c
@@ -42,6 +42,19 @@ static inline void irq_handler_transfer(SPI_TypeDef *spi, spi_t dev);
 
 static spi_state_t spi_config[SPI_NUMOF];
 
+/* static bus div mapping */
+static const uint8_t spi_bus_div_map[SPI_NUMOF] = {
+#if SPI_0_EN
+    [SPI_0] = SPI_0_BUS_DIV,
+#endif
+#if SPI_1_EN
+    [SPI_1] = SPI_1_BUS_DIV,
+#endif
+#if SPI_2_EN
+    [SPI_2] = SPI_2_BUS_DIV,
+#endif
+};
+
 int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
 {
     uint8_t speed_devider;
@@ -49,19 +62,19 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
 
     switch (speed) {
         case SPI_SPEED_100KHZ:
-            return -2;          /* not possible for stm32f4 */
+            return -2;          /* not possible for stm32f4, APB2 minimum is 328 kHz */
             break;
         case SPI_SPEED_400KHZ:
-            speed_devider = 7;  /* makes 656 kHz */
+            speed_devider = 0x05 + spi_bus_div_map[dev];  /* makes 656 kHz */
             break;
         case SPI_SPEED_1MHZ:
-            speed_devider = 6;  /* makes 1.3 MHz */
+            speed_devider = 0x04 + spi_bus_div_map[dev];  /* makes 1.3 MHz */
             break;
         case SPI_SPEED_5MHZ:
-            speed_devider = 4;  /* makes 5.3 MHz */
+            speed_devider = 0x02 + spi_bus_div_map[dev];  /* makes 5.3 MHz */
             break;
         case SPI_SPEED_10MHZ:
-            speed_devider = 3;  /* makes 10.5 MHz */
+            speed_devider = 0x01 + spi_bus_div_map[dev];  /* makes 10.5 MHz */
             break;
         default:
             return -1;


### PR DESCRIPTION
The baudrate control for the SPIs are currently not set correctly during initialization. The SPIs on the stm32f4xx series run either on the APB1 or the APB2 bus which are clocked differently (APB1=42MHz, APB2=84MHz). Therefore during spi initialization we need to distinguish between the two possible clock rates to compute our prescaler.

Additionally, the previously configured prescalers were wrong as well and didn't lead to the desired speed on either bus. Please refer to baud rate control bits in the control register at page 905 of the [reference manual](www.st.com/web/en/resource/technical/document/reference_manual/DM00031020.pdf) where f_pclk is the clock speed of the used bus.