### PR TITLE
ng_ipv6/netif: doc fix (interfaces => interface)

### DIFF
--- a/sys/include/net/ng_ipv6/netif.h
+++ b/sys/include/net/ng_ipv6/netif.h
@@ -228,7 +228,7 @@ kernel_pid_t ng_ipv6_netif_find_by_prefix(ng_ipv6_addr_t **out,
 
 /**
  * @brief   Searches for the first address matching a prefix best on an
- *          interfaces.
+ *          interface.
  *
  * @param[in] pid       The PID to the interface.
  * @param[in] prefix    The prefix you want to search for.


### PR DESCRIPTION
I extracted this change from #2940, because there might start a discussion, which is independent from this fix.