### PR TITLE
ipv6_netif: prepare for NDP

### DIFF
--- a/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
+++ b/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
@@ -44,7 +44,7 @@ static ng_ipv6_addr_t *_add_addr_to_entry(ng_ipv6_netif_t *entry, const ng_ipv6_
 
         if (ng_ipv6_addr_is_unspecified(&(entry->addrs[i].addr))) {
             memcpy(&(entry->addrs[i].addr), addr, sizeof(ng_ipv6_addr_t));
-            DEBUG("Added %s/%" PRIu8 " to interface %" PRIkernel_pid "\n",
+            DEBUG("ipv6 netif: Added %s/%" PRIu8 " to interface %" PRIkernel_pid "\n",
                   ng_ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)),
                   prefix_len, entry->pid);
 
@@ -84,7 +84,7 @@ static ng_ipv6_addr_t *_add_addr_to_entry(ng_ipv6_netif_t *entry, const ng_ipv6_
 
 static void _reset_addr_from_entry(ng_ipv6_netif_t *entry)
 {
-    DEBUG("Reset IPv6 addresses on interface %" PRIkernel_pid "\n", entry->pid);
+    DEBUG("ipv6 netif: Reset IPv6 addresses on interface %" PRIkernel_pid "\n", entry->pid);
     memset(entry->addrs, 0, sizeof(entry->addrs));
 }
 
@@ -109,7 +109,7 @@ void ng_ipv6_netif_add(kernel_pid_t pid)
             ng_ipv6_addr_t addr = NG_IPV6_ADDR_ALL_NODES_LINK_LOCAL;
             mutex_lock(&ipv6_ifs[i].mutex);
 
-            DEBUG("Add IPv6 interface %" PRIkernel_pid " (i = %d)\n", pid, i);
+            DEBUG("ipv6 netif: Add IPv6 interface %" PRIkernel_pid " (i = %d)\n", pid, i);
             ipv6_ifs[i].pid = pid;
             ipv6_ifs[i].mtu = NG_IPV6_NETIF_DEFAULT_MTU;
             ipv6_ifs[i].cur_hl = NG_IPV6_NETIF_DEFAULT_HL;
@@ -127,7 +127,7 @@ void ng_ipv6_netif_add(kernel_pid_t pid)
         }
     }
 
-    DEBUG("Could not add %" PRIkernel_pid " to IPv6: No space left.\n", pid);
+    DEBUG("ipv6 netif: Could not add %" PRIkernel_pid " to IPv6: No space left.\n", pid);
 }
 
 void ng_ipv6_netif_remove(kernel_pid_t pid)
@@ -141,7 +141,7 @@ void ng_ipv6_netif_remove(kernel_pid_t pid)
     mutex_lock(&entry->mutex);
 
     _reset_addr_from_entry(entry);
-    DEBUG("Remove IPv6 interface %" PRIkernel_pid "\n", pid);
+    DEBUG("ipv6 netif: Remove IPv6 interface %" PRIkernel_pid "\n", pid);
     entry->pid = KERNEL_PID_UNDEF;
     entry->flags = 0;
 
@@ -152,7 +152,7 @@ ng_ipv6_netif_t *ng_ipv6_netif_get(kernel_pid_t pid)
 {
     for (int i = 0; i < NG_NETIF_NUMOF; i++) {
         if (ipv6_ifs[i].pid == pid) {
-            DEBUG("Get IPv6 interface %" PRIkernel_pid " (%p, i = %d)\n", pid,
+            DEBUG("ipv6 netif: Get IPv6 interface %" PRIkernel_pid " (%p, i = %d)\n", pid,
                   (void *)(&(ipv6_ifs[i])), i);
             return &(ipv6_ifs[i]);
         }
@@ -187,8 +187,8 @@ static void _remove_addr_from_entry(ng_ipv6_netif_t *entry, ng_ipv6_addr_t *addr
 
     for (int i = 0; i < NG_IPV6_NETIF_ADDR_NUMOF; i++) {
         if (ng_ipv6_addr_equal(&(entry->addrs[i].addr), addr)) {
-            DEBUG("Remove %s to interface %" PRIkernel_pid "\n",
-                  ng_ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)), pid);
+            DEBUG("ipv6 netif: Remove %s to interface %" PRIkernel_pid "\n",
+                  ng_ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)), entry->pid);
             ng_ipv6_addr_set_unspecified(&(entry->addrs[i].addr));
             entry->addrs[i].flags = 0;
 
@@ -240,7 +240,7 @@ kernel_pid_t ng_ipv6_netif_find_by_addr(ng_ipv6_addr_t **out, const ng_ipv6_addr
             *out = ng_ipv6_netif_find_addr(ipv6_ifs[i].pid, addr);
 
             if (*out != NULL) {
-                DEBUG("Found %s on interface %" PRIkernel_pid "\n",
+                DEBUG("ipv6 netif: Found %s on interface %" PRIkernel_pid "\n",
                       ng_ipv6_addr_to_str(addr_str, *out, sizeof(addr_str)),
                       ipv6_ifs[i].pid);
                 return ipv6_ifs[i].pid;
@@ -248,7 +248,7 @@ kernel_pid_t ng_ipv6_netif_find_by_addr(ng_ipv6_addr_t **out, const ng_ipv6_addr
         }
         else {
             if (ng_ipv6_netif_find_addr(ipv6_ifs[i].pid, addr) != NULL) {
-                DEBUG("Found %s on interface %" PRIkernel_pid "\n",
+                DEBUG("ipv6 netif: Found %s on interface %" PRIkernel_pid "\n",
                       ng_ipv6_addr_to_str(addr_str, *out, sizeof(addr_str)),
                       ipv6_ifs[i].pid);
                 return ipv6_ifs[i].pid;
@@ -276,7 +276,7 @@ ng_ipv6_addr_t *ng_ipv6_netif_find_addr(kernel_pid_t pid, const ng_ipv6_addr_t *
     for (int i = 0; i < NG_IPV6_NETIF_ADDR_NUMOF; i++) {
         if (ng_ipv6_addr_equal(&(entry->addrs[i].addr), addr)) {
             mutex_unlock(&entry->mutex);
-            DEBUG("Found %s on interface %" PRIkernel_pid "\n",
+            DEBUG("ipv6 netif: Found %s on interface %" PRIkernel_pid "\n",
                   ng_ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)),
                   pid);
             return &(entry->addrs[i].addr);
@@ -320,7 +320,7 @@ static uint8_t _find_by_prefix_unsafe(ng_ipv6_addr_t **res, ng_ipv6_netif_t *ifa
 
 #if ENABLE_DEBUG
     if (*res != NULL) {
-        DEBUG("Found %s on interface %" PRIkernel_pid " matching ",
+        DEBUG("ipv6 netif: Found %s on interface %" PRIkernel_pid " matching ",
               ng_ipv6_addr_to_str(addr_str, *res, sizeof(addr_str)),
               iface->pid);
         DEBUG("%s by %" PRIu8 " bits (used as source address = %s)\n",
@@ -329,7 +329,7 @@ static uint8_t _find_by_prefix_unsafe(ng_ipv6_addr_t **res, ng_ipv6_netif_t *ifa
               (only_unicast) ? "true" : "false");
     }
     else {
-        DEBUG("Did not found any address on interface %" PRIkernel_pid
+        DEBUG("ipv6 netif: Did not found any address on interface %" PRIkernel_pid
               " matching %s (used as source address = %s)\n",
               iface->pid,
               ng_ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)),
@@ -367,7 +367,7 @@ kernel_pid_t ng_ipv6_netif_find_by_prefix(ng_ipv6_addr_t **out, const ng_ipv6_ad
 
 #if ENABLE_DEBUG
     if (res != KERNEL_PID_UNDEF) {
-        DEBUG("Found %s on interface %" PRIkernel_pid " globally matching ",
+        DEBUG("ipv6 netif: Found %s on interface %" PRIkernel_pid " globally matching ",
               ng_ipv6_addr_to_str(addr_str, *out, sizeof(addr_str)),
               res);
         DEBUG("%s by %" PRIu8 " bits\n",
@@ -375,7 +375,7 @@ kernel_pid_t ng_ipv6_netif_find_by_prefix(ng_ipv6_addr_t **out, const ng_ipv6_ad
               best_match);
     }
     else {
-        DEBUG("Did not found any address globally matching %s\n",
+        DEBUG("ipv6 netif: Did not found any address globally matching %s\n",
               ng_ipv6_addr_to_str(addr_str, prefix, sizeof(addr_str)));
     }
 #endif

--- a/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
+++ b/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
@@ -20,7 +20,6 @@
 
 #include "kernel_types.h"
 #include "mutex.h"
-#include "net/ng_ipv6.h"
 #include "net/ng_ipv6/addr.h"
 #include "net/ng_netif.h"
 
@@ -35,12 +34,12 @@ static ng_ipv6_netif_t ipv6_ifs[NG_NETIF_NUMOF];
 static char addr_str[NG_IPV6_ADDR_MAX_STR_LEN];
 #endif
 
-static int _add_addr_to_entry(ng_ipv6_netif_t *entry, const ng_ipv6_addr_t *addr,
-                              uint8_t prefix_len, bool anycast)
+static ng_ipv6_addr_t *_add_addr_to_entry(ng_ipv6_netif_t *entry, const ng_ipv6_addr_t *addr,
+                                          uint8_t prefix_len, uint8_t flags)
 {
     for (int i = 0; i < NG_IPV6_NETIF_ADDR_NUMOF; i++) {
         if (ng_ipv6_addr_equal(&(entry->addrs[i].addr), addr)) {
-            return 0;
+            return &(entry->addrs[i].addr);
         }
 
         if (ng_ipv6_addr_is_unspecified(&(entry->addrs[i].addr))) {
@@ -49,17 +48,14 @@ static int _add_addr_to_entry(ng_ipv6_netif_t *entry, const ng_ipv6_addr_t *addr
                   ng_ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)),
                   prefix_len, entry->pid);
 
-            if (anycast || ng_ipv6_addr_is_multicast(addr)) {
-                if (ng_ipv6_addr_is_multicast(addr)) {
-                    entry->addrs[i].prefix_len = NG_IPV6_ADDR_BIT_LEN;
-                }
+            entry->addrs[i].prefix_len = prefix_len;
+            entry->addrs[i].flags = flags;
 
-                entry->addrs[i].flags = NG_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST;
-
-                return 0;
+            if (ng_ipv6_addr_is_multicast(addr)) {
+                entry->addrs[i].flags |= NG_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST;
             }
             else {
-                entry->addrs[i].prefix_len = prefix_len;
+                ng_ipv6_addr_t sol_node;
 
                 if (!ng_ipv6_addr_is_link_local(addr)) {
                     /* add also corresponding link-local address */
@@ -68,17 +64,22 @@ static int _add_addr_to_entry(ng_ipv6_netif_t *entry, const ng_ipv6_addr_t *addr
                     ll_addr.u64[1] = addr->u64[1];
                     ng_ipv6_addr_set_link_local_prefix(&ll_addr);
 
-                    entry->addrs[i].flags = NG_IPV6_NETIF_ADDR_FLAGS_UNICAST;
-
-                    return _add_addr_to_entry(entry, &ll_addr, 64, false);
+                    _add_addr_to_entry(entry, &ll_addr, 64,
+                                       flags | NG_IPV6_NETIF_ADDR_FLAGS_NDP_ON_LINK);
+                }
+                else {
+                    entry->addrs[i].flags |= NG_IPV6_NETIF_ADDR_FLAGS_NDP_ON_LINK;
                 }
 
-                return 0;
+                ng_ipv6_addr_set_solicited_nodes(&sol_node, addr);
+                _add_addr_to_entry(entry, &sol_node, NG_IPV6_ADDR_BIT_LEN, 0);
             }
+
+            return &entry->addrs[i].addr;
         }
     }
 
-    return -ENOMEM;
+    return NULL;
 }
 
 static void _reset_addr_from_entry(ng_ipv6_netif_t *entry)
@@ -110,16 +111,18 @@ void ng_ipv6_netif_add(kernel_pid_t pid)
 
             DEBUG("Add IPv6 interface %" PRIkernel_pid " (i = %d)\n", pid, i);
             ipv6_ifs[i].pid = pid;
-            DEBUG(" * pid = %" PRIkernel_pid "  ", ipv6_ifs[i].pid);
             ipv6_ifs[i].mtu = NG_IPV6_NETIF_DEFAULT_MTU;
-            DEBUG("mtu = %d  ", ipv6_ifs[i].mtu);
             ipv6_ifs[i].cur_hl = NG_IPV6_NETIF_DEFAULT_HL;
-            DEBUG("cur_hl = %d  ", ipv6_ifs[i].cur_hl);
+            ipv6_ifs[i].flags = 0;
 
             _add_addr_to_entry(&ipv6_ifs[i], &addr, NG_IPV6_ADDR_BIT_LEN, 0);
 
             mutex_unlock(&ipv6_ifs[i].mutex);
 
+            DEBUG(" * pid = %" PRIkernel_pid "  ", ipv6_ifs[i].pid);
+            DEBUG("cur_hl = %d  ", ipv6_ifs[i].cur_hl);
+            DEBUG("mtu = %d  ", ipv6_ifs[i].mtu);
+            DEBUG("flags = %04" PRIx16 "\n", ipv6_ifs[i].flags);
             return;
         }
     }
@@ -140,6 +143,7 @@ void ng_ipv6_netif_remove(kernel_pid_t pid)
     _reset_addr_from_entry(entry);
     DEBUG("Remove IPv6 interface %" PRIkernel_pid "\n", pid);
     entry->pid = KERNEL_PID_UNDEF;
+    entry->flags = 0;
 
     mutex_unlock(&entry->mutex);
 }
@@ -157,38 +161,28 @@ ng_ipv6_netif_t *ng_ipv6_netif_get(kernel_pid_t pid)
     return NULL;
 }
 
-int ng_ipv6_netif_add_addr(kernel_pid_t pid, const ng_ipv6_addr_t *addr,
-                           uint8_t prefix_len, bool anycast)
+ng_ipv6_addr_t *ng_ipv6_netif_add_addr(kernel_pid_t pid, const ng_ipv6_addr_t *addr,
+                                       uint8_t prefix_len, uint8_t flags)
 {
     ng_ipv6_netif_t *entry = ng_ipv6_netif_get(pid);
-    int res;
+    ng_ipv6_addr_t *res;
 
-    if (entry == NULL) {
-        return -ENOENT;
-    }
-
-    if ((addr == NULL) || (ng_ipv6_addr_is_unspecified(addr)) ||
+    if ((entry == NULL) || (addr == NULL) || (ng_ipv6_addr_is_unspecified(addr)) ||
         ((prefix_len - 1) > 127)) {    /* prefix_len < 1 || prefix_len > 128 */
-        return -EINVAL;
+        return NULL;
     }
 
     mutex_lock(&entry->mutex);
 
-    res = _add_addr_to_entry(entry, addr, prefix_len, anycast);
+    res = _add_addr_to_entry(entry, addr, prefix_len, flags);
 
     mutex_unlock(&entry->mutex);
 
     return res;
 }
 
-void ng_ipv6_netif_remove_addr(kernel_pid_t pid, ng_ipv6_addr_t *addr)
+static void _remove_addr_from_entry(ng_ipv6_netif_t *entry, ng_ipv6_addr_t *addr)
 {
-    ng_ipv6_netif_t *entry = ng_ipv6_netif_get(pid);
-
-    if (entry == NULL) {
-        return;
-    }
-
     mutex_lock(&entry->mutex);
 
     for (int i = 0; i < NG_IPV6_NETIF_ADDR_NUMOF; i++) {
@@ -204,6 +198,24 @@ void ng_ipv6_netif_remove_addr(kernel_pid_t pid, ng_ipv6_addr_t *addr)
     }
 
     mutex_unlock(&entry->mutex);
+}
+
+void ng_ipv6_netif_remove_addr(kernel_pid_t pid, ng_ipv6_addr_t *addr)
+{
+    if (pid == KERNEL_PID_UNDEF) {
+        for (int i = 0; i < NG_NETIF_NUMOF; i++) {
+            if (ipv6_ifs[i].pid == KERNEL_PID_UNDEF) {
+                continue;
+            }
+
+            _remove_addr_from_entry(ipv6_ifs + i, addr);
+        }
+    }
+    else {
+        ng_ipv6_netif_t *entry = ng_ipv6_netif_get(pid);
+
+        _remove_addr_from_entry(entry, addr);
+    }
 }
 
 void ng_ipv6_netif_reset_addr(kernel_pid_t pid)
@@ -307,7 +319,6 @@ static uint8_t _find_by_prefix_unsafe(ng_ipv6_addr_t **res, ng_ipv6_netif_t *ifa
     }
 
 #if ENABLE_DEBUG
-
     if (*res != NULL) {
         DEBUG("Found %s on interface %" PRIkernel_pid " matching ",
               ng_ipv6_addr_to_str(addr_str, *res, sizeof(addr_str)),
@@ -324,8 +335,8 @@ static uint8_t _find_by_prefix_unsafe(ng_ipv6_addr_t **res, ng_ipv6_netif_t *ifa
               ng_ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)),
               (only_unicast) ? "true" : "false");
     }
-
 #endif
+
     return best_match;
 }
 
@@ -355,7 +366,6 @@ kernel_pid_t ng_ipv6_netif_find_by_prefix(ng_ipv6_addr_t **out, const ng_ipv6_ad
     }
 
 #if ENABLE_DEBUG
-
     if (res != KERNEL_PID_UNDEF) {
         DEBUG("Found %s on interface %" PRIkernel_pid " globally matching ",
               ng_ipv6_addr_to_str(addr_str, *out, sizeof(addr_str)),
@@ -368,7 +378,6 @@ kernel_pid_t ng_ipv6_netif_find_by_prefix(ng_ipv6_addr_t **out, const ng_ipv6_ad
         DEBUG("Did not found any address globally matching %s\n",
               ng_ipv6_addr_to_str(addr_str, prefix, sizeof(addr_str)));
     }
-
 #endif
 
     return res;

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -600,7 +600,10 @@ static int _netif_add(char *cmd_name, kernel_pid_t dev, int argc, char **argv)
         return 1;
     }
 
-    if (ng_ipv6_netif_add_addr(dev, &addr, prefix_len, (type == _ANYCAST)) < 0) {
+    if (ng_ipv6_netif_add_addr(dev, &addr, prefix_len,
+                               (type == _ANYCAST) ?
+                               NG_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST :
+                               NG_IPV6_NETIF_ADDR_FLAGS_UNICAST) == NULL) {
         printf("error: unable to add IPv6 address\n");
         return 1;
     }

--- a/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
+++ b/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
@@ -121,22 +121,19 @@ static void test_ipv6_netif_add_addr__no_iface1(void)
 {
     ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
 
-    TEST_ASSERT_EQUAL_INT(-ENOENT, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF,
-                          &addr, DEFAULT_TEST_PREFIX_LEN, false));
+    TEST_ASSERT_NULL(ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr, DEFAULT_TEST_PREFIX_LEN, 0));
 }
 
 static void test_ipv6_netif_add_addr__no_iface2(void)
 {
-    TEST_ASSERT_EQUAL_INT(-ENOENT, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF,
-                          NULL, DEFAULT_TEST_PREFIX_LEN, false));
+    TEST_ASSERT_NULL(ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, NULL, DEFAULT_TEST_PREFIX_LEN, 0));
 }
 
 static void test_ipv6_netif_add_addr__addr_NULL(void)
 {
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
-    TEST_ASSERT_EQUAL_INT(-EINVAL, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF,
-                          NULL, DEFAULT_TEST_PREFIX_LEN, false));
+    TEST_ASSERT_NULL(ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, NULL, DEFAULT_TEST_PREFIX_LEN, 0));
 }
 
 static void test_ipv6_netif_add_addr__addr_unspecified(void)
@@ -145,26 +142,22 @@ static void test_ipv6_netif_add_addr__addr_unspecified(void)
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
-    TEST_ASSERT_EQUAL_INT(-EINVAL, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF,
-                          &addr, DEFAULT_TEST_PREFIX_LEN, false));
+    TEST_ASSERT_NULL(ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr, DEFAULT_TEST_PREFIX_LEN, 0));
 }
 
-static void test_ipv6_netif_add_addr__ENOMEM(void)
+static void test_ipv6_netif_add_addr__full(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
-    int res = 0, i;
+    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR, *res = &addr;
+    int i;
 
     /* make link local to avoid automatic link local adding */
     ng_ipv6_addr_set_link_local_prefix(&addr);
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
-    for (i = 0; res != -ENOMEM; i++, addr.u8[15]++) {
-        res =  ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr,
-                                      DEFAULT_TEST_PREFIX_LEN, false);
+    for (i = 0; res != NULL; i++, addr.u8[15]++) {
+        res =  ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr, DEFAULT_TEST_PREFIX_LEN, 0);
     }
-
-    TEST_ASSERT_EQUAL_INT(NG_IPV6_NETIF_ADDR_NUMOF, i);
 }
 
 static void test_ipv6_netif_add_addr__success(void)
@@ -173,8 +166,7 @@ static void test_ipv6_netif_add_addr__success(void)
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr,
-                          DEFAULT_TEST_PREFIX_LEN, false));
+    TEST_ASSERT_NOT_NULL(ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr, DEFAULT_TEST_PREFIX_LEN, 0));
 }
 
 static void test_ipv6_netif_remove_addr__not_allocated(void)
@@ -378,10 +370,10 @@ static void test_ipv6_netif_find_best_src_addr__no_unicast(void)
     TEST_ASSERT_EQUAL_INT(126, ng_ipv6_addr_match_prefix(&ll_addr2, &ll_addr1));
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &mc_addr,
-                          DEFAULT_TEST_PREFIX_LEN, false));
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &ll_addr1,
-                          DEFAULT_TEST_PREFIX_LEN, true));
+    TEST_ASSERT_NOT_NULL(ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &mc_addr, DEFAULT_TEST_PREFIX_LEN,
+                         0));
+    TEST_ASSERT_NOT_NULL(ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &ll_addr1, DEFAULT_TEST_PREFIX_LEN,
+                         NG_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST));
 
     TEST_ASSERT_NULL(ng_ipv6_netif_find_best_src_addr(DEFAULT_TEST_NETIF, &ll_addr2));
 }
@@ -401,10 +393,10 @@ static void test_ipv6_netif_find_best_src_addr__success(void)
     TEST_ASSERT_EQUAL_INT(126, ng_ipv6_addr_match_prefix(&ll_addr2, &ll_addr1));
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &mc_addr,
-                          DEFAULT_TEST_PREFIX_LEN, false));
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &ll_addr1,
-                          DEFAULT_TEST_PREFIX_LEN, false));
+    TEST_ASSERT_NOT_NULL(ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &mc_addr, DEFAULT_TEST_PREFIX_LEN,
+                         0));
+    TEST_ASSERT_NOT_NULL(ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &ll_addr1, DEFAULT_TEST_PREFIX_LEN,
+                         0));
 
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_find_best_src_addr(DEFAULT_TEST_NETIF, &ll_addr2)));
     TEST_ASSERT(out != &ll_addr1);
@@ -431,8 +423,8 @@ static void test_ipv6_netif_addr_is_non_unicast__anycast(void)
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr,
-                          DEFAULT_TEST_PREFIX_LEN, true));
+    TEST_ASSERT_NOT_NULL(ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr, DEFAULT_TEST_PREFIX_LEN,
+                         NG_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST));
 
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_find_addr(DEFAULT_TEST_NETIF, &addr)));
     TEST_ASSERT_EQUAL_INT(true, ng_ipv6_netif_addr_is_non_unicast(out));
@@ -445,8 +437,7 @@ static void test_ipv6_netif_addr_is_non_unicast__multicast1(void)
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr,
-                          DEFAULT_TEST_PREFIX_LEN, false));
+    TEST_ASSERT_NOT_NULL(ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr, DEFAULT_TEST_PREFIX_LEN, 0));
 
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_find_addr(DEFAULT_TEST_NETIF, &addr)));
     TEST_ASSERT_EQUAL_INT(true, ng_ipv6_netif_addr_is_non_unicast(out));
@@ -459,8 +450,8 @@ static void test_ipv6_netif_addr_is_non_unicast__multicast2(void)
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr,
-                          DEFAULT_TEST_PREFIX_LEN, true));
+    TEST_ASSERT_NOT_NULL(ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr, DEFAULT_TEST_PREFIX_LEN,
+                         NG_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST));
 
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_find_addr(DEFAULT_TEST_NETIF, &addr)));
     TEST_ASSERT_EQUAL_INT(true, ng_ipv6_netif_addr_is_non_unicast(out));
@@ -478,7 +469,7 @@ Test *tests_ipv6_netif_tests(void)
         new_TestFixture(test_ipv6_netif_add_addr__no_iface2),
         new_TestFixture(test_ipv6_netif_add_addr__addr_NULL),
         new_TestFixture(test_ipv6_netif_add_addr__addr_unspecified),
-        new_TestFixture(test_ipv6_netif_add_addr__ENOMEM),
+        new_TestFixture(test_ipv6_netif_add_addr__full),
         new_TestFixture(test_ipv6_netif_add_addr__success),
         new_TestFixture(test_ipv6_netif_remove_addr__not_allocated),
         new_TestFixture(test_ipv6_netif_remove_addr__success),


### PR DESCRIPTION
NDP needs a bigger flag space (this PR introduces some of the new flags). This also simplifies some of the usage.