### PR TITLE
iotlab: append experiment ID to serial_aggregator

### DIFF
--- a/dist/testbed-support/Makefile.iot-lab
+++ b/dist/testbed-support/Makefile.iot-lab
@@ -23,4 +23,4 @@ iotlab-reset: $(IOTLAB_AUTH)
 
 iotlab-term:
 	ssh -t $(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info "test -f ~/.iotlabrc || auth-cli -u $(IOTLAB_USER)"
-	ssh $(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info "serial_aggregator -i $(IOTLAB_EXP_ID)"
+	ssh -t $(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info "serial_aggregator -i $(IOTLAB_EXP_ID)"

--- a/dist/testbed-support/Makefile.iot-lab
+++ b/dist/testbed-support/Makefile.iot-lab
@@ -23,4 +23,4 @@ iotlab-reset: $(IOTLAB_AUTH)
 
 iotlab-term:
 	ssh -t $(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info "test -f ~/.iotlabrc || auth-cli -u $(IOTLAB_USER)"
-	ssh $(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info serial_aggregator
+	ssh $(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info "serial_aggregator -i $(IOTLAB_EXP_ID)"

--- a/dist/testbed-support/Makefile.iot-lab
+++ b/dist/testbed-support/Makefile.iot-lab
@@ -12,15 +12,15 @@ $(IOTLAB_AUTH):
 	auth-cli -u $(IOTLAB_USER)
 
 iotlab-exp: $(IOTLAB_AUTH)
-	experiment-cli submit -d $(IOTLAB_DURATION) -l $(IOTLAB_NODES),archi=$(IOTLAB_TYPE)+site=$(IOTLAB_SITE),$(ELFFILE) -n riot_makefile_experiment
-	experiment-cli wait
+	$(eval NEW_ID := $(shell experiment-cli submit -d $(IOTLAB_DURATION) -l $(IOTLAB_NODES),archi=$(IOTLAB_TYPE)+site=$(IOTLAB_SITE),$(ELFFILE),$(IOTLAB_PROFILE) -n riot_makefile_experiment | grep -Eo '[[:digit:]]+'))
+	$(AD)experiment-cli wait -i $(NEW_ID)
 
 iotlab-flash: $(IOTLAB_AUTH) all
-	node-cli --update $(ELFFILE) -i $(IOTLAB_EXP_ID)
+	$(AD)node-cli --update $(ELFFILE) -i $(IOTLAB_EXP_ID)
 
 iotlab-reset: $(IOTLAB_AUTH)
-	node-cli --reset -i $(IOTLAB_EXP_ID)
+	$(AD)node-cli --reset -i $(IOTLAB_EXP_ID)
 
 iotlab-term:
-	ssh -t $(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info "test -f ~/.iotlabrc || auth-cli -u $(IOTLAB_USER)"
-	ssh -t $(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info "serial_aggregator -i $(IOTLAB_EXP_ID)"
+	$(AD)ssh -t $(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info "test -f ~/.iotlabrc || auth-cli -u $(IOTLAB_USER)"
+	$(AD)ssh -t $(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info "serial_aggregator -i $(IOTLAB_EXP_ID)"

--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -6,12 +6,15 @@ IOTLAB_SITE     ?= grenoble
 IOTLAB_TYPE     ?= "m3:at86rf231"
 IOTLAB_AUTH     ?= $(HOME)/.iotlabrc
 IOTLAB_USER     ?= $(shell cut -f1 -d: $(IOTLAB_AUTH))
-IOTLAB_EXP_ID   ?= $(shell experiment-cli get -l --state Running | grep '"id"' | sed 's/\ *"id":\ \([0-9]*\),/\1/' | head -n1)
+IOTLAB_EXP_ID   ?= $(shell experiment-cli get -l --state Running | grep -m 1 '"id"' | grep -Eo '[[:digit:]]+')
 
 $(IOTLAB_AUTH):
 	auth-cli -u $(IOTLAB_USER)
 
 iotlab-exp: $(IOTLAB_AUTH)
+    ifeq (,$(AD))
+	    @echo "experiment-cli submit -d $(IOTLAB_DURATION) -l $(IOTLAB_NODES),archi=$(IOTLAB_TYPE)+site=$(IOTLAB_SITE),$(ELFFILE),$(IOTLAB_PROFILE) -n riot_makefile_experiment"
+    endif
 	$(eval NEW_ID := $(shell experiment-cli submit -d $(IOTLAB_DURATION) -l $(IOTLAB_NODES),archi=$(IOTLAB_TYPE)+site=$(IOTLAB_SITE),$(ELFFILE),$(IOTLAB_PROFILE) -n riot_makefile_experiment | grep -Eo '[[:digit:]]+'))
 	$(AD)experiment-cli wait -i $(NEW_ID)
 


### PR DESCRIPTION
Otherwise `make iotlab-term` will fail if more than one experiment is running.