### PR TITLE
fib: changed misleading parameter name and documentation

### DIFF
--- a/sys/include/net/ng_fib.h
+++ b/sys/include/net/ng_fib.h
@@ -70,14 +70,15 @@ void fib_deinit(void);
 /**
  * @brief Registration of a routing protocol handler function
  *
- * @param[in] prefix the prefix handled by the according RP
- * @param[in] prefix_size the prefix size
+ * @param[in] prefix                the prefix handled by the according RP
+ * @param[in] prefix_addr_type_size the size of the address type used for the prefix
+ *
  * @return 0 on success
  *           -ENOMEM if the entry cannot be registered (mximum registrations reached)
  *           -EINVAL if the prefix is NULL or the provided size is 0
  *
  */
-int fib_register_rp(uint8_t *prefix, size_t prefix_size);
+int fib_register_rp(uint8_t *prefix, size_t prefix_addr_type_size);
 
 /**
  * @brief Adds a new entry in the corresponding FIB table for global destination and next hop

--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -550,7 +550,7 @@ void fib_deinit(void)
     mutex_unlock(&mtx_access);
 }
 
-int fib_register_rp(uint8_t *prefix, size_t prefix_size)
+int fib_register_rp(uint8_t *prefix, size_t prefix_addr_type_size)
 {
     mutex_lock(&mtx_access);
 
@@ -559,14 +559,14 @@ int fib_register_rp(uint8_t *prefix, size_t prefix_size)
         return -ENOMEM;
     }
 
-    if ((prefix == NULL) || (prefix_size == 0)) {
+    if ((prefix == NULL) || (prefix_addr_type_size == 0)) {
         mutex_unlock(&mtx_access);
         return -EINVAL;
     }
 
     if (notify_rp_pos < FIB_MAX_REGISTERED_RP) {
         notify_rp[notify_rp_pos] = sched_active_pid;
-        universal_address_container_t *container = universal_address_add(prefix, prefix_size);
+        universal_address_container_t *container = universal_address_add(prefix, prefix_addr_type_size);
         prefix_rp[notify_rp_pos] = container;
         notify_rp_pos++;
     }


### PR DESCRIPTION
Rationale: 
The former parameter name suggested that the prefix length, i.e. /64 or /128, should be provided when registering a RP to the FIB.
Neither the doxy pointed the right purpose of the parameter. 