### PR TITLE
Reducing the scope of variable after running static code analyser.

### DIFF
--- a/drivers/cc110x/cc110x-rxtx.c
+++ b/drivers/cc110x/cc110x-rxtx.c
@@ -122,16 +122,18 @@ void cc110x_rx_handler(void *args)
 static uint8_t receive_packet_variable(uint8_t *rxBuffer, radio_packet_length_t length)
 {
     uint8_t status[2];
-    uint8_t packetLength = 0;
-    uint8_t crc_ok = 0;
 
     /* Any bytes available in RX FIFO? */
     if ((cc110x_read_status(CC1100_RXBYTES) & BYTES_IN_RXFIFO)) {
+        uint8_t packetLength = 0;
+
         /* Read length byte (first byte in RX FIFO) */
         packetLength = cc110x_read_reg(CC1100_RXFIFO);
 
         /* Read data from RX FIFO and store in rxBuffer */
         if (packetLength <= length) {
+	     uint8_t crc_ok = 0;
+
             /* Put length byte at first position in RX Buffer */
             rxBuffer[0] = packetLength;
 

--- a/drivers/lis3dh/lis3dh.c
+++ b/drivers/lis3dh/lis3dh.c
@@ -64,7 +64,6 @@ int lis3dh_init(lis3dh_t *dev, spi_t spi, gpio_t cs_pin, gpio_t int1_pin, gpio_t
 
 int lis3dh_read_xyz(const lis3dh_t *dev, lis3dh_data_t *acc_data)
 {
-    int32_t tmp;
     uint8_t i;
     /* Set READ MULTIPLE mode */
     static const uint8_t addr = (LIS3DH_REG_OUT_X_L | LIS3DH_SPI_READ_MASK | LIS3DH_SPI_MULTI_MASK);
@@ -86,7 +85,7 @@ int lis3dh_read_xyz(const lis3dh_t *dev, lis3dh_data_t *acc_data)
 
     /* Scale to milli-G */
     for (i = 0; i < 3; ++i) {
-        tmp = (int32_t)(((int16_t *)acc_data)[i]);
+        int32_t tmp = (int32_t)(((int16_t *)acc_data)[i]);
         tmp *= dev->scale;
         tmp /= 32768;
         (((int16_t *)acc_data)[i]) = (int16_t)tmp;

--- a/sys/net/routing/nhdp/nib_table.c
+++ b/sys/net/routing/nhdp/nib_table.c
@@ -54,12 +54,12 @@ nib_entry_t *nib_process_hello(nhdp_addr_entry_t *nb_list, nhdp_addr_entry_t **o
 {
     nib_entry_t *nb_match = NULL;
     timex_t now;
-    uint8_t matches = 0;
 
     mutex_lock(&mtx_nib_access);
 
     if (nb_list) {
         nib_entry_t *nib_elt, *nib_tmp;
+        uint8_t matches = 0;
 
         vtimer_now(&now);
 
@@ -252,10 +252,10 @@ static void clear_nb_addresses(nib_entry_t *nib_entry, nhdp_addr_entry_t *nb_lis
                                nhdp_addr_entry_t **out_list, timex_t *now)
 {
     nhdp_addr_entry_t *elt, *nib_elt, *nib_tmp;
-    uint8_t found;
 
     LL_FOREACH_SAFE(nib_entry->address_list_head, nib_elt, nib_tmp) {
-        found = 0;
+        uint8_t found = 0;
+
         LL_FOREACH(nb_list, elt) {
             /* Check whether address is still present in the new neighbor address list */
             if (nib_elt->address == elt->address) {


### PR DESCRIPTION
- Part of fix for issue number 480 (variableScope)
- Suppression of warnings that are not needed.