### PR TITLE
ng_at86rf2xx: fix wrong LQI and ensure 802.15.4 compliance with packet length field

### DIFF
--- a/drivers/ng_at86rf2xx/ng_at86rf2xx.c
+++ b/drivers/ng_at86rf2xx/ng_at86rf2xx.c
@@ -236,12 +236,8 @@ size_t ng_at86rf2xx_rx_len(ng_at86rf2xx_t *dev)
     uint8_t phr;
     ng_at86rf2xx_fb_read(dev, &phr, 1);
 
-    /* Mask MSB for 802.15.4 compliance, see
-     * section 37.1.1.2 of SAM R21 datahseet
-     */
-    phr &= ~(1 << 7);
-
-    return (size_t)(phr - 2);    /* subtract length of FCS field (checksum) */
+    /* ignore MSB (see datasheets section 8.1.1.2) and substract length of FCS field */
+    return (size_t)((phr - 2) & 0x7f);
 }
 
 void ng_at86rf2xx_rx_read(ng_at86rf2xx_t *dev, uint8_t *data, size_t len,

--- a/drivers/ng_at86rf2xx/ng_at86rf2xx.c
+++ b/drivers/ng_at86rf2xx/ng_at86rf2xx.c
@@ -233,9 +233,15 @@ void ng_at86rf2xx_tx_exec(ng_at86rf2xx_t *dev)
 
 size_t ng_at86rf2xx_rx_len(ng_at86rf2xx_t *dev)
 {
-    uint8_t res;
-    ng_at86rf2xx_fb_read(dev, &res, 1);
-    return (size_t)(res - 2);           /* extract the PHR and LQI field */
+    uint8_t phr;
+    ng_at86rf2xx_fb_read(dev, &phr, 1);
+
+    /* Mask MSB for 802.15.4 compliance, see
+     * section 37.1.1.2 of SAM R21 datahseet
+     */
+    phr &= ~(1 << 7);
+
+    return (size_t)(phr - 2);    /* subtract length of FCS field (checksum) */
 }
 
 void ng_at86rf2xx_rx_read(ng_at86rf2xx_t *dev, uint8_t *data, size_t len,

--- a/drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c
+++ b/drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c
@@ -293,7 +293,8 @@ static void _receive_data(ng_at86rf2xx_t *dev)
     /* fill missing fields in netif header */
     netif = (ng_netif_hdr_t *)hdr->data;
     netif->if_pid = dev->mac_pid;
-    ng_at86rf2xx_rx_read(dev, &(netif->lqi), 1, pkt_len);
+    /* LQI offset: PHR (1 byte) + Payload (pkt_len) + FCS (2 byte) */
+    ng_at86rf2xx_rx_read(dev, &(netif->lqi), 1, pkt_len + 3);
     netif->rssi = ng_at86rf2xx_reg_read(dev, NG_AT86RF2XX_REG__PHY_ED_LEVEL);
 
     /* allocate payload */

--- a/drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c
+++ b/drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c
@@ -293,8 +293,8 @@ static void _receive_data(ng_at86rf2xx_t *dev)
     /* fill missing fields in netif header */
     netif = (ng_netif_hdr_t *)hdr->data;
     netif->if_pid = dev->mac_pid;
-    /* LQI offset: PHR (1 byte) + Payload (pkt_len) + FCS (2 byte) */
-    ng_at86rf2xx_rx_read(dev, &(netif->lqi), 1, pkt_len + 3);
+    /* LQI offset: Payload (pkt_len) + FCS (2 byte) */
+    ng_at86rf2xx_rx_read(dev, &(netif->lqi), 1, pkt_len + 2);
     netif->rssi = ng_at86rf2xx_reg_read(dev, NG_AT86RF2XX_REG__PHY_ED_LEVEL);
 
     /* allocate payload */


### PR DESCRIPTION
This PR should fix wrong LQI values for the new driver and adds additional measures to ensure IEEE 802.15.4 compliance regarding the PHR field as suggested by the datasheet and already discussed in #2825.