### PR TITLE
travis: Test everything if core or sys has any changes

### DIFF
--- a/dist/tools/compile_test/compile_test.py
+++ b/dist/tools/compile_test/compile_test.py
@@ -109,7 +109,9 @@ def is_updated(application_folder, subprocess_env):
             return True
 
         if ".travis.yml" in diff_files or \
-           any("dist/" in s for s in diff_files):
+           any("dist/" in s for s in diff_files) or \
+           any("core/" in s for s in diff_files) or \
+           any("sys/" in s for s in diff_files):
             return True
 
         boards_changes = set()


### PR DESCRIPTION
It seems like Travis will skip all tests if the only changes are no platform specific changes. This PR adds a check to run all buildtests whenever sys/ or core/ has been modified.

I don't know the details of how the dependency calculations are done in compile_test.py but this should at least not skip all tests for pure `core` changes.

The dependency calculations were introduced in #2822