### PR TITLE
net/eth_netdev: fixed debug hex_dump condition

### DIFF
--- a/sys/net/link_layer/ng_netdev_eth/ng_netdev_eth.c
+++ b/sys/net/link_layer/ng_netdev_eth/ng_netdev_eth.c
@@ -119,7 +119,7 @@ static int _send_data(ng_netdev_t *netdev, ng_pktsnip_t *pkt)
     }
 
     DEBUG("ng_netdev_eth: send %d bytes\n", to_send);
-#if MODULE_OD && defined(ENABLE_DEBUG)
+#if defined(MODULE_OD) && ENABLE_DEBUG
     od_hex_dump(send_buffer, to_send, OD_WIDTH_DEFAULT);
 #endif
 


### PR DESCRIPTION
The eth_netdev module was dumping outgoing data independent of the DEBUG flag status (which was quite annoying...). 