### PR TITLE
make: build with linker garbage collection

### DIFF
--- a/boards/Makefile.include.cortexm_common
+++ b/boards/Makefile.include.cortexm_common
@@ -36,6 +36,7 @@ export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DEBUG)
 export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts -L$(RIOTCPU)/cortexm_common/ldscripts
 export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL).ld -Wl,--fatal-warnings
 export LINKFLAGS += $(CFLAGS_DEBUG) $(CFLAGS_CPU) $(CFLAGS_STYLE) -static -lgcc -nostartfiles
+export LINKFLAGS += -Wl,--gc-sections
 
 # Import all toolchain settings
 include $(RIOTBOARD)/Makefile.include.$(TOOLCHAIN)

--- a/boards/redbee-econotag/Makefile.include
+++ b/boards/redbee-econotag/Makefile.include
@@ -19,7 +19,7 @@ export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
 FLASHER = mc1322x-load.pl
 TERM = pyterm
-LINKFLAGS += -mcpu=arm7tdmi-s -static -lgcc -nostartfiles -T$(RIOTBASE)/cpu/$(CPU)/mc1322x.lds
+LINKFLAGS += -mcpu=arm7tdmi-s -static -lgcc -nostartfiles -Wl,--gc-sections -T$(RIOTBASE)/cpu/$(CPU)/mc1322x.lds
 
 ifeq ($(strip $(PORT)),)
 	export PORT = /dev/ttyUSB0


### PR DESCRIPTION
Adopted #1784 and rebased on latest master.

Currently only has the linker flag --gc-sections defined which tells
the linker to omit dead code. Depending on the application this leads
to significant reduction of code size.