### PR TITLE
sixlowpan: Broadcast message when neighbour not found in cache.

### DIFF
--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -124,7 +124,7 @@ int ipv6_send_packet(ipv6_hdr_t *packet, ipv6_addr_t *next_hop)
                                            nce->lladdr_len, (uint8_t *) packet, length) < 0) {
                 /* XXX: this is wrong, but until ND does work correctly,
                  *      this is the only way (aka the old way)*/
-                uint16_t raddr = dest->uint16[7];
+                uint16_t raddr = 0xffff; /* Broadcast message */
                 sixlowpan_lowpan_sendto(0, &raddr, 2, (uint8_t *) packet,
                                         length);
                 /* return -1; */


### PR DESCRIPTION
References #2493 

I changed the default behaviour when a neighbour is not found in the internal database. Previously we took the last 16 bits of the IPv6 destination address and used it for a IEEE802.15.4 short address. New behaviour is to send to broadcast (short addr: 0xffff).

With this patch it was possible to get some RPL transactions going between the rpl_udp example and a Contiki RPL border router.

I am not sure what the correct behaviour is in this situation...

Is the RPL process supposed to update the local neighbourhood cache when it receives DIOs? My neighbour cache is empty in the RPL UDP example when running as a routing node.