### PR TITLE
ng_sixlowpan_frag: preempt fragmentation

### DIFF
--- a/sys/auto_init/netif/auto_init_kw2xrf.c
+++ b/sys/auto_init/netif/auto_init_kw2xrf.c
@@ -36,7 +36,7 @@
  * @{
  */
 #define KW2XRF_MAC_STACKSIZE     (THREAD_STACKSIZE_DEFAULT)
-#define KW2XRF_MAC_PRIO          (THREAD_PRIORITY_MAIN - 3)
+#define KW2XRF_MAC_PRIO          (THREAD_PRIORITY_MAIN - 4)
 
 #define KW2XRF_NUM (sizeof(kw2xrf_params)/sizeof(kw2xrf_params[0]))
 

--- a/sys/auto_init/netif/auto_init_ng_at86rf2xx.c
+++ b/sys/auto_init/netif/auto_init_ng_at86rf2xx.c
@@ -34,7 +34,7 @@
  * @{
  */
 #define AT86RF2XX_MAC_STACKSIZE     (THREAD_STACKSIZE_DEFAULT)
-#define AT86RF2XX_MAC_PRIO          (THREAD_PRIORITY_MAIN - 3)
+#define AT86RF2XX_MAC_PRIO          (THREAD_PRIORITY_MAIN - 4)
 
 #define AT86RF2XX_NUM (sizeof(at86rf2xx_params)/sizeof(at86rf2xx_params[0]))
 

--- a/sys/auto_init/netif/auto_init_ng_netdev_eth.c
+++ b/sys/auto_init/netif/auto_init_ng_netdev_eth.c
@@ -36,7 +36,7 @@
  * @{
  */
 #define NETDEV_ETH_MAC_STACKSIZE     (THREAD_STACKSIZE_DEFAULT)
-#define NETDEV_ETH_MAC_PRIO          (THREAD_PRIORITY_MAIN - 3)
+#define NETDEV_ETH_MAC_PRIO          (THREAD_PRIORITY_MAIN - 4)
 
 static char _nomac_stack[NETDEV_ETH_MAC_STACKSIZE];
 

--- a/sys/auto_init/netif/auto_init_slip.c
+++ b/sys/auto_init/netif/auto_init_slip.c
@@ -38,7 +38,7 @@ static ng_slip_dev_t slip_devs[SLIP_NUM];
  * @{
  */
 #define SLIP_STACKSIZE          (KERNEL_CONF_STACKSIZE_DEFAULT)
-#define SLIP_PRIO               (PRIORITY_MAIN - 3)
+#define SLIP_PRIO               (PRIORITY_MAIN - 4)
 
 /**
  * @brief   Stacks for the MAC layer threads

--- a/sys/auto_init/netif/auto_init_xbee.c
+++ b/sys/auto_init/netif/auto_init_xbee.c
@@ -38,7 +38,7 @@ static xbee_t xbee_devs[XBEE_NUM];
  * @{
  */
 #define XBEE_MAC_STACKSIZE           (THREAD_STACKSIZE_DEFAULT)
-#define XBEE_MAC_PRIO                (THREAD_PRIORITY_MAIN - 3)
+#define XBEE_MAC_PRIO                (THREAD_PRIORITY_MAIN - 4)
 
 /**
  * @brief   Stacks for the MAC layer threads

--- a/sys/net/network_layer/ng_sixlowpan/frag/ng_sixlowpan_frag.c
+++ b/sys/net/network_layer/ng_sixlowpan/frag/ng_sixlowpan_frag.c
@@ -223,6 +223,7 @@ void ng_sixlowpan_frag_send(kernel_pid_t pid, ng_pktsnip_t *pkt,
     }
 
     offset += res;
+    thread_yield();
 
     while (offset < datagram_size) {
         if ((res = _send_nth_fragment(iface, pkt, payload_len, datagram_size,
@@ -235,6 +236,7 @@ void ng_sixlowpan_frag_send(kernel_pid_t pid, ng_pktsnip_t *pkt,
         }
 
         offset += res;
+        thread_yield();
     }
 
     /* remove original packet from packet buffer */


### PR DESCRIPTION
Fixes #3517 the simplest way (without resizing the queue of the MAC).