### PR TITLE
aodvv2: fix check for redundant RREQ

### DIFF
--- a/sys/net/routing/aodvv2/utils.c
+++ b/sys/net/routing/aodvv2/utils.c
@@ -117,7 +117,7 @@ bool rreqtable_is_redundant(struct aodvv2_packet_data *packet_data)
 {
     struct aodvv2_rreq_entry *comparable_rreq;
     timex_t now;
-    bool result;
+    bool result = false;
 
     mutex_lock(&rreqt_mutex);
     comparable_rreq = _get_comparable_rreq(packet_data);
@@ -125,7 +125,6 @@ bool rreqtable_is_redundant(struct aodvv2_packet_data *packet_data)
     /* if there is no comparable rreq stored, add one and return false */
     if (comparable_rreq == NULL) {
         _add_rreq(packet_data);
-        result = false;
     }
     else {
         int seqnum_comparison = seqnum_cmp(packet_data->origNode.seqnum, comparable_rreq->seqnum);
@@ -140,8 +139,9 @@ bool rreqtable_is_redundant(struct aodvv2_packet_data *packet_data)
         }
 
         if (seqnum_comparison == 1) {
-            /* Update RREQ table entry with new seqnum value */
+            /* Update RREQ table entry with new seqnum and metric value */
             comparable_rreq->seqnum = packet_data->origNode.seqnum;
+            comparable_rreq->metric = packet_data->origNode.metric;
         }
 
         /*
@@ -159,7 +159,6 @@ bool rreqtable_is_redundant(struct aodvv2_packet_data *packet_data)
         /* Since we've changed RREQ info, update the timestamp */
         vtimer_now(&now);
         comparable_rreq->timestamp = now;
-        result = true;
     }
 
     mutex_unlock(&rreqt_mutex);

--- a/sys/net/routing/aodvv2/utils.h
+++ b/sys/net/routing/aodvv2/utils.h
@@ -91,6 +91,7 @@ void rreqtable_init(void);
  * Check if a RREQ is redundant, i.e. was received from another node already.
  * Behaves as described in Sections 5.7. and 7.6.
  * @param packet_data  data of the RREQ in question
+ * @return             true if packet_data is redundant, false otherwise.
  */
 bool rreqtable_is_redundant(struct aodvv2_packet_data *packet_data);
 


### PR DESCRIPTION
``rreqtable_is_redundant()`` checks if the current RREQ is redundant (i.e. the same or a better RREQ has already been received from elsewhere). However, the current implementation *always* deems new RREQs redundant if the RREQ table already holds an entry with the same OrigAddr, TargAddr, and MetricType, even if said entry has a worse metric or sequence number. This PR fixes that.