### PR TITLE
Fix DEBUG_PRINT stack size check

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -50,7 +50,7 @@ extern "C" {
 #include "cpu-conf.h"
 #define DEBUG_PRINT(...) \
     do { \
-        if ((sched_active_thread == NULL) || (sched_active_thread->stack_size > KERNEL_CONF_STACKSIZE_PRINTF)) { \
+        if ((sched_active_thread == NULL) || (sched_active_thread->stack_size >= KERNEL_CONF_STACKSIZE_PRINTF)) { \
             printf(__VA_ARGS__); \
         } \
         else { \


### PR DESCRIPTION
Checking if the current thread's stacksize is _larger_ than
KERNEL_CONF_STACKSIZE_PRINTF seems like a mistake, and the
check should actually be for larger or equal.

Or have I misunderstood the intention of this check? :confused: 

