### PR TITLE
boards/mulle: Reduce RTC crystal load capacitance

### DIFF
--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -793,8 +793,12 @@ extern "C"
 /**
  * RTC module crystal load capacitance configuration bits.
  */
-/* enable 12pF load capacitance, might need adjusting.. */
-#define RTT_LOAD_CAP_BITS   (RTC_CR_SC8P_MASK | RTC_CR_SC4P_MASK)
+/* The crystal on the Mulle is designed for 12.5 pF load capacitance. According
+ * to the data sheet, the K60 will have a 5 pF parasitic capacitance on the
+ * XTAL32/EXTAL32 connection. The board traces might give some minor parasitic
+ * capacitance as well. */
+/* enable 6pF load capacitance, might need adjusting.. */
+#define RTT_LOAD_CAP_BITS   (RTC_CR_SC4P_MASK | RTC_CR_SC2P_MASK | RTC_CR_SC1P_MASK)
 /** @} */
 
 


### PR DESCRIPTION
The old value was too big.

The crystal on the Mulle is designed for 12.5 pF load capacitance. According to the data sheet, the K60 will have a 5 pF parasitic capacitance on the XTAL32/EXTAL32 connection. The board traces might give some minor parasitic capacitance as well.

New value 7pF (configured) + 5 pF (parasitic) + 0.x pF (board traces)

The board traces are 8 mm long (4 mm + 4 mm) according to the PCB layout program.