### PR TITLE
libcoap: switch to the RIOT-OS mirror

### DIFF
--- a/pkg/libcoap/Makefile
+++ b/pkg/libcoap/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME=libcoap
-PKG_URL=http://git.code.sf.net/p/libcoap/code
+PKG_URL=http://github.com/RIOT-OS/libcoap
 PKG_VERSION=ef41ce5d02d64cec0751882ae8fd95f6c32bc018
 PKG_DIR=$(CURDIR)/$(PKG_NAME)
 


### PR DESCRIPTION
At least until sf.net is up again.

@OlafBergmann, do you have a more recent version mirrored somewhere?