### PR TITLE
unittests: don't powerdown node at the end

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
 
 install:
     - sudo apt-get -y install $(./dist/tools/travis-scripts/get-pkg-list.py)
+    - sudo pip install pexpect  # current version in Ubuntu repos is errorneous
     - git config --global user.email "travis@example.com"
     - git config --global user.name "Travis CI"
     - test "$TRAVIS_BRANCH" = "master" || git fetch origin $TRAVIS_BRANCH:$TRAVIS_BRANCH

--- a/dist/tools/travis-scripts/get-pkg-list.py
+++ b/dist/tools/travis-scripts/get-pkg-list.py
@@ -37,7 +37,7 @@ common_pkgs = common_pkgs + ["cmake"]
 arm_pkgs = ["gcc-arm-none-eabi"]
 msp_pkgs = ["gcc-msp430"]
 x86_pkgs = ["qemu-system-x86", "g++-multilib", "gcc-multilib",
-            "build-essential"]
+            "build-essential","python-pip"]
 avr8_pkgs = ["gcc-avr", "binutils-avr", "avr-libc"]
 static_tests_pkgs = ["doxygen", "cppcheck"]
 all_mcu_pkgs = arm_pkgs + msp_pkgs + \

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -78,8 +78,5 @@ else
     CFLAGS += -DTEST_SUITES='$(subst $() $(),$(charCOMMA),$(UNIT_TESTS:tests-%=%))'
 endif
 
-test: SHELL=bash
 test:
-	@exec 5>&1 && \
-	LOG=$$("$(MAKE)" -s term | tee >(cat - >&5)) && \
-	grep 'OK ([1-9][0-9]* tests)' <<< $${LOG} > /dev/null
+	./tests/01-run.py

--- a/tests/unittests/main.c
+++ b/tests/unittests/main.c
@@ -37,6 +37,5 @@ int main(void)
 #endif
     TESTS_END();
 
-    lpm_set(LPM_POWERDOWN);
     return 0;
 }

--- a/tests/unittests/tests/01-run.py
+++ b/tests/unittests/tests/01-run.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2014 Martine Lenders <mlenders@inf.fu-berlin.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os, signal, sys, subprocess
+from pexpect import spawn, TIMEOUT, EOF
+
+DEFAULT_TIMEOUT = 5
+
+def main():
+    env = os.environ.copy()
+    child = spawn("make term", env=env, timeout=DEFAULT_TIMEOUT)
+    child.logfile = sys.stdout
+
+    try:
+        subprocess.check_output(('make', 'reset'), env=env,
+                                stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError:
+        # make reset yields error on some boards even if successful
+        pass
+    try:
+        child.expect(r"OK \([0-9]+ tests\)")
+    except TIMEOUT:
+        print("There where errors in the unittests")
+        return 1
+    finally:
+        print("")
+        child.close()
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This currently only works for default output and `OUTPUT=TEXT`, but since we don't use `OUTPUT=COMPILE` and `OUTPUT=XML` anyways we should be fine.