### PR TITLE
Makefile.buildtests: Fix -Werror bug in 0ae1b31

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -31,11 +31,6 @@ endif
         info-buildsizes-diff info-build info-boards-supported \
         info-features-missing info-boards-features-missing
 
-# Make buildtests error out on warnings by adding -Werror
-ifeq (, $(filter buildtest, $(MAKECMDGOALS)))
-    CFLAGS+=-Werror
-endif
-
 ifeq ($(BUILD_IN_DOCKER),1)
 buildtest: ..in-docker-container
 else
@@ -63,6 +58,7 @@ buildtest:
 					BINDIRBASE=$${BINDIRBASE} \
 					RIOTNOLINK=$${RIOTNOLINK} \
 					RIOT_VERSION=$${RIOT_VERSION} \
+					CFLAGS=-Werror \
 					$(MAKE) -j$(NPROC) 2>&1) ; \
 			if [ "$${?}" = "0" ]; then \
 				${COLOR_ECHO} "${COLOR_GREEN}success${COLOR_RESET}"; \


### PR DESCRIPTION
The intent of 0ae1b31 was to add the `-Werror` flag to `make buildtest` only, but instead added it to all builds. Changing `ifeq` to `ifneq` seemed like a good fix at first, but didn't work because the `buildtest` goal isn't present in the secondary call to `make`.