### PR TITLE
gnrc: remove unnecessary (and possibly dangerous) packed attributes 

### DIFF
--- a/sys/include/net/ng_ipv6/addr.h
+++ b/sys/include/net/ng_ipv6/addr.h
@@ -49,7 +49,7 @@ extern "C" {
 /**
  * @brief Data type to represent an IPv6 address.
  */
-typedef union __attribute__((packed)) {
+typedef union {
     uint8_t u8[16];             /**< devided by 16 8-bit words. */
     network_uint16_t u16[8];    /**< devided by 8 16-bit words. */
     network_uint32_t u32[4];    /**< devided by 4 32-bit words. */

--- a/sys/include/net/ng_ipv6/addr.h
+++ b/sys/include/net/ng_ipv6/addr.h
@@ -50,10 +50,10 @@ extern "C" {
  * @brief Data type to represent an IPv6 address.
  */
 typedef union {
-    uint8_t u8[16];             /**< devided by 16 8-bit words. */
-    network_uint16_t u16[8];    /**< devided by 8 16-bit words. */
-    network_uint32_t u32[4];    /**< devided by 4 32-bit words. */
-    network_uint64_t u64[2];    /**< devided by 2 64-bit words. */
+    uint8_t u8[16];             /**< divided by 16 8-bit words. */
+    network_uint16_t u16[8];    /**< divided by 8 16-bit words. */
+    network_uint32_t u32[4];    /**< divided by 4 32-bit words. */
+    network_uint64_t u64[2];    /**< divided by 2 64-bit words. */
 } ng_ipv6_addr_t;
 
 /**

--- a/sys/include/net/ng_netif/hdr.h
+++ b/sys/include/net/ng_netif/hdr.h
@@ -75,7 +75,7 @@ extern "C" {
  * The link layer addresses included in this header are put in memory directly
  * following this struct.
  */
-typedef struct __attribute__((packed)) {
+typedef struct {
     uint8_t src_l2addr_len;     /**< length of l2 source address in byte */
     uint8_t dst_l2addr_len;     /**< length of l2 destination address in byte */
     kernel_pid_t if_pid;        /**< PID of network interface */

--- a/sys/include/net/ng_pkt.h
+++ b/sys/include/net/ng_pkt.h
@@ -97,7 +97,7 @@ extern "C" {
  *          as factory.
  */
 /* packed to be aligned correctly in the static packet buffer */
-typedef struct __attribute__((packed)) ng_pktsnip {
+typedef struct ng_pktsnip {
     /**
      * @brief   Counter of threads currently having control over this packet.
      *


### PR DESCRIPTION
Does what it says on the tin.