### PR TITLE
net/ng_udp: mark received payload as NETTYPE_UNDEF

### DIFF
--- a/sys/net/transport_layer/ng_udp/ng_udp.c
+++ b/sys/net/transport_layer/ng_udp/ng_udp.c
@@ -114,6 +114,9 @@ static void _receive(ng_pktsnip_t *pkt)
         ng_pktbuf_release(pkt);
         return;
     }
+    /* mark payload as Type: UNDEF */
+    pkt->type = NG_NETTYPE_UNDEF;
+    /* get explicit pointer to UDP header */
     hdr = (ng_udp_hdr_t *)udp->data;
 
     LL_SEARCH_SCALAR(pkt, ipv6, type, NG_NETTYPE_IPV6);


### PR DESCRIPTION
When receiving UDP packets, the payload is still marked as `NG_NETTYPE_UDP` after the header was separated. This leads to `pktdump` trying to parse the output of the UDP payload as UDP header, ending up in outputting useless stuff (or worse). This PR should fix this.