### PR TITLE
cpu/stm32f3: Split the RAM on STM32F334 into RAM and CCM RAM

### DIFF
--- a/cpu/stm32f3/ldscripts/stm32f334r8.ld
+++ b/cpu/stm32f3/ldscripts/stm32f334r8.ld
@@ -21,7 +21,8 @@
 MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 64K
-    ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 16K
+    ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 12K
+    ccmram (rwx): ORIGIN = 0x10000000, LENGTH = 4K
 }
 
 INCLUDE cortexm_base.ld


### PR DESCRIPTION
Hi,

RAM on STM32F334 is divided into RAM and CCMRAM and they are not continuously mapped on memory. See datasheet DM00097745.pdf, page 42. 

