### PR TITLE
RFC: netreg: move to pointer-based API

### DIFF
--- a/sys/include/net/ng_netreg.h
+++ b/sys/include/net/ng_netreg.h
@@ -30,18 +30,22 @@ extern "C" {
 #endif
 
 /**
- * @brief Number of maximum entries to @ref net_ng_netreg
- * @def NG_NETREG_SIZE
+ * @brief   Demux context value to get all packets of a certain type.
+ *
+ * @see ng_netreg_entry_t::demux_ctx
  */
-#ifndef NG_NETREG_SIZE
-#define NG_NETREG_SIZE (NG_NETTYPE_NUMOF)
-#endif
+#define NG_NETREG_DEMUX_CTX_ALL (0xffff0000)
 
 /**
  * @brief   Entry to the @ref net_ng_netreg
  */
 typedef struct ng_netreg_entry {
-    struct ng_netreg_entry *next;   /**< next element in list */
+    /**
+     * @brief next element in list
+     *
+     * @internal
+     */
+    struct ng_netreg_entry *next;
 
     /**
      * @brief   The demultiplexing context for the registering thread.
@@ -50,7 +54,7 @@ typedef struct ng_netreg_entry {
      *          E. g. protocol numbers / next header numbers in IPv4/IPv6,
      *          ports in UDP/TCP, or similar.
      */
-    uint16_t demux_ctx;
+    uint32_t demux_ctx;
     kernel_pid_t pid;       /**< The PID of the registering thread */
 } ng_netreg_entry_t;
 
@@ -62,30 +66,26 @@ void ng_netreg_init(void);
 /**
  * @brief   Registers a thread to the registry.
  *
- * @details The semantics are: Thread @p pid is interested in packets of
- *          protocol @p type with context @p demux_ctx.
+ * @details The semantics are: Thread ng_netreg_entry_t::pid is interested in
+ *          packets of protocol @p type with context ng_netreg_entry_t::demux_ctx.
  *
- * @param[in] type      Type of the protocol. Must not be NG_NETTYPE_UNDEF or
+ * @param[in] type      Type of the protocol. Must not be <= NG_NETTYPE_UNDEF or
  *                      >= NG_NETTYPE_NUMOF.
- * @param[in] demux_ctx The demultiplexing context for the registering thread.
- *                      See ng_netreg_entry_t::demux_ctx.
- * @param[in] pid       The PID of the registering thread.
+ * @param[in] entry     An entry you want to add to the registry with
+ *                      ng_netreg_entry_t::pid and ng_netreg_entry_t::demux_ctx set.
  *
  * @return  0 on success
- * @return  -ENOMEM if no space is left in the registry.
- * @return  -EINVAL if @p type was NG_NETTYPE_UNDEF or >= NG_NETTYPE_NUMOF
+ * @return  -EINVAL if @p type was <= NG_NETTYPE_UNDEF or >= NG_NETTYPE_NUMOF
  */
-int ng_netreg_register(ng_nettype_t type, uint16_t demux_ctx, kernel_pid_t pid);
+int ng_netreg_register(ng_nettype_t type, ng_netreg_entry_t *entry);
 
 /**
  * @brief   Removes a thread from the registry.
  *
  * @param[in] type      Type of the protocol.
- * @param[in] demux_ctx The demultiplexing context for the registered thread.
- *                      See ng_netreg_entry_t::demux_ctx.
- * @param[in] pid       The PID of the registered thread.
+ * @param[in] entry     An entry you want to remove from the registry.
  */
-void ng_netreg_unregister(ng_nettype_t type, uint16_t demux_ctx, kernel_pid_t pid);
+void ng_netreg_unregister(ng_nettype_t type, ng_netreg_entry_t *entry);
 
 /**
  * @brief   Searches for entries with given parameters in the registry and
@@ -98,7 +98,7 @@ void ng_netreg_unregister(ng_nettype_t type, uint16_t demux_ctx, kernel_pid_t pi
  * @return  The first entry fitting the given parameters on success
  * @return  NULL if no entry can be found.
  */
-ng_netreg_entry_t *ng_netreg_lookup(ng_nettype_t type, uint16_t demux_ctx);
+ng_netreg_entry_t *ng_netreg_lookup(ng_nettype_t type, uint32_t demux_ctx);
 
 /**
  * @brief   Returns number of entries with the same ng_netreg_entry_t::type and
@@ -111,7 +111,7 @@ ng_netreg_entry_t *ng_netreg_lookup(ng_nettype_t type, uint16_t demux_ctx);
  * @return  Number of entries with the same ng_netreg_entry_t::type and
  *          ng_netreg_entry_t::demux_ctx as the given parameters.
  */
-int ng_netreg_num(ng_nettype_t type, uint16_t demux_ctx);
+int ng_netreg_num(ng_nettype_t type, uint32_t demux_ctx);
 
 /**
  * @brief   Returns the next entry after @p entry with the same

--- a/sys/net/crosslayer/ng_netreg/ng_netreg.c
+++ b/sys/net/crosslayer/ng_netreg/ng_netreg.c
@@ -25,90 +25,33 @@
 /* The registry as lookup table by ng_nettype_t */
 static ng_netreg_entry_t *netreg[NG_NETTYPE_NUMOF - 1]; /* leave out NG_NETTYPE_UNDEF */
 
-/* unstructured pool of entries, marked as unclaimed by
- * netreg_entries[i].pid == KERNEL_PID_UNDEF */
-static ng_netreg_entry_t netreg_entries[NG_NETREG_SIZE];
-
 void ng_netreg_init(void)
 {
     /* set all pointers in registry to NULL */
     memset(netreg, 0, NG_NETTYPE_NUMOF * sizeof(ng_netreg_entry_t *));
-
-    for (int i = 0; i < NG_NETREG_SIZE; i++) {
-        netreg_entries[i].pid = KERNEL_PID_UNDEF;   /* mark entry pool unclaimed */
-    }
 }
 
-static inline int _netreg_entry_equal(ng_netreg_entry_t *a, ng_netreg_entry_t *b)
+int ng_netreg_register(ng_nettype_t type, ng_netreg_entry_t *entry)
 {
-    /* to be pluggable with utlist, so result must be 0 when match */
-    return ((a->pid != b->pid) || (a->demux_ctx != b->demux_ctx));
-}
-
-int ng_netreg_register(ng_nettype_t type, uint16_t demux_ctx, kernel_pid_t pid)
-{
-    ng_netreg_entry_t *entry = NULL;
-
     if (_INVALID_TYPE(type)) {
         return -EINVAL;
     }
 
-    for (int i = 0; i < NG_NETREG_SIZE; i++) {  /* Search unclaimed entry */
-        if (netreg_entries[i].pid == KERNEL_PID_UNDEF) {
-            entry = &(netreg_entries[i]);
-            break;
-        }
-    }
-
-    if (entry == NULL) {
-        return -ENOMEM;
-    }
-
-    entry->demux_ctx = demux_ctx;
-    entry->pid = pid;
-
-    if (netreg[type - 1] == NULL) {
-        netreg[type - 1] = entry;
-    }
-    else {
-        ng_netreg_entry_t *dup;
-
-        /* search for duplicates to new entry */
-        LL_SEARCH(netreg[type - 1], dup, entry, _netreg_entry_equal);
-
-        if (dup == NULL) {  /* new entry is not a duplicate, add to registry */
-            LL_PREPEND(netreg[type - 1], entry);
-        }
-        else {  /* new entry is a duplicate, mark as unclaimed again */
-            entry->pid = KERNEL_PID_UNDEF;
-        }
-    }
+    LL_PREPEND(netreg[type - 1], entry);
 
     return 0;
 }
 
-void ng_netreg_unregister(ng_nettype_t type, uint16_t demux_ctx, kernel_pid_t pid)
+void ng_netreg_unregister(ng_nettype_t type, ng_netreg_entry_t *entry)
 {
-    ng_netreg_entry_t *entry = netreg[type - 1];
-
     if (_INVALID_TYPE(type)) {
         return;
     }
 
-    while (entry != NULL) {
-        /* Find entry with given parameters in registry */
-        if ((entry->pid == pid) && (entry->demux_ctx == demux_ctx)) {
-            LL_DELETE(netreg[type - 1], entry);
-            entry->pid = KERNEL_PID_UNDEF;
-
-            return;
-        }
-
-        entry = entry->next;
-    }
+    LL_DELETE(netreg[type - 1], entry);
 }
 
-ng_netreg_entry_t *ng_netreg_lookup(ng_nettype_t type, uint16_t demux_ctx)
+ng_netreg_entry_t *ng_netreg_lookup(ng_nettype_t type, uint32_t demux_ctx)
 {
     ng_netreg_entry_t *res;
 
@@ -121,7 +64,7 @@ ng_netreg_entry_t *ng_netreg_lookup(ng_nettype_t type, uint16_t demux_ctx)
     return res;
 }
 
-int ng_netreg_num(ng_nettype_t type, uint16_t demux_ctx)
+int ng_netreg_num(ng_nettype_t type, uint32_t demux_ctx)
 {
     int num = 0;
     ng_netreg_entry_t *entry;
@@ -145,7 +88,7 @@ int ng_netreg_num(ng_nettype_t type, uint16_t demux_ctx)
 
 ng_netreg_entry_t *ng_netreg_getnext(ng_netreg_entry_t *entry)
 {
-    uint16_t demux_ctx;
+    uint32_t demux_ctx;
 
     if (entry == NULL) {
         return NULL;

--- a/tests/unittests/tests-netreg/tests-netreg.c
+++ b/tests/unittests/tests-netreg/tests-netreg.c
@@ -27,84 +27,85 @@ static void set_up(void)
 
 static void test_netreg_register__inval_undef(void)
 {
-    TEST_ASSERT_EQUAL_INT(-EINVAL, ng_netreg_register(NG_NETTYPE_UNDEF, TEST_UINT16,
-                          TEST_UINT8));
+    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
+
+    TEST_ASSERT_EQUAL_INT(-EINVAL, ng_netreg_register(NG_NETTYPE_UNDEF, &entry));
 }
 
 static void test_netreg_register__inval_numof(void)
 {
-    TEST_ASSERT_EQUAL_INT(-EINVAL, ng_netreg_register(NG_NETTYPE_NUMOF, TEST_UINT16,
-                          TEST_UINT8));
-}
+    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
 
-static void test_netreg_register__memfull(void)
-{
-    for (int i = 0; i < NG_NETREG_SIZE; i++) {
-        TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, TEST_UINT16 + i,
-                              TEST_UINT8));
-    }
-
-    TEST_ASSERT_EQUAL_INT(-ENOMEM, ng_netreg_register(NG_NETTYPE_TEST, TEST_UINT16,
-                          TEST_UINT8 + 1));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, ng_netreg_register(NG_NETTYPE_NUMOF, &entry));
 }
 
 static void test_netreg_register__success(void)
 {
-    ng_netreg_entry_t *entry = ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16);
+    ng_netreg_entry_t *res = ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16);
+    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
 
-    TEST_ASSERT_NULL(entry);
+    TEST_ASSERT_NULL(res);
 
-    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, TEST_UINT16,
-                          TEST_UINT8));
-    TEST_ASSERT_NOT_NULL((entry = ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16)));
-    TEST_ASSERT_EQUAL_INT(TEST_UINT16, entry->demux_ctx);
-    TEST_ASSERT_EQUAL_INT(TEST_UINT8, entry->pid);
-    TEST_ASSERT_NULL((ng_netreg_getnext(entry)));
-}
-
-static void test_netreg_register__double_registration(void)
-{
-    ng_netreg_entry_t *entry = NULL;
-
-    for (int i = 0; i < NG_NETREG_SIZE; i++) {
-        TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, TEST_UINT16,
-                              TEST_UINT8));
-    }
-
-    TEST_ASSERT_NOT_NULL((entry = ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16)));
-    TEST_ASSERT_NULL((ng_netreg_getnext(entry)));
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry));
+    TEST_ASSERT_NOT_NULL((res = ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16)));
+    TEST_ASSERT_EQUAL_INT(TEST_UINT16, res->demux_ctx);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8, res->pid);
+    TEST_ASSERT_NULL((ng_netreg_getnext(res)));
 }
 
 void test_netreg_unregister__success(void)
 {
-    test_netreg_register__success();
-    ng_netreg_unregister(NG_NETTYPE_TEST, TEST_UINT16, TEST_UINT8);
+    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
+
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry));
+    TEST_ASSERT_NOT_NULL(ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16));
+    ng_netreg_unregister(NG_NETTYPE_TEST, &entry);
     TEST_ASSERT_NULL(ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16));
 }
 
 void test_netreg_unregister__success2(void)
 {
-    ng_netreg_entry_t *entry = NULL;
+    ng_netreg_entry_t *res = NULL;
+    ng_netreg_entry_t entry1 = { NULL, TEST_UINT16, TEST_UINT8 };
+    ng_netreg_entry_t entry2 = { NULL, TEST_UINT16, TEST_UINT8 + 1 };
 
-    test_netreg_register__success();
-    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, TEST_UINT16,
-                          TEST_UINT8 + 1));
-    ng_netreg_unregister(NG_NETTYPE_TEST, TEST_UINT16, TEST_UINT8);
-    TEST_ASSERT_NOT_NULL((entry = ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16)));
-    TEST_ASSERT_EQUAL_INT(TEST_UINT16, entry->demux_ctx);
-    TEST_ASSERT_EQUAL_INT(TEST_UINT8 + 1, entry->pid);
-    ng_netreg_unregister(NG_NETTYPE_TEST, TEST_UINT16 + 1, TEST_UINT8 + 1);
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry1));
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry2));
+    ng_netreg_unregister(NG_NETTYPE_TEST, &entry1);
+    TEST_ASSERT_NOT_NULL((res = ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16)));
+    TEST_ASSERT_EQUAL_INT(TEST_UINT16, res->demux_ctx);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 + 1, res->pid);
+    ng_netreg_unregister(NG_NETTYPE_TEST, &entry2);
+    TEST_ASSERT_NULL(ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16));
+}
+
+void test_netreg_unregister__success3(void)
+{
+    ng_netreg_entry_t *res = NULL;
+    ng_netreg_entry_t entry1 = { NULL, TEST_UINT16, TEST_UINT8 };
+    ng_netreg_entry_t entry2 = { NULL, TEST_UINT16, TEST_UINT8 + 1 };
+
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry1));
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry2));
+    ng_netreg_unregister(NG_NETTYPE_TEST, &entry2);
+    TEST_ASSERT_NOT_NULL((res = ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16)));
+    TEST_ASSERT_EQUAL_INT(TEST_UINT16, res->demux_ctx);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8, res->pid);
+    ng_netreg_unregister(NG_NETTYPE_TEST, &entry1);
+    TEST_ASSERT_NULL(ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16));
 }
 
 void test_netreg_lookup__wrong_type_undef(void)
 {
-    test_netreg_register__success();
+    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry));
     TEST_ASSERT_NULL(ng_netreg_lookup(NG_NETTYPE_UNDEF, TEST_UINT16));
 }
 
 void test_netreg_lookup__wrong_type_numof(void)
 {
-    test_netreg_register__success();
+    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry));
     TEST_ASSERT_NULL(ng_netreg_lookup(NG_NETTYPE_NUMOF, TEST_UINT16));
 }
 
@@ -112,32 +113,37 @@ void test_netreg_num__empty(void)
 {
     TEST_ASSERT_EQUAL_INT(0, ng_netreg_num(NG_NETTYPE_TEST, TEST_UINT16));
     TEST_ASSERT_EQUAL_INT(0, ng_netreg_num(NG_NETTYPE_TEST, TEST_UINT16 + 1));
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_num(NG_NETTYPE_TEST, NG_NETREG_DEMUX_CTX_ALL));
 }
 
 void test_netreg_num__wrong_type_undef(void)
 {
-    test_netreg_register__success();
+    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry));
     TEST_ASSERT_EQUAL_INT(0, ng_netreg_num(NG_NETTYPE_UNDEF, TEST_UINT16));
 }
 
 void test_netreg_num__wrong_type_numof(void)
 {
-    test_netreg_register__success();
+    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry));
     TEST_ASSERT_EQUAL_INT(0, ng_netreg_num(NG_NETTYPE_NUMOF, TEST_UINT16));
 }
 
 void test_netreg_num__2_entries(void)
 {
-    test_netreg_register__success();
+    ng_netreg_entry_t entry1 = { NULL, TEST_UINT16, TEST_UINT8 };
+    ng_netreg_entry_t entry2 = { NULL, TEST_UINT16, TEST_UINT8 + 1 };
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry1));
     TEST_ASSERT_EQUAL_INT(1, ng_netreg_num(NG_NETTYPE_TEST, TEST_UINT16));
-    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, TEST_UINT16,
-                          TEST_UINT8 + 1));
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry2));
     TEST_ASSERT_EQUAL_INT(2, ng_netreg_num(NG_NETTYPE_TEST, TEST_UINT16));
 }
 
 void test_netreg_getnext__NULL(void)
 {
-    test_netreg_register__success();
+    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry));
     TEST_ASSERT_NULL(ng_netreg_getnext(NULL));
 }
 
@@ -155,11 +161,10 @@ Test *tests_netreg_tests(void)
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_netreg_register__inval_undef),
         new_TestFixture(test_netreg_register__inval_numof),
-        new_TestFixture(test_netreg_register__memfull),
         new_TestFixture(test_netreg_register__success),
-        new_TestFixture(test_netreg_register__double_registration),
         new_TestFixture(test_netreg_unregister__success),
         new_TestFixture(test_netreg_unregister__success2),
+        new_TestFixture(test_netreg_unregister__success3),
         new_TestFixture(test_netreg_lookup__wrong_type_undef),
         new_TestFixture(test_netreg_lookup__wrong_type_numof),
         new_TestFixture(test_netreg_num__empty),


### PR DESCRIPTION
Moving to a pointer-based API simplifies a lot, since there is no need
for an internal pool of entries anymore. Therefore, a lot of
organizational overhead and some restrictions (e.g. an upper limit on
entries) are dropped.

The entries can be stored in the stack of the respective thread.

Thank's to @haukepetersen for the idea.