### PR TITLE
ndp: added a word why we fall through into `NG_IPV6_NC_STATE_DELAY`

### DIFF
--- a/sys/net/network_layer/ng_ndp/ng_ndp.c
+++ b/sys/net/network_layer/ng_ndp/ng_ndp.c
@@ -940,8 +940,7 @@ static void _set_state(ng_ipv6_nc_t *nc_entry, uint8_t state)
         case NG_IPV6_NC_STATE_REACHABLE:
             ipv6_iface = ng_ipv6_netif_get(nc_entry->iface);
             t = ipv6_iface->reach_time;
-            vtimer_remove(&nc_entry->nbr_sol_timer);
-
+            /* we intentionally fall through here to set the desired timeout t */
         case NG_IPV6_NC_STATE_DELAY:
             vtimer_remove(&nc_entry->nbr_sol_timer);
             vtimer_set_msg(&nc_entry->nbr_sol_timer, t, ng_ipv6_pid,


### PR DESCRIPTION
Just added a comment that we intentionally fall through `NG_IPV6_NC_STATE_REACHABLE` into the next state and removed the double `vtimer_remove()`

Related to #3239
