### PR TITLE
core: get rid of warning: unused parameter 'crash_code'

### DIFF
--- a/core/panic.c
+++ b/core/panic.c
@@ -40,6 +40,8 @@ static int crashed = 0;
 /* WARNING: this function NEVER returns! */
 NORETURN void core_panic(int crash_code, const char *message)
 {
+    (void) crash_code;
+
     if (crashed == 0) {
         /* print panic message to console (if possible) */
         crashed = 1;


### PR DESCRIPTION
While building the tests for https://github.com/RIOT-OS/RIOT/pull/2985 I got the warning 

    /home/lotte/riot/RIOT/core/panic.c:41:30: warning: unused parameter 'crash_code' [-Wunused-parameter]
    NORETURN void core_panic(int crash_code, const char *message)
                                 ^
    1 warning generated.

This PR should make it disappear.