### PR TITLE
boards/samr21-xpro: enable compiler optimisation

### DIFF
--- a/boards/samr21-xpro/Makefile.include
+++ b/boards/samr21-xpro/Makefile.include
@@ -21,7 +21,7 @@ export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
 # define build specific options
 export CPU_USAGE = -mcpu=cortex-m0plus
 FPU_USAGE =
-export CFLAGS += -ggdb -g3 -std=gnu99 -O0 -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
+export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -mthumb -mno-thumb-interwork -nostartfiles
 export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
 export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles


### PR DESCRIPTION
The `-Os` flag got `-O0` somewhere on its way.