### PR TITLE
ng_netapi: centralize packet dispatchment for RCV and SND

### DIFF
--- a/sys/include/net/ng_netapi.h
+++ b/sys/include/net/ng_netapi.h
@@ -31,6 +31,7 @@
 #include "kernel.h"
 #include "thread.h"
 #include "net/ng_netconf.h"
+#include "net/ng_nettype.h"
 #include "net/ng_pkt.h"
 
 #ifdef __cplusplus
@@ -84,6 +85,19 @@ typedef struct {
 int ng_netapi_send(kernel_pid_t pid, ng_pktsnip_t *pkt);
 
 /**
+ * @brief   Sends a @ref NG_NETAPI_MSG_TYPE_SND command to all subscribers to
+ *          (@p type, @p demux_ctx).
+ *
+ * @param[in] type      type of the targeted network module.
+ * @param[in] demux_ctx demultiplexing context for @p type.
+ * @param[in] pkt       pointer into the packet buffer holding the data to send
+ *
+ * @return Number of subscribers to (@p type, @p demux_ctx).
+ */
+int ng_netapi_dispatch_send(ng_nettype_t type, uint32_t demux_ctx,
+                            ng_pktsnip_t *pkt);
+
+/**
  * @brief   Shortcut function for sending @ref NG_NETAPI_MSG_TYPE_RCV messages
  *
  * @param[in] pid       PID of the targeted network module
@@ -93,6 +107,19 @@ int ng_netapi_send(kernel_pid_t pid, ng_pktsnip_t *pkt);
  * @return              -1 on error (invalid PID or no space in queue)
  */
 int ng_netapi_receive(kernel_pid_t pid, ng_pktsnip_t *pkt);
+
+/**
+ * @brief   Sends a @ref NG_NETAPI_MSG_TYPE_RCV command to all subscribers to
+ *          (@p type, @p demux_ctx).
+ *
+ * @param[in] type      type of the targeted network module.
+ * @param[in] demux_ctx demultiplexing context for @p type.
+ * @param[in] pkt       pointer into the packet buffer holding the data to send
+ *
+ * @return Number of subscribers to (@p type, @p demux_ctx).
+ */
+int ng_netapi_dispatch_receive(ng_nettype_t type, uint32_t demux_ctx,
+                               ng_pktsnip_t *pkt);
 
 /**
  * @brief   Shortcut function for sending @ref NG_NETAPI_MSG_TYPE_GET messages and

--- a/sys/net/network_layer/ng_sixlowpan/ng_sixlowpan.c
+++ b/sys/net/network_layer/ng_sixlowpan/ng_sixlowpan.c
@@ -57,7 +57,6 @@ static void _receive(ng_pktsnip_t *pkt)
 {
     ng_pktsnip_t *payload;
     uint8_t *dispatch;
-    ng_netreg_entry_t *entry;
 
     /* seize payload as a temporary variable */
     payload = ng_pktbuf_start_write(pkt);   /* need to duplicate since pkt->next
@@ -138,21 +137,9 @@ static void _receive(ng_pktsnip_t *pkt)
 
     payload->type = NG_NETTYPE_IPV6;
 
-    entry = ng_netreg_lookup(NG_NETTYPE_IPV6, NG_NETREG_DEMUX_CTX_ALL);
-
-    if (entry == NULL) {
+    if (!ng_netapi_dispatch_receive(NG_NETTYPE_IPV6, NG_NETREG_DEMUX_CTX_ALL, pkt)) {
         DEBUG("ipv6: No receivers for this packet found\n");
         ng_pktbuf_release(pkt);
-        return;
-    }
-
-    ng_pktbuf_hold(pkt, ng_netreg_num(NG_NETTYPE_IPV6, NG_NETREG_DEMUX_CTX_ALL) - 1);
-
-    while (entry) {
-        DEBUG("6lo: Send receive command for %p to %" PRIu16 "\n",
-              (void *)pkt, entry->pid);
-        ng_netapi_receive(entry->pid, pkt);
-        entry = ng_netreg_getnext(entry);
     }
 }
 


### PR DESCRIPTION
Basically every layer does the 

```C
    sendto = ng_netreg_lookup(type, demux_ctx);

    ng_pktbuf_hold(pkt, numof - 1);

    while (sendto) {
        ng_netapi_*(sendto->pid, cmd, pkt);
        ng_netreg_getnext(sendto);
    }
```

bit. So I thought: why not centralize this. This PR does this ;-)