### PR TITLE
netconf: at86rf231: configure maximum retransmits

### DIFF
--- a/drivers/include/ng_at86rf2xx.h
+++ b/drivers/include/ng_at86rf2xx.h
@@ -317,6 +317,27 @@ int16_t ng_at86rf2xx_get_txpower(ng_at86rf2xx_t *dev);
 void ng_at86rf2xx_set_txpower(ng_at86rf2xx_t *dev, int16_t txpower);
 
 /**
+ * @brief   Get the maximum number of retransmissions
+ *
+ * @param[in] dev           device to read from
+ *
+ * @return                  configured number of retransmissions
+ */
+uint8_t ng_at86rf2xx_get_max_retries(ng_at86rf2xx_t *dev);
+
+/**
+ * @brief   Set the maximum number of retransmissions
+ *
+ * This setting specifies the number of attempts to retransmit a frame, when it
+ * was not acknowledged by the recipient, before the transaction gets cancelled.
+ * The maximum value is 7.
+ *
+ * @param[in] dev           device to write to
+ * @param[in] max           the maximum number of retransmissions
+ */
+void ng_at86rf2xx_set_max_retries(ng_at86rf2xx_t *dev, uint8_t max);
+
+/**
  * @brief   Enable or disable driver specific options
  *
  * @param[in] dev           device to set/clear option flag for

--- a/drivers/ng_at86rf2xx/include/ng_at86rf2xx_registers.h
+++ b/drivers/ng_at86rf2xx/include/ng_at86rf2xx_registers.h
@@ -292,6 +292,15 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief   Bitfield definitions for the XAH_CTRL_0 register
+ * @{
+ */
+#define NG_AT86RF2XX_XAH_CTRL_0__MAX_FRAME_RETRIES              (0xF0)
+#define NG_AT86RF2XX_XAH_CTRL_0__MAX_CSMA_RETRIES               (0x0E)
+#define NG_AT86RF2XX_XAH_CTRL_0__SLOTTED_OPERATION              (0x01)
+/** @} */
+
+/**
  * @brief   Bitfield definitions for the XAH_CTRL_1 register
  * @{
  */

--- a/drivers/ng_at86rf2xx/ng_at86rf2xx_getset.c
+++ b/drivers/ng_at86rf2xx/ng_at86rf2xx_getset.c
@@ -235,6 +235,20 @@ void ng_at86rf2xx_set_txpower(ng_at86rf2xx_t *dev, int16_t txpower)
 #endif
 }
 
+uint8_t ng_at86rf2xx_get_max_retries(ng_at86rf2xx_t *dev)
+{
+    return (ng_at86rf2xx_reg_read(dev, NG_AT86RF2XX_REG__XAH_CTRL_0) >> 4);
+}
+
+void ng_at86rf2xx_set_max_retries(ng_at86rf2xx_t *dev, uint8_t max)
+{
+    max = (max > 7) ? 7 : max;
+    uint8_t tmp = ng_at86rf2xx_reg_read(dev, NG_AT86RF2XX_REG__XAH_CTRL_0);
+    tmp &= ~(NG_AT86RF2XX_XAH_CTRL_0__MAX_FRAME_RETRIES);
+    tmp |= (max << 4);
+    ng_at86rf2xx_reg_write(dev, NG_AT86RF2XX_REG__XAH_CTRL_0, tmp);
+}
+
 void ng_at86rf2xx_set_option(ng_at86rf2xx_t *dev, uint16_t option, bool state)
 {
     uint8_t tmp;

--- a/drivers/ng_at86rf2xx/ng_at86rf2xx_getset.c
+++ b/drivers/ng_at86rf2xx/ng_at86rf2xx_getset.c
@@ -190,7 +190,7 @@ int16_t ng_at86rf2xx_get_txpower(ng_at86rf2xx_t *dev)
 {
 #ifdef MODULE_NG_AT86RF212B
     uint8_t txpower = ng_at86rf2xx_reg_read(dev, NG_AT86RF2XX_REG__PHY_TX_PWR);
-    printf("txpower value: %x\n", txpower);
+    DEBUG("txpower value: %x\n", txpower);
     return tx_pow_to_dbm(dev->freq, txpower);
 #else
     uint8_t txpower = ng_at86rf2xx_reg_read(dev, NG_AT86RF2XX_REG__PHY_TX_PWR)

--- a/drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c
+++ b/drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c
@@ -445,6 +445,13 @@ static int _get(ng_netdev_t *device, ng_netconf_opt_t opt,
             }
             return sizeof(ng_netconf_enable_t);
 
+        case NETCONF_OPT_RETRANS:
+            if (max_len < sizeof(uint8_t)) {
+                return -EOVERFLOW;
+            }
+            *((uint8_t *)val) = ng_at86rf2xx_get_max_retries(dev);
+            return sizeof(uint8_t);
+
         case NETCONF_OPT_PROMISCUOUSMODE:
             if (dev->options & NG_AT86RF2XX_OPT_PROMISCUOUS) {
                 *((ng_netconf_enable_t *)val) = NETCONF_ENABLE;
@@ -576,6 +583,13 @@ static int _set(ng_netdev_t *device, ng_netconf_opt_t opt,
             ng_at86rf2xx_set_option(dev, NG_AT86RF2XX_OPT_AUTOACK,
                                     ((bool *)val)[0]);
             return sizeof(ng_netconf_enable_t);
+
+        case NETCONF_OPT_RETRANS:
+            if (len > sizeof(uint8_t)) {
+                return -EOVERFLOW;
+            }
+            ng_at86rf2xx_set_max_retries(dev, *((uint8_t *)val));
+            return sizeof(uint8_t);
 
         case NETCONF_OPT_PRELOADING:
             ng_at86rf2xx_set_option(dev, NG_AT86RF2XX_OPT_PRELOADING,

--- a/sys/include/net/ng_netconf.h
+++ b/sys/include/net/ng_netconf.h
@@ -72,6 +72,8 @@ typedef enum {
                                      *   the current state */
     NETCONF_OPT_AUTOACK,            /**< en/disable link layer auto ACKs or read
                                      *   the current state */
+    NETCONF_OPT_RETRANS,            /**< get/set the maximum number of
+                                         retransmissions. */
     NETCONF_OPT_PROTO,              /**< get/set the protocol for the layer
                                      *   as type ng_nettype_t. */
     NETCONF_OPT_STATE,              /**< get/set the state of network devices as


### PR DESCRIPTION
To test this enable RX start IRQs, e.g. on IoT-LAB_M3 and set `ENABLE_DEBUG` to `1` in `drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c`:
```C
     bool rx_irq = true;
     uint8_t retries = 0;

     ng_netapi_set(*if_id, NETCONF_OPT_RX_START_IRQ, 0, &rx_irq, sizeof(bool));
     ng_netapi_set(*if_id, NETCONF_OPT_RETRANS, 0, &retries, sizeof(uint8_t));
```

Depending on `retries` you should see several number of debug messages on the receiving node, if you use `txtsnd` with a incorrect destination address.