### PR TITLE
ng_nomac: fix receive

### DIFF
--- a/sys/include/net/ng_netapi.h
+++ b/sys/include/net/ng_netapi.h
@@ -84,6 +84,17 @@ typedef struct {
 int ng_netapi_send(kernel_pid_t pid, ng_pktsnip_t *pkt);
 
 /**
+ * @brief   Shortcut function for sending @ref NG_NETAPI_MSG_TYPE_RCV messages
+ *
+ * @param[in] pid       PID of the targeted network module
+ * @param[in] pkt       pointer into the packet buffer holding the received data
+ *
+ * @return              1 if packet was successfully delivered
+ * @return              -1 on error (invalid PID or no space in queue)
+ */
+int ng_netapi_receive(kernel_pid_t pid, ng_pktsnip_t *pkt);
+
+/**
  * @brief   Shortcut function for sending @ref NG_NETAPI_MSG_TYPE_GET messages and
  *          parsing the returned @ref NG_NETAPI_MSG_TYPE_ACK message
  *

--- a/sys/net/crosslayer/ng_netapi/ng_netapi.c
+++ b/sys/net/crosslayer/ng_netapi/ng_netapi.c
@@ -54,14 +54,24 @@ static inline int _get_set(kernel_pid_t pid, uint16_t type,
     return (int)ack.content.value;
 }
 
-int ng_netapi_send(kernel_pid_t pid, ng_pktsnip_t *pkt)
+static inline int _snd_rcv(kernel_pid_t pid, uint16_t type, ng_pktsnip_t *pkt)
 {
     msg_t msg;
     /* set the outgoing message's fields */
-    msg.type = NG_NETAPI_MSG_TYPE_SND;
+    msg.type = type;
     msg.content.ptr = (void *)pkt;
-    /* send data using netapi */
+    /* send message */
     return msg_send(&msg, pid);
+}
+
+int ng_netapi_send(kernel_pid_t pid, ng_pktsnip_t *pkt)
+{
+    return _snd_rcv(pid, NG_NETAPI_MSG_TYPE_SND, pkt);
+}
+
+int ng_netapi_receive(kernel_pid_t pid, ng_pktsnip_t *pkt)
+{
+    return _snd_rcv(pid, NG_NETAPI_MSG_TYPE_RCV, pkt);
 }
 
 int ng_netapi_get(kernel_pid_t pid, ng_netconf_opt_t opt, uint16_t context,

--- a/sys/net/link_layer/ng_nomac/ng_nomac.c
+++ b/sys/net/link_layer/ng_nomac/ng_nomac.c
@@ -54,7 +54,7 @@ static void _event_cb(ng_netdev_event_t event, void *data)
         ng_pktbuf_hold(pkt, ng_netreg_num(pkt->type, NG_NETREG_DEMUX_CTX_ALL) - 1);
         while (sendto != NULL) {
             DEBUG("nomac: sending pkt %p to PID %u\n", pkt, sendto->pid);
-            ng_netapi_send(sendto->pid, pkt);
+            ng_netapi_receive(sendto->pid, pkt);
             sendto = ng_netreg_getnext(sendto);
         }
     }


### PR DESCRIPTION
In case of a receive event of the driver there was for some reason a SND command issued to the subscribers.