### PR TITLE
dist: Makefile to work with IoT-LAB

### DIFF
--- a/dist/testbed-support/Makefile.iot-lab
+++ b/dist/testbed-support/Makefile.iot-lab
@@ -1,0 +1,26 @@
+.PHONY: iotlab-auth iotlab-exp iotlab-flash iotlab-reset iotlab-term
+
+IOTLAB_NODES    ?= 5
+IOTLAB_DURATION ?= 30
+IOTLAB_SITE     ?= grenoble
+IOTLAB_TYPE     ?= "m3:at86rf231"
+IOTLAB_AUTH     ?= $(HOME)/.iotlabrc
+IOTLAB_USER     ?= $(shell cut -f1 -d: $(IOTLAB_AUTH))
+IOTLAB_EXP_ID   ?= $(shell experiment-cli get -l --state Running | grep '"id"' | sed 's/\ *"id":\ \([0-9]*\),/\1/' | head -n1)
+
+$(IOTLAB_AUTH):
+	auth-cli -u $(IOTLAB_USER)
+
+iotlab-exp: $(IOTLAB_AUTH)
+	experiment-cli submit -d $(IOTLAB_DURATION) -l $(IOTLAB_NODES),archi=$(IOTLAB_TYPE)+site=$(IOTLAB_SITE),$(ELFFILE) -n riot_makefile_experiment
+	experiment-cli wait
+
+iotlab-flash: $(IOTLAB_AUTH) all
+	node-cli --update $(ELFFILE) -i $(IOTLAB_EXP_ID)
+
+iotlab-reset: $(IOTLAB_AUTH)
+	node-cli --reset -i $(IOTLAB_EXP_ID)
+
+iotlab-term:
+	ssh -t $(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info "test -f ~/.iotlabrc || auth-cli -u $(IOTLAB_USER)"
+	ssh $(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info serial_aggregator

--- a/dist/testbed-support/README.iotlab
+++ b/dist/testbed-support/README.iotlab
@@ -1,0 +1,67 @@
+# RIOT integration into IoT-LAB
+
+Check the Wiki to see how to build and run RIOT on FIT IoT-LAB:
+https://github.com/iot-lab/iot-lab/wiki/Riot-support
+
+## Control IoT-LAB via Make
+
+### Requirements
+
+This feature requires to have a valid account for the FIT IoT-LAB
+(registration there is open for everyone) and the
+[iot-lab/cli-tools](https://github.com/iot-lab/cli-tools) to be installed.
+
+### Description
+
+The folder `dist/testbed-support/` contains a `Makefile.iotlab` that defines
+some targets to control RIOT experiments on IoT-LAB using the GNU Make build
+system. In order to use this, one has to include this Makefile at the end of
+the application's Makefile, like this:
+```
+include $(RIOTBASE)/dist/testbed-support/Makefile.iot-lab
+```
+### Variables
+
+This Makefile introduces some additional variables (default values in
+brackets):
+ * IOTLAB_NODES (5)
+ * IOTLAB_DURATION (30 minutes)
+ * IOTLAB_SITE (grenoble.iot-lab.info)
+ * IOTLAB_TYPE (m3:at86rf231)
+ * IOTLAB_AUTH ($HOME/.iotlabrc)
+ * IOTLAB_USER (taken from $IOTLAB_AUTH)
+ * IOTLAB_EXP_ID (taken from first experiment in running state)
+
+### Targets
+
+It defines the following targets:
+ * iotlab-exp
+ * iotlab-flash
+ * iotlab-reset
+ * iotlab-term
+
+**Please note:** All targets that require an already running experiment will
+use the first experiment of the user that has already entered state "Running"
+if `IOTLAB_EXP_ID` is not set.
+
+#### iotlab-exp
+
+This schedules a new experiment on the FIT IoT-LAB and waits until it enters
+"Running" state. It will request `IOTLAB_NODES` nodes of type `IOTLAB_TYPE`
+for `IOTLAB_DURATION` minutes at site `IOTLAB_SITE`. It will also flash the
+binary of the current application to all registered nodes. The name of the
+experiment is set to "riot_makefile_experiment"
+
+#### iotlab-flash
+
+This target updates the application on all registered nodes of the given
+experiment to the current version of the application.
+
+#### iotlab-reset
+
+This target resets all registered nodes of the given experiment.
+
+#### iotlab-term
+
+Uses ssh to login the user on the IoT-LAB server of the specified site and
+start the `serial_aggregator` to communication with all registered nodes.


### PR DESCRIPTION
Introduces a Makefile that can be included into one's application Makefile in order to remotely control experiments on the IoT-LAB testbed. It requires that cli-tools (https://github.com/iot-lab/cli-tools) are installed.