### PR TITLE
Fixing warnings after running static code analyser.

### DIFF
--- a/cpu/x86/x86_memory.c
+++ b/cpu/x86/x86_memory.c
@@ -371,13 +371,13 @@ static void pagefault_handler(uint8_t intr_num, struct x86_pushad *orig_ctx, uns
     }
 #endif
     else if (error_code & PF_EC_P) {
-        printf("Page fault: access violation while %s present page.\n", error_code & PF_EC_W ? "writing to" : "reading from");
+        printf("Page fault: access violation while %s present page.\n", (error_code & PF_EC_W) ? "writing to" : "reading from");
         x86_print_registers(orig_ctx, error_code);
         puts("Halting.");
         x86_hlt();
     }
     else {
-        printf("Page fault: access violation while %s non-present page.\n", error_code & PF_EC_W ? "writing to" : "reading from");
+        printf("Page fault: access violation while %s non-present page.\n", (error_code & PF_EC_W) ? "writing to" : "reading from");
         x86_print_registers(orig_ctx, error_code);
         puts("Halting.");
         x86_hlt();

--- a/cpu/x86/x86_pci.c
+++ b/cpu/x86/x86_pci.c
@@ -149,7 +149,7 @@ static void pci_setup_ios(struct x86_known_pci_device *dev)
         io->bar_num = bar_num;
         ++dev->io_count;
 
-        unsigned addr_offs = tmp_bar & PCI_BAR_IO_SPACE ? PCI_BAR_ADDR_OFFS_IO : PCI_BAR_ADDR_OFFS_MEM;
+        unsigned addr_offs = (tmp_bar & PCI_BAR_IO_SPACE) ? PCI_BAR_ADDR_OFFS_IO : PCI_BAR_ADDR_OFFS_MEM;
         uint32_t length_tmp = tmp_bar >> addr_offs;
         uint32_t length = 1 << addr_offs;
         while ((length_tmp & 1) == 0) {

--- a/cpu/x86/x86_rtc.c
+++ b/cpu/x86/x86_rtc.c
@@ -98,10 +98,10 @@ static void rtc_irq_handler(uint8_t irq_num)
     (void) irq_num; /* == PIC_NUM_RTC */
 
     uint8_t c = x86_cmos_read(RTC_REG_C);
-    DEBUG("RTC: c = 0x%02x, IRQ=%u, A=%u, P=%u, U=%u\n", c, c & RTC_REG_C_IRQ ? 1 : 0,
-                                                            c & RTC_REG_C_IRQ_ALARM ? 1 : 0,
-                                                            c & RTC_REG_C_IRQ_PERIODIC ? 1 : 0,
-                                                            c & RTC_REG_C_IRQ_UPDATE ? 1 : 0);
+    DEBUG("RTC: c = 0x%02x, IRQ=%u, A=%u, P=%u, U=%u\n", c, (c & RTC_REG_C_IRQ) ? 1 : 0,
+                                                            (c & RTC_REG_C_IRQ_ALARM) ? 1 : 0,
+                                                            (c & RTC_REG_C_IRQ_PERIODIC) ? 1 : 0,
+                                                            (c & RTC_REG_C_IRQ_UPDATE) ? 1 : 0);
     if (!(c & RTC_REG_C_IRQ)) {
         return;
     }

--- a/sys/cbor/cbor.c
+++ b/sys/cbor/cbor.c
@@ -157,7 +157,7 @@ double decode_float_half(unsigned char *halfp)
         val = mant == 0 ? INFINITY : NAN;
     }
 
-    return half & 0x8000 ? -val : val;
+    return (half & 0x8000) ? -val : val;
 }
 
 /**


### PR DESCRIPTION
-Changes to fix all the clarifyCalculation warnings.
-Fixes a part of #480