### PR TITLE
ng_net: header building facilities

### DIFF
--- a/sys/include/net/ng_netreg.h
+++ b/sys/include/net/ng_netreg.h
@@ -24,6 +24,7 @@
 
 #include "kernel_types.h"
 #include "net/ng_nettype.h"
+#include "net/ng_pkt.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -125,6 +126,25 @@ int ng_netreg_num(ng_nettype_t type, uint32_t demux_ctx);
  * @return  NULL if no entry new entry can be found.
  */
 ng_netreg_entry_t *ng_netreg_getnext(ng_netreg_entry_t *entry);
+
+/**
+ * @brief   Builds a header for sending and adds it to the packet buffer.
+ *
+ * @param[in] type      Type of the header.
+ * @param[in] payload   Payload for the packet.
+ * @param[in] src       Source address for the header. Can be NULL if not
+ *                      known or required.
+ * @param[in] src_len   Length of @p src. Can be 0 if not known or required.
+ * @param[in] dst       Destination address for the header. Can be NULL if not
+ *                      known or required.
+ * @param[in] dst_len   Length of @p dst. Can be 0 if not known or required.
+ *
+ * @return  The header for the protocol on success.
+ * @return  NULL on error.
+ */
+ng_pktsnip_t *ng_netreg_hdr_build(ng_nettype_t type, ng_pktsnip_t *payload,
+                                  uint8_t *src, uint8_t src_len,
+                                  uint8_t *dst, uint8_t dst_len);
 
 #ifdef __cplusplus
 }

--- a/sys/net/crosslayer/ng_netreg/ng_netreg.c
+++ b/sys/net/crosslayer/ng_netreg/ng_netreg.c
@@ -19,6 +19,7 @@
 #include "utlist.h"
 #include "net/ng_netreg.h"
 #include "net/ng_nettype.h"
+#include "net/ng_ipv6.h"
 
 #define _INVALID_TYPE(type) (((type) < NG_NETTYPE_UNDEF) || ((type) >= NG_NETTYPE_NUMOF))
 
@@ -99,6 +100,32 @@ ng_netreg_entry_t *ng_netreg_getnext(ng_netreg_entry_t *entry)
     LL_SEARCH_SCALAR(entry->next, entry, demux_ctx, demux_ctx);
 
     return entry;
+}
+
+ng_pktsnip_t *ng_netreg_hdr_build(ng_nettype_t type, ng_pktsnip_t *payload,
+                                  uint8_t *src, uint8_t src_len,
+                                  uint8_t *dst, uint8_t dst_len)
+{
+    switch (type) {
+#ifdef MODULE_NG_IPV6
+
+        case NG_NETTYPE_IPV6:
+            return ng_ipv6_hdr_build(payload, src, src_len, dst, dst_len);
+#endif
+#ifdef MODULE_NG_TCP
+
+        case NG_NETTYPE_TCP:
+            return ng_tcp_hdr_build(payload, src, src_len, dst, dst_len);
+#endif
+#ifdef MODULE_NG_UDP
+
+        case NG_NETTYPE_UDP:
+            return ng_udp_hdr_build(payload, src, src_len, dst, dst_len);
+#endif
+
+        default:
+            return NULL;
+    }
 }
 
 /** @} */


### PR DESCRIPTION
This was taken out of #2553 

The idea is that an upper-layer can build a header for the layer it wants to send data over without knowledge about the actual structure of the header. I also added a convinience function of similar format to `ng_netif_hdr`.

~~Depends on #2706~~ (merged)