### PR TITLE
netif: add functions to parse and output hardware addresses

### DIFF
--- a/sys/include/net/ng_netif.h
+++ b/sys/include/net/ng_netif.h
@@ -90,6 +90,44 @@ void ng_netif_remove(kernel_pid_t pid);
  */
 kernel_pid_t *ng_netif_get(size_t *size);
 
+/**
+ * @brief   Converts a hardware address to a human readable string.
+ *
+ * @details The format will be like `xx:xx:xx:xx` where `xx` are the bytes
+ *          of @p addr in hexadecimal representation.
+ *
+ * @pre @p out_len >= 3 * @p addr_len
+ *
+ * @param[out] out      A string to store the output in.
+ * @param[out] out_len  Length of @p out. Must be at least
+ *                      3 * @p addr_len long.
+ * @param[in] addr      A hardware address.
+ * @param[in] addr_len  Length of @p addr.
+ *
+ * @return  Copy of @p out on success.
+ * @return  NULL, if @p out_len < 3 * @p addr_len.
+ */
+char *ng_netif_addr_to_str(char *out, size_t out_len, uint8_t *addr,
+                           size_t addr_len);
+
+/**
+ * @brief   Parses a string of colon-separated hexadecimals to a hardware
+ *          address.
+ *
+ * @details The input format must be like `xx:xx:xx:xx` where `xx` will be the
+ *          bytes of @p addr in hexadecimal representation.
+ *          Changes @p str for simple parsing purposes. Make a copy if you
+ *          need it later.
+ *
+ * @param[out] out      The resulting hardware address.
+ * @param[out] out_len  Length of @p out.
+ * @param[in] str       A string of colon-separated hexadecimals.
+ *
+ * @return  Actual length of @p out on success.
+ * @return  0, on failure.
+ */
+size_t ng_netif_addr_from_str(uint8_t *out, size_t out_len, char *str);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/crosslayer/ng_netif/ng_netif_addr_from_str.c
+++ b/sys/net/crosslayer/ng_netif/ng_netif_addr_from_str.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+
+#include "net/ng_netif.h"
+
+static uint8_t _parse_byte(char *str)
+{
+    uint8_t res = 0;
+
+    for (int i = 0; i < 2; i++) {   /* iterate over half-bytes */
+        if ((str[i] >= '0') && (str[i] <= '9')) {       /* if '0'-'9' */
+            res |= (str[i] - '0') << (4 * (1 - i));     /* set half-byte to 0-9 */
+        }
+        else if ((str[i] >= 'a') && (str[i] <= 'f')) {  /* if 'a'-'f' */
+            res |= (str[i] - 'a' + 10) << (4 * (1 - i));/* set half-byte to 10-15 */
+        }
+
+        /* interpret any other character as 0 */
+    }
+
+    return res;
+}
+
+size_t ng_netif_addr_from_str(uint8_t *out, size_t out_len, char *str)
+{
+    size_t res = 0;
+    char *byte_str = str;
+    int end = 0;
+
+    while (end == 0) {
+        str++;
+
+        if ((res >= out_len) || ((str - byte_str) > 2)) {
+            /* no space left or byte_str has become > 2 chars */
+            return 0;
+        }
+
+        if ((*str == ':') || (*str == '\0')) {
+            end = (*str == '\0');
+            *str = '\0';
+            out[res++] = _parse_byte(byte_str);
+            byte_str = ++str;
+        }
+    }
+
+    return res;
+}
+
+/** @} */

--- a/sys/net/crosslayer/ng_netif/ng_netif_addr_to_str.c
+++ b/sys/net/crosslayer/ng_netif/ng_netif_addr_to_str.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+
+#include "net/ng_netif.h"
+
+static inline char _half_byte_to_char(uint8_t half_byte)
+{
+    return (half_byte < 10) ? ('0' + half_byte) : ('a' + (half_byte - 10));
+}
+
+char *ng_netif_addr_to_str(char *out, size_t out_len, uint8_t *addr,
+                           size_t addr_len)
+{
+    size_t i;
+
+    if (out_len < (3 * addr_len)) { /* 2 for every byte, 1 for ':' or '\0' */
+        return NULL;
+    }
+
+    for (i = 0; i < addr_len; i++) {
+        out[(3 * i)] = _half_byte_to_char(addr[i] >> 4);
+        out[(3 * i) + 1] = _half_byte_to_char(addr[i] & 0xf);
+
+        if (i != (addr_len - 1)) {
+            out[(3 * i) + 2] = ':';
+        }
+        else {
+            out[(3 * i) + 2] = '\0';
+        }
+    }
+
+    return out;
+}
+
+/** @} */

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -79,42 +79,6 @@ static void _set_usage(char *cmd_name)
          "       * \"src_len\" - sets the source address length in byte\n");
 }
 
-static size_t _parse_hwaddr(char *str, uint8_t *addr)
-{
-    char *tok = strtok(str, ":");
-    size_t res = 0;
-
-    while (tok != NULL) {
-        if (res >= MAX_ADDR_LEN) {
-            return 0;
-        }
-
-        unsigned int tmp = strtoul(tok, NULL, 16);
-
-        if (tmp <= 0xff) {
-            addr[res++] = (uint8_t)tmp;
-        }
-        else {
-            return 0;
-        }
-
-        tok = strtok(NULL, ":");
-    }
-
-    return res;
-}
-
-static void _print_hwaddr(uint8_t *addr, uint8_t addr_len)
-{
-    for (uint8_t i = 0; i < addr_len; i++) {
-        printf("%02x", addr[i]);
-
-        if (i != (addr_len - 1)) {
-            printf(":");
-        }
-    }
-}
-
 static void _print_netconf(ng_netconf_opt_t opt)
 {
     switch (opt) {
@@ -160,8 +124,10 @@ void _netif_list(kernel_pid_t dev)
     res = ng_netapi_get(dev, NETCONF_OPT_ADDRESS, 0, hwaddr, sizeof(hwaddr));
 
     if (res >= 0) {
+        char hwaddr_str[res * 3];
         printf(" HWaddr: ");
-        _print_hwaddr(hwaddr, (uint8_t)res);
+        printf("%s", ng_netif_addr_to_str(hwaddr_str, sizeof(hwaddr_str),
+                                          hwaddr, res));
         printf(" ");
     }
 
@@ -188,8 +154,10 @@ void _netif_list(kernel_pid_t dev)
     res = ng_netapi_get(dev, NETCONF_OPT_ADDRESS_LONG, 0, hwaddr, sizeof(hwaddr));
 
     if (res >= 0) {
+        char hwaddr_str[res * 3];
         printf("Long HWaddr: ");
-        _print_hwaddr(hwaddr, (uint8_t)res);
+        printf("%s", ng_netif_addr_to_str(hwaddr_str, sizeof(hwaddr_str),
+                                          hwaddr, res));
         printf("\n            ");
     }
 
@@ -273,7 +241,7 @@ static void _netif_set_addr(kernel_pid_t dev, ng_netconf_opt_t opt,
                             char *addr_str)
 {
     uint8_t addr[MAX_ADDR_LEN];
-    size_t addr_len = _parse_hwaddr(addr_str, addr);
+    size_t addr_len = ng_netif_addr_from_str(addr, sizeof(addr), addr_str);
 
     if (addr_len == 0) {
         puts("error: unable to parse address.\n"
@@ -291,9 +259,7 @@ static void _netif_set_addr(kernel_pid_t dev, ng_netconf_opt_t opt,
 
     printf("success: set ");
     _print_netconf(opt);
-    printf(" on interface %" PRIkernel_pid " to ", dev);
-    _print_hwaddr(addr, addr_len);
-    puts("");
+    printf(" on interface %" PRIkernel_pid " to %s\n", dev, addr_str);
 }
 
 static void _netif_set(char *cmd_name, kernel_pid_t dev, char *key, char *value)
@@ -346,7 +312,7 @@ int _netif_send(int argc, char **argv)
     }
 
     /* parse address */
-    addr_len = _parse_hwaddr(argv[2], addr);
+    addr_len = ng_netif_addr_from_str(addr, sizeof(addr), argv[2]);
 
     if (addr_len == 0) {
         puts("error: invalid address given");

--- a/tests/unittests/tests-netif/tests-netif.c
+++ b/tests/unittests/tests-netif/tests-netif.c
@@ -157,6 +157,65 @@ static void test_ng_netif_get__full(void)
     TEST_ASSERT_EQUAL_INT(NG_NETIF_NUMOF, size);
 }
 
+static void test_ng_netif_addr_to_str__out_too_short(void)
+{
+    uint8_t addr[] = {0x05, 0xcd};
+    char out[2];
+
+    TEST_ASSERT_NULL(ng_netif_addr_to_str(out, sizeof(out), addr, sizeof(addr)));
+}
+
+static void test_ng_netif_addr_to_str__success(void)
+{
+    uint8_t addr[] = {0x05, 0xcd};
+    char out[3 * sizeof(addr)];
+
+    TEST_ASSERT_EQUAL_STRING("05:cd", ng_netif_addr_to_str(out, sizeof(out),
+                             addr, sizeof(addr)));
+}
+
+static void test_ng_netif_addr_from_str__out_too_short(void)
+{
+    char str[] = "05:cd";
+    uint8_t out[1];
+
+    TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
+}
+
+static void test_ng_netif_addr_from_str__ill_formated1(void)
+{
+    char str[] = "576:cd";
+    uint8_t out[sizeof(str)];
+
+    TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
+}
+
+static void test_ng_netif_addr_from_str__ill_formated2(void)
+{
+    char str[] = TEST_STRING8;
+    uint8_t out[sizeof(str)];
+
+    TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
+}
+
+static void test_ng_netif_addr_from_str__ill_formated3(void)
+{
+    char str[] = "05-cd";
+    uint8_t out[sizeof(str)];
+
+    TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
+}
+
+static void test_ng_netif_addr_from_str__success(void)
+{
+    char str[] = "05:cd";
+    uint8_t out[2];
+
+    TEST_ASSERT_EQUAL_INT(2, ng_netif_addr_from_str(out, sizeof(out), str));
+    TEST_ASSERT_EQUAL_INT(0x05, out[0]);
+    TEST_ASSERT_EQUAL_INT(0xcd, out[1]);
+}
+
 Test *tests_netif_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -170,6 +229,13 @@ Test *tests_netif_tests(void)
         new_TestFixture(test_ng_netif_get__empty),
         new_TestFixture(test_ng_netif_get__success_3_minus_one),
         new_TestFixture(test_ng_netif_get__full),
+        new_TestFixture(test_ng_netif_addr_to_str__out_too_short),
+        new_TestFixture(test_ng_netif_addr_to_str__success),
+        new_TestFixture(test_ng_netif_addr_from_str__out_too_short),
+        new_TestFixture(test_ng_netif_addr_from_str__ill_formated1),
+        new_TestFixture(test_ng_netif_addr_from_str__ill_formated2),
+        new_TestFixture(test_ng_netif_addr_from_str__ill_formated3),
+        new_TestFixture(test_ng_netif_addr_from_str__success),
     };
 
     EMB_UNIT_TESTCALLER(netif_tests, set_up, NULL, fixtures);


### PR DESCRIPTION
Adds address parsing and string-conversion functions for hardware addresses in a similar way as I did for `ng_ipv6_addr`.