### PR TITLE
ng_net: add IID option and simplify upper layers accordingly

### DIFF
--- a/drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c
+++ b/drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c
@@ -19,6 +19,7 @@
  * @}
  */
 
+#include "net/eui64.h"
 #include "net/ng_ieee802154.h"
 #include "net/ng_netbase.h"
 #include "ng_at86rf2xx.h"
@@ -399,6 +400,20 @@ static int _get(ng_netdev_t *device, ng_netconf_opt_t opt,
             }
             *((uint16_t *)val) = dev->pan;
             return sizeof(uint16_t);
+
+        case NETCONF_OPT_IPV6_IID:
+            if (max_len < sizeof(eui64_t)) {
+                return -EOVERFLOW;
+            }
+            if (dev->options & NG_AT86RF2XX_OPT_SRC_ADDR_LONG) {
+                uint64_t addr = ng_at86rf2xx_get_addr_long(dev);
+                ng_ieee802154_get_iid(val, (uint8_t *)&addr, 8);
+            }
+            else {
+                uint16_t addr = ng_at86rf2xx_get_addr_short(dev);
+                ng_ieee802154_get_iid(val, (uint8_t *)&addr, 2);
+            }
+            return sizeof(eui64_t);
 
         case NETCONF_OPT_PROTO:
             if (max_len < sizeof(ng_nettype_t)) {

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -25,6 +25,8 @@
 #include "xbee.h"
 #include "hwtimer.h"
 #include "msg.h"
+#include "net/eui64.h"
+#include "net/ng_ieee802154.h"
 #include "periph/cpuid.h"
 
 #define ENABLE_DEBUG    (0)
@@ -620,6 +622,18 @@ static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt,
                 *((uint16_t *)value) = 2;
             }
             return sizeof(uint16_t);
+        case NETCONF_OPT_IPV6_IID:
+            if (max_len < sizeof(eui64_t)) {
+                return -EOVERFLOW;
+            }
+            if (dev->addr_flags & XBEE_ADDR_FLAGS_LONG) {
+                ng_ieee802154_get_iid(value, (uint8_t *)&dev->addr_long, 8);
+            }
+            else {
+                ng_ieee802154_get_iid(value, (uint8_t *)&dev->addr_short, 2);
+            }
+
+            return sizeof(eui64_t);
         case NETCONF_OPT_CHANNEL:
             return _get_channel(dev, (uint8_t *)value, max_len);
         case NETCONF_OPT_MAX_PACKET_SIZE:

--- a/sys/include/net/eui64.h
+++ b/sys/include/net/eui64.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_eui64   IEEE EUI-64 identifier
+ * @ingroup     net
+ * @brief       Type definiton of the IEEE EUI-64 identifier
+ * @see         <a href="http://standards.ieee.org/regauth/oui/tutorials/EUI64.html">
+ *                  IEEE, "Guidelines for 64-bit Global Identifier (EUI-64)"
+ *              </a>
+ * @{
+ *
+ * @file
+ * @brief   EUI-64 data type definition
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author  Oliver Hahm <oliver.hahm@inria.fr>
+ */
+#ifndef EUI64_H_
+#define EUI64_H_
+
+#include <stdint.h>
+#include "byteorder.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Data type to represent an EUI-64.
+ */
+typedef union {
+    network_uint64_t uint64;     /**< represented as 64 bit value */
+    uint8_t uint8[8];            /**< split into 8 8-bit words. */
+    network_uint16_t uint16[4];  /**< split into 4 16-bit words. */
+} eui64_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EUI64_H_ */
+/** @} */

--- a/sys/include/net/ng_ethernet.h
+++ b/sys/include/net/ng_ethernet.h
@@ -22,7 +22,10 @@
 #ifndef NG_ETHERNET_H_
 #define NG_ETHERNET_H_
 
+#include <stdint.h>
+
 #include "net/ng_ethernet/hdr.h"
+#include "net/eui64.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,6 +48,29 @@ extern "C" {
  */
 #define NG_ETHERNET_MAX_LEN     (NG_ETHERNET_FRAME_LEN + \
                                  NG_ETHERNET_FCS_LEN)
+
+/**
+ * @brief   Generates an IPv6 interface identifier from a 48-bit MAC address.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc2464#section-4">
+ *          RFC 2464, section 4
+ *      </a>
+ *
+ * @param[out] eui64    The resulting EUI-64.
+ * @param[in] mac       A 48-bit MAC address. Is expected to be at least
+ *                      @ref NG_ETHERNET_ADDR_LEN long.
+ */
+static inline void ng_ethernet_get_iid(eui64_t *eui64, uint8_t *mac)
+{
+    eui64->uint8[0] = mac[0] ^ 0x02;
+    eui64->uint8[1] = mac[1];
+    eui64->uint8[2] = mac[2];
+    eui64->uint8[3] = 0xff;
+    eui64->uint8[4] = 0xfe;
+    eui64->uint8[5] = mac[3];
+    eui64->uint8[6] = mac[4];
+    eui64->uint8[7] = mac[5];
+}
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/ng_ieee802154.h
+++ b/sys/include/net/ng_ieee802154.h
@@ -21,6 +21,8 @@
 #ifndef NG_IEEE802154_H_
 #define NG_IEEE802154_H_
 
+#include <stdlib.h>
+
 #include "net/eui64.h"
 
 #ifdef __cplusplus
@@ -59,6 +61,64 @@ extern "C" {
 #define NG_IEEE802154_FCF_SRC_ADDR_SHORT    (0x80)
 #define NG_IEEE802154_FCF_SRC_ADDR_LONG     (0xc0)
 /** @} */
+
+/**
+ * @brief   Generates an IPv6 interface identifier from an IEEE 802.15.4 address.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc4944#section-6">
+ *          RFC 4944, section 6
+ *      </a>
+ * @see <a href="https://tools.ietf.org/html/rfc6282#section-3.2.2">
+ *          RFC 6282, section 3.2.2
+ *      </a>
+ *
+ * @param[out] eui64    The resulting EUI-64.
+ * @param[in] addr      An IEEE 802.15.4 address.
+ * @param[in] addr_len  The length of @p addr. Must be 2 (short address),
+ *                      4 (PAN ID + short address), or 8 (long address).
+ *
+ * @return Copy of @p eui64 on success.
+ * @return NULL, if @p addr_len was of illegal length.
+ */
+static inline eui64_t *ng_ieee802154_get_iid(eui64_t *eui64, uint8_t *addr,
+                                             size_t addr_len)
+{
+    int i = 0;
+
+    eui64->uint8[0] = eui64->uint8[1] = 0;
+
+    switch (addr_len) {
+        case 8:
+            eui64->uint8[0] = addr[i++] ^ 0x02;
+            eui64->uint8[1] = addr[i++];
+            eui64->uint8[2] = addr[i++];
+            eui64->uint8[3] = addr[i++];
+            eui64->uint8[4] = addr[i++];
+            eui64->uint8[5] = addr[i++];
+            eui64->uint8[6] = addr[i++];
+            eui64->uint8[7] = addr[i++];
+            break;
+
+        case 4:
+            eui64->uint8[0] = addr[i++] ^ 0x02;
+            eui64->uint8[1] = addr[i++];
+
+        case 2:
+            eui64->uint8[2] = 0;
+            eui64->uint8[3] = 0xff;
+            eui64->uint8[4] = 0xfe;
+            eui64->uint8[5] = 0;
+            eui64->uint8[6] = addr[i++];
+            eui64->uint8[7] = addr[i++];
+            break;
+
+        default:
+            return NULL;
+    }
+
+    return eui64;
+}
+
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/ng_ieee802154.h
+++ b/sys/include/net/ng_ieee802154.h
@@ -21,8 +21,7 @@
 #ifndef NG_IEEE802154_H_
 #define NG_IEEE802154_H_
 
-#include <stdint.h>
-#include "byteorder.h"
+#include "net/eui64.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,15 +59,6 @@ extern "C" {
 #define NG_IEEE802154_FCF_SRC_ADDR_SHORT    (0x80)
 #define NG_IEEE802154_FCF_SRC_ADDR_LONG     (0xc0)
 /** @} */
-
-/**
- * @brief Data type to represent an EUI-64.
- */
-typedef union {
-    le_uint64_t uint64;     /**< represented as 64 bit value */
-    uint8_t uint8[8];       /**< split into 8 8-bit words. */
-    le_uint16_t uint16[4];  /**< split into 4 16-bit words. */
-} eui64_t ;
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/ng_netconf.h
+++ b/sys/include/net/ng_netconf.h
@@ -55,6 +55,22 @@ typedef enum {
      * Examples for this include the PAN ID in IEEE 802.15.4
      */
     NETCONF_OPT_NID,
+
+    /**
+     * @brief   get the IPv6 interface identifier of a network interface as
+     *          eui64_t.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc4291#section-2.5.1">
+     *          RFC 4291, section 2.5.1
+     *      </a>
+     *
+     * The generation of the interface identifier is dependent on the link-layer.
+     * Please refer to the appropriate IPv6 over `<link>` specification for
+     * further implementation details (such as
+     * <a href="https://tools.ietf.org/html/rfc2464">RFC 2464</a> or
+     * <a href="https://tools.ietf.org/html/rfc4944">RFC 4944</a>).
+     */
+    NETCONF_OPT_IPV6_IID,
     NETCONF_OPT_TX_POWER,           /**< get/set the output power for radio
                                      *   devices in dBm as int16_t in host byte
                                      *   order */

--- a/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
+++ b/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
@@ -20,6 +20,7 @@
 
 #include "kernel_types.h"
 #include "mutex.h"
+#include "net/eui64.h"
 #include "net/ng_ipv6/addr.h"
 #include "net/ng_ndp.h"
 #include "net/ng_netapi.h"
@@ -445,62 +446,6 @@ ng_ipv6_addr_t *ng_ipv6_netif_find_best_src_addr(kernel_pid_t pid, const ng_ipv6
     return _match_prefix(pid, dest, true);
 }
 
-/* TODO: put this somewhere more central and L2 protocol dependent */
-#define IID_LEN (8)
-
-static bool _hwaddr_to_iid(uint8_t *iid, const uint8_t *hwaddr, size_t hwaddr_len)
-{
-    uint8_t i = 0;
-
-    memset(iid, 0, IID_LEN);
-
-    switch (hwaddr_len) {
-        case 8:
-            iid[0] = hwaddr[i++];
-            iid[0] ^= 0x02;
-            iid[1] = hwaddr[i++];
-            iid[2] = hwaddr[i++];
-            iid[3] = hwaddr[i++];
-            iid[4] = hwaddr[i++];
-            iid[5] = hwaddr[i++];
-            iid[6] = hwaddr[i++];
-            iid[7] = hwaddr[i++];
-            break;
-
-        case 6:
-            iid[0] = hwaddr[i++];
-            iid[0] ^= 0x02;
-            iid[1] = hwaddr[i++];
-            iid[2] = hwaddr[i++];
-            iid[3] = 0xff;
-            iid[4] = 0xfe;
-            iid[5] = hwaddr[i++];
-            iid[6] = hwaddr[i++];
-            iid[7] = hwaddr[i++];
-            break;
-
-        case 4:
-            iid[0] = hwaddr[i++];
-            iid[0] ^= 0x02;
-            iid[1] = hwaddr[i++];
-
-        case 2:
-            iid[6] = hwaddr[i++];
-
-        case 1:
-            iid[3] = 0xff;
-            iid[4] = 0xfe;
-            iid[7] = hwaddr[i++];
-            break;
-
-        default:
-            DEBUG("Unknown hardware address length\n");
-            return false;
-    }
-
-    return true;
-}
-
 void ng_ipv6_netif_init_by_dev(void)
 {
     kernel_pid_t ifs[NG_NETIF_NUMOF];
@@ -508,11 +453,8 @@ void ng_ipv6_netif_init_by_dev(void)
 
     for (size_t i = 0; i < ifnum; i++) {
         ng_ipv6_addr_t addr;
-        uint16_t hwaddr_len = 0;
-        uint8_t hwaddr[NG_NETIF_HDR_L2ADDR_MAX_LEN];
-        bool try_long = false;
+        eui64_t iid;
         ng_ipv6_netif_t *ipv6_if = ng_ipv6_netif_get(ifs[i]);
-        int res = 0;
 
         if (ipv6_if == NULL) {
             continue;
@@ -532,25 +474,14 @@ void ng_ipv6_netif_init_by_dev(void)
 
 #endif
 
-        if ((ng_netapi_get(ifs[i], NETCONF_OPT_SRC_LEN, 0, &hwaddr_len,
-                           sizeof(hwaddr_len)) != -ENOTSUP) &&
-            (hwaddr_len == 8)) {
-            try_long = true;
+        if ((ng_netapi_get(ifs[i], NETCONF_OPT_IPV6_IID, 0, &iid,
+                           sizeof(eui64_t)) < 0)) {
+            continue;
         }
 
-        if ((try_long && ((res = ng_netapi_get(ifs[i], NETCONF_OPT_ADDRESS_LONG, 0,
-                                               &hwaddr, sizeof(hwaddr))) > 0)) ||
-            ((res = ng_netapi_get(ifs[i], NETCONF_OPT_ADDRESS, 0, &hwaddr,
-                                  sizeof(hwaddr))) > 0)) {
-            uint8_t iid[IID_LEN];
-            hwaddr_len = (uint16_t)res;
-
-            if (_hwaddr_to_iid(iid, hwaddr, hwaddr_len)) {
-                ng_ipv6_addr_set_aiid(&addr, iid);
-                ng_ipv6_addr_set_link_local_prefix(&addr);
-                _add_addr_to_entry(ipv6_if, &addr, 64, 0);
-            }
-        }
+        ng_ipv6_addr_set_aiid(&addr, iid.uint8);
+        ng_ipv6_addr_set_link_local_prefix(&addr);
+        _add_addr_to_entry(ipv6_if, &addr, 64, 0);
 
         mutex_unlock(&ipv6_if->mutex);
     }


### PR DESCRIPTION
This puts the IPv6 IID generation from the link-layer address where it belongs: into the link-layer.

Overview:

* introducing a new option for this `NETCONF_OPT_IPV6_IID`
* introducing a function `ng_xxx_get_iid()` per supported link layer (`ng_ieee802154` and `ng_ethernet`).
* adapting the current `ng_` drivers to support the `NETCONF_OPT_IPV6_IID` option via their respective link layer's `ng_xxx_get_iid()`
* adapting `ng_ipv6_netif` to use `NETCONF_OPT_IPV6_IID` for IPv6 addresse initialization
* adapting `ng_sixlowpan_iphc` to use `NETCONF_OPT_IPV6_IID` for source address (de)compression and `ng_ieee802154_get_iid()` for destination address (de)compression

Depends on #3158.