### PR TITLE
ng_ipv6_ext: initial import of extension header handling (including RPL SRH)

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -112,6 +112,18 @@ ifneq (,$(filter ng_ipv6_hdr,$(USEMODULE)))
   USEMODULE += ng_pktbuf
 endif
 
+ifneq (,$(filter ng_rpl_srh,$(USEMODULE)))
+  USEMODULE += ng_ipv6_ext_rh
+endif
+
+ifneq (,$(filter ng_ipv6_ext_rh,$(USEMODULE)))
+  USEMODULE += ng_ipv6_ext
+endif
+
+ifneq (,$(filter ng_ipv6_ext,$(USEMODULE)))
+  USEMODULE += ng_ipv6
+endif
+
 ifneq (,$(filter ng_ipv6_router,$(USEMODULE)))
   USEMODULE += ng_ipv6
 endif

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -74,6 +74,9 @@ endif
 ifneq (,$(filter ng_ipv6_addr,$(USEMODULE)))
     DIRS += net/network_layer/ng_ipv6/addr
 endif
+ifneq (,$(filter ng_ipv6_ext,$(USEMODULE)))
+    DIRS += net/network_layer/ng_ipv6/ext
+endif
 ifneq (,$(filter ng_ipv6_hdr,$(USEMODULE)))
     DIRS += net/network_layer/ng_ipv6/hdr
 endif

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -77,6 +77,9 @@ endif
 ifneq (,$(filter ng_ipv6_ext,$(USEMODULE)))
     DIRS += net/network_layer/ng_ipv6/ext
 endif
+ifneq (,$(filter ng_ipv6_ext_rh,$(USEMODULE)))
+    DIRS += net/network_layer/ng_ipv6/ext/rh
+endif
 ifneq (,$(filter ng_ipv6_hdr,$(USEMODULE)))
     DIRS += net/network_layer/ng_ipv6/hdr
 endif

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -113,6 +113,9 @@ endif
 ifneq (,$(filter ng_pktbuf,$(USEMODULE)))
     DIRS += net/crosslayer/ng_pktbuf
 endif
+ifneq (,$(filter ng_rpl_srh,$(USEMODULE)))
+    DIRS += net/routing/ng_rpl/srh
+endif
 ifneq (,$(filter ng_sixlowpan,$(USEMODULE)))
     DIRS += net/network_layer/ng_sixlowpan
 endif

--- a/sys/include/net/ng_ipv6.h
+++ b/sys/include/net/ng_ipv6.h
@@ -33,6 +33,7 @@
 #include "thread.h"
 
 #include "net/ng_ipv6/addr.h"
+#include "net/ng_ipv6/ext.h"
 #include "net/ng_ipv6/hdr.h"
 #include "net/ng_ipv6/nc.h"
 #include "net/ng_ipv6/netif.h"

--- a/sys/include/net/ng_ipv6/ext.h
+++ b/sys/include/net/ng_ipv6/ext.h
@@ -32,6 +32,8 @@
 #include "kernel_types.h"
 #include "net/ng_pkt.h"
 
+#include "net/ng_ipv6/ext/rh.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/sys/include/net/ng_ipv6/ext.h
+++ b/sys/include/net/ng_ipv6/ext.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @defgroup    net_ng_ipv6_ext IPv6 extension headers.
+ * @ingroup     net_ng_ipv6
+ * @brief       Implementation of IPv6 extension headers
+ * @see <a href="https://tools.ietf.org/html/rfc2460#section-4">
+ *          RFC 2460, section 4
+ *      </a>
+ * @{
+ *
+ * @file
+ * @brief       Definititions for IPv6 extension headers
+ *
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+
+#ifndef NG_IPV6_EXT_H_
+#define NG_IPV6_EXT_H_
+
+#include <inttypes.h>
+#include <stdbool.h>
+
+#include "byteorder.h"
+#include "kernel_types.h"
+#include "net/ng_pkt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define NG_IPV6_EXT_LEN_UNIT    (8U)    /**< Unit in byte for the extension header's
+                                         *   length field */
+
+/**
+ * @brief   IPv6 extension headers.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc2460#section-4">
+ *          RFC 2460, section 4.1
+ *      </a>
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t nh;     /**< next header */
+    uint8_t len;    /**< length in 8 octets without first octet */
+} ng_ipv6_ext_t;
+
+/**
+ * @brief   Demultiplex extension headers according to @p nh.
+ *
+ * @internal
+ *
+ * @param[in] iface The receiving interface.
+ * @param[in] pkt   A packet.
+ * @param[in] nh    A protocol number (see @ref net_ng_protnum).
+ *
+ * @return  true, on success.
+ * @return  false, on failure.
+ */
+bool ng_ipv6_ext_demux(kernel_pid_t iface, ng_pktsnip_t *pkt,
+                       uint8_t nh);
+
+/**
+ * @brief   Gets the next extension header in a packet.
+ *
+ * @param[in] ext   The current extension header.
+ *
+ * @return  The next extension header.
+ */
+static inline ng_ipv6_ext_t *ng_ipv6_ext_get_next(ng_ipv6_ext_t *ext)
+{
+    return (ng_ipv6_ext_t *)((uint8_t *)(ext) +
+                             (ext->len * NG_IPV6_EXT_LEN_UNIT) +
+                             NG_IPV6_EXT_LEN_UNIT);
+}
+
+/**
+ * @brief   Builds an extension header for sending.
+ *
+ * @param[in] ipv6  The IPv6 header. Can be NULL.
+ * @param[in] next  The next header. Must be a successor to @p ipv6 if it is
+ *                  not NULL.
+ * @param[in] nh    @ref net_ng_protnum of the next header.
+ * @param[in] size  Size of the extension header.
+ *
+ * @return  The extension header on success.
+ * @return  NULL, on error.
+ */
+ng_pktsnip_t *ng_ipv6_ext_build(ng_pktsnip_t *ipv6, ng_pktsnip_t *next,
+                                uint8_t nh, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NG_IPV6_EXT_H_ */
+/**
+ * @}
+ */

--- a/sys/include/net/ng_ipv6/ext/rh.h
+++ b/sys/include/net/ng_ipv6/ext/rh.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_ng_ipv6_ext_rh  IPv6 routing header extension
+ * @ingroup     net_ng_ipv6_ext
+ * @brief       Implementation of IPv6 routing header extension.
+ * @{
+ *
+ * @file
+ * @brief   Routing extension header definitions.
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+#ifndef NG_IPV6_EXT_RH_H_
+#define NG_IPV6_EXT_RH_H_
+
+#include "net/ng_ipv6/addr.h"
+#include "net/ng_ipv6/hdr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   IPv6 routing extension header.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc2460#section-4.4">
+ *          RFC 2460, section 4.4
+ *      </a>
+ *
+ * @extends ng_ipv6_ext_t
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t nh;         /**< next header */
+    uint8_t len;        /**< length in 8 octets without first octet */
+    uint8_t type;       /**< identifier of a particular routing header type */
+    uint8_t seg_left;   /**< number of route segments remaining */
+} ng_ipv6_ext_rh_t;
+
+/**
+ * @brief   Extract next hop from the routing header of an IPv6 packet.
+ *
+ * @param[in] ipv6      An IPv6 packet.
+ *
+ * @return  next hop on success, on success
+ * @return  NULL, if not found.
+ */
+ng_ipv6_addr_t *ng_ipv6_ext_rh_next_hop(ng_ipv6_hdr_t *ipv6);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NG_IPV6_EXT_RH_H_ */
+/** @} */

--- a/sys/include/net/ng_protnum.h
+++ b/sys/include/net/ng_protnum.h
@@ -75,7 +75,7 @@ extern "C" {
 #define NG_PROTNUM_IL                   (40)    /**< IL Transport Protocol */
 #define NG_PROTNUM_IPV6                 (41)    /**< IPv6 encapsulation */
 #define NG_PROTNUM_SDRP                 (42)    /**< Source Demand Routing Protocol */
-#define NG_PROTNUM_IPV6_EXT_ROUTE       (43)    /**< Routing Header for IPv6 */
+#define NG_PROTNUM_IPV6_EXT_RH          (43)    /**< Routing Header for IPv6 */
 #define NG_PROTNUM_IPV6_EXT_FRAG        (44)    /**< Fragment Header for IPv6 */
 #define NG_PROTNUM_IDRP                 (45)    /**< Inter-Domain Routing Protocol */
 #define NG_PROTNUM_RSVP                 (46)    /**< Reservation Protocol */
@@ -95,7 +95,7 @@ extern "C" {
 #define NG_PROTNUM_SKIP                 (57)    /**< SKIP */
 #define NG_PROTNUM_ICMPV6               (58)    /**< ICMP for IPv6 */
 #define NG_PROTNUM_IPV6_NONXT           (59)    /**< No Next Header for IPv6 */
-#define NG_PROTNUM_IPV6_EXT_DEST_OPTS   (60)    /**< IPv6 Extension Header:
+#define NG_PROTNUM_IPV6_EXT_DST         (60)    /**< IPv6 Extension Header:
                                                  *   Destination Options */
 #define NG_PROTNUM_CFTP                 (62)    /**< CFTP */
 #define NG_PROTNUM_SAT_EXPAK            (64)    /**< SATNET and Backroom EXPAK */
@@ -168,7 +168,7 @@ extern "C" {
 #define NG_PROTNUM_SCTP                 (132)   /**< Stream Control Transmission Protocol */
 #define NG_PROTNUM_FC                   (133)   /**< Fibre Channel */
 #define NG_PROTNUM_RSVP_E2E_IGNORE      (134)   /**< RSVP-E2E-IGNORE */
-#define NG_PROTNUM_IPV6_EXT_MOB_HDR     (135)   /**< IPv6 Mobility Extension Header */
+#define NG_PROTNUM_IPV6_EXT_MOB         (135)   /**< IPv6 Mobility Extension Header */
 #define NG_PROTNUM_UDPLITE              (136)   /**< UDPLite */
 #define NG_PROTNUM_MPLS_IN_IP           (137)   /**< MPLS-in-IP */
 #define NG_PROTNUM_MANET                (138)   /**< MANET Protocols */

--- a/sys/include/net/ng_rpl.h
+++ b/sys/include/net/ng_rpl.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_ng_rpl  New RPL
+ * @ingroup     net
+ * @{
+ *
+ * @file
+ * @brief   TODO
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+#ifndef NG_RPL_H_
+#define NG_RPL_H_
+
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NG_RPL_H_ */
+/** @} */

--- a/sys/include/net/ng_rpl/srh.h
+++ b/sys/include/net/ng_rpl/srh.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_rpl_srh RPL source routing header extension
+ * @ingroup     net_rpl
+ * @brief       Implementation of RPL source routing extension headers
+ * @see <a href="https://tools.ietf.org/html/rfc6554">
+ *          RFC 6554
+ *      </a>
+ * @{
+ *
+ * @file
+ * @brief       Definititions for RPL source routing extension headers
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+#ifndef NG_RPL_SRH_H_
+#define NG_RPL_SRH_H_
+
+#include "net/ng_ipv6/addr.h"
+#include "net/ng_ipv6/ext.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Type for source routing header.
+ */
+#define NG_RPL_SRH_TYPE     (3U)
+
+/**
+ * @brief   The RPL Source routing header.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc6554">
+ *          RFC 6554
+ *      </a>
+ *
+ * @extends ng_ipv6_ext_rh_t
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t nh;         /**< next header */
+    uint8_t len;        /**< length in 8 octets without first octet */
+    uint8_t type;       /**< identifier of a particular routing header type */
+    uint8_t seg_left;   /**< number of route segments remaining */
+} ng_rpl_srh_t;
+
+/**
+ * @brief   Extract next hop from the RPL source routing header.
+ *
+ * @param[in] rh        A RPL source routing header.
+ *
+ * @return  next hop, on success
+ * @return  NULL, if not found.
+ */
+ng_ipv6_addr_t *ng_rpl_srh_next_hop(ng_rpl_srh_t *rh);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NG_RPL_SRH_H_ */
+/** @} */

--- a/sys/net/network_layer/ng_ipv6/ext/Makefile
+++ b/sys/net/network_layer/ng_ipv6/ext/Makefile
@@ -1,0 +1,3 @@
+MODULE = ng_ipv6_ext
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/network_layer/ng_ipv6/ext/ng_ipv6_ext.c
+++ b/sys/net/network_layer/ng_ipv6/ext/ng_ipv6_ext.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+
+#include <errno.h>
+
+#include "utlist.h"
+#include "net/ng_pktbuf.h"
+#include "net/ng_ipv6.h"
+
+#include "net/ng_ipv6/ext.h"
+
+bool ng_ipv6_ext_demux(kernel_pid_t iface, ng_pktsnip_t *pkt,
+                       uint8_t nh)
+{
+    ng_pktsnip_t *ext_snip;
+    ng_ipv6_ext_t *ext;
+    unsigned int offset = 0;
+
+    ext = ((ng_ipv6_ext_t *)(((uint8_t *)pkt->data) + sizeof(ng_ipv6_hdr_t)));
+
+    bool c = true;
+
+    while (c) {
+        switch (nh) {
+            case NG_PROTNUM_IPV6_EXT_HOPOPT:
+            case NG_PROTNUM_IPV6_EXT_DST:
+            case NG_PROTNUM_IPV6_EXT_RH:
+            case NG_PROTNUM_IPV6_EXT_FRAG:
+            case NG_PROTNUM_IPV6_EXT_AH:
+            case NG_PROTNUM_IPV6_EXT_ESP:
+            case NG_PROTNUM_IPV6_EXT_MOB:
+                /* TODO: add handling of types */
+                nh = ext->nh;
+                offset += ((ext->len * NG_IPV6_EXT_LEN_UNIT) + NG_IPV6_EXT_LEN_UNIT);
+                ext = ng_ipv6_ext_get_next((ng_ipv6_ext_t *)ext);
+                break;
+
+            default:
+                c = false;
+                offset += ((ext->len * NG_IPV6_EXT_LEN_UNIT) + NG_IPV6_EXT_LEN_UNIT);
+                ext = ng_ipv6_ext_get_next((ng_ipv6_ext_t *)ext);
+                break;
+        }
+    }
+
+    ext_snip = ng_pktbuf_add(pkt, pkt->data, offset, NG_NETTYPE_IPV6);
+
+    if (ext_snip == NULL) {
+        return false;
+    }
+
+    ng_ipv6_demux(iface, pkt, nh); /* demultiplex next header */
+
+    return true;
+}
+
+ng_pktsnip_t *ng_ipv6_ext_build(ng_pktsnip_t *ipv6, ng_pktsnip_t *next,
+                                uint8_t nh, size_t size)
+{
+    ng_pktsnip_t *prev = NULL, *snip;
+    ng_ipv6_ext_t *ext;
+
+    if (ipv6 != NULL) {
+        LL_SEARCH_SCALAR(ipv6, prev, next, next);
+
+        if (prev == NULL) {
+            return NULL;
+        }
+    }
+
+    if (size < NG_IPV6_EXT_LEN_UNIT) {
+        return NULL;
+    }
+
+    snip = ng_pktbuf_add(next, NULL, size, NG_NETTYPE_IPV6);
+
+    if (snip == NULL) {
+        return NULL;
+    }
+
+    ext = snip->data;
+
+    ext->nh = nh;
+
+    if (size & 0x7) { /* not divisible by eight */
+        ext->len = (size / NG_IPV6_EXT_LEN_UNIT);
+    }
+    else {
+        ext->len = (size / NG_IPV6_EXT_LEN_UNIT) - 1;
+    }
+
+    if (prev != NULL) {
+        prev->next = snip;
+    }
+
+    return snip;
+}
+
+
+/** @} */

--- a/sys/net/network_layer/ng_ipv6/ext/rh/Makefile
+++ b/sys/net/network_layer/ng_ipv6/ext/rh/Makefile
@@ -1,0 +1,3 @@
+MODULE = ng_ipv6_ext_rh
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/network_layer/ng_ipv6/ext/rh/ng_ipv6_ext_rh.c
+++ b/sys/net/network_layer/ng_ipv6/ext/rh/ng_ipv6_ext_rh.c
@@ -46,6 +46,11 @@ ng_ipv6_addr_t *ng_ipv6_ext_rh_next_hop(ng_ipv6_hdr_t *ipv6)
 
     if (ipv6->nh == NG_PROTNUM_IPV6_EXT_RH) {
         switch (ext->type) {
+#ifdef MODULE_NG_RPL_SRH
+            case NG_RPL_SRH_TYPE:
+                return ng_rpl_srh_next_hop((ng_rpl_srh_t *)ext);
+#endif
+
             default:
                 break;
         }

--- a/sys/net/network_layer/ng_ipv6/ext/rh/ng_ipv6_ext_rh.c
+++ b/sys/net/network_layer/ng_ipv6/ext/rh/ng_ipv6_ext_rh.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+
+#include <stdbool.h>
+
+#include "net/ng_protnum.h"
+#include "net/ng_rpl/srh.h"
+#include "net/ng_ipv6/ext/rh.h"
+
+ng_ipv6_addr_t *ng_ipv6_ext_rh_next_hop(ng_ipv6_hdr_t *ipv6)
+{
+    ng_ipv6_ext_rh_t *ext = (ng_ipv6_ext_rh_t *)(ipv6 + 1);
+    bool c = true;
+
+    while (c) {
+        switch (ext->type) {
+            case NG_PROTNUM_IPV6_EXT_HOPOPT:
+            case NG_PROTNUM_IPV6_EXT_DST:
+            case NG_PROTNUM_IPV6_EXT_FRAG:
+            case NG_PROTNUM_IPV6_EXT_AH:
+            case NG_PROTNUM_IPV6_EXT_ESP:
+            case NG_PROTNUM_IPV6_EXT_MOB:
+                ext = (ng_ipv6_ext_rh_t *)ng_ipv6_ext_get_next((ng_ipv6_ext_t *)ext);
+                break;
+
+            case NG_PROTNUM_IPV6_EXT_RH:
+                c = false;
+                break;
+
+            default:
+                c = false;
+                break;
+        }
+    }
+
+    if (ipv6->nh == NG_PROTNUM_IPV6_EXT_RH) {
+        switch (ext->type) {
+            default:
+                break;
+        }
+    }
+
+    return NULL;
+}
+
+/** @} */

--- a/sys/net/network_layer/ng_ipv6/ng_ipv6.c
+++ b/sys/net/network_layer/ng_ipv6/ng_ipv6.c
@@ -78,7 +78,18 @@ void ng_ipv6_demux(kernel_pid_t iface, ng_pktsnip_t *pkt, uint8_t nh)
         case NG_PROTNUM_ICMPV6:
             ng_icmpv6_demux(iface, pkt);
             break;
-        /* TODO: add extension header handling */
+        case NG_PROTNUM_IPV6_EXT_HOPOPT:
+        case NG_PROTNUM_IPV6_EXT_DST:
+        case NG_PROTNUM_IPV6_EXT_RH:
+        case NG_PROTNUM_IPV6_EXT_FRAG:
+        case NG_PROTNUM_IPV6_EXT_AH:
+        case NG_PROTNUM_IPV6_EXT_ESP:
+        case NG_PROTNUM_IPV6_EXT_MOB:
+            if (!ng_ipv6_ext_demux(iface, pkt, nh)) {
+                DEBUG("ipv6: unable to parse extension headers.\n");
+                ng_pktbuf_release(pkt);
+                return;
+            }
         case NG_PROTNUM_IPV6:
             _decapsulate(pkt);
             break;

--- a/sys/net/network_layer/ng_ndp/ng_ndp.c
+++ b/sys/net/network_layer/ng_ndp/ng_ndp.c
@@ -20,6 +20,7 @@
 #include "byteorder.h"
 #include "net/ng_icmpv6.h"
 #include "net/ng_ipv6.h"
+#include "net/ng_ipv6/ext/rh.h"
 #include "net/ng_netbase.h"
 #include "random.h"
 #include "utlist.h"
@@ -337,8 +338,14 @@ kernel_pid_t ng_ndp_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
     ng_ipv6_addr_t *next_hop_ip = NULL, *prefix = NULL;
 #ifdef MODULE_FIB
     size_t next_hop_size;
+#endif
 
-    if ((fib_get_next_hop(&iface, (uint8_t *)next_hop_ip, &next_hop_size,
+#ifdef MODULE_NG_IPV6_EXT_RH
+    next_hop_ip = ng_ipv6_ext_rh_next_hop(hdr);
+#endif
+#ifdef MODULE_FIB
+    if ((next_hop_ip == NULL) &&
+        (fib_get_next_hop(&iface, (uint8_t *)next_hop_ip, &next_hop_size,
                           (uint8_t *)dst, sizeof(ng_ipv6_addr_t),
                           0) < 0) || (next_hop_ip != sizeof(ng_ipv6_addr_t))) {
         next_hop_ip = NULL;

--- a/sys/net/routing/ng_rpl/srh/ng_rpl_srh.c
+++ b/sys/net/routing/ng_rpl/srh/ng_rpl_srh.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+
+#include "net/ng_rpl/srh.h"
+
+ng_ipv6_addr_t *ng_rpl_srh_next_hop(ng_rpl_srh_t *rh)
+{
+    /* TODO */
+
+    return NULL;
+}
+
+/** @} */


### PR DESCRIPTION
~~Based on #2555~~ (merged).