### PR TITLE
sys/Makefile: del `USEMODULE`s for `transport_layer` already present in `Makefile.dep`

### DIFF
--- a/sys/Makefile
+++ b/sys/Makefile
@@ -13,10 +13,6 @@ endif
 ifneq (,$(filter l2_ping,$(USEMODULE)))
     DIRS += net/link_layer/ping
 endif
-ifneq (,$(filter transport_layer,$(USEMODULE)))
-    USEMODULE += udp
-    USEMODULE += tcp
-endif
 ifneq (,$(filter socket_base,$(USEMODULE)))
     DIRS += net/transport_layer/socket_base
 endif


### PR DESCRIPTION
Remove the `USEMODULE` dependency handling for `transport_layer` from `sys/Makefile`

Rationale: the module dependency for `transport_layer` is already handled in `Makefile.dep` and misplaced in `sys/Makefile`.