### PR TITLE
core: fix write of thread stack end test marker

### DIFF
--- a/core/thread.c
+++ b/core/thread.c
@@ -161,7 +161,7 @@ kernel_pid_t thread_create(char *stack, int stacksize, char priority, int flags,
     }
     else {
         /* create stack guard */
-        *stack = (uintptr_t) stack;
+        *(uintptr_t *) stack = (uintptr_t) stack;
     }
 #endif
 


### PR DESCRIPTION
Reproducible with any thread without the `CREATE_STACKTEST` `thread_create()` flag, and with  `DEVELHELP` and `SCHED_TEST_STACK` environment variables enabled.

Under these conditions, I was noticing UART output such as  `scheduler(): stack overflow detected, pid=4` for some threads.
Using GDB, I found that these threads *were not overflowing* their thread stack buffers.
I noticed that only the lower half of the marker was being written to the end of the stack while the stack [overflow test condition](https://github.com/RIOT-OS/RIOT/blob/master/core/sched.c#L89) is testing for the entire marker. This is because `stack` is a `char` pointer but the value being written is a `uintptr_t`.

This patch removed the problem

My cpu is an msp430