### PR TITLE
add the FIB as a dependency for sixlowpan

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -46,6 +46,7 @@ ifneq (,$(filter sixlowpan,$(USEMODULE)))
   USEMODULE += net_if
   USEMODULE += posix
   USEMODULE += vtimer
+  USEMODULE += fib
 endif
 
 ifneq (,$(filter ng_netif,$(USEMODULE)))


### PR DESCRIPTION
My Travis builds fail (among other things) because the rpl_udp example (which I didn't change anything about) doesn't build, and on my machine I get the following error:

    /home/lotte/riot/RIOT/sys/net/network_layer/sixlowpan/ip.c:36:10: fatal error: 'ng_fib.h'
          file not found
     #include "ng_fib.h"
              ^

This PR should fix this, although I'm not completely sure if I'm just missing something right now, since this would've stalled quite some builds....