### PR TITLE
mulle: Increase GPIO_NUMOF to match the enabled GPIOs

### DIFF
--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -468,7 +468,7 @@ extern "C"
  * @name GPIO configuration
  * @{
  */
-#define GPIO_NUMOF          26
+#define GPIO_NUMOF          27
 #define GPIO_0_EN           1
 #define GPIO_1_EN           1
 #define GPIO_2_EN           1


### PR DESCRIPTION
silly typo which may cause problems in the future if not fixed.

```
riot/cpu/kinetis_common/gpio.c:153:5: error: excess elements in array initializer [-Werror]
     { .port = GPIO_26_PORT, .gpio = GPIO_26_DEV, .pin = GPIO_26_PIN },
     ^
riot/cpu/kinetis_common/gpio.c:153:5: error: (near initialization for ‘kinetis_gpio_lut’) [-Werror]
cc1: all warnings being treated as errors
```