### PR TITLE
Makefile.cflags: Make -fno-common the default

### DIFF
--- a/Makefile.cflags
+++ b/Makefile.cflags
@@ -47,3 +47,6 @@ ifeq ($(LTO),yes)
   CFLAGS += ${LTOFLAGS}
   LINKFLAGS += ${LTOFLAGS}
 endif
+
+# Forbid common symbols to prevent accidental aliasing.
+CFLAGS += -fno-common


### PR DESCRIPTION
To catch sneaky issues with multiply defined global variables. See #2344 