### PR TITLE
core/priority_queue: cast of root to priority_queue_node_t* is wrong

### DIFF
--- a/core/priority_queue.c
+++ b/core/priority_queue.c
@@ -51,8 +51,12 @@ priority_queue_node_t *priority_queue_remove_head(priority_queue_t *root)
 
 void priority_queue_add(priority_queue_t *root, priority_queue_node_t *new_obj)
 {
-    /* The strict aliasing rules allow this assignment. */
-    priority_queue_node_t *node = (priority_queue_node_t *) root;
+    priority_queue_node_t *node = root->first;
+
+    if (node == NULL) {
+        root->first = node;
+        return;
+    }
 
     while (node->next != NULL) {
         if (node->next->priority > new_obj->priority) {


### PR DESCRIPTION
Casting `root`, which is of type `priority_queue_t`, to `priority_queue_node_t` is wrong. `root->first` should be used for this cast.

This may be the source of the dangling pointers we experience with `ng_ndp`.