### PR TITLE
travis: let all static tests run and aggregate result

### DIFF
--- a/dist/tools/travis-scripts/build_and_test.sh
+++ b/dist/tools/travis-scripts/build_and_test.sh
@@ -16,21 +16,21 @@ then
         make -s -C ./examples/default info-concurrency
         git rebase riot/master || git rebase --abort
 
-        ./dist/tools/whitespacecheck/check.sh master || exit
+        ./dist/tools/whitespacecheck/check.sh master
 
-        ./dist/tools/licenses/check.sh master --diff-filter=MR --error-exitcode=0 || exit
-        ./dist/tools/licenses/check.sh master --diff-filter=AC || exit
+        ./dist/tools/licenses/check.sh master --diff-filter=MR --error-exitcode=0
+        ./dist/tools/licenses/check.sh master --diff-filter=AC
 
-        ./dist/tools/doccheck/check.sh master || exit
+        ./dist/tools/doccheck/check.sh master
 
-        ./dist/tools/externc/check.sh master || exit
+        ./dist/tools/externc/check.sh master
 
         # TODO:
         #   Remove all but `master` parameters to cppcheck (and remove second
         #   invocation) once all warnings of cppcheck have been taken care of
         #   in master.
-        ./dist/tools/cppcheck/check.sh master --diff-filter=MR --error-exitcode=0 || exit
-        ./dist/tools/cppcheck/check.sh master --diff-filter=AC || exit
+        ./dist/tools/cppcheck/check.sh master --diff-filter=MR --error-exitcode=0
+        ./dist/tools/cppcheck/check.sh master --diff-filter=AC
         ./dist/tools/pr_check/pr_check.sh riot/master
         exit 0
     fi

--- a/dist/tools/travis-scripts/build_and_test.sh
+++ b/dist/tools/travis-scripts/build_and_test.sh
@@ -11,37 +11,37 @@ set -e
 
 if [[ $BUILDTEST_MCU_GROUP ]]
 then
-	if [ "$BUILDTEST_MCU_GROUP" == "static-tests" ]
-	then
-		make -s -C ./examples/default info-concurrency
-		git rebase riot/master || git rebase --abort
+    if [ "$BUILDTEST_MCU_GROUP" == "static-tests" ]
+    then
+        make -s -C ./examples/default info-concurrency
+        git rebase riot/master || git rebase --abort
 
-		./dist/tools/whitespacecheck/check.sh master || exit
+        ./dist/tools/whitespacecheck/check.sh master || exit
 
-		./dist/tools/licenses/check.sh master --diff-filter=MR --error-exitcode=0 || exit
-		./dist/tools/licenses/check.sh master --diff-filter=AC || exit
+        ./dist/tools/licenses/check.sh master --diff-filter=MR --error-exitcode=0 || exit
+        ./dist/tools/licenses/check.sh master --diff-filter=AC || exit
 
-		./dist/tools/doccheck/check.sh master || exit
+        ./dist/tools/doccheck/check.sh master || exit
 
-		./dist/tools/externc/check.sh master || exit
+        ./dist/tools/externc/check.sh master || exit
 
-		# TODO:
-		#   Remove all but `master` parameters to cppcheck (and remove second
-		#   invocation) once all warnings of cppcheck have been taken care of
-		#   in master.
-		./dist/tools/cppcheck/check.sh master --diff-filter=MR --error-exitcode=0 || exit
-		./dist/tools/cppcheck/check.sh master --diff-filter=AC || exit
-		./dist/tools/pr_check/pr_check.sh riot/master
-		exit 0
-	fi
-	if [ "$BUILDTEST_MCU_GROUP" == "x86" ]
-	then
+        # TODO:
+        #   Remove all but `master` parameters to cppcheck (and remove second
+        #   invocation) once all warnings of cppcheck have been taken care of
+        #   in master.
+        ./dist/tools/cppcheck/check.sh master --diff-filter=MR --error-exitcode=0 || exit
+        ./dist/tools/cppcheck/check.sh master --diff-filter=AC || exit
+        ./dist/tools/pr_check/pr_check.sh riot/master
+        exit 0
+    fi
+    if [ "$BUILDTEST_MCU_GROUP" == "x86" ]
+    then
 
-		make -C ./tests/unittests all test BOARD=native || exit
-		# TODO:
-		#   Reenable once https://github.com/RIOT-OS/RIOT/issues/2300 is
-		#   resolved:
-		#   - make -C ./tests/unittests all test BOARD=qemu-i386 || exit
-	fi
-	./dist/tools/compile_test/compile_test.py
+        make -C ./tests/unittests all test BOARD=native || exit
+        # TODO:
+        #   Reenable once https://github.com/RIOT-OS/RIOT/issues/2300 is
+        #   resolved:
+        #   - make -C ./tests/unittests all test BOARD=qemu-i386 || exit
+    fi
+    ./dist/tools/compile_test/compile_test.py
 fi

--- a/dist/tools/travis-scripts/build_and_test.sh
+++ b/dist/tools/travis-scripts/build_and_test.sh
@@ -9,30 +9,57 @@
 
 set -e
 
+set_result() {
+    NEW_RESULT=$1
+    LAST_RESULT=$2
+
+    if [ $LAST_RESULT -ne 0 ] && [ $NEW_RESULT -eq 0 ]
+    then
+        NEW_RESULT=$LAST_RESULT
+    fi
+
+    echo $NEW_RESULT
+}
+
 if [[ $BUILDTEST_MCU_GROUP ]]
 then
     if [ "$BUILDTEST_MCU_GROUP" == "static-tests" ]
     then
+        RESULT=0
+
         make -s -C ./examples/default info-concurrency
         git rebase riot/master || git rebase --abort
+        RESULT=$(set_result $? $RESULT)
 
         ./dist/tools/whitespacecheck/check.sh master
+        RESULT=$(set_result $? $RESULT)
 
         ./dist/tools/licenses/check.sh master --diff-filter=MR --error-exitcode=0
+        RESULT=$(set_result $? $RESULT)
+
         ./dist/tools/licenses/check.sh master --diff-filter=AC
+        RESULT=$(set_result $? $RESULT)
 
         ./dist/tools/doccheck/check.sh master
+        RESULT=$(set_result $? $RESULT)
 
         ./dist/tools/externc/check.sh master
+        RESULT=$(set_result $? $RESULT)
 
         # TODO:
         #   Remove all but `master` parameters to cppcheck (and remove second
         #   invocation) once all warnings of cppcheck have been taken care of
         #   in master.
         ./dist/tools/cppcheck/check.sh master --diff-filter=MR --error-exitcode=0
+        RESULT=$(set_result $? $RESULT)
+
         ./dist/tools/cppcheck/check.sh master --diff-filter=AC
+        RESULT=$(set_result $? $RESULT)
+
         ./dist/tools/pr_check/pr_check.sh riot/master
-        exit 0
+        RESULT=$(set_result $? $RESULT)
+
+        exit $RESULT
     fi
     if [ "$BUILDTEST_MCU_GROUP" == "x86" ]
     then


### PR DESCRIPTION
Fixes #2505 and delivers result aggregation (so you can see that something is wrong with the tests right on the build matrix dashboard) as an extra.