### PR TITLE
ng_netif: Add missing include

### DIFF
--- a/sys/include/net/ng_netif.h
+++ b/sys/include/net/ng_netif.h
@@ -24,6 +24,7 @@
 #ifndef NG_NETIF_H_
 #define NG_NETIF_H_
 
+#include <stdlib.h>
 #include "kernel_types.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
Somehow this slipped through. `stdlib.h` is needed for the `size_t` type.