### PR TITLE
debug: add DEBUG_EXTRA_STACKSIZE define

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -119,6 +119,17 @@ extern "C" {
 #endif
 /** @} */
 
+/**
+ * @def DEBUG_EXTRA_STACKSIZE
+ *
+ * @brief Extra stacksize needed when ENABLE_DEBUG==1
+ */
+#if ENABLE_DEBUG
+#define DEBUG_EXTRA_STACKSIZE THREAD_EXTRA_STACKSIZE_PRINTF
+#else
+#define DEBUG_EXTRA_STACKSIZE (0)
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
When once more doing something like

```
#if ENABLE_DEBUG
static char stack[STACKSIZE + THREAD_EXTRA_STACKSIZE_PRINTF];
#else
static char stack[STACKSIZE];
#endif
```

I thought, why not put it in debug.h?
With this change, it is possible to always do
```
static char stack[STACKSIZE + DEBUG_EXTRA_STACKSIZE];
```

and the right thing will happen.