### PR TITLE
gitignore: Ignore KDevelop 4.x project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,6 @@ cachegrind.out*
 .cproject
 .settings
 .idea
+.kdev4
+*.kdev4
 /toolchain


### PR DESCRIPTION
KDevelop creates a project file called `[myproject].kdev4` in the project root, and a hidden directory named .kdev4 containing the project settings. This PR makes git ignore them.