### PR TITLE
sys/net/sixlowpan: prevent deadlock when no IPHC context is recognized

### DIFF
--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -1286,6 +1286,7 @@ void lowpan_iphc_decoding(uint8_t *data, uint8_t length, net_if_eui64_t *s_addr,
 
         if (con == NULL) {
             printf("ERROR: context not found\n");
+            mutex_unlock(&lowpan_context_mutex);
             return;
         }
 
@@ -1386,6 +1387,7 @@ void lowpan_iphc_decoding(uint8_t *data, uint8_t length, net_if_eui64_t *s_addr,
 
             if (con == NULL) {
                 printf("ERROR: context not found\n");
+                mutex_unlock(&lowpan_context_mutex);
                 return;
             }
 
@@ -1462,6 +1464,7 @@ void lowpan_iphc_decoding(uint8_t *data, uint8_t length, net_if_eui64_t *s_addr,
 
             if (con == NULL) {
                 printf("ERROR: context not found\n");
+                mutex_unlock(&lowpan_context_mutex);
                 return;
             }
 


### PR DESCRIPTION
Whenever an `IPHC` context cannot be recognized in [`lowpan.c::lowpan_iphc_decoding()`](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/network_layer/sixlowpan/lowpan.c#L1166), e.g. [here](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/network_layer/sixlowpan/lowpan.c#L1287), the function returns without releasing the [locked](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/network_layer/sixlowpan/lowpan.c#L1280) `lowpan_context_mutex`.
If a further packet with `IPHC` arrives on the node, it produces a deadlock ([here](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/network_layer/sixlowpan/lowpan.c#L396)) since the already locked mutex cannot be acquired and the packet cannot be processed.

This PR just releases the mutex before returning from `lowpan.c::lowpan_iphc_decoding()` on unrecognized context.