### PR TITLE
ng_at86rf2xx: don't ifdef type definitions

### DIFF
--- a/drivers/include/ng_at86rf2xx.h
+++ b/drivers/include/ng_at86rf2xx.h
@@ -119,15 +119,13 @@ extern "C" {
 /** @} */
 
 /**
-  * @brief   Frequency configuration
+  * @brief   Frequency configuration for sub-GHz devices.
   * @{
   */
-#ifdef MODULE_NG_AT86RF212B
 typedef enum {
     NG_AT86RF2XX_FREQ_915MHZ,    /**< frequency 915MHz enabled */
     NG_AT86RF2XX_FREQ_868MHZ,    /**< frequency 868MHz enabled */
 } ng_at86rf2xx_freq_t;
-#endif
 /** @} */
 
 /**


### PR DESCRIPTION
According to @haukepetersen's https://github.com/RIOT-OS/RIOT/pull/3528#issuecomment-126487189 I opened a PR for that.