### PR TITLE
Fix unaligned access on Samr21/Cortex-M0

### DIFF
--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -1107,7 +1107,8 @@ uint8_t lowpan_iphc_encoding(int if_id, const uint8_t *dest, int dest_len,
             else if (ipv6_buf->destaddr.uint32[2] == HTONL(0x000000ff) &&
                      ipv6_buf->destaddr.uint16[6] == HTONS(0xfe00)) {
                 if (dest_len == 2 &&
-                    ipv6_buf->destaddr.uint16[7] == *((uint16_t *) dest)) {
+                    ipv6_buf->destaddr.uint8[14] == dest[0] &&
+                    ipv6_buf->destaddr.uint8[15] == dest[1]) {
                     /* 0 bits. The address is derived using context information
                      * and possibly the link-layer addresses.*/
                     lowpan_iphc[1] |= 0x03;


### PR DESCRIPTION
Disclaimer: My knowledge of CPU architectures is
_very_ limited.

`*((uint16_t)*dest)` results in a `ldrh` (load halfword) instruction
on an address that seems to not be halfword-aligned (?),
causing a hard-fault on the samr21-xpro board (cortex-m0
architecture). The issue seems to be very similar to
the one described in http://stackoverflow.com/a/21661366/124257

The code changes fixes it on my machine™ but is probably not
the optimal solution. Advice on how to fix this properly
would be greatly appreciated.