### PR TITLE
cc430 hwtimers need to map correctly to hardware control registers

### DIFF
--- a/cpu/cc430/hwtimer_cc430.c
+++ b/cpu/cc430/hwtimer_cc430.c
@@ -47,6 +47,7 @@ void timerA_init(void)
         *(ccr + i) = 0;
         *(ctl + i) &= ~(CCIFG);
         *(ctl + i) &= ~(CCIE);
+        msp430_timer[i].ccr_num = i;
     }
 
     TA0CTL |= MC_2;


### PR DESCRIPTION
The `msp_timer` array holds a list of `msp430_timer_t` structs representing hardware timers.
Each of these structs holds a integer `ccr_num` ([defined here](https://github.com/RIOT-OS/RIOT/blob/master/cpu/msp430-common/include/hwtimer_cpu.h#L65)) representing the memory offset of the timer's registers relative to the address of the base timer 0, see how it is used [here](https://github.com/RIOT-OS/RIOT/blob/master/cpu/msp430-common/hwtimer_cpu.c#L65.).

`ccr_num` needs to be set during initialization of cc430 timers. Currently it is not initialized and **all timers are mapped to timer 0.**

You can see [here](https://github.com/RIOT-OS/RIOT/blob/master/cpu/msp430fxyz/hwtimer_msp430.c#L54) how another msp430 variant does it right.