### PR TITLE
sys/net/network_layer/sixlowpan/ip.c: Allow unique local unicast addresses to be selected as the best source address

### DIFF
--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -772,9 +772,7 @@ void ipv6_net_if_get_best_src_addr(ipv6_addr_t *src, const ipv6_addr_t *dest)
                        (net_if_addr_t **) &addr))) {
             if (addr->ndp_state == NDP_ADDR_STATE_PREFERRED) {
                 if (!ipv6_addr_is_link_local(addr->addr_data)
-                    && !ipv6_addr_is_multicast(addr->addr_data)
-                    && !ipv6_addr_is_unique_local_unicast(
-                        addr->addr_data)) {
+                    && !ipv6_addr_is_multicast(addr->addr_data)) {
 
                     if (addr->addr_protocol == NET_IF_L3P_IPV6_PREFIX) {
                         continue;


### PR DESCRIPTION
(old network stack)

It makes no sense preferring `::1` over any unique local address when communicating with other nodes.

Without this change the node was sending ping replies to `fdfd::ff` from `::1` instead of from the node's unique local address `fdfd::5c0c:7122:7392:f27f`