### PR TITLE
core: add logging API

### DIFF
--- a/Makefile.defaultmodules
+++ b/Makefile.defaultmodules
@@ -1,3 +1,4 @@
 DEFAULT_MODULE += cpu core sys
 
 DEFAULT_MODULE += auto_init
+DEFAULT_MODULE += log_printf

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1,3 +1,7 @@
+ifneq (,$(filter log_printfnoformat,$(USEMODULE)))
+	DISABLE_MODULE += log_printf
+endif
+
 ifneq (,$(filter libcoap,$(USEPKG)))
   USEMODULE += pnet
 endif

--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -2,3 +2,4 @@ PSEUDOMODULES += defaulttransceiver
 PSEUDOMODULES += transport_layer
 PSEUDOMODULES += pktqueue
 PSEUDOMODULES += ng_netbase
+PSEUDOMODULES += log_printf

--- a/core/clist.c
+++ b/core/clist.c
@@ -20,7 +20,7 @@
 
 #include <stddef.h>
 #include "clist.h"
-#include <stdio.h>
+#include "log.h"
 
 /* inserts new_node after node */
 void clist_add(clist_node_t **node, clist_node_t *new_node)
@@ -67,7 +67,7 @@ void clist_print(clist_node_t *clist)
     }
 
     do {
-        printf("list entry: %p: prev=%p next=%p\n", clist, clist->prev, clist->next);
+        log.info("list entry: %p: prev=%p next=%p\n", clist, clist->prev, clist->next);
         clist = clist->next;
 
         if (clist == start) {

--- a/core/clist.c
+++ b/core/clist.c
@@ -67,7 +67,7 @@ void clist_print(clist_node_t *clist)
     }
 
     do {
-        log.info("list entry: %p: prev=%p next=%p\n", clist, clist->prev, clist->next);
+        log_info("list entry: %p: prev=%p next=%p\n", clist, clist->prev, clist->next);
         clist = clist->next;
 
         if (clist == start) {

--- a/core/hwtimer.c
+++ b/core/hwtimer.c
@@ -22,14 +22,13 @@
  * @}
  */
 
-#include <stdio.h>
-
 #include "kernel.h"
 #include "thread.h"
 #include "lifo.h"
 #include "mutex.h"
 #include "irq.h"
 #include "board.h"
+#include "log.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -157,7 +156,7 @@ static int _hwtimer_set(unsigned long offset, void (*callback)(void*), void *ptr
     if (n == -1) {
         restoreIRQ(state);
 
-        puts("No hwtimer left.");
+        log_warning("No hwtimer left.");
         return -1;
     }
 

--- a/core/include/log.h
+++ b/core/include/log.h
@@ -69,8 +69,8 @@
  * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
  */
 
-#ifndef __LOG_H_
-#define __LOG_H_
+#ifndef LOG_H_
+#define LOG_H_
 
 #include <stdio.h>
 
@@ -170,5 +170,5 @@ void log_error(const char *format, ...);
 }
 #endif
 
-#endif /* __LOG_H_ */
+#endif /* LOG_H_ */
 /** @} */

--- a/core/include/log.h
+++ b/core/include/log.h
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2015 Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    core_log  Logging
+ * @ingroup     core
+ * @brief       Logging API
+ *
+ * ## Logging Modules
+ *
+ * The logging API can be implemented by several modules. Applications can
+ * choose a module that best suits their purpose.
+ *
+ * If no module is selected explicitly, the built-in default
+ * "log_printf" is used. It is a macro based implementation which
+ * replaces logging calls with printf expressions.
+ *
+ * ## Severity Levels
+ *
+ * To differentiate between importance of log messages, there are three
+ * severity levels:
+ * - info
+ * - warning
+ * - error
+ *
+ * ### Disabling Severity Levels
+ *
+ * Logging implementations may be configured to discard log messages of any
+ * kind.
+ *
+ * To discard logging levels explicitly, three macros may be set to `1`:
+ * - LOG_DISCARD_INFO
+ * - LOG_DISCARD_WARNING
+ * - LOG_DISCARD_ERROR
+ *
+ * ## Implementation Details
+ *
+ * To save memory, implementations are free to only process the first
+ * parameter.
+ *
+ * Implementations are not required to process every log message.
+ * A networked remote logging implementation for example could decide
+ * not to buffer messages that are logged while the network connection
+ * is unavailable.
+ *
+ * All implementations are required to document how they process
+ * messages if they deviate from expected behavior.
+ *
+ * ## Message Formatting
+ *
+ * All modules must prepend a severity level indicator to messages, so log
+ * readers may differentiate between them.
+ * The prefix is a single capital letter for the severity level followed by
+ * a colon and a space character:
+ * - info messages will be prefixed "I: "
+ * - warning messages will be prefixed "W: "
+ * - error messages will be prefixed "E: "
+ *
+ * @{
+ *
+ * @file
+ * @brief       Declaration of the logging API.
+ *
+ * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ */
+
+#ifndef __LOG_H_
+#define __LOG_H_
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * @brief macro controlling whether to discard info log messages
+ *
+ * When set to 0, info log messages will be processed, they will
+ * be discarded otherwise.
+ */
+#ifndef LOG_DISCARD_INFO
+#define LOG_DISCARD_INFO 0
+#endif
+
+/**
+ * @brief macro controlling whether to discard warning log messages
+ *
+ * When set to 0, warning log messages will be processed, they will
+ * be discarded otherwise.
+ */
+#ifndef LOG_DISCARD_WARNING
+#define LOG_DISCARD_WARNING 0
+#endif
+
+/**
+ * @brief macro controlling whether to discard error log messages
+ *
+ * When set to 0, error log messages will be processed, they will
+ * be discarded otherwise.
+ */
+#ifndef LOG_DISCARD_ERROR
+#define LOG_DISCARD_ERROR 0
+#endif
+
+/**
+ * @brief log a string with informative but unimportant content
+ *
+ * Examples of messages which should be logged as info include the reception
+ * of a packet, successful execution of some function, or activation of a
+ * sleep mode
+ *
+ * @param[in] format    format string in printf syntax
+ */
+#ifndef MODULE_LOG_PRINTF
+void log_info(const char *format, ...);
+#else
+#if LOG_DISCARD_INFO
+#define log_info(...)
+#else
+#define log_info(...) printf("I: " __VA_ARGS__)
+#endif
+#endif
+
+/**
+ * @brief log a string indicating an exceptional event which could lead to
+ * an error
+ *
+ * Examples of messages which should be logged as warning include dropping
+ * of a network packet due to full transceiver queue, detection of an
+ * invalid packet payload, or the discovery that the battery is empty
+ *
+ * @param[in] format    format string in printf syntax
+ */
+#ifndef MODULE_LOG_PRINTF
+void log_warning(const char *format, ...);
+#else
+#if LOG_DISCARD_WARNING
+#define log_warning(...)
+#else
+#define log_warning(...) printf("W: " __VA_ARGS__)
+#endif
+#endif
+
+/**
+ * @brief log a string describing an error
+ *
+ * Examples of messages which should be logged as error include unhandled
+ * errors of a function execution, detection of a hardware failure,
+ * inability to perform hardware initialization, or a stack overflow
+ *
+ * @param[in] format    format string in printf syntax
+ */
+#ifndef MODULE_LOG_PRINTF
+void log_error(const char *format, ...);
+#else
+#if LOG_DISCARD_ERROR
+#define log_error(...)
+#else
+#define log_error(...) printf("E: " __VA_ARGS__)
+#endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __LOG_H_ */
+/** @} */

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -18,7 +18,6 @@
  * @}
  */
 
-#include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <errno.h>
@@ -32,6 +31,7 @@
 #include "thread.h"
 #include "hwtimer.h"
 #include "irq.h"
+#include "log.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -82,19 +82,19 @@ static char idle_stack[KERNEL_CONF_STACKSIZE_IDLE];
 void kernel_init(void)
 {
     (void) disableIRQ();
-    printf("kernel_init(): This is RIOT! (Version: %s)\n", RIOT_VERSION);
+    log_info("kernel_init(): This is RIOT! (Version: %s)\n", RIOT_VERSION);
 
     hwtimer_init();
 
     if (thread_create(idle_stack, sizeof(idle_stack), PRIORITY_IDLE, CREATE_WOUT_YIELD | CREATE_STACKTEST, idle_thread, NULL, idle_name) < 0) {
-        printf("kernel_init(): error creating idle task.\n");
+        log_error("kernel_init(): error creating idle task.\n");
     }
 
     if (thread_create(main_stack, sizeof(main_stack), PRIORITY_MAIN, CREATE_WOUT_YIELD | CREATE_STACKTEST, main_trampoline, NULL, main_name) < 0) {
-        printf("kernel_init(): error creating main task.\n");
+        log_error("kernel_init(): error creating main task.\n");
     }
 
-    printf("kernel_init(): jumping into first task...\n");
+    log_info("kernel_init(): jumping into first task...\n");
 
     cpu_switch_context_exit();
 }

--- a/core/lifo.c
+++ b/core/lifo.c
@@ -17,6 +17,7 @@
  */
 
 #include "lifo.h"
+#include "log.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -42,7 +43,7 @@ void lifo_insert(int *array, int i)
 
 #if DEVELHELP
     if ((array[index] != -1) && (array[0] != -1)) {
-        printf("lifo_insert: overwriting array[%i] == %i with %i\n\n\n\t\tThe lifo is broken now.\n\n\n", index, array[index], array[0]);
+        log_error("lifo_insert: overwriting array[%i] == %i with %i\n\n\n\t\tThe lifo is broken now.\n\n\n", index, array[index], array[0]);
     }
 #endif
 

--- a/core/sched.c
+++ b/core/sched.c
@@ -29,6 +29,7 @@
 #include "irq.h"
 #include "thread.h"
 #include "irq.h"
+#include "log.h"
 
 #if SCHEDSTATISTICS
 #include "hwtimer.h"
@@ -86,7 +87,7 @@ int sched_run(void)
 
 #ifdef SCHED_TEST_STACK
         if (*((uintptr_t *) active_thread->stack_start) != (uintptr_t) active_thread->stack_start) {
-            printf("scheduler(): stack overflow detected, pid=%" PRIkernel_pid "\n", active_thread->pid);
+            log_error("scheduler(): stack overflow detected, pid=%" PRIkernel_pid "\n", active_thread->pid);
         }
 #endif
 

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -1,3 +1,6 @@
+ifneq (,$(filter log_printfnoformat,$(USEMODULE)))
+	DIRS += log/log_printfnoformat
+endif
 ifneq (,$(filter pnet,$(USEMODULE)))
     DIRS += posix/pnet
 endif

--- a/sys/log/log_printfnoformat/Makefile
+++ b/sys/log/log_printfnoformat/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/log/log_printfnoformat/log_printfnoformat.c
+++ b/sys/log/log_printfnoformat/log_printfnoformat.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     core_log
+ * @{
+ *
+ * @file
+ * @brief       logging implementation that only prints the first argument
+ *
+ * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+#include "log.h"
+
+void log_info(const char *format, ...)
+{
+    putchar('I');
+    putchar(':');
+    putchar(' ');
+    puts(format);
+}
+
+void log_warning(const char *format, ...)
+{
+    putchar('W');
+    putchar(':');
+    putchar(' ');
+    puts(format);
+}
+
+void log_error(const char *format, ...)
+{
+    putchar('E');
+    putchar(':');
+    putchar(' ');
+    puts(format);
+}


### PR DESCRIPTION
This PR specifies, implements, and partially adopts a minimalistic logging API.

There are two implementations, a macro based implementation which does not lead to any semantic or syntactic changes to current printf/puts based log messages, and a function call based implementation which only uses puts/putchar (thus potentially saving string formatting code).

The API has been applied to `/core`.

For the built-in implementation, **macros** have been chosen over:
- **plain functions**, because current compilers were not able to remove empty function delcarations, thus leading to a static overhead of about 4 instructions for every log message (stack pushing, jumping, returning)
- **static inline**, because it could lead to broken semantics due to inline `va_start` (variable argument handling is needed for printf)