### PR TITLE
net: build fixes for -fno-common

### DIFF
--- a/drivers/at86rf231/at86rf231_rx.c
+++ b/drivers/at86rf231/at86rf231_rx.c
@@ -30,7 +30,7 @@
 #include "debug.h"
 
 at86rf231_packet_t at86rf231_rx_buffer[AT86RF231_RX_BUF_SIZE];
-uint8_t buffer[AT86RF231_RX_BUF_SIZE][AT86RF231_MAX_PKT_LENGTH];
+static uint8_t buffer[AT86RF231_RX_BUF_SIZE][AT86RF231_MAX_PKT_LENGTH];
 volatile uint8_t rx_buffer_next;
 extern netdev_802154_raw_packet_cb_t at86rf231_raw_packet_cb;
 

--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -44,12 +44,12 @@ char addr_str[IPV6_MAX_ADDR_STR_LEN];
 #define LLHDR_IPV6HDR_LEN           (LL_HDR_LEN + IPV6_HDR_LEN)
 #define IPV6_NET_IF_ADDR_BUFFER_LEN (NET_IF_MAX * IPV6_NET_IF_ADDR_LIST_LEN)
 
-uint8_t ip_send_buffer[BUFFER_SIZE];
+static uint8_t ip_send_buffer[BUFFER_SIZE];
 uint8_t buffer[BUFFER_SIZE];
-msg_t ip_msg_queue[IP_PKT_RECV_BUF_SIZE];
-ipv6_hdr_t *ipv6_buf;
-icmpv6_hdr_t *icmp_buf;
-uint8_t *nextheader;
+static msg_t ip_msg_queue[IP_PKT_RECV_BUF_SIZE];
+static ipv6_hdr_t *ipv6_buf;
+static icmpv6_hdr_t *icmp_buf;
+static uint8_t *nextheader;
 
 kernel_pid_t udp_packet_handler_pid = KERNEL_PID_UNDEF;
 kernel_pid_t tcp_packet_handler_pid = KERNEL_PID_UNDEF;

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -76,7 +76,7 @@ uint8_t rpl_max_routing_entries;
 ipv6_addr_t my_address;
 
 /* IPv6 message buffer */
-ipv6_hdr_t *ipv6_buf;
+static ipv6_hdr_t *ipv6_buf;
 
 uint8_t rpl_init(int if_id)
 {

--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -31,7 +31,6 @@ char addr_str[IPV6_MAX_ADDR_STR_LEN];
 #endif
 #include "debug.h"
 
-kernel_pid_t rpl_process_pid;
 rpl_instance_t instances[RPL_MAX_INSTANCES];
 rpl_dodag_t dodags[RPL_MAX_DODAGS];
 rpl_parent_t parents[RPL_MAX_PARENTS];

--- a/sys/transceiver/transceiver.c
+++ b/sys/transceiver/transceiver.c
@@ -73,23 +73,23 @@
 
 /*------------------------------------------------------------------------------------*/
 /* used transceiver types */
-transceiver_type_t transceivers = TRANSCEIVER_NONE;
+static transceiver_type_t transceivers = TRANSCEIVER_NONE;
 
 /* registered upper layer threads */
-registered_t reg[TRANSCEIVER_MAX_REGISTERED];
+static registered_t reg[TRANSCEIVER_MAX_REGISTERED];
 
 /* packet buffers */
 #if MODULE_AT86RF231 || MODULE_CC2420 || MODULE_MC1322X
-ieee802154_packet_t transceiver_buffer[TRANSCEIVER_BUFFER_SIZE];
+static ieee802154_packet_t transceiver_buffer[TRANSCEIVER_BUFFER_SIZE];
 #else
-radio_packet_t transceiver_buffer[TRANSCEIVER_BUFFER_SIZE];
+static radio_packet_t transceiver_buffer[TRANSCEIVER_BUFFER_SIZE];
 #endif
-uint8_t data_buffer[TRANSCEIVER_BUFFER_SIZE * PAYLOAD_SIZE];
+static uint8_t data_buffer[TRANSCEIVER_BUFFER_SIZE * PAYLOAD_SIZE];
 
 /* message buffer */
-msg_t msg_buffer[TRANSCEIVER_MSG_BUFFER_SIZE];
+static msg_t msg_buffer[TRANSCEIVER_MSG_BUFFER_SIZE];
 
-uint32_t response; ///< response bytes for messages to upper layer threads
+static uint32_t response; ///< response bytes for messages to upper layer threads
 
 volatile kernel_pid_t transceiver_pid = KERNEL_PID_UNDEF; ///< the transceiver thread's pid
 
@@ -97,15 +97,15 @@ static volatile uint8_t rx_buffer_pos = 0;
 static volatile uint8_t transceiver_buffer_pos = 0;
 
 #ifdef MODULE_CC110X_LEGACY_CSMA
-void *cc1100_payload;
-int cc1100_payload_size;
-packet_info_t *cc1100_packet_info;
-uint8_t cc1100_pkt[CC1100_MAX_DATA_LENGTH];
+static void *cc1100_payload;
+static int cc1100_payload_size;
+static packet_info_t *cc1100_packet_info;
+static uint8_t cc1100_pkt[CC1100_MAX_DATA_LENGTH];
 #endif
 
 
 /* transceiver stack */
-char transceiver_stack[TRANSCEIVER_STACK_SIZE];
+static char transceiver_stack[TRANSCEIVER_STACK_SIZE];
 
 /*------------------------------------------------------------------------------------*/
 /* function prototypes */


### PR DESCRIPTION
These changes are necessary to build the rpl_udp example with `-fno-common`

See #2346 