### PR TITLE
ng_netconf: add source length identifier

### DIFF
--- a/sys/include/net/ng_netconf.h
+++ b/sys/include/net/ng_netconf.h
@@ -45,7 +45,9 @@ typedef enum {
     NETCONF_OPT_ADDR_LEN,           /**< get the default address length a
                                      *   network device expects as uint16_t in
                                      *   host byte order */
-
+    NETCONF_OPT_SRC_LEN,            /**< get/set the address length to choose
+                                     *   for the network device's source address
+                                     *   as uint16_t in host byte order */
     /**
      * @brief    get/set the network ID as uint16_t in host byte order
      *


### PR DESCRIPTION
The rational is that for devices with dual addressing modes (or more) as
for example IEEE 802.15.4 you can get or set these addressing modes for
the source address of a packet. The length of the destination address is clear
since it usually arrives through the `ng_netif_hdr_t`.

In case of IEEE 802.15.4 this is needed to determine the compression
state of source IPv6 addresses in 6LoWPAN IPHC.