### PR TITLE
ipv6_netif: add prefix list to interface

### DIFF
--- a/sys/include/net/ng_ipv6/netif.h
+++ b/sys/include/net/ng_ipv6/netif.h
@@ -68,6 +68,7 @@ extern "C" {
 typedef struct {
     ng_ipv6_addr_t addr;    /**< The address data */
     uint8_t flags;          /**< flags */
+    uint8_t prefix_len;     /**< length of the prefix of the address */
 } ng_ipv6_netif_addr_t;
 
 /**
@@ -117,24 +118,27 @@ ng_ipv6_netif_t *ng_ipv6_netif_get(kernel_pid_t pid);
 /**
  * @brief   Adds an address to an interface.
  *
- * @param[in] pid       The PID to the interface.
- * @param[in] addr      An address you want to add to the interface.
- * @param[in] anycast   If @p addr should be an anycast address, @p anycast
- *                      must be true. Otherwise set it false.
- *                      If @p addr is a multicast address, @p anycast will be
- *                      ignored.
+ * @param[in] pid           The PID to the interface.
+ * @param[in] addr          An address you want to add to the interface.
+ * @param[in] prefix_len    Length of the prefix of the address.
+ *                          Must be between 1 and 128.
+ * @param[in] anycast       If @p addr should be an anycast address, @p anycast
+ *                          must be true. Otherwise set it false.
+ *                          If @p addr is a multicast address, @p anycast will be
+ *                          ignored.
  *
  * @see <a href="https://tools.ietf.org/html/rfc4291#section-2.6">
  *          RFC 4291, section 2.6
  *      </a>
  *
  * @return  0, on success.
- * @return  -EINVAL, if @p addr is NULL or unspecified address.
+ * @return  -EINVAL, if @p addr is NULL or unspecified address or if
+ *          @p prefix length was < 1 or > 128.
  * @return  -ENOENT, if @p pid is no interface.
  * @return  -ENOMEM, if there is no space left to store @p addr.
  */
 int ng_ipv6_netif_add_addr(kernel_pid_t pid, const ng_ipv6_addr_t *addr,
-                           bool anycast);
+                           uint8_t prefix_len, bool anycast);
 
 /**
  * @brief   Remove an address from the interface.

--- a/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
+++ b/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
@@ -32,6 +32,9 @@
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f \
         } \
     }
+/* default IPv6 prefix length */
+#define DEFAULT_TEST_PREFIX_LEN (18)
+
 /* another interface for testing */
 #define OTHER_TEST_NETIF        (TEST_UINT16 + TEST_UINT8)
 /* another IPv6 addr for testing */
@@ -118,22 +121,22 @@ static void test_ipv6_netif_add_addr__no_iface1(void)
 {
     ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
 
-    TEST_ASSERT_EQUAL_INT(-ENOENT, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr,
-                          false));
+    TEST_ASSERT_EQUAL_INT(-ENOENT, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF,
+                          &addr, DEFAULT_TEST_PREFIX_LEN, false));
 }
 
 static void test_ipv6_netif_add_addr__no_iface2(void)
 {
-    TEST_ASSERT_EQUAL_INT(-ENOENT, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, NULL,
-                          false));
+    TEST_ASSERT_EQUAL_INT(-ENOENT, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF,
+                          NULL, DEFAULT_TEST_PREFIX_LEN, false));
 }
 
 static void test_ipv6_netif_add_addr__addr_NULL(void)
 {
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
-    TEST_ASSERT_EQUAL_INT(-EINVAL, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, NULL,
-                          false));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF,
+                          NULL, DEFAULT_TEST_PREFIX_LEN, false));
 }
 
 static void test_ipv6_netif_add_addr__addr_unspecified(void)
@@ -142,8 +145,8 @@ static void test_ipv6_netif_add_addr__addr_unspecified(void)
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
-    TEST_ASSERT_EQUAL_INT(-EINVAL, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr,
-                          false));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF,
+                          &addr, DEFAULT_TEST_PREFIX_LEN, false));
 }
 
 static void test_ipv6_netif_add_addr__ENOMEM(void)
@@ -154,7 +157,8 @@ static void test_ipv6_netif_add_addr__ENOMEM(void)
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
     for (i = 0; res != -ENOMEM; i++, addr.u8[15]++) {
-        res =  ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr, false);
+        res =  ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr,
+                                      DEFAULT_TEST_PREFIX_LEN, false);
     }
 
     TEST_ASSERT_EQUAL_INT(NG_IPV6_NETIF_ADDR_NUMOF, i);
@@ -166,7 +170,8 @@ static void test_ipv6_netif_add_addr__success(void)
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr, false));
+    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr,
+                          DEFAULT_TEST_PREFIX_LEN, false));
 }
 
 static void test_ipv6_netif_remove_addr__not_allocated(void)
@@ -365,8 +370,10 @@ static void test_ipv6_netif_find_best_src_addr__no_unicast(void)
     TEST_ASSERT_EQUAL_INT(126, ng_ipv6_addr_match_prefix(&ll_addr2, &ll_addr1));
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &mc_addr, false));
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &ll_addr1, true));
+    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &mc_addr,
+                          DEFAULT_TEST_PREFIX_LEN, false));
+    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &ll_addr1,
+                          DEFAULT_TEST_PREFIX_LEN, true));
 
     TEST_ASSERT_NULL(ng_ipv6_netif_find_best_src_addr(DEFAULT_TEST_NETIF, &ll_addr2));
 }
@@ -386,8 +393,10 @@ static void test_ipv6_netif_find_best_src_addr__success(void)
     TEST_ASSERT_EQUAL_INT(126, ng_ipv6_addr_match_prefix(&ll_addr2, &ll_addr1));
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &mc_addr, false));
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &ll_addr1, false));
+    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &mc_addr,
+                          DEFAULT_TEST_PREFIX_LEN, false));
+    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &ll_addr1,
+                          DEFAULT_TEST_PREFIX_LEN, false));
 
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_find_best_src_addr(DEFAULT_TEST_NETIF, &ll_addr2)));
     TEST_ASSERT(out != &ll_addr1);
@@ -414,7 +423,8 @@ static void test_ipv6_netif_addr_is_non_unicast__anycast(void)
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr, true));
+    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr,
+                          DEFAULT_TEST_PREFIX_LEN, true));
 
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_find_addr(DEFAULT_TEST_NETIF, &addr)));
     TEST_ASSERT_EQUAL_INT(true, ng_ipv6_netif_addr_is_non_unicast(out));
@@ -427,7 +437,8 @@ static void test_ipv6_netif_addr_is_non_unicast__multicast1(void)
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr, false));
+    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr,
+                          DEFAULT_TEST_PREFIX_LEN, false));
 
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_find_addr(DEFAULT_TEST_NETIF, &addr)));
     TEST_ASSERT_EQUAL_INT(true, ng_ipv6_netif_addr_is_non_unicast(out));
@@ -440,7 +451,8 @@ static void test_ipv6_netif_addr_is_non_unicast__multicast2(void)
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr, true));
+    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr,
+                          DEFAULT_TEST_PREFIX_LEN, true));
 
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_find_addr(DEFAULT_TEST_NETIF, &addr)));
     TEST_ASSERT_EQUAL_INT(true, ng_ipv6_netif_addr_is_non_unicast(out));


### PR DESCRIPTION
This adds the prefix list, needed for [Neighbor Discovery](https://tools.ietf.org/html/rfc4861#section-5.1) to `ipv6_netif` by adding a `prefix_len` field to its address list.