### PR TITLE
travis: allow failures for static tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - NPROC_MAX=8 BUILDTEST_MCU_GROUP=cortex_m3_2
     - NPROC_MAX=8 BUILDTEST_MCU_GROUP=cortex_m4
 
+
 matrix:
   allow_failures:
     - env: NPROC_MAX=8 BUILDTEST_MCU_GROUP=static-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ env:
     - NPROC_MAX=8 BUILDTEST_MCU_GROUP=cortex_m3_2
     - NPROC_MAX=8 BUILDTEST_MCU_GROUP=cortex_m4
 
+matrix:
+  allow_failures:
+    - env: NPROC_MAX=8 BUILDTEST_MCU_GROUP=static-tests
+
 before_install:
     - sudo apt-get install emdebian-archive-keyring
     - echo 'deb http://emdebian.bytesatwork.ch/mirror/toolchains/ wheezy main' | sudo tee /etc/apt/sources.list.d/emdebian.list > /dev/null


### PR DESCRIPTION
This is only a test. I'm mainly interested what build status will be shown if an `allow_failures` test fails. If it passes it's no real use, if it is different from 'failed' I would prefer it.