### PR TITLE
core: priority_queue_add hangs on duplicate adds

### DIFF
--- a/core/priority_queue.c
+++ b/core/priority_queue.c
@@ -55,6 +55,13 @@ void priority_queue_add(priority_queue_t *root, priority_queue_node_t *new_obj)
     priority_queue_node_t *node = (priority_queue_node_t *) root;
 
     while (node->next != NULL) {
+        if (node->next == new_obj) {
+            /* Trying to add an item that is already in queue */
+#if DEVELHELP
+            core_panic(123, "priority_queue_add already existing new_obj\n");
+#endif
+            return;
+        }
         if (node->next->priority > new_obj->priority) {
             new_obj->next = node->next;
             node->next = new_obj;


### PR DESCRIPTION
The current priority_queue implementation only allows for an object to exist at a single point in the queue. I ran into this duplicate add when running the vtimer_msg test with ENABLE_DEBUG 1 in both vtimer.c and priority_queue.c. (it was probably some debug printout which took too long to complete which made the vtimer try to add the same item twice.)

Adding the same item twice is an error which should be handled somehow.