### PR TITLE
rpl: use the all-RPL-nodes multicast address

### DIFF
--- a/sys/net/include/sixlowpan/ip.h
+++ b/sys/net/include/sixlowpan/ip.h
@@ -298,6 +298,25 @@ static inline void ipv6_addr_set_all_nodes_addr(ipv6_addr_t *ipv6_addr)
 }
 
 /**
+ * @brief   Set *ipv6_addr* to the all-RPL-nodes multicast address
+ *          (ff02::1a).
+ *
+ * @see <a href="http://tools.ietf.org/html/rfc6550#section-6">
+ *          RFC 6550
+ *      </a>
+ *
+ * @param[out] ipv6_addr    Is set to the all-RPL-nodes multicast
+ *                          address.
+ */
+static inline void ipv6_addr_set_all_rpl_nodes_addr(ipv6_addr_t *ipv6_addr)
+{
+    ipv6_addr->uint32[0] = HTONL(0xff020000);
+    ipv6_addr->uint32[1] = 0;
+    ipv6_addr->uint32[2] = 0;
+    ipv6_addr->uint32[3] = HTONL(0x1a);
+}
+
+/**
  * @brief   Set *ipv6_addr_out* to the solicited-node multicast address
  *          computed from *ipv6_addr_in*.
  *

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -92,6 +92,12 @@ uint8_t rpl_init(int if_id)
     ipv6_addr_set_link_local_prefix(&ll_address);
     ipv6_net_if_get_best_src_addr(&my_address, &ll_address);
     ipv6_register_rpl_handler(rpl_process_pid);
+
+    /* add all-RPL-nodes address */
+    ipv6_addr_t all_rpl_nodes;
+    ipv6_addr_set_all_rpl_nodes_addr(&all_rpl_nodes);
+    ipv6_net_if_add_addr(if_id, &all_rpl_nodes, NDP_ADDR_STATE_ANY, 0, 0, 0);
+
 #if (RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE)
     ipv6_iface_set_srh_indicator(rpl_is_root);
 #endif

--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -40,7 +40,7 @@ void rpl_trickle_send_dio(void *args)
     (void) args;
     ipv6_addr_t mcast;
 
-    ipv6_addr_set_all_nodes_addr(&mcast);
+    ipv6_addr_set_all_rpl_nodes_addr(&mcast);
     rpl_send_DIO(&mcast);
 }
 


### PR DESCRIPTION
References #2490 
Currently, control messages have the destination address `ff02::1`.
However, [RFC 6550](http://tools.ietf.org/html/rfc6550#section-6) states to use the new all-RPL-nodes multicast address `ff02::1a`