### PR TITLE
board: arduino-mega2560: use uart_stdio

### DIFF
--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -12,7 +12,7 @@ export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
 export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm
-export TERMFLAGS = -b 38400 -p $(PORT)
+export TERMFLAGS = -b 9600 -p $(PORT)
 
 #define the flash-tool and default port depending on the host operating system
 OS = $(shell uname)

--- a/boards/arduino-mega2560/board.c
+++ b/boards/arduino-mega2560/board.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ *               2015 Kaspar Schleiser <kaspar@schleiser.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @brief       Board specific implementations for the Arduino Mega 2560 board
  *
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  * @}
  */

--- a/boards/arduino-mega2560/board.c
+++ b/boards/arduino-mega2560/board.c
@@ -23,25 +23,7 @@
 
 #include "board.h"
 #include "cpu.h"
-#include "periph/uart.h"
-
-#ifndef MODULE_UART0
-#include "ringbuffer.h"
-#include "mutex.h"
-#endif
-
-#ifdef MODULE_UART0
-#include "board_uart0.h"
-#endif
-
-/**
- * @brief use mutex for waiting on incoming UART chars
- */
-#ifndef MODULE_UART0
-static mutex_t uart_rx_mutex;
-static char rx_buf_mem[STDIO_RX_BUFSIZE];
-static ringbuffer_t rx_buf;
-#endif
+#include "uart_stdio.h"
 
 void led_init(void);
 void SystemInit(void);
@@ -50,30 +32,6 @@ static int uart_getchar(FILE *stream);
 
 static FILE uart_stdout = FDEV_SETUP_STREAM(uart_putchar, NULL, _FDEV_SETUP_WRITE);
 static FILE uart_stdin = FDEV_SETUP_STREAM(NULL, uart_getchar, _FDEV_SETUP_READ);
-
-
-/**
- * @brief Receive a new character from the UART and put it into the receive
- * buffer
- *
- * @param[in] data    the newly received byte
- */
-
-void rx_cb(void *arg, char data)
-{
-    LED_TOGGLE;
-#ifndef MODULE_UART0
-    ringbuffer_add_one(&rx_buf, data);
-    mutex_unlock(&uart_rx_mutex);
-#elif MODULE_UART0
-
-    if (uart0_handler_pid) {
-        uart0_handle_incoming(data);
-        uart0_notify_thread();
-    }
-
-#endif
-}
 
 void board_init(void)
 {
@@ -111,11 +69,7 @@ void led_init(void)
 void SystemInit(void)
 {
     /* initialize UART_0 for use as stdout */
-#ifndef MODULE_UART0
-    mutex_init(&uart_rx_mutex);
-    ringbuffer_init(&rx_buf, rx_buf_mem, STDIO_RX_BUFSIZE);
-#endif
-    uart_init(STDIO, STDIO_BAUDRATE, (uart_rx_cb_t) rx_cb, NULL, NULL);
+    uart_stdio_init();
 
     stdout = &uart_stdout;
     stdin = &uart_stdin;
@@ -126,23 +80,13 @@ void SystemInit(void)
 
 static int uart_putchar(char c, FILE *stream)
 {
-    uart_write_blocking(UART_0, c);
+    uart_stdio_write(&c, 1);
     return 0;
 }
 
 int uart_getchar(FILE *stream)
 {
-#ifndef MODULE_UART0
-
-    if (rx_buf.avail == 0) {
-        mutex_lock(&uart_rx_mutex);
-    }
-
-    return ringbuffer_get_one(&rx_buf);
-#else
-    LED_TOGGLE;
-    char temp;
-    temp = (char) uart0_readc();
-    return temp;
-#endif
+    char c;
+    uart_stdio_read(&c, 1);
+    return (int)c;
 }

--- a/boards/arduino-mega2560/include/board.h
+++ b/boards/arduino-mega2560/include/board.h
@@ -42,9 +42,9 @@ extern "C" {
 * @name Define UART device and baudrate for stdio
 * @{
 */
-#define STDIO UART_0
-#define STDIO_BAUDRATE (38400U)
-#define STDIO_RX_BUFSIZE (64U)
+#define STDIO               UART_0
+#define STDIO_BAUDRATE      (9600U)
+#define STDIO_RX_BUFSIZE    (64U)
 /** @} */
 
 /**

--- a/cpu/atmega2560/Makefile.include
+++ b/cpu/atmega2560/Makefile.include
@@ -3,10 +3,15 @@ export CFLAGS += -DCOREIF_NG=1
 
 # tell the build system that the CPU depends on the atmega common files
 USEMODULE += atmega_common
+
 # use hwtimer compatibility module
 USEMODULE += hwtimer_compat
+
 # export the peripheral drivers to be linked into the final binary
 export USEMODULE += periph
+
+# the atmel port uses uart_stdio
+export USEMODULE += uart_stdio
 
 # define path to atmega common module, which is needed for this CPU
 export ATMEGA_COMMON = $(RIOTCPU)/atmega_common/


### PR DESCRIPTION
This removes uart0 support and makes the port use shared uart_stdio code instead.

I don't remember where, but someone reported this patch doesn't work correctly. I don't have the board, so I can't debug. Volunteers?

~~(I marked it "waiting for other PR" as this breaks all tests that use uart0 without #3402)~~