### PR TITLE
cortexm: minor CFLAGS changes

### DIFF
--- a/boards/Makefile.include.cortexm_common
+++ b/boards/Makefile.include.cortexm_common
@@ -11,7 +11,7 @@ include $(RIOTBOARD)/Makefile.include.gnu
 export CFLAGS_CPU   = -mcpu=$(MCPU) -mlittle-endian -mthumb -mno-thumb-interwork $(CFLAGS_FPU)
 export CFLAGS_STYLE = -std=gnu99 -Wall -Wstrict-prototypes -Werror=implicit-function-declaration
 export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin
-export CFLAGS_DBG   = -ggdb -g3
+export CFLAGS_DBG   ?= -ggdb -g3
 export CFLAGS_OPT   ?= -Os
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_STYLE) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 

--- a/boards/Makefile.include.cortexm_common
+++ b/boards/Makefile.include.cortexm_common
@@ -9,7 +9,7 @@ include $(RIOTBOARD)/Makefile.include.gnu
 
 # define build specific options
 export CFLAGS_CPU   = -mcpu=$(MCPU) -mlittle-endian -mthumb -mno-thumb-interwork $(CFLAGS_FPU)
-export CFLAGS_STYLE = -std=gnu99 -Wall -Wstrict-prototypes
+export CFLAGS_STYLE = -std=gnu99 -Wall -Wstrict-prototypes -Werror=implicit-function-declaration
 export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin
 export CFLAGS_DBG   = -ggdb -g3
 export CFLAGS_OPT   ?= -Os


### PR DESCRIPTION
 - Added `-Werror=implicit-function-declaration` to easier detect missing header during development
 - Allow `CFLAGS_DBG` to be overridden from the environment