### PR TITLE
periph_pwm: Return actual frequency (like the docs say)

### DIFF
--- a/cpu/lpc2387/periph/pwm.c
+++ b/cpu/lpc2387/periph/pwm.c
@@ -82,7 +82,7 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
 #endif
     }
 
-    return 0;
+    return frequency;
 }
 
 int pwm_set(pwm_t dev, int channel, unsigned int value)

--- a/cpu/stm32f3/periph/pwm.c
+++ b/cpu/stm32f3/periph/pwm.c
@@ -125,7 +125,7 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
     /* enable PWM generation */
     pwm_start(dev);
 
-    return 0;
+    return frequency;
 }
 
 int pwm_set(pwm_t dev, int channel, unsigned int value)

--- a/cpu/stm32f4/periph/pwm.c
+++ b/cpu/stm32f4/periph/pwm.c
@@ -157,7 +157,7 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
     /* enable timer ergo the PWM generation */
     pwm_start(dev);
 
-    return 0;
+    return frequency;
 }
 
 int pwm_set(pwm_t dev, int channel, unsigned int value)

--- a/drivers/include/periph/pwm.h
+++ b/drivers/include/periph/pwm.h
@@ -76,7 +76,7 @@ typedef enum {
  * @param[in] frequency     the PWM frequency in Hz
  * @param[in] resolution    the PWM resolution
  *
- * @return                  0 on success
+ * @return                  Actual PWM frequency on success
  * @return                  -1 on mode not applicable
  * @return                  -2 on frequency and resolution not applicable
  */

--- a/tests/periph_pwm/main.c
+++ b/tests/periph_pwm/main.c
@@ -48,16 +48,15 @@ int main(void)
     int step = STEP;
 
     puts("\nRIOT PWM test");
-    puts("Connect an LED or scope to PWM pins to see something\n");
+    puts("Connect an LED or scope to PWM pins to see something");
 
     res = pwm_init(DEV, MODE, FREQU, STEPS);
-    if (res == 0) {
-        puts("PWM successfully initialized.\n");
-    }
-    else {
+    if (res < 0) {
         puts("Errors while initializing PWM");
         return -1;
     }
+    puts("PWM initialized.");
+    printf("requested: %d Hz, got %d Hz\n", FREQU, res);
 
     while (1) {
         for (int i = 0; i < CHANNELS; i++) {


### PR DESCRIPTION
The documentation and the implementation were not entirely coherent for the PWM peripheral API.

This PR changes the return value of `pwm_init` to be the actual frequency achieved by the PWM peripheral.

The long description of `pwm_init` in Doxygen has the following text:

>The desired frequency and resolution may not be possible on a given device when chosen too large. In this case the PWM driver will always keep the resolution and decrease the frequency if needed. **To verify the correct settings compare the returned value which is the actually set frequency.**

Returning the actual frequency achieved is useful in cases where the timing is more important than the resolution.

STM32F3, STM32F4 and LPC2387 seem to use a very flexible prescaler for the PWM clock and can achieve almost any frequency requested, but the Kinetis platforms only support prescaler values that are a power of two, and only up to 128 (1, 2, 4, 8, 16, 32, 64, 128). 