### PR TITLE
Remove RPL warning removal in rpl_udp example

### DIFF
--- a/examples/rpl_udp/Makefile
+++ b/examples/rpl_udp/Makefile
@@ -27,13 +27,6 @@ CFLAGS += -DDEVELHELP
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
-# get rid of the mandatory RPL warning
-ifeq ($(shell $(CC) -Wno-cpp -E - 2>/dev/null >/dev/null dev/null ; echo $$?),0)
-	ifeq ($(shell LANG=C $(CC) -Wno-cpp -E - 2>&1 1>/dev/null dev/null | grep warning: | grep -- -Wno-cpp),)
-		CFLAGS += -Wno-cpp
-	endif
-endif
-
 BOARD_INSUFFICIENT_RAM := chronos msb-430h redbee-econotag telosb wsn430-v1_3b wsn430-v1_4 z1 samr21-xpro
 
 # arduino-mega2560: time.h missing from avr-libc


### PR DESCRIPTION
No warnings are produced on my machine for native and iot-lab_M3 configurations.

Also, compiling rpl_udp example gets stuck on these lines on a debian squeeze machine.
The GCC version is waiting for data on standard input.

```
harter   19624  0.0  0.0   3952   564 pts/14   S+   17:38   0:00 /bin/sh -c cc -Wno-cpp -E - 2>/dev/null >/dev/null dev/null ; echo $?
harter   19625  0.0  0.0   5584   840 pts/14   S+   17:38   0:00 cc -Wno-cpp -E - dev/null
harter   19626  0.0  0.0  23088  1808 pts/14   S+   17:38   0:00 /usr/lib/gcc/x86_64-linux-gnu/4.4.5/cc1 -E -quiet - -mtune=generic -Wno-cpp
```
This could have been fixed by doing `echo '' | $(CC) ...` instead of `$(CC) dev/null`.

However, this ps trace was catched when compiling with:

    BOARD=iot-lab_M3 make all

which should have executed the `Wno-cpp` check with "arm-gcc" and not the system gcc.
So the check is wrong when cross compiling.

