### PR TITLE
Various warning fixes

### DIFF
--- a/cpu/cortexm_common/include/core_cmFunc.h
+++ b/cpu/cortexm_common/include/core_cmFunc.h
@@ -598,6 +598,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_FPSCR(void)
 }
 
 
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
 /** \brief  Set FPSCR
 
     This function assigns the given value to the Floating Point Status/Control register.
@@ -606,13 +607,12 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_FPSCR(void)
  */
 __attribute__( ( always_inline ) ) __STATIC_INLINE void __set_FPSCR(uint32_t fpscr)
 {
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
   /* Empty asm statement works as a scheduling barrier */
   __ASM volatile ("");
   __ASM volatile ("VMSR fpscr, %0" : : "r" (fpscr) : "vfpcc");
   __ASM volatile ("");
-#endif
 }
+#endif
 
 #endif /* (__CORTEX_M == 0x04) || (__CORTEX_M == 0x07) */
 

--- a/cpu/k60/devio/devio-null.c
+++ b/cpu/k60/devio/devio-null.c
@@ -25,22 +25,33 @@
 
 int  devnull_open_r(struct _reent *r, const char *path, int flags, int mode)
 {
+    (void) r;
+    (void) path;
+    (void) flags;
+    (void) mode;
     return 0;
 }
 
 int  devnull_close_r(struct _reent *r, int fd)
 {
+    (void) r;
+    (void) fd;
     return 0;
 }
 
 long devnull_write_r(struct _reent *r, int fd, const char *ptr, int len)
 {
+    (void) r;
+    (void) fd;
+    (void) ptr;
     /* Aaand... it's gone!*/
     return len;
 }
 
 long devnull_read_r(struct _reent *r, int fd, char *ptr, int len)
 {
+    (void) r;
+    (void) fd;
     /* Read null bytes */
     memset(ptr, '\0', len);
     return len;
@@ -48,12 +59,20 @@ long devnull_read_r(struct _reent *r, int fd, char *ptr, int len)
 
 long devnull_lseek_r(struct _reent *r, int fd, int ptr, int dir)
 {
+    (void) r;
+    (void) fd;
+    (void) ptr;
+    (void) dir;
     r->_errno = ENOSYS;
     return -1;
 }
 
 long devnull_fstat_r(struct _reent *r, int fd, char *ptr, int len)
 {
+    (void) r;
+    (void) fd;
+    (void) ptr;
+    (void) len;
     r->_errno = ENOSYS;
     return -1;
 }

--- a/cpu/k60/devio/devio-uart.c
+++ b/cpu/k60/devio/devio-uart.c
@@ -26,6 +26,8 @@
 static inline long uart_write_r(uart_t uart_num, struct _reent *r, int fd, const char *ptr,
                                 int len)
 {
+    (void) r;
+    (void) fd;
     int i = 0;
 
     while (i < len) {
@@ -39,6 +41,11 @@ static inline long uart_write_r(uart_t uart_num, struct _reent *r, int fd, const
 static long uart_read_r(uart_t uart_num, struct _reent *r, int fd, char *ptr, int len)
 {
     /* not yet implemented */
+    (void) uart_num;
+    (void) r;
+    (void) fd;
+    (void) ptr;
+    (void) len;
     return 0;
 }
 

--- a/cpu/k60/syscalls.c
+++ b/cpu/k60/syscalls.c
@@ -67,19 +67,17 @@ static ringbuffer_t rx_buf;
  */
 static void stdio_rx_cb(void *arg, char data)
 {
-#ifndef MODULE_UART0
     (void)arg;
 
-    ringbuffer_add_one(&rx_buf, data);
-    mutex_unlock(&uart_rx_mutex);
-#else
-
+#ifdef MODULE_UART0
     if (uart0_handler_pid) {
         uart0_handle_incoming(data);
 
         uart0_notify_thread();
     }
-
+#else
+    ringbuffer_add_one(&rx_buf, data);
+    mutex_unlock(&uart_rx_mutex);
 #endif
 }
 
@@ -119,6 +117,7 @@ _exit(int code)
     /* See local variable `status` during debugger break. */
     asm volatile ("bkpt #0");
 #else
+    (void) code;
     NVIC_SystemReset();
 #endif
 

--- a/cpu/kinetis_common/hwtimer_arch.c
+++ b/cpu/kinetis_common/hwtimer_arch.c
@@ -87,6 +87,7 @@ inline static void hwtimer_stop(void)
 
 void hwtimer_arch_init(void (*handler)(int), uint32_t fcpu)
 {
+    (void) fcpu; /* fcpu does not affect the Low power timer module frequency */
     timeout_handler = handler;
 
     /* unlock LPTIMER_DEV */
@@ -146,7 +147,7 @@ void hwtimer_arch_disable_interrupt(void)
 
 void hwtimer_arch_set(unsigned long offset, short timer)
 {
-    (void)timer;
+    (void)timer; /* we only support one timer */
     stimer.counter32b += lptmr_get_cnr();
     hwtimer_stop();
 
@@ -165,7 +166,7 @@ void hwtimer_arch_set(unsigned long offset, short timer)
 
 void hwtimer_arch_set_absolute(unsigned long value, short timer)
 {
-    (void)timer;
+    (void)timer; /* we only support one timer */
     stimer.counter32b += lptmr_get_cnr();
     hwtimer_stop();
 
@@ -184,6 +185,7 @@ void hwtimer_arch_set_absolute(unsigned long value, short timer)
 
 void hwtimer_arch_unset(short timer)
 {
+    (void)timer; /* we only support one timer */
     stimer.counter32b += lptmr_get_cnr();
     hwtimer_stop();
     stimer.diff = 0;

--- a/cpu/kinetis_common/i2c.c
+++ b/cpu/kinetis_common/i2c.c
@@ -155,6 +155,8 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
 int i2c_init_slave(i2c_t dev, uint8_t address)
 {
     /* TODO: implement slave mode */
+    (void) dev;
+    (void) address;
     return -1;
 }
 

--- a/cpu/kinetis_common/random_rnga.c
+++ b/cpu/kinetis_common/random_rnga.c
@@ -35,7 +35,7 @@ void random_init(void)
 
 int random_read(char *buf, unsigned int num)
 {
-    int count = 0;
+    unsigned int count = 0;
 
     /* self-seeding */
     while (!(KINETIS_RNGA->SR & RNG_SR_OREG_LVL_MASK));
@@ -55,7 +55,7 @@ int random_read(char *buf, unsigned int num)
         }
     }
 
-    return count;
+    return (int)count;
 }
 
 void random_poweron(void)

--- a/cpu/kinetis_common/random_rngb.c
+++ b/cpu/kinetis_common/random_rngb.c
@@ -37,7 +37,7 @@ void random_init(void)
 
 int random_read(char *buf, unsigned int num)
 {
-    int count = 0;
+    unsigned int count = 0;
 
     while (count < num) {
         uint32_t tmp;
@@ -54,7 +54,7 @@ int random_read(char *buf, unsigned int num)
         }
     }
 
-    return count;
+    return (int)count;
 }
 
 void random_poweron(void)

--- a/cpu/kinetis_common/spi.c
+++ b/cpu/kinetis_common/spi.c
@@ -832,6 +832,9 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
 
     spi_dev->RSER = (uint32_t)0;
 
+    /* set callback */
+    spi_config[dev].cb = cb;
+
     return 0;
 }
 

--- a/cpu/kinetis_common/spi.c
+++ b/cpu/kinetis_common/spi.c
@@ -464,12 +464,12 @@ static spi_state_t spi_config[SPI_NUMOF];
  * @return The actual achieved frequency on success
  * @return Less than 0 on error.
  */
-static int find_closest_baudrate_scalers(const uint32_t module_clock, const uint32_t target_clock,
+static long find_closest_baudrate_scalers(const uint32_t module_clock, const long target_clock,
         uint8_t *closest_prescaler, uint8_t *closest_scaler)
 {
     uint8_t i;
     uint8_t k;
-    int freq;
+    long freq;
     static const uint8_t num_scalers = 16;
     static const uint8_t num_prescalers = 4;
     static const int br_scalers[16] = {
@@ -478,7 +478,7 @@ static int find_closest_baudrate_scalers(const uint32_t module_clock, const uint
     };
     static const int br_prescalers[4] = {2, 3, 5, 7};
 
-    int closest_frequency = -1;
+    long closest_frequency = -1;
 
     /* Test all combinations until we arrive close to the target clock */
     for (i = 0; i < num_prescalers; ++i) {
@@ -533,18 +533,18 @@ static int find_closest_baudrate_scalers(const uint32_t module_clock, const uint
  * @return The actual achieved frequency on success
  * @return Less than 0 on error.
  */
-static int find_closest_delay_scalers(const uint32_t module_clock, const uint32_t target_freq,
+static long find_closest_delay_scalers(const uint32_t module_clock, const long target_freq,
                                       uint8_t *closest_prescaler, uint8_t *closest_scaler)
 {
     uint8_t i;
     uint8_t k;
-    int freq;
+    long freq;
     int prescaler;
     int scaler;
     static const uint8_t num_scalers = 16;
     static const uint8_t num_prescalers = 4;
 
-    int closest_frequency = -1;
+    long closest_frequency = -1;
 
     /* Test all combinations until we arrive close to the target clock */
     for (i = 0; i < num_prescalers; ++i) {
@@ -1041,13 +1041,13 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
     /* Default: send idle data */
     byte_out = (uint8_t)SPI_IDLE_DATA;
 
-    for (i = 0; i < length; i++) {
+    for (i = 0; i < (int)length; i++) {
         if (out != NULL) {
             /* Send given out data */
             byte_out = (uint8_t)out[i];
         }
 
-        if (i >= length - 1) {
+        if (i >= (int)length - 1) {
             /* Last byte, set End-of-Queue flag, clear Continue flag. */
             flags &= ~(SPI_PUSHR_CONT_MASK);
             flags |= SPI_PUSHR_EOQ_MASK;
@@ -1248,13 +1248,13 @@ int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int 
     /* Default: send idle data */
     byte_out = (uint8_t)SPI_IDLE_DATA;
 
-    for (i = 0; i < length; i++) {
+    for (i = 0; i < (int)length; i++) {
         if (out != NULL) {
             /* Send given out data */
             byte_out = (uint8_t)out[i];
         }
 
-        if (i >= length - 1) {
+        if (i >= (int)length - 1) {
             /* Last byte, set End-of-Queue flag, clear Continue flag. */
             flags &= ~(SPI_PUSHR_CONT_MASK);
             flags |= SPI_PUSHR_EOQ_MASK;

--- a/cpu/kinetis_common/spi.c
+++ b/cpu/kinetis_common/spi.c
@@ -352,8 +352,11 @@
 /**
  * @brief Array holding one pre-initialized mutex for each hardware SPI device
  */
-/* TODO: Avoid adding duplicate entries with the same index. GCC warns about it
- * but it works. It does look strange in the preprocessed output, however.
+/* We try to avoid adding duplicate entries with the same index by comparing the
+ * SPI_x_INDEX macros, the #if statements become quite long though.
+ *
+ * If not checking for multiple initializations GCC will warn about it
+ * but the binary still works. It does look strange in the preprocessed output, however.
  *
  * The warning message is:
  * warning: initialized field overwritten [-Woverride-init]
@@ -371,25 +374,34 @@ static mutex_t locks[] =  {
 #if SPI_0_EN
     [SPI_0_INDEX] = MUTEX_INIT,
 #endif
-#if SPI_1_EN
+#if SPI_1_EN && (SPI_1_INDEX != SPI_0_INDEX)
     [SPI_1_INDEX] = MUTEX_INIT,
 #endif
-#if SPI_2_EN
+#if SPI_2_EN && (SPI_2_INDEX != SPI_0_INDEX) && (SPI_2_INDEX != SPI_1_INDEX)
     [SPI_2_INDEX] = MUTEX_INIT,
 #endif
-#if SPI_3_EN
+#if SPI_3_EN && (SPI_3_INDEX != SPI_0_INDEX) && (SPI_3_INDEX != SPI_1_INDEX) \
+    && (SPI_3_INDEX != SPI_2_INDEX)
     [SPI_3_INDEX] = MUTEX_INIT,
 #endif
-#if SPI_4_EN
+#if SPI_4_EN && (SPI_4_INDEX != SPI_0_INDEX) && (SPI_4_INDEX != SPI_1_INDEX) \
+    && (SPI_4_INDEX != SPI_2_INDEX) && (SPI_4_INDEX != SPI_3_INDEX)
     [SPI_4_INDEX] = MUTEX_INIT,
 #endif
-#if SPI_5_EN
+#if SPI_5_EN && (SPI_5_INDEX != SPI_0_INDEX) && (SPI_5_INDEX != SPI_1_INDEX) \
+    && (SPI_5_INDEX != SPI_2_INDEX) && (SPI_5_INDEX != SPI_3_INDEX) \
+    && (SPI_5_INDEX != SPI_4_INDEX)
     [SPI_5_INDEX] = MUTEX_INIT,
 #endif
-#if SPI_6_EN
+#if SPI_6_EN && (SPI_6_INDEX != SPI_0_INDEX) && (SPI_6_INDEX != SPI_1_INDEX) \
+    && (SPI_6_INDEX != SPI_2_INDEX) && (SPI_6_INDEX != SPI_3_INDEX) \
+    && (SPI_6_INDEX != SPI_4_INDEX) && (SPI_6_INDEX != SPI_5_INDEX)
     [SPI_6_INDEX] = MUTEX_INIT,
 #endif
-#if SPI_7_EN
+#if SPI_7_EN && (SPI_7_INDEX != SPI_0_INDEX) && (SPI_7_INDEX != SPI_1_INDEX) \
+    && (SPI_7_INDEX != SPI_2_INDEX) && (SPI_7_INDEX != SPI_3_INDEX) \
+    && (SPI_7_INDEX != SPI_4_INDEX) && (SPI_7_INDEX != SPI_5_INDEX) \
+    && (SPI_7_INDEX != SPI_6_INDEX)
     [SPI_7_INDEX] = MUTEX_INIT,
 #endif
 };

--- a/cpu/kinetis_common/timer.c
+++ b/cpu/kinetis_common/timer.c
@@ -144,6 +144,7 @@ int timer_set(tim_t dev, int channel, unsigned int timeout)
 
 int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 {
+    (void) channel; /* we only support one channel */
     switch (dev) {
 #if TIMER_0_EN
 
@@ -179,6 +180,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 
 int timer_clear(tim_t dev, int channel)
 {
+    (void) channel; /* we only support one channel */
     switch (dev) {
 #if TIMER_0_EN
 

--- a/cpu/stm32f4/periph/i2c.c
+++ b/cpu/stm32f4/periph/i2c.c
@@ -218,6 +218,8 @@ static void _toggle_pins(GPIO_TypeDef *port_scl, GPIO_TypeDef *port_sda, int pin
 int i2c_init_slave(i2c_t dev, uint8_t address)
 {
     /* TODO: implement slave mode */
+    (void) dev;
+    (void) address;
     return -1;
 }
 

--- a/cpu/stm32f4/periph/random.c
+++ b/cpu/stm32f4/periph/random.c
@@ -34,7 +34,7 @@ int random_read(char *buf, unsigned int num)
 {
     /* cppcheck-suppress variableScope */
     uint32_t tmp;
-    int count = 0;
+    unsigned int count = 0;
 
     while (count < num) {
         /* wait for random data to be ready to read */
@@ -48,7 +48,7 @@ int random_read(char *buf, unsigned int num)
         }
     }
 
-    return count;
+    return (int)count;
 }
 
 void random_poweron(void)

--- a/cpu/stm32f4/periph/spi.c
+++ b/cpu/stm32f4/periph/spi.c
@@ -352,20 +352,23 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
 
 int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
 {
+    int trans_bytes = 0;
 
-    int i, trans_ret, trans_bytes = 0;
-    char in_temp;
+    for (unsigned int i = 0; i < length; i++) {
+        char in_temp;
+        int trans_ret;
 
-    for (i = 0; i < length; i++) {
         if (out) {
             trans_ret = spi_transfer_byte(dev, out[i], &in_temp);
         }
         else {
             trans_ret = spi_transfer_byte(dev, 0, &in_temp);
         }
+
         if (trans_ret < 0) {
             return -1;
         }
+
         if (in != NULL) {
             in[i] = in_temp;
         }

--- a/drivers/at86rf231/at86rf231.c
+++ b/drivers/at86rf231/at86rf231.c
@@ -66,6 +66,7 @@ void at86rf231_init(kernel_pid_t tpid)
 
 int at86rf231_initialize(netdev_t *dev)
 {
+    (void)dev;
     at86rf231_gpio_spi_interrupts_init();
 
     at86rf231_reset();
@@ -234,6 +235,7 @@ int at86rf231_rem_raw_recv_callback(netdev_t *dev,
                                     netdev_802154_raw_packet_cb_t recv_cb)
 {
     (void)dev;
+    (void)recv_cb;
 
     at86rf231_raw_packet_cb = NULL;
     return 0;
@@ -256,6 +258,7 @@ int at86rf231_rem_data_recv_callback(netdev_t *dev,
                                      netdev_rcv_data_cb_t recv_cb)
 {
     (void)dev;
+    (void)recv_cb;
 
     at86rf231_data_packet_cb = NULL;
     return 0;

--- a/sys/newlib/syscalls.c
+++ b/sys/newlib/syscalls.c
@@ -64,17 +64,17 @@ static ringbuffer_t rx_buf;
  */
 void rx_cb(void *arg, char data)
 {
-#ifndef MODULE_UART0
     (void)arg;
 
-    ringbuffer_add_one(&rx_buf, data);
-    mutex_unlock(&uart_rx_mutex);
-#else
+#ifdef MODULE_UART0
     if (uart0_handler_pid) {
         uart0_handle_incoming(data);
 
         uart0_notify_thread();
     }
+#else
+    ringbuffer_add_one(&rx_buf, data);
+    mutex_unlock(&uart_rx_mutex);
 #endif
 }
 
@@ -162,6 +162,8 @@ int _getpid(void)
 __attribute__ ((weak))
 int _kill_r(struct _reent *r, int pid, int sig)
 {
+    (void) pid;
+    (void) sig;
     r->_errno = ESRCH;                      /* not implemented yet */
     return -1;
 }
@@ -177,6 +179,8 @@ int _kill_r(struct _reent *r, int pid, int sig)
  */
 int _open_r(struct _reent *r, const char *name, int mode)
 {
+    (void) name;
+    (void) mode;
     r->_errno = ENODEV;                     /* not implemented yet */
     return -1;
 }
@@ -229,13 +233,15 @@ int _read_r(struct _reent *r, int fd, void *buffer, unsigned int count)
  */
 int _write_r(struct _reent *r, int fd, const void *data, unsigned int count)
 {
-    int i = 0;
+    (void) r;
+    (void) fd;
+    unsigned int i = 0;
 
     while (i < count) {
         uart_write_blocking(STDIO, ((char*)data)[i++]);
     }
 
-    return i;
+    return (int)i;
 }
 
 /**
@@ -248,6 +254,7 @@ int _write_r(struct _reent *r, int fd, const void *data, unsigned int count)
  */
 int _close_r(struct _reent *r, int fd)
 {
+    (void) fd;
     r->_errno = ENODEV;                     /* not implemented yet */
     return -1;
 }
@@ -264,6 +271,9 @@ int _close_r(struct _reent *r, int fd)
  */
 _off_t _lseek_r(struct _reent *r, int fd, _off_t pos, int dir)
 {
+    (void) fd;
+    (void) pos;
+    (void) dir;
     r->_errno = ENODEV;                     /* not implemented yet */
     return -1;
 }
@@ -277,8 +287,10 @@ _off_t _lseek_r(struct _reent *r, int fd, _off_t pos, int dir)
  *
  * @return      TODO
  */
-int _fstat_r(struct _reent *r, int fd, struct stat * st)
+int _fstat_r(struct _reent *r, int fd, struct stat *st)
 {
+    (void) fd;
+    (void) st;
     r->_errno = ENODEV;                     /* not implemented yet */
     return -1;
 }
@@ -294,6 +306,8 @@ int _fstat_r(struct _reent *r, int fd, struct stat * st)
  */
 int _stat_r(struct _reent *r, char *name, struct stat *st)
 {
+    (void) name;
+    (void) st;
     r->_errno = ENODEV;                     /* not implemented yet */
     return -1;
 }
@@ -325,8 +339,9 @@ int _isatty_r(struct _reent *r, int fd)
  *
  * @return      TODO
  */
-int _unlink_r(struct _reent *r, char* path)
+int _unlink_r(struct _reent *r, char *path)
 {
+    (void) path;
     r->_errno = ENODEV;                     /* not implemented yet */
     return -1;
 }
@@ -342,6 +357,8 @@ int _unlink_r(struct _reent *r, char* path)
 __attribute__ ((weak))
 int _kill(int pid, int sig)
 {
+    (void) pid;
+    (void) sig;
     errno = ESRCH;                         /* not implemented yet */
     return -1;
 }


### PR DESCRIPTION
This PR fixes all warnings that I encountered when adding with `-Wall -Wextra` to `Makefile.include` and building `examples/rpl_udp` for mulle and `examples/default` for stm32f4discovery

Most warnings were harmless but there were a few mistakes that were corrected as well:
 - ~~Potential buffer overflow in `sys/newlib/syscalls.c`(`_read_r()`)~~ split to #3110 
 - Missing callback assignment in Kinetis SPI slave mode implementation
 - Empty definition of `__set_FPSCR` when building for Cortex-M4 without FPU - duplicated in #3128 