### PR TITLE
cpu, drivers, boards, tests: remove trailing whitespace

### DIFF
--- a/boards/msba2-common/include/msba2_common.h
+++ b/boards/msba2-common/include/msba2_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Kaspar Schleiser <kaspar@schleiser.de> 
+ * Copyright 2014 Kaspar Schleiser <kaspar@schleiser.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -30,7 +30,7 @@
  *
  * Given threads with priorities A=6, B=1, and C=3, B has the highest
  * priority.
- * 
+ *
  * A higher priority means that the scheduler will run this thread
  * whenever it becomes runnable instead of a thread with a lower
  * priority.

--- a/cpu/kinetis_common/i2c.c
+++ b/cpu/kinetis_common/i2c.c
@@ -113,16 +113,16 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
     i2c_port->PCR[pin_scl] = I2C_0_PORT_CFG;
     i2c_port->PCR[pin_sda] = I2C_0_PORT_CFG;
 
-    /* 
-    * TODO: Add baud rate selection function
-    * See the Chapter "I2C divider and hold values":
-    *     Kinetis K60 Reference Manual, section 51.4.1.10, Table 51-41. 
-    *     Kinetis MKW2x  Reference Manual, section 52.4.1.10, Table 52-41. 
-    *
-    * baud rate = I2C_module_clock / (mul × ICR)
-    *
-    * The assignment below will set baud rate to I2C_module_clock / (240 x 2).
-    */
+    /*
+     * TODO: Add baud rate selection function
+     * See the Chapter "I2C divider and hold values":
+     *     Kinetis K60 Reference Manual, section 51.4.1.10, Table 51-41.
+     *     Kinetis MKW2x  Reference Manual, section 52.4.1.10, Table 52-41.
+     *
+     * baud rate = I2C_module_clock / (mul × ICR)
+     *
+     * The assignment below will set baud rate to I2C_module_clock / (240 x 2).
+     */
     i2c->F = I2C_F_MULT(1) | I2C_F_ICR(0x1f);
 
     /* enable i2c-module and interrupt */

--- a/cpu/kinetis_common/include/wdog.h
+++ b/cpu/kinetis_common/include/wdog.h
@@ -19,11 +19,11 @@
  *
  *              ### WDOG Configuration Example (for periph_conf.h) ###
  *              The driver attempts to determine the type of the WDOG.
- *              Also you can force the use of advanced WDOG: 
+ *              Also you can force the use of advanced WDOG:
  *
  *                  #define KINETIS_WDOG_ADVANCED    1
  *
- *              Or the use of COP WDOG: 
+ *              Or the use of COP WDOG:
  *
  *                  #define KINETIS_WDOG_ADVANCED    0
  *

--- a/cpu/samd21/periph/i2c.c
+++ b/cpu/samd21/periph/i2c.c
@@ -93,22 +93,22 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
     }
     /* DISABLE I2C MASTER */
     i2c_poweroff(dev);
-    
+
     /*Reset I2C */
     I2CSercom->CTRLA.reg = SERCOM_I2CS_CTRLA_SWRST;
     while(I2CSercom->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK);
-    
+
     /* Turn on power manager for sercom */
     PM->APBCMASK.reg |= (PM_APBCMASK_SERCOM0 << (sercom_core - 20));
 
     /*I2C using CLK GEN 0*/
-    GCLK->CLKCTRL.reg = (uint32_t)(GCLK_CLKCTRL_CLKEN 
-                                   | GCLK_CLKCTRL_GEN_GCLK0 << GCLK_CLKCTRL_GEN_Pos 
+    GCLK->CLKCTRL.reg = (uint32_t)(GCLK_CLKCTRL_CLKEN
+                                   | GCLK_CLKCTRL_GEN_GCLK0 << GCLK_CLKCTRL_GEN_Pos
                                    | (sercom_core << GCLK_CLKCTRL_ID_Pos));
     while (GCLK->STATUS.bit.SYNCBUSY);
 
-    GCLK->CLKCTRL.reg = (uint16_t)(GCLK_CLKCTRL_CLKEN 
-                                   | GCLK_CLKCTRL_GEN_GCLK0 << GCLK_CLKCTRL_GEN_Pos  
+    GCLK->CLKCTRL.reg = (uint16_t)(GCLK_CLKCTRL_CLKEN
+                                   | GCLK_CLKCTRL_GEN_GCLK0 << GCLK_CLKCTRL_GEN_Pos
                                    | (sercom_gclk_id_slow << GCLK_CLKCTRL_ID_Pos));
     while (GCLK->STATUS.bit.SYNCBUSY);
 
@@ -123,12 +123,12 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
         DEBUG("STATUS_BUSY\n");
         return -3;
     }
-    
+
     /************ SERCOM PAD0 - SDA and SERCOM PAD1 - SCL  ************/
     /* DIR + INEN at one: in/out pin. DIRSET modifies DIR in order to set I2C SDA/SCL on output*/
     port_group->DIRSET.reg = (1 << pin_scl);
     port_group->DIRSET.reg = (1 << pin_sda);
-    
+
     /* The Write Configuration register (WRCONFIG) requires the
      * pins to to grouped into two 16-bit half-words (PIN are set up to 31)*/
     uint32_t lower_pin_mask = (i2c_pins & 0xFFFF);
@@ -141,7 +141,7 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
         | PORT_WRCONFIG_INEN \
         | PORT_WRCONFIG_WRPMUX \
         | PORT_WRCONFIG_WRPINCFG;
-    
+
     port_group->WRCONFIG.reg =
           (upper_pin_mask << PORT_WRCONFIG_PINMASK_Pos) \
         | PORT_WRCONFIG_PMUXEN \
@@ -150,8 +150,8 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
         | PORT_WRCONFIG_WRPMUX \
         | PORT_WRCONFIG_WRPINCFG \
         | PORT_WRCONFIG_HWSEL;
-    
-    
+
+
     /* I2C CONFIGURATION */
     while(I2CSercom->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK);
 
@@ -160,8 +160,8 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
 
     /* Enable Smart Mode (ACK is sent when DATA.DATA is read) */
     I2CSercom->CTRLB.reg = SERCOM_I2CM_CTRLB_SMEN;
-    
-    /* Find and set baudrate. Read speed configuration. Set transfer speed: 
+
+    /* Find and set baudrate. Read speed configuration. Set transfer speed:
     * SERCOM_I2CM_CTRLA_SPEED(0): Standard-mode (Sm) up to 100 kHz and Fast-mode (Fm) up to 400 kHz*/
     switch (speed) {
         case I2C_SPEED_NORMAL:
@@ -189,10 +189,10 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
             DEBUG("BAD BAUDRATE\n");
             return -2;
     }
-    
+
     /* ENABLE I2C MASTER */
     i2c_poweron(dev);
-    
+
     /* Start timeout if bus state is unknown. */
     while (!(I2CSercom->STATUS.reg & SERCOM_I2CM_STATUS_BUSSTATE(1))) {
         if(timeout_counter++ >= SAMD21_I2C_TIMEOUT) {
@@ -233,9 +233,9 @@ int i2c_read_byte(i2c_t dev, uint8_t address, char *data)
 }
 
 int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
-{ 
+{
     SercomI2cm *i2c;
-    
+
     switch (dev) {
 #if I2C_0_EN
         case I2C_0:
@@ -289,7 +289,7 @@ int i2c_write_byte(i2c_t dev, uint8_t address, char data)
 int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
 {
     SercomI2cm *I2CSercom;
-    
+
     switch (dev) {
 #if I2C_0_EN
         case I2C_0:
@@ -299,7 +299,7 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
         default:
             return -1;
     }
-    
+
     _start(I2CSercom, address, I2C_FLAG_WRITE);
     _write(I2CSercom, data, length);
     _stop(I2CSercom);
@@ -372,10 +372,10 @@ static void _start(SercomI2cm *dev, uint8_t address, uint8_t rw_flag)
     /*Wait for hardware module to sync*/
     DEBUG("Wait for device to be ready\n");
     while(dev->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK);
-    
+
     /* Set action to ACK. */
     dev->CTRLB.reg &= ~SERCOM_I2CM_CTRLB_ACKACT;
-    
+
     /* Send Start | Address | Write/Read   */
     DEBUG("Generate start condition by sending address\n");
     dev->ADDR.reg = (address << 1) | rw_flag | (0 << SERCOM_I2CM_ADDR_HS_Pos);
@@ -414,7 +414,7 @@ static inline void _write(SercomI2cm *dev, char *data, int length)
     uint16_t tmp_data_length = length;
     uint32_t timeout_counter = 0;
     uint16_t buffer_counter = 0;
-    
+
     /* Write data buffer until the end. */
     DEBUG("Looping through bytes\n");
     while (tmp_data_length--) {
@@ -426,12 +426,12 @@ static inline void _write(SercomI2cm *dev, char *data, int length)
 
         /*Wait for hardware module to sync*/
         while(dev->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK);
-        
+
         DEBUG("Written %i byte to data reg, now waiting for DR to be empty again\n", buffer_counter);
         dev->DATA.reg = data[buffer_counter++];
 
         DEBUG("Wait for response.\n");
-        while (!(dev->INTFLAG.reg & SERCOM_I2CM_INTFLAG_MB) 
+        while (!(dev->INTFLAG.reg & SERCOM_I2CM_INTFLAG_MB)
                && !(dev->INTFLAG.reg & SERCOM_I2CM_INTFLAG_SB)) {
             if (++timeout_counter >= SAMD21_I2C_TIMEOUT) {
                 DEBUG("STATUS_ERR_TIMEOUT\n");
@@ -467,10 +467,10 @@ static inline void _read(SercomI2cm *dev, char *data, int length)
         while(dev->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK);
         /* Save data to buffer. */
         data[count] = dev->DATA.reg;
-        
+
         /* Wait for response. */
         timeout_counter = 0;
-        while (!(dev->INTFLAG.reg & SERCOM_I2CM_INTFLAG_MB) 
+        while (!(dev->INTFLAG.reg & SERCOM_I2CM_INTFLAG_MB)
                && !(dev->INTFLAG.reg & SERCOM_I2CM_INTFLAG_SB)) {
             if (++timeout_counter >= SAMD21_I2C_TIMEOUT) {
                 DEBUG("STATUS_ERR_TIMEOUT\n");

--- a/cpu/samd21/periph/timer.c
+++ b/cpu/samd21/periph/timer.c
@@ -333,7 +333,7 @@ void TIMER_0_ISR(void)
         if(config[TIMER_0].cb) {
             TIMER_0_DEV.INTFLAG.bit.MC0 = 1;
             TIMER_0_DEV.INTENCLR.reg = TC_INTENCLR_MC0;
-            config[TIMER_0].cb(0);            
+            config[TIMER_0].cb(0);
         }
     }
     else if (TIMER_0_DEV.INTFLAG.bit.MC1 && TIMER_0_DEV.INTENSET.bit.MC1) {

--- a/cpu/stm32f4/periph/dac.c
+++ b/cpu/stm32f4/periph/dac.c
@@ -99,7 +99,7 @@ int8_t dac_write(dac_t dev, uint8_t channel, uint16_t value)
             /* Value out of Range */
             return -3;
         }
-        
+
         switch(channel){
             case 0:
                 dac->DHR12R1 = val;

--- a/drivers/hdc1000/hdc1000.c
+++ b/drivers/hdc1000/hdc1000.c
@@ -78,7 +78,7 @@ int hdc1000_test(hdc1000_t *dev)
     if (tmp != HDC1000_MID_VALUE) {
         return -1;
     }
-    
+
     return 0;
 }
 
@@ -173,7 +173,7 @@ int hdc1000_read(hdc1000_t *dev, uint16_t *rawtemp, uint16_t *rawhum)
     /* Register bytes are sent MSB first. */
     *rawtemp = ((uint16_t)buf[0] << 8) | buf[1];
     *rawhum = ((uint16_t)buf[2] << 8) | buf[3];
-  
+
     i2c_release(dev->i2c);
     return 0;
 }

--- a/drivers/include/mag3110.h
+++ b/drivers/include/mag3110.h
@@ -12,11 +12,11 @@
  * @brief       Driver for the Freescale MAG3110 magnetometer.
  *              After initialization and set activ the magnetometer
  *              will make measurements at periodic times.
- *              The output rate and over sample ratio 
+ *              The output rate and over sample ratio
  *              can be determined by magnetometer initialization.
  *              The measured values of magnetic field strength and
  *              die temperature have uncalibrated offsets.
- *              To get correct measuremend values, the individual 
+ *              To get correct measuremend values, the individual
  *              offsets must be measured and set accordingly.
  *
  * @{
@@ -152,8 +152,8 @@ int mag3110_set_standby(mag3110_t *dev);
  *
  * @param[in]  dev          device descriptor of magnetometer
  *
- * @return                  >0 if x-, y- and z-axis new sample is ready 
- * @return                  0 if measurement is in progress 
+ * @return                  >0 if x-, y- and z-axis new sample is ready
+ * @return                  0 if measurement is in progress
  * @return                  -1 on error
  */
 int mag3110_is_ready(mag3110_t *dev);
@@ -178,7 +178,7 @@ int mag3110_read(mag3110_t *dev, int16_t *x, int16_t *y, int16_t *z, uint8_t *st
  * @brief Read die temperature.
  *
  * @param[in]  dev          device descriptor of magnetometer
- * @param[out] dtemp        die temperature 
+ * @param[out] dtemp        die temperature
  *
  * @return                  0 on success
  * @return                  -1 on error

--- a/drivers/include/mpl3115a2.h
+++ b/drivers/include/mpl3115a2.h
@@ -10,7 +10,7 @@
  * @defgroup    drivers_mpl3115a2 MPL3115A2 Pressure Sensor
  * @ingroup     drivers
  * @brief       Driver for the Freescale MPL3115A2 pressure sensor.
- *              The driver will initialize the sensor for 
+ *              The driver will initialize the sensor for
  *              pressure measurement. The conversion duration
  *              depends on oversample ratio.
  *              After initialization and set activ the sensor

--- a/drivers/include/periph/dac.h
+++ b/drivers/include/periph/dac.h
@@ -67,7 +67,7 @@ typedef enum {
 /**
  * @brief Initialization of a given DAC device
  *
- * The DAC will be initialized with all possilble channels active. 
+ * The DAC will be initialized with all possilble channels active.
  * On each channel will be initialized with a Zero on it.
  *
  * @param[in] dev          the device to initialize
@@ -83,19 +83,19 @@ int8_t dac_init(dac_t dev, dac_precision_t precision);
  * @brief Write a value onto DAC Device on a given Channel.
  *
  * @param[in] dev          the DAC device to use
- * @param[in] channel      the channel used for Digital/Analoge conversion 
- * @param[in] value        the value to write onto DAC. 
- * 
+ * @param[in] channel      the channel used for Digital/Analoge conversion
+ * @param[in] value        the value to write onto DAC.
+ *
  * @return                 0 on success
  * @return                 -1 on unknown DAC Device
- * @return                 -2 on invalid channel 
- * @return                 -3 if value is out of range. 
+ * @return                 -2 on invalid channel
+ * @return                 -3 if value is out of range.
  */
 int8_t dac_write(dac_t dev, uint8_t channel, uint16_t value);
 
 /**
  * @brief Enable power for the given DAC Device
- * 
+ *
  * @param[in] dev          the DAC device to power up.
  *
  * @return                 0 on success
@@ -107,7 +107,7 @@ int8_t dac_poweron(dac_t dev);
  * @brief Disable power for the given DAC Device
  *
  * @param[in] dev          the DAC device to power down
- * 
+ *
  * @return                 0 on success
  * @return                 -1 on unknown DAC Device
  */
@@ -115,10 +115,10 @@ int8_t dac_poweroff(dac_t dev);
 
 /**
  * @brief Helper function to map a given integer range to a valid DAC value.
- * 
+ *
  * This function is useful for converting ranges of values to a valid DAC output value.
  *
- * The min value is assumed to be smaller than max value and value is assumed 
+ * The min value is assumed to be smaller than max value and value is assumed
  * to be between min and max.
  *
  * @param[in] dev          the DAC Device to read precision value from
@@ -132,19 +132,19 @@ uint16_t dac_map(dac_t dev, int value, int min, int max);
 
 /**
  * @brief Helper function to map a given float value range to a valid DAC value.
- * 
+ *
  * @see dac_map
  *
  * @param[in] dev          the DAC Device to read precision value from
  * @param[in] value        the value to map onto min and max
  * @param[in] min          the lower bound of the target interval
  * @param[in] max          the upper bound of the target interval
- * 
+ *
  * @return                 the mapped value, in valid DAC range
  */
 uint16_t dac_mapf(dac_t dev, float value, float min, float max);
 
-#endif/* DAC_NUMOF */ 
+#endif/* DAC_NUMOF */
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/srf08.h
+++ b/drivers/include/srf08.h
@@ -119,7 +119,7 @@ int srf08_set_max_range(srf08_t *dev, uint8_t max_range);
  * @brief       Set the maximum of the analog stages.
  *
  * @ note
- * This value is just a limitation of the maximum amplification and not the actual. 
+ * This value is just a limitation of the maximum amplification and not the actual.
  * While measuing, this value starts at its minimum and increases approx. each 75 us
  * until the maximum value is reached.
  *

--- a/drivers/nrf24l01p/include/nrf24l01p_settings.h
+++ b/drivers/nrf24l01p/include/nrf24l01p_settings.h
@@ -37,9 +37,9 @@ extern "C" {
 #define DELAY_CHANGE_PWR_MODE_US            HWTIMER_TICKS(1500)
 #define DELAY_CHANGE_TXRX_US                HWTIMER_TICKS(130)
 #define DELAY_CE_START_US                   HWTIMER_TICKS(5)
-/* 
+/*
  * This is the time which is needed to physically transmit the data.
- * Compare nrf24l01+ pruduct specification p.42. It is computed just 
+ * Compare nrf24l01+ pruduct specification p.42. It is computed just
  * for this setup
  */
 #define DELAY_DATA_ON_AIR                   HWTIMER_TICKS(1300)

--- a/tests/unittests/tests-ubjson/tests-ubjson.c
+++ b/tests/unittests/tests-ubjson/tests-ubjson.c
@@ -90,7 +90,7 @@ void test_ubjson_test(void (*sender_fun)(void), void (*receiver_fun)(void))
                                               PRIORITY_MAIN, CREATE_WOUT_YIELD,
                                               test_ubjson_receiver_trampoline, &data, "receiver");
     TEST_ASSERT(pid_is_valid(receiver_pid));
-    
+
     sender_fun();
 
     mutex_lock(&data.mutexes[0]);


### PR DESCRIPTION
Also contains some comment reformatting on the go.