### PR TITLE
ipv6_addr: rename ng_ipv6_hdr_is_ipv6_hdr() to something less silly

### DIFF
--- a/sys/include/net/ng_ipv6/hdr.h
+++ b/sys/include/net/ng_ipv6/hdr.h
@@ -78,7 +78,7 @@ typedef struct __attribute__((packed)) {
      * fields accordingly:
      * * ng_ipv6_hdr_set_version()
      * * ng_ipv6_hdr_get_version()
-     * * ng_ipv6_hdr_is_ipv6_hdr()
+     * * ng_ipv6_hdr_is()
      * * ng_ipv6_hdr_set_tc()
      * * ng_ipv6_hdr_set_tc_ecn()
      * * ng_ipv6_hdr_set_tc_dscp()
@@ -127,7 +127,7 @@ static inline uint8_t ng_ipv6_hdr_get_version(const ng_ipv6_hdr_t *hdr)
  * @return  true, if version field is 6
  * @return  false, otherwise
  */
-static inline bool ng_ipv6_hdr_is_ipv6_hdr(const ng_ipv6_hdr_t *hdr)
+static inline bool ng_ipv6_hdr_is(const ng_ipv6_hdr_t *hdr)
 {
     return (((hdr->v_tc_fl.u8[0]) & 0xf0) == 0x60);
 }

--- a/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
+++ b/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
@@ -67,7 +67,7 @@ static void _dump_ipv6_hdr(ng_ipv6_hdr_t *hdr)
 {
     char addr_str[NG_IPV6_ADDR_MAX_STR_LEN];
 
-    if (!ng_ipv6_hdr_is_ipv6_hdr(hdr)) {
+    if (!ng_ipv6_hdr_is(hdr)) {
         printf("illegal version field: %" PRIu8 "\n", ng_ipv6_hdr_get_version(hdr));
     }
 

--- a/sys/net/network_layer/ng_ipv6/ng_ipv6.c
+++ b/sys/net/network_layer/ng_ipv6/ng_ipv6.c
@@ -432,14 +432,14 @@ static void _receive(ng_pktsnip_t *pkt)
         /* IP header was already marked. Take it. */
         ipv6 = pkt->next;
 
-        if (!ng_ipv6_hdr_is_ipv6_hdr(ipv6->data)) {
+        if (!ng_ipv6_hdr_is(ipv6->data)) {
             DEBUG("ipv6: Received packet was not IPv6, dropping packet\n");
             ng_pktbuf_release(pkt);
             return;
         }
     }
     else {
-        if (!ng_ipv6_hdr_is_ipv6_hdr(pkt->data)) {
+        if (!ng_ipv6_hdr_is(pkt->data)) {
             DEBUG("ipv6: Received packet was not IPv6, dropping packet\n");
             ng_pktbuf_release(pkt);
             return;

--- a/tests/unittests/tests-ipv6_hdr/tests-ipv6_hdr.c
+++ b/tests/unittests/tests-ipv6_hdr/tests-ipv6_hdr.c
@@ -80,7 +80,7 @@ static void test_ipv6_hdr_is_ipv6_hdr__false(void)
      */
     uint8_t val[] = { 0 };
 
-    TEST_ASSERT(!ng_ipv6_hdr_is_ipv6_hdr((ng_ipv6_hdr_t *)val));
+    TEST_ASSERT(!ng_ipv6_hdr_is((ng_ipv6_hdr_t *)val));
 }
 
 static void test_ipv6_hdr_is_ipv6_hdr__true(void)
@@ -94,7 +94,7 @@ static void test_ipv6_hdr_is_ipv6_hdr__true(void)
      */
     uint8_t val[] = { 0x60 | (TEST_UINT8 & 0x0f) };
 
-    TEST_ASSERT(ng_ipv6_hdr_is_ipv6_hdr((ng_ipv6_hdr_t *)val));
+    TEST_ASSERT(ng_ipv6_hdr_is((ng_ipv6_hdr_t *)val));
 }
 
 static void test_ipv6_hdr_set_tc(void)
@@ -314,7 +314,7 @@ static void test_ipv6_hdr_build__src_NULL(void)
                                 sizeof(ng_ipv6_addr_t))));
     hdr = pkt->data;
     TEST_ASSERT_NOT_NULL(hdr);
-    TEST_ASSERT(ng_ipv6_hdr_is_ipv6_hdr(hdr));
+    TEST_ASSERT(ng_ipv6_hdr_is(hdr));
     TEST_ASSERT_EQUAL_INT(0, ng_ipv6_hdr_get_tc(hdr));
     TEST_ASSERT_EQUAL_INT(0, ng_ipv6_hdr_get_fl(hdr));
     TEST_ASSERT_EQUAL_INT(NG_PROTNUM_RESERVED, hdr->nh);
@@ -336,7 +336,7 @@ static void test_ipv6_hdr_build__dst_NULL(void)
                                 NULL, 0)));
     hdr = pkt->data;
     TEST_ASSERT_NOT_NULL(hdr);
-    TEST_ASSERT(ng_ipv6_hdr_is_ipv6_hdr(hdr));
+    TEST_ASSERT(ng_ipv6_hdr_is(hdr));
     TEST_ASSERT_EQUAL_INT(0, ng_ipv6_hdr_get_tc(hdr));
     TEST_ASSERT_EQUAL_INT(0, ng_ipv6_hdr_get_fl(hdr));
     TEST_ASSERT_EQUAL_INT(NG_PROTNUM_RESERVED, hdr->nh);
@@ -360,7 +360,7 @@ static void test_ipv6_hdr_build__complete(void)
                                 sizeof(ng_ipv6_addr_t))));
     hdr = pkt->data;
     TEST_ASSERT_NOT_NULL(hdr);
-    TEST_ASSERT(ng_ipv6_hdr_is_ipv6_hdr(hdr));
+    TEST_ASSERT(ng_ipv6_hdr_is(hdr));
     TEST_ASSERT_EQUAL_INT(0, ng_ipv6_hdr_get_tc(hdr));
     TEST_ASSERT_EQUAL_INT(0, ng_ipv6_hdr_get_fl(hdr));
     TEST_ASSERT_EQUAL_INT(NG_PROTNUM_RESERVED, hdr->nh);


### PR DESCRIPTION
Suggested in https://github.com/RIOT-OS/RIOT/pull/2454#discussion_r28870632. Ready for delivery.