### PR TITLE
ng_sixlowpan: Fix typo in preprocessor condition for calling pktbuf statistics

### DIFF
--- a/sys/net/network_layer/ng_sixlowpan/ng_sixlowpan.c
+++ b/sys/net/network_layer/ng_sixlowpan/ng_sixlowpan.c
@@ -69,7 +69,7 @@ static void _receive(ng_pktsnip_t *pkt)
 
     if (payload == NULL) {
         DEBUG("6lo: can not get write access on received packet\n");
-#if defined(DEVELHELP) && defined(ENABLE_DEBUG)
+#if defined(DEVELHELP) && ENABLE_DEBUG
         ng_pktbuf_stats();
 #endif
         ng_pktbuf_release(pkt);
@@ -95,7 +95,7 @@ static void _receive(ng_pktsnip_t *pkt)
 
         if (payload == NULL) {
             DEBUG("6lo: can not get write access on received packet\n");
-#if defined(DEVELHELP) && defined(ENABLE_DEBUG)
+#if defined(DEVELHELP) && ENABLE_DEBUG
             ng_pktbuf_stats();
 #endif
             ng_pktbuf_release(pkt);


### PR DESCRIPTION
There was a mistake in the condition causing it to check for a definition of `ENABLE_DEBUG` rather than the value of it.