### PR TITLE
scan-build: Add make goal for running Clang static code analyzer (ccc-analyzer)

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -51,6 +51,7 @@ export DOCKER_ENV_VARS = \
   UNDEF \
   BUILDTEST_MCU_GROUP \
   BUILDTEST_VERBOSE \
+  TOOLCHAIN \
   #
 
 # Find which variables were set using the command line or the environment and
@@ -59,9 +60,9 @@ export DOCKER_ENV_VARS = \
 # of the environment variables will be overwritten by Makefile.include and their
 # origin is changed to "file"
 DOCKER_ENVIRONMENT_CMDLINE := $(foreach varname,$(DOCKER_ENV_VARS), \
-    $(if $(filter environment command,$(origin $(varname))), \
-    -e '$(varname)=$($(varname))', \
-    ))
+  $(if $(filter environment command,$(origin $(varname))), \
+  -e '$(varname)=$(subst ','\'',$($(varname)))', \
+  ))
 DOCKER_ENVIRONMENT_CMDLINE := $(strip $(DOCKER_ENVIRONMENT_CMDLINE))
 
 # This will execute `make $(DOCKER_MAKECMDGOALS)` inside a Docker container.

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -24,38 +24,38 @@ export DOCKER_MAKECMDGOALS ?= all
 # Docker container, they will only be passed if they are set from the
 # environment, not if they are only default Makefile values.
 export DOCKER_ENV_VARS = \
-  BINDIRBASE \
-  BOARD \
-  QUIET \
-  RIOT_VERSION \
   APPDIR \
-  BINDIR \
-  BUILDRELPATH \
-  ELFFILE \
-  HEXFILE \
-  LINKFLAGPREFIX \
-  CPPMIX \
-  PREFIX \
-  CC \
-  CXX \
-  CFLAGS \
-  CXXUWFLAGS \
-  CXXEXFLAGS \
   AR \
   ARFLAGS \
   AS \
   ASFLAGS \
+  BINDIR \
+  BINDIRBASE \
+  BOARD \
+  BUILDRELPATH \
+  BUILDTEST_MCU_GROUP \
+  BUILDTEST_VERBOSE \
+  CC \
+  CFLAGS \
+  CPPMIX \
+  CXX \
+  CXXEXFLAGS \
+  CXXUWFLAGS \
+  ELFFILE \
+  HEXFILE \
   LINK \
+  LINKFLAGPREFIX \
   LINKFLAGS \
   OBJCOPY \
   OFLAGS \
-  SIZE \
-  UNDEF \
-  BUILDTEST_MCU_GROUP \
-  BUILDTEST_VERBOSE \
-  TOOLCHAIN \
-  SCANBUILD_OUTPUTDIR \
+  PREFIX \
+  QUIET \
+  RIOT_VERSION \
   SCANBUILD_ARGS \
+  SCANBUILD_OUTPUTDIR \
+  SIZE \
+  TOOLCHAIN \
+  UNDEF \
   #
 
 # Find which variables were set using the command line or the environment and

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -8,6 +8,14 @@ export DOCKER_MAKECMDGOALS_POSSIBLE = \
   #
 export DOCKER_MAKECMDGOALS = $(filter $(MAKECMDGOALS),$(DOCKER_MAKECMDGOALS_POSSIBLE))
 
+# Docker creates the files .dockerinit and .dockerenv in the root directory of
+# the container, we check for the files to determine if we are inside a container.
+ifneq (,$(wildcard /.dockerinit /.dockerenv))
+  export INSIDE_DOCKER := 1
+else
+  export INSIDE_DOCKER := 0
+endif
+
 # Default target for building inside a Docker container if nothing was given
 export DOCKER_MAKECMDGOALS ?= all
 # List of all exported environment variables that shall be passed on to the

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -79,6 +79,7 @@ DOCKER_ENVIRONMENT_CMDLINE := $(strip $(DOCKER_ENVIRONMENT_CMDLINE))
 	    -v '$(RIOTCPU):$(DOCKER_BUILD_ROOT)/riotcpu' \
 	    -v '$(RIOTBOARD):$(DOCKER_BUILD_ROOT)/riotboard' \
 	    -v '$(RIOTPROJECT):$(DOCKER_BUILD_ROOT)/riotproject' \
+	    -v /etc/localtime:/etc/localtime:ro \
 	    -e 'RIOTBASE=$(DOCKER_BUILD_ROOT)/riotbase' \
 	    -e 'RIOTCPU=$(DOCKER_BUILD_ROOT)/riotcpu' \
 	    -e 'RIOTBOARD=$(DOCKER_BUILD_ROOT)/riotboard' \

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -5,6 +5,8 @@ export DOCKER_FLAGS ?= --rm
 export DOCKER_MAKECMDGOALS_POSSIBLE = \
   all \
   buildtest \
+  scan-build \
+  scan-build-analyze \
   #
 export DOCKER_MAKECMDGOALS = $(filter $(MAKECMDGOALS),$(DOCKER_MAKECMDGOALS_POSSIBLE))
 
@@ -52,6 +54,8 @@ export DOCKER_ENV_VARS = \
   BUILDTEST_MCU_GROUP \
   BUILDTEST_VERBOSE \
   TOOLCHAIN \
+  SCANBUILD_OUTPUTDIR \
+  SCANBUILD_ARGS \
   #
 
 # Find which variables were set using the command line or the environment and

--- a/Makefile.include
+++ b/Makefile.include
@@ -18,6 +18,9 @@ RIOTPROJECT := $(abspath $(RIOTPROJECT))
 # using abspath, strip etc.
 include $(RIOTBASE)/Makefile.docker
 
+# Static code analysis tools provided by LLVM
+include $(RIOTBASE)/Makefile.scan-build
+
 # Path to the current directory relative to the git root
 BUILDRELPATH ?= $(shell git rev-parse --show-prefix)
 
@@ -52,6 +55,12 @@ ifeq (, ${JENKINS_URL})
       COLOR_ECHO   := /bin/echo -e
     endif
   endif
+endif
+
+ifeq ($(OS),Darwin)
+  OPEN   := open
+else
+  OPEN   := xdg-open
 endif
 
 ifeq ($(QUIET),1)

--- a/Makefile.scan-build
+++ b/Makefile.scan-build
@@ -1,0 +1,91 @@
+SCANBUILD_ENV_VARS := \
+  APPDIR \
+  AR \
+  ARFLAGS \
+  AS \
+  ASFLAGS \
+  BINDIR \
+  BINDIRBASE \
+  BOARD \
+  BUILDRELPATH \
+  CC \
+  CFLAGS \
+  CPPMIX \
+  CXX \
+  CXXEXFLAGS \
+  CXXUWFLAGS \
+  ELFFILE \
+  HEXFILE \
+  HOME \
+  LINK \
+  LINKFLAGPREFIX \
+  LINKFLAGS \
+  OBJCOPY \
+  OFLAGS \
+  PATH \
+  PREFIX \
+  QUIET \
+  RIOT_VERSION \
+  SIZE \
+  TOOLCHAIN \
+  UNDEF \
+  USER \
+  #
+
+SCANBUILD_ARGS ?= \
+  -analyze-headers \
+  --use-cc=$(CC) \
+  --use-c++=$(CXX) \
+  -analyzer-config stable-report-filename=true \
+  #
+
+export SCANBUILD_OUTPUTDIR = $(CURDIR)/scan-build/
+
+# Find all variables given on the command line and recreate the command.
+CMDVARS := $(strip $(foreach varname, $(SCANBUILD_ENV_VARS), \
+  $(if $(filter command, $(origin $(varname))), \
+  '$(varname)=$(subst ','\'',$($(varname)))', \
+  )))
+ENVVARS := $(strip $(foreach varname, $(SCANBUILD_ENV_VARS), \
+  $(if $(filter environment, $(origin $(varname))), \
+  '$(varname)=$(subst ','\'',$($(varname)))', \
+  )))
+
+.PHONY: scan-build scan-build-analyze scan-build-view
+scan-build: scan-build-view scan-build-analyze
+scan-build-view: scan-build-analyze
+ifeq ($(BUILD_IN_DOCKER),1)
+scan-build-analyze: ..in-docker-container
+else # BUILD_IN_DOCKER
+scan-build-analyze: clean
+	@$(COLOR_ECHO) '$(COLOR_GREEN)Performing Clang static code analysis using toolchain "$(TOOLCHAIN)".$(COLOR_RESET)'
+# ccc-analyzer needs to be told the proper -target setting for best results,
+# otherwise false error reports about unknown register names etc will be produced.
+# These kinds of errors can be safely ignored as long as they only come from LLVM
+	@if [ "$${TOOLCHAIN}" != "llvm" -a "$${BOARD}" != "native" ]; then \
+	  $(COLOR_ECHO) '$(COLOR_YELLOW)Recommend using TOOLCHAIN=llvm for best results.$(COLOR_RESET)'; \
+	  $(COLOR_ECHO) '$(COLOR_YELLOW)Ignore any "error: unknown register name '\''rX'\'' in asm" messages.$(COLOR_RESET)'; \
+	fi
+	$(AD)mkdir -p '$(SCANBUILD_OUTPUTDIR)'
+	$(AD)env -i $(ENVVARS) \
+	    scan-build -o '$(SCANBUILD_OUTPUTDIR)' $(SCANBUILD_ARGS) \
+	      make -C $(CURDIR) all $(strip $(CMDVARS));
+endif # BUILD_IN_DOCKER
+
+ifeq (1,$(INSIDE_DOCKER))
+scan-build-view:
+	@
+else
+	@echo "Showing most recent report in your web browser..."
+	@REPORT_FILE="$$(find '$(SCANBUILD_OUTPUTDIR)' -maxdepth 2 -mindepth 2 \
+	            -type f -name 'index.html' 2>/dev/null | sort | tail -n 1)"; \
+	  if [ -n "$${REPORT_FILE}" ]; then \
+	    echo "$(OPEN) $${REPORT_FILE}"; \
+	    $(OPEN) "$${REPORT_FILE}"; \
+	  else \
+	    echo "No report found"; \
+	  fi
+endif
+
+# Reset the default goal.
+.DEFAULT_GOAL :=


### PR DESCRIPTION
usage:
`make scan-build` will generate a report under `$PWD/scan-build/.....` and open it in the user's web browser of choice.

supported running inside a Docker container as well.

Some Docker fixes are included:
 - Pass TOOLCHAIN variable to container
 - Share `/etc/localtime` with container (the current time is used as a base for the output directory name, it gets confusing for the user when the time zone is wrong inside the container)
 - Sorted all environment variable names in Makefile.docker, for easier navigation
 - Detect if running inside Docker (avoid calling xdg-open inside the container)