### PR TITLE
cpu/native: do not exit when real_read returns 0

### DIFF
--- a/cpu/native/net/tap.c
+++ b/cpu/native/net/tap.c
@@ -149,6 +149,9 @@ void _native_handle_tap_input(void)
             err(EXIT_FAILURE, "_native_handle_tap_input: read");
         }
     }
+    else if (nread == 0) {
+        DEBUG("_native_handle_tap_input: ignoring null-event\n");
+    }
     else {
         errx(EXIT_FAILURE, "internal error _native_handle_tap_input");
     }


### PR DESCRIPTION
When `real_read()` returns 0 bytes, the application exits with an error. Posix states, that `0` indicates EOF and is not really an error case. So I propose to remove this `else`-check to not end the execution of native in such a case. See #2664 