### PR TITLE
net/ng_pktdump: manage stack internal and use msg queue

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -86,6 +86,10 @@
 #include "l2_ping.h"
 #endif
 
+#ifdef MODULE_NG_PKTDUMP
+#include "net/ng_pktdump.h"
+#endif
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -271,5 +275,9 @@ void auto_init(void)
 #ifdef MODULE_TCP
     DEBUG("Auto init transport layer module: [tcp].\n");
     tcp_init_transport_layer();
+#endif
+#ifdef MODULE_NG_PKTDUMP
+    DEBUG("Auto init ng_pktdump module.\n");
+    ng_pktdump_init();
 #endif
 }

--- a/sys/include/net/ng_pktdump.h
+++ b/sys/include/net/ng_pktdump.h
@@ -29,6 +29,13 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Message queue size for the pktdump thread
+ */
+#ifndef NG_PKTDUMP_MSG_QUEUE_SIZE
+#define NG_PKTDUMP_MSG_QUEUE_SIZE       (8U)
+#endif
+
+/**
  * @brief   Start the packet dump thread and listening for incoming packets
  *
  * @param[in] stack         stack for the packet dump thread

--- a/sys/include/net/ng_pktdump.h
+++ b/sys/include/net/ng_pktdump.h
@@ -36,18 +36,34 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Priority of the pktdump thread
+ */
+#ifndef NG_PKTDUMP_PRIO
+#define NG_PKTDUMP_PRIO                 (PRIORITY_MIN - 1)
+#endif
+
+/**
+ * @brief   Stack size used for the pktdump thread
+ */
+#ifndef NG_PKTDUMP_STACKSIZE
+#define NG_PKTDUMP_STACKSIZE            (KERNEL_CONF_STACKSIZE_MAIN)
+#endif
+
+/**
+ * @brief   Get the PID of the pktdump thread
+ *
+ * @return  PID of the pktdump thread
+ * @return  @ref KERNEL_PID_UNDEF if not initialized
+ */
+kernel_pid_t ng_pktdump_getpid(void);
+
+/**
  * @brief   Start the packet dump thread and listening for incoming packets
  *
- * @param[in] stack         stack for the packet dump thread
- * @param[in] stacksize     size of @p stack
- * @param[in] priority      priority of the packet dump thread
- * @param[in] name          name for the packet dump thread
- *
- * @return                  PID of newly created task on success
- * @return                  negative value on error
+ * @return  PID of the pktdump thread
+ * @return  negative value on error
  */
-kernel_pid_t ng_pktdump_init(char *stack, int stacksize,
-                             char priority, char *name);
+kernel_pid_t ng_pktdump_init(void);
 
 #ifdef __cplusplus
 }

--- a/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
+++ b/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
@@ -90,6 +90,10 @@ void *_eventloop(void *arg)
 {
     (void)arg;
     msg_t msg;
+    msg_t msg_queue[NG_PKTDUMP_MSG_QUEUE_SIZE];
+
+    /* setup the message queue */
+    msg_init_queue(msg_queue, NG_PKTDUMP_MSG_QUEUE_SIZE);
 
     while (1) {
         msg_receive(&msg);

--- a/tests/driver_xbee/main.c
+++ b/tests/driver_xbee/main.c
@@ -56,11 +56,6 @@ static xbee_t dev;
 static char nomac_stack[KERNEL_CONF_STACKSIZE_DEFAULT];
 
 /**
- * @brief   Stack for the pktdump thread
- */
-static char dump_stack[KERNEL_CONF_STACKSIZE_MAIN];
-
-/**
  * @brief   Read chars from STDIO
  */
 int shell_read(void)
@@ -93,8 +88,7 @@ int main(void)
     ng_netif_init();
 
     /* initialize and register pktdump */
-    dump.pid = ng_pktdump_init(dump_stack, sizeof(dump_stack), PRIORITY_MAIN - 2,
-                           "dump");
+    dump.pid = ng_pktdump_getpid();
     if (dump.pid <= KERNEL_PID_UNDEF) {
         puts("Error starting pktdump thread");
         return -1;


### PR DESCRIPTION
It does not make sense to run more than one instance of the `ng_pktdump` module. For this it is easier to handle the stack inside the module and just ask the module for the PID whenever you want to register for outputting packets of a certain type at `ng_netreg`.

The eventually higher frequency of incoming messages is handled by by a message queue.

A nice side effect is, that the initialization can be handled by `auto_init` now...