### PR TITLE
ipv6_nc: add iterators

### DIFF
--- a/sys/include/net/ng_ipv6/nc.h
+++ b/sys/include/net/ng_ipv6/nc.h
@@ -176,6 +176,24 @@ void ng_ipv6_nc_remove(kernel_pid_t iface, const ng_ipv6_addr_t *ipv6_addr);
 ng_ipv6_nc_t *ng_ipv6_nc_get(kernel_pid_t iface, const ng_ipv6_addr_t *ipv6_addr);
 
 /**
+ * @brief   Gets next entry in neighbor cache after @p prev.
+ *
+ * @param[in] prev  Previous entry. NULL to start iteration.
+ *
+ * @return  The next entry in neighbor cache.
+ */
+ng_ipv6_nc_t *ng_ipv6_nc_get_next(ng_ipv6_nc_t *prev);
+
+/**
+ * @brief   Gets next reachable router entry in neighbor cache after @p prev.
+ *
+ * @param[in] prev  Previous router entry. NULL to start iteration.
+ *
+ * @return  The next reachable router entry in neighbor cache.
+ */
+ng_ipv6_nc_t *ng_ipv6_nc_get_next_router(ng_ipv6_nc_t *prev);
+
+/**
  * @brief   Searches for any neighbor cache entry fitting the @p ipv6_addr,
  *          where you currently can send a packet to (do not confuse with
  *          NG_IPV6_NC_STATE_REACHABLE).

--- a/sys/net/network_layer/ng_ipv6/nc/ng_ipv6_nc.c
+++ b/sys/net/network_layer/ng_ipv6/nc/ng_ipv6_nc.c
@@ -136,6 +136,50 @@ ng_ipv6_nc_t *ng_ipv6_nc_get(kernel_pid_t iface, const ng_ipv6_addr_t *ipv6_addr
     return NULL;
 }
 
+ng_ipv6_nc_t *ng_ipv6_nc_get_next(ng_ipv6_nc_t *prev)
+{
+    if (prev == NULL) {
+        prev = ncache;
+    }
+    else {
+        prev++;     /* get next entry */
+    }
+
+    while (prev < (ncache + NG_IPV6_NC_SIZE)) { /* while not reached end */
+        if (!ng_ipv6_addr_is_unspecified(&(prev->ipv6_addr))) {
+            return prev;
+        }
+
+        prev++;
+    }
+
+    return NULL;
+}
+
+static inline bool _is_reachable(ng_ipv6_nc_t *entry)
+{
+    switch ((entry->flags & NG_IPV6_NC_STATE_MASK) >> NG_IPV6_NC_STATE_POS) {
+        case NG_IPV6_NC_STATE_UNREACHABLE:
+        case NG_IPV6_NC_STATE_INCOMPLETE:
+            return false;
+
+        default:
+            return true;
+    }
+}
+
+ng_ipv6_nc_t *ng_ipv6_nc_get_next_router(ng_ipv6_nc_t *prev)
+{
+    for (ng_ipv6_nc_t *router = ng_ipv6_nc_get_next(prev); router != NULL;
+         router = ng_ipv6_nc_get_next(router)) {
+        if (router->flags & NG_IPV6_NC_IS_ROUTER) {
+            return router;
+        }
+    }
+
+    return NULL;
+}
+
 ng_ipv6_nc_t *ng_ipv6_nc_get_reachable(kernel_pid_t iface,
                                        const ng_ipv6_addr_t *ipv6_addr)
 {
@@ -148,17 +192,11 @@ ng_ipv6_nc_t *ng_ipv6_nc_get_reachable(kernel_pid_t iface,
         return NULL;
     }
 
-    switch ((entry->flags & NG_IPV6_NC_STATE_MASK) >> NG_IPV6_NC_STATE_POS) {
-        case NG_IPV6_NC_STATE_UNREACHABLE:
-        case NG_IPV6_NC_STATE_INCOMPLETE:
-            DEBUG("ipv6_nc: Entry %s is unreachable (flags = 0x%02x)\n",
-                  ng_ipv6_addr_to_str(addr_str, ipv6_addr, sizeof(addr_str)),
-                  entry->flags);
-            return NULL;
-
-        default:
-            return entry;
+    if (_is_reachable(entry)) {
+        return entry;
     }
+
+    return NULL;
 }
 
 ng_ipv6_nc_t *ng_ipv6_nc_still_reachable(const ng_ipv6_addr_t *ipv6_addr)

--- a/sys/shell/commands/sc_ipv6_nc.c
+++ b/sys/shell/commands/sc_ipv6_nc.c
@@ -26,6 +26,64 @@
 /* maximum length of L2 address */
 #define MAX_L2_ADDR_LEN (8U)
 
+static void _print_nc_state(ng_ipv6_nc_t *entry)
+{
+    switch (entry->flags & NG_IPV6_NC_STATE_MASK) {
+        case NG_IPV6_NC_STATE_UNMANAGED:
+            printf("UNMANAGED");
+            break;
+
+        case NG_IPV6_NC_STATE_UNREACHABLE:
+            printf("UNREACHABLE");
+            break;
+
+        case NG_IPV6_NC_STATE_INCOMPLETE:
+            printf("INCOMPLETE");
+            break;
+
+        case NG_IPV6_NC_STATE_STALE:
+            printf("STALE");
+            break;
+
+        case NG_IPV6_NC_STATE_DELAY:
+            printf("DELAY");
+            break;
+
+        case NG_IPV6_NC_STATE_PROBE:
+            printf("PROBE");
+            break;
+
+        case NG_IPV6_NC_STATE_REACHABLE:
+            printf("REACHABLE");
+            break;
+
+        default:
+            printf("UNKNOWN");
+            break;
+    }
+}
+
+static void _print_nc_type(ng_ipv6_nc_t *entry)
+{
+    switch (entry->flags & NG_IPV6_NC_TYPE_MASK) {
+        case NG_IPV6_NC_TYPE_GC:
+            printf("GC");
+            break;
+
+        case NG_IPV6_NC_TYPE_TENTATIVE:
+            printf("T");
+            break;
+
+        case NG_IPV6_NC_TYPE_REGISTERED:
+            printf("R");
+            break;
+
+        default:
+            printf("-");
+            break;
+    }
+}
+
 static bool _is_iface(kernel_pid_t iface)
 {
 #ifdef MODULE_NG_NETIF
@@ -42,6 +100,30 @@ static bool _is_iface(kernel_pid_t iface)
 #else
     return (thread_get(iface) != NULL);
 #endif
+}
+
+static int _ipv6_nc_list(void)
+{
+    char ipv6_str[NG_IPV6_ADDR_MAX_STR_LEN];
+    char l2addr_str[3 * MAX_L2_ADDR_LEN];
+
+    puts("IPv6 address                    if  L2 address                state      type");
+    puts("-----------------------------------------------------------------------------");
+
+    for (ng_ipv6_nc_t *entry = ng_ipv6_nc_get_next(NULL);
+         entry != NULL;
+         entry = ng_ipv6_nc_get_next(entry)) {
+        printf("%-30s  %2" PRIkernel_pid "  %-24s  ",
+               ng_ipv6_addr_to_str(ipv6_str, &entry->ipv6_addr, sizeof(ipv6_str)),
+               entry->iface,
+               ng_netif_addr_to_str(l2addr_str, sizeof(l2addr_str),
+                                    entry->l2_addr, entry->l2_addr_len));
+        _print_nc_state(entry);
+        _print_nc_type(entry);
+        puts("");
+    }
+
+    return 0;
 }
 
 static int _ipv6_nc_add(kernel_pid_t iface, char *ipv6_addr_str,
@@ -88,6 +170,10 @@ static int _ipv6_nc_del(char *ipv6_addr_str)
 
 int _ipv6_nc_manage(int argc, char **argv)
 {
+    if ((argc == 1) || (strcmp("list", argv[1]) == 0)) {
+        return _ipv6_nc_list();
+    }
+
     if (argc > 2) {
         if ((argc > 4) && (strcmp("add", argv[1]) == 0)) {
             kernel_pid_t iface = (kernel_pid_t)atoi(argv[2]);
@@ -105,9 +191,44 @@ int _ipv6_nc_manage(int argc, char **argv)
         }
     }
 
-    printf("usage: %s add <iface pid> <ipv6_addr> <l2_addr>\n"
-           "   or: %s del <ipv6_addr>\n", argv[0], argv[0]);
+    printf("usage: %s [list]\n"
+           "   or: %s add <iface pid> <ipv6_addr> <l2_addr>\n"
+           "   or: %s del <ipv6_addr>\n", argv[0], argv[0], argv[0]);
     return 1;
+}
+
+int _ipv6_nc_routers(int argc, char **argv)
+{
+    kernel_pid_t iface = KERNEL_PID_UNDEF;
+    char ipv6_str[NG_IPV6_ADDR_MAX_STR_LEN];
+
+    if (argc > 1) {
+        iface = atoi(argv[1]);
+
+        if (!_is_iface(iface)) {
+            printf("usage: %s [<iface pid>]\n", argv[0]);
+            return 1;
+        }
+    }
+
+    puts("if  Router                          state      type");
+    puts("---------------------------------------------------");
+
+    for (ng_ipv6_nc_t *entry = ng_ipv6_nc_get_next_router(NULL);
+         entry != NULL;
+         entry = ng_ipv6_nc_get_next_router(entry)) {
+        if ((iface != KERNEL_PID_UNDEF) && (iface != entry->iface)) {
+            continue;
+        }
+
+        printf("%2" PRIkernel_pid "  %-30s  ", entry->iface,
+               ng_ipv6_addr_to_str(ipv6_str, &entry->ipv6_addr, sizeof(ipv6_str)));
+        _print_nc_state(entry);
+        _print_nc_type(entry);
+        puts("");
+    }
+
+    return 0;
 }
 
 /**

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -165,6 +165,7 @@ extern int _fib_route_handler(int argc, char **argv);
 
 #ifdef MODULE_NG_IPV6_NC
 extern int _ipv6_nc_manage(int argc, char **argv);
+extern int _ipv6_nc_routers(int argc, char **argv);
 #endif
 
 const shell_command_t _shell_command_list[] = {
@@ -273,6 +274,7 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_NG_IPV6_NC
     {"ncache", "manage neighbor cache by hand", _ipv6_nc_manage },
+    {"routers", "IPv6 default router list", _ipv6_nc_routers },
 #endif
     {NULL, NULL, NULL}
 };


### PR DESCRIPTION
Adds iterators for the neighbor cache. Inspired by iterators in `utlist`.