### PR TITLE
at86rf231: Set AT86RF231_MIN_CHANNEL to 0 to support AT86RF212B

### DIFF
--- a/drivers/include/at86rf231.h
+++ b/drivers/include/at86rf231.h
@@ -61,7 +61,7 @@ extern "C" {
 /**
  * @brief at86rf231's lowest supported channel
  */
-#define AT86RF231_MIN_CHANNEL       (11)
+#define AT86RF231_MIN_CHANNEL       (0)
 
 /**
  * @brief at86rf231's highest supported channel


### PR DESCRIPTION
(old network stack)
channel 0 is valid for 212b but not for 231. ng_at86rf2xx handles this in a better way, but this PR is only to enable using at86rf212b with the old stack.