### PR TITLE
Make use of doxygen todo

### DIFF
--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -23,16 +23,14 @@
  * @author      Stefan Pfeiffer <stefan.pfeiffer@fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Joakim Gebart <joakim.gebart@eistec.se>
+ *
+ * @todo        remove include irq.h once core was adjusted
  */
 
 #ifndef CPU_H_
 #define CPU_H_
 
 #include "cpu_conf.h"
-
-/*
- * TODO: remove once core was adjusted
- */
 #include "irq.h"
 
 #ifdef __cplusplus
@@ -49,8 +47,8 @@ extern "C" {
  * If needed, you can overwrite these values the the `cpu_conf.h` file of the
  * specific CPU implementation.
  *
- * TODO: Adjust values for Cortex-M4F with FPU?
- * TODO: Configure second set if no newlib nano.specs are available?
+ * @todo Adjust values for Cortex-M4F with FPU?
+ * @todo Configure second set if no newlib nano.specs are available?
  * @{
  */
 #ifndef THREAD_EXTRA_STACKSIZE_PRINTF
@@ -67,7 +65,7 @@ extern "C" {
 /**
  * @brief   UART0 buffer size definition for compatibility reasons
  *
- * TODO: remove once the remodeling of the uart0 driver is done
+ * @todo remove once the remodeling of the uart0 driver is done
  * @{
  */
 #ifndef UART0_BUFSIZE

--- a/drivers/include/ng_at86rf2xx.h
+++ b/drivers/include/ng_at86rf2xx.h
@@ -70,7 +70,7 @@ extern "C" {
 /**
  * @brief   Default PAN ID
  *
- * TODO: Read some global network stack specific configuration value
+ * @todo    Read some global network stack specific configuration value
  */
 #define NG_AT86RF2XX_DEFAULT_PANID      (0x0023)
 

--- a/sys/include/cbor.h
+++ b/sys/include/cbor.h
@@ -94,7 +94,7 @@
  * -  24-31: (Reserved)      - No support
  * - 32-255: (Unassigned)    - No support
  *
- * TODO: API for Indefinite-Length Byte Strings and Text Strings
+ * @todo API for Indefinite-Length Byte Strings and Text Strings
  *       (see https://tools.ietf.org/html/rfc7049#section-2.2.2)
  */
 

--- a/sys/include/net/ng_fib.h
+++ b/sys/include/net/ng_fib.h
@@ -40,7 +40,7 @@ typedef struct rp_address_msg_t {
 
 /**
  * @brief the size in bytes of a full address
- * TODO: replace with UNIVERSAL_ADDRESS_SIZE (#3022)
+ * @todo replace with UNIVERSAL_ADDRESS_SIZE (#3022)
 */
 #define FIB_DESTINATION_SIZE_SUBSTITUTE (16)
 

--- a/sys/include/net/ng_icmpv6.h
+++ b/sys/include/net/ng_icmpv6.h
@@ -20,6 +20,8 @@
  * @brief       Definitions for ICMPv6
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * @todo build error messages
  */
 
 #ifndef NG_ICMPV6_H_
@@ -76,8 +78,6 @@ void ng_icmpv6_demux(kernel_pid_t iface, ng_pktsnip_t *pkt);
  * @return  NULL, on failure
  */
 ng_pktsnip_t *ng_icmpv6_build(ng_pktsnip_t *next, uint8_t type, uint8_t code, size_t size);
-
-/* TODO: build error messages */
 
 /**
  * @brief   Calculates the checksum for an ICMPv6 packet.

--- a/sys/include/net/ng_icmpv6/error.h
+++ b/sys/include/net/ng_icmpv6/error.h
@@ -16,6 +16,8 @@
  * @brief   ICMPv6 error message definitions
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * @todo implement build and handle functions
  */
 #ifndef NG_ICMPV6_ERROR_H_
 #define NG_ICMPV6_ERROR_H_
@@ -145,8 +147,6 @@ typedef struct __attribute__((packed)) {
     network_uint16_t csum;  /**< checksum */
     network_uint32_t ptr;   /**< pointer */
 } ng_icmpv6_error_param_prob_t;
-
-/* TODO: implement build and handle functions */
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/ng_zep.h
+++ b/sys/include/net/ng_zep.h
@@ -92,7 +92,7 @@ extern "C" {
 /**
  * @brief   Default PAN ID
  *
- * TODO: Read some global network stack specific configuration value
+ * @todo Read some global network stack specific configuration value
  */
 #define NG_ZEP_DEFAULT_PANID    (0x0023)
 

--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -173,6 +173,8 @@ static inline timex_t timex_from_uint64(const uint64_t timestamp)
  * @note The buffer must have a size of TIMEX_MAX_STR_LEN characters
  *
  * @return A pointer to the string representation of the timestamp
+ *
+ * @todo replace call to snprintf by something more efficient
  */
 static inline const char *timex_to_str(timex_t t, char *timestamp)
 {
@@ -180,7 +182,6 @@ static inline const char *timex_to_str(timex_t t, char *timestamp)
     /* 2^32 seconds have maximum 10 digits, microseconds are always < 1000000
      * in a normalized timestamp, plus two chars for the point and terminator
      * => 10 + 6 + 2 = 20 */
-    /* TODO: replace call to snprintf by something more efficient */
     snprintf(timestamp, TIMEX_MAX_STR_LEN, "%" PRIu32 ".%06" PRIu32 " s",
              t.seconds, t.microseconds);
     return timestamp;


### PR DESCRIPTION
This PR replaces some TODO comments that I found with the appropriate `@todo` doxygen annotation in order to list them in the doc's `Todo List` section.