### PR TITLE
dist/tools/whitespacecheck: Do not redirect stdout.

### DIFF
--- a/dist/tools/whitespacecheck/check.sh
+++ b/dist/tools/whitespacecheck/check.sh
@@ -27,7 +27,7 @@ if [ -z "${BRANCH}" ]; then
     BRANCH=$(git rev-list HEAD | tail -n 1)
 fi
 
-git diff --check $(git merge-base ${BRANCH} HEAD) > /dev/null
+git diff --check $(git merge-base ${BRANCH} HEAD)
 if [ $? -gt 0 ]
 then
     echo "ERROR: This change introduces new whitespace errors"


### PR DESCRIPTION
Shows new whitespace errors in Travis log for easier code review. The command `git diff --check` only prints anything if there are any new whitespace errors, otherwise it will be silent as before the change.