### PR TITLE
gnrc_ndp_router: Initial import of router behavior of router discovery

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -86,10 +86,16 @@ endif
 ifneq (,$(filter gnrc_ipv6_router_default,$(USEMODULE)))
   USEMODULE += gnrc_ipv6_router
   USEMODULE += gnrc_icmpv6
-  USEMODULE += gnrc_ndp_node
+  USEMODULE += gnrc_ndp_router
 endif
 
 ifneq (,$(filter gnrc_ndp_host,$(USEMODULE)))
+  USEMODULE += gnrc_ndp_node
+  USEMODULE += random
+  USEMODULE += vtimer
+endif
+
+ifneq (,$(filter gnrc_ndp_router,$(USEMODULE)))
   USEMODULE += gnrc_ndp_node
   USEMODULE += random
   USEMODULE += vtimer

--- a/sys/include/net/gnrc/ndp.h
+++ b/sys/include/net/gnrc/ndp.h
@@ -34,6 +34,7 @@
 
 #include "net/gnrc/ndp/host.h"
 #include "net/gnrc/ndp/internal.h"
+#include "net/gnrc/ndp/router.h"
 #include "net/gnrc/ndp/node.h"
 
 #ifdef __cplusplus
@@ -44,6 +45,8 @@ extern "C" {
 #define GNRC_NDP_MSG_ADDR_TIMEOUT       (0x0211)    /**< Message type for address timeouts */
 #define GNRC_NDP_MSG_NBR_SOL_RETRANS    (0x0212)    /**< Message type for multicast
                                                      *   neighbor solicitation retransmissions */
+#define GNRC_NDP_MSG_RTR_ADV_RETRANS    (0x0213)    /**< Message type for periodic router advertisements */
+#define GNRC_NDP_MSG_RTR_ADV_DELAY      (0x0214)    /**< Message type for delayed router advertisements */
 #define GNRC_NDP_MSG_RTR_SOL_RETRANS    (0x0215)    /**< Message type for periodic router solicitations */
 #define GNRC_NDP_MSG_NC_STATE_TIMEOUT   (0x0216)    /**< Message type for neighbor cache state timeouts */
 
@@ -131,9 +134,43 @@ extern "C" {
  * @brief   Upper bound for randomised reachable time calculation.
  */
 #define GNRC_NDP_MAX_RAND               (15U)
+/** @} */
+
 /**
- * @}
+ * @name    Router constants
+ * @{
+ * @see     <a href="https://tools.ietf.org/html/rfc4861#section-10">
+ *              RFC 4861, section 10
+ *          </a>
  */
+/**
+ * @brief   Initial router advertisement interval in seconds
+ */
+#define GNRC_NDP_MAX_INIT_RTR_ADV_INT   (16U)
+
+/**
+ * @brief   Maximum number of initial router advertisement transmissions
+ */
+#define GNRC_NDP_MAX_INIT_RTR_ADV_NUMOF (3U)
+
+/**
+ * @brief   Maximum number of final router advertisement transmissions
+ */
+#define GNRC_NDP_MAX_FIN_RTR_ADV_NUMOF  (3U)
+
+/**
+ * @brief   Minimum delay in seconds between router advertisement
+ *          transmissions
+ */
+#define GNRC_NDP_MIN_RTR_ADV_DELAY      (3U)
+
+/**
+ * @brief   Upper bound for randomised delay in microseconds between router
+ *          solicitation reception and responding router advertisement
+ *          transmission.
+ */
+#define GNRC_NDP_MAX_RTR_ADV_DELAY      (500U * MS_IN_USEC)
+/** @} */
 
 /**
  * @brief   Handles received neighbor solicitations.
@@ -160,6 +197,32 @@ void gnrc_ndp_nbr_sol_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
 void gnrc_ndp_nbr_adv_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
                              ipv6_hdr_t *ipv6, ndp_nbr_adv_t *nbr_adv,
                              size_t icmpv6_size);
+
+#if (defined(MODULE_GNRC_NDP_ROUTER) || defined(MODULE_GNRC_SIXLOWPAN_ND_ROUTER))
+/**
+ * @brief   Handles received router solicitations.
+ *
+ * @param[in] iface         The receiving interface.
+ * @param[in] pkt           The received packet.
+ * @param[in] ipv6          The IPv6 header in @p pkt.
+ * @param[in] rtr_sol       The router solicitation in @p pkt.
+ * @param[in] icmpv6_size   The overall size of the router solicitation.
+ */
+void gnrc_ndp_rtr_sol_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
+                             ipv6_hdr_t *ipv6, ndp_rtr_sol_t *rtr_sol,
+                             size_t icmpv6_size);
+#else
+/**
+ * @brief   A host *must* silently discard all received router solicitations.
+ * @see     <a href="https://tools.ietf.org/html/rfc4861#section-6.2.6">
+ *              RFC 4861, section 6.2.6
+ *          </a>
+ *
+ * This macro is primarily an optimization to not go into the function defined
+ * above.
+ */
+#define gnrc_ndp_rtr_sol_handle(iface, pkt, ipv6, rtr_sol, size)
+#endif
 
 /**
  * @brief   Handles received router advertisements
@@ -292,6 +355,65 @@ gnrc_pktsnip_t *gnrc_ndp_nbr_adv_build(uint8_t flags, ipv6_addr_t *tgt,
 gnrc_pktsnip_t *gnrc_ndp_rtr_sol_build(gnrc_pktsnip_t *options);
 
 /**
+ * @brief   Builds a router solicitation message for sending.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.1">
+ *          RFC 4861, section 4.1
+ *      </a>
+ *
+ * @param[in] options   Options to append to the router solicitation.
+ *
+ * @return  The resulting ICMPv6 packet on success.
+ * @return  NULL, on failure.
+ */
+gnrc_pktsnip_t *gnrc_ndp_rtr_sol_build(gnrc_pktsnip_t *options);
+
+#if (defined(MODULE_GNRC_NDP_ROUTER) || defined(MODULE_GNRC_SIXLOWPAN_ND_ROUTER))
+/**
+ * @brief   Builds a router advertisement message for sending.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.2">
+ *          RFC 4861, section 4.2
+ *      </a>
+ *
+ * @note    The source address for the packet MUST be the link-local address
+ *          of the interface.
+ *
+ * @param[in] cur_hl        Default hop limit for outgoing IP packets, 0 if
+ *                          unspecified by this router.
+ * @param[in] flags         Flags as defined above.
+ *                          @ref GNRC_NDP_RTR_ADV_FLAGS_M == 1 indicates, that the
+ *                          addresses are managed by DHCPv6,
+ *                          @ref GNRC_NDP_RTR_ADV_FLAGS_O == 1 indicates that other
+ *                          configuration information is available via DHCPv6.
+ * @param[in] ltime         Lifetime of the default router in seconds.
+ * @param[in] reach_time    Time in milliseconds a node should assume a neighbor
+ *                          reachable. 0 means unspecified by the router.
+ * @param[in] retrans_timer Time in milliseconds between retransmitted
+ *                          neighbor solicitations. 0 means unspecified by
+ *                          the router.
+ * @param[in] options       Options to append to the router advertisement.
+ *
+ * @return  The resulting ICMPv6 packet on success.
+ * @return  NULL, on failure.
+ */
+gnrc_pktsnip_t *gnrc_ndp_rtr_adv_build(uint8_t cur_hl, uint8_t flags, uint16_t ltime,
+                                       uint32_t reach_time, uint32_t retrans_timer,
+                                       gnrc_pktsnip_t *options);
+#else
+/**
+ * @brief   A host *must not* send router advertisements at any time (so why build them?)
+ * @see     <a href="https://tools.ietf.org/html/rfc4861#section-6.3.4">
+ *              RFC 4861, section 6.3.4
+ *          </a>
+ *
+ * This macro is primarily an optimization to not go into the function defined
+ * above.
+ */
+#define gnrc_ndp_rtr_adv_build(cur_hl, flags, ltime, reach_time, retrans_timer, options) (NULL)
+#endif
+
+/**
  * @brief   Builds a generic NDP option.
  *
  * @param[in] type  Type of the option.
@@ -345,6 +467,81 @@ gnrc_pktsnip_t *gnrc_ndp_opt_sl2a_build(const uint8_t *l2addr, uint8_t l2addr_le
  */
 gnrc_pktsnip_t *gnrc_ndp_opt_tl2a_build(const uint8_t *l2addr, uint8_t l2addr_len,
                                         gnrc_pktsnip_t *next);
+
+#if (defined(MODULE_GNRC_NDP_ROUTER) || defined(MODULE_GNRC_SIXLOWPAN_ND_ROUTER))
+/**
+ * @brief   Builds the prefix information option.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.6.2">
+ *          RFC 4861, section 4.6.2
+ *      </a>
+ *
+ * @note    Must only be used with router advertisemnents. This is not checked
+ *          however, since nodes should silently ignore it in other NDP messages.
+ *
+ * @param[in] prefix_len    The length of @p prefix in bits. Must be between
+ *                          0 and 128.
+ * @param[in] flags         Flags as defined above.
+ *                          @ref GNRC_NDP_OPT_PI_FLAGS_L == 1 indicates, that
+ *                          @p prefix can be used for on-link determination,
+ *                          @ref GNRC_NDP_OPT_PI_FLAGS_A == 1 indicates, that
+ *                          @p prefix can be used for stateless address
+ *                          configuration.
+ * @param[in] valid_ltime   Length of time in seconds that @p prefix is valid.
+ *                          UINT32_MAX represents infinity.
+ * @param[in] pref_ltime    Length of time in seconds that addresses using
+ *                          @p prefix remain prefered. UINT32_MAX represents
+ *                          infinity.
+ * @param[in] prefix        An IPv6 address or a prefix of an IPv6 address.
+ * @param[in] next          More options in the packet. NULL, if there are none.
+ *
+ * @return  The packet snip list of options, on success
+ * @return  NULL, if packet buffer is full
+ */
+gnrc_pktsnip_t *gnrc_ndp_opt_pi_build(uint8_t prefix_len, uint8_t flags,
+                                      uint32_t valid_ltime, uint32_t pref_ltime,
+                                      ipv6_addr_t *prefix, gnrc_pktsnip_t *next);
+
+/**
+ * @brief   Builds the MTU option.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.6.4">
+ *          RFC 4861, section 4.6.4
+ *      </a>
+ *
+ * @note    Must only be used with router advertisemnents. This is not checked
+ *          however, since nodes should silently ignore it in other NDP messages.
+ *
+ * @param[in] mtu           The recommended MTU for the link.
+ * @param[in] next          More options in the packet. NULL, if there are none.
+ *
+ * @return  The packet snip list of options, on success
+ * @return  NULL, if packet buffer is full
+ */
+gnrc_pktsnip_t *gnrc_ndp_opt_mtu_build(uint32_t mtu, gnrc_pktsnip_t *next);
+#else
+/**
+ * @brief   A host *must not* send router advertisements at any time (so why build their options?)
+ * @see     <a href="https://tools.ietf.org/html/rfc4861#section-6.3.4">
+ *              RFC 4861, section 6.3.4
+ *          </a>
+ *
+ * This macro is primarily an optimization to not go into the function defined
+ * above.
+ */
+#define gnrc_ndp_opt_pi_build(prefix_len, flags, valid_ltime, pref_ltime, prefix, next) (NULL)
+
+/**
+ * @brief   A host *must not* send router advertisements at any time (so why build their options?)
+ * @see     <a href="https://tools.ietf.org/html/rfc4861#section-6.3.4">
+ *              RFC 4861, section 6.3.4
+ *          </a>
+ *
+ * This macro is primarily an optimization to not go into the function defined
+ * above.
+ */
+#define gnrc_ndp_opt_mtu_build(mtu, next)   (NULL)
+#endif
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/ndp/internal.h
+++ b/sys/include/net/gnrc/ndp/internal.h
@@ -99,6 +99,30 @@ void gnrc_ndp_internal_send_nbr_adv(kernel_pid_t iface, ipv6_addr_t *tgt, ipv6_a
  */
 void gnrc_ndp_internal_send_rtr_sol(kernel_pid_t iface, ipv6_addr_t *dst);
 
+#if (defined(MODULE_GNRC_NDP_ROUTER) || defined(MODULE_GNRC_SIXLOWPAN_ND_ROUTER))
+/**
+ * @brief   Handles received router solicitations.
+ *
+ * @param[in] iface         Interface to send over. May not be KERNEL_PID_UNDEF.
+ * @param[in] src           Source address for the router advertisement. May be NULL to be determined
+ *                          by source address selection (:: if no @p iface has no address).
+ * @param[in] dst           Destination address for router advertisement.
+ *                          @ref IPV6_ADDR_ALL_NODES_LINK_LOCAL if NULL.
+ * @param[in] fin           This is part of the router's final batch of router advertisements
+ *                          before ceising to be a router (set's router lifetime field to 0).
+ */
+void gnrc_ndp_internal_send_rtr_adv(kernel_pid_t iface, ipv6_addr_t *src,
+                                    ipv6_addr_t *dst, bool fin);
+#else
+/**
+ * @brief   A host *must not* send router advertisements at any time.
+ *
+ * This macro is primarily an optimization to not go into the function defined
+ * above.
+ */
+#define gnrc_ndp_internal_send_rtr_adv(iface, dst, fin)
+#endif
+
 /**
  * @brief   Handles a SL2A option.
  *

--- a/sys/include/net/gnrc/ndp/router.h
+++ b/sys/include/net/gnrc/ndp/router.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_gnrc_ndp_router Router-specific part of router discovery.
+ * @ingroup     net_gnrc_ndp
+ * @brief       Router-specific part for the router discovery in IPv6
+ *              neighbor discovery.
+ * @{
+ *
+ * @file
+ * @brief   Router-specific router discovery definitions
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+#ifndef GNRC_NDP_ROUTER_H_
+#define GNRC_NDP_ROUTER_H_
+
+#include <stdbool.h>
+
+#include "kernel_types.h"
+#include "net/ipv6/hdr.h"
+#include "net/ndp.h"
+#include "net/gnrc/ipv6/nc.h"
+#include "timex.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Set @p iface to router mode.
+ *
+ * @details This sets/unsets the GNRC_IPV6_NETIF_FLAGS_ROUTER and
+ *          GNRC_IPV6_NETIF_FLAGS_RTR_ADV and initializes or ceases router
+ *          behavior for neighbor discovery.
+ *
+ * @param[in] iface     An IPv6 interface. Must not be NULL.
+ * @param[in] enable    Status for the GNRC_IPV6_NETIF_FLAGS_ROUTER and
+ *                      GNRC_IPV6_NETIF_FLAGS_RTR_ADV flags.
+ */
+void gnrc_ndp_router_set_router(gnrc_ipv6_netif_t *iface, bool enable);
+
+/**
+ * @brief   Set/Unset GNRC_IPV6_NETIF_FLAGS_RTR_ADV flag for @p iface.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc4861#section-6.2.2">
+ *          RFC 4861, section 6.2.2
+ *      </a>
+ * @see <a href="https://tools.ietf.org/html/rfc4861#section-6.2.5">
+ *          RFC 4861, section 6.2.5
+ *      </a>
+ *
+ * @details GNRC_IPV6_NETIF_FLAGS_RTR_ADV and initializes or ceases
+ *          periodic router advertising behavior for neighbor discovery.
+ *
+ * @param[in] iface     An IPv6 interface. Must not be NULL.
+ * @param[in] enable    Status for the GNRC_IPV6_NETIF_FLAGS_RTR_ADV flags.
+ */
+void gnrc_ndp_router_set_rtr_adv(gnrc_ipv6_netif_t *iface, bool enable);
+
+/**
+ * @brief   Send an unsolicited router advertisement over @p iface
+ *          and reset the timer for the next one if necessary.
+ *
+ * @param[in] iface An IPv6 interface.
+ */
+void gnrc_ndp_router_retrans_rtr_adv(gnrc_ipv6_netif_t *iface);
+
+/**
+ * @brief   Send an solicited router advertisement to IPv6 address of
+ *          @p neighbor.
+ *
+ * @param[in] neighbor  A neighbor cache entry.
+ */
+void gnrc_ndp_router_send_rtr_adv(gnrc_ipv6_nc_t *neighbor);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GNRC_NDP_ROUTER_H_ */
+/** @} */

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -31,6 +31,9 @@ endif
 ifneq (,$(filter gnrc_ndp_node,$(USEMODULE)))
     DIRS += network_layer/ndp/node
 endif
+ifneq (,$(filter gnrc_ndp_router,$(USEMODULE)))
+    DIRS += network_layer/ndp/router
+endif
 ifneq (,$(filter gnrc_netapi,$(USEMODULE)))
     DIRS += netapi
 endif

--- a/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
+++ b/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
@@ -87,10 +87,13 @@ void gnrc_icmpv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *pkt)
             break;
 #endif
 
+#if (defined(MODULE_GNRC_NDP_ROUTER) || defined(MODULE_GNRC_SIXLOWPAN_ND_ROUTER))
         case ICMPV6_RTR_SOL:
             DEBUG("icmpv6: router solicitation received\n");
-            /* TODO */
+            gnrc_ndp_rtr_sol_handle(iface, pkt, ipv6->data, (ndp_rtr_sol_t *)hdr,
+                                    icmpv6->size);
             break;
+#endif
 
 #ifdef MODULE_GNRC_NDP
         case ICMPV6_RTR_ADV:

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -212,6 +212,16 @@ static void *_event_loop(void *args)
                 gnrc_ndp_state_timeout((gnrc_ipv6_nc_t *)msg.content.ptr);
                 break;
 #endif
+#ifdef MODULE_GNRC_NDP_ROUTER
+            case GNRC_NDP_MSG_RTR_ADV_RETRANS:
+                DEBUG("ipv6: Router advertisement retransmission event received\n");
+                gnrc_ndp_router_retrans_rtr_adv((gnrc_ipv6_netif_t *)msg.content.ptr);
+                break;
+            case GNRC_NDP_MSG_RTR_ADV_DELAY:
+                DEBUG("ipv6: Delayed router advertisement event received\n");
+                gnrc_ndp_router_send_rtr_adv((gnrc_ipv6_nc_t *)msg.content.ptr);
+                break;
+#endif
 #ifdef MODULE_GNRC_NDP_HOST
             case GNRC_NDP_MSG_RTR_SOL_RETRANS:
                 DEBUG("ipv6: Router solicitation retransmission event received\n");

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -101,6 +101,18 @@ static ipv6_addr_t *_add_addr_to_entry(gnrc_ipv6_netif_t *entry, const ipv6_addr
 
             _add_addr_to_entry(entry, &ll_addr, 64,
                                flags | GNRC_IPV6_NETIF_ADDR_FLAGS_NDP_ON_LINK);
+#ifdef MODULE_GNRC_NDP_ROUTER
+            /* New prefixes MAY allow the router to retransmit up to
+             * GNRC_NDP_MAX_INIT_RTR_ADV_NUMOF unsolicited RA
+             * (see https://tools.ietf.org/html/rfc4861#section-6.2.4) */
+            if ((entry->flags & GNRC_IPV6_NETIF_FLAGS_ROUTER) &&
+                (entry->flags & GNRC_IPV6_NETIF_FLAGS_RTR_ADV)) {
+                entry->rtr_adv_count = GNRC_NDP_MAX_INIT_RTR_ADV_NUMOF;
+                mutex_unlock(&entry->mutex);    /* function below relocks mutex */
+                gnrc_ndp_router_retrans_rtr_adv(entry);
+                mutex_lock(&entry->mutex);      /* relock mutex */
+            }
+#endif
         }
         else {
             tmp_addr->flags |= GNRC_IPV6_NETIF_ADDR_FLAGS_NDP_ON_LINK;
@@ -215,6 +227,18 @@ gnrc_ipv6_netif_t *gnrc_ipv6_netif_get(kernel_pid_t pid)
     return NULL;
 }
 
+#if defined(MODULE_GNRC_NDP_ROUTER)
+void gnrc_ipv6_netif_set_router(gnrc_ipv6_netif_t *netif, bool enable)
+{
+    gnrc_ndp_router_set_router(netif, enable);
+}
+
+void gnrc_ipv6_netif_set_rtr_adv(gnrc_ipv6_netif_t *netif, bool enable)
+{
+    gnrc_ndp_router_set_rtr_adv(netif, enable);
+}
+#endif
+
 ipv6_addr_t *gnrc_ipv6_netif_add_addr(kernel_pid_t pid, const ipv6_addr_t *addr,
                                       uint8_t prefix_len, uint8_t flags)
 {
@@ -245,6 +269,20 @@ static void _remove_addr_from_entry(gnrc_ipv6_netif_t *entry, ipv6_addr_t *addr)
                   ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)), entry->pid);
             ipv6_addr_set_unspecified(&(entry->addrs[i].addr));
             entry->addrs[i].flags = 0;
+#ifdef MODULE_GNRC_NDP_ROUTER
+            /* Removal of prefixes MAY allow the router to retransmit up to
+             * GNRC_NDP_MAX_INIT_RTR_ADV_NUMOF unsolicited RA
+             * (see https://tools.ietf.org/html/rfc4861#section-6.2.4) */
+            if ((entry->flags & GNRC_IPV6_NETIF_FLAGS_ROUTER) &&
+                (entry->flags & GNRC_IPV6_NETIF_FLAGS_RTR_ADV) &&
+                (!ipv6_addr_is_multicast(addr) &&
+                 !ipv6_addr_is_link_local(addr))) {
+                entry->rtr_adv_count = GNRC_NDP_MAX_INIT_RTR_ADV_NUMOF;
+                mutex_unlock(&entry->mutex);    /* function below relocks the mutex */
+                gnrc_ndp_router_retrans_rtr_adv(entry);
+                return;
+            }
+#endif
 
             mutex_unlock(&entry->mutex);
             return;
@@ -763,6 +801,9 @@ void gnrc_ipv6_netif_init_by_dev(void)
         }
 
         mutex_unlock(&ipv6_if->mutex);
+#if (defined(MODULE_GNRC_NDP_ROUTER) || defined(MODULE_GNRC_SIXLOWPAN_ND_ROUTER))
+        gnrc_ipv6_netif_set_router(ipv6_if, true);
+#endif
 #ifdef MODULE_GNRC_NDP_HOST
         /* start periodic router solicitations */
         gnrc_ndp_host_init(ipv6_if);

--- a/sys/net/gnrc/network_layer/ndp/router/Makefile
+++ b/sys/net/gnrc/network_layer/ndp/router/Makefile
@@ -1,0 +1,3 @@
+MODULE = gnrc_ndp_router
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/network_layer/ndp/router/gnrc_ndp_router.c
+++ b/sys/net/gnrc/network_layer/ndp/router/gnrc_ndp_router.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+
+#include "net/gnrc/ipv6.h"
+#include "net/gnrc/ndp.h"
+#include "net/gnrc/ndp/internal.h"
+#include "random.h"
+#include "timex.h"
+#include "vtimer.h"
+
+#include "net/gnrc/ndp/router.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+static void _send_rtr_adv(gnrc_ipv6_netif_t *iface, ipv6_addr_t *dst);
+
+void gnrc_ndp_router_set_router(gnrc_ipv6_netif_t *iface, bool enable)
+{
+    ipv6_addr_t all_routers = IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL;
+    if (enable && !(iface->flags & GNRC_IPV6_NETIF_FLAGS_ROUTER)) {
+        gnrc_ipv6_netif_add_addr(iface->pid, &all_routers, 128,
+                                 GNRC_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST);
+        mutex_lock(&iface->mutex);
+        iface->flags |= GNRC_IPV6_NETIF_FLAGS_ROUTER;
+        iface->max_adv_int = GNRC_IPV6_NETIF_DEFAULT_MAX_ADV_INT;
+        iface->min_adv_int = GNRC_IPV6_NETIF_DEFAULT_MIN_ADV_INT;
+        iface->adv_ltime = GNRC_IPV6_NETIF_DEFAULT_ROUTER_LTIME;
+        mutex_unlock(&iface->mutex);
+        gnrc_ndp_router_set_rtr_adv(iface, enable);
+    }
+    else if (!enable && (iface->flags & GNRC_IPV6_NETIF_FLAGS_ROUTER)) {
+        gnrc_ipv6_netif_remove_addr(iface->pid, &all_routers);
+        gnrc_ndp_router_set_rtr_adv(iface, enable);
+    }
+}
+
+void gnrc_ndp_router_set_rtr_adv(gnrc_ipv6_netif_t *iface, bool enable)
+{
+    if (enable && !(iface->flags & GNRC_IPV6_NETIF_FLAGS_RTR_ADV)) {
+        mutex_lock(&iface->mutex);
+        iface->flags |= GNRC_IPV6_NETIF_FLAGS_RTR_ADV;
+        iface->rtr_adv_count = GNRC_NDP_MAX_INIT_RTR_ADV_NUMOF;
+        mutex_unlock(&iface->mutex);
+        _send_rtr_adv(iface, NULL);
+    }
+    else if (!enable && (iface->flags & GNRC_IPV6_NETIF_FLAGS_RTR_ADV)) {
+        mutex_lock(&iface->mutex);
+        iface->rtr_adv_count = GNRC_NDP_MAX_FIN_RTR_ADV_NUMOF;
+        iface->flags &= ~GNRC_IPV6_NETIF_FLAGS_RTR_ADV;
+        iface->adv_ltime = 0;
+#ifdef MODULE_GNRC_NDP_HOST
+        iface->rtr_sol_count = GNRC_NDP_MAX_RTR_SOL_NUMOF;
+#endif
+        mutex_unlock(&iface->mutex);
+        _send_rtr_adv(iface, NULL);
+#ifdef MODULE_GNRC_NDP_HOST
+        gnrc_ndp_host_retrans_rtr_sol(iface);
+#endif
+    }
+}
+
+void gnrc_ndp_router_retrans_rtr_adv(gnrc_ipv6_netif_t *iface)
+{
+    _send_rtr_adv(iface, NULL);
+}
+
+void gnrc_ndp_router_send_rtr_adv(gnrc_ipv6_nc_t *neighbor)
+{
+    gnrc_ipv6_netif_t *iface = gnrc_ipv6_netif_get(neighbor->iface);
+    _send_rtr_adv(iface, &neighbor->ipv6_addr);
+}
+
+static void _send_rtr_adv(gnrc_ipv6_netif_t *iface, ipv6_addr_t *dst)
+{
+    bool fin;
+    uint32_t interval;
+
+    mutex_lock(&iface->mutex);
+    fin = (iface->adv_ltime == 0);
+    interval = genrand_uint32_range(iface->min_adv_int, iface->max_adv_int);
+    if (!fin && !((iface->flags | GNRC_IPV6_NETIF_FLAGS_ROUTER) &&
+                  (iface->flags | GNRC_IPV6_NETIF_FLAGS_RTR_ADV))) {
+        DEBUG("ndp rtr: interface %" PRIkernel_pid " is not an advertising interface\n",
+              iface->pid);
+        return;
+    }
+    if (iface->rtr_adv_count > 1) { /* regard for off-by-one error */
+        iface->rtr_adv_count--;
+        if (!fin && (interval > GNRC_NDP_MAX_INIT_RTR_ADV_INT)) {
+            interval = GNRC_NDP_MAX_INIT_RTR_ADV_INT;
+        }
+    }
+    if (!fin || (iface->rtr_adv_count > 1)) {   /* regard for off-by-one-error */
+        /* reset timer for next router advertisement */
+        vtimer_remove(&iface->rtr_adv_timer);
+        vtimer_set_msg(&iface->rtr_adv_timer, timex_set(interval, 0),
+                       gnrc_ipv6_pid, GNRC_NDP_MSG_RTR_ADV_RETRANS, iface);
+    }
+    mutex_unlock(&iface->mutex);
+    for (int i = 0; i < GNRC_IPV6_NETIF_ADDR_NUMOF; i++) {
+        ipv6_addr_t *src = &iface->addrs[i].addr;
+
+        if (!ipv6_addr_is_unspecified(src) && ipv6_addr_is_link_local(src) &&
+            !gnrc_ipv6_netif_addr_is_non_unicast(src)) {
+            /* send one for every link local address (ideally there is only one) */
+            gnrc_ndp_internal_send_rtr_adv(iface->pid, src, dst, fin);
+        }
+    }
+}
+
+/** @} */


### PR DESCRIPTION
This imports [router behavior](https://tools.ietf.org/html/rfc4861#section-6.2) for [NDP router discovery](https://tools.ietf.org/html/rfc4861#section-6). This encompasses:

* building and sending of (periodic) router advertisement (including all available options specified in [RFC 4861](https://tools.ietf.org/html/rfc4861))
* handling of router solicitations and their options

Depends on:
* ~~#3628: address-less link-layer handling for NDP~~ (merged)
* ~~#3745: `gnrc_ipv6_netif` adaptations for router discovery~~ (merged)
* ~~#3746: host-behavior for router discovery~~ (merged)