### PR TITLE
native: Fix a bug in native_isr_entry() and another in the way native timers are armed (WIP)

### DIFF
--- a/cpu/native/include/hwtimer_cpu.h
+++ b/cpu/native/include/hwtimer_cpu.h
@@ -25,6 +25,8 @@ extern "C" {
 #define HWTIMER_SPEED 1000000
 #define HWTIMER_MAXTICKS (0xFFFFFFFF)
 
+void hwtimer_arm(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -325,6 +325,7 @@ void native_isr_entry(int sig, siginfo_t *info, void *context)
     _native_cur_ctx = (ucontext_t *)sched_active_thread->sp;
 
     DEBUG("\n\n\t\tnative_isr_entry: return to _native_sig_leave_tramp\n\n");
+    dINT();
     /* disable interrupts in context */
     isr_set_sigmask((ucontext_t *)context);
     _native_in_isr = 1;

--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -309,10 +309,13 @@ void native_isr_entry(int sig, siginfo_t *info, void *context)
         return;
     }
 
-    /* XXX: Workaround safety check - whenever this happens it really
-     * indicates a bug in disableIRQ */
+    /* As we arm timers before interrupt are enabled again and after signals
+     * are enabled again the handler may be called when interrupt are still
+     * disabled.
+     * Just guard the signal handler against it: the signal will be queued for
+     * later consumptioni (_sig_pipefd).
+     */
     if (native_interrupts_enabled == 0) {
-        //printf("interrupts are off, but I caught a signal.\n");
         return;
     }
     if (_native_in_isr != 0) {

--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -42,6 +42,8 @@
 
 #include "native_internal.h"
 
+#include "hwtimer_cpu.h"
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -183,6 +185,11 @@ unsigned enableIRQ(void)
     if (sigprocmask(SIG_SETMASK, &_native_sig_set, NULL) == -1) {
         err(EXIT_FAILURE, "enableIRQ: sigprocmask");
     }
+
+    /* Arm the timer to be scheduled now that signals are enabled again. No
+     * periodic timers are used so we are safe.
+     */
+    hwtimer_arm();
 
     prev_state = native_interrupts_enabled;
     native_interrupts_enabled = 1;


### PR DESCRIPTION
-native_isr_entry() was forgetting to disable interrupts and this would confuse restoreIRQ().

-the scheduler_timer() function was try arm native timer while signals where disabled and this would lead to the signals being ignored causing deadlocks.

This close two longstanding bugs.

Aditional cleanup patches will be required.