### PR TITLE
compile_test.py / buildtest: fix output for failed boards

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -37,6 +37,7 @@ else
 buildtest:
 	@ \
 	BUILDTESTOK=true; \
+	APP_RETRY=0; \
 	rm -rf "$$BINDIRBASE"; \
 	for BOARD in $$($(MAKE) -s info-boards-supported); do \
 		RIOTNOLINK=$$(echo $(BOARD_INSUFFICIENT_RAM) | grep $${BOARD} 2>&1 >/dev/null && echo 1); \
@@ -60,12 +61,13 @@ buildtest:
 					$(MAKE) -j$(NPROC) 2>&1) ; \
 			if [ "$${?}" = "0" ]; then \
 				${COLOR_ECHO} "${COLOR_GREEN}success${COLOR_RESET}"; \
-			elif [ -n "$${RIOT_DO_RETRY}" ] && $${BUILDTESTOK} && [ $${NTH_TRY} != 3 ]; then \
+			elif [ -n "$${RIOT_DO_RETRY}" ] && [ "$${APP_RETRY}" -lt "3" ] && [ $${NTH_TRY} != 3 ]; then \
 				${COLOR_ECHO} -n "${COLOR_PURPLE}retrying${COLOR_RESET} "; \
 				continue; \
 			else \
 				${COLOR_ECHO} "${COLOR_RED}failed${COLOR_RESET}"; \
 				echo "$${LOG}" | grep -v -E '^make(\[[[:digit:]]])?:'; \
+				APP_RETRY=`expr $${APP_RETRY} + 1`; \
 				BUILDTESTOK=false; \
 			fi; \
 			break; \

--- a/dist/tools/compile_test/compile_test.py
+++ b/dist/tools/compile_test/compile_test.py
@@ -62,7 +62,7 @@ def get_lines(readline, prefix):
             continue
 
         result = result[len(prefix):].rstrip().split(' .. ')[::-1]
-        if (len(result) == 2) or (len(result) == 3 and 'retrying' in result[1]):
+        if (len(result) > 1) and ('success' in result[0] or 'failed' in result[0]):
             stdout.write('.')
             stdout.flush()
             yield (' .. '.join(result[:-1]), result[-1])
@@ -177,7 +177,6 @@ for folder in ('examples', 'tests'):
                 success.append(application)
             else:
                 failed.append(application)
-                subprocess_env.pop('RIOT_DO_RETRY', None)
         except Exception, e:
             print('\n\t\tException: {}'.format(e))
             exceptions.append(application)


### PR DESCRIPTION
This fixes #3329. Additionally, I changed the behavior slightly. Now ```buildtest``` allows up to two boards to retry and to fail until retries are disabled for the application.

The old behavior was: as soon as one board retried and failed all other boards were denied a chance to retry for the same application. 

