### PR TITLE
rpl: pass dodag to the rpl_find_parent function

### DIFF
--- a/sys/net/include/rpl/rpl_dodag.h
+++ b/sys/net/include/rpl/rpl_dodag.h
@@ -38,7 +38,7 @@ rpl_dodag_t *rpl_get_my_dodag(void);
 void rpl_join_dodag(rpl_dodag_t *dodag, ipv6_addr_t *parent, uint16_t parent_rank);
 void rpl_del_dodag(rpl_dodag_t *dodag);
 rpl_parent_t *rpl_new_parent(rpl_dodag_t *dodag, ipv6_addr_t *address, uint16_t rank);
-rpl_parent_t *rpl_find_parent(ipv6_addr_t *address);
+rpl_parent_t *rpl_find_parent(rpl_dodag_t *dodag, ipv6_addr_t *address);
 void rpl_leave_dodag(rpl_dodag_t *dodag);
 bool rpl_equal_id(ipv6_addr_t *id1, ipv6_addr_t *id2);
 ipv6_addr_t *rpl_get_my_preferred_parent(void);

--- a/sys/net/routing/rpl/rpl_control_messages.c
+++ b/sys/net/routing/rpl/rpl_control_messages.c
@@ -736,7 +736,7 @@ void rpl_recv_DIO(void)
     /*********************  Parent Handling *********************/
 
     rpl_parent_t *parent;
-    parent = rpl_find_parent(&ipv6_buf->srcaddr);
+    parent = rpl_find_parent(my_dodag, &ipv6_buf->srcaddr);
 
     if (parent == NULL) {
         /* add new parent candidate */

--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -188,13 +188,16 @@ rpl_parent_t *rpl_new_parent(rpl_dodag_t *dodag, ipv6_addr_t *address, uint16_t 
     return rpl_new_parent(dodag, address, rank);
 }
 
-rpl_parent_t *rpl_find_parent(ipv6_addr_t *address)
+rpl_parent_t *rpl_find_parent(rpl_dodag_t *dodag, ipv6_addr_t *address)
 {
     rpl_parent_t *parent;
     rpl_parent_t *end;
 
     for (parent = &parents[0], end = parents + RPL_MAX_PARENTS; parent < end; parent++) {
-        if ((parent->used) && (rpl_equal_id(address, &parent->addr))) {
+        if ((parent->used) && (rpl_equal_id(address, &parent->addr)
+                    && (parent->dodag->instance->id == dodag->instance->id)
+                    && (!memcmp(&parent->dodag->dodag_id,
+                        &dodag->dodag_id, sizeof(ipv6_addr_t))))) {
             return parent;
         }
     }


### PR DESCRIPTION
This PR extends the condition to find a parent by checking if it belongs to the dodag. Otherwise, the function could return a parent belonging to another dodag.