### PR TITLE
native: fix termflags

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -74,9 +74,7 @@ else
 	export PORT =
 endif
 
-ifeq (,$(filter $(PORT),$(TERMFLAGS)))
-    export TERMFLAGS += $(PORT)
-endif
+export TERMFLAGS := $(PORT) $(TERMFLAGS)
 
 export ASFLAGS =
 export DEBUGGER_FLAGS = --args $(ELF) $(TERMFLAGS)


### PR DESCRIPTION
Allows for external inclusion of `TERMFLAGS` without having to include the `PORT`. This was previously broken.