### PR TITLE
sys/net/routing/rpl: use types from `byteorder.h` for `uint16_t`

### DIFF
--- a/examples/rpl_udp/rpl.c
+++ b/examples/rpl_udp/rpl.c
@@ -167,7 +167,7 @@ void rpl_udp_dodag(int argc, char **argv)
     printf("Part of Dodag:\n");
     printf("%s\n", ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN,
                                     (&mydodag->dodag_id)));
-    printf("my rank: %d\n", mydodag->my_rank);
+    printf("my rank: %d\n", NTOHS(mydodag->my_rank.u16));
 
     if (!is_root) {
         printf("my preferred parent:\n");

--- a/examples/rpl_udp/rpl.c
+++ b/examples/rpl_udp/rpl.c
@@ -167,7 +167,7 @@ void rpl_udp_dodag(int argc, char **argv)
     printf("Part of Dodag:\n");
     printf("%s\n", ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN,
                                     (&mydodag->dodag_id)));
-    printf("my rank: %d\n", NTOHS(mydodag->my_rank.u16));
+    printf("my rank: %d\n", byteorder_ntohs(mydodag->my_rank));
 
     if (!is_root) {
         printf("my preferred parent:\n");

--- a/sys/net/include/rpl/rpl_dodag.h
+++ b/sys/net/include/rpl/rpl_dodag.h
@@ -35,9 +35,9 @@ rpl_instance_t *rpl_get_my_instance(void);
 rpl_dodag_t *rpl_new_dodag(uint8_t instanceid, ipv6_addr_t *id);
 rpl_dodag_t *rpl_get_dodag(ipv6_addr_t *id);
 rpl_dodag_t *rpl_get_my_dodag(void);
-void rpl_join_dodag(rpl_dodag_t *dodag, ipv6_addr_t *parent, uint16_t parent_rank);
+void rpl_join_dodag(rpl_dodag_t *dodag, ipv6_addr_t *parent, network_uint16_t parent_rank);
 void rpl_del_dodag(rpl_dodag_t *dodag);
-rpl_parent_t *rpl_new_parent(rpl_dodag_t *dodag, ipv6_addr_t *address, uint16_t rank);
+rpl_parent_t *rpl_new_parent(rpl_dodag_t *dodag, ipv6_addr_t *address, network_uint16_t rank);
 rpl_parent_t *rpl_find_parent(ipv6_addr_t *address);
 void rpl_leave_dodag(rpl_dodag_t *dodag);
 bool rpl_equal_id(ipv6_addr_t *id1, ipv6_addr_t *id2);
@@ -47,9 +47,9 @@ void rpl_delete_worst_parent(void);
 void rpl_delete_all_parents(void);
 rpl_parent_t *rpl_find_preferred_parent(void);
 void rpl_parent_update(rpl_parent_t *parent);
-void rpl_global_repair(rpl_dodag_t *dodag, ipv6_addr_t *p_addr, uint16_t rank);
+void rpl_global_repair(rpl_dodag_t *dodag, ipv6_addr_t *p_addr, network_uint16_t rank);
 void rpl_local_repair(void);
-uint16_t rpl_calc_rank(uint16_t abs_rank, uint16_t minhoprankincrease);
+network_uint16_t rpl_calc_rank(network_uint16_t abs_rank, network_uint16_t minhoprankincrease);
 
 #ifdef __cplusplus
 }

--- a/sys/net/include/rpl/rpl_of_manager.h
+++ b/sys/net/include/rpl/rpl_of_manager.h
@@ -36,7 +36,7 @@ void rpl_of_manager_init(ipv6_addr_t *my_address);
  * @param[in]   ocp Objective code point of objective function
  * @return      Pointer of corresponding objective function implementation
 */
-rpl_of_t *rpl_get_of_for_ocp(uint16_t ocp);
+rpl_of_t *rpl_get_of_for_ocp(network_uint16_t ocp);
 
 #ifdef __cplusplus
 }

--- a/sys/net/include/rpl/rpl_structs.h
+++ b/sys/net/include/rpl/rpl_structs.h
@@ -35,7 +35,7 @@ extern "C" {
 typedef struct __attribute__((packed)) {
     uint8_t rpl_instanceid;
     uint8_t version_number;
-    uint16_t rank;
+    network_uint16_t rank;
     uint8_t g_mop_prf;
     uint8_t dtsn;
     uint8_t flags;
@@ -84,12 +84,12 @@ typedef struct __attribute__((packed)) {
     uint8_t DIOIntDoubl;
     uint8_t DIOIntMin;
     uint8_t DIORedun;
-    uint16_t MaxRankIncrease;
-    uint16_t MinHopRankIncrease;
-    uint16_t ocp;
+    network_uint16_t MaxRankIncrease;
+    network_uint16_t MinHopRankIncrease;
+    network_uint16_t ocp;
     uint8_t reserved;
     uint8_t default_lifetime;
-    uint16_t lifetime_unit;
+    network_uint16_t lifetime_unit;
 } rpl_opt_dodag_conf_t;
 
 /* RPL Solicited Information Option (RFC 6550 Fig. 28) */
@@ -127,10 +127,10 @@ struct rpl_dodag_t;
 
 typedef struct {
     ipv6_addr_t         addr;
-    uint16_t            rank;
+    network_uint16_t            rank;
     uint8_t             dtsn;
     struct rpl_dodag_t *dodag;
-    uint16_t            lifetime;
+    network_uint16_t            lifetime;
     double              link_metric;
     uint8_t             link_metric_type;
     uint8_t             used;
@@ -155,16 +155,16 @@ typedef struct rpl_dodag_t {
     uint8_t dio_interval_doubling;
     uint8_t dio_min;
     uint8_t dio_redundancy;
-    uint16_t maxrankincrease;
-    uint16_t minhoprankincrease;
+    network_uint16_t maxrankincrease;
+    network_uint16_t minhoprankincrease;
     uint8_t default_lifetime;
-    uint16_t lifetime_unit;
+    network_uint16_t lifetime_unit;
     uint8_t version;
     uint8_t grounded;
-    uint16_t my_rank;
+    network_uint16_t my_rank;
     uint8_t node_status;
     uint8_t dao_seq;
-    uint16_t min_rank;
+    network_uint16_t min_rank;
     uint8_t joined;
     rpl_parent_t *my_preferred_parent;
     struct rpl_of_t *of;
@@ -176,8 +176,8 @@ typedef struct rpl_dodag_t {
 } rpl_dodag_t;
 
 typedef struct rpl_of_t {
-    uint16_t ocp;
-    uint16_t (*calc_rank)(rpl_parent_t *parent, uint16_t base_rank);
+    network_uint16_t ocp;
+    network_uint16_t (*calc_rank)(rpl_parent_t *parent, network_uint16_t base_rank);
     rpl_parent_t *(*which_parent)(rpl_parent_t *, rpl_parent_t *);
     rpl_dodag_t *(*which_dodag)(rpl_dodag_t *, rpl_dodag_t *);
     void (*reset)(rpl_dodag_t *);
@@ -189,7 +189,7 @@ typedef struct rpl_of_t {
 typedef struct {
     ipv6_addr_t address;
     ipv6_addr_t next_hop;
-    uint16_t lifetime;
+    network_uint16_t lifetime;
     uint8_t used;
 } rpl_routing_entry_t;
 

--- a/sys/net/routing/rpl/of0.c
+++ b/sys/net/routing/rpl/of0.c
@@ -22,13 +22,13 @@
 #include "of0.h"
 
 //Function Prototypes
-static uint16_t calc_rank(rpl_parent_t *, uint16_t);
+static network_uint16_t calc_rank(rpl_parent_t *, network_uint16_t);
 static rpl_parent_t *which_parent(rpl_parent_t *, rpl_parent_t *);
 static rpl_dodag_t *which_dodag(rpl_dodag_t *, rpl_dodag_t *);
 static void reset(rpl_dodag_t *);
 
 static rpl_of_t rpl_of0 = {
-    0x0,
+    {0x0000},
     calc_rank,
     which_parent,
     which_dodag,
@@ -49,36 +49,42 @@ void reset(rpl_dodag_t *dodag)
     (void) dodag;
 }
 
-uint16_t calc_rank(rpl_parent_t *parent, uint16_t base_rank)
+network_uint16_t calc_rank(rpl_parent_t *parent, network_uint16_t base_rank)
 {
-    if (base_rank == 0) {
+    network_uint16_t net_inf_rank = {HTONS(INFINITE_RANK)};
+    network_uint16_t net_min_rank = {HTONS(DEFAULT_MIN_HOP_RANK_INCREASE)};
+    network_uint16_t net_inc_rank = {0x0};
+
+    if (base_rank.u16 == 0x0) {
         if (parent == NULL) {
-            return INFINITE_RANK;
+            return net_inf_rank;
         }
 
         base_rank = parent->rank;
     }
 
-    uint16_t add;
+    network_uint16_t add;
 
     if (parent != NULL) {
         add = parent->dodag->minhoprankincrease;
     }
     else {
-        add = DEFAULT_MIN_HOP_RANK_INCREASE;
+        add = net_min_rank;
     }
 
-    if (base_rank + add < base_rank) {
-        return INFINITE_RANK;
+    net_inc_rank.u16 = (base_rank.u16 + add.u16);
+
+    if ( NTOHS(net_inc_rank.u16) < NTOHS(base_rank.u16) ) {
+        return net_inf_rank;
     }
 
-    return base_rank + add;
+    return net_inc_rank;
 }
 
 /* We simply return the Parent with lower rank */
 rpl_parent_t *which_parent(rpl_parent_t *p1, rpl_parent_t *p2)
 {
-    if (p1->rank < p2->rank) {
+    if ( NTOHS(p1->rank.u16) < NTOHS(p2->rank.u16) ) {
         return p1;
     }
 

--- a/sys/net/routing/rpl/of0.c
+++ b/sys/net/routing/rpl/of0.c
@@ -51,13 +51,11 @@ void reset(rpl_dodag_t *dodag)
 
 network_uint16_t calc_rank(rpl_parent_t *parent, network_uint16_t base_rank)
 {
-    network_uint16_t net_inf_rank = {HTONS(INFINITE_RANK)};
-    network_uint16_t net_min_rank = {HTONS(DEFAULT_MIN_HOP_RANK_INCREASE)};
-    network_uint16_t net_inc_rank = {0x0};
+    network_uint16_t net_inc_rank = byteorder_htons(0x0);
 
-    if (base_rank.u16 == 0x0) {
+    if ( byteorder_ntohs(base_rank) == 0x0) {
         if (parent == NULL) {
-            return net_inf_rank;
+            return byteorder_htons(INFINITE_RANK);
         }
 
         base_rank = parent->rank;
@@ -69,13 +67,13 @@ network_uint16_t calc_rank(rpl_parent_t *parent, network_uint16_t base_rank)
         add = parent->dodag->minhoprankincrease;
     }
     else {
-        add = net_min_rank;
+        add = byteorder_htons(DEFAULT_MIN_HOP_RANK_INCREASE);
     }
 
-    net_inc_rank.u16 = (base_rank.u16 + add.u16);
+    net_inc_rank = byteorder_htons(byteorder_ntohs(base_rank) + byteorder_ntohs(add));
 
-    if ( NTOHS(net_inc_rank.u16) < NTOHS(base_rank.u16) ) {
-        return net_inf_rank;
+    if ( byteorder_ntohs(net_inc_rank) < byteorder_ntohs(base_rank) ) {
+        return byteorder_htons(INFINITE_RANK);
     }
 
     return net_inc_rank;
@@ -84,7 +82,7 @@ network_uint16_t calc_rank(rpl_parent_t *parent, network_uint16_t base_rank)
 /* We simply return the Parent with lower rank */
 rpl_parent_t *which_parent(rpl_parent_t *p1, rpl_parent_t *p2)
 {
-    if ( NTOHS(p1->rank.u16) < NTOHS(p2->rank.u16) ) {
+    if ( byteorder_ntohs(p1->rank) < byteorder_ntohs(p2->rank) ) {
         return p1;
     }
 

--- a/sys/net/routing/rpl/of_mrhof.c
+++ b/sys/net/routing/rpl/of_mrhof.c
@@ -90,15 +90,15 @@ static uint16_t calc_path_cost(rpl_parent_t *parent)
             return MAX_PATH_COST;
         }
 
-        if (etx_value * ETX_RANK_MULTIPLIER + NTOHS(parent->rank.u16)
-            < NTOHS(parent->rank.u16)) {
+        if (etx_value * ETX_RANK_MULTIPLIER + byteorder_ntohs(parent->rank)
+            < byteorder_ntohs(parent->rank)) {
             //Overflow
             return MAX_PATH_COST;
         }
 
         //TODO runden
         return etx_value * ETX_RANK_MULTIPLIER
-               + NTOHS(parent->rank.u16);
+               + byteorder_ntohs(parent->rank);
     }
     else {
         // IMPLEMENT HANDLING OF OTHER METRICS HERE
@@ -111,8 +111,6 @@ static uint16_t calc_path_cost(rpl_parent_t *parent)
 static network_uint16_t calc_rank(rpl_parent_t *parent, network_uint16_t base_rank)
 {
     DEBUGF("calc_rank\n");
-    network_uint16_t net_inf_rank = {HTONS(INFINITE_RANK)};
-    network_uint16_t net_min_rank = {HTONS(DEFAULT_MIN_HOP_RANK_INCREASE)};
     network_uint16_t net_inc_rank = {0x0};
     network_uint16_t calculated_pcost = {0x0};
 
@@ -124,9 +122,9 @@ static network_uint16_t calc_rank(rpl_parent_t *parent, network_uint16_t base_ra
      * Baserank is pretty much only used to find out if a node is a root or not.
      */
     if (parent == NULL) {
-        if (base_rank.u16 == 0x0) {
+        if (byteorder_ntohs(base_rank) == 0x0) {
             //No parent, no rank, a root node would have a rank != 0
-            return net_inf_rank;
+            return byteorder_htons(INFINITE_RANK);
         }
 
         /*
@@ -135,7 +133,7 @@ static network_uint16_t calc_rank(rpl_parent_t *parent, network_uint16_t base_ra
          * Since a recalculating node must have a parent in this implementation
          * (see rpl.c, function global_repair), we can assume this node is root.
          */
-        return net_min_rank;
+        return byteorder_htons(DEFAULT_MIN_HOP_RANK_INCREASE);
     }
     else {
         /*
@@ -143,11 +141,11 @@ static network_uint16_t calc_rank(rpl_parent_t *parent, network_uint16_t base_ra
          * the parent and choose the maximum of that value and the advertised
          * rank of the parent + minhoprankincrease for our rank.
          */
-         calculated_pcost.u16 = HTONS(calc_path_cost(parent));
-         net_inc_rank.u16 = (parent->rank.u16 + parent->dodag->minhoprankincrease.u16);
-        if (NTOHS(calculated_pcost.u16) < MAX_PATH_COST) {
-            if (( NTOHS(net_inc_rank.u16))
-                > NTOHS(calculated_pcost.u16)) {
+         calculated_pcost = byteorder_htons(calc_path_cost(parent));
+         net_inc_rank = byteorder_htons(byteorder_ntohs(parent->rank) + byteorder_ntohs(parent->dodag->minhoprankincrease));
+        if (byteorder_ntohs(calculated_pcost) < MAX_PATH_COST) {
+            if ((byteorder_ntohs(net_inc_rank))
+                > byteorder_ntohs(calculated_pcost)) {
                 return net_inc_rank;
             }
             else {
@@ -156,7 +154,7 @@ static network_uint16_t calc_rank(rpl_parent_t *parent, network_uint16_t base_ra
         }
         else {
             //Path costs are greater than allowed
-            return net_inf_rank;
+            return byteorder_htons(INFINITE_RANK);
         }
     }
 }

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -370,24 +370,24 @@ void _rpl_update_routing_table(void) {
 
         for (uint8_t i = 0; i < rpl_max_routing_entries; i++) {
             if (rt[i].used) {
-                if (NTOHS(rt[i].lifetime.u16) <= 1) {
+                if (byteorder_ntohs(rt[i].lifetime) <= 1) {
                     memset(&rt[i], 0, sizeof(rt[i]));
                 }
                 else {
-                    rt[i].lifetime.u16 = rt[i].lifetime.u16 - HTONS(RPL_LIFETIME_STEP);
+                    rt[i].lifetime = byteorder_htons(byteorder_ntohs(rt[i].lifetime) - RPL_LIFETIME_STEP);
                 }
             }
         }
 
         /* Parent is NULL for root too */
         if (my_dodag->my_preferred_parent != NULL) {
-            if (NTOHS(my_dodag->my_preferred_parent->lifetime.u16) <= 1) {
+            if (byteorder_ntohs(my_dodag->my_preferred_parent->lifetime) <= 1) {
                 DEBUGF("parent lifetime timeout\n");
                 rpl_parent_update(NULL);
             }
             else {
-                my_dodag->my_preferred_parent->lifetime.u16 =
-                    my_dodag->my_preferred_parent->lifetime.u16 - HTONS(RPL_LIFETIME_STEP);
+                my_dodag->my_preferred_parent->lifetime =
+                byteorder_htons(byteorder_ntohs(my_dodag->my_preferred_parent->lifetime) - RPL_LIFETIME_STEP);
             }
         }
     }
@@ -482,7 +482,7 @@ void rpl_add_routing_entry(ipv6_addr_t *addr, ipv6_addr_t *next_hop, uint16_t li
     rpl_routing_entry_t *entry = rpl_find_routing_entry(addr);
 
     if (entry != NULL) {
-        entry->lifetime.u16 = HTONS(lifetime);
+        entry->lifetime = byteorder_htons(lifetime);
         return;
     }
 
@@ -492,7 +492,7 @@ void rpl_add_routing_entry(ipv6_addr_t *addr, ipv6_addr_t *next_hop, uint16_t li
         if (!rpl_routing_table[i].used) {
             memcpy(&rpl_routing_table[i].address, addr, sizeof(ipv6_addr_t));
             memcpy(&rpl_routing_table[i].next_hop, next_hop, sizeof(ipv6_addr_t));
-            rpl_routing_table[i].lifetime.u16 = HTONS(lifetime);
+            rpl_routing_table[i].lifetime = byteorder_htons(lifetime);
             rpl_routing_table[i].used = 1;
             break;
         }

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -370,24 +370,24 @@ void _rpl_update_routing_table(void) {
 
         for (uint8_t i = 0; i < rpl_max_routing_entries; i++) {
             if (rt[i].used) {
-                if (rt[i].lifetime <= 1) {
+                if (NTOHS(rt[i].lifetime.u16) <= 1) {
                     memset(&rt[i], 0, sizeof(rt[i]));
                 }
                 else {
-                    rt[i].lifetime = rt[i].lifetime - RPL_LIFETIME_STEP;
+                    rt[i].lifetime.u16 = rt[i].lifetime.u16 - HTONS(RPL_LIFETIME_STEP);
                 }
             }
         }
 
         /* Parent is NULL for root too */
         if (my_dodag->my_preferred_parent != NULL) {
-            if (my_dodag->my_preferred_parent->lifetime <= 1) {
+            if (NTOHS(my_dodag->my_preferred_parent->lifetime.u16) <= 1) {
                 DEBUGF("parent lifetime timeout\n");
                 rpl_parent_update(NULL);
             }
             else {
-                my_dodag->my_preferred_parent->lifetime =
-                    my_dodag->my_preferred_parent->lifetime - RPL_LIFETIME_STEP;
+                my_dodag->my_preferred_parent->lifetime.u16 =
+                    my_dodag->my_preferred_parent->lifetime.u16 - HTONS(RPL_LIFETIME_STEP);
             }
         }
     }
@@ -482,7 +482,7 @@ void rpl_add_routing_entry(ipv6_addr_t *addr, ipv6_addr_t *next_hop, uint16_t li
     rpl_routing_entry_t *entry = rpl_find_routing_entry(addr);
 
     if (entry != NULL) {
-        entry->lifetime = lifetime;
+        entry->lifetime.u16 = HTONS(lifetime);
         return;
     }
 
@@ -492,7 +492,7 @@ void rpl_add_routing_entry(ipv6_addr_t *addr, ipv6_addr_t *next_hop, uint16_t li
         if (!rpl_routing_table[i].used) {
             memcpy(&rpl_routing_table[i].address, addr, sizeof(ipv6_addr_t));
             memcpy(&rpl_routing_table[i].next_hop, next_hop, sizeof(ipv6_addr_t));
-            rpl_routing_table[i].lifetime = lifetime;
+            rpl_routing_table[i].lifetime.u16 = HTONS(lifetime);
             rpl_routing_table[i].used = 1;
             break;
         }

--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -104,7 +104,7 @@ rpl_dodag_t *rpl_new_dodag(uint8_t instanceid, ipv6_addr_t *dodagid)
         if (dodag->used == 0) {
             memset(dodag, 0, sizeof(*dodag));
             dodag->instance = inst;
-            dodag->my_rank = INFINITE_RANK;
+            dodag->my_rank.u16 = HTONS(INFINITE_RANK);
             dodag->used = 1;
             dodag->ack_received = true;
             dodag->dao_counter = 0;
@@ -167,7 +167,7 @@ bool rpl_equal_id(ipv6_addr_t *id1, ipv6_addr_t *id2)
 
 }
 
-rpl_parent_t *rpl_new_parent(rpl_dodag_t *dodag, ipv6_addr_t *address, uint16_t rank)
+rpl_parent_t *rpl_new_parent(rpl_dodag_t *dodag, ipv6_addr_t *address, network_uint16_t rank)
 {
     rpl_parent_t *parent;
     rpl_parent_t *end;
@@ -179,7 +179,7 @@ rpl_parent_t *rpl_new_parent(rpl_dodag_t *dodag, ipv6_addr_t *address, uint16_t 
             parent->addr = *address;
             parent->rank = rank;
             parent->dodag = dodag;
-            parent->lifetime = dodag->default_lifetime * dodag->lifetime_unit;
+            parent->lifetime.u16 = HTONS(dodag->default_lifetime * NTOHS(dodag->lifetime_unit.u16));
             /* dtsn is set at the end of recv_dio function */
             parent->dtsn = 0;
             return parent;
@@ -222,9 +222,9 @@ void rpl_delete_worst_parent(void)
     uint16_t max_rank = 0x0000;
 
     for (int i = 0; i < RPL_MAX_PARENTS; i++) {
-        if (parents[i].rank > max_rank) {
+        if (NTOHS(parents[i].rank.u16) > max_rank) {
             worst = i;
-            max_rank = parents[i].rank;
+            max_rank = NTOHS(parents[i].rank.u16);
         }
     }
 
@@ -262,7 +262,7 @@ rpl_parent_t *rpl_find_preferred_parent(void)
 
     for (uint8_t i = 0; i < RPL_MAX_PARENTS; i++) {
         if (parents[i].used) {
-            if ((parents[i].rank == INFINITE_RANK) || (parents[i].lifetime <= 1)) {
+            if ((parents[i].rank.u16 == HTONS(INFINITE_RANK)) || (NTOHS(parents[i].lifetime.u16) <= 1)) {
                 DEBUG("Infinite rank, bad parent\n");
                 continue;
             }
@@ -305,7 +305,7 @@ rpl_parent_t *rpl_find_preferred_parent(void)
 void rpl_parent_update(rpl_parent_t *parent)
 {
     rpl_dodag_t *my_dodag = rpl_get_my_dodag();
-    uint16_t old_rank;
+    network_uint16_t old_rank;
 
     if (my_dodag == NULL) {
         DEBUG("Not part of a dodag - this should not happen");
@@ -316,16 +316,16 @@ void rpl_parent_update(rpl_parent_t *parent)
 
     /* update Parent lifetime */
     if (parent != NULL) {
-        parent->lifetime = my_dodag->default_lifetime * my_dodag->lifetime_unit;
+        parent->lifetime.u16 = HTONS(my_dodag->default_lifetime * NTOHS(my_dodag->lifetime_unit.u16));
     }
 
     if (rpl_find_preferred_parent() == NULL) {
         rpl_local_repair();
     }
 
-    if (rpl_calc_rank(old_rank, my_dodag->minhoprankincrease) !=
-        rpl_calc_rank(my_dodag->my_rank, my_dodag->minhoprankincrease)) {
-        if (my_dodag->my_rank < my_dodag->min_rank) {
+    if (rpl_calc_rank(old_rank, my_dodag->minhoprankincrease).u16 !=
+        rpl_calc_rank(my_dodag->my_rank, my_dodag->minhoprankincrease).u16 ) {
+        if (NTOHS(my_dodag->my_rank.u16) < NTOHS(my_dodag->min_rank.u16)) {
             my_dodag->min_rank = my_dodag->my_rank;
         }
 
@@ -333,7 +333,7 @@ void rpl_parent_update(rpl_parent_t *parent)
     }
 }
 
-void rpl_join_dodag(rpl_dodag_t *dodag, ipv6_addr_t *parent, uint16_t parent_rank)
+void rpl_join_dodag(rpl_dodag_t *dodag, ipv6_addr_t *parent, network_uint16_t parent_rank)
 {
     rpl_dodag_t *my_dodag;
     rpl_parent_t *preferred_parent;
@@ -373,14 +373,14 @@ void rpl_join_dodag(rpl_dodag_t *dodag, ipv6_addr_t *parent, uint16_t parent_ran
     my_dodag->min_rank = my_dodag->my_rank;
     DEBUG("Joint DODAG:\n");
     DEBUG("\tMOP:\t%02X\n", my_dodag->mop);
-    DEBUG("\tminhoprankincrease :\t%04X\n", my_dodag->minhoprankincrease);
+    DEBUG("\tminhoprankincrease :\t%04X\n", NTOHS(my_dodag->minhoprankincrease.u16));
     DEBUG("\tdefault_lifetime:\t%02X\n", my_dodag->default_lifetime);
     DEBUG("\tgrounded:\t%02X\n", my_dodag->grounded);
     DEBUG("\tmy_preferred_parent:\t%s\n",
           ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN,
                            &my_dodag->my_preferred_parent->addr));
-    DEBUG("\tmy_preferred_parent rank\t%02X\n", my_dodag->my_preferred_parent->rank);
-    DEBUG("\tmy_preferred_parent lifetime\t%04X\n", my_dodag->my_preferred_parent->lifetime);
+    DEBUG("\tmy_preferred_parent rank\t%02X\n", NTOHS(my_dodag->my_preferred_parent->rank.u16));
+    DEBUG("\tmy_preferred_parent lifetime\t%04X\n", NTOHS(my_dodag->my_preferred_parent->lifetime.u16));
 
     trickle_start(rpl_process_pid, &my_dodag->trickle, RPL_MSG_TYPE_TRICKLE_INTERVAL,
             RPL_MSG_TYPE_TRICKLE_CALLBACK, (1 << my_dodag->dio_min), my_dodag->dio_interval_doubling,
@@ -388,7 +388,7 @@ void rpl_join_dodag(rpl_dodag_t *dodag, ipv6_addr_t *parent, uint16_t parent_ran
     rpl_delay_dao(my_dodag);
 }
 
-void rpl_global_repair(rpl_dodag_t *dodag, ipv6_addr_t *p_addr, uint16_t rank)
+void rpl_global_repair(rpl_dodag_t *dodag, ipv6_addr_t *p_addr, network_uint16_t rank)
 {
     DEBUGF("[INFO] Global repair started\n");
     rpl_dodag_t *my_dodag = rpl_get_my_dodag();
@@ -405,7 +405,7 @@ void rpl_global_repair(rpl_dodag_t *dodag, ipv6_addr_t *p_addr, uint16_t rank)
 
     if (my_dodag->my_preferred_parent == NULL) {
         DEBUGF("[Error] no more parent after global repair\n");
-        my_dodag->my_rank = INFINITE_RANK;
+        my_dodag->my_rank.u16 = HTONS(INFINITE_RANK);
     }
     else {
         /* Calc new Rank */
@@ -417,7 +417,7 @@ void rpl_global_repair(rpl_dodag_t *dodag, ipv6_addr_t *p_addr, uint16_t rank)
     }
 
     DEBUGF("Migrated to DODAG Version %d. My new Rank: %d\n", my_dodag->version,
-           my_dodag->my_rank);
+           NTOHS(my_dodag->my_rank.u16));
 }
 
 void rpl_local_repair(void)
@@ -430,7 +430,7 @@ void rpl_local_repair(void)
         return;
     }
 
-    my_dodag->my_rank = INFINITE_RANK;
+    my_dodag->my_rank.u16 = HTONS(INFINITE_RANK);
     my_dodag->dtsn++;
     rpl_delete_all_parents();
     trickle_reset_timer(&my_dodag->trickle);
@@ -448,7 +448,8 @@ ipv6_addr_t *rpl_get_my_preferred_parent(void)
     return &my_dodag->my_preferred_parent->addr;
 }
 
-uint16_t rpl_calc_rank(uint16_t abs_rank, uint16_t minhoprankincrease)
+network_uint16_t rpl_calc_rank(network_uint16_t abs_rank, network_uint16_t minhoprankincrease)
 {
-    return abs_rank / minhoprankincrease;
+    network_uint16_t ret = {HTONS(NTOHS(abs_rank.u16) / NTOHS(minhoprankincrease.u16))};
+    return ret;
 }

--- a/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
+++ b/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
@@ -169,7 +169,6 @@ void rpl_init_root_mode(void)
 {
     rpl_instance_t *inst;
     rpl_dodag_t *dodag;
-    network_uint16_t rpl_def_ocp = {HTONS(RPL_DEFAULT_OCP)};
 
     inst = rpl_new_instance(RPL_DEFAULT_INSTANCE);
 
@@ -187,7 +186,7 @@ void rpl_init_root_mode(void)
     i_am_root = 1;
 
     if (dodag != NULL) {
-        dodag->of = (struct rpl_of_t *) rpl_get_of_for_ocp(rpl_def_ocp);
+        dodag->of = (struct rpl_of_t *) rpl_get_of_for_ocp(byteorder_htons(RPL_DEFAULT_OCP));
         DEBUGF("Dodag init done.\n");
         dodag->instance = inst;
         dodag->mop = RPL_DEFAULT_MOP;
@@ -196,14 +195,14 @@ void rpl_init_root_mode(void)
         dodag->dio_interval_doubling = DEFAULT_DIO_INTERVAL_DOUBLINGS;
         dodag->dio_min = DEFAULT_DIO_INTERVAL_MIN;
         dodag->dio_redundancy = DEFAULT_DIO_REDUNDANCY_CONSTANT;
-        dodag->maxrankincrease.u16 = 0x0;
-        dodag->minhoprankincrease.u16 = HTONS(DEFAULT_MIN_HOP_RANK_INCREASE);
+        dodag->maxrankincrease = byteorder_htons(0x0);
+        dodag->minhoprankincrease = byteorder_htons(DEFAULT_MIN_HOP_RANK_INCREASE);
         dodag->default_lifetime = (uint8_t)RPL_DEFAULT_LIFETIME;
-        dodag->lifetime_unit.u16 = HTONS(RPL_LIFETIME_UNIT);
+        dodag->lifetime_unit = byteorder_htons(RPL_LIFETIME_UNIT);
         dodag->version = RPL_COUNTER_INIT;
         dodag->grounded = RPL_GROUNDED;
         dodag->node_status = (uint8_t) ROOT_NODE;
-        dodag->my_rank.u16 = HTONS(RPL_ROOT_RANK);
+        dodag->my_rank = byteorder_htons(RPL_ROOT_RANK);
         dodag->joined = 1;
         dodag->my_preferred_parent = NULL;
         memcpy(&dodag->dodag_id, &my_address, sizeof(ipv6_addr_t));
@@ -252,7 +251,7 @@ void rpl_send_DIO_mode(ipv6_addr_t *destination)
     DEBUG("instance %02X ", rpl_send_dio_buf->rpl_instanceid);
     rpl_send_dio_buf->version_number = mydodag->version;
     rpl_send_dio_buf->rank = mydodag->my_rank;
-    DEBUG("rank %04X\n", NTOHS(rpl_send_dio_buf->rank.u16));
+    DEBUG("rank %04X\n", byteorder_ntohs(rpl_send_dio_buf->rank));
     rpl_send_dio_buf->g_mop_prf = (mydodag->grounded << RPL_GROUNDED_SHIFT) |
             (mydodag->mop << RPL_MOP_SHIFT) | mydodag->prf;
     rpl_send_dio_buf->dtsn = mydodag->dtsn;
@@ -389,7 +388,7 @@ void rpl_recv_DIO_mode(void)
             &ipv6_buf->srcaddr));
 
     rpl_dio_buf = get_rpl_dio_buf();
-    DEBUGF("instance %04X rank %04X\n", rpl_dio_buf->rpl_instanceid, NTOHS(rpl_dio_buf->rank.u16));
+    DEBUGF("instance %04X rank %04X\n", rpl_dio_buf->rpl_instanceid, byteorder_ntohs(rpl_dio_buf->rank));
     int len = DIO_BASE_LEN;
 
     rpl_instance_t *dio_inst = rpl_get_instance(rpl_dio_buf->rpl_instanceid);
@@ -507,7 +506,6 @@ void rpl_recv_DIO_mode(void)
     DEBUGF("Handle packet content.\n");
     /* handle packet content... */
     rpl_dodag_t *my_dodag = rpl_get_my_dodag();
-    network_uint16_t rpl_inf_rank = {HTONS(INFINITE_RANK)};
 
     if (my_dodag == NULL) {
         if (!has_dodag_conf_opt) {
@@ -515,14 +513,14 @@ void rpl_recv_DIO_mode(void)
             rpl_send_DIS(&ipv6_buf->srcaddr);
         }
 
-        if (rpl_dio_buf->rank.u16 < HTONS(ROOT_RANK)) {
+        if (byteorder_ntohs(rpl_dio_buf->rank) < ROOT_RANK) {
             DEBUGF("DIO with Rank < ROOT_RANK\n");
         }
 
         if (dio_dodag.mop != RPL_DEFAULT_MOP) {
             i_am_leaf = 1;
             DEBUGF("Will join DODAG as LEAF\n");
-            rpl_join_dodag(&dio_dodag, &ipv6_buf->srcaddr, rpl_inf_rank);
+            rpl_join_dodag(&dio_dodag, &ipv6_buf->srcaddr, byteorder_htons(INFINITE_RANK));
             DEBUGF("Joined DODAG\n");
             DEBUGF("The DODAG-root is: %s\n", ipv6_addr_to_str(addr_str_mode, IPV6_MAX_ADDR_STR_LEN,
                     &dio_dodag.dodag_id));
@@ -532,7 +530,7 @@ void rpl_recv_DIO_mode(void)
             DEBUGF("Required objective function not supported\n");
         }
 
-        if (rpl_dio_buf->rank.u16 != HTONS(INFINITE_RANK)) {
+        if (byteorder_ntohs(rpl_dio_buf->rank) != HTONS(INFINITE_RANK)) {
             DEBUGF("Will join DODAG\n");
             rpl_join_dodag(&dio_dodag, &ipv6_buf->srcaddr, rpl_dio_buf->rank);
             DEBUGF("Joined DODAG\n");
@@ -549,7 +547,7 @@ void rpl_recv_DIO_mode(void)
     if (rpl_equal_id(&my_dodag->dodag_id, &dio_dodag.dodag_id)) {
         /* "our" DODAG */
         if (RPL_COUNTER_GREATER_THAN(dio_dodag.version, my_dodag->version)) {
-            if (my_dodag->my_rank.u16 == HTONS(ROOT_RANK)) {
+            if (byteorder_ntohs(my_dodag->my_rank) == ROOT_RANK) {
                 DEBUGF("[Warning] Inconsistent Dodag Version\n");
                 my_dodag->version = RPL_COUNTER_INCREMENT(dio_dodag.version);
                 trickle_reset_timer(&my_dodag->trickle);
@@ -568,13 +566,13 @@ void rpl_recv_DIO_mode(void)
     }
 
     /* version matches, DODAG matches */
-    if (rpl_dio_buf->rank.u16 == HTONS(INFINITE_RANK)) {
+    if (byteorder_ntohs(rpl_dio_buf->rank) == INFINITE_RANK) {
         trickle_reset_timer(&my_dodag->trickle);
     }
 
     /* We are root, all done!*/
-    if (my_dodag->my_rank.u16 == HTONS(ROOT_RANK)) {
-        if (rpl_dio_buf->rank.u16 != HTONS(INFINITE_RANK)) {
+    if (byteorder_ntohs(my_dodag->my_rank) == ROOT_RANK) {
+        if (byteorder_ntohs(rpl_dio_buf->rank) != INFINITE_RANK) {
             trickle_increment_counter(&my_dodag->trickle);
         }
 

--- a/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
+++ b/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
@@ -530,7 +530,7 @@ void rpl_recv_DIO_mode(void)
             DEBUGF("Required objective function not supported\n");
         }
 
-        if (byteorder_ntohs(rpl_dio_buf->rank) != HTONS(INFINITE_RANK)) {
+        if (byteorder_ntohs(rpl_dio_buf->rank) != INFINITE_RANK) {
             DEBUGF("Will join DODAG\n");
             rpl_join_dodag(&dio_dodag, &ipv6_buf->srcaddr, rpl_dio_buf->rank);
             DEBUGF("Joined DODAG\n");

--- a/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
+++ b/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
@@ -169,6 +169,7 @@ void rpl_init_root_mode(void)
 {
     rpl_instance_t *inst;
     rpl_dodag_t *dodag;
+    network_uint16_t rpl_def_ocp = {HTONS(RPL_DEFAULT_OCP)};
 
     inst = rpl_new_instance(RPL_DEFAULT_INSTANCE);
 
@@ -186,7 +187,7 @@ void rpl_init_root_mode(void)
     i_am_root = 1;
 
     if (dodag != NULL) {
-        dodag->of = (struct rpl_of_t *) rpl_get_of_for_ocp(RPL_DEFAULT_OCP);
+        dodag->of = (struct rpl_of_t *) rpl_get_of_for_ocp(rpl_def_ocp);
         DEBUGF("Dodag init done.\n");
         dodag->instance = inst;
         dodag->mop = RPL_DEFAULT_MOP;
@@ -195,14 +196,14 @@ void rpl_init_root_mode(void)
         dodag->dio_interval_doubling = DEFAULT_DIO_INTERVAL_DOUBLINGS;
         dodag->dio_min = DEFAULT_DIO_INTERVAL_MIN;
         dodag->dio_redundancy = DEFAULT_DIO_REDUNDANCY_CONSTANT;
-        dodag->maxrankincrease = 0;
-        dodag->minhoprankincrease = (uint16_t)DEFAULT_MIN_HOP_RANK_INCREASE;
+        dodag->maxrankincrease.u16 = 0x0;
+        dodag->minhoprankincrease.u16 = HTONS(DEFAULT_MIN_HOP_RANK_INCREASE);
         dodag->default_lifetime = (uint8_t)RPL_DEFAULT_LIFETIME;
-        dodag->lifetime_unit = RPL_LIFETIME_UNIT;
+        dodag->lifetime_unit.u16 = HTONS(RPL_LIFETIME_UNIT);
         dodag->version = RPL_COUNTER_INIT;
         dodag->grounded = RPL_GROUNDED;
         dodag->node_status = (uint8_t) ROOT_NODE;
-        dodag->my_rank = RPL_ROOT_RANK;
+        dodag->my_rank.u16 = HTONS(RPL_ROOT_RANK);
         dodag->joined = 1;
         dodag->my_preferred_parent = NULL;
         memcpy(&dodag->dodag_id, &my_address, sizeof(ipv6_addr_t));
@@ -251,7 +252,7 @@ void rpl_send_DIO_mode(ipv6_addr_t *destination)
     DEBUG("instance %02X ", rpl_send_dio_buf->rpl_instanceid);
     rpl_send_dio_buf->version_number = mydodag->version;
     rpl_send_dio_buf->rank = mydodag->my_rank;
-    DEBUG("rank %04X\n", rpl_send_dio_buf->rank);
+    DEBUG("rank %04X\n", NTOHS(rpl_send_dio_buf->rank.u16));
     rpl_send_dio_buf->g_mop_prf = (mydodag->grounded << RPL_GROUNDED_SHIFT) |
             (mydodag->mop << RPL_MOP_SHIFT) | mydodag->prf;
     rpl_send_dio_buf->dtsn = mydodag->dtsn;
@@ -388,7 +389,7 @@ void rpl_recv_DIO_mode(void)
             &ipv6_buf->srcaddr));
 
     rpl_dio_buf = get_rpl_dio_buf();
-    DEBUGF("instance %04X rank %04X\n", rpl_dio_buf->rpl_instanceid, rpl_dio_buf->rank);
+    DEBUGF("instance %04X rank %04X\n", rpl_dio_buf->rpl_instanceid, NTOHS(rpl_dio_buf->rank.u16));
     int len = DIO_BASE_LEN;
 
     rpl_instance_t *dio_inst = rpl_get_instance(rpl_dio_buf->rpl_instanceid);
@@ -506,6 +507,7 @@ void rpl_recv_DIO_mode(void)
     DEBUGF("Handle packet content.\n");
     /* handle packet content... */
     rpl_dodag_t *my_dodag = rpl_get_my_dodag();
+    network_uint16_t rpl_inf_rank = {HTONS(INFINITE_RANK)};
 
     if (my_dodag == NULL) {
         if (!has_dodag_conf_opt) {
@@ -513,14 +515,14 @@ void rpl_recv_DIO_mode(void)
             rpl_send_DIS(&ipv6_buf->srcaddr);
         }
 
-        if (rpl_dio_buf->rank < ROOT_RANK) {
+        if (rpl_dio_buf->rank.u16 < HTONS(ROOT_RANK)) {
             DEBUGF("DIO with Rank < ROOT_RANK\n");
         }
 
         if (dio_dodag.mop != RPL_DEFAULT_MOP) {
             i_am_leaf = 1;
             DEBUGF("Will join DODAG as LEAF\n");
-            rpl_join_dodag(&dio_dodag, &ipv6_buf->srcaddr, INFINITE_RANK);
+            rpl_join_dodag(&dio_dodag, &ipv6_buf->srcaddr, rpl_inf_rank);
             DEBUGF("Joined DODAG\n");
             DEBUGF("The DODAG-root is: %s\n", ipv6_addr_to_str(addr_str_mode, IPV6_MAX_ADDR_STR_LEN,
                     &dio_dodag.dodag_id));
@@ -530,7 +532,7 @@ void rpl_recv_DIO_mode(void)
             DEBUGF("Required objective function not supported\n");
         }
 
-        if (rpl_dio_buf->rank != INFINITE_RANK) {
+        if (rpl_dio_buf->rank.u16 != HTONS(INFINITE_RANK)) {
             DEBUGF("Will join DODAG\n");
             rpl_join_dodag(&dio_dodag, &ipv6_buf->srcaddr, rpl_dio_buf->rank);
             DEBUGF("Joined DODAG\n");
@@ -547,7 +549,7 @@ void rpl_recv_DIO_mode(void)
     if (rpl_equal_id(&my_dodag->dodag_id, &dio_dodag.dodag_id)) {
         /* "our" DODAG */
         if (RPL_COUNTER_GREATER_THAN(dio_dodag.version, my_dodag->version)) {
-            if (my_dodag->my_rank == ROOT_RANK) {
+            if (my_dodag->my_rank.u16 == HTONS(ROOT_RANK)) {
                 DEBUGF("[Warning] Inconsistent Dodag Version\n");
                 my_dodag->version = RPL_COUNTER_INCREMENT(dio_dodag.version);
                 trickle_reset_timer(&my_dodag->trickle);
@@ -566,13 +568,13 @@ void rpl_recv_DIO_mode(void)
     }
 
     /* version matches, DODAG matches */
-    if (rpl_dio_buf->rank == INFINITE_RANK) {
+    if (rpl_dio_buf->rank.u16 == HTONS(INFINITE_RANK)) {
         trickle_reset_timer(&my_dodag->trickle);
     }
 
     /* We are root, all done!*/
-    if (my_dodag->my_rank == ROOT_RANK) {
-        if (rpl_dio_buf->rank != INFINITE_RANK) {
+    if (my_dodag->my_rank.u16 == HTONS(ROOT_RANK)) {
+        if (rpl_dio_buf->rank.u16 != HTONS(INFINITE_RANK)) {
             trickle_increment_counter(&my_dodag->trickle);
         }
 

--- a/sys/net/routing/rpl/rpl_of_manager.c
+++ b/sys/net/routing/rpl/rpl_of_manager.c
@@ -51,7 +51,7 @@ rpl_of_t *rpl_get_of_for_ocp(network_uint16_t ocp)
             /* fallback if something goes wrong */
             return rpl_get_of0();
         }
-        else if (ocp.u16 == objective_functions[i]->ocp.u16) {
+        else if (byteorder_ntohs(ocp) == byteorder_ntohs(objective_functions[i]->ocp)) {
             return objective_functions[i];
         }
     }

--- a/sys/net/routing/rpl/rpl_of_manager.c
+++ b/sys/net/routing/rpl/rpl_of_manager.c
@@ -44,14 +44,14 @@ void rpl_of_manager_init(ipv6_addr_t *my_address)
 }
 
 /* find implemented OF via objective code point */
-rpl_of_t *rpl_get_of_for_ocp(uint16_t ocp)
+rpl_of_t *rpl_get_of_for_ocp(network_uint16_t ocp)
 {
     for (uint16_t i = 0; i < NUMBER_IMPLEMENTED_OFS; i++) {
         if (objective_functions[i] == NULL) {
             /* fallback if something goes wrong */
             return rpl_get_of0();
         }
-        else if (ocp == objective_functions[i]->ocp) {
+        else if (ocp.u16 == objective_functions[i]->ocp.u16) {
             return objective_functions[i];
         }
     }

--- a/sys/net/routing/rpl/rpl_storing/rpl_storing.c
+++ b/sys/net/routing/rpl/rpl_storing/rpl_storing.c
@@ -176,6 +176,7 @@ void rpl_init_root_mode(void)
 {
     rpl_instance_t *inst;
     rpl_dodag_t *dodag;
+    network_uint16_t rpl_def_ocp = {HTONS(RPL_DEFAULT_OCP)};
 
     inst = rpl_new_instance(RPL_DEFAULT_INSTANCE);
 
@@ -190,7 +191,7 @@ void rpl_init_root_mode(void)
     dodag = rpl_new_dodag(RPL_DEFAULT_INSTANCE, &my_address);
 
     if (dodag != NULL) {
-        dodag->of = (struct rpl_of_t *) rpl_get_of_for_ocp(RPL_DEFAULT_OCP);
+        dodag->of = (struct rpl_of_t *) rpl_get_of_for_ocp(rpl_def_ocp);
         dodag->instance = inst;
         dodag->mop = RPL_DEFAULT_MOP;
         dodag->dtsn = 1;
@@ -198,14 +199,14 @@ void rpl_init_root_mode(void)
         dodag->dio_interval_doubling = DEFAULT_DIO_INTERVAL_DOUBLINGS;
         dodag->dio_min = DEFAULT_DIO_INTERVAL_MIN;
         dodag->dio_redundancy = DEFAULT_DIO_REDUNDANCY_CONSTANT;
-        dodag->maxrankincrease = 0;
-        dodag->minhoprankincrease = (uint16_t)DEFAULT_MIN_HOP_RANK_INCREASE;
+        dodag->maxrankincrease.u16 = 0x0;
+        dodag->minhoprankincrease.u16 = HTONS(DEFAULT_MIN_HOP_RANK_INCREASE);
         dodag->default_lifetime = (uint8_t)RPL_DEFAULT_LIFETIME;
-        dodag->lifetime_unit = RPL_LIFETIME_UNIT;
+        dodag->lifetime_unit.u16 = HTONS(RPL_LIFETIME_UNIT);
         dodag->version = RPL_COUNTER_INIT;
         dodag->grounded = RPL_GROUNDED;
         dodag->node_status = (uint8_t) ROOT_NODE;
-        dodag->my_rank = RPL_ROOT_RANK;
+        dodag->my_rank.u16 = HTONS(RPL_ROOT_RANK);
         dodag->joined = 1;
         dodag->my_preferred_parent = NULL;
     }
@@ -250,7 +251,7 @@ void rpl_send_DIO_mode(ipv6_addr_t *destination)
     DEBUG("instance %02X ", rpl_send_dio_buf->rpl_instanceid);
     rpl_send_dio_buf->version_number = mydodag->version;
     rpl_send_dio_buf->rank = mydodag->my_rank;
-    DEBUG("rank %04X\n", rpl_send_dio_buf->rank);
+    DEBUG("rank %04X\n", NTOHS(rpl_send_dio_buf->rank.u16));
     rpl_send_dio_buf->g_mop_prf = (mydodag->grounded << RPL_GROUNDED_SHIFT) |
             (mydodag->mop << RPL_MOP_SHIFT) | mydodag->prf;
     rpl_send_dio_buf->dtsn = mydodag->dtsn;
@@ -419,7 +420,7 @@ void rpl_recv_DIO_mode(void)
 
     rpl_dio_buf = get_rpl_dio_buf();
     DEBUGF("instance %04X ", rpl_dio_buf->rpl_instanceid);
-    DEBUGF("rank %04X\n", rpl_dio_buf->rank);
+    DEBUGF("rank %04X\n", NTOHS(rpl_dio_buf->rank.u16));
     int len = DIO_BASE_LEN;
 
     rpl_instance_t *dio_inst = rpl_get_instance(rpl_dio_buf->rpl_instanceid);
@@ -543,7 +544,7 @@ void rpl_recv_DIO_mode(void)
             rpl_send_DIS(&ipv6_buf->srcaddr);
         }
 
-        if (rpl_dio_buf->rank < ROOT_RANK) {
+        if (rpl_dio_buf->rank.u16 < HTONS(ROOT_RANK)) {
             DEBUGF("DIO with Rank < ROOT_RANK\n");
         }
 
@@ -555,7 +556,7 @@ void rpl_recv_DIO_mode(void)
             DEBUGF("Required objective function not supported\n");
         }
 
-        if (rpl_dio_buf->rank != INFINITE_RANK) {
+        if (rpl_dio_buf->rank.u16 != HTONS(INFINITE_RANK)) {
             DEBUGF("Will join DODAG\n");
             rpl_join_dodag(&dio_dodag, &ipv6_buf->srcaddr, rpl_dio_buf->rank);
         }
@@ -569,7 +570,7 @@ void rpl_recv_DIO_mode(void)
     if (rpl_equal_id(&my_dodag->dodag_id, &dio_dodag.dodag_id)) {
         /* "our" DODAG */
         if (RPL_COUNTER_GREATER_THAN(dio_dodag.version, my_dodag->version)) {
-            if (my_dodag->my_rank == ROOT_RANK) {
+            if (my_dodag->my_rank.u16 == HTONS(ROOT_RANK)) {
                 DEBUGF("[Warning] Inconsistent Dodag Version\n");
                 my_dodag->version = RPL_COUNTER_INCREMENT(dio_dodag.version);
                 trickle_reset_timer(&my_dodag->trickle);
@@ -589,13 +590,13 @@ void rpl_recv_DIO_mode(void)
     }
 
     /* version matches, DODAG matches */
-    if (rpl_dio_buf->rank == INFINITE_RANK) {
+    if (rpl_dio_buf->rank.u16 == HTONS(INFINITE_RANK)) {
         trickle_reset_timer(&my_dodag->trickle);
     }
 
     /* We are root, all done!*/
-    if (my_dodag->my_rank == ROOT_RANK) {
-        if (rpl_dio_buf->rank != INFINITE_RANK) {
+    if (my_dodag->my_rank.u16 == HTONS(ROOT_RANK)) {
+        if (rpl_dio_buf->rank.u16 != HTONS(INFINITE_RANK)) {
             trickle_increment_counter(&my_dodag->trickle);
         }
 
@@ -697,9 +698,9 @@ void rpl_recv_DAO_mode(void)
                 DEBUG("Adding routing information: Target: %s, Source: %s, Lifetime: %u\n",
                       ipv6_addr_to_str(addr_str_mode, IPV6_MAX_ADDR_STR_LEN, &rpl_opt_target_buf->target),
                       ipv6_addr_to_str(addr_str_mode, IPV6_MAX_ADDR_STR_LEN, &ipv6_buf->srcaddr),
-                      (rpl_opt_transit_buf->path_lifetime * my_dodag->lifetime_unit));
+                      (rpl_opt_transit_buf->path_lifetime * NTOHS(my_dodag->lifetime_unit.u16)));
                 rpl_add_routing_entry(&rpl_opt_target_buf->target, &ipv6_buf->srcaddr,
-                        rpl_opt_transit_buf->path_lifetime * my_dodag->lifetime_unit);
+                        rpl_opt_transit_buf->path_lifetime * NTOHS(my_dodag->lifetime_unit.u16));
 #endif
                 increment_seq = 1;
                 break;

--- a/sys/shell/commands/sc_rpl.c
+++ b/sys/shell/commands/sc_rpl.c
@@ -43,7 +43,7 @@ void _rpl_route_handler(int argc, char **argv)
                                                 (&rtable[i].address)));
                 printf("%-18s  ", ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN,
                                                 (&rtable[i].next_hop)));
-                printf("%d\n", rtable[i].lifetime);
+                printf("%d\n", NTOHS(rtable[i].lifetime.u16));
 
             }
         }

--- a/sys/shell/commands/sc_rpl.c
+++ b/sys/shell/commands/sc_rpl.c
@@ -43,7 +43,7 @@ void _rpl_route_handler(int argc, char **argv)
                                                 (&rtable[i].address)));
                 printf("%-18s  ", ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN,
                                                 (&rtable[i].next_hop)));
-                printf("%d\n", NTOHS(rtable[i].lifetime.u16));
+                printf("%d\n", byteorder_ntohs(rtable[i].lifetime));
 
             }
         }


### PR DESCRIPTION
Rationale:
The byteorder has not been considered when receiving DIOs, which resulted in wrong values when trying to join a DODAG.
This PR replaces the former `uint16_t` variables  with the bytorder type [`network_uint16_t`](https://github.com/RIOT-OS/RIOT/blob/master/core/include/byteorder.h#L110) from [1] and enforces the correct byteorder.
This PR is an alternative to #2431.

[1] https://github.com/RIOT-OS/RIOT/blob/master/core/include/byteorder.h