### PR TITLE
[RFC] ng_netif_hdr: add flags for multicast and broadcast

### DIFF
--- a/sys/include/net/ng_netif/hdr.h
+++ b/sys/include/net/ng_netif/hdr.h
@@ -33,6 +33,37 @@ extern "C" {
 #endif
 
 /**
+ * @{
+ * @name    Flags for the ng_netif_hdr_t
+ */
+/**
+ * @brief   Send packet broadcast.
+ *
+ * @details Packets with this flag set must be send broadcast.
+ *          ng_netif_hdr_t::dst_l2addr_len and any appended destination
+ *          address must be ignored.
+ *          If the link layer does not support broadcast the packet must be
+ *          dropped silently.
+ */
+#define NG_NETIF_HDR_FLAGS_BROADCAST    (0x80)
+
+/**
+ * @brief   Send packet multicast.
+ *
+ * @details Packets with this flag set must be send multicast.
+ *          ng_netif_hdr_t::dst_l2addr_len and any appended destination
+ *          address must be ignored.
+ *          The context for the multicast address must be derived from the
+ *          network layer destination address.
+ *          If the link layer does not support multicast it should interpret
+ *          this flag the same way it does @ref NG_NETIF_HDR_FLAGS_BROADCAST.
+ */
+#define NG_NETIF_HDR_FLAGS_MULTICAST    (0x40)
+/**
+ * @}
+ */
+
+/**
  * @brief   Generic network interface header
  *
  * The link layer addresses included in this header are put in memory directly
@@ -42,6 +73,7 @@ typedef struct __attribute__((packed)) {
     uint8_t src_l2addr_len;     /**< length of l2 source address in byte */
     uint8_t dst_l2addr_len;     /**< length of l2 destination address in byte */
     kernel_pid_t if_pid;        /**< PID of network interface */
+    uint8_t flags;              /**< flags as defined above */
     uint8_t rssi;               /**< rssi of received packet (optional) */
     uint8_t lqi;                /**< lqi of received packet (optional) */
 } ng_netif_hdr_t;
@@ -61,6 +93,7 @@ static inline void ng_netif_hdr_init(ng_netif_hdr_t *hdr, uint8_t src_l2addr_len
     hdr->if_pid = KERNEL_PID_UNDEF;
     hdr->rssi = 0;
     hdr->lqi = 0;
+    hdr->flags = 0;
 }
 
 /**

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -296,10 +296,10 @@ int _netif_send(int argc, char **argv)
     size_t addr_len;
     ng_pktsnip_t *pkt;
     ng_netif_hdr_t *nethdr;
-
+    uint8_t flags = 0x00;
 
     if (argc < 4) {
-        printf("usage: %s <if> <addr> <data>\n", argv[0]);
+        printf("usage: %s <if> [<addr>|bcast] <data>\n", argv[0]);
         return 1;
     }
 
@@ -315,8 +315,13 @@ int _netif_send(int argc, char **argv)
     addr_len = ng_netif_addr_from_str(addr, sizeof(addr), argv[2]);
 
     if (addr_len == 0) {
-        puts("error: invalid address given");
-        return 1;
+        if (strcmp(argv[2], "bcast") == 0) {
+            flags |= NG_NETIF_HDR_FLAGS_BROADCAST;
+        }
+        else {
+            puts("error: invalid address given");
+            return 1;
+        }
     }
 
     /* put packet together */
@@ -326,6 +331,7 @@ int _netif_send(int argc, char **argv)
     nethdr = (ng_netif_hdr_t *)pkt->data;
     ng_netif_hdr_init(nethdr, 0, addr_len);
     ng_netif_hdr_set_dst_addr(nethdr, addr, addr_len);
+    nethdr->flags = flags;
     /* and send it */
     ng_netapi_send(dev, pkt);
 


### PR DESCRIPTION
~~A first idea in the direction of IPv6 multicast address resolution.~~

~~The problem I faced with the current IPv6 implementation is that Ethernet defines it's multicast addresses for IPv6 as follows: `33:33:xx:xx:xx:xx`, where the `xx`s represent the last 4 byte of the IPv6 address (source: http://tools.ietf.org/html/rfc7042#section-2.3.1). This is an attempt to unify this with our current scheme of just assuming that the broadcast address will be `ff:ff:…`.~~

~~Devices that don't support multicast (but have either EUI-48 or EUI-64 addressing) are requested to check the individual/group-bit (the 8th MSB in the address for either case), and transform it into there individual broadcast address if it is set to group.~~

~~As I've said: this is only a first idea and a starting point for discussion. I'm not that happy with this solution either.~~

[edit] I changed this PR completely in the wake of https://github.com/RIOT-OS/RIOT/pull/2600#issuecomment-86483289:

> I've got an idea: instead of assuming and stating how a general link-layer broadcast/multicast-address for link-layers should look like, we just let the link-layer decide this stuff completely:
> We introduce a flag field to the general link-layer header ng_netif_hdr_t with a bit for either broadcast and multicast. If the network layer encounters any address format different then unicast, it sets the destination length for ng_netif_hdr_t to 0 and sets the flags accordingly. The driver then can decides itself how to handle that: IEEE 802.15.4 will just set it's preferred broadcast address on either broadcast or multicast == 1, and Ethernet can decide upon encountering these bits how to translate the address based on the next header.

I also adapted the already existing implementations for it.

People interested into discussing this might be @BytesGalore, @cgundogan, @emmanuelsearch,  @haukepetersen, @Lotterleben, @PeterKietzmann, @phiros, and @OlegHahm.