### PR TITLE
arm: stm32f0discovery led color fix

### DIFF
--- a/boards/stm32f0discovery/include/board.h
+++ b/boards/stm32f0discovery/include/board.h
@@ -65,12 +65,12 @@ extern "C" {
 #define LD4_TOGGLE          (LED_PORT->ODR ^= LD4_PIN)
 
 /* for compatibility to other boards */
-#define LED_GREEN_ON        LD4_ON
-#define LED_GREEN_OFF       LD4_OFF
-#define LED_GREEN_TOGGLE    LD4_TOGGLE
-#define LED_RED_ON          LD3_ON
-#define LED_RED_OFF         LD3_OFF
-#define LED_RED_TOGGLE      LD3_TOGGLE
+#define LED_GREEN_ON        LD3_ON
+#define LED_GREEN_OFF       LD3_OFF
+#define LED_GREEN_TOGGLE    LD3_TOGGLE
+#define LED_RED_ON          LD4_ON
+#define LED_RED_OFF         LD4_OFF
+#define LED_RED_TOGGLE      LD4_TOGGLE
 /** @} */
 
 /**


### PR DESCRIPTION
Green LED now points to the Green LED on board and Red LED points to Blue LED on board. Previously it was the other way around.