### PR TITLE
cpu/stm32f3: Add missing closing Doxygen braces for addtogroup

### DIFF
--- a/cpu/stm32f3/include/stm32f303xc.h
+++ b/cpu/stm32f3/include/stm32f303xc.h
@@ -6987,4 +6987,8 @@ typedef struct
   * @}
   */
 
+/**
+  * @}
+  */
+
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/cpu/stm32f3/include/stm32f303xe.h
+++ b/cpu/stm32f3/include/stm32f303xe.h
@@ -8208,4 +8208,8 @@ typedef struct
   * @}
   */
 
+/**
+  * @}
+  */
+
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE*****/

--- a/cpu/stm32f3/include/stm32f334x8.h
+++ b/cpu/stm32f3/include/stm32f334x8.h
@@ -7600,4 +7600,8 @@ typedef struct
  * @}
  */
 
+/**
+ * @}
+ */
+
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
The candidates locations for the closing braces were confirmed by looking at
cpu/stm32f0 headers.

The closing brace styles stick with the style of each file.

Closes #2956