### PR TITLE
ng_nettype: add translation capabilities to ethertype and protnum

### DIFF
--- a/sys/include/net/ng_nettype.h
+++ b/sys/include/net/ng_nettype.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    net_ng_nettype  Protocol type definitions.
+ * @defgroup    net_ng_nettype  Protocol type
  * @ingroup     net
  * @brief       Protocol type definitions to be used with the @ref net_ng_netapi,
  *              the @ref net_ng_netdev, the @ref net_ng_netreg, and

--- a/sys/include/net/ng_nettype.h
+++ b/sys/include/net/ng_nettype.h
@@ -22,6 +22,11 @@
 #ifndef NG_NETTYPE_H_
 #define NG_NETTYPE_H_
 
+#include <inttypes.h>
+
+#include "net/ng_ethertype.h"
+#include "net/ng_protnum.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -77,6 +82,122 @@ typedef enum {
 
     NG_NETTYPE_NUMOF,           /**< maximum number of available protocols */
 } ng_nettype_t;
+
+/**
+ * @brief   Translates an Ether Type number to @ref net_ng_nettype
+ * @see     <a href="http://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml#ieee-802-numbers-1">
+ *              IANA, ETHER TYPES
+ *          </a>
+ *
+ * @param[in] type  An Ether Type number
+ *
+ * @return  The corresponding @ref net_ng_nettype to @p type.
+ * @return  @ref NG_NETTYPE_UNDEF if @p type not translatable.
+ */
+static inline ng_nettype_t ng_nettype_from_ethertype(uint16_t type)
+{
+    switch (type) {
+#ifdef MODULE_NG_IPV6
+        case NG_ETHERTYPE_IPV6:
+            return NG_NETTYPE_IPV6;
+#endif
+        default:
+            return NG_NETTYPE_UNDEF;
+    }
+}
+
+/**
+ * @brief   Translates @ref net_ng_nettype to an Ether Type number
+ * @see     <a href="http://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml#ieee-802-numbers-1">
+ *              IANA, ETHER TYPES
+ *          </a>
+ *
+ * @param[in] type  A protocol type
+ *
+ * @return  The corresponding Ether Type number to @p type.
+ * @return  @ref NG_ETHERTYPE_RESERVED if @p type not translatable.
+ */
+static inline uint16_t ng_nettype_to_ethertype(ng_nettype_t type)
+{
+    switch (type) {
+#ifdef MODULE_NG_IPV6
+        case NG_NETTYPE_IPV6:
+            return NG_ETHERTYPE_IPV6;
+#endif
+        default:
+            return NG_ETHERTYPE_RESERVED;
+    }
+}
+
+/**
+ * @brief   Translates a Protocol Number to @ref net_ng_nettype
+ * @see     <a href="http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml">
+ *              IANA, Assigned Internet Protocol Numbers
+ *          </a>
+ *
+ * @param[in] num   A Protocol Number
+ *
+ * @return  The corresponding @ref net_ng_nettype to @p num.
+ * @return  @ref NG_NETTYPE_UNDEF if @p num not translatable.
+ */
+static inline ng_nettype_t ng_nettype_from_protnum(uint8_t num)
+{
+    switch (num) {
+#ifdef MODULE_NG_ICMPV6
+        case NG_PROTNUM_ICMPV6:
+            return NG_NETTYPE_IPCMPV6;
+#endif
+#ifdef MODULE_NG_IPV6
+        case NG_PROTNUM_IPV6:
+            return NG_NETTYPE_IPV6;
+#endif
+#ifdef MODULE_NG_TCP
+        case NG_PROTNUM_TCP:
+            return NG_NETTYPE_TCP;
+#endif
+#ifdef MODULE_NG_UDP
+        case NG_PROTNUM_UDP:
+            return NG_NETTYPE_UDP;
+#endif
+        default:
+            return NG_NETTYPE_UNDEF;
+    }
+}
+
+/**
+ * @brief   Translates @ref net_ng_nettype to a Protocol Number
+ * @see     <a href="http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml">
+ *              IANA, Assigned Internet Protocol Numbers
+ *          </a>
+ *
+ * @param[in] type  A protocol type
+ *
+ * @return  The corresponding Protocol Number to @p type.
+ * @return  @ref NG_PROTNUM_RESERVED if @p type not translatable.
+ */
+static inline uint8_t ng_nettype_to_protnum(ng_nettype_t type)
+{
+    switch (type) {
+#ifdef MODULE_NG_ICMPV6
+        case NG_NETTYPE_ICMPV6:
+            return NG_PROTNUM_IPCMPV6;
+#endif
+#ifdef MODULE_NG_IPV6
+        case NG_NETTYPE_IPV6:
+            return NG_PROTNUM_IPV6;
+#endif
+#ifdef MODULE_NG_TCP
+        case NG_NETTYPE_TCP:
+            return NG_PROTNUM_TCP;
+#endif
+#ifdef MODULE_NG_UDP
+        case NG_NETTYPE_UDP:
+            return NG_PROTNUM_UDP;
+#endif
+        default:
+            return NG_PROTNUM_RESERVED;
+    }
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
~~Depends on #2579~~ (merged)

The rational is that we need these translations in several points in the network stack (every ethernet device, every transport layer and every network layer protocol).

1. this is a lot of code duplication, just for translating something
2. if we introduce new values to `ng_nettype_t` we might need to change every one of these instances. This centralizes these `#ifdef`s and also beautifies the using code this way ;-).