### PR TITLE
shell: fixed warning for FIB shell command handler not providing a proper return value

### DIFF
--- a/sys/shell/commands/sc_fib.c
+++ b/sys/shell/commands/sc_fib.c
@@ -66,7 +66,7 @@ static void _fib_usage(int info)
     };
 }
 
-void _fib_route_handler(int argc, char **argv)
+int _fib_route_handler(int argc, char **argv)
 {
     /* e.g. fibroute right now dont care about the adress/protocol family */
     if (argc == 1) {
@@ -86,12 +86,12 @@ void _fib_route_handler(int argc, char **argv)
             puts("\nunrecognized parameter1.\nPlease enter fibroute [add|del] for more information.");
         }
 
-        return;
+        return 1;
     }
 
     if (argc > 2 && !((strcmp("add", argv[1]) == 0) || (strcmp("del", argv[1]) == 0))) {
         puts("\nunrecognized parameter2.\nPlease enter fibroute [add|del] for more information.");
-        return;
+        return 1;
     }
 
     /* e.g. fibroute del <destination> */
@@ -106,7 +106,7 @@ void _fib_route_handler(int argc, char **argv)
             fib_remove_entry((uint8_t *)argv[2], (strlen(argv[2])));
         }
 
-        return;
+        return 0;
     }
 
     /* e.g. fibroute add <destination> via <next hop> dev <device> */
@@ -152,9 +152,10 @@ void _fib_route_handler(int argc, char **argv)
         }
         else {
             _fib_usage(1);
+            return 1;
         }
 
-        return;
+        return 0;
     }
 
     /* e.g. fibroute add <destination> via <next hop> dev <device> lifetime <lifetime> */
@@ -201,9 +202,10 @@ void _fib_route_handler(int argc, char **argv)
         }
         else {
             _fib_usage(2);
+            return 1;
         }
 
-        return;
+        return 0;
     }
 
     puts("\nunrecognized parameters.\nPlease enter fibroute [add|del] for more information.");

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -160,7 +160,7 @@ extern int _netif_send(int argc, char **argv);
 #endif
 
 #ifdef MODULE_FIB
-extern void _fib_route_handler( int argc, char **argv );
+extern int _fib_route_handler(int argc, char **argv);
 #endif
 
 const shell_command_t _shell_command_list[] = {
@@ -265,11 +265,7 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #endif
 #ifdef MODULE_FIB
-    {
-        "fibroute",
-        "Manipulate the FIB (info: 'fibroute [add|del]')",
-        _fib_route_handler
-    },
+    {"fibroute", "Manipulate the FIB (info: 'fibroute [add|del]')", _fib_route_handler},
 #endif
     {NULL, NULL, NULL}
 };


### PR DESCRIPTION
The `_fib_route_handler()` had an incompatible pointer type due to a `void` return value.
This PR changes the return type to the expected `int` 