### PR TITLE
pkg/libfixmath checkout fixes

### DIFF
--- a/pkg/libfixmath/Makefile
+++ b/pkg/libfixmath/Makefile
@@ -31,7 +31,7 @@ $(BINDIR)$(PKG_NAME)-src/Makefile: $(CHECKOUT_FOLDER)/svn_info.xml
 	$(AD)cd $(@D) && sed -i -e 's/1 <</(uint32_t) 1 <</g' uint32.c
 	$(AD)cd $(@D) && sed -i -e 's/is\([a-z]*\)(\*buf)/is\1((unsigned char) *buf)/g' fix16_str.c
 
-$(BINDIR)$(PKG_NAME)-unittests-src/Makefile:
+$(BINDIR)$(PKG_NAME)-unittests-src/Makefile: $(CHECKOUT_FOLDER)/svn_info.xml
 	@rm -rf $(@D)
 	@mkdir -p $(@D)
 	$(AD)cp $(CURDIR)/Makefile.template-unittests $@

--- a/pkg/libfixmath/Makefile
+++ b/pkg/libfixmath/Makefile
@@ -22,8 +22,8 @@ $(BINDIR)$(PKG_NAME)-unittests.a: $(BINDIR)$(PKG_NAME)-unittests-src/Makefile $(
 	"$(MAKE)" -C $(<D)
 
 $(BINDIR)$(PKG_NAME)-src/Makefile: $(CHECKOUT_FOLDER)/svn_info.xml
-	@rm -rf $(@D)
-	@mkdir -p $(@D)
+	$(AD)rm -rf $(@D)
+	$(AD)mkdir -p $(@D)
 	$(AD)cp $(CURDIR)/Makefile.template $@
 	$(AD)cp $(CHECKOUT_FOLDER)/libfixmath/*.[ch] $(@D)
 	$(AD)rm -f $(BINDIR)$(PKG_NAME)-src/fix16.h
@@ -32,8 +32,8 @@ $(BINDIR)$(PKG_NAME)-src/Makefile: $(CHECKOUT_FOLDER)/svn_info.xml
 	$(AD)cd $(@D) && sed -i -e 's/is\([a-z]*\)(\*buf)/is\1((unsigned char) *buf)/g' fix16_str.c
 
 $(BINDIR)$(PKG_NAME)-unittests-src/Makefile: $(CHECKOUT_FOLDER)/svn_info.xml
-	@rm -rf $(@D)
-	@mkdir -p $(@D)
+	$(AD)rm -rf $(@D)
+	$(AD)mkdir -p $(@D)
 	$(AD)cp $(CURDIR)/Makefile.template-unittests $@
 	$(AD)cp $(CHECKOUT_FOLDER)/unittests/*.[ch] $(@D)
 
@@ -46,22 +46,22 @@ $(BINDIR)$(PKG_NAME)-unittests-src/Makefile: $(CHECKOUT_FOLDER)/svn_info.xml
 	$(AD)cd $(@D) && patch -p1 --ignore-whitespace < $(CURDIR)/libfixmath-unittests-printf-format.patch
 
 $(BINDIR)$(PKG_NAME)-headers/fix16.h: $(CHECKOUT_FOLDER)/svn_info.xml
-	@rm -rf $(@D)
-	@mkdir -p $(@D)
+	$(AD)rm -rf $(@D)
+	$(AD)mkdir -p $(@D)
 	$(AD)cp $(CHECKOUT_FOLDER)/libfixmath/fix16.h $(@D)
-	@echo $(patsubst %,'extern int %(void);',$(shell for f in $(CHECKOUT_FOLDER)/unittests/*.c; do basename $${f} .c; done )) \
+	$(AD)echo $(patsubst %,'extern int %(void);',$(shell for f in $(CHECKOUT_FOLDER)/unittests/*.c; do basename $${f} .c; done )) \
 	      $(patsubst %,'%();',$(shell for f in $(CHECKOUT_FOLDER)/unittests/*.c; do basename $${f} .c; done)) | sed -e 's/;\s*/;\n/g' > $(@D)/fix16_unittests.inc
 
 $(CHECKOUT_FOLDER)/svn_info.xml:
-	@mkdir -p $(@D)
-	svn checkout -q -r $(PKG_VERSION) $(PKG_URL) $(@D)
-	@svn info --xml $(@D) > $@
+	$(AD)mkdir -p $(@D)
+	$(AD)svn checkout -q -r $(PKG_VERSION) $(PKG_URL) $(@D)
+	$(AD)svn info --xml $(@D) > $@
 
 clean::
-	rm -rf $(BINDIR)$(PKG_NAME)-src/ $(BINDIR)$(PKG_NAME)-headers/
+	$(AD)rm -rf $(BINDIR)$(PKG_NAME)-src/ $(BINDIR)$(PKG_NAME)-headers/
 
 distclean:: clean
-	rm -rf $(CHECKOUT_FOLDER)
+	$(AD)rm -rf $(CHECKOUT_FOLDER)
 
 Makefile.include:
 	@true

--- a/pkg/libfixmath/Makefile
+++ b/pkg/libfixmath/Makefile
@@ -49,8 +49,8 @@ $(BINDIR)$(PKG_NAME)-headers/fix16.h: $(CHECKOUT_FOLDER)/svn_info.xml
 	@rm -rf $(@D)
 	@mkdir -p $(@D)
 	$(AD)cp $(CHECKOUT_FOLDER)/libfixmath/fix16.h $(@D)
-	@echo $(patsubst %,'extern int %(void);',$(shell basename -a -s .c $(CHECKOUT_FOLDER)/unittests/*.c)) \
-	      $(patsubst %,'%();',$(shell basename -a -s .c $(CHECKOUT_FOLDER)/unittests/*.c)) | sed -e 's/;\s*/;\n/g' > $(@D)/fix16_unittests.inc
+	@echo $(patsubst %,'extern int %(void);',$(shell for f in $(CHECKOUT_FOLDER)/unittests/*.c; do basename $${f} .c; done )) \
+	      $(patsubst %,'%();',$(shell for f in $(CHECKOUT_FOLDER)/unittests/*.c; do basename $${f} .c; done)) | sed -e 's/;\s*/;\n/g' > $(@D)/fix16_unittests.inc
 
 $(CHECKOUT_FOLDER)/svn_info.xml:
 	@mkdir -p $(@D)

--- a/pkg/libfixmath/Makefile
+++ b/pkg/libfixmath/Makefile
@@ -54,7 +54,7 @@ $(BINDIR)$(PKG_NAME)-headers/fix16.h: $(CHECKOUT_FOLDER)/svn_info.xml
 
 $(CHECKOUT_FOLDER)/svn_info.xml:
 	@mkdir -p $(@D)
-	svn checkout -r $(PKG_VERSION) $(PKG_URL) $(@D)
+	svn checkout -q -r $(PKG_VERSION) $(PKG_URL) $(@D)
 	@svn info --xml $(@D) > $@
 
 clean::


### PR DESCRIPTION
basename -a is not supported on Travis.
Also added -q to svn command line to suppress printing each filename to stdout.