### PR TITLE
examples: demonstrate how a proprietary library can be integrated to RIOT

### DIFF
--- a/examples/satisfy_lgpl/Makefile
+++ b/examples/satisfy_lgpl/Makefile
@@ -1,0 +1,80 @@
+# name of your application
+APPLICATION = satisfy_lgpl
+
+# Name of your propriatary library
+LIBNAME = my_cool_lib
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+CFLAGS += -DDEVELHELP
+
+# Include path to your library headers
+CFLAGS += -I$(CURDIR)
+
+# Use the build library when linking if PROPRIETARY_BUILD is set
+ifneq (,$(PROPRIETARY_BUILD))
+	BASELIBS += $(CURDIR)/$(LIBNAME).a
+endif
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+# An additional module used from the library to demonstrate the integration/interaction
+USEMODULE += base64
+
+include $(RIOTBASE)/Makefile.include
+
+# Indicates if the library source is excluded from the build
+LIBSOURCE_OFF = $(wildcard $(CURDIR)/library.c_off)
+
+# Target to apply the provided patch and create a revert patch
+apply_patch:
+ifeq ($(wildcard $(CURDIR)/mutex_revert.patch),)
+	cp ../../core/mutex.c mutex_bak.c
+	patch ../../core/mutex.c < mutex_apply.patch
+	diff -u ../../core/mutex.c mutex_bak.c > mutex_revert.patch || exit 0
+	rm mutex_bak.c
+endif
+
+# Target to apply the revert patch if available and finally removing it
+revert_patch:
+ifneq ($(wildcard $(CURDIR)/mutex_revert.patch),)
+	patch ../../core/mutex.c < mutex_revert.patch
+	rm mutex_revert.patch
+endif
+
+# Target to include the library source to the build directly, used for testing
+use_source: apply_patch
+ifneq ($(LIBSOURCE_OFF),)
+	mv library.c_off library.c
+endif
+
+# Target to exclude the library source from the build, used for releasing the library
+use_library: apply_patch
+ifeq ($(LIBSOURCE_OFF),)
+	mv library.c library.c_off
+endif
+
+# Target to create the library
+create_library: use_source clean all
+ifneq ($(wildcard $(CURRDIR)/$(LIBNAME).a),)
+	rm $(CURRDIR)/$(LIBNAME).a
+endif
+	ar -rcs $(CURDIR)/$(LIBNAME).a  $(CURDIR)/bin/$(BOARD)/$(APPLICATION)/library.o
+
+# Target to build your application with the source, used for developing/testing
+with_source: use_source clean all
+
+# Target to build your application with the library,
+# use this target with PROPRIETARY_BUILD=1 to link to the library
+with_library: use_library clean all
+
+# Target to revert the changes and do some housekeeping
+unmodify: use_source revert_patch clean

--- a/examples/satisfy_lgpl/README.md
+++ b/examples/satisfy_lgpl/README.md
@@ -1,0 +1,55 @@
+Satisfy LGPL - a small example
+==============================
+This is an example showing how you can use your own library to replace or add specific proprietary functions to RIOT not violating LGPL.
+
+The basic example just uses a `mutex` and greets you, thats it.
+The proprietary modifications are applied to `./RIOT/core/mutex.c mutex_lock()` function.  
+If you run the build with `make` followed by `make term` you will be using the original unmodified RIOT functions.
+
+##First lets test if our proprietary functions just work:
+```
+make with_source
+```
+does this for us.  
+It applies a patch (`mutex_apply.patch`) to `./RIOT/core/mutex.c`, builds RIOT with the changes and creates `mutex_revert.patch` to undo the modifications.
+Entering `make term` will show us that the modifications were applied.
+
+##Now lets make our proprietary library:
+```
+make PROPRIETARY_BUILD=1 create_library
+```
+does this for us.
+If `mutex_revert.patch` is not present it creates it to enable undo the modifications.
+It also applies a patch (`mutex_apply.patch`) to `./RIOT/core/mutex.c`, builds RIOT with the changes and finally creates a `my_cool_lib.a` for us, whereas the name is specified by `LIBNAME` in the `Makefile`.  
+
+
+##Lets link it
+To link the created library we enter:
+```
+make PROPRIETARY_BUILD=1 with_library
+```
+which renames `library.c` to `library.c_off` to exclude it from the build process.  
+Then it builds RIOT linking the `my_cool_lib.a`.
+Again, entering `make term` will show us that the modifications were applied.
+
+##Summing up
+Providing a proprietary library created with a specific RIOT version and a hook patch allows us to build an executable to verify if LGPL has been respected.  
+The binary resulting from the build process should be always the same if the build conditions are equal, e.g. a specific compiler version and libc libraries.  
+
+In this example I would ship:
+- the `mutex_apply.patch` including the hook to our library functions
+- the `library.h` providing the interfaces to the hooks
+- the `Makefile` to ease up the build
+- the build target information, i.e. `native` for this example
+- the used compiler version, i.e. `gcc version 4.8.2 (Ubuntu 4.8.2-19ubuntu1)`
+- the RIOT version hash, i.e. `319f1b25ae4c8146aee0bf171bf7271b3854a233`
+- the md5 checksum of the built binary with the linked library, i.e. `7e80ce210c52ca481c7228830f1d2942  bin/native/satisfy_lgpl.elf`
+- and of course the used library `my_cool_lib.a`
+
+This information should allow anyone to reproduce the build and to verify if RIOT has been modified other than the changes from `mutex_apply.patch`.
+
+##To clean thing up we enter
+```
+make unmodify
+```
+to revert the `mutex_apply.patch` changes by applying the generated patch `mutex_revert.patch` and rename the `library.c_off` to `library.c`

--- a/examples/satisfy_lgpl/library.c
+++ b/examples/satisfy_lgpl/library.c
@@ -1,0 +1,33 @@
+/*
+* Copyright (C) 2015 Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+*
+* This file is subject to the terms and conditions of the GNU Lesser
+* General Public License v2.1. See the file LICENSE in the top level
+* directory for more details.
+*/
+
+/**
+* @ingroup examples
+* @{
+* @file
+* @brief Sample proprietary library code
+*
+* @author  Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+* @}
+*
+*/
+
+#include "library.h"
+#include "base64.h"
+
+void HOOK_library_01(void) {
+    unsigned char data_in[] = "[HOOK] Bazinga!";
+    size_t data_in_size = 15;
+    size_t base64_out_size = 0;
+
+    unsigned char base64_out[20];
+    base64_encode(data_in, data_in_size, NULL, &base64_out_size);
+    base64_encode(data_in, data_in_size, base64_out, &base64_out_size);
+
+    printf("\n%s ( %s )\n\n", (char*)data_in, (char*)base64_out );
+}

--- a/examples/satisfy_lgpl/library.h
+++ b/examples/satisfy_lgpl/library.h
@@ -1,0 +1,36 @@
+/*
+* Copyright (C) 2015 Martin Landsmann
+*
+* This file is subject to the terms and conditions of the GNU Lesser
+* General Public License v2.1. See the file LICENSE in the top level
+* directory for more details.
+*/
+
+/**
+* @ingroup  examples
+* @{
+*
+* @brief    Definitions for our library hooks
+* @author   Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+*/
+
+#ifndef _LIBRARY_H
+#define _LIBRARY_H
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+*    @breif A test function to be hooked in the `core`
+*/
+void HOOK_library_01(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* _LIBRARY_H */

--- a/examples/satisfy_lgpl/main.c
+++ b/examples/satisfy_lgpl/main.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2015
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Satisfy LGPL example application
+ *
+ * @author
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include "mutex.h"
+
+int main(void)
+{
+    puts("Hello LGPL!");
+    mutex_t mtx;
+    mutex_init(&mtx);
+    mutex_lock(&mtx);
+
+    printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
+    printf("This board features a(n) %s MCU.\n", RIOT_MCU);
+
+    mutex_unlock(&mtx);
+    return 0;
+}

--- a/examples/satisfy_lgpl/mutex_apply.patch
+++ b/examples/satisfy_lgpl/mutex_apply.patch
@@ -1,0 +1,22 @@
+--- mutex.c	2015-01-27 08:18:55.760449705 +0100
++++ mutex.c	2015-01-27 10:48:29.836814372 +0100
+@@ -30,6 +30,9 @@
+ #include "irq.h"
+ #include "thread.h"
+
++/* [HOOK] interface */
++#include "library.h"
++
+ #define ENABLE_DEBUG    (0)
+ #include "debug.h"
+
+@@ -43,6 +46,9 @@
+
+ void mutex_lock(struct mutex_t *mutex)
+ {
++    /* [HOOK] call */
++    HOOK_library_01();
++
+     DEBUG("%s: trying to get mutex. val: %u\n", sched_active_thread->name, mutex->val);
+
+     if (atomic_set_return(&mutex->val, 1) != 0) {


### PR DESCRIPTION
Some time ago we had a passionate discussion on switching from LGPL to some other license model.
We heard often that companies are not willing to use LGPL cause of the hurdles to integrate their propriatary code to RIOT without open it to the public.

This example is meant to assist in integrating and shipping proprietary code/libraries.
It shows that applying LGPL and closed source is not that complicated and fearsome to handle.

