### PR TITLE
rpl: Send DAOs for adding /128 routes (host-only) to the parent instead of /16

### DIFF
--- a/sys/net/include/rpl/rpl_config.h
+++ b/sys/net/include/rpl/rpl_config.h
@@ -133,7 +133,7 @@ static inline bool RPL_COUNTER_GREATER_THAN(uint8_t A, uint8_t B)
 #define REGULAR_DAO_INTERVAL 300
 #define DAO_SEND_RETRIES 4
 #define DEFAULT_WAIT_FOR_DAO_ACK 15
-#define RPL_DODAG_ID_LEN 16
+#define RPL_DODAG_ID_LEN 128
 
 /* others */
 


### PR DESCRIPTION
References #2569 

This change makes the RPL implementation send the node's full IPv6 address (/128) as a RPL target to the RPL parent instead of sending only a /16 network. When the parent receives this information it should add a route to this address via the host's link-local address to its routing table.