### PR TITLE
rpl: pass rpl_instance_t directly instead of its id

### DIFF
--- a/sys/net/include/rpl/rpl_dodag.h
+++ b/sys/net/include/rpl/rpl_dodag.h
@@ -32,7 +32,7 @@ void rpl_instances_init(void);
 rpl_instance_t *rpl_new_instance(uint8_t instanceid);
 rpl_instance_t *rpl_get_instance(uint8_t instanceid);
 rpl_instance_t *rpl_get_my_instance(void);
-rpl_dodag_t *rpl_new_dodag(uint8_t instanceid, ipv6_addr_t *id);
+rpl_dodag_t *rpl_new_dodag(rpl_instance_t *inst, ipv6_addr_t *id);
 rpl_dodag_t *rpl_get_dodag(ipv6_addr_t *id);
 rpl_dodag_t *rpl_get_my_dodag(void);
 void rpl_join_dodag(rpl_dodag_t *dodag, ipv6_addr_t *parent, uint16_t parent_rank);

--- a/sys/net/routing/rpl/rpl_control_messages.c
+++ b/sys/net/routing/rpl/rpl_control_messages.c
@@ -208,7 +208,7 @@ void rpl_init_root(rpl_options_t *rpl_opts)
 
     inst->joined = 1;
 
-    dodag = rpl_new_dodag(inst->id, &my_address);
+    dodag = rpl_new_dodag(inst, &my_address);
 
     if (dodag != NULL) {
         dodag->of = (struct rpl_of_t *) rpl_get_of_for_ocp(RPL_DEFAULT_OCP);

--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -87,11 +87,8 @@ rpl_instance_t *rpl_get_my_instance(void)
     return NULL;
 }
 
-rpl_dodag_t *rpl_new_dodag(uint8_t instanceid, ipv6_addr_t *dodagid)
+rpl_dodag_t *rpl_new_dodag(rpl_instance_t *inst, ipv6_addr_t *dodagid)
 {
-    rpl_instance_t *inst;
-    inst = rpl_get_instance(instanceid);
-
     if (inst == NULL) {
         DEBUGF("Error - No instance found for id %d. This should not happen\n",
                instanceid);
@@ -338,7 +335,7 @@ void rpl_join_dodag(rpl_dodag_t *dodag, ipv6_addr_t *parent, uint16_t parent_ran
 {
     rpl_dodag_t *my_dodag;
     rpl_parent_t *preferred_parent;
-    my_dodag = rpl_new_dodag(dodag->instance->id, &dodag->dodag_id);
+    my_dodag = rpl_new_dodag(dodag->instance, &dodag->dodag_id);
 
     if (my_dodag == NULL) {
         return;


### PR DESCRIPTION
Instead of passing the id of a `rpl_instance_t` struct to look it up in `rpl_new_dodag()`, I suggest to pass the struct itself to the function.