### PR TITLE
ng_net: use printf-stack size where it is needed

### DIFF
--- a/sys/net/network_layer/ng_ipv6/ng_ipv6.c
+++ b/sys/net/network_layer/ng_ipv6/ng_ipv6.c
@@ -35,7 +35,11 @@
 
 #define _MAX_L2_ADDR_LEN    (8U)
 
+#if ENABLE_DEBUG
+static char _stack[NG_IPV6_STACK_SIZE + THREAD_EXTRA_STACKSIZE_PRINTF];
+#else
 static char _stack[NG_IPV6_STACK_SIZE];
+#endif
 
 #if ENABLE_DEBUG
 static char addr_str[NG_IPV6_ADDR_MAX_STR_LEN];

--- a/sys/net/network_layer/ng_sixlowpan/ng_sixlowpan.c
+++ b/sys/net/network_layer/ng_sixlowpan/ng_sixlowpan.c
@@ -25,7 +25,13 @@
 #include "debug.h"
 
 static kernel_pid_t _pid = KERNEL_PID_UNDEF;
+
+#if ENABLE_DEBUG
+static char _stack[NG_SIXLOWPAN_STACK_SIZE + THREAD_EXTRA_STACKSIZE_PRINTF];
+#else
 static char _stack[NG_SIXLOWPAN_STACK_SIZE];
+#endif
+
 
 /* handles NG_NETAPI_MSG_TYPE_RCV commands */
 void _receive(ng_pktsnip_t *pkt);

--- a/sys/net/transport_layer/ng_udp/ng_udp.c
+++ b/sys/net/transport_layer/ng_udp/ng_udp.c
@@ -44,7 +44,11 @@ static kernel_pid_t _pid = KERNEL_PID_UNDEF;
 /**
  * @brief   Allocate memory for the UDP thread's stack
  */
+#if ENABLE_DEBUG
+static char _stack[NG_UDP_STACK_SIZE + THREAD_EXTRA_STACKSIZE_PRINTF];
+#else
 static char _stack[NG_UDP_STACK_SIZE];
+#endif
 
 /**
  * @brief   Calculate the UDP checksum dependent on the network protocol

--- a/sys/net/transport_layer/ng_udp/ng_udp.c
+++ b/sys/net/transport_layer/ng_udp/ng_udp.c
@@ -240,7 +240,8 @@ int ng_udp_calc_csum(ng_pktsnip_t *hdr, ng_pktsnip_t *pseudo_hdr)
 
 ng_pktsnip_t *ng_udp_hdr_build(ng_pktsnip_t *payload,
                                uint8_t *src, size_t src_len,
-                               uint8_t *dst, size_t dst_len) {
+                               uint8_t *dst, size_t dst_len)
+{
     ng_pktsnip_t *res;
     ng_udp_hdr_t *hdr;
 


### PR DESCRIPTION
Adds `THREAD_EXTRA_STACKSIZE_PRINTF` where it is needed.