### PR TITLE
net_if: include pan id for eui-64/IID generation from short address

### DIFF
--- a/examples/rpl_udp/rpl.c
+++ b/examples/rpl_udp/rpl.c
@@ -41,6 +41,7 @@
 
 static char monitor_stack_buffer[MONITOR_STACK_SIZE];
 radio_address_t id;
+int32_t pan_id = -1;
 
 static uint8_t is_root = 0;
 
@@ -96,6 +97,17 @@ void rpl_udp_init(int argc, char **argv)
 
         printf("Channel set to %" PRIi32 "\n", chan);
 
+        tcmd.transceivers = TRANSCEIVER;
+        tcmd.data = &pan_id;
+        m.type = GET_PAN;
+        m.content.ptr = (void *) &tcmd;
+
+        msg_send_receive(&m, &m, transceiver_pid);
+        if ( pan_id < 0 ) {
+            puts("ERROR: pan id NOT set! Aborting initialization.");
+            return;
+        }
+
         if (command != 'h') {
             DEBUGF("Initializing RPL for interface 0\n");
             uint8_t state = rpl_init(0);
@@ -141,7 +153,7 @@ void rpl_udp_init(int argc, char **argv)
     /* add global address */
     ipv6_addr_t tmp;
     /* initialize prefix */
-    ipv6_addr_init(&tmp, 0xabcd, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, id);
+    ipv6_addr_init(&tmp, (uint16_t) pan_id, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, id);
     /* set host suffix */
     ipv6_addr_set_by_eui64(&tmp, 0, &tmp);
     ipv6_net_if_add_addr(0, &tmp, NDP_ADDR_STATE_PREFERRED, 0, 0, 0);

--- a/examples/rpl_udp/rpl_udp.h
+++ b/examples/rpl_udp/rpl_udp.h
@@ -9,6 +9,8 @@
 #ifndef RPL_UDP_H
 #define RPL_UDP_H
 
+#include <stdio.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -100,6 +102,7 @@ extern radio_address_t id;
 
 /** @brief Char array for IP address printing */
 extern char addr_str[IPV6_MAX_ADDR_STR_LEN];
+extern int32_t pan_id;
 
 #ifdef __cplusplus
 }

--- a/examples/rpl_udp/udp.c
+++ b/examples/rpl_udp/udp.c
@@ -122,7 +122,7 @@ void udp_send(int argc, char **argv)
     memset(&sa, 0, sizeof(sa));
 
     if (address) {
-        ipv6_addr_init(&ipaddr, 0xabcd, 0x0, 0x0, 0x0, 0x0, 0x00ff, 0xfe00, (uint16_t)address);
+        ipv6_addr_init(&ipaddr, (uint16_t) pan_id, 0x0, 0x0, 0x0, (uint16_t) pan_id, 0x00ff, 0xfe00, (uint16_t)address);
     }
     else {
         ipv6_addr_set_all_nodes_addr(&ipaddr);

--- a/sys/net/include/sixlowpan/lowpan.h
+++ b/sys/net/include/sixlowpan/lowpan.h
@@ -195,24 +195,6 @@ typedef struct __attribute__((packed)) {
 int sixlowpan_lowpan_init_interface(int if_id);
 
 /**
- * @brief   Checks if an EUI-64 was set from a short address. If so
- *          it returns this address, else 0
- *
- * @param[in] iid   An EUI-64.
- *
- * @return  The short address on success, 0 on failure.
- */
-static inline uint16_t sixlowpan_lowpan_eui64_to_short_addr(const net_if_eui64_t *iid)
-{
-    if (iid->uint32[0] == HTONL(0x000000ff) &&
-        iid->uint16[2] == HTONS(0xfe00)) {
-        return NTOHS(iid->uint16[3]);
-    }
-
-    return 0;
-}
-
-/**
  * @brief   Initializes all addresses and prefixes on an interface needed
  *          for 6LoWPAN. Calling this function together with
  *          sixlowpan_lowpan_init_interface() is not necessary.

--- a/sys/net/link_layer/net_if/net_if.c
+++ b/sys/net/link_layer/net_if/net_if.c
@@ -423,28 +423,21 @@ int net_if_get_eui64(net_if_eui64_t *eui64, int if_id, int force_generation)
 
     if (eui64->uint64 == 0 || force_generation) {
         uint16_t hwaddr = net_if_get_hardware_address(if_id);
+        int32_t pan_id = net_if_get_pan_id(if_id);
 
         if (hwaddr == 0) {
             return 0;
         }
 
-        /* RFC 6282 Section 3.2.2 / RFC 2464 Section 4 */
-        eui64->uint32[0] = HTONL(0x000000ff);
-        eui64->uint16[2] = HTONS(0xfe00);
-
-        if (sizeof(hwaddr) == 2) {
-            eui64->uint16[3] = HTONS(hwaddr);
-        }
-        else if (sizeof(hwaddr) == 1) {
-            eui64->uint8[6] = 0;
-            eui64->uint8[7] = (uint8_t)hwaddr;
-        }
-        else {
-            DEBUG("Error on EUI-64 generation: do not know what to do with "
-                  "hardware address of length %d\n", sizeof(hwaddr));
+        if(pan_id < 0) {
             return 0;
         }
 
+        /* RFC 6282 Section 3.2.2 / RFC 2464 Section 4 */
+        eui64->uint16[0] = HTONS((uint16_t)pan_id) & ~(1 << 1);
+        eui64->uint16[1] = HTONS(0x00ff);
+        eui64->uint16[2] = HTONS(0xfe00);
+        eui64->uint16[3] = HTONS(hwaddr);
     }
 
     return 1;

--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -690,15 +690,7 @@ ipv6_addr_t *ipv6_addr_set_by_eui64(ipv6_addr_t *out, int if_id,
 
     if (net_if_get_eui64((net_if_eui64_t *) &out->uint8[8], if_id,
                          force_generation)) {
-#ifdef MODULE_SIXLOWPAN
-
-        if (!sixlowpan_lowpan_eui64_to_short_addr((net_if_eui64_t *)&out->uint8[8])) {
-            out->uint8[8] ^= 0x02;
-        }
-
-#else
         out->uint8[8] ^= 0x02;
-#endif
         return out;
     }
     else {


### PR DESCRIPTION
Currently, the link-local address generation is odd, due to some complications and confusions regarding the generation of the EUI-64/IID.
This PR fixes the problems (that we are facing with RPL right now) according to the discussion in #2508 

IIDs generated from short addresses will be of the form 16_bit_PAN:00ff:fe00:16_bit_short_address, **with an U/L-Bit set to 0**.