### PR TITLE
rpl: remove needless initializers

### DIFF
--- a/sys/net/include/rpl.h
+++ b/sys/net/include/rpl.h
@@ -234,15 +234,6 @@ void rpl_del_routing_entry(ipv6_addr_t *addr);
 rpl_routing_entry_t *rpl_find_routing_entry(ipv6_addr_t *addr);
 
 /**
- * @brief Clears routing table.
- *
- * @deprecated This function is obsolete and will be removed shortly. This will be replaced with a
- * common routing information base.
- *
- * */
-void rpl_clear_routing_table(void);
-
-/**
  * @brief Returns routing table
  *
  * @deprecated This function is obsolete and will be removed shortly. This will be replaced with a

--- a/sys/net/include/rpl/rpl_dodag.h
+++ b/sys/net/include/rpl/rpl_dodag.h
@@ -28,7 +28,6 @@ extern "C" {
 
 void rpl_dao_ack_received(rpl_dodag_t *dodag);
 void rpl_delay_dao(rpl_dodag_t *dodag);
-void rpl_instances_init(void);
 rpl_instance_t *rpl_new_instance(uint8_t instanceid);
 rpl_instance_t *rpl_get_instance(uint8_t instanceid);
 rpl_instance_t *rpl_get_my_instance(void);

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -76,12 +76,10 @@ static ipv6_hdr_t *ipv6_buf;
 uint8_t rpl_init(int if_id, ipv6_addr_t *address)
 {
     rpl_if_id = if_id;
-    rpl_instances_init();
 
     /* initialize routing table */
 #if RPL_MAX_ROUTING_ENTRIES != 0
     rpl_max_routing_entries = RPL_MAX_ROUTING_ENTRIES;
-    rpl_clear_routing_table();
 #endif
 
     rpl_process_pid = thread_create(rpl_process_buf, RPL_PROCESS_STACKSIZE,
@@ -447,16 +445,6 @@ rpl_routing_entry_t *rpl_find_routing_entry(ipv6_addr_t *addr)
     }
 
     return NULL;
-}
-#endif
-
-#if RPL_MAX_ROUTING_ENTRIES != 0
-void rpl_clear_routing_table(void)
-{
-
-    for (uint8_t i = 0; i < rpl_max_routing_entries; i++) {
-        memset(&rpl_routing_table[i], 0, sizeof(rpl_routing_table[i]));
-    }
 }
 #endif
 

--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -43,11 +43,6 @@ void rpl_trickle_send_dio(void *args)
     rpl_send_DIO((rpl_dodag_t *) args, &mcast);
 }
 
-void rpl_instances_init(void)
-{
-    memset(instances, 0, sizeof(rpl_instance_t) * RPL_MAX_INSTANCES);
-}
-
 rpl_instance_t *rpl_new_instance(uint8_t instanceid)
 {
     rpl_instance_t *inst;


### PR DESCRIPTION
`rpl_instances_init()` is used in `rpl_init()`. However, since the `instances` array is statically allocated, the content is zeroed anyways. Calling `rpl_init()` multiple times would also overwrite the existing instances.

The same is the case for `rpl_clear_routing_table()`. The `rpl_routing_table` is initialized statically and thus zeroed. Furthermore, this function is marked as depcrecated and not used anywhere else.