### PR TITLE
ng_netif: clear out buffer before creating output

### DIFF
--- a/sys/net/crosslayer/ng_netif/ng_netif_addr_to_str.c
+++ b/sys/net/crosslayer/ng_netif/ng_netif_addr_to_str.c
@@ -28,6 +28,8 @@ char *ng_netif_addr_to_str(char *out, size_t out_len, uint8_t *addr,
         return NULL;
     }
 
+    out[0] = '\0';
+
     for (i = 0; i < addr_len; i++) {
         out[(3 * i)] = _half_byte_to_char(addr[i] >> 4);
         out[(3 * i) + 1] = _half_byte_to_char(addr[i] & 0xf);


### PR DESCRIPTION
The `out` buffer may contain data from previous calls to `ng_netif_addr_to_str()`.
I had a use case, where I accidentally did input `0` for `addr_len` and it did show me the output of my previous calls to this function, because the for loop will be omitted and the `out` buffer still has the old content.