### PR TITLE
Make git ignore doxygen sqlite database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ doc/doxygen/html
 doc/doxygen/latex
 doc/doxygen/man
 doc/doxygen/*.log
+doc/doxygen/*.db
+doc/doxygen/*.tmp
 *bin
 *~
 *.orig


### PR DESCRIPTION
Doxygen version 1.8.8 creates a sqlite database
file inside doc/doxygen/ which was not previously
ignored.

![screen shot 2015-02-19 at 21 09 09](https://cloud.githubusercontent.com/assets/243719/6274956/9be189fc-b87b-11e4-91ee-9dc1f245bb12.png)