### PR TITLE
net/fib: adapted to gnrc include style

### DIFF
--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -71,10 +71,6 @@ ifneq (,$(filter oneway_malloc,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/sys/oneway-malloc/include
 endif
 
-ifneq (,$(filter fib,$(USEMODULE)))
-    USEMODULE_INCLUDES += $(RIOTBASE)/sys/include/net
-endif
-
 ifneq (,$(filter cpp11-compat,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/sys/cpp11-compat/include
 endif

--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -27,8 +27,8 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-#include "ng_fib.h"
-#include "ng_fib/ng_fib_table.h"
+#include "net/ng_fib.h"
+#include "net/ng_fib/ng_fib_table.h"
 
 /**
  * @brief access mutex to control exclusive operations on calls

--- a/sys/net/network_layer/sixlowpan/ip.c
+++ b/sys/net/network_layer/sixlowpan/ip.c
@@ -33,7 +33,7 @@
 #include "lowpan.h"
 
 #ifdef FIB_COMPAT
-#include "ng_fib.h"
+#include "net/ng_fib.h"
 #endif
 
 #include "net_help.h"

--- a/sys/net/routing/aodvv2/aodv.c
+++ b/sys/net/routing/aodvv2/aodv.c
@@ -20,7 +20,7 @@
 #include "aodv.h"
 #include "aodvv2/aodvv2.h"
 #include "aodv_debug.h"
-#include "ng_fib.h"
+#include "net/ng_fib.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"

--- a/sys/net/routing/aodvv2/reader.c
+++ b/sys/net/routing/aodvv2/reader.c
@@ -23,7 +23,7 @@
 
 #include "reader.h"
 #include "aodv_debug.h"
-#include "ng_fib.h"
+#include "net/ng_fib.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"

--- a/sys/shell/commands/sc_fib.c
+++ b/sys/shell/commands/sc_fib.c
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include "thread.h"
 #include "inet_pton.h"
-#include "ng_fib.h"
+#include "net/ng_fib.h"
 
 #define INFO1_TXT "fibroute add <destination> via <next hop> dev <device>"
 #define INFO2_TXT " [lifetime <lifetime>]"

--- a/tests/aodvv2/aodv_fib_tests.c
+++ b/tests/aodvv2/aodv_fib_tests.c
@@ -28,7 +28,7 @@
 #include "common/autobuf.h"
 #include "rfc5444/rfc5444_writer.h"
 #include "rfc5444/rfc5444_print.h"
-#include "ng_fib.h"
+#include "net/ng_fib.h"
 
 #include "reader.h"
 #include "utils.h"

--- a/tests/unittests/tests-fib/tests-fib.c
+++ b/tests/unittests/tests-fib/tests-fib.c
@@ -16,7 +16,7 @@
 #include "vtimer.h"
 
 #include "thread.h"
-#include "ng_fib.h"
+#include "net/ng_fib.h"
 #include "universal_address.h"
 
 /*


### PR DESCRIPTION
Make the FIB use the same style of includes than the rest of the GNRC stack.