### PR TITLE
aodvv2: tidy debug output, remove VDEBUG(), add LOG()

### DIFF
--- a/sys/net/routing/aodvv2/reader.c
+++ b/sys/net/routing/aodvv2/reader.c
@@ -33,13 +33,6 @@
 #include <inttypes.h>
 #endif
 
-#define VERBOSE_DEBUG (0)
-#if VERBOSE_DEBUG
-#define VDEBUG(...) AODV_DEBUG(__VA_ARGS__)
-#else
-#define VDEBUG(...)
-#endif
-
 static enum rfc5444_result _cb_rreq_blocktlv_addresstlvs_okay(
     struct rfc5444_reader_tlvblock_context *cont);
 static enum rfc5444_result _cb_rreq_blocktlv_messagetlvs_okay(
@@ -62,6 +55,8 @@ static enum rfc5444_result _cb_rerr_end_callback(
     struct rfc5444_reader_tlvblock_context *cont, bool dropped);
 
 /* helper functions */
+static void print_json_received_rreq(void);
+static void print_json_received_rrep(void);
 static uint8_t _get_link_cost(aodvv2_metric_t metricType);
 static uint8_t _get_max_metric(aodvv2_metric_t metricType);
 static uint8_t _get_route_cost(aodvv2_metric_t metricType, uint8_t metric);
@@ -73,7 +68,7 @@ static int num_unreachable_nodes;
 static int aodvv2_validity_t = (AODVV2_ACTIVE_INTERVAL + AODVV2_MAX_IDLETIME) * 1000; /* milliseconds */
 
 static struct rfc5444_reader reader;
-#if ENABLE_DEBUG
+#if AODV_DEBUG
 static struct netaddr_str nbuf;
 #endif
 
@@ -174,19 +169,18 @@ static struct rfc5444_reader_tlvblock_consumer_entry _rerr_address_consumer_entr
  */
 static enum rfc5444_result _cb_rreq_blocktlv_messagetlvs_okay(struct rfc5444_reader_tlvblock_context *cont)
 {
-    VDEBUG("%s()\n", __func__);
-
     if (!cont->has_hoplimit) {
-        DEBUG("\tERROR: missing hop limit\n");
+        AODV_DEBUG("\tERROR: missing hop limit\n");
         return RFC5444_DROP_PACKET;
     }
 
     packet_data.hoplimit = cont->hoplimit;
     if (packet_data.hoplimit == 0) {
-        DEBUG("\tERROR: Hoplimit is 0.\n");
+        AODV_DEBUG("\tERROR: Hoplimit is 0.\n");
         return RFC5444_DROP_PACKET;
     }
     packet_data.hoplimit--;
+
     return RFC5444_OKAY;
 }
 
@@ -198,20 +192,16 @@ static enum rfc5444_result _cb_rreq_blocktlv_messagetlvs_okay(struct rfc5444_rea
  */
 static enum rfc5444_result _cb_rreq_blocktlv_addresstlvs_okay(struct rfc5444_reader_tlvblock_context *cont)
 {
-#if ENABLE_DEBUG
+#if AODV_DEBUG
     struct netaddr_str nbuf;
 #endif
     struct rfc5444_reader_tlvblock_entry *tlv;
     bool is_origNode_addr = false;
     bool is_targNode_addr = false;
 
-    VDEBUG("%s()\n", __func__);
-    DEBUG("\taddr: %s\n", netaddr_to_string(&nbuf, &cont->addr));
-
     /* handle OrigNode SeqNum TLV */
     tlv = _rreq_rrep_address_consumer_entries[RFC5444_MSGTLV_ORIGSEQNUM].tlv;
     if (tlv) {
-        DEBUG("\ttlv RFC5444_MSGTLV_ORIGSEQNUM: %d\n", *tlv->single_value);
         is_origNode_addr = true;
         packet_data.origNode.addr = cont->addr;
         packet_data.origNode.seqnum = *tlv->single_value;
@@ -220,7 +210,6 @@ static enum rfc5444_result _cb_rreq_blocktlv_addresstlvs_okay(struct rfc5444_rea
     /* handle TargNode SeqNum TLV */
     tlv = _rreq_rrep_address_consumer_entries[RFC5444_MSGTLV_TARGSEQNUM].tlv;
     if (tlv) {
-        DEBUG("\ttlv RFC5444_MSGTLV_TARGSEQNUM: %d\n", *tlv->single_value);
         is_targNode_addr = true;
         packet_data.targNode.addr = cont->addr;
         packet_data.targNode.seqnum = *tlv->single_value;
@@ -231,7 +220,7 @@ static enum rfc5444_result _cb_rreq_blocktlv_addresstlvs_okay(struct rfc5444_rea
         packet_data.targNode.addr = cont->addr;
     }
     if (!is_origNode_addr && !is_targNode_addr) {
-        DEBUG("\tERROR: mandatory RFC5444_MSGTLV_ORIGSEQNUM TLV missing.\n");
+        AODV_DEBUG("\tERROR: mandatory RFC5444_MSGTLV_ORIGSEQNUM TLV missing.\n");
         return RFC5444_DROP_PACKET;
     }
 
@@ -241,19 +230,18 @@ static enum rfc5444_result _cb_rreq_blocktlv_addresstlvs_okay(struct rfc5444_rea
     /* cppcheck-suppress arrayIndexOutOfBounds */
     tlv = _rreq_rrep_address_consumer_entries[RFC5444_MSGTLV_METRIC].tlv;
     if (!tlv && is_origNode_addr) {
-        DEBUG("\tERROR: Missing or unknown metric TLV.\n");
+        AODV_DEBUG("\tERROR: Missing or unknown metric TLV.\n");
         return RFC5444_DROP_PACKET;
     }
     if (tlv) {
         if (!is_origNode_addr) {
-            DEBUG("\tERROR: Metric TLV belongs to wrong address.\n");
+            AODV_DEBUG("\tERROR: Metric TLV belongs to wrong address.\n");
             return RFC5444_DROP_PACKET;
         }
-        VDEBUG("\ttlv RFC5444_MSGTLV_METRIC val: %d, exttype: %d\n",
-               *tlv->single_value, tlv->type_ext);
         packet_data.metricType = tlv->type_ext;
         packet_data.origNode.metric = *tlv->single_value;
     }
+
     return RFC5444_OKAY;
 }
 
@@ -272,26 +260,29 @@ static enum rfc5444_result _cb_rreq_end_callback(
     struct aodvv2_routing_entry_t *rt_entry;
     timex_t now;
 
+    /* We've received a valid RREQ, log this. */
+    print_json_received_rreq();
+
     /* Check if packet contains the required information */
     if (dropped) {
-        DEBUG("\t Dropping packet.\n");
+        AODV_DEBUG("\t Dropping packet.\n");
         return RFC5444_DROP_PACKET;
     }
     if ((packet_data.origNode.addr._type == AF_UNSPEC) || !packet_data.origNode.seqnum) {
-        DEBUG("\tERROR: missing OrigNode Address or SeqNum. Dropping packet.\n");
+        AODV_DEBUG("\tERROR: missing OrigNode Address or SeqNum. Dropping packet.\n");
         return RFC5444_DROP_PACKET;
     }
     if (packet_data.targNode.addr._type == AF_UNSPEC) {
-        DEBUG("\tERROR: missing TargNode Address. Dropping packet.\n");
+        AODV_DEBUG("\tERROR: missing TargNode Address. Dropping packet.\n");
         return RFC5444_DROP_PACKET;
     }
     if (packet_data.hoplimit == 0) {
-        DEBUG("\tERROR: Hoplimit is 0. Dropping packet.\n");
+        AODV_DEBUG("\tERROR: Hoplimit is 0. Dropping packet.\n");
         return RFC5444_DROP_PACKET;
     }
     if ((_get_max_metric(packet_data.metricType) - _get_link_cost(packet_data.metricType))
         <= packet_data.origNode.metric) {
-        DEBUG("\tMetric Limit reached. Dropping packet.\n");
+        AODV_DEBUG("\tMetric Limit reached. Dropping packet.\n");
         return RFC5444_DROP_PACKET;
     }
 
@@ -302,7 +293,7 @@ static enum rfc5444_result _cb_rreq_end_callback(
       is taken.
     */
     if (rreqtable_is_redundant(&packet_data)) {
-        DEBUG("\tPacket is redundant. Dropping Packet. %i\n", RFC5444_DROP_PACKET);
+        AODV_DEBUG("\tPacket is redundant. Dropping Packet. %i\n", RFC5444_DROP_PACKET);
         return RFC5444_DROP_PACKET;
     }
 
@@ -339,12 +330,10 @@ static enum rfc5444_result _cb_rreq_end_callback(
         ndp_neighbor_cache_t *ndp_nc_entry = ndp_neighbor_cache_search(&sender_tmp);
 
         if (ndp_nc_entry == NULL) {
-            DEBUG("OH NOES! No bidirectional link to sender. Dropping packet.\n");
+            AODV_DEBUG("No bidirectional link to sender. Dropping packet.\n");
             return RFC5444_DROP_PACKET;
         }
         /* HACKY FIX ENDS HERE */
-
-        VDEBUG("\tCreating new Routing Table entry...\n");
 
         struct aodvv2_routing_entry_t *tmp_rt_entry = (struct aodvv2_routing_entry_t *)
                                                        malloc(sizeof(struct aodvv2_routing_entry_t));
@@ -361,12 +350,12 @@ static enum rfc5444_result _cb_rreq_end_callback(
     }
     else {
         if (!routingtable_offers_improvement(rt_entry, &packet_data.origNode)) {
-            DEBUG("\tPacket offers no improvement over known route. Dropping Packet.\n");
+            AODV_DEBUG("\tPacket offers no improvement over known route. Dropping Packet.\n");
             return RFC5444_DROP_PACKET;
         }
         /* The incoming routing information is better than existing routing
          * table information and SHOULD be used to improve the route table. */
-        VDEBUG("\tUpdating Routing Table entry...\n");
+        AODV_DEBUG("\tUpdating Routing Table entry...\n");
         routingtable_fill_routing_entry_t_rreq(&packet_data, rt_entry);
 
         /* update the FIB */
@@ -402,20 +391,19 @@ static enum rfc5444_result _cb_rreq_end_callback(
  */
 static enum rfc5444_result _cb_rrep_blocktlv_messagetlvs_okay(struct rfc5444_reader_tlvblock_context *cont)
 {
-    VDEBUG("%s()\n", __func__);
-
     if (!cont->has_hoplimit) {
-        VDEBUG("\tERROR: missing hop limit\n");
+        AODV_DEBUG("\tERROR: missing hop limit\n");
         return RFC5444_DROP_PACKET;
     }
 
     packet_data.hoplimit = cont->hoplimit;
     if (packet_data.hoplimit == 0) {
-        VDEBUG("\tERROR: Hoplimit is 0.\n");
+        AODV_DEBUG("\tERROR: Hoplimit is 0.\n");
         return RFC5444_DROP_PACKET;
     }
 
     packet_data.hoplimit--;
+
     return RFC5444_OKAY;
 }
 
@@ -427,20 +415,16 @@ static enum rfc5444_result _cb_rrep_blocktlv_messagetlvs_okay(struct rfc5444_rea
  */
 static enum rfc5444_result _cb_rrep_blocktlv_addresstlvs_okay(struct rfc5444_reader_tlvblock_context *cont)
 {
-#if ENABLE_DEBUG
-    /* cppcheck-suppress unusedVariable as nbuf is needed by VDEBUG. */
+#if AODV_DEBUG
+    /* cppcheck-suppress unusedVariable as nbuf is needed by AODV_DEBUG. */
     struct netaddr_str nbuf;
 #endif
     struct rfc5444_reader_tlvblock_entry *tlv;
     bool is_targNode_addr = false;
 
-    VDEBUG("%s()\n", __func__);
-    VDEBUG("\taddr: %s\n", netaddr_to_string(&nbuf, &cont->addr));
-
     /* handle TargNode SeqNum TLV */
     tlv = _rreq_rrep_address_consumer_entries[RFC5444_MSGTLV_TARGSEQNUM].tlv;
     if (tlv) {
-        VDEBUG("\ttlv RFC5444_MSGTLV_TARGSEQNUM: %d\n", *tlv->single_value);
         is_targNode_addr = true;
         packet_data.targNode.addr = cont->addr;
         packet_data.targNode.seqnum = *tlv->single_value;
@@ -449,13 +433,12 @@ static enum rfc5444_result _cb_rrep_blocktlv_addresstlvs_okay(struct rfc5444_rea
     /* handle OrigNode SeqNum TLV */
     tlv = _rreq_rrep_address_consumer_entries[RFC5444_MSGTLV_ORIGSEQNUM].tlv;
     if (tlv) {
-        VDEBUG("\ttlv RFC5444_MSGTLV_ORIGSEQNUM: %d\n", *tlv->single_value);
         is_targNode_addr = false;
         packet_data.origNode.addr = cont->addr;
         packet_data.origNode.seqnum = *tlv->single_value;
     }
     if (!tlv && !is_targNode_addr) {
-        DEBUG("\tERROR: mandatory SeqNum TLV missing.\n");
+        AODV_DEBUG("\tERROR: mandatory SeqNum TLV missing.\n");
         return RFC5444_DROP_PACKET;
     }
 
@@ -465,16 +448,14 @@ static enum rfc5444_result _cb_rrep_blocktlv_addresstlvs_okay(struct rfc5444_rea
     /* cppcheck-suppress arrayIndexOutOfBounds */
     tlv = _rreq_rrep_address_consumer_entries[RFC5444_MSGTLV_METRIC].tlv;
     if (!tlv && is_targNode_addr) {
-        DEBUG("\tERROR: Missing or unknown metric TLV.\n");
+        AODV_DEBUG("\tERROR: Missing or unknown metric TLV.\n");
         return RFC5444_DROP_PACKET;
     }
     if (tlv) {
         if (!is_targNode_addr) {
-            DEBUG("\tERROR: metric TLV belongs to wrong address.\n");
+            AODV_DEBUG("\tERROR: metric TLV belongs to wrong address.\n");
             return RFC5444_DROP_PACKET;
         }
-        VDEBUG("\ttlv RFC5444_MSGTLV_METRIC val: %d, exttype: %d\n",
-               *tlv->single_value, tlv->type_ext);
         packet_data.metricType = tlv->type_ext;
         packet_data.targNode.metric = *tlv->single_value;
     }
@@ -493,32 +474,33 @@ static enum rfc5444_result _cb_rrep_end_callback(
 {
     (void) cont;
 
-    VDEBUG("%s()\n", __func__);
-
     struct aodvv2_routing_entry_t *rt_entry;
-#if ENABLE_DEBUG
+#if AODV_DEBUG
     struct netaddr_str nbuf;
 #endif
     timex_t now;
 
+    /* We've received a valid RREP, log this. */
+    print_json_received_rrep();
+
     /* Check if packet contains the required information */
     if (dropped) {
-        DEBUG("\t Dropping packet.\n");
+        AODV_DEBUG("\t Dropping packet.\n");
         return RFC5444_DROP_PACKET;
     }
     if ((packet_data.origNode.addr._type == AF_UNSPEC)
         || !packet_data.origNode.seqnum) {
-        DEBUG("\tERROR: missing OrigNode Address or SeqNum. Dropping packet.\n");
+        AODV_DEBUG("\tERROR: missing OrigNode Address or SeqNum. Dropping packet.\n");
         return RFC5444_DROP_PACKET;
     }
     if ((packet_data.targNode.addr._type == AF_UNSPEC)
         || !packet_data.targNode.seqnum) {
-        DEBUG("\tERROR: missing TargNode Address or SeqNum. Dropping packet.\n");
+        AODV_DEBUG("\tERROR: missing TargNode Address or SeqNum. Dropping packet.\n");
         return RFC5444_DROP_PACKET;
     }
     if ((_get_max_metric(packet_data.metricType) - _get_link_cost(packet_data.metricType))
         <= packet_data.targNode.metric) {
-        DEBUG("\tMetric Limit reached. Dropping packet.\n");
+        AODV_DEBUG("\tMetric Limit reached. Dropping packet.\n");
         return RFC5444_DROP_PACKET;
     }
 
@@ -552,11 +534,10 @@ static enum rfc5444_result _cb_rrep_end_callback(
         ndp_neighbor_cache_t *ndp_nc_entry = ndp_neighbor_cache_search(&sender_tmp);
 
         if (ndp_nc_entry == NULL) {
-            DEBUG("OH NOES! No bidirectional link to sender. Dropping packet.\n");
+            AODV_DEBUG("No bidirectional link to sender. Dropping packet.\n");
             return RFC5444_DROP_PACKET;
         }
         /* HACKY FIX ENDS HERE */
-        VDEBUG("\tCreating new Routing Table entry...\n");
 
         struct aodvv2_routing_entry_t *tmp_rt_entry = (struct aodvv2_routing_entry_t *)
                                                        malloc(sizeof(struct aodvv2_routing_entry_t));
@@ -573,12 +554,12 @@ static enum rfc5444_result _cb_rrep_end_callback(
     }
     else {
         if (!routingtable_offers_improvement(rt_entry, &packet_data.targNode)) {
-            DEBUG("\tPacket offers no improvement over known route. Dropping Packet.\n");
+            AODV_DEBUG("\tPacket offers no improvement over known route. Dropping Packet.\n");
             return RFC5444_DROP_PACKET;
         }
         /* The incoming routing information is better than existing routing
          * table information and SHOULD be used to improve the route table. */
-        VDEBUG("\tUpdating Routing Table entry...\n");
+        AODV_DEBUG("\tUpdating Routing Table entry...\n");
         routingtable_fill_routing_entry_t_rrep(&packet_data, rt_entry);
 
         /* update the FIB */
@@ -590,13 +571,8 @@ static enum rfc5444_result _cb_rrep_end_callback(
     earlier RREQ, and RREP processing is completed.  Any packets
     buffered for OrigNode should be transmitted. */
     if (clienttable_is_client(&packet_data.origNode.addr)) {
-#if ENABLE_DEBUG
-        static struct netaddr_str nbuf2;
-#endif
-
-        DEBUG("\t{%" PRIu32 ":%" PRIu32 "} %s:  This is my RREP (SeqNum: %d). We are done here, thanks %s!\n",
-              now.seconds, now.microseconds, netaddr_to_string(&nbuf, &packet_data.origNode.addr),
-              packet_data.origNode.seqnum, netaddr_to_string(&nbuf2, &packet_data.targNode.addr));
+        AODV_DEBUG("\t%s:  This is my RREP. We are done here!\n",
+              netaddr_to_string(&nbuf, &packet_data.origNode.addr));
     }
 
     else {
@@ -611,16 +587,14 @@ static enum rfc5444_result _cb_rrep_end_callback(
 
 static enum rfc5444_result _cb_rerr_blocktlv_messagetlvs_okay(struct rfc5444_reader_tlvblock_context *cont)
 {
-    VDEBUG("%s()\n", __func__);
-
     if (!cont->has_hoplimit) {
-        VDEBUG("\tERROR: missing hop limit\n");
+        AODV_DEBUG("\tERROR: missing hop limit\n");
         return RFC5444_DROP_PACKET;
     }
 
     packet_data.hoplimit = cont->hoplimit;
     if (packet_data.hoplimit == 0) {
-        VDEBUG("\tERROR: Hoplimit is 0.\n");
+        AODV_DEBUG("\tERROR: Hoplimit is 0.\n");
         return RFC5444_DROP_PACKET;
     }
 
@@ -636,16 +610,16 @@ static enum rfc5444_result _cb_rerr_blocktlv_messagetlvs_okay(struct rfc5444_rea
 
 static enum rfc5444_result _cb_rerr_blocktlv_addresstlvs_okay(struct rfc5444_reader_tlvblock_context *cont)
 {
-#if ENABLE_DEBUG
-    /* cppcheck-suppress unusedVariable as nbuf is needed by VDEBUG. */
+#if AODV_DEBUG
+    /* cppcheck-suppress unusedVariable as nbuf is needed by AODV_DEBUG. */
     struct netaddr_str nbuf;
 #endif
     struct aodvv2_routing_entry_t *unreachable_entry;
     struct rfc5444_reader_tlvblock_entry *tlv;
 
-    VDEBUG("%s()\n", __func__);
-    VDEBUG("\tmessage type: %d\n", cont->type);
-    VDEBUG("\taddr: %s\n", netaddr_to_string(&nbuf, &cont->addr));
+    AODV_DEBUG("%s()\n", __func__);
+    AODV_DEBUG("\tmessage type: %d\n", cont->type);
+    AODV_DEBUG("\taddr: %s\n", netaddr_to_string(&nbuf, &cont->addr));
 
     /* Out of buffer size for more unreachable nodes. We're screwed, basically. */
     if (num_unreachable_nodes == AODVV2_MAX_UNREACHABLE_NODES) {
@@ -661,14 +635,14 @@ static enum rfc5444_result _cb_rerr_blocktlv_addresstlvs_okay(struct rfc5444_rea
     /* cppcheck-suppress arrayIndexOutOfBounds */
     tlv = _rerr_address_consumer_entries[RFC5444_MSGTLV_UNREACHABLE_NODE_SEQNUM].tlv;
     if (tlv) {
-        VDEBUG("\ttlv RFC5444_MSGTLV_UNREACHABLE_NODE_SEQNUM: %d\n", *tlv->single_value);
+        AODV_DEBUG("\ttlv RFC5444_MSGTLV_UNREACHABLE_NODE_SEQNUM: %d\n", *tlv->single_value);
         packet_data.origNode.seqnum = *tlv->single_value;
     }
 
     /* Check if there is an entry for unreachable node in our routing table */
     unreachable_entry = routingtable_get_entry(&packet_data.origNode.addr, packet_data.metricType);
     if (unreachable_entry) {
-        VDEBUG("\t found possibly unreachable entry.\n");
+        AODV_DEBUG("\t found possibly unreachable entry.\n");
 
         /* check if route to unreachable node has to be marked as broken and RERR has to be forwarded */
         if (netaddr_cmp(&unreachable_entry->nextHopAddr, &packet_data.sender) == 0
@@ -691,12 +665,12 @@ static enum rfc5444_result _cb_rerr_end_callback(struct rfc5444_reader_tlvblock_
     (void) cont;
 
     if (dropped) {
-        VDEBUG("\tDropping packet.\n");
+        AODV_DEBUG("\tDropping packet.\n");
         return RFC5444_DROP_PACKET;
     }
 
     if (num_unreachable_nodes == 0) {
-        VDEBUG("\tNo unreachable nodes from my routing table. Dropping Packet.\n");
+        AODV_DEBUG("\tNo unreachable nodes from my routing table. Dropping Packet.\n");
         return RFC5444_DROP_PACKET;
     }
     /* gather all unreachable nodes and put them into a RERR */
@@ -706,7 +680,7 @@ static enum rfc5444_result _cb_rerr_end_callback(struct rfc5444_reader_tlvblock_
 
 void aodv_packet_reader_init(void)
 {
-    VDEBUG("%s()\n", __func__);
+    AODV_DEBUG("%s()\n", __func__);
 
     /* initialize reader */
     rfc5444_reader_init(&reader);
@@ -734,20 +708,49 @@ void aodv_packet_reader_init(void)
 
 void aodv_packet_reader_cleanup(void)
 {
-    VDEBUG("%s()\n", __func__);
     rfc5444_reader_cleanup(&reader);
 }
 
 int aodv_packet_reader_handle_packet(void *buffer, size_t length, struct netaddr *sender)
 {
-    AODV_DEBUG("%s()\n", __func__);
     memcpy(&packet_data.sender, sender, sizeof(*sender));
-    DEBUG("\t sender: %s\n", netaddr_to_string(&nbuf, &packet_data.sender));
 
     return rfc5444_reader_handle_packet(&reader, buffer, length);
 }
 
 /*============= HELPER FUNCTIONS =============================================*/
+
+static void print_json_received_rreq(void)
+{
+#if TEST_SETUP
+    static struct netaddr_str nbuf_origaddr, nbuf_targaddr, nbuf_send;
+
+    printf("{\"log_type\": \"received_rreq\", "
+        "\"log_data\":{ \"last_hop\": \"%s\", \"orig_addr\": \"%s\", "
+        "\"orig_seqnum\": %d, \"targ_addr\": \"%s\", \"metric\": %d}}\n",
+        netaddr_to_string(&nbuf_send, &packet_data.sender),
+        netaddr_to_string(&nbuf_origaddr, &packet_data.origNode.addr),
+        packet_data.origNode.seqnum,
+        netaddr_to_string(&nbuf_targaddr, &packet_data.targNode.addr),
+        packet_data.origNode.metric);
+#endif
+}
+
+static void print_json_received_rrep(void)
+{
+#if TEST_SETUP
+    static struct netaddr_str nbuf_origaddr, nbuf_targaddr, nbuf_send;
+
+    printf("{\"log_type\": \"received_rrep\", "
+        "\"log_data\":{ \"last_hop\": \"%s\", \"orig_addr\": \"%s\", "
+        "\"orig_seqnum\": %d, \"targ_addr\": \"%s\", \"targ_seqnum\":%d}}\n",
+        netaddr_to_string(&nbuf_send, &packet_data.sender),
+        netaddr_to_string(&nbuf_origaddr, &packet_data.origNode.addr),
+        packet_data.origNode.seqnum,
+        netaddr_to_string(&nbuf_targaddr, &packet_data.targNode.addr),
+        packet_data.targNode.seqnum);
+#endif
+}
 
 /*
  * Cost(L): Get Cost of a Link regarding the specified metric.

--- a/sys/net/routing/aodvv2/routingtable.c
+++ b/sys/net/routing/aodvv2/routingtable.c
@@ -28,6 +28,7 @@
 
 /* helper functions */
 static void _reset_entry_if_stale(uint8_t i);
+static void print_json_added_rt_entry(struct aodvv2_routing_entry_t *entry);
 
 static struct aodvv2_routing_entry_t routing_table[AODVV2_MAX_ROUTING_ENTRIES];
 static timex_t null_time, max_seqnum_lifetime, active_interval, max_idletime, validity_t;
@@ -59,6 +60,8 @@ struct netaddr *routingtable_get_next_hop(struct netaddr *dest, aodvv2_metric_t 
 
 void routingtable_add_entry(struct aodvv2_routing_entry_t *entry)
 {
+    print_json_added_rt_entry(entry);
+
     /* only add if we don't already know the address */
     if (routingtable_get_entry(&(entry->addr), entry->metricType)) {
         return;
@@ -236,6 +239,32 @@ void routingtable_fill_routing_entry_t_rrep(struct aodvv2_packet_data *packet_da
     rt_entry->metricType = packet_data->metricType;
     rt_entry->metric = packet_data->targNode.metric;
     rt_entry->state = ROUTE_STATE_ACTIVE;
+}
+
+#if TEST_SETUP
+/* Write JSON representation of rt_entry to json_str */
+static void routingtable_entry_to_json(struct aodvv2_routing_entry_t *rt_entry, char* json_str)
+{
+
+    struct netaddr_str nbuf_addr, nbuf_nexthop;
+
+    sprintf(json_str,"{\"addr\": \"%s\", \"next_hop\": \"%s\", \"seqnum\": %d,"
+                     "\"metric\": %d, \"state\": %d}",
+                     netaddr_to_string(&nbuf_addr, &rt_entry->addr),
+                     netaddr_to_string(&nbuf_nexthop, &rt_entry->nextHopAddr),
+                     rt_entry->seqnum, rt_entry->metric, rt_entry->state);
+}
+#endif
+
+static void print_json_added_rt_entry(struct aodvv2_routing_entry_t *entry)
+{
+#if TEST_SETUP
+    char rt_entry_json [500];
+    routingtable_entry_to_json(entry, rt_entry_json);
+    printf("{\"log_type\": \"added_rt_entry\", \"log_data\": %s}\n", rt_entry_json);
+#else
+    (void) entry; /* silence compiler */
+#endif
 }
 
 void print_routingtable(void)


### PR DESCRIPTION
AODVv2 has a lot of (hard to read) debug output.. In order to be able to do some blackbox tests (see https://github.com/Lotterleben/aodvv2_test_blackboxtests) I decided to boil the relevant info (RREQ/RREP received with data xy, Routing table Entry added with data xy) down into JSON and tidy up the rest of the debug a bit. VDEBUG() is now gone, and all testing JSONs are printed with LOG() so they can easily be turned off and on.
This PR is still lacking proper output for RERRs, and the JSONs could be put together more elegantly than this, but it's a start... and hopefully makes the code a bit less messy.
In the interest of workload balancing, I'll assign this PR to @x3ro, but I'm not sure if I should ask @OlegHahm / @authmillenon / @cgundogan / .. “for permission”, i.e. if this is a really bad idea please shout at me? (not a pressing matter at all)