### PR TITLE
unittests: remove unnecessary MODULE macro definition

### DIFF
--- a/tests/unittests/tests-base64/Makefile
+++ b/tests/unittests/tests-base64/Makefile
@@ -1,3 +1,1 @@
-MODULE = tests-base64
-
 include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-bloom/Makefile
+++ b/tests/unittests/tests-bloom/Makefile
@@ -1,3 +1,1 @@
-MODULE = tests-bloom
-
 include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-cbor/Makefile
+++ b/tests/unittests/tests-cbor/Makefile
@@ -1,5 +1,3 @@
-MODULE = tests-cbor
-
 CFLAGS += -DCBOR_NO_PRINT
 
 ifeq (,$(filter native,$(BOARD)))

--- a/tests/unittests/tests-ipv6_addr/Makefile
+++ b/tests/unittests/tests-ipv6_addr/Makefile
@@ -1,3 +1,1 @@
-MODULE = tests-ipv6_addr
-
 include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-netdev_dummy/Makefile
+++ b/tests/unittests/tests-netdev_dummy/Makefile
@@ -1,4 +1,2 @@
-MODULE = tests-netdev_dummy
-
 include $(RIOTBASE)/Makefile.base
 

--- a/tests/unittests/tests-netif/Makefile
+++ b/tests/unittests/tests-netif/Makefile
@@ -1,3 +1,1 @@
-MODULE = tests-netif
-
 include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-netreg/Makefile
+++ b/tests/unittests/tests-netreg/Makefile
@@ -1,3 +1,1 @@
-MODULE = tests-netreg
-
 include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-pkt/Makefile
+++ b/tests/unittests/tests-pkt/Makefile
@@ -1,3 +1,1 @@
-MODULE = tests-pkt
-
 include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-pktbuf/Makefile
+++ b/tests/unittests/tests-pktbuf/Makefile
@@ -1,3 +1,1 @@
-MODULE = tests-pktbuf
-
 include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-pktqueue/Makefile
+++ b/tests/unittests/tests-pktqueue/Makefile
@@ -1,3 +1,1 @@
-MODULE = tests-pktqueue
-
 include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-timex/Makefile
+++ b/tests/unittests/tests-timex/Makefile
@@ -1,3 +1,1 @@
-MODULE = tests-timex
-
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
The definition of those macros is not needed any more for a long time