### PR TITLE
cpu: centralized cortex initialization and some defines

### DIFF
--- a/cpu/cc2538/cpu.c
+++ b/cpu/cc2538/cpu.c
@@ -34,8 +34,6 @@
 
 #define CLOCK_STA_MASK ( OSC32K | OSC )
 
-extern const void *interrupt_vector[];
-
 static void cpu_clock_init(void);
 
 /**
@@ -43,18 +41,12 @@ static void cpu_clock_init(void);
  */
 void cpu_init(void)
 {
-    /* configure the vector table location to internal flash */
-    assert((uintptr_t)&interrupt_vector % CC2538_VTOR_ALIGN == 0);
-    SCB->VTOR = (uintptr_t)&interrupt_vector;
-
+    /* initialize the Cortex-M core */
+    cortexm_init();
     /* Enable the CC2538's more compact alternate interrupt mapping */
     SYS_CTRL->I_MAP = 1;
-
     /* initialize the clock system */
     cpu_clock_init();
-
-    /* set pendSV interrupt to lowest possible priority */
-    NVIC_SetPriority(PendSV_IRQn, 0xff);
 }
 
 /**

--- a/cpu/cc2538/include/cpu_conf.h
+++ b/cpu/cc2538/include/cpu_conf.h
@@ -33,25 +33,12 @@ extern "C" {
 #endif
 
 /**
- * @name Kernel configuration
+ * @brief   ARM Cortex-M specific CPU configuration
  * @{
  */
-#define THREAD_EXTRA_STACKSIZE_PRINTF    1024
-
-#ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT   1024
-#endif
-
-#define THREAD_STACKSIZE_IDLE      512
-/** @} */
-
-/**
- * @name UART0 buffer size definition for compatibility reasons
- * @{
- */
-#ifndef UART0_BUFSIZE
-#define UART0_BUFSIZE                   128
-#endif
+#define CPU_DEFAULT_IRQ_PRIO            (1U)
+#define CPU_IRQ_NUMOF                   PERIPH_COUNT_IRQn
+#define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
 /**

--- a/cpu/cortexm_common/cortexm_init.c
+++ b/cpu/cortexm_common/cortexm_init.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_cortexm_common
+ * @{
+ *
+ * @file
+ * @brief       Cortex-M specific configuration and initialization options
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+
+/**
+ * @name   Pattern to write into the co-processor Access Control Register to
+ *         allow full FPU access
+ */
+#define FULL_FPU_ACCESS         (0x00f00000)
+
+void cortexm_init(void)
+{
+    /* initialize the FPU on Cortex-M4F CPUs */
+#ifdef CPU_ARCH_CORTEX_M4F
+    /* give full access to the FPU */
+    SCB->CPACR |= (uint32_t)FULL_FPU_ACCESS;
+#endif
+
+    /* configure the vector table location to internal flash */
+#if defined(CPU_ARCH_CORTEX_M3) || defined(CPU_ARCH_CORTEX_M4) || \
+    defined(CPU_ARCH_CORTEX_M4F)
+    SCB->VTOR = CPU_FLASH_BASE;
+#endif
+
+    /* initialize the interrupt priorities */
+    /* set pendSV interrupt to lowest possible priority */
+    NVIC_SetPriority(PendSV_IRQn, 0xff);
+    /* set SVC interrupt to same priority as the rest */
+    NVIC_SetPriority(SVCall_IRQn, CPU_DEFAULT_IRQ_PRIO);
+    /* initialize all vendor specific interrupts with the same value */
+    for (int i = 0; i < CPU_IRQ_NUMOF; i++) {
+        NVIC_SetPriority(i, CPU_DEFAULT_IRQ_PRIO);
+    }
+}

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -25,13 +25,12 @@
  * @author      Joakim Gebart <joakim.gebart@eistec.se>
  */
 
-#ifndef CORTEXM_COMMON_H_
-#define CORTEXM_COMMON_H_
-
+#ifndef CPU_H_
+#define CPU_H_
 
 #include "cpu_conf.h"
 
-/**
+/*
  * TODO: remove once core was adjusted
  */
 #include "irq.h"
@@ -41,16 +40,52 @@ extern "C" {
 #endif
 
 /**
- * @brief   Deprecated interrupt control function for backward compatibility
+ * @brief    Configuration of default stack sizes
+ *
+ * As all members of the Cortex-M family behave identical in terms of stack
+ * usage, we define the default stack size values here centrally for all CPU
+ * implementations.
+ *
+ * If needed, you can overwrite these values the the `cpu_conf.h` file of the
+ * specific CPU implementation.
+ *
+ * TODO: Adjust values for Cortex-M4F with FPU?
+ * TODO: Configure second set if no newlib nano.specs are available?
  * @{
  */
-#define eINT            enableIRQ
-#define dINT            disableIRQ
+#ifndef THREAD_EXTRA_STACKSIZE_PRINTF
+#define THREAD_EXTRA_STACKSIZE_PRINTF   (512)
+#endif
+#ifndef THREAD_STACKSIZE_DEFAULT
+#define THREAD_STACKSIZE_DEFAULT        (1024)
+#endif
+#ifndef THREAD_STACKSIZE_IDLE
+#define THREAD_STACKSIZE_IDLE           (256)
+#endif
 /** @} */
 
 /**
- * @brief   Some members of the Cortex-M family have architecture specific atomic
- *          operations in atomic_arch.c
+ * @brief   UART0 buffer size definition for compatibility reasons
+ *
+ * TODO: remove once the remodeling of the uart0 driver is done
+ * @{
+ */
+#ifndef UART0_BUFSIZE
+#define UART0_BUFSIZE                   (128)
+#endif
+/** @} */
+
+/**
+ * @brief   Deprecated interrupt control function for backward compatibility
+ * @{
+ */
+#define eINT                            enableIRQ
+#define dINT                            disableIRQ
+/** @} */
+
+/**
+ * @brief   Some members of the Cortex-M family have architecture specific
+ *          atomic operations in atomic_arch.c
  */
 #if defined(CPU_ARCH_CORTEX_M3) || defined(CPU_ARCH_CORTEX_M4) || \
     defined(CPU_ARCH_CORTEX_M4F)
@@ -58,13 +93,34 @@ extern "C" {
 #endif
 
 /**
+ * @brief Definition of available panic modes
+ */
+typedef enum {
+    PANIC_NMI_HANDLER,       /**< non maskable interrupt */
+    PANIC_HARD_FAULT,        /**< hard fault */
+#if defined(CPU_ARCH_CORTEX_M3) || defined(CPU_ARCH_CORTEX_M4) || \
+    defined(CPU_ARCH_CORTEX_M4F)
+    PANIC_MEM_MANAGE,        /**< memory controller interrupt */
+    PANIC_BUS_FAULT,         /**< bus fault */
+    PANIC_USAGE_FAULT,       /**< undefined instruction or unaligned access */
+    PANIC_DEBUG_MON,         /**< debug interrupt */
+#endif
+    PANIC_DUMMY_HANDLER,     /**< unhandled interrupt */
+} panic_t;
+
+/**
  * @brief   Initialization of the CPU
  */
 void cpu_init(void);
+
+/**
+ * @brief   Initialize Cortex-M specific core parts of the CPU
+ */
+void cortexm_init(void);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* CORTEXM_COMMON_H_ */
+#endif /* CPU_H_ */
 /** @} */

--- a/cpu/k60/Makefile.include
+++ b/cpu/k60/Makefile.include
@@ -29,9 +29,11 @@ include $(KINETIS_COMMON)Makefile.include
 export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts
 export LINKERSCRIPT = $(CPU_MODEL).ld
 
-#export the CPU model
+#export the CPU model and architecture
 MODEL = $(shell echo $(CPU_MODEL)|tr 'a-z' 'A-Z')
 export CFLAGS += -DCPU_MODEL_$(MODEL)
+ARCH = $(shell echo $(CPU_ARCH) | tr 'a-z-' 'A-Z_')
+export CFLAGS += -DCPU_ARCH_$(ARCH)
 
 # include CPU specific includes
 export INCLUDES += -I$(RIOTCPU)/$(CPU)/include

--- a/cpu/k60/cpu.c
+++ b/cpu/k60/cpu.c
@@ -20,8 +20,6 @@
  * @author      Joakim Gebart <joakim.gebart@eistec.se>
  */
 
-extern void *_vector_rom[];
-
 /** @brief Current core clock frequency */
 uint32_t SystemCoreClock = DEFAULT_SYSTEM_CLOCK;
 /** @brief Current system clock frequency */
@@ -46,15 +44,10 @@ static void check_running_cpu_revision(void);
  */
 void cpu_init(void)
 {
+    /* initialize the Cortex-M core */
+    cortexm_init();
     /* Check that we are running on the CPU that this code was built for */
     check_running_cpu_revision();
-
-    /* configure the vector table location to internal flash */
-    SCB->VTOR = (uint32_t)_vector_rom;
-
-    /* set pendSV interrupt to lowest possible priority */
-    NVIC_SetPriority(PendSV_IRQn, 0xff);
-
 }
 
 static void check_running_cpu_revision(void)

--- a/cpu/k60/include/cpu_conf.h
+++ b/cpu/k60/include/cpu_conf.h
@@ -62,6 +62,15 @@ extern "C"
 #include "MK60-comp.h"
 
 /**
+ * @brief   ARM Cortex-M specific CPU configuration
+ * @{
+ */
+#define CPU_DEFAULT_IRQ_PRIO            (1U)
+#define CPU_IRQ_NUMOF                   (104U)
+#define CPU_FLASH_BASE                  (0x00000000)
+/** @} */
+
+/**
  * @name GPIO pin mux function numbers
  */
 /** @{ */
@@ -76,20 +85,6 @@ extern "C"
 #define PIN_INTERRUPT_FALLING 0b1010
 #define PIN_INTERRUPT_EDGE 0b1011
 /** @} */
-/**
- * @name Kernel stack size configuration
- *
- * TODO: Tune this
- * @{
- */
-#define THREAD_EXTRA_STACKSIZE_PRINTF    (1024)
-
-#ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT   (1024)
-#endif
-
-#define THREAD_STACKSIZE_IDLE      (256)
-/** @} */
 
 /**
  * @name Length and address for reading CPU_ID (named UID in Freescale documents)
@@ -98,15 +93,6 @@ extern "C"
 #define CPUID_ID_LEN                    (16)
 #define CPUID_ID_PTR                    ((void *)(&(SIM->UIDH)))
 /** @} */
-
-#ifndef UART0_BUFSIZE
-/**
- * @brief UART0 buffer size definition for compatibility reasons
- *
- * TODO: remove once the remodeling of the uart0 driver is done
- */
-#define UART0_BUFSIZE                   (128)
-#endif
 
 /**
  * @name UART driver settings

--- a/cpu/kinetis_common/fault_handlers.c
+++ b/cpu/kinetis_common/fault_handlers.c
@@ -21,6 +21,7 @@
  */
 
 #include <stdint.h>
+#include "cpu.h"
 #include "panic.h"
 #include "fault_handlers.h"
 
@@ -56,5 +57,5 @@ void isr_debug_mon(void)
 
 void isr_unhandled(void)
 {
-    core_panic(PANIC_UNHANDLED_ISR, "UNHANDLED ISR");
+    core_panic(PANIC_DUMMY_HANDLER, "UNHANDLED ISR");
 }

--- a/cpu/kinetis_common/include/fault_handlers.h
+++ b/cpu/kinetis_common/include/fault_handlers.h
@@ -63,20 +63,6 @@ void isr_debug_mon(void);
  */
 void isr_unhandled(void);
 
-/**
- * @brief Definition of different panic modes
- */
-typedef enum {
-    PANIC_NMI_HANDLER,       /**< non maskable interrupt */
-    PANIC_HARD_FAULT,        /**< hard fault */
-    PANIC_MEM_MANAGE,        /**< memory controller interrupt */
-    PANIC_BUS_FAULT,         /**< bus fault */
-    PANIC_USAGE_FAULT,       /**< undefined instruction or unaligned access */
-    PANIC_DEBUG_MON,         /**< debug interrupt */
-    PANIC_UNHANDLED_ISR,     /**< unhandled interrupt */
-} panic_t;
-
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/kw2x/Makefile.include
+++ b/cpu/kw2x/Makefile.include
@@ -1,3 +1,5 @@
+export CPU_ARCH = cortex-m4
+
 # this CPU implementation is using the explicit core/CPU interface
 export CFLAGS += -DCOREIF_NG=1
 
@@ -26,6 +28,8 @@ export LINKERSCRIPT = $(RIOTCPU)/$(CPU)/$(CPU_MODEL)_linkerscript.ld
 #export the CPU model
 MODEL = $(shell echo $(CPU_MODEL)|tr 'a-z' 'A-Z')
 export CFLAGS += -DCPU_MODEL_$(MODEL)
+ARCH = $(shell echo $(CPU_ARCH) | tr 'a-z-' 'A-Z_')
+export CFLAGS += -DCPU_ARCH_$(ARCH)
 
 # include CPU specific includes
 export INCLUDES += -I$(RIOTCPU)/$(CPU)/include

--- a/cpu/kw2x/cpu.c
+++ b/cpu/kw2x/cpu.c
@@ -31,14 +31,10 @@ static void cpu_clock_init(void);
  */
 void cpu_init(void)
 {
-    /* configure the vector table location to internal flash */
-    SCB->VTOR = FLASH_BASE;
-
+    /* initialize the Cortex-M core */
+    cortexm_init();
     /* initialize the clock system */
     cpu_clock_init();
-
-    /* set pendSV interrupt to lowest possible priority */
-    NVIC_SetPriority(PendSV_IRQn, 0xff);
 }
 
 static inline void modem_clock_init(void)

--- a/cpu/kw2x/include/cpu_conf.h
+++ b/cpu/kw2x/include/cpu_conf.h
@@ -43,17 +43,12 @@ extern "C"
 #endif
 
 /**
- * @name Kernel configuration
- *
+ * @brief   ARM Cortex-M specific CPU configuration
  * @{
  */
-#define THREAD_EXTRA_STACKSIZE_PRINTF     (1024)
-
-#ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT    (1024)
-#endif
-
-#define THREAD_STACKSIZE_IDLE       (256)
+#define CPU_DEFAULT_IRQ_PRIO            (1U)
+#define CPU_IRQ_NUMOF                   (65U)
+#define CPU_FLASH_BASE                  (0x00000000)
 /** @} */
 
 /**
@@ -65,17 +60,6 @@ extern "C"
  * @brief Pointer to CPU_ID
  */
 #define CPUID_ID_PTR                     ((void *)(&(SIM_UIDH)))
-
-/**
- * @name UART0 buffer size definition for compatibility reasons.
- *
- * TODO: remove once the remodeling of the uart0 driver is done.
- * @{
- */
-#ifndef UART0_BUFSIZE
-#define UART0_BUFSIZE                    (128)
-#endif
-/** @} */
 
 #define TRANSCEIVER_BUFFER_SIZE          (3) /**< Buffer Size for Transceiver Module */
 

--- a/cpu/lpc1768/cpu.c
+++ b/cpu/lpc1768/cpu.c
@@ -24,6 +24,6 @@
  */
 void cpu_init(void)
 {
-    /* set pendSV interrupt to lowest possible priority */
-    NVIC_SetPriority(PendSV_IRQn, 0xff);
+    /* initialize the Cortex-M core */
+    cortexm_init();
 }

--- a/cpu/lpc1768/include/cpu_conf.h
+++ b/cpu/lpc1768/include/cpu_conf.h
@@ -14,7 +14,7 @@
  *
  * @file
  * @brief           CPU specific hwtimer configuration options
- *12
+ *
  * @author          Hauke Petersen <hauke.peterse@fu-berlin.de>
  */
 
@@ -28,32 +28,12 @@ extern "C" {
 #endif
 
 /**
- * @name Kernel configuration
- *
- * The absolute minimum stack size is 140 byte (68 byte for the tcb + 72 byte
- * for a complete context save).
- *
- * TODO: measure and adjust for the Cortex-M3
+ * @brief   ARM Cortex-M specific CPU configuration
  * @{
  */
-#define THREAD_EXTRA_STACKSIZE_PRINTF    (1024)
-
-#ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT   (1024)
-#endif
-
-#define THREAD_STACKSIZE_IDLE      (256)
-/** @} */
-
-/**
- * @name UART0 buffer size definition for compatibility reasons
- *
- * TODO: remove once the remodeling of the uart0 driver is done
- * @{
- */
-#ifndef UART0_BUFSIZE
-#define UART0_BUFSIZE                   (128)
-#endif
+#define CPU_DEFAULT_IRQ_PRIO            (1U)
+#define CPU_IRQ_NUMOF                   (35U)
+#define CPU_FLASH_BASE                  LPC_FLASH_BASE
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/nrf51822/cpu.c
+++ b/cpu/nrf51822/cpu.c
@@ -25,9 +25,8 @@
  */
 void cpu_init(void)
 {
-    /* set pendSV interrupt to lowest possible priority */
-    NVIC_SetPriority(PendSV_IRQn, 0xff);
-
+    /* initialize the Cortex-M core */
+    cortexm_init();
     /* set the correct clock source for HFCLK */
 #if CLOCK_CRYSTAL == 32
     NRF_CLOCK->XTALFREQ = CLOCK_XTALFREQ_XTALFREQ_32MHz;

--- a/cpu/nrf51822/include/cpu_conf.h
+++ b/cpu/nrf51822/include/cpu_conf.h
@@ -27,42 +27,17 @@ extern "C" {
 #endif
 
 /**
- * @name Kernel configuration
+ * @brief   ARM Cortex-M specific CPU configuration
  * @{
  */
-#define THREAD_EXTRA_STACKSIZE_PRINTF   (512)
-
-#ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT        (1024)
-#endif
-
-#define THREAD_STACKSIZE_IDLE           (256)
-/** @} */
-
-/**
- * @name UART0 buffer size definition for compatibility reasons
- *
- * TODO: remove once the remodeling of the uart0 driver is done
- * @{
- */
-#ifndef UART0_BUFSIZE
-#define UART0_BUFSIZE                   (128)
-#endif
+#define CPU_DEFAULT_IRQ_PRIO            (1U)
+#define CPU_IRQ_NUMOF                   (26U)
 /** @} */
 
 /**
  * @name Length in bytes for reading CPU_ID
  */
 #define CPUID_ID_LEN                    (8)
-
-/**
- * @brief Definition of different panic modes
- */
-typedef enum {
-    HARD_FAULT,             /**< hard fault */
-    NMI_HANDLER,            /**< non maskable interrupt */
-    DUMMY_HANDLER           /**< dummy interrupt handler */
-} panic_t;
 
 #ifdef __cplusplus
 }

--- a/cpu/nrf51822/startup.c
+++ b/cpu/nrf51822/startup.c
@@ -88,17 +88,17 @@ void reset_handler(void)
  */
 void dummy_handler(void)
 {
-    core_panic(DUMMY_HANDLER, "DUMMY ISR HANDLER");
+    core_panic(PANIC_DUMMY_HANDLER, "DUMMY ISR HANDLER");
 }
 
 void isr_nmi(void)
 {
-    core_panic(NMI_HANDLER, "NMI HANDLER");
+    core_panic(PANIC_NMI_HANDLER, "NMI HANDLER");
 }
 
 void isr_hard_fault(void)
 {
-    core_panic(HARD_FAULT, "HARD FAULT");
+    core_panic(PANIC_HARD_FAULT, "HARD FAULT");
 }
 
 /* Cortex-M specific interrupt vectors */

--- a/cpu/sam3x8e/cpu.c
+++ b/cpu/sam3x8e/cpu.c
@@ -26,7 +26,6 @@ void cpu_init(void)
 {
     /* disable the watchdog timer */
     WDT->WDT_MR |= WDT_MR_WDDIS;
-
-    /* set PendSV interrupt priority to lowest possible value */
-    NVIC_SetPriority(PendSV_IRQn, 0xff);
+    /* initialize the Cortex-M core */
+    cortexm_init();
 }

--- a/cpu/sam3x8e/include/cpu_conf.h
+++ b/cpu/sam3x8e/include/cpu_conf.h
@@ -25,40 +25,13 @@ extern "C" {
 #endif
 
 /**
- * @name Kernel configuration
- *
- * TODO: measure and adjust for the cortex-m3
+ * @brief   ARM Cortex-M specific CPU configuration
  * @{
  */
-#define THREAD_EXTRA_STACKSIZE_PRINTF    (2500)
-
-#ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT   (2500)
-#endif
-
-#define THREAD_STACKSIZE_IDLE      (512)
+#define CPU_DEFAULT_IRQ_PRIO            (1U)
+#define CPU_IRQ_NUMOF                   (45U)
+#define CPU_FLASH_BASE                  IFLASH0_ADDR
 /** @} */
-
-/**
- * @name UART0 buffer size definition for compatibility reasons
- *
- * TODO: remove once the remodeling of the uart0 driver is done
- * @{
- */
-#ifndef UART0_BUFSIZE
-#define UART0_BUFSIZE                   (128)
-#endif
-/** @} */
-
-/**
- * @brief Definition of different panic modes
- */
-typedef enum {
-    HARD_FAULT,
-    BUS_FAULT,
-    USAGE_FAULT,
-    DUMMY_HANDLER
-} panic_t;
 
 #ifdef __cplusplus
 }

--- a/cpu/sam3x8e/startup.c
+++ b/cpu/sam3x8e/startup.c
@@ -80,7 +80,7 @@ void reset_handler(void)
  */
 void dummy_handler(void)
 {
-    core_panic(DUMMY_HANDLER, "DUMMY HANDLER");
+    core_panic(PANIC_DUMMY_HANDLER, "DUMMY HANDLER");
 }
 
 void isr_nmi(void)
@@ -100,17 +100,17 @@ void isr_debug_mon(void)
 
 void isr_hard_fault(void)
 {
-    core_panic(HARD_FAULT, "HARD FAULT");
+    core_panic(PANIC_HARD_FAULT, "HARD FAULT");
 }
 
 void isr_bus_fault(void)
 {
-    core_panic(BUS_FAULT, "BUS FAULT");
+    core_panic(PANIC_BUS_FAULT, "BUS FAULT");
 }
 
 void isr_usage_fault(void)
 {
-    core_panic(USAGE_FAULT, "USAGE FAULT");
+    core_panic(PANIC_USAGE_FAULT, "USAGE FAULT");
 }
 
 /* Cortex-M specific interrupt vectors */

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -32,10 +32,8 @@ void cpu_init(void)
     PM->APBBMASK.reg |= PM_APBBMASK_PORT;
     /* disable the watchdog timer */
     WDT->CTRL.bit.ENABLE = 0;
-
-    /* set pendSV interrupt to lowest possible priority */
-    NVIC_SetPriority(PendSV_IRQn, 0xff);
-
+    /* initialize the Cortex-M core */
+    cortexm_init();
     /* Initialise clock sources and generic clocks */
     clk_init();
 }

--- a/cpu/samd21/include/cpu_conf.h
+++ b/cpu/samd21/include/cpu_conf.h
@@ -25,29 +25,12 @@ extern "C" {
 #endif
 
 /**
- * @name Kernel configuration
- *
- * TODO: measure and adjust for the cortex-m0
+ * @brief   ARM Cortex-M specific CPU configuration
  * @{
  */
-#define THREAD_EXTRA_STACKSIZE_PRINTF   (512)
-
-#ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT        (1024)
-#endif
-
-#define THREAD_STACKSIZE_IDLE           (256)
-/** @} */
-
-/**
- * @name UART0 buffer size definition for compatibility reasons
- *
- * TODO: remove once the remodeling of the uart0 driver is done
- * @{
- */
-#ifndef UART0_BUFSIZE
-#define UART0_BUFSIZE                   (128)
-#endif
+#define CPU_DEFAULT_IRQ_PRIO            (1U)
+#define CPU_IRQ_NUMOF                   PERIPH_COUNT_IRQn
+#define CPU_FLASH_BASE                  FLASH_ADDR
 /** @} */
 
 /**

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -28,8 +28,8 @@ void cpu_init(void)
     /* disable the watchdog timer */
     WDT->CTRLA.bit.ENABLE = 0;
 
-    /* set pendSV interrupt to lowest possible priority */
-    NVIC_SetPriority(PendSV_IRQn, 0xff);
+    /* initialize the Cortex-M core */
+    cortexm_init();
 
     /* turn on MCLK */
     MCLK->APBAMASK.reg |= MCLK_APBAMASK_GCLK;

--- a/cpu/saml21/include/cpu_conf.h
+++ b/cpu/saml21/include/cpu_conf.h
@@ -18,51 +18,25 @@
 #ifndef __CPU_CONF_H
 #define __CPU_CONF_H
 
+#include "atmel/saml21.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include "atmel/saml21.h"
-
 /**
- * @name Kernel configuration
- *
- * TODO: measure and adjust for the cortex-m0
+ * @brief   ARM Cortex-M specific CPU configuration
  * @{
  */
-#define THREAD_EXTRA_STACKSIZE_PRINTF    (512)
-
-#ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT   (1024)
-#endif
-
-#define THREAD_STACKSIZE_IDLE      (256)
-/** @} */
-
-/**
- * @name UART0 buffer size definition for compatibility reasons
- *
- * TODO: remove once the remodeling of the uart0 driver is done
- * @{
- */
-#ifndef UART0_BUFSIZE
-#define UART0_BUFSIZE                   (128)
-#endif
+#define CPU_DEFAULT_IRQ_PRIO            (1U)
+#define CPU_IRQ_NUMOF                   PERIPH_COUNT_IRQn
+#define CPU_FLASH_BASE                  FLASH_ADDR
 /** @} */
 
 /**
  * @brief CPUID_ID_LEN length of cpuid in bytes
  */
 #define CPUID_ID_LEN (16) /* 128 bits long, 16 bytes long */
-
-/**
- * @brief Definition of different panic modes
- */
-typedef enum {
-    NMI_HANDLER,            /**< non maskable interrupt */
-    HARD_FAULT,             /**< hard fault */
-    DUMMY_HANDLER           /**< dummy interrupt handler */
-} panic_t;
 
 #ifdef __cplusplus
 }

--- a/cpu/saml21/startup.c
+++ b/cpu/saml21/startup.c
@@ -82,12 +82,12 @@ void reset_handler(void)
 
 void isr_nmi(void)
 {
-    core_panic(NMI_HANDLER, "NMI HANDLER");
+    core_panic(PANIC_NMI_HANDLER, "NMI HANDLER");
 }
 
 void isr_hard_fault(void)
 {
-    core_panic(HARD_FAULT, "HARD FAULT");
+    core_panic(PANIC_HARD_FAULT, "HARD FAULT");
 }
 
 /**
@@ -95,7 +95,7 @@ void isr_hard_fault(void)
  */
 void dummy_handler(void)
 {
-    core_panic(DUMMY_HANDLER, "DUMMY HANDLER");
+    core_panic(PANIC_DUMMY_HANDLER, "DUMMY HANDLER");
 }
 
 /* Cortex-M specific interrupt vectors */

--- a/cpu/stm32f0/cpu.c
+++ b/cpu/stm32f0/cpu.c
@@ -28,11 +28,10 @@ static void clock_init(void);
  */
 void cpu_init(void)
 {
+    /* initialize the Cortex-M core */
+    cortexm_init();
     /* initialize the clock system */
     clock_init();
-
-    /* set pendSV interrupt to lowest possible priority */
-    NVIC_SetPriority(PendSV_IRQn, 0xff);
 }
 
 /**

--- a/cpu/stm32f0/include/cpu_conf.h
+++ b/cpu/stm32f0/include/cpu_conf.h
@@ -33,47 +33,17 @@ extern "C" {
 #endif
 
 /**
- * @name Kernel configuration
- *
- * The absolute minimum stack size is 140 byte (68 byte for the tcb + 72 byte
- * for a complete context save).
- *
- * TODO: measure and adjust for the Cortex-M0
+ * @brief   ARM Cortex-M specific CPU configuration
  * @{
  */
-#define THREAD_EXTRA_STACKSIZE_PRINTF    (512)
-
-#ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT   (512)
-#endif
-
-#define THREAD_STACKSIZE_IDLE      (192)
-/** @} */
-
-/**
- * @name UART0 buffer size definition for compatibility reasons
- *
- * TODO: remove once the remodeling of the uart0 driver is done
- * @{
- */
-#ifndef UART0_BUFSIZE
-#define UART0_BUFSIZE                   (128)
-#endif
+#define CPU_DEFAULT_IRQ_PRIO            (1U)
+#define CPU_IRQ_NUMOF                   (31U)
 /** @} */
 
 /**
  * @brief Length for reading CPU_ID
  */
 #define CPUID_ID_LEN                    (12)
-
-/**
- * @brief Definition of different panic modes
- */
-typedef enum {
-    HARD_FAULT,             /**< hard fault */
-    NMI_HANDLER,            /**< non maskable interrupt */
-    DUMMY_HANDLER           /**< dummy interrupt handler */
-} panic_t;
 
 #ifdef __cplusplus
 }

--- a/cpu/stm32f0/include/stm32f051x8.h
+++ b/cpu/stm32f0/include/stm32f051x8.h
@@ -85,7 +85,7 @@ typedef enum
 /******  Cortex-M0 Processor Exceptions Numbers **************************************************************/
   NonMaskableInt_IRQn         = -14,    /*!< 2 Non Maskable Interrupt                                        */
   HardFault_IRQn              = -13,    /*!< 3 Cortex-M0 Hard Fault Interrupt                                */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M0 SV Call Interrupt                                  */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M0 SV Call Interrupt                                  */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M0 Pend SV Interrupt                                  */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M0 System Tick Interrupt                              */
 

--- a/cpu/stm32f0/include/stm32f091xc.h
+++ b/cpu/stm32f0/include/stm32f091xc.h
@@ -84,7 +84,7 @@ typedef enum
 /******  Cortex-M0 Processor Exceptions Numbers **************************************************************/
   NonMaskableInt_IRQn         = -14,    /*!< 2 Non Maskable Interrupt                                        */
   HardFault_IRQn              = -13,    /*!< 3 Cortex-M0 Hard Fault Interrupt                                */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M0 SV Call Interrupt                                  */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M0 SV Call Interrupt                                  */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M0 Pend SV Interrupt                                  */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M0 System Tick Interrupt                              */
 

--- a/cpu/stm32f0/startup.c
+++ b/cpu/stm32f0/startup.c
@@ -80,17 +80,17 @@ void reset_handler(void)
  */
 void dummy_handler(void)
 {
-    core_panic(DUMMY_HANDLER, "DUMMY HANDLER");
+    core_panic(PANIC_DUMMY_HANDLER, "DUMMY HANDLER");
 }
 
 void isr_nmi(void)
 {
-    core_panic(NMI_HANDLER, "NMI HANDLER");
+    core_panic(PANIC_NMI_HANDLER, "NMI HANDLER");
 }
 
 void isr_hard_fault(void)
 {
-    core_panic(HARD_FAULT, "HARD FAULT");
+    core_panic(PANIC_HARD_FAULT, "HARD FAULT");
 }
 
 /* Cortex-M specific interrupt vectors */

--- a/cpu/stm32f1/cpu.c
+++ b/cpu/stm32f1/cpu.c
@@ -29,10 +29,8 @@ static void clk_init(void);
 
 void cpu_init(void)
 {
-    /* set PendSV priority to the lowest possible priority */
-    NVIC_SetPriority(PendSV_IRQn, 0xff);
-    /* configure the vector table location to internal flash */
-    SCB->VTOR = FLASH_BASE;
+    /* initialize the Cortex-M core */
+    cortexm_init();
     /* initialize system clocks */
     clk_init();
 }

--- a/cpu/stm32f1/include/cpu_conf.h
+++ b/cpu/stm32f1/include/cpu_conf.h
@@ -30,29 +30,12 @@ extern "C" {
 #endif
 
 /**
- * @name Kernel configuration
- *
- * TODO: measure and adjust for the cortex-m3
+ * @brief   ARM Cortex-M specific CPU configuration
  * @{
  */
-#define THREAD_EXTRA_STACKSIZE_PRINTF    (1024)
-
-#ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT   (1024)
-#endif
-
-#define THREAD_STACKSIZE_IDLE      (256)
-/** @} */
-
-/**
- * @name UART0 buffer size definition for compatibility reasons
- *
- * TODO: remove once the remodeling of the uart0 driver is done
- * @{
- */
-#ifndef UART0_BUFSIZE
-#define UART0_BUFSIZE                   (128)
-#endif
+#define CPU_DEFAULT_IRQ_PRIO            (1U)
+#define CPU_IRQ_NUMOF                   (60U)
+#define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
 /**
@@ -60,20 +43,6 @@ extern "C" {
  */
 #define CPUID_ID_LEN                    (12)
 
-/**
- * @brief Definition of different panic modes
- */
-typedef enum {
-    HARD_FAULT,
-    WATCHDOG,
-    BUS_FAULT,
-    USAGE_FAULT,
-    DUMMY_HANDLER
-} panic_t;
-
-/**
- * @brief Buffer size to use by the transceiver
- */
 #define TRANSCEIVER_BUFFER_SIZE (3)
 
 /**

--- a/cpu/stm32f1/startup.c
+++ b/cpu/stm32f1/startup.c
@@ -82,8 +82,7 @@ void reset_handler(void)
  */
 void dummy_handler(void)
 {
-    core_panic(DUMMY_HANDLER, "DUMMY HANDLER");
-    while (1) {asm ("nop");}
+    core_panic(PANIC_DUMMY_HANDLER, "DUMMY HANDLER");
 }
 
 void isr_nmi(void)
@@ -103,20 +102,17 @@ void isr_debug_mon(void)
 
 void isr_hard_fault(void)
 {
-    core_panic(HARD_FAULT, "HARD FAULT");
-    while (1) {asm ("nop");}
+    core_panic(PANIC_HARD_FAULT, "HARD FAULT");
 }
 
 void isr_bus_fault(void)
 {
-    core_panic(BUS_FAULT, "BUS FAULT");
-    while (1) {asm ("nop");}
+    core_panic(PANIC_BUS_FAULT, "BUS FAULT");
 }
 
 void isr_usage_fault(void)
 {
-    core_panic(USAGE_FAULT, "USAGE FAULT");
-    while (1) {asm ("nop");}
+    core_panic(PANIC_USAGE_FAULT, "USAGE FAULT");
 }
 
 /* Cortex-M specific interrupt vectors */

--- a/cpu/stm32f3/cpu.c
+++ b/cpu/stm32f3/cpu.c
@@ -21,11 +21,6 @@
 #include "cpu.h"
 #include "periph_conf.h"
 
-/**
- * @name Pattern to write into the Coprocessor Access Control Register to allow full FPU access
- */
-#define FULL_FPU_ACCESS         (0x00f00000)
-
 static void cpu_clock_init(void);
 
 /**
@@ -33,17 +28,10 @@ static void cpu_clock_init(void);
  */
 void cpu_init(void)
 {
-    /* give full access to the FPU */
-    SCB->CPACR |= (uint32_t)FULL_FPU_ACCESS;
-
-    /* configure the vector table location to internal flash */
-    SCB->VTOR = FLASH_BASE;
-
+    /* initialize the Cortex-M core */
+    cortexm_init();
     /* initialize the clock system */
     cpu_clock_init();
-
-    /* set pendSV interrupt to lowest possible priority */
-    NVIC_SetPriority(PendSV_IRQn, 0xff);
 }
 
 /**

--- a/cpu/stm32f3/include/cpu_conf.h
+++ b/cpu/stm32f3/include/cpu_conf.h
@@ -28,30 +28,17 @@
 #include "stm32f334x8.h"
 #endif
 
-/**
- * @name Kernel configuration
- *
- * TODO: measure and adjust for the Cortex-M4f
- * @{
- */
-#define THREAD_EXTRA_STACKSIZE_PRINTF    (1024)
-
-#ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT   (1024)
+#ifdef __cplusplus
+extern "C" {
 #endif
 
-#define THREAD_STACKSIZE_IDLE      (256)
-/** @} */
-
 /**
- * @name UART0 buffer size definition for compatibility reasons
- *
- * TODO: remove once the remodeling of the uart0 driver is done
+ * @brief   ARM Cortex-M specific CPU configuration
  * @{
  */
-#ifndef UART0_BUFSIZE
-#define UART0_BUFSIZE                   (128)
-#endif
+#define CPU_DEFAULT_IRQ_PRIO            (1U)
+#define CPU_IRQ_NUMOF                   (82U)
+#define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
 /**
@@ -59,9 +46,6 @@
  */
 #define CPUID_ID_LEN                    (12)
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #ifdef __cplusplus
 }

--- a/cpu/stm32f4/cpu.c
+++ b/cpu/stm32f4/cpu.c
@@ -21,10 +21,6 @@
 #include "cpu.h"
 #include "periph_conf.h"
 
-/**
- * @name Pattern to write into the Coprocessor Access Control Register to allow full FPU access
- */
-#define FULL_FPU_ACCESS         (0x00f00000)
 
 
 static void cpu_clock_init(void);
@@ -34,17 +30,10 @@ static void cpu_clock_init(void);
  */
 void cpu_init(void)
 {
-    /* give full access to the FPU */
-    SCB->CPACR |= (uint32_t)FULL_FPU_ACCESS;
-
-    /* configure the vector table location to internal flash */
-    SCB->VTOR = FLASH_BASE;
-
+    /* initialize the Cortex-M core */
+    cortexm_init();
     /* initialize the clock system */
     cpu_clock_init();
-
-    /* set pendSV interrupt to lowest possible priority */
-    NVIC_SetPriority(PendSV_IRQn, 0xff);
 }
 
 /**

--- a/cpu/stm32f4/include/cpu_conf.h
+++ b/cpu/stm32f4/include/cpu_conf.h
@@ -21,36 +21,23 @@
 #ifndef __CPU_CONF_H
 #define __CPU_CONF_H
 
-#ifdef CPU_MODEL_STM32F407VG
+#if defined(CPU_MODEL_STM32F407VG)
 #include "stm32f407xx.h"
-#elif defined CPU_MODEL_STM32F415RG
+#elif defined(CPU_MODEL_STM32F415RG)
 #include "stm32f415xx.h"
 #endif
 
-/**
- * @name Kernel configuration
- *
- * TODO: measure and adjust for the Cortex-M4f
- * @{
- */
-#define THREAD_EXTRA_STACKSIZE_PRINTF    (2500)
-
-#ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT   (2500)
+#ifdef __cplusplus
+extern "C" {
 #endif
 
-#define THREAD_STACKSIZE_IDLE      (512)
-/** @} */
-
 /**
- * @name UART0 buffer size definition for compatibility reasons
- *
- * TODO: remove once the remodeling of the uart0 driver is done
+ * @brief   ARM Cortex-M specific CPU configuration
  * @{
  */
-#ifndef UART0_BUFSIZE
-#define UART0_BUFSIZE                   (128)
-#endif
+#define CPU_DEFAULT_IRQ_PRIO            (1U)
+#define CPU_IRQ_NUMOF                   (82U)
+#define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
 /**
@@ -67,10 +54,6 @@
 #define RX_BUF_SIZE                     (10)
 #endif
 /** @} */
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #ifdef __cplusplus
 }

--- a/cpu/stm32l1/cpu.c
+++ b/cpu/stm32l1/cpu.c
@@ -26,14 +26,10 @@ static void clk_init(void);
 
 void cpu_init(void)
 {
-    /* set PendSV priority to the lowest possible priority */
-    NVIC_SetPriority(PendSV_IRQn, 0xff);
-
+    /* initialize the Cortex-M core */
+    cortexm_init();
     /* initialize system clocks */
     clk_init();
-
-    /* configure the vector table location to internal flash */
-    SCB->VTOR = FLASH_BASE;
 }
 
 /**

--- a/cpu/stm32l1/include/cpu_conf.h
+++ b/cpu/stm32l1/include/cpu_conf.h
@@ -28,45 +28,18 @@ extern "C" {
 #endif
 
 /**
- * @name Kernel configuration
- *
+ * @brief   ARM Cortex-M specific CPU configuration
  * @{
  */
-#define THREAD_EXTRA_STACKSIZE_PRINTF    (1024)
-
-#ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT   (1024)
-#endif
-
-#define THREAD_STACKSIZE_IDLE      (256)
-/** @} */
-
-/**
- * @name UART0 buffer size definition for compatibility reasons
- *
- * TODO: remove once the remodeling of the uart0 driver is done
- * @{
- */
-#ifndef UART0_BUFSIZE
-#define UART0_BUFSIZE                   (128)
-#endif
+#define CPU_DEFAULT_IRQ_PRIO            (1U)
+#define CPU_IRQ_NUMOF                   (57U)
+#define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
 /**
  * @name Length for reading CPU_ID
  */
 #define CPUID_ID_LEN                      (12)
-
-/**
- * @name Definition of different panic modes
- */
-typedef enum {
-    HARD_FAULT,
-    WATCHDOG,
-    BUS_FAULT,
-    USAGE_FAULT,
-    DUMMY_HANDLER
-} panic_t;
 
 #define TRANSCEIVER_BUFFER_SIZE (3)
 

--- a/cpu/stm32l1/include/stm32l1xx.h
+++ b/cpu/stm32l1/include/stm32l1xx.h
@@ -179,7 +179,7 @@ typedef enum IRQn
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                 */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                         */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                       */
-  SVC_IRQn                    = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M3 SV Call Interrupt                          */
   DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M3 Debug Monitor Interrupt                    */
   PendSV_IRQn                 = -2,     /*!< 14 Cortex-M3 Pend SV Interrupt                          */
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M3 System Tick Interrupt                      */

--- a/cpu/stm32l1/startup.c
+++ b/cpu/stm32l1/startup.c
@@ -82,8 +82,7 @@ void reset_handler(void)
  */
 void dummy_handler(void)
 {
-    core_panic(DUMMY_HANDLER, "DUMMY HANDLER");
-    while (1) {asm ("nop");}
+    core_panic(PANIC_DUMMY_HANDLER, "DUMMY HANDLER");
 }
 
 void isr_nmi(void)
@@ -103,19 +102,19 @@ void isr_debug_mon(void)
 
 void isr_hard_fault(void)
 {
-    core_panic(HARD_FAULT, "HARD FAULT");
+    core_panic(PANIC_HARD_FAULT, "HARD FAULT");
     while (1) {asm ("nop");}
 }
 
 void isr_bus_fault(void)
 {
-    core_panic(BUS_FAULT, "BUS FAULT");
+    core_panic(PANIC_BUS_FAULT, "BUS FAULT");
     while (1) {asm ("nop");}
 }
 
 void isr_usage_fault(void)
 {
-    core_panic(USAGE_FAULT, "USAGE FAULT");
+    core_panic(PANIC_USAGE_FAULT, "USAGE FAULT");
     while (1) {asm ("nop");}
 }
 

--- a/sys/include/board_uart0.h
+++ b/sys/include/board_uart0.h
@@ -21,7 +21,8 @@
 #define __BOARD_UART0_H
 
 #include "kernel_types.h"
-#include "cpu_conf.h"   /* To give user access to UART0_BUFSIZE */
+#include "cpu.h"        /* To give user access to UART0_BUFSIZE */
+#include "cpu_conf.h"   /* Some CPUs define this in cpu_conf.h... */
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Based on #3023

- added a centralized core implementation for all cortex CPUs
- moved default stack size defines to cpu.h in cortexm_common
- moved uart0 bufsize define to cpu.h in cortexm_common
- moved typed of panic_t to cpu.h in cortexm_common
- adapted all effected CPUs

EDIT:
Forgot to explain one feature: The device specific interrupt priorities are now initialized on startup to a default value. As we are using only one interrupt priority for everything to prevent interrupt preemtion, this saves the need to set the interrupt priority in during peripheral initialization -> helps to keep the periph code smaller.