### PR TITLE
Fix packet processing in mac

### DIFF
--- a/sys/net/network_layer/sixlowpan/mac.c
+++ b/sys/net/network_layer/sixlowpan/mac.c
@@ -136,6 +136,7 @@ static void *recv_ieee802154_frame(void *arg)
             }
             else {
                 DEBUG("Unknown IEEE 802.15.4 source address mode.\n");
+                p->processing--;
                 continue;
             }
 


### PR DESCRIPTION
This PR adds a missing ```p->processing--``` in recv_ieee802154_frame.
See #2432