### PR TITLE
keyword_space.sed: Add \b to avoid changing functions which end with the same letters as the keywords.

### DIFF
--- a/keyword_space.sed
+++ b/keyword_space.sed
@@ -1,7 +1,7 @@
-s/if(/if (/
-s/switch(/switch (/
-s/case(/case (/
-s/while(/while (/
-s/for(/for (/
-s/do(/do (/
+s/\bif(/if (/
+s/\bswitch(/switch (/
+s/\bcase(/case (/
+s/\bwhile(/while (/
+s/\bfor(/for (/
+s/\bdo(/do (/
 s/! /!/


### PR DESCRIPTION
Avoids adding spaces to calls to functions which have the same ending as the keywords matched, e.g. `sched_switch()` etc.