### PR TITLE
board/pba-d-01-kw2x: Adaptions to make ng_udp example work

### DIFF
--- a/boards/pba-d-01-kw2x/Makefile.dep
+++ b/boards/pba-d-01-kw2x/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter ng_netif,$(USEMODULE)))
+ifneq (,$(filter ng_netif_default,$(USEMODULE)))
   USEMODULE += kw2xrf
   USEMODULE += ng_nomac
 endif


### PR DESCRIPTION
Based on #2895

This PR adds HW-address setting according to the CPUID (1.) and implementation of correct broadcast behavior (2.) .

Tested with #2895 on the pba-d-01-kw2x board -> ping and sending UDP-packets works.