### PR TITLE
net/fib: added configuration header for the FIB

### DIFF
--- a/sys/include/net/ng_fib.h
+++ b/sys/include/net/ng_fib.h
@@ -22,6 +22,7 @@
 #define FIB_H_
 
 #include "timex.h"
+#include "ng_fib/ng_fib_config.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,26 +37,13 @@ typedef struct rp_address_msg_t {
     uint32_t address_flags; /**< The flags for the given address */
 } rp_address_msg_t;
 
-#define FIB_MSG_RP_SIGNAL (0x99)     /**< message type for RP notifications */
-
-/**
- * @brief the size in bytes of a full address
- * TODO: replace with UNIVERSAL_ADDRESS_SIZE (#3022)
-*/
-#define FIB_DESTINATION_SIZE_SUBSTITUTE (16)
-
 /**
  * @brief entry used to collect available destinations
  */
 typedef struct fib_destination_set_entry_t {
-    uint8_t dest[FIB_DESTINATION_SIZE_SUBSTITUTE]; /**< The destination address */
+    uint8_t dest[UNIVERSAL_ADDRESS_SIZE]; /**< The destination address */
     size_t dest_size;    /**< The destination address size */
 } fib_destination_set_entry_t;
-
-/**
- * @brief indicator of a lifetime that does not expire (2^32 - 1)
- */
-#define FIB_LIFETIME_NO_EXPIRE (0xFFFFFFFF)
 
 /**
  * @brief initializes all FIB entries with 0
@@ -138,8 +126,8 @@ void fib_remove_entry(uint8_t *dst, size_t dst_size);
  * @param[in] dst_flags           the destination address flags
  *
  * @return 0 on success
- *         -EHOSTUNREACH if no next hop is available in any FIB table
- *                                           all RRPs are notified before the return
+ *         -EHOSTUNREACH if no next hop is available in the FIB table
+ *                                           all RPs are notified before the return
  *         -ENOBUFS if the size for the next hop address is insufficient low
  *         -EFAULT if dst and/or next_hop is not a valid pointer
  *         -EINVAL if one of the other passed out pointers is NULL
@@ -154,10 +142,10 @@ int fib_get_next_hop(kernel_pid_t *iface_id,
 * the function will continue to count the number of matching entries
 * and provide the number to the caller.
 *
-* @param[in] prefix           the destination address
-* @param[in] prefix_size      the destination address size
-* @param[out] dst_set         the destination addresses matching the prefix
-* @param[in, out] dst_size    the number of entries available on in and used on out
+* @param[in] prefix            the destination address
+* @param[in] prefix_size       the destination address size
+* @param[out] dst_set          the destination addresses matching the prefix
+* @param[in, out] dst_set_size the number of entries available on in and used on out
 *
 * @return 0 on success
 *         -EHOSTUNREACH if no entry matches the type in the FIB

--- a/sys/include/net/ng_fib/ng_fib_config.h
+++ b/sys/include/net/ng_fib/ng_fib_config.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015  Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_fib
+ * @brief       configurations for the FIB
+ *
+ * @{
+ *
+ * @file
+ * @brief       configuration header for the FIB
+ * @author      Martin Landsmann
+ */
+
+ #ifndef FIB_CONFIG_H_
+ #define FIB_CONFIG_H_
+
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+
+ /**
+  * @brief the used memory in bytes for one universal address entry
+  */
+ #define UNIVERSAL_ADDRESS_SIZE (16)
+
+ /**
+  * @brief Maximum number of universal address entries handled
+  */
+ #define UNIVERSAL_ADDRESS_MAX_ENTRIES (40)
+
+ /**
+  * @brief maximum number of FIB tables entries handled
+  * @note the value should be UNIVERSAL_ADDRESS_MAX_ENTRIES/2 to be safe since,
+  *       in the worst case, each FIB entry points to 2 unique universal addresses.
+  */
+ #define FIB_MAX_FIB_TABLE_ENTRIES (20)
+
+ /**
+  * @brief maximum number of handled routing protocols (RP)
+  *        used to notify the saved kernel_pid_t on ureachable destination
+  */
+ #define FIB_MAX_REGISTERED_RP (5)
+
+ /**
+  * @brief message type for RP notifications on unreachable destination
+  */
+ #define FIB_MSG_RP_SIGNAL (0x99)
+
+ /**
+  * @brief indicator of a FIB entry lifetime that does not expire (2^32 - 1)
+  */
+ #define FIB_LIFETIME_NO_EXPIRE (0xFFFFFFFF)
+
+ #ifdef __cplusplus
+ }
+ #endif
+
+#endif /* FIB_CONFIG_H_ */
+/** @} */

--- a/sys/include/net/ng_fib/ng_universal_address.h
+++ b/sys/include/net/ng_fib/ng_universal_address.h
@@ -21,14 +21,14 @@
 #ifndef UNIVERSAL_ADDRESS_H_
 #define UNIVERSAL_ADDRESS_H_
 
+#include "ng_fib_config.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define UNIVERSAL_ADDRESS_SIZE (16)         /**< size of the used addresses in bytes        */
-
 /**
- * @brief The container descriptor used to identify a universal address entry
+ * @brief The container descriptor used to identify an universal address entry
  */
 typedef struct universal_address_container_t {
     uint8_t use_count;                       /**< The number of entries link here */

--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -36,12 +36,6 @@
 static mutex_t mtx_access = MUTEX_INIT;
 
 /**
- * @brief maximum number of handled routing protocols (RP)
- *        used to notify the saved kernel_pid_t on ureachable destination
- */
-#define FIB_MAX_REGISTERED_RP (5)
-
-/**
  * @brief registered RPs for notifications about unreachable destinations
  */
 static size_t notify_rp_pos = 0;
@@ -55,11 +49,6 @@ static kernel_pid_t notify_rp[FIB_MAX_REGISTERED_RP];
  * @brief the prefix handled by the RP
  */
 static universal_address_container_t* prefix_rp[FIB_MAX_REGISTERED_RP];
-
-/**
- * @brief maximum number of FIB tables entries handled
- */
-#define FIB_MAX_FIB_TABLE_ENTRIES (20)
 
 /**
  * @brief array of the FIB tables

--- a/sys/net/network_layer/fib/universal_address.c
+++ b/sys/net/network_layer/fib/universal_address.c
@@ -26,11 +26,6 @@
 #include "ng_fib/ng_universal_address.h"
 
 /**
- * @brief Maximum number of entries handled
- */
-#define UNIVERSAL_ADDRESS_MAX_ENTRIES (40)
-
-/**
  * @brief counter indicating the number of entries allocated
  */
 static size_t universal_address_table_filled = 0;


### PR DESCRIPTION
Rationale: this introduces a new header to easily configure the FIB. 
Mainly to provide one configuration file for all important defines, i.e. sizes for the actual data fields for FIB entries and universal addresses, and message types.