### PR TITLE
kinetis: Add SPI_[2-7] to spi_transmission_begin

### DIFF
--- a/cpu/kinetis_common/spi.c
+++ b/cpu/kinetis_common/spi.c
@@ -1294,6 +1294,54 @@ void spi_transmission_begin(spi_t dev, char reset_val)
                                | SPI_PUSHR_TXDATA(reset_val);
             break;
 #endif
+#if SPI_2_EN
+
+        case SPI_2:
+            SPI_2_DEV->PUSHR = SPI_PUSHR_CTAS(SPI_2_CTAS)
+                               | SPI_PUSHR_EOQ_MASK
+                               | SPI_PUSHR_TXDATA(reset_val);
+            break;
+#endif
+#if SPI_3_EN
+
+        case SPI_3:
+            SPI_3_DEV->PUSHR = SPI_PUSHR_CTAS(SPI_3_CTAS)
+                               | SPI_PUSHR_EOQ_MASK
+                               | SPI_PUSHR_TXDATA(reset_val);
+            break;
+#endif
+#if SPI_4_EN
+
+        case SPI_4:
+            SPI_4_DEV->PUSHR = SPI_PUSHR_CTAS(SPI_4_CTAS)
+                               | SPI_PUSHR_EOQ_MASK
+                               | SPI_PUSHR_TXDATA(reset_val);
+            break;
+#endif
+#if SPI_5_EN
+
+        case SPI_5:
+            SPI_5_DEV->PUSHR = SPI_PUSHR_CTAS(SPI_5_CTAS)
+                               | SPI_PUSHR_EOQ_MASK
+                               | SPI_PUSHR_TXDATA(reset_val);
+            break;
+#endif
+#if SPI_6_EN
+
+        case SPI_6:
+            SPI_6_DEV->PUSHR = SPI_PUSHR_CTAS(SPI_6_CTAS)
+                               | SPI_PUSHR_EOQ_MASK
+                               | SPI_PUSHR_TXDATA(reset_val);
+            break;
+#endif
+#if SPI_7_EN
+
+        case SPI_7:
+            SPI_7_DEV->PUSHR = SPI_PUSHR_CTAS(SPI_7_CTAS)
+                               | SPI_PUSHR_EOQ_MASK
+                               | SPI_PUSHR_TXDATA(reset_val);
+            break;
+#endif
     }
 }
 


### PR DESCRIPTION
Simple fix for compiler warning about unhandled switch cases.

```
.../riot/cpu/kinetis_common/spi.c: In function ‘spi_transmission_begin’:
.../riot/cpu/kinetis_common/spi.c:1280:5: warning: enumeration value ‘SPI_2’ not handled in switch [-Wswitch]
     switch (dev) {
     ^
```

This is a simple copy and paste from the SPI_0 case, which should be sufficient. 

The function is only used in slave mode, and slave mode initialization is so far only implemented for the SPI_0 case. I have no intention of putting in any work on slave mode until I have a project that needs it, this PR is only for silencing these annoying warnings.