### PR TITLE
periph/spi: Update clock polarity and phase documentation for clarity.

### DIFF
--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -57,10 +57,30 @@ typedef enum {
  *        clock phase.
  */
 typedef enum {
-    SPI_CONF_FIRST_RISING = 0,  /**< first data bit is transacted on the first rising SCK edge */
-    SPI_CONF_SECOND_RISING,     /**< first data bit is transacted on the second rising SCK edge */
-    SPI_CONF_FIRST_FALLING,     /**< first data bit is transacted on the first falling SCK edge */
-    SPI_CONF_SECOND_FALLING     /**< first data bit is transacted on the second falling SCK edge */
+    /**
+     * The first data bit is sampled by the receiver on the first SCK edge. The
+     * first edge of SCK is rising. This is sometimes also referred to as SPI
+     * mode 0, or (CPOL=0, CPHA=0).
+     */
+    SPI_CONF_FIRST_RISING = 0,
+    /**
+     * The first data bit is sampled by the receiver on the second SCK edge. The
+     * first edge of SCK is rising, i.e. the sampling edge is falling. This is
+     * sometimes also referred to as SPI mode 1, or (CPOL=0, CPHA=1).
+     */
+    SPI_CONF_SECOND_RISING = 1,
+    /**
+     * The first data bit is sampled by the receiver on the first SCK edge. The
+     * first edge of SCK is falling. This is sometimes also referred to as SPI
+     * mode 2, or (CPOL=1, CPHA=0).
+     */
+    SPI_CONF_FIRST_FALLING = 2,
+    /**
+     * The first data bit is sampled by the receiver on the second SCK edge. The
+     * first edge of SCK is falling, i.e. the sampling edge is rising. This is
+     * sometimes also referred to as SPI mode 3, or (CPOL=1, CPHA=1).
+     */
+    SPI_CONF_SECOND_FALLING = 3
 } spi_conf_t;
 
 /**


### PR DESCRIPTION
I think "transacted" is a very unclear wording in the documentation for SPI mode (clock polarity and phase).

This change is a clarification of what each of the modes mean in practice. The reason for the overly verbose wording is that each data sheet I have read have described this in different ways and hopefully this will help bus and device driver developers to understand which mode enum is the correct one to use for their device.

I also added defined values for each of the enum values that correspond to the SPI mode number, this ensures that drivers that pass the enum straight to hardware (e.g. stm32f1) will have explicit values that can be validated against the data sheet/ref. man.