### PR TITLE
sys: ble: introduce low-level ble driver API

### DIFF
--- a/boards/yunjia-nrf51822/Makefile.dep
+++ b/boards/yunjia-nrf51822/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter ng_ble,$(USEMODULE)))
+  USEMODULE += ng_ble
+endif

--- a/boards/yunjia-nrf51822/Makefile.features
+++ b/boards/yunjia-nrf51822/Makefile.features
@@ -1,4 +1,5 @@
 FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += ng_ble
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_random

--- a/boards/yunjia-nrf51822/Makefile.include
+++ b/boards/yunjia-nrf51822/Makefile.include
@@ -57,3 +57,4 @@ endif
 
 # export board specific includes to the global includes-listing
 export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/yunjia-nrf51822/include/periph_conf.h
+++ b/boards/yunjia-nrf51822/include/periph_conf.h
@@ -107,6 +107,16 @@ extern "C" {
 /** @} */
 
 /**
+ * @name Radio device configuration
+ *
+ * The radio is not guarded by a NUMOF define, as the radio is selected by its
+ * own module in the build system.
+ * @{
+ */
+#define RADIO_IRQ_PRIO      1
+/** @} */
+
+/**
  * @name SPI configuration
  * @{
  */

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -33,7 +33,7 @@
 #include "hwtimer.h"
 #include "irq.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG (1)
 #include "debug.h"
 
 #ifdef MODULE_AUTO_INIT

--- a/core/msg.c
+++ b/core/msg.c
@@ -32,7 +32,7 @@
 
 #include "flags.h"
 
-#define ENABLE_DEBUG    (0)
+#define ENABLE_DEBUG    (1)
 #include "debug.h"
 #include "thread.h"
 

--- a/core/thread.c
+++ b/core/thread.c
@@ -25,7 +25,7 @@
 #include "kernel.h"
 #include "irq.h"
 
-#define ENABLE_DEBUG    (0)
+#define ENABLE_DEBUG    (1)
 #include "debug.h"
 #include "kernel_internal.h"
 #include "bitarithm.h"

--- a/cpu/nrf51822/Makefile
+++ b/cpu/nrf51822/Makefile
@@ -3,5 +3,8 @@ MODULE = cpu
 
 # add a list of subdirectories, that should also be build
 DIRS = periph $(CORTEX_COMMON)
+ifneq (,$(filter ng_ble,$(USEMODULE)))
+	DIRS += ng_ble
+endif
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/nrf51822/include/dev_ble_nrf.h
+++ b/cpu/nrf51822/include/dev_ble_nrf.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 Jan Wagner <mail@jwagner.eu>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     dev_ble_nrf Low-Level Driver Inteface
+ * @{
+ *
+ * @file
+ * @brief       Low-level ble driver for the NRF51822 radio interface
+ *
+ * @author      James Hollister <jhollisterjr@gmail.com>
+ * @author      Jan Wagner <mail@jwagner.eu>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ */
+
+#ifndef DEV_BLE_NRF_H
+#define DEV_BLE_NRF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include "net/dev_ble.h"
+
+/**
+ * @brief tap interface state
+ */
+typedef struct dev_ble_nrf {
+    dev_ble_t bledev;                   /**< dev_ble internal member */
+    int ble_fd;                         /**< host file descriptor for the TAP */
+} dev_ble_nrf_t;
+
+/**
+ * @brief global device struct. driver only supports one tap device as of now.
+ */
+extern dev_ble_nrf_t dev_ble_nrf;
+
+/**
+ * @brief Setup dev_ble_nrf_t structure
+ *
+ * @param dev  the preallocated dev_ble_nrf device handle to setup
+ */
+void dev_ble_nrf_setup(dev_ble_nrf_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+/** @} */
+#endif /* DEV_BLE_NRF_H */

--- a/cpu/nrf51822/ng_ble/Makefile
+++ b/cpu/nrf51822/ng_ble/Makefile
@@ -1,0 +1,3 @@
+MODULE = ng_ble
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/nrf51822/ng_ble/dev_ble_nrf.c
+++ b/cpu/nrf51822/ng_ble/dev_ble_nrf.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2015 Jan Wagner <mail@jwagner.eu>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     dev_ble_nrf Low-Level Driver Inteface
+ * @{
+ *
+ * @file
+ * @brief       Low-level bluetooth low-energy driver for the NRF51822 radio interface
+ *
+ * @author      James Hollister <jhollisterjr@gmail.com>
+ * @author      Jan Wagner <mail@jwagner.eu>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include "net/dev_ble.h"
+#include "dev_ble_nrf.h"
+
+#define ENABLE_DEBUG (1)
+#include "debug.h"
+
+/* support one tap interface for now */
+dev_ble_nrf_t dev_ble_nrf;
+
+/* dev_ble interface */
+static int _init(dev_ble_t *bledev);
+static int _send(dev_ble_t *bledev, char* buf, int n);
+static int _recv(dev_ble_t *bledev, char* buf, int n);
+
+static int _recv(dev_ble_t *bledev, char *buf, int len) {
+    dev_ble_nrf_t *dev = (dev_ble_nrf_t*)bledev;
+    DEBUG("dev_ble_nrf: _recv (dev=0x%08x)\n", (unsigned) dev);
+    return 0;
+}
+
+static int _send(dev_ble_t *bledev, char* buf, int n) {
+    dev_ble_nrf_t *dev = (dev_ble_nrf_t*)bledev;
+    DEBUG("dev_ble_nrf: _send (dev=0x%08x)\n", (unsigned) dev);
+    return 0;
+}
+
+static inline void _isr(dev_ble_t *bledev) {
+    DEBUG("dev_ble_nrf: _isr(dev=0x%08x)\n", (unsigned) bledev);
+    dev_ble_rx_handler(bledev);
+}
+
+static int _init(dev_ble_t *bledev)
+{
+    DEBUG("_init\n");
+    dev_ble_nrf_t *dev = (dev_ble_nrf_t*)bledev;
+    DEBUG("dev_ble_nrf: _init (dev=0x%08x)\n", (unsigned) dev);
+
+    /* check device parametrs */
+    if (dev == NULL) {
+        return -ENODEV;
+    }
+    return 1;
+}
+
+static ble_driver_t ble_driver_nrf = {
+    .init = _init,
+    .send = _send,
+    .recv = _recv,
+    .isr = _isr,
+};
+
+void dev_ble_nrf_setup(dev_ble_nrf_t *dev) {
+    dev->bledev.driver = &ble_driver_nrf;
+}

--- a/sys/auto_init/Makefile
+++ b/sys/auto_init/Makefile
@@ -8,4 +8,8 @@ endif
 
 DIRS += $(AUTO_INIT_MODULES)
 
+ifneq (,$(filter dev_ble_autoinit,$(USEMODULE)))
+DIRS += $(RIOTBASE)/sys/auto_init/dev_ble
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -103,6 +103,11 @@
 #include "net/ng_udp.h"
 #endif
 
+#ifdef MODULE_DEV_BLE_AUTOINIT
+#include "net/dev_ble.h"
+#include "dev_ble_autoinit.h"
+#endif
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 

--- a/sys/auto_init/dev_ble/Makefile
+++ b/sys/auto_init/dev_ble/Makefile
@@ -1,0 +1,3 @@
+MODULE = dev_ble_autoinit
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/auto_init/dev_ble/dev_ble_autoinit.c
+++ b/sys/auto_init/dev_ble/dev_ble_autoinit.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2015 Jan Wagner <mail@jwagner.eu>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     dev_ble_nrf Low-Level Driver Inteface
+ * @{
+ *
+ * @file
+ * @brief       Auto-init function for the low-level ble driver
+ *
+ * @author      James Hollister <jhollisterjr@gmail.com>
+ * @author      Jan Wagner <mail@jwagner.eu>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "net/dev_ble.h"
+#include "dev_ble_autoinit.h"
+
+#ifdef MODULE_NG_BLE
+#include "dev_ble_nrf.h"
+#endif
+
+#define ENABLE_DEBUG (1)
+#include "debug.h"
+
+dev_ble_t * const dev_ble_devices[] = {
+    [DEV_BLE_NRF] = (dev_ble_t*)&dev_ble_nrf
+};
+
+void dev_ble_autoinit(void)
+{
+    DEBUG("dev_ble_autoinit: dev_ble_autoinit()\n");
+    return;
+}

--- a/sys/include/dev_ble_autoinit.h
+++ b/sys/include/dev_ble_autoinit.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 Jan Wagner <mail@jwagner.eu>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     dev_ble_nrf Low-Level Driver Inteface
+ * @{
+ *
+ * @file
+ * @brief       Header for auto-init function for the low-level ble driver
+ *
+ * @author      James Hollister <jhollisterjr@gmail.com>
+ * @author      Jan Wagner <mail@jwagner.eu>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ */
+
+#ifndef DEV_BLE_AUTOINIT_H
+#define DEV_BLE_AUTOINIT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief enum for available ethernet devices
+ */
+enum {
+#ifdef MODULE_NG_BLE
+    DEV_BLE_NRF,
+#endif
+    /* must be last: */
+    NUM_DEV_BLE
+};
+
+/**
+ * @brief Array of const pointers to available ethernet devices
+ */
+extern dev_ble_t *const dev_ble_devices[];
+
+/**
+ * @brief Automatically sets up available dev_ble ble devices
+ *
+ * ... by calling the respective *_setup() functions if available.
+ */
+void dev_ble_autoinit(void);
+
+#ifdef __cplusplus
+}
+#endif
+/** @} */
+#endif /* DEV_BLE_AUTOINIT_H */

--- a/sys/include/net/dev_ble.h
+++ b/sys/include/net/dev_ble.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2015 Jan Wagner <mail@jwagner.eu>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     dev_ble_nrf ble Low-Level Driver Inteface
+ * @{
+ *
+ * @file
+ * @brief       Low-level bluetooth low-energy interface
+ *
+ * @author      James Hollister <jhollisterjr@gmail.com>
+ * @author      Jan Wagner <mail@jwagner.eu>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ */
+
+#ifndef DEV_BLE_H
+#define DEV_BLE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/**
+ * @brief Structure to hold driver state
+ *
+ * Supposed to be extended by driver implementations.
+ * The extended structure should contain all variable driver state.
+ */
+typedef struct dev_ble {
+    const struct ble_driver *driver; /**< ptr to that driver's interface.
+                                     driver->init() expects this to be present,
+                                     so set this before using the device. */
+} dev_ble_t;
+
+/**
+ * @brief Structure to hold driver interface -> function mapping
+ *
+ */
+typedef struct ble_driver {
+    /**
+     * @brief Send a ble frame
+     *
+     * @param buf buffer to read from
+     * @param len nr of bytes to send
+     *
+     * @return nr of bytes sent, or <=0 on error
+     */
+    int (*send)(dev_ble_t *dev, char* buf, int len);
+
+    /**
+     * @brief Get a received ble frame
+     *
+     * @param buf buffer to write to
+     * @param len maximum nr. of bytes to read
+     *
+     * @return nr of bytes read or <=0 on error
+     */
+    int (*recv)(dev_ble_t *dev, char* buf, int len);
+
+    /**
+     * @brief the driver's initialization function
+     *
+     * @return <=0 on error, >0 on success
+     */
+    int (*init)(dev_ble_t *dev);
+    /**
+     * @brief a driver's user-space ISR handler
+     *
+     */
+    void (*isr)(dev_ble_t *dev);
+} ble_driver_t;
+
+/**
+ * @brief Initialize a device given by dev (convenience function)
+ *
+ * The device given as parameter *must* be previously setup by the
+ * drivers *_setup() function.
+ *
+ */
+static inline int dev_ble_init(dev_ble_t *dev) {
+    return dev->driver->init(dev);
+}
+
+/**
+ * @brief global dev_ble interrupt handling function.
+ *
+ * This function should be called from your device's ISR from whithin ISR context.
+ * It is supposed to wake up a waiting user-space event loop.
+ */
+extern void dev_ble_isr(dev_ble_t *dev);
+
+/**
+ * @brief dev_ble event callback for packets that were received.
+ *
+ * This function should be called from whithin your driver's isr()
+ * (as defined in ble_driver_t), once for every packet that was received.
+ *
+ * It needs to call dev->driver->recv() in order to get received packet
+ * from the driver.
+ */
+extern void dev_ble_rx_handler(dev_ble_t *dev);
+
+/**
+ * @brief dev_ble ble link state handler
+ *
+ * This function should be called from whithin your driver's isr()
+ * (as defined in ble_driver_t) for every layer 2 link state change.
+ *
+ * @param dev device that triggered the event
+ * @param newstate 1 for "link established", 0 for "link down"
+ */
+extern void dev_ble_linkstate_handler(dev_ble_t *dev, int newstate);
+#ifdef __cplusplus
+}
+#endif
+/** @} */
+#endif /* DEV_BLE_H */

--- a/tests/dev_ble/Makefile
+++ b/tests/dev_ble/Makefile
@@ -1,0 +1,12 @@
+APPLICATION = dev_ble
+include ../Makefile.tests_common
+
+BOARD_WHITELIST = yunjia-nrf51822
+
+ifneq (,$(filter yunjia-nrf51822,$(BOARD)))
+USEMODULE += ng_ble
+endif
+
+USEMODULE += dev_ble_autoinit
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/dev_ble/main.c
+++ b/tests/dev_ble/main.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2015 Jan Wagner <mail@jwagner.eu>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests 
+ * @{
+ *
+ * @file
+ * @brief       Test application for dev_ble low-level bluetooth low-energy drivers
+ *
+ * @author      James Hollister <jhollisterjr@gmail.com>
+ * @author      Jan Wagner <mail@jwagner.eu>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "thread.h"
+#include "board.h"
+#include "vtimer.h"
+#include "periph/spi.h"
+#include "periph/gpio.h"
+
+#include "net/dev_ble.h"
+#include "dev_ble_autoinit.h"
+
+#define ENABLE_DEBUG (1)
+#include "debug.h"
+
+kernel_pid_t handler_pid = KERNEL_PID_UNDEF;
+
+char _rxbuf[2000];
+
+void dev_ble_isr(dev_ble_t *dev) {
+    (void)dev;
+    thread_wakeup(handler_pid);
+}
+
+void dev_ble_rx_handler(dev_ble_t *dev) {
+    DEBUG("dev_ble_rx_handler dev=0x%08x\n", (unsigned) dev);
+
+    int n = dev->driver->recv(dev, _rxbuf, sizeof(_rxbuf));
+
+    DEBUG("handle_incoming: received %i bytes\n", n);
+}
+
+void dev_ble_linkstate_handler(dev_ble_t *dev, int newstate)
+{
+    DEBUG("dev_ble: dev=0x%08x link %s\n", (unsigned)dev, newstate ? "UP" : "DOWN");
+}
+
+int main(void)
+{
+    dev_ble_t *const dev = dev_ble_devices[0];
+
+    DEBUG("dev_ble: main\n");
+    handler_pid = thread_getpid();
+
+    DEBUG("dev_ble: dev_ble_init\n");
+    dev_ble_init(dev);
+
+    while(1) {
+        DEBUG("dev_ble: dev->driver->isr\n");
+        dev->driver->isr(dev);
+        thread_sleep();
+        DEBUG("main: woke up\n");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR is part of the RIOT-OS GSoC 2015 Bluetooth Low Energy project. The current BLE proof of concept code [#2946](https://github.com/RIOT-OS/RIOT/pull/2946) was implemented as ng_netdev. After ongoing discussion in the project team we (not yet finaly) decided to design a more independent general dev_ble interface.

This PR was created to implement a minimal proof of concept ble device - the current version of the code still has issues with the dev_ble setup / auto_init aka "crashes hard" - early alpha version with much work in progress. next steps are to port ble device setup function from  [#2946](https://github.com/RIOT-OS/RIOT/pull/2946) and enable basic interrupt and receive handling.

The PR is heavily based on [#2766](https://github.com/RIOT-OS/RIOT/pull/2766) and the work of others - the future goal is to have a netdev support for the dev_ble in the final proof of concept PR code -> [#2776](https://github.com/RIOT-OS/RIOT/pull/2776) to enable sniffing via ng_sniffer application.
