### PR TITLE
sys: Set Local bit in EUI64 generated from CPU ID

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -144,6 +144,8 @@ void auto_init_net_if(void)
 
         memcpy(&(eui64.uint32[0]), &hash_h, sizeof(uint32_t));
         memcpy(&(eui64.uint32[1]), &hash_l, sizeof(uint32_t));
+        /* Set Local/Universal bit to Local since this EUI64 is made up. */
+        eui64.uint8[0] |= 0x02;
         net_if_set_eui64(iface, &eui64);
 
 #if ENABLE_DEBUG


### PR DESCRIPTION
This changes the auto_init procedure for generating EUI-64 from CPU ID to always set the Local/Universal bit in the generated EUI-64. The bit should only be cleared on globally unique EUI-64 addresses, which are assigned by the device manufacturers. When we generate an EUI-64 from the CPU ID hash we can not guarantee that it is globally unique. Also the OUI part of the address (first three bytes) in a globally unique address should point to the manufacturer of the device, which it won't when we pick one at random.

Comments on this?