### PR TITLE
cpu/cc430: fixed missing include in adc driver

### DIFF
--- a/cpu/cc430/cc430-adc.c
+++ b/cpu/cc430/cc430-adc.c
@@ -48,6 +48,7 @@
 
 
 #include <legacymsp430.h>
+#include "irq.h"
 #include "cpu.h"
 #include "cc430-adc.h"
 #include "hwtimer.h"


### PR DESCRIPTION
When Travis was building some unrelated PRs, it failed constantly to build for the 'chronos'. Building the default example for the chronos from the current master also failed locally. The reason was a missing `irq.h` include in the cc430's ADC driver. Should be fixed with this PR....