### PR TITLE
saml21: add lpm implementation

### DIFF
--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -57,12 +57,14 @@ extern "C" {
 #define UART_0_DEV          SERCOM3->USART
 #define UART_0_IRQ          SERCOM3_IRQn
 #define UART_0_ISR          isr_sercom3
+#define UART_0_REF_F        (16000000UL)
+#define UART_0_RUNSTDBY     1
+
 /* UART 0 pin configuration */
 #define UART_0_PORT         (PORT->Group[0])
 #define UART_0_TX_PIN       (22)
 #define UART_0_RX_PIN       (23)
 #define UART_0_PINS         (((PORT_PA22 | PORT_PA23) >> 16) | PORT_WRCONFIG_HWSEL)
-#define UART_0_REF_F        (16000000UL)
 /** @} */
 
 /**
@@ -99,7 +101,7 @@ extern "C" {
  * @{
  */
 #define RTT_FREQUENCY       (32768U)
-#define RTT_MAX_VALUE        (0xffffffffU)
+#define RTT_MAX_VALUE       (0xffffffffU)
 #define RTT_NUMOF           (1)
 /** @} */
 

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -18,7 +18,15 @@
  * @}
  */
 
+#include "arch/lpm_arch.h"
+
 #include "cpu.h"
+
+static void _gclk_setup(int gclk, uint32_t reg)
+{
+    while (GCLK->SYNCBUSY.reg & GCLK_SYNCBUSY_GENCTRL(gclk));
+    GCLK->GENCTRL[gclk].reg = reg;
+}
 
 /**
  * @brief Initialize the CPU, set IRQ priorities, clocks
@@ -31,8 +39,21 @@ void cpu_init(void)
     /* initialize the Cortex-M core */
     cortexm_init();
 
-    /* turn on MCLK */
-    MCLK->APBAMASK.reg |= MCLK_APBAMASK_GCLK;
+    /* turn on only needed APB peripherals */
+    MCLK->APBAMASK.reg =
+        MCLK_APBAMASK_PM
+        |MCLK_APBAMASK_MCLK
+        |MCLK_APBAMASK_RSTC
+        |MCLK_APBAMASK_OSCCTRL
+        |MCLK_APBAMASK_OSC32KCTRL
+        |MCLK_APBAMASK_SUPC
+        |MCLK_APBAMASK_GCLK
+        |MCLK_APBAMASK_WDT
+        |MCLK_APBAMASK_RTC
+        |MCLK_APBAMASK_EIC
+        |MCLK_APBAMASK_PORT
+        //|MCLK_APBAMASK_TAL
+        ;
 
     /* Software reset the GCLK module to ensure it is re-initialized correctly */
     GCLK->CTRLA.reg = GCLK_CTRLA_SWRST;
@@ -41,11 +62,12 @@ void cpu_init(void)
 
     /* set OSC16M to 16MHz */
     OSCCTRL->OSC16MCTRL.bit.FSEL = 3;
+    OSCCTRL->OSC16MCTRL.bit.ONDEMAND = 0;
+    OSCCTRL->OSC16MCTRL.bit.RUNSTDBY = 0;
 
-    /* Select the correct generator */
-    while (GCLK->SYNCBUSY.reg & GCLK_SYNCBUSY_GENCTRL(0));
-    GCLK->GENCTRL[0].reg = (
-            GCLK_GENCTRL_GENEN          /* enable gclk */
-            | GCLK_GENCTRL_SRC_OSC16M
-            );
+    /* Setup GCLK generators */
+    _gclk_setup(0, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M);
+    _gclk_setup(1, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSCULP32K);
+
+    lpm_arch_init();
 }

--- a/cpu/saml21/periph/uart.c
+++ b/cpu/saml21/periph/uart.c
@@ -123,7 +123,7 @@ int uart_init_blocking(uart_t uart, uint32_t baudrate)
                                     | SERCOM_USART_CTRLA_RXPO(0x1) \
                                     | SERCOM_USART_CTRLA_SAMPR(0x0) \
                                     | SERCOM_USART_CTRLA_MODE(0x1) \
-                                    | SERCOM_USART_CTRLA_RUNSTDBY;
+                                    | (UART_0_RUNSTDBY ? SERCOM_USART_CTRLA_RUNSTDBY : 0);
 
             /* Set baud rate */
             UART_0_DEV.BAUD.bit.BAUD = baud_calculated;


### PR DESCRIPTION
~~(depends on #3018)~~

Adds lpm modes to the SAM L21 port.

Idle power consumption goes down from 1.5mA to ~0.7mA. Sleep power consumption is <2uA.