### PR TITLE
openocd: use exit instead of shutdown

### DIFF
--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -124,8 +124,7 @@ do_flash() {
             -c "init" \
             -c "targets" \
             -c "reset halt" \
-            -c "program ${HEXFILE} verify exit" \
-            -c "reset run"
+            -c "program ${HEXFILE} verify reset exit"
 }
 
 do_debug() {

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -124,7 +124,7 @@ do_flash() {
             -c "init" \
             -c "targets" \
             -c "reset halt" \
-            -c "program ${HEXFILE} verify" \
+            -c "program ${HEXFILE} verify exit" \
             -c "reset run"
 }
 


### PR DESCRIPTION
Using the shutdown command directly will trigger an exit code.