### PR TITLE
ng_at86rf2xx: Implement CSMA en/disable and setting retries

### DIFF
--- a/drivers/at86rf2xx/include/at86rf2xx_registers.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_registers.h
@@ -317,6 +317,7 @@ extern "C" {
 #define AT86RF2XX_CSMA_SEED_1__AACK_SET_PD                      (0x20)
 #define AT86RF2XX_CSMA_SEED_1__AACK_DIS_ACK                     (0x10)
 #define AT86RF2XX_CSMA_SEED_1__AACK_I_AM_COORD                  (0x08)
+#define AT86RF2XX_CSMA_SEED_1__CSMA_SEED_1                      (0x07)
 /** @} */
 
 /**

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -21,6 +21,7 @@
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Daniel Krebs <github@daniel-krebs.net>
  */
 
 #ifndef AT86RF2XX_H_
@@ -333,6 +334,48 @@ uint8_t at86rf2xx_get_max_retries(at86rf2xx_t *dev);
  * @param[in] max           the maximum number of retransmissions
  */
 void at86rf2xx_set_max_retries(at86rf2xx_t *dev, uint8_t max);
+
+/**
+ * @brief   Get the maximum number of channel access attempts per frame (CSMA)
+ *
+ * @param[in] dev           device to read from
+ *
+ * @return                  configured number of retries
+ */
+uint8_t at86rf2xx_get_csma_max_retries(at86rf2xx_t *dev);
+
+/**
+ * @brief   Set the maximum number of channel access attempts per frame (CSMA)
+ *
+ * This setting specifies the number of attempts to access the channel to
+ * transmit a frame. If the channel is busy @p retries times, then frame
+ * transmission fails.
+ * Valid values: 0 to 5, -1 means CSMA disabled
+ *
+ * @param[in] dev           device to write to
+ * @param[in] max           the maximum number of retries
+ */
+void at86rf2xx_set_csma_max_retries(at86rf2xx_t *dev, int8_t retries);
+
+/**
+ * @brief   Set the min and max backoff exponent for CSMA/CA
+ *
+ * - Maximum BE: 0 - 8
+ * - Minimum BE: 0 - [max]
+ *
+ * @param[in] dev           device to write to
+ * @param[in] min           the minimum BE
+ * @param[in] max           the maximum BE
+ */
+void at86rf2xx_set_csma_backoff_exp(at86rf2xx_t *dev, uint8_t min, uint8_t max);
+
+/**
+ * @brief   Set seed for CSMA random backoff
+ *
+ * @param[in] dev           device to write to
+ * @param[in] entropy       11 bit of entropy as seed for random backoff
+ */
+void at86rf2xx_set_csma_seed(at86rf2xx_t *dev, uint8_t entropy[2]);
 
 /**
  * @brief   Enable or disable driver specific options

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -137,9 +137,31 @@ typedef enum {
      * @note not all transceivers may support this interrupt
      */
     NETOPT_TX_END_IRQ,
-    NETOPT_AUTOCCA,             /**< en/disable to check automatically
-                                 *   before sending the channel is clear. */
 
+    /**
+     * @brief Check automatically before sending if the channel is clear.
+     *
+     * This may be a hardware feature of the given transceiver, or might be
+     * otherwise implemented in software. If the device supports CSMA this
+     * option will enable CSMA with a certain set of parameters to emulate the
+     * desired behaviour.
+     *
+     * @note Be sure not to set NETCONF_OPT_CSMA simultaneously.
+     *
+     * TODO: How to get feedback?
+     */
+    NETOPT_AUTOCCA,
+
+    /**
+     * @brief en/disable CSMA/CA support
+     *
+     * If the device supports CSMA in hardware, this option enables it with
+     * default parameters. For further configuration refer to the other
+     * NETCONF_OPT_CSMA_* options.
+     */
+    NETOPT_CSMA,
+    NETOPT_CSMA_RETRIES,            /**< get/set the number of retries when
+                                         when channel is busy */
     /**
      * @brief read-only check for a wired interface.
      *

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -46,6 +46,8 @@ static const char *_netopt_strmap[] = {
     [NETOPT_TX_START_IRQ]    = "NETOPT_TX_START_IRQ",
     [NETOPT_TX_END_IRQ]      = "NETOPT_TX_END_IRQ",
     [NETOPT_AUTOCCA]         = "NETOPT_AUTOCCA",
+    [NETOPT_CSMA]            = "NETOPT_CSMA",
+    [NETOPT_CSMA_RETRIES]    = "NETOPT_CSMA_RETRIES",
     [NETOPT_IS_WIRED]        = "NETOPT_IS_WIRED",
     [NETOPT_NUMOF]           = "NETOPT_NUMOF",
 };


### PR DESCRIPTION
When enabling CSMA it defaults to 4 retries and sets min BE to 3 and max BE 5. I'm not sure if these are sensible defaults, they are the reset values of the transceiver. 

The BE cannot yet be configured though. I wasn't sure how to integrate the BE setting into the given interfaces, so any proposal is welcome!

I'm not sure if there is a way to test and verify this in the current state, but I've got more changes in the pipe that depend on this (namely TX feedback, see https://github.com/RIOT-OS/RIOT/issues/3125).
