### PR TITLE
sys: shell: commands: fix NG_NETIF_NUMOF related compile warning

### DIFF
--- a/sys/shell/commands/sc_ipv6_nc.c
+++ b/sys/shell/commands/sc_ipv6_nc.c
@@ -90,7 +90,7 @@ static bool _is_iface(kernel_pid_t iface)
     kernel_pid_t ifs[NG_NETIF_NUMOF];
     size_t numof = ng_netif_get(ifs);
 
-    for (size_t i = 0; i < numof; i++) {
+    for (size_t i = 0; i < numof && i < NG_NETIF_NUMOF; i++) {
         if (ifs[i] == iface) {
             return true;
         }

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -56,7 +56,7 @@ static bool _is_iface(kernel_pid_t dev)
     kernel_pid_t ifs[NG_NETIF_NUMOF];
     size_t numof = ng_netif_get(ifs);
 
-    for (size_t i = 0; i < numof; i++) {
+    for (size_t i = 0; i < numof && i < NG_NETIF_NUMOF; i++) {
         if (ifs[i] == dev) {
             return true;
         }
@@ -704,7 +704,7 @@ int _netif_config(int argc, char **argv)
         kernel_pid_t ifs[NG_NETIF_NUMOF];
         size_t numof = ng_netif_get(ifs);
 
-        for (size_t i = 0; i < numof; i++) {
+        for (size_t i = 0; i < numof && i < NG_NETIF_NUMOF; i++) {
             _netif_list(ifs[i]);
         }
 


### PR DESCRIPTION
Fixes some errors like:

```
"make" -C /home/kaspar/src/riot.10/sys/shell/commands
/home/kaspar/src/riot.10/sys/shell/commands/sc_netif.c: In function '_netif_send':
/home/kaspar/src/riot.10/sys/shell/commands/sc_netif.c:60:16: error: array subscript is above array bounds [-Werror=array-bounds]
         if (ifs[i] == dev) {
                ^
/home/kaspar/src/riot.10/sys/shell/commands/sc_netif.c: In function '_netif_config':
/home/kaspar/src/riot.10/sys/shell/commands/sc_netif.c:708:13: error: array subscript is above array bounds [-Werror=array-bounds]
             _netif_list(ifs[i]);
             ^
/home/kaspar/src/riot.10/sys/shell/commands/sc_netif.c:60:16: error: array subscript is above array bounds [-Werror=array-bounds]
         if (ifs[i] == dev) {
                ^
cc1: all warnings being treated as errors
/home/kaspar/src/riot.10/Makefile.base:60: recipe for target '/home/kaspar/src/riot.10/examples/ng_networking/bin/samr21-xpro/shell_commands/sc_netif.o' failed
```

... by adding a safety condition to some for loops.