### PR TITLE
sys: factor stdio uart functions out of newlib's syscalls

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -325,3 +325,7 @@ ifneq (,$(filter cpp11-compat,$(USEMODULE)))
   USEMODULE += timex
   FEATURES_REQUIRED += cpp
 endif
+
+ifneq (,$(filter newlib,$(USEMODULE)))
+  USEMODULE += uart_stdio
+endif

--- a/sys/include/uart_stdio.h
+++ b/sys/include/uart_stdio.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_uart_stdio UART stdio
+ * @ingroup     sys
+ *
+ * @brief       stdio init/read/write functions for UARTs
+ *
+ * @{
+ * @file
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+#ifndef UART_STDIO_H
+#define UART_STDIO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief initialize the module
+ */
+void uart_stdio_init(void);
+
+/**
+ * @brief read @p len bytes from stdio uart into @p buffer
+ *
+ * @param[out]  buffer  buffer to read into
+ * @param[in]   len     nr of bytes to read
+ *
+ * @return nr of bytes read
+ * @return <0 on error
+ */
+int uart_stdio_read(char* buffer, int len);
+
+/**
+ * @brief write @p len bytes from @p buffer into uart
+ *
+ * @param[in]   buffer  buffer to read from
+ * @param[in]   len     nr of bytes to write
+ *
+ * @return nr of bytes written
+ * @return <0 on error
+ */
+int uart_stdio_write(const char* buffer, int len);
+
+/**
+ * @brief internal callback for periph/uart drivers
+ *
+ * @param[in]   arg     (unused)
+ * @param[in]   data    character that has been received
+ */
+void uart_stdio_rx_cb(void *arg, char data);
+
+#ifdef __cplusplus
+}
+#endif
+/** @} */
+#endif /* UART_STDIO_H */

--- a/sys/uart_stdio/Makefile
+++ b/sys/uart_stdio/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/uart_stdio/uart_stdio.c
+++ b/sys/uart_stdio/uart_stdio.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2013 INRIA
+ *               2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys
+ * @{
+ *
+ * @file
+ * @brief UART stdio implementation
+ *
+ * This file implements a UART callback and read/write functions.
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "cpu_conf.h"
+#include "ringbuffer.h"
+#include "thread.h"
+#include "mutex.h"
+#include "irq.h"
+
+#include "periph/uart.h"
+
+#include "board.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+#ifndef STDIO_RX_BUFSIZE
+#define STDIO_RX_BUFSIZE (64)
+#endif
+
+/**
+ * @brief use mutex for waiting on incoming UART chars
+ */
+static mutex_t _rx_mutex = MUTEX_INIT;
+static char _rx_buf_mem[STDIO_RX_BUFSIZE];
+static ringbuffer_t _rx_buf;
+
+/**
+ * @brief Receive a new character from the UART and put it into the receive buffer
+ */
+void uart_stdio_rx_cb(void *arg, char data)
+{
+    (void)arg;
+    ringbuffer_add_one(&_rx_buf, data);
+    mutex_unlock(&_rx_mutex);
+}
+
+void uart_stdio_init(void)
+{
+    mutex_lock(&_rx_mutex);
+    ringbuffer_init(&_rx_buf, _rx_buf_mem, STDIO_RX_BUFSIZE);
+    uart_init(STDIO, STDIO_BAUDRATE, uart_stdio_rx_cb, 0, 0);
+}
+
+int uart_stdio_read(char* buffer, int count)
+{
+    int res;
+    mutex_lock(&_rx_mutex);
+    unsigned state = disableIRQ();
+    count = (count < _rx_buf.avail) ? count : _rx_buf.avail;
+    res = ringbuffer_get(&_rx_buf, (char*)buffer, count);
+    restoreIRQ(state);
+    return res;
+}
+
+int uart_stdio_write(const char* buffer, int len)
+{
+    unsigned int i = len;
+
+    while (i--) {
+        uart_write_blocking(STDIO, *buffer++);
+    }
+
+    return len;
+}


### PR DESCRIPTION
I'll be introducing a musl libc port for RIOT soon. This is groundwork to decouple shared functionality.