### PR TITLE
ng_slip: rename xbee_params_t to ng_slip_params_t

### DIFF
--- a/sys/include/net/ng_slip.h
+++ b/sys/include/net/ng_slip.h
@@ -65,7 +65,7 @@ typedef struct {
 typedef struct xbee_params {
     uart_t uart;            /**< UART interfaced the device is connected to */
     uint32_t baudrate;      /**< baudrate to use */
-} xbee_params_t;
+} ng_slip_params_t;
 
 /**
  * @brief   Initializes a new @ref net_ng_slip control thread for UART device

--- a/tests/slip/slip_params.h
+++ b/tests/slip/slip_params.h
@@ -19,11 +19,13 @@
 #ifndef SLIP_PARAMS_H
 #define SLIP_PARAMS_H
 
+#include "net/ng_slip.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-static xbee_params_t xbee_params[] = {
+static ng_slip_params_t xbee_params[] = {
     {
         .uart = SLIP_UART,
         .baudrate = SLIP_BAUDRATE,


### PR DESCRIPTION
Fixed copy pasta

(see https://github.com/RIOT-OS/RIOT/pull/2688#discussion_r31020739)