### PR TITLE
ng_net: changed semantic of get and set command slightly

### DIFF
--- a/sys/include/net/ng_netapi.h
+++ b/sys/include/net/ng_netapi.h
@@ -91,12 +91,12 @@ int ng_netapi_send(kernel_pid_t pid, ng_pktsnip_t *pkt);
  * @param[in] opt       option to get
  * @param[in] context   (optional) context to the given option
  * @param[in] data      pointer to buffer for reading the option's value
- * @param[in] data_len  size of the given buffer
+ * @param[in] max_len   maximum number of bytes that fit into @p data
  *
  * @return              value returned by the @ref NG_NETAPI_MSG_TYPE_ACK message
  */
 int ng_netapi_get(kernel_pid_t pid, ng_netconf_opt_t opt, uint16_t context,
-                  void *data, size_t data_len);
+                  void *data, size_t max_len);
 
 /**
  * @brief   Shortcut function for sending @ref NG_NETAPI_MSG_TYPE_SET messages and

--- a/sys/include/net/ng_netdev.h
+++ b/sys/include/net/ng_netdev.h
@@ -115,17 +115,17 @@ typedef struct {
      * @param[in] dev           network device descriptor
      * @param[in] opt           option type
      * @param[out] value        pointer to store the option's value in
-     * @param[in,out] value_len the length of @p value. Must be initialized to
-     *                          the available space in @p value on call.
+     * @param[in] max_len       maximal amount of byte that fit into @p value
      *
-     * @return              0 on success
+     * @return              number of bytes written to @p value
      * @return              -ENODEV if @p dev is invalid
      * @return              -ENOTSUP if @p opt is not supported
      * @return              -EOVERFLOW if available space in @p value given in
-     *                      @p value_len is too small to store the option value
+     *                      @p max_len is too small to store the option value
+     * @return              -ECANCELED if internal driver error occurred
      */
     int (*get)(ng_netdev_t *dev, ng_netconf_opt_t opt,
-               void *value, size_t *value_len);
+               void *value, size_t max_len);
 
     /**
      * @brief   Set an option value for a given network device
@@ -135,10 +135,11 @@ typedef struct {
      * @param[in] value     value to set
      * @param[in] value_len the length of @p value
      *
-     * @return              0 on success
+     * @return              number of bytes used from @p value
      * @return              -ENODEV if @p dev is invalid
      * @return              -ENOTSUP if @p opt is not supported
      * @return              -EINVAL if @p value is invalid
+     * @return              -ECANCELED if internal driver error occurred
      */
     int (*set)(ng_netdev_t *dev, ng_netconf_opt_t opt,
                void *value, size_t value_len);

--- a/sys/net/link_layer/ng_nomac/ng_nomac.c
+++ b/sys/net/link_layer/ng_nomac/ng_nomac.c
@@ -110,6 +110,7 @@ static void *_nomac_thread(void *args)
                 opt = (ng_netapi_opt_t *)msg.content.ptr;
                 /* set option for device driver */
                 res = dev->driver->set(dev, opt->opt, opt->data, opt->data_len);
+                DEBUG("nomac: response of netdev->set: %i\n", res);
                 /* send reply to calling thread */
                 reply.type = NG_NETAPI_MSG_TYPE_ACK;
                 reply.content.value = (uint32_t)res;
@@ -122,8 +123,8 @@ static void *_nomac_thread(void *args)
                 /* read incoming options */
                 opt = (ng_netapi_opt_t *)msg.content.ptr;
                 /* get option from device driver */
-                res = dev->driver->get(dev, opt->opt, opt->data,
-                                       (size_t*)(&(opt->data_len)));
+                res = dev->driver->get(dev, opt->opt, opt->data, opt->data_len);
+                DEBUG("nomac: response of netdev->get: %i\n", res);
                 /* send reply to calling thread */
                 reply.type = NG_NETAPI_MSG_TYPE_ACK;
                 reply.content.value = (uint32_t)res;


### PR DESCRIPTION
When working with netdev/netapi, I found the get function over complicated. This PR simplifies the semantics a little by making use of the `netdev->get()` functions return value (like every Linux programmer would expect)...

So when reading for example a network address from a device, the max_length parameter can be used to specify how many bytes should be read. The device driver can then take from this number which address it should read, e.g. a 802.15.4 device returns the short address if 2 byte are asked for and the long address if 8 byte are asked for...