### PR TITLE
sys/.../icmp.c: fix prefix search

### DIFF
--- a/sys/net/network_layer/sixlowpan/icmp.c
+++ b/sys/net/network_layer/sixlowpan/icmp.c
@@ -1846,7 +1846,7 @@ ndp_prefix_info_t *ndp_prefix_info_search(int if_id, const ipv6_addr_t *addr,
                 }
             }
 
-            if (prefix->prefix_len == 0 && match > best_match) {
+            if ((prefix->prefix_len != 0) && (match > best_match)) {
                 tmp = prefix;
                 best_match = match;
             }


### PR DESCRIPTION
Replace equal operator inside ndp_prefix_info_search by not equal.
Otherwise, the existing prefix can not be found.