### PR TITLE
ng_ndp: passing integer instead of pointer to fib

### DIFF
--- a/sys/net/network_layer/ng_ndp/ng_ndp.c
+++ b/sys/net/network_layer/ng_ndp/ng_ndp.c
@@ -441,7 +441,7 @@ kernel_pid_t ng_ndp_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
     if ((next_hop_ip == NULL) &&
         (fib_get_next_hop(&iface, next_hop_actual.u8, &next_hop_size,
                           &next_hop_flags, (uint8_t *)dst,
-                          &next_hop_size, 0) >= 0) &&
+                          sizeof(ng_ipv6_addr_t), 0) >= 0) &&
         (next_hop_size == sizeof(ng_ipv6_addr_t))) {
         next_hop_ip = &next_hop_actual;
     }


### PR DESCRIPTION
c1e20c51561ba6df5cc4cc9191ff4593e643fb4d broke it.