### PR TITLE
net/ng_sixlowpan: fix check for pkt==NULL

### DIFF
--- a/sys/net/network_layer/ng_sixlowpan/frag/ng_sixlowpan_frag.c
+++ b/sys/net/network_layer/ng_sixlowpan/frag/ng_sixlowpan_frag.c
@@ -154,7 +154,7 @@ static uint16_t _send_nth_fragment(ng_sixlowpan_netif_t *iface, ng_pktsnip_t *pk
     hdr->offset = (uint8_t)(offset >> 3);
     pkt = pkt->next;    /* don't copy netif header */
 
-    while ((pkt != NULL) || (offset_count == offset)) {   /* go to offset */
+    while ((pkt != NULL) && (offset_count != offset)) {   /* go to offset */
         offset_count += (uint16_t)pkt->size;
 
         if (offset_count > offset) {    /* we overshot */


### PR DESCRIPTION
This loop has a problem: In is possible, that `pkt` is `NULL`, but `offset_count` is equal to `offset`. In this case, the while loop condition would be true and we would enter the loop, only to dereference a NULL pointer in the next line.

I am not sure though, that I fixed it correctly. Could someone verify this?