### PR TITLE
Makefile: Respect ARFLAGS and refactor OSX ar test

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -49,7 +49,7 @@ $(BINDIR)$(MODULE)/:
 $(BINDIR)$(MODULE).a $(OBJ): | $(BINDIR)$(MODULE)/
 
 $(BINDIR)$(MODULE).a: $(OBJ) | ${DIRS:%=ALL--%}
-	$(AD)$(AR) -rcs $@ $?
+	$(AD)$(AR) $(ARFLAGS) $@ $?
 
 
 CXXFLAGS = $(filter-out $(CXXUWFLAGS), $(CFLAGS)) $(CXXEXFLAGS)

--- a/Makefile.cflags
+++ b/Makefile.cflags
@@ -50,3 +50,9 @@ endif
 
 # Forbid common symbols to prevent accidental aliasing.
 CFLAGS += -fno-common
+
+# Default ARFLAGS for platforms which do not specify it.
+# Note: make by default provides ARFLAGS=rv which we want to override
+ifeq ($(origin ARFLAGS),default)
+  ARFLAGS = rcs
+endif

--- a/Makefile.include
+++ b/Makefile.include
@@ -112,7 +112,7 @@ CFLAGS += -DCPU_$(CPUDEF)=\"$(CPU)\" -DRIOT_CPU=CPU_$(CPUDEF)
 CFLAGS += -DMCU_$(MCUDEF)=\"$(MCU)\" -DRIOT_MCU=MCU_$(MCUDEF)
 
 # OSX fails to create empty archives. Provide a wrapper to catch that error.
-ifneq (0, $(shell mkdir -p $(BINDIR); $(AR) -rc $(BINDIR)empty-archive.a 2> /dev/null; echo $$?))
+ifneq (0, $(shell mkdir -p $(BINDIR); $(AR) rc $(BINDIR)empty-archive.a 2> /dev/null; echo $$?))
 	AR := $(RIOTBASE)/dist/ar-wrapper $(AR)
 endif
 

--- a/Makefile.vars
+++ b/Makefile.vars
@@ -26,6 +26,7 @@ export CFLAGS                # The compiler flags. Must only ever be used with `
 export CXXUWFLAGS            # (Patters of) flags in CFLAGS, that should not be passed to CXX.
 export CXXEXFLAGS            # Additional flags that should be passed to CXX.
 export AR                    # The command to create the object file archives.
+export ARFLAGS               # Command-line options to pass to AR, default `rcs`.
 export AS                    # The assembler.
 export ASFLAGS               # Flags for the assembler.
 export LINK                  # The command used to link the files. Must take the same parameters as GCC, i.e. "ld" won't work.


### PR DESCRIPTION
I ran into a problem when trying to use LLVM `llvm-ar` instead of GNU binutils `ar` for building static archives:

```
llvm-ar: Unknown command line argument '-rcs'.  Try: 'llvm-ar -help'
llvm-ar: Did you mean '-mlsm'?
```

It works if I remove the leading dash on the `ar` command line. I also found that there is a check for OSX ar in Makefile.base since #1333, #1334 which gave a false positive because of the same problem, the command errored out because of wrong arguments, not because of unsupported features.

I have refactored the root Makefiles to use a new variable `AROPTS` for passing options to `ar`.

I need someone who has access to the broken version of OSX `ar` (a version for which the `dist/ar-wrapper` script was written) to test that the check is still valid after removing the leading dash on the arguments to `ar` (@thomaseichinger ?)