### PR TITLE
debug.h: check stacksize fixed

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -50,7 +50,7 @@ extern "C" {
 #include "cpu-conf.h"
 #define DEBUG_PRINT(...) \
     do { \
-        if ((sched_active_thread == NULL) || (sched_active_thread->stack_size > KERNEL_CONF_STACKSIZE_PRINTF)) { \
+        if ((sched_active_thread == NULL) || (sched_active_thread->stack_size >= KERNEL_CONF_STACKSIZE_PRINTF)) { \
             printf(__VA_ARGS__); \
         } \
         else { \


### PR DESCRIPTION
Changed Stacksize check im DEBUG-Makro from > KERNEL_CONF_STACKSIZE_PRINTF to >= KERNEL_CONF_STACKSIZE_PRINTF.

This makes usage of the DEBUG Makro possible if the calling thread has a stacksize thats intended for Printf usage.