### PR TITLE
sys: fix uart0

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -244,9 +244,11 @@ void auto_init(void)
     DEBUG("Auto init vtimer module.\n");
     vtimer_init();
 #endif
+#ifndef MODULE_UART_STDIO
 #ifdef MODULE_UART0
     DEBUG("Auto init uart0 module.\n");
     board_uart0_init();
+#endif
 #endif
 #ifdef MODULE_RTC
     DEBUG("Auto init rtc module.\n");

--- a/sys/posix/posix_io.c
+++ b/sys/posix/posix_io.c
@@ -47,6 +47,9 @@ static int _posix_fileop_data(kernel_pid_t pid, int op, char *buffer, int nbytes
 
 int posix_open(int pid, int flags)
 {
+    if (pid == KERNEL_PID_UNDEF) {
+        return -1;
+    }
     return _posix_fileop((kernel_pid_t) pid, OPEN, flags);
 }
 

--- a/sys/uart0/uart0.c
+++ b/sys/uart0/uart0.c
@@ -21,6 +21,24 @@
 
 #include <stdio.h>
 
+#include "kernel_types.h"
+#include "board_uart0.h"
+
+kernel_pid_t uart0_handler_pid = KERNEL_PID_UNDEF;
+
+#ifdef MODULE_UART_STDIO
+
+#include "uart_stdio.h"
+
+void board_uart0_init(void){}
+int uart0_readc(void)
+{
+    char c = 0;
+    uart_stdio_read(&c, 1);
+    return c;
+}
+#else
+
 #include "cpu_conf.h"
 #include "chardev_thread.h"
 #include "ringbuffer.h"
@@ -28,8 +46,6 @@
 #include "msg.h"
 #include "posix_io.h"
 #include "irq.h"
-
-#include "board_uart0.h"
 
 #ifndef UART0_BUFSIZE
 #define UART0_BUFSIZE       (128)
@@ -39,7 +55,6 @@
 #define UART0_STACKSIZE     (THREAD_STACKSIZE_DEFAULT)
 
 ringbuffer_t uart0_ringbuffer;
-kernel_pid_t uart0_handler_pid = KERNEL_PID_UNDEF;
 
 static char buffer[UART0_BUFSIZE];
 
@@ -80,6 +95,7 @@ int uart0_readc(void)
     posix_read(uart0_handler_pid, &c, 1);
     return c;
 }
+#endif
 
 int uart0_putc(int c)
 {


### PR DESCRIPTION
#3161 broke newlib platforms when module_uart0 was used.

This PR bypasses uart0 to uart_stdio when the latter is linked in.

fixes #3413, tested on native, msba2, iot-lab_M3, samr21-xpro.

(uart0 must die!)