### PR TITLE
cpu: added dev_enums.h include to all periph_cpu.h

### DIFF
--- a/cpu/nrf51822/include/periph_cpu.h
+++ b/cpu/nrf51822/include/periph_cpu.h
@@ -19,6 +19,8 @@
 #ifndef CPU_PERIPH_H_
 #define CPU_PERIPH_H_
 
+#include "periph/dev_enums.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -20,6 +20,7 @@
 #define CPU_PERIPH_H_
 
 #include "cpu.h"
+#include "periph/dev_enums.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -20,6 +20,7 @@
 #define PERIPH_CPU_H_
 
 #include "cpu.h"
+#include "periph/dev_enums.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/stm32f3/include/periph_cpu.h
+++ b/cpu/stm32f3/include/periph_cpu.h
@@ -20,6 +20,7 @@
 #define PERIPH_CPU_H_
 
 #include "cpu.h"
+#include "periph/dev_enums.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/stm32f4/include/periph_cpu.h
+++ b/cpu/stm32f4/include/periph_cpu.h
@@ -20,6 +20,7 @@
 #define CPU_PERIPH_H_
 
 #include "cpu.h"
+#include "periph/dev_enums.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This PR is just a small preparation for updating further peripheral driver interfaces down the line to simplify PR dependencies...