### PR TITLE
boards/Makefile.include.cortexm_common: Add TOOLCHAIN=gcc as an alias for TOOLCHAIN=gnu

### DIFF
--- a/boards/Makefile.include.cortexm_common
+++ b/boards/Makefile.include.cortexm_common
@@ -11,6 +11,12 @@ ifeq (clang,$(TOOLCHAIN))
 # opposed to one set in the environment)
 override TOOLCHAIN := llvm
 endif
+# TOOLCHAIN = gcc is an alias for TOOLCHAIN = gnu
+ifeq (gcc,$(TOOLCHAIN))
+# use override so that we can redefine a variable set on the command line (as
+# opposed to one set in the environment)
+override TOOLCHAIN := gnu
+endif
 
 export TOOLCHAIN
 


### PR DESCRIPTION
Convenience alias if the user forgets `TOOLCHAIN=gnu` and types `TOOLCHAIN=gcc` instead. To go with the already existing alias of `clang`->`llvm`