### PR TITLE
Fix implementation of strncasecmp()

### DIFF
--- a/sys/posix/strings.c
+++ b/sys/posix/strings.c
@@ -18,7 +18,7 @@
 int strncasecmp(const char *s1, const char *s2, size_t n)
 {
     while (n-- && tolower((unsigned char) *s1) == tolower((unsigned char) *s2)) {
-        if (!n && !*s1) {
+        if (!n || !*s1) {
             break;
         }
 


### PR DESCRIPTION
This should be a OR or when comparing only parts os strings would
return a wrong value.

const char *first = "testA";
const char *second = "test";
uint8_t contains = strncasecmp(first, second, strlen(second));

######

Anyone know witch toolchain was not providing strncasecmp()?
On my board I'm compiling with newlib and the Riot implementation of strncasecmp() was being used instead of newlib one.