### PR TITLE
rpl: use global ip addresses instead of link-local ones

### DIFF
--- a/sys/net/include/rpl.h
+++ b/sys/net/include/rpl.h
@@ -73,12 +73,13 @@ void rpl_send(ipv6_addr_t *destination, uint8_t *payload, uint16_t p_len, uint8_
  * corresponding objective functions and sixlowpan (including own address).
  *
  * @param[in] if_id             ID of the interface, which correspond to the network under RPL-control
+ * @param[in] address           Global IPv6 address to use
  *
  * @return 1 if initialization was successful
  * @return 0 if initialization was not successful
  *
  */
-uint8_t rpl_init(int if_id);
+uint8_t rpl_init(int if_id, ipv6_addr_t *address);
 
 /**
  * @brief Initialization of RPL-root.

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -73,7 +73,7 @@ ipv6_addr_t my_address;
 /* IPv6 message buffer */
 static ipv6_hdr_t *ipv6_buf;
 
-uint8_t rpl_init(int if_id)
+uint8_t rpl_init(int if_id, ipv6_addr_t *address)
 {
     rpl_if_id = if_id;
     rpl_instances_init();
@@ -89,11 +89,12 @@ uint8_t rpl_init(int if_id)
                                     rpl_process, NULL, "rpl_process");
 
     sixlowpan_lowpan_init_interface(if_id);
-    /* need link local prefix to query _our_ corresponding address  */
-    ipv6_addr_t ll_address;
-    ipv6_addr_set_link_local_prefix(&ll_address);
-    ipv6_net_if_get_best_src_addr(&my_address, &ll_address);
     ipv6_register_rpl_handler(rpl_process_pid);
+
+    if (address) {
+        my_address = *address;
+        ipv6_net_if_add_addr(if_id, &my_address, NDP_ADDR_STATE_PREFERRED, 0, 0, 0);
+    }
 
     /* add all-RPL-nodes address */
     ipv6_addr_t all_rpl_nodes;

--- a/sys/net/routing/rpl/rpl_control_messages.c
+++ b/sys/net/routing/rpl/rpl_control_messages.c
@@ -426,7 +426,14 @@ void rpl_send_DAO(ipv6_addr_t *destination, uint8_t lifetime, bool default_lifet
     rpl_send_opt_target_buf->length = RPL_OPT_TARGET_LEN;
     rpl_send_opt_target_buf->flags = 0x00;
     rpl_send_opt_target_buf->prefix_length = RPL_DODAG_ID_LEN;
-    memcpy(&rpl_send_opt_target_buf->target, &my_address, sizeof(ipv6_addr_t));
+    if (!ipv6_addr_is_unspecified(&my_dodag->prefix)) {
+        ipv6_addr_t tmp;
+        ipv6_addr_set_by_eui64(&tmp, rpl_if_id, &my_dodag->prefix);
+        memcpy(&rpl_send_opt_target_buf->target, &tmp, sizeof(ipv6_addr_t));
+    }
+    else {
+        memcpy(&rpl_send_opt_target_buf->target, &my_address, sizeof(ipv6_addr_t));
+    }
     opt_len += RPL_OPT_TARGET_LEN_WITH_OPT_LEN;
 
     rpl_send_opt_transit_buf = get_rpl_send_opt_transit_buf(DAO_BASE_LEN + opt_len);


### PR DESCRIPTION
Currently, RPL utilizes link-local addresses in DAOs, which results in the root node knowing all about link-local addresses of its children('s children('s children...)) in its routing table. Strictly speaking, these link-local addresses are useless for the root node, as per definition they (link-local addresses) lose their validity when they are used outside of their link context. 

This PR extends the `rpl_init` function by another parameter to specify the desired global ip address to use for the `DODAG-ID` and in all `DAOs`.