### PR TITLE
pktdump: reply to netapi get/set

### DIFF
--- a/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
+++ b/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
@@ -100,11 +100,14 @@ static void _dump(ng_pktsnip_t *pkt)
 static void *_eventloop(void *arg)
 {
     (void)arg;
-    msg_t msg;
+    msg_t msg, reply;
     msg_t msg_queue[NG_PKTDUMP_MSG_QUEUE_SIZE];
 
     /* setup the message queue */
     msg_init_queue(msg_queue, NG_PKTDUMP_MSG_QUEUE_SIZE);
+
+    reply.content.value = (uint32_t)(-ENOTSUP);
+    reply.type = NG_NETAPI_MSG_TYPE_ACK;
 
     while (1) {
         msg_receive(&msg);
@@ -117,6 +120,10 @@ static void *_eventloop(void *arg)
             case NG_NETAPI_MSG_TYPE_SND:
                 puts("PKTDUMP: data to send:");
                 _dump((ng_pktsnip_t *)msg.content.ptr);
+                break;
+            case NG_NETAPI_MSG_TYPE_GET:
+            case NG_NETAPI_MSG_TYPE_SET:
+                msg_reply(&msg, &reply);
                 break;
             default:
                 puts("PKTDUMP: received something unexpected");


### PR DESCRIPTION
Since some layers need to get options from their neighboring layers the
previous behavior is potentially stack breaking when testing with this
module since no reply is given to this requests, reply blocking the
requesting thread in the process.