### PR TITLE
auto_init: add initialization for random module

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -84,6 +84,10 @@
 #include "net/fib.h"
 #endif
 
+#ifdef MODULE_RANDOM
+#include "random.h"
+#endif
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -145,6 +149,10 @@ void auto_init(void)
 #ifdef MODULE_GNRC_UDP
     DEBUG("Auto init UDP module.\n");
     gnrc_udp_init();
+#endif
+#ifdef MODULE_RANDOM
+    DEBUG("Auto init random module.\n");
+    genrand_init(genrand_getseed());
 #endif
 
 

--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -38,6 +38,13 @@ extern "C" {
 void genrand_init(uint32_t s);
 
 /**
+ * @brief generates a random seed from hardware
+ *
+ * @return a random seed
+ */
+uint32_t genrand_get_seed(void);
+
+/**
  * @brief initialize by an array with array-length
  * init_key is the array for initializing keys
  * key_length is its length

--- a/sys/random/seed.c
+++ b/sys/random/seed.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+
+#include <stdint.h>
+#include <time.h>
+
+#include "hwtimer.h"
+#include "periph/cpuid.h"
+#include "periph/random.h"
+#include "periph/timer.h"
+
+#include "random.h"
+
+#if defined(MODULE_PERIPH_CPUID) && !defined(MODULE_PERIPH_RANDOM)
+static inline uint32_t cpuid_to_uint32()
+{
+    uint8_t cpuid[CPUID_ID_LEN], uint8_t shift = 0;
+    uint32_t res = 0;
+
+    cpuid_get(cpuid);
+    for (unsigned int i = 0; i < CPUID_ID_LEN; i++) {
+        res |= cpuid[i] << (sizeof(uint8_t) * shift);
+        shift = (shift + 1) & 0xff; /* (shift + 1) % 4  */
+    }
+
+    return res;
+}
+#endif
+
+uint32_t genrand_get_seed(void)
+{
+    uint32_t seed;
+
+#if   defined(MODULE_PERIPH_RANDOM)
+    random_init();
+    random_read((char *)(&seed), sizeof(seed));
+    random_poweroff();
+#elif defined(MODULE_PERIPH_TIMER) && defined(MODULE_PERIPH_CPUID)
+    seed = timer_read(TIMER_0) ^ cpuid_to_uint32();
+#elif defined(MODULE_PERIPH_CPUID)
+    seed = cpuid_to_uint32();
+#elif defined(MODULE_PERIPH_TIMER)
+    seed = timer_read(TIMER_0);
+#else
+    seed = (uint32_t)hwtimer_now();
+#endif
+
+    return seed;
+}
+
+/** @} */


### PR DESCRIPTION
Currently the mersenne twister in the random module does not receive an initial seed, resulting in all generated values on all devices to be the same. This tries to be at least a little bit less predictable.

Depends weakly on #3420.