### PR TITLE
Changing return type of vtimer_set_msg

### DIFF
--- a/sys/include/vtimer.h
+++ b/sys/include/vtimer.h
@@ -80,10 +80,8 @@ void vtimer_get_localtime(struct tm *localt);
 
 /**
  * @brief   Initializes the vtimer subsystem. To be called once at system initialization. Will be initialized by auto_init.
- *
- * @return  always 0
  */
-int vtimer_init(void);
+void vtimer_init(void);
 
 /**
  * @brief   will cause the calling thread to be suspended from excecution until the number of microseconds has elapsed
@@ -106,9 +104,8 @@ int vtimer_sleep(timex_t time);
  * @param[in]   pid         process id
  * @param[in]   type        value for the msg_t type
  * @param[in]   ptr         message value
- * @return      0 on success, < 0 on error
  */
-int vtimer_set_msg(vtimer_t *t, timex_t interval, kernel_pid_t pid, uint16_t type, void *ptr);
+void vtimer_set_msg(vtimer_t *t, timex_t interval, kernel_pid_t pid, uint16_t type, void *ptr);
 
 /**
  * @brief   set a vtimer with wakeup event
@@ -122,9 +119,8 @@ int vtimer_set_wakeup(vtimer_t *t, timex_t interval, kernel_pid_t pid);
 /**
  * @brief   remove a vtimer
  * @param[in]   t           pointer to preinitialised vtimer_t
- * @return      0 on success, < 0 on error
  */
-int vtimer_remove(vtimer_t *t);
+void vtimer_remove(vtimer_t *t);
 
 
 /**

--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -313,7 +313,7 @@ void vtimer_get_localtime(struct tm *localt)
     // TODO: fill the other fields
 }
 
-int vtimer_init(void)
+void vtimer_init(void)
 {
     DEBUG("vtimer_init().\n");
     unsigned state = disableIRQ();
@@ -333,7 +333,6 @@ int vtimer_init(void)
     update_shortterm();
 
     restoreIRQ(state);
-    return 0;
 }
 
 int vtimer_set_wakeup(vtimer_t *t, timex_t interval, kernel_pid_t pid)
@@ -379,7 +378,7 @@ int vtimer_sleep(timex_t time)
     return ret;
 }
 
-int vtimer_remove(vtimer_t *t)
+void vtimer_remove(vtimer_t *t)
 {
     unsigned irq_state = disableIRQ();
 
@@ -389,10 +388,9 @@ int vtimer_remove(vtimer_t *t)
 
     restoreIRQ(irq_state);
 
-    return 0;
 }
 
-int vtimer_set_msg(vtimer_t *t, timex_t interval, kernel_pid_t pid, uint16_t type, void *ptr)
+void vtimer_set_msg(vtimer_t *t, timex_t interval, kernel_pid_t pid, uint16_t type, void *ptr)
 {
     t->action = vtimer_callback_msg;
     t->type = type;
@@ -400,7 +398,6 @@ int vtimer_set_msg(vtimer_t *t, timex_t interval, kernel_pid_t pid, uint16_t typ
     t->absolute = interval;
     t->pid = pid;
     vtimer_set(t);
-    return 0;
 }
 
 int vtimer_msg_receive_timeout(msg_t *m, timex_t timeout) {

--- a/tests/vtimer_msg/main.c
+++ b/tests/vtimer_msg/main.c
@@ -63,13 +63,6 @@ void *timer_thread(void *arg)
                tmsg->interval.seconds,
                tmsg->interval.microseconds,
                tmsg->msg);
-
-        if (vtimer_set_msg(&tmsg->timer, tmsg->interval, thread_getpid(), MSG_TIMER, tmsg) != 0) {
-            puts("something went wrong");
-        }
-        else {
-            puts("timer_thread: set timer successfully");
-        }
     }
 }
 

--- a/tests/vtimer_msg_diff/main.c
+++ b/tests/vtimer_msg_diff/main.c
@@ -87,10 +87,6 @@ void *timer_thread(void *arg)
             printf("WARNING: timer difference %" PRId64 "us exceeds MAXDIFF(%d)!\n", diff, MAXDIFF);
         }
 
-        if (vtimer_set_msg(&tmsg->timer, tmsg->interval, thread_getpid(), MSG_TIMER, tmsg) != 0) {
-            puts("something went wrong setting a timer");
-        }
-
         if (tmsg->count >= MAXCOUNT) {
             printf("Maximum count reached. (%d) Exiting.\n", MAXCOUNT);
             break;


### PR DESCRIPTION
-The current return value is not used anywhere and has no meaning attached to it.
- A fix for #1533 