### PR TITLE
gnrc/ng_ipv6_netif: missing break?

### DIFF
--- a/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
+++ b/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
@@ -483,9 +483,11 @@ static bool _hwaddr_to_iid(uint8_t *iid, const uint8_t *hwaddr, size_t hwaddr_le
             iid[0] = hwaddr[i++];
             iid[0] ^= 0x02;
             iid[1] = hwaddr[i++];
+            break;
 
         case 2:
             iid[6] = hwaddr[i++];
+            break;
 
         case 1:
             iid[3] = 0xff;


### PR DESCRIPTION
I really don't know if this is wanted or not. Just stumbled upon it. Please merge or just close this PR.