### PR TITLE
k60: Add workaround for errata e4218

### DIFF
--- a/cpu/k60/vector.c
+++ b/cpu/k60/vector.c
@@ -36,10 +36,16 @@
  */
 extern uint32_t _estack;
 
-void pre_startup (void)
+void pre_startup(void)
 {
     /* disable the WDOG */
     wdog_disable();
+
+    /*
+     * Workaround for hardware errata e4218: "SIM/FLEXBUS: SIM_SCGC7[FLEXBUS]
+     * bit should be cleared when the FlexBus is not being used."
+     */
+    BITBAND_REG32(SIM->SCGC7, SIM_SCGC7_FLEXBUS_SHIFT) = 0;
 }
 
 void dummy_handler(void)


### PR DESCRIPTION
>e4218: SIM/FLEXBUS: SIM_SCGC7[FLEXBUS] bit should be cleared when the FlexBus is not being used.
-----

>**Errata type:** Errata
>
>**Description:**
>
>The SIM_SCGC7[FLEXBUS] bit is set by default. This means that the FlexBus will be enabled and come up in global chip select mode. With some code sequence and register value combinations the core could attempt to prefetch from the FlexBus even though it might not actually use the value it prefetched. In the case where the FlexBus is unconfigured, this can result in a hung bus cycle on the FlexBus.
>
>**Workaround:**
>
> - If the FlexBus is not being used, disabled the clock to the FlexBus during chip initialization by clearing the SIM_SCGC7[FLEXBUS] bit.
> - If the FlexBus will be used, then enable at least one chip select as early in the chip initialization process as possible.

See: http://cache.freescale.com/files/microcontrollers/doc/errata/KINETIS_4N22D.pdf?fasp=1