### PR TITLE
kinetis: Refactor RTC into RTT, add RTC wrapper.

### DIFF
--- a/cpu/kinetis_common/rtc.c
+++ b/cpu/kinetis_common/rtc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 PHYTEC Messtechnik GmbH
+ * Copyright (C) 2015 Eistec AB
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -7,24 +7,24 @@
  */
 
 /**
- * @ingroup     cpu_kinetis_common_rtc
+ * @ingroup     cpu_kinetis_common_rtt
  *
  * @{
  *
  * @file
- * @brief       Low-level RTC driver implementation for Freescale Kinetis MCUs.
+ * @brief       RTC interface wrapper for use with RTT modules.
  *
- * @author      Johann Fischer <j.fischer@phytec.de>
+ * @author      Joakim Gebart <joakim.gebart@eistec.se>
  *
  * @}
  */
 
+#include <stdint.h>
 #include <time.h>
 #include "cpu.h"
 #include "periph/rtc.h"
+#include "periph/rtt.h"
 #include "periph_conf.h"
-#include "sched.h"
-#include "thread.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -32,100 +32,56 @@
 #if RTC_NUMOF
 
 
-#ifndef RTC_LOAD_CAP_BITS
-#define RTC_LOAD_CAP_BITS    0
-#endif
-
 typedef struct {
     rtc_alarm_cb_t cb;        /**< callback called from RTC interrupt */
-    void *arg;                /**< argument passed to the callback */
 } rtc_state_t;
 
 static rtc_state_t rtc_callback;
 
+/**
+ * @brief Wrapper function to call RTC callback from RTT interrupt
+ *
+ * @param[inout] arg    argument passed from the RTT interrupt
+ */
+static void rtc_cb(void* arg);
+
 void rtc_init(void)
 {
-    RTC_Type *rtc = RTC_DEV;
-
-    RTC_UNLOCK();
-    /* Reset RTC */
-    rtc->CR = RTC_CR_SWR_MASK;
-    rtc->CR = 0;
-
-    if (rtc->SR & RTC_SR_TIF_MASK) {
-        /* Clear TIF by writing TSR. */
-        rtc->TSR = 0;
-    }
-
-    /* Enable RTC oscillator and non-supervisor mode accesses. */
-    /* Enable load capacitance as configured by periph_conf.h */
-    rtc->CR = RTC_CR_OSCE_MASK | RTC_CR_SUP_MASK | RTC_LOAD_CAP_BITS;
-
-    /* Clear TAF by writing TAR. */
-    rtc->TAR = 0xffffff42;
-
-    /* Disable all RTC interrupts. */
-    rtc->IER = 0;
-
-    rtc_poweron();
+    rtt_init();
 }
 
 int rtc_set_time(struct tm *time)
 {
-    RTC_Type *rtc = RTC_DEV;
     time_t t = mktime(time);
 
-    /* Disable Time Counter */
-    rtc->SR &= ~RTC_SR_TCE_MASK;
-    rtc->TSR = t;
-    rtc->SR |= RTC_SR_TCE_MASK;
+    rtt_set_counter((uint32_t)t);
+
     return 0;
 }
 
 int rtc_get_time(struct tm *time)
 {
-    RTC_Type *rtc = RTC_DEV;
-    time_t t;
+    time_t t = (time_t)rtt_get_counter();
 
-    for (int i = 0; i < 3; i++) {
-        t = rtc->TSR;
+    gmtime_r(&t, time);
 
-        if (t == (time_t)rtc->TSR) {
-            gmtime_r(&t, time);
-            return 0;
-        }
-    }
-
-    return -1;
+    return 0;
 }
 
 int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
 {
-    RTC_Type *rtc = RTC_DEV;
     time_t t = mktime(time);
 
-    /* Disable Timer Alarm Interrupt */
-    rtc->IER &= ~RTC_IER_TAIE_MASK;
-
-    rtc->TAR = t;
-
     rtc_callback.cb = cb;
-    rtc_callback.arg = arg;
 
-    /* Enable Timer Alarm Interrupt */
-    rtc->IER |= RTC_IER_TAIE_MASK;
-
-    /* Enable RTC interrupts */
-    NVIC_SetPriority(RTC_IRQn, 10);
-    NVIC_EnableIRQ(RTC_IRQn);
+    rtt_set_alarm((uint32_t)t, rtc_cb, arg);
 
     return 0;
 }
 
 int rtc_get_alarm(struct tm *time)
 {
-    RTC_Type *rtc = RTC_DEV;
-    time_t t = rtc->TAR;
+    time_t t = (time_t)rtt_get_alarm();
 
     gmtime_r(&t, time);
 
@@ -134,43 +90,24 @@ int rtc_get_alarm(struct tm *time)
 
 void rtc_clear_alarm(void)
 {
-    RTC_Type *rtc = RTC_DEV;
-
-    NVIC_DisableIRQ(RTC_IRQn);
-    /* Disable Timer Alarm Interrupt */
-    rtc->IER &= ~RTC_IER_TAIE_MASK;
-    rtc->TAR = 0;
+    rtt_clear_alarm();
     rtc_callback.cb = NULL;
-    rtc_callback.arg = NULL;
 }
-
-/* RTC module has independent power suply. We can not really turn it on/off. */
 
 void rtc_poweron(void)
 {
-    RTC_Type *rtc = RTC_DEV;
-    /* Enable Time Counter */
-    rtc->SR |= RTC_SR_TCE_MASK;
+    rtt_poweron();
 }
 
 void rtc_poweroff(void)
 {
-    RTC_Type *rtc = RTC_DEV;
-    /* Disable Time Counter */
-    rtc->SR &= ~RTC_SR_TCE_MASK;
+    rtt_poweroff();
 }
 
-void isr_rtc(void)
+static void rtc_cb(void* arg)
 {
-    RTC_Type *rtc = RTC_DEV;
-
-    if (rtc->SR & RTC_SR_TAF_MASK) {
-        rtc_callback.cb(rtc_callback.arg);
-        rtc->TAR = 0;
-    }
-
-    if (sched_context_switch_request) {
-        thread_yield();
+    if (rtc_callback.cb != NULL) {
+        rtc_callback.cb(arg);
     }
 }
 

--- a/cpu/kinetis_common/rtt.c
+++ b/cpu/kinetis_common/rtt.c
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2014 PHYTEC Messtechnik GmbH
+ * Copyright (C) 2015 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_kinetis_common_rtt
+ *
+ * @{
+ *
+ * @file
+ * @brief       Low-level RTT interface implementation for Freescale Kinetis
+ *              MCUs. Freescale's RTC module is what RIOT calls a Real-Time
+ *              Timer (RTT), a simple counter which counts seconds; RIOT Real-
+ *              Time Clocks (RTC) counts seconds, minutes, hours etc. We provide
+ *              an RTT->RTC wrapper layer in a separate file to allow using the
+ *              RTT as a system real time clock.
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ * @author      Joakim Gebart <joakim.gebart@eistec.se>
+ *
+ * @}
+ */
+
+#include <time.h>
+#include "cpu.h"
+#include "periph/rtt.h"
+#include "periph_conf.h"
+#include "sched.h"
+#include "thread.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#if RTT_NUMOF
+
+
+#ifndef RTC_LOAD_CAP_BITS
+#define RTC_LOAD_CAP_BITS    0
+#endif
+
+typedef struct {
+    rtt_cb_t alarm_cb;              /**< callback called from RTC alarm */
+    void *alarm_arg;                /**< argument passed to the callback */
+    rtt_cb_t overflow_cb;           /**< callback called when RTC overflows */
+    void *overflow_arg;             /**< argument passed to the callback */
+} rtt_state_t;
+
+static rtt_state_t rtt_callback;
+
+void rtt_init(void)
+{
+    RTC_Type *rtt = RTT_DEV;
+
+    RTT_UNLOCK();
+    /* Reset RTC */
+    rtt->CR = RTC_CR_SWR_MASK;
+    rtt->CR = 0;
+
+    if (rtt->SR & RTC_SR_TIF_MASK) {
+        /* Clear TIF by writing TSR. */
+        rtt->TSR = 0;
+    }
+
+    /* Enable RTC oscillator and non-supervisor mode accesses. */
+    /* Enable load capacitance as configured by periph_conf.h */
+    rtt->CR = RTC_CR_OSCE_MASK | RTC_CR_SUP_MASK | RTC_LOAD_CAP_BITS;
+
+    /* Clear TAF by writing TAR. */
+    rtt->TAR = 0xffffff42;
+
+    /* Disable all RTC interrupts. */
+    rtt->IER = 0;
+
+    rtt_poweron();
+}
+
+void rtt_set_overflow_cb(rtt_cb_t cb, void *arg)
+{
+    RTC_Type *rtt = RTT_DEV;
+    rtt_callback.overflow_cb = cb;
+    rtt_callback.overflow_arg = arg;
+    rtt->IER |= RTC_IER_TOIE_MASK;
+}
+
+void rtt_clear_overflow_cb(void)
+{
+    RTC_Type *rtt = RTT_DEV;
+    rtt_callback.overflow_cb = NULL;
+    rtt_callback.overflow_arg = NULL;
+    rtt->IER &= ~(RTC_IER_TOIE_MASK);
+}
+
+uint32_t rtt_get_counter(void)
+{
+    RTC_Type *rtt = RTT_DEV;
+    uint32_t t;
+    for (int i = 0; i < 3; i++) {
+        /* Read twice to make sure we get a stable reading */
+        t = rtt->TSR;
+
+        if (t == rtt->TSR) {
+            return t;
+        }
+    }
+    /* Fallback if we are not getting stable readings */
+    return t;
+}
+
+void rtt_set_counter(uint32_t counter)
+{
+    RTC_Type *rtt = RTT_DEV;
+
+    /* Disable time counter before writing to the timestamp register */
+    rtt->SR &= ~RTC_SR_TCE_MASK;
+    rtt->TSR = counter;
+    /* Enable when done */
+    rtt->SR |= RTC_SR_TCE_MASK;
+}
+
+
+void rtt_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)
+{
+    RTC_Type *rtt = RTT_DEV;
+
+    /* Disable Timer Alarm Interrupt */
+    rtt->IER &= ~(RTC_IER_TAIE_MASK);
+
+    rtt->TAR = alarm;
+
+    rtt_callback.alarm_cb = cb;
+    rtt_callback.alarm_arg = arg;
+
+    /* Enable Timer Alarm Interrupt */
+    rtt->IER |= RTC_IER_TAIE_MASK;
+
+    /* Enable RTC interrupts */
+    NVIC_SetPriority(RTT_IRQ, RTT_IRQ_PRIO);
+    NVIC_EnableIRQ(RTT_IRQ);
+}
+
+uint32_t rtt_get_alarm(void)
+{
+    RTC_Type *rtt = RTT_DEV;
+    return rtt->TAR;
+}
+
+void rtt_clear_alarm(void)
+{
+    RTC_Type *rtt = RTT_DEV;
+
+    /* Disable Timer Alarm Interrupt */
+    rtt->IER &= ~RTC_IER_TAIE_MASK;
+    rtt->TAR = 0;
+    rtt_callback.alarm_cb = NULL;
+    rtt_callback.alarm_arg = NULL;
+}
+
+/* RTC module has independent power suply. We can not really turn it on/off. */
+
+void rtt_poweron(void)
+{
+    RTC_Type *rtt = RTT_DEV;
+    /* Enable Time Counter */
+    rtt->SR |= RTC_SR_TCE_MASK;
+}
+
+void rtt_poweroff(void)
+{
+    RTC_Type *rtt = RTT_DEV;
+    /* Disable Time Counter */
+    rtt->SR &= ~RTC_SR_TCE_MASK;
+}
+
+void RTT_ISR(void)
+{
+    RTC_Type *rtt = RTT_DEV;
+
+    if (rtt->SR & RTC_SR_TAF_MASK) {
+        if (rtt_callback.alarm_cb != NULL) {
+            /* Disable Timer Alarm Interrupt */
+            rtt->IER &= ~RTC_IER_TAIE_MASK;
+            rtt_callback.alarm_cb(rtt_callback.alarm_arg);
+        }
+    }
+
+    if (rtt->SR & RTC_SR_TOF_MASK) {
+        if (rtt_callback.overflow_cb != NULL) {
+            rtt_callback.overflow_cb(rtt_callback.overflow_arg);
+        }
+    }
+
+    if (sched_context_switch_request) {
+        thread_yield();
+    }
+}
+
+#endif /* RTC_NUMOF */


### PR DESCRIPTION
This is a refactor of the RTC module in kinetis_common which is closer to the actual CPU hardware. The Kinetis RTC module is what RIOT refers to as an RTT (a second counter). Added is also an RTC wrapper layer which could be used by any other platform without RTC implementation, but with a working RTT implementation (STM32F1 for example).

Question: How do I integrate a generic RTC implementation for platforms with RTT but without RTC into the current RIOT structure?
Should I add some check for `FEATURES=(periph_rtt and not periph_rtc)` in some Makefile in the drivers directory?