### PR TITLE
ng_icmpv6_echo: fix call to undefined function

### DIFF
--- a/sys/net/network_layer/ng_icmpv6/echo/ng_icmpv6_echo.c
+++ b/sys/net/network_layer/ng_icmpv6/echo/ng_icmpv6_echo.c
@@ -67,9 +67,9 @@ void ng_icmpv6_echo_req_handle(kernel_pid_t iface, ng_ipv6_hdr_t *ipv6_hdr,
         return;
     }
 
-    pkt = _echo_build(NG_ICMPV6_ECHO_REP, byteorder_ntohs(echo->id),
-                      byteorder_ntohs(echo->seq), payload,
-                      len - sizeof(ng_icmpv6_echo_t));
+    pkt = ng_icmpv6_echo_build(NG_ICMPV6_ECHO_REP, byteorder_ntohs(echo->id),
+                               byteorder_ntohs(echo->seq), payload,
+                               len - sizeof(ng_icmpv6_echo_t));
 
     if (pkt == NULL) {
         DEBUG("icmpv6_echo: no space left in packet buffer\n");


### PR DESCRIPTION
`_echo_build` doesn't exist. Didn't test it, but I don't seem to be the first in that respect ;)
This module should at least have some test trying to build it but I don't know where that would go.