### PR TITLE
ng_sixlowpan: add missing ng_ipv6 dependency

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -49,6 +49,7 @@ ifneq (,$(filter sixlowpan,$(USEMODULE)))
 endif
 
 ifneq (,$(filter ng_sixlowpan,$(USEMODULE)))
+  USEMODULE += ng_ipv6
   USEMODULE += ng_sixlowpan_netif
   USEMODULE += ng_netbase
 endif


### PR DESCRIPTION
Is needed so `NG_NETTYPE_IPV6` can be resolved (which is used for by the `ng_netreg` lookup in receive).