### PR TITLE
cpu/cortexm: raised ISR stack size to safer value

### DIFF
--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -33,8 +33,8 @@ SEARCH_DIR(.)
 
 /* Define the default stack size for interrupt mode. As no context is
    saved on this stack and ISRs are supposed to be short, it can be fairly
-   small. 256 byte should be a save assumption here */
-STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x100; /* 256 byte */
+   small. 512 byte should be a save assumption here */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x200; /* 512 byte */
 
 /* Section Definitions */
 SECTIONS


### PR DESCRIPTION
256 Byte were not enough for some boards (not sure why, yet).
So go back to 512 byte as a save (and known working value).

I found this on the samr21-xpro, as RIOT is broken for this BOARD without this fix. So lets merge this VERY soon to prevent trouble for other people!