### PR TITLE
drivers/periph/spi: Implement thread safety for all SPI devices

### DIFF
--- a/cpu/stm32f0/periph/spi.c
+++ b/cpu/stm32f0/periph/spi.c
@@ -16,12 +16,14 @@
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  * @author      Hauke Petersen <mail@haukepetersen.de>
  * @author      Fabian Nack <nack@inf.fu-berlin.de>
+ * @author      Joakim Gebart <joakim.gebart@eistec.se>
  *
  * @}
  */
 
 #include "cpu.h"
 #include "board.h"
+#include "mutex.h"
 #include "periph/spi.h"
 #include "periph_conf.h"
 #include "thread.h"
@@ -29,6 +31,21 @@
 
 /* guard file in case no SPI device is defined */
 #if SPI_NUMOF
+
+/**
+ * @brief Array holding one pre-initialized mutex for each SPI device
+ */
+static mutex_t locks[] =  {
+#if SPI_0_EN
+    [SPI_0] = MUTEX_INIT,
+#endif
+#if SPI_1_EN
+    [SPI_1] = MUTEX_INIT,
+#endif
+#if SPI_2_EN
+    [SPI_2] = MUTEX_INIT
+#endif
+};
 
 int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
 {
@@ -139,6 +156,24 @@ int spi_conf_pins(spi_t dev)
         port->AFR[hl] |= (af << ((pin[i] - (hl * 8)) * 4));
     }
 
+    return 0;
+}
+
+int spi_acquire(spi_t dev)
+{
+    if (dev >= SPI_NUMOF) {
+        return -1;
+    }
+    mutex_lock(&locks[dev]);
+    return 0;
+}
+
+int spi_release(spi_t dev)
+{
+    if (dev >= SPI_NUMOF) {
+        return -1;
+    }
+    mutex_unlock(&locks[dev]);
     return 0;
 }
 

--- a/cpu/stm32f1/periph/spi.c
+++ b/cpu/stm32f1/periph/spi.c
@@ -15,11 +15,14 @@
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  * @author      Fabian Nack <nack@inf.fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Joakim Gebart <joakim.gebart@eistec.se>
  *
  * @}
  */
 
 #include "stm32f10x.h"
+#include "mutex.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
 #include "periph_conf.h"
@@ -30,6 +33,21 @@
 
 /* guard file in case no SPI device is defined */
 #if SPI_0_EN
+
+/**
+ * @brief Array holding one pre-initialized mutex for each SPI device
+ */
+static mutex_t locks[] =  {
+#if SPI_0_EN
+    [SPI_0] = MUTEX_INIT,
+#endif
+#if SPI_1_EN
+    [SPI_1] = MUTEX_INIT,
+#endif
+#if SPI_2_EN
+    [SPI_2] = MUTEX_INIT
+#endif
+};
 
 int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
 {
@@ -122,6 +140,24 @@ int spi_conf_pins(spi_t dev)
         }
     }
 
+    return 0;
+}
+
+int spi_acquire(spi_t dev)
+{
+    if (dev >= SPI_NUMOF) {
+        return -1;
+    }
+    mutex_lock(&locks[dev]);
+    return 0;
+}
+
+int spi_release(spi_t dev)
+{
+    if (dev >= SPI_NUMOF) {
+        return -1;
+    }
+    mutex_unlock(&locks[dev]);
     return 0;
 }
 

--- a/drivers/at86rf231/at86rf231.c
+++ b/drivers/at86rf231/at86rf231.c
@@ -411,7 +411,9 @@ int at86rf231_get_monitor(void)
 void at86rf231_gpio_spi_interrupts_init(void)
 {
     /* SPI init */
+    spi_acquire(AT86RF231_SPI);
     spi_init_master(AT86RF231_SPI, SPI_CONF_FIRST_RISING, SPI_SPEED);
+    spi_release(AT86RF231_SPI);
     /* IRQ0 */
     gpio_init_int(AT86RF231_INT, GPIO_NOPULL, GPIO_RISING, (gpio_cb_t)at86rf231_rx_irq, NULL);
     /* CS */

--- a/drivers/at86rf231/at86rf231_spi.c
+++ b/drivers/at86rf231/at86rf231_spi.c
@@ -15,6 +15,7 @@
  *
  * @author      Alaeddine Weslati <alaeddine.weslati@inria.fr>
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ * @author      Joakim Gebart <joakim.gebart@eistec.se>
  *
  * @}
  */
@@ -27,29 +28,39 @@
 
 void at86rf231_reg_write(uint8_t addr, uint8_t value)
 {
+    /* Acquire exclusive access to the bus. */
+    spi_acquire(AT86RF231_SPI);
     /* Start the SPI transfer */
     gpio_clear(AT86RF231_CS);
     /* write to register */
     spi_transfer_reg(AT86RF231_SPI, AT86RF231_ACCESS_REG | AT86RF231_ACCESS_WRITE | addr, value, 0);
     /* End the SPI transfer */
     gpio_set(AT86RF231_CS);
+    /* Release the bus for other threads. */
+    spi_release(AT86RF231_SPI);
 }
 
 uint8_t at86rf231_reg_read(uint8_t addr)
 {
     char value;
 
+    /* Acquire exclusive access to the bus. */
+    spi_acquire(AT86RF231_SPI);
     /* Start the SPI transfer */
     gpio_clear(AT86RF231_CS);
     /* read from register */
     spi_transfer_reg(AT86RF231_SPI, AT86RF231_ACCESS_REG | AT86RF231_ACCESS_READ | addr, 0, &value);
     /* End the SPI transfer */
     gpio_set(AT86RF231_CS);
+    /* Release the bus for other threads. */
+    spi_release(AT86RF231_SPI);
     return (uint8_t)value;
 }
 
 void at86rf231_read_fifo(uint8_t *data, radio_packet_length_t length)
 {
+    /* Acquire exclusive access to the bus. */
+    spi_acquire(AT86RF231_SPI);
     /* Start the SPI transfer */
     gpio_clear(AT86RF231_CS);
     /* Read a number of bytes from the devices frame buffer */
@@ -57,10 +68,14 @@ void at86rf231_read_fifo(uint8_t *data, radio_packet_length_t length)
                       0, (char*)data, length);
     /* End the SPI transfer */
     gpio_set(AT86RF231_CS);
+    /* Release the bus for other threads. */
+    spi_release(AT86RF231_SPI);
 }
 
 void at86rf231_write_fifo(const uint8_t *data, radio_packet_length_t length)
 {
+    /* Acquire exclusive access to the bus. */
+    spi_acquire(AT86RF231_SPI);
     /* Start the SPI transfer */
     gpio_clear(AT86RF231_CS);
     /* Send Frame Buffer Write access */
@@ -68,6 +83,8 @@ void at86rf231_write_fifo(const uint8_t *data, radio_packet_length_t length)
                       (char*)data, 0, length);
     /* End the SPI transfer */
     gpio_set(AT86RF231_CS);
+    /* Release the bus for other threads. */
+    spi_release(AT86RF231_SPI);
 }
 
 uint8_t at86rf231_get_status(void)

--- a/drivers/cc110x/cc110x-spi.c
+++ b/drivers/cc110x/cc110x-spi.c
@@ -16,6 +16,7 @@
  * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>
  * @author      Heiko Will <hwill@inf.fu-berlin.de>
  * @author      Fabian Nack <nack@inf.fu-berlin.de>
+ * @author      Joakim Gebart <joakim.gebart@eistec.se>
  * @}
  */
 
@@ -65,17 +66,22 @@ void cc110x_cs(void)
 
 void cc110x_writeburst_reg(uint8_t addr, char *src, uint8_t count)
 {
-    unsigned int cpsr = disableIRQ();
+    unsigned int cpsr;
+    spi_acquire(CC110X_SPI);
+    cpsr = disableIRQ();
     cc110x_cs();
     spi_transfer_regs(CC110X_SPI, addr | CC1100_WRITE_BURST, src, 0, count);
     gpio_set(CC110X_CS);
     restoreIRQ(cpsr);
+    spi_release(CC110X_SPI);
 }
 
 void cc110x_readburst_reg(uint8_t addr, char *buffer, uint8_t count)
 {
     int i = 0;
-    unsigned int cpsr = disableIRQ();
+    unsigned int cpsr;
+    spi_acquire(CC110X_SPI);
+    cpsr = disableIRQ();
     cc110x_cs();
     spi_transfer_byte(CC110X_SPI, addr | CC1100_READ_BURST, 0);
     while (i < count) {
@@ -84,46 +90,59 @@ void cc110x_readburst_reg(uint8_t addr, char *buffer, uint8_t count)
     }
     gpio_set(CC110X_CS);
     restoreIRQ(cpsr);
+    spi_release(CC110X_SPI);
 }
 
 void cc110x_write_reg(uint8_t addr, uint8_t value)
 {
-    unsigned int cpsr = disableIRQ();
+    unsigned int cpsr;
+    spi_acquire(CC110X_SPI);
+    cpsr = disableIRQ();
     cc110x_cs();
     spi_transfer_reg(CC110X_SPI, addr, value, 0);
     gpio_set(CC110X_CS);
     restoreIRQ(cpsr);
+    spi_release(CC110X_SPI);
 }
 
 uint8_t cc110x_read_reg(uint8_t addr)
 {
     char result;
-    unsigned int cpsr = disableIRQ();
+    unsigned int cpsr;
+    spi_acquire(CC110X_SPI);
+    cpsr = disableIRQ();
     cc110x_cs();
     spi_transfer_reg(CC110X_SPI, addr | CC1100_READ_SINGLE, CC1100_NOBYTE, &result);
     gpio_set(CC110X_CS);
     restoreIRQ(cpsr);
+    spi_release(CC110X_SPI);
     return (uint8_t) result;
 }
 
 uint8_t cc110x_read_status(uint8_t addr)
 {
     char result;
-    unsigned int cpsr = disableIRQ();
+    unsigned int cpsr;
+    spi_acquire(CC110X_SPI);
+    cpsr = disableIRQ();
     cc110x_cs();
     spi_transfer_reg(CC110X_SPI, addr | CC1100_READ_BURST, CC1100_NOBYTE, &result);
     gpio_set(CC110X_CS);
     restoreIRQ(cpsr);
+    spi_release(CC110X_SPI);
     return (uint8_t) result;
 }
 
 uint8_t cc110x_strobe(uint8_t c)
 {
     char result;
-    unsigned int cpsr = disableIRQ();
+    unsigned int cpsr;
+    spi_acquire(CC110X_SPI);
+    cpsr = disableIRQ();
     cc110x_cs();
     spi_transfer_byte(CC110X_SPI, c, &result);
     gpio_set(CC110X_CS);
     restoreIRQ(cpsr);
+    spi_release(CC110X_SPI);
     return (uint8_t) result;
 }

--- a/drivers/cc110x/cc110x.c
+++ b/drivers/cc110x/cc110x.c
@@ -76,7 +76,9 @@ int cc110x_initialize(netdev_t *dev)
 
     /* Configure SPI */
     spi_poweron(CC110X_SPI);
+    spi_acquire(CC110X_SPI);
     spi_init_master(CC110X_SPI, SPI_CONF_FIRST_RISING, SPI_SPEED_5MHZ);
+    spi_release(CC110X_SPI);
 
     /* Load driver & reset */
     power_up_reset();

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -10,10 +10,12 @@
  * @ingroup     drivers_nrf24l01p
  * @{
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ * @author      Joakim Gebart <joakim.gebart@eistec.se>
  * @}
  */
 #include "nrf24l01p.h"
 #include "nrf24l01p_settings.h"
+#include "mutex.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
 #include "hwtimer.h"
@@ -29,11 +31,15 @@ int nrf24l01p_read_reg(nrf24l01p_t *dev, char reg, char *answer)
 {
     int status;
 
+    /* Acquire exclusive access to the bus. */
+    spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     status = spi_transfer_reg(dev->spi, (CMD_R_REGISTER | (REGISTER_MASK & reg)), CMD_NOP, answer);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
+    /* Release the bus for other threads. */
+    spi_release(dev->spi);
 
     hwtimer_spin(DELAY_AFTER_FUNC_TICKS);
 
@@ -45,11 +51,15 @@ int nrf24l01p_write_reg(nrf24l01p_t *dev, char reg, char write)
     int status;
     char reg_content;
 
+    /* Acquire exclusive access to the bus. */
+    spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     status = spi_transfer_reg(dev->spi, (CMD_W_REGISTER | (REGISTER_MASK & reg)), write, &reg_content);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
+    /* Release the bus for other threads. */
+    spi_release(dev->spi);
 
     hwtimer_spin(DELAY_AFTER_FUNC_TICKS);
 
@@ -82,7 +92,9 @@ int nrf24l01p_init(nrf24l01p_t *dev, spi_t spi, gpio_t ce, gpio_t cs, gpio_t irq
 
     /* Init SPI */
     spi_poweron(dev->spi);
+    spi_acquire(dev->spi);
     status = spi_init_master(dev->spi, SPI_CONF_FIRST_RISING, SPI_SPEED_400KHZ);
+    spi_release(dev->spi);
 
     if (status < 0) {
         return status;
@@ -223,12 +235,16 @@ int nrf24l01p_read_payload(nrf24l01p_t *dev, char *answer, unsigned int size)
 {
     int status;
 
+    /* Acquire exclusive access to the bus. */
+    spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     status = spi_transfer_regs(dev->spi, CMD_R_RX_PAYLOAD, 0, answer, size);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
     hwtimer_spin(DELAY_AFTER_FUNC_TICKS);
+    /* Release the bus for other threads. */
+    spi_release(dev->spi);
 
     return status;
 }
@@ -272,11 +288,15 @@ int nrf24l01p_preload(nrf24l01p_t *dev, char *data, unsigned int size)
 
     size = (size <= 32) ? size : 32;
 
+    /* Acquire exclusive access to the bus. */
+    spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     status = spi_transfer_regs(dev->spi, CMD_W_TX_PAYLOAD, data, NULL, size);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
+    /* Release the bus for other threads. */
+    spi_release(dev->spi);
 
     hwtimer_spin(DELAY_AFTER_FUNC_TICKS);
 
@@ -373,11 +393,15 @@ int nrf24l01p_set_tx_address(nrf24l01p_t *dev, char *saddr, unsigned int length)
 {
     int status;
 
+    /* Acquire exclusive access to the bus. */
+    spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     status = spi_transfer_regs(dev->spi, (CMD_W_REGISTER | (REGISTER_MASK & REG_TX_ADDR)), saddr, NULL, length); /* address width is 5 byte */
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
+    /* Release the bus for other threads. */
+    spi_release(dev->spi);
 
     hwtimer_spin(DELAY_AFTER_FUNC_TICKS);
 
@@ -400,11 +424,15 @@ int nrf24l01p_set_tx_address_long(nrf24l01p_t *dev, uint64_t saddr, unsigned int
         return -1;
     }
 
+    /* Acquire exclusive access to the bus. */
+    spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     status = spi_transfer_regs(dev->spi, (CMD_W_REGISTER | (REGISTER_MASK & REG_TX_ADDR)), buf, NULL, length); /* address width is 5 byte */
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
+    /* Release the bus for other threads. */
+    spi_release(dev->spi);
 
     hwtimer_spin(DELAY_AFTER_FUNC_TICKS);
 
@@ -417,11 +445,15 @@ uint64_t nrf24l01p_get_tx_address_long(nrf24l01p_t *dev)
     uint64_t saddr_64 = 0;
     char addr_array[INITIAL_ADDRESS_WIDTH];
 
+    /* Acquire exclusive access to the bus. */
+    spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     status = spi_transfer_regs(dev->spi, (CMD_R_REGISTER | (REGISTER_MASK & REG_TX_ADDR)), 0, addr_array, INITIAL_ADDRESS_WIDTH); /* address width is 5 byte */
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
+    /* Release the bus for other threads. */
+    spi_release(dev->spi);
 
     hwtimer_spin(DELAY_AFTER_FUNC_TICKS);
 
@@ -473,11 +505,15 @@ int nrf24l01p_set_rx_address(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char *s
             return -1;
     }
 
+    /* Acquire exclusive access to the bus. */
+    spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     status = spi_transfer_regs(dev->spi, (CMD_W_REGISTER | (REGISTER_MASK & pipe_addr)), saddr, NULL, length); /* address width is 5 byte */
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
+    /* Release the bus for other threads. */
+    spi_release(dev->spi);
 
     hwtimer_spin(DELAY_AFTER_FUNC_TICKS);
 
@@ -541,11 +577,15 @@ uint64_t nrf24l01p_get_rx_address_long(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pip
             return -1;
     }
 
+    /* Acquire exclusive access to the bus. */
+    spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     status = spi_transfer_regs(dev->spi, (CMD_R_REGISTER | (REGISTER_MASK & pipe_addr)), 0, addr_array, INITIAL_ADDRESS_WIDTH); /* address width is 5 byte */
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
+    /* Release the bus for other threads. */
+    spi_release(dev->spi);
 
     if (status < 0) {
         return -1;
@@ -592,11 +632,15 @@ int nrf24l01p_set_datarate(nrf24l01p_t *dev, nrf24l01p_dr_t dr)
 int nrf24l01p_get_status(nrf24l01p_t *dev)
 {
     char status;
+    /* Acquire exclusive access to the bus. */
+    spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     spi_transfer_byte(dev->spi, CMD_NOP, &status);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
+    /* Release the bus for other threads. */
+    spi_release(dev->spi);
 
     hwtimer_spin(DELAY_AFTER_FUNC_TICKS);
 
@@ -831,11 +875,15 @@ int nrf24l01p_flush_tx_fifo(nrf24l01p_t *dev)
     int status;
     char reg_content;
 
+    /* Acquire exclusive access to the bus. */
+    spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     status = spi_transfer_byte(dev->spi, CMD_FLUSH_TX, &reg_content);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
+    /* Release the bus for other threads. */
+    spi_release(dev->spi);
 
     hwtimer_spin(DELAY_AFTER_FUNC_TICKS);
 
@@ -847,12 +895,15 @@ int nrf24l01p_flush_rx_fifo(nrf24l01p_t *dev)
     int status;
     char reg_content;
 
+    /* Acquire exclusive access to the bus. */
+    spi_acquire(dev->spi);
     gpio_clear(dev->cs);
-
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     status = spi_transfer_byte(dev->spi, CMD_FLUSH_RX, &reg_content);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
+    /* Release the bus for other threads. */
+    spi_release(dev->spi);
 
     hwtimer_spin(DELAY_AFTER_FUNC_TICKS);
 

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -189,12 +189,10 @@ int nrf24l01p_on(nrf24l01p_t *dev)
     char read;
     int status;
 
-    gpio_clear(dev->cs);
     nrf24l01p_read_reg(dev, REG_CONFIG, &read);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     status = nrf24l01p_write_reg(dev, REG_CONFIG, (read | PWR_UP));
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
-    gpio_set(dev->cs);
 
     hwtimer_wait(DELAY_CHANGE_PWR_MODE_US);
 
@@ -206,12 +204,10 @@ int nrf24l01p_off(nrf24l01p_t *dev)
     char read;
     int status;
 
-    gpio_clear(dev->cs);
     nrf24l01p_read_reg(dev, REG_CONFIG, &read);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     status = nrf24l01p_write_reg(dev, REG_CONFIG, (read & ~PWR_UP));
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
-    gpio_set(dev->cs);
 
     hwtimer_wait(DELAY_CHANGE_PWR_MODE_US);
 

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -190,9 +190,7 @@ int nrf24l01p_on(nrf24l01p_t *dev)
     int status;
 
     nrf24l01p_read_reg(dev, REG_CONFIG, &read);
-    hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     status = nrf24l01p_write_reg(dev, REG_CONFIG, (read | PWR_UP));
-    hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
 
     hwtimer_wait(DELAY_CHANGE_PWR_MODE_US);
 
@@ -205,9 +203,7 @@ int nrf24l01p_off(nrf24l01p_t *dev)
     int status;
 
     nrf24l01p_read_reg(dev, REG_CONFIG, &read);
-    hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     status = nrf24l01p_write_reg(dev, REG_CONFIG, (read & ~PWR_UP));
-    hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
 
     hwtimer_wait(DELAY_CHANGE_PWR_MODE_US);
 

--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -178,7 +178,9 @@ void cmd_init_master(int argc, char **argv)
     if (parse_spi_dev(argc, argv) < 0) {
         return;
     }
+    spi_acquire(spi_dev);
     res = spi_init_master(spi_dev, spi_mode, spi_speed);
+    spi_release(spi_dev);
     if (res < 0) {
         printf("spi_init_master: error initializing SPI_%i device (code %i)\n", spi_dev, res);
         return;
@@ -202,7 +204,9 @@ void cmd_init_slave(int argc, char **argv)
     if (parse_spi_dev(argc, argv) < 0) {
         return;
     }
+    spi_acquire(spi_dev);
     res = spi_init_slave(spi_dev, spi_mode, slave_on_data);
+    spi_release(spi_dev);
     if (res < 0) {
         printf("spi_init_slave: error initializing SPI_%i device (code: %i)\n", spi_dev, res);
         return;
@@ -236,9 +240,11 @@ void cmd_transfer(int argc, char **argv)
     }
 
     /* do the actual data transfer */
+    spi_acquire(spi_dev);
     gpio_clear(spi_cs);
     res = spi_transfer_bytes(spi_dev, hello, buffer, strlen(hello));
     gpio_set(spi_cs);
+    spi_release(spi_dev);
 
     /* look at the results */
     if (res < 0) {


### PR DESCRIPTION
This implements #2314 for the SPI drivers. (edit: Except for STM32F4 which is implemented in #2290)
I added the generic implementation of SPI thread safety as proposed by @haukepetersen in #2290 to all CPU `periph/spi` implementations and made all drivers which are currently using `periph/spi` to acquire/release the bus when necessary.

I also found a mistake in the nrf24l01p driver, the CS line was cleared/set twice when turning on/off the device.