### PR TITLE
sys/nhdp: Add metric infrastructure and DAT metric computation

### DIFF
--- a/sys/net/routing/nhdp/lib_table.c
+++ b/sys/net/routing/nhdp/lib_table.c
@@ -109,7 +109,8 @@ void lib_fill_wr_addresses(kernel_pid_t if_pid, struct rfc5444_writer *wr)
         if (lib_elt->if_pid == if_pid) {
             LL_FOREACH(lib_elt->if_addr_list_head, add_tmp) {
                 nhdp_writer_add_addr(wr, add_tmp->address,
-                                     RFC5444_ADDRTLV_LOCAL_IF, RFC5444_LOCALIF_THIS_IF);
+                                     RFC5444_ADDRTLV_LOCAL_IF, RFC5444_LOCALIF_THIS_IF,
+                                     NHDP_METRIC_UNKNOWN, NHDP_METRIC_UNKNOWN);
                 add_tmp->address->in_tmp_table = NHDP_ADDR_TMP_ANY;
             }
             break;
@@ -124,7 +125,8 @@ void lib_fill_wr_addresses(kernel_pid_t if_pid, struct rfc5444_writer *wr)
                 if (!NHDP_ADDR_TMP_IN_ANY(add_tmp->address)) {
                     /* Address can be added */
                     nhdp_writer_add_addr(wr, add_tmp->address,
-                                         RFC5444_ADDRTLV_LOCAL_IF, RFC5444_LOCALIF_OTHER_IF);
+                                         RFC5444_ADDRTLV_LOCAL_IF, RFC5444_LOCALIF_OTHER_IF,
+                                         NHDP_METRIC_UNKNOWN, NHDP_METRIC_UNKNOWN);
                     add_tmp->address->in_tmp_table = NHDP_ADDR_TMP_ANY;
                 }
             }

--- a/sys/net/routing/nhdp/nhdp.h
+++ b/sys/net/routing/nhdp/nhdp.h
@@ -25,6 +25,7 @@
 #include "kernel_types.h"
 #include "socket_base/socket.h"
 
+#include "nhdp_metric.h"
 #include "rfc5444/rfc5444_writer.h"
 
 #ifdef __cplusplus

--- a/sys/net/routing/nhdp/nhdp_address.c
+++ b/sys/net/routing/nhdp/nhdp_address.c
@@ -71,6 +71,7 @@ nhdp_addr_t *nhdp_addr_db_get_address(uint8_t *addr, size_t addr_size, uint8_t a
         addr_elt->addr_type = addr_type;
         addr_elt->usg_count = 0;
         addr_elt->in_tmp_table = NHDP_ADDR_TMP_NONE;
+        addr_elt->tmp_metric_val = NHDP_METRIC_UNKNOWN;
         LL_PREPEND(nhdp_addr_db_head, addr_elt);
     }
 
@@ -146,6 +147,7 @@ void nhdp_reset_addresses_tmp_usg(uint8_t decr_usg)
     nhdp_addr_t *addr_elt, *addr_tmp;
 
     LL_FOREACH_SAFE(nhdp_addr_db_head, addr_elt, addr_tmp) {
+        addr_elt->tmp_metric_val = NHDP_METRIC_UNKNOWN;
         if (addr_elt->in_tmp_table) {
             addr_elt->in_tmp_table = NHDP_ADDR_TMP_NONE;
             if (decr_usg) {

--- a/sys/net/routing/nhdp/nhdp_address.h
+++ b/sys/net/routing/nhdp/nhdp_address.h
@@ -32,6 +32,7 @@ typedef struct nhdp_addr_t {
     uint8_t addr_type;                  /**< AF type for the address */
     uint8_t usg_count;                  /**< Usage count in information bases */
     uint8_t in_tmp_table;               /**< Signals usage in a writers temp table */
+    uint16_t tmp_metric_val;            /**< Encoded metric value used during HELLO processing */
     struct nhdp_addr_t *next;           /**< Pointer to next address (used in central storage) */
 } nhdp_addr_t;
 

--- a/sys/net/routing/nhdp/nhdp_metric.h
+++ b/sys/net/routing/nhdp/nhdp_metric.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     nhdp
+ * @{
+ *
+ * @file
+ * @brief       Macros for NHDP metric computation
+ *
+ * The used infrastructure for exchanging metric values is based on the rules defined in the RFC
+ * of <a href="https://tools.ietf.org/html/rfc7181">OLSRv2</a>. The calculations for the
+ * Directional Airtime Metric (DAT) are based on
+ * <a href="https://tools.ietf.org/html/draft-ietf-manet-olsrv2-dat-metric-05">DAT Draft v5</a>.
+ *
+ * @author      Fabian Nack <nack@inf.fu-berlin.de>
+ */
+
+#ifndef NHDP_METRIC_H_
+#define NHDP_METRIC_H_
+
+#include "rfc5444/rfc5444.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    NHDP protocol macros
+ *
+ * @{
+ */
+/** @brief Hop Count metric extension value for metric TLV extension field */
+#define NHDP_LMT_HOP_COUNT          (163)
+/** @brief DAT metric extension value for metric TLV extension field */
+#define NHDP_LMT_DAT                (165)
+
+/** @brief Used metric (change to switch to another metric type) */
+#define NHDP_METRIC                 (NHDP_LMT_HOP_COUNT)
+
+/** @brief Randomly chosen number for NHDP's metric timer event */
+#define NHDP_METRIC_TIMER           (5445)
+/** @brief Macro controlling the start of a periodic timer event for matric computation */
+#define NHDP_METRIC_NEEDS_TIMER     (NHDP_METRIC == NHDP_LMT_DAT)
+
+#define NHDP_METRIC_UNKNOWN         (0)
+#define NHDP_METRIC_MINIMUM         (RFC5444_METRIC_MIN)
+#define NHDP_METRIC_MAXIMUM         (RFC5444_METRIC_MAX)
+
+/** @brief Default queue size for metrics using a queue to determine link loss */
+#define NHDP_Q_MEM_LENGTH           (64)
+/** @brief Restart detection value for packet sequence number based link loss computation */
+#define NHDP_SEQNO_RESTART_DETECT   (256)
+
+/** @brief Encoding for an incoming link metric value in metric TLV */
+#define NHDP_KD_LM_INC              (0x8000)
+/** @brief Encoding for an outgoing link metric value in metric TLV */
+#define NHDP_KD_LM_OUT              (0x4000)
+/** @brief Encoding for an incoming neighbor metric value in metric TLV */
+#define NHDP_KD_NM_INC              (0x2000)
+/** @brief Encoding for an outgoing neighbor metric value in metric TLV */
+#define NHDP_KD_NM_OUT              (0x1000)
+/** @} */
+
+/**
+ * @name    DAT metric specific macros
+ *
+ * @{
+ */
+/** @brief Length of RCVD and TOTAL queue of DAT metric */
+#define DAT_MEMORY_LENGTH           (NHDP_Q_MEM_LENGTH)
+/** @brief Time between DAT metric refreshal */
+#define DAT_REFRESH_INTERVAL        (1)
+/** @brief Factor to spread HELLO interval */
+#define DAT_HELLO_TIMEOUT_FACTOR    (1.2)
+/** @brief Minimal supported bit rate in bps (default value for new links) */
+#define DAT_MINIMUM_BITRATE         (1000)
+/** @brief Maximum allowed loss in expected/rcvd HELLOs (should not be changed) */
+#define DAT_MAXIMUM_LOSS            (8)
+/** @brief Constant value needed for DAT metric computation (should not be changed) */
+#define DAT_CONSTANT                (16777216)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NHDP_METRIC_H_ */

--- a/sys/net/routing/nhdp/nhdp_writer.h
+++ b/sys/net/routing/nhdp/nhdp_writer.h
@@ -65,9 +65,12 @@ void nhdp_writer_send_hello(nhdp_if_entry_t *if_entry);
  * @param[in] addr          Pointer to a NHDP address to add to the HELLO message
  * @param[in] type          TLV type for the address
  * @param[in] value         TLV value for the address
+ * @param[in] metric_in     Encoded incoming link metric value
+ * @param[in] metric_out    Encoded outgoing link metric value
  */
 void nhdp_writer_add_addr(struct rfc5444_writer *wr, nhdp_addr_t *addr,
-                          enum rfc5444_addrtlv_iana type, uint8_t value);
+                          enum rfc5444_addrtlv_iana type, uint8_t value,
+                          uint16_t metric_in, uint16_t metric_out);
 
 #ifdef __cplusplus
 }

--- a/sys/net/routing/nhdp/nib_table.c
+++ b/sys/net/routing/nhdp/nib_table.c
@@ -122,7 +122,9 @@ void nib_fill_wr_addresses(struct rfc5444_writer *wr)
                 /* Check whether address is not already included with link status symmetric */
                 if (!NHDP_ADDR_TMP_IN_SYM(addr_elt->address)) {
                     nhdp_writer_add_addr(wr, addr_elt->address, RFC5444_ADDRTLV_OTHER_NEIGHB,
-                                         RFC5444_OTHERNEIGHB_SYMMETRIC);
+                                         RFC5444_OTHERNEIGHB_SYMMETRIC,
+                                         rfc5444_metric_encode(nib_elt->metric_in),
+                                         rfc5444_metric_encode(nib_elt->metric_out));
                     addr_elt->address->in_tmp_table = NHDP_ADDR_TMP_SYM;
                 }
             }
@@ -140,7 +142,8 @@ void nib_fill_wr_addresses(struct rfc5444_writer *wr)
             if (!NHDP_ADDR_TMP_IN_ANY(lost_elt->address)) {
                 /* Address is not present in one of the lists, add it */
                 nhdp_writer_add_addr(wr, lost_elt->address, RFC5444_ADDRTLV_OTHER_NEIGHB,
-                                     RFC5444_OTHERNEIGHB_LOST);
+                                     RFC5444_OTHERNEIGHB_LOST, NHDP_METRIC_UNKNOWN,
+                                     NHDP_METRIC_UNKNOWN);
             }
         }
     }
@@ -215,6 +218,8 @@ static nib_entry_t *add_nib_entry_for_nb_addr_list(void)
     }
 
     new_elem->symmetric = 0;
+    new_elem->metric_in = NHDP_METRIC_UNKNOWN;
+    new_elem->metric_out = NHDP_METRIC_UNKNOWN;
     LL_PREPEND(nib_entry_head, new_elem);
 
     return new_elem;

--- a/sys/net/routing/nhdp/nib_table.h
+++ b/sys/net/routing/nhdp/nib_table.h
@@ -35,6 +35,8 @@ extern "C" {
 typedef struct nib_entry_t {
     nhdp_addr_entry_t *address_list_head;   /**< Pointer to this tuple's addresses*/
     uint8_t symmetric;                      /**< Flag whether sym link to this nb exists */
+    uint32_t metric_in;                     /**< Lowest metric value for incoming link */
+    uint32_t metric_out;                    /**< Lowest metric value for outgoing link */
     struct nib_entry_t *next;               /**< Pointer to next list entry */
 } nib_entry_t;
 


### PR DESCRIPTION
This PR extends NHDP's functionality with the possibility to calculate and exchange link metric values for the detected links.

The PR depends on ~~#2500~~ and ~~#2576~~.
