### PR TITLE
shell/sc_netif: added missing return statements

### DIFF
--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -225,6 +225,7 @@ static void _netif_set_u16(kernel_pid_t dev, ng_netconf_opt_t opt,
         printf("error: unable to set ");
         _print_netconf(opt);
         puts("");
+        return;
     }
 
     printf("success: set ");
@@ -249,12 +250,14 @@ static void _netif_set_addr(kernel_pid_t dev, ng_netconf_opt_t opt,
         puts("error: unable to parse address.\n"
              "Must be of format [0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*\n"
              "(hex pairs delimited by colons)");
+        return;
     }
 
     if (ng_netapi_set(dev, opt, 0, addr, addr_len) < 0) {
         printf("error: unable to set ");
         _print_netconf(opt);
         puts("");
+        return;
     }
 
     printf("success: set ");


### PR DESCRIPTION
found three placed in sc_netif where the functions did not return on errors.