### PR TITLE
drivers/include/periph/timer.h: add dev_enums.h include until all platforms have been updated

### DIFF
--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -22,6 +22,8 @@
 #define PERIPH_TIMER_H
 
 #include "periph_cpu.h"
+/** @todo remove dev_enums.h include once all platforms are ported to the updated periph interface */
+#include "periph/dev_enums.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
#3265 didn't compile on mulle without this. ~~`cpu/kinetis_common/timer.c` in master is broken without this change.~~ not broken.

See also #3552 