### PR TITLE
drivers/hdc1000: Acquire exclusive access to I2C bus and  minor bug fixes

### DIFF
--- a/drivers/include/hdc1000.h
+++ b/drivers/include/hdc1000.h
@@ -18,7 +18,10 @@
  *              be started by a write access to the address 0x00
  *              (HDC1000_TEMPERATURE). After completing the measurement
  *              the sensor will return to sleep mode. Typical
- *              Conversion Time by 14 bit resolution is 6.50ms.
+ *              Conversion Time by 14 bit resolution is 6.50ms
+ *              for humidity and 6.35ms for temperature.
+ *              HDC1000_CONVERSION_TIME is twice as large to prevent
+ *              the problems with timer resolution.
  *
  * @{
  *
@@ -41,11 +44,11 @@ extern "C"
 #endif
 
 #ifndef HDC1000_I2C_ADDRESS
-#define HDC1000_I2C_ADDRESS           0x41
+#define HDC1000_I2C_ADDRESS           0x43 /**< Default Device Address */
 #endif
 
 #ifndef HDC1000_CONVERSION_TIME
-#define HDC1000_CONVERSION_TIME       6500
+#define HDC1000_CONVERSION_TIME       26000 /**< Default Conversion Time */
 #endif
 
 /**
@@ -109,6 +112,8 @@ int hdc1000_startmeasure(hdc1000_t *dev);
  * @brief Read sensor's data.
  *
  * @param[in]  dev          device descriptor of sensor
+ * @param[out] rawtemp      raw temperature value
+ * @param[out] rawhum       raw humidity value
  *
  * @return                  0 on success
  * @return                  -1 on error

--- a/tests/driver_hdc1000/main.c
+++ b/tests/driver_hdc1000/main.c
@@ -56,6 +56,7 @@ int main(void)
             return -1;
         }
         vtimer_usleep(HDC1000_CONVERSION_TIME);
+
         hdc1000_read(&dev, &rawtemp, &rawhum);
         printf("Raw data T: %5i   RH: %5i\n", rawtemp, rawhum);
 
@@ -63,6 +64,7 @@ int main(void)
         printf("Data T: %d   RH: %d\n", temp, hum);
 
         vtimer_usleep(SLEEP);
+
     }
 
     return 0;


### PR DESCRIPTION
This PR adds exclusive access to I2C bus and minor bug fixes for HDC1000 driver:
- fix doxygen warnings
- change default address
- remove redundant vtimer_usleep call