### PR TITLE
boards/mulle: Add fallback for PORT

### DIFF
--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -85,6 +85,10 @@ ifeq ($(PORT),)
     PORT := $(shell ls -1 /dev/tty.usbserial* | head -n 1)
   endif
 endif
+ifeq ($(PORT),)
+  # fall back to a sensible default
+  PORT := /dev/ttyUSB0
+endif
 
 # We need special handling of the watchdog if we want to speed up the flash
 # verification by using the MCU to compute the image checksum after flashing.


### PR DESCRIPTION
Fixes a problem with make buildtest if `export BOARD=mulle` was run and no USB serial device connected:

    $ export BOARD=mulle
    $ make buildtest
    Warning: no PORT set!
    Building for Warning: .. failed
    .../riot/Makefile.include:110: *** The specified board Warning: does not exist..  Stop.
    .../riot/Makefile.include:110: *** The specified board Warning: does not exist..  Stop.
    Building for no (no linking) .. failed
    .../riot/Makefile.include:110: *** The specified board no does not exist..  Stop.
    .../riot/Makefile.include:110: *** The specified board no does not exist..  Stop.
    Building for PORT .. failed
    .../riot/Makefile.include:110: *** The specified board PORT does not exist..  Stop.
    .../riot/Makefile.include:110: *** The specified board PORT does not exist..  Stop.
    Building for set! .. failed
    .../riot/Makefile.include:110: *** The specified board set! does not exist..  Stop.
    .../riot/Makefile.include:110: *** The specified board set! does not exist..  Stop.
    Building for airfy-beacon (no linking) .. ^C