### PR TITLE
drivers/... : Acquire exclusive access to I2C bus

### DIFF
--- a/drivers/l3g4200d/l3g4200d.c
+++ b/drivers/l3g4200d/l3g4200d.c
@@ -14,12 +14,14 @@
  * @brief       Device driver implementation for the L3G4200D gyroscope
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  *
  * @}
  */
 
 #include <stdint.h>
 
+#include "mutex.h"
 #include "l3g4200d.h"
 #include "l3g4200d-regs.h"
 #include "periph/i2c.h"
@@ -38,10 +40,15 @@ int l3g4200d_init(l3g4200d_t *dev, i2c_t i2c, uint8_t address,
 {
     char tmp;
 
+    /* Acquire exclusive access to the bus. */
+    i2c_acquire(dev->i2c);
     /* initialize the I2C bus */
     if (i2c_init_master(i2c, I2C_SPEED) < 0) {
+        /* Release the bus for other threads. */
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     /* write device descriptor */
     dev->i2c = i2c;
@@ -67,13 +74,17 @@ int l3g4200d_init(l3g4200d_t *dev, i2c_t i2c, uint8_t address,
 
     /* configure CTRL_REG1 */
     tmp = ((mode & 0xf) << L3G4200D_CTRL1_MODE_POS) | L3G4200D_CTRL1_ALLON;
+    i2c_acquire(dev->i2c);
     if (i2c_write_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL1, tmp) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
     tmp = ((scale & 0x3) << L3G4200D_CTRL4_FS_POS) | L3G4200D_CTRL4_BDU;
     if (i2c_write_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL4, tmp) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
     return 0;
 }
 
@@ -82,8 +93,10 @@ int l3g4200d_read(l3g4200d_t *dev, l3g4200d_data_t *data)
     char tmp[6];
     int16_t res;
 
+    i2c_acquire(dev->i2c);
     /* get acceleration in x direction */
     i2c_read_regs(dev->i2c, dev->addr, L3G4200D_REG_OUT_X_L | L3G4200D_AUTOINC, tmp, 6);
+    i2c_release(dev->i2c);
 
     /* parse and normalize data into result vector */
     res = (tmp[1] << 8) | tmp[0];
@@ -100,14 +113,18 @@ int l3g4200d_enable(l3g4200d_t *dev)
     char tmp;
     int res;
 
+    i2c_acquire(dev->i2c);
     res = i2c_read_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL1, &tmp);
     if (res < 1) {
+        i2c_release(dev->i2c);
         return res;
     }
     tmp |= L3G4200D_CTRL1_PD;
     if (i2c_write_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL1, tmp) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
     return 0;
 }
 
@@ -116,13 +133,17 @@ int l3g4200d_disable(l3g4200d_t *dev)
     char tmp;
     int res;
 
+    i2c_acquire(dev->i2c);
     res = i2c_read_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL1, &tmp);
     if (res < 1) {
+        i2c_release(dev->i2c);
         return res;
     }
     tmp &= ~L3G4200D_CTRL1_PD;
     if (i2c_write_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL1, tmp) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
     return 0;
 }

--- a/drivers/l3g4200d/l3g4200d.c
+++ b/drivers/l3g4200d/l3g4200d.c
@@ -21,7 +21,6 @@
 
 #include <stdint.h>
 
-#include "mutex.h"
 #include "l3g4200d.h"
 #include "l3g4200d-regs.h"
 #include "periph/i2c.h"

--- a/drivers/lps331ap/lps331ap.c
+++ b/drivers/lps331ap/lps331ap.c
@@ -25,7 +25,6 @@
 
 #include <stdint.h>
 
-#include "mutex.h"
 #include "periph/i2c.h"
 #include "lps331ap.h"
 #include "lps331ap-internal.h"

--- a/drivers/lps331ap/lps331ap.c
+++ b/drivers/lps331ap/lps331ap.c
@@ -18,12 +18,14 @@
  *       used.
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  *
  * @}
  */
 
 #include <stdint.h>
 
+#include "mutex.h"
 #include "periph/i2c.h"
 #include "lps331ap.h"
 #include "lps331ap-internal.h"
@@ -53,8 +55,12 @@ int lps331ap_init(lps331ap_t *dev, i2c_t i2c, uint8_t address, lps331ap_rate_t r
     dev->i2c = i2c;
     dev->address = address;
 
+    /* Acquire exclusive access to the bus. */
+    i2c_acquire(dev->i2c);
     /* initialize underlying I2C bus */
     if (i2c_init_master(dev->i2c, BUS_SPEED) < 0) {
+        /* Release the bus for other threads. */
+        i2c_release(dev->i2c);
         return -1;
     }
 
@@ -62,8 +68,10 @@ int lps331ap_init(lps331ap_t *dev, i2c_t i2c, uint8_t address, lps331ap_rate_t r
     tmp = LPS331AP_CTRL_REG1_DBDU | LPS331AP_CTRL_REG1_PD |
           (rate << LPS331AP_CTRL_REG1_ODR_POS);
     if (i2c_write_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, tmp) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     return 0;
 }
@@ -74,9 +82,11 @@ int lps331ap_read_temp(lps331ap_t *dev)
     int16_t val = 0;
     float res = TEMP_BASE;      /* reference value -> see datasheet */
 
+    i2c_acquire(dev->i2c);
     i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_TEMP_OUT_L, &tmp);
     val |= tmp;
     i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_TEMP_OUT_H, &tmp);
+    i2c_release(dev->i2c);
     val |= (tmp << 8);
 
     /* compute actual temperature value in °C */
@@ -92,11 +102,13 @@ int lps331ap_read_pres(lps331ap_t *dev)
     int32_t val = 0;
     float res;
 
+    i2c_acquire(dev->i2c);
     i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_PRESS_OUT_XL, &tmp);
     val |= tmp;
     i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_PRESS_OUT_L, &tmp);
     val |= (tmp << 8);
     i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_PRESS_OUT_H, &tmp);
+    i2c_release(dev->i2c);
     val |= (tmp << 16);
     /* see if value is negative */
     if (tmp & 0x80) {
@@ -113,19 +125,33 @@ int lps331ap_read_pres(lps331ap_t *dev)
 int lps331ap_enable(lps331ap_t *dev)
 {
     char tmp;
+    int status;
+
+    i2c_acquire(dev->i2c);
     if (i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, &tmp) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
     tmp |= (LPS331AP_CTRL_REG1_PD);
-    return i2c_write_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, tmp);
+    status = i2c_write_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, tmp);
+    i2c_release(dev->i2c);
+
+    return status;
 }
 
 int lps331ap_disable(lps331ap_t *dev)
 {
     char tmp;
+    int status;
+
+    i2c_acquire(dev->i2c);
     if (i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, &tmp) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
     tmp &= ~(LPS331AP_CTRL_REG1_PD);
-    return i2c_write_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, tmp);
+    status = i2c_write_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, tmp);
+    i2c_release(dev->i2c);
+
+    return status;
 }

--- a/drivers/lsm303dlhc/lsm303dlhc.c
+++ b/drivers/lsm303dlhc/lsm303dlhc.c
@@ -19,7 +19,6 @@
  * @}
  */
 
-#include "mutex.h"
 #include "lsm303dlhc.h"
 #include "lsm303dlhc-internal.h"
 

--- a/drivers/lsm303dlhc/lsm303dlhc.c
+++ b/drivers/lsm303dlhc/lsm303dlhc.c
@@ -14,10 +14,12 @@
  * @brief       Device driver implementation for the LSM303DLHC light sensor
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  *
  * @}
  */
 
+#include "mutex.h"
 #include "lsm303dlhc.h"
 #include "lsm303dlhc-internal.h"
 
@@ -41,11 +43,15 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, i2c_t i2c, gpio_t acc_pin, gpio_t mag_pin
     dev->acc_pin     = acc_pin;
     dev->mag_pin     = mag_pin;
 
+    /* Acquire exclusive access to the bus. */
+    i2c_acquire(dev->i2c);
     i2c_init_master(i2c, I2C_SPEED_NORMAL);
 
     DEBUG("lsm303dlhc reboot ");
     res = i2c_write_reg(dev->i2c, dev->acc_address,
                         LSM303DLHC_REG_CTRL5_A, LSM303DLHC_REG_CTRL5_A_BOOT);
+    /* Release the bus for other threads. */
+    i2c_release(dev->i2c);
     DEBUG("[OK]");
 
     /* configure accelerometer */
@@ -54,6 +60,7 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, i2c_t i2c, gpio_t acc_pin, gpio_t mag_pin
           | LSM303DLHC_CTRL1_A_YEN
           | LSM303DLHC_CTRL1_A_ZEN
           | acc_sample_rate);
+    i2c_acquire(dev->i2c);
     res += i2c_write_reg(dev->i2c, dev->acc_address,
                          LSM303DLHC_REG_CTRL1_A, tmp);
     /* update on read, MSB @ low address, scale and high-resolution */
@@ -77,6 +84,7 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, i2c_t i2c, gpio_t acc_pin, gpio_t mag_pin
     /* set continuous mode */
     res += i2c_write_reg(dev->i2c, dev->mag_address,
                          LSM303DLHC_REG_MR_M, LSM303DLHC_MAG_MODE_CONTINUOUS);
+    i2c_release(dev->i2c);
     /* configure mag data ready pin */
     gpio_init_in(mag_pin, GPIO_NOPULL);
 
@@ -88,6 +96,7 @@ int lsm303dlhc_read_acc(lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data)
     int res;
     char tmp;
 
+    i2c_acquire(dev->i2c);
     i2c_read_reg(dev->i2c, dev->acc_address, LSM303DLHC_REG_STATUS_A, &tmp);
     DEBUG("lsm303dlhc status: %x\n", tmp);
     DEBUG("lsm303dlhc: wait for acc values ... ");
@@ -110,6 +119,7 @@ int lsm303dlhc_read_acc(lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data)
     res += i2c_read_reg(dev->i2c, dev->acc_address,
                         LSM303DLHC_REG_OUT_Z_H_A, &tmp);
     data->z_axis |= tmp<<8;
+    i2c_release(dev->i2c);
     DEBUG("read ... ");
 
     data->x_axis = data->x_axis>>4;
@@ -134,8 +144,10 @@ int lsm303dlhc_read_mag(lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data)
 
     DEBUG("read ... ");
 
+    i2c_acquire(dev->i2c);
     res = i2c_read_regs(dev->i2c, dev->mag_address,
                         LSM303DLHC_REG_OUT_X_H_M, (char*)data, 6);
+    i2c_release(dev->i2c);
 
     if (res < 6) {
         DEBUG("[!!failed!!]\n");
@@ -160,7 +172,9 @@ int lsm303dlhc_read_temp(lsm303dlhc_t *dev, int16_t *value)
 {
     int res;
 
+    i2c_acquire(dev->i2c);
     res = i2c_read_regs(dev->i2c, dev->mag_address, LSM303DLHC_REG_TEMP_OUT_H, (char*)value, 2);
+    i2c_release(dev->i2c);
 
     if (res < 2) {
         return -1;
@@ -176,12 +190,15 @@ int lsm303dlhc_read_temp(lsm303dlhc_t *dev, int16_t *value)
 int lsm303dlhc_disable(lsm303dlhc_t *dev)
 {
     int res;
+
+    i2c_acquire(dev->i2c);
     res = i2c_write_reg(dev->i2c, dev->acc_address,
                         LSM303DLHC_REG_CTRL1_A, LSM303DLHC_CTRL1_A_POWEROFF);
     res += i2c_write_reg(dev->i2c, dev->mag_address,
                         LSM303DLHC_REG_MR_M, LSM303DLHC_MAG_MODE_SLEEP);
     res += i2c_write_reg(dev->i2c, dev->acc_address,
                         LSM303DLHC_REG_CRA_M, LSM303DLHC_TEMP_DIS);
+    i2c_release(dev->i2c);
 
     return (res < 3) ? -1 : 0;
 }
@@ -193,6 +210,7 @@ int lsm303dlhc_enable(lsm303dlhc_t *dev)
                 | LSM303DLHC_CTRL1_A_YEN
                 | LSM303DLHC_CTRL1_A_ZEN
                 | LSM303DLHC_CTRL1_A_N1344HZ_L5376HZ);
+    i2c_acquire(dev->i2c);
     res = i2c_write_reg(dev->i2c, dev->acc_address, LSM303DLHC_REG_CTRL1_A, tmp);
 
     tmp = (LSM303DLHC_CTRL4_A_BDU| LSM303DLHC_CTRL4_A_SCALE_2G | LSM303DLHC_CTRL4_A_HR);
@@ -208,6 +226,7 @@ int lsm303dlhc_enable(lsm303dlhc_t *dev)
 
     res += i2c_write_reg(dev->i2c, dev->mag_address,
                         LSM303DLHC_REG_MR_M, LSM303DLHC_MAG_MODE_CONTINUOUS);
+    i2c_release(dev->i2c);
 
     gpio_init_in(dev->mag_pin, GPIO_NOPULL);
 

--- a/drivers/mag3110/mag3110.c
+++ b/drivers/mag3110/mag3110.c
@@ -15,12 +15,14 @@
  * @brief       Driver for the Freescale MAG3110 magnetometer.
  *
  * @author      Johann Fischer <j.fischer@phytec.de>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  *
  * @}
  */
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "mutex.h"
 #include "periph/i2c.h"
 #include "mag3110.h"
 #include "mag3110_reg.h"
@@ -34,9 +36,14 @@ int mag3110_test(mag3110_t *dev)
 {
     char reg;
 
+    /* Acquire exclusive access to the bus. */
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MAG3110_WHO_AM_I, &reg, 1) != 1) {
+        /* Release the bus for other threads. */
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     if (reg != MAG3110_ID) {
         return -1;
@@ -58,10 +65,13 @@ int mag3110_init(mag3110_t *dev, i2c_t i2c, uint8_t address, uint8_t dros)
         return -1;
     }
 
+    i2c_acquire(dev->i2c);
     /* initialize the I2C bus */
     if (i2c_init_master(i2c, I2C_SPEED) < 0) {
+        i2c_release(dev->i2c);
         return -2;
     }
+    i2c_release(dev->i2c);
 
     if (mag3110_test(dev)) {
         return -3;
@@ -70,15 +80,19 @@ int mag3110_init(mag3110_t *dev, i2c_t i2c, uint8_t address, uint8_t dros)
     /* enable automatic magnetic sensor reset */
     reg = MAG3110_CTRL_REG2_AUTO_MRST_EN;
 
+    i2c_acquire(dev->i2c);
     if (i2c_write_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG2, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -4;
     }
 
     reg = MAG3110_CTRL_REG1_DROS(dros);
 
     if (i2c_write_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG1, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -4;
     }
+    i2c_release(dev->i2c);
 
     dev->initialized = true;
 
@@ -96,9 +110,12 @@ int mag3110_set_user_offset(mag3110_t *dev, int16_t x, int16_t y, int16_t z)
     buf[4] = (char)(z >> 8);
     buf[5] = (char)z;
 
+    i2c_acquire(dev->i2c);
     if (i2c_write_regs(dev->i2c, dev->addr, MAG3110_OFF_X_MSB, buf, 6) != 6) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     return 0;
 }
@@ -111,15 +128,19 @@ int mag3110_set_active(mag3110_t *dev)
         return -1;
     }
 
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG1, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
 
     reg |= MAG3110_CTRL_REG1_AC;
 
     if (i2c_write_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG1, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     return 0;
 }
@@ -128,15 +149,19 @@ int mag3110_set_standby(mag3110_t *dev)
 {
     char reg;
 
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG1, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
 
     reg &= ~MAG3110_CTRL_REG1_AC;
 
     if (i2c_write_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG1, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     return 0;
 }
@@ -149,9 +174,12 @@ int mag3110_is_ready(mag3110_t *dev)
         return -1;
     }
 
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MAG3110_DR_STATUS, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     return (int)(reg & MAG3110_DR_STATUS_ZYXDR);
 }
@@ -164,9 +192,12 @@ int mag3110_read(mag3110_t *dev, int16_t *x, int16_t *y, int16_t *z, uint8_t *st
         return -1;
     }
 
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MAG3110_DR_STATUS, buf, 7) != 7) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     *status = buf[0];
     *x = ((int16_t)buf[1] << 8) | buf[2];
@@ -182,9 +213,12 @@ int mag3110_read_dtemp(mag3110_t *dev, int8_t *dtemp)
         return -1;
     }
 
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MAG3110_DIE_TEMP, (char *)dtemp, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     return 0;
 }

--- a/drivers/mag3110/mag3110.c
+++ b/drivers/mag3110/mag3110.c
@@ -22,7 +22,6 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "mutex.h"
 #include "periph/i2c.h"
 #include "mag3110.h"
 #include "mag3110_reg.h"

--- a/drivers/mma8652/mma8652.c
+++ b/drivers/mma8652/mma8652.c
@@ -15,12 +15,14 @@
  * @brief       Driver for the Freescale MMA8652 accelerometer.
  *
  * @author      Johann Fischer <j.fischer@phytec.de>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  *
  * @}
  */
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "mutex.h"
 #include "periph/i2c.h"
 #include "mma8652.h"
 #include "mma8652_reg.h"
@@ -34,9 +36,14 @@ int mma8652_test(mma8652_t *dev)
 {
     char reg;
 
+    /* Acquire exclusive access to the bus. */
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MMA8652_WHO_AM_I, &reg, 1) != 1) {
+        /* Release the bus for other threads. */
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     if (reg != MMA8652_ID) {
         return -1;
@@ -58,10 +65,13 @@ int mma8652_init(mma8652_t *dev, i2c_t i2c, uint8_t address, uint8_t dr, uint8_t
         return -1;
     }
 
+    i2c_acquire(dev->i2c);
     /* initialize the I2C bus */
     if (i2c_init_master(i2c, I2C_SPEED) < 0) {
+        i2c_release(dev->i2c);
         return -2;
     }
+    i2c_release(dev->i2c);
 
     if (mma8652_test(dev)) {
         return -3;
@@ -69,15 +79,19 @@ int mma8652_init(mma8652_t *dev, i2c_t i2c, uint8_t address, uint8_t dr, uint8_t
 
     reg = MMA8652_XYZ_DATA_CFG_FS(range);
 
+    i2c_acquire(dev->i2c);
     if (i2c_write_regs(dev->i2c, dev->addr, MMA8652_XYZ_DATA_CFG, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -4;
     }
 
     reg = MMA8652_CTRL_REG1_DR(dr);
 
     if (i2c_write_regs(dev->i2c, dev->addr, MMA8652_CTRL_REG1, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -4;
     }
+    i2c_release(dev->i2c);
 
     dev->initialized = true;
 
@@ -92,9 +106,12 @@ int mma8652_set_user_offset(mma8652_t *dev, int8_t x, int8_t y, int8_t z)
     buf[1] = (char)y;
     buf[2] = (char)z;
 
+    i2c_acquire(dev->i2c);
     if (i2c_write_regs(dev->i2c, dev->addr, MMA8652_OFF_X, buf, 3) != 3) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     return 0;
 }
@@ -106,9 +123,12 @@ int mma8652_reset(mma8652_t *dev)
     dev->initialized = false;
     reg = MMA8652_CTRL_REG2_RST;
 
+    i2c_acquire(dev->i2c);
     if (i2c_write_regs(dev->i2c, dev->addr, MMA8652_CTRL_REG2, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     return 0;
 }
@@ -121,15 +141,19 @@ int mma8652_set_active(mma8652_t *dev)
         return -1;
     }
 
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MMA8652_CTRL_REG1, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
 
     reg |= MMA8652_CTRL_REG1_ACTIVE;
 
     if (i2c_write_regs(dev->i2c, dev->addr, MMA8652_CTRL_REG1, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     return 0;
 }
@@ -138,15 +162,19 @@ int mma8652_set_standby(mma8652_t *dev)
 {
     char reg;
 
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MMA8652_CTRL_REG1, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
 
     reg &= ~MMA8652_CTRL_REG1_ACTIVE;
 
     if (i2c_write_regs(dev->i2c, dev->addr, MMA8652_CTRL_REG1, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     return 0;
 }
@@ -159,9 +187,12 @@ int mma8652_is_ready(mma8652_t *dev)
         return -1;
     }
 
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MMA8652_STATUS, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     return reg & MMA8652_STATUS_ZYXDR;
 }
@@ -174,9 +205,12 @@ int mma8652_read(mma8652_t *dev, int16_t *x, int16_t *y, int16_t *z, uint8_t *st
         return -1;
     }
 
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MMA8652_STATUS, buf, 7) != 7) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     *status = buf[0];
     *x = (int16_t)(((int16_t)buf[1] << 8) | buf[2]) / 16;

--- a/drivers/mma8652/mma8652.c
+++ b/drivers/mma8652/mma8652.c
@@ -22,7 +22,6 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "mutex.h"
 #include "periph/i2c.h"
 #include "mma8652.h"
 #include "mma8652_reg.h"

--- a/drivers/mpl3115a2/mpl3115a2.c
+++ b/drivers/mpl3115a2/mpl3115a2.c
@@ -22,7 +22,6 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "mutex.h"
 #include "periph/i2c.h"
 #include "mpl3115a2.h"
 #include "mpl3115a2_reg.h"

--- a/drivers/mpl3115a2/mpl3115a2.c
+++ b/drivers/mpl3115a2/mpl3115a2.c
@@ -15,12 +15,14 @@
  * @brief       Driver for the Freescale MPL3115A2 Sensor.
  *
  * @author      Johann Fischer <j.fischer@phytec.de>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  *
  * @}
  */
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "mutex.h"
 #include "periph/i2c.h"
 #include "mpl3115a2.h"
 #include "mpl3115a2_reg.h"
@@ -34,10 +36,15 @@ int mpl3115a2_test(mpl3115a2_t *dev)
 {
     char reg;
 
+    /* Acquire exclusive access to the bus. */
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_WHO_AM_I, &reg, 1) != 1) {
+        /* Release the bus for other threads. */
+        i2c_release(dev->i2c);
         return -1;
     }
 
+    i2c_release(dev->i2c);
     if (reg != MPL3115A2_ID) {
         return -1;
     }
@@ -58,10 +65,13 @@ int mpl3115a2_init(mpl3115a2_t *dev, i2c_t i2c, uint8_t address, uint8_t os_rati
         return -1;
     }
 
+    i2c_acquire(dev->i2c);
     /* initialize the I2C bus */
     if (i2c_init_master(i2c, I2C_SPEED) < 0) {
+        i2c_release(dev->i2c);
         return -2;
     }
+    i2c_release(dev->i2c);
 
     if (mpl3115a2_test(dev)) {
         return -3;
@@ -69,18 +79,24 @@ int mpl3115a2_init(mpl3115a2_t *dev, i2c_t i2c, uint8_t address, uint8_t os_rati
 
     reg = MPL3115A2_CTRL_REG1_OS(os_ratio);
 
+    i2c_acquire(dev->i2c);
     if (i2c_write_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -4;
     }
+    i2c_release(dev->i2c);
 
     reg = MPL3115A2_PT_DATA_CFG_TDEFE
           | MPL3115A2_PT_DATA_CFG_PDEFE
           | MPL3115A2_PT_DATA_CFG_DREM;
 
+    i2c_acquire(dev->i2c);
     if (i2c_write_regs(dev->i2c, dev->addr, MPL3115A2_PT_DATA_CFG, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -4;
     }
 
+    i2c_release(dev->i2c);
     dev->initialized = true;
 
     return 0;
@@ -93,10 +109,13 @@ int mpl3115a2_reset(mpl3115a2_t *dev)
     dev->initialized = false;
     reg = MPL3115A2_CTRL_REG1_RST;
 
+    i2c_acquire(dev->i2c);
     if (i2c_write_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
 
+    i2c_release(dev->i2c);
     return 0;
 }
 
@@ -108,16 +127,20 @@ int mpl3115a2_set_active(mpl3115a2_t *dev)
         return -1;
     }
 
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
 
     reg |= MPL3115A2_CTRL_REG1_SBYB;
 
     if (i2c_write_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
 
+    i2c_release(dev->i2c);
     return 0;
 }
 
@@ -125,16 +148,20 @@ int mpl3115a2_set_standby(mpl3115a2_t *dev)
 {
     char reg;
 
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
 
     reg &= ~MPL3115A2_CTRL_REG1_SBYB;
 
     if (i2c_write_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
 
+    i2c_release(dev->i2c);
     return 0;
 }
 
@@ -146,10 +173,13 @@ int mpl3115a2_is_ready(mpl3115a2_t *dev)
         return -1;
     }
 
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_STATUS, &reg, 1) != 1) {
+        i2c_release(dev->i2c);
         return -1;
     }
 
+    i2c_release(dev->i2c);
     return reg & MPL3115A2_STATUS_PTDR;
 }
 
@@ -161,9 +191,12 @@ int mpl3115a2_read_pressure(mpl3115a2_t *dev, uint32_t *pres, uint8_t *status)
         return -1;
     }
 
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_STATUS, buf, 4) != 4) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     *status = buf[0];
 
@@ -181,9 +214,12 @@ int mpl3115a2_read_temp(mpl3115a2_t *dev, int16_t *temp)
         return -1;
     }
 
+    i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_OUT_T_MSB, buf, 2) != 2) {
+        i2c_release(dev->i2c);
         return -1;
     }
+    i2c_release(dev->i2c);
 
     *temp = ((int16_t)(((int16_t)buf[0] << 8) | buf[1]) * 10) / 256;
 

--- a/drivers/srf02/srf02.c
+++ b/drivers/srf02/srf02.c
@@ -23,7 +23,6 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include "mutex.h"
 #include "hwtimer.h"
 #include "srf02.h"
 #include "periph/i2c.h"

--- a/drivers/srf08/srf08.c
+++ b/drivers/srf08/srf08.c
@@ -21,8 +21,6 @@
  * @}
  */
 
-
-#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include "hwtimer.h"
@@ -35,17 +33,27 @@
 
 int srf08_init(srf08_t *dev, i2c_t i2c, uint8_t addr, i2c_speed_t speed)
 {
+    int status;
+
     dev->i2c = i2c;
     dev->addr = addr;
 
+    /* Acquire exclusive access to the bus. */
+    i2c_acquire(dev->i2c);
     /* initialize i2c interface */
-    if(i2c_init_master(i2c, speed) < 0) {
+    status = i2c_init_master(dev->i2c, speed);
+    /* Release the bus for other threads. */
+    i2c_release(dev->i2c);
+
+    if(status < 0) {
         return -1;
     }
+
     /* set the maximum range */
     if (srf08_set_max_range(dev, SRF08_MAX_RANGE_6M) < 0) {
         return -3;
     }
+
     /* set the maximum gain */
     if (srf08_set_max_gain(dev, SRF08_MAX_GAIN) < 0) {
         return -4;
@@ -57,13 +65,29 @@ int srf08_init(srf08_t *dev, i2c_t i2c, uint8_t addr, i2c_speed_t speed)
 
 int srf08_set_max_range(srf08_t *dev, uint8_t max_range)
 {
-    return i2c_write_reg(dev->i2c, dev->addr, SRF08_RANGE_REG, max_range);
+    int status;
+
+    /* Acquire exclusive access to the bus. */
+    i2c_acquire(dev->i2c);
+    status = i2c_write_reg(dev->i2c, dev->addr, SRF08_RANGE_REG, max_range);
+    /* Release the bus for other threads. */
+    i2c_release(dev->i2c);
+
+    return status;
 }
 
 
 int srf08_set_max_gain(srf08_t *dev, uint8_t gain)
 {
-    return i2c_write_reg(dev->i2c, dev->addr, SRF08_GAIN_REG, gain);
+    int status;
+
+    /* Acquire exclusive access to the bus. */
+    i2c_acquire(dev->i2c);
+    status = i2c_write_reg(dev->i2c, dev->addr, SRF08_GAIN_REG, gain);
+    /* Release the bus for other threads. */
+    i2c_release(dev->i2c);
+
+    return status;
 }
 
 
@@ -75,8 +99,12 @@ int srf08_get_distances(srf08_t *dev, uint16_t *range_array, int num_echos, srf0
     char register_location;
     char max_reg_no_read = (num_echos * sizeof(range_bytes)) +1;
 
+    /* Acquire exclusive access to the bus. */
+    i2c_acquire(dev->i2c);
     /* set ranging mode */
     status = i2c_write_reg(dev->i2c, dev->addr, SRF08_COMMAND_REG, ranging_mode);
+    /* Release the bus for other threads. */
+    i2c_release(dev->i2c);
 
     if (!status) {
         DEBUG("Write the ranging command to the i2c-interface is failed");
@@ -94,8 +122,12 @@ int srf08_get_distances(srf08_t *dev, uint16_t *range_array, int num_echos, srf0
     for (register_location = 2; register_location < max_reg_no_read;
          register_location += sizeof(range_bytes)) {
 
+        /* Acquire exclusive access to the bus. */
+        i2c_acquire(dev->i2c);
         /* read the echo bytes */
         status = i2c_read_regs(dev->i2c, dev->addr, register_location, range_bytes, sizeof(range_bytes));
+        /* Release the bus for other threads. */
+        i2c_release(dev->i2c);
 
         if (!status) {
             DEBUG("Read the echo bytes from the i2c-interface is failed");

--- a/drivers/tmp006/tmp006.c
+++ b/drivers/tmp006/tmp006.c
@@ -23,7 +23,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <math.h>
-#include "mutex.h"
 #include "periph/i2c.h"
 #include "tmp006.h"
 


### PR DESCRIPTION
As discussed in #2289 this PR adapts all i2c-based sensor drivers to use the i2c interface safely within multiple threads. I will push separate commits for each sensor driver.