### PR TITLE
boards/pba-d-01-kw2x: add board to m4 travis build group

### DIFF
--- a/boards/pba-d-01-kw2x/Makefile.features
+++ b/boards/pba-d-01-kw2x/Makefile.features
@@ -8,3 +8,4 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_random
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_MCU_GROUP = cortex_m4


### PR DESCRIPTION
Travis did not build pba-d-01-kw2x board, since it was not assigned to any cpu-group. This PR adds the board to m4-group.