### PR TITLE
sys/nhdp: Remove temp address lists to optimize hello processing

### DIFF
--- a/sys/net/routing/nhdp/iib_table.h
+++ b/sys/net/routing/nhdp/iib_table.h
@@ -96,20 +96,14 @@ int iib_register_if(kernel_pid_t pid);
  *
  * @param[in] if_pid        PID of the interface the message was received on
  * @param[in] nb_elt        Pointer to the Neighbor Tuple for the message originator
- * @param[in] send_list     Pointer to the Sending Address List from the received HELLO
- * @param[in] th_sym_list   Pointer to the Addr List of the originator's symmetric 2-Hop neighbors
- * @param[in] th_rem_list   Pointer to the Addr List of the originator's lost 2-Hop neighbors
- * @param[in] rem_list      Pointer to the Removed Address List
  * @param[in] validity_time Validity time in milliseconds for the originator's information
  * @param[in] is_sym_nb     Flag whether the link to the originator is symmetric
  * @param[in] is_lost       Flag whether the originator marked this link as lost
  *
  * @return                  0 on success
  */
-int iib_process_hello(kernel_pid_t if_pid, nib_entry_t *nb_elt, nhdp_addr_entry_t *send_list,
-                      nhdp_addr_entry_t *th_sym_list, nhdp_addr_entry_t *th_rem_list,
-                      nhdp_addr_entry_t *rem_list, uint64_t validity_time, uint8_t is_sym_nb,
-                      uint8_t is_lost);
+int iib_process_hello(kernel_pid_t if_pid, nib_entry_t *nb_elt,
+                      uint64_t validity_time, uint8_t is_sym_nb, uint8_t is_lost);
 
 /**
  * @brief                   Add addresses to the currently constructed HELLO message

--- a/sys/net/routing/nhdp/nhdp_address.c
+++ b/sys/net/routing/nhdp/nhdp_address.c
@@ -115,34 +115,47 @@ void nhdp_free_addr_entry(nhdp_addr_entry_t *addr_entry)
     free(addr_entry);
 }
 
-nhdp_addr_entry_t *nhdp_generate_new_addr_list(nhdp_addr_entry_t *orig_list)
+nhdp_addr_entry_t *nhdp_generate_addr_list_from_tmp(uint8_t tmp_type)
 {
-    nhdp_addr_entry_t *new_list_head, *addr_elt;
+    nhdp_addr_entry_t *new_list_head;
+    nhdp_addr_t *addr_elt;
 
     new_list_head = NULL;
-    LL_FOREACH(orig_list, addr_elt) {
-        nhdp_addr_entry_t *new_entry = (nhdp_addr_entry_t *) malloc(sizeof(nhdp_addr_entry_t));
+    LL_FOREACH(nhdp_addr_db_head, addr_elt) {
+        if (addr_elt->in_tmp_table & tmp_type) {
+            nhdp_addr_entry_t *new_entry = (nhdp_addr_entry_t *) malloc(sizeof(nhdp_addr_entry_t));
 
-        if (!new_entry) {
-            /* Insufficient memory, free all previously allocated memory */
-            nhdp_free_addr_list(new_list_head);
-            return NULL;
+            if (!new_entry) {
+                /* Insufficient memory, free all previously allocated memory */
+                nhdp_free_addr_list(new_list_head);
+                return NULL;
+            }
+
+            new_entry->address = addr_elt;
+            /* Increment usage counter of address in central NHDP address storage */
+            addr_elt->usg_count++;
+            LL_PREPEND(new_list_head, new_entry);
         }
-
-        new_entry->address = addr_elt->address;
-        /* Increment usage counter of address in central NHDP address storage */
-        addr_elt->address->usg_count++;
-        LL_PREPEND(new_list_head, new_entry);
     }
 
     return new_list_head;
 }
 
-void nhdp_reset_addresses_tmp_usg(void)
+void nhdp_reset_addresses_tmp_usg(uint8_t decr_usg)
 {
-    nhdp_addr_t *addr_elt;
+    nhdp_addr_t *addr_elt, *addr_tmp;
 
-    LL_FOREACH(nhdp_addr_db_head, addr_elt) {
-        addr_elt->in_tmp_table = NHDP_ADDR_TMP_NONE;
+    LL_FOREACH_SAFE(nhdp_addr_db_head, addr_elt, addr_tmp) {
+        if (addr_elt->in_tmp_table) {
+            addr_elt->in_tmp_table = NHDP_ADDR_TMP_NONE;
+            if (decr_usg) {
+                nhdp_decrement_addr_usage(addr_elt);
+            }
+        }
     }
+}
+
+nhdp_addr_t *nhdp_get_addr_db_head(void)
+{
+    return nhdp_addr_db_head;
 }

--- a/sys/net/routing/nhdp/nhdp_address.h
+++ b/sys/net/routing/nhdp/nhdp_address.h
@@ -51,9 +51,19 @@ typedef struct nhdp_addr_entry_t {
 #define NHDP_ADDR_TMP_NONE          (0x00)
 #define NHDP_ADDR_TMP_ANY           (0x01)
 #define NHDP_ADDR_TMP_SYM           (0x03)
+#define NHDP_ADDR_TMP_REM_LIST      (0x04)
+#define NHDP_ADDR_TMP_TH_REM_LIST   (0x08)
+#define NHDP_ADDR_TMP_TH_SYM_LIST   (0x10)
+#define NHDP_ADDR_TMP_NB_LIST       (0x20)
+#define NHDP_ADDR_TMP_SEND_LIST     (0x60)
 
-#define NHDP_ADDR_TMP_IN_SYM(addr)  ((addr->in_tmp_table & 0x02) >> 1)
-#define NHDP_ADDR_TMP_IN_ANY(addr)  ((addr->in_tmp_table & 0x01))
+#define NHDP_ADDR_TMP_IN_ANY(addr)          ((addr->in_tmp_table & 0x01))
+#define NHDP_ADDR_TMP_IN_SYM(addr)          ((addr->in_tmp_table & 0x02) >> 1)
+#define NHDP_ADDR_TMP_IN_REM_LIST(addr)     ((addr->in_tmp_table & 0x04) >> 2)
+#define NHDP_ADDR_TMP_IN_TH_REM_LIST(addr)  ((addr->in_tmp_table & 0x08) >> 3)
+#define NHDP_ADDR_TMP_IN_TH_SYM_LIST(addr)  ((addr->in_tmp_table & 0x10) >> 4)
+#define NHDP_ADDR_TMP_IN_NB_LIST(addr)      ((addr->in_tmp_table & 0x20) >> 5)
+#define NHDP_ADDR_TMP_IN_SEND_LIST(addr)    ((addr->in_tmp_table & 0x40) >> 6)
 /** @} */
 
 /**
@@ -97,22 +107,31 @@ void nhdp_free_addr_list(nhdp_addr_entry_t *list_head);
 void nhdp_free_addr_entry(nhdp_addr_entry_t *addr_entry);
 
 /**
- * @brief                   Construct an address list containing the addresses of the given list
- *
- * @param[in] orig_list     Pointer to the head of the address list to 'clone'
+ * @brief                   Construct an addr list containing all addresses with
+ *                          the given tmp_type
  *
  * @return                  Pointer to the head of the newly created address list
  * @return                  NULL on error
  */
-nhdp_addr_entry_t *nhdp_generate_new_addr_list(nhdp_addr_entry_t *orig_list);
+nhdp_addr_entry_t *nhdp_generate_addr_list_from_tmp(uint8_t tmp_type);
 
 /**
  * @brief                   Reset in_tmp_table flag of all NHDP addresses
  *
  * @note
- * Must not be called from outside the NHDP writer's message creation process.
+ * Must not be called from outside the NHDP writer's or reader's message creation process.
+ *
+ * @param[in] decr_usg      Flag whether the usage counter of a resetted addr has to be decremented
  */
-void nhdp_reset_addresses_tmp_usg(void);
+void nhdp_reset_addresses_tmp_usg(uint8_t decr_usg);
+
+/**
+ * @brief                   Get a pointer to the head of the address storage list
+ *
+ * @return                  Pointer to the head of the central storage address list
+ * @return                  NULL if no addresses are registered
+ */
+nhdp_addr_t *nhdp_get_addr_db_head(void);
 
 #ifdef __cplusplus
 }

--- a/sys/net/routing/nhdp/nhdp_reader.c
+++ b/sys/net/routing/nhdp/nhdp_reader.c
@@ -36,12 +36,6 @@
 struct rfc5444_reader reader;
 static mutex_t mtx_packet_handler = MUTEX_INIT;
 
-static nhdp_addr_entry_t *send_addr_list_head;
-static nhdp_addr_entry_t *nb_addr_list_head;
-static nhdp_addr_entry_t *th_sym_addr_list_head;
-static nhdp_addr_entry_t *th_rem_addr_list_head;
-static nhdp_addr_entry_t *rem_addr_list_head;
-
 static kernel_pid_t if_pid;
 static uint64_t val_time;
 static uint64_t int_time;
@@ -57,7 +51,6 @@ static enum rfc5444_result check_msg_validity(struct rfc5444_reader_tlvblock_con
 static enum rfc5444_result check_addr_validity(nhdp_addr_t *addr);
 static nhdp_addr_t *get_nhdp_db_addr(uint8_t *addr, uint8_t prefix);
 static void process_temp_tables(void);
-static void cleanup_temp_addr_lists(void);
 
 /* Array containing the processable message TLVs for HELLO messages */
 static struct rfc5444_reader_tlvblock_consumer_entry _nhdp_msg_tlvs[] = {
@@ -93,13 +86,6 @@ static struct rfc5444_reader_tlvblock_consumer _nhdp_address_consumer = {
 
 void nhdp_reader_init(void)
 {
-    /* Reset locally created address lists */
-    send_addr_list_head = NULL;
-    nb_addr_list_head = NULL;
-    th_sym_addr_list_head = NULL;
-    th_rem_addr_list_head = NULL;
-    rem_addr_list_head = NULL;
-
     /* Initialize reader */
     rfc5444_reader_init(&reader);
 
@@ -128,7 +114,6 @@ int nhdp_reader_handle_packet(kernel_pid_t rcvg_if_pid, void *buffer, size_t len
 
 void nhdp_reader_cleanup(void)
 {
-    cleanup_temp_addr_lists();
     rfc5444_reader_cleanup(&reader);
 }
 
@@ -145,26 +130,18 @@ static enum rfc5444_result
 _nhdp_blocktlv_address_cb(struct rfc5444_reader_tlvblock_context *cont)
 {
     uint8_t tmp_result;
-    /* Create address list entry to add it later to one of the temp address lists */
-    nhdp_addr_entry_t *current_addr = (nhdp_addr_entry_t *) malloc(sizeof(nhdp_addr_entry_t));
+
+    /* Get NHDP address for the current netaddr */
+    nhdp_addr_t *current_addr = get_nhdp_db_addr(&cont->addr._addr[0], cont->addr._prefix_len);
 
     if (!current_addr) {
         /* Insufficient memory */
         return RFC5444_DROP_MESSAGE;
     }
 
-    /* Get NHDP address for the current netaddr */
-    current_addr->address = get_nhdp_db_addr(&cont->addr._addr[0], cont->addr._prefix_len);
-
-    if (!current_addr->address) {
-        /* Insufficient memory */
-        free(current_addr);
-        return RFC5444_DROP_MESSAGE;
-    }
-
     /* Check validity of address tlvs */
-    if (check_addr_validity(current_addr->address) != RFC5444_OKAY) {
-        nhdp_free_addr_entry(current_addr);
+    if (check_addr_validity(current_addr) != RFC5444_OKAY) {
+        nhdp_decrement_addr_usage(current_addr);
         return RFC5444_DROP_MESSAGE;
     }
 
@@ -172,32 +149,20 @@ _nhdp_blocktlv_address_cb(struct rfc5444_reader_tlvblock_context *cont)
     if (_nhdp_addr_tlvs[RFC5444_ADDRTLV_LOCAL_IF].tlv) {
         switch (*_nhdp_addr_tlvs[RFC5444_ADDRTLV_LOCAL_IF].tlv->single_value) {
             case RFC5444_LOCALIF_THIS_IF:
-                LL_PREPEND(send_addr_list_head, current_addr);
-                /* Local IF marked addresses have to be added to two temp lists */
-                nhdp_addr_entry_t *sec_container =
-                    (nhdp_addr_entry_t *) malloc(sizeof(nhdp_addr_entry_t));
-
-                if (!sec_container) {
-                    return RFC5444_DROP_MESSAGE;
-                }
-
-                /* Increment usage counter of address in central NHDP address storage */
-                current_addr->address->usg_count++;
-                sec_container->address = current_addr->address;
-                LL_PREPEND(nb_addr_list_head, sec_container);
+                current_addr->in_tmp_table = NHDP_ADDR_TMP_SEND_LIST;
                 break;
 
             case RFC5444_LOCALIF_OTHER_IF:
-                LL_PREPEND(nb_addr_list_head, current_addr);
+                current_addr->in_tmp_table = NHDP_ADDR_TMP_NB_LIST;
                 break;
 
             default:
                 /* Wrong value, drop message */
-                nhdp_free_addr_entry(current_addr);
+                nhdp_decrement_addr_usage(current_addr);
                 return RFC5444_DROP_MESSAGE;
         }
     }
-    else if ((tmp_result = lib_is_reg_addr(if_pid, current_addr->address))) {
+    else if ((tmp_result = lib_is_reg_addr(if_pid, current_addr))) {
         /* The address is one of our local addresses (do not add it for processing) */
         if ((!sym) && (tmp_result == 1) && _nhdp_addr_tlvs[RFC5444_ADDRTLV_LINK_STATUS].tlv) {
             /* If address is a local address of the receiving interface, check */
@@ -216,18 +181,18 @@ _nhdp_blocktlv_address_cb(struct rfc5444_reader_tlvblock_context *cont)
 
                 default:
                     /* Wrong value, drop message */
-                    nhdp_free_addr_entry(current_addr);
+                    nhdp_decrement_addr_usage(current_addr);
                     return RFC5444_DROP_MESSAGE;
             }
         }
 
         /* Address is one of our own addresses, ignore it */
-        nhdp_free_addr_entry(current_addr);
+        nhdp_decrement_addr_usage(current_addr);
     }
     else if (_nhdp_addr_tlvs[RFC5444_ADDRTLV_LINK_STATUS].tlv) {
         switch (*_nhdp_addr_tlvs[RFC5444_ADDRTLV_LINK_STATUS].tlv->single_value) {
             case RFC5444_LINKSTATUS_SYMMETRIC:
-                LL_PREPEND(th_sym_addr_list_head, current_addr);
+                current_addr->in_tmp_table = NHDP_ADDR_TMP_TH_SYM_LIST;
                 break;
 
             case RFC5444_LINKSTATUS_HEARD:
@@ -238,39 +203,39 @@ _nhdp_blocktlv_address_cb(struct rfc5444_reader_tlvblock_context *cont)
                     && *_nhdp_addr_tlvs[RFC5444_ADDRTLV_OTHER_NEIGHB].tlv->single_value
                     == RFC5444_OTHERNEIGHB_SYMMETRIC) {
                     /* Symmetric has higher priority */
-                    LL_PREPEND(th_sym_addr_list_head, current_addr);
+                    current_addr->in_tmp_table = NHDP_ADDR_TMP_TH_SYM_LIST;
                 }
                 else {
-                    LL_PREPEND(th_rem_addr_list_head, current_addr);
+                    current_addr->in_tmp_table = NHDP_ADDR_TMP_TH_REM_LIST;
                 }
 
                 break;
 
             default:
                 /* Wrong value, drop message */
-                nhdp_free_addr_entry(current_addr);
+                nhdp_decrement_addr_usage(current_addr);
                 return RFC5444_DROP_MESSAGE;
         }
     }
     else if (_nhdp_addr_tlvs[RFC5444_ADDRTLV_OTHER_NEIGHB].tlv) {
         switch (*_nhdp_addr_tlvs[RFC5444_ADDRTLV_OTHER_NEIGHB].tlv->single_value) {
             case RFC5444_OTHERNEIGHB_SYMMETRIC:
-                LL_PREPEND(th_sym_addr_list_head, current_addr);
+                current_addr->in_tmp_table = NHDP_ADDR_TMP_TH_SYM_LIST;
                 break;
 
             case RFC5444_OTHERNEIGHB_LOST:
-                LL_PREPEND(th_rem_addr_list_head, current_addr);
+                current_addr->in_tmp_table = NHDP_ADDR_TMP_TH_REM_LIST;
                 break;
 
             default:
                 /* Wrong value, drop message */
-                nhdp_free_addr_entry(current_addr);
+                nhdp_decrement_addr_usage(current_addr);
                 return RFC5444_DROP_MESSAGE;
         }
     }
     else {
         /* Addresses without expected TLV are ignored */
-        nhdp_free_addr_entry(current_addr);
+        nhdp_decrement_addr_usage(current_addr);
         return RFC5444_DROP_ADDRESS;
     }
 
@@ -320,7 +285,7 @@ _nhdp_msg_end_cb(struct rfc5444_reader_tlvblock_context *cont __attribute__((unu
     int_time = 0ULL;
     sym = 0;
     lost = 0;
-    cleanup_temp_addr_lists();
+    nhdp_reset_addresses_tmp_usg(1);
 
     if (dropped) {
         return RFC5444_DROP_MESSAGE;
@@ -430,27 +395,9 @@ static void process_temp_tables(void)
     vtimer_now(&now);
     iib_update_lt_status(&now);
 
-    nib_elt = nib_process_hello(nb_addr_list_head, &rem_addr_list_head);
+    nib_elt = nib_process_hello();
 
     if (nib_elt) {
-        iib_process_hello(if_pid, nib_elt, send_addr_list_head, th_sym_addr_list_head,
-                          th_rem_addr_list_head, rem_addr_list_head, val_time, sym, lost);
+        iib_process_hello(if_pid, nib_elt, val_time, sym, lost);
     }
-}
-
-/**
- * Free all allocated space for the temporary address lists
- */
-static void cleanup_temp_addr_lists(void)
-{
-    nhdp_free_addr_list(send_addr_list_head);
-    nhdp_free_addr_list(nb_addr_list_head);
-    nhdp_free_addr_list(th_sym_addr_list_head);
-    nhdp_free_addr_list(th_rem_addr_list_head);
-    nhdp_free_addr_list(rem_addr_list_head);
-    send_addr_list_head = NULL;
-    nb_addr_list_head = NULL;
-    th_sym_addr_list_head = NULL;
-    th_rem_addr_list_head = NULL;
-    rem_addr_list_head = NULL;
 }

--- a/sys/net/routing/nhdp/nhdp_writer.c
+++ b/sys/net/routing/nhdp/nhdp_writer.c
@@ -209,7 +209,7 @@ static void _nhdp_add_addresses_cb(struct rfc5444_writer *wr)
     lib_fill_wr_addresses(nhdp_wr_curr_if_entry->if_pid, wr);
     iib_fill_wr_addresses(nhdp_wr_curr_if_entry->if_pid, wr);
     nib_fill_wr_addresses(wr);
-    nhdp_reset_addresses_tmp_usg();
+    nhdp_reset_addresses_tmp_usg(0);
 }
 
 /**

--- a/sys/net/routing/nhdp/nib_table.h
+++ b/sys/net/routing/nhdp/nib_table.h
@@ -53,13 +53,10 @@ typedef struct nib_lost_address_entry_t {
  * @note
  * Must not be called from outside the NHDP reader's message processing.
  *
- * @param[in] nb_list       Pointer to the Neighbor Address List from the received HELLO
- * @param[out] out_list     Pointer to the created Removed Address List
- *
  * @return                  Pointer to the new Neighbor Tuple
  * @return                  NULL on error
  */
-nib_entry_t *nib_process_hello(nhdp_addr_entry_t *nb_list, nhdp_addr_entry_t **out_list);
+nib_entry_t *nib_process_hello(void);
 
 /**
  * @brief                   Add addresses to the currently constructed HELLO message


### PR DESCRIPTION
This PR removes the temporary address lists used during hello processing. Instead of the lists the `in_tmp_table` flag of the addresses in the centralized address storage is used to signal whether an address is included in one of the temporary lists used in NHDP for hello processing.

This simplifies the code and reduces the code size and the usage of dynamic memory allocation.

An adapted example application can be found [here](https://github.com/fnack/RIOT/compare/nhdp_app_opt).