### PR TITLE
sys: newlib: make _read_r thread safe

### DIFF
--- a/sys/newlib/syscalls.c
+++ b/sys/newlib/syscalls.c
@@ -203,11 +203,13 @@ int _open_r(struct _reent *r, const char *name, int mode)
 int _read_r(struct _reent *r, int fd, void *buffer, unsigned int count)
 {
 #ifndef MODULE_UART0
+    int res;
     mutex_lock(&uart_rx_mutex);
-
+    unsigned state = disableIRQ();
     count = count < rx_buf.avail ? count : rx_buf.avail;
-
-    return ringbuffer_get(&rx_buf, (char*)buffer, count);
+    res = ringbuffer_get(&rx_buf, (char*)buffer, count);
+    restoreIRQ(state);
+    return res;
 #else
     char *res = (char*)buffer;
     res[0] = (char)uart0_readc();


### PR DESCRIPTION
previously, there was a potential race condition because both ISR and the thread could access the ringbuffer simultaneously. This PR wraps the ringbuffer access from the thread into disable/restreIRQ calls.

(depends on #3111)