### PR TITLE
ng_udp: add CREATE_STACKTEST to thread creation

### DIFF
--- a/sys/net/transport_layer/ng_udp/ng_udp.c
+++ b/sys/net/transport_layer/ng_udp/ng_udp.c
@@ -263,8 +263,8 @@ int ng_udp_init(void)
     /* check if thread is already running */
     if (_pid == KERNEL_PID_UNDEF) {
         /* start UDP thread */
-        _pid = thread_create(_stack, sizeof(_stack), NG_UDP_PRIO, 0,
-                             _event_loop, NULL, "udp");
+        _pid = thread_create(_stack, sizeof(_stack), NG_UDP_PRIO,
+                             CREATE_STACKTEST, _event_loop, NULL, "udp");
     }
     return _pid;
 }


### PR DESCRIPTION
Independent from the stalled discussion in https://github.com/RIOT-OS/RIOT/issues/2761, we should set this to be consistent with the rest of the stack.