### PR TITLE
cpu/cortexm_common: additional information on hardfault

### DIFF
--- a/cpu/cc2538/ldscripts/cc2538.ld
+++ b/cpu/cc2538/ldscripts/cc2538.ld
@@ -144,6 +144,10 @@ SECTIONS
     _sheap = . ;
     _eheap = ORIGIN(ram) + LENGTH(ram);
 
+    /* Populate information abour ram size */
+    _sram = ORIGIN(ram);
+    _eram = ORIGIN(ram) + LENGTH(ram);
+
     .flashcca :
     {
         KEEP(*(.flashcca))

--- a/cpu/cortexm_common/include/vectors_cortexm.h
+++ b/cpu/cortexm_common/include/vectors_cortexm.h
@@ -62,7 +62,7 @@ void nmi_default(void);
  * causes of hard faults are access to un-aligned pointers on Cortex-M0 CPUs
  * and calls of function pointers that are set to NULL.
  */
-void hard_fault_default(void);
+void hard_fault_default(void) __attribute__((naked));
 
 /* The following four exceptions are only present for Cortex-M3 and -M4 CPUs */
 #if defined(CPU_ARCH_CORTEX_M3) || defined(CPU_ARCH_CORTEX_M4) || \

--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -143,4 +143,8 @@ SECTIONS
     . = ALIGN(4);
     _sheap = . ;
     _eheap = ORIGIN(ram) + LENGTH(ram);
+
+    /* Populate information abour ram size */
+    _sram = ORIGIN(ram);
+    _eram = ORIGIN(ram) + LENGTH(ram);
 }

--- a/cpu/kinetis_common/ldscripts/kinetis.ld
+++ b/cpu/kinetis_common/ldscripts/kinetis.ld
@@ -199,6 +199,10 @@ SECTIONS
     _sheap = . ;
     _eheap = ORIGIN(sram) + LENGTH(sram);
 
+    /* Populate information abour ram size */
+    _sram = ORIGIN(sram);
+    _eram = ORIGIN(sram) + LENGTH(sram);
+
     /* Any debugging sections */
     /* Stabs debugging sections.  */
     .stab          0 : { *(.stab) }


### PR DESCRIPTION
I was so annoyed by debugging hardfaults on my platform (cortex m0+) that I added some helper for much nicer debugging. My problem always was that when the cpu goes to hardfault, I couldn't figure out where the error happened because the backtace in GDB didn't work.

This PR outputs additional information before calling `core_panic(...)`. The most useful is the value of the program counter when the exception was raised. I don't know if you want to merge this, but I wanted to share at least.

When debugging with GDB use like this:
```
# pc: 0x35e2
breakpoint *0x35e2
monitor reset halt
continue
```
Now GDB resets the cpu and stops at the instruction that caused the hardfault in the first place.

Concerning the broken backtrace in case someone is interested (and for documentary purposes for myself):

The Cortex M* architecture has 2 running modes, *Thread mode* and *Handler mode*. Both have their own stack (registers `psp` = **P**rocess sp and `msp` = **M**ain sp). Depending on the mode the cpu is in, the given stackpointer is aliased as `sp`.
RIOT runs the reset handler and every interrupt in *Handler mode* (maybe also parts of the scheduling, not sure), whereas each thread runs in *Thread mode*. That's why backtrace from inside a hardfault doesn't work.

Additionally, given that ISRs run in *Handler mode*, this is why doing crazy stuff inside a ISR leads to problems, because the main stack is not very large.