### PR TITLE
fib: repaired prefix/default gateway handling and added two according unittests

### DIFF
--- a/sys/net/network_layer/fib/universal_address.c
+++ b/sys/net/network_layer/fib/universal_address.c
@@ -182,7 +182,7 @@ int universal_address_compare(universal_address_container_t *entry,
 
     /* Get the index of the first trailing `0` (indicates a prefix) */
     int i = 0;
-    for( i = entry->address_size-1; i >= 0; --i) {
+    for( i = entry->address_size-1; i > 0; --i) {
         if( entry->address[i] != 0 ) {
             break;
         }
@@ -201,7 +201,7 @@ int universal_address_compare(universal_address_container_t *entry,
         }
         if( (entry->address[i] & bitmask) == (addr[i] & bitmask) ) {
             ret = entry->address[i] != addr[i];
-            *addr_size_in_bits = (i<<3) + j;
+            *addr_size_in_bits = (i<<3) + (8-j);
             if( ret == 0 ) {
                 /* check if the remaining bits from addr are significant */
                 i++;


### PR DESCRIPTION
Adding default gateway address has not been properly handled by the FIB, i.e. the size calculation was broken.

This PR fixes it and adds 2 unittests:
1. testing if the default gateway next-hop address can be changed properly
2. testing if adding removing a prefix works properly