### PR TITLE
tests/driver_kw2xrf/Makefile: Blacklisted nucleo-f334 board

### DIFF
--- a/tests/driver_kw2xrf/Makefile
+++ b/tests/driver_kw2xrf/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi periph_gpio
 
-BOARD_INSUFFICIENT_RAM := stm32f0discovery
+BOARD_INSUFFICIENT_RAM := stm32f0discovery nucleo-f334
 
 ifneq (,$(filter pba-d-01-kw2x,$(BOARD)))
   DRIVER ?= kw2xrf


### PR DESCRIPTION
As discussed in #3315, this PR blacklists the nucleo-f334 board because of insufficient RAM.