### PR TITLE
boards/nucleo-l1: check presence of stm32l.cfg

### DIFF
--- a/boards/nucleo-l1/dist/openocd.cfg
+++ b/boards/nucleo-l1/dist/openocd.cfg
@@ -3,4 +3,16 @@ source [find interface/stlink-v2-1.cfg]
 
 transport select hla_swd
 
-source [find target/stm32l.cfg]
+# during development of openocd the existing configuration
+# for this board's MCU got renamed. This tries to test against
+# the different versions.
+# See https://github.com/RIOT-OS/RIOT/pull/2343
+# Should be obsolete with http://openocd.zylin.com/#/c/2489/
+
+if [catch {find target/stm32l.cfg}] {
+    source [find target/stm32l1.cfg]
+    reset_config srst_only
+} else {
+    source [find target/stm32l.cfg]
+    reset_config srst_only srst_nogate
+}


### PR DESCRIPTION
In current updates OpenOCD split up stm32l.cfg into stm32l1.cfg and
stm32l0.cfg. This provides a check in openocd.cfg for this file so
openocd doesn't fail.