### PR TITLE
make: clean buildtest artifacts after build success/fail

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -70,6 +70,20 @@ buildtest:
 			fi; \
 			break; \
 		done; \
+		env -i \
+			HOME=$${HOME} \
+			PATH=$${PATH} \
+			BOARD=$${BOARD} \
+			CCACHE=$${CCACHE} \
+			CCACHE_DIR=$${CCACHE_DIR} \
+			CCACHE_BASEDIR=$${CCACHE_BASEDIR} \
+			RIOTBASE=$${RIOTBASE} \
+			RIOTBOARD=$${RIOTBOARD} \
+			RIOTCPU=$${RIOTCPU} \
+			BINDIRBASE=$${BINDIRBASE} \
+			RIOTNOLINK=$${RIOTNOLINK} \
+			RIOT_VERSION=$${RIOT_VERSION} \
+			$(MAKE) clean 2>&1 >/dev/null || true; \
 	done; \
 	$${BUILDTESTOK}
 endif # BUILD_IN_DOCKER


### PR DESCRIPTION
Currently, the buildtest target just builds each application without cleaning up afterwards.
This is problematic (see the table) when you run a full buildtest (all applications / tests compiled for all platforms).
I solved this problem by executing the ```clean``` target after each individual successful / failed build process. Since, this is not very costly (IO doesn't seem to be a bottle-neck for the buildtest) I think we
can afford to run ```clean``` often (running out of storage space is definitely worse than waiting a few minutes more).

Current disk space usage after a buildtest (sorted by MCU group):
```
390M	arm7
248M	avr8
15G		cortex_m0
7.4G	cortex_m3_1
5.6G	cortex_m3_2
16G		cortex_m4
464M	msp430
163M	static-tests
243M	x86
```
Also: I suspect that some of the weird / non-reproducible travis failures we encountered (e.g. #2479) can be attributed to this high disk space usage.