### PR TITLE
make: add ccache support

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -57,13 +57,13 @@ CXXFLAGS = $(filter-out $(CXXUWFLAGS), $(CFLAGS)) $(CXXEXFLAGS)
 # compile and generate dependency info
 
 $(OBJC): $(BINDIR)$(MODULE)/%.o: %.c
-	$(AD)$(CC) \
+	$(AD)$(CCACHE) $(CC) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
 		$(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
 $(OBJCXX): $(BINDIR)$(MODULE)/%.o: %.cpp
-	$(AD)$(CXX) \
+	$(AD)$(CCACHE) $(CXX) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
 		$(CXXFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)

--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -48,6 +48,9 @@ buildtest:
 					HOME=$${HOME} \
 					PATH=$${PATH} \
 					BOARD=$${BOARD} \
+					CCACHE=$${CCACHE} \
+					CCACHE_DIR=$${CCACHE_DIR} \
+					CCACHE_BASEDIR=$${CCACHE_BASEDIR} \
 					RIOTBASE=$${RIOTBASE} \
 					RIOTBOARD=$${RIOTBOARD} \
 					RIOTCPU=$${RIOTCPU} \

--- a/Makefile.include
+++ b/Makefile.include
@@ -152,7 +152,12 @@ ifeq ($(origin RIOT_VERSION), undefined)
     RIOT_VERSION := "UNKNOWN (builddir: $(RIOTBASE))"
   endif
 endif
+
+ifneq (,$(RIOT_VERSION_OVERRIDE))
+export CFLAGS += -DRIOT_VERSION=\"$(RIOT_VERSION_OVERRIDE)\"
+else
 export CFLAGS += -DRIOT_VERSION=\"$(RIOT_VERSION)\"
+endif
 
 # the binaries to link
 BASELIBS += $(BINDIR)$(BOARD)_base.a

--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -10,6 +10,14 @@
 # Usage:
 # 3. cd to riot root
 # 4. # docker run -i -t -u $UID -v $(pwd):/data/riotbuild riotbuild ./dist/tools/compile_test/compile_test.py
+#
+# If you want to use a persistent ccache, map a directory to '/data/ccache'
+# and set CCACHE=ccache:
+#
+# 4. # docker run -i -t -u $UID -v $(pwd):/data/riotbuild -v /tmp/riot_ccache:/data/ccache \
+#           -e CCACHE=ccache -e RIOT_VERSION_OVERRIDE=buildtest \
+#            riotbuild ./dist/tools/compile_test/compile_test.py
+#
 
 FROM ubuntu
 
@@ -33,6 +41,13 @@ RUN apt-get -y install qemu-system-x86 python3
 RUN apt-get -y install g++-multilib
 RUN apt-get -y install gcc-avr binutils-avr avr-libc
 RUN apt-get -y install subversion curl wget python p7zip unzip
+
+RUN wget http://launchpadlibrarian.net/206632429/ccache_3.2.2-2_amd64.deb -O /tmp/ccache_3.2.2-2_amd64.deb
+RUN dpkg -i /tmp/ccache_3.2.2-2_amd64.deb
+
+RUN mkdir -p /data/ccache
+RUN chmod 777 /data/ccache
+ENV CCACHE_DIR /data/ccache
 
 RUN mkdir -p /data/riotbuild
 WORKDIR /data/riotbuild

--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -31,22 +31,22 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key FE324A81C208C89497EF
 RUN apt-get update
 RUN apt-get -y dist-upgrade
 
-RUN apt-get -y install build-essential
-RUN apt-get -y install git
-RUN apt-get -y install gcc-multilib
-RUN apt-get -y install gcc-arm-none-eabi
-RUN apt-get -y install gcc-msp430
-RUN apt-get -y install pcregrep libpcre3
-RUN apt-get -y install qemu-system-x86 python3
-RUN apt-get -y install g++-multilib
-RUN apt-get -y install gcc-avr binutils-avr avr-libc
-RUN apt-get -y install subversion curl wget python p7zip unzip
+RUN apt-get -y install build-essential \
+ git \
+ gcc-multilib \
+ gcc-arm-none-eabi \
+ gcc-msp430 \
+ pcregrep libpcre3 \
+ qemu-system-x86 python3 \
+ g++-multilib \
+ gcc-avr binutils-avr avr-libc \
+ subversion curl wget python p7zip unzip
 
-RUN wget http://launchpadlibrarian.net/206632429/ccache_3.2.2-2_amd64.deb -O /tmp/ccache_3.2.2-2_amd64.deb
-RUN dpkg -i /tmp/ccache_3.2.2-2_amd64.deb
+RUN wget http://launchpadlibrarian.net/206632429/ccache_3.2.2-2_amd64.deb \
+        -O /tmp/ccache_3.2.2-2_amd64.deb \
+        && dpkg -i /tmp/ccache_3.2.2-2_amd64.deb
 
-RUN mkdir -p /data/ccache
-RUN chmod 777 /data/ccache
+RUN mkdir -m 777 -p /data/ccache
 ENV CCACHE_DIR /data/ccache
 
 RUN mkdir -p /data/riotbuild


### PR DESCRIPTION
This PR contains a some small commits to enable the build system to use ccache.

This speeds up a second compile_test run from about 90min to about 30min. While travis won't take advantage due to it's distributed nature, as soon as we run our own CI, this should speed up things quite a bit...

Unfortunately ubuntu LTS ships a horribly outdated version of ccache. I don't like the hack I introduced (download the package of a newer ubuntu by using direct url), but it works.