### PR TITLE
cpu/kinetis_common: Cast device index enums to unsigned int before comparing for out of range values

### DIFF
--- a/cpu/kinetis_common/gpio.c
+++ b/cpu/kinetis_common/gpio.c
@@ -675,7 +675,7 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 
 void gpio_irq_enable(gpio_t dev)
 {
-    if (dev >= GPIO_NUMOF) {
+    if ((unsigned int)dev >= GPIO_NUMOF) {
         DEBUG("gpio_t out of range: %d >= %d\n", dev, GPIO_NUMOF);
         return;
     }
@@ -689,7 +689,7 @@ void gpio_irq_enable(gpio_t dev)
 
 void gpio_irq_disable(gpio_t dev)
 {
-    if (dev >= GPIO_NUMOF) {
+    if ((unsigned int)dev >= GPIO_NUMOF) {
         DEBUG("gpio_t out of range: %d >= %d\n", dev, GPIO_NUMOF);
         return;
     }
@@ -703,7 +703,7 @@ void gpio_irq_disable(gpio_t dev)
 
 int gpio_read(gpio_t dev)
 {
-    if (dev >= GPIO_NUMOF) {
+    if ((unsigned int)dev >= GPIO_NUMOF) {
         DEBUG("gpio_t out of range: %d >= %d\n", dev, GPIO_NUMOF);
         return -1;
     }
@@ -722,7 +722,7 @@ int gpio_read(gpio_t dev)
 
 void gpio_set(gpio_t dev)
 {
-    if (dev >= GPIO_NUMOF) {
+    if ((unsigned int)dev >= GPIO_NUMOF) {
         DEBUG("gpio_t out of range: %d >= %d\n", dev, GPIO_NUMOF);
         return;
     }
@@ -731,7 +731,7 @@ void gpio_set(gpio_t dev)
 
 void gpio_clear(gpio_t dev)
 {
-    if (dev >= GPIO_NUMOF) {
+    if ((unsigned int)dev >= GPIO_NUMOF) {
         DEBUG("gpio_t out of range: %d >= %d\n", dev, GPIO_NUMOF);
         return;
     }
@@ -740,7 +740,7 @@ void gpio_clear(gpio_t dev)
 
 void gpio_toggle(gpio_t dev)
 {
-    if (dev >= GPIO_NUMOF) {
+    if ((unsigned int)dev >= GPIO_NUMOF) {
         DEBUG("gpio_t out of range: %d >= %d\n", dev, GPIO_NUMOF);
         return;
     }

--- a/cpu/kinetis_common/i2c.c
+++ b/cpu/kinetis_common/i2c.c
@@ -58,7 +58,7 @@ static mutex_t locks[] =  {
 
 int i2c_acquire(i2c_t dev)
 {
-    if (dev >= I2C_NUMOF) {
+    if ((unsigned int)dev >= I2C_NUMOF) {
         return -1;
     }
     mutex_lock(&locks[dev]);
@@ -67,7 +67,7 @@ int i2c_acquire(i2c_t dev)
 
 int i2c_release(i2c_t dev)
 {
-    if (dev >= I2C_NUMOF) {
+    if ((unsigned int)dev >= I2C_NUMOF) {
         return -1;
     }
     mutex_unlock(&locks[dev]);

--- a/cpu/kinetis_common/spi.c
+++ b/cpu/kinetis_common/spi.c
@@ -852,7 +852,7 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
 
 int spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
 
@@ -862,7 +862,7 @@ int spi_acquire(spi_t dev)
 
 int spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
 


### PR DESCRIPTION
Suppresses false warning in Clang:

    warning: comparison of constant 42 with expression of type 'xxx_t'
    is always false [-Wtautological-constant-out-of-range-compare]

See:
 - https://llvm.org/bugs/show_bug.cgi?id=16154
 - https://llvm.org/bugs/show_bug.cgi?id=22062