### PR TITLE
ipv6_netif: fix ng_ipv6_netif_find_best_src_addr() for multicast

### DIFF
--- a/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
+++ b/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
@@ -313,7 +313,8 @@ static uint8_t _find_by_prefix_unsafe(ng_ipv6_addr_t **res, ng_ipv6_netif_t *ifa
 
         match = ng_ipv6_addr_match_prefix(&(iface->addrs[i].addr), addr);
 
-        if (match < iface->addrs[i].prefix_len) {
+        if (only_unicast && !ng_ipv6_addr_is_multicast(addr) &&
+            (match < iface->addrs[i].prefix_len)) {
             /* match but not of same subnet */
             continue;
         }

--- a/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
+++ b/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
@@ -404,6 +404,19 @@ static void test_ipv6_netif_find_best_src_addr__success(void)
     TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(out, &ll_addr1));
 }
 
+static void test_ipv6_netif_find_best_src_addr__multicast_input(void)
+{
+    ng_ipv6_addr_t mc_addr = NG_IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL;
+    ng_ipv6_addr_t *out = NULL;
+
+    /* Adds DEFAULT_TEST_NETIF as interface and to it fe80::1, fe80::2 and ff02::1 */
+    test_ipv6_netif_find_best_src_addr__success();
+
+    TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_find_best_src_addr(DEFAULT_TEST_NETIF, &mc_addr)));
+    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_equal(&mc_addr, out));
+    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_unspecified(out));
+}
+
 static void test_ipv6_netif_addr_is_non_unicast__unicast(void)
 {
     ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
@@ -488,6 +501,7 @@ Test *tests_ipv6_netif_tests(void)
         new_TestFixture(test_ipv6_netif_match_prefix__success3),
         new_TestFixture(test_ipv6_netif_find_best_src_addr__no_unicast),
         new_TestFixture(test_ipv6_netif_find_best_src_addr__success),
+        new_TestFixture(test_ipv6_netif_find_best_src_addr__multicast_input),
         new_TestFixture(test_ipv6_netif_addr_is_non_unicast__unicast),
         new_TestFixture(test_ipv6_netif_addr_is_non_unicast__anycast),
         new_TestFixture(test_ipv6_netif_addr_is_non_unicast__multicast1),


### PR DESCRIPTION
Without this fix `ng_ipv6_netif_find_best_src_addr()` will return `::` for most multicast addresses