### PR TITLE
netconf: at86rf231: setting the SFD IRQ

### DIFF
--- a/drivers/ng_at86rf2xx/ng_at86rf2xx.c
+++ b/drivers/ng_at86rf2xx/ng_at86rf2xx.c
@@ -154,8 +154,7 @@ void ng_at86rf2xx_reset(ng_at86rf2xx_t *dev)
     ng_at86rf2xx_reg_write(dev, NG_AT86RF2XX_REG__TRX_CTRL_2, tmp);
     /* enable interrupts */
     ng_at86rf2xx_reg_write(dev, NG_AT86RF2XX_REG__IRQ_MASK,
-                           (NG_AT86RF2XX_IRQ_STATUS_MASK__RX_START |
-                            NG_AT86RF2XX_IRQ_STATUS_MASK__TRX_END));
+                           NG_AT86RF2XX_IRQ_STATUS_MASK__TRX_END);
     /* go into RX state */
     ng_at86rf2xx_set_state(dev, NG_AT86RF2XX_STATE_RX_AACK_ON);
 

--- a/drivers/ng_at86rf2xx/ng_at86rf2xx_getset.c
+++ b/drivers/ng_at86rf2xx/ng_at86rf2xx_getset.c
@@ -154,6 +154,12 @@ void ng_at86rf2xx_set_option(ng_at86rf2xx_t *dev, uint16_t option, bool state)
                 tmp &= ~(NG_AT86RF2XX_CSMA_SEED_1__AACK_DIS_ACK);
                 ng_at86rf2xx_reg_write(dev, NG_AT86RF2XX_REG__CSMA_SEED_1, tmp);
                 break;
+            case NG_AT86RF2XX_OPT_TELL_RX_START:
+                DEBUG("[ng_at86rf2xx] opt: enabling SFD IRQ\n");
+                tmp = ng_at86rf2xx_reg_read(dev, NG_AT86RF2XX_REG__IRQ_MASK);
+                tmp |= NG_AT86RF2XX_IRQ_STATUS_MASK__RX_START;
+                ng_at86rf2xx_reg_write(dev, NG_AT86RF2XX_REG__IRQ_MASK, tmp);
+                break;
             default:
                 /* do nothing */
                 break;
@@ -184,6 +190,12 @@ void ng_at86rf2xx_set_option(ng_at86rf2xx_t *dev, uint16_t option, bool state)
                 tmp = ng_at86rf2xx_reg_read(dev, NG_AT86RF2XX_REG__CSMA_SEED_1);
                 tmp |= NG_AT86RF2XX_CSMA_SEED_1__AACK_DIS_ACK;
                 ng_at86rf2xx_reg_write(dev, NG_AT86RF2XX_REG__CSMA_SEED_1, tmp);
+                break;
+            case NG_AT86RF2XX_OPT_TELL_RX_START:
+                DEBUG("[ng_at86rf2xx] opt: disabling SFD IRQ\n");
+                tmp = ng_at86rf2xx_reg_read(dev, NG_AT86RF2XX_REG__IRQ_MASK);
+                tmp &= ~NG_AT86RF2XX_IRQ_STATUS_MASK__RX_START;
+                ng_at86rf2xx_reg_write(dev, NG_AT86RF2XX_REG__IRQ_MASK, tmp);
                 break;
             default:
                 /* do nothing */

--- a/drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c
+++ b/drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c
@@ -357,6 +357,7 @@ static int _get(ng_netdev_t *device, ng_netconf_opt_t opt,
     ng_at86rf2xx_t *dev = (ng_at86rf2xx_t *) device;
 
     switch (opt) {
+        uint8_t irq_mask;
 
         case NETCONF_OPT_ADDRESS:
             if (max_len < sizeof(uint16_t)) {
@@ -485,6 +486,12 @@ static int _get(ng_netdev_t *device, ng_netconf_opt_t opt,
             else {
                 *((ng_netconf_enable_t *)val) = NETCONF_DISABLE;
             }
+            return sizeof(ng_netconf_enable_t);
+
+        case NETCONT_OPT_SFD_INT:
+            irq_mask = ng_at86rf2xx_reg_read(dev, NG_AT86RF2XX_REG__IRQ_MASK);
+            ng_at86rf2xx_reg_write(dev, NG_AT86RF2XX_REG__IRQ_MASK,
+                    (irq_mask ^ NG_AT86RF2XX_IRQ_STATUS_MASK__RX_START));
             return sizeof(ng_netconf_enable_t);
 
         default:

--- a/sys/include/net/ng_netconf.h
+++ b/sys/include/net/ng_netconf.h
@@ -17,6 +17,7 @@
  * @brief       Definition of global configuration options
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
  */
 
 #ifndef NG_NET_CONF_H_
@@ -78,6 +79,45 @@ typedef enum {
     NETCONF_OPT_RAWMODE,            /**< en/disable the pre-processing of data
                                          in a network device driver as type
                                          ng_nettype_t */
+
+    /**
+     * @brief en/disable the interrupt at reception start.
+     *
+     * It is mostly triggered after the preamble is correctly received
+     *
+     * @note not all transceivers may support this interrupt
+     */
+    NETCONF_OPT_RX_START_IRQ,
+
+    /**
+     * @brief en/disable the interrupt after packet reception.
+     *
+     * This interrupt is triggered after a complete packet is received.
+     *
+     * @note in case a transceiver does not support this interrupt, the event
+     *       may be triggered by the driver
+     */
+    NETCONF_OPT_RX_END_IRQ,
+
+    /**
+     * @brief en/disable the interrupt right in the beginning of transmission.
+     *
+     * This interrupt is triggered when the transceiver starts to send out the
+     * packet.
+     *
+     * @note in case a transceiver does not support this interrupt, the event
+     *       may be triggered by the driver
+     */
+    NETCONF_OPT_TX_START_IRQ,
+
+    /**
+     * @brief en/disable the interrupt after packet transmission.
+     *
+     * This interrupt is triggered when the full packet is transmitted.
+     *
+     * @note not all transceivers may support this interrupt
+     */
+    NETCONF_OPT_TX_END_IRQ,
     /* add more options if needed */
 } ng_netconf_opt_t;
 


### PR DESCRIPTION
This PR introduces a netconf option to toggle the interrupt for a SFD reception. This interrupt is only required for time critical operation (i.e. IEEE 802.15.4e) and should be disabled by default, since it causes an interrupt for every received packet, independent if it's targeted for this node or not. Therefore, this PR disables this IRQ for the AT86RF231 per default.