### PR TITLE
Makefile.cflags: Build with -Wall -Werror by default (including fixes to correct all existing warnings)

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -31,6 +31,11 @@ endif
         info-buildsizes-diff info-build info-boards-supported \
         info-features-missing info-boards-features-missing
 
+# Make buildtests error out on warnings by adding -Werror
+ifeq (, $(filter buildtest, $(MAKECMDGOALS)))
+    CFLAGS+=-Werror
+endif
+
 ifeq ($(BUILD_IN_DOCKER),1)
 buildtest: ..in-docker-container
 else

--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -40,70 +40,70 @@ buildtest:
 	APP_RETRY=0; \
 	rm -rf "$$BINDIRBASE"; \
 	for BOARD in $$($(MAKE) -s info-boards-supported); do \
-		RIOTNOLINK=$$(echo $(BOARD_INSUFFICIENT_RAM) | grep $${BOARD} 2>&1 >/dev/null && echo 1); \
-		${COLOR_ECHO} -n "Building for $${BOARD} "; \
-		[ -n "$${RIOTNOLINK}" ] && ${COLOR_ECHO} -n "(no linking) "; \
-		for NTH_TRY in 1 2 3; do \
-			${COLOR_ECHO} -n ".. "; \
-			LOG=$$(env -i \
-					HOME=$${HOME} \
-					PATH=$${PATH} \
-					BOARD=$${BOARD} \
-					CCACHE=$${CCACHE} \
-					CCACHE_DIR=$${CCACHE_DIR} \
-					CCACHE_BASEDIR=$${CCACHE_BASEDIR} \
-					RIOTBASE=$${RIOTBASE} \
-					RIOTBOARD=$${RIOTBOARD} \
-					RIOTCPU=$${RIOTCPU} \
-					BINDIRBASE=$${BINDIRBASE} \
-					RIOTNOLINK=$${RIOTNOLINK} \
-					RIOT_VERSION=$${RIOT_VERSION} \
-					$(MAKE) -j$(NPROC) 2>&1) ; \
-			if [ "$${?}" = "0" ]; then \
-				${COLOR_ECHO} "${COLOR_GREEN}success${COLOR_RESET}"; \
-			elif [ -n "$${RIOT_DO_RETRY}" ] && [ "$${APP_RETRY}" -lt "3" ] && [ $${NTH_TRY} != 3 ]; then \
-				${COLOR_ECHO} -n "${COLOR_PURPLE}retrying${COLOR_RESET} "; \
-				continue; \
-			else \
-				${COLOR_ECHO} "${COLOR_RED}failed${COLOR_RESET}"; \
-				echo "$${LOG}" | grep -v -E '^make(\[[[:digit:]]])?:'; \
-				APP_RETRY=`expr $${APP_RETRY} + 1`; \
-				BUILDTESTOK=false; \
-			fi; \
-			break; \
-		done; \
-		env -i \
-			HOME=$${HOME} \
-			PATH=$${PATH} \
-			BOARD=$${BOARD} \
-			CCACHE=$${CCACHE} \
-			CCACHE_DIR=$${CCACHE_DIR} \
-			CCACHE_BASEDIR=$${CCACHE_BASEDIR} \
-			RIOTBASE=$${RIOTBASE} \
-			RIOTBOARD=$${RIOTBOARD} \
-			RIOTCPU=$${RIOTCPU} \
-			BINDIRBASE=$${BINDIRBASE} \
-			RIOTNOLINK=$${RIOTNOLINK} \
-			RIOT_VERSION=$${RIOT_VERSION} \
-			$(MAKE) clean-intermediates 2>&1 >/dev/null || true; \
+	  RIOTNOLINK=$$(echo $(BOARD_INSUFFICIENT_RAM) | grep $${BOARD} 2>&1 >/dev/null && echo 1); \
+	  ${COLOR_ECHO} -n "Building for $${BOARD} "; \
+	  [ -n "$${RIOTNOLINK}" ] && ${COLOR_ECHO} -n "(no linking) "; \
+	  for NTH_TRY in 1 2 3; do \
+	    ${COLOR_ECHO} -n ".. "; \
+	    LOG=$$(env -i \
+	        HOME=$${HOME} \
+	        PATH=$${PATH} \
+	        BOARD=$${BOARD} \
+	        CCACHE=$${CCACHE} \
+	        CCACHE_DIR=$${CCACHE_DIR} \
+	        CCACHE_BASEDIR=$${CCACHE_BASEDIR} \
+	        RIOTBASE=$${RIOTBASE} \
+	        RIOTBOARD=$${RIOTBOARD} \
+	        RIOTCPU=$${RIOTCPU} \
+	        BINDIRBASE=$${BINDIRBASE} \
+	        RIOTNOLINK=$${RIOTNOLINK} \
+	        RIOT_VERSION=$${RIOT_VERSION} \
+	        $(MAKE) -j$(NPROC) 2>&1) ; \
+	    if [ "$${?}" = "0" ]; then \
+	      ${COLOR_ECHO} "${COLOR_GREEN}success${COLOR_RESET}"; \
+	    elif [ -n "$${RIOT_DO_RETRY}" ] && [ "$${APP_RETRY}" -lt "3" ] && [ $${NTH_TRY} != 3 ]; then \
+	      ${COLOR_ECHO} -n "${COLOR_PURPLE}retrying${COLOR_RESET} "; \
+	      continue; \
+	    else \
+	      ${COLOR_ECHO} "${COLOR_RED}failed${COLOR_RESET}"; \
+	      echo "$${LOG}" | grep -v -E '^make(\[[[:digit:]]])?:'; \
+	      APP_RETRY=`expr $${APP_RETRY} + 1`; \
+	      BUILDTESTOK=false; \
+	    fi; \
+	    break; \
+	  done; \
+	  env -i \
+	    HOME=$${HOME} \
+	    PATH=$${PATH} \
+	    BOARD=$${BOARD} \
+	    CCACHE=$${CCACHE} \
+	    CCACHE_DIR=$${CCACHE_DIR} \
+	    CCACHE_BASEDIR=$${CCACHE_BASEDIR} \
+	    RIOTBASE=$${RIOTBASE} \
+	    RIOTBOARD=$${RIOTBOARD} \
+	    RIOTCPU=$${RIOTCPU} \
+	    BINDIRBASE=$${BINDIRBASE} \
+	    RIOTNOLINK=$${RIOTNOLINK} \
+	    RIOT_VERSION=$${RIOT_VERSION} \
+	    $(MAKE) clean-intermediates 2>&1 >/dev/null || true; \
 	done; \
 	$${BUILDTESTOK}
 endif # BUILD_IN_DOCKER
 
 info-objsize:
 	@case "${SORTROW}" in \
-		text) SORTROW=1 ;; \
-		data) SORTROW=2 ;; \
-		bss) SORTROW=3 ;; \
-		dec) SORTROW=4 ;; \
-		"") SORTROW=4 ;; \
-		*) echo "Usage: $(MAKE) info-objsize SORTROW=[text|data|bss|dec]" ; return ;; \
+	  text) SORTROW=1 ;; \
+	  data) SORTROW=2 ;; \
+	  bss) SORTROW=3 ;; \
+	  dec) SORTROW=4 ;; \
+	  "") SORTROW=4 ;; \
+	  *) echo "Usage: $(MAKE) info-objsize SORTROW=[text|data|bss|dec]" ; return ;; \
 	esac; \
 	echo '   text\t   data\t    bss\t    dec\t    hex\tfilename'; \
 	$(SIZE) -dB $(BASELIBS) | \
-		tail -n+2 | \
-		sed -e 's#$(BINDIR)##' | \
-		sort -rnk$${SORTROW}
+	  tail -n+2 | \
+	  sed -e 's#$(BINDIR)##' | \
+	  sort -rnk$${SORTROW}
 
 info-buildsize:
 	@$(SIZE) -dB $(BINDIR)$(APPLICATION).elf || echo ''
@@ -112,47 +112,47 @@ info-buildsizes: SHELL=bash
 info-buildsizes:
 	@echo -e "   text\t   data\t    bss\t    dec\tboard"; \
 	for BOARD in $$($(MAKE) -s info-boards-supported); do \
-		echo "$$(env -i \
-			HOME=$${HOME} \
-			PATH=$${PATH} \
-			BOARD=$${BOARD} \
-			RIOTBASE=$${RIOTBASE} \
-			RIOTBOARD=$${RIOTBOARD} \
-			RIOTCPU=$${RIOTCPU} \
-			BINDIRBASE=$${BINDIRBASE} \
-			$(MAKE) info-buildsize 2>/dev/null | tail -n-1 | cut -f-4)" "$${BOARD}"; \
+	  echo "$$(env -i \
+	    HOME=$${HOME} \
+	    PATH=$${PATH} \
+	    BOARD=$${BOARD} \
+	    RIOTBASE=$${RIOTBASE} \
+	    RIOTBOARD=$${RIOTBOARD} \
+	    RIOTCPU=$${RIOTCPU} \
+	    BINDIRBASE=$${BINDIRBASE} \
+	    $(MAKE) info-buildsize 2>/dev/null | tail -n-1 | cut -f-4)" "$${BOARD}"; \
 	done;
 
 info-buildsizes-diff: SHELL=bash
 info-buildsizes-diff:
 	@echo -e "text\tdata\tbss\tdec\tBOARD/BINDIRBASE\n"; \
 	for BOARD in $$($(MAKE) -s info-boards-supported); do \
-		for BINDIRBASE in $${OLDBIN} $${NEWBIN}; do \
-			env -i \
-				HOME=$${HOME} \
-				PATH=$${PATH} \
-				BOARD=$${BOARD} \
-				RIOTBASE=$${RIOTBASE} \
-				RIOTBOARD=$${RIOTBOARD} \
-				RIOTCPU=$${RIOTCPU} \
-				BINDIRBASE=$${BINDIRBASE} \
-				$(MAKE) info-buildsize 2>/dev/null | tail -n-1 | cut -f-4; \
-		done | \
-		while read -a OLD && read -a NEW; do \
-			for I in 0 1 2 3; do \
-				if [[ -n "$${NEW[I]}" && -n "$${OLD[I]}" ]]; then \
-					DIFF=$$(($${NEW[I]} - $${OLD[I]})); \
-					if [[ "$${DIFF}" -gt 0 ]]; then $(COLOR_ECHO) -n "${COLOR_RED}"; fi; \
-					if [[ "$${DIFF}" -lt 0 ]]; then $(COLOR_ECHO) -n "${COLOR_GREEN}"; fi; \
-				else \
-					DIFF="${COLOR_RED}ERR"; \
-				fi; \
-				echo -ne "$${DIFF}\t${COLOR_RESET}"; \
-			done; \
-			echo "$${BOARD}"; \
-			for I in 0 1 2 3; do echo -ne "$${OLD[I]-${COLOR_RED}ERR${COLOR_RESET}}\t"; done; echo -e "$${OLDBIN}"; \
-			for I in 0 1 2 3; do echo -ne "$${NEW[I]-${COLOR_RED}ERR${COLOR_RESET}}\t"; done; echo -e "$${NEWBIN}\n"; \
-		done; \
+	  for BINDIRBASE in $${OLDBIN} $${NEWBIN}; do \
+	    env -i \
+	      HOME=$${HOME} \
+	      PATH=$${PATH} \
+	      BOARD=$${BOARD} \
+	      RIOTBASE=$${RIOTBASE} \
+	      RIOTBOARD=$${RIOTBOARD} \
+	      RIOTCPU=$${RIOTCPU} \
+	      BINDIRBASE=$${BINDIRBASE} \
+	      $(MAKE) info-buildsize 2>/dev/null | tail -n-1 | cut -f-4; \
+	  done | \
+	  while read -a OLD && read -a NEW; do \
+	    for I in 0 1 2 3; do \
+	      if [[ -n "$${NEW[I]}" && -n "$${OLD[I]}" ]]; then \
+	        DIFF=$$(($${NEW[I]} - $${OLD[I]})); \
+	        if [[ "$${DIFF}" -gt 0 ]]; then $(COLOR_ECHO) -n "${COLOR_RED}"; fi; \
+	        if [[ "$${DIFF}" -lt 0 ]]; then $(COLOR_ECHO) -n "${COLOR_GREEN}"; fi; \
+	      else \
+	        DIFF="${COLOR_RED}ERR"; \
+	      fi; \
+	      echo -ne "$${DIFF}\t${COLOR_RESET}"; \
+	    done; \
+	    echo "$${BOARD}"; \
+	    for I in 0 1 2 3; do echo -ne "$${OLD[I]-${COLOR_RED}ERR${COLOR_RESET}}\t"; done; echo -e "$${OLDBIN}"; \
+	    for I in 0 1 2 3; do echo -ne "$${NEW[I]-${COLOR_RED}ERR${COLOR_RESET}}\t"; done; echo -e "$${NEWBIN}\n"; \
+	  done; \
 	done;
 
 info-build:
@@ -243,10 +243,10 @@ ifneq (, $(filter info-boards-supported info-boards-features-missing info-build,
     FEATURES_PROVIDED := $(FEATURES_PROVIDED_BAK)
     -include $${RIOTBOARD}/${1}/Makefile.features
     ifdef BUILDTEST_MCU_GROUP
-       ifneq ($(BUILDTEST_MCU_GROUP), $$(FEATURES_MCU_GROUP))
-          BOARDS_FEATURES_MISSING += "${1} $${BUILDTEST_MCU_GROUP}"
-          BOARDS_WITH_MISSING_FEATURES += ${1}
-       endif
+      ifneq ($(BUILDTEST_MCU_GROUP), $$(FEATURES_MCU_GROUP))
+        BOARDS_FEATURES_MISSING += "${1} $${BUILDTEST_MCU_GROUP}"
+        BOARDS_WITH_MISSING_FEATURES += ${1}
+      endif
     endif
 
     FEATURES_MISSING := $$(filter-out $$(FEATURES_PROVIDED), $$(FEATURES_REQUIRED))
@@ -276,17 +276,17 @@ info-concurrency:
 info-files: QUITE := 0
 info-files:
 	@( \
-		echo "$(abspath $(shell echo "$(MAKEFILE_LIST)"))" | tr ' ' '\n'; \
-		CSRC="$$($(MAKE) USEPKG="" -Bn | grep -o -e "[^ ]\+\.[csS]$$" -e "[^ ]\+\.[csS][ \']" | grep -v -e "^\s*-D")"; \
-		echo "$$CSRC"; \
-		echo "$(RIOTBASE)/Makefile.base"; \
-		echo "$$CSRC" | xargs dirname -- | sort | uniq | xargs -I{} find {} -name "Makefile*"; \
-		echo "$$CSRC" | xargs $(CC) $(CFLAGS) $(INCLUDES) -MM 2> /dev/null | grep -o "[^ ]\+\.h"; \
-		if [ -n "$$SRCXX" ]; then \
-			CPPSRC="$$($(MAKE) -Bn USEPKG="" | grep -o -e "[^ ]\+\.cpp" | grep -v -e "^\s*-D")"; \
-			echo "$$CPPSRC"; \
-			echo "$$CPPSRC" | xargs dirname -- | sort | uniq | xargs -I{} find {} -name "Makefile*"; \
-			echo "$$CPPSRC" | xargs $(CXX) $(CXXFLAGS) $(INCLUDES) -MM 2> /dev/null | grep -o "[^ ]\+\.h"; \
-		fi; \
-		$(foreach pkg,$(USEPKG),find $(RIOTBASE)/pkg/$(pkg) -type f;) \
+	  echo "$(abspath $(shell echo "$(MAKEFILE_LIST)"))" | tr ' ' '\n'; \
+	  CSRC="$$($(MAKE) USEPKG="" -Bn | grep -o -e "[^ ]\+\.[csS]$$" -e "[^ ]\+\.[csS][ \']" | grep -v -e "^\s*-D")"; \
+	  echo "$$CSRC"; \
+	  echo "$(RIOTBASE)/Makefile.base"; \
+	  echo "$$CSRC" | xargs dirname -- | sort | uniq | xargs -I{} find {} -name "Makefile*"; \
+	  echo "$$CSRC" | xargs $(CC) $(CFLAGS) $(INCLUDES) -MM 2> /dev/null | grep -o "[^ ]\+\.h"; \
+	  if [ -n "$$SRCXX" ]; then \
+	    CPPSRC="$$($(MAKE) -Bn USEPKG="" | grep -o -e "[^ ]\+\.cpp" | grep -v -e "^\s*-D")"; \
+	    echo "$$CPPSRC"; \
+	    echo "$$CPPSRC" | xargs dirname -- | sort | uniq | xargs -I{} find {} -name "Makefile*"; \
+	    echo "$$CPPSRC" | xargs $(CXX) $(CXXFLAGS) $(INCLUDES) -MM 2> /dev/null | grep -o "[^ ]\+\.h"; \
+	  fi; \
+	  $(foreach pkg,$(USEPKG),find $(RIOTBASE)/pkg/$(pkg) -type f;) \
 	) | sort | uniq | sed 's#$(RIOTBASE)/##'

--- a/Makefile.cflags
+++ b/Makefile.cflags
@@ -52,6 +52,9 @@ endif
 # Forbid common symbols to prevent accidental aliasing.
 CFLAGS += -fno-common
 
+# Enable all default warnings
+CFLAGS += -Wall
+
 # Default ARFLAGS for platforms which do not specify it.
 # Note: make by default provides ARFLAGS=rv which we want to override
 ifeq ($(origin ARFLAGS),default)

--- a/boards/msb-430-common/uart1.c
+++ b/boards/msb-430-common/uart1.c
@@ -28,6 +28,14 @@
 #define UART1_TX                        TXBUF1
 #define UART1_WAIT_TXDONE()       while( (UTCTL1 & TXEPT) == 0 ) { _NOP(); }
 
+int getchar(void)
+{
+#ifdef MODULE_UART0
+    return uart0_readc();
+#else
+    return U1RXBUF;
+#endif
+}
 
 int putchar(int c)
 {

--- a/boards/openmote/include/periph_conf.h
+++ b/boards/openmote/include/periph_conf.h
@@ -120,54 +120,19 @@
 #define GPIO_11_EN          1
 #define GPIO_IRQ_PRIO       1
 
-/* GPIO 0 configuration */
-#define GPIO_0_PORT         GPIO_A
-#define GPIO_0_PIN          0
-#define GPIO_0_OVER         PA_OVER
-/* GPIO 1 configuration */
-#define GPIO_1_PORT         GPIO_A
-#define GPIO_1_PIN          1
-#define GPIO_1_OVER         PA_OVER
-/* GPIO 2 configuration */
-#define GPIO_2_PORT         GPIO_A
-#define GPIO_2_PIN          2
-#define GPIO_2_OVER         PA_OVER
-/* GPIO 3 configuration */
-#define GPIO_3_PORT         GPIO_A
-#define GPIO_3_PIN          3
-#define GPIO_3_OVER         PA_OVER
-/* GPIO 4 configuration */
-#define GPIO_4_PORT         GPIO_A
-#define GPIO_4_PIN          4
-#define GPIO_4_OVER         PA_OVER
-/* GPIO 5 configuration */
-#define GPIO_5_PORT         GPIO_A
-#define GPIO_5_PIN          5
-#define GPIO_5_OVER         PA_OVER
-/* GPIO 6 configuration */
-#define GPIO_6_PORT         GPIO_A
-#define GPIO_6_PIN          6
-#define GPIO_6_OVER         PA_OVER
-/* GPIO 7 configuration */
-#define GPIO_7_PORT         GPIO_A
-#define GPIO_7_PIN          7
-#define GPIO_7_OVER         PA_OVER
-/* GPIO 8 configuration */
-#define GPIO_8_PORT         GPIO_B
-#define GPIO_8_PIN          0
-#define GPIO_8_OVER         PB_OVER
-/* GPIO 9 configuration */
-#define GPIO_9_PORT         GPIO_B
-#define GPIO_9_PIN          1
-#define GPIO_9_OVER         PB_OVER
-/* GPIO 10 configuration */
-#define GPIO_10_PORT        GPIO_B
-#define GPIO_10_PIN         2
-#define GPIO_10_OVER        PB_OVER
-/* GPIO 11 configuration */
-#define GPIO_11_PORT        GPIO_B
-#define GPIO_11_PIN         3
-#define GPIO_11_OVER        PB_OVER
+/* GPIO channel configuration */
+#define GPIO_0_PIN          GPIO_PA0
+#define GPIO_1_PIN          GPIO_PA1
+#define GPIO_2_PIN          GPIO_PA2
+#define GPIO_3_PIN          GPIO_PA3
+#define GPIO_4_PIN          GPIO_PA4
+#define GPIO_5_PIN          GPIO_PA5
+#define GPIO_6_PIN          GPIO_PA6
+#define GPIO_7_PIN          GPIO_PA7
+#define GPIO_8_PIN          GPIO_PB0
+#define GPIO_9_PIN          GPIO_PB1
+#define GPIO_10_PIN         GPIO_PB2
+#define GPIO_11_PIN         GPIO_PB3
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/openmote/include/periph_conf.h
+++ b/boards/openmote/include/periph_conf.h
@@ -106,6 +106,8 @@
  * @name GPIO configuration
  * @{
  */
+#define GPIO_IRQ_PRIO       1
+
 #define GPIO_0_EN           1
 #define GPIO_1_EN           1
 #define GPIO_2_EN           1
@@ -118,7 +120,26 @@
 #define GPIO_9_EN           1
 #define GPIO_10_EN          1
 #define GPIO_11_EN          1
-#define GPIO_IRQ_PRIO       1
+#define GPIO_12_EN          1
+#define GPIO_13_EN          1
+#define GPIO_14_EN          1
+#define GPIO_15_EN          1
+#define GPIO_16_EN          1
+#define GPIO_17_EN          1
+#define GPIO_18_EN          1
+#define GPIO_19_EN          1
+#define GPIO_20_EN          1
+#define GPIO_21_EN          1
+#define GPIO_22_EN          1
+#define GPIO_23_EN          1
+#define GPIO_24_EN          1
+#define GPIO_25_EN          1
+#define GPIO_26_EN          1
+#define GPIO_27_EN          1
+#define GPIO_28_EN          1
+#define GPIO_29_EN          1
+#define GPIO_30_EN          1
+#define GPIO_31_EN          1
 
 /* GPIO channel configuration */
 #define GPIO_0_PIN          GPIO_PA0
@@ -133,6 +154,26 @@
 #define GPIO_9_PIN          GPIO_PB1
 #define GPIO_10_PIN         GPIO_PB2
 #define GPIO_11_PIN         GPIO_PB3
+#define GPIO_12_PIN         GPIO_PB4
+#define GPIO_13_PIN         GPIO_PB5
+#define GPIO_14_PIN         GPIO_PB6
+#define GPIO_15_PIN         GPIO_PB7
+#define GPIO_16_PIN         GPIO_PC0
+#define GPIO_17_PIN         GPIO_PC1
+#define GPIO_18_PIN         GPIO_PC2
+#define GPIO_19_PIN         GPIO_PC3
+#define GPIO_20_PIN         GPIO_PC4
+#define GPIO_21_PIN         GPIO_PC5
+#define GPIO_22_PIN         GPIO_PC6
+#define GPIO_23_PIN         GPIO_PC7
+#define GPIO_24_PIN         GPIO_PD0
+#define GPIO_25_PIN         GPIO_PD1
+#define GPIO_26_PIN         GPIO_PD2
+#define GPIO_27_PIN         GPIO_PD3
+#define GPIO_28_PIN         GPIO_PD4
+#define GPIO_29_PIN         GPIO_PD5
+#define GPIO_30_PIN         GPIO_PD6
+#define GPIO_31_PIN         GPIO_PD7
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/redbee-econotag/Makefile.include
+++ b/boards/redbee-econotag/Makefile.include
@@ -6,10 +6,10 @@ export PREFIX = arm-none-eabi-
 export CC = $(PREFIX)gcc
 export AR = $(PREFIX)ar
 export CFLAGS += -march=armv4t -mtune=arm7tdmi-s -mlong-calls \
-		-msoft-float -mthumb-interwork -fno-strict-aliasing -fno-common \
-		-ffixed-r8 -ffunction-sections -ffreestanding -fno-builtin \
-		-nodefaultlibs -Wcast-align -Wall -Wstrict-prototypes -Wextra \
-		-Os -pipe
+  -msoft-float -mthumb-interwork -fno-strict-aliasing -fno-common \
+  -ffixed-r8 -ffunction-sections -ffreestanding -fno-builtin \
+  -nodefaultlibs -Wall -Wstrict-prototypes \
+  -Os -pipe
 export CFLAGS_MTHUMB ?= -mthumb
 # TODO add -mthumb
 export AFLAGS = -Wa,-gstabs $(CFLAGS)

--- a/boards/telosb/uart.c
+++ b/boards/telosb/uart.c
@@ -72,6 +72,15 @@ int putchar(int c)
     return c;
 }
 
+int getchar(void)
+{
+#ifdef MODULE_UART0
+    return uart0_readc();
+#else
+    return U1RXBUF;
+#endif
+}
+
 uint8_t uart_readByte(void)
 {
     return U1RXBUF;

--- a/boards/wsn430-common/wsn430-uart0.c
+++ b/boards/wsn430-common/wsn430-uart0.c
@@ -35,7 +35,7 @@ void usart0irq(void);
  * \brief the interrupt function
  */
 interrupt(USART0RX_VECTOR) usart0irq(void) {
-    int dummy = 0;
+    volatile int dummy = 0;
     /* Check status register for receive errors. */
     if(U0RCTL & RXERR) {
         if (U0RCTL & FE) {
@@ -52,12 +52,13 @@ interrupt(USART0RX_VECTOR) usart0irq(void) {
         }
         /* Clear error flags by forcing a dummy read. */
         dummy = U0RXBUF;
+        (void)dummy;
     }
 #ifdef MODULE_UART0
     else if (uart0_handler_pid != KERNEL_PID_UNDEF) {
-                dummy = U0RXBUF;
-                uart0_handle_incoming(dummy);
-                uart0_notify_thread();
-            }
+        dummy = U0RXBUF;
+        uart0_handle_incoming(dummy);
+        uart0_notify_thread();
+    }
 #endif
 }

--- a/boards/wsn430-common/wsn430-uart0.c
+++ b/boards/wsn430-common/wsn430-uart0.c
@@ -30,6 +30,15 @@ int putchar(int c)
     return c;
 }
 
+int getchar(void)
+{
+#ifdef MODULE_UART0
+    return uart0_readc();
+#else
+    return U0RXBUF;
+#endif
+}
+
 void usart0irq(void);
 /**
  * \brief the interrupt function

--- a/cpu/arm7_common/syscalls.c
+++ b/cpu/arm7_common/syscalls.c
@@ -27,7 +27,7 @@
 
 #include "arm_cpu.h"
 #include "board_uart0.h"
-// core
+/* core */
 #include "kernel.h"
 #include "irq.h"
 #if defined MODULE_RTC
@@ -216,10 +216,11 @@ pid_t _getpid(void)
 __attribute__ ((weak))
 int _kill_r(struct _reent *r, int pid, int sig)
 {
+    (void) r;
     (void) pid;
     (void) sig;
     /* not implemented */
-    r->_errno = ESRCH;      // no such process
+    r->_errno = ESRCH;      /* no such process */
     return -1;
 }
 
@@ -237,6 +238,9 @@ void _fini(void) {}
 __attribute__ ((weak))
 int _kill(int pid, int sig)
 {
-    errno = ESRCH;                         /* not implemented yet */
+    (void) pid;
+    (void) sig;
+    /* not implemented */
+    errno = ESRCH;      /* no such process */
     return -1;
 }

--- a/cpu/cc430/cc110x_cc430.c
+++ b/cpu/cc430/cc110x_cc430.c
@@ -123,6 +123,7 @@ void cc110x_write_reg(uint8_t addr, uint8_t value)
     /* cppcheck-suppress unreadVariable */
     i = RF1ADOUTB;                            /* Reset RFDOUTIFG flag which contains status byte */
 
+    (void)i; /* Ignore variable 'i' set but not used [-Werror=unused-but-set-variable] */
     restoreIRQ(int_state);
 }
 

--- a/cpu/cc430/flashrom.c
+++ b/cpu/cc430/flashrom.c
@@ -23,8 +23,8 @@
 #include "cpu.h"
 #include "irq.h"
 
-static uint8_t prepare(void);
-static void finish(uint8_t istate);
+static inline uint8_t prepare(void);
+static inline void finish(uint8_t istate);
 static inline void busy_wait(void);
 
 /**
@@ -52,7 +52,7 @@ uint8_t flashrom_write(uint8_t *dst, const uint8_t *src, size_t size)
 /**
  * @TODO implement this function
  */
-static uint8_t prepare(void)
+static inline uint8_t prepare(void)
 {
     return 0;
 }
@@ -60,7 +60,7 @@ static uint8_t prepare(void)
 /**
  * @TODO implement this function
  */
-void finish(uint8_t istate)
+static inline void finish(uint8_t istate)
 {
     (void) istate;
 }

--- a/cpu/cortexm_common/cortexm_init.c
+++ b/cpu/cortexm_common/cortexm_init.c
@@ -46,7 +46,7 @@ void cortexm_init(void)
     /* set SVC interrupt to same priority as the rest */
     NVIC_SetPriority(SVCall_IRQn, CPU_DEFAULT_IRQ_PRIO);
     /* initialize all vendor specific interrupts with the same value */
-    for (int i = 0; i < CPU_IRQ_NUMOF; i++) {
+    for (IRQn_Type i = 0; i < CPU_IRQ_NUMOF; i++) {
         NVIC_SetPriority(i, CPU_DEFAULT_IRQ_PRIO);
     }
 }

--- a/cpu/msp430-common/include/stdio.h
+++ b/cpu/msp430-common/include/stdio.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     msp430
+ * @{
+ *
+ * @file
+ * @brief       stdio.h wrapper for MSP430
+ * @see http://www.cplusplus.com/reference/cstdio/
+ *
+ * @author      Joakim Gebart <joakim.gebart@eistec.se
+ */
+
+#ifndef RIOT_MSP430_STDIO_H_
+#define RIOT_MSP430_STDIO_H_
+
+/*
+ * The MSP430 toolchain does not provide getchar in stdio.h.
+ * As a workaround, we include the system stdio.h here and then add getchar.
+ */
+
+#include_next <stdio.h>
+
+int getchar(void);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RIOT_MSP430_STDIO_H_ */

--- a/cpu/msp430-common/include/stdlib.h
+++ b/cpu/msp430-common/include/stdlib.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     msp430
+ * @{
+ *
+ * @file
+ * @brief       stdlib.h wrapper for MSP430
+ * @see http://www.cplusplus.com/reference/cstdlib/
+ *
+ * @author      Joakim Gebart <joakim.gebart@eistec.se
+ */
+
+#ifndef RIOT_MSP430_STDLIB_H_
+#define RIOT_MSP430_STDLIB_H_
+
+/*
+ * The MSP430 toolchain does not provide malloc, free, calloc etc. in stdlib.h.
+ * As a workaround, we include the system stdlib.h here and then add malloc.
+ */
+
+#include_next <stdlib.h>
+
+#include <malloc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RIOT_MSP430_STDLIB_H_ */

--- a/dist/tools/toolchains/build_x86.sh
+++ b/dist/tools/toolchains/build_x86.sh
@@ -299,8 +299,8 @@ extract() {
         for (( I=0; I < ${#NEWLIB_PATCHES[@]}; I+=1 )); do
             echo "Applying Newlib patch ${NEWLIB_PATCHES[$I]}"
             for (( P=0; P < 4; P+=1 )); do
-                patch -p${P} --dry-run -f < "${PATCHDIR}/${NEWLIB_PATCHES[$I]}" 2>&1 > /dev/null || continue
-                patch -p${P} -f < "${PATCHDIR}/${NEWLIB_PATCHES[$I]}" || return $?
+                patch -p${P} --ignore-whitespace --dry-run -f < "${PATCHDIR}/${NEWLIB_PATCHES[$I]}" 2>&1 > /dev/null || continue
+                patch -p${P} --ignore-whitespace -f < "${PATCHDIR}/${NEWLIB_PATCHES[$I]}" || return $?
                 break
             done
         done

--- a/dist/tools/toolchains/patches/newlib-2.1.0-RIOT-i586-none-elf.patch
+++ b/dist/tools/toolchains/patches/newlib-2.1.0-RIOT-i586-none-elf.patch
@@ -15,13 +15,13 @@ index 480b2ec..a4f615d 100644
 @@ -57,11 +57,12 @@
   * should be.
   */
- 
+
 +#include <string.h>
 +
  #ifndef lint
  static char sccsid[] = "@(#)gmon.c	5.3 (Berkeley) 5/22/91";
  #endif /* not lint */
- 
+
 -#define DEBUG
  #ifdef DEBUG
  #include <stdio.h>
@@ -33,7 +33,7 @@ index c2418fa..ba61ab7 100644
 @@ -613,36 +613,7 @@ _ELIDABLE_INLINE int __sgetc_r(struct _reent *__ptr, FILE *__p)
  #define __sgetc_r(__ptr, __p) __sgetc_raw_r(__ptr, __p)
  #endif
- 
+
 -#ifdef _never /* __GNUC__ */
 -/* If this inline is actually used, then systems using coff debugging
 -   info get hopelessly confused.  21sept93 rich@cygnus.com.  */
@@ -65,13 +65,13 @@ index c2418fa..ba61ab7 100644
 -#endif
 -#endif
 +int _EXFUN(__sputc_r, (struct _reent *, int, FILE *));
- 
+
  #define	__sfeof(p)	(((p)->_flags & __SEOF) != 0)
  #define	__sferror(p)	(((p)->_flags & __SERR) != 0)
 @@ -655,17 +626,6 @@ _ELIDABLE_INLINE int __sputc_r(struct _reent *_ptr, int _c, FILE *_p) {
  #define	clearerr(p)	__sclearerr(p)
  #endif
- 
+
 -#if 0 /*ndef __STRICT_ANSI__ - FIXME: must initialize stdio first, use fn */
 -#define	fileno(p)	__sfileno(p)
 -#endif
@@ -87,23 +87,23 @@ index c2418fa..ba61ab7 100644
  /* fast always-buffered version, true iff error */
  #define	fast_putc(x,p) (--(p)->_w < 0 ? \
 @@ -679,9 +639,6 @@ _ELIDABLE_INLINE int __sputc_r(struct _reent *_ptr, int _c, FILE *_p) {
- 
+
  #endif /* !__CUSTOM_FILE_IO__ */
- 
+
 -#define	getchar()	getc(stdin)
 -#define	putchar(x)	putc(x, stdout)
 -
  _END_STD_C
- 
+
  #endif /* _STDIO_H_ */
 diff --git a/newlib/libc/stdio/putc.c b/newlib/libc/stdio/putc.c
 index 2b1fd1b..f64925e 100644
 --- a/newlib/libc/stdio/putc.c
 +++ b/newlib/libc/stdio/putc.c
 @@ -89,6 +89,13 @@ static char sccsid[] = "%W% (Berkeley) %G%";
- 
+
  #undef putc
- 
+
 +int __sputc_r(struct _reent *_ptr, int _c, FILE *_p) {
 +    if (--_p->_w >= 0 || (_p->_w >= _p->_lbfsize && (char)_c != '\\n'))
 +        return (*_p->_p++ = _c);
@@ -123,24 +123,24 @@ index ecc445f..c9f5a00 100644
 -int _dummy_mallocr = 1;
 -#else
  /* ---------- To make a malloc.h, start cutting here ------------ */
- 
- /* 
+
+ /*
 @@ -381,11 +378,7 @@ extern void __malloc_unlock();
- 
+
  */
- 
--#if DEBUG 
+
+-#if DEBUG
 -#include <assert.h>
 -#else
  #define assert(x) ((void)0)
 -#endif
- 
- 
+
+
  /*
 @@ -1761,141 +1754,6 @@ extern unsigned long max_mmapped_mem;
-   Debugging support 
+   Debugging support
  */
- 
+
 -#if DEBUG
 -
 -
@@ -153,11 +153,11 @@ index ecc445f..c9f5a00 100644
 -*/
 -
 -#if __STD_C
--static void do_check_chunk(mchunkptr p) 
+-static void do_check_chunk(mchunkptr p)
 -#else
 -static void do_check_chunk(p) mchunkptr p;
 -#endif
--{ 
+-{
 -  INTERNAL_SIZE_T sz = p->size & ~PREV_INUSE;
 -
 -  /* No checkable chunk is mmapped */
@@ -165,7 +165,7 @@ index ecc445f..c9f5a00 100644
 -
 -  /* Check for legal address ... */
 -  assert((char*)p >= sbrk_base);
--  if (p != top) 
+-  if (p != top)
 -    assert((char*)p + sz <= (char*)top);
 -  else
 -    assert((char*)p + sz <= sbrk_base + sbrked_mem);
@@ -174,11 +174,11 @@ index ecc445f..c9f5a00 100644
 -
 -
 -#if __STD_C
--static void do_check_free_chunk(mchunkptr p) 
+-static void do_check_free_chunk(mchunkptr p)
 -#else
 -static void do_check_free_chunk(p) mchunkptr p;
 -#endif
--{ 
+-{
 -  INTERNAL_SIZE_T sz = p->size & ~PREV_INUSE;
 -  mchunkptr next = chunk_at_offset(p, sz);
 -
@@ -197,21 +197,21 @@ index ecc445f..c9f5a00 100644
 -    /* ... and is fully consolidated */
 -    assert(prev_inuse(p));
 -    assert (next == top || inuse(next));
--    
+-
 -    /* ... and has minimally sane links */
 -    assert(p->fd->bk == p);
 -    assert(p->bk->fd == p);
 -  }
 -  else /* markers are always of size SIZE_SZ */
--    assert(sz == SIZE_SZ); 
+-    assert(sz == SIZE_SZ);
 -}
 -
 -#if __STD_C
--static void do_check_inuse_chunk(mchunkptr p) 
+-static void do_check_inuse_chunk(mchunkptr p)
 -#else
 -static void do_check_inuse_chunk(p) mchunkptr p;
 -#endif
--{ 
+-{
 -  mchunkptr next = next_chunk(p);
 -  do_check_chunk(p);
 -
@@ -222,7 +222,7 @@ index ecc445f..c9f5a00 100644
 -    Since more things can be checked with free chunks than inuse ones,
 -    if an inuse chunk borders them and debug is on, it's worth doing them.
 -  */
--  if (!prev_inuse(p)) 
+-  if (!prev_inuse(p))
 -  {
 -    mchunkptr prv = prev_chunk(p);
 -    assert(next_chunk(prv) == p);
@@ -239,7 +239,7 @@ index ecc445f..c9f5a00 100644
 -}
 -
 -#if __STD_C
--static void do_check_malloced_chunk(mchunkptr p, INTERNAL_SIZE_T s) 
+-static void do_check_malloced_chunk(mchunkptr p, INTERNAL_SIZE_T s)
 -#else
 -static void do_check_malloced_chunk(p, s) mchunkptr p; INTERNAL_SIZE_T s;
 -#endif
@@ -270,29 +270,29 @@ index ecc445f..c9f5a00 100644
 -#define check_chunk(P) do_check_chunk(P)
 -#define check_malloced_chunk(P,N) do_check_malloced_chunk(P,N)
 -#else
--#define check_free_chunk(P) 
+-#define check_free_chunk(P)
 -#define check_inuse_chunk(P)
 -#define check_chunk(P)
 -#define check_malloced_chunk(P,N)
 -#endif
 -
- 
- 
- /* 
+
+
+ /*
 @@ -2126,7 +1984,7 @@ static mchunkptr mremap_chunk(p, new_size) mchunkptr p; size_t new_size;
- 
- 
- 
+
+
+
 -#ifdef DEFINE_MALLOC
 +#if defined (DEFINE_MALLOC) && !defined (MALLOC_PROVIDED)
- 
- /* 
+
+ /*
    Extend the top-most chunk by obtaining memory from system.
 @@ -3275,99 +3133,7 @@ void cfree(mem) Void_t *mem;
  #endif
- 
+
  #endif /* DEFINE_CFREE */
--
+-
 -#ifdef DEFINE_FREE
 -
 -/*
@@ -335,7 +335,7 @@ index ecc445f..c9f5a00 100644
 -
 -  top_size = chunksize(top);
 -  extra = ((top_size - pad - MINSIZE + (pagesz-1)) / pagesz - 1) * pagesz;
- 
+
 -  if (extra < (long)pagesz)  /* Not enough memory to release */
 -  {
 -    MALLOC_UNLOCK;
@@ -355,7 +355,7 @@ index ecc445f..c9f5a00 100644
 -    else
 -    {
 -      new_brk = (char*)(MORECORE (-extra));
--      
+-
 -      if (new_brk == (char*)(MORECORE_FAILURE)) /* sbrk failed? */
 -      {
 -        /* Try to figure out what we have */
@@ -368,7 +368,7 @@ index ecc445f..c9f5a00 100644
 -        }
 -        check_chunk(top);
 -	MALLOC_UNLOCK;
--        return 0; 
+-        return 0;
 -      }
 -
 -      else
@@ -385,9 +385,9 @@ index ecc445f..c9f5a00 100644
 -}
 -
 -#endif /* DEFINE_FREE */
- 
+
  #ifdef DEFINE_MALLOC_USABLE_SIZE
- 
+
 @@ -3397,11 +3163,6 @@ size_t malloc_usable_size(RARG mem) RDECL Void_t* mem;
      if(!chunk_is_mmapped(p))
      {
@@ -407,17 +407,17 @@ index ecc445f..c9f5a00 100644
 -#if DEBUG
 -  mchunkptr q;
 -#endif
- 
+
    INTERNAL_SIZE_T avail = chunksize(top);
    int   navail = ((long)(avail) >= (long)MINSIZE)? 1 : 0;
 @@ -3431,13 +3189,6 @@ STATIC void malloc_update_mallinfo()
      b = bin_at(i);
-     for (p = last(b); p != b; p = p->bk) 
+     for (p = last(b); p != b; p = p->bk)
      {
 -#if DEBUG
 -      check_free_chunk(p);
--      for (q = next_chunk(p); 
--           q < top && inuse(q) && (long)(chunksize(q)) >= (long)MINSIZE; 
+-      for (q = next_chunk(p);
+-           q < top && inuse(q) && (long)(chunksize(q)) >= (long)MINSIZE;
 -           q = next_chunk(q))
 -        check_inuse_chunk(q);
 -#endif
@@ -426,7 +426,7 @@ index ecc445f..c9f5a00 100644
      }
 @@ -3697,4 +3448,3 @@ History:
           structure of old version,  but most details differ.)
- 
+
  */
 -#endif
 diff --git a/newlib/libc/stdlib/mlock.c b/newlib/libc/stdlib/mlock.c

--- a/dist/tools/toolchains/patches/newlib-2.2.0.20150623-RIOT-i586-none-elf.patch
+++ b/dist/tools/toolchains/patches/newlib-2.2.0.20150623-RIOT-i586-none-elf.patch
@@ -15,13 +15,13 @@ index 480b2ec..a4f615d 100644
 @@ -57,11 +57,12 @@
   * should be.
   */
- 
+
 +#include <string.h>
 +
  #ifndef lint
  static char sccsid[] = "@(#)gmon.c	5.3 (Berkeley) 5/22/91";
  #endif /* not lint */
- 
+
 -#define DEBUG
  #ifdef DEBUG
  #include <stdio.h>
@@ -33,7 +33,7 @@ index 9d8fd86..9d1063f 100644
 @@ -645,36 +645,7 @@ _ELIDABLE_INLINE int __sgetc_r(struct _reent *__ptr, FILE *__p)
  #define __sgetc_r(__ptr, __p) __sgetc_raw_r(__ptr, __p)
  #endif
- 
+
 -#ifdef _never /* __GNUC__ */
 -/* If this inline is actually used, then systems using coff debugging
 -   info get hopelessly confused.  21sept93 rich@cygnus.com.  */
@@ -65,13 +65,13 @@ index 9d8fd86..9d1063f 100644
 -#endif
 -#endif
 +int _EXFUN(__sputc_r, (struct _reent *, int, FILE *));
- 
+
  #define	__sfeof(p)	((int)(((p)->_flags & __SEOF) != 0))
  #define	__sferror(p)	((int)(((p)->_flags & __SERR) != 0))
 @@ -693,17 +664,6 @@ _ELIDABLE_INLINE int __sputc_r(struct _reent *_ptr, int _c, FILE *_p) {
  #endif /* __BSD_VISIBLE */
  #endif /* _REENT_SMALL */
- 
+
 -#if 0 /*ndef __STRICT_ANSI__ - FIXME: must initialize stdio first, use fn */
 -#define	fileno(p)	__sfileno(p)
 -#endif
@@ -87,9 +87,9 @@ index 9d8fd86..9d1063f 100644
  /* fast always-buffered version, true iff error */
  #define	fast_putc(x,p) (--(p)->_w < 0 ? \
 @@ -717,14 +677,6 @@ _ELIDABLE_INLINE int __sputc_r(struct _reent *_ptr, int _c, FILE *_p) {
- 
+
  #endif /* !__CUSTOM_FILE_IO__ */
- 
+
 -#define	getchar()	getc(stdin)
 -#define	putchar(x)	putc(x, stdout)
 -
@@ -99,16 +99,16 @@ index 9d8fd86..9d1063f 100644
 -#endif
 -
  _END_STD_C
- 
+
  #endif /* _STDIO_H_ */
 diff --git a/newlib-2.2.0.20150623/newlib/libc/stdio/putc.c b/newlib-2.2.0.20150623/newlib/libc/stdio/putc.c
 index 2b1fd1b..f64925e 100644
 --- a/newlib-2.2.0.20150623/newlib/libc/stdio/putc.c
 +++ b/newlib-2.2.0.20150623/newlib/libc/stdio/putc.c
 @@ -89,6 +89,13 @@ static char sccsid[] = "%W% (Berkeley) %G%";
- 
+
  #undef putc
- 
+
 +int __sputc_r(struct _reent *_ptr, int _c, FILE *_p) {
 +    if (--_p->_w >= 0 || (_p->_w >= _p->_lbfsize && (char)_c != '\\n'))
 +        return (*_p->_p++ = _c);
@@ -128,24 +128,24 @@ index ecc445f..c9f5a00 100644
 -int _dummy_mallocr = 1;
 -#else
  /* ---------- To make a malloc.h, start cutting here ------------ */
- 
- /* 
+
+ /*
 @@ -381,11 +378,7 @@ extern void __malloc_unlock();
- 
+
  */
- 
--#if DEBUG 
+
+-#if DEBUG
 -#include <assert.h>
 -#else
  #define assert(x) ((void)0)
 -#endif
- 
- 
+
+
  /*
 @@ -1761,141 +1754,6 @@ extern unsigned long max_mmapped_mem;
-   Debugging support 
+   Debugging support
  */
- 
+
 -#if DEBUG
 -
 -
@@ -158,11 +158,11 @@ index ecc445f..c9f5a00 100644
 -*/
 -
 -#if __STD_C
--static void do_check_chunk(mchunkptr p) 
+-static void do_check_chunk(mchunkptr p)
 -#else
 -static void do_check_chunk(p) mchunkptr p;
 -#endif
--{ 
+-{
 -  INTERNAL_SIZE_T sz = p->size & ~PREV_INUSE;
 -
 -  /* No checkable chunk is mmapped */
@@ -170,7 +170,7 @@ index ecc445f..c9f5a00 100644
 -
 -  /* Check for legal address ... */
 -  assert((char*)p >= sbrk_base);
--  if (p != top) 
+-  if (p != top)
 -    assert((char*)p + sz <= (char*)top);
 -  else
 -    assert((char*)p + sz <= sbrk_base + sbrked_mem);
@@ -179,11 +179,11 @@ index ecc445f..c9f5a00 100644
 -
 -
 -#if __STD_C
--static void do_check_free_chunk(mchunkptr p) 
+-static void do_check_free_chunk(mchunkptr p)
 -#else
 -static void do_check_free_chunk(p) mchunkptr p;
 -#endif
--{ 
+-{
 -  INTERNAL_SIZE_T sz = p->size & ~PREV_INUSE;
 -  mchunkptr next = chunk_at_offset(p, sz);
 -
@@ -202,21 +202,21 @@ index ecc445f..c9f5a00 100644
 -    /* ... and is fully consolidated */
 -    assert(prev_inuse(p));
 -    assert (next == top || inuse(next));
--    
+-
 -    /* ... and has minimally sane links */
 -    assert(p->fd->bk == p);
 -    assert(p->bk->fd == p);
 -  }
 -  else /* markers are always of size SIZE_SZ */
--    assert(sz == SIZE_SZ); 
+-    assert(sz == SIZE_SZ);
 -}
 -
 -#if __STD_C
--static void do_check_inuse_chunk(mchunkptr p) 
+-static void do_check_inuse_chunk(mchunkptr p)
 -#else
 -static void do_check_inuse_chunk(p) mchunkptr p;
 -#endif
--{ 
+-{
 -  mchunkptr next = next_chunk(p);
 -  do_check_chunk(p);
 -
@@ -227,7 +227,7 @@ index ecc445f..c9f5a00 100644
 -    Since more things can be checked with free chunks than inuse ones,
 -    if an inuse chunk borders them and debug is on, it's worth doing them.
 -  */
--  if (!prev_inuse(p)) 
+-  if (!prev_inuse(p))
 -  {
 -    mchunkptr prv = prev_chunk(p);
 -    assert(next_chunk(prv) == p);
@@ -244,7 +244,7 @@ index ecc445f..c9f5a00 100644
 -}
 -
 -#if __STD_C
--static void do_check_malloced_chunk(mchunkptr p, INTERNAL_SIZE_T s) 
+-static void do_check_malloced_chunk(mchunkptr p, INTERNAL_SIZE_T s)
 -#else
 -static void do_check_malloced_chunk(p, s) mchunkptr p; INTERNAL_SIZE_T s;
 -#endif
@@ -275,29 +275,29 @@ index ecc445f..c9f5a00 100644
 -#define check_chunk(P) do_check_chunk(P)
 -#define check_malloced_chunk(P,N) do_check_malloced_chunk(P,N)
 -#else
--#define check_free_chunk(P) 
+-#define check_free_chunk(P)
 -#define check_inuse_chunk(P)
 -#define check_chunk(P)
 -#define check_malloced_chunk(P,N)
 -#endif
 -
- 
- 
- /* 
+
+
+ /*
 @@ -2126,7 +1984,7 @@ static mchunkptr mremap_chunk(p, new_size) mchunkptr p; size_t new_size;
- 
- 
- 
+
+
+
 -#ifdef DEFINE_MALLOC
 +#if defined (DEFINE_MALLOC) && !defined (MALLOC_PROVIDED)
- 
- /* 
+
+ /*
    Extend the top-most chunk by obtaining memory from system.
 @@ -3275,99 +3133,7 @@ void cfree(mem) Void_t *mem;
  #endif
- 
+
  #endif /* DEFINE_CFREE */
--
+-
 -#ifdef DEFINE_FREE
 -
 -/*
@@ -340,7 +340,7 @@ index ecc445f..c9f5a00 100644
 -
 -  top_size = chunksize(top);
 -  extra = ((top_size - pad - MINSIZE + (pagesz-1)) / pagesz - 1) * pagesz;
- 
+
 -  if (extra < (long)pagesz)  /* Not enough memory to release */
 -  {
 -    MALLOC_UNLOCK;
@@ -360,7 +360,7 @@ index ecc445f..c9f5a00 100644
 -    else
 -    {
 -      new_brk = (char*)(MORECORE (-extra));
--      
+-
 -      if (new_brk == (char*)(MORECORE_FAILURE)) /* sbrk failed? */
 -      {
 -        /* Try to figure out what we have */
@@ -373,7 +373,7 @@ index ecc445f..c9f5a00 100644
 -        }
 -        check_chunk(top);
 -	MALLOC_UNLOCK;
--        return 0; 
+-        return 0;
 -      }
 -
 -      else
@@ -390,9 +390,9 @@ index ecc445f..c9f5a00 100644
 -}
 -
 -#endif /* DEFINE_FREE */
- 
+
  #ifdef DEFINE_MALLOC_USABLE_SIZE
- 
+
 @@ -3397,11 +3163,6 @@ size_t malloc_usable_size(RARG mem) RDECL Void_t* mem;
      if(!chunk_is_mmapped(p))
      {
@@ -412,17 +412,17 @@ index ecc445f..c9f5a00 100644
 -#if DEBUG
 -  mchunkptr q;
 -#endif
- 
+
    INTERNAL_SIZE_T avail = chunksize(top);
    int   navail = ((long)(avail) >= (long)MINSIZE)? 1 : 0;
 @@ -3431,13 +3189,6 @@ STATIC void malloc_update_mallinfo()
      b = bin_at(i);
-     for (p = last(b); p != b; p = p->bk) 
+     for (p = last(b); p != b; p = p->bk)
      {
 -#if DEBUG
 -      check_free_chunk(p);
--      for (q = next_chunk(p); 
--           q < top && inuse(q) && (long)(chunksize(q)) >= (long)MINSIZE; 
+-      for (q = next_chunk(p);
+-           q < top && inuse(q) && (long)(chunksize(q)) >= (long)MINSIZE;
 -           q = next_chunk(q))
 -        check_inuse_chunk(q);
 -#endif
@@ -431,7 +431,7 @@ index ecc445f..c9f5a00 100644
      }
 @@ -3697,4 +3448,3 @@ History:
           structure of old version,  but most details differ.)
- 
+
  */
 -#endif
 diff --git a/newlib-2.2.0.20150623/newlib/libc/stdlib/mlock.c b/newlib-2.2.0.20150623/newlib/libc/stdlib/mlock.c

--- a/examples/ccn-lite-client/Makefile
+++ b/examples/ccn-lite-client/Makefile
@@ -27,7 +27,8 @@ CFLAGS += -DDEVELHELP
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
-BOARD_INSUFFICIENT_RAM := chronos msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1 redbee-econotag
+# The CCN-lite API is currently expecting unsigned int to be at least 32 bits wide.
+BOARD_BLACKLIST := chronos msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1 redbee-econotag
 
 # Modules to include:
 

--- a/examples/ccn-lite-client/main.c
+++ b/examples/ccn-lite-client/main.c
@@ -121,6 +121,9 @@ static int riot_ccn_register_prefix(int argc, char **argv)
     char *faceid = argv[3]; // 0=trans;1=msg
 
     int content_len = ccnl_riot_client_publish(_relay_pid, small_buf, faceid, type, big_buf);
+#if !ENABLE_DEBUG
+    (void) content_len;
+#endif
 
     DEBUG("shell received: '%s'\n", big_buf);
     DEBUG("received %d bytes.\n", content_len);
@@ -145,6 +148,8 @@ static int riot_ccn_relay_config(int argc, char **argv)
     m.content.value = atoi(argv[1]);
     m.type = CCNL_RIOT_CONFIG_CACHE;
     msg_send(&m, _relay_pid);
+
+    return 0;
 }
 
 static void riot_ccn_transceiver_start(kernel_pid_t _relay_pid)

--- a/examples/ccn-lite-relay/Makefile
+++ b/examples/ccn-lite-relay/Makefile
@@ -27,7 +27,8 @@ CFLAGS += -DDEVELHELP
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
-BOARD_INSUFFICIENT_RAM := chronos msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1 redbee-econotag
+# The CCN-lite API is currently expecting unsigned int to be at least 32 bits wide.
+BOARD_BLACKLIST := chronos msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1 redbee-econotag
 
 # Modules to include:
 

--- a/pkg/libfixmath/Makefile
+++ b/pkg/libfixmath/Makefile
@@ -28,7 +28,8 @@ $(BINDIR)$(PKG_NAME)-src/Makefile: $(CHECKOUT_FOLDER)/svn_info.xml
 	$(AD)cp $(CHECKOUT_FOLDER)/libfixmath/*.[ch] $(@D)
 	$(AD)rm -f $(BINDIR)$(PKG_NAME)-src/fix16.h
 
-	cd $(@D) && sed -i -e "s/1 <</(uint32_t) 1 <</g" uint32.c
+	cd $(@D) && sed -i -e 's/1 <</(uint32_t) 1 <</g' uint32.c
+	cd $(@D) && sed -i -e 's/is\([a-z]*\)(\*buf)/is\1((unsigned char) *buf)/g' fix16_str.c
 
 $(BINDIR)$(PKG_NAME)-unittests-src/Makefile:
 	@rm -rf $(@D)

--- a/pkg/libfixmath/Makefile
+++ b/pkg/libfixmath/Makefile
@@ -28,8 +28,8 @@ $(BINDIR)$(PKG_NAME)-src/Makefile: $(CHECKOUT_FOLDER)/svn_info.xml
 	$(AD)cp $(CHECKOUT_FOLDER)/libfixmath/*.[ch] $(@D)
 	$(AD)rm -f $(BINDIR)$(PKG_NAME)-src/fix16.h
 
-	cd $(@D) && sed -i -e 's/1 <</(uint32_t) 1 <</g' uint32.c
-	cd $(@D) && sed -i -e 's/is\([a-z]*\)(\*buf)/is\1((unsigned char) *buf)/g' fix16_str.c
+	$(AD)cd $(@D) && sed -i -e 's/1 <</(uint32_t) 1 <</g' uint32.c
+	$(AD)cd $(@D) && sed -i -e 's/is\([a-z]*\)(\*buf)/is\1((unsigned char) *buf)/g' fix16_str.c
 
 $(BINDIR)$(PKG_NAME)-unittests-src/Makefile:
 	@rm -rf $(@D)
@@ -43,6 +43,7 @@ $(BINDIR)$(PKG_NAME)-unittests-src/Makefile:
 		    -e 's/fprintf(std[^,]*,/printf(/' \
 		    -i $${C_FILE}; \
 	done
+	$(AD)cd $(@D) && patch -p1 --ignore-whitespace < $(CURDIR)/libfixmath-unittests-printf-format.patch
 
 $(BINDIR)$(PKG_NAME)-headers/fix16.h: $(CHECKOUT_FOLDER)/svn_info.xml
 	@rm -rf $(@D)

--- a/pkg/libfixmath/libfixmath-unittests-printf-format.patch
+++ b/pkg/libfixmath/libfixmath-unittests-printf-format.patch
@@ -1,0 +1,136 @@
+diff --git a/fix16_unittests.c b/fix16_unittests.c
+index 96b5a11..5f3f9fe 100644
+--- a/fix16_unittests.c
++++ b/fix16_unittests.c
+@@ -101,7 +101,7 @@ int fix16_unittests(void)
+             #ifndef FIXMATH_NO_OVERFLOW
+             if (result != fix16_overflow)
+             {
+-              printf("\n%d * %d overflow not detected!\n", a, b);
++              printf("\n%ld * %ld overflow not detected!\n", (long)a, (long)b);
+               failures++;
+             }
+             #endif
+@@ -109,8 +109,8 @@ int fix16_unittests(void)
+             continue;
+           }
+
+-          printf("\n%d * %d = %d\n", a, b, result);
+-          printf("%f * %f = %d\n", fa, fb, fresult);
++          printf("\n%ld * %ld = %ld\n", (long)a, (long)b, (long)result);
++          printf("%f * %f = %ld\n", fa, fb, (long)fresult);
+           failures++;
+         }
+       }
+@@ -176,7 +176,7 @@ int fix16_unittests(void)
+             #ifndef FIXMATH_NO_OVERFLOW
+             if (result != fix16_overflow)
+             {
+-              printf("\n%d / %d overflow not detected!\n", a, b);
++              printf("\n%ld / %ld overflow not detected!\n", (long)a, (long)b);
+               failures++;
+             }
+             #endif
+@@ -222,7 +222,7 @@ int fix16_unittests(void)
+             #ifndef FIXMATH_NO_OVERFLOW
+             if (result != fix16_overflow)
+             {
+-              printf("\n%d + %d overflow not detected!\n", a, b);
++              printf("\n%ld + %ld overflow not detected!\n", (long)a, (long)b);
+               failures++;
+             }
+             #endif
+@@ -230,8 +230,8 @@ int fix16_unittests(void)
+             continue;
+           }
+
+-          printf("\n%d + %d = %d\n", a, b, result);
+-          printf("%f + %f = %d\n", fa, fb, fresult);
++          printf("\n%ld + %ld = %ld\n", (long)a, (long)b, (long)result);
++          printf("%f + %f = %ld\n", fa, fb, (long)fresult);
+           failures++;
+         }
+       }
+@@ -268,7 +268,7 @@ int fix16_unittests(void)
+             #ifndef FIXMATH_NO_OVERFLOW
+             if (result != fix16_overflow)
+             {
+-              printf("\n%d - %d overflow not detected!\n", a, b);
++              printf("\n%ld - %ld overflow not detected!\n", (long)a, (long)b);
+               failures++;
+             }
+             #endif
+@@ -276,8 +276,8 @@ int fix16_unittests(void)
+             continue;
+           }
+
+-          printf("\n%d - %d = %d\n", a, b, result);
+-          printf("%f - %f = %d\n", fa, fb, fresult);
++          printf("\n%ld - %ld = %ld\n", (long)a, (long)b, (long)result);
++          printf("%f - %f = %ld\n", fa, fb, (long)fresult);
+           failures++;
+         }
+       }
+@@ -321,8 +321,8 @@ int fix16_unittests(void)
+
+       if (delta(fresult, result) > max_delta)
+       {
+-        printf("\nfix16_sqrt(%d) = %d\n", a, result);
+-        printf("sqrt(%f) = %d\n", fa, fresult);
++        printf("\nfix16_sqrt(%ld) = %ld\n", (long)a, (long)result);
++        printf("sqrt(%f) = %ld\n", fa, (long)fresult);
+         failures++;
+       }
+     }
+diff --git a/fix16_str_unittests.c b/fix16_str_unittests.c
+index c70da60..c7df566 100644
+--- a/fix16_str_unittests.c
++++ b/fix16_str_unittests.c
+@@ -93,14 +93,14 @@ int fix16_str_unittests(void)
+
+             if (strcmp(goodbuf, testbuf) != 0)
+             {
+-                printf("Value (fix16_t)%d gave %s, should be %s\n", value, testbuf, goodbuf);
++                printf("Value (fix16_t)%ld gave %s, should be %s\n", (long)value, testbuf, goodbuf);
+                 ok = false;
+             }
+
+             fix16_t roundtrip = fix16_from_str(testbuf);
+             if (roundtrip != value)
+             {
+-                printf("Roundtrip failed: (fix16_t)%d -> %s -> (fix16_t)%d\n", value, testbuf, roundtrip);
++                printf("Roundtrip failed: (fix16_t)%ld -> %s -> (fix16_t)%ld\n", (long)value, testbuf, (long)roundtrip);
+                 ok = false;
+             }
+
+diff --git a/fix16_exp_unittests.c b/fix16_exp_unittests.c
+index 01620df..658c873 100644
+--- a/fix16_exp_unittests.c
++++ b/fix16_exp_unittests.c
+@@ -41,7 +41,7 @@ int fix16_exp_unittests(void)
+             count++;
+         }
+
+-        printf("Worst delta %d with input %d\n", max_delta, worst);
++        printf("Worst delta %ld with input %ld\n", (long)max_delta, (long)worst);
+         printf("Average delta %0.2f\n", (float)sum / count);
+
+         TEST(max_delta < 200);
+@@ -80,7 +80,7 @@ int fix16_exp_unittests(void)
+             count++;
+         }
+
+-        printf("Worst delta %0.4f%% with input %d\n", max_delta, worst);
++        printf("Worst delta %0.4f%% with input %ld\n", max_delta, (long)worst);
+         printf("Average delta %0.4f%%\n", sum / count);
+
+         TEST(max_delta < 1);
+@@ -111,7 +111,7 @@ int fix16_exp_unittests(void)
+             count++;
+         }
+
+-        printf("Worst delta %d with input %d\n", max_delta, worst);
++        printf("Worst delta %ld with input %ld\n", (long)max_delta, (long)worst);
+         printf("Average delta %0.2f\n", (float)sum / count);
+
+         TEST(max_delta < 20);

--- a/sys/include/crypto/twofish.h
+++ b/sys/include/crypto/twofish.h
@@ -187,7 +187,7 @@ extern "C" {
 
 #define INPACK(n, x, m) \
    x = in[4 * (n)] ^ (in[4 * (n) + 1] << 8) \
-     ^ (in[4 * (n) + 2] << 16) ^ (in[4 * (n) + 3] << 24) ^ ctx->w[m]
+     ^ ((uint32_t)in[4 * (n) + 2] << 16) ^ ((uint32_t)in[4 * (n) + 3] << 24) ^ ctx->w[m]
 
 #define OUTUNPACK(n, x, m) \
    x ^= ctx->w[m]; \

--- a/sys/net/ccn_lite/ccn-lite-relay.c
+++ b/sys/net/ccn_lite/ccn-lite-relay.c
@@ -355,10 +355,11 @@ int ccnl_io_loop(struct ccnl_relay_s *ccnl)
 #endif
 
 #if MODULE_AT86RF231 || MODULE_CC2420 || MODULE_MC1322X
+                uint16_t src_addr = ((p->frame.src_addr[1] << 8) | p->frame.src_addr[0]);
                 ccnl_core_RX(ccnl, RIOT_TRANS_IDX,
                              (unsigned char *) p->frame.payload,
                              (int) p->frame.payload_len,
-                             *((uint16_t*) p->frame.src_addr));
+                             src_addr);
 #else
                 ccnl_core_RX(ccnl, RIOT_TRANS_IDX,
                              (unsigned char *) p->data,

--- a/sys/net/include/etx_beaconing.h
+++ b/sys/net/include/etx_beaconing.h
@@ -21,6 +21,7 @@
 #define ETX_BEACONING_H_
 #include <stdint.h>
 #include "sixlowpan.h"
+#include "timex.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,7 +43,6 @@ extern "C" {
 #define ETX_MAX_CANDIDATE_NEIGHBORS (40)
 #endif
 //ETX Interval parameters
-#define MS  (1000)
 
 /*
  * ETX_INTERVAL
@@ -51,13 +51,13 @@ extern "C" {
  * Should be divisible through 2 (For ETX_DEF_JIT_CORRECT)
  * and 5 (For ETX_MAX_JITTER) unless those values are adjusted too.
  */
-#define ETX_INTERVAL        (1000)
+#define ETX_INTERVAL        (1ul * MS_IN_USEC)
 #define ETX_WINDOW          (10)                    //10 is the default value
 #define ETX_BEST_CANDIDATES (15)                    //Sent only 15 candidates in a beaconing packet
 #define ETX_TUPLE_SIZE      (2)                     //1 Byte for Addr, 1 Byte for packets rec.
 #define ETX_PKT_REC_OFFSET  (ETX_TUPLE_SIZE - 1)    //Offset in a tuple of (addr,pkt_rec), will always be the last byte
 #define ETX_IPV6_LAST_BYTE  (15)                    //The last byte for an ipv6 address
-#define ETX_MAX_JITTER      (ETX_INTERVAL / 5)      //The default value is 20% of ETX_INTERVAL
+#define ETX_MAX_JITTER      (ETX_INTERVAL / 5ul)    //The default value is 20% of ETX_INTERVAL
 #define ETX_JITTER_MOD      (ETX_MAX_JITTER + 1)    //The modulo value for jitter computation
 #define ETX_DEF_JIT_CORRECT (ETX_MAX_JITTER / 2)    //Default Jitter correction value (normally ETX_MAX_JITTER / 2)
 #define ETX_CLOCK_ADJUST    (52500)                 //Adjustment for clockthread computations to stay close/near ETX_INTERVAL

--- a/sys/net/network_layer/sixlowpan/lowpan.c
+++ b/sys/net/network_layer/sixlowpan/lowpan.c
@@ -57,7 +57,7 @@ static char addr_str[IPV6_MAX_ADDR_STR_LEN];
 
 #define SIXLOWPAN_MAX_REGISTERED        (4)
 
-#define LOWPAN_REAS_BUF_TIMEOUT         (15 * 1000 * 1000)
+#define LOWPAN_REAS_BUF_TIMEOUT         (15ul * 1000ul * 1000ul)
 /* TODO: Set back to 3 * 1000 * (1000) */
 
 #define IPV6_LL_ADDR_LEN                (8)

--- a/sys/newlib/syscalls.c
+++ b/sys/newlib/syscalls.c
@@ -202,6 +202,8 @@ int _open_r(struct _reent *r, const char *name, int mode)
  */
 int _read_r(struct _reent *r, int fd, void *buffer, unsigned int count)
 {
+    (void)r;
+    (void)fd;
 #ifndef MODULE_UART0
     int res;
     mutex_lock(&uart_rx_mutex);

--- a/sys/posix/pthread/include/pthread_spin.h
+++ b/sys/posix/pthread/include/pthread_spin.h
@@ -17,8 +17,8 @@
  *          Use disableIRQ() and restoreIRQ() for shortterm locks instead.
  */
 
-#ifndef __SYS__POSIX__PTHREAD_SPIN__H
-#define __SYS__POSIX__PTHREAD_SPIN__H
+#ifndef SYS_POSIX_PTHREAD_SPIN_H_
+#define SYS_POSIX_PTHREAD_SPIN_H_
 
 #include <errno.h>
 
@@ -32,7 +32,9 @@ extern "C" {
  *                  They will burn away the battery needlessly, and may not work because RIOT is tickless.
  *                  Use disableIRQ() and restoreIRQ() for shortterm locks instead.
  */
-typedef volatile unsigned pthread_spinlock_t;
+typedef struct {
+    atomic_int_t value;
+} pthread_spinlock_t;
 
 /**
  * @brief           Intializes a spinlock.

--- a/sys/posix/pthread/pthread_spin.c
+++ b/sys/posix/pthread/pthread_spin.c
@@ -27,7 +27,7 @@ int pthread_spin_init(pthread_spinlock_t *lock, int pshared)
     }
 
     (void) pshared;
-    *lock = 0;
+    ATOMIC_VALUE(lock->value) = 0;
     return 0;
 }
 
@@ -47,7 +47,7 @@ int pthread_spin_lock(pthread_spinlock_t *lock)
         return EINVAL;
     }
 
-    while (atomic_set_to_one((int *)lock) == 0) {
+    while (atomic_set_to_one(&(lock->value)) == 0) {
         /* spin */
     }
 
@@ -60,7 +60,7 @@ int pthread_spin_trylock(pthread_spinlock_t *lock)
         return EINVAL;
     }
 
-    if (atomic_set_to_one((int *)lock) == 0) {
+    if (atomic_set_to_one(&(lock->value)) == 0) {
         return EBUSY;
     }
 
@@ -73,7 +73,7 @@ int pthread_spin_unlock(pthread_spinlock_t *lock)
         return EINVAL;
     }
 
-    if (atomic_set_to_zero((int *)lock) == 0) {
+    if (atomic_set_to_zero(&(lock->value)) == 0) {
         return EPERM;
     }
 

--- a/sys/transceiver/transceiver.c
+++ b/sys/transceiver/transceiver.c
@@ -634,7 +634,7 @@ void receive_mc1322x_packet(ieee802154_packet_t *trans_p)
 {
     maca_packet_t *maca_pkt;
     dINT();
-    maca_pkt = maca_get_rx_packet();
+    maca_pkt = (maca_packet_t *)maca_get_rx_packet();
     trans_p->lqi = maca_pkt->lqi;
     trans_p->length = maca_pkt->length;
     memcpy((void *) &(data_buffer[transceiver_buffer_pos * PAYLOAD_SIZE]), maca_pkt->data, MACA_MAX_PAYLOAD_SIZE);
@@ -748,7 +748,7 @@ static int8_t send_packet(transceiver_type_t t, void *pkt)
     cc110x_packet_t cc110x_pkt;
 #endif
 #ifdef MODULE_MC1322X
-    maca_packet_t *maca_pkt = maca_get_free_packet();
+    maca_packet_t *maca_pkt = (maca_packet_t *)maca_get_free_packet();
 #endif
 
 #ifdef MODULE_CC2420

--- a/tests/bitarithm_timings/main.c
+++ b/tests/bitarithm_timings/main.c
@@ -33,9 +33,10 @@
 
 #include "bitarithm.h"
 #include "hwtimer.h"
+#include "timex.h"
 
-#define TIMEOUT_S (5)
-#define TIMEOUT_US (TIMEOUT_S * 1000 * 1000)
+#define TIMEOUT_S (5ul)
+#define TIMEOUT_US (TIMEOUT_S * SEC_IN_USEC)
 #define TIMEOUT (HWTIMER_TICKS(TIMEOUT_US))
 #define PER_ITERATION (4)
 

--- a/tests/driver_dht/main.c
+++ b/tests/driver_dht/main.c
@@ -40,7 +40,7 @@ int main(void)
 
     puts("DHT temperature and humidity sensor test application\n");
 
-    printf("Initializing DHT sensor at GPIO_%i... ", DHT_GPIO);
+    printf("Initializing DHT sensor at GPIO_%ld... ", (long)DHT_GPIO);
     if (dht_init(&dev, DHT_TYPE, DHT_GPIO) == 0) {
         puts("[OK]\n");
     }

--- a/tests/driver_nrf24l01p_lowlevel/main.c
+++ b/tests/driver_nrf24l01p_lowlevel/main.c
@@ -53,16 +53,12 @@
 
 #define SHELL_BUFFER_SIZE        128
 
-static int shell_read(void);
-static void shell_write(int);
 static int cmd_send(int argc, char **argv);
 static int cmd_print_regs(int argc, char **argv);
 static int cmd_its(int argc, char **argv);
 
-
 void printbin(unsigned byte);
 void print_register(char reg, int num_bytes);
-
 
 static nrf24l01p_t nrf24l01p_0;
 
@@ -192,7 +188,7 @@ int cmd_its(int argc, char **argv)
     /* initialize transceiver device */
     if (nrf24l01p_init(&nrf24l01p_0, SPI_PORT, CE_PIN, CS_PIN, IRQ_PIN) < 0) {
         puts("Error in nrf24l01p_init");
-        return;
+        return 1;
     }
 
     /* create thread that gets msg when data arrives */
@@ -200,7 +196,7 @@ int cmd_its(int argc, char **argv)
         rx_handler_stack, sizeof(rx_handler_stack), THREAD_PRIORITY_MAIN - 1, 0,
         nrf24l01p_rx_handler, 0, "nrf24l01p_rx_handler") < 0) {
         puts("Error in thread_create");
-        return;
+        return 1;
     }
 
     /* setup device as receiver */
@@ -232,17 +228,17 @@ int cmd_send(int argc, char **argv)
     /* power on the device */
     if (nrf24l01p_on(&nrf24l01p_0) < 0) {
         puts("Error in nrf24l01p_on");
-        return;
+        return 1;
     }
     /* setup device as transmitter */
     if (nrf24l01p_set_txmode(&nrf24l01p_0) < 0) {
         puts("Error in nrf24l01p_set_txmode");
-        return;
+        return 1;
     }
     /* load data to transmit into device */
     if (nrf24l01p_preload(&nrf24l01p_0, tx_buf, NRF24L01P_MAX_DATA_LENGTH) < 0) {
         puts("Error in nrf24l01p_preload");
-        return;
+        return 1;
     }
     /* trigger transmitting */
     nrf24l01p_transmit(&nrf24l01p_0);

--- a/tests/driver_pir/main.c
+++ b/tests/driver_pir/main.c
@@ -62,7 +62,7 @@ void* pir_handler(void *arg)
 int main(void)
 {
     puts("PIR motion sensor test application\n");
-    printf("Initializing PIR sensor at GPIO_%i... ", PIR_GPIO);
+    printf("Initializing PIR sensor at GPIO_%ld... ", (long)PIR_GPIO);
     if (pir_init(&dev, PIR_GPIO) == 0) {
         puts("[OK]\n");
     }

--- a/tests/libfixmath_unittests/Makefile
+++ b/tests/libfixmath_unittests/Makefile
@@ -6,7 +6,7 @@ BOARD_BLACKLIST := arduino-mega2560
 # differences in the toolchain)
 
 # The MSP boards don't feature round(), exp(), and log(), which are used in the unittests
-BOARD_INSUFFICIENT_RAM := chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
+BOARD_BLACKLIST += chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
 
 # Insufficient RAM / ROM
 BOARD_INSUFFICIENT_RAM += redbee-econotag stm32f0discovery

--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -182,18 +182,20 @@ int cmd_init_master(int argc, char **argv)
     res = spi_init_master(spi_dev, spi_mode, spi_speed);
     spi_release(spi_dev);
     if (res < 0) {
-        printf("spi_init_master: error initializing SPI_%i device (code %i)\n", spi_dev, res);
+        printf("spi_init_master: error initializing SPI_%i device (code %i)\n",
+                spi_dev, res);
         return 1;
     }
     res = gpio_init(spi_cs, GPIO_DIR_OUT, GPIO_PULLUP);
     if (res < 0){
-        printf("gpio_init: error initializing GPIO_%i as CS line (code %i)\n", spi_cs, res);
+        printf("gpio_init: error initializing GPIO_%ld as CS line (code %i)\n",
+                (long)spi_cs, res);
         return 1;
     }
     gpio_set(spi_cs);
     spi_master = 1;
-    printf("SPI_%i successfully initialized as master, cs: GPIO_%i, mode: %i, speed: %i\n",
-            spi_dev, spi_cs, spi_mode, spi_speed);
+    printf("SPI_%i successfully initialized as master, cs: GPIO_%ld, mode: %i, speed: %i\n",
+            spi_dev, (long)spi_cs, spi_mode, spi_speed);
     return 0;
 }
 
@@ -208,17 +210,19 @@ int cmd_init_slave(int argc, char **argv)
     res = spi_init_slave(spi_dev, spi_mode, slave_on_data);
     spi_release(spi_dev);
     if (res < 0) {
-        printf("spi_init_slave: error initializing SPI_%i device (code: %i)\n", spi_dev, res);
+        printf("spi_init_slave: error initializing SPI_%i device (code: %i)\n",
+                spi_dev, res);
         return 1;
     }
     res = gpio_init_int(spi_cs, GPIO_NOPULL, GPIO_FALLING, slave_on_cs, 0);
     if (res < 0){
-        printf("gpio_init_int: error initializing GPIO_%i as CS line (code %i)\n", spi_cs, res);
+        printf("gpio_init_int: error initializing GPIO_%ld as CS line (code %i)\n",
+                (long)spi_cs, res);
         return 1;
     }
     spi_master = 0;
-    printf("SPI_%i successfully initialized as slave, cs: GPIO_%i, mode: %i\n",
-            spi_dev, spi_cs, spi_mode);
+    printf("SPI_%i successfully initialized as slave, cs: GPIO_%ld, mode: %i\n",
+            spi_dev, (long)spi_cs, spi_mode);
     return 0;
 }
 

--- a/tests/periph_uart_blocking/main.c
+++ b/tests/periph_uart_blocking/main.c
@@ -26,6 +26,8 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
+#include <inttypes.h>
 
 #include "board.h"
 #include "periph/uart.h"
@@ -33,7 +35,7 @@
 /* only build this test, if the target supports the UART driver interface */
 #if UART_NUMOF
 
-static int baudrates[] = {115200, 57600, 9600, 38400, 115200, 115200};
+static uint32_t baudrates[] = {115200, 57600, 9600, 38400, 115200, 115200};
 
 void uart_print(uart_t dev, char *str)
 {
@@ -56,7 +58,7 @@ int main(void)
     puts("Setting up remaining UART devices:");
     for (int i = UART_0; i < UART_NUMOF; i++) {
         if (i != STDIO) {
-            printf("Setting up UART_%i @ %i", i, baudrates[i]);
+            printf("Setting up UART_%d @ %" PRIu32, i, baudrates[i]);
             if (uart_init_blocking(i, baudrates[i]) >= 0) {
                 puts("   ...ok");
             }
@@ -70,7 +72,7 @@ int main(void)
 
     for (i = UART_0; i < UART_NUMOF; i++) {
         if (i != STDIO) {
-            printf("Please Connect to UART_%i @ %i now, press return when done\n", i, baudrates[i]);
+            printf("Please Connect to UART_%d @ %" PRIu32 " now, press return when done\n", i, baudrates[i]);
             do {
                 tmp = getchar();
             } while (tmp != '\n');

--- a/tests/periph_uart_int/main.c
+++ b/tests/periph_uart_int/main.c
@@ -28,6 +28,8 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
+#include <inttypes.h>
 
 #include "cpu.h"
 #include "msg.h"
@@ -85,7 +87,7 @@ void *uart_thread(void *arg)
         ringbuffer_add(&tx_buf, status, strlen(status));
         uart_tx_begin(DEV);
 
-        vtimer_usleep(2000 * 1000);
+        vtimer_usleep(2000ul * 1000ul);
     }
 
     return 0;
@@ -101,7 +103,7 @@ int main(void)
     ringbuffer_init(&rx_buf, rx_mem, 128);
     ringbuffer_init(&tx_buf, tx_mem, 128);
 
-    printf("Initializing UART @ %i", BAUD);
+    printf("Initializing UART @ %" PRIu32, (uint32_t)BAUD);
     if (uart_init(DEV, BAUD, rx, tx, 0) >= 0) {
         puts("   ...done");
     }

--- a/tests/pthread_condition_variable/main.c
+++ b/tests/pthread_condition_variable/main.c
@@ -54,7 +54,7 @@ int main(void)
 {
     count = 0;
     is_finished = 0;
-    expected_value = 1000*1000;
+    expected_value = 1000ul * 1000ul;
     pthread_cond_init(&cv, NULL);
 
     kernel_pid_t pid = thread_create(stack,sizeof(stack), THREAD_PRIORITY_MAIN - 1,

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -8,4 +8,7 @@ USEMODULE += uart0
 
 DISABLE_MODULE += auto_init
 
+# chronos is missing a getchar implementation
+BOARD_BLACKLIST += chronos
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -56,21 +56,6 @@ static int print_echo(int argc, char **argv)
     return 0;
 }
 
-static int shell_readc(void)
-{
-    char c;
-    int result = posix_read(uart0_handler_pid, &c, 1);
-    if (result != 1) {
-        return -1;
-    }
-    return (unsigned char) c;
-}
-
-static void shell_putchar(int c)
-{
-    putchar(c);
-}
-
 static const shell_command_t shell_commands[] = {
     { "start_test", "starts a test", print_teststart },
     { "end_test", "ends a test", print_testend },
@@ -89,8 +74,7 @@ int main(void)
 
     /* define own shell commands */
     shell_t shell;
-    shell_init(&shell, shell_commands, SHELL_BUFSIZE, shell_readc,
-               shell_putchar);
+    shell_init(&shell, shell_commands, SHELL_BUFSIZE, getchar, putchar);
     shell_run(&shell);
 
     /* or use only system shell commands */

--- a/tests/slip/main.c
+++ b/tests/slip/main.c
@@ -31,22 +31,6 @@
 #define SHELL_BUFSIZE           (64U)
 
 /**
- * @brief   Read chars from STDIO
- */
-int shell_read(void)
-{
-    return (int)getchar();
-}
-
-/**
- * @brief   Write chars to STDIO
- */
-void shell_put(int c)
-{
-    putchar((char)c);
-}
-
-/**
  * @brief   Maybe you are a golfer?!
  */
 int main(void)
@@ -69,7 +53,7 @@ int main(void)
 
     /* start the shell */
     puts("Initialization OK, starting shell now");
-    shell_init(&shell, NULL, SHELL_BUFSIZE, shell_read, shell_put);
+    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
     shell_run(&shell);
 
     return 0;

--- a/tests/unittests/tests-core/tests-core-atomic.c
+++ b/tests/unittests/tests-core/tests-core-atomic.c
@@ -162,13 +162,13 @@ static void test_atomic_cas_same(void)
 {
     atomic_int_t res = ATOMIC_INIT(0);
 
-    TEST_ASSERT_EQUAL_INT(1, atomic_cas(&res, 0, 1234567));
-    TEST_ASSERT_EQUAL_INT(1234567, ATOMIC_VALUE(res));
-    TEST_ASSERT_EQUAL_INT(1, atomic_cas(&res, 1234567, -987654321));
-    TEST_ASSERT_EQUAL_INT(-987654321, ATOMIC_VALUE(res));
-    TEST_ASSERT_EQUAL_INT(1, atomic_cas(&res, -987654321, -987654321));
-    TEST_ASSERT_EQUAL_INT(-987654321, ATOMIC_VALUE(res));
-    TEST_ASSERT_EQUAL_INT(1, atomic_cas(&res, -987654321, 0));
+    TEST_ASSERT_EQUAL_INT(1, atomic_cas(&res, 0, 12345));
+    TEST_ASSERT_EQUAL_INT(12345, ATOMIC_VALUE(res));
+    TEST_ASSERT_EQUAL_INT(1, atomic_cas(&res, 12345, -9876));
+    TEST_ASSERT_EQUAL_INT(-9876, ATOMIC_VALUE(res));
+    TEST_ASSERT_EQUAL_INT(1, atomic_cas(&res, -9876, -9876));
+    TEST_ASSERT_EQUAL_INT(-9876, ATOMIC_VALUE(res));
+    TEST_ASSERT_EQUAL_INT(1, atomic_cas(&res, -9876, 0));
     TEST_ASSERT_EQUAL_INT(0, ATOMIC_VALUE(res));
 }
 
@@ -177,15 +177,15 @@ static void test_atomic_cas_diff(void)
 {
     atomic_int_t res = ATOMIC_INIT(32767);
 
-    TEST_ASSERT_EQUAL_INT(0, atomic_cas(&res, 65535, 12345));
+    TEST_ASSERT_EQUAL_INT(0, atomic_cas(&res, 22222, 12345));
     TEST_ASSERT_EQUAL_INT(32767, ATOMIC_VALUE(res));
-    ATOMIC_VALUE(res) = -12345687;
-    TEST_ASSERT_EQUAL_INT(0, atomic_cas(&res, 12345687, 123456789));
-    TEST_ASSERT_EQUAL_INT(-12345687, ATOMIC_VALUE(res));
-    TEST_ASSERT_EQUAL_INT(0, atomic_cas(&res, 12345687, 12345687));
-    TEST_ASSERT_EQUAL_INT(-12345687, ATOMIC_VALUE(res));
-    TEST_ASSERT_EQUAL_INT(0, atomic_cas(&res, 12345687, -12345687));
-    TEST_ASSERT_EQUAL_INT(-12345687, ATOMIC_VALUE(res));
+    ATOMIC_VALUE(res) = -12345;
+    TEST_ASSERT_EQUAL_INT(0, atomic_cas(&res, 12345, 12345));
+    TEST_ASSERT_EQUAL_INT(-12345, ATOMIC_VALUE(res));
+    TEST_ASSERT_EQUAL_INT(0, atomic_cas(&res, 12345, 12345));
+    TEST_ASSERT_EQUAL_INT(-12345, ATOMIC_VALUE(res));
+    TEST_ASSERT_EQUAL_INT(0, atomic_cas(&res, 12345, -12345));
+    TEST_ASSERT_EQUAL_INT(-12345, ATOMIC_VALUE(res));
 }
 
 /* Test ATOMIC_VALUE */
@@ -195,10 +195,10 @@ static void test_atomic_value(void)
     atomic_int_t *ptr = &res;
 
     TEST_ASSERT_EQUAL_INT(12345, ATOMIC_VALUE(res));
-    ATOMIC_VALUE(res) = 54332;
-    TEST_ASSERT_EQUAL_INT(54332, ATOMIC_VALUE(res));
-    TEST_ASSERT_EQUAL_INT(54332, res.value);
-    res.value = 1232342131;
+    ATOMIC_VALUE(res) = 24332;
+    TEST_ASSERT_EQUAL_INT(24332, ATOMIC_VALUE(res));
+    TEST_ASSERT_EQUAL_INT(24332, res.value);
+    res.value = 12323;
     TEST_ASSERT_EQUAL_INT(ATOMIC_VALUE(res), res.value);
     TEST_ASSERT_EQUAL_INT(ATOMIC_VALUE(*ptr), res.value);
 }

--- a/tests/unittests/tests-ipv6_hdr/tests-ipv6_hdr.c
+++ b/tests/unittests/tests-ipv6_hdr/tests-ipv6_hdr.c
@@ -244,7 +244,7 @@ static void test_ipv6_hdr_get_fl(void)
      * |  6 |   tc   |     flow label     |
      * +----+--------+--------------------+
      */
-    TEST_ASSERT_EQUAL_INT((OTHER_BYTE & 0x0f) << 16,
+    TEST_ASSERT_EQUAL_INT((uint32_t)(OTHER_BYTE & 0x0f) << 16,
                           ng_ipv6_hdr_get_fl((ng_ipv6_hdr_t *)val));
 }
 


### PR DESCRIPTION
Fixes a lot of warnings. This is a stepping stone towards #1121.

`make buildtest` with `CFLAGS += -Wall -Werror` (not `-Wextra`) added to `Makefile.include` now completes without errors on ~~`examples/hello-world`, `examples/default`, `examples/rpl_udp`, `tests/unittests`~~ all tests

Worth extra notice:
 - openmote GPIO periph_conf has been redefined to allow all pins as GPIOs (before only the few first were defined)
 - redbee-econotag does not set `CFLAGS += -Wextra` in the board Makefile anymore
 - msp430 now has a wrapper stdlib.h header for including malloc et al. as expected from `<stdlib.h>`