### PR TITLE
sixlowpan: Handle 16-bit addresses correctly (both decode and encode)

### DIFF
--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -1011,12 +1011,11 @@ uint8_t lowpan_iphc_encoding(int if_id, const uint8_t *dest, int dest_len,
                  * and possibly the link-layer addresses.*/
                 lowpan_iphc[1] |= 0x30;
             }
-            else if ((ipv6_buf->srcaddr.uint16[4] == 0) &&
-                     (ipv6_buf->srcaddr.uint16[5] == 0) &&
-                     (ipv6_buf->srcaddr.uint16[6] == 0) &&
-                     ((ipv6_buf->srcaddr.uint8[14]) & 0x80) == 0) {
-                /* 49-bit of interface identifier are 0, so we can compress
-                 * source address-iid to 16-bit */
+            else if ((ipv6_buf->srcaddr.uint32[2] == HTONL(0x000000ffu)) &&
+                     (ipv6_buf->srcaddr.uint16[6] == HTONL(0xfe00u))) {
+                /* The 48 leading bits of the interface identifier are
+                 * 0000:00FF:FE00, so we can compress the source address-iid to
+                 * 16-bit */
                 memcpy(&ipv6_hdr_fields[hdr_pos], &ipv6_buf->srcaddr.uint16[7], 2);
                 hdr_pos += 2;
                 /* 16 bits. The address is derived using context information

--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -874,7 +874,7 @@ void lowpan_read(uint8_t *data, uint8_t length, net_if_eui64_t *s_addr,
 
 }
 
-/* draft-ietf-6lowpan-hc-13#section-3.1 */
+/* RFC6282 https://tools.ietf.org/html/rfc6282#section-3.1 */
 uint8_t lowpan_iphc_encoding(int if_id, const uint8_t *dest, int dest_len,
                              ipv6_hdr_t *ipv6_buf_extra, uint8_t *ptr)
 {

--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -1271,6 +1271,7 @@ void lowpan_iphc_decoding(uint8_t *data, uint8_t length, net_if_eui64_t *s_addr,
     /* Generate IPv6 address from stateless information, if SAC=1 we will use
      * this stateless information as a starting point for the stateful
      * information. */
+    /* RFC 6282 describes each of the following address compression methods */
     switch (((lowpan_iphc[1] & SIXLOWPAN_IPHC2_SAM) >> 4) & 0x03) {
         case (0x01): {
             /* 64-bits */
@@ -1284,7 +1285,10 @@ void lowpan_iphc_decoding(uint8_t *data, uint8_t length, net_if_eui64_t *s_addr,
         case (0x02): {
             /* 16-bits */
             memcpy(&(ipv6_buf->srcaddr.uint8[0]), &ll_prefix[0], 2);
-            memset(&(ipv6_buf->srcaddr.uint8[2]), 0, 12);
+            ipv6_buf->srcaddr.uint16[1] = HTONS(0x0000u);
+            ipv6_buf->srcaddr.uint32[1] = HTONL(0x00000000u);
+            ipv6_buf->srcaddr.uint32[2] = HTONL(0x000000ffu);
+            ipv6_buf->srcaddr.uint16[6] = HTONS(0xfe00u);
             memcpy(&(ipv6_buf->srcaddr.uint8[14]), &ipv6_hdr_fields[hdr_pos], 2);
             hdr_pos += 2;
             break;
@@ -1418,7 +1422,10 @@ void lowpan_iphc_decoding(uint8_t *data, uint8_t length, net_if_eui64_t *s_addr,
             case (0x02): {
                 /* 16-bits */
                 memcpy(&(ipv6_buf->destaddr.uint8[0]), &ll_prefix[0], 2);
-                memset(&(ipv6_buf->destaddr.uint8[2]), 0, 12);
+                ipv6_buf->destaddr.uint16[1] = HTONS(0x0000u);
+                ipv6_buf->destaddr.uint32[1] = HTONL(0x00000000u);
+                ipv6_buf->destaddr.uint32[2] = HTONL(0x000000ffu);
+                ipv6_buf->destaddr.uint16[6] = HTONS(0xfe00u);
                 memcpy(&(ipv6_buf->destaddr.uint8[14]), &ipv6_hdr_fields[hdr_pos], 2);
                 hdr_pos += 2;
                 break;


### PR DESCRIPTION
The 16 bit address decoding was setting all elided bits to zero, according to RFC 6282 it should set FFFE in the middle of the last 64 bits.

10:  16 bits.  The first 112 bits of the address are elided.
The value of the first 64 bits is the link-local prefix padded with zeros.
The following 64 bits are 0000:00ff:fe00:XXXX, where XXXX are the 16 bits carried in-line.

See https://tools.ietf.org/html/rfc6282