### PR TITLE
Tests: Removing extra newline from Makefile.include

### DIFF
--- a/tests/unittests/tests-bloom/Makefile.include
+++ b/tests/unittests/tests-bloom/Makefile.include
@@ -1,3 +1,2 @@
 USEMODULE += bloom
 USEMODULE += hashes
-

--- a/tests/unittests/tests-crypto/Makefile.include
+++ b/tests/unittests/tests-crypto/Makefile.include
@@ -1,2 +1,1 @@
 USEMODULE += crypto
-

--- a/tests/unittests/tests-timex/Makefile.include
+++ b/tests/unittests/tests-timex/Makefile.include
@@ -1,2 +1,1 @@
 USEMODULE += timex
-


### PR DESCRIPTION
- Removing the extra newline from Makefile.include for tests-bloom, tests-crypto and tests-timex 