### PR TITLE
ng_ipv6/addr: add static initializer for all-RPL-nodes multicast addr

### DIFF
--- a/sys/include/net/ng_ipv6/addr.h
+++ b/sys/include/net/ng_ipv6/addr.h
@@ -131,6 +131,17 @@ typedef union __attribute__((packed)) {
                                                0, 0, 0, 0, 0, 0, 0, 2 }}
 
 /**
+ * @brief   Static initializer for the all-RPL-nodes multicast IPv6
+ *          address (ff02::1a)
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc6550#section-6">
+ *          RFC 6550, section 6
+ *      </a>
+ */
+#define NG_IPV6_ADDR_ALL_RPL_NODES {{ 0xff, 0x02, 0, 0, 0, 0, 0, 0, \
+                                               0, 0, 0, 0, 0, 0, 0, 0x1a }}
+
+/**
  * @brief   Values for the flag field in multicast addresses.
  *
  * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7">


### PR DESCRIPTION
This PR adds a static initializer for the `all-RPL-nodes`[(see RFC6550#Section-6)](https://tools.ietf.org/html/rfc6550#section-6) ipv6 multicast address to `ng_ipv6/addr`.