### PR TITLE
nettype: introduce type for ng_netif_hdr_t

### DIFF
--- a/sys/include/net/ng_nettype.h
+++ b/sys/include/net/ng_nettype.h
@@ -37,6 +37,11 @@ extern "C" {
  * @note    Expand at will.
  */
 typedef enum {
+    /**
+     * @brief   Protocol is as defined in @ref ng_netif_hdr_t. Not usable with
+     *          @ref net_ng_netreg
+     */
+    NG_NETTYPE_NETIF = -1,
     NG_NETTYPE_UNDEF = 0,       /**< Protocol is undefined */
 
 #ifdef MODULE_NG_SIXLOWPAN

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -324,7 +324,7 @@ void _netif_send(int argc, char **argv)
     /* put packet together */
     pkt = ng_pktbuf_add(NULL, argv[3], strlen(argv[3]), NG_NETTYPE_UNDEF);
     pkt = ng_pktbuf_add(pkt, NULL, sizeof(ng_netif_hdr_t) + addr_len,
-                        NG_NETTYPE_UNDEF);
+                        NG_NETTYPE_NETIF);
     nethdr = (ng_netif_hdr_t *)pkt->data;
     ng_netif_hdr_init(nethdr, 0, addr_len);
     ng_netif_hdr_set_dst_addr(nethdr, addr, addr_len);


### PR DESCRIPTION
Introduces nettype for the `ng_netif_hdr_t` header.