### PR TITLE
board/stm32f4discovery: fixed doxygen in periph_conf

### DIFF
--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -1,17 +1,17 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin
  *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
  */
 
 /**
- * @ingroup     boards_stm32f3discovery
+ * @ingroup     boards_stm32f4discovery
  * @{
  *
  * @file
- * @name       Peripheral MCU configuration for the STM32F4discovery board
+ * @name        Peripheral MCU configuration for the STM32F4discovery board
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>


### PR DESCRIPTION
fixed wrong doxygen group, some indention and moved to default license header