### PR TITLE
cpu: cortexm_common: set pendSV to default priority

### DIFF
--- a/cpu/cortexm_common/cortexm_init.c
+++ b/cpu/cortexm_common/cortexm_init.c
@@ -41,8 +41,8 @@ void cortexm_init(void)
 #endif
 
     /* initialize the interrupt priorities */
-    /* set pendSV interrupt to lowest possible priority */
-    NVIC_SetPriority(PendSV_IRQn, 0xff);
+    /* set pendSV interrupt to same priority as the rest */
+    NVIC_SetPriority(PendSV_IRQn, CPU_DEFAULT_IRQ_PRIO);
     /* set SVC interrupt to same priority as the rest */
     NVIC_SetPriority(SVCall_IRQn, CPU_DEFAULT_IRQ_PRIO);
     /* initialize all vendor specific interrupts with the same value */


### PR DESCRIPTION
While debugging #3438, some strange, timing dependent behaviour caused the thread calling ```uart_stdio_read()``` to never return from ```mutex_lock()```, even when that mutex gets unlocked from within the ISR.

This problem shows only at very high baudrates (e.g., 500000).

Setting pendSV makes it vanish.

Ideas?