### PR TITLE
mulle: Update OpenOCD conf to work with 0.9.0

### DIFF
--- a/boards/mulle/dist/openocd/mulle-programmer-0.60.conf
+++ b/boards/mulle/dist/openocd/mulle-programmer-0.60.conf
@@ -39,16 +39,18 @@ source [find target/k60.cfg]
 
 #
 # Bank definition for the 'program flash' (instructions and/or data)
+# OpenOCD 0.9.0 has a definition of the first flash bank in target/kx.cfg, but
+# not OpenOCD 0.8.0 and earlier.
 #
-flash bank $_CHIPNAME.pflash.0 kinetis 0x00000000 0x20000 0 4 $_TARGETNAME
-flash bank $_CHIPNAME.pflash.1 kinetis 0x00020000 0x20000 0 4 $_TARGETNAME
+catch {flash bank $_CHIPNAME.flash kinetis 0 0 0 0 $_TARGETNAME}
+catch {flash bank $_CHIPNAME.flash2 kinetis 0 0 0 0 $_TARGETNAME}
 
 # Work-area is a space in RAM used for flash programming
-# By default use 16kB
+# By default use 4 kB
 if { [info exists WORKAREASIZE] } {
     set  _WORKAREASIZE $WORKAREASIZE
 } else {
-    set  _WORKAREASIZE 0x4000
+    set  _WORKAREASIZE 0x1000
 }
 
 $_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size $_WORKAREASIZE -work-area-backup 0

--- a/boards/mulle/dist/openocd/mulle-programmer-0.70.conf
+++ b/boards/mulle/dist/openocd/mulle-programmer-0.70.conf
@@ -38,16 +38,18 @@ source [find target/k60.cfg]
 
 #
 # Bank definition for the 'program flash' (instructions and/or data)
+# OpenOCD 0.9.0 has a definition of the first flash bank in target/kx.cfg, but
+# not OpenOCD 0.8.0 and earlier.
 #
-flash bank $_CHIPNAME.pflash.0 kinetis 0x00000000 0x40000 0 4 $_TARGETNAME
-flash bank $_CHIPNAME.pflash.1 kinetis 0x00040000 0x40000 0 4 $_TARGETNAME
+catch {flash bank $_CHIPNAME.flash kinetis 0 0 0 0 $_TARGETNAME}
+catch {flash bank $_CHIPNAME.flash2 kinetis 0 0 0 0 $_TARGETNAME}
 
 # Work-area is a space in RAM used for flash programming
-# By default use 16kB
+# By default use 4 kB
 if { [info exists WORKAREASIZE] } {
     set  _WORKAREASIZE $WORKAREASIZE
 } else {
-    set  _WORKAREASIZE 0x4000
+    set  _WORKAREASIZE 0x1000
 }
 
 $_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size $_WORKAREASIZE -work-area-backup 0


### PR DESCRIPTION
OpenOCD 0.9.0 added a definition of a single flash bank as
"$_CHIPNAME.flash" (the chip has two flash banks), the new flash bank
definitions are enclosed in catch statements to avoid startup errors.

The original configuration when combined with openocd 0.9.0 caused an
error during flash probing (which happens during GDB connect), because
of three defined flash banks, which made openocd drop the GDB
connection.

Fixes #3156