### PR TITLE
Initial import of csma_mac protocol

### DIFF
--- a/boards/pba-d-01-kw2x/Makefile.dep
+++ b/boards/pba-d-01-kw2x/Makefile.dep
@@ -1,4 +1,4 @@
 ifneq (,$(filter ng_netif_default,$(USEMODULE)))
   USEMODULE += kw2xrf
-  USEMODULE += ng_nomac
+  USEMODULE += ng_csma_mac
 endif

--- a/drivers/include/kw2xrf.h
+++ b/drivers/include/kw2xrf.h
@@ -86,17 +86,18 @@ extern "C" {
  * @brief   Internal device option flags
  * @{
  */
-#define KW2XRF_OPT_AUTOACK       (0x0001)  /**< auto ACKs active */
-#define KW2XRF_OPT_CSMA          (0x0002)  /**< CSMA active */
-#define KW2XRF_OPT_PROMISCUOUS   (0x0004)  /**< promiscuous mode active */
-#define KW2XRF_OPT_PRELOADING    (0x0008)  /**< preloading enabled */
-#define KW2XRF_OPT_TELL_TX_START (0x0010)  /**< notify MAC layer on TX start */
-#define KW2XRF_OPT_TELL_TX_END   (0x0020)  /**< notify MAC layer on TX finished */
-#define KW2XRF_OPT_TELL_RX_START (0x0040)  /**< notify MAC layer on RX start */
-#define KW2XRF_OPT_TELL_RX_END   (0x0080)  /**< notify MAC layer on RX finished */
-#define KW2XRF_OPT_RAWDUMP       (0x0100)  /**< pass RAW frame data to upper layer */
-#define KW2XRF_OPT_SRC_ADDR_LONG (0x0200)  /**< send data using long source address */
-#define KW2XRF_OPT_USE_SRC_PAN   (0x0400)  /**< do not compress source PAN ID */
+#define KW2XRF_OPT_AUTOACK        (0x0001)  /**< auto ACKs active */
+#define KW2XRF_OPT_CSMA           (0x0002)  /**< CSMA active */
+#define KW2XRF_OPT_PROMISCUOUS    (0x0004)  /**< promiscuous mode active */
+#define KW2XRF_OPT_PRELOADING     (0x0008)  /**< preloading enabled */
+#define KW2XRF_OPT_TELL_TX_START  (0x0010)  /**< notify MAC layer on TX start */
+#define KW2XRF_OPT_TELL_TX_END    (0x0020)  /**< notify MAC layer on TX finished */
+#define KW2XRF_OPT_TELL_RX_START  (0x0040)  /**< notify MAC layer on RX start */
+#define KW2XRF_OPT_TELL_RX_END    (0x0080)  /**< notify MAC layer on RX finished */
+#define KW2XRF_OPT_RAWDUMP        (0x0100)  /**< pass RAW frame data to upper layer */
+#define KW2XRF_OPT_SRC_ADDR_LONG  (0x0200)  /**< send data using long source address */
+#define KW2XRF_OPT_USE_SRC_PAN    (0x0400)  /**< do not compress source PAN ID */
+#define KW2XRF_OPT_CURR_PKT_BCAST (0x0800)  /**< current pkt is a bcast paket */
 /** @} */
 
 /**

--- a/drivers/kw2xrf/include/kw2xrf_reg.h
+++ b/drivers/kw2xrf/include/kw2xrf_reg.h
@@ -130,7 +130,7 @@ enum mkw2xdrf_dregister {
 #define MKW2XDM_PHY_CTRL1_CCABFRTX                  (1 << 5)
 #define MKW2XDM_PHY_CTRL1_RXACKRQD                  (1 << 4)
 #define MKW2XDM_PHY_CTRL1_AUTOACK                   (1 << 3)
-#define MKW2XDM_PHY_CTRL1_XCVSEQ_MASK               0x03u
+#define MKW2XDM_PHY_CTRL1_XCVSEQ_MASK               0x07u
 #define MKW2XDM_PHY_CTRL1_XCVSEQ(x)                 (((uint8_t)(((uint8_t)(x))<<0))&MKW2XDM_PHY_CTRL1_XCVSEQ_MASK)
 
 #define MKW2XDM_PHY_CTRL2_CRC_MSK                   (1 << 7)

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -27,7 +27,7 @@
 #include "net/ng_netbase.h"
 #include "net/ng_ieee802154.h"
 
-#define ENABLE_DEBUG    (0)
+#define ENABLE_DEBUG    (1)
 #include "debug.h"
 
 /**
@@ -216,14 +216,15 @@ void kw2xrf_set_sequence(kw2xrf_t *dev, kw2xrf_physeq_t seq)
     /* TODO: This should only used in combination with
      *       an CSMA-MAC layer. Currently not working
      */
-    /*if((seq == XCVSEQ_TRANSMIT) || (seq == XCVSEQ_TX_RX)) {
-        if((dev->option) & KW2XRF_OPT_AUTOACK) {
+    if((seq == XCVSEQ_TRANSMIT) || (seq == XCVSEQ_TX_RX)) {
+        if (((dev->option) & KW2XRF_OPT_AUTOACK)
+        && !((dev->option) & KW2XRF_OPT_CURR_PKT_BCAST)) {
             seq = XCVSEQ_TX_RX;
         }
         else {
             seq = XCVSEQ_TRANSMIT;
         }
-    }*/
+    }
 
     DEBUG("kw2xrf: Set sequence to %i\n", seq);
     reg = kw2xrf_read_dreg(MKW2XDM_PHY_CTRL1);
@@ -649,6 +650,7 @@ void kw2xrf_set_option(kw2xrf_t *dev, uint16_t option, bool state)
                 DEBUG("[kw2xrf] opt: enabling auto ACKs\n");
                 reg = kw2xrf_read_dreg(MKW2XDM_PHY_CTRL1);
                 reg |= MKW2XDM_PHY_CTRL1_AUTOACK;
+                reg |= MKW2XDM_PHY_CTRL1_RXACKRQD;
                 kw2xrf_write_dreg(MKW2XDM_PHY_CTRL1, reg);
                 break;
 
@@ -686,6 +688,7 @@ void kw2xrf_set_option(kw2xrf_t *dev, uint16_t option, bool state)
             case KW2XRF_OPT_AUTOACK:
                 reg = kw2xrf_read_dreg(MKW2XDM_PHY_CTRL1);
                 reg &= ~(MKW2XDM_PHY_CTRL1_AUTOACK);
+                reg &= ~(MKW2XDM_PHY_CTRL1_RXACKRQD);
                 kw2xrf_write_dreg(MKW2XDM_PHY_CTRL1, reg);
                 break;
 
@@ -782,6 +785,16 @@ int kw2xrf_set(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value, size_t va
 
         case NETCONF_OPT_AUTOCCA:
             kw2xrf_set_option(dev, KW2XRF_OPT_CSMA,
+                              ((bool *)value)[0]);
+            return sizeof(ng_netconf_enable_t);
+
+        case NETCONF_OPT_RX_END_IRQ:
+            kw2xrf_set_option(dev, KW2XRF_OPT_TELL_RX_END,
+                              ((bool *)value)[0]);
+            return sizeof(ng_netconf_enable_t);
+
+        case NETCONF_OPT_TX_END_IRQ:
+            kw2xrf_set_option(dev, KW2XRF_OPT_TELL_TX_END,
                               ((bool *)value)[0]);
             return sizeof(ng_netconf_enable_t);
 
@@ -954,7 +967,7 @@ void _receive_data(kw2xrf_t *dev)
         }
 
         payload->data = dev->buf;
-        dev->event_cb(NETDEV_EVENT_RX_COMPLETE, payload);
+        dev->event_cb((ng_netdev_t*)dev, NETDEV_EVENT_RX_COMPLETE, payload);
         return;
     }
 
@@ -993,7 +1006,7 @@ void _receive_data(kw2xrf_t *dev)
         return;
     }
 
-    dev->event_cb(NETDEV_EVENT_RX_COMPLETE, payload);
+    dev->event_cb((ng_netdev_t*)dev, NETDEV_EVENT_RX_COMPLETE, payload);
 }
 
 void kw2xrf_isr_event(ng_netdev_t *netdev, uint32_t event_type)
@@ -1005,13 +1018,18 @@ void kw2xrf_isr_event(ng_netdev_t *netdev, uint32_t event_type)
     if ((irqst1 & MKW2XDM_IRQSTS1_RXIRQ) && (irqst1 & MKW2XDM_IRQSTS1_SEQIRQ)) {
         /* RX */
         DEBUG("kw2xrf: RX Int\n");
-        _receive_data(dev);
+        if (dev->option & KW2XRF_OPT_TELL_RX_END) {
+            _receive_data(dev);
+        }
         kw2xrf_set_sequence(dev, XCVSEQ_RECEIVE);
         kw2xrf_write_dreg(MKW2XDM_IRQSTS1, MKW2XDM_IRQSTS1_RXIRQ | MKW2XDM_IRQSTS1_SEQIRQ);
     }
     else if ((irqst1 & MKW2XDM_IRQSTS1_TXIRQ) && (irqst1 & MKW2XDM_IRQSTS1_SEQIRQ)) {
         /* TX_Complete */
-        /* Device is automatically in Radio-idle state when TX is done */
+        DEBUG("kw2xrf: TX Complete\n");
+        if (dev->event_cb && (dev->option & KW2XRF_OPT_TELL_TX_END)) {
+            dev->event_cb(netdev, NETDEV_EVENT_TX_COMPLETE, NULL);
+        }
         kw2xrf_set_sequence(dev, XCVSEQ_RECEIVE);
         DEBUG("kw2xrf: TX Complete\n");
         kw2xrf_write_dreg(MKW2XDM_IRQSTS1, MKW2XDM_IRQSTS1_TXIRQ | MKW2XDM_IRQSTS1_SEQIRQ);
@@ -1020,9 +1038,15 @@ void kw2xrf_isr_event(ng_netdev_t *netdev, uint32_t event_type)
         /* TX_Started (CCA_done) */
         if (irqst2 & MKW2XDM_IRQSTS2_CCA) {
             DEBUG("kw2xrf: CCA done -> Channel busy\n");
+            if (dev->event_cb && (dev->option & KW2XRF_OPT_TELL_TX_END)) {
+                dev->event_cb(netdev, NETDEV_EVENT_CCA_CHANNEL_BUSY, NULL);
+            }
         }
         else {
             DEBUG("kw2xrf: CCA done -> Channel idle\n");
+            if (dev->event_cb && (dev->option & KW2XRF_OPT_TELL_TX_END)) {
+                dev->event_cb(netdev, NETDEV_EVENT_CCA_CHANNEL_IDLE, NULL);
+            }
         }
 
         kw2xrf_write_dreg(MKW2XDM_IRQSTS1, MKW2XDM_IRQSTS1_CCAIRQ | MKW2XDM_IRQSTS1_SEQIRQ);
@@ -1056,17 +1080,12 @@ int _assemble_tx_buf(kw2xrf_t *dev, ng_pktsnip_t *pkt)
     hdr = (ng_netif_hdr_t *)pkt->data;
 
     /* FCF, set up data frame, request for ack, panid_compression */
-    /* TODO: Currently we don´t request for Ack in this device.
-     * since this is a soft_mac device this has to be
-     * handled in a upcoming CSMA-MAC layer.
-     */
-    /*if(dev->option & KW2XRF_OPT_AUTOACK) {
+    if(dev->option & KW2XRF_OPT_AUTOACK) {
         dev->buf[1] = 0x61;
     }
     else {
         dev->buf[1] = 0x51;
-    }*/
-    dev->buf[1] = 0x51;
+    }
 
     /* set sequence number */
     dev->buf[3] = dev->seq_nr++;
@@ -1080,6 +1099,7 @@ int _assemble_tx_buf(kw2xrf_t *dev, ng_pktsnip_t *pkt)
     /* fill in destination address */
     if (hdr->flags &
         (NG_NETIF_HDR_FLAGS_BROADCAST | NG_NETIF_HDR_FLAGS_MULTICAST)) {
+        dev->option |= KW2XRF_OPT_CURR_PKT_BCAST;
         dev->buf[2] = 0x88;
         dev->buf[index++] = 0xff;
         dev->buf[index++] = 0xff;
@@ -1088,6 +1108,7 @@ int _assemble_tx_buf(kw2xrf_t *dev, ng_pktsnip_t *pkt)
         dev->buf[index++] = (uint8_t)(dev->addr_short[1]);
     }
     else if (hdr->dst_l2addr_len == 2) {
+        dev->option &= ~(KW2XRF_OPT_CURR_PKT_BCAST);
         /* set to short addressing mode */
         dev->buf[2] = 0x88;
         /* set destination address, byte order is inverted */
@@ -1101,6 +1122,7 @@ int _assemble_tx_buf(kw2xrf_t *dev, ng_pktsnip_t *pkt)
         dev->buf[index++] = (uint8_t)(dev->addr_short[1]);
     }
     else if (hdr->dst_l2addr_len == 8) {
+        dev->option &= ~(KW2XRF_OPT_CURR_PKT_BCAST);
         /* default to use long address mode for src and dst */
         dev->buf[2] |= 0xcc;
         /* set destination address located directly after ng_ifhrd_t in memory */

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -16,6 +16,9 @@ endif
 ifneq (,$(filter nomac,$(USEMODULE)))
     DIRS += net/link_layer/nomac
 endif
+ifneq (,$(filter ng_csma_mac,$(USEMODULE)))
+    DIRS += net/link_layer/ng_csma_mac
+endif
 ifneq (,$(filter transport_layer,$(USEMODULE)))
     USEMODULE += udp
     USEMODULE += tcp

--- a/sys/auto_init/netif/auto_init_kw2xrf.c
+++ b/sys/auto_init/netif/auto_init_kw2xrf.c
@@ -22,9 +22,16 @@
 #ifdef MODULE_KW2XRF
 
 #include "board.h"
-#include "net/ng_nomac.h"
-#include "net/ng_netbase.h"
 
+#ifdef MODULE_NG_NOMAC
+#include "net/ng_nomac.h"
+#endif /* MODULE_NG_NOMAC */
+
+#ifdef MODULE_NG_CSMA_MAC
+#include "net/ng_csma_mac.h"
+#endif /* MODULE_NG_CSMA_MAC */
+
+#include "net/ng_netbase.h"
 #include "kw2xrf.h"
 #include "kw2xrf_params.h"
 
@@ -41,7 +48,7 @@
 #define KW2XRF_NUM (sizeof(kw2xrf_params)/sizeof(kw2xrf_params[0]))
 
 static kw2xrf_t kw2xrf_devs[KW2XRF_NUM];
-static char _nomac_stacks[KW2XRF_MAC_STACKSIZE][KW2XRF_NUM];
+static char _mac_stacks[KW2XRF_MAC_STACKSIZE][KW2XRF_NUM];
 
 void auto_init_kw2xrf(void)
 {
@@ -59,14 +66,21 @@ void auto_init_kw2xrf(void)
             DEBUG("Error initializing KW2xrf radio device!");
         }
         else {
-            ng_nomac_init(_nomac_stacks[i],
+#ifdef MODULE_NG_NOMAC
+            ng_nomac_init(_mac_stacks[i],
                     KW2XRF_MAC_STACKSIZE, KW2XRF_MAC_PRIO,
                     "kw2xrf", (ng_netdev_t *)&kw2xrf_devs[i]);
+#endif /* MODULE_NG_NOMAC */
+#ifdef MODULE_NG_CSMA_MAC
+            csma_mac_init(_mac_stacks[i],
+                    KW2XRF_MAC_STACKSIZE, KW2XRF_MAC_PRIO,
+                    "kw2xrf", (ng_netdev_t *)&kw2xrf_devs[i]);
+#endif /* MODULE_NG_CSMA_MAC */
         }
     }
 }
 #else
 typedef int dont_be_pedantic;
-#endif /* MODULE_NG_KW2XRF */
+#endif /* MODULE_KW2XRF */
 
 /** @} */

--- a/sys/include/net/ng_csma_mac.h
+++ b/sys/include/net/ng_csma_mac.h
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_csma_mac basic CSMA MAC layer
+ * @ingroup     net
+ * @brief       Basic CSMA MAC protocol that sends in unslotted CSMA Mode
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for the CSMA MAC layer
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Jonas Remmert <j.remmert@phytec.de>
+ */
+
+#ifndef NG_CSMA_MAC_H_
+#define NG_CSMA_MAC_H_
+
+#include "kernel.h"
+#include "net/ng_netdev.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* MAC sublayer constants, referring to IEEE 802.15.4-2011 Table 51, 52 */
+
+/**
+ * @brief    The maximum value of the backoff exponent BE.
+ * @details  The IEEE 802.15.4 Standard allows values from 3-8.
+ */
+#define CSMA_MAC_MAX_BE                  5
+
+/**
+ * @brief    The minimum value of the backoff exponent BE.
+ * @details  The IEEE 802.15.4 Standard allows values from 0-CSMA_MAC_MAX_BE.
+ */
+#define CSMA_MAC_MIN_BE                  3
+
+/**
+ * @brief    The maximum number of retries allowed after a transmission failure.
+ * @details  The IEEE 802.15.4 Standard allows values from 0-7.
+ */
+#define CSMA_MAC_MAX_FRAME_RETRIES       3
+
+/**
+ * @brief   The physical timer that is used for the MAC-layer, (periph/timer - IF).
+ */
+#define CSMA_MAC_TIMER               TIMER_0
+
+/**
+ * @brief   The physical timer that is used for the MAC-layer, (periph/timer - IF).
+ */
+#define CSMA_MAC_TIMER_CH              0
+
+/**
+ * @brief   Set the default message queue size for CSMA_MAC layers
+ */
+#ifndef CSMA_MAC_MSG_QUEUE_SIZE
+#define CSMA_MAC_MSG_QUEUE_SIZE         (8U)
+#endif
+
+/******************************************************************************
+ * TODO: The timer definition will move to the board.h file. For testing purposes
+ * it is temporarily defined at this place.
+ */
+/**
+ * @brief   The physical timer that is used for the MAC-layer, (periph/timer - IF).
+ */
+#define CSMA_MAC_TIMER               TIMER_0
+
+/**
+ * @brief   The physical timer that is used for the MAC-layer, (periph/timer - IF).
+ */
+#define CSMA_MAC_TIMER_CH              0
+
+/******************************************************************************
+ * TODO: The following defines are Phy dependent. We have to decide where to put them.
+ * They are directly related to the netdev dev, so what possibilities do we have
+ * to link them to the network dev? Do it in a similar way like the linux kernel.
+ * and store them in a device stuct.
+ */
+
+/**
+ * @brief   Length of a single simbol in us. (PHY dependant)
+ * @details Is calculated as follows:
+ */
+#define CSMA_MAC_SYMBOL_LENGTH           16
+#define BIT_PER_SYMBOL                   4
+#define N_SFD_DURATION                   (8 / BIT_PER_SYMBOL)
+#define N_PREAMBLE_DURATION              (32 / BIT_PER_SYMBOL)
+#define SHR_DURATION                     (N_PREAMBLE_DURATION + N_SFD_DURATION) * CSMA_MAC_SYMBOL_LENGTH
+#define TURNAROUND_TIME                  12 * CSMA_MAC_SYMBOL_LENGTH
+
+/**
+ * @brief   The number of symbols forming the basic time period
+ *          used by the CSMA-CA algorithm.
+ */
+#define CSMA_MAC_UNIT_BACKOFF_PERIOD     20 * CSMA_MAC_SYMBOL_LENGTH
+
+/**
+ * @brief    Max time to wait for ack [us].
+ * @details  The maximum amount of time to
+ *           wait for an acknowledgment frame to arrive after TX process is done.
+ *           This value is dependent on the supported PHY.
+ */
+#define CSMA_MAC_MAX_ACK_WAIT_DURATION   CSMA_MAC_UNIT_BACKOFF_PERIOD\
+                        + TURNAROUND_TIME + SHR_DURATION + 6*(8/BIT_PER_SYMBOL) * CSMA_MAC_SYMBOL_LENGTH
+
+/**
+ * @brief   Device specific option: Automatic CCA before TX supported
+ */
+#define CSMA_MAC_DEV_SUPPORTS_AUTOCCA  (1 << 0)
+
+/**
+ * @brief   Device specific option: Automatic send of ACK frame after receive
+ */
+#define CSMA_MAC_DEV_SUPPORTS_AUTOACK  (1 << 1)
+
+/**
+ * @brief   Device specific option: PRELOADING
+ */
+#define CSMA_MAC_DEV_SUPPORTS_PRELOADING  (1 << 1)
+
+/**
+ * @brief   Size of the buffer that stores pointer to
+ *          queued NG_NETAPI_MSG_TYPE_SND-Messages
+ */
+#define CSMA_MAC_BUFSIZE 100
+
+/******************************************************************************/
+
+
+/**
+ * @brief   Initialize an instance of the CSMA_MAC layer
+ *
+ * The initialization starts a new thread that connects to the given netdev
+ * device and starts a link layer event loop.
+ *
+ * @param[in] stack         stack for the control thread
+ * @param[in] stacksize     size of *stack*
+ * @param[in] priority      priority for the thread housing the CSMA_MAC instance
+ * @param[in] name          name of the thread housing the CSMA_MAC instance
+ * @param[in] dev           netdev device, needs to be already initialized
+ *
+ * @return                  PID of CSMA_MAC thread on success
+ * @return                  -EINVAL if creation of thread fails
+ * @return                  -ENODEV if *dev* is invalid
+ */
+kernel_pid_t csma_mac_init(char *stack, int stacksize, char priority,
+                        const char *name, ng_netdev_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CSMA_MAC_H_ */
+/** @} */

--- a/sys/include/net/ng_netdev.h
+++ b/sys/include/net/ng_netdev.h
@@ -44,20 +44,14 @@ extern "C" {
  *          MAC layer
  */
 typedef enum {
-    NETDEV_EVENT_RX_STARTED     = 0x0001,   /**< started to receive a packet */
-    NETDEV_EVENT_RX_COMPLETE    = 0x0002,   /**< finished receiving a packet */
-    NETDEV_EVENT_TX_STARTED     = 0x0004,   /**< started to transfer a packet */
-    NETDEV_EVENT_TX_COMPLETE    = 0x0008,   /**< finished transferring packet */
+    NETDEV_EVENT_RX_STARTED             = 0x0001,   /**< started to receive a packet */
+    NETDEV_EVENT_RX_COMPLETE            = 0x0002,   /**< finished receiving a packet */
+    NETDEV_EVENT_TX_STARTED             = 0x0004,   /**< started to transfer a packet */
+    NETDEV_EVENT_TX_COMPLETE            = 0x0008,   /**< finished transferring packet */
+    NETDEV_EVENT_CCA_CHANNEL_BUSY       = 0x0010,   /**< finished CCA with busy channel*/
+    NETDEV_EVENT_CCA_CHANNEL_IDLE       = 0x0020,   /**< finished CCA with idle channel*/
     /* expand this list if needed */
 } ng_netdev_event_t;
-
-/**
- * @brief   Event callback for signaling event to a MAC layer
- *
- * @param[in] type          type of the event
- * @param[in] arg           event argument, can e.g. contain a pktsnip_t pointer
- */
-typedef void (*ng_netdev_event_cb_t)(ng_netdev_event_t type, void *arg);
 
 /**
  * @brief   Forward declaration of ng_netdev_t due to cyclic dependency to
@@ -66,6 +60,14 @@ typedef void (*ng_netdev_event_cb_t)(ng_netdev_event_t type, void *arg);
  * @see ng_netdev
  */
 typedef struct ng_netdev ng_netdev_t;
+
+/**
+ * @brief   Event callback for signaling event to a MAC layer
+ *
+ * @param[in] type          type of the event
+ * @param[in] arg           event argument, can e.g. contain a pktsnip_t pointer
+ */
+typedef void (*ng_netdev_event_cb_t)(ng_netdev_t *dev, ng_netdev_event_t type, void *arg);
 
 /**
  * @brief   Network device API definition.

--- a/sys/net/link_layer/ng_csma_mac/Makefile
+++ b/sys/net/link_layer/ng_csma_mac/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/link_layer/ng_csma_mac/ng_csma_mac.c
+++ b/sys/net/link_layer/ng_csma_mac/ng_csma_mac.c
@@ -1,0 +1,493 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net_csma_mac
+ * @file
+ * @brief       Implementation of the CSMA_MAC MAC protocol
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Jonas Remmert <j.remmert@phytec.de>
+ * @}
+ */
+
+#include <errno.h>
+#include "kernel.h"
+#include "msg.h"
+#include "thread.h"
+#include "net/ng_netbase.h"
+#include "periph/timer.h"
+#include "periph/random.h"
+#include "ng_csma_mac_internal.h"
+#include "net/ng_csma_mac.h"
+#include "hwtimer.h"
+#include "mutex.h"
+#include "vtimer.h"
+
+#define ENABLE_DEBUG        (1)
+
+/* Enables integrated testing functions, such as LED-toggling
+ * on state-change and idle-wait functions to test arbitration
+ * using multiple boards.
+ */
+#define TESTING_FUNCTIONS   (0)
+#include "debug.h"
+
+static csma_mac_states_t csma_mac_state = CSMA_IDLE;
+static tim_t mac_tmr = CSMA_MAC_TIMER;
+static msg_t msg;
+static mutex_t mutex = MUTEX_INIT;
+static ng_netapi_opt_t *opt;
+static uint8_t dev_options;
+static uint8_t ack_received;
+static ng_pktsnip_t *csma_mac_txbuf[CSMA_MAC_BUFSIZE];
+static uint16_t csma_mac_txbuf_pos;
+uint8_t backoff_exponent;
+uint8_t retries;
+
+/* needed as callback function for the timer-interface */
+inline static void task_release(int tmr_dev){
+    mutex_unlock(&mutex);
+}
+
+/**
+ * @brief   Function called by the device driver on device events
+ *
+ * @param[in] event         type of event
+ * @param[in] data          optional parameter
+ */
+static void _event_cb(ng_netdev_t *dev, ng_netdev_event_t event, void *data)
+{
+    DEBUG("csma_mac: event triggered -> %i\n", event);
+
+    switch (event) {
+
+    case NETDEV_EVENT_RX_COMPLETE:
+        {
+            ng_pktsnip_t *pkt;
+            ng_netreg_entry_t *sendto;
+
+            /* get pointer to the received packet */
+            pkt = (ng_pktsnip_t *)data;
+            /* find out, who to send the packet to */
+            sendto = ng_netreg_lookup(pkt->type, NG_NETREG_DEMUX_CTX_ALL);
+            /* throw away packet if no one is interested */
+            if (sendto == NULL) {
+                DEBUG("csma_mac: unable to forward packet of type %i\n", pkt->type);
+                ng_pktbuf_release(pkt);
+            }
+            /* send the packet to everyone interested in it's type */
+            ng_pktbuf_hold(pkt, ng_netreg_num(pkt->type, NG_NETREG_DEMUX_CTX_ALL) - 1);
+            while (sendto != NULL) {
+                DEBUG("csma_mac: sending pkt %p to PID %u\n", pkt, sendto->pid);
+                ng_netapi_send(sendto->pid, pkt);
+                sendto = ng_netreg_getnext(sendto);
+            }
+        }
+        break;
+
+    case NETDEV_EVENT_TX_COMPLETE:
+            _mac_send_statemachine(dev, NETDEV_EVENT_TX_COMPLETE);
+        break;
+
+    case NETDEV_EVENT_CCA_CHANNEL_BUSY:
+            _mac_send_statemachine(dev, NETDEV_EVENT_CCA_CHANNEL_BUSY);
+        break;
+
+    default:
+        DEBUG("csma_mac-error: Unknown Event triggered\n");
+        break;
+        }
+}
+
+/**
+ * @brief     Random wait function; max delay is determined with
+ *            backoff exponent.
+ *
+ * @param[in] be    expects a number between
+              CSMA_MAC_MIN_BE and CSMA_MAC_MAX_BE.
+ */
+static void backoff_wait(uint8_t be)
+{
+    uint16_t random = 0;
+    uint16_t backoff_intervall = 0;
+    char buf[2];
+
+    /* backoff_intervall is defined as ((2^bf)-1)*CSMA_MAC_SYMBOL_LENGTH */
+    backoff_intervall = 1;
+    backoff_intervall <<= be;
+    backoff_intervall--;
+    backoff_intervall *= CSMA_MAC_UNIT_BACKOFF_PERIOD * CSMA_MAC_SYMBOL_LENGTH;
+
+    /* Generate 16bit random number */
+    if (random_read(buf, 2) != 2) {
+        return;   /* what to return in case of random_read error? */
+    }
+
+    random = buf[0];
+    random <<= 8;
+    random = random | (0x00ff & buf[1]);
+
+    if (backoff_intervall) {  /* avoid div/0 */
+        backoff_intervall = random % backoff_intervall;
+    }
+
+    DEBUG("csma_mac-info: Backoff_wait:Random Backoff_interval = %ius\n"\
+    , backoff_intervall);
+
+    #if (TESTING_FUNCTIONS)
+    LED_B_ON; /* Measurement indication for Wait duration */
+    #endif
+    if (backoff_intervall > 10) {   /* Spinlock barrier for Timer, skip wait because span is to short */
+        timer_reset(mac_tmr);
+        timer_set(mac_tmr, CSMA_MAC_TIMER_CH, backoff_intervall);
+        mutex_lock(&mutex);
+        mutex_lock(&mutex);
+        mutex_unlock(&mutex);
+        timer_clear(mac_tmr, CSMA_MAC_TIMER_CH);
+    }
+    #if (TESTING_FUNCTIONS)
+    LED_B_OFF; /* Measurement indication for Wait duration */
+    #endif
+    return;
+}
+
+/**
+ * @brief            Random wait function; max delay is defined by parameter.
+ *
+ * @param[in] max    maximum wait-time.
+ */
+#if (TESTING_FUNCTIONS)
+static void random_wait(uint16_t max)
+{
+    uint16_t random = 0;
+    char buf[2];
+
+    /* Generate 16bit random number */
+    if (random_read(buf, 2) != 2) {
+        return;   /* what to return in case of random_read error? */
+    }
+
+    random = buf[0];
+    random <<= 8;
+    random = random | (0x00ff & buf[1]);
+
+    if (max) {  /* avoid div/0 */
+        max = random % max;
+    }
+
+    LED_G_ON; /* Measurement indication for Wait duration */
+    vtimer_usleep(max);
+    LED_G_OFF; /* Measurement indication for Wait duration */
+    return;
+}
+#endif
+
+void _csma_mac_reset(void)
+{
+    DEBUG("csma_mac: RESET\n");
+    backoff_exponent= CSMA_MAC_MIN_BE;
+    retries = 0;
+    ack_received = 0;
+}
+
+
+/**
+ * @brief     If the mac layer needs to send out a packet,
+ *            this state-machine handles the send process.
+ *
+ * @return number of bytes that were actually send out; -1 if packet could not sent out.
+ */
+static int _mac_send_statemachine(ng_netdev_t *dev, ng_netdev_event_t event)
+{
+    ng_netconf_state_t res;
+
+#if (TESTING_FUNCTIONS)
+    uint16_t random_max_val = 16000; /* wait max 4ms */
+#endif
+
+    /* Send data without CSMA algorithm if device
+     * is not capable of doing CCA before TX */
+    if (!(dev_options & CSMA_MAC_DEV_SUPPORTS_AUTOCCA)) {
+        res = dev->driver->send_data(dev, csma_mac_txbuf[csma_mac_txbuf_pos]);
+        csma_mac_txbuf_pos--;
+        return 0;
+    }
+
+    switch (csma_mac_state) {
+
+        case CSMA_IDLE:
+            DEBUG("csma_mac-state: CSMA_IDLE\n");
+            csma_mac_state = CSMA_TX;
+            res = dev->driver->send_data(dev, csma_mac_txbuf[csma_mac_txbuf_pos]);
+            if (res < 0) {
+                return res;
+            }
+            break;
+
+        case CSMA_TX:
+            DEBUG("csma_mac-state: CSMA_TX\n");
+            if (event == NETDEV_EVENT_TX_COMPLETE) {
+                csma_mac_state = CSMA_IDLE; 
+                csma_mac_txbuf_pos--;
+                _csma_mac_reset();
+            }
+            else if (event == NETDEV_EVENT_CCA_CHANNEL_BUSY) {
+                 csma_mac_state = CSMA_WAIT;
+            }
+            break;
+
+        case CSMA_WAIT:
+            DEBUG("csma_mac-state: CSMA_WAIT.\n");
+
+            DEBUG("csma_mac-info: CCA: Channel busy, backoff_exponent = %i\n", backoff_exponent);
+            backoff_exponent++;
+            if (backoff_exponent > CSMA_MAC_MAX_BE) {  /* return error code */
+                DEBUG("csma_mac-error: CCA Failed, max retries reached. Exiting with -EBUSY.\n");
+                csma_mac_state = CSMA_IDLE;
+                csma_mac_txbuf_pos--;
+                _csma_mac_reset();
+                return -EBUSY;                         /* Resource busy */
+            } 
+            backoff_wait(backoff_exponent);
+            csma_mac_state = CSMA_IDLE;
+            break;
+
+        case CSMA_WAIT_FOR_ACK:
+            DEBUG("csma_mac-state: CSMA_WAIT_FOR_ACK.\n");
+            /* TODO: Packet was sent, abort at this point for testing */
+            csma_mac_state = CSMA_WAIT_FOR_ACK;
+            return 0;
+            /* TODO: Set RX state but only react on ACK, maybe introduce a new state */
+            opt->opt = NETCONF_OPT_STATE;
+            int tmp = NETCONF_STATE_RX;
+            opt->data = &tmp;
+            res = dev->driver->set(dev,
+                                 opt->opt, opt->data,(size_t)opt->data_len);
+            if (res != sizeof(opt->data_len)) {
+                return res;
+            }
+
+                #if (TESTING_FUNCTIONS)
+                random_wait(random_max_val);
+                #endif
+            /* In case of no ACK, proceed in state machine */
+            retries ++;
+
+            if (retries > CSMA_MAC_MAX_FRAME_RETRIES) {
+                backoff_exponent = CSMA_MAC_MIN_BE;
+                csma_mac_state = CSMA_TX;
+                DEBUG("csma_mac-error: Ack failed, retries: %i\n", retries);
+                break;
+            }
+            else {
+                DEBUG("csma_mac-error: Ack failed, max retries reached. Exiting with -EBUSY.\n");
+                return -EBUSY;                  /* Resource busy */
+            }
+            break;
+
+        default:
+            DEBUG("csma_mac-error: Default state, error in state machine\n");
+            return -ENOTSUP;
+     }
+    return 0;
+}
+
+/**
+ * @brief   Startup code and event loop of the CSMA_MAC layer
+ *
+ * @param[in] args          expects a pointer to the underlying netdev device
+ *
+ * @return                  never returns
+ */
+static void *_csma_mac_thread(void *args)
+{
+    ng_netdev_t *dev = (ng_netdev_t *)args;
+    int res;
+    msg_t reply, msg_queue[CSMA_MAC_MSG_QUEUE_SIZE];
+    dev_options=0;
+
+    /* TODO: Initialization, move to main or so */
+    bool tmp;
+
+    /* Enable Autocca */
+    tmp = NETCONF_ENABLE;
+    res = dev->driver->set(dev, NETCONF_OPT_AUTOCCA, &tmp , sizeof(uint8_t)) ;
+    if(res) {
+        DEBUG("csma_mac: AUTOCCA set\n");
+        dev_options |= (CSMA_MAC_DEV_SUPPORTS_AUTOCCA);
+    }
+    else {
+        dev_options &= ~(CSMA_MAC_DEV_SUPPORTS_AUTOCCA);
+        DEBUG("csma_mac-error %d: Radio device does not support automatic CCA before TX!\
+                 MAC layer will perform send without CSMA instead.\n", res);
+    }
+
+    /* Enable Preloading */
+    /*tmp = NETCONF_ENABLE;
+    res = dev->driver->set(dev, NETCONF_OPT_PRELOADING, &tmp , sizeof(uint8_t)) ;
+    if(res) {
+        DEBUG("csma_mac: PRELOADING set\n");
+        dev_options |= (CSMA_MAC_DEV_SUPPORTS_PRELOADING);
+    }
+    else {
+        dev_options &= ~(CSMA_MAC_DEV_SUPPORTS_PRELOADING);
+        DEBUG("csma_mac-error %d: Radio device does\
+                 not support PRELOADING\n", res);
+    }*/
+
+    /* Enable Autoack */
+    tmp = NETCONF_ENABLE;
+    res = dev->driver->set(dev, NETCONF_OPT_AUTOACK, &tmp , sizeof(uint8_t)) ;
+    if(res) {
+        DEBUG("csma_mac: AUTOACK set\n");
+        dev_options |= (CSMA_MAC_DEV_SUPPORTS_AUTOACK);
+    }
+    else {
+        dev_options &= ~(CSMA_MAC_DEV_SUPPORTS_AUTOACK);
+        DEBUG("csma_mac-error %d: Radio device does not\
+                 support AUTOACK\n", res);
+    }
+
+    /* Enable RX_READY_IRQ */
+    tmp = NETCONF_ENABLE;
+    res = dev->driver->set(dev, NETCONF_OPT_RX_END_IRQ, &tmp , sizeof(uint8_t)) ;
+    if(res) {
+        DEBUG("csma_mac: RX_READY_IRQ activated\n");
+        dev_options |= (CSMA_MAC_DEV_SUPPORTS_AUTOACK);
+    }
+    else {
+        dev_options &= ~(CSMA_MAC_DEV_SUPPORTS_AUTOACK);
+        DEBUG("csma_mac-error %d: Radio device does not\
+                 support RX_READY_IRQ\n", res);
+    }
+
+    /* Enable TX_READY_IRQ */
+    tmp = NETCONF_ENABLE;
+    res = dev->driver->set(dev, NETCONF_OPT_TX_END_IRQ, &tmp , sizeof(uint8_t)) ;
+    if(res) {
+        DEBUG("csma_mac: TX_READY_IRQ activated\n");
+        dev_options |= (CSMA_MAC_DEV_SUPPORTS_AUTOACK);
+    }
+    else {
+        dev_options &= ~(CSMA_MAC_DEV_SUPPORTS_AUTOACK);
+        DEBUG("csma_mac-error %d: Radio device does not\
+                 support TX_READY_IRQ\n", res);
+    }
+
+    /* setup the MAC layers message queue */
+    msg_init_queue(msg_queue, CSMA_MAC_MSG_QUEUE_SIZE);
+    /* save the PID to the device descriptor and register the device */
+    dev->mac_pid = thread_getpid();
+    ng_netif_add(dev->mac_pid);
+    /* register the event callback with the device driver */
+    dev->driver->add_event_callback(dev, _event_cb);
+
+    /* start the event loop */
+    while (1) {
+        DEBUG("csma_mac: waiting for incoming messages\n");
+        while(1){
+            if(((csma_mac_state == CSMA_IDLE) & (csma_mac_txbuf_pos == 0))
+                   || (csma_mac_state != CSMA_IDLE)) {
+                msg_receive(&msg);
+                if(msg.type == NG_NETAPI_MSG_TYPE_SND) {
+                    if (csma_mac_txbuf_pos < CSMA_MAC_BUFSIZE) {
+                        csma_mac_txbuf_pos ++;
+                        csma_mac_txbuf[csma_mac_txbuf_pos] = (ng_pktsnip_t *)msg.content.ptr;
+                    } else {
+                        DEBUG("csma_mac_error: txbuf full, msg dropped\n");
+                    }
+                }
+                /* Exit to execute command */
+                break;
+            }
+            else {
+                /* Exit to send message */
+            msg.type = NG_NETAPI_MSG_TYPE_SND;
+                break;
+            }
+        }
+        /* dispatch NETDEV and NETAPI mssages */
+        switch (msg.type) {
+            case NG_NETDEV_MSG_TYPE_EVENT:
+                DEBUG("csma_mac: NG_NETDEV_MSG_TYPE_EVENT received\n");
+                dev->driver->isr_event(dev, msg.content.value);
+                break;
+
+            case NG_NETAPI_MSG_TYPE_SND:
+                _mac_send_statemachine(dev, 0);
+                break;
+            case NG_NETAPI_MSG_TYPE_SET:
+                /* TODO: filter out MAC layer options -> for now forward
+                         everything to the device driver */
+                DEBUG("csma_mac: NG_NETAPI_MSG_TYPE_SET received\n");
+                /* read incoming options */
+                opt = (ng_netapi_opt_t *)msg.content.ptr;
+                /* set option for device driver */
+                res = dev->driver->set(dev, opt->opt, opt->data, opt->data_len);
+                if (res != sizeof(opt->data_len)) {
+                    DEBUG("csma_mac-error: set returned %i\n", res);
+                }
+                /* send reply to calling thread */
+                reply.type = NG_NETAPI_MSG_TYPE_ACK;
+                reply.content.value = (uint32_t)res;
+                msg_reply(&msg, &reply);
+                break;
+            case NG_NETAPI_MSG_TYPE_GET:
+                /* TODO: filter out MAC layer options -> for now forward
+                         everything to the device driver */
+                DEBUG("csma_mac: NG_NETAPI_MSG_TYPE_GET received\n");
+                /* read incoming options */
+                opt = (ng_netapi_opt_t *)msg.content.ptr;
+                /* get option from device driver */
+                res = dev->driver->get(dev, opt->opt, opt->data, opt->data_len);
+                /* send reply to calling thread */
+                reply.type = NG_NETAPI_MSG_TYPE_ACK;
+                reply.content.value = (uint32_t)res;
+                msg_reply(&msg, &reply);
+                break;
+            default:
+                DEBUG("csma_mac: Unknown command %" PRIu16 "\n", msg.type);
+                break;
+        }
+        while(csma_mac_state == CSMA_WAIT) {
+            _mac_send_statemachine(dev, 0);
+        }
+    }
+    /* never reached */
+    return NULL;
+}
+
+kernel_pid_t csma_mac_init(char *stack, int stacksize, char priority,
+                               const char *name, ng_netdev_t *dev)
+{
+    unsigned int us_per_tick = 1;
+    kernel_pid_t res;
+
+    /* check if given netdev device is defined */
+    if (dev == NULL) {
+        return -ENODEV;
+    }
+
+    /* create new CSMA_MAC thread */
+    res = thread_create(stack, stacksize, priority, CREATE_STACKTEST,
+                        _csma_mac_thread, (void *)dev, name);
+
+    if (res <= 0) {
+        return -EINVAL;
+    }
+
+    random_init();
+    /* If timer event occures, _mac_send_statemachine is called in ISR. */
+    timer_init(mac_tmr, us_per_tick, task_release);
+    timer_start(mac_tmr);
+    DEBUG("csma_mac-info: Timer and RNG successfull initialized.\n");
+    return res;
+}

--- a/sys/net/link_layer/ng_csma_mac/ng_csma_mac_internal.h
+++ b/sys/net/link_layer/ng_csma_mac/ng_csma_mac_internal.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_csma_mac
+ * @{
+ * 
+ * @file
+ * @brief       Internal definitions of the CSMA MAC layer
+ *
+ * @author      Jonas Remmert <j.remmert@phytec.de>
+ */
+
+#ifndef NG_CSMA_MAC_INTERNAL_H_
+#define NG_CSMA_MAC_INTERNAL_H_
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    CSMA_IDLE,
+    CSMA_WAIT,
+    CSMA_TX,
+    CSMA_WAIT_FOR_ACK
+} csma_mac_states_t;
+
+
+static int _mac_send_statemachine(ng_netdev_t *dev, ng_netdev_event_t event);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NG_AT86RF2XX_INTERNAL_H_ */
+/** @} */

--- a/tests/driver_kw2xrf/Makefile
+++ b/tests/driver_kw2xrf/Makefile
@@ -52,7 +52,8 @@ endif # USE_BOARD_PARAMETERS=false
 
 USEMODULE += auto_init_ng_netif
 USEMODULE += ng_netif
-USEMODULE += ng_nomac
+#USEMODULE += ng_nomac
+USEMODULE += ng_csma_mac
 USEMODULE += ng_pktdump
 USEMODULE += uart0
 USEMODULE += shell

--- a/tests/driver_kw2xrf/Makefile
+++ b/tests/driver_kw2xrf/Makefile
@@ -52,7 +52,6 @@ endif # USE_BOARD_PARAMETERS=false
 
 USEMODULE += auto_init_ng_netif
 USEMODULE += ng_netif
-#USEMODULE += ng_nomac
 USEMODULE += ng_csma_mac
 USEMODULE += ng_pktdump
 USEMODULE += uart0


### PR DESCRIPTION
This PR adds an approach to a simple CSMA MAC layer (simplemac).
It is partly pseudo-code and not a testable implementation yet.

There is also a state-chart diagram that describes the course architecture. You can find it here:
 https://github.com/jremmert-phytec-iot/Pictures_Phytec_IOT/blob/master/CSMA_MAC.pdf

I made some assumptions that should be discussed.
1. Actions on the radio are interrupt driven (perform CCA, successfull ACK receive).
	-> That enables a statemachine driven approach without context switching.
2. Statemachine <_mac_send_statechart()> will be accessed in irq context (e.g. if CCA-ready Int occured, cb-function if timer expires).
3. The time in the ISRs will be short, as each state only pokes the next action and returns from the statechart immediately.