### PR TITLE
core: include missing thread.h to debug.h

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -31,6 +31,7 @@
 
 #include <stdio.h>
 #include "sched.h"
+#include "thread.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The thread sizes are now defined via `thread.h` so we need to include it in `debug.h` if `DEVELHELP` is activated