### PR TITLE
travis: cache pkg directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: c
 
-cache: apt
+cache:
+    - apt
+    - directories:
+        - pkg
 
 env:
     - NPROC_MAX=8 BUILDTEST_MCU_GROUP=static-tests


### PR DESCRIPTION
I hope build failures will decrease through this, since we will be less dependent on the upstream reposititories of our packages for testing.