### PR TITLE
cpu: native: add vtimer dependency

### DIFF
--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -6,3 +6,4 @@ ifeq ($(BUILDOSXNATIVE),1)
 endif
 
 export USEMODULE += periph
+export USEMODULE += vtimer


### PR DESCRIPTION
native's 'gettimeofday' implementation uses vtimer's gettimeofday, so
native needs to pull in vtimer as dependency.