### PR TITLE
sys/auto_init: added mechanism for initialization of network devices

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -48,6 +48,14 @@ ifneq (,$(filter sixlowpan,$(USEMODULE)))
   USEMODULE += vtimer
 endif
 
+ifneq (,$(filter ng_netif,$(USEMODULE)))
+  USEMODULE += ng_netbase
+endif
+
+ifneq (,$(filter ng_nomac,$(USEMODULE)))
+  USEMODULE += ng_netbase
+endif
+
 ifneq (,$(filter ng_sixlowpan_frag,$(USEMODULE)))
   USEMODULE += ng_sixlowpan
   USEMODULE += vtimer

--- a/Makefile.include
+++ b/Makefile.include
@@ -16,7 +16,10 @@ RIOTPROJECT := $(abspath $(RIOTPROJECT))
 # Path to the current directory relative to the git root
 BUILDRELPATH ?= $(shell git rev-parse --show-prefix)
 
-BINDIRBASE ?= $(CURDIR)/bin
+APPDIR ?= $(CURDIR)
+APPDIR := $(abspath $(APPDIR))/
+
+BINDIRBASE ?= $(APPDIR)/bin
 BINDIRBASE := $(abspath $(BINDIRBASE))
 
 BINDIR ?= $(BINDIRBASE)/$(BOARD)

--- a/Makefile.vars
+++ b/Makefile.vars
@@ -19,6 +19,7 @@ export RIOTBOARD             # For third party BOARDs this folder is the base of
 export RIOTPROJECT           # Top level git root of the project being built, or PWD if not a git repository
 export BINDIRBASE            # This is the folder where the application should be built in. For each BOARD a different subfolder is used.
 export BINDIR                # This is the folder where the application should be built in.
+export APPDIR                # The base folder containing the application
 
 export PREFIX                # The prefix of the toolchain commands, e.g. "arm-non-eabi-" or "msp430-".
 export CC                    # The C compiler to use.

--- a/boards/iot-lab_M3/Makefile.dep
+++ b/boards/iot-lab_M3/Makefile.dep
@@ -4,3 +4,8 @@ ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
         USEMODULE += transceiver
     endif
 endif
+
+ifneq (,$(filter ng_netif,$(USEMODULE)))
+  USEMODULE += ng_at86rf231
+  USEMODULE += ng_nomac
+endif

--- a/boards/iot-lab_M3/auto_init_ng_netif/Makefile
+++ b/boards/iot-lab_M3/auto_init_ng_netif/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/boards/iot-lab_M3/auto_init_ng_netif/netif_board.c
+++ b/boards/iot-lab_M3/auto_init_ng_netif/netif_board.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_iot-lab_M3
+ * @{
+ *
+ * @file
+ * @brief       Network device initialization code
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "board.h"
+#include "auto_init.h"
+#include "ng_at86rf2xx.h"
+#include "net/ng_nomac.h"
+#include "net/ng_netbase.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+/**
+ * @brief   Define stack parameters for the MAC layer thread
+ * @{
+ */
+#define MAC_STACKSIZE           (KERNEL_CONF_STACKSIZE_DEFAULT)
+#define MAC_PRIO                (PRIORITY_MAIN - 3)
+/** @} */
+
+/**
+ * @brief   Device descriptor for the Atmel radio
+ */
+static ng_at86rf2xx_t radio;
+
+/**
+ * @brief   Stack for the MAC layer thread
+ */
+static char nomac_stack[MAC_STACKSIZE];
+
+
+void auto_init_ng_netif(void)
+{
+    /* initialize the radio */
+    DEBUG("Initializing AT86RF231 radio\n");
+    ng_at86rf2xx_init(&radio, AT86RF231_SPI, AT86RF231_SPI_CLK,
+                      AT86RF231_CS, AT86RF231_INT,
+                      AT86RF231_SLEEP, AT86RF231_RESET);
+    /* starting NOMAC */
+    DEBUG("Starting the MAC layer\n");
+    ng_nomac_init(nomac_stack, sizeof(nomac_stack), MAC_PRIO, "at86rf233",
+                  (ng_netdev_t *)(&radio));
+    DEBUG("Auto init of on-board radio complete\n");
+}

--- a/boards/iot-lab_M3/include/board.h
+++ b/boards/iot-lab_M3/include/board.h
@@ -68,6 +68,7 @@ extern "C" {
 #define AT86RF231_INT       GPIO_12
 #define AT86RF231_RESET     GPIO_13
 #define AT86RF231_SLEEP     GPIO_14
+#define AT86RF231_SPI_CLK   SPI_SPEED_5MHZ
 /** @} */
 
 /**

--- a/boards/samr21-xpro/Makefile.dep
+++ b/boards/samr21-xpro/Makefile.dep
@@ -4,3 +4,8 @@ ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
         USEMODULE += transceiver
     endif
 endif
+
+ifneq (,$(filter ng_netif,$(USEMODULE)))
+  USEMODULE += ng_at86rf233
+  USEMODULE += ng_nomac
+endif

--- a/boards/samr21-xpro/auto_init_ng_netif/Makefile
+++ b/boards/samr21-xpro/auto_init_ng_netif/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/boards/samr21-xpro/auto_init_ng_netif/netif_board.c
+++ b/boards/samr21-xpro/auto_init_ng_netif/netif_board.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_samr21-xpro
+ * @{
+ *
+ * @file
+ * @brief       Network device initialization code
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "board.h"
+#include "auto_init.h"
+#include "ng_at86rf2xx.h"
+#include "net/ng_nomac.h"
+#include "net/ng_netbase.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+/**
+ * @brief   Define stack parameters for the MAC layer thread
+ * @{
+ */
+#define MAC_STACKSIZE           (KERNEL_CONF_STACKSIZE_DEFAULT)
+#define MAC_PRIO                (PRIORITY_MAIN - 3)
+/** @} */
+
+/**
+ * @brief   Device descriptor for the Atmel radio
+ */
+static ng_at86rf2xx_t radio;
+
+/**
+ * @brief   Stack for the MAC layer thread
+ */
+static char nomac_stack[MAC_STACKSIZE];
+
+void auto_init_ng_netif(void)
+{
+    /* initialize the radio */
+    DEBUG("Initializing AT86RF233 radio\n");
+    ng_at86rf2xx_init(&radio, NG_AT86RF233_SPI, NG_AT86RF233_SPI_CLK,
+                      NG_AT86RF233_CS, NG_AT86RF233_INT,
+                      NG_AT86RF233_SLEEP, NG_AT86RF233_RESET);
+    /* starting NOMAC */
+    DEBUG("Starting the MAC layer\n");
+    ng_nomac_init(nomac_stack, sizeof(nomac_stack), MAC_PRIO, "at86rf233",
+                  (ng_netdev_t *)(&radio));
+    DEBUG("Auto init of on-board radio complete\n");
+}

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -38,6 +38,18 @@ extern "C" {
 #define HW_TIMER            TIMER_1
 
 /**
+* @name NG_AT86RF233 configuration
+* @{
+*/
+#define NG_AT86RF233_SPI        (SPI_0)
+#define NG_AT86RF233_CS         (GPIO_4)
+#define NG_AT86RF233_INT        (GPIO_5)
+#define NG_AT86RF233_RESET      (GPIO_6)
+#define NG_AT86RF233_SLEEP      (GPIO_7)
+#define NG_AT86RF233_SPI_CLK    (SPI_SPEED_1MHZ)
+/** @}*/
+
+/**
 * @name AT86RF231 config
 * @{
 */
@@ -48,7 +60,8 @@ extern "C" {
 #define AT86RF231_SLEEP    GPIO_7
 
 #define AT86RF231_SPI_SPEED SPI_SPEED_1MHZ
-/** @}*/
+/** @} */
+
 /**
  * @name Define UART device and baudrate for stdio
  * @{

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -1,3 +1,6 @@
+ifneq (,$(filter auto_init,$(USEMODULE)))
+    include $(RIOTBASE)/sys/auto_init/Makefile.include
+endif
 ifneq (,$(filter nomac,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include
 endif

--- a/sys/auto_init/Makefile
+++ b/sys/auto_init/Makefile
@@ -6,4 +6,6 @@ ifneq (,$(filter nomac,$(USEMODULE)))
 	INCLUDES += -I$(RIOTBASE)/sys/net/include/
 endif
 
+DIRS += $(AUTO_INIT_MODULES)
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/auto_init/Makefile.include
+++ b/sys/auto_init/Makefile.include
@@ -1,0 +1,13 @@
+# try to find the ng_netif auto init implementation in the application or in
+# the board, respectively. If it is not found, nothing is called.
+ifneq (,$(filter ng_netif,$(USEMODULE)))
+  ifneq (,$(wildcard $(APPDIR)/auto_init_ng_netif/*))
+    export AUTO_INIT_MODULES += $(APPDIR)/auto_init_ng_netif
+    export USEMODULE += auto_init_ng_netif
+  else
+    ifneq (,$(wildcard $(RIOTBOARD)/$(BOARD)/auto_init_ng_netif/*))
+      export AUTO_INIT_MODULES += $(RIOTBOARD)/$(BOARD)/auto_init_ng_netif
+      export USEMODULE += auto_init_ng_netif
+    endif
+  endif
+endif

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -12,6 +12,7 @@
  * @file    auto_init_c
  * @brief   initializes any used module that has a trivial init function
  * @author  Oliver Hahm <oliver.hahm@inria.fr>
+ * @author  Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @}
  */
 #include <stdint.h>
@@ -303,5 +304,9 @@ void auto_init(void)
 #ifdef MODULE_NG_UDP
     DEBUG("Auto init UDP module.\n");
     ng_udp_init();
+#endif
+#ifdef MODULE_AUTO_INIT_NG_NETIF
+    DEBUG("Auto init network interfaces.\n");
+    auto_init_ng_netif();
 #endif
 }

--- a/sys/include/auto_init.h
+++ b/sys/include/auto_init.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Freie Universität Berlin
+ * Copyright (C) 2010,2015 Freie Universität Berlin
  * Copyright (C) 2010 Kaspar Schleiser
  * Copyright (C) 2013 INRIA
  *
@@ -27,6 +27,10 @@
  * @{
  *
  * @file        auto_init.h
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
 #ifndef AUTO_INIT_H
@@ -44,6 +48,22 @@ extern "C" {
  *        kernel_init right before jumping into @e main.
  */
 void auto_init(void);
+
+/**
+ * @brief Initialize network interfaces and register them with ng_netif
+ *
+ *        This function must be implemented in the board or in the application,
+ *        in a subfolder that must be named auto_init_ng_netif
+ *        This function is called under two conditions:
+ *          1. the ng_netif module is used (USEMODULE contains ng_netif)
+ *          2. the board or the application contains a subfolder called
+ *             auto_init_ng_netif
+ *        If the board and the application both contain the mentioned subfolder,
+ *        the contents from the applications subfolder have a higher priority
+ *        and will be compiled and linked, while the board's subfolder is then
+ *        ignored.
+ */
+void auto_init_ng_netif(void);
 
 #ifdef __cplusplus
 }

--- a/tests/driver_at86rf2xx/Makefile
+++ b/tests/driver_at86rf2xx/Makefile
@@ -39,7 +39,7 @@ ifneq (,$(DRIVER))
 else
   USEMODULE += ng_at86rf231         # default to ng_at86rf231
 endif
-USEMODULE += ng_netbase
+USEMODULE += ng_netif
 USEMODULE += ng_nomac
 USEMODULE += ng_pktdump
 USEMODULE += uart0

--- a/tests/driver_at86rf2xx/auto_init_ng_netif/Makefile
+++ b/tests/driver_at86rf2xx/auto_init_ng_netif/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/driver_at86rf2xx/auto_init_ng_netif/netif_app.c
+++ b/tests/driver_at86rf2xx/auto_init_ng_netif/netif_app.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for AT86RF2xx network device driver
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "kernel.h"
+#include "ng_at86rf2xx.h"
+#include "net/ng_nomac.h"
+#include "net/ng_netbase.h"
+
+/* make sure the SPI port and the needed GPIO pins are defined */
+#ifndef ATRF_SPI
+#error "SPI not defined"
+#endif
+#ifndef ATRF_CS
+#error "Chip select pin not defined"
+#endif
+#ifndef ATRF_INT
+#error "Interrupt pin not defined"
+#endif
+#ifndef ATRF_SLEEP
+#error "Sleep pin not defined"
+#endif
+#ifndef ATRF_RESET
+#error "Reset pin not defined"
+#endif
+#ifndef ATRF_SPI_SPEED
+#define ATRF_SPI_SPEED          (SPI_SPEED_5MHZ)
+#endif
+
+/**
+ * @brief   MAC layer stack configuration
+ * @{
+ */
+#define STACKSIZE               (KERNEL_CONF_STACKSIZE_MAIN)
+#define PRIO                    (0)
+/** @} */
+
+/**
+ * @brief   Allocate the AT86RF2xx device descriptor
+ */
+static ng_at86rf2xx_t dev;
+
+/**
+ * @brief   Stack for the nomac thread
+ */
+static char nomac_stack[STACKSIZE];
+
+
+void auto_init_ng_netif(void)
+{
+    kernel_pid_t iface;
+    int res;
+
+    /* initialize the AT86RF2xx device */
+    printf("Initializing the AT86RF2xx radio at SPI_%i... \n", ATRF_SPI);
+    res = ng_at86rf2xx_init(&dev, ATRF_SPI, ATRF_SPI_SPEED,
+                            ATRF_CS, ATRF_INT,
+                            ATRF_SLEEP, ATRF_RESET);
+    if (res < 0) {
+        puts("Error initializing AT86RF2xx radio device");
+        return;
+    }
+
+    /* start MAC layer */
+    puts("Starting the NOMAC layer on top of the driver");
+    iface = ng_nomac_init(nomac_stack, sizeof(nomac_stack), PRIO, "at86rf2xx",
+                          (ng_netdev_t *)(&dev));
+    if (iface <= KERNEL_PID_UNDEF) {
+        puts("Error initializing MAC layer");
+        return;
+    }
+
+}

--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -20,51 +20,18 @@
 
 #include <stdio.h>
 
-#include "board.h"
-#include "kernel.h"
+
 #include "shell.h"
 #include "shell_commands.h"
 #include "posix_io.h"
 #include "board_uart0.h"
-#include "ng_at86rf2xx.h"
-#include "net/ng_netbase.h"
-#include "net/ng_nomac.h"
 #include "net/ng_pktdump.h"
-
-/* make sure the SPI port and the needed GPIO pins are defined */
-#ifndef ATRF_SPI
-#error "SPI not defined"
-#endif
-#ifndef ATRF_CS
-#error "Chip select pin not defined"
-#endif
-#ifndef ATRF_INT
-#error "Interrupt pin not defined"
-#endif
-#ifndef ATRF_SLEEP
-#error "Sleep pin not defined"
-#endif
-#ifndef ATRF_RESET
-#error "Reset pin not defined"
-#endif
-#ifndef ATRF_SPI_SPEED
-#define ATRF_SPI_SPEED          (SPI_SPEED_5MHZ)
-#endif
+#include "net/ng_netbase.h"
 
 /**
  * @brief   Buffer size used by the shell
  */
 #define SHELL_BUFSIZE           (64U)
-
-/**
- * @brief   Allocate the AT86RF2xx device descriptor
- */
-static ng_at86rf2xx_t dev;
-
-/**
- * @brief   Stack for the nomac thread
- */
-static char nomac_stack[KERNEL_CONF_STACKSIZE_MAIN];
 
 /**
  * @brief   Read chars from STDIO
@@ -89,38 +56,16 @@ void shell_put(int c)
  */
 int main(void)
 {
-    kernel_pid_t iface;
-    int res;
     shell_t shell;
     ng_netreg_entry_t dump;
 
     puts("AT86RF2xx device driver test");
-    printf("Initializing the radio at SPI_%i... \n", ATRF_SPI);
 
     /* register the pktdump thread */
     puts("Register the packet dump thread for NG_NETTYPE_UNDEF packets");
     dump.pid = ng_pktdump_getpid();
     dump.demux_ctx = NG_NETREG_DEMUX_CTX_ALL;
     ng_netreg_register(NG_NETTYPE_UNDEF, &dump);
-
-    /* initialize the AT86RF2xx device */
-    puts("Initialize the AT86RF2xx radio device");
-    res = ng_at86rf2xx_init(&dev, ATRF_SPI, ATRF_SPI_SPEED,
-                            ATRF_CS, ATRF_INT,
-                            ATRF_SLEEP, ATRF_RESET);
-    if (res < 0) {
-        puts("Error initializing AT86RF2xx radio device");
-        return -1;
-    }
-
-    /* start MAC layer */
-    puts("Starting the NOMAC layer on top of the driver");
-    iface = ng_nomac_init(nomac_stack, sizeof(nomac_stack), PRIORITY_MAIN - 3,
-                          "at86rf2xx", (ng_netdev_t *)&dev);
-    if (iface <= KERNEL_PID_UNDEF) {
-        puts("Error initializing MAC layer");
-        return -1;
-    }
 
     /* start the shell */
     puts("Initialization successful - starting the shell now");

--- a/tests/driver_xbee/Makefile
+++ b/tests/driver_xbee/Makefile
@@ -17,7 +17,7 @@ ifneq (,$(filter nucleo-f091,$(BOARD)))
 endif
 
 USEMODULE += xbee
-USEMODULE += ng_netbase
+USEMODULE += ng_netif
 USEMODULE += ng_nomac
 USEMODULE += ng_pktdump
 USEMODULE += shell

--- a/tests/driver_xbee/auto_init_ng_netif/Makefile
+++ b/tests/driver_xbee/auto_init_ng_netif/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/driver_xbee/auto_init_ng_netif/netif_app.c
+++ b/tests/driver_xbee/auto_init_ng_netif/netif_app.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Xbee device initialization
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "kernel.h"
+#include "xbee.h"
+#include "net/ng_nomac.h"
+#include "net/ng_netbase.h"
+
+/* make sure an UART to device is defined in the Makefile */
+#ifndef XBEE_UART
+#error "XBEE_UART not defined"
+#endif
+
+/**
+ * @brief   This is the default baudrate the Xbee modules are programmed to
+ *          when you buy them
+ */
+#define XBEE_BAUDRATE           (9600U)
+
+/**
+ * @brief   MAC layer stack configuration
+ * @{
+ */
+#define STACKSIZE               (KERNEL_CONF_STACKSIZE_DEFAULT)
+#define PRIO                    (0)
+/** @} */
+
+/**
+ * @brief   The Xbee device descriptor
+ */
+static xbee_t dev;
+
+/**
+ * @brief   Stack for the nomac thread
+ */
+static char nomac_stack[STACKSIZE];
+
+
+void auto_init_ng_netif(void)
+{
+    int res;
+    kernel_pid_t iface;
+
+    /* setup Xbee device */
+    printf("Initializing the Xbee S1 device UART_%i... \n", XBEE_UART);
+    res = xbee_init(&dev, XBEE_UART, XBEE_BAUDRATE, GPIO_NUMOF, GPIO_NUMOF);
+    if (res < 0) {
+        puts("Error initializing xbee device driver");
+        return;
+    }
+    /* start MAC layer */
+    iface = ng_nomac_init(nomac_stack, sizeof(nomac_stack), PRIO, "xbee",
+                          (ng_netdev_t *)(&dev));
+    if (iface <= KERNEL_PID_UNDEF) {
+        puts("Error initializing MAC layer");
+        return;
+    }
+}

--- a/tests/driver_xbee/main.c
+++ b/tests/driver_xbee/main.c
@@ -20,40 +20,15 @@
 
 #include <stdio.h>
 
-#include "board.h"
-#include "kernel.h"
 #include "shell.h"
 #include "shell_commands.h"
-#include "xbee.h"
 #include "net/ng_netbase.h"
-#include "net/ng_nomac.h"
 #include "net/ng_pktdump.h"
-
-/* make sure an UART to device is defined in the Makefile */
-#ifndef XBEE_UART
-#error "XBEE_UART not defined"
-#endif
-
-/**
- * @brief   This is the default baudrate the Xbee modules are programmed to
- *          when you buy them
- */
-#define XBEE_BAUDRATE           (9600U)
 
 /**
  * @brief   Buffer size used by the shell
  */
 #define SHELL_BUFSIZE           (64U)
-
-/**
- * @brief   The Xbee device descriptor
- */
-static xbee_t dev;
-
-/**
- * @brief   Stack for the nomac thread
- */
-static char nomac_stack[KERNEL_CONF_STACKSIZE_DEFAULT];
 
 /**
  * @brief   Read chars from STDIO
@@ -76,16 +51,10 @@ void shell_put(int c)
  */
 int main(void)
 {
-    kernel_pid_t iface;
-    int res;
     shell_t shell;
     ng_netreg_entry_t dump;
 
     puts("Xbee S1 device driver test");
-    printf("Initializing the Xbee S1 device UART_%i... \n", XBEE_UART);
-
-    /* initialize network module(s) */
-    ng_netif_init();
 
     /* initialize and register pktdump */
     dump.pid = ng_pktdump_getpid();
@@ -95,20 +64,6 @@ int main(void)
     }
     dump.demux_ctx = NG_NETREG_DEMUX_CTX_ALL;
     ng_netreg_register(NG_NETTYPE_UNDEF, &dump);
-
-    /* setup Xbee device */
-    res = xbee_init(&dev, XBEE_UART, XBEE_BAUDRATE, GPIO_NUMOF, GPIO_NUMOF);
-    if (res < 0) {
-        puts("Error initializing xbee device driver");
-        return -1;
-    }
-    /* start MAC layer */
-    iface = ng_nomac_init(nomac_stack, sizeof(nomac_stack), PRIORITY_MAIN - 3,
-                          "xbee_l2", (ng_netdev_t *)&dev);
-    if (iface <= KERNEL_PID_UNDEF) {
-        puts("Error initializing MAC layer");
-        return -1;
-    }
 
     /* start the shell */
     puts("Initialization OK, starting shell now");


### PR DESCRIPTION
This PR introduces a mechanism, that allows for auto-configuration of network interfaces. The configuration is normally done by each board (of course it is interesting only for those that have network interfaces), but can be overwritten by the application (may you want a different MAC layer...).