### PR TITLE
sys/vtimer: Fix two vtimer issues (hwtimer tick conversion).

### DIFF
--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -120,7 +120,8 @@ static int update_shortterm(void)
     uint32_t next = hwtimer_next_absolute;
 
     /* current short term time */
-    uint32_t now = HWTIMER_TICKS_TO_US(hwtimer_now());
+    uint32_t now_ticks = hwtimer_now();
+    uint32_t now = HWTIMER_TICKS_TO_US(now_ticks);
 
     /* make sure the longterm_tick_timer does not get truncated */
     if (node_get_timer(shortterm_priority_queue_root.first)->action != vtimer_callback_tick) {
@@ -134,8 +135,9 @@ static int update_shortterm(void)
         next = now +  HWTIMER_TICKS_TO_US(VTIMER_BACKOFF);
     }
 
-    DEBUG("update_shortterm: Set hwtimer to %" PRIu32 " (now=%lu)\n", next, HWTIMER_TICKS_TO_US(hwtimer_now()));
-    hwtimer_id = hwtimer_set_absolute(HWTIMER_TICKS(next), vtimer_callback, NULL);
+    DEBUG("update_shortterm: Set hwtimer to %" PRIu32 " (now=%lu)\n", next, now);
+    uint32_t next_ticks = now_ticks + HWTIMER_TICKS(next - now);
+    hwtimer_id = hwtimer_set_absolute(next_ticks, vtimer_callback, NULL);
 
     return 0;
 }
@@ -286,7 +288,7 @@ static int vtimer_set(vtimer_t *timer)
 
 void vtimer_now(timex_t *out)
 {
-    uint32_t us = HWTIMER_TICKS_TO_US(hwtimer_now() - longterm_tick_start);
+    uint32_t us = HWTIMER_TICKS_TO_US(hwtimer_now()) - longterm_tick_start;
     uint32_t us_per_s = 1000ul * 1000ul;
 
     out->seconds = seconds + us / us_per_s;


### PR DESCRIPTION
I am using a K22 port based on the open K60/mulle port pull request (great work, thanks!)
A little blinking application that uses vtimer_usleep and toggles a LED every second fails to schedule the timer properly after ~1h09.

First I blamed the K60 port or my quick K22 port, but turns out the different timer overflows in vtimer are not handled properly.Maybe I am totally wrong as I have no complete understanding of everything going on there, but I found at least two occurences that do not look right:

in update_shortterm: HWTIMER_TICKS cannot be just applied to next, this will be wrong when next overflows.
in vtimer_now: wrong parentheses mix up vtimer and hwtimer ticks, goes wrong as soon as the first vtimer longterm tick happens and longterm_tick_start becomes nonzero.
Correcting these makes the system run nicely through the first vtimer longterm tick and the first 32bit us overflow, however a long running test (>6hours over night) resulted in a RIOT crash at some later point in time, rerunning this test currently.
Btw, I doubt that this will run through the hwtimer overflow nicely, but this would happen after 36 hours (for 32768 kHz).

I wonder how this could go unnoticed that long, does RIOT usually run with HWTIMER == 1MHz only (it is 32768 kHz here)?
As a newbie, are vtimers kind of optional and I should use something else?

This may also be related to #2435 and/or #1753, however timings (at least the first ticket) are different.


Commit message:
vtimer does not handle well the different timers (vtimer <-> hwtimer)
with regard  to their overflows:

* in update_shortterm HWTIMER_TICKS cannot be just applied to next, this will be wrong when next overflows.
* in vtimer_now wrong parentheses mix up vtimer and hwtimer ticks.

Issue:
* https://github.com/RIOT-OS/RIOT/issues/2514

Maybe related issues:
* https://github.com/RIOT-OS/RIOT/issues/2435
* https://github.com/RIOT-OS/RIOT/issues/1753