### PR TITLE
ng_rpl: auto address configuration

### DIFF
--- a/sys/include/net/ng_rpl.h
+++ b/sys/include/net/ng_rpl.h
@@ -210,6 +210,16 @@ static inline bool NG_RPL_COUNTER_GREATER_THAN(uint8_t A, uint8_t B)
 #define NG_RPL_LIFETIME_STEP (2)
 
 /**
+ * @brief Default prefix length for the DODAG id
+ */
+#define NG_RPL_DEFAULT_PREFIX_LEN   (64)
+
+/**
+ * @brief Default prefix valid and preferred time for the DODAG id
+ */
+#define NG_RPL_DEFAULT_PREFIX_LIFETIME  (0xFFFFFFFF)
+
+/**
  * @brief A DODAG can be grounded or floating
  * @see <a href="https://tools.ietf.org/html/rfc6550#section-3.2.4">
  *          Grounded and Floating DODAGs

--- a/sys/include/net/ng_rpl/structs.h
+++ b/sys/include/net/ng_rpl/structs.h
@@ -147,6 +147,23 @@ typedef struct __attribute__((packed)) {
     uint8_t path_lifetime;      /**< lifetime of routes */
 } ng_rpl_opt_transit_t;
 
+/**
+ * @brief Prefix Information Option
+ * @see <a href="https://tools.ietf.org/html/rfc6550#section-6.7.10">
+ *          RFC6550, section 6.7.10, Prefix Information
+ *      </a>
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t type;               /**< option type */
+    uint8_t length;             /**< option length without the first two bytes */
+    uint8_t prefix_len;         /**< prefix length */
+    uint8_t LAR_flags;          /**< flags and resereved */
+    uint32_t valid_lifetime;    /**< valid lifetime */
+    uint32_t pref_lifetime;     /**< preferred lifetime */
+    uint32_t reserved;          /**< reserved */
+    ipv6_addr_t prefix;         /**< prefix used for Stateless Address Autoconfiguration */
+} ng_rpl_opt_prefix_info_t;
+
 typedef struct ng_rpl_dodag ng_rpl_dodag_t;
 typedef struct ng_rpl_parent ng_rpl_parent_t;
 
@@ -201,6 +218,9 @@ struct ng_rpl_dodag {
     ng_rpl_dodag_t *next;           /**< pointer to the next dodag */
     ng_rpl_parent_t *parents;       /**< pointer to the parents list of this DODAG */
     ipv6_addr_t dodag_id;           /**< id of the DODAG */
+    uint8_t prefix_len;             /**< length of the prefix for the DODAG id */
+    uint32_t addr_preferred;        /**< time in seconds the DODAG id is preferred */
+    uint32_t addr_valid;            /**< time in seconds the DODAG id is valid */
     uint8_t state;                  /**< 0 for unused, 1 for used */
     uint8_t dtsn;                   /**< DAO Trigger Sequence Number */
     uint8_t prf;                    /**< preferred flag */

--- a/sys/net/routing/ng_rpl/ng_rpl.c
+++ b/sys/net/routing/ng_rpl/ng_rpl.c
@@ -106,6 +106,7 @@ static ng_rpl_dodag_t *_root_dodag_init(uint8_t instance_id, ipv6_addr_t *dodag_
     }
 
     ipv6_addr_t *configured_addr;
+    ng_ipv6_netif_addr_t *netif_addr = NULL;
     ng_rpl_instance_t *inst = NULL;
     ng_rpl_dodag_t *dodag = NULL;
 
@@ -117,6 +118,12 @@ static ng_rpl_dodag_t *_root_dodag_init(uint8_t instance_id, ipv6_addr_t *dodag_
     if (ng_ipv6_netif_find_by_addr(&configured_addr, dodag_id) == KERNEL_PID_UNDEF) {
         DEBUG("RPL: no IPv6 address configured to match the given dodag id: %s\n",
               ipv6_addr_to_str(addr_str, dodag_id, sizeof(addr_str)));
+        return NULL;
+    }
+
+    if ((netif_addr = ng_ipv6_netif_addr_get(configured_addr)) == NULL) {
+        DEBUG("RPL: no netif address found for %s\n", ipv6_addr_to_str(addr_str, configured_addr,
+                sizeof(addr_str)));
         return NULL;
     }
 
@@ -140,6 +147,10 @@ static ng_rpl_dodag_t *_root_dodag_init(uint8_t instance_id, ipv6_addr_t *dodag_
                 ipv6_addr_to_str(addr_str, dodag_id, sizeof(addr_str)));
         return NULL;
     }
+
+    dodag->prefix_len = netif_addr->prefix_len;
+    dodag->addr_preferred = netif_addr->preferred;
+    dodag->addr_valid = netif_addr->valid;
 
     return dodag;
 }

--- a/sys/net/routing/ng_rpl/ng_rpl_dodag.c
+++ b/sys/net/routing/ng_rpl/ng_rpl_dodag.c
@@ -19,6 +19,7 @@
 #include "net/ng_rpl/dodag.h"
 #include "net/ng_rpl/structs.h"
 #include "utlist.h"
+#include "net/ng_rpl.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
@@ -135,6 +136,9 @@ bool ng_rpl_dodag_add(ng_rpl_instance_t *instance, ipv6_addr_t *dodag_id, ng_rpl
         LL_APPEND(instance->dodags, *dodag);
         (*dodag)->state = 1;
         (*dodag)->dodag_id = *dodag_id;
+        (*dodag)->prefix_len = NG_RPL_DEFAULT_PREFIX_LEN;
+        (*dodag)->addr_preferred = NG_RPL_DEFAULT_PREFIX_LIFETIME;
+        (*dodag)->addr_valid = NG_RPL_DEFAULT_PREFIX_LIFETIME;
         (*dodag)->my_rank = NG_RPL_INFINITE_RANK;
         (*dodag)->trickle.callback.func = &rpl_trickle_send_dio;
         (*dodag)->trickle.callback.args = *dodag;


### PR DESCRIPTION
Use `Prefix Information Option` for auto address configuration.

@gebart I am not sure if you started to work on this feature yet. ~~This is a very simple implementation and takes the 64 bits of the dodag-id to configure the ipv6 address of all nodes.~~

Depends on #3050 