### PR TITLE
openocd: don't reset cpu for target 'debug'

### DIFF
--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -199,7 +199,7 @@ do_debug() {
             -c 'gdb_port ${GDB_PORT}' \
             -c 'init' \
             -c 'targets' \
-            -c 'reset halt' \
+            -c 'halt' \
             -l /dev/null" &
     # save PID for terminating the server afterwards
     OCD_PID=$?


### PR DESCRIPTION
When debugging my target board, the use case is usually, that I don't run my program from within gdb, but I just flash it all the time. If then something goes wrong, maybe after some time or only in rare cases, I need to attach with GDB. There is this neat shortcut `make debug`, but it resets the cpu by default. Why would you want that?

So this PR just halts the cpu but doesn't reset, giving the possibility to debug the running program. If needed, the cpu can be reset by GDB anyway.

Any thoughts?