### PR TITLE
SAMR21: Optimizations to make RPL_UDP example works

### DIFF
--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -48,6 +48,13 @@ extern "C" {
 #define AT86RF231_SLEEP    GPIO_7
 
 #define AT86RF231_SPI_SPEED SPI_SPEED_1MHZ
+
+/*Thread optimization for samr21*/
+#define RADIO_STACK_SIZE            (1024)
+#define RPL_PROCESS_STACKSIZE           (1024)
+
+/*samr21 is very memory constrained and does not run with the default RPL_MAX_ROUTING_ENTRIES (= 128)*/
+#define RPL_MAX_ROUTING_ENTRIES            (8)
 /** @}*/
 /**
  * @name Define UART device and baudrate for stdio

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -50,7 +50,7 @@ extern "C" {
 #define AT86RF231_SPI_SPEED SPI_SPEED_1MHZ
 
 /*Thread optimization for samr21*/
-#define RADIO_STACK_SIZE            (1024)
+#define RADIO_STACK_SIZE                (1024)
 #define RPL_PROCESS_STACKSIZE           (1024)
 
 /*samr21 is very memory constrained and does not run with the default RPL_MAX_ROUTING_ENTRIES (= 128)*/

--- a/examples/rpl_udp/Makefile
+++ b/examples/rpl_udp/Makefile
@@ -34,7 +34,7 @@ ifeq ($(shell $(CC) -Wno-cpp -E - 2>/dev/null >/dev/null dev/null ; echo $$?),0)
 	endif
 endif
 
-BOARD_INSUFFICIENT_RAM := chronos msb-430h redbee-econotag telosb wsn430-v1_3b wsn430-v1_4 z1 samr21-xpro
+BOARD_INSUFFICIENT_RAM := chronos msb-430h redbee-econotag telosb wsn430-v1_3b wsn430-v1_4 z1
 
 # arduino-mega2560: time.h missing from avr-libc
 BOARD_BLACKLIST := arduino-mega2560

--- a/examples/rpl_udp/rpl_udp.h
+++ b/examples/rpl_udp/rpl_udp.h
@@ -15,7 +15,11 @@ extern "C" {
 
 #define APP_VERSION "1.2"
 
+#ifdef MODULE_AT86RF231
+#define RADIO_CHANNEL   (12)
+#else
 #define RADIO_CHANNEL   (10)
+#endif
 
 #define MONITOR_STACK_SIZE  (KERNEL_CONF_STACKSIZE_MAIN)
 #define RCV_BUFFER_SIZE     (32)

--- a/sys/net/include/rpl.h
+++ b/sys/net/include/rpl.h
@@ -41,7 +41,9 @@ extern "C" {
 #define CC1100_RADIO_MODE CC1100_MODE_WOR
 
 #define RPL_PKT_RECV_BUF_SIZE 16
+#ifndef RPL_PROCESS_STACKSIZE
 #define RPL_PROCESS_STACKSIZE KERNEL_CONF_STACKSIZE_MAIN
+#endif
 
 /* global variables */
 extern kernel_pid_t rpl_process_pid;

--- a/sys/net/network_layer/sixlowpan/mac.c
+++ b/sys/net/network_layer/sixlowpan/mac.c
@@ -39,7 +39,9 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+#ifndef RADIO_STACK_SIZE
 #define RADIO_STACK_SIZE            (KERNEL_CONF_STACKSIZE_MAIN)
+#endif
 #define RADIO_RCV_BUF_SIZE          (64)
 #define RADIO_SENDING_DELAY         (1000)
 


### PR DESCRIPTION
Optimizations to make samr21-xpro board works with RPL_UDP example :  
-Setting channel to 12 between  AT86RF231_MIN_CHANNEL (11) to AT86RF231_MAX_CHANNEL (26).
-Modification of makefile to allow RPL_UDP example to work on samr21-xpro board.
-Modification of radio and rpl_process thread size to optimize bss.
-Modification of RPL_MAX_ROUTING_ENTRIES to fit RAM size.