### PR TITLE
sys/newlib: use reboot() instead of NVIC_SystemReset()

### DIFF
--- a/sys/newlib/syscalls.c
+++ b/sys/newlib/syscalls.c
@@ -107,7 +107,7 @@ void _fini(void)
 void _exit(int n)
 {
     printf("#! exit %i: resetting\n", n);
-    NVIC_SystemReset();
+    reboot(RB_AUTOBOOT);
     while(1);
 }
 


### PR DESCRIPTION
Using `NVIC_SystemReset()` in `_exit()` limits the usage to (arm?) boards with an NVI Controller only. This PR replaces this with the architecture-agnostic `reboot()` function defined in `kernel.h`.