### PR TITLE
ng_ipv6: remove redefinition of ifnum

### DIFF
--- a/sys/net/network_layer/ng_ipv6/ng_ipv6.c
+++ b/sys/net/network_layer/ng_ipv6/ng_ipv6.c
@@ -353,7 +353,7 @@ static void _send_multicast(kernel_pid_t iface, ng_pktsnip_t *pkt,
 
     if (iface == KERNEL_PID_UNDEF) {
         /* get list of interfaces */
-        size_t ifnum = ng_netif_get(ifs);
+        ifnum = ng_netif_get(ifs);
 
         /* throw away packet if no one is interested */
         if (ifnum == 0) {


### PR DESCRIPTION
#3245 moved the definition of `ifnum` to the top of the function. However the definition of `ifnum` in the if-branch was not removed.