### PR TITLE
ipv6_netif: auto-add corresponding link-local addresses

### DIFF
--- a/sys/include/net/ng_ipv6/netif.h
+++ b/sys/include/net/ng_ipv6/netif.h
@@ -255,7 +255,7 @@ ng_ipv6_addr_t *ng_ipv6_netif_find_best_src_addr(kernel_pid_t pid, const ng_ipv6
  * * ng_ipv6_find_addr_local()
  * * ng_ipv6_find_prefix_match()
  * * ng_ipv6_find_prefix_match_local()
- * * ng_ipv6_find_best_src_address
+ * * ng_ipv6_find_best_src_address()
  *
  * The behaviour for other addresses is undefined.
  *

--- a/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
+++ b/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
@@ -154,6 +154,9 @@ static void test_ipv6_netif_add_addr__ENOMEM(void)
     ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
     int res = 0, i;
 
+    /* make link local to avoid automatic link local adding */
+    ng_ipv6_addr_set_link_local_prefix(&addr);
+
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
     for (i = 0; res != -ENOMEM; i++, addr.u8[15]++) {
@@ -272,6 +275,11 @@ static void test_ipv6_netif_find_addr__success(void)
 
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_find_addr(DEFAULT_TEST_NETIF, &addr)));
     TEST_ASSERT(out != &addr);
+    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(out, &addr));
+
+    /* also test for link local address */
+    ng_ipv6_addr_set_link_local_prefix(&addr);
+    TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_find_addr(DEFAULT_TEST_NETIF, &addr)));
     TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(out, &addr));
 }
 


### PR DESCRIPTION
One needs to add the corresponding link-local address to an interface anyways, since the neighbor discovery requires it in most cases to communicate properly.

Based upon #2723 to avoid merge errors.