### PR TITLE
Added cpuid_get for STM boards

### DIFF
--- a/boards/stm32f0discovery/Makefile.features
+++ b/boards/stm32f0discovery/Makefile.features
@@ -1,2 +1,2 @@
-FEATURES_PROVIDED += periph_adc periph_gpio periph_spi periph_uart cpp
+FEATURES_PROVIDED += periph_adc periph_gpio periph_spi periph_uart cpp periph_cpuid
 FEATURES_MCU_GROUP = cortex_m0

--- a/boards/stm32f3discovery/Makefile.features
+++ b/boards/stm32f3discovery/Makefile.features
@@ -1,3 +1,3 @@
 FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart periph_gpio periph_pwm periph_spi
+FEATURES_PROVIDED += periph_uart periph_gpio periph_pwm periph_spi periph_cpuid
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/stm32f4discovery/Makefile.features
+++ b/boards/stm32f4discovery/Makefile.features
@@ -1,4 +1,4 @@
 FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += periph_uart periph_gpio periph_spi periph_i2c periph_pwm periph_random \
-                     periph_adc periph_dac
+                     periph_adc periph_dac periph_cpuid
 FEATURES_MCU_GROUP = cortex_m4

--- a/cpu/stm32f0/include/cpu-conf.h
+++ b/cpu/stm32f0/include/cpu-conf.h
@@ -58,6 +58,11 @@ extern "C" {
 #endif
 /** @} */
 
+/**
+ * @brief Length for reading CPU_ID
+ */
+#define CPUID_ID_LEN                    (12)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32f0/periph/cpuid.c
+++ b/cpu/stm32f0/periph/cpuid.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 James Hollister
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  driver_periph
+ * @{
+ *
+ * @file
+ * @brief       Low-level CPUID driver implementation
+ *
+ * @author      James Hollister <jhollisterjr@gmail.com>
+ */
+
+#include <string.h>
+#include "cpu-conf.h"
+
+#include "periph/cpuid.h"
+
+#define STM32F0_CPUID_ADDR (0x1ffff7ac)
+
+void cpuid_get(void *id)
+{
+    memcpy(id, (void *)(STM32F0_CPUID_ADDR), CPUID_ID_LEN);
+}
+
+/** @} */

--- a/cpu/stm32f3/include/cpu-conf.h
+++ b/cpu/stm32f3/include/cpu-conf.h
@@ -54,6 +54,11 @@
 #endif
 /** @} */
 
+/**
+ * @brief Length for reading CPU_ID
+ */
+#define CPUID_ID_LEN                    (12)
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/stm32f3/periph/cpuid.c
+++ b/cpu/stm32f3/periph/cpuid.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 James Hollister
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  driver_periph
+ * @{
+ *
+ * @file
+ * @brief       Low-level CPUID driver implementation
+ *
+ * @author      James Hollister <jhollisterjr@gmail.com>
+ */
+
+#include <string.h>
+#include "cpu-conf.h"
+
+#include "periph/cpuid.h"
+
+#define STM32F3_CPUID_ADDR (0x1ffff7ac)
+
+void cpuid_get(void *id)
+{
+    memcpy(id, (void *)(STM32F3_CPUID_ADDR), CPUID_ID_LEN);
+}
+
+/** @} */

--- a/cpu/stm32f4/include/cpu-conf.h
+++ b/cpu/stm32f4/include/cpu-conf.h
@@ -54,6 +54,11 @@
 /** @} */
 
 /**
+ * @brief Length for reading CPU_ID
+ */
+#define CPUID_ID_LEN                    (12)
+
+/**
  * @name CC110X buffer size definitions for the stm32f4
  * @{
  */

--- a/cpu/stm32f4/periph/cpuid.c
+++ b/cpu/stm32f4/periph/cpuid.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 James Hollister
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  driver_periph
+ * @{
+ *
+ * @file
+ * @brief       Low-level CPUID driver implementation
+ *
+ * @author      James Hollister <jhollisterjr@gmail.com>
+ */
+
+#include <string.h>
+#include "cpu-conf.h"
+
+#include "periph/cpuid.h"
+
+#define STM32F4_CPUID_ADDR  (0x1fff7a10)
+
+void cpuid_get(void *id)
+{
+    memcpy(id, (void *)(STM32F4_CPUID_ADDR), CPUID_ID_LEN);
+}
+
+/** @} */


### PR DESCRIPTION
Adds cpuid_get for the rest of the STM boards as per issue #1511. All of the values were obtained from reference manuals for the corresponding board but I wasn't able to test each function.