### PR TITLE
native: Disable interrupts for real in native_isr_entry()

### DIFF
--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -325,6 +325,7 @@ void native_isr_entry(int sig, siginfo_t *info, void *context)
     _native_cur_ctx = (ucontext_t *)sched_active_thread->sp;
 
     DEBUG("\n\n\t\tnative_isr_entry: return to _native_sig_leave_tramp\n\n");
+    dINT();
     /* disable interrupts in context */
     isr_set_sigmask((ucontext_t *)context);
     _native_in_isr = 1;


### PR DESCRIPTION
The trampoline will call eINT() when jumping so it seems
logical to call dInt() first.

Reading the commit 2c7070bf0c7202e1d924994c91f508f4b3cfdf9e
shows that eINT() was added in the trampoline while dINT()
was not added. This fact confirm that dINT() is missing.

Fix this by calling dINT() at the right place.

Closes #2530. 

(Needs further external testing.)