### PR TITLE
sixlowpan: Properly print source address when ENABLE_DEBUG

### DIFF
--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -890,9 +890,10 @@ uint16_t ipv6_csum(ipv6_hdr_t *ipv6_header, uint8_t *buf, uint16_t len,
                    uint8_t proto)
 {
     uint16_t sum = 0;
-    DEBUG("Calculate checksum over src: %s, dst: %s, len: %04X, buf: %p, proto: %u\n",
+    DEBUG("Calculate checksum over src: %s, ",
           ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN,
-                           &ipv6_header->srcaddr),
+                           &ipv6_header->srcaddr));
+    DEBUG("dst: %s, len: %04X, buf: %p, proto: %u\n",
           ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN,
                            &ipv6_header->destaddr),
           len, buf, proto);


### PR DESCRIPTION
The addr_str buffer was overwritten by the second call to ipv6_addr_to_str.