### PR TITLE
shell: sc_icmpv6_echo: don't fail if packet buffer is full

### DIFF
--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -213,7 +213,7 @@ int _icmpv6_ping(int argc, char **argv)
 
         if (pkt == NULL) {
             puts("error: packet buffer full");
-            return 1;
+            continue;
         }
 
         _set_payload(pkt->data, payload_len);
@@ -223,7 +223,7 @@ int _icmpv6_ping(int argc, char **argv)
 
         if (pkt == NULL) {
             puts("error: packet buffer full");
-            return 1;
+            continue;
         }
 
         vtimer_now(&start);


### PR DESCRIPTION
Fixes #3512.