### PR TITLE
ng_netreg: Allow registration of NG_NETTYPE_UNDEF

### DIFF
--- a/sys/net/crosslayer/ng_netreg/ng_netreg.c
+++ b/sys/net/crosslayer/ng_netreg/ng_netreg.c
@@ -20,10 +20,10 @@
 #include "net/ng_nettype.h"
 #include "utlist.h"
 
-#define _INVALID_TYPE(type) (((type) <= NG_NETTYPE_UNDEF) || ((type) >= NG_NETTYPE_NUMOF))
+#define _INVALID_TYPE(type) (((type) < NG_NETTYPE_UNDEF) || ((type) >= NG_NETTYPE_NUMOF))
 
 /* The registry as lookup table by ng_nettype_t */
-static ng_netreg_entry_t *netreg[NG_NETTYPE_NUMOF - 1]; /* leave out NG_NETTYPE_UNDEF */
+static ng_netreg_entry_t *netreg[NG_NETTYPE_NUMOF];
 
 void ng_netreg_init(void)
 {
@@ -37,7 +37,7 @@ int ng_netreg_register(ng_nettype_t type, ng_netreg_entry_t *entry)
         return -EINVAL;
     }
 
-    LL_PREPEND(netreg[type - 1], entry);
+    LL_PREPEND(netreg[type], entry);
 
     return 0;
 }
@@ -48,7 +48,7 @@ void ng_netreg_unregister(ng_nettype_t type, ng_netreg_entry_t *entry)
         return;
     }
 
-    LL_DELETE(netreg[type - 1], entry);
+    LL_DELETE(netreg[type], entry);
 }
 
 ng_netreg_entry_t *ng_netreg_lookup(ng_nettype_t type, uint32_t demux_ctx)
@@ -59,7 +59,7 @@ ng_netreg_entry_t *ng_netreg_lookup(ng_nettype_t type, uint32_t demux_ctx)
         return NULL;
     }
 
-    LL_SEARCH_SCALAR(netreg[type - 1], res, demux_ctx, demux_ctx);
+    LL_SEARCH_SCALAR(netreg[type], res, demux_ctx, demux_ctx);
 
     return res;
 }
@@ -73,7 +73,7 @@ int ng_netreg_num(ng_nettype_t type, uint32_t demux_ctx)
         return 0;
     }
 
-    entry = netreg[type - 1];
+    entry = netreg[type];
 
     while (entry != NULL) {
         if (entry->demux_ctx == demux_ctx) {

--- a/tests/unittests/tests-netreg/tests-netreg.c
+++ b/tests/unittests/tests-netreg/tests-netreg.c
@@ -25,13 +25,6 @@ static void set_up(void)
     ng_netreg_init();
 }
 
-static void test_netreg_register__inval_undef(void)
-{
-    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
-
-    TEST_ASSERT_EQUAL_INT(-EINVAL, ng_netreg_register(NG_NETTYPE_UNDEF, &entry));
-}
-
 static void test_netreg_register__inval_numof(void)
 {
     ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
@@ -159,7 +152,6 @@ void test_netreg_getnext__2_entries(void)
 Test *tests_netreg_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
-        new_TestFixture(test_netreg_register__inval_undef),
         new_TestFixture(test_netreg_register__inval_numof),
         new_TestFixture(test_netreg_register__success),
         new_TestFixture(test_netreg_unregister__success),


### PR DESCRIPTION
This is an alternative to #2564.

I think it makes sense to allow registration to `NG_NETTYPE_UNDEF`, e. g. to receive packets from radio drivers that don't have an Ethertype-like field in their header. Or just for someone to receive the packet.