### PR TITLE
cc110x: remove warning about the transceiver mode

### DIFF
--- a/drivers/include/cc110x_legacy_csma/cc1100-interface.h
+++ b/drivers/include/cc110x_legacy_csma/cc1100-interface.h
@@ -50,9 +50,6 @@ extern "C" {
 /* Define default radio mode to constant RX if no application specific setting
  * is available. */
 #ifndef CC1100_RADIO_MODE
-#ifdef MODULE_RPL
-#warning RPL currently works with CC1100_MODE_WOR
-#endif
 #define CC1100_RADIO_MODE CC1100_MODE_CONSTANT_RX
 #endif
 


### PR DESCRIPTION
* RPL is currently working with both transceiver modes (wake on radio _and_ constant RX)
* tested on MSB-A2 in the DES testbed