### PR TITLE
vtimer: Add forward declarations of debug functions

### DIFF
--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -35,6 +35,14 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+#if ENABLE_DEBUG
+
+void vtimer_print_short_queue(void);
+void vtimer_print_long_queue(void);
+void vtimer_print(vtimer_t *t);
+
+#endif
+
 #define VTIMER_THRESHOLD 20UL
 #define VTIMER_BACKOFF 10UL
 

--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -21,6 +21,9 @@
 #include <string.h>
 #include <inttypes.h>
 
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
 #include "irq.h"
 #include "priority_queue.h"
 #include "timex.h"
@@ -32,8 +35,6 @@
 
 #include "vtimer.h"
 
-#define ENABLE_DEBUG    (0)
-#include "debug.h"
 
 #if ENABLE_DEBUG
 


### PR DESCRIPTION
It caused build errors because of implicit declaration and conflicting types.

    riot/sys/vtimer/vtimer.c: In function ‘vtimer_callback’:
    riot/sys/vtimer/vtimer.c:207:9: error: implicit declaration of function ‘vtimer_print’ [-Werror=implicit-function-declaration]
             vtimer_print(timer);
             ^
    riot/sys/vtimer/vtimer.c: In function ‘vtimer_print_short_queue’:
    riot/sys/vtimer/vtimer.c:424:5: error: implicit declaration of function ‘priority_queue_print’ [-Werror=implicit-function-declaration]
         priority_queue_print(&shortterm_priority_queue_root);
         ^
    riot/sys/vtimer/vtimer.c: At top level:
    riot/sys/vtimer/vtimer.c:431:6: warning: conflicting types for ‘vtimer_print’
     void vtimer_print(vtimer_t *t)
          ^
    riot/sys/vtimer/vtimer.c:207:9: note: previous implicit declaration of ‘vtimer_print’ was here
             vtimer_print(timer);
             ^
    cc1: some warnings being treated as errors
    riot/Makefile.base:60: recipe for target 'riot/tests/vtimer_msg/bin/mulle/vtimer/vtimer.o' failed
    make[3]: *** [riot/tests/vtimer_msg/bin/mulle/vtimer/vtimer.o] Error 1
