### PR TITLE
Doxygen fixes

### DIFF
--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -2,4 +2,4 @@ doc:
 	doxygen riot.doxyfile
 
 clean:
-	-@rm -rf latex man html
+	-@rm -rf latex man html doxygen_objdb_*.tmp

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -1981,7 +1981,8 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = __attribute__(x)= \
+PREDEFINED             = DOXYGEN \
+                         __attribute__(x)= \
                          ADC_NUMOF \
                          CPUID_ID_LEN \
                          DAC_NUMOF \

--- a/drivers/include/netdev/802154.h
+++ b/drivers/include/netdev/802154.h
@@ -7,7 +7,9 @@
  */
 
 /**
- * @addtogroup  netdev
+ * @defgroup netdev_802154 Network device interface for IEEE 802.15.4 transceivers
+ * @ingroup  netdev
+ * @brief    Network device driver API for IEEE 802.15.4 radio transceivers
  *
  * @{
  * @file

--- a/drivers/include/netdev/default.h
+++ b/drivers/include/netdev/default.h
@@ -22,11 +22,13 @@
 
 #include "netdev/base.h"
 
+#ifdef DOXYGEN
 /**
- * @def     NETDEV_DEFAULT
- *
  * @brief   Default device as a pointer of netdev_t.
  */
+#define NETDEV_DEFAULT
+#endif
+
 #ifdef MODULE_AT86RF231
 #include "at86rf231.h"
 


### PR DESCRIPTION
Some drive-by fixes for Doxygen warnings

 - `make clean` in `doc/doxygen` now removes leftover `doxygen_objdb_xxxxx.tmp` files
 - Added `DOXYGEN` as a predefined macro in Doxygen
 - Add missing `@defgroup netdev_802154` which was causing a warning for an undefined reference.
 - Use `#ifdef DOXYGEN` to document the `NETDEV_DEFAULT` macro