### PR TITLE
lowpan.c: add udp header decompression

### DIFF
--- a/sys/net/include/sixlowpan/lowpan.h
+++ b/sys/net/include/sixlowpan/lowpan.h
@@ -78,6 +78,8 @@ extern "C" {
  *      </a>
  */
 #define SIXLOWPAN_IPHC1_NH          (0x04)
+#define SIXLOWPAN_NHC_UDP_MASK      (0xF8)
+#define SIXLOWPAN_NHC_UDP_ID        (0xF0)
 
 /**
  * @brief   Flag for Context Identifier Extention (part of second byte


### PR DESCRIPTION
This patch adds udp header decompression. It's not finished, but better than without udp header decompression.

From the category "Communication between RIOT and Linux host"