### PR TITLE
boards/samr21-xpro: fix led macros/init

### DIFF
--- a/boards/samr21-xpro/board.c
+++ b/boards/samr21-xpro/board.c
@@ -48,6 +48,7 @@ void board_init(void)
  */
 void led_init(void)
 {
-    LED_PORT.DIRSET.reg = LED_PIN;
+    LED_PORT.DIRSET.reg = 1 << LED_PIN;
     LED_PORT.OUTSET.reg = LED_PIN;
+    LED_PORT.PINCFG[LED_PIN].bit.PULLEN = false;
 }

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -70,9 +70,9 @@ extern "C" {
  * @name Macros for controlling the on-board LEDs.
  * @{
  */
-#define LED_ON              (LED_PORT.OUTCLR.reg = LED_PIN)
-#define LED_OFF             (LED_PORT.OUTSET.reg = LED_PIN)
-#define LED_TOGGLE          (LED_PORT.OUTTGL.reg = LED_PIN)
+#define LED_ON              (LED_PORT.OUTCLR.reg = 1<<LED_PIN)
+#define LED_OFF             (LED_PORT.OUTSET.reg = 1<<LED_PIN)
+#define LED_TOGGLE          (LED_PORT.OUTTGL.reg = 1<<LED_PIN)
 
 /* for compatability to other boards */
 #define LED_GREEN_ON        /* not available */


### PR DESCRIPTION
The LED macros are broken on the `samr21-xpro`. This PR fixes them.

The initialization section needs checking.