### PR TITLE
drivers/nrf24l01p: fixes

### DIFF
--- a/drivers/include/nrf24l01p.h
+++ b/drivers/include/nrf24l01p.h
@@ -417,7 +417,7 @@ int nrf24l01p_get_status(nrf24l01p_t *dev);
 * @return           1 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_power(nrf24l01p_t *dev, int *pwr);
+int nrf24l01p_set_power(nrf24l01p_t *dev, int pwr);
 
 /**
 * @brief Get the transmit power for the nrf24l01+ transceiver device.

--- a/drivers/nrf24l01p/include/nrf24l01p_settings.h
+++ b/drivers/nrf24l01p/include/nrf24l01p_settings.h
@@ -29,6 +29,7 @@ extern "C" {
 #define INITIAL_ADDRESS_WIDTH       5
 #define NRF24L01P_MAX_DATA_LENGTH   32
 #define INITIAL_RF_CHANNEL          5
+#define INITIAL_RX_POWER_0dB        0
 
 #define DELAY_CS_TOGGLE_TICKS               2
 #define DELAY_AFTER_FUNC_TICKS              2

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -110,7 +110,7 @@ int nrf24l01p_init(nrf24l01p_t *dev, spi_t spi, gpio_t ce, gpio_t cs, gpio_t irq
     }
 
     /* Flush RX FIFIO */
-    status = nrf24l01p_flush_tx_fifo(dev);
+    status = nrf24l01p_flush_rx_fifo(dev);
 
     if (status < 0) {
         return status;
@@ -138,7 +138,7 @@ int nrf24l01p_init(nrf24l01p_t *dev, spi_t spi, gpio_t ce, gpio_t cs, gpio_t irq
     }
 
     /* Set RF power */
-    status = nrf24l01p_set_power(dev, 0);
+    status = nrf24l01p_set_power(dev, INITIAL_RX_POWER_0dB);
 
     if (status < 0) {
         return status;
@@ -647,32 +647,28 @@ int nrf24l01p_get_status(nrf24l01p_t *dev)
     return (int)status;
 }
 
-int nrf24l01p_set_power(nrf24l01p_t *dev, int *pwr)
+int nrf24l01p_set_power(nrf24l01p_t *dev, int pwr)
 {
     char rf_setup;
 
     nrf24l01p_read_reg(dev, REG_RF_SETUP, &rf_setup);
 
-    if (pwr == NULL) {
-        return -1;
-    }
-
-    if (*pwr >= -3) {
+    if (pwr >= -3) {
         rf_setup &= ~(3 << 1);
         rf_setup |= (NRF24L01P_PWR_0DBM << 1);
     }
 
-    if (*pwr < -3) {
+    if (pwr < -3) {
         rf_setup &= ~(3 << 1);
         rf_setup |= (NRF24L01P_PWR_N6DBM << 1);
     }
 
-    if (*pwr < -9) {
+    if (pwr < -9) {
         rf_setup &= ~(3 << 1);
         rf_setup |= (NRF24L01P_PWR_N12DBM << 1);
     }
 
-    if (*pwr < -15) {
+    if (pwr < -15) {
         rf_setup &= ~(3 << 1);
     }
 

--- a/tests/driver_nrf24l01p_lowlevel/README.md
+++ b/tests/driver_nrf24l01p_lowlevel/README.md
@@ -1,7 +1,7 @@
 # Test for nrf24l01p lowlevel functions 
 
 ## About
-This is a small test application to see how the lowlevel-driver functions of the proprietary nrf24l01p-transceiver work. These functions consist of general SPI and GPIO commands, which abstract the driver-functions from the used board. In order to build this application, you need to add the board to the Makefile's `WHITELIST` first and define a pin mapping.
+This is a small test application to see how the lowlevel-driver functions of the proprietary nrf24l01p-transceiver work. These functions consist of general SPI and GPIO commands, which abstract the driver-functions from the used board.
 
 ## Predefined pin mapping
 Please compare the `tests/driver_nrf24l01p_lowlevel/Makefile` for predefined pin-mappings on different boards. (In addition, you also need to connect to 3V and GND)


### PR DESCRIPTION
This PR 
1. fixes one small error in the nrf24l01p initialization code (flush tx **and** rx fifo)
2. changes the API of `nrf24l01p_set_power` a bit. This corrects the (then) faulty function call (by value). With this change the function looks more consistent to the other functions and the NULL pointer check inside becomes superfluous. 
3. extends the test application so return values are checked for errors