### PR TITLE
ip: make addr_str static

### DIFF
--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -36,7 +36,7 @@
 
 #define ENABLE_DEBUG    (0)
 #if ENABLE_DEBUG
-char addr_str[IPV6_MAX_ADDR_STR_LEN];
+static char addr_str[IPV6_MAX_ADDR_STR_LEN];
 #endif
 #include "debug.h"
 


### PR DESCRIPTION
When setting the `ENABLE_DEBUG` flag to *1* in ip.c,
the **rpl_udp** example won't compile, because the variable `addr_str`
is also defined in **rpl_udp.h** as extern.
Prefixing `addr_str` with `static` in ip.c solves this problem.