### PR TITLE
debug: Make DEBUGF more platform-independent

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -13,7 +13,7 @@
  * @file        debug.h
  * @brief       Debug-header
  *
- * @details     If ENABLE_DEBUG is set, before this header is included, 
+ * @details     If ENABLE_DEBUG is set, before this header is included,
  *              ::DEBUG will print out to stdout, otherwise do nothing
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
@@ -70,12 +70,29 @@
  */
 #if ENABLE_DEBUG
 #include "tcb.h"
+
+/**
+ * @def DEBUG_FUNC
+ *
+ * @brief   Contains the function name if given compiler supports it.
+ *          Otherwise it is an empty string.
+ */
+# if defined(__cplusplus) && defined(__GNUC__)
+#  define DEBUG_FUNC __PRETTY_FUNCTION__
+# elif __STDC_VERSION__ >= 199901L
+#  define DEBUG_FUNC __func__
+# elif __GNUC__ >= 2
+#  define DEBUG_FUNC __FUNCTION__
+# else
+#  define DEBUF_FUNC ""
+# endif
+
 #define DEBUG(...) DEBUG_PRINT(__VA_ARGS__)
 #define DEBUGF(...) \
     do { \
         DEBUG_PRINT("DEBUG(%s): %s:%d in %s: ", \
                 sched_active_thread ? sched_active_thread->name : "NO THREAD", \
-                __FILE__, __LINE__, __func__); \
+                __FILE__, __LINE__, DEBUG_FUNC); \
         DEBUG_PRINT(__VA_ARGS__); \
     } while (0)
 #else

--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -84,7 +84,7 @@
 # elif __GNUC__ >= 2
 #  define DEBUG_FUNC __FUNCTION__
 # else
-#  define DEBUF_FUNC ""
+#  define DEBUG_FUNC ""
 # endif
 
 #define DEBUG(...) DEBUG_PRINT(__VA_ARGS__)


### PR DESCRIPTION
Introduces the macro `DEBUG_FUNC` and uses it in `DEBUGF` which is equivalent to `__func__` in stdc or similar, but ensures that it is actually implemented in the given compiler.