### PR TITLE
sys/bloom: changed doc from bytes -> bits

### DIFF
--- a/sys/include/bloom.h
+++ b/sys/include/bloom.h
@@ -140,7 +140,7 @@ typedef uint32_t (*hashfp_t)(const uint8_t *, int len);
  * @brief bloom_t bloom filter object
  */
 typedef struct {
-    /** number of bytes in the bloom array */
+    /** number of bits in the bloom array */
     size_t m;
     /** number of hash functions */
     size_t k;
@@ -155,7 +155,7 @@ typedef struct {
  *
  * For best results, make 'size' a power of 2.
  *
- * @param size        size of the bit array in the filter
+ * @param size        size of the bit array of the filter in bits
  * @param num_hashes  the number of hash functions
  * @param ...         varg function pointers, use hashfp_t
  *

--- a/tests/unittests/tests-bloom/tests-bloom.c
+++ b/tests/unittests/tests-bloom/tests-bloom.c
@@ -16,7 +16,7 @@
 
 #include "tests-bloom-sets.h"
 
-#define TESTS_BLOOM_BYTES (128)
+#define TESTS_BLOOM_BITS (128)
 #define TESTS_BLOOM_HASHF (6)
 #define TESTS_BLOOM_PROB_IN_FILTER (4)
 #define TESTS_BLOOM_NOT_IN_FILTER (996)
@@ -35,7 +35,7 @@ static void load_dictionary_fixture(void)
 
 static void set_up_bloom(void)
 {
-    bloom = bloom_new(TESTS_BLOOM_BYTES, TESTS_BLOOM_HASHF, fnv_hash, sax_hash,
+    bloom = bloom_new(TESTS_BLOOM_BITS, TESTS_BLOOM_HASHF, fnv_hash, sax_hash,
             sdbm_hash, djb2_hash, kr_hash, dek_hash, rotating_hash,
             one_at_a_time_hash);
 }
@@ -47,7 +47,7 @@ static void tear_down_bloom(void)
 
 static void test_bloom_parameters_bytes_hashf(void)
 {
-    TEST_ASSERT_EQUAL_INT(TESTS_BLOOM_BYTES, bloom->m);
+    TEST_ASSERT_EQUAL_INT(TESTS_BLOOM_BITS, bloom->m);
     TEST_ASSERT_EQUAL_INT(TESTS_BLOOM_HASHF, bloom->k);
 }
 


### PR DESCRIPTION
Looking at the code in `bloom_new()`, `size` is used to allocate the filter by converting `size` to bytes (with `ROUND()`). Therefore, the doc should say **bits** instead of **bytes** for `size` and `m`.
Furthermore, `m` is generally associated with the size in **bits** in several papers.