### PR TITLE
dist: exec drone build script in parallel

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get -y install build-essential \
  qemu-system-x86 python3 \
  g++-multilib \
  gcc-avr binutils-avr avr-libc \
- subversion curl wget python p7zip unzip
+ subversion curl wget python p7zip unzip parallel
 
 RUN wget http://launchpadlibrarian.net/206632429/ccache_3.2.2-2_amd64.deb \
         -O /tmp/ccache_3.2.2-2_amd64.deb \

--- a/dist/tools/drone-scripts/build_and_test.sh
+++ b/dist/tools/drone-scripts/build_and_test.sh
@@ -5,10 +5,23 @@
 # Public License v2.1. See the file LICENSE in the top level directory for more
 # details.
 
-# For now, just ride on the Travis build scripts
-
-# Drone has not yet implemented Travis' Matrix Build feature,
+# Drone has not yet implemented Travis Matrix Build feature,
 # see https://github.com/drone/drone/issues/6
+
+function exec_build_func {
+    group=$1
+    shift
+    if [ -z "$1" ]; then
+        fileargs=$@
+    fi
+
+    echo "Begin group ${group}"
+    # For now, just ride on the Travis build scripts
+    BUILDTEST_MCU_GROUP=${group} ./dist/tools/travis-scripts/build_and_test.sh "${fileargs}"
+    RES=$?
+    echo "Result (${group}): ${RES}"
+}
+
 FAILURES=0
 SUMMARY_MESSAGE="Summary of test groups run:\n"
 
@@ -19,26 +32,31 @@ export TRAVIS_BUILD_NUMBER="${CI_BUILD_NUMBER}"
 export TRAVIS_COMMIT="${DRONE_COMMIT}"
 export TRAVIS_BUILD_DIR="${DRONE_BUILD_DIR}"
 
-for group in static-tests \
-             avr8         \
-             msp430       \
-             x86          \
-             arm7         \
-             cortex_m0    \
-             cortex_m3_1  \
-             cortex_m3_2  \
-             cortex_m4    \
-    ;
-do
-    echo "Begin group ${group}"
-    BUILDTEST_MCU_GROUP=${group} ./dist/tools/travis-scripts/build_and_test.sh "$@"
-    RES=$?
-    echo "Result (${group}): ${RES}"
-    if [ ${RES} -ne 0 ]; then
-        FAILURES=$((${FAILURES} + 1))
+export -f exec_build_func
+
+MYTMPDIR=$(mktemp -d)
+trap 'rm -rf "$MYTMPDIR"' EXIT
+
+# Execute all groups in parallel (-k ensures correct ordering of the
+# output)
+parallel -k exec_build_func {} "$@"  ::: static-tests avr8 msp430 x86 arm7 \
+                                         cortex_m0 cortex_m3_1 cortex_m3_2 \
+                                         cortex_m4 \
+|& tee -a "$MYTMPDIR/output.log"
+
+# Check the log for failures
+RESULTS=$(cat "$MYTMPDIR/output.log" | grep "Result.*:" | cut -d ":" -f2 \
+        | tr "\n" " ")
+
+for retval in $RESULTS;do
+    if [ $retval -ne "0" ];then
+        ((FAILURES++))
     fi
-    SUMMARY_MESSAGE="${SUMMARY_MESSAGE}${group}: ${RES}\n"
 done
+
+SUMMARY=$(cat "$MYTMPDIR/output.log" | grep -e "^Result.*:" \
+        | awk -F '[()]' '{print $(NF-1) $(NF-0)}')
+SUMMARY_MESSAGE="${SUMMARY_MESSAGE}${SUMMARY}\n"
 
 echo -n -e "${SUMMARY_MESSAGE}"
 


### PR DESCRIPTION
Use GNU parallel in the drone build script.

TODO:
- [X] swap out for loop with GNU parallel
- [x] correct text output (variables are currently thread local)