### PR TITLE
net/network_layer/fib: added clearing flags for expired entries

### DIFF
--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -107,6 +107,9 @@ static int fib_find_entry(uint8_t *dst, size_t dst_size,
                 /* remove this entry if its lifetime expired */
                 fib_table[i].lifetime.seconds = 0;
                 fib_table[i].lifetime.microseconds = 0;
+                fib_table[i].global_flags = 0;
+                fib_table[i].next_hop_flags = 0;
+                fib_table[i].iface_id = KERNEL_PID_UNDEF;
 
                 if (fib_table[i].global != NULL) {
                     universal_address_rem(fib_table[i].global);


### PR DESCRIPTION
When the lifetime of a FIB entry expired, the flags have not been cleared.
This PR fixes this and clears the flags for the entry.