### PR TITLE
net: introduced ng_netbase pseudo module and header

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -52,9 +52,10 @@ ifneq (,$(filter ng_ipv6_nc,$(USEMODULE)))
   USEMODULE += ng_ipv6_addr
 endif
 
-ifneq (,$(filter ng_netif,$(USEMODULE)))
+ifneq (,$(filter ng_netbase,$(USEMODULE)))
   USEMODULE += ng_netapi
   USEMODULE += ng_netreg
+  USEMODULE += ng_netif
   USEMODULE += ng_pktbuf
 endif
 

--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -1,3 +1,4 @@
 PSEUDOMODULES += defaulttransceiver
 PSEUDOMODULES += transport_layer
 PSEUDOMODULES += pktqueue
+PSEUDOMODULES += ng_netbase

--- a/sys/include/net/ng_netbase.h
+++ b/sys/include/net/ng_netbase.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_ng_netbase  Network Stack Pseudo Header
+ * @ingroup     net
+ * @{
+ *
+ * @file
+ * @brief       Pseudo header that includes all network stack base modules
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef NG_NETBASE_H_
+#define NG_NETBASE_H_
+
+#include "net/ng_netdev.h"
+#include "net/ng_netapi.h"
+#include "net/ng_netconf.h"
+#include "net/ng_netreg.h"
+#include "net/ng_nettype.h"
+#include "net/ng_netif.h"
+#include "net/ng_pktbuf.h"
+#include "net/ng_pkt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* this file does not provide anything on it's own */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NG_NETBASE_H_ */
+/** @} */

--- a/sys/include/net/ng_netdev.h
+++ b/sys/include/net/ng_netdev.h
@@ -26,6 +26,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "kernel.h"
 #include "net/ng_pkt.h"
 #include "net/ng_netconf.h"
 

--- a/sys/net/crosslayer/ng_netreg/ng_netreg.c
+++ b/sys/net/crosslayer/ng_netreg/ng_netreg.c
@@ -16,9 +16,9 @@
 #include <string.h>
 
 #include "clist.h"
+#include "utlist.h"
 #include "net/ng_netreg.h"
 #include "net/ng_nettype.h"
-#include "utlist.h"
 
 #define _INVALID_TYPE(type) (((type) <= NG_NETTYPE_UNDEF) || ((type) >= NG_NETTYPE_NUMOF))
 

--- a/sys/net/crosslayer/ng_pktbuf/ng_pktbuf.c
+++ b/sys/net/crosslayer/ng_pktbuf/ng_pktbuf.c
@@ -23,11 +23,10 @@
 
 #include "clist.h"
 #include "mutex.h"
+#include "utlist.h"
+#include "net/ng_pktbuf.h"
 #include "net/ng_nettype.h"
 #include "net/ng_pkt.h"
-#include "utlist.h"
-
-#include "net/ng_pktbuf.h"
 
 #include "_pktbuf_internal.h"
 

--- a/sys/net/link_layer/ng_nomac/ng_nomac.c
+++ b/sys/net/link_layer/ng_nomac/ng_nomac.c
@@ -22,13 +22,7 @@
 #include "msg.h"
 #include "thread.h"
 #include "net/ng_nomac.h"
-#include "net/ng_netreg.h"
-#include "net/ng_pkt.h"
-#include "net/ng_nettype.h"
-#include "net/ng_netdev.h"
-#include "net/ng_netapi.h"
-#include "net/ng_netif.h"
-#include "net/ng_pktbuf.h"
+#include "net/ng_netbase.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"


### PR DESCRIPTION
With this PR it is possible to pull up all network stack functionality, so that the link layer is functional and the upper layer protocols have everything they need as a base. This PR is further the base of my follow-up PR regarding the network stack initialization -> this will come later tonight...