### PR TITLE
board/native: adapted Makefile.dep for netif init

### DIFF
--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -1,5 +1,6 @@
 PSEUDOMODULES += defaulttransceiver
 PSEUDOMODULES += transport_layer
+PSEUDOMODULES += ng_netif_default
 PSEUDOMODULES += ng_ieee802154
 PSEUDOMODULES += ng_ipv6_default
 PSEUDOMODULES += ng_ipv6_router

--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -1,9 +1,13 @@
 ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
-    ifeq (,$(filter ng_netif,$(USEMODULE)))
-        USEMODULE += nativenet
+    USEMODULE += nativenet
+    ifeq (,$(filter netdev_base,$(USEMODULE)))
         USEMODULE += transceiver
-    else
-        USEMODULE += ng_nativenet
-        USEMODULE += ng_netdev_eth
     endif
+endif
+
+ifneq (,$(filter ng_netif_default,$(USEMODULE)))
+    USEMODULE += ng_netif
+    USEMODULE += ng_nativenet
+    USEMODULE += ng_netdev_eth
+    USEMODULE += ng_nomac
 endif

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -374,7 +374,7 @@ __attribute__((constructor)) static void startup(int argc, char **argv)
 #endif
 #ifdef MODULE_NG_NATIVENET
 # ifdef MODULE_NATIVENET
-#  error  "Modules nativenet and ng_native are mutually exclusive."
+#  error  "Modules nativenet and ng_nativenet are mutually exclusive."
 # endif
     dev_eth_tap_setup(&dev_eth_tap, argv[1]);
 #endif


### PR DESCRIPTION
The new network stack does not now the concept of the defaulttransceiver, so this fix makes auto_init_ng_netif work for now.