### PR TITLE
openocd: fix SERIAL env to select board

### DIFF
--- a/boards/samr21-xpro/Makefile.include
+++ b/boards/samr21-xpro/Makefile.include
@@ -11,6 +11,13 @@ include $(RIOTBOARD)/$(BOARD)/Makefile.dep
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial
 
+# Add board selector (USB serial) to OpenOCD options if specified.
+# Use /dist/tools/usb-serial/list-ttys.sh to find out serial number.
+#   Usage: SERIAL="ATML..." BOARD="samr21-xpro" make flash
+ifneq (,$(SERIAL))
+export OPENOCD_EXTRA_INIT += "-c cmsis_dap_serial $(SERIAL)"
+endif
+
 # this board uses openocd
 include $(RIOTBOARD)/Makefile.include.openocd
 


### PR DESCRIPTION
Selecting a board when `make flash`ing by `SERIAL` environment variable has been broken by f5c67ebe626580da732d3dd73942a03bebb68728. This PR fixes it.