### PR TITLE
oonf_common: add missing dependencies

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -156,3 +156,7 @@ ifneq (,$(filter fib,$(USEMODULE)))
   USEMODULE += vtimer
   USEMODULE += net_help
 endif
+
+ifneq (,$(filter oonf_common,$(USEMODULE)))
+  USEMODULE += socket_base
+endif

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -158,5 +158,6 @@ ifneq (,$(filter fib,$(USEMODULE)))
 endif
 
 ifneq (,$(filter oonf_common,$(USEMODULE)))
+  USEPKG += oonf_api
   USEMODULE += socket_base
 endif


### PR DESCRIPTION
* oonf_common includes "socket_base/socket.h", thus, this dependency is missing.
* oonf_common depends on the oonf_api package