### PR TITLE
board:stm32f0discover LED name fixes 

### DIFF
--- a/boards/stm32f0discovery/include/board.h
+++ b/boards/stm32f0discovery/include/board.h
@@ -65,12 +65,12 @@ extern "C" {
 #define LD4_TOGGLE          (LED_PORT->ODR ^= LD4_PIN)
 
 /* for compatibility to other boards */
-#define LED_GREEN_ON        LD4_ON
-#define LED_GREEN_OFF       LD4_OFF
-#define LED_GREEN_TOGGLE    LD4_TOGGLE
-#define LED_RED_ON          LD3_ON
-#define LED_RED_OFF         LD3_OFF
-#define LED_RED_TOGGLE      LD3_TOGGLE
+#define LED_GREEN_ON        LD3_ON
+#define LED_GREEN_OFF       LD3_OFF
+#define LED_GREEN_TOGGLE    LD3_TOGGLE
+#define LED_RED_ON          LD4_ON
+#define LED_RED_OFF         LD4_OFF
+#define LED_RED_TOGGLE      LD4_TOGGLE
 /** @} */
 
 /**


### PR DESCRIPTION
Previously Green LED was mapped to Blue LED and Red LED was mapped to Green LED.
This patch fixes it by mapping the Green LED to Green LED and Red LED to Blue LED.
