### PR TITLE
sys/universal_address: separate universal_address from fib

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -317,6 +317,7 @@ ifneq (,$(filter nhdp,$(USEMODULE)))
 endif
 
 ifneq (,$(filter fib,$(USEMODULE)))
+  USEMODULE += universal_address
   USEMODULE += timex
   USEMODULE += vtimer
   USEMODULE += net_help

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -167,6 +167,9 @@ endif
 ifneq (,$(filter ng_netdev_eth,$(USEMODULE)))
     DIRS += net/link_layer/ng_netdev_eth
 endif
+ifneq (,$(filter universal_address,$(USEMODULE)))
+    DIRS += universal_address
+endif
 
 DIRS += $(dir $(wildcard $(addsuffix /Makefile, ${USEMODULE})))
 

--- a/sys/include/net/ng_fib/ng_fib_table.h
+++ b/sys/include/net/ng_fib/ng_fib_table.h
@@ -22,7 +22,7 @@
 
 #include <stdint.h>
 #include "vtimer.h"
-#include "ng_universal_address.h"
+#include "universal_address.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/universal_address.h
+++ b/sys/include/universal_address.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    net_universal_address Universal Address Container
- * @ingroup     net
+ * @defgroup    sys_universal_address Universal Address Container
+ * @ingroup     sys
  * @brief       universal address container
  *
  * @{
@@ -24,6 +24,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stdint.h>
+#include <stdlib.h>
 
 #define UNIVERSAL_ADDRESS_SIZE (16)         /**< size of the used addresses in bytes        */
 

--- a/sys/universal_address/Makefile
+++ b/sys/universal_address/Makefile
@@ -1,0 +1,3 @@
+MODULE = universal_address
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/universal_address/universal_address.c
+++ b/sys/universal_address/universal_address.c
@@ -7,7 +7,7 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  *
- * @ingroup fib
+ * @ingroup sys_universal_address
  * @{
  * @file
  * @brief   Functions to manage universal address container
@@ -23,7 +23,7 @@
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
-#include "ng_fib/ng_universal_address.h"
+#include "universal_address.h"
 
 /**
  * @brief Maximum number of entries handled

--- a/tests/unittests/tests-fib/tests-fib.c
+++ b/tests/unittests/tests-fib/tests-fib.c
@@ -17,7 +17,7 @@
 
 #include "thread.h"
 #include "ng_fib.h"
-#include "ng_fib/ng_universal_address.h"
+#include "universal_address.h"
 
 /*
 * @brief helper to fill FIB with unique entries


### PR DESCRIPTION
Separating `universal_address` related code from the `fib` implementation makes it reusable for other modules.
`universal_address` would reside as a module in the `sys` folder.