### PR TITLE
boards/msbiot: Switch from st-util to openocd

### DIFF
--- a/boards/msbiot/Makefile.include
+++ b/boards/msbiot/Makefile.include
@@ -23,10 +23,12 @@ export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
+export DBG = $(PREFIX)gdb
 export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm
-export FLASHER = st-flash
-export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
-export DEBUGSERVER = st-util
+export FLASHER = $(RIOTBASE)/dist/tools/openocd/openocd.sh
+export DEBUGGER = $(RIOTBASE)/dist/tools/openocd/openocd.sh
+export DEBUGSERVER = $(RIOTBASE)/dist/tools/openocd/openocd.sh
+export RESET = $(RIOTBASE)/dist/tools/openocd/openocd.sh
 
 # define build specific options
 CPU_USAGE = -mcpu=cortex-m4
@@ -36,10 +38,12 @@ export CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian
 export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -mlittle-endian -static -lgcc -mthumb -mno-thumb-interwork -nostartfiles
 export LINKFLAGS += -T$(LINKERSCRIPT)
-export OFLAGS = -O binary
-export FFLAGS = write bin/$(BOARD)/$(APPLICATION).hex 0x8000000
-export DEBUGGER_FLAGS = $(RIOTBOARD)/$(BOARD)/dist/gdb.conf $(BINDIR)/$(APPLICATION).elf
+export OFLAGS = -O ihex
 export TERMFLAGS += -p "$(PORT)"
+export FFLAGS = flash
+export DEBUGGER_FLAGS = debug
+export DEBUGSERVER_FLAGS = debug-server
+export RESET_FLAGS = reset
 
 # unwanted (CXXUWFLAGS) and extra (CXXEXFLAGS) flags for c++
 export CXXUWFLAGS +=

--- a/boards/msbiot/dist/debug.sh
+++ b/boards/msbiot/dist/debug.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-echo "Debugging $1"
-arm-none-eabi-gdb -tui -command=$1 $2

--- a/boards/msbiot/dist/gdb.conf
+++ b/boards/msbiot/dist/gdb.conf
@@ -1,1 +1,0 @@
-tar extended-remote :4242

--- a/boards/msbiot/dist/openocd.cfg
+++ b/boards/msbiot/dist/openocd.cfg
@@ -1,0 +1,1 @@
+source [find board/stm32f4discovery.cfg]


### PR DESCRIPTION
This PR is supposed to switch the flashing and debugging for the MSB-IoT from using st-util to OpenOCD.

It reuses OpenOCD's board configuration for the STM32F4-Discovery board as the STM32F415RG microcontroller is pretty much similar to the discovery board's STM32F407VG.