### PR TITLE
gnrc: fix possibly ommited mutex unlock in ng_ipv6_netif_init_by_dev

### DIFF
--- a/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
+++ b/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
@@ -481,6 +481,7 @@ void ng_ipv6_netif_init_by_dev(void)
 
         if ((ng_netapi_get(ifs[i], NETCONF_OPT_IPV6_IID, 0, &iid,
                            sizeof(eui64_t)) < 0)) {
+            mutex_unlock(&ipv6_if->mutex);
             continue;
         }
 


### PR DESCRIPTION
```ng_ipv6_netif_init_by_dev``` loops over devices, locking each one's ipv6 state, configuring it, then unlocking it again. But in case the device doesn't give a correct ```NETCONF_OPT_IPV6_IID``` reply, the function continues with the next device, without unlocking the current device's ipv6 mutex.