### PR TITLE
sys/net/fib: added a notification for RRPs if a destination has been used

### DIFF
--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -378,7 +378,6 @@ static int fib_signal_rp(fib_table_t *table, uint16_t type, uint8_t *dat,
             }
         }
     }
-
     return ret;
 }
 
@@ -533,7 +532,11 @@ int fib_get_next_hop(fib_table_t *table, kernel_pid_t *iface_id,
 
     *iface_id = entry[0]->iface_id;
     *next_hop_flags = entry[0]->next_hop_flags;
-    mutex_unlock(&(table->mtx_access));
+
+    /* notify all RPs that a route has been used */
+    fib_signal_rp(table, FIB_MSG_RP_SIGNAL_DESTINATION_USED, dst, dst_size, dst_flags);
+
+    mutex_unlock(&table->mtx_access);
     return 0;
 }
 


### PR DESCRIPTION
Using AODVv2 requires to know if a route is in use, i.e. packets are forwarded towards a destination.
With this PR,  a message is sent to all registered RPs on a successful `fib_get_next_hop()` lookup, containing the destination address.

_Just as with the signal for a route discovery, the FIB requires that the content address **MUST** be copied into the context of the caller (if it is needed for processing) and a reply is sent to the FIB._
