### PR TITLE
sys/vtimer: initialize all values in get_localtime

### DIFF
--- a/sys/vtimer/vtimer.c
+++ b/sys/vtimer/vtimer.c
@@ -308,11 +308,10 @@ void vtimer_get_localtime(struct tm *localt)
     timex_t now;
     vtimer_now(&now);
 
+    memset(localt, 0, sizeof(struct tm));
     localt->tm_sec = now.seconds % 60;
     localt->tm_min = (now.seconds / 60) % 60;
     localt->tm_hour = (now.seconds / 60 / 60) % 24;
-
-    // TODO: fill the other fields
 }
 
 void vtimer_init(void)


### PR DESCRIPTION
Stumbled upon this when debugging using valgrind on native: valgrind was complaining about some values in the `struct tm` not being proberly initialized (also coverity is complaining about this). Explicitly resetting the struct to zero should prevent errors from random values...