### PR TITLE
mulle: Initialize NVRAM storage at boot, update boot counter

### DIFF
--- a/boards/mulle/Makefile.dep
+++ b/boards/mulle/Makefile.dep
@@ -6,6 +6,9 @@ endif
 # The RTT clock drives the core clock in the default configuration
 FEATURES_REQUIRED += periph_rtt
 
+# The RTT clock drives the core clock in the default configuration
+FEATURES_REQUIRED += periph_rtt
+
 # The Mulle uses NVRAM to store persistent variables, such as boot count.
-#~ USEMODULE += nvram_spi
-# Uncomment above when #2353 is merged.
+USEMODULE += nvram_spi
+FEATURES_REQUIRED += periph_spi

--- a/boards/mulle/include/board.h
+++ b/boards/mulle/include/board.h
@@ -23,6 +23,7 @@
 
 #include "cpu.h"
 #include "periph_conf.h"
+#include "mulle-nvram.h"
 
 /* Use the on board RTC 32kHz clock for LPTMR clocking. */
 #undef LPTIMER_CLKSRC
@@ -118,6 +119,17 @@ void board_init(void);
 #define MULLE_POWER_AVDD    GPIO_6 /**< AVDD enable pin */
 #define MULLE_POWER_VPERIPH GPIO_7 /**< VPERIPH enable pin */
 #define MULLE_POWER_VSEC    GPIO_5 /**< VSEC enable pin */
+/** @} */
+
+/**
+ * @name Mulle NVRAM hardware configuration
+ */
+/** @{ */
+/** FRAM SPI bus, SPI_2 in RIOT is mapped to hardware bus SPI0, see periph_conf.h */
+#define MULLE_NVRAM_SPI_DEV           SPI_2
+#define MULLE_NVRAM_SPI_CS            GPIO_16 /**< FRAM CS pin */
+#define MULLE_NVRAM_CAPACITY          512     /**< FRAM size, in bytes */
+#define MULLE_NVRAM_SPI_ADDRESS_COUNT 1       /**< FRAM addressing size, in bytes */
 /** @} */
 
 /**

--- a/boards/mulle/include/mulle-nvram.h
+++ b/boards/mulle/include/mulle-nvram.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+#ifndef MULLE_NVRAM_H_
+#define MULLE_NVRAM_H_
+
+#include "nvram.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @ingroup     board_mulle
+ * @{
+ *
+ * @file
+ * @brief       NVRAM offsets for the Eistec Mulle IoT board
+ *
+ * @author      Joakim Gebart <joakim.gebart@eistec.se>
+ */
+
+typedef enum mulle_nvram_address {
+    /** @brief NVRAM magic number, used to identify an initialized FRAM device. */
+    MULLE_NVRAM_MAGIC        = 0x0000,
+    /** @brief Reboot counter */
+    MULLE_NVRAM_BOOT_COUNT = 0x0004,
+} mulle_nvram_address_t;
+
+#define MULLE_NVRAM_MAGIC_EXPECTED (0x4c4c554dul) /* == "MULL" in ASCII */
+
+extern nvram_t *mulle_nvram;
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MULLE_NVRAM_H_ */


### PR DESCRIPTION
Add initialization of the on-board NVRAM chip, and write a 32 bit boot counter to the NVRAM on each boot.

Also includes a cleanup commit for removing some leftovers from the unification of Cortex-M platform code.