### PR TITLE
cpu/samd21: Add samd21 UART_1 implementation

### DIFF
--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -14,6 +14,7 @@
  * @brief       Peripheral MCU configuration for the Atmel SAM R21 Xplained Pro board
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  */
 
 #ifndef __PERIPH_CONF_H
@@ -49,9 +50,9 @@ extern "C" {
  * @name UART configuration
  * @{
  */
-#define UART_NUMOF          (1U)
+#define UART_NUMOF          (2U)
 #define UART_0_EN           1
-#define UART_1_EN           0
+#define UART_1_EN           1
 #define UART_2_EN           0
 #define UART_3_EN           0
 #define UART_IRQ_PRIO       1
@@ -69,12 +70,15 @@ extern "C" {
 
 
 /* UART 1 device configuration */
-#define UART_1_DEV
-#define UART_1_IRQ
-#define UART_1_ISR
+#define UART_1_DEV          SERCOM5->USART
+#define UART_1_IRQ          SERCOM5_IRQn
+#define UART_1_ISR          isr_sercom5
 /* UART 1 pin configuration */
-#define UART_1_PORT
-#define UART_1_PINS
+#define UART_1_PORT         (PORT->Group[0])
+#define UART_1_TX_PIN       (22)
+#define UART_1_RX_PIN       (23)
+#define UART_1_PINS         (PORT_PA22 | PORT_PA23)
+#define UART_1_REF_F        (8000000UL)
 /** @} */
 
 

--- a/cpu/samd21/periph/uart.c
+++ b/cpu/samd21/periph/uart.c
@@ -112,9 +112,6 @@ int uart_init_blocking(uart_t uart, uint32_t baudrate)
             /* Turn on power manager for sercom0 */
             PM->APBCMASK.reg |= PM_APBCMASK_SERCOM0;
 
-            /* Enable generic clock generator0 */
-            GCLK->GENCTRL.reg = (GCLK_GENCTRL_GENEN | (GCLK_CLKCTRL_ID(GCLK_CLKCTRL_GEN_GCLK0_Val)));
-
             /* configure GCLK0 to feed sercom0 */;
             GCLK->CLKCTRL.reg = (uint16_t)((GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 | (SERCOM0_GCLK_ID_CORE << GCLK_CLKCTRL_ID_Pos)));
             while (GCLK->STATUS.bit.SYNCBUSY);
@@ -136,14 +133,11 @@ int uart_init_blocking(uart_t uart, uint32_t baudrate)
             /* Turn on power manager for sercom5 */
             PM->APBCMASK.reg |= PM_APBCMASK_SERCOM5;
 
-            /* Enable generic clock generator1 */
-            GCLK->GENCTRL.reg = (GCLK_GENCTRL_GENEN | (GCLK_CLKCTRL_ID(GCLK_CLKCTRL_GEN_GCLK1_Val)));
-
-            /* configure GCLK1 to feed sercom5 */;
-            GCLK->CLKCTRL.reg = (uint16_t)((GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK1 | (SERCOM5_GCLK_ID_CORE << GCLK_CLKCTRL_ID_Pos)));
+            /* configure GCLK0 to feed sercom5 */;
+            GCLK->CLKCTRL.reg = (uint16_t)((GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 | (SERCOM5_GCLK_ID_CORE << GCLK_CLKCTRL_ID_Pos)));
             while (GCLK->STATUS.bit.SYNCBUSY);
 
-            GCLK->CLKCTRL.reg = (uint16_t)((GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK1 | (SERCOM5_GCLK_ID_SLOW << GCLK_CLKCTRL_ID_Pos)));
+            GCLK->CLKCTRL.reg = (uint16_t)((GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 | (SERCOM5_GCLK_ID_SLOW << GCLK_CLKCTRL_ID_Pos)));
             while (GCLK->STATUS.bit.SYNCBUSY);
 
             break;

--- a/cpu/samd21/periph/uart.c
+++ b/cpu/samd21/periph/uart.c
@@ -97,6 +97,7 @@ int uart_init_blocking(uart_t uart, uint32_t baudrate)
     uint32_t tx_pin = 0;
     uint32_t rx_pin = 0;
     uint32_t pins = 0;
+    uint32_t HWSEL = 0;
 
 
     switch (uart) {
@@ -108,6 +109,7 @@ int uart_init_blocking(uart_t uart, uint32_t baudrate)
             tx_pin = UART_0_TX_PIN;
             rx_pin = UART_0_RX_PIN;
             pins = UART_0_PINS;
+            HWSEL = 0;
 
             /* Turn on power manager for sercom0 */
             PM->APBCMASK.reg |= PM_APBCMASK_SERCOM0;
@@ -129,6 +131,7 @@ int uart_init_blocking(uart_t uart, uint32_t baudrate)
             tx_pin = UART_1_TX_PIN;
             rx_pin = UART_1_RX_PIN;
             pins = UART_1_PINS;
+            HWSEL = (PORT_WRCONFIG_HWSEL);
 
             /* Turn on power manager for sercom5 */
             PM->APBCMASK.reg |= PM_APBCMASK_SERCOM5;
@@ -161,7 +164,8 @@ int uart_init_blocking(uart_t uart, uint32_t baudrate)
 
 
     /* enable PMUX for pins and set to config D. See spec p. 12 */
-    port_group->WRCONFIG.reg = PORT_WRCONFIG_WRPINCFG     /* PINCFGy registers of the selected pins will be updated */
+    port_group->WRCONFIG.reg = HWSEL                      /* Upper/lower 16 pins of PORT will be configured */
+                                | PORT_WRCONFIG_WRPINCFG  /* PINCFGy registers of the selected pins will be updated */
                                 | PORT_WRCONFIG_WRPMUX    /* PMUXn registers of the selected pins will be updated */
                                 | PORT_WRCONFIG_PMUX(0x3) /* Multiplexer peripheral function D */
                                 | PORT_WRCONFIG_PMUXEN    /* Peripheral multiplexer enable */

--- a/cpu/samd21/periph/uart.c
+++ b/cpu/samd21/periph/uart.c
@@ -202,12 +202,40 @@ int uart_init_blocking(uart_t uart, uint32_t baudrate)
 
 void uart_tx_begin(uart_t uart)
 {
-
+    switch (uart) {
+#if UART_0_EN
+        case UART_0:
+            if (uart_config[uart].tx_cb(uart_config[uart].arg) != 0) {
+                /* TXC flag is also cleared by writing data to DATA register */
+                UART_0_DEV.INTENSET.bit.TXC = 1;
+            }
+            break;
+#endif
+#if UART_1_EN
+    case UART_1:
+            if (uart_config[uart].tx_cb(uart_config[uart].arg) != 0) {
+                /* TXC flag is also cleared by writing data to DATA register */
+                UART_1_DEV.INTENSET.bit.TXC = 1;
+            }
+            break;
+#endif
+    }
 }
 
 void uart_tx_end(uart_t uart)
 {
-
+    switch (uart) {
+#if UART_0_EN
+        case UART_0:
+                UART_0_DEV.INTENCLR.bit.TXC = 1;
+            break;
+#endif
+#if UART_1_EN
+    case UART_1:
+                UART_1_DEV.INTENCLR.bit.TXC = 1;
+            break;
+#endif
+    }
 }
 
 int uart_write(uart_t uart, char data)

--- a/cpu/samd21/periph/uart.c
+++ b/cpu/samd21/periph/uart.c
@@ -96,7 +96,6 @@ int uart_init_blocking(uart_t uart, uint32_t baudrate)
     uint32_t uart_ref_f = 0;
     uint32_t tx_pin = 0;
     uint32_t rx_pin = 0;
-    uint32_t pins = 0;
     uint32_t HWSEL = 0;
 
 
@@ -108,7 +107,6 @@ int uart_init_blocking(uart_t uart, uint32_t baudrate)
             uart_ref_f = UART_0_REF_F;
             tx_pin = UART_0_TX_PIN;
             rx_pin = UART_0_RX_PIN;
-            pins = UART_0_PINS;
             HWSEL = 0;
 
             /* Turn on power manager for sercom0 */
@@ -130,7 +128,6 @@ int uart_init_blocking(uart_t uart, uint32_t baudrate)
             uart_ref_f = UART_1_REF_F;
             tx_pin = UART_1_TX_PIN;
             rx_pin = UART_1_RX_PIN;
-            pins = UART_1_PINS;
             HWSEL = (PORT_WRCONFIG_HWSEL);
 
             /* Turn on power manager for sercom5 */
@@ -169,7 +166,8 @@ int uart_init_blocking(uart_t uart, uint32_t baudrate)
                                 | PORT_WRCONFIG_WRPMUX    /* PMUXn registers of the selected pins will be updated */
                                 | PORT_WRCONFIG_PMUX(0x3) /* Multiplexer peripheral function D */
                                 | PORT_WRCONFIG_PMUXEN    /* Peripheral multiplexer enable */
-                                | pins;                   /* Pinmask */
+                                | (1 << ( tx_pin % 16 ))  /* Pinmask */
+                                | (1 << ( rx_pin % 16 )); /* Pinmask */
 
     uart_dev->CTRLA.bit.ENABLE = 0; /* Disable to write, need to sync to */
     while(uart_dev->SYNCBUSY.bit.ENABLE);

--- a/tests/periph_uart_int/main.c
+++ b/tests/periph_uart_int/main.c
@@ -42,7 +42,7 @@
 /* only build this test if the UART driver is supported */
 #if UART_NUMOF
 
-#define DEV             UART_0
+#define DEV             UART_1
 #define BAUD            115200
 
 static volatile int main_pid;


### PR DESCRIPTION
Hey guys, I started implementing the UART_1 for samr-xpro boards but I could not get it running. I need this to free the PA04 pin from UART_0 so I can use the pin for the ADC ref. voltage function. Does anyone know what is missing or wrong? I think @wiredsource mentioned in #2063 that he already implemented UART_1, is that correct?
Thanks!