### PR TITLE
RIOT port for the KW01Z128 SiP  and Phytec PhyWave-KW01 Evaluations-Board

### DIFF
--- a/boards/pba-d-01-kw01/Makefile
+++ b/boards/pba-d-01-kw01/Makefile
@@ -1,0 +1,4 @@
+# tell the Makefile.base which module to build
+MODULE = $(BOARD)_base
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/pba-d-01-kw01/Makefile.features
+++ b/boards/pba-d-01-kw01/Makefile.features
@@ -1,0 +1,6 @@
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_cpuid

--- a/boards/pba-d-01-kw01/Makefile.include
+++ b/boards/pba-d-01-kw01/Makefile.include
@@ -1,0 +1,49 @@
+# define the cpu used by the phyWAVE-KW01 Board
+export CPU = kw0x
+export CPU_MODEL = kw01z128
+
+#define the default port depending on the host OS
+OS := $(shell uname)
+ifeq ($(OS),Linux)
+  PORT ?= /dev/ttyACM0
+else ifeq ($(OS),Darwin)
+  PORT ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+else
+  $(info CAUTION: No flash tool for your host system found!)
+endif
+export PORT
+
+# define tools used for building the project
+export PREFIX = arm-none-eabi-
+export CC = $(PREFIX)gcc
+export AR = $(PREFIX)ar
+export AS = $(PREFIX)as
+export LINK = $(PREFIX)gcc
+export SIZE = $(PREFIX)size
+export OBJCOPY = $(PREFIX)objcopy
+export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm
+export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
+export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
+export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
+export DEBUGSERVER = openocd
+
+# define build specific options
+CPU_USAGE = -mcpu=cortex-m0 -mabi=aapcs
+FPU_USAGE = -msoft-float
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
+export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
+export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -T$(LINKERSCRIPT)
+export OFLAGS = -O binary
+export FFLAGS = $(HEXFILE)
+export DEBUGGER_FLAGS = $(RIOTBOARD)/$(BOARD)/dist/gdb.conf $(ELFFILE)
+export TERMFLAGS = -p $(PORT)
+
+# use newLib nano-specs if available
+ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+export LINKFLAGS += -specs=nano.specs -lc -lnosys
+endif
+
+# export board specific includes to the global includes-listing
+export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/

--- a/boards/pba-d-01-kw01/board.c
+++ b/boards/pba-d-01-kw01/board.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     board_pba-d-01-kw01
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the Phytec
+ *              phyWAVE-KW01 evaluation board (KW01Z128 Module).
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ *
+ * @}
+ */
+
+#include "board.h"
+
+static void leds_init(void);
+
+void board_init(void)
+{
+    leds_init();
+    cpu_init();
+}
+
+/**
+ * @brief Initialize the boards on-board RGB-LED
+ *
+ */
+static void leds_init(void)
+{
+    /* enable clock */
+    LED_B_PORT_CLKEN();
+    LED_G_PORT_CLKEN();
+    LED_R_PORT_CLKEN();
+    /* configure pins as gpio */
+    LED_B_PORT->PCR[LED_B_PIN] = PORT_PCR_MUX(1);
+    LED_G_PORT->PCR[LED_G_PIN] = PORT_PCR_MUX(1);
+    LED_R_PORT->PCR[LED_R_PIN] = PORT_PCR_MUX(1);
+    LED_B_GPIO->PDDR |= (1 << LED_B_PIN);
+    LED_G_GPIO->PDDR |= (1 << LED_G_PIN);
+    LED_R_GPIO->PDDR |= (1 << LED_R_PIN);
+    /* turn all LEDs off */
+    LED_B_GPIO->PSOR |= (1 << LED_B_PIN);
+    LED_G_GPIO->PSOR |= (1 << LED_G_PIN);
+    LED_R_GPIO->PSOR |= (1 << LED_R_PIN);
+}

--- a/boards/pba-d-01-kw01/dist/debug.sh
+++ b/boards/pba-d-01-kw01/dist/debug.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Based on iot-lab_M3 debug.sh script.
+# Author: Jonas Remmert j.remmert@phytec.de
+
+red='\033[0;31m'
+green='\033[0;32m'
+NC='\033[0m'
+
+openocd -f "$RIOTBASE/boards/pba-d-01-kw01/dist/mkw01z128.cfg" \
+    -c "tcl_port 6333" \
+    -c "telnet_port 4444" \
+    -c "init" \
+    -c "targets" \
+    -c "reset halt" \
+    -l /dev/null &
+
+# save pid to terminate afterwards
+OCD_PID=$?
+
+# needed for openocd to set up
+sleep 1
+
+retval=$(arm-none-eabi-readelf -x .fcfield $2  | awk '/0x00000400/ {print $2 $3 $4 $5}')
+unlocked_fcfield="fffffffffffffffffffffffffeffffff"
+
+if [ "$retval" == "$unlocked_fcfield" ]; then
+echo -e "Flash configuration tested...${green} [OK]${NC}"
+arm-none-eabi-gdb -tui --command=${1} ${2}
+#cgdb -d arm-none-eabi-gdb --command=${1} ${2}
+
+else
+echo "Hexdump, .fcfield of $2"
+retval=$(arm-none-eabi-readelf -x .fcfield $2)
+echo $retval
+echo -e "Fcfield not fitting to MKW01Z128, danger of bricking the device during flash...${red} [ABORT]${NC}"
+fi
+kill ${OCD_PID}

--- a/boards/pba-d-01-kw01/dist/flash.sh
+++ b/boards/pba-d-01-kw01/dist/flash.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Based on iot-lab_M3 debug.sh script.
+# Author: Jonas Remmert j.remmert@phytec.de
+
+elffile=`echo $1 | sed 's/.hex/.elf/'`
+
+red='\033[0;31m'
+green='\033[0;32m'
+NC='\033[0m'
+
+echo The file: $elffile will be flashed to the board: $BOARD .
+echo Press y to proceed, v to proceed with verify or any other key to abort.
+read x
+
+retval=$(arm-none-eabi-readelf -x .fcfield $elffile  | awk '/0x00000400/ {print $2 $3 $4 $5}')
+unlocked_fcfield="fffffffffffffffffffffffffeffffff"
+
+if [ "$retval" != "$unlocked_fcfield" ]; then
+echo "Hexdump, .fcfield of $elffile"
+retval=$(arm-none-eabi-readelf -x .fcfield $elffile)
+echo $retval
+echo -e "Fcfield not fitting to MKW01Z128, danger of bricking the device during flash...${red} [ABORT]${NC}"
+exit 0
+fi
+echo -e "Flash configuration tested...${green} [OK]${NC}"
+
+
+# flash without verify
+#if [ $x = "y" ] || [ $x = "v" ];# -o $x -eq v ];
+#then
+echo -e "${red}Flashing device, do not disconnect or reset the target until this script exits!!!${NC}"
+openocd -f "$RIOTBASE/boards/pba-d-01-kw01/dist/mkw01z128.cfg" \
+	-c "init" \
+	-c "reset halt" \
+        -c "flash write_image erase $elffile" \
+	-c "reset run" \
+	-c "exit"
+#fi
+
+# verify
+#if [ "$x" = "v" ];
+#then
+#echo -e "${red}Flashing device, do not disconnect or reset the target until this script exits!!!${NC}"
+#openocd -f "$RIOTBASE/boards/pba-d-01-kw01/dist/mkw01z128.cfg" \
+#        -c "init" \
+#        -c "reset halt" \
+#        -c "verify_image $elffile" \
+#        -c "reset run" \
+#        -c "exit"
+#fi
+echo -e "${green}done...${NC}"

--- a/boards/pba-d-01-kw01/dist/gdb.conf
+++ b/boards/pba-d-01-kw01/dist/gdb.conf
@@ -1,0 +1,4 @@
+target remote localhost:3333
+monitor reset halt
+set print pretty
+set arm force-mode thumb

--- a/boards/pba-d-01-kw01/dist/mkw01z128.cfg
+++ b/boards/pba-d-01-kw01/dist/mkw01z128.cfg
@@ -1,0 +1,71 @@
+#
+# Freescale Kinetis MKW01Z128 devices
+#
+source [find interface/cmsis-dap.cfg]
+
+#
+# K21 devices support both JTAG and SWD transports.
+#
+source [find target/swj-dp.tcl]
+
+if { [info exists CHIPNAME] } {
+    set _CHIPNAME $CHIPNAME
+} else {
+    set _CHIPNAME kw01z128
+}
+
+# Work-area is a space in RAM used for flash programming
+set WORKAREASIZE 0x1000
+
+if { [info exists WORKAREASIZE] } {
+   set _WORKAREASIZE $WORKAREASIZE
+} else {
+   set _WORKAREASIZE 0x1000
+}
+
+if { [info exists ENDIAN] } {
+    set _ENDIAN $ENDIAN
+} else {
+    set _ENDIAN little
+}
+
+if { [info exists CPUTAPID] } {
+    set _CPUTAPID $CPUTAPID
+} else {
+    set _CPUTAPID 0x0bc11477
+}
+
+set _TARGETNAME $_CHIPNAME.cpu
+
+swj_newdap $_CHIPNAME cpu -irlen 4 -expected-id $_CPUTAPID
+#swj_newdap $_CHIPNAME cpu -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_CPUTAPID
+
+target create $_TARGETNAME cortex_m -chain-position $_CHIPNAME.cpu
+
+$_CHIPNAME.cpu configure -event examine-start { puts "START..." ; }
+
+# It is important that "kinetis mdm check_security" is called for
+# 'examine-end' event and not 'eximine-start'. Calling it in 'examine-start'
+# causes "kinetis mdm check_security" to fail the first time openocd
+# calls it when it tries to connect after the CPU has been power-cycled.
+$_CHIPNAME.cpu configure -event examine-end {
+	kinetis mdm check_security
+}
+
+$_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size $_WORKAREASIZE -work-area-backup 0
+
+set _FLASHNAME $_CHIPNAME.flash
+flash bank $_FLASHNAME kinetis 0 0 0 0 $_TARGETNAME
+
+#reset_config srst_only srst_nogate connect_assert_srst
+adapter_khz 10000
+
+if {![using_hla]} {
+   # if srst is not fitted use SYSRESETREQ to
+   # perform a soft reset
+   cortex_m reset_config sysresetreq
+}
+
+$_TARGETNAME configure -event reset-init {
+    adapter_khz 24000
+}

--- a/boards/pba-d-01-kw01/dist/reset.sh
+++ b/boards/pba-d-01-kw01/dist/reset.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+openocd -f "$RIOTBASE/boards/pba-d-01-kw01/dist/mkw01z128.cfg" \
+    -c "init" \
+    -c "reset run" \
+    -c "shutdown"

--- a/boards/pba-d-01-kw01/include/board.h
+++ b/boards/pba-d-01-kw01/include/board.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    board_pba-d-01-kw01 phyWAVE-KW01 Evalboard
+ * @ingroup     boards
+ * @brief       Board specific implementations for the phyWAVE-KW01 evaluation board
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the phyWAVE-KW01 evaluation board
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ */
+
+#ifndef __BOARD_H
+#define __BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * Define the nominal CPU core clock in this board
+ */
+#define F_CPU               CLOCK_CORECLOCK
+
+/**
+ * @name Define UART device and baudrate for stdio
+ * @{
+ */
+#define STDIO               UART_0
+#define STDIO_RX_BUFSIZE    (64U)
+#define STDIO_BAUDRATE      (115200U)
+/** @} */
+
+/**
+ * @name LED pin definitions
+ * @{
+ */
+#define LED_R_PORT_CLKEN()    (SIM->SCGC5 |= (SIM_SCGC5_PORTA_MASK)) /**< Clock Enable for PORTD*/
+#define LED_G_PORT_CLKEN()    (SIM->SCGC5 |= (SIM_SCGC5_PORTB_MASK)) /**< Clock Enable for PORTD*/
+#define LED_B_PORT_CLKEN()    (SIM->SCGC5 |= (SIM_SCGC5_PORTC_MASK)) /**< Clock Enable for PORTA*/
+#define LED_R_PORT            PORTA /**< PORT for Red LED */
+#define LED_R_GPIO            GPIOA /**< GPIO-Device for Red LED */
+#define LED_G_PORT            PORTB /**< PORT for Green LED */
+#define LED_G_GPIO            GPIOB /**< GPIO-Device for Green LED */
+#define LED_B_PORT            PORTC /**< PORT for Blue LED */
+#define LED_B_GPIO            GPIOC /**< GPIO-Device for Blue LED */
+#define LED_R_PIN             4	    /**< Red LED connected to PINx */
+#define LED_G_PIN             2	    /**< Green LED connected to PINx */
+#define LED_B_PIN             3	    /**< Blue LED connected to PINx */
+/** @} */
+
+/**
+ * @name Macros for controlling the on-board LEDs.
+ * @{
+ */
+#define LED_B_ON            (LED_B_GPIO->PCOR |= (1 << LED_B_PIN))
+#define LED_B_OFF           (LED_B_GPIO->PSOR |= (1 << LED_B_PIN))
+#define LED_B_TOGGLE        (LED_B_GPIO->PTOR |= (1 << LED_B_PIN))
+#define LED_G_ON            (LED_G_GPIO->PCOR |= (1 << LED_G_PIN))
+#define LED_G_OFF           (LED_G_GPIO->PSOR |= (1 << LED_G_PIN))
+#define LED_G_TOGGLE        (LED_G_GPIO->PTOR |= (1 << LED_G_PIN))
+#define LED_R_ON            (LED_R_GPIO->PCOR |= (1 << LED_R_PIN))
+#define LED_R_OFF           (LED_R_GPIO->PSOR |= (1 << LED_R_PIN))
+#define LED_R_TOGGLE        (LED_R_GPIO->PTOR |= (1 << LED_R_PIN))
+
+/* for compatability to other boards */
+#define LED_GREEN_ON        LED_G_ON
+#define LED_GREEN_OFF       LED_G_OFF
+#define LED_GREEN_TOGGLE    LED_G_TOGGLE
+#define LED_RED_ON          LED_R_ON
+#define LED_RED_OFF         LED_R_OFF
+#define LED_RED_TOGGLE      LED_R_TOGGLE
+/** @} */
+
+/**
+ * Define the type for the radio packet length for the transceiver
+ */
+typedef uint8_t radio_packet_length_t;
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /** __BOARD_H */
+/** @} */

--- a/boards/pba-d-01-kw01/include/periph_conf.h
+++ b/boards/pba-d-01-kw01/include/periph_conf.h
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     board_pba-d-01-kw01
+ * @{
+ *
+ * @file
+ * @name        Peripheral MCU configuration for the phyWAVE-KW01
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ */
+
+#ifndef __PERIPH_CONF_H
+#define __PERIPH_CONF_H
+
+#include "cpu-conf.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @name Clock system configuration
+ * @{
+ */
+#define KINETIS_CPU_USE_MCG               1
+
+#define KINETIS_MCG_USE_ERC               1
+#define KINETIS_MCG_ERC_FREQ              32768
+#define KINETIS_MCG_ERC_FRDIV             0
+#define KINETIS_MCG_ERC_RANGE             0
+#define KINETIS_MCG_ERC_OSCILLATOR        1
+
+#define KINETIS_MCG_USE_PLL               0
+
+#define KINETIS_MCG_USE_FAST_IRC          0
+
+#define CLOCK_CORECLOCK                   (48e6)        /* core clock frequency */
+/** @} */
+
+
+/**
+ * @name Timer configuration
+ * @{
+ */
+#define TIMER_NUMOF         (0U)
+#define TIMER_0_EN          0
+#define TIMER_1_EN          0
+#define TIMER_2_EN          0
+#define TIMER_IRQ_PRIO      1
+/** @} */
+
+
+/**
+ * @name UART configuration
+ * @{
+ */
+#define UART_NUMOF          (1U)
+#define UART_0_EN           1
+#define UART_1_EN           0
+#define UART_IRQ_PRIO       1
+#define UART_CLK            (48e6)
+
+/* UART 0 device configuration */
+#define KINETIS_UART        UART0_Type
+#define UART_0_DEV          UART0
+#define UART_0_CLKEN()      (SIM->SCGC4 |= (SIM_SCGC4_UART0_MASK))
+#define UART_0_CLK          UART_CLK
+#define UART_0_IRQ_CHAN     UART0_IRQn
+#define UART_0_ISR          isr_uart0
+/* UART 0 pin configuration */
+#define UART_0_PORT_CLKEN() (SIM->SCGC5 |= (SIM_SCGC5_PORTA_MASK))
+#define UART_0_PORT         PORTA
+#define UART_0_RX_PIN       1
+#define UART_0_TX_PIN       2
+#define UART_0_AF           2
+/** @} */
+
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_NUMOF           (0U)
+#define ADC_0_EN            0
+#define ADC_MAX_CHANNELS    0
+/** @} */
+
+
+/**
+ * @name PWM configuration
+ * @{
+ */
+#define PWM_NUMOF           (0U)
+#define PWM_0_EN            0
+#define PWM_MAX_CHANNELS    0
+/** @} */
+
+
+/**
+ * @name SPI configuration
+ * @{
+ */
+#define SPI_NUMOF               (0U)
+#define SPI_CLK                 (48e6)
+#define SPI_0_EN                0
+#define SPI_IRQ_PRIO            1
+
+/* SPI 0 device config */
+#define SPI_0_DEV               SPI0
+#define SPI_0_CLKEN()           (SIM->SCGC6 |= (SIM_SCGC4_SPI1_MASK))
+#define SPI_0_CLKDIS()          (SIM->SCGC6 &= ~(SIM_SCGC4_SPI1_MASK))
+#define SPI_0_IRQ               SPI0_IRQn
+#define SPI_0_IRQ_HANDLER       isr_spi0
+/* SPI 0 pin configuration */
+#define SPI_0_PORT              PORTD
+#define SPI_0_PORT_CLKEN()      (SIM->SCGC5 |= (SIM_SCGC5_PORTD_MASK))
+#define SPI_0_PIN_AF            2
+#define SPI_0_PCS0_PIN          4
+#define SPI_0_SCK_PIN           5
+#define SPI_0_SOUT_PIN          6
+#define SPI_0_SIN_PIN           7
+/** @} */
+
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+#define I2C_NUMOF               (1U)
+#define I2C_CLK                 (48e6)
+#define I2C_0_EN                1
+#define I2C_IRQ_PRIO            1
+/* Low (10 kHz): MUL = 4, SCL divider = 2560, total: 10240 */
+#define KINETIS_I2C_F_ICR_LOW        (0x3D)
+#define KINETIS_I2C_F_MULT_LOW       (2)
+/* Normal (100 kHz): MUL = 2, SCL divider = 240, total: 480 */
+#define KINETIS_I2C_F_ICR_NORMAL     (0x1F)
+#define KINETIS_I2C_F_MULT_NORMAL    (1)
+/* Fast (400 kHz): MUL = 1, SCL divider = 128, total: 128 */
+#define KINETIS_I2C_F_ICR_FAST       (0x17)
+#define KINETIS_I2C_F_MULT_FAST      (0)
+/* Fast plus (1000 kHz): MUL = 1, SCL divider = 48, total: 48 */
+#define KINETIS_I2C_F_ICR_FAST_PLUS  (0x10)
+#define KINETIS_I2C_F_MULT_FAST_PLUS (0)
+
+/* I2C 0 device configuration */
+#define I2C_0_DEV               I2C1
+#define I2C_0_CLKEN()           (SIM->SCGC4 |= (SIM_SCGC4_I2C1_MASK))
+#define I2C_0_CLKDIS()          (SIM->SCGC4 &= ~(SIM_SCGC4_I2C1_MASK))
+#define I2C_0_IRQ               I2C1_IRQn
+#define I2C_0_IRQ_HANDLER       isr_i2c1
+/* I2C 0 pin configuration */
+#define I2C_0_PORT              PORTC
+#define I2C_0_PORT_CLKEN()      (SIM->SCGC5 |= (SIM_SCGC5_PORTC_MASK))
+#define I2C_0_PIN_AF            2
+#define I2C_0_SDA_PIN           2
+#define I2C_0_SCL_PIN           1
+#define I2C_0_PORT_CFG          (PORT_PCR_MUX(I2C_0_PIN_AF))
+
+/** @} */
+
+
+/**
+ * @name GPIO configuration
+ * @{
+ */
+#define GPIO_NUMOF          3
+#define GPIO_0_EN           1    /* DIO11 */
+#define GPIO_1_EN           1    /* DIO27 */
+#define GPIO_2_EN           1    /* DIO2 */
+#define GPIO_IRQ_PRIO       1
+
+/* GPIO channel 0 config */
+#define GPIO_0_DEV          GPIOA
+#define GPIO_0_PORT         PORTA
+#define GPIO_0_PIN          4
+#define GPIO_0_CLKEN()      (SIM->SCGC5 |= (SIM_SCGC5_PORTA_MASK))
+#define GPIO_0_IRQ          PORTA_IRQn
+#define GPIO_0_ISR          isr_porta
+/* GPIO channel 1 config */
+#define GPIO_1_DEV          GPIOC
+#define GPIO_1_PORT         PORTC
+#define GPIO_1_PIN          3
+#define GPIO_1_CLKEN()      (SIM->SCGC5 |= (SIM_SCGC5_PORTC_MASK))
+#define GPIO_1_IRQ          PORTC_PORTD_IRQn
+#define GPIO_1_ISR          isr_portc
+/* GPIO channel 3 config */
+#define GPIO_2_DEV          GPIOD
+#define GPIO_2_PORT         PORTD
+#define GPIO_2_PIN          4
+#define GPIO_2_CLKEN()      (SIM->SCGC5 |= (SIM_SCGC5_PORTD_MASK))
+#define GPIO_2_IRQ          PORTC_PORTD_IRQn
+#define GPIO_2_ISR          isr_portd
+/** @} */
+
+/**
+* @name RTT and RTC configuration
+* @{
+*/
+#define RTT_NUMOF            (1U)
+#define RTC_NUMOF            (1U)
+#define RTT_DEV              RTC
+#define RTT_IRQ              RTC_IRQn
+#define RTT_IRQ_PRIO         10
+#define RTT_UNLOCK()         (SIM->SCGC6 |= (SIM_SCGC6_RTC_MASK))
+#define RTT_ISR              isr_rtc
+#define RTT_FREQUENCY        (1)
+#define RTT_MAX_VALUE        (0xffffffff)
+/** @} */
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __PERIPH_CONF_H */
+/** @} */

--- a/cpu/kinetis_common/ldscripts/kinetis-kl0x.ld
+++ b/cpu/kinetis_common/ldscripts/kinetis-kl0x.ld
@@ -1,0 +1,257 @@
+/* RAM limits */
+__sram_start  = ORIGIN(sram);
+__sram_length = LENGTH(sram);
+__sram_end    = __sram_start + __sram_length;
+_ramcode_start = 0x0;
+_ramcode_end = 0x0;
+_ramcode_load = 0x0;
+
+/* Define the default stack size for interrupt mode. As no context is
+   saved on this stack and ISRs are supposed to be short, it can be fairly
+   small. 512 byte should be a safe assumption here */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x200; /* 512 byte */
+
+RAMVECT_SIZE = DEFINED(RAMVECT_SIZE) ? RAMVECT_SIZE : 0;
+
+SECTIONS
+{
+    /* Interrupt vectors 0x00-0x3ff. */
+    .vector_table :
+    {
+        _vector_rom = .;
+        KEEP(*(.isr_vector))
+        KEEP(*(.vector_table))
+    } > vectors
+    ASSERT (SIZEOF(.vector_table) == 0x100, "Interrupt vector table of invalid size.")
+    ASSERT (ADDR(.vector_table) == 0x00000000, "Interrupt vector table at invalid location (linker-script error?)")
+    ASSERT (LOADADDR(.vector_table) == 0x00000000, "Interrupt vector table at invalid location (linker-script error?)")
+
+    /* Flash configuration field, very important in order to not accidentally lock the device */
+    /* Flash configuration field 0x400-0x40f. */
+    .fcfield :
+    {
+        . = ALIGN(4);
+        KEEP(*(.fcfield))
+        . = ALIGN(4);
+    } > flashsec
+    ASSERT (SIZEOF(.fcfield) == 0x10, "Flash configuration field of invalid size (linker-script error?)")
+    ASSERT (ADDR(.fcfield) == 0x400, "Flash configuration field at invalid position (linker-script error?)")
+    ASSERT (LOADADDR(.fcfield) == 0x400, "Flash configuration field at invalid position (linker-script error?)")
+
+    /* Program code 0x410-. */
+    .text :
+    {
+        . = ALIGN(4);
+        _text_load = LOADADDR(.text);
+        _text_start = .;
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(SORT(.preinit_array.*)))
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+        . = ALIGN(4);
+
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+        . = ALIGN(4);
+
+        /* fini data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+        . = ALIGN(4);
+
+        KEEP (*(SORT_NONE(.init)))
+        KEEP (*(SORT_NONE(.fini)))
+        /* Default ISR handlers */
+        KEEP(*(.default_handlers))
+        *(.text.unlikely .text.*_unlikely .text.unlikely.*)
+        *(.text.exit .text.exit.*)
+        *(.text.startup .text.startup.*)
+        *(.text.hot .text.hot.*)
+        *(.text .stub .text.* .gnu.linkonce.t.*)
+
+        /* gcc uses crtbegin.o to find the start of
+           the constructors, so we make sure it is
+           first.  Because this is a wildcard, it
+           doesn't matter if the user does not
+           actually link against crtbegin.o; the
+           linker won't look for a file to match a
+           wildcard.  The wildcard also means that it
+           doesn't matter which directory crtbegin.o
+           is in.  */
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*crtbegin?.o(.ctors))
+        KEEP (*crtbeginTS.o(.ctors))
+        /* We don't want to include the .ctor section from
+           the crtend.o file until after the sorted ctors.
+           The .ctor section from the crtend file contains the
+           end of ctors marker and it must be last */
+        KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*(.ctors))
+
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*crtbegin?.o(.dtors))
+        KEEP (*crtbeginTS.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*(.dtors))
+        . = ALIGN(4);
+        _rodata_start = .;
+        *(.rodata .rodata* .gnu.linkonce.r.*)
+        . = ALIGN(4);
+        _rodata_end = .;
+        _text_end = .;
+    } > flash
+
+    /* The .extab, .exidx sections are used for C++ exception handling */
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > flash
+
+    PROVIDE_HIDDEN (__exidx_start = .);
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > flash
+    PROVIDE_HIDDEN (__exidx_end = .);
+
+    .eh_frame_hdr :
+    {
+        *(.eh_frame_hdr)
+    } > flash
+
+    .eh_frame : ONLY_IF_RO
+    {
+        KEEP (*(.eh_frame))
+    } > flash
+
+    .gcc_except_table : ONLY_IF_RO
+    {
+        *(.gcc_except_table .gcc_except_table.*)
+    } > flash
+
+    . = ALIGN(4);
+    _etext = .;
+
+    /*
+     * Allocate space for interrupt vector in RAM
+     * This can safely be removed to free up 0x100 bytes of RAM if the code does
+     * not make use of this CPU feature.
+     */
+    .ramvect :
+    {
+        . = ALIGN(4);
+        _vector_ram_start = .;
+        . = _vector_ram_start + RAMVECT_SIZE;
+        . = ALIGN(4);
+        _vector_ram_end = .;
+    } > sram
+
+    /* Program data, values stored in flash and loaded upon init. */
+    .relocate : AT (_etext)
+    {
+        . = ALIGN(4);
+        _data_load  = LOADADDR(.relocate);
+        _data_start = .;
+        _srelocate = .;
+        *(.ramfunc .ramfunc.*);
+        *(.data .data.*);
+        . = ALIGN(4);
+        _erelocate = .;
+        _data_end = .;
+    } > sram
+
+    /* .bss section, zeroed out during init. */
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        _sbss = . ;
+        __bss_start = .;
+        _szero = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = . ;
+        __bss_end = .;
+        _ezero = .;
+    } > sram
+
+    /* Make sure we set _end, in case we want dynamic memory management... */
+    _end = .;
+    __end = .;
+    __end__ = .;
+    PROVIDE(end = .);
+
+    . = ALIGN(8);
+    HEAP_SIZE = ORIGIN(sram) + LENGTH(sram) - STACK_SIZE - .;
+
+    .heap (NOLOAD):
+    {
+        _heap_start = .;
+        PROVIDE(__heap_start = .);
+        . = . + HEAP_SIZE;
+        _heap_end = .;
+        PROVIDE(__heap_max = .);
+    } > sram
+
+    /* stack section */
+    .stack (NOLOAD):
+    {
+        . = ALIGN(8);
+        _sstack = .;
+        . = . + STACK_SIZE;
+        _estack = .;
+    } > sram
+
+    /* Any debugging sections */
+    /* Stabs debugging sections.  */
+    .stab          0 : { *(.stab) }
+    .stabstr       0 : { *(.stabstr) }
+    .stab.excl     0 : { *(.stab.excl) }
+    .stab.exclstr  0 : { *(.stab.exclstr) }
+    .stab.index    0 : { *(.stab.index) }
+    .stab.indexstr 0 : { *(.stab.indexstr) }
+    .comment       0 : { *(.comment) }
+    /* DWARF debug sections.
+       Symbols in the DWARF debugging sections are relative to the beginning
+       of the section so we begin them at 0.  */
+    /* DWARF 1 */
+    .debug          0 : { *(.debug) }
+    .line           0 : { *(.line) }
+    /* GNU DWARF 1 extensions */
+    .debug_srcinfo  0 : { *(.debug_srcinfo) }
+    .debug_sfnames  0 : { *(.debug_sfnames) }
+    /* DWARF 1.1 and DWARF 2 */
+    .debug_aranges  0 : { *(.debug_aranges) }
+    .debug_pubnames 0 : { *(.debug_pubnames) }
+    /* DWARF 2 */
+    .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+    .debug_abbrev   0 : { *(.debug_abbrev) }
+    .debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end ) }
+    .debug_frame    0 : { *(.debug_frame) }
+    .debug_str      0 : { *(.debug_str) }
+    .debug_loc      0 : { *(.debug_loc) }
+    .debug_macinfo  0 : { *(.debug_macinfo) }
+    /* SGI/MIPS DWARF 2 extensions */
+    .debug_weaknames 0 : { *(.debug_weaknames) }
+    .debug_funcnames 0 : { *(.debug_funcnames) }
+    .debug_typenames 0 : { *(.debug_typenames) }
+    .debug_varnames  0 : { *(.debug_varnames) }
+    /* DWARF 3 */
+    .debug_pubtypes 0 : { *(.debug_pubtypes) }
+    .debug_ranges   0 : { *(.debug_ranges) }
+    /* DWARF Extension.  */
+    .debug_macro    0 : { *(.debug_macro) }
+
+    /* XXX: what is the purpose of these sections? */
+    .ARM.attributes 0 : { KEEP (*(.ARM.attributes)) KEEP (*(.gnu.attributes)) }
+    .note.gnu.arm.ident 0 : { KEEP (*(.note.gnu.arm.ident)) }
+    /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }
+}

--- a/cpu/kw0x/Makefile
+++ b/cpu/kw0x/Makefile
@@ -1,0 +1,7 @@
+# define the module that is build
+MODULE = cpu
+
+# add a list of subdirectories, that should also be build
+DIRS = periph $(CORTEX_M0_COMMON) $(KINETIS_COMMON)
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/kw0x/Makefile.include
+++ b/cpu/kw0x/Makefile.include
@@ -1,0 +1,37 @@
+# this CPU implementation is using the explicit core/CPU interface
+export CFLAGS += -DCOREIF_NG=1
+
+# export the peripheral drivers to be linked into the final binary
+export USEMODULE += periph
+
+# tell the build system that the CPU depends on the Cortex-M common files
+export USEMODULE += cortex-m0_common
+
+# tell the build system that the CPU depends on the Kinetis common files
+export USEMODULE += kinetis_common
+
+# define path to cortex-m common module, which is needed for this CPU
+export CORTEX_M0_COMMON = $(RIOTCPU)/cortex-m0_common/
+
+# define path to kinetis module, which is needed for this CPU
+export KINETIS_COMMON = $(RIOTCPU)/kinetis_common/
+
+# CPU depends on the cortex-m common module, so include it
+include $(CORTEX_M0_COMMON)Makefile.include
+
+# CPU depends on the kinetis module, so include it
+include $(KINETIS_COMMON)Makefile.include
+
+# define the linker script to use for this CPU
+export LINKERSCRIPT = $(RIOTCPU)/$(CPU)/$(CPU_MODEL)_linkerscript.ld
+
+#export the CPU model
+MODEL = $(shell echo $(CPU_MODEL)|tr 'a-z' 'A-Z')
+export CFLAGS += -DCPU_MODEL_$(MODEL)
+
+# include CPU specific includes
+export INCLUDES += -I$(RIOTCPU)/$(CPU)/include
+
+# add the CPU specific system calls implementations for the linker
+export UNDEF += $(BINDIR)cpu/interrupt-vector.o
+export UNDEF += $(BINDIR)cpu/syscalls.o

--- a/cpu/kw0x/cpu.c
+++ b/cpu/kw0x/cpu.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_kw0x
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the KW0x CPU initialization
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ * @}
+ */
+
+#include <stdint.h>
+#include "cpu-conf.h"
+
+#define FLASH_BASE         	(0x00000000)
+
+static void cpu_clock_init(void);
+
+/**
+ * @brief Initialize the CPU, set IRQ priorities
+ */
+void cpu_init(void)
+{
+    /* configure the vector table location to internal flash */
+    SCB->VTOR = FLASH_BASE;
+
+    /* initialize the clock system */
+    cpu_clock_init();
+
+    /* set pendSV interrupt to lowest possible priority */
+    NVIC_SetPriority(PendSV_IRQn, 0xff);
+}
+
+/**
+ * @brief Configure the controllers clock system
+ *
+ */
+static void cpu_clock_init(void)
+{
+    /* setup system prescalers */
+    SIM->CLKDIV1 = (uint32_t)SIM_CLKDIV1_OUTDIV4(1);
+
+    kinetis_mcg_set_mode(KINETIS_MCG_FEE);
+
+    /* Setup System Intergraion Module */
+    SIM->SOPT2 = SIM_SOPT2_UART0SRC(1) | SIM_SOPT2_TPMSRC(1);
+    /* Selects the clock source OSC32KCLK for RTC and LPTMR (ERCLK32K) */
+    SIM->SOPT1 = SIM_SOPT1_OSC32KSEL(0);
+
+#ifdef KW01Z128_FLL_PLL_TEST
+    SIM->SCGC5 |= (SIM_SCGC5_PORTE_MASK);
+    PORTE->PCR[0] = PORT_PCR_MUX(4);
+    /* OSCERCLK is output on the RTC_CLKOUT pin */
+    SIM->SOPT2 |= SIM_SOPT2_RTCCLKOUTSEL_MASK;
+
+    SIM->SCGC5 |= (SIM_SCGC5_PORTA_MASK);
+    PORTA->PCR[1] = PORT_PCR_MUX(1);
+    GPIOA->PDDR |= (1 << 1);
+    while(42) {
+        GPIOA->PTOR = (1 << 1);
+    }
+#endif
+}

--- a/cpu/kw0x/include/MKW01Z4.h
+++ b/cpu/kw0x/include/MKW01Z4.h
@@ -1,0 +1,6066 @@
+/*
+** ###################################################################
+**     Compilers:           Keil ARM C/C++ Compiler
+**                          Freescale C/C++ for Embedded ARM
+**                          GNU C Compiler
+**                          GNU C Compiler - CodeSourcery Sourcery G++
+**                          IAR ANSI C/C++ Compiler for ARM
+**
+**     Reference manual:    MKW01xxRM, Rev.1, December 2013
+**     Version:             rev. 1.0, 2013-11-22
+**     Build:               b141128
+**
+**     Abstract:
+**         CMSIS Peripheral Access Layer for MKW01Z4
+**
+**     Copyright (c) 1997 - 2013 Freescale Semiconductor, Inc.
+**     All rights reserved.
+**
+**     Redistribution and use in source and binary forms, with or without modification,
+**     are permitted provided that the following conditions are met:
+**
+**     o Redistributions of source code must retain the above copyright notice, this list
+**       of conditions and the following disclaimer.
+**
+**     o Redistributions in binary form must reproduce the above copyright notice, this
+**       list of conditions and the following disclaimer in the documentation and/or
+**       other materials provided with the distribution.
+**
+**     o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+**       contributors may be used to endorse or promote products derived from this
+**       software without specific prior written permission.
+**
+**     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+**     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+**     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+**     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+**     ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+**     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+**     ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+**     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+**     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+**     http:                 www.freescale.com
+**     mail:                 support@freescale.com
+**
+**     Revisions:
+**     - rev. 1.0 (2013-11-22)
+**         Initial version.
+**
+** ###################################################################
+*/
+
+/*!
+ * @file MKW01Z4.h
+ * @version 1.0
+ * @date 2013-11-22
+ * @brief CMSIS Peripheral Access Layer for MKW01Z4
+ *
+ * CMSIS Peripheral Access Layer for MKW01Z4
+ */
+
+
+/* ----------------------------------------------------------------------------
+   -- MCU activation
+   ---------------------------------------------------------------------------- */
+
+/* Prevention from multiple including the same memory map */
+#if !defined(MKW01Z4_H_)  /* Check if memory map has not been already included */
+#define MKW01Z4_H_
+#define MCU_MKW01Z4
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* Check if another memory map has not been also included */
+#if (defined(MCU_ACTIVE))
+  #error MKW01Z4 memory map: There is already included another memory map. Only one memory map can be included.
+#endif /* (defined(MCU_ACTIVE)) */
+#define MCU_ACTIVE
+
+#include <stdint.h>
+
+/** Memory map major version (memory maps with equal major version number are
+ * compatible) */
+#define MCU_MEM_MAP_VERSION 0x0100u
+/** Memory map minor version */
+#define MCU_MEM_MAP_VERSION_MINOR 0x0000u
+
+
+/* ----------------------------------------------------------------------------
+   -- Interrupt vector numbers
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup Interrupt_vector_numbers Interrupt vector numbers
+ * @{
+ */
+
+/** Interrupt Number Definitions */
+#define NUMBER_OF_INT_VECTORS 48                 /**< Number of interrupts in the Vector table */
+
+typedef enum IRQn {
+  /* Auxiliary constants */
+  NotAvail_IRQn                = -128,             /**< Not available device specific interrupt */
+
+  /* Core interrupts */
+  NonMaskableInt_IRQn          = -14,              /**< Non Maskable Interrupt */
+  HardFault_IRQn               = -13,              /**< Cortex-M0 SV Hard Fault Interrupt */
+  SVCall_IRQn                  = -5,               /**< Cortex-M0 SV Call Interrupt */
+  PendSV_IRQn                  = -2,               /**< Cortex-M0 Pend SV Interrupt */
+  SysTick_IRQn                 = -1,               /**< Cortex-M0 System Tick Interrupt */
+
+  /* Device specific interrupts */
+  DMA0_IRQn                    = 0,                /**< DMA channel 0 transfer complete and error interrupt */
+  DMA1_IRQn                    = 1,                /**< DMA channel 1 transfer complete and error interrupt */
+  DMA2_IRQn                    = 2,                /**< DMA channel 2 transfer complete and error interrupt */
+  DMA3_IRQn                    = 3,                /**< DMA channel 3 transfer complete and error interrupt */
+  Reserved20_IRQn              = 4,                /**< Reserved interrupt */
+  FTFA_IRQn                    = 5,                /**< FTFA command complete and read collision */
+  LVD_LVW_IRQn                 = 6,                /**< Low-voltage detect, low-voltage warning */
+  LLWU_IRQn                    = 7,                /**< Low Leakage Wakeup */
+  I2C0_IRQn                    = 8,                /**< I2C0 interrupt */
+  I2C1_IRQn                    = 9,                /**< I2C1 interrupt */
+  SPI0_IRQn                    = 10,               /**< SPI0 single interrupt vector for all sources */
+  SPI1_IRQn                    = 11,               /**< SPI1 single interrupt vector for all sources */
+  UART0_IRQn                   = 12,               /**< UART0 status and error */
+  UART1_IRQn                   = 13,               /**< UART1 status and error */
+  UART2_IRQn                   = 14,               /**< UART2 status and error */
+  ADC0_IRQn                    = 15,               /**< ADC0 interrupt */
+  CMP0_IRQn                    = 16,               /**< CMP0 interrupt */
+  TPM0_IRQn                    = 17,               /**< TPM0 single interrupt vector for all sources */
+  TPM1_IRQn                    = 18,               /**< TPM1 single interrupt vector for all sources */
+  TPM2_IRQn                    = 19,               /**< TPM2 single interrupt vector for all sources */
+  RTC_IRQn                     = 20,               /**< RTC alarm interrupt */
+  RTC_Seconds_IRQn             = 21,               /**< RTC seconds interrupt */
+  PIT_IRQn                     = 22,               /**< PIT single interrupt vector for all channels */
+  Reserved39_IRQn              = 23,               /**< Reserved interrupt */
+  Reserved40_IRQn              = 24,               /**< Reserved interrupt */
+  DAC0_IRQn                    = 25,               /**< DAC0 interrupt */
+  TSI0_IRQn                    = 26,               /**< TSI0 interrupt */
+  MCG_IRQn                     = 27,               /**< MCG interrupt */
+  LPTMR0_IRQn                  = 28,               /**< LPTMR0 interrupt */
+  Reserved45_IRQn              = 29,               /**< Reserved interrupt */
+  PORTA_IRQn                   = 30,               /**< PORTA pin detect */
+  PORTC_PORTD_IRQn             = 31                /**< Single interrupt vector for PORTC and PORTD pin detect */
+} IRQn_Type;
+
+/*!
+ * @}
+ */ /* end of group Interrupt_vector_numbers */
+
+
+/* ----------------------------------------------------------------------------
+   -- Cortex M0 Core Configuration
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup Cortex_Core_Configuration Cortex M0 Core Configuration
+ * @{
+ */
+
+#define __CM0PLUS_REV                  0x0000    /**< Core revision r0p0 */
+#define __MPU_PRESENT                  0         /**< Defines if an MPU is present or not */
+#define __VTOR_PRESENT                 1         /**< Defines if an MPU is present or not */
+#define __NVIC_PRIO_BITS               2         /**< Number of priority bits implemented in the NVIC */
+#define __Vendor_SysTickConfig         0         /**< Vendor specific implementation of SysTickConfig is defined */
+
+#include "core_cm0plus.h"              /* Core Peripheral Access Layer */
+//#include "system_MKW01Z4.h"            /* Device specific configuration file */
+
+/*!
+ * @}
+ */ /* end of group Cortex_Core_Configuration */
+
+
+/* ----------------------------------------------------------------------------
+   -- Device Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup Peripheral_access_layer Device Peripheral Access Layer
+ * @{
+ */
+
+
+/*
+** Start of section using anonymous unions
+*/
+
+#if defined(__ARMCC_VERSION)
+  #pragma push
+  #pragma anon_unions
+#elif defined(__CWCC__)
+  #pragma push
+  #pragma cpp_extensions on
+#elif defined(__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined(__IAR_SYSTEMS_ICC__)
+  #pragma language=extended
+#else
+  #error Not supported compiler type
+#endif
+
+/* ----------------------------------------------------------------------------
+   -- ADC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ADC_Peripheral_Access_Layer ADC Peripheral Access Layer
+ * @{
+ */
+
+/** ADC - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t SC1[2];                            /**< ADC Status and Control Registers 1, array offset: 0x0, array step: 0x4 */
+  __IO uint32_t CFG1;                              /**< ADC Configuration Register 1, offset: 0x8 */
+  __IO uint32_t CFG2;                              /**< ADC Configuration Register 2, offset: 0xC */
+  __I  uint32_t R[2];                              /**< ADC Data Result Register, array offset: 0x10, array step: 0x4 */
+  __IO uint32_t CV1;                               /**< Compare Value Registers, offset: 0x18 */
+  __IO uint32_t CV2;                               /**< Compare Value Registers, offset: 0x1C */
+  __IO uint32_t SC2;                               /**< Status and Control Register 2, offset: 0x20 */
+  __IO uint32_t SC3;                               /**< Status and Control Register 3, offset: 0x24 */
+  __IO uint32_t OFS;                               /**< ADC Offset Correction Register, offset: 0x28 */
+  __IO uint32_t PG;                                /**< ADC Plus-Side Gain Register, offset: 0x2C */
+  __IO uint32_t MG;                                /**< ADC Minus-Side Gain Register, offset: 0x30 */
+  __IO uint32_t CLPD;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x34 */
+  __IO uint32_t CLPS;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x38 */
+  __IO uint32_t CLP4;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x3C */
+  __IO uint32_t CLP3;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x40 */
+  __IO uint32_t CLP2;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x44 */
+  __IO uint32_t CLP1;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x48 */
+  __IO uint32_t CLP0;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x4C */
+       uint8_t RESERVED_0[4];
+  __IO uint32_t CLMD;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x54 */
+  __IO uint32_t CLMS;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x58 */
+  __IO uint32_t CLM4;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x5C */
+  __IO uint32_t CLM3;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x60 */
+  __IO uint32_t CLM2;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x64 */
+  __IO uint32_t CLM1;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x68 */
+  __IO uint32_t CLM0;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x6C */
+} ADC_Type, *ADC_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- ADC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ADC_Register_Accessor_Macros ADC - Register accessor macros
+ * @{
+ */
+
+
+/* ADC - Register accessors */
+#define ADC_SC1_REG(base,index)                  ((base)->SC1[index])
+#define ADC_CFG1_REG(base)                       ((base)->CFG1)
+#define ADC_CFG2_REG(base)                       ((base)->CFG2)
+#define ADC_R_REG(base,index)                    ((base)->R[index])
+#define ADC_CV1_REG(base)                        ((base)->CV1)
+#define ADC_CV2_REG(base)                        ((base)->CV2)
+#define ADC_SC2_REG(base)                        ((base)->SC2)
+#define ADC_SC3_REG(base)                        ((base)->SC3)
+#define ADC_OFS_REG(base)                        ((base)->OFS)
+#define ADC_PG_REG(base)                         ((base)->PG)
+#define ADC_MG_REG(base)                         ((base)->MG)
+#define ADC_CLPD_REG(base)                       ((base)->CLPD)
+#define ADC_CLPS_REG(base)                       ((base)->CLPS)
+#define ADC_CLP4_REG(base)                       ((base)->CLP4)
+#define ADC_CLP3_REG(base)                       ((base)->CLP3)
+#define ADC_CLP2_REG(base)                       ((base)->CLP2)
+#define ADC_CLP1_REG(base)                       ((base)->CLP1)
+#define ADC_CLP0_REG(base)                       ((base)->CLP0)
+#define ADC_CLMD_REG(base)                       ((base)->CLMD)
+#define ADC_CLMS_REG(base)                       ((base)->CLMS)
+#define ADC_CLM4_REG(base)                       ((base)->CLM4)
+#define ADC_CLM3_REG(base)                       ((base)->CLM3)
+#define ADC_CLM2_REG(base)                       ((base)->CLM2)
+#define ADC_CLM1_REG(base)                       ((base)->CLM1)
+#define ADC_CLM0_REG(base)                       ((base)->CLM0)
+
+/*!
+ * @}
+ */ /* end of group ADC_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- ADC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ADC_Register_Masks ADC Register Masks
+ * @{
+ */
+
+/* SC1 Bit Fields */
+#define ADC_SC1_ADCH_MASK                        0x1Fu
+#define ADC_SC1_ADCH_SHIFT                       0
+#define ADC_SC1_ADCH(x)                          (((uint32_t)(((uint32_t)(x))<<ADC_SC1_ADCH_SHIFT))&ADC_SC1_ADCH_MASK)
+#define ADC_SC1_DIFF_MASK                        0x20u
+#define ADC_SC1_DIFF_SHIFT                       5
+#define ADC_SC1_AIEN_MASK                        0x40u
+#define ADC_SC1_AIEN_SHIFT                       6
+#define ADC_SC1_COCO_MASK                        0x80u
+#define ADC_SC1_COCO_SHIFT                       7
+/* CFG1 Bit Fields */
+#define ADC_CFG1_ADICLK_MASK                     0x3u
+#define ADC_CFG1_ADICLK_SHIFT                    0
+#define ADC_CFG1_ADICLK(x)                       (((uint32_t)(((uint32_t)(x))<<ADC_CFG1_ADICLK_SHIFT))&ADC_CFG1_ADICLK_MASK)
+#define ADC_CFG1_MODE_MASK                       0xCu
+#define ADC_CFG1_MODE_SHIFT                      2
+#define ADC_CFG1_MODE(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CFG1_MODE_SHIFT))&ADC_CFG1_MODE_MASK)
+#define ADC_CFG1_ADLSMP_MASK                     0x10u
+#define ADC_CFG1_ADLSMP_SHIFT                    4
+#define ADC_CFG1_ADIV_MASK                       0x60u
+#define ADC_CFG1_ADIV_SHIFT                      5
+#define ADC_CFG1_ADIV(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CFG1_ADIV_SHIFT))&ADC_CFG1_ADIV_MASK)
+#define ADC_CFG1_ADLPC_MASK                      0x80u
+#define ADC_CFG1_ADLPC_SHIFT                     7
+/* CFG2 Bit Fields */
+#define ADC_CFG2_ADLSTS_MASK                     0x3u
+#define ADC_CFG2_ADLSTS_SHIFT                    0
+#define ADC_CFG2_ADLSTS(x)                       (((uint32_t)(((uint32_t)(x))<<ADC_CFG2_ADLSTS_SHIFT))&ADC_CFG2_ADLSTS_MASK)
+#define ADC_CFG2_ADHSC_MASK                      0x4u
+#define ADC_CFG2_ADHSC_SHIFT                     2
+#define ADC_CFG2_ADACKEN_MASK                    0x8u
+#define ADC_CFG2_ADACKEN_SHIFT                   3
+#define ADC_CFG2_MUXSEL_MASK                     0x10u
+#define ADC_CFG2_MUXSEL_SHIFT                    4
+/* R Bit Fields */
+#define ADC_R_D_MASK                             0xFFFFu
+#define ADC_R_D_SHIFT                            0
+#define ADC_R_D(x)                               (((uint32_t)(((uint32_t)(x))<<ADC_R_D_SHIFT))&ADC_R_D_MASK)
+/* CV1 Bit Fields */
+#define ADC_CV1_CV_MASK                          0xFFFFu
+#define ADC_CV1_CV_SHIFT                         0
+#define ADC_CV1_CV(x)                            (((uint32_t)(((uint32_t)(x))<<ADC_CV1_CV_SHIFT))&ADC_CV1_CV_MASK)
+/* CV2 Bit Fields */
+#define ADC_CV2_CV_MASK                          0xFFFFu
+#define ADC_CV2_CV_SHIFT                         0
+#define ADC_CV2_CV(x)                            (((uint32_t)(((uint32_t)(x))<<ADC_CV2_CV_SHIFT))&ADC_CV2_CV_MASK)
+/* SC2 Bit Fields */
+#define ADC_SC2_REFSEL_MASK                      0x3u
+#define ADC_SC2_REFSEL_SHIFT                     0
+#define ADC_SC2_REFSEL(x)                        (((uint32_t)(((uint32_t)(x))<<ADC_SC2_REFSEL_SHIFT))&ADC_SC2_REFSEL_MASK)
+#define ADC_SC2_DMAEN_MASK                       0x4u
+#define ADC_SC2_DMAEN_SHIFT                      2
+#define ADC_SC2_ACREN_MASK                       0x8u
+#define ADC_SC2_ACREN_SHIFT                      3
+#define ADC_SC2_ACFGT_MASK                       0x10u
+#define ADC_SC2_ACFGT_SHIFT                      4
+#define ADC_SC2_ACFE_MASK                        0x20u
+#define ADC_SC2_ACFE_SHIFT                       5
+#define ADC_SC2_ADTRG_MASK                       0x40u
+#define ADC_SC2_ADTRG_SHIFT                      6
+#define ADC_SC2_ADACT_MASK                       0x80u
+#define ADC_SC2_ADACT_SHIFT                      7
+/* SC3 Bit Fields */
+#define ADC_SC3_AVGS_MASK                        0x3u
+#define ADC_SC3_AVGS_SHIFT                       0
+#define ADC_SC3_AVGS(x)                          (((uint32_t)(((uint32_t)(x))<<ADC_SC3_AVGS_SHIFT))&ADC_SC3_AVGS_MASK)
+#define ADC_SC3_AVGE_MASK                        0x4u
+#define ADC_SC3_AVGE_SHIFT                       2
+#define ADC_SC3_ADCO_MASK                        0x8u
+#define ADC_SC3_ADCO_SHIFT                       3
+#define ADC_SC3_CALF_MASK                        0x40u
+#define ADC_SC3_CALF_SHIFT                       6
+#define ADC_SC3_CAL_MASK                         0x80u
+#define ADC_SC3_CAL_SHIFT                        7
+/* OFS Bit Fields */
+#define ADC_OFS_OFS_MASK                         0xFFFFu
+#define ADC_OFS_OFS_SHIFT                        0
+#define ADC_OFS_OFS(x)                           (((uint32_t)(((uint32_t)(x))<<ADC_OFS_OFS_SHIFT))&ADC_OFS_OFS_MASK)
+/* PG Bit Fields */
+#define ADC_PG_PG_MASK                           0xFFFFu
+#define ADC_PG_PG_SHIFT                          0
+#define ADC_PG_PG(x)                             (((uint32_t)(((uint32_t)(x))<<ADC_PG_PG_SHIFT))&ADC_PG_PG_MASK)
+/* MG Bit Fields */
+#define ADC_MG_MG_MASK                           0xFFFFu
+#define ADC_MG_MG_SHIFT                          0
+#define ADC_MG_MG(x)                             (((uint32_t)(((uint32_t)(x))<<ADC_MG_MG_SHIFT))&ADC_MG_MG_MASK)
+/* CLPD Bit Fields */
+#define ADC_CLPD_CLPD_MASK                       0x3Fu
+#define ADC_CLPD_CLPD_SHIFT                      0
+#define ADC_CLPD_CLPD(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLPD_CLPD_SHIFT))&ADC_CLPD_CLPD_MASK)
+/* CLPS Bit Fields */
+#define ADC_CLPS_CLPS_MASK                       0x3Fu
+#define ADC_CLPS_CLPS_SHIFT                      0
+#define ADC_CLPS_CLPS(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLPS_CLPS_SHIFT))&ADC_CLPS_CLPS_MASK)
+/* CLP4 Bit Fields */
+#define ADC_CLP4_CLP4_MASK                       0x3FFu
+#define ADC_CLP4_CLP4_SHIFT                      0
+#define ADC_CLP4_CLP4(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLP4_CLP4_SHIFT))&ADC_CLP4_CLP4_MASK)
+/* CLP3 Bit Fields */
+#define ADC_CLP3_CLP3_MASK                       0x1FFu
+#define ADC_CLP3_CLP3_SHIFT                      0
+#define ADC_CLP3_CLP3(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLP3_CLP3_SHIFT))&ADC_CLP3_CLP3_MASK)
+/* CLP2 Bit Fields */
+#define ADC_CLP2_CLP2_MASK                       0xFFu
+#define ADC_CLP2_CLP2_SHIFT                      0
+#define ADC_CLP2_CLP2(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLP2_CLP2_SHIFT))&ADC_CLP2_CLP2_MASK)
+/* CLP1 Bit Fields */
+#define ADC_CLP1_CLP1_MASK                       0x7Fu
+#define ADC_CLP1_CLP1_SHIFT                      0
+#define ADC_CLP1_CLP1(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLP1_CLP1_SHIFT))&ADC_CLP1_CLP1_MASK)
+/* CLP0 Bit Fields */
+#define ADC_CLP0_CLP0_MASK                       0x3Fu
+#define ADC_CLP0_CLP0_SHIFT                      0
+#define ADC_CLP0_CLP0(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLP0_CLP0_SHIFT))&ADC_CLP0_CLP0_MASK)
+/* CLMD Bit Fields */
+#define ADC_CLMD_CLMD_MASK                       0x3Fu
+#define ADC_CLMD_CLMD_SHIFT                      0
+#define ADC_CLMD_CLMD(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLMD_CLMD_SHIFT))&ADC_CLMD_CLMD_MASK)
+/* CLMS Bit Fields */
+#define ADC_CLMS_CLMS_MASK                       0x3Fu
+#define ADC_CLMS_CLMS_SHIFT                      0
+#define ADC_CLMS_CLMS(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLMS_CLMS_SHIFT))&ADC_CLMS_CLMS_MASK)
+/* CLM4 Bit Fields */
+#define ADC_CLM4_CLM4_MASK                       0x3FFu
+#define ADC_CLM4_CLM4_SHIFT                      0
+#define ADC_CLM4_CLM4(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLM4_CLM4_SHIFT))&ADC_CLM4_CLM4_MASK)
+/* CLM3 Bit Fields */
+#define ADC_CLM3_CLM3_MASK                       0x1FFu
+#define ADC_CLM3_CLM3_SHIFT                      0
+#define ADC_CLM3_CLM3(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLM3_CLM3_SHIFT))&ADC_CLM3_CLM3_MASK)
+/* CLM2 Bit Fields */
+#define ADC_CLM2_CLM2_MASK                       0xFFu
+#define ADC_CLM2_CLM2_SHIFT                      0
+#define ADC_CLM2_CLM2(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLM2_CLM2_SHIFT))&ADC_CLM2_CLM2_MASK)
+/* CLM1 Bit Fields */
+#define ADC_CLM1_CLM1_MASK                       0x7Fu
+#define ADC_CLM1_CLM1_SHIFT                      0
+#define ADC_CLM1_CLM1(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLM1_CLM1_SHIFT))&ADC_CLM1_CLM1_MASK)
+/* CLM0 Bit Fields */
+#define ADC_CLM0_CLM0_MASK                       0x3Fu
+#define ADC_CLM0_CLM0_SHIFT                      0
+#define ADC_CLM0_CLM0(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLM0_CLM0_SHIFT))&ADC_CLM0_CLM0_MASK)
+
+/*!
+ * @}
+ */ /* end of group ADC_Register_Masks */
+
+
+/* ADC - Peripheral instance base addresses */
+/** Peripheral ADC0 base address */
+#define ADC0_BASE                                (0x4003B000u)
+/** Peripheral ADC0 base pointer */
+#define ADC0                                     ((ADC_Type *)ADC0_BASE)
+#define ADC0_BASE_PTR                            (ADC0)
+/** Array initializer of ADC peripheral base addresses */
+#define ADC_BASE_ADDRS                           { ADC0_BASE }
+/** Array initializer of ADC peripheral base pointers */
+#define ADC_BASE_PTRS                            { ADC0 }
+/** Interrupt vectors for the ADC peripheral type */
+#define ADC_IRQS                                 { ADC0_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- ADC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ADC_Register_Accessor_Macros ADC - Register accessor macros
+ * @{
+ */
+
+
+/* ADC - Register instance definitions */
+/* ADC0 */
+#define ADC0_SC1A                                ADC_SC1_REG(ADC0,0)
+#define ADC0_SC1B                                ADC_SC1_REG(ADC0,1)
+#define ADC0_CFG1                                ADC_CFG1_REG(ADC0)
+#define ADC0_CFG2                                ADC_CFG2_REG(ADC0)
+#define ADC0_RA                                  ADC_R_REG(ADC0,0)
+#define ADC0_RB                                  ADC_R_REG(ADC0,1)
+#define ADC0_CV1                                 ADC_CV1_REG(ADC0)
+#define ADC0_CV2                                 ADC_CV2_REG(ADC0)
+#define ADC0_SC2                                 ADC_SC2_REG(ADC0)
+#define ADC0_SC3                                 ADC_SC3_REG(ADC0)
+#define ADC0_OFS                                 ADC_OFS_REG(ADC0)
+#define ADC0_PG                                  ADC_PG_REG(ADC0)
+#define ADC0_MG                                  ADC_MG_REG(ADC0)
+#define ADC0_CLPD                                ADC_CLPD_REG(ADC0)
+#define ADC0_CLPS                                ADC_CLPS_REG(ADC0)
+#define ADC0_CLP4                                ADC_CLP4_REG(ADC0)
+#define ADC0_CLP3                                ADC_CLP3_REG(ADC0)
+#define ADC0_CLP2                                ADC_CLP2_REG(ADC0)
+#define ADC0_CLP1                                ADC_CLP1_REG(ADC0)
+#define ADC0_CLP0                                ADC_CLP0_REG(ADC0)
+#define ADC0_CLMD                                ADC_CLMD_REG(ADC0)
+#define ADC0_CLMS                                ADC_CLMS_REG(ADC0)
+#define ADC0_CLM4                                ADC_CLM4_REG(ADC0)
+#define ADC0_CLM3                                ADC_CLM3_REG(ADC0)
+#define ADC0_CLM2                                ADC_CLM2_REG(ADC0)
+#define ADC0_CLM1                                ADC_CLM1_REG(ADC0)
+#define ADC0_CLM0                                ADC_CLM0_REG(ADC0)
+
+/* ADC - Register array accessors */
+#define ADC0_SC1(index)                          ADC_SC1_REG(ADC0,index)
+#define ADC0_R(index)                            ADC_R_REG(ADC0,index)
+
+/*!
+ * @}
+ */ /* end of group ADC_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group ADC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- CMP Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CMP_Peripheral_Access_Layer CMP Peripheral Access Layer
+ * @{
+ */
+
+/** CMP - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t CR0;                                /**< CMP Control Register 0, offset: 0x0 */
+  __IO uint8_t CR1;                                /**< CMP Control Register 1, offset: 0x1 */
+  __IO uint8_t FPR;                                /**< CMP Filter Period Register, offset: 0x2 */
+  __IO uint8_t SCR;                                /**< CMP Status and Control Register, offset: 0x3 */
+  __IO uint8_t DACCR;                              /**< DAC Control Register, offset: 0x4 */
+  __IO uint8_t MUXCR;                              /**< MUX Control Register, offset: 0x5 */
+} CMP_Type, *CMP_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- CMP - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CMP_Register_Accessor_Macros CMP - Register accessor macros
+ * @{
+ */
+
+
+/* CMP - Register accessors */
+#define CMP_CR0_REG(base)                        ((base)->CR0)
+#define CMP_CR1_REG(base)                        ((base)->CR1)
+#define CMP_FPR_REG(base)                        ((base)->FPR)
+#define CMP_SCR_REG(base)                        ((base)->SCR)
+#define CMP_DACCR_REG(base)                      ((base)->DACCR)
+#define CMP_MUXCR_REG(base)                      ((base)->MUXCR)
+
+/*!
+ * @}
+ */ /* end of group CMP_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- CMP Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CMP_Register_Masks CMP Register Masks
+ * @{
+ */
+
+/* CR0 Bit Fields */
+#define CMP_CR0_HYSTCTR_MASK                     0x3u
+#define CMP_CR0_HYSTCTR_SHIFT                    0
+#define CMP_CR0_HYSTCTR(x)                       (((uint8_t)(((uint8_t)(x))<<CMP_CR0_HYSTCTR_SHIFT))&CMP_CR0_HYSTCTR_MASK)
+#define CMP_CR0_FILTER_CNT_MASK                  0x70u
+#define CMP_CR0_FILTER_CNT_SHIFT                 4
+#define CMP_CR0_FILTER_CNT(x)                    (((uint8_t)(((uint8_t)(x))<<CMP_CR0_FILTER_CNT_SHIFT))&CMP_CR0_FILTER_CNT_MASK)
+/* CR1 Bit Fields */
+#define CMP_CR1_EN_MASK                          0x1u
+#define CMP_CR1_EN_SHIFT                         0
+#define CMP_CR1_OPE_MASK                         0x2u
+#define CMP_CR1_OPE_SHIFT                        1
+#define CMP_CR1_COS_MASK                         0x4u
+#define CMP_CR1_COS_SHIFT                        2
+#define CMP_CR1_INV_MASK                         0x8u
+#define CMP_CR1_INV_SHIFT                        3
+#define CMP_CR1_PMODE_MASK                       0x10u
+#define CMP_CR1_PMODE_SHIFT                      4
+#define CMP_CR1_TRIGM_MASK                       0x20u
+#define CMP_CR1_TRIGM_SHIFT                      5
+#define CMP_CR1_WE_MASK                          0x40u
+#define CMP_CR1_WE_SHIFT                         6
+#define CMP_CR1_SE_MASK                          0x80u
+#define CMP_CR1_SE_SHIFT                         7
+/* FPR Bit Fields */
+#define CMP_FPR_FILT_PER_MASK                    0xFFu
+#define CMP_FPR_FILT_PER_SHIFT                   0
+#define CMP_FPR_FILT_PER(x)                      (((uint8_t)(((uint8_t)(x))<<CMP_FPR_FILT_PER_SHIFT))&CMP_FPR_FILT_PER_MASK)
+/* SCR Bit Fields */
+#define CMP_SCR_COUT_MASK                        0x1u
+#define CMP_SCR_COUT_SHIFT                       0
+#define CMP_SCR_CFF_MASK                         0x2u
+#define CMP_SCR_CFF_SHIFT                        1
+#define CMP_SCR_CFR_MASK                         0x4u
+#define CMP_SCR_CFR_SHIFT                        2
+#define CMP_SCR_IEF_MASK                         0x8u
+#define CMP_SCR_IEF_SHIFT                        3
+#define CMP_SCR_IER_MASK                         0x10u
+#define CMP_SCR_IER_SHIFT                        4
+#define CMP_SCR_DMAEN_MASK                       0x40u
+#define CMP_SCR_DMAEN_SHIFT                      6
+/* DACCR Bit Fields */
+#define CMP_DACCR_VOSEL_MASK                     0x3Fu
+#define CMP_DACCR_VOSEL_SHIFT                    0
+#define CMP_DACCR_VOSEL(x)                       (((uint8_t)(((uint8_t)(x))<<CMP_DACCR_VOSEL_SHIFT))&CMP_DACCR_VOSEL_MASK)
+#define CMP_DACCR_VRSEL_MASK                     0x40u
+#define CMP_DACCR_VRSEL_SHIFT                    6
+#define CMP_DACCR_DACEN_MASK                     0x80u
+#define CMP_DACCR_DACEN_SHIFT                    7
+/* MUXCR Bit Fields */
+#define CMP_MUXCR_MSEL_MASK                      0x7u
+#define CMP_MUXCR_MSEL_SHIFT                     0
+#define CMP_MUXCR_MSEL(x)                        (((uint8_t)(((uint8_t)(x))<<CMP_MUXCR_MSEL_SHIFT))&CMP_MUXCR_MSEL_MASK)
+#define CMP_MUXCR_PSEL_MASK                      0x38u
+#define CMP_MUXCR_PSEL_SHIFT                     3
+#define CMP_MUXCR_PSEL(x)                        (((uint8_t)(((uint8_t)(x))<<CMP_MUXCR_PSEL_SHIFT))&CMP_MUXCR_PSEL_MASK)
+#define CMP_MUXCR_PSTM_MASK                      0x80u
+#define CMP_MUXCR_PSTM_SHIFT                     7
+
+/*!
+ * @}
+ */ /* end of group CMP_Register_Masks */
+
+
+/* CMP - Peripheral instance base addresses */
+/** Peripheral CMP0 base address */
+#define CMP0_BASE                                (0x40073000u)
+/** Peripheral CMP0 base pointer */
+#define CMP0                                     ((CMP_Type *)CMP0_BASE)
+#define CMP0_BASE_PTR                            (CMP0)
+/** Array initializer of CMP peripheral base addresses */
+#define CMP_BASE_ADDRS                           { CMP0_BASE }
+/** Array initializer of CMP peripheral base pointers */
+#define CMP_BASE_PTRS                            { CMP0 }
+/** Interrupt vectors for the CMP peripheral type */
+#define CMP_IRQS                                 { CMP0_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- CMP - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CMP_Register_Accessor_Macros CMP - Register accessor macros
+ * @{
+ */
+
+
+/* CMP - Register instance definitions */
+/* CMP0 */
+#define CMP0_CR0                                 CMP_CR0_REG(CMP0)
+#define CMP0_CR1                                 CMP_CR1_REG(CMP0)
+#define CMP0_FPR                                 CMP_FPR_REG(CMP0)
+#define CMP0_SCR                                 CMP_SCR_REG(CMP0)
+#define CMP0_DACCR                               CMP_DACCR_REG(CMP0)
+#define CMP0_MUXCR                               CMP_MUXCR_REG(CMP0)
+
+/*!
+ * @}
+ */ /* end of group CMP_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group CMP_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- DAC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DAC_Peripheral_Access_Layer DAC Peripheral Access Layer
+ * @{
+ */
+
+/** DAC - Register Layout Typedef */
+typedef struct {
+  struct {                                         /* offset: 0x0, array step: 0x2 */
+    __IO uint8_t DATL;                               /**< DAC Data Low Register, array offset: 0x0, array step: 0x2 */
+    __IO uint8_t DATH;                               /**< DAC Data High Register, array offset: 0x1, array step: 0x2 */
+  } DAT[2];
+       uint8_t RESERVED_0[28];
+  __IO uint8_t SR;                                 /**< DAC Status Register, offset: 0x20 */
+  __IO uint8_t C0;                                 /**< DAC Control Register, offset: 0x21 */
+  __IO uint8_t C1;                                 /**< DAC Control Register 1, offset: 0x22 */
+  __IO uint8_t C2;                                 /**< DAC Control Register 2, offset: 0x23 */
+} DAC_Type, *DAC_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- DAC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DAC_Register_Accessor_Macros DAC - Register accessor macros
+ * @{
+ */
+
+
+/* DAC - Register accessors */
+#define DAC_DATL_REG(base,index)                 ((base)->DAT[index].DATL)
+#define DAC_DATH_REG(base,index)                 ((base)->DAT[index].DATH)
+#define DAC_SR_REG(base)                         ((base)->SR)
+#define DAC_C0_REG(base)                         ((base)->C0)
+#define DAC_C1_REG(base)                         ((base)->C1)
+#define DAC_C2_REG(base)                         ((base)->C2)
+
+/*!
+ * @}
+ */ /* end of group DAC_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- DAC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DAC_Register_Masks DAC Register Masks
+ * @{
+ */
+
+/* DATL Bit Fields */
+#define DAC_DATL_DATA0_MASK                      0xFFu
+#define DAC_DATL_DATA0_SHIFT                     0
+#define DAC_DATL_DATA0(x)                        (((uint8_t)(((uint8_t)(x))<<DAC_DATL_DATA0_SHIFT))&DAC_DATL_DATA0_MASK)
+/* DATH Bit Fields */
+#define DAC_DATH_DATA1_MASK                      0xFu
+#define DAC_DATH_DATA1_SHIFT                     0
+#define DAC_DATH_DATA1(x)                        (((uint8_t)(((uint8_t)(x))<<DAC_DATH_DATA1_SHIFT))&DAC_DATH_DATA1_MASK)
+/* SR Bit Fields */
+#define DAC_SR_DACBFRPBF_MASK                    0x1u
+#define DAC_SR_DACBFRPBF_SHIFT                   0
+#define DAC_SR_DACBFRPTF_MASK                    0x2u
+#define DAC_SR_DACBFRPTF_SHIFT                   1
+/* C0 Bit Fields */
+#define DAC_C0_DACBBIEN_MASK                     0x1u
+#define DAC_C0_DACBBIEN_SHIFT                    0
+#define DAC_C0_DACBTIEN_MASK                     0x2u
+#define DAC_C0_DACBTIEN_SHIFT                    1
+#define DAC_C0_LPEN_MASK                         0x8u
+#define DAC_C0_LPEN_SHIFT                        3
+#define DAC_C0_DACSWTRG_MASK                     0x10u
+#define DAC_C0_DACSWTRG_SHIFT                    4
+#define DAC_C0_DACTRGSEL_MASK                    0x20u
+#define DAC_C0_DACTRGSEL_SHIFT                   5
+#define DAC_C0_DACRFS_MASK                       0x40u
+#define DAC_C0_DACRFS_SHIFT                      6
+#define DAC_C0_DACEN_MASK                        0x80u
+#define DAC_C0_DACEN_SHIFT                       7
+/* C1 Bit Fields */
+#define DAC_C1_DACBFEN_MASK                      0x1u
+#define DAC_C1_DACBFEN_SHIFT                     0
+#define DAC_C1_DACBFMD_MASK                      0x4u
+#define DAC_C1_DACBFMD_SHIFT                     2
+#define DAC_C1_DMAEN_MASK                        0x80u
+#define DAC_C1_DMAEN_SHIFT                       7
+/* C2 Bit Fields */
+#define DAC_C2_DACBFUP_MASK                      0x1u
+#define DAC_C2_DACBFUP_SHIFT                     0
+#define DAC_C2_DACBFRP_MASK                      0x10u
+#define DAC_C2_DACBFRP_SHIFT                     4
+
+/*!
+ * @}
+ */ /* end of group DAC_Register_Masks */
+
+
+/* DAC - Peripheral instance base addresses */
+/** Peripheral DAC0 base address */
+#define DAC0_BASE                                (0x4003F000u)
+/** Peripheral DAC0 base pointer */
+#define DAC0                                     ((DAC_Type *)DAC0_BASE)
+#define DAC0_BASE_PTR                            (DAC0)
+/** Array initializer of DAC peripheral base addresses */
+#define DAC_BASE_ADDRS                           { DAC0_BASE }
+/** Array initializer of DAC peripheral base pointers */
+#define DAC_BASE_PTRS                            { DAC0 }
+/** Interrupt vectors for the DAC peripheral type */
+#define DAC_IRQS                                 { DAC0_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- DAC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DAC_Register_Accessor_Macros DAC - Register accessor macros
+ * @{
+ */
+
+
+/* DAC - Register instance definitions */
+/* DAC0 */
+#define DAC0_DAT0L                               DAC_DATL_REG(DAC0,0)
+#define DAC0_DAT0H                               DAC_DATH_REG(DAC0,0)
+#define DAC0_DAT1L                               DAC_DATL_REG(DAC0,1)
+#define DAC0_DAT1H                               DAC_DATH_REG(DAC0,1)
+#define DAC0_SR                                  DAC_SR_REG(DAC0)
+#define DAC0_C0                                  DAC_C0_REG(DAC0)
+#define DAC0_C1                                  DAC_C1_REG(DAC0)
+#define DAC0_C2                                  DAC_C2_REG(DAC0)
+
+/* DAC - Register array accessors */
+#define DAC0_DATL(index)                         DAC_DATL_REG(DAC0,index)
+#define DAC0_DATH(index)                         DAC_DATH_REG(DAC0,index)
+
+/*!
+ * @}
+ */ /* end of group DAC_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group DAC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- DMA Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMA_Peripheral_Access_Layer DMA Peripheral Access Layer
+ * @{
+ */
+
+/** DMA - Register Layout Typedef */
+typedef struct {
+       uint8_t RESERVED_0[256];
+  struct {                                         /* offset: 0x100, array step: 0x10 */
+    __IO uint32_t SAR;                               /**< Source Address Register, array offset: 0x100, array step: 0x10 */
+    __IO uint32_t DAR;                               /**< Destination Address Register, array offset: 0x104, array step: 0x10 */
+    union {                                          /* offset: 0x108, array step: 0x10 */
+      __IO uint32_t DSR_BCR;                           /**< DMA Status Register / Byte Count Register, array offset: 0x108, array step: 0x10 */
+      struct {                                         /* offset: 0x108, array step: 0x10 */
+             uint8_t RESERVED_0[3];
+        __IO uint8_t DSR;                                /**< DMA_DSR0 register...DMA_DSR3 register., array offset: 0x10B, array step: 0x10 */
+      } DMA_DSR_ACCESS8BIT;
+    };
+    __IO uint32_t DCR;                               /**< DMA Control Register, array offset: 0x10C, array step: 0x10 */
+  } DMA[4];
+} DMA_Type, *DMA_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- DMA - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMA_Register_Accessor_Macros DMA - Register accessor macros
+ * @{
+ */
+
+
+/* DMA - Register accessors */
+#define DMA_SAR_REG(base,index)                  ((base)->DMA[index].SAR)
+#define DMA_DAR_REG(base,index)                  ((base)->DMA[index].DAR)
+#define DMA_DSR_BCR_REG(base,index)              ((base)->DMA[index].DSR_BCR)
+#define DMA_DSR_REG(base,index)                  ((base)->DMA[index].DMA_DSR_ACCESS8BIT.DSR)
+#define DMA_DCR_REG(base,index)                  ((base)->DMA[index].DCR)
+
+/*!
+ * @}
+ */ /* end of group DMA_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- DMA Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMA_Register_Masks DMA Register Masks
+ * @{
+ */
+
+/* SAR Bit Fields */
+#define DMA_SAR_SAR_MASK                         0xFFFFFFFFu
+#define DMA_SAR_SAR_SHIFT                        0
+#define DMA_SAR_SAR(x)                           (((uint32_t)(((uint32_t)(x))<<DMA_SAR_SAR_SHIFT))&DMA_SAR_SAR_MASK)
+/* DAR Bit Fields */
+#define DMA_DAR_DAR_MASK                         0xFFFFFFFFu
+#define DMA_DAR_DAR_SHIFT                        0
+#define DMA_DAR_DAR(x)                           (((uint32_t)(((uint32_t)(x))<<DMA_DAR_DAR_SHIFT))&DMA_DAR_DAR_MASK)
+/* DSR_BCR Bit Fields */
+#define DMA_DSR_BCR_BCR_MASK                     0xFFFFFFu
+#define DMA_DSR_BCR_BCR_SHIFT                    0
+#define DMA_DSR_BCR_BCR(x)                       (((uint32_t)(((uint32_t)(x))<<DMA_DSR_BCR_BCR_SHIFT))&DMA_DSR_BCR_BCR_MASK)
+#define DMA_DSR_BCR_DONE_MASK                    0x1000000u
+#define DMA_DSR_BCR_DONE_SHIFT                   24
+#define DMA_DSR_BCR_BSY_MASK                     0x2000000u
+#define DMA_DSR_BCR_BSY_SHIFT                    25
+#define DMA_DSR_BCR_REQ_MASK                     0x4000000u
+#define DMA_DSR_BCR_REQ_SHIFT                    26
+#define DMA_DSR_BCR_BED_MASK                     0x10000000u
+#define DMA_DSR_BCR_BED_SHIFT                    28
+#define DMA_DSR_BCR_BES_MASK                     0x20000000u
+#define DMA_DSR_BCR_BES_SHIFT                    29
+#define DMA_DSR_BCR_CE_MASK                      0x40000000u
+#define DMA_DSR_BCR_CE_SHIFT                     30
+/* DCR Bit Fields */
+#define DMA_DCR_LCH2_MASK                        0x3u
+#define DMA_DCR_LCH2_SHIFT                       0
+#define DMA_DCR_LCH2(x)                          (((uint32_t)(((uint32_t)(x))<<DMA_DCR_LCH2_SHIFT))&DMA_DCR_LCH2_MASK)
+#define DMA_DCR_LCH1_MASK                        0xCu
+#define DMA_DCR_LCH1_SHIFT                       2
+#define DMA_DCR_LCH1(x)                          (((uint32_t)(((uint32_t)(x))<<DMA_DCR_LCH1_SHIFT))&DMA_DCR_LCH1_MASK)
+#define DMA_DCR_LINKCC_MASK                      0x30u
+#define DMA_DCR_LINKCC_SHIFT                     4
+#define DMA_DCR_LINKCC(x)                        (((uint32_t)(((uint32_t)(x))<<DMA_DCR_LINKCC_SHIFT))&DMA_DCR_LINKCC_MASK)
+#define DMA_DCR_D_REQ_MASK                       0x80u
+#define DMA_DCR_D_REQ_SHIFT                      7
+#define DMA_DCR_DMOD_MASK                        0xF00u
+#define DMA_DCR_DMOD_SHIFT                       8
+#define DMA_DCR_DMOD(x)                          (((uint32_t)(((uint32_t)(x))<<DMA_DCR_DMOD_SHIFT))&DMA_DCR_DMOD_MASK)
+#define DMA_DCR_SMOD_MASK                        0xF000u
+#define DMA_DCR_SMOD_SHIFT                       12
+#define DMA_DCR_SMOD(x)                          (((uint32_t)(((uint32_t)(x))<<DMA_DCR_SMOD_SHIFT))&DMA_DCR_SMOD_MASK)
+#define DMA_DCR_START_MASK                       0x10000u
+#define DMA_DCR_START_SHIFT                      16
+#define DMA_DCR_DSIZE_MASK                       0x60000u
+#define DMA_DCR_DSIZE_SHIFT                      17
+#define DMA_DCR_DSIZE(x)                         (((uint32_t)(((uint32_t)(x))<<DMA_DCR_DSIZE_SHIFT))&DMA_DCR_DSIZE_MASK)
+#define DMA_DCR_DINC_MASK                        0x80000u
+#define DMA_DCR_DINC_SHIFT                       19
+#define DMA_DCR_SSIZE_MASK                       0x300000u
+#define DMA_DCR_SSIZE_SHIFT                      20
+#define DMA_DCR_SSIZE(x)                         (((uint32_t)(((uint32_t)(x))<<DMA_DCR_SSIZE_SHIFT))&DMA_DCR_SSIZE_MASK)
+#define DMA_DCR_SINC_MASK                        0x400000u
+#define DMA_DCR_SINC_SHIFT                       22
+#define DMA_DCR_EADREQ_MASK                      0x800000u
+#define DMA_DCR_EADREQ_SHIFT                     23
+#define DMA_DCR_AA_MASK                          0x10000000u
+#define DMA_DCR_AA_SHIFT                         28
+#define DMA_DCR_CS_MASK                          0x20000000u
+#define DMA_DCR_CS_SHIFT                         29
+#define DMA_DCR_ERQ_MASK                         0x40000000u
+#define DMA_DCR_ERQ_SHIFT                        30
+#define DMA_DCR_EINT_MASK                        0x80000000u
+#define DMA_DCR_EINT_SHIFT                       31
+
+/*!
+ * @}
+ */ /* end of group DMA_Register_Masks */
+
+
+/* DMA - Peripheral instance base addresses */
+/** Peripheral DMA base address */
+#define DMA_BASE                                 (0x40008000u)
+/** Peripheral DMA base pointer */
+#define DMA0                                     ((DMA_Type *)DMA_BASE)
+#define DMA_BASE_PTR                             (DMA0)
+/** Array initializer of DMA peripheral base addresses */
+#define DMA_BASE_ADDRS                           { DMA_BASE }
+/** Array initializer of DMA peripheral base pointers */
+#define DMA_BASE_PTRS                            { DMA0 }
+/** Interrupt vectors for the DMA peripheral type */
+#define DMA_CHN_IRQS                             { DMA0_IRQn, DMA1_IRQn, DMA2_IRQn, DMA3_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- DMA - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMA_Register_Accessor_Macros DMA - Register accessor macros
+ * @{
+ */
+
+
+/* DMA - Register instance definitions */
+/* DMA */
+#define DMA_SAR0                                 DMA_SAR_REG(DMA0,0)
+#define DMA_DAR0                                 DMA_DAR_REG(DMA0,0)
+#define DMA_DSR_BCR0                             DMA_DSR_BCR_REG(DMA0,0)
+#define DMA_DSR0                                 DMA_DSR_REG(DMA0,0)
+#define DMA_DCR0                                 DMA_DCR_REG(DMA0,0)
+#define DMA_SAR1                                 DMA_SAR_REG(DMA0,1)
+#define DMA_DAR1                                 DMA_DAR_REG(DMA0,1)
+#define DMA_DSR_BCR1                             DMA_DSR_BCR_REG(DMA0,1)
+#define DMA_DSR1                                 DMA_DSR_REG(DMA0,1)
+#define DMA_DCR1                                 DMA_DCR_REG(DMA0,1)
+#define DMA_SAR2                                 DMA_SAR_REG(DMA0,2)
+#define DMA_DAR2                                 DMA_DAR_REG(DMA0,2)
+#define DMA_DSR_BCR2                             DMA_DSR_BCR_REG(DMA0,2)
+#define DMA_DSR2                                 DMA_DSR_REG(DMA0,2)
+#define DMA_DCR2                                 DMA_DCR_REG(DMA0,2)
+#define DMA_SAR3                                 DMA_SAR_REG(DMA0,3)
+#define DMA_DAR3                                 DMA_DAR_REG(DMA0,3)
+#define DMA_DSR_BCR3                             DMA_DSR_BCR_REG(DMA0,3)
+#define DMA_DSR3                                 DMA_DSR_REG(DMA0,3)
+#define DMA_DCR3                                 DMA_DCR_REG(DMA0,3)
+
+/* DMA - Register array accessors */
+#define DMA_SAR(index)                           DMA_SAR_REG(DMA0,index)
+#define DMA_DAR(index)                           DMA_DAR_REG(DMA0,index)
+#define DMA_DSR_BCR(index)                       DMA_DSR_BCR_REG(DMA0,index)
+#define DMA_DSR(index)                           DMA_DSR_REG(DMA0,index)
+#define DMA_DCR(index)                           DMA_DCR_REG(DMA0,index)
+
+/*!
+ * @}
+ */ /* end of group DMA_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group DMA_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- DMAMUX Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMAMUX_Peripheral_Access_Layer DMAMUX Peripheral Access Layer
+ * @{
+ */
+
+/** DMAMUX - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t CHCFG[4];                           /**< Channel Configuration register, array offset: 0x0, array step: 0x1 */
+} DMAMUX_Type, *DMAMUX_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- DMAMUX - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMAMUX_Register_Accessor_Macros DMAMUX - Register accessor macros
+ * @{
+ */
+
+
+/* DMAMUX - Register accessors */
+#define DMAMUX_CHCFG_REG(base,index)             ((base)->CHCFG[index])
+
+/*!
+ * @}
+ */ /* end of group DMAMUX_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- DMAMUX Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMAMUX_Register_Masks DMAMUX Register Masks
+ * @{
+ */
+
+/* CHCFG Bit Fields */
+#define DMAMUX_CHCFG_SOURCE_MASK                 0x3Fu
+#define DMAMUX_CHCFG_SOURCE_SHIFT                0
+#define DMAMUX_CHCFG_SOURCE(x)                   (((uint8_t)(((uint8_t)(x))<<DMAMUX_CHCFG_SOURCE_SHIFT))&DMAMUX_CHCFG_SOURCE_MASK)
+#define DMAMUX_CHCFG_TRIG_MASK                   0x40u
+#define DMAMUX_CHCFG_TRIG_SHIFT                  6
+#define DMAMUX_CHCFG_ENBL_MASK                   0x80u
+#define DMAMUX_CHCFG_ENBL_SHIFT                  7
+
+/*!
+ * @}
+ */ /* end of group DMAMUX_Register_Masks */
+
+
+/* DMAMUX - Peripheral instance base addresses */
+/** Peripheral DMAMUX0 base address */
+#define DMAMUX0_BASE                             (0x40021000u)
+/** Peripheral DMAMUX0 base pointer */
+#define DMAMUX0                                  ((DMAMUX_Type *)DMAMUX0_BASE)
+#define DMAMUX0_BASE_PTR                         (DMAMUX0)
+/** Array initializer of DMAMUX peripheral base addresses */
+#define DMAMUX_BASE_ADDRS                        { DMAMUX0_BASE }
+/** Array initializer of DMAMUX peripheral base pointers */
+#define DMAMUX_BASE_PTRS                         { DMAMUX0 }
+
+/* ----------------------------------------------------------------------------
+   -- DMAMUX - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMAMUX_Register_Accessor_Macros DMAMUX - Register accessor macros
+ * @{
+ */
+
+
+/* DMAMUX - Register instance definitions */
+/* DMAMUX0 */
+#define DMAMUX0_CHCFG0                           DMAMUX_CHCFG_REG(DMAMUX0,0)
+#define DMAMUX0_CHCFG1                           DMAMUX_CHCFG_REG(DMAMUX0,1)
+#define DMAMUX0_CHCFG2                           DMAMUX_CHCFG_REG(DMAMUX0,2)
+#define DMAMUX0_CHCFG3                           DMAMUX_CHCFG_REG(DMAMUX0,3)
+
+/* DMAMUX - Register array accessors */
+#define DMAMUX0_CHCFG(index)                     DMAMUX_CHCFG_REG(DMAMUX0,index)
+
+/*!
+ * @}
+ */ /* end of group DMAMUX_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group DMAMUX_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- FGPIO Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FGPIO_Peripheral_Access_Layer FGPIO Peripheral Access Layer
+ * @{
+ */
+
+/** FGPIO - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t PDOR;                              /**< Port Data Output Register, offset: 0x0 */
+  __O  uint32_t PSOR;                              /**< Port Set Output Register, offset: 0x4 */
+  __O  uint32_t PCOR;                              /**< Port Clear Output Register, offset: 0x8 */
+  __O  uint32_t PTOR;                              /**< Port Toggle Output Register, offset: 0xC */
+  __I  uint32_t PDIR;                              /**< Port Data Input Register, offset: 0x10 */
+  __IO uint32_t PDDR;                              /**< Port Data Direction Register, offset: 0x14 */
+} FGPIO_Type, *FGPIO_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- FGPIO - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FGPIO_Register_Accessor_Macros FGPIO - Register accessor macros
+ * @{
+ */
+
+
+/* FGPIO - Register accessors */
+#define FGPIO_PDOR_REG(base)                     ((base)->PDOR)
+#define FGPIO_PSOR_REG(base)                     ((base)->PSOR)
+#define FGPIO_PCOR_REG(base)                     ((base)->PCOR)
+#define FGPIO_PTOR_REG(base)                     ((base)->PTOR)
+#define FGPIO_PDIR_REG(base)                     ((base)->PDIR)
+#define FGPIO_PDDR_REG(base)                     ((base)->PDDR)
+
+/*!
+ * @}
+ */ /* end of group FGPIO_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- FGPIO Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FGPIO_Register_Masks FGPIO Register Masks
+ * @{
+ */
+
+/* PDOR Bit Fields */
+#define FGPIO_PDOR_PDO_MASK                      0xFFFFFFFFu
+#define FGPIO_PDOR_PDO_SHIFT                     0
+#define FGPIO_PDOR_PDO(x)                        (((uint32_t)(((uint32_t)(x))<<FGPIO_PDOR_PDO_SHIFT))&FGPIO_PDOR_PDO_MASK)
+/* PSOR Bit Fields */
+#define FGPIO_PSOR_PTSO_MASK                     0xFFFFFFFFu
+#define FGPIO_PSOR_PTSO_SHIFT                    0
+#define FGPIO_PSOR_PTSO(x)                       (((uint32_t)(((uint32_t)(x))<<FGPIO_PSOR_PTSO_SHIFT))&FGPIO_PSOR_PTSO_MASK)
+/* PCOR Bit Fields */
+#define FGPIO_PCOR_PTCO_MASK                     0xFFFFFFFFu
+#define FGPIO_PCOR_PTCO_SHIFT                    0
+#define FGPIO_PCOR_PTCO(x)                       (((uint32_t)(((uint32_t)(x))<<FGPIO_PCOR_PTCO_SHIFT))&FGPIO_PCOR_PTCO_MASK)
+/* PTOR Bit Fields */
+#define FGPIO_PTOR_PTTO_MASK                     0xFFFFFFFFu
+#define FGPIO_PTOR_PTTO_SHIFT                    0
+#define FGPIO_PTOR_PTTO(x)                       (((uint32_t)(((uint32_t)(x))<<FGPIO_PTOR_PTTO_SHIFT))&FGPIO_PTOR_PTTO_MASK)
+/* PDIR Bit Fields */
+#define FGPIO_PDIR_PDI_MASK                      0xFFFFFFFFu
+#define FGPIO_PDIR_PDI_SHIFT                     0
+#define FGPIO_PDIR_PDI(x)                        (((uint32_t)(((uint32_t)(x))<<FGPIO_PDIR_PDI_SHIFT))&FGPIO_PDIR_PDI_MASK)
+/* PDDR Bit Fields */
+#define FGPIO_PDDR_PDD_MASK                      0xFFFFFFFFu
+#define FGPIO_PDDR_PDD_SHIFT                     0
+#define FGPIO_PDDR_PDD(x)                        (((uint32_t)(((uint32_t)(x))<<FGPIO_PDDR_PDD_SHIFT))&FGPIO_PDDR_PDD_MASK)
+
+/*!
+ * @}
+ */ /* end of group FGPIO_Register_Masks */
+
+
+/* FGPIO - Peripheral instance base addresses */
+/** Peripheral FGPIOA base address */
+#define FGPIOA_BASE                              (0xF8000000u)
+/** Peripheral FGPIOA base pointer */
+#define FGPIOA                                   ((FGPIO_Type *)FGPIOA_BASE)
+#define FGPIOA_BASE_PTR                          (FGPIOA)
+/** Peripheral FGPIOB base address */
+#define FGPIOB_BASE                              (0xF8000040u)
+/** Peripheral FGPIOB base pointer */
+#define FGPIOB                                   ((FGPIO_Type *)FGPIOB_BASE)
+#define FGPIOB_BASE_PTR                          (FGPIOB)
+/** Peripheral FGPIOC base address */
+#define FGPIOC_BASE                              (0xF8000080u)
+/** Peripheral FGPIOC base pointer */
+#define FGPIOC                                   ((FGPIO_Type *)FGPIOC_BASE)
+#define FGPIOC_BASE_PTR                          (FGPIOC)
+/** Peripheral FGPIOD base address */
+#define FGPIOD_BASE                              (0xF80000C0u)
+/** Peripheral FGPIOD base pointer */
+#define FGPIOD                                   ((FGPIO_Type *)FGPIOD_BASE)
+#define FGPIOD_BASE_PTR                          (FGPIOD)
+/** Peripheral FGPIOE base address */
+#define FGPIOE_BASE                              (0xF8000100u)
+/** Peripheral FGPIOE base pointer */
+#define FGPIOE                                   ((FGPIO_Type *)FGPIOE_BASE)
+#define FGPIOE_BASE_PTR                          (FGPIOE)
+/** Array initializer of FGPIO peripheral base addresses */
+#define FGPIO_BASE_ADDRS                         { FGPIOA_BASE, FGPIOB_BASE, FGPIOC_BASE, FGPIOD_BASE, FGPIOE_BASE }
+/** Array initializer of FGPIO peripheral base pointers */
+#define FGPIO_BASE_PTRS                          { FGPIOA, FGPIOB, FGPIOC, FGPIOD, FGPIOE }
+
+/* ----------------------------------------------------------------------------
+   -- FGPIO - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FGPIO_Register_Accessor_Macros FGPIO - Register accessor macros
+ * @{
+ */
+
+
+/* FGPIO - Register instance definitions */
+/* FGPIOA */
+#define FGPIOA_PDOR                              FGPIO_PDOR_REG(FGPIOA)
+#define FGPIOA_PSOR                              FGPIO_PSOR_REG(FGPIOA)
+#define FGPIOA_PCOR                              FGPIO_PCOR_REG(FGPIOA)
+#define FGPIOA_PTOR                              FGPIO_PTOR_REG(FGPIOA)
+#define FGPIOA_PDIR                              FGPIO_PDIR_REG(FGPIOA)
+#define FGPIOA_PDDR                              FGPIO_PDDR_REG(FGPIOA)
+/* FGPIOB */
+#define FGPIOB_PDOR                              FGPIO_PDOR_REG(FGPIOB)
+#define FGPIOB_PSOR                              FGPIO_PSOR_REG(FGPIOB)
+#define FGPIOB_PCOR                              FGPIO_PCOR_REG(FGPIOB)
+#define FGPIOB_PTOR                              FGPIO_PTOR_REG(FGPIOB)
+#define FGPIOB_PDIR                              FGPIO_PDIR_REG(FGPIOB)
+#define FGPIOB_PDDR                              FGPIO_PDDR_REG(FGPIOB)
+/* FGPIOC */
+#define FGPIOC_PDOR                              FGPIO_PDOR_REG(FGPIOC)
+#define FGPIOC_PSOR                              FGPIO_PSOR_REG(FGPIOC)
+#define FGPIOC_PCOR                              FGPIO_PCOR_REG(FGPIOC)
+#define FGPIOC_PTOR                              FGPIO_PTOR_REG(FGPIOC)
+#define FGPIOC_PDIR                              FGPIO_PDIR_REG(FGPIOC)
+#define FGPIOC_PDDR                              FGPIO_PDDR_REG(FGPIOC)
+/* FGPIOD */
+#define FGPIOD_PDOR                              FGPIO_PDOR_REG(FGPIOD)
+#define FGPIOD_PSOR                              FGPIO_PSOR_REG(FGPIOD)
+#define FGPIOD_PCOR                              FGPIO_PCOR_REG(FGPIOD)
+#define FGPIOD_PTOR                              FGPIO_PTOR_REG(FGPIOD)
+#define FGPIOD_PDIR                              FGPIO_PDIR_REG(FGPIOD)
+#define FGPIOD_PDDR                              FGPIO_PDDR_REG(FGPIOD)
+/* FGPIOE */
+#define FGPIOE_PDOR                              FGPIO_PDOR_REG(FGPIOE)
+#define FGPIOE_PSOR                              FGPIO_PSOR_REG(FGPIOE)
+#define FGPIOE_PCOR                              FGPIO_PCOR_REG(FGPIOE)
+#define FGPIOE_PTOR                              FGPIO_PTOR_REG(FGPIOE)
+#define FGPIOE_PDIR                              FGPIO_PDIR_REG(FGPIOE)
+#define FGPIOE_PDDR                              FGPIO_PDDR_REG(FGPIOE)
+
+/*!
+ * @}
+ */ /* end of group FGPIO_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group FGPIO_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- FTFA Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FTFA_Peripheral_Access_Layer FTFA Peripheral Access Layer
+ * @{
+ */
+
+/** FTFA - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t FSTAT;                              /**< Flash Status Register, offset: 0x0 */
+  __IO uint8_t FCNFG;                              /**< Flash Configuration Register, offset: 0x1 */
+  __I  uint8_t FSEC;                               /**< Flash Security Register, offset: 0x2 */
+  __I  uint8_t FOPT;                               /**< Flash Option Register, offset: 0x3 */
+  __IO uint8_t FCCOB3;                             /**< Flash Common Command Object Registers, offset: 0x4 */
+  __IO uint8_t FCCOB2;                             /**< Flash Common Command Object Registers, offset: 0x5 */
+  __IO uint8_t FCCOB1;                             /**< Flash Common Command Object Registers, offset: 0x6 */
+  __IO uint8_t FCCOB0;                             /**< Flash Common Command Object Registers, offset: 0x7 */
+  __IO uint8_t FCCOB7;                             /**< Flash Common Command Object Registers, offset: 0x8 */
+  __IO uint8_t FCCOB6;                             /**< Flash Common Command Object Registers, offset: 0x9 */
+  __IO uint8_t FCCOB5;                             /**< Flash Common Command Object Registers, offset: 0xA */
+  __IO uint8_t FCCOB4;                             /**< Flash Common Command Object Registers, offset: 0xB */
+  __IO uint8_t FCCOBB;                             /**< Flash Common Command Object Registers, offset: 0xC */
+  __IO uint8_t FCCOBA;                             /**< Flash Common Command Object Registers, offset: 0xD */
+  __IO uint8_t FCCOB9;                             /**< Flash Common Command Object Registers, offset: 0xE */
+  __IO uint8_t FCCOB8;                             /**< Flash Common Command Object Registers, offset: 0xF */
+  __IO uint8_t FPROT3;                             /**< Program Flash Protection Registers, offset: 0x10 */
+  __IO uint8_t FPROT2;                             /**< Program Flash Protection Registers, offset: 0x11 */
+  __IO uint8_t FPROT1;                             /**< Program Flash Protection Registers, offset: 0x12 */
+  __IO uint8_t FPROT0;                             /**< Program Flash Protection Registers, offset: 0x13 */
+} FTFA_Type, *FTFA_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- FTFA - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FTFA_Register_Accessor_Macros FTFA - Register accessor macros
+ * @{
+ */
+
+
+/* FTFA - Register accessors */
+#define FTFA_FSTAT_REG(base)                     ((base)->FSTAT)
+#define FTFA_FCNFG_REG(base)                     ((base)->FCNFG)
+#define FTFA_FSEC_REG(base)                      ((base)->FSEC)
+#define FTFA_FOPT_REG(base)                      ((base)->FOPT)
+#define FTFA_FCCOB3_REG(base)                    ((base)->FCCOB3)
+#define FTFA_FCCOB2_REG(base)                    ((base)->FCCOB2)
+#define FTFA_FCCOB1_REG(base)                    ((base)->FCCOB1)
+#define FTFA_FCCOB0_REG(base)                    ((base)->FCCOB0)
+#define FTFA_FCCOB7_REG(base)                    ((base)->FCCOB7)
+#define FTFA_FCCOB6_REG(base)                    ((base)->FCCOB6)
+#define FTFA_FCCOB5_REG(base)                    ((base)->FCCOB5)
+#define FTFA_FCCOB4_REG(base)                    ((base)->FCCOB4)
+#define FTFA_FCCOBB_REG(base)                    ((base)->FCCOBB)
+#define FTFA_FCCOBA_REG(base)                    ((base)->FCCOBA)
+#define FTFA_FCCOB9_REG(base)                    ((base)->FCCOB9)
+#define FTFA_FCCOB8_REG(base)                    ((base)->FCCOB8)
+#define FTFA_FPROT3_REG(base)                    ((base)->FPROT3)
+#define FTFA_FPROT2_REG(base)                    ((base)->FPROT2)
+#define FTFA_FPROT1_REG(base)                    ((base)->FPROT1)
+#define FTFA_FPROT0_REG(base)                    ((base)->FPROT0)
+
+/*!
+ * @}
+ */ /* end of group FTFA_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- FTFA Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FTFA_Register_Masks FTFA Register Masks
+ * @{
+ */
+
+/* FSTAT Bit Fields */
+#define FTFA_FSTAT_MGSTAT0_MASK                  0x1u
+#define FTFA_FSTAT_MGSTAT0_SHIFT                 0
+#define FTFA_FSTAT_FPVIOL_MASK                   0x10u
+#define FTFA_FSTAT_FPVIOL_SHIFT                  4
+#define FTFA_FSTAT_ACCERR_MASK                   0x20u
+#define FTFA_FSTAT_ACCERR_SHIFT                  5
+#define FTFA_FSTAT_RDCOLERR_MASK                 0x40u
+#define FTFA_FSTAT_RDCOLERR_SHIFT                6
+#define FTFA_FSTAT_CCIF_MASK                     0x80u
+#define FTFA_FSTAT_CCIF_SHIFT                    7
+/* FCNFG Bit Fields */
+#define FTFA_FCNFG_ERSSUSP_MASK                  0x10u
+#define FTFA_FCNFG_ERSSUSP_SHIFT                 4
+#define FTFA_FCNFG_ERSAREQ_MASK                  0x20u
+#define FTFA_FCNFG_ERSAREQ_SHIFT                 5
+#define FTFA_FCNFG_RDCOLLIE_MASK                 0x40u
+#define FTFA_FCNFG_RDCOLLIE_SHIFT                6
+#define FTFA_FCNFG_CCIE_MASK                     0x80u
+#define FTFA_FCNFG_CCIE_SHIFT                    7
+/* FSEC Bit Fields */
+#define FTFA_FSEC_SEC_MASK                       0x3u
+#define FTFA_FSEC_SEC_SHIFT                      0
+#define FTFA_FSEC_SEC(x)                         (((uint8_t)(((uint8_t)(x))<<FTFA_FSEC_SEC_SHIFT))&FTFA_FSEC_SEC_MASK)
+#define FTFA_FSEC_FSLACC_MASK                    0xCu
+#define FTFA_FSEC_FSLACC_SHIFT                   2
+#define FTFA_FSEC_FSLACC(x)                      (((uint8_t)(((uint8_t)(x))<<FTFA_FSEC_FSLACC_SHIFT))&FTFA_FSEC_FSLACC_MASK)
+#define FTFA_FSEC_MEEN_MASK                      0x30u
+#define FTFA_FSEC_MEEN_SHIFT                     4
+#define FTFA_FSEC_MEEN(x)                        (((uint8_t)(((uint8_t)(x))<<FTFA_FSEC_MEEN_SHIFT))&FTFA_FSEC_MEEN_MASK)
+#define FTFA_FSEC_KEYEN_MASK                     0xC0u
+#define FTFA_FSEC_KEYEN_SHIFT                    6
+#define FTFA_FSEC_KEYEN(x)                       (((uint8_t)(((uint8_t)(x))<<FTFA_FSEC_KEYEN_SHIFT))&FTFA_FSEC_KEYEN_MASK)
+/* FOPT Bit Fields */
+#define FTFA_FOPT_OPT_MASK                       0xFFu
+#define FTFA_FOPT_OPT_SHIFT                      0
+#define FTFA_FOPT_OPT(x)                         (((uint8_t)(((uint8_t)(x))<<FTFA_FOPT_OPT_SHIFT))&FTFA_FOPT_OPT_MASK)
+/* FCCOB3 Bit Fields */
+#define FTFA_FCCOB3_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB3_CCOBn_SHIFT                  0
+#define FTFA_FCCOB3_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB3_CCOBn_SHIFT))&FTFA_FCCOB3_CCOBn_MASK)
+/* FCCOB2 Bit Fields */
+#define FTFA_FCCOB2_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB2_CCOBn_SHIFT                  0
+#define FTFA_FCCOB2_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB2_CCOBn_SHIFT))&FTFA_FCCOB2_CCOBn_MASK)
+/* FCCOB1 Bit Fields */
+#define FTFA_FCCOB1_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB1_CCOBn_SHIFT                  0
+#define FTFA_FCCOB1_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB1_CCOBn_SHIFT))&FTFA_FCCOB1_CCOBn_MASK)
+/* FCCOB0 Bit Fields */
+#define FTFA_FCCOB0_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB0_CCOBn_SHIFT                  0
+#define FTFA_FCCOB0_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB0_CCOBn_SHIFT))&FTFA_FCCOB0_CCOBn_MASK)
+/* FCCOB7 Bit Fields */
+#define FTFA_FCCOB7_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB7_CCOBn_SHIFT                  0
+#define FTFA_FCCOB7_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB7_CCOBn_SHIFT))&FTFA_FCCOB7_CCOBn_MASK)
+/* FCCOB6 Bit Fields */
+#define FTFA_FCCOB6_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB6_CCOBn_SHIFT                  0
+#define FTFA_FCCOB6_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB6_CCOBn_SHIFT))&FTFA_FCCOB6_CCOBn_MASK)
+/* FCCOB5 Bit Fields */
+#define FTFA_FCCOB5_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB5_CCOBn_SHIFT                  0
+#define FTFA_FCCOB5_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB5_CCOBn_SHIFT))&FTFA_FCCOB5_CCOBn_MASK)
+/* FCCOB4 Bit Fields */
+#define FTFA_FCCOB4_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB4_CCOBn_SHIFT                  0
+#define FTFA_FCCOB4_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB4_CCOBn_SHIFT))&FTFA_FCCOB4_CCOBn_MASK)
+/* FCCOBB Bit Fields */
+#define FTFA_FCCOBB_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOBB_CCOBn_SHIFT                  0
+#define FTFA_FCCOBB_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOBB_CCOBn_SHIFT))&FTFA_FCCOBB_CCOBn_MASK)
+/* FCCOBA Bit Fields */
+#define FTFA_FCCOBA_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOBA_CCOBn_SHIFT                  0
+#define FTFA_FCCOBA_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOBA_CCOBn_SHIFT))&FTFA_FCCOBA_CCOBn_MASK)
+/* FCCOB9 Bit Fields */
+#define FTFA_FCCOB9_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB9_CCOBn_SHIFT                  0
+#define FTFA_FCCOB9_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB9_CCOBn_SHIFT))&FTFA_FCCOB9_CCOBn_MASK)
+/* FCCOB8 Bit Fields */
+#define FTFA_FCCOB8_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB8_CCOBn_SHIFT                  0
+#define FTFA_FCCOB8_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB8_CCOBn_SHIFT))&FTFA_FCCOB8_CCOBn_MASK)
+/* FPROT3 Bit Fields */
+#define FTFA_FPROT3_PROT_MASK                    0xFFu
+#define FTFA_FPROT3_PROT_SHIFT                   0
+#define FTFA_FPROT3_PROT(x)                      (((uint8_t)(((uint8_t)(x))<<FTFA_FPROT3_PROT_SHIFT))&FTFA_FPROT3_PROT_MASK)
+/* FPROT2 Bit Fields */
+#define FTFA_FPROT2_PROT_MASK                    0xFFu
+#define FTFA_FPROT2_PROT_SHIFT                   0
+#define FTFA_FPROT2_PROT(x)                      (((uint8_t)(((uint8_t)(x))<<FTFA_FPROT2_PROT_SHIFT))&FTFA_FPROT2_PROT_MASK)
+/* FPROT1 Bit Fields */
+#define FTFA_FPROT1_PROT_MASK                    0xFFu
+#define FTFA_FPROT1_PROT_SHIFT                   0
+#define FTFA_FPROT1_PROT(x)                      (((uint8_t)(((uint8_t)(x))<<FTFA_FPROT1_PROT_SHIFT))&FTFA_FPROT1_PROT_MASK)
+/* FPROT0 Bit Fields */
+#define FTFA_FPROT0_PROT_MASK                    0xFFu
+#define FTFA_FPROT0_PROT_SHIFT                   0
+#define FTFA_FPROT0_PROT(x)                      (((uint8_t)(((uint8_t)(x))<<FTFA_FPROT0_PROT_SHIFT))&FTFA_FPROT0_PROT_MASK)
+
+/*!
+ * @}
+ */ /* end of group FTFA_Register_Masks */
+
+
+/* FTFA - Peripheral instance base addresses */
+/** Peripheral FTFA base address */
+#define FTFA_BASE                                (0x40020000u)
+/** Peripheral FTFA base pointer */
+#define FTFA                                     ((FTFA_Type *)FTFA_BASE)
+#define FTFA_BASE_PTR                            (FTFA)
+/** Array initializer of FTFA peripheral base addresses */
+#define FTFA_BASE_ADDRS                          { FTFA_BASE }
+/** Array initializer of FTFA peripheral base pointers */
+#define FTFA_BASE_PTRS                           { FTFA }
+/** Interrupt vectors for the FTFA peripheral type */
+#define FTFA_COMMAND_COMPLETE_IRQS               { FTFA_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- FTFA - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FTFA_Register_Accessor_Macros FTFA - Register accessor macros
+ * @{
+ */
+
+
+/* FTFA - Register instance definitions */
+/* FTFA */
+#define FTFA_FSTAT                               FTFA_FSTAT_REG(FTFA)
+#define FTFA_FCNFG                               FTFA_FCNFG_REG(FTFA)
+#define FTFA_FSEC                                FTFA_FSEC_REG(FTFA)
+#define FTFA_FOPT                                FTFA_FOPT_REG(FTFA)
+#define FTFA_FCCOB3                              FTFA_FCCOB3_REG(FTFA)
+#define FTFA_FCCOB2                              FTFA_FCCOB2_REG(FTFA)
+#define FTFA_FCCOB1                              FTFA_FCCOB1_REG(FTFA)
+#define FTFA_FCCOB0                              FTFA_FCCOB0_REG(FTFA)
+#define FTFA_FCCOB7                              FTFA_FCCOB7_REG(FTFA)
+#define FTFA_FCCOB6                              FTFA_FCCOB6_REG(FTFA)
+#define FTFA_FCCOB5                              FTFA_FCCOB5_REG(FTFA)
+#define FTFA_FCCOB4                              FTFA_FCCOB4_REG(FTFA)
+#define FTFA_FCCOBB                              FTFA_FCCOBB_REG(FTFA)
+#define FTFA_FCCOBA                              FTFA_FCCOBA_REG(FTFA)
+#define FTFA_FCCOB9                              FTFA_FCCOB9_REG(FTFA)
+#define FTFA_FCCOB8                              FTFA_FCCOB8_REG(FTFA)
+#define FTFA_FPROT3                              FTFA_FPROT3_REG(FTFA)
+#define FTFA_FPROT2                              FTFA_FPROT2_REG(FTFA)
+#define FTFA_FPROT1                              FTFA_FPROT1_REG(FTFA)
+#define FTFA_FPROT0                              FTFA_FPROT0_REG(FTFA)
+
+/*!
+ * @}
+ */ /* end of group FTFA_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group FTFA_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- GPIO Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup GPIO_Peripheral_Access_Layer GPIO Peripheral Access Layer
+ * @{
+ */
+
+/** GPIO - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t PDOR;                              /**< Port Data Output Register, offset: 0x0 */
+  __O  uint32_t PSOR;                              /**< Port Set Output Register, offset: 0x4 */
+  __O  uint32_t PCOR;                              /**< Port Clear Output Register, offset: 0x8 */
+  __O  uint32_t PTOR;                              /**< Port Toggle Output Register, offset: 0xC */
+  __I  uint32_t PDIR;                              /**< Port Data Input Register, offset: 0x10 */
+  __IO uint32_t PDDR;                              /**< Port Data Direction Register, offset: 0x14 */
+} GPIO_Type, *GPIO_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- GPIO - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup GPIO_Register_Accessor_Macros GPIO - Register accessor macros
+ * @{
+ */
+
+
+/* GPIO - Register accessors */
+#define GPIO_PDOR_REG(base)                      ((base)->PDOR)
+#define GPIO_PSOR_REG(base)                      ((base)->PSOR)
+#define GPIO_PCOR_REG(base)                      ((base)->PCOR)
+#define GPIO_PTOR_REG(base)                      ((base)->PTOR)
+#define GPIO_PDIR_REG(base)                      ((base)->PDIR)
+#define GPIO_PDDR_REG(base)                      ((base)->PDDR)
+
+/*!
+ * @}
+ */ /* end of group GPIO_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- GPIO Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup GPIO_Register_Masks GPIO Register Masks
+ * @{
+ */
+
+/* PDOR Bit Fields */
+#define GPIO_PDOR_PDO_MASK                       0xFFFFFFFFu
+#define GPIO_PDOR_PDO_SHIFT                      0
+#define GPIO_PDOR_PDO(x)                         (((uint32_t)(((uint32_t)(x))<<GPIO_PDOR_PDO_SHIFT))&GPIO_PDOR_PDO_MASK)
+/* PSOR Bit Fields */
+#define GPIO_PSOR_PTSO_MASK                      0xFFFFFFFFu
+#define GPIO_PSOR_PTSO_SHIFT                     0
+#define GPIO_PSOR_PTSO(x)                        (((uint32_t)(((uint32_t)(x))<<GPIO_PSOR_PTSO_SHIFT))&GPIO_PSOR_PTSO_MASK)
+/* PCOR Bit Fields */
+#define GPIO_PCOR_PTCO_MASK                      0xFFFFFFFFu
+#define GPIO_PCOR_PTCO_SHIFT                     0
+#define GPIO_PCOR_PTCO(x)                        (((uint32_t)(((uint32_t)(x))<<GPIO_PCOR_PTCO_SHIFT))&GPIO_PCOR_PTCO_MASK)
+/* PTOR Bit Fields */
+#define GPIO_PTOR_PTTO_MASK                      0xFFFFFFFFu
+#define GPIO_PTOR_PTTO_SHIFT                     0
+#define GPIO_PTOR_PTTO(x)                        (((uint32_t)(((uint32_t)(x))<<GPIO_PTOR_PTTO_SHIFT))&GPIO_PTOR_PTTO_MASK)
+/* PDIR Bit Fields */
+#define GPIO_PDIR_PDI_MASK                       0xFFFFFFFFu
+#define GPIO_PDIR_PDI_SHIFT                      0
+#define GPIO_PDIR_PDI(x)                         (((uint32_t)(((uint32_t)(x))<<GPIO_PDIR_PDI_SHIFT))&GPIO_PDIR_PDI_MASK)
+/* PDDR Bit Fields */
+#define GPIO_PDDR_PDD_MASK                       0xFFFFFFFFu
+#define GPIO_PDDR_PDD_SHIFT                      0
+#define GPIO_PDDR_PDD(x)                         (((uint32_t)(((uint32_t)(x))<<GPIO_PDDR_PDD_SHIFT))&GPIO_PDDR_PDD_MASK)
+
+/*!
+ * @}
+ */ /* end of group GPIO_Register_Masks */
+
+
+/* GPIO - Peripheral instance base addresses */
+/** Peripheral GPIOA base address */
+#define GPIOA_BASE                               (0x400FF000u)
+/** Peripheral GPIOA base pointer */
+#define GPIOA                                    ((GPIO_Type *)GPIOA_BASE)
+#define GPIOA_BASE_PTR                           (GPIOA)
+/** Peripheral GPIOB base address */
+#define GPIOB_BASE                               (0x400FF040u)
+/** Peripheral GPIOB base pointer */
+#define GPIOB                                    ((GPIO_Type *)GPIOB_BASE)
+#define GPIOB_BASE_PTR                           (GPIOB)
+/** Peripheral GPIOC base address */
+#define GPIOC_BASE                               (0x400FF080u)
+/** Peripheral GPIOC base pointer */
+#define GPIOC                                    ((GPIO_Type *)GPIOC_BASE)
+#define GPIOC_BASE_PTR                           (GPIOC)
+/** Peripheral GPIOD base address */
+#define GPIOD_BASE                               (0x400FF0C0u)
+/** Peripheral GPIOD base pointer */
+#define GPIOD                                    ((GPIO_Type *)GPIOD_BASE)
+#define GPIOD_BASE_PTR                           (GPIOD)
+/** Peripheral GPIOE base address */
+#define GPIOE_BASE                               (0x400FF100u)
+/** Peripheral GPIOE base pointer */
+#define GPIOE                                    ((GPIO_Type *)GPIOE_BASE)
+#define GPIOE_BASE_PTR                           (GPIOE)
+/** Array initializer of GPIO peripheral base addresses */
+#define GPIO_BASE_ADDRS                          { GPIOA_BASE, GPIOB_BASE, GPIOC_BASE, GPIOD_BASE, GPIOE_BASE }
+/** Array initializer of GPIO peripheral base pointers */
+#define GPIO_BASE_PTRS                           { GPIOA, GPIOB, GPIOC, GPIOD, GPIOE }
+
+/* ----------------------------------------------------------------------------
+   -- GPIO - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup GPIO_Register_Accessor_Macros GPIO - Register accessor macros
+ * @{
+ */
+
+
+/* GPIO - Register instance definitions */
+/* GPIOA */
+#define GPIOA_PDOR                               GPIO_PDOR_REG(GPIOA)
+#define GPIOA_PSOR                               GPIO_PSOR_REG(GPIOA)
+#define GPIOA_PCOR                               GPIO_PCOR_REG(GPIOA)
+#define GPIOA_PTOR                               GPIO_PTOR_REG(GPIOA)
+#define GPIOA_PDIR                               GPIO_PDIR_REG(GPIOA)
+#define GPIOA_PDDR                               GPIO_PDDR_REG(GPIOA)
+/* GPIOB */
+#define GPIOB_PDOR                               GPIO_PDOR_REG(GPIOB)
+#define GPIOB_PSOR                               GPIO_PSOR_REG(GPIOB)
+#define GPIOB_PCOR                               GPIO_PCOR_REG(GPIOB)
+#define GPIOB_PTOR                               GPIO_PTOR_REG(GPIOB)
+#define GPIOB_PDIR                               GPIO_PDIR_REG(GPIOB)
+#define GPIOB_PDDR                               GPIO_PDDR_REG(GPIOB)
+/* GPIOC */
+#define GPIOC_PDOR                               GPIO_PDOR_REG(GPIOC)
+#define GPIOC_PSOR                               GPIO_PSOR_REG(GPIOC)
+#define GPIOC_PCOR                               GPIO_PCOR_REG(GPIOC)
+#define GPIOC_PTOR                               GPIO_PTOR_REG(GPIOC)
+#define GPIOC_PDIR                               GPIO_PDIR_REG(GPIOC)
+#define GPIOC_PDDR                               GPIO_PDDR_REG(GPIOC)
+/* GPIOD */
+#define GPIOD_PDOR                               GPIO_PDOR_REG(GPIOD)
+#define GPIOD_PSOR                               GPIO_PSOR_REG(GPIOD)
+#define GPIOD_PCOR                               GPIO_PCOR_REG(GPIOD)
+#define GPIOD_PTOR                               GPIO_PTOR_REG(GPIOD)
+#define GPIOD_PDIR                               GPIO_PDIR_REG(GPIOD)
+#define GPIOD_PDDR                               GPIO_PDDR_REG(GPIOD)
+/* GPIOE */
+#define GPIOE_PDOR                               GPIO_PDOR_REG(GPIOE)
+#define GPIOE_PSOR                               GPIO_PSOR_REG(GPIOE)
+#define GPIOE_PCOR                               GPIO_PCOR_REG(GPIOE)
+#define GPIOE_PTOR                               GPIO_PTOR_REG(GPIOE)
+#define GPIOE_PDIR                               GPIO_PDIR_REG(GPIOE)
+#define GPIOE_PDDR                               GPIO_PDDR_REG(GPIOE)
+
+/*!
+ * @}
+ */ /* end of group GPIO_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group GPIO_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- I2C Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup I2C_Peripheral_Access_Layer I2C Peripheral Access Layer
+ * @{
+ */
+
+/** I2C - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t A1;                                 /**< I2C Address Register 1, offset: 0x0 */
+  __IO uint8_t F;                                  /**< I2C Frequency Divider register, offset: 0x1 */
+  __IO uint8_t C1;                                 /**< I2C Control Register 1, offset: 0x2 */
+  __IO uint8_t S;                                  /**< I2C Status register, offset: 0x3 */
+  __IO uint8_t D;                                  /**< I2C Data I/O register, offset: 0x4 */
+  __IO uint8_t C2;                                 /**< I2C Control Register 2, offset: 0x5 */
+  __IO uint8_t FLT;                                /**< I2C Programmable Input Glitch Filter register, offset: 0x6 */
+  __IO uint8_t RA;                                 /**< I2C Range Address register, offset: 0x7 */
+  __IO uint8_t SMB;                                /**< I2C SMBus Control and Status register, offset: 0x8 */
+  __IO uint8_t A2;                                 /**< I2C Address Register 2, offset: 0x9 */
+  __IO uint8_t SLTH;                               /**< I2C SCL Low Timeout Register High, offset: 0xA */
+  __IO uint8_t SLTL;                               /**< I2C SCL Low Timeout Register Low, offset: 0xB */
+} I2C_Type, *I2C_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- I2C - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup I2C_Register_Accessor_Macros I2C - Register accessor macros
+ * @{
+ */
+
+
+/* I2C - Register accessors */
+#define I2C_A1_REG(base)                         ((base)->A1)
+#define I2C_F_REG(base)                          ((base)->F)
+#define I2C_C1_REG(base)                         ((base)->C1)
+#define I2C_S_REG(base)                          ((base)->S)
+#define I2C_D_REG(base)                          ((base)->D)
+#define I2C_C2_REG(base)                         ((base)->C2)
+#define I2C_FLT_REG(base)                        ((base)->FLT)
+#define I2C_RA_REG(base)                         ((base)->RA)
+#define I2C_SMB_REG(base)                        ((base)->SMB)
+#define I2C_A2_REG(base)                         ((base)->A2)
+#define I2C_SLTH_REG(base)                       ((base)->SLTH)
+#define I2C_SLTL_REG(base)                       ((base)->SLTL)
+
+/*!
+ * @}
+ */ /* end of group I2C_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- I2C Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup I2C_Register_Masks I2C Register Masks
+ * @{
+ */
+
+/* A1 Bit Fields */
+#define I2C_A1_AD_MASK                           0xFEu
+#define I2C_A1_AD_SHIFT                          1
+#define I2C_A1_AD(x)                             (((uint8_t)(((uint8_t)(x))<<I2C_A1_AD_SHIFT))&I2C_A1_AD_MASK)
+/* F Bit Fields */
+#define I2C_F_ICR_MASK                           0x3Fu
+#define I2C_F_ICR_SHIFT                          0
+#define I2C_F_ICR(x)                             (((uint8_t)(((uint8_t)(x))<<I2C_F_ICR_SHIFT))&I2C_F_ICR_MASK)
+#define I2C_F_MULT_MASK                          0xC0u
+#define I2C_F_MULT_SHIFT                         6
+#define I2C_F_MULT(x)                            (((uint8_t)(((uint8_t)(x))<<I2C_F_MULT_SHIFT))&I2C_F_MULT_MASK)
+/* C1 Bit Fields */
+#define I2C_C1_DMAEN_MASK                        0x1u
+#define I2C_C1_DMAEN_SHIFT                       0
+#define I2C_C1_WUEN_MASK                         0x2u
+#define I2C_C1_WUEN_SHIFT                        1
+#define I2C_C1_RSTA_MASK                         0x4u
+#define I2C_C1_RSTA_SHIFT                        2
+#define I2C_C1_TXAK_MASK                         0x8u
+#define I2C_C1_TXAK_SHIFT                        3
+#define I2C_C1_TX_MASK                           0x10u
+#define I2C_C1_TX_SHIFT                          4
+#define I2C_C1_MST_MASK                          0x20u
+#define I2C_C1_MST_SHIFT                         5
+#define I2C_C1_IICIE_MASK                        0x40u
+#define I2C_C1_IICIE_SHIFT                       6
+#define I2C_C1_IICEN_MASK                        0x80u
+#define I2C_C1_IICEN_SHIFT                       7
+/* S Bit Fields */
+#define I2C_S_RXAK_MASK                          0x1u
+#define I2C_S_RXAK_SHIFT                         0
+#define I2C_S_IICIF_MASK                         0x2u
+#define I2C_S_IICIF_SHIFT                        1
+#define I2C_S_SRW_MASK                           0x4u
+#define I2C_S_SRW_SHIFT                          2
+#define I2C_S_RAM_MASK                           0x8u
+#define I2C_S_RAM_SHIFT                          3
+#define I2C_S_ARBL_MASK                          0x10u
+#define I2C_S_ARBL_SHIFT                         4
+#define I2C_S_BUSY_MASK                          0x20u
+#define I2C_S_BUSY_SHIFT                         5
+#define I2C_S_IAAS_MASK                          0x40u
+#define I2C_S_IAAS_SHIFT                         6
+#define I2C_S_TCF_MASK                           0x80u
+#define I2C_S_TCF_SHIFT                          7
+/* D Bit Fields */
+#define I2C_D_DATA_MASK                          0xFFu
+#define I2C_D_DATA_SHIFT                         0
+#define I2C_D_DATA(x)                            (((uint8_t)(((uint8_t)(x))<<I2C_D_DATA_SHIFT))&I2C_D_DATA_MASK)
+/* C2 Bit Fields */
+#define I2C_C2_AD_MASK                           0x7u
+#define I2C_C2_AD_SHIFT                          0
+#define I2C_C2_AD(x)                             (((uint8_t)(((uint8_t)(x))<<I2C_C2_AD_SHIFT))&I2C_C2_AD_MASK)
+#define I2C_C2_RMEN_MASK                         0x8u
+#define I2C_C2_RMEN_SHIFT                        3
+#define I2C_C2_SBRC_MASK                         0x10u
+#define I2C_C2_SBRC_SHIFT                        4
+#define I2C_C2_HDRS_MASK                         0x20u
+#define I2C_C2_HDRS_SHIFT                        5
+#define I2C_C2_ADEXT_MASK                        0x40u
+#define I2C_C2_ADEXT_SHIFT                       6
+#define I2C_C2_GCAEN_MASK                        0x80u
+#define I2C_C2_GCAEN_SHIFT                       7
+/* FLT Bit Fields */
+#define I2C_FLT_FLT_MASK                         0xFu
+#define I2C_FLT_FLT_SHIFT                        0
+#define I2C_FLT_FLT(x)                           (((uint8_t)(((uint8_t)(x))<<I2C_FLT_FLT_SHIFT))&I2C_FLT_FLT_MASK)
+#define I2C_FLT_STARTF_MASK                      0x10u
+#define I2C_FLT_STARTF_SHIFT                     4
+#define I2C_FLT_SSIE_MASK                        0x20u
+#define I2C_FLT_SSIE_SHIFT                       5
+#define I2C_FLT_STOPF_MASK                       0x40u
+#define I2C_FLT_STOPF_SHIFT                      6
+#define I2C_FLT_SHEN_MASK                        0x80u
+#define I2C_FLT_SHEN_SHIFT                       7
+/* RA Bit Fields */
+#define I2C_RA_RAD_MASK                          0xFEu
+#define I2C_RA_RAD_SHIFT                         1
+#define I2C_RA_RAD(x)                            (((uint8_t)(((uint8_t)(x))<<I2C_RA_RAD_SHIFT))&I2C_RA_RAD_MASK)
+/* SMB Bit Fields */
+#define I2C_SMB_SHTF2IE_MASK                     0x1u
+#define I2C_SMB_SHTF2IE_SHIFT                    0
+#define I2C_SMB_SHTF2_MASK                       0x2u
+#define I2C_SMB_SHTF2_SHIFT                      1
+#define I2C_SMB_SHTF1_MASK                       0x4u
+#define I2C_SMB_SHTF1_SHIFT                      2
+#define I2C_SMB_SLTF_MASK                        0x8u
+#define I2C_SMB_SLTF_SHIFT                       3
+#define I2C_SMB_TCKSEL_MASK                      0x10u
+#define I2C_SMB_TCKSEL_SHIFT                     4
+#define I2C_SMB_SIICAEN_MASK                     0x20u
+#define I2C_SMB_SIICAEN_SHIFT                    5
+#define I2C_SMB_ALERTEN_MASK                     0x40u
+#define I2C_SMB_ALERTEN_SHIFT                    6
+#define I2C_SMB_FACK_MASK                        0x80u
+#define I2C_SMB_FACK_SHIFT                       7
+/* A2 Bit Fields */
+#define I2C_A2_SAD_MASK                          0xFEu
+#define I2C_A2_SAD_SHIFT                         1
+#define I2C_A2_SAD(x)                            (((uint8_t)(((uint8_t)(x))<<I2C_A2_SAD_SHIFT))&I2C_A2_SAD_MASK)
+/* SLTH Bit Fields */
+#define I2C_SLTH_SSLT_MASK                       0xFFu
+#define I2C_SLTH_SSLT_SHIFT                      0
+#define I2C_SLTH_SSLT(x)                         (((uint8_t)(((uint8_t)(x))<<I2C_SLTH_SSLT_SHIFT))&I2C_SLTH_SSLT_MASK)
+/* SLTL Bit Fields */
+#define I2C_SLTL_SSLT_MASK                       0xFFu
+#define I2C_SLTL_SSLT_SHIFT                      0
+#define I2C_SLTL_SSLT(x)                         (((uint8_t)(((uint8_t)(x))<<I2C_SLTL_SSLT_SHIFT))&I2C_SLTL_SSLT_MASK)
+
+/*!
+ * @}
+ */ /* end of group I2C_Register_Masks */
+
+
+/* I2C - Peripheral instance base addresses */
+/** Peripheral I2C0 base address */
+#define I2C0_BASE                                (0x40066000u)
+/** Peripheral I2C0 base pointer */
+#define I2C0                                     ((I2C_Type *)I2C0_BASE)
+#define I2C0_BASE_PTR                            (I2C0)
+/** Peripheral I2C1 base address */
+#define I2C1_BASE                                (0x40067000u)
+/** Peripheral I2C1 base pointer */
+#define I2C1                                     ((I2C_Type *)I2C1_BASE)
+#define I2C1_BASE_PTR                            (I2C1)
+/** Array initializer of I2C peripheral base addresses */
+#define I2C_BASE_ADDRS                           { I2C0_BASE, I2C1_BASE }
+/** Array initializer of I2C peripheral base pointers */
+#define I2C_BASE_PTRS                            { I2C0, I2C1 }
+/** Interrupt vectors for the I2C peripheral type */
+#define I2C_IRQS                                 { I2C0_IRQn, I2C1_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- I2C - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup I2C_Register_Accessor_Macros I2C - Register accessor macros
+ * @{
+ */
+
+
+/* I2C - Register instance definitions */
+/* I2C0 */
+#define I2C0_A1                                  I2C_A1_REG(I2C0)
+#define I2C0_F                                   I2C_F_REG(I2C0)
+#define I2C0_C1                                  I2C_C1_REG(I2C0)
+#define I2C0_S                                   I2C_S_REG(I2C0)
+#define I2C0_D                                   I2C_D_REG(I2C0)
+#define I2C0_C2                                  I2C_C2_REG(I2C0)
+#define I2C0_FLT                                 I2C_FLT_REG(I2C0)
+#define I2C0_RA                                  I2C_RA_REG(I2C0)
+#define I2C0_SMB                                 I2C_SMB_REG(I2C0)
+#define I2C0_A2                                  I2C_A2_REG(I2C0)
+#define I2C0_SLTH                                I2C_SLTH_REG(I2C0)
+#define I2C0_SLTL                                I2C_SLTL_REG(I2C0)
+/* I2C1 */
+#define I2C1_A1                                  I2C_A1_REG(I2C1)
+#define I2C1_F                                   I2C_F_REG(I2C1)
+#define I2C1_C1                                  I2C_C1_REG(I2C1)
+#define I2C1_S                                   I2C_S_REG(I2C1)
+#define I2C1_D                                   I2C_D_REG(I2C1)
+#define I2C1_C2                                  I2C_C2_REG(I2C1)
+#define I2C1_FLT                                 I2C_FLT_REG(I2C1)
+#define I2C1_RA                                  I2C_RA_REG(I2C1)
+#define I2C1_SMB                                 I2C_SMB_REG(I2C1)
+#define I2C1_A2                                  I2C_A2_REG(I2C1)
+#define I2C1_SLTH                                I2C_SLTH_REG(I2C1)
+#define I2C1_SLTL                                I2C_SLTL_REG(I2C1)
+
+/*!
+ * @}
+ */ /* end of group I2C_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group I2C_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- LLWU Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LLWU_Peripheral_Access_Layer LLWU Peripheral Access Layer
+ * @{
+ */
+
+/** LLWU - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t PE1;                                /**< LLWU Pin Enable 1 register, offset: 0x0 */
+  __IO uint8_t PE2;                                /**< LLWU Pin Enable 2 register, offset: 0x1 */
+  __IO uint8_t PE3;                                /**< LLWU Pin Enable 3 register, offset: 0x2 */
+  __IO uint8_t PE4;                                /**< LLWU Pin Enable 4 register, offset: 0x3 */
+  __IO uint8_t ME;                                 /**< LLWU Module Enable register, offset: 0x4 */
+  __IO uint8_t F1;                                 /**< LLWU Flag 1 register, offset: 0x5 */
+  __IO uint8_t F2;                                 /**< LLWU Flag 2 register, offset: 0x6 */
+  __I  uint8_t F3;                                 /**< LLWU Flag 3 register, offset: 0x7 */
+  __IO uint8_t FILT1;                              /**< LLWU Pin Filter 1 register, offset: 0x8 */
+  __IO uint8_t FILT2;                              /**< LLWU Pin Filter 2 register, offset: 0x9 */
+} LLWU_Type, *LLWU_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- LLWU - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LLWU_Register_Accessor_Macros LLWU - Register accessor macros
+ * @{
+ */
+
+
+/* LLWU - Register accessors */
+#define LLWU_PE1_REG(base)                       ((base)->PE1)
+#define LLWU_PE2_REG(base)                       ((base)->PE2)
+#define LLWU_PE3_REG(base)                       ((base)->PE3)
+#define LLWU_PE4_REG(base)                       ((base)->PE4)
+#define LLWU_ME_REG(base)                        ((base)->ME)
+#define LLWU_F1_REG(base)                        ((base)->F1)
+#define LLWU_F2_REG(base)                        ((base)->F2)
+#define LLWU_F3_REG(base)                        ((base)->F3)
+#define LLWU_FILT1_REG(base)                     ((base)->FILT1)
+#define LLWU_FILT2_REG(base)                     ((base)->FILT2)
+
+/*!
+ * @}
+ */ /* end of group LLWU_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- LLWU Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LLWU_Register_Masks LLWU Register Masks
+ * @{
+ */
+
+/* PE1 Bit Fields */
+#define LLWU_PE1_WUPE0_MASK                      0x3u
+#define LLWU_PE1_WUPE0_SHIFT                     0
+#define LLWU_PE1_WUPE0(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE1_WUPE0_SHIFT))&LLWU_PE1_WUPE0_MASK)
+#define LLWU_PE1_WUPE1_MASK                      0xCu
+#define LLWU_PE1_WUPE1_SHIFT                     2
+#define LLWU_PE1_WUPE1(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE1_WUPE1_SHIFT))&LLWU_PE1_WUPE1_MASK)
+#define LLWU_PE1_WUPE2_MASK                      0x30u
+#define LLWU_PE1_WUPE2_SHIFT                     4
+#define LLWU_PE1_WUPE2(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE1_WUPE2_SHIFT))&LLWU_PE1_WUPE2_MASK)
+#define LLWU_PE1_WUPE3_MASK                      0xC0u
+#define LLWU_PE1_WUPE3_SHIFT                     6
+#define LLWU_PE1_WUPE3(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE1_WUPE3_SHIFT))&LLWU_PE1_WUPE3_MASK)
+/* PE2 Bit Fields */
+#define LLWU_PE2_WUPE4_MASK                      0x3u
+#define LLWU_PE2_WUPE4_SHIFT                     0
+#define LLWU_PE2_WUPE4(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE2_WUPE4_SHIFT))&LLWU_PE2_WUPE4_MASK)
+#define LLWU_PE2_WUPE5_MASK                      0xCu
+#define LLWU_PE2_WUPE5_SHIFT                     2
+#define LLWU_PE2_WUPE5(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE2_WUPE5_SHIFT))&LLWU_PE2_WUPE5_MASK)
+#define LLWU_PE2_WUPE6_MASK                      0x30u
+#define LLWU_PE2_WUPE6_SHIFT                     4
+#define LLWU_PE2_WUPE6(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE2_WUPE6_SHIFT))&LLWU_PE2_WUPE6_MASK)
+#define LLWU_PE2_WUPE7_MASK                      0xC0u
+#define LLWU_PE2_WUPE7_SHIFT                     6
+#define LLWU_PE2_WUPE7(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE2_WUPE7_SHIFT))&LLWU_PE2_WUPE7_MASK)
+/* PE3 Bit Fields */
+#define LLWU_PE3_WUPE8_MASK                      0x3u
+#define LLWU_PE3_WUPE8_SHIFT                     0
+#define LLWU_PE3_WUPE8(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE3_WUPE8_SHIFT))&LLWU_PE3_WUPE8_MASK)
+#define LLWU_PE3_WUPE9_MASK                      0xCu
+#define LLWU_PE3_WUPE9_SHIFT                     2
+#define LLWU_PE3_WUPE9(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE3_WUPE9_SHIFT))&LLWU_PE3_WUPE9_MASK)
+#define LLWU_PE3_WUPE10_MASK                     0x30u
+#define LLWU_PE3_WUPE10_SHIFT                    4
+#define LLWU_PE3_WUPE10(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE3_WUPE10_SHIFT))&LLWU_PE3_WUPE10_MASK)
+#define LLWU_PE3_WUPE11_MASK                     0xC0u
+#define LLWU_PE3_WUPE11_SHIFT                    6
+#define LLWU_PE3_WUPE11(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE3_WUPE11_SHIFT))&LLWU_PE3_WUPE11_MASK)
+/* PE4 Bit Fields */
+#define LLWU_PE4_WUPE12_MASK                     0x3u
+#define LLWU_PE4_WUPE12_SHIFT                    0
+#define LLWU_PE4_WUPE12(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE4_WUPE12_SHIFT))&LLWU_PE4_WUPE12_MASK)
+#define LLWU_PE4_WUPE13_MASK                     0xCu
+#define LLWU_PE4_WUPE13_SHIFT                    2
+#define LLWU_PE4_WUPE13(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE4_WUPE13_SHIFT))&LLWU_PE4_WUPE13_MASK)
+#define LLWU_PE4_WUPE14_MASK                     0x30u
+#define LLWU_PE4_WUPE14_SHIFT                    4
+#define LLWU_PE4_WUPE14(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE4_WUPE14_SHIFT))&LLWU_PE4_WUPE14_MASK)
+#define LLWU_PE4_WUPE15_MASK                     0xC0u
+#define LLWU_PE4_WUPE15_SHIFT                    6
+#define LLWU_PE4_WUPE15(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE4_WUPE15_SHIFT))&LLWU_PE4_WUPE15_MASK)
+/* ME Bit Fields */
+#define LLWU_ME_WUME0_MASK                       0x1u
+#define LLWU_ME_WUME0_SHIFT                      0
+#define LLWU_ME_WUME1_MASK                       0x2u
+#define LLWU_ME_WUME1_SHIFT                      1
+#define LLWU_ME_WUME2_MASK                       0x4u
+#define LLWU_ME_WUME2_SHIFT                      2
+#define LLWU_ME_WUME3_MASK                       0x8u
+#define LLWU_ME_WUME3_SHIFT                      3
+#define LLWU_ME_WUME4_MASK                       0x10u
+#define LLWU_ME_WUME4_SHIFT                      4
+#define LLWU_ME_WUME5_MASK                       0x20u
+#define LLWU_ME_WUME5_SHIFT                      5
+#define LLWU_ME_WUME6_MASK                       0x40u
+#define LLWU_ME_WUME6_SHIFT                      6
+#define LLWU_ME_WUME7_MASK                       0x80u
+#define LLWU_ME_WUME7_SHIFT                      7
+/* F1 Bit Fields */
+#define LLWU_F1_WUF0_MASK                        0x1u
+#define LLWU_F1_WUF0_SHIFT                       0
+#define LLWU_F1_WUF1_MASK                        0x2u
+#define LLWU_F1_WUF1_SHIFT                       1
+#define LLWU_F1_WUF2_MASK                        0x4u
+#define LLWU_F1_WUF2_SHIFT                       2
+#define LLWU_F1_WUF3_MASK                        0x8u
+#define LLWU_F1_WUF3_SHIFT                       3
+#define LLWU_F1_WUF4_MASK                        0x10u
+#define LLWU_F1_WUF4_SHIFT                       4
+#define LLWU_F1_WUF5_MASK                        0x20u
+#define LLWU_F1_WUF5_SHIFT                       5
+#define LLWU_F1_WUF6_MASK                        0x40u
+#define LLWU_F1_WUF6_SHIFT                       6
+#define LLWU_F1_WUF7_MASK                        0x80u
+#define LLWU_F1_WUF7_SHIFT                       7
+/* F2 Bit Fields */
+#define LLWU_F2_WUF8_MASK                        0x1u
+#define LLWU_F2_WUF8_SHIFT                       0
+#define LLWU_F2_WUF9_MASK                        0x2u
+#define LLWU_F2_WUF9_SHIFT                       1
+#define LLWU_F2_WUF10_MASK                       0x4u
+#define LLWU_F2_WUF10_SHIFT                      2
+#define LLWU_F2_WUF11_MASK                       0x8u
+#define LLWU_F2_WUF11_SHIFT                      3
+#define LLWU_F2_WUF12_MASK                       0x10u
+#define LLWU_F2_WUF12_SHIFT                      4
+#define LLWU_F2_WUF13_MASK                       0x20u
+#define LLWU_F2_WUF13_SHIFT                      5
+#define LLWU_F2_WUF14_MASK                       0x40u
+#define LLWU_F2_WUF14_SHIFT                      6
+#define LLWU_F2_WUF15_MASK                       0x80u
+#define LLWU_F2_WUF15_SHIFT                      7
+/* F3 Bit Fields */
+#define LLWU_F3_MWUF0_MASK                       0x1u
+#define LLWU_F3_MWUF0_SHIFT                      0
+#define LLWU_F3_MWUF1_MASK                       0x2u
+#define LLWU_F3_MWUF1_SHIFT                      1
+#define LLWU_F3_MWUF2_MASK                       0x4u
+#define LLWU_F3_MWUF2_SHIFT                      2
+#define LLWU_F3_MWUF3_MASK                       0x8u
+#define LLWU_F3_MWUF3_SHIFT                      3
+#define LLWU_F3_MWUF4_MASK                       0x10u
+#define LLWU_F3_MWUF4_SHIFT                      4
+#define LLWU_F3_MWUF5_MASK                       0x20u
+#define LLWU_F3_MWUF5_SHIFT                      5
+#define LLWU_F3_MWUF6_MASK                       0x40u
+#define LLWU_F3_MWUF6_SHIFT                      6
+#define LLWU_F3_MWUF7_MASK                       0x80u
+#define LLWU_F3_MWUF7_SHIFT                      7
+/* FILT1 Bit Fields */
+#define LLWU_FILT1_FILTSEL_MASK                  0xFu
+#define LLWU_FILT1_FILTSEL_SHIFT                 0
+#define LLWU_FILT1_FILTSEL(x)                    (((uint8_t)(((uint8_t)(x))<<LLWU_FILT1_FILTSEL_SHIFT))&LLWU_FILT1_FILTSEL_MASK)
+#define LLWU_FILT1_FILTE_MASK                    0x60u
+#define LLWU_FILT1_FILTE_SHIFT                   5
+#define LLWU_FILT1_FILTE(x)                      (((uint8_t)(((uint8_t)(x))<<LLWU_FILT1_FILTE_SHIFT))&LLWU_FILT1_FILTE_MASK)
+#define LLWU_FILT1_FILTF_MASK                    0x80u
+#define LLWU_FILT1_FILTF_SHIFT                   7
+/* FILT2 Bit Fields */
+#define LLWU_FILT2_FILTSEL_MASK                  0xFu
+#define LLWU_FILT2_FILTSEL_SHIFT                 0
+#define LLWU_FILT2_FILTSEL(x)                    (((uint8_t)(((uint8_t)(x))<<LLWU_FILT2_FILTSEL_SHIFT))&LLWU_FILT2_FILTSEL_MASK)
+#define LLWU_FILT2_FILTE_MASK                    0x60u
+#define LLWU_FILT2_FILTE_SHIFT                   5
+#define LLWU_FILT2_FILTE(x)                      (((uint8_t)(((uint8_t)(x))<<LLWU_FILT2_FILTE_SHIFT))&LLWU_FILT2_FILTE_MASK)
+#define LLWU_FILT2_FILTF_MASK                    0x80u
+#define LLWU_FILT2_FILTF_SHIFT                   7
+
+/*!
+ * @}
+ */ /* end of group LLWU_Register_Masks */
+
+
+/* LLWU - Peripheral instance base addresses */
+/** Peripheral LLWU base address */
+#define LLWU_BASE                                (0x4007C000u)
+/** Peripheral LLWU base pointer */
+#define LLWU                                     ((LLWU_Type *)LLWU_BASE)
+#define LLWU_BASE_PTR                            (LLWU)
+/** Array initializer of LLWU peripheral base addresses */
+#define LLWU_BASE_ADDRS                          { LLWU_BASE }
+/** Array initializer of LLWU peripheral base pointers */
+#define LLWU_BASE_PTRS                           { LLWU }
+/** Interrupt vectors for the LLWU peripheral type */
+#define LLWU_IRQS                                { LLWU_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- LLWU - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LLWU_Register_Accessor_Macros LLWU - Register accessor macros
+ * @{
+ */
+
+
+/* LLWU - Register instance definitions */
+/* LLWU */
+#define LLWU_PE1                                 LLWU_PE1_REG(LLWU)
+#define LLWU_PE2                                 LLWU_PE2_REG(LLWU)
+#define LLWU_PE3                                 LLWU_PE3_REG(LLWU)
+#define LLWU_PE4                                 LLWU_PE4_REG(LLWU)
+#define LLWU_ME                                  LLWU_ME_REG(LLWU)
+#define LLWU_F1                                  LLWU_F1_REG(LLWU)
+#define LLWU_F2                                  LLWU_F2_REG(LLWU)
+#define LLWU_F3                                  LLWU_F3_REG(LLWU)
+#define LLWU_FILT1                               LLWU_FILT1_REG(LLWU)
+#define LLWU_FILT2                               LLWU_FILT2_REG(LLWU)
+
+/*!
+ * @}
+ */ /* end of group LLWU_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group LLWU_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- LPTMR Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LPTMR_Peripheral_Access_Layer LPTMR Peripheral Access Layer
+ * @{
+ */
+
+/** LPTMR - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t CSR;                               /**< Low Power Timer Control Status Register, offset: 0x0 */
+  __IO uint32_t PSR;                               /**< Low Power Timer Prescale Register, offset: 0x4 */
+  __IO uint32_t CMR;                               /**< Low Power Timer Compare Register, offset: 0x8 */
+  __IO uint32_t CNR;                               /**< Low Power Timer Counter Register, offset: 0xC */
+} LPTMR_Type, *LPTMR_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- LPTMR - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LPTMR_Register_Accessor_Macros LPTMR - Register accessor macros
+ * @{
+ */
+
+
+/* LPTMR - Register accessors */
+#define LPTMR_CSR_REG(base)                      ((base)->CSR)
+#define LPTMR_PSR_REG(base)                      ((base)->PSR)
+#define LPTMR_CMR_REG(base)                      ((base)->CMR)
+#define LPTMR_CNR_REG(base)                      ((base)->CNR)
+
+/*!
+ * @}
+ */ /* end of group LPTMR_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- LPTMR Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LPTMR_Register_Masks LPTMR Register Masks
+ * @{
+ */
+
+/* CSR Bit Fields */
+#define LPTMR_CSR_TEN_MASK                       0x1u
+#define LPTMR_CSR_TEN_SHIFT                      0
+#define LPTMR_CSR_TMS_MASK                       0x2u
+#define LPTMR_CSR_TMS_SHIFT                      1
+#define LPTMR_CSR_TFC_MASK                       0x4u
+#define LPTMR_CSR_TFC_SHIFT                      2
+#define LPTMR_CSR_TPP_MASK                       0x8u
+#define LPTMR_CSR_TPP_SHIFT                      3
+#define LPTMR_CSR_TPS_MASK                       0x30u
+#define LPTMR_CSR_TPS_SHIFT                      4
+#define LPTMR_CSR_TPS(x)                         (((uint32_t)(((uint32_t)(x))<<LPTMR_CSR_TPS_SHIFT))&LPTMR_CSR_TPS_MASK)
+#define LPTMR_CSR_TIE_MASK                       0x40u
+#define LPTMR_CSR_TIE_SHIFT                      6
+#define LPTMR_CSR_TCF_MASK                       0x80u
+#define LPTMR_CSR_TCF_SHIFT                      7
+/* PSR Bit Fields */
+#define LPTMR_PSR_PCS_MASK                       0x3u
+#define LPTMR_PSR_PCS_SHIFT                      0
+#define LPTMR_PSR_PCS(x)                         (((uint32_t)(((uint32_t)(x))<<LPTMR_PSR_PCS_SHIFT))&LPTMR_PSR_PCS_MASK)
+#define LPTMR_PSR_PBYP_MASK                      0x4u
+#define LPTMR_PSR_PBYP_SHIFT                     2
+#define LPTMR_PSR_PRESCALE_MASK                  0x78u
+#define LPTMR_PSR_PRESCALE_SHIFT                 3
+#define LPTMR_PSR_PRESCALE(x)                    (((uint32_t)(((uint32_t)(x))<<LPTMR_PSR_PRESCALE_SHIFT))&LPTMR_PSR_PRESCALE_MASK)
+/* CMR Bit Fields */
+#define LPTMR_CMR_COMPARE_MASK                   0xFFFFu
+#define LPTMR_CMR_COMPARE_SHIFT                  0
+#define LPTMR_CMR_COMPARE(x)                     (((uint32_t)(((uint32_t)(x))<<LPTMR_CMR_COMPARE_SHIFT))&LPTMR_CMR_COMPARE_MASK)
+/* CNR Bit Fields */
+#define LPTMR_CNR_COUNTER_MASK                   0xFFFFu
+#define LPTMR_CNR_COUNTER_SHIFT                  0
+#define LPTMR_CNR_COUNTER(x)                     (((uint32_t)(((uint32_t)(x))<<LPTMR_CNR_COUNTER_SHIFT))&LPTMR_CNR_COUNTER_MASK)
+
+/*!
+ * @}
+ */ /* end of group LPTMR_Register_Masks */
+
+
+/* LPTMR - Peripheral instance base addresses */
+/** Peripheral LPTMR0 base address */
+#define LPTMR0_BASE                              (0x40040000u)
+/** Peripheral LPTMR0 base pointer */
+#define LPTMR0                                   ((LPTMR_Type *)LPTMR0_BASE)
+#define LPTMR0_BASE_PTR                          (LPTMR0)
+/** Array initializer of LPTMR peripheral base addresses */
+#define LPTMR_BASE_ADDRS                         { LPTMR0_BASE }
+/** Array initializer of LPTMR peripheral base pointers */
+#define LPTMR_BASE_PTRS                          { LPTMR0 }
+/** Interrupt vectors for the LPTMR peripheral type */
+#define LPTMR_IRQS                               { LPTMR0_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- LPTMR - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LPTMR_Register_Accessor_Macros LPTMR - Register accessor macros
+ * @{
+ */
+
+
+/* LPTMR - Register instance definitions */
+/* LPTMR0 */
+#define LPTMR0_CSR                               LPTMR_CSR_REG(LPTMR0)
+#define LPTMR0_PSR                               LPTMR_PSR_REG(LPTMR0)
+#define LPTMR0_CMR                               LPTMR_CMR_REG(LPTMR0)
+#define LPTMR0_CNR                               LPTMR_CNR_REG(LPTMR0)
+
+/*!
+ * @}
+ */ /* end of group LPTMR_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group LPTMR_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- MCG Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCG_Peripheral_Access_Layer MCG Peripheral Access Layer
+ * @{
+ */
+
+/** MCG - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t C1;                                 /**< MCG Control 1 Register, offset: 0x0 */
+  __IO uint8_t C2;                                 /**< MCG Control 2 Register, offset: 0x1 */
+  __IO uint8_t C3;                                 /**< MCG Control 3 Register, offset: 0x2 */
+  __IO uint8_t C4;                                 /**< MCG Control 4 Register, offset: 0x3 */
+  __IO uint8_t C5;                                 /**< MCG Control 5 Register, offset: 0x4 */
+  __IO uint8_t C6;                                 /**< MCG Control 6 Register, offset: 0x5 */
+  __IO uint8_t S;                                  /**< MCG Status Register, offset: 0x6 */
+       uint8_t RESERVED_0[1];
+  __IO uint8_t SC;                                 /**< MCG Status and Control Register, offset: 0x8 */
+       uint8_t RESERVED_1[1];
+  __IO uint8_t ATCVH;                              /**< MCG Auto Trim Compare Value High Register, offset: 0xA */
+  __IO uint8_t ATCVL;                              /**< MCG Auto Trim Compare Value Low Register, offset: 0xB */
+       uint8_t RESERVED_2[1];
+  __IO uint8_t C8;                                 /**< MCG Control 8 Register, offset: 0xD */
+  __I  uint8_t C9;                                 /**< MCG Control 9 Register, offset: 0xE */
+  __I  uint8_t C10;                                /**< MCG Control 10 Register, offset: 0xF */
+} MCG_Type, *MCG_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- MCG - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCG_Register_Accessor_Macros MCG - Register accessor macros
+ * @{
+ */
+
+
+/* MCG - Register accessors */
+#define MCG_C1_REG(base)                         ((base)->C1)
+#define MCG_C2_REG(base)                         ((base)->C2)
+#define MCG_C3_REG(base)                         ((base)->C3)
+#define MCG_C4_REG(base)                         ((base)->C4)
+#define MCG_C5_REG(base)                         ((base)->C5)
+#define MCG_C6_REG(base)                         ((base)->C6)
+#define MCG_S_REG(base)                          ((base)->S)
+#define MCG_SC_REG(base)                         ((base)->SC)
+#define MCG_ATCVH_REG(base)                      ((base)->ATCVH)
+#define MCG_ATCVL_REG(base)                      ((base)->ATCVL)
+#define MCG_C8_REG(base)                         ((base)->C8)
+#define MCG_C9_REG(base)                         ((base)->C9)
+#define MCG_C10_REG(base)                        ((base)->C10)
+
+/*!
+ * @}
+ */ /* end of group MCG_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- MCG Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCG_Register_Masks MCG Register Masks
+ * @{
+ */
+
+/* C1 Bit Fields */
+#define MCG_C1_IREFSTEN_MASK                     0x1u
+#define MCG_C1_IREFSTEN_SHIFT                    0
+#define MCG_C1_IRCLKEN_MASK                      0x2u
+#define MCG_C1_IRCLKEN_SHIFT                     1
+#define MCG_C1_IREFS_MASK                        0x4u
+#define MCG_C1_IREFS_SHIFT                       2
+#define MCG_C1_FRDIV_MASK                        0x38u
+#define MCG_C1_FRDIV_SHIFT                       3
+#define MCG_C1_FRDIV(x)                          (((uint8_t)(((uint8_t)(x))<<MCG_C1_FRDIV_SHIFT))&MCG_C1_FRDIV_MASK)
+#define MCG_C1_CLKS_MASK                         0xC0u
+#define MCG_C1_CLKS_SHIFT                        6
+#define MCG_C1_CLKS(x)                           (((uint8_t)(((uint8_t)(x))<<MCG_C1_CLKS_SHIFT))&MCG_C1_CLKS_MASK)
+/* C2 Bit Fields */
+#define MCG_C2_IRCS_MASK                         0x1u
+#define MCG_C2_IRCS_SHIFT                        0
+#define MCG_C2_LP_MASK                           0x2u
+#define MCG_C2_LP_SHIFT                          1
+#define MCG_C2_EREFS0_MASK                       0x4u
+#define MCG_C2_EREFS0_SHIFT                      2
+#define MCG_C2_HGO0_MASK                         0x8u
+#define MCG_C2_HGO0_SHIFT                        3
+#define MCG_C2_RANGE0_MASK                       0x30u
+#define MCG_C2_RANGE0_SHIFT                      4
+#define MCG_C2_RANGE0(x)                         (((uint8_t)(((uint8_t)(x))<<MCG_C2_RANGE0_SHIFT))&MCG_C2_RANGE0_MASK)
+#define MCG_C2_FCFTRIM_MASK                      0x40u
+#define MCG_C2_FCFTRIM_SHIFT                     6
+#define MCG_C2_LOCRE0_MASK                       0x80u
+#define MCG_C2_LOCRE0_SHIFT                      7
+/* C3 Bit Fields */
+#define MCG_C3_SCTRIM_MASK                       0xFFu
+#define MCG_C3_SCTRIM_SHIFT                      0
+#define MCG_C3_SCTRIM(x)                         (((uint8_t)(((uint8_t)(x))<<MCG_C3_SCTRIM_SHIFT))&MCG_C3_SCTRIM_MASK)
+/* C4 Bit Fields */
+#define MCG_C4_SCFTRIM_MASK                      0x1u
+#define MCG_C4_SCFTRIM_SHIFT                     0
+#define MCG_C4_FCTRIM_MASK                       0x1Eu
+#define MCG_C4_FCTRIM_SHIFT                      1
+#define MCG_C4_FCTRIM(x)                         (((uint8_t)(((uint8_t)(x))<<MCG_C4_FCTRIM_SHIFT))&MCG_C4_FCTRIM_MASK)
+#define MCG_C4_DRST_DRS_MASK                     0x60u
+#define MCG_C4_DRST_DRS_SHIFT                    5
+#define MCG_C4_DRST_DRS(x)                       (((uint8_t)(((uint8_t)(x))<<MCG_C4_DRST_DRS_SHIFT))&MCG_C4_DRST_DRS_MASK)
+#define MCG_C4_DMX32_MASK                        0x80u
+#define MCG_C4_DMX32_SHIFT                       7
+/* C5 Bit Fields */
+#define MCG_C5_PRDIV0_MASK                       0x1Fu
+#define MCG_C5_PRDIV0_SHIFT                      0
+#define MCG_C5_PRDIV0(x)                         (((uint8_t)(((uint8_t)(x))<<MCG_C5_PRDIV0_SHIFT))&MCG_C5_PRDIV0_MASK)
+#define MCG_C5_PLLSTEN0_MASK                     0x20u
+#define MCG_C5_PLLSTEN0_SHIFT                    5
+#define MCG_C5_PLLCLKEN0_MASK                    0x40u
+#define MCG_C5_PLLCLKEN0_SHIFT                   6
+/* C6 Bit Fields */
+#define MCG_C6_VDIV0_MASK                        0x1Fu
+#define MCG_C6_VDIV0_SHIFT                       0
+#define MCG_C6_VDIV0(x)                          (((uint8_t)(((uint8_t)(x))<<MCG_C6_VDIV0_SHIFT))&MCG_C6_VDIV0_MASK)
+#define MCG_C6_CME0_MASK                         0x20u
+#define MCG_C6_CME0_SHIFT                        5
+#define MCG_C6_PLLS_MASK                         0x40u
+#define MCG_C6_PLLS_SHIFT                        6
+#define MCG_C6_LOLIE0_MASK                       0x80u
+#define MCG_C6_LOLIE0_SHIFT                      7
+/* S Bit Fields */
+#define MCG_S_IRCST_MASK                         0x1u
+#define MCG_S_IRCST_SHIFT                        0
+#define MCG_S_OSCINIT0_MASK                      0x2u
+#define MCG_S_OSCINIT0_SHIFT                     1
+#define MCG_S_CLKST_MASK                         0xCu
+#define MCG_S_CLKST_SHIFT                        2
+#define MCG_S_CLKST(x)                           (((uint8_t)(((uint8_t)(x))<<MCG_S_CLKST_SHIFT))&MCG_S_CLKST_MASK)
+#define MCG_S_IREFST_MASK                        0x10u
+#define MCG_S_IREFST_SHIFT                       4
+#define MCG_S_PLLST_MASK                         0x20u
+#define MCG_S_PLLST_SHIFT                        5
+#define MCG_S_LOCK0_MASK                         0x40u
+#define MCG_S_LOCK0_SHIFT                        6
+#define MCG_S_LOLS0_MASK                         0x80u
+#define MCG_S_LOLS0_SHIFT                        7
+/* SC Bit Fields */
+#define MCG_SC_LOCS0_MASK                        0x1u
+#define MCG_SC_LOCS0_SHIFT                       0
+#define MCG_SC_FCRDIV_MASK                       0xEu
+#define MCG_SC_FCRDIV_SHIFT                      1
+#define MCG_SC_FCRDIV(x)                         (((uint8_t)(((uint8_t)(x))<<MCG_SC_FCRDIV_SHIFT))&MCG_SC_FCRDIV_MASK)
+#define MCG_SC_FLTPRSRV_MASK                     0x10u
+#define MCG_SC_FLTPRSRV_SHIFT                    4
+#define MCG_SC_ATMF_MASK                         0x20u
+#define MCG_SC_ATMF_SHIFT                        5
+#define MCG_SC_ATMS_MASK                         0x40u
+#define MCG_SC_ATMS_SHIFT                        6
+#define MCG_SC_ATME_MASK                         0x80u
+#define MCG_SC_ATME_SHIFT                        7
+/* ATCVH Bit Fields */
+#define MCG_ATCVH_ATCVH_MASK                     0xFFu
+#define MCG_ATCVH_ATCVH_SHIFT                    0
+#define MCG_ATCVH_ATCVH(x)                       (((uint8_t)(((uint8_t)(x))<<MCG_ATCVH_ATCVH_SHIFT))&MCG_ATCVH_ATCVH_MASK)
+/* ATCVL Bit Fields */
+#define MCG_ATCVL_ATCVL_MASK                     0xFFu
+#define MCG_ATCVL_ATCVL_SHIFT                    0
+#define MCG_ATCVL_ATCVL(x)                       (((uint8_t)(((uint8_t)(x))<<MCG_ATCVL_ATCVL_SHIFT))&MCG_ATCVL_ATCVL_MASK)
+/* C8 Bit Fields */
+#define MCG_C8_LOLRE_MASK                        0x40u
+#define MCG_C8_LOLRE_SHIFT                       6
+
+/*!
+ * @}
+ */ /* end of group MCG_Register_Masks */
+
+
+/* MCG - Peripheral instance base addresses */
+/** Peripheral MCG base address */
+#define MCG_BASE                                 (0x40064000u)
+/** Peripheral MCG base pointer */
+#define MCG                                      ((MCG_Type *)MCG_BASE)
+#define MCG_BASE_PTR                             (MCG)
+/** Array initializer of MCG peripheral base addresses */
+#define MCG_BASE_ADDRS                           { MCG_BASE }
+/** Array initializer of MCG peripheral base pointers */
+#define MCG_BASE_PTRS                            { MCG }
+/** Interrupt vectors for the MCG peripheral type */
+#define MCG_IRQS                                 { MCG_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- MCG - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCG_Register_Accessor_Macros MCG - Register accessor macros
+ * @{
+ */
+
+
+/* MCG - Register instance definitions */
+/* MCG */
+#define MCG_C1                                   MCG_C1_REG(MCG)
+#define MCG_C2                                   MCG_C2_REG(MCG)
+#define MCG_C3                                   MCG_C3_REG(MCG)
+#define MCG_C4                                   MCG_C4_REG(MCG)
+#define MCG_C5                                   MCG_C5_REG(MCG)
+#define MCG_C6                                   MCG_C6_REG(MCG)
+#define MCG_S                                    MCG_S_REG(MCG)
+#define MCG_SC                                   MCG_SC_REG(MCG)
+#define MCG_ATCVH                                MCG_ATCVH_REG(MCG)
+#define MCG_ATCVL                                MCG_ATCVL_REG(MCG)
+#define MCG_C8                                   MCG_C8_REG(MCG)
+#define MCG_C9                                   MCG_C9_REG(MCG)
+#define MCG_C10                                  MCG_C10_REG(MCG)
+
+/*!
+ * @}
+ */ /* end of group MCG_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group MCG_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- MCM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCM_Peripheral_Access_Layer MCM Peripheral Access Layer
+ * @{
+ */
+
+/** MCM - Register Layout Typedef */
+typedef struct {
+       uint8_t RESERVED_0[8];
+  __I  uint16_t PLASC;                             /**< Crossbar Switch (AXBS) Slave Configuration, offset: 0x8 */
+  __I  uint16_t PLAMC;                             /**< Crossbar Switch (AXBS) Master Configuration, offset: 0xA */
+  __IO uint32_t PLACR;                             /**< Platform Control Register, offset: 0xC */
+       uint8_t RESERVED_1[48];
+  __IO uint32_t CPO;                               /**< Compute Operation Control Register, offset: 0x40 */
+} MCM_Type, *MCM_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- MCM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCM_Register_Accessor_Macros MCM - Register accessor macros
+ * @{
+ */
+
+
+/* MCM - Register accessors */
+#define MCM_PLASC_REG(base)                      ((base)->PLASC)
+#define MCM_PLAMC_REG(base)                      ((base)->PLAMC)
+#define MCM_PLACR_REG(base)                      ((base)->PLACR)
+#define MCM_CPO_REG(base)                        ((base)->CPO)
+
+/*!
+ * @}
+ */ /* end of group MCM_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- MCM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCM_Register_Masks MCM Register Masks
+ * @{
+ */
+
+/* PLASC Bit Fields */
+#define MCM_PLASC_ASC_MASK                       0xFFu
+#define MCM_PLASC_ASC_SHIFT                      0
+#define MCM_PLASC_ASC(x)                         (((uint16_t)(((uint16_t)(x))<<MCM_PLASC_ASC_SHIFT))&MCM_PLASC_ASC_MASK)
+/* PLAMC Bit Fields */
+#define MCM_PLAMC_AMC_MASK                       0xFFu
+#define MCM_PLAMC_AMC_SHIFT                      0
+#define MCM_PLAMC_AMC(x)                         (((uint16_t)(((uint16_t)(x))<<MCM_PLAMC_AMC_SHIFT))&MCM_PLAMC_AMC_MASK)
+/* PLACR Bit Fields */
+#define MCM_PLACR_ARB_MASK                       0x200u
+#define MCM_PLACR_ARB_SHIFT                      9
+#define MCM_PLACR_CFCC_MASK                      0x400u
+#define MCM_PLACR_CFCC_SHIFT                     10
+#define MCM_PLACR_DFCDA_MASK                     0x800u
+#define MCM_PLACR_DFCDA_SHIFT                    11
+#define MCM_PLACR_DFCIC_MASK                     0x1000u
+#define MCM_PLACR_DFCIC_SHIFT                    12
+#define MCM_PLACR_DFCC_MASK                      0x2000u
+#define MCM_PLACR_DFCC_SHIFT                     13
+#define MCM_PLACR_EFDS_MASK                      0x4000u
+#define MCM_PLACR_EFDS_SHIFT                     14
+#define MCM_PLACR_DFCS_MASK                      0x8000u
+#define MCM_PLACR_DFCS_SHIFT                     15
+#define MCM_PLACR_ESFC_MASK                      0x10000u
+#define MCM_PLACR_ESFC_SHIFT                     16
+/* CPO Bit Fields */
+#define MCM_CPO_CPOREQ_MASK                      0x1u
+#define MCM_CPO_CPOREQ_SHIFT                     0
+#define MCM_CPO_CPOACK_MASK                      0x2u
+#define MCM_CPO_CPOACK_SHIFT                     1
+#define MCM_CPO_CPOWOI_MASK                      0x4u
+#define MCM_CPO_CPOWOI_SHIFT                     2
+
+/*!
+ * @}
+ */ /* end of group MCM_Register_Masks */
+
+
+/* MCM - Peripheral instance base addresses */
+/** Peripheral MCM base address */
+#define MCM_BASE                                 (0xF0003000u)
+/** Peripheral MCM base pointer */
+#define MCM                                      ((MCM_Type *)MCM_BASE)
+#define MCM_BASE_PTR                             (MCM)
+/** Array initializer of MCM peripheral base addresses */
+#define MCM_BASE_ADDRS                           { MCM_BASE }
+/** Array initializer of MCM peripheral base pointers */
+#define MCM_BASE_PTRS                            { MCM }
+
+/* ----------------------------------------------------------------------------
+   -- MCM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCM_Register_Accessor_Macros MCM - Register accessor macros
+ * @{
+ */
+
+
+/* MCM - Register instance definitions */
+/* MCM */
+#define MCM_PLASC                                MCM_PLASC_REG(MCM)
+#define MCM_PLAMC                                MCM_PLAMC_REG(MCM)
+#define MCM_PLACR                                MCM_PLACR_REG(MCM)
+#define MCM_CPO                                  MCM_CPO_REG(MCM)
+
+/*!
+ * @}
+ */ /* end of group MCM_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group MCM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- MTB Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MTB_Peripheral_Access_Layer MTB Peripheral Access Layer
+ * @{
+ */
+
+/** MTB - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t POSITION;                          /**< MTB Position Register, offset: 0x0 */
+  __IO uint32_t MASTER;                            /**< MTB Master Register, offset: 0x4 */
+  __IO uint32_t FLOW;                              /**< MTB Flow Register, offset: 0x8 */
+  __I  uint32_t BASE;                              /**< MTB Base Register, offset: 0xC */
+       uint8_t RESERVED_0[3824];
+  __I  uint32_t MODECTRL;                          /**< Integration Mode Control Register, offset: 0xF00 */
+       uint8_t RESERVED_1[156];
+  __I  uint32_t TAGSET;                            /**< Claim TAG Set Register, offset: 0xFA0 */
+  __I  uint32_t TAGCLEAR;                          /**< Claim TAG Clear Register, offset: 0xFA4 */
+       uint8_t RESERVED_2[8];
+  __I  uint32_t LOCKACCESS;                        /**< Lock Access Register, offset: 0xFB0 */
+  __I  uint32_t LOCKSTAT;                          /**< Lock Status Register, offset: 0xFB4 */
+  __I  uint32_t AUTHSTAT;                          /**< Authentication Status Register, offset: 0xFB8 */
+  __I  uint32_t DEVICEARCH;                        /**< Device Architecture Register, offset: 0xFBC */
+       uint8_t RESERVED_3[8];
+  __I  uint32_t DEVICECFG;                         /**< Device Configuration Register, offset: 0xFC8 */
+  __I  uint32_t DEVICETYPID;                       /**< Device Type Identifier Register, offset: 0xFCC */
+  __I  uint32_t PERIPHID[8];                       /**< Peripheral ID Register, array offset: 0xFD0, array step: 0x4 */
+  __I  uint32_t COMPID[4];                         /**< Component ID Register, array offset: 0xFF0, array step: 0x4 */
+} MTB_Type, *MTB_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- MTB - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MTB_Register_Accessor_Macros MTB - Register accessor macros
+ * @{
+ */
+
+
+/* MTB - Register accessors */
+#define MTB_POSITION_REG(base)                   ((base)->POSITION)
+#define MTB_MASTER_REG(base)                     ((base)->MASTER)
+#define MTB_FLOW_REG(base)                       ((base)->FLOW)
+#define MTB_BASE_REG(base)                       ((base)->BASE)
+#define MTB_MODECTRL_REG(base)                   ((base)->MODECTRL)
+#define MTB_TAGSET_REG(base)                     ((base)->TAGSET)
+#define MTB_TAGCLEAR_REG(base)                   ((base)->TAGCLEAR)
+#define MTB_LOCKACCESS_REG(base)                 ((base)->LOCKACCESS)
+#define MTB_LOCKSTAT_REG(base)                   ((base)->LOCKSTAT)
+#define MTB_AUTHSTAT_REG(base)                   ((base)->AUTHSTAT)
+#define MTB_DEVICEARCH_REG(base)                 ((base)->DEVICEARCH)
+#define MTB_DEVICECFG_REG(base)                  ((base)->DEVICECFG)
+#define MTB_DEVICETYPID_REG(base)                ((base)->DEVICETYPID)
+#define MTB_PERIPHID_REG(base,index)             ((base)->PERIPHID[index])
+#define MTB_COMPID_REG(base,index)               ((base)->COMPID[index])
+
+/*!
+ * @}
+ */ /* end of group MTB_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- MTB Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MTB_Register_Masks MTB Register Masks
+ * @{
+ */
+
+/* POSITION Bit Fields */
+#define MTB_POSITION_WRAP_MASK                   0x4u
+#define MTB_POSITION_WRAP_SHIFT                  2
+#define MTB_POSITION_POINTER_MASK                0xFFFFFFF8u
+#define MTB_POSITION_POINTER_SHIFT               3
+#define MTB_POSITION_POINTER(x)                  (((uint32_t)(((uint32_t)(x))<<MTB_POSITION_POINTER_SHIFT))&MTB_POSITION_POINTER_MASK)
+/* MASTER Bit Fields */
+#define MTB_MASTER_MASK_MASK                     0x1Fu
+#define MTB_MASTER_MASK_SHIFT                    0
+#define MTB_MASTER_MASK(x)                       (((uint32_t)(((uint32_t)(x))<<MTB_MASTER_MASK_SHIFT))&MTB_MASTER_MASK_MASK)
+#define MTB_MASTER_TSTARTEN_MASK                 0x20u
+#define MTB_MASTER_TSTARTEN_SHIFT                5
+#define MTB_MASTER_TSTOPEN_MASK                  0x40u
+#define MTB_MASTER_TSTOPEN_SHIFT                 6
+#define MTB_MASTER_SFRWPRIV_MASK                 0x80u
+#define MTB_MASTER_SFRWPRIV_SHIFT                7
+#define MTB_MASTER_RAMPRIV_MASK                  0x100u
+#define MTB_MASTER_RAMPRIV_SHIFT                 8
+#define MTB_MASTER_HALTREQ_MASK                  0x200u
+#define MTB_MASTER_HALTREQ_SHIFT                 9
+#define MTB_MASTER_EN_MASK                       0x80000000u
+#define MTB_MASTER_EN_SHIFT                      31
+/* FLOW Bit Fields */
+#define MTB_FLOW_AUTOSTOP_MASK                   0x1u
+#define MTB_FLOW_AUTOSTOP_SHIFT                  0
+#define MTB_FLOW_AUTOHALT_MASK                   0x2u
+#define MTB_FLOW_AUTOHALT_SHIFT                  1
+#define MTB_FLOW_WATERMARK_MASK                  0xFFFFFFF8u
+#define MTB_FLOW_WATERMARK_SHIFT                 3
+#define MTB_FLOW_WATERMARK(x)                    (((uint32_t)(((uint32_t)(x))<<MTB_FLOW_WATERMARK_SHIFT))&MTB_FLOW_WATERMARK_MASK)
+/* BASE Bit Fields */
+#define MTB_BASE_BASEADDR_MASK                   0xFFFFFFFFu
+#define MTB_BASE_BASEADDR_SHIFT                  0
+#define MTB_BASE_BASEADDR(x)                     (((uint32_t)(((uint32_t)(x))<<MTB_BASE_BASEADDR_SHIFT))&MTB_BASE_BASEADDR_MASK)
+/* MODECTRL Bit Fields */
+#define MTB_MODECTRL_MODECTRL_MASK               0xFFFFFFFFu
+#define MTB_MODECTRL_MODECTRL_SHIFT              0
+#define MTB_MODECTRL_MODECTRL(x)                 (((uint32_t)(((uint32_t)(x))<<MTB_MODECTRL_MODECTRL_SHIFT))&MTB_MODECTRL_MODECTRL_MASK)
+/* TAGSET Bit Fields */
+#define MTB_TAGSET_TAGSET_MASK                   0xFFFFFFFFu
+#define MTB_TAGSET_TAGSET_SHIFT                  0
+#define MTB_TAGSET_TAGSET(x)                     (((uint32_t)(((uint32_t)(x))<<MTB_TAGSET_TAGSET_SHIFT))&MTB_TAGSET_TAGSET_MASK)
+/* TAGCLEAR Bit Fields */
+#define MTB_TAGCLEAR_TAGCLEAR_MASK               0xFFFFFFFFu
+#define MTB_TAGCLEAR_TAGCLEAR_SHIFT              0
+#define MTB_TAGCLEAR_TAGCLEAR(x)                 (((uint32_t)(((uint32_t)(x))<<MTB_TAGCLEAR_TAGCLEAR_SHIFT))&MTB_TAGCLEAR_TAGCLEAR_MASK)
+/* LOCKACCESS Bit Fields */
+#define MTB_LOCKACCESS_LOCKACCESS_MASK           0xFFFFFFFFu
+#define MTB_LOCKACCESS_LOCKACCESS_SHIFT          0
+#define MTB_LOCKACCESS_LOCKACCESS(x)             (((uint32_t)(((uint32_t)(x))<<MTB_LOCKACCESS_LOCKACCESS_SHIFT))&MTB_LOCKACCESS_LOCKACCESS_MASK)
+/* LOCKSTAT Bit Fields */
+#define MTB_LOCKSTAT_LOCKSTAT_MASK               0xFFFFFFFFu
+#define MTB_LOCKSTAT_LOCKSTAT_SHIFT              0
+#define MTB_LOCKSTAT_LOCKSTAT(x)                 (((uint32_t)(((uint32_t)(x))<<MTB_LOCKSTAT_LOCKSTAT_SHIFT))&MTB_LOCKSTAT_LOCKSTAT_MASK)
+/* AUTHSTAT Bit Fields */
+#define MTB_AUTHSTAT_BIT0_MASK                   0x1u
+#define MTB_AUTHSTAT_BIT0_SHIFT                  0
+#define MTB_AUTHSTAT_BIT1_MASK                   0x2u
+#define MTB_AUTHSTAT_BIT1_SHIFT                  1
+#define MTB_AUTHSTAT_BIT2_MASK                   0x4u
+#define MTB_AUTHSTAT_BIT2_SHIFT                  2
+#define MTB_AUTHSTAT_BIT3_MASK                   0x8u
+#define MTB_AUTHSTAT_BIT3_SHIFT                  3
+/* DEVICEARCH Bit Fields */
+#define MTB_DEVICEARCH_DEVICEARCH_MASK           0xFFFFFFFFu
+#define MTB_DEVICEARCH_DEVICEARCH_SHIFT          0
+#define MTB_DEVICEARCH_DEVICEARCH(x)             (((uint32_t)(((uint32_t)(x))<<MTB_DEVICEARCH_DEVICEARCH_SHIFT))&MTB_DEVICEARCH_DEVICEARCH_MASK)
+/* DEVICECFG Bit Fields */
+#define MTB_DEVICECFG_DEVICECFG_MASK             0xFFFFFFFFu
+#define MTB_DEVICECFG_DEVICECFG_SHIFT            0
+#define MTB_DEVICECFG_DEVICECFG(x)               (((uint32_t)(((uint32_t)(x))<<MTB_DEVICECFG_DEVICECFG_SHIFT))&MTB_DEVICECFG_DEVICECFG_MASK)
+/* DEVICETYPID Bit Fields */
+#define MTB_DEVICETYPID_DEVICETYPID_MASK         0xFFFFFFFFu
+#define MTB_DEVICETYPID_DEVICETYPID_SHIFT        0
+#define MTB_DEVICETYPID_DEVICETYPID(x)           (((uint32_t)(((uint32_t)(x))<<MTB_DEVICETYPID_DEVICETYPID_SHIFT))&MTB_DEVICETYPID_DEVICETYPID_MASK)
+/* PERIPHID Bit Fields */
+#define MTB_PERIPHID_PERIPHID_MASK               0xFFFFFFFFu
+#define MTB_PERIPHID_PERIPHID_SHIFT              0
+#define MTB_PERIPHID_PERIPHID(x)                 (((uint32_t)(((uint32_t)(x))<<MTB_PERIPHID_PERIPHID_SHIFT))&MTB_PERIPHID_PERIPHID_MASK)
+/* COMPID Bit Fields */
+#define MTB_COMPID_COMPID_MASK                   0xFFFFFFFFu
+#define MTB_COMPID_COMPID_SHIFT                  0
+#define MTB_COMPID_COMPID(x)                     (((uint32_t)(((uint32_t)(x))<<MTB_COMPID_COMPID_SHIFT))&MTB_COMPID_COMPID_MASK)
+
+/*!
+ * @}
+ */ /* end of group MTB_Register_Masks */
+
+
+/* MTB - Peripheral instance base addresses */
+/** Peripheral MTB base address */
+#define MTB_BASE                                 (0xF0000000u)
+/** Peripheral MTB base pointer */
+#define MTB                                      ((MTB_Type *)MTB_BASE)
+#define MTB_BASE_PTR                             (MTB)
+/** Array initializer of MTB peripheral base addresses */
+#define MTB_BASE_ADDRS                           { MTB_BASE }
+/** Array initializer of MTB peripheral base pointers */
+#define MTB_BASE_PTRS                            { MTB }
+
+/* ----------------------------------------------------------------------------
+   -- MTB - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MTB_Register_Accessor_Macros MTB - Register accessor macros
+ * @{
+ */
+
+
+/* MTB - Register instance definitions */
+/* MTB */
+#define MTB_POSITION                             MTB_POSITION_REG(MTB)
+#define MTB_MASTER                               MTB_MASTER_REG(MTB)
+#define MTB_FLOW                                 MTB_FLOW_REG(MTB)
+#define MTB_BASEr                                MTB_BASE_REG(MTB)
+#define MTB_MODECTRL                             MTB_MODECTRL_REG(MTB)
+#define MTB_TAGSET                               MTB_TAGSET_REG(MTB)
+#define MTB_TAGCLEAR                             MTB_TAGCLEAR_REG(MTB)
+#define MTB_LOCKACCESS                           MTB_LOCKACCESS_REG(MTB)
+#define MTB_LOCKSTAT                             MTB_LOCKSTAT_REG(MTB)
+#define MTB_AUTHSTAT                             MTB_AUTHSTAT_REG(MTB)
+#define MTB_DEVICEARCH                           MTB_DEVICEARCH_REG(MTB)
+#define MTB_DEVICECFG                            MTB_DEVICECFG_REG(MTB)
+#define MTB_DEVICETYPID                          MTB_DEVICETYPID_REG(MTB)
+#define MTB_PERIPHID4                            MTB_PERIPHID_REG(MTB,0)
+#define MTB_PERIPHID5                            MTB_PERIPHID_REG(MTB,1)
+#define MTB_PERIPHID6                            MTB_PERIPHID_REG(MTB,2)
+#define MTB_PERIPHID7                            MTB_PERIPHID_REG(MTB,3)
+#define MTB_PERIPHID0                            MTB_PERIPHID_REG(MTB,4)
+#define MTB_PERIPHID1                            MTB_PERIPHID_REG(MTB,5)
+#define MTB_PERIPHID2                            MTB_PERIPHID_REG(MTB,6)
+#define MTB_PERIPHID3                            MTB_PERIPHID_REG(MTB,7)
+#define MTB_COMPID0                              MTB_COMPID_REG(MTB,0)
+#define MTB_COMPID1                              MTB_COMPID_REG(MTB,1)
+#define MTB_COMPID2                              MTB_COMPID_REG(MTB,2)
+#define MTB_COMPID3                              MTB_COMPID_REG(MTB,3)
+
+/* MTB - Register array accessors */
+#define MTB_PERIPHID(index)                      MTB_PERIPHID_REG(MTB,index)
+#define MTB_COMPID(index)                        MTB_COMPID_REG(MTB,index)
+
+/*!
+ * @}
+ */ /* end of group MTB_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group MTB_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- MTBDWT Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MTBDWT_Peripheral_Access_Layer MTBDWT Peripheral Access Layer
+ * @{
+ */
+
+/** MTBDWT - Register Layout Typedef */
+typedef struct {
+  __I  uint32_t CTRL;                              /**< MTB DWT Control Register, offset: 0x0 */
+       uint8_t RESERVED_0[28];
+  struct {                                         /* offset: 0x20, array step: 0x10 */
+    __IO uint32_t COMP;                              /**< MTB_DWT Comparator Register, array offset: 0x20, array step: 0x10 */
+    __IO uint32_t MASK;                              /**< MTB_DWT Comparator Mask Register, array offset: 0x24, array step: 0x10 */
+    __IO uint32_t FCT;                               /**< MTB_DWT Comparator Function Register 0..MTB_DWT Comparator Function Register 1, array offset: 0x28, array step: 0x10 */
+         uint8_t RESERVED_0[4];
+  } COMPARATOR[2];
+       uint8_t RESERVED_1[448];
+  __IO uint32_t TBCTRL;                            /**< MTB_DWT Trace Buffer Control Register, offset: 0x200 */
+       uint8_t RESERVED_2[3524];
+  __I  uint32_t DEVICECFG;                         /**< Device Configuration Register, offset: 0xFC8 */
+  __I  uint32_t DEVICETYPID;                       /**< Device Type Identifier Register, offset: 0xFCC */
+  __I  uint32_t PERIPHID[8];                       /**< Peripheral ID Register, array offset: 0xFD0, array step: 0x4 */
+  __I  uint32_t COMPID[4];                         /**< Component ID Register, array offset: 0xFF0, array step: 0x4 */
+} MTBDWT_Type, *MTBDWT_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- MTBDWT - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MTBDWT_Register_Accessor_Macros MTBDWT - Register accessor macros
+ * @{
+ */
+
+
+/* MTBDWT - Register accessors */
+#define MTBDWT_CTRL_REG(base)                    ((base)->CTRL)
+#define MTBDWT_COMP_REG(base,index)              ((base)->COMPARATOR[index].COMP)
+#define MTBDWT_MASK_REG(base,index)              ((base)->COMPARATOR[index].MASK)
+#define MTBDWT_FCT_REG(base,index)               ((base)->COMPARATOR[index].FCT)
+#define MTBDWT_TBCTRL_REG(base)                  ((base)->TBCTRL)
+#define MTBDWT_DEVICECFG_REG(base)               ((base)->DEVICECFG)
+#define MTBDWT_DEVICETYPID_REG(base)             ((base)->DEVICETYPID)
+#define MTBDWT_PERIPHID_REG(base,index)          ((base)->PERIPHID[index])
+#define MTBDWT_COMPID_REG(base,index)            ((base)->COMPID[index])
+
+/*!
+ * @}
+ */ /* end of group MTBDWT_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- MTBDWT Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MTBDWT_Register_Masks MTBDWT Register Masks
+ * @{
+ */
+
+/* CTRL Bit Fields */
+#define MTBDWT_CTRL_DWTCFGCTRL_MASK              0xFFFFFFFu
+#define MTBDWT_CTRL_DWTCFGCTRL_SHIFT             0
+#define MTBDWT_CTRL_DWTCFGCTRL(x)                (((uint32_t)(((uint32_t)(x))<<MTBDWT_CTRL_DWTCFGCTRL_SHIFT))&MTBDWT_CTRL_DWTCFGCTRL_MASK)
+#define MTBDWT_CTRL_NUMCMP_MASK                  0xF0000000u
+#define MTBDWT_CTRL_NUMCMP_SHIFT                 28
+#define MTBDWT_CTRL_NUMCMP(x)                    (((uint32_t)(((uint32_t)(x))<<MTBDWT_CTRL_NUMCMP_SHIFT))&MTBDWT_CTRL_NUMCMP_MASK)
+/* COMP Bit Fields */
+#define MTBDWT_COMP_COMP_MASK                    0xFFFFFFFFu
+#define MTBDWT_COMP_COMP_SHIFT                   0
+#define MTBDWT_COMP_COMP(x)                      (((uint32_t)(((uint32_t)(x))<<MTBDWT_COMP_COMP_SHIFT))&MTBDWT_COMP_COMP_MASK)
+/* MASK Bit Fields */
+#define MTBDWT_MASK_MASK_MASK                    0x1Fu
+#define MTBDWT_MASK_MASK_SHIFT                   0
+#define MTBDWT_MASK_MASK(x)                      (((uint32_t)(((uint32_t)(x))<<MTBDWT_MASK_MASK_SHIFT))&MTBDWT_MASK_MASK_MASK)
+/* FCT Bit Fields */
+#define MTBDWT_FCT_FUNCTION_MASK                 0xFu
+#define MTBDWT_FCT_FUNCTION_SHIFT                0
+#define MTBDWT_FCT_FUNCTION(x)                   (((uint32_t)(((uint32_t)(x))<<MTBDWT_FCT_FUNCTION_SHIFT))&MTBDWT_FCT_FUNCTION_MASK)
+#define MTBDWT_FCT_DATAVMATCH_MASK               0x100u
+#define MTBDWT_FCT_DATAVMATCH_SHIFT              8
+#define MTBDWT_FCT_DATAVSIZE_MASK                0xC00u
+#define MTBDWT_FCT_DATAVSIZE_SHIFT               10
+#define MTBDWT_FCT_DATAVSIZE(x)                  (((uint32_t)(((uint32_t)(x))<<MTBDWT_FCT_DATAVSIZE_SHIFT))&MTBDWT_FCT_DATAVSIZE_MASK)
+#define MTBDWT_FCT_DATAVADDR0_MASK               0xF000u
+#define MTBDWT_FCT_DATAVADDR0_SHIFT              12
+#define MTBDWT_FCT_DATAVADDR0(x)                 (((uint32_t)(((uint32_t)(x))<<MTBDWT_FCT_DATAVADDR0_SHIFT))&MTBDWT_FCT_DATAVADDR0_MASK)
+#define MTBDWT_FCT_MATCHED_MASK                  0x1000000u
+#define MTBDWT_FCT_MATCHED_SHIFT                 24
+/* TBCTRL Bit Fields */
+#define MTBDWT_TBCTRL_ACOMP0_MASK                0x1u
+#define MTBDWT_TBCTRL_ACOMP0_SHIFT               0
+#define MTBDWT_TBCTRL_ACOMP1_MASK                0x2u
+#define MTBDWT_TBCTRL_ACOMP1_SHIFT               1
+#define MTBDWT_TBCTRL_NUMCOMP_MASK               0xF0000000u
+#define MTBDWT_TBCTRL_NUMCOMP_SHIFT              28
+#define MTBDWT_TBCTRL_NUMCOMP(x)                 (((uint32_t)(((uint32_t)(x))<<MTBDWT_TBCTRL_NUMCOMP_SHIFT))&MTBDWT_TBCTRL_NUMCOMP_MASK)
+/* DEVICECFG Bit Fields */
+#define MTBDWT_DEVICECFG_DEVICECFG_MASK          0xFFFFFFFFu
+#define MTBDWT_DEVICECFG_DEVICECFG_SHIFT         0
+#define MTBDWT_DEVICECFG_DEVICECFG(x)            (((uint32_t)(((uint32_t)(x))<<MTBDWT_DEVICECFG_DEVICECFG_SHIFT))&MTBDWT_DEVICECFG_DEVICECFG_MASK)
+/* DEVICETYPID Bit Fields */
+#define MTBDWT_DEVICETYPID_DEVICETYPID_MASK      0xFFFFFFFFu
+#define MTBDWT_DEVICETYPID_DEVICETYPID_SHIFT     0
+#define MTBDWT_DEVICETYPID_DEVICETYPID(x)        (((uint32_t)(((uint32_t)(x))<<MTBDWT_DEVICETYPID_DEVICETYPID_SHIFT))&MTBDWT_DEVICETYPID_DEVICETYPID_MASK)
+/* PERIPHID Bit Fields */
+#define MTBDWT_PERIPHID_PERIPHID_MASK            0xFFFFFFFFu
+#define MTBDWT_PERIPHID_PERIPHID_SHIFT           0
+#define MTBDWT_PERIPHID_PERIPHID(x)              (((uint32_t)(((uint32_t)(x))<<MTBDWT_PERIPHID_PERIPHID_SHIFT))&MTBDWT_PERIPHID_PERIPHID_MASK)
+/* COMPID Bit Fields */
+#define MTBDWT_COMPID_COMPID_MASK                0xFFFFFFFFu
+#define MTBDWT_COMPID_COMPID_SHIFT               0
+#define MTBDWT_COMPID_COMPID(x)                  (((uint32_t)(((uint32_t)(x))<<MTBDWT_COMPID_COMPID_SHIFT))&MTBDWT_COMPID_COMPID_MASK)
+
+/*!
+ * @}
+ */ /* end of group MTBDWT_Register_Masks */
+
+
+/* MTBDWT - Peripheral instance base addresses */
+/** Peripheral MTBDWT base address */
+#define MTBDWT_BASE                              (0xF0001000u)
+/** Peripheral MTBDWT base pointer */
+#define MTBDWT                                   ((MTBDWT_Type *)MTBDWT_BASE)
+#define MTBDWT_BASE_PTR                          (MTBDWT)
+/** Array initializer of MTBDWT peripheral base addresses */
+#define MTBDWT_BASE_ADDRS                        { MTBDWT_BASE }
+/** Array initializer of MTBDWT peripheral base pointers */
+#define MTBDWT_BASE_PTRS                         { MTBDWT }
+
+/* ----------------------------------------------------------------------------
+   -- MTBDWT - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MTBDWT_Register_Accessor_Macros MTBDWT - Register accessor macros
+ * @{
+ */
+
+
+/* MTBDWT - Register instance definitions */
+/* MTBDWT */
+#define MTBDWT_CTRL                              MTBDWT_CTRL_REG(MTBDWT)
+#define MTBDWT_COMP0                             MTBDWT_COMP_REG(MTBDWT,0)
+#define MTBDWT_MASK0                             MTBDWT_MASK_REG(MTBDWT,0)
+#define MTBDWT_FCT0                              MTBDWT_FCT_REG(MTBDWT,0)
+#define MTBDWT_COMP1                             MTBDWT_COMP_REG(MTBDWT,1)
+#define MTBDWT_MASK1                             MTBDWT_MASK_REG(MTBDWT,1)
+#define MTBDWT_FCT1                              MTBDWT_FCT_REG(MTBDWT,1)
+#define MTBDWT_TBCTRL                            MTBDWT_TBCTRL_REG(MTBDWT)
+#define MTBDWT_DEVICECFG                         MTBDWT_DEVICECFG_REG(MTBDWT)
+#define MTBDWT_DEVICETYPID                       MTBDWT_DEVICETYPID_REG(MTBDWT)
+#define MTBDWT_PERIPHID4                         MTBDWT_PERIPHID_REG(MTBDWT,0)
+#define MTBDWT_PERIPHID5                         MTBDWT_PERIPHID_REG(MTBDWT,1)
+#define MTBDWT_PERIPHID6                         MTBDWT_PERIPHID_REG(MTBDWT,2)
+#define MTBDWT_PERIPHID7                         MTBDWT_PERIPHID_REG(MTBDWT,3)
+#define MTBDWT_PERIPHID0                         MTBDWT_PERIPHID_REG(MTBDWT,4)
+#define MTBDWT_PERIPHID1                         MTBDWT_PERIPHID_REG(MTBDWT,5)
+#define MTBDWT_PERIPHID2                         MTBDWT_PERIPHID_REG(MTBDWT,6)
+#define MTBDWT_PERIPHID3                         MTBDWT_PERIPHID_REG(MTBDWT,7)
+#define MTBDWT_COMPID0                           MTBDWT_COMPID_REG(MTBDWT,0)
+#define MTBDWT_COMPID1                           MTBDWT_COMPID_REG(MTBDWT,1)
+#define MTBDWT_COMPID2                           MTBDWT_COMPID_REG(MTBDWT,2)
+#define MTBDWT_COMPID3                           MTBDWT_COMPID_REG(MTBDWT,3)
+
+/* MTBDWT - Register array accessors */
+#define MTBDWT_COMP(index)                       MTBDWT_COMP_REG(MTBDWT,index)
+#define MTBDWT_MASK(index)                       MTBDWT_MASK_REG(MTBDWT,index)
+#define MTBDWT_FCT(index)                        MTBDWT_FCT_REG(MTBDWT,index)
+#define MTBDWT_PERIPHID(index)                   MTBDWT_PERIPHID_REG(MTBDWT,index)
+#define MTBDWT_COMPID(index)                     MTBDWT_COMPID_REG(MTBDWT,index)
+
+/*!
+ * @}
+ */ /* end of group MTBDWT_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group MTBDWT_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- NV Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup NV_Peripheral_Access_Layer NV Peripheral Access Layer
+ * @{
+ */
+
+/** NV - Register Layout Typedef */
+typedef struct {
+  __I  uint8_t BACKKEY3;                           /**< Backdoor Comparison Key 3., offset: 0x0 */
+  __I  uint8_t BACKKEY2;                           /**< Backdoor Comparison Key 2., offset: 0x1 */
+  __I  uint8_t BACKKEY1;                           /**< Backdoor Comparison Key 1., offset: 0x2 */
+  __I  uint8_t BACKKEY0;                           /**< Backdoor Comparison Key 0., offset: 0x3 */
+  __I  uint8_t BACKKEY7;                           /**< Backdoor Comparison Key 7., offset: 0x4 */
+  __I  uint8_t BACKKEY6;                           /**< Backdoor Comparison Key 6., offset: 0x5 */
+  __I  uint8_t BACKKEY5;                           /**< Backdoor Comparison Key 5., offset: 0x6 */
+  __I  uint8_t BACKKEY4;                           /**< Backdoor Comparison Key 4., offset: 0x7 */
+  __I  uint8_t FPROT3;                             /**< Non-volatile P-Flash Protection 1 - Low Register, offset: 0x8 */
+  __I  uint8_t FPROT2;                             /**< Non-volatile P-Flash Protection 1 - High Register, offset: 0x9 */
+  __I  uint8_t FPROT1;                             /**< Non-volatile P-Flash Protection 0 - Low Register, offset: 0xA */
+  __I  uint8_t FPROT0;                             /**< Non-volatile P-Flash Protection 0 - High Register, offset: 0xB */
+  __I  uint8_t FSEC;                               /**< Non-volatile Flash Security Register, offset: 0xC */
+  __I  uint8_t FOPT;                               /**< Non-volatile Flash Option Register, offset: 0xD */
+} NV_Type, *NV_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- NV - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup NV_Register_Accessor_Macros NV - Register accessor macros
+ * @{
+ */
+
+
+/* NV - Register accessors */
+#define NV_BACKKEY3_REG(base)                    ((base)->BACKKEY3)
+#define NV_BACKKEY2_REG(base)                    ((base)->BACKKEY2)
+#define NV_BACKKEY1_REG(base)                    ((base)->BACKKEY1)
+#define NV_BACKKEY0_REG(base)                    ((base)->BACKKEY0)
+#define NV_BACKKEY7_REG(base)                    ((base)->BACKKEY7)
+#define NV_BACKKEY6_REG(base)                    ((base)->BACKKEY6)
+#define NV_BACKKEY5_REG(base)                    ((base)->BACKKEY5)
+#define NV_BACKKEY4_REG(base)                    ((base)->BACKKEY4)
+#define NV_FPROT3_REG(base)                      ((base)->FPROT3)
+#define NV_FPROT2_REG(base)                      ((base)->FPROT2)
+#define NV_FPROT1_REG(base)                      ((base)->FPROT1)
+#define NV_FPROT0_REG(base)                      ((base)->FPROT0)
+#define NV_FSEC_REG(base)                        ((base)->FSEC)
+#define NV_FOPT_REG(base)                        ((base)->FOPT)
+
+/*!
+ * @}
+ */ /* end of group NV_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- NV Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup NV_Register_Masks NV Register Masks
+ * @{
+ */
+
+/* BACKKEY3 Bit Fields */
+#define NV_BACKKEY3_KEY_MASK                     0xFFu
+#define NV_BACKKEY3_KEY_SHIFT                    0
+#define NV_BACKKEY3_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY3_KEY_SHIFT))&NV_BACKKEY3_KEY_MASK)
+/* BACKKEY2 Bit Fields */
+#define NV_BACKKEY2_KEY_MASK                     0xFFu
+#define NV_BACKKEY2_KEY_SHIFT                    0
+#define NV_BACKKEY2_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY2_KEY_SHIFT))&NV_BACKKEY2_KEY_MASK)
+/* BACKKEY1 Bit Fields */
+#define NV_BACKKEY1_KEY_MASK                     0xFFu
+#define NV_BACKKEY1_KEY_SHIFT                    0
+#define NV_BACKKEY1_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY1_KEY_SHIFT))&NV_BACKKEY1_KEY_MASK)
+/* BACKKEY0 Bit Fields */
+#define NV_BACKKEY0_KEY_MASK                     0xFFu
+#define NV_BACKKEY0_KEY_SHIFT                    0
+#define NV_BACKKEY0_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY0_KEY_SHIFT))&NV_BACKKEY0_KEY_MASK)
+/* BACKKEY7 Bit Fields */
+#define NV_BACKKEY7_KEY_MASK                     0xFFu
+#define NV_BACKKEY7_KEY_SHIFT                    0
+#define NV_BACKKEY7_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY7_KEY_SHIFT))&NV_BACKKEY7_KEY_MASK)
+/* BACKKEY6 Bit Fields */
+#define NV_BACKKEY6_KEY_MASK                     0xFFu
+#define NV_BACKKEY6_KEY_SHIFT                    0
+#define NV_BACKKEY6_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY6_KEY_SHIFT))&NV_BACKKEY6_KEY_MASK)
+/* BACKKEY5 Bit Fields */
+#define NV_BACKKEY5_KEY_MASK                     0xFFu
+#define NV_BACKKEY5_KEY_SHIFT                    0
+#define NV_BACKKEY5_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY5_KEY_SHIFT))&NV_BACKKEY5_KEY_MASK)
+/* BACKKEY4 Bit Fields */
+#define NV_BACKKEY4_KEY_MASK                     0xFFu
+#define NV_BACKKEY4_KEY_SHIFT                    0
+#define NV_BACKKEY4_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY4_KEY_SHIFT))&NV_BACKKEY4_KEY_MASK)
+/* FPROT3 Bit Fields */
+#define NV_FPROT3_PROT_MASK                      0xFFu
+#define NV_FPROT3_PROT_SHIFT                     0
+#define NV_FPROT3_PROT(x)                        (((uint8_t)(((uint8_t)(x))<<NV_FPROT3_PROT_SHIFT))&NV_FPROT3_PROT_MASK)
+/* FPROT2 Bit Fields */
+#define NV_FPROT2_PROT_MASK                      0xFFu
+#define NV_FPROT2_PROT_SHIFT                     0
+#define NV_FPROT2_PROT(x)                        (((uint8_t)(((uint8_t)(x))<<NV_FPROT2_PROT_SHIFT))&NV_FPROT2_PROT_MASK)
+/* FPROT1 Bit Fields */
+#define NV_FPROT1_PROT_MASK                      0xFFu
+#define NV_FPROT1_PROT_SHIFT                     0
+#define NV_FPROT1_PROT(x)                        (((uint8_t)(((uint8_t)(x))<<NV_FPROT1_PROT_SHIFT))&NV_FPROT1_PROT_MASK)
+/* FPROT0 Bit Fields */
+#define NV_FPROT0_PROT_MASK                      0xFFu
+#define NV_FPROT0_PROT_SHIFT                     0
+#define NV_FPROT0_PROT(x)                        (((uint8_t)(((uint8_t)(x))<<NV_FPROT0_PROT_SHIFT))&NV_FPROT0_PROT_MASK)
+/* FSEC Bit Fields */
+#define NV_FSEC_SEC_MASK                         0x3u
+#define NV_FSEC_SEC_SHIFT                        0
+#define NV_FSEC_SEC(x)                           (((uint8_t)(((uint8_t)(x))<<NV_FSEC_SEC_SHIFT))&NV_FSEC_SEC_MASK)
+#define NV_FSEC_FSLACC_MASK                      0xCu
+#define NV_FSEC_FSLACC_SHIFT                     2
+#define NV_FSEC_FSLACC(x)                        (((uint8_t)(((uint8_t)(x))<<NV_FSEC_FSLACC_SHIFT))&NV_FSEC_FSLACC_MASK)
+#define NV_FSEC_MEEN_MASK                        0x30u
+#define NV_FSEC_MEEN_SHIFT                       4
+#define NV_FSEC_MEEN(x)                          (((uint8_t)(((uint8_t)(x))<<NV_FSEC_MEEN_SHIFT))&NV_FSEC_MEEN_MASK)
+#define NV_FSEC_KEYEN_MASK                       0xC0u
+#define NV_FSEC_KEYEN_SHIFT                      6
+#define NV_FSEC_KEYEN(x)                         (((uint8_t)(((uint8_t)(x))<<NV_FSEC_KEYEN_SHIFT))&NV_FSEC_KEYEN_MASK)
+/* FOPT Bit Fields */
+#define NV_FOPT_LPBOOT0_MASK                     0x1u
+#define NV_FOPT_LPBOOT0_SHIFT                    0
+#define NV_FOPT_NMI_DIS_MASK                     0x4u
+#define NV_FOPT_NMI_DIS_SHIFT                    2
+#define NV_FOPT_RESET_PIN_CFG_MASK               0x8u
+#define NV_FOPT_RESET_PIN_CFG_SHIFT              3
+#define NV_FOPT_LPBOOT1_MASK                     0x10u
+#define NV_FOPT_LPBOOT1_SHIFT                    4
+#define NV_FOPT_FAST_INIT_MASK                   0x20u
+#define NV_FOPT_FAST_INIT_SHIFT                  5
+
+/*!
+ * @}
+ */ /* end of group NV_Register_Masks */
+
+
+/* NV - Peripheral instance base addresses */
+/** Peripheral FTFA_FlashConfig base address */
+#define FTFA_FlashConfig_BASE                    (0x400u)
+/** Peripheral FTFA_FlashConfig base pointer */
+#define FTFA_FlashConfig                         ((NV_Type *)FTFA_FlashConfig_BASE)
+#define FTFA_FlashConfig_BASE_PTR                (FTFA_FlashConfig)
+/** Array initializer of NV peripheral base addresses */
+#define NV_BASE_ADDRS                            { FTFA_FlashConfig_BASE }
+/** Array initializer of NV peripheral base pointers */
+#define NV_BASE_PTRS                             { FTFA_FlashConfig }
+
+/* ----------------------------------------------------------------------------
+   -- NV - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup NV_Register_Accessor_Macros NV - Register accessor macros
+ * @{
+ */
+
+
+/* NV - Register instance definitions */
+/* FTFA_FlashConfig */
+#define NV_BACKKEY3                              NV_BACKKEY3_REG(FTFA_FlashConfig)
+#define NV_BACKKEY2                              NV_BACKKEY2_REG(FTFA_FlashConfig)
+#define NV_BACKKEY1                              NV_BACKKEY1_REG(FTFA_FlashConfig)
+#define NV_BACKKEY0                              NV_BACKKEY0_REG(FTFA_FlashConfig)
+#define NV_BACKKEY7                              NV_BACKKEY7_REG(FTFA_FlashConfig)
+#define NV_BACKKEY6                              NV_BACKKEY6_REG(FTFA_FlashConfig)
+#define NV_BACKKEY5                              NV_BACKKEY5_REG(FTFA_FlashConfig)
+#define NV_BACKKEY4                              NV_BACKKEY4_REG(FTFA_FlashConfig)
+#define NV_FPROT3                                NV_FPROT3_REG(FTFA_FlashConfig)
+#define NV_FPROT2                                NV_FPROT2_REG(FTFA_FlashConfig)
+#define NV_FPROT1                                NV_FPROT1_REG(FTFA_FlashConfig)
+#define NV_FPROT0                                NV_FPROT0_REG(FTFA_FlashConfig)
+#define NV_FSEC                                  NV_FSEC_REG(FTFA_FlashConfig)
+#define NV_FOPT                                  NV_FOPT_REG(FTFA_FlashConfig)
+
+/*!
+ * @}
+ */ /* end of group NV_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group NV_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- OSC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup OSC_Peripheral_Access_Layer OSC Peripheral Access Layer
+ * @{
+ */
+
+/** OSC - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t CR;                                 /**< OSC Control Register, offset: 0x0 */
+} OSC_Type, *OSC_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- OSC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup OSC_Register_Accessor_Macros OSC - Register accessor macros
+ * @{
+ */
+
+
+/* OSC - Register accessors */
+#define OSC_CR_REG(base)                         ((base)->CR)
+
+/*!
+ * @}
+ */ /* end of group OSC_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- OSC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup OSC_Register_Masks OSC Register Masks
+ * @{
+ */
+
+/* CR Bit Fields */
+#define OSC_CR_SC16P_MASK                        0x1u
+#define OSC_CR_SC16P_SHIFT                       0
+#define OSC_CR_SC8P_MASK                         0x2u
+#define OSC_CR_SC8P_SHIFT                        1
+#define OSC_CR_SC4P_MASK                         0x4u
+#define OSC_CR_SC4P_SHIFT                        2
+#define OSC_CR_SC2P_MASK                         0x8u
+#define OSC_CR_SC2P_SHIFT                        3
+#define OSC_CR_EREFSTEN_MASK                     0x20u
+#define OSC_CR_EREFSTEN_SHIFT                    5
+#define OSC_CR_ERCLKEN_MASK                      0x80u
+#define OSC_CR_ERCLKEN_SHIFT                     7
+
+/*!
+ * @}
+ */ /* end of group OSC_Register_Masks */
+
+
+/* OSC - Peripheral instance base addresses */
+/** Peripheral OSC0 base address */
+#define OSC0_BASE                                (0x40065000u)
+/** Peripheral OSC0 base pointer */
+#define OSC0                                     ((OSC_Type *)OSC0_BASE)
+#define OSC0_BASE_PTR                            (OSC0)
+/** Array initializer of OSC peripheral base addresses */
+#define OSC_BASE_ADDRS                           { OSC0_BASE }
+/** Array initializer of OSC peripheral base pointers */
+#define OSC_BASE_PTRS                            { OSC0 }
+
+/* ----------------------------------------------------------------------------
+   -- OSC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup OSC_Register_Accessor_Macros OSC - Register accessor macros
+ * @{
+ */
+
+
+/* OSC - Register instance definitions */
+/* OSC0 */
+#define OSC0_CR                                  OSC_CR_REG(OSC0)
+
+/*!
+ * @}
+ */ /* end of group OSC_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group OSC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- PIT Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PIT_Peripheral_Access_Layer PIT Peripheral Access Layer
+ * @{
+ */
+
+/** PIT - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t MCR;                               /**< PIT Module Control Register, offset: 0x0 */
+       uint8_t RESERVED_0[220];
+  __I  uint32_t LTMR64H;                           /**< PIT Upper Lifetime Timer Register, offset: 0xE0 */
+  __I  uint32_t LTMR64L;                           /**< PIT Lower Lifetime Timer Register, offset: 0xE4 */
+       uint8_t RESERVED_1[24];
+  struct {                                         /* offset: 0x100, array step: 0x10 */
+    __IO uint32_t LDVAL;                             /**< Timer Load Value Register, array offset: 0x100, array step: 0x10 */
+    __I  uint32_t CVAL;                              /**< Current Timer Value Register, array offset: 0x104, array step: 0x10 */
+    __IO uint32_t TCTRL;                             /**< Timer Control Register, array offset: 0x108, array step: 0x10 */
+    __IO uint32_t TFLG;                              /**< Timer Flag Register, array offset: 0x10C, array step: 0x10 */
+  } CHANNEL[2];
+} PIT_Type, *PIT_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- PIT - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PIT_Register_Accessor_Macros PIT - Register accessor macros
+ * @{
+ */
+
+
+/* PIT - Register accessors */
+#define PIT_MCR_REG(base)                        ((base)->MCR)
+#define PIT_LTMR64H_REG(base)                    ((base)->LTMR64H)
+#define PIT_LTMR64L_REG(base)                    ((base)->LTMR64L)
+#define PIT_LDVAL_REG(base,index)                ((base)->CHANNEL[index].LDVAL)
+#define PIT_CVAL_REG(base,index)                 ((base)->CHANNEL[index].CVAL)
+#define PIT_TCTRL_REG(base,index)                ((base)->CHANNEL[index].TCTRL)
+#define PIT_TFLG_REG(base,index)                 ((base)->CHANNEL[index].TFLG)
+
+/*!
+ * @}
+ */ /* end of group PIT_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- PIT Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PIT_Register_Masks PIT Register Masks
+ * @{
+ */
+
+/* MCR Bit Fields */
+#define PIT_MCR_FRZ_MASK                         0x1u
+#define PIT_MCR_FRZ_SHIFT                        0
+#define PIT_MCR_MDIS_MASK                        0x2u
+#define PIT_MCR_MDIS_SHIFT                       1
+/* LTMR64H Bit Fields */
+#define PIT_LTMR64H_LTH_MASK                     0xFFFFFFFFu
+#define PIT_LTMR64H_LTH_SHIFT                    0
+#define PIT_LTMR64H_LTH(x)                       (((uint32_t)(((uint32_t)(x))<<PIT_LTMR64H_LTH_SHIFT))&PIT_LTMR64H_LTH_MASK)
+/* LTMR64L Bit Fields */
+#define PIT_LTMR64L_LTL_MASK                     0xFFFFFFFFu
+#define PIT_LTMR64L_LTL_SHIFT                    0
+#define PIT_LTMR64L_LTL(x)                       (((uint32_t)(((uint32_t)(x))<<PIT_LTMR64L_LTL_SHIFT))&PIT_LTMR64L_LTL_MASK)
+/* LDVAL Bit Fields */
+#define PIT_LDVAL_TSV_MASK                       0xFFFFFFFFu
+#define PIT_LDVAL_TSV_SHIFT                      0
+#define PIT_LDVAL_TSV(x)                         (((uint32_t)(((uint32_t)(x))<<PIT_LDVAL_TSV_SHIFT))&PIT_LDVAL_TSV_MASK)
+/* CVAL Bit Fields */
+#define PIT_CVAL_TVL_MASK                        0xFFFFFFFFu
+#define PIT_CVAL_TVL_SHIFT                       0
+#define PIT_CVAL_TVL(x)                          (((uint32_t)(((uint32_t)(x))<<PIT_CVAL_TVL_SHIFT))&PIT_CVAL_TVL_MASK)
+/* TCTRL Bit Fields */
+#define PIT_TCTRL_TEN_MASK                       0x1u
+#define PIT_TCTRL_TEN_SHIFT                      0
+#define PIT_TCTRL_TIE_MASK                       0x2u
+#define PIT_TCTRL_TIE_SHIFT                      1
+#define PIT_TCTRL_CHN_MASK                       0x4u
+#define PIT_TCTRL_CHN_SHIFT                      2
+/* TFLG Bit Fields */
+#define PIT_TFLG_TIF_MASK                        0x1u
+#define PIT_TFLG_TIF_SHIFT                       0
+
+/*!
+ * @}
+ */ /* end of group PIT_Register_Masks */
+
+
+/* PIT - Peripheral instance base addresses */
+/** Peripheral PIT base address */
+#define PIT_BASE                                 (0x40037000u)
+/** Peripheral PIT base pointer */
+#define PIT                                      ((PIT_Type *)PIT_BASE)
+#define PIT_BASE_PTR                             (PIT)
+/** Array initializer of PIT peripheral base addresses */
+#define PIT_BASE_ADDRS                           { PIT_BASE }
+/** Array initializer of PIT peripheral base pointers */
+#define PIT_BASE_PTRS                            { PIT }
+/** Interrupt vectors for the PIT peripheral type */
+#define PIT_IRQS                                 { PIT_IRQn, PIT_IRQn, PIT_IRQn, PIT_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- PIT - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PIT_Register_Accessor_Macros PIT - Register accessor macros
+ * @{
+ */
+
+
+/* PIT - Register instance definitions */
+/* PIT */
+#define PIT_MCR                                  PIT_MCR_REG(PIT)
+#define PIT_LTMR64H                              PIT_LTMR64H_REG(PIT)
+#define PIT_LTMR64L                              PIT_LTMR64L_REG(PIT)
+#define PIT_LDVAL0                               PIT_LDVAL_REG(PIT,0)
+#define PIT_CVAL0                                PIT_CVAL_REG(PIT,0)
+#define PIT_TCTRL0                               PIT_TCTRL_REG(PIT,0)
+#define PIT_TFLG0                                PIT_TFLG_REG(PIT,0)
+#define PIT_LDVAL1                               PIT_LDVAL_REG(PIT,1)
+#define PIT_CVAL1                                PIT_CVAL_REG(PIT,1)
+#define PIT_TCTRL1                               PIT_TCTRL_REG(PIT,1)
+#define PIT_TFLG1                                PIT_TFLG_REG(PIT,1)
+
+/* PIT - Register array accessors */
+#define PIT_LDVAL(index)                         PIT_LDVAL_REG(PIT,index)
+#define PIT_CVAL(index)                          PIT_CVAL_REG(PIT,index)
+#define PIT_TCTRL(index)                         PIT_TCTRL_REG(PIT,index)
+#define PIT_TFLG(index)                          PIT_TFLG_REG(PIT,index)
+
+/*!
+ * @}
+ */ /* end of group PIT_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group PIT_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- PMC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PMC_Peripheral_Access_Layer PMC Peripheral Access Layer
+ * @{
+ */
+
+/** PMC - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t LVDSC1;                             /**< Low Voltage Detect Status And Control 1 register, offset: 0x0 */
+  __IO uint8_t LVDSC2;                             /**< Low Voltage Detect Status And Control 2 register, offset: 0x1 */
+  __IO uint8_t REGSC;                              /**< Regulator Status And Control register, offset: 0x2 */
+} PMC_Type, *PMC_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- PMC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PMC_Register_Accessor_Macros PMC - Register accessor macros
+ * @{
+ */
+
+
+/* PMC - Register accessors */
+#define PMC_LVDSC1_REG(base)                     ((base)->LVDSC1)
+#define PMC_LVDSC2_REG(base)                     ((base)->LVDSC2)
+#define PMC_REGSC_REG(base)                      ((base)->REGSC)
+
+/*!
+ * @}
+ */ /* end of group PMC_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- PMC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PMC_Register_Masks PMC Register Masks
+ * @{
+ */
+
+/* LVDSC1 Bit Fields */
+#define PMC_LVDSC1_LVDV_MASK                     0x3u
+#define PMC_LVDSC1_LVDV_SHIFT                    0
+#define PMC_LVDSC1_LVDV(x)                       (((uint8_t)(((uint8_t)(x))<<PMC_LVDSC1_LVDV_SHIFT))&PMC_LVDSC1_LVDV_MASK)
+#define PMC_LVDSC1_LVDRE_MASK                    0x10u
+#define PMC_LVDSC1_LVDRE_SHIFT                   4
+#define PMC_LVDSC1_LVDIE_MASK                    0x20u
+#define PMC_LVDSC1_LVDIE_SHIFT                   5
+#define PMC_LVDSC1_LVDACK_MASK                   0x40u
+#define PMC_LVDSC1_LVDACK_SHIFT                  6
+#define PMC_LVDSC1_LVDF_MASK                     0x80u
+#define PMC_LVDSC1_LVDF_SHIFT                    7
+/* LVDSC2 Bit Fields */
+#define PMC_LVDSC2_LVWV_MASK                     0x3u
+#define PMC_LVDSC2_LVWV_SHIFT                    0
+#define PMC_LVDSC2_LVWV(x)                       (((uint8_t)(((uint8_t)(x))<<PMC_LVDSC2_LVWV_SHIFT))&PMC_LVDSC2_LVWV_MASK)
+#define PMC_LVDSC2_LVWIE_MASK                    0x20u
+#define PMC_LVDSC2_LVWIE_SHIFT                   5
+#define PMC_LVDSC2_LVWACK_MASK                   0x40u
+#define PMC_LVDSC2_LVWACK_SHIFT                  6
+#define PMC_LVDSC2_LVWF_MASK                     0x80u
+#define PMC_LVDSC2_LVWF_SHIFT                    7
+/* REGSC Bit Fields */
+#define PMC_REGSC_BGBE_MASK                      0x1u
+#define PMC_REGSC_BGBE_SHIFT                     0
+#define PMC_REGSC_REGONS_MASK                    0x4u
+#define PMC_REGSC_REGONS_SHIFT                   2
+#define PMC_REGSC_ACKISO_MASK                    0x8u
+#define PMC_REGSC_ACKISO_SHIFT                   3
+#define PMC_REGSC_BGEN_MASK                      0x10u
+#define PMC_REGSC_BGEN_SHIFT                     4
+
+/*!
+ * @}
+ */ /* end of group PMC_Register_Masks */
+
+
+/* PMC - Peripheral instance base addresses */
+/** Peripheral PMC base address */
+#define PMC_BASE                                 (0x4007D000u)
+/** Peripheral PMC base pointer */
+#define PMC                                      ((PMC_Type *)PMC_BASE)
+#define PMC_BASE_PTR                             (PMC)
+/** Array initializer of PMC peripheral base addresses */
+#define PMC_BASE_ADDRS                           { PMC_BASE }
+/** Array initializer of PMC peripheral base pointers */
+#define PMC_BASE_PTRS                            { PMC }
+/** Interrupt vectors for the PMC peripheral type */
+#define PMC_IRQS                                 { LVD_LVW_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- PMC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PMC_Register_Accessor_Macros PMC - Register accessor macros
+ * @{
+ */
+
+
+/* PMC - Register instance definitions */
+/* PMC */
+#define PMC_LVDSC1                               PMC_LVDSC1_REG(PMC)
+#define PMC_LVDSC2                               PMC_LVDSC2_REG(PMC)
+#define PMC_REGSC                                PMC_REGSC_REG(PMC)
+
+/*!
+ * @}
+ */ /* end of group PMC_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group PMC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- PORT Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PORT_Peripheral_Access_Layer PORT Peripheral Access Layer
+ * @{
+ */
+
+/** PORT - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t PCR[32];                           /**< Pin Control Register n, array offset: 0x0, array step: 0x4 */
+  __O  uint32_t GPCLR;                             /**< Global Pin Control Low Register, offset: 0x80 */
+  __O  uint32_t GPCHR;                             /**< Global Pin Control High Register, offset: 0x84 */
+       uint8_t RESERVED_0[24];
+  __IO uint32_t ISFR;                              /**< Interrupt Status Flag Register, offset: 0xA0 */
+} PORT_Type, *PORT_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- PORT - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PORT_Register_Accessor_Macros PORT - Register accessor macros
+ * @{
+ */
+
+
+/* PORT - Register accessors */
+#define PORT_PCR_REG(base,index)                 ((base)->PCR[index])
+#define PORT_GPCLR_REG(base)                     ((base)->GPCLR)
+#define PORT_GPCHR_REG(base)                     ((base)->GPCHR)
+#define PORT_ISFR_REG(base)                      ((base)->ISFR)
+
+/*!
+ * @}
+ */ /* end of group PORT_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- PORT Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PORT_Register_Masks PORT Register Masks
+ * @{
+ */
+
+/* PCR Bit Fields */
+#define PORT_PCR_PS_MASK                         0x1u
+#define PORT_PCR_PS_SHIFT                        0
+#define PORT_PCR_PE_MASK                         0x2u
+#define PORT_PCR_PE_SHIFT                        1
+#define PORT_PCR_SRE_MASK                        0x4u
+#define PORT_PCR_SRE_SHIFT                       2
+#define PORT_PCR_PFE_MASK                        0x10u
+#define PORT_PCR_PFE_SHIFT                       4
+#define PORT_PCR_DSE_MASK                        0x40u
+#define PORT_PCR_DSE_SHIFT                       6
+#define PORT_PCR_MUX_MASK                        0x700u
+#define PORT_PCR_MUX_SHIFT                       8
+#define PORT_PCR_MUX(x)                          (((uint32_t)(((uint32_t)(x))<<PORT_PCR_MUX_SHIFT))&PORT_PCR_MUX_MASK)
+#define PORT_PCR_IRQC_MASK                       0xF0000u
+#define PORT_PCR_IRQC_SHIFT                      16
+#define PORT_PCR_IRQC(x)                         (((uint32_t)(((uint32_t)(x))<<PORT_PCR_IRQC_SHIFT))&PORT_PCR_IRQC_MASK)
+#define PORT_PCR_ISF_MASK                        0x1000000u
+#define PORT_PCR_ISF_SHIFT                       24
+/* GPCLR Bit Fields */
+#define PORT_GPCLR_GPWD_MASK                     0xFFFFu
+#define PORT_GPCLR_GPWD_SHIFT                    0
+#define PORT_GPCLR_GPWD(x)                       (((uint32_t)(((uint32_t)(x))<<PORT_GPCLR_GPWD_SHIFT))&PORT_GPCLR_GPWD_MASK)
+#define PORT_GPCLR_GPWE_MASK                     0xFFFF0000u
+#define PORT_GPCLR_GPWE_SHIFT                    16
+#define PORT_GPCLR_GPWE(x)                       (((uint32_t)(((uint32_t)(x))<<PORT_GPCLR_GPWE_SHIFT))&PORT_GPCLR_GPWE_MASK)
+/* GPCHR Bit Fields */
+#define PORT_GPCHR_GPWD_MASK                     0xFFFFu
+#define PORT_GPCHR_GPWD_SHIFT                    0
+#define PORT_GPCHR_GPWD(x)                       (((uint32_t)(((uint32_t)(x))<<PORT_GPCHR_GPWD_SHIFT))&PORT_GPCHR_GPWD_MASK)
+#define PORT_GPCHR_GPWE_MASK                     0xFFFF0000u
+#define PORT_GPCHR_GPWE_SHIFT                    16
+#define PORT_GPCHR_GPWE(x)                       (((uint32_t)(((uint32_t)(x))<<PORT_GPCHR_GPWE_SHIFT))&PORT_GPCHR_GPWE_MASK)
+/* ISFR Bit Fields */
+#define PORT_ISFR_ISF_MASK                       0xFFFFFFFFu
+#define PORT_ISFR_ISF_SHIFT                      0
+#define PORT_ISFR_ISF(x)                         (((uint32_t)(((uint32_t)(x))<<PORT_ISFR_ISF_SHIFT))&PORT_ISFR_ISF_MASK)
+
+/*!
+ * @}
+ */ /* end of group PORT_Register_Masks */
+
+
+/* PORT - Peripheral instance base addresses */
+/** Peripheral PORTA base address */
+#define PORTA_BASE                               (0x40049000u)
+/** Peripheral PORTA base pointer */
+#define PORTA                                    ((PORT_Type *)PORTA_BASE)
+#define PORTA_BASE_PTR                           (PORTA)
+/** Peripheral PORTB base address */
+#define PORTB_BASE                               (0x4004A000u)
+/** Peripheral PORTB base pointer */
+#define PORTB                                    ((PORT_Type *)PORTB_BASE)
+#define PORTB_BASE_PTR                           (PORTB)
+/** Peripheral PORTC base address */
+#define PORTC_BASE                               (0x4004B000u)
+/** Peripheral PORTC base pointer */
+#define PORTC                                    ((PORT_Type *)PORTC_BASE)
+#define PORTC_BASE_PTR                           (PORTC)
+/** Peripheral PORTD base address */
+#define PORTD_BASE                               (0x4004C000u)
+/** Peripheral PORTD base pointer */
+#define PORTD                                    ((PORT_Type *)PORTD_BASE)
+#define PORTD_BASE_PTR                           (PORTD)
+/** Peripheral PORTE base address */
+#define PORTE_BASE                               (0x4004D000u)
+/** Peripheral PORTE base pointer */
+#define PORTE                                    ((PORT_Type *)PORTE_BASE)
+#define PORTE_BASE_PTR                           (PORTE)
+/** Array initializer of PORT peripheral base addresses */
+#define PORT_BASE_ADDRS                          { PORTA_BASE, PORTB_BASE, PORTC_BASE, PORTD_BASE, PORTE_BASE }
+/** Array initializer of PORT peripheral base pointers */
+#define PORT_BASE_PTRS                           { PORTA, PORTB, PORTC, PORTD, PORTE }
+/** Interrupt vectors for the PORT peripheral type */
+#define PORT_IRQS                                { PORTA_IRQn, NotAvail_IRQn, PORTC_PORTD_IRQn, PORTC_PORTD_IRQn, NotAvail_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- PORT - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PORT_Register_Accessor_Macros PORT - Register accessor macros
+ * @{
+ */
+
+
+/* PORT - Register instance definitions */
+/* PORTA */
+#define PORTA_PCR0                               PORT_PCR_REG(PORTA,0)
+#define PORTA_PCR1                               PORT_PCR_REG(PORTA,1)
+#define PORTA_PCR2                               PORT_PCR_REG(PORTA,2)
+#define PORTA_PCR3                               PORT_PCR_REG(PORTA,3)
+#define PORTA_PCR4                               PORT_PCR_REG(PORTA,4)
+#define PORTA_PCR5                               PORT_PCR_REG(PORTA,5)
+#define PORTA_PCR6                               PORT_PCR_REG(PORTA,6)
+#define PORTA_PCR7                               PORT_PCR_REG(PORTA,7)
+#define PORTA_PCR8                               PORT_PCR_REG(PORTA,8)
+#define PORTA_PCR9                               PORT_PCR_REG(PORTA,9)
+#define PORTA_PCR10                              PORT_PCR_REG(PORTA,10)
+#define PORTA_PCR11                              PORT_PCR_REG(PORTA,11)
+#define PORTA_PCR12                              PORT_PCR_REG(PORTA,12)
+#define PORTA_PCR13                              PORT_PCR_REG(PORTA,13)
+#define PORTA_PCR14                              PORT_PCR_REG(PORTA,14)
+#define PORTA_PCR15                              PORT_PCR_REG(PORTA,15)
+#define PORTA_PCR16                              PORT_PCR_REG(PORTA,16)
+#define PORTA_PCR17                              PORT_PCR_REG(PORTA,17)
+#define PORTA_PCR18                              PORT_PCR_REG(PORTA,18)
+#define PORTA_PCR19                              PORT_PCR_REG(PORTA,19)
+#define PORTA_PCR20                              PORT_PCR_REG(PORTA,20)
+#define PORTA_PCR21                              PORT_PCR_REG(PORTA,21)
+#define PORTA_PCR22                              PORT_PCR_REG(PORTA,22)
+#define PORTA_PCR23                              PORT_PCR_REG(PORTA,23)
+#define PORTA_PCR24                              PORT_PCR_REG(PORTA,24)
+#define PORTA_PCR25                              PORT_PCR_REG(PORTA,25)
+#define PORTA_PCR26                              PORT_PCR_REG(PORTA,26)
+#define PORTA_PCR27                              PORT_PCR_REG(PORTA,27)
+#define PORTA_PCR28                              PORT_PCR_REG(PORTA,28)
+#define PORTA_PCR29                              PORT_PCR_REG(PORTA,29)
+#define PORTA_PCR30                              PORT_PCR_REG(PORTA,30)
+#define PORTA_PCR31                              PORT_PCR_REG(PORTA,31)
+#define PORTA_GPCLR                              PORT_GPCLR_REG(PORTA)
+#define PORTA_GPCHR                              PORT_GPCHR_REG(PORTA)
+#define PORTA_ISFR                               PORT_ISFR_REG(PORTA)
+/* PORTB */
+#define PORTB_PCR0                               PORT_PCR_REG(PORTB,0)
+#define PORTB_PCR1                               PORT_PCR_REG(PORTB,1)
+#define PORTB_PCR2                               PORT_PCR_REG(PORTB,2)
+#define PORTB_PCR3                               PORT_PCR_REG(PORTB,3)
+#define PORTB_PCR4                               PORT_PCR_REG(PORTB,4)
+#define PORTB_PCR5                               PORT_PCR_REG(PORTB,5)
+#define PORTB_PCR6                               PORT_PCR_REG(PORTB,6)
+#define PORTB_PCR7                               PORT_PCR_REG(PORTB,7)
+#define PORTB_PCR8                               PORT_PCR_REG(PORTB,8)
+#define PORTB_PCR9                               PORT_PCR_REG(PORTB,9)
+#define PORTB_PCR10                              PORT_PCR_REG(PORTB,10)
+#define PORTB_PCR11                              PORT_PCR_REG(PORTB,11)
+#define PORTB_PCR12                              PORT_PCR_REG(PORTB,12)
+#define PORTB_PCR13                              PORT_PCR_REG(PORTB,13)
+#define PORTB_PCR14                              PORT_PCR_REG(PORTB,14)
+#define PORTB_PCR15                              PORT_PCR_REG(PORTB,15)
+#define PORTB_PCR16                              PORT_PCR_REG(PORTB,16)
+#define PORTB_PCR17                              PORT_PCR_REG(PORTB,17)
+#define PORTB_PCR18                              PORT_PCR_REG(PORTB,18)
+#define PORTB_PCR19                              PORT_PCR_REG(PORTB,19)
+#define PORTB_PCR20                              PORT_PCR_REG(PORTB,20)
+#define PORTB_PCR21                              PORT_PCR_REG(PORTB,21)
+#define PORTB_PCR22                              PORT_PCR_REG(PORTB,22)
+#define PORTB_PCR23                              PORT_PCR_REG(PORTB,23)
+#define PORTB_PCR24                              PORT_PCR_REG(PORTB,24)
+#define PORTB_PCR25                              PORT_PCR_REG(PORTB,25)
+#define PORTB_PCR26                              PORT_PCR_REG(PORTB,26)
+#define PORTB_PCR27                              PORT_PCR_REG(PORTB,27)
+#define PORTB_PCR28                              PORT_PCR_REG(PORTB,28)
+#define PORTB_PCR29                              PORT_PCR_REG(PORTB,29)
+#define PORTB_PCR30                              PORT_PCR_REG(PORTB,30)
+#define PORTB_PCR31                              PORT_PCR_REG(PORTB,31)
+#define PORTB_GPCLR                              PORT_GPCLR_REG(PORTB)
+#define PORTB_GPCHR                              PORT_GPCHR_REG(PORTB)
+#define PORTB_ISFR                               PORT_ISFR_REG(PORTB)
+/* PORTC */
+#define PORTC_PCR0                               PORT_PCR_REG(PORTC,0)
+#define PORTC_PCR1                               PORT_PCR_REG(PORTC,1)
+#define PORTC_PCR2                               PORT_PCR_REG(PORTC,2)
+#define PORTC_PCR3                               PORT_PCR_REG(PORTC,3)
+#define PORTC_PCR4                               PORT_PCR_REG(PORTC,4)
+#define PORTC_PCR5                               PORT_PCR_REG(PORTC,5)
+#define PORTC_PCR6                               PORT_PCR_REG(PORTC,6)
+#define PORTC_PCR7                               PORT_PCR_REG(PORTC,7)
+#define PORTC_PCR8                               PORT_PCR_REG(PORTC,8)
+#define PORTC_PCR9                               PORT_PCR_REG(PORTC,9)
+#define PORTC_PCR10                              PORT_PCR_REG(PORTC,10)
+#define PORTC_PCR11                              PORT_PCR_REG(PORTC,11)
+#define PORTC_PCR12                              PORT_PCR_REG(PORTC,12)
+#define PORTC_PCR13                              PORT_PCR_REG(PORTC,13)
+#define PORTC_PCR14                              PORT_PCR_REG(PORTC,14)
+#define PORTC_PCR15                              PORT_PCR_REG(PORTC,15)
+#define PORTC_PCR16                              PORT_PCR_REG(PORTC,16)
+#define PORTC_PCR17                              PORT_PCR_REG(PORTC,17)
+#define PORTC_PCR18                              PORT_PCR_REG(PORTC,18)
+#define PORTC_PCR19                              PORT_PCR_REG(PORTC,19)
+#define PORTC_PCR20                              PORT_PCR_REG(PORTC,20)
+#define PORTC_PCR21                              PORT_PCR_REG(PORTC,21)
+#define PORTC_PCR22                              PORT_PCR_REG(PORTC,22)
+#define PORTC_PCR23                              PORT_PCR_REG(PORTC,23)
+#define PORTC_PCR24                              PORT_PCR_REG(PORTC,24)
+#define PORTC_PCR25                              PORT_PCR_REG(PORTC,25)
+#define PORTC_PCR26                              PORT_PCR_REG(PORTC,26)
+#define PORTC_PCR27                              PORT_PCR_REG(PORTC,27)
+#define PORTC_PCR28                              PORT_PCR_REG(PORTC,28)
+#define PORTC_PCR29                              PORT_PCR_REG(PORTC,29)
+#define PORTC_PCR30                              PORT_PCR_REG(PORTC,30)
+#define PORTC_PCR31                              PORT_PCR_REG(PORTC,31)
+#define PORTC_GPCLR                              PORT_GPCLR_REG(PORTC)
+#define PORTC_GPCHR                              PORT_GPCHR_REG(PORTC)
+#define PORTC_ISFR                               PORT_ISFR_REG(PORTC)
+/* PORTD */
+#define PORTD_PCR0                               PORT_PCR_REG(PORTD,0)
+#define PORTD_PCR1                               PORT_PCR_REG(PORTD,1)
+#define PORTD_PCR2                               PORT_PCR_REG(PORTD,2)
+#define PORTD_PCR3                               PORT_PCR_REG(PORTD,3)
+#define PORTD_PCR4                               PORT_PCR_REG(PORTD,4)
+#define PORTD_PCR5                               PORT_PCR_REG(PORTD,5)
+#define PORTD_PCR6                               PORT_PCR_REG(PORTD,6)
+#define PORTD_PCR7                               PORT_PCR_REG(PORTD,7)
+#define PORTD_PCR8                               PORT_PCR_REG(PORTD,8)
+#define PORTD_PCR9                               PORT_PCR_REG(PORTD,9)
+#define PORTD_PCR10                              PORT_PCR_REG(PORTD,10)
+#define PORTD_PCR11                              PORT_PCR_REG(PORTD,11)
+#define PORTD_PCR12                              PORT_PCR_REG(PORTD,12)
+#define PORTD_PCR13                              PORT_PCR_REG(PORTD,13)
+#define PORTD_PCR14                              PORT_PCR_REG(PORTD,14)
+#define PORTD_PCR15                              PORT_PCR_REG(PORTD,15)
+#define PORTD_PCR16                              PORT_PCR_REG(PORTD,16)
+#define PORTD_PCR17                              PORT_PCR_REG(PORTD,17)
+#define PORTD_PCR18                              PORT_PCR_REG(PORTD,18)
+#define PORTD_PCR19                              PORT_PCR_REG(PORTD,19)
+#define PORTD_PCR20                              PORT_PCR_REG(PORTD,20)
+#define PORTD_PCR21                              PORT_PCR_REG(PORTD,21)
+#define PORTD_PCR22                              PORT_PCR_REG(PORTD,22)
+#define PORTD_PCR23                              PORT_PCR_REG(PORTD,23)
+#define PORTD_PCR24                              PORT_PCR_REG(PORTD,24)
+#define PORTD_PCR25                              PORT_PCR_REG(PORTD,25)
+#define PORTD_PCR26                              PORT_PCR_REG(PORTD,26)
+#define PORTD_PCR27                              PORT_PCR_REG(PORTD,27)
+#define PORTD_PCR28                              PORT_PCR_REG(PORTD,28)
+#define PORTD_PCR29                              PORT_PCR_REG(PORTD,29)
+#define PORTD_PCR30                              PORT_PCR_REG(PORTD,30)
+#define PORTD_PCR31                              PORT_PCR_REG(PORTD,31)
+#define PORTD_GPCLR                              PORT_GPCLR_REG(PORTD)
+#define PORTD_GPCHR                              PORT_GPCHR_REG(PORTD)
+#define PORTD_ISFR                               PORT_ISFR_REG(PORTD)
+/* PORTE */
+#define PORTE_PCR0                               PORT_PCR_REG(PORTE,0)
+#define PORTE_PCR1                               PORT_PCR_REG(PORTE,1)
+#define PORTE_PCR2                               PORT_PCR_REG(PORTE,2)
+#define PORTE_PCR3                               PORT_PCR_REG(PORTE,3)
+#define PORTE_PCR4                               PORT_PCR_REG(PORTE,4)
+#define PORTE_PCR5                               PORT_PCR_REG(PORTE,5)
+#define PORTE_PCR6                               PORT_PCR_REG(PORTE,6)
+#define PORTE_PCR7                               PORT_PCR_REG(PORTE,7)
+#define PORTE_PCR8                               PORT_PCR_REG(PORTE,8)
+#define PORTE_PCR9                               PORT_PCR_REG(PORTE,9)
+#define PORTE_PCR10                              PORT_PCR_REG(PORTE,10)
+#define PORTE_PCR11                              PORT_PCR_REG(PORTE,11)
+#define PORTE_PCR12                              PORT_PCR_REG(PORTE,12)
+#define PORTE_PCR13                              PORT_PCR_REG(PORTE,13)
+#define PORTE_PCR14                              PORT_PCR_REG(PORTE,14)
+#define PORTE_PCR15                              PORT_PCR_REG(PORTE,15)
+#define PORTE_PCR16                              PORT_PCR_REG(PORTE,16)
+#define PORTE_PCR17                              PORT_PCR_REG(PORTE,17)
+#define PORTE_PCR18                              PORT_PCR_REG(PORTE,18)
+#define PORTE_PCR19                              PORT_PCR_REG(PORTE,19)
+#define PORTE_PCR20                              PORT_PCR_REG(PORTE,20)
+#define PORTE_PCR21                              PORT_PCR_REG(PORTE,21)
+#define PORTE_PCR22                              PORT_PCR_REG(PORTE,22)
+#define PORTE_PCR23                              PORT_PCR_REG(PORTE,23)
+#define PORTE_PCR24                              PORT_PCR_REG(PORTE,24)
+#define PORTE_PCR25                              PORT_PCR_REG(PORTE,25)
+#define PORTE_PCR26                              PORT_PCR_REG(PORTE,26)
+#define PORTE_PCR27                              PORT_PCR_REG(PORTE,27)
+#define PORTE_PCR28                              PORT_PCR_REG(PORTE,28)
+#define PORTE_PCR29                              PORT_PCR_REG(PORTE,29)
+#define PORTE_PCR30                              PORT_PCR_REG(PORTE,30)
+#define PORTE_PCR31                              PORT_PCR_REG(PORTE,31)
+#define PORTE_GPCLR                              PORT_GPCLR_REG(PORTE)
+#define PORTE_GPCHR                              PORT_GPCHR_REG(PORTE)
+#define PORTE_ISFR                               PORT_ISFR_REG(PORTE)
+
+/* PORT - Register array accessors */
+#define PORTA_PCR(index)                         PORT_PCR_REG(PORTA,index)
+#define PORTB_PCR(index)                         PORT_PCR_REG(PORTB,index)
+#define PORTC_PCR(index)                         PORT_PCR_REG(PORTC,index)
+#define PORTD_PCR(index)                         PORT_PCR_REG(PORTD,index)
+#define PORTE_PCR(index)                         PORT_PCR_REG(PORTE,index)
+
+/*!
+ * @}
+ */ /* end of group PORT_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group PORT_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- RCM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RCM_Peripheral_Access_Layer RCM Peripheral Access Layer
+ * @{
+ */
+
+/** RCM - Register Layout Typedef */
+typedef struct {
+  __I  uint8_t SRS0;                               /**< System Reset Status Register 0, offset: 0x0 */
+  __I  uint8_t SRS1;                               /**< System Reset Status Register 1, offset: 0x1 */
+       uint8_t RESERVED_0[2];
+  __IO uint8_t RPFC;                               /**< Reset Pin Filter Control register, offset: 0x4 */
+  __IO uint8_t RPFW;                               /**< Reset Pin Filter Width register, offset: 0x5 */
+} RCM_Type, *RCM_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- RCM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RCM_Register_Accessor_Macros RCM - Register accessor macros
+ * @{
+ */
+
+
+/* RCM - Register accessors */
+#define RCM_SRS0_REG(base)                       ((base)->SRS0)
+#define RCM_SRS1_REG(base)                       ((base)->SRS1)
+#define RCM_RPFC_REG(base)                       ((base)->RPFC)
+#define RCM_RPFW_REG(base)                       ((base)->RPFW)
+
+/*!
+ * @}
+ */ /* end of group RCM_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- RCM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RCM_Register_Masks RCM Register Masks
+ * @{
+ */
+
+/* SRS0 Bit Fields */
+#define RCM_SRS0_WAKEUP_MASK                     0x1u
+#define RCM_SRS0_WAKEUP_SHIFT                    0
+#define RCM_SRS0_LVD_MASK                        0x2u
+#define RCM_SRS0_LVD_SHIFT                       1
+#define RCM_SRS0_LOC_MASK                        0x4u
+#define RCM_SRS0_LOC_SHIFT                       2
+#define RCM_SRS0_LOL_MASK                        0x8u
+#define RCM_SRS0_LOL_SHIFT                       3
+#define RCM_SRS0_WDOG_MASK                       0x20u
+#define RCM_SRS0_WDOG_SHIFT                      5
+#define RCM_SRS0_PIN_MASK                        0x40u
+#define RCM_SRS0_PIN_SHIFT                       6
+#define RCM_SRS0_POR_MASK                        0x80u
+#define RCM_SRS0_POR_SHIFT                       7
+/* SRS1 Bit Fields */
+#define RCM_SRS1_LOCKUP_MASK                     0x2u
+#define RCM_SRS1_LOCKUP_SHIFT                    1
+#define RCM_SRS1_SW_MASK                         0x4u
+#define RCM_SRS1_SW_SHIFT                        2
+#define RCM_SRS1_MDM_AP_MASK                     0x8u
+#define RCM_SRS1_MDM_AP_SHIFT                    3
+#define RCM_SRS1_SACKERR_MASK                    0x20u
+#define RCM_SRS1_SACKERR_SHIFT                   5
+/* RPFC Bit Fields */
+#define RCM_RPFC_RSTFLTSRW_MASK                  0x3u
+#define RCM_RPFC_RSTFLTSRW_SHIFT                 0
+#define RCM_RPFC_RSTFLTSRW(x)                    (((uint8_t)(((uint8_t)(x))<<RCM_RPFC_RSTFLTSRW_SHIFT))&RCM_RPFC_RSTFLTSRW_MASK)
+#define RCM_RPFC_RSTFLTSS_MASK                   0x4u
+#define RCM_RPFC_RSTFLTSS_SHIFT                  2
+/* RPFW Bit Fields */
+#define RCM_RPFW_RSTFLTSEL_MASK                  0x1Fu
+#define RCM_RPFW_RSTFLTSEL_SHIFT                 0
+#define RCM_RPFW_RSTFLTSEL(x)                    (((uint8_t)(((uint8_t)(x))<<RCM_RPFW_RSTFLTSEL_SHIFT))&RCM_RPFW_RSTFLTSEL_MASK)
+
+/*!
+ * @}
+ */ /* end of group RCM_Register_Masks */
+
+
+/* RCM - Peripheral instance base addresses */
+/** Peripheral RCM base address */
+#define RCM_BASE                                 (0x4007F000u)
+/** Peripheral RCM base pointer */
+#define RCM                                      ((RCM_Type *)RCM_BASE)
+#define RCM_BASE_PTR                             (RCM)
+/** Array initializer of RCM peripheral base addresses */
+#define RCM_BASE_ADDRS                           { RCM_BASE }
+/** Array initializer of RCM peripheral base pointers */
+#define RCM_BASE_PTRS                            { RCM }
+
+/* ----------------------------------------------------------------------------
+   -- RCM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RCM_Register_Accessor_Macros RCM - Register accessor macros
+ * @{
+ */
+
+
+/* RCM - Register instance definitions */
+/* RCM */
+#define RCM_SRS0                                 RCM_SRS0_REG(RCM)
+#define RCM_SRS1                                 RCM_SRS1_REG(RCM)
+#define RCM_RPFC                                 RCM_RPFC_REG(RCM)
+#define RCM_RPFW                                 RCM_RPFW_REG(RCM)
+
+/*!
+ * @}
+ */ /* end of group RCM_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group RCM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- ROM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ROM_Peripheral_Access_Layer ROM Peripheral Access Layer
+ * @{
+ */
+
+/** ROM - Register Layout Typedef */
+typedef struct {
+  __I  uint32_t ENTRY[3];                          /**< Entry, array offset: 0x0, array step: 0x4 */
+  __I  uint32_t TABLEMARK;                         /**< End of Table Marker Register, offset: 0xC */
+       uint8_t RESERVED_0[4028];
+  __I  uint32_t SYSACCESS;                         /**< System Access Register, offset: 0xFCC */
+  __I  uint32_t PERIPHID4;                         /**< Peripheral ID Register, offset: 0xFD0 */
+  __I  uint32_t PERIPHID5;                         /**< Peripheral ID Register, offset: 0xFD4 */
+  __I  uint32_t PERIPHID6;                         /**< Peripheral ID Register, offset: 0xFD8 */
+  __I  uint32_t PERIPHID7;                         /**< Peripheral ID Register, offset: 0xFDC */
+  __I  uint32_t PERIPHID0;                         /**< Peripheral ID Register, offset: 0xFE0 */
+  __I  uint32_t PERIPHID1;                         /**< Peripheral ID Register, offset: 0xFE4 */
+  __I  uint32_t PERIPHID2;                         /**< Peripheral ID Register, offset: 0xFE8 */
+  __I  uint32_t PERIPHID3;                         /**< Peripheral ID Register, offset: 0xFEC */
+  __I  uint32_t COMPID[4];                         /**< Component ID Register, array offset: 0xFF0, array step: 0x4 */
+} ROM_Type, *ROM_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- ROM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ROM_Register_Accessor_Macros ROM - Register accessor macros
+ * @{
+ */
+
+
+/* ROM - Register accessors */
+#define ROM_ENTRY_REG(base,index)                ((base)->ENTRY[index])
+#define ROM_TABLEMARK_REG(base)                  ((base)->TABLEMARK)
+#define ROM_SYSACCESS_REG(base)                  ((base)->SYSACCESS)
+#define ROM_PERIPHID4_REG(base)                  ((base)->PERIPHID4)
+#define ROM_PERIPHID5_REG(base)                  ((base)->PERIPHID5)
+#define ROM_PERIPHID6_REG(base)                  ((base)->PERIPHID6)
+#define ROM_PERIPHID7_REG(base)                  ((base)->PERIPHID7)
+#define ROM_PERIPHID0_REG(base)                  ((base)->PERIPHID0)
+#define ROM_PERIPHID1_REG(base)                  ((base)->PERIPHID1)
+#define ROM_PERIPHID2_REG(base)                  ((base)->PERIPHID2)
+#define ROM_PERIPHID3_REG(base)                  ((base)->PERIPHID3)
+#define ROM_COMPID_REG(base,index)               ((base)->COMPID[index])
+
+/*!
+ * @}
+ */ /* end of group ROM_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- ROM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ROM_Register_Masks ROM Register Masks
+ * @{
+ */
+
+/* ENTRY Bit Fields */
+#define ROM_ENTRY_ENTRY_MASK                     0xFFFFFFFFu
+#define ROM_ENTRY_ENTRY_SHIFT                    0
+#define ROM_ENTRY_ENTRY(x)                       (((uint32_t)(((uint32_t)(x))<<ROM_ENTRY_ENTRY_SHIFT))&ROM_ENTRY_ENTRY_MASK)
+/* TABLEMARK Bit Fields */
+#define ROM_TABLEMARK_MARK_MASK                  0xFFFFFFFFu
+#define ROM_TABLEMARK_MARK_SHIFT                 0
+#define ROM_TABLEMARK_MARK(x)                    (((uint32_t)(((uint32_t)(x))<<ROM_TABLEMARK_MARK_SHIFT))&ROM_TABLEMARK_MARK_MASK)
+/* SYSACCESS Bit Fields */
+#define ROM_SYSACCESS_SYSACCESS_MASK             0xFFFFFFFFu
+#define ROM_SYSACCESS_SYSACCESS_SHIFT            0
+#define ROM_SYSACCESS_SYSACCESS(x)               (((uint32_t)(((uint32_t)(x))<<ROM_SYSACCESS_SYSACCESS_SHIFT))&ROM_SYSACCESS_SYSACCESS_MASK)
+/* PERIPHID4 Bit Fields */
+#define ROM_PERIPHID4_PERIPHID_MASK              0xFFFFFFFFu
+#define ROM_PERIPHID4_PERIPHID_SHIFT             0
+#define ROM_PERIPHID4_PERIPHID(x)                (((uint32_t)(((uint32_t)(x))<<ROM_PERIPHID4_PERIPHID_SHIFT))&ROM_PERIPHID4_PERIPHID_MASK)
+/* PERIPHID5 Bit Fields */
+#define ROM_PERIPHID5_PERIPHID_MASK              0xFFFFFFFFu
+#define ROM_PERIPHID5_PERIPHID_SHIFT             0
+#define ROM_PERIPHID5_PERIPHID(x)                (((uint32_t)(((uint32_t)(x))<<ROM_PERIPHID5_PERIPHID_SHIFT))&ROM_PERIPHID5_PERIPHID_MASK)
+/* PERIPHID6 Bit Fields */
+#define ROM_PERIPHID6_PERIPHID_MASK              0xFFFFFFFFu
+#define ROM_PERIPHID6_PERIPHID_SHIFT             0
+#define ROM_PERIPHID6_PERIPHID(x)                (((uint32_t)(((uint32_t)(x))<<ROM_PERIPHID6_PERIPHID_SHIFT))&ROM_PERIPHID6_PERIPHID_MASK)
+/* PERIPHID7 Bit Fields */
+#define ROM_PERIPHID7_PERIPHID_MASK              0xFFFFFFFFu
+#define ROM_PERIPHID7_PERIPHID_SHIFT             0
+#define ROM_PERIPHID7_PERIPHID(x)                (((uint32_t)(((uint32_t)(x))<<ROM_PERIPHID7_PERIPHID_SHIFT))&ROM_PERIPHID7_PERIPHID_MASK)
+/* PERIPHID0 Bit Fields */
+#define ROM_PERIPHID0_PERIPHID_MASK              0xFFFFFFFFu
+#define ROM_PERIPHID0_PERIPHID_SHIFT             0
+#define ROM_PERIPHID0_PERIPHID(x)                (((uint32_t)(((uint32_t)(x))<<ROM_PERIPHID0_PERIPHID_SHIFT))&ROM_PERIPHID0_PERIPHID_MASK)
+/* PERIPHID1 Bit Fields */
+#define ROM_PERIPHID1_PERIPHID_MASK              0xFFFFFFFFu
+#define ROM_PERIPHID1_PERIPHID_SHIFT             0
+#define ROM_PERIPHID1_PERIPHID(x)                (((uint32_t)(((uint32_t)(x))<<ROM_PERIPHID1_PERIPHID_SHIFT))&ROM_PERIPHID1_PERIPHID_MASK)
+/* PERIPHID2 Bit Fields */
+#define ROM_PERIPHID2_PERIPHID_MASK              0xFFFFFFFFu
+#define ROM_PERIPHID2_PERIPHID_SHIFT             0
+#define ROM_PERIPHID2_PERIPHID(x)                (((uint32_t)(((uint32_t)(x))<<ROM_PERIPHID2_PERIPHID_SHIFT))&ROM_PERIPHID2_PERIPHID_MASK)
+/* PERIPHID3 Bit Fields */
+#define ROM_PERIPHID3_PERIPHID_MASK              0xFFFFFFFFu
+#define ROM_PERIPHID3_PERIPHID_SHIFT             0
+#define ROM_PERIPHID3_PERIPHID(x)                (((uint32_t)(((uint32_t)(x))<<ROM_PERIPHID3_PERIPHID_SHIFT))&ROM_PERIPHID3_PERIPHID_MASK)
+/* COMPID Bit Fields */
+#define ROM_COMPID_COMPID_MASK                   0xFFFFFFFFu
+#define ROM_COMPID_COMPID_SHIFT                  0
+#define ROM_COMPID_COMPID(x)                     (((uint32_t)(((uint32_t)(x))<<ROM_COMPID_COMPID_SHIFT))&ROM_COMPID_COMPID_MASK)
+
+/*!
+ * @}
+ */ /* end of group ROM_Register_Masks */
+
+
+/* ROM - Peripheral instance base addresses */
+/** Peripheral ROM base address */
+#define ROM_BASE                                 (0xF0002000u)
+/** Peripheral ROM base pointer */
+#define ROM                                      ((ROM_Type *)ROM_BASE)
+#define ROM_BASE_PTR                             (ROM)
+/** Array initializer of ROM peripheral base addresses */
+#define ROM_BASE_ADDRS                           { ROM_BASE }
+/** Array initializer of ROM peripheral base pointers */
+#define ROM_BASE_PTRS                            { ROM }
+
+/* ----------------------------------------------------------------------------
+   -- ROM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ROM_Register_Accessor_Macros ROM - Register accessor macros
+ * @{
+ */
+
+
+/* ROM - Register instance definitions */
+/* ROM */
+#define ROM_ENTRY0                               ROM_ENTRY_REG(ROM,0)
+#define ROM_ENTRY1                               ROM_ENTRY_REG(ROM,1)
+#define ROM_ENTRY2                               ROM_ENTRY_REG(ROM,2)
+#define ROM_TABLEMARK                            ROM_TABLEMARK_REG(ROM)
+#define ROM_SYSACCESS                            ROM_SYSACCESS_REG(ROM)
+#define ROM_PERIPHID4                            ROM_PERIPHID4_REG(ROM)
+#define ROM_PERIPHID5                            ROM_PERIPHID5_REG(ROM)
+#define ROM_PERIPHID6                            ROM_PERIPHID6_REG(ROM)
+#define ROM_PERIPHID7                            ROM_PERIPHID7_REG(ROM)
+#define ROM_PERIPHID0                            ROM_PERIPHID0_REG(ROM)
+#define ROM_PERIPHID1                            ROM_PERIPHID1_REG(ROM)
+#define ROM_PERIPHID2                            ROM_PERIPHID2_REG(ROM)
+#define ROM_PERIPHID3                            ROM_PERIPHID3_REG(ROM)
+#define ROM_COMPID0                              ROM_COMPID_REG(ROM,0)
+#define ROM_COMPID1                              ROM_COMPID_REG(ROM,1)
+#define ROM_COMPID2                              ROM_COMPID_REG(ROM,2)
+#define ROM_COMPID3                              ROM_COMPID_REG(ROM,3)
+
+/* ROM - Register array accessors */
+#define ROM_ENTRY(index)                         ROM_ENTRY_REG(ROM,index)
+#define ROM_COMPID(index)                        ROM_COMPID_REG(ROM,index)
+
+/*!
+ * @}
+ */ /* end of group ROM_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group ROM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- RTC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RTC_Peripheral_Access_Layer RTC Peripheral Access Layer
+ * @{
+ */
+
+/** RTC - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t TSR;                               /**< RTC Time Seconds Register, offset: 0x0 */
+  __IO uint32_t TPR;                               /**< RTC Time Prescaler Register, offset: 0x4 */
+  __IO uint32_t TAR;                               /**< RTC Time Alarm Register, offset: 0x8 */
+  __IO uint32_t TCR;                               /**< RTC Time Compensation Register, offset: 0xC */
+  __IO uint32_t CR;                                /**< RTC Control Register, offset: 0x10 */
+  __IO uint32_t SR;                                /**< RTC Status Register, offset: 0x14 */
+  __IO uint32_t LR;                                /**< RTC Lock Register, offset: 0x18 */
+  __IO uint32_t IER;                               /**< RTC Interrupt Enable Register, offset: 0x1C */
+} RTC_Type, *RTC_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- RTC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RTC_Register_Accessor_Macros RTC - Register accessor macros
+ * @{
+ */
+
+
+/* RTC - Register accessors */
+#define RTC_TSR_REG(base)                        ((base)->TSR)
+#define RTC_TPR_REG(base)                        ((base)->TPR)
+#define RTC_TAR_REG(base)                        ((base)->TAR)
+#define RTC_TCR_REG(base)                        ((base)->TCR)
+#define RTC_CR_REG(base)                         ((base)->CR)
+#define RTC_SR_REG(base)                         ((base)->SR)
+#define RTC_LR_REG(base)                         ((base)->LR)
+#define RTC_IER_REG(base)                        ((base)->IER)
+
+/*!
+ * @}
+ */ /* end of group RTC_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- RTC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RTC_Register_Masks RTC Register Masks
+ * @{
+ */
+
+/* TSR Bit Fields */
+#define RTC_TSR_TSR_MASK                         0xFFFFFFFFu
+#define RTC_TSR_TSR_SHIFT                        0
+#define RTC_TSR_TSR(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TSR_TSR_SHIFT))&RTC_TSR_TSR_MASK)
+/* TPR Bit Fields */
+#define RTC_TPR_TPR_MASK                         0xFFFFu
+#define RTC_TPR_TPR_SHIFT                        0
+#define RTC_TPR_TPR(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TPR_TPR_SHIFT))&RTC_TPR_TPR_MASK)
+/* TAR Bit Fields */
+#define RTC_TAR_TAR_MASK                         0xFFFFFFFFu
+#define RTC_TAR_TAR_SHIFT                        0
+#define RTC_TAR_TAR(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TAR_TAR_SHIFT))&RTC_TAR_TAR_MASK)
+/* TCR Bit Fields */
+#define RTC_TCR_TCR_MASK                         0xFFu
+#define RTC_TCR_TCR_SHIFT                        0
+#define RTC_TCR_TCR(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TCR_TCR_SHIFT))&RTC_TCR_TCR_MASK)
+#define RTC_TCR_CIR_MASK                         0xFF00u
+#define RTC_TCR_CIR_SHIFT                        8
+#define RTC_TCR_CIR(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TCR_CIR_SHIFT))&RTC_TCR_CIR_MASK)
+#define RTC_TCR_TCV_MASK                         0xFF0000u
+#define RTC_TCR_TCV_SHIFT                        16
+#define RTC_TCR_TCV(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TCR_TCV_SHIFT))&RTC_TCR_TCV_MASK)
+#define RTC_TCR_CIC_MASK                         0xFF000000u
+#define RTC_TCR_CIC_SHIFT                        24
+#define RTC_TCR_CIC(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TCR_CIC_SHIFT))&RTC_TCR_CIC_MASK)
+/* CR Bit Fields */
+#define RTC_CR_SWR_MASK                          0x1u
+#define RTC_CR_SWR_SHIFT                         0
+#define RTC_CR_WPE_MASK                          0x2u
+#define RTC_CR_WPE_SHIFT                         1
+#define RTC_CR_SUP_MASK                          0x4u
+#define RTC_CR_SUP_SHIFT                         2
+#define RTC_CR_UM_MASK                           0x8u
+#define RTC_CR_UM_SHIFT                          3
+#define RTC_CR_WPS_MASK                          0x10u
+#define RTC_CR_WPS_SHIFT                         4
+#define RTC_CR_OSCE_MASK                         0x100u
+#define RTC_CR_OSCE_SHIFT                        8
+#define RTC_CR_CLKO_MASK                         0x200u
+#define RTC_CR_CLKO_SHIFT                        9
+#define RTC_CR_SC16P_MASK                        0x400u
+#define RTC_CR_SC16P_SHIFT                       10
+#define RTC_CR_SC8P_MASK                         0x800u
+#define RTC_CR_SC8P_SHIFT                        11
+#define RTC_CR_SC4P_MASK                         0x1000u
+#define RTC_CR_SC4P_SHIFT                        12
+#define RTC_CR_SC2P_MASK                         0x2000u
+#define RTC_CR_SC2P_SHIFT                        13
+/* SR Bit Fields */
+#define RTC_SR_TIF_MASK                          0x1u
+#define RTC_SR_TIF_SHIFT                         0
+#define RTC_SR_TOF_MASK                          0x2u
+#define RTC_SR_TOF_SHIFT                         1
+#define RTC_SR_TAF_MASK                          0x4u
+#define RTC_SR_TAF_SHIFT                         2
+#define RTC_SR_TCE_MASK                          0x10u
+#define RTC_SR_TCE_SHIFT                         4
+/* LR Bit Fields */
+#define RTC_LR_TCL_MASK                          0x8u
+#define RTC_LR_TCL_SHIFT                         3
+#define RTC_LR_CRL_MASK                          0x10u
+#define RTC_LR_CRL_SHIFT                         4
+#define RTC_LR_SRL_MASK                          0x20u
+#define RTC_LR_SRL_SHIFT                         5
+#define RTC_LR_LRL_MASK                          0x40u
+#define RTC_LR_LRL_SHIFT                         6
+/* IER Bit Fields */
+#define RTC_IER_TIIE_MASK                        0x1u
+#define RTC_IER_TIIE_SHIFT                       0
+#define RTC_IER_TOIE_MASK                        0x2u
+#define RTC_IER_TOIE_SHIFT                       1
+#define RTC_IER_TAIE_MASK                        0x4u
+#define RTC_IER_TAIE_SHIFT                       2
+#define RTC_IER_TSIE_MASK                        0x10u
+#define RTC_IER_TSIE_SHIFT                       4
+#define RTC_IER_WPON_MASK                        0x80u
+#define RTC_IER_WPON_SHIFT                       7
+
+/*!
+ * @}
+ */ /* end of group RTC_Register_Masks */
+
+
+/* RTC - Peripheral instance base addresses */
+/** Peripheral RTC base address */
+#define RTC_BASE                                 (0x4003D000u)
+/** Peripheral RTC base pointer */
+#define RTC                                      ((RTC_Type *)RTC_BASE)
+#define RTC_BASE_PTR                             (RTC)
+/** Array initializer of RTC peripheral base addresses */
+#define RTC_BASE_ADDRS                           { RTC_BASE }
+/** Array initializer of RTC peripheral base pointers */
+#define RTC_BASE_PTRS                            { RTC }
+/** Interrupt vectors for the RTC peripheral type */
+#define RTC_IRQS                                 { RTC_IRQn }
+#define RTC_SECONDS_IRQS                         { RTC_Seconds_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- RTC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RTC_Register_Accessor_Macros RTC - Register accessor macros
+ * @{
+ */
+
+
+/* RTC - Register instance definitions */
+/* RTC */
+#define RTC_TSR                                  RTC_TSR_REG(RTC)
+#define RTC_TPR                                  RTC_TPR_REG(RTC)
+#define RTC_TAR                                  RTC_TAR_REG(RTC)
+#define RTC_TCR                                  RTC_TCR_REG(RTC)
+#define RTC_CR                                   RTC_CR_REG(RTC)
+#define RTC_SR                                   RTC_SR_REG(RTC)
+#define RTC_LR                                   RTC_LR_REG(RTC)
+#define RTC_IER                                  RTC_IER_REG(RTC)
+
+/*!
+ * @}
+ */ /* end of group RTC_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group RTC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- SIM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SIM_Peripheral_Access_Layer SIM Peripheral Access Layer
+ * @{
+ */
+
+/** SIM - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t SOPT1;                             /**< System Options Register 1, offset: 0x0 */
+       uint8_t RESERVED_0[4096];
+  __IO uint32_t SOPT2;                             /**< System Options Register 2, offset: 0x1004 */
+       uint8_t RESERVED_1[4];
+  __IO uint32_t SOPT4;                             /**< System Options Register 4, offset: 0x100C */
+  __IO uint32_t SOPT5;                             /**< System Options Register 5, offset: 0x1010 */
+       uint8_t RESERVED_2[4];
+  __IO uint32_t SOPT7;                             /**< System Options Register 7, offset: 0x1018 */
+       uint8_t RESERVED_3[8];
+  __I  uint32_t SDID;                              /**< System Device Identification Register, offset: 0x1024 */
+       uint8_t RESERVED_4[12];
+  __IO uint32_t SCGC4;                             /**< System Clock Gating Control Register 4, offset: 0x1034 */
+  __IO uint32_t SCGC5;                             /**< System Clock Gating Control Register 5, offset: 0x1038 */
+  __IO uint32_t SCGC6;                             /**< System Clock Gating Control Register 6, offset: 0x103C */
+  __IO uint32_t SCGC7;                             /**< System Clock Gating Control Register 7, offset: 0x1040 */
+  __IO uint32_t CLKDIV1;                           /**< System Clock Divider Register 1, offset: 0x1044 */
+       uint8_t RESERVED_5[4];
+  __IO uint32_t FCFG1;                             /**< Flash Configuration Register 1, offset: 0x104C */
+  __I  uint32_t FCFG2;                             /**< Flash Configuration Register 2, offset: 0x1050 */
+       uint8_t RESERVED_6[4];
+  __I  uint32_t UIDMH;                             /**< Unique Identification Register Mid-High, offset: 0x1058 */
+  __I  uint32_t UIDML;                             /**< Unique Identification Register Mid Low, offset: 0x105C */
+  __I  uint32_t UIDL;                              /**< Unique Identification Register Low, offset: 0x1060 */
+       uint8_t RESERVED_7[156];
+  __IO uint32_t COPC;                              /**< COP Control Register, offset: 0x1100 */
+  __O  uint32_t SRVCOP;                            /**< Service COP, offset: 0x1104 */
+} SIM_Type, *SIM_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- SIM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SIM_Register_Accessor_Macros SIM - Register accessor macros
+ * @{
+ */
+
+
+/* SIM - Register accessors */
+#define SIM_SOPT1_REG(base)                      ((base)->SOPT1)
+#define SIM_SOPT2_REG(base)                      ((base)->SOPT2)
+#define SIM_SOPT4_REG(base)                      ((base)->SOPT4)
+#define SIM_SOPT5_REG(base)                      ((base)->SOPT5)
+#define SIM_SOPT7_REG(base)                      ((base)->SOPT7)
+#define SIM_SDID_REG(base)                       ((base)->SDID)
+#define SIM_SCGC4_REG(base)                      ((base)->SCGC4)
+#define SIM_SCGC5_REG(base)                      ((base)->SCGC5)
+#define SIM_SCGC6_REG(base)                      ((base)->SCGC6)
+#define SIM_SCGC7_REG(base)                      ((base)->SCGC7)
+#define SIM_CLKDIV1_REG(base)                    ((base)->CLKDIV1)
+#define SIM_FCFG1_REG(base)                      ((base)->FCFG1)
+#define SIM_FCFG2_REG(base)                      ((base)->FCFG2)
+#define SIM_UIDMH_REG(base)                      ((base)->UIDMH)
+#define SIM_UIDML_REG(base)                      ((base)->UIDML)
+#define SIM_UIDL_REG(base)                       ((base)->UIDL)
+#define SIM_COPC_REG(base)                       ((base)->COPC)
+#define SIM_SRVCOP_REG(base)                     ((base)->SRVCOP)
+
+/*!
+ * @}
+ */ /* end of group SIM_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- SIM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SIM_Register_Masks SIM Register Masks
+ * @{
+ */
+
+/* SOPT1 Bit Fields */
+#define SIM_SOPT1_OSC32KSEL_MASK                 0xC0000u
+#define SIM_SOPT1_OSC32KSEL_SHIFT                18
+#define SIM_SOPT1_OSC32KSEL(x)                   (((uint32_t)(((uint32_t)(x))<<SIM_SOPT1_OSC32KSEL_SHIFT))&SIM_SOPT1_OSC32KSEL_MASK)
+/* SOPT2 Bit Fields */
+#define SIM_SOPT2_RTCCLKOUTSEL_MASK              0x10u
+#define SIM_SOPT2_RTCCLKOUTSEL_SHIFT             4
+#define SIM_SOPT2_CLKOUTSEL_MASK                 0xE0u
+#define SIM_SOPT2_CLKOUTSEL_SHIFT                5
+#define SIM_SOPT2_CLKOUTSEL(x)                   (((uint32_t)(((uint32_t)(x))<<SIM_SOPT2_CLKOUTSEL_SHIFT))&SIM_SOPT2_CLKOUTSEL_MASK)
+#define SIM_SOPT2_PLLFLLSEL_MASK                 0x10000u
+#define SIM_SOPT2_PLLFLLSEL_SHIFT                16
+#define SIM_SOPT2_TPMSRC_MASK                    0x3000000u
+#define SIM_SOPT2_TPMSRC_SHIFT                   24
+#define SIM_SOPT2_TPMSRC(x)                      (((uint32_t)(((uint32_t)(x))<<SIM_SOPT2_TPMSRC_SHIFT))&SIM_SOPT2_TPMSRC_MASK)
+#define SIM_SOPT2_UART0SRC_MASK                  0xC000000u
+#define SIM_SOPT2_UART0SRC_SHIFT                 26
+#define SIM_SOPT2_UART0SRC(x)                    (((uint32_t)(((uint32_t)(x))<<SIM_SOPT2_UART0SRC_SHIFT))&SIM_SOPT2_UART0SRC_MASK)
+/* SOPT4 Bit Fields */
+#define SIM_SOPT4_TPM1CH0SRC_MASK                0xC0000u
+#define SIM_SOPT4_TPM1CH0SRC_SHIFT               18
+#define SIM_SOPT4_TPM1CH0SRC(x)                  (((uint32_t)(((uint32_t)(x))<<SIM_SOPT4_TPM1CH0SRC_SHIFT))&SIM_SOPT4_TPM1CH0SRC_MASK)
+#define SIM_SOPT4_TPM2CH0SRC_MASK                0x100000u
+#define SIM_SOPT4_TPM2CH0SRC_SHIFT               20
+#define SIM_SOPT4_TPM0CLKSEL_MASK                0x1000000u
+#define SIM_SOPT4_TPM0CLKSEL_SHIFT               24
+#define SIM_SOPT4_TPM1CLKSEL_MASK                0x2000000u
+#define SIM_SOPT4_TPM1CLKSEL_SHIFT               25
+#define SIM_SOPT4_TPM2CLKSEL_MASK                0x4000000u
+#define SIM_SOPT4_TPM2CLKSEL_SHIFT               26
+/* SOPT5 Bit Fields */
+#define SIM_SOPT5_UART0TXSRC_MASK                0x3u
+#define SIM_SOPT5_UART0TXSRC_SHIFT               0
+#define SIM_SOPT5_UART0TXSRC(x)                  (((uint32_t)(((uint32_t)(x))<<SIM_SOPT5_UART0TXSRC_SHIFT))&SIM_SOPT5_UART0TXSRC_MASK)
+#define SIM_SOPT5_UART0RXSRC_MASK                0x4u
+#define SIM_SOPT5_UART0RXSRC_SHIFT               2
+#define SIM_SOPT5_UART1TXSRC_MASK                0x30u
+#define SIM_SOPT5_UART1TXSRC_SHIFT               4
+#define SIM_SOPT5_UART1TXSRC(x)                  (((uint32_t)(((uint32_t)(x))<<SIM_SOPT5_UART1TXSRC_SHIFT))&SIM_SOPT5_UART1TXSRC_MASK)
+#define SIM_SOPT5_UART1RXSRC_MASK                0x40u
+#define SIM_SOPT5_UART1RXSRC_SHIFT               6
+#define SIM_SOPT5_UART0ODE_MASK                  0x10000u
+#define SIM_SOPT5_UART0ODE_SHIFT                 16
+#define SIM_SOPT5_UART1ODE_MASK                  0x20000u
+#define SIM_SOPT5_UART1ODE_SHIFT                 17
+#define SIM_SOPT5_UART2ODE_MASK                  0x40000u
+#define SIM_SOPT5_UART2ODE_SHIFT                 18
+/* SOPT7 Bit Fields */
+#define SIM_SOPT7_ADC0TRGSEL_MASK                0xFu
+#define SIM_SOPT7_ADC0TRGSEL_SHIFT               0
+#define SIM_SOPT7_ADC0TRGSEL(x)                  (((uint32_t)(((uint32_t)(x))<<SIM_SOPT7_ADC0TRGSEL_SHIFT))&SIM_SOPT7_ADC0TRGSEL_MASK)
+#define SIM_SOPT7_ADC0PRETRGSEL_MASK             0x10u
+#define SIM_SOPT7_ADC0PRETRGSEL_SHIFT            4
+#define SIM_SOPT7_ADC0ALTTRGEN_MASK              0x80u
+#define SIM_SOPT7_ADC0ALTTRGEN_SHIFT             7
+/* SDID Bit Fields */
+#define SIM_SDID_PINID_MASK                      0xFu
+#define SIM_SDID_PINID_SHIFT                     0
+#define SIM_SDID_PINID(x)                        (((uint32_t)(((uint32_t)(x))<<SIM_SDID_PINID_SHIFT))&SIM_SDID_PINID_MASK)
+#define SIM_SDID_DIEID_MASK                      0xF80u
+#define SIM_SDID_DIEID_SHIFT                     7
+#define SIM_SDID_DIEID(x)                        (((uint32_t)(((uint32_t)(x))<<SIM_SDID_DIEID_SHIFT))&SIM_SDID_DIEID_MASK)
+#define SIM_SDID_REVID_MASK                      0xF000u
+#define SIM_SDID_REVID_SHIFT                     12
+#define SIM_SDID_REVID(x)                        (((uint32_t)(((uint32_t)(x))<<SIM_SDID_REVID_SHIFT))&SIM_SDID_REVID_MASK)
+#define SIM_SDID_SRAMSIZE_MASK                   0xF0000u
+#define SIM_SDID_SRAMSIZE_SHIFT                  16
+#define SIM_SDID_SRAMSIZE(x)                     (((uint32_t)(((uint32_t)(x))<<SIM_SDID_SRAMSIZE_SHIFT))&SIM_SDID_SRAMSIZE_MASK)
+#define SIM_SDID_SERIESID_MASK                   0xF00000u
+#define SIM_SDID_SERIESID_SHIFT                  20
+#define SIM_SDID_SERIESID(x)                     (((uint32_t)(((uint32_t)(x))<<SIM_SDID_SERIESID_SHIFT))&SIM_SDID_SERIESID_MASK)
+#define SIM_SDID_SUBFAMID_MASK                   0xF000000u
+#define SIM_SDID_SUBFAMID_SHIFT                  24
+#define SIM_SDID_SUBFAMID(x)                     (((uint32_t)(((uint32_t)(x))<<SIM_SDID_SUBFAMID_SHIFT))&SIM_SDID_SUBFAMID_MASK)
+#define SIM_SDID_FAMID_MASK                      0xF0000000u
+#define SIM_SDID_FAMID_SHIFT                     28
+#define SIM_SDID_FAMID(x)                        (((uint32_t)(((uint32_t)(x))<<SIM_SDID_FAMID_SHIFT))&SIM_SDID_FAMID_MASK)
+/* SCGC4 Bit Fields */
+#define SIM_SCGC4_I2C0_MASK                      0x40u
+#define SIM_SCGC4_I2C0_SHIFT                     6
+#define SIM_SCGC4_I2C1_MASK                      0x80u
+#define SIM_SCGC4_I2C1_SHIFT                     7
+#define SIM_SCGC4_UART0_MASK                     0x400u
+#define SIM_SCGC4_UART0_SHIFT                    10
+#define SIM_SCGC4_UART1_MASK                     0x800u
+#define SIM_SCGC4_UART1_SHIFT                    11
+#define SIM_SCGC4_UART2_MASK                     0x1000u
+#define SIM_SCGC4_UART2_SHIFT                    12
+#define SIM_SCGC4_CMP_MASK                       0x80000u
+#define SIM_SCGC4_CMP_SHIFT                      19
+#define SIM_SCGC4_SPI0_MASK                      0x400000u
+#define SIM_SCGC4_SPI0_SHIFT                     22
+#define SIM_SCGC4_SPI1_MASK                      0x800000u
+#define SIM_SCGC4_SPI1_SHIFT                     23
+/* SCGC5 Bit Fields */
+#define SIM_SCGC5_LPTMR_MASK                     0x1u
+#define SIM_SCGC5_LPTMR_SHIFT                    0
+#define SIM_SCGC5_TSI_MASK                       0x20u
+#define SIM_SCGC5_TSI_SHIFT                      5
+#define SIM_SCGC5_PORTA_MASK                     0x200u
+#define SIM_SCGC5_PORTA_SHIFT                    9
+#define SIM_SCGC5_PORTB_MASK                     0x400u
+#define SIM_SCGC5_PORTB_SHIFT                    10
+#define SIM_SCGC5_PORTC_MASK                     0x800u
+#define SIM_SCGC5_PORTC_SHIFT                    11
+#define SIM_SCGC5_PORTD_MASK                     0x1000u
+#define SIM_SCGC5_PORTD_SHIFT                    12
+#define SIM_SCGC5_PORTE_MASK                     0x2000u
+#define SIM_SCGC5_PORTE_SHIFT                    13
+/* SCGC6 Bit Fields */
+#define SIM_SCGC6_FTF_MASK                       0x1u
+#define SIM_SCGC6_FTF_SHIFT                      0
+#define SIM_SCGC6_DMAMUX_MASK                    0x2u
+#define SIM_SCGC6_DMAMUX_SHIFT                   1
+#define SIM_SCGC6_I2S_MASK                       0x8000u
+#define SIM_SCGC6_I2S_SHIFT                      15
+#define SIM_SCGC6_PIT_MASK                       0x800000u
+#define SIM_SCGC6_PIT_SHIFT                      23
+#define SIM_SCGC6_TPM0_MASK                      0x1000000u
+#define SIM_SCGC6_TPM0_SHIFT                     24
+#define SIM_SCGC6_TPM1_MASK                      0x2000000u
+#define SIM_SCGC6_TPM1_SHIFT                     25
+#define SIM_SCGC6_TPM2_MASK                      0x4000000u
+#define SIM_SCGC6_TPM2_SHIFT                     26
+#define SIM_SCGC6_ADC0_MASK                      0x8000000u
+#define SIM_SCGC6_ADC0_SHIFT                     27
+#define SIM_SCGC6_RTC_MASK                       0x20000000u
+#define SIM_SCGC6_RTC_SHIFT                      29
+#define SIM_SCGC6_DAC0_MASK                      0x80000000u
+#define SIM_SCGC6_DAC0_SHIFT                     31
+/* SCGC7 Bit Fields */
+#define SIM_SCGC7_DMA_MASK                       0x100u
+#define SIM_SCGC7_DMA_SHIFT                      8
+/* CLKDIV1 Bit Fields */
+#define SIM_CLKDIV1_OUTDIV4_MASK                 0x70000u
+#define SIM_CLKDIV1_OUTDIV4_SHIFT                16
+#define SIM_CLKDIV1_OUTDIV4(x)                   (((uint32_t)(((uint32_t)(x))<<SIM_CLKDIV1_OUTDIV4_SHIFT))&SIM_CLKDIV1_OUTDIV4_MASK)
+#define SIM_CLKDIV1_OUTDIV1_MASK                 0xF0000000u
+#define SIM_CLKDIV1_OUTDIV1_SHIFT                28
+#define SIM_CLKDIV1_OUTDIV1(x)                   (((uint32_t)(((uint32_t)(x))<<SIM_CLKDIV1_OUTDIV1_SHIFT))&SIM_CLKDIV1_OUTDIV1_MASK)
+/* FCFG1 Bit Fields */
+#define SIM_FCFG1_FLASHDIS_MASK                  0x1u
+#define SIM_FCFG1_FLASHDIS_SHIFT                 0
+#define SIM_FCFG1_FLASHDOZE_MASK                 0x2u
+#define SIM_FCFG1_FLASHDOZE_SHIFT                1
+#define SIM_FCFG1_PFSIZE_MASK                    0xF000000u
+#define SIM_FCFG1_PFSIZE_SHIFT                   24
+#define SIM_FCFG1_PFSIZE(x)                      (((uint32_t)(((uint32_t)(x))<<SIM_FCFG1_PFSIZE_SHIFT))&SIM_FCFG1_PFSIZE_MASK)
+/* FCFG2 Bit Fields */
+#define SIM_FCFG2_MAXADDR1_MASK                  0x7F0000u
+#define SIM_FCFG2_MAXADDR1_SHIFT                 16
+#define SIM_FCFG2_MAXADDR1(x)                    (((uint32_t)(((uint32_t)(x))<<SIM_FCFG2_MAXADDR1_SHIFT))&SIM_FCFG2_MAXADDR1_MASK)
+#define SIM_FCFG2_MAXADDR0_MASK                  0x7F000000u
+#define SIM_FCFG2_MAXADDR0_SHIFT                 24
+#define SIM_FCFG2_MAXADDR0(x)                    (((uint32_t)(((uint32_t)(x))<<SIM_FCFG2_MAXADDR0_SHIFT))&SIM_FCFG2_MAXADDR0_MASK)
+/* UIDMH Bit Fields */
+#define SIM_UIDMH_UID_MASK                       0xFFFFu
+#define SIM_UIDMH_UID_SHIFT                      0
+#define SIM_UIDMH_UID(x)                         (((uint32_t)(((uint32_t)(x))<<SIM_UIDMH_UID_SHIFT))&SIM_UIDMH_UID_MASK)
+/* UIDML Bit Fields */
+#define SIM_UIDML_UID_MASK                       0xFFFFFFFFu
+#define SIM_UIDML_UID_SHIFT                      0
+#define SIM_UIDML_UID(x)                         (((uint32_t)(((uint32_t)(x))<<SIM_UIDML_UID_SHIFT))&SIM_UIDML_UID_MASK)
+/* UIDL Bit Fields */
+#define SIM_UIDL_UID_MASK                        0xFFFFFFFFu
+#define SIM_UIDL_UID_SHIFT                       0
+#define SIM_UIDL_UID(x)                          (((uint32_t)(((uint32_t)(x))<<SIM_UIDL_UID_SHIFT))&SIM_UIDL_UID_MASK)
+/* COPC Bit Fields */
+#define SIM_COPC_COPW_MASK                       0x1u
+#define SIM_COPC_COPW_SHIFT                      0
+#define SIM_COPC_COPCLKS_MASK                    0x2u
+#define SIM_COPC_COPCLKS_SHIFT                   1
+#define SIM_COPC_COPT_MASK                       0xCu
+#define SIM_COPC_COPT_SHIFT                      2
+#define SIM_COPC_COPT(x)                         (((uint32_t)(((uint32_t)(x))<<SIM_COPC_COPT_SHIFT))&SIM_COPC_COPT_MASK)
+/* SRVCOP Bit Fields */
+#define SIM_SRVCOP_SRVCOP_MASK                   0xFFu
+#define SIM_SRVCOP_SRVCOP_SHIFT                  0
+#define SIM_SRVCOP_SRVCOP(x)                     (((uint32_t)(((uint32_t)(x))<<SIM_SRVCOP_SRVCOP_SHIFT))&SIM_SRVCOP_SRVCOP_MASK)
+
+/*!
+ * @}
+ */ /* end of group SIM_Register_Masks */
+
+
+/* SIM - Peripheral instance base addresses */
+/** Peripheral SIM base address */
+#define SIM_BASE                                 (0x40047000u)
+/** Peripheral SIM base pointer */
+#define SIM                                      ((SIM_Type *)SIM_BASE)
+#define SIM_BASE_PTR                             (SIM)
+/** Array initializer of SIM peripheral base addresses */
+#define SIM_BASE_ADDRS                           { SIM_BASE }
+/** Array initializer of SIM peripheral base pointers */
+#define SIM_BASE_PTRS                            { SIM }
+
+/* ----------------------------------------------------------------------------
+   -- SIM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SIM_Register_Accessor_Macros SIM - Register accessor macros
+ * @{
+ */
+
+
+/* SIM - Register instance definitions */
+/* SIM */
+#define SIM_SOPT1                                SIM_SOPT1_REG(SIM)
+#define SIM_SOPT2                                SIM_SOPT2_REG(SIM)
+#define SIM_SOPT4                                SIM_SOPT4_REG(SIM)
+#define SIM_SOPT5                                SIM_SOPT5_REG(SIM)
+#define SIM_SOPT7                                SIM_SOPT7_REG(SIM)
+#define SIM_SDID                                 SIM_SDID_REG(SIM)
+#define SIM_SCGC4                                SIM_SCGC4_REG(SIM)
+#define SIM_SCGC5                                SIM_SCGC5_REG(SIM)
+#define SIM_SCGC6                                SIM_SCGC6_REG(SIM)
+#define SIM_SCGC7                                SIM_SCGC7_REG(SIM)
+#define SIM_CLKDIV1                              SIM_CLKDIV1_REG(SIM)
+#define SIM_FCFG1                                SIM_FCFG1_REG(SIM)
+#define SIM_FCFG2                                SIM_FCFG2_REG(SIM)
+#define SIM_UIDMH                                SIM_UIDMH_REG(SIM)
+#define SIM_UIDML                                SIM_UIDML_REG(SIM)
+#define SIM_UIDL                                 SIM_UIDL_REG(SIM)
+#define SIM_COPC                                 SIM_COPC_REG(SIM)
+#define SIM_SRVCOP                               SIM_SRVCOP_REG(SIM)
+
+/*!
+ * @}
+ */ /* end of group SIM_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group SIM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- SMC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SMC_Peripheral_Access_Layer SMC Peripheral Access Layer
+ * @{
+ */
+
+/** SMC - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t PMPROT;                             /**< Power Mode Protection register, offset: 0x0 */
+  __IO uint8_t PMCTRL;                             /**< Power Mode Control register, offset: 0x1 */
+  __IO uint8_t STOPCTRL;                           /**< Stop Control Register, offset: 0x2 */
+  __I  uint8_t PMSTAT;                             /**< Power Mode Status register, offset: 0x3 */
+} SMC_Type, *SMC_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- SMC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SMC_Register_Accessor_Macros SMC - Register accessor macros
+ * @{
+ */
+
+
+/* SMC - Register accessors */
+#define SMC_PMPROT_REG(base)                     ((base)->PMPROT)
+#define SMC_PMCTRL_REG(base)                     ((base)->PMCTRL)
+#define SMC_STOPCTRL_REG(base)                   ((base)->STOPCTRL)
+#define SMC_PMSTAT_REG(base)                     ((base)->PMSTAT)
+
+/*!
+ * @}
+ */ /* end of group SMC_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- SMC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SMC_Register_Masks SMC Register Masks
+ * @{
+ */
+
+/* PMPROT Bit Fields */
+#define SMC_PMPROT_AVLLS_MASK                    0x2u
+#define SMC_PMPROT_AVLLS_SHIFT                   1
+#define SMC_PMPROT_ALLS_MASK                     0x8u
+#define SMC_PMPROT_ALLS_SHIFT                    3
+#define SMC_PMPROT_AVLP_MASK                     0x20u
+#define SMC_PMPROT_AVLP_SHIFT                    5
+/* PMCTRL Bit Fields */
+#define SMC_PMCTRL_STOPM_MASK                    0x7u
+#define SMC_PMCTRL_STOPM_SHIFT                   0
+#define SMC_PMCTRL_STOPM(x)                      (((uint8_t)(((uint8_t)(x))<<SMC_PMCTRL_STOPM_SHIFT))&SMC_PMCTRL_STOPM_MASK)
+#define SMC_PMCTRL_STOPA_MASK                    0x8u
+#define SMC_PMCTRL_STOPA_SHIFT                   3
+#define SMC_PMCTRL_RUNM_MASK                     0x60u
+#define SMC_PMCTRL_RUNM_SHIFT                    5
+#define SMC_PMCTRL_RUNM(x)                       (((uint8_t)(((uint8_t)(x))<<SMC_PMCTRL_RUNM_SHIFT))&SMC_PMCTRL_RUNM_MASK)
+/* STOPCTRL Bit Fields */
+#define SMC_STOPCTRL_VLLSM_MASK                  0x7u
+#define SMC_STOPCTRL_VLLSM_SHIFT                 0
+#define SMC_STOPCTRL_VLLSM(x)                    (((uint8_t)(((uint8_t)(x))<<SMC_STOPCTRL_VLLSM_SHIFT))&SMC_STOPCTRL_VLLSM_MASK)
+#define SMC_STOPCTRL_PORPO_MASK                  0x20u
+#define SMC_STOPCTRL_PORPO_SHIFT                 5
+#define SMC_STOPCTRL_PSTOPO_MASK                 0xC0u
+#define SMC_STOPCTRL_PSTOPO_SHIFT                6
+#define SMC_STOPCTRL_PSTOPO(x)                   (((uint8_t)(((uint8_t)(x))<<SMC_STOPCTRL_PSTOPO_SHIFT))&SMC_STOPCTRL_PSTOPO_MASK)
+/* PMSTAT Bit Fields */
+#define SMC_PMSTAT_PMSTAT_MASK                   0x7Fu
+#define SMC_PMSTAT_PMSTAT_SHIFT                  0
+#define SMC_PMSTAT_PMSTAT(x)                     (((uint8_t)(((uint8_t)(x))<<SMC_PMSTAT_PMSTAT_SHIFT))&SMC_PMSTAT_PMSTAT_MASK)
+
+/*!
+ * @}
+ */ /* end of group SMC_Register_Masks */
+
+
+/* SMC - Peripheral instance base addresses */
+/** Peripheral SMC base address */
+#define SMC_BASE                                 (0x4007E000u)
+/** Peripheral SMC base pointer */
+#define SMC                                      ((SMC_Type *)SMC_BASE)
+#define SMC_BASE_PTR                             (SMC)
+/** Array initializer of SMC peripheral base addresses */
+#define SMC_BASE_ADDRS                           { SMC_BASE }
+/** Array initializer of SMC peripheral base pointers */
+#define SMC_BASE_PTRS                            { SMC }
+
+/* ----------------------------------------------------------------------------
+   -- SMC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SMC_Register_Accessor_Macros SMC - Register accessor macros
+ * @{
+ */
+
+
+/* SMC - Register instance definitions */
+/* SMC */
+#define SMC_PMPROT                               SMC_PMPROT_REG(SMC)
+#define SMC_PMCTRL                               SMC_PMCTRL_REG(SMC)
+#define SMC_STOPCTRL                             SMC_STOPCTRL_REG(SMC)
+#define SMC_PMSTAT                               SMC_PMSTAT_REG(SMC)
+
+/*!
+ * @}
+ */ /* end of group SMC_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group SMC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- SPI Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SPI_Peripheral_Access_Layer SPI Peripheral Access Layer
+ * @{
+ */
+
+/** SPI - Register Layout Typedef */
+typedef struct {
+  __I  uint8_t S;                                  /**< SPI Status Register, offset: 0x0 */
+  __IO uint8_t BR;                                 /**< SPI Baud Rate Register, offset: 0x1 */
+  __IO uint8_t C2;                                 /**< SPI Control Register 2, offset: 0x2 */
+  __IO uint8_t C1;                                 /**< SPI Control Register 1, offset: 0x3 */
+  __IO uint8_t ML;                                 /**< SPI Match Register low, offset: 0x4 */
+  __IO uint8_t MH;                                 /**< SPI match register high, offset: 0x5 */
+  __IO uint8_t DL;                                 /**< SPI Data Register low, offset: 0x6 */
+  __IO uint8_t DH;                                 /**< SPI data register high, offset: 0x7 */
+       uint8_t RESERVED_0[2];
+  __IO uint8_t CI;                                 /**< SPI clear interrupt register, offset: 0xA */
+  __IO uint8_t C3;                                 /**< SPI control register 3, offset: 0xB */
+} SPI_Type, *SPI_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- SPI - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SPI_Register_Accessor_Macros SPI - Register accessor macros
+ * @{
+ */
+
+
+/* SPI - Register accessors */
+#define SPI_S_REG(base)                          ((base)->S)
+#define SPI_BR_REG(base)                         ((base)->BR)
+#define SPI_C2_REG(base)                         ((base)->C2)
+#define SPI_C1_REG(base)                         ((base)->C1)
+#define SPI_ML_REG(base)                         ((base)->ML)
+#define SPI_MH_REG(base)                         ((base)->MH)
+#define SPI_DL_REG(base)                         ((base)->DL)
+#define SPI_DH_REG(base)                         ((base)->DH)
+#define SPI_CI_REG(base)                         ((base)->CI)
+#define SPI_C3_REG(base)                         ((base)->C3)
+
+/*!
+ * @}
+ */ /* end of group SPI_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- SPI Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SPI_Register_Masks SPI Register Masks
+ * @{
+ */
+
+/* S Bit Fields */
+#define SPI_S_RFIFOEF_MASK                       0x1u
+#define SPI_S_RFIFOEF_SHIFT                      0
+#define SPI_S_TXFULLF_MASK                       0x2u
+#define SPI_S_TXFULLF_SHIFT                      1
+#define SPI_S_TNEAREF_MASK                       0x4u
+#define SPI_S_TNEAREF_SHIFT                      2
+#define SPI_S_RNFULLF_MASK                       0x8u
+#define SPI_S_RNFULLF_SHIFT                      3
+#define SPI_S_MODF_MASK                          0x10u
+#define SPI_S_MODF_SHIFT                         4
+#define SPI_S_SPTEF_MASK                         0x20u
+#define SPI_S_SPTEF_SHIFT                        5
+#define SPI_S_SPMF_MASK                          0x40u
+#define SPI_S_SPMF_SHIFT                         6
+#define SPI_S_SPRF_MASK                          0x80u
+#define SPI_S_SPRF_SHIFT                         7
+/* BR Bit Fields */
+#define SPI_BR_SPR_MASK                          0xFu
+#define SPI_BR_SPR_SHIFT                         0
+#define SPI_BR_SPR(x)                            (((uint8_t)(((uint8_t)(x))<<SPI_BR_SPR_SHIFT))&SPI_BR_SPR_MASK)
+#define SPI_BR_SPPR_MASK                         0x70u
+#define SPI_BR_SPPR_SHIFT                        4
+#define SPI_BR_SPPR(x)                           (((uint8_t)(((uint8_t)(x))<<SPI_BR_SPPR_SHIFT))&SPI_BR_SPPR_MASK)
+/* C2 Bit Fields */
+#define SPI_C2_SPC0_MASK                         0x1u
+#define SPI_C2_SPC0_SHIFT                        0
+#define SPI_C2_SPISWAI_MASK                      0x2u
+#define SPI_C2_SPISWAI_SHIFT                     1
+#define SPI_C2_RXDMAE_MASK                       0x4u
+#define SPI_C2_RXDMAE_SHIFT                      2
+#define SPI_C2_BIDIROE_MASK                      0x8u
+#define SPI_C2_BIDIROE_SHIFT                     3
+#define SPI_C2_MODFEN_MASK                       0x10u
+#define SPI_C2_MODFEN_SHIFT                      4
+#define SPI_C2_TXDMAE_MASK                       0x20u
+#define SPI_C2_TXDMAE_SHIFT                      5
+#define SPI_C2_SPIMODE_MASK                      0x40u
+#define SPI_C2_SPIMODE_SHIFT                     6
+#define SPI_C2_SPMIE_MASK                        0x80u
+#define SPI_C2_SPMIE_SHIFT                       7
+/* C1 Bit Fields */
+#define SPI_C1_LSBFE_MASK                        0x1u
+#define SPI_C1_LSBFE_SHIFT                       0
+#define SPI_C1_SSOE_MASK                         0x2u
+#define SPI_C1_SSOE_SHIFT                        1
+#define SPI_C1_CPHA_MASK                         0x4u
+#define SPI_C1_CPHA_SHIFT                        2
+#define SPI_C1_CPOL_MASK                         0x8u
+#define SPI_C1_CPOL_SHIFT                        3
+#define SPI_C1_MSTR_MASK                         0x10u
+#define SPI_C1_MSTR_SHIFT                        4
+#define SPI_C1_SPTIE_MASK                        0x20u
+#define SPI_C1_SPTIE_SHIFT                       5
+#define SPI_C1_SPE_MASK                          0x40u
+#define SPI_C1_SPE_SHIFT                         6
+#define SPI_C1_SPIE_MASK                         0x80u
+#define SPI_C1_SPIE_SHIFT                        7
+/* ML Bit Fields */
+#define SPI_ML_Bits_MASK                         0xFFu
+#define SPI_ML_Bits_SHIFT                        0
+#define SPI_ML_Bits(x)                           (((uint8_t)(((uint8_t)(x))<<SPI_ML_Bits_SHIFT))&SPI_ML_Bits_MASK)
+/* MH Bit Fields */
+#define SPI_MH_Bits_MASK                         0xFFu
+#define SPI_MH_Bits_SHIFT                        0
+#define SPI_MH_Bits(x)                           (((uint8_t)(((uint8_t)(x))<<SPI_MH_Bits_SHIFT))&SPI_MH_Bits_MASK)
+/* DL Bit Fields */
+#define SPI_DL_Bits_MASK                         0xFFu
+#define SPI_DL_Bits_SHIFT                        0
+#define SPI_DL_Bits(x)                           (((uint8_t)(((uint8_t)(x))<<SPI_DL_Bits_SHIFT))&SPI_DL_Bits_MASK)
+/* DH Bit Fields */
+#define SPI_DH_Bits_MASK                         0xFFu
+#define SPI_DH_Bits_SHIFT                        0
+#define SPI_DH_Bits(x)                           (((uint8_t)(((uint8_t)(x))<<SPI_DH_Bits_SHIFT))&SPI_DH_Bits_MASK)
+/* CI Bit Fields */
+#define SPI_CI_SPRFCI_MASK                       0x1u
+#define SPI_CI_SPRFCI_SHIFT                      0
+#define SPI_CI_SPTEFCI_MASK                      0x2u
+#define SPI_CI_SPTEFCI_SHIFT                     1
+#define SPI_CI_RNFULLFCI_MASK                    0x4u
+#define SPI_CI_RNFULLFCI_SHIFT                   2
+#define SPI_CI_TNEAREFCI_MASK                    0x8u
+#define SPI_CI_TNEAREFCI_SHIFT                   3
+#define SPI_CI_RXFOF_MASK                        0x10u
+#define SPI_CI_RXFOF_SHIFT                       4
+#define SPI_CI_TXFOF_MASK                        0x20u
+#define SPI_CI_TXFOF_SHIFT                       5
+#define SPI_CI_RXFERR_MASK                       0x40u
+#define SPI_CI_RXFERR_SHIFT                      6
+#define SPI_CI_TXFERR_MASK                       0x80u
+#define SPI_CI_TXFERR_SHIFT                      7
+/* C3 Bit Fields */
+#define SPI_C3_FIFOMODE_MASK                     0x1u
+#define SPI_C3_FIFOMODE_SHIFT                    0
+#define SPI_C3_RNFULLIEN_MASK                    0x2u
+#define SPI_C3_RNFULLIEN_SHIFT                   1
+#define SPI_C3_TNEARIEN_MASK                     0x4u
+#define SPI_C3_TNEARIEN_SHIFT                    2
+#define SPI_C3_INTCLR_MASK                       0x8u
+#define SPI_C3_INTCLR_SHIFT                      3
+#define SPI_C3_RNFULLF_MARK_MASK                 0x10u
+#define SPI_C3_RNFULLF_MARK_SHIFT                4
+#define SPI_C3_TNEAREF_MARK_MASK                 0x20u
+#define SPI_C3_TNEAREF_MARK_SHIFT                5
+
+/*!
+ * @}
+ */ /* end of group SPI_Register_Masks */
+
+
+/* SPI - Peripheral instance base addresses */
+/** Peripheral SPI0 base address */
+#define SPI0_BASE                                (0x40076000u)
+/** Peripheral SPI0 base pointer */
+#define SPI0                                     ((SPI_Type *)SPI0_BASE)
+#define SPI0_BASE_PTR                            (SPI0)
+/** Peripheral SPI1 base address */
+#define SPI1_BASE                                (0x40077000u)
+/** Peripheral SPI1 base pointer */
+#define SPI1                                     ((SPI_Type *)SPI1_BASE)
+#define SPI1_BASE_PTR                            (SPI1)
+/** Array initializer of SPI peripheral base addresses */
+#define SPI_BASE_ADDRS                           { SPI0_BASE, SPI1_BASE }
+/** Array initializer of SPI peripheral base pointers */
+#define SPI_BASE_PTRS                            { SPI0, SPI1 }
+/** Interrupt vectors for the SPI peripheral type */
+#define SPI_IRQS                                 { SPI0_IRQn, SPI1_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- SPI - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SPI_Register_Accessor_Macros SPI - Register accessor macros
+ * @{
+ */
+
+
+/* SPI - Register instance definitions */
+/* SPI0 */
+#define SPI0_S                                   SPI_S_REG(SPI0)
+#define SPI0_BR                                  SPI_BR_REG(SPI0)
+#define SPI0_C2                                  SPI_C2_REG(SPI0)
+#define SPI0_C1                                  SPI_C1_REG(SPI0)
+#define SPI0_ML                                  SPI_ML_REG(SPI0)
+#define SPI0_MH                                  SPI_MH_REG(SPI0)
+#define SPI0_DL                                  SPI_DL_REG(SPI0)
+#define SPI0_DH                                  SPI_DH_REG(SPI0)
+/* SPI1 */
+#define SPI1_S                                   SPI_S_REG(SPI1)
+#define SPI1_BR                                  SPI_BR_REG(SPI1)
+#define SPI1_C2                                  SPI_C2_REG(SPI1)
+#define SPI1_C1                                  SPI_C1_REG(SPI1)
+#define SPI1_ML                                  SPI_ML_REG(SPI1)
+#define SPI1_MH                                  SPI_MH_REG(SPI1)
+#define SPI1_DL                                  SPI_DL_REG(SPI1)
+#define SPI1_DH                                  SPI_DH_REG(SPI1)
+#define SPI1_CI                                  SPI_CI_REG(SPI1)
+#define SPI1_C3                                  SPI_C3_REG(SPI1)
+
+/*!
+ * @}
+ */ /* end of group SPI_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group SPI_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- TPM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup TPM_Peripheral_Access_Layer TPM Peripheral Access Layer
+ * @{
+ */
+
+/** TPM - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t SC;                                /**< Status and Control, offset: 0x0 */
+  __IO uint32_t CNT;                               /**< Counter, offset: 0x4 */
+  __IO uint32_t MOD;                               /**< Modulo, offset: 0x8 */
+  struct {                                         /* offset: 0xC, array step: 0x8 */
+    __IO uint32_t CnSC;                              /**< Channel (n) Status and Control, array offset: 0xC, array step: 0x8 */
+    __IO uint32_t CnV;                               /**< Channel (n) Value, array offset: 0x10, array step: 0x8 */
+  } CONTROLS[6];
+       uint8_t RESERVED_0[20];
+  __IO uint32_t STATUS;                            /**< Capture and Compare Status, offset: 0x50 */
+       uint8_t RESERVED_1[48];
+  __IO uint32_t CONF;                              /**< Configuration, offset: 0x84 */
+} TPM_Type, *TPM_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- TPM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup TPM_Register_Accessor_Macros TPM - Register accessor macros
+ * @{
+ */
+
+
+/* TPM - Register accessors */
+#define TPM_SC_REG(base)                         ((base)->SC)
+#define TPM_CNT_REG(base)                        ((base)->CNT)
+#define TPM_MOD_REG(base)                        ((base)->MOD)
+#define TPM_CnSC_REG(base,index)                 ((base)->CONTROLS[index].CnSC)
+#define TPM_CnV_REG(base,index)                  ((base)->CONTROLS[index].CnV)
+#define TPM_STATUS_REG(base)                     ((base)->STATUS)
+#define TPM_CONF_REG(base)                       ((base)->CONF)
+
+/*!
+ * @}
+ */ /* end of group TPM_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- TPM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup TPM_Register_Masks TPM Register Masks
+ * @{
+ */
+
+/* SC Bit Fields */
+#define TPM_SC_PS_MASK                           0x7u
+#define TPM_SC_PS_SHIFT                          0
+#define TPM_SC_PS(x)                             (((uint32_t)(((uint32_t)(x))<<TPM_SC_PS_SHIFT))&TPM_SC_PS_MASK)
+#define TPM_SC_CMOD_MASK                         0x18u
+#define TPM_SC_CMOD_SHIFT                        3
+#define TPM_SC_CMOD(x)                           (((uint32_t)(((uint32_t)(x))<<TPM_SC_CMOD_SHIFT))&TPM_SC_CMOD_MASK)
+#define TPM_SC_CPWMS_MASK                        0x20u
+#define TPM_SC_CPWMS_SHIFT                       5
+#define TPM_SC_TOIE_MASK                         0x40u
+#define TPM_SC_TOIE_SHIFT                        6
+#define TPM_SC_TOF_MASK                          0x80u
+#define TPM_SC_TOF_SHIFT                         7
+#define TPM_SC_DMA_MASK                          0x100u
+#define TPM_SC_DMA_SHIFT                         8
+/* CNT Bit Fields */
+#define TPM_CNT_COUNT_MASK                       0xFFFFu
+#define TPM_CNT_COUNT_SHIFT                      0
+#define TPM_CNT_COUNT(x)                         (((uint32_t)(((uint32_t)(x))<<TPM_CNT_COUNT_SHIFT))&TPM_CNT_COUNT_MASK)
+/* MOD Bit Fields */
+#define TPM_MOD_MOD_MASK                         0xFFFFu
+#define TPM_MOD_MOD_SHIFT                        0
+#define TPM_MOD_MOD(x)                           (((uint32_t)(((uint32_t)(x))<<TPM_MOD_MOD_SHIFT))&TPM_MOD_MOD_MASK)
+/* CnSC Bit Fields */
+#define TPM_CnSC_DMA_MASK                        0x1u
+#define TPM_CnSC_DMA_SHIFT                       0
+#define TPM_CnSC_ELSA_MASK                       0x4u
+#define TPM_CnSC_ELSA_SHIFT                      2
+#define TPM_CnSC_ELSB_MASK                       0x8u
+#define TPM_CnSC_ELSB_SHIFT                      3
+#define TPM_CnSC_MSA_MASK                        0x10u
+#define TPM_CnSC_MSA_SHIFT                       4
+#define TPM_CnSC_MSB_MASK                        0x20u
+#define TPM_CnSC_MSB_SHIFT                       5
+#define TPM_CnSC_CHIE_MASK                       0x40u
+#define TPM_CnSC_CHIE_SHIFT                      6
+#define TPM_CnSC_CHF_MASK                        0x80u
+#define TPM_CnSC_CHF_SHIFT                       7
+/* CnV Bit Fields */
+#define TPM_CnV_VAL_MASK                         0xFFFFu
+#define TPM_CnV_VAL_SHIFT                        0
+#define TPM_CnV_VAL(x)                           (((uint32_t)(((uint32_t)(x))<<TPM_CnV_VAL_SHIFT))&TPM_CnV_VAL_MASK)
+/* STATUS Bit Fields */
+#define TPM_STATUS_CH0F_MASK                     0x1u
+#define TPM_STATUS_CH0F_SHIFT                    0
+#define TPM_STATUS_CH1F_MASK                     0x2u
+#define TPM_STATUS_CH1F_SHIFT                    1
+#define TPM_STATUS_CH2F_MASK                     0x4u
+#define TPM_STATUS_CH2F_SHIFT                    2
+#define TPM_STATUS_CH3F_MASK                     0x8u
+#define TPM_STATUS_CH3F_SHIFT                    3
+#define TPM_STATUS_CH4F_MASK                     0x10u
+#define TPM_STATUS_CH4F_SHIFT                    4
+#define TPM_STATUS_CH5F_MASK                     0x20u
+#define TPM_STATUS_CH5F_SHIFT                    5
+#define TPM_STATUS_TOF_MASK                      0x100u
+#define TPM_STATUS_TOF_SHIFT                     8
+/* CONF Bit Fields */
+#define TPM_CONF_DOZEEN_MASK                     0x20u
+#define TPM_CONF_DOZEEN_SHIFT                    5
+#define TPM_CONF_DBGMODE_MASK                    0xC0u
+#define TPM_CONF_DBGMODE_SHIFT                   6
+#define TPM_CONF_DBGMODE(x)                      (((uint32_t)(((uint32_t)(x))<<TPM_CONF_DBGMODE_SHIFT))&TPM_CONF_DBGMODE_MASK)
+#define TPM_CONF_GTBEEN_MASK                     0x200u
+#define TPM_CONF_GTBEEN_SHIFT                    9
+#define TPM_CONF_CSOT_MASK                       0x10000u
+#define TPM_CONF_CSOT_SHIFT                      16
+#define TPM_CONF_CSOO_MASK                       0x20000u
+#define TPM_CONF_CSOO_SHIFT                      17
+#define TPM_CONF_CROT_MASK                       0x40000u
+#define TPM_CONF_CROT_SHIFT                      18
+#define TPM_CONF_TRGSEL_MASK                     0xF000000u
+#define TPM_CONF_TRGSEL_SHIFT                    24
+#define TPM_CONF_TRGSEL(x)                       (((uint32_t)(((uint32_t)(x))<<TPM_CONF_TRGSEL_SHIFT))&TPM_CONF_TRGSEL_MASK)
+
+/*!
+ * @}
+ */ /* end of group TPM_Register_Masks */
+
+
+/* TPM - Peripheral instance base addresses */
+/** Peripheral TPM0 base address */
+#define TPM0_BASE                                (0x40038000u)
+/** Peripheral TPM0 base pointer */
+#define TPM0                                     ((TPM_Type *)TPM0_BASE)
+#define TPM0_BASE_PTR                            (TPM0)
+/** Peripheral TPM1 base address */
+#define TPM1_BASE                                (0x40039000u)
+/** Peripheral TPM1 base pointer */
+#define TPM1                                     ((TPM_Type *)TPM1_BASE)
+#define TPM1_BASE_PTR                            (TPM1)
+/** Peripheral TPM2 base address */
+#define TPM2_BASE                                (0x4003A000u)
+/** Peripheral TPM2 base pointer */
+#define TPM2                                     ((TPM_Type *)TPM2_BASE)
+#define TPM2_BASE_PTR                            (TPM2)
+/** Array initializer of TPM peripheral base addresses */
+#define TPM_BASE_ADDRS                           { TPM0_BASE, TPM1_BASE, TPM2_BASE }
+/** Array initializer of TPM peripheral base pointers */
+#define TPM_BASE_PTRS                            { TPM0, TPM1, TPM2 }
+/** Interrupt vectors for the TPM peripheral type */
+#define TPM_IRQS                                 { TPM0_IRQn, TPM1_IRQn, TPM2_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- TPM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup TPM_Register_Accessor_Macros TPM - Register accessor macros
+ * @{
+ */
+
+
+/* TPM - Register instance definitions */
+/* TPM0 */
+#define TPM0_SC                                  TPM_SC_REG(TPM0)
+#define TPM0_CNT                                 TPM_CNT_REG(TPM0)
+#define TPM0_MOD                                 TPM_MOD_REG(TPM0)
+#define TPM0_C0SC                                TPM_CnSC_REG(TPM0,0)
+#define TPM0_C0V                                 TPM_CnV_REG(TPM0,0)
+#define TPM0_C1SC                                TPM_CnSC_REG(TPM0,1)
+#define TPM0_C1V                                 TPM_CnV_REG(TPM0,1)
+#define TPM0_C2SC                                TPM_CnSC_REG(TPM0,2)
+#define TPM0_C2V                                 TPM_CnV_REG(TPM0,2)
+#define TPM0_C3SC                                TPM_CnSC_REG(TPM0,3)
+#define TPM0_C3V                                 TPM_CnV_REG(TPM0,3)
+#define TPM0_C4SC                                TPM_CnSC_REG(TPM0,4)
+#define TPM0_C4V                                 TPM_CnV_REG(TPM0,4)
+#define TPM0_C5SC                                TPM_CnSC_REG(TPM0,5)
+#define TPM0_C5V                                 TPM_CnV_REG(TPM0,5)
+#define TPM0_STATUS                              TPM_STATUS_REG(TPM0)
+#define TPM0_CONF                                TPM_CONF_REG(TPM0)
+/* TPM1 */
+#define TPM1_SC                                  TPM_SC_REG(TPM1)
+#define TPM1_CNT                                 TPM_CNT_REG(TPM1)
+#define TPM1_MOD                                 TPM_MOD_REG(TPM1)
+#define TPM1_C0SC                                TPM_CnSC_REG(TPM1,0)
+#define TPM1_C0V                                 TPM_CnV_REG(TPM1,0)
+#define TPM1_C1SC                                TPM_CnSC_REG(TPM1,1)
+#define TPM1_C1V                                 TPM_CnV_REG(TPM1,1)
+#define TPM1_STATUS                              TPM_STATUS_REG(TPM1)
+#define TPM1_CONF                                TPM_CONF_REG(TPM1)
+/* TPM2 */
+#define TPM2_SC                                  TPM_SC_REG(TPM2)
+#define TPM2_CNT                                 TPM_CNT_REG(TPM2)
+#define TPM2_MOD                                 TPM_MOD_REG(TPM2)
+#define TPM2_C0SC                                TPM_CnSC_REG(TPM2,0)
+#define TPM2_C0V                                 TPM_CnV_REG(TPM2,0)
+#define TPM2_C1SC                                TPM_CnSC_REG(TPM2,1)
+#define TPM2_C1V                                 TPM_CnV_REG(TPM2,1)
+#define TPM2_STATUS                              TPM_STATUS_REG(TPM2)
+#define TPM2_CONF                                TPM_CONF_REG(TPM2)
+
+/* TPM - Register array accessors */
+#define TPM0_CnSC(index)                         TPM_CnSC_REG(TPM0,index)
+#define TPM1_CnSC(index)                         TPM_CnSC_REG(TPM1,index)
+#define TPM2_CnSC(index)                         TPM_CnSC_REG(TPM2,index)
+#define TPM0_CnV(index)                          TPM_CnV_REG(TPM0,index)
+#define TPM1_CnV(index)                          TPM_CnV_REG(TPM1,index)
+#define TPM2_CnV(index)                          TPM_CnV_REG(TPM2,index)
+
+/*!
+ * @}
+ */ /* end of group TPM_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group TPM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- TSI Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup TSI_Peripheral_Access_Layer TSI Peripheral Access Layer
+ * @{
+ */
+
+/** TSI - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t GENCS;                             /**< TSI General Control and Status Register, offset: 0x0 */
+  __IO uint32_t DATA;                              /**< TSI DATA Register, offset: 0x4 */
+  __IO uint32_t TSHD;                              /**< TSI Threshold Register, offset: 0x8 */
+} TSI_Type, *TSI_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- TSI - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup TSI_Register_Accessor_Macros TSI - Register accessor macros
+ * @{
+ */
+
+
+/* TSI - Register accessors */
+#define TSI_GENCS_REG(base)                      ((base)->GENCS)
+#define TSI_DATA_REG(base)                       ((base)->DATA)
+#define TSI_TSHD_REG(base)                       ((base)->TSHD)
+
+/*!
+ * @}
+ */ /* end of group TSI_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- TSI Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup TSI_Register_Masks TSI Register Masks
+ * @{
+ */
+
+/* GENCS Bit Fields */
+#define TSI_GENCS_CURSW_MASK                     0x2u
+#define TSI_GENCS_CURSW_SHIFT                    1
+#define TSI_GENCS_EOSF_MASK                      0x4u
+#define TSI_GENCS_EOSF_SHIFT                     2
+#define TSI_GENCS_SCNIP_MASK                     0x8u
+#define TSI_GENCS_SCNIP_SHIFT                    3
+#define TSI_GENCS_STM_MASK                       0x10u
+#define TSI_GENCS_STM_SHIFT                      4
+#define TSI_GENCS_STPE_MASK                      0x20u
+#define TSI_GENCS_STPE_SHIFT                     5
+#define TSI_GENCS_TSIIEN_MASK                    0x40u
+#define TSI_GENCS_TSIIEN_SHIFT                   6
+#define TSI_GENCS_TSIEN_MASK                     0x80u
+#define TSI_GENCS_TSIEN_SHIFT                    7
+#define TSI_GENCS_NSCN_MASK                      0x1F00u
+#define TSI_GENCS_NSCN_SHIFT                     8
+#define TSI_GENCS_NSCN(x)                        (((uint32_t)(((uint32_t)(x))<<TSI_GENCS_NSCN_SHIFT))&TSI_GENCS_NSCN_MASK)
+#define TSI_GENCS_PS_MASK                        0xE000u
+#define TSI_GENCS_PS_SHIFT                       13
+#define TSI_GENCS_PS(x)                          (((uint32_t)(((uint32_t)(x))<<TSI_GENCS_PS_SHIFT))&TSI_GENCS_PS_MASK)
+#define TSI_GENCS_EXTCHRG_MASK                   0x70000u
+#define TSI_GENCS_EXTCHRG_SHIFT                  16
+#define TSI_GENCS_EXTCHRG(x)                     (((uint32_t)(((uint32_t)(x))<<TSI_GENCS_EXTCHRG_SHIFT))&TSI_GENCS_EXTCHRG_MASK)
+#define TSI_GENCS_DVOLT_MASK                     0x180000u
+#define TSI_GENCS_DVOLT_SHIFT                    19
+#define TSI_GENCS_DVOLT(x)                       (((uint32_t)(((uint32_t)(x))<<TSI_GENCS_DVOLT_SHIFT))&TSI_GENCS_DVOLT_MASK)
+#define TSI_GENCS_REFCHRG_MASK                   0xE00000u
+#define TSI_GENCS_REFCHRG_SHIFT                  21
+#define TSI_GENCS_REFCHRG(x)                     (((uint32_t)(((uint32_t)(x))<<TSI_GENCS_REFCHRG_SHIFT))&TSI_GENCS_REFCHRG_MASK)
+#define TSI_GENCS_MODE_MASK                      0xF000000u
+#define TSI_GENCS_MODE_SHIFT                     24
+#define TSI_GENCS_MODE(x)                        (((uint32_t)(((uint32_t)(x))<<TSI_GENCS_MODE_SHIFT))&TSI_GENCS_MODE_MASK)
+#define TSI_GENCS_ESOR_MASK                      0x10000000u
+#define TSI_GENCS_ESOR_SHIFT                     28
+#define TSI_GENCS_OUTRGF_MASK                    0x80000000u
+#define TSI_GENCS_OUTRGF_SHIFT                   31
+/* DATA Bit Fields */
+#define TSI_DATA_TSICNT_MASK                     0xFFFFu
+#define TSI_DATA_TSICNT_SHIFT                    0
+#define TSI_DATA_TSICNT(x)                       (((uint32_t)(((uint32_t)(x))<<TSI_DATA_TSICNT_SHIFT))&TSI_DATA_TSICNT_MASK)
+#define TSI_DATA_SWTS_MASK                       0x400000u
+#define TSI_DATA_SWTS_SHIFT                      22
+#define TSI_DATA_DMAEN_MASK                      0x800000u
+#define TSI_DATA_DMAEN_SHIFT                     23
+#define TSI_DATA_TSICH_MASK                      0xF0000000u
+#define TSI_DATA_TSICH_SHIFT                     28
+#define TSI_DATA_TSICH(x)                        (((uint32_t)(((uint32_t)(x))<<TSI_DATA_TSICH_SHIFT))&TSI_DATA_TSICH_MASK)
+/* TSHD Bit Fields */
+#define TSI_TSHD_THRESL_MASK                     0xFFFFu
+#define TSI_TSHD_THRESL_SHIFT                    0
+#define TSI_TSHD_THRESL(x)                       (((uint32_t)(((uint32_t)(x))<<TSI_TSHD_THRESL_SHIFT))&TSI_TSHD_THRESL_MASK)
+#define TSI_TSHD_THRESH_MASK                     0xFFFF0000u
+#define TSI_TSHD_THRESH_SHIFT                    16
+#define TSI_TSHD_THRESH(x)                       (((uint32_t)(((uint32_t)(x))<<TSI_TSHD_THRESH_SHIFT))&TSI_TSHD_THRESH_MASK)
+
+/*!
+ * @}
+ */ /* end of group TSI_Register_Masks */
+
+
+/* TSI - Peripheral instance base addresses */
+/** Peripheral TSI0 base address */
+#define TSI0_BASE                                (0x40045000u)
+/** Peripheral TSI0 base pointer */
+#define TSI0                                     ((TSI_Type *)TSI0_BASE)
+#define TSI0_BASE_PTR                            (TSI0)
+/** Array initializer of TSI peripheral base addresses */
+#define TSI_BASE_ADDRS                           { TSI0_BASE }
+/** Array initializer of TSI peripheral base pointers */
+#define TSI_BASE_PTRS                            { TSI0 }
+/** Interrupt vectors for the TSI peripheral type */
+#define TSI_IRQS                                 { TSI0_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- TSI - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup TSI_Register_Accessor_Macros TSI - Register accessor macros
+ * @{
+ */
+
+
+/* TSI - Register instance definitions */
+/* TSI0 */
+#define TSI0_GENCS                               TSI_GENCS_REG(TSI0)
+#define TSI0_DATA                                TSI_DATA_REG(TSI0)
+#define TSI0_TSHD                                TSI_TSHD_REG(TSI0)
+
+/*!
+ * @}
+ */ /* end of group TSI_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group TSI_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- UART Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup UART_Peripheral_Access_Layer UART Peripheral Access Layer
+ * @{
+ */
+
+/** UART - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t BDH;                                /**< UART Baud Rate Register: High, offset: 0x0 */
+  __IO uint8_t BDL;                                /**< UART Baud Rate Register: Low, offset: 0x1 */
+  __IO uint8_t C1;                                 /**< UART Control Register 1, offset: 0x2 */
+  __IO uint8_t C2;                                 /**< UART Control Register 2, offset: 0x3 */
+  __I  uint8_t S1;                                 /**< UART Status Register 1, offset: 0x4 */
+  __IO uint8_t S2;                                 /**< UART Status Register 2, offset: 0x5 */
+  __IO uint8_t C3;                                 /**< UART Control Register 3, offset: 0x6 */
+  __IO uint8_t D;                                  /**< UART Data Register, offset: 0x7 */
+  __IO uint8_t C4;                                 /**< UART Control Register 4, offset: 0x8 */
+} UART_Type, *UART_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- UART - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup UART_Register_Accessor_Macros UART - Register accessor macros
+ * @{
+ */
+
+
+/* UART - Register accessors */
+#define UART_BDH_REG(base)                       ((base)->BDH)
+#define UART_BDL_REG(base)                       ((base)->BDL)
+#define UART_C1_REG(base)                        ((base)->C1)
+#define UART_C2_REG(base)                        ((base)->C2)
+#define UART_S1_REG(base)                        ((base)->S1)
+#define UART_S2_REG(base)                        ((base)->S2)
+#define UART_C3_REG(base)                        ((base)->C3)
+#define UART_D_REG(base)                         ((base)->D)
+#define UART_C4_REG(base)                        ((base)->C4)
+
+/*!
+ * @}
+ */ /* end of group UART_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- UART Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup UART_Register_Masks UART Register Masks
+ * @{
+ */
+
+/* BDH Bit Fields */
+#define UART_BDH_SBR_MASK                        0x1Fu
+#define UART_BDH_SBR_SHIFT                       0
+#define UART_BDH_SBR(x)                          (((uint8_t)(((uint8_t)(x))<<UART_BDH_SBR_SHIFT))&UART_BDH_SBR_MASK)
+#define UART_BDH_SBNS_MASK                       0x20u
+#define UART_BDH_SBNS_SHIFT                      5
+#define UART_BDH_RXEDGIE_MASK                    0x40u
+#define UART_BDH_RXEDGIE_SHIFT                   6
+#define UART_BDH_LBKDIE_MASK                     0x80u
+#define UART_BDH_LBKDIE_SHIFT                    7
+/* BDL Bit Fields */
+#define UART_BDL_SBR_MASK                        0xFFu
+#define UART_BDL_SBR_SHIFT                       0
+#define UART_BDL_SBR(x)                          (((uint8_t)(((uint8_t)(x))<<UART_BDL_SBR_SHIFT))&UART_BDL_SBR_MASK)
+/* C1 Bit Fields */
+#define UART_C1_PT_MASK                          0x1u
+#define UART_C1_PT_SHIFT                         0
+#define UART_C1_PE_MASK                          0x2u
+#define UART_C1_PE_SHIFT                         1
+#define UART_C1_ILT_MASK                         0x4u
+#define UART_C1_ILT_SHIFT                        2
+#define UART_C1_WAKE_MASK                        0x8u
+#define UART_C1_WAKE_SHIFT                       3
+#define UART_C1_M_MASK                           0x10u
+#define UART_C1_M_SHIFT                          4
+#define UART_C1_RSRC_MASK                        0x20u
+#define UART_C1_RSRC_SHIFT                       5
+#define UART_C1_UARTSWAI_MASK                    0x40u
+#define UART_C1_UARTSWAI_SHIFT                   6
+#define UART_C1_LOOPS_MASK                       0x80u
+#define UART_C1_LOOPS_SHIFT                      7
+/* C2 Bit Fields */
+#define UART_C2_SBK_MASK                         0x1u
+#define UART_C2_SBK_SHIFT                        0
+#define UART_C2_RWU_MASK                         0x2u
+#define UART_C2_RWU_SHIFT                        1
+#define UART_C2_RE_MASK                          0x4u
+#define UART_C2_RE_SHIFT                         2
+#define UART_C2_TE_MASK                          0x8u
+#define UART_C2_TE_SHIFT                         3
+#define UART_C2_ILIE_MASK                        0x10u
+#define UART_C2_ILIE_SHIFT                       4
+#define UART_C2_RIE_MASK                         0x20u
+#define UART_C2_RIE_SHIFT                        5
+#define UART_C2_TCIE_MASK                        0x40u
+#define UART_C2_TCIE_SHIFT                       6
+#define UART_C2_TIE_MASK                         0x80u
+#define UART_C2_TIE_SHIFT                        7
+/* S1 Bit Fields */
+#define UART_S1_PF_MASK                          0x1u
+#define UART_S1_PF_SHIFT                         0
+#define UART_S1_FE_MASK                          0x2u
+#define UART_S1_FE_SHIFT                         1
+#define UART_S1_NF_MASK                          0x4u
+#define UART_S1_NF_SHIFT                         2
+#define UART_S1_OR_MASK                          0x8u
+#define UART_S1_OR_SHIFT                         3
+#define UART_S1_IDLE_MASK                        0x10u
+#define UART_S1_IDLE_SHIFT                       4
+#define UART_S1_RDRF_MASK                        0x20u
+#define UART_S1_RDRF_SHIFT                       5
+#define UART_S1_TC_MASK                          0x40u
+#define UART_S1_TC_SHIFT                         6
+#define UART_S1_TDRE_MASK                        0x80u
+#define UART_S1_TDRE_SHIFT                       7
+/* S2 Bit Fields */
+#define UART_S2_RAF_MASK                         0x1u
+#define UART_S2_RAF_SHIFT                        0
+#define UART_S2_LBKDE_MASK                       0x2u
+#define UART_S2_LBKDE_SHIFT                      1
+#define UART_S2_BRK13_MASK                       0x4u
+#define UART_S2_BRK13_SHIFT                      2
+#define UART_S2_RWUID_MASK                       0x8u
+#define UART_S2_RWUID_SHIFT                      3
+#define UART_S2_RXINV_MASK                       0x10u
+#define UART_S2_RXINV_SHIFT                      4
+#define UART_S2_RXEDGIF_MASK                     0x40u
+#define UART_S2_RXEDGIF_SHIFT                    6
+#define UART_S2_LBKDIF_MASK                      0x80u
+#define UART_S2_LBKDIF_SHIFT                     7
+/* C3 Bit Fields */
+#define UART_C3_PEIE_MASK                        0x1u
+#define UART_C3_PEIE_SHIFT                       0
+#define UART_C3_FEIE_MASK                        0x2u
+#define UART_C3_FEIE_SHIFT                       1
+#define UART_C3_NEIE_MASK                        0x4u
+#define UART_C3_NEIE_SHIFT                       2
+#define UART_C3_ORIE_MASK                        0x8u
+#define UART_C3_ORIE_SHIFT                       3
+#define UART_C3_TXINV_MASK                       0x10u
+#define UART_C3_TXINV_SHIFT                      4
+#define UART_C3_TXDIR_MASK                       0x20u
+#define UART_C3_TXDIR_SHIFT                      5
+#define UART_C3_T8_MASK                          0x40u
+#define UART_C3_T8_SHIFT                         6
+#define UART_C3_R8_MASK                          0x80u
+#define UART_C3_R8_SHIFT                         7
+/* D Bit Fields */
+#define UART_D_R0T0_MASK                         0x1u
+#define UART_D_R0T0_SHIFT                        0
+#define UART_D_R1T1_MASK                         0x2u
+#define UART_D_R1T1_SHIFT                        1
+#define UART_D_R2T2_MASK                         0x4u
+#define UART_D_R2T2_SHIFT                        2
+#define UART_D_R3T3_MASK                         0x8u
+#define UART_D_R3T3_SHIFT                        3
+#define UART_D_R4T4_MASK                         0x10u
+#define UART_D_R4T4_SHIFT                        4
+#define UART_D_R5T5_MASK                         0x20u
+#define UART_D_R5T5_SHIFT                        5
+#define UART_D_R6T6_MASK                         0x40u
+#define UART_D_R6T6_SHIFT                        6
+#define UART_D_R7T7_MASK                         0x80u
+#define UART_D_R7T7_SHIFT                        7
+/* C4 Bit Fields */
+#define UART_C4_RDMAS_MASK                       0x20u
+#define UART_C4_RDMAS_SHIFT                      5
+#define UART_C4_TDMAS_MASK                       0x80u
+#define UART_C4_TDMAS_SHIFT                      7
+
+/*!
+ * @}
+ */ /* end of group UART_Register_Masks */
+
+
+/* UART - Peripheral instance base addresses */
+/** Peripheral UART1 base address */
+#define UART1_BASE                               (0x4006B000u)
+/** Peripheral UART1 base pointer */
+#define UART1                                    ((UART_Type *)UART1_BASE)
+#define UART1_BASE_PTR                           (UART1)
+/** Peripheral UART2 base address */
+#define UART2_BASE                               (0x4006C000u)
+/** Peripheral UART2 base pointer */
+#define UART2                                    ((UART_Type *)UART2_BASE)
+#define UART2_BASE_PTR                           (UART2)
+/** Array initializer of UART peripheral base addresses */
+#define UART_BASE_ADDRS                          { UART1_BASE, UART2_BASE }
+/** Array initializer of UART peripheral base pointers */
+#define UART_BASE_PTRS                           { UART1, UART2 }
+/** Interrupt vectors for the UART peripheral type */
+#define UART_RX_TX_IRQS                          { UART1_IRQn, UART2_IRQn }
+#define UART_ERR_IRQS                            { UART1_IRQn, UART2_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- UART - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup UART_Register_Accessor_Macros UART - Register accessor macros
+ * @{
+ */
+
+
+/* UART - Register instance definitions */
+/* UART1 */
+#define UART1_BDH                                UART_BDH_REG(UART1)
+#define UART1_BDL                                UART_BDL_REG(UART1)
+#define UART1_C1                                 UART_C1_REG(UART1)
+#define UART1_C2                                 UART_C2_REG(UART1)
+#define UART1_S1                                 UART_S1_REG(UART1)
+#define UART1_S2                                 UART_S2_REG(UART1)
+#define UART1_C3                                 UART_C3_REG(UART1)
+#define UART1_D                                  UART_D_REG(UART1)
+#define UART1_C4                                 UART_C4_REG(UART1)
+/* UART2 */
+#define UART2_BDH                                UART_BDH_REG(UART2)
+#define UART2_BDL                                UART_BDL_REG(UART2)
+#define UART2_C1                                 UART_C1_REG(UART2)
+#define UART2_C2                                 UART_C2_REG(UART2)
+#define UART2_S1                                 UART_S1_REG(UART2)
+#define UART2_S2                                 UART_S2_REG(UART2)
+#define UART2_C3                                 UART_C3_REG(UART2)
+#define UART2_D                                  UART_D_REG(UART2)
+#define UART2_C4                                 UART_C4_REG(UART2)
+
+/*!
+ * @}
+ */ /* end of group UART_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group UART_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- UART0 Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup UART0_Peripheral_Access_Layer UART0 Peripheral Access Layer
+ * @{
+ */
+
+/** UART0 - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t BDH;                                /**< UART Baud Rate Register High, offset: 0x0 */
+  __IO uint8_t BDL;                                /**< UART Baud Rate Register Low, offset: 0x1 */
+  __IO uint8_t C1;                                 /**< UART Control Register 1, offset: 0x2 */
+  __IO uint8_t C2;                                 /**< UART Control Register 2, offset: 0x3 */
+  __IO uint8_t S1;                                 /**< UART Status Register 1, offset: 0x4 */
+  __IO uint8_t S2;                                 /**< UART Status Register 2, offset: 0x5 */
+  __IO uint8_t C3;                                 /**< UART Control Register 3, offset: 0x6 */
+  __IO uint8_t D;                                  /**< UART Data Register, offset: 0x7 */
+  __IO uint8_t MA1;                                /**< UART Match Address Registers 1, offset: 0x8 */
+  __IO uint8_t MA2;                                /**< UART Match Address Registers 2, offset: 0x9 */
+  __IO uint8_t C4;                                 /**< UART Control Register 4, offset: 0xA */
+  __IO uint8_t C5;                                 /**< UART Control Register 5, offset: 0xB */
+} UART0_Type, *UART0_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- UART0 - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup UART0_Register_Accessor_Macros UART0 - Register accessor macros
+ * @{
+ */
+
+
+/* UART0 - Register accessors */
+#define UART0_BDH_REG(base)                      ((base)->BDH)
+#define UART0_BDL_REG(base)                      ((base)->BDL)
+#define UART0_C1_REG(base)                       ((base)->C1)
+#define UART0_C2_REG(base)                       ((base)->C2)
+#define UART0_S1_REG(base)                       ((base)->S1)
+#define UART0_S2_REG(base)                       ((base)->S2)
+#define UART0_C3_REG(base)                       ((base)->C3)
+#define UART0_D_REG(base)                        ((base)->D)
+#define UART0_MA1_REG(base)                      ((base)->MA1)
+#define UART0_MA2_REG(base)                      ((base)->MA2)
+#define UART0_C4_REG(base)                       ((base)->C4)
+#define UART0_C5_REG(base)                       ((base)->C5)
+
+/*!
+ * @}
+ */ /* end of group UART0_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- UART0 Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup UART0_Register_Masks UART0 Register Masks
+ * @{
+ */
+
+/* BDH Bit Fields */
+#define UART0_BDH_SBR_MASK                       0x1Fu
+#define UART0_BDH_SBR_SHIFT                      0
+#define UART0_BDH_SBR(x)                         (((uint8_t)(((uint8_t)(x))<<UART0_BDH_SBR_SHIFT))&UART0_BDH_SBR_MASK)
+#define UART0_BDH_SBNS_MASK                      0x20u
+#define UART0_BDH_SBNS_SHIFT                     5
+#define UART0_BDH_RXEDGIE_MASK                   0x40u
+#define UART0_BDH_RXEDGIE_SHIFT                  6
+#define UART0_BDH_LBKDIE_MASK                    0x80u
+#define UART0_BDH_LBKDIE_SHIFT                   7
+/* BDL Bit Fields */
+#define UART0_BDL_SBR_MASK                       0xFFu
+#define UART0_BDL_SBR_SHIFT                      0
+#define UART0_BDL_SBR(x)                         (((uint8_t)(((uint8_t)(x))<<UART0_BDL_SBR_SHIFT))&UART0_BDL_SBR_MASK)
+/* C1 Bit Fields */
+#define UART0_C1_PT_MASK                         0x1u
+#define UART0_C1_PT_SHIFT                        0
+#define UART0_C1_PE_MASK                         0x2u
+#define UART0_C1_PE_SHIFT                        1
+#define UART0_C1_ILT_MASK                        0x4u
+#define UART0_C1_ILT_SHIFT                       2
+#define UART0_C1_WAKE_MASK                       0x8u
+#define UART0_C1_WAKE_SHIFT                      3
+#define UART0_C1_M_MASK                          0x10u
+#define UART0_C1_M_SHIFT                         4
+#define UART0_C1_RSRC_MASK                       0x20u
+#define UART0_C1_RSRC_SHIFT                      5
+#define UART0_C1_DOZEEN_MASK                     0x40u
+#define UART0_C1_DOZEEN_SHIFT                    6
+#define UART0_C1_LOOPS_MASK                      0x80u
+#define UART0_C1_LOOPS_SHIFT                     7
+/* C2 Bit Fields */
+#define UART0_C2_SBK_MASK                        0x1u
+#define UART0_C2_SBK_SHIFT                       0
+#define UART0_C2_RWU_MASK                        0x2u
+#define UART0_C2_RWU_SHIFT                       1
+#define UART0_C2_RE_MASK                         0x4u
+#define UART0_C2_RE_SHIFT                        2
+#define UART0_C2_TE_MASK                         0x8u
+#define UART0_C2_TE_SHIFT                        3
+#define UART0_C2_ILIE_MASK                       0x10u
+#define UART0_C2_ILIE_SHIFT                      4
+#define UART0_C2_RIE_MASK                        0x20u
+#define UART0_C2_RIE_SHIFT                       5
+#define UART0_C2_TCIE_MASK                       0x40u
+#define UART0_C2_TCIE_SHIFT                      6
+#define UART0_C2_TIE_MASK                        0x80u
+#define UART0_C2_TIE_SHIFT                       7
+/* S1 Bit Fields */
+#define UART0_S1_PF_MASK                         0x1u
+#define UART0_S1_PF_SHIFT                        0
+#define UART0_S1_FE_MASK                         0x2u
+#define UART0_S1_FE_SHIFT                        1
+#define UART0_S1_NF_MASK                         0x4u
+#define UART0_S1_NF_SHIFT                        2
+#define UART0_S1_OR_MASK                         0x8u
+#define UART0_S1_OR_SHIFT                        3
+#define UART0_S1_IDLE_MASK                       0x10u
+#define UART0_S1_IDLE_SHIFT                      4
+#define UART0_S1_RDRF_MASK                       0x20u
+#define UART0_S1_RDRF_SHIFT                      5
+#define UART0_S1_TC_MASK                         0x40u
+#define UART0_S1_TC_SHIFT                        6
+#define UART0_S1_TDRE_MASK                       0x80u
+#define UART0_S1_TDRE_SHIFT                      7
+/* S2 Bit Fields */
+#define UART0_S2_RAF_MASK                        0x1u
+#define UART0_S2_RAF_SHIFT                       0
+#define UART0_S2_LBKDE_MASK                      0x2u
+#define UART0_S2_LBKDE_SHIFT                     1
+#define UART0_S2_BRK13_MASK                      0x4u
+#define UART0_S2_BRK13_SHIFT                     2
+#define UART0_S2_RWUID_MASK                      0x8u
+#define UART0_S2_RWUID_SHIFT                     3
+#define UART0_S2_RXINV_MASK                      0x10u
+#define UART0_S2_RXINV_SHIFT                     4
+#define UART0_S2_MSBF_MASK                       0x20u
+#define UART0_S2_MSBF_SHIFT                      5
+#define UART0_S2_RXEDGIF_MASK                    0x40u
+#define UART0_S2_RXEDGIF_SHIFT                   6
+#define UART0_S2_LBKDIF_MASK                     0x80u
+#define UART0_S2_LBKDIF_SHIFT                    7
+/* C3 Bit Fields */
+#define UART0_C3_PEIE_MASK                       0x1u
+#define UART0_C3_PEIE_SHIFT                      0
+#define UART0_C3_FEIE_MASK                       0x2u
+#define UART0_C3_FEIE_SHIFT                      1
+#define UART0_C3_NEIE_MASK                       0x4u
+#define UART0_C3_NEIE_SHIFT                      2
+#define UART0_C3_ORIE_MASK                       0x8u
+#define UART0_C3_ORIE_SHIFT                      3
+#define UART0_C3_TXINV_MASK                      0x10u
+#define UART0_C3_TXINV_SHIFT                     4
+#define UART0_C3_TXDIR_MASK                      0x20u
+#define UART0_C3_TXDIR_SHIFT                     5
+#define UART0_C3_R9T8_MASK                       0x40u
+#define UART0_C3_R9T8_SHIFT                      6
+#define UART0_C3_R8T9_MASK                       0x80u
+#define UART0_C3_R8T9_SHIFT                      7
+/* D Bit Fields */
+#define UART0_D_R0T0_MASK                        0x1u
+#define UART0_D_R0T0_SHIFT                       0
+#define UART0_D_R1T1_MASK                        0x2u
+#define UART0_D_R1T1_SHIFT                       1
+#define UART0_D_R2T2_MASK                        0x4u
+#define UART0_D_R2T2_SHIFT                       2
+#define UART0_D_R3T3_MASK                        0x8u
+#define UART0_D_R3T3_SHIFT                       3
+#define UART0_D_R4T4_MASK                        0x10u
+#define UART0_D_R4T4_SHIFT                       4
+#define UART0_D_R5T5_MASK                        0x20u
+#define UART0_D_R5T5_SHIFT                       5
+#define UART0_D_R6T6_MASK                        0x40u
+#define UART0_D_R6T6_SHIFT                       6
+#define UART0_D_R7T7_MASK                        0x80u
+#define UART0_D_R7T7_SHIFT                       7
+/* MA1 Bit Fields */
+#define UART0_MA1_MA_MASK                        0xFFu
+#define UART0_MA1_MA_SHIFT                       0
+#define UART0_MA1_MA(x)                          (((uint8_t)(((uint8_t)(x))<<UART0_MA1_MA_SHIFT))&UART0_MA1_MA_MASK)
+/* MA2 Bit Fields */
+#define UART0_MA2_MA_MASK                        0xFFu
+#define UART0_MA2_MA_SHIFT                       0
+#define UART0_MA2_MA(x)                          (((uint8_t)(((uint8_t)(x))<<UART0_MA2_MA_SHIFT))&UART0_MA2_MA_MASK)
+/* C4 Bit Fields */
+#define UART0_C4_OSR_MASK                        0x1Fu
+#define UART0_C4_OSR_SHIFT                       0
+#define UART0_C4_OSR(x)                          (((uint8_t)(((uint8_t)(x))<<UART0_C4_OSR_SHIFT))&UART0_C4_OSR_MASK)
+#define UART0_C4_M10_MASK                        0x20u
+#define UART0_C4_M10_SHIFT                       5
+#define UART0_C4_MAEN2_MASK                      0x40u
+#define UART0_C4_MAEN2_SHIFT                     6
+#define UART0_C4_MAEN1_MASK                      0x80u
+#define UART0_C4_MAEN1_SHIFT                     7
+/* C5 Bit Fields */
+#define UART0_C5_RESYNCDIS_MASK                  0x1u
+#define UART0_C5_RESYNCDIS_SHIFT                 0
+#define UART0_C5_BOTHEDGE_MASK                   0x2u
+#define UART0_C5_BOTHEDGE_SHIFT                  1
+#define UART0_C5_RDMAE_MASK                      0x20u
+#define UART0_C5_RDMAE_SHIFT                     5
+#define UART0_C5_TDMAE_MASK                      0x80u
+#define UART0_C5_TDMAE_SHIFT                     7
+
+/*!
+ * @}
+ */ /* end of group UART0_Register_Masks */
+
+
+/* UART0 - Peripheral instance base addresses */
+/** Peripheral UART0 base address */
+#define UART0_BASE                               (0x4006A000u)
+/** Peripheral UART0 base pointer */
+#define UART0                                    ((UART0_Type *)UART0_BASE)
+#define UART0_BASE_PTR                           (UART0)
+/** Array initializer of UART0 peripheral base addresses */
+#define UART0_BASE_ADDRS                         { UART0_BASE }
+/** Array initializer of UART0 peripheral base pointers */
+#define UART0_BASE_PTRS                          { UART0 }
+/** Interrupt vectors for the UART0 peripheral type */
+#define UART0_RX_TX_IRQS                         { UART0_IRQn }
+#define UART0_ERR_IRQS                           { UART0_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- UART0 - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup UART0_Register_Accessor_Macros UART0 - Register accessor macros
+ * @{
+ */
+
+
+/* UART0 - Register instance definitions */
+/* UART0 */
+#define UART0_BDH                                UART0_BDH_REG(UART0)
+#define UART0_BDL                                UART0_BDL_REG(UART0)
+#define UART0_C1                                 UART0_C1_REG(UART0)
+#define UART0_C2                                 UART0_C2_REG(UART0)
+#define UART0_S1                                 UART0_S1_REG(UART0)
+#define UART0_S2                                 UART0_S2_REG(UART0)
+#define UART0_C3                                 UART0_C3_REG(UART0)
+#define UART0_D                                  UART0_D_REG(UART0)
+#define UART0_MA1                                UART0_MA1_REG(UART0)
+#define UART0_MA2                                UART0_MA2_REG(UART0)
+#define UART0_C4                                 UART0_C4_REG(UART0)
+#define UART0_C5                                 UART0_C5_REG(UART0)
+
+/*!
+ * @}
+ */ /* end of group UART0_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group UART0_Peripheral_Access_Layer */
+
+
+/*
+** End of section using anonymous unions
+*/
+
+#if defined(__ARMCC_VERSION)
+  #pragma pop
+#elif defined(__CWCC__)
+  #pragma pop
+#elif defined(__GNUC__)
+  /* leave anonymous unions enabled */
+#elif defined(__IAR_SYSTEMS_ICC__)
+  #pragma language=default
+#else
+  #error Not supported compiler type
+#endif
+
+/*!
+ * @}
+ */ /* end of group Peripheral_access_layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- Backward Compatibility
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup Backward_Compatibility_Symbols Backward Compatibility
+ * @{
+ */
+
+#define FPTA_BASE                                FGPIOA_BASE
+#define FPTA                                     FGPIOA
+#define FPTB_BASE                                FGPIOB_BASE
+#define FPTB                                     FGPIOB
+#define FPTC_BASE                                FGPIOC_BASE
+#define FPTC                                     FGPIOC
+#define FPTD_BASE                                FGPIOD_BASE
+#define FPTD                                     FGPIOD
+#define FPTE_BASE                                FGPIOE_BASE
+#define FPTE                                     FGPIOE
+#define PTA_BASE                                 GPIOA_BASE
+#define PTA                                      GPIOA
+#define PTB_BASE                                 GPIOB_BASE
+#define PTB                                      GPIOB
+#define PTC_BASE                                 GPIOC_BASE
+#define PTC                                      GPIOC
+#define PTD_BASE                                 GPIOD_BASE
+#define PTD                                      GPIOD
+#define PTE_BASE                                 GPIOE_BASE
+#define PTE                                      GPIOE
+#define I2C_FLT_STOPIE_MASK                      This_symbol_has_been_deprecated
+#define I2C_FLT_STOPIE_SHIFT                     This_symbol_has_been_deprecated
+#define MCG_S_LOLS_MASK                          MCG_S_LOLS0_MASK
+#define MCG_S_LOLS_SHIFT                         MCG_S_LOLS0_SHIFT
+#define NVIC_ISER_SETENA_MASK                    0xFFFFFFFFu
+#define NVIC_ISER_SETENA_SHIFT                   0
+#define NVIC_ISER_SETENA(x)                      (((uint32_t)(((uint32_t)(x))<<NVIC_ISER_SETENA_SHIFT))&NVIC_ISER_SETENA_MASK)
+#define NVIC_ICER_CLRENA_MASK                    0xFFFFFFFFu
+#define NVIC_ICER_CLRENA_SHIFT                   0
+#define NVIC_ICER_CLRENA(x)                      (((uint32_t)(((uint32_t)(x))<<NVIC_ICER_CLRENA_SHIFT))&NVIC_ICER_CLRENA_MASK)
+#define NVIC_ISPR_SETPEND_MASK                   0xFFFFFFFFu
+#define NVIC_ISPR_SETPEND_SHIFT                  0
+#define NVIC_ISPR_SETPEND(x)                     (((uint32_t)(((uint32_t)(x))<<NVIC_ISPR_SETPEND_SHIFT))&NVIC_ISPR_SETPEND_MASK)
+#define NVIC_ICPR_CLRPEND_MASK                   0xFFFFFFFFu
+#define NVIC_ICPR_CLRPEND_SHIFT                  0
+#define NVIC_ICPR_CLRPEND(x)                     (((uint32_t)(((uint32_t)(x))<<NVIC_ICPR_CLRPEND_SHIFT))&NVIC_ICPR_CLRPEND_MASK)
+#define LPTimer_IRQn                             LPTMR0_IRQn
+#define LPTimer_IRQHandler                       LPTMR0_IRQHandler
+
+/*!
+ * @}
+ */ /* end of group Backward_Compatibility_Symbols */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#else /* #if !defined(MKW01Z4_H_) */
+  /* There is already included the same memory map. Check if it is compatible (has the same major version) */
+  #if (MCU_MEM_MAP_VERSION != 0x0100u)
+    #if (!defined(MCU_MEM_MAP_SUPPRESS_VERSION_WARNING))
+      #warning There are included two not compatible versions of memory maps. Please check possible differences.
+    #endif /* (!defined(MCU_MEM_MAP_SUPPRESS_VERSION_WARNING)) */
+  #endif /* (MCU_MEM_MAP_VERSION != 0x0100u) */
+#endif  /* #if !defined(MKW01Z4_H_) */
+
+/* MKW01Z4.h, eof. */

--- a/cpu/kw0x/include/cpu-conf.h
+++ b/cpu/kw0x/include/cpu-conf.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup        cpu_kw0x KW0x SiP
+ * @ingroup         cpu
+ * @brief           CPU specific implementations for the Freescale MKW0x SiP.
+ *                  The SiP incorporates a low power Sub-1 GHz transceiver and a
+ *                  Kinetis Cortex-M0+ MCU.
+ * @{
+ *
+ * @file
+ * @brief           Implementation specific CPU configuration options
+ *
+ * @author          Hauke Petersen <hauke.peterse@fu-berlin.de>
+ * @author          Johann Fischer <j.fischer@phytec.de>
+ */
+
+#ifndef __CPU_CONF_H
+#define __CPU_CONF_H
+
+#ifdef CPU_MODEL_KW01Z128
+#include "MKW01Z4.h"
+#include "mcg.h"
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @name Kernel configuration
+ *
+ * @{
+ */
+#define KERNEL_CONF_STACKSIZE_PRINTF     (1024)
+
+#ifndef KERNEL_CONF_STACKSIZE_DEFAULT
+#define KERNEL_CONF_STACKSIZE_DEFAULT    (1024)
+#endif
+
+#define KERNEL_CONF_STACKSIZE_IDLE       (256)
+/** @} */
+
+/**
+ * @brief Length for reading CPU_ID in octets
+ */
+#define CPUID_ID_LEN                     (12)
+
+/**
+ * @brief Pointer to CPU_ID
+ */
+#define CPUID_ID_PTR                     ((void *)(&(SIM->UIDMH)))
+
+/**
+ * @name UART0 buffer size definition for compatibility reasons.
+ *
+ * TODO: remove once the remodeling of the uart0 driver is done.
+ * @{
+ */
+#ifndef UART0_BUFSIZE
+#define UART0_BUFSIZE                    (128)
+#endif
+/** @} */
+
+#define TRANSCEIVER_BUFFER_SIZE          (3) /**< Buffer Size for Transceiver Module */
+
+/**
+ * @brief MCU specific Low Power Timer settings.
+ */
+#define LPTIMER_CLKSRC                   LPTIMER_CLKSRC_LPO
+#define LPTIMER_DEV                      (LPTMR0) /**< LPTIMER hardware module */
+#define LPTIMER_CLKEN()                  (SIM->SCGC5 |= SIM_SCGC5_LPTMR_MASK) /**< Enable LPTMR0 clock gate */
+#define LPTIMER_CLKDIS()                 (SIM->SCGC5 &= ~SIM_SCGC5_PTMR_MASK) /**< Disable LPTMR0 clock gate */
+#define LPTIMER_CNR_NEEDS_LATCHING       1 /**< LPTMR.CNR register do not need latching */
+
+/**
+ * @name MKW0XD SiP internal interconnects between MCU and Modem.
+ *
+ * @{
+ */
+/* TODO */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CPU_CONF_H */
+/** @} */

--- a/cpu/kw0x/interrupt-vector.c
+++ b/cpu/kw0x/interrupt-vector.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_kw0x
+ * @{
+ *
+ * @file
+ * @brief       Startup code and interrupt vector definition
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include "cpu-conf.h"
+#include "fault_handlers.h"
+
+/**
+ * memory markers as defined in the linker script
+ */
+extern uint32_t _estack;
+
+extern void reset_handler(void);
+
+void dummy_handler(void)
+{
+    isr_unhandled();
+}
+
+/* Cortex-M specific interrupt vectors */
+void isr_svc(void)                  __attribute__ ((weak, alias("dummy_handler")));
+void isr_pendsv(void)               __attribute__ ((weak, alias("dummy_handler")));
+void isr_systick(void)              __attribute__ ((weak, alias("dummy_handler")));
+
+/* MKW01Z128 specific interrupt vector */
+void isr_dma0(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_dma1(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_dma2(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_dma3(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_ftfa(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_lvd_lvw(void)              __attribute__ ((weak, alias("dummy_handler")));
+void isr_llwu(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_i2c0(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_i2c1(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_spi0(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_spi1(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_uart0(void)                __attribute__ ((weak, alias("dummy_handler")));
+void isr_uart1(void)                __attribute__ ((weak, alias("dummy_handler")));
+void isr_uart2(void)                __attribute__ ((weak, alias("dummy_handler")));
+void isr_adc0(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_cmp0(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_tpm0(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_tpm1(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_tpm2(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_rtc(void)                  __attribute__ ((weak, alias("dummy_handler")));
+void isr_rtc_seconds(void)          __attribute__ ((weak, alias("dummy_handler")));
+void isr_pit(void)                  __attribute__ ((weak, alias("dummy_handler")));
+void isr_i2s0(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_dac0(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_tsi0(void)                 __attribute__ ((weak, alias("dummy_handler")));
+void isr_mcg(void)                  __attribute__ ((weak, alias("dummy_handler")));
+void isr_lptmr0(void)               __attribute__ ((weak, alias("dummy_handler")));
+void isr_porta(void)                __attribute__ ((weak, alias("dummy_handler")));
+void isr_portc_portd(void)          __attribute__ ((weak, alias("dummy_handler")));
+
+/* interrupt vector table */
+__attribute__((section(".vector_table")))
+const void *interrupt_vector[64] = {
+    /* Stack pointer */
+    (void*) (&_estack),             /* pointer to the top of the empty stack */
+    /* Cortex-M4 handlers */
+    (void*) reset_handler,          /* entry point of the program */
+    (void*) isr_nmi,                /* non maskable interrupt handler */
+    (void*) isr_hard_fault,         /* if you end up here its not good */
+    (void*) (0UL),                  /* Reserved */
+    (void*) (0UL),                  /* Reserved */
+    (void*) (0UL),                  /* Reserved */
+    (void*) (0UL),                  /* Reserved */
+    (void*) (0UL),                  /* Reserved */
+    (void*) (0UL),                  /* Reserved */
+    (void*) (0UL),                  /* Reserved */
+    (void*) isr_svc,                /* system call interrupt */
+    (void*) (0UL),                  /* Reserved */
+    (void*) (0UL),                  /* Reserved */
+    (void*) isr_pendsv,             /* pendSV interrupt, used for task switching in RIOT */
+    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
+    /* MKW01Z128 specific peripheral handlers */
+    (void*) isr_dma0,		    /* DMA channel 0 transfer complete */
+    (void*) isr_dma1,		    /* DMA channel 1 transfer complete */
+    (void*) isr_dma2,		    /* DMA channel 2 transfer complete */
+    (void*) isr_dma3,		    /* DMA channel 3 transfer complete */
+    (void*) dummy_handler,          /* Reserved interrupt 4 */
+    (void*) isr_ftfa,		    /* FTFA command complete */
+    (void*) isr_lvd_lvw,            /* Low-Voltage detect and warning */
+    (void*) isr_llwu,		    /* Low leakage wakeup */
+    (void*) isr_i2c0,		    /* Inter-integrated circuit 0 */
+    (void*) isr_i2c1,		    /* Inter-integrated circuit 1 */
+    (void*) isr_spi0,		    /* Serial peripheral Interface 0 */
+    (void*) isr_spi1,		    /* Serial peripheral Interface 1 */
+    (void*) isr_uart0,	            /* UART0 receive/transmit/error interrupt */
+    (void*) isr_uart1,	            /* UART1 receive/transmit/error interrupt */
+    (void*) isr_uart2,	            /* UART2 receive/transmit/error interrupt */
+    (void*) isr_adc0,		    /* Analog-to-digital converter 0 */
+    (void*) isr_cmp0,		    /* Comparator 0 */
+    (void*) isr_tpm0, 		    /* Timer module 0 status interrupt */
+    (void*) isr_tpm1, 		    /* Timer module 1 status interrupt */
+    (void*) isr_tpm2, 		    /* Timer module 2 status interrupt */
+    (void*) isr_rtc,		    /* Real time clock */
+    (void*) isr_rtc_seconds,	    /* Real time clock seconds */
+    (void*) isr_pit,		    /* Periodic interrupt timer channel 0 */
+    (void*) isr_i2s0,	            /* Integrated interchip sound 0 transmit interrupt */
+    (void*) dummy_handler,          /* Reserved interrupt */
+    (void*) isr_dac0,		    /* Digital-to-analog converter 0 */
+    (void*) isr_tsi0,		    /* TSI0 interrupt */
+    (void*) isr_mcg,		    /* Multipurpose clock generator */
+    (void*) isr_lptmr0,		    /* Low power timer interrupt */
+    (void*) dummy_handler,          /* Reserved interrupt 29 */
+    (void*) isr_porta,		    /* Port A pin detect interrupt */
+    (void*) isr_portc_portd,	    /* Port C+D pin detect interrupt */
+};

--- a/cpu/kw0x/kw01z128_linkerscript.ld
+++ b/cpu/kw0x/kw01z128_linkerscript.ld
@@ -1,0 +1,13 @@
+OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+
+/* Memory Spaces Definitions */
+MEMORY
+{
+    vectors (rx)  : ORIGIN = 0x00000000, LENGTH = 0x400
+    flashsec (rx) : ORIGIN = 0x00000400, LENGTH = 0x10
+    flash (rx)    : ORIGIN = 0x00000410, LENGTH = 128K - 0x410
+    sram (rwx)  : ORIGIN = 0x1ffff000, LENGTH = 16K
+}
+
+INCLUDE kinetis-kl0x.ld

--- a/cpu/kw0x/lpm_arch.c
+++ b/cpu/kw0x/lpm_arch.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_kw0x
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the kernels power management interface
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "arch/lpm_arch.h"
+
+void lpm_arch_init(void)
+{
+    /* TODO */
+}
+
+enum lpm_mode lpm_arch_set(enum lpm_mode target)
+{
+    /* TODO */
+    return 0;
+}
+
+enum lpm_mode lpm_arch_get(void)
+{
+    /* TODO */
+    return 0;
+}
+
+void lpm_arch_awake(void)
+{
+    /* TODO */
+}
+
+void lpm_arch_begin_awake(void)
+{
+    /* TODO */
+}
+
+void lpm_arch_end_awake(void)
+{
+    /* TODO */
+}

--- a/cpu/kw0x/periph/Makefile
+++ b/cpu/kw0x/periph/Makefile
@@ -1,0 +1,3 @@
+MODULE = periph
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/kw0x/reboot_arch.c
+++ b/cpu/kw0x/reboot_arch.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_kw0x
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the kernels reboot interface
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "arch/reboot_arch.h"
+#include "cpu.h"
+
+
+int reboot_arch(int mode)
+{
+    printf("Going into reboot, mode %i\n", mode);
+
+    NVIC_SystemReset();
+
+    return 0;
+}

--- a/cpu/kw0x/syscalls.c
+++ b/cpu/kw0x/syscalls.c
@@ -1,0 +1,337 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_kw0x
+ * @{
+ *
+ * @file
+ * @brief       NewLib system call implementations for MKW2xD SiP
+ *
+ * @author      Michael Baar <michael.baar@fu-berlin.de>
+ * @author      Stefan Pfeiffer <pfeiffer@inf.fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ *
+ * @}
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/unistd.h>
+#include <stdint.h>
+
+#include "board.h"
+#include "thread.h"
+#include "kernel.h"
+#include "mutex.h"
+#include "ringbuffer.h"
+#include "irq.h"
+#include "periph/uart.h"
+
+#ifdef MODULE_UART0
+#include "board_uart0.h"
+#endif
+
+/**
+ * manage the heap
+ */
+extern uintptr_t __heap_start;		/* start of heap memory space */
+extern uintptr_t __heap_max;		/* maximum for end of heap memory space */
+
+/* current position in heap */
+static caddr_t heap = {(caddr_t)&__heap_start};
+/* maximum position in heap */
+static const caddr_t heap_max = {(caddr_t)&__heap_max};
+/* start position in heap */
+static const caddr_t heap_start = {(caddr_t)&__heap_start};
+
+#ifndef MODULE_UART0
+/**
+ * @brief use mutex for waiting on incoming UART chars
+ */
+static mutex_t uart_rx_mutex;
+static char rx_buf_mem[STDIO_RX_BUFSIZE];
+static ringbuffer_t rx_buf;
+#endif
+
+/**
+ * @brief Receive a new character from the UART and put it into the receive buffer
+ */
+void rx_cb(void *arg, char data)
+{
+#ifndef MODULE_UART0
+    (void)arg;
+
+    ringbuffer_add_one(&rx_buf, data);
+    mutex_unlock(&uart_rx_mutex);
+#else
+    if (uart0_handler_pid) {
+        uart0_handle_incoming(data);
+
+        uart0_notify_thread();
+    }
+#endif
+}
+
+/**
+ * @brief Initialize NewLib, called by __libc_init_array() from the startup script
+ */
+void _init(void)
+{
+#ifndef MODULE_UART0
+    mutex_init(&uart_rx_mutex);
+    ringbuffer_init(&rx_buf, rx_buf_mem, STDIO_RX_BUFSIZE);
+#endif
+    uart_init(STDIO, STDIO_BAUDRATE, rx_cb, 0, 0);
+}
+
+/**
+ * @brief Free resources on NewLib de-initialization, not used for RIOT
+ */
+void _fini(void)
+{
+    /* nothing to do here */
+}
+
+/**
+ * @brief Exit a program without cleaning up files
+ *
+ * If your system doesn't provide this, it is best to avoid linking with subroutines that
+ * require it (exit, system).
+ *
+ * @param n     the exit code, 0 for all OK, >0 for not OK
+ */
+void _exit(int n)
+{
+    printf("#! exit %i: resetting\n", n);
+    NVIC_SystemReset();
+    while(1);
+}
+
+/**
+ * @brief Allocate memory from the heap.
+ *
+ * The current heap implementation is very rudimentary, it is only able to allocate
+ * memory. But it does not
+ * - check if the returned address is valid (no check if the memory very exists)
+ * - have any means to free memory again
+ *
+ * @return [description]
+ */
+caddr_t _sbrk_r(struct _reent *r, size_t incr)
+{
+    uint32_t cpsr = disableIRQ();
+
+    caddr_t new_heap = heap + incr;
+
+    /* check the heap for a chunk of the requested size */
+    if( new_heap <= heap_max ) {
+        caddr_t prev_heap = heap;
+        heap = new_heap;
+
+        r->_errno = 0;
+        restoreIRQ(cpsr);
+        return prev_heap;
+    }
+
+    restoreIRQ(cpsr);
+    r->_errno = ENOMEM;
+    return NULL;
+}
+
+/**
+ * @brief Get the process-ID of the current thread
+ *
+ * @return      the process ID of the current thread
+ */
+int _getpid(void)
+{
+    return sched_active_thread->pid;
+}
+
+/**
+ * @brief Send a signal to a given thread
+ *
+ * @param r     TODO
+ * @param pid   TODO
+ * @param sig   TODO
+ *
+ * @return      TODO
+ */
+int _kill_r(struct _reent *r, int pid, int sig)
+{
+    r->_errno = ESRCH;                      /* not implemented yet */
+    return -1;
+}
+
+/**
+ * @brief Open a file
+ *
+ * @param r     TODO
+ * @param name  TODO
+ * @param mode  TODO
+ *
+ * @return      TODO
+ */
+int _open_r(struct _reent *r, const char *name, int mode)
+{
+    r->_errno = ENODEV;                     /* not implemented yet */
+    return -1;
+}
+
+/**
+ * @brief Read from a file
+ *
+ * All input is read from UART_0. The function will block until a byte is actually read.
+ *
+ * Note: the read function does not buffer - data will be lost if the function is not
+ * called fast enough.
+ *
+ * TODO: implement more sophisticated read call.
+ *
+ * @param r     TODO
+ * @param fd    TODO
+ * @param buffer TODO
+ * @param int   TODO
+ *
+ * @return      TODO
+ */
+int _read_r(struct _reent *r, int fd, void *buffer, unsigned int count)
+{
+#ifndef MODULE_UART0
+    while (rx_buf.avail == 0) {
+        mutex_lock(&uart_rx_mutex);
+    }
+    return ringbuffer_get(&rx_buf, (char*)buffer, rx_buf.avail);
+#else
+    char *res = (char*)buffer;
+    res[0] = (char)uart0_readc();
+    return 1;
+#endif
+}
+
+/**
+ * @brief Write characters to a file
+ *
+ * All output is currently directed to UART_0, independent of the given file descriptor.
+ * The write call will further block until the byte is actually written to the UART.
+ *
+ * TODO: implement more sophisticated write call.
+ *
+ * @param r     TODO
+ * @param fd    TODO
+ * @param data  TODO
+ * @param int   TODO
+ *
+ * @return      TODO
+ */
+int _write_r(struct _reent *r, int fd, const void *data, unsigned int count)
+{
+    char *c = (char*)data;
+    for (int i = 0; i < count; i++) {
+        uart_write_blocking(STDIO, c[i]);
+    }
+    return count;
+}
+
+/**
+ * @brief Close a file
+ *
+ * @param r     TODO
+ * @param fd    TODO
+ *
+ * @return      TODO
+ */
+int _close_r(struct _reent *r, int fd)
+{
+    r->_errno = ENODEV;                     /* not implemented yet */
+    return -1;
+}
+
+/**
+ * @brief Set position in a file
+ *
+ * @param r     TODO
+ * @param fd    TODO
+ * @param pos   TODO
+ * @param dir   TODO
+ *
+ * @return      TODO
+ */
+_off_t _lseek_r(struct _reent *r, int fd, _off_t pos, int dir)
+{
+    r->_errno = ENODEV;                     /* not implemented yet */
+    return -1;
+}
+
+/**
+ * @brief Status of an open file
+ *
+ * @param r     TODO
+ * @param fd    TODO
+ * @param stat  TODO
+ *
+ * @return      TODO
+ */
+int _fstat_r(struct _reent *r, int fd, struct stat * st)
+{
+    r->_errno = ENODEV;                     /* not implemented yet */
+    return -1;
+}
+
+/**
+ * @brief Status of a file (by name)
+ *
+ * @param r     TODO
+ * @param name  TODO
+ * @param stat  TODO
+ *
+ * @return      TODO
+ */
+int _stat_r(struct _reent *r, char *name, struct stat *st)
+{
+    r->_errno = ENODEV;                     /* not implemented yet */
+    return -1;
+}
+
+/**
+ * @brief Query whether output stream is a terminal
+ *
+ * @param r     TODO
+ * @param fd    TODO
+ *
+ * @return      TODO
+ */
+int _isatty_r(struct _reent *r, int fd)
+{
+    r->_errno = 0;
+    if(fd == STDOUT_FILENO || fd == STDERR_FILENO) {
+        return 1;
+    }
+    else {
+        return 0;
+    }
+}
+
+/**
+ * @brief  Remove a file's directory entry
+ *
+ * @param r     TODO
+ * @param path  TODO
+ *
+ * @return      TODO
+ */
+int _unlink_r(struct _reent *r, char* path)
+{
+    r->_errno = ENODEV;                     /* not implemented yet */
+    return -1;
+}

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -826,6 +826,7 @@ EXCLUDE_PATTERNS       = */board/*/tools/* \
                          */cpu/x86/include/x86_pci.h \
                          */cpu/sam3x8e/include/sam3x8e.h \
                          */cpu/stm32l1/include/stm32l1xx.h \
+                         */cpu/kw0x/include/MKW01Z4.h \
 
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names

--- a/tests/pthread_rwlock/Makefile
+++ b/tests/pthread_rwlock/Makefile
@@ -14,6 +14,6 @@ CFLAGS += -DNATIVE_AUTO_EXIT
 
 BOARD_INSUFFICIENT_RAM += chronos mbed_lpc1768 msb-430 msb-430h stm32f0discovery \
                           pca10000 pca10005 yunjia-nrf51822 spark-core nucleo-f334 \
-                          airfy-beacon
+                          airfy-beacon pba-d-01-kw01
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -2,7 +2,8 @@ APPLICATION = thread_cooperation
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_RAM := chronos msb-430 msb-430h mbed_lpc1768 redbee-econotag stm32f0discovery \
-                          pca10000 pca10005 yunjia-nrf51822 spark-core airfy-beacon nucleo-f334
+                          pca10000 pca10005 yunjia-nrf51822 spark-core airfy-beacon nucleo-f334 \
+                          pba-d-01-kw01
 
 DISABLE_MODULE += auto_init
 


### PR DESCRIPTION
This PR adds support for Freescale KW01Z128 SiP (Cortex-M0 + Sub-1 GHz Radio) and Phytec PhyWave-KW01 Evaluations-Board.
~~This PR depends on #2265.~~