### PR TITLE
tests: add minimal test application

### DIFF
--- a/tests/minimal/Makefile
+++ b/tests/minimal/Makefile
@@ -1,0 +1,19 @@
+# name of your application
+APPLICATION = minimal
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+#
+CFLAGS += -DNDEBUG -DLOG_LEVEL=LOG_NONE
+
+#
+DISABLE_MODULE += auto_init
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/minimal/main.c
+++ b/tests/minimal/main.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     test
+ * @{
+ *
+ * @file
+ * @brief       minimal RIOT application, intended as size test
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+int main(void)
+{
+    return 0;
+}


### PR DESCRIPTION
Curious how small RIOT could get, I "wrote" this test. It tries to minimize the set of selected options and debugging output in order to get the smallest possible binary.