### PR TITLE
Tests : Add missing Makefile and Makefile.include for tests-hash_string

### DIFF
--- a/tests/unittests/tests-hash_string/Makefile
+++ b/tests/unittests/tests-hash_string/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-hash_string/Makefile.include
+++ b/tests/unittests/tests-hash_string/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += hash_string


### PR DESCRIPTION
- Adds the missing files from #2793.