### PR TITLE
cpu/cortexm: disabled hard floats for M4F CPUs

### DIFF
--- a/cpu/Makefile.include.cortexm_common
+++ b/cpu/Makefile.include.cortexm_common
@@ -16,11 +16,13 @@ export CFLAGS += -DCPU_ARCH_$(ARCH)
 
 # set the compiler specific CPU and FPU options
 ifeq ($(CPU_ARCH),cortex-m4f)
-export CFLAGS_FPU += -mfloat-abi=hard -mfpu=fpv4-sp-d16
+# TODO: enable hard floating points for the M4F once the context save/restore
+#       code is adjusted to take care of FPU registers
+#export CFLAGS_FPU += -mfloat-abi=hard -mfpu=fpv4-sp-d16
 export MCPU := cortex-m4
-else
-export MCPU ?= $(CPU_ARCH)
 endif
+CFLAGS_FPU ?= -mfloat-abi=soft
+export MCPU ?= $(CPU_ARCH)
 
 # Include CPU specific includes:
 export INCLUDES += -I$(RIOTCPU)/$(CPU)/include


### PR DESCRIPTION
Currently, the save/restore of FPU registers for Cortex-M4F CPUs is not implemented (see issue #1366). To make sure we don't run into trouble when using floats on these CPUs, this PR disables the use of the hardware FPU in the first place.