### PR TITLE
ieee802.15.4: switch to 26 as default channel

### DIFF
--- a/drivers/cc2420/include/cc2420_settings.h
+++ b/drivers/cc2420/include/cc2420_settings.h
@@ -307,7 +307,7 @@ extern "C" {
 
 
 /* Various configuration settings for the CC2420 drivers  */
-#define CC2420_DEFAULT_CHANNR   18
+#define CC2420_DEFAULT_CHANNR   (26U)
 #define CC2420_SYNC_WORD_TX_TIME 900000
 #define CC2420_RX_BUF_SIZE      3
 #define CC2420_WAIT_TIME        500

--- a/drivers/include/kw2xrf.h
+++ b/drivers/include/kw2xrf.h
@@ -65,7 +65,7 @@ extern "C" {
 /**
  * @brief   Default channel used after initialization
  */
-#define KW2XRF_DEFAULT_CHANNEL        (17U)
+#define KW2XRF_DEFAULT_CHANNEL        (26U)
 
 /**
  * @brief   Default TX_POWER in dbm used after initialization

--- a/drivers/include/ng_at86rf2xx.h
+++ b/drivers/include/ng_at86rf2xx.h
@@ -63,7 +63,7 @@ extern "C" {
 #else
 #define NG_AT86RF2XX_MIN_CHANNEL        (11U)
 #define NG_AT86RF2XX_MAX_CHANNEL        (26U)
-#define NG_AT86RF2XX_DEFAULT_CHANNEL    (17U)
+#define NG_AT86RF2XX_DEFAULT_CHANNEL    (26U)
 #endif
 /** @} */
 

--- a/drivers/include/xbee.h
+++ b/drivers/include/xbee.h
@@ -68,7 +68,7 @@
 /**
  * @brief   Default channel used after initialization
  */
-#define XBEE_DEFAULT_CHANNEL        (17U)
+#define XBEE_DEFAULT_CHANNEL        (26U)
 
 /**
  * @name    Address flags

--- a/sys/include/net/ng_zep.h
+++ b/sys/include/net/ng_zep.h
@@ -84,7 +84,7 @@ extern "C" {
  */
 #define NG_ZEP_MIN_CHANNEL      (11U)
 #define NG_ZEP_MAX_CHANNEL      (26U)
-#define NG_ZEP_DEFAULT_CHANNEL  (17U)
+#define NG_ZEP_DEFAULT_CHANNEL  (26U)
 /**
  * @}
  */


### PR DESCRIPTION
In order to avoid collisions with IEEE 802.11b networks, channel 25 or 26 is the best choice.

See for instance https://www.cs.umd.edu/~ctas/bibs/2007/4.pdf