### PR TITLE
cpu/stm32f1: modernized peripheral GPIO driver

### DIFF
--- a/boards/fox/board.c
+++ b/boards/fox/board.c
@@ -46,7 +46,7 @@ static void leds_init(void)
 {
     /* green pin */
     RCC->APB2ENR |= RCC_APB2ENR_IOPBEN;
-    LED_GREEN_PORT->CRL = (0x3 << ((LED_GREEN_PIN-8)*4));
+    LED_GREEN_PORT->CR[0] = (0x3 << ((LED_GREEN_PIN-8)*4));
     /* red pin */;
-    LED_RED_PORT->CRL = (0x3 << ((LED_RED_PIN-8)*4));
+    LED_RED_PORT->CR[0] = (0x3 << ((LED_RED_PIN-8)*4));
 }

--- a/boards/fox/include/board.h
+++ b/boards/fox/include/board.h
@@ -57,10 +57,10 @@ extern "C" {
  * @{
  */
 #define AT86RF231_SPI       SPI_0
-#define AT86RF231_CS        GPIO_11
-#define AT86RF231_INT       GPIO_12
-#define AT86RF231_RESET     GPIO_13
-#define AT86RF231_SLEEP     GPIO_14
+#define AT86RF231_CS        GPIO(PORT_A,1)
+#define AT86RF231_INT       GPIO(PORT_C,2)
+#define AT86RF231_RESET     GPIO(PORT_C,1)
+#define AT86RF231_SLEEP     GPIO(PORT_A,0)
 /** @} */
 
 /**
@@ -77,8 +77,8 @@ extern "C" {
  */
 #define L3G4200D_I2C        I2C_0
 #define L3G4200D_ADDR       0x68
-#define L3G4200D_DRDY       GPIO_2
-#define L3G4200D_INT        GPIO_1
+#define L3G4200D_DRDY       GPIO(PORT_B,8)
+#define L3G4200D_INT        GPIO(PORT_B,11)
 /** @} */
 
 /**
@@ -88,9 +88,9 @@ extern "C" {
 #define LSM303DLHC_I2C      I2C_0
 #define LSM303DLHC_ACC_ADDR (25)
 #define LSM303DLHC_MAG_ADDR (30)
-#define LSM303DLHC_INT1     GPIO_4
-#define LSM303DLHC_INT2     GPIO_3
-#define LSM303DLHC_DRDY     GPIO_9
+#define LSM303DLHC_INT1     GPIO(PORT_B,9)
+#define LSM303DLHC_INT2     GPIO(PORT_B,5)
+#define LSM303DLHC_DRDY     GPIO(PORT_A,9)
 /** @} */
 
 /**
@@ -99,8 +99,10 @@ extern "C" {
  */
 #define LED_RED_PORT        (GPIOB)
 #define LED_RED_PIN         (10)
+#define LED_RED_GPIO        GPIO(PORT_B,10)
 #define LED_GREEN_PORT      (GPIOB)
 #define LED_GREEN_PIN       (12)
+#define LED_GREEN_GPIO      GPIO(PORT_B,12)
 /** @} */
 
 /**

--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -80,6 +80,7 @@ extern "C" {
 
 /**
  * @brief UART configuration
+ * @{
  */
 #define UART_NUMOF          (1U)
 #define UART_0_EN           1
@@ -111,129 +112,8 @@ extern "C" {
 #define UART_1_RX_PIN       10
 #define UART_1_TX_PIN       9
 #define UART_1_AF           0
+/** @} */
 
-/**
- * @brief GPIO configuration
- */
-#define GPIO_0_EN           1
-#define GPIO_1_EN           1
-#define GPIO_2_EN           1
-#define GPIO_3_EN           1
-#define GPIO_4_EN           1
-#define GPIO_5_EN           1
-#define GPIO_6_EN           1
-#define GPIO_7_EN           1
-#define GPIO_8_EN           1
-#define GPIO_9_EN           1
-#define GPIO_10_EN          1
-#define GPIO_11_EN          1
-#define GPIO_12_EN          1
-#define GPIO_13_EN          1
-#define GPIO_14_EN          1
-#define GPIO_IRQ_PRIO       1
-
-/* IRQ config */
-#define GPIO_IRQ_0          GPIO_7
-#define GPIO_IRQ_2          GPIO_12
-#define GPIO_IRQ_4          GPIO_6
-#define GPIO_IRQ_5          GPIO_3
-#define GPIO_IRQ_6          GPIO_5
-#define GPIO_IRQ_7          GPIO_8
-#define GPIO_IRQ_8          GPIO_2
-#define GPIO_IRQ_9          GPIO_4
-#define GPIO_IRQ_11         GPIO_1
-#define GPIO_IRQ_13         GPIO_0
-
-/* GPIO channel 0 config */
-#define GPIO_0_PORT         GPIOC                   /* user button */
-#define GPIO_0_PIN          13
-#define GPIO_0_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPCEN)
-#define GPIO_0_EXTI_CFG()   (AFIO->EXTICR[3] |= AFIO_EXTICR4_EXTI13_PC)
-#define GPIO_0_IRQ          EXTI15_10_IRQn
-/* GPIO channel 1 config */
-#define GPIO_1_PORT         GPIOB                   /* l3g4200d: int1 */
-#define GPIO_1_PIN          11
-#define GPIO_1_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_1_EXTI_CFG()   (AFIO->EXTICR[2] |= AFIO_EXTICR3_EXTI11_PC)
-#define GPIO_1_IRQ          EXTI15_10_IRQn
-/* GPIO channel 2 config */
-#define GPIO_2_PORT         GPIOB                   /* l3g4200d: int2/drdy */
-#define GPIO_2_PIN          8
-#define GPIO_2_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_2_EXTI_CFG()   (AFIO->EXTICR[2] |= AFIO_EXTICR3_EXTI8_PB)
-#define GPIO_2_IRQ          EXTI9_5_IRQn
-/* GPIO channel 3 config */
-#define GPIO_3_PORT         GPIOB                   /* lsm303dlhc: accelerometer: int2 */
-#define GPIO_3_PIN          5
-#define GPIO_3_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_3_EXTI_CFG()   (AFIO->EXTICR[1] |= AFIO_EXTICR2_EXTI5_PB)
-#define GPIO_3_IRQ          EXTI9_5_IRQn
-/* GPIO channel 4 config */
-#define GPIO_4_PORT         GPIOB                   /* lsm303dlhc: accelerometer: int1*/
-#define GPIO_4_PIN          9
-#define GPIO_4_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_4_EXTI_CFG()   (AFIO->EXTICR[2] |= AFIO_EXTICR3_EXTI9_PB)
-#define GPIO_4_IRQ          EXTI9_5_IRQn
-/* GPIO channel 5 config */
-#define GPIO_5_PORT         GPIOC                   /* battery: high power */
-#define GPIO_5_PIN          6
-#define GPIO_5_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPCEN)
-#define GPIO_5_EXTI_CFG()   (AFIO->EXTICR[1] |= AFIO_EXTICR2_EXTI6_PC)
-#define GPIO_5_IRQ          EXTI9_5_IRQn
-/* GPIO channel 6 config */
-#define GPIO_6_PORT         GPIOC                   /* battery: enable feedback */
-#define GPIO_6_PIN          4
-#define GPIO_6_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPCEN)
-#define GPIO_6_EXTI_CFG()   (AFIO->EXTICR[1] |= AFIO_EXTICR2_EXTI4_PC)
-#define GPIO_6_IRQ          EXTI4_IRQn
-/* GPIO channel 7 config */
-#define GPIO_7_PORT        GPIOC                   /* battery: feedback */
-#define GPIO_7_PIN         0
-#define GPIO_7_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPCEN)
-#define GPIO_7_EXTI_CFG()  (AFIO->EXTICR[0] |= AFIO_EXTICR1_EXTI0_PC)
-#define GPIO_7_IRQ         EXTI0_IRQn
-/* GPIO channel 8 config */
-#define GPIO_8_PORT        GPIOA                    /* extension header */
-#define GPIO_8_PIN         7
-#define GPIO_8_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPAEN)
-#define GPIO_8_EXTI_CFG()  (AFIO->EXTICR[1] |= AFIO_EXTICR2_EXTI7_PA)
-#define GPIO_8_IRQ         EXTI9_5_IRQn
-/* GPIO channel 9 config */
-#define GPIO_9_PORT        GPIOA                    /* lsm303dlhc: magnetometer: drdy */
-#define GPIO_9_PIN         9
-#define GPIO_9_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPAEN)
-#define GPIO_9_EXTI_CFG()  (AFIO->EXTICR[2] |= AFIO_EXTICR3_EXTI9_PA)
-#define GPIO_9_IRQ         EXTI9_5_IRQn
-/* GPIO channel 10 config */
-#define GPIO_10_PORT        GPIOB                    /* extension header, don't use as EXTI */
-#define GPIO_10_PIN         0
-#define GPIO_10_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_10_EXTI_CFG()  (AFIO->EXTICR[0] |= AFIO_EXTICR1_EXTI0_PB)
-#define GPIO_10_IRQ         EXTI0_IRQn
-/* GPIO channel 11 config */
-#define GPIO_11_PORT        GPIOA                    /* radio: cs */
-#define GPIO_11_PIN         1
-#define GPIO_11_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPAEN)
-#define GPIO_11_EXTI_CFG()  (AFIO->EXTICR[0] |= AFIO_EXTICR1_EXTI1_PA)
-#define GPIO_11_IRQ         EXTI1_IRQn
-/* GPIO channel 12 config */
-#define GPIO_12_PORT        GPIOC                    /* radio: INT */
-#define GPIO_12_PIN         2
-#define GPIO_12_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPCEN)
-#define GPIO_12_EXTI_CFG()  (AFIO->EXTICR[0] |= AFIO_EXTICR1_EXTI2_PC)
-#define GPIO_12_IRQ         EXTI2_IRQn
-/* GPIO channel 13 config */
-#define GPIO_13_PORT        GPIOC                    /* radio: reset */
-#define GPIO_13_PIN         1
-#define GPIO_13_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPCEN)
-#define GPIO_13_EXTI_CFG()  (AFIO->EXTICR[0] |= AFIO_EXTICR1_EXTI1_PC)
-#define GPIO_13_IRQ         EXTI1_IRQn
-/* GPIO channel 14 config */
-#define GPIO_14_PORT        GPIOA                    /* radio: sleep */
-#define GPIO_14_PIN         0
-#define GPIO_14_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPAEN)
-#define GPIO_14_EXTI_CFG()  (AFIO->EXTICR[0] |= AFIO_EXTICR1_EXTI0_PA)
-#define GPIO_14_IRQ         EXTI0_IRQn
 /**
  * @brief SPI configuration
  * @{

--- a/boards/iot-lab_M3/board.c
+++ b/boards/iot-lab_M3/board.c
@@ -47,13 +47,13 @@ static void leds_init(void)
 {
     /* green pin */
     RCC->APB2ENR |= RCC_APB2ENR_IOPBEN;
-    LED_GREEN_PORT->CRL = (0x3 << (LED_GREEN_PIN*4));
+    LED_GREEN_PORT->CR[0] = (0x3 << (LED_GREEN_PIN*4));
 
     /* orange pin */
     RCC->APB2ENR |= RCC_APB2ENR_IOPCEN;
-    LED_ORANGE_PORT->CRH = (0x3 << ((LED_ORANGE_PIN-8)*4));
+    LED_ORANGE_PORT->CR[1] = (0x3 << ((LED_ORANGE_PIN-8)*4));
 
     /* red pin */
     RCC->APB2ENR |= RCC_APB2ENR_IOPDEN;
-    LED_RED_PORT->CRL = (0x3 << (LED_RED_PIN*4));
+    LED_RED_PORT->CR[0] = (0x3 << (LED_RED_PIN*4));
 }

--- a/boards/iot-lab_M3/include/board.h
+++ b/boards/iot-lab_M3/include/board.h
@@ -64,10 +64,10 @@ extern "C" {
  * @{
  */
 #define AT86RF231_SPI       SPI_0
-#define AT86RF231_CS        GPIO_11
-#define AT86RF231_INT       GPIO_12
-#define AT86RF231_RESET     GPIO_13
-#define AT86RF231_SLEEP     GPIO_14
+#define AT86RF231_CS        GPIO(PORT_A,4)
+#define AT86RF231_INT       GPIO(PORT_C,4)
+#define AT86RF231_RESET     GPIO(PORT_C,1)
+#define AT86RF231_SLEEP     GPIO(PORT_A,2)
 #define AT86RF231_SPI_CLK   SPI_SPEED_5MHZ
 /** @} */
 
@@ -76,9 +76,9 @@ extern "C" {
  * @{
  */
 #define EXTFLASH_SPI        SPI_1
-#define EXTFLASH_CS         GPIO_8
-#define EXTFLASH_WRITE      GPIO_9
-#define EXTFLASH_HOLD       GPIO_10
+#define EXTFLASH_CS         GPIO(PORT_A,11)
+#define EXTFLASH_WRITE      GPIO(PORT_C,6)
+#define EXTFLASH_HOLD       GPIO(PORT_C,9)
 /** @} */
 
 /**
@@ -103,8 +103,8 @@ extern "C" {
  */
 #define L3G4200D_I2C        I2C_0
 #define L3G4200D_ADDR       0x68
-#define L3G4200D_DRDY       GPIO_4
-#define L3G4200D_INT        GPIO_3
+#define L3G4200D_DRDY       GPIO(PORT_C,0)
+#define L3G4200D_INT        GPIO(PORT_C,5)
 /** @} */
 
 /**
@@ -114,9 +114,9 @@ extern "C" {
 #define LSM303DLHC_I2C      I2C_0
 #define LSM303DLHC_ACC_ADDR (0x19)
 #define LSM303DLHC_MAG_ADDR (0x1e)
-#define LSM303DLHC_INT1     GPIO_5
-#define LSM303DLHC_INT2     GPIO_6
-#define LSM303DLHC_DRDY     GPIO_7
+#define LSM303DLHC_INT1     GPIO(PORT_B,12)
+#define LSM303DLHC_INT2     GPIO(PORT_B,1)
+#define LSM303DLHC_DRDY     GPIO(PORT_B,2)
 /** @} */
 
 /**
@@ -125,10 +125,13 @@ extern "C" {
  */
 #define LED_RED_PORT        (GPIOD)
 #define LED_RED_PIN         (2)
+#define LED_RED_GPIO        GPIO(PORT_D,2)
 #define LED_GREEN_PORT      (GPIOB)
 #define LED_GREEN_PIN       (5)
+#define LED_GREEN_GPIO      GPIO(PORT_B,5)
 #define LED_ORANGE_PORT     (GPIOC)
 #define LED_ORANGE_PIN      (10)
+#define LED_ORANGE_GPIO     GPIO(PORT_C,10)
 /** @} */
 
 /**

--- a/boards/iot-lab_M3/include/periph_conf.h
+++ b/boards/iot-lab_M3/include/periph_conf.h
@@ -81,6 +81,7 @@ extern "C" {
 
 /**
  * @brief UART configuration
+ * @{
  */
 #define UART_NUMOF          (1U)
 #define UART_0_EN           1
@@ -112,142 +113,7 @@ extern "C" {
 #define UART_1_RX_PIN       3
 #define UART_1_TX_PIN       2
 #define UART_1_AF           1
-
-/**
- * @brief GPIO configuration
- */
-#define GPIO_0_EN           1
-#define GPIO_1_EN           1
-#define GPIO_2_EN           1
-#define GPIO_3_EN           1
-#define GPIO_4_EN           1
-#define GPIO_5_EN           1
-#define GPIO_6_EN           1
-#define GPIO_7_EN           1
-#define GPIO_8_EN           1
-#define GPIO_9_EN           1
-#define GPIO_10_EN          1
-#define GPIO_11_EN          1
-#define GPIO_12_EN          1
-#define GPIO_13_EN          1
-#define GPIO_14_EN          1
-#define GPIO_15_EN          1
-#define GPIO_IRQ_PRIO       1
-
-/**
- * @brief IRQ config
- *
- * These defines are used for the backmapping in the matching interrupt
- * service routines to call the correct callbacks.
- * GPIO_IRQ_x where x matches the value defined by GPIO_y_PIN
- */
-#define GPIO_IRQ_0          GPIO_4
-#define GPIO_IRQ_1          GPIO_6
-#define GPIO_IRQ_2          GPIO_7
-#define GPIO_IRQ_3          GPIO_0
-#define GPIO_IRQ_4          GPIO_12
-#define GPIO_IRQ_5          GPIO_3
-#define GPIO_IRQ_6          GPIO_9
-#define GPIO_IRQ_9          GPIO_10
-#define GPIO_IRQ_11         GPIO_8
-#define GPIO_IRQ_12         GPIO_5
-
-/* GPIO channel 0 config */
-#define GPIO_0_PORT         GPIOA                   /* user pin 1 */
-#define GPIO_0_PIN          3
-#define GPIO_0_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPAEN)
-#define GPIO_0_EXTI_CFG()   (AFIO->EXTICR[0] |= AFIO_EXTICR1_EXTI3_PA)
-#define GPIO_0_IRQ          EXTI3_IRQn
-/* GPIO channel 1 config */
-#define GPIO_1_PORT         GPIOB                   /* user pin 2 */
-#define GPIO_1_PIN          9
-#define GPIO_1_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_1_EXTI_CFG()   (AFIO->EXTICR[2] |= AFIO_EXTICR3_EXTI9_PB)
-#define GPIO_1_IRQ          EXTI9_5_IRQn
-/* GPIO channel 2 config */
-#define GPIO_2_PORT         GPIOC                   /* user pin 3, DO NOT USE AS EXTI */
-#define GPIO_2_PIN          11
-#define GPIO_2_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPCEN)
-#define GPIO_2_EXTI_CFG()   (AFIO->EXTICR[2] |= AFIO_EXTICR3_EXTI11_PC)
-#define GPIO_2_IRQ          EXTI15_10_IRQn
-/* GPIO channel 3 config */
-#define GPIO_3_PORT         GPIOC                   /* l3g4200d: int1 */
-#define GPIO_3_PIN          5
-#define GPIO_3_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPCEN)
-#define GPIO_3_EXTI_CFG()   (AFIO->EXTICR[1] |= AFIO_EXTICR2_EXTI5_PC)
-#define GPIO_3_IRQ          EXTI9_5_IRQn
-/* GPIO channel 4 config */
-#define GPIO_4_PORT         GPIOC                   /* l3g4200d: int2/drdy */
-#define GPIO_4_PIN          0
-#define GPIO_4_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPCEN)
-#define GPIO_4_EXTI_CFG()   (AFIO->EXTICR[0] |= AFIO_EXTICR1_EXTI0_PC)
-#define GPIO_4_IRQ          EXTI0_IRQn
-/* GPIO channel 5 config */
-#define GPIO_5_PORT         GPIOB                   /* lsm303dlhc: int1 */
-#define GPIO_5_PIN          12
-#define GPIO_5_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_5_EXTI_CFG()   (AFIO->EXTICR[3] |= AFIO_EXTICR4_EXTI12_PB)
-#define GPIO_5_IRQ          EXTI15_10_IRQn
-/* GPIO channel 6 config */
-#define GPIO_6_PORT         GPIOB                   /* lsm303dlhc: int2 */
-#define GPIO_6_PIN          1
-#define GPIO_6_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_6_EXTI_CFG()   (AFIO->EXTICR[0] |= AFIO_EXTICR1_EXTI1_PB)
-#define GPIO_6_IRQ          EXTI1_IRQn
-/* GPIO channel 7 config */
-#define GPIO_7_PORT         GPIOB                   /* lsm303dlhc: drdy */
-#define GPIO_7_PIN          2
-#define GPIO_7_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_7_EXTI_CFG()   (AFIO->EXTICR[0] |= AFIO_EXTICR1_EXTI2_PB)
-#define GPIO_7_IRQ          EXTI2_IRQn
-/* GPIO channel 8 config */
-#define GPIO_8_PORT         GPIOA                   /* flash: cs */
-#define GPIO_8_PIN          11
-#define GPIO_8_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPAEN)
-#define GPIO_8_EXTI_CFG()   (AFIO->EXTICR[2] |= AFIO_EXTICR3_EXTI11_PA)
-#define GPIO_8_IRQ          EXTI15_10_IRQn
-/* GPIO channel 9 config */
-#define GPIO_9_PORT         GPIOC                   /* flash: write */
-#define GPIO_9_PIN          6
-#define GPIO_9_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPCEN)
-#define GPIO_9_EXTI_CFG()   (AFIO->EXTICR[1] |= AFIO_EXTICR2_EXTI6_PC)
-#define GPIO_9_IRQ          EXTI9_5_IRQn
-/* GPIO channel 10 config */
-#define GPIO_10_PORT        GPIOC                   /* flash: hold */
-#define GPIO_10_PIN         9
-#define GPIO_10_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPCEN)
-#define GPIO_10_EXTI_CFG()  (AFIO->EXTICR[2] |= AFIO_EXTICR3_EXTI9_PC)
-#define GPIO_10_IRQ         EXTI9_5_IRQn
-/* GPIO channel 11 config */
-#define GPIO_11_PORT        GPIOA                   /* radio: cs */
-#define GPIO_11_PIN         4
-#define GPIO_11_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPAEN)
-#define GPIO_11_EXTI_CFG()  (AFIO->EXTICR[1] |= AFIO_EXTICR2_EXTI4_PA)
-#define GPIO_11_IRQ         EXTI4_IRQn
-/* GPIO channel 12 config */
-#define GPIO_12_PORT        GPIOC                   /* radio: int */
-#define GPIO_12_PIN         4
-#define GPIO_12_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPCEN)
-#define GPIO_12_EXTI_CFG()  (AFIO->EXTICR[1] |= AFIO_EXTICR2_EXTI4_PC)
-#define GPIO_12_IRQ         EXTI4_IRQn
-/* GPIO channel 13 config */
-#define GPIO_13_PORT        GPIOC                   /* radio: reset */
-#define GPIO_13_PIN         1
-#define GPIO_13_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPCEN)
-#define GPIO_13_EXTI_CFG()  (AFIO->EXTICR[0] |= AFIO_EXTICR1_EXTI1_PC)
-#define GPIO_13_IRQ         EXTI1_IRQn
-/* GPIO channel 14 config */
-#define GPIO_14_PORT        GPIOA                   /* radio: sleep */
-#define GPIO_14_PIN         2
-#define GPIO_14_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPAEN)
-#define GPIO_14_EXTI_CFG()  (AFIO->EXTICR[0] |= AFIO_EXTICR1_EXTI2_PA)
-#define GPIO_14_IRQ         EXTI2_IRQn
-/* GPIO channel 14 config */
-#define GPIO_15_PORT        GPIOC                   /* battery feedback */
-#define GPIO_15_PIN         13
-#define GPIO_15_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPCEN)
-#define GPIO_15_EXTI_CFG()  (AFIO->EXTICR[3] |= AFIO_EXTICR4_EXTI13_PC)
-#define GPIO_15_IRQ         EXTI15_10_IRQn
+/** @} */
 
 /**
  * @brief SPI configuration

--- a/boards/spark-core/Makefile.features
+++ b/boards/spark-core/Makefile.features
@@ -1,3 +1,4 @@
 FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_gpio
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/spark-core/board.c
+++ b/boards/spark-core/board.c
@@ -51,13 +51,13 @@ static void leds_init(void)
     RCC->APB2ENR |= RCC_APB2ENR_IOPAEN;
 
     /* reset pins */
-    LED_PORT->CRH &= ~(0xf << (4*(LED_RED_PIN - 8)) |
+    LED_PORT->CR[1] &= ~(0xf << (4*(LED_RED_PIN - 8)) |
                        0xf << (4*(LED_GREEN_PIN - 8)) |
                        0xf << (4*(LED_BLUE_PIN - 8)) |
                        0xf << (4*(LED_WHITE_PIN - 8)));
 
     /* set pins to out */
-    LED_PORT->CRH |= (0x3 << (4*(LED_RED_PIN - 8)) |
+    LED_PORT->CR[1] |= (0x3 << (4*(LED_RED_PIN - 8)) |
                       0x3 << (4*(LED_GREEN_PIN - 8)) |
                       0x3 << (4*(LED_BLUE_PIN - 8)) |
                       0x3 << (4*(LED_WHITE_PIN - 8)));

--- a/boards/spark-core/include/board.h
+++ b/boards/spark-core/include/board.h
@@ -86,16 +86,16 @@
 /**
  * @name User button configuration
  */
-#define BUTTON1             GPIO_0
+#define BUTTON1             GPIO(PORT_B,2)
 
 /**
  * @name CC3000 pin configuration
  * @{
  */
 #define CC3000_SPI          SPI_0
-#define CC3000_CS           GPIO_1
-#define CC3000_EN           GPIO_2
-#define CC3000_INT          GPIO_3
+#define CC3000_CS           GPIO(PORT_B,12)
+#define CC3000_EN           GPIO(PORT_B,8)
+#define CC3000_INT          GPIO(PORT_B,11)
 /** @} */
 
 /**
@@ -103,7 +103,7 @@
  * @{
  */
 #define EXTFLASH_SPI        SPI_0
-#define EXTFLASH            GPIO_4
+#define EXTFLASH            GPIO(PORT_B,9)
 /** @} */
 
 /**

--- a/boards/spark-core/include/periph_conf.h
+++ b/boards/spark-core/include/periph_conf.h
@@ -15,6 +15,7 @@
  *
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
  */
+
 #ifndef PERIPH_CONF_H_
 #define PERIPH_CONF_H_
 
@@ -76,8 +77,10 @@
 #define TIMER_1_IRQ_PRIO    1
 #define TIMER_1_TRIG_SEL    TIM_SMCR_TS_1
 /** @} */
+
 /**
  * @brief UART configuration
+ * @{
  */
 #define UART_NUMOF          (1U)
 #define UART_0_EN           1
@@ -95,134 +98,7 @@
 #define UART_0_RX_PIN       3
 #define UART_0_TX_PIN       2
 #define UART_0_AF           0
-
-/**
- * @brief GPIO configuration
- */
-#define GPIO_0_EN           1
-#define GPIO_1_EN           1
-#define GPIO_2_EN           1
-#define GPIO_3_EN           1
-#define GPIO_4_EN           1
-#define GPIO_5_EN           1
-#define GPIO_6_EN           1
-#define GPIO_7_EN           1
-#define GPIO_8_EN           1
-#define GPIO_9_EN           1
-#define GPIO_10_EN          1
-#define GPIO_11_EN          1
-#define GPIO_12_EN          1
-#define GPIO_IRQ_PRIO       1
-
-/* IRQ config */
-#define GPIO_IRQ_0          0 /* not used */
-#define GPIO_IRQ_1          0 /* not used */
-#define GPIO_IRQ_2          GPIO_0
-#define GPIO_IRQ_3          GPIO_9
-#define GPIO_IRQ_4          GPIO_8
-#define GPIO_IRQ_5          GPIO_7
-#define GPIO_IRQ_6          GPIO_6
-#define GPIO_IRQ_7          GPIO_5
-#define GPIO_IRQ_8          GPIO_2
-#define GPIO_IRQ_9          GPIO_4
-#define GPIO_IRQ_10         0 /* not used */
-#define GPIO_IRQ_11         GPIO_3
-#define GPIO_IRQ_12         GPIO_1
-#define GPIO_IRQ_13         GPIO_12
-#define GPIO_IRQ_14         GPIO_11
-#define GPIO_IRQ_15         GPIO_10
-
-/* GPIO channel 0 config */
-#define GPIO_0_PORT         GPIOB                   /* Used for user button 1 */
-#define GPIO_0_PIN          2
-#define GPIO_0_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_0_EXTI_CFG()   (AFIO->EXTICR[0] |= AFIO_EXTICR1_EXTI2_PB)
-#define GPIO_0_EXTI_LINE    2
-#define GPIO_0_IRQ          EXTI4_IRQn
-/* GPIO channel 1 config */
-#define GPIO_1_PORT         GPIOB                   /* Used for CC3000 CS */
-#define GPIO_1_PIN          12
-#define GPIO_1_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_1_EXTI_CFG()   (AFIO->EXTICR[3] |= AFIO_EXTICR4_EXTI12_PB)
-#define GPIO_1_EXTI_LINE    12
-#define GPIO_1_IRQ          EXTI4_IRQn
-/* GPIO channel 2 config */
-#define GPIO_2_PORT         GPIOB                   /* Used for CC3000 EN */
-#define GPIO_2_PIN          8
-#define GPIO_2_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_2_EXTI_CFG()   (AFIO->EXTICR[2] |= AFIO_EXTICR3_EXTI8_PB)
-#define GPIO_2_EXTI_LINE    8
-#define GPIO_2_IRQ          EXTI4_IRQn
-/* GPIO channel 3 config */
-#define GPIO_3_PORT         GPIOB                   /* Used for CC3000 INT */
-#define GPIO_3_PIN          11
-#define GPIO_3_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_3_EXTI_CFG()   (AFIO->EXTICR[2] |= AFIO_EXTICR3_EXTI11_PB)
-#define GPIO_3_EXTI_LINE    11
-#define GPIO_3_IRQ          EXTI4_IRQn
-/* GPIO channel 4 config */
-#define GPIO_4_PORT         GPIOB                   /* Used for EXTFLASH CS */
-#define GPIO_4_PIN          9
-#define GPIO_4_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_4_EXTI_CFG()   (AFIO->EXTICR[2] |= AFIO_EXTICR3_EXTI9_PB)
-#define GPIO_4_EXTI_LINE    9
-#define GPIO_4_IRQ          EXTI4_IRQn
-/* GPIO channel 5 config */
-#define GPIO_5_PORT         GPIOB                   /* D0 */
-#define GPIO_5_PIN          7
-#define GPIO_5_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_5_EXTI_CFG()   (AFIO->EXTICR[1] |= AFIO_EXTICR2_EXTI7_PB)
-#define GPIO_5_EXTI_LINE    7
-#define GPIO_5_IRQ          EXTI4_IRQn
-/* GPIO channel 6 config */
-#define GPIO_6_PORT         GPIOB                   /* D1 */
-#define GPIO_6_PIN          6
-#define GPIO_6_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_6_EXTI_CFG()   (AFIO->EXTICR[1] |= AFIO_EXTICR2_EXTI6_PB)
-#define GPIO_6_EXTI_LINE    6
-#define GPIO_6_IRQ          EXTI3_IRQn
-/* GPIO channel 7 config */
-#define GPIO_7_PORT         GPIOB                   /* D2 */
-#define GPIO_7_PIN          5
-#define GPIO_7_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_7_EXTI_CFG()   (AFIO->EXTICR[1] |= AFIO_EXTICR2_EXTI5_PB)
-#define GPIO_7_EXTI_LINE    5
-#define GPIO_7_IRQ          EXTI3_IRQn
-/* GPIO channel 8 config */
-#define GPIO_8_PORT         GPIOB                   /* D3 */
-#define GPIO_8_PIN          4
-#define GPIO_8_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_8_EXTI_CFG()   (AFIO->EXTICR[1] |= AFIO_EXTICR2_EXTI4_PB)
-#define GPIO_8_EXTI_LINE    4
-#define GPIO_8_IRQ          EXTI4_IRQn
-/* GPIO channel 9 config */
-#define GPIO_9_PORT         GPIOB                   /* D4 */
-#define GPIO_9_PIN          3
-#define GPIO_9_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define GPIO_9_EXTI_CFG()   (AFIO->EXTICR[0] |= AFIO_EXTICR1_EXTI3_PB)
-#define GPIO_9_EXTI_LINE    3
-#define GPIO_9_IRQ          EXTI4_IRQn
-/* GPIO channel 10 config */
-#define GPIO_10_PORT        GPIOA                   /* D5 */
-#define GPIO_10_PIN         15
-#define GPIO_10_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPAEN)
-#define GPIO_10_EXTI_CFG()  (AFIO->EXTICR[3] |= AFIO_EXTICR4_EXTI15_PA)
-#define GPIO_10_EXTI_LINE   15
-#define GPIO_10_IRQ         EXTI4_IRQn
-/* GPIO channel 11 config */
-#define GPIO_11_PORT        GPIOA                   /* D6 */
-#define GPIO_11_PIN         14
-#define GPIO_11_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPAEN)
-#define GPIO_11_EXTI_CFG()  (AFIO->EXTICR[3] |= AFIO_EXTICR4_EXTI14_PA)
-#define GPIO_11_EXTI_LINE   14
-#define GPIO_11_IRQ         EXTI4_IRQn
-/* GPIO channel 12 config */
-#define GPIO_12_PORT        GPIOA                   /* D7 */
-#define GPIO_12_PIN         13
-#define GPIO_12_CLKEN()     (RCC->APB2ENR |= RCC_APB2ENR_IOPAEN)
-#define GPIO_12_EXTI_CFG()  (AFIO->EXTICR[3] |= AFIO_EXTICR4_EXTI13_PA)
-#define GPIO_12_EXTI_LINE   13
-#define GPIO_12_IRQ         EXTI4_IRQn
+/** @} */
 
 /**
  * @brief SPI configuration

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -19,13 +19,88 @@
 #ifndef PERIPH_CPU_H_
 #define PERIPH_CPU_H_
 
+#include "cpu.h"
 #include "periph/dev_enums.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* nothing defined here so far... */
+/**
+ * @brief   Overwrite the default gpio_t type definition
+ * @{
+ */
+#define HAVE_GPIO_T
+typedef uint32_t gpio_t;
+/** @} */
+
+/**
+ * @brief   Definition of a fitting UNDEF value
+ */
+#define GPIO_UNDEF          (0xffffffff)
+
+/**
+ * @brief   Define a CPU specific GPIO pin generator macro
+ */
+#define GPIO(x, y)          ((GPIOA_BASE + (x << 10)) | y)
+
+/**
+ * @brief   Override values for pull register configuration
+ * @{
+ */
+#define HAVE_GPIO_PP_T
+typedef enum {
+    GPIO_NOPULL = 4,        /**< do not use internal pull resistors */
+    GPIO_PULLUP = 9,        /**< enable internal pull-up resistor */
+    GPIO_PULLDOWN = 8       /**< enable internal pull-down resistor */
+} gpio_pp_t;
+/** @} */
+
+/**
+ * @brief   Override flank configuration values
+ * @{
+ */
+#define HAVE_GPIO_FLANK_T
+typedef enum {
+    GPIO_RISING = 1,        /**< emit interrupt on rising flank */
+    GPIO_FALLING = 2,       /**< emit interrupt on falling flank */
+    GPIO_BOTH = 3           /**< emit interrupt on both flanks */
+} gpio_flank_t;
+/** @} */
+
+/**
+ * @brief   Available ports on the STM32F1 family
+ */
+enum {
+    PORT_A = 0,             /**< port A */
+    PORT_B = 1,             /**< port B */
+    PORT_C = 2,             /**< port C */
+    PORT_D = 3,             /**< port D */
+    PORT_E = 4,             /**< port E */
+    PORT_F = 5,             /**< port F */
+    PORT_G = 6,             /**< port G */
+};
+
+/**
+ * @brief   Define alternate function modes
+ *
+ * On this CPU, only the output pins have alternate function modes. The input
+ * pins have to be configured using the default gpio_init() function.
+ */
+typedef enum {
+    GPIO_AF_OUT_PP = 0xb,   /**< alternate function output - push-pull */
+    GPIO_AF_OUT_OD = 0xf,   /**< alternate function output - open-drain */
+} gpio_af_out_t;
+
+/**
+ * @brief   Configure the alternate function for the given pin
+ *
+ * @note    This is meant for internal use in STM32F1 peripheral drivers only
+ *
+ * @param[in] pin       pin to configure
+ * @param[in] af        alternate function to use
+ */
+void gpio_init_af(gpio_t pin, gpio_af_out_t af);
 
 #ifdef __cplusplus
 }

--- a/cpu/stm32f1/include/stm32f10x.h
+++ b/cpu/stm32f1/include/stm32f10x.h
@@ -1009,8 +1009,7 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CRL;
-  __IO uint32_t CRH;
+  __IO uint32_t CR[2];
   __IO uint32_t IDR;
   __IO uint32_t ODR;
   __IO uint32_t BSRR;

--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014-2015 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -30,1015 +30,195 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+/**
+ * @brief   Number of available external interrupt lines
+ */
+#define GPIO_ISR_CHAN_NUMOF             (16U)
+
 typedef struct {
     gpio_cb_t cb;       /**< callback called from GPIO interrupt */
     void *arg;          /**< argument passed to the callback */
-} gpio_state_t;
+} exti_ctx_t;
 
-static gpio_state_t config[GPIO_NUMOF];
+/**
+ * @brief   Allocate memory for one callback and argument per EXTI channel
+ */
+static exti_ctx_t exti_ctx[GPIO_ISR_CHAN_NUMOF];
 
-int gpio_init(gpio_t dev, gpio_dir_t dir, gpio_pp_t pullup)
+/**
+ * @brief   Extract the pin's port base address from the given pin identifier
+ */
+static inline GPIO_TypeDef *_port(gpio_t pin)
 {
-    GPIO_TypeDef *port;
-    uint32_t pin;
+    return (GPIO_TypeDef *)(pin & ~(0x0f));
+}
 
-    switch (dev) {
-#if GPIO_0_EN
-        case GPIO_0:
-            GPIO_0_CLKEN();
-            port = GPIO_0_PORT;
-            pin = GPIO_0_PIN;
-            break;
-#endif
-#if GPIO_1_EN
-        case GPIO_1:
-            GPIO_1_CLKEN();
-            port = GPIO_1_PORT;
-            pin = GPIO_1_PIN;
-            break;
-#endif
-#if GPIO_2_EN
-        case GPIO_2:
-            GPIO_2_CLKEN();
-            port = GPIO_2_PORT;
-            pin = GPIO_2_PIN;
-            break;
-#endif
-#if GPIO_3_EN
-        case GPIO_3:
-            GPIO_3_CLKEN();
-            port = GPIO_3_PORT;
-            pin = GPIO_3_PIN;
-            break;
-#endif
-#if GPIO_4_EN
-        case GPIO_4:
-            GPIO_4_CLKEN();
-            port = GPIO_4_PORT;
-            pin = GPIO_4_PIN;
-            break;
-#endif
-#if GPIO_5_EN
-        case GPIO_5:
-            GPIO_5_CLKEN();
-            port = GPIO_5_PORT;
-            pin = GPIO_5_PIN;
-            break;
-#endif
-#if GPIO_6_EN
-        case GPIO_6:
-            GPIO_6_CLKEN();
-            port = GPIO_6_PORT;
-            pin = GPIO_6_PIN;
-            break;
-#endif
-#if GPIO_7_EN
-        case GPIO_7:
-            GPIO_7_CLKEN();
-            port = GPIO_7_PORT;
-            pin = GPIO_7_PIN;
-            break;
-#endif
-#if GPIO_8_EN
-        case GPIO_8:
-            GPIO_8_CLKEN();
-            port = GPIO_8_PORT;
-            pin = GPIO_8_PIN;
-            break;
-#endif
-#if GPIO_9_EN
-        case GPIO_9:
-            GPIO_9_CLKEN();
-            port = GPIO_9_PORT;
-            pin = GPIO_9_PIN;
-            break;
-#endif
-#if GPIO_10_EN
-        case GPIO_10:
-            GPIO_10_CLKEN();
-            port = GPIO_10_PORT;
-            pin = GPIO_10_PIN;
-            break;
-#endif
-#if GPIO_11_EN
-        case GPIO_11:
-            GPIO_11_CLKEN();
-            port = GPIO_11_PORT;
-            pin = GPIO_11_PIN;
-            break;
-#endif
-#if GPIO_12_EN
-        case GPIO_12:
-            GPIO_12_CLKEN();
-            port = GPIO_12_PORT;
-            pin = GPIO_12_PIN;
-            break;
-#endif
-#if GPIO_13_EN
-        case GPIO_13:
-            GPIO_13_CLKEN();
-            port = GPIO_13_PORT;
-            pin = GPIO_13_PIN;
-            break;
-#endif
-#if GPIO_14_EN
-        case GPIO_14:
-            GPIO_14_CLKEN();
-            port = GPIO_14_PORT;
-            pin = GPIO_14_PIN;
-            break;
-#endif
-#if GPIO_15_EN
-        case GPIO_15:
-            GPIO_15_CLKEN();
-            port = GPIO_15_PORT;
-            pin = GPIO_15_PIN;
-            break;
-#endif
+/**
+ * @brief   Extract the port number from the given pin identifier
+ *
+ * Isolating bits 10 to 13 of the port base addresses leads to unique port
+ * numbers.
+ */
+static inline int _port_num(gpio_t pin)
+{
+    return (((pin >> 10) & 0x0f) - 2);
+}
 
-        default:
-            return -1;
-    }
+/**
+ * @brief   Get the pin number from the pin identifier, encoded in the LSB 4 bit
+ */
+static inline int _pin_num(gpio_t pin)
+{
+    return (pin & 0x0f);
+}
 
+
+int gpio_init(gpio_t pin, gpio_dir_t dir, gpio_pp_t pullup)
+{
+    GPIO_TypeDef *port = _port(pin);
+    int pin_num = _pin_num(pin);
+
+
+    /* enable the clock for the selected port */
+    RCC->APB2ENR |= (RCC_APB2ENR_IOPAEN << _port_num(pin));
+    /* clear configuration */
+    port->CR[pin_num >> 3] &= ~(0xf << ((pin_num & 0x7) * 4));
+    /* set new configuration */
     if (dir == GPIO_DIR_OUT) {
-        if (pin < 8) {
-            port->CRL &= ~(0xf << (4 * pin));
-            port->CRL |= (0x3 << (4* pin)); /* Output mode, 50 MHz */
-                                            /* general purpose push-pull set implicitly */
+        if (pullup != GPIO_NOPULL) {
+            return -1;
         }
-        else {
-            port->CRH &= ~(0xf << (4 * (pin-8)));
-            port->CRH |= (0x3 << (4* (pin-8))); /* Output mode, 50 MHz */
-                                                /* general purpose push-pull set implicitly */
-        }
+        /* set to output, push-pull, 50MHz */
+        port->CR[pin_num >> 3] |= (0x3 << ((pin_num & 0x7) * 4));
+        /* clear pin */
+        port->BRR = (1 << pin_num);
     }
     else {
-        if (pin < 8) {
-            port->CRL &= ~(0xf << (4 * pin));
-            port->CRL |= (0x4 << (4 * pin));
-        }
-        else {
-            port->CRL &= ~(0xf << (4 * pin));
-            port->CRH |= (0x4 << (4 * (pin-8)));
-        }
+        /* configure pin to input, pull register according to the value of
+         * the pullup parameter */
+        port->CR[pin_num >> 3] |= ((pullup & 0xc)  << ((pin_num & 0x7) * 4));
+        port->ODR &= ~(1 << pin_num);
+        port->ODR |=  ((pullup & 0x1) << pin_num);
     }
 
     return 0; /* all OK */
 }
 
-int gpio_init_int(gpio_t dev, gpio_pp_t pullup, gpio_flank_t flank, gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_t pin, gpio_pp_t pullup, gpio_flank_t flank,
+                  gpio_cb_t cb, void *arg)
 {
-    int res;
-    uint8_t exti_line;
-    uint8_t gpio_irq;
+    int pin_num = _pin_num(pin);
 
+    /* disable interrupts on the channel we want to edit (just in case) */
+    EXTI->IMR &= ~(1 << pin_num);
     /* configure pin as input */
-    res = gpio_init(dev, GPIO_DIR_IN, pullup);
-    if (res < 0) {
-        return res;
-    }
-
-    /* set interrupt priority (its the same for all EXTI interrupts) */
-    NVIC_SetPriority(EXTI0_IRQn, GPIO_IRQ_PRIO);
-    NVIC_SetPriority(EXTI1_IRQn, GPIO_IRQ_PRIO);
-    NVIC_SetPriority(EXTI2_IRQn, GPIO_IRQ_PRIO);
-    NVIC_SetPriority(EXTI4_IRQn, GPIO_IRQ_PRIO);
-
-    RCC->APB2ENR |= RCC_APB2ENR_AFIOEN;
-
-    /* read pin number, set EXTI channel and enable global interrupt for EXTI channel */
-    switch (dev) {
-#if GPIO_0_EN
-        case GPIO_0:
-            exti_line = GPIO_0_PIN;
-            gpio_irq = GPIO_0;
-            GPIO_0_EXTI_CFG();
-            NVIC_SetPriority(GPIO_0_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_0_IRQ);
-            break;
-#endif
-#if GPIO_1_EN
-        case GPIO_1:
-            exti_line = GPIO_1_PIN;
-            gpio_irq = GPIO_1;
-            GPIO_1_EXTI_CFG();
-            NVIC_SetPriority(GPIO_1_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_1_IRQ);
-            break;
-#endif
-#if GPIO_2_EN
-        case GPIO_2:
-            exti_line = GPIO_2_PIN;
-            gpio_irq = GPIO_2;
-            GPIO_2_EXTI_CFG();
-            NVIC_SetPriority(GPIO_2_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_2_IRQ);
-            break;
-#endif
-#if GPIO_3_EN
-        case GPIO_3:
-            exti_line = GPIO_3_PIN;
-            gpio_irq = GPIO_3;
-            GPIO_3_EXTI_CFG();
-            NVIC_SetPriority(GPIO_3_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_3_IRQ);
-            break;
-#endif
-#if GPIO_4_EN
-        case GPIO_4:
-            exti_line = GPIO_4_PIN;
-            gpio_irq = GPIO_4;
-            GPIO_4_EXTI_CFG();
-            NVIC_SetPriority(GPIO_4_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_4_IRQ);
-            break;
-#endif
-#if GPIO_5_EN
-        case GPIO_5:
-            exti_line = GPIO_5_PIN;
-            gpio_irq = GPIO_5;
-            GPIO_5_EXTI_CFG();
-            NVIC_SetPriority(GPIO_5_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_5_IRQ);
-            break;
-#endif
-#if GPIO_6_EN
-        case GPIO_6:
-            exti_line = GPIO_6_PIN;
-            gpio_irq = GPIO_6;
-            GPIO_6_EXTI_CFG();
-            NVIC_SetPriority(GPIO_6_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_6_IRQ);
-            break;
-#endif
-#if GPIO_7_EN
-        case GPIO_7:
-            exti_line = GPIO_7_PIN;
-            gpio_irq = GPIO_7;
-            GPIO_7_EXTI_CFG();
-            NVIC_SetPriority(GPIO_7_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_7_IRQ);
-            break;
-#endif
-#if GPIO_8_EN
-        case GPIO_8:
-            exti_line = GPIO_8_PIN;
-            gpio_irq = GPIO_8;
-            GPIO_8_EXTI_CFG();
-            NVIC_SetPriority(GPIO_8_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_8_IRQ);
-            break;
-#endif
-#if GPIO_9_EN
-        case GPIO_9:
-            exti_line = GPIO_9_PIN;
-            gpio_irq = GPIO_9;
-            GPIO_9_EXTI_CFG();
-            NVIC_SetPriority(GPIO_9_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_9_IRQ);
-            break;
-#endif
-#if GPIO_10_EN
-        case GPIO_10:
-            exti_line = GPIO_10_PIN;
-            gpio_irq = GPIO_10;
-            GPIO_10_EXTI_CFG();
-            NVIC_SetPriority(GPIO_10_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_10_IRQ);
-            break;
-#endif
-#if GPIO_11_EN
-        case GPIO_11:
-            exti_line = GPIO_11_PIN;
-            gpio_irq = GPIO_11;
-            GPIO_11_EXTI_CFG();
-            NVIC_SetPriority(GPIO_11_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_11_IRQ);
-            break;
-#endif
-#if GPIO_12_EN
-        case GPIO_12:
-            exti_line = GPIO_12_PIN;
-            gpio_irq = GPIO_12;
-            GPIO_12_EXTI_CFG();
-            NVIC_SetPriority(GPIO_12_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_12_IRQ);
-            break;
-#endif
-#if GPIO_13_EN
-        case GPIO_13:
-            exti_line = GPIO_13_PIN;
-            gpio_irq = GPIO_13;
-            GPIO_13_EXTI_CFG();
-            NVIC_SetPriority(GPIO_13_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_13_IRQ);
-            break;
-#endif
-#if GPIO_14_EN
-        case GPIO_14:
-            exti_line = GPIO_14_PIN;
-            gpio_irq = GPIO_14;
-            GPIO_14_EXTI_CFG();
-            NVIC_SetPriority(GPIO_14_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_14_IRQ);
-            break;
-#endif
-#if GPIO_15_EN
-        case GPIO_15:
-            exti_line = GPIO_15_PIN;
-            gpio_irq = GPIO_15;
-            GPIO_15_EXTI_CFG();
-            NVIC_SetPriority(GPIO_15_IRQ, GPIO_IRQ_PRIO);
-            NVIC_EnableIRQ(GPIO_15_IRQ);
-            break;
-#endif
-        default:
-            return -1;
-    }
-
+    gpio_init(pin, GPIO_DIR_IN, pullup);
     /* set callback */
-    config[gpio_irq].cb = cb;
-    config[gpio_irq].arg = arg;
-
-    /* configure the event that triggers an interrupt */
-    switch (flank) {
-        case GPIO_RISING:
-            EXTI->RTSR |= (1 << exti_line);
-            EXTI->FTSR &= ~(1 << exti_line);
-            break;
-        case GPIO_FALLING:
-            EXTI->RTSR &= ~(1 << exti_line);
-            EXTI->FTSR |= (1 << exti_line);
-            break;
-        case GPIO_BOTH:
-            EXTI->RTSR |= (1 << exti_line);
-            EXTI->FTSR |= (1 << exti_line);
-            break;
+    exti_ctx[pin_num].cb = cb;
+    exti_ctx[pin_num].arg = arg;
+    /* enable alternate function clock for the GPIO module */
+    RCC->APB2ENR |= RCC_APB2ENR_AFIOEN;
+    /* configure the EXTI channel */
+    AFIO->EXTICR[pin_num >> 2] &= ~(0xf << ((pin_num & 0x3) * 4));
+    AFIO->EXTICR[pin_num >> 2] |=  (_port_num(pin) << ((pin_num & 0x3) * 4));
+    /* configure the active flank */
+    EXTI->RTSR &= ~(1 << pin_num);
+    EXTI->RTSR |=  ((flank & 0x1) << pin_num);
+    EXTI->FTSR &= ~(1 << pin_num);
+    EXTI->FTSR |=  ((flank >> 1) << pin_num);
+    /* active global interrupt for the selected port */
+    if (pin_num < 5) {
+        NVIC_EnableIRQ(EXTI0_IRQn + pin_num);
     }
-
+    else if (pin_num < 10) {
+        NVIC_EnableIRQ(EXTI9_5_IRQn);
+    }
+    else {
+        NVIC_EnableIRQ(EXTI15_10_IRQn);
+    }
     /* clear event mask */
-    EXTI->EMR &= ~(1 << exti_line);
+    EXTI->EMR &= ~(1 << pin_num);
     /* unmask the pins interrupt channel */
-    EXTI->IMR |= (1 << exti_line);
-
+    EXTI->IMR |= (1 << pin_num);
     return 0;
 }
 
-void gpio_irq_enable(gpio_t dev)
+void gpio_init_af(gpio_t pin, gpio_af_out_t af)
 {
-    uint8_t exti_line;
+    int pin_num = _pin_num(pin);
+    GPIO_TypeDef *port = _port(pin);
 
-    switch(dev) {
-#if GPIO_0_EN
-        case GPIO_0:
-            exti_line = GPIO_0_PIN;
-            break;
-#endif
-#if GPIO_1_EN
-        case GPIO_1:
-            exti_line = GPIO_1_PIN;
-            break;
-#endif
-#if GPIO_2_EN
-        case GPIO_2:
-            exti_line = GPIO_2_PIN;
-            break;
-#endif
-#if GPIO_3_EN
-        case GPIO_3:
-            exti_line = GPIO_3_PIN;
-            break;
-#endif
-#if GPIO_4_EN
-        case GPIO_4:
-            exti_line = GPIO_4_PIN;
-            break;
-#endif
-#if GPIO_5_EN
-        case GPIO_5:
-            exti_line = GPIO_5_PIN;
-            break;
-#endif
-#if GPIO_6_EN
-        case GPIO_6:
-            exti_line = GPIO_6_PIN;
-            break;
-#endif
-#if GPIO_7_EN
-        case GPIO_7:
-            exti_line = GPIO_7_PIN;
-            break;
-#endif
-#if GPIO_8_EN
-        case GPIO_8:
-            exti_line = GPIO_8_PIN;
-            break;
-#endif
-#if GPIO_9_EN
-        case GPIO_9:
-            exti_line = GPIO_9_PIN;
-            break;
-#endif
-#if GPIO_10_EN
-        case GPIO_10:
-            exti_line = GPIO_10_PIN;
-            break;
-#endif
-#if GPIO_11_EN
-        case GPIO_11:
-            exti_line = GPIO_11_PIN;
-            break;
-#endif
-#if GPIO_12_EN
-        case GPIO_12:
-            exti_line = GPIO_12_PIN;
-            break;
-#endif
-#if GPIO_13_EN
-        case GPIO_13:
-            exti_line = GPIO_13_PIN;
-            break;
-#endif
-#if GPIO_14_EN
-        case GPIO_14:
-            exti_line = GPIO_14_PIN;
-            break;
-#endif
-#if GPIO_15_EN
-        case GPIO_15:
-            exti_line = GPIO_15_PIN;
-            break;
-#endif
-        default:
-            return;
-    }
-
-    /* unmask the pins interrupt channel */
-    EXTI->IMR |= (1 << exti_line);
-
-    return;
+    /* enable the clock for the selected port */
+    RCC->APB2ENR |= (RCC_APB2ENR_IOPAEN << _port_num(pin));
+    /* configure the pin */
+    port->CR[pin_num >> 3] &= ~(0xf << ((pin_num & 0x7) * 4));
+    port->CR[pin_num >> 3] |=  (af << ((pin_num & 0x7) * 4));
 }
 
-void gpio_irq_disable(gpio_t dev)
+void gpio_irq_enable(gpio_t pin)
 {
-    uint8_t exti_line;
-
-    switch(dev) {
-#if GPIO_0_EN
-        case GPIO_0:
-            exti_line = GPIO_0_PIN;
-            break;
-#endif
-#if GPIO_1_EN
-        case GPIO_1:
-            exti_line = GPIO_1_PIN;
-            break;
-#endif
-#if GPIO_2_EN
-        case GPIO_2:
-            exti_line = GPIO_2_PIN;
-            break;
-#endif
-#if GPIO_3_EN
-        case GPIO_3:
-            exti_line = GPIO_3_PIN;
-            break;
-#endif
-#if GPIO_4_EN
-        case GPIO_4:
-            exti_line = GPIO_4_PIN;
-            break;
-#endif
-#if GPIO_5_EN
-        case GPIO_5:
-            exti_line = GPIO_5_PIN;
-            break;
-#endif
-#if GPIO_6_EN
-        case GPIO_6:
-            exti_line = GPIO_6_PIN;
-            break;
-#endif
-#if GPIO_7_EN
-        case GPIO_7:
-            exti_line = GPIO_7_PIN;
-            break;
-#endif
-#if GPIO_8_EN
-        case GPIO_8:
-            exti_line = GPIO_8_PIN;
-            break;
-#endif
-#if GPIO_9_EN
-        case GPIO_9:
-            exti_line = GPIO_9_PIN;
-            break;
-#endif
-#if GPIO_10_EN
-        case GPIO_10:
-            exti_line = GPIO_10_PIN;
-            break;
-#endif
-#if GPIO_11_EN
-        case GPIO_11:
-            exti_line = GPIO_11_PIN;
-            break;
-#endif
-#if GPIO_12_EN
-        case GPIO_12:
-            exti_line = GPIO_12_PIN;
-            break;
-#endif
-#if GPIO_13_EN
-        case GPIO_13:
-            exti_line = GPIO_13_PIN;
-            break;
-#endif
-#if GPIO_14_EN
-        case GPIO_14:
-            exti_line = GPIO_14_PIN;
-            break;
-#endif
-#if GPIO_15_EN
-        case GPIO_15:
-            exti_line = GPIO_15_PIN;
-            break;
-#endif
-        default:
-            return;
-    }
-
-    /* unmask the pins interrupt channel */
-    EXTI->IMR &= ~(1 << exti_line);
-
-    return;
+    EXTI->IMR |= (1 << _pin_num(pin));
 }
 
-int gpio_read(gpio_t dev)
+void gpio_irq_disable(gpio_t pin)
 {
-    GPIO_TypeDef *port;
-    uint32_t pin;
+    EXTI->IMR &= ~(1 << _pin_num(pin));
+}
 
-    switch (dev) {
-#if GPIO_0_EN
-        case GPIO_0:
-            port = GPIO_0_PORT;
-            pin = GPIO_0_PIN;
-            break;
-#endif
-#if GPIO_1_EN
-        case GPIO_1:
-            port = GPIO_1_PORT;
-            pin = GPIO_1_PIN;
-            break;
-#endif
-#if GPIO_2_EN
-        case GPIO_2:
-            port = GPIO_2_PORT;
-            pin = GPIO_2_PIN;
-            break;
-#endif
-#if GPIO_3_EN
-        case GPIO_3:
-            port = GPIO_3_PORT;
-            pin = GPIO_3_PIN;
-            break;
-#endif
-#if GPIO_4_EN
-        case GPIO_4:
-            port = GPIO_4_PORT;
-            pin = GPIO_4_PIN;
-            break;
-#endif
-#if GPIO_5_EN
-        case GPIO_5:
-            port = GPIO_5_PORT;
-            pin = GPIO_5_PIN;
-            break;
-#endif
-#if GPIO_6_EN
-        case GPIO_6:
-            port = GPIO_6_PORT;
-            pin = GPIO_6_PIN;
-            break;
-#endif
-#if GPIO_7_EN
-        case GPIO_7:
-            port = GPIO_7_PORT;
-            pin = GPIO_7_PIN;
-            break;
-#endif
-#if GPIO_8_EN
-        case GPIO_8:
-            port = GPIO_8_PORT;
-            pin = GPIO_8_PIN;
-            break;
-#endif
-#if GPIO_9_EN
-        case GPIO_9:
-            port = GPIO_9_PORT;
-            pin = GPIO_9_PIN;
-            break;
-#endif
-#if GPIO_10_EN
-        case GPIO_10:
-            port = GPIO_10_PORT;
-            pin = GPIO_10_PIN;
-            break;
-#endif
-#if GPIO_11_EN
-        case GPIO_11:
-            port = GPIO_11_PORT;
-            pin = GPIO_11_PIN;
-            break;
-#endif
-#if GPIO_12_EN
-        case GPIO_12:
-            port = GPIO_12_PORT;
-            pin = GPIO_12_PIN;
-            break;
-#endif
-#if GPIO_13_EN
-        case GPIO_13:
-            port = GPIO_13_PORT;
-            pin = GPIO_13_PIN;
-            break;
-#endif
-#if GPIO_14_EN
-        case GPIO_14:
-            port = GPIO_14_PORT;
-            pin = GPIO_14_PIN;
-            break;
-#endif
-#if GPIO_15_EN
-        case GPIO_15:
-            port = GPIO_15_PORT;
-            pin = GPIO_15_PIN;
-            break;
-#endif
-        default:
-            return -1;
-    }
+int gpio_read(gpio_t pin)
+{
+    GPIO_TypeDef *port = _port(pin);
+    int pin_num = _pin_num(pin);
 
-    if (pin < 8) {
-        if (port->CRL & (0x3 << (pin * 4))) {  /* if configured as output */
-            return port->ODR & (1 << pin);          /* read output data register */
-        } else {
-            return port->IDR & (1 << pin);          /* else read input data register */
-        }
+    if (port->CR[pin_num >> 3] & (0x3 << (pin_num & 0x7))) {
+        /* pin is output */
+        return (port->ODR & (1 << pin_num));
     }
     else {
-        if (port->CRH & (0x3 << ((pin-8) * 4))) {  /* if configured as output */
-            return port->ODR & (1 << pin);          /* read output data register */
-        } else {
-            return port->IDR & (1 << pin);          /* else read input data register */
-        }
+        /* or input */
+        return (port->IDR & (1 << pin_num));
     }
 }
 
-void gpio_set(gpio_t dev)
+void gpio_set(gpio_t pin)
 {
-    switch (dev) {
-#if GPIO_0_EN
-        case GPIO_0:
-            GPIO_0_PORT->BSRR = (1 << GPIO_0_PIN);
-            break;
-#endif
-#if GPIO_1_EN
-        case GPIO_1:
-            GPIO_1_PORT->BSRR = (1 << GPIO_1_PIN);
-            break;
-#endif
-#if GPIO_2_EN
-        case GPIO_2:
-            GPIO_2_PORT->BSRR = (1 << GPIO_2_PIN);
-            break;
-#endif
-#if GPIO_3_EN
-        case GPIO_3:
-            GPIO_3_PORT->BSRR = (1 << GPIO_3_PIN);
-            break;
-#endif
-#if GPIO_4_EN
-        case GPIO_4:
-            GPIO_4_PORT->BSRR = (1 << GPIO_4_PIN);
-            break;
-#endif
-#if GPIO_5_EN
-        case GPIO_5:
-            GPIO_5_PORT->BSRR = (1 << GPIO_5_PIN);
-            break;
-#endif
-#if GPIO_6_EN
-        case GPIO_6:
-            GPIO_6_PORT->BSRR = (1 << GPIO_6_PIN);
-            break;
-#endif
-#if GPIO_7_EN
-        case GPIO_7:
-            GPIO_7_PORT->BSRR = (1 << GPIO_7_PIN);
-            break;
-#endif
-#if GPIO_8_EN
-        case GPIO_8:
-            GPIO_8_PORT->BSRR = (1 << GPIO_8_PIN);
-            break;
-#endif
-#if GPIO_9_EN
-        case GPIO_9:
-            GPIO_9_PORT->BSRR = (1 << GPIO_9_PIN);
-            break;
-#endif
-#if GPIO_10_EN
-        case GPIO_10:
-            GPIO_10_PORT->BSRR = (1 << GPIO_10_PIN);
-            break;
-#endif
-#if GPIO_11_EN
-        case GPIO_11:
-            GPIO_11_PORT->BSRR = (1 << GPIO_11_PIN);
-            break;
-#endif
-#if GPIO_12_EN
-        case GPIO_12:
-            GPIO_12_PORT->BSRR = (1 << GPIO_12_PIN);
-            break;
-#endif
-#if GPIO_13_EN
-        case GPIO_13:
-            GPIO_13_PORT->BSRR = (1 << GPIO_13_PIN);
-            break;
-#endif
-#if GPIO_14_EN
-        case GPIO_14:
-            GPIO_14_PORT->BSRR = (1 << GPIO_14_PIN);
-            break;
-#endif
-#if GPIO_15_EN
-        case GPIO_15:
-            GPIO_15_PORT->BSRR = (1 << GPIO_15_PIN);
-            break;
-#endif
-    }
+    _port(pin)->BSRR = (1 << _pin_num(pin));
 }
 
-void gpio_clear(gpio_t dev)
+void gpio_clear(gpio_t pin)
 {
-    switch (dev) {
-#if GPIO_0_EN
-        case GPIO_0:
-            GPIO_0_PORT->BRR = (1 << GPIO_0_PIN);
-            break;
-#endif
-#if GPIO_1_EN
-        case GPIO_1:
-            GPIO_1_PORT->BRR = (1 << GPIO_1_PIN);
-            break;
-#endif
-#if GPIO_2_EN
-        case GPIO_2:
-            GPIO_2_PORT->BRR = (1 << GPIO_2_PIN);
-            break;
-#endif
-#if GPIO_3_EN
-        case GPIO_3:
-            GPIO_3_PORT->BRR = (1 << GPIO_3_PIN);
-            break;
-#endif
-#if GPIO_4_EN
-        case GPIO_4:
-            GPIO_4_PORT->BRR = (1 << GPIO_4_PIN);
-            break;
-#endif
-#if GPIO_5_EN
-        case GPIO_5:
-            GPIO_5_PORT->BRR = (1 << GPIO_5_PIN);
-            break;
-#endif
-#if GPIO_6_EN
-        case GPIO_6:
-            GPIO_6_PORT->BRR = (1 << GPIO_6_PIN);
-            break;
-#endif
-#if GPIO_7_EN
-        case GPIO_7:
-            GPIO_7_PORT->BRR = (1 << GPIO_7_PIN);
-            break;
-#endif
-#if GPIO_8_EN
-        case GPIO_8:
-            GPIO_8_PORT->BRR = (1 << GPIO_8_PIN);
-            break;
-#endif
-#if GPIO_9_EN
-        case GPIO_9:
-            GPIO_9_PORT->BRR = (1 << GPIO_9_PIN);
-            break;
-#endif
-#if GPIO_10_EN
-        case GPIO_10:
-            GPIO_10_PORT->BRR = (1 << GPIO_10_PIN);
-            break;
-#endif
-#if GPIO_11_EN
-        case GPIO_11:
-            GPIO_11_PORT->BRR = (1 << GPIO_11_PIN);
-            break;
-#endif
-#if GPIO_12_EN
-        case GPIO_12:
-            GPIO_12_PORT->BRR = (1 << GPIO_12_PIN);
-            break;
-#endif
-#if GPIO_13_EN
-        case GPIO_13:
-            GPIO_13_PORT->BRR = (1 << GPIO_13_PIN);
-            break;
-#endif
-#if GPIO_14_EN
-        case GPIO_14:
-            GPIO_14_PORT->BRR = (1 << GPIO_14_PIN);
-            break;
-#endif
-#if GPIO_15_EN
-        case GPIO_15:
-            GPIO_15_PORT->BRR = (1 << GPIO_15_PIN);
-            break;
-#endif
-    }
+    _port(pin)->BRR = (1 << _pin_num(pin));
 }
 
-
-void gpio_toggle(gpio_t dev)
+void gpio_toggle(gpio_t pin)
 {
-    if (gpio_read(dev)) {
-        gpio_clear(dev);
+    if (gpio_read(pin)) {
+        gpio_clear(pin);
     }
     else {
-        gpio_set(dev);
+        gpio_set(pin);
     }
 }
 
-void gpio_write(gpio_t dev, int value)
+void gpio_write(gpio_t pin, int value)
 {
     if (value) {
-        gpio_set(dev);
+        _port(pin)->BSRR = (1 << _pin_num(pin));
     }
     else {
-        gpio_clear(dev);
+        _port(pin)->BRR = (1 << _pin_num(pin));
     }
 }
 
-#ifdef GPIO_IRQ_0
-void isr_exti0(void)
+void isr_exti(void)
 {
-    if (EXTI->PR & EXTI_PR_PR0) {
-        EXTI->PR |= EXTI_PR_PR0;        /* clear status bit by writing a 1 to it */
-        config[GPIO_IRQ_0].cb(config[GPIO_IRQ_0].arg);
+    for (int i = 0; i < GPIO_ISR_CHAN_NUMOF; i++) {
+        if (EXTI->PR & (1 << i)) {
+            EXTI->PR = (1 << i);        /* clear by writing a 1 */
+            exti_ctx[i].cb(exti_ctx[i].arg);
+        }
     }
-
     if (sched_context_switch_request) {
         thread_yield();
     }
 }
-#endif
-
-#ifdef GPIO_IRQ_1
-void isr_exti1(void)
-{
-    if (EXTI->PR & EXTI_PR_PR1) {
-        EXTI->PR |= EXTI_PR_PR1;        /* clear status bit by writing a 1 to it */
-        config[GPIO_IRQ_1].cb(config[GPIO_IRQ_1].arg);
-    }
-
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
-}
-#endif
-
-#ifdef GPIO_IRQ_2
-void isr_exti2(void)
-{
-    if (EXTI->PR & EXTI_PR_PR2) {
-        EXTI->PR |= EXTI_PR_PR2;        /* clear status bit by writing a 1 to it */
-        config[GPIO_IRQ_2].cb(config[GPIO_IRQ_2].arg);
-    }
-
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
-}
-#endif
-
-#ifdef GPIO_IRQ_3
-void isr_exti3(void)
-{
-    if (EXTI->PR & EXTI_PR_PR3) {
-        EXTI->PR |= EXTI_PR_PR3;        /* clear status bit by writing a 1 to it */
-        config[GPIO_IRQ_3].cb(config[GPIO_IRQ_3].arg);
-    }
-
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
-}
-#endif
-
-#ifdef GPIO_IRQ_4
-void isr_exti4(void)
-{
-    if (EXTI->PR & EXTI_PR_PR4) {
-        EXTI->PR |= EXTI_PR_PR4;        /* clear status bit by writing a 1 to it */
-        config[GPIO_IRQ_4].cb(config[GPIO_IRQ_4].arg);
-    }
-
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
-}
-#endif
-
-#if defined(GPIO_IRQ_5) || defined(GPIO_IRQ_6) || defined(GPIO_IRQ_7) || defined(GPIO_IRQ_8) || defined(GPIO_IRQ_9)
-void isr_exti9_5(void)
-{
-#ifdef GPIO_IRQ_5
-    if (EXTI->PR & EXTI_PR_PR5) {
-        EXTI->PR |= EXTI_PR_PR5;        /* clear status bit by writing a 1 to it */
-        config[GPIO_IRQ_5].cb(config[GPIO_IRQ_5].arg);
-    }
-#endif
-#ifdef GPIO_IRQ_6
-    if (EXTI->PR & EXTI_PR_PR6) {
-        EXTI->PR |= EXTI_PR_PR6;        /* clear status bit by writing a 1 to it */
-        config[GPIO_IRQ_6].cb(config[GPIO_IRQ_6].arg);
-    }
-#endif
-#ifdef GPIO_IRQ_7
-    if (EXTI->PR & EXTI_PR_PR7) {
-        EXTI->PR |= EXTI_PR_PR7;        /* clear status bit by writing a 1 to it */
-        config[GPIO_IRQ_7].cb(config[GPIO_IRQ_7].arg);
-    }
-#endif
-#ifdef GPIO_IRQ_8
-    if (EXTI->PR & EXTI_PR_PR8) {
-        EXTI->PR |= EXTI_PR_PR8;        /* clear status bit by writing a 1 to it */
-        config[GPIO_IRQ_8].cb(config[GPIO_IRQ_8].arg);
-    }
-#endif
-#ifdef GPIO_IRQ_9
-    if (EXTI->PR & EXTI_PR_PR9) {
-        EXTI->PR |= EXTI_PR_PR9;        /* clear status bit by writing a 1 to it */
-        config[GPIO_IRQ_9].cb(config[GPIO_IRQ_9].arg);
-    }
-#endif
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
-}
-#endif
-
-#if defined(GPIO_IRQ_10) || defined(GPIO_IRQ_11) || defined(GPIO_IRQ_12) || defined(GPIO_IRQ_13) || defined(GPIO_IRQ_14) || defined(GPIO_IRQ_15)
-void isr_exti15_10(void)
-{
-#ifdef GPIO_IRQ_10
-    if (EXTI->PR & EXTI_PR_PR10) {
-        EXTI->PR |= EXTI_PR_PR10;        /* clear status bit by writing a 1 to it */
-        config[GPIO_IRQ_10].cb(config[GPIO_IRQ_10].arg);
-    }
-#endif
-#ifdef GPIO_IRQ_11
-    if (EXTI->PR & EXTI_PR_PR11) {
-        EXTI->PR |= EXTI_PR_PR11;        /* clear status bit by writing a 1 to it */
-        config[GPIO_IRQ_11].cb(config[GPIO_IRQ_11].arg);
-    }
-#endif
-#ifdef GPIO_IRQ_12
-    if (EXTI->PR & EXTI_PR_PR12) {
-        EXTI->PR |= EXTI_PR_PR12;        /* clear status bit by writing a 1 to it */
-        config[GPIO_IRQ_12].cb(config[GPIO_IRQ_12].arg);
-    }
-#endif
-#ifdef GPIO_IRQ_13
-    if (EXTI->PR & EXTI_PR_PR13) {
-        EXTI->PR |= EXTI_PR_PR13;        /* clear status bit by writing a 1 to it */
-        config[GPIO_IRQ_13].cb(config[GPIO_IRQ_13].arg);
-    }
-#endif
-#ifdef GPIO_IRQ_14
-    if (EXTI->PR & EXTI_PR_PR14) {
-        EXTI->PR |= EXTI_PR_PR14;        /* clear status bit by writing a 1 to it */
-        config[GPIO_IRQ_14].cb(config[GPIO_IRQ_14].arg);
-    }
-#endif
-#ifdef GPIO_IRQ_15
-    if (EXTI->PR & EXTI_PR_PR15) {
-        EXTI->PR |= EXTI_PR_PR15;        /* clear status bit by writing a 1 to it */
-        config[GPIO_IRQ_15].cb(config[GPIO_IRQ_15].arg);
-    }
-#endif
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
-}
-#endif

--- a/cpu/stm32f1/periph/i2c.c
+++ b/cpu/stm32f1/periph/i2c.c
@@ -147,16 +147,16 @@ static void _pin_config(GPIO_TypeDef *port_scl, GPIO_TypeDef *port_sda, int pin_
 {
     /* configure pins, alternate output, open-drain, output mode with 50MHz */
     if (pin_scl < 8) {
-        port_scl->CRL |= (0xf << (pin_scl * 4));
+        port_scl->CR[0] |= (0xf << (pin_scl * 4));
     }
     else {
-        port_scl->CRH |= (0xf << ((pin_scl - 8) * 4));
+        port_scl->CR[1] |= (0xf << ((pin_scl - 8) * 4));
     }
     if (pin_sda < 8) {
-        port_sda->CRL |= (0xf << (pin_sda * 4));
+        port_sda->CR[0] |= (0xf << (pin_sda * 4));
     }
     else {
-        port_sda->CRH |= (0xf << ((pin_sda - 8) * 4));
+        port_sda->CR[1] |= (0xf << ((pin_sda - 8) * 4));
     }
 }
 
@@ -164,16 +164,16 @@ static void _toggle_pins(GPIO_TypeDef *port_scl, GPIO_TypeDef *port_sda, int pin
 {
     /* configure pins, output, open-drain, output mode with 50MHz */
     if (pin_scl < 8) {
-        port_scl->CRL |= (0x7 << (pin_scl * 4));
+        port_scl->CR[0] |= (0x7 << (pin_scl * 4));
     }
     else {
-        port_scl->CRH |= (0x7 << ((pin_scl - 8) * 4));
+        port_scl->CR[1] |= (0x7 << ((pin_scl - 8) * 4));
     }
     if (pin_sda < 8) {
-        port_sda->CRL |= (0x7 << (pin_sda * 4));
+        port_sda->CR[0] |= (0x7 << (pin_sda * 4));
     }
     else {
-        port_sda->CRH |= (0x7 << ((pin_sda - 8) * 4));
+        port_sda->CR[1] |= (0x7 << ((pin_sda - 8) * 4));
     }
     /* set both to high */
     port_scl->ODR |= (1 << pin_scl);

--- a/cpu/stm32f1/periph/spi.c
+++ b/cpu/stm32f1/periph/spi.c
@@ -131,12 +131,12 @@ int spi_conf_pins(spi_t dev)
     for (int i = 0; i < 3; i++) {
         int crbitval = (i < 2) ? 0xb : 0x4;
         if (pin[i] < 8) {
-            port[i]->CRL &= ~(0xf << (pin[i] * 4));
-            port[i]->CRL |= (crbitval << (pin[i] * 4));
+            port[i]->CR[0] &= ~(0xf << (pin[i] * 4));
+            port[i]->CR[0] |= (crbitval << (pin[i] * 4));
         }
         else {
-            port[i]->CRH &= ~(0xf << ((pin[i] - 8) * 4));
-            port[i]->CRH |= (crbitval << ((pin[i] - 8) * 4));
+            port[i]->CR[1] &= ~(0xf << ((pin[i] - 8) * 4));
+            port[i]->CR[1] |= (crbitval << ((pin[i] - 8) * 4));
         }
     }
 

--- a/cpu/stm32f1/periph/uart.c
+++ b/cpu/stm32f1/periph/uart.c
@@ -136,21 +136,21 @@ int uart_init_blocking(uart_t uart, uint32_t baudrate)
     }
     /* Configure USART Tx as alternate function push-pull and 50MHz*/
     if (tx_pin < 8) {
-        port->CRL &= ~(0xf << (tx_pin * 4));
-        port->CRL |= (0xB << (tx_pin * 4));
+        port->CR[0] &= ~(0xf << (tx_pin * 4));
+        port->CR[0] |= (0xB << (tx_pin * 4));
     }
     else {
-        port->CRH &= ~(0xf << ((tx_pin-8) * 4));
-        port->CRH |= (0xB << ((tx_pin-8) * 4));
+        port->CR[1] &= ~(0xf << ((tx_pin-8) * 4));
+        port->CR[1] |= (0xB << ((tx_pin-8) * 4));
     }
     /* Configure USART Rx as floating input */
     if (rx_pin < 8) {
-        port->CRL &= ~(0xf << (rx_pin * 4));
-        port->CRL |= (0x4 << (rx_pin * 4));
+        port->CR[0] &= ~(0xf << (rx_pin * 4));
+        port->CR[0] |= (0x4 << (rx_pin * 4));
     }
     else {
-        port->CRH &= ~(0xf << ((rx_pin-8) * 4));
-        port->CRH |= (0x4 << ((rx_pin-8) * 4));
+        port->CR[1] &= ~(0xf << ((rx_pin-8) * 4));
+        port->CR[1] |= (0x4 << ((rx_pin-8) * 4));
     }
 
     /* configure UART to mode 8N1 with given baudrate */

--- a/cpu/stm32f1/vectors.c
+++ b/cpu/stm32f1/vectors.c
@@ -42,11 +42,7 @@ WEAK_DEFAULT void isr_tamper(void);
 WEAK_DEFAULT void isr_rtc(void);
 WEAK_DEFAULT void isr_flash(void);
 WEAK_DEFAULT void isr_rcc(void);
-WEAK_DEFAULT void isr_exti0(void);
-WEAK_DEFAULT void isr_exti1(void);
-WEAK_DEFAULT void isr_exti2(void);
-WEAK_DEFAULT void isr_exti3(void);
-WEAK_DEFAULT void isr_exti4(void);
+WEAK_DEFAULT void isr_exti(void);
 WEAK_DEFAULT void isr_dma1_ch1(void);
 WEAK_DEFAULT void isr_dma1_ch2(void);
 WEAK_DEFAULT void isr_dma1_ch3(void);
@@ -59,7 +55,6 @@ WEAK_DEFAULT void isr_usb_hp_can1_tx(void);
 WEAK_DEFAULT void isr_usb_lp_can1_rx0(void);
 WEAK_DEFAULT void isr_can1_rx1(void);
 WEAK_DEFAULT void isr_can1_sce(void);
-WEAK_DEFAULT void isr_exti9_5(void);
 WEAK_DEFAULT void isr_tim1_brk(void);
 WEAK_DEFAULT void isr_tim1_up(void);
 WEAK_DEFAULT void isr_tim1_trg_com(void);
@@ -76,7 +71,6 @@ WEAK_DEFAULT void isr_spi2(void);
 WEAK_DEFAULT void isr_usart1(void);
 WEAK_DEFAULT void isr_usart2(void);
 WEAK_DEFAULT void isr_usart3(void);
-WEAK_DEFAULT void isr_exti15_10(void);
 WEAK_DEFAULT void isr_rtc_alarm(void);
 WEAK_DEFAULT void isr_usb_wakeup(void);
 WEAK_DEFAULT void isr_tim8_brk(void);
@@ -126,11 +120,11 @@ ISR_VECTORS const void *interrupt_vector[] = {
     (void*) isr_rtc,
     (void*) isr_flash,
     (void*) isr_rcc,
-    (void*) isr_exti0,
-    (void*) isr_exti1,
-    (void*) isr_exti2,
-    (void*) isr_exti3,
-    (void*) isr_exti4,
+    (void*) isr_exti,
+    (void*) isr_exti,
+    (void*) isr_exti,
+    (void*) isr_exti,
+    (void*) isr_exti,
     (void*) isr_dma1_ch1,
     (void*) isr_dma1_ch2,
     (void*) isr_dma1_ch3,
@@ -143,7 +137,7 @@ ISR_VECTORS const void *interrupt_vector[] = {
     (void*) isr_usb_lp_can1_rx0,
     (void*) isr_can1_rx1,
     (void*) isr_can1_sce,
-    (void*) isr_exti9_5,
+    (void*) isr_exti,
     (void*) isr_tim1_brk,
     (void*) isr_tim1_up,
     (void*) isr_tim1_trg_com,
@@ -160,7 +154,7 @@ ISR_VECTORS const void *interrupt_vector[] = {
     (void*) isr_usart1,
     (void*) isr_usart2,
     (void*) isr_usart3,
-    (void*) isr_exti15_10,
+    (void*) isr_exti,
     (void*) isr_rtc_alarm,
     (void*) isr_usb_wakeup,
     (void*) isr_tim8_brk,


### PR DESCRIPTION
One more CPU on the bright side :-)

Code size before (`tests/periph_gpio`, `iot-lab_M3`):
```
   text	   data	    bss	    dec	    hex
  16492	    120	   2888	  19500	   4c2c
```
and after:
```
   text	   data	    bss	    dec	    hex
  15244	    120	   2888	  18252	   474c
```
**Savings ~1,2k**