### PR TITLE
rpl: Make addr_str static

### DIFF
--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -38,7 +38,7 @@
 
 #define ENABLE_DEBUG (0)
 #if ENABLE_DEBUG
-char addr_str[IPV6_MAX_ADDR_STR_LEN];
+static char addr_str[IPV6_MAX_ADDR_STR_LEN];
 #endif
 #include "debug.h"
 


### PR DESCRIPTION
It is only used locally. Enabling debug causes build errors because of conflicts with a similar buffer in the rpl_udp example.