### PR TITLE
Support for Freescale K64F MCU and FRDM-K64F Board

### DIFF
--- a/boards/frdm-k64f/Makefile
+++ b/boards/frdm-k64f/Makefile
@@ -1,0 +1,4 @@
+# tell the Makefile.base which module to build
+MODULE = $(BOARD)_base
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/frdm-k64f/Makefile.features
+++ b/boards/frdm-k64f/Makefile.features
@@ -1,0 +1,12 @@
+FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_random
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_MCU_GROUP = cortex_m4

--- a/boards/frdm-k64f/Makefile.include
+++ b/boards/frdm-k64f/Makefile.include
@@ -1,0 +1,32 @@
+# define the cpu used by the FRDM-K64F board
+export CPU = k64f
+export CPU_MODEL = mk64fn1m0vll12
+
+# set default port depending on operating system
+PORT_LINUX ?= /dev/ttyACM0
+
+.PHONY: flash
+flash: $(RIOTCPU)/kinetis_common/dist/wdog-disable.bin
+
+# Reset the default goal.
+.DEFAULT_GOAL :=
+
+export FFLAGS = flash-elf
+export TUI = 1
+# We need special handling of the watchdog if we want to speed up the flash
+# verification by using the MCU to compute the image checksum after flashing.
+# wdog-disable.bin is a precompiled binary which will disable the watchdog and
+# return control to the debugger (OpenOCD)
+export OPENOCD_PRE_VERIFY_CMDS += \
+  -c 'load_image $(RIOTCPU)/kinetis_common/dist/wdog-disable.bin 0x20000000 bin' \
+  -c 'resume 0x20000000'
+export OPENOCD_EXTRA_INIT
+export PRE_FLASH_CHECK_SCRIPT = $(RIOTCPU)/kinetis_common/dist/check-fcfield-elf.sh
+
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep
+# setup serial terminal
+include $(RIOTBOARD)/Makefile.include.serial
+# this board uses openocd
+include $(RIOTBOARD)/Makefile.include.openocd
+# include cortex defaults
+include $(RIOTBOARD)/Makefile.include.cortexm_common

--- a/boards/frdm-k64f/board.c
+++ b/boards/frdm-k64f/board.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     board_frdm-k64f
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the FRDM-K64F
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ *
+ * @}
+ */
+
+#include "board.h"
+
+static void leds_init(void);
+
+void board_init(void)
+{
+    leds_init();
+    cpu_init();
+}
+
+/**
+ * @brief Initialize the boards on-board RGB-LED
+ *
+ */
+static void leds_init(void)
+{
+    /* enable clock */
+    LED_B_PORT_CLKEN();
+    LED_G_PORT_CLKEN();
+    LED_R_PORT_CLKEN();
+    /* configure pins as gpio */
+    LED_B_PORT->PCR[LED_B_PIN] = PORT_PCR_MUX(1);
+    LED_G_PORT->PCR[LED_G_PIN] = PORT_PCR_MUX(1);
+    LED_R_PORT->PCR[LED_R_PIN] = PORT_PCR_MUX(1);
+    LED_B_GPIO->PDDR |= (1 << LED_B_PIN);
+    LED_G_GPIO->PDDR |= (1 << LED_G_PIN);
+    LED_R_GPIO->PDDR |= (1 << LED_R_PIN);
+    /* turn all LEDs off */
+    LED_B_GPIO->PSOR |= (1 << LED_B_PIN);
+    LED_G_GPIO->PSOR |= (1 << LED_G_PIN);
+    LED_R_GPIO->PSOR |= (1 << LED_R_PIN);
+}

--- a/boards/frdm-k64f/dist/openocd.cfg
+++ b/boards/frdm-k64f/dist/openocd.cfg
@@ -1,0 +1,50 @@
+#
+# Freescale Kinetis k64f devices
+#
+source [find interface/cmsis-dap.cfg]
+
+#
+# k64f devices support both JTAG and SWD transports.
+#
+source [find target/swj-dp.tcl]
+
+if { [info exists CHIPNAME] } {
+    set _CHIPNAME $CHIPNAME
+} else {
+    set _CHIPNAME k64f
+}
+
+if { [info exists CPUTAPID] } {
+    set _CPUTAPID $CPUTAPID
+} else {
+    set _CPUTAPID 0x2ba01477
+}
+
+set _TARGETNAME $_CHIPNAME.cpu
+
+swj_newdap $_CHIPNAME cpu -irlen 4 -expected-id $_CPUTAPID
+
+target create $_TARGETNAME cortex_m -chain-position $_CHIPNAME.cpu
+
+$_CHIPNAME.cpu configure -event examine-start { puts "START..." ; }
+
+# It is important that "kinetis mdm check_security" is called for
+# 'examine-end' event and not 'eximine-start'. Calling it in 'examine-start'
+# causes "kinetis mdm check_security" to fail the first time openocd
+# calls it when it tries to connect after the CPU has been power-cycled.
+$_CHIPNAME.cpu configure -event examine-end {
+    kinetis mdm check_security
+}
+
+$_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size 0x1000 -work-area-backup 0
+
+flash bank $_CHIPNAME.flash kinetis 0 0 0 0 $_TARGETNAME
+
+cortex_m reset_config sysresetreq
+#reset_config srst_only srst_nogate connect_assert_srst
+
+adapter_khz 1000
+
+$_TARGETNAME configure -event gdb-attach {
+  halt
+}

--- a/boards/frdm-k64f/include/board.h
+++ b/boards/frdm-k64f/include/board.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    board_frdm-k64f Freescale FRDM-K64F Board
+ * @ingroup     boards
+ * @brief       Board specific implementations for the FRDM-K64F
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the FRDM-K64F
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ */
+
+#ifndef __BOARD_H
+#define __BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * Define the nominal CPU core clock in this board
+ */
+#define F_CPU               CLOCK_CORECLOCK
+
+/**
+ * @name Define UART device and baudrate for stdio
+ * @{
+ */
+#define STDIO               UART_0
+#define STDIO_RX_BUFSIZE    (64U)
+#define STDIO_BAUDRATE      (115200U)
+/** @} */
+
+/**
+ * @name LED pin definitions
+ * @{
+ */
+#define LED_R_PORT_CLKEN()    (SIM->SCGC5 |= (SIM_SCGC5_PORTB_MASK)) /**< Clock Enable for PORTD*/
+#define LED_G_PORT_CLKEN()    (SIM->SCGC5 |= (SIM_SCGC5_PORTE_MASK)) /**< Clock Enable for PORTD*/
+#define LED_B_PORT_CLKEN()    (SIM->SCGC5 |= (SIM_SCGC5_PORTB_MASK)) /**< Clock Enable for PORTA*/
+#define LED_R_PORT            PORTB /**< PORT for Red LED*/
+#define LED_R_GPIO            GPIOB /**< GPIO-Device for Red LED*/
+#define LED_G_PORT            PORTE /**< PORT for Green LED*/
+#define LED_G_GPIO            GPIOE /**< GPIO-Device for Green LED*/
+#define LED_B_PORT            PORTB /**< PORT for Blue LED*/
+#define LED_B_GPIO            GPIOB /**< GPIO-Device for Blue LED*/
+#define LED_R_PIN             22    /**< Red LED connected to PINx*/
+#define LED_G_PIN             26    /**< Green LED connected to PINx*/
+#define LED_B_PIN             21    /**< Blue LED connected to PINx*/
+/** @} */
+
+/**
+ * @name Macros for controlling the on-board LEDs.
+ * @{
+ */
+#define LED_B_ON            (LED_B_GPIO->PCOR |= (1 << LED_B_PIN))
+#define LED_B_OFF           (LED_B_GPIO->PSOR |= (1 << LED_B_PIN))
+#define LED_B_TOGGLE        (LED_B_GPIO->PTOR |= (1 << LED_B_PIN))
+#define LED_G_ON            (LED_G_GPIO->PCOR |= (1 << LED_G_PIN))
+#define LED_G_OFF           (LED_G_GPIO->PSOR |= (1 << LED_G_PIN))
+#define LED_G_TOGGLE        (LED_G_GPIO->PTOR |= (1 << LED_G_PIN))
+#define LED_R_ON            (LED_R_GPIO->PCOR |= (1 << LED_R_PIN))
+#define LED_R_OFF           (LED_R_GPIO->PSOR |= (1 << LED_R_PIN))
+#define LED_R_TOGGLE        (LED_R_GPIO->PTOR |= (1 << LED_R_PIN))
+
+/* for compatability to other boards */
+#define LED_GREEN_ON        LED_G_ON
+#define LED_GREEN_OFF       LED_G_OFF
+#define LED_GREEN_TOGGLE    LED_G_TOGGLE
+#define LED_RED_ON          LED_R_ON
+#define LED_RED_OFF         LED_R_OFF
+#define LED_RED_TOGGLE      LED_R_TOGGLE
+/** @} */
+
+/**
+ * Define the type for the radio packet length for the transceiver
+ */
+typedef uint8_t radio_packet_length_t;
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /** __BOARD_H */
+/** @} */

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -1,0 +1,348 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     board_frdm-k64f
+ * @{
+ *
+ * @file
+ * @name        Peripheral MCU configuration for the FRDM-K64F
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ */
+
+#ifndef __PERIPH_CONF_H
+#define __PERIPH_CONF_H
+
+#include "cpu_conf.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @name Clock system configuration
+ * @{
+ */
+#define KINETIS_CPU_USE_MCG          1
+
+#define KINETIS_MCG_USE_ERC          1
+#define KINETIS_MCG_USE_PLL          1
+#define KINETIS_MCG_DCO_RANGE        (24000000U)
+#define KINETIS_MCG_ERC_OSCILLATOR   0
+#define KINETIS_MCG_ERC_FRDIV        6           /* ERC devider = 1280 */
+#define KINETIS_MCG_ERC_RANGE        2
+#define KINETIS_MCG_ERC_FREQ         50000000
+#define KINETIS_MCG_PLL_PRDIV        19          /* divide factor = 20 */
+#define KINETIS_MCG_PLL_VDIV0        0           /* multiply factor = 24 */
+#define KINETIS_MCG_PLL_FREQ         60000000
+
+#define CLOCK_CORECLOCK              KINETIS_MCG_PLL_FREQ
+/** @} */
+
+
+/**
+ * @name Timer configuration
+ * @{
+ */
+#define TIMER_NUMOF                  (1U)
+#define TIMER_0_EN                   1
+#define TIMER_1_EN                   0
+#define TIMER_IRQ_PRIO               1
+#define TIMER_DEV                    PIT
+#define TIMER_MAX_VALUE              (0xffffffff)
+#define TIMER_CLOCK                  CLOCK_CORECLOCK
+#define TIMER_CLKEN()                (SIM->SCGC6 |= (SIM_SCGC6_PIT_MASK))
+
+/* Timer 0 configuration */
+#define TIMER_0_PRESCALER_CH         0
+#define TIMER_0_COUNTER_CH           1
+#define TIMER_0_ISR                  isr_pit1
+#define TIMER_0_IRQ_CHAN             PIT1_IRQn
+
+/* Timer 1 configuration */
+#define TIMER_1_PRESCALER_CH         2
+#define TIMER_1_COUNTER_CH           3
+#define TIMER_1_ISR                  isr_pit3
+#define TIMER_1_IRQ_CHAN             PIT3_IRQn
+/** @} */
+
+/**
+* @name UART configuration
+* @{
+*/
+#define UART_NUMOF                   (1U)
+#define UART_0_EN                    1
+#define UART_IRQ_PRIO                1
+#define UART_CLK                     CLOCK_CORECLOCK
+
+/* UART 0 device configuration */
+#define KINETIS_UART                 UART_Type
+#define UART_0_DEV                   UART0
+#define UART_0_CLKEN()               (SIM->SCGC4 |= (SIM_SCGC4_UART0_MASK))
+#define UART_0_CLK                   UART_CLK
+#define UART_0_IRQ_CHAN              UART0_RX_TX_IRQn
+#define UART_0_ISR                   isr_uart0_rx_tx
+/* UART 0 pin configuration */
+#define UART_0_PORT_CLKEN()          (SIM->SCGC5 |= (SIM_SCGC5_PORTB_MASK))
+#define UART_0_PORT                  PORTB
+#define UART_0_RX_PIN                16
+#define UART_0_TX_PIN                17
+#define UART_0_AF                    3
+/** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_NUMOF                    (1U)
+#define ADC_0_EN                     1
+#define ADC_MAX_CHANNELS             6
+
+/* ADC 0 configuration */
+#define ADC_0_DEV                    ADC1
+#define ADC_0_MODULE_CLOCK           CLOCK_CORECLOCK
+#define ADC_0_CHANNELS               6
+#define ADC_0_CLKEN()                (SIM->SCGC3 |= (SIM_SCGC3_ADC1_MASK))
+#define ADC_0_CLKDIS()               (SIM->SCGC3 &= ~(SIM_SCGC3_ADC1_MASK))
+#define ADC_0_PORT_CLKEN()           (SIM->SCGC5 |= (SIM_SCGC5_PORTB_MASK | SIM_SCGC5_PORTC_MASK))
+/* ADC 0 channel 0 pin config */
+#define ADC_0_CH0_PORT               PORTB
+#define ADC_0_CH0_PIN                10
+#define ADC_0_CH0_PIN_AF             0
+#define ADC_0_CH0                    14
+/* ADC 0 channel 1 pin config */
+#define ADC_0_CH1_PORT               PORTB
+#define ADC_0_CH1_PIN                11
+#define ADC_0_CH1_PIN_AF             0
+#define ADC_0_CH1                    15
+/* ADC 0 channel 2 pin config */
+#define ADC_0_CH2_PORT               PORTC
+#define ADC_0_CH2_PIN                11
+#define ADC_0_CH2_PIN_AF             0
+#define ADC_0_CH2                    7
+/* ADC 0 channel 3 pin config */
+#define ADC_0_CH3_PORT               PORTC
+#define ADC_0_CH3_PIN                10
+#define ADC_0_CH3_PIN_AF             0
+#define ADC_0_CH3                    6
+/* ADC 0 channel 4 pin config */
+#define ADC_0_CH4_PORT               PORTC
+#define ADC_0_CH4_PIN                8
+#define ADC_0_CH4_PIN_AF             0
+#define ADC_0_CH4                    4
+/* ADC 0 channel 5 pin config */
+#define ADC_0_CH5_PORT               PORTC
+#define ADC_0_CH5_PIN                9
+#define ADC_0_CH5_PIN_AF             0
+#define ADC_0_CH5                    5
+/** @} */
+
+/**
+* @name PWM configuration
+* @{
+*/
+#define PWM_NUMOF                    (1U)
+#define PWM_0_EN                     1
+#define PWM_MAX_CHANNELS             8
+#define PWM_MAX_VALUE                0xffff
+
+/* PWM 0 device configuration */
+#define PWM_0_DEV                    FTM0
+#define PWM_0_CHANNELS               4
+#define PWM_0_CLK                    CLOCK_CORECLOCK
+#define PWM_0_CLKEN()                (SIM->SCGC6 |= (SIM_SCGC6_FTM0_MASK))
+#define PWM_0_CLKDIS()               (SIM->SCGC6 &= ~(SIM_SCGC6_FTM0_MASK))
+/* PWM 0 pin configuration */
+#define PWM_0_PORT_CLKEN()           (SIM->SCGC5 |= (SIM_SCGC5_PORTA_MASK | SIM_SCGC5_PORTC_MASK))
+/* Arduino Connector D3 */
+#define PWM_0_PORT_CH0               PORTA
+#define PWM_0_PIN_CH0                1
+#define PWM_0_FTMCHAN_CH0            6
+#define PWM_0_PIN_AF_CH0             3
+/* Arduino Connector D5 */
+#define PWM_0_PORT_CH1               PORTA
+#define PWM_0_PIN_CH1                2
+#define PWM_0_FTMCHAN_CH1            7
+#define PWM_0_PIN_AF_CH1             3
+/* Arduino Connector D6 */
+#define PWM_0_PORT_CH2               PORTC
+#define PWM_0_PIN_CH2                2
+#define PWM_0_FTMCHAN_CH2            1
+#define PWM_0_PIN_AF_CH2             4
+/* Arduino Connector D7 */
+#define PWM_0_PORT_CH3               PORTC
+#define PWM_0_PIN_CH3                3
+#define PWM_0_FTMCHAN_CH3            2
+#define PWM_0_PIN_AF_CH3             4
+/** @} */
+
+
+/**
+* @name SPI configuration
+* @{
+*/
+#define SPI_NUMOF                    (1U)
+#define SPI_0_EN                     1
+#define SPI_IRQ_PRIO                 1
+#define KINETIS_SPI_USE_HW_CS        1
+
+/* SPI 0 device config */
+#define SPI_0_DEV                    SPI0
+#define SPI_0_INDEX                  0
+#define SPI_0_CTAS                   0
+#define SPI_0_CLKEN()                (SIM->SCGC6 |= (SIM_SCGC6_SPI0_MASK))
+#define SPI_0_CLKDIS()               (SIM->SCGC6 &= ~(SIM_SCGC6_SPI0_MASK))
+#define SPI_0_IRQ                    SPI0_IRQn
+#define SPI_0_IRQ_HANDLER            isr_spi0
+#define SPI_0_FREQ                   CLOCK_CORECLOCK
+
+/* SPI 0 pin configuration */
+#define SPI_0_PORT                   PORTD
+#define SPI_0_PORT_CLKEN()           (SIM->SCGC5 |= (SIM_SCGC5_PORTD_MASK))
+#define SPI_0_AF                     2
+
+#define SPI_0_PCS0_PIN               0
+#define SPI_0_SCK_PIN                1
+#define SPI_0_SOUT_PIN               2
+#define SPI_0_SIN_PIN                3
+
+#define SPI_0_PCS0_ACTIVE_LOW        1
+/** @} */
+
+
+/**
+* @name I2C configuration
+* @{
+*/
+#define I2C_NUMOF                    (1U)
+#define I2C_CLK                      CLOCK_CORECLOCK
+#define I2C_0_EN                     1
+#define I2C_IRQ_PRIO                 1
+/* Low (10 kHz): MUL = 4, SCL divider = 2560, total: 10240 */
+#define KINETIS_I2C_F_ICR_LOW        (0x3D)
+#define KINETIS_I2C_F_MULT_LOW       (2)
+/* Normal (100 kHz): MUL = 2, SCL divider = 240, total: 480 */
+#define KINETIS_I2C_F_ICR_NORMAL     (0x1F)
+#define KINETIS_I2C_F_MULT_NORMAL    (1)
+/* Fast (400 kHz): MUL = 1, SCL divider = 128, total: 128 */
+#define KINETIS_I2C_F_ICR_FAST       (0x17)
+#define KINETIS_I2C_F_MULT_FAST      (0)
+/* Fast plus (1000 kHz): MUL = 1, SCL divider = 48, total: 48 */
+#define KINETIS_I2C_F_ICR_FAST_PLUS  (0x10)
+#define KINETIS_I2C_F_MULT_FAST_PLUS (0)
+
+/* I2C 0 device configuration */
+#define I2C_0_DEV                    I2C0
+#define I2C_0_CLKEN()                (SIM->SCGC4 |= (SIM_SCGC4_I2C0_MASK))
+#define I2C_0_CLKDIS()               (SIM->SCGC4 &= ~(SIM_SCGC4_I2C0_MASK))
+#define I2C_0_IRQ                    I2C0_IRQn
+#define I2C_0_IRQ_HANDLER            isr_i2c0
+/* I2C 0 pin configuration */
+#define I2C_0_PORT                   PORTE
+#define I2C_0_PORT_CLKEN()           (SIM->SCGC5 |= (SIM_SCGC5_PORTE_MASK))
+#define I2C_0_PIN_AF                 5
+#define I2C_0_SDA_PIN                25
+#define I2C_0_SCL_PIN                24
+#define I2C_0_PORT_CFG               (PORT_PCR_MUX(I2C_0_PIN_AF) | PORT_PCR_ODE_MASK)
+/** @} */
+
+/**
+ * @name GPIO configuration
+ * @{
+ */
+#define GPIO_0_EN                    1
+#define GPIO_1_EN                    1
+#define GPIO_2_EN                    1
+#define GPIO_3_EN                    1
+#define GPIO_4_EN                    1
+#define GPIO_5_EN                    1
+#define GPIO_IRQ_PRIO                1
+#define ISR_PORT_A                   isr_porta
+#define ISR_PORT_B                   isr_portb
+#define ISR_PORT_C                   isr_portc
+#define ISR_PORT_D                   isr_portd
+
+/* GPIO channel 0 config */
+#define GPIO_0_DEV                   GPIOB   /* LED_R */
+#define GPIO_0_PORT                  PORTB
+#define GPIO_0_PORT_BASE             PORTB_BASE
+#define GPIO_0_PIN                   22
+#define GPIO_0_CLKEN()               (SIM->SCGC5 |= (SIM_SCGC5_PORTB_MASK))
+#define GPIO_0_IRQ                   PORTB_IRQn
+/* GPIO channel 1 config */
+#define GPIO_1_DEV                   GPIOE   /* LED_G */
+#define GPIO_1_PORT                  PORTE
+#define GPIO_1_PORT_BASE             PORTE_BASE
+#define GPIO_1_PIN                   26
+#define GPIO_1_CLKEN()               (SIM->SCGC5 |= (SIM_SCGC5_PORTE_MASK))
+#define GPIO_1_IRQ                   PORTE_IRQn
+/* GPIO channel 2 config */
+#define GPIO_2_DEV                   GPIOB   /* LED_B */
+#define GPIO_2_PORT                  PORTB
+#define GPIO_2_PORT_BASE             PORTB_BASE
+#define GPIO_2_PIN                   21
+#define GPIO_2_CLKEN()               (SIM->SCGC5 |= (SIM_SCGC5_PORTB_MASK))
+#define GPIO_2_IRQ                   PORTB_IRQn
+/* GPIO channel 3 config */
+#define GPIO_3_DEV                   GPIOC   /* SW2 */
+#define GPIO_3_PORT                  PORTC
+#define GPIO_3_PORT_BASE             PORTC_BASE
+#define GPIO_3_PIN                   6
+#define GPIO_3_CLKEN()               (SIM->SCGC5 |= (SIM_SCGC5_PORTC_MASK))
+#define GPIO_3_IRQ                   PORTC_IRQn
+/* GPIO channel 4 config */
+#define GPIO_4_DEV                   GPIOB   /* A0 (Arduino Headers) */
+#define GPIO_4_PORT                  PORTB
+#define GPIO_4_PORT_BASE             PORTB_BASE
+#define GPIO_4_PIN                   2
+#define GPIO_4_CLKEN()               (SIM->SCGC5 |= (SIM_SCGC5_PORTB_MASK))
+#define GPIO_4_IRQ                   PORTB_IRQn
+/* GPIO channel 5 config */
+#define GPIO_5_DEV                   GPIOB   /* A1 (Arduino Headers) */
+#define GPIO_5_PORT                  PORTB
+#define GPIO_5_PORT_BASE             PORTB_BASE
+#define GPIO_5_PIN                   3
+#define GPIO_5_CLKEN()               (SIM->SCGC5 |= (SIM_SCGC5_PORTB_MASK))
+#define GPIO_5_IRQ                   PORTB_IRQn
+/** @} */
+
+/**
+* @name RTT and RTC configuration
+* @{
+*/
+#define RTT_NUMOF                    (1U)
+#define RTC_NUMOF                    (1U)
+#define RTT_DEV                      RTC
+#define RTT_IRQ                      RTC_IRQn
+#define RTT_IRQ_PRIO                 10
+#define RTT_UNLOCK()                 (SIM->SCGC6 |= (SIM_SCGC6_RTC_MASK))
+#define RTT_ISR                      isr_rtc
+#define RTT_FREQUENCY                (1)
+#define RTT_MAX_VALUE                (0xffffffff)
+/** @} */
+
+/**
+ * @name Random Number Generator configuration
+ * @{
+ */
+#define RANDOM_NUMOF                 (1U)
+#define KINETIS_RNGA                 RNG
+#define RANDOM_CLKEN()               (SIM->SCGC6 |= (1 << 9))
+#define RANDOM_CLKDIS()              (SIM->SCGC6 &= ~(1 << 9))
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __PERIPH_CONF_H */
+/** @} */

--- a/cpu/k64f/Makefile
+++ b/cpu/k64f/Makefile
@@ -1,0 +1,7 @@
+# define the module that is build
+MODULE = cpu
+
+# add a list of subdirectories, that should also be build
+DIRS = periph $(RIOTCPU)/cortexm_common $(KINETIS_COMMON)
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/k64f/Makefile.include
+++ b/cpu/k64f/Makefile.include
@@ -1,0 +1,26 @@
+# define the CPU architecture for the k64f
+export CPU_ARCH = cortex-m4
+
+# tell the build system that the CPU depends on the Kinetis common files
+export USEMODULE += kinetis_common
+
+# define path to kinetis module, which is needed for this CPU
+export KINETIS_COMMON = $(RIOTCPU)/kinetis_common/
+# CPU depends on the kinetis module, so include it
+include $(KINETIS_COMMON)Makefile.include
+
+export LINKFLAGS += -L$(RIOTCPU)/kinetis_common/ldscripts
+
+#export the CPU model
+MODEL = $(shell echo $(CPU_MODEL)|tr 'a-z' 'A-Z')
+export CFLAGS += -DCPU_MODEL_$(MODEL)
+ARCH = $(shell echo $(CPU_ARCH) | tr 'a-z-' 'A-Z_')
+export CFLAGS += -DCPU_ARCH_$(ARCH)
+
+# this CPU implementation is using kinetis common startup
+export COMMON_STARTUP = $(KINETIS_COMMON)
+
+# add the CPU specific system calls implementations for the linker
+export UNDEF += $(BINDIR)cpu/vectors.o
+
+include $(RIOTCPU)/Makefile.include.cortexm_common

--- a/cpu/k64f/cpu.c
+++ b/cpu/k64f/cpu.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_k64f
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the K64F CPU initialization
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ * @}
+ */
+
+#include <stdint.h>
+#include "cpu.h"
+#include "cpu_conf.h"
+
+#define SIM_CLKDIV1_60MHZ      (SIM_CLKDIV1_OUTDIV1(0) | \
+                                SIM_CLKDIV1_OUTDIV2(0) | \
+                                SIM_CLKDIV1_OUTDIV3(1) | \
+                                SIM_CLKDIV1_OUTDIV4(2))
+
+static void cpu_clock_init(void);
+
+/**
+ * @brief Initialize the CPU, set IRQ priorities
+ */
+void cpu_init(void)
+{
+    /* initialize the Cortex-M core */
+    cortexm_init();
+    /* initialize the clock system */
+    cpu_clock_init();
+}
+
+/**
+ * @brief Configure the controllers clock system
+ *
+ * | Clock name | Run mode frequency (max) | VLPR mode frequency (max) |
+ *
+ * | Core       | 120 MHz                  |   4 MHz                   |
+ * | System     | 120 MHz                  |   4 MHz                   |
+ * | Bus        |  60 MHz                  |   4 MHz                   |
+ * | FlexBus    |  50 MHz                  | 800 kHz                   |
+ * | Flash      |  25 MHz                  |   4 MHz                   |
+ */
+static void cpu_clock_init(void)
+{
+    /* setup system prescalers */
+    SIM->CLKDIV1 = (uint32_t)SIM_CLKDIV1_60MHZ;
+
+    /* RMII RXCLK */
+    SIM->SCGC5 |= SIM_SCGC5_PORTA_MASK;
+    PORTA->PCR[18] &= ~(PORT_PCR_ISF_MASK | PORT_PCR_MUX(0x07));
+
+    kinetis_mcg_set_mode(KINETIS_MCG_PEE);
+}

--- a/cpu/k64f/include/MK64F12.h
+++ b/cpu/k64f/include/MK64F12.h
@@ -1,0 +1,14440 @@
+/*
+** ###################################################################
+**     Processors:          MK64FN1M0VDC12
+**                          MK64FN1M0VLL12
+**                          MK64FN1M0VLQ12
+**                          MK64FN1M0VMD12
+**
+**     Compilers:           Keil ARM C/C++ Compiler
+**                          Freescale C/C++ for Embedded ARM
+**                          GNU C Compiler
+**                          GNU C Compiler - CodeSourcery Sourcery G++
+**                          IAR ANSI C/C++ Compiler for ARM
+**
+**     Reference manual:    K64P144M120SF5RM, Rev.2, January 2014
+**     Version:             rev. 2.5, 2014-02-10
+**     Build:               b140604
+**
+**     Abstract:
+**         CMSIS Peripheral Access Layer for MK64F12
+**
+**     Copyright (c) 1997 - 2014 Freescale Semiconductor, Inc.
+**     All rights reserved.
+**
+**     Redistribution and use in source and binary forms, with or without modification,
+**     are permitted provided that the following conditions are met:
+**
+**     o Redistributions of source code must retain the above copyright notice, this list
+**       of conditions and the following disclaimer.
+**
+**     o Redistributions in binary form must reproduce the above copyright notice, this
+**       list of conditions and the following disclaimer in the documentation and/or
+**       other materials provided with the distribution.
+**
+**     o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+**       contributors may be used to endorse or promote products derived from this
+**       software without specific prior written permission.
+**
+**     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+**     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+**     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+**     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+**     ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+**     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+**     ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+**     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+**     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+**     http:                 www.freescale.com
+**     mail:                 support@freescale.com
+**
+**     Revisions:
+**     - rev. 1.0 (2013-08-12)
+**         Initial version.
+**     - rev. 2.0 (2013-10-29)
+**         Register accessor macros added to the memory map.
+**         Symbols for Processor Expert memory map compatibility added to the memory map.
+**         Startup file for gcc has been updated according to CMSIS 3.2.
+**         System initialization updated.
+**         MCG - registers updated.
+**         PORTA, PORTB, PORTC, PORTE - registers for digital filter removed.
+**     - rev. 2.1 (2013-10-30)
+**         Definition of BITBAND macros updated to support peripherals with 32-bit acces disabled.
+**     - rev. 2.2 (2013-12-09)
+**         DMA - EARS register removed.
+**         AIPS0, AIPS1 - MPRA register updated.
+**     - rev. 2.3 (2014-01-24)
+**         Update according to reference manual rev. 2
+**         ENET, MCG, MCM, SIM, USB - registers updated
+**     - rev. 2.4 (2014-02-10)
+**         The declaration of clock configurations has been moved to separate header file system_MK64F12.h
+**         Update of SystemInit() and SystemCoreClockUpdate() functions.
+**     - rev. 2.5 (2014-02-10)
+**         The declaration of clock configurations has been moved to separate header file system_MK64F12.h
+**         Update of SystemInit() and SystemCoreClockUpdate() functions.
+**         Module access macro module_BASES replaced by module_BASE_PTRS.
+**
+** ###################################################################
+*/
+
+/*!
+ * @file MK64F12.h
+ * @version 2.5
+ * @date 2014-02-10
+ * @brief CMSIS Peripheral Access Layer for MK64F12
+ *
+ * CMSIS Peripheral Access Layer for MK64F12
+ */
+
+
+/* ----------------------------------------------------------------------------
+   -- MCU activation
+   ---------------------------------------------------------------------------- */
+
+/* Prevention from multiple including the same memory map */
+#if !defined(MK64F12_H_)  /* Check if memory map has not been already included */
+#define MK64F12_H_
+#define MCU_MK64F12
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* Check if another memory map has not been also included */
+#if (defined(MCU_ACTIVE))
+  #error MK64F12 memory map: There is already included another memory map. Only one memory map can be included.
+#endif /* (defined(MCU_ACTIVE)) */
+#define MCU_ACTIVE
+
+#include <stdint.h>
+
+/** Memory map major version (memory maps with equal major version number are
+ * compatible) */
+#define MCU_MEM_MAP_VERSION 0x0200u
+/** Memory map minor version */
+#define MCU_MEM_MAP_VERSION_MINOR 0x0005u
+
+/**
+ * @brief Macro to calculate address of an aliased word in the peripheral
+ *        bitband area for a peripheral register and bit (bit band region 0x40000000 to
+ *        0x400FFFFF).
+ * @param Reg Register to access.
+ * @param Bit Bit number to access.
+ * @return  Address of the aliased word in the peripheral bitband area.
+ */
+#define BITBAND_REGADDR(Reg,Bit) (0x42000000u + (32u*((uint32_t)&(Reg) - (uint32_t)0x40000000u)) + (4u*((uint32_t)(Bit))))
+/**
+ * @brief Macro to access a single bit of a peripheral register (bit band region
+ *        0x40000000 to 0x400FFFFF) using the bit-band alias region access. Can
+ *        be used for peripherals with 32bit access allowed.
+ * @param Reg Register to access.
+ * @param Bit Bit number to access.
+ * @return Value of the targeted bit in the bit band region.
+ */
+#define BITBAND_REG32(Reg,Bit) (*((uint32_t volatile*)(BITBAND_REGADDR(Reg,Bit))))
+#define BITBAND_REG(Reg,Bit) (BITBAND_REG32(Reg,Bit))
+/**
+ * @brief Macro to access a single bit of a peripheral register (bit band region
+ *        0x40000000 to 0x400FFFFF) using the bit-band alias region access. Can
+ *        be used for peripherals with 16bit access allowed.
+ * @param Reg Register to access.
+ * @param Bit Bit number to access.
+ * @return Value of the targeted bit in the bit band region.
+ */
+#define BITBAND_REG16(Reg,Bit) (*((uint16_t volatile*)(BITBAND_REGADDR(Reg,Bit))))
+/**
+ * @brief Macro to access a single bit of a peripheral register (bit band region
+ *        0x40000000 to 0x400FFFFF) using the bit-band alias region access. Can
+ *        be used for peripherals with 8bit access allowed.
+ * @param Reg Register to access.
+ * @param Bit Bit number to access.
+ * @return Value of the targeted bit in the bit band region.
+ */
+#define BITBAND_REG8(Reg,Bit) (*((uint8_t volatile*)(BITBAND_REGADDR(Reg,Bit))))
+
+/* ----------------------------------------------------------------------------
+   -- Interrupt vector numbers
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup Interrupt_vector_numbers Interrupt vector numbers
+ * @{
+ */
+
+/** Interrupt Number Definitions */
+#define NUMBER_OF_INT_VECTORS 102                /**< Number of interrupts in the Vector table */
+
+typedef enum IRQn {
+  /* Core interrupts */
+  NonMaskableInt_IRQn          = -14,              /**< Non Maskable Interrupt */
+  HardFault_IRQn               = -13,              /**< Cortex-M4 SV Hard Fault Interrupt */
+  MemoryManagement_IRQn        = -12,              /**< Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn                = -11,              /**< Cortex-M4 Bus Fault Interrupt */
+  UsageFault_IRQn              = -10,              /**< Cortex-M4 Usage Fault Interrupt */
+  SVCall_IRQn                  = -5,               /**< Cortex-M4 SV Call Interrupt */
+  DebugMonitor_IRQn            = -4,               /**< Cortex-M4 Debug Monitor Interrupt */
+  PendSV_IRQn                  = -2,               /**< Cortex-M4 Pend SV Interrupt */
+  SysTick_IRQn                 = -1,               /**< Cortex-M4 System Tick Interrupt */
+
+  /* Device specific interrupts */
+  DMA0_IRQn                    = 0,                /**< DMA Channel 0 Transfer Complete */
+  DMA1_IRQn                    = 1,                /**< DMA Channel 1 Transfer Complete */
+  DMA2_IRQn                    = 2,                /**< DMA Channel 2 Transfer Complete */
+  DMA3_IRQn                    = 3,                /**< DMA Channel 3 Transfer Complete */
+  DMA4_IRQn                    = 4,                /**< DMA Channel 4 Transfer Complete */
+  DMA5_IRQn                    = 5,                /**< DMA Channel 5 Transfer Complete */
+  DMA6_IRQn                    = 6,                /**< DMA Channel 6 Transfer Complete */
+  DMA7_IRQn                    = 7,                /**< DMA Channel 7 Transfer Complete */
+  DMA8_IRQn                    = 8,                /**< DMA Channel 8 Transfer Complete */
+  DMA9_IRQn                    = 9,                /**< DMA Channel 9 Transfer Complete */
+  DMA10_IRQn                   = 10,               /**< DMA Channel 10 Transfer Complete */
+  DMA11_IRQn                   = 11,               /**< DMA Channel 11 Transfer Complete */
+  DMA12_IRQn                   = 12,               /**< DMA Channel 12 Transfer Complete */
+  DMA13_IRQn                   = 13,               /**< DMA Channel 13 Transfer Complete */
+  DMA14_IRQn                   = 14,               /**< DMA Channel 14 Transfer Complete */
+  DMA15_IRQn                   = 15,               /**< DMA Channel 15 Transfer Complete */
+  DMA_Error_IRQn               = 16,               /**< DMA Error Interrupt */
+  MCM_IRQn                     = 17,               /**< Normal Interrupt */
+  FTFE_IRQn                    = 18,               /**< FTFE Command complete interrupt */
+  Read_Collision_IRQn          = 19,               /**< Read Collision Interrupt */
+  LVD_LVW_IRQn                 = 20,               /**< Low Voltage Detect, Low Voltage Warning */
+  LLW_IRQn                     = 21,               /**< Low Leakage Wakeup */
+  Watchdog_IRQn                = 22,               /**< WDOG Interrupt */
+  RNG_IRQn                     = 23,               /**< RNG Interrupt */
+  I2C0_IRQn                    = 24,               /**< I2C0 interrupt */
+  I2C1_IRQn                    = 25,               /**< I2C1 interrupt */
+  SPI0_IRQn                    = 26,               /**< SPI0 Interrupt */
+  SPI1_IRQn                    = 27,               /**< SPI1 Interrupt */
+  I2S0_Tx_IRQn                 = 28,               /**< I2S0 transmit interrupt */
+  I2S0_Rx_IRQn                 = 29,               /**< I2S0 receive interrupt */
+  UART0_LON_IRQn               = 30,               /**< UART0 LON interrupt */
+  UART0_RX_TX_IRQn             = 31,               /**< UART0 Receive/Transmit interrupt */
+  UART0_ERR_IRQn               = 32,               /**< UART0 Error interrupt */
+  UART1_RX_TX_IRQn             = 33,               /**< UART1 Receive/Transmit interrupt */
+  UART1_ERR_IRQn               = 34,               /**< UART1 Error interrupt */
+  UART2_RX_TX_IRQn             = 35,               /**< UART2 Receive/Transmit interrupt */
+  UART2_ERR_IRQn               = 36,               /**< UART2 Error interrupt */
+  UART3_RX_TX_IRQn             = 37,               /**< UART3 Receive/Transmit interrupt */
+  UART3_ERR_IRQn               = 38,               /**< UART3 Error interrupt */
+  ADC0_IRQn                    = 39,               /**< ADC0 interrupt */
+  CMP0_IRQn                    = 40,               /**< CMP0 interrupt */
+  CMP1_IRQn                    = 41,               /**< CMP1 interrupt */
+  FTM0_IRQn                    = 42,               /**< FTM0 fault, overflow and channels interrupt */
+  FTM1_IRQn                    = 43,               /**< FTM1 fault, overflow and channels interrupt */
+  FTM2_IRQn                    = 44,               /**< FTM2 fault, overflow and channels interrupt */
+  CMT_IRQn                     = 45,               /**< CMT interrupt */
+  RTC_IRQn                     = 46,               /**< RTC interrupt */
+  RTC_Seconds_IRQn             = 47,               /**< RTC seconds interrupt */
+  PIT0_IRQn                    = 48,               /**< PIT timer channel 0 interrupt */
+  PIT1_IRQn                    = 49,               /**< PIT timer channel 1 interrupt */
+  PIT2_IRQn                    = 50,               /**< PIT timer channel 2 interrupt */
+  PIT3_IRQn                    = 51,               /**< PIT timer channel 3 interrupt */
+  PDB0_IRQn                    = 52,               /**< PDB0 Interrupt */
+  USB0_IRQn                    = 53,               /**< USB0 interrupt */
+  USBDCD_IRQn                  = 54,               /**< USBDCD Interrupt */
+  Reserved71_IRQn              = 55,               /**< Reserved interrupt 71 */
+  DAC0_IRQn                    = 56,               /**< DAC0 interrupt */
+  MCG_IRQn                     = 57,               /**< MCG Interrupt */
+  LPTimer_IRQn                 = 58,               /**< LPTimer interrupt */
+  PORTA_IRQn                   = 59,               /**< Port A interrupt */
+  PORTB_IRQn                   = 60,               /**< Port B interrupt */
+  PORTC_IRQn                   = 61,               /**< Port C interrupt */
+  PORTD_IRQn                   = 62,               /**< Port D interrupt */
+  PORTE_IRQn                   = 63,               /**< Port E interrupt */
+  SWI_IRQn                     = 64,               /**< Software interrupt */
+  SPI2_IRQn                    = 65,               /**< SPI2 Interrupt */
+  UART4_RX_TX_IRQn             = 66,               /**< UART4 Receive/Transmit interrupt */
+  UART4_ERR_IRQn               = 67,               /**< UART4 Error interrupt */
+  UART5_RX_TX_IRQn             = 68,               /**< UART5 Receive/Transmit interrupt */
+  UART5_ERR_IRQn               = 69,               /**< UART5 Error interrupt */
+  CMP2_IRQn                    = 70,               /**< CMP2 interrupt */
+  FTM3_IRQn                    = 71,               /**< FTM3 fault, overflow and channels interrupt */
+  DAC1_IRQn                    = 72,               /**< DAC1 interrupt */
+  ADC1_IRQn                    = 73,               /**< ADC1 interrupt */
+  I2C2_IRQn                    = 74,               /**< I2C2 interrupt */
+  CAN0_ORed_Message_buffer_IRQn = 75,              /**< CAN0 OR'd message buffers interrupt */
+  CAN0_Bus_Off_IRQn            = 76,               /**< CAN0 bus off interrupt */
+  CAN0_Error_IRQn              = 77,               /**< CAN0 error interrupt */
+  CAN0_Tx_Warning_IRQn         = 78,               /**< CAN0 Tx warning interrupt */
+  CAN0_Rx_Warning_IRQn         = 79,               /**< CAN0 Rx warning interrupt */
+  CAN0_Wake_Up_IRQn            = 80,               /**< CAN0 wake up interrupt */
+  SDHC_IRQn                    = 81,               /**< SDHC interrupt */
+  ENET_1588_Timer_IRQn         = 82,               /**< Ethernet MAC IEEE 1588 Timer Interrupt */
+  ENET_Transmit_IRQn           = 83,               /**< Ethernet MAC Transmit Interrupt */
+  ENET_Receive_IRQn            = 84,               /**< Ethernet MAC Receive Interrupt */
+  ENET_Error_IRQn              = 85                /**< Ethernet MAC Error and miscelaneous Interrupt */
+} IRQn_Type;
+
+/*!
+ * @}
+ */ /* end of group Interrupt_vector_numbers */
+
+
+/* ----------------------------------------------------------------------------
+   -- Cortex M4 Core Configuration
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup Cortex_Core_Configuration Cortex M4 Core Configuration
+ * @{
+ */
+
+#define __MPU_PRESENT                  0         /**< Defines if an MPU is present or not */
+#define __NVIC_PRIO_BITS               4         /**< Number of priority bits implemented in the NVIC */
+#define __Vendor_SysTickConfig         0         /**< Vendor specific implementation of SysTickConfig is defined */
+#define __FPU_PRESENT                  1         /**< Defines if an FPU is present or not */
+
+#include "core_cm4.h"                  /* Core Peripheral Access Layer */
+//#include "system_MK64F12.h"            /* Device specific configuration file */
+
+/*!
+ * @}
+ */ /* end of group Cortex_Core_Configuration */
+
+
+/* ----------------------------------------------------------------------------
+   -- Device Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup Peripheral_access_layer Device Peripheral Access Layer
+ * @{
+ */
+
+
+/*
+** Start of section using anonymous unions
+*/
+
+#if defined(__ARMCC_VERSION)
+  #pragma push
+  #pragma anon_unions
+#elif defined(__CWCC__)
+  #pragma push
+  #pragma cpp_extensions on
+#elif defined(__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined(__IAR_SYSTEMS_ICC__)
+  #pragma language=extended
+#else
+  #error Not supported compiler type
+#endif
+
+/* ----------------------------------------------------------------------------
+   -- ADC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ADC_Peripheral_Access_Layer ADC Peripheral Access Layer
+ * @{
+ */
+
+/** ADC - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t SC1[2];                            /**< ADC Status and Control Registers 1, array offset: 0x0, array step: 0x4 */
+  __IO uint32_t CFG1;                              /**< ADC Configuration Register 1, offset: 0x8 */
+  __IO uint32_t CFG2;                              /**< ADC Configuration Register 2, offset: 0xC */
+  __I  uint32_t R[2];                              /**< ADC Data Result Register, array offset: 0x10, array step: 0x4 */
+  __IO uint32_t CV1;                               /**< Compare Value Registers, offset: 0x18 */
+  __IO uint32_t CV2;                               /**< Compare Value Registers, offset: 0x1C */
+  __IO uint32_t SC2;                               /**< Status and Control Register 2, offset: 0x20 */
+  __IO uint32_t SC3;                               /**< Status and Control Register 3, offset: 0x24 */
+  __IO uint32_t OFS;                               /**< ADC Offset Correction Register, offset: 0x28 */
+  __IO uint32_t PG;                                /**< ADC Plus-Side Gain Register, offset: 0x2C */
+  __IO uint32_t MG;                                /**< ADC Minus-Side Gain Register, offset: 0x30 */
+  __IO uint32_t CLPD;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x34 */
+  __IO uint32_t CLPS;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x38 */
+  __IO uint32_t CLP4;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x3C */
+  __IO uint32_t CLP3;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x40 */
+  __IO uint32_t CLP2;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x44 */
+  __IO uint32_t CLP1;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x48 */
+  __IO uint32_t CLP0;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x4C */
+       uint8_t RESERVED_0[4];
+  __IO uint32_t CLMD;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x54 */
+  __IO uint32_t CLMS;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x58 */
+  __IO uint32_t CLM4;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x5C */
+  __IO uint32_t CLM3;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x60 */
+  __IO uint32_t CLM2;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x64 */
+  __IO uint32_t CLM1;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x68 */
+  __IO uint32_t CLM0;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x6C */
+} ADC_Type, *ADC_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- ADC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ADC_Register_Accessor_Macros ADC - Register accessor macros
+ * @{
+ */
+
+
+/* ADC - Register accessors */
+#define ADC_SC1_REG(base,index)                  ((base)->SC1[index])
+#define ADC_CFG1_REG(base)                       ((base)->CFG1)
+#define ADC_CFG2_REG(base)                       ((base)->CFG2)
+#define ADC_R_REG(base,index)                    ((base)->R[index])
+#define ADC_CV1_REG(base)                        ((base)->CV1)
+#define ADC_CV2_REG(base)                        ((base)->CV2)
+#define ADC_SC2_REG(base)                        ((base)->SC2)
+#define ADC_SC3_REG(base)                        ((base)->SC3)
+#define ADC_OFS_REG(base)                        ((base)->OFS)
+#define ADC_PG_REG(base)                         ((base)->PG)
+#define ADC_MG_REG(base)                         ((base)->MG)
+#define ADC_CLPD_REG(base)                       ((base)->CLPD)
+#define ADC_CLPS_REG(base)                       ((base)->CLPS)
+#define ADC_CLP4_REG(base)                       ((base)->CLP4)
+#define ADC_CLP3_REG(base)                       ((base)->CLP3)
+#define ADC_CLP2_REG(base)                       ((base)->CLP2)
+#define ADC_CLP1_REG(base)                       ((base)->CLP1)
+#define ADC_CLP0_REG(base)                       ((base)->CLP0)
+#define ADC_CLMD_REG(base)                       ((base)->CLMD)
+#define ADC_CLMS_REG(base)                       ((base)->CLMS)
+#define ADC_CLM4_REG(base)                       ((base)->CLM4)
+#define ADC_CLM3_REG(base)                       ((base)->CLM3)
+#define ADC_CLM2_REG(base)                       ((base)->CLM2)
+#define ADC_CLM1_REG(base)                       ((base)->CLM1)
+#define ADC_CLM0_REG(base)                       ((base)->CLM0)
+
+/*!
+ * @}
+ */ /* end of group ADC_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- ADC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ADC_Register_Masks ADC Register Masks
+ * @{
+ */
+
+/* SC1 Bit Fields */
+#define ADC_SC1_ADCH_MASK                        0x1Fu
+#define ADC_SC1_ADCH_SHIFT                       0
+#define ADC_SC1_ADCH(x)                          (((uint32_t)(((uint32_t)(x))<<ADC_SC1_ADCH_SHIFT))&ADC_SC1_ADCH_MASK)
+#define ADC_SC1_DIFF_MASK                        0x20u
+#define ADC_SC1_DIFF_SHIFT                       5
+#define ADC_SC1_AIEN_MASK                        0x40u
+#define ADC_SC1_AIEN_SHIFT                       6
+#define ADC_SC1_COCO_MASK                        0x80u
+#define ADC_SC1_COCO_SHIFT                       7
+/* CFG1 Bit Fields */
+#define ADC_CFG1_ADICLK_MASK                     0x3u
+#define ADC_CFG1_ADICLK_SHIFT                    0
+#define ADC_CFG1_ADICLK(x)                       (((uint32_t)(((uint32_t)(x))<<ADC_CFG1_ADICLK_SHIFT))&ADC_CFG1_ADICLK_MASK)
+#define ADC_CFG1_MODE_MASK                       0xCu
+#define ADC_CFG1_MODE_SHIFT                      2
+#define ADC_CFG1_MODE(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CFG1_MODE_SHIFT))&ADC_CFG1_MODE_MASK)
+#define ADC_CFG1_ADLSMP_MASK                     0x10u
+#define ADC_CFG1_ADLSMP_SHIFT                    4
+#define ADC_CFG1_ADIV_MASK                       0x60u
+#define ADC_CFG1_ADIV_SHIFT                      5
+#define ADC_CFG1_ADIV(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CFG1_ADIV_SHIFT))&ADC_CFG1_ADIV_MASK)
+#define ADC_CFG1_ADLPC_MASK                      0x80u
+#define ADC_CFG1_ADLPC_SHIFT                     7
+/* CFG2 Bit Fields */
+#define ADC_CFG2_ADLSTS_MASK                     0x3u
+#define ADC_CFG2_ADLSTS_SHIFT                    0
+#define ADC_CFG2_ADLSTS(x)                       (((uint32_t)(((uint32_t)(x))<<ADC_CFG2_ADLSTS_SHIFT))&ADC_CFG2_ADLSTS_MASK)
+#define ADC_CFG2_ADHSC_MASK                      0x4u
+#define ADC_CFG2_ADHSC_SHIFT                     2
+#define ADC_CFG2_ADACKEN_MASK                    0x8u
+#define ADC_CFG2_ADACKEN_SHIFT                   3
+#define ADC_CFG2_MUXSEL_MASK                     0x10u
+#define ADC_CFG2_MUXSEL_SHIFT                    4
+/* R Bit Fields */
+#define ADC_R_D_MASK                             0xFFFFu
+#define ADC_R_D_SHIFT                            0
+#define ADC_R_D(x)                               (((uint32_t)(((uint32_t)(x))<<ADC_R_D_SHIFT))&ADC_R_D_MASK)
+/* CV1 Bit Fields */
+#define ADC_CV1_CV_MASK                          0xFFFFu
+#define ADC_CV1_CV_SHIFT                         0
+#define ADC_CV1_CV(x)                            (((uint32_t)(((uint32_t)(x))<<ADC_CV1_CV_SHIFT))&ADC_CV1_CV_MASK)
+/* CV2 Bit Fields */
+#define ADC_CV2_CV_MASK                          0xFFFFu
+#define ADC_CV2_CV_SHIFT                         0
+#define ADC_CV2_CV(x)                            (((uint32_t)(((uint32_t)(x))<<ADC_CV2_CV_SHIFT))&ADC_CV2_CV_MASK)
+/* SC2 Bit Fields */
+#define ADC_SC2_REFSEL_MASK                      0x3u
+#define ADC_SC2_REFSEL_SHIFT                     0
+#define ADC_SC2_REFSEL(x)                        (((uint32_t)(((uint32_t)(x))<<ADC_SC2_REFSEL_SHIFT))&ADC_SC2_REFSEL_MASK)
+#define ADC_SC2_DMAEN_MASK                       0x4u
+#define ADC_SC2_DMAEN_SHIFT                      2
+#define ADC_SC2_ACREN_MASK                       0x8u
+#define ADC_SC2_ACREN_SHIFT                      3
+#define ADC_SC2_ACFGT_MASK                       0x10u
+#define ADC_SC2_ACFGT_SHIFT                      4
+#define ADC_SC2_ACFE_MASK                        0x20u
+#define ADC_SC2_ACFE_SHIFT                       5
+#define ADC_SC2_ADTRG_MASK                       0x40u
+#define ADC_SC2_ADTRG_SHIFT                      6
+#define ADC_SC2_ADACT_MASK                       0x80u
+#define ADC_SC2_ADACT_SHIFT                      7
+/* SC3 Bit Fields */
+#define ADC_SC3_AVGS_MASK                        0x3u
+#define ADC_SC3_AVGS_SHIFT                       0
+#define ADC_SC3_AVGS(x)                          (((uint32_t)(((uint32_t)(x))<<ADC_SC3_AVGS_SHIFT))&ADC_SC3_AVGS_MASK)
+#define ADC_SC3_AVGE_MASK                        0x4u
+#define ADC_SC3_AVGE_SHIFT                       2
+#define ADC_SC3_ADCO_MASK                        0x8u
+#define ADC_SC3_ADCO_SHIFT                       3
+#define ADC_SC3_CALF_MASK                        0x40u
+#define ADC_SC3_CALF_SHIFT                       6
+#define ADC_SC3_CAL_MASK                         0x80u
+#define ADC_SC3_CAL_SHIFT                        7
+/* OFS Bit Fields */
+#define ADC_OFS_OFS_MASK                         0xFFFFu
+#define ADC_OFS_OFS_SHIFT                        0
+#define ADC_OFS_OFS(x)                           (((uint32_t)(((uint32_t)(x))<<ADC_OFS_OFS_SHIFT))&ADC_OFS_OFS_MASK)
+/* PG Bit Fields */
+#define ADC_PG_PG_MASK                           0xFFFFu
+#define ADC_PG_PG_SHIFT                          0
+#define ADC_PG_PG(x)                             (((uint32_t)(((uint32_t)(x))<<ADC_PG_PG_SHIFT))&ADC_PG_PG_MASK)
+/* MG Bit Fields */
+#define ADC_MG_MG_MASK                           0xFFFFu
+#define ADC_MG_MG_SHIFT                          0
+#define ADC_MG_MG(x)                             (((uint32_t)(((uint32_t)(x))<<ADC_MG_MG_SHIFT))&ADC_MG_MG_MASK)
+/* CLPD Bit Fields */
+#define ADC_CLPD_CLPD_MASK                       0x3Fu
+#define ADC_CLPD_CLPD_SHIFT                      0
+#define ADC_CLPD_CLPD(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLPD_CLPD_SHIFT))&ADC_CLPD_CLPD_MASK)
+/* CLPS Bit Fields */
+#define ADC_CLPS_CLPS_MASK                       0x3Fu
+#define ADC_CLPS_CLPS_SHIFT                      0
+#define ADC_CLPS_CLPS(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLPS_CLPS_SHIFT))&ADC_CLPS_CLPS_MASK)
+/* CLP4 Bit Fields */
+#define ADC_CLP4_CLP4_MASK                       0x3FFu
+#define ADC_CLP4_CLP4_SHIFT                      0
+#define ADC_CLP4_CLP4(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLP4_CLP4_SHIFT))&ADC_CLP4_CLP4_MASK)
+/* CLP3 Bit Fields */
+#define ADC_CLP3_CLP3_MASK                       0x1FFu
+#define ADC_CLP3_CLP3_SHIFT                      0
+#define ADC_CLP3_CLP3(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLP3_CLP3_SHIFT))&ADC_CLP3_CLP3_MASK)
+/* CLP2 Bit Fields */
+#define ADC_CLP2_CLP2_MASK                       0xFFu
+#define ADC_CLP2_CLP2_SHIFT                      0
+#define ADC_CLP2_CLP2(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLP2_CLP2_SHIFT))&ADC_CLP2_CLP2_MASK)
+/* CLP1 Bit Fields */
+#define ADC_CLP1_CLP1_MASK                       0x7Fu
+#define ADC_CLP1_CLP1_SHIFT                      0
+#define ADC_CLP1_CLP1(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLP1_CLP1_SHIFT))&ADC_CLP1_CLP1_MASK)
+/* CLP0 Bit Fields */
+#define ADC_CLP0_CLP0_MASK                       0x3Fu
+#define ADC_CLP0_CLP0_SHIFT                      0
+#define ADC_CLP0_CLP0(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLP0_CLP0_SHIFT))&ADC_CLP0_CLP0_MASK)
+/* CLMD Bit Fields */
+#define ADC_CLMD_CLMD_MASK                       0x3Fu
+#define ADC_CLMD_CLMD_SHIFT                      0
+#define ADC_CLMD_CLMD(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLMD_CLMD_SHIFT))&ADC_CLMD_CLMD_MASK)
+/* CLMS Bit Fields */
+#define ADC_CLMS_CLMS_MASK                       0x3Fu
+#define ADC_CLMS_CLMS_SHIFT                      0
+#define ADC_CLMS_CLMS(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLMS_CLMS_SHIFT))&ADC_CLMS_CLMS_MASK)
+/* CLM4 Bit Fields */
+#define ADC_CLM4_CLM4_MASK                       0x3FFu
+#define ADC_CLM4_CLM4_SHIFT                      0
+#define ADC_CLM4_CLM4(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLM4_CLM4_SHIFT))&ADC_CLM4_CLM4_MASK)
+/* CLM3 Bit Fields */
+#define ADC_CLM3_CLM3_MASK                       0x1FFu
+#define ADC_CLM3_CLM3_SHIFT                      0
+#define ADC_CLM3_CLM3(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLM3_CLM3_SHIFT))&ADC_CLM3_CLM3_MASK)
+/* CLM2 Bit Fields */
+#define ADC_CLM2_CLM2_MASK                       0xFFu
+#define ADC_CLM2_CLM2_SHIFT                      0
+#define ADC_CLM2_CLM2(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLM2_CLM2_SHIFT))&ADC_CLM2_CLM2_MASK)
+/* CLM1 Bit Fields */
+#define ADC_CLM1_CLM1_MASK                       0x7Fu
+#define ADC_CLM1_CLM1_SHIFT                      0
+#define ADC_CLM1_CLM1(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLM1_CLM1_SHIFT))&ADC_CLM1_CLM1_MASK)
+/* CLM0 Bit Fields */
+#define ADC_CLM0_CLM0_MASK                       0x3Fu
+#define ADC_CLM0_CLM0_SHIFT                      0
+#define ADC_CLM0_CLM0(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLM0_CLM0_SHIFT))&ADC_CLM0_CLM0_MASK)
+
+/*!
+ * @}
+ */ /* end of group ADC_Register_Masks */
+
+
+/* ADC - Peripheral instance base addresses */
+/** Peripheral ADC0 base address */
+#define ADC0_BASE                                (0x4003B000u)
+/** Peripheral ADC0 base pointer */
+#define ADC0                                     ((ADC_Type *)ADC0_BASE)
+#define ADC0_BASE_PTR                            (ADC0)
+/** Peripheral ADC1 base address */
+#define ADC1_BASE                                (0x400BB000u)
+/** Peripheral ADC1 base pointer */
+#define ADC1                                     ((ADC_Type *)ADC1_BASE)
+#define ADC1_BASE_PTR                            (ADC1)
+/** Array initializer of ADC peripheral base addresses */
+#define ADC_BASE_ADDRS                           { ADC0_BASE, ADC1_BASE }
+/** Array initializer of ADC peripheral base pointers */
+#define ADC_BASE_PTRS                            { ADC0, ADC1 }
+/** Interrupt vectors for the ADC peripheral type */
+#define ADC_IRQS                                 { ADC0_IRQn, ADC1_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- ADC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ADC_Register_Accessor_Macros ADC - Register accessor macros
+ * @{
+ */
+
+
+/* ADC - Register instance definitions */
+/* ADC0 */
+#define ADC0_SC1A                                ADC_SC1_REG(ADC0,0)
+#define ADC0_SC1B                                ADC_SC1_REG(ADC0,1)
+#define ADC0_CFG1                                ADC_CFG1_REG(ADC0)
+#define ADC0_CFG2                                ADC_CFG2_REG(ADC0)
+#define ADC0_RA                                  ADC_R_REG(ADC0,0)
+#define ADC0_RB                                  ADC_R_REG(ADC0,1)
+#define ADC0_CV1                                 ADC_CV1_REG(ADC0)
+#define ADC0_CV2                                 ADC_CV2_REG(ADC0)
+#define ADC0_SC2                                 ADC_SC2_REG(ADC0)
+#define ADC0_SC3                                 ADC_SC3_REG(ADC0)
+#define ADC0_OFS                                 ADC_OFS_REG(ADC0)
+#define ADC0_PG                                  ADC_PG_REG(ADC0)
+#define ADC0_MG                                  ADC_MG_REG(ADC0)
+#define ADC0_CLPD                                ADC_CLPD_REG(ADC0)
+#define ADC0_CLPS                                ADC_CLPS_REG(ADC0)
+#define ADC0_CLP4                                ADC_CLP4_REG(ADC0)
+#define ADC0_CLP3                                ADC_CLP3_REG(ADC0)
+#define ADC0_CLP2                                ADC_CLP2_REG(ADC0)
+#define ADC0_CLP1                                ADC_CLP1_REG(ADC0)
+#define ADC0_CLP0                                ADC_CLP0_REG(ADC0)
+#define ADC0_CLMD                                ADC_CLMD_REG(ADC0)
+#define ADC0_CLMS                                ADC_CLMS_REG(ADC0)
+#define ADC0_CLM4                                ADC_CLM4_REG(ADC0)
+#define ADC0_CLM3                                ADC_CLM3_REG(ADC0)
+#define ADC0_CLM2                                ADC_CLM2_REG(ADC0)
+#define ADC0_CLM1                                ADC_CLM1_REG(ADC0)
+#define ADC0_CLM0                                ADC_CLM0_REG(ADC0)
+/* ADC1 */
+#define ADC1_SC1A                                ADC_SC1_REG(ADC1,0)
+#define ADC1_SC1B                                ADC_SC1_REG(ADC1,1)
+#define ADC1_CFG1                                ADC_CFG1_REG(ADC1)
+#define ADC1_CFG2                                ADC_CFG2_REG(ADC1)
+#define ADC1_RA                                  ADC_R_REG(ADC1,0)
+#define ADC1_RB                                  ADC_R_REG(ADC1,1)
+#define ADC1_CV1                                 ADC_CV1_REG(ADC1)
+#define ADC1_CV2                                 ADC_CV2_REG(ADC1)
+#define ADC1_SC2                                 ADC_SC2_REG(ADC1)
+#define ADC1_SC3                                 ADC_SC3_REG(ADC1)
+#define ADC1_OFS                                 ADC_OFS_REG(ADC1)
+#define ADC1_PG                                  ADC_PG_REG(ADC1)
+#define ADC1_MG                                  ADC_MG_REG(ADC1)
+#define ADC1_CLPD                                ADC_CLPD_REG(ADC1)
+#define ADC1_CLPS                                ADC_CLPS_REG(ADC1)
+#define ADC1_CLP4                                ADC_CLP4_REG(ADC1)
+#define ADC1_CLP3                                ADC_CLP3_REG(ADC1)
+#define ADC1_CLP2                                ADC_CLP2_REG(ADC1)
+#define ADC1_CLP1                                ADC_CLP1_REG(ADC1)
+#define ADC1_CLP0                                ADC_CLP0_REG(ADC1)
+#define ADC1_CLMD                                ADC_CLMD_REG(ADC1)
+#define ADC1_CLMS                                ADC_CLMS_REG(ADC1)
+#define ADC1_CLM4                                ADC_CLM4_REG(ADC1)
+#define ADC1_CLM3                                ADC_CLM3_REG(ADC1)
+#define ADC1_CLM2                                ADC_CLM2_REG(ADC1)
+#define ADC1_CLM1                                ADC_CLM1_REG(ADC1)
+#define ADC1_CLM0                                ADC_CLM0_REG(ADC1)
+
+/* ADC - Register array accessors */
+#define ADC0_SC1(index)                          ADC_SC1_REG(ADC0,index)
+#define ADC1_SC1(index)                          ADC_SC1_REG(ADC1,index)
+#define ADC0_R(index)                            ADC_R_REG(ADC0,index)
+#define ADC1_R(index)                            ADC_R_REG(ADC1,index)
+
+/*!
+ * @}
+ */ /* end of group ADC_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group ADC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- AIPS Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup AIPS_Peripheral_Access_Layer AIPS Peripheral Access Layer
+ * @{
+ */
+
+/** AIPS - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t MPRA;                              /**< Master Privilege Register A, offset: 0x0 */
+       uint8_t RESERVED_0[28];
+  __IO uint32_t PACRA;                             /**< Peripheral Access Control Register, offset: 0x20 */
+  __IO uint32_t PACRB;                             /**< Peripheral Access Control Register, offset: 0x24 */
+  __IO uint32_t PACRC;                             /**< Peripheral Access Control Register, offset: 0x28 */
+  __IO uint32_t PACRD;                             /**< Peripheral Access Control Register, offset: 0x2C */
+       uint8_t RESERVED_1[16];
+  __IO uint32_t PACRE;                             /**< Peripheral Access Control Register, offset: 0x40 */
+  __IO uint32_t PACRF;                             /**< Peripheral Access Control Register, offset: 0x44 */
+  __IO uint32_t PACRG;                             /**< Peripheral Access Control Register, offset: 0x48 */
+  __IO uint32_t PACRH;                             /**< Peripheral Access Control Register, offset: 0x4C */
+  __IO uint32_t PACRI;                             /**< Peripheral Access Control Register, offset: 0x50 */
+  __IO uint32_t PACRJ;                             /**< Peripheral Access Control Register, offset: 0x54 */
+  __IO uint32_t PACRK;                             /**< Peripheral Access Control Register, offset: 0x58 */
+  __IO uint32_t PACRL;                             /**< Peripheral Access Control Register, offset: 0x5C */
+  __IO uint32_t PACRM;                             /**< Peripheral Access Control Register, offset: 0x60 */
+  __IO uint32_t PACRN;                             /**< Peripheral Access Control Register, offset: 0x64 */
+  __IO uint32_t PACRO;                             /**< Peripheral Access Control Register, offset: 0x68 */
+  __IO uint32_t PACRP;                             /**< Peripheral Access Control Register, offset: 0x6C */
+       uint8_t RESERVED_2[16];
+  __IO uint32_t PACRU;                             /**< Peripheral Access Control Register, offset: 0x80 */
+} AIPS_Type, *AIPS_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- AIPS - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup AIPS_Register_Accessor_Macros AIPS - Register accessor macros
+ * @{
+ */
+
+
+/* AIPS - Register accessors */
+#define AIPS_MPRA_REG(base)                      ((base)->MPRA)
+#define AIPS_PACRA_REG(base)                     ((base)->PACRA)
+#define AIPS_PACRB_REG(base)                     ((base)->PACRB)
+#define AIPS_PACRC_REG(base)                     ((base)->PACRC)
+#define AIPS_PACRD_REG(base)                     ((base)->PACRD)
+#define AIPS_PACRE_REG(base)                     ((base)->PACRE)
+#define AIPS_PACRF_REG(base)                     ((base)->PACRF)
+#define AIPS_PACRG_REG(base)                     ((base)->PACRG)
+#define AIPS_PACRH_REG(base)                     ((base)->PACRH)
+#define AIPS_PACRI_REG(base)                     ((base)->PACRI)
+#define AIPS_PACRJ_REG(base)                     ((base)->PACRJ)
+#define AIPS_PACRK_REG(base)                     ((base)->PACRK)
+#define AIPS_PACRL_REG(base)                     ((base)->PACRL)
+#define AIPS_PACRM_REG(base)                     ((base)->PACRM)
+#define AIPS_PACRN_REG(base)                     ((base)->PACRN)
+#define AIPS_PACRO_REG(base)                     ((base)->PACRO)
+#define AIPS_PACRP_REG(base)                     ((base)->PACRP)
+#define AIPS_PACRU_REG(base)                     ((base)->PACRU)
+
+/*!
+ * @}
+ */ /* end of group AIPS_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- AIPS Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup AIPS_Register_Masks AIPS Register Masks
+ * @{
+ */
+
+/* MPRA Bit Fields */
+#define AIPS_MPRA_MPL5_MASK                      0x100u
+#define AIPS_MPRA_MPL5_SHIFT                     8
+#define AIPS_MPRA_MTW5_MASK                      0x200u
+#define AIPS_MPRA_MTW5_SHIFT                     9
+#define AIPS_MPRA_MTR5_MASK                      0x400u
+#define AIPS_MPRA_MTR5_SHIFT                     10
+#define AIPS_MPRA_MPL4_MASK                      0x1000u
+#define AIPS_MPRA_MPL4_SHIFT                     12
+#define AIPS_MPRA_MTW4_MASK                      0x2000u
+#define AIPS_MPRA_MTW4_SHIFT                     13
+#define AIPS_MPRA_MTR4_MASK                      0x4000u
+#define AIPS_MPRA_MTR4_SHIFT                     14
+#define AIPS_MPRA_MPL3_MASK                      0x10000u
+#define AIPS_MPRA_MPL3_SHIFT                     16
+#define AIPS_MPRA_MTW3_MASK                      0x20000u
+#define AIPS_MPRA_MTW3_SHIFT                     17
+#define AIPS_MPRA_MTR3_MASK                      0x40000u
+#define AIPS_MPRA_MTR3_SHIFT                     18
+#define AIPS_MPRA_MPL2_MASK                      0x100000u
+#define AIPS_MPRA_MPL2_SHIFT                     20
+#define AIPS_MPRA_MTW2_MASK                      0x200000u
+#define AIPS_MPRA_MTW2_SHIFT                     21
+#define AIPS_MPRA_MTR2_MASK                      0x400000u
+#define AIPS_MPRA_MTR2_SHIFT                     22
+#define AIPS_MPRA_MPL1_MASK                      0x1000000u
+#define AIPS_MPRA_MPL1_SHIFT                     24
+#define AIPS_MPRA_MTW1_MASK                      0x2000000u
+#define AIPS_MPRA_MTW1_SHIFT                     25
+#define AIPS_MPRA_MTR1_MASK                      0x4000000u
+#define AIPS_MPRA_MTR1_SHIFT                     26
+#define AIPS_MPRA_MPL0_MASK                      0x10000000u
+#define AIPS_MPRA_MPL0_SHIFT                     28
+#define AIPS_MPRA_MTW0_MASK                      0x20000000u
+#define AIPS_MPRA_MTW0_SHIFT                     29
+#define AIPS_MPRA_MTR0_MASK                      0x40000000u
+#define AIPS_MPRA_MTR0_SHIFT                     30
+/* PACRA Bit Fields */
+#define AIPS_PACRA_TP7_MASK                      0x1u
+#define AIPS_PACRA_TP7_SHIFT                     0
+#define AIPS_PACRA_WP7_MASK                      0x2u
+#define AIPS_PACRA_WP7_SHIFT                     1
+#define AIPS_PACRA_SP7_MASK                      0x4u
+#define AIPS_PACRA_SP7_SHIFT                     2
+#define AIPS_PACRA_TP6_MASK                      0x10u
+#define AIPS_PACRA_TP6_SHIFT                     4
+#define AIPS_PACRA_WP6_MASK                      0x20u
+#define AIPS_PACRA_WP6_SHIFT                     5
+#define AIPS_PACRA_SP6_MASK                      0x40u
+#define AIPS_PACRA_SP6_SHIFT                     6
+#define AIPS_PACRA_TP5_MASK                      0x100u
+#define AIPS_PACRA_TP5_SHIFT                     8
+#define AIPS_PACRA_WP5_MASK                      0x200u
+#define AIPS_PACRA_WP5_SHIFT                     9
+#define AIPS_PACRA_SP5_MASK                      0x400u
+#define AIPS_PACRA_SP5_SHIFT                     10
+#define AIPS_PACRA_TP4_MASK                      0x1000u
+#define AIPS_PACRA_TP4_SHIFT                     12
+#define AIPS_PACRA_WP4_MASK                      0x2000u
+#define AIPS_PACRA_WP4_SHIFT                     13
+#define AIPS_PACRA_SP4_MASK                      0x4000u
+#define AIPS_PACRA_SP4_SHIFT                     14
+#define AIPS_PACRA_TP3_MASK                      0x10000u
+#define AIPS_PACRA_TP3_SHIFT                     16
+#define AIPS_PACRA_WP3_MASK                      0x20000u
+#define AIPS_PACRA_WP3_SHIFT                     17
+#define AIPS_PACRA_SP3_MASK                      0x40000u
+#define AIPS_PACRA_SP3_SHIFT                     18
+#define AIPS_PACRA_TP2_MASK                      0x100000u
+#define AIPS_PACRA_TP2_SHIFT                     20
+#define AIPS_PACRA_WP2_MASK                      0x200000u
+#define AIPS_PACRA_WP2_SHIFT                     21
+#define AIPS_PACRA_SP2_MASK                      0x400000u
+#define AIPS_PACRA_SP2_SHIFT                     22
+#define AIPS_PACRA_TP1_MASK                      0x1000000u
+#define AIPS_PACRA_TP1_SHIFT                     24
+#define AIPS_PACRA_WP1_MASK                      0x2000000u
+#define AIPS_PACRA_WP1_SHIFT                     25
+#define AIPS_PACRA_SP1_MASK                      0x4000000u
+#define AIPS_PACRA_SP1_SHIFT                     26
+#define AIPS_PACRA_TP0_MASK                      0x10000000u
+#define AIPS_PACRA_TP0_SHIFT                     28
+#define AIPS_PACRA_WP0_MASK                      0x20000000u
+#define AIPS_PACRA_WP0_SHIFT                     29
+#define AIPS_PACRA_SP0_MASK                      0x40000000u
+#define AIPS_PACRA_SP0_SHIFT                     30
+/* PACRB Bit Fields */
+#define AIPS_PACRB_TP7_MASK                      0x1u
+#define AIPS_PACRB_TP7_SHIFT                     0
+#define AIPS_PACRB_WP7_MASK                      0x2u
+#define AIPS_PACRB_WP7_SHIFT                     1
+#define AIPS_PACRB_SP7_MASK                      0x4u
+#define AIPS_PACRB_SP7_SHIFT                     2
+#define AIPS_PACRB_TP6_MASK                      0x10u
+#define AIPS_PACRB_TP6_SHIFT                     4
+#define AIPS_PACRB_WP6_MASK                      0x20u
+#define AIPS_PACRB_WP6_SHIFT                     5
+#define AIPS_PACRB_SP6_MASK                      0x40u
+#define AIPS_PACRB_SP6_SHIFT                     6
+#define AIPS_PACRB_TP5_MASK                      0x100u
+#define AIPS_PACRB_TP5_SHIFT                     8
+#define AIPS_PACRB_WP5_MASK                      0x200u
+#define AIPS_PACRB_WP5_SHIFT                     9
+#define AIPS_PACRB_SP5_MASK                      0x400u
+#define AIPS_PACRB_SP5_SHIFT                     10
+#define AIPS_PACRB_TP4_MASK                      0x1000u
+#define AIPS_PACRB_TP4_SHIFT                     12
+#define AIPS_PACRB_WP4_MASK                      0x2000u
+#define AIPS_PACRB_WP4_SHIFT                     13
+#define AIPS_PACRB_SP4_MASK                      0x4000u
+#define AIPS_PACRB_SP4_SHIFT                     14
+#define AIPS_PACRB_TP3_MASK                      0x10000u
+#define AIPS_PACRB_TP3_SHIFT                     16
+#define AIPS_PACRB_WP3_MASK                      0x20000u
+#define AIPS_PACRB_WP3_SHIFT                     17
+#define AIPS_PACRB_SP3_MASK                      0x40000u
+#define AIPS_PACRB_SP3_SHIFT                     18
+#define AIPS_PACRB_TP2_MASK                      0x100000u
+#define AIPS_PACRB_TP2_SHIFT                     20
+#define AIPS_PACRB_WP2_MASK                      0x200000u
+#define AIPS_PACRB_WP2_SHIFT                     21
+#define AIPS_PACRB_SP2_MASK                      0x400000u
+#define AIPS_PACRB_SP2_SHIFT                     22
+#define AIPS_PACRB_TP1_MASK                      0x1000000u
+#define AIPS_PACRB_TP1_SHIFT                     24
+#define AIPS_PACRB_WP1_MASK                      0x2000000u
+#define AIPS_PACRB_WP1_SHIFT                     25
+#define AIPS_PACRB_SP1_MASK                      0x4000000u
+#define AIPS_PACRB_SP1_SHIFT                     26
+#define AIPS_PACRB_TP0_MASK                      0x10000000u
+#define AIPS_PACRB_TP0_SHIFT                     28
+#define AIPS_PACRB_WP0_MASK                      0x20000000u
+#define AIPS_PACRB_WP0_SHIFT                     29
+#define AIPS_PACRB_SP0_MASK                      0x40000000u
+#define AIPS_PACRB_SP0_SHIFT                     30
+/* PACRC Bit Fields */
+#define AIPS_PACRC_TP7_MASK                      0x1u
+#define AIPS_PACRC_TP7_SHIFT                     0
+#define AIPS_PACRC_WP7_MASK                      0x2u
+#define AIPS_PACRC_WP7_SHIFT                     1
+#define AIPS_PACRC_SP7_MASK                      0x4u
+#define AIPS_PACRC_SP7_SHIFT                     2
+#define AIPS_PACRC_TP6_MASK                      0x10u
+#define AIPS_PACRC_TP6_SHIFT                     4
+#define AIPS_PACRC_WP6_MASK                      0x20u
+#define AIPS_PACRC_WP6_SHIFT                     5
+#define AIPS_PACRC_SP6_MASK                      0x40u
+#define AIPS_PACRC_SP6_SHIFT                     6
+#define AIPS_PACRC_TP5_MASK                      0x100u
+#define AIPS_PACRC_TP5_SHIFT                     8
+#define AIPS_PACRC_WP5_MASK                      0x200u
+#define AIPS_PACRC_WP5_SHIFT                     9
+#define AIPS_PACRC_SP5_MASK                      0x400u
+#define AIPS_PACRC_SP5_SHIFT                     10
+#define AIPS_PACRC_TP4_MASK                      0x1000u
+#define AIPS_PACRC_TP4_SHIFT                     12
+#define AIPS_PACRC_WP4_MASK                      0x2000u
+#define AIPS_PACRC_WP4_SHIFT                     13
+#define AIPS_PACRC_SP4_MASK                      0x4000u
+#define AIPS_PACRC_SP4_SHIFT                     14
+#define AIPS_PACRC_TP3_MASK                      0x10000u
+#define AIPS_PACRC_TP3_SHIFT                     16
+#define AIPS_PACRC_WP3_MASK                      0x20000u
+#define AIPS_PACRC_WP3_SHIFT                     17
+#define AIPS_PACRC_SP3_MASK                      0x40000u
+#define AIPS_PACRC_SP3_SHIFT                     18
+#define AIPS_PACRC_TP2_MASK                      0x100000u
+#define AIPS_PACRC_TP2_SHIFT                     20
+#define AIPS_PACRC_WP2_MASK                      0x200000u
+#define AIPS_PACRC_WP2_SHIFT                     21
+#define AIPS_PACRC_SP2_MASK                      0x400000u
+#define AIPS_PACRC_SP2_SHIFT                     22
+#define AIPS_PACRC_TP1_MASK                      0x1000000u
+#define AIPS_PACRC_TP1_SHIFT                     24
+#define AIPS_PACRC_WP1_MASK                      0x2000000u
+#define AIPS_PACRC_WP1_SHIFT                     25
+#define AIPS_PACRC_SP1_MASK                      0x4000000u
+#define AIPS_PACRC_SP1_SHIFT                     26
+#define AIPS_PACRC_TP0_MASK                      0x10000000u
+#define AIPS_PACRC_TP0_SHIFT                     28
+#define AIPS_PACRC_WP0_MASK                      0x20000000u
+#define AIPS_PACRC_WP0_SHIFT                     29
+#define AIPS_PACRC_SP0_MASK                      0x40000000u
+#define AIPS_PACRC_SP0_SHIFT                     30
+/* PACRD Bit Fields */
+#define AIPS_PACRD_TP7_MASK                      0x1u
+#define AIPS_PACRD_TP7_SHIFT                     0
+#define AIPS_PACRD_WP7_MASK                      0x2u
+#define AIPS_PACRD_WP7_SHIFT                     1
+#define AIPS_PACRD_SP7_MASK                      0x4u
+#define AIPS_PACRD_SP7_SHIFT                     2
+#define AIPS_PACRD_TP6_MASK                      0x10u
+#define AIPS_PACRD_TP6_SHIFT                     4
+#define AIPS_PACRD_WP6_MASK                      0x20u
+#define AIPS_PACRD_WP6_SHIFT                     5
+#define AIPS_PACRD_SP6_MASK                      0x40u
+#define AIPS_PACRD_SP6_SHIFT                     6
+#define AIPS_PACRD_TP5_MASK                      0x100u
+#define AIPS_PACRD_TP5_SHIFT                     8
+#define AIPS_PACRD_WP5_MASK                      0x200u
+#define AIPS_PACRD_WP5_SHIFT                     9
+#define AIPS_PACRD_SP5_MASK                      0x400u
+#define AIPS_PACRD_SP5_SHIFT                     10
+#define AIPS_PACRD_TP4_MASK                      0x1000u
+#define AIPS_PACRD_TP4_SHIFT                     12
+#define AIPS_PACRD_WP4_MASK                      0x2000u
+#define AIPS_PACRD_WP4_SHIFT                     13
+#define AIPS_PACRD_SP4_MASK                      0x4000u
+#define AIPS_PACRD_SP4_SHIFT                     14
+#define AIPS_PACRD_TP3_MASK                      0x10000u
+#define AIPS_PACRD_TP3_SHIFT                     16
+#define AIPS_PACRD_WP3_MASK                      0x20000u
+#define AIPS_PACRD_WP3_SHIFT                     17
+#define AIPS_PACRD_SP3_MASK                      0x40000u
+#define AIPS_PACRD_SP3_SHIFT                     18
+#define AIPS_PACRD_TP2_MASK                      0x100000u
+#define AIPS_PACRD_TP2_SHIFT                     20
+#define AIPS_PACRD_WP2_MASK                      0x200000u
+#define AIPS_PACRD_WP2_SHIFT                     21
+#define AIPS_PACRD_SP2_MASK                      0x400000u
+#define AIPS_PACRD_SP2_SHIFT                     22
+#define AIPS_PACRD_TP1_MASK                      0x1000000u
+#define AIPS_PACRD_TP1_SHIFT                     24
+#define AIPS_PACRD_WP1_MASK                      0x2000000u
+#define AIPS_PACRD_WP1_SHIFT                     25
+#define AIPS_PACRD_SP1_MASK                      0x4000000u
+#define AIPS_PACRD_SP1_SHIFT                     26
+#define AIPS_PACRD_TP0_MASK                      0x10000000u
+#define AIPS_PACRD_TP0_SHIFT                     28
+#define AIPS_PACRD_WP0_MASK                      0x20000000u
+#define AIPS_PACRD_WP0_SHIFT                     29
+#define AIPS_PACRD_SP0_MASK                      0x40000000u
+#define AIPS_PACRD_SP0_SHIFT                     30
+/* PACRE Bit Fields */
+#define AIPS_PACRE_TP7_MASK                      0x1u
+#define AIPS_PACRE_TP7_SHIFT                     0
+#define AIPS_PACRE_WP7_MASK                      0x2u
+#define AIPS_PACRE_WP7_SHIFT                     1
+#define AIPS_PACRE_SP7_MASK                      0x4u
+#define AIPS_PACRE_SP7_SHIFT                     2
+#define AIPS_PACRE_TP6_MASK                      0x10u
+#define AIPS_PACRE_TP6_SHIFT                     4
+#define AIPS_PACRE_WP6_MASK                      0x20u
+#define AIPS_PACRE_WP6_SHIFT                     5
+#define AIPS_PACRE_SP6_MASK                      0x40u
+#define AIPS_PACRE_SP6_SHIFT                     6
+#define AIPS_PACRE_TP5_MASK                      0x100u
+#define AIPS_PACRE_TP5_SHIFT                     8
+#define AIPS_PACRE_WP5_MASK                      0x200u
+#define AIPS_PACRE_WP5_SHIFT                     9
+#define AIPS_PACRE_SP5_MASK                      0x400u
+#define AIPS_PACRE_SP5_SHIFT                     10
+#define AIPS_PACRE_TP4_MASK                      0x1000u
+#define AIPS_PACRE_TP4_SHIFT                     12
+#define AIPS_PACRE_WP4_MASK                      0x2000u
+#define AIPS_PACRE_WP4_SHIFT                     13
+#define AIPS_PACRE_SP4_MASK                      0x4000u
+#define AIPS_PACRE_SP4_SHIFT                     14
+#define AIPS_PACRE_TP3_MASK                      0x10000u
+#define AIPS_PACRE_TP3_SHIFT                     16
+#define AIPS_PACRE_WP3_MASK                      0x20000u
+#define AIPS_PACRE_WP3_SHIFT                     17
+#define AIPS_PACRE_SP3_MASK                      0x40000u
+#define AIPS_PACRE_SP3_SHIFT                     18
+#define AIPS_PACRE_TP2_MASK                      0x100000u
+#define AIPS_PACRE_TP2_SHIFT                     20
+#define AIPS_PACRE_WP2_MASK                      0x200000u
+#define AIPS_PACRE_WP2_SHIFT                     21
+#define AIPS_PACRE_SP2_MASK                      0x400000u
+#define AIPS_PACRE_SP2_SHIFT                     22
+#define AIPS_PACRE_TP1_MASK                      0x1000000u
+#define AIPS_PACRE_TP1_SHIFT                     24
+#define AIPS_PACRE_WP1_MASK                      0x2000000u
+#define AIPS_PACRE_WP1_SHIFT                     25
+#define AIPS_PACRE_SP1_MASK                      0x4000000u
+#define AIPS_PACRE_SP1_SHIFT                     26
+#define AIPS_PACRE_TP0_MASK                      0x10000000u
+#define AIPS_PACRE_TP0_SHIFT                     28
+#define AIPS_PACRE_WP0_MASK                      0x20000000u
+#define AIPS_PACRE_WP0_SHIFT                     29
+#define AIPS_PACRE_SP0_MASK                      0x40000000u
+#define AIPS_PACRE_SP0_SHIFT                     30
+/* PACRF Bit Fields */
+#define AIPS_PACRF_TP7_MASK                      0x1u
+#define AIPS_PACRF_TP7_SHIFT                     0
+#define AIPS_PACRF_WP7_MASK                      0x2u
+#define AIPS_PACRF_WP7_SHIFT                     1
+#define AIPS_PACRF_SP7_MASK                      0x4u
+#define AIPS_PACRF_SP7_SHIFT                     2
+#define AIPS_PACRF_TP6_MASK                      0x10u
+#define AIPS_PACRF_TP6_SHIFT                     4
+#define AIPS_PACRF_WP6_MASK                      0x20u
+#define AIPS_PACRF_WP6_SHIFT                     5
+#define AIPS_PACRF_SP6_MASK                      0x40u
+#define AIPS_PACRF_SP6_SHIFT                     6
+#define AIPS_PACRF_TP5_MASK                      0x100u
+#define AIPS_PACRF_TP5_SHIFT                     8
+#define AIPS_PACRF_WP5_MASK                      0x200u
+#define AIPS_PACRF_WP5_SHIFT                     9
+#define AIPS_PACRF_SP5_MASK                      0x400u
+#define AIPS_PACRF_SP5_SHIFT                     10
+#define AIPS_PACRF_TP4_MASK                      0x1000u
+#define AIPS_PACRF_TP4_SHIFT                     12
+#define AIPS_PACRF_WP4_MASK                      0x2000u
+#define AIPS_PACRF_WP4_SHIFT                     13
+#define AIPS_PACRF_SP4_MASK                      0x4000u
+#define AIPS_PACRF_SP4_SHIFT                     14
+#define AIPS_PACRF_TP3_MASK                      0x10000u
+#define AIPS_PACRF_TP3_SHIFT                     16
+#define AIPS_PACRF_WP3_MASK                      0x20000u
+#define AIPS_PACRF_WP3_SHIFT                     17
+#define AIPS_PACRF_SP3_MASK                      0x40000u
+#define AIPS_PACRF_SP3_SHIFT                     18
+#define AIPS_PACRF_TP2_MASK                      0x100000u
+#define AIPS_PACRF_TP2_SHIFT                     20
+#define AIPS_PACRF_WP2_MASK                      0x200000u
+#define AIPS_PACRF_WP2_SHIFT                     21
+#define AIPS_PACRF_SP2_MASK                      0x400000u
+#define AIPS_PACRF_SP2_SHIFT                     22
+#define AIPS_PACRF_TP1_MASK                      0x1000000u
+#define AIPS_PACRF_TP1_SHIFT                     24
+#define AIPS_PACRF_WP1_MASK                      0x2000000u
+#define AIPS_PACRF_WP1_SHIFT                     25
+#define AIPS_PACRF_SP1_MASK                      0x4000000u
+#define AIPS_PACRF_SP1_SHIFT                     26
+#define AIPS_PACRF_TP0_MASK                      0x10000000u
+#define AIPS_PACRF_TP0_SHIFT                     28
+#define AIPS_PACRF_WP0_MASK                      0x20000000u
+#define AIPS_PACRF_WP0_SHIFT                     29
+#define AIPS_PACRF_SP0_MASK                      0x40000000u
+#define AIPS_PACRF_SP0_SHIFT                     30
+/* PACRG Bit Fields */
+#define AIPS_PACRG_TP7_MASK                      0x1u
+#define AIPS_PACRG_TP7_SHIFT                     0
+#define AIPS_PACRG_WP7_MASK                      0x2u
+#define AIPS_PACRG_WP7_SHIFT                     1
+#define AIPS_PACRG_SP7_MASK                      0x4u
+#define AIPS_PACRG_SP7_SHIFT                     2
+#define AIPS_PACRG_TP6_MASK                      0x10u
+#define AIPS_PACRG_TP6_SHIFT                     4
+#define AIPS_PACRG_WP6_MASK                      0x20u
+#define AIPS_PACRG_WP6_SHIFT                     5
+#define AIPS_PACRG_SP6_MASK                      0x40u
+#define AIPS_PACRG_SP6_SHIFT                     6
+#define AIPS_PACRG_TP5_MASK                      0x100u
+#define AIPS_PACRG_TP5_SHIFT                     8
+#define AIPS_PACRG_WP5_MASK                      0x200u
+#define AIPS_PACRG_WP5_SHIFT                     9
+#define AIPS_PACRG_SP5_MASK                      0x400u
+#define AIPS_PACRG_SP5_SHIFT                     10
+#define AIPS_PACRG_TP4_MASK                      0x1000u
+#define AIPS_PACRG_TP4_SHIFT                     12
+#define AIPS_PACRG_WP4_MASK                      0x2000u
+#define AIPS_PACRG_WP4_SHIFT                     13
+#define AIPS_PACRG_SP4_MASK                      0x4000u
+#define AIPS_PACRG_SP4_SHIFT                     14
+#define AIPS_PACRG_TP3_MASK                      0x10000u
+#define AIPS_PACRG_TP3_SHIFT                     16
+#define AIPS_PACRG_WP3_MASK                      0x20000u
+#define AIPS_PACRG_WP3_SHIFT                     17
+#define AIPS_PACRG_SP3_MASK                      0x40000u
+#define AIPS_PACRG_SP3_SHIFT                     18
+#define AIPS_PACRG_TP2_MASK                      0x100000u
+#define AIPS_PACRG_TP2_SHIFT                     20
+#define AIPS_PACRG_WP2_MASK                      0x200000u
+#define AIPS_PACRG_WP2_SHIFT                     21
+#define AIPS_PACRG_SP2_MASK                      0x400000u
+#define AIPS_PACRG_SP2_SHIFT                     22
+#define AIPS_PACRG_TP1_MASK                      0x1000000u
+#define AIPS_PACRG_TP1_SHIFT                     24
+#define AIPS_PACRG_WP1_MASK                      0x2000000u
+#define AIPS_PACRG_WP1_SHIFT                     25
+#define AIPS_PACRG_SP1_MASK                      0x4000000u
+#define AIPS_PACRG_SP1_SHIFT                     26
+#define AIPS_PACRG_TP0_MASK                      0x10000000u
+#define AIPS_PACRG_TP0_SHIFT                     28
+#define AIPS_PACRG_WP0_MASK                      0x20000000u
+#define AIPS_PACRG_WP0_SHIFT                     29
+#define AIPS_PACRG_SP0_MASK                      0x40000000u
+#define AIPS_PACRG_SP0_SHIFT                     30
+/* PACRH Bit Fields */
+#define AIPS_PACRH_TP7_MASK                      0x1u
+#define AIPS_PACRH_TP7_SHIFT                     0
+#define AIPS_PACRH_WP7_MASK                      0x2u
+#define AIPS_PACRH_WP7_SHIFT                     1
+#define AIPS_PACRH_SP7_MASK                      0x4u
+#define AIPS_PACRH_SP7_SHIFT                     2
+#define AIPS_PACRH_TP6_MASK                      0x10u
+#define AIPS_PACRH_TP6_SHIFT                     4
+#define AIPS_PACRH_WP6_MASK                      0x20u
+#define AIPS_PACRH_WP6_SHIFT                     5
+#define AIPS_PACRH_SP6_MASK                      0x40u
+#define AIPS_PACRH_SP6_SHIFT                     6
+#define AIPS_PACRH_TP5_MASK                      0x100u
+#define AIPS_PACRH_TP5_SHIFT                     8
+#define AIPS_PACRH_WP5_MASK                      0x200u
+#define AIPS_PACRH_WP5_SHIFT                     9
+#define AIPS_PACRH_SP5_MASK                      0x400u
+#define AIPS_PACRH_SP5_SHIFT                     10
+#define AIPS_PACRH_TP4_MASK                      0x1000u
+#define AIPS_PACRH_TP4_SHIFT                     12
+#define AIPS_PACRH_WP4_MASK                      0x2000u
+#define AIPS_PACRH_WP4_SHIFT                     13
+#define AIPS_PACRH_SP4_MASK                      0x4000u
+#define AIPS_PACRH_SP4_SHIFT                     14
+#define AIPS_PACRH_TP3_MASK                      0x10000u
+#define AIPS_PACRH_TP3_SHIFT                     16
+#define AIPS_PACRH_WP3_MASK                      0x20000u
+#define AIPS_PACRH_WP3_SHIFT                     17
+#define AIPS_PACRH_SP3_MASK                      0x40000u
+#define AIPS_PACRH_SP3_SHIFT                     18
+#define AIPS_PACRH_TP2_MASK                      0x100000u
+#define AIPS_PACRH_TP2_SHIFT                     20
+#define AIPS_PACRH_WP2_MASK                      0x200000u
+#define AIPS_PACRH_WP2_SHIFT                     21
+#define AIPS_PACRH_SP2_MASK                      0x400000u
+#define AIPS_PACRH_SP2_SHIFT                     22
+#define AIPS_PACRH_TP1_MASK                      0x1000000u
+#define AIPS_PACRH_TP1_SHIFT                     24
+#define AIPS_PACRH_WP1_MASK                      0x2000000u
+#define AIPS_PACRH_WP1_SHIFT                     25
+#define AIPS_PACRH_SP1_MASK                      0x4000000u
+#define AIPS_PACRH_SP1_SHIFT                     26
+#define AIPS_PACRH_TP0_MASK                      0x10000000u
+#define AIPS_PACRH_TP0_SHIFT                     28
+#define AIPS_PACRH_WP0_MASK                      0x20000000u
+#define AIPS_PACRH_WP0_SHIFT                     29
+#define AIPS_PACRH_SP0_MASK                      0x40000000u
+#define AIPS_PACRH_SP0_SHIFT                     30
+/* PACRI Bit Fields */
+#define AIPS_PACRI_TP7_MASK                      0x1u
+#define AIPS_PACRI_TP7_SHIFT                     0
+#define AIPS_PACRI_WP7_MASK                      0x2u
+#define AIPS_PACRI_WP7_SHIFT                     1
+#define AIPS_PACRI_SP7_MASK                      0x4u
+#define AIPS_PACRI_SP7_SHIFT                     2
+#define AIPS_PACRI_TP6_MASK                      0x10u
+#define AIPS_PACRI_TP6_SHIFT                     4
+#define AIPS_PACRI_WP6_MASK                      0x20u
+#define AIPS_PACRI_WP6_SHIFT                     5
+#define AIPS_PACRI_SP6_MASK                      0x40u
+#define AIPS_PACRI_SP6_SHIFT                     6
+#define AIPS_PACRI_TP5_MASK                      0x100u
+#define AIPS_PACRI_TP5_SHIFT                     8
+#define AIPS_PACRI_WP5_MASK                      0x200u
+#define AIPS_PACRI_WP5_SHIFT                     9
+#define AIPS_PACRI_SP5_MASK                      0x400u
+#define AIPS_PACRI_SP5_SHIFT                     10
+#define AIPS_PACRI_TP4_MASK                      0x1000u
+#define AIPS_PACRI_TP4_SHIFT                     12
+#define AIPS_PACRI_WP4_MASK                      0x2000u
+#define AIPS_PACRI_WP4_SHIFT                     13
+#define AIPS_PACRI_SP4_MASK                      0x4000u
+#define AIPS_PACRI_SP4_SHIFT                     14
+#define AIPS_PACRI_TP3_MASK                      0x10000u
+#define AIPS_PACRI_TP3_SHIFT                     16
+#define AIPS_PACRI_WP3_MASK                      0x20000u
+#define AIPS_PACRI_WP3_SHIFT                     17
+#define AIPS_PACRI_SP3_MASK                      0x40000u
+#define AIPS_PACRI_SP3_SHIFT                     18
+#define AIPS_PACRI_TP2_MASK                      0x100000u
+#define AIPS_PACRI_TP2_SHIFT                     20
+#define AIPS_PACRI_WP2_MASK                      0x200000u
+#define AIPS_PACRI_WP2_SHIFT                     21
+#define AIPS_PACRI_SP2_MASK                      0x400000u
+#define AIPS_PACRI_SP2_SHIFT                     22
+#define AIPS_PACRI_TP1_MASK                      0x1000000u
+#define AIPS_PACRI_TP1_SHIFT                     24
+#define AIPS_PACRI_WP1_MASK                      0x2000000u
+#define AIPS_PACRI_WP1_SHIFT                     25
+#define AIPS_PACRI_SP1_MASK                      0x4000000u
+#define AIPS_PACRI_SP1_SHIFT                     26
+#define AIPS_PACRI_TP0_MASK                      0x10000000u
+#define AIPS_PACRI_TP0_SHIFT                     28
+#define AIPS_PACRI_WP0_MASK                      0x20000000u
+#define AIPS_PACRI_WP0_SHIFT                     29
+#define AIPS_PACRI_SP0_MASK                      0x40000000u
+#define AIPS_PACRI_SP0_SHIFT                     30
+/* PACRJ Bit Fields */
+#define AIPS_PACRJ_TP7_MASK                      0x1u
+#define AIPS_PACRJ_TP7_SHIFT                     0
+#define AIPS_PACRJ_WP7_MASK                      0x2u
+#define AIPS_PACRJ_WP7_SHIFT                     1
+#define AIPS_PACRJ_SP7_MASK                      0x4u
+#define AIPS_PACRJ_SP7_SHIFT                     2
+#define AIPS_PACRJ_TP6_MASK                      0x10u
+#define AIPS_PACRJ_TP6_SHIFT                     4
+#define AIPS_PACRJ_WP6_MASK                      0x20u
+#define AIPS_PACRJ_WP6_SHIFT                     5
+#define AIPS_PACRJ_SP6_MASK                      0x40u
+#define AIPS_PACRJ_SP6_SHIFT                     6
+#define AIPS_PACRJ_TP5_MASK                      0x100u
+#define AIPS_PACRJ_TP5_SHIFT                     8
+#define AIPS_PACRJ_WP5_MASK                      0x200u
+#define AIPS_PACRJ_WP5_SHIFT                     9
+#define AIPS_PACRJ_SP5_MASK                      0x400u
+#define AIPS_PACRJ_SP5_SHIFT                     10
+#define AIPS_PACRJ_TP4_MASK                      0x1000u
+#define AIPS_PACRJ_TP4_SHIFT                     12
+#define AIPS_PACRJ_WP4_MASK                      0x2000u
+#define AIPS_PACRJ_WP4_SHIFT                     13
+#define AIPS_PACRJ_SP4_MASK                      0x4000u
+#define AIPS_PACRJ_SP4_SHIFT                     14
+#define AIPS_PACRJ_TP3_MASK                      0x10000u
+#define AIPS_PACRJ_TP3_SHIFT                     16
+#define AIPS_PACRJ_WP3_MASK                      0x20000u
+#define AIPS_PACRJ_WP3_SHIFT                     17
+#define AIPS_PACRJ_SP3_MASK                      0x40000u
+#define AIPS_PACRJ_SP3_SHIFT                     18
+#define AIPS_PACRJ_TP2_MASK                      0x100000u
+#define AIPS_PACRJ_TP2_SHIFT                     20
+#define AIPS_PACRJ_WP2_MASK                      0x200000u
+#define AIPS_PACRJ_WP2_SHIFT                     21
+#define AIPS_PACRJ_SP2_MASK                      0x400000u
+#define AIPS_PACRJ_SP2_SHIFT                     22
+#define AIPS_PACRJ_TP1_MASK                      0x1000000u
+#define AIPS_PACRJ_TP1_SHIFT                     24
+#define AIPS_PACRJ_WP1_MASK                      0x2000000u
+#define AIPS_PACRJ_WP1_SHIFT                     25
+#define AIPS_PACRJ_SP1_MASK                      0x4000000u
+#define AIPS_PACRJ_SP1_SHIFT                     26
+#define AIPS_PACRJ_TP0_MASK                      0x10000000u
+#define AIPS_PACRJ_TP0_SHIFT                     28
+#define AIPS_PACRJ_WP0_MASK                      0x20000000u
+#define AIPS_PACRJ_WP0_SHIFT                     29
+#define AIPS_PACRJ_SP0_MASK                      0x40000000u
+#define AIPS_PACRJ_SP0_SHIFT                     30
+/* PACRK Bit Fields */
+#define AIPS_PACRK_TP7_MASK                      0x1u
+#define AIPS_PACRK_TP7_SHIFT                     0
+#define AIPS_PACRK_WP7_MASK                      0x2u
+#define AIPS_PACRK_WP7_SHIFT                     1
+#define AIPS_PACRK_SP7_MASK                      0x4u
+#define AIPS_PACRK_SP7_SHIFT                     2
+#define AIPS_PACRK_TP6_MASK                      0x10u
+#define AIPS_PACRK_TP6_SHIFT                     4
+#define AIPS_PACRK_WP6_MASK                      0x20u
+#define AIPS_PACRK_WP6_SHIFT                     5
+#define AIPS_PACRK_SP6_MASK                      0x40u
+#define AIPS_PACRK_SP6_SHIFT                     6
+#define AIPS_PACRK_TP5_MASK                      0x100u
+#define AIPS_PACRK_TP5_SHIFT                     8
+#define AIPS_PACRK_WP5_MASK                      0x200u
+#define AIPS_PACRK_WP5_SHIFT                     9
+#define AIPS_PACRK_SP5_MASK                      0x400u
+#define AIPS_PACRK_SP5_SHIFT                     10
+#define AIPS_PACRK_TP4_MASK                      0x1000u
+#define AIPS_PACRK_TP4_SHIFT                     12
+#define AIPS_PACRK_WP4_MASK                      0x2000u
+#define AIPS_PACRK_WP4_SHIFT                     13
+#define AIPS_PACRK_SP4_MASK                      0x4000u
+#define AIPS_PACRK_SP4_SHIFT                     14
+#define AIPS_PACRK_TP3_MASK                      0x10000u
+#define AIPS_PACRK_TP3_SHIFT                     16
+#define AIPS_PACRK_WP3_MASK                      0x20000u
+#define AIPS_PACRK_WP3_SHIFT                     17
+#define AIPS_PACRK_SP3_MASK                      0x40000u
+#define AIPS_PACRK_SP3_SHIFT                     18
+#define AIPS_PACRK_TP2_MASK                      0x100000u
+#define AIPS_PACRK_TP2_SHIFT                     20
+#define AIPS_PACRK_WP2_MASK                      0x200000u
+#define AIPS_PACRK_WP2_SHIFT                     21
+#define AIPS_PACRK_SP2_MASK                      0x400000u
+#define AIPS_PACRK_SP2_SHIFT                     22
+#define AIPS_PACRK_TP1_MASK                      0x1000000u
+#define AIPS_PACRK_TP1_SHIFT                     24
+#define AIPS_PACRK_WP1_MASK                      0x2000000u
+#define AIPS_PACRK_WP1_SHIFT                     25
+#define AIPS_PACRK_SP1_MASK                      0x4000000u
+#define AIPS_PACRK_SP1_SHIFT                     26
+#define AIPS_PACRK_TP0_MASK                      0x10000000u
+#define AIPS_PACRK_TP0_SHIFT                     28
+#define AIPS_PACRK_WP0_MASK                      0x20000000u
+#define AIPS_PACRK_WP0_SHIFT                     29
+#define AIPS_PACRK_SP0_MASK                      0x40000000u
+#define AIPS_PACRK_SP0_SHIFT                     30
+/* PACRL Bit Fields */
+#define AIPS_PACRL_TP7_MASK                      0x1u
+#define AIPS_PACRL_TP7_SHIFT                     0
+#define AIPS_PACRL_WP7_MASK                      0x2u
+#define AIPS_PACRL_WP7_SHIFT                     1
+#define AIPS_PACRL_SP7_MASK                      0x4u
+#define AIPS_PACRL_SP7_SHIFT                     2
+#define AIPS_PACRL_TP6_MASK                      0x10u
+#define AIPS_PACRL_TP6_SHIFT                     4
+#define AIPS_PACRL_WP6_MASK                      0x20u
+#define AIPS_PACRL_WP6_SHIFT                     5
+#define AIPS_PACRL_SP6_MASK                      0x40u
+#define AIPS_PACRL_SP6_SHIFT                     6
+#define AIPS_PACRL_TP5_MASK                      0x100u
+#define AIPS_PACRL_TP5_SHIFT                     8
+#define AIPS_PACRL_WP5_MASK                      0x200u
+#define AIPS_PACRL_WP5_SHIFT                     9
+#define AIPS_PACRL_SP5_MASK                      0x400u
+#define AIPS_PACRL_SP5_SHIFT                     10
+#define AIPS_PACRL_TP4_MASK                      0x1000u
+#define AIPS_PACRL_TP4_SHIFT                     12
+#define AIPS_PACRL_WP4_MASK                      0x2000u
+#define AIPS_PACRL_WP4_SHIFT                     13
+#define AIPS_PACRL_SP4_MASK                      0x4000u
+#define AIPS_PACRL_SP4_SHIFT                     14
+#define AIPS_PACRL_TP3_MASK                      0x10000u
+#define AIPS_PACRL_TP3_SHIFT                     16
+#define AIPS_PACRL_WP3_MASK                      0x20000u
+#define AIPS_PACRL_WP3_SHIFT                     17
+#define AIPS_PACRL_SP3_MASK                      0x40000u
+#define AIPS_PACRL_SP3_SHIFT                     18
+#define AIPS_PACRL_TP2_MASK                      0x100000u
+#define AIPS_PACRL_TP2_SHIFT                     20
+#define AIPS_PACRL_WP2_MASK                      0x200000u
+#define AIPS_PACRL_WP2_SHIFT                     21
+#define AIPS_PACRL_SP2_MASK                      0x400000u
+#define AIPS_PACRL_SP2_SHIFT                     22
+#define AIPS_PACRL_TP1_MASK                      0x1000000u
+#define AIPS_PACRL_TP1_SHIFT                     24
+#define AIPS_PACRL_WP1_MASK                      0x2000000u
+#define AIPS_PACRL_WP1_SHIFT                     25
+#define AIPS_PACRL_SP1_MASK                      0x4000000u
+#define AIPS_PACRL_SP1_SHIFT                     26
+#define AIPS_PACRL_TP0_MASK                      0x10000000u
+#define AIPS_PACRL_TP0_SHIFT                     28
+#define AIPS_PACRL_WP0_MASK                      0x20000000u
+#define AIPS_PACRL_WP0_SHIFT                     29
+#define AIPS_PACRL_SP0_MASK                      0x40000000u
+#define AIPS_PACRL_SP0_SHIFT                     30
+/* PACRM Bit Fields */
+#define AIPS_PACRM_TP7_MASK                      0x1u
+#define AIPS_PACRM_TP7_SHIFT                     0
+#define AIPS_PACRM_WP7_MASK                      0x2u
+#define AIPS_PACRM_WP7_SHIFT                     1
+#define AIPS_PACRM_SP7_MASK                      0x4u
+#define AIPS_PACRM_SP7_SHIFT                     2
+#define AIPS_PACRM_TP6_MASK                      0x10u
+#define AIPS_PACRM_TP6_SHIFT                     4
+#define AIPS_PACRM_WP6_MASK                      0x20u
+#define AIPS_PACRM_WP6_SHIFT                     5
+#define AIPS_PACRM_SP6_MASK                      0x40u
+#define AIPS_PACRM_SP6_SHIFT                     6
+#define AIPS_PACRM_TP5_MASK                      0x100u
+#define AIPS_PACRM_TP5_SHIFT                     8
+#define AIPS_PACRM_WP5_MASK                      0x200u
+#define AIPS_PACRM_WP5_SHIFT                     9
+#define AIPS_PACRM_SP5_MASK                      0x400u
+#define AIPS_PACRM_SP5_SHIFT                     10
+#define AIPS_PACRM_TP4_MASK                      0x1000u
+#define AIPS_PACRM_TP4_SHIFT                     12
+#define AIPS_PACRM_WP4_MASK                      0x2000u
+#define AIPS_PACRM_WP4_SHIFT                     13
+#define AIPS_PACRM_SP4_MASK                      0x4000u
+#define AIPS_PACRM_SP4_SHIFT                     14
+#define AIPS_PACRM_TP3_MASK                      0x10000u
+#define AIPS_PACRM_TP3_SHIFT                     16
+#define AIPS_PACRM_WP3_MASK                      0x20000u
+#define AIPS_PACRM_WP3_SHIFT                     17
+#define AIPS_PACRM_SP3_MASK                      0x40000u
+#define AIPS_PACRM_SP3_SHIFT                     18
+#define AIPS_PACRM_TP2_MASK                      0x100000u
+#define AIPS_PACRM_TP2_SHIFT                     20
+#define AIPS_PACRM_WP2_MASK                      0x200000u
+#define AIPS_PACRM_WP2_SHIFT                     21
+#define AIPS_PACRM_SP2_MASK                      0x400000u
+#define AIPS_PACRM_SP2_SHIFT                     22
+#define AIPS_PACRM_TP1_MASK                      0x1000000u
+#define AIPS_PACRM_TP1_SHIFT                     24
+#define AIPS_PACRM_WP1_MASK                      0x2000000u
+#define AIPS_PACRM_WP1_SHIFT                     25
+#define AIPS_PACRM_SP1_MASK                      0x4000000u
+#define AIPS_PACRM_SP1_SHIFT                     26
+#define AIPS_PACRM_TP0_MASK                      0x10000000u
+#define AIPS_PACRM_TP0_SHIFT                     28
+#define AIPS_PACRM_WP0_MASK                      0x20000000u
+#define AIPS_PACRM_WP0_SHIFT                     29
+#define AIPS_PACRM_SP0_MASK                      0x40000000u
+#define AIPS_PACRM_SP0_SHIFT                     30
+/* PACRN Bit Fields */
+#define AIPS_PACRN_TP7_MASK                      0x1u
+#define AIPS_PACRN_TP7_SHIFT                     0
+#define AIPS_PACRN_WP7_MASK                      0x2u
+#define AIPS_PACRN_WP7_SHIFT                     1
+#define AIPS_PACRN_SP7_MASK                      0x4u
+#define AIPS_PACRN_SP7_SHIFT                     2
+#define AIPS_PACRN_TP6_MASK                      0x10u
+#define AIPS_PACRN_TP6_SHIFT                     4
+#define AIPS_PACRN_WP6_MASK                      0x20u
+#define AIPS_PACRN_WP6_SHIFT                     5
+#define AIPS_PACRN_SP6_MASK                      0x40u
+#define AIPS_PACRN_SP6_SHIFT                     6
+#define AIPS_PACRN_TP5_MASK                      0x100u
+#define AIPS_PACRN_TP5_SHIFT                     8
+#define AIPS_PACRN_WP5_MASK                      0x200u
+#define AIPS_PACRN_WP5_SHIFT                     9
+#define AIPS_PACRN_SP5_MASK                      0x400u
+#define AIPS_PACRN_SP5_SHIFT                     10
+#define AIPS_PACRN_TP4_MASK                      0x1000u
+#define AIPS_PACRN_TP4_SHIFT                     12
+#define AIPS_PACRN_WP4_MASK                      0x2000u
+#define AIPS_PACRN_WP4_SHIFT                     13
+#define AIPS_PACRN_SP4_MASK                      0x4000u
+#define AIPS_PACRN_SP4_SHIFT                     14
+#define AIPS_PACRN_TP3_MASK                      0x10000u
+#define AIPS_PACRN_TP3_SHIFT                     16
+#define AIPS_PACRN_WP3_MASK                      0x20000u
+#define AIPS_PACRN_WP3_SHIFT                     17
+#define AIPS_PACRN_SP3_MASK                      0x40000u
+#define AIPS_PACRN_SP3_SHIFT                     18
+#define AIPS_PACRN_TP2_MASK                      0x100000u
+#define AIPS_PACRN_TP2_SHIFT                     20
+#define AIPS_PACRN_WP2_MASK                      0x200000u
+#define AIPS_PACRN_WP2_SHIFT                     21
+#define AIPS_PACRN_SP2_MASK                      0x400000u
+#define AIPS_PACRN_SP2_SHIFT                     22
+#define AIPS_PACRN_TP1_MASK                      0x1000000u
+#define AIPS_PACRN_TP1_SHIFT                     24
+#define AIPS_PACRN_WP1_MASK                      0x2000000u
+#define AIPS_PACRN_WP1_SHIFT                     25
+#define AIPS_PACRN_SP1_MASK                      0x4000000u
+#define AIPS_PACRN_SP1_SHIFT                     26
+#define AIPS_PACRN_TP0_MASK                      0x10000000u
+#define AIPS_PACRN_TP0_SHIFT                     28
+#define AIPS_PACRN_WP0_MASK                      0x20000000u
+#define AIPS_PACRN_WP0_SHIFT                     29
+#define AIPS_PACRN_SP0_MASK                      0x40000000u
+#define AIPS_PACRN_SP0_SHIFT                     30
+/* PACRO Bit Fields */
+#define AIPS_PACRO_TP7_MASK                      0x1u
+#define AIPS_PACRO_TP7_SHIFT                     0
+#define AIPS_PACRO_WP7_MASK                      0x2u
+#define AIPS_PACRO_WP7_SHIFT                     1
+#define AIPS_PACRO_SP7_MASK                      0x4u
+#define AIPS_PACRO_SP7_SHIFT                     2
+#define AIPS_PACRO_TP6_MASK                      0x10u
+#define AIPS_PACRO_TP6_SHIFT                     4
+#define AIPS_PACRO_WP6_MASK                      0x20u
+#define AIPS_PACRO_WP6_SHIFT                     5
+#define AIPS_PACRO_SP6_MASK                      0x40u
+#define AIPS_PACRO_SP6_SHIFT                     6
+#define AIPS_PACRO_TP5_MASK                      0x100u
+#define AIPS_PACRO_TP5_SHIFT                     8
+#define AIPS_PACRO_WP5_MASK                      0x200u
+#define AIPS_PACRO_WP5_SHIFT                     9
+#define AIPS_PACRO_SP5_MASK                      0x400u
+#define AIPS_PACRO_SP5_SHIFT                     10
+#define AIPS_PACRO_TP4_MASK                      0x1000u
+#define AIPS_PACRO_TP4_SHIFT                     12
+#define AIPS_PACRO_WP4_MASK                      0x2000u
+#define AIPS_PACRO_WP4_SHIFT                     13
+#define AIPS_PACRO_SP4_MASK                      0x4000u
+#define AIPS_PACRO_SP4_SHIFT                     14
+#define AIPS_PACRO_TP3_MASK                      0x10000u
+#define AIPS_PACRO_TP3_SHIFT                     16
+#define AIPS_PACRO_WP3_MASK                      0x20000u
+#define AIPS_PACRO_WP3_SHIFT                     17
+#define AIPS_PACRO_SP3_MASK                      0x40000u
+#define AIPS_PACRO_SP3_SHIFT                     18
+#define AIPS_PACRO_TP2_MASK                      0x100000u
+#define AIPS_PACRO_TP2_SHIFT                     20
+#define AIPS_PACRO_WP2_MASK                      0x200000u
+#define AIPS_PACRO_WP2_SHIFT                     21
+#define AIPS_PACRO_SP2_MASK                      0x400000u
+#define AIPS_PACRO_SP2_SHIFT                     22
+#define AIPS_PACRO_TP1_MASK                      0x1000000u
+#define AIPS_PACRO_TP1_SHIFT                     24
+#define AIPS_PACRO_WP1_MASK                      0x2000000u
+#define AIPS_PACRO_WP1_SHIFT                     25
+#define AIPS_PACRO_SP1_MASK                      0x4000000u
+#define AIPS_PACRO_SP1_SHIFT                     26
+#define AIPS_PACRO_TP0_MASK                      0x10000000u
+#define AIPS_PACRO_TP0_SHIFT                     28
+#define AIPS_PACRO_WP0_MASK                      0x20000000u
+#define AIPS_PACRO_WP0_SHIFT                     29
+#define AIPS_PACRO_SP0_MASK                      0x40000000u
+#define AIPS_PACRO_SP0_SHIFT                     30
+/* PACRP Bit Fields */
+#define AIPS_PACRP_TP7_MASK                      0x1u
+#define AIPS_PACRP_TP7_SHIFT                     0
+#define AIPS_PACRP_WP7_MASK                      0x2u
+#define AIPS_PACRP_WP7_SHIFT                     1
+#define AIPS_PACRP_SP7_MASK                      0x4u
+#define AIPS_PACRP_SP7_SHIFT                     2
+#define AIPS_PACRP_TP6_MASK                      0x10u
+#define AIPS_PACRP_TP6_SHIFT                     4
+#define AIPS_PACRP_WP6_MASK                      0x20u
+#define AIPS_PACRP_WP6_SHIFT                     5
+#define AIPS_PACRP_SP6_MASK                      0x40u
+#define AIPS_PACRP_SP6_SHIFT                     6
+#define AIPS_PACRP_TP5_MASK                      0x100u
+#define AIPS_PACRP_TP5_SHIFT                     8
+#define AIPS_PACRP_WP5_MASK                      0x200u
+#define AIPS_PACRP_WP5_SHIFT                     9
+#define AIPS_PACRP_SP5_MASK                      0x400u
+#define AIPS_PACRP_SP5_SHIFT                     10
+#define AIPS_PACRP_TP4_MASK                      0x1000u
+#define AIPS_PACRP_TP4_SHIFT                     12
+#define AIPS_PACRP_WP4_MASK                      0x2000u
+#define AIPS_PACRP_WP4_SHIFT                     13
+#define AIPS_PACRP_SP4_MASK                      0x4000u
+#define AIPS_PACRP_SP4_SHIFT                     14
+#define AIPS_PACRP_TP3_MASK                      0x10000u
+#define AIPS_PACRP_TP3_SHIFT                     16
+#define AIPS_PACRP_WP3_MASK                      0x20000u
+#define AIPS_PACRP_WP3_SHIFT                     17
+#define AIPS_PACRP_SP3_MASK                      0x40000u
+#define AIPS_PACRP_SP3_SHIFT                     18
+#define AIPS_PACRP_TP2_MASK                      0x100000u
+#define AIPS_PACRP_TP2_SHIFT                     20
+#define AIPS_PACRP_WP2_MASK                      0x200000u
+#define AIPS_PACRP_WP2_SHIFT                     21
+#define AIPS_PACRP_SP2_MASK                      0x400000u
+#define AIPS_PACRP_SP2_SHIFT                     22
+#define AIPS_PACRP_TP1_MASK                      0x1000000u
+#define AIPS_PACRP_TP1_SHIFT                     24
+#define AIPS_PACRP_WP1_MASK                      0x2000000u
+#define AIPS_PACRP_WP1_SHIFT                     25
+#define AIPS_PACRP_SP1_MASK                      0x4000000u
+#define AIPS_PACRP_SP1_SHIFT                     26
+#define AIPS_PACRP_TP0_MASK                      0x10000000u
+#define AIPS_PACRP_TP0_SHIFT                     28
+#define AIPS_PACRP_WP0_MASK                      0x20000000u
+#define AIPS_PACRP_WP0_SHIFT                     29
+#define AIPS_PACRP_SP0_MASK                      0x40000000u
+#define AIPS_PACRP_SP0_SHIFT                     30
+/* PACRU Bit Fields */
+#define AIPS_PACRU_TP1_MASK                      0x1000000u
+#define AIPS_PACRU_TP1_SHIFT                     24
+#define AIPS_PACRU_WP1_MASK                      0x2000000u
+#define AIPS_PACRU_WP1_SHIFT                     25
+#define AIPS_PACRU_SP1_MASK                      0x4000000u
+#define AIPS_PACRU_SP1_SHIFT                     26
+#define AIPS_PACRU_TP0_MASK                      0x10000000u
+#define AIPS_PACRU_TP0_SHIFT                     28
+#define AIPS_PACRU_WP0_MASK                      0x20000000u
+#define AIPS_PACRU_WP0_SHIFT                     29
+#define AIPS_PACRU_SP0_MASK                      0x40000000u
+#define AIPS_PACRU_SP0_SHIFT                     30
+
+/*!
+ * @}
+ */ /* end of group AIPS_Register_Masks */
+
+
+/* AIPS - Peripheral instance base addresses */
+/** Peripheral AIPS0 base address */
+#define AIPS0_BASE                               (0x40000000u)
+/** Peripheral AIPS0 base pointer */
+#define AIPS0                                    ((AIPS_Type *)AIPS0_BASE)
+#define AIPS0_BASE_PTR                           (AIPS0)
+/** Peripheral AIPS1 base address */
+#define AIPS1_BASE                               (0x40080000u)
+/** Peripheral AIPS1 base pointer */
+#define AIPS1                                    ((AIPS_Type *)AIPS1_BASE)
+#define AIPS1_BASE_PTR                           (AIPS1)
+/** Array initializer of AIPS peripheral base addresses */
+#define AIPS_BASE_ADDRS                          { AIPS0_BASE, AIPS1_BASE }
+/** Array initializer of AIPS peripheral base pointers */
+#define AIPS_BASE_PTRS                           { AIPS0, AIPS1 }
+
+/* ----------------------------------------------------------------------------
+   -- AIPS - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup AIPS_Register_Accessor_Macros AIPS - Register accessor macros
+ * @{
+ */
+
+
+/* AIPS - Register instance definitions */
+/* AIPS0 */
+#define AIPS0_MPRA                               AIPS_MPRA_REG(AIPS0)
+#define AIPS0_PACRA                              AIPS_PACRA_REG(AIPS0)
+#define AIPS0_PACRB                              AIPS_PACRB_REG(AIPS0)
+#define AIPS0_PACRC                              AIPS_PACRC_REG(AIPS0)
+#define AIPS0_PACRD                              AIPS_PACRD_REG(AIPS0)
+#define AIPS0_PACRE                              AIPS_PACRE_REG(AIPS0)
+#define AIPS0_PACRF                              AIPS_PACRF_REG(AIPS0)
+#define AIPS0_PACRG                              AIPS_PACRG_REG(AIPS0)
+#define AIPS0_PACRH                              AIPS_PACRH_REG(AIPS0)
+#define AIPS0_PACRI                              AIPS_PACRI_REG(AIPS0)
+#define AIPS0_PACRJ                              AIPS_PACRJ_REG(AIPS0)
+#define AIPS0_PACRK                              AIPS_PACRK_REG(AIPS0)
+#define AIPS0_PACRL                              AIPS_PACRL_REG(AIPS0)
+#define AIPS0_PACRM                              AIPS_PACRM_REG(AIPS0)
+#define AIPS0_PACRN                              AIPS_PACRN_REG(AIPS0)
+#define AIPS0_PACRO                              AIPS_PACRO_REG(AIPS0)
+#define AIPS0_PACRP                              AIPS_PACRP_REG(AIPS0)
+#define AIPS0_PACRU                              AIPS_PACRU_REG(AIPS0)
+/* AIPS1 */
+#define AIPS1_MPRA                               AIPS_MPRA_REG(AIPS1)
+#define AIPS1_PACRA                              AIPS_PACRA_REG(AIPS1)
+#define AIPS1_PACRB                              AIPS_PACRB_REG(AIPS1)
+#define AIPS1_PACRC                              AIPS_PACRC_REG(AIPS1)
+#define AIPS1_PACRD                              AIPS_PACRD_REG(AIPS1)
+#define AIPS1_PACRE                              AIPS_PACRE_REG(AIPS1)
+#define AIPS1_PACRF                              AIPS_PACRF_REG(AIPS1)
+#define AIPS1_PACRG                              AIPS_PACRG_REG(AIPS1)
+#define AIPS1_PACRH                              AIPS_PACRH_REG(AIPS1)
+#define AIPS1_PACRI                              AIPS_PACRI_REG(AIPS1)
+#define AIPS1_PACRJ                              AIPS_PACRJ_REG(AIPS1)
+#define AIPS1_PACRK                              AIPS_PACRK_REG(AIPS1)
+#define AIPS1_PACRL                              AIPS_PACRL_REG(AIPS1)
+#define AIPS1_PACRM                              AIPS_PACRM_REG(AIPS1)
+#define AIPS1_PACRN                              AIPS_PACRN_REG(AIPS1)
+#define AIPS1_PACRO                              AIPS_PACRO_REG(AIPS1)
+#define AIPS1_PACRP                              AIPS_PACRP_REG(AIPS1)
+#define AIPS1_PACRU                              AIPS_PACRU_REG(AIPS1)
+
+/*!
+ * @}
+ */ /* end of group AIPS_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group AIPS_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- AXBS Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup AXBS_Peripheral_Access_Layer AXBS Peripheral Access Layer
+ * @{
+ */
+
+/** AXBS - Register Layout Typedef */
+typedef struct {
+  struct {                                         /* offset: 0x0, array step: 0x100 */
+    __IO uint32_t PRS;                               /**< Priority Registers Slave, array offset: 0x0, array step: 0x100 */
+         uint8_t RESERVED_0[12];
+    __IO uint32_t CRS;                               /**< Control Register, array offset: 0x10, array step: 0x100 */
+         uint8_t RESERVED_1[236];
+  } SLAVE[5];
+       uint8_t RESERVED_0[768];
+  __IO uint32_t MGPCR0;                            /**< Master General Purpose Control Register, offset: 0x800 */
+       uint8_t RESERVED_1[252];
+  __IO uint32_t MGPCR1;                            /**< Master General Purpose Control Register, offset: 0x900 */
+       uint8_t RESERVED_2[252];
+  __IO uint32_t MGPCR2;                            /**< Master General Purpose Control Register, offset: 0xA00 */
+       uint8_t RESERVED_3[252];
+  __IO uint32_t MGPCR3;                            /**< Master General Purpose Control Register, offset: 0xB00 */
+       uint8_t RESERVED_4[252];
+  __IO uint32_t MGPCR4;                            /**< Master General Purpose Control Register, offset: 0xC00 */
+       uint8_t RESERVED_5[252];
+  __IO uint32_t MGPCR5;                            /**< Master General Purpose Control Register, offset: 0xD00 */
+} AXBS_Type, *AXBS_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- AXBS - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup AXBS_Register_Accessor_Macros AXBS - Register accessor macros
+ * @{
+ */
+
+
+/* AXBS - Register accessors */
+#define AXBS_PRS_REG(base,index)                 ((base)->SLAVE[index].PRS)
+#define AXBS_CRS_REG(base,index)                 ((base)->SLAVE[index].CRS)
+#define AXBS_MGPCR0_REG(base)                    ((base)->MGPCR0)
+#define AXBS_MGPCR1_REG(base)                    ((base)->MGPCR1)
+#define AXBS_MGPCR2_REG(base)                    ((base)->MGPCR2)
+#define AXBS_MGPCR3_REG(base)                    ((base)->MGPCR3)
+#define AXBS_MGPCR4_REG(base)                    ((base)->MGPCR4)
+#define AXBS_MGPCR5_REG(base)                    ((base)->MGPCR5)
+
+/*!
+ * @}
+ */ /* end of group AXBS_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- AXBS Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup AXBS_Register_Masks AXBS Register Masks
+ * @{
+ */
+
+/* PRS Bit Fields */
+#define AXBS_PRS_M0_MASK                         0x7u
+#define AXBS_PRS_M0_SHIFT                        0
+#define AXBS_PRS_M0(x)                           (((uint32_t)(((uint32_t)(x))<<AXBS_PRS_M0_SHIFT))&AXBS_PRS_M0_MASK)
+#define AXBS_PRS_M1_MASK                         0x70u
+#define AXBS_PRS_M1_SHIFT                        4
+#define AXBS_PRS_M1(x)                           (((uint32_t)(((uint32_t)(x))<<AXBS_PRS_M1_SHIFT))&AXBS_PRS_M1_MASK)
+#define AXBS_PRS_M2_MASK                         0x700u
+#define AXBS_PRS_M2_SHIFT                        8
+#define AXBS_PRS_M2(x)                           (((uint32_t)(((uint32_t)(x))<<AXBS_PRS_M2_SHIFT))&AXBS_PRS_M2_MASK)
+#define AXBS_PRS_M3_MASK                         0x7000u
+#define AXBS_PRS_M3_SHIFT                        12
+#define AXBS_PRS_M3(x)                           (((uint32_t)(((uint32_t)(x))<<AXBS_PRS_M3_SHIFT))&AXBS_PRS_M3_MASK)
+#define AXBS_PRS_M4_MASK                         0x70000u
+#define AXBS_PRS_M4_SHIFT                        16
+#define AXBS_PRS_M4(x)                           (((uint32_t)(((uint32_t)(x))<<AXBS_PRS_M4_SHIFT))&AXBS_PRS_M4_MASK)
+#define AXBS_PRS_M5_MASK                         0x700000u
+#define AXBS_PRS_M5_SHIFT                        20
+#define AXBS_PRS_M5(x)                           (((uint32_t)(((uint32_t)(x))<<AXBS_PRS_M5_SHIFT))&AXBS_PRS_M5_MASK)
+/* CRS Bit Fields */
+#define AXBS_CRS_PARK_MASK                       0x7u
+#define AXBS_CRS_PARK_SHIFT                      0
+#define AXBS_CRS_PARK(x)                         (((uint32_t)(((uint32_t)(x))<<AXBS_CRS_PARK_SHIFT))&AXBS_CRS_PARK_MASK)
+#define AXBS_CRS_PCTL_MASK                       0x30u
+#define AXBS_CRS_PCTL_SHIFT                      4
+#define AXBS_CRS_PCTL(x)                         (((uint32_t)(((uint32_t)(x))<<AXBS_CRS_PCTL_SHIFT))&AXBS_CRS_PCTL_MASK)
+#define AXBS_CRS_ARB_MASK                        0x300u
+#define AXBS_CRS_ARB_SHIFT                       8
+#define AXBS_CRS_ARB(x)                          (((uint32_t)(((uint32_t)(x))<<AXBS_CRS_ARB_SHIFT))&AXBS_CRS_ARB_MASK)
+#define AXBS_CRS_HLP_MASK                        0x40000000u
+#define AXBS_CRS_HLP_SHIFT                       30
+#define AXBS_CRS_RO_MASK                         0x80000000u
+#define AXBS_CRS_RO_SHIFT                        31
+/* MGPCR0 Bit Fields */
+#define AXBS_MGPCR0_AULB_MASK                    0x7u
+#define AXBS_MGPCR0_AULB_SHIFT                   0
+#define AXBS_MGPCR0_AULB(x)                      (((uint32_t)(((uint32_t)(x))<<AXBS_MGPCR0_AULB_SHIFT))&AXBS_MGPCR0_AULB_MASK)
+/* MGPCR1 Bit Fields */
+#define AXBS_MGPCR1_AULB_MASK                    0x7u
+#define AXBS_MGPCR1_AULB_SHIFT                   0
+#define AXBS_MGPCR1_AULB(x)                      (((uint32_t)(((uint32_t)(x))<<AXBS_MGPCR1_AULB_SHIFT))&AXBS_MGPCR1_AULB_MASK)
+/* MGPCR2 Bit Fields */
+#define AXBS_MGPCR2_AULB_MASK                    0x7u
+#define AXBS_MGPCR2_AULB_SHIFT                   0
+#define AXBS_MGPCR2_AULB(x)                      (((uint32_t)(((uint32_t)(x))<<AXBS_MGPCR2_AULB_SHIFT))&AXBS_MGPCR2_AULB_MASK)
+/* MGPCR3 Bit Fields */
+#define AXBS_MGPCR3_AULB_MASK                    0x7u
+#define AXBS_MGPCR3_AULB_SHIFT                   0
+#define AXBS_MGPCR3_AULB(x)                      (((uint32_t)(((uint32_t)(x))<<AXBS_MGPCR3_AULB_SHIFT))&AXBS_MGPCR3_AULB_MASK)
+/* MGPCR4 Bit Fields */
+#define AXBS_MGPCR4_AULB_MASK                    0x7u
+#define AXBS_MGPCR4_AULB_SHIFT                   0
+#define AXBS_MGPCR4_AULB(x)                      (((uint32_t)(((uint32_t)(x))<<AXBS_MGPCR4_AULB_SHIFT))&AXBS_MGPCR4_AULB_MASK)
+/* MGPCR5 Bit Fields */
+#define AXBS_MGPCR5_AULB_MASK                    0x7u
+#define AXBS_MGPCR5_AULB_SHIFT                   0
+#define AXBS_MGPCR5_AULB(x)                      (((uint32_t)(((uint32_t)(x))<<AXBS_MGPCR5_AULB_SHIFT))&AXBS_MGPCR5_AULB_MASK)
+
+/*!
+ * @}
+ */ /* end of group AXBS_Register_Masks */
+
+
+/* AXBS - Peripheral instance base addresses */
+/** Peripheral AXBS base address */
+#define AXBS_BASE                                (0x40004000u)
+/** Peripheral AXBS base pointer */
+#define AXBS                                     ((AXBS_Type *)AXBS_BASE)
+#define AXBS_BASE_PTR                            (AXBS)
+/** Array initializer of AXBS peripheral base addresses */
+#define AXBS_BASE_ADDRS                          { AXBS_BASE }
+/** Array initializer of AXBS peripheral base pointers */
+#define AXBS_BASE_PTRS                           { AXBS }
+
+/* ----------------------------------------------------------------------------
+   -- AXBS - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup AXBS_Register_Accessor_Macros AXBS - Register accessor macros
+ * @{
+ */
+
+
+/* AXBS - Register instance definitions */
+/* AXBS */
+#define AXBS_PRS0                                AXBS_PRS_REG(AXBS,0)
+#define AXBS_CRS0                                AXBS_CRS_REG(AXBS,0)
+#define AXBS_PRS1                                AXBS_PRS_REG(AXBS,1)
+#define AXBS_CRS1                                AXBS_CRS_REG(AXBS,1)
+#define AXBS_PRS2                                AXBS_PRS_REG(AXBS,2)
+#define AXBS_CRS2                                AXBS_CRS_REG(AXBS,2)
+#define AXBS_PRS3                                AXBS_PRS_REG(AXBS,3)
+#define AXBS_CRS3                                AXBS_CRS_REG(AXBS,3)
+#define AXBS_PRS4                                AXBS_PRS_REG(AXBS,4)
+#define AXBS_CRS4                                AXBS_CRS_REG(AXBS,4)
+#define AXBS_MGPCR0                              AXBS_MGPCR0_REG(AXBS)
+#define AXBS_MGPCR1                              AXBS_MGPCR1_REG(AXBS)
+#define AXBS_MGPCR2                              AXBS_MGPCR2_REG(AXBS)
+#define AXBS_MGPCR3                              AXBS_MGPCR3_REG(AXBS)
+#define AXBS_MGPCR4                              AXBS_MGPCR4_REG(AXBS)
+#define AXBS_MGPCR5                              AXBS_MGPCR5_REG(AXBS)
+
+/* AXBS - Register array accessors */
+#define AXBS_PRS(index)                          AXBS_PRS_REG(AXBS,index)
+#define AXBS_CRS(index)                          AXBS_CRS_REG(AXBS,index)
+
+/*!
+ * @}
+ */ /* end of group AXBS_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group AXBS_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- CAN Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CAN_Peripheral_Access_Layer CAN Peripheral Access Layer
+ * @{
+ */
+
+/** CAN - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t MCR;                               /**< Module Configuration Register, offset: 0x0 */
+  __IO uint32_t CTRL1;                             /**< Control 1 register, offset: 0x4 */
+  __IO uint32_t TIMER;                             /**< Free Running Timer, offset: 0x8 */
+       uint8_t RESERVED_0[4];
+  __IO uint32_t RXMGMASK;                          /**< Rx Mailboxes Global Mask Register, offset: 0x10 */
+  __IO uint32_t RX14MASK;                          /**< Rx 14 Mask register, offset: 0x14 */
+  __IO uint32_t RX15MASK;                          /**< Rx 15 Mask register, offset: 0x18 */
+  __IO uint32_t ECR;                               /**< Error Counter, offset: 0x1C */
+  __IO uint32_t ESR1;                              /**< Error and Status 1 register, offset: 0x20 */
+       uint8_t RESERVED_1[4];
+  __IO uint32_t IMASK1;                            /**< Interrupt Masks 1 register, offset: 0x28 */
+       uint8_t RESERVED_2[4];
+  __IO uint32_t IFLAG1;                            /**< Interrupt Flags 1 register, offset: 0x30 */
+  __IO uint32_t CTRL2;                             /**< Control 2 register, offset: 0x34 */
+  __I  uint32_t ESR2;                              /**< Error and Status 2 register, offset: 0x38 */
+       uint8_t RESERVED_3[8];
+  __I  uint32_t CRCR;                              /**< CRC Register, offset: 0x44 */
+  __IO uint32_t RXFGMASK;                          /**< Rx FIFO Global Mask register, offset: 0x48 */
+  __I  uint32_t RXFIR;                             /**< Rx FIFO Information Register, offset: 0x4C */
+       uint8_t RESERVED_4[48];
+  struct {                                         /* offset: 0x80, array step: 0x10 */
+    __IO uint32_t CS;                                /**< Message Buffer 0 CS Register..Message Buffer 15 CS Register, array offset: 0x80, array step: 0x10 */
+    __IO uint32_t ID;                                /**< Message Buffer 0 ID Register..Message Buffer 15 ID Register, array offset: 0x84, array step: 0x10 */
+    __IO uint32_t WORD0;                             /**< Message Buffer 0 WORD0 Register..Message Buffer 15 WORD0 Register, array offset: 0x88, array step: 0x10 */
+    __IO uint32_t WORD1;                             /**< Message Buffer 0 WORD1 Register..Message Buffer 15 WORD1 Register, array offset: 0x8C, array step: 0x10 */
+  } MB[16];
+       uint8_t RESERVED_5[1792];
+  __IO uint32_t RXIMR[16];                         /**< Rx Individual Mask Registers, array offset: 0x880, array step: 0x4 */
+} CAN_Type, *CAN_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- CAN - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CAN_Register_Accessor_Macros CAN - Register accessor macros
+ * @{
+ */
+
+
+/* CAN - Register accessors */
+#define CAN_MCR_REG(base)                        ((base)->MCR)
+#define CAN_CTRL1_REG(base)                      ((base)->CTRL1)
+#define CAN_TIMER_REG(base)                      ((base)->TIMER)
+#define CAN_RXMGMASK_REG(base)                   ((base)->RXMGMASK)
+#define CAN_RX14MASK_REG(base)                   ((base)->RX14MASK)
+#define CAN_RX15MASK_REG(base)                   ((base)->RX15MASK)
+#define CAN_ECR_REG(base)                        ((base)->ECR)
+#define CAN_ESR1_REG(base)                       ((base)->ESR1)
+#define CAN_IMASK1_REG(base)                     ((base)->IMASK1)
+#define CAN_IFLAG1_REG(base)                     ((base)->IFLAG1)
+#define CAN_CTRL2_REG(base)                      ((base)->CTRL2)
+#define CAN_ESR2_REG(base)                       ((base)->ESR2)
+#define CAN_CRCR_REG(base)                       ((base)->CRCR)
+#define CAN_RXFGMASK_REG(base)                   ((base)->RXFGMASK)
+#define CAN_RXFIR_REG(base)                      ((base)->RXFIR)
+#define CAN_CS_REG(base,index)                   ((base)->MB[index].CS)
+#define CAN_ID_REG(base,index)                   ((base)->MB[index].ID)
+#define CAN_WORD0_REG(base,index)                ((base)->MB[index].WORD0)
+#define CAN_WORD1_REG(base,index)                ((base)->MB[index].WORD1)
+#define CAN_RXIMR_REG(base,index)                ((base)->RXIMR[index])
+
+/*!
+ * @}
+ */ /* end of group CAN_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- CAN Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CAN_Register_Masks CAN Register Masks
+ * @{
+ */
+
+/* MCR Bit Fields */
+#define CAN_MCR_MAXMB_MASK                       0x7Fu
+#define CAN_MCR_MAXMB_SHIFT                      0
+#define CAN_MCR_MAXMB(x)                         (((uint32_t)(((uint32_t)(x))<<CAN_MCR_MAXMB_SHIFT))&CAN_MCR_MAXMB_MASK)
+#define CAN_MCR_IDAM_MASK                        0x300u
+#define CAN_MCR_IDAM_SHIFT                       8
+#define CAN_MCR_IDAM(x)                          (((uint32_t)(((uint32_t)(x))<<CAN_MCR_IDAM_SHIFT))&CAN_MCR_IDAM_MASK)
+#define CAN_MCR_AEN_MASK                         0x1000u
+#define CAN_MCR_AEN_SHIFT                        12
+#define CAN_MCR_LPRIOEN_MASK                     0x2000u
+#define CAN_MCR_LPRIOEN_SHIFT                    13
+#define CAN_MCR_IRMQ_MASK                        0x10000u
+#define CAN_MCR_IRMQ_SHIFT                       16
+#define CAN_MCR_SRXDIS_MASK                      0x20000u
+#define CAN_MCR_SRXDIS_SHIFT                     17
+#define CAN_MCR_WAKSRC_MASK                      0x80000u
+#define CAN_MCR_WAKSRC_SHIFT                     19
+#define CAN_MCR_LPMACK_MASK                      0x100000u
+#define CAN_MCR_LPMACK_SHIFT                     20
+#define CAN_MCR_WRNEN_MASK                       0x200000u
+#define CAN_MCR_WRNEN_SHIFT                      21
+#define CAN_MCR_SLFWAK_MASK                      0x400000u
+#define CAN_MCR_SLFWAK_SHIFT                     22
+#define CAN_MCR_SUPV_MASK                        0x800000u
+#define CAN_MCR_SUPV_SHIFT                       23
+#define CAN_MCR_FRZACK_MASK                      0x1000000u
+#define CAN_MCR_FRZACK_SHIFT                     24
+#define CAN_MCR_SOFTRST_MASK                     0x2000000u
+#define CAN_MCR_SOFTRST_SHIFT                    25
+#define CAN_MCR_WAKMSK_MASK                      0x4000000u
+#define CAN_MCR_WAKMSK_SHIFT                     26
+#define CAN_MCR_NOTRDY_MASK                      0x8000000u
+#define CAN_MCR_NOTRDY_SHIFT                     27
+#define CAN_MCR_HALT_MASK                        0x10000000u
+#define CAN_MCR_HALT_SHIFT                       28
+#define CAN_MCR_RFEN_MASK                        0x20000000u
+#define CAN_MCR_RFEN_SHIFT                       29
+#define CAN_MCR_FRZ_MASK                         0x40000000u
+#define CAN_MCR_FRZ_SHIFT                        30
+#define CAN_MCR_MDIS_MASK                        0x80000000u
+#define CAN_MCR_MDIS_SHIFT                       31
+/* CTRL1 Bit Fields */
+#define CAN_CTRL1_PROPSEG_MASK                   0x7u
+#define CAN_CTRL1_PROPSEG_SHIFT                  0
+#define CAN_CTRL1_PROPSEG(x)                     (((uint32_t)(((uint32_t)(x))<<CAN_CTRL1_PROPSEG_SHIFT))&CAN_CTRL1_PROPSEG_MASK)
+#define CAN_CTRL1_LOM_MASK                       0x8u
+#define CAN_CTRL1_LOM_SHIFT                      3
+#define CAN_CTRL1_LBUF_MASK                      0x10u
+#define CAN_CTRL1_LBUF_SHIFT                     4
+#define CAN_CTRL1_TSYN_MASK                      0x20u
+#define CAN_CTRL1_TSYN_SHIFT                     5
+#define CAN_CTRL1_BOFFREC_MASK                   0x40u
+#define CAN_CTRL1_BOFFREC_SHIFT                  6
+#define CAN_CTRL1_SMP_MASK                       0x80u
+#define CAN_CTRL1_SMP_SHIFT                      7
+#define CAN_CTRL1_RWRNMSK_MASK                   0x400u
+#define CAN_CTRL1_RWRNMSK_SHIFT                  10
+#define CAN_CTRL1_TWRNMSK_MASK                   0x800u
+#define CAN_CTRL1_TWRNMSK_SHIFT                  11
+#define CAN_CTRL1_LPB_MASK                       0x1000u
+#define CAN_CTRL1_LPB_SHIFT                      12
+#define CAN_CTRL1_CLKSRC_MASK                    0x2000u
+#define CAN_CTRL1_CLKSRC_SHIFT                   13
+#define CAN_CTRL1_ERRMSK_MASK                    0x4000u
+#define CAN_CTRL1_ERRMSK_SHIFT                   14
+#define CAN_CTRL1_BOFFMSK_MASK                   0x8000u
+#define CAN_CTRL1_BOFFMSK_SHIFT                  15
+#define CAN_CTRL1_PSEG2_MASK                     0x70000u
+#define CAN_CTRL1_PSEG2_SHIFT                    16
+#define CAN_CTRL1_PSEG2(x)                       (((uint32_t)(((uint32_t)(x))<<CAN_CTRL1_PSEG2_SHIFT))&CAN_CTRL1_PSEG2_MASK)
+#define CAN_CTRL1_PSEG1_MASK                     0x380000u
+#define CAN_CTRL1_PSEG1_SHIFT                    19
+#define CAN_CTRL1_PSEG1(x)                       (((uint32_t)(((uint32_t)(x))<<CAN_CTRL1_PSEG1_SHIFT))&CAN_CTRL1_PSEG1_MASK)
+#define CAN_CTRL1_RJW_MASK                       0xC00000u
+#define CAN_CTRL1_RJW_SHIFT                      22
+#define CAN_CTRL1_RJW(x)                         (((uint32_t)(((uint32_t)(x))<<CAN_CTRL1_RJW_SHIFT))&CAN_CTRL1_RJW_MASK)
+#define CAN_CTRL1_PRESDIV_MASK                   0xFF000000u
+#define CAN_CTRL1_PRESDIV_SHIFT                  24
+#define CAN_CTRL1_PRESDIV(x)                     (((uint32_t)(((uint32_t)(x))<<CAN_CTRL1_PRESDIV_SHIFT))&CAN_CTRL1_PRESDIV_MASK)
+/* TIMER Bit Fields */
+#define CAN_TIMER_TIMER_MASK                     0xFFFFu
+#define CAN_TIMER_TIMER_SHIFT                    0
+#define CAN_TIMER_TIMER(x)                       (((uint32_t)(((uint32_t)(x))<<CAN_TIMER_TIMER_SHIFT))&CAN_TIMER_TIMER_MASK)
+/* RXMGMASK Bit Fields */
+#define CAN_RXMGMASK_MG_MASK                     0xFFFFFFFFu
+#define CAN_RXMGMASK_MG_SHIFT                    0
+#define CAN_RXMGMASK_MG(x)                       (((uint32_t)(((uint32_t)(x))<<CAN_RXMGMASK_MG_SHIFT))&CAN_RXMGMASK_MG_MASK)
+/* RX14MASK Bit Fields */
+#define CAN_RX14MASK_RX14M_MASK                  0xFFFFFFFFu
+#define CAN_RX14MASK_RX14M_SHIFT                 0
+#define CAN_RX14MASK_RX14M(x)                    (((uint32_t)(((uint32_t)(x))<<CAN_RX14MASK_RX14M_SHIFT))&CAN_RX14MASK_RX14M_MASK)
+/* RX15MASK Bit Fields */
+#define CAN_RX15MASK_RX15M_MASK                  0xFFFFFFFFu
+#define CAN_RX15MASK_RX15M_SHIFT                 0
+#define CAN_RX15MASK_RX15M(x)                    (((uint32_t)(((uint32_t)(x))<<CAN_RX15MASK_RX15M_SHIFT))&CAN_RX15MASK_RX15M_MASK)
+/* ECR Bit Fields */
+#define CAN_ECR_TXERRCNT_MASK                    0xFFu
+#define CAN_ECR_TXERRCNT_SHIFT                   0
+#define CAN_ECR_TXERRCNT(x)                      (((uint32_t)(((uint32_t)(x))<<CAN_ECR_TXERRCNT_SHIFT))&CAN_ECR_TXERRCNT_MASK)
+#define CAN_ECR_RXERRCNT_MASK                    0xFF00u
+#define CAN_ECR_RXERRCNT_SHIFT                   8
+#define CAN_ECR_RXERRCNT(x)                      (((uint32_t)(((uint32_t)(x))<<CAN_ECR_RXERRCNT_SHIFT))&CAN_ECR_RXERRCNT_MASK)
+/* ESR1 Bit Fields */
+#define CAN_ESR1_WAKINT_MASK                     0x1u
+#define CAN_ESR1_WAKINT_SHIFT                    0
+#define CAN_ESR1_ERRINT_MASK                     0x2u
+#define CAN_ESR1_ERRINT_SHIFT                    1
+#define CAN_ESR1_BOFFINT_MASK                    0x4u
+#define CAN_ESR1_BOFFINT_SHIFT                   2
+#define CAN_ESR1_RX_MASK                         0x8u
+#define CAN_ESR1_RX_SHIFT                        3
+#define CAN_ESR1_FLTCONF_MASK                    0x30u
+#define CAN_ESR1_FLTCONF_SHIFT                   4
+#define CAN_ESR1_FLTCONF(x)                      (((uint32_t)(((uint32_t)(x))<<CAN_ESR1_FLTCONF_SHIFT))&CAN_ESR1_FLTCONF_MASK)
+#define CAN_ESR1_TX_MASK                         0x40u
+#define CAN_ESR1_TX_SHIFT                        6
+#define CAN_ESR1_IDLE_MASK                       0x80u
+#define CAN_ESR1_IDLE_SHIFT                      7
+#define CAN_ESR1_RXWRN_MASK                      0x100u
+#define CAN_ESR1_RXWRN_SHIFT                     8
+#define CAN_ESR1_TXWRN_MASK                      0x200u
+#define CAN_ESR1_TXWRN_SHIFT                     9
+#define CAN_ESR1_STFERR_MASK                     0x400u
+#define CAN_ESR1_STFERR_SHIFT                    10
+#define CAN_ESR1_FRMERR_MASK                     0x800u
+#define CAN_ESR1_FRMERR_SHIFT                    11
+#define CAN_ESR1_CRCERR_MASK                     0x1000u
+#define CAN_ESR1_CRCERR_SHIFT                    12
+#define CAN_ESR1_ACKERR_MASK                     0x2000u
+#define CAN_ESR1_ACKERR_SHIFT                    13
+#define CAN_ESR1_BIT0ERR_MASK                    0x4000u
+#define CAN_ESR1_BIT0ERR_SHIFT                   14
+#define CAN_ESR1_BIT1ERR_MASK                    0x8000u
+#define CAN_ESR1_BIT1ERR_SHIFT                   15
+#define CAN_ESR1_RWRNINT_MASK                    0x10000u
+#define CAN_ESR1_RWRNINT_SHIFT                   16
+#define CAN_ESR1_TWRNINT_MASK                    0x20000u
+#define CAN_ESR1_TWRNINT_SHIFT                   17
+#define CAN_ESR1_SYNCH_MASK                      0x40000u
+#define CAN_ESR1_SYNCH_SHIFT                     18
+/* IMASK1 Bit Fields */
+#define CAN_IMASK1_BUFLM_MASK                    0xFFFFFFFFu
+#define CAN_IMASK1_BUFLM_SHIFT                   0
+#define CAN_IMASK1_BUFLM(x)                      (((uint32_t)(((uint32_t)(x))<<CAN_IMASK1_BUFLM_SHIFT))&CAN_IMASK1_BUFLM_MASK)
+/* IFLAG1 Bit Fields */
+#define CAN_IFLAG1_BUF0I_MASK                    0x1u
+#define CAN_IFLAG1_BUF0I_SHIFT                   0
+#define CAN_IFLAG1_BUF4TO1I_MASK                 0x1Eu
+#define CAN_IFLAG1_BUF4TO1I_SHIFT                1
+#define CAN_IFLAG1_BUF4TO1I(x)                   (((uint32_t)(((uint32_t)(x))<<CAN_IFLAG1_BUF4TO1I_SHIFT))&CAN_IFLAG1_BUF4TO1I_MASK)
+#define CAN_IFLAG1_BUF5I_MASK                    0x20u
+#define CAN_IFLAG1_BUF5I_SHIFT                   5
+#define CAN_IFLAG1_BUF6I_MASK                    0x40u
+#define CAN_IFLAG1_BUF6I_SHIFT                   6
+#define CAN_IFLAG1_BUF7I_MASK                    0x80u
+#define CAN_IFLAG1_BUF7I_SHIFT                   7
+#define CAN_IFLAG1_BUF31TO8I_MASK                0xFFFFFF00u
+#define CAN_IFLAG1_BUF31TO8I_SHIFT               8
+#define CAN_IFLAG1_BUF31TO8I(x)                  (((uint32_t)(((uint32_t)(x))<<CAN_IFLAG1_BUF31TO8I_SHIFT))&CAN_IFLAG1_BUF31TO8I_MASK)
+/* CTRL2 Bit Fields */
+#define CAN_CTRL2_EACEN_MASK                     0x10000u
+#define CAN_CTRL2_EACEN_SHIFT                    16
+#define CAN_CTRL2_RRS_MASK                       0x20000u
+#define CAN_CTRL2_RRS_SHIFT                      17
+#define CAN_CTRL2_MRP_MASK                       0x40000u
+#define CAN_CTRL2_MRP_SHIFT                      18
+#define CAN_CTRL2_TASD_MASK                      0xF80000u
+#define CAN_CTRL2_TASD_SHIFT                     19
+#define CAN_CTRL2_TASD(x)                        (((uint32_t)(((uint32_t)(x))<<CAN_CTRL2_TASD_SHIFT))&CAN_CTRL2_TASD_MASK)
+#define CAN_CTRL2_RFFN_MASK                      0xF000000u
+#define CAN_CTRL2_RFFN_SHIFT                     24
+#define CAN_CTRL2_RFFN(x)                        (((uint32_t)(((uint32_t)(x))<<CAN_CTRL2_RFFN_SHIFT))&CAN_CTRL2_RFFN_MASK)
+#define CAN_CTRL2_WRMFRZ_MASK                    0x10000000u
+#define CAN_CTRL2_WRMFRZ_SHIFT                   28
+/* ESR2 Bit Fields */
+#define CAN_ESR2_IMB_MASK                        0x2000u
+#define CAN_ESR2_IMB_SHIFT                       13
+#define CAN_ESR2_VPS_MASK                        0x4000u
+#define CAN_ESR2_VPS_SHIFT                       14
+#define CAN_ESR2_LPTM_MASK                       0x7F0000u
+#define CAN_ESR2_LPTM_SHIFT                      16
+#define CAN_ESR2_LPTM(x)                         (((uint32_t)(((uint32_t)(x))<<CAN_ESR2_LPTM_SHIFT))&CAN_ESR2_LPTM_MASK)
+/* CRCR Bit Fields */
+#define CAN_CRCR_TXCRC_MASK                      0x7FFFu
+#define CAN_CRCR_TXCRC_SHIFT                     0
+#define CAN_CRCR_TXCRC(x)                        (((uint32_t)(((uint32_t)(x))<<CAN_CRCR_TXCRC_SHIFT))&CAN_CRCR_TXCRC_MASK)
+#define CAN_CRCR_MBCRC_MASK                      0x7F0000u
+#define CAN_CRCR_MBCRC_SHIFT                     16
+#define CAN_CRCR_MBCRC(x)                        (((uint32_t)(((uint32_t)(x))<<CAN_CRCR_MBCRC_SHIFT))&CAN_CRCR_MBCRC_MASK)
+/* RXFGMASK Bit Fields */
+#define CAN_RXFGMASK_FGM_MASK                    0xFFFFFFFFu
+#define CAN_RXFGMASK_FGM_SHIFT                   0
+#define CAN_RXFGMASK_FGM(x)                      (((uint32_t)(((uint32_t)(x))<<CAN_RXFGMASK_FGM_SHIFT))&CAN_RXFGMASK_FGM_MASK)
+/* RXFIR Bit Fields */
+#define CAN_RXFIR_IDHIT_MASK                     0x1FFu
+#define CAN_RXFIR_IDHIT_SHIFT                    0
+#define CAN_RXFIR_IDHIT(x)                       (((uint32_t)(((uint32_t)(x))<<CAN_RXFIR_IDHIT_SHIFT))&CAN_RXFIR_IDHIT_MASK)
+/* CS Bit Fields */
+#define CAN_CS_TIME_STAMP_MASK                   0xFFFFu
+#define CAN_CS_TIME_STAMP_SHIFT                  0
+#define CAN_CS_TIME_STAMP(x)                     (((uint32_t)(((uint32_t)(x))<<CAN_CS_TIME_STAMP_SHIFT))&CAN_CS_TIME_STAMP_MASK)
+#define CAN_CS_DLC_MASK                          0xF0000u
+#define CAN_CS_DLC_SHIFT                         16
+#define CAN_CS_DLC(x)                            (((uint32_t)(((uint32_t)(x))<<CAN_CS_DLC_SHIFT))&CAN_CS_DLC_MASK)
+#define CAN_CS_RTR_MASK                          0x100000u
+#define CAN_CS_RTR_SHIFT                         20
+#define CAN_CS_IDE_MASK                          0x200000u
+#define CAN_CS_IDE_SHIFT                         21
+#define CAN_CS_SRR_MASK                          0x400000u
+#define CAN_CS_SRR_SHIFT                         22
+#define CAN_CS_CODE_MASK                         0xF000000u
+#define CAN_CS_CODE_SHIFT                        24
+#define CAN_CS_CODE(x)                           (((uint32_t)(((uint32_t)(x))<<CAN_CS_CODE_SHIFT))&CAN_CS_CODE_MASK)
+/* ID Bit Fields */
+#define CAN_ID_EXT_MASK                          0x3FFFFu
+#define CAN_ID_EXT_SHIFT                         0
+#define CAN_ID_EXT(x)                            (((uint32_t)(((uint32_t)(x))<<CAN_ID_EXT_SHIFT))&CAN_ID_EXT_MASK)
+#define CAN_ID_STD_MASK                          0x1FFC0000u
+#define CAN_ID_STD_SHIFT                         18
+#define CAN_ID_STD(x)                            (((uint32_t)(((uint32_t)(x))<<CAN_ID_STD_SHIFT))&CAN_ID_STD_MASK)
+#define CAN_ID_PRIO_MASK                         0xE0000000u
+#define CAN_ID_PRIO_SHIFT                        29
+#define CAN_ID_PRIO(x)                           (((uint32_t)(((uint32_t)(x))<<CAN_ID_PRIO_SHIFT))&CAN_ID_PRIO_MASK)
+/* WORD0 Bit Fields */
+#define CAN_WORD0_DATA_BYTE_3_MASK               0xFFu
+#define CAN_WORD0_DATA_BYTE_3_SHIFT              0
+#define CAN_WORD0_DATA_BYTE_3(x)                 (((uint32_t)(((uint32_t)(x))<<CAN_WORD0_DATA_BYTE_3_SHIFT))&CAN_WORD0_DATA_BYTE_3_MASK)
+#define CAN_WORD0_DATA_BYTE_2_MASK               0xFF00u
+#define CAN_WORD0_DATA_BYTE_2_SHIFT              8
+#define CAN_WORD0_DATA_BYTE_2(x)                 (((uint32_t)(((uint32_t)(x))<<CAN_WORD0_DATA_BYTE_2_SHIFT))&CAN_WORD0_DATA_BYTE_2_MASK)
+#define CAN_WORD0_DATA_BYTE_1_MASK               0xFF0000u
+#define CAN_WORD0_DATA_BYTE_1_SHIFT              16
+#define CAN_WORD0_DATA_BYTE_1(x)                 (((uint32_t)(((uint32_t)(x))<<CAN_WORD0_DATA_BYTE_1_SHIFT))&CAN_WORD0_DATA_BYTE_1_MASK)
+#define CAN_WORD0_DATA_BYTE_0_MASK               0xFF000000u
+#define CAN_WORD0_DATA_BYTE_0_SHIFT              24
+#define CAN_WORD0_DATA_BYTE_0(x)                 (((uint32_t)(((uint32_t)(x))<<CAN_WORD0_DATA_BYTE_0_SHIFT))&CAN_WORD0_DATA_BYTE_0_MASK)
+/* WORD1 Bit Fields */
+#define CAN_WORD1_DATA_BYTE_7_MASK               0xFFu
+#define CAN_WORD1_DATA_BYTE_7_SHIFT              0
+#define CAN_WORD1_DATA_BYTE_7(x)                 (((uint32_t)(((uint32_t)(x))<<CAN_WORD1_DATA_BYTE_7_SHIFT))&CAN_WORD1_DATA_BYTE_7_MASK)
+#define CAN_WORD1_DATA_BYTE_6_MASK               0xFF00u
+#define CAN_WORD1_DATA_BYTE_6_SHIFT              8
+#define CAN_WORD1_DATA_BYTE_6(x)                 (((uint32_t)(((uint32_t)(x))<<CAN_WORD1_DATA_BYTE_6_SHIFT))&CAN_WORD1_DATA_BYTE_6_MASK)
+#define CAN_WORD1_DATA_BYTE_5_MASK               0xFF0000u
+#define CAN_WORD1_DATA_BYTE_5_SHIFT              16
+#define CAN_WORD1_DATA_BYTE_5(x)                 (((uint32_t)(((uint32_t)(x))<<CAN_WORD1_DATA_BYTE_5_SHIFT))&CAN_WORD1_DATA_BYTE_5_MASK)
+#define CAN_WORD1_DATA_BYTE_4_MASK               0xFF000000u
+#define CAN_WORD1_DATA_BYTE_4_SHIFT              24
+#define CAN_WORD1_DATA_BYTE_4(x)                 (((uint32_t)(((uint32_t)(x))<<CAN_WORD1_DATA_BYTE_4_SHIFT))&CAN_WORD1_DATA_BYTE_4_MASK)
+/* RXIMR Bit Fields */
+#define CAN_RXIMR_MI_MASK                        0xFFFFFFFFu
+#define CAN_RXIMR_MI_SHIFT                       0
+#define CAN_RXIMR_MI(x)                          (((uint32_t)(((uint32_t)(x))<<CAN_RXIMR_MI_SHIFT))&CAN_RXIMR_MI_MASK)
+
+/*!
+ * @}
+ */ /* end of group CAN_Register_Masks */
+
+
+/* CAN - Peripheral instance base addresses */
+/** Peripheral CAN0 base address */
+#define CAN0_BASE                                (0x40024000u)
+/** Peripheral CAN0 base pointer */
+#define CAN0                                     ((CAN_Type *)CAN0_BASE)
+#define CAN0_BASE_PTR                            (CAN0)
+/** Array initializer of CAN peripheral base addresses */
+#define CAN_BASE_ADDRS                           { CAN0_BASE }
+/** Array initializer of CAN peripheral base pointers */
+#define CAN_BASE_PTRS                            { CAN0 }
+/** Interrupt vectors for the CAN peripheral type */
+#define CAN_Rx_Warning_IRQS                      { CAN0_Rx_Warning_IRQn }
+#define CAN_Tx_Warning_IRQS                      { CAN0_Tx_Warning_IRQn }
+#define CAN_Wake_Up_IRQS                         { CAN0_Wake_Up_IRQn }
+#define CAN_Error_IRQS                           { CAN0_Error_IRQn }
+#define CAN_Bus_Off_IRQS                         { CAN0_Bus_Off_IRQn }
+#define CAN_ORed_Message_buffer_IRQS             { CAN0_ORed_Message_buffer_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- CAN - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CAN_Register_Accessor_Macros CAN - Register accessor macros
+ * @{
+ */
+
+
+/* CAN - Register instance definitions */
+/* CAN0 */
+#define CAN0_MCR                                 CAN_MCR_REG(CAN0)
+#define CAN0_CTRL1                               CAN_CTRL1_REG(CAN0)
+#define CAN0_TIMER                               CAN_TIMER_REG(CAN0)
+#define CAN0_RXMGMASK                            CAN_RXMGMASK_REG(CAN0)
+#define CAN0_RX14MASK                            CAN_RX14MASK_REG(CAN0)
+#define CAN0_RX15MASK                            CAN_RX15MASK_REG(CAN0)
+#define CAN0_ECR                                 CAN_ECR_REG(CAN0)
+#define CAN0_ESR1                                CAN_ESR1_REG(CAN0)
+#define CAN0_IMASK1                              CAN_IMASK1_REG(CAN0)
+#define CAN0_IFLAG1                              CAN_IFLAG1_REG(CAN0)
+#define CAN0_CTRL2                               CAN_CTRL2_REG(CAN0)
+#define CAN0_ESR2                                CAN_ESR2_REG(CAN0)
+#define CAN0_CRCR                                CAN_CRCR_REG(CAN0)
+#define CAN0_RXFGMASK                            CAN_RXFGMASK_REG(CAN0)
+#define CAN0_RXFIR                               CAN_RXFIR_REG(CAN0)
+#define CAN0_CS0                                 CAN_CS_REG(CAN0,0)
+#define CAN0_ID0                                 CAN_ID_REG(CAN0,0)
+#define CAN0_WORD00                              CAN_WORD0_REG(CAN0,0)
+#define CAN0_WORD10                              CAN_WORD1_REG(CAN0,0)
+#define CAN0_CS1                                 CAN_CS_REG(CAN0,1)
+#define CAN0_ID1                                 CAN_ID_REG(CAN0,1)
+#define CAN0_WORD01                              CAN_WORD0_REG(CAN0,1)
+#define CAN0_WORD11                              CAN_WORD1_REG(CAN0,1)
+#define CAN0_CS2                                 CAN_CS_REG(CAN0,2)
+#define CAN0_ID2                                 CAN_ID_REG(CAN0,2)
+#define CAN0_WORD02                              CAN_WORD0_REG(CAN0,2)
+#define CAN0_WORD12                              CAN_WORD1_REG(CAN0,2)
+#define CAN0_CS3                                 CAN_CS_REG(CAN0,3)
+#define CAN0_ID3                                 CAN_ID_REG(CAN0,3)
+#define CAN0_WORD03                              CAN_WORD0_REG(CAN0,3)
+#define CAN0_WORD13                              CAN_WORD1_REG(CAN0,3)
+#define CAN0_CS4                                 CAN_CS_REG(CAN0,4)
+#define CAN0_ID4                                 CAN_ID_REG(CAN0,4)
+#define CAN0_WORD04                              CAN_WORD0_REG(CAN0,4)
+#define CAN0_WORD14                              CAN_WORD1_REG(CAN0,4)
+#define CAN0_CS5                                 CAN_CS_REG(CAN0,5)
+#define CAN0_ID5                                 CAN_ID_REG(CAN0,5)
+#define CAN0_WORD05                              CAN_WORD0_REG(CAN0,5)
+#define CAN0_WORD15                              CAN_WORD1_REG(CAN0,5)
+#define CAN0_CS6                                 CAN_CS_REG(CAN0,6)
+#define CAN0_ID6                                 CAN_ID_REG(CAN0,6)
+#define CAN0_WORD06                              CAN_WORD0_REG(CAN0,6)
+#define CAN0_WORD16                              CAN_WORD1_REG(CAN0,6)
+#define CAN0_CS7                                 CAN_CS_REG(CAN0,7)
+#define CAN0_ID7                                 CAN_ID_REG(CAN0,7)
+#define CAN0_WORD07                              CAN_WORD0_REG(CAN0,7)
+#define CAN0_WORD17                              CAN_WORD1_REG(CAN0,7)
+#define CAN0_CS8                                 CAN_CS_REG(CAN0,8)
+#define CAN0_ID8                                 CAN_ID_REG(CAN0,8)
+#define CAN0_WORD08                              CAN_WORD0_REG(CAN0,8)
+#define CAN0_WORD18                              CAN_WORD1_REG(CAN0,8)
+#define CAN0_CS9                                 CAN_CS_REG(CAN0,9)
+#define CAN0_ID9                                 CAN_ID_REG(CAN0,9)
+#define CAN0_WORD09                              CAN_WORD0_REG(CAN0,9)
+#define CAN0_WORD19                              CAN_WORD1_REG(CAN0,9)
+#define CAN0_CS10                                CAN_CS_REG(CAN0,10)
+#define CAN0_ID10                                CAN_ID_REG(CAN0,10)
+#define CAN0_WORD010                             CAN_WORD0_REG(CAN0,10)
+#define CAN0_WORD110                             CAN_WORD1_REG(CAN0,10)
+#define CAN0_CS11                                CAN_CS_REG(CAN0,11)
+#define CAN0_ID11                                CAN_ID_REG(CAN0,11)
+#define CAN0_WORD011                             CAN_WORD0_REG(CAN0,11)
+#define CAN0_WORD111                             CAN_WORD1_REG(CAN0,11)
+#define CAN0_CS12                                CAN_CS_REG(CAN0,12)
+#define CAN0_ID12                                CAN_ID_REG(CAN0,12)
+#define CAN0_WORD012                             CAN_WORD0_REG(CAN0,12)
+#define CAN0_WORD112                             CAN_WORD1_REG(CAN0,12)
+#define CAN0_CS13                                CAN_CS_REG(CAN0,13)
+#define CAN0_ID13                                CAN_ID_REG(CAN0,13)
+#define CAN0_WORD013                             CAN_WORD0_REG(CAN0,13)
+#define CAN0_WORD113                             CAN_WORD1_REG(CAN0,13)
+#define CAN0_CS14                                CAN_CS_REG(CAN0,14)
+#define CAN0_ID14                                CAN_ID_REG(CAN0,14)
+#define CAN0_WORD014                             CAN_WORD0_REG(CAN0,14)
+#define CAN0_WORD114                             CAN_WORD1_REG(CAN0,14)
+#define CAN0_CS15                                CAN_CS_REG(CAN0,15)
+#define CAN0_ID15                                CAN_ID_REG(CAN0,15)
+#define CAN0_WORD015                             CAN_WORD0_REG(CAN0,15)
+#define CAN0_WORD115                             CAN_WORD1_REG(CAN0,15)
+#define CAN0_RXIMR0                              CAN_RXIMR_REG(CAN0,0)
+#define CAN0_RXIMR1                              CAN_RXIMR_REG(CAN0,1)
+#define CAN0_RXIMR2                              CAN_RXIMR_REG(CAN0,2)
+#define CAN0_RXIMR3                              CAN_RXIMR_REG(CAN0,3)
+#define CAN0_RXIMR4                              CAN_RXIMR_REG(CAN0,4)
+#define CAN0_RXIMR5                              CAN_RXIMR_REG(CAN0,5)
+#define CAN0_RXIMR6                              CAN_RXIMR_REG(CAN0,6)
+#define CAN0_RXIMR7                              CAN_RXIMR_REG(CAN0,7)
+#define CAN0_RXIMR8                              CAN_RXIMR_REG(CAN0,8)
+#define CAN0_RXIMR9                              CAN_RXIMR_REG(CAN0,9)
+#define CAN0_RXIMR10                             CAN_RXIMR_REG(CAN0,10)
+#define CAN0_RXIMR11                             CAN_RXIMR_REG(CAN0,11)
+#define CAN0_RXIMR12                             CAN_RXIMR_REG(CAN0,12)
+#define CAN0_RXIMR13                             CAN_RXIMR_REG(CAN0,13)
+#define CAN0_RXIMR14                             CAN_RXIMR_REG(CAN0,14)
+#define CAN0_RXIMR15                             CAN_RXIMR_REG(CAN0,15)
+
+/* CAN - Register array accessors */
+#define CAN0_CS(index)                           CAN_CS_REG(CAN0,index)
+#define CAN0_ID(index)                           CAN_ID_REG(CAN0,index)
+#define CAN0_WORD0(index)                        CAN_WORD0_REG(CAN0,index)
+#define CAN0_WORD1(index)                        CAN_WORD1_REG(CAN0,index)
+#define CAN0_RXIMR(index)                        CAN_RXIMR_REG(CAN0,index)
+
+/*!
+ * @}
+ */ /* end of group CAN_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group CAN_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- CAU Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CAU_Peripheral_Access_Layer CAU Peripheral Access Layer
+ * @{
+ */
+
+/** CAU - Register Layout Typedef */
+typedef struct {
+  __O  uint32_t DIRECT[16];                        /**< Direct access register 0..Direct access register 15, array offset: 0x0, array step: 0x4 */
+       uint8_t RESERVED_0[2048];
+  __O  uint32_t LDR_CASR;                          /**< Status register  - Load Register command, offset: 0x840 */
+  __O  uint32_t LDR_CAA;                           /**< Accumulator register - Load Register command, offset: 0x844 */
+  __O  uint32_t LDR_CA[9];                         /**< General Purpose Register 0 - Load Register command..General Purpose Register 8 - Load Register command, array offset: 0x848, array step: 0x4 */
+       uint8_t RESERVED_1[20];
+  __I  uint32_t STR_CASR;                          /**< Status register  - Store Register command, offset: 0x880 */
+  __I  uint32_t STR_CAA;                           /**< Accumulator register - Store Register command, offset: 0x884 */
+  __I  uint32_t STR_CA[9];                         /**< General Purpose Register 0 - Store Register command..General Purpose Register 8 - Store Register command, array offset: 0x888, array step: 0x4 */
+       uint8_t RESERVED_2[20];
+  __O  uint32_t ADR_CASR;                          /**< Status register  - Add Register command, offset: 0x8C0 */
+  __O  uint32_t ADR_CAA;                           /**< Accumulator register - Add to register command, offset: 0x8C4 */
+  __O  uint32_t ADR_CA[9];                         /**< General Purpose Register 0 - Add to register command..General Purpose Register 8 - Add to register command, array offset: 0x8C8, array step: 0x4 */
+       uint8_t RESERVED_3[20];
+  __O  uint32_t RADR_CASR;                         /**< Status register  - Reverse and Add to Register command, offset: 0x900 */
+  __O  uint32_t RADR_CAA;                          /**< Accumulator register - Reverse and Add to Register command, offset: 0x904 */
+  __O  uint32_t RADR_CA[9];                        /**< General Purpose Register 0 - Reverse and Add to Register command..General Purpose Register 8 - Reverse and Add to Register command, array offset: 0x908, array step: 0x4 */
+       uint8_t RESERVED_4[84];
+  __O  uint32_t XOR_CASR;                          /**< Status register  - Exclusive Or command, offset: 0x980 */
+  __O  uint32_t XOR_CAA;                           /**< Accumulator register - Exclusive Or command, offset: 0x984 */
+  __O  uint32_t XOR_CA[9];                         /**< General Purpose Register 0 - Exclusive Or command..General Purpose Register 8 - Exclusive Or command, array offset: 0x988, array step: 0x4 */
+       uint8_t RESERVED_5[20];
+  __O  uint32_t ROTL_CASR;                         /**< Status register  - Rotate Left command, offset: 0x9C0 */
+  __O  uint32_t ROTL_CAA;                          /**< Accumulator register - Rotate Left command, offset: 0x9C4 */
+  __O  uint32_t ROTL_CA[9];                        /**< General Purpose Register 0 - Rotate Left command..General Purpose Register 8 - Rotate Left command, array offset: 0x9C8, array step: 0x4 */
+       uint8_t RESERVED_6[276];
+  __O  uint32_t AESC_CASR;                         /**< Status register  - AES Column Operation command, offset: 0xB00 */
+  __O  uint32_t AESC_CAA;                          /**< Accumulator register - AES Column Operation command, offset: 0xB04 */
+  __O  uint32_t AESC_CA[9];                        /**< General Purpose Register 0 - AES Column Operation command..General Purpose Register 8 - AES Column Operation command, array offset: 0xB08, array step: 0x4 */
+       uint8_t RESERVED_7[20];
+  __O  uint32_t AESIC_CASR;                        /**< Status register  - AES Inverse Column Operation command, offset: 0xB40 */
+  __O  uint32_t AESIC_CAA;                         /**< Accumulator register - AES Inverse Column Operation command, offset: 0xB44 */
+  __O  uint32_t AESIC_CA[9];                       /**< General Purpose Register 0 - AES Inverse Column Operation command..General Purpose Register 8 - AES Inverse Column Operation command, array offset: 0xB48, array step: 0x4 */
+} CAU_Type, *CAU_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- CAU - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CAU_Register_Accessor_Macros CAU - Register accessor macros
+ * @{
+ */
+
+
+/* CAU - Register accessors */
+#define CAU_DIRECT_REG(base,index)               ((base)->DIRECT[index])
+#define CAU_LDR_CASR_REG(base)                   ((base)->LDR_CASR)
+#define CAU_LDR_CAA_REG(base)                    ((base)->LDR_CAA)
+#define CAU_LDR_CA_REG(base,index)               ((base)->LDR_CA[index])
+#define CAU_STR_CASR_REG(base)                   ((base)->STR_CASR)
+#define CAU_STR_CAA_REG(base)                    ((base)->STR_CAA)
+#define CAU_STR_CA_REG(base,index)               ((base)->STR_CA[index])
+#define CAU_ADR_CASR_REG(base)                   ((base)->ADR_CASR)
+#define CAU_ADR_CAA_REG(base)                    ((base)->ADR_CAA)
+#define CAU_ADR_CA_REG(base,index)               ((base)->ADR_CA[index])
+#define CAU_RADR_CASR_REG(base)                  ((base)->RADR_CASR)
+#define CAU_RADR_CAA_REG(base)                   ((base)->RADR_CAA)
+#define CAU_RADR_CA_REG(base,index)              ((base)->RADR_CA[index])
+#define CAU_XOR_CASR_REG(base)                   ((base)->XOR_CASR)
+#define CAU_XOR_CAA_REG(base)                    ((base)->XOR_CAA)
+#define CAU_XOR_CA_REG(base,index)               ((base)->XOR_CA[index])
+#define CAU_ROTL_CASR_REG(base)                  ((base)->ROTL_CASR)
+#define CAU_ROTL_CAA_REG(base)                   ((base)->ROTL_CAA)
+#define CAU_ROTL_CA_REG(base,index)              ((base)->ROTL_CA[index])
+#define CAU_AESC_CASR_REG(base)                  ((base)->AESC_CASR)
+#define CAU_AESC_CAA_REG(base)                   ((base)->AESC_CAA)
+#define CAU_AESC_CA_REG(base,index)              ((base)->AESC_CA[index])
+#define CAU_AESIC_CASR_REG(base)                 ((base)->AESIC_CASR)
+#define CAU_AESIC_CAA_REG(base)                  ((base)->AESIC_CAA)
+#define CAU_AESIC_CA_REG(base,index)             ((base)->AESIC_CA[index])
+
+/*!
+ * @}
+ */ /* end of group CAU_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- CAU Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CAU_Register_Masks CAU Register Masks
+ * @{
+ */
+
+/* DIRECT Bit Fields */
+#define CAU_DIRECT_CAU_DIRECT0_MASK              0xFFFFFFFFu
+#define CAU_DIRECT_CAU_DIRECT0_SHIFT             0
+#define CAU_DIRECT_CAU_DIRECT0(x)                (((uint32_t)(((uint32_t)(x))<<CAU_DIRECT_CAU_DIRECT0_SHIFT))&CAU_DIRECT_CAU_DIRECT0_MASK)
+#define CAU_DIRECT_CAU_DIRECT1_MASK              0xFFFFFFFFu
+#define CAU_DIRECT_CAU_DIRECT1_SHIFT             0
+#define CAU_DIRECT_CAU_DIRECT1(x)                (((uint32_t)(((uint32_t)(x))<<CAU_DIRECT_CAU_DIRECT1_SHIFT))&CAU_DIRECT_CAU_DIRECT1_MASK)
+#define CAU_DIRECT_CAU_DIRECT2_MASK              0xFFFFFFFFu
+#define CAU_DIRECT_CAU_DIRECT2_SHIFT             0
+#define CAU_DIRECT_CAU_DIRECT2(x)                (((uint32_t)(((uint32_t)(x))<<CAU_DIRECT_CAU_DIRECT2_SHIFT))&CAU_DIRECT_CAU_DIRECT2_MASK)
+#define CAU_DIRECT_CAU_DIRECT3_MASK              0xFFFFFFFFu
+#define CAU_DIRECT_CAU_DIRECT3_SHIFT             0
+#define CAU_DIRECT_CAU_DIRECT3(x)                (((uint32_t)(((uint32_t)(x))<<CAU_DIRECT_CAU_DIRECT3_SHIFT))&CAU_DIRECT_CAU_DIRECT3_MASK)
+#define CAU_DIRECT_CAU_DIRECT4_MASK              0xFFFFFFFFu
+#define CAU_DIRECT_CAU_DIRECT4_SHIFT             0
+#define CAU_DIRECT_CAU_DIRECT4(x)                (((uint32_t)(((uint32_t)(x))<<CAU_DIRECT_CAU_DIRECT4_SHIFT))&CAU_DIRECT_CAU_DIRECT4_MASK)
+#define CAU_DIRECT_CAU_DIRECT5_MASK              0xFFFFFFFFu
+#define CAU_DIRECT_CAU_DIRECT5_SHIFT             0
+#define CAU_DIRECT_CAU_DIRECT5(x)                (((uint32_t)(((uint32_t)(x))<<CAU_DIRECT_CAU_DIRECT5_SHIFT))&CAU_DIRECT_CAU_DIRECT5_MASK)
+#define CAU_DIRECT_CAU_DIRECT6_MASK              0xFFFFFFFFu
+#define CAU_DIRECT_CAU_DIRECT6_SHIFT             0
+#define CAU_DIRECT_CAU_DIRECT6(x)                (((uint32_t)(((uint32_t)(x))<<CAU_DIRECT_CAU_DIRECT6_SHIFT))&CAU_DIRECT_CAU_DIRECT6_MASK)
+#define CAU_DIRECT_CAU_DIRECT7_MASK              0xFFFFFFFFu
+#define CAU_DIRECT_CAU_DIRECT7_SHIFT             0
+#define CAU_DIRECT_CAU_DIRECT7(x)                (((uint32_t)(((uint32_t)(x))<<CAU_DIRECT_CAU_DIRECT7_SHIFT))&CAU_DIRECT_CAU_DIRECT7_MASK)
+#define CAU_DIRECT_CAU_DIRECT8_MASK              0xFFFFFFFFu
+#define CAU_DIRECT_CAU_DIRECT8_SHIFT             0
+#define CAU_DIRECT_CAU_DIRECT8(x)                (((uint32_t)(((uint32_t)(x))<<CAU_DIRECT_CAU_DIRECT8_SHIFT))&CAU_DIRECT_CAU_DIRECT8_MASK)
+#define CAU_DIRECT_CAU_DIRECT9_MASK              0xFFFFFFFFu
+#define CAU_DIRECT_CAU_DIRECT9_SHIFT             0
+#define CAU_DIRECT_CAU_DIRECT9(x)                (((uint32_t)(((uint32_t)(x))<<CAU_DIRECT_CAU_DIRECT9_SHIFT))&CAU_DIRECT_CAU_DIRECT9_MASK)
+#define CAU_DIRECT_CAU_DIRECT10_MASK             0xFFFFFFFFu
+#define CAU_DIRECT_CAU_DIRECT10_SHIFT            0
+#define CAU_DIRECT_CAU_DIRECT10(x)               (((uint32_t)(((uint32_t)(x))<<CAU_DIRECT_CAU_DIRECT10_SHIFT))&CAU_DIRECT_CAU_DIRECT10_MASK)
+#define CAU_DIRECT_CAU_DIRECT11_MASK             0xFFFFFFFFu
+#define CAU_DIRECT_CAU_DIRECT11_SHIFT            0
+#define CAU_DIRECT_CAU_DIRECT11(x)               (((uint32_t)(((uint32_t)(x))<<CAU_DIRECT_CAU_DIRECT11_SHIFT))&CAU_DIRECT_CAU_DIRECT11_MASK)
+#define CAU_DIRECT_CAU_DIRECT12_MASK             0xFFFFFFFFu
+#define CAU_DIRECT_CAU_DIRECT12_SHIFT            0
+#define CAU_DIRECT_CAU_DIRECT12(x)               (((uint32_t)(((uint32_t)(x))<<CAU_DIRECT_CAU_DIRECT12_SHIFT))&CAU_DIRECT_CAU_DIRECT12_MASK)
+#define CAU_DIRECT_CAU_DIRECT13_MASK             0xFFFFFFFFu
+#define CAU_DIRECT_CAU_DIRECT13_SHIFT            0
+#define CAU_DIRECT_CAU_DIRECT13(x)               (((uint32_t)(((uint32_t)(x))<<CAU_DIRECT_CAU_DIRECT13_SHIFT))&CAU_DIRECT_CAU_DIRECT13_MASK)
+#define CAU_DIRECT_CAU_DIRECT14_MASK             0xFFFFFFFFu
+#define CAU_DIRECT_CAU_DIRECT14_SHIFT            0
+#define CAU_DIRECT_CAU_DIRECT14(x)               (((uint32_t)(((uint32_t)(x))<<CAU_DIRECT_CAU_DIRECT14_SHIFT))&CAU_DIRECT_CAU_DIRECT14_MASK)
+#define CAU_DIRECT_CAU_DIRECT15_MASK             0xFFFFFFFFu
+#define CAU_DIRECT_CAU_DIRECT15_SHIFT            0
+#define CAU_DIRECT_CAU_DIRECT15(x)               (((uint32_t)(((uint32_t)(x))<<CAU_DIRECT_CAU_DIRECT15_SHIFT))&CAU_DIRECT_CAU_DIRECT15_MASK)
+/* LDR_CASR Bit Fields */
+#define CAU_LDR_CASR_IC_MASK                     0x1u
+#define CAU_LDR_CASR_IC_SHIFT                    0
+#define CAU_LDR_CASR_DPE_MASK                    0x2u
+#define CAU_LDR_CASR_DPE_SHIFT                   1
+#define CAU_LDR_CASR_VER_MASK                    0xF0000000u
+#define CAU_LDR_CASR_VER_SHIFT                   28
+#define CAU_LDR_CASR_VER(x)                      (((uint32_t)(((uint32_t)(x))<<CAU_LDR_CASR_VER_SHIFT))&CAU_LDR_CASR_VER_MASK)
+/* LDR_CAA Bit Fields */
+#define CAU_LDR_CAA_ACC_MASK                     0xFFFFFFFFu
+#define CAU_LDR_CAA_ACC_SHIFT                    0
+#define CAU_LDR_CAA_ACC(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_LDR_CAA_ACC_SHIFT))&CAU_LDR_CAA_ACC_MASK)
+/* LDR_CA Bit Fields */
+#define CAU_LDR_CA_CA0_MASK                      0xFFFFFFFFu
+#define CAU_LDR_CA_CA0_SHIFT                     0
+#define CAU_LDR_CA_CA0(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_LDR_CA_CA0_SHIFT))&CAU_LDR_CA_CA0_MASK)
+#define CAU_LDR_CA_CA1_MASK                      0xFFFFFFFFu
+#define CAU_LDR_CA_CA1_SHIFT                     0
+#define CAU_LDR_CA_CA1(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_LDR_CA_CA1_SHIFT))&CAU_LDR_CA_CA1_MASK)
+#define CAU_LDR_CA_CA2_MASK                      0xFFFFFFFFu
+#define CAU_LDR_CA_CA2_SHIFT                     0
+#define CAU_LDR_CA_CA2(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_LDR_CA_CA2_SHIFT))&CAU_LDR_CA_CA2_MASK)
+#define CAU_LDR_CA_CA3_MASK                      0xFFFFFFFFu
+#define CAU_LDR_CA_CA3_SHIFT                     0
+#define CAU_LDR_CA_CA3(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_LDR_CA_CA3_SHIFT))&CAU_LDR_CA_CA3_MASK)
+#define CAU_LDR_CA_CA4_MASK                      0xFFFFFFFFu
+#define CAU_LDR_CA_CA4_SHIFT                     0
+#define CAU_LDR_CA_CA4(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_LDR_CA_CA4_SHIFT))&CAU_LDR_CA_CA4_MASK)
+#define CAU_LDR_CA_CA5_MASK                      0xFFFFFFFFu
+#define CAU_LDR_CA_CA5_SHIFT                     0
+#define CAU_LDR_CA_CA5(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_LDR_CA_CA5_SHIFT))&CAU_LDR_CA_CA5_MASK)
+#define CAU_LDR_CA_CA6_MASK                      0xFFFFFFFFu
+#define CAU_LDR_CA_CA6_SHIFT                     0
+#define CAU_LDR_CA_CA6(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_LDR_CA_CA6_SHIFT))&CAU_LDR_CA_CA6_MASK)
+#define CAU_LDR_CA_CA7_MASK                      0xFFFFFFFFu
+#define CAU_LDR_CA_CA7_SHIFT                     0
+#define CAU_LDR_CA_CA7(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_LDR_CA_CA7_SHIFT))&CAU_LDR_CA_CA7_MASK)
+#define CAU_LDR_CA_CA8_MASK                      0xFFFFFFFFu
+#define CAU_LDR_CA_CA8_SHIFT                     0
+#define CAU_LDR_CA_CA8(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_LDR_CA_CA8_SHIFT))&CAU_LDR_CA_CA8_MASK)
+/* STR_CASR Bit Fields */
+#define CAU_STR_CASR_IC_MASK                     0x1u
+#define CAU_STR_CASR_IC_SHIFT                    0
+#define CAU_STR_CASR_DPE_MASK                    0x2u
+#define CAU_STR_CASR_DPE_SHIFT                   1
+#define CAU_STR_CASR_VER_MASK                    0xF0000000u
+#define CAU_STR_CASR_VER_SHIFT                   28
+#define CAU_STR_CASR_VER(x)                      (((uint32_t)(((uint32_t)(x))<<CAU_STR_CASR_VER_SHIFT))&CAU_STR_CASR_VER_MASK)
+/* STR_CAA Bit Fields */
+#define CAU_STR_CAA_ACC_MASK                     0xFFFFFFFFu
+#define CAU_STR_CAA_ACC_SHIFT                    0
+#define CAU_STR_CAA_ACC(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_STR_CAA_ACC_SHIFT))&CAU_STR_CAA_ACC_MASK)
+/* STR_CA Bit Fields */
+#define CAU_STR_CA_CA0_MASK                      0xFFFFFFFFu
+#define CAU_STR_CA_CA0_SHIFT                     0
+#define CAU_STR_CA_CA0(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_STR_CA_CA0_SHIFT))&CAU_STR_CA_CA0_MASK)
+#define CAU_STR_CA_CA1_MASK                      0xFFFFFFFFu
+#define CAU_STR_CA_CA1_SHIFT                     0
+#define CAU_STR_CA_CA1(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_STR_CA_CA1_SHIFT))&CAU_STR_CA_CA1_MASK)
+#define CAU_STR_CA_CA2_MASK                      0xFFFFFFFFu
+#define CAU_STR_CA_CA2_SHIFT                     0
+#define CAU_STR_CA_CA2(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_STR_CA_CA2_SHIFT))&CAU_STR_CA_CA2_MASK)
+#define CAU_STR_CA_CA3_MASK                      0xFFFFFFFFu
+#define CAU_STR_CA_CA3_SHIFT                     0
+#define CAU_STR_CA_CA3(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_STR_CA_CA3_SHIFT))&CAU_STR_CA_CA3_MASK)
+#define CAU_STR_CA_CA4_MASK                      0xFFFFFFFFu
+#define CAU_STR_CA_CA4_SHIFT                     0
+#define CAU_STR_CA_CA4(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_STR_CA_CA4_SHIFT))&CAU_STR_CA_CA4_MASK)
+#define CAU_STR_CA_CA5_MASK                      0xFFFFFFFFu
+#define CAU_STR_CA_CA5_SHIFT                     0
+#define CAU_STR_CA_CA5(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_STR_CA_CA5_SHIFT))&CAU_STR_CA_CA5_MASK)
+#define CAU_STR_CA_CA6_MASK                      0xFFFFFFFFu
+#define CAU_STR_CA_CA6_SHIFT                     0
+#define CAU_STR_CA_CA6(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_STR_CA_CA6_SHIFT))&CAU_STR_CA_CA6_MASK)
+#define CAU_STR_CA_CA7_MASK                      0xFFFFFFFFu
+#define CAU_STR_CA_CA7_SHIFT                     0
+#define CAU_STR_CA_CA7(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_STR_CA_CA7_SHIFT))&CAU_STR_CA_CA7_MASK)
+#define CAU_STR_CA_CA8_MASK                      0xFFFFFFFFu
+#define CAU_STR_CA_CA8_SHIFT                     0
+#define CAU_STR_CA_CA8(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_STR_CA_CA8_SHIFT))&CAU_STR_CA_CA8_MASK)
+/* ADR_CASR Bit Fields */
+#define CAU_ADR_CASR_IC_MASK                     0x1u
+#define CAU_ADR_CASR_IC_SHIFT                    0
+#define CAU_ADR_CASR_DPE_MASK                    0x2u
+#define CAU_ADR_CASR_DPE_SHIFT                   1
+#define CAU_ADR_CASR_VER_MASK                    0xF0000000u
+#define CAU_ADR_CASR_VER_SHIFT                   28
+#define CAU_ADR_CASR_VER(x)                      (((uint32_t)(((uint32_t)(x))<<CAU_ADR_CASR_VER_SHIFT))&CAU_ADR_CASR_VER_MASK)
+/* ADR_CAA Bit Fields */
+#define CAU_ADR_CAA_ACC_MASK                     0xFFFFFFFFu
+#define CAU_ADR_CAA_ACC_SHIFT                    0
+#define CAU_ADR_CAA_ACC(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_ADR_CAA_ACC_SHIFT))&CAU_ADR_CAA_ACC_MASK)
+/* ADR_CA Bit Fields */
+#define CAU_ADR_CA_CA0_MASK                      0xFFFFFFFFu
+#define CAU_ADR_CA_CA0_SHIFT                     0
+#define CAU_ADR_CA_CA0(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_ADR_CA_CA0_SHIFT))&CAU_ADR_CA_CA0_MASK)
+#define CAU_ADR_CA_CA1_MASK                      0xFFFFFFFFu
+#define CAU_ADR_CA_CA1_SHIFT                     0
+#define CAU_ADR_CA_CA1(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_ADR_CA_CA1_SHIFT))&CAU_ADR_CA_CA1_MASK)
+#define CAU_ADR_CA_CA2_MASK                      0xFFFFFFFFu
+#define CAU_ADR_CA_CA2_SHIFT                     0
+#define CAU_ADR_CA_CA2(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_ADR_CA_CA2_SHIFT))&CAU_ADR_CA_CA2_MASK)
+#define CAU_ADR_CA_CA3_MASK                      0xFFFFFFFFu
+#define CAU_ADR_CA_CA3_SHIFT                     0
+#define CAU_ADR_CA_CA3(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_ADR_CA_CA3_SHIFT))&CAU_ADR_CA_CA3_MASK)
+#define CAU_ADR_CA_CA4_MASK                      0xFFFFFFFFu
+#define CAU_ADR_CA_CA4_SHIFT                     0
+#define CAU_ADR_CA_CA4(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_ADR_CA_CA4_SHIFT))&CAU_ADR_CA_CA4_MASK)
+#define CAU_ADR_CA_CA5_MASK                      0xFFFFFFFFu
+#define CAU_ADR_CA_CA5_SHIFT                     0
+#define CAU_ADR_CA_CA5(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_ADR_CA_CA5_SHIFT))&CAU_ADR_CA_CA5_MASK)
+#define CAU_ADR_CA_CA6_MASK                      0xFFFFFFFFu
+#define CAU_ADR_CA_CA6_SHIFT                     0
+#define CAU_ADR_CA_CA6(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_ADR_CA_CA6_SHIFT))&CAU_ADR_CA_CA6_MASK)
+#define CAU_ADR_CA_CA7_MASK                      0xFFFFFFFFu
+#define CAU_ADR_CA_CA7_SHIFT                     0
+#define CAU_ADR_CA_CA7(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_ADR_CA_CA7_SHIFT))&CAU_ADR_CA_CA7_MASK)
+#define CAU_ADR_CA_CA8_MASK                      0xFFFFFFFFu
+#define CAU_ADR_CA_CA8_SHIFT                     0
+#define CAU_ADR_CA_CA8(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_ADR_CA_CA8_SHIFT))&CAU_ADR_CA_CA8_MASK)
+/* RADR_CASR Bit Fields */
+#define CAU_RADR_CASR_IC_MASK                    0x1u
+#define CAU_RADR_CASR_IC_SHIFT                   0
+#define CAU_RADR_CASR_DPE_MASK                   0x2u
+#define CAU_RADR_CASR_DPE_SHIFT                  1
+#define CAU_RADR_CASR_VER_MASK                   0xF0000000u
+#define CAU_RADR_CASR_VER_SHIFT                  28
+#define CAU_RADR_CASR_VER(x)                     (((uint32_t)(((uint32_t)(x))<<CAU_RADR_CASR_VER_SHIFT))&CAU_RADR_CASR_VER_MASK)
+/* RADR_CAA Bit Fields */
+#define CAU_RADR_CAA_ACC_MASK                    0xFFFFFFFFu
+#define CAU_RADR_CAA_ACC_SHIFT                   0
+#define CAU_RADR_CAA_ACC(x)                      (((uint32_t)(((uint32_t)(x))<<CAU_RADR_CAA_ACC_SHIFT))&CAU_RADR_CAA_ACC_MASK)
+/* RADR_CA Bit Fields */
+#define CAU_RADR_CA_CA0_MASK                     0xFFFFFFFFu
+#define CAU_RADR_CA_CA0_SHIFT                    0
+#define CAU_RADR_CA_CA0(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_RADR_CA_CA0_SHIFT))&CAU_RADR_CA_CA0_MASK)
+#define CAU_RADR_CA_CA1_MASK                     0xFFFFFFFFu
+#define CAU_RADR_CA_CA1_SHIFT                    0
+#define CAU_RADR_CA_CA1(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_RADR_CA_CA1_SHIFT))&CAU_RADR_CA_CA1_MASK)
+#define CAU_RADR_CA_CA2_MASK                     0xFFFFFFFFu
+#define CAU_RADR_CA_CA2_SHIFT                    0
+#define CAU_RADR_CA_CA2(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_RADR_CA_CA2_SHIFT))&CAU_RADR_CA_CA2_MASK)
+#define CAU_RADR_CA_CA3_MASK                     0xFFFFFFFFu
+#define CAU_RADR_CA_CA3_SHIFT                    0
+#define CAU_RADR_CA_CA3(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_RADR_CA_CA3_SHIFT))&CAU_RADR_CA_CA3_MASK)
+#define CAU_RADR_CA_CA4_MASK                     0xFFFFFFFFu
+#define CAU_RADR_CA_CA4_SHIFT                    0
+#define CAU_RADR_CA_CA4(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_RADR_CA_CA4_SHIFT))&CAU_RADR_CA_CA4_MASK)
+#define CAU_RADR_CA_CA5_MASK                     0xFFFFFFFFu
+#define CAU_RADR_CA_CA5_SHIFT                    0
+#define CAU_RADR_CA_CA5(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_RADR_CA_CA5_SHIFT))&CAU_RADR_CA_CA5_MASK)
+#define CAU_RADR_CA_CA6_MASK                     0xFFFFFFFFu
+#define CAU_RADR_CA_CA6_SHIFT                    0
+#define CAU_RADR_CA_CA6(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_RADR_CA_CA6_SHIFT))&CAU_RADR_CA_CA6_MASK)
+#define CAU_RADR_CA_CA7_MASK                     0xFFFFFFFFu
+#define CAU_RADR_CA_CA7_SHIFT                    0
+#define CAU_RADR_CA_CA7(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_RADR_CA_CA7_SHIFT))&CAU_RADR_CA_CA7_MASK)
+#define CAU_RADR_CA_CA8_MASK                     0xFFFFFFFFu
+#define CAU_RADR_CA_CA8_SHIFT                    0
+#define CAU_RADR_CA_CA8(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_RADR_CA_CA8_SHIFT))&CAU_RADR_CA_CA8_MASK)
+/* XOR_CASR Bit Fields */
+#define CAU_XOR_CASR_IC_MASK                     0x1u
+#define CAU_XOR_CASR_IC_SHIFT                    0
+#define CAU_XOR_CASR_DPE_MASK                    0x2u
+#define CAU_XOR_CASR_DPE_SHIFT                   1
+#define CAU_XOR_CASR_VER_MASK                    0xF0000000u
+#define CAU_XOR_CASR_VER_SHIFT                   28
+#define CAU_XOR_CASR_VER(x)                      (((uint32_t)(((uint32_t)(x))<<CAU_XOR_CASR_VER_SHIFT))&CAU_XOR_CASR_VER_MASK)
+/* XOR_CAA Bit Fields */
+#define CAU_XOR_CAA_ACC_MASK                     0xFFFFFFFFu
+#define CAU_XOR_CAA_ACC_SHIFT                    0
+#define CAU_XOR_CAA_ACC(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_XOR_CAA_ACC_SHIFT))&CAU_XOR_CAA_ACC_MASK)
+/* XOR_CA Bit Fields */
+#define CAU_XOR_CA_CA0_MASK                      0xFFFFFFFFu
+#define CAU_XOR_CA_CA0_SHIFT                     0
+#define CAU_XOR_CA_CA0(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_XOR_CA_CA0_SHIFT))&CAU_XOR_CA_CA0_MASK)
+#define CAU_XOR_CA_CA1_MASK                      0xFFFFFFFFu
+#define CAU_XOR_CA_CA1_SHIFT                     0
+#define CAU_XOR_CA_CA1(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_XOR_CA_CA1_SHIFT))&CAU_XOR_CA_CA1_MASK)
+#define CAU_XOR_CA_CA2_MASK                      0xFFFFFFFFu
+#define CAU_XOR_CA_CA2_SHIFT                     0
+#define CAU_XOR_CA_CA2(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_XOR_CA_CA2_SHIFT))&CAU_XOR_CA_CA2_MASK)
+#define CAU_XOR_CA_CA3_MASK                      0xFFFFFFFFu
+#define CAU_XOR_CA_CA3_SHIFT                     0
+#define CAU_XOR_CA_CA3(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_XOR_CA_CA3_SHIFT))&CAU_XOR_CA_CA3_MASK)
+#define CAU_XOR_CA_CA4_MASK                      0xFFFFFFFFu
+#define CAU_XOR_CA_CA4_SHIFT                     0
+#define CAU_XOR_CA_CA4(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_XOR_CA_CA4_SHIFT))&CAU_XOR_CA_CA4_MASK)
+#define CAU_XOR_CA_CA5_MASK                      0xFFFFFFFFu
+#define CAU_XOR_CA_CA5_SHIFT                     0
+#define CAU_XOR_CA_CA5(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_XOR_CA_CA5_SHIFT))&CAU_XOR_CA_CA5_MASK)
+#define CAU_XOR_CA_CA6_MASK                      0xFFFFFFFFu
+#define CAU_XOR_CA_CA6_SHIFT                     0
+#define CAU_XOR_CA_CA6(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_XOR_CA_CA6_SHIFT))&CAU_XOR_CA_CA6_MASK)
+#define CAU_XOR_CA_CA7_MASK                      0xFFFFFFFFu
+#define CAU_XOR_CA_CA7_SHIFT                     0
+#define CAU_XOR_CA_CA7(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_XOR_CA_CA7_SHIFT))&CAU_XOR_CA_CA7_MASK)
+#define CAU_XOR_CA_CA8_MASK                      0xFFFFFFFFu
+#define CAU_XOR_CA_CA8_SHIFT                     0
+#define CAU_XOR_CA_CA8(x)                        (((uint32_t)(((uint32_t)(x))<<CAU_XOR_CA_CA8_SHIFT))&CAU_XOR_CA_CA8_MASK)
+/* ROTL_CASR Bit Fields */
+#define CAU_ROTL_CASR_IC_MASK                    0x1u
+#define CAU_ROTL_CASR_IC_SHIFT                   0
+#define CAU_ROTL_CASR_DPE_MASK                   0x2u
+#define CAU_ROTL_CASR_DPE_SHIFT                  1
+#define CAU_ROTL_CASR_VER_MASK                   0xF0000000u
+#define CAU_ROTL_CASR_VER_SHIFT                  28
+#define CAU_ROTL_CASR_VER(x)                     (((uint32_t)(((uint32_t)(x))<<CAU_ROTL_CASR_VER_SHIFT))&CAU_ROTL_CASR_VER_MASK)
+/* ROTL_CAA Bit Fields */
+#define CAU_ROTL_CAA_ACC_MASK                    0xFFFFFFFFu
+#define CAU_ROTL_CAA_ACC_SHIFT                   0
+#define CAU_ROTL_CAA_ACC(x)                      (((uint32_t)(((uint32_t)(x))<<CAU_ROTL_CAA_ACC_SHIFT))&CAU_ROTL_CAA_ACC_MASK)
+/* ROTL_CA Bit Fields */
+#define CAU_ROTL_CA_CA0_MASK                     0xFFFFFFFFu
+#define CAU_ROTL_CA_CA0_SHIFT                    0
+#define CAU_ROTL_CA_CA0(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_ROTL_CA_CA0_SHIFT))&CAU_ROTL_CA_CA0_MASK)
+#define CAU_ROTL_CA_CA1_MASK                     0xFFFFFFFFu
+#define CAU_ROTL_CA_CA1_SHIFT                    0
+#define CAU_ROTL_CA_CA1(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_ROTL_CA_CA1_SHIFT))&CAU_ROTL_CA_CA1_MASK)
+#define CAU_ROTL_CA_CA2_MASK                     0xFFFFFFFFu
+#define CAU_ROTL_CA_CA2_SHIFT                    0
+#define CAU_ROTL_CA_CA2(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_ROTL_CA_CA2_SHIFT))&CAU_ROTL_CA_CA2_MASK)
+#define CAU_ROTL_CA_CA3_MASK                     0xFFFFFFFFu
+#define CAU_ROTL_CA_CA3_SHIFT                    0
+#define CAU_ROTL_CA_CA3(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_ROTL_CA_CA3_SHIFT))&CAU_ROTL_CA_CA3_MASK)
+#define CAU_ROTL_CA_CA4_MASK                     0xFFFFFFFFu
+#define CAU_ROTL_CA_CA4_SHIFT                    0
+#define CAU_ROTL_CA_CA4(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_ROTL_CA_CA4_SHIFT))&CAU_ROTL_CA_CA4_MASK)
+#define CAU_ROTL_CA_CA5_MASK                     0xFFFFFFFFu
+#define CAU_ROTL_CA_CA5_SHIFT                    0
+#define CAU_ROTL_CA_CA5(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_ROTL_CA_CA5_SHIFT))&CAU_ROTL_CA_CA5_MASK)
+#define CAU_ROTL_CA_CA6_MASK                     0xFFFFFFFFu
+#define CAU_ROTL_CA_CA6_SHIFT                    0
+#define CAU_ROTL_CA_CA6(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_ROTL_CA_CA6_SHIFT))&CAU_ROTL_CA_CA6_MASK)
+#define CAU_ROTL_CA_CA7_MASK                     0xFFFFFFFFu
+#define CAU_ROTL_CA_CA7_SHIFT                    0
+#define CAU_ROTL_CA_CA7(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_ROTL_CA_CA7_SHIFT))&CAU_ROTL_CA_CA7_MASK)
+#define CAU_ROTL_CA_CA8_MASK                     0xFFFFFFFFu
+#define CAU_ROTL_CA_CA8_SHIFT                    0
+#define CAU_ROTL_CA_CA8(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_ROTL_CA_CA8_SHIFT))&CAU_ROTL_CA_CA8_MASK)
+/* AESC_CASR Bit Fields */
+#define CAU_AESC_CASR_IC_MASK                    0x1u
+#define CAU_AESC_CASR_IC_SHIFT                   0
+#define CAU_AESC_CASR_DPE_MASK                   0x2u
+#define CAU_AESC_CASR_DPE_SHIFT                  1
+#define CAU_AESC_CASR_VER_MASK                   0xF0000000u
+#define CAU_AESC_CASR_VER_SHIFT                  28
+#define CAU_AESC_CASR_VER(x)                     (((uint32_t)(((uint32_t)(x))<<CAU_AESC_CASR_VER_SHIFT))&CAU_AESC_CASR_VER_MASK)
+/* AESC_CAA Bit Fields */
+#define CAU_AESC_CAA_ACC_MASK                    0xFFFFFFFFu
+#define CAU_AESC_CAA_ACC_SHIFT                   0
+#define CAU_AESC_CAA_ACC(x)                      (((uint32_t)(((uint32_t)(x))<<CAU_AESC_CAA_ACC_SHIFT))&CAU_AESC_CAA_ACC_MASK)
+/* AESC_CA Bit Fields */
+#define CAU_AESC_CA_CA0_MASK                     0xFFFFFFFFu
+#define CAU_AESC_CA_CA0_SHIFT                    0
+#define CAU_AESC_CA_CA0(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_AESC_CA_CA0_SHIFT))&CAU_AESC_CA_CA0_MASK)
+#define CAU_AESC_CA_CA1_MASK                     0xFFFFFFFFu
+#define CAU_AESC_CA_CA1_SHIFT                    0
+#define CAU_AESC_CA_CA1(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_AESC_CA_CA1_SHIFT))&CAU_AESC_CA_CA1_MASK)
+#define CAU_AESC_CA_CA2_MASK                     0xFFFFFFFFu
+#define CAU_AESC_CA_CA2_SHIFT                    0
+#define CAU_AESC_CA_CA2(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_AESC_CA_CA2_SHIFT))&CAU_AESC_CA_CA2_MASK)
+#define CAU_AESC_CA_CA3_MASK                     0xFFFFFFFFu
+#define CAU_AESC_CA_CA3_SHIFT                    0
+#define CAU_AESC_CA_CA3(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_AESC_CA_CA3_SHIFT))&CAU_AESC_CA_CA3_MASK)
+#define CAU_AESC_CA_CA4_MASK                     0xFFFFFFFFu
+#define CAU_AESC_CA_CA4_SHIFT                    0
+#define CAU_AESC_CA_CA4(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_AESC_CA_CA4_SHIFT))&CAU_AESC_CA_CA4_MASK)
+#define CAU_AESC_CA_CA5_MASK                     0xFFFFFFFFu
+#define CAU_AESC_CA_CA5_SHIFT                    0
+#define CAU_AESC_CA_CA5(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_AESC_CA_CA5_SHIFT))&CAU_AESC_CA_CA5_MASK)
+#define CAU_AESC_CA_CA6_MASK                     0xFFFFFFFFu
+#define CAU_AESC_CA_CA6_SHIFT                    0
+#define CAU_AESC_CA_CA6(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_AESC_CA_CA6_SHIFT))&CAU_AESC_CA_CA6_MASK)
+#define CAU_AESC_CA_CA7_MASK                     0xFFFFFFFFu
+#define CAU_AESC_CA_CA7_SHIFT                    0
+#define CAU_AESC_CA_CA7(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_AESC_CA_CA7_SHIFT))&CAU_AESC_CA_CA7_MASK)
+#define CAU_AESC_CA_CA8_MASK                     0xFFFFFFFFu
+#define CAU_AESC_CA_CA8_SHIFT                    0
+#define CAU_AESC_CA_CA8(x)                       (((uint32_t)(((uint32_t)(x))<<CAU_AESC_CA_CA8_SHIFT))&CAU_AESC_CA_CA8_MASK)
+/* AESIC_CASR Bit Fields */
+#define CAU_AESIC_CASR_IC_MASK                   0x1u
+#define CAU_AESIC_CASR_IC_SHIFT                  0
+#define CAU_AESIC_CASR_DPE_MASK                  0x2u
+#define CAU_AESIC_CASR_DPE_SHIFT                 1
+#define CAU_AESIC_CASR_VER_MASK                  0xF0000000u
+#define CAU_AESIC_CASR_VER_SHIFT                 28
+#define CAU_AESIC_CASR_VER(x)                    (((uint32_t)(((uint32_t)(x))<<CAU_AESIC_CASR_VER_SHIFT))&CAU_AESIC_CASR_VER_MASK)
+/* AESIC_CAA Bit Fields */
+#define CAU_AESIC_CAA_ACC_MASK                   0xFFFFFFFFu
+#define CAU_AESIC_CAA_ACC_SHIFT                  0
+#define CAU_AESIC_CAA_ACC(x)                     (((uint32_t)(((uint32_t)(x))<<CAU_AESIC_CAA_ACC_SHIFT))&CAU_AESIC_CAA_ACC_MASK)
+/* AESIC_CA Bit Fields */
+#define CAU_AESIC_CA_CA0_MASK                    0xFFFFFFFFu
+#define CAU_AESIC_CA_CA0_SHIFT                   0
+#define CAU_AESIC_CA_CA0(x)                      (((uint32_t)(((uint32_t)(x))<<CAU_AESIC_CA_CA0_SHIFT))&CAU_AESIC_CA_CA0_MASK)
+#define CAU_AESIC_CA_CA1_MASK                    0xFFFFFFFFu
+#define CAU_AESIC_CA_CA1_SHIFT                   0
+#define CAU_AESIC_CA_CA1(x)                      (((uint32_t)(((uint32_t)(x))<<CAU_AESIC_CA_CA1_SHIFT))&CAU_AESIC_CA_CA1_MASK)
+#define CAU_AESIC_CA_CA2_MASK                    0xFFFFFFFFu
+#define CAU_AESIC_CA_CA2_SHIFT                   0
+#define CAU_AESIC_CA_CA2(x)                      (((uint32_t)(((uint32_t)(x))<<CAU_AESIC_CA_CA2_SHIFT))&CAU_AESIC_CA_CA2_MASK)
+#define CAU_AESIC_CA_CA3_MASK                    0xFFFFFFFFu
+#define CAU_AESIC_CA_CA3_SHIFT                   0
+#define CAU_AESIC_CA_CA3(x)                      (((uint32_t)(((uint32_t)(x))<<CAU_AESIC_CA_CA3_SHIFT))&CAU_AESIC_CA_CA3_MASK)
+#define CAU_AESIC_CA_CA4_MASK                    0xFFFFFFFFu
+#define CAU_AESIC_CA_CA4_SHIFT                   0
+#define CAU_AESIC_CA_CA4(x)                      (((uint32_t)(((uint32_t)(x))<<CAU_AESIC_CA_CA4_SHIFT))&CAU_AESIC_CA_CA4_MASK)
+#define CAU_AESIC_CA_CA5_MASK                    0xFFFFFFFFu
+#define CAU_AESIC_CA_CA5_SHIFT                   0
+#define CAU_AESIC_CA_CA5(x)                      (((uint32_t)(((uint32_t)(x))<<CAU_AESIC_CA_CA5_SHIFT))&CAU_AESIC_CA_CA5_MASK)
+#define CAU_AESIC_CA_CA6_MASK                    0xFFFFFFFFu
+#define CAU_AESIC_CA_CA6_SHIFT                   0
+#define CAU_AESIC_CA_CA6(x)                      (((uint32_t)(((uint32_t)(x))<<CAU_AESIC_CA_CA6_SHIFT))&CAU_AESIC_CA_CA6_MASK)
+#define CAU_AESIC_CA_CA7_MASK                    0xFFFFFFFFu
+#define CAU_AESIC_CA_CA7_SHIFT                   0
+#define CAU_AESIC_CA_CA7(x)                      (((uint32_t)(((uint32_t)(x))<<CAU_AESIC_CA_CA7_SHIFT))&CAU_AESIC_CA_CA7_MASK)
+#define CAU_AESIC_CA_CA8_MASK                    0xFFFFFFFFu
+#define CAU_AESIC_CA_CA8_SHIFT                   0
+#define CAU_AESIC_CA_CA8(x)                      (((uint32_t)(((uint32_t)(x))<<CAU_AESIC_CA_CA8_SHIFT))&CAU_AESIC_CA_CA8_MASK)
+
+/*!
+ * @}
+ */ /* end of group CAU_Register_Masks */
+
+
+/* CAU - Peripheral instance base addresses */
+/** Peripheral CAU base address */
+#define CAU_BASE                                 (0xE0081000u)
+/** Peripheral CAU base pointer */
+#define CAU                                      ((CAU_Type *)CAU_BASE)
+#define CAU_BASE_PTR                             (CAU)
+/** Array initializer of CAU peripheral base addresses */
+#define CAU_BASE_ADDRS                           { CAU_BASE }
+/** Array initializer of CAU peripheral base pointers */
+#define CAU_BASE_PTRS                            { CAU }
+
+/* ----------------------------------------------------------------------------
+   -- CAU - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CAU_Register_Accessor_Macros CAU - Register accessor macros
+ * @{
+ */
+
+
+/* CAU - Register instance definitions */
+/* CAU */
+#define CAU_DIRECT0                              CAU_DIRECT_REG(CAU,0)
+#define CAU_DIRECT1                              CAU_DIRECT_REG(CAU,1)
+#define CAU_DIRECT2                              CAU_DIRECT_REG(CAU,2)
+#define CAU_DIRECT3                              CAU_DIRECT_REG(CAU,3)
+#define CAU_DIRECT4                              CAU_DIRECT_REG(CAU,4)
+#define CAU_DIRECT5                              CAU_DIRECT_REG(CAU,5)
+#define CAU_DIRECT6                              CAU_DIRECT_REG(CAU,6)
+#define CAU_DIRECT7                              CAU_DIRECT_REG(CAU,7)
+#define CAU_DIRECT8                              CAU_DIRECT_REG(CAU,8)
+#define CAU_DIRECT9                              CAU_DIRECT_REG(CAU,9)
+#define CAU_DIRECT10                             CAU_DIRECT_REG(CAU,10)
+#define CAU_DIRECT11                             CAU_DIRECT_REG(CAU,11)
+#define CAU_DIRECT12                             CAU_DIRECT_REG(CAU,12)
+#define CAU_DIRECT13                             CAU_DIRECT_REG(CAU,13)
+#define CAU_DIRECT14                             CAU_DIRECT_REG(CAU,14)
+#define CAU_DIRECT15                             CAU_DIRECT_REG(CAU,15)
+#define CAU_LDR_CASR                             CAU_LDR_CASR_REG(CAU)
+#define CAU_LDR_CAA                              CAU_LDR_CAA_REG(CAU)
+#define CAU_LDR_CA0                              CAU_LDR_CA_REG(CAU,0)
+#define CAU_LDR_CA1                              CAU_LDR_CA_REG(CAU,1)
+#define CAU_LDR_CA2                              CAU_LDR_CA_REG(CAU,2)
+#define CAU_LDR_CA3                              CAU_LDR_CA_REG(CAU,3)
+#define CAU_LDR_CA4                              CAU_LDR_CA_REG(CAU,4)
+#define CAU_LDR_CA5                              CAU_LDR_CA_REG(CAU,5)
+#define CAU_LDR_CA6                              CAU_LDR_CA_REG(CAU,6)
+#define CAU_LDR_CA7                              CAU_LDR_CA_REG(CAU,7)
+#define CAU_LDR_CA8                              CAU_LDR_CA_REG(CAU,8)
+#define CAU_STR_CASR                             CAU_STR_CASR_REG(CAU)
+#define CAU_STR_CAA                              CAU_STR_CAA_REG(CAU)
+#define CAU_STR_CA0                              CAU_STR_CA_REG(CAU,0)
+#define CAU_STR_CA1                              CAU_STR_CA_REG(CAU,1)
+#define CAU_STR_CA2                              CAU_STR_CA_REG(CAU,2)
+#define CAU_STR_CA3                              CAU_STR_CA_REG(CAU,3)
+#define CAU_STR_CA4                              CAU_STR_CA_REG(CAU,4)
+#define CAU_STR_CA5                              CAU_STR_CA_REG(CAU,5)
+#define CAU_STR_CA6                              CAU_STR_CA_REG(CAU,6)
+#define CAU_STR_CA7                              CAU_STR_CA_REG(CAU,7)
+#define CAU_STR_CA8                              CAU_STR_CA_REG(CAU,8)
+#define CAU_ADR_CASR                             CAU_ADR_CASR_REG(CAU)
+#define CAU_ADR_CAA                              CAU_ADR_CAA_REG(CAU)
+#define CAU_ADR_CA0                              CAU_ADR_CA_REG(CAU,0)
+#define CAU_ADR_CA1                              CAU_ADR_CA_REG(CAU,1)
+#define CAU_ADR_CA2                              CAU_ADR_CA_REG(CAU,2)
+#define CAU_ADR_CA3                              CAU_ADR_CA_REG(CAU,3)
+#define CAU_ADR_CA4                              CAU_ADR_CA_REG(CAU,4)
+#define CAU_ADR_CA5                              CAU_ADR_CA_REG(CAU,5)
+#define CAU_ADR_CA6                              CAU_ADR_CA_REG(CAU,6)
+#define CAU_ADR_CA7                              CAU_ADR_CA_REG(CAU,7)
+#define CAU_ADR_CA8                              CAU_ADR_CA_REG(CAU,8)
+#define CAU_RADR_CASR                            CAU_RADR_CASR_REG(CAU)
+#define CAU_RADR_CAA                             CAU_RADR_CAA_REG(CAU)
+#define CAU_RADR_CA0                             CAU_RADR_CA_REG(CAU,0)
+#define CAU_RADR_CA1                             CAU_RADR_CA_REG(CAU,1)
+#define CAU_RADR_CA2                             CAU_RADR_CA_REG(CAU,2)
+#define CAU_RADR_CA3                             CAU_RADR_CA_REG(CAU,3)
+#define CAU_RADR_CA4                             CAU_RADR_CA_REG(CAU,4)
+#define CAU_RADR_CA5                             CAU_RADR_CA_REG(CAU,5)
+#define CAU_RADR_CA6                             CAU_RADR_CA_REG(CAU,6)
+#define CAU_RADR_CA7                             CAU_RADR_CA_REG(CAU,7)
+#define CAU_RADR_CA8                             CAU_RADR_CA_REG(CAU,8)
+#define CAU_XOR_CASR                             CAU_XOR_CASR_REG(CAU)
+#define CAU_XOR_CAA                              CAU_XOR_CAA_REG(CAU)
+#define CAU_XOR_CA0                              CAU_XOR_CA_REG(CAU,0)
+#define CAU_XOR_CA1                              CAU_XOR_CA_REG(CAU,1)
+#define CAU_XOR_CA2                              CAU_XOR_CA_REG(CAU,2)
+#define CAU_XOR_CA3                              CAU_XOR_CA_REG(CAU,3)
+#define CAU_XOR_CA4                              CAU_XOR_CA_REG(CAU,4)
+#define CAU_XOR_CA5                              CAU_XOR_CA_REG(CAU,5)
+#define CAU_XOR_CA6                              CAU_XOR_CA_REG(CAU,6)
+#define CAU_XOR_CA7                              CAU_XOR_CA_REG(CAU,7)
+#define CAU_XOR_CA8                              CAU_XOR_CA_REG(CAU,8)
+#define CAU_ROTL_CASR                            CAU_ROTL_CASR_REG(CAU)
+#define CAU_ROTL_CAA                             CAU_ROTL_CAA_REG(CAU)
+#define CAU_ROTL_CA0                             CAU_ROTL_CA_REG(CAU,0)
+#define CAU_ROTL_CA1                             CAU_ROTL_CA_REG(CAU,1)
+#define CAU_ROTL_CA2                             CAU_ROTL_CA_REG(CAU,2)
+#define CAU_ROTL_CA3                             CAU_ROTL_CA_REG(CAU,3)
+#define CAU_ROTL_CA4                             CAU_ROTL_CA_REG(CAU,4)
+#define CAU_ROTL_CA5                             CAU_ROTL_CA_REG(CAU,5)
+#define CAU_ROTL_CA6                             CAU_ROTL_CA_REG(CAU,6)
+#define CAU_ROTL_CA7                             CAU_ROTL_CA_REG(CAU,7)
+#define CAU_ROTL_CA8                             CAU_ROTL_CA_REG(CAU,8)
+#define CAU_AESC_CASR                            CAU_AESC_CASR_REG(CAU)
+#define CAU_AESC_CAA                             CAU_AESC_CAA_REG(CAU)
+#define CAU_AESC_CA0                             CAU_AESC_CA_REG(CAU,0)
+#define CAU_AESC_CA1                             CAU_AESC_CA_REG(CAU,1)
+#define CAU_AESC_CA2                             CAU_AESC_CA_REG(CAU,2)
+#define CAU_AESC_CA3                             CAU_AESC_CA_REG(CAU,3)
+#define CAU_AESC_CA4                             CAU_AESC_CA_REG(CAU,4)
+#define CAU_AESC_CA5                             CAU_AESC_CA_REG(CAU,5)
+#define CAU_AESC_CA6                             CAU_AESC_CA_REG(CAU,6)
+#define CAU_AESC_CA7                             CAU_AESC_CA_REG(CAU,7)
+#define CAU_AESC_CA8                             CAU_AESC_CA_REG(CAU,8)
+#define CAU_AESIC_CASR                           CAU_AESIC_CASR_REG(CAU)
+#define CAU_AESIC_CAA                            CAU_AESIC_CAA_REG(CAU)
+#define CAU_AESIC_CA0                            CAU_AESIC_CA_REG(CAU,0)
+#define CAU_AESIC_CA1                            CAU_AESIC_CA_REG(CAU,1)
+#define CAU_AESIC_CA2                            CAU_AESIC_CA_REG(CAU,2)
+#define CAU_AESIC_CA3                            CAU_AESIC_CA_REG(CAU,3)
+#define CAU_AESIC_CA4                            CAU_AESIC_CA_REG(CAU,4)
+#define CAU_AESIC_CA5                            CAU_AESIC_CA_REG(CAU,5)
+#define CAU_AESIC_CA6                            CAU_AESIC_CA_REG(CAU,6)
+#define CAU_AESIC_CA7                            CAU_AESIC_CA_REG(CAU,7)
+#define CAU_AESIC_CA8                            CAU_AESIC_CA_REG(CAU,8)
+
+/* CAU - Register array accessors */
+#define CAU_DIRECT(index)                        CAU_DIRECT_REG(CAU,index)
+#define CAU_LDR_CA(index)                        CAU_LDR_CA_REG(CAU,index)
+#define CAU_STR_CA(index)                        CAU_STR_CA_REG(CAU,index)
+#define CAU_ADR_CA(index)                        CAU_ADR_CA_REG(CAU,index)
+#define CAU_RADR_CA(index)                       CAU_RADR_CA_REG(CAU,index)
+#define CAU_XOR_CA(index)                        CAU_XOR_CA_REG(CAU,index)
+#define CAU_ROTL_CA(index)                       CAU_ROTL_CA_REG(CAU,index)
+#define CAU_AESC_CA(index)                       CAU_AESC_CA_REG(CAU,index)
+#define CAU_AESIC_CA(index)                      CAU_AESIC_CA_REG(CAU,index)
+
+/*!
+ * @}
+ */ /* end of group CAU_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group CAU_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- CMP Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CMP_Peripheral_Access_Layer CMP Peripheral Access Layer
+ * @{
+ */
+
+/** CMP - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t CR0;                                /**< CMP Control Register 0, offset: 0x0 */
+  __IO uint8_t CR1;                                /**< CMP Control Register 1, offset: 0x1 */
+  __IO uint8_t FPR;                                /**< CMP Filter Period Register, offset: 0x2 */
+  __IO uint8_t SCR;                                /**< CMP Status and Control Register, offset: 0x3 */
+  __IO uint8_t DACCR;                              /**< DAC Control Register, offset: 0x4 */
+  __IO uint8_t MUXCR;                              /**< MUX Control Register, offset: 0x5 */
+} CMP_Type, *CMP_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- CMP - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CMP_Register_Accessor_Macros CMP - Register accessor macros
+ * @{
+ */
+
+
+/* CMP - Register accessors */
+#define CMP_CR0_REG(base)                        ((base)->CR0)
+#define CMP_CR1_REG(base)                        ((base)->CR1)
+#define CMP_FPR_REG(base)                        ((base)->FPR)
+#define CMP_SCR_REG(base)                        ((base)->SCR)
+#define CMP_DACCR_REG(base)                      ((base)->DACCR)
+#define CMP_MUXCR_REG(base)                      ((base)->MUXCR)
+
+/*!
+ * @}
+ */ /* end of group CMP_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- CMP Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CMP_Register_Masks CMP Register Masks
+ * @{
+ */
+
+/* CR0 Bit Fields */
+#define CMP_CR0_HYSTCTR_MASK                     0x3u
+#define CMP_CR0_HYSTCTR_SHIFT                    0
+#define CMP_CR0_HYSTCTR(x)                       (((uint8_t)(((uint8_t)(x))<<CMP_CR0_HYSTCTR_SHIFT))&CMP_CR0_HYSTCTR_MASK)
+#define CMP_CR0_FILTER_CNT_MASK                  0x70u
+#define CMP_CR0_FILTER_CNT_SHIFT                 4
+#define CMP_CR0_FILTER_CNT(x)                    (((uint8_t)(((uint8_t)(x))<<CMP_CR0_FILTER_CNT_SHIFT))&CMP_CR0_FILTER_CNT_MASK)
+/* CR1 Bit Fields */
+#define CMP_CR1_EN_MASK                          0x1u
+#define CMP_CR1_EN_SHIFT                         0
+#define CMP_CR1_OPE_MASK                         0x2u
+#define CMP_CR1_OPE_SHIFT                        1
+#define CMP_CR1_COS_MASK                         0x4u
+#define CMP_CR1_COS_SHIFT                        2
+#define CMP_CR1_INV_MASK                         0x8u
+#define CMP_CR1_INV_SHIFT                        3
+#define CMP_CR1_PMODE_MASK                       0x10u
+#define CMP_CR1_PMODE_SHIFT                      4
+#define CMP_CR1_WE_MASK                          0x40u
+#define CMP_CR1_WE_SHIFT                         6
+#define CMP_CR1_SE_MASK                          0x80u
+#define CMP_CR1_SE_SHIFT                         7
+/* FPR Bit Fields */
+#define CMP_FPR_FILT_PER_MASK                    0xFFu
+#define CMP_FPR_FILT_PER_SHIFT                   0
+#define CMP_FPR_FILT_PER(x)                      (((uint8_t)(((uint8_t)(x))<<CMP_FPR_FILT_PER_SHIFT))&CMP_FPR_FILT_PER_MASK)
+/* SCR Bit Fields */
+#define CMP_SCR_COUT_MASK                        0x1u
+#define CMP_SCR_COUT_SHIFT                       0
+#define CMP_SCR_CFF_MASK                         0x2u
+#define CMP_SCR_CFF_SHIFT                        1
+#define CMP_SCR_CFR_MASK                         0x4u
+#define CMP_SCR_CFR_SHIFT                        2
+#define CMP_SCR_IEF_MASK                         0x8u
+#define CMP_SCR_IEF_SHIFT                        3
+#define CMP_SCR_IER_MASK                         0x10u
+#define CMP_SCR_IER_SHIFT                        4
+#define CMP_SCR_DMAEN_MASK                       0x40u
+#define CMP_SCR_DMAEN_SHIFT                      6
+/* DACCR Bit Fields */
+#define CMP_DACCR_VOSEL_MASK                     0x3Fu
+#define CMP_DACCR_VOSEL_SHIFT                    0
+#define CMP_DACCR_VOSEL(x)                       (((uint8_t)(((uint8_t)(x))<<CMP_DACCR_VOSEL_SHIFT))&CMP_DACCR_VOSEL_MASK)
+#define CMP_DACCR_VRSEL_MASK                     0x40u
+#define CMP_DACCR_VRSEL_SHIFT                    6
+#define CMP_DACCR_DACEN_MASK                     0x80u
+#define CMP_DACCR_DACEN_SHIFT                    7
+/* MUXCR Bit Fields */
+#define CMP_MUXCR_MSEL_MASK                      0x7u
+#define CMP_MUXCR_MSEL_SHIFT                     0
+#define CMP_MUXCR_MSEL(x)                        (((uint8_t)(((uint8_t)(x))<<CMP_MUXCR_MSEL_SHIFT))&CMP_MUXCR_MSEL_MASK)
+#define CMP_MUXCR_PSEL_MASK                      0x38u
+#define CMP_MUXCR_PSEL_SHIFT                     3
+#define CMP_MUXCR_PSEL(x)                        (((uint8_t)(((uint8_t)(x))<<CMP_MUXCR_PSEL_SHIFT))&CMP_MUXCR_PSEL_MASK)
+#define CMP_MUXCR_PSTM_MASK                      0x80u
+#define CMP_MUXCR_PSTM_SHIFT                     7
+
+/*!
+ * @}
+ */ /* end of group CMP_Register_Masks */
+
+
+/* CMP - Peripheral instance base addresses */
+/** Peripheral CMP0 base address */
+#define CMP0_BASE                                (0x40073000u)
+/** Peripheral CMP0 base pointer */
+#define CMP0                                     ((CMP_Type *)CMP0_BASE)
+#define CMP0_BASE_PTR                            (CMP0)
+/** Peripheral CMP1 base address */
+#define CMP1_BASE                                (0x40073008u)
+/** Peripheral CMP1 base pointer */
+#define CMP1                                     ((CMP_Type *)CMP1_BASE)
+#define CMP1_BASE_PTR                            (CMP1)
+/** Peripheral CMP2 base address */
+#define CMP2_BASE                                (0x40073010u)
+/** Peripheral CMP2 base pointer */
+#define CMP2                                     ((CMP_Type *)CMP2_BASE)
+#define CMP2_BASE_PTR                            (CMP2)
+/** Array initializer of CMP peripheral base addresses */
+#define CMP_BASE_ADDRS                           { CMP0_BASE, CMP1_BASE, CMP2_BASE }
+/** Array initializer of CMP peripheral base pointers */
+#define CMP_BASE_PTRS                            { CMP0, CMP1, CMP2 }
+/** Interrupt vectors for the CMP peripheral type */
+#define CMP_IRQS                                 { CMP0_IRQn, CMP1_IRQn, CMP2_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- CMP - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CMP_Register_Accessor_Macros CMP - Register accessor macros
+ * @{
+ */
+
+
+/* CMP - Register instance definitions */
+/* CMP0 */
+#define CMP0_CR0                                 CMP_CR0_REG(CMP0)
+#define CMP0_CR1                                 CMP_CR1_REG(CMP0)
+#define CMP0_FPR                                 CMP_FPR_REG(CMP0)
+#define CMP0_SCR                                 CMP_SCR_REG(CMP0)
+#define CMP0_DACCR                               CMP_DACCR_REG(CMP0)
+#define CMP0_MUXCR                               CMP_MUXCR_REG(CMP0)
+/* CMP1 */
+#define CMP1_CR0                                 CMP_CR0_REG(CMP1)
+#define CMP1_CR1                                 CMP_CR1_REG(CMP1)
+#define CMP1_FPR                                 CMP_FPR_REG(CMP1)
+#define CMP1_SCR                                 CMP_SCR_REG(CMP1)
+#define CMP1_DACCR                               CMP_DACCR_REG(CMP1)
+#define CMP1_MUXCR                               CMP_MUXCR_REG(CMP1)
+/* CMP2 */
+#define CMP2_CR0                                 CMP_CR0_REG(CMP2)
+#define CMP2_CR1                                 CMP_CR1_REG(CMP2)
+#define CMP2_FPR                                 CMP_FPR_REG(CMP2)
+#define CMP2_SCR                                 CMP_SCR_REG(CMP2)
+#define CMP2_DACCR                               CMP_DACCR_REG(CMP2)
+#define CMP2_MUXCR                               CMP_MUXCR_REG(CMP2)
+
+/*!
+ * @}
+ */ /* end of group CMP_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group CMP_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- CMT Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CMT_Peripheral_Access_Layer CMT Peripheral Access Layer
+ * @{
+ */
+
+/** CMT - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t CGH1;                               /**< CMT Carrier Generator High Data Register 1, offset: 0x0 */
+  __IO uint8_t CGL1;                               /**< CMT Carrier Generator Low Data Register 1, offset: 0x1 */
+  __IO uint8_t CGH2;                               /**< CMT Carrier Generator High Data Register 2, offset: 0x2 */
+  __IO uint8_t CGL2;                               /**< CMT Carrier Generator Low Data Register 2, offset: 0x3 */
+  __IO uint8_t OC;                                 /**< CMT Output Control Register, offset: 0x4 */
+  __IO uint8_t MSC;                                /**< CMT Modulator Status and Control Register, offset: 0x5 */
+  __IO uint8_t CMD1;                               /**< CMT Modulator Data Register Mark High, offset: 0x6 */
+  __IO uint8_t CMD2;                               /**< CMT Modulator Data Register Mark Low, offset: 0x7 */
+  __IO uint8_t CMD3;                               /**< CMT Modulator Data Register Space High, offset: 0x8 */
+  __IO uint8_t CMD4;                               /**< CMT Modulator Data Register Space Low, offset: 0x9 */
+  __IO uint8_t PPS;                                /**< CMT Primary Prescaler Register, offset: 0xA */
+  __IO uint8_t DMA;                                /**< CMT Direct Memory Access Register, offset: 0xB */
+} CMT_Type, *CMT_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- CMT - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CMT_Register_Accessor_Macros CMT - Register accessor macros
+ * @{
+ */
+
+
+/* CMT - Register accessors */
+#define CMT_CGH1_REG(base)                       ((base)->CGH1)
+#define CMT_CGL1_REG(base)                       ((base)->CGL1)
+#define CMT_CGH2_REG(base)                       ((base)->CGH2)
+#define CMT_CGL2_REG(base)                       ((base)->CGL2)
+#define CMT_OC_REG(base)                         ((base)->OC)
+#define CMT_MSC_REG(base)                        ((base)->MSC)
+#define CMT_CMD1_REG(base)                       ((base)->CMD1)
+#define CMT_CMD2_REG(base)                       ((base)->CMD2)
+#define CMT_CMD3_REG(base)                       ((base)->CMD3)
+#define CMT_CMD4_REG(base)                       ((base)->CMD4)
+#define CMT_PPS_REG(base)                        ((base)->PPS)
+#define CMT_DMA_REG(base)                        ((base)->DMA)
+
+/*!
+ * @}
+ */ /* end of group CMT_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- CMT Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CMT_Register_Masks CMT Register Masks
+ * @{
+ */
+
+/* CGH1 Bit Fields */
+#define CMT_CGH1_PH_MASK                         0xFFu
+#define CMT_CGH1_PH_SHIFT                        0
+#define CMT_CGH1_PH(x)                           (((uint8_t)(((uint8_t)(x))<<CMT_CGH1_PH_SHIFT))&CMT_CGH1_PH_MASK)
+/* CGL1 Bit Fields */
+#define CMT_CGL1_PL_MASK                         0xFFu
+#define CMT_CGL1_PL_SHIFT                        0
+#define CMT_CGL1_PL(x)                           (((uint8_t)(((uint8_t)(x))<<CMT_CGL1_PL_SHIFT))&CMT_CGL1_PL_MASK)
+/* CGH2 Bit Fields */
+#define CMT_CGH2_SH_MASK                         0xFFu
+#define CMT_CGH2_SH_SHIFT                        0
+#define CMT_CGH2_SH(x)                           (((uint8_t)(((uint8_t)(x))<<CMT_CGH2_SH_SHIFT))&CMT_CGH2_SH_MASK)
+/* CGL2 Bit Fields */
+#define CMT_CGL2_SL_MASK                         0xFFu
+#define CMT_CGL2_SL_SHIFT                        0
+#define CMT_CGL2_SL(x)                           (((uint8_t)(((uint8_t)(x))<<CMT_CGL2_SL_SHIFT))&CMT_CGL2_SL_MASK)
+/* OC Bit Fields */
+#define CMT_OC_IROPEN_MASK                       0x20u
+#define CMT_OC_IROPEN_SHIFT                      5
+#define CMT_OC_CMTPOL_MASK                       0x40u
+#define CMT_OC_CMTPOL_SHIFT                      6
+#define CMT_OC_IROL_MASK                         0x80u
+#define CMT_OC_IROL_SHIFT                        7
+/* MSC Bit Fields */
+#define CMT_MSC_MCGEN_MASK                       0x1u
+#define CMT_MSC_MCGEN_SHIFT                      0
+#define CMT_MSC_EOCIE_MASK                       0x2u
+#define CMT_MSC_EOCIE_SHIFT                      1
+#define CMT_MSC_FSK_MASK                         0x4u
+#define CMT_MSC_FSK_SHIFT                        2
+#define CMT_MSC_BASE_MASK                        0x8u
+#define CMT_MSC_BASE_SHIFT                       3
+#define CMT_MSC_EXSPC_MASK                       0x10u
+#define CMT_MSC_EXSPC_SHIFT                      4
+#define CMT_MSC_CMTDIV_MASK                      0x60u
+#define CMT_MSC_CMTDIV_SHIFT                     5
+#define CMT_MSC_CMTDIV(x)                        (((uint8_t)(((uint8_t)(x))<<CMT_MSC_CMTDIV_SHIFT))&CMT_MSC_CMTDIV_MASK)
+#define CMT_MSC_EOCF_MASK                        0x80u
+#define CMT_MSC_EOCF_SHIFT                       7
+/* CMD1 Bit Fields */
+#define CMT_CMD1_MB_MASK                         0xFFu
+#define CMT_CMD1_MB_SHIFT                        0
+#define CMT_CMD1_MB(x)                           (((uint8_t)(((uint8_t)(x))<<CMT_CMD1_MB_SHIFT))&CMT_CMD1_MB_MASK)
+/* CMD2 Bit Fields */
+#define CMT_CMD2_MB_MASK                         0xFFu
+#define CMT_CMD2_MB_SHIFT                        0
+#define CMT_CMD2_MB(x)                           (((uint8_t)(((uint8_t)(x))<<CMT_CMD2_MB_SHIFT))&CMT_CMD2_MB_MASK)
+/* CMD3 Bit Fields */
+#define CMT_CMD3_SB_MASK                         0xFFu
+#define CMT_CMD3_SB_SHIFT                        0
+#define CMT_CMD3_SB(x)                           (((uint8_t)(((uint8_t)(x))<<CMT_CMD3_SB_SHIFT))&CMT_CMD3_SB_MASK)
+/* CMD4 Bit Fields */
+#define CMT_CMD4_SB_MASK                         0xFFu
+#define CMT_CMD4_SB_SHIFT                        0
+#define CMT_CMD4_SB(x)                           (((uint8_t)(((uint8_t)(x))<<CMT_CMD4_SB_SHIFT))&CMT_CMD4_SB_MASK)
+/* PPS Bit Fields */
+#define CMT_PPS_PPSDIV_MASK                      0xFu
+#define CMT_PPS_PPSDIV_SHIFT                     0
+#define CMT_PPS_PPSDIV(x)                        (((uint8_t)(((uint8_t)(x))<<CMT_PPS_PPSDIV_SHIFT))&CMT_PPS_PPSDIV_MASK)
+/* DMA Bit Fields */
+#define CMT_DMA_DMA_MASK                         0x1u
+#define CMT_DMA_DMA_SHIFT                        0
+
+/*!
+ * @}
+ */ /* end of group CMT_Register_Masks */
+
+
+/* CMT - Peripheral instance base addresses */
+/** Peripheral CMT base address */
+#define CMT_BASE                                 (0x40062000u)
+/** Peripheral CMT base pointer */
+#define CMT                                      ((CMT_Type *)CMT_BASE)
+#define CMT_BASE_PTR                             (CMT)
+/** Array initializer of CMT peripheral base addresses */
+#define CMT_BASE_ADDRS                           { CMT_BASE }
+/** Array initializer of CMT peripheral base pointers */
+#define CMT_BASE_PTRS                            { CMT }
+/** Interrupt vectors for the CMT peripheral type */
+#define CMT_IRQS                                 { CMT_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- CMT - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CMT_Register_Accessor_Macros CMT - Register accessor macros
+ * @{
+ */
+
+
+/* CMT - Register instance definitions */
+/* CMT */
+#define CMT_CGH1                                 CMT_CGH1_REG(CMT)
+#define CMT_CGL1                                 CMT_CGL1_REG(CMT)
+#define CMT_CGH2                                 CMT_CGH2_REG(CMT)
+#define CMT_CGL2                                 CMT_CGL2_REG(CMT)
+#define CMT_OC                                   CMT_OC_REG(CMT)
+#define CMT_MSC                                  CMT_MSC_REG(CMT)
+#define CMT_CMD1                                 CMT_CMD1_REG(CMT)
+#define CMT_CMD2                                 CMT_CMD2_REG(CMT)
+#define CMT_CMD3                                 CMT_CMD3_REG(CMT)
+#define CMT_CMD4                                 CMT_CMD4_REG(CMT)
+#define CMT_PPS                                  CMT_PPS_REG(CMT)
+#define CMT_DMA                                  CMT_DMA_REG(CMT)
+
+/*!
+ * @}
+ */ /* end of group CMT_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group CMT_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- CRC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CRC_Peripheral_Access_Layer CRC Peripheral Access Layer
+ * @{
+ */
+
+/** CRC - Register Layout Typedef */
+typedef struct {
+  union {                                          /* offset: 0x0 */
+    struct {                                         /* offset: 0x0 */
+      __IO uint16_t DATAL;                             /**< CRC_DATAL register., offset: 0x0 */
+      __IO uint16_t DATAH;                             /**< CRC_DATAH register., offset: 0x2 */
+    } ACCESS16BIT;
+    __IO uint32_t DATA;                              /**< CRC Data register, offset: 0x0 */
+    struct {                                         /* offset: 0x0 */
+      __IO uint8_t DATALL;                             /**< CRC_DATALL register., offset: 0x0 */
+      __IO uint8_t DATALU;                             /**< CRC_DATALU register., offset: 0x1 */
+      __IO uint8_t DATAHL;                             /**< CRC_DATAHL register., offset: 0x2 */
+      __IO uint8_t DATAHU;                             /**< CRC_DATAHU register., offset: 0x3 */
+    } ACCESS8BIT;
+  };
+  union {                                          /* offset: 0x4 */
+    struct {                                         /* offset: 0x4 */
+      __IO uint16_t GPOLYL;                            /**< CRC_GPOLYL register., offset: 0x4 */
+      __IO uint16_t GPOLYH;                            /**< CRC_GPOLYH register., offset: 0x6 */
+    } GPOLY_ACCESS16BIT;
+    __IO uint32_t GPOLY;                             /**< CRC Polynomial register, offset: 0x4 */
+    struct {                                         /* offset: 0x4 */
+      __IO uint8_t GPOLYLL;                            /**< CRC_GPOLYLL register., offset: 0x4 */
+      __IO uint8_t GPOLYLU;                            /**< CRC_GPOLYLU register., offset: 0x5 */
+      __IO uint8_t GPOLYHL;                            /**< CRC_GPOLYHL register., offset: 0x6 */
+      __IO uint8_t GPOLYHU;                            /**< CRC_GPOLYHU register., offset: 0x7 */
+    } GPOLY_ACCESS8BIT;
+  };
+  union {                                          /* offset: 0x8 */
+    __IO uint32_t CTRL;                              /**< CRC Control register, offset: 0x8 */
+    struct {                                         /* offset: 0x8 */
+           uint8_t RESERVED_0[3];
+      __IO uint8_t CTRLHU;                             /**< CRC_CTRLHU register., offset: 0xB */
+    } CTRL_ACCESS8BIT;
+  };
+} CRC_Type, *CRC_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- CRC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CRC_Register_Accessor_Macros CRC - Register accessor macros
+ * @{
+ */
+
+
+/* CRC - Register accessors */
+#define CRC_DATAL_REG(base)                      ((base)->ACCESS16BIT.DATAL)
+#define CRC_DATAH_REG(base)                      ((base)->ACCESS16BIT.DATAH)
+#define CRC_DATA_REG(base)                       ((base)->DATA)
+#define CRC_DATALL_REG(base)                     ((base)->ACCESS8BIT.DATALL)
+#define CRC_DATALU_REG(base)                     ((base)->ACCESS8BIT.DATALU)
+#define CRC_DATAHL_REG(base)                     ((base)->ACCESS8BIT.DATAHL)
+#define CRC_DATAHU_REG(base)                     ((base)->ACCESS8BIT.DATAHU)
+#define CRC_GPOLYL_REG(base)                     ((base)->GPOLY_ACCESS16BIT.GPOLYL)
+#define CRC_GPOLYH_REG(base)                     ((base)->GPOLY_ACCESS16BIT.GPOLYH)
+#define CRC_GPOLY_REG(base)                      ((base)->GPOLY)
+#define CRC_GPOLYLL_REG(base)                    ((base)->GPOLY_ACCESS8BIT.GPOLYLL)
+#define CRC_GPOLYLU_REG(base)                    ((base)->GPOLY_ACCESS8BIT.GPOLYLU)
+#define CRC_GPOLYHL_REG(base)                    ((base)->GPOLY_ACCESS8BIT.GPOLYHL)
+#define CRC_GPOLYHU_REG(base)                    ((base)->GPOLY_ACCESS8BIT.GPOLYHU)
+#define CRC_CTRL_REG(base)                       ((base)->CTRL)
+#define CRC_CTRLHU_REG(base)                     ((base)->CTRL_ACCESS8BIT.CTRLHU)
+
+/*!
+ * @}
+ */ /* end of group CRC_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- CRC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CRC_Register_Masks CRC Register Masks
+ * @{
+ */
+
+/* DATAL Bit Fields */
+#define CRC_DATAL_DATAL_MASK                     0xFFFFu
+#define CRC_DATAL_DATAL_SHIFT                    0
+#define CRC_DATAL_DATAL(x)                       (((uint16_t)(((uint16_t)(x))<<CRC_DATAL_DATAL_SHIFT))&CRC_DATAL_DATAL_MASK)
+/* DATAH Bit Fields */
+#define CRC_DATAH_DATAH_MASK                     0xFFFFu
+#define CRC_DATAH_DATAH_SHIFT                    0
+#define CRC_DATAH_DATAH(x)                       (((uint16_t)(((uint16_t)(x))<<CRC_DATAH_DATAH_SHIFT))&CRC_DATAH_DATAH_MASK)
+/* DATA Bit Fields */
+#define CRC_DATA_LL_MASK                         0xFFu
+#define CRC_DATA_LL_SHIFT                        0
+#define CRC_DATA_LL(x)                           (((uint32_t)(((uint32_t)(x))<<CRC_DATA_LL_SHIFT))&CRC_DATA_LL_MASK)
+#define CRC_DATA_LU_MASK                         0xFF00u
+#define CRC_DATA_LU_SHIFT                        8
+#define CRC_DATA_LU(x)                           (((uint32_t)(((uint32_t)(x))<<CRC_DATA_LU_SHIFT))&CRC_DATA_LU_MASK)
+#define CRC_DATA_HL_MASK                         0xFF0000u
+#define CRC_DATA_HL_SHIFT                        16
+#define CRC_DATA_HL(x)                           (((uint32_t)(((uint32_t)(x))<<CRC_DATA_HL_SHIFT))&CRC_DATA_HL_MASK)
+#define CRC_DATA_HU_MASK                         0xFF000000u
+#define CRC_DATA_HU_SHIFT                        24
+#define CRC_DATA_HU(x)                           (((uint32_t)(((uint32_t)(x))<<CRC_DATA_HU_SHIFT))&CRC_DATA_HU_MASK)
+/* DATALL Bit Fields */
+#define CRC_DATALL_DATALL_MASK                   0xFFu
+#define CRC_DATALL_DATALL_SHIFT                  0
+#define CRC_DATALL_DATALL(x)                     (((uint8_t)(((uint8_t)(x))<<CRC_DATALL_DATALL_SHIFT))&CRC_DATALL_DATALL_MASK)
+/* DATALU Bit Fields */
+#define CRC_DATALU_DATALU_MASK                   0xFFu
+#define CRC_DATALU_DATALU_SHIFT                  0
+#define CRC_DATALU_DATALU(x)                     (((uint8_t)(((uint8_t)(x))<<CRC_DATALU_DATALU_SHIFT))&CRC_DATALU_DATALU_MASK)
+/* DATAHL Bit Fields */
+#define CRC_DATAHL_DATAHL_MASK                   0xFFu
+#define CRC_DATAHL_DATAHL_SHIFT                  0
+#define CRC_DATAHL_DATAHL(x)                     (((uint8_t)(((uint8_t)(x))<<CRC_DATAHL_DATAHL_SHIFT))&CRC_DATAHL_DATAHL_MASK)
+/* DATAHU Bit Fields */
+#define CRC_DATAHU_DATAHU_MASK                   0xFFu
+#define CRC_DATAHU_DATAHU_SHIFT                  0
+#define CRC_DATAHU_DATAHU(x)                     (((uint8_t)(((uint8_t)(x))<<CRC_DATAHU_DATAHU_SHIFT))&CRC_DATAHU_DATAHU_MASK)
+/* GPOLYL Bit Fields */
+#define CRC_GPOLYL_GPOLYL_MASK                   0xFFFFu
+#define CRC_GPOLYL_GPOLYL_SHIFT                  0
+#define CRC_GPOLYL_GPOLYL(x)                     (((uint16_t)(((uint16_t)(x))<<CRC_GPOLYL_GPOLYL_SHIFT))&CRC_GPOLYL_GPOLYL_MASK)
+/* GPOLYH Bit Fields */
+#define CRC_GPOLYH_GPOLYH_MASK                   0xFFFFu
+#define CRC_GPOLYH_GPOLYH_SHIFT                  0
+#define CRC_GPOLYH_GPOLYH(x)                     (((uint16_t)(((uint16_t)(x))<<CRC_GPOLYH_GPOLYH_SHIFT))&CRC_GPOLYH_GPOLYH_MASK)
+/* GPOLY Bit Fields */
+#define CRC_GPOLY_LOW_MASK                       0xFFFFu
+#define CRC_GPOLY_LOW_SHIFT                      0
+#define CRC_GPOLY_LOW(x)                         (((uint32_t)(((uint32_t)(x))<<CRC_GPOLY_LOW_SHIFT))&CRC_GPOLY_LOW_MASK)
+#define CRC_GPOLY_HIGH_MASK                      0xFFFF0000u
+#define CRC_GPOLY_HIGH_SHIFT                     16
+#define CRC_GPOLY_HIGH(x)                        (((uint32_t)(((uint32_t)(x))<<CRC_GPOLY_HIGH_SHIFT))&CRC_GPOLY_HIGH_MASK)
+/* GPOLYLL Bit Fields */
+#define CRC_GPOLYLL_GPOLYLL_MASK                 0xFFu
+#define CRC_GPOLYLL_GPOLYLL_SHIFT                0
+#define CRC_GPOLYLL_GPOLYLL(x)                   (((uint8_t)(((uint8_t)(x))<<CRC_GPOLYLL_GPOLYLL_SHIFT))&CRC_GPOLYLL_GPOLYLL_MASK)
+/* GPOLYLU Bit Fields */
+#define CRC_GPOLYLU_GPOLYLU_MASK                 0xFFu
+#define CRC_GPOLYLU_GPOLYLU_SHIFT                0
+#define CRC_GPOLYLU_GPOLYLU(x)                   (((uint8_t)(((uint8_t)(x))<<CRC_GPOLYLU_GPOLYLU_SHIFT))&CRC_GPOLYLU_GPOLYLU_MASK)
+/* GPOLYHL Bit Fields */
+#define CRC_GPOLYHL_GPOLYHL_MASK                 0xFFu
+#define CRC_GPOLYHL_GPOLYHL_SHIFT                0
+#define CRC_GPOLYHL_GPOLYHL(x)                   (((uint8_t)(((uint8_t)(x))<<CRC_GPOLYHL_GPOLYHL_SHIFT))&CRC_GPOLYHL_GPOLYHL_MASK)
+/* GPOLYHU Bit Fields */
+#define CRC_GPOLYHU_GPOLYHU_MASK                 0xFFu
+#define CRC_GPOLYHU_GPOLYHU_SHIFT                0
+#define CRC_GPOLYHU_GPOLYHU(x)                   (((uint8_t)(((uint8_t)(x))<<CRC_GPOLYHU_GPOLYHU_SHIFT))&CRC_GPOLYHU_GPOLYHU_MASK)
+/* CTRL Bit Fields */
+#define CRC_CTRL_TCRC_MASK                       0x1000000u
+#define CRC_CTRL_TCRC_SHIFT                      24
+#define CRC_CTRL_WAS_MASK                        0x2000000u
+#define CRC_CTRL_WAS_SHIFT                       25
+#define CRC_CTRL_FXOR_MASK                       0x4000000u
+#define CRC_CTRL_FXOR_SHIFT                      26
+#define CRC_CTRL_TOTR_MASK                       0x30000000u
+#define CRC_CTRL_TOTR_SHIFT                      28
+#define CRC_CTRL_TOTR(x)                         (((uint32_t)(((uint32_t)(x))<<CRC_CTRL_TOTR_SHIFT))&CRC_CTRL_TOTR_MASK)
+#define CRC_CTRL_TOT_MASK                        0xC0000000u
+#define CRC_CTRL_TOT_SHIFT                       30
+#define CRC_CTRL_TOT(x)                          (((uint32_t)(((uint32_t)(x))<<CRC_CTRL_TOT_SHIFT))&CRC_CTRL_TOT_MASK)
+/* CTRLHU Bit Fields */
+#define CRC_CTRLHU_TCRC_MASK                     0x1u
+#define CRC_CTRLHU_TCRC_SHIFT                    0
+#define CRC_CTRLHU_WAS_MASK                      0x2u
+#define CRC_CTRLHU_WAS_SHIFT                     1
+#define CRC_CTRLHU_FXOR_MASK                     0x4u
+#define CRC_CTRLHU_FXOR_SHIFT                    2
+#define CRC_CTRLHU_TOTR_MASK                     0x30u
+#define CRC_CTRLHU_TOTR_SHIFT                    4
+#define CRC_CTRLHU_TOTR(x)                       (((uint8_t)(((uint8_t)(x))<<CRC_CTRLHU_TOTR_SHIFT))&CRC_CTRLHU_TOTR_MASK)
+#define CRC_CTRLHU_TOT_MASK                      0xC0u
+#define CRC_CTRLHU_TOT_SHIFT                     6
+#define CRC_CTRLHU_TOT(x)                        (((uint8_t)(((uint8_t)(x))<<CRC_CTRLHU_TOT_SHIFT))&CRC_CTRLHU_TOT_MASK)
+
+/*!
+ * @}
+ */ /* end of group CRC_Register_Masks */
+
+
+/* CRC - Peripheral instance base addresses */
+/** Peripheral CRC base address */
+#define CRC_BASE                                 (0x40032000u)
+/** Peripheral CRC base pointer */
+#define CRC0                                     ((CRC_Type *)CRC_BASE)
+#define CRC_BASE_PTR                             (CRC0)
+/** Array initializer of CRC peripheral base addresses */
+#define CRC_BASE_ADDRS                           { CRC_BASE }
+/** Array initializer of CRC peripheral base pointers */
+#define CRC_BASE_PTRS                            { CRC0 }
+
+/* ----------------------------------------------------------------------------
+   -- CRC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup CRC_Register_Accessor_Macros CRC - Register accessor macros
+ * @{
+ */
+
+
+/* CRC - Register instance definitions */
+/* CRC */
+#define CRC_DATA                                 CRC_DATA_REG(CRC0)
+#define CRC_DATAL                                CRC_DATAL_REG(CRC0)
+#define CRC_DATALL                               CRC_DATALL_REG(CRC0)
+#define CRC_DATALU                               CRC_DATALU_REG(CRC0)
+#define CRC_DATAH                                CRC_DATAH_REG(CRC0)
+#define CRC_DATAHL                               CRC_DATAHL_REG(CRC0)
+#define CRC_DATAHU                               CRC_DATAHU_REG(CRC0)
+#define CRC_GPOLY                                CRC_GPOLY_REG(CRC0)
+#define CRC_GPOLYL                               CRC_GPOLYL_REG(CRC0)
+#define CRC_GPOLYLL                              CRC_GPOLYLL_REG(CRC0)
+#define CRC_GPOLYLU                              CRC_GPOLYLU_REG(CRC0)
+#define CRC_GPOLYH                               CRC_GPOLYH_REG(CRC0)
+#define CRC_GPOLYHL                              CRC_GPOLYHL_REG(CRC0)
+#define CRC_GPOLYHU                              CRC_GPOLYHU_REG(CRC0)
+#define CRC_CTRL                                 CRC_CTRL_REG(CRC0)
+#define CRC_CTRLHU                               CRC_CTRLHU_REG(CRC0)
+
+/*!
+ * @}
+ */ /* end of group CRC_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group CRC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- DAC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DAC_Peripheral_Access_Layer DAC Peripheral Access Layer
+ * @{
+ */
+
+/** DAC - Register Layout Typedef */
+typedef struct {
+  struct {                                         /* offset: 0x0, array step: 0x2 */
+    __IO uint8_t DATL;                               /**< DAC Data Low Register, array offset: 0x0, array step: 0x2 */
+    __IO uint8_t DATH;                               /**< DAC Data High Register, array offset: 0x1, array step: 0x2 */
+  } DAT[16];
+  __IO uint8_t SR;                                 /**< DAC Status Register, offset: 0x20 */
+  __IO uint8_t C0;                                 /**< DAC Control Register, offset: 0x21 */
+  __IO uint8_t C1;                                 /**< DAC Control Register 1, offset: 0x22 */
+  __IO uint8_t C2;                                 /**< DAC Control Register 2, offset: 0x23 */
+} DAC_Type, *DAC_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- DAC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DAC_Register_Accessor_Macros DAC - Register accessor macros
+ * @{
+ */
+
+
+/* DAC - Register accessors */
+#define DAC_DATL_REG(base,index)                 ((base)->DAT[index].DATL)
+#define DAC_DATH_REG(base,index)                 ((base)->DAT[index].DATH)
+#define DAC_SR_REG(base)                         ((base)->SR)
+#define DAC_C0_REG(base)                         ((base)->C0)
+#define DAC_C1_REG(base)                         ((base)->C1)
+#define DAC_C2_REG(base)                         ((base)->C2)
+
+/*!
+ * @}
+ */ /* end of group DAC_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- DAC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DAC_Register_Masks DAC Register Masks
+ * @{
+ */
+
+/* DATL Bit Fields */
+#define DAC_DATL_DATA0_MASK                      0xFFu
+#define DAC_DATL_DATA0_SHIFT                     0
+#define DAC_DATL_DATA0(x)                        (((uint8_t)(((uint8_t)(x))<<DAC_DATL_DATA0_SHIFT))&DAC_DATL_DATA0_MASK)
+/* DATH Bit Fields */
+#define DAC_DATH_DATA1_MASK                      0xFu
+#define DAC_DATH_DATA1_SHIFT                     0
+#define DAC_DATH_DATA1(x)                        (((uint8_t)(((uint8_t)(x))<<DAC_DATH_DATA1_SHIFT))&DAC_DATH_DATA1_MASK)
+/* SR Bit Fields */
+#define DAC_SR_DACBFRPBF_MASK                    0x1u
+#define DAC_SR_DACBFRPBF_SHIFT                   0
+#define DAC_SR_DACBFRPTF_MASK                    0x2u
+#define DAC_SR_DACBFRPTF_SHIFT                   1
+#define DAC_SR_DACBFWMF_MASK                     0x4u
+#define DAC_SR_DACBFWMF_SHIFT                    2
+/* C0 Bit Fields */
+#define DAC_C0_DACBBIEN_MASK                     0x1u
+#define DAC_C0_DACBBIEN_SHIFT                    0
+#define DAC_C0_DACBTIEN_MASK                     0x2u
+#define DAC_C0_DACBTIEN_SHIFT                    1
+#define DAC_C0_DACBWIEN_MASK                     0x4u
+#define DAC_C0_DACBWIEN_SHIFT                    2
+#define DAC_C0_LPEN_MASK                         0x8u
+#define DAC_C0_LPEN_SHIFT                        3
+#define DAC_C0_DACSWTRG_MASK                     0x10u
+#define DAC_C0_DACSWTRG_SHIFT                    4
+#define DAC_C0_DACTRGSEL_MASK                    0x20u
+#define DAC_C0_DACTRGSEL_SHIFT                   5
+#define DAC_C0_DACRFS_MASK                       0x40u
+#define DAC_C0_DACRFS_SHIFT                      6
+#define DAC_C0_DACEN_MASK                        0x80u
+#define DAC_C0_DACEN_SHIFT                       7
+/* C1 Bit Fields */
+#define DAC_C1_DACBFEN_MASK                      0x1u
+#define DAC_C1_DACBFEN_SHIFT                     0
+#define DAC_C1_DACBFMD_MASK                      0x6u
+#define DAC_C1_DACBFMD_SHIFT                     1
+#define DAC_C1_DACBFMD(x)                        (((uint8_t)(((uint8_t)(x))<<DAC_C1_DACBFMD_SHIFT))&DAC_C1_DACBFMD_MASK)
+#define DAC_C1_DACBFWM_MASK                      0x18u
+#define DAC_C1_DACBFWM_SHIFT                     3
+#define DAC_C1_DACBFWM(x)                        (((uint8_t)(((uint8_t)(x))<<DAC_C1_DACBFWM_SHIFT))&DAC_C1_DACBFWM_MASK)
+#define DAC_C1_DMAEN_MASK                        0x80u
+#define DAC_C1_DMAEN_SHIFT                       7
+/* C2 Bit Fields */
+#define DAC_C2_DACBFUP_MASK                      0xFu
+#define DAC_C2_DACBFUP_SHIFT                     0
+#define DAC_C2_DACBFUP(x)                        (((uint8_t)(((uint8_t)(x))<<DAC_C2_DACBFUP_SHIFT))&DAC_C2_DACBFUP_MASK)
+#define DAC_C2_DACBFRP_MASK                      0xF0u
+#define DAC_C2_DACBFRP_SHIFT                     4
+#define DAC_C2_DACBFRP(x)                        (((uint8_t)(((uint8_t)(x))<<DAC_C2_DACBFRP_SHIFT))&DAC_C2_DACBFRP_MASK)
+
+/*!
+ * @}
+ */ /* end of group DAC_Register_Masks */
+
+
+/* DAC - Peripheral instance base addresses */
+/** Peripheral DAC0 base address */
+#define DAC0_BASE                                (0x400CC000u)
+/** Peripheral DAC0 base pointer */
+#define DAC0                                     ((DAC_Type *)DAC0_BASE)
+#define DAC0_BASE_PTR                            (DAC0)
+/** Peripheral DAC1 base address */
+#define DAC1_BASE                                (0x400CD000u)
+/** Peripheral DAC1 base pointer */
+#define DAC1                                     ((DAC_Type *)DAC1_BASE)
+#define DAC1_BASE_PTR                            (DAC1)
+/** Array initializer of DAC peripheral base addresses */
+#define DAC_BASE_ADDRS                           { DAC0_BASE, DAC1_BASE }
+/** Array initializer of DAC peripheral base pointers */
+#define DAC_BASE_PTRS                            { DAC0, DAC1 }
+/** Interrupt vectors for the DAC peripheral type */
+#define DAC_IRQS                                 { DAC0_IRQn, DAC1_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- DAC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DAC_Register_Accessor_Macros DAC - Register accessor macros
+ * @{
+ */
+
+
+/* DAC - Register instance definitions */
+/* DAC0 */
+#define DAC0_DAT0L                               DAC_DATL_REG(DAC0,0)
+#define DAC0_DAT0H                               DAC_DATH_REG(DAC0,0)
+#define DAC0_DAT1L                               DAC_DATL_REG(DAC0,1)
+#define DAC0_DAT1H                               DAC_DATH_REG(DAC0,1)
+#define DAC0_DAT2L                               DAC_DATL_REG(DAC0,2)
+#define DAC0_DAT2H                               DAC_DATH_REG(DAC0,2)
+#define DAC0_DAT3L                               DAC_DATL_REG(DAC0,3)
+#define DAC0_DAT3H                               DAC_DATH_REG(DAC0,3)
+#define DAC0_DAT4L                               DAC_DATL_REG(DAC0,4)
+#define DAC0_DAT4H                               DAC_DATH_REG(DAC0,4)
+#define DAC0_DAT5L                               DAC_DATL_REG(DAC0,5)
+#define DAC0_DAT5H                               DAC_DATH_REG(DAC0,5)
+#define DAC0_DAT6L                               DAC_DATL_REG(DAC0,6)
+#define DAC0_DAT6H                               DAC_DATH_REG(DAC0,6)
+#define DAC0_DAT7L                               DAC_DATL_REG(DAC0,7)
+#define DAC0_DAT7H                               DAC_DATH_REG(DAC0,7)
+#define DAC0_DAT8L                               DAC_DATL_REG(DAC0,8)
+#define DAC0_DAT8H                               DAC_DATH_REG(DAC0,8)
+#define DAC0_DAT9L                               DAC_DATL_REG(DAC0,9)
+#define DAC0_DAT9H                               DAC_DATH_REG(DAC0,9)
+#define DAC0_DAT10L                              DAC_DATL_REG(DAC0,10)
+#define DAC0_DAT10H                              DAC_DATH_REG(DAC0,10)
+#define DAC0_DAT11L                              DAC_DATL_REG(DAC0,11)
+#define DAC0_DAT11H                              DAC_DATH_REG(DAC0,11)
+#define DAC0_DAT12L                              DAC_DATL_REG(DAC0,12)
+#define DAC0_DAT12H                              DAC_DATH_REG(DAC0,12)
+#define DAC0_DAT13L                              DAC_DATL_REG(DAC0,13)
+#define DAC0_DAT13H                              DAC_DATH_REG(DAC0,13)
+#define DAC0_DAT14L                              DAC_DATL_REG(DAC0,14)
+#define DAC0_DAT14H                              DAC_DATH_REG(DAC0,14)
+#define DAC0_DAT15L                              DAC_DATL_REG(DAC0,15)
+#define DAC0_DAT15H                              DAC_DATH_REG(DAC0,15)
+#define DAC0_SR                                  DAC_SR_REG(DAC0)
+#define DAC0_C0                                  DAC_C0_REG(DAC0)
+#define DAC0_C1                                  DAC_C1_REG(DAC0)
+#define DAC0_C2                                  DAC_C2_REG(DAC0)
+/* DAC1 */
+#define DAC1_DAT0L                               DAC_DATL_REG(DAC1,0)
+#define DAC1_DAT0H                               DAC_DATH_REG(DAC1,0)
+#define DAC1_DAT1L                               DAC_DATL_REG(DAC1,1)
+#define DAC1_DAT1H                               DAC_DATH_REG(DAC1,1)
+#define DAC1_DAT2L                               DAC_DATL_REG(DAC1,2)
+#define DAC1_DAT2H                               DAC_DATH_REG(DAC1,2)
+#define DAC1_DAT3L                               DAC_DATL_REG(DAC1,3)
+#define DAC1_DAT3H                               DAC_DATH_REG(DAC1,3)
+#define DAC1_DAT4L                               DAC_DATL_REG(DAC1,4)
+#define DAC1_DAT4H                               DAC_DATH_REG(DAC1,4)
+#define DAC1_DAT5L                               DAC_DATL_REG(DAC1,5)
+#define DAC1_DAT5H                               DAC_DATH_REG(DAC1,5)
+#define DAC1_DAT6L                               DAC_DATL_REG(DAC1,6)
+#define DAC1_DAT6H                               DAC_DATH_REG(DAC1,6)
+#define DAC1_DAT7L                               DAC_DATL_REG(DAC1,7)
+#define DAC1_DAT7H                               DAC_DATH_REG(DAC1,7)
+#define DAC1_DAT8L                               DAC_DATL_REG(DAC1,8)
+#define DAC1_DAT8H                               DAC_DATH_REG(DAC1,8)
+#define DAC1_DAT9L                               DAC_DATL_REG(DAC1,9)
+#define DAC1_DAT9H                               DAC_DATH_REG(DAC1,9)
+#define DAC1_DAT10L                              DAC_DATL_REG(DAC1,10)
+#define DAC1_DAT10H                              DAC_DATH_REG(DAC1,10)
+#define DAC1_DAT11L                              DAC_DATL_REG(DAC1,11)
+#define DAC1_DAT11H                              DAC_DATH_REG(DAC1,11)
+#define DAC1_DAT12L                              DAC_DATL_REG(DAC1,12)
+#define DAC1_DAT12H                              DAC_DATH_REG(DAC1,12)
+#define DAC1_DAT13L                              DAC_DATL_REG(DAC1,13)
+#define DAC1_DAT13H                              DAC_DATH_REG(DAC1,13)
+#define DAC1_DAT14L                              DAC_DATL_REG(DAC1,14)
+#define DAC1_DAT14H                              DAC_DATH_REG(DAC1,14)
+#define DAC1_DAT15L                              DAC_DATL_REG(DAC1,15)
+#define DAC1_DAT15H                              DAC_DATH_REG(DAC1,15)
+#define DAC1_SR                                  DAC_SR_REG(DAC1)
+#define DAC1_C0                                  DAC_C0_REG(DAC1)
+#define DAC1_C1                                  DAC_C1_REG(DAC1)
+#define DAC1_C2                                  DAC_C2_REG(DAC1)
+
+/* DAC - Register array accessors */
+#define DAC0_DATL(index)                         DAC_DATL_REG(DAC0,index)
+#define DAC1_DATL(index)                         DAC_DATL_REG(DAC1,index)
+#define DAC0_DATH(index)                         DAC_DATH_REG(DAC0,index)
+#define DAC1_DATH(index)                         DAC_DATH_REG(DAC1,index)
+
+/*!
+ * @}
+ */ /* end of group DAC_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group DAC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- DMA Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMA_Peripheral_Access_Layer DMA Peripheral Access Layer
+ * @{
+ */
+
+/** DMA - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t CR;                                /**< Control Register, offset: 0x0 */
+  __I  uint32_t ES;                                /**< Error Status Register, offset: 0x4 */
+       uint8_t RESERVED_0[4];
+  __IO uint32_t ERQ;                               /**< Enable Request Register, offset: 0xC */
+       uint8_t RESERVED_1[4];
+  __IO uint32_t EEI;                               /**< Enable Error Interrupt Register, offset: 0x14 */
+  __O  uint8_t CEEI;                               /**< Clear Enable Error Interrupt Register, offset: 0x18 */
+  __O  uint8_t SEEI;                               /**< Set Enable Error Interrupt Register, offset: 0x19 */
+  __O  uint8_t CERQ;                               /**< Clear Enable Request Register, offset: 0x1A */
+  __O  uint8_t SERQ;                               /**< Set Enable Request Register, offset: 0x1B */
+  __O  uint8_t CDNE;                               /**< Clear DONE Status Bit Register, offset: 0x1C */
+  __O  uint8_t SSRT;                               /**< Set START Bit Register, offset: 0x1D */
+  __O  uint8_t CERR;                               /**< Clear Error Register, offset: 0x1E */
+  __O  uint8_t CINT;                               /**< Clear Interrupt Request Register, offset: 0x1F */
+       uint8_t RESERVED_2[4];
+  __IO uint32_t INT;                               /**< Interrupt Request Register, offset: 0x24 */
+       uint8_t RESERVED_3[4];
+  __IO uint32_t ERR;                               /**< Error Register, offset: 0x2C */
+       uint8_t RESERVED_4[4];
+  __I  uint32_t HRS;                               /**< Hardware Request Status Register, offset: 0x34 */
+       uint8_t RESERVED_5[200];
+  __IO uint8_t DCHPRI3;                            /**< Channel n Priority Register, offset: 0x100 */
+  __IO uint8_t DCHPRI2;                            /**< Channel n Priority Register, offset: 0x101 */
+  __IO uint8_t DCHPRI1;                            /**< Channel n Priority Register, offset: 0x102 */
+  __IO uint8_t DCHPRI0;                            /**< Channel n Priority Register, offset: 0x103 */
+  __IO uint8_t DCHPRI7;                            /**< Channel n Priority Register, offset: 0x104 */
+  __IO uint8_t DCHPRI6;                            /**< Channel n Priority Register, offset: 0x105 */
+  __IO uint8_t DCHPRI5;                            /**< Channel n Priority Register, offset: 0x106 */
+  __IO uint8_t DCHPRI4;                            /**< Channel n Priority Register, offset: 0x107 */
+  __IO uint8_t DCHPRI11;                           /**< Channel n Priority Register, offset: 0x108 */
+  __IO uint8_t DCHPRI10;                           /**< Channel n Priority Register, offset: 0x109 */
+  __IO uint8_t DCHPRI9;                            /**< Channel n Priority Register, offset: 0x10A */
+  __IO uint8_t DCHPRI8;                            /**< Channel n Priority Register, offset: 0x10B */
+  __IO uint8_t DCHPRI15;                           /**< Channel n Priority Register, offset: 0x10C */
+  __IO uint8_t DCHPRI14;                           /**< Channel n Priority Register, offset: 0x10D */
+  __IO uint8_t DCHPRI13;                           /**< Channel n Priority Register, offset: 0x10E */
+  __IO uint8_t DCHPRI12;                           /**< Channel n Priority Register, offset: 0x10F */
+       uint8_t RESERVED_6[3824];
+  struct {                                         /* offset: 0x1000, array step: 0x20 */
+    __IO uint32_t SADDR;                             /**< TCD Source Address, array offset: 0x1000, array step: 0x20 */
+    __IO uint16_t SOFF;                              /**< TCD Signed Source Address Offset, array offset: 0x1004, array step: 0x20 */
+    __IO uint16_t ATTR;                              /**< TCD Transfer Attributes, array offset: 0x1006, array step: 0x20 */
+    union {                                          /* offset: 0x1008, array step: 0x20 */
+      __IO uint32_t NBYTES_MLNO;                       /**< TCD Minor Byte Count (Minor Loop Disabled), array offset: 0x1008, array step: 0x20 */
+      __IO uint32_t NBYTES_MLOFFNO;                    /**< TCD Signed Minor Loop Offset (Minor Loop Enabled and Offset Disabled), array offset: 0x1008, array step: 0x20 */
+      __IO uint32_t NBYTES_MLOFFYES;                   /**< TCD Signed Minor Loop Offset (Minor Loop and Offset Enabled), array offset: 0x1008, array step: 0x20 */
+    };
+    __IO uint32_t SLAST;                             /**< TCD Last Source Address Adjustment, array offset: 0x100C, array step: 0x20 */
+    __IO uint32_t DADDR;                             /**< TCD Destination Address, array offset: 0x1010, array step: 0x20 */
+    __IO uint16_t DOFF;                              /**< TCD Signed Destination Address Offset, array offset: 0x1014, array step: 0x20 */
+    union {                                          /* offset: 0x1016, array step: 0x20 */
+      __IO uint16_t CITER_ELINKNO;                     /**< TCD Current Minor Loop Link, Major Loop Count (Channel Linking Disabled), array offset: 0x1016, array step: 0x20 */
+      __IO uint16_t CITER_ELINKYES;                    /**< TCD Current Minor Loop Link, Major Loop Count (Channel Linking Enabled), array offset: 0x1016, array step: 0x20 */
+    };
+    __IO uint32_t DLAST_SGA;                         /**< TCD Last Destination Address Adjustment/Scatter Gather Address, array offset: 0x1018, array step: 0x20 */
+    __IO uint16_t CSR;                               /**< TCD Control and Status, array offset: 0x101C, array step: 0x20 */
+    union {                                          /* offset: 0x101E, array step: 0x20 */
+      __IO uint16_t BITER_ELINKNO;                     /**< TCD Beginning Minor Loop Link, Major Loop Count (Channel Linking Disabled), array offset: 0x101E, array step: 0x20 */
+      __IO uint16_t BITER_ELINKYES;                    /**< TCD Beginning Minor Loop Link, Major Loop Count (Channel Linking Enabled), array offset: 0x101E, array step: 0x20 */
+    };
+  } TCD[16];
+} DMA_Type, *DMA_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- DMA - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMA_Register_Accessor_Macros DMA - Register accessor macros
+ * @{
+ */
+
+
+/* DMA - Register accessors */
+#define DMA_CR_REG(base)                         ((base)->CR)
+#define DMA_ES_REG(base)                         ((base)->ES)
+#define DMA_ERQ_REG(base)                        ((base)->ERQ)
+#define DMA_EEI_REG(base)                        ((base)->EEI)
+#define DMA_CEEI_REG(base)                       ((base)->CEEI)
+#define DMA_SEEI_REG(base)                       ((base)->SEEI)
+#define DMA_CERQ_REG(base)                       ((base)->CERQ)
+#define DMA_SERQ_REG(base)                       ((base)->SERQ)
+#define DMA_CDNE_REG(base)                       ((base)->CDNE)
+#define DMA_SSRT_REG(base)                       ((base)->SSRT)
+#define DMA_CERR_REG(base)                       ((base)->CERR)
+#define DMA_CINT_REG(base)                       ((base)->CINT)
+#define DMA_INT_REG(base)                        ((base)->INT)
+#define DMA_ERR_REG(base)                        ((base)->ERR)
+#define DMA_HRS_REG(base)                        ((base)->HRS)
+#define DMA_DCHPRI3_REG(base)                    ((base)->DCHPRI3)
+#define DMA_DCHPRI2_REG(base)                    ((base)->DCHPRI2)
+#define DMA_DCHPRI1_REG(base)                    ((base)->DCHPRI1)
+#define DMA_DCHPRI0_REG(base)                    ((base)->DCHPRI0)
+#define DMA_DCHPRI7_REG(base)                    ((base)->DCHPRI7)
+#define DMA_DCHPRI6_REG(base)                    ((base)->DCHPRI6)
+#define DMA_DCHPRI5_REG(base)                    ((base)->DCHPRI5)
+#define DMA_DCHPRI4_REG(base)                    ((base)->DCHPRI4)
+#define DMA_DCHPRI11_REG(base)                   ((base)->DCHPRI11)
+#define DMA_DCHPRI10_REG(base)                   ((base)->DCHPRI10)
+#define DMA_DCHPRI9_REG(base)                    ((base)->DCHPRI9)
+#define DMA_DCHPRI8_REG(base)                    ((base)->DCHPRI8)
+#define DMA_DCHPRI15_REG(base)                   ((base)->DCHPRI15)
+#define DMA_DCHPRI14_REG(base)                   ((base)->DCHPRI14)
+#define DMA_DCHPRI13_REG(base)                   ((base)->DCHPRI13)
+#define DMA_DCHPRI12_REG(base)                   ((base)->DCHPRI12)
+#define DMA_SADDR_REG(base,index)                ((base)->TCD[index].SADDR)
+#define DMA_SOFF_REG(base,index)                 ((base)->TCD[index].SOFF)
+#define DMA_ATTR_REG(base,index)                 ((base)->TCD[index].ATTR)
+#define DMA_NBYTES_MLNO_REG(base,index)          ((base)->TCD[index].NBYTES_MLNO)
+#define DMA_NBYTES_MLOFFNO_REG(base,index)       ((base)->TCD[index].NBYTES_MLOFFNO)
+#define DMA_NBYTES_MLOFFYES_REG(base,index)      ((base)->TCD[index].NBYTES_MLOFFYES)
+#define DMA_SLAST_REG(base,index)                ((base)->TCD[index].SLAST)
+#define DMA_DADDR_REG(base,index)                ((base)->TCD[index].DADDR)
+#define DMA_DOFF_REG(base,index)                 ((base)->TCD[index].DOFF)
+#define DMA_CITER_ELINKNO_REG(base,index)        ((base)->TCD[index].CITER_ELINKNO)
+#define DMA_CITER_ELINKYES_REG(base,index)       ((base)->TCD[index].CITER_ELINKYES)
+#define DMA_DLAST_SGA_REG(base,index)            ((base)->TCD[index].DLAST_SGA)
+#define DMA_CSR_REG(base,index)                  ((base)->TCD[index].CSR)
+#define DMA_BITER_ELINKNO_REG(base,index)        ((base)->TCD[index].BITER_ELINKNO)
+#define DMA_BITER_ELINKYES_REG(base,index)       ((base)->TCD[index].BITER_ELINKYES)
+
+/*!
+ * @}
+ */ /* end of group DMA_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- DMA Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMA_Register_Masks DMA Register Masks
+ * @{
+ */
+
+/* CR Bit Fields */
+#define DMA_CR_EDBG_MASK                         0x2u
+#define DMA_CR_EDBG_SHIFT                        1
+#define DMA_CR_ERCA_MASK                         0x4u
+#define DMA_CR_ERCA_SHIFT                        2
+#define DMA_CR_HOE_MASK                          0x10u
+#define DMA_CR_HOE_SHIFT                         4
+#define DMA_CR_HALT_MASK                         0x20u
+#define DMA_CR_HALT_SHIFT                        5
+#define DMA_CR_CLM_MASK                          0x40u
+#define DMA_CR_CLM_SHIFT                         6
+#define DMA_CR_EMLM_MASK                         0x80u
+#define DMA_CR_EMLM_SHIFT                        7
+#define DMA_CR_ECX_MASK                          0x10000u
+#define DMA_CR_ECX_SHIFT                         16
+#define DMA_CR_CX_MASK                           0x20000u
+#define DMA_CR_CX_SHIFT                          17
+/* ES Bit Fields */
+#define DMA_ES_DBE_MASK                          0x1u
+#define DMA_ES_DBE_SHIFT                         0
+#define DMA_ES_SBE_MASK                          0x2u
+#define DMA_ES_SBE_SHIFT                         1
+#define DMA_ES_SGE_MASK                          0x4u
+#define DMA_ES_SGE_SHIFT                         2
+#define DMA_ES_NCE_MASK                          0x8u
+#define DMA_ES_NCE_SHIFT                         3
+#define DMA_ES_DOE_MASK                          0x10u
+#define DMA_ES_DOE_SHIFT                         4
+#define DMA_ES_DAE_MASK                          0x20u
+#define DMA_ES_DAE_SHIFT                         5
+#define DMA_ES_SOE_MASK                          0x40u
+#define DMA_ES_SOE_SHIFT                         6
+#define DMA_ES_SAE_MASK                          0x80u
+#define DMA_ES_SAE_SHIFT                         7
+#define DMA_ES_ERRCHN_MASK                       0xF00u
+#define DMA_ES_ERRCHN_SHIFT                      8
+#define DMA_ES_ERRCHN(x)                         (((uint32_t)(((uint32_t)(x))<<DMA_ES_ERRCHN_SHIFT))&DMA_ES_ERRCHN_MASK)
+#define DMA_ES_CPE_MASK                          0x4000u
+#define DMA_ES_CPE_SHIFT                         14
+#define DMA_ES_ECX_MASK                          0x10000u
+#define DMA_ES_ECX_SHIFT                         16
+#define DMA_ES_VLD_MASK                          0x80000000u
+#define DMA_ES_VLD_SHIFT                         31
+/* ERQ Bit Fields */
+#define DMA_ERQ_ERQ0_MASK                        0x1u
+#define DMA_ERQ_ERQ0_SHIFT                       0
+#define DMA_ERQ_ERQ1_MASK                        0x2u
+#define DMA_ERQ_ERQ1_SHIFT                       1
+#define DMA_ERQ_ERQ2_MASK                        0x4u
+#define DMA_ERQ_ERQ2_SHIFT                       2
+#define DMA_ERQ_ERQ3_MASK                        0x8u
+#define DMA_ERQ_ERQ3_SHIFT                       3
+#define DMA_ERQ_ERQ4_MASK                        0x10u
+#define DMA_ERQ_ERQ4_SHIFT                       4
+#define DMA_ERQ_ERQ5_MASK                        0x20u
+#define DMA_ERQ_ERQ5_SHIFT                       5
+#define DMA_ERQ_ERQ6_MASK                        0x40u
+#define DMA_ERQ_ERQ6_SHIFT                       6
+#define DMA_ERQ_ERQ7_MASK                        0x80u
+#define DMA_ERQ_ERQ7_SHIFT                       7
+#define DMA_ERQ_ERQ8_MASK                        0x100u
+#define DMA_ERQ_ERQ8_SHIFT                       8
+#define DMA_ERQ_ERQ9_MASK                        0x200u
+#define DMA_ERQ_ERQ9_SHIFT                       9
+#define DMA_ERQ_ERQ10_MASK                       0x400u
+#define DMA_ERQ_ERQ10_SHIFT                      10
+#define DMA_ERQ_ERQ11_MASK                       0x800u
+#define DMA_ERQ_ERQ11_SHIFT                      11
+#define DMA_ERQ_ERQ12_MASK                       0x1000u
+#define DMA_ERQ_ERQ12_SHIFT                      12
+#define DMA_ERQ_ERQ13_MASK                       0x2000u
+#define DMA_ERQ_ERQ13_SHIFT                      13
+#define DMA_ERQ_ERQ14_MASK                       0x4000u
+#define DMA_ERQ_ERQ14_SHIFT                      14
+#define DMA_ERQ_ERQ15_MASK                       0x8000u
+#define DMA_ERQ_ERQ15_SHIFT                      15
+/* EEI Bit Fields */
+#define DMA_EEI_EEI0_MASK                        0x1u
+#define DMA_EEI_EEI0_SHIFT                       0
+#define DMA_EEI_EEI1_MASK                        0x2u
+#define DMA_EEI_EEI1_SHIFT                       1
+#define DMA_EEI_EEI2_MASK                        0x4u
+#define DMA_EEI_EEI2_SHIFT                       2
+#define DMA_EEI_EEI3_MASK                        0x8u
+#define DMA_EEI_EEI3_SHIFT                       3
+#define DMA_EEI_EEI4_MASK                        0x10u
+#define DMA_EEI_EEI4_SHIFT                       4
+#define DMA_EEI_EEI5_MASK                        0x20u
+#define DMA_EEI_EEI5_SHIFT                       5
+#define DMA_EEI_EEI6_MASK                        0x40u
+#define DMA_EEI_EEI6_SHIFT                       6
+#define DMA_EEI_EEI7_MASK                        0x80u
+#define DMA_EEI_EEI7_SHIFT                       7
+#define DMA_EEI_EEI8_MASK                        0x100u
+#define DMA_EEI_EEI8_SHIFT                       8
+#define DMA_EEI_EEI9_MASK                        0x200u
+#define DMA_EEI_EEI9_SHIFT                       9
+#define DMA_EEI_EEI10_MASK                       0x400u
+#define DMA_EEI_EEI10_SHIFT                      10
+#define DMA_EEI_EEI11_MASK                       0x800u
+#define DMA_EEI_EEI11_SHIFT                      11
+#define DMA_EEI_EEI12_MASK                       0x1000u
+#define DMA_EEI_EEI12_SHIFT                      12
+#define DMA_EEI_EEI13_MASK                       0x2000u
+#define DMA_EEI_EEI13_SHIFT                      13
+#define DMA_EEI_EEI14_MASK                       0x4000u
+#define DMA_EEI_EEI14_SHIFT                      14
+#define DMA_EEI_EEI15_MASK                       0x8000u
+#define DMA_EEI_EEI15_SHIFT                      15
+/* CEEI Bit Fields */
+#define DMA_CEEI_CEEI_MASK                       0xFu
+#define DMA_CEEI_CEEI_SHIFT                      0
+#define DMA_CEEI_CEEI(x)                         (((uint8_t)(((uint8_t)(x))<<DMA_CEEI_CEEI_SHIFT))&DMA_CEEI_CEEI_MASK)
+#define DMA_CEEI_CAEE_MASK                       0x40u
+#define DMA_CEEI_CAEE_SHIFT                      6
+#define DMA_CEEI_NOP_MASK                        0x80u
+#define DMA_CEEI_NOP_SHIFT                       7
+/* SEEI Bit Fields */
+#define DMA_SEEI_SEEI_MASK                       0xFu
+#define DMA_SEEI_SEEI_SHIFT                      0
+#define DMA_SEEI_SEEI(x)                         (((uint8_t)(((uint8_t)(x))<<DMA_SEEI_SEEI_SHIFT))&DMA_SEEI_SEEI_MASK)
+#define DMA_SEEI_SAEE_MASK                       0x40u
+#define DMA_SEEI_SAEE_SHIFT                      6
+#define DMA_SEEI_NOP_MASK                        0x80u
+#define DMA_SEEI_NOP_SHIFT                       7
+/* CERQ Bit Fields */
+#define DMA_CERQ_CERQ_MASK                       0xFu
+#define DMA_CERQ_CERQ_SHIFT                      0
+#define DMA_CERQ_CERQ(x)                         (((uint8_t)(((uint8_t)(x))<<DMA_CERQ_CERQ_SHIFT))&DMA_CERQ_CERQ_MASK)
+#define DMA_CERQ_CAER_MASK                       0x40u
+#define DMA_CERQ_CAER_SHIFT                      6
+#define DMA_CERQ_NOP_MASK                        0x80u
+#define DMA_CERQ_NOP_SHIFT                       7
+/* SERQ Bit Fields */
+#define DMA_SERQ_SERQ_MASK                       0xFu
+#define DMA_SERQ_SERQ_SHIFT                      0
+#define DMA_SERQ_SERQ(x)                         (((uint8_t)(((uint8_t)(x))<<DMA_SERQ_SERQ_SHIFT))&DMA_SERQ_SERQ_MASK)
+#define DMA_SERQ_SAER_MASK                       0x40u
+#define DMA_SERQ_SAER_SHIFT                      6
+#define DMA_SERQ_NOP_MASK                        0x80u
+#define DMA_SERQ_NOP_SHIFT                       7
+/* CDNE Bit Fields */
+#define DMA_CDNE_CDNE_MASK                       0xFu
+#define DMA_CDNE_CDNE_SHIFT                      0
+#define DMA_CDNE_CDNE(x)                         (((uint8_t)(((uint8_t)(x))<<DMA_CDNE_CDNE_SHIFT))&DMA_CDNE_CDNE_MASK)
+#define DMA_CDNE_CADN_MASK                       0x40u
+#define DMA_CDNE_CADN_SHIFT                      6
+#define DMA_CDNE_NOP_MASK                        0x80u
+#define DMA_CDNE_NOP_SHIFT                       7
+/* SSRT Bit Fields */
+#define DMA_SSRT_SSRT_MASK                       0xFu
+#define DMA_SSRT_SSRT_SHIFT                      0
+#define DMA_SSRT_SSRT(x)                         (((uint8_t)(((uint8_t)(x))<<DMA_SSRT_SSRT_SHIFT))&DMA_SSRT_SSRT_MASK)
+#define DMA_SSRT_SAST_MASK                       0x40u
+#define DMA_SSRT_SAST_SHIFT                      6
+#define DMA_SSRT_NOP_MASK                        0x80u
+#define DMA_SSRT_NOP_SHIFT                       7
+/* CERR Bit Fields */
+#define DMA_CERR_CERR_MASK                       0xFu
+#define DMA_CERR_CERR_SHIFT                      0
+#define DMA_CERR_CERR(x)                         (((uint8_t)(((uint8_t)(x))<<DMA_CERR_CERR_SHIFT))&DMA_CERR_CERR_MASK)
+#define DMA_CERR_CAEI_MASK                       0x40u
+#define DMA_CERR_CAEI_SHIFT                      6
+#define DMA_CERR_NOP_MASK                        0x80u
+#define DMA_CERR_NOP_SHIFT                       7
+/* CINT Bit Fields */
+#define DMA_CINT_CINT_MASK                       0xFu
+#define DMA_CINT_CINT_SHIFT                      0
+#define DMA_CINT_CINT(x)                         (((uint8_t)(((uint8_t)(x))<<DMA_CINT_CINT_SHIFT))&DMA_CINT_CINT_MASK)
+#define DMA_CINT_CAIR_MASK                       0x40u
+#define DMA_CINT_CAIR_SHIFT                      6
+#define DMA_CINT_NOP_MASK                        0x80u
+#define DMA_CINT_NOP_SHIFT                       7
+/* INT Bit Fields */
+#define DMA_INT_INT0_MASK                        0x1u
+#define DMA_INT_INT0_SHIFT                       0
+#define DMA_INT_INT1_MASK                        0x2u
+#define DMA_INT_INT1_SHIFT                       1
+#define DMA_INT_INT2_MASK                        0x4u
+#define DMA_INT_INT2_SHIFT                       2
+#define DMA_INT_INT3_MASK                        0x8u
+#define DMA_INT_INT3_SHIFT                       3
+#define DMA_INT_INT4_MASK                        0x10u
+#define DMA_INT_INT4_SHIFT                       4
+#define DMA_INT_INT5_MASK                        0x20u
+#define DMA_INT_INT5_SHIFT                       5
+#define DMA_INT_INT6_MASK                        0x40u
+#define DMA_INT_INT6_SHIFT                       6
+#define DMA_INT_INT7_MASK                        0x80u
+#define DMA_INT_INT7_SHIFT                       7
+#define DMA_INT_INT8_MASK                        0x100u
+#define DMA_INT_INT8_SHIFT                       8
+#define DMA_INT_INT9_MASK                        0x200u
+#define DMA_INT_INT9_SHIFT                       9
+#define DMA_INT_INT10_MASK                       0x400u
+#define DMA_INT_INT10_SHIFT                      10
+#define DMA_INT_INT11_MASK                       0x800u
+#define DMA_INT_INT11_SHIFT                      11
+#define DMA_INT_INT12_MASK                       0x1000u
+#define DMA_INT_INT12_SHIFT                      12
+#define DMA_INT_INT13_MASK                       0x2000u
+#define DMA_INT_INT13_SHIFT                      13
+#define DMA_INT_INT14_MASK                       0x4000u
+#define DMA_INT_INT14_SHIFT                      14
+#define DMA_INT_INT15_MASK                       0x8000u
+#define DMA_INT_INT15_SHIFT                      15
+/* ERR Bit Fields */
+#define DMA_ERR_ERR0_MASK                        0x1u
+#define DMA_ERR_ERR0_SHIFT                       0
+#define DMA_ERR_ERR1_MASK                        0x2u
+#define DMA_ERR_ERR1_SHIFT                       1
+#define DMA_ERR_ERR2_MASK                        0x4u
+#define DMA_ERR_ERR2_SHIFT                       2
+#define DMA_ERR_ERR3_MASK                        0x8u
+#define DMA_ERR_ERR3_SHIFT                       3
+#define DMA_ERR_ERR4_MASK                        0x10u
+#define DMA_ERR_ERR4_SHIFT                       4
+#define DMA_ERR_ERR5_MASK                        0x20u
+#define DMA_ERR_ERR5_SHIFT                       5
+#define DMA_ERR_ERR6_MASK                        0x40u
+#define DMA_ERR_ERR6_SHIFT                       6
+#define DMA_ERR_ERR7_MASK                        0x80u
+#define DMA_ERR_ERR7_SHIFT                       7
+#define DMA_ERR_ERR8_MASK                        0x100u
+#define DMA_ERR_ERR8_SHIFT                       8
+#define DMA_ERR_ERR9_MASK                        0x200u
+#define DMA_ERR_ERR9_SHIFT                       9
+#define DMA_ERR_ERR10_MASK                       0x400u
+#define DMA_ERR_ERR10_SHIFT                      10
+#define DMA_ERR_ERR11_MASK                       0x800u
+#define DMA_ERR_ERR11_SHIFT                      11
+#define DMA_ERR_ERR12_MASK                       0x1000u
+#define DMA_ERR_ERR12_SHIFT                      12
+#define DMA_ERR_ERR13_MASK                       0x2000u
+#define DMA_ERR_ERR13_SHIFT                      13
+#define DMA_ERR_ERR14_MASK                       0x4000u
+#define DMA_ERR_ERR14_SHIFT                      14
+#define DMA_ERR_ERR15_MASK                       0x8000u
+#define DMA_ERR_ERR15_SHIFT                      15
+/* HRS Bit Fields */
+#define DMA_HRS_HRS0_MASK                        0x1u
+#define DMA_HRS_HRS0_SHIFT                       0
+#define DMA_HRS_HRS1_MASK                        0x2u
+#define DMA_HRS_HRS1_SHIFT                       1
+#define DMA_HRS_HRS2_MASK                        0x4u
+#define DMA_HRS_HRS2_SHIFT                       2
+#define DMA_HRS_HRS3_MASK                        0x8u
+#define DMA_HRS_HRS3_SHIFT                       3
+#define DMA_HRS_HRS4_MASK                        0x10u
+#define DMA_HRS_HRS4_SHIFT                       4
+#define DMA_HRS_HRS5_MASK                        0x20u
+#define DMA_HRS_HRS5_SHIFT                       5
+#define DMA_HRS_HRS6_MASK                        0x40u
+#define DMA_HRS_HRS6_SHIFT                       6
+#define DMA_HRS_HRS7_MASK                        0x80u
+#define DMA_HRS_HRS7_SHIFT                       7
+#define DMA_HRS_HRS8_MASK                        0x100u
+#define DMA_HRS_HRS8_SHIFT                       8
+#define DMA_HRS_HRS9_MASK                        0x200u
+#define DMA_HRS_HRS9_SHIFT                       9
+#define DMA_HRS_HRS10_MASK                       0x400u
+#define DMA_HRS_HRS10_SHIFT                      10
+#define DMA_HRS_HRS11_MASK                       0x800u
+#define DMA_HRS_HRS11_SHIFT                      11
+#define DMA_HRS_HRS12_MASK                       0x1000u
+#define DMA_HRS_HRS12_SHIFT                      12
+#define DMA_HRS_HRS13_MASK                       0x2000u
+#define DMA_HRS_HRS13_SHIFT                      13
+#define DMA_HRS_HRS14_MASK                       0x4000u
+#define DMA_HRS_HRS14_SHIFT                      14
+#define DMA_HRS_HRS15_MASK                       0x8000u
+#define DMA_HRS_HRS15_SHIFT                      15
+/* DCHPRI3 Bit Fields */
+#define DMA_DCHPRI3_CHPRI_MASK                   0xFu
+#define DMA_DCHPRI3_CHPRI_SHIFT                  0
+#define DMA_DCHPRI3_CHPRI(x)                     (((uint8_t)(((uint8_t)(x))<<DMA_DCHPRI3_CHPRI_SHIFT))&DMA_DCHPRI3_CHPRI_MASK)
+#define DMA_DCHPRI3_DPA_MASK                     0x40u
+#define DMA_DCHPRI3_DPA_SHIFT                    6
+#define DMA_DCHPRI3_ECP_MASK                     0x80u
+#define DMA_DCHPRI3_ECP_SHIFT                    7
+/* DCHPRI2 Bit Fields */
+#define DMA_DCHPRI2_CHPRI_MASK                   0xFu
+#define DMA_DCHPRI2_CHPRI_SHIFT                  0
+#define DMA_DCHPRI2_CHPRI(x)                     (((uint8_t)(((uint8_t)(x))<<DMA_DCHPRI2_CHPRI_SHIFT))&DMA_DCHPRI2_CHPRI_MASK)
+#define DMA_DCHPRI2_DPA_MASK                     0x40u
+#define DMA_DCHPRI2_DPA_SHIFT                    6
+#define DMA_DCHPRI2_ECP_MASK                     0x80u
+#define DMA_DCHPRI2_ECP_SHIFT                    7
+/* DCHPRI1 Bit Fields */
+#define DMA_DCHPRI1_CHPRI_MASK                   0xFu
+#define DMA_DCHPRI1_CHPRI_SHIFT                  0
+#define DMA_DCHPRI1_CHPRI(x)                     (((uint8_t)(((uint8_t)(x))<<DMA_DCHPRI1_CHPRI_SHIFT))&DMA_DCHPRI1_CHPRI_MASK)
+#define DMA_DCHPRI1_DPA_MASK                     0x40u
+#define DMA_DCHPRI1_DPA_SHIFT                    6
+#define DMA_DCHPRI1_ECP_MASK                     0x80u
+#define DMA_DCHPRI1_ECP_SHIFT                    7
+/* DCHPRI0 Bit Fields */
+#define DMA_DCHPRI0_CHPRI_MASK                   0xFu
+#define DMA_DCHPRI0_CHPRI_SHIFT                  0
+#define DMA_DCHPRI0_CHPRI(x)                     (((uint8_t)(((uint8_t)(x))<<DMA_DCHPRI0_CHPRI_SHIFT))&DMA_DCHPRI0_CHPRI_MASK)
+#define DMA_DCHPRI0_DPA_MASK                     0x40u
+#define DMA_DCHPRI0_DPA_SHIFT                    6
+#define DMA_DCHPRI0_ECP_MASK                     0x80u
+#define DMA_DCHPRI0_ECP_SHIFT                    7
+/* DCHPRI7 Bit Fields */
+#define DMA_DCHPRI7_CHPRI_MASK                   0xFu
+#define DMA_DCHPRI7_CHPRI_SHIFT                  0
+#define DMA_DCHPRI7_CHPRI(x)                     (((uint8_t)(((uint8_t)(x))<<DMA_DCHPRI7_CHPRI_SHIFT))&DMA_DCHPRI7_CHPRI_MASK)
+#define DMA_DCHPRI7_DPA_MASK                     0x40u
+#define DMA_DCHPRI7_DPA_SHIFT                    6
+#define DMA_DCHPRI7_ECP_MASK                     0x80u
+#define DMA_DCHPRI7_ECP_SHIFT                    7
+/* DCHPRI6 Bit Fields */
+#define DMA_DCHPRI6_CHPRI_MASK                   0xFu
+#define DMA_DCHPRI6_CHPRI_SHIFT                  0
+#define DMA_DCHPRI6_CHPRI(x)                     (((uint8_t)(((uint8_t)(x))<<DMA_DCHPRI6_CHPRI_SHIFT))&DMA_DCHPRI6_CHPRI_MASK)
+#define DMA_DCHPRI6_DPA_MASK                     0x40u
+#define DMA_DCHPRI6_DPA_SHIFT                    6
+#define DMA_DCHPRI6_ECP_MASK                     0x80u
+#define DMA_DCHPRI6_ECP_SHIFT                    7
+/* DCHPRI5 Bit Fields */
+#define DMA_DCHPRI5_CHPRI_MASK                   0xFu
+#define DMA_DCHPRI5_CHPRI_SHIFT                  0
+#define DMA_DCHPRI5_CHPRI(x)                     (((uint8_t)(((uint8_t)(x))<<DMA_DCHPRI5_CHPRI_SHIFT))&DMA_DCHPRI5_CHPRI_MASK)
+#define DMA_DCHPRI5_DPA_MASK                     0x40u
+#define DMA_DCHPRI5_DPA_SHIFT                    6
+#define DMA_DCHPRI5_ECP_MASK                     0x80u
+#define DMA_DCHPRI5_ECP_SHIFT                    7
+/* DCHPRI4 Bit Fields */
+#define DMA_DCHPRI4_CHPRI_MASK                   0xFu
+#define DMA_DCHPRI4_CHPRI_SHIFT                  0
+#define DMA_DCHPRI4_CHPRI(x)                     (((uint8_t)(((uint8_t)(x))<<DMA_DCHPRI4_CHPRI_SHIFT))&DMA_DCHPRI4_CHPRI_MASK)
+#define DMA_DCHPRI4_DPA_MASK                     0x40u
+#define DMA_DCHPRI4_DPA_SHIFT                    6
+#define DMA_DCHPRI4_ECP_MASK                     0x80u
+#define DMA_DCHPRI4_ECP_SHIFT                    7
+/* DCHPRI11 Bit Fields */
+#define DMA_DCHPRI11_CHPRI_MASK                  0xFu
+#define DMA_DCHPRI11_CHPRI_SHIFT                 0
+#define DMA_DCHPRI11_CHPRI(x)                    (((uint8_t)(((uint8_t)(x))<<DMA_DCHPRI11_CHPRI_SHIFT))&DMA_DCHPRI11_CHPRI_MASK)
+#define DMA_DCHPRI11_DPA_MASK                    0x40u
+#define DMA_DCHPRI11_DPA_SHIFT                   6
+#define DMA_DCHPRI11_ECP_MASK                    0x80u
+#define DMA_DCHPRI11_ECP_SHIFT                   7
+/* DCHPRI10 Bit Fields */
+#define DMA_DCHPRI10_CHPRI_MASK                  0xFu
+#define DMA_DCHPRI10_CHPRI_SHIFT                 0
+#define DMA_DCHPRI10_CHPRI(x)                    (((uint8_t)(((uint8_t)(x))<<DMA_DCHPRI10_CHPRI_SHIFT))&DMA_DCHPRI10_CHPRI_MASK)
+#define DMA_DCHPRI10_DPA_MASK                    0x40u
+#define DMA_DCHPRI10_DPA_SHIFT                   6
+#define DMA_DCHPRI10_ECP_MASK                    0x80u
+#define DMA_DCHPRI10_ECP_SHIFT                   7
+/* DCHPRI9 Bit Fields */
+#define DMA_DCHPRI9_CHPRI_MASK                   0xFu
+#define DMA_DCHPRI9_CHPRI_SHIFT                  0
+#define DMA_DCHPRI9_CHPRI(x)                     (((uint8_t)(((uint8_t)(x))<<DMA_DCHPRI9_CHPRI_SHIFT))&DMA_DCHPRI9_CHPRI_MASK)
+#define DMA_DCHPRI9_DPA_MASK                     0x40u
+#define DMA_DCHPRI9_DPA_SHIFT                    6
+#define DMA_DCHPRI9_ECP_MASK                     0x80u
+#define DMA_DCHPRI9_ECP_SHIFT                    7
+/* DCHPRI8 Bit Fields */
+#define DMA_DCHPRI8_CHPRI_MASK                   0xFu
+#define DMA_DCHPRI8_CHPRI_SHIFT                  0
+#define DMA_DCHPRI8_CHPRI(x)                     (((uint8_t)(((uint8_t)(x))<<DMA_DCHPRI8_CHPRI_SHIFT))&DMA_DCHPRI8_CHPRI_MASK)
+#define DMA_DCHPRI8_DPA_MASK                     0x40u
+#define DMA_DCHPRI8_DPA_SHIFT                    6
+#define DMA_DCHPRI8_ECP_MASK                     0x80u
+#define DMA_DCHPRI8_ECP_SHIFT                    7
+/* DCHPRI15 Bit Fields */
+#define DMA_DCHPRI15_CHPRI_MASK                  0xFu
+#define DMA_DCHPRI15_CHPRI_SHIFT                 0
+#define DMA_DCHPRI15_CHPRI(x)                    (((uint8_t)(((uint8_t)(x))<<DMA_DCHPRI15_CHPRI_SHIFT))&DMA_DCHPRI15_CHPRI_MASK)
+#define DMA_DCHPRI15_DPA_MASK                    0x40u
+#define DMA_DCHPRI15_DPA_SHIFT                   6
+#define DMA_DCHPRI15_ECP_MASK                    0x80u
+#define DMA_DCHPRI15_ECP_SHIFT                   7
+/* DCHPRI14 Bit Fields */
+#define DMA_DCHPRI14_CHPRI_MASK                  0xFu
+#define DMA_DCHPRI14_CHPRI_SHIFT                 0
+#define DMA_DCHPRI14_CHPRI(x)                    (((uint8_t)(((uint8_t)(x))<<DMA_DCHPRI14_CHPRI_SHIFT))&DMA_DCHPRI14_CHPRI_MASK)
+#define DMA_DCHPRI14_DPA_MASK                    0x40u
+#define DMA_DCHPRI14_DPA_SHIFT                   6
+#define DMA_DCHPRI14_ECP_MASK                    0x80u
+#define DMA_DCHPRI14_ECP_SHIFT                   7
+/* DCHPRI13 Bit Fields */
+#define DMA_DCHPRI13_CHPRI_MASK                  0xFu
+#define DMA_DCHPRI13_CHPRI_SHIFT                 0
+#define DMA_DCHPRI13_CHPRI(x)                    (((uint8_t)(((uint8_t)(x))<<DMA_DCHPRI13_CHPRI_SHIFT))&DMA_DCHPRI13_CHPRI_MASK)
+#define DMA_DCHPRI13_DPA_MASK                    0x40u
+#define DMA_DCHPRI13_DPA_SHIFT                   6
+#define DMA_DCHPRI13_ECP_MASK                    0x80u
+#define DMA_DCHPRI13_ECP_SHIFT                   7
+/* DCHPRI12 Bit Fields */
+#define DMA_DCHPRI12_CHPRI_MASK                  0xFu
+#define DMA_DCHPRI12_CHPRI_SHIFT                 0
+#define DMA_DCHPRI12_CHPRI(x)                    (((uint8_t)(((uint8_t)(x))<<DMA_DCHPRI12_CHPRI_SHIFT))&DMA_DCHPRI12_CHPRI_MASK)
+#define DMA_DCHPRI12_DPA_MASK                    0x40u
+#define DMA_DCHPRI12_DPA_SHIFT                   6
+#define DMA_DCHPRI12_ECP_MASK                    0x80u
+#define DMA_DCHPRI12_ECP_SHIFT                   7
+/* SADDR Bit Fields */
+#define DMA_SADDR_SADDR_MASK                     0xFFFFFFFFu
+#define DMA_SADDR_SADDR_SHIFT                    0
+#define DMA_SADDR_SADDR(x)                       (((uint32_t)(((uint32_t)(x))<<DMA_SADDR_SADDR_SHIFT))&DMA_SADDR_SADDR_MASK)
+/* SOFF Bit Fields */
+#define DMA_SOFF_SOFF_MASK                       0xFFFFu
+#define DMA_SOFF_SOFF_SHIFT                      0
+#define DMA_SOFF_SOFF(x)                         (((uint16_t)(((uint16_t)(x))<<DMA_SOFF_SOFF_SHIFT))&DMA_SOFF_SOFF_MASK)
+/* ATTR Bit Fields */
+#define DMA_ATTR_DSIZE_MASK                      0x7u
+#define DMA_ATTR_DSIZE_SHIFT                     0
+#define DMA_ATTR_DSIZE(x)                        (((uint16_t)(((uint16_t)(x))<<DMA_ATTR_DSIZE_SHIFT))&DMA_ATTR_DSIZE_MASK)
+#define DMA_ATTR_DMOD_MASK                       0xF8u
+#define DMA_ATTR_DMOD_SHIFT                      3
+#define DMA_ATTR_DMOD(x)                         (((uint16_t)(((uint16_t)(x))<<DMA_ATTR_DMOD_SHIFT))&DMA_ATTR_DMOD_MASK)
+#define DMA_ATTR_SSIZE_MASK                      0x700u
+#define DMA_ATTR_SSIZE_SHIFT                     8
+#define DMA_ATTR_SSIZE(x)                        (((uint16_t)(((uint16_t)(x))<<DMA_ATTR_SSIZE_SHIFT))&DMA_ATTR_SSIZE_MASK)
+#define DMA_ATTR_SMOD_MASK                       0xF800u
+#define DMA_ATTR_SMOD_SHIFT                      11
+#define DMA_ATTR_SMOD(x)                         (((uint16_t)(((uint16_t)(x))<<DMA_ATTR_SMOD_SHIFT))&DMA_ATTR_SMOD_MASK)
+/* NBYTES_MLNO Bit Fields */
+#define DMA_NBYTES_MLNO_NBYTES_MASK              0xFFFFFFFFu
+#define DMA_NBYTES_MLNO_NBYTES_SHIFT             0
+#define DMA_NBYTES_MLNO_NBYTES(x)                (((uint32_t)(((uint32_t)(x))<<DMA_NBYTES_MLNO_NBYTES_SHIFT))&DMA_NBYTES_MLNO_NBYTES_MASK)
+/* NBYTES_MLOFFNO Bit Fields */
+#define DMA_NBYTES_MLOFFNO_NBYTES_MASK           0x3FFFFFFFu
+#define DMA_NBYTES_MLOFFNO_NBYTES_SHIFT          0
+#define DMA_NBYTES_MLOFFNO_NBYTES(x)             (((uint32_t)(((uint32_t)(x))<<DMA_NBYTES_MLOFFNO_NBYTES_SHIFT))&DMA_NBYTES_MLOFFNO_NBYTES_MASK)
+#define DMA_NBYTES_MLOFFNO_DMLOE_MASK            0x40000000u
+#define DMA_NBYTES_MLOFFNO_DMLOE_SHIFT           30
+#define DMA_NBYTES_MLOFFNO_SMLOE_MASK            0x80000000u
+#define DMA_NBYTES_MLOFFNO_SMLOE_SHIFT           31
+/* NBYTES_MLOFFYES Bit Fields */
+#define DMA_NBYTES_MLOFFYES_NBYTES_MASK          0x3FFu
+#define DMA_NBYTES_MLOFFYES_NBYTES_SHIFT         0
+#define DMA_NBYTES_MLOFFYES_NBYTES(x)            (((uint32_t)(((uint32_t)(x))<<DMA_NBYTES_MLOFFYES_NBYTES_SHIFT))&DMA_NBYTES_MLOFFYES_NBYTES_MASK)
+#define DMA_NBYTES_MLOFFYES_MLOFF_MASK           0x3FFFFC00u
+#define DMA_NBYTES_MLOFFYES_MLOFF_SHIFT          10
+#define DMA_NBYTES_MLOFFYES_MLOFF(x)             (((uint32_t)(((uint32_t)(x))<<DMA_NBYTES_MLOFFYES_MLOFF_SHIFT))&DMA_NBYTES_MLOFFYES_MLOFF_MASK)
+#define DMA_NBYTES_MLOFFYES_DMLOE_MASK           0x40000000u
+#define DMA_NBYTES_MLOFFYES_DMLOE_SHIFT          30
+#define DMA_NBYTES_MLOFFYES_SMLOE_MASK           0x80000000u
+#define DMA_NBYTES_MLOFFYES_SMLOE_SHIFT          31
+/* SLAST Bit Fields */
+#define DMA_SLAST_SLAST_MASK                     0xFFFFFFFFu
+#define DMA_SLAST_SLAST_SHIFT                    0
+#define DMA_SLAST_SLAST(x)                       (((uint32_t)(((uint32_t)(x))<<DMA_SLAST_SLAST_SHIFT))&DMA_SLAST_SLAST_MASK)
+/* DADDR Bit Fields */
+#define DMA_DADDR_DADDR_MASK                     0xFFFFFFFFu
+#define DMA_DADDR_DADDR_SHIFT                    0
+#define DMA_DADDR_DADDR(x)                       (((uint32_t)(((uint32_t)(x))<<DMA_DADDR_DADDR_SHIFT))&DMA_DADDR_DADDR_MASK)
+/* DOFF Bit Fields */
+#define DMA_DOFF_DOFF_MASK                       0xFFFFu
+#define DMA_DOFF_DOFF_SHIFT                      0
+#define DMA_DOFF_DOFF(x)                         (((uint16_t)(((uint16_t)(x))<<DMA_DOFF_DOFF_SHIFT))&DMA_DOFF_DOFF_MASK)
+/* CITER_ELINKNO Bit Fields */
+#define DMA_CITER_ELINKNO_CITER_MASK             0x7FFFu
+#define DMA_CITER_ELINKNO_CITER_SHIFT            0
+#define DMA_CITER_ELINKNO_CITER(x)               (((uint16_t)(((uint16_t)(x))<<DMA_CITER_ELINKNO_CITER_SHIFT))&DMA_CITER_ELINKNO_CITER_MASK)
+#define DMA_CITER_ELINKNO_ELINK_MASK             0x8000u
+#define DMA_CITER_ELINKNO_ELINK_SHIFT            15
+/* CITER_ELINKYES Bit Fields */
+#define DMA_CITER_ELINKYES_CITER_MASK            0x1FFu
+#define DMA_CITER_ELINKYES_CITER_SHIFT           0
+#define DMA_CITER_ELINKYES_CITER(x)              (((uint16_t)(((uint16_t)(x))<<DMA_CITER_ELINKYES_CITER_SHIFT))&DMA_CITER_ELINKYES_CITER_MASK)
+#define DMA_CITER_ELINKYES_LINKCH_MASK           0x1E00u
+#define DMA_CITER_ELINKYES_LINKCH_SHIFT          9
+#define DMA_CITER_ELINKYES_LINKCH(x)             (((uint16_t)(((uint16_t)(x))<<DMA_CITER_ELINKYES_LINKCH_SHIFT))&DMA_CITER_ELINKYES_LINKCH_MASK)
+#define DMA_CITER_ELINKYES_ELINK_MASK            0x8000u
+#define DMA_CITER_ELINKYES_ELINK_SHIFT           15
+/* DLAST_SGA Bit Fields */
+#define DMA_DLAST_SGA_DLASTSGA_MASK              0xFFFFFFFFu
+#define DMA_DLAST_SGA_DLASTSGA_SHIFT             0
+#define DMA_DLAST_SGA_DLASTSGA(x)                (((uint32_t)(((uint32_t)(x))<<DMA_DLAST_SGA_DLASTSGA_SHIFT))&DMA_DLAST_SGA_DLASTSGA_MASK)
+/* CSR Bit Fields */
+#define DMA_CSR_START_MASK                       0x1u
+#define DMA_CSR_START_SHIFT                      0
+#define DMA_CSR_INTMAJOR_MASK                    0x2u
+#define DMA_CSR_INTMAJOR_SHIFT                   1
+#define DMA_CSR_INTHALF_MASK                     0x4u
+#define DMA_CSR_INTHALF_SHIFT                    2
+#define DMA_CSR_DREQ_MASK                        0x8u
+#define DMA_CSR_DREQ_SHIFT                       3
+#define DMA_CSR_ESG_MASK                         0x10u
+#define DMA_CSR_ESG_SHIFT                        4
+#define DMA_CSR_MAJORELINK_MASK                  0x20u
+#define DMA_CSR_MAJORELINK_SHIFT                 5
+#define DMA_CSR_ACTIVE_MASK                      0x40u
+#define DMA_CSR_ACTIVE_SHIFT                     6
+#define DMA_CSR_DONE_MASK                        0x80u
+#define DMA_CSR_DONE_SHIFT                       7
+#define DMA_CSR_MAJORLINKCH_MASK                 0xF00u
+#define DMA_CSR_MAJORLINKCH_SHIFT                8
+#define DMA_CSR_MAJORLINKCH(x)                   (((uint16_t)(((uint16_t)(x))<<DMA_CSR_MAJORLINKCH_SHIFT))&DMA_CSR_MAJORLINKCH_MASK)
+#define DMA_CSR_BWC_MASK                         0xC000u
+#define DMA_CSR_BWC_SHIFT                        14
+#define DMA_CSR_BWC(x)                           (((uint16_t)(((uint16_t)(x))<<DMA_CSR_BWC_SHIFT))&DMA_CSR_BWC_MASK)
+/* BITER_ELINKNO Bit Fields */
+#define DMA_BITER_ELINKNO_BITER_MASK             0x7FFFu
+#define DMA_BITER_ELINKNO_BITER_SHIFT            0
+#define DMA_BITER_ELINKNO_BITER(x)               (((uint16_t)(((uint16_t)(x))<<DMA_BITER_ELINKNO_BITER_SHIFT))&DMA_BITER_ELINKNO_BITER_MASK)
+#define DMA_BITER_ELINKNO_ELINK_MASK             0x8000u
+#define DMA_BITER_ELINKNO_ELINK_SHIFT            15
+/* BITER_ELINKYES Bit Fields */
+#define DMA_BITER_ELINKYES_BITER_MASK            0x1FFu
+#define DMA_BITER_ELINKYES_BITER_SHIFT           0
+#define DMA_BITER_ELINKYES_BITER(x)              (((uint16_t)(((uint16_t)(x))<<DMA_BITER_ELINKYES_BITER_SHIFT))&DMA_BITER_ELINKYES_BITER_MASK)
+#define DMA_BITER_ELINKYES_LINKCH_MASK           0x1E00u
+#define DMA_BITER_ELINKYES_LINKCH_SHIFT          9
+#define DMA_BITER_ELINKYES_LINKCH(x)             (((uint16_t)(((uint16_t)(x))<<DMA_BITER_ELINKYES_LINKCH_SHIFT))&DMA_BITER_ELINKYES_LINKCH_MASK)
+#define DMA_BITER_ELINKYES_ELINK_MASK            0x8000u
+#define DMA_BITER_ELINKYES_ELINK_SHIFT           15
+
+/*!
+ * @}
+ */ /* end of group DMA_Register_Masks */
+
+
+/* DMA - Peripheral instance base addresses */
+/** Peripheral DMA base address */
+#define DMA_BASE                                 (0x40008000u)
+/** Peripheral DMA base pointer */
+#define DMA0                                     ((DMA_Type *)DMA_BASE)
+#define DMA_BASE_PTR                             (DMA0)
+/** Array initializer of DMA peripheral base addresses */
+#define DMA_BASE_ADDRS                           { DMA_BASE }
+/** Array initializer of DMA peripheral base pointers */
+#define DMA_BASE_PTRS                            { DMA0 }
+/** Interrupt vectors for the DMA peripheral type */
+#define DMA_CHN_IRQS                             { DMA0_IRQn, DMA1_IRQn, DMA2_IRQn, DMA3_IRQn, DMA4_IRQn, DMA5_IRQn, DMA6_IRQn, DMA7_IRQn, DMA8_IRQn, DMA9_IRQn, DMA10_IRQn, DMA11_IRQn, DMA12_IRQn, DMA13_IRQn, DMA14_IRQn, DMA15_IRQn }
+#define DMA_ERROR_IRQS                           { DMA_Error_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- DMA - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMA_Register_Accessor_Macros DMA - Register accessor macros
+ * @{
+ */
+
+
+/* DMA - Register instance definitions */
+/* DMA */
+#define DMA_CR                                   DMA_CR_REG(DMA0)
+#define DMA_ES                                   DMA_ES_REG(DMA0)
+#define DMA_ERQ                                  DMA_ERQ_REG(DMA0)
+#define DMA_EEI                                  DMA_EEI_REG(DMA0)
+#define DMA_CEEI                                 DMA_CEEI_REG(DMA0)
+#define DMA_SEEI                                 DMA_SEEI_REG(DMA0)
+#define DMA_CERQ                                 DMA_CERQ_REG(DMA0)
+#define DMA_SERQ                                 DMA_SERQ_REG(DMA0)
+#define DMA_CDNE                                 DMA_CDNE_REG(DMA0)
+#define DMA_SSRT                                 DMA_SSRT_REG(DMA0)
+#define DMA_CERR                                 DMA_CERR_REG(DMA0)
+#define DMA_CINT                                 DMA_CINT_REG(DMA0)
+#define DMA_INT                                  DMA_INT_REG(DMA0)
+#define DMA_ERR                                  DMA_ERR_REG(DMA0)
+#define DMA_HRS                                  DMA_HRS_REG(DMA0)
+#define DMA_DCHPRI3                              DMA_DCHPRI3_REG(DMA0)
+#define DMA_DCHPRI2                              DMA_DCHPRI2_REG(DMA0)
+#define DMA_DCHPRI1                              DMA_DCHPRI1_REG(DMA0)
+#define DMA_DCHPRI0                              DMA_DCHPRI0_REG(DMA0)
+#define DMA_DCHPRI7                              DMA_DCHPRI7_REG(DMA0)
+#define DMA_DCHPRI6                              DMA_DCHPRI6_REG(DMA0)
+#define DMA_DCHPRI5                              DMA_DCHPRI5_REG(DMA0)
+#define DMA_DCHPRI4                              DMA_DCHPRI4_REG(DMA0)
+#define DMA_DCHPRI11                             DMA_DCHPRI11_REG(DMA0)
+#define DMA_DCHPRI10                             DMA_DCHPRI10_REG(DMA0)
+#define DMA_DCHPRI9                              DMA_DCHPRI9_REG(DMA0)
+#define DMA_DCHPRI8                              DMA_DCHPRI8_REG(DMA0)
+#define DMA_DCHPRI15                             DMA_DCHPRI15_REG(DMA0)
+#define DMA_DCHPRI14                             DMA_DCHPRI14_REG(DMA0)
+#define DMA_DCHPRI13                             DMA_DCHPRI13_REG(DMA0)
+#define DMA_DCHPRI12                             DMA_DCHPRI12_REG(DMA0)
+#define DMA_TCD0_SADDR                           DMA_SADDR_REG(DMA0,0)
+#define DMA_TCD0_SOFF                            DMA_SOFF_REG(DMA0,0)
+#define DMA_TCD0_ATTR                            DMA_ATTR_REG(DMA0,0)
+#define DMA_TCD0_NBYTES_MLNO                     DMA_NBYTES_MLNO_REG(DMA0,0)
+#define DMA_TCD0_NBYTES_MLOFFNO                  DMA_NBYTES_MLOFFNO_REG(DMA0,0)
+#define DMA_TCD0_NBYTES_MLOFFYES                 DMA_NBYTES_MLOFFYES_REG(DMA0,0)
+#define DMA_TCD0_SLAST                           DMA_SLAST_REG(DMA0,0)
+#define DMA_TCD0_DADDR                           DMA_DADDR_REG(DMA0,0)
+#define DMA_TCD0_DOFF                            DMA_DOFF_REG(DMA0,0)
+#define DMA_TCD0_CITER_ELINKNO                   DMA_CITER_ELINKNO_REG(DMA0,0)
+#define DMA_TCD0_CITER_ELINKYES                  DMA_CITER_ELINKYES_REG(DMA0,0)
+#define DMA_TCD0_DLASTSGA                        DMA_DLAST_SGA_REG(DMA0,0)
+#define DMA_TCD0_CSR                             DMA_CSR_REG(DMA0,0)
+#define DMA_TCD0_BITER_ELINKNO                   DMA_BITER_ELINKNO_REG(DMA0,0)
+#define DMA_TCD0_BITER_ELINKYES                  DMA_BITER_ELINKYES_REG(DMA0,0)
+#define DMA_TCD1_SADDR                           DMA_SADDR_REG(DMA0,1)
+#define DMA_TCD1_SOFF                            DMA_SOFF_REG(DMA0,1)
+#define DMA_TCD1_ATTR                            DMA_ATTR_REG(DMA0,1)
+#define DMA_TCD1_NBYTES_MLNO                     DMA_NBYTES_MLNO_REG(DMA0,1)
+#define DMA_TCD1_NBYTES_MLOFFNO                  DMA_NBYTES_MLOFFNO_REG(DMA0,1)
+#define DMA_TCD1_NBYTES_MLOFFYES                 DMA_NBYTES_MLOFFYES_REG(DMA0,1)
+#define DMA_TCD1_SLAST                           DMA_SLAST_REG(DMA0,1)
+#define DMA_TCD1_DADDR                           DMA_DADDR_REG(DMA0,1)
+#define DMA_TCD1_DOFF                            DMA_DOFF_REG(DMA0,1)
+#define DMA_TCD1_CITER_ELINKNO                   DMA_CITER_ELINKNO_REG(DMA0,1)
+#define DMA_TCD1_CITER_ELINKYES                  DMA_CITER_ELINKYES_REG(DMA0,1)
+#define DMA_TCD1_DLASTSGA                        DMA_DLAST_SGA_REG(DMA0,1)
+#define DMA_TCD1_CSR                             DMA_CSR_REG(DMA0,1)
+#define DMA_TCD1_BITER_ELINKNO                   DMA_BITER_ELINKNO_REG(DMA0,1)
+#define DMA_TCD1_BITER_ELINKYES                  DMA_BITER_ELINKYES_REG(DMA0,1)
+#define DMA_TCD2_SADDR                           DMA_SADDR_REG(DMA0,2)
+#define DMA_TCD2_SOFF                            DMA_SOFF_REG(DMA0,2)
+#define DMA_TCD2_ATTR                            DMA_ATTR_REG(DMA0,2)
+#define DMA_TCD2_NBYTES_MLNO                     DMA_NBYTES_MLNO_REG(DMA0,2)
+#define DMA_TCD2_NBYTES_MLOFFNO                  DMA_NBYTES_MLOFFNO_REG(DMA0,2)
+#define DMA_TCD2_NBYTES_MLOFFYES                 DMA_NBYTES_MLOFFYES_REG(DMA0,2)
+#define DMA_TCD2_SLAST                           DMA_SLAST_REG(DMA0,2)
+#define DMA_TCD2_DADDR                           DMA_DADDR_REG(DMA0,2)
+#define DMA_TCD2_DOFF                            DMA_DOFF_REG(DMA0,2)
+#define DMA_TCD2_CITER_ELINKNO                   DMA_CITER_ELINKNO_REG(DMA0,2)
+#define DMA_TCD2_CITER_ELINKYES                  DMA_CITER_ELINKYES_REG(DMA0,2)
+#define DMA_TCD2_DLASTSGA                        DMA_DLAST_SGA_REG(DMA0,2)
+#define DMA_TCD2_CSR                             DMA_CSR_REG(DMA0,2)
+#define DMA_TCD2_BITER_ELINKNO                   DMA_BITER_ELINKNO_REG(DMA0,2)
+#define DMA_TCD2_BITER_ELINKYES                  DMA_BITER_ELINKYES_REG(DMA0,2)
+#define DMA_TCD3_SADDR                           DMA_SADDR_REG(DMA0,3)
+#define DMA_TCD3_SOFF                            DMA_SOFF_REG(DMA0,3)
+#define DMA_TCD3_ATTR                            DMA_ATTR_REG(DMA0,3)
+#define DMA_TCD3_NBYTES_MLNO                     DMA_NBYTES_MLNO_REG(DMA0,3)
+#define DMA_TCD3_NBYTES_MLOFFNO                  DMA_NBYTES_MLOFFNO_REG(DMA0,3)
+#define DMA_TCD3_NBYTES_MLOFFYES                 DMA_NBYTES_MLOFFYES_REG(DMA0,3)
+#define DMA_TCD3_SLAST                           DMA_SLAST_REG(DMA0,3)
+#define DMA_TCD3_DADDR                           DMA_DADDR_REG(DMA0,3)
+#define DMA_TCD3_DOFF                            DMA_DOFF_REG(DMA0,3)
+#define DMA_TCD3_CITER_ELINKNO                   DMA_CITER_ELINKNO_REG(DMA0,3)
+#define DMA_TCD3_CITER_ELINKYES                  DMA_CITER_ELINKYES_REG(DMA0,3)
+#define DMA_TCD3_DLASTSGA                        DMA_DLAST_SGA_REG(DMA0,3)
+#define DMA_TCD3_CSR                             DMA_CSR_REG(DMA0,3)
+#define DMA_TCD3_BITER_ELINKNO                   DMA_BITER_ELINKNO_REG(DMA0,3)
+#define DMA_TCD3_BITER_ELINKYES                  DMA_BITER_ELINKYES_REG(DMA0,3)
+#define DMA_TCD4_SADDR                           DMA_SADDR_REG(DMA0,4)
+#define DMA_TCD4_SOFF                            DMA_SOFF_REG(DMA0,4)
+#define DMA_TCD4_ATTR                            DMA_ATTR_REG(DMA0,4)
+#define DMA_TCD4_NBYTES_MLNO                     DMA_NBYTES_MLNO_REG(DMA0,4)
+#define DMA_TCD4_NBYTES_MLOFFNO                  DMA_NBYTES_MLOFFNO_REG(DMA0,4)
+#define DMA_TCD4_NBYTES_MLOFFYES                 DMA_NBYTES_MLOFFYES_REG(DMA0,4)
+#define DMA_TCD4_SLAST                           DMA_SLAST_REG(DMA0,4)
+#define DMA_TCD4_DADDR                           DMA_DADDR_REG(DMA0,4)
+#define DMA_TCD4_DOFF                            DMA_DOFF_REG(DMA0,4)
+#define DMA_TCD4_CITER_ELINKNO                   DMA_CITER_ELINKNO_REG(DMA0,4)
+#define DMA_TCD4_CITER_ELINKYES                  DMA_CITER_ELINKYES_REG(DMA0,4)
+#define DMA_TCD4_DLASTSGA                        DMA_DLAST_SGA_REG(DMA0,4)
+#define DMA_TCD4_CSR                             DMA_CSR_REG(DMA0,4)
+#define DMA_TCD4_BITER_ELINKNO                   DMA_BITER_ELINKNO_REG(DMA0,4)
+#define DMA_TCD4_BITER_ELINKYES                  DMA_BITER_ELINKYES_REG(DMA0,4)
+#define DMA_TCD5_SADDR                           DMA_SADDR_REG(DMA0,5)
+#define DMA_TCD5_SOFF                            DMA_SOFF_REG(DMA0,5)
+#define DMA_TCD5_ATTR                            DMA_ATTR_REG(DMA0,5)
+#define DMA_TCD5_NBYTES_MLNO                     DMA_NBYTES_MLNO_REG(DMA0,5)
+#define DMA_TCD5_NBYTES_MLOFFNO                  DMA_NBYTES_MLOFFNO_REG(DMA0,5)
+#define DMA_TCD5_NBYTES_MLOFFYES                 DMA_NBYTES_MLOFFYES_REG(DMA0,5)
+#define DMA_TCD5_SLAST                           DMA_SLAST_REG(DMA0,5)
+#define DMA_TCD5_DADDR                           DMA_DADDR_REG(DMA0,5)
+#define DMA_TCD5_DOFF                            DMA_DOFF_REG(DMA0,5)
+#define DMA_TCD5_CITER_ELINKNO                   DMA_CITER_ELINKNO_REG(DMA0,5)
+#define DMA_TCD5_CITER_ELINKYES                  DMA_CITER_ELINKYES_REG(DMA0,5)
+#define DMA_TCD5_DLASTSGA                        DMA_DLAST_SGA_REG(DMA0,5)
+#define DMA_TCD5_CSR                             DMA_CSR_REG(DMA0,5)
+#define DMA_TCD5_BITER_ELINKNO                   DMA_BITER_ELINKNO_REG(DMA0,5)
+#define DMA_TCD5_BITER_ELINKYES                  DMA_BITER_ELINKYES_REG(DMA0,5)
+#define DMA_TCD6_SADDR                           DMA_SADDR_REG(DMA0,6)
+#define DMA_TCD6_SOFF                            DMA_SOFF_REG(DMA0,6)
+#define DMA_TCD6_ATTR                            DMA_ATTR_REG(DMA0,6)
+#define DMA_TCD6_NBYTES_MLNO                     DMA_NBYTES_MLNO_REG(DMA0,6)
+#define DMA_TCD6_NBYTES_MLOFFNO                  DMA_NBYTES_MLOFFNO_REG(DMA0,6)
+#define DMA_TCD6_NBYTES_MLOFFYES                 DMA_NBYTES_MLOFFYES_REG(DMA0,6)
+#define DMA_TCD6_SLAST                           DMA_SLAST_REG(DMA0,6)
+#define DMA_TCD6_DADDR                           DMA_DADDR_REG(DMA0,6)
+#define DMA_TCD6_DOFF                            DMA_DOFF_REG(DMA0,6)
+#define DMA_TCD6_CITER_ELINKNO                   DMA_CITER_ELINKNO_REG(DMA0,6)
+#define DMA_TCD6_CITER_ELINKYES                  DMA_CITER_ELINKYES_REG(DMA0,6)
+#define DMA_TCD6_DLASTSGA                        DMA_DLAST_SGA_REG(DMA0,6)
+#define DMA_TCD6_CSR                             DMA_CSR_REG(DMA0,6)
+#define DMA_TCD6_BITER_ELINKNO                   DMA_BITER_ELINKNO_REG(DMA0,6)
+#define DMA_TCD6_BITER_ELINKYES                  DMA_BITER_ELINKYES_REG(DMA0,6)
+#define DMA_TCD7_SADDR                           DMA_SADDR_REG(DMA0,7)
+#define DMA_TCD7_SOFF                            DMA_SOFF_REG(DMA0,7)
+#define DMA_TCD7_ATTR                            DMA_ATTR_REG(DMA0,7)
+#define DMA_TCD7_NBYTES_MLNO                     DMA_NBYTES_MLNO_REG(DMA0,7)
+#define DMA_TCD7_NBYTES_MLOFFNO                  DMA_NBYTES_MLOFFNO_REG(DMA0,7)
+#define DMA_TCD7_NBYTES_MLOFFYES                 DMA_NBYTES_MLOFFYES_REG(DMA0,7)
+#define DMA_TCD7_SLAST                           DMA_SLAST_REG(DMA0,7)
+#define DMA_TCD7_DADDR                           DMA_DADDR_REG(DMA0,7)
+#define DMA_TCD7_DOFF                            DMA_DOFF_REG(DMA0,7)
+#define DMA_TCD7_CITER_ELINKNO                   DMA_CITER_ELINKNO_REG(DMA0,7)
+#define DMA_TCD7_CITER_ELINKYES                  DMA_CITER_ELINKYES_REG(DMA0,7)
+#define DMA_TCD7_DLASTSGA                        DMA_DLAST_SGA_REG(DMA0,7)
+#define DMA_TCD7_CSR                             DMA_CSR_REG(DMA0,7)
+#define DMA_TCD7_BITER_ELINKNO                   DMA_BITER_ELINKNO_REG(DMA0,7)
+#define DMA_TCD7_BITER_ELINKYES                  DMA_BITER_ELINKYES_REG(DMA0,7)
+#define DMA_TCD8_SADDR                           DMA_SADDR_REG(DMA0,8)
+#define DMA_TCD8_SOFF                            DMA_SOFF_REG(DMA0,8)
+#define DMA_TCD8_ATTR                            DMA_ATTR_REG(DMA0,8)
+#define DMA_TCD8_NBYTES_MLNO                     DMA_NBYTES_MLNO_REG(DMA0,8)
+#define DMA_TCD8_NBYTES_MLOFFNO                  DMA_NBYTES_MLOFFNO_REG(DMA0,8)
+#define DMA_TCD8_NBYTES_MLOFFYES                 DMA_NBYTES_MLOFFYES_REG(DMA0,8)
+#define DMA_TCD8_SLAST                           DMA_SLAST_REG(DMA0,8)
+#define DMA_TCD8_DADDR                           DMA_DADDR_REG(DMA0,8)
+#define DMA_TCD8_DOFF                            DMA_DOFF_REG(DMA0,8)
+#define DMA_TCD8_CITER_ELINKNO                   DMA_CITER_ELINKNO_REG(DMA0,8)
+#define DMA_TCD8_CITER_ELINKYES                  DMA_CITER_ELINKYES_REG(DMA0,8)
+#define DMA_TCD8_DLASTSGA                        DMA_DLAST_SGA_REG(DMA0,8)
+#define DMA_TCD8_CSR                             DMA_CSR_REG(DMA0,8)
+#define DMA_TCD8_BITER_ELINKNO                   DMA_BITER_ELINKNO_REG(DMA0,8)
+#define DMA_TCD8_BITER_ELINKYES                  DMA_BITER_ELINKYES_REG(DMA0,8)
+#define DMA_TCD9_SADDR                           DMA_SADDR_REG(DMA0,9)
+#define DMA_TCD9_SOFF                            DMA_SOFF_REG(DMA0,9)
+#define DMA_TCD9_ATTR                            DMA_ATTR_REG(DMA0,9)
+#define DMA_TCD9_NBYTES_MLNO                     DMA_NBYTES_MLNO_REG(DMA0,9)
+#define DMA_TCD9_NBYTES_MLOFFNO                  DMA_NBYTES_MLOFFNO_REG(DMA0,9)
+#define DMA_TCD9_NBYTES_MLOFFYES                 DMA_NBYTES_MLOFFYES_REG(DMA0,9)
+#define DMA_TCD9_SLAST                           DMA_SLAST_REG(DMA0,9)
+#define DMA_TCD9_DADDR                           DMA_DADDR_REG(DMA0,9)
+#define DMA_TCD9_DOFF                            DMA_DOFF_REG(DMA0,9)
+#define DMA_TCD9_CITER_ELINKNO                   DMA_CITER_ELINKNO_REG(DMA0,9)
+#define DMA_TCD9_CITER_ELINKYES                  DMA_CITER_ELINKYES_REG(DMA0,9)
+#define DMA_TCD9_DLASTSGA                        DMA_DLAST_SGA_REG(DMA0,9)
+#define DMA_TCD9_CSR                             DMA_CSR_REG(DMA0,9)
+#define DMA_TCD9_BITER_ELINKNO                   DMA_BITER_ELINKNO_REG(DMA0,9)
+#define DMA_TCD9_BITER_ELINKYES                  DMA_BITER_ELINKYES_REG(DMA0,9)
+#define DMA_TCD10_SADDR                          DMA_SADDR_REG(DMA0,10)
+#define DMA_TCD10_SOFF                           DMA_SOFF_REG(DMA0,10)
+#define DMA_TCD10_ATTR                           DMA_ATTR_REG(DMA0,10)
+#define DMA_TCD10_NBYTES_MLNO                    DMA_NBYTES_MLNO_REG(DMA0,10)
+#define DMA_TCD10_NBYTES_MLOFFNO                 DMA_NBYTES_MLOFFNO_REG(DMA0,10)
+#define DMA_TCD10_NBYTES_MLOFFYES                DMA_NBYTES_MLOFFYES_REG(DMA0,10)
+#define DMA_TCD10_SLAST                          DMA_SLAST_REG(DMA0,10)
+#define DMA_TCD10_DADDR                          DMA_DADDR_REG(DMA0,10)
+#define DMA_TCD10_DOFF                           DMA_DOFF_REG(DMA0,10)
+#define DMA_TCD10_CITER_ELINKNO                  DMA_CITER_ELINKNO_REG(DMA0,10)
+#define DMA_TCD10_CITER_ELINKYES                 DMA_CITER_ELINKYES_REG(DMA0,10)
+#define DMA_TCD10_DLASTSGA                       DMA_DLAST_SGA_REG(DMA0,10)
+#define DMA_TCD10_CSR                            DMA_CSR_REG(DMA0,10)
+#define DMA_TCD10_BITER_ELINKNO                  DMA_BITER_ELINKNO_REG(DMA0,10)
+#define DMA_TCD10_BITER_ELINKYES                 DMA_BITER_ELINKYES_REG(DMA0,10)
+#define DMA_TCD11_SADDR                          DMA_SADDR_REG(DMA0,11)
+#define DMA_TCD11_SOFF                           DMA_SOFF_REG(DMA0,11)
+#define DMA_TCD11_ATTR                           DMA_ATTR_REG(DMA0,11)
+#define DMA_TCD11_NBYTES_MLNO                    DMA_NBYTES_MLNO_REG(DMA0,11)
+#define DMA_TCD11_NBYTES_MLOFFNO                 DMA_NBYTES_MLOFFNO_REG(DMA0,11)
+#define DMA_TCD11_NBYTES_MLOFFYES                DMA_NBYTES_MLOFFYES_REG(DMA0,11)
+#define DMA_TCD11_SLAST                          DMA_SLAST_REG(DMA0,11)
+#define DMA_TCD11_DADDR                          DMA_DADDR_REG(DMA0,11)
+#define DMA_TCD11_DOFF                           DMA_DOFF_REG(DMA0,11)
+#define DMA_TCD11_CITER_ELINKNO                  DMA_CITER_ELINKNO_REG(DMA0,11)
+#define DMA_TCD11_CITER_ELINKYES                 DMA_CITER_ELINKYES_REG(DMA0,11)
+#define DMA_TCD11_DLASTSGA                       DMA_DLAST_SGA_REG(DMA0,11)
+#define DMA_TCD11_CSR                            DMA_CSR_REG(DMA0,11)
+#define DMA_TCD11_BITER_ELINKNO                  DMA_BITER_ELINKNO_REG(DMA0,11)
+#define DMA_TCD11_BITER_ELINKYES                 DMA_BITER_ELINKYES_REG(DMA0,11)
+#define DMA_TCD12_SADDR                          DMA_SADDR_REG(DMA0,12)
+#define DMA_TCD12_SOFF                           DMA_SOFF_REG(DMA0,12)
+#define DMA_TCD12_ATTR                           DMA_ATTR_REG(DMA0,12)
+#define DMA_TCD12_NBYTES_MLNO                    DMA_NBYTES_MLNO_REG(DMA0,12)
+#define DMA_TCD12_NBYTES_MLOFFNO                 DMA_NBYTES_MLOFFNO_REG(DMA0,12)
+#define DMA_TCD12_NBYTES_MLOFFYES                DMA_NBYTES_MLOFFYES_REG(DMA0,12)
+#define DMA_TCD12_SLAST                          DMA_SLAST_REG(DMA0,12)
+#define DMA_TCD12_DADDR                          DMA_DADDR_REG(DMA0,12)
+#define DMA_TCD12_DOFF                           DMA_DOFF_REG(DMA0,12)
+#define DMA_TCD12_CITER_ELINKNO                  DMA_CITER_ELINKNO_REG(DMA0,12)
+#define DMA_TCD12_CITER_ELINKYES                 DMA_CITER_ELINKYES_REG(DMA0,12)
+#define DMA_TCD12_DLASTSGA                       DMA_DLAST_SGA_REG(DMA0,12)
+#define DMA_TCD12_CSR                            DMA_CSR_REG(DMA0,12)
+#define DMA_TCD12_BITER_ELINKNO                  DMA_BITER_ELINKNO_REG(DMA0,12)
+#define DMA_TCD12_BITER_ELINKYES                 DMA_BITER_ELINKYES_REG(DMA0,12)
+#define DMA_TCD13_SADDR                          DMA_SADDR_REG(DMA0,13)
+#define DMA_TCD13_SOFF                           DMA_SOFF_REG(DMA0,13)
+#define DMA_TCD13_ATTR                           DMA_ATTR_REG(DMA0,13)
+#define DMA_TCD13_NBYTES_MLNO                    DMA_NBYTES_MLNO_REG(DMA0,13)
+#define DMA_TCD13_NBYTES_MLOFFNO                 DMA_NBYTES_MLOFFNO_REG(DMA0,13)
+#define DMA_TCD13_NBYTES_MLOFFYES                DMA_NBYTES_MLOFFYES_REG(DMA0,13)
+#define DMA_TCD13_SLAST                          DMA_SLAST_REG(DMA0,13)
+#define DMA_TCD13_DADDR                          DMA_DADDR_REG(DMA0,13)
+#define DMA_TCD13_DOFF                           DMA_DOFF_REG(DMA0,13)
+#define DMA_TCD13_CITER_ELINKNO                  DMA_CITER_ELINKNO_REG(DMA0,13)
+#define DMA_TCD13_CITER_ELINKYES                 DMA_CITER_ELINKYES_REG(DMA0,13)
+#define DMA_TCD13_DLASTSGA                       DMA_DLAST_SGA_REG(DMA0,13)
+#define DMA_TCD13_CSR                            DMA_CSR_REG(DMA0,13)
+#define DMA_TCD13_BITER_ELINKNO                  DMA_BITER_ELINKNO_REG(DMA0,13)
+#define DMA_TCD13_BITER_ELINKYES                 DMA_BITER_ELINKYES_REG(DMA0,13)
+#define DMA_TCD14_SADDR                          DMA_SADDR_REG(DMA0,14)
+#define DMA_TCD14_SOFF                           DMA_SOFF_REG(DMA0,14)
+#define DMA_TCD14_ATTR                           DMA_ATTR_REG(DMA0,14)
+#define DMA_TCD14_NBYTES_MLNO                    DMA_NBYTES_MLNO_REG(DMA0,14)
+#define DMA_TCD14_NBYTES_MLOFFNO                 DMA_NBYTES_MLOFFNO_REG(DMA0,14)
+#define DMA_TCD14_NBYTES_MLOFFYES                DMA_NBYTES_MLOFFYES_REG(DMA0,14)
+#define DMA_TCD14_SLAST                          DMA_SLAST_REG(DMA0,14)
+#define DMA_TCD14_DADDR                          DMA_DADDR_REG(DMA0,14)
+#define DMA_TCD14_DOFF                           DMA_DOFF_REG(DMA0,14)
+#define DMA_TCD14_CITER_ELINKNO                  DMA_CITER_ELINKNO_REG(DMA0,14)
+#define DMA_TCD14_CITER_ELINKYES                 DMA_CITER_ELINKYES_REG(DMA0,14)
+#define DMA_TCD14_DLASTSGA                       DMA_DLAST_SGA_REG(DMA0,14)
+#define DMA_TCD14_CSR                            DMA_CSR_REG(DMA0,14)
+#define DMA_TCD14_BITER_ELINKNO                  DMA_BITER_ELINKNO_REG(DMA0,14)
+#define DMA_TCD14_BITER_ELINKYES                 DMA_BITER_ELINKYES_REG(DMA0,14)
+#define DMA_TCD15_SADDR                          DMA_SADDR_REG(DMA0,15)
+#define DMA_TCD15_SOFF                           DMA_SOFF_REG(DMA0,15)
+#define DMA_TCD15_ATTR                           DMA_ATTR_REG(DMA0,15)
+#define DMA_TCD15_NBYTES_MLNO                    DMA_NBYTES_MLNO_REG(DMA0,15)
+#define DMA_TCD15_NBYTES_MLOFFNO                 DMA_NBYTES_MLOFFNO_REG(DMA0,15)
+#define DMA_TCD15_NBYTES_MLOFFYES                DMA_NBYTES_MLOFFYES_REG(DMA0,15)
+#define DMA_TCD15_SLAST                          DMA_SLAST_REG(DMA0,15)
+#define DMA_TCD15_DADDR                          DMA_DADDR_REG(DMA0,15)
+#define DMA_TCD15_DOFF                           DMA_DOFF_REG(DMA0,15)
+#define DMA_TCD15_CITER_ELINKNO                  DMA_CITER_ELINKNO_REG(DMA0,15)
+#define DMA_TCD15_CITER_ELINKYES                 DMA_CITER_ELINKYES_REG(DMA0,15)
+#define DMA_TCD15_DLASTSGA                       DMA_DLAST_SGA_REG(DMA0,15)
+#define DMA_TCD15_CSR                            DMA_CSR_REG(DMA0,15)
+#define DMA_TCD15_BITER_ELINKNO                  DMA_BITER_ELINKNO_REG(DMA0,15)
+#define DMA_TCD15_BITER_ELINKYES                 DMA_BITER_ELINKYES_REG(DMA0,15)
+
+/* DMA - Register array accessors */
+#define DMA_SADDR(index)                         DMA_SADDR_REG(DMA0,index)
+#define DMA_SOFF(index)                          DMA_SOFF_REG(DMA0,index)
+#define DMA_ATTR(index)                          DMA_ATTR_REG(DMA0,index)
+#define DMA_NBYTES_MLNO(index)                   DMA_NBYTES_MLNO_REG(DMA0,index)
+#define DMA_NBYTES_MLOFFNO(index)                DMA_NBYTES_MLOFFNO_REG(DMA0,index)
+#define DMA_NBYTES_MLOFFYES(index)               DMA_NBYTES_MLOFFYES_REG(DMA0,index)
+#define DMA_SLAST(index)                         DMA_SLAST_REG(DMA0,index)
+#define DMA_DADDR(index)                         DMA_DADDR_REG(DMA0,index)
+#define DMA_DOFF(index)                          DMA_DOFF_REG(DMA0,index)
+#define DMA_CITER_ELINKNO(index)                 DMA_CITER_ELINKNO_REG(DMA0,index)
+#define DMA_CITER_ELINKYES(index)                DMA_CITER_ELINKYES_REG(DMA0,index)
+#define DMA_DLAST_SGA(index)                     DMA_DLAST_SGA_REG(DMA0,index)
+#define DMA_CSR(index)                           DMA_CSR_REG(DMA0,index)
+#define DMA_BITER_ELINKNO(index)                 DMA_BITER_ELINKNO_REG(DMA0,index)
+#define DMA_BITER_ELINKYES(index)                DMA_BITER_ELINKYES_REG(DMA0,index)
+
+/*!
+ * @}
+ */ /* end of group DMA_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group DMA_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- DMAMUX Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMAMUX_Peripheral_Access_Layer DMAMUX Peripheral Access Layer
+ * @{
+ */
+
+/** DMAMUX - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t CHCFG[16];                          /**< Channel Configuration register, array offset: 0x0, array step: 0x1 */
+} DMAMUX_Type, *DMAMUX_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- DMAMUX - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMAMUX_Register_Accessor_Macros DMAMUX - Register accessor macros
+ * @{
+ */
+
+
+/* DMAMUX - Register accessors */
+#define DMAMUX_CHCFG_REG(base,index)             ((base)->CHCFG[index])
+
+/*!
+ * @}
+ */ /* end of group DMAMUX_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- DMAMUX Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMAMUX_Register_Masks DMAMUX Register Masks
+ * @{
+ */
+
+/* CHCFG Bit Fields */
+#define DMAMUX_CHCFG_SOURCE_MASK                 0x3Fu
+#define DMAMUX_CHCFG_SOURCE_SHIFT                0
+#define DMAMUX_CHCFG_SOURCE(x)                   (((uint8_t)(((uint8_t)(x))<<DMAMUX_CHCFG_SOURCE_SHIFT))&DMAMUX_CHCFG_SOURCE_MASK)
+#define DMAMUX_CHCFG_TRIG_MASK                   0x40u
+#define DMAMUX_CHCFG_TRIG_SHIFT                  6
+#define DMAMUX_CHCFG_ENBL_MASK                   0x80u
+#define DMAMUX_CHCFG_ENBL_SHIFT                  7
+
+/*!
+ * @}
+ */ /* end of group DMAMUX_Register_Masks */
+
+
+/* DMAMUX - Peripheral instance base addresses */
+/** Peripheral DMAMUX base address */
+#define DMAMUX_BASE                              (0x40021000u)
+/** Peripheral DMAMUX base pointer */
+#define DMAMUX                                   ((DMAMUX_Type *)DMAMUX_BASE)
+#define DMAMUX_BASE_PTR                          (DMAMUX)
+/** Array initializer of DMAMUX peripheral base addresses */
+#define DMAMUX_BASE_ADDRS                        { DMAMUX_BASE }
+/** Array initializer of DMAMUX peripheral base pointers */
+#define DMAMUX_BASE_PTRS                         { DMAMUX }
+
+/* ----------------------------------------------------------------------------
+   -- DMAMUX - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMAMUX_Register_Accessor_Macros DMAMUX - Register accessor macros
+ * @{
+ */
+
+
+/* DMAMUX - Register instance definitions */
+/* DMAMUX */
+#define DMAMUX_CHCFG0                            DMAMUX_CHCFG_REG(DMAMUX,0)
+#define DMAMUX_CHCFG1                            DMAMUX_CHCFG_REG(DMAMUX,1)
+#define DMAMUX_CHCFG2                            DMAMUX_CHCFG_REG(DMAMUX,2)
+#define DMAMUX_CHCFG3                            DMAMUX_CHCFG_REG(DMAMUX,3)
+#define DMAMUX_CHCFG4                            DMAMUX_CHCFG_REG(DMAMUX,4)
+#define DMAMUX_CHCFG5                            DMAMUX_CHCFG_REG(DMAMUX,5)
+#define DMAMUX_CHCFG6                            DMAMUX_CHCFG_REG(DMAMUX,6)
+#define DMAMUX_CHCFG7                            DMAMUX_CHCFG_REG(DMAMUX,7)
+#define DMAMUX_CHCFG8                            DMAMUX_CHCFG_REG(DMAMUX,8)
+#define DMAMUX_CHCFG9                            DMAMUX_CHCFG_REG(DMAMUX,9)
+#define DMAMUX_CHCFG10                           DMAMUX_CHCFG_REG(DMAMUX,10)
+#define DMAMUX_CHCFG11                           DMAMUX_CHCFG_REG(DMAMUX,11)
+#define DMAMUX_CHCFG12                           DMAMUX_CHCFG_REG(DMAMUX,12)
+#define DMAMUX_CHCFG13                           DMAMUX_CHCFG_REG(DMAMUX,13)
+#define DMAMUX_CHCFG14                           DMAMUX_CHCFG_REG(DMAMUX,14)
+#define DMAMUX_CHCFG15                           DMAMUX_CHCFG_REG(DMAMUX,15)
+
+/* DMAMUX - Register array accessors */
+#define DMAMUX_CHCFG(index)                      DMAMUX_CHCFG_REG(DMAMUX,index)
+
+/*!
+ * @}
+ */ /* end of group DMAMUX_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group DMAMUX_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- ENET Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ENET_Peripheral_Access_Layer ENET Peripheral Access Layer
+ * @{
+ */
+
+/** ENET - Register Layout Typedef */
+typedef struct {
+       uint8_t RESERVED_0[4];
+  __IO uint32_t EIR;                               /**< Interrupt Event Register, offset: 0x4 */
+  __IO uint32_t EIMR;                              /**< Interrupt Mask Register, offset: 0x8 */
+       uint8_t RESERVED_1[4];
+  __IO uint32_t RDAR;                              /**< Receive Descriptor Active Register, offset: 0x10 */
+  __IO uint32_t TDAR;                              /**< Transmit Descriptor Active Register, offset: 0x14 */
+       uint8_t RESERVED_2[12];
+  __IO uint32_t ECR;                               /**< Ethernet Control Register, offset: 0x24 */
+       uint8_t RESERVED_3[24];
+  __IO uint32_t MMFR;                              /**< MII Management Frame Register, offset: 0x40 */
+  __IO uint32_t MSCR;                              /**< MII Speed Control Register, offset: 0x44 */
+       uint8_t RESERVED_4[28];
+  __IO uint32_t MIBC;                              /**< MIB Control Register, offset: 0x64 */
+       uint8_t RESERVED_5[28];
+  __IO uint32_t RCR;                               /**< Receive Control Register, offset: 0x84 */
+       uint8_t RESERVED_6[60];
+  __IO uint32_t TCR;                               /**< Transmit Control Register, offset: 0xC4 */
+       uint8_t RESERVED_7[28];
+  __IO uint32_t PALR;                              /**< Physical Address Lower Register, offset: 0xE4 */
+  __IO uint32_t PAUR;                              /**< Physical Address Upper Register, offset: 0xE8 */
+  __IO uint32_t OPD;                               /**< Opcode/Pause Duration Register, offset: 0xEC */
+       uint8_t RESERVED_8[40];
+  __IO uint32_t IAUR;                              /**< Descriptor Individual Upper Address Register, offset: 0x118 */
+  __IO uint32_t IALR;                              /**< Descriptor Individual Lower Address Register, offset: 0x11C */
+  __IO uint32_t GAUR;                              /**< Descriptor Group Upper Address Register, offset: 0x120 */
+  __IO uint32_t GALR;                              /**< Descriptor Group Lower Address Register, offset: 0x124 */
+       uint8_t RESERVED_9[28];
+  __IO uint32_t TFWR;                              /**< Transmit FIFO Watermark Register, offset: 0x144 */
+       uint8_t RESERVED_10[56];
+  __IO uint32_t RDSR;                              /**< Receive Descriptor Ring Start Register, offset: 0x180 */
+  __IO uint32_t TDSR;                              /**< Transmit Buffer Descriptor Ring Start Register, offset: 0x184 */
+  __IO uint32_t MRBR;                              /**< Maximum Receive Buffer Size Register, offset: 0x188 */
+       uint8_t RESERVED_11[4];
+  __IO uint32_t RSFL;                              /**< Receive FIFO Section Full Threshold, offset: 0x190 */
+  __IO uint32_t RSEM;                              /**< Receive FIFO Section Empty Threshold, offset: 0x194 */
+  __IO uint32_t RAEM;                              /**< Receive FIFO Almost Empty Threshold, offset: 0x198 */
+  __IO uint32_t RAFL;                              /**< Receive FIFO Almost Full Threshold, offset: 0x19C */
+  __IO uint32_t TSEM;                              /**< Transmit FIFO Section Empty Threshold, offset: 0x1A0 */
+  __IO uint32_t TAEM;                              /**< Transmit FIFO Almost Empty Threshold, offset: 0x1A4 */
+  __IO uint32_t TAFL;                              /**< Transmit FIFO Almost Full Threshold, offset: 0x1A8 */
+  __IO uint32_t TIPG;                              /**< Transmit Inter-Packet Gap, offset: 0x1AC */
+  __IO uint32_t FTRL;                              /**< Frame Truncation Length, offset: 0x1B0 */
+       uint8_t RESERVED_12[12];
+  __IO uint32_t TACC;                              /**< Transmit Accelerator Function Configuration, offset: 0x1C0 */
+  __IO uint32_t RACC;                              /**< Receive Accelerator Function Configuration, offset: 0x1C4 */
+       uint8_t RESERVED_13[60];
+  __I  uint32_t RMON_T_PACKETS;                    /**< Tx Packet Count Statistic Register, offset: 0x204 */
+  __I  uint32_t RMON_T_BC_PKT;                     /**< Tx Broadcast Packets Statistic Register, offset: 0x208 */
+  __I  uint32_t RMON_T_MC_PKT;                     /**< Tx Multicast Packets Statistic Register, offset: 0x20C */
+  __I  uint32_t RMON_T_CRC_ALIGN;                  /**< Tx Packets with CRC/Align Error Statistic Register, offset: 0x210 */
+  __I  uint32_t RMON_T_UNDERSIZE;                  /**< Tx Packets Less Than Bytes and Good CRC Statistic Register, offset: 0x214 */
+  __I  uint32_t RMON_T_OVERSIZE;                   /**< Tx Packets GT MAX_FL bytes and Good CRC Statistic Register, offset: 0x218 */
+  __I  uint32_t RMON_T_FRAG;                       /**< Tx Packets Less Than 64 Bytes and Bad CRC Statistic Register, offset: 0x21C */
+  __I  uint32_t RMON_T_JAB;                        /**< Tx Packets Greater Than MAX_FL bytes and Bad CRC Statistic Register, offset: 0x220 */
+  __I  uint32_t RMON_T_COL;                        /**< Tx Collision Count Statistic Register, offset: 0x224 */
+  __I  uint32_t RMON_T_P64;                        /**< Tx 64-Byte Packets Statistic Register, offset: 0x228 */
+  __I  uint32_t RMON_T_P65TO127;                   /**< Tx 65- to 127-byte Packets Statistic Register, offset: 0x22C */
+  __I  uint32_t RMON_T_P128TO255;                  /**< Tx 128- to 255-byte Packets Statistic Register, offset: 0x230 */
+  __I  uint32_t RMON_T_P256TO511;                  /**< Tx 256- to 511-byte Packets Statistic Register, offset: 0x234 */
+  __I  uint32_t RMON_T_P512TO1023;                 /**< Tx 512- to 1023-byte Packets Statistic Register, offset: 0x238 */
+  __I  uint32_t RMON_T_P1024TO2047;                /**< Tx 1024- to 2047-byte Packets Statistic Register, offset: 0x23C */
+  __I  uint32_t RMON_T_P_GTE2048;                  /**< Tx Packets Greater Than 2048 Bytes Statistic Register, offset: 0x240 */
+  __I  uint32_t RMON_T_OCTETS;                     /**< Tx Octets Statistic Register, offset: 0x244 */
+       uint8_t RESERVED_14[4];
+  __I  uint32_t IEEE_T_FRAME_OK;                   /**< Frames Transmitted OK Statistic Register, offset: 0x24C */
+  __I  uint32_t IEEE_T_1COL;                       /**< Frames Transmitted with Single Collision Statistic Register, offset: 0x250 */
+  __I  uint32_t IEEE_T_MCOL;                       /**< Frames Transmitted with Multiple Collisions Statistic Register, offset: 0x254 */
+  __I  uint32_t IEEE_T_DEF;                        /**< Frames Transmitted after Deferral Delay Statistic Register, offset: 0x258 */
+  __I  uint32_t IEEE_T_LCOL;                       /**< Frames Transmitted with Late Collision Statistic Register, offset: 0x25C */
+  __I  uint32_t IEEE_T_EXCOL;                      /**< Frames Transmitted with Excessive Collisions Statistic Register, offset: 0x260 */
+  __I  uint32_t IEEE_T_MACERR;                     /**< Frames Transmitted with Tx FIFO Underrun Statistic Register, offset: 0x264 */
+  __I  uint32_t IEEE_T_CSERR;                      /**< Frames Transmitted with Carrier Sense Error Statistic Register, offset: 0x268 */
+       uint8_t RESERVED_15[4];
+  __I  uint32_t IEEE_T_FDXFC;                      /**< Flow Control Pause Frames Transmitted Statistic Register, offset: 0x270 */
+  __I  uint32_t IEEE_T_OCTETS_OK;                  /**< Octet Count for Frames Transmitted w/o Error Statistic Register, offset: 0x274 */
+       uint8_t RESERVED_16[12];
+  __I  uint32_t RMON_R_PACKETS;                    /**< Rx Packet Count Statistic Register, offset: 0x284 */
+  __I  uint32_t RMON_R_BC_PKT;                     /**< Rx Broadcast Packets Statistic Register, offset: 0x288 */
+  __I  uint32_t RMON_R_MC_PKT;                     /**< Rx Multicast Packets Statistic Register, offset: 0x28C */
+  __I  uint32_t RMON_R_CRC_ALIGN;                  /**< Rx Packets with CRC/Align Error Statistic Register, offset: 0x290 */
+  __I  uint32_t RMON_R_UNDERSIZE;                  /**< Rx Packets with Less Than 64 Bytes and Good CRC Statistic Register, offset: 0x294 */
+  __I  uint32_t RMON_R_OVERSIZE;                   /**< Rx Packets Greater Than MAX_FL and Good CRC Statistic Register, offset: 0x298 */
+  __I  uint32_t RMON_R_FRAG;                       /**< Rx Packets Less Than 64 Bytes and Bad CRC Statistic Register, offset: 0x29C */
+  __I  uint32_t RMON_R_JAB;                        /**< Rx Packets Greater Than MAX_FL Bytes and Bad CRC Statistic Register, offset: 0x2A0 */
+       uint8_t RESERVED_17[4];
+  __I  uint32_t RMON_R_P64;                        /**< Rx 64-Byte Packets Statistic Register, offset: 0x2A8 */
+  __I  uint32_t RMON_R_P65TO127;                   /**< Rx 65- to 127-Byte Packets Statistic Register, offset: 0x2AC */
+  __I  uint32_t RMON_R_P128TO255;                  /**< Rx 128- to 255-Byte Packets Statistic Register, offset: 0x2B0 */
+  __I  uint32_t RMON_R_P256TO511;                  /**< Rx 256- to 511-Byte Packets Statistic Register, offset: 0x2B4 */
+  __I  uint32_t RMON_R_P512TO1023;                 /**< Rx 512- to 1023-Byte Packets Statistic Register, offset: 0x2B8 */
+  __I  uint32_t RMON_R_P1024TO2047;                /**< Rx 1024- to 2047-Byte Packets Statistic Register, offset: 0x2BC */
+  __I  uint32_t RMON_R_P_GTE2048;                  /**< Rx Packets Greater than 2048 Bytes Statistic Register, offset: 0x2C0 */
+  __I  uint32_t RMON_R_OCTETS;                     /**< Rx Octets Statistic Register, offset: 0x2C4 */
+  __I  uint32_t IEEE_R_DROP;                       /**< Frames not Counted Correctly Statistic Register, offset: 0x2C8 */
+  __I  uint32_t IEEE_R_FRAME_OK;                   /**< Frames Received OK Statistic Register, offset: 0x2CC */
+  __I  uint32_t IEEE_R_CRC;                        /**< Frames Received with CRC Error Statistic Register, offset: 0x2D0 */
+  __I  uint32_t IEEE_R_ALIGN;                      /**< Frames Received with Alignment Error Statistic Register, offset: 0x2D4 */
+  __I  uint32_t IEEE_R_MACERR;                     /**< Receive FIFO Overflow Count Statistic Register, offset: 0x2D8 */
+  __I  uint32_t IEEE_R_FDXFC;                      /**< Flow Control Pause Frames Received Statistic Register, offset: 0x2DC */
+  __I  uint32_t IEEE_R_OCTETS_OK;                  /**< Octet Count for Frames Received without Error Statistic Register, offset: 0x2E0 */
+       uint8_t RESERVED_18[284];
+  __IO uint32_t ATCR;                              /**< Adjustable Timer Control Register, offset: 0x400 */
+  __IO uint32_t ATVR;                              /**< Timer Value Register, offset: 0x404 */
+  __IO uint32_t ATOFF;                             /**< Timer Offset Register, offset: 0x408 */
+  __IO uint32_t ATPER;                             /**< Timer Period Register, offset: 0x40C */
+  __IO uint32_t ATCOR;                             /**< Timer Correction Register, offset: 0x410 */
+  __IO uint32_t ATINC;                             /**< Time-Stamping Clock Period Register, offset: 0x414 */
+  __I  uint32_t ATSTMP;                            /**< Timestamp of Last Transmitted Frame, offset: 0x418 */
+       uint8_t RESERVED_19[488];
+  __IO uint32_t TGSR;                              /**< Timer Global Status Register, offset: 0x604 */
+  struct {                                         /* offset: 0x608, array step: 0x8 */
+    __IO uint32_t TCSR;                              /**< Timer Control Status Register, array offset: 0x608, array step: 0x8 */
+    __IO uint32_t TCCR;                              /**< Timer Compare Capture Register, array offset: 0x60C, array step: 0x8 */
+  } CHANNEL[4];
+} ENET_Type, *ENET_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- ENET - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ENET_Register_Accessor_Macros ENET - Register accessor macros
+ * @{
+ */
+
+
+/* ENET - Register accessors */
+#define ENET_EIR_REG(base)                       ((base)->EIR)
+#define ENET_EIMR_REG(base)                      ((base)->EIMR)
+#define ENET_RDAR_REG(base)                      ((base)->RDAR)
+#define ENET_TDAR_REG(base)                      ((base)->TDAR)
+#define ENET_ECR_REG(base)                       ((base)->ECR)
+#define ENET_MMFR_REG(base)                      ((base)->MMFR)
+#define ENET_MSCR_REG(base)                      ((base)->MSCR)
+#define ENET_MIBC_REG(base)                      ((base)->MIBC)
+#define ENET_RCR_REG(base)                       ((base)->RCR)
+#define ENET_TCR_REG(base)                       ((base)->TCR)
+#define ENET_PALR_REG(base)                      ((base)->PALR)
+#define ENET_PAUR_REG(base)                      ((base)->PAUR)
+#define ENET_OPD_REG(base)                       ((base)->OPD)
+#define ENET_IAUR_REG(base)                      ((base)->IAUR)
+#define ENET_IALR_REG(base)                      ((base)->IALR)
+#define ENET_GAUR_REG(base)                      ((base)->GAUR)
+#define ENET_GALR_REG(base)                      ((base)->GALR)
+#define ENET_TFWR_REG(base)                      ((base)->TFWR)
+#define ENET_RDSR_REG(base)                      ((base)->RDSR)
+#define ENET_TDSR_REG(base)                      ((base)->TDSR)
+#define ENET_MRBR_REG(base)                      ((base)->MRBR)
+#define ENET_RSFL_REG(base)                      ((base)->RSFL)
+#define ENET_RSEM_REG(base)                      ((base)->RSEM)
+#define ENET_RAEM_REG(base)                      ((base)->RAEM)
+#define ENET_RAFL_REG(base)                      ((base)->RAFL)
+#define ENET_TSEM_REG(base)                      ((base)->TSEM)
+#define ENET_TAEM_REG(base)                      ((base)->TAEM)
+#define ENET_TAFL_REG(base)                      ((base)->TAFL)
+#define ENET_TIPG_REG(base)                      ((base)->TIPG)
+#define ENET_FTRL_REG(base)                      ((base)->FTRL)
+#define ENET_TACC_REG(base)                      ((base)->TACC)
+#define ENET_RACC_REG(base)                      ((base)->RACC)
+#define ENET_RMON_T_PACKETS_REG(base)            ((base)->RMON_T_PACKETS)
+#define ENET_RMON_T_BC_PKT_REG(base)             ((base)->RMON_T_BC_PKT)
+#define ENET_RMON_T_MC_PKT_REG(base)             ((base)->RMON_T_MC_PKT)
+#define ENET_RMON_T_CRC_ALIGN_REG(base)          ((base)->RMON_T_CRC_ALIGN)
+#define ENET_RMON_T_UNDERSIZE_REG(base)          ((base)->RMON_T_UNDERSIZE)
+#define ENET_RMON_T_OVERSIZE_REG(base)           ((base)->RMON_T_OVERSIZE)
+#define ENET_RMON_T_FRAG_REG(base)               ((base)->RMON_T_FRAG)
+#define ENET_RMON_T_JAB_REG(base)                ((base)->RMON_T_JAB)
+#define ENET_RMON_T_COL_REG(base)                ((base)->RMON_T_COL)
+#define ENET_RMON_T_P64_REG(base)                ((base)->RMON_T_P64)
+#define ENET_RMON_T_P65TO127_REG(base)           ((base)->RMON_T_P65TO127)
+#define ENET_RMON_T_P128TO255_REG(base)          ((base)->RMON_T_P128TO255)
+#define ENET_RMON_T_P256TO511_REG(base)          ((base)->RMON_T_P256TO511)
+#define ENET_RMON_T_P512TO1023_REG(base)         ((base)->RMON_T_P512TO1023)
+#define ENET_RMON_T_P1024TO2047_REG(base)        ((base)->RMON_T_P1024TO2047)
+#define ENET_RMON_T_P_GTE2048_REG(base)          ((base)->RMON_T_P_GTE2048)
+#define ENET_RMON_T_OCTETS_REG(base)             ((base)->RMON_T_OCTETS)
+#define ENET_IEEE_T_FRAME_OK_REG(base)           ((base)->IEEE_T_FRAME_OK)
+#define ENET_IEEE_T_1COL_REG(base)               ((base)->IEEE_T_1COL)
+#define ENET_IEEE_T_MCOL_REG(base)               ((base)->IEEE_T_MCOL)
+#define ENET_IEEE_T_DEF_REG(base)                ((base)->IEEE_T_DEF)
+#define ENET_IEEE_T_LCOL_REG(base)               ((base)->IEEE_T_LCOL)
+#define ENET_IEEE_T_EXCOL_REG(base)              ((base)->IEEE_T_EXCOL)
+#define ENET_IEEE_T_MACERR_REG(base)             ((base)->IEEE_T_MACERR)
+#define ENET_IEEE_T_CSERR_REG(base)              ((base)->IEEE_T_CSERR)
+#define ENET_IEEE_T_FDXFC_REG(base)              ((base)->IEEE_T_FDXFC)
+#define ENET_IEEE_T_OCTETS_OK_REG(base)          ((base)->IEEE_T_OCTETS_OK)
+#define ENET_RMON_R_PACKETS_REG(base)            ((base)->RMON_R_PACKETS)
+#define ENET_RMON_R_BC_PKT_REG(base)             ((base)->RMON_R_BC_PKT)
+#define ENET_RMON_R_MC_PKT_REG(base)             ((base)->RMON_R_MC_PKT)
+#define ENET_RMON_R_CRC_ALIGN_REG(base)          ((base)->RMON_R_CRC_ALIGN)
+#define ENET_RMON_R_UNDERSIZE_REG(base)          ((base)->RMON_R_UNDERSIZE)
+#define ENET_RMON_R_OVERSIZE_REG(base)           ((base)->RMON_R_OVERSIZE)
+#define ENET_RMON_R_FRAG_REG(base)               ((base)->RMON_R_FRAG)
+#define ENET_RMON_R_JAB_REG(base)                ((base)->RMON_R_JAB)
+#define ENET_RMON_R_P64_REG(base)                ((base)->RMON_R_P64)
+#define ENET_RMON_R_P65TO127_REG(base)           ((base)->RMON_R_P65TO127)
+#define ENET_RMON_R_P128TO255_REG(base)          ((base)->RMON_R_P128TO255)
+#define ENET_RMON_R_P256TO511_REG(base)          ((base)->RMON_R_P256TO511)
+#define ENET_RMON_R_P512TO1023_REG(base)         ((base)->RMON_R_P512TO1023)
+#define ENET_RMON_R_P1024TO2047_REG(base)        ((base)->RMON_R_P1024TO2047)
+#define ENET_RMON_R_P_GTE2048_REG(base)          ((base)->RMON_R_P_GTE2048)
+#define ENET_RMON_R_OCTETS_REG(base)             ((base)->RMON_R_OCTETS)
+#define ENET_IEEE_R_DROP_REG(base)               ((base)->IEEE_R_DROP)
+#define ENET_IEEE_R_FRAME_OK_REG(base)           ((base)->IEEE_R_FRAME_OK)
+#define ENET_IEEE_R_CRC_REG(base)                ((base)->IEEE_R_CRC)
+#define ENET_IEEE_R_ALIGN_REG(base)              ((base)->IEEE_R_ALIGN)
+#define ENET_IEEE_R_MACERR_REG(base)             ((base)->IEEE_R_MACERR)
+#define ENET_IEEE_R_FDXFC_REG(base)              ((base)->IEEE_R_FDXFC)
+#define ENET_IEEE_R_OCTETS_OK_REG(base)          ((base)->IEEE_R_OCTETS_OK)
+#define ENET_ATCR_REG(base)                      ((base)->ATCR)
+#define ENET_ATVR_REG(base)                      ((base)->ATVR)
+#define ENET_ATOFF_REG(base)                     ((base)->ATOFF)
+#define ENET_ATPER_REG(base)                     ((base)->ATPER)
+#define ENET_ATCOR_REG(base)                     ((base)->ATCOR)
+#define ENET_ATINC_REG(base)                     ((base)->ATINC)
+#define ENET_ATSTMP_REG(base)                    ((base)->ATSTMP)
+#define ENET_TGSR_REG(base)                      ((base)->TGSR)
+#define ENET_TCSR_REG(base,index)                ((base)->CHANNEL[index].TCSR)
+#define ENET_TCCR_REG(base,index)                ((base)->CHANNEL[index].TCCR)
+
+/*!
+ * @}
+ */ /* end of group ENET_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- ENET Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ENET_Register_Masks ENET Register Masks
+ * @{
+ */
+
+/* EIR Bit Fields */
+#define ENET_EIR_TS_TIMER_MASK                   0x8000u
+#define ENET_EIR_TS_TIMER_SHIFT                  15
+#define ENET_EIR_TS_AVAIL_MASK                   0x10000u
+#define ENET_EIR_TS_AVAIL_SHIFT                  16
+#define ENET_EIR_WAKEUP_MASK                     0x20000u
+#define ENET_EIR_WAKEUP_SHIFT                    17
+#define ENET_EIR_PLR_MASK                        0x40000u
+#define ENET_EIR_PLR_SHIFT                       18
+#define ENET_EIR_UN_MASK                         0x80000u
+#define ENET_EIR_UN_SHIFT                        19
+#define ENET_EIR_RL_MASK                         0x100000u
+#define ENET_EIR_RL_SHIFT                        20
+#define ENET_EIR_LC_MASK                         0x200000u
+#define ENET_EIR_LC_SHIFT                        21
+#define ENET_EIR_EBERR_MASK                      0x400000u
+#define ENET_EIR_EBERR_SHIFT                     22
+#define ENET_EIR_MII_MASK                        0x800000u
+#define ENET_EIR_MII_SHIFT                       23
+#define ENET_EIR_RXB_MASK                        0x1000000u
+#define ENET_EIR_RXB_SHIFT                       24
+#define ENET_EIR_RXF_MASK                        0x2000000u
+#define ENET_EIR_RXF_SHIFT                       25
+#define ENET_EIR_TXB_MASK                        0x4000000u
+#define ENET_EIR_TXB_SHIFT                       26
+#define ENET_EIR_TXF_MASK                        0x8000000u
+#define ENET_EIR_TXF_SHIFT                       27
+#define ENET_EIR_GRA_MASK                        0x10000000u
+#define ENET_EIR_GRA_SHIFT                       28
+#define ENET_EIR_BABT_MASK                       0x20000000u
+#define ENET_EIR_BABT_SHIFT                      29
+#define ENET_EIR_BABR_MASK                       0x40000000u
+#define ENET_EIR_BABR_SHIFT                      30
+/* EIMR Bit Fields */
+#define ENET_EIMR_TS_TIMER_MASK                  0x8000u
+#define ENET_EIMR_TS_TIMER_SHIFT                 15
+#define ENET_EIMR_TS_AVAIL_MASK                  0x10000u
+#define ENET_EIMR_TS_AVAIL_SHIFT                 16
+#define ENET_EIMR_WAKEUP_MASK                    0x20000u
+#define ENET_EIMR_WAKEUP_SHIFT                   17
+#define ENET_EIMR_PLR_MASK                       0x40000u
+#define ENET_EIMR_PLR_SHIFT                      18
+#define ENET_EIMR_UN_MASK                        0x80000u
+#define ENET_EIMR_UN_SHIFT                       19
+#define ENET_EIMR_RL_MASK                        0x100000u
+#define ENET_EIMR_RL_SHIFT                       20
+#define ENET_EIMR_LC_MASK                        0x200000u
+#define ENET_EIMR_LC_SHIFT                       21
+#define ENET_EIMR_EBERR_MASK                     0x400000u
+#define ENET_EIMR_EBERR_SHIFT                    22
+#define ENET_EIMR_MII_MASK                       0x800000u
+#define ENET_EIMR_MII_SHIFT                      23
+#define ENET_EIMR_RXB_MASK                       0x1000000u
+#define ENET_EIMR_RXB_SHIFT                      24
+#define ENET_EIMR_RXF_MASK                       0x2000000u
+#define ENET_EIMR_RXF_SHIFT                      25
+#define ENET_EIMR_TXB_MASK                       0x4000000u
+#define ENET_EIMR_TXB_SHIFT                      26
+#define ENET_EIMR_TXF_MASK                       0x8000000u
+#define ENET_EIMR_TXF_SHIFT                      27
+#define ENET_EIMR_GRA_MASK                       0x10000000u
+#define ENET_EIMR_GRA_SHIFT                      28
+#define ENET_EIMR_BABT_MASK                      0x20000000u
+#define ENET_EIMR_BABT_SHIFT                     29
+#define ENET_EIMR_BABR_MASK                      0x40000000u
+#define ENET_EIMR_BABR_SHIFT                     30
+/* RDAR Bit Fields */
+#define ENET_RDAR_RDAR_MASK                      0x1000000u
+#define ENET_RDAR_RDAR_SHIFT                     24
+/* TDAR Bit Fields */
+#define ENET_TDAR_TDAR_MASK                      0x1000000u
+#define ENET_TDAR_TDAR_SHIFT                     24
+/* ECR Bit Fields */
+#define ENET_ECR_RESET_MASK                      0x1u
+#define ENET_ECR_RESET_SHIFT                     0
+#define ENET_ECR_ETHEREN_MASK                    0x2u
+#define ENET_ECR_ETHEREN_SHIFT                   1
+#define ENET_ECR_MAGICEN_MASK                    0x4u
+#define ENET_ECR_MAGICEN_SHIFT                   2
+#define ENET_ECR_SLEEP_MASK                      0x8u
+#define ENET_ECR_SLEEP_SHIFT                     3
+#define ENET_ECR_EN1588_MASK                     0x10u
+#define ENET_ECR_EN1588_SHIFT                    4
+#define ENET_ECR_DBGEN_MASK                      0x40u
+#define ENET_ECR_DBGEN_SHIFT                     6
+#define ENET_ECR_STOPEN_MASK                     0x80u
+#define ENET_ECR_STOPEN_SHIFT                    7
+#define ENET_ECR_DBSWP_MASK                      0x100u
+#define ENET_ECR_DBSWP_SHIFT                     8
+/* MMFR Bit Fields */
+#define ENET_MMFR_DATA_MASK                      0xFFFFu
+#define ENET_MMFR_DATA_SHIFT                     0
+#define ENET_MMFR_DATA(x)                        (((uint32_t)(((uint32_t)(x))<<ENET_MMFR_DATA_SHIFT))&ENET_MMFR_DATA_MASK)
+#define ENET_MMFR_TA_MASK                        0x30000u
+#define ENET_MMFR_TA_SHIFT                       16
+#define ENET_MMFR_TA(x)                          (((uint32_t)(((uint32_t)(x))<<ENET_MMFR_TA_SHIFT))&ENET_MMFR_TA_MASK)
+#define ENET_MMFR_RA_MASK                        0x7C0000u
+#define ENET_MMFR_RA_SHIFT                       18
+#define ENET_MMFR_RA(x)                          (((uint32_t)(((uint32_t)(x))<<ENET_MMFR_RA_SHIFT))&ENET_MMFR_RA_MASK)
+#define ENET_MMFR_PA_MASK                        0xF800000u
+#define ENET_MMFR_PA_SHIFT                       23
+#define ENET_MMFR_PA(x)                          (((uint32_t)(((uint32_t)(x))<<ENET_MMFR_PA_SHIFT))&ENET_MMFR_PA_MASK)
+#define ENET_MMFR_OP_MASK                        0x30000000u
+#define ENET_MMFR_OP_SHIFT                       28
+#define ENET_MMFR_OP(x)                          (((uint32_t)(((uint32_t)(x))<<ENET_MMFR_OP_SHIFT))&ENET_MMFR_OP_MASK)
+#define ENET_MMFR_ST_MASK                        0xC0000000u
+#define ENET_MMFR_ST_SHIFT                       30
+#define ENET_MMFR_ST(x)                          (((uint32_t)(((uint32_t)(x))<<ENET_MMFR_ST_SHIFT))&ENET_MMFR_ST_MASK)
+/* MSCR Bit Fields */
+#define ENET_MSCR_MII_SPEED_MASK                 0x7Eu
+#define ENET_MSCR_MII_SPEED_SHIFT                1
+#define ENET_MSCR_MII_SPEED(x)                   (((uint32_t)(((uint32_t)(x))<<ENET_MSCR_MII_SPEED_SHIFT))&ENET_MSCR_MII_SPEED_MASK)
+#define ENET_MSCR_DIS_PRE_MASK                   0x80u
+#define ENET_MSCR_DIS_PRE_SHIFT                  7
+#define ENET_MSCR_HOLDTIME_MASK                  0x700u
+#define ENET_MSCR_HOLDTIME_SHIFT                 8
+#define ENET_MSCR_HOLDTIME(x)                    (((uint32_t)(((uint32_t)(x))<<ENET_MSCR_HOLDTIME_SHIFT))&ENET_MSCR_HOLDTIME_MASK)
+/* MIBC Bit Fields */
+#define ENET_MIBC_MIB_CLEAR_MASK                 0x20000000u
+#define ENET_MIBC_MIB_CLEAR_SHIFT                29
+#define ENET_MIBC_MIB_IDLE_MASK                  0x40000000u
+#define ENET_MIBC_MIB_IDLE_SHIFT                 30
+#define ENET_MIBC_MIB_DIS_MASK                   0x80000000u
+#define ENET_MIBC_MIB_DIS_SHIFT                  31
+/* RCR Bit Fields */
+#define ENET_RCR_LOOP_MASK                       0x1u
+#define ENET_RCR_LOOP_SHIFT                      0
+#define ENET_RCR_DRT_MASK                        0x2u
+#define ENET_RCR_DRT_SHIFT                       1
+#define ENET_RCR_MII_MODE_MASK                   0x4u
+#define ENET_RCR_MII_MODE_SHIFT                  2
+#define ENET_RCR_PROM_MASK                       0x8u
+#define ENET_RCR_PROM_SHIFT                      3
+#define ENET_RCR_BC_REJ_MASK                     0x10u
+#define ENET_RCR_BC_REJ_SHIFT                    4
+#define ENET_RCR_FCE_MASK                        0x20u
+#define ENET_RCR_FCE_SHIFT                       5
+#define ENET_RCR_RMII_MODE_MASK                  0x100u
+#define ENET_RCR_RMII_MODE_SHIFT                 8
+#define ENET_RCR_RMII_10T_MASK                   0x200u
+#define ENET_RCR_RMII_10T_SHIFT                  9
+#define ENET_RCR_PADEN_MASK                      0x1000u
+#define ENET_RCR_PADEN_SHIFT                     12
+#define ENET_RCR_PAUFWD_MASK                     0x2000u
+#define ENET_RCR_PAUFWD_SHIFT                    13
+#define ENET_RCR_CRCFWD_MASK                     0x4000u
+#define ENET_RCR_CRCFWD_SHIFT                    14
+#define ENET_RCR_CFEN_MASK                       0x8000u
+#define ENET_RCR_CFEN_SHIFT                      15
+#define ENET_RCR_MAX_FL_MASK                     0x3FFF0000u
+#define ENET_RCR_MAX_FL_SHIFT                    16
+#define ENET_RCR_MAX_FL(x)                       (((uint32_t)(((uint32_t)(x))<<ENET_RCR_MAX_FL_SHIFT))&ENET_RCR_MAX_FL_MASK)
+#define ENET_RCR_NLC_MASK                        0x40000000u
+#define ENET_RCR_NLC_SHIFT                       30
+#define ENET_RCR_GRS_MASK                        0x80000000u
+#define ENET_RCR_GRS_SHIFT                       31
+/* TCR Bit Fields */
+#define ENET_TCR_GTS_MASK                        0x1u
+#define ENET_TCR_GTS_SHIFT                       0
+#define ENET_TCR_FDEN_MASK                       0x4u
+#define ENET_TCR_FDEN_SHIFT                      2
+#define ENET_TCR_TFC_PAUSE_MASK                  0x8u
+#define ENET_TCR_TFC_PAUSE_SHIFT                 3
+#define ENET_TCR_RFC_PAUSE_MASK                  0x10u
+#define ENET_TCR_RFC_PAUSE_SHIFT                 4
+#define ENET_TCR_ADDSEL_MASK                     0xE0u
+#define ENET_TCR_ADDSEL_SHIFT                    5
+#define ENET_TCR_ADDSEL(x)                       (((uint32_t)(((uint32_t)(x))<<ENET_TCR_ADDSEL_SHIFT))&ENET_TCR_ADDSEL_MASK)
+#define ENET_TCR_ADDINS_MASK                     0x100u
+#define ENET_TCR_ADDINS_SHIFT                    8
+#define ENET_TCR_CRCFWD_MASK                     0x200u
+#define ENET_TCR_CRCFWD_SHIFT                    9
+/* PALR Bit Fields */
+#define ENET_PALR_PADDR1_MASK                    0xFFFFFFFFu
+#define ENET_PALR_PADDR1_SHIFT                   0
+#define ENET_PALR_PADDR1(x)                      (((uint32_t)(((uint32_t)(x))<<ENET_PALR_PADDR1_SHIFT))&ENET_PALR_PADDR1_MASK)
+/* PAUR Bit Fields */
+#define ENET_PAUR_TYPE_MASK                      0xFFFFu
+#define ENET_PAUR_TYPE_SHIFT                     0
+#define ENET_PAUR_TYPE(x)                        (((uint32_t)(((uint32_t)(x))<<ENET_PAUR_TYPE_SHIFT))&ENET_PAUR_TYPE_MASK)
+#define ENET_PAUR_PADDR2_MASK                    0xFFFF0000u
+#define ENET_PAUR_PADDR2_SHIFT                   16
+#define ENET_PAUR_PADDR2(x)                      (((uint32_t)(((uint32_t)(x))<<ENET_PAUR_PADDR2_SHIFT))&ENET_PAUR_PADDR2_MASK)
+/* OPD Bit Fields */
+#define ENET_OPD_PAUSE_DUR_MASK                  0xFFFFu
+#define ENET_OPD_PAUSE_DUR_SHIFT                 0
+#define ENET_OPD_PAUSE_DUR(x)                    (((uint32_t)(((uint32_t)(x))<<ENET_OPD_PAUSE_DUR_SHIFT))&ENET_OPD_PAUSE_DUR_MASK)
+#define ENET_OPD_OPCODE_MASK                     0xFFFF0000u
+#define ENET_OPD_OPCODE_SHIFT                    16
+#define ENET_OPD_OPCODE(x)                       (((uint32_t)(((uint32_t)(x))<<ENET_OPD_OPCODE_SHIFT))&ENET_OPD_OPCODE_MASK)
+/* IAUR Bit Fields */
+#define ENET_IAUR_IADDR1_MASK                    0xFFFFFFFFu
+#define ENET_IAUR_IADDR1_SHIFT                   0
+#define ENET_IAUR_IADDR1(x)                      (((uint32_t)(((uint32_t)(x))<<ENET_IAUR_IADDR1_SHIFT))&ENET_IAUR_IADDR1_MASK)
+/* IALR Bit Fields */
+#define ENET_IALR_IADDR2_MASK                    0xFFFFFFFFu
+#define ENET_IALR_IADDR2_SHIFT                   0
+#define ENET_IALR_IADDR2(x)                      (((uint32_t)(((uint32_t)(x))<<ENET_IALR_IADDR2_SHIFT))&ENET_IALR_IADDR2_MASK)
+/* GAUR Bit Fields */
+#define ENET_GAUR_GADDR1_MASK                    0xFFFFFFFFu
+#define ENET_GAUR_GADDR1_SHIFT                   0
+#define ENET_GAUR_GADDR1(x)                      (((uint32_t)(((uint32_t)(x))<<ENET_GAUR_GADDR1_SHIFT))&ENET_GAUR_GADDR1_MASK)
+/* GALR Bit Fields */
+#define ENET_GALR_GADDR2_MASK                    0xFFFFFFFFu
+#define ENET_GALR_GADDR2_SHIFT                   0
+#define ENET_GALR_GADDR2(x)                      (((uint32_t)(((uint32_t)(x))<<ENET_GALR_GADDR2_SHIFT))&ENET_GALR_GADDR2_MASK)
+/* TFWR Bit Fields */
+#define ENET_TFWR_TFWR_MASK                      0x3Fu
+#define ENET_TFWR_TFWR_SHIFT                     0
+#define ENET_TFWR_TFWR(x)                        (((uint32_t)(((uint32_t)(x))<<ENET_TFWR_TFWR_SHIFT))&ENET_TFWR_TFWR_MASK)
+#define ENET_TFWR_STRFWD_MASK                    0x100u
+#define ENET_TFWR_STRFWD_SHIFT                   8
+/* RDSR Bit Fields */
+#define ENET_RDSR_R_DES_START_MASK               0xFFFFFFF8u
+#define ENET_RDSR_R_DES_START_SHIFT              3
+#define ENET_RDSR_R_DES_START(x)                 (((uint32_t)(((uint32_t)(x))<<ENET_RDSR_R_DES_START_SHIFT))&ENET_RDSR_R_DES_START_MASK)
+/* TDSR Bit Fields */
+#define ENET_TDSR_X_DES_START_MASK               0xFFFFFFF8u
+#define ENET_TDSR_X_DES_START_SHIFT              3
+#define ENET_TDSR_X_DES_START(x)                 (((uint32_t)(((uint32_t)(x))<<ENET_TDSR_X_DES_START_SHIFT))&ENET_TDSR_X_DES_START_MASK)
+/* MRBR Bit Fields */
+#define ENET_MRBR_R_BUF_SIZE_MASK                0x3FF0u
+#define ENET_MRBR_R_BUF_SIZE_SHIFT               4
+#define ENET_MRBR_R_BUF_SIZE(x)                  (((uint32_t)(((uint32_t)(x))<<ENET_MRBR_R_BUF_SIZE_SHIFT))&ENET_MRBR_R_BUF_SIZE_MASK)
+/* RSFL Bit Fields */
+#define ENET_RSFL_RX_SECTION_FULL_MASK           0xFFu
+#define ENET_RSFL_RX_SECTION_FULL_SHIFT          0
+#define ENET_RSFL_RX_SECTION_FULL(x)             (((uint32_t)(((uint32_t)(x))<<ENET_RSFL_RX_SECTION_FULL_SHIFT))&ENET_RSFL_RX_SECTION_FULL_MASK)
+/* RSEM Bit Fields */
+#define ENET_RSEM_RX_SECTION_EMPTY_MASK          0xFFu
+#define ENET_RSEM_RX_SECTION_EMPTY_SHIFT         0
+#define ENET_RSEM_RX_SECTION_EMPTY(x)            (((uint32_t)(((uint32_t)(x))<<ENET_RSEM_RX_SECTION_EMPTY_SHIFT))&ENET_RSEM_RX_SECTION_EMPTY_MASK)
+#define ENET_RSEM_STAT_SECTION_EMPTY_MASK        0x1F0000u
+#define ENET_RSEM_STAT_SECTION_EMPTY_SHIFT       16
+#define ENET_RSEM_STAT_SECTION_EMPTY(x)          (((uint32_t)(((uint32_t)(x))<<ENET_RSEM_STAT_SECTION_EMPTY_SHIFT))&ENET_RSEM_STAT_SECTION_EMPTY_MASK)
+/* RAEM Bit Fields */
+#define ENET_RAEM_RX_ALMOST_EMPTY_MASK           0xFFu
+#define ENET_RAEM_RX_ALMOST_EMPTY_SHIFT          0
+#define ENET_RAEM_RX_ALMOST_EMPTY(x)             (((uint32_t)(((uint32_t)(x))<<ENET_RAEM_RX_ALMOST_EMPTY_SHIFT))&ENET_RAEM_RX_ALMOST_EMPTY_MASK)
+/* RAFL Bit Fields */
+#define ENET_RAFL_RX_ALMOST_FULL_MASK            0xFFu
+#define ENET_RAFL_RX_ALMOST_FULL_SHIFT           0
+#define ENET_RAFL_RX_ALMOST_FULL(x)              (((uint32_t)(((uint32_t)(x))<<ENET_RAFL_RX_ALMOST_FULL_SHIFT))&ENET_RAFL_RX_ALMOST_FULL_MASK)
+/* TSEM Bit Fields */
+#define ENET_TSEM_TX_SECTION_EMPTY_MASK          0xFFu
+#define ENET_TSEM_TX_SECTION_EMPTY_SHIFT         0
+#define ENET_TSEM_TX_SECTION_EMPTY(x)            (((uint32_t)(((uint32_t)(x))<<ENET_TSEM_TX_SECTION_EMPTY_SHIFT))&ENET_TSEM_TX_SECTION_EMPTY_MASK)
+/* TAEM Bit Fields */
+#define ENET_TAEM_TX_ALMOST_EMPTY_MASK           0xFFu
+#define ENET_TAEM_TX_ALMOST_EMPTY_SHIFT          0
+#define ENET_TAEM_TX_ALMOST_EMPTY(x)             (((uint32_t)(((uint32_t)(x))<<ENET_TAEM_TX_ALMOST_EMPTY_SHIFT))&ENET_TAEM_TX_ALMOST_EMPTY_MASK)
+/* TAFL Bit Fields */
+#define ENET_TAFL_TX_ALMOST_FULL_MASK            0xFFu
+#define ENET_TAFL_TX_ALMOST_FULL_SHIFT           0
+#define ENET_TAFL_TX_ALMOST_FULL(x)              (((uint32_t)(((uint32_t)(x))<<ENET_TAFL_TX_ALMOST_FULL_SHIFT))&ENET_TAFL_TX_ALMOST_FULL_MASK)
+/* TIPG Bit Fields */
+#define ENET_TIPG_IPG_MASK                       0x1Fu
+#define ENET_TIPG_IPG_SHIFT                      0
+#define ENET_TIPG_IPG(x)                         (((uint32_t)(((uint32_t)(x))<<ENET_TIPG_IPG_SHIFT))&ENET_TIPG_IPG_MASK)
+/* FTRL Bit Fields */
+#define ENET_FTRL_TRUNC_FL_MASK                  0x3FFFu
+#define ENET_FTRL_TRUNC_FL_SHIFT                 0
+#define ENET_FTRL_TRUNC_FL(x)                    (((uint32_t)(((uint32_t)(x))<<ENET_FTRL_TRUNC_FL_SHIFT))&ENET_FTRL_TRUNC_FL_MASK)
+/* TACC Bit Fields */
+#define ENET_TACC_SHIFT16_MASK                   0x1u
+#define ENET_TACC_SHIFT16_SHIFT                  0
+#define ENET_TACC_IPCHK_MASK                     0x8u
+#define ENET_TACC_IPCHK_SHIFT                    3
+#define ENET_TACC_PROCHK_MASK                    0x10u
+#define ENET_TACC_PROCHK_SHIFT                   4
+/* RACC Bit Fields */
+#define ENET_RACC_PADREM_MASK                    0x1u
+#define ENET_RACC_PADREM_SHIFT                   0
+#define ENET_RACC_IPDIS_MASK                     0x2u
+#define ENET_RACC_IPDIS_SHIFT                    1
+#define ENET_RACC_PRODIS_MASK                    0x4u
+#define ENET_RACC_PRODIS_SHIFT                   2
+#define ENET_RACC_LINEDIS_MASK                   0x40u
+#define ENET_RACC_LINEDIS_SHIFT                  6
+#define ENET_RACC_SHIFT16_MASK                   0x80u
+#define ENET_RACC_SHIFT16_SHIFT                  7
+/* RMON_T_PACKETS Bit Fields */
+#define ENET_RMON_T_PACKETS_TXPKTS_MASK          0xFFFFu
+#define ENET_RMON_T_PACKETS_TXPKTS_SHIFT         0
+#define ENET_RMON_T_PACKETS_TXPKTS(x)            (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_PACKETS_TXPKTS_SHIFT))&ENET_RMON_T_PACKETS_TXPKTS_MASK)
+/* RMON_T_BC_PKT Bit Fields */
+#define ENET_RMON_T_BC_PKT_TXPKTS_MASK           0xFFFFu
+#define ENET_RMON_T_BC_PKT_TXPKTS_SHIFT          0
+#define ENET_RMON_T_BC_PKT_TXPKTS(x)             (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_BC_PKT_TXPKTS_SHIFT))&ENET_RMON_T_BC_PKT_TXPKTS_MASK)
+/* RMON_T_MC_PKT Bit Fields */
+#define ENET_RMON_T_MC_PKT_TXPKTS_MASK           0xFFFFu
+#define ENET_RMON_T_MC_PKT_TXPKTS_SHIFT          0
+#define ENET_RMON_T_MC_PKT_TXPKTS(x)             (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_MC_PKT_TXPKTS_SHIFT))&ENET_RMON_T_MC_PKT_TXPKTS_MASK)
+/* RMON_T_CRC_ALIGN Bit Fields */
+#define ENET_RMON_T_CRC_ALIGN_TXPKTS_MASK        0xFFFFu
+#define ENET_RMON_T_CRC_ALIGN_TXPKTS_SHIFT       0
+#define ENET_RMON_T_CRC_ALIGN_TXPKTS(x)          (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_CRC_ALIGN_TXPKTS_SHIFT))&ENET_RMON_T_CRC_ALIGN_TXPKTS_MASK)
+/* RMON_T_UNDERSIZE Bit Fields */
+#define ENET_RMON_T_UNDERSIZE_TXPKTS_MASK        0xFFFFu
+#define ENET_RMON_T_UNDERSIZE_TXPKTS_SHIFT       0
+#define ENET_RMON_T_UNDERSIZE_TXPKTS(x)          (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_UNDERSIZE_TXPKTS_SHIFT))&ENET_RMON_T_UNDERSIZE_TXPKTS_MASK)
+/* RMON_T_OVERSIZE Bit Fields */
+#define ENET_RMON_T_OVERSIZE_TXPKTS_MASK         0xFFFFu
+#define ENET_RMON_T_OVERSIZE_TXPKTS_SHIFT        0
+#define ENET_RMON_T_OVERSIZE_TXPKTS(x)           (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_OVERSIZE_TXPKTS_SHIFT))&ENET_RMON_T_OVERSIZE_TXPKTS_MASK)
+/* RMON_T_FRAG Bit Fields */
+#define ENET_RMON_T_FRAG_TXPKTS_MASK             0xFFFFu
+#define ENET_RMON_T_FRAG_TXPKTS_SHIFT            0
+#define ENET_RMON_T_FRAG_TXPKTS(x)               (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_FRAG_TXPKTS_SHIFT))&ENET_RMON_T_FRAG_TXPKTS_MASK)
+/* RMON_T_JAB Bit Fields */
+#define ENET_RMON_T_JAB_TXPKTS_MASK              0xFFFFu
+#define ENET_RMON_T_JAB_TXPKTS_SHIFT             0
+#define ENET_RMON_T_JAB_TXPKTS(x)                (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_JAB_TXPKTS_SHIFT))&ENET_RMON_T_JAB_TXPKTS_MASK)
+/* RMON_T_COL Bit Fields */
+#define ENET_RMON_T_COL_TXPKTS_MASK              0xFFFFu
+#define ENET_RMON_T_COL_TXPKTS_SHIFT             0
+#define ENET_RMON_T_COL_TXPKTS(x)                (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_COL_TXPKTS_SHIFT))&ENET_RMON_T_COL_TXPKTS_MASK)
+/* RMON_T_P64 Bit Fields */
+#define ENET_RMON_T_P64_TXPKTS_MASK              0xFFFFu
+#define ENET_RMON_T_P64_TXPKTS_SHIFT             0
+#define ENET_RMON_T_P64_TXPKTS(x)                (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_P64_TXPKTS_SHIFT))&ENET_RMON_T_P64_TXPKTS_MASK)
+/* RMON_T_P65TO127 Bit Fields */
+#define ENET_RMON_T_P65TO127_TXPKTS_MASK         0xFFFFu
+#define ENET_RMON_T_P65TO127_TXPKTS_SHIFT        0
+#define ENET_RMON_T_P65TO127_TXPKTS(x)           (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_P65TO127_TXPKTS_SHIFT))&ENET_RMON_T_P65TO127_TXPKTS_MASK)
+/* RMON_T_P128TO255 Bit Fields */
+#define ENET_RMON_T_P128TO255_TXPKTS_MASK        0xFFFFu
+#define ENET_RMON_T_P128TO255_TXPKTS_SHIFT       0
+#define ENET_RMON_T_P128TO255_TXPKTS(x)          (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_P128TO255_TXPKTS_SHIFT))&ENET_RMON_T_P128TO255_TXPKTS_MASK)
+/* RMON_T_P256TO511 Bit Fields */
+#define ENET_RMON_T_P256TO511_TXPKTS_MASK        0xFFFFu
+#define ENET_RMON_T_P256TO511_TXPKTS_SHIFT       0
+#define ENET_RMON_T_P256TO511_TXPKTS(x)          (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_P256TO511_TXPKTS_SHIFT))&ENET_RMON_T_P256TO511_TXPKTS_MASK)
+/* RMON_T_P512TO1023 Bit Fields */
+#define ENET_RMON_T_P512TO1023_TXPKTS_MASK       0xFFFFu
+#define ENET_RMON_T_P512TO1023_TXPKTS_SHIFT      0
+#define ENET_RMON_T_P512TO1023_TXPKTS(x)         (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_P512TO1023_TXPKTS_SHIFT))&ENET_RMON_T_P512TO1023_TXPKTS_MASK)
+/* RMON_T_P1024TO2047 Bit Fields */
+#define ENET_RMON_T_P1024TO2047_TXPKTS_MASK      0xFFFFu
+#define ENET_RMON_T_P1024TO2047_TXPKTS_SHIFT     0
+#define ENET_RMON_T_P1024TO2047_TXPKTS(x)        (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_P1024TO2047_TXPKTS_SHIFT))&ENET_RMON_T_P1024TO2047_TXPKTS_MASK)
+/* RMON_T_P_GTE2048 Bit Fields */
+#define ENET_RMON_T_P_GTE2048_TXPKTS_MASK        0xFFFFu
+#define ENET_RMON_T_P_GTE2048_TXPKTS_SHIFT       0
+#define ENET_RMON_T_P_GTE2048_TXPKTS(x)          (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_P_GTE2048_TXPKTS_SHIFT))&ENET_RMON_T_P_GTE2048_TXPKTS_MASK)
+/* RMON_T_OCTETS Bit Fields */
+#define ENET_RMON_T_OCTETS_TXOCTS_MASK           0xFFFFFFFFu
+#define ENET_RMON_T_OCTETS_TXOCTS_SHIFT          0
+#define ENET_RMON_T_OCTETS_TXOCTS(x)             (((uint32_t)(((uint32_t)(x))<<ENET_RMON_T_OCTETS_TXOCTS_SHIFT))&ENET_RMON_T_OCTETS_TXOCTS_MASK)
+/* IEEE_T_FRAME_OK Bit Fields */
+#define ENET_IEEE_T_FRAME_OK_COUNT_MASK          0xFFFFu
+#define ENET_IEEE_T_FRAME_OK_COUNT_SHIFT         0
+#define ENET_IEEE_T_FRAME_OK_COUNT(x)            (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_T_FRAME_OK_COUNT_SHIFT))&ENET_IEEE_T_FRAME_OK_COUNT_MASK)
+/* IEEE_T_1COL Bit Fields */
+#define ENET_IEEE_T_1COL_COUNT_MASK              0xFFFFu
+#define ENET_IEEE_T_1COL_COUNT_SHIFT             0
+#define ENET_IEEE_T_1COL_COUNT(x)                (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_T_1COL_COUNT_SHIFT))&ENET_IEEE_T_1COL_COUNT_MASK)
+/* IEEE_T_MCOL Bit Fields */
+#define ENET_IEEE_T_MCOL_COUNT_MASK              0xFFFFu
+#define ENET_IEEE_T_MCOL_COUNT_SHIFT             0
+#define ENET_IEEE_T_MCOL_COUNT(x)                (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_T_MCOL_COUNT_SHIFT))&ENET_IEEE_T_MCOL_COUNT_MASK)
+/* IEEE_T_DEF Bit Fields */
+#define ENET_IEEE_T_DEF_COUNT_MASK               0xFFFFu
+#define ENET_IEEE_T_DEF_COUNT_SHIFT              0
+#define ENET_IEEE_T_DEF_COUNT(x)                 (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_T_DEF_COUNT_SHIFT))&ENET_IEEE_T_DEF_COUNT_MASK)
+/* IEEE_T_LCOL Bit Fields */
+#define ENET_IEEE_T_LCOL_COUNT_MASK              0xFFFFu
+#define ENET_IEEE_T_LCOL_COUNT_SHIFT             0
+#define ENET_IEEE_T_LCOL_COUNT(x)                (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_T_LCOL_COUNT_SHIFT))&ENET_IEEE_T_LCOL_COUNT_MASK)
+/* IEEE_T_EXCOL Bit Fields */
+#define ENET_IEEE_T_EXCOL_COUNT_MASK             0xFFFFu
+#define ENET_IEEE_T_EXCOL_COUNT_SHIFT            0
+#define ENET_IEEE_T_EXCOL_COUNT(x)               (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_T_EXCOL_COUNT_SHIFT))&ENET_IEEE_T_EXCOL_COUNT_MASK)
+/* IEEE_T_MACERR Bit Fields */
+#define ENET_IEEE_T_MACERR_COUNT_MASK            0xFFFFu
+#define ENET_IEEE_T_MACERR_COUNT_SHIFT           0
+#define ENET_IEEE_T_MACERR_COUNT(x)              (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_T_MACERR_COUNT_SHIFT))&ENET_IEEE_T_MACERR_COUNT_MASK)
+/* IEEE_T_CSERR Bit Fields */
+#define ENET_IEEE_T_CSERR_COUNT_MASK             0xFFFFu
+#define ENET_IEEE_T_CSERR_COUNT_SHIFT            0
+#define ENET_IEEE_T_CSERR_COUNT(x)               (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_T_CSERR_COUNT_SHIFT))&ENET_IEEE_T_CSERR_COUNT_MASK)
+/* IEEE_T_FDXFC Bit Fields */
+#define ENET_IEEE_T_FDXFC_COUNT_MASK             0xFFFFu
+#define ENET_IEEE_T_FDXFC_COUNT_SHIFT            0
+#define ENET_IEEE_T_FDXFC_COUNT(x)               (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_T_FDXFC_COUNT_SHIFT))&ENET_IEEE_T_FDXFC_COUNT_MASK)
+/* IEEE_T_OCTETS_OK Bit Fields */
+#define ENET_IEEE_T_OCTETS_OK_COUNT_MASK         0xFFFFFFFFu
+#define ENET_IEEE_T_OCTETS_OK_COUNT_SHIFT        0
+#define ENET_IEEE_T_OCTETS_OK_COUNT(x)           (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_T_OCTETS_OK_COUNT_SHIFT))&ENET_IEEE_T_OCTETS_OK_COUNT_MASK)
+/* RMON_R_PACKETS Bit Fields */
+#define ENET_RMON_R_PACKETS_COUNT_MASK           0xFFFFu
+#define ENET_RMON_R_PACKETS_COUNT_SHIFT          0
+#define ENET_RMON_R_PACKETS_COUNT(x)             (((uint32_t)(((uint32_t)(x))<<ENET_RMON_R_PACKETS_COUNT_SHIFT))&ENET_RMON_R_PACKETS_COUNT_MASK)
+/* RMON_R_BC_PKT Bit Fields */
+#define ENET_RMON_R_BC_PKT_COUNT_MASK            0xFFFFu
+#define ENET_RMON_R_BC_PKT_COUNT_SHIFT           0
+#define ENET_RMON_R_BC_PKT_COUNT(x)              (((uint32_t)(((uint32_t)(x))<<ENET_RMON_R_BC_PKT_COUNT_SHIFT))&ENET_RMON_R_BC_PKT_COUNT_MASK)
+/* RMON_R_MC_PKT Bit Fields */
+#define ENET_RMON_R_MC_PKT_COUNT_MASK            0xFFFFu
+#define ENET_RMON_R_MC_PKT_COUNT_SHIFT           0
+#define ENET_RMON_R_MC_PKT_COUNT(x)              (((uint32_t)(((uint32_t)(x))<<ENET_RMON_R_MC_PKT_COUNT_SHIFT))&ENET_RMON_R_MC_PKT_COUNT_MASK)
+/* RMON_R_CRC_ALIGN Bit Fields */
+#define ENET_RMON_R_CRC_ALIGN_COUNT_MASK         0xFFFFu
+#define ENET_RMON_R_CRC_ALIGN_COUNT_SHIFT        0
+#define ENET_RMON_R_CRC_ALIGN_COUNT(x)           (((uint32_t)(((uint32_t)(x))<<ENET_RMON_R_CRC_ALIGN_COUNT_SHIFT))&ENET_RMON_R_CRC_ALIGN_COUNT_MASK)
+/* RMON_R_UNDERSIZE Bit Fields */
+#define ENET_RMON_R_UNDERSIZE_COUNT_MASK         0xFFFFu
+#define ENET_RMON_R_UNDERSIZE_COUNT_SHIFT        0
+#define ENET_RMON_R_UNDERSIZE_COUNT(x)           (((uint32_t)(((uint32_t)(x))<<ENET_RMON_R_UNDERSIZE_COUNT_SHIFT))&ENET_RMON_R_UNDERSIZE_COUNT_MASK)
+/* RMON_R_OVERSIZE Bit Fields */
+#define ENET_RMON_R_OVERSIZE_COUNT_MASK          0xFFFFu
+#define ENET_RMON_R_OVERSIZE_COUNT_SHIFT         0
+#define ENET_RMON_R_OVERSIZE_COUNT(x)            (((uint32_t)(((uint32_t)(x))<<ENET_RMON_R_OVERSIZE_COUNT_SHIFT))&ENET_RMON_R_OVERSIZE_COUNT_MASK)
+/* RMON_R_FRAG Bit Fields */
+#define ENET_RMON_R_FRAG_COUNT_MASK              0xFFFFu
+#define ENET_RMON_R_FRAG_COUNT_SHIFT             0
+#define ENET_RMON_R_FRAG_COUNT(x)                (((uint32_t)(((uint32_t)(x))<<ENET_RMON_R_FRAG_COUNT_SHIFT))&ENET_RMON_R_FRAG_COUNT_MASK)
+/* RMON_R_JAB Bit Fields */
+#define ENET_RMON_R_JAB_COUNT_MASK               0xFFFFu
+#define ENET_RMON_R_JAB_COUNT_SHIFT              0
+#define ENET_RMON_R_JAB_COUNT(x)                 (((uint32_t)(((uint32_t)(x))<<ENET_RMON_R_JAB_COUNT_SHIFT))&ENET_RMON_R_JAB_COUNT_MASK)
+/* RMON_R_P64 Bit Fields */
+#define ENET_RMON_R_P64_COUNT_MASK               0xFFFFu
+#define ENET_RMON_R_P64_COUNT_SHIFT              0
+#define ENET_RMON_R_P64_COUNT(x)                 (((uint32_t)(((uint32_t)(x))<<ENET_RMON_R_P64_COUNT_SHIFT))&ENET_RMON_R_P64_COUNT_MASK)
+/* RMON_R_P65TO127 Bit Fields */
+#define ENET_RMON_R_P65TO127_COUNT_MASK          0xFFFFu
+#define ENET_RMON_R_P65TO127_COUNT_SHIFT         0
+#define ENET_RMON_R_P65TO127_COUNT(x)            (((uint32_t)(((uint32_t)(x))<<ENET_RMON_R_P65TO127_COUNT_SHIFT))&ENET_RMON_R_P65TO127_COUNT_MASK)
+/* RMON_R_P128TO255 Bit Fields */
+#define ENET_RMON_R_P128TO255_COUNT_MASK         0xFFFFu
+#define ENET_RMON_R_P128TO255_COUNT_SHIFT        0
+#define ENET_RMON_R_P128TO255_COUNT(x)           (((uint32_t)(((uint32_t)(x))<<ENET_RMON_R_P128TO255_COUNT_SHIFT))&ENET_RMON_R_P128TO255_COUNT_MASK)
+/* RMON_R_P256TO511 Bit Fields */
+#define ENET_RMON_R_P256TO511_COUNT_MASK         0xFFFFu
+#define ENET_RMON_R_P256TO511_COUNT_SHIFT        0
+#define ENET_RMON_R_P256TO511_COUNT(x)           (((uint32_t)(((uint32_t)(x))<<ENET_RMON_R_P256TO511_COUNT_SHIFT))&ENET_RMON_R_P256TO511_COUNT_MASK)
+/* RMON_R_P512TO1023 Bit Fields */
+#define ENET_RMON_R_P512TO1023_COUNT_MASK        0xFFFFu
+#define ENET_RMON_R_P512TO1023_COUNT_SHIFT       0
+#define ENET_RMON_R_P512TO1023_COUNT(x)          (((uint32_t)(((uint32_t)(x))<<ENET_RMON_R_P512TO1023_COUNT_SHIFT))&ENET_RMON_R_P512TO1023_COUNT_MASK)
+/* RMON_R_P1024TO2047 Bit Fields */
+#define ENET_RMON_R_P1024TO2047_COUNT_MASK       0xFFFFu
+#define ENET_RMON_R_P1024TO2047_COUNT_SHIFT      0
+#define ENET_RMON_R_P1024TO2047_COUNT(x)         (((uint32_t)(((uint32_t)(x))<<ENET_RMON_R_P1024TO2047_COUNT_SHIFT))&ENET_RMON_R_P1024TO2047_COUNT_MASK)
+/* RMON_R_P_GTE2048 Bit Fields */
+#define ENET_RMON_R_P_GTE2048_COUNT_MASK         0xFFFFu
+#define ENET_RMON_R_P_GTE2048_COUNT_SHIFT        0
+#define ENET_RMON_R_P_GTE2048_COUNT(x)           (((uint32_t)(((uint32_t)(x))<<ENET_RMON_R_P_GTE2048_COUNT_SHIFT))&ENET_RMON_R_P_GTE2048_COUNT_MASK)
+/* RMON_R_OCTETS Bit Fields */
+#define ENET_RMON_R_OCTETS_COUNT_MASK            0xFFFFFFFFu
+#define ENET_RMON_R_OCTETS_COUNT_SHIFT           0
+#define ENET_RMON_R_OCTETS_COUNT(x)              (((uint32_t)(((uint32_t)(x))<<ENET_RMON_R_OCTETS_COUNT_SHIFT))&ENET_RMON_R_OCTETS_COUNT_MASK)
+/* IEEE_R_DROP Bit Fields */
+#define ENET_IEEE_R_DROP_COUNT_MASK              0xFFFFu
+#define ENET_IEEE_R_DROP_COUNT_SHIFT             0
+#define ENET_IEEE_R_DROP_COUNT(x)                (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_R_DROP_COUNT_SHIFT))&ENET_IEEE_R_DROP_COUNT_MASK)
+/* IEEE_R_FRAME_OK Bit Fields */
+#define ENET_IEEE_R_FRAME_OK_COUNT_MASK          0xFFFFu
+#define ENET_IEEE_R_FRAME_OK_COUNT_SHIFT         0
+#define ENET_IEEE_R_FRAME_OK_COUNT(x)            (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_R_FRAME_OK_COUNT_SHIFT))&ENET_IEEE_R_FRAME_OK_COUNT_MASK)
+/* IEEE_R_CRC Bit Fields */
+#define ENET_IEEE_R_CRC_COUNT_MASK               0xFFFFu
+#define ENET_IEEE_R_CRC_COUNT_SHIFT              0
+#define ENET_IEEE_R_CRC_COUNT(x)                 (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_R_CRC_COUNT_SHIFT))&ENET_IEEE_R_CRC_COUNT_MASK)
+/* IEEE_R_ALIGN Bit Fields */
+#define ENET_IEEE_R_ALIGN_COUNT_MASK             0xFFFFu
+#define ENET_IEEE_R_ALIGN_COUNT_SHIFT            0
+#define ENET_IEEE_R_ALIGN_COUNT(x)               (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_R_ALIGN_COUNT_SHIFT))&ENET_IEEE_R_ALIGN_COUNT_MASK)
+/* IEEE_R_MACERR Bit Fields */
+#define ENET_IEEE_R_MACERR_COUNT_MASK            0xFFFFu
+#define ENET_IEEE_R_MACERR_COUNT_SHIFT           0
+#define ENET_IEEE_R_MACERR_COUNT(x)              (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_R_MACERR_COUNT_SHIFT))&ENET_IEEE_R_MACERR_COUNT_MASK)
+/* IEEE_R_FDXFC Bit Fields */
+#define ENET_IEEE_R_FDXFC_COUNT_MASK             0xFFFFu
+#define ENET_IEEE_R_FDXFC_COUNT_SHIFT            0
+#define ENET_IEEE_R_FDXFC_COUNT(x)               (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_R_FDXFC_COUNT_SHIFT))&ENET_IEEE_R_FDXFC_COUNT_MASK)
+/* IEEE_R_OCTETS_OK Bit Fields */
+#define ENET_IEEE_R_OCTETS_OK_COUNT_MASK         0xFFFFFFFFu
+#define ENET_IEEE_R_OCTETS_OK_COUNT_SHIFT        0
+#define ENET_IEEE_R_OCTETS_OK_COUNT(x)           (((uint32_t)(((uint32_t)(x))<<ENET_IEEE_R_OCTETS_OK_COUNT_SHIFT))&ENET_IEEE_R_OCTETS_OK_COUNT_MASK)
+/* ATCR Bit Fields */
+#define ENET_ATCR_EN_MASK                        0x1u
+#define ENET_ATCR_EN_SHIFT                       0
+#define ENET_ATCR_OFFEN_MASK                     0x4u
+#define ENET_ATCR_OFFEN_SHIFT                    2
+#define ENET_ATCR_OFFRST_MASK                    0x8u
+#define ENET_ATCR_OFFRST_SHIFT                   3
+#define ENET_ATCR_PEREN_MASK                     0x10u
+#define ENET_ATCR_PEREN_SHIFT                    4
+#define ENET_ATCR_PINPER_MASK                    0x80u
+#define ENET_ATCR_PINPER_SHIFT                   7
+#define ENET_ATCR_RESTART_MASK                   0x200u
+#define ENET_ATCR_RESTART_SHIFT                  9
+#define ENET_ATCR_CAPTURE_MASK                   0x800u
+#define ENET_ATCR_CAPTURE_SHIFT                  11
+#define ENET_ATCR_SLAVE_MASK                     0x2000u
+#define ENET_ATCR_SLAVE_SHIFT                    13
+/* ATVR Bit Fields */
+#define ENET_ATVR_ATIME_MASK                     0xFFFFFFFFu
+#define ENET_ATVR_ATIME_SHIFT                    0
+#define ENET_ATVR_ATIME(x)                       (((uint32_t)(((uint32_t)(x))<<ENET_ATVR_ATIME_SHIFT))&ENET_ATVR_ATIME_MASK)
+/* ATOFF Bit Fields */
+#define ENET_ATOFF_OFFSET_MASK                   0xFFFFFFFFu
+#define ENET_ATOFF_OFFSET_SHIFT                  0
+#define ENET_ATOFF_OFFSET(x)                     (((uint32_t)(((uint32_t)(x))<<ENET_ATOFF_OFFSET_SHIFT))&ENET_ATOFF_OFFSET_MASK)
+/* ATPER Bit Fields */
+#define ENET_ATPER_PERIOD_MASK                   0xFFFFFFFFu
+#define ENET_ATPER_PERIOD_SHIFT                  0
+#define ENET_ATPER_PERIOD(x)                     (((uint32_t)(((uint32_t)(x))<<ENET_ATPER_PERIOD_SHIFT))&ENET_ATPER_PERIOD_MASK)
+/* ATCOR Bit Fields */
+#define ENET_ATCOR_COR_MASK                      0x7FFFFFFFu
+#define ENET_ATCOR_COR_SHIFT                     0
+#define ENET_ATCOR_COR(x)                        (((uint32_t)(((uint32_t)(x))<<ENET_ATCOR_COR_SHIFT))&ENET_ATCOR_COR_MASK)
+/* ATINC Bit Fields */
+#define ENET_ATINC_INC_MASK                      0x7Fu
+#define ENET_ATINC_INC_SHIFT                     0
+#define ENET_ATINC_INC(x)                        (((uint32_t)(((uint32_t)(x))<<ENET_ATINC_INC_SHIFT))&ENET_ATINC_INC_MASK)
+#define ENET_ATINC_INC_CORR_MASK                 0x7F00u
+#define ENET_ATINC_INC_CORR_SHIFT                8
+#define ENET_ATINC_INC_CORR(x)                   (((uint32_t)(((uint32_t)(x))<<ENET_ATINC_INC_CORR_SHIFT))&ENET_ATINC_INC_CORR_MASK)
+/* ATSTMP Bit Fields */
+#define ENET_ATSTMP_TIMESTAMP_MASK               0xFFFFFFFFu
+#define ENET_ATSTMP_TIMESTAMP_SHIFT              0
+#define ENET_ATSTMP_TIMESTAMP(x)                 (((uint32_t)(((uint32_t)(x))<<ENET_ATSTMP_TIMESTAMP_SHIFT))&ENET_ATSTMP_TIMESTAMP_MASK)
+/* TGSR Bit Fields */
+#define ENET_TGSR_TF0_MASK                       0x1u
+#define ENET_TGSR_TF0_SHIFT                      0
+#define ENET_TGSR_TF1_MASK                       0x2u
+#define ENET_TGSR_TF1_SHIFT                      1
+#define ENET_TGSR_TF2_MASK                       0x4u
+#define ENET_TGSR_TF2_SHIFT                      2
+#define ENET_TGSR_TF3_MASK                       0x8u
+#define ENET_TGSR_TF3_SHIFT                      3
+/* TCSR Bit Fields */
+#define ENET_TCSR_TDRE_MASK                      0x1u
+#define ENET_TCSR_TDRE_SHIFT                     0
+#define ENET_TCSR_TMODE_MASK                     0x3Cu
+#define ENET_TCSR_TMODE_SHIFT                    2
+#define ENET_TCSR_TMODE(x)                       (((uint32_t)(((uint32_t)(x))<<ENET_TCSR_TMODE_SHIFT))&ENET_TCSR_TMODE_MASK)
+#define ENET_TCSR_TIE_MASK                       0x40u
+#define ENET_TCSR_TIE_SHIFT                      6
+#define ENET_TCSR_TF_MASK                        0x80u
+#define ENET_TCSR_TF_SHIFT                       7
+/* TCCR Bit Fields */
+#define ENET_TCCR_TCC_MASK                       0xFFFFFFFFu
+#define ENET_TCCR_TCC_SHIFT                      0
+#define ENET_TCCR_TCC(x)                         (((uint32_t)(((uint32_t)(x))<<ENET_TCCR_TCC_SHIFT))&ENET_TCCR_TCC_MASK)
+
+/*!
+ * @}
+ */ /* end of group ENET_Register_Masks */
+
+
+/* ENET - Peripheral instance base addresses */
+/** Peripheral ENET base address */
+#define ENET_BASE                                (0x400C0000u)
+/** Peripheral ENET base pointer */
+#define ENET                                     ((ENET_Type *)ENET_BASE)
+#define ENET_BASE_PTR                            (ENET)
+/** Array initializer of ENET peripheral base addresses */
+#define ENET_BASE_ADDRS                          { ENET_BASE }
+/** Array initializer of ENET peripheral base pointers */
+#define ENET_BASE_PTRS                           { ENET }
+/** Interrupt vectors for the ENET peripheral type */
+#define ENET_Transmit_IRQS                       { ENET_Transmit_IRQn }
+#define ENET_Receive_IRQS                        { ENET_Receive_IRQn }
+#define ENET_Error_IRQS                          { ENET_Error_IRQn }
+#define ENET_1588_Timer_IRQS                     { ENET_1588_Timer_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- ENET - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ENET_Register_Accessor_Macros ENET - Register accessor macros
+ * @{
+ */
+
+
+/* ENET - Register instance definitions */
+/* ENET */
+#define ENET_EIR                                 ENET_EIR_REG(ENET)
+#define ENET_EIMR                                ENET_EIMR_REG(ENET)
+#define ENET_RDAR                                ENET_RDAR_REG(ENET)
+#define ENET_TDAR                                ENET_TDAR_REG(ENET)
+#define ENET_ECR                                 ENET_ECR_REG(ENET)
+#define ENET_MMFR                                ENET_MMFR_REG(ENET)
+#define ENET_MSCR                                ENET_MSCR_REG(ENET)
+#define ENET_MIBC                                ENET_MIBC_REG(ENET)
+#define ENET_RCR                                 ENET_RCR_REG(ENET)
+#define ENET_TCR                                 ENET_TCR_REG(ENET)
+#define ENET_PALR                                ENET_PALR_REG(ENET)
+#define ENET_PAUR                                ENET_PAUR_REG(ENET)
+#define ENET_OPD                                 ENET_OPD_REG(ENET)
+#define ENET_IAUR                                ENET_IAUR_REG(ENET)
+#define ENET_IALR                                ENET_IALR_REG(ENET)
+#define ENET_GAUR                                ENET_GAUR_REG(ENET)
+#define ENET_GALR                                ENET_GALR_REG(ENET)
+#define ENET_TFWR                                ENET_TFWR_REG(ENET)
+#define ENET_RDSR                                ENET_RDSR_REG(ENET)
+#define ENET_TDSR                                ENET_TDSR_REG(ENET)
+#define ENET_MRBR                                ENET_MRBR_REG(ENET)
+#define ENET_RSFL                                ENET_RSFL_REG(ENET)
+#define ENET_RSEM                                ENET_RSEM_REG(ENET)
+#define ENET_RAEM                                ENET_RAEM_REG(ENET)
+#define ENET_RAFL                                ENET_RAFL_REG(ENET)
+#define ENET_TSEM                                ENET_TSEM_REG(ENET)
+#define ENET_TAEM                                ENET_TAEM_REG(ENET)
+#define ENET_TAFL                                ENET_TAFL_REG(ENET)
+#define ENET_TIPG                                ENET_TIPG_REG(ENET)
+#define ENET_FTRL                                ENET_FTRL_REG(ENET)
+#define ENET_TACC                                ENET_TACC_REG(ENET)
+#define ENET_RACC                                ENET_RACC_REG(ENET)
+#define ENET_RMON_T_PACKETS                      ENET_RMON_T_PACKETS_REG(ENET)
+#define ENET_RMON_T_BC_PKT                       ENET_RMON_T_BC_PKT_REG(ENET)
+#define ENET_RMON_T_MC_PKT                       ENET_RMON_T_MC_PKT_REG(ENET)
+#define ENET_RMON_T_CRC_ALIGN                    ENET_RMON_T_CRC_ALIGN_REG(ENET)
+#define ENET_RMON_T_UNDERSIZE                    ENET_RMON_T_UNDERSIZE_REG(ENET)
+#define ENET_RMON_T_OVERSIZE                     ENET_RMON_T_OVERSIZE_REG(ENET)
+#define ENET_RMON_T_FRAG                         ENET_RMON_T_FRAG_REG(ENET)
+#define ENET_RMON_T_JAB                          ENET_RMON_T_JAB_REG(ENET)
+#define ENET_RMON_T_COL                          ENET_RMON_T_COL_REG(ENET)
+#define ENET_RMON_T_P64                          ENET_RMON_T_P64_REG(ENET)
+#define ENET_RMON_T_P65TO127                     ENET_RMON_T_P65TO127_REG(ENET)
+#define ENET_RMON_T_P128TO255                    ENET_RMON_T_P128TO255_REG(ENET)
+#define ENET_RMON_T_P256TO511                    ENET_RMON_T_P256TO511_REG(ENET)
+#define ENET_RMON_T_P512TO1023                   ENET_RMON_T_P512TO1023_REG(ENET)
+#define ENET_RMON_T_P1024TO2047                  ENET_RMON_T_P1024TO2047_REG(ENET)
+#define ENET_RMON_T_P_GTE2048                    ENET_RMON_T_P_GTE2048_REG(ENET)
+#define ENET_RMON_T_OCTETS                       ENET_RMON_T_OCTETS_REG(ENET)
+#define ENET_IEEE_T_FRAME_OK                     ENET_IEEE_T_FRAME_OK_REG(ENET)
+#define ENET_IEEE_T_1COL                         ENET_IEEE_T_1COL_REG(ENET)
+#define ENET_IEEE_T_MCOL                         ENET_IEEE_T_MCOL_REG(ENET)
+#define ENET_IEEE_T_DEF                          ENET_IEEE_T_DEF_REG(ENET)
+#define ENET_IEEE_T_LCOL                         ENET_IEEE_T_LCOL_REG(ENET)
+#define ENET_IEEE_T_EXCOL                        ENET_IEEE_T_EXCOL_REG(ENET)
+#define ENET_IEEE_T_MACERR                       ENET_IEEE_T_MACERR_REG(ENET)
+#define ENET_IEEE_T_CSERR                        ENET_IEEE_T_CSERR_REG(ENET)
+#define ENET_IEEE_T_FDXFC                        ENET_IEEE_T_FDXFC_REG(ENET)
+#define ENET_IEEE_T_OCTETS_OK                    ENET_IEEE_T_OCTETS_OK_REG(ENET)
+#define ENET_RMON_R_PACKETS                      ENET_RMON_R_PACKETS_REG(ENET)
+#define ENET_RMON_R_BC_PKT                       ENET_RMON_R_BC_PKT_REG(ENET)
+#define ENET_RMON_R_MC_PKT                       ENET_RMON_R_MC_PKT_REG(ENET)
+#define ENET_RMON_R_CRC_ALIGN                    ENET_RMON_R_CRC_ALIGN_REG(ENET)
+#define ENET_RMON_R_UNDERSIZE                    ENET_RMON_R_UNDERSIZE_REG(ENET)
+#define ENET_RMON_R_OVERSIZE                     ENET_RMON_R_OVERSIZE_REG(ENET)
+#define ENET_RMON_R_FRAG                         ENET_RMON_R_FRAG_REG(ENET)
+#define ENET_RMON_R_JAB                          ENET_RMON_R_JAB_REG(ENET)
+#define ENET_RMON_R_P64                          ENET_RMON_R_P64_REG(ENET)
+#define ENET_RMON_R_P65TO127                     ENET_RMON_R_P65TO127_REG(ENET)
+#define ENET_RMON_R_P128TO255                    ENET_RMON_R_P128TO255_REG(ENET)
+#define ENET_RMON_R_P256TO511                    ENET_RMON_R_P256TO511_REG(ENET)
+#define ENET_RMON_R_P512TO1023                   ENET_RMON_R_P512TO1023_REG(ENET)
+#define ENET_RMON_R_P1024TO2047                  ENET_RMON_R_P1024TO2047_REG(ENET)
+#define ENET_RMON_R_P_GTE2048                    ENET_RMON_R_P_GTE2048_REG(ENET)
+#define ENET_RMON_R_OCTETS                       ENET_RMON_R_OCTETS_REG(ENET)
+#define ENET_IEEE_R_DROP                         ENET_IEEE_R_DROP_REG(ENET)
+#define ENET_IEEE_R_FRAME_OK                     ENET_IEEE_R_FRAME_OK_REG(ENET)
+#define ENET_IEEE_R_CRC                          ENET_IEEE_R_CRC_REG(ENET)
+#define ENET_IEEE_R_ALIGN                        ENET_IEEE_R_ALIGN_REG(ENET)
+#define ENET_IEEE_R_MACERR                       ENET_IEEE_R_MACERR_REG(ENET)
+#define ENET_IEEE_R_FDXFC                        ENET_IEEE_R_FDXFC_REG(ENET)
+#define ENET_IEEE_R_OCTETS_OK                    ENET_IEEE_R_OCTETS_OK_REG(ENET)
+#define ENET_ATCR                                ENET_ATCR_REG(ENET)
+#define ENET_ATVR                                ENET_ATVR_REG(ENET)
+#define ENET_ATOFF                               ENET_ATOFF_REG(ENET)
+#define ENET_ATPER                               ENET_ATPER_REG(ENET)
+#define ENET_ATCOR                               ENET_ATCOR_REG(ENET)
+#define ENET_ATINC                               ENET_ATINC_REG(ENET)
+#define ENET_ATSTMP                              ENET_ATSTMP_REG(ENET)
+#define ENET_TGSR                                ENET_TGSR_REG(ENET)
+#define ENET_TCSR0                               ENET_TCSR_REG(ENET,0)
+#define ENET_TCCR0                               ENET_TCCR_REG(ENET,0)
+#define ENET_TCSR1                               ENET_TCSR_REG(ENET,1)
+#define ENET_TCCR1                               ENET_TCCR_REG(ENET,1)
+#define ENET_TCSR2                               ENET_TCSR_REG(ENET,2)
+#define ENET_TCCR2                               ENET_TCCR_REG(ENET,2)
+#define ENET_TCSR3                               ENET_TCSR_REG(ENET,3)
+#define ENET_TCCR3                               ENET_TCCR_REG(ENET,3)
+
+/* ENET - Register array accessors */
+#define ENET_TCSR(index)                         ENET_TCSR_REG(ENET,index)
+#define ENET_TCCR(index)                         ENET_TCCR_REG(ENET,index)
+
+/*!
+ * @}
+ */ /* end of group ENET_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group ENET_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- EWM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup EWM_Peripheral_Access_Layer EWM Peripheral Access Layer
+ * @{
+ */
+
+/** EWM - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t CTRL;                               /**< Control Register, offset: 0x0 */
+  __O  uint8_t SERV;                               /**< Service Register, offset: 0x1 */
+  __IO uint8_t CMPL;                               /**< Compare Low Register, offset: 0x2 */
+  __IO uint8_t CMPH;                               /**< Compare High Register, offset: 0x3 */
+} EWM_Type, *EWM_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- EWM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup EWM_Register_Accessor_Macros EWM - Register accessor macros
+ * @{
+ */
+
+
+/* EWM - Register accessors */
+#define EWM_CTRL_REG(base)                       ((base)->CTRL)
+#define EWM_SERV_REG(base)                       ((base)->SERV)
+#define EWM_CMPL_REG(base)                       ((base)->CMPL)
+#define EWM_CMPH_REG(base)                       ((base)->CMPH)
+
+/*!
+ * @}
+ */ /* end of group EWM_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- EWM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup EWM_Register_Masks EWM Register Masks
+ * @{
+ */
+
+/* CTRL Bit Fields */
+#define EWM_CTRL_EWMEN_MASK                      0x1u
+#define EWM_CTRL_EWMEN_SHIFT                     0
+#define EWM_CTRL_ASSIN_MASK                      0x2u
+#define EWM_CTRL_ASSIN_SHIFT                     1
+#define EWM_CTRL_INEN_MASK                       0x4u
+#define EWM_CTRL_INEN_SHIFT                      2
+#define EWM_CTRL_INTEN_MASK                      0x8u
+#define EWM_CTRL_INTEN_SHIFT                     3
+/* SERV Bit Fields */
+#define EWM_SERV_SERVICE_MASK                    0xFFu
+#define EWM_SERV_SERVICE_SHIFT                   0
+#define EWM_SERV_SERVICE(x)                      (((uint8_t)(((uint8_t)(x))<<EWM_SERV_SERVICE_SHIFT))&EWM_SERV_SERVICE_MASK)
+/* CMPL Bit Fields */
+#define EWM_CMPL_COMPAREL_MASK                   0xFFu
+#define EWM_CMPL_COMPAREL_SHIFT                  0
+#define EWM_CMPL_COMPAREL(x)                     (((uint8_t)(((uint8_t)(x))<<EWM_CMPL_COMPAREL_SHIFT))&EWM_CMPL_COMPAREL_MASK)
+/* CMPH Bit Fields */
+#define EWM_CMPH_COMPAREH_MASK                   0xFFu
+#define EWM_CMPH_COMPAREH_SHIFT                  0
+#define EWM_CMPH_COMPAREH(x)                     (((uint8_t)(((uint8_t)(x))<<EWM_CMPH_COMPAREH_SHIFT))&EWM_CMPH_COMPAREH_MASK)
+
+/*!
+ * @}
+ */ /* end of group EWM_Register_Masks */
+
+
+/* EWM - Peripheral instance base addresses */
+/** Peripheral EWM base address */
+#define EWM_BASE                                 (0x40061000u)
+/** Peripheral EWM base pointer */
+#define EWM                                      ((EWM_Type *)EWM_BASE)
+#define EWM_BASE_PTR                             (EWM)
+/** Array initializer of EWM peripheral base addresses */
+#define EWM_BASE_ADDRS                           { EWM_BASE }
+/** Array initializer of EWM peripheral base pointers */
+#define EWM_BASE_PTRS                            { EWM }
+/** Interrupt vectors for the EWM peripheral type */
+#define EWM_IRQS                                 { Watchdog_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- EWM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup EWM_Register_Accessor_Macros EWM - Register accessor macros
+ * @{
+ */
+
+
+/* EWM - Register instance definitions */
+/* EWM */
+#define EWM_CTRL                                 EWM_CTRL_REG(EWM)
+#define EWM_SERV                                 EWM_SERV_REG(EWM)
+#define EWM_CMPL                                 EWM_CMPL_REG(EWM)
+#define EWM_CMPH                                 EWM_CMPH_REG(EWM)
+
+/*!
+ * @}
+ */ /* end of group EWM_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group EWM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- FB Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FB_Peripheral_Access_Layer FB Peripheral Access Layer
+ * @{
+ */
+
+/** FB - Register Layout Typedef */
+typedef struct {
+  struct {                                         /* offset: 0x0, array step: 0xC */
+    __IO uint32_t CSAR;                              /**< Chip Select Address Register, array offset: 0x0, array step: 0xC */
+    __IO uint32_t CSMR;                              /**< Chip Select Mask Register, array offset: 0x4, array step: 0xC */
+    __IO uint32_t CSCR;                              /**< Chip Select Control Register, array offset: 0x8, array step: 0xC */
+  } CS[6];
+       uint8_t RESERVED_0[24];
+  __IO uint32_t CSPMCR;                            /**< Chip Select port Multiplexing Control Register, offset: 0x60 */
+} FB_Type, *FB_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- FB - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FB_Register_Accessor_Macros FB - Register accessor macros
+ * @{
+ */
+
+
+/* FB - Register accessors */
+#define FB_CSAR_REG(base,index)                  ((base)->CS[index].CSAR)
+#define FB_CSMR_REG(base,index)                  ((base)->CS[index].CSMR)
+#define FB_CSCR_REG(base,index)                  ((base)->CS[index].CSCR)
+#define FB_CSPMCR_REG(base)                      ((base)->CSPMCR)
+
+/*!
+ * @}
+ */ /* end of group FB_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- FB Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FB_Register_Masks FB Register Masks
+ * @{
+ */
+
+/* CSAR Bit Fields */
+#define FB_CSAR_BA_MASK                          0xFFFF0000u
+#define FB_CSAR_BA_SHIFT                         16
+#define FB_CSAR_BA(x)                            (((uint32_t)(((uint32_t)(x))<<FB_CSAR_BA_SHIFT))&FB_CSAR_BA_MASK)
+/* CSMR Bit Fields */
+#define FB_CSMR_V_MASK                           0x1u
+#define FB_CSMR_V_SHIFT                          0
+#define FB_CSMR_WP_MASK                          0x100u
+#define FB_CSMR_WP_SHIFT                         8
+#define FB_CSMR_BAM_MASK                         0xFFFF0000u
+#define FB_CSMR_BAM_SHIFT                        16
+#define FB_CSMR_BAM(x)                           (((uint32_t)(((uint32_t)(x))<<FB_CSMR_BAM_SHIFT))&FB_CSMR_BAM_MASK)
+/* CSCR Bit Fields */
+#define FB_CSCR_BSTW_MASK                        0x8u
+#define FB_CSCR_BSTW_SHIFT                       3
+#define FB_CSCR_BSTR_MASK                        0x10u
+#define FB_CSCR_BSTR_SHIFT                       4
+#define FB_CSCR_BEM_MASK                         0x20u
+#define FB_CSCR_BEM_SHIFT                        5
+#define FB_CSCR_PS_MASK                          0xC0u
+#define FB_CSCR_PS_SHIFT                         6
+#define FB_CSCR_PS(x)                            (((uint32_t)(((uint32_t)(x))<<FB_CSCR_PS_SHIFT))&FB_CSCR_PS_MASK)
+#define FB_CSCR_AA_MASK                          0x100u
+#define FB_CSCR_AA_SHIFT                         8
+#define FB_CSCR_BLS_MASK                         0x200u
+#define FB_CSCR_BLS_SHIFT                        9
+#define FB_CSCR_WS_MASK                          0xFC00u
+#define FB_CSCR_WS_SHIFT                         10
+#define FB_CSCR_WS(x)                            (((uint32_t)(((uint32_t)(x))<<FB_CSCR_WS_SHIFT))&FB_CSCR_WS_MASK)
+#define FB_CSCR_WRAH_MASK                        0x30000u
+#define FB_CSCR_WRAH_SHIFT                       16
+#define FB_CSCR_WRAH(x)                          (((uint32_t)(((uint32_t)(x))<<FB_CSCR_WRAH_SHIFT))&FB_CSCR_WRAH_MASK)
+#define FB_CSCR_RDAH_MASK                        0xC0000u
+#define FB_CSCR_RDAH_SHIFT                       18
+#define FB_CSCR_RDAH(x)                          (((uint32_t)(((uint32_t)(x))<<FB_CSCR_RDAH_SHIFT))&FB_CSCR_RDAH_MASK)
+#define FB_CSCR_ASET_MASK                        0x300000u
+#define FB_CSCR_ASET_SHIFT                       20
+#define FB_CSCR_ASET(x)                          (((uint32_t)(((uint32_t)(x))<<FB_CSCR_ASET_SHIFT))&FB_CSCR_ASET_MASK)
+#define FB_CSCR_EXTS_MASK                        0x400000u
+#define FB_CSCR_EXTS_SHIFT                       22
+#define FB_CSCR_SWSEN_MASK                       0x800000u
+#define FB_CSCR_SWSEN_SHIFT                      23
+#define FB_CSCR_SWS_MASK                         0xFC000000u
+#define FB_CSCR_SWS_SHIFT                        26
+#define FB_CSCR_SWS(x)                           (((uint32_t)(((uint32_t)(x))<<FB_CSCR_SWS_SHIFT))&FB_CSCR_SWS_MASK)
+/* CSPMCR Bit Fields */
+#define FB_CSPMCR_GROUP5_MASK                    0xF000u
+#define FB_CSPMCR_GROUP5_SHIFT                   12
+#define FB_CSPMCR_GROUP5(x)                      (((uint32_t)(((uint32_t)(x))<<FB_CSPMCR_GROUP5_SHIFT))&FB_CSPMCR_GROUP5_MASK)
+#define FB_CSPMCR_GROUP4_MASK                    0xF0000u
+#define FB_CSPMCR_GROUP4_SHIFT                   16
+#define FB_CSPMCR_GROUP4(x)                      (((uint32_t)(((uint32_t)(x))<<FB_CSPMCR_GROUP4_SHIFT))&FB_CSPMCR_GROUP4_MASK)
+#define FB_CSPMCR_GROUP3_MASK                    0xF00000u
+#define FB_CSPMCR_GROUP3_SHIFT                   20
+#define FB_CSPMCR_GROUP3(x)                      (((uint32_t)(((uint32_t)(x))<<FB_CSPMCR_GROUP3_SHIFT))&FB_CSPMCR_GROUP3_MASK)
+#define FB_CSPMCR_GROUP2_MASK                    0xF000000u
+#define FB_CSPMCR_GROUP2_SHIFT                   24
+#define FB_CSPMCR_GROUP2(x)                      (((uint32_t)(((uint32_t)(x))<<FB_CSPMCR_GROUP2_SHIFT))&FB_CSPMCR_GROUP2_MASK)
+#define FB_CSPMCR_GROUP1_MASK                    0xF0000000u
+#define FB_CSPMCR_GROUP1_SHIFT                   28
+#define FB_CSPMCR_GROUP1(x)                      (((uint32_t)(((uint32_t)(x))<<FB_CSPMCR_GROUP1_SHIFT))&FB_CSPMCR_GROUP1_MASK)
+
+/*!
+ * @}
+ */ /* end of group FB_Register_Masks */
+
+
+/* FB - Peripheral instance base addresses */
+/** Peripheral FB base address */
+#define FB_BASE                                  (0x4000C000u)
+/** Peripheral FB base pointer */
+#define FB                                       ((FB_Type *)FB_BASE)
+#define FB_BASE_PTR                              (FB)
+/** Array initializer of FB peripheral base addresses */
+#define FB_BASE_ADDRS                            { FB_BASE }
+/** Array initializer of FB peripheral base pointers */
+#define FB_BASE_PTRS                             { FB }
+
+/* ----------------------------------------------------------------------------
+   -- FB - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FB_Register_Accessor_Macros FB - Register accessor macros
+ * @{
+ */
+
+
+/* FB - Register instance definitions */
+/* FB */
+#define FB_CSAR0                                 FB_CSAR_REG(FB,0)
+#define FB_CSMR0                                 FB_CSMR_REG(FB,0)
+#define FB_CSCR0                                 FB_CSCR_REG(FB,0)
+#define FB_CSAR1                                 FB_CSAR_REG(FB,1)
+#define FB_CSMR1                                 FB_CSMR_REG(FB,1)
+#define FB_CSCR1                                 FB_CSCR_REG(FB,1)
+#define FB_CSAR2                                 FB_CSAR_REG(FB,2)
+#define FB_CSMR2                                 FB_CSMR_REG(FB,2)
+#define FB_CSCR2                                 FB_CSCR_REG(FB,2)
+#define FB_CSAR3                                 FB_CSAR_REG(FB,3)
+#define FB_CSMR3                                 FB_CSMR_REG(FB,3)
+#define FB_CSCR3                                 FB_CSCR_REG(FB,3)
+#define FB_CSAR4                                 FB_CSAR_REG(FB,4)
+#define FB_CSMR4                                 FB_CSMR_REG(FB,4)
+#define FB_CSCR4                                 FB_CSCR_REG(FB,4)
+#define FB_CSAR5                                 FB_CSAR_REG(FB,5)
+#define FB_CSMR5                                 FB_CSMR_REG(FB,5)
+#define FB_CSCR5                                 FB_CSCR_REG(FB,5)
+#define FB_CSPMCR                                FB_CSPMCR_REG(FB)
+
+/* FB - Register array accessors */
+#define FB_CSAR(index)                           FB_CSAR_REG(FB,index)
+#define FB_CSMR(index)                           FB_CSMR_REG(FB,index)
+#define FB_CSCR(index)                           FB_CSCR_REG(FB,index)
+
+/*!
+ * @}
+ */ /* end of group FB_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group FB_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- FMC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FMC_Peripheral_Access_Layer FMC Peripheral Access Layer
+ * @{
+ */
+
+/** FMC - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t PFAPR;                             /**< Flash Access Protection Register, offset: 0x0 */
+  __IO uint32_t PFB0CR;                            /**< Flash Bank 0 Control Register, offset: 0x4 */
+  __IO uint32_t PFB1CR;                            /**< Flash Bank 1 Control Register, offset: 0x8 */
+       uint8_t RESERVED_0[244];
+  __IO uint32_t TAGVDW0S[4];                       /**< Cache Tag Storage, array offset: 0x100, array step: 0x4 */
+  __IO uint32_t TAGVDW1S[4];                       /**< Cache Tag Storage, array offset: 0x110, array step: 0x4 */
+  __IO uint32_t TAGVDW2S[4];                       /**< Cache Tag Storage, array offset: 0x120, array step: 0x4 */
+  __IO uint32_t TAGVDW3S[4];                       /**< Cache Tag Storage, array offset: 0x130, array step: 0x4 */
+       uint8_t RESERVED_1[192];
+  struct {                                         /* offset: 0x200, array step: index*0x20, index2*0x8 */
+    __IO uint32_t DATA_U;                            /**< Cache Data Storage (upper word), array offset: 0x200, array step: index*0x20, index2*0x8 */
+    __IO uint32_t DATA_L;                            /**< Cache Data Storage (lower word), array offset: 0x204, array step: index*0x20, index2*0x8 */
+  } SET[4][4];
+} FMC_Type, *FMC_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- FMC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FMC_Register_Accessor_Macros FMC - Register accessor macros
+ * @{
+ */
+
+
+/* FMC - Register accessors */
+#define FMC_PFAPR_REG(base)                      ((base)->PFAPR)
+#define FMC_PFB0CR_REG(base)                     ((base)->PFB0CR)
+#define FMC_PFB1CR_REG(base)                     ((base)->PFB1CR)
+#define FMC_TAGVDW0S_REG(base,index)             ((base)->TAGVDW0S[index])
+#define FMC_TAGVDW1S_REG(base,index)             ((base)->TAGVDW1S[index])
+#define FMC_TAGVDW2S_REG(base,index)             ((base)->TAGVDW2S[index])
+#define FMC_TAGVDW3S_REG(base,index)             ((base)->TAGVDW3S[index])
+#define FMC_DATA_U_REG(base,index,index2)        ((base)->SET[index][index2].DATA_U)
+#define FMC_DATA_L_REG(base,index,index2)        ((base)->SET[index][index2].DATA_L)
+
+/*!
+ * @}
+ */ /* end of group FMC_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- FMC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FMC_Register_Masks FMC Register Masks
+ * @{
+ */
+
+/* PFAPR Bit Fields */
+#define FMC_PFAPR_M0AP_MASK                      0x3u
+#define FMC_PFAPR_M0AP_SHIFT                     0
+#define FMC_PFAPR_M0AP(x)                        (((uint32_t)(((uint32_t)(x))<<FMC_PFAPR_M0AP_SHIFT))&FMC_PFAPR_M0AP_MASK)
+#define FMC_PFAPR_M1AP_MASK                      0xCu
+#define FMC_PFAPR_M1AP_SHIFT                     2
+#define FMC_PFAPR_M1AP(x)                        (((uint32_t)(((uint32_t)(x))<<FMC_PFAPR_M1AP_SHIFT))&FMC_PFAPR_M1AP_MASK)
+#define FMC_PFAPR_M2AP_MASK                      0x30u
+#define FMC_PFAPR_M2AP_SHIFT                     4
+#define FMC_PFAPR_M2AP(x)                        (((uint32_t)(((uint32_t)(x))<<FMC_PFAPR_M2AP_SHIFT))&FMC_PFAPR_M2AP_MASK)
+#define FMC_PFAPR_M3AP_MASK                      0xC0u
+#define FMC_PFAPR_M3AP_SHIFT                     6
+#define FMC_PFAPR_M3AP(x)                        (((uint32_t)(((uint32_t)(x))<<FMC_PFAPR_M3AP_SHIFT))&FMC_PFAPR_M3AP_MASK)
+#define FMC_PFAPR_M4AP_MASK                      0x300u
+#define FMC_PFAPR_M4AP_SHIFT                     8
+#define FMC_PFAPR_M4AP(x)                        (((uint32_t)(((uint32_t)(x))<<FMC_PFAPR_M4AP_SHIFT))&FMC_PFAPR_M4AP_MASK)
+#define FMC_PFAPR_M5AP_MASK                      0xC00u
+#define FMC_PFAPR_M5AP_SHIFT                     10
+#define FMC_PFAPR_M5AP(x)                        (((uint32_t)(((uint32_t)(x))<<FMC_PFAPR_M5AP_SHIFT))&FMC_PFAPR_M5AP_MASK)
+#define FMC_PFAPR_M6AP_MASK                      0x3000u
+#define FMC_PFAPR_M6AP_SHIFT                     12
+#define FMC_PFAPR_M6AP(x)                        (((uint32_t)(((uint32_t)(x))<<FMC_PFAPR_M6AP_SHIFT))&FMC_PFAPR_M6AP_MASK)
+#define FMC_PFAPR_M7AP_MASK                      0xC000u
+#define FMC_PFAPR_M7AP_SHIFT                     14
+#define FMC_PFAPR_M7AP(x)                        (((uint32_t)(((uint32_t)(x))<<FMC_PFAPR_M7AP_SHIFT))&FMC_PFAPR_M7AP_MASK)
+#define FMC_PFAPR_M0PFD_MASK                     0x10000u
+#define FMC_PFAPR_M0PFD_SHIFT                    16
+#define FMC_PFAPR_M1PFD_MASK                     0x20000u
+#define FMC_PFAPR_M1PFD_SHIFT                    17
+#define FMC_PFAPR_M2PFD_MASK                     0x40000u
+#define FMC_PFAPR_M2PFD_SHIFT                    18
+#define FMC_PFAPR_M3PFD_MASK                     0x80000u
+#define FMC_PFAPR_M3PFD_SHIFT                    19
+#define FMC_PFAPR_M4PFD_MASK                     0x100000u
+#define FMC_PFAPR_M4PFD_SHIFT                    20
+#define FMC_PFAPR_M5PFD_MASK                     0x200000u
+#define FMC_PFAPR_M5PFD_SHIFT                    21
+#define FMC_PFAPR_M6PFD_MASK                     0x400000u
+#define FMC_PFAPR_M6PFD_SHIFT                    22
+#define FMC_PFAPR_M7PFD_MASK                     0x800000u
+#define FMC_PFAPR_M7PFD_SHIFT                    23
+/* PFB0CR Bit Fields */
+#define FMC_PFB0CR_B0SEBE_MASK                   0x1u
+#define FMC_PFB0CR_B0SEBE_SHIFT                  0
+#define FMC_PFB0CR_B0IPE_MASK                    0x2u
+#define FMC_PFB0CR_B0IPE_SHIFT                   1
+#define FMC_PFB0CR_B0DPE_MASK                    0x4u
+#define FMC_PFB0CR_B0DPE_SHIFT                   2
+#define FMC_PFB0CR_B0ICE_MASK                    0x8u
+#define FMC_PFB0CR_B0ICE_SHIFT                   3
+#define FMC_PFB0CR_B0DCE_MASK                    0x10u
+#define FMC_PFB0CR_B0DCE_SHIFT                   4
+#define FMC_PFB0CR_CRC_MASK                      0xE0u
+#define FMC_PFB0CR_CRC_SHIFT                     5
+#define FMC_PFB0CR_CRC(x)                        (((uint32_t)(((uint32_t)(x))<<FMC_PFB0CR_CRC_SHIFT))&FMC_PFB0CR_CRC_MASK)
+#define FMC_PFB0CR_B0MW_MASK                     0x60000u
+#define FMC_PFB0CR_B0MW_SHIFT                    17
+#define FMC_PFB0CR_B0MW(x)                       (((uint32_t)(((uint32_t)(x))<<FMC_PFB0CR_B0MW_SHIFT))&FMC_PFB0CR_B0MW_MASK)
+#define FMC_PFB0CR_S_B_INV_MASK                  0x80000u
+#define FMC_PFB0CR_S_B_INV_SHIFT                 19
+#define FMC_PFB0CR_CINV_WAY_MASK                 0xF00000u
+#define FMC_PFB0CR_CINV_WAY_SHIFT                20
+#define FMC_PFB0CR_CINV_WAY(x)                   (((uint32_t)(((uint32_t)(x))<<FMC_PFB0CR_CINV_WAY_SHIFT))&FMC_PFB0CR_CINV_WAY_MASK)
+#define FMC_PFB0CR_CLCK_WAY_MASK                 0xF000000u
+#define FMC_PFB0CR_CLCK_WAY_SHIFT                24
+#define FMC_PFB0CR_CLCK_WAY(x)                   (((uint32_t)(((uint32_t)(x))<<FMC_PFB0CR_CLCK_WAY_SHIFT))&FMC_PFB0CR_CLCK_WAY_MASK)
+#define FMC_PFB0CR_B0RWSC_MASK                   0xF0000000u
+#define FMC_PFB0CR_B0RWSC_SHIFT                  28
+#define FMC_PFB0CR_B0RWSC(x)                     (((uint32_t)(((uint32_t)(x))<<FMC_PFB0CR_B0RWSC_SHIFT))&FMC_PFB0CR_B0RWSC_MASK)
+/* PFB1CR Bit Fields */
+#define FMC_PFB1CR_B1SEBE_MASK                   0x1u
+#define FMC_PFB1CR_B1SEBE_SHIFT                  0
+#define FMC_PFB1CR_B1IPE_MASK                    0x2u
+#define FMC_PFB1CR_B1IPE_SHIFT                   1
+#define FMC_PFB1CR_B1DPE_MASK                    0x4u
+#define FMC_PFB1CR_B1DPE_SHIFT                   2
+#define FMC_PFB1CR_B1ICE_MASK                    0x8u
+#define FMC_PFB1CR_B1ICE_SHIFT                   3
+#define FMC_PFB1CR_B1DCE_MASK                    0x10u
+#define FMC_PFB1CR_B1DCE_SHIFT                   4
+#define FMC_PFB1CR_B1MW_MASK                     0x60000u
+#define FMC_PFB1CR_B1MW_SHIFT                    17
+#define FMC_PFB1CR_B1MW(x)                       (((uint32_t)(((uint32_t)(x))<<FMC_PFB1CR_B1MW_SHIFT))&FMC_PFB1CR_B1MW_MASK)
+#define FMC_PFB1CR_B1RWSC_MASK                   0xF0000000u
+#define FMC_PFB1CR_B1RWSC_SHIFT                  28
+#define FMC_PFB1CR_B1RWSC(x)                     (((uint32_t)(((uint32_t)(x))<<FMC_PFB1CR_B1RWSC_SHIFT))&FMC_PFB1CR_B1RWSC_MASK)
+/* TAGVDW0S Bit Fields */
+#define FMC_TAGVDW0S_valid_MASK                  0x1u
+#define FMC_TAGVDW0S_valid_SHIFT                 0
+#define FMC_TAGVDW0S_tag_MASK                    0x7FFE0u
+#define FMC_TAGVDW0S_tag_SHIFT                   5
+#define FMC_TAGVDW0S_tag(x)                      (((uint32_t)(((uint32_t)(x))<<FMC_TAGVDW0S_tag_SHIFT))&FMC_TAGVDW0S_tag_MASK)
+/* TAGVDW1S Bit Fields */
+#define FMC_TAGVDW1S_valid_MASK                  0x1u
+#define FMC_TAGVDW1S_valid_SHIFT                 0
+#define FMC_TAGVDW1S_tag_MASK                    0x7FFE0u
+#define FMC_TAGVDW1S_tag_SHIFT                   5
+#define FMC_TAGVDW1S_tag(x)                      (((uint32_t)(((uint32_t)(x))<<FMC_TAGVDW1S_tag_SHIFT))&FMC_TAGVDW1S_tag_MASK)
+/* TAGVDW2S Bit Fields */
+#define FMC_TAGVDW2S_valid_MASK                  0x1u
+#define FMC_TAGVDW2S_valid_SHIFT                 0
+#define FMC_TAGVDW2S_tag_MASK                    0x7FFE0u
+#define FMC_TAGVDW2S_tag_SHIFT                   5
+#define FMC_TAGVDW2S_tag(x)                      (((uint32_t)(((uint32_t)(x))<<FMC_TAGVDW2S_tag_SHIFT))&FMC_TAGVDW2S_tag_MASK)
+/* TAGVDW3S Bit Fields */
+#define FMC_TAGVDW3S_valid_MASK                  0x1u
+#define FMC_TAGVDW3S_valid_SHIFT                 0
+#define FMC_TAGVDW3S_tag_MASK                    0x7FFE0u
+#define FMC_TAGVDW3S_tag_SHIFT                   5
+#define FMC_TAGVDW3S_tag(x)                      (((uint32_t)(((uint32_t)(x))<<FMC_TAGVDW3S_tag_SHIFT))&FMC_TAGVDW3S_tag_MASK)
+/* DATA_U Bit Fields */
+#define FMC_DATA_U_data_MASK                     0xFFFFFFFFu
+#define FMC_DATA_U_data_SHIFT                    0
+#define FMC_DATA_U_data(x)                       (((uint32_t)(((uint32_t)(x))<<FMC_DATA_U_data_SHIFT))&FMC_DATA_U_data_MASK)
+/* DATA_L Bit Fields */
+#define FMC_DATA_L_data_MASK                     0xFFFFFFFFu
+#define FMC_DATA_L_data_SHIFT                    0
+#define FMC_DATA_L_data(x)                       (((uint32_t)(((uint32_t)(x))<<FMC_DATA_L_data_SHIFT))&FMC_DATA_L_data_MASK)
+
+/*!
+ * @}
+ */ /* end of group FMC_Register_Masks */
+
+
+/* FMC - Peripheral instance base addresses */
+/** Peripheral FMC base address */
+#define FMC_BASE                                 (0x4001F000u)
+/** Peripheral FMC base pointer */
+#define FMC                                      ((FMC_Type *)FMC_BASE)
+#define FMC_BASE_PTR                             (FMC)
+/** Array initializer of FMC peripheral base addresses */
+#define FMC_BASE_ADDRS                           { FMC_BASE }
+/** Array initializer of FMC peripheral base pointers */
+#define FMC_BASE_PTRS                            { FMC }
+
+/* ----------------------------------------------------------------------------
+   -- FMC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FMC_Register_Accessor_Macros FMC - Register accessor macros
+ * @{
+ */
+
+
+/* FMC - Register instance definitions */
+/* FMC */
+#define FMC_PFAPR                                FMC_PFAPR_REG(FMC)
+#define FMC_PFB0CR                               FMC_PFB0CR_REG(FMC)
+#define FMC_PFB1CR                               FMC_PFB1CR_REG(FMC)
+#define FMC_TAGVDW0S0                            FMC_TAGVDW0S_REG(FMC,0)
+#define FMC_TAGVDW0S1                            FMC_TAGVDW0S_REG(FMC,1)
+#define FMC_TAGVDW0S2                            FMC_TAGVDW0S_REG(FMC,2)
+#define FMC_TAGVDW0S3                            FMC_TAGVDW0S_REG(FMC,3)
+#define FMC_TAGVDW1S0                            FMC_TAGVDW1S_REG(FMC,0)
+#define FMC_TAGVDW1S1                            FMC_TAGVDW1S_REG(FMC,1)
+#define FMC_TAGVDW1S2                            FMC_TAGVDW1S_REG(FMC,2)
+#define FMC_TAGVDW1S3                            FMC_TAGVDW1S_REG(FMC,3)
+#define FMC_TAGVDW2S0                            FMC_TAGVDW2S_REG(FMC,0)
+#define FMC_TAGVDW2S1                            FMC_TAGVDW2S_REG(FMC,1)
+#define FMC_TAGVDW2S2                            FMC_TAGVDW2S_REG(FMC,2)
+#define FMC_TAGVDW2S3                            FMC_TAGVDW2S_REG(FMC,3)
+#define FMC_TAGVDW3S0                            FMC_TAGVDW3S_REG(FMC,0)
+#define FMC_TAGVDW3S1                            FMC_TAGVDW3S_REG(FMC,1)
+#define FMC_TAGVDW3S2                            FMC_TAGVDW3S_REG(FMC,2)
+#define FMC_TAGVDW3S3                            FMC_TAGVDW3S_REG(FMC,3)
+#define FMC_DATAW0S0U                            FMC_DATA_U_REG(FMC,0,0)
+#define FMC_DATAW0S0L                            FMC_DATA_L_REG(FMC,0,0)
+#define FMC_DATAW0S1U                            FMC_DATA_U_REG(FMC,0,1)
+#define FMC_DATAW0S1L                            FMC_DATA_L_REG(FMC,0,1)
+#define FMC_DATAW0S2U                            FMC_DATA_U_REG(FMC,0,2)
+#define FMC_DATAW0S2L                            FMC_DATA_L_REG(FMC,0,2)
+#define FMC_DATAW0S3U                            FMC_DATA_U_REG(FMC,0,3)
+#define FMC_DATAW0S3L                            FMC_DATA_L_REG(FMC,0,3)
+#define FMC_DATAW1S0U                            FMC_DATA_U_REG(FMC,1,0)
+#define FMC_DATAW1S0L                            FMC_DATA_L_REG(FMC,1,0)
+#define FMC_DATAW1S1U                            FMC_DATA_U_REG(FMC,1,1)
+#define FMC_DATAW1S1L                            FMC_DATA_L_REG(FMC,1,1)
+#define FMC_DATAW1S2U                            FMC_DATA_U_REG(FMC,1,2)
+#define FMC_DATAW1S2L                            FMC_DATA_L_REG(FMC,1,2)
+#define FMC_DATAW1S3U                            FMC_DATA_U_REG(FMC,1,3)
+#define FMC_DATAW1S3L                            FMC_DATA_L_REG(FMC,1,3)
+#define FMC_DATAW2S0U                            FMC_DATA_U_REG(FMC,2,0)
+#define FMC_DATAW2S0L                            FMC_DATA_L_REG(FMC,2,0)
+#define FMC_DATAW2S1U                            FMC_DATA_U_REG(FMC,2,1)
+#define FMC_DATAW2S1L                            FMC_DATA_L_REG(FMC,2,1)
+#define FMC_DATAW2S2U                            FMC_DATA_U_REG(FMC,2,2)
+#define FMC_DATAW2S2L                            FMC_DATA_L_REG(FMC,2,2)
+#define FMC_DATAW2S3U                            FMC_DATA_U_REG(FMC,2,3)
+#define FMC_DATAW2S3L                            FMC_DATA_L_REG(FMC,2,3)
+#define FMC_DATAW3S0U                            FMC_DATA_U_REG(FMC,3,0)
+#define FMC_DATAW3S0L                            FMC_DATA_L_REG(FMC,3,0)
+#define FMC_DATAW3S1U                            FMC_DATA_U_REG(FMC,3,1)
+#define FMC_DATAW3S1L                            FMC_DATA_L_REG(FMC,3,1)
+#define FMC_DATAW3S2U                            FMC_DATA_U_REG(FMC,3,2)
+#define FMC_DATAW3S2L                            FMC_DATA_L_REG(FMC,3,2)
+#define FMC_DATAW3S3U                            FMC_DATA_U_REG(FMC,3,3)
+#define FMC_DATAW3S3L                            FMC_DATA_L_REG(FMC,3,3)
+
+/* FMC - Register array accessors */
+#define FMC_TAGVDW0S(index)                      FMC_TAGVDW0S_REG(FMC,index)
+#define FMC_TAGVDW1S(index)                      FMC_TAGVDW1S_REG(FMC,index)
+#define FMC_TAGVDW2S(index)                      FMC_TAGVDW2S_REG(FMC,index)
+#define FMC_TAGVDW3S(index)                      FMC_TAGVDW3S_REG(FMC,index)
+#define FMC_DATA_U(index,index2)                 FMC_DATA_U_REG(FMC,index,index2)
+#define FMC_DATA_L(index,index2)                 FMC_DATA_L_REG(FMC,index,index2)
+
+/*!
+ * @}
+ */ /* end of group FMC_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group FMC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- FTFE Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FTFE_Peripheral_Access_Layer FTFE Peripheral Access Layer
+ * @{
+ */
+
+/** FTFE - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t FSTAT;                              /**< Flash Status Register, offset: 0x0 */
+  __IO uint8_t FCNFG;                              /**< Flash Configuration Register, offset: 0x1 */
+  __I  uint8_t FSEC;                               /**< Flash Security Register, offset: 0x2 */
+  __I  uint8_t FOPT;                               /**< Flash Option Register, offset: 0x3 */
+  __IO uint8_t FCCOB3;                             /**< Flash Common Command Object Registers, offset: 0x4 */
+  __IO uint8_t FCCOB2;                             /**< Flash Common Command Object Registers, offset: 0x5 */
+  __IO uint8_t FCCOB1;                             /**< Flash Common Command Object Registers, offset: 0x6 */
+  __IO uint8_t FCCOB0;                             /**< Flash Common Command Object Registers, offset: 0x7 */
+  __IO uint8_t FCCOB7;                             /**< Flash Common Command Object Registers, offset: 0x8 */
+  __IO uint8_t FCCOB6;                             /**< Flash Common Command Object Registers, offset: 0x9 */
+  __IO uint8_t FCCOB5;                             /**< Flash Common Command Object Registers, offset: 0xA */
+  __IO uint8_t FCCOB4;                             /**< Flash Common Command Object Registers, offset: 0xB */
+  __IO uint8_t FCCOBB;                             /**< Flash Common Command Object Registers, offset: 0xC */
+  __IO uint8_t FCCOBA;                             /**< Flash Common Command Object Registers, offset: 0xD */
+  __IO uint8_t FCCOB9;                             /**< Flash Common Command Object Registers, offset: 0xE */
+  __IO uint8_t FCCOB8;                             /**< Flash Common Command Object Registers, offset: 0xF */
+  __IO uint8_t FPROT3;                             /**< Program Flash Protection Registers, offset: 0x10 */
+  __IO uint8_t FPROT2;                             /**< Program Flash Protection Registers, offset: 0x11 */
+  __IO uint8_t FPROT1;                             /**< Program Flash Protection Registers, offset: 0x12 */
+  __IO uint8_t FPROT0;                             /**< Program Flash Protection Registers, offset: 0x13 */
+       uint8_t RESERVED_0[2];
+  __IO uint8_t FEPROT;                             /**< EEPROM Protection Register, offset: 0x16 */
+  __IO uint8_t FDPROT;                             /**< Data Flash Protection Register, offset: 0x17 */
+} FTFE_Type, *FTFE_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- FTFE - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FTFE_Register_Accessor_Macros FTFE - Register accessor macros
+ * @{
+ */
+
+
+/* FTFE - Register accessors */
+#define FTFE_FSTAT_REG(base)                     ((base)->FSTAT)
+#define FTFE_FCNFG_REG(base)                     ((base)->FCNFG)
+#define FTFE_FSEC_REG(base)                      ((base)->FSEC)
+#define FTFE_FOPT_REG(base)                      ((base)->FOPT)
+#define FTFE_FCCOB3_REG(base)                    ((base)->FCCOB3)
+#define FTFE_FCCOB2_REG(base)                    ((base)->FCCOB2)
+#define FTFE_FCCOB1_REG(base)                    ((base)->FCCOB1)
+#define FTFE_FCCOB0_REG(base)                    ((base)->FCCOB0)
+#define FTFE_FCCOB7_REG(base)                    ((base)->FCCOB7)
+#define FTFE_FCCOB6_REG(base)                    ((base)->FCCOB6)
+#define FTFE_FCCOB5_REG(base)                    ((base)->FCCOB5)
+#define FTFE_FCCOB4_REG(base)                    ((base)->FCCOB4)
+#define FTFE_FCCOBB_REG(base)                    ((base)->FCCOBB)
+#define FTFE_FCCOBA_REG(base)                    ((base)->FCCOBA)
+#define FTFE_FCCOB9_REG(base)                    ((base)->FCCOB9)
+#define FTFE_FCCOB8_REG(base)                    ((base)->FCCOB8)
+#define FTFE_FPROT3_REG(base)                    ((base)->FPROT3)
+#define FTFE_FPROT2_REG(base)                    ((base)->FPROT2)
+#define FTFE_FPROT1_REG(base)                    ((base)->FPROT1)
+#define FTFE_FPROT0_REG(base)                    ((base)->FPROT0)
+#define FTFE_FEPROT_REG(base)                    ((base)->FEPROT)
+#define FTFE_FDPROT_REG(base)                    ((base)->FDPROT)
+
+/*!
+ * @}
+ */ /* end of group FTFE_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- FTFE Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FTFE_Register_Masks FTFE Register Masks
+ * @{
+ */
+
+/* FSTAT Bit Fields */
+#define FTFE_FSTAT_MGSTAT0_MASK                  0x1u
+#define FTFE_FSTAT_MGSTAT0_SHIFT                 0
+#define FTFE_FSTAT_FPVIOL_MASK                   0x10u
+#define FTFE_FSTAT_FPVIOL_SHIFT                  4
+#define FTFE_FSTAT_ACCERR_MASK                   0x20u
+#define FTFE_FSTAT_ACCERR_SHIFT                  5
+#define FTFE_FSTAT_RDCOLERR_MASK                 0x40u
+#define FTFE_FSTAT_RDCOLERR_SHIFT                6
+#define FTFE_FSTAT_CCIF_MASK                     0x80u
+#define FTFE_FSTAT_CCIF_SHIFT                    7
+/* FCNFG Bit Fields */
+#define FTFE_FCNFG_EEERDY_MASK                   0x1u
+#define FTFE_FCNFG_EEERDY_SHIFT                  0
+#define FTFE_FCNFG_RAMRDY_MASK                   0x2u
+#define FTFE_FCNFG_RAMRDY_SHIFT                  1
+#define FTFE_FCNFG_PFLSH_MASK                    0x4u
+#define FTFE_FCNFG_PFLSH_SHIFT                   2
+#define FTFE_FCNFG_SWAP_MASK                     0x8u
+#define FTFE_FCNFG_SWAP_SHIFT                    3
+#define FTFE_FCNFG_ERSSUSP_MASK                  0x10u
+#define FTFE_FCNFG_ERSSUSP_SHIFT                 4
+#define FTFE_FCNFG_ERSAREQ_MASK                  0x20u
+#define FTFE_FCNFG_ERSAREQ_SHIFT                 5
+#define FTFE_FCNFG_RDCOLLIE_MASK                 0x40u
+#define FTFE_FCNFG_RDCOLLIE_SHIFT                6
+#define FTFE_FCNFG_CCIE_MASK                     0x80u
+#define FTFE_FCNFG_CCIE_SHIFT                    7
+/* FSEC Bit Fields */
+#define FTFE_FSEC_SEC_MASK                       0x3u
+#define FTFE_FSEC_SEC_SHIFT                      0
+#define FTFE_FSEC_SEC(x)                         (((uint8_t)(((uint8_t)(x))<<FTFE_FSEC_SEC_SHIFT))&FTFE_FSEC_SEC_MASK)
+#define FTFE_FSEC_FSLACC_MASK                    0xCu
+#define FTFE_FSEC_FSLACC_SHIFT                   2
+#define FTFE_FSEC_FSLACC(x)                      (((uint8_t)(((uint8_t)(x))<<FTFE_FSEC_FSLACC_SHIFT))&FTFE_FSEC_FSLACC_MASK)
+#define FTFE_FSEC_MEEN_MASK                      0x30u
+#define FTFE_FSEC_MEEN_SHIFT                     4
+#define FTFE_FSEC_MEEN(x)                        (((uint8_t)(((uint8_t)(x))<<FTFE_FSEC_MEEN_SHIFT))&FTFE_FSEC_MEEN_MASK)
+#define FTFE_FSEC_KEYEN_MASK                     0xC0u
+#define FTFE_FSEC_KEYEN_SHIFT                    6
+#define FTFE_FSEC_KEYEN(x)                       (((uint8_t)(((uint8_t)(x))<<FTFE_FSEC_KEYEN_SHIFT))&FTFE_FSEC_KEYEN_MASK)
+/* FOPT Bit Fields */
+#define FTFE_FOPT_OPT_MASK                       0xFFu
+#define FTFE_FOPT_OPT_SHIFT                      0
+#define FTFE_FOPT_OPT(x)                         (((uint8_t)(((uint8_t)(x))<<FTFE_FOPT_OPT_SHIFT))&FTFE_FOPT_OPT_MASK)
+/* FCCOB3 Bit Fields */
+#define FTFE_FCCOB3_CCOBn_MASK                   0xFFu
+#define FTFE_FCCOB3_CCOBn_SHIFT                  0
+#define FTFE_FCCOB3_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFE_FCCOB3_CCOBn_SHIFT))&FTFE_FCCOB3_CCOBn_MASK)
+/* FCCOB2 Bit Fields */
+#define FTFE_FCCOB2_CCOBn_MASK                   0xFFu
+#define FTFE_FCCOB2_CCOBn_SHIFT                  0
+#define FTFE_FCCOB2_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFE_FCCOB2_CCOBn_SHIFT))&FTFE_FCCOB2_CCOBn_MASK)
+/* FCCOB1 Bit Fields */
+#define FTFE_FCCOB1_CCOBn_MASK                   0xFFu
+#define FTFE_FCCOB1_CCOBn_SHIFT                  0
+#define FTFE_FCCOB1_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFE_FCCOB1_CCOBn_SHIFT))&FTFE_FCCOB1_CCOBn_MASK)
+/* FCCOB0 Bit Fields */
+#define FTFE_FCCOB0_CCOBn_MASK                   0xFFu
+#define FTFE_FCCOB0_CCOBn_SHIFT                  0
+#define FTFE_FCCOB0_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFE_FCCOB0_CCOBn_SHIFT))&FTFE_FCCOB0_CCOBn_MASK)
+/* FCCOB7 Bit Fields */
+#define FTFE_FCCOB7_CCOBn_MASK                   0xFFu
+#define FTFE_FCCOB7_CCOBn_SHIFT                  0
+#define FTFE_FCCOB7_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFE_FCCOB7_CCOBn_SHIFT))&FTFE_FCCOB7_CCOBn_MASK)
+/* FCCOB6 Bit Fields */
+#define FTFE_FCCOB6_CCOBn_MASK                   0xFFu
+#define FTFE_FCCOB6_CCOBn_SHIFT                  0
+#define FTFE_FCCOB6_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFE_FCCOB6_CCOBn_SHIFT))&FTFE_FCCOB6_CCOBn_MASK)
+/* FCCOB5 Bit Fields */
+#define FTFE_FCCOB5_CCOBn_MASK                   0xFFu
+#define FTFE_FCCOB5_CCOBn_SHIFT                  0
+#define FTFE_FCCOB5_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFE_FCCOB5_CCOBn_SHIFT))&FTFE_FCCOB5_CCOBn_MASK)
+/* FCCOB4 Bit Fields */
+#define FTFE_FCCOB4_CCOBn_MASK                   0xFFu
+#define FTFE_FCCOB4_CCOBn_SHIFT                  0
+#define FTFE_FCCOB4_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFE_FCCOB4_CCOBn_SHIFT))&FTFE_FCCOB4_CCOBn_MASK)
+/* FCCOBB Bit Fields */
+#define FTFE_FCCOBB_CCOBn_MASK                   0xFFu
+#define FTFE_FCCOBB_CCOBn_SHIFT                  0
+#define FTFE_FCCOBB_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFE_FCCOBB_CCOBn_SHIFT))&FTFE_FCCOBB_CCOBn_MASK)
+/* FCCOBA Bit Fields */
+#define FTFE_FCCOBA_CCOBn_MASK                   0xFFu
+#define FTFE_FCCOBA_CCOBn_SHIFT                  0
+#define FTFE_FCCOBA_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFE_FCCOBA_CCOBn_SHIFT))&FTFE_FCCOBA_CCOBn_MASK)
+/* FCCOB9 Bit Fields */
+#define FTFE_FCCOB9_CCOBn_MASK                   0xFFu
+#define FTFE_FCCOB9_CCOBn_SHIFT                  0
+#define FTFE_FCCOB9_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFE_FCCOB9_CCOBn_SHIFT))&FTFE_FCCOB9_CCOBn_MASK)
+/* FCCOB8 Bit Fields */
+#define FTFE_FCCOB8_CCOBn_MASK                   0xFFu
+#define FTFE_FCCOB8_CCOBn_SHIFT                  0
+#define FTFE_FCCOB8_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFE_FCCOB8_CCOBn_SHIFT))&FTFE_FCCOB8_CCOBn_MASK)
+/* FPROT3 Bit Fields */
+#define FTFE_FPROT3_PROT_MASK                    0xFFu
+#define FTFE_FPROT3_PROT_SHIFT                   0
+#define FTFE_FPROT3_PROT(x)                      (((uint8_t)(((uint8_t)(x))<<FTFE_FPROT3_PROT_SHIFT))&FTFE_FPROT3_PROT_MASK)
+/* FPROT2 Bit Fields */
+#define FTFE_FPROT2_PROT_MASK                    0xFFu
+#define FTFE_FPROT2_PROT_SHIFT                   0
+#define FTFE_FPROT2_PROT(x)                      (((uint8_t)(((uint8_t)(x))<<FTFE_FPROT2_PROT_SHIFT))&FTFE_FPROT2_PROT_MASK)
+/* FPROT1 Bit Fields */
+#define FTFE_FPROT1_PROT_MASK                    0xFFu
+#define FTFE_FPROT1_PROT_SHIFT                   0
+#define FTFE_FPROT1_PROT(x)                      (((uint8_t)(((uint8_t)(x))<<FTFE_FPROT1_PROT_SHIFT))&FTFE_FPROT1_PROT_MASK)
+/* FPROT0 Bit Fields */
+#define FTFE_FPROT0_PROT_MASK                    0xFFu
+#define FTFE_FPROT0_PROT_SHIFT                   0
+#define FTFE_FPROT0_PROT(x)                      (((uint8_t)(((uint8_t)(x))<<FTFE_FPROT0_PROT_SHIFT))&FTFE_FPROT0_PROT_MASK)
+/* FEPROT Bit Fields */
+#define FTFE_FEPROT_EPROT_MASK                   0xFFu
+#define FTFE_FEPROT_EPROT_SHIFT                  0
+#define FTFE_FEPROT_EPROT(x)                     (((uint8_t)(((uint8_t)(x))<<FTFE_FEPROT_EPROT_SHIFT))&FTFE_FEPROT_EPROT_MASK)
+/* FDPROT Bit Fields */
+#define FTFE_FDPROT_DPROT_MASK                   0xFFu
+#define FTFE_FDPROT_DPROT_SHIFT                  0
+#define FTFE_FDPROT_DPROT(x)                     (((uint8_t)(((uint8_t)(x))<<FTFE_FDPROT_DPROT_SHIFT))&FTFE_FDPROT_DPROT_MASK)
+
+/*!
+ * @}
+ */ /* end of group FTFE_Register_Masks */
+
+
+/* FTFE - Peripheral instance base addresses */
+/** Peripheral FTFE base address */
+#define FTFE_BASE                                (0x40020000u)
+/** Peripheral FTFE base pointer */
+#define FTFE                                     ((FTFE_Type *)FTFE_BASE)
+#define FTFE_BASE_PTR                            (FTFE)
+/** Array initializer of FTFE peripheral base addresses */
+#define FTFE_BASE_ADDRS                          { FTFE_BASE }
+/** Array initializer of FTFE peripheral base pointers */
+#define FTFE_BASE_PTRS                           { FTFE }
+/** Interrupt vectors for the FTFE peripheral type */
+#define FTFE_COMMAND_COMPLETE_IRQS               { FTFE_IRQn }
+#define FTFE_READ_COLLISION_IRQS                 { Read_Collision_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- FTFE - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FTFE_Register_Accessor_Macros FTFE - Register accessor macros
+ * @{
+ */
+
+
+/* FTFE - Register instance definitions */
+/* FTFE */
+#define FTFE_FSTAT                               FTFE_FSTAT_REG(FTFE)
+#define FTFE_FCNFG                               FTFE_FCNFG_REG(FTFE)
+#define FTFE_FSEC                                FTFE_FSEC_REG(FTFE)
+#define FTFE_FOPT                                FTFE_FOPT_REG(FTFE)
+#define FTFE_FCCOB3                              FTFE_FCCOB3_REG(FTFE)
+#define FTFE_FCCOB2                              FTFE_FCCOB2_REG(FTFE)
+#define FTFE_FCCOB1                              FTFE_FCCOB1_REG(FTFE)
+#define FTFE_FCCOB0                              FTFE_FCCOB0_REG(FTFE)
+#define FTFE_FCCOB7                              FTFE_FCCOB7_REG(FTFE)
+#define FTFE_FCCOB6                              FTFE_FCCOB6_REG(FTFE)
+#define FTFE_FCCOB5                              FTFE_FCCOB5_REG(FTFE)
+#define FTFE_FCCOB4                              FTFE_FCCOB4_REG(FTFE)
+#define FTFE_FCCOBB                              FTFE_FCCOBB_REG(FTFE)
+#define FTFE_FCCOBA                              FTFE_FCCOBA_REG(FTFE)
+#define FTFE_FCCOB9                              FTFE_FCCOB9_REG(FTFE)
+#define FTFE_FCCOB8                              FTFE_FCCOB8_REG(FTFE)
+#define FTFE_FPROT3                              FTFE_FPROT3_REG(FTFE)
+#define FTFE_FPROT2                              FTFE_FPROT2_REG(FTFE)
+#define FTFE_FPROT1                              FTFE_FPROT1_REG(FTFE)
+#define FTFE_FPROT0                              FTFE_FPROT0_REG(FTFE)
+#define FTFE_FEPROT                              FTFE_FEPROT_REG(FTFE)
+#define FTFE_FDPROT                              FTFE_FDPROT_REG(FTFE)
+
+/*!
+ * @}
+ */ /* end of group FTFE_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group FTFE_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- FTM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FTM_Peripheral_Access_Layer FTM Peripheral Access Layer
+ * @{
+ */
+
+/** FTM - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t SC;                                /**< Status And Control, offset: 0x0 */
+  __IO uint32_t CNT;                               /**< Counter, offset: 0x4 */
+  __IO uint32_t MOD;                               /**< Modulo, offset: 0x8 */
+  struct {                                         /* offset: 0xC, array step: 0x8 */
+    __IO uint32_t CnSC;                              /**< Channel (n) Status And Control, array offset: 0xC, array step: 0x8 */
+    __IO uint32_t CnV;                               /**< Channel (n) Value, array offset: 0x10, array step: 0x8 */
+  } CONTROLS[8];
+  __IO uint32_t CNTIN;                             /**< Counter Initial Value, offset: 0x4C */
+  __IO uint32_t STATUS;                            /**< Capture And Compare Status, offset: 0x50 */
+  __IO uint32_t MODE;                              /**< Features Mode Selection, offset: 0x54 */
+  __IO uint32_t SYNC;                              /**< Synchronization, offset: 0x58 */
+  __IO uint32_t OUTINIT;                           /**< Initial State For Channels Output, offset: 0x5C */
+  __IO uint32_t OUTMASK;                           /**< Output Mask, offset: 0x60 */
+  __IO uint32_t COMBINE;                           /**< Function For Linked Channels, offset: 0x64 */
+  __IO uint32_t DEADTIME;                          /**< Deadtime Insertion Control, offset: 0x68 */
+  __IO uint32_t EXTTRIG;                           /**< FTM External Trigger, offset: 0x6C */
+  __IO uint32_t POL;                               /**< Channels Polarity, offset: 0x70 */
+  __IO uint32_t FMS;                               /**< Fault Mode Status, offset: 0x74 */
+  __IO uint32_t FILTER;                            /**< Input Capture Filter Control, offset: 0x78 */
+  __IO uint32_t FLTCTRL;                           /**< Fault Control, offset: 0x7C */
+  __IO uint32_t QDCTRL;                            /**< Quadrature Decoder Control And Status, offset: 0x80 */
+  __IO uint32_t CONF;                              /**< Configuration, offset: 0x84 */
+  __IO uint32_t FLTPOL;                            /**< FTM Fault Input Polarity, offset: 0x88 */
+  __IO uint32_t SYNCONF;                           /**< Synchronization Configuration, offset: 0x8C */
+  __IO uint32_t INVCTRL;                           /**< FTM Inverting Control, offset: 0x90 */
+  __IO uint32_t SWOCTRL;                           /**< FTM Software Output Control, offset: 0x94 */
+  __IO uint32_t PWMLOAD;                           /**< FTM PWM Load, offset: 0x98 */
+} FTM_Type, *FTM_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- FTM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FTM_Register_Accessor_Macros FTM - Register accessor macros
+ * @{
+ */
+
+
+/* FTM - Register accessors */
+#define FTM_SC_REG(base)                         ((base)->SC)
+#define FTM_CNT_REG(base)                        ((base)->CNT)
+#define FTM_MOD_REG(base)                        ((base)->MOD)
+#define FTM_CnSC_REG(base,index)                 ((base)->CONTROLS[index].CnSC)
+#define FTM_CnV_REG(base,index)                  ((base)->CONTROLS[index].CnV)
+#define FTM_CNTIN_REG(base)                      ((base)->CNTIN)
+#define FTM_STATUS_REG(base)                     ((base)->STATUS)
+#define FTM_MODE_REG(base)                       ((base)->MODE)
+#define FTM_SYNC_REG(base)                       ((base)->SYNC)
+#define FTM_OUTINIT_REG(base)                    ((base)->OUTINIT)
+#define FTM_OUTMASK_REG(base)                    ((base)->OUTMASK)
+#define FTM_COMBINE_REG(base)                    ((base)->COMBINE)
+#define FTM_DEADTIME_REG(base)                   ((base)->DEADTIME)
+#define FTM_EXTTRIG_REG(base)                    ((base)->EXTTRIG)
+#define FTM_POL_REG(base)                        ((base)->POL)
+#define FTM_FMS_REG(base)                        ((base)->FMS)
+#define FTM_FILTER_REG(base)                     ((base)->FILTER)
+#define FTM_FLTCTRL_REG(base)                    ((base)->FLTCTRL)
+#define FTM_QDCTRL_REG(base)                     ((base)->QDCTRL)
+#define FTM_CONF_REG(base)                       ((base)->CONF)
+#define FTM_FLTPOL_REG(base)                     ((base)->FLTPOL)
+#define FTM_SYNCONF_REG(base)                    ((base)->SYNCONF)
+#define FTM_INVCTRL_REG(base)                    ((base)->INVCTRL)
+#define FTM_SWOCTRL_REG(base)                    ((base)->SWOCTRL)
+#define FTM_PWMLOAD_REG(base)                    ((base)->PWMLOAD)
+
+/*!
+ * @}
+ */ /* end of group FTM_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- FTM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FTM_Register_Masks FTM Register Masks
+ * @{
+ */
+
+/* SC Bit Fields */
+#define FTM_SC_PS_MASK                           0x7u
+#define FTM_SC_PS_SHIFT                          0
+#define FTM_SC_PS(x)                             (((uint32_t)(((uint32_t)(x))<<FTM_SC_PS_SHIFT))&FTM_SC_PS_MASK)
+#define FTM_SC_CLKS_MASK                         0x18u
+#define FTM_SC_CLKS_SHIFT                        3
+#define FTM_SC_CLKS(x)                           (((uint32_t)(((uint32_t)(x))<<FTM_SC_CLKS_SHIFT))&FTM_SC_CLKS_MASK)
+#define FTM_SC_CPWMS_MASK                        0x20u
+#define FTM_SC_CPWMS_SHIFT                       5
+#define FTM_SC_TOIE_MASK                         0x40u
+#define FTM_SC_TOIE_SHIFT                        6
+#define FTM_SC_TOF_MASK                          0x80u
+#define FTM_SC_TOF_SHIFT                         7
+/* CNT Bit Fields */
+#define FTM_CNT_COUNT_MASK                       0xFFFFu
+#define FTM_CNT_COUNT_SHIFT                      0
+#define FTM_CNT_COUNT(x)                         (((uint32_t)(((uint32_t)(x))<<FTM_CNT_COUNT_SHIFT))&FTM_CNT_COUNT_MASK)
+/* MOD Bit Fields */
+#define FTM_MOD_MOD_MASK                         0xFFFFu
+#define FTM_MOD_MOD_SHIFT                        0
+#define FTM_MOD_MOD(x)                           (((uint32_t)(((uint32_t)(x))<<FTM_MOD_MOD_SHIFT))&FTM_MOD_MOD_MASK)
+/* CnSC Bit Fields */
+#define FTM_CnSC_DMA_MASK                        0x1u
+#define FTM_CnSC_DMA_SHIFT                       0
+#define FTM_CnSC_ELSA_MASK                       0x4u
+#define FTM_CnSC_ELSA_SHIFT                      2
+#define FTM_CnSC_ELSB_MASK                       0x8u
+#define FTM_CnSC_ELSB_SHIFT                      3
+#define FTM_CnSC_MSA_MASK                        0x10u
+#define FTM_CnSC_MSA_SHIFT                       4
+#define FTM_CnSC_MSB_MASK                        0x20u
+#define FTM_CnSC_MSB_SHIFT                       5
+#define FTM_CnSC_CHIE_MASK                       0x40u
+#define FTM_CnSC_CHIE_SHIFT                      6
+#define FTM_CnSC_CHF_MASK                        0x80u
+#define FTM_CnSC_CHF_SHIFT                       7
+/* CnV Bit Fields */
+#define FTM_CnV_VAL_MASK                         0xFFFFu
+#define FTM_CnV_VAL_SHIFT                        0
+#define FTM_CnV_VAL(x)                           (((uint32_t)(((uint32_t)(x))<<FTM_CnV_VAL_SHIFT))&FTM_CnV_VAL_MASK)
+/* CNTIN Bit Fields */
+#define FTM_CNTIN_INIT_MASK                      0xFFFFu
+#define FTM_CNTIN_INIT_SHIFT                     0
+#define FTM_CNTIN_INIT(x)                        (((uint32_t)(((uint32_t)(x))<<FTM_CNTIN_INIT_SHIFT))&FTM_CNTIN_INIT_MASK)
+/* STATUS Bit Fields */
+#define FTM_STATUS_CH0F_MASK                     0x1u
+#define FTM_STATUS_CH0F_SHIFT                    0
+#define FTM_STATUS_CH1F_MASK                     0x2u
+#define FTM_STATUS_CH1F_SHIFT                    1
+#define FTM_STATUS_CH2F_MASK                     0x4u
+#define FTM_STATUS_CH2F_SHIFT                    2
+#define FTM_STATUS_CH3F_MASK                     0x8u
+#define FTM_STATUS_CH3F_SHIFT                    3
+#define FTM_STATUS_CH4F_MASK                     0x10u
+#define FTM_STATUS_CH4F_SHIFT                    4
+#define FTM_STATUS_CH5F_MASK                     0x20u
+#define FTM_STATUS_CH5F_SHIFT                    5
+#define FTM_STATUS_CH6F_MASK                     0x40u
+#define FTM_STATUS_CH6F_SHIFT                    6
+#define FTM_STATUS_CH7F_MASK                     0x80u
+#define FTM_STATUS_CH7F_SHIFT                    7
+/* MODE Bit Fields */
+#define FTM_MODE_FTMEN_MASK                      0x1u
+#define FTM_MODE_FTMEN_SHIFT                     0
+#define FTM_MODE_INIT_MASK                       0x2u
+#define FTM_MODE_INIT_SHIFT                      1
+#define FTM_MODE_WPDIS_MASK                      0x4u
+#define FTM_MODE_WPDIS_SHIFT                     2
+#define FTM_MODE_PWMSYNC_MASK                    0x8u
+#define FTM_MODE_PWMSYNC_SHIFT                   3
+#define FTM_MODE_CAPTEST_MASK                    0x10u
+#define FTM_MODE_CAPTEST_SHIFT                   4
+#define FTM_MODE_FAULTM_MASK                     0x60u
+#define FTM_MODE_FAULTM_SHIFT                    5
+#define FTM_MODE_FAULTM(x)                       (((uint32_t)(((uint32_t)(x))<<FTM_MODE_FAULTM_SHIFT))&FTM_MODE_FAULTM_MASK)
+#define FTM_MODE_FAULTIE_MASK                    0x80u
+#define FTM_MODE_FAULTIE_SHIFT                   7
+/* SYNC Bit Fields */
+#define FTM_SYNC_CNTMIN_MASK                     0x1u
+#define FTM_SYNC_CNTMIN_SHIFT                    0
+#define FTM_SYNC_CNTMAX_MASK                     0x2u
+#define FTM_SYNC_CNTMAX_SHIFT                    1
+#define FTM_SYNC_REINIT_MASK                     0x4u
+#define FTM_SYNC_REINIT_SHIFT                    2
+#define FTM_SYNC_SYNCHOM_MASK                    0x8u
+#define FTM_SYNC_SYNCHOM_SHIFT                   3
+#define FTM_SYNC_TRIG0_MASK                      0x10u
+#define FTM_SYNC_TRIG0_SHIFT                     4
+#define FTM_SYNC_TRIG1_MASK                      0x20u
+#define FTM_SYNC_TRIG1_SHIFT                     5
+#define FTM_SYNC_TRIG2_MASK                      0x40u
+#define FTM_SYNC_TRIG2_SHIFT                     6
+#define FTM_SYNC_SWSYNC_MASK                     0x80u
+#define FTM_SYNC_SWSYNC_SHIFT                    7
+/* OUTINIT Bit Fields */
+#define FTM_OUTINIT_CH0OI_MASK                   0x1u
+#define FTM_OUTINIT_CH0OI_SHIFT                  0
+#define FTM_OUTINIT_CH1OI_MASK                   0x2u
+#define FTM_OUTINIT_CH1OI_SHIFT                  1
+#define FTM_OUTINIT_CH2OI_MASK                   0x4u
+#define FTM_OUTINIT_CH2OI_SHIFT                  2
+#define FTM_OUTINIT_CH3OI_MASK                   0x8u
+#define FTM_OUTINIT_CH3OI_SHIFT                  3
+#define FTM_OUTINIT_CH4OI_MASK                   0x10u
+#define FTM_OUTINIT_CH4OI_SHIFT                  4
+#define FTM_OUTINIT_CH5OI_MASK                   0x20u
+#define FTM_OUTINIT_CH5OI_SHIFT                  5
+#define FTM_OUTINIT_CH6OI_MASK                   0x40u
+#define FTM_OUTINIT_CH6OI_SHIFT                  6
+#define FTM_OUTINIT_CH7OI_MASK                   0x80u
+#define FTM_OUTINIT_CH7OI_SHIFT                  7
+/* OUTMASK Bit Fields */
+#define FTM_OUTMASK_CH0OM_MASK                   0x1u
+#define FTM_OUTMASK_CH0OM_SHIFT                  0
+#define FTM_OUTMASK_CH1OM_MASK                   0x2u
+#define FTM_OUTMASK_CH1OM_SHIFT                  1
+#define FTM_OUTMASK_CH2OM_MASK                   0x4u
+#define FTM_OUTMASK_CH2OM_SHIFT                  2
+#define FTM_OUTMASK_CH3OM_MASK                   0x8u
+#define FTM_OUTMASK_CH3OM_SHIFT                  3
+#define FTM_OUTMASK_CH4OM_MASK                   0x10u
+#define FTM_OUTMASK_CH4OM_SHIFT                  4
+#define FTM_OUTMASK_CH5OM_MASK                   0x20u
+#define FTM_OUTMASK_CH5OM_SHIFT                  5
+#define FTM_OUTMASK_CH6OM_MASK                   0x40u
+#define FTM_OUTMASK_CH6OM_SHIFT                  6
+#define FTM_OUTMASK_CH7OM_MASK                   0x80u
+#define FTM_OUTMASK_CH7OM_SHIFT                  7
+/* COMBINE Bit Fields */
+#define FTM_COMBINE_COMBINE0_MASK                0x1u
+#define FTM_COMBINE_COMBINE0_SHIFT               0
+#define FTM_COMBINE_COMP0_MASK                   0x2u
+#define FTM_COMBINE_COMP0_SHIFT                  1
+#define FTM_COMBINE_DECAPEN0_MASK                0x4u
+#define FTM_COMBINE_DECAPEN0_SHIFT               2
+#define FTM_COMBINE_DECAP0_MASK                  0x8u
+#define FTM_COMBINE_DECAP0_SHIFT                 3
+#define FTM_COMBINE_DTEN0_MASK                   0x10u
+#define FTM_COMBINE_DTEN0_SHIFT                  4
+#define FTM_COMBINE_SYNCEN0_MASK                 0x20u
+#define FTM_COMBINE_SYNCEN0_SHIFT                5
+#define FTM_COMBINE_FAULTEN0_MASK                0x40u
+#define FTM_COMBINE_FAULTEN0_SHIFT               6
+#define FTM_COMBINE_COMBINE1_MASK                0x100u
+#define FTM_COMBINE_COMBINE1_SHIFT               8
+#define FTM_COMBINE_COMP1_MASK                   0x200u
+#define FTM_COMBINE_COMP1_SHIFT                  9
+#define FTM_COMBINE_DECAPEN1_MASK                0x400u
+#define FTM_COMBINE_DECAPEN1_SHIFT               10
+#define FTM_COMBINE_DECAP1_MASK                  0x800u
+#define FTM_COMBINE_DECAP1_SHIFT                 11
+#define FTM_COMBINE_DTEN1_MASK                   0x1000u
+#define FTM_COMBINE_DTEN1_SHIFT                  12
+#define FTM_COMBINE_SYNCEN1_MASK                 0x2000u
+#define FTM_COMBINE_SYNCEN1_SHIFT                13
+#define FTM_COMBINE_FAULTEN1_MASK                0x4000u
+#define FTM_COMBINE_FAULTEN1_SHIFT               14
+#define FTM_COMBINE_COMBINE2_MASK                0x10000u
+#define FTM_COMBINE_COMBINE2_SHIFT               16
+#define FTM_COMBINE_COMP2_MASK                   0x20000u
+#define FTM_COMBINE_COMP2_SHIFT                  17
+#define FTM_COMBINE_DECAPEN2_MASK                0x40000u
+#define FTM_COMBINE_DECAPEN2_SHIFT               18
+#define FTM_COMBINE_DECAP2_MASK                  0x80000u
+#define FTM_COMBINE_DECAP2_SHIFT                 19
+#define FTM_COMBINE_DTEN2_MASK                   0x100000u
+#define FTM_COMBINE_DTEN2_SHIFT                  20
+#define FTM_COMBINE_SYNCEN2_MASK                 0x200000u
+#define FTM_COMBINE_SYNCEN2_SHIFT                21
+#define FTM_COMBINE_FAULTEN2_MASK                0x400000u
+#define FTM_COMBINE_FAULTEN2_SHIFT               22
+#define FTM_COMBINE_COMBINE3_MASK                0x1000000u
+#define FTM_COMBINE_COMBINE3_SHIFT               24
+#define FTM_COMBINE_COMP3_MASK                   0x2000000u
+#define FTM_COMBINE_COMP3_SHIFT                  25
+#define FTM_COMBINE_DECAPEN3_MASK                0x4000000u
+#define FTM_COMBINE_DECAPEN3_SHIFT               26
+#define FTM_COMBINE_DECAP3_MASK                  0x8000000u
+#define FTM_COMBINE_DECAP3_SHIFT                 27
+#define FTM_COMBINE_DTEN3_MASK                   0x10000000u
+#define FTM_COMBINE_DTEN3_SHIFT                  28
+#define FTM_COMBINE_SYNCEN3_MASK                 0x20000000u
+#define FTM_COMBINE_SYNCEN3_SHIFT                29
+#define FTM_COMBINE_FAULTEN3_MASK                0x40000000u
+#define FTM_COMBINE_FAULTEN3_SHIFT               30
+/* DEADTIME Bit Fields */
+#define FTM_DEADTIME_DTVAL_MASK                  0x3Fu
+#define FTM_DEADTIME_DTVAL_SHIFT                 0
+#define FTM_DEADTIME_DTVAL(x)                    (((uint32_t)(((uint32_t)(x))<<FTM_DEADTIME_DTVAL_SHIFT))&FTM_DEADTIME_DTVAL_MASK)
+#define FTM_DEADTIME_DTPS_MASK                   0xC0u
+#define FTM_DEADTIME_DTPS_SHIFT                  6
+#define FTM_DEADTIME_DTPS(x)                     (((uint32_t)(((uint32_t)(x))<<FTM_DEADTIME_DTPS_SHIFT))&FTM_DEADTIME_DTPS_MASK)
+/* EXTTRIG Bit Fields */
+#define FTM_EXTTRIG_CH2TRIG_MASK                 0x1u
+#define FTM_EXTTRIG_CH2TRIG_SHIFT                0
+#define FTM_EXTTRIG_CH3TRIG_MASK                 0x2u
+#define FTM_EXTTRIG_CH3TRIG_SHIFT                1
+#define FTM_EXTTRIG_CH4TRIG_MASK                 0x4u
+#define FTM_EXTTRIG_CH4TRIG_SHIFT                2
+#define FTM_EXTTRIG_CH5TRIG_MASK                 0x8u
+#define FTM_EXTTRIG_CH5TRIG_SHIFT                3
+#define FTM_EXTTRIG_CH0TRIG_MASK                 0x10u
+#define FTM_EXTTRIG_CH0TRIG_SHIFT                4
+#define FTM_EXTTRIG_CH1TRIG_MASK                 0x20u
+#define FTM_EXTTRIG_CH1TRIG_SHIFT                5
+#define FTM_EXTTRIG_INITTRIGEN_MASK              0x40u
+#define FTM_EXTTRIG_INITTRIGEN_SHIFT             6
+#define FTM_EXTTRIG_TRIGF_MASK                   0x80u
+#define FTM_EXTTRIG_TRIGF_SHIFT                  7
+/* POL Bit Fields */
+#define FTM_POL_POL0_MASK                        0x1u
+#define FTM_POL_POL0_SHIFT                       0
+#define FTM_POL_POL1_MASK                        0x2u
+#define FTM_POL_POL1_SHIFT                       1
+#define FTM_POL_POL2_MASK                        0x4u
+#define FTM_POL_POL2_SHIFT                       2
+#define FTM_POL_POL3_MASK                        0x8u
+#define FTM_POL_POL3_SHIFT                       3
+#define FTM_POL_POL4_MASK                        0x10u
+#define FTM_POL_POL4_SHIFT                       4
+#define FTM_POL_POL5_MASK                        0x20u
+#define FTM_POL_POL5_SHIFT                       5
+#define FTM_POL_POL6_MASK                        0x40u
+#define FTM_POL_POL6_SHIFT                       6
+#define FTM_POL_POL7_MASK                        0x80u
+#define FTM_POL_POL7_SHIFT                       7
+/* FMS Bit Fields */
+#define FTM_FMS_FAULTF0_MASK                     0x1u
+#define FTM_FMS_FAULTF0_SHIFT                    0
+#define FTM_FMS_FAULTF1_MASK                     0x2u
+#define FTM_FMS_FAULTF1_SHIFT                    1
+#define FTM_FMS_FAULTF2_MASK                     0x4u
+#define FTM_FMS_FAULTF2_SHIFT                    2
+#define FTM_FMS_FAULTF3_MASK                     0x8u
+#define FTM_FMS_FAULTF3_SHIFT                    3
+#define FTM_FMS_FAULTIN_MASK                     0x20u
+#define FTM_FMS_FAULTIN_SHIFT                    5
+#define FTM_FMS_WPEN_MASK                        0x40u
+#define FTM_FMS_WPEN_SHIFT                       6
+#define FTM_FMS_FAULTF_MASK                      0x80u
+#define FTM_FMS_FAULTF_SHIFT                     7
+/* FILTER Bit Fields */
+#define FTM_FILTER_CH0FVAL_MASK                  0xFu
+#define FTM_FILTER_CH0FVAL_SHIFT                 0
+#define FTM_FILTER_CH0FVAL(x)                    (((uint32_t)(((uint32_t)(x))<<FTM_FILTER_CH0FVAL_SHIFT))&FTM_FILTER_CH0FVAL_MASK)
+#define FTM_FILTER_CH1FVAL_MASK                  0xF0u
+#define FTM_FILTER_CH1FVAL_SHIFT                 4
+#define FTM_FILTER_CH1FVAL(x)                    (((uint32_t)(((uint32_t)(x))<<FTM_FILTER_CH1FVAL_SHIFT))&FTM_FILTER_CH1FVAL_MASK)
+#define FTM_FILTER_CH2FVAL_MASK                  0xF00u
+#define FTM_FILTER_CH2FVAL_SHIFT                 8
+#define FTM_FILTER_CH2FVAL(x)                    (((uint32_t)(((uint32_t)(x))<<FTM_FILTER_CH2FVAL_SHIFT))&FTM_FILTER_CH2FVAL_MASK)
+#define FTM_FILTER_CH3FVAL_MASK                  0xF000u
+#define FTM_FILTER_CH3FVAL_SHIFT                 12
+#define FTM_FILTER_CH3FVAL(x)                    (((uint32_t)(((uint32_t)(x))<<FTM_FILTER_CH3FVAL_SHIFT))&FTM_FILTER_CH3FVAL_MASK)
+/* FLTCTRL Bit Fields */
+#define FTM_FLTCTRL_FAULT0EN_MASK                0x1u
+#define FTM_FLTCTRL_FAULT0EN_SHIFT               0
+#define FTM_FLTCTRL_FAULT1EN_MASK                0x2u
+#define FTM_FLTCTRL_FAULT1EN_SHIFT               1
+#define FTM_FLTCTRL_FAULT2EN_MASK                0x4u
+#define FTM_FLTCTRL_FAULT2EN_SHIFT               2
+#define FTM_FLTCTRL_FAULT3EN_MASK                0x8u
+#define FTM_FLTCTRL_FAULT3EN_SHIFT               3
+#define FTM_FLTCTRL_FFLTR0EN_MASK                0x10u
+#define FTM_FLTCTRL_FFLTR0EN_SHIFT               4
+#define FTM_FLTCTRL_FFLTR1EN_MASK                0x20u
+#define FTM_FLTCTRL_FFLTR1EN_SHIFT               5
+#define FTM_FLTCTRL_FFLTR2EN_MASK                0x40u
+#define FTM_FLTCTRL_FFLTR2EN_SHIFT               6
+#define FTM_FLTCTRL_FFLTR3EN_MASK                0x80u
+#define FTM_FLTCTRL_FFLTR3EN_SHIFT               7
+#define FTM_FLTCTRL_FFVAL_MASK                   0xF00u
+#define FTM_FLTCTRL_FFVAL_SHIFT                  8
+#define FTM_FLTCTRL_FFVAL(x)                     (((uint32_t)(((uint32_t)(x))<<FTM_FLTCTRL_FFVAL_SHIFT))&FTM_FLTCTRL_FFVAL_MASK)
+/* QDCTRL Bit Fields */
+#define FTM_QDCTRL_QUADEN_MASK                   0x1u
+#define FTM_QDCTRL_QUADEN_SHIFT                  0
+#define FTM_QDCTRL_TOFDIR_MASK                   0x2u
+#define FTM_QDCTRL_TOFDIR_SHIFT                  1
+#define FTM_QDCTRL_QUADIR_MASK                   0x4u
+#define FTM_QDCTRL_QUADIR_SHIFT                  2
+#define FTM_QDCTRL_QUADMODE_MASK                 0x8u
+#define FTM_QDCTRL_QUADMODE_SHIFT                3
+#define FTM_QDCTRL_PHBPOL_MASK                   0x10u
+#define FTM_QDCTRL_PHBPOL_SHIFT                  4
+#define FTM_QDCTRL_PHAPOL_MASK                   0x20u
+#define FTM_QDCTRL_PHAPOL_SHIFT                  5
+#define FTM_QDCTRL_PHBFLTREN_MASK                0x40u
+#define FTM_QDCTRL_PHBFLTREN_SHIFT               6
+#define FTM_QDCTRL_PHAFLTREN_MASK                0x80u
+#define FTM_QDCTRL_PHAFLTREN_SHIFT               7
+/* CONF Bit Fields */
+#define FTM_CONF_NUMTOF_MASK                     0x1Fu
+#define FTM_CONF_NUMTOF_SHIFT                    0
+#define FTM_CONF_NUMTOF(x)                       (((uint32_t)(((uint32_t)(x))<<FTM_CONF_NUMTOF_SHIFT))&FTM_CONF_NUMTOF_MASK)
+#define FTM_CONF_BDMMODE_MASK                    0xC0u
+#define FTM_CONF_BDMMODE_SHIFT                   6
+#define FTM_CONF_BDMMODE(x)                      (((uint32_t)(((uint32_t)(x))<<FTM_CONF_BDMMODE_SHIFT))&FTM_CONF_BDMMODE_MASK)
+#define FTM_CONF_GTBEEN_MASK                     0x200u
+#define FTM_CONF_GTBEEN_SHIFT                    9
+#define FTM_CONF_GTBEOUT_MASK                    0x400u
+#define FTM_CONF_GTBEOUT_SHIFT                   10
+/* FLTPOL Bit Fields */
+#define FTM_FLTPOL_FLT0POL_MASK                  0x1u
+#define FTM_FLTPOL_FLT0POL_SHIFT                 0
+#define FTM_FLTPOL_FLT1POL_MASK                  0x2u
+#define FTM_FLTPOL_FLT1POL_SHIFT                 1
+#define FTM_FLTPOL_FLT2POL_MASK                  0x4u
+#define FTM_FLTPOL_FLT2POL_SHIFT                 2
+#define FTM_FLTPOL_FLT3POL_MASK                  0x8u
+#define FTM_FLTPOL_FLT3POL_SHIFT                 3
+/* SYNCONF Bit Fields */
+#define FTM_SYNCONF_HWTRIGMODE_MASK              0x1u
+#define FTM_SYNCONF_HWTRIGMODE_SHIFT             0
+#define FTM_SYNCONF_CNTINC_MASK                  0x4u
+#define FTM_SYNCONF_CNTINC_SHIFT                 2
+#define FTM_SYNCONF_INVC_MASK                    0x10u
+#define FTM_SYNCONF_INVC_SHIFT                   4
+#define FTM_SYNCONF_SWOC_MASK                    0x20u
+#define FTM_SYNCONF_SWOC_SHIFT                   5
+#define FTM_SYNCONF_SYNCMODE_MASK                0x80u
+#define FTM_SYNCONF_SYNCMODE_SHIFT               7
+#define FTM_SYNCONF_SWRSTCNT_MASK                0x100u
+#define FTM_SYNCONF_SWRSTCNT_SHIFT               8
+#define FTM_SYNCONF_SWWRBUF_MASK                 0x200u
+#define FTM_SYNCONF_SWWRBUF_SHIFT                9
+#define FTM_SYNCONF_SWOM_MASK                    0x400u
+#define FTM_SYNCONF_SWOM_SHIFT                   10
+#define FTM_SYNCONF_SWINVC_MASK                  0x800u
+#define FTM_SYNCONF_SWINVC_SHIFT                 11
+#define FTM_SYNCONF_SWSOC_MASK                   0x1000u
+#define FTM_SYNCONF_SWSOC_SHIFT                  12
+#define FTM_SYNCONF_HWRSTCNT_MASK                0x10000u
+#define FTM_SYNCONF_HWRSTCNT_SHIFT               16
+#define FTM_SYNCONF_HWWRBUF_MASK                 0x20000u
+#define FTM_SYNCONF_HWWRBUF_SHIFT                17
+#define FTM_SYNCONF_HWOM_MASK                    0x40000u
+#define FTM_SYNCONF_HWOM_SHIFT                   18
+#define FTM_SYNCONF_HWINVC_MASK                  0x80000u
+#define FTM_SYNCONF_HWINVC_SHIFT                 19
+#define FTM_SYNCONF_HWSOC_MASK                   0x100000u
+#define FTM_SYNCONF_HWSOC_SHIFT                  20
+/* INVCTRL Bit Fields */
+#define FTM_INVCTRL_INV0EN_MASK                  0x1u
+#define FTM_INVCTRL_INV0EN_SHIFT                 0
+#define FTM_INVCTRL_INV1EN_MASK                  0x2u
+#define FTM_INVCTRL_INV1EN_SHIFT                 1
+#define FTM_INVCTRL_INV2EN_MASK                  0x4u
+#define FTM_INVCTRL_INV2EN_SHIFT                 2
+#define FTM_INVCTRL_INV3EN_MASK                  0x8u
+#define FTM_INVCTRL_INV3EN_SHIFT                 3
+/* SWOCTRL Bit Fields */
+#define FTM_SWOCTRL_CH0OC_MASK                   0x1u
+#define FTM_SWOCTRL_CH0OC_SHIFT                  0
+#define FTM_SWOCTRL_CH1OC_MASK                   0x2u
+#define FTM_SWOCTRL_CH1OC_SHIFT                  1
+#define FTM_SWOCTRL_CH2OC_MASK                   0x4u
+#define FTM_SWOCTRL_CH2OC_SHIFT                  2
+#define FTM_SWOCTRL_CH3OC_MASK                   0x8u
+#define FTM_SWOCTRL_CH3OC_SHIFT                  3
+#define FTM_SWOCTRL_CH4OC_MASK                   0x10u
+#define FTM_SWOCTRL_CH4OC_SHIFT                  4
+#define FTM_SWOCTRL_CH5OC_MASK                   0x20u
+#define FTM_SWOCTRL_CH5OC_SHIFT                  5
+#define FTM_SWOCTRL_CH6OC_MASK                   0x40u
+#define FTM_SWOCTRL_CH6OC_SHIFT                  6
+#define FTM_SWOCTRL_CH7OC_MASK                   0x80u
+#define FTM_SWOCTRL_CH7OC_SHIFT                  7
+#define FTM_SWOCTRL_CH0OCV_MASK                  0x100u
+#define FTM_SWOCTRL_CH0OCV_SHIFT                 8
+#define FTM_SWOCTRL_CH1OCV_MASK                  0x200u
+#define FTM_SWOCTRL_CH1OCV_SHIFT                 9
+#define FTM_SWOCTRL_CH2OCV_MASK                  0x400u
+#define FTM_SWOCTRL_CH2OCV_SHIFT                 10
+#define FTM_SWOCTRL_CH3OCV_MASK                  0x800u
+#define FTM_SWOCTRL_CH3OCV_SHIFT                 11
+#define FTM_SWOCTRL_CH4OCV_MASK                  0x1000u
+#define FTM_SWOCTRL_CH4OCV_SHIFT                 12
+#define FTM_SWOCTRL_CH5OCV_MASK                  0x2000u
+#define FTM_SWOCTRL_CH5OCV_SHIFT                 13
+#define FTM_SWOCTRL_CH6OCV_MASK                  0x4000u
+#define FTM_SWOCTRL_CH6OCV_SHIFT                 14
+#define FTM_SWOCTRL_CH7OCV_MASK                  0x8000u
+#define FTM_SWOCTRL_CH7OCV_SHIFT                 15
+/* PWMLOAD Bit Fields */
+#define FTM_PWMLOAD_CH0SEL_MASK                  0x1u
+#define FTM_PWMLOAD_CH0SEL_SHIFT                 0
+#define FTM_PWMLOAD_CH1SEL_MASK                  0x2u
+#define FTM_PWMLOAD_CH1SEL_SHIFT                 1
+#define FTM_PWMLOAD_CH2SEL_MASK                  0x4u
+#define FTM_PWMLOAD_CH2SEL_SHIFT                 2
+#define FTM_PWMLOAD_CH3SEL_MASK                  0x8u
+#define FTM_PWMLOAD_CH3SEL_SHIFT                 3
+#define FTM_PWMLOAD_CH4SEL_MASK                  0x10u
+#define FTM_PWMLOAD_CH4SEL_SHIFT                 4
+#define FTM_PWMLOAD_CH5SEL_MASK                  0x20u
+#define FTM_PWMLOAD_CH5SEL_SHIFT                 5
+#define FTM_PWMLOAD_CH6SEL_MASK                  0x40u
+#define FTM_PWMLOAD_CH6SEL_SHIFT                 6
+#define FTM_PWMLOAD_CH7SEL_MASK                  0x80u
+#define FTM_PWMLOAD_CH7SEL_SHIFT                 7
+#define FTM_PWMLOAD_LDOK_MASK                    0x200u
+#define FTM_PWMLOAD_LDOK_SHIFT                   9
+
+/*!
+ * @}
+ */ /* end of group FTM_Register_Masks */
+
+
+/* FTM - Peripheral instance base addresses */
+/** Peripheral FTM0 base address */
+#define FTM0_BASE                                (0x40038000u)
+/** Peripheral FTM0 base pointer */
+#define FTM0                                     ((FTM_Type *)FTM0_BASE)
+#define FTM0_BASE_PTR                            (FTM0)
+/** Peripheral FTM1 base address */
+#define FTM1_BASE                                (0x40039000u)
+/** Peripheral FTM1 base pointer */
+#define FTM1                                     ((FTM_Type *)FTM1_BASE)
+#define FTM1_BASE_PTR                            (FTM1)
+/** Peripheral FTM2 base address */
+#define FTM2_BASE                                (0x4003A000u)
+/** Peripheral FTM2 base pointer */
+#define FTM2                                     ((FTM_Type *)FTM2_BASE)
+#define FTM2_BASE_PTR                            (FTM2)
+/** Peripheral FTM3 base address */
+#define FTM3_BASE                                (0x400B9000u)
+/** Peripheral FTM3 base pointer */
+#define FTM3                                     ((FTM_Type *)FTM3_BASE)
+#define FTM3_BASE_PTR                            (FTM3)
+/** Array initializer of FTM peripheral base addresses */
+#define FTM_BASE_ADDRS                           { FTM0_BASE, FTM1_BASE, FTM2_BASE, FTM3_BASE }
+/** Array initializer of FTM peripheral base pointers */
+#define FTM_BASE_PTRS                            { FTM0, FTM1, FTM2, FTM3 }
+/** Interrupt vectors for the FTM peripheral type */
+#define FTM_IRQS                                 { FTM0_IRQn, FTM1_IRQn, FTM2_IRQn, FTM3_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- FTM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup FTM_Register_Accessor_Macros FTM - Register accessor macros
+ * @{
+ */
+
+
+/* FTM - Register instance definitions */
+/* FTM0 */
+#define FTM0_SC                                  FTM_SC_REG(FTM0)
+#define FTM0_CNT                                 FTM_CNT_REG(FTM0)
+#define FTM0_MOD                                 FTM_MOD_REG(FTM0)
+#define FTM0_C0SC                                FTM_CnSC_REG(FTM0,0)
+#define FTM0_C0V                                 FTM_CnV_REG(FTM0,0)
+#define FTM0_C1SC                                FTM_CnSC_REG(FTM0,1)
+#define FTM0_C1V                                 FTM_CnV_REG(FTM0,1)
+#define FTM0_C2SC                                FTM_CnSC_REG(FTM0,2)
+#define FTM0_C2V                                 FTM_CnV_REG(FTM0,2)
+#define FTM0_C3SC                                FTM_CnSC_REG(FTM0,3)
+#define FTM0_C3V                                 FTM_CnV_REG(FTM0,3)
+#define FTM0_C4SC                                FTM_CnSC_REG(FTM0,4)
+#define FTM0_C4V                                 FTM_CnV_REG(FTM0,4)
+#define FTM0_C5SC                                FTM_CnSC_REG(FTM0,5)
+#define FTM0_C5V                                 FTM_CnV_REG(FTM0,5)
+#define FTM0_C6SC                                FTM_CnSC_REG(FTM0,6)
+#define FTM0_C6V                                 FTM_CnV_REG(FTM0,6)
+#define FTM0_C7SC                                FTM_CnSC_REG(FTM0,7)
+#define FTM0_C7V                                 FTM_CnV_REG(FTM0,7)
+#define FTM0_CNTIN                               FTM_CNTIN_REG(FTM0)
+#define FTM0_STATUS                              FTM_STATUS_REG(FTM0)
+#define FTM0_MODE                                FTM_MODE_REG(FTM0)
+#define FTM0_SYNC                                FTM_SYNC_REG(FTM0)
+#define FTM0_OUTINIT                             FTM_OUTINIT_REG(FTM0)
+#define FTM0_OUTMASK                             FTM_OUTMASK_REG(FTM0)
+#define FTM0_COMBINE                             FTM_COMBINE_REG(FTM0)
+#define FTM0_DEADTIME                            FTM_DEADTIME_REG(FTM0)
+#define FTM0_EXTTRIG                             FTM_EXTTRIG_REG(FTM0)
+#define FTM0_POL                                 FTM_POL_REG(FTM0)
+#define FTM0_FMS                                 FTM_FMS_REG(FTM0)
+#define FTM0_FILTER                              FTM_FILTER_REG(FTM0)
+#define FTM0_FLTCTRL                             FTM_FLTCTRL_REG(FTM0)
+#define FTM0_QDCTRL                              FTM_QDCTRL_REG(FTM0)
+#define FTM0_CONF                                FTM_CONF_REG(FTM0)
+#define FTM0_FLTPOL                              FTM_FLTPOL_REG(FTM0)
+#define FTM0_SYNCONF                             FTM_SYNCONF_REG(FTM0)
+#define FTM0_INVCTRL                             FTM_INVCTRL_REG(FTM0)
+#define FTM0_SWOCTRL                             FTM_SWOCTRL_REG(FTM0)
+#define FTM0_PWMLOAD                             FTM_PWMLOAD_REG(FTM0)
+/* FTM1 */
+#define FTM1_SC                                  FTM_SC_REG(FTM1)
+#define FTM1_CNT                                 FTM_CNT_REG(FTM1)
+#define FTM1_MOD                                 FTM_MOD_REG(FTM1)
+#define FTM1_C0SC                                FTM_CnSC_REG(FTM1,0)
+#define FTM1_C0V                                 FTM_CnV_REG(FTM1,0)
+#define FTM1_C1SC                                FTM_CnSC_REG(FTM1,1)
+#define FTM1_C1V                                 FTM_CnV_REG(FTM1,1)
+#define FTM1_CNTIN                               FTM_CNTIN_REG(FTM1)
+#define FTM1_STATUS                              FTM_STATUS_REG(FTM1)
+#define FTM1_MODE                                FTM_MODE_REG(FTM1)
+#define FTM1_SYNC                                FTM_SYNC_REG(FTM1)
+#define FTM1_OUTINIT                             FTM_OUTINIT_REG(FTM1)
+#define FTM1_OUTMASK                             FTM_OUTMASK_REG(FTM1)
+#define FTM1_COMBINE                             FTM_COMBINE_REG(FTM1)
+#define FTM1_DEADTIME                            FTM_DEADTIME_REG(FTM1)
+#define FTM1_EXTTRIG                             FTM_EXTTRIG_REG(FTM1)
+#define FTM1_POL                                 FTM_POL_REG(FTM1)
+#define FTM1_FMS                                 FTM_FMS_REG(FTM1)
+#define FTM1_FILTER                              FTM_FILTER_REG(FTM1)
+#define FTM1_FLTCTRL                             FTM_FLTCTRL_REG(FTM1)
+#define FTM1_QDCTRL                              FTM_QDCTRL_REG(FTM1)
+#define FTM1_CONF                                FTM_CONF_REG(FTM1)
+#define FTM1_FLTPOL                              FTM_FLTPOL_REG(FTM1)
+#define FTM1_SYNCONF                             FTM_SYNCONF_REG(FTM1)
+#define FTM1_INVCTRL                             FTM_INVCTRL_REG(FTM1)
+#define FTM1_SWOCTRL                             FTM_SWOCTRL_REG(FTM1)
+#define FTM1_PWMLOAD                             FTM_PWMLOAD_REG(FTM1)
+/* FTM2 */
+#define FTM2_SC                                  FTM_SC_REG(FTM2)
+#define FTM2_CNT                                 FTM_CNT_REG(FTM2)
+#define FTM2_MOD                                 FTM_MOD_REG(FTM2)
+#define FTM2_C0SC                                FTM_CnSC_REG(FTM2,0)
+#define FTM2_C0V                                 FTM_CnV_REG(FTM2,0)
+#define FTM2_C1SC                                FTM_CnSC_REG(FTM2,1)
+#define FTM2_C1V                                 FTM_CnV_REG(FTM2,1)
+#define FTM2_CNTIN                               FTM_CNTIN_REG(FTM2)
+#define FTM2_STATUS                              FTM_STATUS_REG(FTM2)
+#define FTM2_MODE                                FTM_MODE_REG(FTM2)
+#define FTM2_SYNC                                FTM_SYNC_REG(FTM2)
+#define FTM2_OUTINIT                             FTM_OUTINIT_REG(FTM2)
+#define FTM2_OUTMASK                             FTM_OUTMASK_REG(FTM2)
+#define FTM2_COMBINE                             FTM_COMBINE_REG(FTM2)
+#define FTM2_DEADTIME                            FTM_DEADTIME_REG(FTM2)
+#define FTM2_EXTTRIG                             FTM_EXTTRIG_REG(FTM2)
+#define FTM2_POL                                 FTM_POL_REG(FTM2)
+#define FTM2_FMS                                 FTM_FMS_REG(FTM2)
+#define FTM2_FILTER                              FTM_FILTER_REG(FTM2)
+#define FTM2_FLTCTRL                             FTM_FLTCTRL_REG(FTM2)
+#define FTM2_QDCTRL                              FTM_QDCTRL_REG(FTM2)
+#define FTM2_CONF                                FTM_CONF_REG(FTM2)
+#define FTM2_FLTPOL                              FTM_FLTPOL_REG(FTM2)
+#define FTM2_SYNCONF                             FTM_SYNCONF_REG(FTM2)
+#define FTM2_INVCTRL                             FTM_INVCTRL_REG(FTM2)
+#define FTM2_SWOCTRL                             FTM_SWOCTRL_REG(FTM2)
+#define FTM2_PWMLOAD                             FTM_PWMLOAD_REG(FTM2)
+/* FTM3 */
+#define FTM3_SC                                  FTM_SC_REG(FTM3)
+#define FTM3_CNT                                 FTM_CNT_REG(FTM3)
+#define FTM3_MOD                                 FTM_MOD_REG(FTM3)
+#define FTM3_C0SC                                FTM_CnSC_REG(FTM3,0)
+#define FTM3_C0V                                 FTM_CnV_REG(FTM3,0)
+#define FTM3_C1SC                                FTM_CnSC_REG(FTM3,1)
+#define FTM3_C1V                                 FTM_CnV_REG(FTM3,1)
+#define FTM3_C2SC                                FTM_CnSC_REG(FTM3,2)
+#define FTM3_C2V                                 FTM_CnV_REG(FTM3,2)
+#define FTM3_C3SC                                FTM_CnSC_REG(FTM3,3)
+#define FTM3_C3V                                 FTM_CnV_REG(FTM3,3)
+#define FTM3_C4SC                                FTM_CnSC_REG(FTM3,4)
+#define FTM3_C4V                                 FTM_CnV_REG(FTM3,4)
+#define FTM3_C5SC                                FTM_CnSC_REG(FTM3,5)
+#define FTM3_C5V                                 FTM_CnV_REG(FTM3,5)
+#define FTM3_C6SC                                FTM_CnSC_REG(FTM3,6)
+#define FTM3_C6V                                 FTM_CnV_REG(FTM3,6)
+#define FTM3_C7SC                                FTM_CnSC_REG(FTM3,7)
+#define FTM3_C7V                                 FTM_CnV_REG(FTM3,7)
+#define FTM3_CNTIN                               FTM_CNTIN_REG(FTM3)
+#define FTM3_STATUS                              FTM_STATUS_REG(FTM3)
+#define FTM3_MODE                                FTM_MODE_REG(FTM3)
+#define FTM3_SYNC                                FTM_SYNC_REG(FTM3)
+#define FTM3_OUTINIT                             FTM_OUTINIT_REG(FTM3)
+#define FTM3_OUTMASK                             FTM_OUTMASK_REG(FTM3)
+#define FTM3_COMBINE                             FTM_COMBINE_REG(FTM3)
+#define FTM3_DEADTIME                            FTM_DEADTIME_REG(FTM3)
+#define FTM3_EXTTRIG                             FTM_EXTTRIG_REG(FTM3)
+#define FTM3_POL                                 FTM_POL_REG(FTM3)
+#define FTM3_FMS                                 FTM_FMS_REG(FTM3)
+#define FTM3_FILTER                              FTM_FILTER_REG(FTM3)
+#define FTM3_FLTCTRL                             FTM_FLTCTRL_REG(FTM3)
+#define FTM3_QDCTRL                              FTM_QDCTRL_REG(FTM3)
+#define FTM3_CONF                                FTM_CONF_REG(FTM3)
+#define FTM3_FLTPOL                              FTM_FLTPOL_REG(FTM3)
+#define FTM3_SYNCONF                             FTM_SYNCONF_REG(FTM3)
+#define FTM3_INVCTRL                             FTM_INVCTRL_REG(FTM3)
+#define FTM3_SWOCTRL                             FTM_SWOCTRL_REG(FTM3)
+#define FTM3_PWMLOAD                             FTM_PWMLOAD_REG(FTM3)
+
+/* FTM - Register array accessors */
+#define FTM0_CnSC(index)                         FTM_CnSC_REG(FTM0,index)
+#define FTM1_CnSC(index)                         FTM_CnSC_REG(FTM1,index)
+#define FTM2_CnSC(index)                         FTM_CnSC_REG(FTM2,index)
+#define FTM3_CnSC(index)                         FTM_CnSC_REG(FTM3,index)
+#define FTM0_CnV(index)                          FTM_CnV_REG(FTM0,index)
+#define FTM1_CnV(index)                          FTM_CnV_REG(FTM1,index)
+#define FTM2_CnV(index)                          FTM_CnV_REG(FTM2,index)
+#define FTM3_CnV(index)                          FTM_CnV_REG(FTM3,index)
+
+/*!
+ * @}
+ */ /* end of group FTM_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group FTM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- GPIO Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup GPIO_Peripheral_Access_Layer GPIO Peripheral Access Layer
+ * @{
+ */
+
+/** GPIO - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t PDOR;                              /**< Port Data Output Register, offset: 0x0 */
+  __O  uint32_t PSOR;                              /**< Port Set Output Register, offset: 0x4 */
+  __O  uint32_t PCOR;                              /**< Port Clear Output Register, offset: 0x8 */
+  __O  uint32_t PTOR;                              /**< Port Toggle Output Register, offset: 0xC */
+  __I  uint32_t PDIR;                              /**< Port Data Input Register, offset: 0x10 */
+  __IO uint32_t PDDR;                              /**< Port Data Direction Register, offset: 0x14 */
+} GPIO_Type, *GPIO_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- GPIO - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup GPIO_Register_Accessor_Macros GPIO - Register accessor macros
+ * @{
+ */
+
+
+/* GPIO - Register accessors */
+#define GPIO_PDOR_REG(base)                      ((base)->PDOR)
+#define GPIO_PSOR_REG(base)                      ((base)->PSOR)
+#define GPIO_PCOR_REG(base)                      ((base)->PCOR)
+#define GPIO_PTOR_REG(base)                      ((base)->PTOR)
+#define GPIO_PDIR_REG(base)                      ((base)->PDIR)
+#define GPIO_PDDR_REG(base)                      ((base)->PDDR)
+
+/*!
+ * @}
+ */ /* end of group GPIO_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- GPIO Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup GPIO_Register_Masks GPIO Register Masks
+ * @{
+ */
+
+/* PDOR Bit Fields */
+#define GPIO_PDOR_PDO_MASK                       0xFFFFFFFFu
+#define GPIO_PDOR_PDO_SHIFT                      0
+#define GPIO_PDOR_PDO(x)                         (((uint32_t)(((uint32_t)(x))<<GPIO_PDOR_PDO_SHIFT))&GPIO_PDOR_PDO_MASK)
+/* PSOR Bit Fields */
+#define GPIO_PSOR_PTSO_MASK                      0xFFFFFFFFu
+#define GPIO_PSOR_PTSO_SHIFT                     0
+#define GPIO_PSOR_PTSO(x)                        (((uint32_t)(((uint32_t)(x))<<GPIO_PSOR_PTSO_SHIFT))&GPIO_PSOR_PTSO_MASK)
+/* PCOR Bit Fields */
+#define GPIO_PCOR_PTCO_MASK                      0xFFFFFFFFu
+#define GPIO_PCOR_PTCO_SHIFT                     0
+#define GPIO_PCOR_PTCO(x)                        (((uint32_t)(((uint32_t)(x))<<GPIO_PCOR_PTCO_SHIFT))&GPIO_PCOR_PTCO_MASK)
+/* PTOR Bit Fields */
+#define GPIO_PTOR_PTTO_MASK                      0xFFFFFFFFu
+#define GPIO_PTOR_PTTO_SHIFT                     0
+#define GPIO_PTOR_PTTO(x)                        (((uint32_t)(((uint32_t)(x))<<GPIO_PTOR_PTTO_SHIFT))&GPIO_PTOR_PTTO_MASK)
+/* PDIR Bit Fields */
+#define GPIO_PDIR_PDI_MASK                       0xFFFFFFFFu
+#define GPIO_PDIR_PDI_SHIFT                      0
+#define GPIO_PDIR_PDI(x)                         (((uint32_t)(((uint32_t)(x))<<GPIO_PDIR_PDI_SHIFT))&GPIO_PDIR_PDI_MASK)
+/* PDDR Bit Fields */
+#define GPIO_PDDR_PDD_MASK                       0xFFFFFFFFu
+#define GPIO_PDDR_PDD_SHIFT                      0
+#define GPIO_PDDR_PDD(x)                         (((uint32_t)(((uint32_t)(x))<<GPIO_PDDR_PDD_SHIFT))&GPIO_PDDR_PDD_MASK)
+
+/*!
+ * @}
+ */ /* end of group GPIO_Register_Masks */
+
+
+/* GPIO - Peripheral instance base addresses */
+/** Peripheral PTA base address */
+#define PTA_BASE                                 (0x400FF000u)
+/** Peripheral PTA base pointer */
+#define PTA                                      ((GPIO_Type *)PTA_BASE)
+#define PTA_BASE_PTR                             (PTA)
+/** Peripheral PTB base address */
+#define PTB_BASE                                 (0x400FF040u)
+/** Peripheral PTB base pointer */
+#define PTB                                      ((GPIO_Type *)PTB_BASE)
+#define PTB_BASE_PTR                             (PTB)
+/** Peripheral PTC base address */
+#define PTC_BASE                                 (0x400FF080u)
+/** Peripheral PTC base pointer */
+#define PTC                                      ((GPIO_Type *)PTC_BASE)
+#define PTC_BASE_PTR                             (PTC)
+/** Peripheral PTD base address */
+#define PTD_BASE                                 (0x400FF0C0u)
+/** Peripheral PTD base pointer */
+#define PTD                                      ((GPIO_Type *)PTD_BASE)
+#define PTD_BASE_PTR                             (PTD)
+/** Peripheral PTE base address */
+#define PTE_BASE                                 (0x400FF100u)
+/** Peripheral PTE base pointer */
+#define PTE                                      ((GPIO_Type *)PTE_BASE)
+#define PTE_BASE_PTR                             (PTE)
+/** Array initializer of GPIO peripheral base addresses */
+#define GPIO_BASE_ADDRS                          { PTA_BASE, PTB_BASE, PTC_BASE, PTD_BASE, PTE_BASE }
+/** Array initializer of GPIO peripheral base pointers */
+#define GPIO_BASE_PTRS                           { PTA, PTB, PTC, PTD, PTE }
+
+/* ----------------------------------------------------------------------------
+   -- GPIO - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup GPIO_Register_Accessor_Macros GPIO - Register accessor macros
+ * @{
+ */
+
+
+/* GPIO - Register instance definitions */
+/* PTA */
+#define GPIOA_PDOR                               GPIO_PDOR_REG(PTA)
+#define GPIOA_PSOR                               GPIO_PSOR_REG(PTA)
+#define GPIOA_PCOR                               GPIO_PCOR_REG(PTA)
+#define GPIOA_PTOR                               GPIO_PTOR_REG(PTA)
+#define GPIOA_PDIR                               GPIO_PDIR_REG(PTA)
+#define GPIOA_PDDR                               GPIO_PDDR_REG(PTA)
+/* PTB */
+#define GPIOB_PDOR                               GPIO_PDOR_REG(PTB)
+#define GPIOB_PSOR                               GPIO_PSOR_REG(PTB)
+#define GPIOB_PCOR                               GPIO_PCOR_REG(PTB)
+#define GPIOB_PTOR                               GPIO_PTOR_REG(PTB)
+#define GPIOB_PDIR                               GPIO_PDIR_REG(PTB)
+#define GPIOB_PDDR                               GPIO_PDDR_REG(PTB)
+/* PTC */
+#define GPIOC_PDOR                               GPIO_PDOR_REG(PTC)
+#define GPIOC_PSOR                               GPIO_PSOR_REG(PTC)
+#define GPIOC_PCOR                               GPIO_PCOR_REG(PTC)
+#define GPIOC_PTOR                               GPIO_PTOR_REG(PTC)
+#define GPIOC_PDIR                               GPIO_PDIR_REG(PTC)
+#define GPIOC_PDDR                               GPIO_PDDR_REG(PTC)
+/* PTD */
+#define GPIOD_PDOR                               GPIO_PDOR_REG(PTD)
+#define GPIOD_PSOR                               GPIO_PSOR_REG(PTD)
+#define GPIOD_PCOR                               GPIO_PCOR_REG(PTD)
+#define GPIOD_PTOR                               GPIO_PTOR_REG(PTD)
+#define GPIOD_PDIR                               GPIO_PDIR_REG(PTD)
+#define GPIOD_PDDR                               GPIO_PDDR_REG(PTD)
+/* PTE */
+#define GPIOE_PDOR                               GPIO_PDOR_REG(PTE)
+#define GPIOE_PSOR                               GPIO_PSOR_REG(PTE)
+#define GPIOE_PCOR                               GPIO_PCOR_REG(PTE)
+#define GPIOE_PTOR                               GPIO_PTOR_REG(PTE)
+#define GPIOE_PDIR                               GPIO_PDIR_REG(PTE)
+#define GPIOE_PDDR                               GPIO_PDDR_REG(PTE)
+
+/*!
+ * @}
+ */ /* end of group GPIO_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group GPIO_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- I2C Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup I2C_Peripheral_Access_Layer I2C Peripheral Access Layer
+ * @{
+ */
+
+/** I2C - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t A1;                                 /**< I2C Address Register 1, offset: 0x0 */
+  __IO uint8_t F;                                  /**< I2C Frequency Divider register, offset: 0x1 */
+  __IO uint8_t C1;                                 /**< I2C Control Register 1, offset: 0x2 */
+  __IO uint8_t S;                                  /**< I2C Status register, offset: 0x3 */
+  __IO uint8_t D;                                  /**< I2C Data I/O register, offset: 0x4 */
+  __IO uint8_t C2;                                 /**< I2C Control Register 2, offset: 0x5 */
+  __IO uint8_t FLT;                                /**< I2C Programmable Input Glitch Filter register, offset: 0x6 */
+  __IO uint8_t RA;                                 /**< I2C Range Address register, offset: 0x7 */
+  __IO uint8_t SMB;                                /**< I2C SMBus Control and Status register, offset: 0x8 */
+  __IO uint8_t A2;                                 /**< I2C Address Register 2, offset: 0x9 */
+  __IO uint8_t SLTH;                               /**< I2C SCL Low Timeout Register High, offset: 0xA */
+  __IO uint8_t SLTL;                               /**< I2C SCL Low Timeout Register Low, offset: 0xB */
+} I2C_Type, *I2C_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- I2C - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup I2C_Register_Accessor_Macros I2C - Register accessor macros
+ * @{
+ */
+
+
+/* I2C - Register accessors */
+#define I2C_A1_REG(base)                         ((base)->A1)
+#define I2C_F_REG(base)                          ((base)->F)
+#define I2C_C1_REG(base)                         ((base)->C1)
+#define I2C_S_REG(base)                          ((base)->S)
+#define I2C_D_REG(base)                          ((base)->D)
+#define I2C_C2_REG(base)                         ((base)->C2)
+#define I2C_FLT_REG(base)                        ((base)->FLT)
+#define I2C_RA_REG(base)                         ((base)->RA)
+#define I2C_SMB_REG(base)                        ((base)->SMB)
+#define I2C_A2_REG(base)                         ((base)->A2)
+#define I2C_SLTH_REG(base)                       ((base)->SLTH)
+#define I2C_SLTL_REG(base)                       ((base)->SLTL)
+
+/*!
+ * @}
+ */ /* end of group I2C_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- I2C Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup I2C_Register_Masks I2C Register Masks
+ * @{
+ */
+
+/* A1 Bit Fields */
+#define I2C_A1_AD_MASK                           0xFEu
+#define I2C_A1_AD_SHIFT                          1
+#define I2C_A1_AD(x)                             (((uint8_t)(((uint8_t)(x))<<I2C_A1_AD_SHIFT))&I2C_A1_AD_MASK)
+/* F Bit Fields */
+#define I2C_F_ICR_MASK                           0x3Fu
+#define I2C_F_ICR_SHIFT                          0
+#define I2C_F_ICR(x)                             (((uint8_t)(((uint8_t)(x))<<I2C_F_ICR_SHIFT))&I2C_F_ICR_MASK)
+#define I2C_F_MULT_MASK                          0xC0u
+#define I2C_F_MULT_SHIFT                         6
+#define I2C_F_MULT(x)                            (((uint8_t)(((uint8_t)(x))<<I2C_F_MULT_SHIFT))&I2C_F_MULT_MASK)
+/* C1 Bit Fields */
+#define I2C_C1_DMAEN_MASK                        0x1u
+#define I2C_C1_DMAEN_SHIFT                       0
+#define I2C_C1_WUEN_MASK                         0x2u
+#define I2C_C1_WUEN_SHIFT                        1
+#define I2C_C1_RSTA_MASK                         0x4u
+#define I2C_C1_RSTA_SHIFT                        2
+#define I2C_C1_TXAK_MASK                         0x8u
+#define I2C_C1_TXAK_SHIFT                        3
+#define I2C_C1_TX_MASK                           0x10u
+#define I2C_C1_TX_SHIFT                          4
+#define I2C_C1_MST_MASK                          0x20u
+#define I2C_C1_MST_SHIFT                         5
+#define I2C_C1_IICIE_MASK                        0x40u
+#define I2C_C1_IICIE_SHIFT                       6
+#define I2C_C1_IICEN_MASK                        0x80u
+#define I2C_C1_IICEN_SHIFT                       7
+/* S Bit Fields */
+#define I2C_S_RXAK_MASK                          0x1u
+#define I2C_S_RXAK_SHIFT                         0
+#define I2C_S_IICIF_MASK                         0x2u
+#define I2C_S_IICIF_SHIFT                        1
+#define I2C_S_SRW_MASK                           0x4u
+#define I2C_S_SRW_SHIFT                          2
+#define I2C_S_RAM_MASK                           0x8u
+#define I2C_S_RAM_SHIFT                          3
+#define I2C_S_ARBL_MASK                          0x10u
+#define I2C_S_ARBL_SHIFT                         4
+#define I2C_S_BUSY_MASK                          0x20u
+#define I2C_S_BUSY_SHIFT                         5
+#define I2C_S_IAAS_MASK                          0x40u
+#define I2C_S_IAAS_SHIFT                         6
+#define I2C_S_TCF_MASK                           0x80u
+#define I2C_S_TCF_SHIFT                          7
+/* D Bit Fields */
+#define I2C_D_DATA_MASK                          0xFFu
+#define I2C_D_DATA_SHIFT                         0
+#define I2C_D_DATA(x)                            (((uint8_t)(((uint8_t)(x))<<I2C_D_DATA_SHIFT))&I2C_D_DATA_MASK)
+/* C2 Bit Fields */
+#define I2C_C2_AD_MASK                           0x7u
+#define I2C_C2_AD_SHIFT                          0
+#define I2C_C2_AD(x)                             (((uint8_t)(((uint8_t)(x))<<I2C_C2_AD_SHIFT))&I2C_C2_AD_MASK)
+#define I2C_C2_RMEN_MASK                         0x8u
+#define I2C_C2_RMEN_SHIFT                        3
+#define I2C_C2_SBRC_MASK                         0x10u
+#define I2C_C2_SBRC_SHIFT                        4
+#define I2C_C2_HDRS_MASK                         0x20u
+#define I2C_C2_HDRS_SHIFT                        5
+#define I2C_C2_ADEXT_MASK                        0x40u
+#define I2C_C2_ADEXT_SHIFT                       6
+#define I2C_C2_GCAEN_MASK                        0x80u
+#define I2C_C2_GCAEN_SHIFT                       7
+/* FLT Bit Fields */
+#define I2C_FLT_FLT_MASK                         0xFu
+#define I2C_FLT_FLT_SHIFT                        0
+#define I2C_FLT_FLT(x)                           (((uint8_t)(((uint8_t)(x))<<I2C_FLT_FLT_SHIFT))&I2C_FLT_FLT_MASK)
+#define I2C_FLT_STARTF_MASK                      0x10u
+#define I2C_FLT_STARTF_SHIFT                     4
+#define I2C_FLT_SSIE_MASK                        0x20u
+#define I2C_FLT_SSIE_SHIFT                       5
+#define I2C_FLT_STOPF_MASK                       0x40u
+#define I2C_FLT_STOPF_SHIFT                      6
+#define I2C_FLT_SHEN_MASK                        0x80u
+#define I2C_FLT_SHEN_SHIFT                       7
+/* RA Bit Fields */
+#define I2C_RA_RAD_MASK                          0xFEu
+#define I2C_RA_RAD_SHIFT                         1
+#define I2C_RA_RAD(x)                            (((uint8_t)(((uint8_t)(x))<<I2C_RA_RAD_SHIFT))&I2C_RA_RAD_MASK)
+/* SMB Bit Fields */
+#define I2C_SMB_SHTF2IE_MASK                     0x1u
+#define I2C_SMB_SHTF2IE_SHIFT                    0
+#define I2C_SMB_SHTF2_MASK                       0x2u
+#define I2C_SMB_SHTF2_SHIFT                      1
+#define I2C_SMB_SHTF1_MASK                       0x4u
+#define I2C_SMB_SHTF1_SHIFT                      2
+#define I2C_SMB_SLTF_MASK                        0x8u
+#define I2C_SMB_SLTF_SHIFT                       3
+#define I2C_SMB_TCKSEL_MASK                      0x10u
+#define I2C_SMB_TCKSEL_SHIFT                     4
+#define I2C_SMB_SIICAEN_MASK                     0x20u
+#define I2C_SMB_SIICAEN_SHIFT                    5
+#define I2C_SMB_ALERTEN_MASK                     0x40u
+#define I2C_SMB_ALERTEN_SHIFT                    6
+#define I2C_SMB_FACK_MASK                        0x80u
+#define I2C_SMB_FACK_SHIFT                       7
+/* A2 Bit Fields */
+#define I2C_A2_SAD_MASK                          0xFEu
+#define I2C_A2_SAD_SHIFT                         1
+#define I2C_A2_SAD(x)                            (((uint8_t)(((uint8_t)(x))<<I2C_A2_SAD_SHIFT))&I2C_A2_SAD_MASK)
+/* SLTH Bit Fields */
+#define I2C_SLTH_SSLT_MASK                       0xFFu
+#define I2C_SLTH_SSLT_SHIFT                      0
+#define I2C_SLTH_SSLT(x)                         (((uint8_t)(((uint8_t)(x))<<I2C_SLTH_SSLT_SHIFT))&I2C_SLTH_SSLT_MASK)
+/* SLTL Bit Fields */
+#define I2C_SLTL_SSLT_MASK                       0xFFu
+#define I2C_SLTL_SSLT_SHIFT                      0
+#define I2C_SLTL_SSLT(x)                         (((uint8_t)(((uint8_t)(x))<<I2C_SLTL_SSLT_SHIFT))&I2C_SLTL_SSLT_MASK)
+
+/*!
+ * @}
+ */ /* end of group I2C_Register_Masks */
+
+
+/* I2C - Peripheral instance base addresses */
+/** Peripheral I2C0 base address */
+#define I2C0_BASE                                (0x40066000u)
+/** Peripheral I2C0 base pointer */
+#define I2C0                                     ((I2C_Type *)I2C0_BASE)
+#define I2C0_BASE_PTR                            (I2C0)
+/** Peripheral I2C1 base address */
+#define I2C1_BASE                                (0x40067000u)
+/** Peripheral I2C1 base pointer */
+#define I2C1                                     ((I2C_Type *)I2C1_BASE)
+#define I2C1_BASE_PTR                            (I2C1)
+/** Peripheral I2C2 base address */
+#define I2C2_BASE                                (0x400E6000u)
+/** Peripheral I2C2 base pointer */
+#define I2C2                                     ((I2C_Type *)I2C2_BASE)
+#define I2C2_BASE_PTR                            (I2C2)
+/** Array initializer of I2C peripheral base addresses */
+#define I2C_BASE_ADDRS                           { I2C0_BASE, I2C1_BASE, I2C2_BASE }
+/** Array initializer of I2C peripheral base pointers */
+#define I2C_BASE_PTRS                            { I2C0, I2C1, I2C2 }
+/** Interrupt vectors for the I2C peripheral type */
+#define I2C_IRQS                                 { I2C0_IRQn, I2C1_IRQn, I2C2_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- I2C - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup I2C_Register_Accessor_Macros I2C - Register accessor macros
+ * @{
+ */
+
+
+/* I2C - Register instance definitions */
+/* I2C0 */
+#define I2C0_A1                                  I2C_A1_REG(I2C0)
+#define I2C0_F                                   I2C_F_REG(I2C0)
+#define I2C0_C1                                  I2C_C1_REG(I2C0)
+#define I2C0_S                                   I2C_S_REG(I2C0)
+#define I2C0_D                                   I2C_D_REG(I2C0)
+#define I2C0_C2                                  I2C_C2_REG(I2C0)
+#define I2C0_FLT                                 I2C_FLT_REG(I2C0)
+#define I2C0_RA                                  I2C_RA_REG(I2C0)
+#define I2C0_SMB                                 I2C_SMB_REG(I2C0)
+#define I2C0_A2                                  I2C_A2_REG(I2C0)
+#define I2C0_SLTH                                I2C_SLTH_REG(I2C0)
+#define I2C0_SLTL                                I2C_SLTL_REG(I2C0)
+/* I2C1 */
+#define I2C1_A1                                  I2C_A1_REG(I2C1)
+#define I2C1_F                                   I2C_F_REG(I2C1)
+#define I2C1_C1                                  I2C_C1_REG(I2C1)
+#define I2C1_S                                   I2C_S_REG(I2C1)
+#define I2C1_D                                   I2C_D_REG(I2C1)
+#define I2C1_C2                                  I2C_C2_REG(I2C1)
+#define I2C1_FLT                                 I2C_FLT_REG(I2C1)
+#define I2C1_RA                                  I2C_RA_REG(I2C1)
+#define I2C1_SMB                                 I2C_SMB_REG(I2C1)
+#define I2C1_A2                                  I2C_A2_REG(I2C1)
+#define I2C1_SLTH                                I2C_SLTH_REG(I2C1)
+#define I2C1_SLTL                                I2C_SLTL_REG(I2C1)
+/* I2C2 */
+#define I2C2_A1                                  I2C_A1_REG(I2C2)
+#define I2C2_F                                   I2C_F_REG(I2C2)
+#define I2C2_C1                                  I2C_C1_REG(I2C2)
+#define I2C2_S                                   I2C_S_REG(I2C2)
+#define I2C2_D                                   I2C_D_REG(I2C2)
+#define I2C2_C2                                  I2C_C2_REG(I2C2)
+#define I2C2_FLT                                 I2C_FLT_REG(I2C2)
+#define I2C2_RA                                  I2C_RA_REG(I2C2)
+#define I2C2_SMB                                 I2C_SMB_REG(I2C2)
+#define I2C2_A2                                  I2C_A2_REG(I2C2)
+#define I2C2_SLTH                                I2C_SLTH_REG(I2C2)
+#define I2C2_SLTL                                I2C_SLTL_REG(I2C2)
+
+/*!
+ * @}
+ */ /* end of group I2C_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group I2C_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- I2S Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup I2S_Peripheral_Access_Layer I2S Peripheral Access Layer
+ * @{
+ */
+
+/** I2S - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t TCSR;                              /**< SAI Transmit Control Register, offset: 0x0 */
+  __IO uint32_t TCR1;                              /**< SAI Transmit Configuration 1 Register, offset: 0x4 */
+  __IO uint32_t TCR2;                              /**< SAI Transmit Configuration 2 Register, offset: 0x8 */
+  __IO uint32_t TCR3;                              /**< SAI Transmit Configuration 3 Register, offset: 0xC */
+  __IO uint32_t TCR4;                              /**< SAI Transmit Configuration 4 Register, offset: 0x10 */
+  __IO uint32_t TCR5;                              /**< SAI Transmit Configuration 5 Register, offset: 0x14 */
+       uint8_t RESERVED_0[8];
+  __O  uint32_t TDR[2];                            /**< SAI Transmit Data Register, array offset: 0x20, array step: 0x4 */
+       uint8_t RESERVED_1[24];
+  __I  uint32_t TFR[2];                            /**< SAI Transmit FIFO Register, array offset: 0x40, array step: 0x4 */
+       uint8_t RESERVED_2[24];
+  __IO uint32_t TMR;                               /**< SAI Transmit Mask Register, offset: 0x60 */
+       uint8_t RESERVED_3[28];
+  __IO uint32_t RCSR;                              /**< SAI Receive Control Register, offset: 0x80 */
+  __IO uint32_t RCR1;                              /**< SAI Receive Configuration 1 Register, offset: 0x84 */
+  __IO uint32_t RCR2;                              /**< SAI Receive Configuration 2 Register, offset: 0x88 */
+  __IO uint32_t RCR3;                              /**< SAI Receive Configuration 3 Register, offset: 0x8C */
+  __IO uint32_t RCR4;                              /**< SAI Receive Configuration 4 Register, offset: 0x90 */
+  __IO uint32_t RCR5;                              /**< SAI Receive Configuration 5 Register, offset: 0x94 */
+       uint8_t RESERVED_4[8];
+  __I  uint32_t RDR[2];                            /**< SAI Receive Data Register, array offset: 0xA0, array step: 0x4 */
+       uint8_t RESERVED_5[24];
+  __I  uint32_t RFR[2];                            /**< SAI Receive FIFO Register, array offset: 0xC0, array step: 0x4 */
+       uint8_t RESERVED_6[24];
+  __IO uint32_t RMR;                               /**< SAI Receive Mask Register, offset: 0xE0 */
+       uint8_t RESERVED_7[28];
+  __IO uint32_t MCR;                               /**< SAI MCLK Control Register, offset: 0x100 */
+  __IO uint32_t MDR;                               /**< SAI MCLK Divide Register, offset: 0x104 */
+} I2S_Type, *I2S_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- I2S - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup I2S_Register_Accessor_Macros I2S - Register accessor macros
+ * @{
+ */
+
+
+/* I2S - Register accessors */
+#define I2S_TCSR_REG(base)                       ((base)->TCSR)
+#define I2S_TCR1_REG(base)                       ((base)->TCR1)
+#define I2S_TCR2_REG(base)                       ((base)->TCR2)
+#define I2S_TCR3_REG(base)                       ((base)->TCR3)
+#define I2S_TCR4_REG(base)                       ((base)->TCR4)
+#define I2S_TCR5_REG(base)                       ((base)->TCR5)
+#define I2S_TDR_REG(base,index)                  ((base)->TDR[index])
+#define I2S_TFR_REG(base,index)                  ((base)->TFR[index])
+#define I2S_TMR_REG(base)                        ((base)->TMR)
+#define I2S_RCSR_REG(base)                       ((base)->RCSR)
+#define I2S_RCR1_REG(base)                       ((base)->RCR1)
+#define I2S_RCR2_REG(base)                       ((base)->RCR2)
+#define I2S_RCR3_REG(base)                       ((base)->RCR3)
+#define I2S_RCR4_REG(base)                       ((base)->RCR4)
+#define I2S_RCR5_REG(base)                       ((base)->RCR5)
+#define I2S_RDR_REG(base,index)                  ((base)->RDR[index])
+#define I2S_RFR_REG(base,index)                  ((base)->RFR[index])
+#define I2S_RMR_REG(base)                        ((base)->RMR)
+#define I2S_MCR_REG(base)                        ((base)->MCR)
+#define I2S_MDR_REG(base)                        ((base)->MDR)
+
+/*!
+ * @}
+ */ /* end of group I2S_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- I2S Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup I2S_Register_Masks I2S Register Masks
+ * @{
+ */
+
+/* TCSR Bit Fields */
+#define I2S_TCSR_FRDE_MASK                       0x1u
+#define I2S_TCSR_FRDE_SHIFT                      0
+#define I2S_TCSR_FWDE_MASK                       0x2u
+#define I2S_TCSR_FWDE_SHIFT                      1
+#define I2S_TCSR_FRIE_MASK                       0x100u
+#define I2S_TCSR_FRIE_SHIFT                      8
+#define I2S_TCSR_FWIE_MASK                       0x200u
+#define I2S_TCSR_FWIE_SHIFT                      9
+#define I2S_TCSR_FEIE_MASK                       0x400u
+#define I2S_TCSR_FEIE_SHIFT                      10
+#define I2S_TCSR_SEIE_MASK                       0x800u
+#define I2S_TCSR_SEIE_SHIFT                      11
+#define I2S_TCSR_WSIE_MASK                       0x1000u
+#define I2S_TCSR_WSIE_SHIFT                      12
+#define I2S_TCSR_FRF_MASK                        0x10000u
+#define I2S_TCSR_FRF_SHIFT                       16
+#define I2S_TCSR_FWF_MASK                        0x20000u
+#define I2S_TCSR_FWF_SHIFT                       17
+#define I2S_TCSR_FEF_MASK                        0x40000u
+#define I2S_TCSR_FEF_SHIFT                       18
+#define I2S_TCSR_SEF_MASK                        0x80000u
+#define I2S_TCSR_SEF_SHIFT                       19
+#define I2S_TCSR_WSF_MASK                        0x100000u
+#define I2S_TCSR_WSF_SHIFT                       20
+#define I2S_TCSR_SR_MASK                         0x1000000u
+#define I2S_TCSR_SR_SHIFT                        24
+#define I2S_TCSR_FR_MASK                         0x2000000u
+#define I2S_TCSR_FR_SHIFT                        25
+#define I2S_TCSR_BCE_MASK                        0x10000000u
+#define I2S_TCSR_BCE_SHIFT                       28
+#define I2S_TCSR_DBGE_MASK                       0x20000000u
+#define I2S_TCSR_DBGE_SHIFT                      29
+#define I2S_TCSR_STOPE_MASK                      0x40000000u
+#define I2S_TCSR_STOPE_SHIFT                     30
+#define I2S_TCSR_TE_MASK                         0x80000000u
+#define I2S_TCSR_TE_SHIFT                        31
+/* TCR1 Bit Fields */
+#define I2S_TCR1_TFW_MASK                        0x7u
+#define I2S_TCR1_TFW_SHIFT                       0
+#define I2S_TCR1_TFW(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_TCR1_TFW_SHIFT))&I2S_TCR1_TFW_MASK)
+/* TCR2 Bit Fields */
+#define I2S_TCR2_DIV_MASK                        0xFFu
+#define I2S_TCR2_DIV_SHIFT                       0
+#define I2S_TCR2_DIV(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_TCR2_DIV_SHIFT))&I2S_TCR2_DIV_MASK)
+#define I2S_TCR2_BCD_MASK                        0x1000000u
+#define I2S_TCR2_BCD_SHIFT                       24
+#define I2S_TCR2_BCP_MASK                        0x2000000u
+#define I2S_TCR2_BCP_SHIFT                       25
+#define I2S_TCR2_MSEL_MASK                       0xC000000u
+#define I2S_TCR2_MSEL_SHIFT                      26
+#define I2S_TCR2_MSEL(x)                         (((uint32_t)(((uint32_t)(x))<<I2S_TCR2_MSEL_SHIFT))&I2S_TCR2_MSEL_MASK)
+#define I2S_TCR2_BCI_MASK                        0x10000000u
+#define I2S_TCR2_BCI_SHIFT                       28
+#define I2S_TCR2_BCS_MASK                        0x20000000u
+#define I2S_TCR2_BCS_SHIFT                       29
+#define I2S_TCR2_SYNC_MASK                       0xC0000000u
+#define I2S_TCR2_SYNC_SHIFT                      30
+#define I2S_TCR2_SYNC(x)                         (((uint32_t)(((uint32_t)(x))<<I2S_TCR2_SYNC_SHIFT))&I2S_TCR2_SYNC_MASK)
+/* TCR3 Bit Fields */
+#define I2S_TCR3_WDFL_MASK                       0x1Fu
+#define I2S_TCR3_WDFL_SHIFT                      0
+#define I2S_TCR3_WDFL(x)                         (((uint32_t)(((uint32_t)(x))<<I2S_TCR3_WDFL_SHIFT))&I2S_TCR3_WDFL_MASK)
+#define I2S_TCR3_TCE_MASK                        0x30000u
+#define I2S_TCR3_TCE_SHIFT                       16
+#define I2S_TCR3_TCE(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_TCR3_TCE_SHIFT))&I2S_TCR3_TCE_MASK)
+/* TCR4 Bit Fields */
+#define I2S_TCR4_FSD_MASK                        0x1u
+#define I2S_TCR4_FSD_SHIFT                       0
+#define I2S_TCR4_FSP_MASK                        0x2u
+#define I2S_TCR4_FSP_SHIFT                       1
+#define I2S_TCR4_FSE_MASK                        0x8u
+#define I2S_TCR4_FSE_SHIFT                       3
+#define I2S_TCR4_MF_MASK                         0x10u
+#define I2S_TCR4_MF_SHIFT                        4
+#define I2S_TCR4_SYWD_MASK                       0x1F00u
+#define I2S_TCR4_SYWD_SHIFT                      8
+#define I2S_TCR4_SYWD(x)                         (((uint32_t)(((uint32_t)(x))<<I2S_TCR4_SYWD_SHIFT))&I2S_TCR4_SYWD_MASK)
+#define I2S_TCR4_FRSZ_MASK                       0x1F0000u
+#define I2S_TCR4_FRSZ_SHIFT                      16
+#define I2S_TCR4_FRSZ(x)                         (((uint32_t)(((uint32_t)(x))<<I2S_TCR4_FRSZ_SHIFT))&I2S_TCR4_FRSZ_MASK)
+/* TCR5 Bit Fields */
+#define I2S_TCR5_FBT_MASK                        0x1F00u
+#define I2S_TCR5_FBT_SHIFT                       8
+#define I2S_TCR5_FBT(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_TCR5_FBT_SHIFT))&I2S_TCR5_FBT_MASK)
+#define I2S_TCR5_W0W_MASK                        0x1F0000u
+#define I2S_TCR5_W0W_SHIFT                       16
+#define I2S_TCR5_W0W(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_TCR5_W0W_SHIFT))&I2S_TCR5_W0W_MASK)
+#define I2S_TCR5_WNW_MASK                        0x1F000000u
+#define I2S_TCR5_WNW_SHIFT                       24
+#define I2S_TCR5_WNW(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_TCR5_WNW_SHIFT))&I2S_TCR5_WNW_MASK)
+/* TDR Bit Fields */
+#define I2S_TDR_TDR_MASK                         0xFFFFFFFFu
+#define I2S_TDR_TDR_SHIFT                        0
+#define I2S_TDR_TDR(x)                           (((uint32_t)(((uint32_t)(x))<<I2S_TDR_TDR_SHIFT))&I2S_TDR_TDR_MASK)
+/* TFR Bit Fields */
+#define I2S_TFR_RFP_MASK                         0xFu
+#define I2S_TFR_RFP_SHIFT                        0
+#define I2S_TFR_RFP(x)                           (((uint32_t)(((uint32_t)(x))<<I2S_TFR_RFP_SHIFT))&I2S_TFR_RFP_MASK)
+#define I2S_TFR_WFP_MASK                         0xF0000u
+#define I2S_TFR_WFP_SHIFT                        16
+#define I2S_TFR_WFP(x)                           (((uint32_t)(((uint32_t)(x))<<I2S_TFR_WFP_SHIFT))&I2S_TFR_WFP_MASK)
+/* TMR Bit Fields */
+#define I2S_TMR_TWM_MASK                         0xFFFFFFFFu
+#define I2S_TMR_TWM_SHIFT                        0
+#define I2S_TMR_TWM(x)                           (((uint32_t)(((uint32_t)(x))<<I2S_TMR_TWM_SHIFT))&I2S_TMR_TWM_MASK)
+/* RCSR Bit Fields */
+#define I2S_RCSR_FRDE_MASK                       0x1u
+#define I2S_RCSR_FRDE_SHIFT                      0
+#define I2S_RCSR_FWDE_MASK                       0x2u
+#define I2S_RCSR_FWDE_SHIFT                      1
+#define I2S_RCSR_FRIE_MASK                       0x100u
+#define I2S_RCSR_FRIE_SHIFT                      8
+#define I2S_RCSR_FWIE_MASK                       0x200u
+#define I2S_RCSR_FWIE_SHIFT                      9
+#define I2S_RCSR_FEIE_MASK                       0x400u
+#define I2S_RCSR_FEIE_SHIFT                      10
+#define I2S_RCSR_SEIE_MASK                       0x800u
+#define I2S_RCSR_SEIE_SHIFT                      11
+#define I2S_RCSR_WSIE_MASK                       0x1000u
+#define I2S_RCSR_WSIE_SHIFT                      12
+#define I2S_RCSR_FRF_MASK                        0x10000u
+#define I2S_RCSR_FRF_SHIFT                       16
+#define I2S_RCSR_FWF_MASK                        0x20000u
+#define I2S_RCSR_FWF_SHIFT                       17
+#define I2S_RCSR_FEF_MASK                        0x40000u
+#define I2S_RCSR_FEF_SHIFT                       18
+#define I2S_RCSR_SEF_MASK                        0x80000u
+#define I2S_RCSR_SEF_SHIFT                       19
+#define I2S_RCSR_WSF_MASK                        0x100000u
+#define I2S_RCSR_WSF_SHIFT                       20
+#define I2S_RCSR_SR_MASK                         0x1000000u
+#define I2S_RCSR_SR_SHIFT                        24
+#define I2S_RCSR_FR_MASK                         0x2000000u
+#define I2S_RCSR_FR_SHIFT                        25
+#define I2S_RCSR_BCE_MASK                        0x10000000u
+#define I2S_RCSR_BCE_SHIFT                       28
+#define I2S_RCSR_DBGE_MASK                       0x20000000u
+#define I2S_RCSR_DBGE_SHIFT                      29
+#define I2S_RCSR_STOPE_MASK                      0x40000000u
+#define I2S_RCSR_STOPE_SHIFT                     30
+#define I2S_RCSR_RE_MASK                         0x80000000u
+#define I2S_RCSR_RE_SHIFT                        31
+/* RCR1 Bit Fields */
+#define I2S_RCR1_RFW_MASK                        0x7u
+#define I2S_RCR1_RFW_SHIFT                       0
+#define I2S_RCR1_RFW(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_RCR1_RFW_SHIFT))&I2S_RCR1_RFW_MASK)
+/* RCR2 Bit Fields */
+#define I2S_RCR2_DIV_MASK                        0xFFu
+#define I2S_RCR2_DIV_SHIFT                       0
+#define I2S_RCR2_DIV(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_RCR2_DIV_SHIFT))&I2S_RCR2_DIV_MASK)
+#define I2S_RCR2_BCD_MASK                        0x1000000u
+#define I2S_RCR2_BCD_SHIFT                       24
+#define I2S_RCR2_BCP_MASK                        0x2000000u
+#define I2S_RCR2_BCP_SHIFT                       25
+#define I2S_RCR2_MSEL_MASK                       0xC000000u
+#define I2S_RCR2_MSEL_SHIFT                      26
+#define I2S_RCR2_MSEL(x)                         (((uint32_t)(((uint32_t)(x))<<I2S_RCR2_MSEL_SHIFT))&I2S_RCR2_MSEL_MASK)
+#define I2S_RCR2_BCI_MASK                        0x10000000u
+#define I2S_RCR2_BCI_SHIFT                       28
+#define I2S_RCR2_BCS_MASK                        0x20000000u
+#define I2S_RCR2_BCS_SHIFT                       29
+#define I2S_RCR2_SYNC_MASK                       0xC0000000u
+#define I2S_RCR2_SYNC_SHIFT                      30
+#define I2S_RCR2_SYNC(x)                         (((uint32_t)(((uint32_t)(x))<<I2S_RCR2_SYNC_SHIFT))&I2S_RCR2_SYNC_MASK)
+/* RCR3 Bit Fields */
+#define I2S_RCR3_WDFL_MASK                       0x1Fu
+#define I2S_RCR3_WDFL_SHIFT                      0
+#define I2S_RCR3_WDFL(x)                         (((uint32_t)(((uint32_t)(x))<<I2S_RCR3_WDFL_SHIFT))&I2S_RCR3_WDFL_MASK)
+#define I2S_RCR3_RCE_MASK                        0x30000u
+#define I2S_RCR3_RCE_SHIFT                       16
+#define I2S_RCR3_RCE(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_RCR3_RCE_SHIFT))&I2S_RCR3_RCE_MASK)
+/* RCR4 Bit Fields */
+#define I2S_RCR4_FSD_MASK                        0x1u
+#define I2S_RCR4_FSD_SHIFT                       0
+#define I2S_RCR4_FSP_MASK                        0x2u
+#define I2S_RCR4_FSP_SHIFT                       1
+#define I2S_RCR4_FSE_MASK                        0x8u
+#define I2S_RCR4_FSE_SHIFT                       3
+#define I2S_RCR4_MF_MASK                         0x10u
+#define I2S_RCR4_MF_SHIFT                        4
+#define I2S_RCR4_SYWD_MASK                       0x1F00u
+#define I2S_RCR4_SYWD_SHIFT                      8
+#define I2S_RCR4_SYWD(x)                         (((uint32_t)(((uint32_t)(x))<<I2S_RCR4_SYWD_SHIFT))&I2S_RCR4_SYWD_MASK)
+#define I2S_RCR4_FRSZ_MASK                       0x1F0000u
+#define I2S_RCR4_FRSZ_SHIFT                      16
+#define I2S_RCR4_FRSZ(x)                         (((uint32_t)(((uint32_t)(x))<<I2S_RCR4_FRSZ_SHIFT))&I2S_RCR4_FRSZ_MASK)
+/* RCR5 Bit Fields */
+#define I2S_RCR5_FBT_MASK                        0x1F00u
+#define I2S_RCR5_FBT_SHIFT                       8
+#define I2S_RCR5_FBT(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_RCR5_FBT_SHIFT))&I2S_RCR5_FBT_MASK)
+#define I2S_RCR5_W0W_MASK                        0x1F0000u
+#define I2S_RCR5_W0W_SHIFT                       16
+#define I2S_RCR5_W0W(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_RCR5_W0W_SHIFT))&I2S_RCR5_W0W_MASK)
+#define I2S_RCR5_WNW_MASK                        0x1F000000u
+#define I2S_RCR5_WNW_SHIFT                       24
+#define I2S_RCR5_WNW(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_RCR5_WNW_SHIFT))&I2S_RCR5_WNW_MASK)
+/* RDR Bit Fields */
+#define I2S_RDR_RDR_MASK                         0xFFFFFFFFu
+#define I2S_RDR_RDR_SHIFT                        0
+#define I2S_RDR_RDR(x)                           (((uint32_t)(((uint32_t)(x))<<I2S_RDR_RDR_SHIFT))&I2S_RDR_RDR_MASK)
+/* RFR Bit Fields */
+#define I2S_RFR_RFP_MASK                         0xFu
+#define I2S_RFR_RFP_SHIFT                        0
+#define I2S_RFR_RFP(x)                           (((uint32_t)(((uint32_t)(x))<<I2S_RFR_RFP_SHIFT))&I2S_RFR_RFP_MASK)
+#define I2S_RFR_WFP_MASK                         0xF0000u
+#define I2S_RFR_WFP_SHIFT                        16
+#define I2S_RFR_WFP(x)                           (((uint32_t)(((uint32_t)(x))<<I2S_RFR_WFP_SHIFT))&I2S_RFR_WFP_MASK)
+/* RMR Bit Fields */
+#define I2S_RMR_RWM_MASK                         0xFFFFFFFFu
+#define I2S_RMR_RWM_SHIFT                        0
+#define I2S_RMR_RWM(x)                           (((uint32_t)(((uint32_t)(x))<<I2S_RMR_RWM_SHIFT))&I2S_RMR_RWM_MASK)
+/* MCR Bit Fields */
+#define I2S_MCR_MICS_MASK                        0x3000000u
+#define I2S_MCR_MICS_SHIFT                       24
+#define I2S_MCR_MICS(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_MCR_MICS_SHIFT))&I2S_MCR_MICS_MASK)
+#define I2S_MCR_MOE_MASK                         0x40000000u
+#define I2S_MCR_MOE_SHIFT                        30
+#define I2S_MCR_DUF_MASK                         0x80000000u
+#define I2S_MCR_DUF_SHIFT                        31
+/* MDR Bit Fields */
+#define I2S_MDR_DIVIDE_MASK                      0xFFFu
+#define I2S_MDR_DIVIDE_SHIFT                     0
+#define I2S_MDR_DIVIDE(x)                        (((uint32_t)(((uint32_t)(x))<<I2S_MDR_DIVIDE_SHIFT))&I2S_MDR_DIVIDE_MASK)
+#define I2S_MDR_FRACT_MASK                       0xFF000u
+#define I2S_MDR_FRACT_SHIFT                      12
+#define I2S_MDR_FRACT(x)                         (((uint32_t)(((uint32_t)(x))<<I2S_MDR_FRACT_SHIFT))&I2S_MDR_FRACT_MASK)
+
+/*!
+ * @}
+ */ /* end of group I2S_Register_Masks */
+
+
+/* I2S - Peripheral instance base addresses */
+/** Peripheral I2S0 base address */
+#define I2S0_BASE                                (0x4002F000u)
+/** Peripheral I2S0 base pointer */
+#define I2S0                                     ((I2S_Type *)I2S0_BASE)
+#define I2S0_BASE_PTR                            (I2S0)
+/** Array initializer of I2S peripheral base addresses */
+#define I2S_BASE_ADDRS                           { I2S0_BASE }
+/** Array initializer of I2S peripheral base pointers */
+#define I2S_BASE_PTRS                            { I2S0 }
+/** Interrupt vectors for the I2S peripheral type */
+#define I2S_RX_IRQS                              { I2S0_Rx_IRQn }
+#define I2S_TX_IRQS                              { I2S0_Tx_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- I2S - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup I2S_Register_Accessor_Macros I2S - Register accessor macros
+ * @{
+ */
+
+
+/* I2S - Register instance definitions */
+/* I2S0 */
+#define I2S0_TCSR                                I2S_TCSR_REG(I2S0)
+#define I2S0_TCR1                                I2S_TCR1_REG(I2S0)
+#define I2S0_TCR2                                I2S_TCR2_REG(I2S0)
+#define I2S0_TCR3                                I2S_TCR3_REG(I2S0)
+#define I2S0_TCR4                                I2S_TCR4_REG(I2S0)
+#define I2S0_TCR5                                I2S_TCR5_REG(I2S0)
+#define I2S0_TDR0                                I2S_TDR_REG(I2S0,0)
+#define I2S0_TDR1                                I2S_TDR_REG(I2S0,1)
+#define I2S0_TFR0                                I2S_TFR_REG(I2S0,0)
+#define I2S0_TFR1                                I2S_TFR_REG(I2S0,1)
+#define I2S0_TMR                                 I2S_TMR_REG(I2S0)
+#define I2S0_RCSR                                I2S_RCSR_REG(I2S0)
+#define I2S0_RCR1                                I2S_RCR1_REG(I2S0)
+#define I2S0_RCR2                                I2S_RCR2_REG(I2S0)
+#define I2S0_RCR3                                I2S_RCR3_REG(I2S0)
+#define I2S0_RCR4                                I2S_RCR4_REG(I2S0)
+#define I2S0_RCR5                                I2S_RCR5_REG(I2S0)
+#define I2S0_RDR0                                I2S_RDR_REG(I2S0,0)
+#define I2S0_RDR1                                I2S_RDR_REG(I2S0,1)
+#define I2S0_RFR0                                I2S_RFR_REG(I2S0,0)
+#define I2S0_RFR1                                I2S_RFR_REG(I2S0,1)
+#define I2S0_RMR                                 I2S_RMR_REG(I2S0)
+#define I2S0_MCR                                 I2S_MCR_REG(I2S0)
+#define I2S0_MDR                                 I2S_MDR_REG(I2S0)
+
+/* I2S - Register array accessors */
+#define I2S0_TDR(index)                          I2S_TDR_REG(I2S0,index)
+#define I2S0_TFR(index)                          I2S_TFR_REG(I2S0,index)
+#define I2S0_RDR(index)                          I2S_RDR_REG(I2S0,index)
+#define I2S0_RFR(index)                          I2S_RFR_REG(I2S0,index)
+
+/*!
+ * @}
+ */ /* end of group I2S_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group I2S_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- LLWU Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LLWU_Peripheral_Access_Layer LLWU Peripheral Access Layer
+ * @{
+ */
+
+/** LLWU - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t PE1;                                /**< LLWU Pin Enable 1 register, offset: 0x0 */
+  __IO uint8_t PE2;                                /**< LLWU Pin Enable 2 register, offset: 0x1 */
+  __IO uint8_t PE3;                                /**< LLWU Pin Enable 3 register, offset: 0x2 */
+  __IO uint8_t PE4;                                /**< LLWU Pin Enable 4 register, offset: 0x3 */
+  __IO uint8_t ME;                                 /**< LLWU Module Enable register, offset: 0x4 */
+  __IO uint8_t F1;                                 /**< LLWU Flag 1 register, offset: 0x5 */
+  __IO uint8_t F2;                                 /**< LLWU Flag 2 register, offset: 0x6 */
+  __I  uint8_t F3;                                 /**< LLWU Flag 3 register, offset: 0x7 */
+  __IO uint8_t FILT1;                              /**< LLWU Pin Filter 1 register, offset: 0x8 */
+  __IO uint8_t FILT2;                              /**< LLWU Pin Filter 2 register, offset: 0x9 */
+  __IO uint8_t RST;                                /**< LLWU Reset Enable register, offset: 0xA */
+} LLWU_Type, *LLWU_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- LLWU - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LLWU_Register_Accessor_Macros LLWU - Register accessor macros
+ * @{
+ */
+
+
+/* LLWU - Register accessors */
+#define LLWU_PE1_REG(base)                       ((base)->PE1)
+#define LLWU_PE2_REG(base)                       ((base)->PE2)
+#define LLWU_PE3_REG(base)                       ((base)->PE3)
+#define LLWU_PE4_REG(base)                       ((base)->PE4)
+#define LLWU_ME_REG(base)                        ((base)->ME)
+#define LLWU_F1_REG(base)                        ((base)->F1)
+#define LLWU_F2_REG(base)                        ((base)->F2)
+#define LLWU_F3_REG(base)                        ((base)->F3)
+#define LLWU_FILT1_REG(base)                     ((base)->FILT1)
+#define LLWU_FILT2_REG(base)                     ((base)->FILT2)
+#define LLWU_RST_REG(base)                       ((base)->RST)
+
+/*!
+ * @}
+ */ /* end of group LLWU_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- LLWU Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LLWU_Register_Masks LLWU Register Masks
+ * @{
+ */
+
+/* PE1 Bit Fields */
+#define LLWU_PE1_WUPE0_MASK                      0x3u
+#define LLWU_PE1_WUPE0_SHIFT                     0
+#define LLWU_PE1_WUPE0(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE1_WUPE0_SHIFT))&LLWU_PE1_WUPE0_MASK)
+#define LLWU_PE1_WUPE1_MASK                      0xCu
+#define LLWU_PE1_WUPE1_SHIFT                     2
+#define LLWU_PE1_WUPE1(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE1_WUPE1_SHIFT))&LLWU_PE1_WUPE1_MASK)
+#define LLWU_PE1_WUPE2_MASK                      0x30u
+#define LLWU_PE1_WUPE2_SHIFT                     4
+#define LLWU_PE1_WUPE2(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE1_WUPE2_SHIFT))&LLWU_PE1_WUPE2_MASK)
+#define LLWU_PE1_WUPE3_MASK                      0xC0u
+#define LLWU_PE1_WUPE3_SHIFT                     6
+#define LLWU_PE1_WUPE3(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE1_WUPE3_SHIFT))&LLWU_PE1_WUPE3_MASK)
+/* PE2 Bit Fields */
+#define LLWU_PE2_WUPE4_MASK                      0x3u
+#define LLWU_PE2_WUPE4_SHIFT                     0
+#define LLWU_PE2_WUPE4(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE2_WUPE4_SHIFT))&LLWU_PE2_WUPE4_MASK)
+#define LLWU_PE2_WUPE5_MASK                      0xCu
+#define LLWU_PE2_WUPE5_SHIFT                     2
+#define LLWU_PE2_WUPE5(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE2_WUPE5_SHIFT))&LLWU_PE2_WUPE5_MASK)
+#define LLWU_PE2_WUPE6_MASK                      0x30u
+#define LLWU_PE2_WUPE6_SHIFT                     4
+#define LLWU_PE2_WUPE6(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE2_WUPE6_SHIFT))&LLWU_PE2_WUPE6_MASK)
+#define LLWU_PE2_WUPE7_MASK                      0xC0u
+#define LLWU_PE2_WUPE7_SHIFT                     6
+#define LLWU_PE2_WUPE7(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE2_WUPE7_SHIFT))&LLWU_PE2_WUPE7_MASK)
+/* PE3 Bit Fields */
+#define LLWU_PE3_WUPE8_MASK                      0x3u
+#define LLWU_PE3_WUPE8_SHIFT                     0
+#define LLWU_PE3_WUPE8(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE3_WUPE8_SHIFT))&LLWU_PE3_WUPE8_MASK)
+#define LLWU_PE3_WUPE9_MASK                      0xCu
+#define LLWU_PE3_WUPE9_SHIFT                     2
+#define LLWU_PE3_WUPE9(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE3_WUPE9_SHIFT))&LLWU_PE3_WUPE9_MASK)
+#define LLWU_PE3_WUPE10_MASK                     0x30u
+#define LLWU_PE3_WUPE10_SHIFT                    4
+#define LLWU_PE3_WUPE10(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE3_WUPE10_SHIFT))&LLWU_PE3_WUPE10_MASK)
+#define LLWU_PE3_WUPE11_MASK                     0xC0u
+#define LLWU_PE3_WUPE11_SHIFT                    6
+#define LLWU_PE3_WUPE11(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE3_WUPE11_SHIFT))&LLWU_PE3_WUPE11_MASK)
+/* PE4 Bit Fields */
+#define LLWU_PE4_WUPE12_MASK                     0x3u
+#define LLWU_PE4_WUPE12_SHIFT                    0
+#define LLWU_PE4_WUPE12(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE4_WUPE12_SHIFT))&LLWU_PE4_WUPE12_MASK)
+#define LLWU_PE4_WUPE13_MASK                     0xCu
+#define LLWU_PE4_WUPE13_SHIFT                    2
+#define LLWU_PE4_WUPE13(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE4_WUPE13_SHIFT))&LLWU_PE4_WUPE13_MASK)
+#define LLWU_PE4_WUPE14_MASK                     0x30u
+#define LLWU_PE4_WUPE14_SHIFT                    4
+#define LLWU_PE4_WUPE14(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE4_WUPE14_SHIFT))&LLWU_PE4_WUPE14_MASK)
+#define LLWU_PE4_WUPE15_MASK                     0xC0u
+#define LLWU_PE4_WUPE15_SHIFT                    6
+#define LLWU_PE4_WUPE15(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE4_WUPE15_SHIFT))&LLWU_PE4_WUPE15_MASK)
+/* ME Bit Fields */
+#define LLWU_ME_WUME0_MASK                       0x1u
+#define LLWU_ME_WUME0_SHIFT                      0
+#define LLWU_ME_WUME1_MASK                       0x2u
+#define LLWU_ME_WUME1_SHIFT                      1
+#define LLWU_ME_WUME2_MASK                       0x4u
+#define LLWU_ME_WUME2_SHIFT                      2
+#define LLWU_ME_WUME3_MASK                       0x8u
+#define LLWU_ME_WUME3_SHIFT                      3
+#define LLWU_ME_WUME4_MASK                       0x10u
+#define LLWU_ME_WUME4_SHIFT                      4
+#define LLWU_ME_WUME5_MASK                       0x20u
+#define LLWU_ME_WUME5_SHIFT                      5
+#define LLWU_ME_WUME6_MASK                       0x40u
+#define LLWU_ME_WUME6_SHIFT                      6
+#define LLWU_ME_WUME7_MASK                       0x80u
+#define LLWU_ME_WUME7_SHIFT                      7
+/* F1 Bit Fields */
+#define LLWU_F1_WUF0_MASK                        0x1u
+#define LLWU_F1_WUF0_SHIFT                       0
+#define LLWU_F1_WUF1_MASK                        0x2u
+#define LLWU_F1_WUF1_SHIFT                       1
+#define LLWU_F1_WUF2_MASK                        0x4u
+#define LLWU_F1_WUF2_SHIFT                       2
+#define LLWU_F1_WUF3_MASK                        0x8u
+#define LLWU_F1_WUF3_SHIFT                       3
+#define LLWU_F1_WUF4_MASK                        0x10u
+#define LLWU_F1_WUF4_SHIFT                       4
+#define LLWU_F1_WUF5_MASK                        0x20u
+#define LLWU_F1_WUF5_SHIFT                       5
+#define LLWU_F1_WUF6_MASK                        0x40u
+#define LLWU_F1_WUF6_SHIFT                       6
+#define LLWU_F1_WUF7_MASK                        0x80u
+#define LLWU_F1_WUF7_SHIFT                       7
+/* F2 Bit Fields */
+#define LLWU_F2_WUF8_MASK                        0x1u
+#define LLWU_F2_WUF8_SHIFT                       0
+#define LLWU_F2_WUF9_MASK                        0x2u
+#define LLWU_F2_WUF9_SHIFT                       1
+#define LLWU_F2_WUF10_MASK                       0x4u
+#define LLWU_F2_WUF10_SHIFT                      2
+#define LLWU_F2_WUF11_MASK                       0x8u
+#define LLWU_F2_WUF11_SHIFT                      3
+#define LLWU_F2_WUF12_MASK                       0x10u
+#define LLWU_F2_WUF12_SHIFT                      4
+#define LLWU_F2_WUF13_MASK                       0x20u
+#define LLWU_F2_WUF13_SHIFT                      5
+#define LLWU_F2_WUF14_MASK                       0x40u
+#define LLWU_F2_WUF14_SHIFT                      6
+#define LLWU_F2_WUF15_MASK                       0x80u
+#define LLWU_F2_WUF15_SHIFT                      7
+/* F3 Bit Fields */
+#define LLWU_F3_MWUF0_MASK                       0x1u
+#define LLWU_F3_MWUF0_SHIFT                      0
+#define LLWU_F3_MWUF1_MASK                       0x2u
+#define LLWU_F3_MWUF1_SHIFT                      1
+#define LLWU_F3_MWUF2_MASK                       0x4u
+#define LLWU_F3_MWUF2_SHIFT                      2
+#define LLWU_F3_MWUF3_MASK                       0x8u
+#define LLWU_F3_MWUF3_SHIFT                      3
+#define LLWU_F3_MWUF4_MASK                       0x10u
+#define LLWU_F3_MWUF4_SHIFT                      4
+#define LLWU_F3_MWUF5_MASK                       0x20u
+#define LLWU_F3_MWUF5_SHIFT                      5
+#define LLWU_F3_MWUF6_MASK                       0x40u
+#define LLWU_F3_MWUF6_SHIFT                      6
+#define LLWU_F3_MWUF7_MASK                       0x80u
+#define LLWU_F3_MWUF7_SHIFT                      7
+/* FILT1 Bit Fields */
+#define LLWU_FILT1_FILTSEL_MASK                  0xFu
+#define LLWU_FILT1_FILTSEL_SHIFT                 0
+#define LLWU_FILT1_FILTSEL(x)                    (((uint8_t)(((uint8_t)(x))<<LLWU_FILT1_FILTSEL_SHIFT))&LLWU_FILT1_FILTSEL_MASK)
+#define LLWU_FILT1_FILTE_MASK                    0x60u
+#define LLWU_FILT1_FILTE_SHIFT                   5
+#define LLWU_FILT1_FILTE(x)                      (((uint8_t)(((uint8_t)(x))<<LLWU_FILT1_FILTE_SHIFT))&LLWU_FILT1_FILTE_MASK)
+#define LLWU_FILT1_FILTF_MASK                    0x80u
+#define LLWU_FILT1_FILTF_SHIFT                   7
+/* FILT2 Bit Fields */
+#define LLWU_FILT2_FILTSEL_MASK                  0xFu
+#define LLWU_FILT2_FILTSEL_SHIFT                 0
+#define LLWU_FILT2_FILTSEL(x)                    (((uint8_t)(((uint8_t)(x))<<LLWU_FILT2_FILTSEL_SHIFT))&LLWU_FILT2_FILTSEL_MASK)
+#define LLWU_FILT2_FILTE_MASK                    0x60u
+#define LLWU_FILT2_FILTE_SHIFT                   5
+#define LLWU_FILT2_FILTE(x)                      (((uint8_t)(((uint8_t)(x))<<LLWU_FILT2_FILTE_SHIFT))&LLWU_FILT2_FILTE_MASK)
+#define LLWU_FILT2_FILTF_MASK                    0x80u
+#define LLWU_FILT2_FILTF_SHIFT                   7
+/* RST Bit Fields */
+#define LLWU_RST_RSTFILT_MASK                    0x1u
+#define LLWU_RST_RSTFILT_SHIFT                   0
+#define LLWU_RST_LLRSTE_MASK                     0x2u
+#define LLWU_RST_LLRSTE_SHIFT                    1
+
+/*!
+ * @}
+ */ /* end of group LLWU_Register_Masks */
+
+
+/* LLWU - Peripheral instance base addresses */
+/** Peripheral LLWU base address */
+#define LLWU_BASE                                (0x4007C000u)
+/** Peripheral LLWU base pointer */
+#define LLWU                                     ((LLWU_Type *)LLWU_BASE)
+#define LLWU_BASE_PTR                            (LLWU)
+/** Array initializer of LLWU peripheral base addresses */
+#define LLWU_BASE_ADDRS                          { LLWU_BASE }
+/** Array initializer of LLWU peripheral base pointers */
+#define LLWU_BASE_PTRS                           { LLWU }
+/** Interrupt vectors for the LLWU peripheral type */
+#define LLWU_IRQS                                { LLW_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- LLWU - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LLWU_Register_Accessor_Macros LLWU - Register accessor macros
+ * @{
+ */
+
+
+/* LLWU - Register instance definitions */
+/* LLWU */
+#define LLWU_PE1                                 LLWU_PE1_REG(LLWU)
+#define LLWU_PE2                                 LLWU_PE2_REG(LLWU)
+#define LLWU_PE3                                 LLWU_PE3_REG(LLWU)
+#define LLWU_PE4                                 LLWU_PE4_REG(LLWU)
+#define LLWU_ME                                  LLWU_ME_REG(LLWU)
+#define LLWU_F1                                  LLWU_F1_REG(LLWU)
+#define LLWU_F2                                  LLWU_F2_REG(LLWU)
+#define LLWU_F3                                  LLWU_F3_REG(LLWU)
+#define LLWU_FILT1                               LLWU_FILT1_REG(LLWU)
+#define LLWU_FILT2                               LLWU_FILT2_REG(LLWU)
+#define LLWU_RST                                 LLWU_RST_REG(LLWU)
+
+/*!
+ * @}
+ */ /* end of group LLWU_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group LLWU_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- LPTMR Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LPTMR_Peripheral_Access_Layer LPTMR Peripheral Access Layer
+ * @{
+ */
+
+/** LPTMR - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t CSR;                               /**< Low Power Timer Control Status Register, offset: 0x0 */
+  __IO uint32_t PSR;                               /**< Low Power Timer Prescale Register, offset: 0x4 */
+  __IO uint32_t CMR;                               /**< Low Power Timer Compare Register, offset: 0x8 */
+  __IO uint32_t CNR;                               /**< Low Power Timer Counter Register, offset: 0xC */
+} LPTMR_Type, *LPTMR_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- LPTMR - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LPTMR_Register_Accessor_Macros LPTMR - Register accessor macros
+ * @{
+ */
+
+
+/* LPTMR - Register accessors */
+#define LPTMR_CSR_REG(base)                      ((base)->CSR)
+#define LPTMR_PSR_REG(base)                      ((base)->PSR)
+#define LPTMR_CMR_REG(base)                      ((base)->CMR)
+#define LPTMR_CNR_REG(base)                      ((base)->CNR)
+
+/*!
+ * @}
+ */ /* end of group LPTMR_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- LPTMR Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LPTMR_Register_Masks LPTMR Register Masks
+ * @{
+ */
+
+/* CSR Bit Fields */
+#define LPTMR_CSR_TEN_MASK                       0x1u
+#define LPTMR_CSR_TEN_SHIFT                      0
+#define LPTMR_CSR_TMS_MASK                       0x2u
+#define LPTMR_CSR_TMS_SHIFT                      1
+#define LPTMR_CSR_TFC_MASK                       0x4u
+#define LPTMR_CSR_TFC_SHIFT                      2
+#define LPTMR_CSR_TPP_MASK                       0x8u
+#define LPTMR_CSR_TPP_SHIFT                      3
+#define LPTMR_CSR_TPS_MASK                       0x30u
+#define LPTMR_CSR_TPS_SHIFT                      4
+#define LPTMR_CSR_TPS(x)                         (((uint32_t)(((uint32_t)(x))<<LPTMR_CSR_TPS_SHIFT))&LPTMR_CSR_TPS_MASK)
+#define LPTMR_CSR_TIE_MASK                       0x40u
+#define LPTMR_CSR_TIE_SHIFT                      6
+#define LPTMR_CSR_TCF_MASK                       0x80u
+#define LPTMR_CSR_TCF_SHIFT                      7
+/* PSR Bit Fields */
+#define LPTMR_PSR_PCS_MASK                       0x3u
+#define LPTMR_PSR_PCS_SHIFT                      0
+#define LPTMR_PSR_PCS(x)                         (((uint32_t)(((uint32_t)(x))<<LPTMR_PSR_PCS_SHIFT))&LPTMR_PSR_PCS_MASK)
+#define LPTMR_PSR_PBYP_MASK                      0x4u
+#define LPTMR_PSR_PBYP_SHIFT                     2
+#define LPTMR_PSR_PRESCALE_MASK                  0x78u
+#define LPTMR_PSR_PRESCALE_SHIFT                 3
+#define LPTMR_PSR_PRESCALE(x)                    (((uint32_t)(((uint32_t)(x))<<LPTMR_PSR_PRESCALE_SHIFT))&LPTMR_PSR_PRESCALE_MASK)
+/* CMR Bit Fields */
+#define LPTMR_CMR_COMPARE_MASK                   0xFFFFu
+#define LPTMR_CMR_COMPARE_SHIFT                  0
+#define LPTMR_CMR_COMPARE(x)                     (((uint32_t)(((uint32_t)(x))<<LPTMR_CMR_COMPARE_SHIFT))&LPTMR_CMR_COMPARE_MASK)
+/* CNR Bit Fields */
+#define LPTMR_CNR_COUNTER_MASK                   0xFFFFu
+#define LPTMR_CNR_COUNTER_SHIFT                  0
+#define LPTMR_CNR_COUNTER(x)                     (((uint32_t)(((uint32_t)(x))<<LPTMR_CNR_COUNTER_SHIFT))&LPTMR_CNR_COUNTER_MASK)
+
+/*!
+ * @}
+ */ /* end of group LPTMR_Register_Masks */
+
+
+/* LPTMR - Peripheral instance base addresses */
+/** Peripheral LPTMR0 base address */
+#define LPTMR0_BASE                              (0x40040000u)
+/** Peripheral LPTMR0 base pointer */
+#define LPTMR0                                   ((LPTMR_Type *)LPTMR0_BASE)
+#define LPTMR0_BASE_PTR                          (LPTMR0)
+/** Array initializer of LPTMR peripheral base addresses */
+#define LPTMR_BASE_ADDRS                         { LPTMR0_BASE }
+/** Array initializer of LPTMR peripheral base pointers */
+#define LPTMR_BASE_PTRS                          { LPTMR0 }
+/** Interrupt vectors for the LPTMR peripheral type */
+#define LPTMR_IRQS                               { LPTimer_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- LPTMR - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LPTMR_Register_Accessor_Macros LPTMR - Register accessor macros
+ * @{
+ */
+
+
+/* LPTMR - Register instance definitions */
+/* LPTMR0 */
+#define LPTMR0_CSR                               LPTMR_CSR_REG(LPTMR0)
+#define LPTMR0_PSR                               LPTMR_PSR_REG(LPTMR0)
+#define LPTMR0_CMR                               LPTMR_CMR_REG(LPTMR0)
+#define LPTMR0_CNR                               LPTMR_CNR_REG(LPTMR0)
+
+/*!
+ * @}
+ */ /* end of group LPTMR_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group LPTMR_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- MCG Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCG_Peripheral_Access_Layer MCG Peripheral Access Layer
+ * @{
+ */
+
+/** MCG - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t C1;                                 /**< MCG Control 1 Register, offset: 0x0 */
+  __IO uint8_t C2;                                 /**< MCG Control 2 Register, offset: 0x1 */
+  __IO uint8_t C3;                                 /**< MCG Control 3 Register, offset: 0x2 */
+  __IO uint8_t C4;                                 /**< MCG Control 4 Register, offset: 0x3 */
+  __IO uint8_t C5;                                 /**< MCG Control 5 Register, offset: 0x4 */
+  __IO uint8_t C6;                                 /**< MCG Control 6 Register, offset: 0x5 */
+  __IO uint8_t S;                                  /**< MCG Status Register, offset: 0x6 */
+       uint8_t RESERVED_0[1];
+  __IO uint8_t SC;                                 /**< MCG Status and Control Register, offset: 0x8 */
+       uint8_t RESERVED_1[1];
+  __IO uint8_t ATCVH;                              /**< MCG Auto Trim Compare Value High Register, offset: 0xA */
+  __IO uint8_t ATCVL;                              /**< MCG Auto Trim Compare Value Low Register, offset: 0xB */
+  __IO uint8_t C7;                                 /**< MCG Control 7 Register, offset: 0xC */
+  __IO uint8_t C8;                                 /**< MCG Control 8 Register, offset: 0xD */
+} MCG_Type, *MCG_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- MCG - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCG_Register_Accessor_Macros MCG - Register accessor macros
+ * @{
+ */
+
+
+/* MCG - Register accessors */
+#define MCG_C1_REG(base)                         ((base)->C1)
+#define MCG_C2_REG(base)                         ((base)->C2)
+#define MCG_C3_REG(base)                         ((base)->C3)
+#define MCG_C4_REG(base)                         ((base)->C4)
+#define MCG_C5_REG(base)                         ((base)->C5)
+#define MCG_C6_REG(base)                         ((base)->C6)
+#define MCG_S_REG(base)                          ((base)->S)
+#define MCG_SC_REG(base)                         ((base)->SC)
+#define MCG_ATCVH_REG(base)                      ((base)->ATCVH)
+#define MCG_ATCVL_REG(base)                      ((base)->ATCVL)
+#define MCG_C7_REG(base)                         ((base)->C7)
+#define MCG_C8_REG(base)                         ((base)->C8)
+
+/*!
+ * @}
+ */ /* end of group MCG_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- MCG Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCG_Register_Masks MCG Register Masks
+ * @{
+ */
+
+/* C1 Bit Fields */
+#define MCG_C1_IREFSTEN_MASK                     0x1u
+#define MCG_C1_IREFSTEN_SHIFT                    0
+#define MCG_C1_IRCLKEN_MASK                      0x2u
+#define MCG_C1_IRCLKEN_SHIFT                     1
+#define MCG_C1_IREFS_MASK                        0x4u
+#define MCG_C1_IREFS_SHIFT                       2
+#define MCG_C1_FRDIV_MASK                        0x38u
+#define MCG_C1_FRDIV_SHIFT                       3
+#define MCG_C1_FRDIV(x)                          (((uint8_t)(((uint8_t)(x))<<MCG_C1_FRDIV_SHIFT))&MCG_C1_FRDIV_MASK)
+#define MCG_C1_CLKS_MASK                         0xC0u
+#define MCG_C1_CLKS_SHIFT                        6
+#define MCG_C1_CLKS(x)                           (((uint8_t)(((uint8_t)(x))<<MCG_C1_CLKS_SHIFT))&MCG_C1_CLKS_MASK)
+/* C2 Bit Fields */
+#define MCG_C2_IRCS_MASK                         0x1u
+#define MCG_C2_IRCS_SHIFT                        0
+#define MCG_C2_LP_MASK                           0x2u
+#define MCG_C2_LP_SHIFT                          1
+#define MCG_C2_EREFS_MASK                        0x4u
+#define MCG_C2_EREFS_SHIFT                       2
+#define MCG_C2_HGO_MASK                          0x8u
+#define MCG_C2_HGO_SHIFT                         3
+#define MCG_C2_RANGE_MASK                        0x30u
+#define MCG_C2_RANGE_SHIFT                       4
+#define MCG_C2_RANGE(x)                          (((uint8_t)(((uint8_t)(x))<<MCG_C2_RANGE_SHIFT))&MCG_C2_RANGE_MASK)
+#define MCG_C2_FCFTRIM_MASK                      0x40u
+#define MCG_C2_FCFTRIM_SHIFT                     6
+#define MCG_C2_LOCRE0_MASK                       0x80u
+#define MCG_C2_LOCRE0_SHIFT                      7
+/* C3 Bit Fields */
+#define MCG_C3_SCTRIM_MASK                       0xFFu
+#define MCG_C3_SCTRIM_SHIFT                      0
+#define MCG_C3_SCTRIM(x)                         (((uint8_t)(((uint8_t)(x))<<MCG_C3_SCTRIM_SHIFT))&MCG_C3_SCTRIM_MASK)
+/* C4 Bit Fields */
+#define MCG_C4_SCFTRIM_MASK                      0x1u
+#define MCG_C4_SCFTRIM_SHIFT                     0
+#define MCG_C4_FCTRIM_MASK                       0x1Eu
+#define MCG_C4_FCTRIM_SHIFT                      1
+#define MCG_C4_FCTRIM(x)                         (((uint8_t)(((uint8_t)(x))<<MCG_C4_FCTRIM_SHIFT))&MCG_C4_FCTRIM_MASK)
+#define MCG_C4_DRST_DRS_MASK                     0x60u
+#define MCG_C4_DRST_DRS_SHIFT                    5
+#define MCG_C4_DRST_DRS(x)                       (((uint8_t)(((uint8_t)(x))<<MCG_C4_DRST_DRS_SHIFT))&MCG_C4_DRST_DRS_MASK)
+#define MCG_C4_DMX32_MASK                        0x80u
+#define MCG_C4_DMX32_SHIFT                       7
+/* C5 Bit Fields */
+#define MCG_C5_PRDIV0_MASK                       0x1Fu
+#define MCG_C5_PRDIV0_SHIFT                      0
+#define MCG_C5_PRDIV0(x)                         (((uint8_t)(((uint8_t)(x))<<MCG_C5_PRDIV0_SHIFT))&MCG_C5_PRDIV0_MASK)
+#define MCG_C5_PLLSTEN0_MASK                     0x20u
+#define MCG_C5_PLLSTEN0_SHIFT                    5
+#define MCG_C5_PLLCLKEN0_MASK                    0x40u
+#define MCG_C5_PLLCLKEN0_SHIFT                   6
+/* C6 Bit Fields */
+#define MCG_C6_VDIV0_MASK                        0x1Fu
+#define MCG_C6_VDIV0_SHIFT                       0
+#define MCG_C6_VDIV0(x)                          (((uint8_t)(((uint8_t)(x))<<MCG_C6_VDIV0_SHIFT))&MCG_C6_VDIV0_MASK)
+#define MCG_C6_CME0_MASK                         0x20u
+#define MCG_C6_CME0_SHIFT                        5
+#define MCG_C6_PLLS_MASK                         0x40u
+#define MCG_C6_PLLS_SHIFT                        6
+#define MCG_C6_LOLIE0_MASK                       0x80u
+#define MCG_C6_LOLIE0_SHIFT                      7
+/* S Bit Fields */
+#define MCG_S_IRCST_MASK                         0x1u
+#define MCG_S_IRCST_SHIFT                        0
+#define MCG_S_OSCINIT0_MASK                      0x2u
+#define MCG_S_OSCINIT0_SHIFT                     1
+#define MCG_S_CLKST_MASK                         0xCu
+#define MCG_S_CLKST_SHIFT                        2
+#define MCG_S_CLKST(x)                           (((uint8_t)(((uint8_t)(x))<<MCG_S_CLKST_SHIFT))&MCG_S_CLKST_MASK)
+#define MCG_S_IREFST_MASK                        0x10u
+#define MCG_S_IREFST_SHIFT                       4
+#define MCG_S_PLLST_MASK                         0x20u
+#define MCG_S_PLLST_SHIFT                        5
+#define MCG_S_LOCK0_MASK                         0x40u
+#define MCG_S_LOCK0_SHIFT                        6
+#define MCG_S_LOLS0_MASK                         0x80u
+#define MCG_S_LOLS0_SHIFT                        7
+/* SC Bit Fields */
+#define MCG_SC_LOCS0_MASK                        0x1u
+#define MCG_SC_LOCS0_SHIFT                       0
+#define MCG_SC_FCRDIV_MASK                       0xEu
+#define MCG_SC_FCRDIV_SHIFT                      1
+#define MCG_SC_FCRDIV(x)                         (((uint8_t)(((uint8_t)(x))<<MCG_SC_FCRDIV_SHIFT))&MCG_SC_FCRDIV_MASK)
+#define MCG_SC_FLTPRSRV_MASK                     0x10u
+#define MCG_SC_FLTPRSRV_SHIFT                    4
+#define MCG_SC_ATMF_MASK                         0x20u
+#define MCG_SC_ATMF_SHIFT                        5
+#define MCG_SC_ATMS_MASK                         0x40u
+#define MCG_SC_ATMS_SHIFT                        6
+#define MCG_SC_ATME_MASK                         0x80u
+#define MCG_SC_ATME_SHIFT                        7
+/* ATCVH Bit Fields */
+#define MCG_ATCVH_ATCVH_MASK                     0xFFu
+#define MCG_ATCVH_ATCVH_SHIFT                    0
+#define MCG_ATCVH_ATCVH(x)                       (((uint8_t)(((uint8_t)(x))<<MCG_ATCVH_ATCVH_SHIFT))&MCG_ATCVH_ATCVH_MASK)
+/* ATCVL Bit Fields */
+#define MCG_ATCVL_ATCVL_MASK                     0xFFu
+#define MCG_ATCVL_ATCVL_SHIFT                    0
+#define MCG_ATCVL_ATCVL(x)                       (((uint8_t)(((uint8_t)(x))<<MCG_ATCVL_ATCVL_SHIFT))&MCG_ATCVL_ATCVL_MASK)
+/* C7 Bit Fields */
+#define MCG_C7_OSCSEL_MASK                       0x3u
+#define MCG_C7_OSCSEL_SHIFT                      0
+#define MCG_C7_OSCSEL(x)                         (((uint8_t)(((uint8_t)(x))<<MCG_C7_OSCSEL_SHIFT))&MCG_C7_OSCSEL_MASK)
+/* C8 Bit Fields */
+#define MCG_C8_LOCS1_MASK                        0x1u
+#define MCG_C8_LOCS1_SHIFT                       0
+#define MCG_C8_CME1_MASK                         0x20u
+#define MCG_C8_CME1_SHIFT                        5
+#define MCG_C8_LOLRE_MASK                        0x40u
+#define MCG_C8_LOLRE_SHIFT                       6
+#define MCG_C8_LOCRE1_MASK                       0x80u
+#define MCG_C8_LOCRE1_SHIFT                      7
+
+/*!
+ * @}
+ */ /* end of group MCG_Register_Masks */
+
+
+/* MCG - Peripheral instance base addresses */
+/** Peripheral MCG base address */
+#define MCG_BASE                                 (0x40064000u)
+/** Peripheral MCG base pointer */
+#define MCG                                      ((MCG_Type *)MCG_BASE)
+#define MCG_BASE_PTR                             (MCG)
+/** Array initializer of MCG peripheral base addresses */
+#define MCG_BASE_ADDRS                           { MCG_BASE }
+/** Array initializer of MCG peripheral base pointers */
+#define MCG_BASE_PTRS                            { MCG }
+
+/* ----------------------------------------------------------------------------
+   -- MCG - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCG_Register_Accessor_Macros MCG - Register accessor macros
+ * @{
+ */
+
+
+/* MCG - Register instance definitions */
+/* MCG */
+#define MCG_C1                                   MCG_C1_REG(MCG)
+#define MCG_C2                                   MCG_C2_REG(MCG)
+#define MCG_C3                                   MCG_C3_REG(MCG)
+#define MCG_C4                                   MCG_C4_REG(MCG)
+#define MCG_C5                                   MCG_C5_REG(MCG)
+#define MCG_C6                                   MCG_C6_REG(MCG)
+#define MCG_S                                    MCG_S_REG(MCG)
+#define MCG_SC                                   MCG_SC_REG(MCG)
+#define MCG_ATCVH                                MCG_ATCVH_REG(MCG)
+#define MCG_ATCVL                                MCG_ATCVL_REG(MCG)
+#define MCG_C7                                   MCG_C7_REG(MCG)
+#define MCG_C8                                   MCG_C8_REG(MCG)
+
+/*!
+ * @}
+ */ /* end of group MCG_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group MCG_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- MCM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCM_Peripheral_Access_Layer MCM Peripheral Access Layer
+ * @{
+ */
+
+/** MCM - Register Layout Typedef */
+typedef struct {
+       uint8_t RESERVED_0[8];
+  __I  uint16_t PLASC;                             /**< Crossbar Switch (AXBS) Slave Configuration, offset: 0x8 */
+  __I  uint16_t PLAMC;                             /**< Crossbar Switch (AXBS) Master Configuration, offset: 0xA */
+  __IO uint32_t CR;                                /**< Control Register, offset: 0xC */
+  __IO uint32_t ISCR;                              /**< Interrupt Status Register, offset: 0x10 */
+  __IO uint32_t ETBCC;                             /**< ETB Counter Control register, offset: 0x14 */
+  __IO uint32_t ETBRL;                             /**< ETB Reload register, offset: 0x18 */
+  __I  uint32_t ETBCNT;                            /**< ETB Counter Value register, offset: 0x1C */
+       uint8_t RESERVED_1[16];
+  __IO uint32_t PID;                               /**< Process ID register, offset: 0x30 */
+} MCM_Type, *MCM_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- MCM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCM_Register_Accessor_Macros MCM - Register accessor macros
+ * @{
+ */
+
+
+/* MCM - Register accessors */
+#define MCM_PLASC_REG(base)                      ((base)->PLASC)
+#define MCM_PLAMC_REG(base)                      ((base)->PLAMC)
+#define MCM_CR_REG(base)                         ((base)->CR)
+#define MCM_ISCR_REG(base)                       ((base)->ISCR)
+#define MCM_ETBCC_REG(base)                      ((base)->ETBCC)
+#define MCM_ETBRL_REG(base)                      ((base)->ETBRL)
+#define MCM_ETBCNT_REG(base)                     ((base)->ETBCNT)
+#define MCM_PID_REG(base)                        ((base)->PID)
+
+/*!
+ * @}
+ */ /* end of group MCM_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- MCM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCM_Register_Masks MCM Register Masks
+ * @{
+ */
+
+/* PLASC Bit Fields */
+#define MCM_PLASC_ASC_MASK                       0xFFu
+#define MCM_PLASC_ASC_SHIFT                      0
+#define MCM_PLASC_ASC(x)                         (((uint16_t)(((uint16_t)(x))<<MCM_PLASC_ASC_SHIFT))&MCM_PLASC_ASC_MASK)
+/* PLAMC Bit Fields */
+#define MCM_PLAMC_AMC_MASK                       0xFFu
+#define MCM_PLAMC_AMC_SHIFT                      0
+#define MCM_PLAMC_AMC(x)                         (((uint16_t)(((uint16_t)(x))<<MCM_PLAMC_AMC_SHIFT))&MCM_PLAMC_AMC_MASK)
+/* CR Bit Fields */
+#define MCM_CR_SRAMUAP_MASK                      0x3000000u
+#define MCM_CR_SRAMUAP_SHIFT                     24
+#define MCM_CR_SRAMUAP(x)                        (((uint32_t)(((uint32_t)(x))<<MCM_CR_SRAMUAP_SHIFT))&MCM_CR_SRAMUAP_MASK)
+#define MCM_CR_SRAMUWP_MASK                      0x4000000u
+#define MCM_CR_SRAMUWP_SHIFT                     26
+#define MCM_CR_SRAMLAP_MASK                      0x30000000u
+#define MCM_CR_SRAMLAP_SHIFT                     28
+#define MCM_CR_SRAMLAP(x)                        (((uint32_t)(((uint32_t)(x))<<MCM_CR_SRAMLAP_SHIFT))&MCM_CR_SRAMLAP_MASK)
+#define MCM_CR_SRAMLWP_MASK                      0x40000000u
+#define MCM_CR_SRAMLWP_SHIFT                     30
+/* ISCR Bit Fields */
+#define MCM_ISCR_IRQ_MASK                        0x2u
+#define MCM_ISCR_IRQ_SHIFT                       1
+#define MCM_ISCR_NMI_MASK                        0x4u
+#define MCM_ISCR_NMI_SHIFT                       2
+#define MCM_ISCR_DHREQ_MASK                      0x8u
+#define MCM_ISCR_DHREQ_SHIFT                     3
+#define MCM_ISCR_FIOC_MASK                       0x100u
+#define MCM_ISCR_FIOC_SHIFT                      8
+#define MCM_ISCR_FDZC_MASK                       0x200u
+#define MCM_ISCR_FDZC_SHIFT                      9
+#define MCM_ISCR_FOFC_MASK                       0x400u
+#define MCM_ISCR_FOFC_SHIFT                      10
+#define MCM_ISCR_FUFC_MASK                       0x800u
+#define MCM_ISCR_FUFC_SHIFT                      11
+#define MCM_ISCR_FIXC_MASK                       0x1000u
+#define MCM_ISCR_FIXC_SHIFT                      12
+#define MCM_ISCR_FIDC_MASK                       0x8000u
+#define MCM_ISCR_FIDC_SHIFT                      15
+#define MCM_ISCR_FIOCE_MASK                      0x1000000u
+#define MCM_ISCR_FIOCE_SHIFT                     24
+#define MCM_ISCR_FDZCE_MASK                      0x2000000u
+#define MCM_ISCR_FDZCE_SHIFT                     25
+#define MCM_ISCR_FOFCE_MASK                      0x4000000u
+#define MCM_ISCR_FOFCE_SHIFT                     26
+#define MCM_ISCR_FUFCE_MASK                      0x8000000u
+#define MCM_ISCR_FUFCE_SHIFT                     27
+#define MCM_ISCR_FIXCE_MASK                      0x10000000u
+#define MCM_ISCR_FIXCE_SHIFT                     28
+#define MCM_ISCR_FIDCE_MASK                      0x80000000u
+#define MCM_ISCR_FIDCE_SHIFT                     31
+/* ETBCC Bit Fields */
+#define MCM_ETBCC_CNTEN_MASK                     0x1u
+#define MCM_ETBCC_CNTEN_SHIFT                    0
+#define MCM_ETBCC_RSPT_MASK                      0x6u
+#define MCM_ETBCC_RSPT_SHIFT                     1
+#define MCM_ETBCC_RSPT(x)                        (((uint32_t)(((uint32_t)(x))<<MCM_ETBCC_RSPT_SHIFT))&MCM_ETBCC_RSPT_MASK)
+#define MCM_ETBCC_RLRQ_MASK                      0x8u
+#define MCM_ETBCC_RLRQ_SHIFT                     3
+#define MCM_ETBCC_ETDIS_MASK                     0x10u
+#define MCM_ETBCC_ETDIS_SHIFT                    4
+#define MCM_ETBCC_ITDIS_MASK                     0x20u
+#define MCM_ETBCC_ITDIS_SHIFT                    5
+/* ETBRL Bit Fields */
+#define MCM_ETBRL_RELOAD_MASK                    0x7FFu
+#define MCM_ETBRL_RELOAD_SHIFT                   0
+#define MCM_ETBRL_RELOAD(x)                      (((uint32_t)(((uint32_t)(x))<<MCM_ETBRL_RELOAD_SHIFT))&MCM_ETBRL_RELOAD_MASK)
+/* ETBCNT Bit Fields */
+#define MCM_ETBCNT_COUNTER_MASK                  0x7FFu
+#define MCM_ETBCNT_COUNTER_SHIFT                 0
+#define MCM_ETBCNT_COUNTER(x)                    (((uint32_t)(((uint32_t)(x))<<MCM_ETBCNT_COUNTER_SHIFT))&MCM_ETBCNT_COUNTER_MASK)
+/* PID Bit Fields */
+#define MCM_PID_PID_MASK                         0xFFu
+#define MCM_PID_PID_SHIFT                        0
+#define MCM_PID_PID(x)                           (((uint32_t)(((uint32_t)(x))<<MCM_PID_PID_SHIFT))&MCM_PID_PID_MASK)
+
+/*!
+ * @}
+ */ /* end of group MCM_Register_Masks */
+
+
+/* MCM - Peripheral instance base addresses */
+/** Peripheral MCM base address */
+#define MCM_BASE                                 (0xE0080000u)
+/** Peripheral MCM base pointer */
+#define MCM                                      ((MCM_Type *)MCM_BASE)
+#define MCM_BASE_PTR                             (MCM)
+/** Array initializer of MCM peripheral base addresses */
+#define MCM_BASE_ADDRS                           { MCM_BASE }
+/** Array initializer of MCM peripheral base pointers */
+#define MCM_BASE_PTRS                            { MCM }
+
+/* ----------------------------------------------------------------------------
+   -- MCM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MCM_Register_Accessor_Macros MCM - Register accessor macros
+ * @{
+ */
+
+
+/* MCM - Register instance definitions */
+/* MCM */
+#define MCM_PLASC                                MCM_PLASC_REG(MCM)
+#define MCM_PLAMC                                MCM_PLAMC_REG(MCM)
+#define MCM_CR                                   MCM_CR_REG(MCM)
+#define MCM_ISCR                                 MCM_ISCR_REG(MCM)
+#define MCM_ETBCC                                MCM_ETBCC_REG(MCM)
+#define MCM_ETBRL                                MCM_ETBRL_REG(MCM)
+#define MCM_ETBCNT                               MCM_ETBCNT_REG(MCM)
+#define MCM_PID                                  MCM_PID_REG(MCM)
+
+/*!
+ * @}
+ */ /* end of group MCM_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group MCM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- MPU Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MPU_Peripheral_Access_Layer MPU Peripheral Access Layer
+ * @{
+ */
+
+/** MPU - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t CESR;                              /**< Control/Error Status Register, offset: 0x0 */
+       uint8_t RESERVED_0[12];
+  struct {                                         /* offset: 0x10, array step: 0x8 */
+    __I  uint32_t EAR;                               /**< Error Address Register, slave port n, array offset: 0x10, array step: 0x8 */
+    __I  uint32_t EDR;                               /**< Error Detail Register, slave port n, array offset: 0x14, array step: 0x8 */
+  } SP[5];
+       uint8_t RESERVED_1[968];
+  __IO uint32_t WORD[12][4];                       /**< Region Descriptor n, Word 0..Region Descriptor n, Word 3, array offset: 0x400, array step: index*0x10, index2*0x4 */
+       uint8_t RESERVED_2[832];
+  __IO uint32_t RGDAAC[12];                        /**< Region Descriptor Alternate Access Control n, array offset: 0x800, array step: 0x4 */
+} MPU_Type, *MPU_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- MPU - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MPU_Register_Accessor_Macros MPU - Register accessor macros
+ * @{
+ */
+
+
+/* MPU - Register accessors */
+#define MPU_CESR_REG(base)                       ((base)->CESR)
+#define MPU_EAR_REG(base,index)                  ((base)->SP[index].EAR)
+#define MPU_EDR_REG(base,index)                  ((base)->SP[index].EDR)
+#define MPU_WORD_REG(base,index,index2)          ((base)->WORD[index][index2])
+#define MPU_RGDAAC_REG(base,index)               ((base)->RGDAAC[index])
+
+/*!
+ * @}
+ */ /* end of group MPU_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- MPU Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MPU_Register_Masks MPU Register Masks
+ * @{
+ */
+
+/* CESR Bit Fields */
+#define MPU_CESR_VLD_MASK                        0x1u
+#define MPU_CESR_VLD_SHIFT                       0
+#define MPU_CESR_NRGD_MASK                       0xF00u
+#define MPU_CESR_NRGD_SHIFT                      8
+#define MPU_CESR_NRGD(x)                         (((uint32_t)(((uint32_t)(x))<<MPU_CESR_NRGD_SHIFT))&MPU_CESR_NRGD_MASK)
+#define MPU_CESR_NSP_MASK                        0xF000u
+#define MPU_CESR_NSP_SHIFT                       12
+#define MPU_CESR_NSP(x)                          (((uint32_t)(((uint32_t)(x))<<MPU_CESR_NSP_SHIFT))&MPU_CESR_NSP_MASK)
+#define MPU_CESR_HRL_MASK                        0xF0000u
+#define MPU_CESR_HRL_SHIFT                       16
+#define MPU_CESR_HRL(x)                          (((uint32_t)(((uint32_t)(x))<<MPU_CESR_HRL_SHIFT))&MPU_CESR_HRL_MASK)
+#define MPU_CESR_SPERR_MASK                      0xF8000000u
+#define MPU_CESR_SPERR_SHIFT                     27
+#define MPU_CESR_SPERR(x)                        (((uint32_t)(((uint32_t)(x))<<MPU_CESR_SPERR_SHIFT))&MPU_CESR_SPERR_MASK)
+/* EAR Bit Fields */
+#define MPU_EAR_EADDR_MASK                       0xFFFFFFFFu
+#define MPU_EAR_EADDR_SHIFT                      0
+#define MPU_EAR_EADDR(x)                         (((uint32_t)(((uint32_t)(x))<<MPU_EAR_EADDR_SHIFT))&MPU_EAR_EADDR_MASK)
+/* EDR Bit Fields */
+#define MPU_EDR_ERW_MASK                         0x1u
+#define MPU_EDR_ERW_SHIFT                        0
+#define MPU_EDR_EATTR_MASK                       0xEu
+#define MPU_EDR_EATTR_SHIFT                      1
+#define MPU_EDR_EATTR(x)                         (((uint32_t)(((uint32_t)(x))<<MPU_EDR_EATTR_SHIFT))&MPU_EDR_EATTR_MASK)
+#define MPU_EDR_EMN_MASK                         0xF0u
+#define MPU_EDR_EMN_SHIFT                        4
+#define MPU_EDR_EMN(x)                           (((uint32_t)(((uint32_t)(x))<<MPU_EDR_EMN_SHIFT))&MPU_EDR_EMN_MASK)
+#define MPU_EDR_EPID_MASK                        0xFF00u
+#define MPU_EDR_EPID_SHIFT                       8
+#define MPU_EDR_EPID(x)                          (((uint32_t)(((uint32_t)(x))<<MPU_EDR_EPID_SHIFT))&MPU_EDR_EPID_MASK)
+#define MPU_EDR_EACD_MASK                        0xFFFF0000u
+#define MPU_EDR_EACD_SHIFT                       16
+#define MPU_EDR_EACD(x)                          (((uint32_t)(((uint32_t)(x))<<MPU_EDR_EACD_SHIFT))&MPU_EDR_EACD_MASK)
+/* WORD Bit Fields */
+#define MPU_WORD_VLD_MASK                        0x1u
+#define MPU_WORD_VLD_SHIFT                       0
+#define MPU_WORD_M0UM_MASK                       0x7u
+#define MPU_WORD_M0UM_SHIFT                      0
+#define MPU_WORD_M0UM(x)                         (((uint32_t)(((uint32_t)(x))<<MPU_WORD_M0UM_SHIFT))&MPU_WORD_M0UM_MASK)
+#define MPU_WORD_M0SM_MASK                       0x18u
+#define MPU_WORD_M0SM_SHIFT                      3
+#define MPU_WORD_M0SM(x)                         (((uint32_t)(((uint32_t)(x))<<MPU_WORD_M0SM_SHIFT))&MPU_WORD_M0SM_MASK)
+#define MPU_WORD_M0PE_MASK                       0x20u
+#define MPU_WORD_M0PE_SHIFT                      5
+#define MPU_WORD_ENDADDR_MASK                    0xFFFFFFE0u
+#define MPU_WORD_ENDADDR_SHIFT                   5
+#define MPU_WORD_ENDADDR(x)                      (((uint32_t)(((uint32_t)(x))<<MPU_WORD_ENDADDR_SHIFT))&MPU_WORD_ENDADDR_MASK)
+#define MPU_WORD_SRTADDR_MASK                    0xFFFFFFE0u
+#define MPU_WORD_SRTADDR_SHIFT                   5
+#define MPU_WORD_SRTADDR(x)                      (((uint32_t)(((uint32_t)(x))<<MPU_WORD_SRTADDR_SHIFT))&MPU_WORD_SRTADDR_MASK)
+#define MPU_WORD_M1UM_MASK                       0x1C0u
+#define MPU_WORD_M1UM_SHIFT                      6
+#define MPU_WORD_M1UM(x)                         (((uint32_t)(((uint32_t)(x))<<MPU_WORD_M1UM_SHIFT))&MPU_WORD_M1UM_MASK)
+#define MPU_WORD_M1SM_MASK                       0x600u
+#define MPU_WORD_M1SM_SHIFT                      9
+#define MPU_WORD_M1SM(x)                         (((uint32_t)(((uint32_t)(x))<<MPU_WORD_M1SM_SHIFT))&MPU_WORD_M1SM_MASK)
+#define MPU_WORD_M1PE_MASK                       0x800u
+#define MPU_WORD_M1PE_SHIFT                      11
+#define MPU_WORD_M2UM_MASK                       0x7000u
+#define MPU_WORD_M2UM_SHIFT                      12
+#define MPU_WORD_M2UM(x)                         (((uint32_t)(((uint32_t)(x))<<MPU_WORD_M2UM_SHIFT))&MPU_WORD_M2UM_MASK)
+#define MPU_WORD_M2SM_MASK                       0x18000u
+#define MPU_WORD_M2SM_SHIFT                      15
+#define MPU_WORD_M2SM(x)                         (((uint32_t)(((uint32_t)(x))<<MPU_WORD_M2SM_SHIFT))&MPU_WORD_M2SM_MASK)
+#define MPU_WORD_PIDMASK_MASK                    0xFF0000u
+#define MPU_WORD_PIDMASK_SHIFT                   16
+#define MPU_WORD_PIDMASK(x)                      (((uint32_t)(((uint32_t)(x))<<MPU_WORD_PIDMASK_SHIFT))&MPU_WORD_PIDMASK_MASK)
+#define MPU_WORD_M2PE_MASK                       0x20000u
+#define MPU_WORD_M2PE_SHIFT                      17
+#define MPU_WORD_M3UM_MASK                       0x1C0000u
+#define MPU_WORD_M3UM_SHIFT                      18
+#define MPU_WORD_M3UM(x)                         (((uint32_t)(((uint32_t)(x))<<MPU_WORD_M3UM_SHIFT))&MPU_WORD_M3UM_MASK)
+#define MPU_WORD_M3SM_MASK                       0x600000u
+#define MPU_WORD_M3SM_SHIFT                      21
+#define MPU_WORD_M3SM(x)                         (((uint32_t)(((uint32_t)(x))<<MPU_WORD_M3SM_SHIFT))&MPU_WORD_M3SM_MASK)
+#define MPU_WORD_M3PE_MASK                       0x800000u
+#define MPU_WORD_M3PE_SHIFT                      23
+#define MPU_WORD_PID_MASK                        0xFF000000u
+#define MPU_WORD_PID_SHIFT                       24
+#define MPU_WORD_PID(x)                          (((uint32_t)(((uint32_t)(x))<<MPU_WORD_PID_SHIFT))&MPU_WORD_PID_MASK)
+#define MPU_WORD_M4WE_MASK                       0x1000000u
+#define MPU_WORD_M4WE_SHIFT                      24
+#define MPU_WORD_M4RE_MASK                       0x2000000u
+#define MPU_WORD_M4RE_SHIFT                      25
+#define MPU_WORD_M5WE_MASK                       0x4000000u
+#define MPU_WORD_M5WE_SHIFT                      26
+#define MPU_WORD_M5RE_MASK                       0x8000000u
+#define MPU_WORD_M5RE_SHIFT                      27
+#define MPU_WORD_M6WE_MASK                       0x10000000u
+#define MPU_WORD_M6WE_SHIFT                      28
+#define MPU_WORD_M6RE_MASK                       0x20000000u
+#define MPU_WORD_M6RE_SHIFT                      29
+#define MPU_WORD_M7WE_MASK                       0x40000000u
+#define MPU_WORD_M7WE_SHIFT                      30
+#define MPU_WORD_M7RE_MASK                       0x80000000u
+#define MPU_WORD_M7RE_SHIFT                      31
+/* RGDAAC Bit Fields */
+#define MPU_RGDAAC_M0UM_MASK                     0x7u
+#define MPU_RGDAAC_M0UM_SHIFT                    0
+#define MPU_RGDAAC_M0UM(x)                       (((uint32_t)(((uint32_t)(x))<<MPU_RGDAAC_M0UM_SHIFT))&MPU_RGDAAC_M0UM_MASK)
+#define MPU_RGDAAC_M0SM_MASK                     0x18u
+#define MPU_RGDAAC_M0SM_SHIFT                    3
+#define MPU_RGDAAC_M0SM(x)                       (((uint32_t)(((uint32_t)(x))<<MPU_RGDAAC_M0SM_SHIFT))&MPU_RGDAAC_M0SM_MASK)
+#define MPU_RGDAAC_M0PE_MASK                     0x20u
+#define MPU_RGDAAC_M0PE_SHIFT                    5
+#define MPU_RGDAAC_M1UM_MASK                     0x1C0u
+#define MPU_RGDAAC_M1UM_SHIFT                    6
+#define MPU_RGDAAC_M1UM(x)                       (((uint32_t)(((uint32_t)(x))<<MPU_RGDAAC_M1UM_SHIFT))&MPU_RGDAAC_M1UM_MASK)
+#define MPU_RGDAAC_M1SM_MASK                     0x600u
+#define MPU_RGDAAC_M1SM_SHIFT                    9
+#define MPU_RGDAAC_M1SM(x)                       (((uint32_t)(((uint32_t)(x))<<MPU_RGDAAC_M1SM_SHIFT))&MPU_RGDAAC_M1SM_MASK)
+#define MPU_RGDAAC_M1PE_MASK                     0x800u
+#define MPU_RGDAAC_M1PE_SHIFT                    11
+#define MPU_RGDAAC_M2UM_MASK                     0x7000u
+#define MPU_RGDAAC_M2UM_SHIFT                    12
+#define MPU_RGDAAC_M2UM(x)                       (((uint32_t)(((uint32_t)(x))<<MPU_RGDAAC_M2UM_SHIFT))&MPU_RGDAAC_M2UM_MASK)
+#define MPU_RGDAAC_M2SM_MASK                     0x18000u
+#define MPU_RGDAAC_M2SM_SHIFT                    15
+#define MPU_RGDAAC_M2SM(x)                       (((uint32_t)(((uint32_t)(x))<<MPU_RGDAAC_M2SM_SHIFT))&MPU_RGDAAC_M2SM_MASK)
+#define MPU_RGDAAC_M2PE_MASK                     0x20000u
+#define MPU_RGDAAC_M2PE_SHIFT                    17
+#define MPU_RGDAAC_M3UM_MASK                     0x1C0000u
+#define MPU_RGDAAC_M3UM_SHIFT                    18
+#define MPU_RGDAAC_M3UM(x)                       (((uint32_t)(((uint32_t)(x))<<MPU_RGDAAC_M3UM_SHIFT))&MPU_RGDAAC_M3UM_MASK)
+#define MPU_RGDAAC_M3SM_MASK                     0x600000u
+#define MPU_RGDAAC_M3SM_SHIFT                    21
+#define MPU_RGDAAC_M3SM(x)                       (((uint32_t)(((uint32_t)(x))<<MPU_RGDAAC_M3SM_SHIFT))&MPU_RGDAAC_M3SM_MASK)
+#define MPU_RGDAAC_M3PE_MASK                     0x800000u
+#define MPU_RGDAAC_M3PE_SHIFT                    23
+#define MPU_RGDAAC_M4WE_MASK                     0x1000000u
+#define MPU_RGDAAC_M4WE_SHIFT                    24
+#define MPU_RGDAAC_M4RE_MASK                     0x2000000u
+#define MPU_RGDAAC_M4RE_SHIFT                    25
+#define MPU_RGDAAC_M5WE_MASK                     0x4000000u
+#define MPU_RGDAAC_M5WE_SHIFT                    26
+#define MPU_RGDAAC_M5RE_MASK                     0x8000000u
+#define MPU_RGDAAC_M5RE_SHIFT                    27
+#define MPU_RGDAAC_M6WE_MASK                     0x10000000u
+#define MPU_RGDAAC_M6WE_SHIFT                    28
+#define MPU_RGDAAC_M6RE_MASK                     0x20000000u
+#define MPU_RGDAAC_M6RE_SHIFT                    29
+#define MPU_RGDAAC_M7WE_MASK                     0x40000000u
+#define MPU_RGDAAC_M7WE_SHIFT                    30
+#define MPU_RGDAAC_M7RE_MASK                     0x80000000u
+#define MPU_RGDAAC_M7RE_SHIFT                    31
+
+/*!
+ * @}
+ */ /* end of group MPU_Register_Masks */
+
+
+/* MPU - Peripheral instance base addresses */
+/** Peripheral MPU base address */
+#define MPU_BASE                                 (0x4000D000u)
+/** Peripheral MPU base pointer */
+#define MPU                                      ((MPU_Type *)MPU_BASE)
+#define MPU_BASE_PTR                             (MPU)
+/** Array initializer of MPU peripheral base addresses */
+#define MPU_BASE_ADDRS                           { MPU_BASE }
+/** Array initializer of MPU peripheral base pointers */
+#define MPU_BASE_PTRS                            { MPU }
+
+/* ----------------------------------------------------------------------------
+   -- MPU - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup MPU_Register_Accessor_Macros MPU - Register accessor macros
+ * @{
+ */
+
+
+/* MPU - Register instance definitions */
+/* MPU */
+#define MPU_CESR                                 MPU_CESR_REG(MPU)
+#define MPU_EAR0                                 MPU_EAR_REG(MPU,0)
+#define MPU_EDR0                                 MPU_EDR_REG(MPU,0)
+#define MPU_EAR1                                 MPU_EAR_REG(MPU,1)
+#define MPU_EDR1                                 MPU_EDR_REG(MPU,1)
+#define MPU_EAR2                                 MPU_EAR_REG(MPU,2)
+#define MPU_EDR2                                 MPU_EDR_REG(MPU,2)
+#define MPU_EAR3                                 MPU_EAR_REG(MPU,3)
+#define MPU_EDR3                                 MPU_EDR_REG(MPU,3)
+#define MPU_EAR4                                 MPU_EAR_REG(MPU,4)
+#define MPU_EDR4                                 MPU_EDR_REG(MPU,4)
+#define MPU_RGD0_WORD0                           MPU_WORD_REG(MPU,0,0)
+#define MPU_RGD0_WORD1                           MPU_WORD_REG(MPU,0,1)
+#define MPU_RGD0_WORD2                           MPU_WORD_REG(MPU,0,2)
+#define MPU_RGD0_WORD3                           MPU_WORD_REG(MPU,0,3)
+#define MPU_RGD1_WORD0                           MPU_WORD_REG(MPU,1,0)
+#define MPU_RGD1_WORD1                           MPU_WORD_REG(MPU,1,1)
+#define MPU_RGD1_WORD2                           MPU_WORD_REG(MPU,1,2)
+#define MPU_RGD1_WORD3                           MPU_WORD_REG(MPU,1,3)
+#define MPU_RGD2_WORD0                           MPU_WORD_REG(MPU,2,0)
+#define MPU_RGD2_WORD1                           MPU_WORD_REG(MPU,2,1)
+#define MPU_RGD2_WORD2                           MPU_WORD_REG(MPU,2,2)
+#define MPU_RGD2_WORD3                           MPU_WORD_REG(MPU,2,3)
+#define MPU_RGD3_WORD0                           MPU_WORD_REG(MPU,3,0)
+#define MPU_RGD3_WORD1                           MPU_WORD_REG(MPU,3,1)
+#define MPU_RGD3_WORD2                           MPU_WORD_REG(MPU,3,2)
+#define MPU_RGD3_WORD3                           MPU_WORD_REG(MPU,3,3)
+#define MPU_RGD4_WORD0                           MPU_WORD_REG(MPU,4,0)
+#define MPU_RGD4_WORD1                           MPU_WORD_REG(MPU,4,1)
+#define MPU_RGD4_WORD2                           MPU_WORD_REG(MPU,4,2)
+#define MPU_RGD4_WORD3                           MPU_WORD_REG(MPU,4,3)
+#define MPU_RGD5_WORD0                           MPU_WORD_REG(MPU,5,0)
+#define MPU_RGD5_WORD1                           MPU_WORD_REG(MPU,5,1)
+#define MPU_RGD5_WORD2                           MPU_WORD_REG(MPU,5,2)
+#define MPU_RGD5_WORD3                           MPU_WORD_REG(MPU,5,3)
+#define MPU_RGD6_WORD0                           MPU_WORD_REG(MPU,6,0)
+#define MPU_RGD6_WORD1                           MPU_WORD_REG(MPU,6,1)
+#define MPU_RGD6_WORD2                           MPU_WORD_REG(MPU,6,2)
+#define MPU_RGD6_WORD3                           MPU_WORD_REG(MPU,6,3)
+#define MPU_RGD7_WORD0                           MPU_WORD_REG(MPU,7,0)
+#define MPU_RGD7_WORD1                           MPU_WORD_REG(MPU,7,1)
+#define MPU_RGD7_WORD2                           MPU_WORD_REG(MPU,7,2)
+#define MPU_RGD7_WORD3                           MPU_WORD_REG(MPU,7,3)
+#define MPU_RGD8_WORD0                           MPU_WORD_REG(MPU,8,0)
+#define MPU_RGD8_WORD1                           MPU_WORD_REG(MPU,8,1)
+#define MPU_RGD8_WORD2                           MPU_WORD_REG(MPU,8,2)
+#define MPU_RGD8_WORD3                           MPU_WORD_REG(MPU,8,3)
+#define MPU_RGD9_WORD0                           MPU_WORD_REG(MPU,9,0)
+#define MPU_RGD9_WORD1                           MPU_WORD_REG(MPU,9,1)
+#define MPU_RGD9_WORD2                           MPU_WORD_REG(MPU,9,2)
+#define MPU_RGD9_WORD3                           MPU_WORD_REG(MPU,9,3)
+#define MPU_RGD10_WORD0                          MPU_WORD_REG(MPU,10,0)
+#define MPU_RGD10_WORD1                          MPU_WORD_REG(MPU,10,1)
+#define MPU_RGD10_WORD2                          MPU_WORD_REG(MPU,10,2)
+#define MPU_RGD10_WORD3                          MPU_WORD_REG(MPU,10,3)
+#define MPU_RGD11_WORD0                          MPU_WORD_REG(MPU,11,0)
+#define MPU_RGD11_WORD1                          MPU_WORD_REG(MPU,11,1)
+#define MPU_RGD11_WORD2                          MPU_WORD_REG(MPU,11,2)
+#define MPU_RGD11_WORD3                          MPU_WORD_REG(MPU,11,3)
+#define MPU_RGDAAC0                              MPU_RGDAAC_REG(MPU,0)
+#define MPU_RGDAAC1                              MPU_RGDAAC_REG(MPU,1)
+#define MPU_RGDAAC2                              MPU_RGDAAC_REG(MPU,2)
+#define MPU_RGDAAC3                              MPU_RGDAAC_REG(MPU,3)
+#define MPU_RGDAAC4                              MPU_RGDAAC_REG(MPU,4)
+#define MPU_RGDAAC5                              MPU_RGDAAC_REG(MPU,5)
+#define MPU_RGDAAC6                              MPU_RGDAAC_REG(MPU,6)
+#define MPU_RGDAAC7                              MPU_RGDAAC_REG(MPU,7)
+#define MPU_RGDAAC8                              MPU_RGDAAC_REG(MPU,8)
+#define MPU_RGDAAC9                              MPU_RGDAAC_REG(MPU,9)
+#define MPU_RGDAAC10                             MPU_RGDAAC_REG(MPU,10)
+#define MPU_RGDAAC11                             MPU_RGDAAC_REG(MPU,11)
+
+/* MPU - Register array accessors */
+#define MPU_EAR(index)                           MPU_EAR_REG(MPU,index)
+#define MPU_EDR(index)                           MPU_EDR_REG(MPU,index)
+#define MPU_WORD(index,index2)                   MPU_WORD_REG(MPU,index,index2)
+#define MPU_RGDAAC(index)                        MPU_RGDAAC_REG(MPU,index)
+
+/*!
+ * @}
+ */ /* end of group MPU_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group MPU_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- NV Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup NV_Peripheral_Access_Layer NV Peripheral Access Layer
+ * @{
+ */
+
+/** NV - Register Layout Typedef */
+typedef struct {
+  __I  uint8_t BACKKEY3;                           /**< Backdoor Comparison Key 3., offset: 0x0 */
+  __I  uint8_t BACKKEY2;                           /**< Backdoor Comparison Key 2., offset: 0x1 */
+  __I  uint8_t BACKKEY1;                           /**< Backdoor Comparison Key 1., offset: 0x2 */
+  __I  uint8_t BACKKEY0;                           /**< Backdoor Comparison Key 0., offset: 0x3 */
+  __I  uint8_t BACKKEY7;                           /**< Backdoor Comparison Key 7., offset: 0x4 */
+  __I  uint8_t BACKKEY6;                           /**< Backdoor Comparison Key 6., offset: 0x5 */
+  __I  uint8_t BACKKEY5;                           /**< Backdoor Comparison Key 5., offset: 0x6 */
+  __I  uint8_t BACKKEY4;                           /**< Backdoor Comparison Key 4., offset: 0x7 */
+  __I  uint8_t FPROT3;                             /**< Non-volatile P-Flash Protection 1 - Low Register, offset: 0x8 */
+  __I  uint8_t FPROT2;                             /**< Non-volatile P-Flash Protection 1 - High Register, offset: 0x9 */
+  __I  uint8_t FPROT1;                             /**< Non-volatile P-Flash Protection 0 - Low Register, offset: 0xA */
+  __I  uint8_t FPROT0;                             /**< Non-volatile P-Flash Protection 0 - High Register, offset: 0xB */
+  __I  uint8_t FSEC;                               /**< Non-volatile Flash Security Register, offset: 0xC */
+  __I  uint8_t FOPT;                               /**< Non-volatile Flash Option Register, offset: 0xD */
+  __I  uint8_t FEPROT;                             /**< Non-volatile EERAM Protection Register, offset: 0xE */
+  __I  uint8_t FDPROT;                             /**< Non-volatile D-Flash Protection Register, offset: 0xF */
+} NV_Type, *NV_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- NV - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup NV_Register_Accessor_Macros NV - Register accessor macros
+ * @{
+ */
+
+
+/* NV - Register accessors */
+#define NV_BACKKEY3_REG(base)                    ((base)->BACKKEY3)
+#define NV_BACKKEY2_REG(base)                    ((base)->BACKKEY2)
+#define NV_BACKKEY1_REG(base)                    ((base)->BACKKEY1)
+#define NV_BACKKEY0_REG(base)                    ((base)->BACKKEY0)
+#define NV_BACKKEY7_REG(base)                    ((base)->BACKKEY7)
+#define NV_BACKKEY6_REG(base)                    ((base)->BACKKEY6)
+#define NV_BACKKEY5_REG(base)                    ((base)->BACKKEY5)
+#define NV_BACKKEY4_REG(base)                    ((base)->BACKKEY4)
+#define NV_FPROT3_REG(base)                      ((base)->FPROT3)
+#define NV_FPROT2_REG(base)                      ((base)->FPROT2)
+#define NV_FPROT1_REG(base)                      ((base)->FPROT1)
+#define NV_FPROT0_REG(base)                      ((base)->FPROT0)
+#define NV_FSEC_REG(base)                        ((base)->FSEC)
+#define NV_FOPT_REG(base)                        ((base)->FOPT)
+#define NV_FEPROT_REG(base)                      ((base)->FEPROT)
+#define NV_FDPROT_REG(base)                      ((base)->FDPROT)
+
+/*!
+ * @}
+ */ /* end of group NV_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- NV Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup NV_Register_Masks NV Register Masks
+ * @{
+ */
+
+/* BACKKEY3 Bit Fields */
+#define NV_BACKKEY3_KEY_MASK                     0xFFu
+#define NV_BACKKEY3_KEY_SHIFT                    0
+#define NV_BACKKEY3_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY3_KEY_SHIFT))&NV_BACKKEY3_KEY_MASK)
+/* BACKKEY2 Bit Fields */
+#define NV_BACKKEY2_KEY_MASK                     0xFFu
+#define NV_BACKKEY2_KEY_SHIFT                    0
+#define NV_BACKKEY2_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY2_KEY_SHIFT))&NV_BACKKEY2_KEY_MASK)
+/* BACKKEY1 Bit Fields */
+#define NV_BACKKEY1_KEY_MASK                     0xFFu
+#define NV_BACKKEY1_KEY_SHIFT                    0
+#define NV_BACKKEY1_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY1_KEY_SHIFT))&NV_BACKKEY1_KEY_MASK)
+/* BACKKEY0 Bit Fields */
+#define NV_BACKKEY0_KEY_MASK                     0xFFu
+#define NV_BACKKEY0_KEY_SHIFT                    0
+#define NV_BACKKEY0_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY0_KEY_SHIFT))&NV_BACKKEY0_KEY_MASK)
+/* BACKKEY7 Bit Fields */
+#define NV_BACKKEY7_KEY_MASK                     0xFFu
+#define NV_BACKKEY7_KEY_SHIFT                    0
+#define NV_BACKKEY7_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY7_KEY_SHIFT))&NV_BACKKEY7_KEY_MASK)
+/* BACKKEY6 Bit Fields */
+#define NV_BACKKEY6_KEY_MASK                     0xFFu
+#define NV_BACKKEY6_KEY_SHIFT                    0
+#define NV_BACKKEY6_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY6_KEY_SHIFT))&NV_BACKKEY6_KEY_MASK)
+/* BACKKEY5 Bit Fields */
+#define NV_BACKKEY5_KEY_MASK                     0xFFu
+#define NV_BACKKEY5_KEY_SHIFT                    0
+#define NV_BACKKEY5_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY5_KEY_SHIFT))&NV_BACKKEY5_KEY_MASK)
+/* BACKKEY4 Bit Fields */
+#define NV_BACKKEY4_KEY_MASK                     0xFFu
+#define NV_BACKKEY4_KEY_SHIFT                    0
+#define NV_BACKKEY4_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY4_KEY_SHIFT))&NV_BACKKEY4_KEY_MASK)
+/* FPROT3 Bit Fields */
+#define NV_FPROT3_PROT_MASK                      0xFFu
+#define NV_FPROT3_PROT_SHIFT                     0
+#define NV_FPROT3_PROT(x)                        (((uint8_t)(((uint8_t)(x))<<NV_FPROT3_PROT_SHIFT))&NV_FPROT3_PROT_MASK)
+/* FPROT2 Bit Fields */
+#define NV_FPROT2_PROT_MASK                      0xFFu
+#define NV_FPROT2_PROT_SHIFT                     0
+#define NV_FPROT2_PROT(x)                        (((uint8_t)(((uint8_t)(x))<<NV_FPROT2_PROT_SHIFT))&NV_FPROT2_PROT_MASK)
+/* FPROT1 Bit Fields */
+#define NV_FPROT1_PROT_MASK                      0xFFu
+#define NV_FPROT1_PROT_SHIFT                     0
+#define NV_FPROT1_PROT(x)                        (((uint8_t)(((uint8_t)(x))<<NV_FPROT1_PROT_SHIFT))&NV_FPROT1_PROT_MASK)
+/* FPROT0 Bit Fields */
+#define NV_FPROT0_PROT_MASK                      0xFFu
+#define NV_FPROT0_PROT_SHIFT                     0
+#define NV_FPROT0_PROT(x)                        (((uint8_t)(((uint8_t)(x))<<NV_FPROT0_PROT_SHIFT))&NV_FPROT0_PROT_MASK)
+/* FSEC Bit Fields */
+#define NV_FSEC_SEC_MASK                         0x3u
+#define NV_FSEC_SEC_SHIFT                        0
+#define NV_FSEC_SEC(x)                           (((uint8_t)(((uint8_t)(x))<<NV_FSEC_SEC_SHIFT))&NV_FSEC_SEC_MASK)
+#define NV_FSEC_FSLACC_MASK                      0xCu
+#define NV_FSEC_FSLACC_SHIFT                     2
+#define NV_FSEC_FSLACC(x)                        (((uint8_t)(((uint8_t)(x))<<NV_FSEC_FSLACC_SHIFT))&NV_FSEC_FSLACC_MASK)
+#define NV_FSEC_MEEN_MASK                        0x30u
+#define NV_FSEC_MEEN_SHIFT                       4
+#define NV_FSEC_MEEN(x)                          (((uint8_t)(((uint8_t)(x))<<NV_FSEC_MEEN_SHIFT))&NV_FSEC_MEEN_MASK)
+#define NV_FSEC_KEYEN_MASK                       0xC0u
+#define NV_FSEC_KEYEN_SHIFT                      6
+#define NV_FSEC_KEYEN(x)                         (((uint8_t)(((uint8_t)(x))<<NV_FSEC_KEYEN_SHIFT))&NV_FSEC_KEYEN_MASK)
+/* FOPT Bit Fields */
+#define NV_FOPT_LPBOOT_MASK                      0x1u
+#define NV_FOPT_LPBOOT_SHIFT                     0
+#define NV_FOPT_EZPORT_DIS_MASK                  0x2u
+#define NV_FOPT_EZPORT_DIS_SHIFT                 1
+/* FEPROT Bit Fields */
+#define NV_FEPROT_EPROT_MASK                     0xFFu
+#define NV_FEPROT_EPROT_SHIFT                    0
+#define NV_FEPROT_EPROT(x)                       (((uint8_t)(((uint8_t)(x))<<NV_FEPROT_EPROT_SHIFT))&NV_FEPROT_EPROT_MASK)
+/* FDPROT Bit Fields */
+#define NV_FDPROT_DPROT_MASK                     0xFFu
+#define NV_FDPROT_DPROT_SHIFT                    0
+#define NV_FDPROT_DPROT(x)                       (((uint8_t)(((uint8_t)(x))<<NV_FDPROT_DPROT_SHIFT))&NV_FDPROT_DPROT_MASK)
+
+/*!
+ * @}
+ */ /* end of group NV_Register_Masks */
+
+
+/* NV - Peripheral instance base addresses */
+/** Peripheral FTFE_FlashConfig base address */
+#define FTFE_FlashConfig_BASE                    (0x400u)
+/** Peripheral FTFE_FlashConfig base pointer */
+#define FTFE_FlashConfig                         ((NV_Type *)FTFE_FlashConfig_BASE)
+#define FTFE_FlashConfig_BASE_PTR                (FTFE_FlashConfig)
+/** Array initializer of NV peripheral base addresses */
+#define NV_BASE_ADDRS                            { FTFE_FlashConfig_BASE }
+/** Array initializer of NV peripheral base pointers */
+#define NV_BASE_PTRS                             { FTFE_FlashConfig }
+
+/* ----------------------------------------------------------------------------
+   -- NV - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup NV_Register_Accessor_Macros NV - Register accessor macros
+ * @{
+ */
+
+
+/* NV - Register instance definitions */
+/* FTFE_FlashConfig */
+#define NV_BACKKEY3                              NV_BACKKEY3_REG(FTFE_FlashConfig)
+#define NV_BACKKEY2                              NV_BACKKEY2_REG(FTFE_FlashConfig)
+#define NV_BACKKEY1                              NV_BACKKEY1_REG(FTFE_FlashConfig)
+#define NV_BACKKEY0                              NV_BACKKEY0_REG(FTFE_FlashConfig)
+#define NV_BACKKEY7                              NV_BACKKEY7_REG(FTFE_FlashConfig)
+#define NV_BACKKEY6                              NV_BACKKEY6_REG(FTFE_FlashConfig)
+#define NV_BACKKEY5                              NV_BACKKEY5_REG(FTFE_FlashConfig)
+#define NV_BACKKEY4                              NV_BACKKEY4_REG(FTFE_FlashConfig)
+#define NV_FPROT3                                NV_FPROT3_REG(FTFE_FlashConfig)
+#define NV_FPROT2                                NV_FPROT2_REG(FTFE_FlashConfig)
+#define NV_FPROT1                                NV_FPROT1_REG(FTFE_FlashConfig)
+#define NV_FPROT0                                NV_FPROT0_REG(FTFE_FlashConfig)
+#define NV_FSEC                                  NV_FSEC_REG(FTFE_FlashConfig)
+#define NV_FOPT                                  NV_FOPT_REG(FTFE_FlashConfig)
+#define NV_FEPROT                                NV_FEPROT_REG(FTFE_FlashConfig)
+#define NV_FDPROT                                NV_FDPROT_REG(FTFE_FlashConfig)
+
+/*!
+ * @}
+ */ /* end of group NV_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group NV_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- OSC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup OSC_Peripheral_Access_Layer OSC Peripheral Access Layer
+ * @{
+ */
+
+/** OSC - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t CR;                                 /**< OSC Control Register, offset: 0x0 */
+} OSC_Type, *OSC_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- OSC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup OSC_Register_Accessor_Macros OSC - Register accessor macros
+ * @{
+ */
+
+
+/* OSC - Register accessors */
+#define OSC_CR_REG(base)                         ((base)->CR)
+
+/*!
+ * @}
+ */ /* end of group OSC_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- OSC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup OSC_Register_Masks OSC Register Masks
+ * @{
+ */
+
+/* CR Bit Fields */
+#define OSC_CR_SC16P_MASK                        0x1u
+#define OSC_CR_SC16P_SHIFT                       0
+#define OSC_CR_SC8P_MASK                         0x2u
+#define OSC_CR_SC8P_SHIFT                        1
+#define OSC_CR_SC4P_MASK                         0x4u
+#define OSC_CR_SC4P_SHIFT                        2
+#define OSC_CR_SC2P_MASK                         0x8u
+#define OSC_CR_SC2P_SHIFT                        3
+#define OSC_CR_EREFSTEN_MASK                     0x20u
+#define OSC_CR_EREFSTEN_SHIFT                    5
+#define OSC_CR_ERCLKEN_MASK                      0x80u
+#define OSC_CR_ERCLKEN_SHIFT                     7
+
+/*!
+ * @}
+ */ /* end of group OSC_Register_Masks */
+
+
+/* OSC - Peripheral instance base addresses */
+/** Peripheral OSC base address */
+#define OSC_BASE                                 (0x40065000u)
+/** Peripheral OSC base pointer */
+#define OSC                                      ((OSC_Type *)OSC_BASE)
+#define OSC_BASE_PTR                             (OSC)
+/** Array initializer of OSC peripheral base addresses */
+#define OSC_BASE_ADDRS                           { OSC_BASE }
+/** Array initializer of OSC peripheral base pointers */
+#define OSC_BASE_PTRS                            { OSC }
+
+/* ----------------------------------------------------------------------------
+   -- OSC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup OSC_Register_Accessor_Macros OSC - Register accessor macros
+ * @{
+ */
+
+
+/* OSC - Register instance definitions */
+/* OSC */
+#define OSC_CR                                   OSC_CR_REG(OSC)
+
+/*!
+ * @}
+ */ /* end of group OSC_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group OSC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- PDB Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PDB_Peripheral_Access_Layer PDB Peripheral Access Layer
+ * @{
+ */
+
+/** PDB - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t SC;                                /**< Status and Control register, offset: 0x0 */
+  __IO uint32_t MOD;                               /**< Modulus register, offset: 0x4 */
+  __I  uint32_t CNT;                               /**< Counter register, offset: 0x8 */
+  __IO uint32_t IDLY;                              /**< Interrupt Delay register, offset: 0xC */
+  struct {                                         /* offset: 0x10, array step: 0x28 */
+    __IO uint32_t C1;                                /**< Channel n Control register 1, array offset: 0x10, array step: 0x28 */
+    __IO uint32_t S;                                 /**< Channel n Status register, array offset: 0x14, array step: 0x28 */
+    __IO uint32_t DLY[2];                            /**< Channel n Delay 0 register..Channel n Delay 1 register, array offset: 0x18, array step: index*0x28, index2*0x4 */
+         uint8_t RESERVED_0[24];
+  } CH[2];
+       uint8_t RESERVED_0[240];
+  struct {                                         /* offset: 0x150, array step: 0x8 */
+    __IO uint32_t INTC;                              /**< DAC Interval Trigger n Control register, array offset: 0x150, array step: 0x8 */
+    __IO uint32_t INT;                               /**< DAC Interval n register, array offset: 0x154, array step: 0x8 */
+  } DAC[2];
+       uint8_t RESERVED_1[48];
+  __IO uint32_t POEN;                              /**< Pulse-Out n Enable register, offset: 0x190 */
+  __IO uint32_t PODLY[3];                          /**< Pulse-Out n Delay register, array offset: 0x194, array step: 0x4 */
+} PDB_Type, *PDB_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- PDB - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PDB_Register_Accessor_Macros PDB - Register accessor macros
+ * @{
+ */
+
+
+/* PDB - Register accessors */
+#define PDB_SC_REG(base)                         ((base)->SC)
+#define PDB_MOD_REG(base)                        ((base)->MOD)
+#define PDB_CNT_REG(base)                        ((base)->CNT)
+#define PDB_IDLY_REG(base)                       ((base)->IDLY)
+#define PDB_C1_REG(base,index)                   ((base)->CH[index].C1)
+#define PDB_S_REG(base,index)                    ((base)->CH[index].S)
+#define PDB_DLY_REG(base,index,index2)           ((base)->CH[index].DLY[index2])
+#define PDB_INTC_REG(base,index)                 ((base)->DAC[index].INTC)
+#define PDB_INT_REG(base,index)                  ((base)->DAC[index].INT)
+#define PDB_POEN_REG(base)                       ((base)->POEN)
+#define PDB_PODLY_REG(base,index)                ((base)->PODLY[index])
+
+/*!
+ * @}
+ */ /* end of group PDB_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- PDB Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PDB_Register_Masks PDB Register Masks
+ * @{
+ */
+
+/* SC Bit Fields */
+#define PDB_SC_LDOK_MASK                         0x1u
+#define PDB_SC_LDOK_SHIFT                        0
+#define PDB_SC_CONT_MASK                         0x2u
+#define PDB_SC_CONT_SHIFT                        1
+#define PDB_SC_MULT_MASK                         0xCu
+#define PDB_SC_MULT_SHIFT                        2
+#define PDB_SC_MULT(x)                           (((uint32_t)(((uint32_t)(x))<<PDB_SC_MULT_SHIFT))&PDB_SC_MULT_MASK)
+#define PDB_SC_PDBIE_MASK                        0x20u
+#define PDB_SC_PDBIE_SHIFT                       5
+#define PDB_SC_PDBIF_MASK                        0x40u
+#define PDB_SC_PDBIF_SHIFT                       6
+#define PDB_SC_PDBEN_MASK                        0x80u
+#define PDB_SC_PDBEN_SHIFT                       7
+#define PDB_SC_TRGSEL_MASK                       0xF00u
+#define PDB_SC_TRGSEL_SHIFT                      8
+#define PDB_SC_TRGSEL(x)                         (((uint32_t)(((uint32_t)(x))<<PDB_SC_TRGSEL_SHIFT))&PDB_SC_TRGSEL_MASK)
+#define PDB_SC_PRESCALER_MASK                    0x7000u
+#define PDB_SC_PRESCALER_SHIFT                   12
+#define PDB_SC_PRESCALER(x)                      (((uint32_t)(((uint32_t)(x))<<PDB_SC_PRESCALER_SHIFT))&PDB_SC_PRESCALER_MASK)
+#define PDB_SC_DMAEN_MASK                        0x8000u
+#define PDB_SC_DMAEN_SHIFT                       15
+#define PDB_SC_SWTRIG_MASK                       0x10000u
+#define PDB_SC_SWTRIG_SHIFT                      16
+#define PDB_SC_PDBEIE_MASK                       0x20000u
+#define PDB_SC_PDBEIE_SHIFT                      17
+#define PDB_SC_LDMOD_MASK                        0xC0000u
+#define PDB_SC_LDMOD_SHIFT                       18
+#define PDB_SC_LDMOD(x)                          (((uint32_t)(((uint32_t)(x))<<PDB_SC_LDMOD_SHIFT))&PDB_SC_LDMOD_MASK)
+/* MOD Bit Fields */
+#define PDB_MOD_MOD_MASK                         0xFFFFu
+#define PDB_MOD_MOD_SHIFT                        0
+#define PDB_MOD_MOD(x)                           (((uint32_t)(((uint32_t)(x))<<PDB_MOD_MOD_SHIFT))&PDB_MOD_MOD_MASK)
+/* CNT Bit Fields */
+#define PDB_CNT_CNT_MASK                         0xFFFFu
+#define PDB_CNT_CNT_SHIFT                        0
+#define PDB_CNT_CNT(x)                           (((uint32_t)(((uint32_t)(x))<<PDB_CNT_CNT_SHIFT))&PDB_CNT_CNT_MASK)
+/* IDLY Bit Fields */
+#define PDB_IDLY_IDLY_MASK                       0xFFFFu
+#define PDB_IDLY_IDLY_SHIFT                      0
+#define PDB_IDLY_IDLY(x)                         (((uint32_t)(((uint32_t)(x))<<PDB_IDLY_IDLY_SHIFT))&PDB_IDLY_IDLY_MASK)
+/* C1 Bit Fields */
+#define PDB_C1_EN_MASK                           0xFFu
+#define PDB_C1_EN_SHIFT                          0
+#define PDB_C1_EN(x)                             (((uint32_t)(((uint32_t)(x))<<PDB_C1_EN_SHIFT))&PDB_C1_EN_MASK)
+#define PDB_C1_TOS_MASK                          0xFF00u
+#define PDB_C1_TOS_SHIFT                         8
+#define PDB_C1_TOS(x)                            (((uint32_t)(((uint32_t)(x))<<PDB_C1_TOS_SHIFT))&PDB_C1_TOS_MASK)
+#define PDB_C1_BB_MASK                           0xFF0000u
+#define PDB_C1_BB_SHIFT                          16
+#define PDB_C1_BB(x)                             (((uint32_t)(((uint32_t)(x))<<PDB_C1_BB_SHIFT))&PDB_C1_BB_MASK)
+/* S Bit Fields */
+#define PDB_S_ERR_MASK                           0xFFu
+#define PDB_S_ERR_SHIFT                          0
+#define PDB_S_ERR(x)                             (((uint32_t)(((uint32_t)(x))<<PDB_S_ERR_SHIFT))&PDB_S_ERR_MASK)
+#define PDB_S_CF_MASK                            0xFF0000u
+#define PDB_S_CF_SHIFT                           16
+#define PDB_S_CF(x)                              (((uint32_t)(((uint32_t)(x))<<PDB_S_CF_SHIFT))&PDB_S_CF_MASK)
+/* DLY Bit Fields */
+#define PDB_DLY_DLY_MASK                         0xFFFFu
+#define PDB_DLY_DLY_SHIFT                        0
+#define PDB_DLY_DLY(x)                           (((uint32_t)(((uint32_t)(x))<<PDB_DLY_DLY_SHIFT))&PDB_DLY_DLY_MASK)
+/* INTC Bit Fields */
+#define PDB_INTC_TOE_MASK                        0x1u
+#define PDB_INTC_TOE_SHIFT                       0
+#define PDB_INTC_EXT_MASK                        0x2u
+#define PDB_INTC_EXT_SHIFT                       1
+/* INT Bit Fields */
+#define PDB_INT_INT_MASK                         0xFFFFu
+#define PDB_INT_INT_SHIFT                        0
+#define PDB_INT_INT(x)                           (((uint32_t)(((uint32_t)(x))<<PDB_INT_INT_SHIFT))&PDB_INT_INT_MASK)
+/* POEN Bit Fields */
+#define PDB_POEN_POEN_MASK                       0xFFu
+#define PDB_POEN_POEN_SHIFT                      0
+#define PDB_POEN_POEN(x)                         (((uint32_t)(((uint32_t)(x))<<PDB_POEN_POEN_SHIFT))&PDB_POEN_POEN_MASK)
+/* PODLY Bit Fields */
+#define PDB_PODLY_DLY2_MASK                      0xFFFFu
+#define PDB_PODLY_DLY2_SHIFT                     0
+#define PDB_PODLY_DLY2(x)                        (((uint32_t)(((uint32_t)(x))<<PDB_PODLY_DLY2_SHIFT))&PDB_PODLY_DLY2_MASK)
+#define PDB_PODLY_DLY1_MASK                      0xFFFF0000u
+#define PDB_PODLY_DLY1_SHIFT                     16
+#define PDB_PODLY_DLY1(x)                        (((uint32_t)(((uint32_t)(x))<<PDB_PODLY_DLY1_SHIFT))&PDB_PODLY_DLY1_MASK)
+
+/*!
+ * @}
+ */ /* end of group PDB_Register_Masks */
+
+
+/* PDB - Peripheral instance base addresses */
+/** Peripheral PDB0 base address */
+#define PDB0_BASE                                (0x40036000u)
+/** Peripheral PDB0 base pointer */
+#define PDB0                                     ((PDB_Type *)PDB0_BASE)
+#define PDB0_BASE_PTR                            (PDB0)
+/** Array initializer of PDB peripheral base addresses */
+#define PDB_BASE_ADDRS                           { PDB0_BASE }
+/** Array initializer of PDB peripheral base pointers */
+#define PDB_BASE_PTRS                            { PDB0 }
+/** Interrupt vectors for the PDB peripheral type */
+#define PDB_IRQS                                 { PDB0_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- PDB - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PDB_Register_Accessor_Macros PDB - Register accessor macros
+ * @{
+ */
+
+
+/* PDB - Register instance definitions */
+/* PDB0 */
+#define PDB0_SC                                  PDB_SC_REG(PDB0)
+#define PDB0_MOD                                 PDB_MOD_REG(PDB0)
+#define PDB0_CNT                                 PDB_CNT_REG(PDB0)
+#define PDB0_IDLY                                PDB_IDLY_REG(PDB0)
+#define PDB0_CH0C1                               PDB_C1_REG(PDB0,0)
+#define PDB0_CH0S                                PDB_S_REG(PDB0,0)
+#define PDB0_CH0DLY0                             PDB_DLY_REG(PDB0,0,0)
+#define PDB0_CH0DLY1                             PDB_DLY_REG(PDB0,0,1)
+#define PDB0_CH1C1                               PDB_C1_REG(PDB0,1)
+#define PDB0_CH1S                                PDB_S_REG(PDB0,1)
+#define PDB0_CH1DLY0                             PDB_DLY_REG(PDB0,1,0)
+#define PDB0_CH1DLY1                             PDB_DLY_REG(PDB0,1,1)
+#define PDB0_DACINTC0                            PDB_INTC_REG(PDB0,0)
+#define PDB0_DACINT0                             PDB_INT_REG(PDB0,0)
+#define PDB0_DACINTC1                            PDB_INTC_REG(PDB0,1)
+#define PDB0_DACINT1                             PDB_INT_REG(PDB0,1)
+#define PDB0_POEN                                PDB_POEN_REG(PDB0)
+#define PDB0_PO0DLY                              PDB_PODLY_REG(PDB0,0)
+#define PDB0_PO1DLY                              PDB_PODLY_REG(PDB0,1)
+#define PDB0_PO2DLY                              PDB_PODLY_REG(PDB0,2)
+
+/* PDB - Register array accessors */
+#define PDB0_C1(index)                           PDB_C1_REG(PDB0,index)
+#define PDB0_S(index)                            PDB_S_REG(PDB0,index)
+#define PDB0_DLY(index,index2)                   PDB_DLY_REG(PDB0,index,index2)
+#define PDB0_INTC(index)                         PDB_INTC_REG(PDB0,index)
+#define PDB0_INT(index)                          PDB_INT_REG(PDB0,index)
+#define PDB0_PODLY(index)                        PDB_PODLY_REG(PDB0,index)
+
+/*!
+ * @}
+ */ /* end of group PDB_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group PDB_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- PIT Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PIT_Peripheral_Access_Layer PIT Peripheral Access Layer
+ * @{
+ */
+
+/** PIT - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t MCR;                               /**< PIT Module Control Register, offset: 0x0 */
+       uint8_t RESERVED_0[252];
+  struct {                                         /* offset: 0x100, array step: 0x10 */
+    __IO uint32_t LDVAL;                             /**< Timer Load Value Register, array offset: 0x100, array step: 0x10 */
+    __I  uint32_t CVAL;                              /**< Current Timer Value Register, array offset: 0x104, array step: 0x10 */
+    __IO uint32_t TCTRL;                             /**< Timer Control Register, array offset: 0x108, array step: 0x10 */
+    __IO uint32_t TFLG;                              /**< Timer Flag Register, array offset: 0x10C, array step: 0x10 */
+  } CHANNEL[4];
+} PIT_Type, *PIT_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- PIT - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PIT_Register_Accessor_Macros PIT - Register accessor macros
+ * @{
+ */
+
+
+/* PIT - Register accessors */
+#define PIT_MCR_REG(base)                        ((base)->MCR)
+#define PIT_LDVAL_REG(base,index)                ((base)->CHANNEL[index].LDVAL)
+#define PIT_CVAL_REG(base,index)                 ((base)->CHANNEL[index].CVAL)
+#define PIT_TCTRL_REG(base,index)                ((base)->CHANNEL[index].TCTRL)
+#define PIT_TFLG_REG(base,index)                 ((base)->CHANNEL[index].TFLG)
+
+/*!
+ * @}
+ */ /* end of group PIT_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- PIT Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PIT_Register_Masks PIT Register Masks
+ * @{
+ */
+
+/* MCR Bit Fields */
+#define PIT_MCR_FRZ_MASK                         0x1u
+#define PIT_MCR_FRZ_SHIFT                        0
+#define PIT_MCR_MDIS_MASK                        0x2u
+#define PIT_MCR_MDIS_SHIFT                       1
+/* LDVAL Bit Fields */
+#define PIT_LDVAL_TSV_MASK                       0xFFFFFFFFu
+#define PIT_LDVAL_TSV_SHIFT                      0
+#define PIT_LDVAL_TSV(x)                         (((uint32_t)(((uint32_t)(x))<<PIT_LDVAL_TSV_SHIFT))&PIT_LDVAL_TSV_MASK)
+/* CVAL Bit Fields */
+#define PIT_CVAL_TVL_MASK                        0xFFFFFFFFu
+#define PIT_CVAL_TVL_SHIFT                       0
+#define PIT_CVAL_TVL(x)                          (((uint32_t)(((uint32_t)(x))<<PIT_CVAL_TVL_SHIFT))&PIT_CVAL_TVL_MASK)
+/* TCTRL Bit Fields */
+#define PIT_TCTRL_TEN_MASK                       0x1u
+#define PIT_TCTRL_TEN_SHIFT                      0
+#define PIT_TCTRL_TIE_MASK                       0x2u
+#define PIT_TCTRL_TIE_SHIFT                      1
+#define PIT_TCTRL_CHN_MASK                       0x4u
+#define PIT_TCTRL_CHN_SHIFT                      2
+/* TFLG Bit Fields */
+#define PIT_TFLG_TIF_MASK                        0x1u
+#define PIT_TFLG_TIF_SHIFT                       0
+
+/*!
+ * @}
+ */ /* end of group PIT_Register_Masks */
+
+
+/* PIT - Peripheral instance base addresses */
+/** Peripheral PIT base address */
+#define PIT_BASE                                 (0x40037000u)
+/** Peripheral PIT base pointer */
+#define PIT                                      ((PIT_Type *)PIT_BASE)
+#define PIT_BASE_PTR                             (PIT)
+/** Array initializer of PIT peripheral base addresses */
+#define PIT_BASE_ADDRS                           { PIT_BASE }
+/** Array initializer of PIT peripheral base pointers */
+#define PIT_BASE_PTRS                            { PIT }
+/** Interrupt vectors for the PIT peripheral type */
+#define PIT_IRQS                                 { PIT0_IRQn, PIT1_IRQn, PIT2_IRQn, PIT3_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- PIT - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PIT_Register_Accessor_Macros PIT - Register accessor macros
+ * @{
+ */
+
+
+/* PIT - Register instance definitions */
+/* PIT */
+#define PIT_MCR                                  PIT_MCR_REG(PIT)
+#define PIT_LDVAL0                               PIT_LDVAL_REG(PIT,0)
+#define PIT_CVAL0                                PIT_CVAL_REG(PIT,0)
+#define PIT_TCTRL0                               PIT_TCTRL_REG(PIT,0)
+#define PIT_TFLG0                                PIT_TFLG_REG(PIT,0)
+#define PIT_LDVAL1                               PIT_LDVAL_REG(PIT,1)
+#define PIT_CVAL1                                PIT_CVAL_REG(PIT,1)
+#define PIT_TCTRL1                               PIT_TCTRL_REG(PIT,1)
+#define PIT_TFLG1                                PIT_TFLG_REG(PIT,1)
+#define PIT_LDVAL2                               PIT_LDVAL_REG(PIT,2)
+#define PIT_CVAL2                                PIT_CVAL_REG(PIT,2)
+#define PIT_TCTRL2                               PIT_TCTRL_REG(PIT,2)
+#define PIT_TFLG2                                PIT_TFLG_REG(PIT,2)
+#define PIT_LDVAL3                               PIT_LDVAL_REG(PIT,3)
+#define PIT_CVAL3                                PIT_CVAL_REG(PIT,3)
+#define PIT_TCTRL3                               PIT_TCTRL_REG(PIT,3)
+#define PIT_TFLG3                                PIT_TFLG_REG(PIT,3)
+
+/* PIT - Register array accessors */
+#define PIT_LDVAL(index)                         PIT_LDVAL_REG(PIT,index)
+#define PIT_CVAL(index)                          PIT_CVAL_REG(PIT,index)
+#define PIT_TCTRL(index)                         PIT_TCTRL_REG(PIT,index)
+#define PIT_TFLG(index)                          PIT_TFLG_REG(PIT,index)
+
+/*!
+ * @}
+ */ /* end of group PIT_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group PIT_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- PMC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PMC_Peripheral_Access_Layer PMC Peripheral Access Layer
+ * @{
+ */
+
+/** PMC - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t LVDSC1;                             /**< Low Voltage Detect Status And Control 1 register, offset: 0x0 */
+  __IO uint8_t LVDSC2;                             /**< Low Voltage Detect Status And Control 2 register, offset: 0x1 */
+  __IO uint8_t REGSC;                              /**< Regulator Status And Control register, offset: 0x2 */
+} PMC_Type, *PMC_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- PMC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PMC_Register_Accessor_Macros PMC - Register accessor macros
+ * @{
+ */
+
+
+/* PMC - Register accessors */
+#define PMC_LVDSC1_REG(base)                     ((base)->LVDSC1)
+#define PMC_LVDSC2_REG(base)                     ((base)->LVDSC2)
+#define PMC_REGSC_REG(base)                      ((base)->REGSC)
+
+/*!
+ * @}
+ */ /* end of group PMC_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- PMC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PMC_Register_Masks PMC Register Masks
+ * @{
+ */
+
+/* LVDSC1 Bit Fields */
+#define PMC_LVDSC1_LVDV_MASK                     0x3u
+#define PMC_LVDSC1_LVDV_SHIFT                    0
+#define PMC_LVDSC1_LVDV(x)                       (((uint8_t)(((uint8_t)(x))<<PMC_LVDSC1_LVDV_SHIFT))&PMC_LVDSC1_LVDV_MASK)
+#define PMC_LVDSC1_LVDRE_MASK                    0x10u
+#define PMC_LVDSC1_LVDRE_SHIFT                   4
+#define PMC_LVDSC1_LVDIE_MASK                    0x20u
+#define PMC_LVDSC1_LVDIE_SHIFT                   5
+#define PMC_LVDSC1_LVDACK_MASK                   0x40u
+#define PMC_LVDSC1_LVDACK_SHIFT                  6
+#define PMC_LVDSC1_LVDF_MASK                     0x80u
+#define PMC_LVDSC1_LVDF_SHIFT                    7
+/* LVDSC2 Bit Fields */
+#define PMC_LVDSC2_LVWV_MASK                     0x3u
+#define PMC_LVDSC2_LVWV_SHIFT                    0
+#define PMC_LVDSC2_LVWV(x)                       (((uint8_t)(((uint8_t)(x))<<PMC_LVDSC2_LVWV_SHIFT))&PMC_LVDSC2_LVWV_MASK)
+#define PMC_LVDSC2_LVWIE_MASK                    0x20u
+#define PMC_LVDSC2_LVWIE_SHIFT                   5
+#define PMC_LVDSC2_LVWACK_MASK                   0x40u
+#define PMC_LVDSC2_LVWACK_SHIFT                  6
+#define PMC_LVDSC2_LVWF_MASK                     0x80u
+#define PMC_LVDSC2_LVWF_SHIFT                    7
+/* REGSC Bit Fields */
+#define PMC_REGSC_BGBE_MASK                      0x1u
+#define PMC_REGSC_BGBE_SHIFT                     0
+#define PMC_REGSC_REGONS_MASK                    0x4u
+#define PMC_REGSC_REGONS_SHIFT                   2
+#define PMC_REGSC_ACKISO_MASK                    0x8u
+#define PMC_REGSC_ACKISO_SHIFT                   3
+#define PMC_REGSC_BGEN_MASK                      0x10u
+#define PMC_REGSC_BGEN_SHIFT                     4
+
+/*!
+ * @}
+ */ /* end of group PMC_Register_Masks */
+
+
+/* PMC - Peripheral instance base addresses */
+/** Peripheral PMC base address */
+#define PMC_BASE                                 (0x4007D000u)
+/** Peripheral PMC base pointer */
+#define PMC                                      ((PMC_Type *)PMC_BASE)
+#define PMC_BASE_PTR                             (PMC)
+/** Array initializer of PMC peripheral base addresses */
+#define PMC_BASE_ADDRS                           { PMC_BASE }
+/** Array initializer of PMC peripheral base pointers */
+#define PMC_BASE_PTRS                            { PMC }
+/** Interrupt vectors for the PMC peripheral type */
+#define PMC_IRQS                                 { LVD_LVW_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- PMC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PMC_Register_Accessor_Macros PMC - Register accessor macros
+ * @{
+ */
+
+
+/* PMC - Register instance definitions */
+/* PMC */
+#define PMC_LVDSC1                               PMC_LVDSC1_REG(PMC)
+#define PMC_LVDSC2                               PMC_LVDSC2_REG(PMC)
+#define PMC_REGSC                                PMC_REGSC_REG(PMC)
+
+/*!
+ * @}
+ */ /* end of group PMC_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group PMC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- PORT Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PORT_Peripheral_Access_Layer PORT Peripheral Access Layer
+ * @{
+ */
+
+/** PORT - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t PCR[32];                           /**< Pin Control Register n, array offset: 0x0, array step: 0x4 */
+  __O  uint32_t GPCLR;                             /**< Global Pin Control Low Register, offset: 0x80 */
+  __O  uint32_t GPCHR;                             /**< Global Pin Control High Register, offset: 0x84 */
+       uint8_t RESERVED_0[24];
+  __IO uint32_t ISFR;                              /**< Interrupt Status Flag Register, offset: 0xA0 */
+       uint8_t RESERVED_1[28];
+  __IO uint32_t DFER;                              /**< Digital Filter Enable Register, offset: 0xC0 */
+  __IO uint32_t DFCR;                              /**< Digital Filter Clock Register, offset: 0xC4 */
+  __IO uint32_t DFWR;                              /**< Digital Filter Width Register, offset: 0xC8 */
+} PORT_Type, *PORT_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- PORT - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PORT_Register_Accessor_Macros PORT - Register accessor macros
+ * @{
+ */
+
+
+/* PORT - Register accessors */
+#define PORT_PCR_REG(base,index)                 ((base)->PCR[index])
+#define PORT_GPCLR_REG(base)                     ((base)->GPCLR)
+#define PORT_GPCHR_REG(base)                     ((base)->GPCHR)
+#define PORT_ISFR_REG(base)                      ((base)->ISFR)
+#define PORT_DFER_REG(base)                      ((base)->DFER)
+#define PORT_DFCR_REG(base)                      ((base)->DFCR)
+#define PORT_DFWR_REG(base)                      ((base)->DFWR)
+
+/*!
+ * @}
+ */ /* end of group PORT_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- PORT Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PORT_Register_Masks PORT Register Masks
+ * @{
+ */
+
+/* PCR Bit Fields */
+#define PORT_PCR_PS_MASK                         0x1u
+#define PORT_PCR_PS_SHIFT                        0
+#define PORT_PCR_PE_MASK                         0x2u
+#define PORT_PCR_PE_SHIFT                        1
+#define PORT_PCR_SRE_MASK                        0x4u
+#define PORT_PCR_SRE_SHIFT                       2
+#define PORT_PCR_PFE_MASK                        0x10u
+#define PORT_PCR_PFE_SHIFT                       4
+#define PORT_PCR_ODE_MASK                        0x20u
+#define PORT_PCR_ODE_SHIFT                       5
+#define PORT_PCR_DSE_MASK                        0x40u
+#define PORT_PCR_DSE_SHIFT                       6
+#define PORT_PCR_MUX_MASK                        0x700u
+#define PORT_PCR_MUX_SHIFT                       8
+#define PORT_PCR_MUX(x)                          (((uint32_t)(((uint32_t)(x))<<PORT_PCR_MUX_SHIFT))&PORT_PCR_MUX_MASK)
+#define PORT_PCR_LK_MASK                         0x8000u
+#define PORT_PCR_LK_SHIFT                        15
+#define PORT_PCR_IRQC_MASK                       0xF0000u
+#define PORT_PCR_IRQC_SHIFT                      16
+#define PORT_PCR_IRQC(x)                         (((uint32_t)(((uint32_t)(x))<<PORT_PCR_IRQC_SHIFT))&PORT_PCR_IRQC_MASK)
+#define PORT_PCR_ISF_MASK                        0x1000000u
+#define PORT_PCR_ISF_SHIFT                       24
+/* GPCLR Bit Fields */
+#define PORT_GPCLR_GPWD_MASK                     0xFFFFu
+#define PORT_GPCLR_GPWD_SHIFT                    0
+#define PORT_GPCLR_GPWD(x)                       (((uint32_t)(((uint32_t)(x))<<PORT_GPCLR_GPWD_SHIFT))&PORT_GPCLR_GPWD_MASK)
+#define PORT_GPCLR_GPWE_MASK                     0xFFFF0000u
+#define PORT_GPCLR_GPWE_SHIFT                    16
+#define PORT_GPCLR_GPWE(x)                       (((uint32_t)(((uint32_t)(x))<<PORT_GPCLR_GPWE_SHIFT))&PORT_GPCLR_GPWE_MASK)
+/* GPCHR Bit Fields */
+#define PORT_GPCHR_GPWD_MASK                     0xFFFFu
+#define PORT_GPCHR_GPWD_SHIFT                    0
+#define PORT_GPCHR_GPWD(x)                       (((uint32_t)(((uint32_t)(x))<<PORT_GPCHR_GPWD_SHIFT))&PORT_GPCHR_GPWD_MASK)
+#define PORT_GPCHR_GPWE_MASK                     0xFFFF0000u
+#define PORT_GPCHR_GPWE_SHIFT                    16
+#define PORT_GPCHR_GPWE(x)                       (((uint32_t)(((uint32_t)(x))<<PORT_GPCHR_GPWE_SHIFT))&PORT_GPCHR_GPWE_MASK)
+/* ISFR Bit Fields */
+#define PORT_ISFR_ISF_MASK                       0xFFFFFFFFu
+#define PORT_ISFR_ISF_SHIFT                      0
+#define PORT_ISFR_ISF(x)                         (((uint32_t)(((uint32_t)(x))<<PORT_ISFR_ISF_SHIFT))&PORT_ISFR_ISF_MASK)
+/* DFER Bit Fields */
+#define PORT_DFER_DFE_MASK                       0xFFFFFFFFu
+#define PORT_DFER_DFE_SHIFT                      0
+#define PORT_DFER_DFE(x)                         (((uint32_t)(((uint32_t)(x))<<PORT_DFER_DFE_SHIFT))&PORT_DFER_DFE_MASK)
+/* DFCR Bit Fields */
+#define PORT_DFCR_CS_MASK                        0x1u
+#define PORT_DFCR_CS_SHIFT                       0
+/* DFWR Bit Fields */
+#define PORT_DFWR_FILT_MASK                      0x1Fu
+#define PORT_DFWR_FILT_SHIFT                     0
+#define PORT_DFWR_FILT(x)                        (((uint32_t)(((uint32_t)(x))<<PORT_DFWR_FILT_SHIFT))&PORT_DFWR_FILT_MASK)
+
+/*!
+ * @}
+ */ /* end of group PORT_Register_Masks */
+
+
+/* PORT - Peripheral instance base addresses */
+/** Peripheral PORTA base address */
+#define PORTA_BASE                               (0x40049000u)
+/** Peripheral PORTA base pointer */
+#define PORTA                                    ((PORT_Type *)PORTA_BASE)
+#define PORTA_BASE_PTR                           (PORTA)
+/** Peripheral PORTB base address */
+#define PORTB_BASE                               (0x4004A000u)
+/** Peripheral PORTB base pointer */
+#define PORTB                                    ((PORT_Type *)PORTB_BASE)
+#define PORTB_BASE_PTR                           (PORTB)
+/** Peripheral PORTC base address */
+#define PORTC_BASE                               (0x4004B000u)
+/** Peripheral PORTC base pointer */
+#define PORTC                                    ((PORT_Type *)PORTC_BASE)
+#define PORTC_BASE_PTR                           (PORTC)
+/** Peripheral PORTD base address */
+#define PORTD_BASE                               (0x4004C000u)
+/** Peripheral PORTD base pointer */
+#define PORTD                                    ((PORT_Type *)PORTD_BASE)
+#define PORTD_BASE_PTR                           (PORTD)
+/** Peripheral PORTE base address */
+#define PORTE_BASE                               (0x4004D000u)
+/** Peripheral PORTE base pointer */
+#define PORTE                                    ((PORT_Type *)PORTE_BASE)
+#define PORTE_BASE_PTR                           (PORTE)
+/** Array initializer of PORT peripheral base addresses */
+#define PORT_BASE_ADDRS                          { PORTA_BASE, PORTB_BASE, PORTC_BASE, PORTD_BASE, PORTE_BASE }
+/** Array initializer of PORT peripheral base pointers */
+#define PORT_BASE_PTRS                           { PORTA, PORTB, PORTC, PORTD, PORTE }
+/** Interrupt vectors for the PORT peripheral type */
+#define PORT_IRQS                                { PORTA_IRQn, PORTB_IRQn, PORTC_IRQn, PORTD_IRQn, PORTE_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- PORT - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup PORT_Register_Accessor_Macros PORT - Register accessor macros
+ * @{
+ */
+
+
+/* PORT - Register instance definitions */
+/* PORTA */
+#define PORTA_PCR0                               PORT_PCR_REG(PORTA,0)
+#define PORTA_PCR1                               PORT_PCR_REG(PORTA,1)
+#define PORTA_PCR2                               PORT_PCR_REG(PORTA,2)
+#define PORTA_PCR3                               PORT_PCR_REG(PORTA,3)
+#define PORTA_PCR4                               PORT_PCR_REG(PORTA,4)
+#define PORTA_PCR5                               PORT_PCR_REG(PORTA,5)
+#define PORTA_PCR6                               PORT_PCR_REG(PORTA,6)
+#define PORTA_PCR7                               PORT_PCR_REG(PORTA,7)
+#define PORTA_PCR8                               PORT_PCR_REG(PORTA,8)
+#define PORTA_PCR9                               PORT_PCR_REG(PORTA,9)
+#define PORTA_PCR10                              PORT_PCR_REG(PORTA,10)
+#define PORTA_PCR11                              PORT_PCR_REG(PORTA,11)
+#define PORTA_PCR12                              PORT_PCR_REG(PORTA,12)
+#define PORTA_PCR13                              PORT_PCR_REG(PORTA,13)
+#define PORTA_PCR14                              PORT_PCR_REG(PORTA,14)
+#define PORTA_PCR15                              PORT_PCR_REG(PORTA,15)
+#define PORTA_PCR16                              PORT_PCR_REG(PORTA,16)
+#define PORTA_PCR17                              PORT_PCR_REG(PORTA,17)
+#define PORTA_PCR18                              PORT_PCR_REG(PORTA,18)
+#define PORTA_PCR19                              PORT_PCR_REG(PORTA,19)
+#define PORTA_PCR20                              PORT_PCR_REG(PORTA,20)
+#define PORTA_PCR21                              PORT_PCR_REG(PORTA,21)
+#define PORTA_PCR22                              PORT_PCR_REG(PORTA,22)
+#define PORTA_PCR23                              PORT_PCR_REG(PORTA,23)
+#define PORTA_PCR24                              PORT_PCR_REG(PORTA,24)
+#define PORTA_PCR25                              PORT_PCR_REG(PORTA,25)
+#define PORTA_PCR26                              PORT_PCR_REG(PORTA,26)
+#define PORTA_PCR27                              PORT_PCR_REG(PORTA,27)
+#define PORTA_PCR28                              PORT_PCR_REG(PORTA,28)
+#define PORTA_PCR29                              PORT_PCR_REG(PORTA,29)
+#define PORTA_PCR30                              PORT_PCR_REG(PORTA,30)
+#define PORTA_PCR31                              PORT_PCR_REG(PORTA,31)
+#define PORTA_GPCLR                              PORT_GPCLR_REG(PORTA)
+#define PORTA_GPCHR                              PORT_GPCHR_REG(PORTA)
+#define PORTA_ISFR                               PORT_ISFR_REG(PORTA)
+/* PORTB */
+#define PORTB_PCR0                               PORT_PCR_REG(PORTB,0)
+#define PORTB_PCR1                               PORT_PCR_REG(PORTB,1)
+#define PORTB_PCR2                               PORT_PCR_REG(PORTB,2)
+#define PORTB_PCR3                               PORT_PCR_REG(PORTB,3)
+#define PORTB_PCR4                               PORT_PCR_REG(PORTB,4)
+#define PORTB_PCR5                               PORT_PCR_REG(PORTB,5)
+#define PORTB_PCR6                               PORT_PCR_REG(PORTB,6)
+#define PORTB_PCR7                               PORT_PCR_REG(PORTB,7)
+#define PORTB_PCR8                               PORT_PCR_REG(PORTB,8)
+#define PORTB_PCR9                               PORT_PCR_REG(PORTB,9)
+#define PORTB_PCR10                              PORT_PCR_REG(PORTB,10)
+#define PORTB_PCR11                              PORT_PCR_REG(PORTB,11)
+#define PORTB_PCR12                              PORT_PCR_REG(PORTB,12)
+#define PORTB_PCR13                              PORT_PCR_REG(PORTB,13)
+#define PORTB_PCR14                              PORT_PCR_REG(PORTB,14)
+#define PORTB_PCR15                              PORT_PCR_REG(PORTB,15)
+#define PORTB_PCR16                              PORT_PCR_REG(PORTB,16)
+#define PORTB_PCR17                              PORT_PCR_REG(PORTB,17)
+#define PORTB_PCR18                              PORT_PCR_REG(PORTB,18)
+#define PORTB_PCR19                              PORT_PCR_REG(PORTB,19)
+#define PORTB_PCR20                              PORT_PCR_REG(PORTB,20)
+#define PORTB_PCR21                              PORT_PCR_REG(PORTB,21)
+#define PORTB_PCR22                              PORT_PCR_REG(PORTB,22)
+#define PORTB_PCR23                              PORT_PCR_REG(PORTB,23)
+#define PORTB_PCR24                              PORT_PCR_REG(PORTB,24)
+#define PORTB_PCR25                              PORT_PCR_REG(PORTB,25)
+#define PORTB_PCR26                              PORT_PCR_REG(PORTB,26)
+#define PORTB_PCR27                              PORT_PCR_REG(PORTB,27)
+#define PORTB_PCR28                              PORT_PCR_REG(PORTB,28)
+#define PORTB_PCR29                              PORT_PCR_REG(PORTB,29)
+#define PORTB_PCR30                              PORT_PCR_REG(PORTB,30)
+#define PORTB_PCR31                              PORT_PCR_REG(PORTB,31)
+#define PORTB_GPCLR                              PORT_GPCLR_REG(PORTB)
+#define PORTB_GPCHR                              PORT_GPCHR_REG(PORTB)
+#define PORTB_ISFR                               PORT_ISFR_REG(PORTB)
+/* PORTC */
+#define PORTC_PCR0                               PORT_PCR_REG(PORTC,0)
+#define PORTC_PCR1                               PORT_PCR_REG(PORTC,1)
+#define PORTC_PCR2                               PORT_PCR_REG(PORTC,2)
+#define PORTC_PCR3                               PORT_PCR_REG(PORTC,3)
+#define PORTC_PCR4                               PORT_PCR_REG(PORTC,4)
+#define PORTC_PCR5                               PORT_PCR_REG(PORTC,5)
+#define PORTC_PCR6                               PORT_PCR_REG(PORTC,6)
+#define PORTC_PCR7                               PORT_PCR_REG(PORTC,7)
+#define PORTC_PCR8                               PORT_PCR_REG(PORTC,8)
+#define PORTC_PCR9                               PORT_PCR_REG(PORTC,9)
+#define PORTC_PCR10                              PORT_PCR_REG(PORTC,10)
+#define PORTC_PCR11                              PORT_PCR_REG(PORTC,11)
+#define PORTC_PCR12                              PORT_PCR_REG(PORTC,12)
+#define PORTC_PCR13                              PORT_PCR_REG(PORTC,13)
+#define PORTC_PCR14                              PORT_PCR_REG(PORTC,14)
+#define PORTC_PCR15                              PORT_PCR_REG(PORTC,15)
+#define PORTC_PCR16                              PORT_PCR_REG(PORTC,16)
+#define PORTC_PCR17                              PORT_PCR_REG(PORTC,17)
+#define PORTC_PCR18                              PORT_PCR_REG(PORTC,18)
+#define PORTC_PCR19                              PORT_PCR_REG(PORTC,19)
+#define PORTC_PCR20                              PORT_PCR_REG(PORTC,20)
+#define PORTC_PCR21                              PORT_PCR_REG(PORTC,21)
+#define PORTC_PCR22                              PORT_PCR_REG(PORTC,22)
+#define PORTC_PCR23                              PORT_PCR_REG(PORTC,23)
+#define PORTC_PCR24                              PORT_PCR_REG(PORTC,24)
+#define PORTC_PCR25                              PORT_PCR_REG(PORTC,25)
+#define PORTC_PCR26                              PORT_PCR_REG(PORTC,26)
+#define PORTC_PCR27                              PORT_PCR_REG(PORTC,27)
+#define PORTC_PCR28                              PORT_PCR_REG(PORTC,28)
+#define PORTC_PCR29                              PORT_PCR_REG(PORTC,29)
+#define PORTC_PCR30                              PORT_PCR_REG(PORTC,30)
+#define PORTC_PCR31                              PORT_PCR_REG(PORTC,31)
+#define PORTC_GPCLR                              PORT_GPCLR_REG(PORTC)
+#define PORTC_GPCHR                              PORT_GPCHR_REG(PORTC)
+#define PORTC_ISFR                               PORT_ISFR_REG(PORTC)
+/* PORTD */
+#define PORTD_PCR0                               PORT_PCR_REG(PORTD,0)
+#define PORTD_PCR1                               PORT_PCR_REG(PORTD,1)
+#define PORTD_PCR2                               PORT_PCR_REG(PORTD,2)
+#define PORTD_PCR3                               PORT_PCR_REG(PORTD,3)
+#define PORTD_PCR4                               PORT_PCR_REG(PORTD,4)
+#define PORTD_PCR5                               PORT_PCR_REG(PORTD,5)
+#define PORTD_PCR6                               PORT_PCR_REG(PORTD,6)
+#define PORTD_PCR7                               PORT_PCR_REG(PORTD,7)
+#define PORTD_PCR8                               PORT_PCR_REG(PORTD,8)
+#define PORTD_PCR9                               PORT_PCR_REG(PORTD,9)
+#define PORTD_PCR10                              PORT_PCR_REG(PORTD,10)
+#define PORTD_PCR11                              PORT_PCR_REG(PORTD,11)
+#define PORTD_PCR12                              PORT_PCR_REG(PORTD,12)
+#define PORTD_PCR13                              PORT_PCR_REG(PORTD,13)
+#define PORTD_PCR14                              PORT_PCR_REG(PORTD,14)
+#define PORTD_PCR15                              PORT_PCR_REG(PORTD,15)
+#define PORTD_PCR16                              PORT_PCR_REG(PORTD,16)
+#define PORTD_PCR17                              PORT_PCR_REG(PORTD,17)
+#define PORTD_PCR18                              PORT_PCR_REG(PORTD,18)
+#define PORTD_PCR19                              PORT_PCR_REG(PORTD,19)
+#define PORTD_PCR20                              PORT_PCR_REG(PORTD,20)
+#define PORTD_PCR21                              PORT_PCR_REG(PORTD,21)
+#define PORTD_PCR22                              PORT_PCR_REG(PORTD,22)
+#define PORTD_PCR23                              PORT_PCR_REG(PORTD,23)
+#define PORTD_PCR24                              PORT_PCR_REG(PORTD,24)
+#define PORTD_PCR25                              PORT_PCR_REG(PORTD,25)
+#define PORTD_PCR26                              PORT_PCR_REG(PORTD,26)
+#define PORTD_PCR27                              PORT_PCR_REG(PORTD,27)
+#define PORTD_PCR28                              PORT_PCR_REG(PORTD,28)
+#define PORTD_PCR29                              PORT_PCR_REG(PORTD,29)
+#define PORTD_PCR30                              PORT_PCR_REG(PORTD,30)
+#define PORTD_PCR31                              PORT_PCR_REG(PORTD,31)
+#define PORTD_GPCLR                              PORT_GPCLR_REG(PORTD)
+#define PORTD_GPCHR                              PORT_GPCHR_REG(PORTD)
+#define PORTD_ISFR                               PORT_ISFR_REG(PORTD)
+#define PORTD_DFER                               PORT_DFER_REG(PORTD)
+#define PORTD_DFCR                               PORT_DFCR_REG(PORTD)
+#define PORTD_DFWR                               PORT_DFWR_REG(PORTD)
+/* PORTE */
+#define PORTE_PCR0                               PORT_PCR_REG(PORTE,0)
+#define PORTE_PCR1                               PORT_PCR_REG(PORTE,1)
+#define PORTE_PCR2                               PORT_PCR_REG(PORTE,2)
+#define PORTE_PCR3                               PORT_PCR_REG(PORTE,3)
+#define PORTE_PCR4                               PORT_PCR_REG(PORTE,4)
+#define PORTE_PCR5                               PORT_PCR_REG(PORTE,5)
+#define PORTE_PCR6                               PORT_PCR_REG(PORTE,6)
+#define PORTE_PCR7                               PORT_PCR_REG(PORTE,7)
+#define PORTE_PCR8                               PORT_PCR_REG(PORTE,8)
+#define PORTE_PCR9                               PORT_PCR_REG(PORTE,9)
+#define PORTE_PCR10                              PORT_PCR_REG(PORTE,10)
+#define PORTE_PCR11                              PORT_PCR_REG(PORTE,11)
+#define PORTE_PCR12                              PORT_PCR_REG(PORTE,12)
+#define PORTE_PCR13                              PORT_PCR_REG(PORTE,13)
+#define PORTE_PCR14                              PORT_PCR_REG(PORTE,14)
+#define PORTE_PCR15                              PORT_PCR_REG(PORTE,15)
+#define PORTE_PCR16                              PORT_PCR_REG(PORTE,16)
+#define PORTE_PCR17                              PORT_PCR_REG(PORTE,17)
+#define PORTE_PCR18                              PORT_PCR_REG(PORTE,18)
+#define PORTE_PCR19                              PORT_PCR_REG(PORTE,19)
+#define PORTE_PCR20                              PORT_PCR_REG(PORTE,20)
+#define PORTE_PCR21                              PORT_PCR_REG(PORTE,21)
+#define PORTE_PCR22                              PORT_PCR_REG(PORTE,22)
+#define PORTE_PCR23                              PORT_PCR_REG(PORTE,23)
+#define PORTE_PCR24                              PORT_PCR_REG(PORTE,24)
+#define PORTE_PCR25                              PORT_PCR_REG(PORTE,25)
+#define PORTE_PCR26                              PORT_PCR_REG(PORTE,26)
+#define PORTE_PCR27                              PORT_PCR_REG(PORTE,27)
+#define PORTE_PCR28                              PORT_PCR_REG(PORTE,28)
+#define PORTE_PCR29                              PORT_PCR_REG(PORTE,29)
+#define PORTE_PCR30                              PORT_PCR_REG(PORTE,30)
+#define PORTE_PCR31                              PORT_PCR_REG(PORTE,31)
+#define PORTE_GPCLR                              PORT_GPCLR_REG(PORTE)
+#define PORTE_GPCHR                              PORT_GPCHR_REG(PORTE)
+#define PORTE_ISFR                               PORT_ISFR_REG(PORTE)
+
+/* PORT - Register array accessors */
+#define PORTA_PCR(index)                         PORT_PCR_REG(PORTA,index)
+#define PORTB_PCR(index)                         PORT_PCR_REG(PORTB,index)
+#define PORTC_PCR(index)                         PORT_PCR_REG(PORTC,index)
+#define PORTD_PCR(index)                         PORT_PCR_REG(PORTD,index)
+#define PORTE_PCR(index)                         PORT_PCR_REG(PORTE,index)
+
+/*!
+ * @}
+ */ /* end of group PORT_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group PORT_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- RCM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RCM_Peripheral_Access_Layer RCM Peripheral Access Layer
+ * @{
+ */
+
+/** RCM - Register Layout Typedef */
+typedef struct {
+  __I  uint8_t SRS0;                               /**< System Reset Status Register 0, offset: 0x0 */
+  __I  uint8_t SRS1;                               /**< System Reset Status Register 1, offset: 0x1 */
+       uint8_t RESERVED_0[2];
+  __IO uint8_t RPFC;                               /**< Reset Pin Filter Control register, offset: 0x4 */
+  __IO uint8_t RPFW;                               /**< Reset Pin Filter Width register, offset: 0x5 */
+       uint8_t RESERVED_1[1];
+  __I  uint8_t MR;                                 /**< Mode Register, offset: 0x7 */
+} RCM_Type, *RCM_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- RCM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RCM_Register_Accessor_Macros RCM - Register accessor macros
+ * @{
+ */
+
+
+/* RCM - Register accessors */
+#define RCM_SRS0_REG(base)                       ((base)->SRS0)
+#define RCM_SRS1_REG(base)                       ((base)->SRS1)
+#define RCM_RPFC_REG(base)                       ((base)->RPFC)
+#define RCM_RPFW_REG(base)                       ((base)->RPFW)
+#define RCM_MR_REG(base)                         ((base)->MR)
+
+/*!
+ * @}
+ */ /* end of group RCM_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- RCM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RCM_Register_Masks RCM Register Masks
+ * @{
+ */
+
+/* SRS0 Bit Fields */
+#define RCM_SRS0_WAKEUP_MASK                     0x1u
+#define RCM_SRS0_WAKEUP_SHIFT                    0
+#define RCM_SRS0_LVD_MASK                        0x2u
+#define RCM_SRS0_LVD_SHIFT                       1
+#define RCM_SRS0_LOC_MASK                        0x4u
+#define RCM_SRS0_LOC_SHIFT                       2
+#define RCM_SRS0_LOL_MASK                        0x8u
+#define RCM_SRS0_LOL_SHIFT                       3
+#define RCM_SRS0_WDOG_MASK                       0x20u
+#define RCM_SRS0_WDOG_SHIFT                      5
+#define RCM_SRS0_PIN_MASK                        0x40u
+#define RCM_SRS0_PIN_SHIFT                       6
+#define RCM_SRS0_POR_MASK                        0x80u
+#define RCM_SRS0_POR_SHIFT                       7
+/* SRS1 Bit Fields */
+#define RCM_SRS1_JTAG_MASK                       0x1u
+#define RCM_SRS1_JTAG_SHIFT                      0
+#define RCM_SRS1_LOCKUP_MASK                     0x2u
+#define RCM_SRS1_LOCKUP_SHIFT                    1
+#define RCM_SRS1_SW_MASK                         0x4u
+#define RCM_SRS1_SW_SHIFT                        2
+#define RCM_SRS1_MDM_AP_MASK                     0x8u
+#define RCM_SRS1_MDM_AP_SHIFT                    3
+#define RCM_SRS1_EZPT_MASK                       0x10u
+#define RCM_SRS1_EZPT_SHIFT                      4
+#define RCM_SRS1_SACKERR_MASK                    0x20u
+#define RCM_SRS1_SACKERR_SHIFT                   5
+/* RPFC Bit Fields */
+#define RCM_RPFC_RSTFLTSRW_MASK                  0x3u
+#define RCM_RPFC_RSTFLTSRW_SHIFT                 0
+#define RCM_RPFC_RSTFLTSRW(x)                    (((uint8_t)(((uint8_t)(x))<<RCM_RPFC_RSTFLTSRW_SHIFT))&RCM_RPFC_RSTFLTSRW_MASK)
+#define RCM_RPFC_RSTFLTSS_MASK                   0x4u
+#define RCM_RPFC_RSTFLTSS_SHIFT                  2
+/* RPFW Bit Fields */
+#define RCM_RPFW_RSTFLTSEL_MASK                  0x1Fu
+#define RCM_RPFW_RSTFLTSEL_SHIFT                 0
+#define RCM_RPFW_RSTFLTSEL(x)                    (((uint8_t)(((uint8_t)(x))<<RCM_RPFW_RSTFLTSEL_SHIFT))&RCM_RPFW_RSTFLTSEL_MASK)
+/* MR Bit Fields */
+#define RCM_MR_EZP_MS_MASK                       0x2u
+#define RCM_MR_EZP_MS_SHIFT                      1
+
+/*!
+ * @}
+ */ /* end of group RCM_Register_Masks */
+
+
+/* RCM - Peripheral instance base addresses */
+/** Peripheral RCM base address */
+#define RCM_BASE                                 (0x4007F000u)
+/** Peripheral RCM base pointer */
+#define RCM                                      ((RCM_Type *)RCM_BASE)
+#define RCM_BASE_PTR                             (RCM)
+/** Array initializer of RCM peripheral base addresses */
+#define RCM_BASE_ADDRS                           { RCM_BASE }
+/** Array initializer of RCM peripheral base pointers */
+#define RCM_BASE_PTRS                            { RCM }
+
+/* ----------------------------------------------------------------------------
+   -- RCM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RCM_Register_Accessor_Macros RCM - Register accessor macros
+ * @{
+ */
+
+
+/* RCM - Register instance definitions */
+/* RCM */
+#define RCM_SRS0                                 RCM_SRS0_REG(RCM)
+#define RCM_SRS1                                 RCM_SRS1_REG(RCM)
+#define RCM_RPFC                                 RCM_RPFC_REG(RCM)
+#define RCM_RPFW                                 RCM_RPFW_REG(RCM)
+#define RCM_MR                                   RCM_MR_REG(RCM)
+
+/*!
+ * @}
+ */ /* end of group RCM_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group RCM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- RFSYS Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RFSYS_Peripheral_Access_Layer RFSYS Peripheral Access Layer
+ * @{
+ */
+
+/** RFSYS - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t REG[8];                            /**< Register file register, array offset: 0x0, array step: 0x4 */
+} RFSYS_Type, *RFSYS_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- RFSYS - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RFSYS_Register_Accessor_Macros RFSYS - Register accessor macros
+ * @{
+ */
+
+
+/* RFSYS - Register accessors */
+#define RFSYS_REG_REG(base,index)                ((base)->REG[index])
+
+/*!
+ * @}
+ */ /* end of group RFSYS_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- RFSYS Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RFSYS_Register_Masks RFSYS Register Masks
+ * @{
+ */
+
+/* REG Bit Fields */
+#define RFSYS_REG_LL_MASK                        0xFFu
+#define RFSYS_REG_LL_SHIFT                       0
+#define RFSYS_REG_LL(x)                          (((uint32_t)(((uint32_t)(x))<<RFSYS_REG_LL_SHIFT))&RFSYS_REG_LL_MASK)
+#define RFSYS_REG_LH_MASK                        0xFF00u
+#define RFSYS_REG_LH_SHIFT                       8
+#define RFSYS_REG_LH(x)                          (((uint32_t)(((uint32_t)(x))<<RFSYS_REG_LH_SHIFT))&RFSYS_REG_LH_MASK)
+#define RFSYS_REG_HL_MASK                        0xFF0000u
+#define RFSYS_REG_HL_SHIFT                       16
+#define RFSYS_REG_HL(x)                          (((uint32_t)(((uint32_t)(x))<<RFSYS_REG_HL_SHIFT))&RFSYS_REG_HL_MASK)
+#define RFSYS_REG_HH_MASK                        0xFF000000u
+#define RFSYS_REG_HH_SHIFT                       24
+#define RFSYS_REG_HH(x)                          (((uint32_t)(((uint32_t)(x))<<RFSYS_REG_HH_SHIFT))&RFSYS_REG_HH_MASK)
+
+/*!
+ * @}
+ */ /* end of group RFSYS_Register_Masks */
+
+
+/* RFSYS - Peripheral instance base addresses */
+/** Peripheral RFSYS base address */
+#define RFSYS_BASE                               (0x40041000u)
+/** Peripheral RFSYS base pointer */
+#define RFSYS                                    ((RFSYS_Type *)RFSYS_BASE)
+#define RFSYS_BASE_PTR                           (RFSYS)
+/** Array initializer of RFSYS peripheral base addresses */
+#define RFSYS_BASE_ADDRS                         { RFSYS_BASE }
+/** Array initializer of RFSYS peripheral base pointers */
+#define RFSYS_BASE_PTRS                          { RFSYS }
+
+/* ----------------------------------------------------------------------------
+   -- RFSYS - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RFSYS_Register_Accessor_Macros RFSYS - Register accessor macros
+ * @{
+ */
+
+
+/* RFSYS - Register instance definitions */
+/* RFSYS */
+#define RFSYS_REG0                               RFSYS_REG_REG(RFSYS,0)
+#define RFSYS_REG1                               RFSYS_REG_REG(RFSYS,1)
+#define RFSYS_REG2                               RFSYS_REG_REG(RFSYS,2)
+#define RFSYS_REG3                               RFSYS_REG_REG(RFSYS,3)
+#define RFSYS_REG4                               RFSYS_REG_REG(RFSYS,4)
+#define RFSYS_REG5                               RFSYS_REG_REG(RFSYS,5)
+#define RFSYS_REG6                               RFSYS_REG_REG(RFSYS,6)
+#define RFSYS_REG7                               RFSYS_REG_REG(RFSYS,7)
+
+/* RFSYS - Register array accessors */
+#define RFSYS_REG(index)                         RFSYS_REG_REG(RFSYS,index)
+
+/*!
+ * @}
+ */ /* end of group RFSYS_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group RFSYS_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- RFVBAT Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RFVBAT_Peripheral_Access_Layer RFVBAT Peripheral Access Layer
+ * @{
+ */
+
+/** RFVBAT - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t REG[8];                            /**< VBAT register file register, array offset: 0x0, array step: 0x4 */
+} RFVBAT_Type, *RFVBAT_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- RFVBAT - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RFVBAT_Register_Accessor_Macros RFVBAT - Register accessor macros
+ * @{
+ */
+
+
+/* RFVBAT - Register accessors */
+#define RFVBAT_REG_REG(base,index)               ((base)->REG[index])
+
+/*!
+ * @}
+ */ /* end of group RFVBAT_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- RFVBAT Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RFVBAT_Register_Masks RFVBAT Register Masks
+ * @{
+ */
+
+/* REG Bit Fields */
+#define RFVBAT_REG_LL_MASK                       0xFFu
+#define RFVBAT_REG_LL_SHIFT                      0
+#define RFVBAT_REG_LL(x)                         (((uint32_t)(((uint32_t)(x))<<RFVBAT_REG_LL_SHIFT))&RFVBAT_REG_LL_MASK)
+#define RFVBAT_REG_LH_MASK                       0xFF00u
+#define RFVBAT_REG_LH_SHIFT                      8
+#define RFVBAT_REG_LH(x)                         (((uint32_t)(((uint32_t)(x))<<RFVBAT_REG_LH_SHIFT))&RFVBAT_REG_LH_MASK)
+#define RFVBAT_REG_HL_MASK                       0xFF0000u
+#define RFVBAT_REG_HL_SHIFT                      16
+#define RFVBAT_REG_HL(x)                         (((uint32_t)(((uint32_t)(x))<<RFVBAT_REG_HL_SHIFT))&RFVBAT_REG_HL_MASK)
+#define RFVBAT_REG_HH_MASK                       0xFF000000u
+#define RFVBAT_REG_HH_SHIFT                      24
+#define RFVBAT_REG_HH(x)                         (((uint32_t)(((uint32_t)(x))<<RFVBAT_REG_HH_SHIFT))&RFVBAT_REG_HH_MASK)
+
+/*!
+ * @}
+ */ /* end of group RFVBAT_Register_Masks */
+
+
+/* RFVBAT - Peripheral instance base addresses */
+/** Peripheral RFVBAT base address */
+#define RFVBAT_BASE                              (0x4003E000u)
+/** Peripheral RFVBAT base pointer */
+#define RFVBAT                                   ((RFVBAT_Type *)RFVBAT_BASE)
+#define RFVBAT_BASE_PTR                          (RFVBAT)
+/** Array initializer of RFVBAT peripheral base addresses */
+#define RFVBAT_BASE_ADDRS                        { RFVBAT_BASE }
+/** Array initializer of RFVBAT peripheral base pointers */
+#define RFVBAT_BASE_PTRS                         { RFVBAT }
+
+/* ----------------------------------------------------------------------------
+   -- RFVBAT - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RFVBAT_Register_Accessor_Macros RFVBAT - Register accessor macros
+ * @{
+ */
+
+
+/* RFVBAT - Register instance definitions */
+/* RFVBAT */
+#define RFVBAT_REG0                              RFVBAT_REG_REG(RFVBAT,0)
+#define RFVBAT_REG1                              RFVBAT_REG_REG(RFVBAT,1)
+#define RFVBAT_REG2                              RFVBAT_REG_REG(RFVBAT,2)
+#define RFVBAT_REG3                              RFVBAT_REG_REG(RFVBAT,3)
+#define RFVBAT_REG4                              RFVBAT_REG_REG(RFVBAT,4)
+#define RFVBAT_REG5                              RFVBAT_REG_REG(RFVBAT,5)
+#define RFVBAT_REG6                              RFVBAT_REG_REG(RFVBAT,6)
+#define RFVBAT_REG7                              RFVBAT_REG_REG(RFVBAT,7)
+
+/* RFVBAT - Register array accessors */
+#define RFVBAT_REG(index)                        RFVBAT_REG_REG(RFVBAT,index)
+
+/*!
+ * @}
+ */ /* end of group RFVBAT_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group RFVBAT_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- RNG Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RNG_Peripheral_Access_Layer RNG Peripheral Access Layer
+ * @{
+ */
+
+/** RNG - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t CR;                                /**< RNGA Control Register, offset: 0x0 */
+  __I  uint32_t SR;                                /**< RNGA Status Register, offset: 0x4 */
+  __O  uint32_t ER;                                /**< RNGA Entropy Register, offset: 0x8 */
+  __I  uint32_t OR;                                /**< RNGA Output Register, offset: 0xC */
+} RNG_Type, *RNG_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- RNG - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RNG_Register_Accessor_Macros RNG - Register accessor macros
+ * @{
+ */
+
+
+/* RNG - Register accessors */
+#define RNG_CR_REG(base)                         ((base)->CR)
+#define RNG_SR_REG(base)                         ((base)->SR)
+#define RNG_ER_REG(base)                         ((base)->ER)
+#define RNG_OR_REG(base)                         ((base)->OR)
+
+/*!
+ * @}
+ */ /* end of group RNG_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- RNG Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RNG_Register_Masks RNG Register Masks
+ * @{
+ */
+
+/* CR Bit Fields */
+#define RNG_CR_GO_MASK                           0x1u
+#define RNG_CR_GO_SHIFT                          0
+#define RNG_CR_HA_MASK                           0x2u
+#define RNG_CR_HA_SHIFT                          1
+#define RNG_CR_INTM_MASK                         0x4u
+#define RNG_CR_INTM_SHIFT                        2
+#define RNG_CR_CLRI_MASK                         0x8u
+#define RNG_CR_CLRI_SHIFT                        3
+#define RNG_CR_SLP_MASK                          0x10u
+#define RNG_CR_SLP_SHIFT                         4
+/* SR Bit Fields */
+#define RNG_SR_SECV_MASK                         0x1u
+#define RNG_SR_SECV_SHIFT                        0
+#define RNG_SR_LRS_MASK                          0x2u
+#define RNG_SR_LRS_SHIFT                         1
+#define RNG_SR_ORU_MASK                          0x4u
+#define RNG_SR_ORU_SHIFT                         2
+#define RNG_SR_ERRI_MASK                         0x8u
+#define RNG_SR_ERRI_SHIFT                        3
+#define RNG_SR_SLP_MASK                          0x10u
+#define RNG_SR_SLP_SHIFT                         4
+#define RNG_SR_OREG_LVL_MASK                     0xFF00u
+#define RNG_SR_OREG_LVL_SHIFT                    8
+#define RNG_SR_OREG_LVL(x)                       (((uint32_t)(((uint32_t)(x))<<RNG_SR_OREG_LVL_SHIFT))&RNG_SR_OREG_LVL_MASK)
+#define RNG_SR_OREG_SIZE_MASK                    0xFF0000u
+#define RNG_SR_OREG_SIZE_SHIFT                   16
+#define RNG_SR_OREG_SIZE(x)                      (((uint32_t)(((uint32_t)(x))<<RNG_SR_OREG_SIZE_SHIFT))&RNG_SR_OREG_SIZE_MASK)
+/* ER Bit Fields */
+#define RNG_ER_EXT_ENT_MASK                      0xFFFFFFFFu
+#define RNG_ER_EXT_ENT_SHIFT                     0
+#define RNG_ER_EXT_ENT(x)                        (((uint32_t)(((uint32_t)(x))<<RNG_ER_EXT_ENT_SHIFT))&RNG_ER_EXT_ENT_MASK)
+/* OR Bit Fields */
+#define RNG_OR_RANDOUT_MASK                      0xFFFFFFFFu
+#define RNG_OR_RANDOUT_SHIFT                     0
+#define RNG_OR_RANDOUT(x)                        (((uint32_t)(((uint32_t)(x))<<RNG_OR_RANDOUT_SHIFT))&RNG_OR_RANDOUT_MASK)
+
+/*!
+ * @}
+ */ /* end of group RNG_Register_Masks */
+
+
+/* RNG - Peripheral instance base addresses */
+/** Peripheral RNG base address */
+#define RNG_BASE                                 (0x40029000u)
+/** Peripheral RNG base pointer */
+#define RNG                                      ((RNG_Type *)RNG_BASE)
+#define RNG_BASE_PTR                             (RNG)
+/** Array initializer of RNG peripheral base addresses */
+#define RNG_BASE_ADDRS                           { RNG_BASE }
+/** Array initializer of RNG peripheral base pointers */
+#define RNG_BASE_PTRS                            { RNG }
+/** Interrupt vectors for the RNG peripheral type */
+#define RNG_IRQS                                 { RNG_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- RNG - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RNG_Register_Accessor_Macros RNG - Register accessor macros
+ * @{
+ */
+
+
+/* RNG - Register instance definitions */
+/* RNG */
+#define RNG_CR                                   RNG_CR_REG(RNG)
+#define RNG_SR                                   RNG_SR_REG(RNG)
+#define RNG_ER                                   RNG_ER_REG(RNG)
+#define RNG_OR                                   RNG_OR_REG(RNG)
+
+/*!
+ * @}
+ */ /* end of group RNG_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group RNG_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- RTC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RTC_Peripheral_Access_Layer RTC Peripheral Access Layer
+ * @{
+ */
+
+/** RTC - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t TSR;                               /**< RTC Time Seconds Register, offset: 0x0 */
+  __IO uint32_t TPR;                               /**< RTC Time Prescaler Register, offset: 0x4 */
+  __IO uint32_t TAR;                               /**< RTC Time Alarm Register, offset: 0x8 */
+  __IO uint32_t TCR;                               /**< RTC Time Compensation Register, offset: 0xC */
+  __IO uint32_t CR;                                /**< RTC Control Register, offset: 0x10 */
+  __IO uint32_t SR;                                /**< RTC Status Register, offset: 0x14 */
+  __IO uint32_t LR;                                /**< RTC Lock Register, offset: 0x18 */
+  __IO uint32_t IER;                               /**< RTC Interrupt Enable Register, offset: 0x1C */
+       uint8_t RESERVED_0[2016];
+  __IO uint32_t WAR;                               /**< RTC Write Access Register, offset: 0x800 */
+  __IO uint32_t RAR;                               /**< RTC Read Access Register, offset: 0x804 */
+} RTC_Type, *RTC_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- RTC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RTC_Register_Accessor_Macros RTC - Register accessor macros
+ * @{
+ */
+
+
+/* RTC - Register accessors */
+#define RTC_TSR_REG(base)                        ((base)->TSR)
+#define RTC_TPR_REG(base)                        ((base)->TPR)
+#define RTC_TAR_REG(base)                        ((base)->TAR)
+#define RTC_TCR_REG(base)                        ((base)->TCR)
+#define RTC_CR_REG(base)                         ((base)->CR)
+#define RTC_SR_REG(base)                         ((base)->SR)
+#define RTC_LR_REG(base)                         ((base)->LR)
+#define RTC_IER_REG(base)                        ((base)->IER)
+#define RTC_WAR_REG(base)                        ((base)->WAR)
+#define RTC_RAR_REG(base)                        ((base)->RAR)
+
+/*!
+ * @}
+ */ /* end of group RTC_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- RTC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RTC_Register_Masks RTC Register Masks
+ * @{
+ */
+
+/* TSR Bit Fields */
+#define RTC_TSR_TSR_MASK                         0xFFFFFFFFu
+#define RTC_TSR_TSR_SHIFT                        0
+#define RTC_TSR_TSR(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TSR_TSR_SHIFT))&RTC_TSR_TSR_MASK)
+/* TPR Bit Fields */
+#define RTC_TPR_TPR_MASK                         0xFFFFu
+#define RTC_TPR_TPR_SHIFT                        0
+#define RTC_TPR_TPR(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TPR_TPR_SHIFT))&RTC_TPR_TPR_MASK)
+/* TAR Bit Fields */
+#define RTC_TAR_TAR_MASK                         0xFFFFFFFFu
+#define RTC_TAR_TAR_SHIFT                        0
+#define RTC_TAR_TAR(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TAR_TAR_SHIFT))&RTC_TAR_TAR_MASK)
+/* TCR Bit Fields */
+#define RTC_TCR_TCR_MASK                         0xFFu
+#define RTC_TCR_TCR_SHIFT                        0
+#define RTC_TCR_TCR(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TCR_TCR_SHIFT))&RTC_TCR_TCR_MASK)
+#define RTC_TCR_CIR_MASK                         0xFF00u
+#define RTC_TCR_CIR_SHIFT                        8
+#define RTC_TCR_CIR(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TCR_CIR_SHIFT))&RTC_TCR_CIR_MASK)
+#define RTC_TCR_TCV_MASK                         0xFF0000u
+#define RTC_TCR_TCV_SHIFT                        16
+#define RTC_TCR_TCV(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TCR_TCV_SHIFT))&RTC_TCR_TCV_MASK)
+#define RTC_TCR_CIC_MASK                         0xFF000000u
+#define RTC_TCR_CIC_SHIFT                        24
+#define RTC_TCR_CIC(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TCR_CIC_SHIFT))&RTC_TCR_CIC_MASK)
+/* CR Bit Fields */
+#define RTC_CR_SWR_MASK                          0x1u
+#define RTC_CR_SWR_SHIFT                         0
+#define RTC_CR_WPE_MASK                          0x2u
+#define RTC_CR_WPE_SHIFT                         1
+#define RTC_CR_SUP_MASK                          0x4u
+#define RTC_CR_SUP_SHIFT                         2
+#define RTC_CR_UM_MASK                           0x8u
+#define RTC_CR_UM_SHIFT                          3
+#define RTC_CR_WPS_MASK                          0x10u
+#define RTC_CR_WPS_SHIFT                         4
+#define RTC_CR_OSCE_MASK                         0x100u
+#define RTC_CR_OSCE_SHIFT                        8
+#define RTC_CR_CLKO_MASK                         0x200u
+#define RTC_CR_CLKO_SHIFT                        9
+#define RTC_CR_SC16P_MASK                        0x400u
+#define RTC_CR_SC16P_SHIFT                       10
+#define RTC_CR_SC8P_MASK                         0x800u
+#define RTC_CR_SC8P_SHIFT                        11
+#define RTC_CR_SC4P_MASK                         0x1000u
+#define RTC_CR_SC4P_SHIFT                        12
+#define RTC_CR_SC2P_MASK                         0x2000u
+#define RTC_CR_SC2P_SHIFT                        13
+/* SR Bit Fields */
+#define RTC_SR_TIF_MASK                          0x1u
+#define RTC_SR_TIF_SHIFT                         0
+#define RTC_SR_TOF_MASK                          0x2u
+#define RTC_SR_TOF_SHIFT                         1
+#define RTC_SR_TAF_MASK                          0x4u
+#define RTC_SR_TAF_SHIFT                         2
+#define RTC_SR_TCE_MASK                          0x10u
+#define RTC_SR_TCE_SHIFT                         4
+/* LR Bit Fields */
+#define RTC_LR_TCL_MASK                          0x8u
+#define RTC_LR_TCL_SHIFT                         3
+#define RTC_LR_CRL_MASK                          0x10u
+#define RTC_LR_CRL_SHIFT                         4
+#define RTC_LR_SRL_MASK                          0x20u
+#define RTC_LR_SRL_SHIFT                         5
+#define RTC_LR_LRL_MASK                          0x40u
+#define RTC_LR_LRL_SHIFT                         6
+/* IER Bit Fields */
+#define RTC_IER_TIIE_MASK                        0x1u
+#define RTC_IER_TIIE_SHIFT                       0
+#define RTC_IER_TOIE_MASK                        0x2u
+#define RTC_IER_TOIE_SHIFT                       1
+#define RTC_IER_TAIE_MASK                        0x4u
+#define RTC_IER_TAIE_SHIFT                       2
+#define RTC_IER_TSIE_MASK                        0x10u
+#define RTC_IER_TSIE_SHIFT                       4
+#define RTC_IER_WPON_MASK                        0x80u
+#define RTC_IER_WPON_SHIFT                       7
+/* WAR Bit Fields */
+#define RTC_WAR_TSRW_MASK                        0x1u
+#define RTC_WAR_TSRW_SHIFT                       0
+#define RTC_WAR_TPRW_MASK                        0x2u
+#define RTC_WAR_TPRW_SHIFT                       1
+#define RTC_WAR_TARW_MASK                        0x4u
+#define RTC_WAR_TARW_SHIFT                       2
+#define RTC_WAR_TCRW_MASK                        0x8u
+#define RTC_WAR_TCRW_SHIFT                       3
+#define RTC_WAR_CRW_MASK                         0x10u
+#define RTC_WAR_CRW_SHIFT                        4
+#define RTC_WAR_SRW_MASK                         0x20u
+#define RTC_WAR_SRW_SHIFT                        5
+#define RTC_WAR_LRW_MASK                         0x40u
+#define RTC_WAR_LRW_SHIFT                        6
+#define RTC_WAR_IERW_MASK                        0x80u
+#define RTC_WAR_IERW_SHIFT                       7
+/* RAR Bit Fields */
+#define RTC_RAR_TSRR_MASK                        0x1u
+#define RTC_RAR_TSRR_SHIFT                       0
+#define RTC_RAR_TPRR_MASK                        0x2u
+#define RTC_RAR_TPRR_SHIFT                       1
+#define RTC_RAR_TARR_MASK                        0x4u
+#define RTC_RAR_TARR_SHIFT                       2
+#define RTC_RAR_TCRR_MASK                        0x8u
+#define RTC_RAR_TCRR_SHIFT                       3
+#define RTC_RAR_CRR_MASK                         0x10u
+#define RTC_RAR_CRR_SHIFT                        4
+#define RTC_RAR_SRR_MASK                         0x20u
+#define RTC_RAR_SRR_SHIFT                        5
+#define RTC_RAR_LRR_MASK                         0x40u
+#define RTC_RAR_LRR_SHIFT                        6
+#define RTC_RAR_IERR_MASK                        0x80u
+#define RTC_RAR_IERR_SHIFT                       7
+
+/*!
+ * @}
+ */ /* end of group RTC_Register_Masks */
+
+
+/* RTC - Peripheral instance base addresses */
+/** Peripheral RTC base address */
+#define RTC_BASE                                 (0x4003D000u)
+/** Peripheral RTC base pointer */
+#define RTC                                      ((RTC_Type *)RTC_BASE)
+#define RTC_BASE_PTR                             (RTC)
+/** Array initializer of RTC peripheral base addresses */
+#define RTC_BASE_ADDRS                           { RTC_BASE }
+/** Array initializer of RTC peripheral base pointers */
+#define RTC_BASE_PTRS                            { RTC }
+/** Interrupt vectors for the RTC peripheral type */
+#define RTC_IRQS                                 { RTC_IRQn }
+#define RTC_SECONDS_IRQS                         { RTC_Seconds_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- RTC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RTC_Register_Accessor_Macros RTC - Register accessor macros
+ * @{
+ */
+
+
+/* RTC - Register instance definitions */
+/* RTC */
+#define RTC_TSR                                  RTC_TSR_REG(RTC)
+#define RTC_TPR                                  RTC_TPR_REG(RTC)
+#define RTC_TAR                                  RTC_TAR_REG(RTC)
+#define RTC_TCR                                  RTC_TCR_REG(RTC)
+#define RTC_CR                                   RTC_CR_REG(RTC)
+#define RTC_SR                                   RTC_SR_REG(RTC)
+#define RTC_LR                                   RTC_LR_REG(RTC)
+#define RTC_IER                                  RTC_IER_REG(RTC)
+#define RTC_WAR                                  RTC_WAR_REG(RTC)
+#define RTC_RAR                                  RTC_RAR_REG(RTC)
+
+/*!
+ * @}
+ */ /* end of group RTC_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group RTC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- SDHC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SDHC_Peripheral_Access_Layer SDHC Peripheral Access Layer
+ * @{
+ */
+
+/** SDHC - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t DSADDR;                            /**< DMA System Address register, offset: 0x0 */
+  __IO uint32_t BLKATTR;                           /**< Block Attributes register, offset: 0x4 */
+  __IO uint32_t CMDARG;                            /**< Command Argument register, offset: 0x8 */
+  __IO uint32_t XFERTYP;                           /**< Transfer Type register, offset: 0xC */
+  __I  uint32_t CMDRSP[4];                         /**< Command Response 0..Command Response 3, array offset: 0x10, array step: 0x4 */
+  __IO uint32_t DATPORT;                           /**< Buffer Data Port register, offset: 0x20 */
+  __I  uint32_t PRSSTAT;                           /**< Present State register, offset: 0x24 */
+  __IO uint32_t PROCTL;                            /**< Protocol Control register, offset: 0x28 */
+  __IO uint32_t SYSCTL;                            /**< System Control register, offset: 0x2C */
+  __IO uint32_t IRQSTAT;                           /**< Interrupt Status register, offset: 0x30 */
+  __IO uint32_t IRQSTATEN;                         /**< Interrupt Status Enable register, offset: 0x34 */
+  __IO uint32_t IRQSIGEN;                          /**< Interrupt Signal Enable register, offset: 0x38 */
+  __I  uint32_t AC12ERR;                           /**< Auto CMD12 Error Status Register, offset: 0x3C */
+  __I  uint32_t HTCAPBLT;                          /**< Host Controller Capabilities, offset: 0x40 */
+  __IO uint32_t WML;                               /**< Watermark Level Register, offset: 0x44 */
+       uint8_t RESERVED_0[8];
+  __O  uint32_t FEVT;                              /**< Force Event register, offset: 0x50 */
+  __I  uint32_t ADMAES;                            /**< ADMA Error Status register, offset: 0x54 */
+  __IO uint32_t ADSADDR;                           /**< ADMA System Addressregister, offset: 0x58 */
+       uint8_t RESERVED_1[100];
+  __IO uint32_t VENDOR;                            /**< Vendor Specific register, offset: 0xC0 */
+  __IO uint32_t MMCBOOT;                           /**< MMC Boot register, offset: 0xC4 */
+       uint8_t RESERVED_2[52];
+  __I  uint32_t HOSTVER;                           /**< Host Controller Version, offset: 0xFC */
+} SDHC_Type, *SDHC_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- SDHC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SDHC_Register_Accessor_Macros SDHC - Register accessor macros
+ * @{
+ */
+
+
+/* SDHC - Register accessors */
+#define SDHC_DSADDR_REG(base)                    ((base)->DSADDR)
+#define SDHC_BLKATTR_REG(base)                   ((base)->BLKATTR)
+#define SDHC_CMDARG_REG(base)                    ((base)->CMDARG)
+#define SDHC_XFERTYP_REG(base)                   ((base)->XFERTYP)
+#define SDHC_CMDRSP_REG(base,index)              ((base)->CMDRSP[index])
+#define SDHC_DATPORT_REG(base)                   ((base)->DATPORT)
+#define SDHC_PRSSTAT_REG(base)                   ((base)->PRSSTAT)
+#define SDHC_PROCTL_REG(base)                    ((base)->PROCTL)
+#define SDHC_SYSCTL_REG(base)                    ((base)->SYSCTL)
+#define SDHC_IRQSTAT_REG(base)                   ((base)->IRQSTAT)
+#define SDHC_IRQSTATEN_REG(base)                 ((base)->IRQSTATEN)
+#define SDHC_IRQSIGEN_REG(base)                  ((base)->IRQSIGEN)
+#define SDHC_AC12ERR_REG(base)                   ((base)->AC12ERR)
+#define SDHC_HTCAPBLT_REG(base)                  ((base)->HTCAPBLT)
+#define SDHC_WML_REG(base)                       ((base)->WML)
+#define SDHC_FEVT_REG(base)                      ((base)->FEVT)
+#define SDHC_ADMAES_REG(base)                    ((base)->ADMAES)
+#define SDHC_ADSADDR_REG(base)                   ((base)->ADSADDR)
+#define SDHC_VENDOR_REG(base)                    ((base)->VENDOR)
+#define SDHC_MMCBOOT_REG(base)                   ((base)->MMCBOOT)
+#define SDHC_HOSTVER_REG(base)                   ((base)->HOSTVER)
+
+/*!
+ * @}
+ */ /* end of group SDHC_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- SDHC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SDHC_Register_Masks SDHC Register Masks
+ * @{
+ */
+
+/* DSADDR Bit Fields */
+#define SDHC_DSADDR_DSADDR_MASK                  0xFFFFFFFCu
+#define SDHC_DSADDR_DSADDR_SHIFT                 2
+#define SDHC_DSADDR_DSADDR(x)                    (((uint32_t)(((uint32_t)(x))<<SDHC_DSADDR_DSADDR_SHIFT))&SDHC_DSADDR_DSADDR_MASK)
+/* BLKATTR Bit Fields */
+#define SDHC_BLKATTR_BLKSIZE_MASK                0x1FFFu
+#define SDHC_BLKATTR_BLKSIZE_SHIFT               0
+#define SDHC_BLKATTR_BLKSIZE(x)                  (((uint32_t)(((uint32_t)(x))<<SDHC_BLKATTR_BLKSIZE_SHIFT))&SDHC_BLKATTR_BLKSIZE_MASK)
+#define SDHC_BLKATTR_BLKCNT_MASK                 0xFFFF0000u
+#define SDHC_BLKATTR_BLKCNT_SHIFT                16
+#define SDHC_BLKATTR_BLKCNT(x)                   (((uint32_t)(((uint32_t)(x))<<SDHC_BLKATTR_BLKCNT_SHIFT))&SDHC_BLKATTR_BLKCNT_MASK)
+/* CMDARG Bit Fields */
+#define SDHC_CMDARG_CMDARG_MASK                  0xFFFFFFFFu
+#define SDHC_CMDARG_CMDARG_SHIFT                 0
+#define SDHC_CMDARG_CMDARG(x)                    (((uint32_t)(((uint32_t)(x))<<SDHC_CMDARG_CMDARG_SHIFT))&SDHC_CMDARG_CMDARG_MASK)
+/* XFERTYP Bit Fields */
+#define SDHC_XFERTYP_DMAEN_MASK                  0x1u
+#define SDHC_XFERTYP_DMAEN_SHIFT                 0
+#define SDHC_XFERTYP_BCEN_MASK                   0x2u
+#define SDHC_XFERTYP_BCEN_SHIFT                  1
+#define SDHC_XFERTYP_AC12EN_MASK                 0x4u
+#define SDHC_XFERTYP_AC12EN_SHIFT                2
+#define SDHC_XFERTYP_DTDSEL_MASK                 0x10u
+#define SDHC_XFERTYP_DTDSEL_SHIFT                4
+#define SDHC_XFERTYP_MSBSEL_MASK                 0x20u
+#define SDHC_XFERTYP_MSBSEL_SHIFT                5
+#define SDHC_XFERTYP_RSPTYP_MASK                 0x30000u
+#define SDHC_XFERTYP_RSPTYP_SHIFT                16
+#define SDHC_XFERTYP_RSPTYP(x)                   (((uint32_t)(((uint32_t)(x))<<SDHC_XFERTYP_RSPTYP_SHIFT))&SDHC_XFERTYP_RSPTYP_MASK)
+#define SDHC_XFERTYP_CCCEN_MASK                  0x80000u
+#define SDHC_XFERTYP_CCCEN_SHIFT                 19
+#define SDHC_XFERTYP_CICEN_MASK                  0x100000u
+#define SDHC_XFERTYP_CICEN_SHIFT                 20
+#define SDHC_XFERTYP_DPSEL_MASK                  0x200000u
+#define SDHC_XFERTYP_DPSEL_SHIFT                 21
+#define SDHC_XFERTYP_CMDTYP_MASK                 0xC00000u
+#define SDHC_XFERTYP_CMDTYP_SHIFT                22
+#define SDHC_XFERTYP_CMDTYP(x)                   (((uint32_t)(((uint32_t)(x))<<SDHC_XFERTYP_CMDTYP_SHIFT))&SDHC_XFERTYP_CMDTYP_MASK)
+#define SDHC_XFERTYP_CMDINX_MASK                 0x3F000000u
+#define SDHC_XFERTYP_CMDINX_SHIFT                24
+#define SDHC_XFERTYP_CMDINX(x)                   (((uint32_t)(((uint32_t)(x))<<SDHC_XFERTYP_CMDINX_SHIFT))&SDHC_XFERTYP_CMDINX_MASK)
+/* CMDRSP Bit Fields */
+#define SDHC_CMDRSP_CMDRSP0_MASK                 0xFFFFFFFFu
+#define SDHC_CMDRSP_CMDRSP0_SHIFT                0
+#define SDHC_CMDRSP_CMDRSP0(x)                   (((uint32_t)(((uint32_t)(x))<<SDHC_CMDRSP_CMDRSP0_SHIFT))&SDHC_CMDRSP_CMDRSP0_MASK)
+#define SDHC_CMDRSP_CMDRSP1_MASK                 0xFFFFFFFFu
+#define SDHC_CMDRSP_CMDRSP1_SHIFT                0
+#define SDHC_CMDRSP_CMDRSP1(x)                   (((uint32_t)(((uint32_t)(x))<<SDHC_CMDRSP_CMDRSP1_SHIFT))&SDHC_CMDRSP_CMDRSP1_MASK)
+#define SDHC_CMDRSP_CMDRSP2_MASK                 0xFFFFFFFFu
+#define SDHC_CMDRSP_CMDRSP2_SHIFT                0
+#define SDHC_CMDRSP_CMDRSP2(x)                   (((uint32_t)(((uint32_t)(x))<<SDHC_CMDRSP_CMDRSP2_SHIFT))&SDHC_CMDRSP_CMDRSP2_MASK)
+#define SDHC_CMDRSP_CMDRSP3_MASK                 0xFFFFFFFFu
+#define SDHC_CMDRSP_CMDRSP3_SHIFT                0
+#define SDHC_CMDRSP_CMDRSP3(x)                   (((uint32_t)(((uint32_t)(x))<<SDHC_CMDRSP_CMDRSP3_SHIFT))&SDHC_CMDRSP_CMDRSP3_MASK)
+/* DATPORT Bit Fields */
+#define SDHC_DATPORT_DATCONT_MASK                0xFFFFFFFFu
+#define SDHC_DATPORT_DATCONT_SHIFT               0
+#define SDHC_DATPORT_DATCONT(x)                  (((uint32_t)(((uint32_t)(x))<<SDHC_DATPORT_DATCONT_SHIFT))&SDHC_DATPORT_DATCONT_MASK)
+/* PRSSTAT Bit Fields */
+#define SDHC_PRSSTAT_CIHB_MASK                   0x1u
+#define SDHC_PRSSTAT_CIHB_SHIFT                  0
+#define SDHC_PRSSTAT_CDIHB_MASK                  0x2u
+#define SDHC_PRSSTAT_CDIHB_SHIFT                 1
+#define SDHC_PRSSTAT_DLA_MASK                    0x4u
+#define SDHC_PRSSTAT_DLA_SHIFT                   2
+#define SDHC_PRSSTAT_SDSTB_MASK                  0x8u
+#define SDHC_PRSSTAT_SDSTB_SHIFT                 3
+#define SDHC_PRSSTAT_IPGOFF_MASK                 0x10u
+#define SDHC_PRSSTAT_IPGOFF_SHIFT                4
+#define SDHC_PRSSTAT_HCKOFF_MASK                 0x20u
+#define SDHC_PRSSTAT_HCKOFF_SHIFT                5
+#define SDHC_PRSSTAT_PEROFF_MASK                 0x40u
+#define SDHC_PRSSTAT_PEROFF_SHIFT                6
+#define SDHC_PRSSTAT_SDOFF_MASK                  0x80u
+#define SDHC_PRSSTAT_SDOFF_SHIFT                 7
+#define SDHC_PRSSTAT_WTA_MASK                    0x100u
+#define SDHC_PRSSTAT_WTA_SHIFT                   8
+#define SDHC_PRSSTAT_RTA_MASK                    0x200u
+#define SDHC_PRSSTAT_RTA_SHIFT                   9
+#define SDHC_PRSSTAT_BWEN_MASK                   0x400u
+#define SDHC_PRSSTAT_BWEN_SHIFT                  10
+#define SDHC_PRSSTAT_BREN_MASK                   0x800u
+#define SDHC_PRSSTAT_BREN_SHIFT                  11
+#define SDHC_PRSSTAT_CINS_MASK                   0x10000u
+#define SDHC_PRSSTAT_CINS_SHIFT                  16
+#define SDHC_PRSSTAT_CLSL_MASK                   0x800000u
+#define SDHC_PRSSTAT_CLSL_SHIFT                  23
+#define SDHC_PRSSTAT_DLSL_MASK                   0xFF000000u
+#define SDHC_PRSSTAT_DLSL_SHIFT                  24
+#define SDHC_PRSSTAT_DLSL(x)                     (((uint32_t)(((uint32_t)(x))<<SDHC_PRSSTAT_DLSL_SHIFT))&SDHC_PRSSTAT_DLSL_MASK)
+/* PROCTL Bit Fields */
+#define SDHC_PROCTL_LCTL_MASK                    0x1u
+#define SDHC_PROCTL_LCTL_SHIFT                   0
+#define SDHC_PROCTL_DTW_MASK                     0x6u
+#define SDHC_PROCTL_DTW_SHIFT                    1
+#define SDHC_PROCTL_DTW(x)                       (((uint32_t)(((uint32_t)(x))<<SDHC_PROCTL_DTW_SHIFT))&SDHC_PROCTL_DTW_MASK)
+#define SDHC_PROCTL_D3CD_MASK                    0x8u
+#define SDHC_PROCTL_D3CD_SHIFT                   3
+#define SDHC_PROCTL_EMODE_MASK                   0x30u
+#define SDHC_PROCTL_EMODE_SHIFT                  4
+#define SDHC_PROCTL_EMODE(x)                     (((uint32_t)(((uint32_t)(x))<<SDHC_PROCTL_EMODE_SHIFT))&SDHC_PROCTL_EMODE_MASK)
+#define SDHC_PROCTL_CDTL_MASK                    0x40u
+#define SDHC_PROCTL_CDTL_SHIFT                   6
+#define SDHC_PROCTL_CDSS_MASK                    0x80u
+#define SDHC_PROCTL_CDSS_SHIFT                   7
+#define SDHC_PROCTL_DMAS_MASK                    0x300u
+#define SDHC_PROCTL_DMAS_SHIFT                   8
+#define SDHC_PROCTL_DMAS(x)                      (((uint32_t)(((uint32_t)(x))<<SDHC_PROCTL_DMAS_SHIFT))&SDHC_PROCTL_DMAS_MASK)
+#define SDHC_PROCTL_SABGREQ_MASK                 0x10000u
+#define SDHC_PROCTL_SABGREQ_SHIFT                16
+#define SDHC_PROCTL_CREQ_MASK                    0x20000u
+#define SDHC_PROCTL_CREQ_SHIFT                   17
+#define SDHC_PROCTL_RWCTL_MASK                   0x40000u
+#define SDHC_PROCTL_RWCTL_SHIFT                  18
+#define SDHC_PROCTL_IABG_MASK                    0x80000u
+#define SDHC_PROCTL_IABG_SHIFT                   19
+#define SDHC_PROCTL_WECINT_MASK                  0x1000000u
+#define SDHC_PROCTL_WECINT_SHIFT                 24
+#define SDHC_PROCTL_WECINS_MASK                  0x2000000u
+#define SDHC_PROCTL_WECINS_SHIFT                 25
+#define SDHC_PROCTL_WECRM_MASK                   0x4000000u
+#define SDHC_PROCTL_WECRM_SHIFT                  26
+/* SYSCTL Bit Fields */
+#define SDHC_SYSCTL_IPGEN_MASK                   0x1u
+#define SDHC_SYSCTL_IPGEN_SHIFT                  0
+#define SDHC_SYSCTL_HCKEN_MASK                   0x2u
+#define SDHC_SYSCTL_HCKEN_SHIFT                  1
+#define SDHC_SYSCTL_PEREN_MASK                   0x4u
+#define SDHC_SYSCTL_PEREN_SHIFT                  2
+#define SDHC_SYSCTL_SDCLKEN_MASK                 0x8u
+#define SDHC_SYSCTL_SDCLKEN_SHIFT                3
+#define SDHC_SYSCTL_DVS_MASK                     0xF0u
+#define SDHC_SYSCTL_DVS_SHIFT                    4
+#define SDHC_SYSCTL_DVS(x)                       (((uint32_t)(((uint32_t)(x))<<SDHC_SYSCTL_DVS_SHIFT))&SDHC_SYSCTL_DVS_MASK)
+#define SDHC_SYSCTL_SDCLKFS_MASK                 0xFF00u
+#define SDHC_SYSCTL_SDCLKFS_SHIFT                8
+#define SDHC_SYSCTL_SDCLKFS(x)                   (((uint32_t)(((uint32_t)(x))<<SDHC_SYSCTL_SDCLKFS_SHIFT))&SDHC_SYSCTL_SDCLKFS_MASK)
+#define SDHC_SYSCTL_DTOCV_MASK                   0xF0000u
+#define SDHC_SYSCTL_DTOCV_SHIFT                  16
+#define SDHC_SYSCTL_DTOCV(x)                     (((uint32_t)(((uint32_t)(x))<<SDHC_SYSCTL_DTOCV_SHIFT))&SDHC_SYSCTL_DTOCV_MASK)
+#define SDHC_SYSCTL_RSTA_MASK                    0x1000000u
+#define SDHC_SYSCTL_RSTA_SHIFT                   24
+#define SDHC_SYSCTL_RSTC_MASK                    0x2000000u
+#define SDHC_SYSCTL_RSTC_SHIFT                   25
+#define SDHC_SYSCTL_RSTD_MASK                    0x4000000u
+#define SDHC_SYSCTL_RSTD_SHIFT                   26
+#define SDHC_SYSCTL_INITA_MASK                   0x8000000u
+#define SDHC_SYSCTL_INITA_SHIFT                  27
+/* IRQSTAT Bit Fields */
+#define SDHC_IRQSTAT_CC_MASK                     0x1u
+#define SDHC_IRQSTAT_CC_SHIFT                    0
+#define SDHC_IRQSTAT_TC_MASK                     0x2u
+#define SDHC_IRQSTAT_TC_SHIFT                    1
+#define SDHC_IRQSTAT_BGE_MASK                    0x4u
+#define SDHC_IRQSTAT_BGE_SHIFT                   2
+#define SDHC_IRQSTAT_DINT_MASK                   0x8u
+#define SDHC_IRQSTAT_DINT_SHIFT                  3
+#define SDHC_IRQSTAT_BWR_MASK                    0x10u
+#define SDHC_IRQSTAT_BWR_SHIFT                   4
+#define SDHC_IRQSTAT_BRR_MASK                    0x20u
+#define SDHC_IRQSTAT_BRR_SHIFT                   5
+#define SDHC_IRQSTAT_CINS_MASK                   0x40u
+#define SDHC_IRQSTAT_CINS_SHIFT                  6
+#define SDHC_IRQSTAT_CRM_MASK                    0x80u
+#define SDHC_IRQSTAT_CRM_SHIFT                   7
+#define SDHC_IRQSTAT_CINT_MASK                   0x100u
+#define SDHC_IRQSTAT_CINT_SHIFT                  8
+#define SDHC_IRQSTAT_CTOE_MASK                   0x10000u
+#define SDHC_IRQSTAT_CTOE_SHIFT                  16
+#define SDHC_IRQSTAT_CCE_MASK                    0x20000u
+#define SDHC_IRQSTAT_CCE_SHIFT                   17
+#define SDHC_IRQSTAT_CEBE_MASK                   0x40000u
+#define SDHC_IRQSTAT_CEBE_SHIFT                  18
+#define SDHC_IRQSTAT_CIE_MASK                    0x80000u
+#define SDHC_IRQSTAT_CIE_SHIFT                   19
+#define SDHC_IRQSTAT_DTOE_MASK                   0x100000u
+#define SDHC_IRQSTAT_DTOE_SHIFT                  20
+#define SDHC_IRQSTAT_DCE_MASK                    0x200000u
+#define SDHC_IRQSTAT_DCE_SHIFT                   21
+#define SDHC_IRQSTAT_DEBE_MASK                   0x400000u
+#define SDHC_IRQSTAT_DEBE_SHIFT                  22
+#define SDHC_IRQSTAT_AC12E_MASK                  0x1000000u
+#define SDHC_IRQSTAT_AC12E_SHIFT                 24
+#define SDHC_IRQSTAT_DMAE_MASK                   0x10000000u
+#define SDHC_IRQSTAT_DMAE_SHIFT                  28
+/* IRQSTATEN Bit Fields */
+#define SDHC_IRQSTATEN_CCSEN_MASK                0x1u
+#define SDHC_IRQSTATEN_CCSEN_SHIFT               0
+#define SDHC_IRQSTATEN_TCSEN_MASK                0x2u
+#define SDHC_IRQSTATEN_TCSEN_SHIFT               1
+#define SDHC_IRQSTATEN_BGESEN_MASK               0x4u
+#define SDHC_IRQSTATEN_BGESEN_SHIFT              2
+#define SDHC_IRQSTATEN_DINTSEN_MASK              0x8u
+#define SDHC_IRQSTATEN_DINTSEN_SHIFT             3
+#define SDHC_IRQSTATEN_BWRSEN_MASK               0x10u
+#define SDHC_IRQSTATEN_BWRSEN_SHIFT              4
+#define SDHC_IRQSTATEN_BRRSEN_MASK               0x20u
+#define SDHC_IRQSTATEN_BRRSEN_SHIFT              5
+#define SDHC_IRQSTATEN_CINSEN_MASK               0x40u
+#define SDHC_IRQSTATEN_CINSEN_SHIFT              6
+#define SDHC_IRQSTATEN_CRMSEN_MASK               0x80u
+#define SDHC_IRQSTATEN_CRMSEN_SHIFT              7
+#define SDHC_IRQSTATEN_CINTSEN_MASK              0x100u
+#define SDHC_IRQSTATEN_CINTSEN_SHIFT             8
+#define SDHC_IRQSTATEN_CTOESEN_MASK              0x10000u
+#define SDHC_IRQSTATEN_CTOESEN_SHIFT             16
+#define SDHC_IRQSTATEN_CCESEN_MASK               0x20000u
+#define SDHC_IRQSTATEN_CCESEN_SHIFT              17
+#define SDHC_IRQSTATEN_CEBESEN_MASK              0x40000u
+#define SDHC_IRQSTATEN_CEBESEN_SHIFT             18
+#define SDHC_IRQSTATEN_CIESEN_MASK               0x80000u
+#define SDHC_IRQSTATEN_CIESEN_SHIFT              19
+#define SDHC_IRQSTATEN_DTOESEN_MASK              0x100000u
+#define SDHC_IRQSTATEN_DTOESEN_SHIFT             20
+#define SDHC_IRQSTATEN_DCESEN_MASK               0x200000u
+#define SDHC_IRQSTATEN_DCESEN_SHIFT              21
+#define SDHC_IRQSTATEN_DEBESEN_MASK              0x400000u
+#define SDHC_IRQSTATEN_DEBESEN_SHIFT             22
+#define SDHC_IRQSTATEN_AC12ESEN_MASK             0x1000000u
+#define SDHC_IRQSTATEN_AC12ESEN_SHIFT            24
+#define SDHC_IRQSTATEN_DMAESEN_MASK              0x10000000u
+#define SDHC_IRQSTATEN_DMAESEN_SHIFT             28
+/* IRQSIGEN Bit Fields */
+#define SDHC_IRQSIGEN_CCIEN_MASK                 0x1u
+#define SDHC_IRQSIGEN_CCIEN_SHIFT                0
+#define SDHC_IRQSIGEN_TCIEN_MASK                 0x2u
+#define SDHC_IRQSIGEN_TCIEN_SHIFT                1
+#define SDHC_IRQSIGEN_BGEIEN_MASK                0x4u
+#define SDHC_IRQSIGEN_BGEIEN_SHIFT               2
+#define SDHC_IRQSIGEN_DINTIEN_MASK               0x8u
+#define SDHC_IRQSIGEN_DINTIEN_SHIFT              3
+#define SDHC_IRQSIGEN_BWRIEN_MASK                0x10u
+#define SDHC_IRQSIGEN_BWRIEN_SHIFT               4
+#define SDHC_IRQSIGEN_BRRIEN_MASK                0x20u
+#define SDHC_IRQSIGEN_BRRIEN_SHIFT               5
+#define SDHC_IRQSIGEN_CINSIEN_MASK               0x40u
+#define SDHC_IRQSIGEN_CINSIEN_SHIFT              6
+#define SDHC_IRQSIGEN_CRMIEN_MASK                0x80u
+#define SDHC_IRQSIGEN_CRMIEN_SHIFT               7
+#define SDHC_IRQSIGEN_CINTIEN_MASK               0x100u
+#define SDHC_IRQSIGEN_CINTIEN_SHIFT              8
+#define SDHC_IRQSIGEN_CTOEIEN_MASK               0x10000u
+#define SDHC_IRQSIGEN_CTOEIEN_SHIFT              16
+#define SDHC_IRQSIGEN_CCEIEN_MASK                0x20000u
+#define SDHC_IRQSIGEN_CCEIEN_SHIFT               17
+#define SDHC_IRQSIGEN_CEBEIEN_MASK               0x40000u
+#define SDHC_IRQSIGEN_CEBEIEN_SHIFT              18
+#define SDHC_IRQSIGEN_CIEIEN_MASK                0x80000u
+#define SDHC_IRQSIGEN_CIEIEN_SHIFT               19
+#define SDHC_IRQSIGEN_DTOEIEN_MASK               0x100000u
+#define SDHC_IRQSIGEN_DTOEIEN_SHIFT              20
+#define SDHC_IRQSIGEN_DCEIEN_MASK                0x200000u
+#define SDHC_IRQSIGEN_DCEIEN_SHIFT               21
+#define SDHC_IRQSIGEN_DEBEIEN_MASK               0x400000u
+#define SDHC_IRQSIGEN_DEBEIEN_SHIFT              22
+#define SDHC_IRQSIGEN_AC12EIEN_MASK              0x1000000u
+#define SDHC_IRQSIGEN_AC12EIEN_SHIFT             24
+#define SDHC_IRQSIGEN_DMAEIEN_MASK               0x10000000u
+#define SDHC_IRQSIGEN_DMAEIEN_SHIFT              28
+/* AC12ERR Bit Fields */
+#define SDHC_AC12ERR_AC12NE_MASK                 0x1u
+#define SDHC_AC12ERR_AC12NE_SHIFT                0
+#define SDHC_AC12ERR_AC12TOE_MASK                0x2u
+#define SDHC_AC12ERR_AC12TOE_SHIFT               1
+#define SDHC_AC12ERR_AC12EBE_MASK                0x4u
+#define SDHC_AC12ERR_AC12EBE_SHIFT               2
+#define SDHC_AC12ERR_AC12CE_MASK                 0x8u
+#define SDHC_AC12ERR_AC12CE_SHIFT                3
+#define SDHC_AC12ERR_AC12IE_MASK                 0x10u
+#define SDHC_AC12ERR_AC12IE_SHIFT                4
+#define SDHC_AC12ERR_CNIBAC12E_MASK              0x80u
+#define SDHC_AC12ERR_CNIBAC12E_SHIFT             7
+/* HTCAPBLT Bit Fields */
+#define SDHC_HTCAPBLT_MBL_MASK                   0x70000u
+#define SDHC_HTCAPBLT_MBL_SHIFT                  16
+#define SDHC_HTCAPBLT_MBL(x)                     (((uint32_t)(((uint32_t)(x))<<SDHC_HTCAPBLT_MBL_SHIFT))&SDHC_HTCAPBLT_MBL_MASK)
+#define SDHC_HTCAPBLT_ADMAS_MASK                 0x100000u
+#define SDHC_HTCAPBLT_ADMAS_SHIFT                20
+#define SDHC_HTCAPBLT_HSS_MASK                   0x200000u
+#define SDHC_HTCAPBLT_HSS_SHIFT                  21
+#define SDHC_HTCAPBLT_DMAS_MASK                  0x400000u
+#define SDHC_HTCAPBLT_DMAS_SHIFT                 22
+#define SDHC_HTCAPBLT_SRS_MASK                   0x800000u
+#define SDHC_HTCAPBLT_SRS_SHIFT                  23
+#define SDHC_HTCAPBLT_VS33_MASK                  0x1000000u
+#define SDHC_HTCAPBLT_VS33_SHIFT                 24
+/* WML Bit Fields */
+#define SDHC_WML_RDWML_MASK                      0xFFu
+#define SDHC_WML_RDWML_SHIFT                     0
+#define SDHC_WML_RDWML(x)                        (((uint32_t)(((uint32_t)(x))<<SDHC_WML_RDWML_SHIFT))&SDHC_WML_RDWML_MASK)
+#define SDHC_WML_WRWML_MASK                      0xFF0000u
+#define SDHC_WML_WRWML_SHIFT                     16
+#define SDHC_WML_WRWML(x)                        (((uint32_t)(((uint32_t)(x))<<SDHC_WML_WRWML_SHIFT))&SDHC_WML_WRWML_MASK)
+/* FEVT Bit Fields */
+#define SDHC_FEVT_AC12NE_MASK                    0x1u
+#define SDHC_FEVT_AC12NE_SHIFT                   0
+#define SDHC_FEVT_AC12TOE_MASK                   0x2u
+#define SDHC_FEVT_AC12TOE_SHIFT                  1
+#define SDHC_FEVT_AC12CE_MASK                    0x4u
+#define SDHC_FEVT_AC12CE_SHIFT                   2
+#define SDHC_FEVT_AC12EBE_MASK                   0x8u
+#define SDHC_FEVT_AC12EBE_SHIFT                  3
+#define SDHC_FEVT_AC12IE_MASK                    0x10u
+#define SDHC_FEVT_AC12IE_SHIFT                   4
+#define SDHC_FEVT_CNIBAC12E_MASK                 0x80u
+#define SDHC_FEVT_CNIBAC12E_SHIFT                7
+#define SDHC_FEVT_CTOE_MASK                      0x10000u
+#define SDHC_FEVT_CTOE_SHIFT                     16
+#define SDHC_FEVT_CCE_MASK                       0x20000u
+#define SDHC_FEVT_CCE_SHIFT                      17
+#define SDHC_FEVT_CEBE_MASK                      0x40000u
+#define SDHC_FEVT_CEBE_SHIFT                     18
+#define SDHC_FEVT_CIE_MASK                       0x80000u
+#define SDHC_FEVT_CIE_SHIFT                      19
+#define SDHC_FEVT_DTOE_MASK                      0x100000u
+#define SDHC_FEVT_DTOE_SHIFT                     20
+#define SDHC_FEVT_DCE_MASK                       0x200000u
+#define SDHC_FEVT_DCE_SHIFT                      21
+#define SDHC_FEVT_DEBE_MASK                      0x400000u
+#define SDHC_FEVT_DEBE_SHIFT                     22
+#define SDHC_FEVT_AC12E_MASK                     0x1000000u
+#define SDHC_FEVT_AC12E_SHIFT                    24
+#define SDHC_FEVT_DMAE_MASK                      0x10000000u
+#define SDHC_FEVT_DMAE_SHIFT                     28
+#define SDHC_FEVT_CINT_MASK                      0x80000000u
+#define SDHC_FEVT_CINT_SHIFT                     31
+/* ADMAES Bit Fields */
+#define SDHC_ADMAES_ADMAES_MASK                  0x3u
+#define SDHC_ADMAES_ADMAES_SHIFT                 0
+#define SDHC_ADMAES_ADMAES(x)                    (((uint32_t)(((uint32_t)(x))<<SDHC_ADMAES_ADMAES_SHIFT))&SDHC_ADMAES_ADMAES_MASK)
+#define SDHC_ADMAES_ADMALME_MASK                 0x4u
+#define SDHC_ADMAES_ADMALME_SHIFT                2
+#define SDHC_ADMAES_ADMADCE_MASK                 0x8u
+#define SDHC_ADMAES_ADMADCE_SHIFT                3
+/* ADSADDR Bit Fields */
+#define SDHC_ADSADDR_ADSADDR_MASK                0xFFFFFFFCu
+#define SDHC_ADSADDR_ADSADDR_SHIFT               2
+#define SDHC_ADSADDR_ADSADDR(x)                  (((uint32_t)(((uint32_t)(x))<<SDHC_ADSADDR_ADSADDR_SHIFT))&SDHC_ADSADDR_ADSADDR_MASK)
+/* VENDOR Bit Fields */
+#define SDHC_VENDOR_EXTDMAEN_MASK                0x1u
+#define SDHC_VENDOR_EXTDMAEN_SHIFT               0
+#define SDHC_VENDOR_EXBLKNU_MASK                 0x2u
+#define SDHC_VENDOR_EXBLKNU_SHIFT                1
+#define SDHC_VENDOR_INTSTVAL_MASK                0xFF0000u
+#define SDHC_VENDOR_INTSTVAL_SHIFT               16
+#define SDHC_VENDOR_INTSTVAL(x)                  (((uint32_t)(((uint32_t)(x))<<SDHC_VENDOR_INTSTVAL_SHIFT))&SDHC_VENDOR_INTSTVAL_MASK)
+/* MMCBOOT Bit Fields */
+#define SDHC_MMCBOOT_DTOCVACK_MASK               0xFu
+#define SDHC_MMCBOOT_DTOCVACK_SHIFT              0
+#define SDHC_MMCBOOT_DTOCVACK(x)                 (((uint32_t)(((uint32_t)(x))<<SDHC_MMCBOOT_DTOCVACK_SHIFT))&SDHC_MMCBOOT_DTOCVACK_MASK)
+#define SDHC_MMCBOOT_BOOTACK_MASK                0x10u
+#define SDHC_MMCBOOT_BOOTACK_SHIFT               4
+#define SDHC_MMCBOOT_BOOTMODE_MASK               0x20u
+#define SDHC_MMCBOOT_BOOTMODE_SHIFT              5
+#define SDHC_MMCBOOT_BOOTEN_MASK                 0x40u
+#define SDHC_MMCBOOT_BOOTEN_SHIFT                6
+#define SDHC_MMCBOOT_AUTOSABGEN_MASK             0x80u
+#define SDHC_MMCBOOT_AUTOSABGEN_SHIFT            7
+#define SDHC_MMCBOOT_BOOTBLKCNT_MASK             0xFFFF0000u
+#define SDHC_MMCBOOT_BOOTBLKCNT_SHIFT            16
+#define SDHC_MMCBOOT_BOOTBLKCNT(x)               (((uint32_t)(((uint32_t)(x))<<SDHC_MMCBOOT_BOOTBLKCNT_SHIFT))&SDHC_MMCBOOT_BOOTBLKCNT_MASK)
+/* HOSTVER Bit Fields */
+#define SDHC_HOSTVER_SVN_MASK                    0xFFu
+#define SDHC_HOSTVER_SVN_SHIFT                   0
+#define SDHC_HOSTVER_SVN(x)                      (((uint32_t)(((uint32_t)(x))<<SDHC_HOSTVER_SVN_SHIFT))&SDHC_HOSTVER_SVN_MASK)
+#define SDHC_HOSTVER_VVN_MASK                    0xFF00u
+#define SDHC_HOSTVER_VVN_SHIFT                   8
+#define SDHC_HOSTVER_VVN(x)                      (((uint32_t)(((uint32_t)(x))<<SDHC_HOSTVER_VVN_SHIFT))&SDHC_HOSTVER_VVN_MASK)
+
+/*!
+ * @}
+ */ /* end of group SDHC_Register_Masks */
+
+
+/* SDHC - Peripheral instance base addresses */
+/** Peripheral SDHC base address */
+#define SDHC_BASE                                (0x400B1000u)
+/** Peripheral SDHC base pointer */
+#define SDHC                                     ((SDHC_Type *)SDHC_BASE)
+#define SDHC_BASE_PTR                            (SDHC)
+/** Array initializer of SDHC peripheral base addresses */
+#define SDHC_BASE_ADDRS                          { SDHC_BASE }
+/** Array initializer of SDHC peripheral base pointers */
+#define SDHC_BASE_PTRS                           { SDHC }
+/** Interrupt vectors for the SDHC peripheral type */
+#define SDHC_IRQS                                { SDHC_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- SDHC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SDHC_Register_Accessor_Macros SDHC - Register accessor macros
+ * @{
+ */
+
+
+/* SDHC - Register instance definitions */
+/* SDHC */
+#define SDHC_DSADDR                              SDHC_DSADDR_REG(SDHC)
+#define SDHC_BLKATTR                             SDHC_BLKATTR_REG(SDHC)
+#define SDHC_CMDARG                              SDHC_CMDARG_REG(SDHC)
+#define SDHC_XFERTYP                             SDHC_XFERTYP_REG(SDHC)
+#define SDHC_CMDRSP0                             SDHC_CMDRSP_REG(SDHC,0)
+#define SDHC_CMDRSP1                             SDHC_CMDRSP_REG(SDHC,1)
+#define SDHC_CMDRSP2                             SDHC_CMDRSP_REG(SDHC,2)
+#define SDHC_CMDRSP3                             SDHC_CMDRSP_REG(SDHC,3)
+#define SDHC_DATPORT                             SDHC_DATPORT_REG(SDHC)
+#define SDHC_PRSSTAT                             SDHC_PRSSTAT_REG(SDHC)
+#define SDHC_PROCTL                              SDHC_PROCTL_REG(SDHC)
+#define SDHC_SYSCTL                              SDHC_SYSCTL_REG(SDHC)
+#define SDHC_IRQSTAT                             SDHC_IRQSTAT_REG(SDHC)
+#define SDHC_IRQSTATEN                           SDHC_IRQSTATEN_REG(SDHC)
+#define SDHC_IRQSIGEN                            SDHC_IRQSIGEN_REG(SDHC)
+#define SDHC_AC12ERR                             SDHC_AC12ERR_REG(SDHC)
+#define SDHC_HTCAPBLT                            SDHC_HTCAPBLT_REG(SDHC)
+#define SDHC_WML                                 SDHC_WML_REG(SDHC)
+#define SDHC_FEVT                                SDHC_FEVT_REG(SDHC)
+#define SDHC_ADMAES                              SDHC_ADMAES_REG(SDHC)
+#define SDHC_ADSADDR                             SDHC_ADSADDR_REG(SDHC)
+#define SDHC_VENDOR                              SDHC_VENDOR_REG(SDHC)
+#define SDHC_MMCBOOT                             SDHC_MMCBOOT_REG(SDHC)
+#define SDHC_HOSTVER                             SDHC_HOSTVER_REG(SDHC)
+
+/* SDHC - Register array accessors */
+#define SDHC_CMDRSP(index)                       SDHC_CMDRSP_REG(SDHC,index)
+
+/*!
+ * @}
+ */ /* end of group SDHC_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group SDHC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- SIM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SIM_Peripheral_Access_Layer SIM Peripheral Access Layer
+ * @{
+ */
+
+/** SIM - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t SOPT1;                             /**< System Options Register 1, offset: 0x0 */
+  __IO uint32_t SOPT1CFG;                          /**< SOPT1 Configuration Register, offset: 0x4 */
+       uint8_t RESERVED_0[4092];
+  __IO uint32_t SOPT2;                             /**< System Options Register 2, offset: 0x1004 */
+       uint8_t RESERVED_1[4];
+  __IO uint32_t SOPT4;                             /**< System Options Register 4, offset: 0x100C */
+  __IO uint32_t SOPT5;                             /**< System Options Register 5, offset: 0x1010 */
+       uint8_t RESERVED_2[4];
+  __IO uint32_t SOPT7;                             /**< System Options Register 7, offset: 0x1018 */
+       uint8_t RESERVED_3[8];
+  __I  uint32_t SDID;                              /**< System Device Identification Register, offset: 0x1024 */
+  __IO uint32_t SCGC1;                             /**< System Clock Gating Control Register 1, offset: 0x1028 */
+  __IO uint32_t SCGC2;                             /**< System Clock Gating Control Register 2, offset: 0x102C */
+  __IO uint32_t SCGC3;                             /**< System Clock Gating Control Register 3, offset: 0x1030 */
+  __IO uint32_t SCGC4;                             /**< System Clock Gating Control Register 4, offset: 0x1034 */
+  __IO uint32_t SCGC5;                             /**< System Clock Gating Control Register 5, offset: 0x1038 */
+  __IO uint32_t SCGC6;                             /**< System Clock Gating Control Register 6, offset: 0x103C */
+  __IO uint32_t SCGC7;                             /**< System Clock Gating Control Register 7, offset: 0x1040 */
+  __IO uint32_t CLKDIV1;                           /**< System Clock Divider Register 1, offset: 0x1044 */
+  __IO uint32_t CLKDIV2;                           /**< System Clock Divider Register 2, offset: 0x1048 */
+  __IO uint32_t FCFG1;                             /**< Flash Configuration Register 1, offset: 0x104C */
+  __I  uint32_t FCFG2;                             /**< Flash Configuration Register 2, offset: 0x1050 */
+  __I  uint32_t UIDH;                              /**< Unique Identification Register High, offset: 0x1054 */
+  __I  uint32_t UIDMH;                             /**< Unique Identification Register Mid-High, offset: 0x1058 */
+  __I  uint32_t UIDML;                             /**< Unique Identification Register Mid Low, offset: 0x105C */
+  __I  uint32_t UIDL;                              /**< Unique Identification Register Low, offset: 0x1060 */
+} SIM_Type, *SIM_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- SIM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SIM_Register_Accessor_Macros SIM - Register accessor macros
+ * @{
+ */
+
+
+/* SIM - Register accessors */
+#define SIM_SOPT1_REG(base)                      ((base)->SOPT1)
+#define SIM_SOPT1CFG_REG(base)                   ((base)->SOPT1CFG)
+#define SIM_SOPT2_REG(base)                      ((base)->SOPT2)
+#define SIM_SOPT4_REG(base)                      ((base)->SOPT4)
+#define SIM_SOPT5_REG(base)                      ((base)->SOPT5)
+#define SIM_SOPT7_REG(base)                      ((base)->SOPT7)
+#define SIM_SDID_REG(base)                       ((base)->SDID)
+#define SIM_SCGC1_REG(base)                      ((base)->SCGC1)
+#define SIM_SCGC2_REG(base)                      ((base)->SCGC2)
+#define SIM_SCGC3_REG(base)                      ((base)->SCGC3)
+#define SIM_SCGC4_REG(base)                      ((base)->SCGC4)
+#define SIM_SCGC5_REG(base)                      ((base)->SCGC5)
+#define SIM_SCGC6_REG(base)                      ((base)->SCGC6)
+#define SIM_SCGC7_REG(base)                      ((base)->SCGC7)
+#define SIM_CLKDIV1_REG(base)                    ((base)->CLKDIV1)
+#define SIM_CLKDIV2_REG(base)                    ((base)->CLKDIV2)
+#define SIM_FCFG1_REG(base)                      ((base)->FCFG1)
+#define SIM_FCFG2_REG(base)                      ((base)->FCFG2)
+#define SIM_UIDH_REG(base)                       ((base)->UIDH)
+#define SIM_UIDMH_REG(base)                      ((base)->UIDMH)
+#define SIM_UIDML_REG(base)                      ((base)->UIDML)
+#define SIM_UIDL_REG(base)                       ((base)->UIDL)
+
+/*!
+ * @}
+ */ /* end of group SIM_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- SIM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SIM_Register_Masks SIM Register Masks
+ * @{
+ */
+
+/* SOPT1 Bit Fields */
+#define SIM_SOPT1_RAMSIZE_MASK                   0xF000u
+#define SIM_SOPT1_RAMSIZE_SHIFT                  12
+#define SIM_SOPT1_RAMSIZE(x)                     (((uint32_t)(((uint32_t)(x))<<SIM_SOPT1_RAMSIZE_SHIFT))&SIM_SOPT1_RAMSIZE_MASK)
+#define SIM_SOPT1_OSC32KSEL_MASK                 0xC0000u
+#define SIM_SOPT1_OSC32KSEL_SHIFT                18
+#define SIM_SOPT1_OSC32KSEL(x)                   (((uint32_t)(((uint32_t)(x))<<SIM_SOPT1_OSC32KSEL_SHIFT))&SIM_SOPT1_OSC32KSEL_MASK)
+#define SIM_SOPT1_USBVSTBY_MASK                  0x20000000u
+#define SIM_SOPT1_USBVSTBY_SHIFT                 29
+#define SIM_SOPT1_USBSSTBY_MASK                  0x40000000u
+#define SIM_SOPT1_USBSSTBY_SHIFT                 30
+#define SIM_SOPT1_USBREGEN_MASK                  0x80000000u
+#define SIM_SOPT1_USBREGEN_SHIFT                 31
+/* SOPT1CFG Bit Fields */
+#define SIM_SOPT1CFG_URWE_MASK                   0x1000000u
+#define SIM_SOPT1CFG_URWE_SHIFT                  24
+#define SIM_SOPT1CFG_UVSWE_MASK                  0x2000000u
+#define SIM_SOPT1CFG_UVSWE_SHIFT                 25
+#define SIM_SOPT1CFG_USSWE_MASK                  0x4000000u
+#define SIM_SOPT1CFG_USSWE_SHIFT                 26
+/* SOPT2 Bit Fields */
+#define SIM_SOPT2_RTCCLKOUTSEL_MASK              0x10u
+#define SIM_SOPT2_RTCCLKOUTSEL_SHIFT             4
+#define SIM_SOPT2_CLKOUTSEL_MASK                 0xE0u
+#define SIM_SOPT2_CLKOUTSEL_SHIFT                5
+#define SIM_SOPT2_CLKOUTSEL(x)                   (((uint32_t)(((uint32_t)(x))<<SIM_SOPT2_CLKOUTSEL_SHIFT))&SIM_SOPT2_CLKOUTSEL_MASK)
+#define SIM_SOPT2_FBSL_MASK                      0x300u
+#define SIM_SOPT2_FBSL_SHIFT                     8
+#define SIM_SOPT2_FBSL(x)                        (((uint32_t)(((uint32_t)(x))<<SIM_SOPT2_FBSL_SHIFT))&SIM_SOPT2_FBSL_MASK)
+#define SIM_SOPT2_PTD7PAD_MASK                   0x800u
+#define SIM_SOPT2_PTD7PAD_SHIFT                  11
+#define SIM_SOPT2_TRACECLKSEL_MASK               0x1000u
+#define SIM_SOPT2_TRACECLKSEL_SHIFT              12
+#define SIM_SOPT2_PLLFLLSEL_MASK                 0x30000u
+#define SIM_SOPT2_PLLFLLSEL_SHIFT                16
+#define SIM_SOPT2_PLLFLLSEL(x)                   (((uint32_t)(((uint32_t)(x))<<SIM_SOPT2_PLLFLLSEL_SHIFT))&SIM_SOPT2_PLLFLLSEL_MASK)
+#define SIM_SOPT2_USBSRC_MASK                    0x40000u
+#define SIM_SOPT2_USBSRC_SHIFT                   18
+#define SIM_SOPT2_RMIISRC_MASK                   0x80000u
+#define SIM_SOPT2_RMIISRC_SHIFT                  19
+#define SIM_SOPT2_TIMESRC_MASK                   0x300000u
+#define SIM_SOPT2_TIMESRC_SHIFT                  20
+#define SIM_SOPT2_TIMESRC(x)                     (((uint32_t)(((uint32_t)(x))<<SIM_SOPT2_TIMESRC_SHIFT))&SIM_SOPT2_TIMESRC_MASK)
+#define SIM_SOPT2_SDHCSRC_MASK                   0x30000000u
+#define SIM_SOPT2_SDHCSRC_SHIFT                  28
+#define SIM_SOPT2_SDHCSRC(x)                     (((uint32_t)(((uint32_t)(x))<<SIM_SOPT2_SDHCSRC_SHIFT))&SIM_SOPT2_SDHCSRC_MASK)
+/* SOPT4 Bit Fields */
+#define SIM_SOPT4_FTM0FLT0_MASK                  0x1u
+#define SIM_SOPT4_FTM0FLT0_SHIFT                 0
+#define SIM_SOPT4_FTM0FLT1_MASK                  0x2u
+#define SIM_SOPT4_FTM0FLT1_SHIFT                 1
+#define SIM_SOPT4_FTM0FLT2_MASK                  0x4u
+#define SIM_SOPT4_FTM0FLT2_SHIFT                 2
+#define SIM_SOPT4_FTM1FLT0_MASK                  0x10u
+#define SIM_SOPT4_FTM1FLT0_SHIFT                 4
+#define SIM_SOPT4_FTM2FLT0_MASK                  0x100u
+#define SIM_SOPT4_FTM2FLT0_SHIFT                 8
+#define SIM_SOPT4_FTM3FLT0_MASK                  0x1000u
+#define SIM_SOPT4_FTM3FLT0_SHIFT                 12
+#define SIM_SOPT4_FTM1CH0SRC_MASK                0xC0000u
+#define SIM_SOPT4_FTM1CH0SRC_SHIFT               18
+#define SIM_SOPT4_FTM1CH0SRC(x)                  (((uint32_t)(((uint32_t)(x))<<SIM_SOPT4_FTM1CH0SRC_SHIFT))&SIM_SOPT4_FTM1CH0SRC_MASK)
+#define SIM_SOPT4_FTM2CH0SRC_MASK                0x300000u
+#define SIM_SOPT4_FTM2CH0SRC_SHIFT               20
+#define SIM_SOPT4_FTM2CH0SRC(x)                  (((uint32_t)(((uint32_t)(x))<<SIM_SOPT4_FTM2CH0SRC_SHIFT))&SIM_SOPT4_FTM2CH0SRC_MASK)
+#define SIM_SOPT4_FTM0CLKSEL_MASK                0x1000000u
+#define SIM_SOPT4_FTM0CLKSEL_SHIFT               24
+#define SIM_SOPT4_FTM1CLKSEL_MASK                0x2000000u
+#define SIM_SOPT4_FTM1CLKSEL_SHIFT               25
+#define SIM_SOPT4_FTM2CLKSEL_MASK                0x4000000u
+#define SIM_SOPT4_FTM2CLKSEL_SHIFT               26
+#define SIM_SOPT4_FTM3CLKSEL_MASK                0x8000000u
+#define SIM_SOPT4_FTM3CLKSEL_SHIFT               27
+#define SIM_SOPT4_FTM0TRG0SRC_MASK               0x10000000u
+#define SIM_SOPT4_FTM0TRG0SRC_SHIFT              28
+#define SIM_SOPT4_FTM0TRG1SRC_MASK               0x20000000u
+#define SIM_SOPT4_FTM0TRG1SRC_SHIFT              29
+#define SIM_SOPT4_FTM3TRG0SRC_MASK               0x40000000u
+#define SIM_SOPT4_FTM3TRG0SRC_SHIFT              30
+#define SIM_SOPT4_FTM3TRG1SRC_MASK               0x80000000u
+#define SIM_SOPT4_FTM3TRG1SRC_SHIFT              31
+/* SOPT5 Bit Fields */
+#define SIM_SOPT5_UART0TXSRC_MASK                0x3u
+#define SIM_SOPT5_UART0TXSRC_SHIFT               0
+#define SIM_SOPT5_UART0TXSRC(x)                  (((uint32_t)(((uint32_t)(x))<<SIM_SOPT5_UART0TXSRC_SHIFT))&SIM_SOPT5_UART0TXSRC_MASK)
+#define SIM_SOPT5_UART0RXSRC_MASK                0xCu
+#define SIM_SOPT5_UART0RXSRC_SHIFT               2
+#define SIM_SOPT5_UART0RXSRC(x)                  (((uint32_t)(((uint32_t)(x))<<SIM_SOPT5_UART0RXSRC_SHIFT))&SIM_SOPT5_UART0RXSRC_MASK)
+#define SIM_SOPT5_UART1TXSRC_MASK                0x30u
+#define SIM_SOPT5_UART1TXSRC_SHIFT               4
+#define SIM_SOPT5_UART1TXSRC(x)                  (((uint32_t)(((uint32_t)(x))<<SIM_SOPT5_UART1TXSRC_SHIFT))&SIM_SOPT5_UART1TXSRC_MASK)
+#define SIM_SOPT5_UART1RXSRC_MASK                0xC0u
+#define SIM_SOPT5_UART1RXSRC_SHIFT               6
+#define SIM_SOPT5_UART1RXSRC(x)                  (((uint32_t)(((uint32_t)(x))<<SIM_SOPT5_UART1RXSRC_SHIFT))&SIM_SOPT5_UART1RXSRC_MASK)
+/* SOPT7 Bit Fields */
+#define SIM_SOPT7_ADC0TRGSEL_MASK                0xFu
+#define SIM_SOPT7_ADC0TRGSEL_SHIFT               0
+#define SIM_SOPT7_ADC0TRGSEL(x)                  (((uint32_t)(((uint32_t)(x))<<SIM_SOPT7_ADC0TRGSEL_SHIFT))&SIM_SOPT7_ADC0TRGSEL_MASK)
+#define SIM_SOPT7_ADC0PRETRGSEL_MASK             0x10u
+#define SIM_SOPT7_ADC0PRETRGSEL_SHIFT            4
+#define SIM_SOPT7_ADC0ALTTRGEN_MASK              0x80u
+#define SIM_SOPT7_ADC0ALTTRGEN_SHIFT             7
+#define SIM_SOPT7_ADC1TRGSEL_MASK                0xF00u
+#define SIM_SOPT7_ADC1TRGSEL_SHIFT               8
+#define SIM_SOPT7_ADC1TRGSEL(x)                  (((uint32_t)(((uint32_t)(x))<<SIM_SOPT7_ADC1TRGSEL_SHIFT))&SIM_SOPT7_ADC1TRGSEL_MASK)
+#define SIM_SOPT7_ADC1PRETRGSEL_MASK             0x1000u
+#define SIM_SOPT7_ADC1PRETRGSEL_SHIFT            12
+#define SIM_SOPT7_ADC1ALTTRGEN_MASK              0x8000u
+#define SIM_SOPT7_ADC1ALTTRGEN_SHIFT             15
+/* SDID Bit Fields */
+#define SIM_SDID_PINID_MASK                      0xFu
+#define SIM_SDID_PINID_SHIFT                     0
+#define SIM_SDID_PINID(x)                        (((uint32_t)(((uint32_t)(x))<<SIM_SDID_PINID_SHIFT))&SIM_SDID_PINID_MASK)
+#define SIM_SDID_FAMID_MASK                      0x70u
+#define SIM_SDID_FAMID_SHIFT                     4
+#define SIM_SDID_FAMID(x)                        (((uint32_t)(((uint32_t)(x))<<SIM_SDID_FAMID_SHIFT))&SIM_SDID_FAMID_MASK)
+#define SIM_SDID_DIEID_MASK                      0xF80u
+#define SIM_SDID_DIEID_SHIFT                     7
+#define SIM_SDID_DIEID(x)                        (((uint32_t)(((uint32_t)(x))<<SIM_SDID_DIEID_SHIFT))&SIM_SDID_DIEID_MASK)
+#define SIM_SDID_REVID_MASK                      0xF000u
+#define SIM_SDID_REVID_SHIFT                     12
+#define SIM_SDID_REVID(x)                        (((uint32_t)(((uint32_t)(x))<<SIM_SDID_REVID_SHIFT))&SIM_SDID_REVID_MASK)
+#define SIM_SDID_SERIESID_MASK                   0xF00000u
+#define SIM_SDID_SERIESID_SHIFT                  20
+#define SIM_SDID_SERIESID(x)                     (((uint32_t)(((uint32_t)(x))<<SIM_SDID_SERIESID_SHIFT))&SIM_SDID_SERIESID_MASK)
+#define SIM_SDID_SUBFAMID_MASK                   0xF000000u
+#define SIM_SDID_SUBFAMID_SHIFT                  24
+#define SIM_SDID_SUBFAMID(x)                     (((uint32_t)(((uint32_t)(x))<<SIM_SDID_SUBFAMID_SHIFT))&SIM_SDID_SUBFAMID_MASK)
+#define SIM_SDID_FAMILYID_MASK                   0xF0000000u
+#define SIM_SDID_FAMILYID_SHIFT                  28
+#define SIM_SDID_FAMILYID(x)                     (((uint32_t)(((uint32_t)(x))<<SIM_SDID_FAMILYID_SHIFT))&SIM_SDID_FAMILYID_MASK)
+/* SCGC1 Bit Fields */
+#define SIM_SCGC1_I2C2_MASK                      0x40u
+#define SIM_SCGC1_I2C2_SHIFT                     6
+#define SIM_SCGC1_UART4_MASK                     0x400u
+#define SIM_SCGC1_UART4_SHIFT                    10
+#define SIM_SCGC1_UART5_MASK                     0x800u
+#define SIM_SCGC1_UART5_SHIFT                    11
+/* SCGC2 Bit Fields */
+#define SIM_SCGC2_ENET_MASK                      0x1u
+#define SIM_SCGC2_ENET_SHIFT                     0
+#define SIM_SCGC2_DAC0_MASK                      0x1000u
+#define SIM_SCGC2_DAC0_SHIFT                     12
+#define SIM_SCGC2_DAC1_MASK                      0x2000u
+#define SIM_SCGC2_DAC1_SHIFT                     13
+/* SCGC3 Bit Fields */
+#define SIM_SCGC3_RNGA_MASK                      0x1u
+#define SIM_SCGC3_RNGA_SHIFT                     0
+#define SIM_SCGC3_SPI2_MASK                      0x1000u
+#define SIM_SCGC3_SPI2_SHIFT                     12
+#define SIM_SCGC3_SDHC_MASK                      0x20000u
+#define SIM_SCGC3_SDHC_SHIFT                     17
+#define SIM_SCGC3_FTM2_MASK                      0x1000000u
+#define SIM_SCGC3_FTM2_SHIFT                     24
+#define SIM_SCGC3_FTM3_MASK                      0x2000000u
+#define SIM_SCGC3_FTM3_SHIFT                     25
+#define SIM_SCGC3_ADC1_MASK                      0x8000000u
+#define SIM_SCGC3_ADC1_SHIFT                     27
+/* SCGC4 Bit Fields */
+#define SIM_SCGC4_EWM_MASK                       0x2u
+#define SIM_SCGC4_EWM_SHIFT                      1
+#define SIM_SCGC4_CMT_MASK                       0x4u
+#define SIM_SCGC4_CMT_SHIFT                      2
+#define SIM_SCGC4_I2C0_MASK                      0x40u
+#define SIM_SCGC4_I2C0_SHIFT                     6
+#define SIM_SCGC4_I2C1_MASK                      0x80u
+#define SIM_SCGC4_I2C1_SHIFT                     7
+#define SIM_SCGC4_UART0_MASK                     0x400u
+#define SIM_SCGC4_UART0_SHIFT                    10
+#define SIM_SCGC4_UART1_MASK                     0x800u
+#define SIM_SCGC4_UART1_SHIFT                    11
+#define SIM_SCGC4_UART2_MASK                     0x1000u
+#define SIM_SCGC4_UART2_SHIFT                    12
+#define SIM_SCGC4_UART3_MASK                     0x2000u
+#define SIM_SCGC4_UART3_SHIFT                    13
+#define SIM_SCGC4_USBOTG_MASK                    0x40000u
+#define SIM_SCGC4_USBOTG_SHIFT                   18
+#define SIM_SCGC4_CMP_MASK                       0x80000u
+#define SIM_SCGC4_CMP_SHIFT                      19
+#define SIM_SCGC4_VREF_MASK                      0x100000u
+#define SIM_SCGC4_VREF_SHIFT                     20
+/* SCGC5 Bit Fields */
+#define SIM_SCGC5_LPTMR_MASK                     0x1u
+#define SIM_SCGC5_LPTMR_SHIFT                    0
+#define SIM_SCGC5_PORTA_MASK                     0x200u
+#define SIM_SCGC5_PORTA_SHIFT                    9
+#define SIM_SCGC5_PORTB_MASK                     0x400u
+#define SIM_SCGC5_PORTB_SHIFT                    10
+#define SIM_SCGC5_PORTC_MASK                     0x800u
+#define SIM_SCGC5_PORTC_SHIFT                    11
+#define SIM_SCGC5_PORTD_MASK                     0x1000u
+#define SIM_SCGC5_PORTD_SHIFT                    12
+#define SIM_SCGC5_PORTE_MASK                     0x2000u
+#define SIM_SCGC5_PORTE_SHIFT                    13
+/* SCGC6 Bit Fields */
+#define SIM_SCGC6_FTF_MASK                       0x1u
+#define SIM_SCGC6_FTF_SHIFT                      0
+#define SIM_SCGC6_DMAMUX_MASK                    0x2u
+#define SIM_SCGC6_DMAMUX_SHIFT                   1
+#define SIM_SCGC6_FLEXCAN0_MASK                  0x10u
+#define SIM_SCGC6_FLEXCAN0_SHIFT                 4
+#define SIM_SCGC6_RNGA_MASK                      0x200u
+#define SIM_SCGC6_RNGA_SHIFT                     9
+#define SIM_SCGC6_SPI0_MASK                      0x1000u
+#define SIM_SCGC6_SPI0_SHIFT                     12
+#define SIM_SCGC6_SPI1_MASK                      0x2000u
+#define SIM_SCGC6_SPI1_SHIFT                     13
+#define SIM_SCGC6_I2S_MASK                       0x8000u
+#define SIM_SCGC6_I2S_SHIFT                      15
+#define SIM_SCGC6_CRC_MASK                       0x40000u
+#define SIM_SCGC6_CRC_SHIFT                      18
+#define SIM_SCGC6_USBDCD_MASK                    0x200000u
+#define SIM_SCGC6_USBDCD_SHIFT                   21
+#define SIM_SCGC6_PDB_MASK                       0x400000u
+#define SIM_SCGC6_PDB_SHIFT                      22
+#define SIM_SCGC6_PIT_MASK                       0x800000u
+#define SIM_SCGC6_PIT_SHIFT                      23
+#define SIM_SCGC6_FTM0_MASK                      0x1000000u
+#define SIM_SCGC6_FTM0_SHIFT                     24
+#define SIM_SCGC6_FTM1_MASK                      0x2000000u
+#define SIM_SCGC6_FTM1_SHIFT                     25
+#define SIM_SCGC6_FTM2_MASK                      0x4000000u
+#define SIM_SCGC6_FTM2_SHIFT                     26
+#define SIM_SCGC6_ADC0_MASK                      0x8000000u
+#define SIM_SCGC6_ADC0_SHIFT                     27
+#define SIM_SCGC6_RTC_MASK                       0x20000000u
+#define SIM_SCGC6_RTC_SHIFT                      29
+#define SIM_SCGC6_DAC0_MASK                      0x80000000u
+#define SIM_SCGC6_DAC0_SHIFT                     31
+/* SCGC7 Bit Fields */
+#define SIM_SCGC7_FLEXBUS_MASK                   0x1u
+#define SIM_SCGC7_FLEXBUS_SHIFT                  0
+#define SIM_SCGC7_DMA_MASK                       0x2u
+#define SIM_SCGC7_DMA_SHIFT                      1
+#define SIM_SCGC7_MPU_MASK                       0x4u
+#define SIM_SCGC7_MPU_SHIFT                      2
+/* CLKDIV1 Bit Fields */
+#define SIM_CLKDIV1_OUTDIV4_MASK                 0xF0000u
+#define SIM_CLKDIV1_OUTDIV4_SHIFT                16
+#define SIM_CLKDIV1_OUTDIV4(x)                   (((uint32_t)(((uint32_t)(x))<<SIM_CLKDIV1_OUTDIV4_SHIFT))&SIM_CLKDIV1_OUTDIV4_MASK)
+#define SIM_CLKDIV1_OUTDIV3_MASK                 0xF00000u
+#define SIM_CLKDIV1_OUTDIV3_SHIFT                20
+#define SIM_CLKDIV1_OUTDIV3(x)                   (((uint32_t)(((uint32_t)(x))<<SIM_CLKDIV1_OUTDIV3_SHIFT))&SIM_CLKDIV1_OUTDIV3_MASK)
+#define SIM_CLKDIV1_OUTDIV2_MASK                 0xF000000u
+#define SIM_CLKDIV1_OUTDIV2_SHIFT                24
+#define SIM_CLKDIV1_OUTDIV2(x)                   (((uint32_t)(((uint32_t)(x))<<SIM_CLKDIV1_OUTDIV2_SHIFT))&SIM_CLKDIV1_OUTDIV2_MASK)
+#define SIM_CLKDIV1_OUTDIV1_MASK                 0xF0000000u
+#define SIM_CLKDIV1_OUTDIV1_SHIFT                28
+#define SIM_CLKDIV1_OUTDIV1(x)                   (((uint32_t)(((uint32_t)(x))<<SIM_CLKDIV1_OUTDIV1_SHIFT))&SIM_CLKDIV1_OUTDIV1_MASK)
+/* CLKDIV2 Bit Fields */
+#define SIM_CLKDIV2_USBFRAC_MASK                 0x1u
+#define SIM_CLKDIV2_USBFRAC_SHIFT                0
+#define SIM_CLKDIV2_USBDIV_MASK                  0xEu
+#define SIM_CLKDIV2_USBDIV_SHIFT                 1
+#define SIM_CLKDIV2_USBDIV(x)                    (((uint32_t)(((uint32_t)(x))<<SIM_CLKDIV2_USBDIV_SHIFT))&SIM_CLKDIV2_USBDIV_MASK)
+/* FCFG1 Bit Fields */
+#define SIM_FCFG1_FLASHDIS_MASK                  0x1u
+#define SIM_FCFG1_FLASHDIS_SHIFT                 0
+#define SIM_FCFG1_FLASHDOZE_MASK                 0x2u
+#define SIM_FCFG1_FLASHDOZE_SHIFT                1
+#define SIM_FCFG1_DEPART_MASK                    0xF00u
+#define SIM_FCFG1_DEPART_SHIFT                   8
+#define SIM_FCFG1_DEPART(x)                      (((uint32_t)(((uint32_t)(x))<<SIM_FCFG1_DEPART_SHIFT))&SIM_FCFG1_DEPART_MASK)
+#define SIM_FCFG1_EESIZE_MASK                    0xF0000u
+#define SIM_FCFG1_EESIZE_SHIFT                   16
+#define SIM_FCFG1_EESIZE(x)                      (((uint32_t)(((uint32_t)(x))<<SIM_FCFG1_EESIZE_SHIFT))&SIM_FCFG1_EESIZE_MASK)
+#define SIM_FCFG1_PFSIZE_MASK                    0xF000000u
+#define SIM_FCFG1_PFSIZE_SHIFT                   24
+#define SIM_FCFG1_PFSIZE(x)                      (((uint32_t)(((uint32_t)(x))<<SIM_FCFG1_PFSIZE_SHIFT))&SIM_FCFG1_PFSIZE_MASK)
+#define SIM_FCFG1_NVMSIZE_MASK                   0xF0000000u
+#define SIM_FCFG1_NVMSIZE_SHIFT                  28
+#define SIM_FCFG1_NVMSIZE(x)                     (((uint32_t)(((uint32_t)(x))<<SIM_FCFG1_NVMSIZE_SHIFT))&SIM_FCFG1_NVMSIZE_MASK)
+/* FCFG2 Bit Fields */
+#define SIM_FCFG2_MAXADDR1_MASK                  0x7F0000u
+#define SIM_FCFG2_MAXADDR1_SHIFT                 16
+#define SIM_FCFG2_MAXADDR1(x)                    (((uint32_t)(((uint32_t)(x))<<SIM_FCFG2_MAXADDR1_SHIFT))&SIM_FCFG2_MAXADDR1_MASK)
+#define SIM_FCFG2_PFLSH_MASK                     0x800000u
+#define SIM_FCFG2_PFLSH_SHIFT                    23
+#define SIM_FCFG2_MAXADDR0_MASK                  0x7F000000u
+#define SIM_FCFG2_MAXADDR0_SHIFT                 24
+#define SIM_FCFG2_MAXADDR0(x)                    (((uint32_t)(((uint32_t)(x))<<SIM_FCFG2_MAXADDR0_SHIFT))&SIM_FCFG2_MAXADDR0_MASK)
+/* UIDH Bit Fields */
+#define SIM_UIDH_UID_MASK                        0xFFFFFFFFu
+#define SIM_UIDH_UID_SHIFT                       0
+#define SIM_UIDH_UID(x)                          (((uint32_t)(((uint32_t)(x))<<SIM_UIDH_UID_SHIFT))&SIM_UIDH_UID_MASK)
+/* UIDMH Bit Fields */
+#define SIM_UIDMH_UID_MASK                       0xFFFFFFFFu
+#define SIM_UIDMH_UID_SHIFT                      0
+#define SIM_UIDMH_UID(x)                         (((uint32_t)(((uint32_t)(x))<<SIM_UIDMH_UID_SHIFT))&SIM_UIDMH_UID_MASK)
+/* UIDML Bit Fields */
+#define SIM_UIDML_UID_MASK                       0xFFFFFFFFu
+#define SIM_UIDML_UID_SHIFT                      0
+#define SIM_UIDML_UID(x)                         (((uint32_t)(((uint32_t)(x))<<SIM_UIDML_UID_SHIFT))&SIM_UIDML_UID_MASK)
+/* UIDL Bit Fields */
+#define SIM_UIDL_UID_MASK                        0xFFFFFFFFu
+#define SIM_UIDL_UID_SHIFT                       0
+#define SIM_UIDL_UID(x)                          (((uint32_t)(((uint32_t)(x))<<SIM_UIDL_UID_SHIFT))&SIM_UIDL_UID_MASK)
+
+/*!
+ * @}
+ */ /* end of group SIM_Register_Masks */
+
+
+/* SIM - Peripheral instance base addresses */
+/** Peripheral SIM base address */
+#define SIM_BASE                                 (0x40047000u)
+/** Peripheral SIM base pointer */
+#define SIM                                      ((SIM_Type *)SIM_BASE)
+#define SIM_BASE_PTR                             (SIM)
+/** Array initializer of SIM peripheral base addresses */
+#define SIM_BASE_ADDRS                           { SIM_BASE }
+/** Array initializer of SIM peripheral base pointers */
+#define SIM_BASE_PTRS                            { SIM }
+
+/* ----------------------------------------------------------------------------
+   -- SIM - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SIM_Register_Accessor_Macros SIM - Register accessor macros
+ * @{
+ */
+
+
+/* SIM - Register instance definitions */
+/* SIM */
+#define SIM_SOPT1                                SIM_SOPT1_REG(SIM)
+#define SIM_SOPT1CFG                             SIM_SOPT1CFG_REG(SIM)
+#define SIM_SOPT2                                SIM_SOPT2_REG(SIM)
+#define SIM_SOPT4                                SIM_SOPT4_REG(SIM)
+#define SIM_SOPT5                                SIM_SOPT5_REG(SIM)
+#define SIM_SOPT7                                SIM_SOPT7_REG(SIM)
+#define SIM_SDID                                 SIM_SDID_REG(SIM)
+#define SIM_SCGC1                                SIM_SCGC1_REG(SIM)
+#define SIM_SCGC2                                SIM_SCGC2_REG(SIM)
+#define SIM_SCGC3                                SIM_SCGC3_REG(SIM)
+#define SIM_SCGC4                                SIM_SCGC4_REG(SIM)
+#define SIM_SCGC5                                SIM_SCGC5_REG(SIM)
+#define SIM_SCGC6                                SIM_SCGC6_REG(SIM)
+#define SIM_SCGC7                                SIM_SCGC7_REG(SIM)
+#define SIM_CLKDIV1                              SIM_CLKDIV1_REG(SIM)
+#define SIM_CLKDIV2                              SIM_CLKDIV2_REG(SIM)
+#define SIM_FCFG1                                SIM_FCFG1_REG(SIM)
+#define SIM_FCFG2                                SIM_FCFG2_REG(SIM)
+#define SIM_UIDH                                 SIM_UIDH_REG(SIM)
+#define SIM_UIDMH                                SIM_UIDMH_REG(SIM)
+#define SIM_UIDML                                SIM_UIDML_REG(SIM)
+#define SIM_UIDL                                 SIM_UIDL_REG(SIM)
+
+/*!
+ * @}
+ */ /* end of group SIM_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group SIM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- SMC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SMC_Peripheral_Access_Layer SMC Peripheral Access Layer
+ * @{
+ */
+
+/** SMC - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t PMPROT;                             /**< Power Mode Protection register, offset: 0x0 */
+  __IO uint8_t PMCTRL;                             /**< Power Mode Control register, offset: 0x1 */
+  __IO uint8_t VLLSCTRL;                           /**< VLLS Control register, offset: 0x2 */
+  __I  uint8_t PMSTAT;                             /**< Power Mode Status register, offset: 0x3 */
+} SMC_Type, *SMC_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- SMC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SMC_Register_Accessor_Macros SMC - Register accessor macros
+ * @{
+ */
+
+
+/* SMC - Register accessors */
+#define SMC_PMPROT_REG(base)                     ((base)->PMPROT)
+#define SMC_PMCTRL_REG(base)                     ((base)->PMCTRL)
+#define SMC_VLLSCTRL_REG(base)                   ((base)->VLLSCTRL)
+#define SMC_PMSTAT_REG(base)                     ((base)->PMSTAT)
+
+/*!
+ * @}
+ */ /* end of group SMC_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- SMC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SMC_Register_Masks SMC Register Masks
+ * @{
+ */
+
+/* PMPROT Bit Fields */
+#define SMC_PMPROT_AVLLS_MASK                    0x2u
+#define SMC_PMPROT_AVLLS_SHIFT                   1
+#define SMC_PMPROT_ALLS_MASK                     0x8u
+#define SMC_PMPROT_ALLS_SHIFT                    3
+#define SMC_PMPROT_AVLP_MASK                     0x20u
+#define SMC_PMPROT_AVLP_SHIFT                    5
+/* PMCTRL Bit Fields */
+#define SMC_PMCTRL_STOPM_MASK                    0x7u
+#define SMC_PMCTRL_STOPM_SHIFT                   0
+#define SMC_PMCTRL_STOPM(x)                      (((uint8_t)(((uint8_t)(x))<<SMC_PMCTRL_STOPM_SHIFT))&SMC_PMCTRL_STOPM_MASK)
+#define SMC_PMCTRL_STOPA_MASK                    0x8u
+#define SMC_PMCTRL_STOPA_SHIFT                   3
+#define SMC_PMCTRL_RUNM_MASK                     0x60u
+#define SMC_PMCTRL_RUNM_SHIFT                    5
+#define SMC_PMCTRL_RUNM(x)                       (((uint8_t)(((uint8_t)(x))<<SMC_PMCTRL_RUNM_SHIFT))&SMC_PMCTRL_RUNM_MASK)
+#define SMC_PMCTRL_LPWUI_MASK                    0x80u
+#define SMC_PMCTRL_LPWUI_SHIFT                   7
+/* VLLSCTRL Bit Fields */
+#define SMC_VLLSCTRL_VLLSM_MASK                  0x7u
+#define SMC_VLLSCTRL_VLLSM_SHIFT                 0
+#define SMC_VLLSCTRL_VLLSM(x)                    (((uint8_t)(((uint8_t)(x))<<SMC_VLLSCTRL_VLLSM_SHIFT))&SMC_VLLSCTRL_VLLSM_MASK)
+#define SMC_VLLSCTRL_PORPO_MASK                  0x20u
+#define SMC_VLLSCTRL_PORPO_SHIFT                 5
+/* PMSTAT Bit Fields */
+#define SMC_PMSTAT_PMSTAT_MASK                   0x7Fu
+#define SMC_PMSTAT_PMSTAT_SHIFT                  0
+#define SMC_PMSTAT_PMSTAT(x)                     (((uint8_t)(((uint8_t)(x))<<SMC_PMSTAT_PMSTAT_SHIFT))&SMC_PMSTAT_PMSTAT_MASK)
+
+/*!
+ * @}
+ */ /* end of group SMC_Register_Masks */
+
+
+/* SMC - Peripheral instance base addresses */
+/** Peripheral SMC base address */
+#define SMC_BASE                                 (0x4007E000u)
+/** Peripheral SMC base pointer */
+#define SMC                                      ((SMC_Type *)SMC_BASE)
+#define SMC_BASE_PTR                             (SMC)
+/** Array initializer of SMC peripheral base addresses */
+#define SMC_BASE_ADDRS                           { SMC_BASE }
+/** Array initializer of SMC peripheral base pointers */
+#define SMC_BASE_PTRS                            { SMC }
+
+/* ----------------------------------------------------------------------------
+   -- SMC - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SMC_Register_Accessor_Macros SMC - Register accessor macros
+ * @{
+ */
+
+
+/* SMC - Register instance definitions */
+/* SMC */
+#define SMC_PMPROT                               SMC_PMPROT_REG(SMC)
+#define SMC_PMCTRL                               SMC_PMCTRL_REG(SMC)
+#define SMC_VLLSCTRL                             SMC_VLLSCTRL_REG(SMC)
+#define SMC_PMSTAT                               SMC_PMSTAT_REG(SMC)
+
+/*!
+ * @}
+ */ /* end of group SMC_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group SMC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- SPI Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SPI_Peripheral_Access_Layer SPI Peripheral Access Layer
+ * @{
+ */
+
+/** SPI - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t MCR;                               /**< Module Configuration Register, offset: 0x0 */
+       uint8_t RESERVED_0[4];
+  __IO uint32_t TCR;                               /**< Transfer Count Register, offset: 0x8 */
+  union {                                          /* offset: 0xC */
+    __IO uint32_t CTAR[2];                           /**< Clock and Transfer Attributes Register (In Master Mode), array offset: 0xC, array step: 0x4 */
+    __IO uint32_t CTAR_SLAVE[1];                     /**< Clock and Transfer Attributes Register (In Slave Mode), array offset: 0xC, array step: 0x4 */
+  };
+       uint8_t RESERVED_1[24];
+  __IO uint32_t SR;                                /**< Status Register, offset: 0x2C */
+  __IO uint32_t RSER;                              /**< DMA/Interrupt Request Select and Enable Register, offset: 0x30 */
+  union {                                          /* offset: 0x34 */
+    __IO uint32_t PUSHR;                             /**< PUSH TX FIFO Register In Master Mode, offset: 0x34 */
+    __IO uint32_t PUSHR_SLAVE;                       /**< PUSH TX FIFO Register In Slave Mode, offset: 0x34 */
+  };
+  __I  uint32_t POPR;                              /**< POP RX FIFO Register, offset: 0x38 */
+  __I  uint32_t TXFR0;                             /**< Transmit FIFO Registers, offset: 0x3C */
+  __I  uint32_t TXFR1;                             /**< Transmit FIFO Registers, offset: 0x40 */
+  __I  uint32_t TXFR2;                             /**< Transmit FIFO Registers, offset: 0x44 */
+  __I  uint32_t TXFR3;                             /**< Transmit FIFO Registers, offset: 0x48 */
+       uint8_t RESERVED_2[48];
+  __I  uint32_t RXFR0;                             /**< Receive FIFO Registers, offset: 0x7C */
+  __I  uint32_t RXFR1;                             /**< Receive FIFO Registers, offset: 0x80 */
+  __I  uint32_t RXFR2;                             /**< Receive FIFO Registers, offset: 0x84 */
+  __I  uint32_t RXFR3;                             /**< Receive FIFO Registers, offset: 0x88 */
+} SPI_Type, *SPI_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- SPI - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SPI_Register_Accessor_Macros SPI - Register accessor macros
+ * @{
+ */
+
+
+/* SPI - Register accessors */
+#define SPI_MCR_REG(base)                        ((base)->MCR)
+#define SPI_TCR_REG(base)                        ((base)->TCR)
+#define SPI_CTAR_REG(base,index2)                ((base)->CTAR[index2])
+#define SPI_CTAR_SLAVE_REG(base,index2)          ((base)->CTAR_SLAVE[index2])
+#define SPI_SR_REG(base)                         ((base)->SR)
+#define SPI_RSER_REG(base)                       ((base)->RSER)
+#define SPI_PUSHR_REG(base)                      ((base)->PUSHR)
+#define SPI_PUSHR_SLAVE_REG(base)                ((base)->PUSHR_SLAVE)
+#define SPI_POPR_REG(base)                       ((base)->POPR)
+#define SPI_TXFR0_REG(base)                      ((base)->TXFR0)
+#define SPI_TXFR1_REG(base)                      ((base)->TXFR1)
+#define SPI_TXFR2_REG(base)                      ((base)->TXFR2)
+#define SPI_TXFR3_REG(base)                      ((base)->TXFR3)
+#define SPI_RXFR0_REG(base)                      ((base)->RXFR0)
+#define SPI_RXFR1_REG(base)                      ((base)->RXFR1)
+#define SPI_RXFR2_REG(base)                      ((base)->RXFR2)
+#define SPI_RXFR3_REG(base)                      ((base)->RXFR3)
+
+/*!
+ * @}
+ */ /* end of group SPI_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- SPI Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SPI_Register_Masks SPI Register Masks
+ * @{
+ */
+
+/* MCR Bit Fields */
+#define SPI_MCR_HALT_MASK                        0x1u
+#define SPI_MCR_HALT_SHIFT                       0
+#define SPI_MCR_SMPL_PT_MASK                     0x300u
+#define SPI_MCR_SMPL_PT_SHIFT                    8
+#define SPI_MCR_SMPL_PT(x)                       (((uint32_t)(((uint32_t)(x))<<SPI_MCR_SMPL_PT_SHIFT))&SPI_MCR_SMPL_PT_MASK)
+#define SPI_MCR_CLR_RXF_MASK                     0x400u
+#define SPI_MCR_CLR_RXF_SHIFT                    10
+#define SPI_MCR_CLR_TXF_MASK                     0x800u
+#define SPI_MCR_CLR_TXF_SHIFT                    11
+#define SPI_MCR_DIS_RXF_MASK                     0x1000u
+#define SPI_MCR_DIS_RXF_SHIFT                    12
+#define SPI_MCR_DIS_TXF_MASK                     0x2000u
+#define SPI_MCR_DIS_TXF_SHIFT                    13
+#define SPI_MCR_MDIS_MASK                        0x4000u
+#define SPI_MCR_MDIS_SHIFT                       14
+#define SPI_MCR_DOZE_MASK                        0x8000u
+#define SPI_MCR_DOZE_SHIFT                       15
+#define SPI_MCR_PCSIS_MASK                       0x3F0000u
+#define SPI_MCR_PCSIS_SHIFT                      16
+#define SPI_MCR_PCSIS(x)                         (((uint32_t)(((uint32_t)(x))<<SPI_MCR_PCSIS_SHIFT))&SPI_MCR_PCSIS_MASK)
+#define SPI_MCR_ROOE_MASK                        0x1000000u
+#define SPI_MCR_ROOE_SHIFT                       24
+#define SPI_MCR_PCSSE_MASK                       0x2000000u
+#define SPI_MCR_PCSSE_SHIFT                      25
+#define SPI_MCR_MTFE_MASK                        0x4000000u
+#define SPI_MCR_MTFE_SHIFT                       26
+#define SPI_MCR_FRZ_MASK                         0x8000000u
+#define SPI_MCR_FRZ_SHIFT                        27
+#define SPI_MCR_DCONF_MASK                       0x30000000u
+#define SPI_MCR_DCONF_SHIFT                      28
+#define SPI_MCR_DCONF(x)                         (((uint32_t)(((uint32_t)(x))<<SPI_MCR_DCONF_SHIFT))&SPI_MCR_DCONF_MASK)
+#define SPI_MCR_CONT_SCKE_MASK                   0x40000000u
+#define SPI_MCR_CONT_SCKE_SHIFT                  30
+#define SPI_MCR_MSTR_MASK                        0x80000000u
+#define SPI_MCR_MSTR_SHIFT                       31
+/* TCR Bit Fields */
+#define SPI_TCR_SPI_TCNT_MASK                    0xFFFF0000u
+#define SPI_TCR_SPI_TCNT_SHIFT                   16
+#define SPI_TCR_SPI_TCNT(x)                      (((uint32_t)(((uint32_t)(x))<<SPI_TCR_SPI_TCNT_SHIFT))&SPI_TCR_SPI_TCNT_MASK)
+/* CTAR Bit Fields */
+#define SPI_CTAR_BR_MASK                         0xFu
+#define SPI_CTAR_BR_SHIFT                        0
+#define SPI_CTAR_BR(x)                           (((uint32_t)(((uint32_t)(x))<<SPI_CTAR_BR_SHIFT))&SPI_CTAR_BR_MASK)
+#define SPI_CTAR_DT_MASK                         0xF0u
+#define SPI_CTAR_DT_SHIFT                        4
+#define SPI_CTAR_DT(x)                           (((uint32_t)(((uint32_t)(x))<<SPI_CTAR_DT_SHIFT))&SPI_CTAR_DT_MASK)
+#define SPI_CTAR_ASC_MASK                        0xF00u
+#define SPI_CTAR_ASC_SHIFT                       8
+#define SPI_CTAR_ASC(x)                          (((uint32_t)(((uint32_t)(x))<<SPI_CTAR_ASC_SHIFT))&SPI_CTAR_ASC_MASK)
+#define SPI_CTAR_CSSCK_MASK                      0xF000u
+#define SPI_CTAR_CSSCK_SHIFT                     12
+#define SPI_CTAR_CSSCK(x)                        (((uint32_t)(((uint32_t)(x))<<SPI_CTAR_CSSCK_SHIFT))&SPI_CTAR_CSSCK_MASK)
+#define SPI_CTAR_PBR_MASK                        0x30000u
+#define SPI_CTAR_PBR_SHIFT                       16
+#define SPI_CTAR_PBR(x)                          (((uint32_t)(((uint32_t)(x))<<SPI_CTAR_PBR_SHIFT))&SPI_CTAR_PBR_MASK)
+#define SPI_CTAR_PDT_MASK                        0xC0000u
+#define SPI_CTAR_PDT_SHIFT                       18
+#define SPI_CTAR_PDT(x)                          (((uint32_t)(((uint32_t)(x))<<SPI_CTAR_PDT_SHIFT))&SPI_CTAR_PDT_MASK)
+#define SPI_CTAR_PASC_MASK                       0x300000u
+#define SPI_CTAR_PASC_SHIFT                      20
+#define SPI_CTAR_PASC(x)                         (((uint32_t)(((uint32_t)(x))<<SPI_CTAR_PASC_SHIFT))&SPI_CTAR_PASC_MASK)
+#define SPI_CTAR_PCSSCK_MASK                     0xC00000u
+#define SPI_CTAR_PCSSCK_SHIFT                    22
+#define SPI_CTAR_PCSSCK(x)                       (((uint32_t)(((uint32_t)(x))<<SPI_CTAR_PCSSCK_SHIFT))&SPI_CTAR_PCSSCK_MASK)
+#define SPI_CTAR_LSBFE_MASK                      0x1000000u
+#define SPI_CTAR_LSBFE_SHIFT                     24
+#define SPI_CTAR_CPHA_MASK                       0x2000000u
+#define SPI_CTAR_CPHA_SHIFT                      25
+#define SPI_CTAR_CPOL_MASK                       0x4000000u
+#define SPI_CTAR_CPOL_SHIFT                      26
+#define SPI_CTAR_FMSZ_MASK                       0x78000000u
+#define SPI_CTAR_FMSZ_SHIFT                      27
+#define SPI_CTAR_FMSZ(x)                         (((uint32_t)(((uint32_t)(x))<<SPI_CTAR_FMSZ_SHIFT))&SPI_CTAR_FMSZ_MASK)
+#define SPI_CTAR_DBR_MASK                        0x80000000u
+#define SPI_CTAR_DBR_SHIFT                       31
+/* CTAR_SLAVE Bit Fields */
+#define SPI_CTAR_SLAVE_CPHA_MASK                 0x2000000u
+#define SPI_CTAR_SLAVE_CPHA_SHIFT                25
+#define SPI_CTAR_SLAVE_CPOL_MASK                 0x4000000u
+#define SPI_CTAR_SLAVE_CPOL_SHIFT                26
+#define SPI_CTAR_SLAVE_FMSZ_MASK                 0xF8000000u
+#define SPI_CTAR_SLAVE_FMSZ_SHIFT                27
+#define SPI_CTAR_SLAVE_FMSZ(x)                   (((uint32_t)(((uint32_t)(x))<<SPI_CTAR_SLAVE_FMSZ_SHIFT))&SPI_CTAR_SLAVE_FMSZ_MASK)
+/* SR Bit Fields */
+#define SPI_SR_POPNXTPTR_MASK                    0xFu
+#define SPI_SR_POPNXTPTR_SHIFT                   0
+#define SPI_SR_POPNXTPTR(x)                      (((uint32_t)(((uint32_t)(x))<<SPI_SR_POPNXTPTR_SHIFT))&SPI_SR_POPNXTPTR_MASK)
+#define SPI_SR_RXCTR_MASK                        0xF0u
+#define SPI_SR_RXCTR_SHIFT                       4
+#define SPI_SR_RXCTR(x)                          (((uint32_t)(((uint32_t)(x))<<SPI_SR_RXCTR_SHIFT))&SPI_SR_RXCTR_MASK)
+#define SPI_SR_TXNXTPTR_MASK                     0xF00u
+#define SPI_SR_TXNXTPTR_SHIFT                    8
+#define SPI_SR_TXNXTPTR(x)                       (((uint32_t)(((uint32_t)(x))<<SPI_SR_TXNXTPTR_SHIFT))&SPI_SR_TXNXTPTR_MASK)
+#define SPI_SR_TXCTR_MASK                        0xF000u
+#define SPI_SR_TXCTR_SHIFT                       12
+#define SPI_SR_TXCTR(x)                          (((uint32_t)(((uint32_t)(x))<<SPI_SR_TXCTR_SHIFT))&SPI_SR_TXCTR_MASK)
+#define SPI_SR_RFDF_MASK                         0x20000u
+#define SPI_SR_RFDF_SHIFT                        17
+#define SPI_SR_RFOF_MASK                         0x80000u
+#define SPI_SR_RFOF_SHIFT                        19
+#define SPI_SR_TFFF_MASK                         0x2000000u
+#define SPI_SR_TFFF_SHIFT                        25
+#define SPI_SR_TFUF_MASK                         0x8000000u
+#define SPI_SR_TFUF_SHIFT                        27
+#define SPI_SR_EOQF_MASK                         0x10000000u
+#define SPI_SR_EOQF_SHIFT                        28
+#define SPI_SR_TXRXS_MASK                        0x40000000u
+#define SPI_SR_TXRXS_SHIFT                       30
+#define SPI_SR_TCF_MASK                          0x80000000u
+#define SPI_SR_TCF_SHIFT                         31
+/* RSER Bit Fields */
+#define SPI_RSER_RFDF_DIRS_MASK                  0x10000u
+#define SPI_RSER_RFDF_DIRS_SHIFT                 16
+#define SPI_RSER_RFDF_RE_MASK                    0x20000u
+#define SPI_RSER_RFDF_RE_SHIFT                   17
+#define SPI_RSER_RFOF_RE_MASK                    0x80000u
+#define SPI_RSER_RFOF_RE_SHIFT                   19
+#define SPI_RSER_TFFF_DIRS_MASK                  0x1000000u
+#define SPI_RSER_TFFF_DIRS_SHIFT                 24
+#define SPI_RSER_TFFF_RE_MASK                    0x2000000u
+#define SPI_RSER_TFFF_RE_SHIFT                   25
+#define SPI_RSER_TFUF_RE_MASK                    0x8000000u
+#define SPI_RSER_TFUF_RE_SHIFT                   27
+#define SPI_RSER_EOQF_RE_MASK                    0x10000000u
+#define SPI_RSER_EOQF_RE_SHIFT                   28
+#define SPI_RSER_TCF_RE_MASK                     0x80000000u
+#define SPI_RSER_TCF_RE_SHIFT                    31
+/* PUSHR Bit Fields */
+#define SPI_PUSHR_TXDATA_MASK                    0xFFFFu
+#define SPI_PUSHR_TXDATA_SHIFT                   0
+#define SPI_PUSHR_TXDATA(x)                      (((uint32_t)(((uint32_t)(x))<<SPI_PUSHR_TXDATA_SHIFT))&SPI_PUSHR_TXDATA_MASK)
+#define SPI_PUSHR_PCS_MASK                       0x3F0000u
+#define SPI_PUSHR_PCS_SHIFT                      16
+#define SPI_PUSHR_PCS(x)                         (((uint32_t)(((uint32_t)(x))<<SPI_PUSHR_PCS_SHIFT))&SPI_PUSHR_PCS_MASK)
+#define SPI_PUSHR_CTCNT_MASK                     0x4000000u
+#define SPI_PUSHR_CTCNT_SHIFT                    26
+#define SPI_PUSHR_EOQ_MASK                       0x8000000u
+#define SPI_PUSHR_EOQ_SHIFT                      27
+#define SPI_PUSHR_CTAS_MASK                      0x70000000u
+#define SPI_PUSHR_CTAS_SHIFT                     28
+#define SPI_PUSHR_CTAS(x)                        (((uint32_t)(((uint32_t)(x))<<SPI_PUSHR_CTAS_SHIFT))&SPI_PUSHR_CTAS_MASK)
+#define SPI_PUSHR_CONT_MASK                      0x80000000u
+#define SPI_PUSHR_CONT_SHIFT                     31
+/* PUSHR_SLAVE Bit Fields */
+#define SPI_PUSHR_SLAVE_TXDATA_MASK              0xFFFFFFFFu
+#define SPI_PUSHR_SLAVE_TXDATA_SHIFT             0
+#define SPI_PUSHR_SLAVE_TXDATA(x)                (((uint32_t)(((uint32_t)(x))<<SPI_PUSHR_SLAVE_TXDATA_SHIFT))&SPI_PUSHR_SLAVE_TXDATA_MASK)
+/* POPR Bit Fields */
+#define SPI_POPR_RXDATA_MASK                     0xFFFFFFFFu
+#define SPI_POPR_RXDATA_SHIFT                    0
+#define SPI_POPR_RXDATA(x)                       (((uint32_t)(((uint32_t)(x))<<SPI_POPR_RXDATA_SHIFT))&SPI_POPR_RXDATA_MASK)
+/* TXFR0 Bit Fields */
+#define SPI_TXFR0_TXDATA_MASK                    0xFFFFu
+#define SPI_TXFR0_TXDATA_SHIFT                   0
+#define SPI_TXFR0_TXDATA(x)                      (((uint32_t)(((uint32_t)(x))<<SPI_TXFR0_TXDATA_SHIFT))&SPI_TXFR0_TXDATA_MASK)
+#define SPI_TXFR0_TXCMD_TXDATA_MASK              0xFFFF0000u
+#define SPI_TXFR0_TXCMD_TXDATA_SHIFT             16
+#define SPI_TXFR0_TXCMD_TXDATA(x)                (((uint32_t)(((uint32_t)(x))<<SPI_TXFR0_TXCMD_TXDATA_SHIFT))&SPI_TXFR0_TXCMD_TXDATA_MASK)
+/* TXFR1 Bit Fields */
+#define SPI_TXFR1_TXDATA_MASK                    0xFFFFu
+#define SPI_TXFR1_TXDATA_SHIFT                   0
+#define SPI_TXFR1_TXDATA(x)                      (((uint32_t)(((uint32_t)(x))<<SPI_TXFR1_TXDATA_SHIFT))&SPI_TXFR1_TXDATA_MASK)
+#define SPI_TXFR1_TXCMD_TXDATA_MASK              0xFFFF0000u
+#define SPI_TXFR1_TXCMD_TXDATA_SHIFT             16
+#define SPI_TXFR1_TXCMD_TXDATA(x)                (((uint32_t)(((uint32_t)(x))<<SPI_TXFR1_TXCMD_TXDATA_SHIFT))&SPI_TXFR1_TXCMD_TXDATA_MASK)
+/* TXFR2 Bit Fields */
+#define SPI_TXFR2_TXDATA_MASK                    0xFFFFu
+#define SPI_TXFR2_TXDATA_SHIFT                   0
+#define SPI_TXFR2_TXDATA(x)                      (((uint32_t)(((uint32_t)(x))<<SPI_TXFR2_TXDATA_SHIFT))&SPI_TXFR2_TXDATA_MASK)
+#define SPI_TXFR2_TXCMD_TXDATA_MASK              0xFFFF0000u
+#define SPI_TXFR2_TXCMD_TXDATA_SHIFT             16
+#define SPI_TXFR2_TXCMD_TXDATA(x)                (((uint32_t)(((uint32_t)(x))<<SPI_TXFR2_TXCMD_TXDATA_SHIFT))&SPI_TXFR2_TXCMD_TXDATA_MASK)
+/* TXFR3 Bit Fields */
+#define SPI_TXFR3_TXDATA_MASK                    0xFFFFu
+#define SPI_TXFR3_TXDATA_SHIFT                   0
+#define SPI_TXFR3_TXDATA(x)                      (((uint32_t)(((uint32_t)(x))<<SPI_TXFR3_TXDATA_SHIFT))&SPI_TXFR3_TXDATA_MASK)
+#define SPI_TXFR3_TXCMD_TXDATA_MASK              0xFFFF0000u
+#define SPI_TXFR3_TXCMD_TXDATA_SHIFT             16
+#define SPI_TXFR3_TXCMD_TXDATA(x)                (((uint32_t)(((uint32_t)(x))<<SPI_TXFR3_TXCMD_TXDATA_SHIFT))&SPI_TXFR3_TXCMD_TXDATA_MASK)
+/* RXFR0 Bit Fields */
+#define SPI_RXFR0_RXDATA_MASK                    0xFFFFFFFFu
+#define SPI_RXFR0_RXDATA_SHIFT                   0
+#define SPI_RXFR0_RXDATA(x)                      (((uint32_t)(((uint32_t)(x))<<SPI_RXFR0_RXDATA_SHIFT))&SPI_RXFR0_RXDATA_MASK)
+/* RXFR1 Bit Fields */
+#define SPI_RXFR1_RXDATA_MASK                    0xFFFFFFFFu
+#define SPI_RXFR1_RXDATA_SHIFT                   0
+#define SPI_RXFR1_RXDATA(x)                      (((uint32_t)(((uint32_t)(x))<<SPI_RXFR1_RXDATA_SHIFT))&SPI_RXFR1_RXDATA_MASK)
+/* RXFR2 Bit Fields */
+#define SPI_RXFR2_RXDATA_MASK                    0xFFFFFFFFu
+#define SPI_RXFR2_RXDATA_SHIFT                   0
+#define SPI_RXFR2_RXDATA(x)                      (((uint32_t)(((uint32_t)(x))<<SPI_RXFR2_RXDATA_SHIFT))&SPI_RXFR2_RXDATA_MASK)
+/* RXFR3 Bit Fields */
+#define SPI_RXFR3_RXDATA_MASK                    0xFFFFFFFFu
+#define SPI_RXFR3_RXDATA_SHIFT                   0
+#define SPI_RXFR3_RXDATA(x)                      (((uint32_t)(((uint32_t)(x))<<SPI_RXFR3_RXDATA_SHIFT))&SPI_RXFR3_RXDATA_MASK)
+
+/*!
+ * @}
+ */ /* end of group SPI_Register_Masks */
+
+
+/* SPI - Peripheral instance base addresses */
+/** Peripheral SPI0 base address */
+#define SPI0_BASE                                (0x4002C000u)
+/** Peripheral SPI0 base pointer */
+#define SPI0                                     ((SPI_Type *)SPI0_BASE)
+#define SPI0_BASE_PTR                            (SPI0)
+/** Peripheral SPI1 base address */
+#define SPI1_BASE                                (0x4002D000u)
+/** Peripheral SPI1 base pointer */
+#define SPI1                                     ((SPI_Type *)SPI1_BASE)
+#define SPI1_BASE_PTR                            (SPI1)
+/** Peripheral SPI2 base address */
+#define SPI2_BASE                                (0x400AC000u)
+/** Peripheral SPI2 base pointer */
+#define SPI2                                     ((SPI_Type *)SPI2_BASE)
+#define SPI2_BASE_PTR                            (SPI2)
+/** Array initializer of SPI peripheral base addresses */
+#define SPI_BASE_ADDRS                           { SPI0_BASE, SPI1_BASE, SPI2_BASE }
+/** Array initializer of SPI peripheral base pointers */
+#define SPI_BASE_PTRS                            { SPI0, SPI1, SPI2 }
+/** Interrupt vectors for the SPI peripheral type */
+#define SPI_IRQS                                 { SPI0_IRQn, SPI1_IRQn, SPI2_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- SPI - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup SPI_Register_Accessor_Macros SPI - Register accessor macros
+ * @{
+ */
+
+
+/* SPI - Register instance definitions */
+/* SPI0 */
+#define SPI0_MCR                                 SPI_MCR_REG(SPI0)
+#define SPI0_TCR                                 SPI_TCR_REG(SPI0)
+#define SPI0_CTAR0                               SPI_CTAR_REG(SPI0,0)
+#define SPI0_CTAR0_SLAVE                         SPI_CTAR_SLAVE_REG(SPI0,0)
+#define SPI0_CTAR1                               SPI_CTAR_REG(SPI0,1)
+#define SPI0_SR                                  SPI_SR_REG(SPI0)
+#define SPI0_RSER                                SPI_RSER_REG(SPI0)
+#define SPI0_PUSHR                               SPI_PUSHR_REG(SPI0)
+#define SPI0_PUSHR_SLAVE                         SPI_PUSHR_SLAVE_REG(SPI0)
+#define SPI0_POPR                                SPI_POPR_REG(SPI0)
+#define SPI0_TXFR0                               SPI_TXFR0_REG(SPI0)
+#define SPI0_TXFR1                               SPI_TXFR1_REG(SPI0)
+#define SPI0_TXFR2                               SPI_TXFR2_REG(SPI0)
+#define SPI0_TXFR3                               SPI_TXFR3_REG(SPI0)
+#define SPI0_RXFR0                               SPI_RXFR0_REG(SPI0)
+#define SPI0_RXFR1                               SPI_RXFR1_REG(SPI0)
+#define SPI0_RXFR2                               SPI_RXFR2_REG(SPI0)
+#define SPI0_RXFR3                               SPI_RXFR3_REG(SPI0)
+/* SPI1 */
+#define SPI1_MCR                                 SPI_MCR_REG(SPI1)
+#define SPI1_TCR                                 SPI_TCR_REG(SPI1)
+#define SPI1_CTAR0                               SPI_CTAR_REG(SPI1,0)
+#define SPI1_CTAR0_SLAVE                         SPI_CTAR_SLAVE_REG(SPI1,0)
+#define SPI1_CTAR1                               SPI_CTAR_REG(SPI1,1)
+#define SPI1_SR                                  SPI_SR_REG(SPI1)
+#define SPI1_RSER                                SPI_RSER_REG(SPI1)
+#define SPI1_PUSHR                               SPI_PUSHR_REG(SPI1)
+#define SPI1_PUSHR_SLAVE                         SPI_PUSHR_SLAVE_REG(SPI1)
+#define SPI1_POPR                                SPI_POPR_REG(SPI1)
+#define SPI1_TXFR0                               SPI_TXFR0_REG(SPI1)
+#define SPI1_TXFR1                               SPI_TXFR1_REG(SPI1)
+#define SPI1_TXFR2                               SPI_TXFR2_REG(SPI1)
+#define SPI1_TXFR3                               SPI_TXFR3_REG(SPI1)
+#define SPI1_RXFR0                               SPI_RXFR0_REG(SPI1)
+#define SPI1_RXFR1                               SPI_RXFR1_REG(SPI1)
+#define SPI1_RXFR2                               SPI_RXFR2_REG(SPI1)
+#define SPI1_RXFR3                               SPI_RXFR3_REG(SPI1)
+/* SPI2 */
+#define SPI2_MCR                                 SPI_MCR_REG(SPI2)
+#define SPI2_TCR                                 SPI_TCR_REG(SPI2)
+#define SPI2_CTAR0                               SPI_CTAR_REG(SPI2,0)
+#define SPI2_CTAR0_SLAVE                         SPI_CTAR_SLAVE_REG(SPI2,0)
+#define SPI2_CTAR1                               SPI_CTAR_REG(SPI2,1)
+#define SPI2_SR                                  SPI_SR_REG(SPI2)
+#define SPI2_RSER                                SPI_RSER_REG(SPI2)
+#define SPI2_PUSHR                               SPI_PUSHR_REG(SPI2)
+#define SPI2_PUSHR_SLAVE                         SPI_PUSHR_SLAVE_REG(SPI2)
+#define SPI2_POPR                                SPI_POPR_REG(SPI2)
+#define SPI2_TXFR0                               SPI_TXFR0_REG(SPI2)
+#define SPI2_TXFR1                               SPI_TXFR1_REG(SPI2)
+#define SPI2_TXFR2                               SPI_TXFR2_REG(SPI2)
+#define SPI2_TXFR3                               SPI_TXFR3_REG(SPI2)
+#define SPI2_RXFR0                               SPI_RXFR0_REG(SPI2)
+#define SPI2_RXFR1                               SPI_RXFR1_REG(SPI2)
+#define SPI2_RXFR2                               SPI_RXFR2_REG(SPI2)
+#define SPI2_RXFR3                               SPI_RXFR3_REG(SPI2)
+
+/* SPI - Register array accessors */
+#define SPI0_CTAR(index2)                        SPI_CTAR_REG(SPI0,index2)
+#define SPI1_CTAR(index2)                        SPI_CTAR_REG(SPI1,index2)
+#define SPI2_CTAR(index2)                        SPI_CTAR_REG(SPI2,index2)
+#define SPI0_CTAR_SLAVE(index2)                  SPI_CTAR_SLAVE_REG(SPI0,index2)
+#define SPI1_CTAR_SLAVE(index2)                  SPI_CTAR_SLAVE_REG(SPI1,index2)
+#define SPI2_CTAR_SLAVE(index2)                  SPI_CTAR_SLAVE_REG(SPI2,index2)
+
+/*!
+ * @}
+ */ /* end of group SPI_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group SPI_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- UART Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup UART_Peripheral_Access_Layer UART Peripheral Access Layer
+ * @{
+ */
+
+/** UART - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t BDH;                                /**< UART Baud Rate Registers: High, offset: 0x0 */
+  __IO uint8_t BDL;                                /**< UART Baud Rate Registers: Low, offset: 0x1 */
+  __IO uint8_t C1;                                 /**< UART Control Register 1, offset: 0x2 */
+  __IO uint8_t C2;                                 /**< UART Control Register 2, offset: 0x3 */
+  __I  uint8_t S1;                                 /**< UART Status Register 1, offset: 0x4 */
+  __IO uint8_t S2;                                 /**< UART Status Register 2, offset: 0x5 */
+  __IO uint8_t C3;                                 /**< UART Control Register 3, offset: 0x6 */
+  __IO uint8_t D;                                  /**< UART Data Register, offset: 0x7 */
+  __IO uint8_t MA1;                                /**< UART Match Address Registers 1, offset: 0x8 */
+  __IO uint8_t MA2;                                /**< UART Match Address Registers 2, offset: 0x9 */
+  __IO uint8_t C4;                                 /**< UART Control Register 4, offset: 0xA */
+  __IO uint8_t C5;                                 /**< UART Control Register 5, offset: 0xB */
+  __I  uint8_t ED;                                 /**< UART Extended Data Register, offset: 0xC */
+  __IO uint8_t MODEM;                              /**< UART Modem Register, offset: 0xD */
+  __IO uint8_t IR;                                 /**< UART Infrared Register, offset: 0xE */
+       uint8_t RESERVED_0[1];
+  __IO uint8_t PFIFO;                              /**< UART FIFO Parameters, offset: 0x10 */
+  __IO uint8_t CFIFO;                              /**< UART FIFO Control Register, offset: 0x11 */
+  __IO uint8_t SFIFO;                              /**< UART FIFO Status Register, offset: 0x12 */
+  __IO uint8_t TWFIFO;                             /**< UART FIFO Transmit Watermark, offset: 0x13 */
+  __I  uint8_t TCFIFO;                             /**< UART FIFO Transmit Count, offset: 0x14 */
+  __IO uint8_t RWFIFO;                             /**< UART FIFO Receive Watermark, offset: 0x15 */
+  __I  uint8_t RCFIFO;                             /**< UART FIFO Receive Count, offset: 0x16 */
+       uint8_t RESERVED_1[1];
+  __IO uint8_t C7816;                              /**< UART 7816 Control Register, offset: 0x18 */
+  __IO uint8_t IE7816;                             /**< UART 7816 Interrupt Enable Register, offset: 0x19 */
+  __IO uint8_t IS7816;                             /**< UART 7816 Interrupt Status Register, offset: 0x1A */
+  union {                                          /* offset: 0x1B */
+    __IO uint8_t WP7816T0;                           /**< UART 7816 Wait Parameter Register, offset: 0x1B */
+    __IO uint8_t WP7816T1;                           /**< UART 7816 Wait Parameter Register, offset: 0x1B */
+  };
+  __IO uint8_t WN7816;                             /**< UART 7816 Wait N Register, offset: 0x1C */
+  __IO uint8_t WF7816;                             /**< UART 7816 Wait FD Register, offset: 0x1D */
+  __IO uint8_t ET7816;                             /**< UART 7816 Error Threshold Register, offset: 0x1E */
+  __IO uint8_t TL7816;                             /**< UART 7816 Transmit Length Register, offset: 0x1F */
+} UART_Type, *UART_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- UART - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup UART_Register_Accessor_Macros UART - Register accessor macros
+ * @{
+ */
+
+
+/* UART - Register accessors */
+#define UART_BDH_REG(base)                       ((base)->BDH)
+#define UART_BDL_REG(base)                       ((base)->BDL)
+#define UART_C1_REG(base)                        ((base)->C1)
+#define UART_C2_REG(base)                        ((base)->C2)
+#define UART_S1_REG(base)                        ((base)->S1)
+#define UART_S2_REG(base)                        ((base)->S2)
+#define UART_C3_REG(base)                        ((base)->C3)
+#define UART_D_REG(base)                         ((base)->D)
+#define UART_MA1_REG(base)                       ((base)->MA1)
+#define UART_MA2_REG(base)                       ((base)->MA2)
+#define UART_C4_REG(base)                        ((base)->C4)
+#define UART_C5_REG(base)                        ((base)->C5)
+#define UART_ED_REG(base)                        ((base)->ED)
+#define UART_MODEM_REG(base)                     ((base)->MODEM)
+#define UART_IR_REG(base)                        ((base)->IR)
+#define UART_PFIFO_REG(base)                     ((base)->PFIFO)
+#define UART_CFIFO_REG(base)                     ((base)->CFIFO)
+#define UART_SFIFO_REG(base)                     ((base)->SFIFO)
+#define UART_TWFIFO_REG(base)                    ((base)->TWFIFO)
+#define UART_TCFIFO_REG(base)                    ((base)->TCFIFO)
+#define UART_RWFIFO_REG(base)                    ((base)->RWFIFO)
+#define UART_RCFIFO_REG(base)                    ((base)->RCFIFO)
+#define UART_C7816_REG(base)                     ((base)->C7816)
+#define UART_IE7816_REG(base)                    ((base)->IE7816)
+#define UART_IS7816_REG(base)                    ((base)->IS7816)
+#define UART_WP7816T0_REG(base)                  ((base)->WP7816T0)
+#define UART_WP7816T1_REG(base)                  ((base)->WP7816T1)
+#define UART_WN7816_REG(base)                    ((base)->WN7816)
+#define UART_WF7816_REG(base)                    ((base)->WF7816)
+#define UART_ET7816_REG(base)                    ((base)->ET7816)
+#define UART_TL7816_REG(base)                    ((base)->TL7816)
+
+/*!
+ * @}
+ */ /* end of group UART_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- UART Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup UART_Register_Masks UART Register Masks
+ * @{
+ */
+
+/* BDH Bit Fields */
+#define UART_BDH_SBR_MASK                        0x1Fu
+#define UART_BDH_SBR_SHIFT                       0
+#define UART_BDH_SBR(x)                          (((uint8_t)(((uint8_t)(x))<<UART_BDH_SBR_SHIFT))&UART_BDH_SBR_MASK)
+#define UART_BDH_SBNS_MASK                       0x20u
+#define UART_BDH_SBNS_SHIFT                      5
+#define UART_BDH_RXEDGIE_MASK                    0x40u
+#define UART_BDH_RXEDGIE_SHIFT                   6
+#define UART_BDH_LBKDIE_MASK                     0x80u
+#define UART_BDH_LBKDIE_SHIFT                    7
+/* BDL Bit Fields */
+#define UART_BDL_SBR_MASK                        0xFFu
+#define UART_BDL_SBR_SHIFT                       0
+#define UART_BDL_SBR(x)                          (((uint8_t)(((uint8_t)(x))<<UART_BDL_SBR_SHIFT))&UART_BDL_SBR_MASK)
+/* C1 Bit Fields */
+#define UART_C1_PT_MASK                          0x1u
+#define UART_C1_PT_SHIFT                         0
+#define UART_C1_PE_MASK                          0x2u
+#define UART_C1_PE_SHIFT                         1
+#define UART_C1_ILT_MASK                         0x4u
+#define UART_C1_ILT_SHIFT                        2
+#define UART_C1_WAKE_MASK                        0x8u
+#define UART_C1_WAKE_SHIFT                       3
+#define UART_C1_M_MASK                           0x10u
+#define UART_C1_M_SHIFT                          4
+#define UART_C1_RSRC_MASK                        0x20u
+#define UART_C1_RSRC_SHIFT                       5
+#define UART_C1_UARTSWAI_MASK                    0x40u
+#define UART_C1_UARTSWAI_SHIFT                   6
+#define UART_C1_LOOPS_MASK                       0x80u
+#define UART_C1_LOOPS_SHIFT                      7
+/* C2 Bit Fields */
+#define UART_C2_SBK_MASK                         0x1u
+#define UART_C2_SBK_SHIFT                        0
+#define UART_C2_RWU_MASK                         0x2u
+#define UART_C2_RWU_SHIFT                        1
+#define UART_C2_RE_MASK                          0x4u
+#define UART_C2_RE_SHIFT                         2
+#define UART_C2_TE_MASK                          0x8u
+#define UART_C2_TE_SHIFT                         3
+#define UART_C2_ILIE_MASK                        0x10u
+#define UART_C2_ILIE_SHIFT                       4
+#define UART_C2_RIE_MASK                         0x20u
+#define UART_C2_RIE_SHIFT                        5
+#define UART_C2_TCIE_MASK                        0x40u
+#define UART_C2_TCIE_SHIFT                       6
+#define UART_C2_TIE_MASK                         0x80u
+#define UART_C2_TIE_SHIFT                        7
+/* S1 Bit Fields */
+#define UART_S1_PF_MASK                          0x1u
+#define UART_S1_PF_SHIFT                         0
+#define UART_S1_FE_MASK                          0x2u
+#define UART_S1_FE_SHIFT                         1
+#define UART_S1_NF_MASK                          0x4u
+#define UART_S1_NF_SHIFT                         2
+#define UART_S1_OR_MASK                          0x8u
+#define UART_S1_OR_SHIFT                         3
+#define UART_S1_IDLE_MASK                        0x10u
+#define UART_S1_IDLE_SHIFT                       4
+#define UART_S1_RDRF_MASK                        0x20u
+#define UART_S1_RDRF_SHIFT                       5
+#define UART_S1_TC_MASK                          0x40u
+#define UART_S1_TC_SHIFT                         6
+#define UART_S1_TDRE_MASK                        0x80u
+#define UART_S1_TDRE_SHIFT                       7
+/* S2 Bit Fields */
+#define UART_S2_RAF_MASK                         0x1u
+#define UART_S2_RAF_SHIFT                        0
+#define UART_S2_LBKDE_MASK                       0x2u
+#define UART_S2_LBKDE_SHIFT                      1
+#define UART_S2_BRK13_MASK                       0x4u
+#define UART_S2_BRK13_SHIFT                      2
+#define UART_S2_RWUID_MASK                       0x8u
+#define UART_S2_RWUID_SHIFT                      3
+#define UART_S2_RXINV_MASK                       0x10u
+#define UART_S2_RXINV_SHIFT                      4
+#define UART_S2_MSBF_MASK                        0x20u
+#define UART_S2_MSBF_SHIFT                       5
+#define UART_S2_RXEDGIF_MASK                     0x40u
+#define UART_S2_RXEDGIF_SHIFT                    6
+#define UART_S2_LBKDIF_MASK                      0x80u
+#define UART_S2_LBKDIF_SHIFT                     7
+/* C3 Bit Fields */
+#define UART_C3_PEIE_MASK                        0x1u
+#define UART_C3_PEIE_SHIFT                       0
+#define UART_C3_FEIE_MASK                        0x2u
+#define UART_C3_FEIE_SHIFT                       1
+#define UART_C3_NEIE_MASK                        0x4u
+#define UART_C3_NEIE_SHIFT                       2
+#define UART_C3_ORIE_MASK                        0x8u
+#define UART_C3_ORIE_SHIFT                       3
+#define UART_C3_TXINV_MASK                       0x10u
+#define UART_C3_TXINV_SHIFT                      4
+#define UART_C3_TXDIR_MASK                       0x20u
+#define UART_C3_TXDIR_SHIFT                      5
+#define UART_C3_T8_MASK                          0x40u
+#define UART_C3_T8_SHIFT                         6
+#define UART_C3_R8_MASK                          0x80u
+#define UART_C3_R8_SHIFT                         7
+/* D Bit Fields */
+#define UART_D_RT_MASK                           0xFFu
+#define UART_D_RT_SHIFT                          0
+#define UART_D_RT(x)                             (((uint8_t)(((uint8_t)(x))<<UART_D_RT_SHIFT))&UART_D_RT_MASK)
+/* MA1 Bit Fields */
+#define UART_MA1_MA_MASK                         0xFFu
+#define UART_MA1_MA_SHIFT                        0
+#define UART_MA1_MA(x)                           (((uint8_t)(((uint8_t)(x))<<UART_MA1_MA_SHIFT))&UART_MA1_MA_MASK)
+/* MA2 Bit Fields */
+#define UART_MA2_MA_MASK                         0xFFu
+#define UART_MA2_MA_SHIFT                        0
+#define UART_MA2_MA(x)                           (((uint8_t)(((uint8_t)(x))<<UART_MA2_MA_SHIFT))&UART_MA2_MA_MASK)
+/* C4 Bit Fields */
+#define UART_C4_BRFA_MASK                        0x1Fu
+#define UART_C4_BRFA_SHIFT                       0
+#define UART_C4_BRFA(x)                          (((uint8_t)(((uint8_t)(x))<<UART_C4_BRFA_SHIFT))&UART_C4_BRFA_MASK)
+#define UART_C4_M10_MASK                         0x20u
+#define UART_C4_M10_SHIFT                        5
+#define UART_C4_MAEN2_MASK                       0x40u
+#define UART_C4_MAEN2_SHIFT                      6
+#define UART_C4_MAEN1_MASK                       0x80u
+#define UART_C4_MAEN1_SHIFT                      7
+/* C5 Bit Fields */
+#define UART_C5_LBKDDMAS_MASK                    0x8u
+#define UART_C5_LBKDDMAS_SHIFT                   3
+#define UART_C5_ILDMAS_MASK                      0x10u
+#define UART_C5_ILDMAS_SHIFT                     4
+#define UART_C5_RDMAS_MASK                       0x20u
+#define UART_C5_RDMAS_SHIFT                      5
+#define UART_C5_TCDMAS_MASK                      0x40u
+#define UART_C5_TCDMAS_SHIFT                     6
+#define UART_C5_TDMAS_MASK                       0x80u
+#define UART_C5_TDMAS_SHIFT                      7
+/* ED Bit Fields */
+#define UART_ED_PARITYE_MASK                     0x40u
+#define UART_ED_PARITYE_SHIFT                    6
+#define UART_ED_NOISY_MASK                       0x80u
+#define UART_ED_NOISY_SHIFT                      7
+/* MODEM Bit Fields */
+#define UART_MODEM_TXCTSE_MASK                   0x1u
+#define UART_MODEM_TXCTSE_SHIFT                  0
+#define UART_MODEM_TXRTSE_MASK                   0x2u
+#define UART_MODEM_TXRTSE_SHIFT                  1
+#define UART_MODEM_TXRTSPOL_MASK                 0x4u
+#define UART_MODEM_TXRTSPOL_SHIFT                2
+#define UART_MODEM_RXRTSE_MASK                   0x8u
+#define UART_MODEM_RXRTSE_SHIFT                  3
+/* IR Bit Fields */
+#define UART_IR_TNP_MASK                         0x3u
+#define UART_IR_TNP_SHIFT                        0
+#define UART_IR_TNP(x)                           (((uint8_t)(((uint8_t)(x))<<UART_IR_TNP_SHIFT))&UART_IR_TNP_MASK)
+#define UART_IR_IREN_MASK                        0x4u
+#define UART_IR_IREN_SHIFT                       2
+/* PFIFO Bit Fields */
+#define UART_PFIFO_RXFIFOSIZE_MASK               0x7u
+#define UART_PFIFO_RXFIFOSIZE_SHIFT              0
+#define UART_PFIFO_RXFIFOSIZE(x)                 (((uint8_t)(((uint8_t)(x))<<UART_PFIFO_RXFIFOSIZE_SHIFT))&UART_PFIFO_RXFIFOSIZE_MASK)
+#define UART_PFIFO_RXFE_MASK                     0x8u
+#define UART_PFIFO_RXFE_SHIFT                    3
+#define UART_PFIFO_TXFIFOSIZE_MASK               0x70u
+#define UART_PFIFO_TXFIFOSIZE_SHIFT              4
+#define UART_PFIFO_TXFIFOSIZE(x)                 (((uint8_t)(((uint8_t)(x))<<UART_PFIFO_TXFIFOSIZE_SHIFT))&UART_PFIFO_TXFIFOSIZE_MASK)
+#define UART_PFIFO_TXFE_MASK                     0x80u
+#define UART_PFIFO_TXFE_SHIFT                    7
+/* CFIFO Bit Fields */
+#define UART_CFIFO_RXUFE_MASK                    0x1u
+#define UART_CFIFO_RXUFE_SHIFT                   0
+#define UART_CFIFO_TXOFE_MASK                    0x2u
+#define UART_CFIFO_TXOFE_SHIFT                   1
+#define UART_CFIFO_RXOFE_MASK                    0x4u
+#define UART_CFIFO_RXOFE_SHIFT                   2
+#define UART_CFIFO_RXFLUSH_MASK                  0x40u
+#define UART_CFIFO_RXFLUSH_SHIFT                 6
+#define UART_CFIFO_TXFLUSH_MASK                  0x80u
+#define UART_CFIFO_TXFLUSH_SHIFT                 7
+/* SFIFO Bit Fields */
+#define UART_SFIFO_RXUF_MASK                     0x1u
+#define UART_SFIFO_RXUF_SHIFT                    0
+#define UART_SFIFO_TXOF_MASK                     0x2u
+#define UART_SFIFO_TXOF_SHIFT                    1
+#define UART_SFIFO_RXOF_MASK                     0x4u
+#define UART_SFIFO_RXOF_SHIFT                    2
+#define UART_SFIFO_RXEMPT_MASK                   0x40u
+#define UART_SFIFO_RXEMPT_SHIFT                  6
+#define UART_SFIFO_TXEMPT_MASK                   0x80u
+#define UART_SFIFO_TXEMPT_SHIFT                  7
+/* TWFIFO Bit Fields */
+#define UART_TWFIFO_TXWATER_MASK                 0xFFu
+#define UART_TWFIFO_TXWATER_SHIFT                0
+#define UART_TWFIFO_TXWATER(x)                   (((uint8_t)(((uint8_t)(x))<<UART_TWFIFO_TXWATER_SHIFT))&UART_TWFIFO_TXWATER_MASK)
+/* TCFIFO Bit Fields */
+#define UART_TCFIFO_TXCOUNT_MASK                 0xFFu
+#define UART_TCFIFO_TXCOUNT_SHIFT                0
+#define UART_TCFIFO_TXCOUNT(x)                   (((uint8_t)(((uint8_t)(x))<<UART_TCFIFO_TXCOUNT_SHIFT))&UART_TCFIFO_TXCOUNT_MASK)
+/* RWFIFO Bit Fields */
+#define UART_RWFIFO_RXWATER_MASK                 0xFFu
+#define UART_RWFIFO_RXWATER_SHIFT                0
+#define UART_RWFIFO_RXWATER(x)                   (((uint8_t)(((uint8_t)(x))<<UART_RWFIFO_RXWATER_SHIFT))&UART_RWFIFO_RXWATER_MASK)
+/* RCFIFO Bit Fields */
+#define UART_RCFIFO_RXCOUNT_MASK                 0xFFu
+#define UART_RCFIFO_RXCOUNT_SHIFT                0
+#define UART_RCFIFO_RXCOUNT(x)                   (((uint8_t)(((uint8_t)(x))<<UART_RCFIFO_RXCOUNT_SHIFT))&UART_RCFIFO_RXCOUNT_MASK)
+/* C7816 Bit Fields */
+#define UART_C7816_ISO_7816E_MASK                0x1u
+#define UART_C7816_ISO_7816E_SHIFT               0
+#define UART_C7816_TTYPE_MASK                    0x2u
+#define UART_C7816_TTYPE_SHIFT                   1
+#define UART_C7816_INIT_MASK                     0x4u
+#define UART_C7816_INIT_SHIFT                    2
+#define UART_C7816_ANACK_MASK                    0x8u
+#define UART_C7816_ANACK_SHIFT                   3
+#define UART_C7816_ONACK_MASK                    0x10u
+#define UART_C7816_ONACK_SHIFT                   4
+/* IE7816 Bit Fields */
+#define UART_IE7816_RXTE_MASK                    0x1u
+#define UART_IE7816_RXTE_SHIFT                   0
+#define UART_IE7816_TXTE_MASK                    0x2u
+#define UART_IE7816_TXTE_SHIFT                   1
+#define UART_IE7816_GTVE_MASK                    0x4u
+#define UART_IE7816_GTVE_SHIFT                   2
+#define UART_IE7816_INITDE_MASK                  0x10u
+#define UART_IE7816_INITDE_SHIFT                 4
+#define UART_IE7816_BWTE_MASK                    0x20u
+#define UART_IE7816_BWTE_SHIFT                   5
+#define UART_IE7816_CWTE_MASK                    0x40u
+#define UART_IE7816_CWTE_SHIFT                   6
+#define UART_IE7816_WTE_MASK                     0x80u
+#define UART_IE7816_WTE_SHIFT                    7
+/* IS7816 Bit Fields */
+#define UART_IS7816_RXT_MASK                     0x1u
+#define UART_IS7816_RXT_SHIFT                    0
+#define UART_IS7816_TXT_MASK                     0x2u
+#define UART_IS7816_TXT_SHIFT                    1
+#define UART_IS7816_GTV_MASK                     0x4u
+#define UART_IS7816_GTV_SHIFT                    2
+#define UART_IS7816_INITD_MASK                   0x10u
+#define UART_IS7816_INITD_SHIFT                  4
+#define UART_IS7816_BWT_MASK                     0x20u
+#define UART_IS7816_BWT_SHIFT                    5
+#define UART_IS7816_CWT_MASK                     0x40u
+#define UART_IS7816_CWT_SHIFT                    6
+#define UART_IS7816_WT_MASK                      0x80u
+#define UART_IS7816_WT_SHIFT                     7
+/* WP7816T0 Bit Fields */
+#define UART_WP7816T0_WI_MASK                    0xFFu
+#define UART_WP7816T0_WI_SHIFT                   0
+#define UART_WP7816T0_WI(x)                      (((uint8_t)(((uint8_t)(x))<<UART_WP7816T0_WI_SHIFT))&UART_WP7816T0_WI_MASK)
+/* WP7816T1 Bit Fields */
+#define UART_WP7816T1_BWI_MASK                   0xFu
+#define UART_WP7816T1_BWI_SHIFT                  0
+#define UART_WP7816T1_BWI(x)                     (((uint8_t)(((uint8_t)(x))<<UART_WP7816T1_BWI_SHIFT))&UART_WP7816T1_BWI_MASK)
+#define UART_WP7816T1_CWI_MASK                   0xF0u
+#define UART_WP7816T1_CWI_SHIFT                  4
+#define UART_WP7816T1_CWI(x)                     (((uint8_t)(((uint8_t)(x))<<UART_WP7816T1_CWI_SHIFT))&UART_WP7816T1_CWI_MASK)
+/* WN7816 Bit Fields */
+#define UART_WN7816_GTN_MASK                     0xFFu
+#define UART_WN7816_GTN_SHIFT                    0
+#define UART_WN7816_GTN(x)                       (((uint8_t)(((uint8_t)(x))<<UART_WN7816_GTN_SHIFT))&UART_WN7816_GTN_MASK)
+/* WF7816 Bit Fields */
+#define UART_WF7816_GTFD_MASK                    0xFFu
+#define UART_WF7816_GTFD_SHIFT                   0
+#define UART_WF7816_GTFD(x)                      (((uint8_t)(((uint8_t)(x))<<UART_WF7816_GTFD_SHIFT))&UART_WF7816_GTFD_MASK)
+/* ET7816 Bit Fields */
+#define UART_ET7816_RXTHRESHOLD_MASK             0xFu
+#define UART_ET7816_RXTHRESHOLD_SHIFT            0
+#define UART_ET7816_RXTHRESHOLD(x)               (((uint8_t)(((uint8_t)(x))<<UART_ET7816_RXTHRESHOLD_SHIFT))&UART_ET7816_RXTHRESHOLD_MASK)
+#define UART_ET7816_TXTHRESHOLD_MASK             0xF0u
+#define UART_ET7816_TXTHRESHOLD_SHIFT            4
+#define UART_ET7816_TXTHRESHOLD(x)               (((uint8_t)(((uint8_t)(x))<<UART_ET7816_TXTHRESHOLD_SHIFT))&UART_ET7816_TXTHRESHOLD_MASK)
+/* TL7816 Bit Fields */
+#define UART_TL7816_TLEN_MASK                    0xFFu
+#define UART_TL7816_TLEN_SHIFT                   0
+#define UART_TL7816_TLEN(x)                      (((uint8_t)(((uint8_t)(x))<<UART_TL7816_TLEN_SHIFT))&UART_TL7816_TLEN_MASK)
+
+/*!
+ * @}
+ */ /* end of group UART_Register_Masks */
+
+
+/* UART - Peripheral instance base addresses */
+/** Peripheral UART0 base address */
+#define UART0_BASE                               (0x4006A000u)
+/** Peripheral UART0 base pointer */
+#define UART0                                    ((UART_Type *)UART0_BASE)
+#define UART0_BASE_PTR                           (UART0)
+/** Peripheral UART1 base address */
+#define UART1_BASE                               (0x4006B000u)
+/** Peripheral UART1 base pointer */
+#define UART1                                    ((UART_Type *)UART1_BASE)
+#define UART1_BASE_PTR                           (UART1)
+/** Peripheral UART2 base address */
+#define UART2_BASE                               (0x4006C000u)
+/** Peripheral UART2 base pointer */
+#define UART2                                    ((UART_Type *)UART2_BASE)
+#define UART2_BASE_PTR                           (UART2)
+/** Peripheral UART3 base address */
+#define UART3_BASE                               (0x4006D000u)
+/** Peripheral UART3 base pointer */
+#define UART3                                    ((UART_Type *)UART3_BASE)
+#define UART3_BASE_PTR                           (UART3)
+/** Peripheral UART4 base address */
+#define UART4_BASE                               (0x400EA000u)
+/** Peripheral UART4 base pointer */
+#define UART4                                    ((UART_Type *)UART4_BASE)
+#define UART4_BASE_PTR                           (UART4)
+/** Peripheral UART5 base address */
+#define UART5_BASE                               (0x400EB000u)
+/** Peripheral UART5 base pointer */
+#define UART5                                    ((UART_Type *)UART5_BASE)
+#define UART5_BASE_PTR                           (UART5)
+/** Array initializer of UART peripheral base addresses */
+#define UART_BASE_ADDRS                          { UART0_BASE, UART1_BASE, UART2_BASE, UART3_BASE, UART4_BASE, UART5_BASE }
+/** Array initializer of UART peripheral base pointers */
+#define UART_BASE_PTRS                           { UART0, UART1, UART2, UART3, UART4, UART5 }
+/** Interrupt vectors for the UART peripheral type */
+#define UART_RX_TX_IRQS                          { UART0_RX_TX_IRQn, UART1_RX_TX_IRQn, UART2_RX_TX_IRQn, UART3_RX_TX_IRQn, UART4_RX_TX_IRQn, UART5_RX_TX_IRQn }
+#define UART_ERR_IRQS                            { UART0_ERR_IRQn, UART1_ERR_IRQn, UART2_ERR_IRQn, UART3_ERR_IRQn, UART4_ERR_IRQn, UART5_ERR_IRQn }
+#define UART_LON_IRQS                            { UART0_LON_IRQn, 0, 0, 0, 0, 0 }
+
+/* ----------------------------------------------------------------------------
+   -- UART - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup UART_Register_Accessor_Macros UART - Register accessor macros
+ * @{
+ */
+
+
+/* UART - Register instance definitions */
+/* UART0 */
+#define UART0_BDH                                UART_BDH_REG(UART0)
+#define UART0_BDL                                UART_BDL_REG(UART0)
+#define UART0_C1                                 UART_C1_REG(UART0)
+#define UART0_C2                                 UART_C2_REG(UART0)
+#define UART0_S1                                 UART_S1_REG(UART0)
+#define UART0_S2                                 UART_S2_REG(UART0)
+#define UART0_C3                                 UART_C3_REG(UART0)
+#define UART0_D                                  UART_D_REG(UART0)
+#define UART0_MA1                                UART_MA1_REG(UART0)
+#define UART0_MA2                                UART_MA2_REG(UART0)
+#define UART0_C4                                 UART_C4_REG(UART0)
+#define UART0_C5                                 UART_C5_REG(UART0)
+#define UART0_ED                                 UART_ED_REG(UART0)
+#define UART0_MODEM                              UART_MODEM_REG(UART0)
+#define UART0_IR                                 UART_IR_REG(UART0)
+#define UART0_PFIFO                              UART_PFIFO_REG(UART0)
+#define UART0_CFIFO                              UART_CFIFO_REG(UART0)
+#define UART0_SFIFO                              UART_SFIFO_REG(UART0)
+#define UART0_TWFIFO                             UART_TWFIFO_REG(UART0)
+#define UART0_TCFIFO                             UART_TCFIFO_REG(UART0)
+#define UART0_RWFIFO                             UART_RWFIFO_REG(UART0)
+#define UART0_RCFIFO                             UART_RCFIFO_REG(UART0)
+#define UART0_C7816                              UART_C7816_REG(UART0)
+#define UART0_IE7816                             UART_IE7816_REG(UART0)
+#define UART0_IS7816                             UART_IS7816_REG(UART0)
+#define UART0_WP7816T0                           UART_WP7816T0_REG(UART0)
+#define UART0_WP7816T1                           UART_WP7816T1_REG(UART0)
+#define UART0_WN7816                             UART_WN7816_REG(UART0)
+#define UART0_WF7816                             UART_WF7816_REG(UART0)
+#define UART0_ET7816                             UART_ET7816_REG(UART0)
+#define UART0_TL7816                             UART_TL7816_REG(UART0)
+/* UART1 */
+#define UART1_BDH                                UART_BDH_REG(UART1)
+#define UART1_BDL                                UART_BDL_REG(UART1)
+#define UART1_C1                                 UART_C1_REG(UART1)
+#define UART1_C2                                 UART_C2_REG(UART1)
+#define UART1_S1                                 UART_S1_REG(UART1)
+#define UART1_S2                                 UART_S2_REG(UART1)
+#define UART1_C3                                 UART_C3_REG(UART1)
+#define UART1_D                                  UART_D_REG(UART1)
+#define UART1_MA1                                UART_MA1_REG(UART1)
+#define UART1_MA2                                UART_MA2_REG(UART1)
+#define UART1_C4                                 UART_C4_REG(UART1)
+#define UART1_C5                                 UART_C5_REG(UART1)
+#define UART1_ED                                 UART_ED_REG(UART1)
+#define UART1_MODEM                              UART_MODEM_REG(UART1)
+#define UART1_IR                                 UART_IR_REG(UART1)
+#define UART1_PFIFO                              UART_PFIFO_REG(UART1)
+#define UART1_CFIFO                              UART_CFIFO_REG(UART1)
+#define UART1_SFIFO                              UART_SFIFO_REG(UART1)
+#define UART1_TWFIFO                             UART_TWFIFO_REG(UART1)
+#define UART1_TCFIFO                             UART_TCFIFO_REG(UART1)
+#define UART1_RWFIFO                             UART_RWFIFO_REG(UART1)
+#define UART1_RCFIFO                             UART_RCFIFO_REG(UART1)
+/* UART2 */
+#define UART2_BDH                                UART_BDH_REG(UART2)
+#define UART2_BDL                                UART_BDL_REG(UART2)
+#define UART2_C1                                 UART_C1_REG(UART2)
+#define UART2_C2                                 UART_C2_REG(UART2)
+#define UART2_S1                                 UART_S1_REG(UART2)
+#define UART2_S2                                 UART_S2_REG(UART2)
+#define UART2_C3                                 UART_C3_REG(UART2)
+#define UART2_D                                  UART_D_REG(UART2)
+#define UART2_MA1                                UART_MA1_REG(UART2)
+#define UART2_MA2                                UART_MA2_REG(UART2)
+#define UART2_C4                                 UART_C4_REG(UART2)
+#define UART2_C5                                 UART_C5_REG(UART2)
+#define UART2_ED                                 UART_ED_REG(UART2)
+#define UART2_MODEM                              UART_MODEM_REG(UART2)
+#define UART2_IR                                 UART_IR_REG(UART2)
+#define UART2_PFIFO                              UART_PFIFO_REG(UART2)
+#define UART2_CFIFO                              UART_CFIFO_REG(UART2)
+#define UART2_SFIFO                              UART_SFIFO_REG(UART2)
+#define UART2_TWFIFO                             UART_TWFIFO_REG(UART2)
+#define UART2_TCFIFO                             UART_TCFIFO_REG(UART2)
+#define UART2_RWFIFO                             UART_RWFIFO_REG(UART2)
+#define UART2_RCFIFO                             UART_RCFIFO_REG(UART2)
+/* UART3 */
+#define UART3_BDH                                UART_BDH_REG(UART3)
+#define UART3_BDL                                UART_BDL_REG(UART3)
+#define UART3_C1                                 UART_C1_REG(UART3)
+#define UART3_C2                                 UART_C2_REG(UART3)
+#define UART3_S1                                 UART_S1_REG(UART3)
+#define UART3_S2                                 UART_S2_REG(UART3)
+#define UART3_C3                                 UART_C3_REG(UART3)
+#define UART3_D                                  UART_D_REG(UART3)
+#define UART3_MA1                                UART_MA1_REG(UART3)
+#define UART3_MA2                                UART_MA2_REG(UART3)
+#define UART3_C4                                 UART_C4_REG(UART3)
+#define UART3_C5                                 UART_C5_REG(UART3)
+#define UART3_ED                                 UART_ED_REG(UART3)
+#define UART3_MODEM                              UART_MODEM_REG(UART3)
+#define UART3_IR                                 UART_IR_REG(UART3)
+#define UART3_PFIFO                              UART_PFIFO_REG(UART3)
+#define UART3_CFIFO                              UART_CFIFO_REG(UART3)
+#define UART3_SFIFO                              UART_SFIFO_REG(UART3)
+#define UART3_TWFIFO                             UART_TWFIFO_REG(UART3)
+#define UART3_TCFIFO                             UART_TCFIFO_REG(UART3)
+#define UART3_RWFIFO                             UART_RWFIFO_REG(UART3)
+#define UART3_RCFIFO                             UART_RCFIFO_REG(UART3)
+/* UART4 */
+#define UART4_BDH                                UART_BDH_REG(UART4)
+#define UART4_BDL                                UART_BDL_REG(UART4)
+#define UART4_C1                                 UART_C1_REG(UART4)
+#define UART4_C2                                 UART_C2_REG(UART4)
+#define UART4_S1                                 UART_S1_REG(UART4)
+#define UART4_S2                                 UART_S2_REG(UART4)
+#define UART4_C3                                 UART_C3_REG(UART4)
+#define UART4_D                                  UART_D_REG(UART4)
+#define UART4_MA1                                UART_MA1_REG(UART4)
+#define UART4_MA2                                UART_MA2_REG(UART4)
+#define UART4_C4                                 UART_C4_REG(UART4)
+#define UART4_C5                                 UART_C5_REG(UART4)
+#define UART4_ED                                 UART_ED_REG(UART4)
+#define UART4_MODEM                              UART_MODEM_REG(UART4)
+#define UART4_IR                                 UART_IR_REG(UART4)
+#define UART4_PFIFO                              UART_PFIFO_REG(UART4)
+#define UART4_CFIFO                              UART_CFIFO_REG(UART4)
+#define UART4_SFIFO                              UART_SFIFO_REG(UART4)
+#define UART4_TWFIFO                             UART_TWFIFO_REG(UART4)
+#define UART4_TCFIFO                             UART_TCFIFO_REG(UART4)
+#define UART4_RWFIFO                             UART_RWFIFO_REG(UART4)
+#define UART4_RCFIFO                             UART_RCFIFO_REG(UART4)
+/* UART5 */
+#define UART5_BDH                                UART_BDH_REG(UART5)
+#define UART5_BDL                                UART_BDL_REG(UART5)
+#define UART5_C1                                 UART_C1_REG(UART5)
+#define UART5_C2                                 UART_C2_REG(UART5)
+#define UART5_S1                                 UART_S1_REG(UART5)
+#define UART5_S2                                 UART_S2_REG(UART5)
+#define UART5_C3                                 UART_C3_REG(UART5)
+#define UART5_D                                  UART_D_REG(UART5)
+#define UART5_MA1                                UART_MA1_REG(UART5)
+#define UART5_MA2                                UART_MA2_REG(UART5)
+#define UART5_C4                                 UART_C4_REG(UART5)
+#define UART5_C5                                 UART_C5_REG(UART5)
+#define UART5_ED                                 UART_ED_REG(UART5)
+#define UART5_MODEM                              UART_MODEM_REG(UART5)
+#define UART5_IR                                 UART_IR_REG(UART5)
+#define UART5_PFIFO                              UART_PFIFO_REG(UART5)
+#define UART5_CFIFO                              UART_CFIFO_REG(UART5)
+#define UART5_SFIFO                              UART_SFIFO_REG(UART5)
+#define UART5_TWFIFO                             UART_TWFIFO_REG(UART5)
+#define UART5_TCFIFO                             UART_TCFIFO_REG(UART5)
+#define UART5_RWFIFO                             UART_RWFIFO_REG(UART5)
+#define UART5_RCFIFO                             UART_RCFIFO_REG(UART5)
+
+/*!
+ * @}
+ */ /* end of group UART_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group UART_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- USB Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup USB_Peripheral_Access_Layer USB Peripheral Access Layer
+ * @{
+ */
+
+/** USB - Register Layout Typedef */
+typedef struct {
+  __I  uint8_t PERID;                              /**< Peripheral ID register, offset: 0x0 */
+       uint8_t RESERVED_0[3];
+  __I  uint8_t IDCOMP;                             /**< Peripheral ID Complement register, offset: 0x4 */
+       uint8_t RESERVED_1[3];
+  __I  uint8_t REV;                                /**< Peripheral Revision register, offset: 0x8 */
+       uint8_t RESERVED_2[3];
+  __I  uint8_t ADDINFO;                            /**< Peripheral Additional Info register, offset: 0xC */
+       uint8_t RESERVED_3[3];
+  __IO uint8_t OTGISTAT;                           /**< OTG Interrupt Status register, offset: 0x10 */
+       uint8_t RESERVED_4[3];
+  __IO uint8_t OTGICR;                             /**< OTG Interrupt Control register, offset: 0x14 */
+       uint8_t RESERVED_5[3];
+  __IO uint8_t OTGSTAT;                            /**< OTG Status register, offset: 0x18 */
+       uint8_t RESERVED_6[3];
+  __IO uint8_t OTGCTL;                             /**< OTG Control register, offset: 0x1C */
+       uint8_t RESERVED_7[99];
+  __IO uint8_t ISTAT;                              /**< Interrupt Status register, offset: 0x80 */
+       uint8_t RESERVED_8[3];
+  __IO uint8_t INTEN;                              /**< Interrupt Enable register, offset: 0x84 */
+       uint8_t RESERVED_9[3];
+  __IO uint8_t ERRSTAT;                            /**< Error Interrupt Status register, offset: 0x88 */
+       uint8_t RESERVED_10[3];
+  __IO uint8_t ERREN;                              /**< Error Interrupt Enable register, offset: 0x8C */
+       uint8_t RESERVED_11[3];
+  __I  uint8_t STAT;                               /**< Status register, offset: 0x90 */
+       uint8_t RESERVED_12[3];
+  __IO uint8_t CTL;                                /**< Control register, offset: 0x94 */
+       uint8_t RESERVED_13[3];
+  __IO uint8_t ADDR;                               /**< Address register, offset: 0x98 */
+       uint8_t RESERVED_14[3];
+  __IO uint8_t BDTPAGE1;                           /**< BDT Page register 1, offset: 0x9C */
+       uint8_t RESERVED_15[3];
+  __IO uint8_t FRMNUML;                            /**< Frame Number register Low, offset: 0xA0 */
+       uint8_t RESERVED_16[3];
+  __IO uint8_t FRMNUMH;                            /**< Frame Number register High, offset: 0xA4 */
+       uint8_t RESERVED_17[3];
+  __IO uint8_t TOKEN;                              /**< Token register, offset: 0xA8 */
+       uint8_t RESERVED_18[3];
+  __IO uint8_t SOFTHLD;                            /**< SOF Threshold register, offset: 0xAC */
+       uint8_t RESERVED_19[3];
+  __IO uint8_t BDTPAGE2;                           /**< BDT Page Register 2, offset: 0xB0 */
+       uint8_t RESERVED_20[3];
+  __IO uint8_t BDTPAGE3;                           /**< BDT Page Register 3, offset: 0xB4 */
+       uint8_t RESERVED_21[11];
+  struct {                                         /* offset: 0xC0, array step: 0x4 */
+    __IO uint8_t ENDPT;                              /**< Endpoint Control register, array offset: 0xC0, array step: 0x4 */
+         uint8_t RESERVED_0[3];
+  } ENDPOINT[16];
+  __IO uint8_t USBCTRL;                            /**< USB Control register, offset: 0x100 */
+       uint8_t RESERVED_22[3];
+  __I  uint8_t OBSERVE;                            /**< USB OTG Observe register, offset: 0x104 */
+       uint8_t RESERVED_23[3];
+  __IO uint8_t CONTROL;                            /**< USB OTG Control register, offset: 0x108 */
+       uint8_t RESERVED_24[3];
+  __IO uint8_t USBTRC0;                            /**< USB Transceiver Control register 0, offset: 0x10C */
+       uint8_t RESERVED_25[7];
+  __IO uint8_t USBFRMADJUST;                       /**< Frame Adjust Register, offset: 0x114 */
+       uint8_t RESERVED_26[43];
+  __IO uint8_t CLK_RECOVER_CTRL;                   /**< USB Clock recovery control, offset: 0x140 */
+       uint8_t RESERVED_27[3];
+  __IO uint8_t CLK_RECOVER_IRC_EN;                 /**< IRC48M oscillator enable register, offset: 0x144 */
+       uint8_t RESERVED_28[23];
+  __IO uint8_t CLK_RECOVER_INT_STATUS;             /**< Clock recovery separated interrupt status, offset: 0x15C */
+} USB_Type, *USB_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- USB - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup USB_Register_Accessor_Macros USB - Register accessor macros
+ * @{
+ */
+
+
+/* USB - Register accessors */
+#define USB_PERID_REG(base)                      ((base)->PERID)
+#define USB_IDCOMP_REG(base)                     ((base)->IDCOMP)
+#define USB_REV_REG(base)                        ((base)->REV)
+#define USB_ADDINFO_REG(base)                    ((base)->ADDINFO)
+#define USB_OTGISTAT_REG(base)                   ((base)->OTGISTAT)
+#define USB_OTGICR_REG(base)                     ((base)->OTGICR)
+#define USB_OTGSTAT_REG(base)                    ((base)->OTGSTAT)
+#define USB_OTGCTL_REG(base)                     ((base)->OTGCTL)
+#define USB_ISTAT_REG(base)                      ((base)->ISTAT)
+#define USB_INTEN_REG(base)                      ((base)->INTEN)
+#define USB_ERRSTAT_REG(base)                    ((base)->ERRSTAT)
+#define USB_ERREN_REG(base)                      ((base)->ERREN)
+#define USB_STAT_REG(base)                       ((base)->STAT)
+#define USB_CTL_REG(base)                        ((base)->CTL)
+#define USB_ADDR_REG(base)                       ((base)->ADDR)
+#define USB_BDTPAGE1_REG(base)                   ((base)->BDTPAGE1)
+#define USB_FRMNUML_REG(base)                    ((base)->FRMNUML)
+#define USB_FRMNUMH_REG(base)                    ((base)->FRMNUMH)
+#define USB_TOKEN_REG(base)                      ((base)->TOKEN)
+#define USB_SOFTHLD_REG(base)                    ((base)->SOFTHLD)
+#define USB_BDTPAGE2_REG(base)                   ((base)->BDTPAGE2)
+#define USB_BDTPAGE3_REG(base)                   ((base)->BDTPAGE3)
+#define USB_ENDPT_REG(base,index)                ((base)->ENDPOINT[index].ENDPT)
+#define USB_USBCTRL_REG(base)                    ((base)->USBCTRL)
+#define USB_OBSERVE_REG(base)                    ((base)->OBSERVE)
+#define USB_CONTROL_REG(base)                    ((base)->CONTROL)
+#define USB_USBTRC0_REG(base)                    ((base)->USBTRC0)
+#define USB_USBFRMADJUST_REG(base)               ((base)->USBFRMADJUST)
+#define USB_CLK_RECOVER_CTRL_REG(base)           ((base)->CLK_RECOVER_CTRL)
+#define USB_CLK_RECOVER_IRC_EN_REG(base)         ((base)->CLK_RECOVER_IRC_EN)
+#define USB_CLK_RECOVER_INT_STATUS_REG(base)     ((base)->CLK_RECOVER_INT_STATUS)
+
+/*!
+ * @}
+ */ /* end of group USB_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- USB Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup USB_Register_Masks USB Register Masks
+ * @{
+ */
+
+/* PERID Bit Fields */
+#define USB_PERID_ID_MASK                        0x3Fu
+#define USB_PERID_ID_SHIFT                       0
+#define USB_PERID_ID(x)                          (((uint8_t)(((uint8_t)(x))<<USB_PERID_ID_SHIFT))&USB_PERID_ID_MASK)
+/* IDCOMP Bit Fields */
+#define USB_IDCOMP_NID_MASK                      0x3Fu
+#define USB_IDCOMP_NID_SHIFT                     0
+#define USB_IDCOMP_NID(x)                        (((uint8_t)(((uint8_t)(x))<<USB_IDCOMP_NID_SHIFT))&USB_IDCOMP_NID_MASK)
+/* REV Bit Fields */
+#define USB_REV_REV_MASK                         0xFFu
+#define USB_REV_REV_SHIFT                        0
+#define USB_REV_REV(x)                           (((uint8_t)(((uint8_t)(x))<<USB_REV_REV_SHIFT))&USB_REV_REV_MASK)
+/* ADDINFO Bit Fields */
+#define USB_ADDINFO_IEHOST_MASK                  0x1u
+#define USB_ADDINFO_IEHOST_SHIFT                 0
+#define USB_ADDINFO_IRQNUM_MASK                  0xF8u
+#define USB_ADDINFO_IRQNUM_SHIFT                 3
+#define USB_ADDINFO_IRQNUM(x)                    (((uint8_t)(((uint8_t)(x))<<USB_ADDINFO_IRQNUM_SHIFT))&USB_ADDINFO_IRQNUM_MASK)
+/* OTGISTAT Bit Fields */
+#define USB_OTGISTAT_AVBUSCHG_MASK               0x1u
+#define USB_OTGISTAT_AVBUSCHG_SHIFT              0
+#define USB_OTGISTAT_B_SESS_CHG_MASK             0x4u
+#define USB_OTGISTAT_B_SESS_CHG_SHIFT            2
+#define USB_OTGISTAT_SESSVLDCHG_MASK             0x8u
+#define USB_OTGISTAT_SESSVLDCHG_SHIFT            3
+#define USB_OTGISTAT_LINE_STATE_CHG_MASK         0x20u
+#define USB_OTGISTAT_LINE_STATE_CHG_SHIFT        5
+#define USB_OTGISTAT_ONEMSEC_MASK                0x40u
+#define USB_OTGISTAT_ONEMSEC_SHIFT               6
+#define USB_OTGISTAT_IDCHG_MASK                  0x80u
+#define USB_OTGISTAT_IDCHG_SHIFT                 7
+/* OTGICR Bit Fields */
+#define USB_OTGICR_AVBUSEN_MASK                  0x1u
+#define USB_OTGICR_AVBUSEN_SHIFT                 0
+#define USB_OTGICR_BSESSEN_MASK                  0x4u
+#define USB_OTGICR_BSESSEN_SHIFT                 2
+#define USB_OTGICR_SESSVLDEN_MASK                0x8u
+#define USB_OTGICR_SESSVLDEN_SHIFT               3
+#define USB_OTGICR_LINESTATEEN_MASK              0x20u
+#define USB_OTGICR_LINESTATEEN_SHIFT             5
+#define USB_OTGICR_ONEMSECEN_MASK                0x40u
+#define USB_OTGICR_ONEMSECEN_SHIFT               6
+#define USB_OTGICR_IDEN_MASK                     0x80u
+#define USB_OTGICR_IDEN_SHIFT                    7
+/* OTGSTAT Bit Fields */
+#define USB_OTGSTAT_AVBUSVLD_MASK                0x1u
+#define USB_OTGSTAT_AVBUSVLD_SHIFT               0
+#define USB_OTGSTAT_BSESSEND_MASK                0x4u
+#define USB_OTGSTAT_BSESSEND_SHIFT               2
+#define USB_OTGSTAT_SESS_VLD_MASK                0x8u
+#define USB_OTGSTAT_SESS_VLD_SHIFT               3
+#define USB_OTGSTAT_LINESTATESTABLE_MASK         0x20u
+#define USB_OTGSTAT_LINESTATESTABLE_SHIFT        5
+#define USB_OTGSTAT_ONEMSECEN_MASK               0x40u
+#define USB_OTGSTAT_ONEMSECEN_SHIFT              6
+#define USB_OTGSTAT_ID_MASK                      0x80u
+#define USB_OTGSTAT_ID_SHIFT                     7
+/* OTGCTL Bit Fields */
+#define USB_OTGCTL_OTGEN_MASK                    0x4u
+#define USB_OTGCTL_OTGEN_SHIFT                   2
+#define USB_OTGCTL_DMLOW_MASK                    0x10u
+#define USB_OTGCTL_DMLOW_SHIFT                   4
+#define USB_OTGCTL_DPLOW_MASK                    0x20u
+#define USB_OTGCTL_DPLOW_SHIFT                   5
+#define USB_OTGCTL_DPHIGH_MASK                   0x80u
+#define USB_OTGCTL_DPHIGH_SHIFT                  7
+/* ISTAT Bit Fields */
+#define USB_ISTAT_USBRST_MASK                    0x1u
+#define USB_ISTAT_USBRST_SHIFT                   0
+#define USB_ISTAT_ERROR_MASK                     0x2u
+#define USB_ISTAT_ERROR_SHIFT                    1
+#define USB_ISTAT_SOFTOK_MASK                    0x4u
+#define USB_ISTAT_SOFTOK_SHIFT                   2
+#define USB_ISTAT_TOKDNE_MASK                    0x8u
+#define USB_ISTAT_TOKDNE_SHIFT                   3
+#define USB_ISTAT_SLEEP_MASK                     0x10u
+#define USB_ISTAT_SLEEP_SHIFT                    4
+#define USB_ISTAT_RESUME_MASK                    0x20u
+#define USB_ISTAT_RESUME_SHIFT                   5
+#define USB_ISTAT_ATTACH_MASK                    0x40u
+#define USB_ISTAT_ATTACH_SHIFT                   6
+#define USB_ISTAT_STALL_MASK                     0x80u
+#define USB_ISTAT_STALL_SHIFT                    7
+/* INTEN Bit Fields */
+#define USB_INTEN_USBRSTEN_MASK                  0x1u
+#define USB_INTEN_USBRSTEN_SHIFT                 0
+#define USB_INTEN_ERROREN_MASK                   0x2u
+#define USB_INTEN_ERROREN_SHIFT                  1
+#define USB_INTEN_SOFTOKEN_MASK                  0x4u
+#define USB_INTEN_SOFTOKEN_SHIFT                 2
+#define USB_INTEN_TOKDNEEN_MASK                  0x8u
+#define USB_INTEN_TOKDNEEN_SHIFT                 3
+#define USB_INTEN_SLEEPEN_MASK                   0x10u
+#define USB_INTEN_SLEEPEN_SHIFT                  4
+#define USB_INTEN_RESUMEEN_MASK                  0x20u
+#define USB_INTEN_RESUMEEN_SHIFT                 5
+#define USB_INTEN_ATTACHEN_MASK                  0x40u
+#define USB_INTEN_ATTACHEN_SHIFT                 6
+#define USB_INTEN_STALLEN_MASK                   0x80u
+#define USB_INTEN_STALLEN_SHIFT                  7
+/* ERRSTAT Bit Fields */
+#define USB_ERRSTAT_PIDERR_MASK                  0x1u
+#define USB_ERRSTAT_PIDERR_SHIFT                 0
+#define USB_ERRSTAT_CRC5EOF_MASK                 0x2u
+#define USB_ERRSTAT_CRC5EOF_SHIFT                1
+#define USB_ERRSTAT_CRC16_MASK                   0x4u
+#define USB_ERRSTAT_CRC16_SHIFT                  2
+#define USB_ERRSTAT_DFN8_MASK                    0x8u
+#define USB_ERRSTAT_DFN8_SHIFT                   3
+#define USB_ERRSTAT_BTOERR_MASK                  0x10u
+#define USB_ERRSTAT_BTOERR_SHIFT                 4
+#define USB_ERRSTAT_DMAERR_MASK                  0x20u
+#define USB_ERRSTAT_DMAERR_SHIFT                 5
+#define USB_ERRSTAT_BTSERR_MASK                  0x80u
+#define USB_ERRSTAT_BTSERR_SHIFT                 7
+/* ERREN Bit Fields */
+#define USB_ERREN_PIDERREN_MASK                  0x1u
+#define USB_ERREN_PIDERREN_SHIFT                 0
+#define USB_ERREN_CRC5EOFEN_MASK                 0x2u
+#define USB_ERREN_CRC5EOFEN_SHIFT                1
+#define USB_ERREN_CRC16EN_MASK                   0x4u
+#define USB_ERREN_CRC16EN_SHIFT                  2
+#define USB_ERREN_DFN8EN_MASK                    0x8u
+#define USB_ERREN_DFN8EN_SHIFT                   3
+#define USB_ERREN_BTOERREN_MASK                  0x10u
+#define USB_ERREN_BTOERREN_SHIFT                 4
+#define USB_ERREN_DMAERREN_MASK                  0x20u
+#define USB_ERREN_DMAERREN_SHIFT                 5
+#define USB_ERREN_BTSERREN_MASK                  0x80u
+#define USB_ERREN_BTSERREN_SHIFT                 7
+/* STAT Bit Fields */
+#define USB_STAT_ODD_MASK                        0x4u
+#define USB_STAT_ODD_SHIFT                       2
+#define USB_STAT_TX_MASK                         0x8u
+#define USB_STAT_TX_SHIFT                        3
+#define USB_STAT_ENDP_MASK                       0xF0u
+#define USB_STAT_ENDP_SHIFT                      4
+#define USB_STAT_ENDP(x)                         (((uint8_t)(((uint8_t)(x))<<USB_STAT_ENDP_SHIFT))&USB_STAT_ENDP_MASK)
+/* CTL Bit Fields */
+#define USB_CTL_USBENSOFEN_MASK                  0x1u
+#define USB_CTL_USBENSOFEN_SHIFT                 0
+#define USB_CTL_ODDRST_MASK                      0x2u
+#define USB_CTL_ODDRST_SHIFT                     1
+#define USB_CTL_RESUME_MASK                      0x4u
+#define USB_CTL_RESUME_SHIFT                     2
+#define USB_CTL_HOSTMODEEN_MASK                  0x8u
+#define USB_CTL_HOSTMODEEN_SHIFT                 3
+#define USB_CTL_RESET_MASK                       0x10u
+#define USB_CTL_RESET_SHIFT                      4
+#define USB_CTL_TXSUSPENDTOKENBUSY_MASK          0x20u
+#define USB_CTL_TXSUSPENDTOKENBUSY_SHIFT         5
+#define USB_CTL_SE0_MASK                         0x40u
+#define USB_CTL_SE0_SHIFT                        6
+#define USB_CTL_JSTATE_MASK                      0x80u
+#define USB_CTL_JSTATE_SHIFT                     7
+/* ADDR Bit Fields */
+#define USB_ADDR_ADDR_MASK                       0x7Fu
+#define USB_ADDR_ADDR_SHIFT                      0
+#define USB_ADDR_ADDR(x)                         (((uint8_t)(((uint8_t)(x))<<USB_ADDR_ADDR_SHIFT))&USB_ADDR_ADDR_MASK)
+#define USB_ADDR_LSEN_MASK                       0x80u
+#define USB_ADDR_LSEN_SHIFT                      7
+/* BDTPAGE1 Bit Fields */
+#define USB_BDTPAGE1_BDTBA_MASK                  0xFEu
+#define USB_BDTPAGE1_BDTBA_SHIFT                 1
+#define USB_BDTPAGE1_BDTBA(x)                    (((uint8_t)(((uint8_t)(x))<<USB_BDTPAGE1_BDTBA_SHIFT))&USB_BDTPAGE1_BDTBA_MASK)
+/* FRMNUML Bit Fields */
+#define USB_FRMNUML_FRM_MASK                     0xFFu
+#define USB_FRMNUML_FRM_SHIFT                    0
+#define USB_FRMNUML_FRM(x)                       (((uint8_t)(((uint8_t)(x))<<USB_FRMNUML_FRM_SHIFT))&USB_FRMNUML_FRM_MASK)
+/* FRMNUMH Bit Fields */
+#define USB_FRMNUMH_FRM_MASK                     0x7u
+#define USB_FRMNUMH_FRM_SHIFT                    0
+#define USB_FRMNUMH_FRM(x)                       (((uint8_t)(((uint8_t)(x))<<USB_FRMNUMH_FRM_SHIFT))&USB_FRMNUMH_FRM_MASK)
+/* TOKEN Bit Fields */
+#define USB_TOKEN_TOKENENDPT_MASK                0xFu
+#define USB_TOKEN_TOKENENDPT_SHIFT               0
+#define USB_TOKEN_TOKENENDPT(x)                  (((uint8_t)(((uint8_t)(x))<<USB_TOKEN_TOKENENDPT_SHIFT))&USB_TOKEN_TOKENENDPT_MASK)
+#define USB_TOKEN_TOKENPID_MASK                  0xF0u
+#define USB_TOKEN_TOKENPID_SHIFT                 4
+#define USB_TOKEN_TOKENPID(x)                    (((uint8_t)(((uint8_t)(x))<<USB_TOKEN_TOKENPID_SHIFT))&USB_TOKEN_TOKENPID_MASK)
+/* SOFTHLD Bit Fields */
+#define USB_SOFTHLD_CNT_MASK                     0xFFu
+#define USB_SOFTHLD_CNT_SHIFT                    0
+#define USB_SOFTHLD_CNT(x)                       (((uint8_t)(((uint8_t)(x))<<USB_SOFTHLD_CNT_SHIFT))&USB_SOFTHLD_CNT_MASK)
+/* BDTPAGE2 Bit Fields */
+#define USB_BDTPAGE2_BDTBA_MASK                  0xFFu
+#define USB_BDTPAGE2_BDTBA_SHIFT                 0
+#define USB_BDTPAGE2_BDTBA(x)                    (((uint8_t)(((uint8_t)(x))<<USB_BDTPAGE2_BDTBA_SHIFT))&USB_BDTPAGE2_BDTBA_MASK)
+/* BDTPAGE3 Bit Fields */
+#define USB_BDTPAGE3_BDTBA_MASK                  0xFFu
+#define USB_BDTPAGE3_BDTBA_SHIFT                 0
+#define USB_BDTPAGE3_BDTBA(x)                    (((uint8_t)(((uint8_t)(x))<<USB_BDTPAGE3_BDTBA_SHIFT))&USB_BDTPAGE3_BDTBA_MASK)
+/* ENDPT Bit Fields */
+#define USB_ENDPT_EPHSHK_MASK                    0x1u
+#define USB_ENDPT_EPHSHK_SHIFT                   0
+#define USB_ENDPT_EPSTALL_MASK                   0x2u
+#define USB_ENDPT_EPSTALL_SHIFT                  1
+#define USB_ENDPT_EPTXEN_MASK                    0x4u
+#define USB_ENDPT_EPTXEN_SHIFT                   2
+#define USB_ENDPT_EPRXEN_MASK                    0x8u
+#define USB_ENDPT_EPRXEN_SHIFT                   3
+#define USB_ENDPT_EPCTLDIS_MASK                  0x10u
+#define USB_ENDPT_EPCTLDIS_SHIFT                 4
+#define USB_ENDPT_RETRYDIS_MASK                  0x40u
+#define USB_ENDPT_RETRYDIS_SHIFT                 6
+#define USB_ENDPT_HOSTWOHUB_MASK                 0x80u
+#define USB_ENDPT_HOSTWOHUB_SHIFT                7
+/* USBCTRL Bit Fields */
+#define USB_USBCTRL_PDE_MASK                     0x40u
+#define USB_USBCTRL_PDE_SHIFT                    6
+#define USB_USBCTRL_SUSP_MASK                    0x80u
+#define USB_USBCTRL_SUSP_SHIFT                   7
+/* OBSERVE Bit Fields */
+#define USB_OBSERVE_DMPD_MASK                    0x10u
+#define USB_OBSERVE_DMPD_SHIFT                   4
+#define USB_OBSERVE_DPPD_MASK                    0x40u
+#define USB_OBSERVE_DPPD_SHIFT                   6
+#define USB_OBSERVE_DPPU_MASK                    0x80u
+#define USB_OBSERVE_DPPU_SHIFT                   7
+/* CONTROL Bit Fields */
+#define USB_CONTROL_DPPULLUPNONOTG_MASK          0x10u
+#define USB_CONTROL_DPPULLUPNONOTG_SHIFT         4
+/* USBTRC0 Bit Fields */
+#define USB_USBTRC0_USB_RESUME_INT_MASK          0x1u
+#define USB_USBTRC0_USB_RESUME_INT_SHIFT         0
+#define USB_USBTRC0_SYNC_DET_MASK                0x2u
+#define USB_USBTRC0_SYNC_DET_SHIFT               1
+#define USB_USBTRC0_USB_CLK_RECOVERY_INT_MASK    0x4u
+#define USB_USBTRC0_USB_CLK_RECOVERY_INT_SHIFT   2
+#define USB_USBTRC0_USBRESMEN_MASK               0x20u
+#define USB_USBTRC0_USBRESMEN_SHIFT              5
+#define USB_USBTRC0_USBRESET_MASK                0x80u
+#define USB_USBTRC0_USBRESET_SHIFT               7
+/* USBFRMADJUST Bit Fields */
+#define USB_USBFRMADJUST_ADJ_MASK                0xFFu
+#define USB_USBFRMADJUST_ADJ_SHIFT               0
+#define USB_USBFRMADJUST_ADJ(x)                  (((uint8_t)(((uint8_t)(x))<<USB_USBFRMADJUST_ADJ_SHIFT))&USB_USBFRMADJUST_ADJ_MASK)
+/* CLK_RECOVER_CTRL Bit Fields */
+#define USB_CLK_RECOVER_CTRL_RESTART_IFRTRIM_EN_MASK 0x20u
+#define USB_CLK_RECOVER_CTRL_RESTART_IFRTRIM_EN_SHIFT 5
+#define USB_CLK_RECOVER_CTRL_RESET_RESUME_ROUGH_EN_MASK 0x40u
+#define USB_CLK_RECOVER_CTRL_RESET_RESUME_ROUGH_EN_SHIFT 6
+#define USB_CLK_RECOVER_CTRL_CLOCK_RECOVER_EN_MASK 0x80u
+#define USB_CLK_RECOVER_CTRL_CLOCK_RECOVER_EN_SHIFT 7
+/* CLK_RECOVER_IRC_EN Bit Fields */
+#define USB_CLK_RECOVER_IRC_EN_REG_EN_MASK       0x1u
+#define USB_CLK_RECOVER_IRC_EN_REG_EN_SHIFT      0
+#define USB_CLK_RECOVER_IRC_EN_IRC_EN_MASK       0x2u
+#define USB_CLK_RECOVER_IRC_EN_IRC_EN_SHIFT      1
+/* CLK_RECOVER_INT_STATUS Bit Fields */
+#define USB_CLK_RECOVER_INT_STATUS_OVF_ERROR_MASK 0x10u
+#define USB_CLK_RECOVER_INT_STATUS_OVF_ERROR_SHIFT 4
+
+/*!
+ * @}
+ */ /* end of group USB_Register_Masks */
+
+
+/* USB - Peripheral instance base addresses */
+/** Peripheral USB0 base address */
+#define USB0_BASE                                (0x40072000u)
+/** Peripheral USB0 base pointer */
+#define USB0                                     ((USB_Type *)USB0_BASE)
+#define USB0_BASE_PTR                            (USB0)
+/** Array initializer of USB peripheral base addresses */
+#define USB_BASE_ADDRS                           { USB0_BASE }
+/** Array initializer of USB peripheral base pointers */
+#define USB_BASE_PTRS                            { USB0 }
+/** Interrupt vectors for the USB peripheral type */
+#define USB_IRQS                                 { USB0_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- USB - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup USB_Register_Accessor_Macros USB - Register accessor macros
+ * @{
+ */
+
+
+/* USB - Register instance definitions */
+/* USB0 */
+#define USB0_PERID                               USB_PERID_REG(USB0)
+#define USB0_IDCOMP                              USB_IDCOMP_REG(USB0)
+#define USB0_REV                                 USB_REV_REG(USB0)
+#define USB0_ADDINFO                             USB_ADDINFO_REG(USB0)
+#define USB0_OTGISTAT                            USB_OTGISTAT_REG(USB0)
+#define USB0_OTGICR                              USB_OTGICR_REG(USB0)
+#define USB0_OTGSTAT                             USB_OTGSTAT_REG(USB0)
+#define USB0_OTGCTL                              USB_OTGCTL_REG(USB0)
+#define USB0_ISTAT                               USB_ISTAT_REG(USB0)
+#define USB0_INTEN                               USB_INTEN_REG(USB0)
+#define USB0_ERRSTAT                             USB_ERRSTAT_REG(USB0)
+#define USB0_ERREN                               USB_ERREN_REG(USB0)
+#define USB0_STAT                                USB_STAT_REG(USB0)
+#define USB0_CTL                                 USB_CTL_REG(USB0)
+#define USB0_ADDR                                USB_ADDR_REG(USB0)
+#define USB0_BDTPAGE1                            USB_BDTPAGE1_REG(USB0)
+#define USB0_FRMNUML                             USB_FRMNUML_REG(USB0)
+#define USB0_FRMNUMH                             USB_FRMNUMH_REG(USB0)
+#define USB0_TOKEN                               USB_TOKEN_REG(USB0)
+#define USB0_SOFTHLD                             USB_SOFTHLD_REG(USB0)
+#define USB0_BDTPAGE2                            USB_BDTPAGE2_REG(USB0)
+#define USB0_BDTPAGE3                            USB_BDTPAGE3_REG(USB0)
+#define USB0_ENDPT0                              USB_ENDPT_REG(USB0,0)
+#define USB0_ENDPT1                              USB_ENDPT_REG(USB0,1)
+#define USB0_ENDPT2                              USB_ENDPT_REG(USB0,2)
+#define USB0_ENDPT3                              USB_ENDPT_REG(USB0,3)
+#define USB0_ENDPT4                              USB_ENDPT_REG(USB0,4)
+#define USB0_ENDPT5                              USB_ENDPT_REG(USB0,5)
+#define USB0_ENDPT6                              USB_ENDPT_REG(USB0,6)
+#define USB0_ENDPT7                              USB_ENDPT_REG(USB0,7)
+#define USB0_ENDPT8                              USB_ENDPT_REG(USB0,8)
+#define USB0_ENDPT9                              USB_ENDPT_REG(USB0,9)
+#define USB0_ENDPT10                             USB_ENDPT_REG(USB0,10)
+#define USB0_ENDPT11                             USB_ENDPT_REG(USB0,11)
+#define USB0_ENDPT12                             USB_ENDPT_REG(USB0,12)
+#define USB0_ENDPT13                             USB_ENDPT_REG(USB0,13)
+#define USB0_ENDPT14                             USB_ENDPT_REG(USB0,14)
+#define USB0_ENDPT15                             USB_ENDPT_REG(USB0,15)
+#define USB0_USBCTRL                             USB_USBCTRL_REG(USB0)
+#define USB0_OBSERVE                             USB_OBSERVE_REG(USB0)
+#define USB0_CONTROL                             USB_CONTROL_REG(USB0)
+#define USB0_USBTRC0                             USB_USBTRC0_REG(USB0)
+#define USB0_USBFRMADJUST                        USB_USBFRMADJUST_REG(USB0)
+#define USB0_CLK_RECOVER_CTRL                    USB_CLK_RECOVER_CTRL_REG(USB0)
+#define USB0_CLK_RECOVER_IRC_EN                  USB_CLK_RECOVER_IRC_EN_REG(USB0)
+#define USB0_CLK_RECOVER_INT_STATUS              USB_CLK_RECOVER_INT_STATUS_REG(USB0)
+
+/* USB - Register array accessors */
+#define USB0_ENDPT(index)                        USB_ENDPT_REG(USB0,index)
+
+/*!
+ * @}
+ */ /* end of group USB_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group USB_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- USBDCD Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup USBDCD_Peripheral_Access_Layer USBDCD Peripheral Access Layer
+ * @{
+ */
+
+/** USBDCD - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t CONTROL;                           /**< Control register, offset: 0x0 */
+  __IO uint32_t CLOCK;                             /**< Clock register, offset: 0x4 */
+  __I  uint32_t STATUS;                            /**< Status register, offset: 0x8 */
+       uint8_t RESERVED_0[4];
+  __IO uint32_t TIMER0;                            /**< TIMER0 register, offset: 0x10 */
+  __IO uint32_t TIMER1;                            /**< TIMER1 register, offset: 0x14 */
+  union {                                          /* offset: 0x18 */
+    __IO uint32_t TIMER2_BC11;                       /**< TIMER2_BC11 register, offset: 0x18 */
+    __IO uint32_t TIMER2_BC12;                       /**< TIMER2_BC12 register, offset: 0x18 */
+  };
+} USBDCD_Type, *USBDCD_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- USBDCD - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup USBDCD_Register_Accessor_Macros USBDCD - Register accessor macros
+ * @{
+ */
+
+
+/* USBDCD - Register accessors */
+#define USBDCD_CONTROL_REG(base)                 ((base)->CONTROL)
+#define USBDCD_CLOCK_REG(base)                   ((base)->CLOCK)
+#define USBDCD_STATUS_REG(base)                  ((base)->STATUS)
+#define USBDCD_TIMER0_REG(base)                  ((base)->TIMER0)
+#define USBDCD_TIMER1_REG(base)                  ((base)->TIMER1)
+#define USBDCD_TIMER2_BC11_REG(base)             ((base)->TIMER2_BC11)
+#define USBDCD_TIMER2_BC12_REG(base)             ((base)->TIMER2_BC12)
+
+/*!
+ * @}
+ */ /* end of group USBDCD_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- USBDCD Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup USBDCD_Register_Masks USBDCD Register Masks
+ * @{
+ */
+
+/* CONTROL Bit Fields */
+#define USBDCD_CONTROL_IACK_MASK                 0x1u
+#define USBDCD_CONTROL_IACK_SHIFT                0
+#define USBDCD_CONTROL_IF_MASK                   0x100u
+#define USBDCD_CONTROL_IF_SHIFT                  8
+#define USBDCD_CONTROL_IE_MASK                   0x10000u
+#define USBDCD_CONTROL_IE_SHIFT                  16
+#define USBDCD_CONTROL_BC12_MASK                 0x20000u
+#define USBDCD_CONTROL_BC12_SHIFT                17
+#define USBDCD_CONTROL_START_MASK                0x1000000u
+#define USBDCD_CONTROL_START_SHIFT               24
+#define USBDCD_CONTROL_SR_MASK                   0x2000000u
+#define USBDCD_CONTROL_SR_SHIFT                  25
+/* CLOCK Bit Fields */
+#define USBDCD_CLOCK_CLOCK_UNIT_MASK             0x1u
+#define USBDCD_CLOCK_CLOCK_UNIT_SHIFT            0
+#define USBDCD_CLOCK_CLOCK_SPEED_MASK            0xFFCu
+#define USBDCD_CLOCK_CLOCK_SPEED_SHIFT           2
+#define USBDCD_CLOCK_CLOCK_SPEED(x)              (((uint32_t)(((uint32_t)(x))<<USBDCD_CLOCK_CLOCK_SPEED_SHIFT))&USBDCD_CLOCK_CLOCK_SPEED_MASK)
+/* STATUS Bit Fields */
+#define USBDCD_STATUS_SEQ_RES_MASK               0x30000u
+#define USBDCD_STATUS_SEQ_RES_SHIFT              16
+#define USBDCD_STATUS_SEQ_RES(x)                 (((uint32_t)(((uint32_t)(x))<<USBDCD_STATUS_SEQ_RES_SHIFT))&USBDCD_STATUS_SEQ_RES_MASK)
+#define USBDCD_STATUS_SEQ_STAT_MASK              0xC0000u
+#define USBDCD_STATUS_SEQ_STAT_SHIFT             18
+#define USBDCD_STATUS_SEQ_STAT(x)                (((uint32_t)(((uint32_t)(x))<<USBDCD_STATUS_SEQ_STAT_SHIFT))&USBDCD_STATUS_SEQ_STAT_MASK)
+#define USBDCD_STATUS_ERR_MASK                   0x100000u
+#define USBDCD_STATUS_ERR_SHIFT                  20
+#define USBDCD_STATUS_TO_MASK                    0x200000u
+#define USBDCD_STATUS_TO_SHIFT                   21
+#define USBDCD_STATUS_ACTIVE_MASK                0x400000u
+#define USBDCD_STATUS_ACTIVE_SHIFT               22
+/* TIMER0 Bit Fields */
+#define USBDCD_TIMER0_TUNITCON_MASK              0xFFFu
+#define USBDCD_TIMER0_TUNITCON_SHIFT             0
+#define USBDCD_TIMER0_TUNITCON(x)                (((uint32_t)(((uint32_t)(x))<<USBDCD_TIMER0_TUNITCON_SHIFT))&USBDCD_TIMER0_TUNITCON_MASK)
+#define USBDCD_TIMER0_TSEQ_INIT_MASK             0x3FF0000u
+#define USBDCD_TIMER0_TSEQ_INIT_SHIFT            16
+#define USBDCD_TIMER0_TSEQ_INIT(x)               (((uint32_t)(((uint32_t)(x))<<USBDCD_TIMER0_TSEQ_INIT_SHIFT))&USBDCD_TIMER0_TSEQ_INIT_MASK)
+/* TIMER1 Bit Fields */
+#define USBDCD_TIMER1_TVDPSRC_ON_MASK            0x3FFu
+#define USBDCD_TIMER1_TVDPSRC_ON_SHIFT           0
+#define USBDCD_TIMER1_TVDPSRC_ON(x)              (((uint32_t)(((uint32_t)(x))<<USBDCD_TIMER1_TVDPSRC_ON_SHIFT))&USBDCD_TIMER1_TVDPSRC_ON_MASK)
+#define USBDCD_TIMER1_TDCD_DBNC_MASK             0x3FF0000u
+#define USBDCD_TIMER1_TDCD_DBNC_SHIFT            16
+#define USBDCD_TIMER1_TDCD_DBNC(x)               (((uint32_t)(((uint32_t)(x))<<USBDCD_TIMER1_TDCD_DBNC_SHIFT))&USBDCD_TIMER1_TDCD_DBNC_MASK)
+/* TIMER2_BC11 Bit Fields */
+#define USBDCD_TIMER2_BC11_CHECK_DM_MASK         0xFu
+#define USBDCD_TIMER2_BC11_CHECK_DM_SHIFT        0
+#define USBDCD_TIMER2_BC11_CHECK_DM(x)           (((uint32_t)(((uint32_t)(x))<<USBDCD_TIMER2_BC11_CHECK_DM_SHIFT))&USBDCD_TIMER2_BC11_CHECK_DM_MASK)
+#define USBDCD_TIMER2_BC11_TVDPSRC_CON_MASK      0x3FF0000u
+#define USBDCD_TIMER2_BC11_TVDPSRC_CON_SHIFT     16
+#define USBDCD_TIMER2_BC11_TVDPSRC_CON(x)        (((uint32_t)(((uint32_t)(x))<<USBDCD_TIMER2_BC11_TVDPSRC_CON_SHIFT))&USBDCD_TIMER2_BC11_TVDPSRC_CON_MASK)
+/* TIMER2_BC12 Bit Fields */
+#define USBDCD_TIMER2_BC12_TVDMSRC_ON_MASK       0x3FFu
+#define USBDCD_TIMER2_BC12_TVDMSRC_ON_SHIFT      0
+#define USBDCD_TIMER2_BC12_TVDMSRC_ON(x)         (((uint32_t)(((uint32_t)(x))<<USBDCD_TIMER2_BC12_TVDMSRC_ON_SHIFT))&USBDCD_TIMER2_BC12_TVDMSRC_ON_MASK)
+#define USBDCD_TIMER2_BC12_TWAIT_AFTER_PRD_MASK  0x3FF0000u
+#define USBDCD_TIMER2_BC12_TWAIT_AFTER_PRD_SHIFT 16
+#define USBDCD_TIMER2_BC12_TWAIT_AFTER_PRD(x)    (((uint32_t)(((uint32_t)(x))<<USBDCD_TIMER2_BC12_TWAIT_AFTER_PRD_SHIFT))&USBDCD_TIMER2_BC12_TWAIT_AFTER_PRD_MASK)
+
+/*!
+ * @}
+ */ /* end of group USBDCD_Register_Masks */
+
+
+/* USBDCD - Peripheral instance base addresses */
+/** Peripheral USBDCD base address */
+#define USBDCD_BASE                              (0x40035000u)
+/** Peripheral USBDCD base pointer */
+#define USBDCD                                   ((USBDCD_Type *)USBDCD_BASE)
+#define USBDCD_BASE_PTR                          (USBDCD)
+/** Array initializer of USBDCD peripheral base addresses */
+#define USBDCD_BASE_ADDRS                        { USBDCD_BASE }
+/** Array initializer of USBDCD peripheral base pointers */
+#define USBDCD_BASE_PTRS                         { USBDCD }
+/** Interrupt vectors for the USBDCD peripheral type */
+#define USBDCD_IRQS                              { USBDCD_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- USBDCD - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup USBDCD_Register_Accessor_Macros USBDCD - Register accessor macros
+ * @{
+ */
+
+
+/* USBDCD - Register instance definitions */
+/* USBDCD */
+#define USBDCD_CONTROL                           USBDCD_CONTROL_REG(USBDCD)
+#define USBDCD_CLOCK                             USBDCD_CLOCK_REG(USBDCD)
+#define USBDCD_STATUS                            USBDCD_STATUS_REG(USBDCD)
+#define USBDCD_TIMER0                            USBDCD_TIMER0_REG(USBDCD)
+#define USBDCD_TIMER1                            USBDCD_TIMER1_REG(USBDCD)
+#define USBDCD_TIMER2_BC11                       USBDCD_TIMER2_BC11_REG(USBDCD)
+#define USBDCD_TIMER2_BC12                       USBDCD_TIMER2_BC12_REG(USBDCD)
+
+/*!
+ * @}
+ */ /* end of group USBDCD_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group USBDCD_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- VREF Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup VREF_Peripheral_Access_Layer VREF Peripheral Access Layer
+ * @{
+ */
+
+/** VREF - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t TRM;                                /**< VREF Trim Register, offset: 0x0 */
+  __IO uint8_t SC;                                 /**< VREF Status and Control Register, offset: 0x1 */
+} VREF_Type, *VREF_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- VREF - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup VREF_Register_Accessor_Macros VREF - Register accessor macros
+ * @{
+ */
+
+
+/* VREF - Register accessors */
+#define VREF_TRM_REG(base)                       ((base)->TRM)
+#define VREF_SC_REG(base)                        ((base)->SC)
+
+/*!
+ * @}
+ */ /* end of group VREF_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- VREF Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup VREF_Register_Masks VREF Register Masks
+ * @{
+ */
+
+/* TRM Bit Fields */
+#define VREF_TRM_TRIM_MASK                       0x3Fu
+#define VREF_TRM_TRIM_SHIFT                      0
+#define VREF_TRM_TRIM(x)                         (((uint8_t)(((uint8_t)(x))<<VREF_TRM_TRIM_SHIFT))&VREF_TRM_TRIM_MASK)
+#define VREF_TRM_CHOPEN_MASK                     0x40u
+#define VREF_TRM_CHOPEN_SHIFT                    6
+/* SC Bit Fields */
+#define VREF_SC_MODE_LV_MASK                     0x3u
+#define VREF_SC_MODE_LV_SHIFT                    0
+#define VREF_SC_MODE_LV(x)                       (((uint8_t)(((uint8_t)(x))<<VREF_SC_MODE_LV_SHIFT))&VREF_SC_MODE_LV_MASK)
+#define VREF_SC_VREFST_MASK                      0x4u
+#define VREF_SC_VREFST_SHIFT                     2
+#define VREF_SC_ICOMPEN_MASK                     0x20u
+#define VREF_SC_ICOMPEN_SHIFT                    5
+#define VREF_SC_REGEN_MASK                       0x40u
+#define VREF_SC_REGEN_SHIFT                      6
+#define VREF_SC_VREFEN_MASK                      0x80u
+#define VREF_SC_VREFEN_SHIFT                     7
+
+/*!
+ * @}
+ */ /* end of group VREF_Register_Masks */
+
+
+/* VREF - Peripheral instance base addresses */
+/** Peripheral VREF base address */
+#define VREF_BASE                                (0x40074000u)
+/** Peripheral VREF base pointer */
+#define VREF                                     ((VREF_Type *)VREF_BASE)
+#define VREF_BASE_PTR                            (VREF)
+/** Array initializer of VREF peripheral base addresses */
+#define VREF_BASE_ADDRS                          { VREF_BASE }
+/** Array initializer of VREF peripheral base pointers */
+#define VREF_BASE_PTRS                           { VREF }
+
+/* ----------------------------------------------------------------------------
+   -- VREF - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup VREF_Register_Accessor_Macros VREF - Register accessor macros
+ * @{
+ */
+
+
+/* VREF - Register instance definitions */
+/* VREF */
+#define VREF_TRM                                 VREF_TRM_REG(VREF)
+#define VREF_SC                                  VREF_SC_REG(VREF)
+
+/*!
+ * @}
+ */ /* end of group VREF_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group VREF_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- WDOG Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup WDOG_Peripheral_Access_Layer WDOG Peripheral Access Layer
+ * @{
+ */
+
+/** WDOG - Register Layout Typedef */
+typedef struct {
+  __IO uint16_t STCTRLH;                           /**< Watchdog Status and Control Register High, offset: 0x0 */
+  __IO uint16_t STCTRLL;                           /**< Watchdog Status and Control Register Low, offset: 0x2 */
+  __IO uint16_t TOVALH;                            /**< Watchdog Time-out Value Register High, offset: 0x4 */
+  __IO uint16_t TOVALL;                            /**< Watchdog Time-out Value Register Low, offset: 0x6 */
+  __IO uint16_t WINH;                              /**< Watchdog Window Register High, offset: 0x8 */
+  __IO uint16_t WINL;                              /**< Watchdog Window Register Low, offset: 0xA */
+  __IO uint16_t REFRESH;                           /**< Watchdog Refresh register, offset: 0xC */
+  __IO uint16_t UNLOCK;                            /**< Watchdog Unlock register, offset: 0xE */
+  __IO uint16_t TMROUTH;                           /**< Watchdog Timer Output Register High, offset: 0x10 */
+  __IO uint16_t TMROUTL;                           /**< Watchdog Timer Output Register Low, offset: 0x12 */
+  __IO uint16_t RSTCNT;                            /**< Watchdog Reset Count register, offset: 0x14 */
+  __IO uint16_t PRESC;                             /**< Watchdog Prescaler register, offset: 0x16 */
+} WDOG_Type, *WDOG_MemMapPtr;
+
+/* ----------------------------------------------------------------------------
+   -- WDOG - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup WDOG_Register_Accessor_Macros WDOG - Register accessor macros
+ * @{
+ */
+
+
+/* WDOG - Register accessors */
+#define WDOG_STCTRLH_REG(base)                   ((base)->STCTRLH)
+#define WDOG_STCTRLL_REG(base)                   ((base)->STCTRLL)
+#define WDOG_TOVALH_REG(base)                    ((base)->TOVALH)
+#define WDOG_TOVALL_REG(base)                    ((base)->TOVALL)
+#define WDOG_WINH_REG(base)                      ((base)->WINH)
+#define WDOG_WINL_REG(base)                      ((base)->WINL)
+#define WDOG_REFRESH_REG(base)                   ((base)->REFRESH)
+#define WDOG_UNLOCK_REG(base)                    ((base)->UNLOCK)
+#define WDOG_TMROUTH_REG(base)                   ((base)->TMROUTH)
+#define WDOG_TMROUTL_REG(base)                   ((base)->TMROUTL)
+#define WDOG_RSTCNT_REG(base)                    ((base)->RSTCNT)
+#define WDOG_PRESC_REG(base)                     ((base)->PRESC)
+
+/*!
+ * @}
+ */ /* end of group WDOG_Register_Accessor_Macros */
+
+
+/* ----------------------------------------------------------------------------
+   -- WDOG Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup WDOG_Register_Masks WDOG Register Masks
+ * @{
+ */
+
+/* STCTRLH Bit Fields */
+#define WDOG_STCTRLH_WDOGEN_MASK                 0x1u
+#define WDOG_STCTRLH_WDOGEN_SHIFT                0
+#define WDOG_STCTRLH_CLKSRC_MASK                 0x2u
+#define WDOG_STCTRLH_CLKSRC_SHIFT                1
+#define WDOG_STCTRLH_IRQRSTEN_MASK               0x4u
+#define WDOG_STCTRLH_IRQRSTEN_SHIFT              2
+#define WDOG_STCTRLH_WINEN_MASK                  0x8u
+#define WDOG_STCTRLH_WINEN_SHIFT                 3
+#define WDOG_STCTRLH_ALLOWUPDATE_MASK            0x10u
+#define WDOG_STCTRLH_ALLOWUPDATE_SHIFT           4
+#define WDOG_STCTRLH_DBGEN_MASK                  0x20u
+#define WDOG_STCTRLH_DBGEN_SHIFT                 5
+#define WDOG_STCTRLH_STOPEN_MASK                 0x40u
+#define WDOG_STCTRLH_STOPEN_SHIFT                6
+#define WDOG_STCTRLH_WAITEN_MASK                 0x80u
+#define WDOG_STCTRLH_WAITEN_SHIFT                7
+#define WDOG_STCTRLH_TESTWDOG_MASK               0x400u
+#define WDOG_STCTRLH_TESTWDOG_SHIFT              10
+#define WDOG_STCTRLH_TESTSEL_MASK                0x800u
+#define WDOG_STCTRLH_TESTSEL_SHIFT               11
+#define WDOG_STCTRLH_BYTESEL_MASK                0x3000u
+#define WDOG_STCTRLH_BYTESEL_SHIFT               12
+#define WDOG_STCTRLH_BYTESEL(x)                  (((uint16_t)(((uint16_t)(x))<<WDOG_STCTRLH_BYTESEL_SHIFT))&WDOG_STCTRLH_BYTESEL_MASK)
+#define WDOG_STCTRLH_DISTESTWDOG_MASK            0x4000u
+#define WDOG_STCTRLH_DISTESTWDOG_SHIFT           14
+/* STCTRLL Bit Fields */
+#define WDOG_STCTRLL_INTFLG_MASK                 0x8000u
+#define WDOG_STCTRLL_INTFLG_SHIFT                15
+/* TOVALH Bit Fields */
+#define WDOG_TOVALH_TOVALHIGH_MASK               0xFFFFu
+#define WDOG_TOVALH_TOVALHIGH_SHIFT              0
+#define WDOG_TOVALH_TOVALHIGH(x)                 (((uint16_t)(((uint16_t)(x))<<WDOG_TOVALH_TOVALHIGH_SHIFT))&WDOG_TOVALH_TOVALHIGH_MASK)
+/* TOVALL Bit Fields */
+#define WDOG_TOVALL_TOVALLOW_MASK                0xFFFFu
+#define WDOG_TOVALL_TOVALLOW_SHIFT               0
+#define WDOG_TOVALL_TOVALLOW(x)                  (((uint16_t)(((uint16_t)(x))<<WDOG_TOVALL_TOVALLOW_SHIFT))&WDOG_TOVALL_TOVALLOW_MASK)
+/* WINH Bit Fields */
+#define WDOG_WINH_WINHIGH_MASK                   0xFFFFu
+#define WDOG_WINH_WINHIGH_SHIFT                  0
+#define WDOG_WINH_WINHIGH(x)                     (((uint16_t)(((uint16_t)(x))<<WDOG_WINH_WINHIGH_SHIFT))&WDOG_WINH_WINHIGH_MASK)
+/* WINL Bit Fields */
+#define WDOG_WINL_WINLOW_MASK                    0xFFFFu
+#define WDOG_WINL_WINLOW_SHIFT                   0
+#define WDOG_WINL_WINLOW(x)                      (((uint16_t)(((uint16_t)(x))<<WDOG_WINL_WINLOW_SHIFT))&WDOG_WINL_WINLOW_MASK)
+/* REFRESH Bit Fields */
+#define WDOG_REFRESH_WDOGREFRESH_MASK            0xFFFFu
+#define WDOG_REFRESH_WDOGREFRESH_SHIFT           0
+#define WDOG_REFRESH_WDOGREFRESH(x)              (((uint16_t)(((uint16_t)(x))<<WDOG_REFRESH_WDOGREFRESH_SHIFT))&WDOG_REFRESH_WDOGREFRESH_MASK)
+/* UNLOCK Bit Fields */
+#define WDOG_UNLOCK_WDOGUNLOCK_MASK              0xFFFFu
+#define WDOG_UNLOCK_WDOGUNLOCK_SHIFT             0
+#define WDOG_UNLOCK_WDOGUNLOCK(x)                (((uint16_t)(((uint16_t)(x))<<WDOG_UNLOCK_WDOGUNLOCK_SHIFT))&WDOG_UNLOCK_WDOGUNLOCK_MASK)
+/* TMROUTH Bit Fields */
+#define WDOG_TMROUTH_TIMEROUTHIGH_MASK           0xFFFFu
+#define WDOG_TMROUTH_TIMEROUTHIGH_SHIFT          0
+#define WDOG_TMROUTH_TIMEROUTHIGH(x)             (((uint16_t)(((uint16_t)(x))<<WDOG_TMROUTH_TIMEROUTHIGH_SHIFT))&WDOG_TMROUTH_TIMEROUTHIGH_MASK)
+/* TMROUTL Bit Fields */
+#define WDOG_TMROUTL_TIMEROUTLOW_MASK            0xFFFFu
+#define WDOG_TMROUTL_TIMEROUTLOW_SHIFT           0
+#define WDOG_TMROUTL_TIMEROUTLOW(x)              (((uint16_t)(((uint16_t)(x))<<WDOG_TMROUTL_TIMEROUTLOW_SHIFT))&WDOG_TMROUTL_TIMEROUTLOW_MASK)
+/* RSTCNT Bit Fields */
+#define WDOG_RSTCNT_RSTCNT_MASK                  0xFFFFu
+#define WDOG_RSTCNT_RSTCNT_SHIFT                 0
+#define WDOG_RSTCNT_RSTCNT(x)                    (((uint16_t)(((uint16_t)(x))<<WDOG_RSTCNT_RSTCNT_SHIFT))&WDOG_RSTCNT_RSTCNT_MASK)
+/* PRESC Bit Fields */
+#define WDOG_PRESC_PRESCVAL_MASK                 0x700u
+#define WDOG_PRESC_PRESCVAL_SHIFT                8
+#define WDOG_PRESC_PRESCVAL(x)                   (((uint16_t)(((uint16_t)(x))<<WDOG_PRESC_PRESCVAL_SHIFT))&WDOG_PRESC_PRESCVAL_MASK)
+
+/*!
+ * @}
+ */ /* end of group WDOG_Register_Masks */
+
+
+/* WDOG - Peripheral instance base addresses */
+/** Peripheral WDOG base address */
+#define WDOG_BASE                                (0x40052000u)
+/** Peripheral WDOG base pointer */
+#define WDOG                                     ((WDOG_Type *)WDOG_BASE)
+#define WDOG_BASE_PTR                            (WDOG)
+/** Array initializer of WDOG peripheral base addresses */
+#define WDOG_BASE_ADDRS                          { WDOG_BASE }
+/** Array initializer of WDOG peripheral base pointers */
+#define WDOG_BASE_PTRS                           { WDOG }
+/** Interrupt vectors for the WDOG peripheral type */
+#define WDOG_IRQS                                { Watchdog_IRQn }
+
+/* ----------------------------------------------------------------------------
+   -- WDOG - Register accessor macros
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup WDOG_Register_Accessor_Macros WDOG - Register accessor macros
+ * @{
+ */
+
+
+/* WDOG - Register instance definitions */
+/* WDOG */
+#define WDOG_STCTRLH                             WDOG_STCTRLH_REG(WDOG)
+#define WDOG_STCTRLL                             WDOG_STCTRLL_REG(WDOG)
+#define WDOG_TOVALH                              WDOG_TOVALH_REG(WDOG)
+#define WDOG_TOVALL                              WDOG_TOVALL_REG(WDOG)
+#define WDOG_WINH                                WDOG_WINH_REG(WDOG)
+#define WDOG_WINL                                WDOG_WINL_REG(WDOG)
+#define WDOG_REFRESH                             WDOG_REFRESH_REG(WDOG)
+#define WDOG_UNLOCK                              WDOG_UNLOCK_REG(WDOG)
+#define WDOG_TMROUTH                             WDOG_TMROUTH_REG(WDOG)
+#define WDOG_TMROUTL                             WDOG_TMROUTL_REG(WDOG)
+#define WDOG_RSTCNT                              WDOG_RSTCNT_REG(WDOG)
+#define WDOG_PRESC                               WDOG_PRESC_REG(WDOG)
+
+/*!
+ * @}
+ */ /* end of group WDOG_Register_Accessor_Macros */
+
+
+/*!
+ * @}
+ */ /* end of group WDOG_Peripheral_Access_Layer */
+
+
+/*
+** End of section using anonymous unions
+*/
+
+#if defined(__ARMCC_VERSION)
+  #pragma pop
+#elif defined(__CWCC__)
+  #pragma pop
+#elif defined(__GNUC__)
+  /* leave anonymous unions enabled */
+#elif defined(__IAR_SYSTEMS_ICC__)
+  #pragma language=default
+#else
+  #error Not supported compiler type
+#endif
+
+/*!
+ * @}
+ */ /* end of group Peripheral_access_layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- Backward Compatibility
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup Backward_Compatibility_Symbols Backward Compatibility
+ * @{
+ */
+
+#define GPIOA_BASE                               PTA_BASE
+#define GPIOA                                    PTA
+#define GPIOB_BASE                               PTB_BASE
+#define GPIOB                                    PTB
+#define GPIOC_BASE                               PTC_BASE
+#define GPIOC                                    PTC
+#define GPIOD_BASE                               PTD_BASE
+#define GPIOD                                    PTD
+#define GPIOE_BASE                               PTE_BASE
+#define GPIOE                                    PTE
+#define DMA_EARS_REG(base)                       This_symbol_has_been_deprecated
+#define DMA_EARS                                 This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_0_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_0_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_1_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_1_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_2_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_2_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_3_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_3_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_4_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_4_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_5_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_5_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_6_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_6_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_7_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_7_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_8_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_8_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_9_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_9_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_10_MASK                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_10_SHIFT                  This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_11_MASK                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_11_SHIFT                  This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_12_MASK                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_12_SHIFT                  This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_13_MASK                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_13_SHIFT                  This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_14_MASK                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_14_SHIFT                  This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_15_MASK                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_15_SHIFT                  This_symbol_has_been_deprecated
+#define ENET_RMON_T_DROP_REG(base)               This_symbol_has_been_deprecated
+#define ENET_IEEE_T_DROP_REG(base)               This_symbol_has_been_deprecated
+#define ENET_IEEE_T_SQE_REG(base)                This_symbol_has_been_deprecated
+#define ENET_RMON_R_RESVD_0_REG(base)            This_symbol_has_been_deprecated
+#define ENET_RMON_R_DROP_REG(base)               ENET_IEEE_R_DROP_REG(base)
+#define ENET_RMON_R_FRAME_OK_REG(base)           ENET_IEEE_R_FRAME_OK_REG(base)
+#define ENET_RMON_T_DROP                         This_symbol_has_been_deprecated
+#define ENET_IEEE_T_DROP                         This_symbol_has_been_deprecated
+#define ENET_IEEE_T_SQE                          This_symbol_has_been_deprecated
+#define ENET_RMON_R_RESVD_0                      This_symbol_has_been_deprecated
+#define MCG_C9_REG(base)                         This_symbol_has_been_deprecated
+#define MCG_C2_EREFS0_MASK                       MCG_C2_EREFS_MASK
+#define MCG_C2_EREFS0_SHIFT                      MCG_C2_EREFS_SHIFT
+#define MCG_C2_HGO0_MASK                         MCG_C2_HGO_MASK
+#define MCG_C2_HGO0_SHIFT                        MCG_C2_HGO_SHIFT
+#define MCG_C2_RANGE0_MASK                       MCG_C2_RANGE_MASK
+#define MCG_C2_RANGE0_SHIFT                      MCG_C2_RANGE_SHIFT
+#define MCG_C2_RANGE0(x)                         MCG_C2_RANGE(x)
+#define MCG_C9                                   This_symbol_has_been_deprecated
+#define MCM_PLACR_REG(base)                      This_symbol_has_been_deprecated
+#define MCM_PLACR_ARB_MASK                       This_symbol_has_been_deprecated
+#define MCM_PLACR_ARB_SHIFT                      This_symbol_has_been_deprecated
+#define MCM_PLACR                                This_symbol_has_been_deprecated
+#define ADC_BASES                    ADC_BASE_PTRS
+#define AIPS_BASES                   AIPS_BASE_PTRS
+#define AXBS_BASES                   AXBS_BASE_PTRS
+#define CAN_BASES                    CAN_BASE_PTRS
+#define CAU_BASES                    CAU_BASE_PTRS
+#define CMP_BASES                    CMP_BASE_PTRS
+#define CMT_BASES                    CMT_BASE_PTRS
+#define CRC_BASES                    CRC_BASE_PTRS
+#define DAC_BASES                    DAC_BASE_PTRS
+#define DMA_BASES                    DMA_BASE_PTRS
+#define DMAMUX_BASES                 DMAMUX_BASE_PTRS
+#define ENET_BASES                   ENET_BASE_PTRS
+#define EWM_BASES                    EWM_BASE_PTRS
+#define FB_BASES                     FB_BASE_PTRS
+#define FMC_BASES                    FMC_BASE_PTRS
+#define FTFE_BASES                   FTFE_BASE_PTRS
+#define FTM_BASES                    FTM_BASE_PTRS
+#define GPIO_BASES                   GPIO_BASE_PTRS
+#define I2C_BASES                    I2C_BASE_PTRS
+#define I2S_BASES                    I2S_BASE_PTRS
+#define LLWU_BASES                   LLWU_BASE_PTRS
+#define LPTMR_BASES                  LPTMR_BASE_PTRS
+#define LPTMR0_IRQn                  LPTimer_IRQn
+#define MCG_BASES                    MCG_BASE_PTRS
+#define MCM_ISR_REG(base)            MCM_ISCR_REG(base)
+#define MCM_ISR_FIOC_MASK            MCM_ISCR_FIOC_MASK
+#define MCM_ISR_FIOC_SHIFT           MCM_ISCR_FIOC_SHIFT
+#define MCM_ISR_FDZC_MASK            MCM_ISCR_FDZC_MASK
+#define MCM_ISR_FDZC_SHIFT           MCM_ISCR_FDZC_SHIFT
+#define MCM_ISR_FOFC_MASK            MCM_ISCR_FOFC_MASK
+#define MCM_ISR_FOFC_SHIFT           MCM_ISCR_FOFC_SHIFT
+#define MCM_ISR_FUFC_MASK            MCM_ISCR_FUFC_MASK
+#define MCM_ISR_FUFC_SHIFT           MCM_ISCR_FUFC_SHIFT
+#define MCM_ISR_FIXC_MASK            MCM_ISCR_FIXC_MASK
+#define MCM_ISR_FIXC_SHIFT           MCM_ISCR_FIXC_SHIFT
+#define MCM_ISR_FIDC_MASK            MCM_ISCR_FIDC_MASK
+#define MCM_ISR_FIDC_SHIFT           MCM_ISCR_FIDC_SHIFT
+#define MCM_ISR_FIOCE_MASK           MCM_ISCR_FIOCE_MASK
+#define MCM_ISR_FIOCE_SHIFT          MCM_ISCR_FIOCE_SHIFT
+#define MCM_ISR_FDZCE_MASK           MCM_ISCR_FDZCE_MASK
+#define MCM_ISR_FDZCE_SHIFT          MCM_ISCR_FDZCE_SHIFT
+#define MCM_ISR_FOFCE_MASK           MCM_ISCR_FOFCE_MASK
+#define MCM_ISR_FOFCE_SHIFT          MCM_ISCR_FOFCE_SHIFT
+#define MCM_ISR_FUFCE_MASK           MCM_ISCR_FUFCE_MASK
+#define MCM_ISR_FUFCE_SHIFT          MCM_ISCR_FUFCE_SHIFT
+#define MCM_ISR_FIXCE_MASK           MCM_ISCR_FIXCE_MASK
+#define MCM_ISR_FIXCE_SHIFT          MCM_ISCR_FIXCE_SHIFT
+#define MCM_ISR_FIDCE_MASK           MCM_ISCR_FIDCE_MASK
+#define MCM_ISR_FIDCE_SHIFT          MCM_ISCR_FIDCE_SHIFT
+#define MCM_BASES                    MCM_BASE_PTRS
+#define MPU_BASES                    MPU_BASE_PTRS
+#define NV_BASES                     NV_BASE_PTRS
+#define OSC_BASES                    OSC_BASE_PTRS
+#define OSC0                         ((OSC_Type *)OSC_BASE)
+#define PDB_BASES                    PDB_BASE_PTRS
+#define PIT_BASES                    PIT_BASE_PTRS
+#define PMC_BASES                    PMC_BASE_PTRS
+#define PORT_BASES                   PORT_BASE_PTRS
+#define RCM_BASES                    RCM_BASE_PTRS
+#define RFSYS_BASES                  RFSYS_BASE_PTRS
+#define RFVBAT_BASES                 RFVBAT_BASE_PTRS
+#define RNG_BASES                    RNG_BASE_PTRS
+#define RTC_BASES                    RTC_BASE_PTRS
+#define SDHC_BASES                   SDHC_BASE_PTRS
+#define SIM_BASES                    SIM_BASE_PTRS
+#define SMC_BASES                    SMC_BASE_PTRS
+#define SPI_BASES                    SPI_BASE_PTRS
+#define UART_WP7816_T_TYPE0_REG(base) UART_WP7816T0_REG(base)
+#define UART_WP7816_T_TYPE1_REG(base) UART_WP7816T1_REG(base)
+#define UART_WP7816_T_TYPE0_WI_MASK  UART_WP7816T0_WI_MASK
+#define UART_WP7816_T_TYPE0_WI_SHIFT UART_WP7816T0_WI_SHIFT
+#define UART_WP7816_T_TYPE0_WI(x)    UART_WP7816T0_WI(x)
+#define UART_WP7816_T_TYPE1_BWI_MASK UART_WP7816T1_BWI_MASK
+#define UART_WP7816_T_TYPE1_BWI_SHIFT UART_WP7816T1_BWI_SHIFT
+#define UART_WP7816_T_TYPE1_BWI(x)   UART_WP7816T1_BWI(x)
+#define UART_WP7816_T_TYPE1_CWI_MASK UART_WP7816T1_CWI_MASK
+#define UART_WP7816_T_TYPE1_CWI_SHIFT UART_WP7816T1_CWI_SHIFT
+#define UART_WP7816_T_TYPE1_CWI(x)   UART_WP7816T1_CWI(x)
+#define UART_BASES                   UART_BASE_PTRS
+#define USB_BASES                    USB_BASE_PTRS
+#define USBDCD_BASES                 USBDCD_BASE_PTRS
+#define VREF_BASES                   VREF_BASE_PTRS
+#define WDOG_BASES                   WDOG_BASE_PTRS
+#define DMA_EARS_REG(base)                       This_symbol_has_been_deprecated
+#define DMA_EARS                                 This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_0_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_0_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_1_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_1_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_2_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_2_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_3_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_3_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_4_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_4_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_5_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_5_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_6_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_6_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_7_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_7_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_8_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_8_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_9_MASK                    This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_9_SHIFT                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_10_MASK                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_10_SHIFT                  This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_11_MASK                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_11_SHIFT                  This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_12_MASK                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_12_SHIFT                  This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_13_MASK                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_13_SHIFT                  This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_14_MASK                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_14_SHIFT                  This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_15_MASK                   This_symbol_has_been_deprecated
+#define DMA_EARS_EDREQ_15_SHIFT                  This_symbol_has_been_deprecated
+#define ENET_RMON_T_DROP_REG(base)               This_symbol_has_been_deprecated
+#define ENET_IEEE_T_DROP_REG(base)               This_symbol_has_been_deprecated
+#define ENET_IEEE_T_SQE_REG(base)                This_symbol_has_been_deprecated
+#define ENET_RMON_R_RESVD_0_REG(base)            This_symbol_has_been_deprecated
+#define ENET_RMON_R_DROP_REG(base)               ENET_IEEE_R_DROP_REG(base)
+#define ENET_RMON_R_FRAME_OK_REG(base)           ENET_IEEE_R_FRAME_OK_REG(base)
+#define ENET_RMON_T_DROP                         This_symbol_has_been_deprecated
+#define ENET_IEEE_T_DROP                         This_symbol_has_been_deprecated
+#define ENET_IEEE_T_SQE                          This_symbol_has_been_deprecated
+#define ENET_RMON_R_RESVD_0                      This_symbol_has_been_deprecated
+#define MCG_C9_REG(base)                         This_symbol_has_been_deprecated
+#define MCG_C2_EREFS0_MASK                       MCG_C2_EREFS_MASK
+#define MCG_C2_EREFS0_SHIFT                      MCG_C2_EREFS_SHIFT
+#define MCG_C2_HGO0_MASK                         MCG_C2_HGO_MASK
+#define MCG_C2_HGO0_SHIFT                        MCG_C2_HGO_SHIFT
+#define MCG_C2_RANGE0_MASK                       MCG_C2_RANGE_MASK
+#define MCG_C2_RANGE0_SHIFT                      MCG_C2_RANGE_SHIFT
+#define MCG_C2_RANGE0(x)                         MCG_C2_RANGE(x)
+#define MCG_C9                                   This_symbol_has_been_deprecated
+#define MCM_PLACR_REG(base)                      This_symbol_has_been_deprecated
+#define MCM_PLACR_ARB_MASK                       This_symbol_has_been_deprecated
+#define MCM_PLACR_ARB_SHIFT                      This_symbol_has_been_deprecated
+#define MCM_PLACR                                This_symbol_has_been_deprecated
+#define ADC_BASES                    ADC_BASE_PTRS
+#define AIPS_BASES                   AIPS_BASE_PTRS
+#define AXBS_BASES                   AXBS_BASE_PTRS
+#define CAN_BASES                    CAN_BASE_PTRS
+#define CAU_BASES                    CAU_BASE_PTRS
+#define CMP_BASES                    CMP_BASE_PTRS
+#define CMT_BASES                    CMT_BASE_PTRS
+#define CRC_BASES                    CRC_BASE_PTRS
+#define DAC_BASES                    DAC_BASE_PTRS
+#define DMA_BASES                    DMA_BASE_PTRS
+#define DMAMUX_BASES                 DMAMUX_BASE_PTRS
+#define ENET_BASES                   ENET_BASE_PTRS
+#define EWM_BASES                    EWM_BASE_PTRS
+#define FB_BASES                     FB_BASE_PTRS
+#define FMC_BASES                    FMC_BASE_PTRS
+#define FTFE_BASES                   FTFE_BASE_PTRS
+#define FTM_BASES                    FTM_BASE_PTRS
+#define GPIO_BASES                   GPIO_BASE_PTRS
+#define I2C_BASES                    I2C_BASE_PTRS
+#define I2S_BASES                    I2S_BASE_PTRS
+#define LLWU_BASES                   LLWU_BASE_PTRS
+#define LPTMR_BASES                  LPTMR_BASE_PTRS
+#define MCG_BASES                    MCG_BASE_PTRS
+#define MCM_ISR_REG(base)            MCM_ISCR_REG(base)
+#define MCM_ISR_FIOC_MASK            MCM_ISCR_FIOC_MASK
+#define MCM_ISR_FIOC_SHIFT           MCM_ISCR_FIOC_SHIFT
+#define MCM_ISR_FDZC_MASK            MCM_ISCR_FDZC_MASK
+#define MCM_ISR_FDZC_SHIFT           MCM_ISCR_FDZC_SHIFT
+#define MCM_ISR_FOFC_MASK            MCM_ISCR_FOFC_MASK
+#define MCM_ISR_FOFC_SHIFT           MCM_ISCR_FOFC_SHIFT
+#define MCM_ISR_FUFC_MASK            MCM_ISCR_FUFC_MASK
+#define MCM_ISR_FUFC_SHIFT           MCM_ISCR_FUFC_SHIFT
+#define MCM_ISR_FIXC_MASK            MCM_ISCR_FIXC_MASK
+#define MCM_ISR_FIXC_SHIFT           MCM_ISCR_FIXC_SHIFT
+#define MCM_ISR_FIDC_MASK            MCM_ISCR_FIDC_MASK
+#define MCM_ISR_FIDC_SHIFT           MCM_ISCR_FIDC_SHIFT
+#define MCM_ISR_FIOCE_MASK           MCM_ISCR_FIOCE_MASK
+#define MCM_ISR_FIOCE_SHIFT          MCM_ISCR_FIOCE_SHIFT
+#define MCM_ISR_FDZCE_MASK           MCM_ISCR_FDZCE_MASK
+#define MCM_ISR_FDZCE_SHIFT          MCM_ISCR_FDZCE_SHIFT
+#define MCM_ISR_FOFCE_MASK           MCM_ISCR_FOFCE_MASK
+#define MCM_ISR_FOFCE_SHIFT          MCM_ISCR_FOFCE_SHIFT
+#define MCM_ISR_FUFCE_MASK           MCM_ISCR_FUFCE_MASK
+#define MCM_ISR_FUFCE_SHIFT          MCM_ISCR_FUFCE_SHIFT
+#define MCM_ISR_FIXCE_MASK           MCM_ISCR_FIXCE_MASK
+#define MCM_ISR_FIXCE_SHIFT          MCM_ISCR_FIXCE_SHIFT
+#define MCM_ISR_FIDCE_MASK           MCM_ISCR_FIDCE_MASK
+#define MCM_ISR_FIDCE_SHIFT          MCM_ISCR_FIDCE_SHIFT
+#define MCM_BASES                    MCM_BASE_PTRS
+#define MPU_BASES                    MPU_BASE_PTRS
+#define NV_BASES                     NV_BASE_PTRS
+#define OSC_BASES                    OSC_BASE_PTRS
+#define PDB_BASES                    PDB_BASE_PTRS
+#define PIT_BASES                    PIT_BASE_PTRS
+#define PMC_BASES                    PMC_BASE_PTRS
+#define PORT_BASES                   PORT_BASE_PTRS
+#define RCM_BASES                    RCM_BASE_PTRS
+#define RFSYS_BASES                  RFSYS_BASE_PTRS
+#define RFVBAT_BASES                 RFVBAT_BASE_PTRS
+#define RNG_BASES                    RNG_BASE_PTRS
+#define RTC_BASES                    RTC_BASE_PTRS
+#define SDHC_BASES                   SDHC_BASE_PTRS
+#define SIM_BASES                    SIM_BASE_PTRS
+#define SMC_BASES                    SMC_BASE_PTRS
+#define SPI_BASES                    SPI_BASE_PTRS
+#define UART_WP7816_T_TYPE0_REG(base) UART_WP7816T0_REG(base)
+#define UART_WP7816_T_TYPE1_REG(base) UART_WP7816T1_REG(base)
+#define UART_WP7816_T_TYPE0_WI_MASK  UART_WP7816T0_WI_MASK
+#define UART_WP7816_T_TYPE0_WI_SHIFT UART_WP7816T0_WI_SHIFT
+#define UART_WP7816_T_TYPE0_WI(x)    UART_WP7816T0_WI(x)
+#define UART_WP7816_T_TYPE1_BWI_MASK UART_WP7816T1_BWI_MASK
+#define UART_WP7816_T_TYPE1_BWI_SHIFT UART_WP7816T1_BWI_SHIFT
+#define UART_WP7816_T_TYPE1_BWI(x)   UART_WP7816T1_BWI(x)
+#define UART_WP7816_T_TYPE1_CWI_MASK UART_WP7816T1_CWI_MASK
+#define UART_WP7816_T_TYPE1_CWI_SHIFT UART_WP7816T1_CWI_SHIFT
+#define UART_WP7816_T_TYPE1_CWI(x)   UART_WP7816T1_CWI(x)
+#define UART_BASES                   UART_BASE_PTRS
+#define USB_BASES                    USB_BASE_PTRS
+#define USBDCD_BASES                 USBDCD_BASE_PTRS
+#define VREF_BASES                   VREF_BASE_PTRS
+#define WDOG_BASES                   WDOG_BASE_PTRS
+
+/*!
+ * @}
+ */ /* end of group Backward_Compatibility_Symbols */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#else /* #if !defined(MK64F12_H_) */
+  /* There is already included the same memory map. Check if it is compatible (has the same major version) */
+  #if (MCU_MEM_MAP_VERSION != 0x0200u)
+    #if (!defined(MCU_MEM_MAP_SUPPRESS_VERSION_WARNING))
+      #warning There are included two not compatible versions of memory maps. Please check possible differences.
+    #endif /* (!defined(MCU_MEM_MAP_SUPPRESS_VERSION_WARNING)) */
+  #endif /* (MCU_MEM_MAP_VERSION != 0x0200u) */
+#endif  /* #if !defined(MK64F12_H_) */
+
+/* MK64F12.h, eof. */

--- a/cpu/k64f/include/cpu_conf.h
+++ b/cpu/k64f/include/cpu_conf.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup        cpu_k64f Freescale K64F MCU
+ * @ingroup         cpu
+ * @brief           CPU specific implementations for the Freescale K64F
+ *                  Kinetis Cortex-M4 MCU.
+ * @{
+ *
+ * @file
+ * @brief           Implementation specific CPU configuration options
+ *
+ * @author          Hauke Petersen <hauke.peterse@fu-berlin.de>
+ * @author          Johann Fischer <j.fischer@phytec.de>
+ */
+
+#ifndef __CPU_CONF_H
+#define __CPU_CONF_H
+
+#ifdef CPU_MODEL_MK64FN1M0VLL12
+#include "MK64F12.h"
+#else
+#error "undefined CPU_MODEL"
+#endif
+
+#include "mcg.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @brief   ARM Cortex-M specific CPU configuration
+ * @{
+ */
+#define CPU_DEFAULT_IRQ_PRIO            (1U)
+#define CPU_IRQ_NUMOF                   (86U)
+#define CPU_FLASH_BASE                  (0x00000000)
+/** @} */
+
+/**
+ * @brief Length for reading CPU_ID in octets
+ */
+#define CPUID_ID_LEN                     (16)
+
+/**
+ * @brief Pointer to CPU_ID
+ */
+#define CPUID_ID_PTR                     ((void *)(&(SIM_UIDH)))
+
+
+/**
+ * @brief MCU specific Low Power Timer settings.
+ */
+#define LPTIMER_CLKSRC                   LPTIMER_CLKSRC_LPO
+#define LPTIMER_DEV                      (LPTMR0) /**< LPTIMER hardware module */
+#define LPTIMER_CLKEN()                  (SIM->SCGC5 |= SIM_SCGC5_LPTMR_MASK) /**< Enable LPTMR0 clock gate */
+#define LPTIMER_CLKDIS()                 (SIM->SCGC5 &= ~SIM_SCGC5_PTMR_MASK) /**< Disable LPTMR0 clock gate */
+#define LPTIMER_CNR_NEEDS_LATCHING       1 /**< LPTMR.CNR register do not need latching */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CPU_CONF_H */
+/** @} */

--- a/cpu/k64f/ldscripts/mk64fn1m0vll12.ld
+++ b/cpu/k64f/ldscripts/mk64fn1m0vll12.ld
@@ -1,0 +1,12 @@
+OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+
+MEMORY
+{
+    vectors (rx) : ORIGIN = 0x00000000, LENGTH = 0x400
+    flashsec (rx) : ORIGIN = 0x00000400, LENGTH = 0x10
+    flash (rx)    : ORIGIN = 0x00000410, LENGTH = 1024K - 0x410
+    sram (rwx)   : ORIGIN = 0x1fff0198, LENGTH = 256K-0x198
+}
+
+INCLUDE kinetis-noramcode.ld

--- a/cpu/k64f/lpm_arch.c
+++ b/cpu/k64f/lpm_arch.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_k64f
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the kernels power management interface
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "arch/lpm_arch.h"
+
+void lpm_arch_init(void)
+{
+    /* TODO */
+}
+
+enum lpm_mode lpm_arch_set(enum lpm_mode target)
+{
+    /* TODO */
+    return 0;
+}
+
+enum lpm_mode lpm_arch_get(void)
+{
+    /* TODO */
+    return 0;
+}
+
+void lpm_arch_awake(void)
+{
+    /* TODO */
+}
+
+void lpm_arch_begin_awake(void)
+{
+    /* TODO */
+}
+
+void lpm_arch_end_awake(void)
+{
+    /* TODO */
+}

--- a/cpu/k64f/periph/Makefile
+++ b/cpu/k64f/periph/Makefile
@@ -1,0 +1,3 @@
+MODULE = periph
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/k64f/vectors.c
+++ b/cpu/k64f/vectors.c
@@ -1,0 +1,398 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_k64f
+ * @{
+ *
+ * @file
+ * @brief       Interrupt vector definition for K64F MCUs
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include "vectors_cortexm.h"
+#include "wdog.h"
+
+/**
+ * memory markers as defined in the linker script
+ */
+extern uint32_t _estack;
+
+void pre_startup (void)
+{
+    /* disable the WDOG */
+    wdog_disable();
+}
+
+void dummy_handler(void)
+{
+    dummy_handler_default();
+}
+
+/* Cortex-M specific interrupt vectors */
+WEAK_DEFAULT void isr_svc(void);
+WEAK_DEFAULT void isr_pendsv(void);
+WEAK_DEFAULT void isr_systick(void);
+/* K64F specific interrupt vector */
+WEAK_DEFAULT void isr_dma0(void);
+WEAK_DEFAULT void isr_dma1(void);
+WEAK_DEFAULT void isr_dma2(void);
+WEAK_DEFAULT void isr_dma3(void);
+WEAK_DEFAULT void isr_dma4(void);
+WEAK_DEFAULT void isr_dma5(void);
+WEAK_DEFAULT void isr_dma6(void);
+WEAK_DEFAULT void isr_dma7(void);
+WEAK_DEFAULT void isr_dma8(void);
+WEAK_DEFAULT void isr_dma9(void);
+WEAK_DEFAULT void isr_dma10(void);
+WEAK_DEFAULT void isr_dma11(void);
+WEAK_DEFAULT void isr_dma12(void);
+WEAK_DEFAULT void isr_dma13(void);
+WEAK_DEFAULT void isr_dma14(void);
+WEAK_DEFAULT void isr_dma15(void);
+WEAK_DEFAULT void isr_dma_error(void);
+WEAK_DEFAULT void isr_mcm(void);
+WEAK_DEFAULT void isr_ftfl(void);
+WEAK_DEFAULT void isr_ftfl_collision(void);
+WEAK_DEFAULT void isr_pmc(void);
+WEAK_DEFAULT void isr_llwu(void);
+WEAK_DEFAULT void isr_wdog_ewm(void);
+WEAK_DEFAULT void isr_rng(void);
+WEAK_DEFAULT void isr_i2c0(void);
+WEAK_DEFAULT void isr_i2c1(void);
+WEAK_DEFAULT void isr_spi0(void);
+WEAK_DEFAULT void isr_spi1(void);
+WEAK_DEFAULT void isr_i2s0_tx(void);
+WEAK_DEFAULT void isr_i2s0_rx(void);
+WEAK_DEFAULT void isr_uart0_lon(void);
+WEAK_DEFAULT void isr_uart0_rx_tx(void);
+WEAK_DEFAULT void isr_uart0_err(void);
+WEAK_DEFAULT void isr_uart1_rx_tx(void);
+WEAK_DEFAULT void isr_uart1_err(void);
+WEAK_DEFAULT void isr_uart2_rx_tx(void);
+WEAK_DEFAULT void isr_uart2_err(void);
+WEAK_DEFAULT void isr_uart3_rx_tx(void);
+WEAK_DEFAULT void isr_uart3_err(void);
+WEAK_DEFAULT void isr_adc0(void);
+WEAK_DEFAULT void isr_cmp0(void);
+WEAK_DEFAULT void isr_cmp1(void);
+WEAK_DEFAULT void isr_ftm0(void);
+WEAK_DEFAULT void isr_ftm1(void);
+WEAK_DEFAULT void isr_ftm2(void);
+WEAK_DEFAULT void isr_cmt(void);
+WEAK_DEFAULT void isr_rtc(void);
+WEAK_DEFAULT void isr_rtc_seconds(void);
+WEAK_DEFAULT void isr_pit0(void);
+WEAK_DEFAULT void isr_pit1(void);
+WEAK_DEFAULT void isr_pit2(void);
+WEAK_DEFAULT void isr_pit3(void);
+WEAK_DEFAULT void isr_pdb0(void);
+WEAK_DEFAULT void isr_usb0(void);
+WEAK_DEFAULT void isr_usbdcd(void);
+WEAK_DEFAULT void isr_dac0(void);
+WEAK_DEFAULT void isr_mcg(void);
+WEAK_DEFAULT void isr_lptmr0(void);
+WEAK_DEFAULT void isr_porta(void);
+WEAK_DEFAULT void isr_portb(void);
+WEAK_DEFAULT void isr_portc(void);
+WEAK_DEFAULT void isr_portd(void);
+WEAK_DEFAULT void isr_porte(void);
+WEAK_DEFAULT void isr_swi(void);
+WEAK_DEFAULT void isr_spi2(void);
+WEAK_DEFAULT void isr_uart4_rx_tx(void);
+WEAK_DEFAULT void isr_uart4_err(void);
+WEAK_DEFAULT void isr_uart5_rx_tx(void);
+WEAK_DEFAULT void isr_uart5_err(void);
+WEAK_DEFAULT void isr_cmp2(void);
+WEAK_DEFAULT void isr_ftm3(void);
+WEAK_DEFAULT void isr_dac1(void);
+WEAK_DEFAULT void isr_adc1(void);
+WEAK_DEFAULT void isr_i2c2(void);
+WEAK_DEFAULT void isr_can0_mb(void);
+WEAK_DEFAULT void isr_can0_bus_off(void);
+WEAK_DEFAULT void isr_can0_error(void);
+WEAK_DEFAULT void isr_can0_tx_warning(void);
+WEAK_DEFAULT void isr_can0_rx_warning(void);
+WEAK_DEFAULT void isr_can0_wake_up(void);
+WEAK_DEFAULT void isr_sdhc(void);
+WEAK_DEFAULT void isr_enet_1588_timer(void);
+WEAK_DEFAULT void isr_enet_transmit(void);
+WEAK_DEFAULT void isr_enet_receive(void);
+WEAK_DEFAULT void isr_enet_error(void);
+
+/* interrupt vector table */
+__attribute__((section(".vector_table")))
+const void *interrupt_vector[] = {
+    /* Stack pointer */
+    (void *)(&_estack),             /* pointer to the top of the empty stack */
+    /* Cortex-M4 handlers */
+    (void*) reset_handler_default,  /* entry point of the program */
+    (void*) nmi_default,            /* non maskable interrupt handler */
+    (void*) hard_fault_default,     /* hard fault exception */
+    (void*) mem_manage_default,     /* memory manage exception */
+    (void*) bus_fault_default,      /* bus fault exception */
+    (void*) usage_fault_default,    /* usage fault exception */
+    (void*) (0UL),                  /* Reserved */
+    (void*) (0UL),                  /* Reserved */
+    (void*) (0UL),                  /* Reserved */
+    (void*) (0UL),                  /* Reserved */
+    (void*) isr_svc,                /* system call interrupt, in RIOT used for
+                                     * switching into thread context on boot */
+    (void*) debug_mon_default,      /* debug monitor exception */
+    (void*) (0UL),                  /* Reserved */
+    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
+                                     * context switching is happening here */
+    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
+    /* K64F specific peripheral handlers */
+    (void *) isr_dma0,              /* DMA channel 0 transfer complete */
+    (void *) isr_dma1,              /* DMA channel 1 transfer complete */
+    (void *) isr_dma2,              /* DMA channel 2 transfer complete */
+    (void *) isr_dma3,              /* DMA channel 3 transfer complete */
+    (void *) isr_dma4,              /* DMA channel 4 transfer complete */
+    (void *) isr_dma5,              /* DMA channel 5 transfer complete */
+    (void *) isr_dma6,              /* DMA channel 6 transfer complete */
+    (void *) isr_dma7,              /* DMA channel 7 transfer complete */
+    (void *) isr_dma8,              /* DMA channel 8 transfer complete */
+    (void *) isr_dma9,              /* DMA channel 9 transfer complete */
+    (void *) isr_dma10,             /* DMA channel 10 transfer complete */
+    (void *) isr_dma11,             /* DMA channel 11 transfer complete */
+    (void *) isr_dma12,             /* DMA channel 12 transfer complete */
+    (void *) isr_dma13,             /* DMA channel 13 transfer complete */
+    (void *) isr_dma14,             /* DMA channel 14 transfer complete */
+    (void *) isr_dma15,             /* DMA channel 15 transfer complete */
+    (void *) isr_dma_error,         /* DMA channel 0 - 15 error */
+    (void *) isr_mcm,               /* MCM normal interrupt */
+    (void *) isr_ftfl,              /* FTFL command complete */
+    (void *) isr_ftfl_collision,    /* FTFL read collision */
+    (void *) isr_pmc,               /* PMC controller low-voltage detect low-voltage warning */
+    (void *) isr_llwu,              /* Low leakage wakeup */
+    (void *) isr_wdog_ewm,          /* Single interrupt vector for  WDOG and EWM */
+    (void *) isr_rng,               /* Randon number generator */
+    (void *) isr_i2c0,              /* Inter-integrated circuit 0 */
+    (void *) isr_i2c1,              /* Inter-integrated circuit 1 */
+    (void *) isr_spi0,              /* Serial peripheral Interface 0 */
+    (void *) isr_spi1,              /* Serial peripheral Interface 1 */
+    (void *) isr_i2s0_tx,           /* Integrated interchip sound 0 transmit interrupt */
+    (void *) isr_i2s0_rx,           /* Integrated interchip sound 0 receive interrupt */
+    (void *) isr_uart0_lon,         /* UART0 LON interrupt */
+    (void *) isr_uart0_rx_tx,       /* UART0 receive/transmit interrupt */
+    (void *) isr_uart0_err,         /* UART0 error interrupt */
+    (void *) isr_uart1_rx_tx,       /* UART1 receive/transmit interrupt */
+    (void *) isr_uart1_err,         /* UART1 error interrupt */
+    (void *) isr_uart2_rx_tx,       /* UART2 receive/transmit interrupt */
+    (void *) isr_uart2_err,         /* UART2 error interrupt */
+    (void *) isr_uart3_rx_tx,       /* UART3 receive/transmit interrupt */
+    (void *) isr_uart3_err,         /* UART3 error interrupt */
+    (void *) isr_adc0,              /* Analog-to-digital converter 0 */
+    (void *) isr_cmp0,              /* Comparator 0 */
+    (void *) isr_cmp1,              /* Comparator 1 */
+    (void *) isr_ftm0,              /* FlexTimer module 0 fault overflow and channels interrupt */
+    (void *) isr_ftm1,              /* FlexTimer module 1 fault overflow and channels interrupt */
+    (void *) isr_ftm2,              /* FlexTimer module 2 fault overflow and channels interrupt */
+    (void *) isr_cmt,               /* Carrier modulator transmitter */
+    (void *) isr_rtc,               /* Real time clock */
+    (void *) isr_rtc_seconds,       /* Real time clock seconds */
+    (void *) isr_pit0,              /* Periodic interrupt timer channel 0 */
+    (void *) isr_pit1,              /* Periodic interrupt timer channel 1 */
+    (void *) isr_pit2,              /* Periodic interrupt timer channel 2 */
+    (void *) isr_pit3,              /* Periodic interrupt timer channel 3 */
+    (void *) isr_pdb0,              /* Programmable delay block */
+    (void *) isr_usb0,              /* USB OTG interrupt */
+    (void *) isr_usbdcd,            /* USB charger detect */
+    (void *) dummy_handler,         /* Reserved interrupt */
+    (void *) isr_dac0,              /* Digital-to-analog converter 0 */
+    (void *) isr_mcg,               /* Multipurpose clock generator */
+    (void *) isr_lptmr0,            /* Low power timer interrupt */
+    (void *) isr_porta,             /* Port A pin detect interrupt */
+    (void *) isr_portb,             /* Port B pin detect interrupt */
+    (void *) isr_portc,             /* Port C pin detect interrupt */
+    (void *) isr_portd,             /* Port D pin detect interrupt */
+    (void *) isr_porte,             /* Port E pin detect interrupt */
+    (void *) isr_swi,               /* Software interrupt */
+    (void *) isr_spi2,              /* Serial peripheral Interface 2 */
+    (void *) isr_uart4_rx_tx,       /* UART4 receive/transmit interrupt */
+    (void *) isr_uart4_err,         /* UART4 error interrupt */
+    (void *) isr_uart5_rx_tx,       /* UART5 receive/transmit interrupt */
+    (void *) isr_uart5_err,         /* UART5 error interrupt */
+    (void *) isr_cmp2,              /* Comparator 2 */
+    (void *) isr_ftm3,              /* FlexTimer module 3 fault overflow and channels interrupt */
+    (void *) isr_dac1,              /* Digital-to-analog converter 1 */
+    (void *) isr_adc1,              /* Analog-to-digital converter 1 */
+    (void *) isr_i2c2,              /* Inter-integrated circuit 2 */
+    (void *) isr_can0_mb,           /* CAN0 OR'd message buffers interrupt */
+    (void *) isr_can0_bus_off,      /* CAN0 bus off interrupt */
+    (void *) isr_can0_error,        /* CAN0 error interrupt */
+    (void *) isr_can0_tx_warning,   /* CAN0 tx warning interrupt */
+    (void *) isr_can0_rx_warning,   /* CAN0 rx warning interrupt */
+    (void *) isr_can0_wake_up,      /* CAN0 wake up interrupt */
+    (void *) isr_sdhc,              /* SDHC interrupt */
+    (void *) isr_enet_1588_timer,   /* Ethernet MAC IEEE 1588 Timer interrupt */
+    (void *) isr_enet_transmit,     /* Ethernet MAC transmit interrupt */
+    (void *) isr_enet_receive,      /* Ethernet MAC receive interrupt */
+    (void *) isr_enet_error,        /* Ethernet MAC error interrupt */
+    (void *) dummy_handler,         /* reserved 102 */
+    (void *) dummy_handler,         /* reserved 103 */
+    (void *) dummy_handler,         /* reserved 104 */
+    (void *) dummy_handler,         /* reserved 105 */
+    (void *) dummy_handler,         /* reserved 106 */
+    (void *) dummy_handler,         /* reserved 107 */
+    (void *) dummy_handler,         /* reserved 108 */
+    (void *) dummy_handler,         /* reserved 109 */
+    (void *) dummy_handler,         /* reserved 110 */
+    (void *) dummy_handler,         /* reserved 111 */
+    (void *) dummy_handler,         /* reserved 112 */
+    (void *) dummy_handler,         /* reserved 113 */
+    (void *) dummy_handler,         /* reserved 114 */
+    (void *) dummy_handler,         /* reserved 115 */
+    (void *) dummy_handler,         /* reserved 116 */
+    (void *) dummy_handler,         /* reserved 117 */
+    (void *) dummy_handler,         /* reserved 118 */
+    (void *) dummy_handler,         /* reserved 119 */
+    (void *) dummy_handler,         /* reserved 120 */
+    (void *) dummy_handler,         /* reserved 121 */
+    (void *) dummy_handler,         /* reserved 122 */
+    (void *) dummy_handler,         /* reserved 123 */
+    (void *) dummy_handler,         /* reserved 124 */
+    (void *) dummy_handler,         /* reserved 125 */
+    (void *) dummy_handler,         /* reserved 126 */
+    (void *) dummy_handler,         /* reserved 127 */
+    (void *) dummy_handler,         /* reserved 128 */
+    (void *) dummy_handler,         /* reserved 129 */
+    (void *) dummy_handler,         /* reserved 130 */
+    (void *) dummy_handler,         /* reserved 131 */
+    (void *) dummy_handler,         /* reserved 132 */
+    (void *) dummy_handler,         /* reserved 133 */
+    (void *) dummy_handler,         /* reserved 134 */
+    (void *) dummy_handler,         /* reserved 135 */
+    (void *) dummy_handler,         /* reserved 136 */
+    (void *) dummy_handler,         /* reserved 137 */
+    (void *) dummy_handler,         /* reserved 138 */
+    (void *) dummy_handler,         /* reserved 139 */
+    (void *) dummy_handler,         /* reserved 140 */
+    (void *) dummy_handler,         /* reserved 141 */
+    (void *) dummy_handler,         /* reserved 142 */
+    (void *) dummy_handler,         /* reserved 143 */
+    (void *) dummy_handler,         /* reserved 144 */
+    (void *) dummy_handler,         /* reserved 145 */
+    (void *) dummy_handler,         /* reserved 146 */
+    (void *) dummy_handler,         /* reserved 147 */
+    (void *) dummy_handler,         /* reserved 148 */
+    (void *) dummy_handler,         /* reserved 149 */
+    (void *) dummy_handler,         /* reserved 150 */
+    (void *) dummy_handler,         /* reserved 151 */
+    (void *) dummy_handler,         /* reserved 152 */
+    (void *) dummy_handler,         /* reserved 153 */
+    (void *) dummy_handler,         /* reserved 154 */
+    (void *) dummy_handler,         /* reserved 155 */
+    (void *) dummy_handler,         /* reserved 156 */
+    (void *) dummy_handler,         /* reserved 157 */
+    (void *) dummy_handler,         /* reserved 158 */
+    (void *) dummy_handler,         /* reserved 159 */
+    (void *) dummy_handler,         /* reserved 160 */
+    (void *) dummy_handler,         /* reserved 161 */
+    (void *) dummy_handler,         /* reserved 162 */
+    (void *) dummy_handler,         /* reserved 163 */
+    (void *) dummy_handler,         /* reserved 164 */
+    (void *) dummy_handler,         /* reserved 165 */
+    (void *) dummy_handler,         /* reserved 166 */
+    (void *) dummy_handler,         /* reserved 167 */
+    (void *) dummy_handler,         /* reserved 168 */
+    (void *) dummy_handler,         /* reserved 169 */
+    (void *) dummy_handler,         /* reserved 170 */
+    (void *) dummy_handler,         /* reserved 171 */
+    (void *) dummy_handler,         /* reserved 172 */
+    (void *) dummy_handler,         /* reserved 173 */
+    (void *) dummy_handler,         /* reserved 174 */
+    (void *) dummy_handler,         /* reserved 175 */
+    (void *) dummy_handler,         /* reserved 176 */
+    (void *) dummy_handler,         /* reserved 177 */
+    (void *) dummy_handler,         /* reserved 178 */
+    (void *) dummy_handler,         /* reserved 179 */
+    (void *) dummy_handler,         /* reserved 180 */
+    (void *) dummy_handler,         /* reserved 181 */
+    (void *) dummy_handler,         /* reserved 182 */
+    (void *) dummy_handler,         /* reserved 183 */
+    (void *) dummy_handler,         /* reserved 184 */
+    (void *) dummy_handler,         /* reserved 185 */
+    (void *) dummy_handler,         /* reserved 186 */
+    (void *) dummy_handler,         /* reserved 187 */
+    (void *) dummy_handler,         /* reserved 188 */
+    (void *) dummy_handler,         /* reserved 189 */
+    (void *) dummy_handler,         /* reserved 190 */
+    (void *) dummy_handler,         /* reserved 191 */
+    (void *) dummy_handler,         /* reserved 192 */
+    (void *) dummy_handler,         /* reserved 193 */
+    (void *) dummy_handler,         /* reserved 194 */
+    (void *) dummy_handler,         /* reserved 195 */
+    (void *) dummy_handler,         /* reserved 196 */
+    (void *) dummy_handler,         /* reserved 197 */
+    (void *) dummy_handler,         /* reserved 198 */
+    (void *) dummy_handler,         /* reserved 199 */
+    (void *) dummy_handler,         /* reserved 200 */
+    (void *) dummy_handler,         /* reserved 201 */
+    (void *) dummy_handler,         /* reserved 202 */
+    (void *) dummy_handler,         /* reserved 203 */
+    (void *) dummy_handler,         /* reserved 204 */
+    (void *) dummy_handler,         /* reserved 205 */
+    (void *) dummy_handler,         /* reserved 206 */
+    (void *) dummy_handler,         /* reserved 207 */
+    (void *) dummy_handler,         /* reserved 208 */
+    (void *) dummy_handler,         /* reserved 209 */
+    (void *) dummy_handler,         /* reserved 210 */
+    (void *) dummy_handler,         /* reserved 211 */
+    (void *) dummy_handler,         /* reserved 212 */
+    (void *) dummy_handler,         /* reserved 213 */
+    (void *) dummy_handler,         /* reserved 214 */
+    (void *) dummy_handler,         /* reserved 215 */
+    (void *) dummy_handler,         /* reserved 216 */
+    (void *) dummy_handler,         /* reserved 217 */
+    (void *) dummy_handler,         /* reserved 218 */
+    (void *) dummy_handler,         /* reserved 219 */
+    (void *) dummy_handler,         /* reserved 220 */
+    (void *) dummy_handler,         /* reserved 221 */
+    (void *) dummy_handler,         /* reserved 222 */
+    (void *) dummy_handler,         /* reserved 223 */
+    (void *) dummy_handler,         /* reserved 224 */
+    (void *) dummy_handler,         /* reserved 225 */
+    (void *) dummy_handler,         /* reserved 226 */
+    (void *) dummy_handler,         /* reserved 227 */
+    (void *) dummy_handler,         /* reserved 228 */
+    (void *) dummy_handler,         /* reserved 229 */
+    (void *) dummy_handler,         /* reserved 230 */
+    (void *) dummy_handler,         /* reserved 231 */
+    (void *) dummy_handler,         /* reserved 232 */
+    (void *) dummy_handler,         /* reserved 233 */
+    (void *) dummy_handler,         /* reserved 234 */
+    (void *) dummy_handler,         /* reserved 235 */
+    (void *) dummy_handler,         /* reserved 236 */
+    (void *) dummy_handler,         /* reserved 237 */
+    (void *) dummy_handler,         /* reserved 238 */
+    (void *) dummy_handler,         /* reserved 239 */
+    (void *) dummy_handler,         /* reserved 240 */
+    (void *) dummy_handler,         /* reserved 241 */
+    (void *) dummy_handler,         /* reserved 242 */
+    (void *) dummy_handler,         /* reserved 243 */
+    (void *) dummy_handler,         /* reserved 244 */
+    (void *) dummy_handler,         /* reserved 245 */
+    (void *) dummy_handler,         /* reserved 246 */
+    (void *) dummy_handler,         /* reserved 247 */
+    (void *) dummy_handler,         /* reserved 248 */
+    (void *) dummy_handler,         /* reserved 249 */
+    (void *) dummy_handler,         /* reserved 250 */
+    (void *) dummy_handler,         /* reserved 251 */
+    (void *) dummy_handler,         /* reserved 252 */
+    (void *) dummy_handler,         /* reserved 253 */
+    (void *) dummy_handler,         /* reserved 254 */
+    (void *) dummy_handler,         /* reserved 255 */
+};

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -829,6 +829,7 @@ EXCLUDE_PATTERNS       = */board/*/tools/* \
                          */cpu/k60/include/MK60D10.h \
                          */cpu/k60/include/MK60DZ10.h \
                          */cpu/kw2x/include/MKW22D5.h \
+                         */cpu/k64f/include/MK64F12.h \
 
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names


### PR DESCRIPTION
This PR adds support for Freescale K64F MCU and FRDM-K64F Board.

~~base on #3099~~

If someone wants to test it, http://openocd.zylin.com/#/c/2773/ or
https://github.com/jfischer-phytec-iot/openocd/tree/wip%40phytec
could be relevant.