### PR TITLE
cortexm: Add support for building with LLVM/Clang

### DIFF
--- a/boards/Makefile.include.cortexm_common
+++ b/boards/Makefile.include.cortexm_common
@@ -1,18 +1,35 @@
 # Target triple for the build. Use arm-none-eabi if you are unsure.
 export TARGET_TRIPLE ?= arm-none-eabi
 
-# Toolchain prefix, defaults to target triple followed by a dash, you will most likely not need to touch this.
+# Use TOOLCHAIN environment variable to select the toolchain to use.
+# Default: gnu
+TOOLCHAIN ?= gnu
+
+# TOOLCHAIN = clang is an alias for TOOLCHAIN = llvm
+ifeq (clang,$(TOOLCHAIN))
+# use override so that we can redefine a variable set on the command line (as
+# opposed to one set in the environment)
+override TOOLCHAIN := llvm
+endif
+
+export TOOLCHAIN
+
+# default toolchain prefix, defaults to target triple followed by a dash, you
+# will most likely not need to touch this.
 export PREFIX ?= $(if $(TARGET_TRIPLE),$(TARGET_TRIPLE)-)
 
-# we build all cortex boards with the GNU toolchain
-include $(RIOTBOARD)/Makefile.include.gnu
-
 # define build specific options
-export CFLAGS_CPU   = -mcpu=$(MCPU) -mlittle-endian -mthumb -mno-thumb-interwork $(CFLAGS_FPU)
+export CFLAGS_CPU   = -mcpu=$(MCPU) -mlittle-endian -mthumb $(CFLAGS_FPU)
+ifneq (llvm,$(TOOLCHAIN))
+# Clang (observed with v3.7) does not understand  -mno-thumb-interwork, only add if
+# not building with LLVM
+export CFLAGS_CPU  += -mno-thumb-interwork
+endif
 export CFLAGS_STYLE = -std=gnu99 -Wall -Wstrict-prototypes -Werror=implicit-function-declaration
-export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin
-export CFLAGS_DBG   ?= -ggdb -g3
-export CFLAGS_OPT   ?= -Os
+export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
+export CFLAGS_DBG   = -ggdb -g3
+export CFLAGS_OPT  ?= -Os
+
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_STYLE) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 
 export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DEBUG)
@@ -20,7 +37,10 @@ export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts -L$(RIOTCPU)/cortexm_common/ld
 export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL).ld -Wl,--fatal-warnings
 export LINKFLAGS += $(CFLAGS_DEBUG) $(CFLAGS_CPU) $(CFLAGS_STYLE) -static -lgcc -nostartfiles
 
-# use the nano-specs of the NewLib when available
+# Import all toolchain settings
+include $(RIOTBOARD)/Makefile.include.$(TOOLCHAIN)
+
+# use the nano-specs of Newlib when available
 ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
 export LINKFLAGS += -specs=nano.specs -lc -lnosys
 endif

--- a/boards/Makefile.include.llvm
+++ b/boards/Makefile.include.llvm
@@ -1,0 +1,23 @@
+export GDBPREFIX  ?= $(PREFIX)
+export LLVMPREFIX ?= llvm-
+export CC          = clang
+export CXX         = clang++
+export LINK        = $(CC)
+export AS          = $(LLVMPREFIX)as
+export AR          = $(LLVMPREFIX)ar
+export NM          = $(LLVMPREFIX)nm
+# There is no LLVM linker yet, use GNU binutils.
+#export LINKER      = $(LLVMPREFIX)ld
+# objcopy does not have a clear substitute in LLVM, use GNU binutils
+#export OBJCOPY     = $(LLVMPREFIX)objcopy
+export OBJCOPY     = $(PREFIX)objcopy
+export OBJDUMP     = $(LLVMPREFIX)objdump
+export SIZE        = $(LLVMPREFIX)size
+export DBG         = $(GDBPREFIX)gdb
+# LLVM lacks a binutils strip tool as well...
+#export STRIP      = $(LLVMPREFIX)strip
+
+# Tell clang to cross compile
+export CFLAGS     += -target $(TARGET_TRIPLE)
+export CXXFLAGS   += -target $(TARGET_TRIPLE)
+export LINKFLAGS  += -target $(TARGET_TRIPLE)

--- a/sys/newlib/Makefile.include
+++ b/sys/newlib/Makefile.include
@@ -1,1 +1,33 @@
 UNDEF := $(BINDIR)newlib/syscalls.o $(UNDEF)
+
+# Search for Newlib include directories
+
+# Since Clang is not installed as a separate instance for each crossdev target
+# we need to tell it where to look for platform specific includes (Newlib
+# headers instead of Linux/Glibc headers.)
+# On GCC this is done when building the cross compiler toolchain so we do not
+# actually need to specify the include paths for system includes.
+# Ubuntu gcc-arm-embedded toolchain (https://launchpad.net/gcc-arm-embedded)
+# places newlib headers in several places, but the primary source seem to be
+# /etc/alternatives/gcc-arm-none-eabi-include
+# Gentoo Linux crossdev place the newlib headers in /usr/arm-none-eabi/include
+# Arch Linux also place the newlib headers in /usr/arm-none-eabi/include
+# Ubuntu seem to put a copy of the newlib headers in the same place as
+# Gentoo crossdev, but we prefer to look at /etc/alternatives first.
+# On OSX, newlib includes are possibly located in
+# /usr/local/opt/arm-none-eabi*/arm-none-eabi/include
+NEWLIB_INCLUDE_PATTERNS ?= \
+  /etc/alternatives/gcc-$(TARGET_TRIPLE)-include \
+  /usr/$(TARGET_TRIPLE)/include \
+  /usr/local/opt/$(TARGET_TRIPLE)*/$(TARGET_TRIPLE)/include \
+  #
+# Use the wildcard Makefile function to search for existing directories matching
+# the patterns above. We use the -isystem gcc/clang argument to add the include
+# directories as system include directories, which means they will not be
+# searched until after all the project specific include directories (-I/path)
+NEWLIB_INCLUDES ?= \
+    $(foreach dir, \
+        $(foreach pat, $(NEWLIB_INCLUDE_PATTERNS), $(wildcard $(pat))), \
+        -isystem $(dir))
+
+export INCLUDES += $(NEWLIB_INCLUDES)


### PR DESCRIPTION
as an alternative to the default GCC toolchain.

~~export BUILD_WITH_CLANG=1~~
~~export CC=clang~~

    export TOOLCHAIN=llvm

or 

    export TOOLCHAIN=clang

to build with Clang instead of GCC