### PR TITLE
openocd: return error if flashing went wrong

### DIFF
--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -152,7 +152,7 @@ do_flash() {
             ${OPENOCD_PRE_VERIFY_CMDS} \
             -c 'verify_image \"${HEXFILE}\"' \
             -c 'reset run' \
-            -c 'shutdown'"
+            -c 'shutdown'" &&
     echo 'Done flashing'
 }
 
@@ -182,7 +182,7 @@ do_flash_elf() {
             ${OPENOCD_PRE_VERIFY_CMDS} \
             -c 'verify_image \"${ELFFILE}\"' \
             -c 'reset run' \
-            -c 'shutdown'"
+            -c 'shutdown'" &&
     echo 'Done flashing'
 }
 


### PR DESCRIPTION
without this change, flashing with openocd always seems to succeed, even if it didn't.