### PR TITLE
cpu/native: Fix for missing malloc.h in OSX

### DIFF
--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -1,2 +1,8 @@
 export NATIVEINCLUDES += -I$(RIOTCPU)/native/include -I$(RIOTBASE)/sys/include
+
+# Local include for malloc.h on OSX
+ifeq ($(BUILDOSXNATIVE),1)
+    export NATIVEINCLUDES += -I$(RIOTBASE)/sys/malloc/include
+endif
+
 export USEMODULE += periph

--- a/sys/malloc/include/malloc.h
+++ b/sys/malloc/include/malloc.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2015 James Hollister
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys
+ *
+ * @brief       Malloc header for use with native on OSX since there is no
+ *              malloc.h file in the standard include path.
+ *
+ * @{
+ * @file
+ *
+ * @author      James Hollister <jhollisterjr@gmail.com>
+ */
+
+#ifndef MALLOC_H
+#define MALLOC_H
+
+#include <stddef.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief       Allocate SIZE bytes of memory.
+ * @param[in]   size    Size of the block to allocate.
+ * @returns     New memory block. NULL if failed to allocate.
+ */
+extern void *malloc (size_t size);
+
+/**
+ * @brief  Allocate NMEMB elements of SIZE bytes each, all initialized to 0.
+ * @param[in]   nmemb   Number of elements to be allocated.
+ * @param[in]   size    Size of the block to allocate.
+ * @returns     New memory block. NULL if failed to allocate.
+ */
+extern void *calloc (size_t nmemb, size_t size);
+
+/**
+ * @brief       Re-allocate the previously allocated block in ptr, making the new
+ *              block SIZE bytes long.
+ * @param[in]   ptr     Old memory block.
+ * @param[in]   size    Size of the new block to allocate.
+ * @returns     New memory block. NULL if failed to allocate.
+ */
+extern void *realloc (void *ptr, size_t size);
+
+/**
+ * @brief       Free a block allocated by `malloc', `realloc' or `calloc'.
+ * @param[in]   ptr   Memory block that was allocated with 'malloc, 'realloc,
+ *              or 'calloc'.
+ */
+extern void free (void *ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* malloc.h */
+
+/**
+ * @}
+ */


### PR DESCRIPTION
Extends the include when building on OSX to fix issue #2361. Currently using the local `malloc.h` found in `./sys/oneway-malloc/include/` but I think it might be better to add a different `malloc.h` since that's not really made to be used like this. I wanted to get the PR started though to get some feedback.