### PR TITLE
ccn-lite: initialize pointer

### DIFF
--- a/sys/net/ccn_lite/ccnl-core.c
+++ b/sys/net/ccn_lite/ccnl-core.c
@@ -721,7 +721,8 @@ int ccnl_face_enqueue(struct ccnl_relay_s *ccnl, struct ccnl_face_s *to,
 int ccnl_nonce_find_or_append(struct ccnl_relay_s *ccnl,
                               struct ccnl_buf_s *nonce)
 {
-    struct ccnl_nonce_s *n, *last;
+    struct ccnl_nonce_s *n;
+    struct ccnl_nonce_s *last = NULL;
     int i;
     DEBUGMSG(99, "ccnl_nonce_find_or_append: %u:%u:%u:%u\n",
              nonce->data[0], nonce->data[1], nonce->data[2], nonce->data[3]);


### PR DESCRIPTION
Just to get rid of:
```
/home/oleg/git/RIOT/sys/net/ccn_lite/ccnl-core.c: In function 'ccnl_nonce_find_or_append'
/home/oleg/git/RIOT/sys/net/ccn_lite/ccnl-core.c:750:9: error: 'last' may be used uninitialized in this function [-Werror=maybe-uninitialized]
         ccnl_nonce_remove(ccnl, last);
         ^
cc1: all warnings being treated as errors

```