### PR TITLE
fib: auto init

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -112,6 +112,10 @@
 #include "dev_eth_autoinit.h"
 #endif
 
+#ifdef MODULE_FIB
+#include "net/ng_fib.h"
+#endif
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -314,6 +318,10 @@ void auto_init(void)
 #ifdef MODULE_NG_UDP
     DEBUG("Auto init UDP module.\n");
     ng_udp_init();
+#endif
+#ifdef MODULE_FIB
+    DEBUG("Auto init FIB module.\n");
+    fib_init();
 #endif
 
 


### PR DESCRIPTION
see https://github.com/RIOT-OS/RIOT/pull/3050#discussion_r31076340

Since `fib_init()` doesn't expect any arguments, it makes sense to put this into `auto_init`.