### PR TITLE
sys/net/fib: added switchable function prototypes to the FIB

### DIFF
--- a/sys/include/net/ng_fib.h
+++ b/sys/include/net/ng_fib.h
@@ -14,12 +14,24 @@
  * @{
  *
  * @file
- * @brief       Types and functions for FIB
+ * @brief       Types and functions for the FIB
  * @author      Martin Landsmann
  */
 
 #ifndef FIB_H_
 #define FIB_H_
+
+/**
+* @note: The specific prototype functions to manipulate FIB entries are present in
+* each of the following headers.
+*
+* This separation enables to extend the prototypes for specific address types easily.
+* Additionally it allows to switch only the required function prototypes by
+* only include the required fib_addon_*.h header(s).
+* At least one header MUST be included.
+*/
+#include "ng_fib/ng_fib_addon_generic.h"
+#include "ng_fib/ng_fib_addon_ipv6.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,14 +54,9 @@ typedef struct rp_address_msg_t {
 #define FIB_LIFETIME_NO_EXPIRE (0xFFFFFFFF)
 
 /**
- * @brief initializes all FIB entries with 0
+ * @brief maximum number of FIB table entries handled
  */
-void fib_init(void);
-
-/**
- * @brief de-initializes the FIB entries
- */
-void fib_deinit(void);
+#define FIB_MAX_FIB_TABLE_ENTRIES (20)
 
 /**
  * @brief Registration of a routing protocol handler function
@@ -64,69 +71,14 @@ void fib_deinit(void);
 int fib_register_rp(uint8_t *prefix, size_t prefix_size);
 
 /**
- * @brief Adds a new entry in the corresponding FIB table for global destination and next hop
- *
- * @param[in] iface_id       the interface ID
- * @param[in] dst            the destination address
- * @param[in] dst_size       the destination address size
- * @param[in] dst_flags      the destination address flags
- * @param[in] next_hop       the next hop address to be updated
- * @param[in] next_hop_size  the next hop address size
- * @param[in] next_hop_flags the next-hop address flags
- * @param[in] lifetime       the lifetime in ms to be updates
- *
- * @return 0 on success
- *         -ENOMEM if the entry cannot be created due to insufficient RAM
+ * @brief initializes all FIB entries with 0
  */
-int fib_add_entry(kernel_pid_t iface_id, uint8_t *dst, size_t dst_size, uint32_t dst_flags,
-                  uint8_t *next_hop, size_t next_hop_size, uint32_t next_hop_flags,
-                  uint32_t lifetime);
+void fib_init(void);
 
 /**
- * @brief Updates an entry in the FIB table with next hop and lifetime
- *
- * @param[in] dst            the destination address
- * @param[in] dst_size       the destination address size
- * @param[in] next_hop       the next hop address to be updated
- * @param[in] next_hop_size  the next hop address size
- * @param[in] next_hop_flags the next-hop address flags
- * @param[in] lifetime       the lifetime in ms to be updates
- *
- * @return 0 on success
- *         -ENOMEM if the entry cannot be updated due to insufficient RAM
+ * @brief de-initializes the FIB entries
  */
-int fib_update_entry(uint8_t *dst, size_t dst_size,
-                     uint8_t *next_hop, size_t next_hop_size, uint32_t next_hop_flags,
-                     uint32_t lifetime);
-
-/**
- * @brief removes an entry from the corresponding FIB table
- *
- * @param[in] dst       the destination address
- * @param[in] dst_size  the destination address size
- */
-void fib_remove_entry(uint8_t *dst, size_t dst_size);
-
-/**
- * @brief provides a next hop for a given destination
- *
- * @param[in, out] iface_id       pointer to store the interface ID for the next hop
- * @param[out] next_hop           pointer where the next hop address should be stored
- * @param[in, out] next_hop_size  the next hop address size. The value is
- *                                overwritten with the actual next hop size
- * @param[out] next_hop_flags     the next-hop address flags, e.g. compression type
- * @param[in] dst                 the destination address
- * @param[in] dst_size            the destination address size
- * @param[in] dst_flags           the destination address flags
- *
- * @return 0 on success
- *         -EHOSTUNREACH if no next hop is available in any FIB table
- *                                           all RRPs are notified before the return
- *         -ENOBUFS if the size for the next hop address is insufficient low
- */
-int fib_get_next_hop(kernel_pid_t *iface_id,
-                     uint8_t *next_hop, size_t *next_hop_size, uint32_t* next_hop_flags,
-                     uint8_t *dst, size_t dst_size, uint32_t dst_flags);
+void fib_deinit(void);
 
 /**
  * @brief returns the actual number of used FIB entries

--- a/sys/include/net/ng_fib/ng_fib_addon_generic.h
+++ b/sys/include/net/ng_fib/ng_fib_addon_generic.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2015  Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_fib
+ * @brief       FIB - generic address addon
+ *
+ * @{
+ *
+ * @file
+ * @brief       extends the FIB functions to use generic addresses.
+ *
+ * @author      Martin Landsmann
+ */
+
+#ifndef FIB_ADDON_GENERIC_H_
+#define FIB_ADDON_GENERIC_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Adds a new entry in the corresponding FIB table for global destination and next hop
+ *
+ * @param[in] iface_id       the interface ID
+ * @param[in] dst            the destination address
+ * @param[in] dst_size       the destination address size
+ * @param[in] dst_flags      the destination address flags
+ * @param[in] next_hop       the next hop address to be updated
+ * @param[in] next_hop_size  the next hop address size
+ * @param[in] next_hop_flags the next-hop address flags
+ * @param[in] lifetime       the lifetime in ms to be updates
+ *
+ * @return 0 on success
+ *         -ENOMEM if the entry cannot be created due to unsufficient RAM
+ */
+int fib_add_entry(kernel_pid_t iface_id, uint8_t *dst, size_t dst_size, uint32_t dst_flags,
+                  uint8_t *next_hop, size_t next_hop_size, uint32_t next_hop_flags,
+                  uint32_t lifetime);
+
+/**
+ * @brief Updates an entry in the FIB table with next hop and lifetime
+ *
+ * @param[in] dst            the destination address
+ * @param[in] dst_size       the destination address size
+ * @param[in] next_hop       the next hop address to be updated
+ * @param[in] next_hop_size  the next hop address size
+ * @param[in] next_hop_flags the next-hop address flags
+ * @param[in] lifetime       the lifetime in ms to be updates
+ *
+ * @return 0 on success
+ *         -ENOMEM if the entry cannot be updated due to unsufficient RAM
+ */
+int fib_update_entry(uint8_t *dst, size_t dst_size,
+                     uint8_t *next_hop, size_t next_hop_size, uint32_t next_hop_flags,
+                     uint32_t lifetime);
+
+/**
+ * @brief removes an entry from the corresponding FIB table
+ *
+ * @param[in] dst       the destination address
+ * @param[in] dst_size  the destination address size
+ */
+void fib_remove_entry(uint8_t *dst, size_t dst_size);
+
+/**
+ * @brief provides a next hop for a given destination
+ *
+ * @param[in, out] iface_id       pointer to store the interface ID for the next hop
+ * @param[out] next_hop           pointer where the next hop address should be stored
+ * @param[in, out] next_hop_size  the next hop address size. The value is
+ *                                overwritten with the actual next hop size
+ * @param[out] next_hop_flags     the next-hop address flags, e.g. compression type
+ * @param[in] dst                 the destination address
+ * @param[in] dst_size            the destination address size
+ * @param[in] dst_flags           the destination address flags
+ *
+ * @return 0 on success
+ *         -EHOSTUNREACH if no next hop is available in any FIB table
+ *                                           all RRPs are notified before the return
+ *         -ENOBUFS if the size for the next hop address is insufficient low
+ */
+int fib_get_next_hop(kernel_pid_t *iface_id,
+                     uint8_t *next_hop, size_t *next_hop_size, uint32_t *next_hop_flags,
+                     uint8_t *dst, size_t dst_size, uint32_t dst_flags);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FIB_ADDON_GENERIC_H_ */
+/** @} */

--- a/sys/include/net/ng_fib/ng_fib_addon_ipv6.h
+++ b/sys/include/net/ng_fib/ng_fib_addon_ipv6.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2015  Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_fib
+ * @brief       FIB - ipv6 addon
+ *
+ * @{
+ *
+ * @file
+ * @brief       extends the FIB functions specifically for ipv6.
+ *
+ * @author      Martin Landsmann
+ */
+
+#ifndef FIB_ADDON_IPV6_H_
+#define FIB_ADDON_IPV6_H_
+
+#include "ng_ipv6/addr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Adds a new ipv6 entry in the FIB table for global destination and next hop
+ *
+ * @param[in] iface_id       the interface ID
+ * @param[in] dst            the destination address
+ * @param[in] next_hop       the next hop address to be updated
+ * @param[in] lifetime       the lifetime in ms to be updates
+ *
+ * @return 0 on success
+ *         -ENOMEM if the entry cannot be created due to unsufficient RAM
+ */
+int fib_add_entry_ipv6(kernel_pid_t iface_id, ng_ipv6_addr_t *dst,
+                       ng_ipv6_addr_t *next_hop, uint32_t lifetime);
+
+/**
+ * @brief Updates an ipv6 entry in the FIB table with next hop and lifetime
+ *
+ * @param[in] dst            the destination address
+ * @param[in] next_hop       the next hop address to be updated
+ * @param[in] lifetime       the lifetime in ms to be updates
+ *
+ * @return 0 on success
+ *         -ENOMEM if the entry cannot be updated due to unsufficient RAM
+ */
+int fib_update_entry_ipv6(ng_ipv6_addr_t *dst, ng_ipv6_addr_t *next_hop,
+                          uint32_t lifetime);
+
+/**
+ * @brief removes an entry from the corresponding FIB table
+ *
+ * @param[in] dst       the destination address
+ */
+void fib_remove_entry_ipv6(ng_ipv6_addr_t *dst);
+
+/**
+ * @brief provides a next hop for a given destination
+ *
+ * @param[in, out] iface_id       pointer to store the interface ID for the next hop
+ * @param[out] next_hop           pointer where the next hop address should be stored
+ * @param[in] dst                 the destination address
+ *
+ * @return 0 on success
+ *         -EHOSTUNREACH if no next hop is available in any FIB table
+ *                                           all RRPs are notified before the return
+ *         -ENOBUFS if the size for the next hop address is insufficient low
+ */
+int fib_get_next_hop_ipv6(kernel_pid_t *iface_id, ng_ipv6_addr_t *next_hop,
+                          ng_ipv6_addr_t *dst);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FIB_ADDON_IPV6_H_ */
+/** @} */

--- a/sys/include/net/ng_fib/ng_fib_table.h
+++ b/sys/include/net/ng_fib/ng_fib_table.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @brief       forwarding table structs
+ * @brief       forwarding table structs and base functions
  * @ingroup     net_fib
  *
  * @{
  *
  * @file
- * @brief       Types and functions for operating fib tables
+ * @brief       Types and functions for internally operating fib tables
  * @author      Martin Landsmann
  */
 
@@ -21,6 +21,7 @@
 #define FIB_TABLE_H_
 
 #include <stdint.h>
+#include "mutex.h"
 #include "vtimer.h"
 #include "ng_universal_address.h"
 
@@ -45,6 +46,96 @@ typedef struct fib_entry_t {
     /** Pointer to the shared generic address */
     struct universal_address_container_t *next_hop;
 } fib_entry_t;
+
+/**
+ * @brief convert given ms to a timepoint from now on in the future
+ * @param[in] ms the miliseconds to be converted
+ * @param[out] timex the converted timepoint
+ */
+void fib_ms_to_timex(uint32_t ms, timex_t *timex);
+
+/**
+ * @brief returns pointer to the entry for the given destination address
+ *
+ * @param[in] dst                  the destination address
+ * @param[in] dst_size             the destination address size
+ * @param[out] entry_arr           the array to scribe the found match
+ * @param[in, out] entry_arr_size  the number of entries provided by entry_arr (should be always 1)
+ *                                 this value is overwritten with the actual found number
+ *
+ * @return 0 if we found a next-hop prefix
+ *         1 if we found the exact address next-hop
+ *         -EHOSTUNREACH if no fitting next-hop is available
+ */
+int fib_find_entry(uint8_t *dst, size_t dst_size,
+                   fib_entry_t **entry_arr, size_t *entry_arr_size);
+
+/**
+* @brief updates the next hop the lifetime and the interface id for a given entry
+*
+* @param[in] entry          the entry to be updated
+* @param[in] next_hop       the next hop address to be updated
+* @param[in] next_hop_size  the next hop address size
+* @param[in] next_hop_flags the next-hop address flags
+* @param[in] lifetime       the lifetime in ms
+*
+* @return 0 if the entry has been updated
+*         -ENOMEM if the entry cannot be updated due to unsufficient RAM
+*/
+int fib_upd_entry(fib_entry_t *entry,
+                  uint8_t *next_hop, size_t next_hop_size, uint32_t next_hop_flags,
+                  uint32_t lifetime);
+
+/**
+* @brief creates a new FIB entry with the provided parameters
+*
+* @param[in] iface_id       the interface ID
+* @param[in] dst            the destination address
+* @param[in] dst_size       the destination address size
+* @param[in] dst_flags      the destination address flags
+* @param[in] next_hop       the next hop address
+* @param[in] next_hop_size  the next hop address size
+* @param[in] next_hop_flags the next-hop address flags
+* @param[in] lifetime       the lifetime in ms
+*
+* @return 0 on success
+*         -ENOMEM if no new entry can be created
+*/
+int fib_create_entry(kernel_pid_t iface_id,
+                     uint8_t *dst, size_t dst_size, uint32_t dst_flags,
+                     uint8_t *next_hop, size_t next_hop_size, uint32_t next_hop_flags,
+                     uint32_t lifetime);
+
+/**
+* @brief removes the given entry
+*
+* @param[in] entry the entry to be removed
+*
+* @return 0 on success
+*/
+int fib_remove(fib_entry_t *entry);
+
+/**
+* @brief returns the pointer to the access mutex
+*
+* @return the pointer to mtx_access
+*/
+mutex_t *fib_get_mutex(void);
+
+/**
+ * @brief signals (sends a message to) all registered routing protocols
+ *        registered with a matching prefix (usually this should be only one).
+ *        The message informs the recipient that no next-hop is available for the
+ *        requested destination address.
+ *        The receiver MUST copy the content, i.e. the address before reply.
+ *
+ * @param[in] dst       the destination address
+ * @param[in] dst_size  the destination address size
+ *
+ * @return 0 on a new available entry,
+ *         -ENOENT if no suiting entry is provided.
+ */
+int fib_signal_rp(uint8_t *dst, size_t dst_size, uint32_t dst_flags);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/ng_fib/ng_universal_address.h
+++ b/sys/include/net/ng_fib/ng_universal_address.h
@@ -25,7 +25,16 @@
 extern "C" {
 #endif
 
-#define UNIVERSAL_ADDRESS_SIZE (16)         /**< size of the used addresses in bytes        */
+/**
+ * @brief Maximum number of entries handled
+ *        This should be 2*FIB_MAX_FIB_TABLE_ENTRIES for the worst case
+ */
+#define UNIVERSAL_ADDRESS_MAX_ENTRIES (40)
+
+/**
+* @brief size of the provided bytes for one address
+*/
+#define UNIVERSAL_ADDRESS_SIZE (16)
 
 /**
  * @brief The container descriptor used to identify a universal address entry
@@ -77,7 +86,7 @@ void universal_address_rem(universal_address_container_t *entry);
  * @return addr if the address is copied to the addr destination
  *         NULL if the size is unsufficient for copy
  */
-uint8_t* universal_address_get_address(universal_address_container_t *entry,
+uint8_t *universal_address_get_address(universal_address_container_t *entry,
                                        uint8_t *addr, size_t *addr_size);
 
 /**

--- a/sys/net/network_layer/fib/fib_addon_generic.c
+++ b/sys/net/network_layer/fib/fib_addon_generic.c
@@ -1,0 +1,141 @@
+/**
+ * FIB addon implementation - for generic address types
+ *
+ * Copyright (C) 2015 Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ * @ingroup fib
+ * @{
+ * @file    fib_addon_generic.c
+ * @brief   Functions to manage generic FIB entries
+ * @author  Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ * @}
+ */
+
+#include <errno.h>
+#include "ng_fib/ng_fib_table.h"
+#include "ng_fib/ng_fib_addon_generic.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+int fib_add_entry(kernel_pid_t iface_id, uint8_t *dst, size_t dst_size, uint32_t dst_flags,
+                  uint8_t *next_hop, size_t next_hop_size, uint32_t next_hop_flags,
+                  uint32_t lifetime)
+{
+    mutex_t *mtx_access = fib_get_mutex();
+    mutex_lock(mtx_access);
+    DEBUG("[fib_add_entry]");
+    size_t count = 1;
+    fib_entry_t *entry[count];
+
+    int ret = fib_find_entry(dst, dst_size, &(entry[0]), &count);
+
+    if (ret == 1) {
+        /* we must take the according entry and update the values */
+        ret = fib_upd_entry(entry[0], next_hop, next_hop_size, next_hop_flags, lifetime);
+    }
+    else {
+        ret = fib_create_entry(iface_id, dst, dst_size, dst_flags,
+                               next_hop, next_hop_size, next_hop_flags, lifetime);
+    }
+
+    mutex_unlock(mtx_access);
+    return ret;
+}
+
+int fib_update_entry(uint8_t *dst, size_t dst_size,
+                     uint8_t *next_hop, size_t next_hop_size, uint32_t next_hop_flags,
+                     uint32_t lifetime)
+{
+    mutex_t *mtx_access = fib_get_mutex();
+    mutex_lock(mtx_access);
+    DEBUG("[fib_update_entry]");
+    size_t count = 1;
+    fib_entry_t *entry[count];
+    int ret = -ENOMEM;
+
+    if (fib_find_entry(dst, dst_size, &(entry[0]), &count) == 1) {
+        DEBUG("[fib_update_entry] found entry: %p\n", (void *)(entry[0]));
+        /* we must take the according entry and update the values */
+        ret = fib_upd_entry(entry[0], next_hop, next_hop_size, next_hop_flags, lifetime);
+    }
+    else {
+        /* we have ambigious entries, i.e. count > 1
+         * this should never happen
+         */
+        DEBUG("[fib_update_entry] ambigious entries detected!!!");
+    }
+
+    mutex_unlock(mtx_access);
+    return ret;
+}
+
+void fib_remove_entry(uint8_t *dst, size_t dst_size)
+{
+    mutex_t *mtx_access = fib_get_mutex();
+    mutex_lock(mtx_access);
+    DEBUG("[fib_remove_entry]");
+    size_t count = 1;
+    fib_entry_t *entry[count];
+
+    int ret = fib_find_entry(dst, dst_size, &(entry[0]), &count);
+
+    if (ret == 1) {
+        /* we must take the according entry and update the values */
+        fib_remove(entry[0]);
+    }
+    else {
+        /* we have ambigious entries, i.e. count > 1
+         * this should never happen
+         */
+        DEBUG("[fib_update_entry] ambigious entries detected!!!");
+    }
+
+    mutex_unlock(mtx_access);
+}
+
+int fib_get_next_hop(kernel_pid_t *iface_id,
+                     uint8_t *next_hop, size_t *next_hop_size, uint32_t *next_hop_flags,
+                     uint8_t *dst, size_t dst_size, uint32_t dst_flags)
+{
+    mutex_t *mtx_access = fib_get_mutex();
+    mutex_lock(mtx_access);
+    DEBUG("[fib_get_next_hop]");
+    size_t count = 1;
+    fib_entry_t *entry[count];
+
+    int ret = fib_find_entry(dst, dst_size, &(entry[0]), &count);
+
+    if (!(ret == 0 || ret == 1)) {
+        /* notify all RRPs for route discovery if available */
+        if (fib_signal_rp(dst, dst_size, dst_flags) == 0) {
+            count = 1;
+            /* now lets see if the RRPs have found a valid next-hop */
+            ret = fib_find_entry(dst, dst_size, &(entry[0]), &count);
+        }
+    }
+
+    if (ret == 0 || ret == 1) {
+
+        uint8_t *address_ret = universal_address_get_address(entry[0]->next_hop,
+                               next_hop, next_hop_size);
+
+        if (address_ret == NULL) {
+            mutex_unlock(mtx_access);
+            return -ENOBUFS;
+        }
+    }
+    else {
+        mutex_unlock(mtx_access);
+        return -EHOSTUNREACH;
+    }
+
+    *iface_id = entry[0]->iface_id;
+    *next_hop_flags = entry[0]->next_hop_flags;
+    mutex_unlock(mtx_access);
+    return 0;
+}

--- a/sys/net/network_layer/fib/fib_addon_ipv6.c
+++ b/sys/net/network_layer/fib/fib_addon_ipv6.c
@@ -1,0 +1,141 @@
+/**
+ * FIB addon implementation - for ipv6 address types
+ *
+ * Copyright (C) 2015 Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ * @ingroup fib
+ * @{
+ * @file    fib_addon_ipv6.c
+ * @brief   Functions to manage ipv6 FIB entries
+ * @author  Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ * @}
+ */
+
+#include <errno.h>
+#include "socket_base/socket.h" /**< needed for IN6ADDRSZ and AF_INET6 */
+#include "ng_fib/ng_fib_table.h"
+#include "ng_fib/ng_fib_addon_ipv6.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+int fib_add_entry_ipv6(kernel_pid_t iface_id, ng_ipv6_addr_t *dst,
+                       ng_ipv6_addr_t *next_hop,
+                       uint32_t lifetime)
+{
+    mutex_t *mtx_access = fib_get_mutex();
+    mutex_lock(mtx_access);
+    DEBUG("[fib_add_entry_ipv6]");
+    size_t count = 1;
+    fib_entry_t *entry[count];
+
+    int ret = fib_find_entry((uint8_t *)dst, IN6ADDRSZ, &(entry[0]), &count);
+
+    if (ret == 1) {
+        /* we must take the according entry and update the values */
+        ret = fib_upd_entry(entry[0], (uint8_t *)next_hop, IN6ADDRSZ, AF_INET6, lifetime);
+    }
+    else {
+        ret = fib_create_entry(iface_id, (uint8_t *)dst, IN6ADDRSZ, AF_INET6,
+                               (uint8_t *)next_hop, IN6ADDRSZ, AF_INET6, lifetime);
+    }
+
+    mutex_unlock(mtx_access);
+    return ret;
+}
+
+int fib_update_entry_ipv6(ng_ipv6_addr_t *dst,
+                          ng_ipv6_addr_t *next_hop,
+                          uint32_t lifetime)
+{
+    mutex_t *mtx_access = fib_get_mutex();
+    mutex_lock(mtx_access);
+    DEBUG("[fib_update_entry_ipv6]");
+    size_t count = 1;
+    fib_entry_t *entry[count];
+    int ret = -ENOMEM;
+
+    if (fib_find_entry((uint8_t *)dst, IN6ADDRSZ, &(entry[0]), &count) == 1) {
+        DEBUG("[fib_update_entry_ipv6] found entry: %p\n", (void *)(entry[0]));
+        /* we must take the according entry and update the values */
+        ret = fib_upd_entry(entry[0], (uint8_t *)next_hop, IN6ADDRSZ, AF_INET6, lifetime);
+    }
+    else {
+        /* we have ambigious entries, i.e. count > 1
+         * this should never happen
+         */
+        DEBUG("[fib_update_entry_ipv6] ambigious entries detected!!!");
+    }
+
+    mutex_unlock(mtx_access);
+    return ret;
+}
+
+void fib_remove_entry_ipv6(ng_ipv6_addr_t *dst)
+{
+    mutex_t *mtx_access = fib_get_mutex();
+    mutex_lock(mtx_access);
+    DEBUG("[fib_remove_entry_ipv6]");
+    size_t count = 1;
+    fib_entry_t *entry[count];
+
+    int ret = fib_find_entry((uint8_t *)dst, IN6ADDRSZ, &(entry[0]), &count);
+
+    if (ret == 1) {
+        /* we must take the according entry and update the values */
+        fib_remove(entry[0]);
+    }
+    else {
+        /* we have ambigious entries, i.e. count > 1
+         * this should never happen
+         */
+        DEBUG("[fib_update_entry_ipv6] ambigious entries detected!!!");
+    }
+
+    mutex_unlock(mtx_access);
+}
+
+int fib_get_next_hop_ipv6(kernel_pid_t *iface_id,
+                          ng_ipv6_addr_t *next_hop,
+                          ng_ipv6_addr_t *dst)
+{
+    mutex_t *mtx_access = fib_get_mutex();
+    mutex_lock(mtx_access);
+    DEBUG("[fib_get_next_hop_ipv6]");
+    size_t count = 1;
+    fib_entry_t *entry[count];
+
+    int ret = fib_find_entry((uint8_t *)dst, IN6ADDRSZ, &(entry[0]), &count);
+
+    if (!(ret == 0 || ret == 1)) {
+        /* notify all RRPs for route discovery if available */
+        if (fib_signal_rp((uint8_t *)dst, IN6ADDRSZ, AF_INET6) == 0) {
+            count = 1;
+            /* now lets see if the RRPs have found a valid next-hop */
+            ret = fib_find_entry((uint8_t *)dst, IN6ADDRSZ, &(entry[0]), &count);
+        }
+    }
+
+    if (ret == 0 || ret == 1) {
+        size_t next_hop_size = IN6ADDRSZ;
+        uint8_t *address_ret = universal_address_get_address(entry[0]->next_hop,
+                               (uint8_t *)next_hop, &next_hop_size);
+
+        if (address_ret == NULL) {
+            mutex_unlock(mtx_access);
+            return -ENOBUFS;
+        }
+    }
+    else {
+        mutex_unlock(mtx_access);
+        return -EHOSTUNREACH;
+    }
+
+    *iface_id = entry[0]->iface_id;
+    mutex_unlock(mtx_access);
+    return 0;
+}

--- a/sys/net/network_layer/fib/universal_address.c
+++ b/sys/net/network_layer/fib/universal_address.c
@@ -26,11 +26,6 @@
 #include "ng_fib/ng_universal_address.h"
 
 /**
- * @brief Maximum number of entries handled
- */
-#define UNIVERSAL_ADDRESS_MAX_ENTRIES (40)
-
-/**
  * @brief counter indicating the number of entries allocated
  */
 static size_t universal_address_table_filled = 0;
@@ -150,8 +145,8 @@ void universal_address_rem(universal_address_container_t *entry)
     mutex_unlock(&mtx_access);
 }
 
-uint8_t* universal_address_get_address(universal_address_container_t *entry,
-                                  uint8_t *addr, size_t *addr_size)
+uint8_t *universal_address_get_address(universal_address_container_t *entry,
+                                       uint8_t *addr, size_t *addr_size)
 {
     mutex_lock(&mtx_access);
 
@@ -182,15 +177,16 @@ int universal_address_compare(universal_address_container_t *entry,
 
     /* Get the index of the first trailing `0` (indicates a network prefix) */
     int i = 0;
-    for( i = entry->address_size-1; i >= 0; --i) {
-        if( entry->address[i] != 0 ) {
+
+    for (i = entry->address_size - 1; i >= 0; --i) {
+        if (entry->address[i] != 0) {
             break;
         }
     }
 
-    if( memcmp(entry->address, addr, i+1) == 0 ) {
+    if (memcmp(entry->address, addr, i + 1) == 0) {
         ret = 0;
-        *addr_size = i+1;
+        *addr_size = i + 1;
     }
 
     mutex_unlock(&mtx_access);


### PR DESCRIPTION
The initial FIB has only function prototypes for passing `uint8_t*` based addresses.
This PR introduces switching desired prototypes when for instance only IPv6 addresses are used by the RIOT node. 
The switching is performed on compile time by including specific `ng_fib_addon_*.h` header(s) [here](https://github.com/RIOT-OS/RIOT/compare/master...BytesGalore:modular_fib?expand=1#diff-8280ac5698b19568363eff17b1a76a97R33).

Additionally it provides an addon header extending the function prototypes to allow using `ng_ipv6_addr_t`, which is an optimization for IPv6 address usage.

Note: The `API CHANGE` label relates to the IPv6 addon header. The former API is unchanged and present in `ng_fib_addon_generic.h` 