### PR TITLE
AODVv2: rm unnecessary initialization of na_mcast

### DIFF
--- a/sys/net/routing/aodvv2/aodv.c
+++ b/sys/net/routing/aodvv2/aodv.c
@@ -57,7 +57,7 @@ static mutex_t rreq_mutex;
 static mutex_t rrep_mutex;
 static mutex_t rerr_mutex;
 
-struct netaddr na_mcast = (struct netaddr){};
+struct netaddr na_mcast;
 
 void aodv_init(void)
 {


### PR DESCRIPTION
Remove the unnecessary and faulty initialization of ``na_mcast `` which makes gcc very unhappy:

    /home/lotte/riot/RIOT/sys/net/routing/aodvv2/aodv.c:60:43: warning: ISO C forbids empty initializer braces [-Wpedantic]
     struct netaddr na_mcast = (struct netaddr){};
                                               ^
    /home/lotte/riot/RIOT/sys/net/routing/aodvv2/aodv.c:60:35: warning: missing initializer for field ‘_addr’ of ‘struct netaddr’ [-Wmissing-field-initializers]
     struct netaddr na_mcast = (struct netaddr){};
                                       ^
    In file included from /home/lotte/riot/RIOT/sys/net/include/aodvv2/types.h:23:0,
                     from /home/lotte/riot/RIOT/sys/net/routing/aodvv2/aodv.h:31,
                     from /home/lotte/riot/RIOT/sys/net/routing/aodvv2/aodv.c:20:
    /home/lotte/riot/RIOT/pkg/oonf_api/oonf_api/src-api/common/netaddr.h:94:11: note: ‘_addr’ declared here
       uint8_t _addr[NETADDR_MAX_LENGTH];
               ^
    /home/lotte/riot/RIOT/sys/net/routing/aodvv2/aodv.c:60:35: error: initializer element is not constant
     struct netaddr na_mcast = (struct netaddr){};