### PR TITLE
travis: remove unnecessary nproc output

### DIFF
--- a/dist/tools/travis-scripts/build_and_test.sh
+++ b/dist/tools/travis-scripts/build_and_test.sh
@@ -27,7 +27,6 @@ then
     then
         RESULT=0
 
-        make -s -C ./examples/default info-concurrency
         git rebase riot/master || git rebase --abort
         RESULT=$(set_result $? $RESULT)
 


### PR DESCRIPTION
I don't see any use for this information cramped up in the output.