### PR TITLE
sys: add sys/uio.h header

### DIFF
--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -103,3 +103,5 @@ endif
 ifneq (,$(filter newlib,$(USEMODULE)))
     include $(RIOTBASE)/sys/newlib/Makefile.include
 endif
+
+INCLUDES += -I$(RIOTBASE)/sys/libc/include

--- a/sys/libc/include/sys/uio.h
+++ b/sys/libc/include/sys/uio.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  posix
+ * @{
+ */
+
+/**
+ * @file
+ * @brief   libc header for scatter/gather I/O
+ *
+ * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ */
+#ifndef UIO_H
+#define UIO_H
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Structure for scatter/gather I/O.
+ */
+struct iovec {
+    void *iov_base;     /**< Pointer to data.   */
+    size_t iov_len;     /**< Length of data.    */
+};
+
+#ifdef __cplusplus
+}
+#endif
+/** @} */
+#endif /* UIO_H */


### PR DESCRIPTION
The next version of netdev will use ```struct iovec``` for passing packet snippets. Unfortunately, our libc's don't have this header.

This PR adds it.