### PR TITLE
cpu/samd21: Add samd21 pwm driver

### DIFF
--- a/boards/samr21-xpro/Makefile.features
+++ b/boards/samr21-xpro/Makefile.features
@@ -1,2 +1,2 @@
-FEATURES_PROVIDED += transceiver periph_gpio periph_spi cpp periph_timer periph_uart periph_i2c cpp periph_rtc periph_cpuid
+FEATURES_PROVIDED += transceiver periph_gpio periph_spi cpp periph_timer periph_uart periph_i2c cpp periph_rtc periph_cpuid periph_pwm
 FEATURES_MCU_GROUP = cortex_m0

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -14,6 +14,7 @@
  * @brief       Peripheral MCU configuration for the Atmel SAM R21 Xplained Pro board
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  */
 
 #ifndef __PERIPH_CONF_H
@@ -42,7 +43,37 @@ extern "C" {
 #define TIMER_1_CHANNELS   2
 #define TIMER_1_MAX_VALUE  (0xffffffff)
 #define TIMER_1_ISR        isr_tc4
+/** @} */
 
+/**
+ * @name PWM configuration
+ * @{
+ */
+#define PWM_NUMOF           (2U)
+#define PWM_0_EN            1
+#define PWM_1_EN            1
+#define PWM_MAX_CHANNELS    2
+
+/* PWM 0 device configuration */
+#define PWM_0_DEV           TCC0
+#define PWM_0_CHANNELS      1
+#define PWM_0_REF_F         (8000000UL)
+#define PWM_0_CLK_ID        TCC0_GCLK_ID
+#define PWM_0_PM            PM_APBCMASK_TCC0
+/* PWM 0 pin configuration */
+#define PWM_0_PORT          (PORT->Group[0])
+#define PWM_0_PIN_CH0       (8)
+
+/* PWM 1 device configuration */
+#define PWM_1_DEV           TCC1
+#define PWM_1_CHANNELS      2
+#define PWM_1_REF_F         (8000000UL)
+#define PWM_1_CLK_ID        TCC1_GCLK_ID
+#define PWM_1_PM            PM_APBCMASK_TCC1
+/* PWM 1 pin configuration */
+#define PWM_1_PORT          (PORT->Group[0])
+#define PWM_1_PIN_CH0       (6)
+#define PWM_1_PIN_CH1       (7)
 /** @} */
 
 /**

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -66,13 +66,12 @@ extern "C" {
 
 /* PWM 1 device configuration */
 #define PWM_1_DEV           TCC1
-#define PWM_1_CHANNELS      2
+#define PWM_1_CHANNELS      1
 #define PWM_1_REF_F         (8000000UL)
 #define PWM_1_CLK_ID        TCC1_GCLK_ID
 #define PWM_1_PM            PM_APBCMASK_TCC1
 /* PWM 1 pin configuration */
 #define PWM_1_PORT          (PORT->Group[0])
-#define PWM_1_PIN_CH0       (6)
 #define PWM_1_PIN_CH1       (7)
 /** @} */
 

--- a/cpu/samd21/periph/pwm.c
+++ b/cpu/samd21/periph/pwm.c
@@ -1,0 +1,306 @@
+/*
+ * Copyright (C) 2014 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_samd21
+ * @{
+ *
+ * @file
+ * @brief       Low-level PWM driver implementation
+ *
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "cpu.h"
+#include "periph/pwm.h"
+#include "periph_conf.h"
+
+/* ignore file in case no PWM devices are defined */
+#if PWM_NUMOF
+
+static int round_to_prescaler(unsigned int frequency, unsigned int resolution, int *presc);
+
+
+int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int resolution)
+{
+    Tcc* pwm_dev = NULL;
+    PortGroup* pwm_port = NULL;
+
+    uint32_t pwm_pins[PWM_MAX_CHANNELS];
+    int pwm_clk_id = 0;
+    int pwm_clk_ref = 0;
+    int channels = 0;
+
+    int presc;
+    int presc_num;
+
+    /* round to an available prescaler/clock divider */
+    presc_num = round_to_prescaler(frequency, resolution, &presc);
+
+    /* check if frequency and resolution were applicable */
+    if (presc_num < 0) {
+        return -2;
+    }
+
+    switch (dev) {
+#if PWM_0_EN
+        case PWM_0:
+            pwm_dev = PWM_0_DEV;
+            pwm_port = &PWM_0_PORT;
+            pwm_pins[0] = PWM_0_PIN_CH0;
+#if (PWM_0_CHANNELS > 1)
+            pwm_pins[1] = PWM_0_PIN_CH1;
+#endif
+            channels = PWM_0_CHANNELS;
+            pwm_clk_id = PWM_0_CLK_ID;
+            pwm_clk_ref = PWM_0_REF_F;
+            break;
+#endif
+#if PWM_1_EN
+        case PWM_1:
+            pwm_dev = PWM_1_DEV;
+            pwm_port = &PWM_1_PORT;
+            pwm_pins[0] = PWM_1_PIN_CH0;
+#if (PWM_1_CHANNELS > 1)
+            pwm_pins[1] = PWM_1_PIN_CH1;
+#endif
+            channels = PWM_1_CHANNELS;
+            pwm_clk_id = PWM_1_CLK_ID;
+            pwm_clk_ref = PWM_1_REF_F;
+            break;
+#endif
+    }
+
+    /* setup pins */
+    for (int i = 0; i < channels; i++) {
+        pwm_port->DIRSET.reg = (1 << pwm_pins[i]);  /* direction is output */
+        /* enable PMUX for pins and set to config E. See spec p. 12 */
+        pwm_port->WRCONFIG.reg = PORT_WRCONFIG_WRPINCFG
+                                        | PORT_WRCONFIG_WRPMUX
+                                        | PORT_WRCONFIG_PMUX(0x4) /* Peripheral function E */
+                                        | PORT_WRCONFIG_PMUXEN
+                                        | (1 << (pwm_pins[i] % 16));
+    }
+
+    /* turn on power manager */
+    pwm_poweron(dev);
+
+    /* configure GCLK0 to feed TCC */;
+    GCLK->CLKCTRL.reg = (uint16_t)((GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 | (pwm_clk_id << GCLK_CLKCTRL_ID_Pos)));
+    while (GCLK->STATUS.bit.SYNCBUSY);
+
+    /* disable to configure CTRLA */
+    pwm_stop(dev);
+
+    /* reset timer */
+    pwm_dev->CTRLA.bit.SWRST = 1;
+    while (pwm_dev->CTRLA.bit.SWRST);
+
+    /* reload or reset the counter on next generic clock */
+    pwm_dev->CTRLA.bit.PRESCSYNC = TCC_CTRLA_PRESCSYNC_GCLK_Val;
+    /* 8MHz  source divided by presc */
+    pwm_dev->CTRLA.bit.PRESCALER = presc;
+
+    /* the timer/counter is counting up */
+    pwm_dev->CTRLBCLR.reg |= TCC_CTRLBSET_DIR;
+    /* reload or reset the counter on next generic clock */
+    pwm_dev->CTRLBCLR.reg |= TCC_CTRLBSET_ONESHOT;
+    while (pwm_dev->SYNCBUSY.bit.CTRLB);
+
+    /* select the waveform generation operation */
+    pwm_dev->WAVE.bit.WAVEGEN = TCC_WAVE_WAVEGEN_NPWM_Val; /* normal PWM */
+    while (pwm_dev->SYNCBUSY.bit.WAVE);
+
+    /* the period time is controlled by the PER */
+    pwm_dev->PER.bit.PER = (pwm_clk_ref / (presc_num * frequency)) - 1;
+    while (pwm_dev->SYNCBUSY.bit.PER);
+
+    /* set PWM mode */
+    switch (mode) {
+        case PWM_LEFT:
+            break;
+        case PWM_RIGHT:
+            break;
+        case PWM_CENTER:
+            break;
+        //default:
+        //    return -1;
+    }
+
+    pwm_start(dev);
+
+    return 0;
+}
+
+int pwm_set(pwm_t dev, int channel, unsigned int value)
+{
+    Tcc* pwm_dev = NULL;
+
+    switch (dev) {
+#if PWM_0_EN
+        case PWM_0:
+            pwm_dev = PWM_0_DEV;
+            if (channel >= PWM_0_CHANNELS) {
+                return -1;
+            }
+            break;
+#endif
+#if PWM_1_EN
+        case PWM_1:
+            pwm_dev = PWM_1_DEV;
+            if (channel >= PWM_1_CHANNELS) {
+                return -1;
+            }
+            break;
+#endif
+    }
+
+    /* norm value to maximum possible value */
+    if (value > pwm_dev->PER.bit.PER) {
+        value = (unsigned int) pwm_dev->PER.bit.PER;
+    }
+
+    switch (channel) {
+        case 0:
+            pwm_dev->INTFLAG.bit.MC0 = 1;
+            pwm_dev->CC[0].bit.CC = value;
+            pwm_dev->INTENSET.bit.MC0 = 1;
+            break;
+        case 1:
+            pwm_dev->INTFLAG.bit.MC1 = 1;
+            pwm_dev->CC[1].bit.CC = value;
+            pwm_dev->INTENSET.bit.MC1 = 1;
+            break;
+        default:
+            return -1;
+    }
+
+    return 0;
+}
+
+void pwm_start(pwm_t dev)
+{
+    switch (dev) {
+#if PWM_0_EN
+        case PWM_0:
+            PWM_0_DEV->CTRLA.bit.ENABLE = 1;
+            while(PWM_0_DEV->SYNCBUSY.bit.ENABLE);
+            break;
+#endif
+#if PWM_1_EN
+        case PWM_1:
+            PWM_1_DEV->CTRLA.bit.ENABLE = 1;
+            while(PWM_1_DEV->SYNCBUSY.bit.ENABLE);
+            break;
+#endif
+    }
+}
+
+void pwm_stop(pwm_t dev)
+{
+    switch (dev) {
+#if PWM_0_EN
+        case PWM_0:
+            PWM_0_DEV->CTRLA.bit.ENABLE = 0;
+            while(PWM_0_DEV->SYNCBUSY.bit.ENABLE);
+            break;
+#endif
+#if PWM_1_EN
+        case PWM_1:
+            PWM_1_DEV->CTRLA.bit.ENABLE = 0;
+            while(PWM_1_DEV->SYNCBUSY.bit.ENABLE);
+            break;
+#endif
+    }
+}
+
+void pwm_poweron(pwm_t dev)
+{
+    switch (dev) {
+#if PWM_0_EN
+        case PWM_0:
+            PM->APBCMASK.reg |= PWM_0_PM;
+            break;
+#endif
+#if PWM_1_EN
+        case PWM_1:
+            PM->APBCMASK.reg |= PWM_1_PM;
+            break;
+#endif
+    }
+}
+
+void pwm_poweroff(pwm_t dev)
+{
+    switch (dev) {
+#if PWM_0_EN
+        case PWM_0:
+            PM->APBCMASK.reg &= ~PWM_0_PM;
+            break;
+#endif
+#if PWM_1_EN
+        case PWM_1:
+            PM->APBCMASK.reg &= ~PWM_1_PM;
+            break;
+#endif
+    }
+}
+
+static int round_to_prescaler(unsigned int frequency, unsigned int resolution, int *presc) {
+
+    uint32_t presc_comp;
+    int presc_num;
+
+    presc_comp = (PWM_0_REF_F / ( resolution * frequency)) -1;
+
+    /* this is just an estimation about a max. tolerable rounding error */ 
+    if (presc_comp >= 1500) {
+        return -2;
+    }
+
+    if (presc_comp >= 640) {
+        *presc = TCC_CTRLA_PRESCALER_DIV1024_Val;
+        presc_num = 1024;
+    }
+    if (presc_comp < 640) {
+        *presc = TCC_CTRLA_PRESCALER_DIV256_Val;
+        presc_num = 256;
+    }
+    if (presc_comp < 160) {
+        *presc = TCC_CTRLA_PRESCALER_DIV64_Val;
+        presc_num = 64;
+    }
+    if (presc_comp < 30) {
+        *presc = TCC_CTRLA_PRESCALER_DIV16_Val;
+        presc_num = 16;
+    }
+    if (presc_comp < 12) {
+        *presc = TCC_CTRLA_PRESCALER_DIV8_Val;
+        presc_num = 8;
+    }
+    if (presc_comp < 6) {
+        *presc = TCC_CTRLA_PRESCALER_DIV4_Val;
+        presc_num = 4;
+    }
+    if (presc_comp < 3) {
+        *presc = TCC_CTRLA_PRESCALER_DIV2_Val;
+        presc_num = 2;
+    }
+    if (presc_comp <= 1) {
+        *presc = TCC_CTRLA_PRESCALER_DIV1_Val;
+        presc_num = 1;
+    }
+    return presc_num;
+}
+
+#endif /* PWM_NUMOF */

--- a/cpu/samd21/periph/pwm.c
+++ b/cpu/samd21/periph/pwm.c
@@ -111,10 +111,8 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
     /* 8MHz  source divided by presc */
     pwm_dev->CTRLA.bit.PRESCALER = presc;
 
-    /* the timer/counter is counting up */
-    pwm_dev->CTRLBCLR.reg |= TCC_CTRLBSET_DIR;
     /* reload or reset the counter on next generic clock */
-    pwm_dev->CTRLBCLR.reg |= TCC_CTRLBSET_ONESHOT;
+    pwm_dev->CTRLBCLR.bit.ONESHOT = 1;
     while (pwm_dev->SYNCBUSY.bit.CTRLB);
 
     /* select the waveform generation operation */
@@ -128,13 +126,20 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
     /* set PWM mode */
     switch (mode) {
         case PWM_LEFT:
+            /* the timer/counter is counting up */
+            pwm_dev->CTRLBCLR.bit.DIR = 1;
+            while (pwm_dev->SYNCBUSY.bit.CTRLB);
             break;
         case PWM_RIGHT:
+            /* the timer/counter is counting down */
+            pwm_dev->CTRLBSET.bit.DIR = 1;
+            while (pwm_dev->SYNCBUSY.bit.CTRLB);
             break;
         case PWM_CENTER:
-            break;
-        //default:
-        //    return -1;
+            /* the center mode is not supported */
+            return -1;
+        default:
+            return -1;
     }
 
     pwm_start(dev);

--- a/tests/REMOVE_ME_pwm_test/Makefile
+++ b/tests/REMOVE_ME_pwm_test/Makefile
@@ -1,0 +1,9 @@
+export APPLICATION = REMOVE_ME_pwm_test
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_pwm
+
+USEMODULE += vtimer
+DISABLE_MODULE += auto_init
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/REMOVE_ME_pwm_test/main.c
+++ b/tests/REMOVE_ME_pwm_test/main.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2014 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test for low-level PWM drivers
+ *
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "cpu.h"
+#include "board.h"
+#include "vtimer.h"
+#include "periph/pwm.h"
+#include "periph/gpio.h"
+
+#define GPIO_DEBUG  GPIO_0
+#define DEV         PWM_0
+#define DEV_CHAN    (0)
+#define MODE_1      PWM_LEFT
+#define MODE_2      PWM_RIGHT
+#define FREQU       (1000U)
+#define STEPS       (1000U)
+#define DUTY        (100)
+
+
+int main(void)
+{
+    puts("\nRIOT PWM test");
+
+    gpio_init_out(GPIO_DEBUG, GPIO_NOPULL);
+
+    int res = pwm_init(DEV, MODE_1, FREQU, STEPS);
+    if (res == 0) {
+        puts("PWM successfully initialized.\n");
+    }
+    else {
+        puts("Errors while initializing PWM");
+        return -1;
+    }
+    printf("PER value 1: %i\n", PWM_0_DEV->PER.bit.PER);
+    printf("Counter directrion value 1: %i\n", PWM_0_DEV->CTRLBCLR.reg);
+
+    vtimer_usleep(10000);
+
+    gpio_set(GPIO_DEBUG);
+    pwm_set(DEV, DEV_CHAN, DUTY);
+    gpio_clear(GPIO_DEBUG);
+
+    vtimer_usleep(10000);
+
+    printf("\n");
+    res = pwm_init(DEV, MODE_2, FREQU, STEPS);
+    if (res == 0) {
+        puts("PWM successfully initialized.\n");
+    }
+    else {
+        puts("Errors while initializing PWM");
+        return -1;
+    }
+    printf("PER value 2: %i\n", PWM_0_DEV->PER.bit.PER);
+    printf("Counter directrion value 2: %i\n", PWM_0_DEV->CTRLBCLR.reg);
+
+    vtimer_usleep(10000);
+
+    gpio_set(GPIO_DEBUG);
+    pwm_set(DEV, DEV_CHAN, DUTY);
+    gpio_clear(GPIO_DEBUG);
+
+    return 0;
+}


### PR DESCRIPTION
This is an implementation of a pwm lowlevel driver for samr21-xpro boards. Please note that the `pwm_mode_t mode` is not yet implemented for this board.