### PR TITLE
board: Add nrf6310 (nRF51)

### DIFF
--- a/boards/nrf6310/Makefile
+++ b/boards/nrf6310/Makefile
@@ -1,0 +1,4 @@
+# tell the Makefile.base which module to build
+MODULE = $(BOARD)_base
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nrf6310/Makefile.features
+++ b/boards/nrf6310/Makefile.features
@@ -1,0 +1,9 @@
+FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += radio_nrfmin
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_random
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_spi
+FEATURES_MCU_GROUP = cortex_m0

--- a/boards/nrf6310/Makefile.include
+++ b/boards/nrf6310/Makefile.include
@@ -1,0 +1,26 @@
+# define the used CPU
+export CPU = nrf51
+export CPU_MODEL = nrf51x22xxaa
+
+# set default port depending on operating system
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+
+# define flash and debugging environment
+export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
+export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
+export DEBUGSERVER = JLinkGDBServer -device nrf51822 -if SWD
+export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
+
+export OFLAGS = -O binary
+export HEXFILE = $(ELFFILE:.elf=.bin)
+export TERMFLAGS += -p "$(PORT)"
+export FFLAGS = $(BINDIR) $(HEXFILE)
+export DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
+export RESET_FLAGS = $(BINDIR)
+
+# setup serial terminal
+include $(RIOTBOARD)/Makefile.include.serial
+
+# include cortex defaults
+include $(RIOTBOARD)/Makefile.include.cortexm_common

--- a/boards/nrf6310/board.c
+++ b/boards/nrf6310/board.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     board_nrf6310
+ * @{
+ *
+ * @file        board.c
+ * @brief       Board specific implementations for the nRF51822 evaluation board pca10005
+ *
+ * @author      Christian Kühling <kuehling@zedat.fu-berlin.de>
+ * @author      Timo Ziegler <timo.ziegler@fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "cpu.h"
+
+void board_init(void)
+{
+    /* setup led(s) for debugging */
+    NRF_GPIO->PIN_CNF[LED_RED_PIN] = GPIO_PIN_CNF_DIR_Output;
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/nrf6310/dist/debug.sh
+++ b/boards/nrf6310/dist/debug.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Start in-circuit debugging on this board: this script starts up the GDB
+# client and connects to a GDB server.
+#
+# Start the GDB server first using the 'make debugserver' target
+
+# @author Hauke Petersen <hauke.petersen@fu-berlin.de>
+
+BINDIR=$1
+ELFFILE=$2
+
+# write GDB config file
+echo "target extended-remote 127.0.0.1:2331" > $BINDIR/gdb.cfg
+
+# run GDB
+arm-none-eabi-gdb -tui -command=$BINDIR/gdb.cfg $ELFFILE

--- a/boards/nrf6310/dist/flash.sh
+++ b/boards/nrf6310/dist/flash.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# This flash script dynamically generates a file with a set of commands which
+# have to be handed to the flashing script of SEGGER (JLinkExe >4.84).
+# After that, JLinkExe will be executed with that set of commands to flash the
+# latest .bin file to the board.
+
+# @author Timo Ziegler <timo.ziegler@fu-berlin.de>
+# @author Hauke Petersen <hauke.petersen@fu-berlin.de>
+
+BINDIR=$1
+HEXFILE=$2
+
+# setup JLink command file
+echo "device nrf51822" > $BINDIR/burn.seg
+echo "speed 1000" >> $BINDIR/burn.seg
+echo "w4 4001e504 1" >> $BINDIR/burn.seg
+echo "loadbin $HEXFILE 0" >> $BINDIR/burn.seg
+echo "r" >> $BINDIR/burn.seg
+echo "g" >> $BINDIR/burn.seg
+echo "exit" >> $BINDIR/burn.seg
+echo "" >> $BINDIR/burn.seg
+
+# flash new binary to the board
+JLinkExe < $BINDIR/burn.seg

--- a/boards/nrf6310/dist/reset.sh
+++ b/boards/nrf6310/dist/reset.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# This script resets a nrf51822 target using JLink called
+# with a pre-defined reset sequence.
+
+# @author Hauke Petersen <hauke.petersen@fu-berlin.de>
+
+BINDIR=$1
+
+# create JLink command file for resetting the board
+echo "device nrf51822" > $BINDIR/reset.seg
+echo "r" >> $BINDIR/reset.seg
+echo "g" >> $BINDIR/reset.seg
+echo "exit" >> $BINDIR/reset.seg
+echo " " >> $BINDIR/reset.seg
+
+# reset the board
+JLinkExe < $BINDIR/reset.seg

--- a/boards/nrf6310/include/board.h
+++ b/boards/nrf6310/include/board.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    board_nrf6310 NRF6310 (Nordic NRF Hardware Development Kit)
+ * @ingroup     boards
+ * @brief       Board specific files for the nRF51 boards nrf6310 or MOMMOSOFT BLE DEVKIT.N
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the nRF51 evaluation board nrf6310
+ *
+ * @author      Christian Kühling <kuehling@zedat.fu-berlin.de>
+ * @author      Timo Ziegler <timo.ziegler@fu-berlin.de>
+ * @author      Frank Holtz <frank-riot2015@holtznet.de>
+ */
+
+#ifndef __BOARD_H
+#define __BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Define the nominal CPU core clock in this board
+ */
+#define F_CPU               (16000000UL)
+
+/**
+ * @name Define the boards stdio
+ * @{
+ */
+#define STDIO               UART_0
+#define STDIO_BAUDRATE      (115200U)
+#define STDIO_RX_BUFSIZE    (64U)
+/** @} */
+
+/**
+ * @name Assign the hardware timer
+ */
+#define HW_TIMER            TIMER_0
+
+/**
+ * @name    LED pin definitions
+ * @{
+ */
+#define ONBOARD_LED         1
+#define LED_RED_PIN         (1 << 8)
+#define LED_GREEN_PIN       (1 << 9)
+#define LED_BLUE_PIN        (1 << 10)
+/** @} */
+
+/**
+ * @name Macros for controlling the on-board LEDs.
+ * @{
+ */
+#define LED_RED_ON          (NRF_GPIO->OUTCLR = LED_RED_PIN)
+#define LED_RED_OFF         (NRF_GPIO->OUTSET = LED_RED_PIN)
+#define LED_RED_TOGGLE      (NRF_GPIO->OUT ^= LED_RED_PIN)
+#define LED_GREEN_ON        (NRF_GPIO->OUTCLR = LED_GREEN_PIN)
+#define LED_GREEN_OFF       (NRF_GPIO->OUTSET = LED_GREEN_PIN)
+#define LED_GREEN_TOGGLE    (NRF_GPIO->OUT ^= LED_GREEN_PIN)
+#define LED_BLUE_ON         (NRF_GPIO->OUTCLR = LED_BLUE_PIN)
+#define LED_BLUE_OFF        (NRF_GPIO->OUTSET = LED_BLUE_PIN)
+#define LED_BLUE_TOGGLE     (NRF_GPIO->OUT ^= LED_BLUE_PIN)
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /** __BOARD_H */
+/** @} */

--- a/boards/nrf6310/include/periph_conf.h
+++ b/boards/nrf6310/include/periph_conf.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     board_nrf6310
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the nRF51 board nrf6310
+ *
+ * @author      Christian Kühling <kuehling@zedat.fu-berlin.de>
+ * @author      Timo Ziegler <timo.ziegler@fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Frank Holtz <frank-riot2015@holtznet.de>
+ */
+
+#ifndef __PERIPH_CONF_H
+#define __PERIPH_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Clock configuration
+ *
+ * @note: the radio will not work with the internal RC oscillator!
+ *
+ * @{
+ */
+#define CLOCK_CORECLOCK     (16000000U)     /* fixed for all NRF51822 */
+#define CLOCK_CRYSTAL       (16U)           /* set to  0: internal RC oscillator
+                                                      16: 16MHz crystal
+                                                      32: 32MHz crystal */
+/** @} */
+
+/**
+ * @name Timer configuration
+ * @{
+ */
+#define TIMER_NUMOF         (1U)
+#define TIMER_0_EN          1
+#define TIMER_1_EN          0
+#define TIMER_2_EN          0
+#define TIMER_IRQ_PRIO      1
+
+/* Timer 0 configuration */
+#define TIMER_0_DEV         NRF_TIMER0
+#define TIMER_0_CHANNELS    3
+#define TIMER_0_MAX_VALUE   (0xffffff)
+#define TIMER_0_BITMODE     TIMER_BITMODE_BITMODE_24Bit
+#define TIMER_0_ISR         isr_timer0
+#define TIMER_0_IRQ         TIMER0_IRQn
+
+/* Timer 1 configuration */
+#define TIMER_1_DEV         NRF_TIMER1
+#define TIMER_1_CHANNELS    3
+#define TIMER_1_MAX_VALUE   (0xffff)
+#define TIEMR_1_BITMODE     TIMER_BITMODE_BITMODE_16Bit
+#define TIMER_1_ISR         isr_timer1
+#define TIMER_1_IRQ         TIMER1_IRQn
+
+/* Timer 2 configuration */
+#define TIMER_2_DEV         NRF_TIMER2
+#define TIMER_2_CHANNELS    3
+#define TIMER_2_MAX_VALUE   (0xffff)
+#define TIMER_2_BITMODE     TIMER_BITMODE_BITMODE_16Bit
+#define TIMER_2_ISR         isr_timer2
+#define TIMER_2_IRQ         TIMER2_IRQn
+/** @} */
+
+/**
+ * @name Real time counter configuration
+ * @{
+ */
+#define RTT_NUMOF           (1U)
+#define RTT_IRQ_PRIO        1
+
+#define RTT_DEV             NRF_RTC1
+#define RTT_IRQ             RTC1_IRQn
+#define RTT_ISR             isr_rtc1
+#define RTT_MAX_VALUE       (0xffffff)
+#define RTT_FREQUENCY       (10)            /* in Hz */
+#define RTT_PRESCALER       (3275U)         /* run with 10 Hz */
+/** @} */
+
+/**
+ * @name UART configuration
+ * @{
+ */
+#define UART_NUMOF          (1U)
+#define UART_0_EN           1
+#define UART_IRQ_PRIO       1
+
+/* UART pin configuration */
+#define UART_PIN_RX       16
+#define UART_PIN_TX       17
+#define UART_HWFLOWCTRL   0
+#define UART_PIN_RTS      19
+#define UART_PIN_CTS      18
+/** @} */
+
+/**
+ * @name Random Number Generator configuration
+ * @{
+ */
+#define RANDOM_NUMOF        (1U)
+/** @} */
+
+/**
+ * @name Radio device configuration
+ *
+ * The radio is not guarded by a NUMOF define, as the radio is selected by its
+ * own module in the build system.
+ * @{
+ */
+#define RADIO_IRQ_PRIO      1
+/** @} */
+
+/**
+ * @name SPI configuration
+ * @{
+ */
+#define SPI_NUMOF           (2U)
+#define SPI_0_EN            1
+#define SPI_1_EN            1
+#define SPI_IRQ_PRIO        1
+
+/* SPI Master 0 pin configuration */
+#define SPI_0_DEV           NRF_SPI0
+#define SPI_0_PIN_SCK       23
+#define SPI_0_PIN_MISO      22
+#define SPI_0_PIN_MOSI      20
+
+/* SPI Master 1 pin configuration */
+#define SPI_1_DEV           NRF_SPI1
+#define SPI_1_PIN_SCK       16
+#define SPI_1_PIN_MISO      17
+#define SPI_1_PIN_MOSI      18
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __PERIPH_CONF_H */

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -8,7 +8,7 @@ BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_RAM := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
-                          nucleo-f334 pca10000 pca10005 redbee-econotag \
+                          nrf6310 nucleo-f334 pca10000 pca10005 redbee-econotag \
                           stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 \
                           yunjia-nrf51822 z1
 

--- a/tests/pkg_cmsis-dsp/Makefile
+++ b/tests/pkg_cmsis-dsp/Makefile
@@ -29,6 +29,7 @@ BOARD_WHITELIST := \
   stm32f4discovery \
   udoo \
   yunjia-nrf51822 \
+  nrf6310 \
   #
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/posix_semaphore/Makefile
+++ b/tests/posix_semaphore/Makefile
@@ -2,7 +2,7 @@ APPLICATION = posix_semaphore
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_RAM := msb-430 msb-430h mbed_lpc1768 redbee-econotag chronos stm32f0discovery \
-                          pca10000 pca10005 yunjia-nrf51822 spark-core
+                          pca10000 pca10005 yunjia-nrf51822 nrf6310 spark-core
 
 USEMODULE += posix
 

--- a/tests/pthread_rwlock/Makefile
+++ b/tests/pthread_rwlock/Makefile
@@ -14,6 +14,6 @@ CFLAGS += -DNATIVE_AUTO_EXIT
 
 BOARD_INSUFFICIENT_RAM += chronos mbed_lpc1768 msb-430 msb-430h stm32f0discovery \
                           pca10000 pca10005 yunjia-nrf51822 spark-core nucleo-f334 \
-                          airfy-beacon nrf51dongle
+                          airfy-beacon nrf51dongle nrf6310
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.tests_common
 BOARD_INSUFFICIENT_RAM := chronos msb-430 msb-430h mbed_lpc1768 \
                           redbee-econotag stm32f0discovery pca10000 pca10005 \
                           yunjia-nrf51822 spark-core airfy-beacon nucleo-f334 \
-                          nrf51dongle
+                          nrf51dongle nrf6310
 
 DISABLE_MODULE += auto_init
 

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -5,7 +5,7 @@ BOARD_INSUFFICIENT_RAM := airfy-beacon chronos msb-430 msb-430h pca10000 \
                           pca10005 redbee-econotag spark-core stm32f0discovery \
                           telosb wsn430-v1_3b wsn430-v1_4 z1 nucleo-f334 \
                           yunjia-nrf51822 samr21-xpro arduino-mega2560 \
-                          airfy-beacon nrf51dongle
+                          airfy-beacon nrf51dongle nrf6310
 
 USEMODULE += embunit
 

--- a/tests/vtimer_msg_diff/Makefile
+++ b/tests/vtimer_msg_diff/Makefile
@@ -1,7 +1,7 @@
 APPLICATION = vtimer_msg_diff
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_RAM := mbed_lpc1768 stm32f0discovery pca10000 pca10005
+BOARD_INSUFFICIENT_RAM := mbed_lpc1768 stm32f0discovery nrf6310 pca10000 pca10005
 
 USEMODULE += vtimer
 


### PR DESCRIPTION
This Board is for nRF51 HDK. Tested with nrf6310 compatible BLE DEVKIT.N R2 boards by mommosoft using PCA1000(4|5|6|7) boards.