### PR TITLE
examples/rpl_udp: changed printing the actual set channel

### DIFF
--- a/examples/rpl_udp/rpl.c
+++ b/examples/rpl_udp/rpl.c
@@ -90,7 +90,7 @@ void rpl_udp_init(int argc, char **argv)
             return;
         }
 
-        printf("Channel set to %d\n", chan);
+        printf("Channel set to %" PRIi32 "\n", chan);
 
         if (command != 'h') {
             DEBUGF("Initializing RPL for interface 0\n");


### PR DESCRIPTION
Rationale:
This resolves the `int vs. int32_t` compile time warning for printing the actual set channel.

(Sorry for that. I don't know why the warning slipped through my compiler before and why it has not been complained by Travis.)