### PR TITLE
sys/hashes: Add Fletcher's checksums

### DIFF
--- a/sys/hashes/hashes.c
+++ b/sys/hashes/hashes.c
@@ -12,6 +12,7 @@
  * @file
  * @author      Jason Linehan <patientulysses@gmail.com>
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
+ * @author      Joakim Gebart <joakim.gebart@eistec.se>
  */
 
 #include "hashes.h"
@@ -108,4 +109,42 @@ uint32_t one_at_a_time_hash(const uint8_t *buf, size_t len)
     hash ^= hash >> 11;
     hash += hash << 15;
     return hash;
+}
+
+uint16_t fletcher16(const uint8_t *data, size_t bytes)
+{
+    uint16_t sum1 = 0xff, sum2 = 0xff;
+
+    while (bytes) {
+        size_t tlen = bytes > 20 ? 20 : bytes;
+        bytes -= tlen;
+        do {
+            sum2 += sum1 += *data++;
+        } while (--tlen);
+        sum1 = (sum1 & 0xff) + (sum1 >> 8);
+        sum2 = (sum2 & 0xff) + (sum2 >> 8);
+    }
+    /* Second reduction step to reduce sums to 8 bits */
+    sum1 = (sum1 & 0xff) + (sum1 >> 8);
+    sum2 = (sum2 & 0xff) + (sum2 >> 8);
+    return (sum2 << 8) | sum1;
+}
+
+uint32_t fletcher32(const uint16_t *data, size_t words)
+{
+    uint32_t sum1 = 0xffff, sum2 = 0xffff;
+
+    while (words) {
+        unsigned tlen = words > 359 ? 359 : words;
+        words -= tlen;
+        do {
+            sum2 += sum1 += *data++;
+        } while (--tlen);
+        sum1 = (sum1 & 0xffff) + (sum1 >> 16);
+        sum2 = (sum2 & 0xffff) + (sum2 >> 16);
+    }
+    /* Second reduction step to reduce sums to 16 bits */
+    sum1 = (sum1 & 0xffff) + (sum1 >> 16);
+    sum2 = (sum2 & 0xffff) + (sum2 >> 16);
+    return (sum2 << 16) | sum1;
 }

--- a/sys/include/hashes.h
+++ b/sys/include/hashes.h
@@ -19,8 +19,8 @@
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
  */
 
-#ifndef __HASHES_H
-#define __HASHES_H
+#ifndef HASHES_H_
+#define HASHES_H_
 
 #include <stddef.h>
 #include <inttypes.h>
@@ -164,4 +164,4 @@ uint32_t one_at_a_time_hash(const uint8_t *buf, size_t len);
 #endif
 
 /** @} */
-#endif /* __HASHES_H */
+#endif /* HASHES_H_ */

--- a/sys/include/hashes.h
+++ b/sys/include/hashes.h
@@ -17,6 +17,7 @@
  *
  * @author      Jason Linehan <patientulysses@gmail.com>
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
+ * @author      Joakim Gebart <joakim.gebart@eistec.se>
  */
 
 #ifndef HASHES_H_
@@ -158,6 +159,36 @@ uint32_t rotating_hash(const uint8_t *buf, size_t len);
  * @return 32 bit sized hash
  */
 uint32_t one_at_a_time_hash(const uint8_t *buf, size_t len);
+
+/**
+ * @brief Fletcher's 16 bit checksum
+ *
+ * found on
+ * http://en.wikipedia.org/w/index.php?title=Fletcher%27s_checksum&oldid=661273016#Optimizations
+ *
+ * @note the returned sum is never 0
+ *
+ * @param buf input buffer to hash
+ * @param bytes length of buffer, in bytes
+ * @return 16 bit sized hash in the interval [1..65535]
+ */
+uint16_t fletcher16(const uint8_t *buf, size_t bytes);
+
+/**
+ * @brief Fletcher's 32 bit checksum
+ *
+ * found on
+ * http://en.wikipedia.org/w/index.php?title=Fletcher%27s_checksum&oldid=661273016#Optimizations
+ *
+ * @note the returned sum is never 0
+ * @note pay attention to alignment issues since this operates on an input
+ *       buffer containing 16 bit words, not bytes.
+ *
+ * @param buf input buffer to hash
+ * @param words length of buffer, in 16 bit words
+ * @return 32 bit sized hash in the interval [1..2^32]
+ */
+uint32_t fletcher32(const uint16_t *buf, size_t words);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Adds Fletcher's checksum implementations by an anonymous contributor on Wikipedia.

I have been using these functions in hobby projects for many years on ARM, Atmega8 and AVR32 platforms, but I have not performed any formal tests of them other than that they seem to work fine for detecting lost bytes or other transmission errors when using UART to dump data to the PC.