### PR TITLE
sys/net/network_layer/sixlowpan/lowpan.c: reduce scope of debug variable

### DIFF
--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -48,7 +48,7 @@
 
 #define ENABLE_DEBUG    (0)
 #if ENABLE_DEBUG
-char addr_str[IPV6_MAX_ADDR_STR_LEN];
+static char addr_str[IPV6_MAX_ADDR_STR_LEN];
 #endif
 #include "debug.h"
 


### PR DESCRIPTION
This PR reduces the scope of debug variable addr_str.