### PR TITLE
sys/net/routing/rpl: Remove redundant self-assign in rpl global repair

### DIFF
--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -397,7 +397,6 @@ void rpl_global_repair(rpl_dodag_t *my_dodag, ipv6_addr_t *p_addr, uint16_t rank
     }
 
     rpl_delete_all_parents(my_dodag);
-    my_dodag->version = my_dodag->version;
     my_dodag->dtsn++;
     my_dodag->my_preferred_parent = rpl_new_parent(my_dodag, p_addr, rank);
 


### PR DESCRIPTION
cppcheck said:
`sys/net/routing/rpl/rpl_dodag.c:400: warning (selfAssignment): Redundant assignment of 'my_dodag.version' to itself.`

RFC6550 says:
>A DODAG root institutes a global repair operation by incrementing the DODAGVersionNumber.  This initiates a new DODAG Version.

I am not sure if the global repair is actually supported in this implementation since I can only find one reference to this function in the code, but the implementation should at least not assign a variable to itself.