### PR TITLE
net/fib: Added network prefix flag to indicate a network destination

### DIFF
--- a/sys/include/net/fib.h
+++ b/sys/include/net/fib.h
@@ -83,6 +83,11 @@ typedef struct fib_destination_set_entry_t {
 #define FIB_FLAG_RPL_ROUTE (1UL << 0)
 
 /**
+ * @brief flag to identify if the FIB-Entry is a net prefix (MSB == 1)
+ */
+#define FIB_FLAG_NET_PREFIX (1UL<<31)
+
+/**
  * @brief initializes all FIB entries with 0
  *
  * @param[in] table         the fib instance to initialize

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -242,7 +242,8 @@ void gnrc_rpl_parent_update(gnrc_rpl_dodag_t *dodag, gnrc_rpl_parent_t *parent)
             ipv6_addr_t all_RPL_nodes = GNRC_RPL_ALL_NODES_ADDR;
             kernel_pid_t if_id;
             if ((if_id = gnrc_ipv6_netif_find_by_addr(NULL, &all_RPL_nodes)) != KERNEL_PID_UNDEF) {
-                fib_add_entry(&gnrc_ipv6_fib_table, if_id, def.u8, sizeof(ipv6_addr_t), 0x0,
+                fib_add_entry(&gnrc_ipv6_fib_table, if_id, def.u8, sizeof(ipv6_addr_t),
+                              (FIB_FLAG_NET_PREFIX | 0x0),
                               parent->addr.u8, sizeof(ipv6_addr_t), FIB_FLAG_RPL_ROUTE,
                               (dodag->default_lifetime * dodag->lifetime_unit) * SEC_IN_MS);
             }
@@ -304,7 +305,7 @@ static gnrc_rpl_parent_t *_gnrc_rpl_find_preferred_parent(gnrc_rpl_dodag_t *doda
         }
 
         fib_add_entry(&gnrc_ipv6_fib_table, if_id, def.u8, sizeof(ipv6_addr_t),
-                      0x0, dodag->parents->addr.u8, sizeof(ipv6_addr_t),
+                      (FIB_FLAG_NET_PREFIX | 0x0), dodag->parents->addr.u8, sizeof(ipv6_addr_t),
                       FIB_FLAG_RPL_ROUTE, (dodag->default_lifetime * dodag->lifetime_unit)
                       * SEC_IN_MS);
     }

--- a/tests/unittests/tests-fib/tests-fib.c
+++ b/tests/unittests/tests-fib/tests-fib.c
@@ -492,20 +492,24 @@ static void test_fib_14_exact_and_prefix_match(void)
 
     snprintf(addr_dst, add_buf_size, "Test addr12");
     snprintf(addr_nxt, add_buf_size, "Test address %02d", 12);
+
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
-                  add_buf_size - 1, 0x12, (uint8_t *)addr_nxt, add_buf_size - 1,
+                  add_buf_size - 1, (FIB_FLAG_NET_PREFIX | 0x12),
+                  (uint8_t *)addr_nxt, add_buf_size - 1,
                   0x12, 100000);
 
     snprintf(addr_dst, add_buf_size, "Test addr123");
     snprintf(addr_nxt, add_buf_size, "Test address %02d", 23);
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
-                  add_buf_size - 1, 0x123, (uint8_t *)addr_nxt, add_buf_size - 1,
+                  add_buf_size - 1, (FIB_FLAG_NET_PREFIX | 0x123),
+                  (uint8_t *)addr_nxt, add_buf_size - 1,
                   0x23, 100000);
 
     snprintf(addr_dst, add_buf_size, "Test addr1234");
     snprintf(addr_nxt, add_buf_size, "Test address %02d", 34);
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
-                  add_buf_size - 1, 0x1234, (uint8_t *)addr_nxt, add_buf_size - 1,
+                  add_buf_size - 1, (FIB_FLAG_NET_PREFIX | 0x1234),
+                  (uint8_t *)addr_nxt, add_buf_size - 1,
                   0x34, 100000);
 
     memset(addr_lookup, 0, add_buf_size);
@@ -609,12 +613,14 @@ static void test_fib_16_prefix_match(void)
     addr_lookup[14] = (char)0x87; /* 1000 0111 */
 
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
-                  add_buf_size - 1, 0x123, (uint8_t *)addr_nxt, add_buf_size - 1,
+                  add_buf_size - 1, (FIB_FLAG_NET_PREFIX | 0x123),
+                  (uint8_t *)addr_nxt, add_buf_size - 1,
                   0x23, 100000);
 
     addr_dst[14] = (char)0x3c;    /* 0011 1100 */
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
-                  add_buf_size - 1, 0x123, (uint8_t *)addr_nxt, add_buf_size - 1,
+                  add_buf_size - 1, (FIB_FLAG_NET_PREFIX | 0x123),
+                  (uint8_t *)addr_nxt, add_buf_size - 1,
                   0x23, 100000);
 
     memset(addr_nxt, 0, add_buf_size);
@@ -631,7 +637,8 @@ static void test_fib_16_prefix_match(void)
     add_buf_size = 16;
 
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
-                  add_buf_size - 1, 0x123, (uint8_t *)addr_nxt, add_buf_size -
+                  add_buf_size - 1, (FIB_FLAG_NET_PREFIX | 0x123),
+                  (uint8_t *)addr_nxt, add_buf_size -
                   1, 0x23, 100000);
 
     memset(addr_nxt, 0, add_buf_size);
@@ -687,6 +694,9 @@ static void test_fib_17_get_entry_set(void)
     fib_destination_set_entry_t arr_dst[arr_size];
     char prefix[addr_buf_size];
     memset(prefix,0, addr_buf_size);
+    /* cppcheck: prefix is set to all 0 before adding an address
+    */
+    /* cppcheck-suppress redundantCopy */
     snprintf(prefix, addr_buf_size, "Test address 1");
 
     int ret = fib_get_destination_set(&test_fib_table,
@@ -699,6 +709,9 @@ static void test_fib_17_get_entry_set(void)
     arr_size = 20;
 
     memset(prefix,0, addr_buf_size);
+    /* cppcheck: prefix is set to all 0 before adding an address
+    */
+    /* cppcheck-suppress redundantCopy */
     snprintf(prefix, addr_buf_size, "Test address 0");
 
     ret = fib_get_destination_set(&test_fib_table,
@@ -800,7 +813,8 @@ static void test_fib_19_default_gateway(void)
 
     /* add a default gateway entry */
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
-                  add_buf_size, 0x123, (uint8_t *)addr_nxt, add_buf_size, 0x23,
+                  add_buf_size, (FIB_FLAG_NET_PREFIX | 0x123),
+                  (uint8_t *)addr_nxt, add_buf_size, 0x23,
                   100000);
 
     /* check if it matches all */
@@ -876,7 +890,8 @@ static void test_fib_20_replace_prefix(void)
 
     /* add a prefix entry */
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
-                  add_buf_size, 0x123, (uint8_t *)addr_nxt, add_buf_size, 0x23,
+                  add_buf_size, (FIB_FLAG_NET_PREFIX | 0x123),
+                  (uint8_t *)addr_nxt, add_buf_size, 0x23,
                   100000);
 
     /* check if it matches */
@@ -905,7 +920,8 @@ static void test_fib_20_replace_prefix(void)
 
     /* change the prefix entry */
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
-                  add_buf_size, 0x123, (uint8_t *)addr_nxt, add_buf_size, 0x24,
+                  add_buf_size, (FIB_FLAG_NET_PREFIX | 0x123),
+                  (uint8_t *)addr_nxt, add_buf_size, 0x24,
                   100000);
 
     /* and check again if it matches  */


### PR DESCRIPTION
This PR introduces a specific flag (`FIB_FLAG_NET_PREFIX`) for FIB entries used to indicate if a destination of the entry is a host or a network.

**edit:** The FIB now considers this flag to decide if the given address is a host or network. 
So if not set the FIB assumes a host address, even if the address is all (trailing)zeros `::`