### PR TITLE
unittests: move netreg entries out of stack space

### DIFF
--- a/tests/unittests/tests-netreg/tests-netreg.c
+++ b/tests/unittests/tests-netreg/tests-netreg.c
@@ -21,6 +21,11 @@
 #include "unittests-constants.h"
 #include "tests-netreg.h"
 
+static ng_netreg_entry_t entries[] = {
+    { NULL, TEST_UINT16, TEST_UINT8 },
+    { NULL, TEST_UINT16, TEST_UINT8 + 1 }
+};
+
 static void set_up(void)
 {
     ng_netreg_init();
@@ -28,19 +33,16 @@ static void set_up(void)
 
 static void test_netreg_register__inval_numof(void)
 {
-    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
-
-    TEST_ASSERT_EQUAL_INT(-EINVAL, ng_netreg_register(NG_NETTYPE_NUMOF, &entry));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, ng_netreg_register(NG_NETTYPE_NUMOF, &entries[0]));
 }
 
 static void test_netreg_register__success(void)
 {
     ng_netreg_entry_t *res = ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16);
-    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
 
     TEST_ASSERT_NULL(res);
 
-    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry));
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entries[0]));
     TEST_ASSERT_NOT_NULL((res = ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16)));
     TEST_ASSERT_EQUAL_INT(TEST_UINT16, res->demux_ctx);
     TEST_ASSERT_EQUAL_INT(TEST_UINT8, res->pid);
@@ -49,57 +51,49 @@ static void test_netreg_register__success(void)
 
 void test_netreg_unregister__success(void)
 {
-    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
-
-    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry));
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entries[0]));
     TEST_ASSERT_NOT_NULL(ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16));
-    ng_netreg_unregister(NG_NETTYPE_TEST, &entry);
+    ng_netreg_unregister(NG_NETTYPE_TEST, &entries[0]);
     TEST_ASSERT_NULL(ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16));
 }
 
 void test_netreg_unregister__success2(void)
 {
     ng_netreg_entry_t *res = NULL;
-    ng_netreg_entry_t entry1 = { NULL, TEST_UINT16, TEST_UINT8 };
-    ng_netreg_entry_t entry2 = { NULL, TEST_UINT16, TEST_UINT8 + 1 };
 
-    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry1));
-    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry2));
-    ng_netreg_unregister(NG_NETTYPE_TEST, &entry1);
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entries[0]));
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entries[1]));
+    ng_netreg_unregister(NG_NETTYPE_TEST, &entries[0]);
     TEST_ASSERT_NOT_NULL((res = ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16)));
     TEST_ASSERT_EQUAL_INT(TEST_UINT16, res->demux_ctx);
     TEST_ASSERT_EQUAL_INT(TEST_UINT8 + 1, res->pid);
-    ng_netreg_unregister(NG_NETTYPE_TEST, &entry2);
+    ng_netreg_unregister(NG_NETTYPE_TEST, &entries[1]);
     TEST_ASSERT_NULL(ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16));
 }
 
 void test_netreg_unregister__success3(void)
 {
     ng_netreg_entry_t *res = NULL;
-    ng_netreg_entry_t entry1 = { NULL, TEST_UINT16, TEST_UINT8 };
-    ng_netreg_entry_t entry2 = { NULL, TEST_UINT16, TEST_UINT8 + 1 };
 
-    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry1));
-    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry2));
-    ng_netreg_unregister(NG_NETTYPE_TEST, &entry2);
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entries[0]));
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entries[1]));
+    ng_netreg_unregister(NG_NETTYPE_TEST, &entries[1]);
     TEST_ASSERT_NOT_NULL((res = ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16)));
     TEST_ASSERT_EQUAL_INT(TEST_UINT16, res->demux_ctx);
     TEST_ASSERT_EQUAL_INT(TEST_UINT8, res->pid);
-    ng_netreg_unregister(NG_NETTYPE_TEST, &entry1);
+    ng_netreg_unregister(NG_NETTYPE_TEST, &entries[0]);
     TEST_ASSERT_NULL(ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16));
 }
 
 void test_netreg_lookup__wrong_type_undef(void)
 {
-    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
-    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry));
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entries[0]));
     TEST_ASSERT_NULL(ng_netreg_lookup(NG_NETTYPE_UNDEF, TEST_UINT16));
 }
 
 void test_netreg_lookup__wrong_type_numof(void)
 {
-    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
-    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry));
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entries[0]));
     TEST_ASSERT_NULL(ng_netreg_lookup(NG_NETTYPE_NUMOF, TEST_UINT16));
 }
 
@@ -112,42 +106,37 @@ void test_netreg_num__empty(void)
 
 void test_netreg_num__wrong_type_undef(void)
 {
-    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
-    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry));
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entries[0]));
     TEST_ASSERT_EQUAL_INT(0, ng_netreg_num(NG_NETTYPE_UNDEF, TEST_UINT16));
 }
 
 void test_netreg_num__wrong_type_numof(void)
 {
-    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
-    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry));
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entries[0]));
     TEST_ASSERT_EQUAL_INT(0, ng_netreg_num(NG_NETTYPE_NUMOF, TEST_UINT16));
 }
 
 void test_netreg_num__2_entries(void)
 {
-    ng_netreg_entry_t entry1 = { NULL, TEST_UINT16, TEST_UINT8 };
-    ng_netreg_entry_t entry2 = { NULL, TEST_UINT16, TEST_UINT8 + 1 };
-    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry1));
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entries[0]));
     TEST_ASSERT_EQUAL_INT(1, ng_netreg_num(NG_NETTYPE_TEST, TEST_UINT16));
-    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry2));
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entries[1]));
     TEST_ASSERT_EQUAL_INT(2, ng_netreg_num(NG_NETTYPE_TEST, TEST_UINT16));
 }
 
 void test_netreg_getnext__NULL(void)
 {
-    ng_netreg_entry_t entry = { NULL, TEST_UINT16, TEST_UINT8 };
-    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entry));
+    TEST_ASSERT_EQUAL_INT(0, ng_netreg_register(NG_NETTYPE_TEST, &entries[0]));
     TEST_ASSERT_NULL(ng_netreg_getnext(NULL));
 }
 
 void test_netreg_getnext__2_entries(void)
 {
-    ng_netreg_entry_t *entry = NULL;
+    ng_netreg_entry_t *res = NULL;
 
     test_netreg_num__2_entries();
-    TEST_ASSERT_NOT_NULL((entry = ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16)));
-    TEST_ASSERT_NOT_NULL(ng_netreg_getnext(entry));
+    TEST_ASSERT_NOT_NULL((res = ng_netreg_lookup(NG_NETTYPE_TEST, TEST_UINT16)));
+    TEST_ASSERT_NOT_NULL(ng_netreg_getnext(res));
 }
 
 Test *tests_netreg_tests(void)


### PR DESCRIPTION
Fixes #2840.