### PR TITLE
kinetis: Refactor GPIO to use a look-up-table

### DIFF
--- a/cpu/kinetis_common/gpio.c
+++ b/cpu/kinetis_common/gpio.c
@@ -32,6 +32,9 @@
 
 #if GPIO_NUMOF
 
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
 #ifndef PIN_MUX_FUNCTION_ANALOG
 #define PIN_MUX_FUNCTION_ANALOG     0
 #endif
@@ -52,11 +55,119 @@
 #define PIN_INTERRUPT_EDGE          0xb
 #endif
 
+/**
+ * @brief Look up table entry for a GPIO configuration
+ */
+typedef struct kinetis_gpio_lut_entry {
+    PORT_Type* port; /**< PORT module */
+    GPIO_Type* gpio; /**< GPIO module */
+    uint8_t pin;     /**< Pin number within the port */
+} kinetis_gpio_lut_entry_t;
+
 typedef struct {
-    gpio_cb_t cb;       /**< callback called from GPIO interrupt */
-    void *arg;          /**< argument passed to the callback */
-    uint32_t irqc;      /**< remember interrupt configuration between disable/enable */
+    gpio_cb_t cb;    /**< callback called from GPIO interrupt */
+    void *arg;       /**< argument passed to the callback */
+    uint32_t irqc;   /**< remember interrupt configuration between disable/enable */
 } gpio_state_t;
+
+static const kinetis_gpio_lut_entry_t kinetis_gpio_lut[GPIO_NUMOF] = {
+#if GPIO_0_EN
+    { .port = GPIO_0_PORT, .gpio = GPIO_0_DEV, .pin = GPIO_0_PIN },
+#endif
+#if GPIO_1_EN
+    { .port = GPIO_1_PORT, .gpio = GPIO_1_DEV, .pin = GPIO_1_PIN },
+#endif
+#if GPIO_2_EN
+    { .port = GPIO_2_PORT, .gpio = GPIO_2_DEV, .pin = GPIO_2_PIN },
+#endif
+#if GPIO_3_EN
+    { .port = GPIO_3_PORT, .gpio = GPIO_3_DEV, .pin = GPIO_3_PIN },
+#endif
+#if GPIO_4_EN
+    { .port = GPIO_4_PORT, .gpio = GPIO_4_DEV, .pin = GPIO_4_PIN },
+#endif
+#if GPIO_5_EN
+    { .port = GPIO_5_PORT, .gpio = GPIO_5_DEV, .pin = GPIO_5_PIN },
+#endif
+#if GPIO_6_EN
+    { .port = GPIO_6_PORT, .gpio = GPIO_6_DEV, .pin = GPIO_6_PIN },
+#endif
+#if GPIO_7_EN
+    { .port = GPIO_7_PORT, .gpio = GPIO_7_DEV, .pin = GPIO_7_PIN },
+#endif
+#if GPIO_8_EN
+    { .port = GPIO_8_PORT, .gpio = GPIO_8_DEV, .pin = GPIO_8_PIN },
+#endif
+#if GPIO_9_EN
+    { .port = GPIO_9_PORT, .gpio = GPIO_9_DEV, .pin = GPIO_9_PIN },
+#endif
+#if GPIO_10_EN
+    { .port = GPIO_10_PORT, .gpio = GPIO_10_DEV, .pin = GPIO_10_PIN },
+#endif
+#if GPIO_11_EN
+    { .port = GPIO_11_PORT, .gpio = GPIO_11_DEV, .pin = GPIO_11_PIN },
+#endif
+#if GPIO_12_EN
+    { .port = GPIO_12_PORT, .gpio = GPIO_12_DEV, .pin = GPIO_12_PIN },
+#endif
+#if GPIO_13_EN
+    { .port = GPIO_13_PORT, .gpio = GPIO_13_DEV, .pin = GPIO_13_PIN },
+#endif
+#if GPIO_14_EN
+    { .port = GPIO_14_PORT, .gpio = GPIO_14_DEV, .pin = GPIO_14_PIN },
+#endif
+#if GPIO_15_EN
+    { .port = GPIO_15_PORT, .gpio = GPIO_15_DEV, .pin = GPIO_15_PIN },
+#endif
+#if GPIO_16_EN
+    { .port = GPIO_16_PORT, .gpio = GPIO_16_DEV, .pin = GPIO_16_PIN },
+#endif
+#if GPIO_17_EN
+    { .port = GPIO_17_PORT, .gpio = GPIO_17_DEV, .pin = GPIO_17_PIN },
+#endif
+#if GPIO_18_EN
+    { .port = GPIO_18_PORT, .gpio = GPIO_18_DEV, .pin = GPIO_18_PIN },
+#endif
+#if GPIO_19_EN
+    { .port = GPIO_19_PORT, .gpio = GPIO_19_DEV, .pin = GPIO_19_PIN },
+#endif
+#if GPIO_20_EN
+    { .port = GPIO_20_PORT, .gpio = GPIO_20_DEV, .pin = GPIO_20_PIN },
+#endif
+#if GPIO_21_EN
+    { .port = GPIO_21_PORT, .gpio = GPIO_21_DEV, .pin = GPIO_21_PIN },
+#endif
+#if GPIO_22_EN
+    { .port = GPIO_22_PORT, .gpio = GPIO_22_DEV, .pin = GPIO_22_PIN },
+#endif
+#if GPIO_23_EN
+    { .port = GPIO_23_PORT, .gpio = GPIO_23_DEV, .pin = GPIO_23_PIN },
+#endif
+#if GPIO_24_EN
+    { .port = GPIO_24_PORT, .gpio = GPIO_24_DEV, .pin = GPIO_24_PIN },
+#endif
+#if GPIO_25_EN
+    { .port = GPIO_25_PORT, .gpio = GPIO_25_DEV, .pin = GPIO_25_PIN },
+#endif
+#if GPIO_26_EN
+    { .port = GPIO_26_PORT, .gpio = GPIO_26_DEV, .pin = GPIO_26_PIN },
+#endif
+#if GPIO_27_EN
+    { .port = GPIO_27_PORT, .gpio = GPIO_27_DEV, .pin = GPIO_27_PIN },
+#endif
+#if GPIO_28_EN
+    { .port = GPIO_28_PORT, .gpio = GPIO_28_DEV, .pin = GPIO_28_PIN },
+#endif
+#if GPIO_29_EN
+    { .port = GPIO_29_PORT, .gpio = GPIO_29_DEV, .pin = GPIO_29_PIN },
+#endif
+#if GPIO_30_EN
+    { .port = GPIO_30_PORT, .gpio = GPIO_30_DEV, .pin = GPIO_30_PIN },
+#endif
+#if GPIO_31_EN
+    { .port = GPIO_31_PORT, .gpio = GPIO_31_DEV, .pin = GPIO_31_PIN },
+#endif
+};
 
 /**
  * @brief Unified IRQ handler shared by all interrupt routines
@@ -72,303 +183,187 @@ static gpio_state_t config[GPIO_NUMOF];
 
 int gpio_init_out(gpio_t dev, gpio_pp_t pushpull)
 {
-    PORT_Type *port;
-    GPIO_Type *gpio;
-    uint32_t pin = 0;
-
     switch (dev) {
 #if GPIO_0_EN
-
         case GPIO_0:
             GPIO_0_CLKEN();
-            port = GPIO_0_PORT;
-            gpio = GPIO_0_DEV;
-            pin = GPIO_0_PIN;
             break;
 #endif
 #if GPIO_1_EN
-
         case GPIO_1:
             GPIO_1_CLKEN();
-            port = GPIO_1_PORT;
-            gpio = GPIO_1_DEV;
-            pin = GPIO_1_PIN;
             break;
 #endif
 #if GPIO_2_EN
-
         case GPIO_2:
             GPIO_2_CLKEN();
-            port = GPIO_2_PORT;
-            gpio = GPIO_2_DEV;
-            pin = GPIO_2_PIN;
             break;
 #endif
 #if GPIO_3_EN
 
         case GPIO_3:
             GPIO_3_CLKEN();
-            port = GPIO_3_PORT;
-            gpio = GPIO_3_DEV;
-            pin = GPIO_3_PIN;
             break;
 #endif
 #if GPIO_4_EN
-
         case GPIO_4:
             GPIO_4_CLKEN();
-            port = GPIO_4_PORT;
-            gpio = GPIO_4_DEV;
-            pin = GPIO_4_PIN;
             break;
 #endif
 #if GPIO_5_EN
-
         case GPIO_5:
             GPIO_5_CLKEN();
-            port = GPIO_5_PORT;
-            gpio = GPIO_5_DEV;
-            pin = GPIO_5_PIN;
             break;
 #endif
 #if GPIO_6_EN
-
         case GPIO_6:
             GPIO_6_CLKEN();
-            port = GPIO_6_PORT;
-            gpio = GPIO_6_DEV;
-            pin = GPIO_6_PIN;
             break;
 #endif
 #if GPIO_7_EN
 
         case GPIO_7:
             GPIO_7_CLKEN();
-            port = GPIO_7_PORT;
-            gpio = GPIO_7_DEV;
-            pin = GPIO_7_PIN;
             break;
 #endif
 #if GPIO_8_EN
 
         case GPIO_8:
             GPIO_8_CLKEN();
-            port = GPIO_8_PORT;
-            gpio = GPIO_8_DEV;
-            pin = GPIO_8_PIN;
             break;
 #endif
 #if GPIO_9_EN
 
         case GPIO_9:
             GPIO_9_CLKEN();
-            port = GPIO_9_PORT;
-            gpio = GPIO_9_DEV;
-            pin = GPIO_9_PIN;
             break;
 #endif
 #if GPIO_10_EN
 
         case GPIO_10:
             GPIO_10_CLKEN();
-            port = GPIO_10_PORT;
-            gpio = GPIO_10_DEV;
-            pin = GPIO_10_PIN;
             break;
 #endif
 #if GPIO_11_EN
 
         case GPIO_11:
             GPIO_11_CLKEN();
-            port = GPIO_11_PORT;
-            gpio = GPIO_11_DEV;
-            pin = GPIO_11_PIN;
             break;
 #endif
 #if GPIO_12_EN
 
         case GPIO_12:
             GPIO_12_CLKEN();
-            port = GPIO_12_PORT;
-            gpio = GPIO_12_DEV;
-            pin = GPIO_12_PIN;
             break;
 #endif
 #if GPIO_13_EN
 
         case GPIO_13:
             GPIO_13_CLKEN();
-            port = GPIO_13_PORT;
-            gpio = GPIO_13_DEV;
-            pin = GPIO_13_PIN;
             break;
 #endif
 #if GPIO_14_EN
 
         case GPIO_14:
             GPIO_14_CLKEN();
-            port = GPIO_14_PORT;
-            gpio = GPIO_14_DEV;
-            pin = GPIO_14_PIN;
             break;
 #endif
 #if GPIO_15_EN
 
         case GPIO_15:
             GPIO_15_CLKEN();
-            port = GPIO_15_PORT;
-            gpio = GPIO_15_DEV;
-            pin = GPIO_15_PIN;
             break;
 #endif
 #if GPIO_16_EN
 
         case GPIO_16:
             GPIO_16_CLKEN();
-            port = GPIO_16_PORT;
-            gpio = GPIO_16_DEV;
-            pin = GPIO_16_PIN;
             break;
 #endif
 #if GPIO_17_EN
 
         case GPIO_17:
             GPIO_17_CLKEN();
-            port = GPIO_17_PORT;
-            gpio = GPIO_17_DEV;
-            pin = GPIO_17_PIN;
             break;
 #endif
 #if GPIO_18_EN
 
         case GPIO_18:
             GPIO_18_CLKEN();
-            port = GPIO_18_PORT;
-            gpio = GPIO_18_DEV;
-            pin = GPIO_18_PIN;
             break;
 #endif
 #if GPIO_19_EN
-
         case GPIO_19:
             GPIO_19_CLKEN();
-            port = GPIO_19_PORT;
-            gpio = GPIO_19_DEV;
-            pin = GPIO_19_PIN;
             break;
 #endif
 #if GPIO_20_EN
-
         case GPIO_20:
             GPIO_20_CLKEN();
-            port = GPIO_20_PORT;
-            gpio = GPIO_20_DEV;
-            pin = GPIO_20_PIN;
             break;
 #endif
 #if GPIO_21_EN
-
         case GPIO_21:
             GPIO_21_CLKEN();
-            port = GPIO_21_PORT;
-            gpio = GPIO_21_DEV;
-            pin = GPIO_21_PIN;
             break;
 #endif
 #if GPIO_22_EN
-
         case GPIO_22:
             GPIO_22_CLKEN();
-            port = GPIO_22_PORT;
-            gpio = GPIO_22_DEV;
-            pin = GPIO_22_PIN;
             break;
 #endif
 #if GPIO_23_EN
-
         case GPIO_23:
             GPIO_23_CLKEN();
-            port = GPIO_23_PORT;
-            gpio = GPIO_23_DEV;
-            pin = GPIO_23_PIN;
             break;
 #endif
 #if GPIO_24_EN
-
         case GPIO_24:
             GPIO_24_CLKEN();
-            port = GPIO_24_PORT;
-            gpio = GPIO_24_DEV;
-            pin = GPIO_24_PIN;
             break;
 #endif
 #if GPIO_25_EN
-
         case GPIO_25:
             GPIO_25_CLKEN();
-            port = GPIO_25_PORT;
-            gpio = GPIO_25_DEV;
-            pin = GPIO_25_PIN;
             break;
 #endif
 #if GPIO_26_EN
-
         case GPIO_26:
             GPIO_26_CLKEN();
-            port = GPIO_26_PORT;
-            gpio = GPIO_26_DEV;
-            pin = GPIO_26_PIN;
             break;
 #endif
 #if GPIO_27_EN
-
         case GPIO_27:
             GPIO_27_CLKEN();
-            port = GPIO_27_PORT;
-            gpio = GPIO_27_DEV;
-            pin = GPIO_27_PIN;
             break;
 #endif
 #if GPIO_28_EN
-
         case GPIO_28:
             GPIO_28_CLKEN();
-            port = GPIO_28_PORT;
-            gpio = GPIO_28_DEV;
-            pin = GPIO_28_PIN;
             break;
 #endif
 #if GPIO_29_EN
-
         case GPIO_29:
             GPIO_29_CLKEN();
-            port = GPIO_29_PORT;
-            gpio = GPIO_29_DEV;
-            pin = GPIO_29_PIN;
             break;
 #endif
 #if GPIO_30_EN
-
         case GPIO_30:
             GPIO_30_CLKEN();
-            port = GPIO_30_PORT;
-            gpio = GPIO_30_DEV;
-            pin = GPIO_30_PIN;
             break;
 #endif
 #if GPIO_31_EN
-
         case GPIO_31:
             GPIO_31_CLKEN();
-            port = GPIO_31_PORT;
-            gpio = GPIO_31_DEV;
-            pin = GPIO_31_PIN;
             break;
 #endif
-
         default:
             return -1;
     }
+
+    uint8_t pin = kinetis_gpio_lut[dev].pin;
+    PORT_Type *port = kinetis_gpio_lut[dev].port;
+    GPIO_Type *gpio = kinetis_gpio_lut[dev].gpio;
 
     /* Clear interrupt config */
     config[dev].cb = NULL;
@@ -403,303 +398,187 @@ int gpio_init_out(gpio_t dev, gpio_pp_t pushpull)
 
 int gpio_init_in(gpio_t dev, gpio_pp_t pushpull)
 {
-    PORT_Type *port;
-    GPIO_Type *gpio;
-    uint32_t pin = 0;
-
     switch (dev) {
 #if GPIO_0_EN
-
         case GPIO_0:
             GPIO_0_CLKEN();
-            port = GPIO_0_PORT;
-            gpio = GPIO_0_DEV;
-            pin = GPIO_0_PIN;
             break;
 #endif
 #if GPIO_1_EN
-
         case GPIO_1:
             GPIO_1_CLKEN();
-            port = GPIO_1_PORT;
-            gpio = GPIO_1_DEV;
-            pin = GPIO_1_PIN;
             break;
 #endif
 #if GPIO_2_EN
-
         case GPIO_2:
             GPIO_2_CLKEN();
-            port = GPIO_2_PORT;
-            gpio = GPIO_2_DEV;
-            pin = GPIO_2_PIN;
             break;
 #endif
 #if GPIO_3_EN
 
         case GPIO_3:
             GPIO_3_CLKEN();
-            port = GPIO_3_PORT;
-            gpio = GPIO_3_DEV;
-            pin = GPIO_3_PIN;
             break;
 #endif
 #if GPIO_4_EN
-
         case GPIO_4:
             GPIO_4_CLKEN();
-            port = GPIO_4_PORT;
-            gpio = GPIO_4_DEV;
-            pin = GPIO_4_PIN;
             break;
 #endif
 #if GPIO_5_EN
-
         case GPIO_5:
             GPIO_5_CLKEN();
-            port = GPIO_5_PORT;
-            gpio = GPIO_5_DEV;
-            pin = GPIO_5_PIN;
             break;
 #endif
 #if GPIO_6_EN
-
         case GPIO_6:
             GPIO_6_CLKEN();
-            port = GPIO_6_PORT;
-            gpio = GPIO_6_DEV;
-            pin = GPIO_6_PIN;
             break;
 #endif
 #if GPIO_7_EN
 
         case GPIO_7:
             GPIO_7_CLKEN();
-            port = GPIO_7_PORT;
-            gpio = GPIO_7_DEV;
-            pin = GPIO_7_PIN;
             break;
 #endif
 #if GPIO_8_EN
 
         case GPIO_8:
             GPIO_8_CLKEN();
-            port = GPIO_8_PORT;
-            gpio = GPIO_8_DEV;
-            pin = GPIO_8_PIN;
             break;
 #endif
 #if GPIO_9_EN
 
         case GPIO_9:
             GPIO_9_CLKEN();
-            port = GPIO_9_PORT;
-            gpio = GPIO_9_DEV;
-            pin = GPIO_9_PIN;
             break;
 #endif
 #if GPIO_10_EN
 
         case GPIO_10:
             GPIO_10_CLKEN();
-            port = GPIO_10_PORT;
-            gpio = GPIO_10_DEV;
-            pin = GPIO_10_PIN;
             break;
 #endif
 #if GPIO_11_EN
 
         case GPIO_11:
             GPIO_11_CLKEN();
-            port = GPIO_11_PORT;
-            gpio = GPIO_11_DEV;
-            pin = GPIO_11_PIN;
             break;
 #endif
 #if GPIO_12_EN
 
         case GPIO_12:
             GPIO_12_CLKEN();
-            port = GPIO_12_PORT;
-            gpio = GPIO_12_DEV;
-            pin = GPIO_12_PIN;
             break;
 #endif
 #if GPIO_13_EN
 
         case GPIO_13:
             GPIO_13_CLKEN();
-            port = GPIO_13_PORT;
-            gpio = GPIO_13_DEV;
-            pin = GPIO_13_PIN;
             break;
 #endif
 #if GPIO_14_EN
 
         case GPIO_14:
             GPIO_14_CLKEN();
-            port = GPIO_14_PORT;
-            gpio = GPIO_14_DEV;
-            pin = GPIO_14_PIN;
             break;
 #endif
 #if GPIO_15_EN
 
         case GPIO_15:
             GPIO_15_CLKEN();
-            port = GPIO_15_PORT;
-            gpio = GPIO_15_DEV;
-            pin = GPIO_15_PIN;
             break;
 #endif
 #if GPIO_16_EN
 
         case GPIO_16:
             GPIO_16_CLKEN();
-            port = GPIO_16_PORT;
-            gpio = GPIO_16_DEV;
-            pin = GPIO_16_PIN;
             break;
 #endif
 #if GPIO_17_EN
 
         case GPIO_17:
             GPIO_17_CLKEN();
-            port = GPIO_17_PORT;
-            gpio = GPIO_17_DEV;
-            pin = GPIO_17_PIN;
             break;
 #endif
 #if GPIO_18_EN
 
         case GPIO_18:
             GPIO_18_CLKEN();
-            port = GPIO_18_PORT;
-            gpio = GPIO_18_DEV;
-            pin = GPIO_18_PIN;
             break;
 #endif
 #if GPIO_19_EN
-
         case GPIO_19:
             GPIO_19_CLKEN();
-            port = GPIO_19_PORT;
-            gpio = GPIO_19_DEV;
-            pin = GPIO_19_PIN;
             break;
 #endif
 #if GPIO_20_EN
-
         case GPIO_20:
             GPIO_20_CLKEN();
-            port = GPIO_20_PORT;
-            gpio = GPIO_20_DEV;
-            pin = GPIO_20_PIN;
             break;
 #endif
 #if GPIO_21_EN
-
         case GPIO_21:
             GPIO_21_CLKEN();
-            port = GPIO_21_PORT;
-            gpio = GPIO_21_DEV;
-            pin = GPIO_21_PIN;
             break;
 #endif
 #if GPIO_22_EN
-
         case GPIO_22:
             GPIO_22_CLKEN();
-            port = GPIO_22_PORT;
-            gpio = GPIO_22_DEV;
-            pin = GPIO_22_PIN;
             break;
 #endif
 #if GPIO_23_EN
-
         case GPIO_23:
             GPIO_23_CLKEN();
-            port = GPIO_23_PORT;
-            gpio = GPIO_23_DEV;
-            pin = GPIO_23_PIN;
             break;
 #endif
 #if GPIO_24_EN
-
         case GPIO_24:
             GPIO_24_CLKEN();
-            port = GPIO_24_PORT;
-            gpio = GPIO_24_DEV;
-            pin = GPIO_24_PIN;
             break;
 #endif
 #if GPIO_25_EN
-
         case GPIO_25:
             GPIO_25_CLKEN();
-            port = GPIO_25_PORT;
-            gpio = GPIO_25_DEV;
-            pin = GPIO_25_PIN;
             break;
 #endif
 #if GPIO_26_EN
-
         case GPIO_26:
             GPIO_26_CLKEN();
-            port = GPIO_26_PORT;
-            gpio = GPIO_26_DEV;
-            pin = GPIO_26_PIN;
             break;
 #endif
 #if GPIO_27_EN
-
         case GPIO_27:
             GPIO_27_CLKEN();
-            port = GPIO_27_PORT;
-            gpio = GPIO_27_DEV;
-            pin = GPIO_27_PIN;
             break;
 #endif
 #if GPIO_28_EN
-
         case GPIO_28:
             GPIO_28_CLKEN();
-            port = GPIO_28_PORT;
-            gpio = GPIO_28_DEV;
-            pin = GPIO_28_PIN;
             break;
 #endif
 #if GPIO_29_EN
-
         case GPIO_29:
             GPIO_29_CLKEN();
-            port = GPIO_29_PORT;
-            gpio = GPIO_29_DEV;
-            pin = GPIO_29_PIN;
             break;
 #endif
 #if GPIO_30_EN
-
         case GPIO_30:
             GPIO_30_CLKEN();
-            port = GPIO_30_PORT;
-            gpio = GPIO_30_DEV;
-            pin = GPIO_30_PIN;
             break;
 #endif
 #if GPIO_31_EN
-
         case GPIO_31:
             GPIO_31_CLKEN();
-            port = GPIO_31_PORT;
-            gpio = GPIO_31_DEV;
-            pin = GPIO_31_PIN;
             break;
 #endif
-
         default:
             return -1;
     }
+
+    uint8_t pin = kinetis_gpio_lut[dev].pin;
+    PORT_Type *port = kinetis_gpio_lut[dev].port;
+    GPIO_Type *gpio = kinetis_gpio_lut[dev].gpio;
 
     /* Reset all pin control settings for the pin */
     /* Switch to analog input function while fiddling with the settings, to be safe. */
@@ -731,9 +610,7 @@ int gpio_init_in(gpio_t dev, gpio_pp_t pushpull)
 
 int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    PORT_Type *port;
     int res;
-    uint32_t pin = 0;
 
     res = gpio_init_in(dev, pushpull);
 
@@ -743,28 +620,19 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 
     switch (dev) {
 #if GPIO_0_EN
-
         case GPIO_0:
-            port = GPIO_0_PORT;
-            pin = GPIO_0_PIN;
             NVIC_SetPriority(GPIO_0_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_0_IRQ);
             break;
 #endif
 #if GPIO_1_EN
-
         case GPIO_1:
-            port = GPIO_1_PORT;
-            pin = GPIO_1_PIN;
             NVIC_SetPriority(GPIO_1_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_1_IRQ);
             break;
 #endif
 #if GPIO_2_EN
-
         case GPIO_2:
-            port = GPIO_2_PORT;
-            pin = GPIO_2_PIN;
             NVIC_SetPriority(GPIO_2_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_2_IRQ);
             break;
@@ -772,8 +640,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_3_EN
 
         case GPIO_3:
-            port = GPIO_3_PORT;
-            pin = GPIO_3_PIN;
             NVIC_SetPriority(GPIO_3_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_3_IRQ);
             break;
@@ -781,8 +647,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_4_EN
 
         case GPIO_4:
-            port = GPIO_4_PORT;
-            pin = GPIO_4_PIN;
             NVIC_SetPriority(GPIO_4_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_4_IRQ);
             break;
@@ -790,8 +654,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_5_EN
 
         case GPIO_5:
-            port = GPIO_5_PORT;
-            pin = GPIO_5_PIN;
             NVIC_SetPriority(GPIO_5_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_5_IRQ);
             break;
@@ -799,8 +661,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_6_EN
 
         case GPIO_6:
-            port = GPIO_6_PORT;
-            pin = GPIO_6_PIN;
             NVIC_SetPriority(GPIO_6_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_6_IRQ);
             break;
@@ -808,8 +668,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_7_EN
 
         case GPIO_7:
-            port = GPIO_7_PORT;
-            pin = GPIO_7_PIN;
             NVIC_SetPriority(GPIO_7_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_7_IRQ);
             break;
@@ -817,8 +675,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_8_EN
 
         case GPIO_8:
-            port = GPIO_8_PORT;
-            pin = GPIO_8_PIN;
             NVIC_SetPriority(GPIO_8_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_8_IRQ);
             break;
@@ -826,8 +682,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_9_EN
 
         case GPIO_9:
-            port = GPIO_9_PORT;
-            pin = GPIO_9_PIN;
             NVIC_SetPriority(GPIO_9_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_9_IRQ);
             break;
@@ -835,8 +689,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_10_EN
 
         case GPIO_10:
-            port = GPIO_10_PORT;
-            pin = GPIO_10_PIN;
             NVIC_SetPriority(GPIO_10_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_10_IRQ);
             break;
@@ -844,8 +696,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_11_EN
 
         case GPIO_11:
-            port = GPIO_11_PORT;
-            pin = GPIO_11_PIN;
             NVIC_SetPriority(GPIO_11_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_11_IRQ);
             break;
@@ -853,8 +703,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_12_EN
 
         case GPIO_12:
-            port = GPIO_12_PORT;
-            pin = GPIO_12_PIN;
             NVIC_SetPriority(GPIO_12_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_12_IRQ);
             break;
@@ -862,8 +710,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_13_EN
 
         case GPIO_13:
-            port = GPIO_13_PORT;
-            pin = GPIO_13_PIN;
             NVIC_SetPriority(GPIO_13_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_13_IRQ);
             break;
@@ -871,8 +717,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_14_EN
 
         case GPIO_14:
-            port = GPIO_14_PORT;
-            pin = GPIO_14_PIN;
             NVIC_SetPriority(GPIO_14_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_14_IRQ);
             break;
@@ -880,8 +724,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_15_EN
 
         case GPIO_15:
-            port = GPIO_15_PORT;
-            pin = GPIO_15_PIN;
             NVIC_SetPriority(GPIO_15_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_15_IRQ);
             break;
@@ -889,8 +731,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_16_EN
 
         case GPIO_16:
-            port = GPIO_16_PORT;
-            pin = GPIO_16_PIN;
             NVIC_SetPriority(GPIO_16_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_16_IRQ);
             break;
@@ -898,8 +738,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_17_EN
 
         case GPIO_17:
-            port = GPIO_17_PORT;
-            pin = GPIO_17_PIN;
             NVIC_SetPriority(GPIO_17_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_17_IRQ);
             break;
@@ -907,8 +745,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_18_EN
 
         case GPIO_18:
-            port = GPIO_18_PORT;
-            pin = GPIO_18_PIN;
             NVIC_SetPriority(GPIO_18_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_18_IRQ);
             break;
@@ -916,8 +752,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_19_EN
 
         case GPIO_19:
-            port = GPIO_19_PORT;
-            pin = GPIO_19_PIN;
             NVIC_SetPriority(GPIO_19_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_19_IRQ);
             break;
@@ -925,8 +759,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_20_EN
 
         case GPIO_20:
-            port = GPIO_20_PORT;
-            pin = GPIO_20_PIN;
             NVIC_SetPriority(GPIO_20_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_20_IRQ);
             break;
@@ -934,8 +766,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_21_EN
 
         case GPIO_21:
-            port = GPIO_21_PORT;
-            pin = GPIO_21_PIN;
             NVIC_SetPriority(GPIO_21_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_21_IRQ);
             break;
@@ -943,8 +773,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_22_EN
 
         case GPIO_22:
-            port = GPIO_22_PORT;
-            pin = GPIO_22_PIN;
             NVIC_SetPriority(GPIO_22_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_22_IRQ);
             break;
@@ -952,8 +780,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_23_EN
 
         case GPIO_23:
-            port = GPIO_23_PORT;
-            pin = GPIO_23_PIN;
             NVIC_SetPriority(GPIO_23_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_23_IRQ);
             break;
@@ -961,8 +787,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_24_EN
 
         case GPIO_24:
-            port = GPIO_24_PORT;
-            pin = GPIO_24_PIN;
             NVIC_SetPriority(GPIO_24_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_24_IRQ);
             break;
@@ -970,8 +794,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_25_EN
 
         case GPIO_25:
-            port = GPIO_25_PORT;
-            pin = GPIO_25_PIN;
             NVIC_SetPriority(GPIO_25_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_25_IRQ);
             break;
@@ -979,8 +801,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_26_EN
 
         case GPIO_26:
-            port = GPIO_26_PORT;
-            pin = GPIO_26_PIN;
             NVIC_SetPriority(GPIO_26_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_26_IRQ);
             break;
@@ -988,8 +808,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_27_EN
 
         case GPIO_27:
-            port = GPIO_27_PORT;
-            pin = GPIO_27_PIN;
             NVIC_SetPriority(GPIO_27_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_27_IRQ);
             break;
@@ -997,8 +815,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_28_EN
 
         case GPIO_28:
-            port = GPIO_28_PORT;
-            pin = GPIO_28_PIN;
             NVIC_SetPriority(GPIO_28_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_28_IRQ);
             break;
@@ -1006,8 +822,6 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_29_EN
 
         case GPIO_29:
-            port = GPIO_29_PORT;
-            pin = GPIO_29_PIN;
             NVIC_SetPriority(GPIO_29_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_29_IRQ);
             break;
@@ -1015,25 +829,22 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 #if GPIO_30_EN
 
         case GPIO_30:
-            port = GPIO_30_PORT;
-            pin = GPIO_30_PIN;
             NVIC_SetPriority(GPIO_30_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_30_IRQ);
             break;
 #endif
 #if GPIO_31_EN
-
         case GPIO_31:
-            port = GPIO_31_PORT;
-            pin = GPIO_31_PIN;
             NVIC_SetPriority(GPIO_31_IRQ, GPIO_IRQ_PRIO);
             NVIC_EnableIRQ(GPIO_31_IRQ);
             break;
 #endif
-
         default:
             return -1;
     }
+
+    uint8_t pin = kinetis_gpio_lut[dev].pin;
+    PORT_Type *port = kinetis_gpio_lut[dev].port;
 
     /* set callback */
     config[dev].cb = cb;
@@ -1072,238 +883,12 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 
 void gpio_irq_enable(gpio_t dev)
 {
-    PORT_Type *port;
-    uint32_t pin = 0;
-
-    switch (dev) {
-#if GPIO_0_EN
-
-        case GPIO_0:
-            port = GPIO_0_PORT;
-            pin = GPIO_0_PIN;
-            break;
-#endif
-#if GPIO_1_EN
-
-        case GPIO_1:
-            port = GPIO_1_PORT;
-            pin = GPIO_1_PIN;
-            break;
-#endif
-#if GPIO_2_EN
-
-        case GPIO_2:
-            port = GPIO_2_PORT;
-            pin = GPIO_2_PIN;
-            break;
-#endif
-#if GPIO_3_EN
-
-        case GPIO_3:
-            port = GPIO_3_PORT;
-            pin = GPIO_3_PIN;
-            break;
-#endif
-#if GPIO_4_EN
-
-        case GPIO_4:
-            port = GPIO_4_PORT;
-            pin = GPIO_4_PIN;
-            break;
-#endif
-#if GPIO_5_EN
-
-        case GPIO_5:
-            port = GPIO_5_PORT;
-            pin = GPIO_5_PIN;
-            break;
-#endif
-#if GPIO_6_EN
-
-        case GPIO_6:
-            port = GPIO_6_PORT;
-            pin = GPIO_6_PIN;
-            break;
-#endif
-#if GPIO_7_EN
-
-        case GPIO_7:
-            port = GPIO_7_PORT;
-            pin = GPIO_7_PIN;
-            break;
-#endif
-#if GPIO_8_EN
-
-        case GPIO_8:
-            port = GPIO_8_PORT;
-            pin = GPIO_8_PIN;
-            break;
-#endif
-#if GPIO_9_EN
-
-        case GPIO_9:
-            port = GPIO_9_PORT;
-            pin = GPIO_9_PIN;
-            break;
-#endif
-#if GPIO_10_EN
-
-        case GPIO_10:
-            port = GPIO_10_PORT;
-            pin = GPIO_10_PIN;
-            break;
-#endif
-#if GPIO_11_EN
-
-        case GPIO_11:
-            port = GPIO_11_PORT;
-            pin = GPIO_11_PIN;
-            break;
-#endif
-#if GPIO_12_EN
-
-        case GPIO_12:
-            port = GPIO_12_PORT;
-            pin = GPIO_12_PIN;
-            break;
-#endif
-#if GPIO_13_EN
-
-        case GPIO_13:
-            port = GPIO_13_PORT;
-            pin = GPIO_13_PIN;
-            break;
-#endif
-#if GPIO_14_EN
-
-        case GPIO_14:
-            port = GPIO_14_PORT;
-            pin = GPIO_14_PIN;
-            break;
-#endif
-#if GPIO_15_EN
-
-        case GPIO_15:
-            port = GPIO_15_PORT;
-            pin = GPIO_15_PIN;
-            break;
-#endif
-#if GPIO_16_EN
-
-        case GPIO_16:
-            port = GPIO_16_PORT;
-            pin = GPIO_16_PIN;
-            break;
-#endif
-#if GPIO_17_EN
-
-        case GPIO_17:
-            port = GPIO_17_PORT;
-            pin = GPIO_17_PIN;
-            break;
-#endif
-#if GPIO_18_EN
-
-        case GPIO_18:
-            port = GPIO_18_PORT;
-            pin = GPIO_18_PIN;
-            break;
-#endif
-#if GPIO_19_EN
-
-        case GPIO_19:
-            port = GPIO_19_PORT;
-            pin = GPIO_19_PIN;
-            break;
-#endif
-#if GPIO_20_EN
-
-        case GPIO_20:
-            port = GPIO_20_PORT;
-            pin = GPIO_20_PIN;
-            break;
-#endif
-#if GPIO_21_EN
-
-        case GPIO_21:
-            port = GPIO_21_PORT;
-            pin = GPIO_21_PIN;
-            break;
-#endif
-#if GPIO_22_EN
-
-        case GPIO_22:
-            port = GPIO_22_PORT;
-            pin = GPIO_22_PIN;
-            break;
-#endif
-#if GPIO_23_EN
-
-        case GPIO_23:
-            port = GPIO_23_PORT;
-            pin = GPIO_23_PIN;
-            break;
-#endif
-#if GPIO_24_EN
-
-        case GPIO_24:
-            port = GPIO_24_PORT;
-            pin = GPIO_24_PIN;
-            break;
-#endif
-#if GPIO_25_EN
-
-        case GPIO_25:
-            port = GPIO_25_PORT;
-            pin = GPIO_25_PIN;
-            break;
-#endif
-#if GPIO_26_EN
-
-        case GPIO_26:
-            port = GPIO_26_PORT;
-            pin = GPIO_26_PIN;
-            break;
-#endif
-#if GPIO_27_EN
-
-        case GPIO_27:
-            port = GPIO_27_PORT;
-            pin = GPIO_27_PIN;
-            break;
-#endif
-#if GPIO_28_EN
-
-        case GPIO_28:
-            port = GPIO_28_PORT;
-            pin = GPIO_28_PIN;
-            break;
-#endif
-#if GPIO_29_EN
-
-        case GPIO_29:
-            port = GPIO_29_PORT;
-            pin = GPIO_29_PIN;
-            break;
-#endif
-#if GPIO_30_EN
-
-        case GPIO_30:
-            port = GPIO_30_PORT;
-            pin = GPIO_30_PIN;
-            break;
-#endif
-#if GPIO_31_EN
-
-        case GPIO_31:
-            port = GPIO_31_PORT;
-            pin = GPIO_31_PIN;
-            break;
-#endif
-
-        default:
-            return;
+    if (dev >= GPIO_NUMOF) {
+        DEBUG("gpio_t out of range: %d >= %d\n", dev, GPIO_NUMOF);
+        return;
     }
+    uint8_t pin = kinetis_gpio_lut[dev].pin;
+    PORT_Type *port = kinetis_gpio_lut[dev].port;
 
     /* Restore saved state */
     port->PCR[pin] &= ~(PORT_PCR_IRQC_MASK);
@@ -1312,238 +897,12 @@ void gpio_irq_enable(gpio_t dev)
 
 void gpio_irq_disable(gpio_t dev)
 {
-    PORT_Type *port;
-    uint32_t pin = 0;
-
-    switch (dev) {
-#if GPIO_0_EN
-
-        case GPIO_0:
-            port = GPIO_0_PORT;
-            pin = GPIO_0_PIN;
-            break;
-#endif
-#if GPIO_1_EN
-
-        case GPIO_1:
-            port = GPIO_1_PORT;
-            pin = GPIO_1_PIN;
-            break;
-#endif
-#if GPIO_2_EN
-
-        case GPIO_2:
-            port = GPIO_2_PORT;
-            pin = GPIO_2_PIN;
-            break;
-#endif
-#if GPIO_3_EN
-
-        case GPIO_3:
-            port = GPIO_3_PORT;
-            pin = GPIO_3_PIN;
-            break;
-#endif
-#if GPIO_4_EN
-
-        case GPIO_4:
-            port = GPIO_4_PORT;
-            pin = GPIO_4_PIN;
-            break;
-#endif
-#if GPIO_5_EN
-
-        case GPIO_5:
-            port = GPIO_5_PORT;
-            pin = GPIO_5_PIN;
-            break;
-#endif
-#if GPIO_6_EN
-
-        case GPIO_6:
-            port = GPIO_6_PORT;
-            pin = GPIO_6_PIN;
-            break;
-#endif
-#if GPIO_7_EN
-
-        case GPIO_7:
-            port = GPIO_7_PORT;
-            pin = GPIO_7_PIN;
-            break;
-#endif
-#if GPIO_8_EN
-
-        case GPIO_8:
-            port = GPIO_8_PORT;
-            pin = GPIO_8_PIN;
-            break;
-#endif
-#if GPIO_9_EN
-
-        case GPIO_9:
-            port = GPIO_9_PORT;
-            pin = GPIO_9_PIN;
-            break;
-#endif
-#if GPIO_10_EN
-
-        case GPIO_10:
-            port = GPIO_10_PORT;
-            pin = GPIO_10_PIN;
-            break;
-#endif
-#if GPIO_11_EN
-
-        case GPIO_11:
-            port = GPIO_11_PORT;
-            pin = GPIO_11_PIN;
-            break;
-#endif
-#if GPIO_12_EN
-
-        case GPIO_12:
-            port = GPIO_12_PORT;
-            pin = GPIO_12_PIN;
-            break;
-#endif
-#if GPIO_13_EN
-
-        case GPIO_13:
-            port = GPIO_13_PORT;
-            pin = GPIO_13_PIN;
-            break;
-#endif
-#if GPIO_14_EN
-
-        case GPIO_14:
-            port = GPIO_14_PORT;
-            pin = GPIO_14_PIN;
-            break;
-#endif
-#if GPIO_15_EN
-
-        case GPIO_15:
-            port = GPIO_15_PORT;
-            pin = GPIO_15_PIN;
-            break;
-#endif
-#if GPIO_16_EN
-
-        case GPIO_16:
-            port = GPIO_16_PORT;
-            pin = GPIO_16_PIN;
-            break;
-#endif
-#if GPIO_17_EN
-
-        case GPIO_17:
-            port = GPIO_17_PORT;
-            pin = GPIO_17_PIN;
-            break;
-#endif
-#if GPIO_18_EN
-
-        case GPIO_18:
-            port = GPIO_18_PORT;
-            pin = GPIO_18_PIN;
-            break;
-#endif
-#if GPIO_19_EN
-
-        case GPIO_19:
-            port = GPIO_19_PORT;
-            pin = GPIO_19_PIN;
-            break;
-#endif
-#if GPIO_20_EN
-
-        case GPIO_20:
-            port = GPIO_20_PORT;
-            pin = GPIO_20_PIN;
-            break;
-#endif
-#if GPIO_21_EN
-
-        case GPIO_21:
-            port = GPIO_21_PORT;
-            pin = GPIO_21_PIN;
-            break;
-#endif
-#if GPIO_22_EN
-
-        case GPIO_22:
-            port = GPIO_22_PORT;
-            pin = GPIO_22_PIN;
-            break;
-#endif
-#if GPIO_23_EN
-
-        case GPIO_23:
-            port = GPIO_23_PORT;
-            pin = GPIO_23_PIN;
-            break;
-#endif
-#if GPIO_24_EN
-
-        case GPIO_24:
-            port = GPIO_24_PORT;
-            pin = GPIO_24_PIN;
-            break;
-#endif
-#if GPIO_25_EN
-
-        case GPIO_25:
-            port = GPIO_25_PORT;
-            pin = GPIO_25_PIN;
-            break;
-#endif
-#if GPIO_26_EN
-
-        case GPIO_26:
-            port = GPIO_26_PORT;
-            pin = GPIO_26_PIN;
-            break;
-#endif
-#if GPIO_27_EN
-
-        case GPIO_27:
-            port = GPIO_27_PORT;
-            pin = GPIO_27_PIN;
-            break;
-#endif
-#if GPIO_28_EN
-
-        case GPIO_28:
-            port = GPIO_28_PORT;
-            pin = GPIO_28_PIN;
-            break;
-#endif
-#if GPIO_29_EN
-
-        case GPIO_29:
-            port = GPIO_29_PORT;
-            pin = GPIO_29_PIN;
-            break;
-#endif
-#if GPIO_30_EN
-
-        case GPIO_30:
-            port = GPIO_30_PORT;
-            pin = GPIO_30_PIN;
-            break;
-#endif
-#if GPIO_31_EN
-
-        case GPIO_31:
-            port = GPIO_31_PORT;
-            pin = GPIO_31_PIN;
-            break;
-#endif
-
-        default:
-            return;
+    if (dev >= GPIO_NUMOF) {
+        DEBUG("gpio_t out of range: %d >= %d\n", dev, GPIO_NUMOF);
+        return;
     }
+    uint8_t pin = kinetis_gpio_lut[dev].pin;
+    PORT_Type *port = kinetis_gpio_lut[dev].port;
 
     /* Save irqc state before disabling to allow enabling with the same trigger settings later. */
     config[dev].irqc = PORT_PCR_IRQC_MASK & port->PCR[pin];
@@ -1552,839 +911,48 @@ void gpio_irq_disable(gpio_t dev)
 
 int gpio_read(gpio_t dev)
 {
-    GPIO_Type *gpio;
-    uint32_t pin = 0;
-
-    switch (dev) {
-#if GPIO_0_EN
-
-        case GPIO_0:
-            gpio = GPIO_0_DEV;
-            pin = GPIO_0_PIN;
-            break;
-#endif
-#if GPIO_1_EN
-
-        case GPIO_1:
-            gpio = GPIO_1_DEV;
-            pin = GPIO_1_PIN;
-            break;
-#endif
-#if GPIO_2_EN
-
-        case GPIO_2:
-            gpio = GPIO_2_DEV;
-            pin = GPIO_2_PIN;
-            break;
-#endif
-#if GPIO_3_EN
-
-        case GPIO_3:
-            gpio = GPIO_3_DEV;
-            pin = GPIO_3_PIN;
-            break;
-#endif
-#if GPIO_4_EN
-
-        case GPIO_4:
-            gpio = GPIO_4_DEV;
-            pin = GPIO_4_PIN;
-            break;
-#endif
-#if GPIO_5_EN
-
-        case GPIO_5:
-            gpio = GPIO_5_DEV;
-            pin = GPIO_5_PIN;
-            break;
-#endif
-#if GPIO_6_EN
-
-        case GPIO_6:
-            gpio = GPIO_6_DEV;
-            pin = GPIO_6_PIN;
-            break;
-#endif
-#if GPIO_7_EN
-
-        case GPIO_7:
-            gpio = GPIO_7_DEV;
-            pin = GPIO_7_PIN;
-            break;
-#endif
-#if GPIO_8_EN
-
-        case GPIO_8:
-            gpio = GPIO_8_DEV;
-            pin = GPIO_8_PIN;
-            break;
-#endif
-#if GPIO_9_EN
-
-        case GPIO_9:
-            gpio = GPIO_9_DEV;
-            pin = GPIO_9_PIN;
-            break;
-#endif
-#if GPIO_10_EN
-
-        case GPIO_10:
-            gpio = GPIO_10_DEV;
-            pin = GPIO_10_PIN;
-            break;
-#endif
-#if GPIO_11_EN
-
-        case GPIO_11:
-            gpio = GPIO_11_DEV;
-            pin = GPIO_11_PIN;
-            break;
-#endif
-#if GPIO_12_EN
-
-        case GPIO_12:
-            gpio = GPIO_12_DEV;
-            pin = GPIO_12_PIN;
-            break;
-#endif
-#if GPIO_13_EN
-
-        case GPIO_13:
-            gpio = GPIO_13_DEV;
-            pin = GPIO_13_PIN;
-            break;
-#endif
-#if GPIO_14_EN
-
-        case GPIO_14:
-            gpio = GPIO_14_DEV;
-            pin = GPIO_14_PIN;
-            break;
-#endif
-#if GPIO_15_EN
-
-        case GPIO_15:
-            gpio = GPIO_15_DEV;
-            pin = GPIO_15_PIN;
-            break;
-#endif
-#if GPIO_16_EN
-
-        case GPIO_16:
-            gpio = GPIO_16_DEV;
-            pin = GPIO_16_PIN;
-            break;
-#endif
-#if GPIO_17_EN
-
-        case GPIO_17:
-            gpio = GPIO_17_DEV;
-            pin = GPIO_17_PIN;
-            break;
-#endif
-#if GPIO_18_EN
-
-        case GPIO_18:
-            gpio = GPIO_18_DEV;
-            pin = GPIO_18_PIN;
-            break;
-#endif
-#if GPIO_19_EN
-
-        case GPIO_19:
-            gpio = GPIO_19_DEV;
-            pin = GPIO_19_PIN;
-            break;
-#endif
-#if GPIO_20_EN
-
-        case GPIO_20:
-            gpio = GPIO_20_DEV;
-            pin = GPIO_20_PIN;
-            break;
-#endif
-#if GPIO_21_EN
-
-        case GPIO_21:
-            gpio = GPIO_21_DEV;
-            pin = GPIO_21_PIN;
-            break;
-#endif
-#if GPIO_22_EN
-
-        case GPIO_22:
-            gpio = GPIO_22_DEV;
-            pin = GPIO_22_PIN;
-            break;
-#endif
-#if GPIO_23_EN
-
-        case GPIO_23:
-            gpio = GPIO_23_DEV;
-            pin = GPIO_23_PIN;
-            break;
-#endif
-#if GPIO_24_EN
-
-        case GPIO_24:
-            gpio = GPIO_24_DEV;
-            pin = GPIO_24_PIN;
-            break;
-#endif
-#if GPIO_25_EN
-
-        case GPIO_25:
-            gpio = GPIO_25_DEV;
-            pin = GPIO_25_PIN;
-            break;
-#endif
-#if GPIO_26_EN
-
-        case GPIO_26:
-            gpio = GPIO_26_DEV;
-            pin = GPIO_26_PIN;
-            break;
-#endif
-#if GPIO_27_EN
-
-        case GPIO_27:
-            gpio = GPIO_27_DEV;
-            pin = GPIO_27_PIN;
-            break;
-#endif
-#if GPIO_28_EN
-
-        case GPIO_28:
-            gpio = GPIO_28_DEV;
-            pin = GPIO_28_PIN;
-            break;
-#endif
-#if GPIO_29_EN
-
-        case GPIO_29:
-            gpio = GPIO_29_DEV;
-            pin = GPIO_29_PIN;
-            break;
-#endif
-#if GPIO_30_EN
-
-        case GPIO_30:
-            gpio = GPIO_30_DEV;
-            pin = GPIO_30_PIN;
-            break;
-#endif
-#if GPIO_31_EN
-
-        case GPIO_31:
-            gpio = GPIO_31_DEV;
-            pin = GPIO_31_PIN;
-            break;
-#endif
-
-        default:
-            return -1;
+    if (dev >= GPIO_NUMOF) {
+        DEBUG("gpio_t out of range: %d >= %d\n", dev, GPIO_NUMOF);
+        return -1;
     }
+    uint8_t pin = kinetis_gpio_lut[dev].pin;
+    GPIO_Type *gpio = kinetis_gpio_lut[dev].gpio;
 
-    if (gpio->PDDR & GPIO_PDDR_PDD(1 << pin)) {      /* if configured as output */
-        return gpio->PDOR & GPIO_PDOR_PDO(1 << pin); /* read output data register */
+    if (gpio->PDDR & GPIO_PDDR_PDD(1 << pin)) { /* if configured as output */
+        /* read output data register */
+        return gpio->PDOR & GPIO_PDOR_PDO(1 << pin);
     }
     else {
-        return gpio->PDIR & GPIO_PDIR_PDI(1 << pin); /* else read input data register */
+        /* else read input data register */
+        return gpio->PDIR & GPIO_PDIR_PDI(1 << pin);
     }
 }
 
 void gpio_set(gpio_t dev)
 {
-    switch (dev) {
-#if GPIO_0_EN
-
-        case GPIO_0:
-            GPIO_0_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_0_PIN);
-            break;
-#endif
-#if GPIO_1_EN
-
-        case GPIO_1:
-            GPIO_1_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_1_PIN);
-            break;
-#endif
-#if GPIO_2_EN
-
-        case GPIO_2:
-            GPIO_2_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_2_PIN);
-            break;
-#endif
-#if GPIO_3_EN
-
-        case GPIO_3:
-            GPIO_3_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_3_PIN);
-            break;
-#endif
-#if GPIO_4_EN
-
-        case GPIO_4:
-            GPIO_4_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_4_PIN);
-            break;
-#endif
-#if GPIO_5_EN
-
-        case GPIO_5:
-            GPIO_5_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_5_PIN);
-            break;
-#endif
-#if GPIO_6_EN
-
-        case GPIO_6:
-            GPIO_6_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_6_PIN);
-            break;
-#endif
-#if GPIO_7_EN
-
-        case GPIO_7:
-            GPIO_7_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_7_PIN);
-            break;
-#endif
-#if GPIO_8_EN
-
-        case GPIO_8:
-            GPIO_8_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_8_PIN);
-            break;
-#endif
-#if GPIO_9_EN
-
-        case GPIO_9:
-            GPIO_9_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_9_PIN);
-            break;
-#endif
-#if GPIO_10_EN
-
-        case GPIO_10:
-            GPIO_10_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_10_PIN);
-            break;
-#endif
-#if GPIO_11_EN
-
-        case GPIO_11:
-            GPIO_11_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_11_PIN);
-            break;
-#endif
-#if GPIO_12_EN
-
-        case GPIO_12:
-            GPIO_12_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_12_PIN);
-            break;
-#endif
-#if GPIO_13_EN
-
-        case GPIO_13:
-            GPIO_13_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_13_PIN);
-            break;
-#endif
-#if GPIO_14_EN
-
-        case GPIO_14:
-            GPIO_14_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_14_PIN);
-            break;
-#endif
-#if GPIO_15_EN
-
-        case GPIO_15:
-            GPIO_15_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_15_PIN);
-            break;
-#endif
-#if GPIO_16_EN
-
-        case GPIO_16:
-            GPIO_16_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_16_PIN);
-            break;
-#endif
-#if GPIO_17_EN
-
-        case GPIO_17:
-            GPIO_17_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_17_PIN);
-            break;
-#endif
-#if GPIO_18_EN
-
-        case GPIO_18:
-            GPIO_18_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_18_PIN);
-            break;
-#endif
-#if GPIO_19_EN
-
-        case GPIO_19:
-            GPIO_19_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_19_PIN);
-            break;
-#endif
-#if GPIO_20_EN
-
-        case GPIO_20:
-            GPIO_20_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_20_PIN);
-            break;
-#endif
-#if GPIO_21_EN
-
-        case GPIO_21:
-            GPIO_21_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_21_PIN);
-            break;
-#endif
-#if GPIO_22_EN
-
-        case GPIO_22:
-            GPIO_22_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_22_PIN);
-            break;
-#endif
-#if GPIO_23_EN
-
-        case GPIO_23:
-            GPIO_23_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_23_PIN);
-            break;
-#endif
-#if GPIO_24_EN
-
-        case GPIO_24:
-            GPIO_24_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_24_PIN);
-            break;
-#endif
-#if GPIO_25_EN
-
-        case GPIO_25:
-            GPIO_25_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_25_PIN);
-            break;
-#endif
-#if GPIO_26_EN
-
-        case GPIO_26:
-            GPIO_26_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_26_PIN);
-            break;
-#endif
-#if GPIO_27_EN
-
-        case GPIO_27:
-            GPIO_27_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_27_PIN);
-            break;
-#endif
-#if GPIO_28_EN
-
-        case GPIO_28:
-            GPIO_28_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_28_PIN);
-            break;
-#endif
-#if GPIO_29_EN
-
-        case GPIO_29:
-            GPIO_29_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_29_PIN);
-            break;
-#endif
-#if GPIO_30_EN
-
-        case GPIO_30:
-            GPIO_30_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_30_PIN);
-            break;
-#endif
-#if GPIO_31_EN
-
-        case GPIO_31:
-            GPIO_31_DEV->PSOR |= GPIO_PSOR_PTSO(1 << GPIO_31_PIN);
-            break;
-#endif
+    if (dev >= GPIO_NUMOF) {
+        DEBUG("gpio_t out of range: %d >= %d\n", dev, GPIO_NUMOF);
+        return;
     }
+    kinetis_gpio_lut[dev].gpio->PSOR = (1 << kinetis_gpio_lut[dev].pin);
 }
 
 void gpio_clear(gpio_t dev)
 {
-    switch (dev) {
-#if GPIO_0_EN
-
-        case GPIO_0:
-            GPIO_0_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_0_PIN);
-            break;
-#endif
-#if GPIO_1_EN
-
-        case GPIO_1:
-            GPIO_1_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_1_PIN);
-            break;
-#endif
-#if GPIO_2_EN
-
-        case GPIO_2:
-            GPIO_2_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_2_PIN);
-            break;
-#endif
-#if GPIO_3_EN
-
-        case GPIO_3:
-            GPIO_3_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_3_PIN);
-            break;
-#endif
-#if GPIO_4_EN
-
-        case GPIO_4:
-            GPIO_4_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_4_PIN);
-            break;
-#endif
-#if GPIO_5_EN
-
-        case GPIO_5:
-            GPIO_5_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_5_PIN);
-            break;
-#endif
-#if GPIO_6_EN
-
-        case GPIO_6:
-            GPIO_6_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_6_PIN);
-            break;
-#endif
-#if GPIO_7_EN
-
-        case GPIO_7:
-            GPIO_7_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_7_PIN);
-            break;
-#endif
-#if GPIO_8_EN
-
-        case GPIO_8:
-            GPIO_8_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_8_PIN);
-            break;
-#endif
-#if GPIO_9_EN
-
-        case GPIO_9:
-            GPIO_9_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_9_PIN);
-            break;
-#endif
-#if GPIO_10_EN
-
-        case GPIO_10:
-            GPIO_10_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_10_PIN);
-            break;
-#endif
-#if GPIO_11_EN
-
-        case GPIO_11:
-            GPIO_11_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_11_PIN);
-            break;
-#endif
-#if GPIO_12_EN
-
-        case GPIO_12:
-            GPIO_12_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_12_PIN);
-            break;
-#endif
-#if GPIO_13_EN
-
-        case GPIO_13:
-            GPIO_13_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_13_PIN);
-            break;
-#endif
-#if GPIO_14_EN
-
-        case GPIO_14:
-            GPIO_14_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_14_PIN);
-            break;
-#endif
-#if GPIO_15_EN
-
-        case GPIO_15:
-            GPIO_15_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_15_PIN);
-            break;
-#endif
-#if GPIO_16_EN
-
-        case GPIO_16:
-            GPIO_16_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_16_PIN);
-            break;
-#endif
-#if GPIO_17_EN
-
-        case GPIO_17:
-            GPIO_17_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_17_PIN);
-            break;
-#endif
-#if GPIO_18_EN
-
-        case GPIO_18:
-            GPIO_18_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_18_PIN);
-            break;
-#endif
-#if GPIO_19_EN
-
-        case GPIO_19:
-            GPIO_19_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_19_PIN);
-            break;
-#endif
-#if GPIO_20_EN
-
-        case GPIO_20:
-            GPIO_20_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_20_PIN);
-            break;
-#endif
-#if GPIO_21_EN
-
-        case GPIO_21:
-            GPIO_21_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_21_PIN);
-            break;
-#endif
-#if GPIO_22_EN
-
-        case GPIO_22:
-            GPIO_22_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_22_PIN);
-            break;
-#endif
-#if GPIO_23_EN
-
-        case GPIO_23:
-            GPIO_23_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_23_PIN);
-            break;
-#endif
-#if GPIO_24_EN
-
-        case GPIO_24:
-            GPIO_24_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_24_PIN);
-            break;
-#endif
-#if GPIO_25_EN
-
-        case GPIO_25:
-            GPIO_25_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_25_PIN);
-            break;
-#endif
-#if GPIO_26_EN
-
-        case GPIO_26:
-            GPIO_26_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_26_PIN);
-            break;
-#endif
-#if GPIO_27_EN
-
-        case GPIO_27:
-            GPIO_27_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_27_PIN);
-            break;
-#endif
-#if GPIO_28_EN
-
-        case GPIO_28:
-            GPIO_28_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_28_PIN);
-            break;
-#endif
-#if GPIO_29_EN
-
-        case GPIO_29:
-            GPIO_29_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_29_PIN);
-            break;
-#endif
-#if GPIO_30_EN
-
-        case GPIO_30:
-            GPIO_30_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_30_PIN);
-            break;
-#endif
-#if GPIO_31_EN
-
-        case GPIO_31:
-            GPIO_31_DEV->PCOR |= GPIO_PCOR_PTCO(1 << GPIO_31_PIN);
-            break;
-#endif
+    if (dev >= GPIO_NUMOF) {
+        DEBUG("gpio_t out of range: %d >= %d\n", dev, GPIO_NUMOF);
+        return;
     }
+    kinetis_gpio_lut[dev].gpio->PCOR = (1 << kinetis_gpio_lut[dev].pin);
 }
 
 void gpio_toggle(gpio_t dev)
 {
-    switch (dev) {
-#if GPIO_0_EN
-
-        case GPIO_0:
-            GPIO_0_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_0_PIN);
-            break;
-#endif
-#if GPIO_1_EN
-
-        case GPIO_1:
-            GPIO_1_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_1_PIN);
-            break;
-#endif
-#if GPIO_2_EN
-
-        case GPIO_2:
-            GPIO_2_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_2_PIN);
-            break;
-#endif
-#if GPIO_3_EN
-
-        case GPIO_3:
-            GPIO_3_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_3_PIN);
-            break;
-#endif
-#if GPIO_4_EN
-
-        case GPIO_4:
-            GPIO_4_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_4_PIN);
-            break;
-#endif
-#if GPIO_5_EN
-
-        case GPIO_5:
-            GPIO_5_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_5_PIN);
-            break;
-#endif
-#if GPIO_6_EN
-
-        case GPIO_6:
-            GPIO_6_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_6_PIN);
-            break;
-#endif
-#if GPIO_7_EN
-
-        case GPIO_7:
-            GPIO_7_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_7_PIN);
-            break;
-#endif
-#if GPIO_8_EN
-
-        case GPIO_8:
-            GPIO_8_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_8_PIN);
-            break;
-#endif
-#if GPIO_9_EN
-
-        case GPIO_9:
-            GPIO_9_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_9_PIN);
-            break;
-#endif
-#if GPIO_10_EN
-
-        case GPIO_10:
-            GPIO_10_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_10_PIN);
-            break;
-#endif
-#if GPIO_11_EN
-
-        case GPIO_11:
-            GPIO_11_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_11_PIN);
-            break;
-#endif
-#if GPIO_12_EN
-
-        case GPIO_12:
-            GPIO_12_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_12_PIN);
-            break;
-#endif
-#if GPIO_13_EN
-
-        case GPIO_13:
-            GPIO_13_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_13_PIN);
-            break;
-#endif
-#if GPIO_14_EN
-
-        case GPIO_14:
-            GPIO_14_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_14_PIN);
-            break;
-#endif
-#if GPIO_15_EN
-
-        case GPIO_15:
-            GPIO_15_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_15_PIN);
-            break;
-#endif
-#if GPIO_16_EN
-
-        case GPIO_16:
-            GPIO_16_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_16_PIN);
-            break;
-#endif
-#if GPIO_17_EN
-
-        case GPIO_17:
-            GPIO_17_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_17_PIN);
-            break;
-#endif
-#if GPIO_18_EN
-
-        case GPIO_18:
-            GPIO_18_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_18_PIN);
-            break;
-#endif
-#if GPIO_19_EN
-
-        case GPIO_19:
-            GPIO_19_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_19_PIN);
-            break;
-#endif
-#if GPIO_20_EN
-
-        case GPIO_20:
-            GPIO_20_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_20_PIN);
-            break;
-#endif
-#if GPIO_21_EN
-
-        case GPIO_21:
-            GPIO_21_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_21_PIN);
-            break;
-#endif
-#if GPIO_22_EN
-
-        case GPIO_22:
-            GPIO_22_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_22_PIN);
-            break;
-#endif
-#if GPIO_23_EN
-
-        case GPIO_23:
-            GPIO_23_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_23_PIN);
-            break;
-#endif
-#if GPIO_24_EN
-
-        case GPIO_24:
-            GPIO_24_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_24_PIN);
-            break;
-#endif
-#if GPIO_25_EN
-
-        case GPIO_25:
-            GPIO_25_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_25_PIN);
-            break;
-#endif
-#if GPIO_26_EN
-
-        case GPIO_26:
-            GPIO_26_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_26_PIN);
-            break;
-#endif
-#if GPIO_27_EN
-
-        case GPIO_27:
-            GPIO_27_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_27_PIN);
-            break;
-#endif
-#if GPIO_28_EN
-
-        case GPIO_28:
-            GPIO_28_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_28_PIN);
-            break;
-#endif
-#if GPIO_29_EN
-
-        case GPIO_29:
-            GPIO_29_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_29_PIN);
-            break;
-#endif
-#if GPIO_30_EN
-
-        case GPIO_30:
-            GPIO_30_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_30_PIN);
-            break;
-#endif
-#if GPIO_31_EN
-
-        case GPIO_31:
-            GPIO_31_DEV->PTOR |= GPIO_PTOR_PTTO(1 << GPIO_31_PIN);
-            break;
-#endif
+    if (dev >= GPIO_NUMOF) {
+        DEBUG("gpio_t out of range: %d >= %d\n", dev, GPIO_NUMOF);
+        return;
     }
+    kinetis_gpio_lut[dev].gpio->PTOR = (1 << kinetis_gpio_lut[dev].pin);
 }
 
 void gpio_write(gpio_t dev, int value)


### PR DESCRIPTION
Saves a bunch of ROM space and possibly reduces latency as well.

mulle, gcc-4.9:
```
   text    data     bss     dec     hex filename
  20800     216   65320   86336   15140 /data/riotbuild/riotproject/tests/periph_gpio/bin/mulle/periph_gpio.elf
  18992     216   65320   84528   14a30 /data/riotbuild/riotproject/tests/periph_gpio/bin/mulle/periph_gpio.elf
  diff = 1808
  36080     272   65264  101616   18cf0 /data/riotbuild/riotproject/examples/default/bin/mulle/default.elf
  34296     272   65264   99832   185f8 /data/riotbuild/riotproject/examples/default/bin/mulle/default.elf
  diff = 1784
```

also it improves code readability alot.

I refactored the out of bounds checking to only occur when DEVELHELP is set.