### PR TITLE
make: introduce __SHORT_FILE__ define

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -57,10 +57,16 @@ CXXFLAGS = $(filter-out $(CXXUWFLAGS), $(CFLAGS)) $(CXXEXFLAGS)
 # compile and generate dependency info
 
 $(OBJC): $(BINDIR)$(MODULE)/%.o: %.c
-	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
+	$(AD)$(CC) \
+		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
+		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
+		$(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
 $(OBJCXX): $(BINDIR)$(MODULE)/%.o: %.cpp
-	$(AD)$(CXX) $(CXXFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
+	$(AD)$(CXX) \
+		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
+		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
+		$(CXXFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
 $(ASMOBJ): $(BINDIR)$(MODULE)/%.o: %.s
 	$(AD)$(AS) $(ASFLAGS) -o $@ $(abspath $<)


### PR DESCRIPTION
While fiddling with the logging, I realized that currently the RIOT make system uses absolute paths for filenames, causing ```__FILE__``` to contain the full path.

That is longer than necessary and also exposes the build system (the messages contain e.g., "/home/kaspar/src/riot.bullshit/*"...), it makes it a lot harder to get reproducable builds built on different build systems.

So I propose the define ```__SHORT_FILE__``` that only contains the path starting from $(RIOTBASE).
I tried redefining ```__FILE__```, but gcc complains about that.

Opinions?