### PR TITLE
remove common globals for rpl with regard to #2346

### DIFF
--- a/examples/rpl_udp/main.c
+++ b/examples/rpl_udp/main.c
@@ -29,7 +29,7 @@
 
 #include "rpl_udp.h"
 
-const shell_command_t shell_commands[] = {
+static const shell_command_t shell_commands[] = {
     {"init", "Initialize network", rpl_udp_init},
     {"set", "Set ID", rpl_udp_set_id},
     {"dodag", "Shows the dodag", rpl_udp_dodag},

--- a/examples/rpl_udp/rpl.c
+++ b/examples/rpl_udp/rpl.c
@@ -35,10 +35,10 @@
 
 #define TRANSCEIVER TRANSCEIVER_DEFAULT
 
-char monitor_stack_buffer[MONITOR_STACK_SIZE];
+static char monitor_stack_buffer[MONITOR_STACK_SIZE];
 radio_address_t id;
 
-uint8_t is_root = 0;
+static uint8_t is_root = 0;
 
 void rpl_udp_init(int argc, char **argv)
 {

--- a/examples/rpl_udp/udp.c
+++ b/examples/rpl_udp/udp.c
@@ -35,7 +35,7 @@
 #define UDP_BUFFER_SIZE     (128)
 #define SERVER_PORT     (0xFF01)
 
-char udp_server_stack_buffer[KERNEL_CONF_STACKSIZE_MAIN];
+static char udp_server_stack_buffer[KERNEL_CONF_STACKSIZE_MAIN];
 char addr_str[IPV6_MAX_ADDR_STR_LEN];
 
 static void *init_udp_server(void *);

--- a/sys/net/routing/rpl/of0.c
+++ b/sys/net/routing/rpl/of0.c
@@ -27,7 +27,7 @@ static rpl_parent_t *which_parent(rpl_parent_t *, rpl_parent_t *);
 static rpl_dodag_t *which_dodag(rpl_dodag_t *, rpl_dodag_t *);
 static void reset(rpl_dodag_t *);
 
-rpl_of_t rpl_of0 = {
+static rpl_of_t rpl_of0 = {
     0x0,
     calc_rank,
     which_parent,

--- a/sys/net/routing/rpl/of_mrhof.c
+++ b/sys/net/routing/rpl/of_mrhof.c
@@ -34,10 +34,10 @@ static rpl_dodag_t *which_dodag(rpl_dodag_t *, rpl_dodag_t *);
 static void reset(rpl_dodag_t *);
 static uint16_t calc_path_cost(rpl_parent_t *parent);
 
-uint16_t cur_min_path_cost = MAX_PATH_COST;
-rpl_parent_t *cur_preferred_parent = NULL;
+static uint16_t cur_min_path_cost = MAX_PATH_COST;
+static rpl_parent_t *cur_preferred_parent = NULL;
 
-rpl_of_t rpl_of_mrhof = {
+static rpl_of_t rpl_of_mrhof = {
     0x1,
     calc_rank,
     which_parent,

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -62,7 +62,9 @@ static void _dao_handle_send(rpl_dodag_t *dodag);
 static void _rpl_update_routing_table(void);
 
 #if RPL_DEFAULT_MOP == RPL_NON_STORING_MODE
+#if RPL_MAX_ROUTING_ENTRIES != 0
 static uint8_t srh_buffer[BUFFER_SIZE];
+#endif
 static uint8_t srh_send_buffer[BUFFER_SIZE];
 static ipv6_addr_t *down_next_hop;
 static ipv6_srh_t *srh_header;

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -62,18 +62,18 @@ static void _dao_handle_send(rpl_dodag_t *dodag);
 static void _rpl_update_routing_table(void);
 
 #if RPL_DEFAULT_MOP == RPL_NON_STORING_MODE
-uint8_t srh_buffer[BUFFER_SIZE];
-uint8_t srh_send_buffer[BUFFER_SIZE];
-ipv6_addr_t *down_next_hop;
-ipv6_srh_t *srh_header;
-msg_t srh_m_send, srh_m_recv;
+static uint8_t srh_buffer[BUFFER_SIZE];
+static uint8_t srh_send_buffer[BUFFER_SIZE];
+static ipv6_addr_t *down_next_hop;
+static ipv6_srh_t *srh_header;
+static msg_t srh_m_send, srh_m_recv;
 #endif
 
 #if RPL_MAX_ROUTING_ENTRIES != 0
-rpl_routing_entry_t rpl_routing_table[RPL_MAX_ROUTING_ENTRIES];
+static rpl_routing_entry_t rpl_routing_table[RPL_MAX_ROUTING_ENTRIES];
 #endif
 uint8_t rpl_max_routing_entries;
-ipv6_addr_t my_address;
+static ipv6_addr_t my_address;
 
 /* IPv6 message buffer */
 static ipv6_hdr_t *ipv6_buf;

--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -31,9 +31,9 @@ char addr_str[IPV6_MAX_ADDR_STR_LEN];
 #endif
 #include "debug.h"
 
-rpl_instance_t instances[RPL_MAX_INSTANCES];
-rpl_dodag_t dodags[RPL_MAX_DODAGS];
-rpl_parent_t parents[RPL_MAX_PARENTS];
+static rpl_instance_t instances[RPL_MAX_INSTANCES];
+static rpl_dodag_t dodags[RPL_MAX_DODAGS];
+static rpl_parent_t parents[RPL_MAX_PARENTS];
 
 void rpl_trickle_send_dio(void *args) {
     (void) args;

--- a/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
+++ b/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
@@ -27,7 +27,7 @@
 
 #define ENABLE_DEBUG    (0)
 #if ENABLE_DEBUG
-char addr_str_mode[IPV6_MAX_ADDR_STR_LEN];
+static char addr_str_mode[IPV6_MAX_ADDR_STR_LEN];
 #endif
 #include "debug.h"
 

--- a/sys/net/routing/rpl/rpl_of_manager.c
+++ b/sys/net/routing/rpl/rpl_of_manager.c
@@ -29,7 +29,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-rpl_of_t *objective_functions[NUMBER_IMPLEMENTED_OFS];
+static rpl_of_t *objective_functions[NUMBER_IMPLEMENTED_OFS];
 
 void rpl_of_manager_init(ipv6_addr_t *my_address)
 {

--- a/sys/net/routing/rpl/rpl_storing/rpl_storing.c
+++ b/sys/net/routing/rpl/rpl_storing/rpl_storing.c
@@ -28,7 +28,7 @@
 
 #define ENABLE_DEBUG    (0)
 #if ENABLE_DEBUG
-char addr_str_mode[IPV6_MAX_ADDR_STR_LEN];
+static char addr_str_mode[IPV6_MAX_ADDR_STR_LEN];
 #endif
 #include "debug.h"
 


### PR DESCRIPTION
This PR removes common globals for the **rpl** module and the **rpl_udp** example.
More information can be found in #2346 