### PR TITLE
sys: net: introduce low-level ethernet driver API

### DIFF
--- a/boards/native/Makefile.features
+++ b/boards/native/Makefile.features
@@ -1,3 +1,4 @@
+FEATURES_PROVIDED += ethernet
 FEATURES_PROVIDED += transceiver
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += config

--- a/cpu/native/Makefile
+++ b/cpu/native/Makefile
@@ -4,6 +4,9 @@ DIRS += periph
 ifneq (,$(filter nativenet,$(USEMODULE)))
 	DIRS += net
 endif
+ifneq (,$(filter ng_nativenet,$(USEMODULE)))
+	DIRS += ng_net
+endif
 
 include $(RIOTBASE)/Makefile.base
 

--- a/cpu/native/include/dev_eth_tap.h
+++ b/cpu/native/include/dev_eth_tap.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @defgroup    net_dev_eth_impl Low-level Ethernet driver implementations
+ * @ingroup     net_dev_eth_ll
+ * @brief       Low-level ethernet driver for native tap interfaces
+ * @{
+ *
+ * @file
+ * @brief       Definitions for low-level ethernet driver for native tap interfaces
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+#ifndef DEV_ETH_TAP_H
+#define DEV_ETH_TAP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include "net/dev_eth.h"
+
+#include "net/if.h"
+
+/**
+ * @brief tap interface state
+ */
+typedef struct dev_eth_tap {
+    dev_eth_t ethdev;                   /**< dev_eth internal member */
+    char tap_name[IFNAMSIZ];            /**< host dev file name */
+    int tap_fd;                         /**< host file descriptor for the TAP */
+    uint8_t addr[NG_ETHERNET_ADDR_LEN]; /**< The MAC address of the TAP */
+    uint8_t promiscous;                 /**< Flag for promiscous mode */
+} dev_eth_tap_t;
+
+/**
+ * @brief global device struct. driver only supports one tap device as of now.
+ */
+extern dev_eth_tap_t dev_eth_tap;
+
+/**
+ * @brief Setup dev_eth_tap_t structure.
+ *
+ * @param dev  the preallocated dev_eth_tap device handle to setup
+ * @param name Name of the host system's tap inteface to bind to.
+ */
+void dev_eth_tap_setup(dev_eth_tap_t *dev, const char *name);
+
+#ifdef __cplusplus
+}
+#endif
+/** @} */
+#endif /* DEV_ETH_TAP_H */

--- a/cpu/native/ng_net/Makefile
+++ b/cpu/native/ng_net/Makefile
@@ -1,0 +1,5 @@
+MODULE = ng_nativenet
+
+include $(RIOTBASE)/Makefile.base
+
+INCLUDES = $(NATIVEINCLUDES)

--- a/cpu/native/ng_net/dev_eth_tap.c
+++ b/cpu/native/ng_net/dev_eth_tap.c
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2015 Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>,
+ *                    Martine Lenders <mlenders@inf.fu-berlin.de>
+ *                    Kaspar Schleiser <kaspar@schleiser.de>
+ *                    Ell-i open source co-operative
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/*
+ * @ingroup net_dev_eth
+ * @{
+ * @brief   Low-level ethernet driver for tap interfaces
+ * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ * @}
+ */
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#ifdef __MACH__
+#define _POSIX_C_SOURCE
+#include <net/if.h>
+#undef _POSIX_C_SOURCE
+#include <ifaddrs.h>
+#include <net/if_dl.h>
+#elif defined(__FreeBSD__)
+#include <sys/socket.h>
+#include <net/if.h>
+#include <ifaddrs.h>
+#include <net/if_dl.h>
+#else
+#include <net/if.h>
+#include <linux/if_tun.h>
+#include <linux/if_ether.h>
+#endif
+
+#include "native_internal.h"
+
+#include "net/dev_eth.h"
+#include "dev_eth_tap.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+/* support one tap interface for now */
+dev_eth_tap_t dev_eth_tap;
+
+/* dev_eth interface */
+static int _init(dev_eth_t *ethdev);
+static int _send(dev_eth_t *ethdev, char* buf, int n);
+static int _recv(dev_eth_t *ethdev, char* buf, int n);
+
+static inline void _get_mac_addr(dev_eth_t *ethdev, uint8_t *dst) {
+    dev_eth_tap_t *dev = (dev_eth_tap_t*)ethdev;
+    memcpy(dst, dev->addr, NG_ETHERNET_ADDR_LEN);
+}
+
+static inline int _get_promiscous(dev_eth_t *ethdev) {
+    dev_eth_tap_t *dev = (dev_eth_tap_t*)ethdev;
+    return dev->promiscous;
+}
+
+static inline int _set_promiscous(dev_eth_t *ethdev, int value) {
+    dev_eth_tap_t *dev = (dev_eth_tap_t*)ethdev;
+    dev->promiscous = value;
+    return value;
+}
+
+static inline void _isr(dev_eth_t *ethdev) {
+    dev_eth_rx_handler(ethdev);
+}
+
+static eth_driver_t eth_driver_tap = {
+    .init = _init,
+    .send = _send,
+    .recv = _recv,
+    .get_mac_addr = _get_mac_addr,
+    .get_promiscous = _get_promiscous,
+    .set_promiscous = _set_promiscous,
+    .isr = _isr,
+};
+
+/* driver implementation */
+static inline bool _is_addr_broadcast(uint8_t *addr)
+{
+    return ((addr[0] == 0xff) && (addr[1] == 0xff) && (addr[2] == 0xff) &&
+            (addr[3] == 0xff) && (addr[4] == 0xff) && (addr[5] == 0xff));
+}
+
+static inline bool _is_addr_multicast(uint8_t *addr)
+{
+    /* source: http://ieee802.org/secmail/pdfocSP2xXA6d.pdf */
+    return (addr[0] & 0x01);
+}
+
+static int _recv(dev_eth_t *dev_eth, char *buf, int len) {
+    dev_eth_tap_t *dev = (dev_eth_tap_t*)dev_eth;
+
+    int nread = real_read(dev->tap_fd, buf, len);
+    DEBUG("ng_tapnet: read %d bytes\n", nread);
+
+    if (nread > 0) {
+        ng_ethernet_hdr_t *hdr = (ng_ethernet_hdr_t *)buf;
+        if (!(dev->promiscous) && !_is_addr_multicast(hdr->dst) &&
+            !_is_addr_broadcast(hdr->dst) &&
+            (memcmp(hdr->dst, dev->addr, NG_ETHERNET_ADDR_LEN) != 0)) {
+            DEBUG("ng_eth_dev: received for %02x:%02x:%02x:%02x:%02x:%02x\n"
+                  "That's not me => Dropped\n",
+                  hdr->dst[0], hdr->dst[1], hdr->dst[2],
+                  hdr->dst[3], hdr->dst[4], hdr->dst[5]);
+            return 0;
+        }
+        /* work around lost signals */
+        fd_set rfds;
+        struct timeval t;
+        memset(&t, 0, sizeof(t));
+        FD_ZERO(&rfds);
+        FD_SET(dev->tap_fd, &rfds);
+
+        _native_in_syscall++; /* no switching here */
+
+        if (real_select(dev->tap_fd + 1, &rfds, NULL, NULL, &t) == 1) {
+            int sig = SIGIO;
+            extern int _sig_pipefd[2];
+            extern ssize_t (*real_write)(int fd, const void * buf, size_t count);
+            real_write(_sig_pipefd[1], &sig, sizeof(int));
+            _native_sigpend++;
+            DEBUG("dev_eth_tap: sigpend++\n");
+        }
+        else {
+#ifdef __MACH__
+            kill(_sigio_child_pid, SIGCONT);
+#endif
+        }
+
+        _native_in_syscall--;
+
+        return nread;
+    }
+    else if (nread == -1) {
+        if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
+        }
+        else {
+            err(EXIT_FAILURE, "dev_eth_tap: read");
+        }
+    }
+    else if (nread == 0) {
+        DEBUG("_native_handle_tap_input: ignoring null-event");
+    }
+    else {
+        errx(EXIT_FAILURE, "internal error _rx_event");
+    }
+
+    return -1;
+}
+
+static int _send(dev_eth_t *ethdev, char* buf, int n) {
+    dev_eth_tap_t *dev = (dev_eth_tap_t*)ethdev;
+    return _native_write(dev->tap_fd, buf, n);
+}
+
+void dev_eth_tap_setup(dev_eth_tap_t *dev, const char *name) {
+    dev->ethdev.driver = &eth_driver_tap;
+    strncpy(dev->tap_name, name, IFNAMSIZ);
+}
+
+static void _tap_isr(void) {
+    dev_eth_isr(((dev_eth_t *) &dev_eth_tap));
+}
+
+static int _init(dev_eth_t *ethdev)
+{
+    dev_eth_tap_t *dev = (dev_eth_tap_t*)ethdev;
+
+    /* check device parametrs */
+    if (dev == NULL) {
+        return -ENODEV;
+    }
+
+    char *name = dev->tap_name;
+#ifdef __MACH__ /* OSX */
+    char clonedev[255] = "/dev/"; /* XXX bad size */
+    strncpy(clonedev + 5, name, 250);
+#elif defined(__FreeBSD__)
+    char clonedev[255] = "/dev/"; /* XXX bad size */
+    strncpy(clonedev + 5, name, 250);
+#else /* Linux */
+    struct ifreq ifr;
+    const char *clonedev = "/dev/net/tun";
+#endif
+    /* initialize device descriptor */
+    dev->promiscous = 0;
+    /* implicitly create the tap interface */
+    if ((dev->tap_fd = real_open(clonedev , O_RDWR)) == -1) {
+        err(EXIT_FAILURE, "open(%s)", clonedev);
+    }
+#if (defined(__MACH__) || defined(__FreeBSD__)) /* OSX/FreeBSD */
+    struct ifaddrs *iflist;
+    if (real_getifaddrs(&iflist) == 0) {
+        for (struct ifaddrs *cur = iflist; cur; cur = cur->ifa_next) {
+            if ((cur->ifa_addr->sa_family == AF_LINK) && (strcmp(cur->ifa_name, name) == 0) && cur->ifa_addr) {
+                struct sockaddr_dl *sdl = (struct sockaddr_dl *)cur->ifa_addr;
+                memcpy(dev->addr, LLADDR(sdl), sdl->sdl_alen);
+                break;
+            }
+        }
+        real_freeifaddrs(iflist);
+    }
+#else /* Linux */
+    memset(&ifr, 0, sizeof(ifr));
+    ifr.ifr_flags = IFF_TAP | IFF_NO_PI;
+    strncpy(ifr.ifr_name, name, IFNAMSIZ);
+    if (real_ioctl(dev->tap_fd, TUNSETIFF, (void *)&ifr) == -1) {
+        _native_in_syscall++;
+        warn("ioctl TUNSETIFF");
+        warnx("probably the tap interface (%s) does not exist or is already in use", name);
+        real_exit(EXIT_FAILURE);
+    }
+
+    /* get MAC address */
+    memset(&ifr, 0, sizeof(ifr));
+    snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", name);
+    if (real_ioctl(dev->tap_fd, SIOCGIFHWADDR, &ifr) == -1) {
+        _native_in_syscall++;
+        warn("ioctl SIOCGIFHWADDR");
+        if (real_close(dev->tap_fd) == -1) {
+            warn("close");
+        }
+        real_exit(EXIT_FAILURE);
+    }
+    memcpy(dev->addr, ifr.ifr_hwaddr.sa_data, NG_ETHERNET_ADDR_LEN);
+
+    /* change mac addr so it differs from what the host is using */
+    dev->addr[5]++;
+#endif
+    DEBUG("ng_tapnet_init(): dev->addr = %02x:%02x:%02x:%02x:%02x:%02x\n",
+            dev->addr[0], dev->addr[1], dev->addr[2],
+            dev->addr[3], dev->addr[4], dev->addr[5]);
+    /* configure signal handler for fds */
+    register_interrupt(SIGIO, _tap_isr);
+#ifdef __MACH__
+    /* tuntap signalled IO is not working in OSX,
+     * * check http://sourceforge.net/p/tuntaposx/bugs/17/ */
+    _sigio_child(dev);
+#else
+    /* configure fds to send signals on io */
+    if (fcntl(dev->tap_fd, F_SETOWN, _native_pid) == -1) {
+        err(EXIT_FAILURE, "ng_tapnet_init(): fcntl(F_SETOWN)");
+    }
+    /* set file access mode to non-blocking */
+    if (fcntl(dev->tap_fd, F_SETFL, O_NONBLOCK | O_ASYNC) == -1) {
+        err(EXIT_FAILURE, "ng_tabnet_init(): fcntl(F_SETFL)");
+    }
+#endif /* not OSX */
+    DEBUG("ng_tapnet: initialized.\n");
+    return 0;
+}
+
+#ifdef __MACH__
+static void _sigio_child(ng_tapnet_t *dev)
+{
+    pid_t parent = _native_pid;
+    if ((_sigio_child_pid = real_fork()) == -1) {
+        err(EXIT_FAILURE, "sigio_child: fork");
+    }
+    if (_sigio_child_pid > 0) {
+        /* return in parent process */
+        return;
+    }
+    /* watch tap interface and signal parent process if data is
+     * available */
+    fd_set rfds;
+    while (1) {
+        FD_ZERO(&rfds);
+        FD_SET(dev->tap_fd, &rfds);
+        if (real_select(dev->tap_fd + 1, &rfds, NULL, NULL, NULL) == 1) {
+            kill(parent, SIGIO);
+        }
+        else {
+            kill(parent, SIGKILL);
+            err(EXIT_FAILURE, "osx_sigio_child: select");
+        }
+        pause();
+    }
+}
+#endif

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -47,6 +47,11 @@ unsigned _native_rng_seed = 0;
 int _native_rng_mode = 0;
 const char *_native_unix_socket_path = NULL;
 
+#ifdef MODULE_NG_NATIVENET
+#include "dev_eth_tap.h"
+extern dev_eth_tap_t dev_eth_tap;
+#endif
+
 /**
  * initialize _native_null_in_pipe to allow for reading from stdin
  * @param stdiotype: "stdio" (only initialize pipe) or any string
@@ -192,7 +197,7 @@ void usage_exit(void)
 {
     real_printf("usage: %s", _progname);
 
-#ifdef MODULE_NATIVENET
+#if defined(MODULE_NATIVENET) || defined(MODULE_NG_NATIVENET)
     real_printf(" <tap interface>");
 #endif
 
@@ -252,7 +257,7 @@ __attribute__((constructor)) static void startup(int argc, char **argv)
     int replay = 0;
 #endif
 
-#ifdef MODULE_NATIVENET
+#if defined(MODULE_NATIVENET) || defined(MODULE_NG_NATIVENET)
     if (
             (argc < 2)
             || (
@@ -366,6 +371,12 @@ __attribute__((constructor)) static void startup(int argc, char **argv)
     native_interrupt_init();
 #ifdef MODULE_NATIVENET
     tap_init(argv[1]);
+#endif
+#ifdef MODULE_NG_NATIVENET
+# ifdef MODULE_NATIVENET
+#  error  "Modules nativenet and ng_native are mutually exclusive."
+# endif
+    dev_eth_tap_setup(&dev_eth_tap, argv[1]);
 #endif
 
     board_init();

--- a/sys/auto_init/Makefile
+++ b/sys/auto_init/Makefile
@@ -12,4 +12,8 @@ ifneq (,$(filter auto_init_ng_netif,$(USEMODULE)))
 DIRS += netif
 endif
 
+ifneq (,$(filter dev_eth_autoinit,$(USEMODULE)))
+DIRS += $(RIOTBASE)/sys/auto_init/dev_eth
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -103,6 +103,11 @@
 #include "net/ng_udp.h"
 #endif
 
+#ifdef MODULE_DEV_ETH_AUTOINIT
+#include "net/dev_eth.h"
+#include "dev_eth_autoinit.h"
+#endif
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 

--- a/sys/auto_init/dev_eth/Makefile
+++ b/sys/auto_init/dev_eth/Makefile
@@ -1,0 +1,3 @@
+MODULE = dev_eth_autoinit
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/auto_init/dev_eth/dev_eth_autoinit.c
+++ b/sys/auto_init/dev_eth/dev_eth_autoinit.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include "net/dev_eth.h"
+#include "dev_eth_autoinit.h"
+
+#ifdef MODULE_NG_NATIVENET
+#include "dev_eth_tap.h"
+#endif
+
+#ifdef MODULE_ENCX24J600
+#include "encx24j600.h"
+encx24j600_t dev_eth_encx24j600;
+#endif
+
+dev_eth_t * const dev_eth_devices[] = {
+#ifdef MODULE_NG_NATIVENET
+    [DEV_ETH_TAP] = (dev_eth_t*)&dev_eth_tap,
+#endif
+#ifdef MODULE_ENCX24J600
+    [DEV_ETH_ENCX24J600] = (dev_eth_t*)&dev_eth_encx24j600,
+#endif
+};
+
+void dev_eth_autoinit(void)
+{
+#ifdef MODULE_ENCX24J600
+    /* TODO: use sensible defines */
+    encx24j600_setup(&dev_eth_encx24j600, SPI_0, GPIO_1, GPIO_2);
+#endif
+}

--- a/sys/include/dev_eth_autoinit.h
+++ b/sys/include/dev_eth_autoinit.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_net_dev_eth dev_eth auto setup
+ * @ingroup     sys_net_eth
+ * @file
+ * @brief       Automatically setup available ethernet devices
+ * @{
+ *
+ * @brief       header for dev_eth automatic initialization
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef DEV_ETH_AUTOINIT_H
+#define DEV_ETH_AUTOINIT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief enum for available ethernet devices
+ */
+enum {
+#ifdef MODULE_NG_NATIVENET
+    DEV_ETH_TAP,
+#endif
+#ifdef MODULE_ENCX24J600
+    DEV_ETH_ENCX24J600,
+#endif
+    /* must be last: */
+    NUM_DEV_ETH
+};
+
+/**
+ * @brief Array of const pointers to available ethernet devices
+ */
+extern dev_eth_t *const dev_eth_devices[];
+
+/**
+ * @brief Automatically sets up available dev_eth ethernet devices
+ *
+ * ... by calling the respective *_setup() functions if available.
+ */
+void dev_eth_autoinit(void);
+
+#ifdef __cplusplus
+}
+#endif
+/** @} */
+#endif /* DEV_ETH_AUTOINIT_H */

--- a/sys/include/net/dev_eth.h
+++ b/sys/include/net/dev_eth.h
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *                    Ell-i open source co-operative
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @defgroup    net_dev_eth_ll Low-Level Driver Inteface
+ * @ingroup     net_ng_ethernet
+ * @file
+ * @brief       Low-level ethernet driver interface
+ * @{
+ *
+ * This interface is supposed to be a low-level interface for ethernet drivers.
+ * In order to be universally usable, it leaves out many implementation details
+ * to the implementation of an actual network stack using this interface.
+ *
+ * In order to write a driver for this interface, you have to
+ *
+ * 1. create a (possibly const) eth_driver_t structure for your device type,
+ *    implement it's functions
+ *
+ * 2. create a dev_eth_t structure, used as device state and handle, for each device
+ *
+ * In order to use this interface, you have to
+ *
+ * 1. implement dev_eth_isr, dev_eth_rx_handler and dev_eth_linkstate_handler
+ * 2. run a loop that get's notified by dev_eth_isr
+ *
+ * A devices send function should always be able to send a frame (and make sure of proper locking).
+ *
+ * Receive packet flow:
+ *
+ * 1. Ethernet driver receives packet, executes driver's internal ISR.
+ * 2. driver's internal ISR should do minimal acknowledging and house keeping and then
+ *    call dev_eth_isr
+ * 3. dev_eth_isr should notify a user of this API (e.g., the network stack's L2 thread)
+ * 4. That thread executes the driver's user-space isr (dev->driver->isr)
+ * 5. user space ISR handles less timing critical stuff, eventually calling
+ *    dev_eth_linkstate_handler and / or dev_eth_rx_handler
+ *
+ * Check out the dev_eth test application as example.
+ *
+ * @file
+ * @brief       Definitions low-level ethernet driver interface
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef DEV_ETH_H
+#define DEV_ETH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include "ng_ethernet/hdr.h"
+
+/**
+ * @brief Structure to hold driver state
+ *
+ * Supposed to be extended by driver implementations.
+ * The extended structure should contain all variable driver state.
+ */
+typedef struct dev_eth {
+    const struct eth_driver *driver; /**< ptr to that driver's interface.
+                                     driver->init() expects this to be present,
+                                     so set this before using the device. */
+} dev_eth_t;
+
+/**
+ * @brief Structure to hold driver interface -> function mapping
+ *
+ * The send/receive functions expect/return a full ethernet
+ * frame (dst mac, src mac, ethertype, payload, no checksum).
+ */
+typedef struct eth_driver {
+    /**
+     * @brief Send ethernet frame
+     *
+     * Expects a full ethernet frame (dst mac, src mac, ethertype, payload,
+     * no checksum).
+     *
+     * @param buf buffer to read from
+     * @param len nr of bytes to send
+     *
+     * @return nr of bytes sent, or <=0 on error
+     */
+    int (*send)(dev_eth_t *dev, char* buf, int len);
+
+    /**
+     * @brief Get a received ethernet frame
+     *
+     * Supposed to be called from dev_eth_rx_handler().
+     *
+     * Make sure buf can hold the maximum expected ethernet frame size.
+     *
+     * @param buf buffer to write to
+     * @param len maximum nr. of bytes to read
+     *
+     * @return nr of bytes read or <=0 on error
+     */
+    int (*recv)(dev_eth_t *dev, char* buf, int len);
+
+    /**
+     * @brief get the device's MAC address
+     *
+     * @param buf location to write to. Make sure this is can take least 6 bytes
+     */
+    void (*get_mac_addr)(dev_eth_t *dev, uint8_t *buf);
+
+    /**
+     * @brief get the device's promiscous status
+     *
+     * Default is not promiscous.
+     * Promiscous means, receive all ethernet frames.
+     * Not promiscous means only receive broadcast, multicast or frames with
+     * the device's MAC address as dst address.
+     *
+     * @return 1 for promiscous, 0 for not promiscous
+     */
+    int (*get_promiscous)(dev_eth_t *dev);
+    /**
+     * @brief set the devices promiscous mode
+     *
+     * @param value 1 for promiscous, 0 for not promiscous
+     * @return the new value (device might not support wanted mode)
+     */
+    int (*set_promiscous)(dev_eth_t *dev, int value);
+    /**
+     * @brief the driver's initialization function
+     *
+     * @return <=0 on error, >0 on success
+     */
+    int (*init)(dev_eth_t *dev);
+    /**
+     * @brief a driver's user-space ISR handler
+     *
+     * This function will be called from a network stack's loop when being notified
+     * by dev_eth_isr.
+     *
+     * It is supposed to call dev_eth_rx_handler for each available received packed,
+     * and dev_eth_linkstate_handler whenever a link state change event occurs.
+     *
+     * See receive packet flow description for details.
+     */
+    void (*isr)(dev_eth_t *dev);
+} eth_driver_t;
+
+/**
+ * @brief Initialize a device given by dev (convenience function)
+ *
+ * The device given as parameter *must* be previously setup by the
+ * drivers *_setup() function.
+ *
+ */
+static inline int dev_eth_init(dev_eth_t *dev) {
+    return dev->driver->init(dev);
+}
+
+/**
+ * @brief global dev_eth interrupt handling function.
+ *
+ * This function should be called from your device's ISR from whithin ISR context.
+ * It is supposed to wake up a waiting user-space event loop.
+ */
+extern void dev_eth_isr(dev_eth_t *dev);
+
+/**
+ * @brief dev_eth event callback for packets that were received.
+ *
+ * This function should be called from whithin your driver's isr()
+ * (as defined in eth_driver_t), once for every packet that was received.
+ *
+ * It needs to call dev->driver->recv() in order to get received packet
+ * from the driver.
+ */
+extern void dev_eth_rx_handler(dev_eth_t *dev);
+
+/**
+ * @brief dev_eth ethernet link state handler
+ *
+ * This function should be called from whithin your driver's isr()
+ * (as defined in eth_driver_t) for every layer 2 link state change.
+ *
+ * @param dev device that triggered the event
+ * @param newstate 1 for "link established", 0 for "link down"
+ */
+extern void dev_eth_linkstate_handler(dev_eth_t *dev, int newstate);
+
+#ifdef __cplusplus
+}
+#endif
+/** @} */
+#endif /* DEV_ETH_H */

--- a/tests/dev_eth/Makefile
+++ b/tests/dev_eth/Makefile
@@ -1,0 +1,13 @@
+APPLICATION = dev_eth
+include ../Makefile.tests_common
+
+BOARD_WHITELIST = native
+FEATURES_REQUIRED += ethernet
+
+ifneq (,$(filter native,$(BOARD)))
+USEMODULE += ng_nativenet
+endif
+
+USEMODULE += dev_eth_autoinit
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/dev_eth/main.c
+++ b/tests/dev_eth/main.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *                    Ell-i open source co-operative
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for dev_eth low level ethernet drivers
+ *
+ * This test application will bounce back every received l2 ethernet
+ * frame by exchanging target and destination MAC addresses.
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "thread.h"
+#include "board.h"
+#include "vtimer.h"
+#include "periph/spi.h"
+#include "periph/gpio.h"
+
+#include "net/dev_eth.h"
+#include "dev_eth_autoinit.h"
+
+#define ENABLE_DEBUG 1
+#include "debug.h"
+
+kernel_pid_t handler_pid = KERNEL_PID_UNDEF;
+
+char _rxbuf[2000];
+
+/* reverse src/dst addresses in raw ethernet packet */
+void turn_packet(char *pkt) {
+    uint8_t mac[6];
+    /* save old dst addr */
+    memcpy(mac, pkt, 6);
+
+    /* use sender MAC address as new destination */
+    memcpy(pkt, pkt+6, 6);
+
+    /* set our MAC address as sender */
+    memcpy(pkt+6, mac, 6);
+}
+
+void dev_eth_isr(dev_eth_t *dev) {
+    (void)dev;
+    thread_wakeup(handler_pid);
+}
+
+void dev_eth_rx_handler(dev_eth_t *dev) {
+    DEBUG("dev_eth_rx_handler dev=0x%08x\n", (unsigned) dev);
+
+    int n = dev->driver->recv(dev, _rxbuf, sizeof(_rxbuf));
+
+    DEBUG("handle_incoming: received %i bytes\n", n);
+
+    if (n>0) {
+        turn_packet(_rxbuf);
+        dev->driver->send(dev, _rxbuf, n);
+    }
+}
+
+void dev_eth_linkstate_handler(dev_eth_t *dev, int newstate)
+{
+    DEBUG("dev_eth: dev=0x%08x link %s\n", (unsigned)dev, newstate ? "UP" : "DOWN");
+}
+
+int main(void)
+{
+    handler_pid = thread_getpid();
+
+    /* always use first ethernet device for test */
+    dev_eth_t *const dev = dev_eth_devices[0];
+
+    dev_eth_init(dev);
+
+    while(1) {
+        dev->driver->isr(dev);
+        thread_sleep();
+        DEBUG("main: woke up\n");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
While implementing the ethernet driver for encx24j600, I realized that ng_netdev is too fat for some applications, so I tried to create an interface just for ethernet drivers.

The actual tap device handling is taken from #2558.

*edit*
Let me rephrase the "too fat" statement, as it is totally inaccurate.

IMHO the currently developed network stack might not be the only one we might have in RIOT.
So when I started developing an ethernet driver for RIOT, I didn't want to tie it to netdev and friends.
netdev does make some assumptions on how a driver has to be implemented, and also implies a lot of dependencies.

This PR introduces a fairly thin interface with no dependencies, which can easily be used with netdev (see #2776), but doesn't depend on it.

I've implemented two drivers using it (the tap driver in this PR and a driver for encx24j600 chips, which I'll PR soon). As always with interfaces designed by yourself, I'm quite happy with the result.

The only disadvantage of using this interface instead of directly writing a driver for netdev is that pktsnips have to be converted to a flat buffer before sending to the device. This could be added to the interface if deemed necessary.