### PR TITLE
ng_netif: adapt ng_netif_get for holey lists

### DIFF
--- a/sys/include/net/ng_netif.h
+++ b/sys/include/net/ng_netif.h
@@ -83,12 +83,12 @@ void ng_netif_remove(kernel_pid_t pid);
 /**
  * @brief   Get all active interfaces.
  *
- * @param[out] size Size of the resulting array.
+ * @param[out] netifs   List of all active interfaces. There is no order ensured.
+ *                      It must at least fit @ref NG_NETIF_NUMOF elements.
  *
- * @return  All active interfaces. If @p size is 0 on return, the return value
- *          is undefined. No order must be ensured.
+ * @return  The number of active interfaces.
  */
-kernel_pid_t *ng_netif_get(size_t *size);
+size_t ng_netif_get(kernel_pid_t *netifs);
 
 /**
  * @brief   Converts a hardware address to a human readable string.

--- a/sys/net/crosslayer/ng_netif/ng_netif.c
+++ b/sys/net/crosslayer/ng_netif/ng_netif.c
@@ -91,13 +91,17 @@ void ng_netif_remove(kernel_pid_t pid)
     ifs[i] = KERNEL_PID_UNDEF;  /* set in case of i == (NG_NETIF_NUMOF - 1) */
 }
 
-kernel_pid_t *ng_netif_get(size_t *size)
+size_t ng_netif_get(kernel_pid_t *netifs)
 {
-    for (*size = 0;
-         (*size < NG_NETIF_NUMOF) && (ifs[*size] != KERNEL_PID_UNDEF);
-         (*size)++);
+    size_t size = 0;
 
-    return ifs;
+    for (int i = 0; i < NG_NETIF_NUMOF; i++) {
+        if (ifs[i] != KERNEL_PID_UNDEF) {
+            netifs[size++] = ifs[i];
+        }
+    }
+
+    return size;
 }
 
 /** @} */

--- a/sys/net/network_layer/ng_ipv6/ng_ipv6.c
+++ b/sys/net/network_layer/ng_ipv6/ng_ipv6.c
@@ -326,12 +326,11 @@ static void _send_multicast(kernel_pid_t iface, ng_pktsnip_t *pkt,
                             bool prep_hdr)
 {
     ng_pktsnip_t *netif;
-    kernel_pid_t *ifs;
-    size_t ifnum;
+    kernel_pid_t ifs[NG_NETIF_NUMOF];
 
     if (iface == KERNEL_PID_UNDEF) {
         /* get list of interfaces */
-        ifs = ng_netif_get(&ifnum);
+        size_t ifnum = ng_netif_get(ifs);
 
         /* throw away packet if no one is interested */
         if (ifnum == 0) {

--- a/sys/net/network_layer/ng_ndp/ng_ndp.c
+++ b/sys/net/network_layer/ng_ndp/ng_ndp.c
@@ -220,10 +220,8 @@ void ng_ndp_retrans_nbr_sol(ng_ipv6_nc_t *nc_entry)
 
         if (nc_entry->iface == KERNEL_PID_UNDEF) {
             timex_t t = { 0, NG_NDP_RETRANS_TIMER };
-            kernel_pid_t *ifs;
-            size_t ifnum;
-
-            ifs = ng_netif_get(&ifnum);
+            kernel_pid_t ifs[NG_NETIF_NUMOF];
+            size_t ifnum = ng_netif_get(ifs);
 
             for (size_t i = 0; i < ifnum; i++) {
                 _send_nbr_sol(ifs[i], &nc_entry->ipv6_addr, &dst);
@@ -413,10 +411,8 @@ kernel_pid_t ng_ndp_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
 
             if (iface == KERNEL_PID_UNDEF) {
                 timex_t t = { 0, NG_NDP_RETRANS_TIMER };
-                kernel_pid_t *ifs;
-                size_t ifnum;
-
-                ifs = ng_netif_get(&ifnum);
+                kernel_pid_t ifs[NG_NETIF_NUMOF];
+                size_t ifnum = ng_netif_get(ifs);
 
                 for (size_t i = 0; i < ifnum; i++) {
                     _send_nbr_sol(ifs[i], next_hop_ip, &dst_sol);

--- a/sys/shell/commands/sc_ipv6_nc.c
+++ b/sys/shell/commands/sc_ipv6_nc.c
@@ -87,8 +87,8 @@ static void _print_nc_type(ng_ipv6_nc_t *entry)
 static bool _is_iface(kernel_pid_t iface)
 {
 #ifdef MODULE_NG_NETIF
-    size_t numof;
-    kernel_pid_t *ifs = ng_netif_get(&numof);
+    kernel_pid_t ifs[NG_NETIF_NUMOF];
+    size_t numof = ng_netif_get(ifs);
 
     for (size_t i = 0; i < numof; i++) {
         if (ifs[i] == iface) {

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -52,8 +52,8 @@ static bool _is_number(char *str)
 
 static bool _is_iface(kernel_pid_t dev)
 {
-    size_t numof;
-    kernel_pid_t *ifs = ng_netif_get(&numof);
+    kernel_pid_t ifs[NG_NETIF_NUMOF];
+    size_t numof = ng_netif_get(ifs);
 
     for (size_t i = 0; i < numof; i++) {
         if (ifs[i] == dev) {
@@ -700,8 +700,8 @@ int _netif_send(int argc, char **argv)
 int _netif_config(int argc, char **argv)
 {
     if (argc < 2) {
-        size_t numof;
-        kernel_pid_t *ifs = ng_netif_get(&numof);
+        kernel_pid_t ifs[NG_NETIF_NUMOF];
+        size_t numof = ng_netif_get(ifs);
 
         for (size_t i = 0; i < numof; i++) {
             _netif_list(ifs[i]);

--- a/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
+++ b/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
@@ -80,14 +80,14 @@ static void test_ipv6_netif_add__success(void)
 
 static void test_netif_add__success_with_ipv6(void)
 {
-    kernel_pid_t *pids;
+    kernel_pid_t pids[NG_NETIF_NUMOF];
     size_t pid_num;
     ng_ipv6_netif_t *entry;
     ng_ipv6_addr_t exp_addr = NG_IPV6_ADDR_ALL_NODES_LINK_LOCAL;
 
     ng_netif_add(DEFAULT_TEST_NETIF);
 
-    TEST_ASSERT_NOT_NULL((pids = ng_netif_get(&pid_num)));
+    TEST_ASSERT_NOT_NULL((pid_num = ng_netif_get(pids)));
     TEST_ASSERT_EQUAL_INT(1, pid_num);
     TEST_ASSERT_EQUAL_INT(DEFAULT_TEST_NETIF, pids[0]);
     TEST_ASSERT_NOT_NULL((entry = ng_ipv6_netif_get(DEFAULT_TEST_NETIF)));

--- a/tests/unittests/tests-netif/tests-netif.c
+++ b/tests/unittests/tests-netif/tests-netif.c
@@ -29,10 +29,11 @@ static void set_up(void)
 
 static void test_ng_netif_add__KERNEL_PID_UNDEF(void)
 {
-    size_t size = TEST_UINT8;
+    kernel_pid_t ifs[NG_NETIF_NUMOF];
+    size_t size;
 
     TEST_ASSERT_EQUAL_INT(0, ng_netif_add(KERNEL_PID_UNDEF));
-    ng_netif_get(&size);
+    size = ng_netif_get(ifs);
     TEST_ASSERT_EQUAL_INT(0, size);
 }
 
@@ -47,75 +48,75 @@ static void test_ng_netif_add__memfull(void)
 
 static void test_ng_netif_add__success(void)
 {
-    size_t size = TEST_UINT8;
-    kernel_pid_t *res = NULL;
+    kernel_pid_t ifs[NG_NETIF_NUMOF];
+    size_t size;
 
     TEST_ASSERT_EQUAL_INT(0, ng_netif_add(TEST_UINT8));
 
-    res = ng_netif_get(&size);
+    size = ng_netif_get(ifs);
     TEST_ASSERT_EQUAL_INT(1, size);
-    TEST_ASSERT_EQUAL_INT(TEST_UINT8, res[0]);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8, ifs[0]);
 }
 
 static void test_ng_netif_add__duplicate_entry(void)
 {
-    size_t size = TEST_UINT8;
-    kernel_pid_t *res = NULL;
+    kernel_pid_t ifs[NG_NETIF_NUMOF];
+    size_t size;
 
     for (int i = 0; i < NG_NETIF_NUMOF + 4; i++) {
         TEST_ASSERT_EQUAL_INT(0, ng_netif_add(TEST_UINT8));
     }
 
-    res = ng_netif_get(&size);
+    size = ng_netif_get(ifs);
     TEST_ASSERT_EQUAL_INT(1, size);
-    TEST_ASSERT_EQUAL_INT(TEST_UINT8, res[0]);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8, ifs[0]);
 }
 
 static void test_ng_netif_remove__KERNEL_PID_UNDEF(void)
 {
-    size_t size = TEST_UINT8;
-    kernel_pid_t *res = NULL;
+    kernel_pid_t ifs[NG_NETIF_NUMOF];
+    size_t size;
 
     test_ng_netif_add__success();
 
     ng_netif_remove(KERNEL_PID_UNDEF);
 
-    res = ng_netif_get(&size);
+    size = ng_netif_get(ifs);
     TEST_ASSERT_EQUAL_INT(1, size);
-    TEST_ASSERT_EQUAL_INT(TEST_UINT8, res[0]);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8, ifs[0]);
 }
 
 static void test_ng_netif_remove__not_an_if(void)
 {
-    size_t size = TEST_UINT8;
-    kernel_pid_t *res = NULL;
+    kernel_pid_t ifs[NG_NETIF_NUMOF];
+    size_t size;
 
     test_ng_netif_add__success();
 
     ng_netif_remove(TEST_UINT8 + 1);
 
-    res = ng_netif_get(&size);
+    size = ng_netif_get(ifs);
     TEST_ASSERT_EQUAL_INT(1, size);
-    TEST_ASSERT_EQUAL_INT(TEST_UINT8, res[0]);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8, ifs[0]);
 }
 
 static void test_ng_netif_remove__success(void)
 {
-    size_t size = TEST_UINT8;
+    kernel_pid_t ifs[NG_NETIF_NUMOF];
+    size_t size;
 
     test_ng_netif_add__success();
 
     ng_netif_remove(TEST_UINT8);
 
-    ng_netif_get(&size);
+    size = ng_netif_get(ifs);
     TEST_ASSERT_EQUAL_INT(0, size);
 }
 
 static void test_ng_netif_get__empty(void)
 {
-    size_t size = TEST_UINT8;
-
-    ng_netif_get(&size);
+    kernel_pid_t ifs[NG_NETIF_NUMOF];
+    size_t size = ng_netif_get(ifs);
     TEST_ASSERT_EQUAL_INT(0, size);
 }
 
@@ -123,8 +124,8 @@ static void test_ng_netif_get__empty(void)
  * are gotten regardless */
 static void test_ng_netif_get__success_3_minus_one(void)
 {
-    size_t size = TEST_UINT8;
-    kernel_pid_t *ifs;
+    kernel_pid_t ifs[NG_NETIF_NUMOF];
+    size_t size;
     int count = 0;
 
     for (int i = 0; i < 3; i++) {
@@ -133,7 +134,7 @@ static void test_ng_netif_get__success_3_minus_one(void)
 
     ng_netif_remove(TEST_UINT8 + 1);
 
-    ifs = ng_netif_get(&size);
+    size = ng_netif_get(ifs);
     TEST_ASSERT_EQUAL_INT(2, size);
 
     for (size_t i = 0; i < size; i++) {
@@ -147,13 +148,14 @@ static void test_ng_netif_get__success_3_minus_one(void)
 
 static void test_ng_netif_get__full(void)
 {
-    size_t size = TEST_UINT8;
+    kernel_pid_t ifs[NG_NETIF_NUMOF];
+    size_t size;
 
     for (int i = 0; i < NG_NETIF_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, ng_netif_add(TEST_UINT8 + i));
     }
 
-    TEST_ASSERT_NOT_NULL(ng_netif_get(&size));
+    size = ng_netif_get(ifs);
     TEST_ASSERT_EQUAL_INT(NG_NETIF_NUMOF, size);
 }
 


### PR DESCRIPTION
The bug fixed in #3057 doesn't considered `ng_netif_get()`. This also is a far more logical usage of the return values.