### PR TITLE
fib: fixed wrong passed destination address size and return value

### DIFF
--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -314,7 +314,8 @@ static int fib_signal_rp(uint8_t *dst, size_t dst_size, uint32_t dst_flags)
                   msg.content.ptr, (int)i, (int)notify_rp[i]);
 
             /* do only signal a RP if its registered prefix matches */
-            if (universal_address_compare(prefix_rp[i], dst, &dst_size) == 0) {
+            size_t dst_size_in_bits = dst_size<<3;
+            if (universal_address_compare(prefix_rp[i], dst, &dst_size_in_bits) == 1) {
                 /* the receiver, i.e. the RP, MUST copy the content value.
                  * using the provided pointer after replying this message
                  * will lead to errors


### PR DESCRIPTION
Fix to determine if a prefix matches the searched destination address.

Rationale: 
Notifying a RP about an  unknown destination has
1. used a wrong calculated size of the searched destination, i.e. `universal_address_compare()` requires the size in bits not in bytes
2. interpreted the wrong return value, since `0` indicates equal addresses, but we have a prefix and probably a  matching address handled by the registered prefix, (indicated by `1`)

which prevented the FIB to signal a RP. 

~~waiting for #3233 to provide proper determination of the significant prefix bits.~~ <- merged

