### PR TITLE
cpu/nrf51822: use core_panic in startup code

### DIFF
--- a/cpu/nrf51822/include/cpu-conf.h
+++ b/cpu/nrf51822/include/cpu-conf.h
@@ -55,6 +55,15 @@ extern "C" {
  */
 #define CPUID_ID_LEN                    (8)
 
+/**
+ * @brief Definition of different panic modes
+ */
+typedef enum {
+    HARD_FAULT,             /**< hard fault */
+    NMI_HANDLER,            /**< non maskable interrupt */
+    DUMMY_HANDLER           /**< dummy interrupt handler */
+} panic_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/nrf51822/startup.c
+++ b/cpu/nrf51822/startup.c
@@ -19,8 +19,10 @@
  */
 
 #include <stdint.h>
+
 #include "board.h"
 #include "cpu.h"
+#include "crash.h"
 
 /**
  * memory markers as defined in the linker script
@@ -86,22 +88,17 @@ void reset_handler(void)
  */
 void dummy_handler(void)
 {
-    while (1) {asm ("nop");}
+    core_panic(DUMMY_HANDLER, "DUMMY ISR HANDLER");
 }
 
 void isr_nmi(void)
 {
-    while (1) {asm ("nop");}
+    core_panic(NMI_HANDLER, "NMI HANDLER");
 }
 
 void isr_hard_fault(void)
 {
-    while (1) {
-        for (int i = 0; i < 500000; i++) {
-            asm("nop");
-        }
-        LED_RED_TOGGLE;
-    }
+    core_panic(HARD_FAULT, "HARD FAULT");
 }
 
 /* Cortex-M specific interrupt vectors */


### PR DESCRIPTION
added missing `crash.c` files to cortex M0 and M4 common and integrated them into the NRF51822 cpu

~~base on #2415~~