### PR TITLE
ng_icmpv6: pre-set checksum field to 0 for sending

### DIFF
--- a/sys/net/network_layer/ng_icmpv6/ng_icmpv6.c
+++ b/sys/net/network_layer/ng_icmpv6/ng_icmpv6.c
@@ -144,6 +144,7 @@ ng_pktsnip_t *ng_icmpv6_build(ng_pktsnip_t *next, uint8_t type, uint8_t code,
     icmpv6 = (ng_icmpv6_hdr_t *)pkt->data;
     icmpv6->type = type;
     icmpv6->code = code;
+    icmpv6->csum.u16 = 0;
 
     return pkt;
 }


### PR DESCRIPTION
Hopefully fixes #2988.