### PR TITLE
cpu/cortexm: workaround for hardfault in reset handler when -O0

### DIFF
--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -79,6 +79,9 @@ void reset_handler_default(void)
         *(dst++) = STACK_CANARY_WORD;
     }
 
+    /* Workaround for compiling without optimization: -O0 */
+    src = &_etext;
+
     /* load data section from flash to ram */
     for (dst = &_srelocate; dst < &_erelocate; ) {
         *(dst++) = *(src++);


### PR DESCRIPTION
So I wanted to debug something and tried to change back to no optimization (-O0 instead of -Os), but on my platform (samr21-xpro) it hardfaulted inside the reset handler. What happens?

```c
void reset_handler_default(void)
{
    uint32_t *dst;
    uint32_t *src = &_etext;

    for (dst = &_sstack; dst < &_estack; ) {
        *(dst++) = STACK_CANARY_WORD;
    }

    for (dst = &_srelocate; dst < &_erelocate; ) {
        *(dst++) = *(src++);
    }
````

The first for loop fills the entire (ISR?) stack with `STACK_CANARY_WORD`, so `uint32_t *src` also gets overwritten. Of course the second for loop then leads to a hardfault because `src` is dereferenced.

I guess when compiling with optimization the compiler doesn't allocate `src` on the stack so this works out, but surely fails when not using optimization.

So my solution is just a workaround. When not assigning `src = &_etext;` at the beginning but only after the first loop, it hardfaults because of other reasons. As I don't care too much about this (I wanted to debug *my* problem), I only supply a workaround. So any improvements are welcome!

How to reproduce:

```bash
$ cd tests/driver_at86rf2xx/
$ BOARD=samr21-xpro make clean
$ BOARD=samr21-xpro CFLAGS_OPT="-O0" make flash
```