### PR TITLE
sys: net: ng_pktdump: add missing errno.h

### DIFF
--- a/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
+++ b/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
@@ -21,6 +21,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#include <errno.h>
 #include "byteorder.h"
 #include "thread.h"
 #include "msg.h"


### PR DESCRIPTION
file misses "ENOTSUP" otherwise