### PR TITLE
cpu/cc2538: initialize the GPIO controller to a default state

### DIFF
--- a/cpu/cc2538/cc2538-gpio.c
+++ b/cpu/cc2538/cc2538-gpio.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 Loci Controls Inc.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup cpu_cc2538
+ * @{
+ *
+ * @file            cc2538-gpio.c
+ * @brief           cc2538 GPIO controller driver implementation
+ *
+ * @author          Ian Martin <ian@locicontrols.com>
+ * @{
+ */
+
+#include "cc2538_gpio.h"
+
+void cc2538_gpio_port_init(cc2538_gpio_t* gpio_port) {
+    /* Disable power-up interrupts */
+    gpio_port->PI_IEN = 0;
+
+    /* Disable normal interrupts */
+    gpio_port->IE = 0;
+
+    /* Clear any pending interrupts */
+    gpio_port->IC = 0xff;
+}
+
+void cc2538_gpio_init(void) {
+    cc2538_gpio_port_init(GPIO_A);
+    cc2538_gpio_port_init(GPIO_B);
+    cc2538_gpio_port_init(GPIO_C);
+    cc2538_gpio_port_init(GPIO_D);
+}

--- a/cpu/cc2538/cpu.c
+++ b/cpu/cc2538/cpu.c
@@ -47,6 +47,8 @@ void cpu_init(void)
     SYS_CTRL->I_MAP = 1;
     /* initialize the clock system */
     cpu_clock_init();
+    /* initialize the GPIO controller */
+    cc2538_gpio_init();
 }
 
 /**

--- a/cpu/cc2538/include/cc2538_gpio.h
+++ b/cpu/cc2538/include/cc2538_gpio.h
@@ -281,6 +281,19 @@ typedef struct {
 #define IOC    ((cc2538_ioc_t *)0x400d4000)     /**< IOC instance */
 /** @} */
 
+/**
+ * @brief     Initialize a GPIO port.
+ * @details   Initializes the port to a default state, disables interrupts and
+ *            clears any pending interrupts.
+ * @param[in] gpio_port A pointer to the port's instance, e.g. "GPIO_A".
+ */
+void cc2538_gpio_port_init(cc2538_gpio_t* gpio_port);
+
+/**
+ * @brief     Initialize all four GPIO ports.
+ */
+void cc2538_gpio_init(void);
+
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif


### PR DESCRIPTION
The MCU's bootloader seems to leave some GPIO interrupts enabled, which can cause spurious interrupts under RIOT. This patch avoids the problem by initializing the GPIO registers to a default state.