### PR TITLE
ng_ipv6: rm duplicate call to _dispatch_recv_pkt

### DIFF
--- a/sys/net/network_layer/ng_ipv6/ng_ipv6.c
+++ b/sys/net/network_layer/ng_ipv6/ng_ipv6.c
@@ -119,7 +119,6 @@ void ng_ipv6_demux(kernel_pid_t iface, ng_pktsnip_t *pkt, uint8_t nh)
     ng_pktbuf_hold(pkt, receiver_num - 1);
     /* IPv6 is not interested anymore so `- 1` */
     _dispatch_rcv_pkt(pkt->type, NG_NETREG_DEMUX_CTX_ALL, pkt);
-    _dispatch_rcv_pkt(NG_NETTYPE_IPV6, nh, pkt);
 }
 
 /* internal functions */


### PR DESCRIPTION
The pktsnip is dispatch two times in `ng_ipv6_demux`.

@authmillenon I was not sure if the call to `_dispatch_recv_pkt` was duplicated by intention or not. Please close this PR if yes.