### PR TITLE
rpl: make send_DIO aware of multiple dodags

### DIFF
--- a/sys/net/include/rpl.h
+++ b/sys/net/include/rpl.h
@@ -91,14 +91,15 @@ uint8_t rpl_init(int if_id);
 void rpl_init_root(rpl_options_t *rpl_opts);
 
 /**
- * @brief Sends a DIO-message to a given destination
+ * @brief Sends a DIO-message to a given destination in a given dodag
  *
- * This function sends a DIO message to a given destination.
+ * This function sends a DIO message to a given destination in a given dodag.
  *
+ * @param[in] dodag             Dodag of the DIO-message.
  * @param[in] destination       IPv6-address of the destination of the DIO. Should be a direct neighbor.
  *
  */
-void rpl_send_DIO(ipv6_addr_t *destination);
+void rpl_send_DIO(rpl_dodag_t *dodag, ipv6_addr_t *destination);
 
 /**
  * @brief Sends a DAO-message to a given destination

--- a/sys/net/routing/rpl/rpl_control_messages.c
+++ b/sys/net/routing/rpl/rpl_control_messages.c
@@ -257,7 +257,7 @@ uint8_t rpl_is_root(void)
     return i_am_root;
 }
 
-void rpl_send_DIO(ipv6_addr_t *destination)
+void rpl_send_DIO(rpl_dodag_t *mydodag, ipv6_addr_t *destination)
 {
 #if ENABLE_DEBUG
 
@@ -266,10 +266,7 @@ void rpl_send_DIO(ipv6_addr_t *destination)
     }
 
 #endif
-    rpl_dodag_t *mydodag;
     icmp_send_buf = get_rpl_send_icmpv6_buf(ipv6_ext_hdr_len);
-
-    mydodag = rpl_get_my_dodag();
 
     if (mydodag == NULL) {
         DEBUGF("Error - trying to send DIO without being part of a dodag.\n");
@@ -936,7 +933,7 @@ void rpl_recv_DIS(void)
         }
     }
 
-    rpl_send_DIO(&ipv6_buf->srcaddr);
+    rpl_send_DIO(my_dodag, &ipv6_buf->srcaddr);
 
 }
 

--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -37,11 +37,10 @@ static rpl_parent_t parents[RPL_MAX_PARENTS];
 
 void rpl_trickle_send_dio(void *args)
 {
-    (void) args;
     ipv6_addr_t mcast;
 
     ipv6_addr_set_all_rpl_nodes_addr(&mcast);
-    rpl_send_DIO(&mcast);
+    rpl_send_DIO((rpl_dodag_t *) args, &mcast);
 }
 
 void rpl_instances_init(void)
@@ -110,6 +109,7 @@ rpl_dodag_t *rpl_new_dodag(uint8_t instanceid, ipv6_addr_t *dodagid)
             dodag->ack_received = true;
             dodag->dao_counter = 0;
             dodag->trickle.callback.func = &rpl_trickle_send_dio;
+            dodag->trickle.callback.args = dodag;
             memcpy(&dodag->dodag_id, dodagid, sizeof(*dodagid));
             return dodag;
         }


### PR DESCRIPTION
This PR removes the usage of the rpl_get_my_dodag() function in send_DIO(), by passing the corresponding dodag as a function parameter.
This way, `send_DIO()` can be used for multiple dodags, instead only for the default dodag.