### PR TITLE
make: added a check for compiler existence

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -154,7 +154,7 @@ LINKFLAGPREFIX ?= -Wl,
 DIRS += $(EXTERNAL_MODULE_DIRS)
 
 ## make script for your application. Build RIOT-base here!
-all: ..build-message $(USEPKG:%=${BINDIR}%.a) $(APPDEPS)
+all: ..compiler-check ..build-message $(USEPKG:%=${BINDIR}%.a) $(APPDEPS)
 	$(AD)DIRS="$(DIRS)" "$(MAKE)" -C $(CURDIR) -f $(RIOTBASE)/Makefile.application
 ifeq (,$(RIOTNOLINK))
 ifeq ($(BUILDOSXNATIVE),1)
@@ -165,6 +165,12 @@ endif
 	$(AD)$(SIZE) $(ELFFILE)
 	$(AD)$(OBJCOPY) $(OFLAGS) $(ELFFILE) $(HEXFILE)
 endif
+
+..compiler-check:
+	$(AD)command -v $(CC) >/dev/null 2>&1 || \
+		{ $(COLOR_ECHO) \
+		'${COLOR_RED} Compiler $(CC) is required but not found in PATH.  Aborting.${COLOR_RESET}'; \
+		exit 1; }
 
 ..build-message:
 	@$(COLOR_ECHO) '${COLOR_GREEN}Building application "$(APPLICATION)" for "$(BOARD)" with MCU "$(MCU)".${COLOR_RESET}'

--- a/Makefile.include
+++ b/Makefile.include
@@ -212,24 +212,48 @@ distclean:
 	-@rm -rf $(BINDIRBASE)
 
 flash: all
+	$(AD)command -v $(FLASHER) >/dev/null 2>&1 || \
+		{ $(COLOR_ECHO) \
+		'${COLOR_RED} Flash program $(FLASHER) not found. Aborting.${COLOR_RESET}'; \
+		exit 1; }
 	$(FLASHER) $(FFLAGS)
 
 term: $(filter flash, $(MAKECMDGOALS))
+	$(AD)command -v $(TERMPROG) >/dev/null 2>&1 || \
+		{ $(COLOR_ECHO) \
+		'${COLOR_RED} Terminal program $(TERMPROG) not found. Aborting.${COLOR_RESET}'; \
+		exit 1; }
 	$(TERMPROG) $(TERMFLAGS)
 
 doc:
 	make -BC $(RIOTBASE) doc
 
 debug:
+	$(AD)command -v $(DEBUGGER) >/dev/null 2>&1 || \
+		{ $(COLOR_ECHO) \
+		'${COLOR_RED} Debug program $(DEBUGGER) not found. Aborting.${COLOR_RESET}'; \
+		exit 1; }
 	$(DEBUGGER) $(DEBUGGER_FLAGS)
 
 debug-server:
+	$(AD)command -v $(DEBUGSERVER) >/dev/null 2>&1 || \
+		{ $(COLOR_ECHO) \
+		'${COLOR_RED} Debug server program $(DEBUGSERVER) not found. Aborting.${COLOR_RESET}'; \
+		exit 1; }
 	$(DEBUGSERVER) $(DEBUGSERVER_FLAGS)
 
 reset:
+	$(AD)command -v $(RESET) >/dev/null 2>&1 || \
+		{ $(COLOR_ECHO) \
+		'${COLOR_RED} Reset program $(RESET) not found. Aborting.${COLOR_RESET}'; \
+		exit 1; }
 	$(RESET) $(RESET_FLAGS)
 
 objdump:
+	$(AD)command -v $(PREFIX)objdump >/dev/null 2>&1 || \
+		{ $(COLOR_ECHO) \
+		'${COLOR_RED} Objdump program $(PREFIX)objdump not found. Aborting.${COLOR_RESET}'; \
+		exit 1; }
 	$(PREFIX)objdump -S -D -h $(ELFFILE) | less
 
 # Extra make goals for testing and comparing changes.

--- a/Makefile.include
+++ b/Makefile.include
@@ -91,6 +91,10 @@ ifeq (,$(UNZIP_HERE))
   endif
 endif
 
+ifneq (0,$(shell test -d $(RIOTBOARD)/$(BOARD); echo $$?))
+    $(error The specified board $(BOARD) does not exist.)
+endif
+
 # mandatory includes!
 include $(RIOTBASE)/Makefile.modules
 include $(RIOTBOARD)/$(BOARD)/Makefile.include


### PR DESCRIPTION
Fixes #1110.

- [x] check for compiler existence
- [x]  missing flash tool (i.e., st-link)
- [x]  pyterm not in path
- [x]  board does not exist

~~- [ ]  RIOTBASE is wrongly set~~
