### PR TITLE
travis: get arm install packages for cortex_m3_1

### DIFF
--- a/dist/tools/travis-scripts/get-pkg-list.py
+++ b/dist/tools/travis-scripts/get-pkg-list.py
@@ -20,7 +20,7 @@
 
 import os
 
-arm_mcu_groups = ["arm7", "cortex_m0", "cortex_m3", "cortex_m3_2", "cortex_m4"]
+arm_mcu_groups = ["arm7", "cortex_m0", "cortex_m3_1", "cortex_m3_2", "cortex_m4"]
 msp_mcu_groups = ["msp430"]
 x86_mcu_groups = ["x86"]
 avr8_mcu_groups = ["avr8"]


### PR DESCRIPTION
fix typo that caused all packages to be installed when building group cortex_m3_1