### PR TITLE
sys/net/routing/rpl: changed `addr_str[]` to static due to conflicting definitions

### DIFF
--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -45,7 +45,7 @@
 
 #define ENABLE_DEBUG (0)
 #if ENABLE_DEBUG
-char addr_str[IPV6_MAX_ADDR_STR_LEN];
+static char addr_str[IPV6_MAX_ADDR_STR_LEN];
 #endif
 #include "debug.h"
 


### PR DESCRIPTION
Rationale:
When enabling debug in [rpl.c](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/routing/rpl/rpl.c#L46), the used global [`addr_str[]`](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/routing/rpl/rpl.c#L48) conflicts with the first parameter of [ipv6_addr_to_str()`](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/include/sixlowpan/ip.h#L336) defined in [ip.h](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/include/sixlowpan/ip.h)

This name clash happens using:
`gcc version 4.9.3 20141119 (release)`
while using:
`gcc version 4.8.4 20140725 (release)`
reveals no conflicts.

~~Anyway, this global variable should be `static`.~~ <- No. I confused it with functions