### PR TITLE
sys/shell: fixed percentage calc of ping6 shell cmd

### DIFF
--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -220,7 +220,8 @@ int _icmpv6_ping(int argc, char **argv)
     if (success > 0) {
         timex_normalize(&sum_rtt);
         printf("%d packets transmitted, %d received, %d%% packet loss, time %"
-               PRIu32 ".06%" PRIu32 " s\n", n, success, (success - n) / n,
+               PRIu32 ".06%" PRIu32 " s\n", n, success,
+               (100 - ((success * 100) / n)),
                sum_rtt.seconds, sum_rtt.microseconds);
         timex_t avg_rtt = timex_from_uint64(timex_uint64(sum_rtt) / n);  /* get average */
         printf("rtt min/avg/max = "


### PR DESCRIPTION
I was wondering why I always got 0% packet loss, even when losing one out of 100 -> 1%. Turns out the percentage calculation was wrong...