### PR TITLE
auto_init_ng_netif: fix DEBUG output for xbee

### DIFF
--- a/sys/auto_init/netif/auto_init_xbee.c
+++ b/sys/auto_init/netif/auto_init_xbee.c
@@ -48,8 +48,8 @@ static char _nomac_stacks[XBEE_MAC_STACKSIZE][XBEE_NUM];
 void auto_init_xbee(void)
 {
     for (int i = 0; i < XBEE_NUM; i++) {
-        DEBUG("Initializing XBee radio at UART_%i\n", i);
         const xbee_params_t *p = &xbee_params[i];
+        DEBUG("Initializing XBee radio at UART_%i\n", p->uart);
         int res = xbee_init(&xbee_devs[i],
                 p->uart,
                 p->baudrate,


### PR DESCRIPTION
Output UART number instead of `xbee_param_t` index.