### PR TITLE
make: actually disable a DISABLED_MODULE

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -298,6 +298,7 @@ ifneq (, $(filter all, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
   ifneq (, $(filter $(DISABLE_MODULE), $(USEMODULE)))
     $(shell $(COLOR_ECHO) "$(COLOR_RED)Required modules were disabled using DISABLE_MODULE:$(COLOR_RESET)"\
                           "$(sort $(filter $(DISABLE_MODULE), $(USEMODULE)))" 1>&2)
+    USEMODULE := $(filter-out $(DISABLE_MODULE), $(USEMODULE))
     EXPECT_ERRORS := 1
   endif
 


### PR DESCRIPTION
Make warns about the disablement of a module but does not actually disable it. This fixes it.