### PR TITLE
native: Take care of cleaning up networking properly on reboot

### DIFF
--- a/cpu/native/include/dev_eth_tap.h
+++ b/cpu/native/include/dev_eth_tap.h
@@ -53,6 +53,13 @@ extern dev_eth_tap_t dev_eth_tap;
  */
 void dev_eth_tap_setup(dev_eth_tap_t *dev, const char *name);
 
+/**
+ * @brief Cleanup dev_eth_tap_t structure.
+ *
+ * @param dev  the dev_eth_tap device handle to cleanup
+ */
+void dev_eth_tap_cleanup(dev_eth_tap_t *dev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/native/include/tap.h
+++ b/cpu/native/include/tap.h
@@ -36,7 +36,11 @@ extern "C" {
  */
 int tap_init(char *name);
 
-extern int _native_tap_fd;
+/**
+ * Close tap device
+ */
+void tap_cleanup(void);
+
 extern unsigned char _native_tap_mac[ETHER_ADDR_LEN];
 
 struct nativenet_header {

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -51,6 +51,10 @@
 #ifdef MODULE_NATIVENET
 #include "tap.h"
 #endif
+#ifdef MODULE_NG_NATIVENET
+#include "dev_eth_tap.h"
+extern dev_eth_tap_t dev_eth_tap;
+#endif
 
 #include "native_internal.h"
 
@@ -74,6 +78,9 @@ int reboot_arch(int mode)
 #endif
 #ifdef MODULE_NATIVENET
     tap_cleanup();
+#endif
+#ifdef MODULE_NG_NATIVENET
+    dev_eth_tap_cleanup(&dev_eth_tap);
 #endif
 
     if (real_execve(_native_argv[0], _native_argv, NULL) == -1) {

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -73,9 +73,7 @@ int reboot_arch(int mode)
     /* TODO: close stdio fds */
 #endif
 #ifdef MODULE_NATIVENET
-    if (_native_tap_fd != -1) {
-        real_close(_native_tap_fd);
-    }
+    tap_cleanup();
 #endif
 
     if (real_execve(_native_argv[0], _native_argv, NULL) == -1) {

--- a/cpu/native/net/tap.c
+++ b/cpu/native/net/tap.c
@@ -354,6 +354,11 @@ int tap_init(char *name)
 
 void tap_cleanup(void)
 {
+    unregister_interrupt(SIGIO);
+#ifdef __MACH__
+    kill(sigio_child_pid, SIGKILL);
+#endif
+
     if (_native_tap_fd == -1) {
         return;
     }

--- a/cpu/native/net/tap.c
+++ b/cpu/native/net/tap.c
@@ -351,4 +351,15 @@ int tap_init(char *name)
     DEBUG("RIOT native tap initialized.\n");
     return _native_tap_fd;
 }
+
+void tap_cleanup(void)
+{
+    if (_native_tap_fd == -1) {
+        return;
+    }
+
+    real_close(_native_tap_fd);
+    _native_tap_fd = -1;
+
+}
 /** @} */

--- a/sys/include/net/dev_eth.h
+++ b/sys/include/net/dev_eth.h
@@ -138,6 +138,10 @@ typedef struct eth_driver {
      */
     int (*init)(dev_eth_t *dev);
     /**
+     * @brief the driver's cleanup function (optional)
+     */
+    void (*cleanup)(dev_eth_t *dev);
+    /**
      * @brief a driver's user-space ISR handler
      *
      * This function will be called from a network stack's loop when being notified
@@ -160,6 +164,19 @@ typedef struct eth_driver {
  */
 static inline int dev_eth_init(dev_eth_t *dev) {
     return dev->driver->init(dev);
+}
+
+/**
+ * @brief Cleanup a device given by dev (convenience function)
+ *
+ * This function is to be called on reboot if the init function is not
+ * idempotent.
+ *
+ */
+static inline void dev_eth_cleanup(dev_eth_t *dev) {
+    if (dev->driver->cleanup) {
+        dev->driver->cleanup(dev);
+    }
 }
 
 /**


### PR DESCRIPTION

These patch touch both the old tap implementation and the new one while
taking care of being cross platform.

Tested on Linux and not on OSx