### PR TITLE
Sys: Adding defgroup to rpl.h

### DIFF
--- a/sys/net/include/rpl.h
+++ b/sys/net/include/rpl.h
@@ -8,7 +8,11 @@
  */
 
 /**
+ * @defgroup    rpl RPL Header
+ * @brief       Provides core functionality for RPL 
+ * 
  * @ingroup     rpl
+ *
  * @{
  *
  * @file        rpl.h


### PR DESCRIPTION
- Adding @defgroup and brief section to rpl.h
- Part of fix for #2656 