### PR TITLE
rpl: Fix DEBUG print which broke in 5585413ce0

### DIFF
--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -89,8 +89,8 @@ rpl_instance_t *rpl_get_my_instance(void)
 rpl_dodag_t *rpl_new_dodag(rpl_instance_t *inst, ipv6_addr_t *dodagid)
 {
     if (inst == NULL) {
-        DEBUGF("Error - No instance found for id %d. This should not happen\n",
-               instanceid);
+        DEBUGF("Error - No instance found for id %p. This should not happen\n",
+               inst);
         return NULL;
     }
 


### PR DESCRIPTION
Been broken since rpl: pass rpl_instance_t directly instead of its id #2604
https://github.com/RIOT-OS/RIOT/pull/2604