### PR TITLE
ng_pktqueue: remove priority queue dependency

### DIFF
--- a/sys/include/net/ng_ipv6/nc.h
+++ b/sys/include/net/ng_ipv6/nc.h
@@ -118,7 +118,7 @@ extern "C" {
  *          </a>.
  */
 typedef struct {
-    ng_pktqueue_t pkts;                     /**< Packets waiting for address resolution */
+    ng_pktqueue_t *pkts;                    /**< Packets waiting for address resolution */
     ng_ipv6_addr_t ipv6_addr;               /**< IPv6 address of the neighbor */
     uint8_t l2_addr[NG_IPV6_NC_L2_ADDR_MAX];/**< Link layer address of the neighbor */
     uint8_t l2_addr_len;                    /**< Length of ng_ipv6_nc_t::l2_addr */

--- a/sys/net/network_layer/ng_ndp/ng_ndp.c
+++ b/sys/net/network_layer/ng_ndp/ng_ndp.c
@@ -805,7 +805,7 @@ ng_pktsnip_t *ng_ndp_opt_tl2a_build(const uint8_t *l2addr, uint8_t l2addr_len,
 /* packet queue node allocation */
 static ng_pktqueue_t *_alloc_pkt_node(ng_pktsnip_t *pkt)
 {
-    for (size_t i = 0; i < sizeof(_pkt_nodes); i++) {
+    for (size_t i = 0; i < sizeof(_pkt_nodes) / sizeof(ng_pktqueue_t); i++) {
         if ((_pkt_nodes[i].pkt == NULL) && (_pkt_nodes[i].next == NULL)) {
             _pkt_nodes[i].pkt = pkt;
 

--- a/sys/net/network_layer/ng_ndp/ng_ndp.c
+++ b/sys/net/network_layer/ng_ndp/ng_ndp.c
@@ -38,7 +38,7 @@
 static char addr_str[NG_IPV6_ADDR_MAX_STR_LEN];
 #endif
 
-static ng_pktqueue_node_t _pkt_nodes[NG_IPV6_NC_SIZE * 2];
+static ng_pktqueue_t _pkt_nodes[NG_IPV6_NC_SIZE * 2];
 static ng_ipv6_nc_t *_last_router = NULL;   /* last router chosen as default
                                              * router. Only used if reachability
                                              * is suspect (i. e. incomplete or
@@ -73,7 +73,7 @@ static inline void _send_delayed(vtimer_t *t, timex_t interval, ng_pktsnip_t *pk
 }
 
 /* packet queue node allocation */
-static ng_pktqueue_node_t *_alloc_pkt_node(ng_pktsnip_t *pkt);
+static ng_pktqueue_t *_alloc_pkt_node(ng_pktsnip_t *pkt);
 
 void ng_ndp_nbr_sol_handle(kernel_pid_t iface, ng_pktsnip_t *pkt,
                            ng_ipv6_hdr_t *ipv6, ng_ndp_nbr_sol_t *nbr_sol,
@@ -197,7 +197,7 @@ void ng_ndp_nbr_adv_handle(kernel_pid_t iface, ng_pktsnip_t *pkt,
     }
 
     if (ng_ipv6_nc_get_state(nc_entry) == NG_IPV6_NC_STATE_INCOMPLETE) {
-        ng_pktqueue_node_t *queued_pkt;
+        ng_pktqueue_t *queued_pkt;
 
         if (_pkt_has_l2addr(netif_hdr) && (l2tgt_len == 0)) {
             /* link-layer has addresses, but no TLLAO supplied: discard silently
@@ -225,8 +225,8 @@ void ng_ndp_nbr_adv_handle(kernel_pid_t iface, ng_pktsnip_t *pkt,
         }
 
         while ((queued_pkt = ng_pktqueue_remove_head(&nc_entry->pkts)) != NULL) {
-            ng_netapi_send(ng_ipv6_pid, queued_pkt->data);
-            queued_pkt->data = NULL;
+            ng_netapi_send(ng_ipv6_pid, queued_pkt->pkt);
+            queued_pkt->pkt = NULL;
         }
     }
     else {
@@ -326,24 +326,11 @@ void ng_ndp_retrans_nbr_sol(ng_ipv6_nc_t *nc_entry)
         }
     }
     else if (nc_entry->probes_remaining <= 1) {
-        ng_pktqueue_node_t *queue_node;
-
-        /* No need to call ng_ipv6_nc_remove() we know already were the
-         * entry is */
-
         DEBUG("ndp: Remove nc entry %s for interface %" PRIkernel_pid "\n",
               ng_ipv6_addr_to_str(addr_str, &nc_entry->ipv6_addr, sizeof(addr_str)),
               nc_entry->iface);
 
-        while ((queue_node = ng_pktqueue_remove_head(&nc_entry->pkts))) {
-            ng_pktbuf_release(queue_node->data);
-            queue_node->data = NULL;
-        }
-
-        ng_ipv6_addr_set_unspecified(&(nc_entry->ipv6_addr));
-        nc_entry->iface = KERNEL_PID_UNDEF;
-        nc_entry->flags = 0;
-        nc_entry->probes_remaining = 0;
+        ng_ipv6_nc_remove(nc_entry->iface, &nc_entry->ipv6_addr);
     }
 }
 
@@ -474,7 +461,7 @@ kernel_pid_t ng_ndp_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
             return nc_entry->iface;
         }
         else if (nc_entry == NULL) {
-            ng_pktqueue_node_t *pkt_node;
+            ng_pktqueue_t *pkt_node;
             ng_ipv6_addr_t dst_sol;
 
             nc_entry = ng_ipv6_nc_add(iface, next_hop_ip, NULL, 0,
@@ -492,7 +479,7 @@ kernel_pid_t ng_ndp_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
             }
             else {
                 /* prevent packet from being released by IPv6 */
-                ng_pktbuf_hold(pkt_node->data, 1);
+                ng_pktbuf_hold(pkt_node->pkt, 1);
                 ng_pktqueue_add(&nc_entry->pkts, pkt_node);
             }
 
@@ -816,12 +803,11 @@ ng_pktsnip_t *ng_ndp_opt_tl2a_build(const uint8_t *l2addr, uint8_t l2addr_len,
 
 /* internal functions */
 /* packet queue node allocation */
-static ng_pktqueue_node_t *_alloc_pkt_node(ng_pktsnip_t *pkt)
+static ng_pktqueue_t *_alloc_pkt_node(ng_pktsnip_t *pkt)
 {
     for (size_t i = 0; i < sizeof(_pkt_nodes); i++) {
-        if (_pkt_nodes[i].data == NULL) {
-            ng_pktqueue_node_init(_pkt_nodes + i);
-            _pkt_nodes[i].data = pkt;
+        if ((_pkt_nodes[i].pkt == NULL) && (_pkt_nodes[i].next == NULL)) {
+            _pkt_nodes[i].pkt = pkt;
 
             return &(_pkt_nodes[i]);
         }

--- a/tests/unittests/tests-pktqueue/tests-pktqueue.c
+++ b/tests/unittests/tests-pktqueue/tests-pktqueue.c
@@ -18,142 +18,149 @@
 #include "net/ng_pkt.h"
 #include "net/ng_pktqueue.h"
 
+#include "unittests-constants.h"
 #include "tests-pktqueue.h"
 
-#define Q_LEN (4)
+#define PKT_INIT_ELEM(len, data, next) \
+    { 1, (next), (data), (len), NG_NETTYPE_UNDEF }
+#define PKT_INIT_ELEM_STATIC_DATA(data, next) PKT_INIT_ELEM(sizeof(data), data, next)
+#define PKTQUEUE_INIT_ELEM(pkt) { NULL, pkt }
 
-static ng_pktqueue_t q = NG_PKTQUEUE_INIT;
-static ng_pktqueue_node_t qe[Q_LEN];
+static ng_pktqueue_t *root;
 
 static void set_up(void)
 {
-    ng_pktqueue_init(&q);
-
-    for (unsigned i = 0; i < Q_LEN; ++i) {
-        ng_pktqueue_node_init(&(qe[i]));
-    }
-}
-
-static void test_pktqueue_remove_head_empty(void)
-{
-    ng_pktqueue_t *root = &q;
-    ng_pktqueue_node_t *res;
-
-    res = ng_pktqueue_remove_head(root);
-
-    TEST_ASSERT_NULL(res);
-}
-
-static void test_pktqueue_remove_head_one(void)
-{
-    ng_pktqueue_t *root = &q;
-    ng_pktqueue_node_t *elem = &(qe[1]), *res;
-
-    elem->data = (ng_pktsnip_t *)62801;
-
-    ng_pktqueue_add(root, elem);
-
-    res = ng_pktqueue_remove_head(root);
-
-    TEST_ASSERT(res == elem);
-    TEST_ASSERT(((ng_pktsnip_t *)62801) == res->data);
-
-    res = ng_pktqueue_remove_head(root);
-
-    TEST_ASSERT_NULL(res);
+    root = NULL;
 }
 
 static void test_pktqueue_add_one(void)
 {
-    ng_pktqueue_t *root = &q;
-    ng_pktqueue_node_t *elem = &(qe[1]);
+    ng_pktsnip_t pkt = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING8, NULL);
+    ng_pktqueue_t elem = PKTQUEUE_INIT_ELEM(&pkt);
 
-    elem->data = (ng_pktsnip_t *)7317;
-    elem->priority = 713643658;
+    ng_pktqueue_add(&root, &elem);
 
-    ng_pktqueue_add(root, elem);
-
-    TEST_ASSERT(root->first == elem);
-    TEST_ASSERT(((ng_pktsnip_t *)7317) == root->first->data);
-    TEST_ASSERT_EQUAL_INT(713643658, root->first->priority);
-
-    TEST_ASSERT_NULL(root->first->next);
+    TEST_ASSERT(root == &elem);
+    TEST_ASSERT_EQUAL_INT(1, root->pkt->users);
+    TEST_ASSERT_NULL(root->pkt->next);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING8, root->pkt->data);
+    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING8), root->pkt->size);
+    TEST_ASSERT_EQUAL_INT(NG_NETTYPE_UNDEF, root->pkt->type);
 }
 
-static void test_pktqueue_add_two_equal(void)
+static void test_pktqueue_add_two(void)
 {
-    ng_pktqueue_t *root = &q;
-    ng_pktqueue_node_t *elem1 = &(qe[1]), *elem2 = &(qe[2]);
+    ng_pktsnip_t pkt1 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING8, NULL);
+    ng_pktsnip_t pkt2 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING16, NULL);
+    ng_pktqueue_t elem1 = PKTQUEUE_INIT_ELEM(&pkt1);
+    ng_pktqueue_t elem2 = PKTQUEUE_INIT_ELEM(&pkt2);
 
-    elem1->data = (ng_pktsnip_t *)27088;
-    elem1->priority = 14202;
+    ng_pktqueue_add(&root, &elem1);
+    ng_pktqueue_add(&root, &elem2);
 
-    elem2->data = (ng_pktsnip_t *)4356;
-    elem2->priority = 14202;
-
-    ng_pktqueue_add(root, elem1);
-    ng_pktqueue_add(root, elem2);
-
-    TEST_ASSERT(root->first == elem1);
-    TEST_ASSERT(((ng_pktsnip_t *)27088) == root->first->data);
-    TEST_ASSERT_EQUAL_INT(14202, root->first->priority);
-
-    TEST_ASSERT(root->first->next == elem2);
-    TEST_ASSERT(((ng_pktsnip_t *)4356) == root->first->next->data);
-    TEST_ASSERT_EQUAL_INT(14202, root->first->next->priority);
-
-    TEST_ASSERT_NULL(root->first->next->next);
+    TEST_ASSERT(root == &elem1);
+    TEST_ASSERT(root->next == &elem2);
+    TEST_ASSERT_EQUAL_INT(1, root->pkt->users);
+    TEST_ASSERT_NULL(root->pkt->next);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING8, root->pkt->data);
+    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING8), root->pkt->size);
+    TEST_ASSERT_EQUAL_INT(NG_NETTYPE_UNDEF, root->pkt->type);
+    TEST_ASSERT_EQUAL_INT(1, root->next->pkt->users);
+    TEST_ASSERT_NULL(root->next->pkt->next);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING16, root->next->pkt->data);
+    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING16), root->next->pkt->size);
+    TEST_ASSERT_EQUAL_INT(NG_NETTYPE_UNDEF, root->next->pkt->type);
 }
 
-static void test_pktqueue_add_two_distinct(void)
+static void test_pktqueue_remove(void)
 {
-    ng_pktqueue_t *root = &q;
-    ng_pktqueue_node_t *elem1 = &(qe[1]), *elem2 = &(qe[2]);
+    ng_pktsnip_t pkt1 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING8, NULL);
+    ng_pktsnip_t pkt2 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING16, NULL);
+    ng_pktqueue_t *res;
+    ng_pktqueue_t elem1 = PKTQUEUE_INIT_ELEM(&pkt1);
+    ng_pktqueue_t elem2 = PKTQUEUE_INIT_ELEM(&pkt2);
 
-    elem1->data = (ng_pktsnip_t *)46421;
-    elem1->priority = 4567;
+    ng_pktqueue_add(&root, &elem1);
+    ng_pktqueue_add(&root, &elem2);
 
-    elem2->data = (ng_pktsnip_t *)43088;
-    elem2->priority = 1234;
+    res = ng_pktqueue_remove(&root, &elem2);
 
-    ng_pktqueue_add(root, elem1);
-    ng_pktqueue_add(root, elem2);
+    TEST_ASSERT(res == &elem2);
+    TEST_ASSERT(root == &elem1);
+    TEST_ASSERT_EQUAL_INT(1, res->pkt->users);
+    TEST_ASSERT_NULL(res->pkt->next);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING16, res->pkt->data);
+    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING16), res->pkt->size);
+    TEST_ASSERT_EQUAL_INT(NG_NETTYPE_UNDEF, res->pkt->type);
 
-    TEST_ASSERT(root->first == elem2);
-    TEST_ASSERT(((ng_pktsnip_t *)43088) == root->first->data);
-    TEST_ASSERT_EQUAL_INT(1234, root->first->priority);
+    res = ng_pktqueue_remove(&root, &elem1);
 
-    TEST_ASSERT(root->first->next == elem1);
-    TEST_ASSERT(((ng_pktsnip_t *)46421) == root->first->next->data);
-    TEST_ASSERT_EQUAL_INT(4567, root->first->next->priority);
+    TEST_ASSERT_NULL(root);
+    TEST_ASSERT(res == &elem1);
+    TEST_ASSERT_EQUAL_INT(NG_NETTYPE_UNDEF, res->pkt->type);
+    TEST_ASSERT_EQUAL_INT(1, res->pkt->users);
+    TEST_ASSERT_NULL(res->pkt->next);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING8, res->pkt->data);
+    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING8), res->pkt->size);
+    TEST_ASSERT_EQUAL_INT(NG_NETTYPE_UNDEF, res->pkt->type);
 
-    TEST_ASSERT_NULL(root->first->next->next);
+    res = ng_pktqueue_remove(&root, NULL);
+
+    TEST_ASSERT_NULL(root);
+    TEST_ASSERT_NULL(res);
 }
 
-static void test_pktqueue_remove_one(void)
+static void test_pktqueue_remove_head_empty(void)
 {
-    ng_pktqueue_t *root = &q;
-    ng_pktqueue_node_t *elem1 = &(qe[1]), *elem2 = &(qe[2]), *elem3 = &(qe[3]);
+    ng_pktqueue_t *res;
 
-    ng_pktqueue_add(root, elem1);
-    ng_pktqueue_add(root, elem2);
-    ng_pktqueue_add(root, elem3);
-    ng_pktqueue_remove(root, elem2);
+    res = ng_pktqueue_remove_head(&root);
 
-    TEST_ASSERT(root->first == elem1);
-    TEST_ASSERT(root->first->next == elem3);
-    TEST_ASSERT_NULL(root->first->next->next);
+    TEST_ASSERT_NULL(root);
+    TEST_ASSERT_NULL(res);
+}
+
+static void test_pktqueue_remove_head(void)
+{
+    ng_pktsnip_t pkt1 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING8, NULL);
+    ng_pktsnip_t pkt2 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING16, NULL);
+    ng_pktqueue_t *res;
+    ng_pktqueue_t elem1 = PKTQUEUE_INIT_ELEM(&pkt1);
+    ng_pktqueue_t elem2 = PKTQUEUE_INIT_ELEM(&pkt2);
+
+    ng_pktqueue_add(&root, &elem1);
+    ng_pktqueue_add(&root, &elem2);
+
+    res = ng_pktqueue_remove_head(&root);
+
+    TEST_ASSERT(res == &elem1);
+    TEST_ASSERT(root == &elem2);
+    TEST_ASSERT_EQUAL_INT(1, res->pkt->users);
+    TEST_ASSERT_NULL(res->pkt->next);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING8, res->pkt->data);
+    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING8), res->pkt->size);
+    TEST_ASSERT_EQUAL_INT(NG_NETTYPE_UNDEF, res->pkt->type);
+
+    res = ng_pktqueue_remove_head(&root);
+
+    TEST_ASSERT_NULL(root);
+    TEST_ASSERT(res == &elem2);
+    TEST_ASSERT_EQUAL_INT(NG_NETTYPE_UNDEF, res->pkt->type);
+    TEST_ASSERT_EQUAL_INT(1, res->pkt->users);
+    TEST_ASSERT_NULL(res->pkt->next);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING16, res->pkt->data);
+    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING16), res->pkt->size);
+    TEST_ASSERT_EQUAL_INT(NG_NETTYPE_UNDEF, res->pkt->type);
 }
 
 Test *tests_pktqueue_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
-        new_TestFixture(test_pktqueue_remove_head_empty),
-        new_TestFixture(test_pktqueue_remove_head_one),
         new_TestFixture(test_pktqueue_add_one),
-        new_TestFixture(test_pktqueue_add_two_equal),
-        new_TestFixture(test_pktqueue_add_two_distinct),
-        new_TestFixture(test_pktqueue_remove_one),
+        new_TestFixture(test_pktqueue_add_two),
+        new_TestFixture(test_pktqueue_remove),
+        new_TestFixture(test_pktqueue_remove_head_empty),
+        new_TestFixture(test_pktqueue_remove_head),
     };
 
     EMB_UNIT_TESTCALLER(pktqueue_tests, set_up, NULL, fixtures);


### PR DESCRIPTION
As discussed in https://github.com/RIOT-OS/RIOT/pull/3228: I use the `priority_queue` implementation through `ng_pktqueue` wrong in the IPv6 implementation. @cgundogan was also pointing out that in its current implementation IPv6 doesn't really need a priority queue anymore, just a queue.

This lead me to try out if this very simple reimplementation of the packet queue without any priorities would fix our problems in the stack. Sadly it does not, but it simplifies the implementation of the packet queue a lot, so I decided to provide it anyways.