### PR TITLE
Travis: Refactor label checking

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,16 +4,16 @@ env:
     - NPROC_MAX=8
 
 script:
+    - printenv
     - git config --global user.email "drone@example.com"
     - git config --global user.name "Drone CI"
     - git remote add riot https://github.com/RIOT-OS/RIOT.git
     - git fetch riot master
     - git log -1 --pretty=format:%H riot/master
     - git branch -f master riot/master
-    - pwd
-    - set
     - git status
     - git branch
     - git remote -v
     - git branch -avv
+    - pwd
     - ./dist/tools/drone-scripts/build_and_test.sh riot/master

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
     - echo 'deb http://us.archive.ubuntu.com/ubuntu trusty-updates   main restricted universe multiverse' | sudo tee -a /etc/apt/sources.list.d/trusty.list > /dev/null
     - sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
     - sudo apt-get update
+    - printenv
 
 install:
     - >

--- a/dist/tools/pr_check/check_labels.sh
+++ b/dist/tools/pr_check/check_labels.sh
@@ -22,11 +22,26 @@ else
     exit 2
 fi
 
-LABELS_JSON=$(${GET} "${GITHUB_API_HOST}/repos/${GITHUB_REPO}/issues/${TRAVIS_PULL_REQUEST}/labels" 2> /dev/null)
+# initialize label cache variable
+LABELS_JSON=
 
 check_gh_label() {
+    if [ -z "${CI_PULL_REQUEST}" ]; then
+        # No pull request number, this happens if we run the CI on a branch
+        # which is not part of a PR, e.g. master, or if we run the CI scripts
+        # from the command line.
+        return 2
+    fi
     LABEL="${1}"
 
-    echo "${LABELS_JSON}" | grep -q "${LABEL}"
+    if [ -z "${LABELS_JSON}" ]; then
+        LABELS_JSON=$(${GET} "${GITHUB_API_HOST}/repos/${GITHUB_REPO}/issues/${CI_PULL_REQUEST}/labels" 2> /dev/null)
+        if [ "$?" -ne 0 ]; then
+            # Reading labels failed
+            return 3
+        fi
+    fi
+
+    printf '%s\n' "${LABELS_JSON}" | grep -q "${LABEL}"
     return $?
 }

--- a/dist/tools/pr_check/pr_check.sh
+++ b/dist/tools/pr_check/pr_check.sh
@@ -33,7 +33,7 @@ if [ -n "${SQUASH_COMMITS}" ]; then
     EXIT_CODE=1
 fi
 
-if [ -n "$TRAVIS_PULL_REQUEST" ]; then
+if [ -n "${CI_PULL_REQUEST}" ]; then
     if check_gh_label "NEEDS SQUASHING"; then
         echo -e "${CERROR}Pull request needs squashing according to its labels set on GitHub${CRESET}"
         EXIT_CODE=1


### PR DESCRIPTION
This PR makes Travis (and Drone implicitly because it uses the Travis scripts) always perform build tests if the current job does not have a PR number. This happens when you configure the CI system to build all pushed branches instead of only build on new pull requests.
Additionally, the proposed solution defers polling the Github API server until the first label query is made from the build script.
Also added is printing of the environment variables at the beginning of each Travis run.