### PR TITLE
sys: simplify shell

### DIFF
--- a/boards/chronos/stdio.c
+++ b/boards/chronos/stdio.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 INRIA
+ *               2015 Kaspar Schleiser <kaspar@schleiser.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -13,12 +14,14 @@
 
 /**
  * @file
- * @brief       eZ430-chronos putchar dummy implementation
+ * @brief       eZ430-chronos getchar/putchar dummy implementation
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  */
+
+#include <stdio.h>
 
 static void _dummy(int c)
 {
@@ -30,4 +33,10 @@ int putchar(int c)
 {
     _putchar(c);
     return c;
+}
+
+int getchar(void)
+{
+    /* dummy implementation */
+    return EOF;
 }

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -29,7 +29,6 @@ QUIET ?= 1
 
 # Modules to include:
 
-USEMODULE += uart0
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps

--- a/examples/default/main.c
+++ b/examples/default/main.c
@@ -26,14 +26,10 @@
 #include <string.h>
 
 #include "thread.h"
-#ifdef MODULE_NEWLIB
-#   include "uart_stdio.h"
-#else
-#   include "posix_io.h"
-#   include "board_uart0.h"
-#endif
+#include "posix_io.h"
 #include "shell.h"
 #include "shell_commands.h"
+#include "board_uart0.h"
 
 #if FEATURE_PERIPH_RTC
 #include "periph/rtc.h"
@@ -46,6 +42,7 @@
 int main(void)
 {
     shell_t shell;
+    (void) posix_open(uart0_handler_pid, 0);
 
 #ifdef MODULE_LTC4150
     ltc4150_start();
@@ -57,12 +54,7 @@ int main(void)
 
     (void) puts("Welcome to RIOT!");
 
-#ifndef MODULE_NEWLIB
-    (void) posix_open(uart0_handler_pid, 0);
     shell_init(&shell, NULL, UART0_BUFSIZE, uart0_readc, uart0_putc);
-#else
-    shell_init(&shell, NULL, UART0_BUFSIZE, getchar, putchar);
-#endif
 
     shell_run(&shell);
     return 0;

--- a/examples/default/main.c
+++ b/examples/default/main.c
@@ -26,10 +26,8 @@
 #include <string.h>
 
 #include "thread.h"
-#include "posix_io.h"
 #include "shell.h"
 #include "shell_commands.h"
-#include "board_uart0.h"
 
 #if FEATURE_PERIPH_RTC
 #include "periph/rtc.h"
@@ -41,9 +39,6 @@
 
 int main(void)
 {
-    shell_t shell;
-    (void) posix_open(uart0_handler_pid, 0);
-
 #ifdef MODULE_LTC4150
     ltc4150_start();
 #endif
@@ -54,8 +49,8 @@ int main(void)
 
     (void) puts("Welcome to RIOT!");
 
-    shell_init(&shell, NULL, UART0_BUFSIZE, uart0_readc, uart0_putc);
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
-    shell_run(&shell);
     return 0;
 }

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -28,8 +28,7 @@ USEMODULE += gnrc_rpl
 USEMODULE += gnrc_pktdump
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
-# Add also the shell, some shell commands (which are based on uart0 in this app)
-USEMODULE += uart0
+# Add also the shell, some shell commands
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps

--- a/examples/gnrc_networking/main.c
+++ b/examples/gnrc_networking/main.c
@@ -21,8 +21,6 @@
 #include <stdio.h>
 
 #include "shell.h"
-#include "board_uart0.h"
-#include "posix_io.h"
 
 extern int udp_cmd(int argc, char **argv);
 
@@ -33,15 +31,12 @@ static const shell_command_t shell_commands[] = {
 
 int main(void)
 {
-    shell_t shell;
-
     puts("RIOT network stack example application");
 
     /* start shell */
     puts("All up, running the shell now");
-    posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, shell_commands, UART0_BUFSIZE, uart0_readc, uart0_putc);
-    shell_run(&shell);
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* should be never reached */
     return 0;

--- a/examples/gnrc_networking/main.c
+++ b/examples/gnrc_networking/main.c
@@ -20,14 +20,9 @@
 
 #include <stdio.h>
 
-#include "kernel.h"
 #include "shell.h"
-#ifdef MODULE_NEWLIB
-#   include "uart_stdio.h"
-#else
-#   include "posix_io.h"
-#   include "board_uart0.h"
-#endif
+#include "board_uart0.h"
+#include "posix_io.h"
 
 extern int udp_cmd(int argc, char **argv);
 
@@ -44,12 +39,8 @@ int main(void)
 
     /* start shell */
     puts("All up, running the shell now");
-#ifndef MODULE_NEWLIB
-    (void) posix_open(uart0_handler_pid, 0);
+    posix_open(uart0_handler_pid, 0);
     shell_init(&shell, shell_commands, UART0_BUFSIZE, uart0_readc, uart0_putc);
-#else
-    shell_init(&shell, shell_commands, UART0_BUFSIZE, getchar, putchar);
-#endif
     shell_run(&shell);
 
     /* should be never reached */

--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -29,6 +29,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief Default shell buffer size (maximum line length shell can handle)
+ */
+#define SHELL_DEFAULT_BUFSIZE   (128)
+
+/**
  * @brief           Protype of a shell callback handler.
  * @details         The functions supplied to shell_init() must use this signature.
  *                  The argument list is terminated with a NULL, i.e ``argv[argc] == NULL`.
@@ -59,42 +64,15 @@ typedef struct shell_command_t {
 } shell_command_t;
 
 /**
- * @brief           The internal state of a shell session.
- * @details         Use shell_init() to initialize the datum,
- *                  and shell_run() to run the REPL session.
- */
-typedef struct shell_t {
-    const shell_command_t *command_list; /**< The commandlist supplied to shell_init(). */
-    uint16_t shell_buffer_size;          /**< The maximum line length supplied to shell_init(). */
-    int (*readchar)(void);               /**< The read function supplied to shell_init(). */
-    int (*put_char)(int);                /**< The write function supplied to shell_init(). */
-} shell_t;
-
-/**
- * @brief           Initialize a shell session state.
- * @param[out]      shell               The datum to initialize.
- * @param[in]       shell_commands      Null-terminated list of commands to understand.
- *                                      Supply `NULL` to only feature the default commands.
- * @param           shell_buffer_size   The backing buffer for the command line.
- *                                      Allocated on the stack!
- * @param           read_char           A blocking function that reads one 8-bit character at a time.
- *                                      The valid code range is [0;255].
- *                                      A value of `< 0` denotes a read error.
- * @param           put_char            Function used to print back the last read character.
- *                                      Only valid unsigned chars in [0;255] will be supplied.
- */
-void shell_init(shell_t *shell,
-                const shell_command_t *shell_commands,
-                uint16_t shell_buffer_size,
-                int (*read_char)(void),
-                int (*put_char)(int));
-
-/**
- * @brief           Start the shell session.
- * @param[in]       shell   The session that was previously initialized with shell_init().
+ * @brief           Start a shell.
+ *
+ * @param[in]       commands    ptr to array of command structs
+ * @param[in]       line_buf    Buffer that will be used for reading a line
+ * @param[in]       len         nr of bytes that fit in line_buf
+ *
  * @returns         This function does not return.
  */
-void shell_run(shell_t *shell) NORETURN;
+void shell_run(const shell_command_t *commands, char *line_buf, int len) NORETURN;
 
 #ifdef __cplusplus
 }

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009, Freie Universitaet Berlin (FUB).
  * Copyright (C) 2013, INRIA.
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -86,7 +87,7 @@ static void print_help(const shell_command_t *command_list)
     }
 }
 
-static void handle_input_line(shell_t *shell, char *line)
+static void handle_input_line(const shell_command_t *command_list, char *line)
 {
     static const char *INCORRECT_QUOTING = "shell: incorrect quoting";
 
@@ -190,13 +191,13 @@ static void handle_input_line(shell_t *shell, char *line)
     }
 
     /* then we call the appropriate handler */
-    shell_command_handler_t handler = find_handler(shell->command_list, argv[0]);
+    shell_command_handler_t handler = find_handler(command_list, argv[0]);
     if (handler != NULL) {
         handler(argc, argv);
     }
     else {
         if (strcmp("help", argv[0]) == 0) {
-            print_help(shell->command_list);
+            print_help(command_list);
         }
         else {
             printf("shell: command not found: %s\n", argv[0]);
@@ -204,7 +205,7 @@ static void handle_input_line(shell_t *shell, char *line)
     }
 }
 
-static int readline(shell_t *shell, char *buf, size_t size)
+static int readline(char *buf, size_t size)
 {
     char *line_buf_ptr = buf;
 
@@ -213,7 +214,7 @@ static int readline(shell_t *shell, char *buf, size_t size)
             return -1;
         }
 
-        int c = shell->readchar();
+        int c = getchar();
         if (c < 0) {
             return 1;
         }
@@ -223,8 +224,8 @@ static int readline(shell_t *shell, char *buf, size_t size)
         /* DOS newlines are handled like hitting enter twice, but empty lines are ignored. */
         if (c == '\r' || c == '\n') {
             *line_buf_ptr = '\0';
-            shell->put_char('\r');
-            shell->put_char('\n');
+            putchar('\r');
+            putchar('\n');
 
             /* return 1 if line is empty, 0 otherwise */
             return line_buf_ptr == buf;
@@ -238,51 +239,38 @@ static int readline(shell_t *shell, char *buf, size_t size)
 
             *--line_buf_ptr = '\0';
             /* white-tape the character */
-            shell->put_char('\b');
-            shell->put_char(' ');
-            shell->put_char('\b');
+            putchar('\b');
+            putchar(' ');
+            putchar('\b');
         }
         else {
             *line_buf_ptr++ = c;
-            shell->put_char(c);
+            putchar(c);
         }
     }
 }
 
-static inline void print_prompt(shell_t *shell)
+static inline void print_prompt(void)
 {
-    shell->put_char('>');
-    shell->put_char(' ');
+    putchar('>');
+    putchar(' ');
 
 #ifdef MODULE_NEWLIB
     fflush(stdout);
 #endif
-
-    return;
 }
 
-void shell_run(shell_t *shell)
+void shell_run(const shell_command_t *shell_commands, char *line_buf, int len)
 {
-    char line_buf[shell->shell_buffer_size];
-
-    print_prompt(shell);
+    print_prompt();
 
     while (1) {
-        int res = readline(shell, line_buf, sizeof(line_buf));
+        int res = readline(line_buf, len);
 
         if (!res) {
-            handle_input_line(shell, line_buf);
+            handle_input_line(shell_commands, line_buf);
         }
 
-        print_prompt(shell);
+        print_prompt();
     }
-}
-
-void shell_init(shell_t *shell, const shell_command_t *shell_commands,
-                uint16_t shell_buffer_size, int(*readchar)(void), int(*put_char)(int))
-{
-    shell->command_list = shell_commands;
-    shell->shell_buffer_size = shell_buffer_size;
-    shell->readchar = readchar;
-    shell->put_char = put_char;
 }

--- a/tests/driver_at86rf2xx/Makefile
+++ b/tests/driver_at86rf2xx/Makefile
@@ -65,7 +65,6 @@ USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_netif
 USEMODULE += gnrc_nomac
 USEMODULE += gnrc_pktdump
-USEMODULE += uart0
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps

--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -22,22 +22,14 @@
 
 #include "shell.h"
 #include "shell_commands.h"
-#include "posix_io.h"
-#include "board_uart0.h"
 #include "net/gnrc/pktdump.h"
 #include "net/gnrc.h"
-
-/**
- * @brief   Buffer size used by the shell
- */
-#define SHELL_BUFSIZE           (64U)
 
 /**
  * @brief   Maybe you are a golfer?!
  */
 int main(void)
 {
-    shell_t shell;
     gnrc_netreg_entry_t dump;
 
     puts("AT86RF2xx device driver test");
@@ -50,9 +42,9 @@ int main(void)
 
     /* start the shell */
     puts("Initialization successful - starting the shell now");
-    (void) posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
-    shell_run(&shell);
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -22,12 +22,8 @@
 
 #include "shell.h"
 #include "shell_commands.h"
-#ifdef MODULE_NEWLIB
-#   include "uart_stdio.h"
-#else
-#   include "posix_io.h"
-#   include "board_uart0.h"
-#endif
+#include "posix_io.h"
+#include "board_uart0.h"
 #include "net/gnrc/pktdump.h"
 #include "net/gnrc.h"
 
@@ -54,12 +50,8 @@ int main(void)
 
     /* start the shell */
     puts("Initialization successful - starting the shell now");
-#ifndef MODULE_NEWLIB
     (void) posix_open(uart0_handler_pid, 0);
     shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
-#else
-    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
-#endif
     shell_run(&shell);
 
     return 0;

--- a/tests/driver_kw2xrf/Makefile
+++ b/tests/driver_kw2xrf/Makefile
@@ -54,7 +54,6 @@ USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_netif
 USEMODULE += gnrc_nomac
 USEMODULE += gnrc_pktdump
-USEMODULE += uart0
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps

--- a/tests/driver_kw2xrf/main.c
+++ b/tests/driver_kw2xrf/main.c
@@ -21,12 +21,8 @@
 
 #include "shell.h"
 #include "shell_commands.h"
-#ifdef MODULE_NEWLIB
-#   include "uart_stdio.h"
-#else
-#   include "posix_io.h"
-#   include "board_uart0.h"
-#endif
+#include "posix_io.h"
+#include "board_uart0.h"
 #include "net/gnrc.h"
 #include "net/gnrc/pktdump.h"
 
@@ -50,13 +46,9 @@ int main(void)
 
     /* start the shell */
     puts("Initialization successful - starting the shell now");
-#ifndef MODULE_NEWLIB
     (void) posix_open(uart0_handler_pid, 0);
     shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
-#else
-    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
-#endif
-        shell_run(&shell);
+    shell_run(&shell);
 
     return 0;
 }

--- a/tests/driver_kw2xrf/main.c
+++ b/tests/driver_kw2xrf/main.c
@@ -21,19 +21,11 @@
 
 #include "shell.h"
 #include "shell_commands.h"
-#include "posix_io.h"
-#include "board_uart0.h"
 #include "net/gnrc.h"
 #include "net/gnrc/pktdump.h"
 
-/**
- * @brief   Buffer size used by the shell
- */
-#define SHELL_BUFSIZE   (64U)
-
 int main(void)
 {
-    shell_t shell;
     gnrc_netreg_entry_t dump;
 
     puts("KW2XRF device driver test");
@@ -46,9 +38,9 @@ int main(void)
 
     /* start the shell */
     puts("Initialization successful - starting the shell now");
-    (void) posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
-    shell_run(&shell);
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/driver_netdev_eth/main.c
+++ b/tests/driver_netdev_eth/main.c
@@ -34,16 +34,10 @@
 #include "dev_eth_tap.h"
 
 /**
- * @brief   Buffer size used by the shell
- */
-#define SHELL_BUFSIZE           (64U)
-
-/**
  * @brief   Maybe you are a golfer?!
  */
 int main(void)
 {
-    shell_t shell;
     gnrc_netreg_entry_t dump;
 
     puts("netdev ethernet device driver test");
@@ -60,8 +54,8 @@ int main(void)
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
 
     /* start the shell */
-    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
-    shell_run(&shell);
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/driver_nrf24l01p_lowlevel/main.c
+++ b/tests/driver_nrf24l01p_lowlevel/main.c
@@ -51,8 +51,6 @@
 
 #define TEST_RX_MSG                1
 
-#define SHELL_BUFFER_SIZE        128
-
 static int cmd_send(int argc, char **argv);
 static int cmd_print_regs(int argc, char **argv);
 static int cmd_its(int argc, char **argv);
@@ -325,14 +323,10 @@ int cmd_print_regs(int argc, char **argv)
 
 int main(void)
 {
-    shell_t shell;
-
     puts("Welcome to RIOT!");
 
-    puts("Initializing shell...");
-    shell_init(&shell, shell_commands, SHELL_BUFFER_SIZE, getchar, putchar);
-
     puts("Starting shell...");
-    shell_run(&shell);
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
     return 0;
 }

--- a/tests/driver_nrfmin/Makefile
+++ b/tests/driver_nrfmin/Makefile
@@ -6,7 +6,6 @@ FEATURES_REQUIRED = radio_nrfmin
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
-USEMODULE += uart0
 USEMODULE += radio_nrfmin
 USEMODULE += gnrc
 USEMODULE += gnrc_nomac

--- a/tests/driver_nrfmin/main.c
+++ b/tests/driver_nrfmin/main.c
@@ -21,20 +21,15 @@
 #include <stdio.h>
 
 #include "shell.h"
-#include "posix_io.h"
-#include "board_uart0.h"
 #include "nrfmin.h"
 #include "net/gnrc.h"
 #include "net/gnrc/nomac.h"
 #include "net/gnrc/pktdump.h"
 
-#define SHELL_BUFSIZE       (UART0_BUFSIZE)
-
 static char nomac_stack[THREAD_STACKSIZE_DEFAULT];
 
 int main(void)
 {
-    shell_t shell;
     gnrc_netdev_t dev;
     gnrc_netreg_entry_t netobj;
 
@@ -51,10 +46,8 @@ int main(void)
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &netobj);
 
     /* initialize and run the shell */
-    board_uart0_init();
-    posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
-    shell_run(&shell);
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/driver_nrfmin/main.c
+++ b/tests/driver_nrfmin/main.c
@@ -21,12 +21,8 @@
 #include <stdio.h>
 
 #include "shell.h"
-#ifdef MODULE_NEWLIB
-#   include "uart_stdio.h"
-#else
-#   include "posix_io.h"
-#   include "board_uart0.h"
-#endif
+#include "posix_io.h"
+#include "board_uart0.h"
 #include "nrfmin.h"
 #include "net/gnrc.h"
 #include "net/gnrc/nomac.h"
@@ -55,13 +51,9 @@ int main(void)
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &netobj);
 
     /* initialize and run the shell */
-#ifndef MODULE_NEWLIB
     board_uart0_init();
-    (void) posix_open(uart0_handler_pid, 0);
+    posix_open(uart0_handler_pid, 0);
     shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
-#else
-    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
-#endif
     shell_run(&shell);
 
     return 0;

--- a/tests/driver_pcd8544/Makefile
+++ b/tests/driver_pcd8544/Makefile
@@ -3,7 +3,6 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_gpio periph_spi
 
-USEMODULE += uart0
 USEMODULE += shell
 USEMODULE += pcd8544
 

--- a/tests/driver_pcd8544/main.c
+++ b/tests/driver_pcd8544/main.c
@@ -35,12 +35,8 @@
 #include <string.h>
 #include <stdlib.h>
 
-#ifdef MODULE_NEWLIB
-#   include "uart_stdio.h"
-#else
-#   include "posix_io.h"
-#   include "board_uart0.h"
-#endif
+#include "posix_io.h"
+#include "board_uart0.h"
 #include "shell.h"
 #include "pcd8544.h"
 
@@ -174,12 +170,8 @@ int main(void)
 
     /* run shell */
     puts("All OK, running shell now");
-#ifndef MODULE_NEWLIB
     (void) posix_open(uart0_handler_pid, 0);
     shell_init(&shell, shell_commands, SHELL_BUFSIZE, uart0_readc, uart0_putc);
-#else
-    shell_init(&shell, shell_commands, SHELL_BUFSIZE, getchar, putchar);
-#endif
     shell_run(&shell);
 
     return 0;

--- a/tests/driver_pcd8544/main.c
+++ b/tests/driver_pcd8544/main.c
@@ -35,12 +35,8 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include "posix_io.h"
-#include "board_uart0.h"
 #include "shell.h"
 #include "pcd8544.h"
-
-#define SHELL_BUFSIZE           (64U)
 
 static pcd8544_t dev;
 
@@ -158,8 +154,6 @@ static const shell_command_t shell_commands[] = {
 
 int main(void)
 {
-    shell_t shell;
-
     puts("PCD8544 LCD display test application\n");
     printf("Initializing PCD8544 LCD at SPI_%i... ", TEST_PCD8544_SPI);
     if (pcd8544_init(&dev, TEST_PCD8544_SPI, TEST_PCD8544_CS,
@@ -170,9 +164,9 @@ int main(void)
 
     /* run shell */
     puts("All OK, running shell now");
-    (void) posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, shell_commands, SHELL_BUFSIZE, uart0_readc, uart0_putc);
-    shell_run(&shell);
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/driver_xbee/main.c
+++ b/tests/driver_xbee/main.c
@@ -26,16 +26,10 @@
 #include "net/gnrc/pktdump.h"
 
 /**
- * @brief   Buffer size used by the shell
- */
-#define SHELL_BUFSIZE           (64U)
-
-/**
  * @brief   Maybe you are a golfer?!
  */
 int main(void)
 {
-    shell_t shell;
     gnrc_netreg_entry_t dump;
 
     puts("Xbee S1 device driver test");
@@ -51,8 +45,9 @@ int main(void)
 
     /* start the shell */
     puts("Initialization OK, starting shell now");
-    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
-    shell_run(&shell);
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/periph_gpio/Makefile
+++ b/tests/periph_gpio/Makefile
@@ -3,7 +3,6 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_gpio
 
-USEMODULE += uart0
 USEMODULE += shell
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -22,12 +22,8 @@
 #include <stdlib.h>
 
 #include "shell.h"
-#include "posix_io.h"
-#include "board_uart0.h"
 #include "periph/gpio.h"
 #include "hwtimer.h"
-
-#define SHELL_BUFSIZE       (64U)
 
 static void cb(void *arg)
 {
@@ -237,8 +233,6 @@ static const shell_command_t shell_commands[] = {
 
 int main(void)
 {
-    shell_t shell;
-
     puts("GPIO peripheral driver test\n");
     puts("In this test, pins are specified by integer port and pin numbers.\n"
          "So if your platform has a pin PA01, it will be port=0 and pin=1,\n"
@@ -247,9 +241,8 @@ int main(void)
          "      behavior for not existing ports/pins is not defined!");
 
     /* start the shell */
-    (void) posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, shell_commands, SHELL_BUFSIZE, uart0_readc, uart0_putc);
-    shell_run(&shell);
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -22,12 +22,8 @@
 #include <stdlib.h>
 
 #include "shell.h"
-#ifdef MODULE_NEWLIB
-#   include "uart_stdio.h"
-#else
-#   include "posix_io.h"
-#   include "board_uart0.h"
-#endif
+#include "posix_io.h"
+#include "board_uart0.h"
 #include "periph/gpio.h"
 #include "hwtimer.h"
 
@@ -251,12 +247,8 @@ int main(void)
          "      behavior for not existing ports/pins is not defined!");
 
     /* start the shell */
-#ifndef MODULE_NEWLIB
     (void) posix_open(uart0_handler_pid, 0);
     shell_init(&shell, shell_commands, SHELL_BUFSIZE, uart0_readc, uart0_putc);
-#else
-    shell_init(&shell, shell_commands, SHELL_BUFSIZE, getchar, putchar);
-#endif
     shell_run(&shell);
 
     return 0;

--- a/tests/periph_i2c/Makefile
+++ b/tests/periph_i2c/Makefile
@@ -4,6 +4,5 @@ include ../Makefile.tests_common
 FEATURES_REQUIRED = periph_i2c
 
 USEMODULE += shell
-USEMODULE += uart0
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_i2c/main.c
+++ b/tests/periph_i2c/main.c
@@ -24,8 +24,6 @@
 #include "periph_conf.h"
 #include "periph/i2c.h"
 #include "shell.h"
-#include "posix_io.h"
-#include "board_uart0.h"
 
 #define BUFSIZE        (128U)
 
@@ -306,17 +304,11 @@ static const shell_command_t shell_commands[] = {
 
 int main(void)
 {
-    shell_t shell;
-
     puts("Test for the low-level I2C driver");
 
-    /* prepare I/O for shell */
-    board_uart0_init();
-    (void) posix_open(uart0_handler_pid, 0);
-
     /* define own shell commands */
-    shell_init(&shell, shell_commands, UART0_BUFSIZE, uart0_readc, uart0_putc);
-    shell_run(&shell);
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/periph_i2c/main.c
+++ b/tests/periph_i2c/main.c
@@ -21,16 +21,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "kernel.h"
 #include "periph_conf.h"
 #include "periph/i2c.h"
 #include "shell.h"
-#ifdef MODULE_NEWLIB
-#   include "uart_stdio.h"
-#else
-#   include "posix_io.h"
-#   include "board_uart0.h"
-#endif
+#include "posix_io.h"
+#include "board_uart0.h"
 
 #define BUFSIZE        (128U)
 
@@ -315,16 +310,12 @@ int main(void)
 
     puts("Test for the low-level I2C driver");
 
-#ifndef MODULE_NEWLIB
     /* prepare I/O for shell */
     board_uart0_init();
     (void) posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, shell_commands, UART0_BUFSIZE, uart0_readc, uart0_putc);
-#else
-    shell_init(&shell, shell_commands, UART0_BUFSIZE, getchar, putchar);
-#endif
 
     /* define own shell commands */
+    shell_init(&shell, shell_commands, UART0_BUFSIZE, uart0_readc, uart0_putc);
     shell_run(&shell);
 
     return 0;

--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -29,8 +29,6 @@
 #include "periph/spi.h"
 #include "periph/gpio.h"
 
-#define SHELL_BUFSIZE       (128U)
-
 enum {
     READ = 0,
     WRITE,
@@ -288,15 +286,13 @@ static const shell_command_t shell_commands[] = {
 
 int main(void)
 {
-    shell_t shell;
-
     puts("\nRIOT low-level SPI driver test");
     puts("This application enables you to test a platforms SPI driver implementation.");
     puts("Enter 'help' to get started\n");
 
     /* run the shell */
-    shell_init(&shell, shell_commands, SHELL_BUFSIZE, getchar, putchar);
-    shell_run(&shell);
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -4,7 +4,6 @@ include ../Makefile.tests_common
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
-USEMODULE += uart0
 
 DISABLE_MODULE += auto_init
 

--- a/tests/shell/ReadMe.txt
+++ b/tests/shell/ReadMe.txt
@@ -1,15 +1,14 @@
 This application shows how to use own or the system shell commands. In order to use
 the system shell commands:
 
-1. Additionally to the module: shell, shell_commands and posix,
+1. Additionally to the module: shell, shell_commands,
    the module for the corresponding system command is to include, e.g.
    module ps for the ps command (cf. the Makefile in the application root
    directory).
-2. The shell must be initialized as follows:
-        2.1 shell_t sys_shell;
-        2.2 shell_init(&shell, shell_commands, shell_bufsize, shell_readc,
-                       shell_putchar);
-            or shell_init(&sys_shell, NULL, shell_bufsize,
-                          shell_readc, shell_putchar);
-            /* to initialize without the built-in shell commands */
-        2.3 shell_run(&sys_shell);
+2. Start the shell like this:
+    2.1 reserve buffer:
+        char line_buf[SHELL_DEFAULT_BUFSIZE];
+    2.1a run shell only with system commands:
+        shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+    2.1b run shell with provided commands in addition to system commands:
+        shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -22,11 +22,7 @@
 #include <string.h>
 
 #include "shell_commands.h"
-#include "posix_io.h"
 #include "shell.h"
-#include "board_uart0.h"
-
-#define SHELL_BUFSIZE   (UART0_BUFSIZE)
 
 static int print_teststart(int argc, char **argv)
 {
@@ -68,20 +64,16 @@ int main(void)
 
     printf("test_shell.\n");
 
-    board_uart0_init();
 
-    posix_open(uart0_handler_pid, 0);
+    /* define buffer to be used by the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
 
     /* define own shell commands */
-    shell_t shell;
-    shell_init(&shell, shell_commands, SHELL_BUFSIZE, getchar, putchar);
-    shell_run(&shell);
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* or use only system shell commands */
     /*
-    shell_t sys_shell;
-    shell_init(&sys_shell, NULL, SHELL_BUFSIZE, shell_readc, shell_putchar);
-    shell_run(&sys_shell);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
     */
 
     return 0;

--- a/tests/slip/main.c
+++ b/tests/slip/main.c
@@ -26,16 +26,10 @@
 #include "net/gnrc/pktdump.h"
 
 /**
- * @brief   Buffer size used by the shell
- */
-#define SHELL_BUFSIZE           (64U)
-
-/**
  * @brief   Maybe you are a golfer?!
  */
 int main(void)
 {
-    shell_t shell;
     gnrc_netreg_entry_t dump;
 
     puts("SLIP test");
@@ -53,8 +47,9 @@ int main(void)
 
     /* start the shell */
     puts("Initialization OK, starting shell now");
-    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
-    shell_run(&shell);
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/struct_tm_utility/Makefile
+++ b/tests/struct_tm_utility/Makefile
@@ -4,7 +4,6 @@ include ../Makefile.tests_common
 DISABLE_MODULE += auto_init
 
 USEMODULE += shell
-USEMODULE += uart0
 USEMODULE += timex
 
 # The MSP-430 toolchain lacks sscanf:

--- a/tests/struct_tm_utility/main.c
+++ b/tests/struct_tm_utility/main.c
@@ -30,11 +30,7 @@
 #include <stdbool.h>
 
 #include "shell.h"
-#include "posix_io.h"
-#include "board_uart0.h"
 #include "tm.h"
-
-#define SHELL_BUFSIZE (UART0_BUFSIZE)
 
 static const char MON_NAMES[12][3] = {
     "JAN", "FEB", "MAR", "APR",
@@ -136,14 +132,10 @@ static const shell_command_t shell_commands[] = {
 
 int main(void)
 {
-    board_uart0_init();
-    posix_open(uart0_handler_pid, 0);
-
-    shell_t shell;
-    shell_init(&shell, shell_commands, SHELL_BUFSIZE, uart0_readc, uart0_putc);
-
     puts("`struct tm` utility shell.");
-    shell_run(&shell);
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/zep/main.c
+++ b/tests/zep/main.c
@@ -26,32 +26,10 @@
 #include "net/gnrc/pktdump.h"
 
 /**
- * @brief   Buffer size used by the shell
- */
-#define SHELL_BUFSIZE           (64U)
-
-/**
- * @brief   Read chars from STDIO
- */
-int shell_read(void)
-{
-    return (int)getchar();
-}
-
-/**
- * @brief   Write chars to STDIO
- */
-void shell_put(int c)
-{
-    putchar((char)c);
-}
-
-/**
  * @brief   Maybe you are a golfer?!
  */
 int main(void)
 {
-    shell_t shell;
     gnrc_netreg_entry_t dump;
 
     puts("ZEP module test");
@@ -69,8 +47,8 @@ int main(void)
 
     /* start the shell */
     puts("Initialization OK, starting shell now");
-    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
-    shell_run(&shell);
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }


### PR DESCRIPTION
seeing multiple different types of getchar/putchar given to shell, with no actual effect as all output goes to the default stdio anyways, I've decided to get rid of the parameters.

If we one day want shells with IO other than stdio, we should implement it right and redirect stdio.

~~This is breaks all platforms not offering getchar/putchar. (WIP because of this)~~