### PR TITLE
periph/random: simplify random API

### DIFF
--- a/cpu/cc2538/periph/random.c
+++ b/cpu/cc2538/periph/random.c
@@ -27,7 +27,7 @@
 /* only compile this driver if enabled in the board's periph_conf.h */
 #if RANDOM_NUMOF
 
-void random_init(void)
+void random_poweron(void)
 {
     uint16_t seed = 0;
     int i;
@@ -71,8 +71,6 @@ void random_init(void)
 
     /* Turn RF off: */
     RFCORE_SFR_RFST = ISRFOFF;
-
-    random_poweron();
 }
 
 int random_read(char *buf, unsigned int num)
@@ -90,10 +88,6 @@ int random_read(char *buf, unsigned int num)
     }
 
     return count;
-}
-
-void random_poweron(void)
-{
 }
 
 void random_poweroff(void)

--- a/cpu/native/periph/random.c
+++ b/cpu/native/periph/random.c
@@ -48,25 +48,6 @@ unsigned _native_rng_read_hq(char *buf, unsigned num);
  * public API implementation
  **********************************************************************/
 
-void random_init(void)
-{
-    DEBUG("random_init: initializing\n");
-    switch (_native_rng_mode) {
-        case 0:
-            _native_rng_init_hq();
-            break;
-        case 1:
-            _native_rng_init_det();
-            break;
-        default:
-            err(EXIT_FAILURE, "random_init: _native_rng_mode is in invalid state %i\n",
-                   _native_rng_mode);
-            break;
-    }
-    DEBUG("random_init: powering on\n");
-    random_poweron();
-}
-
 int random_read(char *buf, unsigned int num)
 {
     if (!powered) {
@@ -94,6 +75,18 @@ int random_read(char *buf, unsigned int num)
 void random_poweron(void)
 {
     DEBUG("random_poweron: power on\n");
+    switch (_native_rng_mode) {
+        case 0:
+            _native_rng_init_hq();
+            break;
+        case 1:
+            _native_rng_init_det();
+            break;
+        default:
+            err(EXIT_FAILURE, "random_init: _native_rng_mode is in invalid state %i\n",
+                   _native_rng_mode);
+            break;
+    }
     powered = 1;
 }
 

--- a/cpu/nrf51822/periph/random.c
+++ b/cpu/nrf51822/periph/random.c
@@ -25,12 +25,6 @@
 /* guard file in case no random device was specified */
 #if RANDOM_NUMOF
 
-void random_init(void)
-{
-    NRF_RNG->POWER = 1;
-    NRF_RNG->TASKS_START = 1;
-}
-
 int random_read(char *buf, unsigned int num)
 {
     unsigned int count = 0;
@@ -47,6 +41,7 @@ int random_read(char *buf, unsigned int num)
 void random_poweron(void)
 {
     NRF_RNG->POWER = 1;
+    NRF_RNG->TASKS_START = 1;
 }
 
 void random_poweroff(void)

--- a/cpu/sam3x8e/periph/random.c
+++ b/cpu/sam3x8e/periph/random.c
@@ -31,11 +31,6 @@
  */
 #define KEY             (0x524e4700)
 
-void random_init(void)
-{
-    random_poweron();
-}
-
 int random_read(char *buf, unsigned int num)
 {
     /* cppcheck-suppress variableScope */

--- a/cpu/stm32f4/periph/random.c
+++ b/cpu/stm32f4/periph/random.c
@@ -25,11 +25,6 @@
 /* ignore file in case no RNG device is defined */
 #if RANDOM_NUMOF
 
-void random_init(void)
-{
-    random_poweron();
-}
-
 int random_read(char *buf, unsigned int num)
 {
     /* cppcheck-suppress variableScope */

--- a/drivers/include/periph/random.h
+++ b/drivers/include/periph/random.h
@@ -24,6 +24,7 @@
  * @brief       Low-level random peripheral driver interface definitions
  *
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
+ * @author      Frank Holtz <frank-riot2015@holtznet.de>
  */
 
 #ifndef __RANDOM_H
@@ -39,16 +40,6 @@ extern "C" {
 #if RANDOM_NUMOF
 
 /**
- * @brief Initializes the source of randomness
- *
- * In case of a hardware random number generator, this peripheral
- * is initialized and powered on. If such a device is not present,
- * it depends on the implementation how a source for randomness
- * is created and initialized.
- */
-void random_init(void);
-
-/**
  * @brief Reads num or less bytes of randomness from the source, will
  *        block until random data is available
  *
@@ -62,7 +53,14 @@ void random_init(void);
 int random_read(char *buf, unsigned int num);
 
 /**
- * @brief Power on the random number generator
+ * @brief Initializes the source of randomness
+ *
+ * In case of a hardware random number generator, this peripheral
+ * is initialized and powered on. If such a device is not present,
+ * it depends on the implementation how a source for randomness
+ * is created and initialized.
+ * 
+ * @param[in] rng_mode one of rng_modes
  */
 void random_poweron(void);
 

--- a/tests/periph_random/main.c
+++ b/tests/periph_random/main.c
@@ -34,7 +34,7 @@ int main(void)
     printf("This test will print from 1 to %i random bytes about every second\n\n", LIMIT);
 
     puts("Initializing Random Number Generator driver.\n");
-    random_init();
+    random_poweron();
 
     while (1) {
         /* zero out buffer */


### PR DESCRIPTION
This PR changes random API. It removes random_init() and integrates this functionality into random_poweron().

Why i do this?
- Powering RNG on needs extra energy (16-300uA in nRF51 specification) so there is a need to call poweroff() after init() this adds complexity
- When init() is needed an thread must be safe if RNG are initialized or need to call init() and poweron() every time an random number is needed. This adds also complexity. 
- Most implementations do equivalent in init() and poweron()