### PR TITLE
Yet another doxygen fix

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -13,9 +13,16 @@
  * @file        debug.h
  * @brief       Debug-header
  *
- * @details     If ENABLE_DEBUG is set, before this header is included,
- *              ::DEBUG will print out to stdout, otherwise do nothing
+ * @details     If *ENABLE_DEBUG* is defined inside an implementation file, all
+ *              calls to ::DEBUG and ::DEBUGF* will work the same as *printf*
+ *              and output the given information to stdout. If *ENABLE_DEBUG*
+ *              is not defined, all calls to ::DEBUG and ::DEBUGF will be
+ *              ignored.
  *
+ *              In addition to just printing the given information ::DEBUGF
+ *              will further print extended debug information about the current
+ *              thread and function.
+     *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
@@ -37,14 +44,14 @@ extern "C" {
  */
 
 /**
- * @name Print debug information if the calling thread stack is large enough
+ * @def DEBUG_PRINT
+ *
+ * @brief Print debug information if the calling thread stack is large enough
  *
  * Use this macro the same as `printf`. When `DEVELHELP` is defined inside an
- * implementation file, all usages of `DEBUG_PRINT` will print the given
- * information to std-out after verifying the stack is big enough. If `DEVELHELP`
+ * implementation file, all usages of ::DEBUG_PRINT will print the given
+ * information to stdout after verifying the stack is big enough. If `DEVELHELP`
  * is not set, this check is not performed. (CPU exception may occur)
- *
- * @{
  */
 #if DEVELHELP
 #include "cpu-conf.h"
@@ -60,18 +67,8 @@ extern "C" {
 #else
 #define DEBUG_PRINT(...) printf(__VA_ARGS__)
 #endif
-/** @} */
 
 /**
- * @brief Print debug information to std-out
- *
- * If *ENABLE_DEBUG* is defined inside an implementation file, all calls to
- * *DEBUG* and *DEBUGF* will work the same as *printf* and output the given
- * information to stdout. If *ENABLE_DEBUG* is not defined, all calls to
- * *DEBUG* and *DEBUGF* will be ignored.
- *
- * In addition to just printing the given information *DEBUGF* will further
- * print extended debug information about the current thread and function.
  *
  * @{
  */
@@ -94,7 +91,20 @@ extern "C" {
 #  define DEBUG_FUNC ""
 # endif
 
+/**
+ * @def DEBUG
+ *
+ * @brief Print debug information to stdout
+ *
+ * @note Another name for ::DEBUG_PRINT
+ */
 #define DEBUG(...) DEBUG_PRINT(__VA_ARGS__)
+/**
+ * @def DEBUGF
+ *
+ * @brief Print extended debug information about the current thread and
+ *        function to stdout
+ */
 #define DEBUGF(...) \
     do { \
         DEBUG_PRINT("DEBUG(%s): %s:%d in %s: ", \

--- a/core/include/priority_queue.h
+++ b/core/include/priority_queue.h
@@ -110,7 +110,18 @@ void priority_queue_add(priority_queue_t *root, priority_queue_node_t *new_obj);
 void priority_queue_remove(priority_queue_t *root, priority_queue_node_t *node);
 
 #if ENABLE_DEBUG
+/**
+ * @brief print the data and priority of every node in the given priority queue
+ *
+ * @note requires ::ENABLE_DEBUG to be set to 1 for this file
+ */
 void priority_queue_print(priority_queue_t *root);
+
+/**
+ * @brief print the data, priority, and successor of a given node
+ *
+ * @note requires ::ENABLE_DEBUG to be set to 1 for this file
+ */
 void priority_queue_print_node(priority_queue_t *root);
 #endif
 

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -753,7 +753,8 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../../core \
+INPUT                  = ../../doc.txt \
+                         ../../core \
                          ../../cpu \
                          ../../boards \
                          ../../drivers \

--- a/sys/include/net/ng_sixlowpan/ctx.h
+++ b/sys/include/net/ng_sixlowpan/ctx.h
@@ -7,6 +7,9 @@
  */
 
 /**
+ * @defgroup    net_ng_sixlowpan    6LoWPAN
+ * @ingroup     net
+ *
  * @defgroup    net_ng_sixlowpan_ctx    Contexts for 6LoWPAN address compression
  * @ingroup     net_ng_sixlowpan
  * @brief       Context buffer for stateful 6LoWPAN address compression

--- a/sys/net/routing/aodvv2/aodv_debug.h
+++ b/sys/net/routing/aodvv2/aodv_debug.h
@@ -7,10 +7,9 @@
  */
 
 /**
- * @addtogroup  core_util
+ * @ingroup     aodvv2
  * @{
  *
- * @ingroup     aodvv2
  * @brief       Debug-header for aodvv2 debug messages
  *
  *


### PR DESCRIPTION
However, `doc.txt` seems still not be properly evaluated. The two macros do not show up in the documentation.

Also, the sorting is somewhat weird. Will open another issue for that.

@Lotterleben, please check if you agree on the AODVv2 specific change.

@authmillenon, please add a commit to  #2614 to revert 4ee380d