### PR TITLE
sys/net/fib: added function to request a set of destination addresses

### DIFF
--- a/sys/include/net/ng_fib.h
+++ b/sys/include/net/ng_fib.h
@@ -39,6 +39,20 @@ typedef struct rp_address_msg_t {
 #define FIB_MSG_RP_SIGNAL (0x99)     /**< message type for RP notifications */
 
 /**
+ * @brief the size in bytes of a full address
+ * TODO: replace with UNIVERSAL_ADDRESS_SIZE (#3022)
+*/
+#define FIB_DESTINATION_SIZE_SUBSTITUTE (16)
+
+/**
+ * @brief entry used to collect available destinations
+ */
+typedef struct fib_destination_set_entry_t {
+    uint8_t dest[FIB_DESTINATION_SIZE_SUBSTITUTE]; /**< The destination address */
+    size_t dest_size;    /**< The destination address size */
+} fib_destination_set_entry_t;
+
+/**
  * @brief indicator of a lifetime that does not expire (2^32 - 1)
  */
 #define FIB_LIFETIME_NO_EXPIRE (0xFFFFFFFF)
@@ -129,6 +143,27 @@ void fib_remove_entry(uint8_t *dst, size_t dst_size);
 int fib_get_next_hop(kernel_pid_t *iface_id,
                      uint8_t *next_hop, size_t *next_hop_size, uint32_t* next_hop_flags,
                      uint8_t *dst, size_t dst_size, uint32_t dst_flags);
+
+/**
+* @brief provides a set of destination addresses matching the given prefix
+* If the out buffer is insufficient low or passed as NULL,
+* the function will continue to count the number of matching entries
+* and provide the number to the caller.
+*
+* @param[in] prefix           the destination address
+* @param[in] prefix_size      the destination address size
+* @param[out] dst_set         the destination addresses matching the prefix
+* @param[in, out] dst_size    the number of entries available on in and used on out
+*
+* @return 0 on success
+*         -EHOSTUNREACH if no entry matches the type in the FIB
+*         -ENOBUFS if the size for the found entries is insufficient low
+*                  The actual needed size is stored then in dst_set_size,
+*                  however the required size may change in between calls.
+*/
+int fib_get_destination_set(uint8_t *prefix, size_t prefix_size,
+                            fib_destination_set_entry_t *dst_set, size_t* dst_set_size);
+
 
 /**
  * @brief returns the actual number of used FIB entries

--- a/sys/include/net/ng_fib/ng_universal_address.h
+++ b/sys/include/net/ng_fib/ng_universal_address.h
@@ -82,19 +82,43 @@ uint8_t* universal_address_get_address(universal_address_container_t *entry,
 
 /**
  * @brief determines if the entry equals the provided address
+ *        This function requires to be provided with the full size of the used
+ *        address type behind *addr to be compareable with the address stored in *entry.
  *
  * @param[in] entry       pointer to the universal_address_container_t for compare
  * @param[in] addr        pointer to the address for compare
- * @param[in, out] addr_size   the number of bytes used for the address entry
- *                             on sucessfull return this value is overwritten
- *                             with the number of matching bytes till the
- *                             first of trailing `0`s indicating a prefix
+ * @param[in, out] addr_size_in_bits  the number of bits  used for the address entry
+ *                                    on sucessfull return this value is overwritten
+ *                                    with the number of matching bits till the
+ *                                    first of trailing `0`s
  *
- * @return 0 if the entries are equal or comperable
+ * @return 0 if the entries are equal
+ *         1 if the entry match to a certain prefix (trailing '0's in *entry)
  *         -ENOENT if the given adresses do not match
  */
 int universal_address_compare(universal_address_container_t *entry,
-                              uint8_t *addr, size_t *addr_size);
+                              uint8_t *addr, size_t *addr_size_in_bits);
+
+
+/**
+* @brief determines if the entry equals the provided prefix
+*        This function requires to be provided with the full size of the used
+*        address type behind *prefix to be compareable with the address stored in *entry.
+*
+*
+* @param[in] entry       pointer to the universal_address_container_t for compare
+* @param[in] prefix      pointer to the address for compare
+* @param[in] prefix_size_in_bits the number of bits used for the prefix entry.
+*                                This size MUST be the full address size including trailing '0's,
+*                                e.g. for an ng_ipv6_addr_t it would be sizeof(ng_ipv6_addr_t)
+*                                regardless if the stored prefix is < ::/128
+*
+* @return 0 if the entries are equal
+*         1 if the entry match to a certain prefix (trailing '0's in *prefix)
+*         -ENOENT if the given adresses do not match
+*/
+int universal_address_compare_prefix(universal_address_container_t *entry,
+                            uint8_t *prefix, size_t prefix_size_in_bits);
 
 /**
  * @brief Prints the content of the given entry

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.tests_common
 BOARD_INSUFFICIENT_RAM := airfy-beacon chronos msb-430 msb-430h pca10000 \
                           pca10005 redbee-econotag spark-core stm32f0discovery \
                           telosb wsn430-v1_3b wsn430-v1_4 z1 nucleo-f334 \
-                          yunjia-nrf51822
+                          yunjia-nrf51822 samr21-xpro
 
 USEMODULE += embunit
 


### PR DESCRIPTION
This PR introduces an access function to the FIB, that collects all destination addresses matching specific prefix.
(This is meant as a base for discussion)

Rationale:
Using the FIB with RPL requires in storing MOP that all destination addresses reachable from a node, which are constructed by receiving DIOs and all target options from all received DAOs recursively, are put in the DAO messages disseminated by the node.
The former FIB did not provided access for a set of destination addresses matching a specific prefix.

