### PR TITLE
net/ng_netconf: added option for setting RAW mode

### DIFF
--- a/sys/include/net/ng_netconf.h
+++ b/sys/include/net/ng_netconf.h
@@ -75,6 +75,9 @@ typedef enum {
                                      *   as type ng_nettype_t. */
     NETCONF_OPT_STATE,              /**< get/set the state of network devices as
                                      *   type ng_netconf_state_t */
+    NETCONF_OPT_RAWMODE,            /**< en/disable the pre-processing of data
+                                         in a network device driver as type
+                                         ng_nettype_t */
     /* add more options if needed */
 } ng_netconf_opt_t;
 


### PR DESCRIPTION
with this option one can disable the preprocessing (parsing of link layer headers into netif headers). This is needed for packet dumping (e.g. for a sniffer). Also this might be interesting for specialized MAC layers, that want to read the un-touched link layer header.