### PR TITLE
native: Add -ffunction-sections -fdata-sections to CFLAGS

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -39,6 +39,7 @@ export GPROF ?= gprof
 
 # basic cflags:
 export CFLAGS += -Wall -Wextra -pedantic
+export CFLAGS += -ffunction-sections -fdata-sections
 ifeq ($(shell uname -m),x86_64)
 export CFLAGS += -m32
 endif


### PR DESCRIPTION
Added -ffunction-sections -fdata-sections to native board Makefile.include.
Tested on Linux/GCC.

Can someone test this on OSX and/or somethingBSD? 

It should work fine since Clang too supports this option too.