### PR TITLE
net/ng_ndp: fixed wrong for loop limits

### DIFF
--- a/sys/net/network_layer/ng_ndp/ng_ndp.c
+++ b/sys/net/network_layer/ng_ndp/ng_ndp.c
@@ -818,9 +818,10 @@ ng_pktsnip_t *ng_ndp_opt_tl2a_build(const uint8_t *l2addr, uint8_t l2addr_len,
 /* packet queue node allocation */
 static ng_pktqueue_node_t *_alloc_pkt_node(ng_pktsnip_t *pkt)
 {
-    for (size_t i = 0; i < sizeof(_pkt_nodes); i++) {
+    for (size_t i = 0; i < (sizeof(_pkt_nodes) / sizeof(ng_pktqueue_node_t));
+         i++) {
         if (_pkt_nodes[i].data == NULL) {
-            ng_pktqueue_node_init(_pkt_nodes + i);
+            ng_pktqueue_node_init(&(_pkt_nodes[i]));
             _pkt_nodes[i].data = pkt;
 
             return &(_pkt_nodes[i]);


### PR DESCRIPTION
Not sure if this code was changed/is going to be changed as of todays discussions, if yes, just close this PR...

But in the current state its definitely broken: `sizeof(_pkt_nodes)` returns the size in byte, while the loop should iterate over the number of elements in the array...