### PR TITLE
native: irq: Get rid of dINT() and eINT()

### DIFF
--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -160,7 +160,7 @@ void cpu_switch_context_exit(void)
 #endif
 
     if (_native_in_isr == 0) {
-        dINT();
+        disableIRQ();
         _native_in_isr = 1;
         native_isr_context.uc_stack.ss_sp = __isr_stack;
         native_isr_context.uc_stack.ss_size = SIGSTKSZ;
@@ -197,7 +197,7 @@ void thread_yield_higher(void)
     ucontext_t *ctx = (ucontext_t *)(sched_active_thread->sp);
     if (_native_in_isr == 0) {
         _native_in_isr = 1;
-        dINT();
+        disableIRQ();
         native_isr_context.uc_stack.ss_sp = __isr_stack;
         native_isr_context.uc_stack.ss_size = SIGSTKSZ;
         native_isr_context.uc_stack.ss_flags = 0;
@@ -205,7 +205,7 @@ void thread_yield_higher(void)
         if (swapcontext(ctx, &native_isr_context) == -1) {
             err(EXIT_FAILURE, "thread_yield_higher: swapcontext");
         }
-        eINT();
+        enableIRQ();
     }
     else {
         isr_thread_yield();

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -120,7 +120,7 @@ void _native_syscall_leave(void)
        )
     {
         _native_in_isr = 1;
-        dINT();
+        disableIRQ();
         _native_cur_ctx = (ucontext_t *)sched_active_thread->sp;
         native_isr_context.uc_stack.ss_sp = __isr_stack;
         native_isr_context.uc_stack.ss_size = SIGSTKSZ;
@@ -129,7 +129,7 @@ void _native_syscall_leave(void)
         if (swapcontext(_native_cur_ctx, &native_isr_context) == -1) {
             err(EXIT_FAILURE, "_native_syscall_leave: swapcontext");
         }
-        eINT();
+        enableIRQ();
     }
 }
 

--- a/cpu/native/tramp.S
+++ b/cpu/native/tramp.S
@@ -21,7 +21,7 @@ __native_sig_leave_tramp:
     call _swapcontext
     addl $8, %esp
 
-    call _eINT
+    call _enableIRQ
 
     movl $0x0, __native_in_isr
     popal
@@ -53,7 +53,7 @@ _native_sig_leave_tramp:
     bl      swapcontext
 
     /* reeanble interrupts */
-    bl      eINT
+    bl      enableIRQ
 
     /* _native_in_isr = 0 */
     eor     r0, r0, r0
@@ -78,7 +78,7 @@ _native_sig_leave_tramp:
     call swapcontext
     addl $8, %esp
 
-    call eINT
+    call enableIRQ
 
     movl $0x0, _native_in_isr
     popal


### PR DESCRIPTION
Get rid of internal usage of the old IRQ
API and keep it's implementation while
waiting for other modules to kill it.