### PR TITLE
fib: added check for passing NULL pointers to `fib_get_next_hop()`

### DIFF
--- a/sys/include/net/ng_fib.h
+++ b/sys/include/net/ng_fib.h
@@ -139,6 +139,7 @@ void fib_remove_entry(uint8_t *dst, size_t dst_size);
  *         -EHOSTUNREACH if no next hop is available in any FIB table
  *                                           all RRPs are notified before the return
  *         -ENOBUFS if the size for the next hop address is insufficient low
+ *         -EINVAL if one of the passed out pointers is NULL
  */
 int fib_get_next_hop(kernel_pid_t *iface_id,
                      uint8_t *next_hop, size_t *next_hop_size, uint32_t* next_hop_flags,

--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -409,6 +409,15 @@ int fib_get_next_hop(kernel_pid_t *iface_id,
     size_t count = 1;
     fib_entry_t *entry[count];
 
+    if( iface_id == NULL
+        || next_hop == NULL
+        || next_hop_size == NULL
+        || next_hop_flags == NULL
+        || dst == NULL) {
+            mutex_unlock(&mtx_access);
+            return -EINVAL;
+        }
+
     int ret = fib_find_entry(dst, dst_size, &(entry[0]), &count);
     if (!(ret == 0 || ret == 1)) {
         /* notify all responsible RPs for unknown  next-hop for the destination address */

--- a/tests/unittests/tests-fib/tests-fib.c
+++ b/tests/unittests/tests-fib/tests-fib.c
@@ -700,6 +700,45 @@ static void test_fib_17_get_entry_set(void)
     fib_deinit();
 }
 
+/*
+* @brief call get next hop with invalid parameters
+* It is expected to receive -EINVAL on calling get_next_hop()
+*/
+static void test_fib_18_get_next_hop_invalid_parameters(void)
+{
+    size_t add_buf_size = 16; /* includes space for terminating \0 */
+    char addr_dst[] = "Test address 13";
+    char addr_expect[] = "Test address 02";
+    kernel_pid_t iface_id = KERNEL_PID_UNDEF;
+    uint32_t next_hop_flags = 0;
+    char addr_nxt[add_buf_size];
+
+    size_t entries = 20;
+    _fill_FIB_multiple(entries, 11);
+
+    int ret = fib_get_next_hop(NULL, NULL, NULL, NULL,NULL,
+                               add_buf_size - 1, 0x13);
+
+    TEST_ASSERT_EQUAL_INT(-EINVAL, ret);
+
+    ret = fib_get_next_hop(&iface_id,
+                           (uint8_t *)addr_nxt, &add_buf_size, &next_hop_flags,
+                           (uint8_t *)addr_dst, add_buf_size - 1, 0x13);
+
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    ret = strncmp(addr_expect, addr_nxt, add_buf_size);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+#if (TEST_FIB_SHOW_OUTPUT == 1)
+    fib_print_fib_table();
+    puts("");
+    universal_address_print_table();
+    puts("");
+#endif
+    fib_deinit();
+}
+
 Test *tests_fib_tests(void)
 {
     fib_init();
@@ -721,6 +760,7 @@ Test *tests_fib_tests(void)
                         new_TestFixture(test_fib_15_get_lifetime),
                         new_TestFixture(test_fib_16_prefix_match),
                         new_TestFixture(test_fib_17_get_entry_set),
+                        new_TestFixture(test_fib_18_get_next_hop_invalid_parameters),
     };
 
     EMB_UNIT_TESTCALLER(fib_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
Added a check on the `fib_get_next_hop()` call if one of the out-parameters is a NULL pointer.
Doing so will return `-EINVAL` to the caller, so basically its a tiny API change/extension.
This PR originated from the discussion in #3233 and might help with issue #3249

Additionally added a unittest covering this change.
