### PR TITLE
pkt: add functions to allocate packet data [WIP]

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -105,6 +105,10 @@ ifneq (,$(filter net_if,$(USEMODULE)))
 	USEMODULE += hashes
 endif
 
+ifneq (,$(filter pkt,$(USEMODULE)))
+	USEMODULE += pktbuf
+endif
+
 ifneq (,$(filter ccn_lite,$(USEMODULE)))
 	USEMODULE += crypto
 endif

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -25,6 +25,9 @@ endif
 ifneq (,$(filter net_if,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include
 endif
+ifneq (,$(filter pkt,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include
+endif
 ifneq (,$(filter pktbuf,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include
 endif

--- a/sys/net/crosslayer/pkt/pkt.c
+++ b/sys/net/crosslayer/pkt/pkt.c
@@ -9,10 +9,39 @@
 /**
  * @{
  *
- * @file    pkt.c
+ * @file
  */
 
+#include <errno.h>
+
 #include "pkt.h"
+#include "pktbuf.h"
+
+pkt_t *pkt_init(pkt_t *pkt, void *payload_data, pktsize_t payload_len)
+{
+    if (pktbuf_contains(payload_data)) {
+        pkt->payload_data = payload_data;
+    }
+    else {
+        pkt->payload_data = (payload_data == NULL) ? pktbuf_alloc(payload_len) :
+                            pktbuf_insert(payload_data, payload_len);
+    }
+
+    pkt->payload_len = payload_len;
+    return (pkt->payload_data) ? pkt : NULL;
+}
+
+pkt_t *pkt_realloc(pkt_t *pkt, pktsize_t payload_len)
+{
+    void *data = pktbuf_realloc(pkt->payload_data, payload_len);
+
+    if (data == NULL) {
+        return NULL;
+    }
+
+    pkt->payload_len = payload_len;
+    return (pkt->payload_data) ? pkt : NULL;
+}
 
 pktsize_t pkt_hlist_len(pkt_hlist_t *list)
 {
@@ -64,6 +93,87 @@ void pkt_hlist_remove(pkt_hlist_t **list, pkt_hlist_t *header)
         }
     }
 
+}
+
+int pkt_add_header(pkt_t *pkt, void *header_data, pktsize_t header_len,
+                   pkt_proto_t header_proto)
+{
+    pkt_hlist_t header, *ptr;
+
+#ifdef DEVELHELP
+
+    if (pkt == NULL) {
+        return -EINVAL;
+    }
+
+#endif
+
+    if (header_data == NULL) {
+        if ((header.header_data = pktbuf_alloc(header_len)) == NULL) {
+            return -ENOMEM;
+        }
+    }
+    else if (pktbuf_contains(header_data)) {
+        header.header_data = header_data;
+    }
+    else {
+        if ((header.header_data = pktbuf_insert(header_data, header_len)) == NULL) {
+            return -ENOMEM;
+        }
+    }
+
+    header.header_len = header_len;
+    header.header_proto = header_proto;
+
+    if ((ptr = pktbuf_insert(&header, sizeof(pkt_hlist_t))) == NULL) {
+        pktbuf_release(header.header_data);
+        return -ENOMEM;
+    }
+
+    pkt_hlist_add(&(pkt->headers), ptr);
+
+    return 0;
+}
+
+void pkt_remove_header(pkt_t *pkt, pkt_hlist_t *header)
+{
+#ifdef DEVELHELP
+
+    if (pkt == NULL) {
+        return;
+    }
+
+#endif
+
+    pkt_hlist_remove(&(pkt->headers), header);
+    pkt_release(header->header_data);
+    pkt_release((void *)header);
+}
+
+void pkt_hold(pkt_t *pkt)
+{
+    pkt_hlist_t *ptr = pkt->headers;
+
+    pktbuf_hold(pkt->payload_data);
+
+    while (ptr) {
+        pktbuf_hold(ptr);
+        pktbuf_hold(ptr->header_data);
+        pkt_hlist_advance(&ptr);
+    }
+}
+
+void pkt_release(pkt_t *pkt)
+{
+    pkt_hlist_t *ptr = pkt->headers;
+
+    pktbuf_release(pkt->payload_data);
+
+    while (ptr) {
+        pktbuf_release(ptr);
+        pktbuf_release(ptr->header_data);
+        pkt_hlist_advance(&ptr);
+    }
 }
 
 /** @} */


### PR DESCRIPTION
Alternative to #2285. Still WIP (tests need to be adapted).

There were two problems in #2285:

1) To move the pointer `pkt->payload_data` was not thread-safe.
2) adding new headers would always require allocate new data (just because of the way the pktbuf was handled internally there).

The solution for both is more or less to keep `pktbuf` a void pointer oriented buffer and (for (1) specifically) to not put `pkt_t` structs into it. This way every thread is responsible for their own instance of `pkt_t` and a moving `payload_data` is not the problem anymore. The header problem get's solved, since the internal organizing structure does not inherit from `pkt_header_t` anymore now.

Since through this we lost some requirements for `pkt`, I simplified it a little:
* I moved `pkt.h` to `sys/net/include` since it has `pktbuf` as dependency anyway (technically this is not due to a requirement-loss ;-))
* I removed the `packed` attribute from `pkt_t` since it is not stored in the `pktbuf` anymore
* I removed the member `payload_proto` from `pkt_t` since I don't see any use-case for it and we save this way a few byte. It was introduced, since I needed a relationship between `pkt_t` and `pkt_hlist_t` to use a modified version of them as `pktbuf`'s internal organizing structure.