### PR TITLE
ng_netif: cleanup array after remove

### DIFF
--- a/sys/net/crosslayer/ng_netif/ng_netif.c
+++ b/sys/net/crosslayer/ng_netif/ng_netif.c
@@ -60,7 +60,9 @@ int ng_netif_add(kernel_pid_t pid)
 
 void ng_netif_remove(kernel_pid_t pid)
 {
-    for (int i = 0; i < NG_NETIF_NUMOF; i++) {
+    int i;
+
+    for (i = 0; i < NG_NETIF_NUMOF; i++) {
         if (ifs[i] == pid) {
             ifs[i] = KERNEL_PID_UNDEF;
 
@@ -68,10 +70,15 @@ void ng_netif_remove(kernel_pid_t pid)
                 if_handler[j].remove(pid);
             }
 
-            return;
+            break;
         }
     }
 
+    for (; (i < (NG_NETIF_NUMOF - 1)) && (ifs[i + 1] != KERNEL_PID_UNDEF); i++) {
+        ifs[i] = ifs[i + 1];
+    }
+
+    ifs[i] = KERNEL_PID_UNDEF;  /* set in case of i == (NG_NETIF_NUMOF - 1) */
 }
 
 kernel_pid_t *ng_netif_get(size_t *size)

--- a/tests/unittests/tests-netif/Makefile.include
+++ b/tests/unittests/tests-netif/Makefile.include
@@ -1,1 +1,3 @@
 USEMODULE += ng_netif
+
+CFLAGS += -DNG_NETIF_NUMOF=3

--- a/tests/unittests/tests-netif/tests-netif.c
+++ b/tests/unittests/tests-netif/tests-netif.c
@@ -152,7 +152,7 @@ static void test_ng_netif_get__full(void)
         TEST_ASSERT_EQUAL_INT(0, ng_netif_add(TEST_UINT8 + i));
     }
 
-    ng_netif_get(&size);
+    TEST_ASSERT_NOT_NULL(ng_netif_get(&size));
     TEST_ASSERT_EQUAL_INT(NG_NETIF_NUMOF, size);
 }
 

--- a/tests/unittests/tests-netif/tests-netif.c
+++ b/tests/unittests/tests-netif/tests-netif.c
@@ -118,6 +118,32 @@ static void test_ng_netif_get__empty(void)
     TEST_ASSERT_EQUAL_INT(0, size);
 }
 
+/* takes one out of the middle of the netif list and checks if all interfaces
+ * are gotten regardless */
+static void test_ng_netif_get__success_3_minus_one(void)
+{
+    size_t size = TEST_UINT8;
+    kernel_pid_t *ifs;
+    int count = 0;
+
+    for (int i = 0; i < 3; i++) {
+        TEST_ASSERT_EQUAL_INT(0, ng_netif_add(TEST_UINT8 + i));
+    }
+
+    ng_netif_remove(TEST_UINT8 + 1);
+
+    ifs = ng_netif_get(&size);
+    TEST_ASSERT_EQUAL_INT(2, size);
+
+    for (size_t i = 0; i < size; i++) {
+        if ((ifs[i] == TEST_UINT8) || ifs[i] == (TEST_UINT8 + 2)) {
+            count++;
+        }
+    }
+
+    TEST_ASSERT_EQUAL_INT(size, count);
+}
+
 static void test_ng_netif_get__full(void)
 {
     size_t size = TEST_UINT8;
@@ -141,6 +167,7 @@ Test *tests_netif_tests(void)
         new_TestFixture(test_ng_netif_remove__not_an_if),
         new_TestFixture(test_ng_netif_remove__success),
         new_TestFixture(test_ng_netif_get__empty),
+        new_TestFixture(test_ng_netif_get__success_3_minus_one),
         new_TestFixture(test_ng_netif_get__full),
     };
 


### PR DESCRIPTION
Currently, if `ng_netif_get()` is called on the interface list, not all interfaces will be returned if `NG_NETIF_NUMOF > 1` and one of the entries before the last registered ones are removed. This fixes it by reordering the array after remove.