### PR TITLE
ng_tapnet: initial import of a pure Ethernet device for native

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -57,6 +57,10 @@ ifneq (,$(filter ng_ipv6_netif,$(USEMODULE)))
   USEMODULE += ng_netif
 endif
 
+ifneq (,$(filter ng_tapnet,$(USEMODULE)))
+  USEMODULE += ng_pktbuf
+endif
+
 ifneq (,$(filter ng_netbase,$(USEMODULE)))
   USEMODULE += ng_netapi
   USEMODULE += ng_netreg

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -68,7 +68,7 @@ export LINKFLAGS += -ldl
 endif
 
 # set the tap interface for term/valgrind
-ifneq (,$(filter nativenet,$(USEMODULE)))
+ifneq (,$(filter nativenet ng_tapnet,$(USEMODULE)))
 	export PORT ?= tap0
 else
 	export PORT =

--- a/cpu/native/Makefile
+++ b/cpu/native/Makefile
@@ -4,6 +4,9 @@ DIRS += periph
 ifneq (,$(filter nativenet,$(USEMODULE)))
 	DIRS += net
 endif
+ifneq (,$(filter ng_tapnet,$(USEMODULE)))
+	DIRS += ng_tapnet
+endif
 
 include $(RIOTBASE)/Makefile.base
 

--- a/cpu/native/include/ng_tapnet.h
+++ b/cpu/native/include/ng_tapnet.h
@@ -43,7 +43,7 @@ typedef struct {
     ng_netdev_driver_t *driver;         /**< pointer to the devices interface */
     ng_netdev_event_cb_t event_cb;      /**< netdev event callback */
     kernel_pid_t mac_pid;               /**< the driver's thread's PID */
-    int tap_fd;                         /**< file descriptor for the TAP */
+    int tap_fd;                         /**< host file descriptor for the TAP */
     uint8_t addr[NG_ETHERNET_ADDR_LEN]; /**< The MAC address of the TAP */
     uint8_t promiscous;                 /**< Flag for promiscous mode */
 } ng_tapnet_t;

--- a/cpu/native/include/ng_tapnet.h
+++ b/cpu/native/include/ng_tapnet.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @defgroup    cpu_native_ng_tapnet   TAP interface as netdev device.
+ * @ingroup     native_cpu
+ *
+ * @brief   Allows for usage of multiple TAP interfaces as ethernet netdev
+ *          devices.
+ * @{
+ *
+ * @file
+ * @brief       Definitions for @ref cpu_native_ng_tapnet
+ *
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+
+#ifndef NG_TAPNET_H_
+#define NG_TAPNET_H_
+
+#include <inttypes.h>
+
+#include "kernel_types.h"
+#include "net/ng_netdev.h"
+#include "net/ng_ethernet/hdr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Definition of the TAP device
+ * @extends ng_netdev_t
+ * @internal
+ */
+typedef struct {
+    ng_netdev_driver_t *driver;         /**< pointer to the devices interface */
+    ng_netdev_event_cb_t event_cb;      /**< netdev event callback */
+    kernel_pid_t mac_pid;               /**< the driver's thread's PID */
+    int tap_fd;                         /**< file descriptor for the TAP */
+    uint8_t addr[NG_ETHERNET_ADDR_LEN]; /**< The MAC address of the TAP */
+    uint8_t promiscous;                 /**< Flag for promiscous mode */
+} ng_tapnet_t;
+
+/**
+ * @brief   Reference to the TAP driver interface
+ */
+extern const ng_netdev_driver_t ng_tapnet_driver;
+
+/**
+ * @brief   Reference to the TAP device
+ */
+extern ng_tapnet_t ng_tapnet; /* XXX: this is only here since I do not know how
+                               * to get the device in the interrupt handler */
+
+/**
+ * @brief   Initialize a given TAP device
+ *
+ * @param[out] dev      TAP device to initialize
+ * @param[in] name      Name of the TAP interface.
+ *                      If @p name is an empty string, the kernel chooses a name.
+ *                      If @p name is an existing device, that device is used.
+ *                      Otherwise a device named "name" is created
+ * @param[in] name_len  Length of @p name.
+ *
+ * @return  0 on success
+ * @return  -ENODEV on invalid device descriptor
+ * @return  -ENXIO on error with TAP device creation
+ */
+int ng_tapnet_init(ng_tapnet_t *dev, char *name, size_t name_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NG_TAPNET_H_ */
+/**
+ * @}
+ */

--- a/cpu/native/ng_tapnet/Makefile
+++ b/cpu/native/ng_tapnet/Makefile
@@ -1,0 +1,3 @@
+include $(RIOTBASE)/Makefile.base
+
+INCLUDES = $(NATIVEINCLUDES)

--- a/cpu/native/ng_tapnet/ng_tapnet.c
+++ b/cpu/native/ng_tapnet/ng_tapnet.c
@@ -499,7 +499,7 @@ static inline void _addr_set_multicast(uint8_t *dst, ng_pktsnip_t *payload)
             /* TODO change to proper types when ng_ipv6_hdr_t got merged */
             break;
 #endif
-       default:
+        default:
             _addr_set_broadcast(dst);
             break;
     }
@@ -546,7 +546,8 @@ static int _marshall_ethernet(ng_tapnet_t *dev, uint8_t *buffer, ng_pktsnip_t *p
     else if (netif_hdr->dst_l2addr_len == NG_ETHERNET_ADDR_LEN) {
         memcpy(hdr->dst, ng_netif_hdr_get_dst_addr(netif_hdr),
                NG_ETHERNET_ADDR_LEN);
-    } else {
+    }
+    else {
         DEBUG("ng_tapnet: destination address had unexpected format\n");
         return -EBADMSG;
     }

--- a/cpu/native/ng_tapnet/ng_tapnet.c
+++ b/cpu/native/ng_tapnet/ng_tapnet.c
@@ -101,14 +101,14 @@ const ng_netdev_driver_t ng_tapnet_driver = {
 
 static inline bool _has_src(ng_pktsnip_t *pkt)
 {
-    return ((pkt->size > sizeof(ng_netif_hdr_t)) &&
+    return ((pkt->type == NG_NETTYPE_NETIF) &&
             ((ng_netif_hdr_t *)pkt->data)->src_l2addr_len == NG_ETHERNET_ADDR_LEN);
 }
 
 static inline bool _for_ethernet(ng_pktsnip_t *pkt)
 {
-    return (((pkt->size > (sizeof(ng_netif_hdr_t)) &&
-              (((ng_netif_hdr_t *)pkt->data)->dst_l2addr_len == NG_ETHERNET_ADDR_LEN))) ||
+    return (((pkt->type == NG_NETTYPE_NETIF) &&
+             (((ng_netif_hdr_t *)pkt->data)->dst_l2addr_len == NG_ETHERNET_ADDR_LEN)) ||
             _has_src(pkt));
 }
 
@@ -591,7 +591,7 @@ static void _rx_event(ng_tapnet_t *dev)
         }
 
         netif_hdr = ng_pktbuf_add(NULL, NULL, sizeof(ng_netif_hdr_t) + (2 * NG_ETHERNET_ADDR_LEN),
-                                  NG_NETTYPE_UNDEF);
+                                  NG_NETTYPE_NETIF);
 
         if (netif_hdr == NULL) {
             DEBUG("ng_tapnet: no space left in packet buffer\n");

--- a/cpu/native/ng_tapnet/ng_tapnet.c
+++ b/cpu/native/ng_tapnet/ng_tapnet.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ * Copyright (C) 2015 Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>,
+ *                    Martine Lenders <mlenders@inf.fu-berlin.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for

--- a/cpu/native/ng_tapnet/ng_tapnet.c
+++ b/cpu/native/ng_tapnet/ng_tapnet.c
@@ -1,0 +1,672 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @ingroup     cpu_native_ng_tapnet
+ * @{
+ *
+ * @file
+ *
+ * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#ifdef __MACH__
+#define _POSIX_C_SOURCE
+#include <net/if.h>
+#undef _POSIX_C_SOURCE
+#include <ifaddrs.h>
+#include <net/if_dl.h>
+
+#elif defined(__FreeBSD__)
+#include <sys/socket.h>
+#include <net/if.h>
+#include <ifaddrs.h>
+#include <net/if_dl.h>
+
+#else
+#include <net/if.h>
+#include <linux/if_tun.h>
+#include <linux/if_ether.h>
+#endif
+
+#include "byteorder.h"
+#include "native_internal.h"
+#include "net/ng_ethernet.h"
+#include "net/ng_ethertype.h"
+#include "net/ng_netdev.h"
+#include "net/ng_netif/hdr.h"
+#include "net/ng_pkt.h"
+#include "net/ng_pktbuf.h"
+#include "od.h"
+#include "thread.h"
+#include "utlist.h"
+
+#include "ng_tapnet.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#define _ISR_EVENT_RX   (1U)
+
+ng_tapnet_t ng_tapnet;
+
+static uint8_t send_buffer[NG_ETHERNET_MAX_LEN];
+static uint8_t recv_buffer[NG_ETHERNET_MAX_LEN];
+
+/* MAC OSX specific variables and functions */
+#ifdef __MACH__
+pid_t _sigio_child_pid;
+
+static void _sigio_child(ng_tapnet_t *dev);
+#endif
+
+/* driver function definitions */
+static int _send_data(ng_netdev_t *netdev, ng_pktsnip_t *pkt);
+static int _add_event_callback(ng_netdev_t *dev, ng_netdev_event_cb_t cb);
+static int _rem_event_callback(ng_netdev_t *dev, ng_netdev_event_cb_t cb);
+static int _get(ng_netdev_t *dev, ng_netconf_opt_t opt, void *value,
+                size_t max_len);
+static int _set(ng_netdev_t *dev, ng_netconf_opt_t opt, void *value,
+                size_t value_len);
+static void _isr_event(ng_netdev_t *dev, uint32_t event_type);
+
+/* netdev driver struct */
+const ng_netdev_driver_t ng_tapnet_driver = {
+    _send_data,
+    _add_event_callback,
+    _rem_event_callback,
+    _get,
+    _set,
+    _isr_event,
+};
+
+/* internal function definitions */
+
+static inline bool _has_src(ng_pktsnip_t *pkt)
+{
+    return ((pkt->size > sizeof(ng_netif_hdr_t)) &&
+            ((ng_netif_hdr_t *)pkt->data)->src_l2addr_len == NG_ETHERNET_ADDR_LEN);
+}
+
+static inline bool _for_ethernet(ng_pktsnip_t *pkt)
+{
+    return (((pkt->size > (sizeof(ng_netif_hdr_t)) &&
+              (((ng_netif_hdr_t *)pkt->data)->dst_l2addr_len == NG_ETHERNET_ADDR_LEN))) ||
+            _has_src(pkt));
+}
+
+static inline bool _addr_broadcast(uint8_t *addr)
+{
+    return ((addr[0] == 0xff) && (addr[1] == 0xff) && (addr[2] == 0xff) &&
+            (addr[3] == 0xff) && (addr[4] == 0xff) && (addr[5] == 0xff));
+}
+
+/* build Ethernet packet from pkt */
+static int _marshall_ethernet(ng_tapnet_t *dev, uint8_t *buffer, ng_pktsnip_t *pkt);
+
+/* build ISR handler for ISR events */
+void _trigger_isr_event(void);
+
+/* driver implementation */
+int ng_tapnet_init(ng_tapnet_t *dev, char *name, size_t name_len)
+{
+#ifdef __MACH__ /* OSX */
+    char clonedev[255] = "/dev/"; /* XXX bad size */
+    strncpy(clonedev + 5, name, 250);
+#elif defined(__FreeBSD__)
+    char clonedev[255] = "/dev/"; /* XXX bad size */
+    strncpy(clonedev + 5, name, 250);
+#else /* Linux */
+    struct ifreq ifr;
+    const char *clonedev = "/dev/net/tun";
+#endif
+
+    /* check device parametrs */
+    if ((dev == NULL) || (dev != &ng_tapnet)) {
+        return -ENODEV;
+    }
+
+    /* initialize device descriptor */
+    dev->driver = (ng_netdev_driver_t *)(&ng_tapnet_driver);
+    dev->promiscous = 0;
+
+    /* implicitly create the tap interface */
+    if ((dev->tap_fd = real_open(clonedev , O_RDWR)) == -1) {
+        err(EXIT_FAILURE, "open(%s)", clonedev);
+    }
+
+#if (defined(__MACH__) || defined(__FreeBSD__)) /* OSX/FreeBSD */
+    struct ifaddrs *iflist;
+
+    if (real_getifaddrs(&iflist) == 0) {
+        for (struct ifaddrs *cur = iflist; cur; cur = cur->ifa_next) {
+            if ((cur->ifa_addr->sa_family == AF_LINK) && (strcmp(cur->ifa_name, name) == 0) && cur->ifa_addr) {
+                struct sockaddr_dl *sdl = (struct sockaddr_dl *)cur->ifa_addr;
+                memcpy(dev->addr, LLADDR(sdl), sdl->sdl_alen);
+                break;
+            }
+        }
+
+        real_freeifaddrs(iflist);
+    }
+
+#else /* Linux */
+    memset(&ifr, 0, sizeof(ifr));
+    ifr.ifr_flags = IFF_TAP | IFF_NO_PI;
+    strncpy(ifr.ifr_name, name, IFNAMSIZ);
+
+    if (real_ioctl(dev->tap_fd, TUNSETIFF, (void *)&ifr) == -1) {
+        _native_in_syscall++;
+        warn("ioctl TUNSETIFF");
+        warnx("probably the tap interface (%s) does not exist or is already in use", name);
+        real_exit(EXIT_FAILURE);
+    }
+
+    strncpy(name, ifr.ifr_name, name_len);
+
+
+    /* get MAC address */
+    memset(&ifr, 0, sizeof(ifr));
+    snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", name);
+
+    if (real_ioctl(dev->tap_fd, SIOCGIFHWADDR, &ifr) == -1) {
+        _native_in_syscall++;
+        warn("ioctl SIOCGIFHWADDR");
+
+        if (real_close(dev->tap_fd) == -1) {
+            warn("close");
+        }
+
+        real_exit(EXIT_FAILURE);
+    }
+
+    memcpy(dev->addr, ifr.ifr_hwaddr.sa_data, NG_ETHERNET_ADDR_LEN);
+#endif
+    DEBUG("ng_tapnet_init(): dev->addr = %02x:%02x:%02x:%02x:%02x:%02x\n",
+          dev->addr[0], dev->addr[1], dev->addr[2],
+          dev->addr[3], dev->addr[4], dev->addr[5]);
+
+    /* configure signal handler for fds */
+    register_interrupt(SIGIO, _trigger_isr_event);
+
+#ifdef __MACH__
+    /* tuntap signalled IO is not working in OSX,
+     * check http://sourceforge.net/p/tuntaposx/bugs/17/ */
+    _sigio_child(dev);
+#else
+
+    /* configure fds to send signals on io */
+    if (fcntl(dev->tap_fd, F_SETOWN, _native_pid) == -1) {
+        err(EXIT_FAILURE, "ng_tapnet_init(): fcntl(F_SETOWN)");
+    }
+
+    /* set file access mode to non-blocking */
+    if (fcntl(dev->tap_fd, F_SETFL, O_NONBLOCK | O_ASYNC) == -1) {
+        err(EXIT_FAILURE, "ng_tabnet_init(): fcntl(F_SETFL)");
+    }
+
+#endif /* not OSX */
+
+    DEBUG("ng_tapnet: initialized.\n");
+
+    return 0;
+}
+
+static int _send_data(ng_netdev_t *netdev, ng_pktsnip_t *pkt)
+{
+    int nsent, to_send;
+    ng_tapnet_t *dev = (ng_tapnet_t *)netdev;
+
+    DEBUG("ng_tapnet: send data ");
+
+    if (pkt == NULL) {
+        return -EFAULT;
+    }
+
+    if ((dev == NULL) || (dev->driver != &ng_tapnet_driver)) {
+        DEBUG("[wrong device descriptor]\n");
+        ng_pktbuf_release(pkt);
+        return -ENODEV;
+    }
+
+    DEBUG("\n");
+
+    to_send = _marshall_ethernet(dev, send_buffer, pkt);
+    ng_pktbuf_release(pkt);
+
+    if (to_send < 0) {
+        errno = -to_send;
+        warn("marshall");
+        return to_send;
+    }
+
+    DEBUG("ng_tapnet: send %d bytes\n", to_send);
+#if MODULE_OD && defined(ENABLE_DEBUG)
+    od_hex_dump(send_buffer, to_send, OD_WIDTH_DEFAULT);
+#endif
+
+    if ((nsent = _native_write(dev->tap_fd, send_buffer, to_send)) < 0) {
+        warn("write");
+        return -EIO;
+    }
+
+    return nsent;
+}
+
+static int _add_event_callback(ng_netdev_t *dev, ng_netdev_event_cb_t cb)
+{
+    DEBUG("ng_tapnet: add event callback");
+
+    if ((dev == NULL) || (dev->driver != &ng_tapnet_driver)) {
+        DEBUG(" [wrong device descriptor]\n");
+        return -ENODEV;
+    }
+
+    if (dev->event_cb != NULL) {
+        DEBUG(" [no space left]\n");
+        return -ENOBUFS;
+    }
+
+    DEBUG("\n");
+    dev->event_cb = cb;
+
+    return 0;
+}
+
+static int _rem_event_callback(ng_netdev_t *dev, ng_netdev_event_cb_t cb)
+{
+    DEBUG("ng_tapnet: remove event callback");
+
+    if ((dev == NULL) || (dev->driver != &ng_tapnet_driver)) {
+        DEBUG(" [wrong device descriptor]\n");
+        return -ENODEV;
+    }
+
+    if (dev->event_cb != cb) {
+        DEBUG(" [not found]\n");
+        return -ENOENT;
+    }
+
+    DEBUG("\n");
+    dev->event_cb = NULL;
+
+    return 0;
+}
+
+/* individual option getters to be called by _get() */
+static inline int _get_addr(ng_tapnet_t *dev, uint8_t *value, size_t max_len)
+{
+    if (max_len < NG_ETHERNET_ADDR_LEN) {
+        /* value buffer not big enough */
+        return -EOVERFLOW;
+    }
+
+    memcpy(value, dev->addr, NG_ETHERNET_ADDR_LEN);
+
+    return NG_ETHERNET_ADDR_LEN;
+}
+
+static inline int _get_addr_len(uint16_t *value, size_t max_len)
+{
+    if (max_len != sizeof(uint16_t)) {
+        /* value buffer not big enough */
+        return -EOVERFLOW;
+    }
+
+    *value = NG_ETHERNET_ADDR_LEN;
+
+    return sizeof(uint16_t);
+}
+
+static inline int _get_max_pkt_sz(uint16_t *value, size_t max_len)
+{
+    if (max_len != sizeof(uint16_t)) {
+        /* value buffer not big enough */
+        return -EOVERFLOW;
+    }
+
+    *value = NG_ETHERNET_MAX_LEN;
+
+    return sizeof(uint16_t);
+}
+
+static inline int _get_promiscousmode(ng_tapnet_t *dev, ng_netconf_enable_t *value,
+                                      size_t max_len)
+{
+    if (max_len != sizeof(ng_netconf_enable_t)) {
+        /* value buffer not big enough */
+        return -EOVERFLOW;
+    }
+
+    *value = (ng_netconf_enable_t)dev->promiscous;
+
+    return sizeof(ng_netconf_enable_t);
+}
+
+static int _get(ng_netdev_t *dev, ng_netconf_opt_t opt, void *value,
+                size_t max_len)
+{
+    DEBUG("ng_tapnet: get ");
+
+    if ((dev == NULL) || (dev->driver != &ng_tapnet_driver)) {
+        DEBUG("[wrong device descriptor]\n");
+        return -ENODEV;
+    }
+
+    switch (opt) {
+        case NETCONF_OPT_ADDRESS:
+            DEBUG("address\n");
+            return _get_addr((ng_tapnet_t *)dev, value, max_len);
+
+        case NETCONF_OPT_ADDR_LEN:
+            DEBUG("address length\n");
+            return _get_addr_len(value, max_len);
+
+        case NETCONF_OPT_MAX_PACKET_SIZE:
+            DEBUG("maximum packet size\n");
+            return _get_max_pkt_sz(value, max_len);
+
+        case NETCONF_OPT_PROMISCUOUSMODE:
+            DEBUG("promiscous mode\n");
+            return _get_promiscousmode((ng_tapnet_t *)dev, value, max_len);
+
+        default:
+            DEBUG("[not supported: %d]\n", opt);
+            return -ENOTSUP;
+    }
+}
+
+/* individual option getters to be called by _get() */
+static inline int _set_promiscousmode(ng_tapnet_t *dev, ng_netconf_enable_t *value,
+                                      size_t value_len)
+{
+    if (value_len != sizeof(ng_netconf_enable_t)) {
+        /* value buffer not big enough */
+        return -EOVERFLOW;
+    }
+
+    dev->promiscous = (uint8_t)(*value);
+
+    return sizeof(ng_netconf_enable_t);
+}
+
+static int _set(ng_netdev_t *dev, ng_netconf_opt_t opt, void *value,
+                size_t value_len)
+{
+    DEBUG("ng_tapnet: set ");
+
+    if ((dev == NULL) || (dev->driver != &ng_tapnet_driver)) {
+        DEBUG("[wrong device descriptor]\n");
+        return -ENODEV;
+    }
+
+    switch (opt) {
+        case NETCONF_OPT_PROMISCUOUSMODE:
+            DEBUG("promiscous mode\n");
+            return _set_promiscousmode((ng_tapnet_t *)dev, value, value_len);
+
+        default:
+            DEBUG("[not supported: %d]\n", opt);
+            return -ENOTSUP;
+    }
+}
+
+/* individual event handlers called by _isr_event() */
+static void _rx_event(ng_tapnet_t *dev);
+
+static void _isr_event(ng_netdev_t *dev, uint32_t event_type)
+{
+    DEBUG("ng_tapnet: ISR event ");
+
+    if ((dev == NULL) || (dev->driver != &ng_tapnet_driver)) {
+        return;
+    }
+
+    switch (event_type) {
+        case _ISR_EVENT_RX:
+            DEBUG("[RX]\n");
+            _rx_event((ng_tapnet_t *)dev);
+            break;
+
+        default:
+            DEBUG("[unknown event_type]\n");
+            break;
+    }
+}
+
+/* internal implementations */
+#ifdef __MACH__
+static void _sigio_child(ng_tapnet_t *dev)
+{
+    pid_t parent = _native_pid;
+
+    if ((_sigio_child_pid = real_fork()) == -1) {
+        err(EXIT_FAILURE, "sigio_child: fork");
+    }
+
+    if (_sigio_child_pid > 0) {
+        /* return in parent process */
+        return;
+    }
+
+    /* watch tap interface and signal parent process if data is
+     * available */
+
+    fd_set rfds;
+
+    while (1) {
+        FD_ZERO(&rfds);
+        FD_SET(dev->tap_fd, &rfds);
+
+        if (real_select(dev->tap_fd + 1, &rfds, NULL, NULL, NULL) == 1) {
+            kill(parent, SIGIO);
+        }
+        else {
+            kill(parent, SIGKILL);
+            err(EXIT_FAILURE, "osx_sigio_child: select");
+        }
+
+        pause();
+    }
+}
+#endif
+
+static int _marshall_ethernet(ng_tapnet_t *dev, uint8_t *buffer, ng_pktsnip_t *pkt)
+{
+    int data_len = 0;
+    ng_ethernet_hdr_t *hdr = (ng_ethernet_hdr_t *)buffer;
+    ng_netif_hdr_t *netif_hdr;
+    ng_pktsnip_t *payload;
+
+    if (pkt == NULL) {
+        DEBUG("ng_tapnet: pkt was NULL");
+        return -EINVAL;
+    }
+
+    payload = pkt->next;
+
+    if (!_for_ethernet(pkt)) {
+        DEBUG("ng_tapnet: First header was not generic netif header for Ethernet\n");
+        return -EBADMSG;
+    }
+
+    hdr->type = byteorder_htons(ng_nettype_to_ethertype(pkt->next->type));
+
+    netif_hdr = pkt->data;
+
+    /* set ethernet header */
+    if (_has_src(pkt)) {
+        memcpy(hdr->dst, ng_netif_hdr_get_src_addr(netif_hdr),
+               netif_hdr->src_l2addr_len);
+    }
+    else {
+        memcpy(hdr->src, dev->addr, NG_ETHERNET_ADDR_LEN);
+    }
+
+    memcpy(hdr->dst, ng_netif_hdr_get_dst_addr(netif_hdr),
+           netif_hdr->dst_l2addr_len);
+    DEBUG("ng_tapnet: send to %02x:%02x:%02x:%02x:%02x:%02x\n",
+          hdr->dst[0], hdr->dst[1], hdr->dst[2],
+          hdr->dst[3], hdr->dst[4], hdr->dst[5]);
+
+    data_len += sizeof(ng_ethernet_hdr_t);
+
+    while (payload != NULL) {
+        if ((data_len + payload->size) > NG_ETHERNET_MAX_LEN) {
+            DEBUG("ng_tapnet: Packet too big for ethernet frame\n");
+            return -ENOBUFS;
+        }
+
+        memcpy(send_buffer + data_len, payload->data, payload->size);
+
+        data_len += payload->size;
+        payload = payload->next;
+    }
+
+    /* Pad to minimum payload size.
+     * Linux does this on its own, but it doesn't hurt to do it here.
+     * As of now only tuntaposx needs this. */
+    if (data_len < (NG_ETHERNET_MIN_LEN)) {
+        DEBUG("ng_tapnet: padding data! (%d -> ", data_len);
+        memset(send_buffer + data_len, 0, NG_ETHERNET_MIN_LEN - data_len);
+        data_len = NG_ETHERNET_MIN_LEN;
+        DEBUG("%d)\n", data_len);
+    }
+
+    return data_len;
+}
+
+void _trigger_isr_event(void)
+{
+    msg_t msg;
+
+    DEBUG("ng_tapnet: Trigger ISR event\n");
+
+    /* TODO: check whether this is an input or an output event
+       TODO: refactor this into general io-signal multiplexer */
+
+    msg.type = NG_NETDEV_MSG_TYPE_EVENT;
+    msg.content.value = _ISR_EVENT_RX;
+
+    msg_send(&msg, ng_tapnet.mac_pid);
+}
+
+static void _rx_event(ng_tapnet_t *dev)
+{
+    int nread = real_read(dev->tap_fd, recv_buffer, NG_ETHERNET_MAX_LEN);
+
+    DEBUG("ng_tapnet: read %d bytes\n", nread);
+
+    if (nread > 0) {
+        ng_ethernet_hdr_t *hdr = (ng_ethernet_hdr_t *)recv_buffer;
+        ng_pktsnip_t *netif_hdr, *pkt;
+        ng_nettype_t receive_type = NG_NETTYPE_UNDEF;
+        size_t data_len = (nread - sizeof(ng_ethernet_hdr_t));
+
+        if (!(dev->promiscous) && (memcmp(hdr->dst, dev->addr, NG_ETHERNET_ADDR_LEN) != 0) &&
+            (!_addr_broadcast(hdr->dst))) {
+            /* TODO: check multicast */
+            DEBUG("ng_tapnet: received for %02x:%02x:%02x:%02x:%02x:%02x\n"
+                  "That's not me => Dropped\n",
+                  hdr->dst[0], hdr->dst[1], hdr->dst[2],
+                  hdr->dst[3], hdr->dst[4], hdr->dst[5]);
+            return;
+        }
+
+        netif_hdr = ng_pktbuf_add(NULL, NULL, sizeof(ng_netif_hdr_t) + (2 * NG_ETHERNET_ADDR_LEN),
+                                  NG_NETTYPE_UNDEF);
+
+        if (netif_hdr == NULL) {
+            DEBUG("ng_tapnet: no space left in packet buffer\n");
+            return;
+        }
+
+        ng_netif_hdr_init(netif_hdr->data, NG_ETHERNET_ADDR_LEN, NG_ETHERNET_ADDR_LEN);
+        ng_netif_hdr_set_src_addr(netif_hdr->data, hdr->src, NG_ETHERNET_ADDR_LEN);
+        ng_netif_hdr_set_dst_addr(netif_hdr->data, hdr->dst, NG_ETHERNET_ADDR_LEN);
+        ((ng_netif_hdr_t *)netif_hdr->data)->if_pid = thread_getpid();
+
+        receive_type = ng_nettype_from_ethertype(byteorder_ntohs(hdr->type));
+
+        DEBUG("ng_tapnet: received packet from %02x:%02x:%02x:%02x:%02x:%02x "
+              "of length %zu\n",
+              hdr->src[0], hdr->src[1], hdr->src[2], hdr->src[3], hdr->src[4],
+              hdr->src[5], data_len);
+#if defined(MODULE_OD) && ENABLE_DEBUG
+        od_hex_dump(hdr, nread, OD_WIDTH_DEFAULT);
+#endif
+
+        /* Mark netif header and payload for next layer */
+        if ((pkt = ng_pktbuf_add(netif_hdr, recv_buffer + sizeof(ng_ethernet_hdr_t),
+                                 data_len, receive_type)) == NULL) {
+            ng_pktbuf_release(netif_hdr);
+            DEBUG("ng_tapnet: no space left in packet buffer\n");
+            return;
+        }
+
+        if (dev->event_cb != NULL) {
+            dev->event_cb(NETDEV_EVENT_RX_COMPLETE, pkt);
+        }
+        else {
+            ng_pktbuf_release(pkt); /* netif_hdr is released automatically too */
+        }
+
+        /* work around lost signals */
+        fd_set rfds;
+        struct timeval t;
+        memset(&t, 0, sizeof(t));
+        FD_ZERO(&rfds);
+        FD_SET(dev->tap_fd, &rfds);
+
+        _native_in_syscall++; // no switching here
+
+        if (real_select(dev->tap_fd + 1, &rfds, NULL, NULL, &t) == 1) {
+            int sig = SIGIO;
+            extern int _sig_pipefd[2];
+            extern ssize_t (*real_write)(int fd, const void * buf, size_t count);
+            real_write(_sig_pipefd[1], &sig, sizeof(int));
+            _native_sigpend++;
+            DEBUG("ng_tapnet: sigpend++\n");
+        }
+        else {
+            DEBUG("ng_tapnet: no more pending tap data\n");
+#ifdef __MACH__
+            kill(_sigio_child_pid, SIGCONT);
+#endif
+        }
+
+        _native_in_syscall--;
+    }
+    else if (nread == -1) {
+        if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
+            //warn("read");
+        }
+        else {
+            err(EXIT_FAILURE, "ng_tapnet: read");
+        }
+    }
+    else {
+        errx(EXIT_FAILURE, "internal error _rx_event");
+    }
+}
+
+/**
+ * @}
+ */

--- a/cpu/native/tapsetup.sh
+++ b/cpu/native/tapsetup.sh
@@ -30,13 +30,11 @@ if [ "${COMMAND}" = 'create' ]; then
 
     echo "creating ${BRNAME} ..."
     sudo brctl addbr ${BRNAME} || exit 1
-    sudo -s sh -c "echo 1  > /proc/sys/net/ipv6/conf/${BRNAME}/disable_ipv6" || exit 1
     sudo ip link set ${BRNAME} up || exit 1
 
     for N in $(seq 0 "$((COUNT - 1))"); do
         echo "creating ${TAPNAME}${N} ..."
         sudo ip tuntap add dev ${TAPNAME}${N} mode tap user ${USER} || exit 1
-        sudo -s sh -c "echo 1 > /proc/sys/net/ipv6/conf/${TAPNAME}${N}/disable_ipv6" || exit 1
         sudo brctl addif ${BRNAME} ${TAPNAME}${N} || exit 1
         sudo ip link set ${TAPNAME}${N} up || exit 1
     done

--- a/sys/include/net/ng_ethertype.h
+++ b/sys/include/net/ng_ethertype.h
@@ -35,6 +35,7 @@ extern "C" {
 #define NG_ETHERTYPE_IPV4       (0x0800)    /**< Internet protocol version 4 */
 #define NG_ETHERTYPE_ARP        (0x0806)    /**< Address resolution protocol */
 #define NG_ETHERTYPE_IPV6       (0x86dd)    /**< Internet protocol version 6 */
+#define NG_ETHERTYPE_RAW        (0xffff)    /**< Raw ethernet frame */
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/ng_netif/hdr.h
+++ b/sys/include/net/ng_netif/hdr.h
@@ -33,6 +33,37 @@ extern "C" {
 #endif
 
 /**
+ * @{
+ * @name    Flags for the ng_netif_hdr_t
+ */
+/**
+ * @brief   Send packet broadcast.
+ *
+ * @details Packets with this flag set must be send broadcast.
+ *          ng_netif_hdr_t::dst_l2addr_len and any appended destination
+ *          address must be ignored.
+ *          If the link layer does not support broadcast the packet must be
+ *          dropped silently.
+ */
+#define NG_NETIF_HDR_FLAGS_BROADCAST    (0x80)
+
+/**
+ * @brief   Send packet multicast.
+ *
+ * @details Packets with this flag set must be send multicast.
+ *          ng_netif_hdr_t::dst_l2addr_len and any appended destination
+ *          address must be ignored.
+ *          The context for the multicast address must be derived from the
+ *          network layer destination address.
+ *          If the link layer does not support multicast it should interpret
+ *          this flag the same way it does @ref NG_NETIF_HDR_FLAGS_BROADCAST.
+ */
+#define NG_NETIF_HDR_FLAGS_MULTICAST    (0x40)
+/**
+ * @}
+ */
+
+/**
  * @brief   Generic network interface header
  *
  * The link layer addresses included in this header are put in memory directly
@@ -42,6 +73,7 @@ typedef struct __attribute__((packed)) {
     uint8_t src_l2addr_len;     /**< length of l2 source address in byte */
     uint8_t dst_l2addr_len;     /**< length of l2 destination address in byte */
     kernel_pid_t if_pid;        /**< PID of network interface */
+    uint8_t flags;              /**< flags as defined above */
     uint8_t rssi;               /**< rssi of received packet (optional) */
     uint8_t lqi;                /**< lqi of received packet (optional) */
 } ng_netif_hdr_t;
@@ -61,6 +93,7 @@ static inline void ng_netif_hdr_init(ng_netif_hdr_t *hdr, uint8_t src_l2addr_len
     hdr->if_pid = KERNEL_PID_UNDEF;
     hdr->rssi = 0;
     hdr->lqi = 0;
+    hdr->flags = 0;
 }
 
 /**

--- a/sys/include/net/ng_nettype.h
+++ b/sys/include/net/ng_nettype.h
@@ -103,9 +103,11 @@ static inline ng_nettype_t ng_nettype_from_ethertype(uint16_t type)
 {
     switch (type) {
 #ifdef MODULE_NG_IPV6
+
         case NG_ETHERTYPE_IPV6:
             return NG_NETTYPE_IPV6;
 #endif
+
         default:
             return NG_NETTYPE_UNDEF;
     }
@@ -126,9 +128,11 @@ static inline uint16_t ng_nettype_to_ethertype(ng_nettype_t type)
 {
     switch (type) {
 #ifdef MODULE_NG_IPV6
+
         case NG_NETTYPE_IPV6:
             return NG_ETHERTYPE_IPV6;
 #endif
+
         default:
             return NG_ETHERTYPE_RAW;
     }
@@ -149,21 +153,26 @@ static inline ng_nettype_t ng_nettype_from_protnum(uint8_t num)
 {
     switch (num) {
 #ifdef MODULE_NG_ICMPV6
+
         case NG_PROTNUM_ICMPV6:
             return NG_NETTYPE_ICMPV6;
 #endif
 #ifdef MODULE_NG_IPV6
+
         case NG_PROTNUM_IPV6:
             return NG_NETTYPE_IPV6;
 #endif
 #ifdef MODULE_NG_TCP
+
         case NG_PROTNUM_TCP:
             return NG_NETTYPE_TCP;
 #endif
 #ifdef MODULE_NG_UDP
+
         case NG_PROTNUM_UDP:
             return NG_NETTYPE_UDP;
 #endif
+
         default:
             return NG_NETTYPE_UNDEF;
     }
@@ -184,21 +193,26 @@ static inline uint8_t ng_nettype_to_protnum(ng_nettype_t type)
 {
     switch (type) {
 #ifdef MODULE_NG_ICMPV6
+
         case NG_NETTYPE_ICMPV6:
             return NG_PROTNUM_ICMPV6;
 #endif
 #ifdef MODULE_NG_IPV6
+
         case NG_NETTYPE_IPV6:
             return NG_PROTNUM_IPV6;
 #endif
 #ifdef MODULE_NG_TCP
+
         case NG_NETTYPE_TCP:
             return NG_PROTNUM_TCP;
 #endif
 #ifdef MODULE_NG_UDP
+
         case NG_NETTYPE_UDP:
             return NG_PROTNUM_UDP;
 #endif
+
         default:
             return NG_PROTNUM_RESERVED;
     }

--- a/sys/include/net/ng_nettype.h
+++ b/sys/include/net/ng_nettype.h
@@ -130,7 +130,7 @@ static inline uint16_t ng_nettype_to_ethertype(ng_nettype_t type)
             return NG_ETHERTYPE_IPV6;
 #endif
         default:
-            return NG_ETHERTYPE_RESERVED;
+            return NG_ETHERTYPE_RAW;
     }
 }
 

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -296,10 +296,10 @@ int _netif_send(int argc, char **argv)
     size_t addr_len;
     ng_pktsnip_t *pkt;
     ng_netif_hdr_t *nethdr;
-
+    uint8_t flags = 0x00;
 
     if (argc < 4) {
-        printf("usage: %s <if> <addr> <data>\n", argv[0]);
+        printf("usage: %s <if> [<addr>|bcast] <data>\n", argv[0]);
         return 1;
     }
 
@@ -315,8 +315,13 @@ int _netif_send(int argc, char **argv)
     addr_len = ng_netif_addr_from_str(addr, sizeof(addr), argv[2]);
 
     if (addr_len == 0) {
-        puts("error: invalid address given");
-        return 1;
+        if (strcmp(argv[2], "bcast") == 0) {
+            flags |= NG_NETIF_HDR_FLAGS_BROADCAST;
+        }
+        else {
+            puts("error: invalid address given");
+            return 1;
+        }
     }
 
     /* put packet together */
@@ -326,6 +331,7 @@ int _netif_send(int argc, char **argv)
     nethdr = (ng_netif_hdr_t *)pkt->data;
     ng_netif_hdr_init(nethdr, 0, addr_len);
     ng_netif_hdr_set_dst_addr(nethdr, addr, addr_len);
+    nethdr->flags = flags;
     /* and send it */
     ng_netapi_send(dev, pkt);
 

--- a/tests/driver_tapnet/Makefile
+++ b/tests/driver_tapnet/Makefile
@@ -1,0 +1,13 @@
+APPLICATION = driver_tapnet
+include ../Makefile.tests_common
+
+BOARD_WHITELIST := native
+
+USEMODULE += ng_netbase
+USEMODULE += ng_nomac
+USEMODULE += ng_pktdump
+USEMODULE += ng_tapnet
+USEMODULE += shell
+USEMODULE += shell_commands
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_tapnet/main.c
+++ b/tests/driver_tapnet/main.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for ng_tapnet network device driver
+ *
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "board.h"
+#include "kernel.h"
+#include "shell.h"
+#include "shell_commands.h"
+#include "ng_tapnet.h"
+#include "net/ng_netbase.h"
+#include "net/ng_nomac.h"
+#include "net/ng_pktdump.h"
+
+/**
+ * @brief   Buffer size used by the shell
+ */
+#define SHELL_BUFSIZE           (64U)
+
+/**
+ * @brief   Stack for the nomac thread
+ */
+static char nomac_stack[KERNEL_CONF_STACKSIZE_DEFAULT];
+
+/**
+ * @brief   Stack for the pktdump thread
+ */
+static char dump_stack[KERNEL_CONF_STACKSIZE_MAIN];
+
+/**
+ * @brief   Read chars from STDIO
+ */
+int shell_read(void)
+{
+    return (int)getchar();
+}
+
+/**
+ * @brief   Write chars to STDIO
+ */
+void shell_put(int c)
+{
+    putchar((char)c);
+}
+
+/**
+ * @brief   Maybe you are a golfer?!
+ */
+int main(void)
+{
+    int res;
+    shell_t shell;
+    ng_netreg_entry_t dump;
+
+    puts("tapnet device driver test");
+    printf("Initializing tapnet... \n");
+
+    /* initialize network module(s) */
+    ng_netif_init();
+
+    /* initialize and register pktdump */
+    dump.pid = ng_pktdump_init(dump_stack, sizeof(dump_stack), PRIORITY_MAIN - 2,
+                               "dump");
+    dump.demux_ctx = NG_NETREG_DEMUX_CTX_ALL;
+
+    if (dump.pid <= KERNEL_PID_UNDEF) {
+        puts("Error starting pktdump thread");
+        return -1;
+    }
+
+    ng_netreg_register(NG_NETTYPE_UNDEF, &dump);
+
+    /* ng_tapnet is initialized on native start-up */
+    /* start MAC layer */
+    res = ng_nomac_init(nomac_stack, sizeof(nomac_stack), PRIORITY_MAIN - 3,
+                        "tapnet_l2", (ng_netdev_t *)&ng_tapnet);
+
+    if (res < 0) {
+        puts("Error starting nomac thread");
+        return -1;
+    }
+    /* start the shell */
+    shell_init(&shell, NULL, SHELL_BUFSIZE, shell_read, shell_put);
+    shell_run(&shell);
+
+    return 0;
+}

--- a/tests/driver_tapnet/main.c
+++ b/tests/driver_tapnet/main.c
@@ -40,11 +40,6 @@
 static char nomac_stack[KERNEL_CONF_STACKSIZE_DEFAULT];
 
 /**
- * @brief   Stack for the pktdump thread
- */
-static char dump_stack[KERNEL_CONF_STACKSIZE_MAIN];
-
-/**
  * @brief   Read chars from STDIO
  */
 int shell_read(void)
@@ -76,8 +71,7 @@ int main(void)
     ng_netif_init();
 
     /* initialize and register pktdump */
-    dump.pid = ng_pktdump_init(dump_stack, sizeof(dump_stack), PRIORITY_MAIN - 2,
-                               "dump");
+    dump.pid = ng_pktdump_init();
     dump.demux_ctx = NG_NETREG_DEMUX_CTX_ALL;
 
     if (dump.pid <= KERNEL_PID_UNDEF) {
@@ -96,6 +90,7 @@ int main(void)
         puts("Error starting nomac thread");
         return -1;
     }
+
     /* start the shell */
     shell_init(&shell, NULL, SHELL_BUFSIZE, shell_read, shell_put);
     shell_run(&shell);


### PR DESCRIPTION
This introduces `ng_tapnet` which is basically `nativenet` without all the RIOT-proprietary headers (so pure Ethernet frames) but with full ng_netdev support.

~~Depends on #2661~~ (merged).
~~Depends on #2706~~ (merged).
Depends on #2600 for multicast.

Open issues:
- [ ] No messages are delivered