### PR TITLE
sys: bitfield.h: some fixes

### DIFF
--- a/sys/include/bitfield.h
+++ b/sys/include/bitfield.h
@@ -27,6 +27,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,7 +39,7 @@ extern "C" {
  * @note    SIZE should be a constant expression. This avoids variable length
  *          arrays.
  */
-#define BITFIELD(NAME, SIZE)  (uint8_t NAME[((SIZE) + 7) / 8])
+#define BITFIELD(NAME, SIZE)  uint8_t NAME[((SIZE) + 7) / 8]
 
 /**
  * @brief   Set the bit to 1


### PR DESCRIPTION
1. include missing header for ```size_t```
2. remove parentheses around BITFIELD define, prevents following error:

<pre>
/home/kaspar/src/steelyard/sys/include/bitfield.h:42:32: error: expected identifier or '(' before 'uint8_t'
 #define BITFIELD(NAME, SIZE)  (uint8_t NAME[((SIZE) + 7) / 8])
                                ^
/home/kaspar/src/steelyard/cpu/itron_m3/periph/gpio.c:14:1: note: in expansion of macro 'BITFIELD'
 BITFIELD(_gpio_config_bitfield, GPIO_NUM_ISR);
 ^
</pre>