### PR TITLE
boards/nucleo-f334: indicate periph_cpuid feature

### DIFF
--- a/boards/nucleo-f334/Makefile.features
+++ b/boards/nucleo-f334/Makefile.features
@@ -1,3 +1,4 @@
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += cpp
 FEATURES_MCU_GROUP = cortex_m4


### PR DESCRIPTION
Follow up to https://github.com/RIOT-OS/RIOT/pull/2552 by  @jhollister 