### PR TITLE
ISL29020 fixes

### DIFF
--- a/drivers/include/isl29020.h
+++ b/drivers/include/isl29020.h
@@ -39,11 +39,11 @@ extern "C" {
 typedef struct {
     i2c_t i2c;                  /**< I2C device the sensor is connected to */
     uint8_t address;            /**< I2C bus address of the sensor */
-    float lux_fac;              /**< factor to calculate actual LUX value */
+    float lux_fac;              /**< factor to calculate actual lux value */
 } isl29020_t;
 
 /**
- * @brief Possible modes for the ISR29020 sensor
+ * @brief Possible modes for the ISL29020 sensor
  */
 typedef enum {
     ISL29020_MODE_AMBIENT = 0,  /**< set sensor to detect ambient light */
@@ -51,13 +51,13 @@ typedef enum {
 } isl29020_mode_t;
 
 /**
- * @brief Possible range values for the ISR29020 sensor
+ * @brief Possible range values for the ISL29020 sensor
  */
 typedef enum {
-    ISL29020_RANGE_1K = 0,      /**< set range to 0-1000 LUX */
-    ISL29020_RANGE_4K = 1,      /**< set range to 0-4000 LUX */
-    ISL29020_RANGE_16K = 2,     /**< set range to 0-16000 LUX */
-    ISL29020_RANGE_64K = 3      /**< set range to 0-64000 LUX */
+    ISL29020_RANGE_1K = 0,      /**< set range to 0-1000 lux */
+    ISL29020_RANGE_4K = 1,      /**< set range to 0-4000 lux */
+    ISL29020_RANGE_16K = 2,     /**< set range to 0-16000 lux */
+    ISL29020_RANGE_64K = 3      /**< set range to 0-64000 lux */
 } isl29020_range_t;
 
 /**
@@ -76,11 +76,11 @@ int isl29020_init(isl29020_t *dev, i2c_t i2c, uint8_t address,
                   isl29020_range_t range, isl29020_mode_t mode);
 
 /**
- * @brief Read a lighting value from the sensor, the result is given in LUX
+ * @brief Read a lighting value from the sensor, the result is given in lux
  *
  * @param[in] dev       device descriptor of an ISL29020 device
  *
- * @return              the measured brightness in LUX
+ * @return              the measured brightness in lux
  * @return              -1 on error
  */
 int isl29020_read(isl29020_t *dev);

--- a/drivers/isl29020/isl29020.c
+++ b/drivers/isl29020/isl29020.c
@@ -57,13 +57,14 @@ int isl29020_read(isl29020_t *dev)
 {
     char low, high;
     uint16_t res;
+    int ret;
 
     i2c_acquire(dev->i2c);
     /* read lighting value */
-    res = i2c_read_reg(dev->i2c, dev->address, ISL29020_REG_LDATA, &low);
-    res += i2c_read_reg(dev->i2c, dev->address, ISL29020_REG_HDATA, &high);
+    ret = i2c_read_reg(dev->i2c, dev->address, ISL29020_REG_LDATA, &low);
+    ret += i2c_read_reg(dev->i2c, dev->address, ISL29020_REG_HDATA, &high);
     i2c_release(dev->i2c);
-    if (res < 2) {
+    if (ret < 2) {
         return -1;
     }
     res = (high << 8) | low;

--- a/drivers/isl29020/isl29020.c
+++ b/drivers/isl29020/isl29020.c
@@ -37,7 +37,7 @@ int isl29020_init(isl29020_t *dev, i2c_t i2c, uint8_t address,
     dev->address = address;
     dev->lux_fac = (float)((1 << (10 + (2 * range))) - 1) / 0xffff;
 
-    /* Acquire exclusive access to the bus. */
+    /* acquire exclusive access to the bus */
     i2c_acquire(dev->i2c);
     /* initialize the I2C bus */
     i2c_init_master(i2c, I2C_SPEED_NORMAL);
@@ -45,7 +45,7 @@ int isl29020_init(isl29020_t *dev, i2c_t i2c, uint8_t address,
     /* configure and enable the sensor */
     tmp = ISL29020_CMD_EN | ISL29020_CMD_MODE | ISL29020_RES_INT_16 | range | (mode << 5);
     res = i2c_write_reg(dev->i2c, address, ISL29020_REG_CMD, tmp);
-    /* Release the bus for other threads. */
+    /* release the bus for other threads */
     i2c_release(dev->i2c);
     if (res < 1) {
         return -1;
@@ -59,7 +59,7 @@ int isl29020_read(isl29020_t *dev)
     uint16_t res;
 
     i2c_acquire(dev->i2c);
-    /* read lightning value */
+    /* read lighting value */
     res = i2c_read_reg(dev->i2c, dev->address, ISL29020_REG_LDATA, &low);
     res += i2c_read_reg(dev->i2c, dev->address, ISL29020_REG_HDATA, &high);
     i2c_release(dev->i2c);
@@ -68,7 +68,7 @@ int isl29020_read(isl29020_t *dev)
     }
     res = (high << 8) | low;
     DEBUG("ISL29020: Raw value: %i - high: %i, low: %i\n", res, high, low);
-    /* calculate and return actually LUX value */
+    /* calculate and return the actual lux value */
     return (int)(dev->lux_fac * res);
 }
 


### PR DESCRIPTION
## Problem
Since `i2c_read_reg` returns (signed) `int` values, the result can be negative. However, the variable used to save the result is unsigned.

## Fix
Add and use a signed variable for return value storing.

## Extra
Furthermore some spelling errors and inconsistencies are fixed.