### PR TITLE
Added color to the output of the embUnit "standard" and of the "text" outputters

### DIFF
--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -81,5 +81,7 @@ ifneq (,$(filter embunit,$(USEMODULE)))
         CFLAGS += -DOUTPUT=OUTPUT_TEXT
     else ifeq ($(OUTPUT),COMPILER)
         CFLAGS += -DOUTPUT=OUTPUT_COMPILER
+    else ifeq ($(OUTPUT),COLORTEXT)
+        CFLAGS += -DOUTPUT=OUTPUT_COLORTEXT
     endif
 endif

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -83,5 +83,7 @@ ifneq (,$(filter embunit,$(USEMODULE)))
         CFLAGS += -DOUTPUT=OUTPUT_COMPILER
     else ifeq ($(OUTPUT),COLORTEXT)
         CFLAGS += -DOUTPUT=OUTPUT_COLORTEXT
+    else ifeq ($(OUTPUT),COLOR)
+        CFLAGS += -DOUTPUT=OUTPUT_COLOR
     endif
 endif

--- a/sys/embunit/ColorOutputter.c
+++ b/sys/embunit/ColorOutputter.c
@@ -34,6 +34,7 @@
  */
 #include <stdio.h>
 #include "ColorOutputter.h"
+#include "ColorTextColors.h"
 
 static void ColorOutputter_printHeader(OutputterRef self)
 {

--- a/sys/embunit/ColorOutputter.c
+++ b/sys/embunit/ColorOutputter.c
@@ -57,30 +57,28 @@ static void ColorOutputter_printSuccessful(OutputterRef self, TestRef test, int 
     (void) self;
     (void) test;
     (void) runCount;
+    printf(CGREEN "." CDEFAULT);
 }
 
 static void ColorOutputter_printFailure(OutputterRef self, TestRef test, char *msg, int line,
         char *file, int runCount)
 {
     (void) self;
-    (void) test;
-    (void) msg;
-    (void) line;
-    (void) file;
     (void) runCount;
+    printf("\n" CRED "FAILED %s (%s:%d) %s" CDEFAULT "\n", Test_name(test), file, line, msg);
 }
 
 void ColorOutputter_printStatistics(OutputterRef self, TestResultRef result)
 {
     (void) self;
     if (result->failureCount) {
-        printf("\n\033[41;1mFAILED\033[21m (%d of %d failed)", result->failureCount,
+        printf("\n" BGRED SBOLD "FAILED" SDEFAULT " (%d of %d failed)", result->failureCount,
                 result->runCount);
     }
     else {
-        printf("\n\033[42;1mOK\033[21m (%d tests)", result->runCount);
+        printf("\n" BGGREEN SBOLD "OK" SDEFAULT " (%d tests)", result->runCount);
     }
-    printf("\033[K\033[0m\n");
+    printf(LINEFILL BGDEFAULT "\n");
 }
 
 static const OutputterImplement ColorOutputterImplement = {

--- a/sys/embunit/ColorOutputter.c
+++ b/sys/embunit/ColorOutputter.c
@@ -1,0 +1,102 @@
+/*
+ * COPYRIGHT AND PERMISSION NOTICE
+ *
+ * Copyright (c) 2003 Embedded Unit Project
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons
+ * to whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies
+ * of the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
+ * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Except as contained in this notice, the name of a copyright holder
+ * shall not be used in advertising or otherwise to promote the sale,
+ * use or other dealings in this Software without prior written
+ * authorization of the copyright holder.
+ *
+ * $Id: ColorOutputter.c,v 1.4 2003/09/06 13:28:27 arms22 Exp $
+ */
+#include <stdio.h>
+#include "ColorOutputter.h"
+
+static void ColorOutputter_printHeader(OutputterRef self)
+{
+    (void) self;
+}
+
+static void ColorOutputter_printStartTest(OutputterRef self, TestRef test)
+{
+    (void) self;
+    (void) test;
+}
+
+static void ColorOutputter_printEndTest(OutputterRef self, TestRef test)
+{
+    (void) self;
+    (void) test;
+}
+
+static void ColorOutputter_printSuccessful(OutputterRef self, TestRef test, int runCount)
+{
+    (void) self;
+    (void) test;
+    (void) runCount;
+}
+
+static void ColorOutputter_printFailure(OutputterRef self, TestRef test, char *msg, int line,
+        char *file, int runCount)
+{
+    (void) self;
+    (void) test;
+    (void) msg;
+    (void) line;
+    (void) file;
+    (void) runCount;
+}
+
+void ColorOutputter_printStatistics(OutputterRef self, TestResultRef result)
+{
+    (void) self;
+    if (result->failureCount) {
+        printf("\n\033[41;1mFAILED\033[21m (%d of %d failed)", result->failureCount,
+                result->runCount);
+    }
+    else {
+        printf("\n\033[42;1mOK\033[21m (%d tests)", result->runCount);
+    }
+    printf("\033[K\033[0m\n");
+}
+
+static const OutputterImplement ColorOutputterImplement = {
+    (OutputterPrintHeaderFunction) ColorOutputter_printHeader,
+    (OutputterPrintStartTestFunction) ColorOutputter_printStartTest,
+    (OutputterPrintEndTestFunction) ColorOutputter_printEndTest,
+    (OutputterPrintSuccessfulFunction) ColorOutputter_printSuccessful,
+    (OutputterPrintFailureFunction) ColorOutputter_printFailure,
+    (OutputterPrintStatisticsFunction) ColorOutputter_printStatistics
+};
+
+static const Outputter ColorOutputter = {
+    (OutputterImplementRef) &ColorOutputterImplement
+};
+
+OutputterRef ColorOutputter_outputter(void)
+{
+    return (OutputterRef) &ColorOutputter;
+}

--- a/sys/embunit/ColorOutputter.c
+++ b/sys/embunit/ColorOutputter.c
@@ -1,36 +1,15 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
+ * Copyright (C) 2015 Janos Kutscherauer <noshky@gmail.com>
  *
- * Copyright (c) 2003 Embedded Unit Project
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
  *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: ColorOutputter.c,v 1.4 2003/09/06 13:28:27 arms22 Exp $
+ * @file    ColorOutputter.c
  */
 #include <stdio.h>
 #include "ColorOutputter.h"
@@ -99,3 +78,4 @@ OutputterRef ColorOutputter_outputter(void)
 {
     return (OutputterRef) &ColorOutputter;
 }
+/** @} */

--- a/sys/embunit/ColorTextColors.h
+++ b/sys/embunit/ColorTextColors.h
@@ -1,36 +1,15 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
+ * Copyright (C) 2015 Janos Kutscherauer <noshky@gmail.com>
  *
- * Copyright (c) 2003 Embedded Unit Project
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
  *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: ColorTextOutputter.h,v 1.2 2003/09/06 13:28:27 arms22 Exp $
+ * @file    ColorTextColors.h
  */
 #ifndef __COLORTEXTCOLORS_H__
 #define __COLORTEXTCOLORS_H__
@@ -63,3 +42,4 @@ extern "C" {
 #endif
 
 #endif/*__COLORTEXTCOLORS_H__*/
+/** @} */

--- a/sys/embunit/ColorTextColors.h
+++ b/sys/embunit/ColorTextColors.h
@@ -30,23 +30,36 @@
  * use or other dealings in this Software without prior written
  * authorization of the copyright holder.
  *
- * $Id: ColorOutputter.h,v 1.2 2003/09/06 13:28:27 arms22 Exp $
+ * $Id: ColorTextOutputter.h,v 1.2 2003/09/06 13:28:27 arms22 Exp $
  */
-#ifndef __COLOROUTPUTTER_H__
-#define __COLOROUTPUTTER_H__
-
-#include "Outputter.h"
+#ifndef __COLORTEXTCOLORS_H__
+#define __COLORTEXTCOLORS_H__
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-OutputterRef ColorOutputter_outputter(void);
-
-void ColorOutputter_printStatistics(OutputterRef self, TestResultRef result);
+/*
+ * Some terminal color definitions:
+ * C<color>:    text color
+ * CDEFAULT:    default text color
+ * BG<color>:   background color
+ * BGDEFAULT:   default background color
+ * S<style>:    text style
+ * SDEFAULT:    default text style
+ */
+#define CRED        "\033[31m"
+#define CGREEN      "\033[32m"
+#define CDEFAULT    "\033[39m"
+#define BGRED       "\033[41m"
+#define BGGREEN     "\033[42m"
+#define BGDEFAULT   "\033[49m"
+#define SBOLD       "\033[1m"
+#define SDEFAULT    "\033[21m"
+#define LINEFILL    "\033[K"
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif/*__COLOROUTPUTTER_H__*/
+#endif/*__COLORTEXTCOLORS_H__*/

--- a/sys/embunit/ColorTextOutputter.c
+++ b/sys/embunit/ColorTextOutputter.c
@@ -1,0 +1,93 @@
+/*
+ * COPYRIGHT AND PERMISSION NOTICE
+ *
+ * Copyright (c) 2003 Embedded Unit Project
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons
+ * to whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies
+ * of the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
+ * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Except as contained in this notice, the name of a copyright holder
+ * shall not be used in advertising or otherwise to promote the sale,
+ * use or other dealings in this Software without prior written
+ * authorization of the copyright holder.
+ *
+ * $Id: ColorTextOutputter.c,v 1.4 2003/09/06 13:28:27 arms22 Exp $
+ */
+#include <stdio.h>
+#include "ColorTextOutputter.h"
+
+static void ColorTextOutputter_printHeader(OutputterRef self)
+{
+    (void)self;
+}
+
+static void ColorTextOutputter_printStartTest(OutputterRef self,TestRef test)
+{
+    (void)self;
+    printf("- %s\n",Test_name(test));
+}
+
+static void ColorTextOutputter_printEndTest(OutputterRef self,TestRef test)
+{
+    (void)self;
+    (void)test;
+}
+
+static void ColorTextOutputter_printSuccessful(OutputterRef self,TestRef test,int runCount)
+{
+    (void)self;
+    printf("\033[32m%d) OK %s\033[0m\n", runCount, Test_name(test));
+}
+
+static void ColorTextOutputter_printFailure(OutputterRef self,TestRef test,char *msg,int line,char *file,int runCount)
+{
+    (void)self;
+    printf("\033[31m%d) NG %s\033[0m (%s %d) %s\n", runCount, Test_name(test), file, line, msg);
+}
+
+static void ColorTextOutputter_printStatistics(OutputterRef self,TestResultRef result)
+{
+    (void)self;
+    if (result->failureCount) {
+        printf("\n\033[31;1mFAILED\033[21m (%d of %d failed)\033[0m\n",result->failureCount,result->runCount);
+    } else {
+        printf("\n\033[32;1mOK\033[21m (%d tests)\033[0m\n",result->runCount);
+    }
+}
+
+static const OutputterImplement ColorTextOutputterImplement = {
+    (OutputterPrintHeaderFunction)      ColorTextOutputter_printHeader,
+    (OutputterPrintStartTestFunction)   ColorTextOutputter_printStartTest,
+    (OutputterPrintEndTestFunction)     ColorTextOutputter_printEndTest,
+    (OutputterPrintSuccessfulFunction)  ColorTextOutputter_printSuccessful,
+    (OutputterPrintFailureFunction)     ColorTextOutputter_printFailure,
+    (OutputterPrintStatisticsFunction)  ColorTextOutputter_printStatistics,
+};
+
+static const Outputter ColorTextOutputter = {
+    (OutputterImplementRef)&ColorTextOutputterImplement,
+};
+
+OutputterRef ColorTextOutputter_outputter(void)
+{
+    return (OutputterRef)&ColorTextOutputter;
+}

--- a/sys/embunit/ColorTextOutputter.c
+++ b/sys/embunit/ColorTextOutputter.c
@@ -34,6 +34,7 @@
  */
 #include <stdio.h>
 #include "ColorTextOutputter.h"
+#include "ColorOutputter.h"
 
 static void ColorTextOutputter_printHeader(OutputterRef self)
 {
@@ -64,14 +65,9 @@ static void ColorTextOutputter_printFailure(OutputterRef self,TestRef test,char 
     printf("\033[31m%d) NG %s\033[0m (%s %d) %s\n", runCount, Test_name(test), file, line, msg);
 }
 
-static void ColorTextOutputter_printStatistics(OutputterRef self,TestResultRef result)
+void ColorTextOutputter_printStatistics(OutputterRef self,TestResultRef result)
 {
-    (void)self;
-    if (result->failureCount) {
-        printf("\n\033[31;1mFAILED\033[21m (%d of %d failed)\033[0m\n",result->failureCount,result->runCount);
-    } else {
-        printf("\n\033[32;1mOK\033[21m (%d tests)\033[0m\n",result->runCount);
-    }
+    ColorOutputter_printStatistics(self, result);
 }
 
 static const OutputterImplement ColorTextOutputterImplement = {

--- a/sys/embunit/ColorTextOutputter.c
+++ b/sys/embunit/ColorTextOutputter.c
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include "ColorTextOutputter.h"
 #include "ColorOutputter.h"
+#include "ColorTextColors.h"
 
 static void ColorTextOutputter_printHeader(OutputterRef self)
 {

--- a/sys/embunit/ColorTextOutputter.c
+++ b/sys/embunit/ColorTextOutputter.c
@@ -56,13 +56,13 @@ static void ColorTextOutputter_printEndTest(OutputterRef self,TestRef test)
 static void ColorTextOutputter_printSuccessful(OutputterRef self,TestRef test,int runCount)
 {
     (void)self;
-    printf("\033[32m%d) OK %s\033[0m\n", runCount, Test_name(test));
+    printf(CGREEN "%d) OK %s" CDEFAULT "\n", runCount, Test_name(test));
 }
 
 static void ColorTextOutputter_printFailure(OutputterRef self,TestRef test,char *msg,int line,char *file,int runCount)
 {
     (void)self;
-    printf("\033[31m%d) NG %s\033[0m (%s %d) %s\n", runCount, Test_name(test), file, line, msg);
+    printf(CRED "%d) NG %s" CDEFAULT " (%s:%d) %s\n", runCount, Test_name(test), file, line, msg);
 }
 
 void ColorTextOutputter_printStatistics(OutputterRef self,TestResultRef result)

--- a/sys/embunit/ColorTextOutputter.c
+++ b/sys/embunit/ColorTextOutputter.c
@@ -1,36 +1,15 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
+ * Copyright (C) 2015 Janos Kutscherauer <noshky@gmail.com>
  *
- * Copyright (c) 2003 Embedded Unit Project
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
  *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: ColorTextOutputter.c,v 1.4 2003/09/06 13:28:27 arms22 Exp $
+ * @file    ColorTextOutputter.c
  */
 #include <stdio.h>
 #include "ColorTextOutputter.h"
@@ -88,3 +67,4 @@ OutputterRef ColorTextOutputter_outputter(void)
 {
     return (OutputterRef)&ColorTextOutputter;
 }
+/** @} */

--- a/sys/include/embUnit.h
+++ b/sys/include/embUnit.h
@@ -35,6 +35,9 @@
 #   elif (OUTPUT==OUTPUT_COMPILER)
 #       include "embUnit/CompilerOutputter.h"
 #       define OUTPUTTER   (CompilerOutputter_outputter())
+#   elif (OUTPUT==OUTPUT_COLORTEXT)
+#       include "embUnit/ColorTextOutputter.h"
+#       define OUTPUTTER   (ColorTextOutputter_outputter())
 #   endif
 
 #   include "embUnit/TextUIRunner.h"

--- a/sys/include/embUnit.h
+++ b/sys/include/embUnit.h
@@ -22,9 +22,11 @@
 #include "embUnit/embUnit.h"
 
 #ifdef OUTPUT
-#   define OUTPUT_XML      (1)
-#   define OUTPUT_TEXT     (2)
-#   define OUTPUT_COMPILER (4)
+#   define OUTPUT_XML       (1)
+#   define OUTPUT_TEXT      (2)
+#   define OUTPUT_COMPILER  (4)
+#   define OUTPUT_COLORTEXT (8)
+#   define OUTPUT_COLOR     (16)
 
 #   if (OUTPUT==OUTPUT_XML)
 #       include "embUnit/XMLOutputter.h"
@@ -38,6 +40,9 @@
 #   elif (OUTPUT==OUTPUT_COLORTEXT)
 #       include "embUnit/ColorTextOutputter.h"
 #       define OUTPUTTER   (ColorTextOutputter_outputter())
+#   elif (OUTPUT==OUTPUT_COLOR)
+#       include "embUnit/ColorOutputter.h"
+#       define OUTPUTTER   (ColorOutputter_outputter())
 #   endif
 
 #   include "embUnit/TextUIRunner.h"

--- a/sys/include/embUnit/ColorOutputter.h
+++ b/sys/include/embUnit/ColorOutputter.h
@@ -1,36 +1,15 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
+ * Copyright (C) 2015 Janos Kutscherauer <noshky@gmail.com>
  *
- * Copyright (c) 2003 Embedded Unit Project
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
  *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: ColorOutputter.h,v 1.2 2003/09/06 13:28:27 arms22 Exp $
+ * @file    ColorOutputter.h
  */
 #ifndef __COLOROUTPUTTER_H__
 #define __COLOROUTPUTTER_H__
@@ -50,3 +29,4 @@ void ColorOutputter_printStatistics(OutputterRef self, TestResultRef result);
 #endif
 
 #endif/*__COLOROUTPUTTER_H__*/
+/** @} */

--- a/sys/include/embUnit/ColorOutputter.h
+++ b/sys/include/embUnit/ColorOutputter.h
@@ -41,6 +41,25 @@
 extern "C" {
 #endif
 
+/*
+ * Some terminal color definitions:
+ * C<color>:    text color
+ * CDEFAULT:    default text color
+ * BG<color>:   background color
+ * BGDEFAULT:   default background color
+ * S<style>:    text style
+ * SDEFAULT:    default text style
+ */
+#define CRED        "\033[31m"
+#define CGREEN      "\033[32m"
+#define CDEFAULT    "\033[39m"
+#define BGRED       "\033[41m"
+#define BGGREEN     "\033[42m"
+#define BGDEFAULT   "\033[49m"
+#define SBOLD       "\033[1m"
+#define SDEFAULT    "\033[21m"
+#define LINEFILL    "\033[K"
+
 OutputterRef ColorOutputter_outputter(void);
 
 void ColorOutputter_printStatistics(OutputterRef self, TestResultRef result);

--- a/sys/include/embUnit/ColorOutputter.h
+++ b/sys/include/embUnit/ColorOutputter.h
@@ -1,0 +1,52 @@
+/*
+ * COPYRIGHT AND PERMISSION NOTICE
+ *
+ * Copyright (c) 2003 Embedded Unit Project
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons
+ * to whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies
+ * of the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
+ * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Except as contained in this notice, the name of a copyright holder
+ * shall not be used in advertising or otherwise to promote the sale,
+ * use or other dealings in this Software without prior written
+ * authorization of the copyright holder.
+ *
+ * $Id: ColorOutputter.h,v 1.2 2003/09/06 13:28:27 arms22 Exp $
+ */
+#ifndef __COLOROUTPUTTER_H__
+#define __COLOROUTPUTTER_H__
+
+#include "Outputter.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+OutputterRef ColorOutputter_outputter(void);
+
+void ColorOutputter_printStatistics(OutputterRef self, TestResultRef result);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif/*__COLOROUTPUTTER_H__*/

--- a/sys/include/embUnit/ColorTextOutputter.h
+++ b/sys/include/embUnit/ColorTextOutputter.h
@@ -1,36 +1,15 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
+ * Copyright (C) 2015 Janos Kutscherauer <noshky@gmail.com>
  *
- * Copyright (c) 2003 Embedded Unit Project
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
  *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: ColorTextOutputter.h,v 1.2 2003/09/06 13:28:27 arms22 Exp $
+ * @file    ColorTextOutputter.h
  */
 #ifndef __COLORTEXTOUTPUTTER_H__
 #define __COLORTEXTOUTPUTTER_H__
@@ -48,3 +27,4 @@ OutputterRef ColorTextOutputter_outputter(void);
 #endif
 
 #endif/*__COLORTEXTOUTPUTTER_H__*/
+/** @} */

--- a/sys/include/embUnit/ColorTextOutputter.h
+++ b/sys/include/embUnit/ColorTextOutputter.h
@@ -1,0 +1,50 @@
+/*
+ * COPYRIGHT AND PERMISSION NOTICE
+ *
+ * Copyright (c) 2003 Embedded Unit Project
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons
+ * to whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies
+ * of the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
+ * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Except as contained in this notice, the name of a copyright holder
+ * shall not be used in advertising or otherwise to promote the sale,
+ * use or other dealings in this Software without prior written
+ * authorization of the copyright holder.
+ *
+ * $Id: ColorTextOutputter.h,v 1.2 2003/09/06 13:28:27 arms22 Exp $
+ */
+#ifndef __COLORTEXTOUTPUTTER_H__
+#define __COLORTEXTOUTPUTTER_H__
+
+#include "Outputter.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+OutputterRef ColorTextOutputter_outputter(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif/*__COLORTEXTOUTPUTTER_H__*/

--- a/tests/unittests/README.md
+++ b/tests/unittests/README.md
@@ -30,6 +30,8 @@ Other output formats using [*embUnit*](http://embunit.sourceforge.net/)'s ``text
 * Compiler: ``OUTPUT="COMPILER"``
 * Text: ``OUTPUT="TEXT"``
 * XML: ``OUTPUT="XML"``
+* Color: ``OUTPUT="COLOR"`` (like default, but with red/green output)
+* Colored-Text: ``OUTPUT="COLORTEXT"`` (like ``TEXT``, but with red/green output)
 
 #### Compile example
 ```bash


### PR DESCRIPTION
This change prints succesful test runs in GREEN, and failed runs in RED.

The failed message was slightly adjusted to a more meaningful message:
Before: run 10 failures 3
Now: FAILED (3 of 10 failed)

(It has to be checked that no external tools rely on this output message. If that would be the case, this change should be discarded.)