### PR TITLE
doc: enable helper macros for doxygen

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -26,8 +26,15 @@
 #include "sched.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
+
+/**
+ * @def ENABLE_DEBUG
+ * @brief   This macro can be defined as 0 or other on a file-based level.
+ *          If ENABLE_DEBUG is 0 @ref DEBUG() and @ref DEBUGF() will generate
+ *          no output if not they will generate output.
+ */
 
 /**
  * @name Print debug information if the calling thread stack is large enough

--- a/doc.txt
+++ b/doc.txt
@@ -1,0 +1,11 @@
+/**
+ * @def DEVELHELP
+ * @brief   This global macro activates some behavior that helps you while
+ *          developing but is otherwise optimized out.
+ */
+
+/**
+ * @def TEST_SUITES
+ * @brief   This global macro activates functionality that is needed for
+ *          automated testing but not needed otherwise.
+ */

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -1990,7 +1990,10 @@ PREDEFINED             = __attribute__(x)= \
                          RTT_NUMOF \
                          GPIO_NUMOF \
                          SPI_NUMOF \
-                         UART_NUMOF
+                         UART_NUMOF \
+                         DEVELHELP \
+                         ENABLE_DEBUG \
+                         TEST_SUITES
 
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this


### PR DESCRIPTION
With this PR most functions, variables and defines that normally wouldn't make it to the web-doc, since they are surrounded by `#ifdef`s of undefined macros, will be included. Namely, doxygen is now aware of
* `ENABLE_DEBUG`,
* `DEVELHELP`, and
* `TEST_SUITES`

**edit:** I also added documentation for these variables so doxygen can generate references for them.