### PR TITLE
oonf_api: update pkg url

### DIFF
--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME=oonf_api
-PKG_URL=git://olsr.org/oonf_api.git
+PKG_URL=git://olsr.org/oonf.git
 PKG_VERSION=v0.3.0
 
 ifneq ($(RIOTBOARD),)


### PR DESCRIPTION
The old url from which we cloned the oonf api was apparently deprecated and the repo got deleted now (causing Travis to complain ;) ). This PR updates it.