### PR TITLE
unittests: initial import of IPV6 tests

### DIFF
--- a/tests/unittests/tests-ipv6/Makefile
+++ b/tests/unittests/tests-ipv6/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-ipv6/Makefile.include
+++ b/tests/unittests/tests-ipv6/Makefile.include
@@ -1,4 +1,1 @@
 USEMODULE += gnrc_ipv6
-
-USEMODULE += gnrc_icmpv6
-USEMODULE += gnrc_ndp

--- a/tests/unittests/tests-ipv6/Makefile.include
+++ b/tests/unittests/tests-ipv6/Makefile.include
@@ -1,4 +1,4 @@
-USEMODULE += ng_ipv6
+USEMODULE += gnrc_ipv6
 
-USEMODULE += ng_icmpv6
-USEMODULE += ng_ndp
+USEMODULE += gnrc_icmpv6
+USEMODULE += gnrc_ndp

--- a/tests/unittests/tests-ipv6/Makefile.include
+++ b/tests/unittests/tests-ipv6/Makefile.include
@@ -1,0 +1,4 @@
+USEMODULE += ng_ipv6
+
+USEMODULE += ng_icmpv6
+USEMODULE += ng_ndp

--- a/tests/unittests/tests-ipv6/tests-ipv6.c
+++ b/tests/unittests/tests-ipv6/tests-ipv6.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2015 Andreas "Paul" Pauli <andreas.pauli@haw-hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+#include <errno.h>
+#include <stdint.h>
+
+#include "embUnit/embUnit.h"
+
+#include "kernel_types.h"
+#include "byteorder.h"
+
+#include "net/ng_ipv6.h"
+
+#include "unittests-constants.h"
+#include "tests-ipv6.h"
+
+
+static void set_up(void)
+{
+    ;
+}
+
+
+static void tear_down(void)
+{
+    ;
+}
+
+
+/*
+ * Tests for function "ng_ipv6_init"
+ */
+
+/*
+ * Tests normal case.
+ *
+ * Pre: No IPV6 thread has been initialized.
+ * Post: One single IPV6 thread has been initialized.
+ * ENHANCE:
+ *   - Provide check for existece of thread.
+ *   - Provide check if pid didn't exist before..
+ */
+static void test_ipv6_init__first(void)
+{
+    const char *errstr = "IPV6 not initialized";
+    kernel_pid_t retval = KERNEL_PID_UNDEF;
+
+    retval = ng_ipv6_init();
+
+    TEST_ASSERT_MESSAGE((KERNEL_PID_FIRST <= retval) &&
+                        (KERNEL_PID_LAST  >= retval),
+                        errstr);
+}
+
+/* Tests check for error condition 1
+ *
+ * Pre: IPV6 thread has already been initialized.
+ * Post: No new IPV6 thread has already been initialized.
+ * ENHANCE:
+ *   - Provide check for uniqueness of first thread.
+ */
+static void test_ipv6_init__uniq(void)
+{
+    const char *errstr = "IPV6 initialized twice";
+    kernel_pid_t retval = KERNEL_PID_UNDEF;
+
+    /*
+     * ATM the thread has been initialized in test_*__uniq.
+     */
+    retval = ng_ipv6_init();
+
+    TEST_ASSERT_MESSAGE(EEXIST == retval,
+                        errstr);
+}
+
+/* Deferred!
+ * Tests recognition for error condition 2.
+ *
+ * Pre: No IPV6 thread has been initialized and MAXTHREADS threads already
+ *       exist.
+ * Post: No IPV6 thread has been initialized.
+ * TODO:
+ *   - Remove thread from former test.
+ *   - Controlled creation of precondition.
+ */
+static void test_ipv6_init__maxthr(void)
+{
+    const char *errstr = "!Test insufficient.!";
+    kernel_pid_t retval = KERNEL_PID_UNDEF;
+
+    retval = ng_ipv6_init();
+
+    TEST_ASSERT_MESSAGE(-EOVERFLOW == retval,
+                        errstr);
+}
+
+
+/*
+ * Tests for function "ng_ipv6_init"
+ */
+
+/* Deferred!
+ * Pre: ...
+ * Post: ....
+ * TODO:
+ *   - Provide specification of function behaviour, pre- and postconditions.
+ *   - Provide (in)valid values for function parameters.
+ */
+static void test_ipv6_demux__stub1(void)
+{
+    const char *errstr = "!Test insufficient.!";
+    kernel_pid_t iface = KERNEL_PID_UNDEF;
+    ng_pktsnip_t  *pkt = NULL;
+    uint8_t         nh = 0;
+
+    iface = ng_ipv6_init();
+    ng_ipv6_demux(iface, pkt, nh);
+
+    TEST_ASSERT_MESSAGE(NULL == pkt,
+                        errstr);
+}
+
+
+Test *tests_ipv6_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_ipv6_init__first),
+                        new_TestFixture(test_ipv6_init__uniq)
+                        /* Deferred, See function comments.
+                          new_TestFixture(test_ipv6_init__maxthr),
+                          new_TestFixture(test_ipv6_demux__stub1)
+                         */
+    };
+
+    EMB_UNIT_TESTCALLER(ipv6_tests, set_up, tear_down, fixtures);
+
+    return (Test *)&ipv6_tests;
+}
+
+void tests_ipv6(void)
+{
+    TESTS_RUN(tests_ipv6_tests());
+}
+/** @} */

--- a/tests/unittests/tests-ipv6/tests-ipv6.c
+++ b/tests/unittests/tests-ipv6/tests-ipv6.c
@@ -19,7 +19,7 @@
 #include "kernel_types.h"
 #include "byteorder.h"
 
-#include "net/ng_ipv6.h"
+#include "net/gnrc/ipv6.h"
 
 #include "unittests-constants.h"
 #include "tests-ipv6.h"
@@ -38,7 +38,7 @@ static void tear_down(void)
 
 
 /*
- * Tests for function "ng_ipv6_init"
+ * Tests for function "ipv6_init"
  */
 
 /*
@@ -46,6 +46,7 @@ static void tear_down(void)
  *
  * Pre: No IPV6 thread has been initialized.
  * Post: One single IPV6 thread has been initialized.
+ * todo: Make 'test_ipv6_init__maxthr' and 'test_ipv6_demux__stub1' work.
  * ENHANCE:
  *   - Provide check for existece of thread.
  *   - Provide check if pid didn't exist before..
@@ -55,7 +56,7 @@ static void test_ipv6_init__first(void)
     const char *errstr = "IPV6 not initialized";
     kernel_pid_t retval = KERNEL_PID_UNDEF;
 
-    retval = ng_ipv6_init();
+    retval = gnrc_ipv6_init();
 
     TEST_ASSERT_MESSAGE((KERNEL_PID_FIRST <= retval) &&
                         (KERNEL_PID_LAST  >= retval),
@@ -77,11 +78,14 @@ static void test_ipv6_init__uniq(void)
     /*
      * ATM the thread has been initialized in test_*__uniq.
      */
-    retval = ng_ipv6_init();
+    retval = gnrc_ipv6_init();
 
     TEST_ASSERT_MESSAGE(EEXIST == retval,
                         errstr);
 }
+
+/* Two functions disbled temporary */
+#ifdef XYZ
 
 /* Deferred!
  * Tests recognition for error condition 2.
@@ -98,7 +102,7 @@ static void test_ipv6_init__maxthr(void)
     const char *errstr = "!Test insufficient.!";
     kernel_pid_t retval = KERNEL_PID_UNDEF;
 
-    retval = ng_ipv6_init();
+    retval = gnrc_ipv6_init();
 
     TEST_ASSERT_MESSAGE(-EOVERFLOW == retval,
                         errstr);
@@ -106,7 +110,7 @@ static void test_ipv6_init__maxthr(void)
 
 
 /*
- * Tests for function "ng_ipv6_init"
+ * Tests for function "gnrc_ipv6_init"
  */
 
 /* Deferred!
@@ -118,17 +122,19 @@ static void test_ipv6_init__maxthr(void)
  */
 static void test_ipv6_demux__stub1(void)
 {
-    const char *errstr = "!Test insufficient.!";
-    kernel_pid_t iface = KERNEL_PID_UNDEF;
-    ng_pktsnip_t  *pkt = NULL;
-    uint8_t         nh = 0;
+    const char  *errstr = "!Test insufficient.!";
+    kernel_pid_t  iface = KERNEL_PID_UNDEF;
+    gnrc_pktsnip_t *pkt = NULL;
+    uint8_t          nh = 0;
 
-    iface = ng_ipv6_init();
-    ng_ipv6_demux(iface, pkt, nh);
+    iface = gnrc_ipv6_init();
+    gnrc_ipv6_demux(iface, pkt, nh);
 
     TEST_ASSERT_MESSAGE(NULL == pkt,
                         errstr);
 }
+
+#endif
 
 
 Test *tests_ipv6_tests(void)

--- a/tests/unittests/tests-ipv6/tests-ipv6.h
+++ b/tests/unittests/tests-ipv6/tests-ipv6.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2015 Andreas "Paul" Pauli <andreas.pauli@haw-hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the ``ng_ipv6`` module
+ *
+ * @author      Andreas "Paul" Pauli <andreas.pauli@haw-hamburg.de>
+ */
+#ifndef TESTS_IPV6_H_
+#define TESTS_IPV6_H_
+
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The entry point of this test suite.
+ */
+void tests_ipv6(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_IPV6_H_ */
+/** @} */


### PR DESCRIPTION
Implemented some tests and activated 2 for now.

Some improvement + extension needed. ( e.g I ran into the same difficulties with (re-)initializing threads as in https://github.com/RIOT-OS/RIOT/pull/3307)

After rebase the "__ng__" in branch name isn't correct anymore as it's now based on _gnrc_.

Still some advice needed for creating unit preconditions and test data (See comments of test functions in _tests-ng_ipv6.c_.)
