### PR TITLE
boards/msbiot: Extend the provided features

### DIFF
--- a/boards/msbiot/Makefile.features
+++ b/boards/msbiot/Makefile.features
@@ -1,4 +1,4 @@
 FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart periph_gpio periph_spi periph_i2c periph_pwm
+FEATURES_PROVIDED += periph_uart periph_gpio periph_spi periph_i2c periph_pwm periph_random
 FEATURES_PROVIDED += transceiver
 FEATURES_MCU_GROUP = cortex_m4

--- a/boards/msbiot/Makefile.features
+++ b/boards/msbiot/Makefile.features
@@ -1,5 +1,5 @@
 FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += periph_uart periph_gpio periph_spi periph_i2c periph_pwm periph_random \
-                     periph_adc
+                     periph_adc periph_dac
 FEATURES_PROVIDED += transceiver
 FEATURES_MCU_GROUP = cortex_m4

--- a/boards/msbiot/Makefile.features
+++ b/boards/msbiot/Makefile.features
@@ -1,4 +1,5 @@
 FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart periph_gpio periph_spi periph_i2c periph_pwm periph_random
+FEATURES_PROVIDED += periph_uart periph_gpio periph_spi periph_i2c periph_pwm periph_random \
+                     periph_adc
 FEATURES_PROVIDED += transceiver
 FEATURES_MCU_GROUP = cortex_m4

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -92,6 +92,13 @@ extern "C" {
 /** @} */
 
 /**
+ * @name Random Number Generator configuration
+ * @{
+ */
+#define RANDOM_NUMOF        (1U)
+/** @} */
+
+/**
  * @name UART configuration
  * @{
  */

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -92,6 +92,29 @@ extern "C" {
 /** @} */
 
 /**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_NUMOF           (1U)
+#define ADC_0_EN            1
+#define ADC_MAX_CHANNELS    2
+
+/* ADC 0 configuration */
+#define ADC_0_DEV           ADC1
+#define ADC_0_CHANNELS      2
+#define ADC_0_CLKEN()       (RCC->APB2ENR |= RCC_APB2ENR_ADC1EN)
+#define ADC_0_CLKDIS()      (RCC->APB2ENR &= ~(RCC_APB2ENR_ADC1EN))
+#define ADC_0_PORT          GPIOB
+#define ADC_0_PORT_CLKEN()  (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+/* ADC 0 channel 0 pin config */
+#define ADC_0_CH0           8
+#define ADC_0_CH0_PIN       0
+/* ADC 0 channel 1 pin config */
+#define ADC_0_CH1           9
+#define ADC_0_CH1_PIN       1
+/** @} */
+
+/**
  * @name Random Number Generator configuration
  * @{
  */

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -115,6 +115,26 @@ extern "C" {
 /** @} */
 
 /**
+ * @name DAC configuration
+ * @{
+ */
+#define DAC_NUMOF          (1U)
+#define DAC_0_EN           1
+#define DAC_MAX_CHANNELS   2
+
+/* DAC 0 configuration */
+#define DAC_0_DEV            DAC
+#define DAC_0_CHANNELS       2
+#define DAC_0_CLKEN()        (RCC->APB1ENR |=  (RCC_APB1ENR_DACEN))
+#define DAC_0_CLKDIS()       (RCC->APB1ENR &= ~(RCC_APB1ENR_DACEN))
+#define DAC_0_PORT           GPIOA
+#define DAC_0_PORT_CLKEN()   (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+/* DAC 0 channel config */
+#define DAC_0_CH0_PIN        4
+#define DAC_0_CH1_PIN        5
+/** @} */
+
+/**
  * @name Random Number Generator configuration
  * @{
  */


### PR DESCRIPTION
This PR extends the `periph_conf.h` of the MSB-IoT with configurations for RNG, ADC and DAC to provide these features out of the box.