### PR TITLE
dist/tools/openocd: Add more configurability

### DIFF
--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -6,6 +6,13 @@
 # as it depends on certain environment variables. An OpenOCD
 # configuration file must be present in a the boards dist folder.
 #
+# Global environment variables used:
+# OPENOCD:             OpenOCD command name, default: "openocd"
+# OPENOCD_CONFIG:      OpenOCD configuration file name,
+#                      default: "${RIOTBOARD}/${BOARD}/dist/openocd.cfg"
+# OPENOCD_EXTRA_INIT:  extra parameters to pass on the OpenOCD command line
+#                      before any initialization commands, default: (empty)
+#
 # The script supports the following actions:
 #
 # flash:        flash a given hexfile to the target.

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -55,13 +55,13 @@ _OPENOCD=openocd
 # a couple of tests for certain configuration options
 #
 test_config() {
-    if [ -z ${OPENOCD} ]; then
+    if [ -z "${OPENOCD}" ]; then
         OPENOCD=${_OPENOCD}
     fi
-    if [ -z ${OPENOCD_CONFIG} ]; then
+    if [ -z "${OPENOCD_CONFIG}" ]; then
         OPENOCD_CONFIG=${_OPENOCD_CONFIG}
     fi
-    if [ ! -f ${OPENOCD_CONFIG} ]; then
+    if [ ! -f "${OPENOCD_CONFIG}" ]; then
         echo "Error: Unable to locate OpenOCD configuration file"
         echo "       (${OPENOCD_CONFIG})"
         exit 1
@@ -69,7 +69,7 @@ test_config() {
 }
 
 test_hexfile() {
-    if [ ! -f ${HEXFILE} ]; then
+    if [ ! -f "${HEXFILE}" ]; then
         echo "Error: Unable to locate HEXFILE"
         echo "       (${HEXFILE})"
         exit 1
@@ -77,7 +77,7 @@ test_hexfile() {
 }
 
 test_elffile() {
-    if [ ! -f ${ELFFILE} ]; then
+    if [ ! -f "${ELFFILE}" ]; then
         echo "Error: Unable to locate ELFFILE"
         echo "       (${ELFFILE})"
         exit 1
@@ -85,13 +85,13 @@ test_elffile() {
 }
 
 test_ports() {
-    if [ -z ${GDB_PORT} ]; then
+    if [ -z "${GDB_PORT}" ]; then
         GDB_PORT=${_GDB_PORT}
     fi
-    if [ -z ${TELNET_PORT} ]; then
+    if [ -z "${TELNET_PORT}" ]; then
         TELNET_PORT=${_TELNET_PORT}
     fi
-    if [ -z ${TCL_PORT} ]; then
+    if [ -z "${TCL_PORT}" ]; then
         TCL_PORT=${_TCL_PORT}
     fi
 }
@@ -109,7 +109,7 @@ do_flash() {
     test_config
     test_hexfile
     # flash device
-    ${OPENOCD} -f ${OPENOCD_CONFIG} \
+    ${OPENOCD} -f "${OPENOCD_CONFIG}" \
             ${OPENOCD_EXTRA_INIT} \
             -c "tcl_port 0" \
             -c "telnet_port 0" \
@@ -127,7 +127,7 @@ do_debug() {
     test_ports
     test_tui
     # start OpenOCD as GDB server
-    ${OPENOCD} -f ${OPENOCD_CONFIG} \
+    ${OPENOCD} -f "${OPENOCD_CONFIG}" \
             ${OPENOCD_EXTRA_INIT} \
             -c "tcl_port ${TCL_PORT}" \
             -c "telnet_port ${TELNET_PORT}" \
@@ -148,7 +148,7 @@ do_debugserver() {
     test_config
     test_ports
     # start OpenOCD as GDB server
-    ${OPENOCD} -f ${OPENOCD_CONFIG} \
+    ${OPENOCD} -f "${OPENOCD_CONFIG}" \
             ${OPENOCD_EXTRA_INIT} \
             -c "tcl_port ${TCL_PORT}" \
             -c "telnet_port ${TELNET_PORT}" \
@@ -161,7 +161,7 @@ do_debugserver() {
 do_reset() {
     test_config
     # start OpenOCD and invoke board reset
-    ${OPENOCD} -f ${OPENOCD_CONFIG} \
+    ${OPENOCD} -f "${OPENOCD_CONFIG}" \
             ${OPENOCD_EXTRA_INIT} \
             -c "tcl_port 0" \
             -c "telnet_port 0" \

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -38,6 +38,7 @@
 #
 #
 # @author       Hauke Peteresen <hauke.petersen@fu-berlin.de>
+# @author       Joakim Gebart <joakim.gebart@eistec.se>
 
 # default GDB port
 _GDB_PORT=3333
@@ -45,16 +46,19 @@ _GDB_PORT=3333
 _TELNET_PORT=4444
 # default TCL port
 _TCL_PORT=6333
-# path to OpenOCD configuration file
-CONFIG=${RIOTBOARD}/${BOARD}/dist/openocd.cfg
+# default path to OpenOCD configuration file
+_OPENOCD_CONFIG=${RIOTBOARD}/${BOARD}/dist/openocd.cfg
 
 #
 # a couple of tests for certain configuration options
 #
 test_config() {
-    if [ ! -f ${CONFIG} ]; then
+    if [ -z ${OPENOCD_CONFIG} ]; then
+        OPENOCD_CONFIG=${_OPENOCD_CONFIG}
+    fi
+    if [ ! -f ${OPENOCD_CONFIG} ]; then
         echo "Error: Unable to locate OpenOCD configuration file"
-        echo "       (${CONFIG})"
+        echo "       (${OPENOCD_CONFIG})"
         exit 1
     fi
 }
@@ -100,7 +104,8 @@ do_flash() {
     test_config
     test_hexfile
     # flash device
-    openocd -f ${CONFIG} \
+    openocd -f ${OPENOCD_CONFIG} \
+            ${OPENOCD_EXTRA_INIT} \
             -c "tcl_port 0" \
             -c "telnet_port 0" \
             -c "gdb_port 0" \
@@ -117,7 +122,8 @@ do_debug() {
     test_ports
     test_tui
     # start OpenOCD as GDB server
-    openocd -f ${CONFIG} \
+    openocd -f ${OPENOCD_CONFIG} \
+            ${OPENOCD_EXTRA_INIT} \
             -c "tcl_port ${TCL_PORT}" \
             -c "telnet_port ${TELNET_PORT}" \
             -c "gdb_port ${GDB_PORT}" \
@@ -137,7 +143,8 @@ do_debugserver() {
     test_config
     test_ports
     # start OpenOCD as GDB server
-    openocd -f ${CONFIG} \
+    openocd -f ${OPENOCD_CONFIG} \
+            ${OPENOCD_EXTRA_INIT} \
             -c "tcl_port ${TCL_PORT}" \
             -c "telnet_port ${TELNET_PORT}" \
             -c "gdb_port ${GDB_PORT}" \
@@ -149,7 +156,8 @@ do_debugserver() {
 do_reset() {
     test_config
     # start OpenOCD and invoke board reset
-    openocd -f ${CONFIG} \
+    openocd -f ${OPENOCD_CONFIG} \
+            ${OPENOCD_EXTRA_INIT} \
             -c "tcl_port 0" \
             -c "telnet_port 0" \
             -c "gdb_port 0" \
@@ -179,6 +187,6 @@ case "$1" in
     do_reset
     ;;
   *)
-    echo "Usage: $0 {flash|debug|debug-server|reset} [PARAM]"
+    echo "Usage: $0 {flash|debug|debug-server|reset}"
     ;;
 esac

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -48,11 +48,16 @@ _TELNET_PORT=4444
 _TCL_PORT=6333
 # default path to OpenOCD configuration file
 _OPENOCD_CONFIG=${RIOTBOARD}/${BOARD}/dist/openocd.cfg
+# default OpenOCD command
+_OPENOCD=openocd
 
 #
 # a couple of tests for certain configuration options
 #
 test_config() {
+    if [ -z ${OPENOCD} ]; then
+        OPENOCD=${_OPENOCD}
+    fi
     if [ -z ${OPENOCD_CONFIG} ]; then
         OPENOCD_CONFIG=${_OPENOCD_CONFIG}
     fi
@@ -104,7 +109,7 @@ do_flash() {
     test_config
     test_hexfile
     # flash device
-    openocd -f ${OPENOCD_CONFIG} \
+    ${OPENOCD} -f ${OPENOCD_CONFIG} \
             ${OPENOCD_EXTRA_INIT} \
             -c "tcl_port 0" \
             -c "telnet_port 0" \
@@ -122,7 +127,7 @@ do_debug() {
     test_ports
     test_tui
     # start OpenOCD as GDB server
-    openocd -f ${OPENOCD_CONFIG} \
+    ${OPENOCD} -f ${OPENOCD_CONFIG} \
             ${OPENOCD_EXTRA_INIT} \
             -c "tcl_port ${TCL_PORT}" \
             -c "telnet_port ${TELNET_PORT}" \
@@ -143,7 +148,7 @@ do_debugserver() {
     test_config
     test_ports
     # start OpenOCD as GDB server
-    openocd -f ${OPENOCD_CONFIG} \
+    ${OPENOCD} -f ${OPENOCD_CONFIG} \
             ${OPENOCD_EXTRA_INIT} \
             -c "tcl_port ${TCL_PORT}" \
             -c "telnet_port ${TELNET_PORT}" \
@@ -156,7 +161,7 @@ do_debugserver() {
 do_reset() {
     test_config
     # start OpenOCD and invoke board reset
-    openocd -f ${OPENOCD_CONFIG} \
+    ${OPENOCD} -f ${OPENOCD_CONFIG} \
             ${OPENOCD_EXTRA_INIT} \
             -c "tcl_port 0" \
             -c "telnet_port 0" \


### PR DESCRIPTION
 - OpenOCD configuration file name overridable via environment variable OPENOCD_CONFIG.
 - Extra OpenOCD commands can be passed via OPENOCD_EXTRA_INIT
 - Quote all file name environment variables when using them
 - OpenOCD command name can be overridden via OPENOCD env var.

Background/use case:
I need to be able to choose between two different configs depending on which programmer version is connected, this is because of changes to the SRST hardware on the programming board. I also want to be able to add `-c 'ftdi_serial $myserialnumber'` to the OpenOCD command line to pick the correct programmer device depending on serial number when more than one programmer is connected.