### PR TITLE
net/ng_ndp: added missing break in _set_state()

### DIFF
--- a/sys/net/network_layer/ng_ndp/ng_ndp.c
+++ b/sys/net/network_layer/ng_ndp/ng_ndp.c
@@ -941,6 +941,7 @@ static void _set_state(ng_ipv6_nc_t *nc_entry, uint8_t state)
             ipv6_iface = ng_ipv6_netif_get(nc_entry->iface);
             t = ipv6_iface->reach_time;
             vtimer_remove(&nc_entry->nbr_sol_timer);
+            break;
 
         case NG_IPV6_NC_STATE_DELAY:
             vtimer_remove(&nc_entry->nbr_sol_timer);


### PR DESCRIPTION
Actually I am not sure about this one, but shouldn't here be a `break`? Otherwise lets put in a comment that the fall-through is on purpose...