### PR TITLE
rpl: ignore DIOs containing my address as DODAGID

### DIFF
--- a/sys/net/routing/rpl/rpl_control_messages.c
+++ b/sys/net/routing/rpl/rpl_control_messages.c
@@ -519,6 +519,13 @@ void rpl_recv_DIO(void)
     rpl_dio_buf = get_rpl_dio_buf();
     DEBUGF("instance %04X ", rpl_dio_buf->rpl_instanceid);
     DEBUGF("rank %04X\n", byteorder_ntohs(rpl_dio_buf->rank));
+
+    /* do not process incoming DIOs containing my address as DODAGID */
+    if (ipv6_addr_is_equal(&my_address, &rpl_dio_buf->dodagid)) {
+        DEBUGF("Ignoring DIO with my address as DODAGID\n");
+        return;
+    }
+
     int len = DIO_BASE_LEN;
 
     rpl_instance_t *dio_inst = rpl_get_instance(rpl_dio_buf->rpl_instanceid);


### PR DESCRIPTION
When a root node decides to leave its current (temporary) DODAG and receives a DIO from its children for the same DODAG, the root will join the same DODAG as a child of one of its previous children.
This PR introduces a check if the DODAGID matches the RPL configured ipv6 address and discards the DIO if equal.