### PR TITLE
unittests: move test data to common header

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -7,21 +7,6 @@ BOARD_INSUFFICIENT_RAM := chronos msb-430 msb-430h redbee-econotag spark-core \
 
 USEMODULE += embunit
 
-# Some randomly generated but still deterministic values for testing
-CFLAGS += -DTEST_STRING4="\"J&(d\""
-CFLAGS += -DTEST_STRING8="\"o<\\\\rrB/q\""
-CFLAGS += -DTEST_STRING12="\"50U'HLKC3_ft\""
-CFLAGS += -DTEST_STRING16="\"nvxuO*6o3C=a6g7]\""
-CFLAGS += -DTEST_STRING64="\"3key9'=4\\\\wvAM&;.E&U/rOG:>\\\\C!r{K k.E[%;(}_I(D%XQk8+T>_M^G'Mm49,n:))]}\""
-CFLAGS += -DTEST_INT8=-69
-CFLAGS += -DTEST_INT16=-12229
-CFLAGS += -DTEST_INT32=-1894529023L
-CFLAGS += -DTEST_INT64=-4562349816927799244LL
-CFLAGS += -DTEST_UINT8=95U
-CFLAGS += -DTEST_UINT16=10098U
-CFLAGS += -DTEST_UINT32=2831907245LU
-CFLAGS += -DTEST_UINT64=13500266397057512199LLU
-
 ifeq (, $(filter tests-%, $(MAKECMDGOALS)))
     UNIT_TESTS := $(foreach d,$(wildcard tests-*/Makefile),$(shell dirname $(d)))
 else
@@ -42,13 +27,9 @@ endif
 DIRS += $(UNIT_TESTS)
 BASELIBS += $(UNIT_TESTS:%=$(BINDIR)%.a)
 
-include $(RIOTBASE)/Makefile.include
+INCLUDES += -I$(RIOTBASE)/tests/unittests/common
 
-ifeq (,$(filter msp430fxyz,$(CPU)))
-    CFLAGS += -DTEST_INT=TEST_INT32
-else
-    CFLAGS += -DTEST_INT=TEST_INT16
-endif
+include $(RIOTBASE)/Makefile.include
 
 .PHONY: FORCE $(UNIT_TESTS)
 

--- a/tests/unittests/common/unittests-constants.h
+++ b/tests/unittests/common/unittests-constants.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2015 Philipp Rosenkranz <philipp.rosenkranz@fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef __UNITTESTS_CONSTANTS_H__
+#define __UNITTESTS_CONSTANTS_H_
+#include "embUnit/embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Some randomly generated but still deterministic values for testing */
+#ifndef TEST_STRING4
+#define TEST_STRING4 "J&(d"
+#endif
+#ifndef TEST_STRING8
+#define TEST_STRING8 "o\\rrB/q"
+#endif
+#ifndef TEST_STRING12
+#define TEST_STRING12 "50U'HLKC3_ft"
+#endif
+#ifndef TEST_STRING16
+#define TEST_STRING16 "nvxuO*6o3C=a6g7]"
+#endif
+#ifndef TEST_STRING64
+#define TEST_STRING64 "3key9'=4\\wvAM&;.E&U/rOG:>\\C!r{K k.E[%;(}_I(D%XQk8+T>_M^G'Mm49,n:))]}"
+#endif
+#ifndef TEST_INT8
+#define TEST_INT8 (-69)
+#endif
+#ifndef TEST_INT16
+#define TEST_INT16 (-12229)
+#endif
+#ifndef TEST_INT32
+#define TEST_INT32 (-1894529023L)
+#endif
+#ifndef TEST_INT64
+#define TEST_INT64 (-4562349816927799244LL)
+#endif
+#ifndef TEST_UINT8
+#define TEST_UINT8 (95U)
+#endif
+#ifndef TEST_UINT16
+#define TEST_UINT16 (10098U)
+#endif
+#ifndef TEST_UINT32
+#define TEST_UINT32 (2831907245LU)
+#endif
+#ifndef TEST_UINT64
+#define TEST_UINT64 (13500266397057512199LLU)
+#endif
+
+#if defined(CPU_CC430) || defined(CPU_MSP430FXYZ) || defined(CPU_ATMEGA2560)
+#define TEST_INT TEST_INT16
+#else
+#define TEST_INT TEST_INT32
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __UNITTESTS_CONSTANTS_H_ */
+/** @} */

--- a/tests/unittests/tests-ipv6_nc/tests-ipv6_nc.c
+++ b/tests/unittests/tests-ipv6_nc/tests-ipv6_nc.c
@@ -19,6 +19,7 @@
 #include "net/ng_ipv6/addr.h"
 #include "net/ng_ipv6/nc.h"
 
+#include "unittests-constants.h"
 #include "tests-ipv6_nc.h"
 
 /* default interface for testing */

--- a/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
+++ b/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
@@ -21,6 +21,7 @@
 #include "net/ng_netif.h"
 #include "net/ng_ipv6/netif.h"
 
+#include "unittests-constants.h"
 #include "tests-ipv6_netif.h"
 
 /* default interface for testing */

--- a/tests/unittests/tests-netdev_dummy/tests-netdev_dummy.c
+++ b/tests/unittests/tests-netdev_dummy/tests-netdev_dummy.c
@@ -16,6 +16,7 @@
 
 #include "netdev_dummy.h"
 
+#include "unittests-constants.h"
 #include "tests-netdev_dummy.h"
 
 static netdev_t *dev = &(unittest_netdev_dummy_devs[0]);

--- a/tests/unittests/tests-netif/tests-netif.c
+++ b/tests/unittests/tests-netif/tests-netif.c
@@ -19,6 +19,7 @@
 #include "kernel_types.h"
 #include "net/ng_netif.h"
 
+#include "unittests-constants.h"
 #include "tests-netif.h"
 
 static void set_up(void)

--- a/tests/unittests/tests-netreg/tests-netreg.c
+++ b/tests/unittests/tests-netreg/tests-netreg.c
@@ -18,6 +18,7 @@
 #include "net/ng_netreg.h"
 #include "net/ng_nettype.h"
 
+#include "unittests-constants.h"
 #include "tests-netreg.h"
 
 static void set_up(void)

--- a/tests/unittests/tests-pkt/tests-pkt.c
+++ b/tests/unittests/tests-pkt/tests-pkt.c
@@ -18,6 +18,7 @@
 #include "net/ng_pkt.h"
 #include "net/ng_nettype.h"
 
+#include "unittests-constants.h"
 #include "tests-pkt.h"
 
 #define _INIT_ELEM(len, data, next) \

--- a/tests/unittests/tests-pktbuf/tests-pktbuf.c
+++ b/tests/unittests/tests-pktbuf/tests-pktbuf.c
@@ -20,6 +20,7 @@
 #include "net/ng_pkt.h"
 #include "net/ng_pktbuf.h"
 
+#include "unittests-constants.h"
 #include "tests-pktbuf.h"
 
 typedef struct __attribute__((packed)) {


### PR DESCRIPTION
Fix for #2557: moves test data constants from tests/unittests/Makefile into a common header file.
