### PR TITLE
tests/driver_xbee: use uart0

### DIFF
--- a/tests/driver_xbee/Makefile
+++ b/tests/driver_xbee/Makefile
@@ -20,6 +20,7 @@ USEMODULE += xbee
 USEMODULE += ng_netbase
 USEMODULE += ng_nomac
 USEMODULE += ng_pktdump
+USEMODULE += uart0
 USEMODULE += shell
 USEMODULE += shell_commands
 

--- a/tests/driver_xbee/main.c
+++ b/tests/driver_xbee/main.c
@@ -22,6 +22,8 @@
 
 #include "board.h"
 #include "kernel.h"
+#include "posix_io.h"
+#include "board_uart0.h"
 #include "shell.h"
 #include "shell_commands.h"
 #include "xbee.h"
@@ -60,7 +62,9 @@ static char nomac_stack[KERNEL_CONF_STACKSIZE_DEFAULT];
  */
 int shell_read(void)
 {
-    return (int)getchar();
+    char c = 0;
+    posix_read(uart0_handler_pid, &c, 1);
+    return c;
 }
 
 /**
@@ -111,6 +115,7 @@ int main(void)
     }
 
     /* start the shell */
+    posix_open(uart0_handler_pid, 0);
     shell_init(&shell, NULL, SHELL_BUFSIZE, shell_read, shell_put);
     shell_run(&shell);
 


### PR DESCRIPTION
I am not sure if we have a bug in the system calls or low-level UART drivers, but using the uart0 module in the xbee test seems to lead to a more stable behavior.