### PR TITLE
cpu/stm32f1: fixed uart_init()

### DIFF
--- a/cpu/stm32f1/periph/uart.c
+++ b/cpu/stm32f1/periph/uart.c
@@ -57,7 +57,8 @@ static inline void irq_handler(uart_t uartnum, USART_TypeDef *uart);
 static uart_conf_t config[UART_NUMOF];
 
 
-int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, uart_tx_cb_t tx_cb, void *arg)
+int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb,
+              uart_tx_cb_t tx_cb, void *arg)
 {
     int res;
 
@@ -90,6 +91,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, uart_tx_cb_t t
     /* register callbacks */
     config[uart].rx_cb = rx_cb;
     config[uart].tx_cb = tx_cb;
+    config[uart].arg = arg;
 
     return 0;
 }


### PR DESCRIPTION
- added linebreak to funtion declaration
- fixed saving of callback argument