### PR TITLE
mulle: ng_at86rf2xx parameters

### DIFF
--- a/boards/mulle/Makefile.dep
+++ b/boards/mulle/Makefile.dep
@@ -4,6 +4,12 @@ ifneq (,$(filter defaulttransceiver,$(USEMODULE)))
         USEMODULE += transceiver
     endif
 endif
+
+ifneq (,$(filter ng_netif_default,$(USEMODULE)))
+  USEMODULE += ng_at86rf212b
+  USEMODULE += ng_nomac
+endif
+
 # The Mulle uses NVRAM to store persistent variables, such as boot count.
 #~ USEMODULE += nvram_spi
 # Uncomment above when #2353 is merged.

--- a/boards/mulle/include/board.h
+++ b/boards/mulle/include/board.h
@@ -104,7 +104,7 @@ typedef uint8_t radio_packet_length_t;
 #endif
 
 /**
- * @name Define the interface to the AT86RF231 radio
+ * @name Define the interface to the AT86RF212B radio
  * @{
  */
 #define AT86RF231_SPI       SPI_0
@@ -113,6 +113,7 @@ typedef uint8_t radio_packet_length_t;
 /** @todo work around missing RESET pin on Mulle v0.6x */
 #define AT86RF231_RESET     GPIO_5
 #define AT86RF231_SLEEP     GPIO_13
+#define AT86RF231_SPI_CLK   SPI_SPEED_5MHZ
 /** @} */
 
 /**

--- a/boards/mulle/include/ng_at86rf2xx_params.h
+++ b/boards/mulle/include/ng_at86rf2xx_params.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * Copyright (C) 2015 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   board_mulle
+ * @{
+ *
+ * @file
+ * @brief     at86rf231 board specific configuration
+ *
+ * @author    Kaspar Schleiser <kaspar@schleiser.de>
+ * @author    Joakim Gebart <joakim.gebart@eistec.se>
+ */
+
+#ifndef NG_AT86RF2XX_PARAMS_H_
+#define NG_AT86RF2XX_PARAMS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name AT86RF212B configuration
+ */
+static const  at86rf2xx_params_t at86rf2xx_params[] =
+    {
+        {
+            .spi = AT86RF231_SPI,
+            .spi_speed = AT86RF231_SPI_CLK,
+            .cs_pin = AT86RF231_CS,
+            .int_pin = AT86RF231_INT,
+            .sleep_pin = AT86RF231_SLEEP,
+            .reset_pin = AT86RF231_RESET,
+        },
+    };
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* NG_AT86RF2XX_PARAMS_H */
+/** @} */


### PR DESCRIPTION
I mimiced the configuration at iot-lab_M3 to set parameters for the ng_at86rf212b.
@authmillenon @haukepetersen is this the right way to configure the board for ng_networking?