### PR TITLE
rpl: check all dodags when receiving DIS messages

### DIFF
--- a/sys/net/routing/rpl/rpl_control_messages.c
+++ b/sys/net/routing/rpl/rpl_control_messages.c
@@ -874,15 +874,11 @@ void rpl_recv_DAO(void)
 
 void rpl_recv_DIS(void)
 {
-    rpl_dodag_t *my_dodag = rpl_get_my_dodag();
-
-    if (my_dodag == NULL) {
-        return;
-    }
-
     ipv6_buf = get_rpl_ipv6_buf();
     rpl_dis_buf = get_rpl_dis_buf();
     int len = DIS_BASE_LEN;
+    rpl_dodag_t *dodag, *end;
+    uint8_t options_missing = 1;
 
     while (len < (NTOHS(ipv6_buf->length) - ICMPV6_HDR_LEN)) {
         rpl_opt_buf = get_rpl_opt_buf(len);
@@ -899,6 +895,7 @@ void rpl_recv_DIS(void)
             }
 
             case (RPL_OPT_SOLICITED_INFO): {
+                options_missing = 0;
                 len += RPL_OPT_SOLICITED_INFO_LEN;
 
                 /* extract and check */
@@ -909,21 +906,28 @@ void rpl_recv_DIS(void)
 
                 rpl_opt_solicited_buf = get_rpl_opt_solicited_buf(len);
 
-                if (rpl_opt_solicited_buf->VID_Flags & RPL_DIS_I_MASK) {
-                    if (my_dodag->instance->id != rpl_opt_solicited_buf->rplinstanceid) {
-                        return;
-                    }
-                }
+                for (dodag = rpl_dodags, end = dodag + RPL_MAX_DODAGS; dodag < end; dodag++) {
+                    if (dodag->joined) {
+                        if (rpl_opt_solicited_buf->VID_Flags & RPL_DIS_I_MASK) {
+                            if (dodag->instance->id != rpl_opt_solicited_buf->rplinstanceid) {
+                                continue;
+                            }
+                        }
 
-                if (rpl_opt_solicited_buf->VID_Flags & RPL_DIS_D_MASK) {
-                    if (!rpl_equal_id(&my_dodag->dodag_id, &rpl_opt_solicited_buf->dodagid)) {
-                        return;
-                    }
-                }
+                        if (rpl_opt_solicited_buf->VID_Flags & RPL_DIS_D_MASK) {
+                            if (!rpl_equal_id(&dodag->dodag_id, &rpl_opt_solicited_buf->dodagid)) {
+                                continue;
+                            }
+                        }
 
-                if (rpl_opt_solicited_buf->VID_Flags & RPL_DIS_V_MASK) {
-                    if (my_dodag->version != rpl_opt_solicited_buf->version) {
-                        return;
+                        if (rpl_opt_solicited_buf->VID_Flags & RPL_DIS_V_MASK) {
+                            if (dodag->version != rpl_opt_solicited_buf->version) {
+                                continue;
+                            }
+                        }
+
+                        rpl_send_DIO(dodag, &ipv6_buf->srcaddr);
+                        trickle_reset_timer(&dodag->trickle);
                     }
                 }
 
@@ -935,8 +939,14 @@ void rpl_recv_DIS(void)
         }
     }
 
-    rpl_send_DIO(my_dodag, &ipv6_buf->srcaddr);
-
+    if (options_missing) {
+        for (dodag = rpl_dodags, end = dodag + RPL_MAX_DODAGS; dodag < end; dodag++) {
+            if (dodag->joined) {
+                rpl_send_DIO(dodag, &ipv6_buf->srcaddr);
+                trickle_reset_timer(&dodag->trickle);
+            }
+        }
+    }
 }
 
 void rpl_recv_DAO_ACK(void)


### PR DESCRIPTION
This PR removes the call to the function `rpl_get_my_dodag()` in `rpl_recv_DIS()` and iterates over all dodags instead. When options are included in the *DIS*, a *DIO* will be sent out for each dodag matching the criteria.

based on #2609  and #2622 