### PR TITLE
microcoap: remove trailing whitespaces

### DIFF
--- a/pkg/microcoap/0003-change-flag-from-DEBUG-to-MICROCOAP_DEBUG.patch
+++ b/pkg/microcoap/0003-change-flag-from-DEBUG-to-MICROCOAP_DEBUG.patch
@@ -58,13 +58,13 @@ index c132334..4a7adc5 100644
  ///////////////////////
 +#ifdef MICROCOAP_DEBUG
  void coap_dumpPacket(coap_packet_t *pkt);
-+#else 
++#else
 +#define coap_dumpPacket(pkt)
 +#endif
 +
 +#ifdef MICROCOAP_DEBUG
 +void coap_dump(const uint8_t *buf, size_t buflen, bool bare);
-+#else 
++#else
 +#define coap_dump(buf, buflen, bare)
 +#endif
 +


### PR DESCRIPTION
Remove trailing whitespaces in the third patch to get rid of this warning:

    /home/lotte/riot/RIOT/pkg/microcoap/microcoap/.git/rebase-apply/patch:56: trailing whitespace.
    #else
    /home/lotte/riot/RIOT/pkg/microcoap/microcoap/.git/rebase-apply/patch:62: trailing whitespace.
    #else