### PR TITLE
doc / dist: documentation and one example script for pytermcontroller

### DIFF
--- a/dist/tools/pyterm/README.md
+++ b/dist/tools/pyterm/README.md
@@ -14,6 +14,16 @@ pytermcontroller.
 demonstrates some of the features of pytermcontroller. A look into
 ```pytermcontroller-example/desvirt/exampleDesVirt.py``` is advisable.
 
+# Dependencies
+
+* pyterm: requires a few basic python modules (inlcuding twisted). 
+Check the import statements at the top of the ```pyterm``` file for more 
+details. 
+* pytermcontroller: requires twisted python modules.
+* testbeds: most classes require GNU ```screen``` to be in your ```$PATH``` 
+The DESTestbed class additionally requires the command ```parallel-ssh```
+(see https://code.google.com/p/parallel-ssh/).
+
 # pyterm
 
 ```
@@ -69,10 +79,11 @@ This module contains the following classes:
 It declares multiple functions a testbed should have (e.g. flashing nodes,
 initializing nodes, assignment of transceiver addresses etc.)
 * DESTestbed: An implementation of Testbed for the DES-testbed at Freie
-Universität Berlin. The init function of this class must be supplied with
-a host file which is a newline separated list of mesh-router host names. The
-numerical transceiver addresses for each node corresponds to the line number in
-the host file. The corresponding ExperimentRuner should be executed on "uhu".
+Universität Berlin (http://des-testbed.net). The init function of this class 
+must be supplied with a host file which is a newline separated list of mesh-router 
+host names. The numerical transceiver addresses for each node corresponds to 
+the line number in the host file. The corresponding ExperimentRuner should 
+be executed on on host "uhu.imp.fu-berlin.de", the DES-testbed server. 
 * LocalTestbed: This class automatically finds all locally connected boards and
 treats those boards as a testbed. This is done by searching for ttyUSB\* devices
 in /dev. Transceiver addresses are assigned in the order the devices are found

--- a/dist/tools/pyterm/README.md
+++ b/dist/tools/pyterm/README.md
@@ -1,0 +1,84 @@
+# About
+This directory contains:
+
+* pyterm: A terminal program written in python.
+
+* pytermcontroller: A python module which implements a control server for
+pyterms.
+
+* testbeds: Contains classes which abstract certain functions of different
+testbeds. The classes are designed to be used in conjuction with
+pytermcontroller.
+
+* pytermcontroller-example: This directory contains scripts which
+demonstrates some of the features of pytermcontroller. A look into
+```pytermcontroller-example/desvirt/exampleDesVirt.py``` is advisable.
+
+# pyterm
+
+```
+usage: pyterm [-h] [-p PORT] [-ts TCP_SERIAL] [-b BAUDRATE] [-d DIRECTORY]
+              [-c CONFIG] [-s SERVER] [-P TCP_PORT] [-H HOST] [-rn RUN_NAME]
+              [-ln LOG_DIR_NAME]
+
+Pyterm - The Python terminal program
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -p PORT, --port PORT  Specifies the serial port to use, default is
+                        /dev/ttyUSB0
+  -ts TCP_SERIAL, --tcp-serial TCP_SERIAL
+                        Connect to a TCP port instead of a serial port
+  -b BAUDRATE, --baudrate BAUDRATE
+                        Specifies baudrate for the serial port, default is
+                        115200
+  -d DIRECTORY, --directory DIRECTORY
+                        Specify the Pyterm directory, default is
+                        /home/philipp/.pyterm
+  -c CONFIG, --config CONFIG
+                        Specify the config filename, default is pyterm-
+                        isengart.conf
+  -s SERVER, --server SERVER
+                        Connect via TCP to this server to send output as JSON
+  -P TCP_PORT, --tcp_port TCP_PORT
+                        Port at the JSON server
+  -H HOST, --host HOST  Hostname of this maschine
+  -rn RUN_NAME, --run-name RUN_NAME
+                        Run name, used for logfile
+  -ln LOG_DIR_NAME, --log-dir-name LOG_DIR_NAME
+                        Log directory name (default is hostname e.g.
+                        /home/foobar/.pyterm/<hostname>)
+```
+
+
+# pytermcontroller
+
+Currently, the module pytermcontroller contains the following classes:
+
+* PubProtocol and PubFactory: For internal use only.
+* Experiment: An abstract implementation of an experiment. If you define your own
+experiment you are expected to inherent from this class.
+* ExperimentRunner: A class which executes a given experiment on a given testbed.
+This class also starts a TCP server. A pyterm instance may connect to this server
+by using the -s and -P option.
+
+# testbeds
+
+This module contains the following classes:
+* Testbed: An abstract class every testbed implementation must inherent from.
+It declares multiple functions a testbed should have (e.g. flashing nodes,
+initializing nodes, assignment of transceiver addresses etc.)
+* DESTestbed: An implementation of Testbed for the DES-testbed at Freie
+Universität Berlin. The init function of this class must be supplied with
+a host file which is a newline separated list of mesh-router host names. The
+numerical transceiver addresses for each node corresponds to the line number in
+the host file. The corresponding ExperimentRuner should be executed on "uhu".
+* LocalTestbed: This class automatically finds all locally connected boards and
+treats those boards as a testbed. This is done by searching for ttyUSB\* devices
+in /dev. Transceiver addresses are assigned in the order the devices are found
+(typically /dev/ttyUSB0 gets address 1, /dev/ttyUSB1 gets address 2 etc.).
+* DesVirtTestbed: Allows you to run your experiment in a network consisting of
+native port instances. The init function needs to be supplied with the path to
+ desvirt (see https://github.com/des-testbed/desvirt for details) and the name
+ of a topology. The topology must be created according to the desvirt howto
+ beforehand.

--- a/dist/tools/pyterm/pytermcontroller-example/desvirt/README.md
+++ b/dist/tools/pyterm/pytermcontroller-example/desvirt/README.md
@@ -1,0 +1,60 @@
+# About
+This script uses desvirt (native port + native net) in order to illustrate
+the usage of pytermcontroller.
+
+## Usage
+1. Make sure desvirt is setup. In order to do so execute ```make``` in
+RIOT/pkg/desvirt. This will also setup a simple network toplogy consisting of
+three nodes. Each node will execute RIOT/example/default/bin/native/default.elf.
+
+2. If you haven't already done it compile RIOT/example/default for native:
+
+```Shell
+cd your_riot_path/example/default
+make
+```
+
+3. Execute exampleDesVirt.py. It might be that you are asked for your sudo password. This is required in order
+to setup the network bridges etc.
+
+6. You should see an output similar to this:
+```
+Running preHook
+executing: ./vnet --start --name example in: ./../../../../../pkg/desvirt/desvirt
+vnet           : Lockfile .desvirt/lib/example.lock exists, network is already defined.
+[sudo] password for philipp:
+name: example_a1 port: 4711
+name: example_a2 port: 4713
+name: example_a3 port: 4712
+Running experiment
+rm -rf /home/philipp/.pyterm/log/*.log
+screen -S pyterm-example_a1 -d -m python ./../../pyterm -slocalhost -P 1025 -H example_a1 -rn example_a1 -ts 4711 -ln log
+screen -S pyterm-example_a2 -d -m python ./../../pyterm -slocalhost -P 1025 -H example_a2 -rn example_a2 -ts 4713 -ln log
+screen -S pyterm-example_a3 -d -m python ./../../pyterm -slocalhost -P 1025 -H example_a3 -rn example_a3 -ts 4712 -ln log
+new connection made
+dataReceived added: example_a2
+new connection made
+dataReceived added: example_a1
+new connection made
+dataReceived added: example_a3
+Running postHook
+cd /home/philipp/.pyterm/log/..; tar -cjf archived_logs-MyExperiment_2015-02-22_17_05_06.tar.bz2 log/*.log
+stop called
+screen -X -S pyterm-example_a1 quit
+screen -X -S pyterm-example_a2 quit
+screen -X -S pyterm-example_a3 quit
+vnet           : Loaded statefile .desvirt/lib/example.macs.
+vnet           : Loaded statefile .desvirt/lib/example.taps.
+vnet           : Loaded statefile .desvirt/lib/example.pids.
+vnet           : Network Name: example
+vnet           : Shutting down bridge and links...
+vnet           : Shutting down nodes...
+riotnative     : Kill the RIOT: ../../../examples/default/bin/native/default.elf (28599)
+riotnative     : Kill the RIOT: ../../../examples/default/bin/native/default.elf (28602)
+riotnative     : Kill the RIOT: ../../../examples/default/bin/native/default.elf (28605)
+vnet           : Network stopped.
+```
+
+6. The resulting log files can be found in ```~/.pyterm/log```. Each file name in this directory corresponds
+to the host name of a node. In addition to that a bz2 compressed tar ball is created when the experiment ends.
+This file can be found in ```~/pyterm/``` (the exact filename can be found in the output of script).

--- a/dist/tools/pyterm/pytermcontroller-example/desvirt/README.md
+++ b/dist/tools/pyterm/pytermcontroller-example/desvirt/README.md
@@ -4,7 +4,7 @@ the usage of pytermcontroller.
 
 ## Usage
 1. Make sure desvirt is setup. In order to do so execute ```make``` in
-RIOT/pkg/desvirt. This will also setup a simple network toplogy consisting of
+RIOT/dist/tools/desvirt. This will also setup a simple network toplogy consisting of
 three nodes. Each node will execute RIOT/example/default/bin/native/default.elf.
 
 2. If you haven't already done it compile RIOT/example/default for native:
@@ -20,7 +20,7 @@ to setup the network bridges etc.
 6. You should see an output similar to this:
 ```
 Running preHook
-executing: ./vnet --start --name example in: ./../../../../../pkg/desvirt/desvirt
+executing: ./vnet --start --name example in: ./../../../../../dist/tools/desvirt/desvirt
 vnet           : Lockfile .desvirt/lib/example.lock exists, network is already defined.
 [sudo] password for philipp:
 name: example_a1 port: 4711

--- a/dist/tools/pyterm/pytermcontroller-example/desvirt/exampleDesVirt.py
+++ b/dist/tools/pyterm/pytermcontroller-example/desvirt/exampleDesVirt.py
@@ -35,7 +35,8 @@ from testbeds import DesVirtTestbed
 serverHost = "localhost"
 serverPort = 1025
 desvirtPath = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir,
-                           os.pardir, os.pardir, os.pardir, "pkg", "desvirt", "desvirt")
+                           os.pardir, os.pardir, os.pardir, "dist", "tools",
+                           "desvirt", "desvirt")
 topologyName = "example"
 pytermArgs = " -s" + serverHost + " -P " + str(serverPort)
 pyterm = os.path.join(pytermDir, "pyterm") + pytermArgs
@@ -53,8 +54,8 @@ class MyExperiment(Experiment):
         This can easily achieved by using the waitAndCall method.
 
         Keep in mind that starting pyterms and connecting those to the server
-        will take time. This function is executed regardless of how many pyterms
-        are connected to the server.
+        will take time. This function is executed regardless of how many
+        pyterms are connected to the server.
         """
         self.waitAndCall(10, self.setup)  # assign addresses to all nodes
                                           # after 10s
@@ -68,10 +69,11 @@ class MyExperiment(Experiment):
                     connection, "addr " + str(self.hostid[host]))
 
     def sendMessages(self):
-        """ Sends a simple command to all connected pyterm instances which causes
-        all nodes to broadcast a message over their transceiver.
+        """ Sends a simple command to all connected pyterm instances which
+        causes all nodes to broadcast a message over their transceiver.
 
-        Check the log files in your home directory (.pyterm/log) for the result.
+        Check the log files in your home directory (.pyterm/log) for the
+        result.
         """
         self.sendToAll("txtsnd 0 \"hello world\"")
 

--- a/dist/tools/pyterm/pytermcontroller-example/desvirt/exampleDesVirt.py
+++ b/dist/tools/pyterm/pytermcontroller-example/desvirt/exampleDesVirt.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014  Philipp Rosenkranz <philipp.rosenkranz@fu-berlin.de>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+import sys
+import os
+import re
+import datetime
+from os.path import expanduser
+
+# Add pytermcontroller and testbeds to class path
+pytermDir = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+sys.path.append(os.path.join(pytermDir, "pytermcontroller"))
+sys.path.append(os.path.join(pytermDir, "testbeds"))
+
+from pytermcontroller import Experiment, ExperimentRunner
+from testbeds import DesVirtTestbed
+
+serverHost = "localhost"
+serverPort = 1025
+desvirtPath = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir,
+                           os.pardir, os.pardir, os.pardir, "pkg", "desvirt", "desvirt")
+topologyName = "example"
+pytermArgs = " -s" + serverHost + " -P " + str(serverPort)
+pyterm = os.path.join(pytermDir, "pyterm") + pytermArgs
+logFilePath = os.path.join(expanduser("~"), ".pyterm", "log")
+
+
+class MyExperiment(Experiment):
+
+    def start(self):
+        """ This Method will be executed by the ExperimentRunner as soon as the
+        the control server is up.
+
+        It should be used to describe the chronology of actions executed by the
+        server.
+        This can easily achieved by using the waitAndCall method.
+
+        Keep in mind that starting pyterms and connecting those to the server
+        will take time. This function is executed regardless of how many pyterms
+        are connected to the server.
+        """
+        self.waitAndCall(10, self.setup)  # assign addresses to all nodes
+                                          # after 10s
+        self.waitAndCall(2, self.sendMessages)  # send a message on all nodes
+        self.waitAndCall(2, self.stop)  # shutdown the experiment / server
+
+    def setup(self):
+        for host, connection in self.clientIterator():
+            if self.hostid[host]:
+                self.sendToConnection(
+                    connection, "addr " + str(self.hostid[host]))
+
+    def sendMessages(self):
+        """ Sends a simple command to all connected pyterm instances which causes
+        all nodes to broadcast a message over their transceiver.
+
+        Check the log files in your home directory (.pyterm/log) for the result.
+        """
+        self.sendToAll("txtsnd 0 \"hello world\"")
+
+    def postHook(self):
+        """ Will be run after self.stop was called.
+        """
+        # archive log files (in your ~/.pyterm directory) with the name
+        # MyExperiment and the current date/time.
+        self.runner.testbed.archiveLogs("MyExperiment")
+
+
+class DesVirtMyExperiment(MyExperiment):
+
+    """ Some boilerplate code.
+
+    In newer versions of pytermcontroller this will be unnecessary.
+    """
+
+    def preHook(self):
+        """ will run before the start method is executed """
+        self.runner.testbed.startDesVirtNetwork()
+        namePortList = self.runner.testbed.findPorts()
+        address = 1
+        for tuple in namePortList:
+            self.hostid[tuple[0]] = address
+            address += 1
+
+
+testbed = DesVirtTestbed(serverHost, serverPort, desvirtPath, topologyName,
+                         pyterm, logFilePath)
+
+testbed.flashNodes()  # Note: this has no effect on DesVirtTestbed
+experiment = ExperimentRunner(DesVirtMyExperiment, testbed)
+experiment.run()

--- a/dist/tools/pyterm/testbeds/testbeds.py
+++ b/dist/tools/pyterm/testbeds/testbeds.py
@@ -19,7 +19,7 @@
 # 02110-1301 USA
 
 
-import os, re, datetime
+import sys, os, re, datetime
 from subprocess import call, Popen, PIPE
 
 
@@ -139,6 +139,9 @@ class DesVirtTestbed(Testbed):
         self.pyterm = pyterm
         self.logFilePath = logFilePath
         self.namePortList = []
+	if not os.path.isdir(self.desvirtPath):
+		print("desvirt not found! Try running 'make' in RIOT/pkg/desvirt")
+		sys.exit(-1)
         
     def findPorts(self):        
         return self.namePortList

--- a/dist/tools/pyterm/testbeds/testbeds.py
+++ b/dist/tools/pyterm/testbeds/testbeds.py
@@ -140,7 +140,7 @@ class DesVirtTestbed(Testbed):
         self.logFilePath = logFilePath
         self.namePortList = []
 	if not os.path.isdir(self.desvirtPath):
-		print("desvirt not found! Try running 'make' in RIOT/pkg/desvirt")
+		print("desvirt not found! Try running 'make' in RIOT/dist/tools/desvirt")
 		sys.exit(-1)
         
     def findPorts(self):        


### PR DESCRIPTION
This adds documentation for pytermcontroller and a example script which illustrates its usage.
The example script uses desvirt as a testbed. Thus this PR is based on #2484.