### PR TITLE
ng_netdev_eth: default to NG_ETHERTYPE_UNKNOWN when no payload avail.

### DIFF
--- a/sys/net/link_layer/ng_netdev_eth/ng_netdev_eth.c
+++ b/sys/net/link_layer/ng_netdev_eth/ng_netdev_eth.c
@@ -373,7 +373,12 @@ static int _marshall_ethernet(ng_netdev_eth_t *dev, uint8_t *buffer, ng_pktsnip_
         return -EBADMSG;
     }
 
-    hdr->type = byteorder_htons(ng_nettype_to_ethertype(pkt->next->type));
+    if (payload) {
+        hdr->type = byteorder_htons(ng_nettype_to_ethertype(payload->type));
+    }
+    else {
+        hdr->type = byteorder_htons(NG_ETHERTYPE_UNKNOWN);
+    }
 
     netif_hdr = pkt->data;
 


### PR DESCRIPTION
When sending pure l2 frames without any included upper layers or payload, the current implementation segfaults on the sending side, because `pkt->next` is `NULL`