### PR TITLE
gnrc_icmpv6_error: Initial import of IPv6 error convenience functions

### DIFF
--- a/sys/include/net/gnrc/icmpv6/error.h
+++ b/sys/include/net/gnrc/icmpv6/error.h
@@ -20,10 +20,13 @@
 #ifndef GNRC_ICMPV6_ERROR_H_
 #define GNRC_ICMPV6_ERROR_H_
 
+#include <errno.h>
 #include <stdint.h>
 
 #include "net/icmpv6.h"
 #include "net/ipv6/hdr.h"
+#include "net/gnrc/ipv6.h"
+#include "net/gnrc/netapi.h"
 #include "net/gnrc/pkt.h"
 
 #ifdef __cplusplus
@@ -75,6 +78,88 @@ gnrc_pktsnip_t *gnrc_icmpv6_error_time_exc_build(uint8_t code, gnrc_pktsnip_t *o
  */
 gnrc_pktsnip_t *gnrc_icmpv6_error_param_prob_build(uint8_t code, void *ptr,
                                                    gnrc_pktsnip_t *orig_pkt);
+
+/**
+ * @brief   Sends an ICMPv6 destination unreachable message for sending.
+ *
+ * @param[in] code      The code for the message @see net/icmpv6.h.
+ * @param[in] orig_pkt  The invoking packet.
+ */
+static inline void gnrc_icmpv6_error_dst_unr_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
+{
+    gnrc_pktsnip_t *pkt = gnrc_icmpv6_error_dst_unr_build(code, orig_pkt);
+
+    if (pkt != NULL) {
+        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
+    }
+#ifdef MODULE_GNRC_PKTBUF
+    gnrc_pktbuf_release_error(orig_pkt, EHOSTUNREACH);
+#else
+    (void)orig_pkt;
+#endif
+}
+
+/**
+ * @brief   Sends an ICMPv6 packet too big message for sending.
+ *
+ * @param[in] mtu       The maximum transission unit of the next-hop link.
+ * @param[in] orig_pkt  The invoking packet.
+ */
+static inline void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu, gnrc_pktsnip_t *orig_pkt)
+{
+    gnrc_pktsnip_t *pkt = gnrc_icmpv6_error_pkt_too_big_build(mtu, orig_pkt);
+
+    if (pkt != NULL) {
+        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
+    }
+#ifdef MODULE_GNRC_PKTBUF
+    gnrc_pktbuf_release_error(orig_pkt, EMSGSIZE);
+#else
+    (void)orig_pkt;
+#endif
+}
+
+/**
+ * @brief   Sends an ICMPv6 time exceeded message for sending.
+ *
+ * @param[in] code      The code for the message @see net/icmpv6.h.
+ * @param[in] orig_pkt  The invoking packet.
+ */
+static inline void gnrc_icmpv6_error_time_exc_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
+{
+    gnrc_pktsnip_t *pkt = gnrc_icmpv6_error_time_exc_build(code, orig_pkt);
+
+    if (pkt != NULL) {
+        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
+    }
+#ifdef MODULE_GNRC_PKTBUF
+    gnrc_pktbuf_release_error(orig_pkt, ETIMEDOUT);
+#else
+    (void)orig_pkt;
+#endif
+}
+
+/**
+ * @brief   Sends an ICMPv6 parameter problem message for sending.
+ *
+ * @param[in] code      The code for the message @see net/icmpv6.h.
+ * @param[in] ptr       Pointer to the errorneous octet in @p orig_pkt.
+ * @param[in] orig_pkt  The invoking packet.
+ */
+static inline void gnrc_icmpv6_error_param_prob_send(uint8_t code, void *ptr,
+                                                     gnrc_pktsnip_t *orig_pkt)
+{
+    gnrc_pktsnip_t *pkt = gnrc_icmpv6_error_param_prob_build(code, ptr, orig_pkt);
+
+    if (pkt != NULL) {
+        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
+    }
+#ifdef MODULE_GNRC_PKTBUF
+    gnrc_pktbuf_release_error(orig_pkt, EINVAL);
+#else
+    (void)orig_pkt;
+#endif
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Allows for sending ICMPv6 error messages and releasing the invoking packet with a fitting error code in one call.

Depends on ~~#3184 and #3362.~~ (merged)