### PR TITLE
ng_icmpv6: fix release of pkt

### DIFF
--- a/sys/net/network_layer/ng_icmpv6/ng_icmpv6.c
+++ b/sys/net/network_layer/ng_icmpv6/ng_icmpv6.c
@@ -135,7 +135,7 @@ void ng_icmpv6_demux(kernel_pid_t iface, ng_pktsnip_t *pkt)
     }
 
     /* ICMPv6 is not interested anymore so `- 1` */
-    ng_pktbuf_hold(pkt, ng_netreg_num(NG_NETTYPE_ICMPV6, hdr->type) - 1);
+    ng_pktbuf_hold(pkt, ng_netreg_num(NG_NETTYPE_ICMPV6, hdr->type));
 
     while (sendto != NULL) {
         ng_netapi_receive(sendto->pid, pkt);

--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -178,8 +178,10 @@ int _icmpv6_ping(int argc, char **argv)
                 case NG_NETAPI_MSG_TYPE_RCV:
                     vtimer_now(&stop);
                     stop = timex_sub(stop, start);
-                    success += _handle_reply((ng_pktsnip_t *)msg.content.ptr,
-                                             timex_uint64(stop));
+
+                    ng_pktsnip_t *pkt = (ng_pktsnip_t *)msg.content.ptr;
+                    success += _handle_reply(pkt, timex_uint64(stop));
+                    ng_pktbuf_release(pkt);
 
                     if (timex_cmp(stop, max_rtt) > 0) {
                         max_rtt = stop;


### PR DESCRIPTION
This PR may fix the Ping of Death issue. Needs some more testing.
Can you verify @haukepetersen @authmillenon ?

EDIT:
Rationale:
It appears to me that the number of users of the current icmpv6 packet is reduced to zero before it is send to the ping shell handler. Thus, it gets released in [ng_ipv6.c#L111](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/network_layer/ng_ipv6/ng_ipv6.c#L111) somewhen before/after/or in the middle of the shell handler processing the ping reply.

EDIT2:
Which makes sense, because the ip(/icmp) thread never registered for icmpv6 messages, but for ipv6 messages, therefore it should not reduce the users count.