### PR TITLE
shell: fix rtc alarm handler

### DIFF
--- a/sys/shell/commands/sc_rtc.c
+++ b/sys/shell/commands/sc_rtc.c
@@ -29,7 +29,7 @@
 
 #include "periph/rtc.h"
 
-int _alarm_handler(void *arg)
+static void _alarm_handler(void *arg)
 {
     (void) arg;
 


### PR DESCRIPTION
Was accidentally confused for a shell handler in #2602.