### PR TITLE
cpu/stm32f3: Fix Issue#3197

### DIFF
--- a/boards/nucleo-f303/include/periph_conf.h
+++ b/boards/nucleo-f303/include/periph_conf.h
@@ -120,7 +120,7 @@ extern "C" {
 /* PWM 0 device configuration */
 #define PWM_0_DEV           TIM3
 #define PWM_0_CHANNELS      4
-#define PWM_0_CLK           (36000000U)
+#define PWM_0_CLK           (72000000U)
 #define PWM_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_TIM3EN)
 #define PWM_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM3EN))
 /* PWM 0 pin configuration */

--- a/boards/stm32f3discovery/include/periph_conf.h
+++ b/boards/stm32f3discovery/include/periph_conf.h
@@ -134,7 +134,7 @@ extern "C" {
 /* PWM 1 device configuration */
 #define PWM_1_DEV           TIM4
 #define PWM_1_CHANNELS      4
-#define PWM_1_CLK           (36000000U)
+#define PWM_1_CLK           (72000000U)
 #define PWM_1_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_TIM4EN)
 #define PWM_1_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM4EN))
 /* PWM 1 pin configuration */

--- a/boards/stm32f3discovery/include/periph_conf.h
+++ b/boards/stm32f3discovery/include/periph_conf.h
@@ -119,7 +119,7 @@ extern "C" {
 /* PWM 0 device configuration */
 #define PWM_0_DEV           TIM3
 #define PWM_0_CHANNELS      4
-#define PWM_0_CLK           (36000000U)
+#define PWM_0_CLK           (72000000U)
 #define PWM_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_TIM3EN)
 #define PWM_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM3EN))
 /* PWM 0 pin configuration */


### PR DESCRIPTION
The PWM frequency is twice as high as desired on  nucleo-f303 and stm32f3discovery.
In both `periph_conf.h` the actual clock for `TIM3` is defined with wrong value, resulting in half sized clock divider in *pwm.c*.

Already tested with *nucleo-f303* board.