### PR TITLE
ng_pktbuf_static: enhance _pktbuf_contains

### DIFF
--- a/sys/net/crosslayer/ng_pktbuf_static/ng_pktbuf_static.c
+++ b/sys/net/crosslayer/ng_pktbuf_static/ng_pktbuf_static.c
@@ -52,8 +52,7 @@ static void _pktbuf_free(void *data, size_t size);
 
 static inline bool _pktbuf_contains(void *ptr)
 {
-    return (&_pktbuf[0] <= (uint8_t *)ptr) &&
-           ((uint8_t *)ptr <= &_pktbuf[NG_PKTBUF_SIZE - 1]);
+    return (unsigned)((uint8_t *)ptr - _pktbuf) < NG_PKTBUF_SIZE;
 }
 
 /* fits size to byte alignment */


### PR DESCRIPTION
This modification *slightly* (8-16 byte) reduces the rom size, but the real advantage is that it kills one branch instruction. The unittests for the pktbuf ran successful with this change. @authmillenon what's your opinion on this?