### PR TITLE
rpl: implement basic prefix information option for DIOs

### DIFF
--- a/sys/net/include/rpl.h
+++ b/sys/net/include/rpl.h
@@ -51,6 +51,7 @@ extern ipv6_addr_t my_address;
 extern msg_t rpl_msg_queue[RPL_PKT_RECV_BUF_SIZE];
 extern char rpl_process_buf[RPL_PROCESS_STACKSIZE];
 extern uint8_t rpl_buffer[BUFFER_SIZE - LL_HDR_LEN];
+extern uint8_t rpl_if_id;
 
 /**
  * @brief Sends a RPL message to a given destination
@@ -84,8 +85,10 @@ uint8_t rpl_init(int if_id);
  *
  * This function initializes all RPL resources to act as a root node.
  *
+ * @param[in] rpl_opts          RPL root node configurations
+ *
  */
-void rpl_init_root(void);
+void rpl_init_root(rpl_options_t *rpl_opts);
 
 /**
  * @brief Sends a DIO-message to a given destination

--- a/sys/net/include/rpl/rpl_structs.h
+++ b/sys/net/include/rpl/rpl_structs.h
@@ -123,6 +123,22 @@ typedef struct __attribute__((packed)) {
     ipv6_addr_t parent;
 } rpl_opt_transit_t;
 
+/* RPL Prefix Information Option (RFC 6550 Fig. 29) */
+typedef struct __attribute__((packed)) {
+    uint8_t type;
+    uint8_t length;
+    uint8_t prefix_length;
+/* RFC 6550 https://tools.ietf.org/html/rfc6550#page-61 */
+#define RPL_PREFIX_INFO_ROUTER_ADDRESS      (1 << 5)
+#define RPL_PREFIX_INFO_AUTO_ADDR_CONF      (1 << 6)
+#define RPL_PREFIX_INFO_ON_LINK             (1 << 7)
+    uint8_t flags;
+    network_uint32_t valid_lifetime;
+    network_uint32_t preferred_lifetime;
+    network_uint32_t reserved2;
+    ipv6_addr_t prefix;
+} rpl_opt_prefix_information_t;
+
 struct rpl_dodag_t;
 
 typedef struct {
@@ -171,6 +187,11 @@ typedef struct rpl_dodag_t {
     trickle_t trickle;
     bool ack_received;
     uint8_t dao_counter;
+    ipv6_addr_t prefix;
+    uint8_t prefix_length;
+    uint32_t prefix_valid_lifetime;
+    uint32_t prefix_preferred_lifetime;
+    uint8_t prefix_flags;
     timex_t dao_time;
     vtimer_t dao_timer;
 } rpl_dodag_t;
@@ -192,6 +213,16 @@ typedef struct {
     uint16_t lifetime;
     uint8_t used;
 } rpl_routing_entry_t;
+
+/* Parameters passed to RPL on initialization */
+typedef struct {
+    uint8_t instance_id;
+    ipv6_addr_t prefix;
+    uint8_t prefix_len;
+    uint8_t prefix_flags;
+    uint32_t prefix_valid_lifetime;
+    uint32_t prefix_preferred_lifetime;
+} rpl_options_t;
 
 #ifdef __cplusplus
 }

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -49,6 +49,7 @@ char rpl_process_buf[RPL_PROCESS_STACKSIZE];
 uint8_t rpl_buffer[BUFFER_SIZE - LL_HDR_LEN];
 static timex_t rt_time;
 static vtimer_t rt_timer;
+uint8_t rpl_if_id;
 
 static void _dao_handle_send(rpl_dodag_t *dodag);
 static void _rpl_update_routing_table(void);
@@ -74,6 +75,7 @@ static ipv6_hdr_t *ipv6_buf;
 
 uint8_t rpl_init(int if_id)
 {
+    rpl_if_id = if_id;
     rpl_instances_init();
 
     /* initialize routing table */

--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -358,6 +358,11 @@ void rpl_join_dodag(rpl_dodag_t *dodag, ipv6_addr_t *parent, uint16_t parent_ran
     my_dodag->lifetime_unit = dodag->lifetime_unit;
     my_dodag->version = dodag->version;
     my_dodag->grounded = dodag->grounded;
+    my_dodag->prefix_length = dodag->prefix_length;
+    my_dodag->prefix = dodag->prefix;
+    my_dodag->prefix_valid_lifetime = dodag->prefix_valid_lifetime;
+    my_dodag->prefix_preferred_lifetime = dodag->prefix_preferred_lifetime;
+    my_dodag->prefix_flags = dodag->prefix_flags;
     my_dodag->joined = 1;
 
     preferred_parent = rpl_new_parent(my_dodag, parent, parent_rank);


### PR DESCRIPTION
This is a basic implementation of the RPL prefix information DIO option (#2510)

EDIT: I changed the rpl_udp example in the following way:
rpl nodes have no global ip address configured. The rpl root sends the global prefix and after receiving this DIO, the global prefix will be taken from the prefix information option and configured.