### PR TITLE
sys: net: ipv6: fix max ipv6 address string length

### DIFF
--- a/sys/include/net/ng_ipv6/addr.h
+++ b/sys/include/net/ng_ipv6/addr.h
@@ -44,7 +44,7 @@ extern "C" {
  * @brief   Maximum length of an IPv6 address as string.
  */
 #define NG_IPV6_ADDR_MAX_STR_LEN    (sizeof("ffff:ffff:ffff:ffff:" \
-                                            "ffff:ffff:ffff:ffff"))
+                                            "ffff:ffff:255.255.255.255"))
 
 /**
  * @brief Data type to represent an IPv6 address.

--- a/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
+++ b/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
@@ -812,13 +812,13 @@ static void test_ipv6_addr_from_str__success5(void)
 static void test_ipv6_addr_from_str__success6(void)
 {
     ng_ipv6_addr_t a = { {
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0xff, 0xff, 192, 168, 0, 1
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 255, 255, 255, 255
         }
     };
     ng_ipv6_addr_t result;
 
-    TEST_ASSERT_NOT_NULL(ng_ipv6_addr_from_str(&result, "::ffff:192.168.0.1"));
+    TEST_ASSERT_NOT_NULL(ng_ipv6_addr_from_str(&result, "ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255"));
     TEST_ASSERT(ng_ipv6_addr_equal(&a, &result));
 }
 


### PR DESCRIPTION
IPv6 address can have (per RFC) an IPv4 style ending in their textual representation.
This PR fixes the corresponding length define.