### PR TITLE
travis: exit before before_install phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
     - NPROC_MAX=8 BUILDTEST_MCU_GROUP=cortex_m4
 
 before_install:
+    - source ./dist/tools/pr_check/check_labels.sh
+    - test -z "$TRAVIS_PULL_REQUEST" || test "$BUILDTEST_MCU_GROUP" = "static-tests" || check_gh_label "Ready for CI build" || exit 1
     - sudo apt-get install emdebian-archive-keyring
     - echo 'deb http://ftp.uk.debian.org/emdebian/toolchains wheezy main' | sudo tee /etc/apt/sources.list.d/emdebian.list > /dev/null
 

--- a/dist/tools/travis-scripts/build_and_test.sh
+++ b/dist/tools/travis-scripts/build_and_test.sh
@@ -62,21 +62,13 @@ then
         exit $RESULT
     fi
 
-    source ./dist/tools/pr_check/check_labels.sh
-
-    if check_gh_label "Ready for CI build"; then
-        if [ "$BUILDTEST_MCU_GROUP" == "x86" ]
-        then
-            make -C ./tests/unittests all test BOARD=native || exit
-            # TODO:
-            #   Reenable once https://github.com/RIOT-OS/RIOT/issues/2300 is
-            #   resolved:
-            #   - make -C ./tests/unittests all test BOARD=qemu-i386 || exit
-        fi
-        echo -e "\e[0;32mCompile tests will be performed for this pull request\e[0m"
-        ./dist/tools/compile_test/compile_test.py riot/master
-    else
-        echo -e "\e[33;40mCompile tests will be skipped for this pull request\e[0m"
-        exit 1
+    if [ "$BUILDTEST_MCU_GROUP" == "x86" ]
+    then
+        make -C ./tests/unittests all test BOARD=native || exit
+        # TODO:
+        #   Reenable once https://github.com/RIOT-OS/RIOT/issues/2300 is
+        #   resolved:
+        #   - make -C ./tests/unittests all test BOARD=qemu-i386 || exit
     fi
+    ./dist/tools/compile_test/compile_test.py riot/master
 fi


### PR DESCRIPTION
This keeps Travis from even installing, if "Ready for CI build" is not set yet.