### PR TITLE
rpl: remove get_my_dodag dependency by passing the dodag as parameter

### DIFF
--- a/sys/net/include/rpl/rpl_dodag.h
+++ b/sys/net/include/rpl/rpl_dodag.h
@@ -45,10 +45,10 @@ ipv6_addr_t *rpl_get_my_preferred_parent(void);
 void rpl_delete_parent(rpl_parent_t *parent);
 void rpl_delete_worst_parent(void);
 void rpl_delete_all_parents(void);
-rpl_parent_t *rpl_find_preferred_parent(void);
-void rpl_parent_update(rpl_parent_t *parent);
+rpl_parent_t *rpl_find_preferred_parent(rpl_dodag_t *dodag);
+void rpl_parent_update(rpl_dodag_t *dodag, rpl_parent_t *parent);
 void rpl_global_repair(rpl_dodag_t *dodag, ipv6_addr_t *p_addr, uint16_t rank);
-void rpl_local_repair(void);
+void rpl_local_repair(rpl_dodag_t *dodag);
 uint16_t rpl_calc_rank(uint16_t abs_rank, uint16_t minhoprankincrease);
 
 #ifdef __cplusplus

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -299,7 +299,7 @@ void _rpl_update_routing_table(void)
         if (my_dodag->my_preferred_parent != NULL) {
             if (my_dodag->my_preferred_parent->lifetime <= 1) {
                 DEBUGF("parent lifetime timeout\n");
-                rpl_parent_update(NULL);
+                rpl_parent_update(my_dodag, NULL);
             }
             else {
                 my_dodag->my_preferred_parent->lifetime =

--- a/sys/net/routing/rpl/rpl_control_messages.c
+++ b/sys/net/routing/rpl/rpl_control_messages.c
@@ -707,7 +707,8 @@ void rpl_recv_DIO(void)
             }
             else {
                 DEBUGF("my dodag has no preferred_parent yet - seems to be odd since I have a parent.\n");
-                rpl_global_repair(&dio_dodag, &ipv6_buf->srcaddr, byteorder_ntohs(rpl_dio_buf->rank));
+                my_dodag->version = dio_dodag.version;
+                rpl_global_repair(my_dodag, &ipv6_buf->srcaddr, byteorder_ntohs(rpl_dio_buf->rank));
             }
 
             return;
@@ -753,7 +754,7 @@ void rpl_recv_DIO(void)
 
     /* update parent rank */
     parent->rank = byteorder_ntohs(rpl_dio_buf->rank);
-    rpl_parent_update(parent);
+    rpl_parent_update(my_dodag, parent);
 
     if (my_dodag->my_preferred_parent == NULL) {
         DEBUGF("My dodag has no preferred_parent yet - seems to be odd since I have a parent...\n");


### PR DESCRIPTION
This PR removes further dependencies to `rpl_get_my_dodag()` by passing the dodag as a function poiner.