### PR TITLE
cpu/samd21: set optimization level to -Os

### DIFF
--- a/cpu/samd21/Makefile.include
+++ b/cpu/samd21/Makefile.include
@@ -6,7 +6,4 @@ export CFLAGS += -DDONT_USE_CMSIS_INIT
 # use the hwtimer compatibility layer
 USEMODULE += hwtimer_compat
 
-# TODO: remove once the CPU implementation is stable with -Os
-CFLAGS_OPT = -O0
-
 include $(RIOTCPU)/Makefile.include.cortexm_common


### PR DESCRIPTION
I was wondering about the huge code-size for the samr21-xpro - turned out, the optimization for the board is turned off... Looks better now.

