### PR TITLE
sys/compat/hwtimer: fix unused fcpu warning

### DIFF
--- a/sys/compat/hwtimer/hwtimer_arch.c
+++ b/sys/compat/hwtimer/hwtimer_arch.c
@@ -35,6 +35,8 @@ void (*timeout_handler)(int);
 
 void hwtimer_arch_init(void (*handler)(int), uint32_t fcpu)
 {
+    (void) fcpu;
+
     timeout_handler = handler;
     timer_init(HW_TIMER, 1, &irq_handler);
 }


### PR DESCRIPTION
Fixes the warning mentioned here:
https://github.com/RIOT-OS/RIOT/pull/2870#issuecomment-100448051