### PR TITLE
drivers/mpu9150: Add missing I2C release for error case

### DIFF
--- a/drivers/mpu9150/mpu9150.c
+++ b/drivers/mpu9150/mpu9150.c
@@ -90,6 +90,7 @@ int mpu9150_init(mpu9150_t *dev, i2c_t i2c, mpu9150_hw_addr_t hw_addr,
 
     /* Initialize magnetometer */
     if (compass_init(dev)) {
+        i2c_release(dev->i2c_dev);
         return -2;
     }
     /* Release the bus, it is acquired again inside each function */


### PR DESCRIPTION
This PR is a small bugfix for the MPU-9150 driver implementation. 
As pointed out by @sirtian: when the compass initialization returned an error the I2C bus was not released.