### PR TITLE
Various: LTO fixes

### DIFF
--- a/Makefile.cflags
+++ b/Makefile.cflags
@@ -57,7 +57,7 @@ else
 endif
 ifeq ($(LTO),1)
   $(info Building with Link-Time-Optimizations is currently an experimental feature. Expect broken binaries.)
-  LTOFLAGS = -flto -ffat-lto-objects
+  LTOFLAGS = -flto
   CFLAGS += ${LTOFLAGS}
   LINKFLAGS += ${LTOFLAGS}
 endif

--- a/Makefile.cflags
+++ b/Makefile.cflags
@@ -56,7 +56,7 @@ else
   export LTO := 0
 endif
 ifeq ($(LTO),1)
-  $(info Building with Link-Time-Optimizations is currently an experimental feature. Expect broken binaries.)
+  $(warning Building with Link-Time-Optimizations is currently an experimental feature. Expect broken binaries.)
   LTOFLAGS = -flto
   CFLAGS += ${LTOFLAGS}
   LINKFLAGS += ${LTOFLAGS}

--- a/Makefile.cflags
+++ b/Makefile.cflags
@@ -42,7 +42,20 @@ endif
 # Unwanted flags for c++
 CXXUWFLAGS += -std=%
 
-ifeq ($(LTO),yes)
+# Translate yes/no into 1/0
+# Backwards-compatibility case to handle LTO=yes
+ifdef LTO
+  ifeq ($(LTO),yes)
+    override LTO := 1
+  endif
+  ifeq ($(LTO),no)
+    override LTO := 0
+  endif
+  export LTO
+else
+  export LTO := 0
+endif
+ifeq ($(LTO),1)
   $(info Building with Link-Time-Optimizations is currently an experimental feature. Expect broken binaries.)
   LTOFLAGS = -flto -ffat-lto-objects
   CFLAGS += ${LTOFLAGS}

--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -44,3 +44,10 @@ export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
 export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc -e reset_handler
 export OFLAGS += -j .text -j .data -O ihex
 export FFLAGS += -p m2560 -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -D -U flash:w:bin/$(BOARD)/$(PROJECT)$(APPLICATION).hex
+
+ifeq ($(LTO),1)
+  # avr-gcc <4.8.3 has a bug when using LTO which causes a warning to be printed always:
+  # '_vector_25' appears to be a misspelled signal handler [enabled by default]
+  # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59396
+  export LINKFLAGS += -Wno-error
+endif

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -14,7 +14,11 @@ USEMODULE += native-drivers
 export PREFIX =
 export CC ?= $(PREFIX)gcc
 export CXX ?= $(PREFIX)g++
-export AR ?= $(PREFIX)ar
+ifeq ($(LTO),1)
+export AR = $(PREFIX)gcc-ar
+else
+export AR = $(PREFIX)ar
+endif
 export AS ?= $(PREFIX)as
 export LINK ?= $(PREFIX)gcc
 export SIZE ?= $(PREFIX)size

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -45,7 +45,6 @@ export GPROF ?= gprof
 
 # basic cflags:
 export CFLAGS += -Wall -Wextra -pedantic
-export CFLAGS += -ffunction-sections -fdata-sections
 ifeq ($(shell uname -m),x86_64)
 export CFLAGS += -m32
 endif
@@ -76,6 +75,10 @@ export LINKFLAGS += -L $(BINDIR)
 else
 export LINKFLAGS += -ldl
 endif
+
+# clean up unused functions
+export CFLAGS += -ffunction-sections -fdata-sections
+export LINKFLAGS += -Wl,--gc-sections
 
 # set the tap interface for term/valgrind
 ifneq (,$(filter netdev2_tap,$(USEMODULE)))

--- a/boards/x86-multiboot-common/Makefile.include
+++ b/boards/x86-multiboot-common/Makefile.include
@@ -32,7 +32,11 @@ export CPU = x86
 
 # toolchain config
 export CC ?= $(PREFIX)gcc
-export AR ?= $(PREFIX)ar
+ifeq ($(LTO),1)
+export AR = $(PREFIX)gcc-ar
+else
+export AR = $(PREFIX)ar
+endif
 export AS ?= $(PREFIX)as
 export RANLIB ?= $(PREFIX)ranlib
 export LINK ?= $(RIOTBASE)/boards/x86-multiboot-common/dist/link $(PREFIX)gcc

--- a/boards/x86-multiboot-common/Makefile.include
+++ b/boards/x86-multiboot-common/Makefile.include
@@ -50,6 +50,11 @@ LINKFLAGS += -m32 -nostdlib -nostdinc -nostartfiles -nodefaultlibs \
              --prefix=$(NEWLIB_BASE) \
              -Wl,-rpath,$(NEWLIB_BASE)/lib \
              -T$(RIOTBASE)/boards/x86-multiboot-common/linker.ld
+
+# clean up unused functions
+export CFLAGS += -ffunction-sections -fdata-sections
+export LINKFLAGS += -Wl,--gc-sections
+
 UNDEF += $(BINDIR)x86-multiboot-common/startup.o
 
 BASELIBS += $(NEWLIB_BASE)/lib/libc.a \

--- a/cpu/Makefile.include.gnu
+++ b/cpu/Makefile.include.gnu
@@ -1,7 +1,11 @@
 export GDBPREFIX ?= $(PREFIX)
 export CC = $(PREFIX)gcc
 export CXX = $(PREFIX)g++
+ifeq ($(LTO),1)
+export AR = $(PREFIX)gcc-ar
+else
 export AR = $(PREFIX)ar
+endif
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size

--- a/cpu/atmega2560/startup.c
+++ b/cpu/atmega2560/startup.c
@@ -43,19 +43,20 @@ extern void __libc_init_array(void);
  * which should never be reached but just in case jumps to exit.
  * This way there should be no way to call main directly.
  */
-void init7_ovr(void) __attribute__((naked)) __attribute__((section(".init7")));
-void init8_ovr(void) __attribute__((naked)) __attribute__((section(".init8")));
+void init7_ovr(void) __attribute__((section(".init7")));
+void init8_ovr(void) __attribute__((section(".init8")));
 
 
-void init7_ovr(void)
+__attribute__((used,naked)) void init7_ovr(void)
 {
     __asm__("call reset_handler");
 }
 
-void init8_ovr(void)
+__attribute__((used,naked)) void init8_ovr(void)
 {
     __asm__("jmp exit");
 }
+
 /**
  * @brief This function is the entry point after a system reset
  *
@@ -63,7 +64,7 @@ void init8_ovr(void)
  * 1. initialize the board (sync clock, setup std-IO)
  * 2. initialize and start RIOTs kernel
  */
-void reset_handler(void)
+__attribute__((used)) void reset_handler(void)
 {
     /* initialize the board and startup the kernel */
     board_init();

--- a/cpu/lpc1768/vectors.c
+++ b/cpu/lpc1768/vectors.c
@@ -70,7 +70,7 @@ WEAK_DEFAULT void isr_qei(void);
 WEAK_DEFAULT void isr_pll1(void);
 
 /* interrupt vector table */
-__attribute__ ((section(".vectors")))
+__attribute__ ((used,section(".vectors")))
 const void *interrupt_vector[] = {
     /* Exception stack pointer */
     (void*) (&_estack),             /* pointer to the top of the stack */

--- a/cpu/x86/x86_interrupts.c
+++ b/cpu/x86/x86_interrupts.c
@@ -169,7 +169,7 @@ static void continue_after_intr(void)
 }
 
 static unsigned in_intr_handler = 0, old_intr;
-void x86_int_handler(void)
+__attribute__((used)) void x86_int_handler(void)
 {
     switch (in_intr_handler++) {
         case 0:
@@ -213,7 +213,7 @@ void x86_int_handler(void)
     __builtin_unreachable();
 }
 
-void ASM_FUN_ATTRIBUTES NORETURN x86_int_entry(void)
+__attribute__((used)) void ASM_FUN_ATTRIBUTES NORETURN x86_int_entry(void)
 {
     __asm__ volatile ("mov %eax, (4*0 + x86_interrupted_ctx)");
     __asm__ volatile ("mov %ecx, (4*1 + x86_interrupted_ctx)");
@@ -239,7 +239,7 @@ void ASM_FUN_ATTRIBUTES NORETURN x86_int_entry(void)
     __builtin_unreachable();
 }
 
-void ASM_FUN_ATTRIBUTES NORETURN x86_int_exit(void)
+__attribute__((used)) void ASM_FUN_ATTRIBUTES NORETURN x86_int_exit(void)
 {
     __asm__ volatile ("mov (4*0 + x86_interrupted_ctx), %eax");
     __asm__ volatile ("mov (4*1 + x86_interrupted_ctx), %ecx");

--- a/sys/newlib/syscalls.c
+++ b/sys/newlib/syscalls.c
@@ -66,7 +66,8 @@ void _init(void)
 /**
  * @brief Free resources on NewLib de-initialization, not used for RIOT
  */
-void _fini(void)
+/* __attribute__((used)) fixes linker errors when building with LTO, but without nano.specs */
+__attribute__((used)) void _fini(void)
 {
     /* nothing to do here */
 }


### PR DESCRIPTION
~~(based on top of #3163 and #3358)~~ - merged

This PR intends to make all modern platforms build properly with LTO.

Including:
- Add `__attribute__((used))` when necessary
- ~~Pass LTO variable to Docker container~~ - merged in #4751
- ~~Pass LTO variable to `make buildtest`~~ - merged in #4751
- Avoid fat LTO objects
- Use `gcc-ar` wrapper for building archives when building with LTO

TODO:
- [ ] Add automatic check for testing whether `-ffat-lto-objects` is needed. (Does LTO even make sense if the tools require fat LTO objects?)
- [ ] Build with Clang for all platforms where that is supported
- [x] Correct some more 0 size binaries (missing `__attribute__((used))`).
- [ ] Run extensive `info-buildsizes-diff` for comparison
