### PR TITLE
tests: vtimer_msg: get back vtimer_set_msg call

### DIFF
--- a/tests/vtimer_msg/main.c
+++ b/tests/vtimer_msg/main.c
@@ -63,6 +63,8 @@ void *timer_thread(void *arg)
                tmsg->interval.seconds,
                tmsg->interval.microseconds,
                tmsg->msg);
+
+        vtimer_set_msg(&tmsg->timer, tmsg->interval, thread_getpid(), MSG_TIMER, tmsg);
     }
 }
 

--- a/tests/vtimer_msg_diff/main.c
+++ b/tests/vtimer_msg_diff/main.c
@@ -87,6 +87,8 @@ void *timer_thread(void *arg)
             printf("WARNING: timer difference %" PRId64 "us exceeds MAXDIFF(%d)!\n", diff, MAXDIFF);
         }
 
+        vtimer_set_msg(&tmsg->timer, tmsg->interval, thread_getpid(), MSG_TIMER, tmsg);
+
         if (tmsg->count >= MAXCOUNT) {
             printf("Maximum count reached. (%d) Exiting.\n", MAXCOUNT);
             break;


### PR DESCRIPTION
accidently removed in #2545. Nice reviewing! ;)