### PR TITLE
Fix for #2096 "core: limit message queue size"

### DIFF
--- a/core/include/cib.h
+++ b/core/include/cib.h
@@ -44,7 +44,7 @@ typedef struct {
  *
  * @param[out] cib      Buffer to initialize.
  *                      Must not be NULL.
- * @param[in]  size     Size of the buffer, must not exceed MAXINT/2.
+ * @param[in]  size     Size of the buffer, must not exceed 65,534.
  */
 static inline void cib_init(cib_t *__restrict cib, uint16_t size)
 {

--- a/core/include/cib.h
+++ b/core/include/cib.h
@@ -33,7 +33,7 @@ extern "C" {
 typedef struct {
     uint16_t read_count;    /**< number of (successful) read accesses */
     uint16_t write_count;   /**< number of (successful) write accesses */
-    uint16_t mask;          /**< Size of buffer -1, i.e. mask of the bits */
+    int16_t mask;          /**< Size of buffer -1, i.e. mask of the bits */
 } cib_t;
 
 /**
@@ -46,7 +46,7 @@ typedef struct {
  *
  * @param[out] cib      Buffer to initialize.
  *                      Must not be NULL.
- * @param[in]  size     Size of the buffer, must not exceed 65,534.
+ * @param[in]  size     Size of the buffer, must not exceed 32,767
  */
 static inline void cib_init(cib_t *__restrict cib, uint16_t size)
 {

--- a/core/include/cib.h
+++ b/core/include/cib.h
@@ -29,9 +29,9 @@ extern "C" {
  * @brief circular integer buffer structure
  */
 typedef struct {
-    unsigned int read_count;    /**< number of (successful) read accesses */
-    unsigned int write_count;   /**< number of (successful) write accesses */
-    unsigned int mask;          /**< Size of buffer -1, i.e. mask of the bits */
+    uint16_t read_count;    /**< number of (successful) read accesses */
+    uint16_t write_count;   /**< number of (successful) write accesses */
+    uint16_t mask;          /**< Size of buffer -1, i.e. mask of the bits */
 } cib_t;
 
 /**
@@ -46,7 +46,7 @@ typedef struct {
  *                      Must not be NULL.
  * @param[in]  size     Size of the buffer, must not exceed MAXINT/2.
  */
-static inline void cib_init(cib_t *__restrict cib, unsigned int size)
+static inline void cib_init(cib_t *__restrict cib, uint16_t size)
 {
     cib_t c = CIB_INIT(size);
     *cib = c;
@@ -59,7 +59,7 @@ static inline void cib_init(cib_t *__restrict cib, unsigned int size)
  *                      Must not be NULL.
  * @return How often cib_get() can be called before the CIB is empty.
  */
-static inline unsigned int cib_avail(cib_t *__restrict cib)
+static inline uint16_t cib_avail(cib_t *__restrict cib)
 {
     return cib->write_count - cib->read_count;
 }
@@ -73,7 +73,7 @@ static inline unsigned int cib_avail(cib_t *__restrict cib)
  */
 static inline int cib_get(cib_t *__restrict cib)
 {
-    unsigned int avail = cib_avail(cib);
+    uint16_t avail = cib_avail(cib);
 
     if (avail > 0) {
         return (int) (cib->read_count++ & cib->mask);
@@ -91,7 +91,7 @@ static inline int cib_get(cib_t *__restrict cib)
  */
 static inline int cib_put(cib_t *__restrict cib)
 {
-    unsigned int avail = cib_avail(cib);
+    uint16_t avail = cib_avail(cib);
 
     /* We use a signed compare, because the mask is -1u for an empty CIB. */
     if ((int) avail <= (int) cib->mask) {

--- a/core/include/cib.h
+++ b/core/include/cib.h
@@ -18,6 +18,8 @@
  * @author      unknown, propably Kaspar Schleiser <kaspar@schleiser.de>
  */
 
+#include <stdint.h>
+
 #ifndef __CIB_H
 #define __CIB_H
 

--- a/tests/unittests/README.md
+++ b/tests/unittests/README.md
@@ -140,8 +140,8 @@ The test header ``tests-<modulename>/tests-<module>.h`` of a module you add to `
  *
  * @author      <author>
  */
-#ifndef __TESTS_<MODULE>_H_
-#define __TESTS_<MODULE>_H_
+#ifndef TESTS_<MODULE>_H_
+#define TESTS_<MODULE>_H_
 #include "embUnit/embUnit.h"
 
 #ifdef __cplusplus
@@ -168,7 +168,7 @@ Test *tests_<module>_<header2>_tests(void);
 }
 #endif
 
-#endif /* __TESTS_<MODULE>_H_ */
+#endif /* TESTS_<MODULE>_H_ */
 /** @} */
 ```
 

--- a/tests/unittests/netdev_dummy/include/netdev_dummy.h
+++ b/tests/unittests/netdev_dummy/include/netdev_dummy.h
@@ -17,8 +17,8 @@
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
-#ifndef __UNITTESTS_NETDEV_DUMMY_H_
-#define __UNITTESTS_NETDEV_DUMMY_H_
+#ifndef UNITTESTS_NETDEV_DUMMY_H_
+#define UNITTESTS_NETDEV_DUMMY_H_
 
 #include <stdlib.h>
 
@@ -153,7 +153,7 @@ void unittest_netdev_dummy_init(void);
 }
 #endif
 
-#endif /* __UNITTESTS_NETDEV_DUMMY_H_ */
+#endif /* UNITTESTS_NETDEV_DUMMY_H_ */
 
 /**
  * @}


### PR DESCRIPTION
Changed from unsigned int to uint16_t so it will not be dependent on the platform implementation.