### PR TITLE
aodvv2: fix one-off metric bug

### DIFF
--- a/sys/net/routing/aodvv2/routingtable.c
+++ b/sys/net/routing/aodvv2/routingtable.c
@@ -210,8 +210,7 @@ bool routingtable_offers_improvement(struct aodvv2_routing_entry_t *rt_entry,
 }
 
 void routingtable_fill_routing_entry_t_rreq(struct aodvv2_packet_data *packet_data,
-                                            struct aodvv2_routing_entry_t *rt_entry,
-                                            uint8_t link_cost)
+                                            struct aodvv2_routing_entry_t *rt_entry)
 {
     rt_entry->addr = packet_data->origNode.addr;
     rt_entry->seqnum = packet_data->origNode.seqnum;
@@ -219,13 +218,12 @@ void routingtable_fill_routing_entry_t_rreq(struct aodvv2_packet_data *packet_da
     rt_entry->lastUsed = packet_data->timestamp;
     rt_entry->expirationTime = timex_add(packet_data->timestamp, validity_t);
     rt_entry->metricType = packet_data->metricType;
-    rt_entry->metric = packet_data->origNode.metric + link_cost;
+    rt_entry->metric = packet_data->origNode.metric;
     rt_entry->state = ROUTE_STATE_ACTIVE;
 }
 
 void routingtable_fill_routing_entry_t_rrep(struct aodvv2_packet_data *packet_data,
-                                            struct aodvv2_routing_entry_t *rt_entry,
-                                            uint8_t link_cost)
+                                            struct aodvv2_routing_entry_t *rt_entry)
 {
     rt_entry->addr = packet_data->targNode.addr;
     rt_entry->seqnum = packet_data->targNode.seqnum;
@@ -233,7 +231,7 @@ void routingtable_fill_routing_entry_t_rrep(struct aodvv2_packet_data *packet_da
     rt_entry->lastUsed = packet_data->timestamp;
     rt_entry->expirationTime = timex_add(packet_data->timestamp, validity_t);
     rt_entry->metricType = packet_data->metricType;
-    rt_entry->metric = packet_data->targNode.metric + link_cost;
+    rt_entry->metric = packet_data->targNode.metric;
     rt_entry->state = ROUTE_STATE_ACTIVE;
 }
 

--- a/sys/net/routing/aodvv2/routingtable.h
+++ b/sys/net/routing/aodvv2/routingtable.h
@@ -139,8 +139,7 @@ bool routingtable_offers_improvement(struct aodvv2_routing_entry_t *rt_entry,
  * @param link_cost           the link cost for this RREQ
  */
 void routingtable_fill_routing_entry_t_rreq(struct aodvv2_packet_data *packet_data,
-                                            struct aodvv2_routing_entry_t *rt_entry,
-                                            uint8_t link_cost);
+                                            struct aodvv2_routing_entry_t *rt_entry);
 
 /**
  * Fills a routing table entry with the data of a RREP.
@@ -149,8 +148,7 @@ void routingtable_fill_routing_entry_t_rreq(struct aodvv2_packet_data *packet_da
  * @param link_cost           the link cost for this RREP
  */
 void routingtable_fill_routing_entry_t_rrep(struct aodvv2_packet_data *packet_data,
-                                            struct aodvv2_routing_entry_t *rt_entry,
-                                            uint8_t link_cost);
+                                            struct aodvv2_routing_entry_t *rt_entry);
 
 void print_routingtable(void);
 void print_routingtable_entry(struct aodvv2_routing_entry_t *rt_entry);


### PR DESCRIPTION
Given the following topology:
A->B->....
When receiving a RREQ, B will store the route back towards A with a metric value of 2, i.e. B assumes that A is two rather than one hop away. This is caused by ``link_cost`` being added to the old metric value twice, once during the packet handling and once when adding the route table entry. 
(the same will happen when a RREP is received)

This PR fixes this bug and gets rid of the rather confusing ``_update_metric()`` in favor of ``_get_route_cost()``, which is closer to the AODVv2 spec, too.