### PR TITLE
rpl: remove some usages of rpl_get_my_dodag

### DIFF
--- a/sys/net/include/rpl/rpl_dodag.h
+++ b/sys/net/include/rpl/rpl_dodag.h
@@ -33,7 +33,7 @@ rpl_instance_t *rpl_new_instance(uint8_t instanceid);
 rpl_instance_t *rpl_get_instance(uint8_t instanceid);
 rpl_instance_t *rpl_get_my_instance(void);
 rpl_dodag_t *rpl_new_dodag(rpl_instance_t *inst, ipv6_addr_t *id);
-rpl_dodag_t *rpl_get_dodag(ipv6_addr_t *id);
+rpl_dodag_t *rpl_get_joined_dodag(uint8_t instanceid);
 rpl_dodag_t *rpl_get_my_dodag(void);
 void rpl_join_dodag(rpl_dodag_t *dodag, ipv6_addr_t *parent, uint16_t parent_rank);
 void rpl_del_dodag(rpl_dodag_t *dodag);

--- a/sys/net/routing/rpl/rpl_control_messages.c
+++ b/sys/net/routing/rpl/rpl_control_messages.c
@@ -666,7 +666,7 @@ void rpl_recv_DIO(void)
     }
 
     /* handle packet content... */
-    rpl_dodag_t *my_dodag = rpl_get_my_dodag();
+    rpl_dodag_t *my_dodag = rpl_get_joined_dodag(dio_inst->id);
 
     if (my_dodag == NULL) {
         if (!has_dodag_conf_opt) {
@@ -769,13 +769,6 @@ void rpl_recv_DIO(void)
 
 void rpl_recv_DAO(void)
 {
-    rpl_dodag_t *my_dodag = rpl_get_my_dodag();
-
-    if (my_dodag == NULL) {
-        DEBUG("[Error] got DAO although not a DODAG\n");
-        return;
-    }
-
 #if RPL_DEFAULT_MOP == RPL_MOP_NON_STORING_MODE
 
     if (!i_am_root) {
@@ -788,6 +781,13 @@ void rpl_recv_DAO(void)
     rpl_dao_buf = get_rpl_dao_buf();
     DEBUG("instance %04X ", rpl_dao_buf->rpl_instanceid);
     DEBUG("sequence %04X\n", rpl_dao_buf->dao_sequence);
+
+    rpl_dodag_t *my_dodag = rpl_get_joined_dodag(rpl_dao_buf->rpl_instanceid);
+
+    if (my_dodag == NULL) {
+        DEBUG("[Error] got DAO although not a DODAG\n");
+        return;
+    }
 
     int len = DAO_BASE_LEN;
     uint8_t increment_seq = 0;
@@ -941,13 +941,13 @@ void rpl_recv_DIS(void)
 
 void rpl_recv_DAO_ACK(void)
 {
-    rpl_dodag_t *my_dodag = rpl_get_my_dodag();
+    rpl_dao_ack_buf = get_rpl_dao_ack_buf();
+
+    rpl_dodag_t *my_dodag = rpl_get_joined_dodag(rpl_dao_ack_buf->rpl_instanceid);
 
     if (my_dodag == NULL) {
         return;
     }
-
-    rpl_dao_ack_buf = get_rpl_dao_ack_buf();
 
     if (rpl_dao_ack_buf->rpl_instanceid != my_dodag->instance->id) {
         return;

--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -116,10 +116,10 @@ rpl_dodag_t *rpl_new_dodag(rpl_instance_t *inst, ipv6_addr_t *dodagid)
 
 }
 
-rpl_dodag_t *rpl_get_dodag(ipv6_addr_t *id)
+rpl_dodag_t *rpl_get_joined_dodag(uint8_t instanceid)
 {
     for (int i = 0; i < RPL_MAX_DODAGS; i++) {
-        if (rpl_dodags[i].used && (rpl_equal_id(&rpl_dodags[i].dodag_id, id))) {
+        if (rpl_dodags[i].joined && rpl_dodags[i].instance->id == instanceid) {
             return &rpl_dodags[i];
         }
     }


### PR DESCRIPTION
The function `rpl_get_my_dodag()` is used throughout the rpl implementation, but has the disadvantage of tying the code to the *default* dodag. This and following PRs will gradually decrease the usage of `rpl_get_my_dodag()`.