### PR TITLE
everything: Remove filename from @file Doxygen command

### DIFF
--- a/boards/airfy-beacon/board.c
+++ b/boards/airfy-beacon/board.c
@@ -10,7 +10,7 @@
  * @ingroup     boards_airfy-beacon
  * @{
  *
- * @file        board.c
+ * @file
  * @brief       Board specific implementations for the Airfy Beacon board
  *
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>

--- a/boards/arduino-due/board.c
+++ b/boards/arduino-due/board.c
@@ -10,7 +10,7 @@
  * @ingroup     boards_arduino-due
  * @{
  *
- * @file        board.c
+ * @file
  * @brief       Board specific implementations for the Arduino Due board
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/boards/arduino-mega2560/board.c
+++ b/boards/arduino-mega2560/board.c
@@ -10,7 +10,7 @@
  * @ingroup     boards_arduino-mega2560
  * @{
  *
- * @file        board.c
+ * @file
  * @brief       Board specific implementations for the Arduino Mega 2560 board
  *
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>

--- a/boards/fox/board.c
+++ b/boards/fox/board.c
@@ -10,7 +10,7 @@
  * @ingroup     boards_fox
  * @{
  *
- * @file        board.c
+ * @file
  * @brief       Board specific implementations for the fox board
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/boards/iot-lab_M3/board.c
+++ b/boards/iot-lab_M3/board.c
@@ -10,7 +10,7 @@
  * @ingroup     boards_iot-lab_M3
  * @{
  *
- * @file        board.c
+ * @file
  * @brief       Board specific implementations for the iot-lab_M3 board
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/boards/mbed_lpc1768/system.c
+++ b/boards/mbed_lpc1768/system.c
@@ -1,5 +1,5 @@
 /**************************************************************************//**
- * @file     boards_init.c
+ * @file
  * @brief    CMSIS Cortex-M3 Device Peripheral Access Layer Source File
  *           for the NXP LPC17xx Device Series
  * @version  V1.09

--- a/boards/pca10000/board.c
+++ b/boards/pca10000/board.c
@@ -10,7 +10,7 @@
  * @ingroup     boards_pca10000
  * @{
  *
- * @file        board.c
+ * @file
  * @brief       Board specific implementations for the nRF51822 evaluation board pca10000
  *
  * @author      Christian Kühling <kuehling@zedat.fu-berlin.de>

--- a/boards/pca10005/board.c
+++ b/boards/pca10005/board.c
@@ -10,7 +10,7 @@
  * @ingroup     boards_pca10005
  * @{
  *
- * @file        board.c
+ * @file
  * @brief       Board specific implementations for the nRF51822 evaluation board pca10005
  *
  * @author      Christian Kühling <kuehling@zedat.fu-berlin.de>

--- a/boards/samr21-xpro/board.c
+++ b/boards/samr21-xpro/board.c
@@ -10,7 +10,7 @@
  * @ingroup     boards_samr21-xpro
  * @{
  *
- * @file        board.c
+ * @file
  * @brief       Board specific implementations for the Atem SAM R21 Xplained Pro board
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/boards/udoo/board.c
+++ b/boards/udoo/board.c
@@ -10,7 +10,7 @@
  * @ingroup     boards_udoo
  * @{
  *
- * @file        board.c
+ * @file
  * @brief       Board specific implementations for the UDOO board
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/boards/yunjia-nrf51822/board.c
+++ b/boards/yunjia-nrf51822/board.c
@@ -10,7 +10,7 @@
  * @ingroup     boards_yunjia-nrf51822
  * @{
  *
- * @file        board.c
+ * @file
  * @brief       Board specific implementations for the Yunjia NRF51822 board
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/boards/z1/board.c
+++ b/boards/z1/board.c
@@ -13,7 +13,7 @@
  * @ingroup     boards_z1
  * @{
  *
- * @file        board.c
+ * @file
  * @brief       Board specific implementations for the Zolertia Z1
  *
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>

--- a/boards/z1/driver_cc2420.c
+++ b/boards/z1/driver_cc2420.c
@@ -14,7 +14,7 @@
  * @ingroup     boards_z1
  * @{
  *
- * @file        driver_cc2420.c
+ * @file
  * @brief       Board specific CC2420 driver HAL for the Zolertia Z1
  *
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>

--- a/boards/z1/uart.c
+++ b/boards/z1/uart.c
@@ -13,7 +13,7 @@
  * @ingroup     boards_z1
  * @{
  *
- * @file        uart.c
+ * @file
  * @brief       Board specific UART/USB driver HAL for the Zolertia Z1
  *
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>

--- a/core/bitarithm.c
+++ b/core/bitarithm.c
@@ -10,7 +10,7 @@
  * @ingroup     core_util
  * @{
  *
- * @file        bitarithm.c
+ * @file
  * @brief       Bit arithmetic helper functions implementation
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/core/clist.c
+++ b/core/clist.c
@@ -10,7 +10,7 @@
  * @ingroup     core_util
  * @{
  *
- * @file        clist.c
+ * @file
  * @brief       Circular linked list implementation
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/core/hwtimer.c
+++ b/core/hwtimer.c
@@ -10,7 +10,7 @@
  * @ingroup     core_hwtimer
  * @{
  *
- * @file        hwtimer.c
+ * @file
  * @brief       Hardware timer abstraction implementation
  *
  * @author      Heiko Will <hwill@inf.fu-berlin.de>

--- a/core/include/arch/atomic_arch.h
+++ b/core/include/arch/atomic_arch.h
@@ -10,7 +10,7 @@
  * @ingroup     core_arch
  * @{
  *
- * @file        atomic_arch.h
+ * @file
  * @brief       Architecture dependent interface for an atomic set operation
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/core/include/arch/hwtimer_arch.h
+++ b/core/include/arch/hwtimer_arch.h
@@ -10,7 +10,7 @@
  * @ingroup     core_arch
  * @{
  *
- * @file        hwtimer_arch.h
+ * @file
  * @brief       The kernel's hardware timer abstraction interface
  *
  * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>

--- a/core/include/arch/irq_arch.h
+++ b/core/include/arch/irq_arch.h
@@ -10,7 +10,7 @@
  * @ingroup     core_arch
  * @{
  *
- * @file        irq_arch.h
+ * @file
  * @brief       Interrupt handling interface for globally en- and disabling interrupts
  *
  * This file acts as a wrapper between the kernels interrupt interface and the architecture

--- a/core/include/arch/lpm_arch.h
+++ b/core/include/arch/lpm_arch.h
@@ -10,7 +10,7 @@
  * @ingroup     core_arch
  * @{
  *
- * @file        lpm_arch.h
+ * @file
  * @brief       Architecture dependent interface for power mode management
  *
  * This file acts as a wrapper between the kernels power management interface and the architecture

--- a/core/include/arch/reboot_arch.h
+++ b/core/include/arch/reboot_arch.h
@@ -10,7 +10,7 @@
  * @ingroup     core_arch
  * @{
  *
- * @file        reboot_arch.h
+ * @file
  * @brief       Architecture dependent interface rebooting
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/core/include/arch/thread_arch.h
+++ b/core/include/arch/thread_arch.h
@@ -10,7 +10,7 @@
  * @ingroup     core_arch
  * @{
  *
- * @file        thread_arch.h
+ * @file
  * @brief       Architecture dependent kernel interface for handling and managing threads
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/core/include/attributes.h
+++ b/core/include/attributes.h
@@ -10,7 +10,7 @@
  * @addtogroup  core_internal
  * @{
  *
- * @file        attributes.h
+ * @file
  * @brief       Compiler attributes/pragmas configuration
  *
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>

--- a/core/include/bitarithm.h
+++ b/core/include/bitarithm.h
@@ -10,7 +10,7 @@
  * @addtogroup  core_util
  * @{
  *
- * @file        bitarithm.h
+ * @file
  * @brief       Helper functions for bit arithmetic
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -10,7 +10,7 @@
  * @addtogroup     core_util
  * @{
  *
- * @file           byteorder.h
+ * @file
  * @brief          Functions to work with different byte orders.
  *
  * @author         René Kijewski <rene.kijewski@fu-berlin.de>

--- a/core/include/cib.h
+++ b/core/include/cib.h
@@ -10,7 +10,7 @@
  * @addtogroup  core_util
  * @{
  *
- * @file        cib.h
+ * @file
  * @brief       Circular integer buffer interface
  * @details     This structure provides an organizational interface
  *              and combined with an memory array forms a circular buffer.

--- a/core/include/clist.h
+++ b/core/include/clist.h
@@ -10,7 +10,7 @@
  * @addtogroup  core_util
  * @{
  *
- * @file        clist.h
+ * @file
  * @brief       Circular linked list
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -10,7 +10,7 @@
  * @addtogroup  core_util
  * @{
  *
- * @file        debug.h
+ * @file
  * @brief       Debug-header
  *
  * @details     If *ENABLE_DEBUG* is defined inside an implementation file, all

--- a/core/include/flags.h
+++ b/core/include/flags.h
@@ -10,7 +10,7 @@
  * @addtogroup  core_internal
  * @{
  *
- * @file        flags.h
+ * @file
  * @brief       Misc flag definitions
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/core/include/irq.h
+++ b/core/include/irq.h
@@ -12,7 +12,7 @@
  * @brief       Provides an API to control interrupt processing
  * @{
  *
- * @file        irq.h
+ * @file
  * @brief       IRQ driver interface
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics

--- a/core/include/kernel.h
+++ b/core/include/kernel.h
@@ -10,7 +10,7 @@
  * @addtogroup  core_internal
  * @{
  *
- * @file        kernel.h
+ * @file
  * @brief       Kernel compile time configuration
  *
  *              A reboot() function is also provided

--- a/core/include/kernel_internal.h
+++ b/core/include/kernel_internal.h
@@ -10,7 +10,7 @@
  * @addtogroup  core_internal
  * @{
  *
- * @file        kernel_internal.h
+ * @file
  * @brief       prototypes for kernel internal functions
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>

--- a/core/include/kernel_macros.h
+++ b/core/include/kernel_macros.h
@@ -10,7 +10,7 @@
  * @addtogroup  core_util
  * @{
  *
- * @file        kernel_macros.h
+ * @file
  * @brief       common macros
  *
  * @author      René Kijewski

--- a/core/include/kernel_types.h
+++ b/core/include/kernel_types.h
@@ -10,7 +10,7 @@
  * @addtogroup  core_util
  * @{
  *
- * @file        kernel_types.h
+ * @file
  * @brief       Types used by the kernel
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>

--- a/core/include/lifo.h
+++ b/core/include/lifo.h
@@ -10,7 +10,7 @@
  * @addtogroup  core_util
  * @{
  *
- * @file    lifo.h
+ * @file
  * @brief   LIFO buffer API, read long description carefully
  * @author  Heiko Will <hwill@inf.fu-berlin.de>
  *

--- a/core/include/lpm.h
+++ b/core/include/lpm.h
@@ -12,7 +12,7 @@
  * @brief       The kernels power management interface
  * @{
  *
- * @file        lpm.h
+ * @file
  * @brief       Power management interface
  *
  * This interface needs to be implemented for each platform.

--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -22,7 +22,7 @@
  *
  * @{
  *
- * @file        msg.h
+ * @file
  * @brief       Messaging API for inter process communication
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -12,7 +12,7 @@
  * @ingroup     core
  * @{
  *
- * @file        mutex.h
+ * @file
  * @brief       RIOT synchronization API
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/core/include/native_sched.h
+++ b/core/include/native_sched.h
@@ -14,7 +14,7 @@
  *
  * @{
  *
- * @file        native_sched.h
+ * @file
  * @brief       Add definitions required on the native board
  *
  * @author      Raphael Hiesgen <raphael.hiesgen@haw-hamburg.de>

--- a/core/include/priority_queue.h
+++ b/core/include/priority_queue.h
@@ -10,7 +10,7 @@
  * @addtogroup  core_util
  * @{
  *
- * @file        priority_queue.h
+ * @file
  * @brief       A simple priority queue
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/core/include/ringbuffer.h
+++ b/core/include/ringbuffer.h
@@ -10,7 +10,7 @@
  *
  * @ingroup  core_util
  * @{
- * @file   ringbuffer.h
+ * @file
  * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @author René Kijewski <rene.kijewski@fu-berlin.de>
  * @}

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -71,7 +71,7 @@
  *
  * @{
  *
- * @file        sched.h
+ * @file
  * @brief       Scheduler API definition
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/core/include/tcb.h
+++ b/core/include/tcb.h
@@ -10,7 +10,7 @@
  * @addtogroup  core_thread
  * @{
  *
- * @file        tcb.h
+ * @file
  * @brief       Thread context block definition
  *
  * @author      Heiko Will

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -13,7 +13,7 @@
  *
  * @{
  *
- * @file        thread.h
+ * @file
  * @brief       Threading API
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -10,7 +10,7 @@
  * @ingroup     core_internal
  * @{
  *
- * @file        kernel_init.c
+ * @file
  * @brief       Platform-independent kernel initilization
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/core/lifo.c
+++ b/core/lifo.c
@@ -9,7 +9,7 @@
 /**
  * @ingroup     core_util
  * @{
- * @file        lifo.c
+ * @file
  * @brief       LIFO buffer implementation
  *
  * @author      Heiko Will <hwill@inf.fu-berlin.de>

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -10,7 +10,7 @@
  * @ingroup     core_sync
  * @{
  *
- * @file        mutex.c
+ * @file
  * @brief       Kernel mutex implementation
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/core/priority_queue.c
+++ b/core/priority_queue.c
@@ -10,7 +10,7 @@
  * @ingroup     core_util
  * @{
  *
- * @file        priority_queue.c
+ * @file
  * @brief       A simple priority queue
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/core/reboot.c
+++ b/core/reboot.c
@@ -10,7 +10,7 @@
  * @ingroup     core_util
  * @{
  *
- * @file        reboot.c
+ * @file
  * @brief       Reboot function
  *
  * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de

--- a/core/ringbuffer.c
+++ b/core/ringbuffer.c
@@ -10,7 +10,7 @@
  *
  * @ingroup  core_util
  * @{
- * @file   ringbuffer.c
+ * @file
  * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @author René Kijewski <rene.kijewski@fu-berlin.de>
  * @}

--- a/core/sched.c
+++ b/core/sched.c
@@ -10,7 +10,7 @@
  * @ingroup     core_sched
  * @{
  *
- * @file        sched.c
+ * @file
  * @brief       Scheduler implementation
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/core/thread.c
+++ b/core/thread.c
@@ -10,7 +10,7 @@
  * @ingroup     core_thread
  * @{
  *
- * @file        thread.c
+ * @file
  * @brief       Threading implementation
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/cpu/atmega2560/cpu.c
+++ b/cpu/atmega2560/cpu.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_atmega2560
  * @{
  *
- * @file        cpu.c
+ * @file
  * @brief       Implementation of the CPU initialization
  *
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>

--- a/cpu/atmega2560/hwtimer_arch.c
+++ b/cpu/atmega2560/hwtimer_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_atmega2560
  * @{
  *
- * @file        hwtimer_arch.c
+ * @file
  * @brief       Implementation of the kernels hwtimer interface
  *
  * The hardware timer implementation uses the ATmega2560 build-in system timer as back-end.

--- a/cpu/atmega2560/lpm_arch.c
+++ b/cpu/atmega2560/lpm_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_atmega2560
  * @{
  *
- * @file        lpm_arch.c
+ * @file
  * @brief       Implementation of the kernels power management interface
  *
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>

--- a/cpu/atmega2560/periph/gpio.c
+++ b/cpu/atmega2560/periph/gpio.c
@@ -10,7 +10,7 @@
  * @ingroup     driver_periph
  * @{
  *
- * @file        gpio.c
+ * @file
  * @brief       Low-level GPIO driver implementation
  *
  * @author      Hauke Petersen <mail@haukepetersen.de>

--- a/cpu/atmega2560/periph/timer.c
+++ b/cpu/atmega2560/periph/timer.c
@@ -10,7 +10,7 @@
  * @ingroup     driver_periph
  * @{
  *
- * @file        timer.c
+ * @file
  * @brief       Low-level timer driver implementation for the ATmega2560 CPU
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/atmega2560/periph/uart.c
+++ b/cpu/atmega2560/periph/uart.c
@@ -10,7 +10,7 @@
  * @ingroup     driver_periph
  * @{
  *
- * @file        uart.c
+ * @file
  * @brief       Low-level UART driver implementation
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/atmega2560/reboot_arch.c
+++ b/cpu/atmega2560/reboot_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_atmega2560
  * @{
  *
- * @file        reboot_arch.c
+ * @file
  * @brief       Implementation of the kernels reboot interface
  *
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>

--- a/cpu/atmega2560/startup.c
+++ b/cpu/atmega2560/startup.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_atmega2560
  * @{
  *
- * @file        startup.c
+ * @file
  * @brief       Startup code and interrupt vector definition
  *
  * @author     Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>

--- a/cpu/atmega_common/irq_arch.c
+++ b/cpu/atmega_common/irq_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_atmega_common
  * @{
  *
- * @file        irq_arch.c
+ * @file
  * @brief       Implementation of the kernels irq interface
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/atmega_common/thread_arch.c
+++ b/cpu/atmega_common/thread_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_atmega_common
  * @{
  *
- * @file        thread_arch.c
+ * @file
  * @brief       Implementation of the kernel's architecture dependent thread interface
  *
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>

--- a/cpu/cc2538/cc2538nf11_linkerscript.ld
+++ b/cpu/cc2538/cc2538nf11_linkerscript.ld
@@ -10,7 +10,7 @@
  * @addtogroup      cpu_cc2538
  * @{
  *
- * @file            cc2538nf11_linkerscript.ld
+ * @file
  * @brief           Linker script for the CC2538NF11 model MCU
  *
  * @author          Ian Martin <ian@locicontrols.com>

--- a/cpu/cc2538/cc2538nf23_linkerscript.ld
+++ b/cpu/cc2538/cc2538nf23_linkerscript.ld
@@ -10,7 +10,7 @@
  * @addtogroup      cpu_cc2538
  * @{
  *
- * @file            cc2538nf23_linkerscript.ld
+ * @file
  * @brief           Linker script for the CC2538NF23 and CC2538SF23 model MCUs
  *
  * @author          Ian Martin <ian@locicontrols.com>

--- a/cpu/cc2538/cc2538nf53_linkerscript.ld
+++ b/cpu/cc2538/cc2538nf53_linkerscript.ld
@@ -10,7 +10,7 @@
  * @addtogroup      cpu_cc2538
  * @{
  *
- * @file            cc2538nf53_linkerscript.ld
+ * @file
  * @brief           Linker script for the CC2538NF53 and CC2538SF53 model MCUs
  *
  * @author          Ian Martin <ian@locicontrols.com>

--- a/cpu/cc2538/cpu.c
+++ b/cpu/cc2538/cpu.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_cc2538
  * @{
  *
- * @file        cpu.c
+ * @file
  * @brief       Implementation of the CPU initialization
  *
  * @author      Ian Martin <ian@locicontrols.com>

--- a/cpu/cc2538/hwtimer_arch.c
+++ b/cpu/cc2538/hwtimer_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_cc2538
  * @{
  *
- * @file        hwtimer_arch.c
+ * @file
  * @brief       Implementation of the kernels hwtimer interface
  *
  * The hardware timer implementation uses the Cortex build-in system timer as back-end.

--- a/cpu/cc2538/include/cc2538-gpio.h
+++ b/cpu/cc2538/include/cc2538-gpio.h
@@ -10,7 +10,7 @@
  * @addtogroup cpu_cc2538
  * @{
  *
- * @file            cc2538-gpio.h
+ * @file
  * @brief           Driver for the cc2538 GPIO controller
  *
  * Header file with register and macro declarations for the cc2538 GPIO module

--- a/cpu/cc2538/include/cc2538-uart.h
+++ b/cpu/cc2538/include/cc2538-uart.h
@@ -10,7 +10,7 @@
  * @addtogroup      cpu_cc2538
  * @{
  *
- * @file            cc2538-uart.h
+ * @file
  * @brief           CC2538 UART interface
  *
  * @author          Ian Martin <ian@locicontrols.com>

--- a/cpu/cc2538/include/cc2538.h
+++ b/cpu/cc2538/include/cc2538.h
@@ -10,7 +10,7 @@
  * @ingroup         cpu_cc2538_definitions
  * @{
  *
- * @file            cc2538.h
+ * @file
  * @brief           CC2538 MCU interrupt and register definitions
  *
  * @author          Ian Martin <ian@locicontrols.com>

--- a/cpu/cc2538/include/gptimer.h
+++ b/cpu/cc2538/include/gptimer.h
@@ -10,7 +10,7 @@
  * @addtogroup      cpu_cc2538
  * @{
  *
- * @file            gptimer.h
+ * @file
  * @brief           CC2538 General Purpose Timer (GPTIMER) driver
  *
  * @author          Ian Martin <ian@locicontrols.com>

--- a/cpu/cc2538/include/ioc.h
+++ b/cpu/cc2538/include/ioc.h
@@ -9,7 +9,7 @@
 /**
  * @{
  *
- * @file            ioc.h
+ * @file
  * @brief           CC2538 I/O Control driver
  *
  * @author          Ian Martin <ian@locicontrols.com>

--- a/cpu/cc2538/include/rfcore.h
+++ b/cpu/cc2538/include/rfcore.h
@@ -9,7 +9,7 @@
 /**
  * @{
  *
- * @file            rfcore.h
+ * @file
  * @brief           CC2538 RF core interface
  *
  * @author          Ian Martin <ian@locicontrols.com>

--- a/cpu/cc2538/include/soc-adc.h
+++ b/cpu/cc2538/include/soc-adc.h
@@ -10,7 +10,7 @@
  * @ingroup         cpu_cc2538
  * @{
  *
- * @file            soc-adc.h
+ * @file
  * @brief           CC2538 SOC ADC interface
  *
  * @author          Ian Martin <ian@locicontrols.com>

--- a/cpu/cc2538/include/sys-ctrl.h
+++ b/cpu/cc2538/include/sys-ctrl.h
@@ -10,7 +10,7 @@
  * @ingroup         cpu_cc2538
  * @{
  *
- * @file            sys-ctrl.h
+ * @file
  * @brief           CC2538 System Control interface
  *
  * @author          Ian Martin <ian@locicontrols.com>

--- a/cpu/cc2538/lpm_arch.c
+++ b/cpu/cc2538/lpm_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_cc2538
  * @{
  *
- * @file        lpm_arch.c
+ * @file
  * @brief       Implementation of the kernels power management interface
  *
  * @author      Ian Martin <ian@locicontrols.com>

--- a/cpu/cc2538/periph/cpuid.c
+++ b/cpu/cc2538/periph/cpuid.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_cc2538
  * @{
  *
- * @file        cpuid.c
+ * @file
  * @brief       CPU-ID driver implementation
  *
  * The CC2538 provides a 64-bit unique identifier, that is unique for each shipped unit.

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -10,7 +10,7 @@
  * @ingroup     driver_periph
  * @{
  *
- * @file        gpio.c
+ * @file
  * @brief       Low-level GPIO driver implementation
  *
  * @author      Ian Martin <ian@locicontrols.com>

--- a/cpu/cc2538/periph/random.c
+++ b/cpu/cc2538/periph/random.c
@@ -10,7 +10,7 @@
  * @ingroup     driver_periph
  * @{
  *
- * @file        random.c
+ * @file
  * @brief       Low-level random number generator driver implementation
  *
  * @author      Ian Martin <ian@locicontrols.com>

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -10,7 +10,7 @@
  * @ingroup     driver_periph
  * @{
  *
- * @file        timer.c
+ * @file
  * @brief       Low-level timer driver implementation for the CC2538 CPU
  *
  * @author      Ian Martin <ian@locicontrols.com>

--- a/cpu/cc2538/periph/uart.c
+++ b/cpu/cc2538/periph/uart.c
@@ -10,7 +10,7 @@
  * @ingroup     driver_periph
  * @{
  *
- * @file        uart.c
+ * @file
  * @brief       Low-level UART driver implementation
  *
  * @author      Ian Martin <ian@locicontrols.com>

--- a/cpu/cc2538/startup.c
+++ b/cpu/cc2538/startup.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_cc2538
  * @{
  *
- * @file        startup.c
+ * @file
  * @brief       Startup code and interrupt vector definition
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/cc2538/syscalls.c
+++ b/cpu/cc2538/syscalls.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_cc2538
  * @{
  *
- * @file        syscalls.c
+ * @file
  * @brief       NewLib system calls implementations for CC2538
  *
  * @author      Michael Baar <michael.baar@fu-berlin.de>

--- a/cpu/cc430/cc430-gpioint.c
+++ b/cpu/cc430/cc430-gpioint.c
@@ -9,7 +9,7 @@
 
 /**
  * @ingroup     cc430
- * @file        cc430-gpioint.c
+ * @file
  * @brief       CC430 GPIO Interrupt Multiplexer implementation
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  */

--- a/cpu/cc430/include/cc430-rtc.h
+++ b/cpu/cc430/include/cc430-rtc.h
@@ -20,7 +20,7 @@ extern "C" {
  */
 
 /**
- * @file    cc430-rtc.h
+ * @file
  * @brief   CC430 Real Time Clock
  *
  * @author  Freie Universität Berlin, Computer Systems & Telematics, RIOT

--- a/cpu/cortex-m3_common/irq_arch.c
+++ b/cpu/cortex-m3_common/irq_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_cortexm3_common
  * @{
  *
- * @file        irq_arch.c
+ * @file
  * @brief       Implementation of the kernels irq interface
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/cortex-m3_common/thread_arch.c
+++ b/cpu/cortex-m3_common/thread_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_cortexm3_common
  * @{
  *
- * @file        thread_arch.c
+ * @file
  * @brief       Implementation of the kernel's architecture dependent thread interface
  *
  * @author      Stefan Pfeiffer <stefan.pfeiffer@fu-berlin.de>

--- a/cpu/kw2x/include/MKW22D5.h
+++ b/cpu/kw2x/include/MKW22D5.h
@@ -71,7 +71,7 @@
 */
 
 /*!
- * @file MKW22D5.h
+ * @file
  * @version 1.7
  * @date 2015-01-21
  * @brief CMSIS Peripheral Access Layer for MKW22D5

--- a/cpu/lpc1768/include/LPC17xx.h
+++ b/cpu/lpc1768/include/LPC17xx.h
@@ -1,5 +1,5 @@
 /**************************************************************************//**
- * @file     LPC17xx.h
+ * @file
  * @brief    CMSIS Cortex-M3 Core Peripheral Access Layer Header File for
  *           NXP LPC17xx Device Series
  * @version: V1.09

--- a/cpu/msp430-common/irq.c
+++ b/cpu/msp430-common/irq.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu
 * @{
  *
- * @file        irq.c
+ * @file
  * @brief       ISR related functions
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/cpu/msp430-common/lpm_cpu.c
+++ b/cpu/msp430-common/lpm_cpu.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu
  * @{
  *
- * @file        lpm_cpu.c
+ * @file
  * @brief       low-power mode implementation for MSP430 MCUs
  *
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>

--- a/cpu/msp430-common/msp430-main.c
+++ b/cpu/msp430-common/msp430-main.c
@@ -33,7 +33,7 @@
  * @ingroup     cpu
  * @{
  *
- * @file        msp430-main.c
+ * @file
  * @brief       MSP430 CPU initialization
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/cpu/msp430-common/startup.c
+++ b/cpu/msp430-common/startup.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu
  * @{
  *
- * @file        startup.c
+ * @file
  * @brief       Calls startup functions on MSP430-based platforms
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/cpu/msp430fxyz/flashrom.c
+++ b/cpu/msp430fxyz/flashrom.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu
  * @{
  *
- * @file        flashrom.c
+ * @file
  * @brief       MSP430Fxyz flashrom functions
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>

--- a/cpu/msp430fxyz/hwtimer_msp430.c
+++ b/cpu/msp430fxyz/hwtimer_msp430.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu
  * @{
  *
- * @file        hwtimer_msp430_.c
+ * @file
  * @brief       MSP430Fxyz timer functions
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>

--- a/cpu/native/periph/cpuid.c
+++ b/cpu/native/periph/cpuid.c
@@ -10,7 +10,7 @@
  * @addtogroup  driver_periph
  * @{
  *
- * @file        cpuid.c
+ * @file
  * @brief       Implementation
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/cpu/nrf51822/cpu.c
+++ b/cpu/nrf51822/cpu.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_nrf51822
  * @{
  *
- * @file        cpu.c
+ * @file
  * @brief       Implementation of the CPU initialization
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/nrf51822/hwtimer_arch.c
+++ b/cpu/nrf51822/hwtimer_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_nrf51822
  * @{
  *
- * @file        hwtimer_arch.c
+ * @file
  * @brief       Implementation of the kernels hwtimer interface
  *
  * The hardware timer implementation uses a direct mapping to the low-level UART driver.

--- a/cpu/nrf51822/include/nrf51.h
+++ b/cpu/nrf51822/include/nrf51.h
@@ -1,6 +1,6 @@
 /****************************************************************************************************/
 /**
- * @file     nRF51.h
+ * @file
  *
  * @brief    CMSIS Cortex-M0 Peripheral Access Layer Header File for
  *           nRF51 from Nordic Semiconductor.

--- a/cpu/nrf51822/lpm_arch.c
+++ b/cpu/nrf51822/lpm_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_nrf51822
  * @{
  *
- * @file        lpm_arch.c
+ * @file
  * @brief       Implementation of the kernels power management interface
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/nrf51822/periph/gpio.c
+++ b/cpu/nrf51822/periph/gpio.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_nrf51822
  * @{
  *
- * @file        gpio.c
+ * @file
  * @brief       Low-level GPIO driver implementation
  *
  * NOTE: this GPIO driver implementation supports due to hardware limitations

--- a/cpu/nrf51822/periph/rtt.c
+++ b/cpu/nrf51822/periph/rtt.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_nrf51822
  * @{
  *
- * @file        rtt.c
+ * @file
  * @brief       Real-time timer driver implementation
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/nrf51822/periph/spi.c
+++ b/cpu/nrf51822/periph/spi.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_nrf51822
  * @{
  *
- * @file        gpio.c
+ * @file
  * @brief       Low-level SPI driver implementation
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/nrf51822/periph/timer.c
+++ b/cpu/nrf51822/periph/timer.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_nrf51822
  * @{
  *
- * @file        timer.c
+ * @file
  * @brief       Low-level timer driver implementation
  *
  * @author      Christian Kühling <kuehling@zedat.fu-berlin.de>

--- a/cpu/nrf51822/periph/uart.c
+++ b/cpu/nrf51822/periph/uart.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_nrf51822
  * @{
  *
- * @file        uart.c
+ * @file
  * @brief       Low-level UART driver implementation
  *
  * @author      Christian Kühling <kuehling@zedat.fu-berlin.de>

--- a/cpu/nrf51822/startup.c
+++ b/cpu/nrf51822/startup.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_nrf51822
  * @{
  *
- * @file        startup.c
+ * @file
  * @brief       Startup code and interrupt vector definition
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/nrf51822/syscalls.c
+++ b/cpu/nrf51822/syscalls.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_nrf51822
  * @{
  *
- * @file        syscalls.c
+ * @file
  * @brief       NewLib system calls implementations for nRF51822
  *
  * @author      Michael Baar <michael.baar@fu-berlin.de>

--- a/cpu/sam3x8e/cpu.c
+++ b/cpu/sam3x8e/cpu.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_sam3x8e
  * @{
  *
- * @file        cpu.c
+ * @file
  * @brief       Implementation of the CPU initialization
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/sam3x8e/hwtimer_arch.c
+++ b/cpu/sam3x8e/hwtimer_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_sam3x8e
  * @{
  *
- * @file        hwtimer_arch.c
+ * @file
  * @brief       Implementation of the kernels hwtimer interface
  *
  * The hardware timer implementation uses the Cortex build-in system timer as back-end.

--- a/cpu/sam3x8e/lpm_arch.c
+++ b/cpu/sam3x8e/lpm_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_sam3x8e
  * @{
  *
- * @file        lpm_arch.c
+ * @file
  * @brief       Implementation of the kernels power management interface
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/sam3x8e/periph/gpio.c
+++ b/cpu/sam3x8e/periph/gpio.c
@@ -10,7 +10,7 @@
  * @ingroup     driver_periph
  * @{
  *
- * @file        gpio.c
+ * @file
  * @brief       Low-level GPIO driver implementation
  *
  * @author      Hauke Petersen <mail@haukepetersen.de>

--- a/cpu/sam3x8e/periph/spi.c
+++ b/cpu/sam3x8e/periph/spi.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_sam3x8e
  * @{
  *
- * @file        spi.c
+ * @file
  * @brief       Low-level SPI driver implementation
  *
  * @author      Maxime Blanloeil <maxime.blanloeil@phelma.grenoble-inp.fr>

--- a/cpu/sam3x8e/periph/timer.c
+++ b/cpu/sam3x8e/periph/timer.c
@@ -10,7 +10,7 @@
  * @ingroup     driver_periph
  * @{
  *
- * @file        timer.c
+ * @file
  * @brief       Low-level timer driver implementation for the SAM3X8E CPU
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/sam3x8e/periph/uart.c
+++ b/cpu/sam3x8e/periph/uart.c
@@ -10,7 +10,7 @@
  * @ingroup     driver_periph
  * @{
  *
- * @file        uart.c
+ * @file
  * @brief       Low-level UART driver implementation
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/sam3x8e/startup.c
+++ b/cpu/sam3x8e/startup.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_sam3x8e
  * @{
  *
- * @file        startup.c
+ * @file
  * @brief       Startup code and interrupt vector definition
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/sam3x8e/syscalls.c
+++ b/cpu/sam3x8e/syscalls.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_sam3x8e
  * @{
  *
- * @file        syscalls.c
+ * @file
  * @brief       NewLib system calls implementations for SAM3X8E
  *
  * @author      Michael Baar <michael.baar@fu-berlin.de>

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_samd21
  * @{
  *
- * @file        cpu.c
+ * @file
  * @brief       Implementation of the CPU initialization
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/cpu/samd21/lpm_arch.c
+++ b/cpu/samd21/lpm_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_samd21
  * @{
  *
- * @file        lpm_arch.c
+ * @file
  * @brief       Implementation of the kernels power management interface
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/cpu/samd21/periph/cpuid.c
+++ b/cpu/samd21/periph/cpuid.c
@@ -10,7 +10,7 @@
  * @addtogroup  driver_periph
  * @{
  *
- * @file        cpuid.c
+ * @file
  * @brief       Low-level CPUID driver implementation
  *
  * @author      Troels Hoffmeyer <troels.d.hoffmeyer@gmail.com>

--- a/cpu/samd21/periph/gpio.c
+++ b/cpu/samd21/periph/gpio.c
@@ -10,7 +10,7 @@
  * @ingroup     driver_periph
  * @{
  *
- * @file        gpio.c
+ * @file
  * @brief       Low-level GPIO driver implementation
  *
  * @author      Troels Hoffmeyer <troels.d.hoffmeyer@gmail.com>

--- a/cpu/samd21/periph/spi.c
+++ b/cpu/samd21/periph/spi.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_samd21
  * @{
  *
- * @file        spi.c
+ * @file
  * @brief       Low-level SPI driver implementation
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/cpu/samd21/periph/timer.c
+++ b/cpu/samd21/periph/timer.c
@@ -10,7 +10,7 @@
  * @ingroup     driver_periph
  * @{
  *
- * @file        timer.c
+ * @file
  * @brief       Low-level timer driver implementation
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/cpu/samd21/periph/uart.c
+++ b/cpu/samd21/periph/uart.c
@@ -10,7 +10,7 @@
  * @ingroup     driver_periph
  * @{
  *
- * @file        uart.c
+ * @file
  * @brief       Low-level UART driver implementation
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/cpu/samd21/startup.c
+++ b/cpu/samd21/startup.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_samd21
  * @{
  *
- * @file        startup.c
+ * @file
  * @brief       Startup code and interrupt vector definition
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/cpu/samd21/syscalls.c
+++ b/cpu/samd21/syscalls.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_samd21
  * @{
  *
- * @file        syscalls.c
+ * @file
  * @brief       NewLib system calls implementations for samd21
  *
  * @author      Michael Baar <michael.baar@fu-berlin.de>

--- a/cpu/stm32f1/cpu.c
+++ b/cpu/stm32f1/cpu.c
@@ -11,7 +11,7 @@
  * @ingroup     cpu_stm32f1
  * @{
  *
- * @file        cpu.c
+ * @file
  * @brief       Implementation of the kernel cpu functions
  *
  * @author      Stefan Pfeiffer <stefan.pfeiffer@fu-berlin.de>

--- a/cpu/stm32f1/hwtimer_arch.c
+++ b/cpu/stm32f1/hwtimer_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_stm32f1
  * @{
  *
- * @file        hwtimer_arch.c
+ * @file
  * @brief       Implementation of the kernels hwtimer interface
  *
  * The hardware timer implementation uses the Coretex build-in system timer as backend.

--- a/cpu/stm32f1/lpm_arch.c
+++ b/cpu/stm32f1/lpm_arch.c
@@ -11,7 +11,7 @@
  * @ingroup     cpu_stm32f1
  * @{
  *
- * @file        lpm_arch.c
+ * @file
  * @brief       Implementation of the kernel's lpm interface
  *
  * @author      Alaeddine Weslati <alaeddine.weslati@inria.fr>

--- a/cpu/stm32f1/periph/cpuid.c
+++ b/cpu/stm32f1/periph/cpuid.c
@@ -10,7 +10,7 @@
  * @addtogroup  driver_periph
  * @{
  *
- * @file        cpuid.c
+ * @file
  * @brief       Low-level CPUID driver implementation
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_stm32f1
  * @{
  *
- * @file        gpio.c
+ * @file
  * @brief       Low-level GPIO driver implementation
  *
  * @author      Hauke Petersen <mail@haukepetersen.de>

--- a/cpu/stm32f1/periph/rtt.c
+++ b/cpu/stm32f1/periph/rtt.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_stm32f1
  * @{
  *
- * @file        rtt.c
+ * @file
  * @brief       Low-level RTT driver implementation
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/cpu/stm32f1/periph/spi.c
+++ b/cpu/stm32f1/periph/spi.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_stm32f1
  * @{
  *
- * @file        spi.c
+ * @file
  * @brief       Low-level SPI driver implementation
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/cpu/stm32f1/periph/timer.c
+++ b/cpu/stm32f1/periph/timer.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_stm32f1
  * @{
  *
- * @file        timer.c
+ * @file
  * @brief       Low-level timer driver implementation
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/stm32f1/periph/uart.c
+++ b/cpu/stm32f1/periph/uart.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_stm32f1
  * @{
  *
- * @file        uart.c
+ * @file
  * @brief       Low-level UART driver implementation
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/stm32f1/startup.c
+++ b/cpu/stm32f1/startup.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_stm32f1
  * @{
  *
- * @file        startup.c
+ * @file
  * @brief       Startup code and interrupt vector definition
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/stm32f1/syscalls.c
+++ b/cpu/stm32f1/syscalls.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_stm32f1
  * @{
  *
- * @file        syscalls.c
+ * @file
  * @brief       NewLib system calls implementations for stm32f1
  *
  * @author      Michael Baar <michael.baar@fu-berlin.de>

--- a/cpu/stm32l1/cpu.c
+++ b/cpu/stm32l1/cpu.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_stm32l1
  * @{
  *
- * @file        cpu.c
+ * @file
  * @brief       Implementation of the kernel cpu functions
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/cpu/stm32l1/hwtimer_arch.c
+++ b/cpu/stm32l1/hwtimer_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_stm32l1
  * @{
  *
- * @file        hwtimer_arch.c
+ * @file
  * @brief       Implementation of the kernels hwtimer interface
  *
  * The hardware timer implementation uses the Cortex build-in system timer as backend.

--- a/cpu/stm32l1/lpm_arch.c
+++ b/cpu/stm32l1/lpm_arch.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_stm32l1
  * @{
  *
- * @file        lpm_arch.c
+ * @file
  * @brief       Implementation of the kernel's lpm interface
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/stm32l1/periph/cpuid.c
+++ b/cpu/stm32l1/periph/cpuid.c
@@ -10,7 +10,7 @@
  * @addtogroup  driver_periph
  * @{
  *
- * @file        cpuid.c
+ * @file
  * @brief       Low-level CPUID driver implementation
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/cpu/stm32l1/startup.c
+++ b/cpu/stm32l1/startup.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_stm32l1
  * @{
  *
- * @file        startup.c
+ * @file
  * @brief       Startup code and interrupt vector definition
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/stm32l1/syscalls.c
+++ b/cpu/stm32l1/syscalls.c
@@ -10,7 +10,7 @@
  * @ingroup     cpu_stm32l1
  * @{
  *
- * @file        syscalls.c
+ * @file
  * @brief       NewLib system calls implementations for stm32l1
  *
  * @author      Michael Baar <michael.baar@fu-berlin.de>

--- a/dist/tools/linux-border_router/flowcontrol.h
+++ b/dist/tools/linux-border_router/flowcontrol.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file    flowcontrol.h
+ * @file
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @brief   Public declarations for the flow control jobs via the
  *          serial interface for the 6LoWPAN Border Router driver.

--- a/dist/tools/linux-border_router/multiplex.h
+++ b/dist/tools/linux-border_router/multiplex.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file    multiplex.h
+ * @file
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @brief   Public declarations for the multiplexing jobs via the
  *          serial interface for the 6LoWPAN Border Router driver.

--- a/dist/tools/linux-border_router/serialnumber.h
+++ b/dist/tools/linux-border_router/serialnumber.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file    serialnumber.h
+ * @file
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @brief   Serial number arithmetics after RFC 1982, section 3
  */

--- a/dist/tools/linux-border_router/sixlowdriver.h
+++ b/dist/tools/linux-border_router/sixlowdriver.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file    sixlowdriver.h
+ * @file
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @brief   Public declarations for the 6LoWPAN Border Router driver.
  */

--- a/dist/tools/linux-border_router/testing.h
+++ b/dist/tools/linux-border_router/testing.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file    testing.h
+ * @file
  * @brief   Test suite for the 6LoWPAN Border Router.
  *
  *          The tests are managed in the following way:

--- a/drivers/cc110x/cc110x-netdev.c
+++ b/drivers/cc110x/cc110x-netdev.c
@@ -9,7 +9,7 @@
 /**
  * @ingroup     drivers_cc110x
  * @{
- * @file        cc110x_netdev.c
+ * @file
  * @brief       Functionality for netdev base interface
  *
  * @author      Fabian Nack <nack@inf.fu-berlin.de>

--- a/drivers/cc110x/cc110x-rxtx.c
+++ b/drivers/cc110x/cc110x-rxtx.c
@@ -10,7 +10,7 @@
 /**
  * @ingroup     drivers_cc110x
  * @{
- * @file        cc110x-rx.c
+ * @file
  * @brief       Functions for packet reception and transmission on cc110x devices
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>

--- a/drivers/cc110x/cc110x-spi.c
+++ b/drivers/cc110x/cc110x-spi.c
@@ -10,7 +10,7 @@
  * @ingroup     drivers_cc110x
  * @{
  *
- * @file        cc110x_spi.c
+ * @file
  * @brief       TI Chipcon CC110x SPI driver
  *
  * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>

--- a/drivers/cc110x/cc110x.c
+++ b/drivers/cc110x/cc110x.c
@@ -10,7 +10,7 @@
 /**
  * @ingroup     drivers_cc110x
  * @{
- * @file        cc110x.c
+ * @file
  * @brief       Basic functionality of cc110x driver
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>

--- a/drivers/cc110x_legacy/cc110x-rx.c
+++ b/drivers/cc110x_legacy/cc110x-rx.c
@@ -10,7 +10,7 @@
 /**
  * @ingroup     drivers_cc110x_legacy
  * @{
- * @file        cc110x-rx.c
+ * @file
  * @brief       Functions for packet reception on cc110x
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>

--- a/drivers/cc110x_legacy/cc110x-tx.c
+++ b/drivers/cc110x_legacy/cc110x-tx.c
@@ -10,7 +10,7 @@
 /**
  * @ingroup     drivers_cc110x_legacy
  * @{
- * @file        cc110x-tx.c
+ * @file
  * @brief       Functions for packet transmission on cc110x
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>

--- a/drivers/cc110x_legacy/cc110x.c
+++ b/drivers/cc110x_legacy/cc110x.c
@@ -10,7 +10,7 @@
 /**
  * @ingroup     drivers_cc110x_legacy
  * @{
- * @file        cc110x.c
+ * @file
  * @brief       Basic functionality of cc110x driver
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>

--- a/drivers/cc110x_legacy/spi/cc110x_spi.c
+++ b/drivers/cc110x_legacy/spi/cc110x_spi.c
@@ -10,7 +10,7 @@
  * @ingroup     drivers_cc110x_legacy
  * @{
  *
- * @file        cc110x_spi.c
+ * @file
  * @brief       TI Chipcon CC1100 SPI driver
  *
  * @author      Thomas Hillebrandt <hillebra@inf.fu-berlin.de>

--- a/drivers/include/cc110x/cc110x-netdev.h
+++ b/drivers/include/cc110x/cc110x-netdev.h
@@ -10,7 +10,7 @@
  * @ingroup     drivers_cc110x
  * @{
  *
- * @file        cc110x-netdev.h
+ * @file
  * @brief       Variables for the cc110x netdev base interface
  *
  * @author      Fabian Nack <nack@inf.fu-berlin.de>

--- a/drivers/include/cc110x_legacy/cc110x-arch.h
+++ b/drivers/include/cc110x_legacy/cc110x-arch.h
@@ -10,7 +10,7 @@
  * @ingroup     drivers_cc110x_legacy
  * @{
  *
- * @file        cc110x-arch.h
+ * @file
  * @brief       CC1100 architecture dependent functions
  *
  * @author      Heiko Will <hwill@inf.fu-berlin.de>

--- a/drivers/include/cc110x_legacy/cc110x-interface.h
+++ b/drivers/include/cc110x_legacy/cc110x-interface.h
@@ -13,7 +13,7 @@
  * @ingroup     drivers
  * @{
  *
- * @file        cc110x_legacy.h
+ * @file
  * @brief       Data structures and variables for the cc110x driver interface
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>

--- a/drivers/include/diskio.h
+++ b/drivers/include/diskio.h
@@ -15,7 +15,7 @@
  *
  * @{
  *
- * @file        diskio.h
+ * @file
  *
  * @author      unknown
  */

--- a/drivers/include/ltc4150_arch.h
+++ b/drivers/include/ltc4150_arch.h
@@ -19,7 +19,7 @@ extern "C" {
  * @brief       Driver for the Linear Technology LTC4150 Coulomb Counter
  * @{
  *
- * @file        ltc4150_arch.h
+ * @file
  * @brief       LTC4150 Coulomb Counter
  *
  * @author      Heiko Will

--- a/drivers/include/netdev/base.h
+++ b/drivers/include/netdev/base.h
@@ -10,7 +10,7 @@
  * @addtogroup  netdev
  * @{
  *
- * @file        netdev/base.h
+ * @file
  * @brief       Basic network device driver interface definitions.
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/drivers/include/netdev/default.h
+++ b/drivers/include/netdev/default.h
@@ -10,7 +10,7 @@
  * @addtogroup  netdev
  * @{
  *
- * @file        netdev/default.h
+ * @file
  * @brief       Supplies the users with default values for the use of
  *              @ref netdev
  *

--- a/drivers/include/sht11.h
+++ b/drivers/include/sht11.h
@@ -15,7 +15,7 @@
  * @ingroup     drivers
  * @{
  *
- * @file        sht11.h
+ * @file
  * @brief       SHT11 Device Driver
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics

--- a/drivers/include/srf02.h
+++ b/drivers/include/srf02.h
@@ -15,7 +15,7 @@
  *
  * @{
  *
- * @file        srf02.h
+ * @file
  * @brief       Driver definitions for the SRF02 ultrasonic ranger.
  *
  * The connection between the SRF02 and the MCU is based on the i2c interface.

--- a/drivers/include/srf08.h
+++ b/drivers/include/srf08.h
@@ -15,7 +15,7 @@
  *
  * @{
  *
- * @file        srf08.h
+ * @file
  * @brief       Driver definitions for the SRF02 ultrasonic ranger.
  *
  * The connection between the SRF08 and the MCU is based on the i2c interface.

--- a/drivers/kw2xrf/include/kw2xrf_spi.h
+++ b/drivers/kw2xrf/include/kw2xrf_spi.h
@@ -9,7 +9,7 @@
 /**
  * @ingroup     drivers_kw2xrf
  * @{
- * @file        kw2xrf_spi.h
+ * @file
  * @brief       Definition of KW2XRF SPI functions
  *
  * @author      Johann Fischer <j.fischer@phytec.de>

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -9,7 +9,7 @@
 /**
  * @ingroup     kw2xrf
  * @{
- * @file        kw2xrf.c
+ * @file
  * @brief       Basic functionality of kw2xrf driver
  *
  * @author      Johann Fischer <j.fischer@phytec.de>

--- a/drivers/kw2xrf/kw2xrf_spi.c
+++ b/drivers/kw2xrf/kw2xrf_spi.c
@@ -9,7 +9,7 @@
 /**
  * @ingroup     drivers_kw2xrf
  * @{
- * @file        kw2xrf_spi.c
+ * @file
  * @brief       Implementation of SPI-functions for the kw2xrf driver
  *
  * @author      Johann Fischer <j.fischer@phytec.de>

--- a/drivers/netdev/802154/802154.c
+++ b/drivers/netdev/802154/802154.c
@@ -10,7 +10,7 @@
  * @addtogroup  netdev
  * @{
  *
- * @file        802154.c
+ * @file
  * @brief       Provides wrappers of @ref netdev/base.h functions to
  *              netdev/802154.h functions.
  *

--- a/drivers/netdev/base/base.c
+++ b/drivers/netdev/base/base.c
@@ -10,7 +10,7 @@
  * @addtogroup  netdev
  * @{
  *
- * @file        base.c
+ * @file
  * @brief       Provides helper functions to the API in @ref netdev/base.h.
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/drivers/srf02/srf02.c
+++ b/drivers/srf02/srf02.c
@@ -10,7 +10,7 @@
  * @ingroup     driver_srf02
  * @{
  *
- * @file        srf02.c
+ * @file
  * @brief       Driver for the SRF02 ultrasonic ranger.
  *              The connection between the MCU and the SRF02 is based on the
  *              i2c-interface.

--- a/drivers/srf08/srf08.c
+++ b/drivers/srf08/srf08.c
@@ -10,7 +10,7 @@
  * @ingroup     driver_srf08
  * @{
  *
- * @file        srf08.c
+ * @file
  * @brief       Driver for the SRF08 ultrasonic ranger.
  *              The connection between the MCU and the SRF08 is based on the
  *              i2c-interface.

--- a/examples/riot_and_cpp/c_functions.c
+++ b/examples/riot_and_cpp/c_functions.c
@@ -10,7 +10,7 @@
  * @ingroup     examples
  * @{
  *
- * @file        c_functions.c
+ * @file
  * @brief       Some functions implementaion in C.
  *
  * @author      DangNhat Pham-Huu <51002279@hcmut.edu.vn>

--- a/examples/riot_and_cpp/c_functions.h
+++ b/examples/riot_and_cpp/c_functions.h
@@ -10,7 +10,7 @@
  * @ingroup     examples
  * @{
  *
- * @file        c_functions.h
+ * @file
  * @brief       Definitions for some c functions.
  *
  * @author      DangNhat Pham-Huu <51002279@hcmut.edu.vn>

--- a/examples/riot_and_cpp/cpp_class.cpp
+++ b/examples/riot_and_cpp/cpp_class.cpp
@@ -11,7 +11,7 @@
  * @ingroup     examples
  * @{
  *
- * @file        cpp_class.cpp
+ * @file
  * @brief       implementation of declared functions of object cpp_class
  *
  * @author      Martin Landsmann <martin.landsmann@haw-hamburg.de>

--- a/examples/riot_and_cpp/cpp_class.hpp
+++ b/examples/riot_and_cpp/cpp_class.hpp
@@ -13,7 +13,7 @@
  * @ingroup     examples
  * @{
  *
- * @file        cpp_class.hpp
+ * @file
  * @brief       simple c++ object declaration with public and private functions
  *
  * @author      Martin Landsmann <martin.landsmann@haw-hamburg.de>

--- a/examples/riot_and_cpp/main.cpp
+++ b/examples/riot_and_cpp/main.cpp
@@ -8,7 +8,7 @@
  */
 
 /**
- * @file        main.cpp
+ * @file
  * @brief       Demonstration of mixed c++ and c user application with pure c RIOT
  *              - mixing of c and c++ source to test name mangling
  *              - introducing a namespace to declarative block, avoiding to qualify calls, e.g. std::vector

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -9,7 +9,7 @@
  *
  * @ingroup auto_init
  * @{
- * @file    auto_init_c
+ * @file
  * @brief   initializes any used module that has a trivial init function
  * @author  Oliver Hahm <oliver.hahm@inria.fr>
  * @author  Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/sys/base64/base64.c
+++ b/sys/base64/base64.c
@@ -10,7 +10,7 @@
 /**
  * @ingroup base64
  * @{
- * @file    base64.c
+ * @file
  * @brief   Functions to encode and decode base64
  *
  * @author  Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>

--- a/sys/chardev_thread.c
+++ b/sys/chardev_thread.c
@@ -9,7 +9,7 @@
  *
  * @ingroup chardev
  * @{
- * @file    chardev_thread.c
+ * @file
  * @brief   Runs an infinite loop in a separate thread to handle access to character devices such as uart.
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  * @}

--- a/sys/compat/hwtimer/hwtimer_arch.c
+++ b/sys/compat/hwtimer/hwtimer_arch.c
@@ -12,7 +12,7 @@
  * @ingroup     sys_compat
  * @{
  *
- * @file        hwtimer_arch.c
+ * @file
  * @brief       Implementation of the kernels hwtimer interface over periph timers
  *
  * This hwtimer implementation wraps one periph timer

--- a/sys/config/config.c
+++ b/sys/config/config.c
@@ -9,7 +9,7 @@
  *
  * @ingroup config
  * @{
- * @file    config_c
+ * @file
  * @brief   Provides system configuration struct with default values.
  * @author  Oliver Hahm <oliver.hahm@inria.fr>
  * @}

--- a/sys/cpp11-compat/condition_variable.cpp
+++ b/sys/cpp11-compat/condition_variable.cpp
@@ -10,7 +10,7 @@
  * @ingroup cpp11-compat
  * @{
  *
- * @file    condition_variable.cpp
+ * @file
  * @brief   C++11 condition variable drop in replacement
  *
  * @author  Raphael Hiesgen <raphael.hiesgen (at) haw-hamburg.de>

--- a/sys/cpp11-compat/include/riot/chrono.hpp
+++ b/sys/cpp11-compat/include/riot/chrono.hpp
@@ -10,7 +10,7 @@
  * @ingroup cpp11-compat
  * @{
  *
- * @file   chrono.hpp
+ * @file
  * @brief  C++11 chrono drop in replacement that adds the function now based on
  *         vtimer/timex
  * @see    <a href="http://en.cppreference.com/w/cpp/thread/thread">

--- a/sys/cpp11-compat/include/riot/condition_variable.hpp
+++ b/sys/cpp11-compat/include/riot/condition_variable.hpp
@@ -10,7 +10,7 @@
  * @ingroup cpp11-compat
  * @{
  *
- * @file   condition_variable.hpp
+ * @file
  * @brief  C++11 condition variable drop in replacement
  * @see    <a href="http://en.cppreference.com/w/cpp/thread/condition_variable">
  *           std::condition_variable

--- a/sys/cpp11-compat/include/riot/detail/thread_util.hpp
+++ b/sys/cpp11-compat/include/riot/detail/thread_util.hpp
@@ -10,7 +10,7 @@
  * @ingroup cpp11-compat
  * @{
  *
- * @file    thread_util.hpp
+ * @file
  * @brief   utility functions
  *
  * @author  Dominik Charousset <dominik.charousset (at) haw-hamburg.de>

--- a/sys/cpp11-compat/include/riot/mutex.hpp
+++ b/sys/cpp11-compat/include/riot/mutex.hpp
@@ -10,7 +10,7 @@
  * @ingroup cpp11-compat
  * @{
  *
- * @file    mutex.hpp
+ * @file
  * @brief   C++11 mutex drop in replacement
  * @see     <a href="http://en.cppreference.com/w/cpp/thread/mutex">
  *            std::mutex, std::lock_guard and std::unique_lock

--- a/sys/cpp11-compat/include/riot/thread.hpp
+++ b/sys/cpp11-compat/include/riot/thread.hpp
@@ -10,7 +10,7 @@
  * @ingroup cpp11-compat
  * @{
  *
- * @file    thread.hpp
+ * @file
  * @brief   C++11 thread drop in replacement
  * @see     <a href="http://en.cppreference.com/w/cpp/thread/thread">
  *            std::thread, std::this_thread

--- a/sys/cpp11-compat/mutex.cpp
+++ b/sys/cpp11-compat/mutex.cpp
@@ -10,7 +10,7 @@
  * @ingroup cpp11-compat
  * @{
  *
- * @file    mutex.cpp
+ * @file
  * @brief   C++11 mutex drop in replacement
  *
  * @author  Raphael Hiesgen <raphael.hiesgen (at) haw-hamburg.de>

--- a/sys/cpp11-compat/thread.cpp
+++ b/sys/cpp11-compat/thread.cpp
@@ -10,7 +10,7 @@
  * @ingroup cpp11-compat
  * @{
  *
- * @file    thread.cpp
+ * @file
  * @brief   C++11 thread drop in replacement
  *
  * @author  Raphael Hiesgen <raphael.hiesgen (at) haw-hamburg.de>

--- a/sys/crypto/3des.c
+++ b/sys/crypto/3des.c
@@ -10,7 +10,7 @@
  * @ingroup     sys_crypto
  * @{
  *
- * @file        3des.c
+ * @file
  * @brief       implementation of the 3DES cipher-algorithm
  *
  * @author      Freie Universitaet Berlin, Computer Systems & Telematics

--- a/sys/crypto/aes.c
+++ b/sys/crypto/aes.c
@@ -10,7 +10,7 @@
  * @ingroup     sys_crypto
  * @{
  *
- * @file        aes.c
+ * @file
  * @brief       implementation of the AES cipher-algorithm
  *
  * @author      Freie Universitaet Berlin, Computer Systems & Telematics

--- a/sys/crypto/rc5.c
+++ b/sys/crypto/rc5.c
@@ -10,7 +10,7 @@
  * @ingroup     sys_crypto
  * @{
  *
- * @file        rc5.c
+ * @file
  * @brief       implementation of the RC5 cipher-algorithm
  *
  * @author      Nicolai Schmittberger <nicolai.schmittberger@fu-berlin.de>

--- a/sys/crypto/sha256.c
+++ b/sys/crypto/sha256.c
@@ -31,7 +31,7 @@
  * @ingroup     sys_crypto
  * @{
  *
- * @file        sha256.c
+ * @file
  * @brief       SHA256 hash function implementation
  *
  * @author      Colin Percival

--- a/sys/crypto/skipjack.c
+++ b/sys/crypto/skipjack.c
@@ -10,7 +10,7 @@
  * @ingroup     sys_crypto
  * @{
  *
- * @file        skipjack.c
+ * @file
  * @brief       implementation of the SkipJack Cipher-Algorithm
  *
  * @author      Freie Universitaet Berlin, Computer Systems & Telematics

--- a/sys/crypto/twofish.c
+++ b/sys/crypto/twofish.c
@@ -11,7 +11,7 @@
  * @ingroup     sys_crypto
  * @{
  *
- * @file        twofish.c
+ * @file
  * @brief       implementation of the twofish cipher-algorithm
  *
  * @author      Freie Universitaet Berlin, Computer Systems & Telematics

--- a/sys/include/auto_init.h
+++ b/sys/include/auto_init.h
@@ -26,7 +26,7 @@
  *
  * @{
  *
- * @file        auto_init.h
+ * @file
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>

--- a/sys/include/bloom.h
+++ b/sys/include/bloom.h
@@ -114,7 +114,7 @@
  * @brief       Bloom filter library
  * @{
  *
- * @file        bloom.h
+ * @file
  * @brief       Bloom filter API
  *
  * @author Christian Mehlis <mehlis@inf.fu-berlin.de>

--- a/sys/include/board_uart0.h
+++ b/sys/include/board_uart0.h
@@ -13,7 +13,7 @@
  * @brief       UART0 interface abstraction
  * @{
  *
- * @file        board_uart0.h
+ * @file
  * @brief       Interface definitions for the UART0 abstraction
  */
 

--- a/sys/include/config.h
+++ b/sys/include/config.h
@@ -10,7 +10,7 @@
  * @addtogroup  core_internal
  * @{
  *
- * @file        config.h
+ * @file
  * @brief       Kernel configuration interface
  *
  * @author      unknown

--- a/sys/include/crypto/3des.h
+++ b/sys/include/crypto/3des.h
@@ -10,7 +10,7 @@
  * @ingroup     sys_crypto
  * @{
  *
- * @file        3des.h
+ * @file
  * @brief       Headers for the implementation of the 3DES cipher-algorithm
  *
  * @author      Freie Universitaet Berlin, Computer Systems & Telematics,

--- a/sys/include/crypto/aes.h
+++ b/sys/include/crypto/aes.h
@@ -10,7 +10,7 @@
  * @ingroup     sys_crypto
  * @{
  *
- * @file        aes.h
+ * @file
  * @brief       Headers for the implementation of the AES cipher-algorithm
  *
  * @author      Freie Universitaet Berlin, Computer Systems & Telematics

--- a/sys/include/crypto/ciphers.h
+++ b/sys/include/crypto/ciphers.h
@@ -10,7 +10,7 @@
  * @ingroup     sys_crypto
  * @{
  *
- * @file        ciphers.h
+ * @file
  * @brief       Headers for the packet encryption class. They are used to encrypt single packets.
  *
  * @author      Freie Universitaet Berlin, Computer Systems & Telematics

--- a/sys/include/crypto/rc5.h
+++ b/sys/include/crypto/rc5.h
@@ -10,7 +10,7 @@
  * @ingroup     sys_crypto
  * @{
  *
- * @file        rc5.h
+ * @file
  * @brief       Headers for the implementation of the RC5 Cipher-Algorithm
  *
  * @author      Freie Universitaet Berlin, Computer Systems & Telematics

--- a/sys/include/crypto/sha256.h
+++ b/sys/include/crypto/sha256.h
@@ -32,7 +32,7 @@
  * @ingroup     sys_crypto
  * @{
  *
- * @file        sha256.h
+ * @file
  * @brief       Header definitions for the SHA256 hash function
  *
  * @author      Colin Percival

--- a/sys/include/crypto/skipjack.h
+++ b/sys/include/crypto/skipjack.h
@@ -10,7 +10,7 @@
  * @ingroup     sys_crypto
  * @{
  *
- * @file        skipjack.h
+ * @file
  * @brief       Headers for the implementation of the SkipJack cipher-algorithm
  *
  * @author      Freie Universitaet Berlin, Computer Systems & Telematics

--- a/sys/include/crypto/twofish.h
+++ b/sys/include/crypto/twofish.h
@@ -10,7 +10,7 @@
  * @ingroup     sys_crypto
  * @{
  *
- * @file        twofish.h
+ * @file
  * @brief       Headers for the implementation of the TwoFish Cipher-Algorithm
  *
  * @author      Freie Universitaet Berlin, Computer Systems & Telematics

--- a/sys/include/fd.h
+++ b/sys/include/fd.h
@@ -12,7 +12,7 @@
  */
 
 /**
- * @file    fd.h
+ * @file
  * @brief   Unifies diverse identifiers of RIOT to POSIX like file descriptors.
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/sys/include/hashes.h
+++ b/sys/include/hashes.h
@@ -12,7 +12,7 @@
  * @brief       Hash function library
  * @{
  *
- * @file        hashes.h
+ * @file
  * @brief       Hash function API
  *
  * @author      Jason Linehan <patientulysses@gmail.com>

--- a/sys/include/od.h
+++ b/sys/include/od.h
@@ -20,7 +20,7 @@
  *      </a>
  * @{
  *
- * @file    od.h
+ * @file
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */

--- a/sys/include/posix_io.h
+++ b/sys/include/posix_io.h
@@ -9,7 +9,7 @@
 /**
  * @ingroup     posix
  * @{
- * @file        posix_io.h
+ * @file
  * @brief       POSIX-like IO
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/sys/include/trickle.h
+++ b/sys/include/trickle.h
@@ -15,7 +15,7 @@
  */
 
 /**
- * @file    trickle.h
+ * @file
  * @brief   Implementation of a generic Trickle Algorithm (RFC 6206)
  *
  * @author  Eric Engel <eric.engel@fu-berlin.de>

--- a/sys/log/log_printfnoformat/log_module.h
+++ b/sys/log/log_printfnoformat/log_module.h
@@ -12,7 +12,7 @@
  * @brief       This module implements an example logging module
  * @{
  *
- * @file        log_module.h
+ * @file
  * @brief       log_module header
  *
  * @author      Jason Linehan <patientulysses@gmail.com>

--- a/sys/net/crosslayer/net_help/net_help.c
+++ b/sys/net/crosslayer/net_help/net_help.c
@@ -8,7 +8,7 @@
 
 /**
  * @{
- * @file    net_help.c
+ * @file
  * @brief   Providing implementation for prototypes defined in net_help.h.
  * @author  Oliver Gesch <oliver.gesch@googlemail.com>
  */

--- a/sys/net/crosslayer/netapi/netapi.c
+++ b/sys/net/crosslayer/netapi/netapi.c
@@ -8,7 +8,7 @@
 
 /**
  * @{
- * @file    netapi.c
+ * @file
  * @brief   You do not necessarily need this file (leave `netapi` out of
  *          `USEMODULE`, the netapi.h file will still be available for
  *          inclusion). It supplies you however with some helper functions

--- a/sys/net/crosslayer/ng_netreg/ng_netreg.c
+++ b/sys/net/crosslayer/ng_netreg/ng_netreg.c
@@ -9,7 +9,7 @@
 /**
  * @{
  *
- * @file    ng_netreg.c
+ * @file
  */
 
 #include <errno.h>

--- a/sys/net/include/aodvv2/aodvv2.h
+++ b/sys/net/include/aodvv2/aodvv2.h
@@ -13,7 +13,7 @@
  * @ingroup     net
  * @{
  *
- * @file        aodvv2/aodvv2.h
+ * @file
  * @brief       Interface for the AODVv2 routing protocol
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>

--- a/sys/net/include/aodvv2/types.h
+++ b/sys/net/include/aodvv2/types.h
@@ -11,7 +11,7 @@
  * @ingroup     aodvv2
  * @{
  *
- * @file        aodvv2/types.h
+ * @file
  * @brief       data types for the aodvv2 routing protocol
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>

--- a/sys/net/include/ccn_lite/util/ccnl-riot-client.h
+++ b/sys/net/include/ccn_lite/util/ccnl-riot-client.h
@@ -19,7 +19,7 @@
 /**
  * @ingroup ccnl
  * @{
- * @file    ccnl-riot-client.h
+ * @file
  * @brief   CCN high level client functions
  * @author  Christian Mehlis <mehlis@inf.fu-berlin.de>
  * @}

--- a/sys/net/include/etx_beaconing.h
+++ b/sys/net/include/etx_beaconing.h
@@ -9,7 +9,7 @@
 /**
  * @ingroup     rpl
  * @{
- * @file        etx_beaconing.h
+ * @file
  *
  * Header-file, which includes all constants and functions used for ETX-based beaconing.
  *

--- a/sys/net/include/ipv6.h
+++ b/sys/net/include/ipv6.h
@@ -9,7 +9,7 @@
 /**
  * @ingroup net_sixlowpan
  * @{
- * @file    ipv6.h
+ * @file
  * @brief   IPv6 and ICMP functions
  *
  *          Wraps all API types, constants and functions of

--- a/sys/net/include/net_help.h
+++ b/sys/net/include/net_help.h
@@ -12,7 +12,7 @@
  * @brief       Helper functions for networking as byte order conversions and checksum calculations
  * @{
  *
- * @file        net_help.h
+ * @file
  *
  * @author      Oliver Gesch <oliver.gesch@googlemail.com>
  */

--- a/sys/net/include/net_if.h
+++ b/sys/net/include/net_if.h
@@ -14,7 +14,7 @@
  *
  * @{
  *
- * @file        net_if.h
+ * @file
  * @brief       Types and functions for network interfaces
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */

--- a/sys/net/include/netapi.h
+++ b/sys/net/include/netapi.h
@@ -43,7 +43,7 @@
  *
  * @{
  *
- * @file        netapi.h
+ * @file
  * @brief       Basic general interface to communicate with a network layer.
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/sys/net/include/rpl.h
+++ b/sys/net/include/rpl.h
@@ -11,7 +11,7 @@
  * @ingroup     rpl
  * @{
  *
- * @file        rpl.h
+ * @file
  * @brief       RPL header. Declaration of global variables and functions needed for
  *              core functionality of RPL.
  *

--- a/sys/net/include/rpl/rpl_config.h
+++ b/sys/net/include/rpl/rpl_config.h
@@ -10,7 +10,7 @@
  * @ingroup     rpl
  * @{
  *
- * @file        rpl_config.h
+ * @file
  * @brief       RPL Config
  *
  * Configuration file, which defines all environmental variables for RPL.

--- a/sys/net/include/rpl/rpl_dodag.h
+++ b/sys/net/include/rpl/rpl_dodag.h
@@ -8,7 +8,7 @@
  * @ingroup rpl
  * @{
  *
- * @file        rpl_dodag.h
+ * @file
  * @brief       RPL DODAG header
  *
  * Header file, which defines all public known DODAG-related functions for RPL.

--- a/sys/net/include/rpl/rpl_of_manager.h
+++ b/sys/net/include/rpl/rpl_of_manager.h
@@ -9,7 +9,7 @@
 *
 * @ingroup rpl
 * @{
-* @file    rpl_of_manager.h
+* @file
 * @brief   RPL Objective functions manager header
 * @author  Fabian Brandt <fabianbr@zedat.fu-berlin.de>
 * @}

--- a/sys/net/include/rpl/rpl_structs.h
+++ b/sys/net/include/rpl/rpl_structs.h
@@ -9,7 +9,7 @@
 /**
  * @ingroup rpl
  * @{
- * @file    rpl_structs.h
+ * @file
  * @brief   RPL data structs
  *
  * File, which defines all structs used by RPL.

--- a/sys/net/include/sixlowpan.h
+++ b/sys/net/include/sixlowpan.h
@@ -34,7 +34,7 @@
  *
  *
  * @{
- * @file        sixlowpan.h
+ * @file
  * @brief       6lowpan link layer and lowpan functions
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/sys/net/include/sixlowpan/error.h
+++ b/sys/net/include/sixlowpan/error.h
@@ -10,7 +10,7 @@
  * @ingroup     net_sixlowpan_lowpan
  * @{
  *
- * @file        sixlowpan/error.h
+ * @file
  * @brief       6LoWPAN error codes
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/sys/net/include/sixlowpan/icmp.h
+++ b/sys/net/include/sixlowpan/icmp.h
@@ -13,7 +13,7 @@
  *
  * @{
  *
- * @file        include/sixlowpan/icmp.h
+ * @file
  * @brief       6LoWPAN ICMP related header
  *
  * @author      Stephan Zeisberg <zeisberg@mi.fu-berlin.de>

--- a/sys/net/include/sixlowpan/ip.h
+++ b/sys/net/include/sixlowpan/ip.h
@@ -12,7 +12,7 @@
  * @brief       Internet Protocol version 6
  * @{
  *
- * @file        include/sixlowpan/ip.h
+ * @file
  * @brief       6LoWPAN constants, data structs, and prototypes for network layer
  *
  * @author      Stephan Zeisberg <zeisberg@mi.fu-berlin.de>

--- a/sys/net/include/sixlowpan/lowpan.h
+++ b/sys/net/include/sixlowpan/lowpan.h
@@ -12,7 +12,7 @@
  * @brief       IPv6 over LoW Power wireless Area Networks
  * @{
  *
- * @file        include/sixlowpan/lowpan.h
+ * @file
  * @brief       6LoWPAN LoWPAN layer header
  *
  * @author      Stephan Zeisberg <zeisberg@mi.fu-berlin.de>

--- a/sys/net/include/sixlowpan/mac.h
+++ b/sys/net/include/sixlowpan/mac.h
@@ -10,7 +10,7 @@
  * @ingroup     net_sixlowpan_lowpan
  * @{
  *
- * @file        sixlowpan/mac.h
+ * @file
  * @brief       6LoWPAN data structs, and prototypes for MAC layer
  *
  * @author      Stephan Zeisberg <zeisberg@mi.fu-berlin.de>

--- a/sys/net/include/sixlowpan/ndp.h
+++ b/sys/net/include/sixlowpan/ndp.h
@@ -12,7 +12,7 @@
  * @brief       Neighbor discovery protocol for 6LoWPAN and IPv6
  * @{
  *
- * @file        sixlowpan/ndp.h
+ * @file
  * @brief       6LoWPAN constants, data structs, and prototypes related to NDP
  *
  * @author      Stephan Zeisberg <zeisberg@mi.fu-berlin.de>

--- a/sys/net/include/sixlowpan/types.h
+++ b/sys/net/include/sixlowpan/types.h
@@ -12,7 +12,7 @@
  * @brief       Structs, constants, and enums for 6LoWPAN and IPv6 related functions
  * @{
  *
- * @file        sixlowpan/types.h
+ * @file
  * @brief       6LoWPAN data types
  *
  * @author      Stephan Zeisberg <zeisberg@mi.fu-berlin.de>

--- a/sys/net/link_layer/ieee802154/ieee802154_frame.c
+++ b/sys/net/link_layer/ieee802154/ieee802154_frame.c
@@ -9,7 +9,7 @@
  *
  * @ingroup sixlowpan
  * @{
- * @file    ieee802154_frame.c
+ * @file
  * @brief   IEEE 802.14.4 framing operations
  * @author  Stephan Zeisberg <zeisberg@mi.fu-berlin.de>
  * @author  Oliver Hahm <oliver.hahm@inria.fr>

--- a/sys/net/link_layer/net_if/net_if.c
+++ b/sys/net/link_layer/net_if/net_if.c
@@ -9,7 +9,7 @@
 /**
  * @ingroup net_if
  * @{
- * @file    net_if.c
+ * @file
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 #include <string.h>

--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -9,7 +9,7 @@
  *
  * @ingroup fib
  * @{
- * @file    fib.c
+ * @file
  * @brief   Functions to manage FIB entries
  * @author  Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
  * @}

--- a/sys/net/network_layer/fib/universal_address.c
+++ b/sys/net/network_layer/fib/universal_address.c
@@ -9,7 +9,7 @@
  *
  * @ingroup fib
  * @{
- * @file    universal_address.c
+ * @file
  * @brief   Functions to manage universal address container
  * @author  Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
  * @}

--- a/sys/net/network_layer/sixlowpan/border/border.c
+++ b/sys/net/network_layer/sixlowpan/border/border.c
@@ -9,7 +9,7 @@
  *
  * @ingroup sixlowpan
  * @{
- * @file    sixlowborder.c
+ * @file
  * @brief   constraint node implementation for a 6lowpan border router
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Oliver Hahm <oliver.hahm@inria.fr>

--- a/sys/net/network_layer/sixlowpan/border/bordermultiplex.c
+++ b/sys/net/network_layer/sixlowpan/border/bordermultiplex.c
@@ -9,7 +9,7 @@
  *
  * @ingroup sixlowpan
  * @{
- * @file    bordermultiplex.c
+ * @file
  * @brief   multiplexiing border router information
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Oliver Hahm <oliver.hahm@inria.fr>

--- a/sys/net/network_layer/sixlowpan/border/bordermultiplex.h
+++ b/sys/net/network_layer/sixlowpan/border/bordermultiplex.h
@@ -9,7 +9,7 @@
  *
  * @ingroup sixlowpan
  * @{
- * @file    bordermultiplex.h
+ * @file
  * @brief   data structs for border router multiplexing
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Oliver Hahm <oliver.hahm@inria.fr>

--- a/sys/net/network_layer/sixlowpan/border/flowcontrol.c
+++ b/sys/net/network_layer/sixlowpan/border/flowcontrol.c
@@ -9,7 +9,7 @@
  *
  * @ingroup sixlowpan
  * @{
- * @file    flowcontrol.c
+ * @file
  * @brief   flowcontrol for constraint node border router implementation
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Oliver Hahm <oliver.hahm@inria.fr>

--- a/sys/net/network_layer/sixlowpan/border/flowcontrol.h
+++ b/sys/net/network_layer/sixlowpan/border/flowcontrol.h
@@ -9,7 +9,7 @@
  *
  * @ingroup sixlowpan
  * @{
- * @file    flowcontrol.h
+ * @file
  * @brief   data structs for border router flowcontrol
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Oliver Hahm <oliver.hahm@inria.fr>

--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -9,7 +9,7 @@
  *
  * @ingroup sixlowpan
  * @{
- * @file    sixlowpan.c
+ * @file
  * @brief   6lowpan functions
  * @author  Stephan Zeisberg <zeisberg@mi.fu-berlin.de>
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/sys/net/network_layer/sixlowpan/lowpan.h
+++ b/sys/net/network_layer/sixlowpan/lowpan.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file        network_layer/sixlowpan/lowpan.h
+ * @file
  * @brief       6lowpan header
  *
  * @author      Stephan Zeisberg <zeisberg@mi.fu-berlin.de>

--- a/sys/net/network_layer/sixlowpan/mac.c
+++ b/sys/net/network_layer/sixlowpan/mac.c
@@ -9,7 +9,7 @@
  *
  * @ingroup sixlowpan
  * @{
- * @file    sixlowmac.c
+ * @file
  * @brief   6lowpan link layer functions
  * @author  Stephan Zeisberg <zeisberg@mi.fu-berlin.de>
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/sys/net/network_layer/sixlowpan/serialnumber.c
+++ b/sys/net/network_layer/sixlowpan/serialnumber.c
@@ -9,7 +9,7 @@
  *
  * @ingroup sixlowpan
  * @{
- * @file    serialnumber.c
+ * @file
  * @brief   serial number arithmetics (corresponding RFC1982) for version field in ABRO
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Oliver Hahm <oliver.hahm@inria.fr>

--- a/sys/net/routing/aodvv2/aodv.c
+++ b/sys/net/routing/aodvv2/aodv.c
@@ -11,7 +11,7 @@
  * @ingroup     aodvv2
  * @{
  *
- * @file        aodv.c
+ * @file
  * @brief       aodvv2 routing protocol
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>

--- a/sys/net/routing/aodvv2/aodv.h
+++ b/sys/net/routing/aodvv2/aodv.h
@@ -11,7 +11,7 @@
  * @ingroup     aodvv2
  * @{
  *
- * @file        aodv.h
+ * @file
  * @brief       aodvv2 routing protocol
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>

--- a/sys/net/routing/aodvv2/constants.h
+++ b/sys/net/routing/aodvv2/constants.h
@@ -11,7 +11,7 @@
  * @ingroup     aodvv2
  * @{
  *
- * @file        constants.h
+ * @file
  * @brief       constants for the aodvv2 routing protocol
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>

--- a/sys/net/routing/aodvv2/reader.c
+++ b/sys/net/routing/aodvv2/reader.c
@@ -11,7 +11,7 @@
  * @ingroup     aodvv2
  * @{
  *
- * @file        reader.c
+ * @file
  * @brief       reading and handling of RFC5444 aodvv2 messages
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>

--- a/sys/net/routing/aodvv2/reader.h
+++ b/sys/net/routing/aodvv2/reader.h
@@ -11,7 +11,7 @@
  * @ingroup     aodvv2
  * @{
  *
- * @file        reader.h
+ * @file
  * @brief       reading and handling of RFC5444 aodvv2 messages
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>

--- a/sys/net/routing/aodvv2/routingtable.c
+++ b/sys/net/routing/aodvv2/routingtable.c
@@ -11,7 +11,7 @@
  * @ingroup     aodvv2
  * @{
  *
- * @file        routing.c
+ * @file
  * @brief       Cobbled-together routing table.
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>

--- a/sys/net/routing/aodvv2/routingtable.h
+++ b/sys/net/routing/aodvv2/routingtable.h
@@ -11,7 +11,7 @@
  * @ingroup     aodvv2
  * @{
  *
- * @file        routingtable.h
+ * @file
  * @brief       Cobbled-together routing table.
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>

--- a/sys/net/routing/aodvv2/seqnum.c
+++ b/sys/net/routing/aodvv2/seqnum.c
@@ -11,7 +11,7 @@
  * @ingroup     aodvv2
  * @{
  *
- * @file        seqnum.c
+ * @file
  * @brief       aodvv2 sequence number
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>

--- a/sys/net/routing/aodvv2/seqnum.h
+++ b/sys/net/routing/aodvv2/seqnum.h
@@ -11,7 +11,7 @@
  * @ingroup     aodvv2
  * @{
  *
- * @file        seqnum.h
+ * @file
  * @brief       aodvv2 sequence number
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>

--- a/sys/net/routing/aodvv2/utils.c
+++ b/sys/net/routing/aodvv2/utils.c
@@ -11,7 +11,7 @@
  * @ingroup     aodvv2
  * @{
  *
- * @file        utils.c
+ * @file
  * @brief       client- and RREQ-table, ipv6 address representation converters
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>

--- a/sys/net/routing/aodvv2/utils.h
+++ b/sys/net/routing/aodvv2/utils.h
@@ -11,7 +11,7 @@
  * @ingroup     aodvv2
  * @{
  *
- * @file        utils.h
+ * @file
  * @brief       client- and RREQ-table, ipv6 address representation converters
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>

--- a/sys/net/routing/aodvv2/writer.c
+++ b/sys/net/routing/aodvv2/writer.c
@@ -11,7 +11,7 @@
  * @ingroup     aodvv2
  * @{
  *
- * @file        writer.c
+ * @file
  * @brief       writer to create RFC5444 aodvv2 messages
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>

--- a/sys/net/routing/aodvv2/writer.h
+++ b/sys/net/routing/aodvv2/writer.h
@@ -11,7 +11,7 @@
  * @ingroup     aodvv2
  * @{
  *
- * @file        writer.h
+ * @file
  * @brief       writer to create RFC5444 aodvv2 messages
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>

--- a/sys/net/routing/etx_beaconing.c
+++ b/sys/net/routing/etx_beaconing.c
@@ -11,7 +11,7 @@
 /**
  * @ingroup     rpl
  * @{
- * @file        etx_beaconing.c
+ * @file
  * @brief       ETX-beaconing implementation
  *
  * Implementation for ETX-based beaconing.

--- a/sys/net/routing/rpl/of0.c
+++ b/sys/net/routing/rpl/of0.c
@@ -9,7 +9,7 @@
 /**
  * @ingroup     rpl
  * @{
- * @file        of0.c
+ * @file
  * @brief       Objective Function Zero.
  *
  * Implementation of Objective Function Zero.

--- a/sys/net/routing/rpl/of0.h
+++ b/sys/net/routing/rpl/of0.h
@@ -9,7 +9,7 @@
 /**
  * @ingroup     rpl
  * @{
- * @file        of0.h
+ * @file
  * @brief       Objective Function Zero.
  *
  * Header-file, which defines all functions for the implementation of Objective Function Zero.

--- a/sys/net/routing/rpl/of_mrhof.c
+++ b/sys/net/routing/rpl/of_mrhof.c
@@ -9,7 +9,7 @@
 /**
  * @ingroup     rpl
  * @{
- * @file        of_mrhof.c
+ * @file
  * @brief       Objective Function MRHOF.
  *
  * Implementation of Objective Function MRHOF.

--- a/sys/net/routing/rpl/of_mrhof.h
+++ b/sys/net/routing/rpl/of_mrhof.h
@@ -9,7 +9,7 @@
 /**
  * @ingroup     rpl
  * @{
- * @file        of_mrhof.h
+ * @file
  * @brief       Objective Function MRHOF.
  *
  * Header-file, which defines all functions for the implementation of Objective Function MRHOF.

--- a/sys/net/routing/rpl/rpl.c
+++ b/sys/net/routing/rpl/rpl.c
@@ -11,7 +11,7 @@
  * @ingroup     rpl
  * @{
  *
- * @file        rpl.c
+ * @file
  * @brief       Implementation of the RPL-core.
  *
  * Implementation of core RPL-functions. Normally it shouldn't be necessary to

--- a/sys/net/routing/rpl/rpl_dodag.c
+++ b/sys/net/routing/rpl/rpl_dodag.c
@@ -8,7 +8,7 @@
  * @ingroup rpl
  * @{
  *
- * @file        rpl_dodag.c
+ * @file
  * @brief       RPL DODAG
  *
  * Implementation of a DODAG for usage with RPL.

--- a/sys/net/routing/rpl/rpl_of_manager.c
+++ b/sys/net/routing/rpl/rpl_of_manager.c
@@ -12,7 +12,7 @@
  *
  * @ingroup rpl
  * @{
- * @file    rpl_of_manager.c
+ * @file
  * @brief   RPL Objective functions manager
  * @author  Fabian Brandt <fabianbr@zedat.fu-berlin.de>
  * @}

--- a/sys/net/transport_layer/socket_base/msg_help.c
+++ b/sys/net/transport_layer/socket_base/msg_help.c
@@ -8,7 +8,7 @@
 
 /**
  * @{
- * @file    msg_help.c
+ * @file
  * @brief   Providing implementation for prototypes defined in msg_help.h.
  * @author  Oliver Gesch <oliver.gesch@googlemail.com>
  */

--- a/sys/net/transport_layer/socket_base/msg_help.h
+++ b/sys/net/transport_layer/socket_base/msg_help.h
@@ -8,7 +8,7 @@
 
 /**
  * @{
- * @file    msg_help.h
+ * @file
  * @author  Oliver Gesch <oliver.gesch@googlemail.com>
  */
 #ifndef MSG_HELP_H_

--- a/sys/net/transport_layer/socket_base/socket.c
+++ b/sys/net/transport_layer/socket_base/socket.c
@@ -9,7 +9,7 @@
 /**
  * @ingroup socket_base
  * @{
- * @file    socket.c
+ * @file
  * @brief   functions for BSD socket API, methods return default values and
  *          will be overwritten by appropriate transport layer protocols.
  * @author  Oliver Gesch <oliver.gesch@googlemail.com>

--- a/sys/net/transport_layer/tcp/tcp.c
+++ b/sys/net/transport_layer/tcp/tcp.c
@@ -9,7 +9,7 @@
  *
  * @ingroup tcp
  * @{
- * @file    tcp.c
+ * @file
  * @brief   TCP implementation
  * @author  Oliver Gesch <oliver.gesch@googlemail.com>
  * @author  Cenk Gündoğan <cnkgndgn@gmail.com>

--- a/sys/net/transport_layer/tcp/tcp_hc.c
+++ b/sys/net/transport_layer/tcp/tcp_hc.c
@@ -9,7 +9,7 @@
  *
  * @ingroup transport_layer
  * @{
- * @file    tcp_hc.c
+ * @file
  * @brief   TCP HC
  * @author  Oliver Gesch <oliver.gesch@googlemail.com>
  * @}

--- a/sys/net/transport_layer/tcp/tcp_timer.c
+++ b/sys/net/transport_layer/tcp/tcp_timer.c
@@ -9,7 +9,7 @@
  *
  * @ingroup transport_layer
  * @{
- * @file    tcp_timer.c
+ * @file
  * @brief   TCP timer
  * @author  Oliver Gesch <oliver.gesch@googlemail.com>
  * @}

--- a/sys/net/transport_layer/tcp/tcp_timer.h
+++ b/sys/net/transport_layer/tcp/tcp_timer.h
@@ -8,7 +8,7 @@
 
 /**
  * @{
- * @file    tcp_timer.h
+ * @file
  * @author  Oliver Gesch <oliver.gesch@googlemail.com>
  */
 

--- a/sys/net/transport_layer/udp/udp.c
+++ b/sys/net/transport_layer/udp/udp.c
@@ -9,7 +9,7 @@
 /**
  * @ingroup udp
  * @{
- * @file    udp.c
+ * @file
  * @brief   UDP implementation
  * @author  Oliver Gesch <oliver.gesch@googlemail.com>
  * @author  Cenk Gündoğan <cnkgndgn@gmail.com>

--- a/sys/od/od.c
+++ b/sys/od/od.c
@@ -9,7 +9,7 @@
 /**
  * @{
  *
- * @file    od.c
+ * @file
  */
 #include <stdio.h>
 #include <string.h>

--- a/sys/oneway-malloc/oneway-malloc.c
+++ b/sys/oneway-malloc/oneway-malloc.c
@@ -11,7 +11,7 @@
  * @ingroup sys
  * @{
  *
- * @file        oneway_malloc.c
+ * @file
  * @brief       Simple malloc wrapper for SBRK
 
  * @author      Kaspar Schleiser <kaspar@schleiser.de>

--- a/sys/posix/fd.c
+++ b/sys/posix/fd.c
@@ -9,7 +9,7 @@
 /**
  * @ingroup posix
  * @{
- * @file    fd.c
+ * @file
  * @brief   Providing unifying file descriptor wrapper for POSIX-compliant
  *          operations.
  * @author  Christian Mehlis <mehlis@inf.fu-berlin.de>

--- a/sys/posix/include/strings.h
+++ b/sys/posix/include/strings.h
@@ -10,7 +10,7 @@
  * @ingroup     posix
  * @{
  *
- * @file    strings.h
+ * @file
  * @brief   string operations
  *
  * @see     <a href="http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/strings.h.html">

--- a/sys/posix/include/unistd.h
+++ b/sys/posix/include/unistd.h
@@ -12,7 +12,7 @@
  */
 
 /**
- * @file    unistd.h
+ * @file
  * @brief   standard symbolic constants and types
  * @see     <a href="http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/unistd.h.html">
  *              The Open Group Base Specifications Issue 7, <unistd.h>

--- a/sys/posix/pnet/include/arpa/inet.h
+++ b/sys/posix/pnet/include/arpa/inet.h
@@ -12,7 +12,7 @@
  */
 
 /**
- * @file    arpa/inet.h
+ * @file
  * @brief   Definitions for internet operations
  * @see     <a href="http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/arpa_inet.h.html">
  *              The Open Group Base Specifications Issue 7, <arpa/inet.h>

--- a/sys/posix/pnet/include/netinet/in.h
+++ b/sys/posix/pnet/include/netinet/in.h
@@ -12,7 +12,7 @@
  */
 
 /**
- * @file    netinet/in.h
+ * @file
  * @brief   Main socket header
  * @see     <a href="http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html">
  *              The Open Group Base Specifications Issue 7, <netinet/in.h>

--- a/sys/posix/pnet/include/sys/socket.h
+++ b/sys/posix/pnet/include/sys/socket.h
@@ -12,7 +12,7 @@
  */
 
 /**
- * @file    sys/socket.h
+ * @file
  * @brief   Main socket header
  * @see     <a href="http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html">
  *              The Open Group Base Specifications Issue 7, <sys/socket.h>

--- a/sys/posix/pnet/netinet_in.c
+++ b/sys/posix/pnet/netinet_in.c
@@ -8,7 +8,7 @@
 
 /**
  * @{
- * @file    netinet_in.c
+ * @file
  * @brief   Providing values for in6addr_any and in6addr_loopback.
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */

--- a/sys/posix/pnet/sys_socket.c
+++ b/sys/posix/pnet/sys_socket.c
@@ -8,7 +8,7 @@
 
 /**
  * @{
- * @file    sys_socket.c
+ * @file
  * @brief   Providing implementation for POSIX socket wrapper.
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */

--- a/sys/posix/posix_io.c
+++ b/sys/posix/posix_io.c
@@ -9,7 +9,7 @@
  *
  * @ingroup sys_posix
  * @{
- * @file    posix_io.c
+ * @file
  * @brief   Implementation of basic POSIX IO functionality.
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  * @}

--- a/sys/posix/pthread/pthread_cond.c
+++ b/sys/posix/pthread/pthread_cond.c
@@ -10,7 +10,7 @@
  * @ingroup     sys
  * @{
  *
- * @file        pthread_cond.c
+ * @file
  * @brief       Condition variable implementation
  *
  * @author      Martin Landsmann <martin.landsmann@haw-hamburg.de>

--- a/sys/posix/semaphore.c
+++ b/sys/posix/semaphore.c
@@ -11,7 +11,7 @@
  *
  * @{
  *
- * @file    semaphore.c
+ * @file
  * @brief   Implementation of semaphores with priority queues
  *
  * @author  Christian Mehlis <mehlis@inf.fu-berlin.de>

--- a/sys/posix/strings.c
+++ b/sys/posix/strings.c
@@ -8,7 +8,7 @@
 
 /**
  * @{
- * @file    strings.c
+ * @file
  * @brief   Providing implementation for prototypes defined in strings.h.
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */

--- a/sys/posix/unistd.c
+++ b/sys/posix/unistd.c
@@ -8,7 +8,7 @@
 
 /**
  * @{
- * @file    fd.c
+ * @file
  * @brief   Providing implementation for close for fds defined in fd.h.
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Christian Mehlis <mehlis@inf.fu-berlin.de>

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -9,7 +9,7 @@
  *
  * @ingroup ps
  * @{
- * @file    ps.c
+ * @file
  * @brief   UNIX like ps command
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  * @}

--- a/sys/transceiver/transceiver.c
+++ b/sys/transceiver/transceiver.c
@@ -9,7 +9,7 @@
  *
  * @ingroup transceiver
  * @{
- * @file    transceiver.c
+ * @file
  * @brief   Providing a generic interface to the driver implementation for any supported network device.
  * @author  Oliver Hahm <oliver.hahm@inria.fr>
  * @}

--- a/tests/unittests/README.md
+++ b/tests/unittests/README.md
@@ -135,7 +135,7 @@ The test header ``tests-<modulename>/tests-<module>.h`` of a module you add to `
  * @addtogroup  unittests
  * @{
  *
- * @file        tests-<module>.h
+ * @file
  * @brief       Unittests for the ``module`` module
  *
  * @author      <author>

--- a/tests/unittests/netdev_dummy/include/netdev_dummy.h
+++ b/tests/unittests/netdev_dummy/include/netdev_dummy.h
@@ -10,7 +10,7 @@
  * @addtogroup  unittests
  * @{
  *
- * @file        netdev_dummy.h
+ * @file
  * @brief       Provides a virtual device that understands the netdev_base API
  *              for testing.
  *

--- a/tests/unittests/netdev_dummy/netdev_dummy.c
+++ b/tests/unittests/netdev_dummy/netdev_dummy.c
@@ -10,7 +10,7 @@
  * @addtogroup
  * @{
  *
- * @file        netdev_dummy.c
+ * @file
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */

--- a/tests/unittests/tests-base64/tests-base64.h
+++ b/tests/unittests/tests-base64/tests-base64.h
@@ -10,7 +10,7 @@
  * @addtogroup  unittests
  * @{
  *
- * @file        tests-base64.h
+ * @file
  * @brief       Unittests for the ``base64`` module
  *
  * @author      Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>

--- a/tests/unittests/tests-bloom/tests-bloom.h
+++ b/tests/unittests/tests-bloom/tests-bloom.h
@@ -10,7 +10,7 @@
  * @addtogroup  unittests
  * @{
  *
- * @file        tests-bloom.h
+ * @file
  * @brief       Unittests for the ``bloom`` module
  *
  * @author      Philipp Rosenkranz <philipp.rosenkranz@fu-berlin.de>

--- a/tests/unittests/tests-core/tests-core.h
+++ b/tests/unittests/tests-core/tests-core.h
@@ -10,7 +10,7 @@
  * @addtogroup  unittests
  * @{
  *
- * @file        tests-core.h
+ * @file
  * @brief       Unittests for the ``core`` module
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/tests/unittests/tests-crypto/tests-crypto.h
+++ b/tests/unittests/tests-crypto/tests-crypto.h
@@ -10,7 +10,7 @@
  * @addtogroup  unittests
  * @{
  *
- * @file        tests-crypto.h
+ * @file
  * @brief       Unittests for the ``crypto`` module
  *
  * @author      Philipp Rosenkranz <philipp.rosenkranz@fu-berlin.de>

--- a/tests/unittests/tests-fib/tests-fib.h
+++ b/tests/unittests/tests-fib/tests-fib.h
@@ -10,7 +10,7 @@
  * @addtogroup  unittests
  * @{
  *
- * @file        tests-fib.h
+ * @file
  * @brief       Unittests for the ``fib`` module
  *
  * @author      Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>

--- a/tests/unittests/tests-hash_string/tests-hash_string.h
+++ b/tests/unittests/tests-hash_string/tests-hash_string.h
@@ -10,7 +10,7 @@
  * @addtogroup  unittests
  * @{
  *
- * @file        tests-hash_string.h
+ * @file
  * @brief       Unittests for the ``hash_string`` module
  *
  * @author      Kushal Singh <kushal.spiderman.singh@gmail.com>

--- a/tests/unittests/tests-inet_csum/tests-inet_csum.h
+++ b/tests/unittests/tests-inet_csum/tests-inet_csum.h
@@ -10,7 +10,7 @@
  * @addtogroup  unittests
  * @{
  *
- * @file        tests-inet_csum.h
+ * @file
  * @brief       Unittests for the ``inet_csum`` module
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
+++ b/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
@@ -9,7 +9,7 @@
 /**
  * @{
  *
- * @file    tests-ipv6_addr.c
+ * @file
  */
 #include <errno.h>
 #include <stdint.h>

--- a/tests/unittests/tests-ipv6_hdr/tests-ipv6_hdr.h
+++ b/tests/unittests/tests-ipv6_hdr/tests-ipv6_hdr.h
@@ -10,7 +10,7 @@
  * @addtogroup  unittests
  * @{
  *
- * @file        tests-ipv6_hdr.h
+ * @file
  * @brief       Unittests for the ``ipv6_hdr`` module
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/tests/unittests/tests-ipv6_nc/tests-ipv6_nc.h
+++ b/tests/unittests/tests-ipv6_nc/tests-ipv6_nc.h
@@ -10,7 +10,7 @@
  * @addtogroup  unittests
  * @{
  *
- * @file        tests-ipv6_nc.h
+ * @file
  * @brief       Unittests for the ``ipv6_nc`` module
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
+++ b/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
@@ -9,7 +9,7 @@
 /**
  * @{
  *
- * @file    tests-ipv6_netif.c
+ * @file
  */
 #include <errno.h>
 #include <stdint.h>

--- a/tests/unittests/tests-netdev_dummy/tests-netdev_dummy.h
+++ b/tests/unittests/tests-netdev_dummy/tests-netdev_dummy.h
@@ -10,7 +10,7 @@
  * @addtogroup  unittests
  * @{
  *
- * @file        tests-netdev_dummy.h
+ * @file
  * @brief       Unittests for the ``netdev_dummy`` module
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/tests/unittests/tests-netif/tests-netif.c
+++ b/tests/unittests/tests-netif/tests-netif.c
@@ -9,7 +9,7 @@
 /**
  * @{
  *
- * @file    tests-netif.c
+ * @file
  */
 #include <errno.h>
 #include <stdint.h>

--- a/tests/unittests/tests-netreg/tests-netreg.h
+++ b/tests/unittests/tests-netreg/tests-netreg.h
@@ -10,7 +10,7 @@
  * @addtogroup  unittests
  * @{
  *
- * @file        tests-netreg.h
+ * @file
  * @brief       Unittests for the ``netreg`` module
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/tests/unittests/tests-pkt/tests-pkt.c
+++ b/tests/unittests/tests-pkt/tests-pkt.c
@@ -9,7 +9,7 @@
 /**
  * @{
  *
- * @file    tests-pktbuf.c
+ * @file
  */
 #include <errno.h>
 #include <stdint.h>

--- a/tests/unittests/tests-pktbuf/tests-pktbuf.c
+++ b/tests/unittests/tests-pktbuf/tests-pktbuf.c
@@ -9,7 +9,7 @@
 /**
  * @{
  *
- * @file    tests-pktbuf.c
+ * @file
  */
 #include <errno.h>
 #include <stdint.h>

--- a/tests/unittests/tests-pktbuf/tests-pktbuf.h
+++ b/tests/unittests/tests-pktbuf/tests-pktbuf.h
@@ -10,7 +10,7 @@
  * @addtogroup  unittests
  * @{
  *
- * @file        tests-pktbuf.h
+ * @file
  * @brief       Unittests for the ``pktbuf`` module
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/tests/unittests/tests-pktqueue/tests-pktqueue.c
+++ b/tests/unittests/tests-pktqueue/tests-pktqueue.c
@@ -9,7 +9,7 @@
 /**
  * @{
  *
- * @file    tests-pktqueue.c
+ * @file
  */
 #include <string.h>
 

--- a/tests/unittests/tests-pktqueue/tests-pktqueue.h
+++ b/tests/unittests/tests-pktqueue/tests-pktqueue.h
@@ -10,7 +10,7 @@
  * @addtogroup  unittests
  * @{
  *
- * @file        tests-pktqueue.h
+ * @file
  * @brief       Unittests for the ``pktqueue`` module
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/tests/unittests/tests-sixlowpan_ctx/tests-sixlowpan_ctx.h
+++ b/tests/unittests/tests-sixlowpan_ctx/tests-sixlowpan_ctx.h
@@ -10,7 +10,7 @@
  * @addtogroup  unittests
  * @{
  *
- * @file        tests-sixlowpan_ctx.h
+ * @file
  * @brief       Unittests for the ``sixlowpan_ctx`` module
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/tests/unittests/tests-timex/tests-timex.h
+++ b/tests/unittests/tests-timex/tests-timex.h
@@ -10,7 +10,7 @@
  * @addtogroup  unittests
  * @{
  *
- * @file        tests-timex.h
+ * @file
  * @brief       Unittests for the ``timex`` module
  *
  * @author      Philipp Rosenkranz <philipp.rosenkranz@fu-berlin.de>


### PR DESCRIPTION
Doxygen can figure out the filename by itself if it is not given as an argument to the `@file` command.

`git grep -l -E '@file\s' | xargs sed -i -e 's/@file\s.*$/@file/'` was used to remove the filename from the `@file` blocks.