### PR TITLE
ng_net: add header print functions

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -100,6 +100,7 @@ ifneq (,$(filter ng_netbase,$(USEMODULE)))
   USEMODULE += ng_netapi
   USEMODULE += ng_netreg
   USEMODULE += ng_netif
+  USEMODULE += ng_netif_hdr
   USEMODULE += ng_pktbuf
 endif
 

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -86,6 +86,9 @@ endif
 ifneq (,$(filter ng_netif,$(USEMODULE)))
     DIRS += net/crosslayer/ng_netif
 endif
+ifneq (,$(filter ng_netif_hdr,$(USEMODULE)))
+    DIRS += net/crosslayer/ng_netif/hdr
+endif
 ifneq (,$(filter ng_netreg,$(USEMODULE)))
     DIRS += net/crosslayer/ng_netreg
 endif

--- a/sys/include/net/ng_ipv6/hdr.h
+++ b/sys/include/net/ng_ipv6/hdr.h
@@ -316,6 +316,13 @@ ng_pktsnip_t *ng_ipv6_hdr_build(ng_pktsnip_t *payload,
                                 uint8_t *src, uint8_t src_len,
                                 uint8_t *dst, uint8_t dst_len);
 
+/**
+ * @brief   Outputs an IPv6 header to stdout.
+ *
+ * @param[in] hdr   An IPv6 header.
+ */
+void ng_ipv6_hdr_print(ng_ipv6_hdr_t *hdr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/ng_netif/hdr.h
+++ b/sys/include/net/ng_netif/hdr.h
@@ -33,6 +33,12 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Maximum length of the l2 addresses of the generic interface header
+ *          in bytes.
+ */
+#define NG_NETIF_HDR_L2ADDR_MAX_LEN     (8)
+
+/**
  * @{
  * @name    Flags for the ng_netif_hdr_t
  */
@@ -207,6 +213,13 @@ static inline ng_pktsnip_t *ng_netif_hdr_build(uint8_t *src, uint8_t src_len,
 
     return pkt;
 }
+
+/**
+ * @brief   Outputs a generic interface header to stdout.
+ *
+ * @param[in] hdr   A generic interface header.
+ */
+void ng_netif_hdr_print(ng_netif_hdr_t *hdr);
 
 #ifdef __cplusplus
 }

--- a/sys/net/crosslayer/ng_netif/hdr/Makefile
+++ b/sys/net/crosslayer/ng_netif/hdr/Makefile
@@ -1,0 +1,3 @@
+MODULE = ng_netif_hdr
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/crosslayer/ng_netif/hdr/ng_netif_hdr_print.c
+++ b/sys/net/crosslayer/ng_netif/hdr/ng_netif_hdr_print.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+
+#include <stdio.h>
+
+#include "net/ng_netif.h"
+#include "net/ng_netif/hdr.h"
+
+void ng_netif_hdr_print(ng_netif_hdr_t *hdr)
+{
+    char addr_str[NG_NETIF_HDR_L2ADDR_MAX_LEN * 3];
+
+    printf("if_pid: %" PRIkernel_pid "  ", hdr->if_pid);
+    printf("rssi: %" PRIu8 "  ", hdr->rssi);
+    printf("lqi: %" PRIu8 "\n", hdr->lqi);
+    printf("src_l2addr: %s\n",
+           ng_netif_addr_to_str(addr_str, sizeof(addr_str),
+                                ng_netif_hdr_get_src_addr(hdr),
+                                (size_t)hdr->src_l2addr_len));
+    printf("dst_l2addr: %s\n",
+           ng_netif_addr_to_str(addr_str, sizeof(addr_str),
+                                ng_netif_hdr_get_dst_addr(hdr),
+                                (size_t)hdr->dst_l2addr_len));
+}
+
+/** @} */

--- a/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
+++ b/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
@@ -100,7 +100,8 @@ static void _dump(ng_pktsnip_t *pkt)
     ng_pktsnip_t *snip = pkt;
 
     while (snip != NULL) {
-        printf("~~ SNIP %2i - size: %3i byte, type: ", snips, snip->size);
+        printf("~~ SNIP %2i - size: %3u byte, type: ", snips,
+               (unsigned int)snip->size);
         _dump_snip(snip);
         ++snips;
         size += snip->size;

--- a/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
+++ b/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
@@ -41,27 +41,6 @@ static kernel_pid_t _pid = KERNEL_PID_UNDEF;
  */
 static char _stack[NG_PKTDUMP_STACKSIZE];
 
-#define ADDR_STR_MAX    (24)
-
-#ifdef MODULE_NG_NETIF
-static void _dump_netif_hdr(ng_netif_hdr_t *hdr)
-{
-    char addr_str[ADDR_STR_MAX];
-
-    printf("if_pid: %" PRIkernel_pid "  ", hdr->if_pid);
-    printf("rssi: %" PRIu8 "  ", hdr->rssi);
-    printf("lqi: %" PRIu8 "\n", hdr->lqi);
-    printf("src_l2addr: %s\n",
-           ng_netif_addr_to_str(addr_str, sizeof(addr_str),
-                                ng_netif_hdr_get_src_addr(hdr),
-                                (size_t)hdr->src_l2addr_len));
-    printf("dst_l2addr: %s\n",
-           ng_netif_addr_to_str(addr_str, sizeof(addr_str),
-                                ng_netif_hdr_get_dst_addr(hdr),
-                                (size_t)hdr->dst_l2addr_len));
-}
-#endif
-
 static void _dump_snip(ng_pktsnip_t *pkt)
 {
     switch (pkt->type) {
@@ -72,7 +51,7 @@ static void _dump_snip(ng_pktsnip_t *pkt)
 #ifdef MODULE_NG_NETIF
         case NG_NETTYPE_NETIF:
             printf("NETTYPE_NETIF (%i)\n", pkt->type);
-            _dump_netif_hdr(pkt->data);
+            ng_netif_hdr_print(pkt->data);
             break;
 #endif
 #ifdef MODULE_NG_SIXLOWPAN

--- a/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
+++ b/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
@@ -62,29 +62,6 @@ static void _dump_netif_hdr(ng_netif_hdr_t *hdr)
 }
 #endif
 
-#ifdef MODULE_NG_IPV6
-static void _dump_ipv6_hdr(ng_ipv6_hdr_t *hdr)
-{
-    char addr_str[NG_IPV6_ADDR_MAX_STR_LEN];
-
-    if (!ng_ipv6_hdr_is(hdr)) {
-        printf("illegal version field: %" PRIu8 "\n", ng_ipv6_hdr_get_version(hdr));
-    }
-
-    printf("traffic class: 0x%02" PRIx8 " (ECN: 0x%" PRIx8 ", DSCP: 0x%02" PRIx8 ")\n",
-           ng_ipv6_hdr_get_tc(hdr), ng_ipv6_hdr_get_tc_ecn(hdr),
-           ng_ipv6_hdr_get_tc_dscp(hdr));
-    printf("flow label: 0x%05" PRIx32 "\n", ng_ipv6_hdr_get_fl(hdr));
-    printf("length: %" PRIu16 "  next header: %" PRIu8 "  hop limit: %" PRIu8 "\n",
-           byteorder_ntohs(hdr->len), hdr->nh, hdr->hl);
-    printf("source address: %s\n", ng_ipv6_addr_to_str(addr_str, &hdr->src,
-            sizeof(addr_str)));
-    printf("destination address: %s\n", ng_ipv6_addr_to_str(addr_str, &hdr->dst,
-            sizeof(addr_str)));
-
-}
-#endif
-
 static void _dump_snip(ng_pktsnip_t *pkt)
 {
     switch (pkt->type) {
@@ -106,7 +83,7 @@ static void _dump_snip(ng_pktsnip_t *pkt)
 #ifdef MODULE_NG_IPV6
         case NG_NETTYPE_IPV6:
             printf("NETTYPE_IPV6 (%i)\n", pkt->type);
-            _dump_ipv6_hdr(pkt->data);
+            ng_ipv6_hdr_print(pkt->data);
             break;
 #endif
 #ifdef MODULE_NG_ICMPV6

--- a/sys/net/network_layer/ng_ipv6/hdr/ng_ipv6_hdr_print.c
+++ b/sys/net/network_layer/ng_ipv6/hdr/ng_ipv6_hdr_print.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+
+#include <stdio.h>
+
+#include "net/ng_ipv6/hdr.h"
+
+void ng_ipv6_hdr_print(ng_ipv6_hdr_t *hdr)
+{
+    char addr_str[NG_IPV6_ADDR_MAX_STR_LEN];
+
+    if (!ng_ipv6_hdr_is(hdr)) {
+        printf("illegal version field: %" PRIu8 "\n", ng_ipv6_hdr_get_version(hdr));
+    }
+
+    printf("traffic class: 0x%02" PRIx8 " (ECN: 0x%" PRIx8 ", DSCP: 0x%02" PRIx8 ")\n",
+           ng_ipv6_hdr_get_tc(hdr), ng_ipv6_hdr_get_tc_ecn(hdr),
+           ng_ipv6_hdr_get_tc_dscp(hdr));
+    printf("flow label: 0x%05" PRIx32 "\n", ng_ipv6_hdr_get_fl(hdr));
+    printf("length: %" PRIu16 "  next header: %" PRIu8 "  hop limit: %" PRIu8 "\n",
+           byteorder_ntohs(hdr->len), hdr->nh, hdr->hl);
+    printf("source address: %s\n", ng_ipv6_addr_to_str(addr_str, &hdr->src,
+            sizeof(addr_str)));
+    printf("destination address: %s\n", ng_ipv6_addr_to_str(addr_str, &hdr->dst,
+            sizeof(addr_str)));
+
+}
+
+/** @} */


### PR DESCRIPTION
As proposed in #2741 by @haukepetersen I moved the output of a header to their respective modules.

I also added a minor fix to the `printf()` formatting of `size_t` variables, since vim was complaining about it, when I edited those files.