### PR TITLE
board/samr21: fixed and cleaned up LED code

### DIFF
--- a/boards/samr21-xpro/board.c
+++ b/boards/samr21-xpro/board.c
@@ -11,9 +11,11 @@
  * @{
  *
  * @file
- * @brief       Board specific implementations for the Atem SAM R21 Xplained Pro board
+ * @brief       Board specific implementations for the Atmel SAM R21 Xplained
+ *              Pro board
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
  * @}
  */
@@ -23,31 +25,11 @@
 #include "board.h"
 #include "cpu.h"
 
-
-void led_init(void);
-
-
 void board_init(void)
 {
     /* initialize the CPU */
     cpu_init();
-
-    /* initialize the boards LEDs */
-    led_init();
-}
-
-
-/**
- * @brief Initialize the boards on-board LED
- *
- * The LED initialization is hard-coded in this function. As the LED is soldered
- * onto the board it is fixed to its CPU pins.
- *
- * The LED is connected to the following pin:
- * - LED: PA19
- */
-void led_init(void)
-{
+    /* initialize the boards LED at pin PA19 */
     LED_PORT.DIRSET.reg = (1 << LED_PIN);
     LED_PORT.OUTSET.reg = (1 << LED_PIN);
     LED_PORT.PINCFG[LED_PIN].bit.PULLEN = false;

--- a/boards/samr21-xpro/board.c
+++ b/boards/samr21-xpro/board.c
@@ -48,7 +48,7 @@ void board_init(void)
  */
 void led_init(void)
 {
-    LED_PORT.DIRSET.reg = 1 << LED_PIN;
-    LED_PORT.OUTSET.reg = LED_PIN;
+    LED_PORT.DIRSET.reg = (1 << LED_PIN);
+    LED_PORT.OUTSET.reg = (1 << LED_PIN);
     LED_PORT.PINCFG[LED_PIN].bit.PULLEN = false;
 }

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -13,7 +13,8 @@
  * @{
  *
  * @file
- * @brief       Board specific definitions for the Atmel SAM R21 Xplained Pro board.
+ * @brief       Board specific definitions for the Atmel SAM R21 Xplained Pro
+ *              board
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  */
@@ -83,9 +84,9 @@ extern "C" {
  * @name Macros for controlling the on-board LEDs.
  * @{
  */
-#define LED_ON              (LED_PORT.OUTCLR.reg = 1<<LED_PIN)
-#define LED_OFF             (LED_PORT.OUTSET.reg = 1<<LED_PIN)
-#define LED_TOGGLE          (LED_PORT.OUTTGL.reg = 1<<LED_PIN)
+#define LED_ON              (LED_PORT.OUTCLR.reg = (1 << LED_PIN))
+#define LED_OFF             (LED_PORT.OUTSET.reg = (1 << LED_PIN))
+#define LED_TOGGLE          (LED_PORT.OUTTGL.reg = (1 << LED_PIN))
 
 /* for compatability to other boards */
 #define LED_GREEN_ON        /* not available */


### PR DESCRIPTION
- fixed error (missing shift) in LED initialization
- fixed line length issue in doxygen headers
- compressed LED init code in board.c
- fixed whitespace issues in board.h