### PR TITLE
gnrc: rename ng_netconf to ng_netopt

### DIFF
--- a/cpu/nrf51/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf51/radio/nrfmin/nrfmin.c
@@ -211,52 +211,52 @@ static void _switch_to_rx(void)
  */
 int _get_state(uint8_t *val, size_t max_len)
 {
-    ng_netconf_state_t state;
+    ng_netopt_state_t state;
 
-    if (max_len < sizeof(ng_netconf_state_t)) {
+    if (max_len < sizeof(ng_netopt_state_t)) {
         return -EOVERFLOW;
     }
     switch (_state) {
         case STATE_OFF:
-            state = NETCONF_STATE_OFF;
+            state = NG_NETOPT_STATE_OFF;
             break;
         case STATE_IDLE:
-            state = NETCONF_STATE_SLEEP;
+            state = NG_NETOPT_STATE_SLEEP;
             break;
         case STATE_RX:
-            state = NETCONF_STATE_IDLE;
+            state = NG_NETOPT_STATE_IDLE;
             break;
         case STATE_TX:
-            state = NETCONF_STATE_TX;
+            state = NG_NETOPT_STATE_TX;
             break;
         default:
             return -ECANCELED;
     }
-    memcpy(val, &state, sizeof(ng_netconf_state_t));
-    return sizeof(ng_netconf_state_t);
+    memcpy(val, &state, sizeof(ng_netopt_state_t));
+    return sizeof(ng_netopt_state_t);
 }
 
 int _set_state(uint8_t *val, size_t len)
 {
-    ng_netconf_state_t state;
+    ng_netopt_state_t state;
 
-    if (len != sizeof(ng_netconf_state_t)) {
+    if (len != sizeof(ng_netopt_state_t)) {
         return -EINVAL;
     }
     /* get target state */
     memcpy(&state, val, len);
     /* switch to target state */
     switch (state) {
-        case NETCONF_STATE_SLEEP:
+        case NG_NETOPT_STATE_SLEEP:
             _switch_to_idle();
             break;
-        case NETCONF_STATE_IDLE:
+        case NG_NETOPT_STATE_IDLE:
             _switch_to_rx();
             break;
         default:
             return -ENOTSUP;
     }
-    return sizeof(ng_netconf_state_t);
+    return sizeof(ng_netopt_state_t);
 }
 
 int _get_address(uint8_t *val, size_t max_len)
@@ -662,42 +662,40 @@ int _rem_event_cb(ng_netdev_t *dev, ng_netdev_event_cb_t cb)
     return -ENOENT;
 }
 
-int _get(ng_netdev_t *dev, ng_netconf_opt_t opt,
-                void *value, size_t max_len)
+int _get(ng_netdev_t *dev, ng_netopt_t opt, void *value, size_t max_len)
 {
     (void)dev;
 
     switch (opt) {
-        case NETCONF_OPT_ADDRESS:
+        case NG_NETOPT_ADDRESS:
             return _get_address(value, max_len);
-        case NETCONF_OPT_CHANNEL:
+        case NG_NETOPT_CHANNEL:
             return _get_channel(value, max_len);
-        case NETCONF_OPT_NID:
+        case NG_NETOPT_NID:
             return _get_pan(value, max_len);
-        case NETCONF_OPT_TX_POWER:
+        case NG_NETOPT_TX_POWER:
             return _get_txpower(value, max_len);
-        case NETCONF_OPT_STATE:
+        case NG_NETOPT_STATE:
             return _get_state(value, max_len);
         default:
             return -ENOTSUP;
     }
 }
 
-int _set(ng_netdev_t *dev, ng_netconf_opt_t opt,
-                void *value, size_t value_len)
+int _set(ng_netdev_t *dev, ng_netopt_t opt, void *value, size_t value_len)
 {
     (void)dev;
 
     switch (opt) {
-        case NETCONF_OPT_ADDRESS:
+        case NG_NETOPT_ADDRESS:
             return _set_address(value, value_len);
-        case NETCONF_OPT_CHANNEL:
+        case NG_NETOPT_CHANNEL:
             return _set_channel(value, value_len);
-        case NETCONF_OPT_NID:
+        case NG_NETOPT_NID:
             return _set_pan(value, value_len);
-        case NETCONF_OPT_TX_POWER:
+        case NG_NETOPT_TX_POWER:
             return _set_txpower(value, value_len);
-        case NETCONF_OPT_STATE:
+        case NG_NETOPT_STATE:
             return _set_state(value, value_len);
         default:
             return -ENOTSUP;

--- a/drivers/include/kw2xrf.h
+++ b/drivers/include/kw2xrf.h
@@ -109,7 +109,7 @@ typedef struct {
     kernel_pid_t mac_pid;                 /**< The driver's thread's PID */
     /* driver specific fields */
     uint8_t buf[KW2XRF_MAX_PKT_LENGTH];   /**< Buffer for incoming or outgoing packets */
-    ng_netconf_state_t state;             /**< Variable to keep radio driver's state */
+    ng_netopt_state_t state;              /**< Variable to keep radio driver's state */
     uint8_t seq_nr;                       /**< Next packets sequence number */
     uint16_t radio_pan;                   /**< The PAN the radio device is using */
     uint8_t radio_channel;                /**< The channel the radio device is using */

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -184,32 +184,32 @@ void kw2xrf_set_sequence(kw2xrf_t *dev, kw2xrf_physeq_t seq)
     /* Progrmm new sequence */
     switch (seq) {
         case XCVSEQ_IDLE:
-            dev->state = NETCONF_STATE_SLEEP;
+            dev->state = NG_NETOPT_STATE_SLEEP;
             break;
 
         case XCVSEQ_RECEIVE:
-            dev->state = NETCONF_STATE_IDLE;
+            dev->state = NG_NETOPT_STATE_IDLE;
             break;
 
         case XCVSEQ_TRANSMIT:
-            dev->state = NETCONF_STATE_TX;
+            dev->state = NG_NETOPT_STATE_TX;
             break;
 
         case XCVSEQ_CCA:
-            dev->state = NETCONF_STATE_TX;
+            dev->state = NG_NETOPT_STATE_TX;
             break;
 
         case XCVSEQ_TX_RX:
-            dev->state = NETCONF_STATE_TX;
+            dev->state = NG_NETOPT_STATE_TX;
             break;
 
         case XCVSEQ_CONTINUOUS_CCA:
-            dev->state = NETCONF_STATE_TX;
+            dev->state = NG_NETOPT_STATE_TX;
             break;
 
         default:
             DEBUG("kw2xrf: undefined state assigned to phy\n");
-            dev->state = NETCONF_STATE_IDLE;
+            dev->state = NG_NETOPT_STATE_IDLE;
     }
 
     /* Mapping of TX-sequences depending on AUTOACK flag */
@@ -352,7 +352,7 @@ int kw2xrf_on(kw2xrf_t *dev)
     /* abort any ongoing sequence */
     kw2xrf_set_sequence(dev, XCVSEQ_IDLE);
 
-    dev->state = NETCONF_STATE_SLEEP;
+    dev->state = NG_NETOPT_STATE_SLEEP;
     return 0;
 }
 
@@ -508,7 +508,7 @@ uint64_t kw2xrf_get_addr_long(kw2xrf_t *dev)
     return addr;
 }
 
-int kw2xrf_get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value, size_t max_len)
+int kw2xrf_get(ng_netdev_t *netdev, ng_netopt_t opt, void *value, size_t max_len)
 {
     kw2xrf_t *dev = (kw2xrf_t *)netdev;
 
@@ -517,7 +517,7 @@ int kw2xrf_get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value, size_t ma
     }
 
     switch (opt) {
-        case NETCONF_OPT_ADDRESS:
+        case NG_NETOPT_ADDRESS:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -525,7 +525,7 @@ int kw2xrf_get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value, size_t ma
             *((uint16_t *)value) = ((dev->addr_short[0] << 8) | dev->addr_short[1]);
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_ADDRESS_LONG:
+        case NG_NETOPT_ADDRESS_LONG:
             if (max_len < sizeof(uint64_t)) {
                 return -EOVERFLOW;
             }
@@ -533,7 +533,7 @@ int kw2xrf_get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value, size_t ma
             *((uint64_t *)value) = kw2xrf_get_addr_long(dev);
             return sizeof(uint64_t);
 
-        case NETCONF_OPT_ADDR_LEN:
+        case NG_NETOPT_ADDR_LEN:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -541,7 +541,7 @@ int kw2xrf_get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value, size_t ma
             *((uint16_t *)value) = 2;
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_SRC_LEN:
+        case NG_NETOPT_SRC_LEN:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -555,7 +555,7 @@ int kw2xrf_get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value, size_t ma
 
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_NID:
+        case NG_NETOPT_NID:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -563,21 +563,21 @@ int kw2xrf_get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value, size_t ma
             *((uint16_t *)value) = dev->radio_pan;
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_CHANNEL:
+        case NG_NETOPT_CHANNEL:
             return kw2xrf_get_channel(dev, (uint8_t *)value, max_len);
 
-        case NETCONF_OPT_PROTO:
+        case NG_NETOPT_PROTO:
             return kw2xrf_get_proto(dev, (uint8_t *)value, max_len);
 
-        case NETCONF_OPT_STATE:
-            if (max_len < sizeof(ng_netconf_state_t)) {
+        case NG_NETOPT_STATE:
+            if (max_len < sizeof(ng_netopt_state_t)) {
                 return -EOVERFLOW;
             }
 
-            *(ng_netconf_state_t *)value = *(ng_netconf_state_t *) & (dev->state);
+            *(ng_netopt_state_t *)value = *(ng_netopt_state_t *) & (dev->state);
             return 0;
 
-        case NETCONF_OPT_TX_POWER:
+        case NG_NETOPT_TX_POWER:
             if (max_len < 1) {
                 return -EOVERFLOW;
             }
@@ -585,7 +585,7 @@ int kw2xrf_get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value, size_t ma
             *(int16_t *)value = dev->tx_power;
             return 0;
 
-        case NETCONF_OPT_MAX_PACKET_SIZE:
+        case NG_NETOPT_MAX_PACKET_SIZE:
             if (max_len < sizeof(int16_t)) {
                 return -EOVERFLOW;
             }
@@ -593,21 +593,21 @@ int kw2xrf_get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value, size_t ma
             *((uint16_t *)value) = KW2XRF_MAX_PKT_LENGTH;
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_PRELOADING:
-            *((ng_netconf_enable_t *)value) = !!(dev->option & KW2XRF_OPT_PRELOADING);
-            return sizeof(ng_netconf_enable_t);
+        case NG_NETOPT_PRELOADING:
+            *((ng_netopt_enable_t *)value) = !!(dev->option & KW2XRF_OPT_PRELOADING);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_AUTOACK:
-            *((ng_netconf_enable_t *)value) = !!(dev->option & KW2XRF_OPT_AUTOACK);
-            return sizeof(ng_netconf_enable_t);
+        case NG_NETOPT_AUTOACK:
+            *((ng_netopt_enable_t *)value) = !!(dev->option & KW2XRF_OPT_AUTOACK);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_PROMISCUOUSMODE:
-            *((ng_netconf_enable_t *)value) = !!(dev->option & KW2XRF_OPT_PROMISCUOUS);
-            return sizeof(ng_netconf_enable_t);
+        case NG_NETOPT_PROMISCUOUSMODE:
+            *((ng_netopt_enable_t *)value) = !!(dev->option & KW2XRF_OPT_PROMISCUOUS);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_RAWMODE:
-            *((ng_netconf_enable_t *)value) = !!(dev->option & KW2XRF_OPT_RAWDUMP);
-            return sizeof(ng_netconf_enable_t);
+        case NG_NETOPT_RAWMODE:
+            *((ng_netopt_enable_t *)value) = !!(dev->option & KW2XRF_OPT_RAWDUMP);
+            return sizeof(ng_netopt_enable_t);
 
         default:
             return -ENOTSUP;
@@ -696,7 +696,7 @@ void kw2xrf_set_option(kw2xrf_t *dev, uint16_t option, bool state)
     }
 }
 
-int kw2xrf_set(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value, size_t value_len)
+int kw2xrf_set(ng_netdev_t *netdev, ng_netopt_t opt, void *value, size_t value_len)
 {
     kw2xrf_t *dev = (kw2xrf_t *)netdev;
 
@@ -705,24 +705,24 @@ int kw2xrf_set(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value, size_t va
     }
 
     switch (opt) {
-        case NETCONF_OPT_CHANNEL:
+        case NG_NETOPT_CHANNEL:
             return kw2xrf_set_channel(dev, (uint8_t *)value, value_len);
 
-        case NETCONF_OPT_ADDRESS:
+        case NG_NETOPT_ADDRESS:
             if (value_len > sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
 
             return kw2xrf_set_addr(dev, *((uint16_t *)value));
 
-        case NETCONF_OPT_ADDRESS_LONG:
+        case NG_NETOPT_ADDRESS_LONG:
             if (value_len > sizeof(uint64_t)) {
                 return -EOVERFLOW;
             }
 
             return kw2xrf_set_addr_long(dev, *((uint64_t *)value));
 
-        case NETCONF_OPT_SRC_LEN:
+        case NG_NETOPT_SRC_LEN:
             if (value_len > sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -741,14 +741,14 @@ int kw2xrf_set(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value, size_t va
 
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_NID:
+        case NG_NETOPT_NID:
             if (value_len > sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
 
             return kw2xrf_set_pan(dev, *((uint16_t *)value));
 
-        case NETCONF_OPT_TX_POWER:
+        case NG_NETOPT_TX_POWER:
             if (value_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -756,48 +756,48 @@ int kw2xrf_set(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value, size_t va
             kw2xrf_set_tx_power(dev, (int8_t *)value, value_len);
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_PROTO:
+        case NG_NETOPT_PROTO:
             return kw2xrf_set_proto(dev, (uint8_t *)value, value_len);
 
-        case NETCONF_OPT_AUTOACK:
+        case NG_NETOPT_AUTOACK:
             /* Set up HW generated automatic ACK after Receive */
             kw2xrf_set_option(dev, KW2XRF_OPT_AUTOACK,
                               ((bool *)value)[0]);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_PROMISCUOUSMODE:
+        case NG_NETOPT_PROMISCUOUSMODE:
             kw2xrf_set_option(dev, KW2XRF_OPT_PROMISCUOUS,
                               ((bool *)value)[0]);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_RAWMODE:
+        case NG_NETOPT_RAWMODE:
             kw2xrf_set_option(dev, KW2XRF_OPT_RAWDUMP,
                               ((bool *)value)[0]);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_PRELOADING:
+        case NG_NETOPT_PRELOADING:
             kw2xrf_set_option(dev, KW2XRF_OPT_PRELOADING,
                               ((bool *)value)[0]);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_AUTOCCA:
+        case NG_NETOPT_AUTOCCA:
             kw2xrf_set_option(dev, KW2XRF_OPT_CSMA,
                               ((bool *)value)[0]);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_STATE:
-            if (*((ng_netconf_state_t *)value) == NETCONF_STATE_TX) {
+        case NG_NETOPT_STATE:
+            if (*((ng_netopt_state_t *)value) == NG_NETOPT_STATE_TX) {
                 DEBUG("kw2xrf: Sending now.\n");
                 kw2xrf_set_sequence(dev, XCVSEQ_TRANSMIT);
-                return sizeof(ng_netconf_state_t);
+                return sizeof(ng_netopt_state_t);
             }
-            else if (*((ng_netconf_state_t *)value) == NETCONF_STATE_SLEEP) {
+            else if (*((ng_netopt_state_t *)value) == NG_NETOPT_STATE_SLEEP) {
                 kw2xrf_set_sequence(dev, XCVSEQ_IDLE);
-                return sizeof(ng_netconf_state_t);
+                return sizeof(ng_netopt_state_t);
             }
-            else if (*((ng_netconf_state_t *)value) == NETCONF_STATE_IDLE) {
+            else if (*((ng_netopt_state_t *)value) == NG_NETOPT_STATE_IDLE) {
                 kw2xrf_set_sequence(dev, XCVSEQ_RECEIVE);
-                return sizeof(ng_netconf_state_t);
+                return sizeof(ng_netopt_state_t);
             }
 
             /* TODO: Implement Off state here, when LPM functions are implemented */
@@ -1188,7 +1188,7 @@ int kw2xrf_send(ng_netdev_t *netdev, ng_pktsnip_t *pkt)
     DEBUG("kw2xrf: packet with size %i loaded to tx_buf\n", dev->buf[0]);
     kw2xrf_write_fifo(dev->buf, dev->buf[0]);
 
-    if ((dev->option & KW2XRF_OPT_PRELOADING) == NETCONF_DISABLE) {
+    if ((dev->option & KW2XRF_OPT_PRELOADING) == NG_NETOPT_DISABLE) {
         DEBUG("kw2xrf: Sending now.\n");
         kw2xrf_set_sequence(dev, XCVSEQ_TRANSMIT);
     }

--- a/drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c
+++ b/drivers/ng_at86rf2xx/ng_at86rf2xx_netdev.c
@@ -312,47 +312,46 @@ static void _receive_data(ng_at86rf2xx_t *dev)
     dev->event_cb(NETDEV_EVENT_RX_COMPLETE, payload);
 }
 
-static int _set_state(ng_at86rf2xx_t *dev, ng_netconf_state_t state)
+static int _set_state(ng_at86rf2xx_t *dev, ng_netopt_state_t state)
 {
     switch (state) {
-        case NETCONF_STATE_SLEEP:
+        case NG_NETOPT_STATE_SLEEP:
             ng_at86rf2xx_set_state(dev, NG_AT86RF2XX_STATE_TRX_OFF);
             break;
-        case NETCONF_STATE_IDLE:
+        case NG_NETOPT_STATE_IDLE:
             ng_at86rf2xx_set_state(dev, NG_AT86RF2XX_STATE_RX_AACK_ON);
             break;
-        case NETCONF_STATE_TX:
+        case NG_NETOPT_STATE_TX:
             if (dev->options & NG_AT86RF2XX_OPT_PRELOADING) {
                 ng_at86rf2xx_tx_exec(dev);
             }
             break;
-        case NETCONF_STATE_RESET:
+        case NG_NETOPT_STATE_RESET:
             ng_at86rf2xx_reset(dev);
             break;
         default:
             return -ENOTSUP;
     }
-    return sizeof(ng_netconf_state_t);
+    return sizeof(ng_netopt_state_t);
 }
 
-ng_netconf_state_t _get_state(ng_at86rf2xx_t *dev)
+ng_netopt_state_t _get_state(ng_at86rf2xx_t *dev)
 {
     switch (ng_at86rf2xx_get_state(dev)) {
         case NG_AT86RF2XX_STATE_SLEEP:
-            return NETCONF_STATE_SLEEP;
+            return NG_NETOPT_STATE_SLEEP;
         case NG_AT86RF2XX_STATE_BUSY_RX_AACK:
-            return NETCONF_STATE_RX;
+            return NG_NETOPT_STATE_RX;
         case NG_AT86RF2XX_STATE_BUSY_TX_ARET:
         case NG_AT86RF2XX_STATE_TX_ARET_ON:
-            return NETCONF_STATE_TX;
+            return NG_NETOPT_STATE_TX;
         case NG_AT86RF2XX_STATE_RX_AACK_ON:
         default:
-            return NETCONF_STATE_IDLE;
+            return NG_NETOPT_STATE_IDLE;
     }
 }
 
-static int _get(ng_netdev_t *device, ng_netconf_opt_t opt,
-                void *val, size_t max_len)
+static int _get(ng_netdev_t *device, ng_netopt_t opt, void *val, size_t max_len)
 {
     if (device == NULL) {
         return -ENODEV;
@@ -361,28 +360,28 @@ static int _get(ng_netdev_t *device, ng_netconf_opt_t opt,
 
     switch (opt) {
 
-        case NETCONF_OPT_ADDRESS:
+        case NG_NETOPT_ADDRESS:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
             *((uint16_t *)val) = ng_at86rf2xx_get_addr_short(dev);
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_ADDRESS_LONG:
+        case NG_NETOPT_ADDRESS_LONG:
             if (max_len < sizeof(uint64_t)) {
                 return -EOVERFLOW;
             }
             *((uint64_t *)val) = ng_at86rf2xx_get_addr_long(dev);
             return sizeof(uint64_t);
 
-        case NETCONF_OPT_ADDR_LEN:
+        case NG_NETOPT_ADDR_LEN:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
             *((uint16_t *)val) = 2;
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_SRC_LEN:
+        case NG_NETOPT_SRC_LEN:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -394,14 +393,14 @@ static int _get(ng_netdev_t *device, ng_netconf_opt_t opt,
             }
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_NID:
+        case NG_NETOPT_NID:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
             *((uint16_t *)val) = dev->pan;
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_IPV6_IID:
+        case NG_NETOPT_IPV6_IID:
             if (max_len < sizeof(eui64_t)) {
                 return -EOVERFLOW;
             }
@@ -415,14 +414,14 @@ static int _get(ng_netdev_t *device, ng_netconf_opt_t opt,
             }
             return sizeof(eui64_t);
 
-        case NETCONF_OPT_PROTO:
+        case NG_NETOPT_PROTO:
             if (max_len < sizeof(ng_nettype_t)) {
                 return -EOVERFLOW;
             }
             *((ng_nettype_t *)val) = dev->proto;
             return sizeof(ng_nettype_t);
 
-        case NETCONF_OPT_CHANNEL:
+        case NG_NETOPT_CHANNEL:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -430,98 +429,98 @@ static int _get(ng_netdev_t *device, ng_netconf_opt_t opt,
             ((uint8_t *)val)[0] = ng_at86rf2xx_get_chan(dev);
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_TX_POWER:
+        case NG_NETOPT_TX_POWER:
             if (max_len < sizeof(int16_t)) {
                 return -EOVERFLOW;
             }
             *((uint16_t *)val) = ng_at86rf2xx_get_txpower(dev);
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_MAX_PACKET_SIZE:
+        case NG_NETOPT_MAX_PACKET_SIZE:
             if (max_len < sizeof(int16_t)) {
                 return -EOVERFLOW;
             }
             *((uint16_t *)val) = NG_AT86RF2XX_MAX_PKT_LENGTH;
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_STATE:
-            if (max_len < sizeof(ng_netconf_state_t)) {
+        case NG_NETOPT_STATE:
+            if (max_len < sizeof(ng_netopt_state_t)) {
                 return -EOVERFLOW;
             }
-            *((ng_netconf_state_t*)val) = _get_state(dev);
+            *((ng_netopt_state_t*)val) = _get_state(dev);
             break;
 
-        case NETCONF_OPT_PRELOADING:
+        case NG_NETOPT_PRELOADING:
             if (dev->options & NG_AT86RF2XX_OPT_PRELOADING) {
-                *((ng_netconf_enable_t *)val) = NETCONF_ENABLE;
+                *((ng_netopt_enable_t *)val) = NG_NETOPT_ENABLE;
             }
             else {
-                *((ng_netconf_enable_t *)val) = NETCONF_DISABLE;
+                *((ng_netopt_enable_t *)val) = NG_NETOPT_DISABLE;
             }
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_AUTOACK:
+        case NG_NETOPT_AUTOACK:
             if (dev->options & NG_AT86RF2XX_OPT_AUTOACK) {
-                *((ng_netconf_enable_t *)val) = NETCONF_ENABLE;
+                *((ng_netopt_enable_t *)val) = NG_NETOPT_ENABLE;
             }
             else {
-                *((ng_netconf_enable_t *)val) = NETCONF_DISABLE;
+                *((ng_netopt_enable_t *)val) = NG_NETOPT_DISABLE;
             }
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_RETRANS:
+        case NG_NETOPT_RETRANS:
             if (max_len < sizeof(uint8_t)) {
                 return -EOVERFLOW;
             }
             *((uint8_t *)val) = ng_at86rf2xx_get_max_retries(dev);
             return sizeof(uint8_t);
 
-        case NETCONF_OPT_PROMISCUOUSMODE:
+        case NG_NETOPT_PROMISCUOUSMODE:
             if (dev->options & NG_AT86RF2XX_OPT_PROMISCUOUS) {
-                *((ng_netconf_enable_t *)val) = NETCONF_ENABLE;
+                *((ng_netopt_enable_t *)val) = NG_NETOPT_ENABLE;
             }
             else {
-                *((ng_netconf_enable_t *)val) = NETCONF_DISABLE;
+                *((ng_netopt_enable_t *)val) = NG_NETOPT_DISABLE;
             }
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_RAWMODE:
+        case NG_NETOPT_RAWMODE:
             if (dev->options & NG_AT86RF2XX_OPT_RAWDUMP) {
-                *((ng_netconf_enable_t *)val) = NETCONF_ENABLE;
+                *((ng_netopt_enable_t *)val) = NG_NETOPT_ENABLE;
             }
             else {
-                *((ng_netconf_enable_t *)val) = NETCONF_DISABLE;
+                *((ng_netopt_enable_t *)val) = NG_NETOPT_DISABLE;
             }
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_IS_CHANNEL_CLR:
+        case NG_NETOPT_IS_CHANNEL_CLR:
             if (ng_at86rf2xx_cca(dev)) {
-                *((ng_netconf_enable_t *)val) = NETCONF_ENABLE;
+                *((ng_netopt_enable_t *)val) = NG_NETOPT_ENABLE;
             }
             else {
-                *((ng_netconf_enable_t *)val) = NETCONF_DISABLE;
+                *((ng_netopt_enable_t *)val) = NG_NETOPT_DISABLE;
             }
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_RX_START_IRQ:
-            *((ng_netconf_enable_t *)val) =
+        case NG_NETOPT_RX_START_IRQ:
+            *((ng_netopt_enable_t *)val) =
                 !!(dev->options & NG_AT86RF2XX_OPT_TELL_RX_START);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_RX_END_IRQ:
-            *((ng_netconf_enable_t *)val) =
+        case NG_NETOPT_RX_END_IRQ:
+            *((ng_netopt_enable_t *)val) =
                 !!(dev->options & NG_AT86RF2XX_OPT_TELL_RX_END);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_TX_START_IRQ:
-            *((ng_netconf_enable_t *)val) =
+        case NG_NETOPT_TX_START_IRQ:
+            *((ng_netopt_enable_t *)val) =
                 !!(dev->options & NG_AT86RF2XX_OPT_TELL_TX_START);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_TX_END_IRQ:
-            *((ng_netconf_enable_t *)val) =
+        case NG_NETOPT_TX_END_IRQ:
+            *((ng_netopt_enable_t *)val) =
                 !!(dev->options & NG_AT86RF2XX_OPT_TELL_TX_END);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
         default:
             return -ENOTSUP;
@@ -530,8 +529,7 @@ static int _get(ng_netdev_t *device, ng_netconf_opt_t opt,
     return 0;
 }
 
-static int _set(ng_netdev_t *device, ng_netconf_opt_t opt,
-                void *val, size_t len)
+static int _set(ng_netdev_t *device, ng_netopt_t opt, void *val, size_t len)
 {
     ng_at86rf2xx_t *dev = (ng_at86rf2xx_t *) device;
 
@@ -540,21 +538,21 @@ static int _set(ng_netdev_t *device, ng_netconf_opt_t opt,
     }
 
     switch (opt) {
-        case NETCONF_OPT_ADDRESS:
+        case NG_NETOPT_ADDRESS:
             if (len > sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
             ng_at86rf2xx_set_addr_short(dev, *((uint16_t*)val));
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_ADDRESS_LONG:
+        case NG_NETOPT_ADDRESS_LONG:
             if (len > sizeof(uint64_t)) {
                 return -EOVERFLOW;
             }
             ng_at86rf2xx_set_addr_long(dev, *((uint64_t*)val));
             return sizeof(uint64_t);
 
-        case NETCONF_OPT_SRC_LEN:
+        case NG_NETOPT_SRC_LEN:
             if (len > sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -571,14 +569,14 @@ static int _set(ng_netdev_t *device, ng_netconf_opt_t opt,
             }
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_NID:
+        case NG_NETOPT_NID:
             if (len > sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
             ng_at86rf2xx_set_pan(dev, *((uint16_t *)val));
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_CHANNEL:
+        case NG_NETOPT_CHANNEL:
             if (len != sizeof(uint16_t)) {
                 return -EINVAL;
             }
@@ -590,65 +588,65 @@ static int _set(ng_netdev_t *device, ng_netconf_opt_t opt,
             ng_at86rf2xx_set_chan(dev, chan);
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_TX_POWER:
+        case NG_NETOPT_TX_POWER:
             if (len > sizeof(int16_t)) {
                 return -EOVERFLOW;
             }
             ng_at86rf2xx_set_txpower(dev, *((int16_t *)val));
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_STATE:
-            if (len > sizeof(ng_netconf_state_t)) {
+        case NG_NETOPT_STATE:
+            if (len > sizeof(ng_netopt_state_t)) {
                 return -EOVERFLOW;
             }
-            return _set_state(dev, *((ng_netconf_state_t *)val));
+            return _set_state(dev, *((ng_netopt_state_t *)val));
 
-        case NETCONF_OPT_AUTOACK:
+        case NG_NETOPT_AUTOACK:
             ng_at86rf2xx_set_option(dev, NG_AT86RF2XX_OPT_AUTOACK,
                                     ((bool *)val)[0]);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_RETRANS:
+        case NG_NETOPT_RETRANS:
             if (len > sizeof(uint8_t)) {
                 return -EOVERFLOW;
             }
             ng_at86rf2xx_set_max_retries(dev, *((uint8_t *)val));
             return sizeof(uint8_t);
 
-        case NETCONF_OPT_PRELOADING:
+        case NG_NETOPT_PRELOADING:
             ng_at86rf2xx_set_option(dev, NG_AT86RF2XX_OPT_PRELOADING,
                                     ((bool *)val)[0]);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_PROMISCUOUSMODE:
+        case NG_NETOPT_PROMISCUOUSMODE:
             ng_at86rf2xx_set_option(dev, NG_AT86RF2XX_OPT_PROMISCUOUS,
                                     ((bool *)val)[0]);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_RAWMODE:
+        case NG_NETOPT_RAWMODE:
             ng_at86rf2xx_set_option(dev, NG_AT86RF2XX_OPT_RAWDUMP,
                                     ((bool *)val)[0]);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_RX_START_IRQ:
+        case NG_NETOPT_RX_START_IRQ:
             ng_at86rf2xx_set_option(dev, NG_AT86RF2XX_OPT_TELL_RX_START,
                                     ((bool *)val)[0]);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_RX_END_IRQ:
+        case NG_NETOPT_RX_END_IRQ:
             ng_at86rf2xx_set_option(dev, NG_AT86RF2XX_OPT_TELL_RX_END,
                                     ((bool *)val)[0]);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_TX_START_IRQ:
+        case NG_NETOPT_TX_START_IRQ:
             ng_at86rf2xx_set_option(dev, NG_AT86RF2XX_OPT_TELL_TX_START,
                                     ((bool *)val)[0]);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
-        case NETCONF_OPT_TX_END_IRQ:
+        case NG_NETOPT_TX_END_IRQ:
             ng_at86rf2xx_set_option(dev, NG_AT86RF2XX_OPT_TELL_TX_END,
                                     ((bool *)val)[0]);
-            return sizeof(ng_netconf_enable_t);
+            return sizeof(ng_netopt_enable_t);
 
         default:
             return -ENOTSUP;

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -597,8 +597,7 @@ static int _rem_cb(ng_netdev_t *dev, ng_netdev_event_cb_t cb)
     return 0;
 }
 
-static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt,
-                void *value, size_t max_len)
+static int _get(ng_netdev_t *netdev, ng_netopt_t opt, void *value, size_t max_len)
 {
     xbee_t *dev = (xbee_t *)netdev;
     if (dev == NULL) {
@@ -606,12 +605,12 @@ static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt,
     }
 
     switch (opt) {
-        case NETCONF_OPT_ADDRESS:
+        case NG_NETOPT_ADDRESS:
             return _get_addr_short(dev, (uint8_t *)value, max_len);
-        case NETCONF_OPT_ADDRESS_LONG:
+        case NG_NETOPT_ADDRESS_LONG:
             return _get_addr_long(dev, (uint8_t *)value, max_len);
-        case NETCONF_OPT_ADDR_LEN:
-        case NETCONF_OPT_SRC_LEN:
+        case NG_NETOPT_ADDR_LEN:
+        case NG_NETOPT_SRC_LEN:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -622,7 +621,7 @@ static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt,
                 *((uint16_t *)value) = 2;
             }
             return sizeof(uint16_t);
-        case NETCONF_OPT_IPV6_IID:
+        case NG_NETOPT_IPV6_IID:
             if (max_len < sizeof(eui64_t)) {
                 return -EOVERFLOW;
             }
@@ -634,25 +633,24 @@ static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt,
             }
 
             return sizeof(eui64_t);
-        case NETCONF_OPT_CHANNEL:
+        case NG_NETOPT_CHANNEL:
             return _get_channel(dev, (uint8_t *)value, max_len);
-        case NETCONF_OPT_MAX_PACKET_SIZE:
+        case NG_NETOPT_MAX_PACKET_SIZE:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
             *((uint16_t *)value) = XBEE_MAX_PAYLOAD_LENGTH;
             return sizeof(uint16_t);
-        case NETCONF_OPT_NID:
+        case NG_NETOPT_NID:
             return _get_panid(dev, (uint8_t *)value, max_len);
-        case NETCONF_OPT_PROTO:
+        case NG_NETOPT_PROTO:
             return _get_proto(dev, (uint8_t *)value, max_len);
         default:
             return -ENOTSUP;
     }
 }
 
-static int _set(ng_netdev_t *netdev, ng_netconf_opt_t opt,
-                void *value, size_t value_len)
+static int _set(ng_netdev_t *netdev, ng_netopt_t opt, void *value, size_t value_len)
 {
     xbee_t *dev = (xbee_t *)netdev;
     if (dev == NULL) {
@@ -660,16 +658,16 @@ static int _set(ng_netdev_t *netdev, ng_netconf_opt_t opt,
     }
 
     switch (opt) {
-        case NETCONF_OPT_ADDRESS:
+        case NG_NETOPT_ADDRESS:
             return _set_addr(dev, (uint8_t *)value, value_len);
-        case NETCONF_OPT_ADDR_LEN:
-        case NETCONF_OPT_SRC_LEN:
+        case NG_NETOPT_ADDR_LEN:
+        case NG_NETOPT_SRC_LEN:
             return _set_addr_len(dev, value, value_len);
-        case NETCONF_OPT_CHANNEL:
+        case NG_NETOPT_CHANNEL:
             return _set_channel(dev, (uint8_t *)value, value_len);
-        case NETCONF_OPT_NID:
+        case NG_NETOPT_NID:
             return _set_panid(dev, (uint8_t *)value, value_len);
-        case NETCONF_OPT_PROTO:
+        case NG_NETOPT_PROTO:
             return _set_proto(dev, (uint8_t *)value, value_len);
         default:
             return -ENOTSUP;

--- a/sys/include/net/ng_netapi.h
+++ b/sys/include/net/ng_netapi.h
@@ -30,7 +30,7 @@
 
 #include "kernel.h"
 #include "thread.h"
-#include "net/ng_netconf.h"
+#include "net/ng_netopt.h"
 #include "net/ng_nettype.h"
 #include "net/ng_pkt.h"
 
@@ -67,7 +67,7 @@ extern "C" {
  * @brief   Data structure to be send for setting and getting options
  */
 typedef struct {
-    ng_netconf_opt_t opt;       /**< the option to get/set */
+    ng_netopt_t opt;            /**< the option to get/set */
     uint16_t context;           /**< (optional) context for that option */
     void *data;                 /**< data to set or buffer to read into */
     uint16_t data_len;          /**< size of the data / the buffer */
@@ -133,7 +133,7 @@ int ng_netapi_dispatch_receive(ng_nettype_t type, uint32_t demux_ctx,
  *
  * @return              value returned by the @ref NG_NETAPI_MSG_TYPE_ACK message
  */
-int ng_netapi_get(kernel_pid_t pid, ng_netconf_opt_t opt, uint16_t context,
+int ng_netapi_get(kernel_pid_t pid, ng_netopt_t opt, uint16_t context,
                   void *data, size_t max_len);
 
 /**
@@ -148,7 +148,7 @@ int ng_netapi_get(kernel_pid_t pid, ng_netconf_opt_t opt, uint16_t context,
  *
  * @return              value returned by the @ref NG_NETAPI_MSG_TYPE_ACK message
  */
-int ng_netapi_set(kernel_pid_t pid, ng_netconf_opt_t opt, uint16_t context,
+int ng_netapi_set(kernel_pid_t pid, ng_netopt_t opt, uint16_t context,
                   void *data, size_t data_len);
 
 #ifdef __cplusplus

--- a/sys/include/net/ng_netbase.h
+++ b/sys/include/net/ng_netbase.h
@@ -22,7 +22,7 @@
 
 #include "net/ng_netdev.h"
 #include "net/ng_netapi.h"
-#include "net/ng_netconf.h"
+#include "net/ng_netopt.h"
 #include "net/ng_netreg.h"
 #include "net/ng_nettype.h"
 #include "net/ng_netif.h"

--- a/sys/include/net/ng_netdev.h
+++ b/sys/include/net/ng_netdev.h
@@ -28,7 +28,7 @@
 
 #include "kernel.h"
 #include "net/ng_pkt.h"
-#include "net/ng_netconf.h"
+#include "net/ng_netopt.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -127,8 +127,7 @@ typedef struct {
      *                      @p max_len is too small to store the option value
      * @return              -ECANCELED if internal driver error occurred
      */
-    int (*get)(ng_netdev_t *dev, ng_netconf_opt_t opt,
-               void *value, size_t max_len);
+    int (*get)(ng_netdev_t *dev, ng_netopt_t opt, void *value, size_t max_len);
 
     /**
      * @brief   Set an option value for a given network device
@@ -144,8 +143,7 @@ typedef struct {
      * @return              -EINVAL if @p value is invalid
      * @return              -ECANCELED if internal driver error occurred
      */
-    int (*set)(ng_netdev_t *dev, ng_netconf_opt_t opt,
-               void *value, size_t value_len);
+    int (*set)(ng_netdev_t *dev, ng_netopt_t opt, void *value, size_t value_len);
 
     /**
      * @brief   This function is called by a MAC layer when a message of type

--- a/sys/include/net/ng_netopt.h
+++ b/sys/include/net/ng_netopt.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    net_ng_netconf  Configuration options for network APIs
+ * @defgroup    net_ng_netopt   Configuration options for network APIs
  * @ingroup     net
  * @brief       List of available configuration options for the
  *              @ref net_ng_netdev and the @ref net_ng_netapi
@@ -20,8 +20,8 @@
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  */
 
-#ifndef NG_NET_CONF_H_
-#define NG_NET_CONF_H_
+#ifndef NG_NETOPT_H_
+#define NG_NETOPT_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,21 +32,21 @@ extern "C" {
  *          network stack, e.g. by netdev and netapi
  */
 typedef enum {
-    NETCONF_OPT_CHANNEL,            /**< get/set channel as uint16_t in host
+    NG_NETOPT_CHANNEL,              /**< get/set channel as uint16_t in host
                                      *   byte order */
-    NETCONF_OPT_IS_CHANNEL_CLR,     /**< check if channel is clear */
-    NETCONF_OPT_ADDRESS,            /**< get/set address in host byte order */
+    NG_NETOPT_IS_CHANNEL_CLR,       /**< check if channel is clear */
+    NG_NETOPT_ADDRESS,              /**< get/set address in host byte order */
 
     /**
      * @brief    get/set long address in host byte order
      *
      * Examples for this include the EUI-64 in IEEE 802.15.4
      */
-    NETCONF_OPT_ADDRESS_LONG,
-    NETCONF_OPT_ADDR_LEN,           /**< get the default address length a
+    NG_NETOPT_ADDRESS_LONG,
+    NG_NETOPT_ADDR_LEN,             /**< get the default address length a
                                      *   network device expects as uint16_t in
                                      *   host byte order */
-    NETCONF_OPT_SRC_LEN,            /**< get/set the address length to choose
+    NG_NETOPT_SRC_LEN,              /**< get/set the address length to choose
                                      *   for the network device's source address
                                      *   as uint16_t in host byte order */
     /**
@@ -54,7 +54,7 @@ typedef enum {
      *
      * Examples for this include the PAN ID in IEEE 802.15.4
      */
-    NETCONF_OPT_NID,
+    NG_NETOPT_NID,
 
     /**
      * @brief   get the IPv6 interface identifier of a network interface as
@@ -70,31 +70,31 @@ typedef enum {
      * <a href="https://tools.ietf.org/html/rfc2464">RFC 2464</a> or
      * <a href="https://tools.ietf.org/html/rfc4944">RFC 4944</a>).
      */
-    NETCONF_OPT_IPV6_IID,
-    NETCONF_OPT_TX_POWER,           /**< get/set the output power for radio
+    NG_NETOPT_IPV6_IID,
+    NG_NETOPT_TX_POWER,             /**< get/set the output power for radio
                                      *   devices in dBm as int16_t in host byte
                                      *   order */
-    NETCONF_OPT_MAX_PACKET_SIZE,    /**< get/set the maximum packet size a
+    NG_NETOPT_MAX_PACKET_SIZE,      /**< get/set the maximum packet size a
                                      *   network module can handle as uint16_t
                                      *   in host byte order */
     /**
      * @brief en/disable preloading or read the current state.
      *
      * Preload using ng_netdev_driver_t::send_data() or ng_netapi_send()
-     * respectively, send setting state to @ref NETCONF_STATE_TX
+     * respectively, send setting state to @ref NG_NETOPT_STATE_TX
      */
-    NETCONF_OPT_PRELOADING,
-    NETCONF_OPT_PROMISCUOUSMODE,    /**< en/disable promiscuous mode or read
+    NG_NETOPT_PRELOADING,
+    NG_NETOPT_PROMISCUOUSMODE,      /**< en/disable promiscuous mode or read
                                      *   the current state */
-    NETCONF_OPT_AUTOACK,            /**< en/disable link layer auto ACKs or read
+    NG_NETOPT_AUTOACK,              /**< en/disable link layer auto ACKs or read
                                      *   the current state */
-    NETCONF_OPT_RETRANS,            /**< get/set the maximum number of
+    NG_NETOPT_RETRANS,              /**< get/set the maximum number of
                                          retransmissions. */
-    NETCONF_OPT_PROTO,              /**< get/set the protocol for the layer
+    NG_NETOPT_PROTO,                /**< get/set the protocol for the layer
                                      *   as type ng_nettype_t. */
-    NETCONF_OPT_STATE,              /**< get/set the state of network devices as
-                                     *   type ng_netconf_state_t */
-    NETCONF_OPT_RAWMODE,            /**< en/disable the pre-processing of data
+    NG_NETOPT_STATE,                /**< get/set the state of network devices as
+                                     *   type ng_netopt_state_t */
+    NG_NETOPT_RAWMODE,              /**< en/disable the pre-processing of data
                                      *   in a network device driver as type
                                      *   ng_nettype_t */
     /**
@@ -104,7 +104,7 @@ typedef enum {
      *
      * @note not all transceivers may support this interrupt
      */
-    NETCONF_OPT_RX_START_IRQ,
+    NG_NETOPT_RX_START_IRQ,
 
     /**
      * @brief en/disable the interrupt after packet reception.
@@ -114,7 +114,7 @@ typedef enum {
      * @note in case a transceiver does not support this interrupt, the event
      *       may be triggered by the driver
      */
-    NETCONF_OPT_RX_END_IRQ,
+    NG_NETOPT_RX_END_IRQ,
 
     /**
      * @brief en/disable the interrupt right in the beginning of transmission.
@@ -125,7 +125,7 @@ typedef enum {
      * @note in case a transceiver does not support this interrupt, the event
      *       may be triggered by the driver
      */
-    NETCONF_OPT_TX_START_IRQ,
+    NG_NETOPT_TX_START_IRQ,
 
     /**
      * @brief en/disable the interrupt after packet transmission.
@@ -134,9 +134,9 @@ typedef enum {
      *
      * @note not all transceivers may support this interrupt
      */
-    NETCONF_OPT_TX_END_IRQ,
-    NETCONF_OPT_AUTOCCA,            /**< en/disable to check automatically
-                                         before sending the channel is clear. */
+    NG_NETOPT_TX_END_IRQ,
+    NG_NETOPT_AUTOCCA,              /**< en/disable to check automatically
+                                     *   before sending the channel is clear. */
     /* add more options if needed */
 
     /**
@@ -144,42 +144,42 @@ typedef enum {
      *
      * @note    Interfaces are not meant to respond to that.
      */
-    NETCONF_OPT_NUMOF,
-} ng_netconf_opt_t;
+    NG_NETOPT_NUMOF,
+} ng_netopt_t;
 
 /**
  * @brief   Binary parameter for enabling and disabling options
  */
 typedef enum {
-    NETCONF_DISABLE = 0,            /**< disable a given option */
-    NETCONF_ENABLE = 1,             /**< enable a given option */
-} ng_netconf_enable_t;
+    NG_NETOPT_DISABLE = 0,          /**< disable a given option */
+    NG_NETOPT_ENABLE = 1,           /**< enable a given option */
+} ng_netopt_enable_t;
 
 /**
- * @brief   Option parameter to be used with @ref NETCONF_OPT_STATE to set or get
+ * @brief   Option parameter to be used with @ref NG_NETOPT_STATE to set or get
  *          the state of a network device or protocol implementation
  */
 typedef enum {
-    NETCONF_STATE_OFF = 0,          /**< powered off */
-    NETCONF_STATE_SLEEP,            /**< sleep mode */
-    NETCONF_STATE_IDLE,             /**< idle mode,
+    NG_NETOPT_STATE_OFF = 0,        /**< powered off */
+    NG_NETOPT_STATE_SLEEP,          /**< sleep mode */
+    NG_NETOPT_STATE_IDLE,           /**< idle mode,
                                      *   the device listens to receive packets */
-    NETCONF_STATE_RX,               /**< receive mode,
+    NG_NETOPT_STATE_RX,             /**< receive mode,
                                      *   the device currently receives a packet */
-    NETCONF_STATE_TX,               /**< transmit mode,
+    NG_NETOPT_STATE_TX,             /**< transmit mode,
                                      *   set: triggers transmission of a preloaded packet
-                                     *   (see *NETCONF_OPT_PRELOADING*). The resulting
-                                     *   state of the network device is *NETCONF_STATE_IDLE*
+                                     *   (see @ref NG_NETOPT_PRELOADING*). The resulting
+                                     *   state of the network device is @ref NG_NETOPT_STATE_IDLE
                                      *   get: the network device is in the process of
                                      *   transmitting a packet */
-    NETCONF_STATE_RESET,            /**< triggers a hardware reset. The resulting
-                                     *   state of the network device is *NETCONF_STATE_IDLE* */
+    NG_NETOPT_STATE_RESET,          /**< triggers a hardware reset. The resulting
+                                     *   state of the network device is @ref NG_NETOPT_STATE_IDLE */
     /* add other states if needed */
-} ng_netconf_state_t;
+} ng_netopt_state_t;
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* NG_NET_CONF_H_ */
+#endif /* NG_NETOPT_H_ */
 /** @} */

--- a/sys/include/net/ng_nettest.h
+++ b/sys/include/net/ng_nettest.h
@@ -26,7 +26,7 @@
 
 #include "kernel_types.h"
 #include "net/ng_netapi.h"
-#include "net/ng_netconf.h"
+#include "net/ng_netopt.h"
 #include "net/ng_nettype.h"
 #include "net/ng_pkt.h"
 #include "thread.h"
@@ -105,7 +105,7 @@ typedef enum {
  * @param[in] opt   The option to register the getter for.
  * @param[in] cb    An option getter. NULL to delete.
  */
-void ng_nettest_register_get(ng_netconf_opt_t opt, ng_nettest_opt_cb_t cb);
+void ng_nettest_register_get(ng_netopt_t opt, ng_nettest_opt_cb_t cb);
 
 /**
  * @brief   Registers a setter for an option.
@@ -115,7 +115,7 @@ void ng_nettest_register_get(ng_netconf_opt_t opt, ng_nettest_opt_cb_t cb);
  * @param[in] opt   The option to register the setter for.
  * @param[in] cb    An option setter. NULL to delete.
  */
-void ng_nettest_register_set(ng_netconf_opt_t opt, ng_nettest_opt_cb_t cb);
+void ng_nettest_register_set(ng_netopt_t opt, ng_nettest_opt_cb_t cb);
 
 /**
  * @brief   Test @ref NG_NETAPI_MSG_TYPE_SND command to @p pid.
@@ -223,7 +223,7 @@ ng_nettest_res_t ng_nettest_receive(kernel_pid_t pid, ng_pktsnip_t *in,
  *
  * @return  @see ng_nettest_res_t
  */
-ng_nettest_res_t ng_nettest_get(kernel_pid_t pid, ng_netconf_opt_t opt,
+ng_nettest_res_t ng_nettest_get(kernel_pid_t pid, ng_netopt_t opt,
                                 uint16_t context, void *data, size_t data_len,
                                 void *exp_data, int exp_res);
 
@@ -242,7 +242,7 @@ ng_nettest_res_t ng_nettest_get(kernel_pid_t pid, ng_netconf_opt_t opt,
  *
  * @return  @see ng_nettest_res_t
  */
-ng_nettest_res_t ng_nettest_set(kernel_pid_t pid, ng_netconf_opt_t opt,
+ng_nettest_res_t ng_nettest_set(kernel_pid_t pid, ng_netopt_t opt,
                                 uint16_t context, void *data, size_t data_len,
                                 int exp_res);
 

--- a/sys/net/application_layer/ng_zep/ng_zep.c
+++ b/sys/net/application_layer/ng_zep/ng_zep.c
@@ -56,10 +56,8 @@ static ringbuffer_t _rx_buf = RINGBUFFER_INIT(_rx_buf_array);
 static int _send(ng_netdev_t *dev, ng_pktsnip_t *pkt);
 static int _add_cb(ng_netdev_t *dev, ng_netdev_event_cb_t cb);
 static int _rem_cb(ng_netdev_t *dev, ng_netdev_event_cb_t cb);
-static int _get(ng_netdev_t *dev, ng_netconf_opt_t opt, void *value,
-                size_t max_len);
-static int _set(ng_netdev_t *dev, ng_netconf_opt_t opt, void *value,
-                size_t value_len);
+static int _get(ng_netdev_t *dev, ng_netopt_t opt, void *value, size_t max_len);
+static int _set(ng_netdev_t *dev, ng_netopt_t opt, void *value, size_t value_len);
 static void _isr_event(ng_netdev_t *dev, uint32_t event_type);
 
 static const ng_netdev_driver_t _zep_driver = {
@@ -184,14 +182,14 @@ static inline void _set_uint64_ptr(uint64_t *ptr, uint64_t val)
     *ptr = val;
 }
 
-static inline void _set_flag_ptr(ng_netconf_enable_t *enable,
+static inline void _set_flag_ptr(ng_netopt_enable_t *enable,
                                  uint16_t flag_field, uint16_t flag)
 {
     if (flag_field & flag) {
-        *enable = NETCONF_ENABLE;
+        *enable = NG_NETOPT_ENABLE;
     }
     else {
-        *enable = NETCONF_DISABLE;
+        *enable = NG_NETOPT_DISABLE;
     }
 }
 
@@ -329,8 +327,7 @@ static int _rem_cb(ng_netdev_t *dev, ng_netdev_event_cb_t cb)
     return 0;
 }
 
-static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
-                size_t max_len)
+static int _get(ng_netdev_t *netdev, ng_netopt_t opt, void *value, size_t max_len)
 {
     ng_zep_t *dev = (ng_zep_t *)netdev;
 
@@ -339,7 +336,7 @@ static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
     }
 
     switch (opt) {
-        case NETCONF_OPT_CHANNEL:
+        case NG_NETOPT_CHANNEL:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -347,7 +344,7 @@ static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
             _set_uint16_ptr(value, (uint16_t)dev->chan);
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_ADDRESS:
+        case NG_NETOPT_ADDRESS:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -355,7 +352,7 @@ static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
             _set_uint16_ptr(value, byteorder_ltobs(dev->addr).u16);
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_ADDRESS_LONG:
+        case NG_NETOPT_ADDRESS_LONG:
             if (max_len < sizeof(uint64_t)) {
                 return -EOVERFLOW;
             }
@@ -363,7 +360,7 @@ static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
             _set_uint64_ptr(value, byteorder_ltobll(dev->eui64).u64);
             return sizeof(uint64_t);
 
-        case NETCONF_OPT_ADDR_LEN:
+        case NG_NETOPT_ADDR_LEN:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -377,7 +374,7 @@ static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
 
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_SRC_LEN:
+        case NG_NETOPT_SRC_LEN:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -391,7 +388,7 @@ static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
 
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_PROTO:
+        case NG_NETOPT_PROTO:
             if (max_len < sizeof(ng_nettype_t)) {
                 return -EOVERFLOW;
             }
@@ -399,7 +396,7 @@ static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
             *((ng_nettype_t *)value) = dev->proto;
             return sizeof(ng_nettype_t);
 
-        case NETCONF_OPT_NID:
+        case NG_NETOPT_NID:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -407,7 +404,7 @@ static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
             _set_uint16_ptr(value, byteorder_ltobs(dev->pan).u16);
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_IPV6_IID:
+        case NG_NETOPT_IPV6_IID:
             if (max_len < sizeof(eui64_t)) {
                 return -EOVERFLOW;
             }
@@ -421,7 +418,7 @@ static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
             }
             return sizeof(eui64_t);
 
-        case NETCONF_OPT_MAX_PACKET_SIZE:
+        case NG_NETOPT_MAX_PACKET_SIZE:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -429,8 +426,8 @@ static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
             _set_uint16_ptr(value, NG_ZEP_MAX_PKT_LENGTH);
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_AUTOACK:
-            if (max_len < sizeof(ng_netconf_enable_t)) {
+        case NG_NETOPT_AUTOACK:
+            if (max_len < sizeof(ng_netopt_enable_t)) {
                 return -EOVERFLOW;
             }
 
@@ -442,8 +439,7 @@ static int _get(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
     }
 }
 
-static int _set(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
-                size_t value_len)
+static int _set(ng_netdev_t *netdev, ng_netopt_t opt, void *value, size_t value_len)
 {
     ng_zep_t *dev = (ng_zep_t *)netdev;
 
@@ -452,7 +448,7 @@ static int _set(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
     }
 
     switch (opt) {
-        case NETCONF_OPT_CHANNEL:
+        case NG_NETOPT_CHANNEL:
             if (value_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -465,7 +461,7 @@ static int _set(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
             dev->chan = *_get_uint16_ptr(value);
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_ADDRESS:
+        case NG_NETOPT_ADDRESS:
             if (value_len < sizeof(be_uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -476,7 +472,7 @@ static int _set(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
                 return sizeof(be_uint16_t);
             }
 
-        case NETCONF_OPT_ADDRESS_LONG:
+        case NG_NETOPT_ADDRESS_LONG:
             if (value_len < sizeof(be_uint64_t)) {
                 return -EOVERFLOW;
             }
@@ -487,7 +483,7 @@ static int _set(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
                 return sizeof(be_uint64_t);
             }
 
-        case NETCONF_OPT_ADDR_LEN:
+        case NG_NETOPT_ADDR_LEN:
             if (value_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -507,7 +503,7 @@ static int _set(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
 
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_SRC_LEN:
+        case NG_NETOPT_SRC_LEN:
             if (value_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -527,7 +523,7 @@ static int _set(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
 
             return sizeof(uint16_t);
 
-        case NETCONF_OPT_NID:
+        case NG_NETOPT_NID:
             if (value_len < sizeof(be_uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -538,8 +534,8 @@ static int _set(ng_netdev_t *netdev, ng_netconf_opt_t opt, void *value,
                 return sizeof(be_uint16_t);
             }
 
-        case NETCONF_OPT_AUTOACK:
-            if (value_len < sizeof(ng_netconf_enable_t)) {
+        case NG_NETOPT_AUTOACK:
+            if (value_len < sizeof(ng_netopt_enable_t)) {
                 return -EOVERFLOW;
             }
 

--- a/sys/net/crosslayer/ng_netapi/ng_netapi.c
+++ b/sys/net/crosslayer/ng_netapi/ng_netapi.c
@@ -70,10 +70,9 @@ static inline int _snd_rcv_dispatch(ng_nettype_t type, uint32_t demux_ctx,
                                     uint16_t cmd, ng_pktsnip_t *pkt)
 {
     int numof = ng_netreg_num(type, demux_ctx);
-    ng_netreg_entry_t *sendto;
 
     if (numof != 0) {
-        sendto = ng_netreg_lookup(type, demux_ctx);
+        ng_netreg_entry_t *sendto = ng_netreg_lookup(type, demux_ctx);
 
         ng_pktbuf_hold(pkt, numof - 1);
 

--- a/sys/net/crosslayer/ng_netapi/ng_netapi.c
+++ b/sys/net/crosslayer/ng_netapi/ng_netapi.c
@@ -36,7 +36,7 @@
  * @return              the value from the received ACK message
  */
 static inline int _get_set(kernel_pid_t pid, uint16_t type,
-                           ng_netconf_opt_t opt, uint16_t context,
+                           ng_netopt_t opt, uint16_t context,
                            void *data, size_t data_len)
 {
     msg_t cmd;
@@ -107,14 +107,14 @@ int ng_netapi_dispatch_receive(ng_nettype_t type, uint32_t demux_ctx,
     return _snd_rcv_dispatch(type, demux_ctx, NG_NETAPI_MSG_TYPE_RCV, pkt);
 }
 
-int ng_netapi_get(kernel_pid_t pid, ng_netconf_opt_t opt, uint16_t context,
+int ng_netapi_get(kernel_pid_t pid, ng_netopt_t opt, uint16_t context,
                   void *data, size_t data_len)
 {
     return _get_set(pid, NG_NETAPI_MSG_TYPE_GET, opt, context,
                     data, data_len);
 }
 
-int ng_netapi_set(kernel_pid_t pid, ng_netconf_opt_t opt, uint16_t context,
+int ng_netapi_set(kernel_pid_t pid, ng_netopt_t opt, uint16_t context,
                   void *data, size_t data_len)
 {
     return _get_set(pid, NG_NETAPI_MSG_TYPE_SET, opt, context,

--- a/sys/net/crosslayer/ng_nettest/ng_nettest.c
+++ b/sys/net/crosslayer/ng_nettest/ng_nettest.c
@@ -19,7 +19,7 @@
 #include "mutex.h"
 #include "net/ng_netapi.h"
 #include "net/ng_netif.h"
-#include "net/ng_netconf.h"
+#include "net/ng_netopt.h"
 #include "net/ng_netreg.h"
 #include "net/ng_pktbuf.h"
 #include "timex.h"
@@ -28,21 +28,21 @@
 
 #include "net/ng_nettest.h"
 
-static ng_nettest_opt_cbs_t _opt_cbs[NETCONF_OPT_NUMOF];
+static ng_nettest_opt_cbs_t _opt_cbs[NG_NETOPT_NUMOF];
 static mutex_t _mutex = MUTEX_INIT;
 static kernel_pid_t _pid = KERNEL_PID_UNDEF;
 static char _stack[NG_NETTEST_STACK_SIZE];
 
 static void *_event_loop(void *arg);
 
-void ng_nettest_register_get(ng_netconf_opt_t opt, ng_nettest_opt_cb_t cb)
+void ng_nettest_register_get(ng_netopt_t opt, ng_nettest_opt_cb_t cb)
 {
     mutex_lock(&_mutex);
     _opt_cbs[opt].get = cb;
     mutex_unlock(&_mutex);
 }
 
-void ng_nettest_register_set(ng_netconf_opt_t opt, ng_nettest_opt_cb_t cb)
+void ng_nettest_register_set(ng_netopt_t opt, ng_nettest_opt_cb_t cb)
 {
     mutex_lock(&_mutex);
     _opt_cbs[opt].set = cb;
@@ -163,7 +163,7 @@ ng_nettest_res_t ng_nettest_receive(kernel_pid_t pid, ng_pktsnip_t *in,
     return res;
 }
 
-ng_nettest_res_t ng_nettest_get(kernel_pid_t pid, ng_netconf_opt_t opt,
+ng_nettest_res_t ng_nettest_get(kernel_pid_t pid, ng_netopt_t opt,
                                 uint16_t context, void *data, size_t data_len,
                                 void *exp_data, int exp_res)
 {
@@ -175,7 +175,7 @@ ng_nettest_res_t ng_nettest_get(kernel_pid_t pid, ng_netconf_opt_t opt,
     return NG_NETTEST_SUCCESS;
 }
 
-ng_nettest_res_t ng_nettest_set(kernel_pid_t pid, ng_netconf_opt_t opt,
+ng_nettest_res_t ng_nettest_set(kernel_pid_t pid, ng_netopt_t opt,
                                 uint16_t context, void *data, size_t data_len,
                                 int exp_res)
 {
@@ -198,7 +198,7 @@ int ng_nettest_init(void)
 
 void ng_nettest_reset(void)
 {
-    for (int i = 0; i < NETCONF_OPT_NUMOF; i++) {
+    for (int i = 0; i < NG_NETOPT_NUMOF; i++) {
         _opt_cbs[i].get = NULL;
         _opt_cbs[i].set = NULL;
     }

--- a/sys/net/link_layer/ng_netdev_eth/ng_netdev_eth.c
+++ b/sys/net/link_layer/ng_netdev_eth/ng_netdev_eth.c
@@ -56,10 +56,8 @@ static uint8_t recv_buffer[NG_ETHERNET_MAX_LEN];
 static int _send_data(ng_netdev_t *netdev, ng_pktsnip_t *pkt);
 static int _add_event_callback(ng_netdev_t *dev, ng_netdev_event_cb_t cb);
 static int _rem_event_callback(ng_netdev_t *dev, ng_netdev_event_cb_t cb);
-static int _get(ng_netdev_t *dev, ng_netconf_opt_t opt, void *value,
-                size_t max_len);
-static int _set(ng_netdev_t *dev, ng_netconf_opt_t opt, void *value,
-                size_t value_len);
+static int _get(ng_netdev_t *dev, ng_netopt_t opt, void *value, size_t max_len);
+static int _set(ng_netdev_t *dev, ng_netopt_t opt, void *value, size_t value_len);
 static void _isr_event(ng_netdev_t *dev, uint32_t event_type);
 
 /* netdev driver struct */
@@ -226,23 +224,22 @@ static inline int _get_max_pkt_sz(uint16_t *value, size_t max_len)
     return sizeof(uint16_t);
 }
 
-static inline int _get_promiscousmode(ng_netdev_eth_t *netdev, ng_netconf_enable_t *value,
+static inline int _get_promiscousmode(ng_netdev_eth_t *netdev, ng_netopt_enable_t *value,
                                       size_t max_len)
 {
-    if (max_len != sizeof(ng_netconf_enable_t)) {
+    if (max_len != sizeof(ng_netopt_enable_t)) {
         /* value buffer not big enough */
         return -EOVERFLOW;
     }
 
 
     dev_eth_t *dev = netdev->ethdev;
-    *value = (ng_netconf_enable_t)dev->driver->get_promiscous(dev);
+    *value = (ng_netopt_enable_t)dev->driver->get_promiscous(dev);
 
-    return sizeof(ng_netconf_enable_t);
+    return sizeof(ng_netopt_enable_t);
 }
 
-static int _get(ng_netdev_t *dev, ng_netconf_opt_t opt, void *value,
-                size_t max_len)
+static int _get(ng_netdev_t *dev, ng_netopt_t opt, void *value, size_t max_len)
 {
     DEBUG("ng_netdev_eth: get ");
 
@@ -252,23 +249,23 @@ static int _get(ng_netdev_t *dev, ng_netconf_opt_t opt, void *value,
     }
 
     switch (opt) {
-        case NETCONF_OPT_ADDRESS:
+        case NG_NETOPT_ADDRESS:
             DEBUG("address\n");
             return _get_addr((ng_netdev_eth_t *)dev, value, max_len);
 
-        case NETCONF_OPT_ADDR_LEN:
+        case NG_NETOPT_ADDR_LEN:
             DEBUG("address length\n");
             return _get_addr_len(value, max_len);
 
-        case NETCONF_OPT_IPV6_IID:
+        case NG_NETOPT_IPV6_IID:
             DEBUG("IPv6 IID\n");
             return _get_iid((ng_netdev_eth_t *)dev, value, max_len);
 
-        case NETCONF_OPT_MAX_PACKET_SIZE:
+        case NG_NETOPT_MAX_PACKET_SIZE:
             DEBUG("maximum packet size\n");
             return _get_max_pkt_sz(value, max_len);
 
-        case NETCONF_OPT_PROMISCUOUSMODE:
+        case NG_NETOPT_PROMISCUOUSMODE:
             DEBUG("promiscous mode\n");
             return _get_promiscousmode((ng_netdev_eth_t *)dev, value, max_len);
 
@@ -279,10 +276,10 @@ static int _get(ng_netdev_t *dev, ng_netconf_opt_t opt, void *value,
 }
 
 /* individual option getters to be called by _get() */
-static inline int _set_promiscousmode(ng_netdev_eth_t *netdev, ng_netconf_enable_t *value,
+static inline int _set_promiscousmode(ng_netdev_eth_t *netdev, ng_netopt_enable_t *value,
                                       size_t value_len)
 {
-    if (value_len != sizeof(ng_netconf_enable_t)) {
+    if (value_len != sizeof(ng_netopt_enable_t)) {
         /* value buffer not big enough */
         return -EOVERFLOW;
     }
@@ -291,11 +288,10 @@ static inline int _set_promiscousmode(ng_netdev_eth_t *netdev, ng_netconf_enable
 
     dev->driver->set_promiscous(dev, (uint8_t)*value);
 
-    return sizeof(ng_netconf_enable_t);
+    return sizeof(ng_netopt_enable_t);
 }
 
-static int _set(ng_netdev_t *dev, ng_netconf_opt_t opt, void *value,
-                size_t value_len)
+static int _set(ng_netdev_t *dev, ng_netopt_t opt, void *value, size_t value_len)
 {
     DEBUG("ng_netdev_eth: set ");
 
@@ -305,7 +301,7 @@ static int _set(ng_netdev_t *dev, ng_netconf_opt_t opt, void *value,
     }
 
     switch (opt) {
-        case NETCONF_OPT_PROMISCUOUSMODE:
+        case NG_NETOPT_PROMISCUOUSMODE:
             DEBUG("promiscous mode\n");
             return _set_promiscousmode((ng_netdev_eth_t *)dev, value, value_len);
 

--- a/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
+++ b/sys/net/network_layer/ng_ipv6/netif/ng_ipv6_netif.c
@@ -470,7 +470,7 @@ void ng_ipv6_netif_init_by_dev(void)
 #ifdef MODULE_NG_SIXLOWPAN
         ng_nettype_t if_type = NG_NETTYPE_UNDEF;
 
-        if ((ng_netapi_get(ifs[i], NETCONF_OPT_PROTO, 0, &if_type,
+        if ((ng_netapi_get(ifs[i], NG_NETOPT_PROTO, 0, &if_type,
                            sizeof(if_type)) != -ENOTSUP) &&
             (if_type == NG_NETTYPE_SIXLOWPAN)) {
             uint16_t src_len = 8;
@@ -478,13 +478,13 @@ void ng_ipv6_netif_init_by_dev(void)
             ipv6_ifs[i].flags |= NG_IPV6_NETIF_FLAGS_SIXLOWPAN;
             /* use EUI-64 (8-byte address) for IID generation and for sending
              * packets */
-            ng_netapi_set(ifs[i], NETCONF_OPT_SRC_LEN, 0, &src_len,
+            ng_netapi_set(ifs[i], NG_NETOPT_SRC_LEN, 0, &src_len,
                           sizeof(src_len)); /* don't care for result */
         }
 
 #endif
 
-        if ((ng_netapi_get(ifs[i], NETCONF_OPT_IPV6_IID, 0, &iid,
+        if ((ng_netapi_get(ifs[i], NG_NETOPT_IPV6_IID, 0, &iid,
                            sizeof(eui64_t)) < 0)) {
             mutex_unlock(&ipv6_if->mutex);
             continue;

--- a/sys/net/network_layer/ng_ndp/ng_ndp.c
+++ b/sys/net/network_layer/ng_ndp/ng_ndp.c
@@ -640,17 +640,17 @@ static uint16_t _get_l2src(uint8_t *l2src, size_t l2src_size, kernel_pid_t iface
     const uint16_t max_short_len = 6;
 
     /* try getting source address */
-    if ((ng_netapi_get(iface, NETCONF_OPT_SRC_LEN, 0, &l2src_len,
+    if ((ng_netapi_get(iface, NG_NETOPT_SRC_LEN, 0, &l2src_len,
                        sizeof(l2src_len)) >= 0) &&
         (l2src_len > max_short_len)) {
         try_long = true;
     }
 
-    if (try_long && ((res = ng_netapi_get(iface, NETCONF_OPT_ADDRESS_LONG, 0,
+    if (try_long && ((res = ng_netapi_get(iface, NG_NETOPT_ADDRESS_LONG, 0,
                                           l2src, l2src_size)) > max_short_len)) {
         l2src_len = (uint16_t)res;
     }
-    else if ((res = ng_netapi_get(iface, NETCONF_OPT_ADDRESS, 0, l2src,
+    else if ((res = ng_netapi_get(iface, NG_NETOPT_ADDRESS, 0, l2src,
                                   l2src_size)) >= 0) {
         l2src_len = (uint16_t)res;
     }

--- a/sys/net/network_layer/ng_sixlowpan/iphc/ng_sixlowpan_iphc.c
+++ b/sys/net/network_layer/ng_sixlowpan/iphc/ng_sixlowpan_iphc.c
@@ -510,7 +510,7 @@ bool ng_sixlowpan_iphc_encode(ng_pktsnip_t *pkt)
             }
             else {
                 /* but take from driver otherwise */
-                ng_netapi_get(netif_hdr->if_pid, NETCONF_OPT_IPV6_IID, 0, &iid,
+                ng_netapi_get(netif_hdr->if_pid, NG_NETOPT_IPV6_IID, 0, &iid,
                               sizeof(eui64_t));
             }
 

--- a/sys/net/network_layer/ng_sixlowpan/ng_sixlowpan.c
+++ b/sys/net/network_layer/ng_sixlowpan/ng_sixlowpan.c
@@ -195,7 +195,7 @@ static void _send(ng_pktsnip_t *pkt)
     iface = ng_sixlowpan_netif_get(hdr->if_pid);
 
     if (iface == NULL) {
-        if (ng_netapi_get(hdr->if_pid, NETCONF_OPT_MAX_PACKET_SIZE,
+        if (ng_netapi_get(hdr->if_pid, NG_NETOPT_MAX_PACKET_SIZE,
                           0, &max_frag_size, sizeof(max_frag_size)) < 0) {
             /* if error we assume it works */
             DEBUG("6lo: can not get max packet size from interface %"

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -29,7 +29,7 @@
 #include "net/ng_ipv6/netif.h"
 #include "net/ng_netif.h"
 #include "net/ng_netapi.h"
-#include "net/ng_netconf.h"
+#include "net/ng_netopt.h"
 #include "net/ng_pkt.h"
 #include "net/ng_pktbuf.h"
 #include "net/ng_netif/hdr.h"
@@ -100,30 +100,30 @@ static void _del_usage(char *cmd_name)
            cmd_name);
 }
 
-static void _print_netconf(ng_netconf_opt_t opt)
+static void _print_netopt(ng_netopt_t opt)
 {
     switch (opt) {
-        case NETCONF_OPT_ADDRESS:
+        case NG_NETOPT_ADDRESS:
             printf("(short) address");
             break;
 
-        case NETCONF_OPT_ADDRESS_LONG:
+        case NG_NETOPT_ADDRESS_LONG:
             printf("long address");
             break;
 
-        case NETCONF_OPT_SRC_LEN:
+        case NG_NETOPT_SRC_LEN:
             printf("source address length");
             break;
 
-        case NETCONF_OPT_CHANNEL:
+        case NG_NETOPT_CHANNEL:
             printf("channel");
             break;
 
-        case NETCONF_OPT_NID:
+        case NG_NETOPT_NID:
             printf("network identifier");
             break;
 
-        case NETCONF_OPT_TX_POWER:
+        case NG_NETOPT_TX_POWER:
             printf("TX power [in dBm]");
             break;
 
@@ -133,25 +133,25 @@ static void _print_netconf(ng_netconf_opt_t opt)
     }
 }
 
-static void _print_netconf_state(ng_netconf_state_t state)
+static void _print_netopt_state(ng_netopt_state_t state)
 {
     switch (state) {
-        case NETCONF_STATE_OFF:
+        case NG_NETOPT_STATE_OFF:
             printf("OFF");
             break;
-        case NETCONF_STATE_SLEEP:
+        case NG_NETOPT_STATE_SLEEP:
             printf("SLEEP");
             break;
-        case NETCONF_STATE_IDLE:
+        case NG_NETOPT_STATE_IDLE:
             printf("IDLE");
             break;
-        case NETCONF_STATE_RX:
+        case NG_NETOPT_STATE_RX:
             printf("RX");
             break;
-        case NETCONF_STATE_TX:
+        case NG_NETOPT_STATE_TX:
             printf("TX");
             break;
-        case NETCONF_STATE_RESET:
+        case NG_NETOPT_STATE_RESET:
             printf("RESET");
             break;
         default:
@@ -166,8 +166,8 @@ static void _netif_list(kernel_pid_t dev)
     uint16_t u16;
     int16_t i16;
     int res;
-    ng_netconf_state_t state;
-    ng_netconf_enable_t enable;
+    ng_netopt_state_t state;
+    ng_netopt_enable_t enable;
     bool linebreak = false;
 #ifdef MODULE_NG_IPV6_NETIF
     ng_ipv6_netif_t *entry = ng_ipv6_netif_get(dev);
@@ -177,7 +177,7 @@ static void _netif_list(kernel_pid_t dev)
 
     printf("Iface %2d  ", dev);
 
-    res = ng_netapi_get(dev, NETCONF_OPT_ADDRESS, 0, hwaddr, sizeof(hwaddr));
+    res = ng_netapi_get(dev, NG_NETOPT_ADDRESS, 0, hwaddr, sizeof(hwaddr));
 
     if (res >= 0) {
         char hwaddr_str[res * 3];
@@ -187,34 +187,34 @@ static void _netif_list(kernel_pid_t dev)
         printf(" ");
     }
 
-    res = ng_netapi_get(dev, NETCONF_OPT_CHANNEL, 0, &u16, sizeof(u16));
+    res = ng_netapi_get(dev, NG_NETOPT_CHANNEL, 0, &u16, sizeof(u16));
 
     if (res >= 0) {
         printf(" Channel: %" PRIu16 " ", u16);
     }
 
-    res = ng_netapi_get(dev, NETCONF_OPT_NID, 0, &u16, sizeof(u16));
+    res = ng_netapi_get(dev, NG_NETOPT_NID, 0, &u16, sizeof(u16));
 
     if (res >= 0) {
         printf(" NID: 0x%" PRIx16 " ", u16);
     }
 
-    res = ng_netapi_get(dev, NETCONF_OPT_TX_POWER, 0, &i16, sizeof(i16));
+    res = ng_netapi_get(dev, NG_NETOPT_TX_POWER, 0, &i16, sizeof(i16));
 
     if (res >= 0) {
         printf(" TX-Power: %" PRIi16 "dBm ", i16);
     }
 
-    res = ng_netapi_get(dev, NETCONF_OPT_STATE, 0, &state, sizeof(state));
+    res = ng_netapi_get(dev, NG_NETOPT_STATE, 0, &state, sizeof(state));
 
     if (res >= 0) {
         printf(" State: ");
-        _print_netconf_state(state);
+        _print_netopt_state(state);
     }
 
     printf("\n           ");
 
-    res = ng_netapi_get(dev, NETCONF_OPT_ADDRESS_LONG, 0, hwaddr, sizeof(hwaddr));
+    res = ng_netapi_get(dev, NG_NETOPT_ADDRESS_LONG, 0, hwaddr, sizeof(hwaddr));
 
     if (res >= 0) {
         char hwaddr_str[res * 3];
@@ -224,30 +224,30 @@ static void _netif_list(kernel_pid_t dev)
         printf("\n           ");
     }
 
-    res = ng_netapi_get(dev, NETCONF_OPT_PROMISCUOUSMODE, 0, &enable, sizeof(enable));
+    res = ng_netapi_get(dev, NG_NETOPT_PROMISCUOUSMODE, 0, &enable, sizeof(enable));
 
-    if ((res >= 0) && (enable == NETCONF_ENABLE)) {
+    if ((res >= 0) && (enable == NG_NETOPT_ENABLE)) {
         printf("PROMISC  ");
         linebreak = true;
     }
 
-    res = ng_netapi_get(dev, NETCONF_OPT_AUTOACK, 0, &enable, sizeof(enable));
+    res = ng_netapi_get(dev, NG_NETOPT_AUTOACK, 0, &enable, sizeof(enable));
 
-    if ((res >= 0) && (enable == NETCONF_ENABLE)) {
+    if ((res >= 0) && (enable == NG_NETOPT_ENABLE)) {
         printf("AUTOACK  ");
         linebreak = true;
     }
 
-    res = ng_netapi_get(dev, NETCONF_OPT_PRELOADING, 0, &enable, sizeof(enable));
+    res = ng_netapi_get(dev, NG_NETOPT_PRELOADING, 0, &enable, sizeof(enable));
 
-    if ((res >= 0) && (enable == NETCONF_ENABLE)) {
+    if ((res >= 0) && (enable == NG_NETOPT_ENABLE)) {
         printf("PRELOAD  ");
         linebreak = true;
     }
 
-    res = ng_netapi_get(dev, NETCONF_OPT_RAWMODE, 0, &enable, sizeof(enable));
+    res = ng_netapi_get(dev, NG_NETOPT_RAWMODE, 0, &enable, sizeof(enable));
 
-    if ((res >= 0) && (enable == NETCONF_ENABLE)) {
+    if ((res >= 0) && (enable == NG_NETOPT_ENABLE)) {
         printf("RAWMODE  ");
         linebreak = true;
     }
@@ -263,7 +263,7 @@ static void _netif_list(kernel_pid_t dev)
         printf("\n           ");
     }
 
-    res = ng_netapi_get(dev, NETCONF_OPT_SRC_LEN, 0, &u16, sizeof(u16));
+    res = ng_netapi_get(dev, NG_NETOPT_SRC_LEN, 0, &u16, sizeof(u16));
 
     if (res >= 0) {
         printf("Source address length: %" PRIu16 "\n           ", u16);
@@ -307,8 +307,7 @@ static void _netif_list(kernel_pid_t dev)
     puts("");
 }
 
-static int _netif_set_u16(kernel_pid_t dev, ng_netconf_opt_t opt,
-                          char *u16_str)
+static int _netif_set_u16(kernel_pid_t dev, ng_netopt_t opt, char *u16_str)
 {
     unsigned int res;
     bool hex = false;
@@ -338,13 +337,13 @@ static int _netif_set_u16(kernel_pid_t dev, ng_netconf_opt_t opt,
 
     if (ng_netapi_set(dev, opt, 0, (uint16_t *)&res, sizeof(uint16_t)) < 0) {
         printf("error: unable to set ");
-        _print_netconf(opt);
+        _print_netopt(opt);
         puts("");
         return 1;
     }
 
     printf("success: set ");
-    _print_netconf(opt);
+    _print_netopt(opt);
     printf(" on interface %" PRIkernel_pid " to ", dev);
 
     if (hex) {
@@ -357,29 +356,28 @@ static int _netif_set_u16(kernel_pid_t dev, ng_netconf_opt_t opt,
     return 0;
 }
 
-static int _netif_set_i16(kernel_pid_t dev, ng_netconf_opt_t opt,
-                          char *i16_str)
+static int _netif_set_i16(kernel_pid_t dev, ng_netopt_t opt, char *i16_str)
 {
     int16_t val = (int16_t)atoi(i16_str);
 
     if (ng_netapi_set(dev, opt, 0, (int16_t *)&val, sizeof(int16_t)) < 0) {
         printf("error: unable to set ");
-        _print_netconf(opt);
+        _print_netopt(opt);
         puts("");
         return 1;
     }
 
     printf("success: set ");
-    _print_netconf(opt);
+    _print_netopt(opt);
     printf(" on interface %" PRIkernel_pid " to %i\n", dev, val);
 
     return 0;
 }
 
-static int _netif_set_flag(kernel_pid_t dev, ng_netconf_opt_t opt,
-                           ng_netconf_enable_t set)
+static int _netif_set_flag(kernel_pid_t dev, ng_netopt_t opt,
+                           ng_netopt_enable_t set)
 {
-    if (ng_netapi_set(dev, opt, 0, &set, sizeof(ng_netconf_enable_t)) < 0) {
+    if (ng_netapi_set(dev, opt, 0, &set, sizeof(ng_netopt_enable_t)) < 0) {
         puts("error: unable to set option");
         return 1;
     }
@@ -387,8 +385,7 @@ static int _netif_set_flag(kernel_pid_t dev, ng_netconf_opt_t opt,
     return 0;
 }
 
-static int _netif_set_addr(kernel_pid_t dev, ng_netconf_opt_t opt,
-                           char *addr_str)
+static int _netif_set_addr(kernel_pid_t dev, ng_netopt_t opt, char *addr_str)
 {
     uint8_t addr[MAX_ADDR_LEN];
     size_t addr_len = ng_netif_addr_from_str(addr, sizeof(addr), addr_str);
@@ -402,13 +399,13 @@ static int _netif_set_addr(kernel_pid_t dev, ng_netconf_opt_t opt,
 
     if (ng_netapi_set(dev, opt, 0, addr, addr_len) < 0) {
         printf("error: unable to set ");
-        _print_netconf(opt);
+        _print_netopt(opt);
         puts("");
         return 1;
     }
 
     printf("success: set ");
-    _print_netconf(opt);
+    _print_netopt(opt);
     printf(" on interface %" PRIkernel_pid " to %s\n", dev, addr_str);
 
     return 0;
@@ -416,35 +413,35 @@ static int _netif_set_addr(kernel_pid_t dev, ng_netconf_opt_t opt,
 
 static int _netif_set_state(kernel_pid_t dev, char *state_str)
 {
-    ng_netconf_state_t state;
+    ng_netopt_state_t state;
     if ((strcmp("off", state_str) == 0) || (strcmp("OFF", state_str) == 0)) {
-        state = NETCONF_STATE_OFF;
+        state = NG_NETOPT_STATE_OFF;
     }
     else if ((strcmp("sleep", state_str) == 0) ||
              (strcmp("SLEEP", state_str) == 0)) {
-        state = NETCONF_STATE_SLEEP;
+        state = NG_NETOPT_STATE_SLEEP;
     }
     else if ((strcmp("idle", state_str) == 0) ||
              (strcmp("IDLE", state_str) == 0)) {
-        state = NETCONF_STATE_IDLE;
+        state = NG_NETOPT_STATE_IDLE;
     }
     else if ((strcmp("reset", state_str) == 0) ||
              (strcmp("RESET", state_str) == 0)) {
-        state = NETCONF_STATE_RESET;
+        state = NG_NETOPT_STATE_RESET;
     }
     else {
         puts("usage: ifconfig <if_id> set state [off|sleep|idle|reset]");
         return 1;
     }
-    if (ng_netapi_set(dev, NETCONF_OPT_STATE, 0,
-                      &state, sizeof(ng_netconf_state_t)) < 0) {
+    if (ng_netapi_set(dev, NG_NETOPT_STATE, 0,
+                      &state, sizeof(ng_netopt_state_t)) < 0) {
         printf("error: unable to set state to ");
-        _print_netconf_state(state);
+        _print_netopt_state(state);
         puts("");
         return 1;
     }
     printf("success: set state of interface %" PRIkernel_pid " to ", dev);
-    _print_netconf_state(state);
+    _print_netopt_state(state);
     puts("");
 
     return 0;
@@ -453,23 +450,23 @@ static int _netif_set_state(kernel_pid_t dev, char *state_str)
 static int _netif_set(char *cmd_name, kernel_pid_t dev, char *key, char *value)
 {
     if ((strcmp("addr", key) == 0) || (strcmp("addr_short", key) == 0)) {
-        return _netif_set_addr(dev, NETCONF_OPT_ADDRESS, value);
+        return _netif_set_addr(dev, NG_NETOPT_ADDRESS, value);
     }
     else if (strcmp("addr_long", key) == 0) {
-        return _netif_set_addr(dev, NETCONF_OPT_ADDRESS_LONG, value);
+        return _netif_set_addr(dev, NG_NETOPT_ADDRESS_LONG, value);
     }
     else if ((strcmp("channel", key) == 0) || (strcmp("chan", key) == 0)) {
-        return _netif_set_u16(dev, NETCONF_OPT_CHANNEL, value);
+        return _netif_set_u16(dev, NG_NETOPT_CHANNEL, value);
     }
     else if ((strcmp("nid", key) == 0) || (strcmp("pan", key) == 0) ||
              (strcmp("pan_id", key) == 0)) {
-        return _netif_set_u16(dev, NETCONF_OPT_NID, value);
+        return _netif_set_u16(dev, NG_NETOPT_NID, value);
     }
     else if (strcmp("power", key) == 0) {
-        return _netif_set_i16(dev, NETCONF_OPT_TX_POWER, value);
+        return _netif_set_i16(dev, NG_NETOPT_TX_POWER, value);
     }
     else if (strcmp("src_len", key) == 0) {
-        return _netif_set_u16(dev, NETCONF_OPT_SRC_LEN, value);
+        return _netif_set_u16(dev, NG_NETOPT_SRC_LEN, value);
     }
     else if (strcmp("state", key) == 0) {
         return _netif_set_state(dev, value);
@@ -481,24 +478,24 @@ static int _netif_set(char *cmd_name, kernel_pid_t dev, char *key, char *value)
 
 static int _netif_flag(char *cmd, kernel_pid_t dev, char *flag)
 {
-    ng_netconf_enable_t set = NETCONF_ENABLE;
+    ng_netopt_enable_t set = NG_NETOPT_ENABLE;
 
     if (flag[0] == '-') {
-        set = NETCONF_DISABLE;
+        set = NG_NETOPT_DISABLE;
         flag++;
     }
 
     if (strcmp(flag, "promisc") == 0) {
-        return _netif_set_flag(dev, NETCONF_OPT_PROMISCUOUSMODE, set);
+        return _netif_set_flag(dev, NG_NETOPT_PROMISCUOUSMODE, set);
     }
     else if (strcmp(flag, "preload") == 0) {
-        return _netif_set_flag(dev, NETCONF_OPT_PRELOADING, set);
+        return _netif_set_flag(dev, NG_NETOPT_PRELOADING, set);
     }
     else if (strcmp(flag, "autoack") == 0) {
-        return _netif_set_flag(dev, NETCONF_OPT_AUTOACK, set);
+        return _netif_set_flag(dev, NG_NETOPT_AUTOACK, set);
     }
     else if (strcmp(flag, "raw") == 0) {
-        return _netif_set_flag(dev, NETCONF_OPT_RAWMODE, set);
+        return _netif_set_flag(dev, NG_NETOPT_RAWMODE, set);
     }
     else if (strcmp(flag, "6lo") == 0) {
 #ifdef MODULE_NG_IPV6_NETIF


### PR DESCRIPTION
Since [NETCONF](https://tools.ietf.org/html/rfc4741) is also a network protocol, the naming of this module already led to some issues regarding communicating about it. This is just an initial rename commit to ask for comments. If there is interest I will adapt the code using the types defined here.