### PR TITLE
ng_netif: non-destructive ng_netif_addr_to_str

### DIFF
--- a/sys/include/net/ng_netif.h
+++ b/sys/include/net/ng_netif.h
@@ -107,7 +107,7 @@ size_t ng_netif_get(kernel_pid_t *netifs);
  * @return  Copy of @p out on success.
  * @return  NULL, if @p out_len < 3 * @p addr_len.
  */
-char *ng_netif_addr_to_str(char *out, size_t out_len, uint8_t *addr,
+char *ng_netif_addr_to_str(char *out, size_t out_len, const uint8_t *addr,
                            size_t addr_len);
 
 /**

--- a/sys/include/net/ng_netif.h
+++ b/sys/include/net/ng_netif.h
@@ -116,8 +116,6 @@ char *ng_netif_addr_to_str(char *out, size_t out_len, uint8_t *addr,
  *
  * @details The input format must be like `xx:xx:xx:xx` where `xx` will be the
  *          bytes of @p addr in hexadecimal representation.
- *          Changes @p str for simple parsing purposes. Make a copy if you
- *          need it later.
  *
  * @param[out] out      The resulting hardware address.
  * @param[out] out_len  Length of @p out.
@@ -126,7 +124,7 @@ char *ng_netif_addr_to_str(char *out, size_t out_len, uint8_t *addr,
  * @return  Actual length of @p out on success.
  * @return  0, on failure.
  */
-size_t ng_netif_addr_from_str(uint8_t *out, size_t out_len, char *str);
+size_t ng_netif_addr_from_str(uint8_t *out, size_t out_len, const char *str);
 
 #ifdef __cplusplus
 }

--- a/sys/net/crosslayer/ng_netif/ng_netif_addr_to_str.c
+++ b/sys/net/crosslayer/ng_netif/ng_netif_addr_to_str.c
@@ -19,7 +19,7 @@ static inline char _half_byte_to_char(uint8_t half_byte)
     return (half_byte < 10) ? ('0' + half_byte) : ('a' + (half_byte - 10));
 }
 
-char *ng_netif_addr_to_str(char *out, size_t out_len, uint8_t *addr,
+char *ng_netif_addr_to_str(char *out, size_t out_len, const uint8_t *addr,
                            size_t addr_len)
 {
     size_t i;

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.tests_common
 BOARD_INSUFFICIENT_RAM := airfy-beacon chronos msb-430 msb-430h pca10000 \
                           pca10005 redbee-econotag spark-core stm32f0discovery \
                           telosb wsn430-v1_3b wsn430-v1_4 z1 nucleo-f334 \
-                          yunjia-nrf51822 samr21-xpro
+                          yunjia-nrf51822 samr21-xpro arduino-mega2560
 
 USEMODULE += embunit
 

--- a/tests/unittests/tests-netif/tests-netif.c
+++ b/tests/unittests/tests-netif/tests-netif.c
@@ -184,12 +184,15 @@ static void test_ng_netif_addr_from_str__out_too_short(void)
     TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
 }
 
-static void test_ng_netif_addr_from_str__ill_formated1(void)
+static void test_ng_netif_addr_from_str__omitted_delimitter(void)
 {
-    static const char str[] = "576:cd";
-    uint8_t out[sizeof(str)];
+    static const char str[] = "4567:cd";
+    uint8_t out[3];
 
-    TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
+    TEST_ASSERT_EQUAL_INT(3, ng_netif_addr_from_str(out, sizeof(out), str));
+    TEST_ASSERT_EQUAL_INT(0x45, out[0]);
+    TEST_ASSERT_EQUAL_INT(0x67, out[1]);
+    TEST_ASSERT_EQUAL_INT(0xcd, out[2]);
 }
 
 static void test_ng_netif_addr_from_str__ill_formated2(void)
@@ -200,33 +203,55 @@ static void test_ng_netif_addr_from_str__ill_formated2(void)
     TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
 }
 
-static void test_ng_netif_addr_from_str__ill_formated3(void)
+static void test_ng_netif_addr_from_str__dash_delimitter(void)
 {
     static const char str[] = "05-cd";
-    uint8_t out[sizeof(str)];
+    uint8_t out[2];
 
-    TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
+    TEST_ASSERT_EQUAL_INT(2, ng_netif_addr_from_str(out, sizeof(out), str));
+    TEST_ASSERT_EQUAL_INT(0x05, out[0]);
+    TEST_ASSERT_EQUAL_INT(0xcd, out[1]);
 }
 
-static void test_ng_netif_addr_from_str__ill_formated4(void)
+static void test_ng_netif_addr_from_str__zero_omitted_back(void)
 {
     static const char str[] = "05:c";
-    uint8_t out[sizeof(str)];
+    uint8_t out[2];
 
-    TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
+    TEST_ASSERT_EQUAL_INT(2, ng_netif_addr_from_str(out, sizeof(out), str));
+    TEST_ASSERT_EQUAL_INT(0x05, out[0]);
+    TEST_ASSERT_EQUAL_INT(0x0c, out[1]);
 }
 
-static void test_ng_netif_addr_from_str__ill_formated5(void)
+static void test_ng_netif_addr_from_str__zero_omitted_front(void)
 {
     static const char str[] = "5:cd";
+    uint8_t out[2];
+
+    TEST_ASSERT_EQUAL_INT(2, ng_netif_addr_from_str(out, sizeof(out), str));
+    TEST_ASSERT_EQUAL_INT(0x05, out[0]);
+    TEST_ASSERT_EQUAL_INT(0xcd, out[1]);
+}
+
+static void test_ng_netif_addr_from_str__ill_trailing_delimitter(void)
+{
+    static const char str[] = "05:cd:";
     uint8_t out[sizeof(str)];
 
     TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
 }
 
-static void test_ng_netif_addr_from_str__ill_formated6(void)
+static void test_ng_netif_addr_from_str__ill_leading_delimitter(void)
 {
-    static const char str[] = "05:cd:";
+    static const char str[] = ":05:cd";
+    uint8_t out[sizeof(str)];
+
+    TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
+}
+
+static void test_ng_netif_addr_from_str__ill_extra_delimitter(void)
+{
+    static const char str[] = "05::cd";
     uint8_t out[sizeof(str)];
 
     TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
@@ -258,12 +283,14 @@ Test *tests_netif_tests(void)
         new_TestFixture(test_ng_netif_addr_to_str__out_too_short),
         new_TestFixture(test_ng_netif_addr_to_str__success),
         new_TestFixture(test_ng_netif_addr_from_str__out_too_short),
-        new_TestFixture(test_ng_netif_addr_from_str__ill_formated1),
+        new_TestFixture(test_ng_netif_addr_from_str__omitted_delimitter),
         new_TestFixture(test_ng_netif_addr_from_str__ill_formated2),
-        new_TestFixture(test_ng_netif_addr_from_str__ill_formated3),
-        new_TestFixture(test_ng_netif_addr_from_str__ill_formated4),
-        new_TestFixture(test_ng_netif_addr_from_str__ill_formated5),
-        new_TestFixture(test_ng_netif_addr_from_str__ill_formated6),
+        new_TestFixture(test_ng_netif_addr_from_str__dash_delimitter),
+        new_TestFixture(test_ng_netif_addr_from_str__zero_omitted_back),
+        new_TestFixture(test_ng_netif_addr_from_str__zero_omitted_front),
+        new_TestFixture(test_ng_netif_addr_from_str__ill_trailing_delimitter),
+        new_TestFixture(test_ng_netif_addr_from_str__ill_leading_delimitter),
+        new_TestFixture(test_ng_netif_addr_from_str__ill_extra_delimitter),
         new_TestFixture(test_ng_netif_addr_from_str__success),
     };
 

--- a/tests/unittests/tests-netif/tests-netif.c
+++ b/tests/unittests/tests-netif/tests-netif.c
@@ -208,6 +208,30 @@ static void test_ng_netif_addr_from_str__ill_formated3(void)
     TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
 }
 
+static void test_ng_netif_addr_from_str__ill_formated4(void)
+{
+    char str[] = "05:c";
+    uint8_t out[sizeof(str)];
+
+    TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
+}
+
+static void test_ng_netif_addr_from_str__ill_formated5(void)
+{
+    char str[] = "5:cd";
+    uint8_t out[sizeof(str)];
+
+    TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
+}
+
+static void test_ng_netif_addr_from_str__ill_formated6(void)
+{
+    char str[] = "05:cd:";
+    uint8_t out[sizeof(str)];
+
+    TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
+}
+
 static void test_ng_netif_addr_from_str__success(void)
 {
     char str[] = "05:cd";
@@ -237,6 +261,9 @@ Test *tests_netif_tests(void)
         new_TestFixture(test_ng_netif_addr_from_str__ill_formated1),
         new_TestFixture(test_ng_netif_addr_from_str__ill_formated2),
         new_TestFixture(test_ng_netif_addr_from_str__ill_formated3),
+        new_TestFixture(test_ng_netif_addr_from_str__ill_formated4),
+        new_TestFixture(test_ng_netif_addr_from_str__ill_formated5),
+        new_TestFixture(test_ng_netif_addr_from_str__ill_formated6),
         new_TestFixture(test_ng_netif_addr_from_str__success),
     };
 

--- a/tests/unittests/tests-netif/tests-netif.c
+++ b/tests/unittests/tests-netif/tests-netif.c
@@ -161,7 +161,7 @@ static void test_ng_netif_get__full(void)
 
 static void test_ng_netif_addr_to_str__out_too_short(void)
 {
-    uint8_t addr[] = {0x05, 0xcd};
+    static const uint8_t addr[] = {0x05, 0xcd};
     char out[2];
 
     TEST_ASSERT_NULL(ng_netif_addr_to_str(out, sizeof(out), addr, sizeof(addr)));
@@ -169,7 +169,7 @@ static void test_ng_netif_addr_to_str__out_too_short(void)
 
 static void test_ng_netif_addr_to_str__success(void)
 {
-    uint8_t addr[] = {0x05, 0xcd};
+    static const uint8_t addr[] = {0x05, 0xcd};
     char out[3 * sizeof(addr)];
 
     TEST_ASSERT_EQUAL_STRING("05:cd", ng_netif_addr_to_str(out, sizeof(out),
@@ -178,7 +178,7 @@ static void test_ng_netif_addr_to_str__success(void)
 
 static void test_ng_netif_addr_from_str__out_too_short(void)
 {
-    char str[] = "05:cd";
+    static const char str[] = "05:cd";
     uint8_t out[1];
 
     TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
@@ -186,7 +186,7 @@ static void test_ng_netif_addr_from_str__out_too_short(void)
 
 static void test_ng_netif_addr_from_str__ill_formated1(void)
 {
-    char str[] = "576:cd";
+    static const char str[] = "576:cd";
     uint8_t out[sizeof(str)];
 
     TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
@@ -194,7 +194,7 @@ static void test_ng_netif_addr_from_str__ill_formated1(void)
 
 static void test_ng_netif_addr_from_str__ill_formated2(void)
 {
-    char str[] = TEST_STRING8;
+    static const char str[] = TEST_STRING8;
     uint8_t out[sizeof(str)];
 
     TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
@@ -202,7 +202,7 @@ static void test_ng_netif_addr_from_str__ill_formated2(void)
 
 static void test_ng_netif_addr_from_str__ill_formated3(void)
 {
-    char str[] = "05-cd";
+    static const char str[] = "05-cd";
     uint8_t out[sizeof(str)];
 
     TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
@@ -210,7 +210,7 @@ static void test_ng_netif_addr_from_str__ill_formated3(void)
 
 static void test_ng_netif_addr_from_str__ill_formated4(void)
 {
-    char str[] = "05:c";
+    static const char str[] = "05:c";
     uint8_t out[sizeof(str)];
 
     TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
@@ -218,7 +218,7 @@ static void test_ng_netif_addr_from_str__ill_formated4(void)
 
 static void test_ng_netif_addr_from_str__ill_formated5(void)
 {
-    char str[] = "5:cd";
+    static const char str[] = "5:cd";
     uint8_t out[sizeof(str)];
 
     TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
@@ -226,7 +226,7 @@ static void test_ng_netif_addr_from_str__ill_formated5(void)
 
 static void test_ng_netif_addr_from_str__ill_formated6(void)
 {
-    char str[] = "05:cd:";
+    static const char str[] = "05:cd:";
     uint8_t out[sizeof(str)];
 
     TEST_ASSERT_EQUAL_INT(0, ng_netif_addr_from_str(out, sizeof(out), str));
@@ -234,7 +234,7 @@ static void test_ng_netif_addr_from_str__ill_formated6(void)
 
 static void test_ng_netif_addr_from_str__success(void)
 {
-    char str[] = "05:cd";
+    static const char str[] = "05:cd";
     uint8_t out[2];
 
     TEST_ASSERT_EQUAL_INT(2, ng_netif_addr_from_str(out, sizeof(out), str));


### PR DESCRIPTION
There is no need for `ng_netif_addr_to_str` to destroy its input.