### PR TITLE
Makefile.docker: Add BUILDTEST_MCU_GROUP to passed variables

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -41,6 +41,7 @@ export DOCKER_ENV_VARS = \
   OFLAGS \
   SIZE \
   UNDEF \
+  BUILDTEST_MCU_GROUP \
   #
 
 # Find which variables were set using the command line or the environment and


### PR DESCRIPTION
In order to be able to run tests like

```
make buildtest BUILD_IN_DOCKER=1 BUILDTEST_MCU_GROUP=msp430
```

from the command line.