### PR TITLE
AODVv2: fix mutex for route message creation

### DIFF
--- a/sys/net/routing/aodvv2/aodv.c
+++ b/sys/net/routing/aodvv2/aodv.c
@@ -53,6 +53,10 @@ static ipv6_addr_t _v6_addr_local, _v6_addr_mcast, _v6_addr_loopback;
 static struct netaddr na_local; /* the same as _v6_addr_local, but to save us
                                  * constant calls to ipv6_addr_t_to_netaddr()... */
 static struct writer_target *wt;
+static mutex_t rreq_mutex;
+static mutex_t rrep_mutex;
+static mutex_t rerr_mutex;
+
 struct netaddr na_mcast = (struct netaddr){};
 
 void aodv_init(void)
@@ -62,6 +66,10 @@ void aodv_init(void)
     /* TODO: set if_id properly */
     int if_id = 0;
     net_if_set_src_address_mode(if_id, NET_IF_TRANS_ADDR_M_SHORT);
+
+    mutex_init(&rreq_mutex);
+    mutex_init(&rrep_mutex);
+    mutex_init(&rerr_mutex);
 
     aodv_set_metric_type(AODVV2_DEFAULT_METRIC_TYPE);
     _init_addresses();
@@ -103,6 +111,9 @@ void aodv_set_metric_type(aodvv2_metric_t metric_type)
 
 void aodv_send_rreq(struct aodvv2_packet_data *packet_data)
 {
+    /* Make sure only one thread is dispatching a RREQ at a time */
+    mutex_lock(&rreq_mutex);
+
     AODV_DEBUG("%s()\n", __func__);
 
     struct aodvv2_packet_data *pd = malloc(sizeof(struct aodvv2_packet_data));
@@ -124,10 +135,14 @@ void aodv_send_rreq(struct aodvv2_packet_data *packet_data)
     msg.content.ptr = (char *) mc;
 
     msg_try_send(&msg, sender_thread);
+    mutex_unlock(&rreq_mutex);
 }
 
 void aodv_send_rrep(struct aodvv2_packet_data *packet_data, struct netaddr *next_hop)
 {
+    /* Make sure only one thread is dispatching a RREP at a time */
+    mutex_lock(&rrep_mutex);
+
     AODV_DEBUG("%s()\n", __func__);
 
     struct aodvv2_packet_data *pd = malloc(sizeof(struct aodvv2_packet_data));
@@ -152,10 +167,14 @@ void aodv_send_rrep(struct aodvv2_packet_data *packet_data, struct netaddr *next
     msg.content.ptr = (char *) mc;
 
     msg_try_send(&msg, sender_thread);
+    mutex_unlock(&rrep_mutex);
 }
 
 void aodv_send_rerr(struct unreachable_node unreachable_nodes[], size_t len, struct netaddr *next_hop)
 {
+    /* Make sure only one thread is dispatching a RERR at a time */
+    mutex_lock(&rerr_mutex);
+
     AODV_DEBUG("%s()\n", __func__);
 
     struct rerr_data *rerrd = malloc(sizeof(struct rerr_data));
@@ -176,6 +195,7 @@ void aodv_send_rerr(struct unreachable_node unreachable_nodes[], size_t len, str
     msg2.content.ptr = (char *) mc2;
 
     msg_try_send(&msg2, sender_thread);
+    mutex_unlock(&rerr_mutex);
 }
 
 /*

--- a/sys/net/routing/aodvv2/writer.c
+++ b/sys/net/routing/aodvv2/writer.c
@@ -35,8 +35,6 @@ static void _cb_rreq_addAddresses(struct rfc5444_writer *wr);
 static void _cb_rrep_addAddresses(struct rfc5444_writer *wr);
 static void _cb_rerr_addAddresses(struct rfc5444_writer *wr);
 
-static mutex_t writer_mutex;
-
 struct rfc5444_writer writer;
 static struct writer_target _target;
 
@@ -220,8 +218,6 @@ void aodv_packet_writer_init(write_packet_func_ptr ptr)
 {
     AODV_DEBUG("%s()\n", __func__);
 
-    mutex_init(&writer_mutex);
-
     /* define interface for generating rfc5444 packets */
     _target.interface.packet_buffer = _packet_buffer;
     _target.interface.packet_size = sizeof(_packet_buffer);
@@ -278,7 +274,6 @@ void aodv_packet_writer_send_rreq(struct aodvv2_packet_data *packet_data, struct
     }
 
     /* Make sure no other thread is using the writer right now */
-    mutex_lock(&writer_mutex);
     memcpy(&_target.packet_data, packet_data, sizeof(struct aodvv2_packet_data));
     _target.type = RFC5444_MSGTYPE_RREQ;
     _target.packet_data.hoplimit = packet_data->hoplimit;
@@ -288,7 +283,6 @@ void aodv_packet_writer_send_rreq(struct aodvv2_packet_data *packet_data, struct
 
     rfc5444_writer_create_message_alltarget(&writer, RFC5444_MSGTYPE_RREQ);
     rfc5444_writer_flush(&writer, &_target.interface, false);
-    mutex_unlock(&writer_mutex);
 }
 
 
@@ -306,8 +300,6 @@ void aodv_packet_writer_send_rrep(struct aodvv2_packet_data *packet_data, struct
         return;
     }
 
-    /* Make sure no other thread is using the writer right now */
-    mutex_lock(&writer_mutex);
     memcpy(&_target.packet_data, packet_data, sizeof(struct aodvv2_packet_data));
     _target.type = RFC5444_MSGTYPE_RREP;
     _target.packet_data.hoplimit = AODVV2_MAX_HOPCOUNT;
@@ -317,7 +309,6 @@ void aodv_packet_writer_send_rrep(struct aodvv2_packet_data *packet_data, struct
 
     rfc5444_writer_create_message_alltarget(&writer, RFC5444_MSGTYPE_RREP);
     rfc5444_writer_flush(&writer, &_target.interface, false);
-    mutex_unlock(&writer_mutex);
 }
 
 /**
@@ -338,7 +329,6 @@ void aodv_packet_writer_send_rerr(struct unreachable_node unreachable_nodes[], s
         return;
     }
 
-    mutex_lock(&writer_mutex);
     _target.packet_data.hoplimit = hoplimit;
     _target.type = RFC5444_MSGTYPE_RERR;
     _unreachable_nodes = unreachable_nodes;
@@ -349,7 +339,6 @@ void aodv_packet_writer_send_rerr(struct unreachable_node unreachable_nodes[], s
 
     rfc5444_writer_create_message_alltarget(&writer, RFC5444_MSGTYPE_RERR);
     rfc5444_writer_flush(&writer, &_target.interface, false);
-    mutex_unlock(&writer_mutex);
 }
 
 void aodv_packet_writer_cleanup(void)


### PR DESCRIPTION
In order to prevent the threads (for example the main and the receiver thread) from using the writer at the same time, causing bogus data in control packets, AODVv2 currently uses the ``writer_mutex``. However, this mutex sits at the wring entry point: 
The ``aodv_send_r*()`` functions are used to send AODVv2 control messages (i.e. RREQ, RREP, RERR). These functions then send the information that a control packet of type x with content y needs to be sent to the ``sender_thread`` via IPC, which then handles these IPC messages one by one and build and dispatches the RREQ/RREP/RERRs sequentially. 
So the critical point is not the writer, but in fact the ``aodv_send_rreq()``, ``aodv_send_rrep()`` and ``aodv_send_rerr()`` functions. This PR removes the unnecessary mutex in the writer and adds one mutex per ``aodv_send_r*()`` function instead.