### PR TITLE
core: print thread table at crash

### DIFF
--- a/core/panic.c
+++ b/core/panic.c
@@ -28,6 +28,10 @@
 #include "panic.h"
 #include "arch/panic_arch.h"
 
+#if DEVELHELP && defined MODULE_PS
+#include "ps.h"
+#endif
+
 #define PANIC_STR_SIZE 80
 
 /* "public" variables holding the crash data */
@@ -51,6 +55,11 @@ NORETURN void core_panic(int crash_code, const char *message)
         puts("******** SYSTEM FAILURE ********\n");
         puts(message);
 #if DEVELHELP
+#ifdef MODULE_PS
+        ps();
+        puts("");
+#endif
+
         puts("******** RIOT HALTS HERE ********\n");
 #else
         puts("******** RIOT WILL REBOOT ********\n");


### PR DESCRIPTION
This PR is based on #2949 and adds prints the current thread table whenever the system crashes and `DEVELHELP` is enabled. This can be very helpful to quickly figure out if the system crashes because of a stack overflow.