### PR TITLE
ipv6: increase number of addresses per interface

### DIFF
--- a/sys/include/net/ng_ipv6/netif.h
+++ b/sys/include/net/ng_ipv6/netif.h
@@ -42,9 +42,9 @@ extern "C" {
  */
 #ifndef NG_IPV6_NETIF_ADDR_NUMOF
 #ifdef MODULE_NG_IPV6_ROUTER
-#define NG_IPV6_NETIF_ADDR_NUMOF    (5) /* router needs all-routers multicast address */
+#define NG_IPV6_NETIF_ADDR_NUMOF    (7) /* router needs all-routers multicast address */
 #else
-#define NG_IPV6_NETIF_ADDR_NUMOF    (4)
+#define NG_IPV6_NETIF_ADDR_NUMOF    (6)
 #endif
 #endif
 


### PR DESCRIPTION
Otherwise one cannot even add a single address to the default configuration, e.g. a manual configured global unicast address, because adding of the corresponding solicited node multicast address will fail.