### PR TITLE
dist: tools: build_and_test.sh: allow skipping of label check

### DIFF
--- a/dist/tools/pr_check/check_labels.sh
+++ b/dist/tools/pr_check/check_labels.sh
@@ -22,7 +22,7 @@ else
     exit 2
 fi
 
-LABELS_JSON=$(${GET} "${GITHUB_API_HOST}/repos/${GITHUB_REPO}/issues/${TRAVIS_PULL_REQUEST}/labels" 2> /dev/null)
+LABELS_JSON=$(${GET} "${GITHUB_API_HOST}/repos/${GITHUB_REPO}/issues/${TRAVIS_PULL_REQUEST}/labels" 2> /dev/null || true)
 
 check_gh_label() {
     LABEL="${1}"


### PR DESCRIPTION
#3037 breaks build_and_test.sh when not using through travis.