### PR TITLE
ng_netif: don't shift entries upon remove

### DIFF
--- a/sys/net/crosslayer/ng_netif/ng_netif.c
+++ b/sys/net/crosslayer/ng_netif/ng_netif.c
@@ -80,15 +80,9 @@ void ng_netif_remove(kernel_pid_t pid)
                 if_handler[j].remove(pid);
             }
 
-            break;
+            return;
         }
     }
-
-    for (; (i < (NG_NETIF_NUMOF - 1)) && (ifs[i + 1] != KERNEL_PID_UNDEF); i++) {
-        ifs[i] = ifs[i + 1];
-    }
-
-    ifs[i] = KERNEL_PID_UNDEF;  /* set in case of i == (NG_NETIF_NUMOF - 1) */
 }
 
 size_t ng_netif_get(kernel_pid_t *netifs)


### PR DESCRIPTION
Because isn't in danger of getting duplicates upon ``ng_netif_add()``, we don't have to shift all successor entries upon delete. This should be a bit more efficient. (once we actually have NG_NETIF_NUMOF > 1 :D)