### PR TITLE
ng_pktbuf: fix alignment overwrite issue

### DIFF
--- a/sys/net/crosslayer/ng_pktbuf/_pktbuf_static.c
+++ b/sys/net/crosslayer/ng_pktbuf/_pktbuf_static.c
@@ -88,18 +88,24 @@ static inline size_t __total_sz(_used_t *node)
 }
 
 /**
- * @brief   aligned size with metadata
+ * @brief   aligns @p size to the next word alignment.
  */
-static inline size_t __al_total_sz(_used_t *node)
+static inline size_t _al_sz(size_t size)
 {
-    size_t size = __total_sz(node);
-
     if (size % _PKTBUF_ALIGN_BYTES) {
         return size + (_PKTBUF_ALIGN_BYTES - (size % _PKTBUF_ALIGN_BYTES));
     }
     else {
         return size;
     }
+}
+
+/**
+ * @brief   aligned size with metadata
+ */
+static inline size_t __al_total_sz(_used_t *node)
+{
+    return _al_sz(__total_sz(node));
 }
 
 /**
@@ -141,6 +147,9 @@ static _used_t *_find(_used_t **prev_ptr, _used_t **node_ptr, const void *ptr)
     return NULL;
 }
 
+/**
+ * @brief   Allocate chunk of @p size in _buf
+ */
 void *_pktbuf_internal_alloc(size_t size)
 {
     _used_t *node = _head(), *old_next, *new_next;
@@ -163,9 +172,9 @@ void *_pktbuf_internal_alloc(size_t size)
         }
     }
 
-    while ((node->next != NULL)
+    while ((node->next != NULL) /* while not last chunk allocation */
            /* and if space between current and next allocation is not big enough */
-           && ((_start_idx(node->next) - _end_idx(node)) < _total_sz(size))) {
+           && ((_start_idx(node->next) - _end_idx(node)) < _al_sz(_total_sz(size)))) {
         node = node->next;
     }
 

--- a/tests/unittests/tests-pktbuf/tests-pktbuf.c
+++ b/tests/unittests/tests-pktbuf/tests-pktbuf.c
@@ -273,6 +273,25 @@ static void test_pktbuf_add__packed_struct(void)
     TEST_ASSERT_EQUAL_INT(data.s64, data_cpy->s64);
 }
 
+static void test_pktbuf_add__unaligned_in_aligned_hole(void)
+{
+    ng_pktsnip_t *pkt1 = ng_pktbuf_add(NULL, NULL, 8, NG_NETTYPE_UNDEF);
+    ng_pktsnip_t *pkt2 = ng_pktbuf_add(NULL, NULL, 8, NG_NETTYPE_UNDEF);
+    ng_pktsnip_t *pkt3 = ng_pktbuf_add(NULL, NULL, 8, NG_NETTYPE_UNDEF);
+    ng_pktsnip_t *pkt4;
+    void *tmp_data2 = pkt2->data;
+
+    ng_pktbuf_release(pkt2);
+    pkt4 = ng_pktbuf_add(NULL, TEST_STRING8, 9, NG_NETTYPE_UNDEF);
+
+    TEST_ASSERT(tmp_data2 != pkt4->data);
+
+    ng_pktbuf_release(pkt1);
+    ng_pktbuf_release(pkt3);
+    ng_pktbuf_release(pkt4);
+    TEST_ASSERT(ng_pktbuf_is_empty());
+}
+
 static void test_pktbuf_realloc_data__pkt_NULL(void)
 {
     TEST_ASSERT_EQUAL_INT(ENOENT, ng_pktbuf_realloc_data(NULL, 0));
@@ -615,6 +634,7 @@ Test *tests_pktbuf_tests(void)
 #endif
         new_TestFixture(test_pktbuf_add__success),
         new_TestFixture(test_pktbuf_add__packed_struct),
+        new_TestFixture(test_pktbuf_add__unaligned_in_aligned_hole),
         new_TestFixture(test_pktbuf_realloc_data__pkt_NULL),
         new_TestFixture(test_pktbuf_realloc_data__pkt_wrong),
         new_TestFixture(test_pktbuf_realloc_data__pkt_data_wrong),


### PR DESCRIPTION
Currently it can happen if there is a spot of size `n` free that a chunk of size `n + 1` is inserted, if `n` is devisable by the word length of the platform. This patch fixes this issue and adds a test to prevent this kind of bug in future implementations.