### PR TITLE
Cortex-M: remove -mthumb-interwork

### DIFF
--- a/boards/airfy-beacon/Makefile.include
+++ b/boards/airfy-beacon/Makefile.include
@@ -32,10 +32,10 @@ export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 # define build specific options
 CPU_USAGE = -mcpu=cortex-m0
 FPU_USAGE =
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 # $(LINKERSCRIPT) is specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary

--- a/boards/arduino-due/Makefile.include
+++ b/boards/arduino-due/Makefile.include
@@ -29,10 +29,10 @@ export PORT
 
 # define build specific options
 export CPU_USAGE = -mcpu=cortex-m3
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 # linkerscript specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS += -O binary

--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -37,7 +37,7 @@ export PORT      ?= /dev/ttyUSB1
 export CPU_USAGE  = -mcpu=cortex-m3
 
 export ASFLAGS   += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export CFLAGS    += $(ASFLAGS) -std=gnu99 -mthumb -mthumb-interwork -nostartfiles -Os -Wall -Wstrict-prototypes -ffunction-sections -fdata-sections -fno-builtin
+export CFLAGS    += $(ASFLAGS) -std=gnu99 -mthumb -mno-thumb-interwork -nostartfiles -Os -Wall -Wstrict-prototypes -ffunction-sections -fdata-sections -fno-builtin
 export LINKFLAGS += $(CFLAGS) -static -lgcc -T$(LINKERSCRIPT) -L$(RIOTCPU)/$(CPU)
 export OFLAGS    += -O binary --gap-fill 0xff
 export HEXFILE = $(ELFFILE:.elf=.bin)

--- a/boards/f4vi1/Makefile.include
+++ b/boards/f4vi1/Makefile.include
@@ -31,10 +31,10 @@ export DEBUGSERVER = st-util
 # define build specific options
 CPU_USAGE = -mcpu=cortex-m4
 FPU_USAGE = -mfloat-abi=hard -mfpu=fpv4-sp-d16
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary
 export FFLAGS = write bin/$(BOARD)/$(APPLICATION).hex 0x8000000

--- a/boards/fox/Makefile.include
+++ b/boards/fox/Makefile.include
@@ -31,7 +31,7 @@ export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 # define build specific options
 export CPU_USAGE = -mcpu=cortex-m3
 export FPU_USAGE =
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 
 # unwanted (CXXUWFLAGS) and extra (CXXEXFLAGS) flags for c++
@@ -39,7 +39,7 @@ export CXXUWFLAGS +=
 export CXXEXFLAGS +=
 
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -ggdb -g3 -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -ggdb -g3 -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 # $(LINKERSCRIPT) is specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O ihex

--- a/boards/iot-lab_M3/Makefile.include
+++ b/boards/iot-lab_M3/Makefile.include
@@ -31,7 +31,7 @@ export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 # define build specific options
 export CPU_USAGE = -mcpu=cortex-m3
 export FPU_USAGE =
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 
 # unwanted (CXXUWFLAGS) and extra (CXXEXFLAGS) flags for c++
@@ -39,7 +39,7 @@ export CXXUWFLAGS +=
 export CXXEXFLAGS +=
 
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -ggdb -g3 -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -ggdb -g3 -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 # $(LINKERSCRIPT) is specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O ihex

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -30,10 +30,10 @@ export DEBUGSERVER =
 # define build specific options
 CPU_USAGE = -mcpu=cortex-m3
 FPU_USAGE =
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary
 export HEXFILE = $(ELFFILE:.elf=.bin)

--- a/boards/msbiot/Makefile.include
+++ b/boards/msbiot/Makefile.include
@@ -31,10 +31,10 @@ export DEBUGSERVER = st-util
 # define build specific options
 CPU_USAGE = -mcpu=cortex-m4
 FPU_USAGE = -mfloat-abi=hard -mfpu=fpv4-sp-d16
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary
 export FFLAGS = write bin/$(BOARD)/$(APPLICATION).hex 0x8000000

--- a/boards/nucleo-f334/Makefile.include
+++ b/boards/nucleo-f334/Makefile.include
@@ -36,10 +36,10 @@ export CXXEXFLAGS +=
 # define build specific options
 export CPU_USAGE = -mcpu=cortex-m4
 export FPU_USAGE =
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -ggdb -g3 -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -ggdb -g3 -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 # $(LINKERSCRIPT) is specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary

--- a/boards/nucleo-l1/Makefile.include
+++ b/boards/nucleo-l1/Makefile.include
@@ -36,10 +36,10 @@ export CXXEXFLAGS +=
 # define build specific options
 export CPU_USAGE = -mcpu=cortex-m3
 export FPU_USAGE =
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -ggdb -g3 -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -ggdb -g3 -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 # $(LINKERSCRIPT) is specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary

--- a/boards/openmote/Makefile.include
+++ b/boards/openmote/Makefile.include
@@ -32,10 +32,10 @@ export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 # define build specific options
 CPU_USAGE = -mcpu=cortex-m3
 FPU_USAGE =
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 # $(LINKERSCRIPT) is specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT) -L$(RIOTCPU)/$(CPU)
 export OFLAGS = -O binary

--- a/boards/pca10000/Makefile.include
+++ b/boards/pca10000/Makefile.include
@@ -32,10 +32,10 @@ export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 # define build specific options
 CPU_USAGE = -mcpu=cortex-m0
 FPU_USAGE =
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 # $(LINKERSCRIPT) is specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary

--- a/boards/pca10005/Makefile.include
+++ b/boards/pca10005/Makefile.include
@@ -32,10 +32,10 @@ export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 # define build specific options
 CPU_USAGE = -mcpu=cortex-m0
 FPU_USAGE =
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 # $(LINKERSCRIPT) is specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary

--- a/boards/samr21-xpro/Makefile.include
+++ b/boards/samr21-xpro/Makefile.include
@@ -21,10 +21,10 @@ export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
 # define build specific options
 export CPU_USAGE = -mcpu=cortex-m0plus
 FPU_USAGE =
-export CFLAGS += -ggdb -g3 -std=gnu99 -O0 -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -O0 -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 # linkerscript specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS += -O binary

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -24,10 +24,10 @@ export RESET = # dfu-util has no support for resetting the device
 # define build specific options
 export CPU_USAGE = -mcpu=cortex-m3
 export FPU_USAGE =
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -ggdb -g3 -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -ggdb -g3 -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 # $(LINKERSCRIPT) is specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O ihex

--- a/boards/stm32f0discovery/Makefile.include
+++ b/boards/stm32f0discovery/Makefile.include
@@ -31,10 +31,10 @@ export DEBUGSERVER = st-util
 # define build specific options
 CPU_USAGE = -mcpu=cortex-m0
 FPU_USAGE =
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 # $(LINKERSCRIPT) is specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary

--- a/boards/stm32f3discovery/Makefile.include
+++ b/boards/stm32f3discovery/Makefile.include
@@ -31,10 +31,10 @@ export DEBUGSERVER = st-util
 # define build specific options
 CPU_USAGE = -mcpu=cortex-m4
 FPU_USAGE = -mfloat-abi=hard -mfpu=fpv4-sp-d16
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary
 export FFLAGS = write bin/$(BOARD)/$(APPLICATION).hex 0x8000000

--- a/boards/stm32f4discovery/Makefile.include
+++ b/boards/stm32f4discovery/Makefile.include
@@ -31,10 +31,10 @@ export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 # define build specific options
 CPU_USAGE = -mcpu=cortex-m4
 FPU_USAGE = -mfloat-abi=hard -mfpu=fpv4-sp-d16
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 # $(LINKERSCRIPT) is specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O ihex

--- a/boards/udoo/Makefile.include
+++ b/boards/udoo/Makefile.include
@@ -29,10 +29,10 @@ export PORT
 
 # define build specific options
 export CPU_USAGE = -mcpu=cortex-m3
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 # linkerscript specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS += -O binary

--- a/boards/yunjia-nrf51822/Makefile.include
+++ b/boards/yunjia-nrf51822/Makefile.include
@@ -32,10 +32,10 @@ export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 # define build specific options
 CPU_USAGE = -mcpu=cortex-m0
 FPU_USAGE =
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mthumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
-export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mthumb-interwork -nostartfiles
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 # $(LINKERSCRIPT) is specified in cpu/Makefile.include
 export LINKFLAGS += -T$(LINKERSCRIPT)
 export OFLAGS = -O binary


### PR DESCRIPTION
`-mthumb-interwork` should not be used on Cortex-M platforms as the CPU will simply go to UsageFault/HardFault (Cortex-M0) if any non-Thumb code is called.
This PR adds `-mno-thumb-interwork` to the Makefiles of all Cortex-M platforms.

References: 
 - http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka12545.html
 - https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html