### PR TITLE
routing/aodv: added return on failed socket creation for receiver thread

### DIFF
--- a/sys/net/routing/aodvv2/aodv.c
+++ b/sys/net/routing/aodvv2/aodv.c
@@ -294,6 +294,7 @@ static void *_aodv_receiver_thread(void *arg)
     if (-1 == socket_base_bind(sock_rcv, &sa_rcv, sizeof(sa_rcv))) {
         DEBUG("Error: bind to receive socket failed!\n");
         socket_base_close(sock_rcv);
+        return NULL;
     }
 
     AODV_DEBUG("ready to receive data\n");


### PR DESCRIPTION
When the receiver socket creation failed, the `_aodv_receiver_thread()` still processed in its receive loop.
This PR returns from the thread when the creation fails to avoid the looping.