### PR TITLE
core: kernel logging

### DIFF
--- a/core/include/kernel_internal.h
+++ b/core/include/kernel_internal.h
@@ -26,6 +26,16 @@
 #endif
 
 /**
+ * @brief   Kernel print function
+ *          Will only print if #KERNEL_MUTE is not set.
+ */
+#ifndef KERNEL_MUTE
+#   define printk(...) printf(__VA_ARGS__)
+#else
+#   define printk(...)
+#endif
+
+/**
  * @brief   Initializes scheduler and creates main and idle task
  */
 void kernel_init(void);

--- a/core/include/log.h
+++ b/core/include/log.h
@@ -26,6 +26,7 @@
  * See "sys/log/log_printfnoformat" for an example.
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
  */
 
 #ifndef __LOG_H
@@ -47,30 +48,28 @@
  * The log function calls of filtered messages will be optimized out at compile
  * time, so a lower log level might result in smaller code size.
  */
-enum {
-    LOG_NONE,       /**< Lowest log level, will output nothing */
-    LOG_KERNEL,     /**< Kernel log level, will print only kernel messages */
-    LOG_ERROR,      /**< Error log level, will print only critical,
-                         non-recoverable errors like hardware initialization
-                         failures */
-    LOG_WARNING,    /**< Warning log level, will print warning messages for
-                         temporary errors */
-    LOG_INFO,       /**< Informational log level, will print purely
-                         informational messages like successful system bootup,
-                         network link state, ...*/
-    LOG_DEBUG,      /**< Debug log level, printing developer stuff considered
-                         too verbose for production use */
-    LOG_ALL         /**< print everything */
-};
+#define LOG_LEVEL_NONE    (0)    /**< Lowest log level, will output nothing */
+#define LOG_LEVEL_KERNEL  (1)    /**< Kernel log level, will print only kernel messages */
+#define LOG_LEVEL_ERROR   (2)    /**< Error log level, will print only critical,
+                                      non-recoverable errors like hardware initialization
+                                      failures */
+#define LOG_LEVEL_WARNING (3)    /**< Warning log level, will print warning messages for
+                                      temporary errors */
+#define LOG_LEVEL_INFO    (4)    /**< Informational log level, will print purely
+                                      informational messages like successful system bootup,
+                                      network link state, ...*/
+#define LOG_LEVEL_DEBUG   (5)    /**< Debug log level, printing developer stuff considered
+                                      too verbose for production use */
+#define LOG_LEVEL_ALL     (6)    /**< print everything */
 
 #ifndef LOG_LEVEL
 /**
  * @brief Default log level define
  */
 #ifdef DEVELHELP
-#   define LOG_LEVEL    LOG_INFO
+#   define LOG_LEVEL    LOG_LEVEL_INFO
 #else
-#   define LOG_LEVEL    LOG_KERNEL
+#   define LOG_LEVEL    LOG_LEVEL_KERNEL
 #endif
 #endif
 
@@ -83,11 +82,11 @@ enum {
  * @brief logging convenience defines
  * @{
  */
-#define LOG_KERNEL(...) LOG(LOG_KERNEL, __VA_ARGS__)
-#define LOG_ERROR(...) LOG(LOG_ERROR, __VA_ARGS__)
-#define LOG_WARNING(...) LOG(LOG_WARNING, __VA_ARGS__)
-#define LOG_INFO(...) LOG(LOG_INFO, __VA_ARGS__)
-#define LOG_DEBUG(...) LOG(LOG_DEBUG, __VA_ARGS__)
+#define LOG_KERNEL(...) LOG(LOG_LEVEL_KERNEL, __VA_ARGS__)
+#define LOG_ERROR(...) LOG(LOG_LEVEL_ERROR, __VA_ARGS__)
+#define LOG_WARNING(...) LOG(LOG_LEVEL_WARNING, __VA_ARGS__)
+#define LOG_INFO(...) LOG(LOG_LEVEL_INFO, __VA_ARGS__)
+#define LOG_DEBUG(...) LOG(LOG_LEVEL_DEBUG, __VA_ARGS__)
 /** @} */
 
 #ifdef MODULE_LOG

--- a/core/include/log.h
+++ b/core/include/log.h
@@ -49,6 +49,7 @@
  */
 enum {
     LOG_NONE,       /**< Lowest log level, will output nothing */
+    LOG_KERNEL,     /**< Kernel log level, will print only kernel messages */
     LOG_ERROR,      /**< Error log level, will print only critical,
                          non-recoverable errors like hardware initialization
                          failures */
@@ -78,6 +79,7 @@ enum {
  * @brief logging convenience defines
  * @{
  */
+#define LOG_KERNEL(...) LOG(LOG_KERNEL, __VA_ARGS__)
 #define LOG_ERROR(...) LOG(LOG_ERROR, __VA_ARGS__)
 #define LOG_WARNING(...) LOG(LOG_WARNING, __VA_ARGS__)
 #define LOG_INFO(...) LOG(LOG_INFO, __VA_ARGS__)

--- a/core/include/log.h
+++ b/core/include/log.h
@@ -49,18 +49,17 @@
  * time, so a lower log level might result in smaller code size.
  */
 #define LOG_LEVEL_NONE    (0)    /**< Lowest log level, will output nothing */
-#define LOG_LEVEL_KERNEL  (1)    /**< Kernel log level, will print only kernel messages */
-#define LOG_LEVEL_ERROR   (2)    /**< Error log level, will print only critical,
+#define LOG_LEVEL_ERROR   (1)    /**< Error log level, will print only critical,
                                       non-recoverable errors like hardware initialization
                                       failures */
-#define LOG_LEVEL_WARNING (3)    /**< Warning log level, will print warning messages for
+#define LOG_LEVEL_WARNING (2)    /**< Warning log level, will print warning messages for
                                       temporary errors */
-#define LOG_LEVEL_INFO    (4)    /**< Informational log level, will print purely
+#define LOG_LEVEL_INFO    (3)    /**< Informational log level, will print purely
                                       informational messages like successful system bootup,
                                       network link state, ...*/
-#define LOG_LEVEL_DEBUG   (5)    /**< Debug log level, printing developer stuff considered
+#define LOG_LEVEL_DEBUG   (4)    /**< Debug log level, printing developer stuff considered
                                       too verbose for production use */
-#define LOG_LEVEL_ALL     (6)    /**< print everything */
+#define LOG_LEVEL_ALL     (5)    /**< print everything */
 
 #ifndef LOG_LEVEL
 /**
@@ -69,7 +68,7 @@
 #ifdef DEVELHELP
 #   define LOG_LEVEL    LOG_LEVEL_INFO
 #else
-#   define LOG_LEVEL    LOG_LEVEL_KERNEL
+#   define LOG_LEVEL    LOG_LEVEL_NONE
 #endif
 #endif
 
@@ -82,7 +81,6 @@
  * @brief logging convenience defines
  * @{
  */
-#define LOG_KERNEL(...) LOG(LOG_LEVEL_KERNEL, __VA_ARGS__)
 #define LOG_ERROR(...) LOG(LOG_LEVEL_ERROR, __VA_ARGS__)
 #define LOG_WARNING(...) LOG(LOG_LEVEL_WARNING, __VA_ARGS__)
 #define LOG_INFO(...) LOG(LOG_LEVEL_INFO, __VA_ARGS__)

--- a/core/include/log.h
+++ b/core/include/log.h
@@ -65,7 +65,9 @@
 /**
  * @brief Default log level define
  */
-#ifdef DEVELHELP
+#if ENABLE_DEBUG
+#   define LOG_LEVEL    LOG_LEVEL_DEBUG
+#elif defined(DEVELHELP)
 #   define LOG_LEVEL    LOG_LEVEL_INFO
 #else
 #   define LOG_LEVEL    LOG_LEVEL_NONE

--- a/core/include/log.h
+++ b/core/include/log.h
@@ -67,7 +67,11 @@ enum {
 /**
  * @brief Default log level define
  */
-#define LOG_LEVEL LOG_INFO
+#ifdef DEVELHELP
+#   define LOG_LEVEL    LOG_INFO
+#else
+#   define LOG_LEVEL    LOG_KERNEL
+#endif
 #endif
 
 /**

--- a/core/include/log.h
+++ b/core/include/log.h
@@ -87,6 +87,11 @@
 #define LOG_DEBUG(...) LOG(LOG_LEVEL_DEBUG, __VA_ARGS__)
 /** @} */
 
+#if (LOG_LEVEL > LOG_LEVEL_NONE)
+/* Logging is likely to make use of PRIu16 etc. */
+#   include <inttypes.h>
+#endif
+
 #ifdef MODULE_LOG
 #include "log_module.h"
 #else

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -82,7 +82,7 @@ static char idle_stack[THREAD_STACKSIZE_IDLE];
 void kernel_init(void)
 {
     (void) disableIRQ();
-    LOG_INFO("kernel_init(): This is RIOT! (Version: %s)\n", RIOT_VERSION);
+    LOG_KERNEL("kernel_init(): This is RIOT! (Version: %s)\n", RIOT_VERSION);
 
     hwtimer_init();
 
@@ -94,7 +94,7 @@ void kernel_init(void)
         printf("kernel_init(): error creating main task.\n");
     }
 
-    LOG_INFO("kernel_init(): jumping into first task...\n");
+    LOG_KERNEL("kernel_init(): jumping into first task...\n");
 
     cpu_switch_context_exit();
 }

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -82,7 +82,7 @@ static char idle_stack[THREAD_STACKSIZE_IDLE];
 void kernel_init(void)
 {
     (void) disableIRQ();
-    LOG_KERNEL("kernel_init(): This is RIOT! (Version: %s)\n", RIOT_VERSION);
+    printk("kernel_init(): This is RIOT! (Version: %s)\n", RIOT_VERSION);
 
     hwtimer_init();
 
@@ -94,7 +94,7 @@ void kernel_init(void)
         printf("kernel_init(): error creating main task.\n");
     }
 
-    LOG_KERNEL("kernel_init(): jumping into first task...\n");
+    printk("kernel_init(): jumping into first task...\n");
 
     cpu_switch_context_exit();
 }

--- a/doc.txt
+++ b/doc.txt
@@ -9,3 +9,8 @@
  * @brief   This global macro activates functionality that is needed for
  *          automated testing but not needed otherwise.
  */
+
+/**
+ * @def KERNEL_MUTE
+ * @brief Will disable any output from the kernel itself.
+ */


### PR DESCRIPTION
Introduces `LOG_KERNEL` for printing kernel messages (similar to `printk()` in Linux). This allows to set the default logging level to a very silent level, in order to make better use of the logging system throughout the system.