### PR TITLE
ng_ipv6: fix behavior for multicast over multiple interfaces

### DIFF
--- a/sys/net/network_layer/ng_ipv6/ng_ipv6.c
+++ b/sys/net/network_layer/ng_ipv6/ng_ipv6.c
@@ -308,7 +308,8 @@ static int _fill_ipv6_hdr(kernel_pid_t iface, ng_pktsnip_t *ipv6,
 
         /* We deal with multiple interfaces here (multicast) => possible
          * different source addresses => duplication of payload needed */
-        while (ptr != payload) {
+        while (ptr != payload->next) {
+            ng_pktsnip_t *old = ptr->next;
             /* duplicate everything including payload */
             ptr->next = ng_pktbuf_start_write(ptr->next);
 
@@ -317,7 +318,7 @@ static int _fill_ipv6_hdr(kernel_pid_t iface, ng_pktsnip_t *ipv6,
                 return -ENOBUFS;
             }
 
-            ptr = ptr->next;
+            ptr = old;
         }
     }
 #endif /* NG_NETIF_NUMOF */
@@ -348,6 +349,7 @@ static void _send_multicast(kernel_pid_t iface, ng_pktsnip_t *pkt,
 {
     ng_pktsnip_t *netif;
     kernel_pid_t ifs[NG_NETIF_NUMOF];
+    size_t ifnum = 0;
 
     if (iface == KERNEL_PID_UNDEF) {
         /* get list of interfaces */
@@ -400,7 +402,7 @@ static void _send_multicast(kernel_pid_t iface, ng_pktsnip_t *pkt,
 
             LL_PREPEND(pkt, netif);
 
-            _send_multicast_over_iface(iface, pkt, netif);
+            _send_multicast_over_iface(ifs[i], pkt, netif);
         }
     }
     else {
@@ -418,6 +420,7 @@ static void _send_multicast(kernel_pid_t iface, ng_pktsnip_t *pkt,
         _send_multicast_over_iface(iface, pkt, netif);
     }
 #else   /* NG_NETIF_NUMOF */
+    (void)ifnum; /* not used in this build branch */
     if (iface == KERNEL_PID_UNDEF) {
         iface = ifs[0];
 


### PR DESCRIPTION
These were my findings from my short interlude with multicast in #2627:

* `ptr->next` is changed in the while loop, so `payload` is never reached (leading the function always to return `-ENOBUFS`).
* Also the payload needs to be duplicated to (since the checksum is always different).
* Lastly we need to send it to the array entry, not to `iface` (which is `KERNEL_PID_UNDEF`) at that point.

This PR fixes all of those issues.