### PR TITLE
sys/shell: changed signature of put_char pointer

### DIFF
--- a/examples/default/main.c
+++ b/examples/default/main.c
@@ -135,18 +135,6 @@ void init_transceiver(void)
 }
 #endif /* MODULE_TRANSCEIVER */
 
-static int shell_readc(void)
-{
-    char c = 0;
-    (void) posix_read(uart0_handler_pid, &c, 1);
-    return c;
-}
-
-static void shell_putchar(int c)
-{
-    (void) putchar(c);
-}
-
 int main(void)
 {
     shell_t shell;
@@ -166,7 +154,7 @@ int main(void)
 
     (void) puts("Welcome to RIOT!");
 
-    shell_init(&shell, NULL, UART0_BUFSIZE, shell_readc, shell_putchar);
+    shell_init(&shell, NULL, UART0_BUFSIZE, uart0_readc, uart0_putc);
 
     shell_run(&shell);
     return 0;

--- a/sys/include/board_uart0.h
+++ b/sys/include/board_uart0.h
@@ -64,7 +64,7 @@ int uart0_readc(void);
  *
  * @param[in] c The character to put on the UART.
  */
-void uart0_putc(int c);
+int uart0_putc(int c);
 
 #ifdef __cplusplus
 }

--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -67,7 +67,7 @@ typedef struct shell_t {
     const shell_command_t *command_list; /**< The commandlist supplied to shell_init(). */
     uint16_t shell_buffer_size;          /**< The maximum line length supplied to shell_init(). */
     int (*readchar)(void);               /**< The read function supplied to shell_init(). */
-    void (*put_char)(int);               /**< The write function supplied to shell_init(). */
+    int (*put_char)(int);                /**< The write function supplied to shell_init(). */
 } shell_t;
 
 /**
@@ -87,7 +87,7 @@ void shell_init(shell_t *shell,
                 const shell_command_t *shell_commands,
                 uint16_t shell_buffer_size,
                 int (*read_char)(void),
-                void (*put_char)(int));
+                int (*put_char)(int));
 
 /**
  * @brief           Start the shell session.

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -278,7 +278,7 @@ void shell_run(shell_t *shell)
 }
 
 void shell_init(shell_t *shell, const shell_command_t *shell_commands,
-                uint16_t shell_buffer_size, int(*readchar)(void), void(*put_char)(int))
+                uint16_t shell_buffer_size, int(*readchar)(void), int(*put_char)(int))
 {
     shell->command_list = shell_commands;
     shell->shell_buffer_size = shell_buffer_size;

--- a/sys/uart0/uart0.c
+++ b/sys/uart0/uart0.c
@@ -81,7 +81,7 @@ int uart0_readc(void)
     return c;
 }
 
-void uart0_putc(int c)
+int uart0_putc(int c)
 {
-    putchar(c);
+    return putchar(c);
 }

--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -33,24 +33,6 @@
 #define SHELL_BUFSIZE           (64U)
 
 /**
- * @brief   Read chars from STDIO
- */
-int shell_read(void)
-{
-    char c = 0;
-    (void) posix_read(uart0_handler_pid, &c, 1);
-    return c;
-}
-
-/**
- * @brief   Write chars to STDIO
- */
-void shell_put(int c)
-{
-    putchar((char)c);
-}
-
-/**
  * @brief   Maybe you are a golfer?!
  */
 int main(void)
@@ -69,7 +51,7 @@ int main(void)
     /* start the shell */
     puts("Initialization successful - starting the shell now");
     (void) posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, NULL, SHELL_BUFSIZE, shell_read, shell_put);
+    shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
     shell_run(&shell);
 
     return 0;

--- a/tests/driver_kw2xrf/main.c
+++ b/tests/driver_kw2xrf/main.c
@@ -31,24 +31,6 @@
  */
 #define SHELL_BUFSIZE   (64U)
 
-/**
- * @brief   Read chars from STDIO
- */
-int shell_read(void)
-{
-    char c = 0;
-    (void) posix_read(uart0_handler_pid, &c, 1);
-    return c;
-}
-
-/**
- * @brief   Write chars to STDIO
- */
-void shell_put(int c)
-{
-    putchar((char)c);
-}
-
 int main(void)
 {
     shell_t shell;
@@ -65,7 +47,7 @@ int main(void)
     /* start the shell */
     puts("Initialization successful - starting the shell now");
     (void) posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, NULL, SHELL_BUFSIZE, shell_read, shell_put);
+    shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
     shell_run(&shell);
 
     return 0;

--- a/tests/driver_netdev_eth/main.c
+++ b/tests/driver_netdev_eth/main.c
@@ -39,22 +39,6 @@
 #define SHELL_BUFSIZE           (64U)
 
 /**
- * @brief   Read chars from STDIO
- */
-int shell_read(void)
-{
-    return (int)getchar();
-}
-
-/**
- * @brief   Write chars to STDIO
- */
-void shell_put(int c)
-{
-    putchar((char)c);
-}
-
-/**
  * @brief   Maybe you are a golfer?!
  */
 int main(void)
@@ -76,7 +60,7 @@ int main(void)
     ng_netreg_register(NG_NETTYPE_UNDEF, &dump);
 
     /* start the shell */
-    shell_init(&shell, NULL, SHELL_BUFSIZE, shell_read, shell_put);
+    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
     shell_run(&shell);
 
     return 0;

--- a/tests/driver_nrf24l01p_lowlevel/main.c
+++ b/tests/driver_nrf24l01p_lowlevel/main.c
@@ -327,23 +327,6 @@ int cmd_print_regs(int argc, char **argv)
     return 0;
 }
 
-
-/**
- * @brief proxy for reading a char from std-in and passing it to the shell
- */
-int shell_read(void)
-{
-    return (int) getchar();
-}
-
-/**
- * @brief proxy for taking a character from the shell and writing it to std-out
- */
-void shell_write(int c)
-{
-    putchar((char)c);
-}
-
 int main(void)
 {
     shell_t shell;
@@ -351,8 +334,7 @@ int main(void)
     puts("Welcome to RIOT!");
 
     puts("Initializing shell...");
-    shell_init(&shell, shell_commands, SHELL_BUFFER_SIZE, shell_read,
-               shell_write);
+    shell_init(&shell, shell_commands, SHELL_BUFFER_SIZE, getchar, putchar);
 
     puts("Starting shell...");
     shell_run(&shell);

--- a/tests/driver_nrfmin/main.c
+++ b/tests/driver_nrfmin/main.c
@@ -32,21 +32,6 @@
 
 static char nomac_stack[THREAD_STACKSIZE_DEFAULT];
 
-int shell_read(void)
-{
-    char c;
-    int result = posix_read(uart0_handler_pid, &c, 1);
-    if (result != 1) {
-        return -1;
-    }
-    return (unsigned char) c;
-}
-
-void shell_put(int c)
-{
-    putchar(c);
-}
-
 int main(void)
 {
     shell_t shell;
@@ -68,7 +53,7 @@ int main(void)
     /* initialize and run the shell */
     board_uart0_init();
     posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, NULL, SHELL_BUFSIZE, shell_read, shell_put);
+    shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
     shell_run(&shell);
 
     return 0;

--- a/tests/driver_pcd8544/main.c
+++ b/tests/driver_pcd8544/main.c
@@ -156,18 +156,6 @@ static const shell_command_t shell_commands[] = {
     { NULL, NULL, NULL }
 };
 
-static int _getchar(void)
-{
-    char c = 0;
-    (void) posix_read(uart0_handler_pid, &c, 1);
-    return c;
-}
-
-static void _putchar(int c)
-{
-    putchar(c);
-}
-
 int main(void)
 {
     shell_t shell;
@@ -183,7 +171,7 @@ int main(void)
     /* run shell */
     puts("All OK, running shell now");
     (void) posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, shell_commands, SHELL_BUFSIZE, _getchar, _putchar);
+    shell_init(&shell, shell_commands, SHELL_BUFSIZE, uart0_readc, uart0_putc);
     shell_run(&shell);
 
     return 0;

--- a/tests/driver_xbee/main.c
+++ b/tests/driver_xbee/main.c
@@ -31,22 +31,6 @@
 #define SHELL_BUFSIZE           (64U)
 
 /**
- * @brief   Read chars from STDIO
- */
-int shell_read(void)
-{
-    return (int)getchar();
-}
-
-/**
- * @brief   Write chars to STDIO
- */
-void shell_put(int c)
-{
-    putchar((char)c);
-}
-
-/**
  * @brief   Maybe you are a golfer?!
  */
 int main(void)
@@ -67,7 +51,7 @@ int main(void)
 
     /* start the shell */
     puts("Initialization OK, starting shell now");
-    shell_init(&shell, NULL, SHELL_BUFSIZE, shell_read, shell_put);
+    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
     shell_run(&shell);
 
     return 0;

--- a/tests/periph_i2c/main.c
+++ b/tests/periph_i2c/main.c
@@ -304,18 +304,6 @@ static const shell_command_t shell_commands[] = {
     { NULL, NULL, NULL }
 };
 
-static int shell_readc(void)
-{
-    char c = 0;
-    (void) posix_read(uart0_handler_pid, &c, 1);
-    return c;
-}
-
-static void shell_putchar(int c)
-{
-    (void) putchar(c);
-}
-
 int main(void)
 {
     shell_t shell;
@@ -327,7 +315,7 @@ int main(void)
     posix_open(uart0_handler_pid, 0);
 
     /* define own shell commands */
-    shell_init(&shell, shell_commands, UART0_BUFSIZE, shell_readc, shell_putchar);
+    shell_init(&shell, shell_commands, UART0_BUFSIZE, uart0_readc, uart0_putc);
     shell_run(&shell);
 
     return 0;

--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -274,16 +274,6 @@ int cmd_print(int argc, char **argv)
     return 0;
 }
 
-int shell_getchar(void)
-{
-    return (int)getchar();
-}
-
-void shell_putchar(int c)
-{
-    putchar((char)c);
-}
-
 static const shell_command_t shell_commands[] = {
     { "init_master", "Initialize node as SPI master", cmd_init_master },
     { "init_slave", "Initialize node as SPI slave", cmd_init_slave },
@@ -301,7 +291,7 @@ int main(void)
     puts("Enter 'help' to get started\n");
 
     /* run the shell */
-    shell_init(&shell, shell_commands, SHELL_BUFSIZE, shell_getchar, shell_putchar);
+    shell_init(&shell, shell_commands, SHELL_BUFSIZE, getchar, putchar);
     shell_run(&shell);
 
     return 0;

--- a/tests/struct_tm_utility/main.c
+++ b/tests/struct_tm_utility/main.c
@@ -134,28 +134,13 @@ static const shell_command_t shell_commands[] = {
     { NULL, NULL, NULL }
 };
 
-static int shell_readc(void)
-{
-    char c;
-    int result = posix_read(uart0_handler_pid, &c, 1);
-    if (result != 1) {
-        return -1;
-    }
-    return (unsigned char) c;
-}
-
-static void shell_putchar(int c)
-{
-    putchar(c);
-}
-
 int main(void)
 {
     board_uart0_init();
     posix_open(uart0_handler_pid, 0);
 
     shell_t shell;
-    shell_init(&shell, shell_commands, SHELL_BUFSIZE, shell_readc, shell_putchar);
+    shell_init(&shell, shell_commands, SHELL_BUFSIZE, uart0_readc, uart0_putc);
 
     puts("`struct tm` utility shell.");
     shell_run(&shell);


### PR DESCRIPTION
The shell initialization is kind of ugly in many applications, as some explicitly define read/write functions to be used by the shell. With the change of the signature for the `put_char` argument, it is now possible to pass the stdlib's `putchar` directly as an argument. This is expacially useful, once uart0 is removed -> see #3164.

I adapted the `uart0_putc()` function in the uart0 module and made all applications that use uart0 use this function. For some tests, that are not using uart0, I adapted them to use the stdlib calls (putchar, getchar) directly.