### PR TITLE
drivers/periph/spi: added missing stdint.h include

### DIFF
--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -25,6 +25,8 @@
 #ifndef SPI_H
 #define SPI_H
 
+#include <stdint.h>
+
 #include "periph_conf.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
the file is using `uint8_t`...