### PR TITLE
sys: net: ng_pktdump: make pktdump have higher-than-main priority

### DIFF
--- a/sys/include/net/ng_pktdump.h
+++ b/sys/include/net/ng_pktdump.h
@@ -39,7 +39,7 @@ extern "C" {
  * @brief   Priority of the pktdump thread
  */
 #ifndef NG_PKTDUMP_PRIO
-#define NG_PKTDUMP_PRIO                 (PRIORITY_MIN - 1)
+#define NG_PKTDUMP_PRIO                 (PRIORITY_MAIN - 1)
 #endif
 
 /**


### PR DESCRIPTION
Some of the simple shell implementations seem to be busy-waiting, causing pktdump to never print anything.
This commit fixes those cases by having pktdump a high-than-main priority.