### PR TITLE
ng_ethertype: add unknown ethertype

### DIFF
--- a/sys/include/net/ng_ethertype.h
+++ b/sys/include/net/ng_ethertype.h
@@ -35,6 +35,7 @@ extern "C" {
 #define NG_ETHERTYPE_IPV4       (0x0800)    /**< Internet protocol version 4 */
 #define NG_ETHERTYPE_ARP        (0x0806)    /**< Address resolution protocol */
 #define NG_ETHERTYPE_IPV6       (0x86dd)    /**< Internet protocol version 6 */
+#define NG_ETHERTYPE_UNKNOWN    (0xffff)    /**< Reserved (no protocol specified) */
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/ng_nettype.h
+++ b/sys/include/net/ng_nettype.h
@@ -130,7 +130,7 @@ static inline uint16_t ng_nettype_to_ethertype(ng_nettype_t type)
             return NG_ETHERTYPE_IPV6;
 #endif
         default:
-            return NG_ETHERTYPE_RESERVED;
+            return NG_ETHERTYPE_UNKNOWN;
     }
 }
 


### PR DESCRIPTION
Wireshark uses `0x0000` to disect a certain protocol (forgot what it was, but don't really care to look it up). This PR introduces `NG_ETHERTYPE_UNKNOWN` == `0xffff` so we can use it experimentally for `NG_NETTYPE_UNDEF` payloads (since it is not disected by Wireshark).