### PR TITLE
icmpv6: add ability to add listed payload in ng_icmpv6_build

### DIFF
--- a/sys/include/net/ng_icmpv6.h
+++ b/sys/include/net/ng_icmpv6.h
@@ -66,6 +66,7 @@ void ng_icmpv6_demux(kernel_pid_t iface, ng_pktsnip_t *pkt);
 /**
  * @brief   Builds an ICMPv6 message for sending.
  *
+ * @param[in] next  Next packet snip in the new packet.
  * @param[in] type  Type for the ICMPv6 message.
  * @param[in] code  Code for the ICMPv6 message.
  * @param[in] size  Size of the ICMPv6 message (needs do be >
@@ -74,7 +75,7 @@ void ng_icmpv6_demux(kernel_pid_t iface, ng_pktsnip_t *pkt);
  * @return  The ICMPv6 message on success
  * @return  NULL, on failure
  */
-ng_pktsnip_t *ng_icmpv6_build(uint8_t type, uint8_t code, size_t size);
+ng_pktsnip_t *ng_icmpv6_build(ng_pktsnip_t *next, uint8_t type, uint8_t code, size_t size);
 
 /* TODO: build error messages */
 

--- a/sys/net/network_layer/ng_icmpv6/echo/ng_icmpv6_echo.c
+++ b/sys/net/network_layer/ng_icmpv6/echo/ng_icmpv6_echo.c
@@ -27,7 +27,7 @@ ng_pktsnip_t *ng_icmpv6_echo_build(uint8_t type, uint16_t id, uint16_t seq,
     ng_pktsnip_t *pkt;
     ng_icmpv6_echo_t *echo;
 
-    if ((pkt = ng_icmpv6_build(type, 0, data_len + sizeof(ng_icmpv6_echo_t))) == NULL) {
+    if ((pkt = ng_icmpv6_build(NULL, type, 0, data_len + sizeof(ng_icmpv6_echo_t))) == NULL) {
         return NULL;
     }
 

--- a/sys/net/network_layer/ng_icmpv6/ng_icmpv6.c
+++ b/sys/net/network_layer/ng_icmpv6/ng_icmpv6.c
@@ -126,12 +126,13 @@ void ng_icmpv6_demux(kernel_pid_t iface, ng_pktsnip_t *pkt)
     }
 }
 
-ng_pktsnip_t *ng_icmpv6_build(uint8_t type, uint8_t code, size_t size)
+ng_pktsnip_t *ng_icmpv6_build(ng_pktsnip_t *next, uint8_t type, uint8_t code,
+                              size_t size)
 {
     ng_pktsnip_t *pkt;
     ng_icmpv6_hdr_t *icmpv6;
 
-    pkt = ng_pktbuf_add(NULL, NULL, size, NG_NETTYPE_ICMPV6);
+    pkt = ng_pktbuf_add(next, NULL, size, NG_NETTYPE_ICMPV6);
 
     if (pkt == NULL) {
         DEBUG("icmpv6_echo: no space left in packet buffer\n");


### PR DESCRIPTION
Since options in NDP are a little bit more versatile than a simple payload, I thought it would be simpler to use the possibilities of the packet buffer here ;-)