### PR TITLE
cppcheck drive-by fixes

### DIFF
--- a/cpu/cortex-m0_common/include/core_cmFunc.h
+++ b/cpu/cortex-m0_common/include/core_cmFunc.h
@@ -345,6 +345,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_CONTROL(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, control" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -372,6 +373,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_IPSR(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, ipsr" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -387,6 +389,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_APSR(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, apsr" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -402,6 +405,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_xPSR(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, xpsr" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -417,6 +421,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PSP(void)
   register uint32_t result;
 
   __ASM volatile ("MRS %0, psp\n"  : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -444,6 +449,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_MSP(void)
   register uint32_t result;
 
   __ASM volatile ("MRS %0, msp\n" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -471,6 +477,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PRIMASK(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, primask" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 

--- a/cpu/cortex-m3_common/include/core_cmFunc.h
+++ b/cpu/cortex-m3_common/include/core_cmFunc.h
@@ -345,6 +345,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_CONTROL(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, control" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -372,6 +373,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_IPSR(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, ipsr" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -387,6 +389,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_APSR(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, apsr" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -402,6 +405,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_xPSR(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, xpsr" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -417,6 +421,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PSP(void)
   register uint32_t result;
 
   __ASM volatile ("MRS %0, psp\n"  : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -444,6 +449,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_MSP(void)
   register uint32_t result;
 
   __ASM volatile ("MRS %0, msp\n" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -471,6 +477,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PRIMASK(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, primask" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 

--- a/cpu/cortex-m4_common/include/core_cmFunc.h
+++ b/cpu/cortex-m4_common/include/core_cmFunc.h
@@ -345,6 +345,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_CONTROL(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, control" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -372,6 +373,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_IPSR(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, ipsr" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -387,6 +389,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_APSR(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, apsr" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -402,6 +405,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_xPSR(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, xpsr" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -417,6 +421,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PSP(void)
   register uint32_t result;
 
   __ASM volatile ("MRS %0, psp\n"  : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -444,6 +449,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_MSP(void)
   register uint32_t result;
 
   __ASM volatile ("MRS %0, msp\n" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -471,6 +477,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PRIMASK(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, primask" : "=r" (result) );
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 

--- a/sys/net/network_layer/ng_ndp/ng_ndp.c
+++ b/sys/net/network_layer/ng_ndp/ng_ndp.c
@@ -545,11 +545,11 @@ static void _send_nbr_sol(kernel_pid_t iface, ng_ipv6_addr_t *tgt,
     ng_pktsnip_t *hdr, *pkt = NULL;
     ng_ipv6_addr_t *src = NULL;
     size_t src_len = 0;
-    uint8_t l2src[8];
-    uint16_t l2src_len;
 
     /* check if there is a fitting source address to target */
     if ((src = ng_ipv6_netif_find_best_src_addr(iface, tgt)) != NULL) {
+        uint8_t l2src[8];
+        uint16_t l2src_len;
         src_len = sizeof(ng_ipv6_addr_t);
         l2src_len = _get_l2src(l2src, sizeof(l2src), iface);
 
@@ -605,8 +605,6 @@ static void _send_nbr_adv(kernel_pid_t iface, ng_ipv6_addr_t *tgt,
                           ng_ipv6_addr_t *dst, bool supply_tl2a)
 {
     ng_pktsnip_t *hdr, *pkt = NULL;
-    uint8_t l2src[8];
-    uint16_t l2src_len;
     uint8_t adv_flags = 0;
 
     if (ng_ipv6_netif_get(iface)->flags & NG_IPV6_NETIF_FLAGS_ROUTER) {
@@ -622,6 +620,8 @@ static void _send_nbr_adv(kernel_pid_t iface, ng_ipv6_addr_t *tgt,
     }
 
     if (supply_tl2a) {
+        uint8_t l2src[8];
+        uint16_t l2src_len;
         /* we previously checked if we are the target, so we can take our L2src */
         l2src_len = _get_l2src(l2src, sizeof(l2src), iface);
 

--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -729,9 +729,9 @@ void ipv6_net_if_get_best_src_addr(ipv6_addr_t *src, const ipv6_addr_t *dest)
     int if_id = 0; // TODO: get this somehow
     ipv6_net_if_addr_t *addr = NULL;
     ipv6_net_if_addr_t *tmp_addr = NULL;
-    uint8_t bmatch = 0;
 
     if (!(ipv6_addr_is_link_local(dest)) && !(ipv6_addr_is_multicast(dest))) {
+        uint8_t bmatch = 0;
         while ((addr = (ipv6_net_if_addr_t *) net_if_iter_addresses(if_id,
                        (net_if_addr_t **) &addr))) {
             if (addr->ndp_state == NDP_ADDR_STATE_PREFERRED) {


### PR DESCRIPTION
 - ng_ndp, sixlowpan: Reduced scope of some variables as per cppcheck's recommendations
 - cortex-m*_common: Suppress false positives.