### PR TITLE
Adding a new Device Unique IDentifier feature to RIOT OS

### DIFF
--- a/cpu/stm32f1/dev_uid_stm32f10x.c
+++ b/cpu/stm32f1/dev_uid_stm32f10x.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2015 INRIA
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_stm32f1
+ * @{
+ *
+ * @file        dev_uid_stm32f10x.c
+ * @brief       Implementation of the unique device ID feature
+ *              for STM32F10x MCUs.
+ *
+ * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "dev_uid.h"
+
+
+/* STM32F10x MCUs offer a 12-byte (96-bit) Unique IDentifier
+   (stored in read-only, special-purpose MCU registers) */
+
+/* Fixed address for UID registers in STM32F10x microcontrollers. */
+#define UNIQUE_DEV_ID_REG_BASE  (0x1FFFF7E8)
+
+
+/* Define the pointer to this device's UID */
+const dev_uid_t const * dev_uid
+     = (const dev_uid_t * const) UNIQUE_DEV_ID_REG_BASE;
+
+/* Print function for device UIDs */
+void print_dev_uid(const dev_uid_t const * uid)
+{
+    /* STM32F1xx UIDs are on 12 bytes */
+    printf("Device UID: Ox");
+    for (int i = 0; i < 12; i++) {
+        printf(" %2.2x", uid->byte[i]);
+    }
+    printf("\n");
+}
+
+/* "Digest" device ID, as computed by HiKoB for IoT-LAB M3 motes
+ *  in their OpenLAB framework. */
+uint16_t get_short_dev_id(void)
+{
+    uint16_t res = dev_uid->byte[10];
+    res <<= 7;
+    res  |= dev_uid->byte[8];
+    res <<= 8;
+    res  |= dev_uid->byte[9];
+    return res;
+}
+

--- a/cpu/stm32f1/include/dev_uid_cpu.h
+++ b/cpu/stm32f1/include/dev_uid_cpu.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup         cpu_stm32f1
+ * @{
+ *
+ * @file            dev_uid_cpu.h
+ * @brief           CPU specific Unique device ID provider declarations
+ *
+ * @author          Kévin Roussel <Kevin.Roussel@inria.fr>
+ */
+
+/* STM32F10x MCUs offer a 12-byte (96-bit) Unique IDentifier
+   (stored in read-only, special-purpose MCU registers) */
+#define DEV_UID_SIZE 12
+
+

--- a/sys/include/dev_uid.h
+++ b/sys/include/dev_uid.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2015  INRIA.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @file    dev_uid.h
+ * @brief   Definitions for providing unique device ID.
+ *
+ * @author  Kévin Roussel <Kevin.Roussel@inria.fr>
+ */
+
+#ifndef DEV_UID_H
+#define DEV_UID_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+#include "dev_uid_cpu.h"
+
+
+/** Type definition for a device unique ID */
+typedef struct {
+    uint8_t byte[DEV_UID_SIZE];   // DEV_UID_SIZE defined per-cpu
+} dev_uid_t;
+
+
+/** Constant pointer to the device's unique, immutable, long ID. */
+extern const dev_uid_t const * dev_uid;
+
+/**
+ * Utility function to pretty-print the given device UID
+ * (using stdio's standard @c printf() function).
+ * 
+ * @param[in]  uid  Device Unique ID to print.
+ */
+void print_dev_uid(const dev_uid_t const * uid);
+
+/**
+ * @return A short device ID, computed from the device unique ID @c dev_uid.
+ */
+uint16_t get_short_dev_id(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEV_UID_H */
+


### PR DESCRIPTION
A proposal for having a simple feature for getting a unique ID for devices on which RIOT is running.

The idea is to give access to any related feature (i.e.: serial number, keys, unique ID, etc.) of the underlying material, as well as providing a shorter, fixed-size number --- I propose here a 16-bit unsigned integer --- easily usable for most basic purposes like: seeds for random number generators (cf. for example #3221), or in-PAN addresses for 802.15.4 radio transceivers.

A working implementation for STM32F10x MCU is provided, that I am currently using for tests on IoT-LAB M3 nodes.