### PR TITLE
ipv6_netif: initialize device dependent values

### DIFF
--- a/drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c
+++ b/drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c
@@ -398,6 +398,13 @@ static int _get(ng_netdev_t *device, ng_netconf_opt_t opt,
             *((uint16_t *)val) = dev->pan;
             return sizeof(uint16_t);
 
+        case NETCONF_OPT_PROTO:
+            if (max_len < sizeof(ng_nettype_t)) {
+                return -EOVERFLOW;
+            }
+            *((ng_nettype_t *)val) = dev->proto;
+            return sizeof(ng_nettype_t);
+
         case NETCONF_OPT_CHANNEL:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -91,6 +91,10 @@
 #include "net/ng_ipv6.h"
 #endif
 
+#ifdef MODULE_NG_IPV6_NETIF
+#include "net/ng_ipv6/netif.h"
+#endif
+
 #ifdef MODULE_L2_PING
 #include "l2_ping.h"
 #endif
@@ -327,4 +331,8 @@ void auto_init(void)
 #endif
 
 #endif /* MODULE_AUTO_INIT_NG_NETIF */
+
+#ifdef MODULE_NG_IPV6_NETIF
+    ng_ipv6_netif_init_by_dev();
+#endif
 }

--- a/sys/include/net/ng_ipv6/netif.h
+++ b/sys/include/net/ng_ipv6/netif.h
@@ -412,6 +412,14 @@ static inline bool ng_ipv6_netif_addr_is_non_unicast(const ng_ipv6_addr_t *addr)
 
 }
 
+/**
+ * @brief   Initializes an interface with device-dependent values.
+ *
+ * @note    Must be called after all interfaces were initialized and must not
+ *          be called in an interface's thread (will otherwise hang up).
+ */
+void ng_ipv6_netif_init_by_dev(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -265,7 +265,7 @@ static void _netif_list(kernel_pid_t dev)
     res = ng_netapi_get(dev, NETCONF_OPT_SRC_LEN, 0, &u16, sizeof(u16));
 
     if (res >= 0) {
-        printf("Source address length: %" PRIu16 "\n            ", u16);
+        printf("Source address length: %" PRIu16 "\n           ", u16);
     }
 
 #ifdef MODULE_NG_IPV6_NETIF


### PR DESCRIPTION
This auto-initializes device dependent values for IPv6 like the link-layer-address dependent IPv6 address or the 6LoWPAN flag. It also fixes some related output. ng_at86rf2xx needed an extra option for get.

Depends on #2901.