### PR TITLE
cpu: cortexm_common: set default value for CPU_MODEL

### DIFF
--- a/boards/arduino-due/Makefile.include
+++ b/boards/arduino-due/Makefile.include
@@ -1,6 +1,5 @@
 # define the cpu used by the arduino due board
 export CPU = sam3x8e
-export CPU_MODEL = sam3x8e
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -1,7 +1,5 @@
 # define the cpu used by the mbed_lpx1768 board
 export CPU = lpc1768
-export CPU_MODEL = lpc1768
-
 
 export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
 export DEBUGGER =

--- a/boards/udoo/Makefile.include
+++ b/boards/udoo/Makefile.include
@@ -1,6 +1,5 @@
 # define the cpu used by the udoo board
 export CPU = sam3x8e
-export CPU_MODEL = sam3x8e
 
 #define the flash-tool and default port depending on the host operating system
 OS := $(shell uname)

--- a/cpu/Makefile.include.cortexm_common
+++ b/cpu/Makefile.include.cortexm_common
@@ -8,6 +8,9 @@ export USEMODULE += periph
 # all cortex MCU's use newlib as libc
 export USEMODULE += newlib
 
+# set default for CPU_MODEL
+export CPU_MODEL ?= $(CPU)
+
 # export the CPU model and architecture
 MODEL = $(shell echo $(CPU_MODEL) | tr 'a-z' 'A-Z')
 export CFLAGS += -DCPU_MODEL_$(MODEL)


### PR DESCRIPTION
Some platforms might not have different models, so why force setting one?