### PR TITLE
net/ng_sixlowpan_frag: added missing return

### DIFF
--- a/sys/net/network_layer/ng_sixlowpan/frag/ng_sixlowpan_frag.c
+++ b/sys/net/network_layer/ng_sixlowpan/frag/ng_sixlowpan_frag.c
@@ -205,6 +205,8 @@ void ng_sixlowpan_frag_send(kernel_pid_t pid, ng_pktsnip_t *pkt,
 #if defined(DEVELHELP) && defined(ENABLE_DEBUG)
     if (iface == NULL) {
         DEBUG("6lo frag: iface == NULL, expect segmentation fault.\n");
+        ng_pktbuf_release(pkt);
+        return;
     }
 #endif
 


### PR DESCRIPTION
Just a minor bug, but if debug is enabled and `iface` is NULL, the function should return here, right?