### PR TITLE
eINT/dINT fixes

### DIFF
--- a/cpu/arm7_common/common.s
+++ b/cpu/arm7_common/common.s
@@ -40,25 +40,6 @@
   .global  cpu_switch_context_exit
   .global  task_return
   .global  ctx_switch
-  .global  dINT
-  .global  eINT
-
-.func
-dINT:
-    mrs     r0,  cpsr
-
-    orr     r0, r0, #NOINT              /* Disable Int */
-    msr     CPSR_c, r0
-    mov     pc,lr
-.endfunc
-
-.func
-eINT:
-    mrs     r0,  cpsr
-    and     r0, r0, #~NOINT              /* Enable Int */
-    msr     CPSR_c, r0
-    mov     pc,lr
-.endfunc
 
 ctx_switch:
     /* Save return address on stack */

--- a/cpu/arm7_common/include/arm_cpu.h
+++ b/cpu/arm7_common/include/arm_cpu.h
@@ -20,9 +20,6 @@
 #define NEW_TASK_CPSR 0x1F
 #define WORDSIZE 32
 
-extern void dINT(void);
-extern void eINT(void);
-
 uint32_t get_system_speed(void);
 void cpu_clock_scale(uint32_t source, uint32_t target, uint32_t *prescale);
 

--- a/cpu/atmega_common/include/cpu.h
+++ b/cpu/atmega_common/include/cpu.h
@@ -43,9 +43,6 @@
 extern "C" {
 #endif
 
-#define eINT            enableIRQ
-#define dINT            disableIRQ
-
 /**
  * @brief global in-ISR state variable
  */

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -65,14 +65,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Deprecated interrupt control function for backward compatibility
- * @{
- */
-#define eINT                            enableIRQ
-#define dINT                            disableIRQ
-/** @} */
-
-/**
  * @brief   Some members of the Cortex-M family have architecture specific
  *          atomic operations in atomic_arch.c
  */

--- a/cpu/native/include/cpu.h
+++ b/cpu/native/include/cpu.h
@@ -26,10 +26,6 @@
 extern "C" {
 #endif
 
-/* TODO: remove once these have been removed from RIOT: */
-void dINT(void);
-void eINT(void);
-
 /**
  * @brief   Prints the last instruction's address
  */

--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -218,17 +218,6 @@ int inISR(void)
     return _native_in_isr;
 }
 
-
-void dINT(void)
-{
-    disableIRQ();
-}
-
-void eINT(void)
-{
-    enableIRQ();
-}
-
 int _native_popsig(void)
 {
     int nread, nleft, i;

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -121,7 +121,7 @@ void _native_syscall_leave(void)
        )
     {
         _native_in_isr = 1;
-        disableIRQ();
+        unsigned int mask = disableIRQ();
         _native_cur_ctx = (ucontext_t *)sched_active_thread->sp;
         native_isr_context.uc_stack.ss_sp = __isr_stack;
         native_isr_context.uc_stack.ss_size = SIGSTKSZ;
@@ -130,7 +130,7 @@ void _native_syscall_leave(void)
         if (swapcontext(_native_cur_ctx, &native_isr_context) == -1) {
             err(EXIT_FAILURE, "_native_syscall_leave: swapcontext");
         }
-        enableIRQ();
+        restoreIRQ(mask);
     }
 }
 

--- a/sys/posix/pthread/pthread.c
+++ b/sys/posix/pthread/pthread.c
@@ -206,7 +206,7 @@ void pthread_exit(void *retval)
             }
         }
 
-        dINT();
+        disableIRQ();
         if (self->stack) {
             msg_t m;
             m.content.ptr = self->stack;


### PR DESCRIPTION
~~(based on #3312)~~
I went through the tree in an attempt to eliminate some more `dINT`/`eINT` calls. These are some `eINT` and `dINT` changes that are less obvious than the transceiver fixes in #3312.

I am not sufficiently involved in the native and x86 platforms to know what to do with the remaining `dINT`/`eINT` calls. ~~Also msp430 uses `eINT`/`dINT` as internal helpers for the higher level `xxxIRQ()` functions.~~ - fixed in #2571 

This PR removes `eINT` and `dINT` definitions from arm7, avr, cortexm, msp430 and native platforms.