### PR TITLE
cpu/samd21:fix gpio bug

### DIFF
--- a/cpu/samd21/periph/gpio.c
+++ b/cpu/samd21/periph/gpio.c
@@ -148,6 +148,21 @@ int gpio_init_out(gpio_t dev, gpio_pp_t pushpull)
     }
 
     /* configure as output */
+    if (pin < 16) {
+        port->WRCONFIG.reg = PORT_WRCONFIG_WRPINCFG \
+                        | PORT_WRCONFIG_WRPMUX \
+                        | PORT_WRCONFIG_PMUX(0x0) \
+                        | PORT_WRCONFIG_DRVSTR \
+                        | (1 << pin);
+    }
+    else {
+        port->WRCONFIG.reg = PORT_WRCONFIG_HWSEL \
+                        | PORT_WRCONFIG_WRPINCFG \
+                        | PORT_WRCONFIG_WRPMUX \
+                        | PORT_WRCONFIG_PMUX(0x0) \
+                        | PORT_WRCONFIG_DRVSTR \
+                        | ((1 << pin) >> 16);
+    }
     port->DIRSET.reg = 1 << pin;
 
     /* configure the pin's pull resistor state */


### PR DESCRIPTION
This PR fix the issue #2713.
DRVSTR controls the output driver strength of an I/O pin configured as an output
0: Pin drive strength is set to normal drive strength.
1: Pin drive strength is set to stronger drive strength.

When the pin is set as an interrupt, this bit is set to 0. When it is back to output, it should be set to 1 again, otherwise, the output level is not set correctly. 