### PR TITLE
ipv6_nc: Make interface optional

### DIFF
--- a/sys/include/net/ng_ipv6/nc.h
+++ b/sys/include/net/ng_ipv6/nc.h
@@ -152,7 +152,6 @@ void ng_ipv6_nc_init(void);
  * @brief   Adds a neighbor to the neighbor cache
  *
  * @param[in] iface         PID to the interface where the neighbor is.
- *                          Must not be KERNEL_PID_UNDEF.
  * @param[in] ipv6_addr     IPv6 address of the neighbor. Must not be NULL.
  * @param[in] l2_addr       Link layer address of the neighbor. NULL if unknown.
  * @param[in] l2_addr_len   Length of @p l2_addr, must be lesser than or equal

--- a/sys/net/network_layer/ng_ipv6/nc/ng_ipv6_nc.c
+++ b/sys/net/network_layer/ng_ipv6/nc/ng_ipv6_nc.c
@@ -51,8 +51,7 @@ ng_ipv6_nc_t *ng_ipv6_nc_add(kernel_pid_t iface, const ng_ipv6_addr_t *ipv6_addr
         return NULL;
     }
 
-    if ((l2_addr_len > NG_IPV6_NC_L2_ADDR_MAX) || (iface == KERNEL_PID_UNDEF) ||
-        ng_ipv6_addr_is_unspecified(ipv6_addr)) {
+    if ((l2_addr_len > NG_IPV6_NC_L2_ADDR_MAX) || ng_ipv6_addr_is_unspecified(ipv6_addr)) {
         DEBUG("ipv6_nc: invalid parameters\n");
         return NULL;
     }

--- a/tests/unittests/tests-ipv6_nc/tests-ipv6_nc.c
+++ b/tests/unittests/tests-ipv6_nc/tests-ipv6_nc.c
@@ -76,8 +76,8 @@ static void test_ipv6_nc_add__iface_KERNEL_PID_UNDEF(void)
 {
     ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
 
-    TEST_ASSERT_NULL(ng_ipv6_nc_add(KERNEL_PID_UNDEF, &addr, TEST_STRING4,
-                                    sizeof(TEST_STRING4), 0));
+    TEST_ASSERT_NOT_NULL(ng_ipv6_nc_add(KERNEL_PID_UNDEF, &addr, TEST_STRING4,
+                                        sizeof(TEST_STRING4), 0));
 }
 
 static void test_ipv6_nc_add__addr_unspecified(void)


### PR DESCRIPTION
This is a follow-up to #2721, since it was already ACK'd a second time due to last-minute changes of mine and this is only for the corner-case, that an interface has no IPv6 addresses assigned to it (which our nodes normally don't have) but there is a next hop in the FIB. It also removes some lines and simplifies the API of the neighbor cache, which is always nice :-)