### PR TITLE
travis: enable travis compile tests on set github label `Ready for Travis build`

### DIFF
--- a/dist/tools/pr_check/check_labels.sh
+++ b/dist/tools/pr_check/check_labels.sh
@@ -1,0 +1,32 @@
+#! /bin/bash
+#
+# Copyright (C) 2014 Martine Lenders <mlenders@inf.fu-berlin.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+# The following script part has been moved here from:
+# ./dist/tools/pr_check/pr_check.sh
+
+GITHUB_API_HOST="https://api.github.com"
+GITHUB_REPO="RIOT-OS/RIOT"
+
+if which wget &> /dev/null; then
+    GET="wget -O -"
+elif which curl &> /dev/null; then
+    GET="curl"
+else
+    echo "Script needs wget or curl" >&2
+    exit 2
+fi
+
+LABELS_JSON=$(${GET} "${GITHUB_API_HOST}/repos/${GITHUB_REPO}/issues/${TRAVIS_PULL_REQUEST}/labels" 2> /dev/null)
+
+check_gh_label() {
+    LABEL="${1}"
+
+    echo "${LABELS_JSON}" | grep -q "${LABEL}"
+    return $?
+}

--- a/dist/tools/pr_check/pr_check.sh
+++ b/dist/tools/pr_check/pr_check.sh
@@ -8,19 +8,7 @@
 #
 
 EXIT_CODE=0
-GITHUB_API_HOST="https://api.github.com"
-GITHUB_REPO="RIOT-OS/RIOT"
-
-if which wget &> /dev/null; then
-    GET="wget -O -"
-elif which curl &> /dev/null; then
-    GET="curl"
-else
-    echo "Script needs wget or curl" >&2
-    exit 2
-fi
-
-LABELS_JSON=$(${GET} "${GITHUB_API_HOST}/repos/${GITHUB_REPO}/issues/${TRAVIS_PULL_REQUEST}/labels" 2> /dev/null)
+source ./dist/tools/pr_check/check_labels.sh
 
 if tput colors &> /dev/null && [ $(tput colors) -ge 8 ]; then
     CERROR="\e[1;31m"
@@ -29,13 +17,6 @@ else
     CERROR=
     CRESET=
 fi
-
-check_gh_label() {
-    LABEL="${1}"
-
-    echo "${LABELS_JSON}" | grep -q "${LABEL}"
-    return $?
-}
 
 if [[ ${#} -eq 1 ]]; then
     RIOT_MASTER="${1}"

--- a/dist/tools/travis-scripts/build_and_test.sh
+++ b/dist/tools/travis-scripts/build_and_test.sh
@@ -23,6 +23,7 @@ set_result() {
 
 if [[ $BUILDTEST_MCU_GROUP ]]
 then
+
     if [ "$BUILDTEST_MCU_GROUP" == "static-tests" ]
     then
         RESULT=0
@@ -60,14 +61,22 @@ then
 
         exit $RESULT
     fi
-    if [ "$BUILDTEST_MCU_GROUP" == "x86" ]
-    then
 
-        make -C ./tests/unittests all test BOARD=native || exit
-        # TODO:
-        #   Reenable once https://github.com/RIOT-OS/RIOT/issues/2300 is
-        #   resolved:
-        #   - make -C ./tests/unittests all test BOARD=qemu-i386 || exit
+    source ./dist/tools/pr_check/check_labels.sh
+
+    if check_gh_label "Ready for CI build"; then
+        if [ "$BUILDTEST_MCU_GROUP" == "x86" ]
+        then
+            make -C ./tests/unittests all test BOARD=native || exit
+            # TODO:
+            #   Reenable once https://github.com/RIOT-OS/RIOT/issues/2300 is
+            #   resolved:
+            #   - make -C ./tests/unittests all test BOARD=qemu-i386 || exit
+        fi
+        echo -e "\e[0;32mCompile tests will be performed for this pull request\e[0m"
+        ./dist/tools/compile_test/compile_test.py riot/master
+    else
+        echo -e "\e[33;40mCompile tests will be skipped for this pull request\e[0m"
+        exit 1
     fi
-    ./dist/tools/compile_test/compile_test.py riot/master
 fi


### PR DESCRIPTION
This hopefully helps to lower the travis backlog.

Rationale: this enables/performs compile tests only if the `Ready for Travis build` label is set on github for a PR