### PR TITLE
ipv6_addr: do not null remaining bits in prefix initialization

### DIFF
--- a/sys/include/net/ng_ipv6/addr.h
+++ b/sys/include/net/ng_ipv6/addr.h
@@ -330,7 +330,7 @@ uint8_t ng_ipv6_addr_match_prefix(const ng_ipv6_addr_t *a, const ng_ipv6_addr_t 
 
 /**
  * @brief   Sets IPv6 address @p out with the first @p bits bit taken
- *          from @p prefix and the remaining bits to 0.
+ *          from @p prefix and leaves the remaining bits untouched.
  *
  * @param[out]  out     Prefix to be set.
  * @param[in]   prefix  Address to take prefix from.

--- a/sys/net/network_layer/ng_ipv6/addr/ng_ipv6_addr.c
+++ b/sys/net/network_layer/ng_ipv6/addr/ng_ipv6_addr.c
@@ -62,8 +62,6 @@ void ng_ipv6_addr_init_prefix(ng_ipv6_addr_t *out, const ng_ipv6_addr_t *prefix,
 {
     uint8_t bytes;
 
-    ng_ipv6_addr_set_unspecified(out);
-
     if (bits > 128) {
         bits = 128;
     }
@@ -75,7 +73,8 @@ void ng_ipv6_addr_init_prefix(ng_ipv6_addr_t *out, const ng_ipv6_addr_t *prefix,
     if (bits % 8) {
         uint8_t mask = 0xff << (8 - (bits - (bytes * 8)));
 
-        out->u8[bytes] = prefix->u8[bytes] & mask;
+        out->u8[bytes] &= ~mask;
+        out->u8[bytes] |= prefix->u8[bytes];
     }
 }
 

--- a/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
+++ b/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
@@ -403,13 +403,23 @@ static void test_ipv6_addr_match_prefix_same_pointer(void)
 
 static void test_ipv6_addr_init_prefix(void)
 {
-    ng_ipv6_addr_t a, b = { {
+    ng_ipv6_addr_t a = { {
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+            0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+        }
+    };
+    ng_ipv6_addr_t b = { {
             0x00, 0x01, 0x02, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
         }
     };
+    ng_ipv6_addr_t c =  { {
+            0xff, 0xfe, 0xfd, 0xfd, 0x04, 0x05, 0x06, 0x07,
+            0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+        }
+    };
 
-    ng_ipv6_addr_init_prefix(&a, &b, 31);
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(&a, &b));
+    ng_ipv6_addr_init_prefix(&c, &b, 31);
+    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(&a, &c));
 }
 
 static void test_ipv6_addr_set_unspecified(void)


### PR DESCRIPTION
To override the prefix of an already existing address seems to be the more common use-case, so I changed the semantics of this function. The previous semantics can still be achieved using

```C
ng_ipv6_addr_set_unspecified(addr);
ng_ipv6_addr_init_prefix(addr, prefix, prefix_len);
```