### PR TITLE
boards/samr21-xpro: enable specifying a flash port

### DIFF
--- a/boards/samr21-xpro/Makefile.include
+++ b/boards/samr21-xpro/Makefile.include
@@ -33,6 +33,9 @@ export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O ihex
 export TERMFLAGS += -p "$(PORT)"
 export FFLAGS = flash
+ifneq (,$(SERIAL))
+export FFLAGS += "-c cmsis_dap_serial $(SERIAL)"
+endif
 export DEBUGGER_FLAGS = debug
 export DEBUGSERVER_FLAGS = debug-server
 export RESET_FLAGS = reset


### PR DESCRIPTION
Usage:
```
BOARD=samr21-xpro SERIAL='ATML1234321000001234' make flash
```

By the way, the old syntax still works:
```
BOARD=samr21-xpro make flash
```
This would just use the default device as before.

edit: updated syntax