### PR TITLE
 Repaired header file include guards in boards directory #2623

### DIFF
--- a/boards/airfy-beacon/include/board.h
+++ b/boards/airfy-beacon/include/board.h
@@ -18,8 +18,8 @@
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "cpu.h"
 
@@ -67,5 +67,5 @@ void board_init(void);
 } /* end extern "C" */
 #endif
 
-#endif /** __BOARD_H */
+#endif /** BOARD_H */
 /** @} */

--- a/boards/airfy-beacon/include/periph_conf.h
+++ b/boards/airfy-beacon/include/periph_conf.h
@@ -17,8 +17,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -155,4 +155,4 @@
 } /* end extern "C" */
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */

--- a/boards/arduino-due/include/board.h
+++ b/boards/arduino-due/include/board.h
@@ -18,8 +18,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "cpu.h"
 
@@ -80,5 +80,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** __BOARD_H */
+#endif /** BOARD_H */
 /** @} */

--- a/boards/arduino-due/include/periph_conf.h
+++ b/boards/arduino-due/include/periph_conf.h
@@ -17,8 +17,8 @@
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -250,5 +250,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/arduino-mega2560/include/board.h
+++ b/boards/arduino-mega2560/include/board.h
@@ -18,8 +18,8 @@
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "cpu.h"
 
@@ -83,5 +83,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** __BOARD_H */
+#endif /** BOARD_H */
 /** @} */

--- a/boards/arduino-mega2560/include/periph_conf.h
+++ b/boards/arduino-mega2560/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -286,4 +286,4 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */

--- a/boards/avsextrem/include/periph_conf.h
+++ b/boards/avsextrem/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #include "lpc2387.h"
 
@@ -54,5 +54,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/avsextrem/include/ssp0-board.h
+++ b/boards/avsextrem/include/ssp0-board.h
@@ -19,8 +19,8 @@
  *
  * @note        $Id:  avsextrem-ssp0.c  3854 2010-01-18 15:27:01Z zkasmi $
  */
-#ifndef __SSP_H__
-#define __SSP_H__
+#ifndef SSP_H__
+#define SSP_H__
 
 #include "stdint.h"
 
@@ -122,4 +122,4 @@ void SSP0Handler(void);
 }
 #endif
 
-#endif  /* __SSP_H__ */
+#endif  /* SSP_H__ */

--- a/boards/cc2538dk/include/board.h
+++ b/boards/cc2538dk/include/board.h
@@ -17,8 +17,8 @@
  * @author      Ian Martin <ian@locicontrols.com>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "cpu.h"
 #include "periph/gpio.h"
@@ -100,5 +100,5 @@ void board_init(void);
 } /* end extern "C" */
 #endif
 
-#endif /** __BOARD_H */
+#endif /** BOARD_H */
 /** @} */

--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Ian Martin <ian@locicontrols.com>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #include "gptimer.h"
 
@@ -192,5 +192,5 @@ extern "C" {
 } /* end extern "C" */
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/chronos/drivers/include/display.h
+++ b/boards/chronos/drivers/include/display.h
@@ -35,8 +35,8 @@
  * Basic display functions.
  * ************************************************************************************************/
 
-#ifndef __DISPLAY_H
-#define __DISPLAY_H
+#ifndef DISPLAY_H
+#define DISPLAY_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/chronos/drivers/include/display_putchar.h
+++ b/boards/chronos/drivers/include/display_putchar.h
@@ -6,8 +6,8 @@
  * directory for more details.
  */
 
-#ifndef __DISPLAY_PUTCHAR_H
-#define __DISPLAY_PUTCHAR_H
+#ifndef DISPLAY_PUTCHAR_H
+#define DISPLAY_PUTCHAR_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,4 +19,4 @@ void init_display_putchar(void);
 }
 #endif
 
-#endif /* __DISPLAY_PUTCHAR_H */
+#endif /* DISPLAY_PUTCHAR_H */

--- a/boards/chronos/include/board.h
+++ b/boards/chronos/include/board.h
@@ -18,8 +18,8 @@
  * @author      unknwon
  */
 
-#ifndef _CHRONOS_BOARD_H
-#define _CHRONOS_BOARD_H
+#ifndef CHRONOS_BOARD_H
+#define CHRONOS_BOARD_H
 
 #include <stdint.h>
 
@@ -28,8 +28,8 @@ extern "C" {
 #endif
 
 // for correct inclusion of <msp430.h>
-#ifndef __CC430F6137__
-#define __CC430F6137__
+#ifndef CC430F6137__
+#define CC430F6137__
 #endif
 
 #define MSP430_INITIAL_CPU_SPEED    7372800uL
@@ -44,5 +44,5 @@ typedef uint8_t radio_packet_length_t;
 }
 #endif
 
-#endif /* _CHRONOS_BOARD_H */
+#endif /* CHRONOS_BOARD_H */
 /** @} */

--- a/boards/f4vi1/include/board.h
+++ b/boards/f4vi1/include/board.h
@@ -19,8 +19,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "cpu.h"
 #include "periph_conf.h"
@@ -94,5 +94,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** __BOARD_H */
+#endif /** BOARD_H */
 /** @} */

--- a/boards/f4vi1/include/periph_conf.h
+++ b/boards/f4vi1/include/periph_conf.h
@@ -18,8 +18,8 @@
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -99,5 +99,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -304,5 +304,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/iot-lab_M3/include/periph_conf.h
+++ b/boards/iot-lab_M3/include/periph_conf.h
@@ -17,8 +17,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -319,5 +319,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/mbed_lpc1768/include/board.h
+++ b/boards/mbed_lpc1768/include/board.h
@@ -20,8 +20,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include <stdint.h>
 
@@ -102,5 +102,5 @@ void board_init(void);
 }
 #endif
 
-#endif /* __BOARD_H */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/mbed_lpc1768/include/periph_conf.h
+++ b/boards/mbed_lpc1768/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -89,5 +89,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/mbed_lpc1768/system.c
+++ b/boards/mbed_lpc1768/system.c
@@ -382,34 +382,34 @@
 
 
 /* F_cco0 = (2 * M * F_in) / N  */
-#define __M               (((PLL0CFG_Val      ) & 0x7FFF) + 1)
-#define __N               (((PLL0CFG_Val >> 16) & 0x00FF) + 1)
-#define __FCCO(__F_IN)    ((2ULL * __M * __F_IN) / __N)
-#define __CCLK_DIV        (((CCLKCFG_Val      ) & 0x00FF) + 1)
+#define M               (((PLL0CFG_Val      ) & 0x7FFF) + 1)
+#define N               (((PLL0CFG_Val >> 16) & 0x00FF) + 1)
+#define FCCO(__F_IN)    ((2ULL * M * __F_IN) / N)
+#define CCLK_DIV        (((CCLKCFG_Val      ) & 0x00FF) + 1)
 
 /* Determine core clock frequency according to settings */
 #if (PLL0_SETUP)
 #if   ((CLKSRCSEL_Val & 0x03) == 1)
-#define __CORE_CLK (__FCCO(OSC_CLK) / __CCLK_DIV)
+#define CORE_CLK (__FCCO(OSC_CLK) / CCLK_DIV)
 #elif ((CLKSRCSEL_Val & 0x03) == 2)
-#define __CORE_CLK (__FCCO(RTC_CLK) / __CCLK_DIV)
+#define CORE_CLK (__FCCO(RTC_CLK) / CCLK_DIV)
 #else
-#define __CORE_CLK (__FCCO(IRC_OSC) / __CCLK_DIV)
+#define CORE_CLK (__FCCO(IRC_OSC) / CCLK_DIV)
 #endif
 #else
 #if   ((CLKSRCSEL_Val & 0x03) == 1)
-#define __CORE_CLK (OSC_CLK         / __CCLK_DIV)
+#define CORE_CLK (OSC_CLK         / CCLK_DIV)
 #elif ((CLKSRCSEL_Val & 0x03) == 2)
-#define __CORE_CLK (RTC_CLK         / __CCLK_DIV)
+#define CORE_CLK (RTC_CLK         / CCLK_DIV)
 #else
-#define __CORE_CLK (IRC_OSC         / __CCLK_DIV)
+#define CORE_CLK (IRC_OSC         / CCLK_DIV)
 #endif
 #endif
 
 /*----------------------------------------------------------------------------
   Clock Variable definitions
  *----------------------------------------------------------------------------*/
-uint32_t system_clock = __CORE_CLK;/*!< System Clock Frequency (Core Clock)*/
+uint32_t system_clock = CORE_CLK;/*!< System Clock Frequency (Core Clock)*/
 
 
 /*----------------------------------------------------------------------------

--- a/boards/msb-430/include/board.h
+++ b/boards/msb-430/include/board.h
@@ -23,8 +23,8 @@
  * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
  */
 
-#ifndef _MSB_BOARD_H
-#define _MSB_BOARD_H
+#ifndef MSB_BOARD_H
+#define MSB_BOARD_H
 
 #include "board-conf.h"
 
@@ -33,8 +33,8 @@ extern "C" {
 #endif
 
 // for correct inclusion of <msp430.h>
-#ifndef __MSP430F1612__
-#define __MSP430F1612__
+#ifndef MSP430F1612__
+#define MSP430F1612__
 #endif
 
 //MSB430 core
@@ -64,4 +64,4 @@ extern "C" {
 typedef uint8_t radio_packet_length_t;
 
 /** @} */
-#endif // _MSB_BOARD_H
+#endif // MSB_BOARD_H

--- a/boards/msb-430h/include/board.h
+++ b/boards/msb-430h/include/board.h
@@ -18,16 +18,16 @@
  * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
  */
 
-#ifndef _MSB_BOARD_H
-#define _MSB_BOARD_H
+#ifndef MSB_BOARD_H
+#define MSB_BOARD_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 // for correct inclusion of <msp430.h>
-#ifndef __MSP430F1612__
-#define __MSP430F1612__
+#ifndef MSP430F1612__
+#define MSP430F1612__
 #endif
 
 //MSB430 core
@@ -57,4 +57,4 @@ extern "C" {
 typedef uint8_t radio_packet_length_t;
 
 /** @} */
-#endif // _MSB_BOARD_H
+#endif // MSB_BOARD_H

--- a/boards/msba2-common/drivers/include/uart0.h
+++ b/boards/msba2-common/drivers/include/uart0.h
@@ -6,8 +6,8 @@
  * directory for more details.
  */
 
-#ifndef __UART0_H
-#define __UART0_H
+#ifndef UART0_H
+#define UART0_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,4 +19,4 @@ extern kernel_pid_t uart0_handler_pid;
 }
 #endif
 
-#endif /* __UART0_H */
+#endif /* UART0_H */

--- a/boards/msba2-common/include/msba2_common.h
+++ b/boards/msba2-common/include/msba2_common.h
@@ -17,8 +17,8 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-#ifndef __MSBA2_COMMON_H
-#define __MSBA2_COMMON_H
+#ifndef MSBA2_COMMON_H
+#define MSBA2_COMMON_H
 
 
 #include <stdint.h>
@@ -41,4 +41,4 @@ static inline void pllfeed(void)
 #endif
 
 /** @} */
-#endif // __MSBA2_COMMON_H
+#endif // MSBA2_COMMON_H

--- a/boards/msba2-common/tools/src/serial.c
+++ b/boards/msba2-common/tools/src/serial.c
@@ -355,7 +355,7 @@ int set_baud(const char *baud_name)
         return -3;
     }
 
-#ifdef __APPLE__
+#ifdef APPLE__
     cfsetspeed(&port_setting, baud);
     port_setting.c_iflag = IGNBRK | IGNPAR;
     port_setting.c_cflag =  CS8 | CREAD | HUPCL | CLOCAL;

--- a/boards/msba2/include/board.h
+++ b/boards/msba2/include/board.h
@@ -18,8 +18,8 @@
  * @author      unknown
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "msba2_common.h"
 #include "bitarithm.h"
@@ -47,5 +47,5 @@ typedef uint8_t radio_packet_length_t;
 }
 #endif
 
-#endif /* __BOARD_H */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/msba2/include/periph_conf.h
+++ b/boards/msba2/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #include "lpc2387.h"
 
@@ -55,5 +55,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -18,8 +18,8 @@
  * @author      Fabian Nack <nack@inf.fu-berlin.de>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "cpu.h"
 #include "periph_conf.h"
@@ -105,5 +105,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** __BOARD_H */
+#endif /** BOARD_H */
 /** @} */

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Fabian Nack <nack@inf.fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -395,5 +395,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/nucleo-f091/include/periph_conf.h
+++ b/boards/nucleo-f091/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -161,5 +161,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/nucleo-f334/include/periph_conf.h
+++ b/boards/nucleo-f334/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -82,5 +82,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/nucleo-l1/include/periph_conf.h
+++ b/boards/nucleo-l1/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -288,5 +288,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/openmote/include/board.h
+++ b/boards/openmote/include/board.h
@@ -18,8 +18,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "cpu.h"
 #include "periph/gpio.h"
@@ -88,5 +88,5 @@ void board_init(void);
 } /* end extern "C" */
 #endif
 
-#endif /** __BOARD_H */
+#endif /** BOARD_H */
 /** @} */

--- a/boards/openmote/include/periph_conf.h
+++ b/boards/openmote/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -175,5 +175,5 @@
 } /* end extern "C" */
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/pca10000/include/board.h
+++ b/boards/pca10000/include/board.h
@@ -19,8 +19,8 @@
  * @author      Timo Ziegler <timo.ziegler@fu-berlin.de>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "cpu.h"
 
@@ -82,5 +82,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** __BOARD_H */
+#endif /** BOARD_H */
 /** @} */

--- a/boards/pca10000/include/periph_conf.h
+++ b/boards/pca10000/include/periph_conf.h
@@ -18,8 +18,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -157,4 +157,4 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */

--- a/boards/pca10005/include/board.h
+++ b/boards/pca10005/include/board.h
@@ -19,8 +19,8 @@
  * @author      Timo Ziegler <timo.ziegler@fu-berlin.de>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "cpu.h"
 
@@ -73,5 +73,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** __BOARD_H */
+#endif /** BOARD_H */
 /** @} */

--- a/boards/pca10005/include/periph_conf.h
+++ b/boards/pca10005/include/periph_conf.h
@@ -18,8 +18,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -154,4 +154,4 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */

--- a/boards/pttu/include/board.h
+++ b/boards/pttu/include/board.h
@@ -18,8 +18,8 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include <stdint.h>
 
@@ -43,4 +43,4 @@ typedef uint8_t radio_packet_length_t;
 #endif
 
 /** @} */
-#endif // __BOARD_H
+#endif // BOARD_H

--- a/boards/pttu/include/periph_conf.h
+++ b/boards/pttu/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #include "lpc2387.h"
 
@@ -54,5 +54,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/qemu-i386/include/board.h
+++ b/boards/qemu-i386/include/board.h
@@ -18,8 +18,8 @@
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef __RIOT__BOARDS__QEMU_I386__BOARD__H
-#define __RIOT__BOARDS__QEMU_I386__BOARD__H
+#ifndef RIOT__BOARDS__QEMU_I386__BOARD__H
+#define RIOT__BOARDS__QEMU_I386__BOARD__H
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/qemu-i386/include/cpu-conf.h
+++ b/boards/qemu-i386/include/cpu-conf.h
@@ -16,8 +16,8 @@
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef __RIOT__BOARDS__QEMU_I386__CPU_CONF__H
-#define __RIOT__BOARDS__QEMU_I386__CPU_CONF__H
+#ifndef RIOT__BOARDS__QEMU_I386__CPU_CONF__H
+#define RIOT__BOARDS__QEMU_I386__CPU_CONF__H
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/redbee-econotag/tools/ftditools/bbmc.c
+++ b/boards/redbee-econotag/tools/ftditools/bbmc.c
@@ -160,7 +160,7 @@ struct layout *find_layout(char *str)
 static uint32_t vendid = 0x0403;
 uint32_t prodid = 0x6010;
 
-#if __APPLE__
+#if APPLE__
 static void restore_ftdi_kext(void)
 {
     system("sudo kextload /System/Library/Extensions/FTDIUSBSerialDriver.kext");
@@ -337,7 +337,7 @@ int main(int argc, char **argv)
                    NULL,
                    NULL,
                    dev_index)) < 0) {
-#if __APPLE__
+#if APPLE__
 
         if ((ret == -5) && (0 == system("sudo kextunload /System/Library/Extensions/FTDIUSBSerialDriver.kext"))) {
             // Try again without the FTDI kext loaded this time
@@ -353,7 +353,7 @@ int main(int argc, char **argv)
         }
 
         if (ret)
-#endif // __APPLE__
+#endif // APPLE__
         {
             fprintf(stderr, "couldn't open dev_index %d, err %d (%s)\n", dev_index, ret, ftdi_get_error_string(&ftdic));
             return EXIT_FAILURE;

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -18,8 +18,8 @@
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "cpu.h"
 
@@ -100,5 +100,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** __BOARD_H */
+#endif /** BOARD_H */
 /** @} */

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -249,5 +249,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/spark-core/include/periph_conf.h
+++ b/boards/spark-core/include/periph_conf.h
@@ -15,8 +15,8 @@
  *
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
  */
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -253,5 +253,5 @@
 } /* end extern "C" */
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/stm32f0discovery/include/board.h
+++ b/boards/stm32f0discovery/include/board.h
@@ -18,8 +18,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "cpu.h"
 
@@ -82,5 +82,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** __BOARD_H */
+#endif /** BOARD_H */
 /** @} */

--- a/boards/stm32f0discovery/include/periph_conf.h
+++ b/boards/stm32f0discovery/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -276,4 +276,4 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */

--- a/boards/stm32f3discovery/include/board.h
+++ b/boards/stm32f3discovery/include/board.h
@@ -18,8 +18,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "cpu.h"
 
@@ -107,5 +107,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** __BOARD_H */
+#endif /** BOARD_H */
 /** @} */

--- a/boards/stm32f3discovery/include/periph_conf.h
+++ b/boards/stm32f3discovery/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -325,4 +325,4 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */

--- a/boards/stm32f4discovery/include/board.h
+++ b/boards/stm32f4discovery/include/board.h
@@ -18,8 +18,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "cpu.h"
 #include "periph_conf.h"
@@ -93,5 +93,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** __BOARD_H */
+#endif /** BOARD_H */
 /** @} */

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -17,8 +17,8 @@
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -409,5 +409,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/telosb/include/board.h
+++ b/boards/telosb/include/board.h
@@ -23,16 +23,16 @@
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  */
 
-#ifndef _TELOSB_BOARD_H
-#define _TELOSB_BOARD_H
+#ifndef TELOSB_BOARD_H
+#define TELOSB_BOARD_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 // for correct inclusion of <msp430.h>
-#ifndef __MSP430F1611__
-#define __MSP430F1611__
+#ifndef MSP430F1611__
+#define MSP430F1611__
 #endif
 
 //TelosB core
@@ -70,4 +70,4 @@ extern "C" {
 typedef uint8_t radio_packet_length_t;
 
 /** @} */
-#endif // _TELOSB_BOARD_H
+#endif // TELOSB_BOARD_H

--- a/boards/udoo/include/board.h
+++ b/boards/udoo/include/board.h
@@ -18,8 +18,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "cpu.h"
 #include "cpu-conf.h"
@@ -82,5 +82,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** __BOARD_H */
+#endif /** BOARD_H */
 /** @} */

--- a/boards/udoo/include/periph_conf.h
+++ b/boards/udoo/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -251,5 +251,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/wsn430-v1_3b/include/board.h
+++ b/boards/wsn430-v1_3b/include/board.h
@@ -23,8 +23,8 @@
  * @author      Milan Babel <babel@inf.fu-berlin.de>
  */
 
-#ifndef _WSN_BOARD_H
-#define _WSN_BOARD_H
+#ifndef WSN_BOARD_H
+#define WSN_BOARD_H
 
 #include "board-conf.h"
 
@@ -33,8 +33,8 @@ extern "C" {
 #endif
 
 // for correct inclusion of <msp430.h>
-#ifndef __MSP430F1611__
-#define __MSP430F1611__
+#ifndef MSP430F1611__
+#define MSP430F1611__
 #endif
 
 //MSB430 core
@@ -72,4 +72,4 @@ extern "C" {
 typedef uint8_t radio_packet_length_t;
 
 /** @} */
-#endif // _WSN_BOARD_H
+#endif // WSN_BOARD_H

--- a/boards/wsn430-v1_4/include/board.h
+++ b/boards/wsn430-v1_4/include/board.h
@@ -23,8 +23,8 @@
  * @author      Milan Babel <babel@inf.fu-berlin.de>
  */
 
-#ifndef _WSN_BOARD_H
-#define _WSN_BOARD_H
+#ifndef WSN_BOARD_H
+#define WSN_BOARD_H
 
 #include "board-conf.h"
 
@@ -33,8 +33,8 @@ extern "C" {
 #endif
 
 // for correct inclusion of <msp430.h>
-#ifndef __MSP430F1611__
-#define __MSP430F1611__
+#ifndef MSP430F1611__
+#define MSP430F1611__
 #endif
 
 //MSB430 core
@@ -72,4 +72,4 @@ extern "C" {
 typedef uint8_t radio_packet_length_t;
 
 /** @} */
-#endif // _WSN_BOARD_H
+#endif // WSN_BOARD_H

--- a/boards/yunjia-nrf51822/include/board.h
+++ b/boards/yunjia-nrf51822/include/board.h
@@ -18,8 +18,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __BOARD_H
-#define __BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "cpu.h"
 
@@ -72,5 +72,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** __BOARD_H */
+#endif /** BOARD_H */
 /** @} */

--- a/boards/yunjia-nrf51822/include/periph_conf.h
+++ b/boards/yunjia-nrf51822/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef __PERIPH_CONF_H
-#define __PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -136,4 +136,4 @@ extern "C" {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */

--- a/boards/z1/include/board.h
+++ b/boards/z1/include/board.h
@@ -7,8 +7,8 @@
  * directory for more details.
  */
 
-#ifndef _Z1_BOARD_H
-#define _Z1_BOARD_H
+#ifndef Z1_BOARD_H
+#define Z1_BOARD_H
 
 /**
  * @defgroup    boards_z1 Zolertia Z1
@@ -36,8 +36,8 @@
 extern "C" {
 #endif
 
-#ifndef __MSP430F2617__
-#define __MSP430F2617__
+#ifndef MSP430F2617__
+#define MSP430F2617__
 #endif
 
 // MSP430 core
@@ -83,4 +83,4 @@ typedef uint8_t radio_packet_length_t;
 #endif
 
 /** @} */
-#endif // _Z1_BOARD_H
+#endif // Z1_BOARD_H


### PR DESCRIPTION
The include guards in boards directory have been repaired. Also the defines beginning with a single underscore are repaired. Require further clarification with reference to defines beginning with single underscore followed by an uppercase letter.