### PR TITLE
net/ng_netdev_eth: added missing NULL ptr check

### DIFF
--- a/sys/net/link_layer/ng_netdev_eth/ng_netdev_eth.c
+++ b/sys/net/link_layer/ng_netdev_eth/ng_netdev_eth.c
@@ -396,7 +396,11 @@ static int _marshall_ethernet(ng_netdev_eth_t *dev, uint8_t *buffer, ng_pktsnip_
         _addr_set_broadcast(hdr->dst);
     }
     else if (netif_hdr->flags & NG_NETIF_HDR_FLAGS_MULTICAST) {
-        _addr_set_multicast(hdr->dst, payload);
+        if (payload) {
+            _addr_set_multicast(hdr->dst, payload);
+        } else {
+            _addr_set_broadcast(hdr->dst);
+        }
     }
     else if (netif_hdr->dst_l2addr_len == NG_ETHERNET_ADDR_LEN) {
         memcpy(hdr->dst, ng_netif_hdr_get_dst_addr(netif_hdr),


### PR DESCRIPTION
When calling `_addr_set_multicast`, payload may be NULL. But `_addr_set_multicast` dereferences `payload` in its first line of implementation. So making sure here, that we only call it, if `payload` is not NULL. 

Maybe it might make sense to move the NULL pointer check into `_addr_set_multicast`? I dont have an opinion here...