### PR TITLE
sixlowpan: rename global buffer->sixlowpan_buffer

### DIFF
--- a/sys/net/network_layer/sixlowpan/icmp.c
+++ b/sys/net/network_layer/sixlowpan/icmp.c
@@ -9,7 +9,7 @@
  *
  * @ingroup sixlowpan
  * @{
- * @file    sixlownd.c
+ * @file
  * @brief   6lowpan neighbor discovery functions
  * @author  Stephan Zeisberg <zeisberg@mi.fu-berlin.de>
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
@@ -167,72 +167,72 @@ int min(int a, int b)
 
 static icmpv6_parameter_prob_hdr_t *get_para_prob_buf(uint8_t ext_len)
 {
-    return ((icmpv6_parameter_prob_hdr_t *) &buffer[LLHDR_ICMPV6HDR_LEN + ext_len]);
+    return ((icmpv6_parameter_prob_hdr_t *) &sixlowpan_buffer[LLHDR_ICMPV6HDR_LEN + ext_len]);
 }
 
 static icmpv6_echo_request_hdr_t *get_echo_req_buf(uint8_t ext_len)
 {
-    return ((icmpv6_echo_request_hdr_t *) &buffer[LLHDR_ICMPV6HDR_LEN + ext_len]);
+    return ((icmpv6_echo_request_hdr_t *) &sixlowpan_buffer[LLHDR_ICMPV6HDR_LEN + ext_len]);
 }
 
 static icmpv6_echo_reply_hdr_t *get_echo_repl_buf(uint8_t ext_len)
 {
-    return ((icmpv6_echo_reply_hdr_t *) &buffer[LLHDR_ICMPV6HDR_LEN + ext_len]);
+    return ((icmpv6_echo_reply_hdr_t *) &sixlowpan_buffer[LLHDR_ICMPV6HDR_LEN + ext_len]);
 }
 
 static icmpv6_router_adv_hdr_t *get_rtr_adv_buf(uint8_t ext_len)
 {
-    return ((icmpv6_router_adv_hdr_t *) &buffer[LLHDR_ICMPV6HDR_LEN + ext_len]);
+    return ((icmpv6_router_adv_hdr_t *) &sixlowpan_buffer[LLHDR_ICMPV6HDR_LEN + ext_len]);
 }
 
 static icmpv6_neighbor_sol_hdr_t *get_nbr_sol_buf(uint8_t ext_len)
 {
-    return ((icmpv6_neighbor_sol_hdr_t *) &buffer[LLHDR_ICMPV6HDR_LEN + ext_len]);
+    return ((icmpv6_neighbor_sol_hdr_t *) &sixlowpan_buffer[LLHDR_ICMPV6HDR_LEN + ext_len]);
 }
 
 static icmpv6_neighbor_adv_hdr_t *get_nbr_adv_buf(uint8_t ext_len)
 {
-    return ((icmpv6_neighbor_adv_hdr_t *) &buffer[LLHDR_ICMPV6HDR_LEN + ext_len]);
+    return ((icmpv6_neighbor_adv_hdr_t *) &sixlowpan_buffer[LLHDR_ICMPV6HDR_LEN + ext_len]);
 }
 
 static icmpv6_ndp_opt_hdr_t *get_opt_buf(uint8_t ext_len, uint8_t opt_len)
 {
-    return ((icmpv6_ndp_opt_hdr_t *) &buffer[LLHDR_ICMPV6HDR_LEN + ext_len + opt_len]);
+    return ((icmpv6_ndp_opt_hdr_t *) &sixlowpan_buffer[LLHDR_ICMPV6HDR_LEN + ext_len + opt_len]);
 }
 
 static icmpv6_ndp_opt_stllao_t *get_opt_stllao_buf(uint8_t ext_len, uint8_t opt_len)
 {
-    return ((icmpv6_ndp_opt_stllao_t *) &buffer[LLHDR_ICMPV6HDR_LEN + ext_len + opt_len]);
+    return ((icmpv6_ndp_opt_stllao_t *) &sixlowpan_buffer[LLHDR_ICMPV6HDR_LEN + ext_len + opt_len]);
 }
 
 static icmpv6_ndp_opt_mtu_t *get_opt_mtu_buf(uint8_t ext_len, uint8_t opt_len)
 {
-    return ((icmpv6_ndp_opt_mtu_t *) &buffer[LLHDR_ICMPV6HDR_LEN + ext_len + opt_len]);
+    return ((icmpv6_ndp_opt_mtu_t *) &sixlowpan_buffer[LLHDR_ICMPV6HDR_LEN + ext_len + opt_len]);
 }
 
 static icmpv6_ndp_opt_abro_t *get_opt_abro_buf(uint8_t ext_len, uint8_t opt_len)
 {
-    return ((icmpv6_ndp_opt_abro_t *) &buffer[LLHDR_ICMPV6HDR_LEN + ext_len + opt_len]);
+    return ((icmpv6_ndp_opt_abro_t *) &sixlowpan_buffer[LLHDR_ICMPV6HDR_LEN + ext_len + opt_len]);
 }
 
 static icmpv6_ndp_opt_6co_hdr_t *get_opt_6co_hdr_buf(uint8_t ext_len, uint8_t opt_len)
 {
-    return ((icmpv6_ndp_opt_6co_hdr_t *) &buffer[LLHDR_ICMPV6HDR_LEN + ext_len + opt_len]);
+    return ((icmpv6_ndp_opt_6co_hdr_t *) &sixlowpan_buffer[LLHDR_ICMPV6HDR_LEN + ext_len + opt_len]);
 }
 
 static uint8_t *get_opt_6co_prefix_buf(uint8_t ext_len, uint8_t opt_len)
 {
-    return ((uint8_t *) &buffer[LLHDR_ICMPV6HDR_LEN + ext_len + opt_len]);
+    return ((uint8_t *) &sixlowpan_buffer[LLHDR_ICMPV6HDR_LEN + ext_len + opt_len]);
 }
 
 static icmpv6_ndp_opt_pi_t *get_opt_pi_buf(uint8_t ext_len, uint8_t opt_len)
 {
-    return ((icmpv6_ndp_opt_pi_t *) &buffer[LLHDR_ICMPV6HDR_LEN + ext_len + opt_len]);
+    return ((icmpv6_ndp_opt_pi_t *) &sixlowpan_buffer[LLHDR_ICMPV6HDR_LEN + ext_len + opt_len]);
 }
 
 static icmpv6_ndp_opt_aro_t *get_opt_aro_buf(uint8_t ext_len, uint8_t opt_len)
 {
-    return ((icmpv6_ndp_opt_aro_t *) &buffer[LLHDR_ICMPV6HDR_LEN + ext_len + opt_len]);
+    return ((icmpv6_ndp_opt_aro_t *) &sixlowpan_buffer[LLHDR_ICMPV6HDR_LEN + ext_len + opt_len]);
 }
 
 void icmpv6_send_echo_request(ipv6_addr_t *destaddr, uint16_t id, uint16_t seq, uint8_t *data, size_t data_len)

--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -9,7 +9,7 @@
  *
  * @ingroup sixlowpan
  * @{
- * @file    sixlowip.c
+ * @file
  * @brief   6lowpan IP layer functions
  * @author  Stephan Zeisberg <zeisberg@mi.fu-berlin.de>
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
@@ -45,7 +45,7 @@ static char addr_str[IPV6_MAX_ADDR_STR_LEN];
 #define IPV6_NET_IF_ADDR_BUFFER_LEN (NET_IF_MAX * IPV6_NET_IF_ADDR_LIST_LEN)
 
 static uint8_t ip_send_buffer[BUFFER_SIZE];
-uint8_t buffer[BUFFER_SIZE];
+uint8_t sixlowpan_buffer[BUFFER_SIZE];
 static msg_t ip_msg_queue[IP_PKT_RECV_BUF_SIZE];
 static ipv6_hdr_t *ipv6_buf;
 static icmpv6_hdr_t *icmp_buf;
@@ -162,17 +162,17 @@ uint8_t *get_payload_buf_send(uint8_t ext_len)
 
 ipv6_hdr_t *ipv6_get_buf(void)
 {
-    return ((ipv6_hdr_t *) &buffer[LL_HDR_LEN]);
+    return ((ipv6_hdr_t *) &sixlowpan_buffer[LL_HDR_LEN]);
 }
 
 icmpv6_hdr_t *get_icmpv6_buf(uint8_t ext_len)
 {
-    return ((icmpv6_hdr_t *) &buffer[LLHDR_IPV6HDR_LEN + ext_len]);
+    return ((icmpv6_hdr_t *) &sixlowpan_buffer[LLHDR_IPV6HDR_LEN + ext_len]);
 }
 
 uint8_t *get_payload_buf(uint8_t ext_len)
 {
-    return &(buffer[LLHDR_IPV6HDR_LEN + ext_len]);
+    return &(sixlowpan_buffer[LLHDR_IPV6HDR_LEN + ext_len]);
 }
 
 int ipv6_sendto(const ipv6_addr_t *dest, uint8_t next_header,

--- a/sys/net/network_layer/sixlowpan/ip.h
+++ b/sys/net/network_layer/sixlowpan/ip.h
@@ -9,7 +9,7 @@
  *
  * @ingroup sixlowpan
  * @{
- * @file    sixlowip.h
+ * @file
  * @brief   6lowpan IP layer header
  * @author  Stephan Zeisberg <zeisberg@mi.fu-berlin.de>
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
@@ -63,7 +63,7 @@ extern int srh_handler_pid;
 #define IPV6_NET_IF_ADDR_LIST_LEN   (10)    // maybe to much
 
 /* buffer */
-extern uint8_t buffer[BUFFER_SIZE];
+extern uint8_t sixlowpan_buffer[BUFFER_SIZE];
 extern char ip_process_buf[IP_PROCESS_STACKSIZE];
 
 extern kernel_pid_t sixlowip_reg[SIXLOWIP_MAX_REGISTERED];

--- a/sys/net/routing/rpl/rpl_control_messages.c
+++ b/sys/net/routing/rpl/rpl_control_messages.c
@@ -160,7 +160,7 @@ static rpl_dao_t *get_rpl_dao_buf(void)
 
 static rpl_dao_ack_t *get_rpl_dao_ack_buf(void)
 {
-    return ((rpl_dao_ack_t *) & (buffer[(LL_HDR_LEN + IPV6_HDR_LEN + ICMPV6_HDR_LEN)]));
+    return ((rpl_dao_ack_t *) & (sixlowpan_buffer[(LL_HDR_LEN + IPV6_HDR_LEN + ICMPV6_HDR_LEN)]));
 }
 
 static rpl_dis_t *get_rpl_dis_buf(void)


### PR DESCRIPTION
The name `buffer` is bound to end up causing naming collisions with RIOT based applications in the future. This PR renames the `buffer` -> `sixlowpan_buffer` as per the naming convention at https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions#naming