### PR TITLE
net_if: change type of pan_id from int32_t to uint16_t

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -187,7 +187,7 @@ void auto_init_net_if(void)
         }
 
 
-        if (net_if_get_pan_id(iface) <= 0) {
+        if (net_if_get_pan_id(iface) == 0) {
             DEBUG("Auto init PAN ID on interface %d to 0x%04x\n", iface, CONF_PAN_ID);
             DEBUG("Change this value at compile time with macro CONF_PAN_ID\n");
             net_if_set_pan_id(iface, CONF_PAN_ID);

--- a/sys/net/include/net_if.h
+++ b/sys/net/include/net_if.h
@@ -484,9 +484,9 @@ int32_t net_if_set_channel(int if_id, uint16_t channel);
  *
  * @param[in]  if_id    The interface's ID
  *
- * @return  The transceiver's PAN ID on success, -1 on failure
+ * @return  The transceiver's PAN ID on success, 0 on failure
  */
-int32_t net_if_get_pan_id(int if_id);
+uint16_t net_if_get_pan_id(int if_id);
 
 /**
  * Sets the PAN ID of the transceiver associated with the given interface.
@@ -497,9 +497,9 @@ int32_t net_if_get_pan_id(int if_id);
  * @param[in]  if_id    The interface's ID
  * @param[in]  pan_id   The new frequency channel
  *
- * @return  the PAN ID on success, -1 on failure.
+ * @return  the PAN ID on success, 0 on failure.
  */
-int32_t net_if_set_pan_id(int if_id, uint16_t pan_id);
+uint16_t net_if_set_pan_id(int if_id, uint16_t pan_id);
 
 #ifdef __cplusplus
 }

--- a/sys/net/link_layer/net_if/net_if.c
+++ b/sys/net/link_layer/net_if/net_if.c
@@ -516,30 +516,24 @@ int32_t net_if_set_channel(int if_id, uint16_t channel)
     return channel;
 }
 
-int32_t net_if_get_pan_id(int if_id)
+uint16_t net_if_get_pan_id(int if_id)
 {
-    int32_t pan_id;
+    uint16_t pan_id;
 
     if (if_id < 0 || if_id >= NET_IF_MAX || !interfaces[if_id].initialized) {
         DEBUG("Get PAN ID: No interface initialized with ID %d.\n", if_id);
-        return -1;
+        return 0;
     }
 
     net_if_transceiver_get_set_handler(if_id, GET_PAN, &pan_id);
-    if (pan_id < 0) {
-        return 0;
-    }
-    else {
-        return pan_id;
-    }
-
+    return pan_id;
 }
 
-int32_t net_if_set_pan_id(int if_id, uint16_t pan_id)
+uint16_t net_if_set_pan_id(int if_id, uint16_t pan_id)
 {
     if (if_id < 0 || if_id >= NET_IF_MAX || !interfaces[if_id].initialized) {
         DEBUG("Set PAN ID: No interface initialized with ID %d.\n", if_id);
-        return -1;
+        return 0;
     }
 
     net_if_transceiver_get_set_handler(if_id, SET_PAN, &pan_id);

--- a/sys/net/network_layer/sixlowpan/mac.c
+++ b/sys/net/network_layer/sixlowpan/mac.c
@@ -188,16 +188,16 @@ void set_ieee802154_fcf_values(ieee802154_frame_t *frame, uint8_t dest_mode,
 void set_ieee802154_frame_values(int if_id, uint16_t dest_pan,
                                  ieee802154_frame_t *frame)
 {
-    int32_t pan_id = net_if_get_pan_id(if_id);
+    uint16_t pan_id = net_if_get_pan_id(if_id);
     // TODO: addresse aus ip paket auslesen und in frame einfuegen
 
-    if (pan_id < 0) {
+    if (pan_id == 0) {
         frame->dest_pan_id = NTOLES(dest_pan);
         frame->src_pan_id = HTOLES(DEFAULT_IEEE_802154_PAN_ID);
     }
     else {
         frame->dest_pan_id = NTOLES(dest_pan);
-        frame->src_pan_id = HTOLES((uint16_t)pan_id);
+        frame->src_pan_id = HTOLES(pan_id);
     }
 
     frame->seq_nr = macdsn;

--- a/sys/shell/commands/sc_net_if.c
+++ b/sys/shell/commands/sc_net_if.c
@@ -540,7 +540,7 @@ void _net_if_ifconfig_list(int if_id)
     transceiver_type_t transceivers;
     uint16_t hw_address;
     int32_t channel;
-    int32_t pan_id;
+    uint16_t pan_id;
     net_if_eui64_t eui64;
     char eui64_str[24];
     net_if_addr_t *addr_ptr = NULL;
@@ -566,11 +566,11 @@ void _net_if_ifconfig_list(int if_id)
         printf(" Channel: %d", (uint16_t) channel);
     }
 
-    if (pan_id < 0) {
+    if (pan_id == 0) {
         printf(" PAN ID: not set");
     }
     else {
-        printf(" PAN ID: 0x%04x", (uint16_t)pan_id);
+        printf(" PAN ID: 0x%04x", pan_id);
     }
 
     printf("\n");

--- a/sys/transceiver/transceiver.c
+++ b/sys/transceiver/transceiver.c
@@ -138,8 +138,8 @@ static radio_address_t set_address(transceiver_type_t t, void *address);
 static transceiver_eui64_t get_long_addr(transceiver_type_t t);
 static transceiver_eui64_t set_long_addr(transceiver_type_t t,
         void *address);
-static int32_t get_pan(transceiver_type_t t);
-static int32_t set_pan(transceiver_type_t t, void *pan);
+static uint16_t get_pan(transceiver_type_t t);
+static uint16_t set_pan(transceiver_type_t t, void *pan);
 
 static void set_monitor(transceiver_type_t t, void *mode);
 static void powerdown(transceiver_type_t t);
@@ -353,12 +353,12 @@ static void *run(void *arg)
                 break;
 
             case GET_PAN:
-                *((int32_t *) cmd->data) = get_pan(cmd->transceivers);
+                *((uint16_t *) cmd->data) = get_pan(cmd->transceivers);
                 msg_reply(&m, &m);
                 break;
 
             case SET_PAN:
-                *((int32_t *) cmd->data) = set_pan(cmd->transceivers, cmd->data);
+                *((uint16_t *) cmd->data) = set_pan(cmd->transceivers, cmd->data);
                 msg_reply(&m, &m);
                 break;
 
@@ -919,9 +919,9 @@ static int32_t get_channel(transceiver_type_t t)
  * @param t         The transceiver device
  * @param pan       The PAN to be set
  *
- * @return The PAN AFTER calling the set command, -1 on error
+ * @return The PAN AFTER calling the set command, 0 on error
  */
-static int32_t set_pan(transceiver_type_t t, void *pan)
+static uint16_t set_pan(transceiver_type_t t, void *pan)
 {
     uint16_t c = *((uint16_t *) pan);
 
@@ -950,7 +950,7 @@ static int32_t set_pan(transceiver_type_t t, void *pan)
         default:
             /* get rid of compiler warning about unused variable */
             (void) c;
-            return -1;
+            return 0;
     }
 }
 
@@ -959,9 +959,9 @@ static int32_t set_pan(transceiver_type_t t, void *pan)
  *
  * @param t     The transceiver device
  *
- * @return The current pan of the transceiver, -1 on error
+ * @return The current pan of the transceiver, 0 on error
  */
-static int32_t get_pan(transceiver_type_t t)
+static uint16_t get_pan(transceiver_type_t t)
 {
     switch (t) {
 #ifdef MODULE_CC2420
@@ -986,7 +986,7 @@ static int32_t get_pan(transceiver_type_t t)
 #endif
 
         default:
-            return -1;
+            return 0;
     }
 }
 /*------------------------------------------------------------------------------------*/

--- a/tests/net_if/main.c
+++ b/tests/net_if/main.c
@@ -341,24 +341,24 @@ int test_net_if_get_set_pan_id(int iface)
 {
     uint16_t pan_id = 0xabcd;
 
-    if (net_if_get_pan_id(iface + 1) >= 0) {
+    if (net_if_get_pan_id(iface + 1) > 0) {
         printf("FAILED: net_if_get_pan_id(%d) not failed\n", iface);
         return 0;
     }
 
-    if (net_if_set_pan_id(iface, pan_id) < 0) {
+    if (net_if_set_pan_id(iface, pan_id) == 0) {
         printf("FAILED: net_if_set_pan_id(%d, 0x%04x) failed\n", iface, pan_id);
         return 0;
     }
 
 #if MODULE_AT86RF231 || MODULE_CC2420 || MODULE_MC1322X
-    int32_t res = net_if_get_pan_id(iface);
+    uint16_t res = net_if_get_pan_id(iface);
     if (res < 0) {
         printf("FAILED: net_if_get_pan_id(%d) failed\n", iface);
         return 0;
     }
 
-    pan_id = (uint16_t) res;
+    pan_id = res;
 #else
     pan_id = 0;
 #endif


### PR DESCRIPTION
At many places the `pan_id` is defined as an `int32_t`, although `uint16_t` would be semantically the right choice. Maybe the implementor widened the value to include errors in the negative range.. However, in my opinion, keeping the `pan_id` at 16 bits is the right choice.