### PR TITLE
sys/shell: fixed and unified doxygen headers

### DIFF
--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -10,6 +10,11 @@
  * @defgroup    sys_shell Shell
  * @ingroup     sys
  * @brief       Simple shell interpreter
+ *
+ * @{
+ *
+ * @file
+ * @brief       Shell interface definition
  */
 
 #ifndef __SHELL_H
@@ -93,3 +98,4 @@ void shell_run(shell_t *shell) NORETURN;
 #endif
 
 #endif /* __SHELL_H */
+/** @} */

--- a/sys/include/shell_commands.h
+++ b/sys/include/shell_commands.h
@@ -6,6 +6,17 @@
  * directory for more details.
  */
 
+/**
+ * @ingroup     sys_shell_commands
+ *
+ * @{
+ *
+ * @file
+ * @brief       Shell command definitions
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
 #ifndef __SHELL_COMMANDS_H
 #define __SHELL_COMMANDS_H
 
@@ -28,3 +39,4 @@ extern const shell_command_t _shell_command_list[];
 #endif
 
 #endif /* __SHELL_COMMANDS_H */
+/** @} */

--- a/sys/shell/commands/sc_cc110x_legacy_csma.c
+++ b/sys/shell/commands/sc_cc110x_legacy_csma.c
@@ -1,18 +1,21 @@
-/**
- * Shell commands for the cc110x driver without a transceiver
- *
+/*
  * Copyright (C) 2013  INRIA.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
- *
- * @ingroup shell_commands
+ */
+
+/**
+ * @ingroup     sys_shell_commands
  * @{
- * @file    sc_cc110x_legacy_csma.c
- * @brief   provides shell commands to configure the cc110x driver
- * @author  Oliver Hahm <oliver.hahm@inria.fr>
- * @author  Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ *
+ * @file
+ * @brief       Provides shell commands to configure the cc110x driver
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ *
  * @}
  */
 

--- a/sys/shell/commands/sc_disk.c
+++ b/sys/shell/commands/sc_disk.c
@@ -1,17 +1,20 @@
-/**
- * Shell commands for accessing storage
- *
+/*
  * Copyright (C) 2013  INRIA.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
- *
- * @ingroup shell_commands
+ */
+
+/**
+ * @ingroup     sys_shell_commands
  * @{
- * @file    sc_disk.c
- * @brief   provides shell commands to access storage (like mmc)
- * @author  Oliver Hahm <oliver.hahm@inria.fr>
+ *
+ * @file
+ * @brief       Provides shell commands to access storage (like MMC)
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ *
  * @}
  */
 

--- a/sys/shell/commands/sc_heap.c
+++ b/sys/shell/commands/sc_heap.c
@@ -1,6 +1,4 @@
 /*
- * sc_heap.c - the handler of the heap state on the command shell.
- *
  * Copyright (C) 2013 Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
@@ -9,13 +7,15 @@
  */
 
 /**
+ * @ingroup     sys_shell_commands
+ * @{
+ *
  * @file
- * @internal
- * @brief   Show the heap state for the LPC2387 on the command shell.
+ * @brief       Print the state of the heap
  *
- * @author  Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
+ * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  *
- * @note    $Id: sc_heap.c 3855 2013-09-05 12:40:11 kasmi $
+ * @}
  */
 
 extern void heap_stats(void);

--- a/sys/shell/commands/sc_id.c
+++ b/sys/shell/commands/sc_id.c
@@ -1,17 +1,20 @@
-/**
- * Shell commands for configuring the node id
- *
+/*
  * Copyright (C) 2014  INRIA.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
- *
- * @ingroup shell_commands
+ */
+
+/**
+ * @ingroup     sys_shell_commands
  * @{
- * @file    sc_id.c
- * @brief   provides shell commands to configure node id
- * @author  Oliver Hahm <oliver.hahm@inria.fr>
+ *
+ * @file
+ * @brief       Provides shell commands to configure node id
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ *
  * @}
  */
 

--- a/sys/shell/commands/sc_isl29020.c
+++ b/sys/shell/commands/sc_isl29020.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup shell_commands
+ * @ingroup     sys_shell_commands
  * @{
  *
  * @file

--- a/sys/shell/commands/sc_l2_ping.c
+++ b/sys/shell/commands/sc_l2_ping.c
@@ -1,17 +1,20 @@
 /*
- * Shell commands for l2_ping module
- *
  * Copyright (C) 2014, INRIA
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for
  * more details.
- *
- * @ingroup shell_commands
+ */
+
+/**
+ * @ingroup     sys_shell_commands
  * @{
+ *
  * @file
- * @brief   provides shell commands use link layer ping functionality
- * @author  Oliver Hahm <oliver.hahm@inria.fr>
+ * @brief       Provides shell commands to use link layer ping functionality
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ *
  * @}
  */
 

--- a/sys/shell/commands/sc_l3g4200d.c
+++ b/sys/shell/commands/sc_l3g4200d.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup shell_commands
+ * @ingroup     sys_shell_commands
  * @{
  *
  * @file

--- a/sys/shell/commands/sc_lps331ap.c
+++ b/sys/shell/commands/sc_lps331ap.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup shell_commands
+ * @ingroup     sys_shell_commands
  * @{
  *
  * @file

--- a/sys/shell/commands/sc_lsm303dlhc.c
+++ b/sys/shell/commands/sc_lsm303dlhc.c
@@ -7,11 +7,11 @@
  */
 
 /**
- * @ingroup shell_commands
+ * @ingroup     sys_shell_commands
  * @{
  *
  * @file
- * @brief       provides shell commands to poll lsm303dlhc sensor
+ * @brief       Provides shell commands to poll lsm303dlhc sensor
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  *

--- a/sys/shell/commands/sc_ltc4150.c
+++ b/sys/shell/commands/sc_ltc4150.c
@@ -1,17 +1,20 @@
-/**
- * Shell commands for coulomb counter
- *
+/*
  * Copyright (C) 2013  INRIA.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
- *
- * @ingroup shell_commands
+ */
+
+/**
+ * @ingroup     sys_shell_commands
  * @{
- * @file    sc_ltc4150.c
- * @brief   provides shell commands to access ltc4150
- * @author  Oliver Hahm <oliver.hahm@inria.fr>
+ *
+ * @file
+ * @brief       Provides shell commands to access ltc4150
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ *
  * @}
  */
 

--- a/sys/shell/commands/sc_mersenne.c
+++ b/sys/shell/commands/sc_mersenne.c
@@ -1,17 +1,20 @@
-/**
- * Shell commands for mersenne twister
- *
+/*
  * Copyright (C) 2013 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
- *
- * @ingroup shell_commands
+ */
+
+/**
+ * @ingroup     sys_shell_commands
  * @{
- * @file    sc_mersenne.c
- * @brief   initializes the PRNG
- * @author  Christian Mehlis <mehlis@inf.fu-berlin.de>
+ *
+ * @file
+ * @brief       Shell commands for mersenne twister
+ *
+ * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
+ *
  * @}
  */
 

--- a/sys/shell/commands/sc_net_if.c
+++ b/sys/shell/commands/sc_net_if.c
@@ -1,6 +1,4 @@
 /*
- * Shell commands for network interfaces
- *
  * Copyright (C) 2013 Martine Lenders <mlenders@inf.fu-berlin.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
@@ -9,11 +7,14 @@
  */
 
 /**
- * @ingroup shell_commands
+ * @ingroup     sys_shell_commands
  * @{
- * @file    sc_net_if.c
- * @brief   provides shell commands to configure network interfaces
- * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * @file
+ * @brief       Provides shell commands to configure network interfaces
+ *
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
  * @}
  */
 

--- a/sys/shell/commands/sc_ps.c
+++ b/sys/shell/commands/sc_ps.c
@@ -1,17 +1,20 @@
-/**
- * Shell commands for ps
- *
+/*
  * Copyright (C) 2013  INRIA.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
- *
- * @ingroup shell_commands
+ */
+
+/**
+ * @ingroup     sys_shell_commands
  * @{
- * @file    sc_ps.c
- * @brief   shows all thread information
- * @author  Oliver Hahm <oliver.hahm@inria.fr>
+ *
+ * @file
+ * @brief       Shell commands for the PS module
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ *
  * @}
  */
 

--- a/sys/shell/commands/sc_rpl.c
+++ b/sys/shell/commands/sc_rpl.c
@@ -7,11 +7,14 @@
  */
 
 /**
- * @ingroup shell_commands
+ * @ingroup     sys_shell_commands
  * @{
- * @file    sc_rpl.c
- * @brief   provides shell commands to manage and query RPL
- * @author  Oliver Hahm <oliver.hahm@inria.fr>
+ *
+ * @file
+ * @brief       Provides shell commands to manage and query RPL
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ *
  * @}
  */
 

--- a/sys/shell/commands/sc_rtc.c
+++ b/sys/shell/commands/sc_rtc.c
@@ -8,13 +8,15 @@
  */
 
 /**
- * @ingroup shell_commands
+ * @ingroup     sys_shell_commands
  * @{
+ *
  * @file
- * @brief   Shell command implementation for the peripheral RTC interface
+ * @brief       Shell command implementation for the peripheral RTC interface
  *
  * @author  Oliver Hahm <oliver.hahm@inria.fr>
- * @author  Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ * @author  Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>#
+ *
  * @}
  */
 

--- a/sys/shell/commands/sc_sht11.c
+++ b/sys/shell/commands/sc_sht11.c
@@ -1,17 +1,20 @@
-/**
- * Shell commands for temperature and humidity sensor
- *
+/*
  * Copyright (C) 2013  INRIA.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
- *
- * @ingroup shell_commands
+ */
+
+/**
+ * @ingroup     sys_shell_commands
  * @{
- * @file    sc_sht11.c
- * @brief   provides shell commands to poll sht11 sensor
- * @author  Oliver Hahm <oliver.hahm@inria.fr>
+ *
+ * @file
+ * @brief       Provides shell commands to poll sht11 sensor
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ *
  * @}
  */
 

--- a/sys/shell/commands/sc_sys.c
+++ b/sys/shell/commands/sc_sys.c
@@ -1,17 +1,20 @@
-/**
- * Shell commands for system calls
- *
+/*
  * Copyright (C) 2014  Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
- *
- * @ingroup shell_commands
+ */
+
+/**
+ * @ingroup     sys_shell_commands
  * @{
+ *
  * @file
- * @brief   shell commands for system calls
- * @author  Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ * @brief       Shell commands for system calls
+ *
+ * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ *
  * @}
  */
 

--- a/sys/shell/commands/sc_transceiver.c
+++ b/sys/shell/commands/sc_transceiver.c
@@ -1,18 +1,21 @@
-/**
- * Shell commands for transceiver module
- *
+/*
  * Copyright (C) 2013 Ludwig Ortmann.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
- *
- * @ingroup shell_commands
+ */
+
+/**
+ * @ingroup     sys_shell_commands
  * @{
- * @file    sc_transceiver.c
- * @brief   provides shell commands to configure the transceiver
- * @author  Oliver Hahm <oliver.hahm@inria.fr>
- * @author  Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ *
+ * @file
+ * @brief       Provides shell commands to configure the transceiver
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ *
  * @}
  */
 

--- a/sys/shell/commands/sc_x86_lspci.c
+++ b/sys/shell/commands/sc_x86_lspci.c
@@ -17,8 +17,7 @@
  */
 
 /**
- * @ingroup     shell_commands
- * @ingroup     x86-irq
+ * @ingroup     sys_shell_commands
  * @{
  *
  * @file

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -1,23 +1,22 @@
-/**
- * Provides prototypes for available shell commands
- *
+/*
  * Copyright (C) 2014  INRIA.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
- *
- *
- *
- * @ingroup shell_commands
+ */
+
+/**
+ * @ingroup     sys_shell_commands
  * @{
- * @file    shell_commands.c
- * @brief   sets up the system shell command struct
- * @author  Oliver Hahm <oliver.hahm@inria.fr>
- * @author  Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
- * @author  Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
  *
- * @note    $Id: shell_commands.c 3855 2013-09-05 12:54:57 kasmi $
+ * @file
+ * @brief       Provides prototypes and sets up available shell commands
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
+ * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ *
  * @}
  */
 

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -1,6 +1,4 @@
-/**
- * Shell interpreter
- *
+/*
  * Copyright (C) 2009, Freie Universitaet Berlin (FUB).
  * Copyright (C) 2013, INRIA.
  *
@@ -10,11 +8,9 @@
  */
 
 /**
- * @ingroup     shell
+ * @ingroup     sys_shell
  * @{
- */
-
-/**
+ *
  * @file
  * @brief       Implementation of a very simple command interpreter.
  *              For each command (i.e. "echo"), a handler can be specified.
@@ -24,6 +20,8 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
+ *
+ * @}
  */
 
 #include <string.h>
@@ -287,5 +285,3 @@ void shell_init(shell_t *shell, const shell_command_t *shell_commands,
     shell->readchar = readchar;
     shell->put_char = put_char;
 }
-
-/** @} */


### PR DESCRIPTION
- changed doxygen group name to sys_shell
- added some missing fields
- unified the doxygen header format