### PR TITLE
drivers/dht: add support for DHT21

### DIFF
--- a/drivers/include/dht.h
+++ b/drivers/include/dht.h
@@ -46,7 +46,8 @@ typedef struct {
  */
 typedef enum {
     DHT11,                  /**< DHT11 device identifier */
-    DHT22                   /**< DHT22 device identifier */
+    DHT22,                  /**< DHT22 device identifier */
+    DHT21 = DHT22           /**< DHT21 device identifier */
 } dht_type_t;
 
 /**


### PR DESCRIPTION
The DHT21 has the exact same interface as the DHT22, just a lower precision.