### PR TITLE
sys/trickle: Makefile and include guards cleanup

### DIFF
--- a/sys/Makefile
+++ b/sys/Makefile
@@ -140,9 +140,6 @@ endif
 ifneq (,$(filter ng_slip,$(USEMODULE)))
     DIRS += net/link_layer/ng_slip
 endif
-ifneq (,$(filter trickle,$(USEMODULE)))
-    DIRS += trickle
-endif
 ifneq (,$(filter nhdp,$(USEMODULE)))
     DIRS += net/routing/nhdp
 endif

--- a/sys/include/trickle.h
+++ b/sys/include/trickle.h
@@ -22,8 +22,8 @@
  * @author  Cenk Gündoğan <cnkgndgn@gmail.com>
  */
 
-#ifndef _TRICKLE_H
-#define _TRICKLE_H
+#ifndef TRICKLE_H
+#define TRICKLE_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -110,5 +110,5 @@ void trickle_callback(trickle_t *trickle);
 }
 #endif
 
-#endif /* _TRICKLE_H */
+#endif /* TRICKLE_H */
 /** @} */

--- a/sys/trickle/Makefile
+++ b/sys/trickle/Makefile
@@ -1,3 +1,1 @@
-MODULE = trickle
-
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
1. The first commit removes unneeded lines in Makefiles for `trickle`
  * `sys/trickle/Makefile`
  * `sys/Makefile`
2. The second commit removes the leading underline for the include guard in `sys/include/trickle.h`

I am not sure about the first commit, but trickle still builds without mentioning it in these Makefiles. I assuming you only need entries there if the module name differ from the folder name or has a more complex path?