### PR TITLE
aodvv2: add routes to FIB

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -226,6 +226,7 @@ ifneq (,$(filter aodvv2,$(USEMODULE)))
   USEMODULE += sixlowpan
   USEMODULE += oonf_common
   USEMODULE += oonf_rfc5444
+  USEMODULE += fib
 endif
 
 ifneq (,$(filter uart0,$(USEMODULE)))

--- a/sys/net/routing/aodvv2/aodv.c
+++ b/sys/net/routing/aodvv2/aodv.c
@@ -20,6 +20,7 @@
 #include "aodv.h"
 #include "aodvv2/aodvv2.h"
 #include "aodv_debug.h"
+#include "ng_fib.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -31,6 +32,8 @@ static void _init_addresses(void);
 static void _init_sock_snd(void);
 static void *_aodv_receiver_thread(void *arg);
 static void *_aodv_sender_thread(void *arg);
+static void *fib_signal_handler_thread(void *arg);
+
 static void _deep_free_msg_container(struct msg_container *msg_container);
 static void _write_packet(struct rfc5444_writer *wr __attribute__ ((unused)),
                           struct rfc5444_writer_target *iface __attribute__((unused)),
@@ -43,6 +46,7 @@ static struct netaddr_str nbuf;
 
 static char aodv_rcv_stack_buf[THREAD_STACKSIZE_MAIN];
 static char aodv_snd_stack_buf[THREAD_STACKSIZE_MAIN];
+static char aodv_fib_stack_buf[THREAD_STACKSIZE_MAIN];
 
 static aodvv2_metric_t _metric_type;
 static int sender_thread;
@@ -58,14 +62,23 @@ static mutex_t rrep_mutex;
 static mutex_t rerr_mutex;
 
 struct netaddr na_mcast;
+kernel_pid_t aodvv2_if_id;
+ipv6_addr_t aodvv2_prefix;
+int aodvv2_prefix_len;
 
 void aodv_init(void)
 {
     AODV_DEBUG("%s()\n", __func__);
 
-    /* TODO: set if_id properly */
-    int if_id = 0;
-    net_if_set_src_address_mode(if_id, NET_IF_TRANS_ADDR_M_SHORT);
+    /* init this thread's IPC msg queue (TODO: do I need to do this?) */
+    msg_t msgq[RCV_MSG_Q_SIZE];
+    msg_init_queue(msgq, sizeof msgq);
+
+    /* TODO: set & handle prefix and prefix_len properly (consider AODVV2_RIOT_PREFIXLEN!) */
+    aodvv2_prefix_len = 0;
+    /* TODO: set if_id properly (as param of aodv_init) */
+    aodvv2_if_id = 0;
+    net_if_set_src_address_mode(aodvv2_if_id, NET_IF_TRANS_ADDR_M_SHORT);
 
     mutex_init(&rreq_mutex);
     mutex_init(&rrep_mutex);
@@ -95,10 +108,9 @@ void aodv_init(void)
     sender_thread = thread_create(aodv_snd_stack_buf, sizeof(aodv_snd_stack_buf),
                                   THREAD_PRIORITY_MAIN, CREATE_STACKTEST, _aodv_sender_thread,
                                   NULL, "_aodv_sender_thread");
-
-    /* register aodv for routing */
-    ipv6_iface_set_routing_provider(aodv_get_next_hop);
-
+    thread_create(aodv_fib_stack_buf, sizeof(aodv_fib_stack_buf),
+                                  THREAD_PRIORITY_MAIN, CREATE_STACKTEST, fib_signal_handler_thread,
+                                  NULL, "fib_signal_handler_thread");
 }
 
 void aodv_set_metric_type(aodvv2_metric_t metric_type)
@@ -107,6 +119,64 @@ void aodv_set_metric_type(aodvv2_metric_t metric_type)
         return;
     }
     _metric_type = metric_type;
+}
+/*
+ * @brief handles callbacks from the FIB when it needs a route
+ */
+void *fib_signal_handler_thread(void *arg)
+{
+    (void) arg;
+    ipv6_addr_t dest;
+    struct netaddr na_dest;
+
+    fib_register_rp((uint8_t*) &aodvv2_prefix, aodvv2_prefix_len);
+
+    while (true) {
+        AODV_DEBUG("%s()\n", __func__);
+        msg_t msg;
+        msg_receive(&msg);
+
+        if (msg.type == FIB_MSG_RP_SIGNAL) {
+            rp_address_msg_t* rp_msg = (rp_address_msg_t*)msg.content.ptr;
+            if (rp_msg->address_size == sizeof(ipv6_addr_t)) {
+                /* We currently only support IPv6*/
+                memcpy(&dest, rp_msg->address, rp_msg->address_size);
+                /* Reply to the FIB so that it can stop blocking */
+                msg_reply(&msg, &msg);
+
+                /* perform/initiate a rreq for dst here*/
+                ipv6_addr_t_to_netaddr(&dest, &na_dest);
+
+                aodvv2_seqnum_t seqnum = seqnum_get();
+                seqnum_inc();
+
+                /* Build new RREQ */
+                struct aodvv2_packet_data rreq_data = (struct aodvv2_packet_data) {
+                    .hoplimit = AODVV2_MAX_HOPCOUNT,
+                    .metricType = _metric_type,
+                    .origNode = (struct node_data) {
+                        .addr = na_local,
+                        .metric = 0,
+                        .seqnum = seqnum,
+                    },
+                    .targNode = (struct node_data) {
+                        .addr = na_dest,
+                    },
+                    .timestamp = (timex_t) {0,0} /* this timestamp is never used, it exists
+                                                  * merely to make the compiler shut up */
+                };
+
+                DEBUG("\tstarting route discovery towards %s... \n",
+                      ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN, &dest));
+                aodv_send_rreq(&rreq_data);
+            }
+            else {
+                /* Reply to the FIB so that it can stop blocking */
+                msg_reply(&msg, &msg);
+            }
+        }
+    }
+    return NULL;
 }
 
 void aodv_send_rreq(struct aodvv2_packet_data *packet_data)
@@ -324,116 +394,6 @@ static void *_aodv_receiver_thread(void *arg)
     }
 
     socket_base_close(sock_rcv);
-
-    return NULL;
-}
-
-ipv6_addr_t *aodv_get_next_hop(ipv6_addr_t *dest)
-{
-    AODV_DEBUG("aodv_get_next_hop() %s:",
-          ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN, &_v6_addr_local));
-    DEBUG(" getting next hop for %s\n",
-          ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN, dest));
-
-    struct netaddr _tmp_dest;
-    ipv6_addr_t_to_netaddr(dest, &_tmp_dest);
-    timex_t now;
-    struct unreachable_node unreachable_nodes[AODVV2_MAX_UNREACHABLE_NODES];
-    size_t len;
-
-    /* The network stack sometimes asks us for the next hop towards our own IP */
-    if (memcmp(dest, &_v6_addr_local, sizeof(ipv6_addr_t)) == 0) {
-        AODV_DEBUG("That's me, returning loopback\n");
-        return &_v6_addr_loopback;
-    }
-
-    /*
-     * TODO use ndp_neighbor_get_ll_address() as soon as it's available.
-     * note: delete check for active/stale/delayed entries, get_ll_address
-     * does that for us then
-    */
-    ndp_neighbor_cache_t *ndp_nc_entry = ndp_neighbor_cache_search(dest);
-    struct aodvv2_routing_entry_t *rt_entry = routingtable_get_entry(&_tmp_dest, _metric_type);
-
-    if (ndp_nc_entry != NULL) {
-        /* Case 2: Broken Link (detected by lower layer) */
-        int link_broken = (ndp_nc_entry->state == NDP_NCE_STATUS_INCOMPLETE ||
-                           ndp_nc_entry->state == NDP_NCE_STATUS_PROBE) &&
-                          (rt_entry != NULL && rt_entry->state != ROUTE_STATE_INVALID);
-
-        if (link_broken) {
-            DEBUG("\tNeighbor Cache entry found, but invalid (state: %i). Sending RERR.\n",
-                  ndp_nc_entry->state);
-
-            /* mark all routes (active, idle, expired) that use next_hop as broken
-             * and add all *Active* routes to the list of unreachable nodes */
-            routingtable_break_and_get_all_hopping_over(&_tmp_dest, unreachable_nodes, &len);
-
-            aodv_send_rerr(unreachable_nodes, len, &na_mcast);
-            return NULL;
-        }
-
-        DEBUG("[aodvv2][ndp] found NC entry. Returning dest addr.\n");
-        return dest;
-    }
-
-    DEBUG("\t[ndp] no entry for addr %s found\n",
-          ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN, dest));
-    if (rt_entry) {
-        /* Case 1: Undeliverable Packet */
-        int packet_indeliverable = rt_entry->state == ROUTE_STATE_INVALID;
-        if (packet_indeliverable) {
-            DEBUG("\tRouting table entry found, but invalid (state %i). Sending RERR.\n",
-                  rt_entry->state);
-            unreachable_nodes[0].addr = _tmp_dest;
-            unreachable_nodes[0].seqnum = rt_entry->seqnum;
-            aodv_send_rerr(unreachable_nodes, 1, &na_mcast);
-            return NULL;
-        }
-
-        DEBUG("\tfound dest %s in routing table\n",
-              ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN, dest));
-
-        vtimer_now(&now);
-        rt_entry->lastUsed = now;
-        if (rt_entry->state == ROUTE_STATE_IDLE) {
-            rt_entry->state = ROUTE_STATE_ACTIVE;
-        }
-
-        /* Currently, there is no way to do this, so I'm doing it the worst
-         * possible, but safe way: I can't make sure that the current call to
-         * aodv_get_next_hop() is overridden by another call to aodv_get_next_hop()
-         * by a thread with higher priority, thus messing up return values if I just
-         * use a static ipv6_addr_t.
-         * The following malloc will never be free()'d. TODO: FIX THIS ASAP.
-        */
-        ipv6_addr_t *next_hop = (ipv6_addr_t *) malloc(sizeof(ipv6_addr_t));
-        netaddr_to_ipv6_addr_t(&rt_entry->nextHopAddr, next_hop);
-
-        return next_hop;
-    }
-
-    aodvv2_seqnum_t seqnum = seqnum_get();
-    seqnum_inc();
-
-    struct aodvv2_packet_data rreq_data = (struct aodvv2_packet_data) {
-        .hoplimit = AODVV2_MAX_HOPCOUNT,
-        .metricType = _metric_type,
-        .origNode = (struct node_data) {
-            .addr = na_local,
-            .metric = 0,
-            .seqnum = seqnum,
-        },
-        .targNode = (struct node_data) {
-            .addr = _tmp_dest,
-        },
-        .timestamp = (timex_t) {0,0} /* this timestamp is never used, it exists
-                                      * merely to make the compiler shut up */
-    };
-
-    DEBUG("\tNo route found towards %s, starting route discovery... \n",
-          ipv6_addr_to_str(addr_str, IPV6_MAX_ADDR_STR_LEN, dest));
-    aodv_send_rreq(&rreq_data);
 
     return NULL;
 }

--- a/sys/net/routing/aodvv2/constants.h
+++ b/sys/net/routing/aodvv2/constants.h
@@ -54,6 +54,9 @@ enum tlv_index
 /* my multicast address */
 extern struct netaddr na_mcast;
 
+/* the interface this protocol operates on */
+extern kernel_pid_t aodvv2_if_id;
+
 #ifdef  __cplusplus
 }
 #endif

--- a/tests/aodvv2/Makefile
+++ b/tests/aodvv2/Makefile
@@ -1,0 +1,31 @@
+# name of your application
+APPLICATION = aodvv2_tests
+include ../Makefile.tests_common
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This test has not been verified to work on any other boards-- proceed with caution.
+BOARD_WHITELIST := native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+CFLAGS += -DDEVELHELP
+CFLAGS += -DRIOT
+CFLAGS += -DFIB_DEVEL_HELPER
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+# Modules to include
+USEMODULE += defaulttransceiver
+USEMODULE += aodvv2
+USEMODULE += udp
+
+export INCLUDES += -I$(RIOTBASE)/sys/net/routing/aodvv2/
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/aodvv2/aodv_fib_tests.c
+++ b/tests/aodvv2/aodv_fib_tests.c
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2014 Hochschule für Angewandte Wissenschaften Hamburg (HAW)
+ * Copyright (C) 2015 Lotte Steenbrink <lotte.steenbrink@haw-hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       tests for the interaction between AODVv2 and the FIB
+ *
+ * @author      Lotte Steenbrink <lotte.steenbrink@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+
+#include "aodv_fib_tests.h"
+#include "aodv_tests.h"
+
+#include "common/autobuf.h"
+#include "rfc5444/rfc5444_writer.h"
+#include "rfc5444/rfc5444_print.h"
+#include "ng_fib.h"
+
+#include "reader.h"
+#include "utils.h"
+
+
+/* make sure packet is not rejected because "sender" is not in the neighbor cache */
+static void _aodv_test_add_to_nc(struct netaddr *sender_na){
+    ipv6_addr_t sender;
+
+    netaddr_to_ipv6_addr_t(sender_na, &sender);
+    /* TODO: isrouter = 1 correct? */
+    ndp_neighbor_cache_add(aodvv2_iface_id, &sender, &sender.uint16[7], 2, 1,
+                        NDP_NCE_STATUS_REACHABLE, NDP_NCE_TYPE_TENTATIVE, 0xffff);
+}
+
+/* Handle RREQ with no anomalies */
+static void aodv_test_add_to_fib_regular_rreq(void)
+{
+    printf("\n============= Handling regular RREQ ================================\n");
+    ipv6_addr_t next_hop;
+    kernel_pid_t iface_id;
+    size_t next_hop_size = sizeof(ipv6_addr_t);
+    uint32_t next_hop_flags = 0;
+
+    _aodv_test_add_to_nc(aodv_test_plain_rreq.sender);
+    aodv_packet_reader_handle_packet((void *) aodv_test_plain_rreq.buffer,
+                                     aodv_test_plain_rreq.length,
+                                     aodv_test_plain_rreq.sender);
+
+    printf("Checking FIB ...\n");
+
+    /* Check if route back to origaddr was created */
+    int fib_success = fib_get_next_hop(&iface_id, &next_hop.uint8[0], &next_hop_size,
+                                       &next_hop_flags, aodvv2_test_origaddr._addr,
+                                       sizeof(ipv6_addr_t), 0);
+    assert(0 == fib_success);
+
+    printf("Done.\n");
+}
+
+/* Handle RREQ with no anomalies */
+static void aodv_test_add_to_fib_regular_rrep(void)
+{
+    printf("\n============= Handling regular RREP ================================\n");
+    ipv6_addr_t next_hop;
+    kernel_pid_t iface_id;
+    size_t next_hop_size = sizeof(ipv6_addr_t);
+    uint32_t next_hop_flags = 0;
+    timex_t now;
+
+    _aodv_test_add_to_nc(aodv_test_plain_rrep.sender);
+
+    /* Make sure route back is known TODO make this global too?!*/
+    vtimer_now(&now);
+    struct aodvv2_routing_entry_t tmp_rt_entry = {
+        .addr = aodvv2_test_origaddr,
+        .seqnum = 1,
+        .nextHopAddr = aodvv2_test_sender_oa,
+        .lastUsed = now,
+        .expirationTime = timex_add(now,
+                                    timex_set(AODVV2_ACTIVE_INTERVAL + AODVV2_MAX_IDLETIME, 0)),
+        .metricType = AODVV2_DEFAULT_METRIC_TYPE,
+        .metric = 2,
+        .state = ROUTE_STATE_ACTIVE,
+    };
+    routingtable_add_entry(&tmp_rt_entry);
+
+    aodv_packet_reader_handle_packet((void *) aodv_test_plain_rrep.buffer,
+                                     aodv_test_plain_rrep.length,
+                                     aodv_test_plain_rrep.sender);
+    printf("Checking FIB ...\n");
+
+    /* Check if route back to origaddr was created */
+    int fib_success = fib_get_next_hop(&iface_id, &next_hop.uint8[0], &next_hop_size,
+                                       &next_hop_flags, aodvv2_test_targaddr._addr,
+                                       sizeof(ipv6_addr_t), 0);
+    assert(0 == fib_success);
+    printf("Done.\n");
+}
+
+static void aodv_test_update_fib_regular_rreq(void)
+{
+    printf("\n============= Handling more recent RREQ ============================\n");
+    timex_t lifetime, now;
+
+    printf("Checking FIB ...\n");
+    aodv_packet_reader_handle_packet((void *) aodv_test_more_recent_rreq.buffer,
+                                     aodv_test_more_recent_rreq.length,
+                                     aodv_test_more_recent_rreq.sender);
+
+    assert(0 == fib_devel_get_lifetime(&lifetime, aodvv2_test_origaddr._addr, sizeof(ipv6_addr_t)));
+
+    /* assuming some ms passed during these operations... */
+    vtimer_now(&now);
+    timex_t cmp_lifetime = timex_add(now, timex_set(0, 900000));
+    assert(1 == timex_cmp(lifetime, cmp_lifetime));
+
+    printf("Done. \n");
+}
+
+static void aodv_test_update_fib_regular_rrep(void)
+{
+    printf("\n============= Handling more recent RREP ============================\n");
+    timex_t lifetime, now;
+
+    printf("Checking FIB ...\n");
+    aodv_packet_reader_handle_packet((void *) aodv_test_more_recent_rrep.buffer,
+                                     aodv_test_more_recent_rrep.length,
+                                     aodv_test_more_recent_rrep.sender);
+
+    assert(0 == fib_devel_get_lifetime(&lifetime, aodvv2_test_targaddr._addr, sizeof(ipv6_addr_t)));
+
+    /* assuming some ms passed during these operations... */
+    vtimer_now(&now);
+    timex_t cmp_lifetime = timex_add(now, timex_set(0, 900000));
+    assert(1 == timex_cmp(lifetime, cmp_lifetime));
+    printf("Done.\n");
+}
+
+static void aodv_test_route_expired(void)
+{
+    printf("\n============= testing if route vanishes after expiring ===========\n");
+    kernel_pid_t iface_id;
+    uint32_t next_hop_flags = 0;
+    size_t next_hop_size = sizeof(ipv6_addr_t);
+    ipv6_addr_t next_hop;
+
+    printf("waiting until route expires... (about 4.5 minutes)\n");
+    /* TODO: use MAXTIME */
+    sleep(AODVV2_ACTIVE_INTERVAL + AODVV2_MAX_IDLETIME);
+    printf("Checking FIB ...\n");
+
+    /* Check if route back to origaddr was created */
+    int fib_success = fib_get_next_hop(&iface_id, &next_hop.uint8[0], &next_hop_size,
+                                       &next_hop_flags, aodvv2_test_origaddr._addr,
+                                       sizeof(ipv6_addr_t), 0);
+    assert( 0 != fib_success);
+
+    printf("Done.\n");
+
+}
+
+void aodv_test_add_to_fib(void)
+{
+    /* overwrite the aodvv2 packet writer so that messages aren't actually swnt */
+    aodv_packet_writer_init(aodv_test_drop_packet);
+
+    printf("Starting tests...\n");
+    aodv_test_add_to_fib_regular_rreq();
+    sleep(5);
+    aodv_test_update_fib_regular_rreq();
+    sleep(5);
+    aodv_test_add_to_fib_regular_rrep();
+    sleep(5);
+    aodv_test_update_fib_regular_rrep();
+    sleep(5);
+    aodv_test_route_expired();
+    printf("All done!\n");
+}

--- a/tests/aodvv2/aodv_fib_tests.h
+++ b/tests/aodvv2/aodv_fib_tests.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2014 Hochschule für Angewandte Wissenschaften Hamburg (HAW)
+ * Copyright (C) 2015 Lotte Steenbrink <lotte.steenbrink@haw-hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       tests for the interaction between AODVv2 and the FIB
+ *
+ * @author      Lotte Steenbrink <lotte.steenbrink@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#ifndef AODV_FIB_TESTS_H_
+#define AODV_FIB_TESTS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void aodv_test_add_to_fib(void);
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* AODV_FIB_TESTS_H_ */

--- a/tests/aodvv2/aodv_tests.h
+++ b/tests/aodvv2/aodv_tests.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2014 Hochschule für Angewandte Wissenschaften Hamburg (HAW)
+ * Copyright (C) 2015 Lotte Steenbrink <lotte.steenbrink@haw-hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       constants and global variables for AODVv2 tests
+ *
+ * @author      Lotte Steenbrink <lotte.steenbrink@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#ifndef AODV_TESTS_H_
+#define AODV_TESTS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "udp.h"
+
+#include "rfc5444/rfc5444_writer.h"
+
+#define AODV_TEST_MSGBUF_MAX            (500)
+
+typedef struct
+{
+    unsigned char buffer[AODV_TEST_MSGBUF_MAX];
+    uint8_t length;
+    struct netaddr* sender;
+} aodvv2_test_msg;
+
+
+extern radio_address_t aodvv2_iface_id;
+
+extern aodvv2_test_msg aodv_test_plain_rreq;
+extern aodvv2_test_msg aodv_test_more_recent_rreq;
+extern aodvv2_test_msg aodv_test_plain_rrep;
+extern aodvv2_test_msg aodv_test_more_recent_rrep;
+
+/*
+Messages will always be sent/stored along the following path:
+OrigAddr -> sender_oa -> TESTNODE -> sender_ta -> TargAddr
+OrigAddr <- sender_oa <- TESTNODE <- sender_ta <- TargAddr */
+extern struct netaddr aodvv2_test_origaddr;
+extern struct netaddr aodvv2_test_sender_oa;
+extern struct netaddr aodvv2_test_sender_ta;
+extern struct netaddr aodvv2_test_targaddr;
+
+/* callback for the rfc5444 packet writer. can be set with aodv_packet_writer_init()
+ * To enforce the dropping of all control packets (and reduce overhead) */
+void aodv_test_drop_packet(struct rfc5444_writer *wr __attribute__ ((unused)),
+                          struct rfc5444_writer_target *iface __attribute__((unused)),
+                          void *buffer, size_t length);
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* AODV_FIB_TESTS_H_ */

--- a/tests/aodvv2/aodv_writer_tests.c
+++ b/tests/aodvv2/aodv_writer_tests.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2014 Hochschule für Angewandte Wissenschaften Hamburg (HAW)
+ * Copyright (C) 2015 Lotte Steenbrink <lotte.steenbrink@haw-hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       tests for the AODVv2 writer
+ *
+ * @author      Lotte Steenbrink <lotte.steenbrink@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <unistd.h>
+
+#include "aodv_writer_tests.h"
+#include "aodv_tests.h"
+
+#include "aodv.h"
+#include "aodvv2/aodvv2.h"
+
+#include "common/autobuf.h"
+#include "rfc5444/rfc5444_writer.h"
+#include "rfc5444/rfc5444_print.h"
+#include "writer.h"
+#include "thread.h"
+
+aodvv2_test_msg aodv_test_plain_rreq;
+aodvv2_test_msg aodv_test_more_recent_rreq;
+aodvv2_test_msg aodv_test_plain_rrep;
+aodvv2_test_msg aodv_test_more_recent_rrep;
+
+static aodvv2_test_msg* current_msg; /* Point to the buffer the current message should be written to.
+                                    * Yes, this is awful, but I fear the oonf_apis
+                                    * callback infrastructure leaves me no other choice...
+                                    * Sorry. :( */
+
+/* All the test data */
+static timex_t now, validity_t;
+
+static struct aodvv2_packet_data plain_rreq_msg, plain_rrep_msg;
+
+static int aodv_test_writer_init_data(void)
+{
+    vtimer_now(&now);
+    validity_t = timex_set(AODVV2_ACTIVE_INTERVAL + AODVV2_MAX_IDLETIME, 0);
+
+    plain_rreq_msg = (struct aodvv2_packet_data) {
+        .hoplimit = AODVV2_MAX_HOPCOUNT,
+        .sender = aodvv2_test_sender_oa,
+        .metricType = AODVV2_DEFAULT_METRIC_TYPE,
+        .origNode = {
+            .addr = aodvv2_test_origaddr,
+            .metric = 2,
+            .seqnum = 1,
+        },
+        .targNode = {
+            .addr = aodvv2_test_targaddr,
+            .metric = 12,
+            .seqnum = 1,
+        },
+        .timestamp = now,
+    };
+
+    vtimer_now(&now);
+    plain_rrep_msg = (struct aodvv2_packet_data) {
+        .hoplimit = AODVV2_MAX_HOPCOUNT,
+        .sender = aodvv2_test_sender_ta,
+        .metricType = AODVV2_DEFAULT_METRIC_TYPE,
+        .origNode = {
+            .addr = aodvv2_test_origaddr,
+            .metric = 4,
+            .seqnum = 1,
+        },
+        .targNode = {
+            .addr = aodvv2_test_targaddr,
+            .metric = 2,
+            .seqnum = 2,
+        },
+        .timestamp = now,
+    };
+
+    return 0;
+}
+
+static void aodv_test_write_packet(struct rfc5444_writer *wr __attribute__ ((unused)),
+                          struct rfc5444_writer_target *iface __attribute__((unused)),
+                          void *buffer, size_t length)
+{
+    printf("Writing message to buffer\n");
+    /* make sure buffer is clear */
+    memcpy(current_msg->buffer, buffer, length);
+    current_msg->length = length;
+    printf("Done.\n");
+}
+
+static void aodv_test_writer_write_new_rreq(void)
+{
+    current_msg = &aodv_test_plain_rreq;
+    current_msg->sender = &aodvv2_test_sender_oa;
+    aodv_send_rreq(&plain_rreq_msg);
+}
+
+static void aodv_test_writer_write_more_recent_rreq(void)
+{
+    plain_rreq_msg.origNode.seqnum += 1;
+    current_msg = &aodv_test_more_recent_rreq;
+    current_msg->sender = &aodvv2_test_sender_oa;
+    aodv_send_rreq(&plain_rreq_msg);
+}
+
+static void aodv_test_writer_write_new_rrep(void)
+{
+    current_msg = &aodv_test_plain_rrep;
+    current_msg->sender = &aodvv2_test_sender_ta;
+    aodv_send_rrep(&plain_rrep_msg, &aodvv2_test_sender_ta);
+}
+
+static void aodv_test_writer_write_more_recent_rrep(void)
+{
+    plain_rrep_msg.targNode.seqnum += 1;
+    current_msg = &aodv_test_more_recent_rrep;
+    current_msg->sender = &aodvv2_test_sender_ta;
+    aodv_send_rrep(&plain_rrep_msg, &aodvv2_test_sender_ta);
+}
+
+/* Store packets in buffers that we can use them for testing */
+void write_packets_to_buf(void)
+{
+    printf("============= Preparing to write packets to buffers ==================\n");
+
+    /* Make sure the threads are up and running */
+    sleep(2);
+
+    if (0 != aodv_test_writer_init_data()){
+        printf ("FAILED: unable to init data!\n");
+        return;
+    }
+    /* overwrite the aodvv2 packet writer */
+    aodv_packet_writer_init(aodv_test_write_packet);
+
+    aodv_test_writer_write_new_rreq();
+
+    /* make sure sender_thread is done */
+    sleep(2);
+    aodv_test_writer_write_more_recent_rreq();
+
+    /* make sure sender_thread is done */
+    sleep(2);
+    aodv_test_writer_write_new_rrep();
+
+    /* make sure sender_thread is done */
+    sleep(2);
+    aodv_test_writer_write_more_recent_rrep();
+
+    /* give current writer time to finish and init aodvv2 again cleanly
+     * to undo the change to the aodv_packet_writer callback */
+    sleep(2);
+    aodv_init();
+}

--- a/tests/aodvv2/aodv_writer_tests.h
+++ b/tests/aodvv2/aodv_writer_tests.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2014 Hochschule für Angewandte Wissenschaften Hamburg (HAW)
+ * Copyright (C) 2015 Lotte Steenbrink <lotte.steenbrink@haw-hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       tests for the AODVv2 writer
+ *
+ * @author      Lotte Steenbrink <lotte.steenbrink@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#ifndef AODV_WRITER_TESTS_H_
+#define AODV_WRITER_TESTS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void write_packets_to_buf(void);
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* AODV_WRITER_TESTS_H_ */

--- a/tests/aodvv2/main.c
+++ b/tests/aodvv2/main.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2014 Hochschule für Angewandte Wissenschaften Hamburg (HAW)
+ * Copyright (C) 2015 Lotte Steenbrink <lotte.steenbrink@haw-hamburg.de>
+ * Copyright (C) 2014 Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       tests for the interaction between AODVv2 and the FIB
+ *
+ * @author      Lotte Steenbrink <lotte.steenbrink@haw-hamburg.de>
+ * @author      Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+
+#include "udp.h"
+#include "thread.h"
+
+#include "aodvv2/aodvv2.h"
+
+#include "aodv_writer_tests.h"
+#include "aodv_fib_tests.h"
+#include "aodv_tests.h"
+
+#define AODVV2_IFACE           (0)      /**< The used Trasmssion device */
+
+/** The node IPv6 address */
+ipv6_addr_t myaddr;
+
+radio_address_t aodvv2_iface_id;
+struct netaddr aodvv2_test_sender_oa, aodvv2_test_sender_ta, aodvv2_test_origaddr, aodvv2_test_targaddr;
+
+/**
+* @brief prepares this node
+* @return 0 on success
+*/
+static int aodvv2_setup_node(void)
+{
+    /* setup the radio interface */
+    if( net_if_set_src_address_mode(AODVV2_IFACE, NET_IF_TRANS_ADDR_M_SHORT) != 1 ) {
+        return -1;
+    }
+
+    aodvv2_iface_id = net_if_get_hardware_address(AODVV2_IFACE);
+    if( aodvv2_iface_id == 0 ) {
+        return -1;
+    }
+
+    /* choose addresses */
+    ipv6_addr_init(&myaddr, 0x2015, 0x3, 0x18, 0x1111, 0x0, 0x0, 0x0, aodvv2_iface_id);
+
+    /* and set it */
+    if( ipv6_net_if_add_addr(AODVV2_IFACE, &myaddr, NDP_ADDR_STATE_PREFERRED, 0, 0, 0) != 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/**
+* @brief init data that needs to be globally known
+*/
+static int aodvv2_init_testdata(void)
+{
+    if( netaddr_from_string(&aodvv2_test_origaddr, "::10") == -1 ) {
+        return -1;
+    }
+
+    if( netaddr_from_string(&aodvv2_test_sender_oa, "::11") == -1 ) {
+        return -1;
+    }
+
+    if( netaddr_from_string(&aodvv2_test_sender_ta, "::12") == -1 ) {
+        return -1;
+    }
+
+    if( netaddr_from_string(&aodvv2_test_targaddr, "::13") == -1 ) {
+        return -1;
+    }
+    return 0;
+}
+
+void aodv_test_drop_packet(struct rfc5444_writer *wr __attribute__ ((unused)),
+                          struct rfc5444_writer_target *iface __attribute__((unused)),
+                          void *buffer, size_t length)
+{
+    (void) buffer;
+    (void) length;
+}
+
+int main(void)
+{
+    if( aodvv2_init_testdata() != 0 ) {
+        return -1;
+    }
+
+    if( aodvv2_setup_node() != 0 ) {
+        return -1;
+    }
+
+    aodv_init();
+
+    write_packets_to_buf();
+
+    sleep(5);
+
+    /* TODO:
+    - use route and see if it updates the lifetime
+    */
+    aodv_test_add_to_fib();
+
+    return 0;
+}


### PR DESCRIPTION
This PR introduces the FIB to AODVv2. All routes which are found will be added to the FIB, and the FIB now initiates route discoveries.
What's still missing is that routes aren't updated when they are used. This will be introduced after https://github.com/RIOT-OS/RIOT/pull/2815 has been merged. 
The tests are pretty rudimentary, but I thought I'd include them anyway for clarity. if you want to, I can remove them.