### PR TITLE
Makefile.cflags: Add warning for LTO

### DIFF
--- a/Makefile.cflags
+++ b/Makefile.cflags
@@ -43,6 +43,7 @@ endif
 CXXUWFLAGS += -std=%
 
 ifeq ($(LTO),yes)
+  $(info Building with Link-Time-Optimizations is currently an experimental feature. Expect broken binaries.)
   LTOFLAGS = -flto -ffat-lto-objects
   CFLAGS += ${LTOFLAGS}
   LINKFLAGS += ${LTOFLAGS}


### PR DESCRIPTION
LTO is currently broken on multiple platforms. This adds a warning until #3361 is merged.