### PR TITLE
make: buildtests, info-buildsizes improvements

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -104,7 +104,7 @@ info-objsize:
 		sort -rnk$${SORTROW}
 
 info-buildsize:
-	@$(SIZE) -dB $(BINDIR)$(APPLICATION).elf
+	@$(SIZE) -dB $(BINDIR)$(APPLICATION).elf || echo ''
 
 info-buildsizes: SHELL=bash
 info-buildsizes:

--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -108,7 +108,7 @@ info-buildsize:
 
 info-buildsizes: SHELL=bash
 info-buildsizes:
-	echo -e "   text\t   data\t    bss\t    dec\tboard"; \
+	@echo -e "   text\t   data\t    bss\t    dec\tboard"; \
 	for BOARD in $$($(MAKE) -s info-boards-supported); do \
 		echo "$$(env -i \
 			HOME=$${HOME} \
@@ -123,7 +123,7 @@ info-buildsizes:
 
 info-buildsizes-diff: SHELL=bash
 info-buildsizes-diff:
-	echo -e "text\tdata\tbss\tdec\tBOARD/BINDIRBASE\n"; \
+	@echo -e "text\tdata\tbss\tdec\tBOARD/BINDIRBASE\n"; \
 	for BOARD in $$($(MAKE) -s info-boards-supported); do \
 		for BINDIRBASE in $${OLDBIN} $${NEWBIN}; do \
 			env -i \

--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -83,7 +83,7 @@ buildtest:
 			BINDIRBASE=$${BINDIRBASE} \
 			RIOTNOLINK=$${RIOTNOLINK} \
 			RIOT_VERSION=$${RIOT_VERSION} \
-			$(MAKE) clean 2>&1 >/dev/null || true; \
+			$(MAKE) clean-intermediates 2>&1 >/dev/null || true; \
 	done; \
 	$${BUILDTESTOK}
 endif # BUILD_IN_DOCKER

--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -143,9 +143,9 @@ info-buildsizes-diff:
 					if [[ "$${DIFF}" -gt 0 ]]; then $(COLOR_ECHO) -n "${COLOR_RED}"; fi; \
 					if [[ "$${DIFF}" -lt 0 ]]; then $(COLOR_ECHO) -n "${COLOR_GREEN}"; fi; \
 				else \
-					DIFF="$${RED}ERR"; \
+					DIFF="${COLOR_RED}ERR"; \
 				fi; \
-				echo -ne "$${DIFF}\t$${RESET}"; \
+				echo -ne "$${DIFF}\t${COLOR_RESET}"; \
 			done; \
 			echo "$${BOARD}"; \
 			for I in 0 1 2 3; do echo -ne "$${OLD[I]-${COLOR_RED}ERR${COLOR_RESET}}\t"; done; echo -e "$${OLDBIN}"; \

--- a/Makefile.include
+++ b/Makefile.include
@@ -237,6 +237,11 @@ clean:
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTBASE)/pkg/$$i clean ; done
 	-@rm -rf $(BINDIR)
 
+# Remove intermediates, but keep the .elf, .hex and .map etc.
+clean-intermediates:
+	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTBASE)/pkg/$$i clean ; done
+	-@rm -rf $(BINDIR)/*.a $(BINDIR)/*/
+
 distclean:
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTBASE)/pkg/$$i distclean ; done
 	-@rm -rf $(BINDIRBASE)


### PR DESCRIPTION
The `make info-buildsizes` target has been somewhat less useful since clean was added as a default target when doing buildtests.
This PR introduces a `clean-intermediates` target which will delete all archives and object files from the build directory but keep the elf and hex files.
`make buildtests` now calls clean-intermediates instead of clean after each platform run.
This PR also fixes a typo with the color codes in the terminal output of info-buildsizes-diff.