### PR TITLE
sys/trickle: remove unneccessary rpl.h include

### DIFF
--- a/sys/trickle/trickle.c
+++ b/sys/trickle/trickle.c
@@ -19,7 +19,6 @@
 
 #include "inttypes.h"
 #include "trickle.h"
-#include "rpl.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"


### PR DESCRIPTION
this is wrong.