### PR TITLE
add infrastructure for binary LGPL compliance checks

### DIFF
--- a/Makefile.bindist
+++ b/Makefile.bindist
@@ -1,0 +1,30 @@
+DIST_FILES += bin/$(BOARD)/$(APPLICATION).a
+
+ifneq (, $(filter check_bindist, $(MAKECMDGOALS)))
+	include Makefile.distcheck
+else
+	DIRS+=$(BINARY_DIRS)
+endif
+
+bindist: all
+	@mkdir -p bindist
+	@for i in $(DIST_FILES) ; do \
+		echo Copying $$i to bindist. ; \
+		cp -a --parents $$i bindist ; \
+		done
+	@cp -a bin/$(BOARD)/$(APPLICATION).elf bindist
+
+	@echo "BINDIST_RIOT_VERSION=$(RIOT_VERSION)" > bindist/Makefile.distcheck
+	@echo "BINDIST_GIT_HEAD=$$(git --work-tree=$(RIOTBASE) describe)" >> bindist/Makefile.distcheck
+
+prepare_check_bindist:
+	@[ "$(BINDIST_RIOT_VERSION)" = "$(RIOT_VERSION)" ] || \
+		echo "Warning! RIOT_VERSION doesn't match!"
+	@[ "$(BINDIST_GIT_HEAD)" = "$$(git --work-tree=$(RIOTBASE) describe)" ] || \
+		echo "Warning! git describe doesn't match!"
+
+check_bindist: prepare_check_bindist all
+	@test $(shell md5sum bin/$(BOARD)/$(APPLICATION).elf | cut -f1 -d\ ) \
+		= $(shell md5sum $(APPLICATION).elf | cut -f1 -d\ ) \
+		&& echo "bin/$(BOARD)/$(APPLICATION).elf matches $(APPLICATION).elf." \
+		|| echo "bin/$(BOARD)/$(APPLICATION).elf and $(APPLICATION).elf don't match!"

--- a/Makefile.include
+++ b/Makefile.include
@@ -451,3 +451,6 @@ endif
 
 # Include desvirt Makefile
 include $(RIOTBASE)/dist/tools/desvirt/Makefile.desvirt
+
+# include bindist target
+include $(RIOTBASE)/Makefile.bindist

--- a/examples/bindist/Makefile
+++ b/examples/bindist/Makefile
@@ -1,0 +1,30 @@
+# name of your application
+APPLICATION = bindist
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+CFLAGS += -DDEVELHELP
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+# bindist specific stuff:
+#
+# build and use module "abc".
+# use BINARY_DIRS instead of DIRS
+BINARY_DIRS += abc
+USEMODULE += abc
+
+# list of files to include in binary distribution
+# "bin/$(BOARD)/$(APPLICATION).elf" will automatically be added
+DIST_FILES += Makefile
+DIST_FILES += bin/$(BOARD)/abc.a
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/bindist/README.md
+++ b/examples/bindist/README.md
@@ -1,0 +1,41 @@
+# Introduction
+
+RIOT allows for creating a "binary distribution", which can be used to ship
+proprietary, compiled objects in a way that makes it possible to re-link them
+against a freshly compiled RIOT.
+This "binary distribution" also contains version information and md5 hashes of
+a linked binary, making verification of correctness of a link possible.
+
+This application serves as simple example for "make bindist".
+It consists of an application module (bindist.a) and another example module
+(abc.a).
+
+## Instructions
+
+Calling "make bindist" creates a folder "bindist", which only contains the
+compiled and linked binary, bindist.a, abc.a and Makefiles.
+
+In order to recompile RIOT, adjust "RIOTBASE" in Makefile to point to a RIOT
+source checkout, then call "make check_bindist".
+
+RIOT will be build as usual, but just take the pre-compiled bindist.a and
+abc.a.  Their source is not necessary.  The resulting binary will then be
+compared with te precompiled  "bindist.elf" (using md5sum) and the result gets
+printed.  If the same RIOT source tree and build environment (compiler version,
+etc.) was used, the binaries should match.
+
+Step-by-step:
+
+1. # cd <riot-checkout>/examples/bindist
+2. # make all
+3. # make bindist
+4. # cd bindist
+5. <adjust RIOTBASE variable (../.. -> ../../..)
+6. # make check_bindist
+
+## Needed Makefile changes
+
+In order to enable "make bindist" for your application, several things have to
+be changed in the main application's Makefile.
+
+See this application's Makefile as example.

--- a/examples/bindist/abc/Makefile
+++ b/examples/bindist/abc/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/examples/bindist/abc/abc.c
+++ b/examples/bindist/abc/abc.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Binary distribution example code
+ *
+ * This file contains just example code that will end up in a example binary
+ * distribution folder.
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+void abc(void)
+{
+    printf("abc!\n");
+}

--- a/examples/bindist/main.c
+++ b/examples/bindist/main.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Binary distribution example
+ *
+ * This application serves as simple example for "make bindist", a makefile
+ * target that can be used to ship proprietary, compiled objects together
+ * with a compiled binary in a way that allows re-linking and makes
+ * verification possible.
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+extern void abc(void);
+
+int main(void)
+{
+    puts("Hello closed-source!");
+    abc();
+
+    return 0;
+}


### PR DESCRIPTION
generalized version of #2357.
Work in progress. beauty-patches welcome! README.md outdated.

This PR adds some new make targets:
```patch``` -> apply all patches in patches/ folder to $RIOTBASE using ```git am```
```bindist``` -> creates a folder "bindist" which contains all files needed for LGPL-compliant distribution
```check_bindist``` -> supposed to be run from within a folder created by "make bindist". Checks if compiled RIOTBASE linked with included .a files md5-matches included .elf.

Please check out the concept before I thorougly document it. ;)


