### PR TITLE
unittests: rm warning for tests-ipv6_netif

### DIFF
--- a/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
+++ b/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
@@ -87,7 +87,7 @@ static void test_netif_add__success_with_ipv6(void)
 
     ng_netif_add(DEFAULT_TEST_NETIF);
 
-    TEST_ASSERT_NOT_NULL((pid_num = ng_netif_get(pids)));
+    TEST_ASSERT_EQUAL_INT(1, (pid_num = ng_netif_get(pids)));
     TEST_ASSERT_EQUAL_INT(1, pid_num);
     TEST_ASSERT_EQUAL_INT(DEFAULT_TEST_NETIF, pids[0]);
     TEST_ASSERT_NOT_NULL((entry = ng_ipv6_netif_get(DEFAULT_TEST_NETIF)));


### PR DESCRIPTION
I merged https://github.com/RIOT-OS/RIOT/pull/3059 too hastily and missed one warning... This PR should get rid of that one too :) 