### PR TITLE
net/ng_netconf: improve comment describing NETCONF_STATE_*

### DIFF
--- a/sys/include/net/ng_netconf.h
+++ b/sys/include/net/ng_netconf.h
@@ -91,10 +91,18 @@ typedef enum {
 typedef enum {
     NETCONF_STATE_OFF = 0,          /**< powered off */
     NETCONF_STATE_SLEEP,            /**< sleep mode */
-    NETCONF_STATE_IDLE,             /**< idle mode */
-    NETCONF_STATE_RX,               /**< receive mode */
-    NETCONF_STATE_TX,               /**< transmit mode */
-    NETCONF_STATE_RESET,            /**< reset mode */
+    NETCONF_STATE_IDLE,             /**< idle mode,
+                                     *   the device listens to receive packets */
+    NETCONF_STATE_RX,               /**< receive mode,
+                                     *   the device currently receives a packet */
+    NETCONF_STATE_TX,               /**< transmit mode,
+                                     *   set: triggers transmission of a preloaded packet
+                                     *   (see *NETCONF_OPT_PRELOADING*). The resulting
+                                     *   state of the network device is *NETCONF_STATE_IDLE*
+                                     *   get: the network device is in the process of
+                                     *   transmitting a packet */
+    NETCONF_STATE_RESET,            /**< triggers a hardware reset. The resulting
+                                     *   state of the network device is *NETCONF_STATE_IDLE* */
     /* add other states if needed */
 } ng_netconf_state_t;
 


### PR DESCRIPTION
followup to #2441 

I think we have to be clear on `NETCONF_STATE_*`. If we interpret `NETCONF_STATE_TX` to **trigger** a transmission I think we need to state the expected state of the driver/device.
Background: from a driver perspective (at least for the at86rf2xx) the device is in "tx mode" already while loading the FIFO.

Also addressing @LudwigOrtmann's [comment](https://github.com/RIOT-OS/RIOT/pull/2441#issuecomment-74068776) and one typo.