### PR TITLE
net_if: proper u/l-bit inversion for short addresses

### DIFF
--- a/examples/rpl_udp/udp.c
+++ b/examples/rpl_udp/udp.c
@@ -122,7 +122,7 @@ void udp_send(int argc, char **argv)
     memset(&sa, 0, sizeof(sa));
 
     if (address) {
-        ipv6_addr_init(&ipaddr, 0xabcd, 0x0, 0x0, 0x0, 0x0200, 0x00ff, 0xfe00, (uint16_t)address);
+        ipv6_addr_init(&ipaddr, 0xabcd, 0x0, 0x0, 0x0, 0x0, 0x00ff, 0xfe00, (uint16_t)address);
     }
     else {
         ipv6_addr_set_all_nodes_addr(&ipaddr);

--- a/examples/rpl_udp/udp.c
+++ b/examples/rpl_udp/udp.c
@@ -122,7 +122,7 @@ void udp_send(int argc, char **argv)
     memset(&sa, 0, sizeof(sa));
 
     if (address) {
-        ipv6_addr_init(&ipaddr, 0xabcd, 0x0, 0x0, 0x0, 0x0, 0x00ff, 0xfe00, (uint16_t)address);
+        ipv6_addr_init(&ipaddr, 0xabcd, 0x0, 0x0, 0x0, 0x0200, 0x00ff, 0xfe00, (uint16_t)address);
     }
     else {
         ipv6_addr_set_all_nodes_addr(&ipaddr);

--- a/sys/net/link_layer/net_if/net_if.c
+++ b/sys/net/link_layer/net_if/net_if.c
@@ -431,20 +431,7 @@ int net_if_get_eui64(net_if_eui64_t *eui64, int if_id, int force_generation)
         /* RFC 6282 Section 3.2.2 / RFC 2464 Section 4 */
         eui64->uint32[0] = HTONL(0x000000ff);
         eui64->uint16[2] = HTONS(0xfe00);
-
-        if (sizeof(hwaddr) == 2) {
-            eui64->uint16[3] = HTONS(hwaddr);
-        }
-        else if (sizeof(hwaddr) == 1) {
-            eui64->uint8[6] = 0;
-            eui64->uint8[7] = (uint8_t)hwaddr;
-        }
-        else {
-            DEBUG("Error on EUI-64 generation: do not know what to do with "
-                  "hardware address of length %d\n", sizeof(hwaddr));
-            return 0;
-        }
-
+        eui64->uint16[3] = HTONS(hwaddr);
     }
 
     return 1;

--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -690,15 +690,7 @@ ipv6_addr_t *ipv6_addr_set_by_eui64(ipv6_addr_t *out, int if_id,
 
     if (net_if_get_eui64((net_if_eui64_t *) &out->uint8[8], if_id,
                          force_generation)) {
-#ifdef MODULE_SIXLOWPAN
-
-        if (!sixlowpan_lowpan_eui64_to_short_addr((net_if_eui64_t *)&out->uint8[8])) {
-            out->uint8[8] ^= 0x02;
-        }
-
-#else
         out->uint8[8] ^= 0x02;
-#endif
         return out;
     }
     else {

--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -690,7 +690,9 @@ ipv6_addr_t *ipv6_addr_set_by_eui64(ipv6_addr_t *out, int if_id,
 
     if (net_if_get_eui64((net_if_eui64_t *) &out->uint8[8], if_id,
                          force_generation)) {
-        out->uint8[8] ^= 0x02;
+        if (!force_generation) {
+            out->uint8[8] ^= 0x02;
+        }
         return out;
     }
     else {

--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -1295,9 +1295,6 @@ void lowpan_iphc_decoding(uint8_t *data, uint8_t length, net_if_eui64_t *s_addr,
             memcpy(&(ipv6_buf->srcaddr.uint8[0]), &ll_prefix[0], 2);
             memset(&(ipv6_buf->srcaddr.uint8[2]), 0, 6);
             memcpy(&(ipv6_buf->srcaddr.uint8[8]), &s_addr->uint8[0], 8);
-            /* Invert Universal/local bit as specified in
-             * RFC4291, section 2.5.1 "Interface Identifiers" */
-            ipv6_buf->srcaddr.uint8[8] ^= 0x02;
             break;
         }
 
@@ -1429,9 +1426,6 @@ void lowpan_iphc_decoding(uint8_t *data, uint8_t length, net_if_eui64_t *s_addr,
                 memcpy(&(ipv6_buf->destaddr.uint8[0]), &ll_prefix[0], 2);
                 memset(&(ipv6_buf->destaddr.uint8[2]), 0, 6);
                 memcpy(&(ipv6_buf->destaddr.uint8[8]), &d_addr->uint8[0], 8);
-                /* Invert Universal/local bit as specified in
-                 * RFC4291, section 2.5.1 "Interface Identifiers" */
-                ipv6_buf->destaddr.uint8[8] ^= 0x02;
                 break;
             }
 


### PR DESCRIPTION
This is an alternative to #2517 and does not introduce the *pan_id* to the IID/EUI-64 generation from short addresses