### PR TITLE
rpl: make send_DAO aware of multiple dodags

### DIFF
--- a/sys/net/include/rpl.h
+++ b/sys/net/include/rpl.h
@@ -103,15 +103,16 @@ void rpl_send_DIO(ipv6_addr_t *destination);
 /**
  * @brief Sends a DAO-message to a given destination
  *
- * This function sends a DAO message to a given destination.
+ * This function sends a DAO message to a given destination in a given dodag.
  *
+ * @param[in] dodag             Dodag of the DAO-message.
  * @param[in] destination       IPv6-address of the destination of the DAO. Should be the preferred parent.
  * @param[in] lifetime          Lifetime of the node. Reflect the estimated time of presence in the network.
  * @param[in] default_lifetime  If true, param lifetime is ignored and lifetime is dodag default-lifetime
  * @param[in] start_index       Describes whether a DAO must be split because of too many routing entries.
  *
  */
-void rpl_send_DAO(ipv6_addr_t *destination, uint8_t lifetime, bool default_lifetime, uint8_t start_index);
+void rpl_send_DAO(rpl_dodag_t *dodag, ipv6_addr_t *destination, uint8_t lifetime, bool default_lifetime, uint8_t start_index);
 
 /**
  * @brief Sends a DIS-message to a given destination
@@ -127,12 +128,13 @@ void rpl_send_DIS(ipv6_addr_t *destination);
 /**
  * @brief Sends a DAO acknowledgment-message to a given destination
  *
- * This function sends a DAO_ACK message to a given destination.
+ * This function sends a DAO_ACK message to a given destination in a given dodag.
  *
+ * @param[in] dodag             Dodag of the DAO_ACK message.
  * @param[in] destination       IPv6-address of the destination of the DAO_ACK. Should be a direct neighbor.
  *
  */
-void rpl_send_DAO_ACK(ipv6_addr_t *destination);
+void rpl_send_DAO_ACK(rpl_dodag_t *dodag, ipv6_addr_t *destination);
 #endif
 
 /**

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -344,7 +344,7 @@ void _dao_handle_send(rpl_dodag_t *dodag)
 {
     if ((dodag->ack_received == false) && (dodag->dao_counter < DAO_SEND_RETRIES)) {
         dodag->dao_counter++;
-        rpl_send_DAO(NULL, 0, true, 0);
+        rpl_send_DAO(dodag, NULL, 0, true, 0);
         dodag->dao_time = timex_set(DEFAULT_WAIT_FOR_DAO_ACK, 0);
         vtimer_remove(&dodag->dao_timer);
         vtimer_set_msg(&dodag->dao_timer, dodag->dao_time,

--- a/sys/net/routing/rpl/rpl_control_messages.c
+++ b/sys/net/routing/rpl/rpl_control_messages.c
@@ -436,7 +436,7 @@ void rpl_send_DAO(rpl_dodag_t *my_dodag, ipv6_addr_t *destination, uint8_t lifet
 
 #if RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE
     rpl_send_opt_transit_buf->length = RPL_OPT_TRANSIT_LEN;
-    memcpy(&rpl_send_opt_transit_buf->parent, rpl_get_my_preferred_parent(), sizeof(ipv6_addr_t));
+    memcpy(&rpl_send_opt_transit_buf->parent, &my_dodag->my_preferred_parent->addr, sizeof(ipv6_addr_t));
     opt_len += RPL_OPT_TRANSIT_LEN_WITH_OPT_LEN;
 #else
     rpl_send_opt_transit_buf->length = (RPL_OPT_TRANSIT_LEN - sizeof(ipv6_addr_t));

--- a/sys/net/routing/rpl/rpl_control_messages.c
+++ b/sys/net/routing/rpl/rpl_control_messages.c
@@ -330,7 +330,7 @@ void rpl_send_DIO(ipv6_addr_t *destination)
     rpl_send(destination, (uint8_t *)icmp_send_buf, plen, IPV6_PROTO_NUM_ICMPV6);
 }
 
-void rpl_send_DAO(ipv6_addr_t *destination, uint8_t lifetime, bool default_lifetime,
+void rpl_send_DAO(rpl_dodag_t *my_dodag, ipv6_addr_t *destination, uint8_t lifetime, bool default_lifetime,
                   uint8_t start_index)
 {
 #if RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE
@@ -349,9 +349,7 @@ void rpl_send_DAO(ipv6_addr_t *destination, uint8_t lifetime, bool default_lifet
         return;
     }
 
-    rpl_dodag_t *my_dodag;
-
-    if ((my_dodag = rpl_get_my_dodag()) == NULL) {
+    if (my_dodag == NULL) {
         DEBUGF("send_DAO: I have no my_dodag\n");
         return;
     }
@@ -451,7 +449,7 @@ void rpl_send_DAO(ipv6_addr_t *destination, uint8_t lifetime, bool default_lifet
 #if RPL_DEFAULT_MOP != RPL_MOP_NON_STORING_MODE
 
     if (continue_index > 1) {
-        rpl_send_DAO(destination, lifetime, default_lifetime, continue_index);
+        rpl_send_DAO(my_dodag, destination, lifetime, default_lifetime, continue_index);
     }
 
 #endif
@@ -479,7 +477,7 @@ void rpl_send_DIS(ipv6_addr_t *destination)
 }
 
 #if RPL_DEFAULT_MOP != RPL_MOP_NON_STORING_MODE
-void rpl_send_DAO_ACK(ipv6_addr_t *destination)
+void rpl_send_DAO_ACK(rpl_dodag_t *my_dodag, ipv6_addr_t *destination)
 {
 #if ENABLE_DEBUG
 
@@ -489,9 +487,6 @@ void rpl_send_DAO_ACK(ipv6_addr_t *destination)
     }
 
 #endif
-
-    rpl_dodag_t *my_dodag;
-    my_dodag = rpl_get_my_dodag();
 
     if (my_dodag == NULL) {
         return;
@@ -864,7 +859,7 @@ void rpl_recv_DAO(void)
     }
 
 #if RPL_DEFAULT_MOP != RPL_MOP_NON_STORING_MODE
-    rpl_send_DAO_ACK(&ipv6_buf->srcaddr);
+    rpl_send_DAO_ACK(my_dodag, &ipv6_buf->srcaddr);
 #endif
 
     if (increment_seq) {

--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -288,7 +288,7 @@ rpl_parent_t *rpl_find_preferred_parent(void)
     if (!rpl_equal_id(&my_dodag->my_preferred_parent->addr, &best->addr)) {
         if (my_dodag->mop != RPL_MOP_NO_DOWNWARD_ROUTES) {
             /* send DAO with ZERO_LIFETIME to old parent */
-            rpl_send_DAO(&my_dodag->my_preferred_parent->addr, 0, false, 0);
+            rpl_send_DAO(my_dodag, &my_dodag->my_preferred_parent->addr, 0, false, 0);
         }
 
         my_dodag->my_preferred_parent = best;


### PR DESCRIPTION
This PR removes the usage of the `rpl_get_my_dodag()` function in `send_DAO()` and `send_DAO_ACK()`, by passing the corresponding dodag as a function parameter.
This way, these functions can be used for multiple dodags, instead only for the *default* dodag.