### PR TITLE
net: use sizeof(stack) for thread_create

### DIFF
--- a/sys/net/network_layer/ng_ipv6/ng_ipv6.c
+++ b/sys/net/network_layer/ng_ipv6/ng_ipv6.c
@@ -56,7 +56,7 @@ static void *_event_loop(void *args);
 kernel_pid_t ng_ipv6_init(void)
 {
     if (_pid == KERNEL_PID_UNDEF) {
-        _pid = thread_create(_stack, NG_IPV6_STACK_SIZE, NG_IPV6_PRIO,
+        _pid = thread_create(_stack, sizeof(_stack), NG_IPV6_PRIO,
                              CREATE_STACKTEST, _event_loop, NULL, "ipv6");
     }
 

--- a/sys/net/network_layer/ng_sixlowpan/ng_sixlowpan.c
+++ b/sys/net/network_layer/ng_sixlowpan/ng_sixlowpan.c
@@ -40,7 +40,7 @@ kernel_pid_t ng_sixlowpan_init(void)
         return _pid;
     }
 
-    _pid = thread_create(_stack, NG_SIXLOWPAN_STACK_SIZE, NG_SIXLOWPAN_PRIO,
+    _pid = thread_create(_stack, sizeof(_stack), NG_SIXLOWPAN_PRIO,
                          CREATE_STACKTEST, _event_loop, NULL, "6lo");
 
     return _pid;

--- a/sys/net/routing/etx_beaconing.c
+++ b/sys/net/routing/etx_beaconing.c
@@ -147,15 +147,15 @@ void etx_init_beaconing(ipv6_addr_t *address)
     DEBUGF("ETX BEACON INIT");
     etx_send_buf[0] = ETX_PKT_OPTVAL;
 
-    etx_beacon_pid = thread_create(etx_beacon_buf, ETX_BEACON_STACKSIZE,
+    etx_beacon_pid = thread_create(etx_beacon_buf, sizeof(etx_beacon_buf),
                                    PRIORITY_MAIN - 1, CREATE_STACKTEST,
                                    etx_beacon, NULL, "etx_beacon");
 
-    etx_radio_pid = thread_create(etx_radio_buf, ETX_RADIO_STACKSIZE,
+    etx_radio_pid = thread_create(etx_radio_buf, sizeof(etx_radio_buf),
                                   PRIORITY_MAIN - 1, CREATE_STACKTEST,
                                   etx_radio, NULL, "etx_radio");
 
-    etx_clock_pid = thread_create(etx_clock_buf, ETX_CLOCK_STACKSIZE,
+    etx_clock_pid = thread_create(etx_clock_buf, sizeof(etx_clock_buf),
                                   PRIORITY_MAIN - 1, CREATE_STACKTEST,
                                   etx_clock, NULL, "etx_clock");
     //register at transceiver

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -82,7 +82,7 @@ uint8_t rpl_init(int if_id, ipv6_addr_t *address)
     rpl_max_routing_entries = RPL_MAX_ROUTING_ENTRIES;
 #endif
 
-    rpl_process_pid = thread_create(rpl_process_buf, RPL_PROCESS_STACKSIZE,
+    rpl_process_pid = thread_create(rpl_process_buf, sizeof(rpl_process_buf),
                                     PRIORITY_MAIN - 1, CREATE_STACKTEST,
                                     rpl_process, NULL, "rpl_process");
 


### PR DESCRIPTION
This makes it easier to modify the stack size. I only touched files that will remain at least for some time part of the network stack.