### PR TITLE
New "readline" module for a better shell

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -156,3 +156,7 @@ ifneq (,$(filter fib,$(USEMODULE)))
   USEMODULE += vtimer
   USEMODULE += net_help
 endif
+
+ifneq (,$(filter readline,$(USEMODULE)))
+	USEMODULE += shell
+endif

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -67,6 +67,8 @@ else
 export LINKFLAGS += -ldl
 endif
 
+LINKFLAGS += -lncurses -ltinfo
+
 # set the tap interface for term/valgrind
 ifneq (,$(filter nativenet,$(USEMODULE)))
 	export PORT ?= tap0

--- a/boards/native/include/board_internal.h
+++ b/boards/native/include/board_internal.h
@@ -24,6 +24,7 @@ void _native_handle_uart0_input(void);
  */
 void _native_init_uart0(char *stdiotype, char *ioparam, int replay);
 int _native_set_uart_fds(void);
+void _native_exit_uart0(void);
 #endif /* MODULE_UART0 */
 
 extern int _native_null_out_file;

--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -147,6 +147,7 @@ extern ucontext_t *_native_cur_ctx, *_native_isr_ctx;
 
 extern const char *_progname;
 extern char **_native_argv;
+extern char **_native_envp;
 extern pid_t _native_pid;
 extern pid_t _native_id;
 extern unsigned _native_rng_seed;

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -48,6 +48,9 @@
 
 #include "cpu.h"
 #include "cpu-conf.h"
+#ifdef MODULE_UART0
+#include "board_internal.h"
+#endif
 #ifdef MODULE_NATIVENET
 #include "tap.h"
 #endif
@@ -71,6 +74,7 @@ int reboot_arch(int mode)
     printf("\n\n\t\t!! REBOOT !!\n\n");
 #ifdef MODULE_UART0
     /* TODO: close stdio fds */
+    _native_exit_uart0();
 #endif
 #ifdef MODULE_NATIVENET
     if (_native_tap_fd != -1) {
@@ -78,11 +82,12 @@ int reboot_arch(int mode)
     }
 #endif
 
-    if (real_execve(_native_argv[0], _native_argv, NULL) == -1) {
+    if (real_execve(_native_argv[0], _native_argv, _native_envp) == -1) {
         err(EXIT_FAILURE, "reboot: execve");
     }
 
     errx(EXIT_FAILURE, "reboot: this should not have been reached");
+    return -1;
 }
 
 /**

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -41,6 +41,7 @@ int _native_null_in_pipe[2];
 int _native_null_out_file;
 const char *_progname;
 char **_native_argv;
+char **_native_envp;
 pid_t _native_pid;
 pid_t _native_id;
 unsigned _native_rng_seed = 0;
@@ -232,11 +233,12 @@ The order of command line arguments matters.\n");
 
 }
 
-__attribute__((constructor)) static void startup(int argc, char **argv)
+__attribute__((constructor)) static void startup(int argc, char **argv, char **envp)
 {
     _native_init_syscalls();
 
     _native_argv = argv;
+    _native_envp = envp;
     _progname = argv[0];
     _native_pid = real_getpid();
 

--- a/sys/include/readline.h
+++ b/sys/include/readline.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef SYS_READLINE_H_
+#define SYS_READLINE_H_
+
+#include "shell.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Module for a better shell.
+ *
+ * Options:
+ * SHELL_HISTORY_SIZE=<n>: Use a simple history implementation. <n> gives the size of the history
+ */
+
+/**
+ * FIXME: The buffer size must be defined globally available by the user of
+ * the shell module. This definition is a copy of the one from "shell.c"
+ */
+#ifndef SHELL_BUFFER_SIZE
+#define SHELL_BUFFER_SIZE 128
+#endif // SHELL_BUFFER_SIZE
+
+int readline(shell_t *shell, char *buf, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYS_READLINE_H_ */

--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -24,6 +24,10 @@
 
 #include "attributes.h"
 
+#ifndef SHELL_TAB_SIZE
+#define SHELL_TAB_SIZE 4
+#endif // SHELL_TAB_SIZE
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/sys/include/shell_colors.h
+++ b/sys/include/shell_colors.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef __SHELL_COLORS_H
+#define __SHELL_COLORS_H
+
+#include "shell.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SHELL_STYLE_BOLD                    1
+#define SHELL_STYLE_DIM                     2
+#define SHELL_STYLE_UNDERLINED              4
+#define SHELL_STYLE_BLINK                   5
+#define SHELL_STYLE_REVERSE                 7
+#define SHELL_STYLE_HIDDEN                  8
+
+#define SHELL_RESET_ALL                     0
+#define SHELL_RESET_BOLD                    21
+#define SHELL_RESET_DIM                     22
+#define SHELL_RESET_UNDERLINED              24
+#define SHELL_RESET_BLINK                   25
+#define SHELL_RESET_REVERSE                 27
+#define SHELL_RESET_HIDDEN                  28
+
+#define SHELL_COLOR_DEFAULT                 39
+#define SHELL_COLOR_BLACK                   30
+#define SHELL_COLOR_RED                     31
+#define SHELL_COLOR_GREEN                   32
+#define SHELL_COLOR_YELLOW                  33
+#define SHELL_COLOR_BLUE                    34
+#define SHELL_COLOR_MAGENTA                 35
+#define SHELL_COLOR_CYAN                    36
+#define SHELL_COLOR_WHITE                   37
+
+#define SHELL_BACKGROUND_DEFAULT            49
+#define SHELL_BACKGROUND_BLACK              40
+#define SHELL_BACKGROUND_RED                41
+#define SHELL_BACKGROUND_GREEN              42
+#define SHELL_BACKGROUND_YELLOW             43
+#define SHELL_BACKGROUND_BLUE               44
+#define SHELL_BACKGROUND_MAGENTA            45
+#define SHELL_BACKGROUND_CYAN               46
+#define SHELL_BACKGROUND_WHITE              47
+
+#define xstr(s) str(s)
+#define str(s) #s
+
+#define SHELL_COLOR_ESC                     \x1b[
+
+#ifndef SHELL_COLOR_MAIN
+#define SHELL_COLOR_MAIN                    xstr(SHELL_COLOR_ESC) xstr(SHELL_RESET_ALL) "m"
+#endif
+#ifndef SHELL_COLOR_PROMPT
+#define SHELL_COLOR_PROMPT                  SHELL_COLOR_STYLE(SHELL_COLOR_GREEN, SHELL_STYLE_BOLD)
+#endif
+#ifndef SHELL_COLOR_ECHO
+#define SHELL_COLOR_ECHO                    SHELL_COLOR(SHELL_COLOR_BLUE)
+#endif
+#ifndef SHELL_COLOR_ERROR
+#define SHELL_COLOR_ERROR                   SHELL_COLOR(SHELL_COLOR_RED)
+#endif
+
+#define SHELL_COLOR(color)                  xstr(SHELL_COLOR_ESC) str(color) "m"
+#define SHELL_COLOR_STYLE(color, style)     xstr(SHELL_COLOR_ESC) str(color) ";" str(style) "m"
+/* Construct a constant string that wrapps colors control around it */
+#define SHELL_COLORED(str, color_string)    color_string str SHELL_COLOR_MAIN
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __SHELL_COLORS_H

--- a/sys/include/shell_print.h
+++ b/sys/include/shell_print.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef SYS_SHELL_SHELL_PRINT_H_
+#define SYS_SHELL_SHELL_PRINT_H_
+
+#include "shell.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define shell_putchar(shell, c) shell->put_char(c)
+
+extern void shell_print(shell_t *shell, const char *string);
+extern void shell_echo_string(shell_t *shell, const char *string);
+extern void shell_print_error(shell_t *shell, const char *string);
+extern void shell_echo_char(shell_t *shell, char c);
+extern void shell_prompt(shell_t *shell);
+
+
+#if USE_SHELL_COLORS
+#define printfc(color, ...) do { \
+                                printf(SHELL_COLOR(color)); \
+                                printf(__VA_ARGS__); \
+                                printf(SHELL_COLOR_MAIN); \
+                            } while(0);
+#define printfs(color, ...) do { \
+                                printf(SHELL_STYLE(color)); \
+                                printf(__VA_ARGS__); \
+                                printf(SHELL_COLOR_MAIN); \
+                            } while(0);
+#define printfcs(color, style, ...) do { \
+                                printf(SHELL_COLOR_STYLE(color, style)); \
+                                printf(__VA_ARGS__); \
+                                printf(SHELL_COLOR_MAIN); \
+                            } while(0);
+#else
+/* Printf with shell-color */
+#define printfc(color, ...) printf(__VA_ARGS__)
+/* Printf with shell-style */
+#define printfs(color, ...) printf(__VA_ARGS__)
+/* Printf with shell-style and shell_color*/
+#define printfcs(color, style, ...) printf(__VA_ARGS__)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYS_SHELL_SHELL_PRINT_H_ */

--- a/sys/readline/Makefile
+++ b/sys/readline/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/readline/doc/ncurses.txt
+++ b/sys/readline/doc/ncurses.txt
@@ -1,0 +1,47 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+NCURSES
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+	$ sudo apt-get install libncurses5 libncurses5-dbg libncurses5-dev
+	$ sudo ln -s /lib/i386-linux-gnu/libncurses.so.5.9 /lib/i386-linux-gnu/libncurses.so
+	$ sudo ln -s /lib/i386-linux-gnu/libtinfo.so.5.9 /lib/i386-linux-gnu/libtinfo.so
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+SOCAT
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+	$ sudo apt-get install socat
+
+	$ socat -d -d PTY,echo=0 PTY,echo=0 
+	Explanation:
+		-d -d provides information of the created tty's
+		This gives two /dev/pts/<port1> and /dev/pts/<port2> numbers, which can be
+		connected
+
+Now a process can be started and pipe stdin and stdout to one of them:
+	$ ./bin/<myprogram> < /dev/pts/<port1> > /dev/pts/<port1>
+
+And MINICOM can be used to connect to the other:
+	$ minicom -p /dev/pts/<port2>
+
+------------------------------------------------------------------------------------------
+A more direct way is to start the process directly in socat and specify a symbolic link
+to the PTS:
+	$ mkdir -p $HOME/dev/pts/
+	$ socat PTY,link=$HOME/dev/pts/1,echo=0 EXEC:./bin/<myprogram>,PTY,echo=0
+
+This will create the symbolic link "$HOME/dev/pts/1" to the /dev/pts/<port1>, which we
+aren't interested in to really know. This link will be deleted when the socat is finished.
+
+We can connect to this with minicom with:
+	$ cd $HOME/dev
+	$ minicom -p pts/1
+
+The sender can also directly send to the virtual pty with ymodem:
+	$ sb <filename> < $HOME/dev/pts/1 > $HOME/dev/pts/1
+
+CAREFUL:
+	The name of the symbolic link must conform to what minicom expects. This is also
+	why we have to enter the directory directly, in which the symbolic link resides, in
+	order to make minicom happy. Carefully read the "-p" option in the minicom manpage!
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/sys/readline/doc/terminal_codes.txt
+++ b/sys/readline/doc/terminal_codes.txt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+                +===================+===================+===================++==============================++
+ TERMINAL CODES |   ZSH             |   MINICOM-VT102   |   MINICOM-ANSI    ||  ACTION                      ||
+++==============+-------------------+-------------------+-------------------++------------------------------+|
+||  NL          |   CR              |   CR              |   CR              ||  <enter>                     ||
+||  ESC         |   ESC             |   ESC             |   ESC             ||  <no action>                 ||
+||  BS          |   DEL             |   DEL             |   BS              ||  Delete 1 before             ||
+||  DEL         |   ESC [ 3 ~       |   ESC [ 3 ~       |   ESC DEL         ||  Delete 1 behind             ||
+||  INS         |   ESC [ 2 ~       |   ESC [ 2 ~       |   ESC [ @         ||  not implemented             ||
+||  HOME        |   ESC O H         |   ESC [ 1 ~       |   ESC [ H         ||  Cursor HOME                 ||
+||  END         |   ESC O F         |   ESC O F         |   ESC O F         ||  Cursor END                  ||
+||  PGUP        |   ESC [ 5 ~       |   ESC [ 5 ~       |   ESC [ V         ||  History up                  ||
+||  PGDWN       |   ESC [ 6 ~       |   ESC [ 6 ~       |   ESC [ U         ||  History down                ||
+||  UP          |   ESC [ A         |   ESC [ A         |   ESC [ A         ||  History up                  ||
+||  DOWN        |   ESC [ B         |   ESC [ B         |   ESC [ B         ||  History down                ||
+||  RIGHT       |   ESC [ C         |   ESC [ C         |   ESC [ C         ||  Cursor right                ||
+||  LEFT        |   ESC [ D         |   ESC [ D         |   ESC [ D         ||  Cursor left                 ||
+|+--------------+-------------------+-------------------+-------------------++------------------------------+|
+||  CTRL+UP     |   ESC [ 1 ; 5 A   |                   |                   ||  History up                  ||
+||  CTRL+DOWN   |   ESC [ 1 ; 5 B   |                   |                   ||  History down                ||
+||  CTRL+RIGHT  |   ESC [ 1 ; 5 C   |                   |                   ||  Cursor skip word right      ||
+||  CTRL+LEFT   |   ESC [ 1 ; 5 D   |                   |                   ||  Cursor skip word left       ||
+||  CTRL+A      |   0x01            |                   |                   ||  Cursor HOME                 ||
+||  CTRL+E      |   0x05            |                   |                   ||  Cursor END                  ||
+|+--------------+-------------------+-------------------+-------------------++------------------------------+|
+||  CTRL+DEL    |   ESC [ 3 ; 5 ~   |                   |                   ||  DELETE word behind cursor   ||
+||  CTRL+U      |   0x15            |                   |                   ||  CUT all                     ||
+||  CTRL+K      |   0x0B            |                   |                   ||  CUT all behind cursor       ||
+||  CTRL+W      |   0x17            |                   |                   ||  CUT word before cursor      ||
+||  ESC+BS      |   ESC BS          |                   |                   ||  CUT word before cursor      ||
+||  ALT+D       |   ESC d           |                   |                   ||  CUT word behind cursor      ||
+||  CTRL+Y      |   0x19            |                   |                   ||  PASTE                       ||
+|+--------------+-------------------+-------------------+-------------------++------------------------------+|
+||  ä           |   Ã 0xA4          |                   |                   ||  <not implemented>           ||
+||  Ä           |   Ã 0x84          |                   |                   ||  <not implemented>           ||
+||  ö           |   Ã 0xB6          |                   |                   ||  <not implemented>           ||
+||  Ö           |   Ã 0x96          |                   |                   ||  <not implemented>           ||
+||  ü           |   Ã 0xBC          |                   |                   ||  <not implemented>           ||
+||  Ü           |   Ã 0x9C          |                   |                   ||  <not implemented>           ||
+||  ß           |   Ã 0x9F          |                   |                   ||  <not implemented>           ||
+++==============+===================+===================+===================++==============================++
+
+
+    +-------+-----------+
+    |   LF  |   0x0A    |
+    |   CR  |   0x0D    |
+    |   ESC |   0x1B    |
+    |   BS  |   0x08    |
+    |   DEL |   0x7F    |
+    |   [   |   0x5B    |
+    |   ~   |   0x7E    |
+    |   ;   |   0x3B    |
+    |   O   |   0x4F    |
+    |   1   |   0x31    |
+    |   3   |   0x33    |
+    |   5   |   0x35    |
+    |   Ã   |   0xC3    |
+    +-------+-----------+
+
+
+
+
++-----------+  DEL,BS                                                           +----------------+
+|   START   +------------------------------------------------------------------->     DONE       |
++-----------+                                                         ctrl:=BS  +----------------+
+|           |  CR,LF                                                            |                |
+|           +------------------------------------------------------------------->                |
+|           |                                                         ctrl:=NL  |                |
+|           |  ESC    +----+  DEL                                               |                |
+|           +--------->    +---------------------------------------------------->                |
+|           |         |    |                                         ctrl:=DEL  |                |
++-----------+         |    |  ESC                                               |                |
+                      |    +---------------------------------------------------->                |
+                      |    |                                         ctrl:=ESC  |                |
+                      |    |                                                    |                |
+                      |    |  '['      +----+  [12356]  +---------------+  '~'  |                |
+                      |    +----------->    +-----------> ctrl:=        +------->                |
+                      |    |           |    |           | $C=='1':HOME  |       |                |
+                      |    |           |    |           |     '2':INS   |       |                |
+                      |    |           |    |           |     '3':DEL   |       | ctrl:=         |
+                      |    |           |    |           |     '5':PGUP  |       | $C=='A':UP     |
++-------------+       |    |           |    |           |     '6':PGDWN |       |     'B':DOWN   |
+| LF     0x0A |       |    |           |    |           +---------------+       |     'C':RIGHT  |
+| CR     0x0D |       |    |           |    |                                   |     'D':LEFT   |
+| ESC    0x1B |       |    |           |    |  [ABCDHUV@]                       |     'H':HOME   |
+| BS     0x08 |       |    |           |    +----------------------------------->     'U':PGDWN  |
+| DEL    0x7F |       |    |           +----+                                   |     'V':PGUP   |
+| [      0x5B |       |    |                                                    |     '@':INS    |
+| ~      0x7E |       |    |  'O'      +----+  [FH]                             |     'F':END    |
+| O      0x4F |       |    +---------> |    +----------------------------------->     'H':HOME   |
++-------------+       +----+           +----+                                   +----------------+
+                                                                                                  
+                                                                                                  
+                                                                                                  
+                                                                 (drawn with http://asciiflow.com)
+
+

--- a/sys/readline/include/readline_history.h
+++ b/sys/readline/include/readline_history.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef SYS_READLINE_HISTORY_H_
+#define SYS_READLINE_HISTORY_H_
+
+void history_put(char *input);
+int history_getprev(char *buf);
+int history_getnext(char *buf);
+void history_reset(void);
+
+/*
+ * For testing
+ */
+void history_reset_internal(void);
+void history_printbuf(void);
+
+#endif /* SYS_READLINE_HISTORY_H_ */

--- a/sys/readline/include/readline_internal.h
+++ b/sys/readline/include/readline_internal.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015, Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef SYS_READLINE_READLINE_INTERNAL_H_
+#define SYS_READLINE_READLINE_INTERNAL_H_
+
+#include "readline.h"
+#include "readline_scan.h"
+#include "readline_history.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void set_screen_cursor(shell_t *shell, int cursor);
+void cut(shell_t *shell, int *cursor, char *buf, char *cut_buf, int count);
+void paste(shell_t *shell, int *cursor, char *buf, char *paste_buf, int count);
+char* find_word_before(int *cursor, char *buf);
+char* find_word_behind(int *cursor, char *buf);
+void cut_word_before(shell_t *shell, int *cursor, char *buf, char *cut_buf);
+void cut_word_behind(shell_t *shell, int *cursor, char *buf, char *cut_buf);
+void move_cursor_word_left(shell_t *shell, int *cursor, char *buf);
+void move_cursor_word_right(shell_t *shell, int *cursor, char *buf);
+control_e readline_control_process(shell_t *shell, int *cursor, char *buf, control_e control);
+
+#if SHELL_HISTORY_SIZE > 0
+void history_cycle_up(shell_t *shell, int *cursor, char *buf);
+void history_cycle_down(shell_t *shell, int *cursor, char *buf);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYS_READLINE_READLINE_INTERNAL_H_ */

--- a/sys/readline/include/readline_scan.h
+++ b/sys/readline/include/readline_scan.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2015, Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef SYS_READLINE_SCAN_H_
+#define SYS_READLINE_SCAN_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LF      '\n' // 0x0A
+#define CR      '\r' // 0x0D
+#define TAB     '\t'
+#define ESC     0x1B
+#define BS      0x08
+#define DEL     0x7F
+#define BRK     '[' // 0x5B
+#define CHO     'O' // 0x4F
+#define TILD    '~' // 0x7E
+#define SEMICOL ';' // 0x3B
+#define UML     0xC3 // Ã
+
+typedef enum
+{
+    CONTROL_NONE = 0,
+    CONTROL_NL,
+    CONTROL_TAB,
+    CONTROL_ESC,
+    CONTROL_BS,
+    CONTROL_DEL,
+    CONTROL_INS,
+    CONTROL_HOME,
+    CONTROL_END,
+    CONTROL_PGUP,
+    CONTROL_PGDWN,
+    CONTROL_UP,
+    CONTROL_DOWN,
+    CONTROL_RIGHT,
+    CONTROL_LEFT,
+    CONTROL_CUT_ALL,
+    CONTROL_CUT_ALL_BEHIND,
+    CONTROL_CUT_WORD_BEFORE,
+    CONTROL_CUT_WORD_AFTER,
+    CONTROL_PASTE,
+    CONTROL_CTRL_UP,
+    CONTROL_CTRL_DOWN,
+    CONTROL_CTRL_RIGHT,
+    CONTROL_CTRL_LEFT,
+    CONTROL_CTRL_DEL,
+    CONTROL_UMLAUT,
+    CONTROL_NONE_PRINTABLE,
+    CONTROL_IN_PROGRESS
+} control_e;
+
+control_e readline_scan_char(unsigned char c);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYS_READLINE_SCAN_H_ */

--- a/sys/readline/readline.c
+++ b/sys/readline/readline.c
@@ -25,8 +25,8 @@
 
 static char cut_buffer[SHELL_BUFFER_SIZE];
 
-// TODO: Introduce definition PROMT_LENGTH (instead of "2")
-#define PROMT_LENGTH 2
+// TODO: Introduce definition PROMPT_LENGTH (instead of "2")
+#define PROMPT_LENGTH 2
 
 /*
  * Create a terminal command to set the cursor to the specified position, plus the size of
@@ -36,7 +36,7 @@ void set_screen_cursor(shell_t *shell, int cursor)
 {
     char buf[4];
     shell_print(shell, "\r\x1b[");
-    snprintf(buf, 4, "%d", cursor + PROMT_LENGTH);
+    snprintf(buf, 4, "%d", cursor + PROMPT_LENGTH);
     shell_print(shell, buf);
     shell_putchar(shell, 'C');
 }

--- a/sys/readline/readline.c
+++ b/sys/readline/readline.c
@@ -1,0 +1,308 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "shell.h"
+#include "shell_print.h"
+#include "shell_colors.h"
+
+#include "readline.h"
+#include "include/readline_internal.h"
+#include "include/readline_scan.h"
+
+#if SHELL_HISTORY_SIZE > 0
+#include "include/readline_history.h"
+#endif
+
+static char cut_buffer[SHELL_BUFFER_SIZE];
+
+// TODO: Introduce definition PROMT_LENGTH (instead of "2")
+#define PROMT_LENGTH 2
+
+/*
+ * Create a terminal command to set the cursor to the specified position, plus the size of
+ * the prompt (e.g. "> ").
+ */
+void set_screen_cursor(shell_t *shell, int cursor)
+{
+    char buf[4];
+    shell_print(shell, "\r\x1b[");
+    snprintf(buf, 4, "%d", cursor + PROMT_LENGTH);
+    shell_print(shell, buf);
+    shell_putchar(shell, 'C');
+}
+
+/*
+ * Cut 'count' characters behind the cursor position and store in
+ * cut-buffer, if 'cutText' is set.
+ * If the count value is larger than there are remaining characters, only
+ * the remaining characters are cut
+ *
+ * ``cursor`` is required to be smaller than strlen(buf)
+ */
+void cut(shell_t *shell, int *cursor, char *buf, char *cut_buf, int count)
+{
+    int len = strlen(buf);
+    if (len == 0 || *cursor > len) {
+        return;
+    }
+    if (*cursor + count > len) {
+        count = len - *cursor;
+    }
+    if (cut_buf) {
+        strncpy(cut_buf, buf + *cursor, count);
+        cut_buf[count] = '\0';         // strncpy doesn't terminate a null-terminated string
+    }
+    memmove(buf + *cursor, buf + *cursor + count, len - *cursor - count + 1);
+    shell_print(shell, "\x1b[K");      // Erase to the right
+    shell_echo_string(shell, buf + *cursor);
+    set_screen_cursor(shell, *cursor);
+}
+
+/*
+ * Caller has to make shure that 'paste_buf' has at least 'count' size.
+ */
+void paste(shell_t *shell, int *cursor, char *buf, char *paste_buf, int count)
+{
+    int len = strlen(buf);
+    if (len + count >= shell->shell_buffer_size || *cursor > len) {
+        return;
+    }
+    int len_paste_buf = strlen(paste_buf);
+    if (count > len_paste_buf) {
+        count = len_paste_buf;
+    }
+    memmove(buf + *cursor + count, buf + *cursor, len - *cursor);
+    memcpy(buf + *cursor, paste_buf, count);
+    buf[len + count] = '\0';
+    shell_echo_string(shell, buf + *cursor);
+    *cursor += count;
+    set_screen_cursor(shell, *cursor);
+}
+
+char* find_word_before(int *cursor, char *buf)
+{
+    /* Skip all preceeding whitespaces */
+    char *tmp_buf = buf + *cursor;
+    while (tmp_buf > buf && *(--tmp_buf) == ' ')
+        ;
+    while (tmp_buf > buf && *tmp_buf != ' ') {
+        tmp_buf--;
+    }
+    if (tmp_buf == buf) {
+        return buf;
+    }
+    return tmp_buf + 1;
+}
+
+char* find_word_behind(int *cursor, char *buf)
+{
+    char *end = strlen(buf) + buf;
+    char *tmp_buf = buf + *cursor;
+    while (tmp_buf < end && *(tmp_buf++) != ' ')
+        ;
+    while (tmp_buf < end && *(tmp_buf++) == ' ')
+        ;
+    if (tmp_buf == buf || tmp_buf == end) {
+        return tmp_buf;
+    }
+    return tmp_buf - 1;
+}
+
+void cut_word_before(shell_t *shell, int *cursor, char *buf, char *cut_buf)
+{
+    char *word = find_word_before(cursor, buf);
+    int count = *cursor - (word - buf);
+    *cursor = word - buf;
+    set_screen_cursor(shell, *cursor);
+    cut(shell, cursor, buf, cut_buf, count);
+}
+
+void cut_word_behind(shell_t *shell, int *cursor, char *buf, char *cut_buf)
+{
+    char *word = buf + *cursor;
+    if (*word == ' ') {
+        word = find_word_behind(cursor, buf);
+    }
+    while (*word && *word != ' ') {
+        word++;
+    }
+    cut(shell, cursor, buf, cut_buf, (word - buf) - *cursor);
+}
+
+void move_cursor_word_left(shell_t *shell, int *cursor, char *buf)
+{
+    char *word = find_word_before(cursor, buf);
+    *cursor = word - buf;
+    set_screen_cursor(shell, *cursor);
+}
+
+void move_cursor_word_right(shell_t *shell, int *cursor, char *buf)
+{
+    char *word = find_word_behind(cursor, buf);
+    *cursor = word - buf;
+    set_screen_cursor(shell, *cursor);
+}
+
+#if SHELL_HISTORY_SIZE > 0
+static void history_cycle(shell_t *shell, int *cursor, char *buf, bool dir)
+{
+    set_screen_cursor(shell, *cursor = 0);
+    cut(shell, cursor, buf, NULL, shell->shell_buffer_size);
+    if (dir) {
+        history_getprev(buf);
+    }
+    else {
+        history_getnext(buf);
+    }
+    *cursor = strlen(buf);
+    shell_echo_string(shell, buf);
+}
+
+void history_cycle_up(shell_t *shell, int *cursor, char *buf)
+{
+    history_cycle(shell, cursor, buf, true);
+}
+
+void history_cycle_down(shell_t *shell, int *cursor, char *buf)
+{
+    history_cycle(shell, cursor, buf, false);
+}
+#endif
+
+/*
+ * In case this returns newline, the cursor will be set at the end of the line, no matter
+ * where it was before.
+ *
+ * c is the last character that was received.
+ */
+control_e readline_control_process(shell_t *shell, int *cursor, char *buf, control_e control)
+{
+    char space = ' ';
+    switch (control) {
+        case CONTROL_NL:
+#if SHELL_HISTORY_SIZE > 0
+            history_reset();
+#endif
+            set_screen_cursor(shell, *cursor = strlen(buf));
+            return CONTROL_NL;
+        case CONTROL_TAB:
+            for (int i = 0; i < SHELL_TAB_SIZE; i++) {
+                paste(shell, cursor, buf, &space, 1);
+            }
+            break;
+        case CONTROL_LEFT:
+            if (*cursor > 0) {
+                set_screen_cursor(shell, --(*cursor));
+            }
+            break;
+        case CONTROL_RIGHT:
+            if (*cursor < (int) strlen(buf)) {
+                set_screen_cursor(shell, ++(*cursor));
+            }
+            break;
+        case CONTROL_HOME:
+            set_screen_cursor(shell, *cursor = 0);
+            break;
+        case CONTROL_END:
+            set_screen_cursor(shell, *cursor = strlen(buf));
+            break;
+        case CONTROL_BS:
+            if (*cursor > 0) {
+                set_screen_cursor(shell, --(*cursor));
+                cut(shell, cursor, buf, NULL, 1);
+            }
+            break;
+        case CONTROL_DEL:
+            cut(shell, cursor, buf, NULL, 1);
+            break;
+#if SHELL_HISTORY_SIZE > 0
+        case CONTROL_UP:
+        case CONTROL_PGUP:
+        case CONTROL_CTRL_UP:
+            history_cycle_up(shell, cursor, buf);
+            break;
+        case CONTROL_DOWN:
+        case CONTROL_PGDWN:
+        case CONTROL_CTRL_DOWN:
+            history_cycle_down(shell, cursor, buf);
+            break;
+#endif
+        case CONTROL_CUT_ALL:
+            set_screen_cursor(shell, *cursor = 0);
+            cut(shell, cursor, buf, cut_buffer, shell->shell_buffer_size);
+            break;
+        case CONTROL_CUT_ALL_BEHIND:
+            cut(shell, cursor, buf, cut_buffer, shell->shell_buffer_size);
+            break;
+        case CONTROL_CUT_WORD_BEFORE:
+            cut_word_before(shell, cursor, buf, cut_buffer);
+            break;
+        case CONTROL_CUT_WORD_AFTER:
+            cut_word_behind(shell, cursor, buf, cut_buffer);
+            break;
+        case CONTROL_PASTE:
+            paste(shell, cursor, buf, cut_buffer, strlen(cut_buffer));
+            break;
+        case CONTROL_CTRL_RIGHT:
+            move_cursor_word_right(shell, cursor, buf);
+            break;
+        case CONTROL_CTRL_LEFT:
+            move_cursor_word_left(shell, cursor, buf);
+            break;
+        case CONTROL_CTRL_DEL: {
+            cut_word_behind(shell, cursor, buf, NULL);
+            break;
+        }
+        case CONTROL_UMLAUT:
+        case CONTROL_INS:
+            // Not implemented yet
+            break;
+        default:
+            break;
+    }
+    return CONTROL_NONE;
+}
+
+int readline(shell_t *shell, char *buf, size_t size)
+{
+    int cursor = 0;
+    *buf = '\0';
+
+    while (1) {
+        if (cursor >= ((int) size) - 1) {
+            return -1;
+        }
+
+        int c = shell->readchar();
+        if (c < 0) {
+            return -1;
+        }
+
+        control_e ctrl = readline_scan_char(c);
+        if (ctrl != CONTROL_NONE) {
+            control_e control = readline_control_process(shell, &cursor, buf, ctrl);
+            switch (control) {
+                case CONTROL_NL:
+#if SHELL_HISTORY_SIZE > 0
+                    history_put(buf);
+#endif
+                    return cursor;
+                default:
+                    break;
+            }
+            continue;
+        }
+        // Any other character
+        paste(shell, &cursor, buf, (char*) &c, 1);
+    }
+}

--- a/sys/readline/readline_history.c
+++ b/sys/readline/readline_history.c
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "readline.h"
+#include "include/readline_history.h"
+
+#if SHELL_HISTORY_SIZE > 0
+
+#define BUFLEN (SHELL_BUFFER_SIZE * SHELL_HISTORY_SIZE)
+static char HISTORY[BUFLEN];
+static char *i_history = NULL;
+static char *i_cycl = NULL;
+
+#define DEC(ptr, inc) ((ptr) - (inc) < HISTORY ? (ptr) - (inc) + BUFLEN : (ptr) - (inc))
+#define INC(ptr, inc) ((ptr) + (inc) >= HISTORY + BUFLEN ? (ptr) + (inc) - BUFLEN : (ptr) + (inc))
+
+static int cpyword(char *to, char *from)
+{
+    int count = 0;
+    while (*from != '\0') {
+        *(to++) = *from;
+        from = INC(from, 1);
+        count++;
+    }
+    *to = '\0';
+    return count;
+}
+
+static char *find_prev_word(char *from) {
+    do {
+        from = DEC(from, 1);
+    } while (*from != '\0');
+    return INC(from, 1);
+}
+
+static char *find_next_word(char *from)
+{
+    do {
+        from = INC(from, 1);
+    } while (*from != '\0');
+    return INC(from, 1);
+}
+
+/*
+ * 4 cases:
+ * case 1: empty history: i_history == NULL
+ * case 2: first cycle
+ *          [aaa_bbbb_cccccc_dddddddd*.....]    (* = +# = .)
+ * case 3: cycling in progress (last cycle was "cccccc")
+ *          [aaa_bbbb+cccccc_dddddddd#.....]    (+ = ., # = .)
+ * case 4: cycling finished (last cycle was
+ *          [aaa_bbbb_cccccc_dddddddd#....+]    (+ = ., # = .)
+ */
+int history_getprev(char *buf)
+{
+    if (i_history == NULL || i_cycl == NULL) {
+        // empty history (i_cycl == NULL is always the case when i_history == NULL)
+        return 0;
+    }
+    char *prev = find_prev_word(i_cycl);
+    if (*prev == '\0') {
+        // End of cycle, return current word again
+        prev = INC(i_cycl, 1);
+    }
+    else {
+        i_cycl = DEC(prev, 1);
+    }
+    // Copy the word into the output buffer
+    return cpyword(buf, prev);
+}
+
+int history_getnext(char *buf)
+{
+    if (i_history == NULL || i_cycl == NULL) {
+        // empty history (i_cycl == NULL is always the case when i_history == NULL)
+        return 0;
+    }
+    char *next = find_next_word(i_cycl);
+    if (*next == '\0') {
+        // End of cycle, return null
+        i_cycl = i_history;
+    }
+    else {
+        i_cycl = DEC(next, 1);
+    }
+    // Copy the word into the output buffer
+    return cpyword(buf, next);
+}
+
+void history_put(char *input)
+{
+    if (i_history == NULL) { // history is empty
+        i_history = HISTORY;
+    }
+    else if (!strncmp(input, find_prev_word(i_cycl), BUFLEN)) {
+        // Check if input is the most recent word
+        return;
+    }
+    int len = strlen(input);
+    if (!len || len >= BUFLEN) {
+        // input empty or doesn't fit
+        return;
+    }
+    i_history = INC(i_history, 1);
+    int avail = HISTORY + BUFLEN - i_history;
+    if (len <= avail) { // input fits behind cursor
+        strncpy(i_history, input, len);
+    }
+    else { // input doesn't fit, has to be split
+        strncpy(i_history, input, avail);
+        strncpy(HISTORY, input + avail, len - avail);
+    }
+    // Mark the end of the word by erasing the next word
+    i_history = INC(i_history, len);
+    char *tmp = i_history;
+    do {
+        *tmp = '\0';
+        tmp = INC(tmp, 1);
+    } while (*tmp != '\0');
+    i_cycl = i_history;
+}
+
+/*
+ * Reset the prev/next cycling.
+ */
+void history_reset(void)
+{
+    i_cycl = i_history;
+}
+
+/*
+ * For unit-tests. Reset the whole history.
+ */
+void history_reset_internal(void)
+{
+    memset(HISTORY, '\0', BUFLEN);
+    i_history = NULL;
+    i_cycl = NULL;
+}
+
+void history_printbuf(void)
+{
+    char *i;
+    putchar('[');
+    for (i = HISTORY; i < HISTORY + BUFLEN; i++) {
+        if (i == i_history && i == i_cycl) {
+            putchar('*');
+        }
+        else if (i == i_history) {
+            putchar('#');
+        }
+        else if (i == i_cycl) {
+            putchar('+');
+        }
+        else if (*i == '\0') {
+            putchar('.');
+        }
+        else {
+            putchar(*i);
+        }
+    }
+    putchar(']');
+    printf(" i:%02d cycl:%02d", i_history == NULL ? -1 : i_history - HISTORY, i_cycl == NULL ? -1 : i_cycl - HISTORY);
+    putchar('\n');
+}
+
+#endif

--- a/sys/readline/readline_keys.c
+++ b/sys/readline/readline_keys.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <stdio.h>
+
+#include "shell_print.h"
+#include "shell_colors.h"
+
+#define printentry(title, text) \
+    printf("      "); \
+    printfc(SHELL_STYLE_BOLD, title); \
+    printf(text); \
+    printf("\n");
+
+void readline_print_keyboard(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    printfcs(SHELL_COLOR_GREEN, SHELL_STYLE_BOLD, "  READLINE KEYBOARD ");
+    printfc(SHELL_COLOR_GREEN, "(bash/zsh compatible)\n");
+
+    printfcs(SHELL_COLOR_RED, SHELL_STYLE_BOLD, "    CURSOR\n");
+    printentry("CTRL+LEFT", "   Skip previous word");
+    printentry("ALT+B", "       Skip previous word");
+    printentry("CTRL+RIGHT", "  Skip next word");
+    printentry("ALT+F", "       Skip next word");
+    printentry("CTRL+A", "      HOME");
+    printentry("CTRL+E", "      END");
+    printentry("CTRL+B", "      Back");
+    printentry("CTRL+F", "      Forward");
+
+    printfcs(SHELL_COLOR_RED, SHELL_STYLE_BOLD, "    EDITING\n");
+    printentry("CTRL+DEL", "    Delete next word");
+    printentry("ALT+D", "       Cut next word");
+    printentry("CTRL+D", "      DEL");
+    printentry("CTRL+K", "      Cut behind cursor");
+    printentry("CTRL+U", "      Cut line");
+    printentry("CTRL+W", "      Cut previous word");
+    printentry("ESC+BS", "      Cut previous word");
+    printentry("CTRL+Y", "      Paste");
+
+    printfcs(SHELL_COLOR_RED, SHELL_STYLE_BOLD, "   HISTORY\n");
+    printentry("UP/DOWN", "     Cycle history");
+    printentry("CTRL+N", "      Next");
+    printentry("CTRL+P", "      Previous");
+}

--- a/sys/readline/readline_scan.c
+++ b/sys/readline/readline_scan.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include "include/readline_scan.h"
+
+#include <stdio.h>
+
+typedef enum
+{
+    STATE_START = 0, //
+    STATE_ESC, //
+    STATE_BRACKET, //
+    STATE_O, //
+    STATE_256, //
+    STATE_UMLAUT,
+    STATE_1, //
+    STATE_3, //
+    STATE_SEMICOLON, //
+    STATE_5
+} state_e;
+
+static state_e state = STATE_START;
+static char tmp = '\0';
+
+#define CTRL(CHAR)  (CHAR - 'A' + 1)
+
+control_e readline_scan_char(unsigned char c)
+{
+    switch (state) {
+        case STATE_START:
+            switch (c) {
+                case DEL: // intentional fall-through
+                case BS:
+                    return CONTROL_BS;
+                case LF: // intentional fall-through
+                case CR:
+                    return CONTROL_NL;
+                case TAB:
+                    return CONTROL_TAB;
+                case ESC:
+                    state = STATE_ESC;
+                    return CONTROL_IN_PROGRESS;
+                case UML:
+                    state = STATE_UMLAUT;
+                    return CONTROL_IN_PROGRESS;
+                case CTRL('A'):
+                    return CONTROL_HOME;
+                case CTRL('B'):
+                    return CONTROL_LEFT;
+                case CTRL('D'):
+                    return CONTROL_DEL;
+                case CTRL('E'):
+                    return CONTROL_END;
+                case CTRL('F'):
+                    return CONTROL_RIGHT;
+                case CTRL('K'):
+                    return CONTROL_CUT_ALL_BEHIND;
+                case CTRL('N'):
+                    return CONTROL_DOWN;
+                case CTRL('P'):
+                    return CONTROL_UP;
+                case CTRL('U'):
+                    return CONTROL_CUT_ALL;
+                case CTRL('W'):
+                    return CONTROL_CUT_WORD_BEFORE;
+                case CTRL('Y'):
+                    return CONTROL_PASTE;
+            }
+            break;
+        case STATE_ESC:
+            state = STATE_START;
+            switch (c) {
+                case ESC:
+                    state = STATE_ESC;
+                    return CONTROL_IN_PROGRESS;
+                case DEL:
+                    return CONTROL_DEL;
+                case BS:
+                    return CONTROL_CUT_WORD_BEFORE;
+                case 'b':
+                    return CONTROL_CTRL_LEFT;
+                case 'd':
+                    return CONTROL_CUT_WORD_AFTER;
+                case 'f':
+                    return CONTROL_CTRL_RIGHT;
+                case BRK:
+                    state = STATE_BRACKET;
+                    return CONTROL_IN_PROGRESS;
+                case CHO:
+                    state = STATE_O;
+                    return CONTROL_IN_PROGRESS;
+            }
+            break;
+        case STATE_BRACKET:
+            state = STATE_START;
+            switch (c) {
+                case '2': // intentional fall-through
+                case '5': // intentional fall-through
+                case '6':
+                    tmp = c;
+                    state = STATE_256;
+                    return CONTROL_IN_PROGRESS;
+                case '1':
+                    state = STATE_1;
+                    return CONTROL_IN_PROGRESS;
+                case '3':
+                    state = STATE_3;
+                    return CONTROL_IN_PROGRESS;
+                case 'A':
+                    return CONTROL_UP;
+                case 'B':
+                    return CONTROL_DOWN;
+                case 'C':
+                    return CONTROL_RIGHT;
+                case 'D':
+                    return CONTROL_LEFT;
+                case 'U':
+                    return CONTROL_PGDWN;
+                case 'V':
+                    return CONTROL_PGUP;
+                case 'H': // intentional fall-through
+                case '@':
+                    return CONTROL_HOME;
+            }
+            break;
+        case STATE_256:
+            state = STATE_START;
+            if (c == TILD) {
+                switch (tmp) {
+                    case '2':
+                        return CONTROL_INS;
+                    case '5':
+                        return CONTROL_PGUP;
+                    case '6':
+                        return CONTROL_PGDWN;
+                }
+            }
+            break;
+        case STATE_O:
+            state = STATE_START;
+            switch (c) {
+                case 'F':
+                    return CONTROL_END;
+                case 'H':
+                    return CONTROL_HOME;
+            }
+            break;
+        case STATE_UMLAUT:
+            state = STATE_START;
+            switch (c) {
+                case 0xA4: // ä
+                case 0x84: // Ä
+                case 0xB6: // ö
+                case 0x96: // Ö
+                case 0xBC: // ü
+                case 0x9C: // Ü
+                case 0x9F: // ß
+                    return CONTROL_UMLAUT;
+            }
+            break;
+        case STATE_1:
+            state = STATE_START;
+            switch (c) {
+                case TILD:
+                    return CONTROL_HOME;
+                case SEMICOL:
+                    state = STATE_SEMICOLON;
+                    return CONTROL_IN_PROGRESS;
+            }
+            break;
+        case STATE_3:
+            state = STATE_START;
+            switch (c) {
+                case TILD:
+                    return CONTROL_DEL;
+                case SEMICOL:
+                    state = STATE_SEMICOLON;
+                    return CONTROL_IN_PROGRESS;
+            }
+            break;
+        case STATE_SEMICOLON:
+            state = STATE_START;
+            switch (c) {
+                case '5':
+                    state = STATE_5;
+                    return CONTROL_IN_PROGRESS;
+            }
+            break;
+        case STATE_5:
+            state = STATE_START;
+            switch (c) {
+                case 'A':
+                    return CONTROL_CTRL_UP;
+                case 'B':
+                    return CONTROL_CTRL_DOWN;
+                case 'C':
+                    return CONTROL_CTRL_RIGHT;
+                case 'D':
+                    return CONTROL_CTRL_LEFT;
+                case TILD:
+                    return CONTROL_CTRL_DEL;
+            }
+            break;
+    }
+    if (c < 0x20 || c > 0x7E) {
+        return CONTROL_NONE_PRINTABLE;
+    }
+    return CONTROL_NONE;
+}

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -69,6 +69,10 @@ extern int _get_current_handler(int argc, char **argv);
 extern int _reset_current_handler(int argc, char **argv);
 #endif
 
+#ifdef MODULE_READLINE
+extern void readline_print_keyboard(int argc, char **argv);
+#endif
+
 #if FEATURE_PERIPH_RTC
 extern int _rtc_handler(int argc, char **argv);
 #endif
@@ -174,6 +178,9 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_LPC_COMMON
     {"heap", "Shows the heap state for the LPC2387 on the command shell.", _heap_handler},
+#endif
+#ifdef MODULE_READLINE
+    { "keys", "Display shell keyboard controls.", readline_print_keyboard },
 #endif
 #ifdef MODULE_PS
     {"ps", "Prints information about running threads.", _ps_handler},

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -32,6 +32,10 @@
 #include "shell_commands.h"
 #include "shell_print.h"
 
+#ifdef MODULE_READLINE
+#include "readline.h"
+#endif
+
 static shell_command_handler_t find_handler(const shell_command_t *command_list, char *command)
 {
     const shell_command_t *command_lists[] = {
@@ -214,75 +218,80 @@ static void handle_input_line(shell_t *shell, char *line)
     }
 }
 
+#ifndef MODULE_READLINE
+
+/*
+ * Return negative if no input is read.
+ * Else return the number of characters read.
+ */
 static int readline(shell_t *shell, char *buf, size_t size)
 {
-    char *line_buf_ptr = buf;
+    int cursor = 0;
+    *buf = '\0';
 
     while (1) {
-        if ((line_buf_ptr - buf) >= ((int) size) - 1) {
+        if (cursor >= ((int) size) - 1) {
             return -1;
         }
 
         int c = shell->readchar();
         if (c < 0) {
-            return 1;
+            return -1;
         }
 
         /* We allow Unix linebreaks (\n), DOS linebreaks (\r\n), and Mac linebreaks (\r). */
         /* QEMU transmits only a single '\r' == 13 on hitting enter ("-serial stdio"). */
         /* DOS newlines are handled like hitting enter twice, but empty lines are ignored. */
         if (c == '\r' || c == '\n') {
-            if (line_buf_ptr == buf) {
-                /* The line is empty. */
-                continue;
-            }
-
-            *line_buf_ptr = '\0';
-            shell->put_char('\r');
-            shell->put_char('\n');
-            return 0;
+            return cursor;
         }
         /* QEMU uses 0x7f (DEL) as backspace, while 0x08 (BS) is for most terminals */
         else if (c == 0x08 || c == 0x7f) {
-            if (line_buf_ptr == buf) {
+            if (cursor == 0) {
                 /* The line is empty. */
                 continue;
             }
-
-            *--line_buf_ptr = '\0';
+            buf[--cursor] = '\0';
             /* white-tape the character */
             shell->put_char('\b');
             shell->put_char(' ');
             shell->put_char('\b');
         }
+        else if (c == '\t') {
+            /* Tabulator */
+            for (int i = 0; i < SHELL_TAB_SIZE; i++) {
+                shell_echo_char(shell, ' ');
+                buf[cursor++] = ' ';
+            }
+            continue;
+        }
         else {
-            *line_buf_ptr++ = c;
-            shell->put_char(c);
+            // Any other character
+            shell_echo_char(shell, c);
+            buf[cursor++] = c;
+            buf[cursor] = '\0';
         }
     }
 }
-
-static inline void print_prompt(shell_t *shell)
-{
-    shell->put_char('>');
-    shell->put_char(' ');
-    return;
-}
+#endif // MODULE_READLINE
 
 void shell_run(shell_t *shell)
 {
     char line_buf[shell->shell_buffer_size];
 
-    print_prompt(shell);
+    shell_prompt(shell);
 
     while (1) {
         int res = readline(shell, line_buf, sizeof(line_buf));
 
-        if (!res) {
+        shell_putchar(shell, '\n');
+        if (res > 0) {
+            /* n characters were read. */
             handle_input_line(shell, line_buf);
+            /* empty the line buffer */
+            *line_buf = '\0';
         }
-
-        print_prompt(shell);
+        shell_prompt(shell);
     }
 }
 

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include "shell.h"
 #include "shell_commands.h"
+#include "shell_print.h"
 
 static shell_command_handler_t find_handler(const shell_command_t *command_list, char *command)
 {
@@ -88,6 +89,7 @@ static void print_help(const shell_command_t *command_list)
 
 static void handle_input_line(shell_t *shell, char *line)
 {
+    static const char *COMMAND_NOT_FOUND = "shell: command not found:";
     static const char *INCORRECT_QUOTING = "shell: incorrect quoting";
 
     /* first we need to calculate the number of arguments */
@@ -103,7 +105,8 @@ static void handle_input_line(shell_t *shell, char *line)
                 do {
                     ++pos;
                     if (!*pos) {
-                        puts(INCORRECT_QUOTING);
+                        shell_print_error(shell, INCORRECT_QUOTING);
+                        shell_putchar(shell, '\n');
                         return;
                     }
                     else if (*pos == '\\') {
@@ -111,14 +114,16 @@ static void handle_input_line(shell_t *shell, char *line)
                         ++contains_esc_seq;
                         ++pos;
                         if (!*pos) {
-                            puts(INCORRECT_QUOTING);
+                            shell_print_error(shell, INCORRECT_QUOTING);
+                            shell_putchar(shell, '\n');
                             return;
                         }
                         continue;
                     }
                 } while (*pos != quote_char);
                 if ((unsigned char) pos[1] > ' ') {
-                    puts(INCORRECT_QUOTING);
+                    shell_print_error(shell, INCORRECT_QUOTING);
+                    shell_putchar(shell, '\n');
                     return;
                 }
             }
@@ -130,13 +135,15 @@ static void handle_input_line(shell_t *shell, char *line)
                         ++contains_esc_seq;
                         ++pos;
                         if (!*pos) {
-                            puts(INCORRECT_QUOTING);
+                            shell_print_error(shell, INCORRECT_QUOTING);
+                            shell_putchar(shell, '\n');
                             return;
                         }
                     }
                     ++pos;
                     if (*pos == '"') {
-                        puts(INCORRECT_QUOTING);
+                        shell_print_error(shell, INCORRECT_QUOTING);
+                        shell_putchar(shell, '\n');
                         return;
                     }
                 } while ((unsigned char) *pos > ' ');
@@ -199,8 +206,10 @@ static void handle_input_line(shell_t *shell, char *line)
             print_help(shell->command_list);
         }
         else {
-            puts("shell: command not found:");
-            puts(argv[0]);
+            shell_print_error(shell, COMMAND_NOT_FOUND);
+            shell_putchar(shell, '\n');
+            shell_print(shell, argv[0]);
+            shell_putchar(shell, '\n');
         }
     }
 }

--- a/sys/shell/shell_print.c
+++ b/sys/shell/shell_print.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include "shell_print.h"
+#include "shell.h"
+
+#if USE_SHELL_COLORS
+#include "shell_colors.h"
+#endif // USE_SHELL_COLORS
+
+inline void shell_print(shell_t *shell, const char *string)
+{
+    while (*string) {
+        shell_putchar(shell, *string);
+        string++;
+    }
+}
+
+inline void shell_echo_string(shell_t *shell, const char *string)
+{
+#if USE_SHELL_COLORS
+    shell_print(shell, SHELL_COLOR_ECHO);
+    shell_print(shell, string);
+    shell_print(shell, SHELL_COLOR_MAIN);
+#else
+    shell_print(shell, string);
+#endif
+}
+
+inline void shell_print_error(shell_t *shell, const char *string)
+{
+#if USE_SHELL_COLORS
+    shell_print(shell, SHELL_COLOR_ERROR);
+    shell_print(shell, string);
+    shell_print(shell, SHELL_COLOR_MAIN);
+#else
+    shell_print(shell, string);
+#endif
+}
+
+inline void shell_echo_char(shell_t *shell, char c)
+{
+#if USE_SHELL_COLORS
+    shell_print(shell, SHELL_COLOR_ECHO);
+    shell_putchar(shell, c);
+    shell_print(shell, SHELL_COLOR_MAIN);
+#else
+    shell_putchar(shell, c);
+#endif
+}
+
+inline void shell_prompt(shell_t *shell)
+{
+#if USE_SHELL_COLORS
+    shell_print(shell, SHELL_COLORED(">", SHELL_COLOR_PROMPT));
+#else
+    shell_putchar(shell, '>');
+#endif
+    shell_putchar(shell, ' ');
+    return;
+}
+

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -1,6 +1,7 @@
 APPLICATION = shell
 include ../Makefile.tests_common
 
+CFLAGS += -DUSE_SHELL_COLORS
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -2,10 +2,13 @@ APPLICATION = shell
 include ../Makefile.tests_common
 
 CFLAGS += -DUSE_SHELL_COLORS
+CFLAGS += -DSHELL_HISTORY_SIZE=10
+
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 USEMODULE += uart0
+USEMODULE += readline
 
 DISABLE_MODULE += auto_init
 

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -56,6 +56,25 @@ static int print_echo(int argc, char **argv)
     return 0;
 }
 
+#ifdef USE_SHELL_COLORS
+unsigned int FGBG[] = { 38, 48 };
+static void print_colors(int argc, char **argv)
+{
+    (void) argc; (void) argv;
+    int color, fgbg;
+    for (fgbg = 0; fgbg < 2; fgbg++) {
+        for (color = 0; color <= 256; color++) {
+            printf("\033[%i;5;%im %i\t\033[0m", FGBG[fgbg], color, color);
+            if (((color + 1) % 10) == 0) {
+                putchar('\n');
+            }
+        }
+        putchar('\n');
+    }
+    puts("\033[94m[Source: http://misc.flogisoft.com/bash/tip_colors_and_formatting]\033[0m");
+}
+#endif // USE_SHELL_COLORS
+
 static int shell_readc(void)
 {
     char c;
@@ -75,6 +94,9 @@ static const shell_command_t shell_commands[] = {
     { "start_test", "starts a test", print_teststart },
     { "end_test", "ends a test", print_testend },
     { "echo", "prints the input command", print_echo },
+#ifdef USE_SHELL_COLORS
+    { "colors", "Show fancy \033[31mC\033[32mo\033[34ml\033[34mo\033[35mr\033[36ms\033[37m!\033[0m", print_colors },
+#endif
     { NULL, NULL, NULL }
 };
 

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -26,6 +26,10 @@
 #include "shell.h"
 #include "board_uart0.h"
 
+#ifdef MODULE_READLINE
+#include "readline.h"
+#endif
+
 #define SHELL_BUFSIZE   (UART0_BUFSIZE)
 
 static int print_teststart(int argc, char **argv)
@@ -102,7 +106,6 @@ static const shell_command_t shell_commands[] = {
 
 int main(void)
 {
-
     printf("test_shell.\n");
 
     board_uart0_init();

--- a/tests/unittests/tests-readline/Makefile
+++ b/tests/unittests/tests-readline/Makefile
@@ -1,0 +1,3 @@
+MODULE = tests-readline
+
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-readline/Makefile.include
+++ b/tests/unittests/tests-readline/Makefile.include
@@ -1,0 +1,4 @@
+USEMODULE += readline
+
+CFLAGS += -DSHELL_HISTORY_SIZE=10
+INCLUDES += -I$(RIOTBASE)/sys/readline/include

--- a/tests/unittests/tests-readline/tests-readline-internal-cursor.c
+++ b/tests/unittests/tests-readline/tests-readline-internal-cursor.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/* clib includes */
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "embUnit/embUnit.h"
+#include "tests-readline.h"
+
+#include "readline.h"
+#include "readline_internal.h"
+
+static shell_t shell;
+static char BUFFER[SHELL_BUFFER_SIZE];
+
+#define TEST_STRING "123456789"
+#define LEN_TEST_STRING 9
+
+static void set_up(void)
+{
+    shell.put_char = put_char_dummy;
+    shell.readchar = get_char_dummy;
+    shell.shell_buffer_size = SHELL_BUFFER_SIZE;
+    memset(BUFFER, 0, SHELL_BUFFER_SIZE);
+}
+
+static int _test_move_left(const char *buf, int cursor)
+{
+    strcpy(BUFFER, buf);
+    _replace_cursor_marks(BUFFER);
+    move_cursor_word_left(&shell, &cursor, BUFFER);
+    return cursor;
+}
+
+static int _test_move_right(char *buf, int cursor)
+{
+    strcpy(BUFFER, buf);
+    _replace_cursor_marks(BUFFER);
+    move_cursor_word_right(&shell, &cursor, BUFFER);
+    return cursor;
+}
+
+static void test_cursor_move_left(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, _test_move_left("", 0));
+    TEST_ASSERT_EQUAL_INT(0, _test_move_left("This is a test", 0));
+    TEST_ASSERT_EQUAL_INT(0, _test_move_left("tHis is a test", 1));
+    TEST_ASSERT_EQUAL_INT(0, _test_move_left("this_is a test", 4));
+    TEST_ASSERT_EQUAL_INT(0, _test_move_left("this Is a test", 5));
+    TEST_ASSERT_EQUAL_INT(5, _test_move_left("this iS a test", 6));
+    TEST_ASSERT_EQUAL_INT(0, _test_move_left(" _ this is a test", 1));
+    TEST_ASSERT_EQUAL_INT(0, _test_move_left("  _this is a test", 2));
+    TEST_ASSERT_EQUAL_INT(3, _test_move_left("   This is a test", 4));
+    TEST_ASSERT_EQUAL_INT(3, _test_move_left("   this   _  is a test", 10));
+    TEST_ASSERT_EQUAL_INT(18, _test_move_left("   this      is a test#", 22));
+}
+
+static void test_cursor_move_right(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, _test_move_right("", 0));
+    TEST_ASSERT_EQUAL_INT(14, _test_move_right("this is a Test", 10));
+    TEST_ASSERT_EQUAL_INT(14, _test_move_right("this is a teSt", 12));
+    TEST_ASSERT_EQUAL_INT(10, _test_move_right("this is a_test", 9));
+    TEST_ASSERT_EQUAL_INT(5, _test_move_right("This is a test", 0));
+    TEST_ASSERT_EQUAL_INT(5, _test_move_right(" _   this is a test", 1));
+    TEST_ASSERT_EQUAL_INT(18, _test_move_right("this is a teSt    ", 12));
+    TEST_ASSERT_EQUAL_INT(10, _test_move_right("this is A test    ", 8));
+    TEST_ASSERT_EQUAL_INT(10, _test_move_right("this is a_test    ", 9));
+}
+
+Test *tests_readline_internal_cursor_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_cursor_move_left),
+        new_TestFixture(test_cursor_move_right),
+    };
+
+    EMB_UNIT_TESTCALLER(readline_internal_cursor_tests, set_up, NULL, fixtures);
+
+    return (Test *)&readline_internal_cursor_tests;
+}

--- a/tests/unittests/tests-readline/tests-readline-internal-cut_paste.c
+++ b/tests/unittests/tests-readline/tests-readline-internal-cut_paste.c
@@ -1,0 +1,513 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/* clib includes */
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "embUnit/embUnit.h"
+#include "tests-readline.h"
+
+#include "readline.h"
+#include "readline_internal.h"
+
+static shell_t shell;
+static char BUFFER[SHELL_BUFFER_SIZE];
+static char CUT_PASTE_BUFFER[SHELL_BUFFER_SIZE];
+static char TEST_BUFFER[SHELL_BUFFER_SIZE];
+
+#define TEST_STRING "123456789"
+#define TEST_STRING2 "abcdefghi"
+#define LEN_TEST_STRING 9
+
+static void set_up(void)
+{
+    shell.put_char = put_char_dummy;
+    shell.readchar = get_char_dummy;
+    shell.shell_buffer_size = SHELL_BUFFER_SIZE;
+    memset(BUFFER, 0, SHELL_BUFFER_SIZE);
+    memset(CUT_PASTE_BUFFER, 0, SHELL_BUFFER_SIZE);
+}
+
+#define MIN(X,Y) ((X) < (Y) ? (X) : (Y))
+
+static void test_cut_loops(void)
+{
+    int cursor = 0;
+    char *buf = BUFFER;
+    char *cut_buf = CUT_PASTE_BUFFER;
+    char *exp_cut_buf = TEST_BUFFER;
+
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+
+    for (int cur = 0; cur < LEN_TEST_STRING; cur++) {
+        for (int cut_len = 0; cut_len < LEN_TEST_STRING; cut_len++) {
+            // Preparation
+            cursor = cur;
+            sprintf(buf, TEST_STRING);
+            int exp_cut_len = MIN(cut_len, LEN_TEST_STRING - cur);
+            strncpy(exp_cut_buf, buf + cur, exp_cut_len);
+            exp_cut_buf[exp_cut_len] = '\0';
+
+            // Action
+            cut(&shell, &cursor, buf, cut_buf, cut_len);
+////            printf("cur: %d, cut_len: %d, exp_cut_len: %d, buf: '%s', cut_buf: '%s'\n",
+//                cur, cut_len, exp_cut_len, buf, cut_buf);
+
+// Tests
+            TEST_ASSERT_EQUAL_INT(LEN_TEST_STRING - exp_cut_len, strlen(buf));
+            TEST_ASSERT_EQUAL_INT(exp_cut_len, strlen(cut_buf));
+            TEST_ASSERT_EQUAL_INT(cur, cursor);
+            TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+        }
+    }
+
+}
+
+static void test_paste_loops(void)
+{
+    int cursor = 0;
+    char *buf = BUFFER;
+    char *paste_buf = CUT_PASTE_BUFFER;
+    char *exp_buf = TEST_BUFFER;
+
+    sprintf(paste_buf, TEST_STRING2);
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+
+    for (int cur = 0; cur < LEN_TEST_STRING; cur++) {
+        for (int paste_len = 0; paste_len < LEN_TEST_STRING; paste_len++) {
+            // Preparation
+            cursor = cur;
+            sprintf(buf, TEST_STRING);
+            int exp_buf_len = paste_len + LEN_TEST_STRING;
+
+            // Construct the expected buffer
+            strncpy(exp_buf, buf, cur);
+            strncpy(exp_buf + cur, paste_buf, paste_len);
+            strncpy(exp_buf + cur + paste_len, buf + cur, LEN_TEST_STRING - cur);
+            exp_buf[exp_buf_len] = '\0';
+
+            // Action
+            paste(&shell, &cursor, buf, paste_buf, paste_len);
+//            printf("cur: %d, paste_len: %d, exp_buf_len: %d, buf: '%s', exp_buf: '%s'\n",
+//                    cur, paste_len, exp_buf_len, buf, exp_buf);
+
+// Tests
+            TEST_ASSERT_EQUAL_INT(exp_buf_len, strlen(buf));
+            TEST_ASSERT_EQUAL_INT(cur + paste_len, cursor);
+            TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+        }
+    }
+
+}
+
+static void test_cut_normal(void)
+{
+    int cursor = 0;
+    char *buf = BUFFER;
+    char *cut_buf = CUT_PASTE_BUFFER;
+
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+
+    sprintf(buf, TEST_STRING);
+    cursor = 0;
+    cut(&shell, &cursor, buf, cut_buf, 1);
+    TEST_ASSERT_EQUAL_INT(8, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(1, strlen(cut_buf));
+    TEST_ASSERT_EQUAL_STRING("23456789", buf);
+    TEST_ASSERT_EQUAL_STRING("1", cut_buf);
+
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, TEST_STRING);
+    cursor = 0;
+    cut(&shell, &cursor, buf, cut_buf, 3);
+    TEST_ASSERT_EQUAL_INT(6, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(3, strlen(cut_buf));
+    TEST_ASSERT_EQUAL_STRING("456789", buf);
+    TEST_ASSERT_EQUAL_STRING("123", cut_buf);
+
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, TEST_STRING);
+    cursor = 3;
+    cut(&shell, &cursor, buf, cut_buf, 3);
+    TEST_ASSERT_EQUAL_INT(6, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(3, strlen(cut_buf));
+    TEST_ASSERT_EQUAL_STRING("123789", buf);
+    TEST_ASSERT_EQUAL_STRING("456", cut_buf);
+}
+
+static void test_cut_bounds_cases(void)
+{
+    int cursor = 0;
+    char *buf = BUFFER;
+    char *cut_buf = CUT_PASTE_BUFFER;
+
+    /*
+     * Test empty buffer behaviour
+     */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    cursor = 0;
+    cut(&shell, &cursor, buf, cut_buf, 0);
+    TEST_ASSERT_EQUAL_INT(0, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(0, strlen(cut_buf));
+
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    cursor = 0;
+    cut(&shell, &cursor, buf, cut_buf, 1);
+    TEST_ASSERT_EQUAL_INT(0, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(0, strlen(cut_buf));
+
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    cursor = 0;
+    cut(&shell, &cursor, buf, cut_buf, LEN_TEST_STRING - 1);
+    TEST_ASSERT_EQUAL_INT(0, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(0, strlen(cut_buf));
+
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    cursor = 0;
+    cut(&shell, &cursor, buf, cut_buf, LEN_TEST_STRING * 2);
+    TEST_ASSERT_EQUAL_INT(0, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(0, strlen(cut_buf));
+
+    /*
+     * Test empty cutting behaviour
+     */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, TEST_STRING);
+    cursor = 0;
+    cut(&shell, &cursor, buf, cut_buf, 0);
+    TEST_ASSERT_EQUAL_INT(LEN_TEST_STRING, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(0, strlen(cut_buf));
+
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    cursor = 5;
+    sprintf(buf, TEST_STRING);
+    cut(&shell, &cursor, buf, cut_buf, 0);
+    TEST_ASSERT_EQUAL_INT(LEN_TEST_STRING, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(0, strlen(cut_buf));
+
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    cursor = LEN_TEST_STRING - 1;
+    sprintf(buf, TEST_STRING);
+    cut(&shell, &cursor, buf, cut_buf, 0);
+    TEST_ASSERT_EQUAL_INT(LEN_TEST_STRING, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(0, strlen(cut_buf));
+
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    cursor = LEN_TEST_STRING;
+    sprintf(buf, TEST_STRING);
+    cut(&shell, &cursor, buf, cut_buf, 0);
+    TEST_ASSERT_EQUAL_INT(LEN_TEST_STRING, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(0, strlen(cut_buf));
+
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    cursor = LEN_TEST_STRING + 1;
+    sprintf(buf, TEST_STRING);
+    cut(&shell, &cursor, buf, cut_buf, 0);
+    TEST_ASSERT_EQUAL_INT(LEN_TEST_STRING, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(0, strlen(cut_buf));
+
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    cursor = LEN_TEST_STRING * 2;
+    sprintf(buf, TEST_STRING);
+    cut(&shell, &cursor, buf, cut_buf, 0);
+    TEST_ASSERT_EQUAL_INT(LEN_TEST_STRING, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(0, strlen(cut_buf));
+}
+
+static void test_cut_overcutting(void)
+{
+    int cursor = 0;
+    char *buf = BUFFER;
+    char *cut_buf = CUT_PASTE_BUFFER;
+
+    /**
+     * Test overcutting behaviour
+     */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, TEST_STRING);
+    cursor = 0;
+    cut(&shell, &cursor, buf, cut_buf, LEN_TEST_STRING);
+    TEST_ASSERT_EQUAL_INT(0, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(LEN_TEST_STRING, strlen(cut_buf));
+    TEST_ASSERT_EQUAL_STRING("", buf);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING, cut_buf);
+
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, TEST_STRING);
+    cursor = 0;
+    cut(&shell, &cursor, buf, cut_buf, LEN_TEST_STRING * 2);
+    TEST_ASSERT_EQUAL_INT(0, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(LEN_TEST_STRING, strlen(cut_buf));
+    TEST_ASSERT_EQUAL_STRING("", buf);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING, cut_buf);
+
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, TEST_STRING);
+    cursor = 4;
+    cut(&shell, &cursor, buf, cut_buf, LEN_TEST_STRING);
+    TEST_ASSERT_EQUAL_INT(4, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(5, strlen(cut_buf));
+    TEST_ASSERT_EQUAL_STRING("1234", buf);
+    TEST_ASSERT_EQUAL_STRING("56789", cut_buf);
+
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, TEST_STRING);
+    cursor = LEN_TEST_STRING - 1;
+    cut(&shell, &cursor, buf, cut_buf, LEN_TEST_STRING);
+    TEST_ASSERT_EQUAL_INT(8, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(1, strlen(cut_buf));
+    TEST_ASSERT_EQUAL_STRING("12345678", buf);
+    TEST_ASSERT_EQUAL_STRING("9", cut_buf);
+
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(cut_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, TEST_STRING);
+    cursor = LEN_TEST_STRING;
+    cut(&shell, &cursor, buf, cut_buf, LEN_TEST_STRING);
+    TEST_ASSERT_EQUAL_INT(LEN_TEST_STRING, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(0, strlen(cut_buf));
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING, buf);
+    TEST_ASSERT_EQUAL_STRING("", cut_buf);
+}
+
+static void test_paste_bounds_cases(void)
+{
+    int cursor = 0;
+    char *buf = BUFFER;
+    char *paste_buf = CUT_PASTE_BUFFER;
+
+    /* Emty buffer, empty paste, pastecount=0 */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    cursor = 0;
+    paste(&shell, &cursor, buf, paste_buf, 0);
+    TEST_ASSERT_EQUAL_INT(0, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(0, cursor);
+
+    /* Emty buffer, paste=teststring, pastecount=0 */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(paste_buf, TEST_STRING);
+    cursor = 0;
+    paste(&shell, &cursor, buf, paste_buf, 0);
+    TEST_ASSERT_EQUAL_INT(0, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(0, cursor);
+
+    /* buffer=teststring, empty paste, pastecount=0 */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, TEST_STRING);
+    cursor = 0;
+    paste(&shell, &cursor, buf, paste_buf, 0);
+    TEST_ASSERT_EQUAL_INT(LEN_TEST_STRING, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(0, cursor);
+
+    /* buffer=teststring, empty paste, pastecount=0, cursor=<end>*/
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, TEST_STRING);
+    cursor = LEN_TEST_STRING;
+    paste(&shell, &cursor, buf, paste_buf, 0);
+    TEST_ASSERT_EQUAL_INT(LEN_TEST_STRING, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(LEN_TEST_STRING, cursor);
+}
+
+static void test_paste_illegal_input(void)
+{
+    int cursor = 0;
+    char *buf = BUFFER;
+    char *paste_buf = CUT_PASTE_BUFFER;
+
+    /* Empty buffer, paste=teststring, pastecount=0, cursor=somewhere illegal */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(paste_buf, TEST_STRING);
+    cursor = 100;
+    paste(&shell, &cursor, buf, paste_buf, 0);
+    TEST_ASSERT_EQUAL_INT(0, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(100, cursor);
+
+    /* Emty buffer, empty paste, pastecount=100 */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    cursor = 0;
+    paste(&shell, &cursor, buf, paste_buf, 100);
+    TEST_ASSERT_EQUAL_INT(0, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(0, cursor);
+
+    /* Emty buffer, empty paste, pastecount=100, cursor=somewhere illegal */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    cursor = 100;
+    paste(&shell, &cursor, buf, paste_buf, 100);
+    TEST_ASSERT_EQUAL_INT(0, strlen(buf));
+    TEST_ASSERT_EQUAL_INT(100, cursor);
+}
+
+static void test_paste_normal(void)
+{
+    int cursor = 0;
+    char *buf = BUFFER;
+    char *paste_buf = CUT_PASTE_BUFFER;
+
+    /* Empty buffer, paste=teststring, pastecount=0, cursor=somewhere illegal */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(paste_buf, "abc");
+    cursor = 0;
+    paste(&shell, &cursor, buf, paste_buf, 1);
+    TEST_ASSERT_EQUAL_INT(1, strlen(buf));
+    TEST_ASSERT_EQUAL_STRING("a", buf);
+    TEST_ASSERT_EQUAL_INT(1, cursor);
+
+    /* Empty buffer, paste=teststring, pastecount=0, cursor=somewhere illegal */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(paste_buf, "abc");
+    cursor = 0;
+    paste(&shell, &cursor, buf, paste_buf, 3);
+    TEST_ASSERT_EQUAL_INT(3, strlen(buf));
+    TEST_ASSERT_EQUAL_STRING("abc", buf);
+    TEST_ASSERT_EQUAL_INT(3, cursor);
+
+    /* Empty buffer, paste=teststring, pastecount=0, cursor=somewhere illegal */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, "xyz");
+    sprintf(paste_buf, "abc");
+    cursor = 0;
+    paste(&shell, &cursor, buf, paste_buf, 3);
+    TEST_ASSERT_EQUAL_INT(6, strlen(buf));
+    TEST_ASSERT_EQUAL_STRING("abcxyz", buf);
+    TEST_ASSERT_EQUAL_INT(3, cursor);
+
+    /* Empty buffer, paste=teststring, pastecount=0, cursor=somewhere illegal */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, "xyz");
+    sprintf(paste_buf, "abc");
+    cursor = 3;
+    paste(&shell, &cursor, buf, paste_buf, 3);
+    TEST_ASSERT_EQUAL_INT(6, strlen(buf));
+    TEST_ASSERT_EQUAL_STRING("xyzabc", buf);
+    TEST_ASSERT_EQUAL_INT(6, cursor);
+
+    /* Empty buffer, paste=teststring, pastecount=0, cursor=somewhere illegal */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, "xyz123");
+    sprintf(paste_buf, "abc");
+    cursor = 3;
+    paste(&shell, &cursor, buf, paste_buf, 2);
+    TEST_ASSERT_EQUAL_INT(8, strlen(buf));
+    TEST_ASSERT_EQUAL_STRING("xyzab123", buf);
+    TEST_ASSERT_EQUAL_INT(5, cursor);
+
+}
+
+static void test_paste_overpasting(void)
+{
+    int cursor = 0;
+    char *buf = BUFFER;
+    char *paste_buf = CUT_PASTE_BUFFER;
+
+    /* Pasting more characters than are in the paste_buf */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(paste_buf, "abc");
+    sprintf(buf, "12345");
+    cursor = 2;
+    paste(&shell, &cursor, buf, paste_buf, 5);
+    TEST_ASSERT_EQUAL_INT(8, strlen(buf));
+    TEST_ASSERT_EQUAL_STRING("12abc345", buf);
+
+    /* Paste the last character */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, "0123456789ABCDEF0123456789ABCDE"); // 31 chars, limit is 32
+    sprintf(paste_buf, "_+-");
+    cursor = 0;
+    paste(&shell, &cursor, buf, paste_buf, 1);
+    TEST_ASSERT_EQUAL_INT(32, strlen(buf));
+    TEST_ASSERT_EQUAL_STRING("_0123456789ABCDEF0123456789ABCDE", buf);
+
+    /* Paste the last character at the end */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, "0123456789ABCDEF0123456789ABCDE"); // 31 chars, limit is 32
+    sprintf(paste_buf, "_+-");
+    cursor = 31;
+    paste(&shell, &cursor, buf, paste_buf, 1);
+    TEST_ASSERT_EQUAL_INT(32, strlen(buf));
+    TEST_ASSERT_EQUAL_STRING("0123456789ABCDEF0123456789ABCDE_", buf);
+    TEST_ASSERT_EQUAL_INT(32, cursor);
+
+    /* Paste the last character inbetween */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, "0123456789ABCDEF0123456789ABCDE"); // 31 chars, limit is 32
+    sprintf(paste_buf, "_+-");
+    cursor = 16;
+    paste(&shell, &cursor, buf, paste_buf, 1);
+    TEST_ASSERT_EQUAL_INT(32, strlen(buf));
+    TEST_ASSERT_EQUAL_STRING("0123456789ABCDEF_0123456789ABCDE", buf);
+    TEST_ASSERT_EQUAL_INT(17, cursor);
+
+    /****************************/
+
+    /* Paste in the full buffer */
+    memset(buf, 0, SHELL_BUFFER_SIZE);
+    memset(paste_buf, 0, SHELL_BUFFER_SIZE);
+    sprintf(buf, "0123456789ABCDEF0123456789ABCDEF"); // 32 chars, limit is 32
+    sprintf(paste_buf, "_+-");
+    cursor = 8;
+    paste(&shell, &cursor, buf, paste_buf, 1);
+    TEST_ASSERT_EQUAL_INT(32, strlen(buf));
+    TEST_ASSERT_EQUAL_STRING("0123456789ABCDEF0123456789ABCDEF", buf);
+    TEST_ASSERT_EQUAL_INT(8, cursor);
+}
+
+Test *tests_readline_internal_cut_paste_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_cut_normal),
+        new_TestFixture(test_cut_bounds_cases),
+        new_TestFixture(test_cut_overcutting),
+        new_TestFixture(test_cut_loops),
+        new_TestFixture(test_paste_normal),
+        new_TestFixture(test_paste_bounds_cases),
+        new_TestFixture(test_paste_overpasting),
+        new_TestFixture(test_paste_illegal_input),
+        new_TestFixture(test_paste_loops),
+    };
+
+    EMB_UNIT_TESTCALLER(readline_internal_cut_paste_tests, set_up, NULL, fixtures);
+
+    return (Test *)&readline_internal_cut_paste_tests;
+}

--- a/tests/unittests/tests-readline/tests-readline-internal-cut_words.c
+++ b/tests/unittests/tests-readline/tests-readline-internal-cut_words.c
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/* clib includes */
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "embUnit/embUnit.h"
+#include "tests-readline.h"
+
+#include "readline.h"
+#include "readline_internal.h"
+
+static shell_t shell;
+
+/* Test-Global variables, which are used to have a cleaner notation of test cases. */
+static char _buf[SHELL_BUFFER_SIZE];
+static char _exp_buf[SHELL_BUFFER_SIZE];
+static char _cut_buf[SHELL_BUFFER_SIZE];
+static char _exp_cut_buf[SHELL_BUFFER_SIZE];
+static int _cursor; // global cursor
+static int _exp_cursor;
+
+#define TEST_STRING "123456789"
+#define TEST_STRING2 "abcdefghi"
+#define LEN_TEST_STRING 9
+
+static void set_up(void)
+{
+    shell.put_char = put_char_dummy;
+    shell.readchar = get_char_dummy;
+    shell.shell_buffer_size = SHELL_BUFFER_SIZE;
+    memset(_buf, 0, SHELL_BUFFER_SIZE);
+    memset(_exp_buf, 0, SHELL_BUFFER_SIZE);
+    memset(_cut_buf, 0, SHELL_BUFFER_SIZE);
+    memset(_exp_cut_buf, 0, SHELL_BUFFER_SIZE);
+}
+
+void _test_cut_word_before(const char *buf, int cursor, const char *exp_buf, int exp_cursor,
+        const char *exp_cut_buf)
+{
+    strcpy(_buf, buf);
+    strcpy(_exp_buf, exp_buf);
+    strcpy(_exp_cut_buf, exp_cut_buf);
+    _replace_cursor_marks(_buf);
+    _replace_cursor_marks(_exp_buf);
+    _replace_cursor_marks(_exp_cut_buf);
+    _cursor = cursor;
+    _exp_cursor = exp_cursor;
+    cut_word_before(&shell, &_cursor, _buf, _cut_buf);
+}
+
+void _test_cut_word_behind(const char *buf, int cursor, const char *exp_buf, int exp_cursor,
+        const char *exp_cut_buf)
+{
+    strcpy(_buf, buf);
+    strcpy(_exp_buf, exp_buf);
+    strcpy(_exp_cut_buf, exp_cut_buf);
+    _replace_cursor_marks(_buf);
+    _replace_cursor_marks(_exp_buf);
+    _replace_cursor_marks(_exp_cut_buf);
+    _cursor = cursor;
+    _exp_cursor = exp_cursor;
+    cut_word_behind(&shell, &_cursor, _buf, _cut_buf);
+}
+
+static void test_cut_word_before(void)
+{
+    char *buf = _buf;
+    char *cut_buf = _cut_buf;
+    char *exp_buf = _exp_buf;
+    char *exp_cut_buf = _exp_cut_buf;
+
+    _test_cut_word_before("#", 0, "", 0, "#");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_before("this_is a test", 4, "_is a test", 0, "this");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_before("This is a test", 0, "This is a test", 0, "");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_before("this is a test#", 14, "this is a #", 10, "test");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_before("this longWord test", 9, "this Word test", 5, "long");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_before(" #", 1, "#", 0, " ");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_before("_", 0, "_", 0, "");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_before(" _ ", 1, "  ", 0, " ");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_before("   thiS    ", 6, "   S    ", 3, "thi");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_before("   this  _ ", 9, "   _ ", 3, "this  ");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+}
+
+static void test_cut_word_behind(void)
+{
+    char *buf = _buf;
+    char *cut_buf = _cut_buf;
+    char *exp_buf = _exp_buf;
+    char *exp_cut_buf = _exp_cut_buf;
+
+    _test_cut_word_behind("#", 0, "#", 0, "");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_behind("this_is a test", 4, "this_a test", 4, " is");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_behind("This is a test", 0, "_is a test", 0, "this");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_behind("tHis     is a test", 1, "t_    is a test", 1, "his");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_behind("this is a test#", 14, "this is a test#", 14, "");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_behind("this longWord test", 9, "this long_test", 9, "word");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_behind(" #", 1, " #", 1, "");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_behind("_", 0, "#", 0, " ");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_behind(" _ ", 1, " #", 1, "  ");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_behind("   tHis    ", 4, "   t_   ", 4, "his");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+
+    _test_cut_word_behind("  _ this    ", 2, "  _   ", 2, "  this");
+    TEST_ASSERT_EQUAL_INT(_exp_cursor, _cursor);
+    TEST_ASSERT_EQUAL_STRING(exp_buf, buf);
+    TEST_ASSERT_EQUAL_STRING(exp_cut_buf, cut_buf);
+}
+
+Test *tests_readline_internal_cut_words_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+    new_TestFixture(test_cut_word_behind),
+    new_TestFixture(test_cut_word_before),
+};
+
+EMB_UNIT_TESTCALLER(readline_internal_cut_words_tests, set_up, NULL, fixtures);
+
+return (Test *)&readline_internal_cut_words_tests;
+}

--- a/tests/unittests/tests-readline/tests-readline-internal-history-internal.c
+++ b/tests/unittests/tests-readline/tests-readline-internal-history-internal.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/* clib includes */
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "embUnit/embUnit.h"
+#include "tests-readline.h"
+
+#include "readline.h"
+#include "readline_internal.h"
+#include "readline_history.h"
+
+/*
+ * TODO: These tests are made for a history-buffer of 16 characters total.
+ */
+#define SSHELL_HISTORY_SIZE 16
+
+static char BUFFER[SHELL_BUFFER_SIZE];
+
+static void set_up(void)
+{
+    memset(BUFFER, 0, SHELL_BUFFER_SIZE);
+}
+
+static void test_history_simple(void)
+{
+    char *buf = BUFFER;
+    int len;
+    history_reset_internal();
+
+    len = history_getprev(buf);
+    TEST_ASSERT_EQUAL_INT(0, len);
+    TEST_ASSERT_EQUAL_STRING("", buf);
+
+    history_put("11111");
+
+    *buf = '\0';
+    len = history_getprev(buf);
+    TEST_ASSERT_EQUAL_INT(5, len);
+    TEST_ASSERT_EQUAL_STRING("11111", buf);
+
+    *buf = '\0';
+    len = history_getprev(buf);
+    TEST_ASSERT_EQUAL_INT(5, len);
+    TEST_ASSERT_EQUAL_STRING("11111", buf);
+
+    history_reset();
+
+    *buf = '\0';
+    len = history_getprev(buf);
+    TEST_ASSERT_EQUAL_INT(5, len);
+    TEST_ASSERT_EQUAL_STRING("11111", buf);
+
+}
+
+static void test_history_filling(void)
+{
+    char BUFFER[SHELL_BUFFER_SIZE];
+    char *buf = BUFFER;
+    int len;
+    history_reset_internal();
+
+    history_put("11111");
+    history_put("222");
+    history_put("3333");
+
+    *buf = '\0';
+    len = history_getprev(buf);
+    TEST_ASSERT_EQUAL_INT(4, len);
+    TEST_ASSERT_EQUAL_STRING("3333", buf);
+
+    *buf = '\0';
+    len = history_getprev(buf);
+    TEST_ASSERT_EQUAL_INT(3, len);
+    TEST_ASSERT_EQUAL_STRING("222", buf);
+
+    *buf = '\0';
+    len = history_getprev(buf);
+    TEST_ASSERT_EQUAL_INT(5, len);
+    TEST_ASSERT_EQUAL_STRING("11111", buf);
+
+    *buf = '\0';
+    len = history_getprev(buf);
+    TEST_ASSERT_EQUAL_INT(5, len);
+    TEST_ASSERT_EQUAL_STRING("11111", buf);
+}
+
+/*
+ * Test that the history returns always the last
+ * item, when there are no more items to cycle.
+ */
+static void test_history_multiprev(void)
+{
+    char BUFFER[SHELL_BUFFER_SIZE];
+    char *buf = BUFFER;
+    int len;
+    history_reset_internal();
+
+    history_put("11111");
+
+    *buf = '\0';
+    len = history_getprev(buf);
+    TEST_ASSERT_EQUAL_INT(5, len);
+    TEST_ASSERT_EQUAL_STRING("11111", buf);
+
+    *buf = '\0';
+    len = history_getprev(buf);
+    TEST_ASSERT_EQUAL_INT(5, len);
+    TEST_ASSERT_EQUAL_STRING("11111", buf);
+
+}
+
+static void test_history_next_prev(void)
+{
+    char BUFFER[SHELL_BUFFER_SIZE];
+    char *buf = BUFFER;
+    int len;
+    history_reset_internal();
+
+    *buf = '\0';
+    len = history_getnext(buf);
+    TEST_ASSERT_EQUAL_INT(0, len);
+    TEST_ASSERT_EQUAL_STRING("", buf);
+
+    history_put("11111");
+
+    *buf = '\0';
+    len = history_getnext(buf);
+    TEST_ASSERT_EQUAL_INT(0, len);
+    TEST_ASSERT_EQUAL_STRING("", buf);
+
+    *buf = '\0';
+    len = history_getprev(buf);
+    TEST_ASSERT_EQUAL_INT(5, len);
+    TEST_ASSERT_EQUAL_STRING("11111", buf);
+
+    *buf = '\0';
+    len = history_getnext(buf);
+    TEST_ASSERT_EQUAL_INT(0, len);
+    TEST_ASSERT_EQUAL_STRING("", buf);
+
+    history_put("222");
+
+    history_put("33");
+
+    *buf = '\0';
+    len = history_getprev(buf);
+    TEST_ASSERT_EQUAL_INT(2, len);
+    TEST_ASSERT_EQUAL_STRING("33", buf);
+
+    *buf = '\0';
+    len = history_getnext(buf);
+    TEST_ASSERT_EQUAL_INT(0, len);
+    TEST_ASSERT_EQUAL_STRING("", buf);
+
+    *buf = '\0';
+    len = history_getprev(buf);
+    TEST_ASSERT_EQUAL_INT(2, len);
+    TEST_ASSERT_EQUAL_STRING("33", buf);
+
+    *buf = '\0';
+    len = history_getprev(buf);
+    TEST_ASSERT_EQUAL_INT(3, len);
+    TEST_ASSERT_EQUAL_STRING("222", buf);
+
+    *buf = '\0';
+    len = history_getprev(buf);
+    TEST_ASSERT_EQUAL_INT(5, len);
+    TEST_ASSERT_EQUAL_STRING("11111", buf);
+
+    *buf = '\0';
+    len = history_getprev(buf);
+    TEST_ASSERT_EQUAL_INT(5, len);
+    TEST_ASSERT_EQUAL_STRING("11111", buf);
+
+    *buf = '\0';
+    len = history_getnext(buf);
+    TEST_ASSERT_EQUAL_INT(3, len);
+    TEST_ASSERT_EQUAL_STRING("222", buf);
+
+    *buf = '\0';
+    len = history_getnext(buf);
+    TEST_ASSERT_EQUAL_INT(2, len);
+    TEST_ASSERT_EQUAL_STRING("33", buf);
+
+    *buf = '\0';
+    len = history_getnext(buf);
+    TEST_ASSERT_EQUAL_INT(0, len);
+    TEST_ASSERT_EQUAL_STRING("", buf);
+
+}
+
+Test *tests_readline_internal_history_tests_internal(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_history_simple),
+        new_TestFixture(test_history_filling),
+        new_TestFixture(test_history_next_prev),
+        new_TestFixture(test_history_multiprev),
+    };
+
+    EMB_UNIT_TESTCALLER(readline_internal_history_tests, set_up, NULL, fixtures);
+
+    return (Test *)&readline_internal_history_tests;
+}

--- a/tests/unittests/tests-readline/tests-readline-internal-history.c
+++ b/tests/unittests/tests-readline/tests-readline-internal-history.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/* clib includes */
+
+#include <string.h>
+#include <stdlib.h>
+
+#include "embUnit/embUnit.h"
+#include "tests-readline.h"
+
+#include "readline.h"
+#include "readline_internal.h"
+#include "readline_history.h"
+
+static shell_t shell;
+static char BUFFER[SHELL_BUFFER_SIZE];
+
+#define TEST_STRING "123456789"
+#define LEN_TEST_STRING 9
+
+static void set_up(void)
+{
+    shell.put_char = put_char_dummy;
+    shell.readchar = get_char_dummy;
+    shell.shell_buffer_size = SHELL_BUFFER_SIZE;
+    memset(BUFFER, 0, SHELL_BUFFER_SIZE);
+}
+
+static void test_history(void)
+{
+    char *buf = BUFFER;
+    int cursor = 0;
+
+    strcpy(buf, "");
+    history_cycle_up(&shell, &cursor, buf);
+    TEST_ASSERT_EQUAL_INT(0, cursor);
+    TEST_ASSERT_EQUAL_STRING("", buf);
+
+    strcpy(buf, "test input");
+    cursor = 10;
+    history_cycle_up(&shell, &cursor, buf);
+    TEST_ASSERT_EQUAL_INT(0, cursor);
+    TEST_ASSERT_EQUAL_STRING("", buf);
+
+    history_put("first history entry");
+    strcpy(buf, "test input");
+    cursor = 10;
+    history_cycle_up(&shell, &cursor, buf);
+    TEST_ASSERT_EQUAL_INT(19, cursor);
+    TEST_ASSERT_EQUAL_STRING("first history entry", buf);
+    history_cycle_up(&shell, &cursor, buf);
+    TEST_ASSERT_EQUAL_INT(19, cursor);
+    TEST_ASSERT_EQUAL_STRING("first history entry", buf);
+    history_cycle_down(&shell, &cursor, buf);
+    TEST_ASSERT_EQUAL_INT(0, cursor);
+    TEST_ASSERT_EQUAL_STRING("", buf);
+    history_cycle_down(&shell, &cursor, buf);
+    TEST_ASSERT_EQUAL_INT(0, cursor);
+    TEST_ASSERT_EQUAL_STRING("", buf);
+
+    history_put("second entry");
+    cursor = 10;
+    history_cycle_up(&shell, &cursor, buf);
+    TEST_ASSERT_EQUAL_INT(12, cursor);
+    TEST_ASSERT_EQUAL_STRING("second entry", buf);
+    history_cycle_up(&shell, &cursor, buf);
+    TEST_ASSERT_EQUAL_INT(19, cursor);
+    TEST_ASSERT_EQUAL_STRING("first history entry", buf);
+    history_cycle_down(&shell, &cursor, buf);
+    TEST_ASSERT_EQUAL_INT(12, cursor);
+    TEST_ASSERT_EQUAL_STRING("second entry", buf);
+    history_cycle_down(&shell, &cursor, buf);
+    TEST_ASSERT_EQUAL_INT(0, cursor);
+    TEST_ASSERT_EQUAL_STRING("", buf);
+}
+
+static void test_history_reset(void)
+{
+    char *buf = BUFFER;
+    int cursor = 0;
+
+    strcpy(buf, "");
+    history_put("first history entry");
+    history_put("second entry");
+    history_put("last one");
+
+    history_cycle_up(&shell, &cursor, buf);
+    TEST_ASSERT_EQUAL_STRING("last one", buf);
+    TEST_ASSERT_EQUAL_INT(strlen(buf), cursor);
+
+    history_cycle_up(&shell, &cursor, buf);
+    TEST_ASSERT_EQUAL_STRING("second entry", buf);
+    TEST_ASSERT_EQUAL_INT(strlen(buf), cursor);
+
+    history_reset();
+
+    history_cycle_up(&shell, &cursor, buf);
+    TEST_ASSERT_EQUAL_STRING("last one", buf);
+    TEST_ASSERT_EQUAL_INT(strlen(buf), cursor);
+
+    history_reset();
+
+    history_cycle_down(&shell, &cursor, buf);
+    TEST_ASSERT_EQUAL_INT(0, cursor);
+    TEST_ASSERT_EQUAL_STRING("", buf);
+}
+
+Test *tests_readline_internal_history_tests(void)
+{
+    (void) test_history;
+    (void) test_history_reset;
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_history),
+//        new_TestFixture(test_history_reset),
+    };
+
+    EMB_UNIT_TESTCALLER(readline_internal_history_tests, set_up, NULL, fixtures);
+
+    return (Test *)&readline_internal_history_tests;
+}

--- a/tests/unittests/tests-readline/tests-readline.c
+++ b/tests/unittests/tests-readline/tests-readline.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer <noshky@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <ctype.h>
+
+#include "tests-readline.h"
+
+void tests_readline(void)
+{
+    TESTS_RUN(tests_readline_internal_cut_paste_tests());
+    TESTS_RUN(tests_readline_internal_cursor_tests());
+    TESTS_RUN(tests_readline_internal_cut_words_tests());
+    TESTS_RUN(tests_readline_internal_history_tests());
+    TESTS_RUN(tests_readline_internal_history_tests_internal());
+}
+
+void put_char_dummy(int c)
+{
+    (void) c;
+}
+
+int get_char_dummy(void)
+{
+    return 0;
+}
+
+/*
+ * In these tests, the current cursor position is marked with
+ * an uppercase character or with '_', if the cursor is at
+ * a whitespace position. The cursor being at the end of the
+ * string is denoted with a '#' character.
+ * The test-wrapper function replaces the '_' with a ' ' and
+ * the '#' character with the '\0' to have a propper test.
+ */
+void _replace_cursor_marks(char *buf)
+{
+    while (*buf) {
+        if (*buf == '_') {
+            *buf = ' ';
+        }
+        else if (*buf == '#') {
+            *buf = '\0';
+        }
+        else if (isupper(*buf)) {
+            *buf = tolower(*buf);
+        }
+        buf++;
+    }
+}

--- a/tests/unittests/tests-readline/tests-readline.h
+++ b/tests/unittests/tests-readline/tests-readline.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer (noshky@gmail.com)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file        tests-readline.h
+ * @brief       Unittests for the ``readline`` module
+ *
+ * @author      Janos Kutscherauer (noshky@gmail.com)
+ */
+#ifndef __TESTS_READLINE_H_
+#define __TESTS_READLINE_H_
+
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Shell buffer, +1 for the \0 character */
+#define SHELL_BUFFER_SIZE (32 + 1)
+
+void put_char_dummy(int c);
+int get_char_dummy(void);
+
+void _replace_cursor_marks(char *buf);
+
+/**
+ * @brief   The entry point of this test suite.
+ */
+void tests_readline(void);
+
+/**
+ * @brief   Generates tests for readline-internal.h
+ *
+ * @return  embUnit tests if successful, NULL if not.
+ */
+Test *tests_readline_internal_cut_paste_tests(void);
+Test *tests_readline_internal_cursor_tests(void);
+Test *tests_readline_internal_cut_words_tests(void);
+Test *tests_readline_internal_history_tests(void);
+Test *tests_readline_internal_history_tests_internal(void);
+
+/* ... */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __TESTS_READLINE_H_ */
+/** @} */


### PR DESCRIPTION
This is a more sophisticated shell implementation, that has colors, cursor-navigation, bash/zsh-like shortcuts and even a history (no tab-completion yet).

The implementation can be integrated as a module via ``USEMODULE += readline``. The dependency to the ``shell``-module is provided.

The shell module can now be configured with ``USE_SHELL_COLORS=1`` to have fancy colors.
The readline module can be configured with ``SHELL_HISTORY_SIZE=<n>`` to have a history-buffer that is n-times the buffer size. ``SHELL_HISTORY_SIZE=0`` compiles without the usage of the history, as well as not mentioning that flag at all.

TODOs:
The SHELL_BUFFER_SIZE has a big FIXME written next to it in ``readline.h``. It should be of the same size as the buffer size used for the ``shell`` module, but i haven't figured a way out yet to combine them.