### PR TITLE
cpu: stm32f1: TIMERx_MAX_VALUE definitions

### DIFF
--- a/boards/iot-lab_M3/include/periph_conf.h
+++ b/boards/iot-lab_M3/include/periph_conf.h
@@ -55,7 +55,7 @@ extern "C" {
 #define TIMER_0_DEV_1       TIM3
 #define TIMER_0_CHANNELS    4
 #define TIMER_0_PRESCALER   (72U)
-#define TIMER_0_MAX_VALUE   (0xffff)
+#define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM2EN | RCC_APB1ENR_TIM3EN))
 #define TIMER_0_ISR_0       isr_tim2
 #define TIMER_0_ISR_1       isr_tim3
@@ -69,7 +69,7 @@ extern "C" {
 #define TIMER_1_DEV_1       TIM5
 #define TIMER_1_CHANNELS    4
 #define TIMER_1_PRESCALER   (72U)
-#define TIMER_1_MAX_VALUE   (0xffff)
+#define TIMER_1_MAX_VALUE   (0xffffffff)
 #define TIMER_1_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM4EN | RCC_APB1ENR_TIM5EN))
 #define TIMER_1_ISR_0       isr_tim4
 #define TIMER_1_ISR_1       isr_tim5

--- a/cpu/stm32f1/periph/timer.c
+++ b/cpu/stm32f1/periph/timer.c
@@ -94,7 +94,7 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
     /* send update event as trigger output */
     timer0->CR2 |= TIM_CR2_MMS_1;
     /* set auto-reload and prescaler values and load new values */
-    timer0->ARR = TIMER_0_MAX_VALUE;
+    timer0->ARR = 0xFFFF;
     timer0->PSC = TIMER_0_PRESCALER * ticks_per_us;
     // timer->EGR |= TIM_EGR_UG;
 


### PR DESCRIPTION
Our implementation of stm32f1 uses two 16bit timers to emulate one 32bit
timer. This PR makes the timer maximum value definitions match the
timers for iot-lab_M3. Also fixes an assignment which became invalid after the initial fix.