### PR TITLE
net/ng_netdev: changed return value of rem_cb

### DIFF
--- a/sys/include/net/ng_netdev.h
+++ b/sys/include/net/ng_netdev.h
@@ -105,7 +105,7 @@ typedef struct {
      *
      * @return              0 on success
      * @return              -ENODEV if @p dev is invalid
-     * @return              -ENOPKG if callback was not registered
+     * @return              -ENOENT if callback was not registered
      */
     int (*rem_event_callback)(ng_netdev_t *dev, ng_netdev_event_cb_t cb);
 


### PR DESCRIPTION
seems like `ENOPKG` is not supported by (my) arm toolchain, and `ENOENT` is a better fit anyway...