### PR TITLE
sys/net/routing/rpl: catch hardfault when OCP from DIO is not supported

### DIFF
--- a/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
+++ b/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c
@@ -483,6 +483,12 @@ void rpl_recv_DIO_mode(void)
                 dio_dodag.default_lifetime = rpl_opt_dodag_conf_buf->default_lifetime;
                 dio_dodag.lifetime_unit = byteorder_ntohs(rpl_opt_dodag_conf_buf->lifetime_unit);
                 dio_dodag.of = (struct rpl_of_t *) rpl_get_of_for_ocp(byteorder_ntohs(rpl_opt_dodag_conf_buf->ocp));
+                if (dio_dodag.of == NULL) {
+                    DEBUGF("[Error] OCP from DIO is not supported! ocp: %x\n",
+                    byteorder_ntohs(rpl_opt_dodag_conf_buf->ocp));
+                    return;
+                }
+
                 len += RPL_OPT_DODAG_CONF_LEN_WITH_OPT_LEN;
                 break;
             }

--- a/sys/net/routing/rpl/rpl_storing/rpl_storing.c
+++ b/sys/net/routing/rpl/rpl_storing/rpl_storing.c
@@ -514,6 +514,12 @@ void rpl_recv_DIO_mode(void)
                 dio_dodag.default_lifetime = rpl_opt_dodag_conf_buf->default_lifetime;
                 dio_dodag.lifetime_unit = byteorder_ntohs(rpl_opt_dodag_conf_buf->lifetime_unit);
                 dio_dodag.of = (struct rpl_of_t *) rpl_get_of_for_ocp(byteorder_ntohs(rpl_opt_dodag_conf_buf->ocp));
+                if (dio_dodag.of == NULL) {
+                    DEBUGF("[Error] OCP from DIO is not supported! ocp: %x\n",
+                    byteorder_ntohs(rpl_opt_dodag_conf_buf->ocp));
+                    return;
+                }
+
                 len += RPL_OPT_DODAG_CONF_LEN_WITH_OPT_LEN;
                 break;
             }


### PR DESCRIPTION
Rationale:
when the OCP from a DIO is not supported, e.g. due to byteorder mismatch, the resulting stored `rpl_of_t*` in `dio_dodag.of` is `NULL`.
When then trying to [join](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/routing/rpl/rpl_nonstoring/rpl_nonstoring.c#L523) the DODAG from this DIO, the node calls [`dodag->of->calc_rank(...)`](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/routing/rpl/rpl_dodag.c#L371), where `dodag->of == NULL` resulting in a null pointer exception and a hard fault.