### PR TITLE
ipv6_netif: expand interface

### DIFF
--- a/sys/include/net/ng_ipv6.h
+++ b/sys/include/net/ng_ipv6.h
@@ -29,15 +29,6 @@
 extern "C" {
 #endif
 
-/**
- * @brief   Default maximum transition unit
- *
- * @see <a href="https://tools.ietf.org/html/rfc2460#section-5">
- *          RFC 2460, section 5
- *      </a>
- */
-#define NG_IPV6_DEFAULT_MTU (1280)
-
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/ng_ipv6/netif.h
+++ b/sys/include/net/ng_ipv6/netif.h
@@ -77,8 +77,8 @@ extern "C" {
  *          RFC 4291, section 2.6
  *      </a>
  */
-#define NG_IPV6_NETIF_FLAGS_UNICAST     (0x00)  /**< unicast address */
-#define NG_IPV6_NETIF_FLAGS_NON_UNICAST (0x01)  /**< non-unicast address */
+#define NG_IPV6_NETIF_ADDR_FLAGS_UNICAST        (0x00)  /**< unicast address */
+#define NG_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST    (0x01)  /**< non-unicast address */
 /**
  * @}
  */
@@ -267,7 +267,7 @@ ng_ipv6_addr_t *ng_ipv6_netif_find_best_src_addr(kernel_pid_t pid, const ng_ipv6
 static inline bool ng_ipv6_netif_addr_is_non_unicast(const ng_ipv6_addr_t *addr)
 {
     return (bool)(container_of(addr, ng_ipv6_netif_addr_t, addr)->flags &
-                  NG_IPV6_NETIF_FLAGS_NON_UNICAST);
+                  NG_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST);
 
 }
 

--- a/sys/include/net/ng_ipv6/netif.h
+++ b/sys/include/net/ng_ipv6/netif.h
@@ -48,6 +48,15 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Default MTU
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc2460#section-5">
+ *          RFC 2460, section 5
+ *      </a>
+ */
+#define NG_IPV6_NETIF_DEFAULT_MTU   (1280)
+
+/**
  * @brief   Default hop limit
  *
  * @see <a href="https://tools.ietf.org/html/rfc4861#section-6.3.2">

--- a/sys/include/net/ng_ipv6/netif.h
+++ b/sys/include/net/ng_ipv6/netif.h
@@ -48,6 +48,18 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Default hop limit
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc4861#section-6.3.2">
+ *          RFC 4861, section 6.3.2
+ *      </a>
+ * @see <a href="http://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml#ip-parameters-2">
+ *          IANA, IP TIME TO LIVE PARAMETER
+ *      </a>
+ */
+#define NG_IPV6_NETIF_DEFAULT_HL    (64)
+
+/**
  * @{
  * @name Flags for a registered IPv6 address.
  * @brief   Needed primarily to identify addresses as either anycast or unicast.
@@ -80,6 +92,7 @@ typedef struct {
     mutex_t mutex;          /**< mutex for the interface */
     kernel_pid_t pid;       /**< PID of the interface */
     uint16_t mtu;           /**< Maximum Transmission Unit (MTU) of the interface */
+    uint8_t cur_hl;         /**< current hop limit for the interface */
 } ng_ipv6_netif_t;
 
 /**

--- a/sys/include/net/ng_ipv6/netif.h
+++ b/sys/include/net/ng_ipv6/netif.h
@@ -102,6 +102,7 @@ typedef struct {
     kernel_pid_t pid;       /**< PID of the interface */
     uint16_t mtu;           /**< Maximum Transmission Unit (MTU) of the interface */
     uint8_t cur_hl;         /**< current hop limit for the interface */
+    uint8_t flags;          /**< flags for 6LoWPAN and Neighbor Discovery */
 } ng_ipv6_netif_t;
 
 /**

--- a/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
+++ b/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
@@ -54,12 +54,12 @@ static int _add_addr_to_entry(ng_ipv6_netif_t *entry, const ng_ipv6_addr_t *addr
                     entry->addrs[i].prefix_len = NG_IPV6_ADDR_BIT_LEN;
                 }
 
-                entry->addrs[i].flags = NG_IPV6_NETIF_FLAGS_NON_UNICAST;
+                entry->addrs[i].flags = NG_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST;
             }
             else {
                 entry->addrs[i].prefix_len = prefix_len;
 
-                entry->addrs[i].flags = NG_IPV6_NETIF_FLAGS_UNICAST;
+                entry->addrs[i].flags = NG_IPV6_NETIF_ADDR_FLAGS_UNICAST;
             }
 
             return 0;

--- a/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
+++ b/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
@@ -20,7 +20,6 @@
 
 #include "kernel_types.h"
 #include "mutex.h"
-#include "net/ng_ipv6.h"
 #include "net/ng_ipv6/addr.h"
 #include "net/ng_netif.h"
 
@@ -100,7 +99,7 @@ void ng_ipv6_netif_add(kernel_pid_t pid)
             DEBUG("Add IPv6 interface %" PRIkernel_pid " (i = %d)\n", pid, i);
             ipv6_ifs[i].pid = pid;
             DEBUG(" * pid = %" PRIkernel_pid "  ", ipv6_ifs[i].pid);
-            ipv6_ifs[i].mtu = NG_IPV6_DEFAULT_MTU;
+            ipv6_ifs[i].mtu = NG_IPV6_NETIF_DEFAULT_MTU;
             DEBUG("mtu = %d  ", ipv6_ifs[i].mtu);
             ipv6_ifs[i].cur_hl = NG_IPV6_NETIF_DEFAULT_HL;
             DEBUG("cur_hl = %d  ", ipv6_ifs[i].cur_hl);

--- a/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
+++ b/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
@@ -99,9 +99,11 @@ void ng_ipv6_netif_add(kernel_pid_t pid)
 
             DEBUG("Add IPv6 interface %" PRIkernel_pid " (i = %d)\n", pid, i);
             ipv6_ifs[i].pid = pid;
-            DEBUG(" * pid = %" PRIkernel_pid "\n", ipv6_ifs[i].pid);
+            DEBUG(" * pid = %" PRIkernel_pid "  ", ipv6_ifs[i].pid);
             ipv6_ifs[i].mtu = NG_IPV6_DEFAULT_MTU;
-            DEBUG(" * mtu = %d\n", ipv6_ifs[i].mtu);
+            DEBUG("mtu = %d  ", ipv6_ifs[i].mtu);
+            ipv6_ifs[i].cur_hl = NG_IPV6_NETIF_DEFAULT_HL;
+            DEBUG("cur_hl = %d  ", ipv6_ifs[i].cur_hl);
 
             _add_addr_to_entry(&ipv6_ifs[i], &addr, NG_IPV6_ADDR_BIT_LEN, 0);
 


### PR DESCRIPTION
Main focus of this PR is to include the current hop limit into the IPv6 interfaces, since the [Neighbor discovery](https://tools.ietf.org/html/rfc4861#section-6.3.2) expects it to be interface local.

Additionally I piggy-backed some cosmetic changes to the macro definitions:
* moved default MTU from `ng_ipv6.h` to `ng_ipv6/netif.h`. We only need it in this module anyways and this way we keep it independent from the main header (avoidance of cyclic inclusion).
* added flags for later modules (`ng_sixlowpan` (#2614) and `ng_ndp` (#2612) namely)
* added `ADDR_` to the address flag macros to distinguish them from the newly included flags for `ng_ipv6_netif_t` itself.