### PR TITLE
fib: rename register function in fib.c too

### DIFF
--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -484,7 +484,7 @@ void fib_deinit(void)
     mutex_unlock(&mtx_access);
 }
 
-int fib_register_rrp(uint8_t *prefix, size_t prefix_size)
+int fib_register_rp(uint8_t *prefix, size_t prefix_size)
 {
     mutex_lock(&mtx_access);
 


### PR DESCRIPTION
https://github.com/RIOT-OS/RIOT/pull/2915 substituted every ``rrp`` with ``rp``, with the exception of ``fib_register_rrp`` in ``fib.c`` (This was a review error on my part). This PR should fix that and the linker drama it causes. 