### PR TITLE
shell: remove unneeded return

### DIFF
--- a/sys/shell/commands/sc_rtc.c
+++ b/sys/shell/commands/sc_rtc.c
@@ -34,7 +34,6 @@ static void _alarm_handler(void *arg)
     (void) arg;
 
     puts("The alarm rang");
-    return 0;
 }
 
 static int dow(int year, int month, int day)


### PR DESCRIPTION
Follow-up to #2737. Forgot to remove the return...