### PR TITLE
sys/nhdp: Add interface-specific sequence number to created RFC5444 packets

### DIFF
--- a/sys/net/routing/nhdp/nhdp.c
+++ b/sys/net/routing/nhdp/nhdp.c
@@ -170,6 +170,8 @@ int nhdp_register_if(kernel_pid_t if_pid, uint8_t *addr, size_t addr_size, uint8
     if_entry->validity_time.microseconds = MS_IN_USEC * val_time_ms;
     timex_normalize(&if_entry->hello_interval);
     timex_normalize(&if_entry->validity_time);
+    /* Reset sequence number */
+    if_entry->seq_no = 0;
 
     /* Everything went well */
     nhdp_decrement_addr_usage(nhdp_addr);

--- a/sys/net/routing/nhdp/nhdp.h
+++ b/sys/net/routing/nhdp/nhdp.h
@@ -92,6 +92,7 @@ typedef struct nhdp_if_entry_t {
     vtimer_t if_timer;                          /**< Vtimer used for the periodic signaling */
     timex_t hello_interval;                     /**< Interval time for periodic HELLOs */
     timex_t validity_time;                      /**< Validity time for propagated information */
+    uint16_t seq_no;                            /**< Sequence number of last send RFC5444 packet */
     struct rfc5444_writer_target wr_target;     /**< Interface specific writer target */
 } nhdp_if_entry_t;
 


### PR DESCRIPTION
This PR adds sequence numbers to the RFC5444 packets containing NHDP's HELLO messages. A sequence number is managed for each registered interface. The change prepares NHDP for metric calculations by allowing to use the sequence number as an indicator of lost packets.

This PR depends on ~~#2549~~.