### PR TITLE
cpu/cc2538: set the VTOR register to the actual address of the vector table

### DIFF
--- a/cpu/cc2538/cpu.c
+++ b/cpu/cc2538/cpu.c
@@ -17,6 +17,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 
 #define BIT(n)          ( 1UL << (n) )
@@ -32,6 +34,8 @@
 
 #define CLOCK_STA_MASK ( OSC32K | OSC )
 
+extern const void *interrupt_vector[];
+
 static void cpu_clock_init(void);
 
 /**
@@ -40,7 +44,8 @@ static void cpu_clock_init(void);
 void cpu_init(void)
 {
     /* configure the vector table location to internal flash */
-    SCB->VTOR = FLASH_BASE;
+    assert((uintptr_t)&interrupt_vector % CC2538_VTOR_ALIGN == 0);
+    SCB->VTOR = (uintptr_t)&interrupt_vector;
 
     /* Enable the CC2538's more compact alternate interrupt mapping */
     SYS_CTRL->I_MAP = 1;

--- a/cpu/cc2538/include/cc2538.h
+++ b/cpu/cc2538/include/cc2538.h
@@ -809,6 +809,8 @@ typedef volatile uint32_t cc2538_reg_t; /**< Least-significant 32 bits of the IE
 #define XOSC32M_FREQ                32000000 /**< 32 MHz external oscillator/clock frequency */
 #define RCOSC16M_FREQ               16000000 /**< 16 MHz internal RC oscillator frequency */
 
+#define CC2538_VTOR_ALIGN                512 /**< CC2538 Vector Table alignment */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/cc2538/startup.c
+++ b/cpu/cc2538/startup.c
@@ -165,7 +165,7 @@ void isr_dma(void)           __attribute__ ((weak, alias("dummy_handler")));
 void isr_dmaerr(void)        __attribute__ ((weak, alias("dummy_handler")));
 
 /* interrupt vector table */
-__attribute__ ((section(".vectors")))
+__attribute__ ((section(".vectors"), aligned(CC2538_VTOR_ALIGN)))
 const void *interrupt_vector[] = {
     /* Stack pointer */
     (void*) (&_estack),             /* pointer to the top of the empty stack */


### PR DESCRIPTION
Previously the vector table was assumed to be at the start of the flash memory. This change allows the vector table to be placed anywhere in flash, which is important if the flash is segmented to contain multiple firmware images.