### PR TITLE
pktdump: dump data of packet snips structured

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -71,6 +71,7 @@ endif
 
 ifneq (,$(filter ng_pktdump,$(USEMODULE)))
   USEMODULE += ng_pktbuf
+  USEMODULE += od
 endif
 
 ifneq (,$(filter aodvv2,$(USEMODULE)))


### PR DESCRIPTION
The idea is to expand on this as new header formats are introduced (next on the list: `ng_ipv6_hdr_t` from #2454 ;-))

Depends on ~~#2705~~ (merged) and ~~#2706~~ (merged).