### PR TITLE
board: Add nrf6310 (nRF51)

### DIFF
--- a/boards/nrf6310/Makefile
+++ b/boards/nrf6310/Makefile
@@ -1,0 +1,4 @@
+# tell the Makefile.base which module to build
+MODULE = $(BOARD)_base
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nrf6310/Makefile.features
+++ b/boards/nrf6310/Makefile.features
@@ -1,2 +1,2 @@
 FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart periph_gpio periph_random periph_rtt periph_cpuid periph_spi
+FEATURES_PROVIDED += periph_uart periph_gpio periph_random periph_rtt periph_cpuid

--- a/boards/nrf6310/Makefile.features
+++ b/boards/nrf6310/Makefile.features
@@ -1,0 +1,2 @@
+FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += periph_uart periph_gpio periph_random periph_rtt periph_cpuid periph_spi

--- a/boards/nrf6310/Makefile.include
+++ b/boards/nrf6310/Makefile.include
@@ -1,0 +1,58 @@
+# define the cpu used by the nRF51822 board nrf6310
+export CPU = nrf51822
+export CPU_MODEL = nrf51822qfaa
+
+#define the default port depending on the host OS
+OS := $(shell uname)
+ifeq ($(OS),Linux)
+  PORT ?= /dev/ttyACM0
+else ifeq ($(OS),Darwin)
+  PORT ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+else
+  $(info CAUTION: No flash tool for your host system found!)
+  # TODO: add support for windows as host platform
+endif
+export PORT
+
+# define tools used for building the project
+export PREFIX = arm-none-eabi-
+export CC = $(PREFIX)gcc
+export CXX = $(PREFIX)g++
+export AR = $(PREFIX)ar
+export AS = $(PREFIX)as
+export LINK = $(PREFIX)gcc
+export SIZE = $(PREFIX)size
+export OBJCOPY = $(PREFIX)objcopy
+export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm
+export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
+export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
+export DEBUGSERVER = JLinkGDBServer -device nrf51822 -if SWD
+export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
+
+# define build specific options
+CPU_USAGE = -mcpu=cortex-m0
+FPU_USAGE =
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
+export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
+export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
+export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
+# $(LINKERSCRIPT) is specified in cpu/Makefile.include
+export LINKFLAGS += -T$(LINKERSCRIPT)
+export OFLAGS = -O binary
+export HEXFILE = $(ELFFILE:.elf=.bin)
+export TERMFLAGS += -p "$(PORT)"
+export FFLAGS = $(BINDIR) $(HEXFILE)
+export DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
+export RESET_FLAGS = $(BINDIR)
+
+# unwanted (CXXUWFLAGS) and extra (CXXEXFLAGS) flags for c++
+export CXXUWFLAGS +=
+export CXXEXFLAGS +=
+
+# use the nano-specs of the NewLib when available
+ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+export LINKFLAGS += -specs=nano.specs -lc -lnosys
+endif
+
+# export board specific includes to the global includes-listing
+export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include

--- a/boards/nrf6310/board.c
+++ b/boards/nrf6310/board.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     board_pca10005
+ * @{
+ *
+ * @file        board.c
+ * @brief       Board specific implementations for the nRF51822 evaluation board pca10005
+ *
+ * @author      Christian Kühling <kuehling@zedat.fu-berlin.de>
+ * @author      Timo Ziegler <timo.ziegler@fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "cpu.h"
+
+void board_init(void)
+{
+    /* setup led(s) for debugging */
+    NRF_GPIO->PIN_CNF[LED_RED_PIN] = GPIO_PIN_CNF_DIR_Output;
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/nrf6310/dist/debug.sh
+++ b/boards/nrf6310/dist/debug.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Start in-circuit debugging on this board: this script starts up the GDB
+# client and connects to a GDB server.
+#
+# Start the GDB server first using the 'make debugserver' target
+
+# @author Hauke Petersen <hauke.petersen@fu-berlin.de>
+
+BINDIR=$1
+ELFFILE=$2
+
+# write GDB config file
+echo "target extended-remote 127.0.0.1:2331" > $BINDIR/gdb.cfg
+
+# run GDB
+arm-none-eabi-gdb -tui -command=$BINDIR/gdb.cfg $ELFFILE

--- a/boards/nrf6310/dist/flash.sh
+++ b/boards/nrf6310/dist/flash.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# This flash script dynamically generates a file with a set of commands which
+# have to be handed to the flashing script of SEGGER (JLinkExe >4.84).
+# After that, JLinkExe will be executed with that set of commands to flash the
+# latest .bin file to the board.
+
+# @author Timo Ziegler <timo.ziegler@fu-berlin.de>
+# @author Hauke Petersen <hauke.petersen@fu-berlin.de>
+
+BINDIR=$1
+HEXFILE=$2
+
+# setup JLink command file
+echo "device nrf51822" > $BINDIR/burn.seg
+echo "speed 1000" >> $BINDIR/burn.seg
+echo "w4 4001e504 1" >> $BINDIR/burn.seg
+echo "loadbin $HEXFILE 0" >> $BINDIR/burn.seg
+echo "r" >> $BINDIR/burn.seg
+echo "g" >> $BINDIR/burn.seg
+echo "exit" >> $BINDIR/burn.seg
+echo "" >> $BINDIR/burn.seg
+
+# flash new binary to the board
+JLinkExe < $BINDIR/burn.seg

--- a/boards/nrf6310/dist/reset.sh
+++ b/boards/nrf6310/dist/reset.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# This script resets a nrf51822 target using JLink called
+# with a pre-defined reset sequence.
+
+# @author Hauke Petersen <hauke.petersen@fu-berlin.de>
+
+BINDIR=$1
+
+# create JLink command file for resetting the board
+echo "device nrf51822" > $BINDIR/reset.seg
+echo "r" >> $BINDIR/reset.seg
+echo "g" >> $BINDIR/reset.seg
+echo "exit" >> $BINDIR/reset.seg
+echo " " >> $BINDIR/reset.seg
+
+# reset the board
+JLinkExe < $BINDIR/reset.seg

--- a/boards/nrf6310/include/board.h
+++ b/boards/nrf6310/include/board.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    board_pca10005 PCA10005 (nRF51822 Development Kit)
+ * @ingroup     boards
+ * @brief       Board specific files for the nRF51822 board pca10005
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the nRF51822 evaluation board pca10005
+ *
+ * @author      Christian Kühling <kuehling@zedat.fu-berlin.de>
+ * @author      Timo Ziegler <timo.ziegler@fu-berlin.de>
+ */
+
+#ifndef __BOARD_H
+#define __BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Define the nominal CPU core clock in this board
+ */
+#define F_CPU               (16000000UL)
+
+/**
+ * @name Define the boards stdio
+ * @{
+ */
+#define STDIO               UART_0
+#define STDIO_BAUDRATE      (115200U)
+#define STDIO_RX_BUFSIZE    (64U)
+/** @} */
+
+/**
+ * @name Assign the hardware timer
+ */
+#define HW_TIMER            TIMER_0
+
+/**
+ * @name Macros for controlling the on-board LEDs.
+ * @{
+ */
+#define LED_0_PIN           8
+#define LED_1_PIN           9
+#define LED_2_PIN           10
+#define LED_3_PIN           11
+#define LED_4_PIN           12
+#define LED_5_PIN           13
+#define LED_6_PIN           14
+#define LED_7_PIN           15
+
+#define LED_RED_PIN         (LED_0_PIN)
+#define LED_GREEN_PIN       (LED_1_PIN)
+#define LED_BLUE_PIN        (LED_2_PIN)
+
+#define LED_RED_ON          (NRF_GPIO->OUTSET = (1 << LED_RED_PIN))
+#define LED_RED_OFF         (NRF_GPIO->OUTCLR = (1 << LED_RED_PIN))
+#define LED_RED_TOGGLE      (NRF_GPIO->OUT ^= (1 << LED_RED_PIN))
+#define LED_GREEN_ON        (NRF_GPIO->OUTSET = (1 << LED_GREEN_PIN))
+#define LED_GREEN_OFF       (NRF_GPIO->OUTCLR = (1 << LED_GREEN_PIN))
+#define LED_GREEN_TOGGLE    (NRF_GPIO->OUT ^= (1 << LED_GREEN_PIN))
+#define LED_BLUE_ON         (NRF_GPIO->OUTSET = (1 << LED_BLUE_PIN))
+#define LED_BLUE_OFF        (NRF_GPIO->OUTCLR = (1 << LED_BLUE_PIN))
+#define LED_BLUE_TOGGLE     (NRF_GPIO->OUT ^= (1 << LED_BLUE_PIN))
+/* @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /** __BOARD_H */
+/** @} */

--- a/boards/nrf6310/include/buttons.h
+++ b/boards/nrf6310/include/buttons.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef BUTTONS_H
+#define BUTTONS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Button ports
+#define BUTTON_0_PIN            0
+#define BUTTON_1_PIN            1
+#define BUTTON_2_PIN            2
+#define BUTTON_3_PIN            3
+#define BUTTON_4_PIN            4
+#define BUTTON_5_PIN            5
+#define BUTTON_6_PIN            6
+#define BUTTON_7_PIN            7
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/boards/nrf6310/include/periph_conf.h
+++ b/boards/nrf6310/include/periph_conf.h
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     board_nrf6310
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the nRF51822 board nrf6310
+ *
+ * @author      Christian Kühling <kuehling@zedat.fu-berlin.de>
+ * @author      Timo Ziegler <timo.ziegler@fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Frank Holtz <frank-riot2015@holtznet.de>
+ */
+
+#ifndef __PERIPH_CONF_H
+#define __PERIPH_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Clock configuration
+ *
+ * @note: the radio will not work with the internal RC oscillator!
+ *
+ * @{
+ */
+#define CLOCK_CORECLOCK     (16000000U)     /* fixed for all NRF51822 */
+#define CLOCK_CRYSTAL       (16U)           /* set to  0: internal RC oscillator
+                                                      16: 16MHz crystal
+                                                      32: 32MHz crystal */
+/** @} */
+
+/**
+ * @name Timer configuration
+ * @{
+ */
+#define TIMER_NUMOF         (1U)
+#define TIMER_0_EN          1
+#define TIMER_1_EN          0
+#define TIMER_2_EN          0
+#define TIMER_IRQ_PRIO      1
+
+/* Timer 0 configuration */
+#define TIMER_0_DEV         NRF_TIMER0
+#define TIMER_0_CHANNELS    3
+#define TIMER_0_MAX_VALUE   (0xffffff)
+#define TIMER_0_BITMODE     TIMER_BITMODE_BITMODE_24Bit
+#define TIMER_0_ISR         isr_timer0
+#define TIMER_0_IRQ         TIMER0_IRQn
+
+/* Timer 1 configuration */
+#define TIMER_1_DEV         NRF_TIMER1
+#define TIMER_1_CHANNELS    3
+#define TIMER_1_MAX_VALUE   (0xffff)
+#define TIEMR_1_BITMODE     TIMER_BITMODE_BITMODE_16Bit
+#define TIMER_1_ISR         isr_timer1
+#define TIMER_1_IRQ         TIMER1_IRQn
+
+/* Timer 2 configuration */
+#define TIMER_2_DEV         NRF_TIMER2
+#define TIMER_2_CHANNELS    3
+#define TIMER_2_MAX_VALUE   (0xffff)
+#define TIMER_2_BITMODE     TIMER_BITMODE_BITMODE_16Bit
+#define TIMER_2_ISR         isr_timer2
+#define TIMER_2_IRQ         TIMER2_IRQn
+/** @} */
+
+/**
+ * @name UART configuration
+ * @{
+ */
+#define UART_NUMOF          (1U)
+#define UART_0_EN           1
+#define UART_IRQ_PRIO       1
+
+/* UART pin configuration */
+#define UART_PIN_RX       16
+#define UART_PIN_TX       17
+#define UART_HWFLOWCTRL   0
+#define UART_PIN_RTS      19
+#define UART_PIN_CTS      18
+/** @} */
+
+/**
+ * @name Real time counter configuration
+ * @{
+ */
+#define RTT_NUMOF           (1U)
+#define RTT_IRQ_PRIO        1
+
+#define RTT_DEV             NRF_RTC0
+#define RTT_IRQ             RTC0_IRQn
+#define RTT_ISR             isr_rtc0
+#define RTT_MAX_VALUE       (0xffffff)
+#define RTT_FREQUENCY       (10)            /* in Hz */
+#define RTT_PRESCALER       (3275U)         /* run with 10 Hz */
+/** @} */
+
+/**
+ * @name Random Number Generator configuration
+ * @{
+ */
+#define RANDOM_NUMOF        (1U)
+/** @} */
+
+/**
+ * @name SPI configuration
+ * @{
+ */
+#define SPI_NUMOF           (2U)
+#define SPI_0_EN            1
+#define SPI_1_EN            1
+#define SPI_S_EN            1
+
+/* SPI Master 0 pin configuration */
+#define SPI_0_SCK_PIN           23
+#define SPI_0_MISO_PIN          22
+#define SPI_0_MOSI_PIN          20
+
+/* SPI Master 1 pin configuration */
+#define SPI_1_SCK_PIN           16
+#define SPI_1_MISO_PIN          22
+#define SPI_1_MOSI_PIN          18
+
+/* SPI Slave pin configuration */
+#define SPI_S_SCK_PIN           23
+#define SPI_S_MISO_PIN          20
+#define SPI_S_MOSI_PIN          22
+
+/** @} */
+
+/**
+ * @name GPIO configuration
+ * @{
+ */
+#define GPIO_NUMOF          16
+#define GPIO_0_EN           1
+#define GPIO_1_EN           1
+#define GPIO_2_EN           1
+#define GPIO_3_EN           1
+#define GPIO_4_EN           1
+#define GPIO_5_EN           1
+#define GPIO_6_EN           1
+#define GPIO_7_EN           1
+#define GPIO_8_EN           1
+#define GPIO_9_EN           1
+#define GPIO_10_EN          1
+#define GPIO_11_EN          1
+#define GPIO_12_EN          1
+#define GPIO_13_EN          1
+#define GPIO_14_EN          1
+#define GPIO_15_EN          1
+#define GPIO_16_EN          1
+#define GPIO_17_EN          1
+#define GPIO_18_EN          1
+#define GPIO_19_EN          1
+#define GPIO_20_EN          1
+#define GPIO_21_EN          1
+#define GPIO_22_EN          1
+#define GPIO_23_EN          1
+#define GPIO_24_EN          1
+/* Disabled when X2 32768kHz
+ * is enabled by jumper
+ * 
+#define GPIO_25_EN          1
+#define GPIO_26_EN          1
+ */
+#define GPIO_27_EN          1
+#define GPIO_28_EN          1
+#define GPIO_29_EN          1
+#define GPIO_30_EN          1
+#define GPIO_IRQ_PRIO       1
+
+/* GPIO pin configuration */
+#define GPIO_0_PIN          0
+#define GPIO_1_PIN          1
+#define GPIO_2_PIN          2
+#define GPIO_3_PIN          3
+#define GPIO_4_PIN          4
+#define GPIO_5_PIN          5
+#define GPIO_6_PIN          6
+#define GPIO_7_PIN          7
+#define GPIO_8_PIN          8
+#define GPIO_9_PIN          9
+#define GPIO_10_PIN         10
+#define GPIO_11_PIN         11
+#define GPIO_12_PIN         12
+#define GPIO_13_PIN         13
+#define GPIO_14_PIN         14
+#define GPIO_15_PIN         15
+#define GPIO_16_PIN         16
+#define GPIO_17_PIN         17
+#define GPIO_18_PIN         18
+#define GPIO_19_PIN         19
+#define GPIO_20_PIN         20
+#define GPIO_21_PIN         21
+#define GPIO_22_PIN         22
+#define GPIO_23_PIN         23
+#define GPIO_24_PIN         24
+#define GPIO_25_PIN         25
+#define GPIO_26_PIN         26
+#define GPIO_27_PIN         27
+#define GPIO_28_PIN         28
+#define GPIO_29_PIN         29
+#define GPIO_30_PIN         30
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __PERIPH_CONF_H */


### PR DESCRIPTION
This Board is for nRF51 HDK. Tested with nrf6310 compatible BLE DEVKIT.N R2 boards by mommosoft using PCA1000(4|5|6|7) boards.