### PR TITLE
net: update ng_* version documentation + some fixes

### DIFF
--- a/sys/include/net/ng_netapi.h
+++ b/sys/include/net/ng_netapi.h
@@ -7,14 +7,14 @@
  */
 
 /**
- * @defgroup    net_netapi Generic network module interface
+ * @defgroup    net_ng_netapi   Generic network module interface
  * @ingroup     net
  * @brief       Generic interface for IPC communication between network modules
  *
  * @details     The idea of this interface is that it provides every network
  *              module with a basic set of commands to communicate with its
  *              neighboring modules. In this model every module runs in its own
- *              thread and communication is done using netapi.
+ *              thread and communication is done using the @ref net_ng_netapi.
  *
  * @{
  *
@@ -73,7 +73,7 @@ typedef struct {
 } ng_netapi_opt_t;
 
 /**
- * @brief   Shortcut function for sending *NETAPI_CMD_SND* messages
+ * @brief   Shortcut function for sending @ref NG_NETAPI_MSG_TYPE_SND messages
  *
  * @param[in] pid       PID of the targeted network module
  * @param[in] pkt       pointer into the packet buffer holding the data to send
@@ -84,8 +84,8 @@ typedef struct {
 int ng_netapi_send(kernel_pid_t pid, ng_pktsnip_t *pkt);
 
 /**
- * @brief   Shortcut function for send *NETAPI_CMD_GETOPT* messages and parsing
- *          the returned *NETAPI_CMD_ACK* message
+ * @brief   Shortcut function for sending @ref NG_NETAPI_MSG_TYPE_GET messages and
+ *          parsing the returned @ref NG_NETAPI_MSG_TYPE_ACK message
  *
  * @param[in] pid       PID of the targeted network module
  * @param[in] opt       option to get
@@ -93,23 +93,22 @@ int ng_netapi_send(kernel_pid_t pid, ng_pktsnip_t *pkt);
  * @param[in] data      pointer to buffer for reading the option's value
  * @param[in] data_len  size of the given buffer
  *
- * @return              value returned by the ACK message
+ * @return              value returned by the @ref NG_NETAPI_MSG_TYPE_ACK message
  */
 int ng_netapi_get(kernel_pid_t pid, ng_netconf_opt_t opt, uint16_t context,
                   void *data, size_t data_len);
 
 /**
- * @brief Set an option of a protocol layer identified by *pid*.
- *
- * @note    Wraps IPC call of NETAPI_CMD_SET.
+ * @brief   Shortcut function for sending @ref NG_NETAPI_MSG_TYPE_SET messages and
+ *          parsing the returned @ref NG_NETAPI_MSG_TYPE_ACK message
  *
  * @param[in] pid       PID of the targeted network module
  * @param[in] opt       option to set
  * @param[in] context   (optional) context to the given option
  * @param[in] data      data to set the given option to
- * @param[in] data_len  size of *data*
+ * @param[in] data_len  size of @p data
  *
- * @return              value returned by the ACK message
+ * @return              value returned by the @ref NG_NETAPI_MSG_TYPE_ACK message
  */
 int ng_netapi_set(kernel_pid_t pid, ng_netconf_opt_t opt, uint16_t context,
                   void *data, size_t data_len);

--- a/sys/include/net/ng_netconf.h
+++ b/sys/include/net/ng_netconf.h
@@ -10,7 +10,7 @@
  * @defgroup    net_ng_netconf  Configuration options for network APIs
  * @ingroup     net
  * @brief       List of available configuration options for the
- *              @ref net_netdev and the @ref net_ng_netapi
+ *              @ref net_ng_netdev and the @ref net_ng_netapi
  * @{
  *
  * @file

--- a/sys/include/net/ng_netconf.h
+++ b/sys/include/net/ng_netconf.h
@@ -7,13 +7,14 @@
  */
 
 /**
- * @defgroup    net_netconf Configuration options for network APIs
+ * @defgroup    net_ng_netconf  Configuration options for network APIs
  * @ingroup     net
- * @brief       List of available configuration options for network APIs
+ * @brief       List of available configuration options for the
+ *              @ref net_netdev and the @ref net_ng_netapi
  * @{
  *
  * @file
- * @brief       Definition of global configuration options for netdev and netapi
+ * @brief       Definition of global configuration options
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
@@ -31,36 +32,47 @@ extern "C" {
  */
 typedef enum {
     NETCONF_OPT_CHANNEL,            /**< get/set channel as uint16_t in host
-                                         byte order */
+                                     *   byte order */
     NETCONF_OPT_IS_CHANNEL_CLR,     /**< check if channel is clear */
-    NETCONF_OPT_ADDRESS,            /**< get/set link layer address in host byte
-                                         order */
-    NETCONF_OPT_ADDRESS_LONG,       /**< long link layer address in host byte
-                                         order (e.g. IEEE802.15.4 EUI-64) */
+    NETCONF_OPT_ADDRESS,            /**< get/set address in host byte order */
+
+    /**
+     * @brief    get/set long address in host byte order
+     *
+     * Examples for this include the EUI-64 in IEEE 802.15.4
+     */
+    NETCONF_OPT_ADDRESS_LONG,
     NETCONF_OPT_ADDR_LEN,           /**< get the default address length a
-                                         network device expects as uint16_t in
-                                         host byte order */
-    NETCONF_OPT_NID,                /**< get/set the network ID (e.g. PAN ID in
-                                         IEEE 802.15.4) as uint16_t in host
-                                         byte order */
+                                     *   network device expects as uint16_t in
+                                     *   host byte order */
+
+    /**
+     * @brief    get/set the network ID as uint16_t in host byte order
+     *
+     * Examples for this include the PAN ID in IEEE 802.15.4
+     */
+    NETCONF_OPT_NID,
     NETCONF_OPT_TX_POWER,           /**< get/set the output power for radio
-                                         devices in dBm as int16_t in host byte
-                                         order */
+                                     *   devices in dBm as int16_t in host byte
+                                     *   order */
     NETCONF_OPT_MAX_PACKET_SIZE,    /**< get/set the maximum packet size a
-                                         network module can handle as uint16_t
-                                         in host byte order */
-    NETCONF_OPT_PRELOADING,         /**< en/disable preloading or read the
-                                         current state. Preload using
-                                         *send_data*, send setting state to
-                                         *NETNETCONF_STATE_TX* */
+                                     *   network module can handle as uint16_t
+                                     *   in host byte order */
+    /**
+     * @brief en/disable preloading or read the current state.
+     *
+     * Preload using ng_netdev_driver_t::send_data() or ng_netapi_send()
+     * respectively, send setting state to @ref NETCONF_STATE_TX
+     */
+    NETCONF_OPT_PRELOADING,
     NETCONF_OPT_PROMISCUOUSMODE,    /**< en/disable promiscuous mode or read
-                                         the current state */
+                                     *   the current state */
     NETCONF_OPT_AUTOACK,            /**< en/disable link layer auto ACKs or read
-                                         the current state */
+                                     *   the current state */
     NETCONF_OPT_PROTO,              /**< get/set the protocol for the layer
-                                         as type *ng_nettype_t*. */
+                                     *   as type ng_nettype_t. */
     NETCONF_OPT_STATE,              /**< get/set the state of network devices as
-                                         type *net_netconf_state_t* */
+                                     *   type ng_netconf_state_t */
     /* add more options if needed */
 } ng_netconf_opt_t;
 
@@ -73,7 +85,7 @@ typedef enum {
 } ng_netconf_enable_t;
 
 /**
- * @brief   Option parameter to be used with *NETCONF_OPT_STATE* to set or get
+ * @brief   Option parameter to be used with @ref NETCONF_OPT_STATE to set or get
  *          the state of a network device or protocol implementation
  */
 typedef enum {

--- a/sys/include/net/ng_netdev.h
+++ b/sys/include/net/ng_netdev.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @defgroup    net_netdev Network device driver interface
+ * @defgroup    net_ng_netdev   Network device driver interface
  * @ingroup     net
  * @{
  *
@@ -59,7 +59,10 @@ typedef enum {
 typedef void (*ng_netdev_event_cb_t)(ng_netdev_event_t type, void *arg);
 
 /**
- * @brief   Forward declaration of *ng_netdev_t*
+ * @brief   Forward declaration of ng_netdev_t due to cyclic dependency to
+ *          @ref ng_netdev_driver_t.
+ *
+ * @see ng_netdev
  */
 typedef struct ng_netdev ng_netdev_t;
 
@@ -77,7 +80,7 @@ typedef struct {
      * @param[in] pkt       pointer to the data in the packet buffer
      *
      * @return              number of bytes that were actually send out
-     * @return              -ENODEV if *dev* is invalid
+     * @return              -ENODEV if @p dev is invalid
      * @return              -ENOMSG if pkt is invalid
      */
     int (*send_data)(ng_netdev_t *dev, ng_pktsnip_t *pkt);
@@ -89,7 +92,7 @@ typedef struct {
      * @param[in] cb        function that is called on events
      *
      * @return              0 on success
-     * @return              -ENODEV if *dev* is invalid
+     * @return              -ENODEV if @p dev is invalid
      * @return              -ENOBUFS if maximum number of callbacks is exceeded
      */
     int (*add_event_callback)(ng_netdev_t *dev, ng_netdev_event_cb_t cb);
@@ -101,7 +104,7 @@ typedef struct {
      * @param[in] cb        callback function
      *
      * @return              0 on success
-     * @return              -ENODEV if *dev* is invalid
+     * @return              -ENODEV if @p dev is invalid
      * @return              -ENOPKG if callback was not registered
      */
     int (*rem_event_callback)(ng_netdev_t *dev, ng_netdev_event_cb_t cb);
@@ -112,14 +115,14 @@ typedef struct {
      * @param[in] dev           network device descriptor
      * @param[in] opt           option type
      * @param[out] value        pointer to store the option's value in
-     * @param[in,out] value_len the length of *value*. Must be initialized to
-     *                          the available space in *value* on call.
+     * @param[in,out] value_len the length of @p value. Must be initialized to
+     *                          the available space in @p value on call.
      *
      * @return              0 on success
-     * @return              -ENODEV if *dev* is invalid
-     * @return              -ENOTSUP if *opt* is not supported
-     * @return              -EOVERFLOW if available space in *value* given in
-     *                      *value_len* is too small to store the option value
+     * @return              -ENODEV if @p dev is invalid
+     * @return              -ENOTSUP if @p opt is not supported
+     * @return              -EOVERFLOW if available space in @p value given in
+     *                      @p value_len is too small to store the option value
      */
     int (*get)(ng_netdev_t *dev, ng_netconf_opt_t opt,
                void *value, size_t *value_len);
@@ -130,12 +133,12 @@ typedef struct {
      * @param[in] dev       network device descriptor
      * @param[in] opt       option type
      * @param[in] value     value to set
-     * @param[in] value_len the length of *value*
+     * @param[in] value_len the length of @p value
      *
      * @return              0 on success
-     * @return              -ENODEV if *dev* is invalid
-     * @return              -ENOTSUP if *opt* is not supported
-     * @return              -EINVAL if *value* is invalid
+     * @return              -ENODEV if @p dev is invalid
+     * @return              -ENOTSUP if @p opt is not supported
+     * @return              -EINVAL if @p value is invalid
      */
     int (*set)(ng_netdev_t *dev, ng_netconf_opt_t opt,
                void *value, size_t value_len);
@@ -157,6 +160,8 @@ typedef struct {
  *          specific fields
  *
  * The netdev structure is the parent for all network device driver descriptors.
+ *
+ * @see ng_netdev_t
  */
 struct ng_netdev {
     ng_netdev_driver_t *driver;     /**< pointer to the devices interface */

--- a/sys/include/net/ng_netif.h
+++ b/sys/include/net/ng_netif.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    ng_netif    Network interfaces
+ * @defgroup    net_ng_netif    Network interfaces
  * @ingroup     net
  * @brief       Abstraction layer for network interfaces
  *

--- a/sys/include/net/ng_netreg.h
+++ b/sys/include/net/ng_netreg.h
@@ -13,7 +13,7 @@
  *
  * @file
  * @brief   Definitions to register network protocol PIDs to use with
- *          @ref net_netapi.
+ *          @ref net_ng_netapi.
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */

--- a/sys/include/net/ng_netreg.h
+++ b/sys/include/net/ng_netreg.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    ng_netreg  Network protocol registry
+ * @defgroup    net_ng_netreg  Network protocol registry
  * @ingroup     net
  * @{
  *
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Number of maximum entries to @ref ng_netreg
+ * @brief Number of maximum entries to @ref net_ng_netreg
  * @def NG_NETREG_SIZE
  */
 #ifndef NG_NETREG_SIZE
@@ -38,7 +38,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Entry to the @ref ng_netreg
+ * @brief   Entry to the @ref net_ng_netreg
  */
 typedef struct ng_netreg_entry {
     struct ng_netreg_entry *next;   /**< next element in list */

--- a/sys/include/net/ng_nettype.h
+++ b/sys/include/net/ng_nettype.h
@@ -7,7 +7,11 @@
  */
 
 /**
+ * @defgroup    net_ng_nettype  Protocol type definitions.
  * @ingroup     net
+ * @brief       Protocol type definitions to be used with the @ref net_ng_netapi,
+ *              the @ref net_ng_netdev, the @ref net_ng_netreg, and
+ *              the @ref ng_pkt
  * @{
  *
  * @file

--- a/sys/include/net/ng_nettype.h
+++ b/sys/include/net/ng_nettype.h
@@ -11,7 +11,7 @@
  * @ingroup     net
  * @brief       Protocol type definitions to be used with the @ref net_ng_netapi,
  *              the @ref net_ng_netdev, the @ref net_ng_netreg, and
- *              the @ref ng_pkt
+ *              the @ref net_ng_pkt
  * @{
  *
  * @file

--- a/sys/include/net/ng_pkt.h
+++ b/sys/include/net/ng_pkt.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    ng_pkt Packet
+ * @defgroup    net_ng_pkt Packet
  * @brief       Network packet abstraction types
  * @ingroup     net
  * @{
@@ -34,8 +34,8 @@ extern "C" {
  *          snip == (packet header || packet payload)) of a network packet
  * @details The idea behind the packet snips is that they either can represent
  *          protocol-specific headers or payload. A packet can be comprised of
- *          *n* `pktsnip_t` elements, where the first element represents the
- *          header of the lowest available network layer and the *(n - 1)*st
+ *          @f$ n @f$ pktsnip_t elements, where the first element represents the
+ *          header of the lowest available network layer and the @f$ (n - 1) @f$-st
  *          element represents the payload of the highest available layer.
  *          Use @ref sys_ut to operate on this.
  *
@@ -44,31 +44,31 @@ extern "C" {
  *                                                                  buffer
  *              +---------------------------+                      +------+
  *              | size = 14                 | data +-------------->|      |
- *              | type = PKT_PROTO_ETHERNET |------+               +------+
+ *              | type = NETTYPE_ETHERNET   |------+               +------+
  *              +---------------------------+         +----------->|      |
  *                    | next                          |            |      |
  *                    v                               |            |      |
  *              +---------------------------+         |            +------+
  *              | size = 40                 | data    |  +-------->|      |
- *              | type = PKT_PROTO_IPV6     |---------+  |         +------+
+ *              | type = NETTYPE_IPV6       |---------+  |         +------+
  *              +---------------------------+            |  +----->|      |
  *                    | next                             |  |      +------+
  *                    v                                  |  |  +-->|      |
  *              +---------------------------+            |  |  |   |      |
  *              | size = 8                  | data       |  |  |   .      .
- *              | type = PKT_PROTO_UDP      |------------+  |  |   .      .
+ *              | type = NETTYPE_UDP        |------------+  |  |   .      .
  *              +---------------------------+               |  |
  *                    | next                                |  |
  *                    v                                     |  |
  *              +---------------------------+               |  |
  *              | size = 5                  | data          |  |
- *              | type = PKT_PROTO_COAP     |---------------+  |
+ *              | type = NETTYPE_COAP       |---------------+  |
  *              +---------------------------+                  |
  *                    | next                                   |
  *                    v                                        |
  *              +---------------------------+                  |
  *              | size = 54                 | data             |
- *              | type = PKT_PROTO_UNKNOWN  |------------------+
+ *              | type = NETTYPE_UNKNOWN    |------------------+
  *              +---------------------------+
  *
  *
@@ -77,9 +77,8 @@ extern "C" {
  * @note    This type has no initializer on purpose. Please use @ref pktbuf
  *          as factory.
  */
-typedef struct __attribute__((packed)) ng_pktsnip {   /* packed to be aligned
-                                                       * correctly in the static
-                                                       * packet buffer */
+/* packed to be aligned correctly in the static packet buffer */
+typedef struct __attribute__((packed)) ng_pktsnip {
     struct ng_pktsnip *next;        /**< next snip in the packet */
     void *data;                     /**< pointer to the data of the snip */
     size_t size;                    /**< the length of the snip in byte */

--- a/sys/include/net/ng_pktqueue.h
+++ b/sys/include/net/ng_pktqueue.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @defgroup    ng_pktqueue Packet Queue
+ * @defgroup    net_ng_pktqueue Packet Queue
  * @brief       Packet wrapper for the Priority Queue
  * @ingroup     net
  * @{
  *
  * @file
- * @brief       `ng_pktsnip_t`-centric wrapper for @ref priority_queue_t
+ * @brief       ng_pktsnip_t-centric wrapper for @ref priority_queue_t
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
@@ -110,7 +110,7 @@ static inline ng_pktqueue_node_t *ng_pktqueue_remove_head(ng_pktqueue_t *queue)
 }
 
 /**
- * @brief       add *node* into *queue* based on its priority
+ * @brief       add @p node into @p queue based on its priority
  *
  * @details     The new node will be appended after objects with the same
  *              priority.
@@ -124,7 +124,7 @@ static inline void ng_pktqueue_add(ng_pktqueue_t *queue, ng_pktqueue_node_t *nod
 }
 
 /**
- * @brief       remove *node* from *queue*
+ * @brief       remove @p node from @p queue
  *
  * @param[in]   queue   the queue
  * @param[in]   node    the node to remove

--- a/sys/net/crosslayer/ng_netapi/ng_netapi.c
+++ b/sys/net/crosslayer/ng_netapi/ng_netapi.c
@@ -8,7 +8,7 @@
 
 /**
  * @{
- * @ingroup     net_netapi
+ * @ingroup     net_ng_netapi
  * @file
  * @brief       This file contains a number of helper functions that provide
  *              some shortcuts for some always repeating code snippets when


### PR DESCRIPTION
Applies naming scheme according to #2422 and fixes some syntax issues.