### PR TITLE
net/ng_netdev: fixed msg type macro name

### DIFF
--- a/sys/include/net/ng_netdev.h
+++ b/sys/include/net/ng_netdev.h
@@ -36,7 +36,7 @@ extern "C" {
 /**
  * @brief   Type for @ref msg_t if device fired an event
  */
-#define NETDEV_MSG_EVENT_TYPE           (0x0100)
+#define NG_NETDEV_MSG_EVENT_TYPE        (0x0100)
 
 /**
  * @brief   Possible event types that are send from the device driver to the


### PR DESCRIPTION
forgot one `NG_`...