### PR TITLE
Updating the README.md for examples/default since date is part of rtc now

### DIFF
--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -50,7 +50,6 @@ Running the `help` command on an msba2:
 2014-05-06 13:14:38,522 - INFO # id                   Gets or sets the node's id.
 2014-05-06 13:14:38,529 - INFO # heap                 Shows the heap state for the LPC2387 on the command shell.
 2014-05-06 13:14:38,535 - INFO # ps                   Prints information about running threads.
-2014-05-06 13:14:38,540 - INFO # date                 Gets or sets current date and time.
 2014-05-06 13:14:38,544 - INFO # temp                 Prints measured temperature.
 2014-05-06 13:14:38,548 - INFO # hum                  Prints measured humidity.
 2014-05-06 13:14:38,553 - INFO # weather              Prints measured humidity and temperature.


### PR DESCRIPTION
- Removing the date command and it's associated description from the README.md