### PR TITLE
ng_pktbuf: change semantics for received packets

### DIFF
--- a/sys/net/crosslayer/ng_pktbuf/ng_pktbuf.c
+++ b/sys/net/crosslayer/ng_pktbuf/ng_pktbuf.c
@@ -67,18 +67,34 @@ int ng_pktbuf_realloc_data(ng_pktsnip_t *pkt, size_t size)
     return 0;
 }
 
-ng_pktsnip_t *ng_pktbuf_add(ng_pktsnip_t *next, void *data, size_t size,
+ng_pktsnip_t *ng_pktbuf_add(ng_pktsnip_t *pkt, void *data, size_t size,
                             ng_nettype_t type)
 {
-    ng_pktsnip_t *snip;
+    ng_pktsnip_t *new_pktsnip;
 
     mutex_lock(&_pktbuf_mutex);
 
-    snip = _pktbuf_add_unsafe(next, data, size, type);
+    new_pktsnip = _pktbuf_add_unsafe(pkt, data, size, type);
 
     mutex_unlock(&_pktbuf_mutex);
 
-    return snip;
+    return new_pktsnip;
+}
+
+void ng_pktbuf_hold(ng_pktsnip_t *pkt, unsigned int num)
+{
+    if ((pkt == NULL) || (num == 0)) {
+        return;
+    }
+
+    mutex_lock(&_pktbuf_mutex);
+
+    while (pkt != NULL) {
+        pkt->users += num;
+        pkt = pkt->next;
+    }
+
+    mutex_unlock(&_pktbuf_mutex);
 }
 
 void ng_pktbuf_release(ng_pktsnip_t *pkt)
@@ -87,16 +103,27 @@ void ng_pktbuf_release(ng_pktsnip_t *pkt)
         return;
     }
 
-    atomic_set_return(&(pkt->users), pkt->users - 1);
+    mutex_lock(&_pktbuf_mutex);
 
-    if (pkt->users == 0 && _pktbuf_internal_contains(pkt->data)) {
-        mutex_lock(&_pktbuf_mutex);
+    while (pkt != NULL) {
+        if (pkt->users > 0) {   /* Don't accidentally overshoot */
+            pkt->users--;
+        }
 
-        _pktbuf_internal_free(pkt->data);
-        _pktbuf_internal_free(pkt);
+        if (pkt->users == 0) {
+            if (_pktbuf_internal_contains(pkt->data)) {
+                _pktbuf_internal_free(pkt->data);
+            }
 
-        mutex_unlock(&_pktbuf_mutex);
+            if (_pktbuf_internal_contains(pkt)) {
+                _pktbuf_internal_free(pkt);
+            }
+        }
+
+        pkt = pkt->next;
     }
+
+    mutex_unlock(&_pktbuf_mutex);
 }
 
 ng_pktsnip_t *ng_pktbuf_start_write(ng_pktsnip_t *pkt)
@@ -147,60 +174,70 @@ static ng_pktsnip_t *_pktbuf_alloc(size_t size)
     return pkt;
 }
 
-static ng_pktsnip_t *_pktbuf_add_unsafe(ng_pktsnip_t *next, void *data,
+static ng_pktsnip_t *_pktbuf_add_unsafe(ng_pktsnip_t *pkt, void *data,
                                         size_t size, ng_nettype_t type)
 {
-    ng_pktsnip_t *snip;
+    ng_pktsnip_t *new_pktsnip;
 
-    if (size == 0) {
-        data = 0;
-    }
+    new_pktsnip = (ng_pktsnip_t *)_pktbuf_internal_alloc(sizeof(ng_pktsnip_t));
 
-    snip = (ng_pktsnip_t *)_pktbuf_internal_alloc(sizeof(ng_pktsnip_t));
-
-    if (snip == NULL) {
+    if (new_pktsnip == NULL) {
         return NULL;
     }
 
-    if (next == NULL || next->data != data) {
-        if (size != 0) {
-            snip->data = _pktbuf_internal_alloc(size);
+    if (pkt == NULL || pkt->data != data) {
+        if ((size != 0) && (!_pktbuf_internal_contains(data))) {
+            new_pktsnip->data = _pktbuf_internal_alloc(size);
 
-            if (snip->data == NULL) {
-                _pktbuf_internal_free(snip);
+            if (new_pktsnip->data == NULL) {
+                _pktbuf_internal_free(new_pktsnip);
 
                 return NULL;
             }
 
             if (data != NULL) {
-                memcpy(snip->data, data, size);
+                memcpy(new_pktsnip->data, data, size);
             }
         }
         else {
-            snip->data = data;
+            if (_pktbuf_internal_contains(data)) {
+                if (!_pktbuf_internal_add_pkt(new_pktsnip->data)) {
+                    _pktbuf_internal_free(new_pktsnip);
+
+                    return NULL;
+                }
+            }
+
+            new_pktsnip->data = data;
         }
+
+        new_pktsnip->next = NULL;
+        LL_PREPEND(pkt, new_pktsnip);
     }
     else {
-        snip->data = data;
+        if (size > pkt->size) {
+            return NULL;
+        }
 
-        next->size -= size;
-        next->data = (void *)(((uint8_t *)next->data) + size);
+        new_pktsnip->next = pkt->next;
+        new_pktsnip->data = data;
 
-        if (!_pktbuf_internal_add_pkt(next->data)) {
-            _pktbuf_internal_free(snip);
+        pkt->next = new_pktsnip;
+        pkt->size -= size;
+        pkt->data = (void *)(((uint8_t *)pkt->data) + size);
+
+        if (!_pktbuf_internal_add_pkt(pkt->data)) {
+            _pktbuf_internal_free(new_pktsnip);
 
             return NULL;
         }
     }
 
-    snip->next = NULL;
-    snip->size = size;
-    snip->type = type;
-    snip->users = 1;
+    new_pktsnip->size = size;
+    new_pktsnip->type = type;
+    new_pktsnip->users = 1;
 
-    LL_PREPEND(next, snip);
-
-    return snip;
+    return new_pktsnip;
 }
 
 static ng_pktsnip_t *_pktbuf_duplicate(const ng_pktsnip_t *pkt)
@@ -217,12 +254,12 @@ static ng_pktsnip_t *_pktbuf_duplicate(const ng_pktsnip_t *pkt)
     res->type = pkt->type;
 
     while (pkt->next) {
-        ng_pktsnip_t *header = NULL;
+        ng_pktsnip_t *hdr = NULL;
 
         pkt = pkt->next;
-        header = _pktbuf_add_unsafe(res, pkt->data, pkt->size, pkt->type);
+        hdr = _pktbuf_add_unsafe(res, pkt->data, pkt->size, pkt->type);
 
-        if (header == NULL) {
+        if (hdr == NULL) {
             do {
                 ng_pktsnip_t *next = res->next;
 

--- a/tests/unittests/tests-pktbuf/tests-pktbuf.c
+++ b/tests/unittests/tests-pktbuf/tests-pktbuf.c
@@ -191,7 +191,7 @@ static void test_pktbuf_add__in_place(void)
     ng_pktsnip_t *header;
 
     TEST_ASSERT_NOT_NULL((header = ng_pktbuf_add(pkt, pkt->data, 4, NG_NETTYPE_UNDEF)));
-    TEST_ASSERT(header->next == pkt);
+    TEST_ASSERT(header == pkt->next);
     TEST_ASSERT_EQUAL_STRING(TEST_STRING16, header->data); /* there is no 0 byte */
     TEST_ASSERT_EQUAL_INT(4, header->size);
     TEST_ASSERT_EQUAL_INT(NG_NETTYPE_UNDEF, header->type);
@@ -312,8 +312,8 @@ static void test_pktbuf_realloc_data__pkt_users_gt_1(void)
 static void test_pktbuf_realloc_data__pkt_next_neq_NULL(void)
 {
     ng_pktsnip_t *pkt = ng_pktbuf_add(NULL, NULL, sizeof(TEST_STRING8), NG_NETTYPE_UNDEF);
-    pkt->next = pkt;
 
+    TEST_ASSERT_NOT_NULL(ng_pktbuf_add(pkt, pkt->data, sizeof(TEST_STRING4), NG_NETTYPE_UNDEF));
     TEST_ASSERT_EQUAL_INT(EINVAL, ng_pktbuf_realloc_data(pkt, sizeof(TEST_STRING8) - 1));
     ng_pktbuf_release(pkt);
     TEST_ASSERT(ng_pktbuf_is_empty());
@@ -458,31 +458,32 @@ static void test_pktbuf_realloc_data__success2(void)
 
 static void test_pktbuf_realloc_data__further_down_the_line(void)
 {
-    ng_pktsnip_t *pkt, *header;
+    ng_pktsnip_t *pkt1, *pkt2, *header;
     void *exp_data;
 
-    pkt = ng_pktbuf_add(NULL, TEST_STRING16, sizeof(TEST_STRING16), NG_NETTYPE_UNDEF);
-    exp_data = pkt->data;
+    pkt1 = ng_pktbuf_add(NULL, TEST_STRING16, sizeof(TEST_STRING16), NG_NETTYPE_UNDEF);
+    exp_data = pkt1->data;
 
-    TEST_ASSERT_NOT_NULL(pkt);
+    TEST_ASSERT_NOT_NULL(pkt1);
 
-    header = ng_pktbuf_add(pkt, pkt->data, 4, NG_NETTYPE_UNDEF);
+    header = ng_pktbuf_add(pkt1, pkt1->data, 4, NG_NETTYPE_UNDEF);
+    pkt2 = ng_pktbuf_add(NULL, TEST_STRING16, sizeof(TEST_STRING16), NG_NETTYPE_UNDEF);
 
     TEST_ASSERT_NOT_NULL(header);
-    TEST_ASSERT(header->next == pkt);
+    TEST_ASSERT(header == pkt1->next);
     TEST_ASSERT_EQUAL_INT(4, header->size);
-    TEST_ASSERT(((uint8_t *)pkt->data) == (((uint8_t *)header->data) + 4));
-    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING16) - 4, pkt->size);
+    TEST_ASSERT(((uint8_t *)pkt1->data) == (((uint8_t *)header->data) + 4));
+    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING16) - 4, pkt1->size);
 
-    TEST_ASSERT_EQUAL_INT(0, ng_pktbuf_realloc_data(pkt, 20));
-    TEST_ASSERT(exp_data != pkt->data);
-    TEST_ASSERT_NULL(pkt->next);
-    TEST_ASSERT_EQUAL_STRING(TEST_STRING16 + 4, pkt->data);
-    TEST_ASSERT_EQUAL_INT(20, pkt->size);
-    TEST_ASSERT_EQUAL_INT(NG_NETTYPE_UNDEF, pkt->type);
-    TEST_ASSERT_EQUAL_INT(1, pkt->users);
-    ng_pktbuf_release(pkt);
-    ng_pktbuf_release(header);
+    TEST_ASSERT_EQUAL_INT(0, ng_pktbuf_realloc_data(header, 40));
+    TEST_ASSERT(exp_data != header->data);
+    TEST_ASSERT_NULL(header->next);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING16, header->data);
+    TEST_ASSERT_EQUAL_INT(40, header->size);
+    TEST_ASSERT_EQUAL_INT(NG_NETTYPE_UNDEF, header->type);
+    TEST_ASSERT_EQUAL_INT(1, header->users);
+    ng_pktbuf_release(pkt1);
+    ng_pktbuf_release(pkt2);
     TEST_ASSERT(ng_pktbuf_is_empty());
 }
 

--- a/tests/unittests/tests-pktbuf/tests-pktbuf.c
+++ b/tests/unittests/tests-pktbuf/tests-pktbuf.c
@@ -95,7 +95,7 @@ static void test_pktbuf_add__pkt_NULL__data_NOT_NULL__size_0(void)
     TEST_ASSERT_NOT_NULL((pkt = ng_pktbuf_add(NULL, TEST_STRING8, 0, NG_NETTYPE_UNDEF)));
 
     TEST_ASSERT_NULL(pkt->next);
-    TEST_ASSERT_NULL(pkt->data);
+    TEST_ASSERT_NOT_NULL(pkt->data);
     TEST_ASSERT_EQUAL_INT(0, pkt->size);
     TEST_ASSERT_EQUAL_INT(NG_NETTYPE_UNDEF, pkt->type);
 
@@ -112,7 +112,7 @@ static void test_pktbuf_add__pkt_NOT_NULL__data_NOT_NULL__size_0(void)
     TEST_ASSERT_NOT_NULL((pkt = ng_pktbuf_add(next, TEST_STRING8, 0, NG_NETTYPE_UNDEF)));
 
     TEST_ASSERT(pkt->next == next);
-    TEST_ASSERT_NULL(pkt->data);
+    TEST_ASSERT_NOT_NULL(pkt->data);
     TEST_ASSERT_EQUAL_INT(0, pkt->size);
     TEST_ASSERT_EQUAL_INT(NG_NETTYPE_UNDEF, pkt->type);
 


### PR DESCRIPTION
Sending packets remain in the same order, receiving packets are reversed. This way we save memory on `ng_pktbuf_start_write()`, since only the parts of the packets of interest for later layers in the line are duplicated:

Some extreme examples below (`next` pointer always points up). Normally, with sending this would only apply for `netif` headers in multicast and L3 in some corner cases. For receiving this can only happen if there are sniffers or dual stacks involved.

```
Sending                          Receiving
=======                          =========

* Payload                        * netif header
|\                               |\
| * L4 header 1                  | * L2.5 header 1
| * L3 header 1                  | * L3 header 1 
| * netif header 1               | * L4 header 1
*   L4 header 2                  | * Payload 1
|\                               *   L3 header 2
| * Network header 2             |\
| * netif header 2               | * L4 header 2
*   Network header 3             | * Payload 2
|\                               *   Payload 3
| * netif header 3
*   netif header 4
```