### PR TITLE
ng_netconf: adapt byte orders to output

### DIFF
--- a/drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c
+++ b/drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c
@@ -19,6 +19,7 @@
  * @}
  */
 
+#include "byteorder.h"
 #include "net/ng_ieee802154.h"
 #include "net/ng_netbase.h"
 #include "ng_at86rf2xx.h"
@@ -359,18 +360,34 @@ static int _get(ng_netdev_t *device, ng_netconf_opt_t opt,
     switch (opt) {
 
         case NETCONF_OPT_ADDRESS:
-            if (max_len < sizeof(uint16_t)) {
+            if (max_len < sizeof(be_uint16_t)) {
                 return -EOVERFLOW;
             }
-            *((uint16_t *)val) = ng_at86rf2xx_get_addr_short(dev);
-            return sizeof(uint16_t);
+            else {
+                be_uint16_t *v = val;
+                le_uint16_t addr;
+
+                addr.u16 = ng_at86rf2xx_get_addr_short(dev);
+
+                *v = byteorder_ltobs(addr);
+
+                return sizeof(be_uint16_t);
+            }
 
         case NETCONF_OPT_ADDRESS_LONG:
-            if (max_len < sizeof(uint64_t)) {
+            if (max_len < sizeof(be_uint64_t)) {
                 return -EOVERFLOW;
             }
-            *((uint64_t *)val) = ng_at86rf2xx_get_addr_long(dev);
-            return sizeof(uint64_t);
+            else {
+                be_uint64_t *v = val;
+                le_uint64_t addr;
+
+                addr.u64 = ng_at86rf2xx_get_addr_long(dev);
+
+                *v = byteorder_ltobll(addr);
+
+                return sizeof(be_uint64_t);
+            }
 
         case NETCONF_OPT_ADDR_LEN:
             if (max_len < sizeof(uint16_t)) {
@@ -392,11 +409,19 @@ static int _get(ng_netdev_t *device, ng_netconf_opt_t opt,
             return sizeof(uint16_t);
 
         case NETCONF_OPT_NID:
-            if (max_len < sizeof(uint16_t)) {
+            if (max_len < sizeof(be_uint16_t)) {
                 return -EOVERFLOW;
             }
-            *((uint16_t *)val) = dev->pan;
-            return sizeof(uint16_t);
+            else {
+                be_uint16_t *v = val;
+                le_uint16_t nid;
+
+                nid.u16 = dev->pan;
+
+                *v = byteorder_ltobs(nid);
+
+                return sizeof(be_uint16_t);
+            }
 
         case NETCONF_OPT_CHANNEL:
             if (max_len < sizeof(uint16_t)) {
@@ -505,18 +530,29 @@ static int _set(ng_netdev_t *device, ng_netconf_opt_t opt,
 
     switch (opt) {
         case NETCONF_OPT_ADDRESS:
-            if (len > sizeof(uint16_t)) {
+            if (len > sizeof(be_uint16_t)) {
                 return -EOVERFLOW;
             }
-            ng_at86rf2xx_set_addr_short(dev, *((uint16_t*)val));
-            return sizeof(uint16_t);
+            else {
+                be_uint16_t *v = val;
+
+                ng_at86rf2xx_set_addr_short(dev, byteorder_btols(v).u16);
+
+                return sizeof(be_uint16_t);
+            }
 
         case NETCONF_OPT_ADDRESS_LONG:
             if (len > sizeof(uint64_t)) {
                 return -EOVERFLOW;
             }
-            ng_at86rf2xx_set_addr_long(dev, *((uint64_t*)val));
-            return sizeof(uint64_t);
+            else {
+                be_uint64_t *v = val;
+
+                ng_at86rf2xx_set_addr_long(dev, byteorder_btolll(v).u64);
+
+                return sizeof(be_uint64_t);
+            }
+
 
         case NETCONF_OPT_SRC_LEN:
             if (len > sizeof(uint16_t)) {
@@ -536,11 +572,17 @@ static int _set(ng_netdev_t *device, ng_netconf_opt_t opt,
             return sizeof(uint16_t);
 
         case NETCONF_OPT_NID:
-            if (len > sizeof(uint16_t)) {
+            if (len > sizeof(be_uint16_t)) {
                 return -EOVERFLOW;
             }
-            ng_at86rf2xx_set_pan(dev, *((uint16_t *)val));
-            return sizeof(uint16_t);
+            else {
+                be_uint16_t *v = val;
+
+                ng_at86rf2xx_set_pan(dev, byteorder_btols(v).u16);
+
+                return sizeof(be_uint16_t);
+            }
+
 
         case NETCONF_OPT_CHANNEL:
             if (len != sizeof(uint16_t)) {

--- a/sys/include/net/ng_netconf.h
+++ b/sys/include/net/ng_netconf.h
@@ -34,10 +34,10 @@ typedef enum {
     NETCONF_OPT_CHANNEL,            /**< get/set channel as uint16_t in host
                                      *   byte order */
     NETCONF_OPT_IS_CHANNEL_CLR,     /**< check if channel is clear */
-    NETCONF_OPT_ADDRESS,            /**< get/set address in host byte order */
+    NETCONF_OPT_ADDRESS,            /**< get/set address in network byte order */
 
     /**
-     * @brief    get/set long address in host byte order
+     * @brief    get/set long address in network byte order
      *
      * Examples for this include the EUI-64 in IEEE 802.15.4
      */
@@ -49,7 +49,7 @@ typedef enum {
                                      *   for the network device's source address
                                      *   as uint16_t in host byte order */
     /**
-     * @brief    get/set the network ID as uint16_t in host byte order
+     * @brief    get/set the network ID as uint16_t in network byte order
      *
      * Examples for this include the PAN ID in IEEE 802.15.4
      */

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -192,10 +192,14 @@ static void _netif_list(kernel_pid_t dev)
         printf(" Channel: %" PRIu16 " ", u16);
     }
 
-    res = ng_netapi_get(dev, NETCONF_OPT_NID, 0, &u16, sizeof(u16));
+    res = ng_netapi_get(dev, NETCONF_OPT_NID, 0, hwaddr, sizeof(hwaddr));
 
     if (res >= 0) {
-        printf(" NID: 0x%" PRIx16 " ", u16);
+        char hwaddr_str[res * 3];
+        printf(" NID: ");
+        printf("%s", ng_netif_addr_to_str(hwaddr_str, sizeof(hwaddr_str),
+                                          hwaddr, res));
+        printf(" ");
     }
 
     res = ng_netapi_get(dev, NETCONF_OPT_TX_POWER, 0, &i16, sizeof(i16));
@@ -462,7 +466,7 @@ static int _netif_set(char *cmd_name, kernel_pid_t dev, char *key, char *value)
     }
     else if ((strcmp("nid", key) == 0) || (strcmp("pan", key) == 0) ||
              (strcmp("pan_id", key) == 0)) {
-        return _netif_set_u16(dev, NETCONF_OPT_NID, value);
+        return _netif_set_addr(dev, NETCONF_OPT_NID, value);
     }
     else if (strcmp("power", key) == 0) {
         return _netif_set_i16(dev, NETCONF_OPT_TX_POWER, value);


### PR DESCRIPTION
The byte order of addresses in ng_netdev/ng_netconf is a little bit messed up:

* The shell output and configuration it's unclear: For Ethernet it's network byte order, though the doc states it's in host byte order, for `ng_at86rf2xx` it is little endian (regardless of the host byte order), because
* for sending `ng_at86rf2xx` assumes the address is stored in little endian
* I don't even know know what `xbee` is doing.

My solution: addresses (including PAN ID) shall always be configured in network byte (big endian) order. If the protocol does not use network byte order (e.g. IEEE 802.15.4) it needs to convert it to their specific order.