### PR TITLE
net/ng_pktbuf: added IOVEC export function

### DIFF
--- a/sys/include/net/ng_nettype.h
+++ b/sys/include/net/ng_nettype.h
@@ -38,6 +38,11 @@ extern "C" {
  */
 typedef enum {
     /**
+     * @brief   Not so much protocol but data type that is passed to network
+     *          devices using the netdev interface
+     */
+    NG_NETTYPE_IOVEC = -2,
+    /**
      * @brief   Protocol is as defined in @ref ng_netif_hdr_t. Not usable with
      *          @ref net_ng_netreg
      */

--- a/sys/include/net/ng_pkt.h
+++ b/sys/include/net/ng_pkt.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014, 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *               2015       Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -16,6 +17,7 @@
  * @brief   General definitions for network packets
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author  Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 #ifndef NG_PKT_H_
 #define NG_PKT_H_
@@ -127,6 +129,25 @@ static inline size_t ng_pkt_len(ng_pktsnip_t *pkt)
     }
 
     return len;
+}
+
+/**
+ * @brief Count the numbers of snips in the given packet
+ *
+ * @param[in] pkt   first snip in the packet
+ *
+ * @return  number of snips in the given packet
+ */
+static inline size_t ng_pkt_count(const ng_pktsnip_t *pkt)
+{
+    size_t count = 0;
+
+    while (pkt) {
+        ++count;
+        pkt = pkt->next;
+    }
+
+    return count;
 }
 
 #ifdef __cplusplus

--- a/sys/include/net/ng_pktbuf.h
+++ b/sys/include/net/ng_pktbuf.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *               2015 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -24,6 +25,7 @@
  *          and layers can allocate space for packets here.
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author  Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 #ifndef NG_PKTBUF_H_
 #define NG_PKTBUF_H_
@@ -156,10 +158,25 @@ void ng_pktbuf_release(ng_pktsnip_t *pkt);
  * @param[in] pkt   The packet you want to write into.
  *
  * @return  The (new) pointer to the pkt.
- * @return  NULL, if ng_pktsnip_t::users of @p pkt > 1 and if there is not enough
- *          space in the packet buffer.
+ * @return  NULL, if ng_pktsnip_t::users of @p pkt > 1 and if there is not
+ *          enough space in the packet buffer.
  */
 ng_pktsnip_t *ng_pktbuf_start_write(ng_pktsnip_t *pkt);
+
+/**
+ * @brief   Create a IOVEC representation of the packet pointed to by *pkt*
+ *
+ * @details This function will create a new packet snip in the packet buffer,
+ *          which points to the given *pkt* and contains a IOVEC representation
+ *          of the referenced packet in its data section.
+ *
+ * @param[in]  pkt  Packet to export as IOVEC
+ * @param[out] len  Number of elements in the IOVEC
+ *
+ * @return  Pointer to the 'IOVEC packet snip'
+ * @return  NULL, if packet is empty of the packet buffer is full
+ */
+ng_pktsnip_t *ng_pktbuf_get_iovec(ng_pktsnip_t *pkt, size_t *len);
 
 /**
  * @brief   Deletes a snip from a packet and the packet buffer.

--- a/sys/libc/include/sys/uio.h
+++ b/sys/libc/include/sys/uio.h
@@ -20,6 +20,7 @@
 #ifndef UIO_H
 #define UIO_H
 
+#include <stdlib.h>
 #include <sys/types.h>
 
 #ifdef __cplusplus

--- a/tests/unittests/tests-pkt/tests-pkt.c
+++ b/tests/unittests/tests-pkt/tests-pkt.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014, 2015 Martine Lenders <mail@martine-lenders.eu>
+ * *             2015       Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -82,6 +83,28 @@ static void test_pkt_len__3_elem(void)
     TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING8) + sizeof(TEST_STRING12), ng_pkt_len(&snip2));
     TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING8), ng_pkt_len(&snip1));
 }
+static void test_pkt_count__1_elem(void)
+{
+    ng_pktsnip_t snip1 = _INIT_ELEM_STATIC_DATA(TEST_STRING8, NULL);
+
+    TEST_ASSERT_EQUAL_INT(1, ng_pkt_count(&snip1));
+}
+
+static void test_pkt_count__5_elem(void)
+{
+    ng_pktsnip_t snip1 = _INIT_ELEM_STATIC_DATA(TEST_STRING8, NULL);
+    ng_pktsnip_t snip2 = _INIT_ELEM_STATIC_DATA(TEST_STRING12, &snip1);
+    ng_pktsnip_t snip3 = _INIT_ELEM(sizeof("a"), "a", &snip2);
+    ng_pktsnip_t snip4 = _INIT_ELEM_STATIC_DATA(TEST_STRING8, &snip3);
+    ng_pktsnip_t snip5 = _INIT_ELEM_STATIC_DATA(TEST_STRING8, &snip4);
+
+    TEST_ASSERT_EQUAL_INT(5, ng_pkt_count(&snip5));
+}
+
+static void test_pkt_count__null(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, ng_pkt_count(NULL));
+}
 
 Test *tests_pkt_tests(void)
 {
@@ -93,6 +116,9 @@ Test *tests_pkt_tests(void)
         new_TestFixture(test_pkt_len__2_elem),
         new_TestFixture(test_pkt_len__2_elem__overflow),
         new_TestFixture(test_pkt_len__3_elem),
+        new_TestFixture(test_pkt_count__1_elem),
+        new_TestFixture(test_pkt_count__5_elem),
+        new_TestFixture(test_pkt_count__null),
     };
 
     EMB_UNIT_TESTCALLER(pkt_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
In preparation for the update of `netdev` (see #3210), we need some functionality to export packets in the packet buffer to `struct iovec` IO vectors. This PR adds this functionality to the packet buffer.