### PR TITLE
fib: check dst and next_hop for invalid pointers

### DIFF
--- a/sys/include/net/ng_fib.h
+++ b/sys/include/net/ng_fib.h
@@ -93,6 +93,7 @@ int fib_register_rp(uint8_t *prefix, size_t prefix_size);
  *
  * @return 0 on success
  *         -ENOMEM if the entry cannot be created due to insufficient RAM
+ *         -EFAULT if dst and/or next_hop is not a valid pointer
  */
 int fib_add_entry(kernel_pid_t iface_id, uint8_t *dst, size_t dst_size, uint32_t dst_flags,
                   uint8_t *next_hop, size_t next_hop_size, uint32_t next_hop_flags,
@@ -110,6 +111,7 @@ int fib_add_entry(kernel_pid_t iface_id, uint8_t *dst, size_t dst_size, uint32_t
  *
  * @return 0 on success
  *         -ENOMEM if the entry cannot be updated due to insufficient RAM
+ *         -EFAULT if dst and/or next_hop is not a valid pointer
  */
 int fib_update_entry(uint8_t *dst, size_t dst_size,
                      uint8_t *next_hop, size_t next_hop_size, uint32_t next_hop_flags,
@@ -139,7 +141,8 @@ void fib_remove_entry(uint8_t *dst, size_t dst_size);
  *         -EHOSTUNREACH if no next hop is available in any FIB table
  *                                           all RRPs are notified before the return
  *         -ENOBUFS if the size for the next hop address is insufficient low
- *         -EINVAL if one of the passed out pointers is NULL
+ *         -EFAULT if dst and/or next_hop is not a valid pointer
+ *         -EINVAL if one of the other passed out pointers is NULL
  */
 int fib_get_next_hop(kernel_pid_t *iface_id,
                      uint8_t *next_hop, size_t *next_hop_size, uint32_t* next_hop_flags,

--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -338,6 +338,12 @@ int fib_add_entry(kernel_pid_t iface_id, uint8_t *dst, size_t dst_size, uint32_t
     size_t count = 1;
     fib_entry_t *entry[count];
 
+    /* check if dst and next_hop are valid pointers */
+    if ((dst == NULL) || (next_hop == NULL)) {
+        mutex_unlock(&mtx_access);
+        return -EFAULT;
+    }
+
     int ret = fib_find_entry(dst, dst_size, &(entry[0]), &count);
 
     if (ret == 1) {
@@ -362,6 +368,12 @@ int fib_update_entry(uint8_t *dst, size_t dst_size,
     size_t count = 1;
     fib_entry_t *entry[count];
     int ret = -ENOMEM;
+
+    /* check if dst and next_hop are valid pointers */
+    if ((dst == NULL) || (next_hop == NULL)) {
+        mutex_unlock(&mtx_access);
+        return -EFAULT;
+    }
 
     if (fib_find_entry(dst, dst_size, &(entry[0]), &count) == 1) {
         DEBUG("[fib_update_entry] found entry: %p\n", (void *)(entry[0]));
@@ -411,14 +423,17 @@ int fib_get_next_hop(kernel_pid_t *iface_id,
     size_t count = 1;
     fib_entry_t *entry[count];
 
-    if( iface_id == NULL
-        || next_hop == NULL
-        || next_hop_size == NULL
-        || next_hop_flags == NULL
-        || dst == NULL) {
+    if ((iface_id == NULL)
+        || (next_hop_size == NULL)
+        || (next_hop_flags == NULL)) {
             mutex_unlock(&mtx_access);
             return -EINVAL;
         }
+
+    if ((dst == NULL) || (next_hop == NULL)) {
+        mutex_unlock(&mtx_access);
+        return -EFAULT;
+    }
 
     int ret = fib_find_entry(dst, dst_size, &(entry[0]), &count);
     if (!(ret == 0 || ret == 1)) {


### PR DESCRIPTION
``fib_add_entry()`` doesn't check if ``dst`` and ``next_hop`` are actually valid pointers, which causes https://github.com/RIOT-OS/RIOT/blob/master/sys/net/network_layer/ng_ndp/ng_ndp.c#L480 to fail (preventing packets from being sent), which in turn caused me to swear a lot :D This PR fixes this for ``fib_add_entry`` and while I was at it I also added checks for the other functions, I'm not sure if that's overkill?