### PR TITLE
cpu/stm32f4: Fix PWM implementation

### DIFF
--- a/boards/msbiot/Makefile.features
+++ b/boards/msbiot/Makefile.features
@@ -1,3 +1,3 @@
 FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart periph_gpio periph_spi
+FEATURES_PROVIDED += periph_uart periph_gpio periph_spi periph_pwm
 FEATURES_PROVIDED += transceiver

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -70,6 +70,26 @@ extern "C" {
 #define TIMER_1_IRQ_CHAN    TIM5_IRQn
 /** @} */
 
+/**
+ * @name PWM configuration
+ * @{
+ */
+#define PWM_NUMOF           (1U)
+#define PWM_0_EN            1
+#define PWM_MAX_CHANNELS    1                   /* Increase if Timer with more channels is used */
+
+/* PWM 0 device configuration */
+#define PWM_0_DEV           TIM11
+#define PWM_0_CHANNELS      1
+#define PWM_0_CLK           (168000000U)
+#define PWM_0_CLKEN()       (RCC->APB2ENR |= RCC_APB2ENR_TIM11EN)
+#define PWM_0_CLKDIS()      (RCC->APB2ENR &= ~RCC_APB2ENR_TIM11EN)
+/* PWM 0 pin configuration */
+#define PWM_0_PORT          GPIOB
+#define PWM_0_PORT_CLKEN()  (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define PWM_0_PIN_CH0       9
+#define PWM_0_PIN_AF        3
+/** @} */
 
 /**
  * @name UART configuration


### PR DESCRIPTION
This PR adapts the current low-level periph PWM implementation to allow timers with less than 4 channels. It also configures a PWM timer for the MSB-IoT that only has one available channel.