### PR TITLE
drivers/spi: updated SPI driver interface

### DIFF
--- a/cpu/kinetis_common/spi.c
+++ b/cpu/kinetis_common/spi.c
@@ -41,9 +41,6 @@
  * @}
  */
 
-/* guard this file in case no SPI device is defined */
-#if SPI_NUMOF
-
 #if SPI_0_EN
 #ifdef SPI_0_PORT
 #define SPI_0_SCK_PORT          SPI_0_PORT
@@ -850,24 +847,14 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
     return 0;
 }
 
-int spi_acquire(spi_t dev)
+void spi_acquire(spi_t dev)
 {
-    if ((unsigned int)dev >= SPI_NUMOF) {
-        return -1;
-    }
-
     mutex_lock(locks_map[dev]);
-    return 0;
 }
 
-int spi_release(spi_t dev)
+void spi_release(spi_t dev)
 {
-    if ((unsigned int)dev >= SPI_NUMOF) {
-        return -1;
-    }
-
     mutex_unlock(locks_map[dev]);
-    return 0;
 }
 
 static inline uint8_t spi_transfer_internal(SPI_Type *spi_dev, uint32_t flags, uint8_t byte_out)
@@ -887,7 +874,7 @@ static inline uint8_t spi_transfer_internal(SPI_Type *spi_dev, uint32_t flags, u
     return (uint8_t)spi_dev->POPR;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+void spi_transfer_byte(spi_t dev, char out, char *in)
 {
     SPI_Type *spi_dev;
     uint8_t byte_in;
@@ -961,7 +948,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
 #endif
 
         default:
-            return -1;
+            return;
     }
 
     byte_in = spi_transfer_internal(spi_dev, flags, out);
@@ -972,11 +959,9 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
     if (in != NULL) {
         *in = (char)byte_in;
     }
-
-    return 1;
 }
 
-int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
+void spi_transfer_bytes(spi_t dev, char *out, char *in, size_t len)
 {
     SPI_Type *spi_dev;
     uint8_t byte_in;
@@ -1050,19 +1035,19 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
 #endif
 
         default:
-            return -1;
+            return;
     }
 
     /* Default: send idle data */
     byte_out = (uint8_t)SPI_IDLE_DATA;
 
-    for (i = 0; i < (int)length; i++) {
+    for (i = 0; i < (int)len; i++) {
         if (out != NULL) {
             /* Send given out data */
             byte_out = (uint8_t)out[i];
         }
 
-        if (i >= (int)length - 1) {
+        if (i >= (int)len - 1) {
             /* Last byte, set End-of-Queue flag, clear Continue flag. */
             flags &= ~(SPI_PUSHR_CONT_MASK);
             flags |= SPI_PUSHR_EOQ_MASK;
@@ -1078,11 +1063,9 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
 
     /* Clear End-of-Queue status flag */
     spi_dev->SR = SPI_SR_EOQF_MASK;
-
-    return i;
 }
 
-int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
+void spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
 {
     SPI_Type *spi_dev;
     uint8_t byte_in;
@@ -1154,7 +1137,7 @@ int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
 #endif
 
         default:
-            return -1;
+            return;
     }
 
     /* Transfer the register address first. */
@@ -1174,17 +1157,15 @@ int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
 
     /* Clear End-of-Queue status flag */
     spi_dev->SR = SPI_SR_EOQF_MASK;
-
-    return 2;
 }
 
-int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int length)
+void spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, size_t len)
 {
     SPI_Type *spi_dev;
     uint8_t byte_in;
     uint8_t byte_out;
     uint32_t flags;
-    int i;
+    size_t i;
 
     switch (dev) {
 #if SPI_0_EN
@@ -1252,7 +1233,7 @@ int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int 
 #endif
 
         default:
-            return -1;
+            return;
     }
 
     byte_out = reg;
@@ -1263,13 +1244,13 @@ int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int 
     /* Default: send idle data */
     byte_out = (uint8_t)SPI_IDLE_DATA;
 
-    for (i = 0; i < (int)length; i++) {
+    for (i = 0; i < (int)len; i++) {
         if (out != NULL) {
             /* Send given out data */
             byte_out = (uint8_t)out[i];
         }
 
-        if (i >= (int)length - 1) {
+        if (i >= (int)len - 1) {
             /* Last byte, set End-of-Queue flag, clear Continue flag. */
             flags &= ~(SPI_PUSHR_CONT_MASK);
             flags |= SPI_PUSHR_EOQ_MASK;
@@ -1285,8 +1266,6 @@ int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int 
 
     /* Clear End-of-Queue status flag */
     spi_dev->SR = SPI_SR_EOQF_MASK;
-
-    return i;
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)
@@ -1575,5 +1554,3 @@ void SPI_7_IRQ_HANDLER(void)
 }
 #endif
 #endif
-
-#endif /* SPI_NUMOF */

--- a/cpu/kinetis_common/spi.c
+++ b/cpu/kinetis_common/spi.c
@@ -874,7 +874,7 @@ static inline uint8_t spi_transfer_internal(SPI_Type *spi_dev, uint32_t flags, u
     return (uint8_t)spi_dev->POPR;
 }
 
-void spi_transfer_byte(spi_t dev, char out, char *in)
+char spi_transfer_byte(spi_t dev, char out)
 {
     SPI_Type *spi_dev;
     uint8_t byte_in;
@@ -948,17 +948,14 @@ void spi_transfer_byte(spi_t dev, char out, char *in)
 #endif
 
         default:
-            return;
+            return 0;
     }
 
     byte_in = spi_transfer_internal(spi_dev, flags, out);
 
     /* Clear End-of-Queue status flag */
     spi_dev->SR = SPI_SR_EOQF_MASK;
-
-    if (in != NULL) {
-        *in = (char)byte_in;
-    }
+    return (char)byte_in;
 }
 
 void spi_transfer_bytes(spi_t dev, char *out, char *in, size_t len)
@@ -1065,7 +1062,7 @@ void spi_transfer_bytes(spi_t dev, char *out, char *in, size_t len)
     spi_dev->SR = SPI_SR_EOQF_MASK;
 }
 
-void spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
+char spi_transfer_reg(spi_t dev, uint8_t reg, char out)
 {
     SPI_Type *spi_dev;
     uint8_t byte_in;
@@ -1137,7 +1134,7 @@ void spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
 #endif
 
         default:
-            return;
+            return 0;
     }
 
     /* Transfer the register address first. */
@@ -1150,13 +1147,9 @@ void spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
     /* Transfer the value. */
     byte_in = spi_transfer_internal(spi_dev, flags, out);
 
-    if (in != NULL) {
-        /* Save input byte to buffer */
-        *in = (char)byte_in;
-    }
-
     /* Clear End-of-Queue status flag */
     spi_dev->SR = SPI_SR_EOQF_MASK;
+    return byte_in;
 }
 
 void spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, size_t len)

--- a/cpu/nrf51/periph/spi.c
+++ b/cpu/nrf51/periph/spi.c
@@ -24,9 +24,6 @@
 #include "periph/spi.h"
 #include "periph_conf.h"
 
-/* guard this file in case no SPI device is defined */
-#if SPI_NUMOF
-
 /* static port mapping */
 static NRF_SPI_Type *const spi[] = {
 #if SPI_0_EN
@@ -127,12 +124,8 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data))
     return -1;
 }
 
-int spi_conf_pins(spi_t dev)
+void spi_conf_pins(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
-
     switch (dev) {
 #if SPI_0_EN
         case SPI_0:
@@ -157,28 +150,24 @@ int spi_conf_pins(spi_t dev)
             break;
 #endif
     }
-    return 0;
 }
 
-int spi_acquire(spi_t dev)
+void spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
     mutex_lock(&locks[dev]);
-    return 0;
 }
 
-int spi_release(spi_t dev)
+void spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
     mutex_unlock(&locks[dev]);
-    return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+void spi_transfer_byte(spi_t dev, char out, char *in)
+{
+    spi_transfer_bytes(dev, &out, in, 1);
+}
+
+void spi_transfer_bytes(spi_t dev, char *out, char *in, size_t len)
 {
     return spi_transfer_bytes(dev, &out, in, 1);
 }
@@ -199,20 +188,18 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
             in[i] = tmp;
         }
     }
-
-    return length;
 }
 
-int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
+void spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
 {
     spi_transfer_byte(dev, reg, 0);
-    return spi_transfer_byte(dev, out, in);
+    spi_transfer_byte(dev, out, in);
 }
 
-int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int length)
+void spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, size_t len)
 {
     spi_transfer_byte(dev, reg, 0);
-    return spi_transfer_bytes(dev, out, in, length);
+    spi_transfer_bytes(dev, out, in, len);
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)
@@ -222,16 +209,10 @@ void spi_transmission_begin(spi_t dev, char reset_val)
 
 void spi_poweron(spi_t dev)
 {
-    if (dev < SPI_NUMOF) {
-        spi[dev]->POWER = 1;
-    }
+    spi[dev]->POWER = 1;
 }
 
 void spi_poweroff(spi_t dev)
 {
-    if (dev < SPI_NUMOF) {
-        spi[dev]->POWER = 0;
-    }
+    spi[dev]->POWER = 0;
 }
-
-#endif /* SPI_NUMOF */

--- a/cpu/nrf51/periph/spi.c
+++ b/cpu/nrf51/periph/spi.c
@@ -162,9 +162,11 @@ void spi_release(spi_t dev)
     mutex_unlock(&locks[dev]);
 }
 
-void spi_transfer_byte(spi_t dev, char out, char *in)
+char spi_transfer_byte(spi_t dev, char out)
 {
-    spi_transfer_bytes(dev, &out, in, 1);
+    char tmp;
+    spi_transfer_bytes(dev, &out, &tmp, 1);
+    return tmp;
 }
 
 void spi_transfer_bytes(spi_t dev, char *out, char *in, size_t len)
@@ -190,15 +192,15 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
     }
 }
 
-void spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
+char spi_transfer_reg(spi_t dev, uint8_t reg, char out)
 {
-    spi_transfer_byte(dev, reg, 0);
-    spi_transfer_byte(dev, out, in);
+    spi_transfer_byte(dev, reg);
+    return spi_transfer_byte(dev, out);
 }
 
 void spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, size_t len)
 {
-    spi_transfer_byte(dev, reg, 0);
+    spi_transfer_byte(dev, reg);
     spi_transfer_bytes(dev, out, in, len);
 }
 

--- a/cpu/sam3/periph/spi.c
+++ b/cpu/sam3/periph/spi.c
@@ -297,7 +297,7 @@ void spi_release(spi_t dev)
     mutex_unlock(&locks[dev]);
 }
 
-void spi_transfer_byte(spi_t dev, char out, char *in)
+char spi_transfer_byte(spi_t dev, char out)
 {
     Spi *spi_port;
     char tmp;
@@ -309,16 +309,14 @@ void spi_transfer_byte(spi_t dev, char out, char *in)
             break;
 #endif /* SPI_0_EN */
         default:
-            return;
+            return 0;
     }
 
     while (!(spi_port->SPI_SR & SPI_SR_TDRE));
     spi_port->SPI_TDR = SPI_TDR_TD(out);
     while (!(spi_port->SPI_SR & SPI_SR_RDRF));
     tmp = (char)(spi_port->SPI_RDR & SPI_RDR_RD_Msk);
-    if (in) {
-        *in = tmp;
-    }
+    return tmp;
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)

--- a/cpu/sam3/periph/spi.c
+++ b/cpu/sam3/periph/spi.c
@@ -30,9 +30,6 @@
 #include "periph/spi.h"
 #include "sam3x8e.h"
 
-/* guard this file in case no SPI device is defined */
-#if SPI_NUMOF
-
 /**
  * @brief Array holding one pre-initialized mutex for each SPI device
  */
@@ -240,7 +237,7 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
     return 0;
 }
 
-int spi_conf_pins(spi_t dev)
+void spi_conf_pins(spi_t dev)
 {
     switch (dev) {
 #if SPI_0_EN
@@ -286,33 +283,24 @@ int spi_conf_pins(spi_t dev)
             break;
 #endif /* SPI_0_EN */
         default:
-            return -1;
+            return;
     }
-
-    return 0;
 }
 
-int spi_acquire(spi_t dev)
+void spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
     mutex_lock(&locks[dev]);
-    return 0;
 }
 
-int spi_release(spi_t dev)
+void spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
     mutex_unlock(&locks[dev]);
-    return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+void spi_transfer_byte(spi_t dev, char out, char *in)
 {
     Spi *spi_port;
+    char tmp;
 
     switch (dev) {
 #if SPI_0_EN
@@ -321,18 +309,16 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
             break;
 #endif /* SPI_0_EN */
         default:
-            return -1;
+            return;
     }
 
     while (!(spi_port->SPI_SR & SPI_SR_TDRE));
-
     spi_port->SPI_TDR = SPI_TDR_TD(out);
-
     while (!(spi_port->SPI_SR & SPI_SR_RDRF));
-
-    *in = spi_port->SPI_RDR & SPI_RDR_RD_Msk;
-
-    return 1;
+    tmp = (char)(spi_port->SPI_RDR & SPI_RDR_RD_Msk);
+    if (in) {
+        *in = tmp;
+    }
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)
@@ -369,5 +355,3 @@ void SPI_0_IRQ_HANDLER(void)
     }
 }
 #endif
-
-#endif /* SPI_NUMOF */

--- a/cpu/samd21/periph/spi.c
+++ b/cpu/samd21/periph/spi.c
@@ -213,7 +213,7 @@ void spi_release(spi_t dev)
     mutex_unlock(&locks[dev]);
 }
 
-void spi_transfer_byte(spi_t dev, char out, char *in)
+char spi_transfer_byte(spi_t dev, char out)
 {
     SercomSpi* spi_dev = 0;
     char tmp;
@@ -230,21 +230,15 @@ void spi_transfer_byte(spi_t dev, char out, char *in)
         spi_dev = &(SPI_1_DEV);
         break;
 #endif
+    default:
+        return 0;
     }
 
-    while (!spi_dev->INTFLAG.bit.DRE); /* while data register is not empty*/
+    while (!spi_dev->INTFLAG.bit.DRE);  /* while data register is not empty*/
     spi_dev->DATA.bit.DATA = out;
-
-    if (in)
-    {
-        while (!spi_dev->INTFLAG.bit.RXC); /* while receive is not complete*/
-        *in = spi_dev->DATA.bit.DATA;
-    }
-    else
-    {
-        /* clear input byte even if we're not interested */
-        spi_dev->DATA.bit.DATA;
-    }
+    while (!spi_dev->INTFLAG.bit.RXC);  /* while receive is not complete*/
+    tmp = spi_dev->DATA.bit.DATA;
+    return tmp;
 }
 
 void spi_poweron(spi_t dev)

--- a/cpu/saml21/periph/spi.c
+++ b/cpu/saml21/periph/spi.c
@@ -186,23 +186,16 @@ void spi_release(spi_t dev)
     mutex_unlock(&locks[dev]);
 }
 
-void spi_transfer_byte(spi_t dev, char out, char *in)
+char spi_transfer_byte(spi_t dev, char out)
 {
     SercomSpi* spi_dev = spi[dev].dev;
+    char tmp;
 
-    while (!spi_dev->INTFLAG.bit.DRE); /* while data register is not empty*/
+    while (!spi_dev->INTFLAG.bit.DRE);  /* while data register is not empty*/
     spi_dev->DATA.bit.DATA = out;
-
-    if (in)
-    {
-        while (!spi_dev->INTFLAG.bit.RXC); /* while receive is not complete*/
-        *in = spi_dev->DATA.bit.DATA;
-    }
-    else
-    {
-        /* clear input byte even if we're not interested */
-        spi_dev->DATA.bit.DATA;
-    }
+    while (!spi_dev->INTFLAG.bit.RXC);  /* while receive is not complete*/
+    tmp = spi_dev->DATA.bit.DATA;
+    return tmp;
 }
 
 void spi_poweron(spi_t dev)

--- a/cpu/saml21/periph/spi.c
+++ b/cpu/saml21/periph/spi.c
@@ -30,9 +30,9 @@
 #include "periph/spi.h"
 #include "periph_conf.h"
 #include "board.h"
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
-#if SPI_0_EN  || SPI_1_EN
 
 #include "saml21_periph.h"
 
@@ -176,30 +176,17 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char))
     return 0;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_acquire(spi_t dev)
 {
-    /* TODO*/
-}
-
-int spi_acquire(spi_t dev)
-{
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
     mutex_lock(&locks[dev]);
-    return 0;
 }
 
-int spi_release(spi_t dev)
+void spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
     mutex_unlock(&locks[dev]);
-    return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+void spi_transfer_byte(spi_t dev, char out, char *in)
 {
     SercomSpi* spi_dev = spi[dev].dev;
 
@@ -216,7 +203,6 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
         /* clear input byte even if we're not interested */
         spi_dev->DATA.bit.DATA;
     }
-    return 1;
 }
 
 void spi_poweron(spi_t dev)
@@ -232,5 +218,3 @@ void spi_poweroff(spi_t dev)
     spi_dev->CTRLA.bit.ENABLE = 0;
     while(spi_dev->SYNCBUSY.bit.ENABLE);
 }
-
-#endif /* SPI_0_EN || SPI_1_EN */

--- a/cpu/stm32f0/periph/spi.c
+++ b/cpu/stm32f0/periph/spi.c
@@ -29,9 +29,6 @@
 #include "thread.h"
 #include "sched.h"
 
-/* guard file in case no SPI device is defined */
-#if SPI_NUMOF
-
 /**
  * @brief Array holding one pre-initialized mutex for each SPI device
  */
@@ -118,7 +115,7 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data))
     return -1;
 }
 
-int spi_conf_pins(spi_t dev)
+void spi_conf_pins(spi_t dev)
 {
     GPIO_TypeDef *port;
     int pin[3];        /* 3 pins: sck, miso, mosi */
@@ -144,7 +141,7 @@ int spi_conf_pins(spi_t dev)
             break;
 #endif
         default:
-            return -1;
+            return;
     }
 
     /* configure pins for their correct alternate function */
@@ -155,29 +152,19 @@ int spi_conf_pins(spi_t dev)
         port->AFR[hl] &= ~(0xf << ((pin[i] - (hl * 8)) * 4));
         port->AFR[hl] |= (af << ((pin[i] - (hl * 8)) * 4));
     }
-
-    return 0;
 }
 
-int spi_acquire(spi_t dev)
+void spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
     mutex_lock(&locks[dev]);
-    return 0;
 }
 
-int spi_release(spi_t dev)
+void spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
     mutex_unlock(&locks[dev]);
-    return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+void spi_transfer_byte(spi_t dev, char out, char *in)
 {
     char tmp;
     SPI_TypeDef *spi = 0;
@@ -194,7 +181,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
             break;
 #endif
         default:
-            return 0;
+            return;
     }
 
     /* wait for an eventually previous byte to be readily transferred */
@@ -209,8 +196,6 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
     if (in) {
         *in = tmp;
     }
-
-    return 1;
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)
@@ -251,5 +236,3 @@ void spi_poweroff(spi_t dev)
 #endif
     }
 }
-
-#endif /* SPI_NUMOF */

--- a/cpu/stm32f0/periph/spi.c
+++ b/cpu/stm32f0/periph/spi.c
@@ -164,7 +164,7 @@ void spi_release(spi_t dev)
     mutex_unlock(&locks[dev]);
 }
 
-void spi_transfer_byte(spi_t dev, char out, char *in)
+char spi_transfer_byte(spi_t dev, char out)
 {
     char tmp;
     SPI_TypeDef *spi = 0;
@@ -181,7 +181,7 @@ void spi_transfer_byte(spi_t dev, char out, char *in)
             break;
 #endif
         default:
-            return;
+            return 0;
     }
 
     /* wait for an eventually previous byte to be readily transferred */
@@ -192,10 +192,7 @@ void spi_transfer_byte(spi_t dev, char out, char *in)
     while(!(spi->SR & SPI_SR_RXNE) );
     /* read response byte to reset flags */
     tmp = *((volatile uint8_t *)(&spi->DR));
-    /* 'return' response byte if wished for */
-    if (in) {
-        *in = tmp;
-    }
+    return tmp;
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)

--- a/cpu/stm32f1/periph/spi.c
+++ b/cpu/stm32f1/periph/spi.c
@@ -31,9 +31,6 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-/* guard file in case no SPI device is defined */
-#if SPI_0_EN
-
 /**
  * @brief Array holding one pre-initialized mutex for each SPI device
  */
@@ -107,7 +104,7 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char))
     return -1;
 }
 
-int spi_conf_pins(spi_t dev)
+void spi_conf_pins(spi_t dev)
 {
     gpio_t mosi, miso, clk;
 
@@ -120,7 +117,7 @@ int spi_conf_pins(spi_t dev)
             break;
 #endif
         default:
-            return -1;
+            return;
     }
 
     /* configure pins for alternate function input (MISO) or output (MOSI, CLK) */
@@ -130,28 +127,20 @@ int spi_conf_pins(spi_t dev)
     return 0;
 }
 
-int spi_acquire(spi_t dev)
+void spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
     mutex_lock(&locks[dev]);
-    return 0;
 }
 
-int spi_release(spi_t dev)
+void spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
     mutex_unlock(&locks[dev]);
-    return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+void spi_transfer_byte(spi_t dev, char out, char *in)
 {
     SPI_TypeDef *spi;
-    int transferred = 0;
+    char tmp;
 
     switch(dev) {
 #ifdef SPI_0_EN
@@ -160,34 +149,16 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
             break;
 #endif
         default:
-            return -1;
+            return;
     }
 
     while ((spi->SR & SPI_SR_TXE) == RESET);
     spi->DR = out;
-    transferred++;
-
     while ((spi->SR & SPI_SR_RXNE) == RESET);
-    if (in != NULL) {
-        *in = spi->DR;
-        transferred++;
+    tmp = spi->DR;
+    if (in) {
+        *in = tmp;
     }
-    else {
-        spi->DR;
-    }
-
-    /* SPI busy */
-    while ((spi->SR & 0x80));
-#if ENABLE_DEBUG
-    if (in != NULL) {
-        DEBUG("\nout: %x in: %x transferred: %x\n", out, *in, transferred);
-    }
-    else {
-        DEBUG("\nout: %x in: was nullPointer transferred: %x\n", out, transferred);
-    }
-#endif /*ENABLE_DEBUG */
-
-    return transferred;
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)
@@ -218,5 +189,3 @@ void spi_poweroff(spi_t dev)
 #endif
     }
 }
-
-#endif /* SPI_0_EN */

--- a/cpu/stm32f1/periph/spi.c
+++ b/cpu/stm32f1/periph/spi.c
@@ -137,7 +137,7 @@ void spi_release(spi_t dev)
     mutex_unlock(&locks[dev]);
 }
 
-void spi_transfer_byte(spi_t dev, char out, char *in)
+char spi_transfer_byte(spi_t dev, char out)
 {
     SPI_TypeDef *spi;
     char tmp;
@@ -149,16 +149,14 @@ void spi_transfer_byte(spi_t dev, char out, char *in)
             break;
 #endif
         default:
-            return;
+            return 0;
     }
 
     while ((spi->SR & SPI_SR_TXE) == RESET);
     spi->DR = out;
     while ((spi->SR & SPI_SR_RXNE) == RESET);
     tmp = spi->DR;
-    if (in) {
-        *in = tmp;
-    }
+    return tmp;
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)

--- a/cpu/stm32f3/periph/spi.c
+++ b/cpu/stm32f3/periph/spi.c
@@ -294,7 +294,7 @@ void spi_release(spi_t dev)
     mutex_unlock(&locks[dev]);
 }
 
-void spi_transfer_byte(spi_t dev, char out, char *in)
+char spi_transfer_byte(spi_t dev, char out)
 {
     char tmp;
 
@@ -308,10 +308,7 @@ void spi_transfer_byte(spi_t dev, char out, char *in)
     while(!(spi[dev]->SR & SPI_SR_RXNE) );
     /* read response byte to reset flags */
     tmp = *DR;
-    /* 'return' response byte if wished for */
-    if (in) {
-        *in = tmp;
-    }
+    return tmp;
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)

--- a/cpu/stm32f3/periph/spi.c
+++ b/cpu/stm32f3/periph/spi.c
@@ -37,9 +37,6 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-/* guard this file in case no SPI device is defined */
-#if SPI_NUMOF
-
 typedef struct {
     char(*cb)(char data);
 } spi_state_t;
@@ -219,7 +216,7 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
     return 0;
 }
 
-int spi_conf_pins(spi_t dev)
+void spi_conf_pins(spi_t dev)
 {
     GPIO_TypeDef *port[3];
     int pin[3], af[3];
@@ -265,7 +262,7 @@ int spi_conf_pins(spi_t dev)
             break;
 #endif /* SPI_2_EN */
         default:
-            return -1;
+            return;
     }
 
     for (int i = 0; i < 3; i++) {
@@ -285,53 +282,36 @@ int spi_conf_pins(spi_t dev)
         port[i]->AFR[hl] &= ~(0xf << ((pin[i] - (hl * 8)) * 4));
         port[i]->AFR[hl] |= (af[i] << ((pin[i] - (hl * 8)) * 4));
     }
-
-    return 0;
 }
 
-int spi_acquire(spi_t dev)
+void spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
     mutex_lock(&locks[dev]);
-    return 0;
 }
 
-int spi_release(spi_t dev)
+void spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
     mutex_unlock(&locks[dev]);
-    return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+void spi_transfer_byte(spi_t dev, char out, char *in)
 {
     char tmp;
 
     /* recast to uint_8 to force 8bit access */
     volatile uint8_t *DR = (volatile uint8_t*) &spi[dev]->DR;
-
     /* wait for an eventually previous byte to be readily transferred */
     while(!(spi[dev]->SR & SPI_SR_TXE));
-
     /* put next byte into the output register */
     *DR = out;
-
     /* wait until the current byte was successfully transferred */
     while(!(spi[dev]->SR & SPI_SR_RXNE) );
-
     /* read response byte to reset flags */
     tmp = *DR;
-
     /* 'return' response byte if wished for */
     if (in) {
         *in = tmp;
     }
-
-    return 1;
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)
@@ -421,5 +401,3 @@ void SPI_2_IRQ_HANDLER(void)
     irq_handler_transfer(SPI_2_DEV, SPI_2);
 }
 #endif
-
-#endif /* SPI_NUMOF */

--- a/cpu/stm32f4/periph/spi.c
+++ b/cpu/stm32f4/periph/spi.c
@@ -20,6 +20,8 @@
  * @}
  */
 #include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
 
 #include "board.h"
 #include "cpu.h"
@@ -32,9 +34,6 @@
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
-
-/* guard this file in case no SPI device is defined */
-#if SPI_NUMOF
 
 /**
  * @brief Data-structure holding the state for a SPI device
@@ -222,7 +221,7 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
     return 0;
 }
 
-int spi_conf_pins(spi_t dev)
+void spi_conf_pins(spi_t dev)
 {
     GPIO_TypeDef *port[3];
     int pin[3], af[3];
@@ -268,7 +267,7 @@ int spi_conf_pins(spi_t dev)
             break;
 #endif /* SPI_2_EN */
         default:
-            return -1;
+            return;
     }
 
     /***************** GPIO-Init *****************/
@@ -289,29 +288,19 @@ int spi_conf_pins(spi_t dev)
         port[i]->AFR[hl] &= ~(0xf << ((pin[i] - (hl * 8)) * 4));
         port[i]->AFR[hl] |= (af[i] << ((pin[i] - (hl * 8)) * 4));
     }
-
-    return 0;
 }
 
-int spi_acquire(spi_t dev)
+void spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
     mutex_lock(&locks[dev]);
-    return 0;
 }
 
-int spi_release(spi_t dev)
+void spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
     mutex_unlock(&locks[dev]);
-    return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+void spi_transfer_byte(spi_t dev, char out, char *in)
 {
     SPI_TypeDef *spi_port;
 
@@ -332,22 +321,18 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
             break;
 #endif
         default:
-            return -1;
+            return;
     }
 
     while (!(spi_port->SR & SPI_SR_TXE));
     spi_port->DR = out;
-
     while (!(spi_port->SR & SPI_SR_RXNE));
-
     if (in != NULL) {
         *in = spi_port->DR;
     }
     else {
         spi_port->DR;
     }
-
-    return 1;
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)
@@ -452,5 +437,3 @@ void SPI_2_IRQ_HANDLER(void)
     irq_handler_transfer(SPI_2_DEV, SPI_2);
 }
 #endif
-
-#endif /* SPI_NUMOF */

--- a/cpu/stm32f4/periph/spi.c
+++ b/cpu/stm32f4/periph/spi.c
@@ -300,9 +300,10 @@ void spi_release(spi_t dev)
     mutex_unlock(&locks[dev]);
 }
 
-void spi_transfer_byte(spi_t dev, char out, char *in)
+char spi_transfer_byte(spi_t dev, char out)
 {
     SPI_TypeDef *spi_port;
+    char tmp;
 
     switch (dev) {
 #if SPI_0_EN
@@ -321,18 +322,14 @@ void spi_transfer_byte(spi_t dev, char out, char *in)
             break;
 #endif
         default:
-            return;
+            return 0;
     }
 
     while (!(spi_port->SR & SPI_SR_TXE));
     spi_port->DR = out;
     while (!(spi_port->SR & SPI_SR_RXNE));
-    if (in != NULL) {
-        *in = spi_port->DR;
-    }
-    else {
-        spi_port->DR;
-    }
+    tmp = (char)spi_port->DR;
+    return tmp;
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)

--- a/cpu/stm32l1/periph/spi.c
+++ b/cpu/stm32l1/periph/spi.c
@@ -29,9 +29,6 @@
 #include "thread.h"
 #include "sched.h"
 
-/* guard file in case no SPI device is defined */
-#if SPI_NUMOF
-
 /**
  * @brief Array holding one pre-initialized mutex for each SPI device
  */
@@ -114,7 +111,7 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data))
     return -1;
 }
 
-int spi_conf_pins(spi_t dev)
+void spi_conf_pins(spi_t dev)
 {
     GPIO_TypeDef *port;
     int pin[3];        /* 3 pins: sck, miso, mosi */
@@ -140,7 +137,7 @@ int spi_conf_pins(spi_t dev)
             break;
 #endif
         default:
-            return -1;
+            return;
     }
 
     /* configure pins for their correct alternate function */
@@ -151,29 +148,19 @@ int spi_conf_pins(spi_t dev)
         port->AFR[hl] &= ~(0xf << ((pin[i] - (hl * 8)) * 4));
         port->AFR[hl] |= (af << ((pin[i] - (hl * 8)) * 4));
     }
-
-    return 0;
 }
 
-int spi_acquire(spi_t dev)
+void spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
     mutex_lock(&locks[dev]);
-    return 0;
 }
 
-int spi_release(spi_t dev)
+void spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
     mutex_unlock(&locks[dev]);
-    return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+void spi_transfer_byte(spi_t dev, char out, char *in)
 {
     char tmp;
     SPI_TypeDef *spi = 0;
@@ -190,7 +177,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
             break;
 #endif
         default:
-            return 0;
+            return;
     }
 
     /* wait for an eventually previous byte to be readily transferred */
@@ -205,17 +192,6 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
     if (in) {
         *in = tmp;
     }
-
-#if ENABLE_DEBUG
-    if (in != NULL) {
-        DEBUG("\nout: %x in: %x \n", out, *in, transferred);
-    }
-    else {
-        DEBUG("\nout: %x in: was nullPointer\n", out, transferred);
-    }
-#endif /*ENABLE_DEBUG */
-
-    return 1;
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)
@@ -256,5 +232,3 @@ void spi_poweroff(spi_t dev)
 #endif
     }
 }
-
-#endif /* SPI_NUMOF */

--- a/cpu/stm32l1/periph/spi.c
+++ b/cpu/stm32l1/periph/spi.c
@@ -160,7 +160,7 @@ void spi_release(spi_t dev)
     mutex_unlock(&locks[dev]);
 }
 
-void spi_transfer_byte(spi_t dev, char out, char *in)
+char spi_transfer_byte(spi_t dev, char out)
 {
     char tmp;
     SPI_TypeDef *spi = 0;
@@ -177,7 +177,7 @@ void spi_transfer_byte(spi_t dev, char out, char *in)
             break;
 #endif
         default:
-            return;
+            return 0;
     }
 
     /* wait for an eventually previous byte to be readily transferred */
@@ -187,11 +187,8 @@ void spi_transfer_byte(spi_t dev, char out, char *in)
     /* wait until the current byte was successfully transferred */
     while(!(spi->SR & SPI_SR_RXNE));
     /* read response byte to reset flags */
-    tmp = spi->DR;
-    /* 'return' response byte if wished for */
-    if (in) {
-        *in = tmp;
-    }
+    tmp = (char)spi->DR;
+    return tmp;
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -32,11 +32,9 @@ void at86rf2xx_reg_write(const at86rf2xx_t *dev,
                          const uint8_t value)
 {
     spi_acquire(dev->spi);
-    gpio_clear(dev->cs_pin);
-    spi_transfer_reg(dev->spi,
+    spi_transfer_reg(dev->spi, dev->cs, false,
                      AT86RF2XX_ACCESS_REG | AT86RF2XX_ACCESS_WRITE | addr,
                      value);
-    gpio_set(dev->cs_pin);
     spi_release(dev->spi);
 }
 
@@ -45,11 +43,9 @@ uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev, const uint8_t addr)
     char value;
 
     spi_acquire(dev->spi);
-    gpio_clear(dev->cs_pin);
-    value = spi_transfer_reg(dev->spi,
-                     AT86RF2XX_ACCESS_REG | AT86RF2XX_ACCESS_READ | addr,
-                     0);
-    gpio_set(dev->cs_pin);
+    value = spi_transfer_reg(dev->spi, dev->cs, false,
+                             AT86RF2XX_ACCESS_REG | AT86RF2XX_ACCESS_READ | addr,
+                             0);
     spi_release(dev->spi);
 
     return (uint8_t)value;
@@ -61,11 +57,10 @@ void at86rf2xx_sram_read(const at86rf2xx_t *dev,
                          const size_t len)
 {
     spi_acquire(dev->spi);
-    gpio_clear(dev->cs_pin);
-    spi_transfer_reg(dev->spi, AT86RF2XX_ACCESS_SRAM | AT86RF2XX_ACCESS_READ,
+    spi_transfer_reg(dev->spi, dev->cs, true,
+                     AT86RF2XX_ACCESS_SRAM | AT86RF2XX_ACCESS_READ,
                      (char)offset);
-    spi_transfer_bytes(dev->spi, NULL, (char*)data, len);
-    gpio_set(dev->cs_pin);
+    spi_transfer_bytes(dev->spi, dev->cs, false, NULL, (char*)data, len);
     spi_release(dev->spi);
 }
 
@@ -75,12 +70,10 @@ void at86rf2xx_sram_write(const at86rf2xx_t *dev,
                           const size_t len)
 {
     spi_acquire(dev->spi);
-    gpio_clear(dev->cs_pin);
-    spi_transfer_reg(dev->spi,
+    spi_transfer_reg(dev->spi, dev->cs, true,
                      AT86RF2XX_ACCESS_SRAM | AT86RF2XX_ACCESS_WRITE,
                      (char)offset);
-    spi_transfer_bytes(dev->spi, (char*)data, NULL, len);
-    gpio_set(dev->cs_pin);
+    spi_transfer_bytes(dev->spi, dev->cs, false, (char*)data, NULL, len);
     spi_release(dev->spi);
 }
 
@@ -89,10 +82,9 @@ void at86rf2xx_fb_read(const at86rf2xx_t *dev,
                        const size_t len)
 {
     spi_acquire(dev->spi);
-    gpio_clear(dev->cs_pin);
-    spi_transfer_byte(dev->spi, AT86RF2XX_ACCESS_FB | AT86RF2XX_ACCESS_READ);
-    spi_transfer_bytes(dev->spi, NULL, (char *)data, len);
-    gpio_set(dev->cs_pin);
+    spi_transfer_byte(dev->spi, dev->cs, true,
+                      AT86RF2XX_ACCESS_FB | AT86RF2XX_ACCESS_READ);
+    spi_transfer_bytes(dev->spi, dev->cs, false, NULL, (char *)data, len);
     spi_release(dev->spi);
 }
 

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -35,7 +35,7 @@ void at86rf2xx_reg_write(const at86rf2xx_t *dev,
     gpio_clear(dev->cs_pin);
     spi_transfer_reg(dev->spi,
                      AT86RF2XX_ACCESS_REG | AT86RF2XX_ACCESS_WRITE | addr,
-                     value, 0);
+                     value);
     gpio_set(dev->cs_pin);
     spi_release(dev->spi);
 }
@@ -46,9 +46,9 @@ uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev, const uint8_t addr)
 
     spi_acquire(dev->spi);
     gpio_clear(dev->cs_pin);
-    spi_transfer_reg(dev->spi,
+    value = spi_transfer_reg(dev->spi,
                      AT86RF2XX_ACCESS_REG | AT86RF2XX_ACCESS_READ | addr,
-                     0, &value);
+                     0);
     gpio_set(dev->cs_pin);
     spi_release(dev->spi);
 
@@ -62,10 +62,9 @@ void at86rf2xx_sram_read(const at86rf2xx_t *dev,
 {
     spi_acquire(dev->spi);
     gpio_clear(dev->cs_pin);
-    spi_transfer_reg(dev->spi,
-                     AT86RF2XX_ACCESS_SRAM | AT86RF2XX_ACCESS_READ,
-                     (char)offset, NULL);
-    spi_transfer_bytes(dev->spi, NULL, (char *)data, len);
+    spi_transfer_reg(dev->spi, AT86RF2XX_ACCESS_SRAM | AT86RF2XX_ACCESS_READ,
+                     (char)offset);
+    spi_transfer_bytes(dev->spi, NULL, (char*)data, len);
     gpio_set(dev->cs_pin);
     spi_release(dev->spi);
 }
@@ -79,8 +78,8 @@ void at86rf2xx_sram_write(const at86rf2xx_t *dev,
     gpio_clear(dev->cs_pin);
     spi_transfer_reg(dev->spi,
                      AT86RF2XX_ACCESS_SRAM | AT86RF2XX_ACCESS_WRITE,
-                     (char)offset, NULL);
-    spi_transfer_bytes(dev->spi, (char *)data, NULL, len);
+                     (char)offset);
+    spi_transfer_bytes(dev->spi, (char*)data, NULL, len);
     gpio_set(dev->cs_pin);
     spi_release(dev->spi);
 }
@@ -91,9 +90,7 @@ void at86rf2xx_fb_read(const at86rf2xx_t *dev,
 {
     spi_acquire(dev->spi);
     gpio_clear(dev->cs_pin);
-    spi_transfer_byte(dev->spi,
-                      AT86RF2XX_ACCESS_FB | AT86RF2XX_ACCESS_READ,
-                      NULL);
+    spi_transfer_byte(dev->spi, AT86RF2XX_ACCESS_FB | AT86RF2XX_ACCESS_READ);
     spi_transfer_bytes(dev->spi, NULL, (char *)data, len);
     gpio_set(dev->cs_pin);
     spi_release(dev->spi);

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -138,7 +138,7 @@ typedef struct {
     kernel_pid_t mac_pid;               /**< the driver's thread's PID */
     /* device specific fields */
     spi_t spi;                          /**< used SPI device */
-    gpio_t cs_pin;                      /**< chip select pin */
+    spi_cs_t cs;                        /**< chip select pin */
     gpio_t sleep_pin;                   /**< sleep pin */
     gpio_t reset_pin;                   /**< reset pin */
     gpio_t int_pin;                     /**< external interrupt pin */

--- a/drivers/include/periph/dev_enums.h
+++ b/drivers/include/periph/dev_enums.h
@@ -154,6 +154,7 @@ enum {
 /**
  * @brief   Legacy definitions of available SPI devices
  */
+#ifdef SPI_NUMOF
 enum {
 #if SPI_0_EN
     SPI_0 = 0,          /**< SPI device 0 */
@@ -168,6 +169,7 @@ enum {
     SPI_3,              /**< SPI device 3 */
 #endif
 };
+#endif
 
 #ifdef __cplusplus
 }

--- a/drivers/include/periph/dev_enums.h
+++ b/drivers/include/periph/dev_enums.h
@@ -20,8 +20,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PERIPH_COMPAT_H_
-#define PERIPH_COMPAT_H_
+#ifndef DEV_ENUMS_H
+#define DEV_ENUMS_H
 
 #include "periph_conf.h"
 
@@ -151,9 +151,27 @@ enum {
     GPIO_NUMOF
 };
 
+/**
+ * @brief   Legacy definitions of available SPI devices
+ */
+enum {
+#if SPI_0_EN
+    SPI_0 = 0,          /**< SPI device 0 */
+#endif
+#if SPI_1_EN
+    SPI_1,              /**< SPI device 1 */
+#endif
+#if SPI_2_EN
+    SPI_2,              /**< SPI device 2 */
+#endif
+#if SPI_3_EN
+    SPI_3,              /**< SPI device 3 */
+#endif
+};
+
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* PERIPH_COMPAT_H_ */
+#endif /* DEV_ENUMS_H */
 /** @} */

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    driver_periph_spi SPI
  * @ingroup     driver_periph
- * @brief       Low-level SPI peripheral driver
+ * @brief       Low-level SPI peripheral driver interface
  *
  * @{
  * @file
@@ -23,9 +23,11 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <stdbool.h>
 
 #include "periph_cpu.h"
 #include "periph_conf.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,10 +48,24 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Define value for unused CS line
+ */
+#ifndef SPI_CS_UNDEF
+#define SPI_CS_UNDEF    (GPIO_UNDEF)
+#endif
+
+/**
  * @brief   Define default SPI device identifier type
  */
 #ifndef HAVE_SPI_T
 typedef int spi_t;
+#endif
+
+/**
+ * @brief   Default CS pin definition
+ */
+#ifndef HAVE_SPI_CS_T
+typedef gpio_t spi_cs_t;
 #endif
 
 /**
@@ -169,21 +185,26 @@ void spi_release(spi_t dev);
  * @brief   Transfer one byte on the given SPI bus
  *
  * @param[in] dev       SPI device to use
+ * @param[in] cs        Chip select line to use
+ * @param[in] cont      Set true for leaving CS active after transfer
  * @param[in] out       Byte to send out, set NULL if only receiving
  *
  * @return              Byte that was read from the slave
  */
-char spi_transfer_byte(spi_t dev, char out);
+char spi_transfer_byte(spi_t dev, spi_cs_t cs, bool cont, char out);
 
 /**
  * @brief   Transfer a number bytes on the given SPI bus
  *
  * @param[in] dev       SPI device to use
+ * @param[in] cs        Chip select line to use
+ * @param[in] cont      Set true for leaving CS active after transfer
  * @param[in] out       Array of bytes to send, set NULL if only receiving
  * @param[out] in       Buffer to receive bytes to, set NULL if only sending
  * @param[in] len       Number of bytes to transfer
  */
-void spi_transfer_bytes(spi_t dev, char *out, char *in, size_t len);
+void spi_transfer_bytes(spi_t dev, spi_cs_t cs, bool cont,
+                        char *out, char *in, size_t len);
 
 /**
  * @brief   Transfer one byte to/from a given register address
@@ -193,13 +214,15 @@ void spi_transfer_bytes(spi_t dev, char *out, char *in, size_t len);
  * function is a convenient shortcut for interfacing with such devices.
  *
  * @param[in] dev       SPI device to use
+ * @param[in] cs        Chip select line to use
+ * @param[in] cont      Set true for leaving CS active after transfer
  * @param[in] reg       Register address to transfer data to/from
  * @param[in] out       Byte to send, set NULL if only receiving data
  * @param[out] in       Byte to read, set NULL if only sending
  *
  * @return              Value that was read from the slave's register
  */
-char spi_transfer_reg(spi_t dev, uint8_t reg, char out);
+char spi_transfer_reg(spi_t dev, spi_cs_t cs, bool cont, uint8_t reg, char out);
 
 /**
  * @brief   Transfer a number of bytes from/to a given register address
@@ -209,12 +232,15 @@ char spi_transfer_reg(spi_t dev, uint8_t reg, char out);
  * function is a convenient shortcut for interfacing with such devices.
  *
  * @param[in] dev       SPI device to use
+ * @param[in] cs        Chip select line to use
+ * @param[in] cont      Set true for leaving CS active after transfer
  * @param[in] reg       Register address to transfer data to/from
  * @param[in] out       Byte array to send data from, set NULL if only receiving
  * @param[out] in       Byte buffer to read into, set NULL if only sending
  * @param[in] len       Number of bytes to transfer
  */
-void spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, size_t len);
+void spi_transfer_regs(spi_t dev, spi_cs_t cs, bool cont,
+                       uint8_t reg, char *out, char *in, size_t len);
 
 /**
  * @brief   Tell the SPI driver that a new transaction was started

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -48,6 +48,13 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Default SPI chip select pin access macro
+ */
+#ifndef SPI_CS_DEV
+#define SPI_CS_DEV(x)   (-x)
+#endif
+
+/**
  * @brief   Define value for unused CS line
  */
 #ifndef SPI_CS_UNDEF
@@ -139,7 +146,7 @@ typedef enum {
  *                      transfer period. If @p start is false, the return value
  *                      should be ignored
  */
-typedef char(spi_cs_cb_t)(bool start);
+typedef uint8_t(spi_cs_cb_t)(void *arg, bool start);
 
 /**
  * @brief   Prototype for callback that is called after every transfered byte
@@ -151,7 +158,7 @@ typedef char(spi_cs_cb_t)(bool start);
  * @return              The character that is send to the master on the next
  *                      transfer period
  */
-typedef char(spi_data_cb_t)(char data);
+typedef uint8_t(spi_data_cb_t)(void *arg, uint8_t data);
 
 /**
  * @brief   Initialize the given SPI device to work in master mode
@@ -168,7 +175,8 @@ typedef char(spi_data_cb_t)(char data);
  * @return              0 on success
  * @return              -1 on undefined device given
  * @return              -2 on unavailable speed value
- * @return              -3 on other errors
+ * @return              -3 on configuration not supported
+ * @return              -4 on other errors
  */
 int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed);
 
@@ -188,10 +196,11 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed);
  *
  * @return              0 on success
  * @return              -1 on undefined device given
- * @return              -2 on other errors
+ * @return              -2 on slave mode not supported
+ * @return              -3 on other errors
  */
 int spi_init_slave(spi_t dev, spi_cs_t cs, spi_cs_pol_t pol, spi_conf_t conf,
-                   spi_cs_cb_t cs_cb, spi_data_cb_t data_cb);
+                   spi_cs_cb_t cs_cb, spi_data_cb_t data_cb, void *arg);
 
 /**
  * @brief   Initialize the given chip select pin
@@ -233,7 +242,7 @@ void spi_release(spi_t dev);
  *
  * @return              Byte that was read from the slave
  */
-char spi_transfer_byte(spi_t dev, spi_cs_t cs, bool cont, char out);
+uint8_t spi_transfer_byte(spi_t dev, spi_cs_t cs, bool cont, uint8_t out);
 
 /**
  * @brief   Transfer a number bytes on the given SPI bus
@@ -246,7 +255,7 @@ char spi_transfer_byte(spi_t dev, spi_cs_t cs, bool cont, char out);
  * @param[in] len       Number of bytes to transfer
  */
 void spi_transfer_bytes(spi_t dev, spi_cs_t cs, bool cont,
-                        char *out, char *in, size_t len);
+                        uint8_t *out, uint8_t *in, size_t len);
 
 /**
  * @brief   Transfer one byte to/from a given register address
@@ -264,7 +273,8 @@ void spi_transfer_bytes(spi_t dev, spi_cs_t cs, bool cont,
  *
  * @return              Value that was read from the slave's register
  */
-char spi_transfer_reg(spi_t dev, spi_cs_t cs, bool cont, uint8_t reg, char out);
+uint8_t spi_transfer_reg(spi_t dev, spi_cs_t cs, bool cont, uint8_t reg,
+                         uint8_t out);
 
 /**
  * @brief   Transfer a number of bytes from/to a given register address
@@ -282,7 +292,7 @@ char spi_transfer_reg(spi_t dev, spi_cs_t cs, bool cont, uint8_t reg, char out);
  * @param[in] len       Number of bytes to transfer
  */
 void spi_transfer_regs(spi_t dev, spi_cs_t cs, bool cont,
-                       uint8_t reg, char *out, char *in, size_t len);
+                       uint8_t reg, uint8_t *out, uint8_t *in, size_t len);
 
 /**
  * @brief Power on the given SPI device

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -32,13 +32,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Make sure the number of available SPI devices is defined
- */
-#ifndef SPI_NUMOF
-#error "SPI_NUMOF undefined for the target platform"
-#endif
-
-/**
  * @brief   Default SPI device access macro
  */
 #ifndef SPI_DEV

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -1,9 +1,9 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014-2015 Freie Universität Berlin
  *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
  */
 
 /**
@@ -11,13 +11,9 @@
  * @ingroup     driver_periph
  * @brief       Low-level SPI peripheral driver
  *
- * The current design of this interface targets implementations that use the SPI in blocking mode.
- *
- * TODO: add means for asynchronous SPI usage
- *
  * @{
  * @file
- * @brief       Low-level SPI peripheral driver interface definitions
+ * @brief       Low-level SPI peripheral driver interface definition
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
@@ -26,38 +22,48 @@
 #define SPI_H
 
 #include <stdint.h>
+#include <string.h>
 
+#include "periph_cpu.h"
 #include "periph_conf.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* add guard for the case that no SPI device is defined */
-#if SPI_NUMOF
+/**
+ * @brief   Make sure the number of available SPI devices is defined
+ */
+#ifndef SPI_NUMOF
+#error "SPI_NUMOF undefined for the target platform"
+#endif
 
 /**
- * @brief Definition available SPI devices
+ * @brief   Default SPI device access macro
  */
-typedef enum {
-#if SPI_0_EN
-    SPI_0 = 0,          /**< SPI device 0 */
+#ifndef SPI_DEV
+#define SPI_DEV(x)      (x)
 #endif
-#if SPI_1_EN
-    SPI_1,              /**< SPI device 1 */
-#endif
-#if SPI_2_EN
-    SPI_2,              /**< SPI device 2 */
-#endif
-#if SPI_3_EN
-    SPI_3,              /**< SPI device 3 */
-#endif
-} spi_t;
 
 /**
- * @brief The SPI mode is defined by the four possible combinations of clock polarity and
- *        clock phase.
+ * @brief   Define global value for undefined SPI device
  */
+#ifndef SPI_UNDEF
+#define SPI_UNDEF       (-1)
+#endif
+
+/**
+ * @brief   Define default SPI device identifier type
+ */
+#ifndef HAVE_SPI_T
+typedef int spi_t;
+#endif
+
+/**
+ * @brief   The SPI mode is defined by the four possible combinations of clock
+ *          polarity and clock phase
+ */
+#ifndef HAVE_SPI_CONF_T
 typedef enum {
     /**
      * The first data bit is sampled by the receiver on the first SCK edge. The
@@ -84,13 +90,16 @@ typedef enum {
      */
     SPI_CONF_SECOND_FALLING = 3
 } spi_conf_t;
+#endif
 
 /**
- * @brief Define a set of pre-defined SPI clock speeds.
+ * @brief   Pre-defined set of SPI clock speeds
  *
- * The actual speed of the bus can vary to some extend, as the combination of CPU clock and
- * available prescale values on certain platforms may not make the exact values possible.
+ * The actual speed of the bus can vary to some extend, as the combination of
+ * CPU clock and available prescaler values on certain platforms may not make
+ * the exact values possible.
  */
+#ifndef HAVE_SPI_SPEED_T
 typedef enum {
     SPI_SPEED_100KHZ = 0,       /**< drive the SPI bus with 100KHz */
     SPI_SPEED_400KHZ,           /**< drive the SPI bus with 400KHz */
@@ -98,31 +107,35 @@ typedef enum {
     SPI_SPEED_5MHZ,             /**< drive the SPI bus with 5MHz */
     SPI_SPEED_10MHZ             /**< drive the SPI bus with 10MHz */
 } spi_speed_t;
+#endif
 
 /**
- * @brief Initialize the given SPI device to work in master mode
+ * @brief   Initialize the given SPI device to work in master mode
  *
- * In master mode the SPI device is configured to control the SPI bus. This means the device
- * will start and end all communication on the bus and control the CLK line. For transferring
- * data on the bus the below defined transfer functions should be used.
+ * In master mode the SPI device is configured to control the SPI bus. This
+ * means the device will start and end all communication on the bus and control
+ * the CLK line. For transferring data on the bus the below defined transfer
+ * functions should be used.
  *
  * @param[in] dev       SPI device to initialize
  * @param[in] conf      Mode of clock phase and clock polarity
  * @param[in] speed     desired clock speed for driving the SPI bus
  *
  * @return              0 on success
- * @return              -1 on unavailable speed value
- * @return              -2 on other errors
+ * @return              -1 on undefined device given
+ * @return              -2 on unavailable speed value
+ * @return              -3 on other errors
  */
 int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed);
 
 /**
- * @brief Initialize the given SPI device to work in slave mode
+ * @brief   Initialize the given SPI device to work in slave mode
  *
- * In slave mode the SPI device is purely reacting to the bus. Transaction will be started and
- * ended by a connected SPI master. When a byte is received, the callback is called in interrupt
- * context with this byte as argument. The return byte of the callback is transferred to the
- * master in the next transmission cycle. This interface enables easy implementation of a register
+ * In slave mode the SPI device is purely reacting to the bus. Transaction will
+ * be started and ended by a connected SPI master. When a byte is received, the
+ * callback is called in interrupt context with this byte as argument. The
+ * return byte of the callback is transferred to the master in the next
+ * transmission cycle. This interface enables easy implementation of a register
  * based access paradigm for the SPI slave.
  *
  * @param[in] dev       The SPI device to initialize as SPI slave
@@ -130,104 +143,90 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed);
  * @param[in] cb        callback called every time a byte was received
  *
  * @return              0 on success
- * @return              -1 on error
+ * @return              -1 on undefined device given
+ * @return              -2 on other errors
  */
 int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data));
 
 /**
- * @brief Configure SCK, MISO and MOSI pins for the given SPI device
+ * @brief   Configure SCK, MISO and MOSI pins for the given SPI device
  *
- * @param[in] dev       SPI device to use
- *
- * @return              0 on success
- * @return              -1 on error
+ * @param[in] dev       SPI device to configure pins for
  */
-int spi_conf_pins(spi_t dev);
+void spi_conf_pins(spi_t dev);
 
 /**
- * @brief Get mutually exclusive access to the given SPI bus
+ * @brief   Get mutually exclusive access to the given SPI bus
  *
- * In case the SPI device is busy, this function will block until the bus is free again.
+ * In case the SPI device is busy, this function will block until the bus is
+ * free again.
  *
  * @param[in] dev       SPI device to access
- *
- * @return              0 on success
- * @return              -1 on error
  */
-int spi_acquire(spi_t dev);
+void spi_acquire(spi_t dev);
 
 /**
- * @brief Release the given SPI device to be used by others
+ * @brief   Release the given SPI device to be used by others
  *
  * @param[in] dev       SPI device to release
- *
- * @return              0 on success
- * @return              -1 on error
  */
-int spi_release(spi_t dev);
+void spi_release(spi_t dev);
 
 /**
- * @brief Transfer one byte on the given SPI bus
+ * @brief   Transfer one byte on the given SPI bus
  *
  * @param[in] dev       SPI device to use
  * @param[in] out       Byte to send out, set NULL if only receiving
- * @param[out] in       Byte to read, set NULL if only sending
  *
- * @return              Number of bytes that were transfered
- * @return              -1 on error
+ * @return              Byte that was read from the slave
  */
-int spi_transfer_byte(spi_t dev, char out, char *in);
+char spi_transfer_byte(spi_t dev, char out);
 
 /**
- * @brief Transfer a number bytes on the given SPI bus
+ * @brief   Transfer a number bytes on the given SPI bus
  *
  * @param[in] dev       SPI device to use
  * @param[in] out       Array of bytes to send, set NULL if only receiving
  * @param[out] in       Buffer to receive bytes to, set NULL if only sending
- * @param[in] length    Number of bytes to transfer
- *
- * @return              Number of bytes that were transfered
- * @return              -1 on error
+ * @param[in] len       Number of bytes to transfer
  */
-int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length);
+void spi_transfer_bytes(spi_t dev, char *out, char *in, size_t len);
 
 /**
- * @brief Transfer one byte to/from a given register address
+ * @brief   Transfer one byte to/from a given register address
  *
- * This function is a shortcut function for easier handling of register based SPI devices. As
- * many SPI devices use a register based addressing scheme, this function is a convenient short-
- * cut for interfacing with such devices.
+ * This function is a shortcut function for easier handling of register based
+ * SPI devices. As many SPI devices use a register based addressing scheme, this
+ * function is a convenient shortcut for interfacing with such devices.
  *
  * @param[in] dev       SPI device to use
  * @param[in] reg       Register address to transfer data to/from
  * @param[in] out       Byte to send, set NULL if only receiving data
  * @param[out] in       Byte to read, set NULL if only sending
  *
- * @return              Number of bytes that were transfered
- * @return              -1 on error
+ * @return              Value that was read from the slave's register
  */
-int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in);
+char spi_transfer_reg(spi_t dev, uint8_t reg, char out);
 
 /**
- * @brief Transfer a number of bytes from/to a given register address
+ * @brief   Transfer a number of bytes from/to a given register address
  *
- * This function is a shortcut function for easier handling of register based SPI devices. As
- * many SPI devices use a register based addressing scheme, this function is a convenient short-
- * cut for interfacing with such devices.
+ * This function is a shortcut function for easier handling of register based
+ * SPI devices. As many SPI devices use a register based addressing scheme, this
+ * function is a convenient shortcut for interfacing with such devices.
  *
  * @param[in] dev       SPI device to use
  * @param[in] reg       Register address to transfer data to/from
  * @param[in] out       Byte array to send data from, set NULL if only receiving
  * @param[out] in       Byte buffer to read into, set NULL if only sending
- * @param[in] length    Number of bytes to transfer
- *
- * @return              Number of bytes that were transfered
- * @return              -1 on error
+ * @param[in] len       Number of bytes to transfer
  */
-int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int length);
+void spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, size_t len);
 
 /**
- * @brief Tell the SPI driver that a new transaction was started. Call only when SPI in slave mode!
+ * @brief   Tell the SPI driver that a new transaction was started
+ *
+ * @note    This function is to be used in slave mode only!
  *
  * @param[in] dev       SPI device that is active
  * @param[in] reset_val The byte that is send to the master as first byte
@@ -247,8 +246,6 @@ void spi_poweron(spi_t dev);
  * @param[in] dev       SPI device to power off
  */
 void spi_poweroff(spi_t dev);
-
-#endif /* SPI_NUMOF */
 
 #ifdef __cplusplus
 }

--- a/drivers/kw2xrf/kw2xrf_spi.c
+++ b/drivers/kw2xrf/kw2xrf_spi.c
@@ -80,7 +80,7 @@ int kw2xrf_spi_init(spi_t spi, spi_speed_t spi_speed,
 void kw2xrf_write_dreg(uint8_t addr, uint8_t value)
 {
     kw2xrf_spi_transfer_head();
-    spi_transfer_reg(kw2xrf_spi, addr, value, NULL);
+    spi_transfer_reg(kw2xrf_spi, addr, value);
     kw2xrf_spi_transfer_tail();
     return;
 }
@@ -89,8 +89,7 @@ uint8_t kw2xrf_read_dreg(uint8_t addr)
 {
     uint8_t value;
     kw2xrf_spi_transfer_head();
-    spi_transfer_reg(kw2xrf_spi, (addr | MKW2XDRF_REG_READ),
-                     0x0, (char *)&value);
+    value = spi_transfer_reg(kw2xrf_spi, (addr | MKW2XDRF_REG_READ), 0x0);
     kw2xrf_spi_transfer_tail();
     return value;
 }

--- a/drivers/lis3dh/lis3dh.c
+++ b/drivers/lis3dh/lis3dh.c
@@ -268,15 +268,7 @@ static int lis3dh_write_reg(const lis3dh_t *dev, const lis3dh_reg_t reg, const u
     spi_acquire(dev->spi);
     /* Perform the transaction */
     gpio_clear(dev->cs);
-
-    if (spi_transfer_reg(dev->spi, addr, value, NULL) < 0) {
-        /* Transfer error */
-        gpio_set(dev->cs);
-        /* Release the bus for other threads. */
-        spi_release(dev->spi);
-        return -1;
-    }
-
+    spi_transfer_reg(dev->spi, addr, value);
     gpio_set(dev->cs);
     /* Release the bus for other threads. */
     spi_release(dev->spi);

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -29,13 +29,11 @@
 
 int nrf24l01p_read_reg(nrf24l01p_t *dev, char reg, char *answer)
 {
-    int status;
-
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
-    status = spi_transfer_reg(dev->spi, (CMD_R_REGISTER | (REGISTER_MASK & reg)), CMD_NOP, answer);
+    *answer = spi_transfer_reg(dev->spi, (CMD_R_REGISTER | (REGISTER_MASK & reg)), CMD_NOP);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
     /* Release the bus for other threads. */
@@ -43,19 +41,16 @@ int nrf24l01p_read_reg(nrf24l01p_t *dev, char reg, char *answer)
 
     hwtimer_spin(DELAY_AFTER_FUNC_TICKS);
 
-    return status;
+    return 1;
 }
 
 int nrf24l01p_write_reg(nrf24l01p_t *dev, char reg, char write)
 {
-    int status;
-    char reg_content;
-
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
-    status = spi_transfer_reg(dev->spi, (CMD_W_REGISTER | (REGISTER_MASK & reg)), write, &reg_content);
+    spi_transfer_reg(dev->spi, (CMD_W_REGISTER | (REGISTER_MASK & reg)), write);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
     /* Release the bus for other threads. */
@@ -63,7 +58,7 @@ int nrf24l01p_write_reg(nrf24l01p_t *dev, char reg, char write)
 
     hwtimer_spin(DELAY_AFTER_FUNC_TICKS);
 
-    return status;
+    return 1;
 }
 
 
@@ -631,12 +626,11 @@ int nrf24l01p_set_datarate(nrf24l01p_t *dev, nrf24l01p_dr_t dr)
 
 int nrf24l01p_get_status(nrf24l01p_t *dev)
 {
-    char status;
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
-    spi_transfer_byte(dev->spi, CMD_NOP, &status);
+    spi_transfer_byte(dev->spi, CMD_NOP);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
     /* Release the bus for other threads. */
@@ -644,7 +638,7 @@ int nrf24l01p_get_status(nrf24l01p_t *dev)
 
     hwtimer_spin(DELAY_AFTER_FUNC_TICKS);
 
-    return (int)status;
+    return 1;
 }
 
 int nrf24l01p_set_power(nrf24l01p_t *dev, int pwr)
@@ -868,34 +862,27 @@ int nrf24l01p_disable_all_auto_ack(nrf24l01p_t *dev)
 
 int nrf24l01p_flush_tx_fifo(nrf24l01p_t *dev)
 {
-    int status;
-    char reg_content;
-
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
-    status = spi_transfer_byte(dev->spi, CMD_FLUSH_TX, &reg_content);
+    spi_transfer_byte(dev->spi, CMD_FLUSH_TX);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
     /* Release the bus for other threads. */
     spi_release(dev->spi);
 
     hwtimer_spin(DELAY_AFTER_FUNC_TICKS);
-
-    return status;
+    return 1;
 }
 
 int nrf24l01p_flush_rx_fifo(nrf24l01p_t *dev)
 {
-    int status;
-    char reg_content;
-
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
-    status = spi_transfer_byte(dev->spi, CMD_FLUSH_RX, &reg_content);
+    spi_transfer_byte(dev->spi, CMD_FLUSH_RX);
     hwtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_set(dev->cs);
     /* Release the bus for other threads. */
@@ -903,7 +890,7 @@ int nrf24l01p_flush_rx_fifo(nrf24l01p_t *dev)
 
     hwtimer_spin(DELAY_AFTER_FUNC_TICKS);
 
-    return status;
+    return 1;
 }
 
 void nrf24l01p_rx_cb(void *arg)

--- a/drivers/nvram_spi/nvram-spi.c
+++ b/drivers/nvram_spi/nvram-spi.c
@@ -136,7 +136,7 @@ static int nvram_spi_write(nvram_t *dev, uint8_t *src, uint32_t dst, size_t len)
     /* Assert CS */
     gpio_clear(spi_dev->cs);
     /* Enable writes */
-    status = spi_transfer_byte(spi_dev->spi, NVRAM_SPI_CMD_WREN, NULL);
+    spi_transfer_byte(spi_dev->spi, NVRAM_SPI_CMD_WREN);
     if (status < 0)
     {
         return status;
@@ -222,20 +222,12 @@ static int nvram_spi_write_9bit_addr(nvram_t *dev, uint8_t *src, uint32_t dst, s
     spi_acquire(spi_dev->spi);
     gpio_clear(spi_dev->cs);
     /* Enable writes */
-    status = spi_transfer_byte(spi_dev->spi, NVRAM_SPI_CMD_WREN, NULL);
-    if (status < 0)
-    {
-        return status;
-    }
+    spi_transfer_byte(spi_dev->spi, NVRAM_SPI_CMD_WREN);
     gpio_set(spi_dev->cs);
     hwtimer_spin(NVRAM_SPI_CS_TOGGLE_TICKS);
     gpio_clear(spi_dev->cs);
     /* Write command and address */
-    status = spi_transfer_reg(spi_dev->spi, cmd, addr, NULL);
-    if (status < 0)
-    {
-        return status;
-    }
+    spi_transfer_reg(spi_dev->spi, cmd, addr);
     /* Keep holding CS and write data */
     status = spi_transfer_bytes(spi_dev->spi, (char *)src, NULL, len);
     if (status < 0)
@@ -265,11 +257,7 @@ static int nvram_spi_read_9bit_addr(nvram_t *dev, uint8_t *dst, uint32_t src, si
     spi_acquire(spi_dev->spi);
     gpio_clear(spi_dev->cs);
     /* Write command and address */
-    status = spi_transfer_reg(spi_dev->spi, (char)cmd, addr, NULL);
-    if (status < 0)
-    {
-        return status;
-    }
+    spi_transfer_reg(spi_dev->spi, (char)cmd, addr);
     /* Keep holding CS and read data */
     status = spi_transfer_bytes(spi_dev->spi, NULL, (char *)dst, len);
     if (status < 0)

--- a/drivers/pcd8544/pcd8544.c
+++ b/drivers/pcd8544/pcd8544.c
@@ -204,7 +204,7 @@ static void _write(pcd8544_t *dev, uint8_t is_data, char data)
     /* write byte to LCD */
     spi_acquire(dev->spi);
     gpio_clear(dev->cs);
-    spi_transfer_byte(dev->spi, data, 0);
+    spi_transfer_byte(dev->spi, data);
     gpio_set(dev->cs);
     spi_release(dev->spi);
 }

--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -228,7 +228,6 @@ int cmd_init_slave(int argc, char **argv)
 
 int cmd_transfer(int argc, char **argv)
 {
-    int res;
     char *hello = "Hello";
 
     if (spi_master != 1) {
@@ -246,21 +245,14 @@ int cmd_transfer(int argc, char **argv)
     /* do the actual data transfer */
     spi_acquire(spi_dev);
     gpio_clear(spi_cs);
-    res = spi_transfer_bytes(spi_dev, hello, buffer, strlen(hello));
+    spi_transfer_bytes(spi_dev, hello, buffer, strlen(hello));
     gpio_set(spi_cs);
     spi_release(spi_dev);
 
-    /* look at the results */
-    if (res < 0) {
-        printf("error: unable to transfer data to slave (code: %i)\n", res);
-        return 1;
-    }
-    else {
-        printf("Transfered %i bytes:\n", res);
-        print_bytes("MOSI", hello, res);
-        print_bytes("MISO", buffer, res);
-        return 0;
-    }
+    printf("Transfered %i bytes:\n", strlen(hello));
+    print_bytes("MOSI", hello, strlen(hello));
+    print_bytes("MISO", buffer, strlen(hello));
+    return 0;
 }
 
 int cmd_print(int argc, char **argv)

--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -37,8 +37,8 @@ enum {
     INIT
 } rw;
 
-static int spi_dev = -1;
-static gpio_t spi_cs = -1;
+static int spi_dev = SPI_UNDEF;
+static spi_cs_t spi_cs = SPI_CS_UNDEF;
 static int spi_mode = -1;
 static int spi_speed = -1;
 static int spi_master = -1;     /* 0 for slave, 1 for master, -1 for not initialized */
@@ -244,9 +244,7 @@ int cmd_transfer(int argc, char **argv)
 
     /* do the actual data transfer */
     spi_acquire(spi_dev);
-    gpio_clear(spi_cs);
-    spi_transfer_bytes(spi_dev, hello, buffer, strlen(hello));
-    gpio_set(spi_cs);
+    spi_transfer_bytes(spi_dev, spi_cs, false, hello, buffer, strlen(hello));
     spi_release(spi_dev);
 
     printf("Transfered %i bytes:\n", strlen(hello));

--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014-2015 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -31,248 +31,316 @@
 
 #define SHELL_BUFSIZE       (128U)
 
-enum {
-    READ = 0,
-    WRITE,
-    INIT
-} rw;
+#define SPI_BUFSIZE         (512U)
 
-static int spi_dev = SPI_UNDEF;
-static spi_cs_t spi_cs = SPI_CS_UNDEF;
-static int spi_mode = -1;
-static int spi_speed = -1;
-static int spi_master = -1;     /* 0 for slave, 1 for master, -1 for not initialized */
+/**
+ * @brief   Shared SPI data buffer for SPI master devices
+ */
+static uint8_t buf[SPI_BUFSIZE];
 
-static char buffer[256];       /* temporary buffer */
-static char rx_buffer[256];    /* global receive buffer */
-static int rx_counter = 0;
+/**
+ * @brief   Save the number of received bytes in slave mode
+ */
+static size_t slave_cnt[SPI_NUMOF];
 
-static volatile int state;
-static char* mem = "Hello Master! abcdefghijklmnopqrstuvwxyz 0123456789 "
-                   "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+/**
+ * @brief   Receive buffer in slave mode
+ */
+static uint8_t slave_buf[SPI_NUMOF][SPI_BUFSIZE];
 
-int parse_spi_dev(int argc, char **argv)
+void dump_hex(uint8_t *data, size_t len)
 {
-    /* reset default values */
-    int port, pin;
-    spi_dev = SPI_0;
-    spi_mode = SPI_CONF_FIRST_RISING;
-    spi_speed = SPI_SPEED_1MHZ;
-
-    if (argc < 4) {
-        printf("usage: %s <dev> <cs port> <cs pin> [mode [speed]]\n", argv[0]);
-        puts("        DEV is the SPI device to use:");
-        for (int i = 0; i < SPI_NUMOF; i++) {
-            printf("             %i - SPI_%i\n", i, i);
-        }
-        puts("        cs port:  port to use as the chip select line");
-        puts("        cs pin:   pin to use on th given port as cs line");
-        puts("        mode: must be one of the following options (* marks "
-                      "default value):");
-        puts("            *0 - POL:0, PHASE:0 - ON FIRST RISING EDGE");
-        puts("             1 - POL:0, PHASE:1 - ON SECOND RISING EDGE");
-        puts("             2 - POL:1, PHASE:0 - ON FIRST FALLING EDGE");
-        puts("             3 - POL:1, PHASE:1 - on second falling edge");
-        puts("        speed: must be one of the following options (only used "
-                      "in master mode):");
-        puts("             0 - 100 KHz");
-        puts("             1 - 400 KHz");
-        puts("            *2 - 1 MHz");
-        puts("             3 - 5 MHz");
-        puts("             4 - 10 MHz\n");
-        return -4;
+    for (int i = 0; i < len; i++) {
+        printf("0x%02x ", data[i]);
     }
-    spi_dev = atoi(argv[1]);
-    if (spi_dev < 0 || spi_dev >= SPI_NUMOF) {
-        puts("error: invalid DEV value given");
-        return -1;
-    }
-    port = atoi(argv[2]);
-    pin = atoi(argv[3]);
-    spi_cs = GPIO(port,pin);
-    if (argc >= 5) {
-        spi_mode = argv[4][0] - '0';
-        if (spi_mode < 0 || spi_mode > 3) {
-            puts("error: invalid MODE value given");
-            return -2;
-        }
-    }
-    if (argc >= 6) {
-        spi_speed = argv[5][0] - '0';
-        if (spi_speed < 0 || spi_speed > 4) {
-            puts("error: invalid SPEED value given");
-            return -3;
-        }
-    }
-    return 0;
-}
-
-void print_bytes(char* title, char* chars, int length)
-{
-    printf("%4s", title);
-    for (int i = 0; i < length; i++) {
-        printf("  %2i ", i);
-    }
-    printf("\n    ");
-    for (int i = 0; i < length; i++) {
-        printf(" 0x%02x", (int)chars[i]);
-    }
-    printf("\n    ");
-    for (int i = 0; i < length; i++) {
-        if (chars[i] < ' ' || chars[i] > '~') {
-            printf("  ?? ");
+    puts("");
+    for (int i = 0; i < len; i++) {
+        if (data[i] > ' ' && data[i] <= '~') {
+            printf("  %c  ", (char)data[i]);
         }
         else {
-            printf("   %c ", chars[i]);
+            printf(" --  ");
         }
     }
-    printf("\n\n");
+    puts("");
 }
 
-void slave_on_cs(void *arg)
+/**
+ * @brief   Function called on connection state change in slave mode
+ */
+static uint8_t slave_cs_cb(void *arg, bool start)
 {
-    (void)arg;
-
-    LED_RED_ON;
-    spi_transmission_begin(spi_dev, 'F');
-    state = 0;
-    rw = INIT;
-    LED_RED_OFF;
+    int dev = (int)arg;
+    if (start) {
+        slave_cnt[dev] = 1;
+    }
+    else {
+        puts("RX:");
+        dump_hex(slave_buf[dev], slave_cnt[dev]);
+    }
+    return 1;
 }
 
-char slave_on_data(char data)
+/**
+ * @brief   Function called on byte transferred in slave mode
+ */
+static uint8_t slave_data_cb(void *arg, uint8_t data)
 {
-    rx_buffer[rx_counter] = data;
-    rx_counter++;
-    if (rx_counter >= 256) {
-        rx_counter = 0;
+    int dev = (int)arg;
+    slave_buf[dev][slave_cnt[dev] - 1] = data;
+    return (uint8_t)(slave_cnt[dev]++);
+}
+
+static void print_modes(void)
+{
+    puts("\tconf:");
+    printf("\t%i - POL:0, PHASE:0 - data on first rising edge\n",
+           SPI_CONF_FIRST_RISING);
+    printf("\t%i - POL:0, PHASE:1 - data on second rising edge\n",
+           SPI_CONF_SECOND_RISING);
+    printf("\t%i - POL:1, PHASE:0 - data on fist falling edge\n",
+           SPI_CONF_FIRST_FALLING);
+    printf("\t%i - POL:1, PHASE:1 - data on second falling edge\n",
+           SPI_CONF_SECOND_FALLING);
+}
+
+static void print_speeds(void)
+{
+    puts("\tspeed:");
+    printf("\t%i - ~100KHz\n", SPI_SPEED_100KHZ);
+    printf("\t%i - ~400KHz\n", SPI_SPEED_400KHZ);
+    printf("\t%i - ~1MHz\n", SPI_SPEED_1MHZ);
+    printf("\t%i - ~5MHz\n", SPI_SPEED_5MHZ);
+    printf("\t%i - ~10MHz\n", SPI_SPEED_10MHZ);
+}
+
+static void print_pol(void)
+{
+    puts("\tCS polarity:");
+    printf("\t%i - low active\n", SPI_CS_POL_LOW_ACTIVE);
+    printf("\t%i - high active\n", SPI_CS_POL_HIGH_ACTIVE);
+}
+
+static int parse_dev(const char *str)
+{
+    int res = atoi(str);
+    if (res >= SPI_NUMOF) {
+        puts("error: unable to parse device");
+        return -1;
+    }
+    return res;
+}
+
+static spi_cs_t parse_cs(const char *port_str, const char *pin_str)
+{
+    int pin = atoi(pin_str);
+    int port = atoi(port_str);
+
+    if (pin < 0 || port < 0) {
+        return SPI_CS_UNDEF;
     }
 
-    switch (rw) {
-        case READ:
-            return mem[state++];
-        case WRITE:
-            mem[state++] = data;
-            return 'o';
-        case INIT:
-            if (data == ' ') {
-                rw = READ;
-                return mem[state++];
-            } else if (data & 0x80) {
-                rw = WRITE;
-                state = (data & 0x7f);
-                return 'W';
-            } else {
-                rw = READ;
-                state = data;
-                return mem[state++];
+    if (port_str[0] == 'h') {
+        return SPI_CS_DEV(pin);
+    }
+    else {
+        return (spi_cs_t)GPIO(port, pin);
+    }
+}
+
+static int parse_speed(const char *str)
+{
+    int speed = atoi(str);
+    if (speed == SPI_SPEED_100KHZ || speed == SPI_SPEED_400KHZ ||
+        speed == SPI_SPEED_1MHZ || speed == SPI_SPEED_5MHZ ||
+        speed == SPI_SPEED_10MHZ) {
+        return speed;
+    }
+    puts("error: unable to parse speed value");
+    return -1;
+}
+
+static int parse_conf(const char *str)
+{
+    int conf = atoi(str);
+    if (conf == SPI_CONF_FIRST_RISING || conf == SPI_CONF_SECOND_RISING ||
+        conf == SPI_CONF_FIRST_FALLING || conf == SPI_CONF_SECOND_FALLING) {
+        return conf;
+    }
+    puts("error: unable to parse conf value");
+    return -1;
+}
+
+static int parse_pol(const char *str)
+{
+    int pol = atoi(str);
+    if (pol == SPI_CS_POL_LOW_ACTIVE || pol == SPI_CS_POL_HIGH_ACTIVE) {
+        return pol;
+    }
+    puts("error: unable to parse CS polarity");
+    return -1;
+}
+
+static int send(int argc, char **argv, bool ascii)
+{
+    int dev;
+    spi_cs_t cs;
+    size_t len = 0;
+    bool cont = false;
+
+    if (argc < 5) {
+        printf("usage: %s <dev> <port> <pin> <data> [c]\n", argv[0]);
+        puts("\tdev: SPI device to use");
+        puts("\tport: Port of CS pin, 'h' for HW chip select");
+        puts("\tpin: PIN to use for CS or number of HW CS line");
+        if (ascii) {
+            puts("\tdata: ASCII string of data to send");
+        }
+        else {
+            puts("\tdata: RAW data in hex format, byte wise 0xYY 0xZZ...");
+        }
+        puts("\tc: if c is given, the transfer will not be terminated");
+    }
+
+    /* parse device and chip select pin */
+    dev = parse_dev(argv[1]);
+    cs = parse_cs(argv[2], argv[3]);
+    if (dev < 0 || cs == SPI_CS_UNDEF) {
+        return 1;
+    }
+
+    /* parse data */
+    if (ascii) {
+        strcpy((char *)buf, argv[4]);
+        if (argc >= 5 && argv[5][0] == 'c') {
+            cont = true;
+        }
+    }
+    else {
+        for (int i = 2; i < argc; i++) {
+            if (argv[i][0] == 'c') {
+                cont = true;
+                break;
             }
+            else {
+                buf[len++] = (uint8_t)strtol(argv[i], NULL, 0);
+            }
+        }
     }
-    return 'e';
+
+    /* transfer data */
+    puts("TX:");
+    dump_hex(buf, len);
+    if (len) {
+        spi_acquire(SPI_DEV(dev));
+        spi_transfer_bytes(SPI_DEV(dev), cs, cont, buf, buf, len);
+        spi_release(SPI_DEV(dev));
+    }
+    puts("RX:");
+    dump_hex(buf, len);
+
+    return 0;
 }
 
 int cmd_init_master(int argc, char **argv)
 {
-    int res;
-    spi_master = -1;
-    if (parse_spi_dev(argc, argv) < 0) {
+    int dev, speed, conf, res;
+
+    if (argc < 4) {
+        printf("usage: %s <dev> <conf> <speed>\n", argv[0]);
+        puts("\tdev: SPI device to use");
+        print_modes();
+        print_speeds();
+    }
+
+    /* parse params */
+    dev = parse_dev(argv[1]);
+    speed = parse_speed(argv[2]);
+    conf = parse_conf(argv[3]);
+    if (dev < 0 || speed < 0 || conf < 0) {
         return 1;
     }
-    spi_acquire(spi_dev);
-    res = spi_init_master(spi_dev, spi_mode, spi_speed);
-    spi_release(spi_dev);
-    if (res < 0) {
-        printf("spi_init_master: error initializing SPI_%i device (code %i)\n",
-                spi_dev, res);
+
+    /* initialize device. As this is a manual application, we get away without
+     * locking the bus first... */
+    res = spi_init_master(SPI_DEV(dev), conf, speed);
+    if (res == -1) {
+        puts("error in spi_init_master(): given device invalid");
         return 1;
     }
-    res = gpio_init(spi_cs, GPIO_DIR_OUT, GPIO_PULLUP);
-    if (res < 0){
-        printf("gpio_init: error initializing GPIO_%ld as CS line (code %i)\n",
-                (long)spi_cs, res);
+    if (res == -2) {
+        puts("error in spi_init_master(): given speed no supported");
         return 1;
     }
-    gpio_set(spi_cs);
-    spi_master = 1;
-    printf("SPI_%i successfully initialized as master, cs: GPIO_%ld, mode: %i, speed: %i\n",
-            spi_dev, (long)spi_cs, spi_mode, spi_speed);
+    if (res == -3) {
+        puts("error in spi_init_master(): configuration not supported");
+        return 1;
+    }
+    if (res < -3) {
+        puts("error in spi_init_master(): unspecified error");
+        return 1;
+    }
+    printf("SPI_DEV(%i) successfully initialized as master\n", dev);
     return 0;
 }
 
 int cmd_init_slave(int argc, char **argv)
 {
-    int res;
-    spi_master = -1;
-    if (parse_spi_dev(argc, argv) < 0) {
+    int dev, conf, pol, res;
+    spi_cs_t cs;
+
+    if (argc < 6) {
+        printf("usage: %s <dev> <conf> <port> <pin> <pol>\n", argv[0]);
+        puts("\tdev: SPI device to use");
+        puts("\tport: Port of CS pin, H for HW chip select");
+        puts("\tpin: PIN to use for CS or number of HW CS line");
+        print_modes();
+        print_pol();
+    }
+
+    /* parse parameters */
+    dev = parse_dev(argv[1]);
+    conf = parse_conf(argv[2]);
+    cs = parse_cs(argv[3], argv[4]);
+    pol = parse_pol(argv[5]);
+    if (dev < 0 || conf < 0 || pol < 0 || cs == SPI_CS_UNDEF) {
         return 1;
     }
-    spi_acquire(spi_dev);
-    res = spi_init_slave(spi_dev, spi_mode, slave_on_data);
-    spi_release(spi_dev);
-    if (res < 0) {
-        printf("spi_init_slave: error initializing SPI_%i device (code: %i)\n",
-                spi_dev, res);
+
+    /* initialize device as SPI slave */
+    res = spi_init_slave(SPI_DEV(dev), cs, pol, conf,
+                         slave_cs_cb, slave_data_cb, (void *)dev);
+    if (res == -1) {
+        puts("error in spi_init_slave(): given device invalid");
         return 1;
     }
-    res = gpio_init_int(spi_cs, GPIO_NOPULL, GPIO_FALLING, slave_on_cs, 0);
-    if (res < 0){
-        printf("gpio_init_int: error initializing GPIO_%ld as CS line (code %i)\n",
-                (long)spi_cs, res);
+    if (res == -2) {
+        puts("error in spi_init_slave(): slave mode not supported by device");
         return 1;
     }
-    spi_master = 0;
-    printf("SPI_%i successfully initialized as slave, cs: GPIO_%ld, mode: %i\n",
-            spi_dev, (long)spi_cs, spi_mode);
+    if (res < -2) {
+        puts("error in spi_init_slave(): unspecified error");
+        return 1;
+    }
+    printf("SPI_DEV(%i) successfully initialized as SPI slave\n", dev);
     return 0;
 }
 
-int cmd_transfer(int argc, char **argv)
+int cmd_ascii(int argc, char **argv)
 {
-    char *hello = "Hello";
-
-    if (spi_master != 1) {
-        puts("error: node is not initialized as master, please do so first");
-        return 1;
-    }
-
-    if (argc < 2) {
-        puts("No data to transfer given, will transfer 'Hello' to device");
-    }
-    else {
-        hello = argv[1];
-    }
-
-    /* do the actual data transfer */
-    spi_acquire(spi_dev);
-    spi_transfer_bytes(spi_dev, spi_cs, false, hello, buffer, strlen(hello));
-    spi_release(spi_dev);
-
-    printf("Transfered %i bytes:\n", strlen(hello));
-    print_bytes("MOSI", hello, strlen(hello));
-    print_bytes("MISO", buffer, strlen(hello));
-    return 0;
+    return send(argc, argv, true);
 }
 
-int cmd_print(int argc, char **argv)
+int cmd_raw(int argc, char **argv)
 {
-    if (spi_master != 0) {
-        puts("error: node is not initialized as slave");
-        return 1;
-    }
-    else {
-        printf("Received %i bytes:\n", rx_counter);
-        print_bytes("MOSI", rx_buffer, rx_counter);
-    }
-    rx_counter = 0;
-    memset(&rx_buffer, 0, 256);
-    return 0;
+    return send(argc, argv, false);
 }
 
 static const shell_command_t shell_commands[] = {
-    { "init_master", "Initialize node as SPI master", cmd_init_master },
-    { "init_slave", "Initialize node as SPI slave", cmd_init_slave },
-    { "send", "Transfer string to slave (only in master mode)", cmd_transfer },
-    { "print_rx", "Print the received string (only in slave mode)", cmd_print },
+    { "init_master", "initialize SPI device in master mode", cmd_init_master },
+    { "init_slave", "initialize SPI device in slave mode", cmd_init_slave },
+    { "send", "transfer string to slave (only in master mode)", cmd_ascii },
+    { "send_hex", "transfer hex encoded bytes(master mode only)", cmd_raw },
     { NULL, NULL, NULL }
 };
 
@@ -280,9 +348,15 @@ int main(void)
 {
     shell_t shell;
 
-    puts("\nRIOT low-level SPI driver test");
-    puts("This application enables you to test a platforms SPI driver implementation.");
-    puts("Enter 'help' to get started\n");
+    puts("\nManual SPI peripheral driver test application");
+    puts("=============================================");
+    puts("With this application it is possible to test all SPI devices that\n"
+         "may be defined for a platform. You can configure available devices\n"
+         "as master or slave, using the provided shell commands.\n\n"
+         "When configured as master, you can test your SPI device by sending\n"
+         "ASCII strings or by sending hex encoded binary data\n\n"
+         "When configured as slave, the device will simply answer with\n"
+         "counting numbers for each byte transferred, starting with 0x01\n");
 
     /* run the shell */
     shell_init(&shell, shell_commands, SHELL_BUFSIZE, getchar, putchar);


### PR DESCRIPTION
- made datastructures overridable by CPU implementations
- made some functions void
- updated doxygen
- adapted SPI test
- adapted SPI implementations
- fixed some bugs in spi transfer functions

The main idea behind this API change is to adapt it to a slightly changed paradigm regarding error handling: The concept is to throw errors on initialization, but to not check all parameters everytime afterwards anymore. This leads to more compact and efficient code while not taking much away in terms of error checking.

On top of this, most implementations are implemented in a way, that there return values were quite useless anyway...

This PR is just the first step in 'modernizing' the existing SPI implementations... 

NOTE: This needs some testing on all affected platforms once we agree on the changes...

