### PR TITLE
cpu/msp430-common: removed e|dINT calls

### DIFF
--- a/cpu/msp430-common/cpu.c
+++ b/cpu/msp430-common/cpu.c
@@ -14,10 +14,6 @@
 #include "sched.h"
 #include "thread.h"
 
-volatile int __inISR = 0;
-
-char __isr_stack[MSP430_ISR_STACK_SIZE];
-
 /*
  * we must prevent the compiler to generate a prologue or an epilogue
  * for thread_yield_higher(), since we rely on the RETI instruction at the end
@@ -95,11 +91,6 @@ char *thread_stack_init(thread_task_func_t task_func, void *arg, void *stack_sta
     }
 
     return (char *) stackptr;
-}
-
-int inISR(void)
-{
-    return __inISR;
 }
 
 /******************************************************************************/

--- a/cpu/msp430-common/include/cpu.h
+++ b/cpu/msp430-common/include/cpu.h
@@ -51,6 +51,13 @@ extern volatile int __inISR;
 extern char __isr_stack[MSP430_ISR_STACK_SIZE];
 
 /**
+ * @brief   definition of legacy interrupt control functions
+ */
+#define eINT            enableIRQ
+#define dINT            disableIRQ
+/** @} */
+
+/**
  * @brief   Save the current thread context from inside an ISR
  */
 inline void __save_context_isr(void)
@@ -149,40 +156,6 @@ inline void __restore_context(unsigned int irqen)
 
     __asm__("reti");
 }
-
-/**
- * @brief   Enable interrupts
- */
-inline void eINT(void)
-{
-    /*    puts("+"); */
-/*    eint();   // problem with MSPGCC intrinsics? */
-    __asm__ __volatile__("bis  %0, r2" : : "i"(GIE));
-    __asm__ __volatile__("nop");
-       /* this NOP is needed to handle a "delay slot" that all MSP430 MCUs
-          impose silently after messing with the GIE bit, DO NOT REMOVE IT! */
-}
-
-/**
- * @brief   Disable interrupts
- */
-inline void dINT(void)
-{
-    /*    puts("-"); */
-/*    dint();   // problem with MSPGCC intrinsics? */
-    __asm__ __volatile__("bic  %0, r2" : : "i"(GIE));
-    __asm__ __volatile__("nop");
-       /* this NOP is needed to handle a "delay slot" that all MSP430 MCUs
-          impose silently after messing with the GIE bit, DO NOT REMOVE IT! */
-}
-
-/**
- * @brief   Check if currently inside an interrupt routine
- *
- * @return  0 if not in interrupt context
- * @return  1 if in interrupt context
- */
-int inISR(void);
 
 /**
  * @brief   Initialize the cpu


### PR DESCRIPTION
One further small step towards removal of the legacy [e|d]INT calls...