### PR TITLE
dist: tools: build_and_test.sh: allow skipping of label check

### DIFF
--- a/dist/tools/pr_check/check_labels.sh
+++ b/dist/tools/pr_check/check_labels.sh
@@ -22,7 +22,7 @@ else
     exit 2
 fi
 
-LABELS_JSON=$(${GET} "${GITHUB_API_HOST}/repos/${GITHUB_REPO}/issues/${TRAVIS_PULL_REQUEST}/labels" 2> /dev/null)
+LABELS_JSON=$(${GET} "${GITHUB_API_HOST}/repos/${GITHUB_REPO}/issues/${TRAVIS_PULL_REQUEST}/labels" 2> /dev/null || true)
 
 check_gh_label() {
     LABEL="${1}"

--- a/dist/tools/travis-scripts/build_and_test.sh
+++ b/dist/tools/travis-scripts/build_and_test.sh
@@ -64,7 +64,7 @@ then
 
     source ./dist/tools/pr_check/check_labels.sh
 
-    if check_gh_label "Ready for CI build"; then
+    if check_gh_label "Ready for CI build" || test "$SKIP_CI_READY_CHECK"="yes"; then
         if [ "$BUILDTEST_MCU_GROUP" == "x86" ]
         then
             make -C ./tests/unittests all test BOARD=native || exit


### PR DESCRIPTION
 #3037 breaks local runs of build_and_test.sh.