### PR TITLE
Add missing inttypes.h includes

### DIFF
--- a/core/sched.c
+++ b/core/sched.c
@@ -38,6 +38,11 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+#if ENABLE_DEBUG
+/* For PRIu16 etc. */
+#include <inttypes.h>
+#endif
+
 volatile int sched_num_threads = 0;
 
 volatile unsigned int sched_context_switch_request;

--- a/cpu/atmega_common/avr-libc-extra/inttypes.h
+++ b/cpu/atmega_common/avr-libc-extra/inttypes.h
@@ -24,10 +24,10 @@
 extern "C" {
 #endif
 
-#define PRIo64  "oll"   /**< Format string for octal 64-bit number */
-#define PRIx64  "xll"   /**< Format string for hexadecimal 64-bit number */
-#define PRIu64  "ull"   /**< Format string for unsigned 64-bit number */
-#define PRId64  "dll"   /**< Format string for signed 64-bit number */
+#define PRIo64  "llo"   /**< Format string for octal 64-bit number */
+#define PRIx64  "llx"   /**< Format string for hexadecimal 64-bit number */
+#define PRIu64  "llu"   /**< Format string for unsigned 64-bit number */
+#define PRId64  "lld"   /**< Format string for signed 64-bit number */
 
 #ifdef __cplusplus
 }

--- a/examples/ng_networking/udp.c
+++ b/examples/ng_networking/udp.c
@@ -19,6 +19,7 @@
  */
 
 #include <stdio.h>
+#include <inttypes.h>
 
 #include "kernel.h"
 #include "net/ng_netbase.h"

--- a/examples/rpl_udp/rpl.c
+++ b/examples/rpl_udp/rpl.c
@@ -20,6 +20,8 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
+
 #include "vtimer.h"
 #include "thread.h"
 #include "net_if.h"

--- a/sys/net/application_layer/ng_zep/ng_zep.c
+++ b/sys/net/application_layer/ng_zep/ng_zep.c
@@ -37,6 +37,11 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+#if ENABLE_DEBUG
+/* For PRIu16 etc. */
+#include <inttypes.h>
+#endif
+
 #define _EVENT_RX_STARTED       (1)
 #define _EVENT_RX_COMPLETE      (2)
 #define _RX_BUF_SIZE            (16U * sizeof(ng_pktsnip_t *))

--- a/sys/net/ccn_lite/ccnl-ext-appserver.c
+++ b/sys/net/ccn_lite/ccnl-ext-appserver.c
@@ -20,6 +20,8 @@
 
 #if RIOT_CCN_APPSERVER
 
+#include <inttypes.h>
+
 #include "msg.h"
 #include "thread.h"
 #include "ccnl-riot-compat.h"

--- a/sys/net/crosslayer/ng_netif/hdr/ng_netif_hdr_print.c
+++ b/sys/net/crosslayer/ng_netif/hdr/ng_netif_hdr_print.c
@@ -13,6 +13,7 @@
  */
 
 #include <stdio.h>
+#include <inttypes.h>
 
 #include "net/ng_netif.h"
 #include "net/ng_netif/hdr.h"

--- a/sys/net/link_layer/net_if/net_if.c
+++ b/sys/net/link_layer/net_if/net_if.c
@@ -26,6 +26,11 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+#if ENABLE_DEBUG
+/* For PRIu16 etc. */
+#include <inttypes.h>
+#endif
+
 net_if_t interfaces[NET_IF_MAX];
 
 #if ENABLE_DEBUG

--- a/sys/net/link_layer/ng_nomac/ng_nomac.c
+++ b/sys/net/link_layer/ng_nomac/ng_nomac.c
@@ -27,6 +27,11 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+#if ENABLE_DEBUG
+/* For PRIu16 etc. */
+#include <inttypes.h>
+#endif
+
 /**
  * @brief   Function called by the device driver on device events
  *

--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 #include <errno.h>
 #include "thread.h"
 #include "mutex.h"

--- a/sys/net/network_layer/ng_icmpv6/echo/ng_icmpv6_echo.c
+++ b/sys/net/network_layer/ng_icmpv6/echo/ng_icmpv6_echo.c
@@ -22,6 +22,11 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+#if ENABLE_DEBUG
+/* For PRIu16 etc. */
+#include <inttypes.h>
+#endif
+
 ng_pktsnip_t *ng_icmpv6_echo_build(uint8_t type, uint16_t id, uint16_t seq,
                                    uint8_t *data, size_t data_len)
 {

--- a/sys/net/network_layer/ng_ipv6/hdr/ng_ipv6_hdr_print.c
+++ b/sys/net/network_layer/ng_ipv6/hdr/ng_ipv6_hdr_print.c
@@ -13,6 +13,7 @@
  */
 
 #include <stdio.h>
+#include <inttypes.h>
 
 #include "net/ng_ipv6/hdr.h"
 

--- a/sys/net/network_layer/ng_ipv6/nc/ng_ipv6_nc.c
+++ b/sys/net/network_layer/ng_ipv6/nc/ng_ipv6_nc.c
@@ -29,6 +29,9 @@
 #include "debug.h"
 
 #if ENABLE_DEBUG
+/* For PRIu8 etc. */
+#include <inttypes.h>
+
 static char addr_str[NG_IPV6_ADDR_MAX_STR_LEN];
 #endif
 

--- a/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
+++ b/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
@@ -32,6 +32,11 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+#if ENABLE_DEBUG
+/* For PRIu16 etc. */
+#include <inttypes.h>
+#endif
+
 static ng_ipv6_netif_t ipv6_ifs[NG_NETIF_NUMOF];
 
 #if ENABLE_DEBUG

--- a/sys/net/network_layer/ng_ndp/ng_ndp.c
+++ b/sys/net/network_layer/ng_ndp/ng_ndp.c
@@ -34,7 +34,10 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#if (ENABLE_DEBUG)
+#if ENABLE_DEBUG
+/* For PRIu8 etc. */
+#include <inttypes.h>
+
 static char addr_str[NG_IPV6_ADDR_MAX_STR_LEN];
 #endif
 

--- a/sys/net/network_layer/ng_sixlowpan/frag/ng_sixlowpan_frag.c
+++ b/sys/net/network_layer/ng_sixlowpan/frag/ng_sixlowpan_frag.c
@@ -25,6 +25,11 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+#if ENABLE_DEBUG
+/* For PRIu16 etc. */
+#include <inttypes.h>
+#endif
+
 static uint16_t _tag;
 
 static inline uint16_t _floor8(uint16_t length)

--- a/sys/net/network_layer/ng_sixlowpan/ng_sixlowpan.c
+++ b/sys/net/network_layer/ng_sixlowpan/ng_sixlowpan.c
@@ -25,6 +25,11 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+#if ENABLE_DEBUG
+/* For PRIu16 etc. */
+#include <inttypes.h>
+#endif
+
 static kernel_pid_t _pid = KERNEL_PID_UNDEF;
 
 #if ENABLE_DEBUG

--- a/sys/net/network_layer/ng_sixlowpan/ng_sixlowpan_print.c
+++ b/sys/net/network_layer/ng_sixlowpan/ng_sixlowpan_print.c
@@ -13,6 +13,7 @@
  */
 
 #include <stdio.h>
+#include <inttypes.h>
 
 #include "od.h"
 #include "net/ng_ipv6/hdr.h"

--- a/sys/net/routing/aodvv2/reader.c
+++ b/sys/net/routing/aodvv2/reader.c
@@ -27,6 +27,11 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+#if ENABLE_DEBUG
+/* For PRIu16 etc. */
+#include <inttypes.h>
+#endif
+
 #define VERBOSE_DEBUG (0)
 #if VERBOSE_DEBUG
 #define VDEBUG(...) AODV_DEBUG(__VA_ARGS__)

--- a/sys/net/routing/aodvv2/routingtable.c
+++ b/sys/net/routing/aodvv2/routingtable.c
@@ -17,6 +17,9 @@
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>
  */
 
+#include <stdio.h>
+#include <inttypes.h>
+
 #include "routingtable.h"
 #include "aodv_debug.h"
 

--- a/sys/net/transport_layer/ng_udp/ng_udp_hdr_print.c
+++ b/sys/net/transport_layer/ng_udp/ng_udp_hdr_print.c
@@ -19,6 +19,7 @@
  */
 
 #include <stdio.h>
+#include <inttypes.h>
 
 #include "net/ng_udp.h"
 

--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -17,6 +17,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 #ifdef MODULE_NG_ICMPV6
 

--- a/sys/shell/commands/sc_l2_ping.c
+++ b/sys/shell/commands/sc_l2_ping.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include "l2_ping.h"
 #include "transceiver.h"

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include "thread.h"
 #include "net/ng_ipv6/addr.h"

--- a/sys/shell/commands/sc_zep.c
+++ b/sys/shell/commands/sc_zep.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 #include "net/ng_ipv6/addr.h"
 #include "net/ng_ipv6/netif.h"

--- a/tests/driver_mpu9150/main.c
+++ b/tests/driver_mpu9150/main.c
@@ -29,6 +29,7 @@
 #endif
 
 #include <stdio.h>
+#include <inttypes.h>
 
 #include "mpu9150.h"
 #include "vtimer.h"

--- a/tests/netdev/main.c
+++ b/tests/netdev/main.c
@@ -22,6 +22,7 @@
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 #ifdef MODULE_NATIVENET
 #include "nativenet.h"

--- a/tests/pthread_barrier/main.c
+++ b/tests/pthread_barrier/main.c
@@ -19,6 +19,7 @@
  */
 
 #include <stdio.h>
+#include <inttypes.h>
 
 #include "pthread.h"
 #include "random.h"

--- a/tests/vtimer_msg/main.c
+++ b/tests/vtimer_msg/main.c
@@ -21,6 +21,7 @@
 
 #include <stdio.h>
 #include <time.h>
+#include <inttypes.h>
 
 #include "vtimer.h"
 #include "thread.h"

--- a/tests/vtimer_msg_diff/Makefile
+++ b/tests/vtimer_msg_diff/Makefile
@@ -1,10 +1,6 @@
 APPLICATION = vtimer_msg_diff
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-mega2560
-# arduino-mega2560: missing define for PRId64, avr-libc's printf function
-# possibly not compatible at all
-
 BOARD_INSUFFICIENT_RAM := mbed_lpc1768 stm32f0discovery pca10000 pca10005
 
 USEMODULE += vtimer

--- a/tests/vtimer_msg_diff/main.c
+++ b/tests/vtimer_msg_diff/main.c
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 #include <time.h>
+#include <inttypes.h>
 
 #include "vtimer.h"
 #include "thread.h"


### PR DESCRIPTION
all of the printf format specifiers `PRIx32`, `PRIu8` etc are defined in `inttypes.h` which is often included implicitly through other files. This PR adds an explicit `#include <inttypes.h>` to all files using the macros for printing.

Also included is a fix for the avr port's inttypes.h wrapper which had the 64 bit format definitions accidentally defined in reverse (`ull`, `dll`, `ill` etc. instead of `llu`, `lld`, `lli`)