### PR TITLE
timex: make timex_to_str more efficient

### DIFF
--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -22,20 +22,10 @@
 #define __TIMEX_H
 
 #include <stdint.h>
-#include <stdio.h>
 #include <inttypes.h>
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-/**
- * @brief Formater for unsigned 32 bit values
- *
- *        mspgcc bug : PRIxxx macros not defined before mid-2011 versions
- */
-#ifndef PRIu32
-#define PRIu32 "lu"
 #endif
 
 /**
@@ -56,7 +46,14 @@ extern "C" {
 /**
  * @brief The maximum length of the string representation of a timex timestamp
  */
-#define TIMEX_MAX_STR_LEN   (18)
+#define TIMEX_MAX_STR_LEN   (20)
+/* 20 =
+ *  + 10 byte: 2^32-1 for seconds
+ *  + 1 byte: decimal point
+ *  + 6 byte: microseconds (normalized)
+ *  + 2 byte: " s" (unit)
+ *  + 1 byte: '\0'
+ */
 
 /**
  * @brief A timex timestamp
@@ -166,26 +163,16 @@ static inline timex_t timex_from_uint64(const uint64_t timestamp)
 /**
  * @brief Converts a timex timestamp to a string
  *
+ * @pre memory at timestamp >= TIMEX_MAX_STR_LEN
+ *
  * @param[in]  t            The timestamp to convert
  * @param[out] timestamp    The output char buffer for the converted timestamp
  *
  * @note The timestamp will be normalized
- * @note The buffer must have a size of TIMEX_MAX_STR_LEN characters
  *
  * @return A pointer to the string representation of the timestamp
- *
- * @todo replace call to snprintf by something more efficient
  */
-static inline const char *timex_to_str(timex_t t, char *timestamp)
-{
-    timex_normalize(&t);
-    /* 2^32 seconds have maximum 10 digits, microseconds are always < 1000000
-     * in a normalized timestamp, plus two chars for the point and terminator
-     * => 10 + 6 + 2 = 20 */
-    snprintf(timestamp, TIMEX_MAX_STR_LEN, "%" PRIu32 ".%06" PRIu32 " s",
-             t.seconds, t.microseconds);
-    return timestamp;
-}
+const char *timex_to_str(timex_t t, char *timestamp);
 
 #ifdef __cplusplus
 }

--- a/sys/shell/commands/sc_ipv6_nc.c
+++ b/sys/shell/commands/sc_ipv6_nc.c
@@ -15,6 +15,7 @@
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
+#include <stdio.h>
 #include <string.h>
 
 #include "kernel_types.h"

--- a/sys/timex/timex_to_str.c
+++ b/sys/timex/timex_to_str.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+
+#include <stdint.h>
+
+#include "timex.h"
+
+#define RADIX   (10)
+
+static unsigned int u32_to_str(char *str, uint32_t u32)
+{
+    int len;
+    int i = 0;
+    if (u32 == 0) {
+        str[i] = '0';
+        return 1;
+    }
+    for (; u32 > 0; u32 /= RADIX) {
+        char digit = (char)(u32 % RADIX);
+        str[i++] = '0' + digit;
+    }
+    len = i;
+    i--;    /* go back to last character */
+    for (int j = 0; j < i; j++, i--) {
+        char tmp = str[i];
+        str[i] = str[j];
+        str[j] = tmp;
+    }
+    return len;
+}
+
+const char *timex_to_str(timex_t t, char *timestamp)
+{
+    timex_normalize(&t);
+    char *dec;
+    uint8_t offset = 6;
+    /* get seconds and set terminating '\0' byte */
+    dec = &timestamp[u32_to_str(timestamp, t.seconds)];
+    *(dec++) = '.';                         /* set decimal point */
+    for (uint32_t i = 100000; i > 1; i /= 10) {  /* timex_normalize() ensures that i < 1000000 */
+        if (t.microseconds < i) {           /* pad with 0's */
+            *(dec++) = '0';
+            offset--;
+        }
+    }
+    u32_to_str(dec, t.microseconds);        /* convert microseconds */
+    dec += offset;
+    *(dec++) = ' ';                         /* append unit */
+    *(dec++) = 's';
+    *(dec) = '\0';
+    return timestamp;
+}
+
+/** @} */

--- a/tests/unittests/tests-timex/tests-timex.c
+++ b/tests/unittests/tests-timex/tests-timex.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Philipp Rosenkranz, Daniel Jentsch
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -44,6 +45,28 @@ static void test_timex_from_uint64(void)
     TEST_ASSERT(time.microseconds == 1000);
 }
 
+static void test_timex_to_str(void)
+{
+    timex_t t = { 0, 0 };
+    char t_str[TIMEX_MAX_STR_LEN];
+
+    TEST_ASSERT_EQUAL_STRING("0.000000 s", timex_to_str(t, t_str));
+    t.seconds = 1;
+    TEST_ASSERT_EQUAL_STRING("1.000000 s", timex_to_str(t, t_str));
+    t.seconds = 9;
+    t.microseconds = 2640288149;
+    TEST_ASSERT_EQUAL_STRING("2649.288149 s", timex_to_str(t, t_str));
+    t.seconds = 1689940699;
+    t.microseconds = 4361;
+    TEST_ASSERT_EQUAL_STRING("1689940699.004361 s", timex_to_str(t, t_str));
+    t.seconds = 100;
+    t.microseconds = 101010;
+    TEST_ASSERT_EQUAL_STRING("100.101010 s", timex_to_str(t, t_str));
+    t.seconds = UINT32_MAX;
+    t.microseconds = 999999;        /* should be .999999 */
+    TEST_ASSERT_EQUAL_STRING("4294967295.999999 s", timex_to_str(t, t_str));
+}
+
 Test *tests_timex_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -51,6 +74,7 @@ Test *tests_timex_tests(void)
         new_TestFixture(test_timex_add),
         new_TestFixture(test_timex_sub),
         new_TestFixture(test_timex_from_uint64),
+        new_TestFixture(test_timex_to_str),
     };
 
     EMB_UNIT_TESTCALLER(timex_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
Attempt to fulfill the marked TODO:

```
text	data	bss	dec	BOARD/BINDIRBASE

-660	0	0	-660	airfy-beacon
9564	112	2688	12364	master-bin
8904	112	2688	11704	timex_to_str-bin

-644	0	0	-644	arduino-due
9852	116	2764	12732	master-bin
9208	116	2764	12088	timex_to_str-bin

124	-12	0	112	arduino-mega2560
8566	334	770	9670	master-bin
8690	322	770	9782	timex_to_str-bin

-8408	0	0	-8408	avsextrem
48516	2232	96069	146817	master-bin
40108	2232	96069	138409	timex_to_str-bin

-644	0	0	-644	cc2538dk
9364	112	2688	12164	master-bin
8720	112	2688	11520	timex_to_str-bin

-110	0	-4	-114	chronos
8762	90	1060	9912	master-bin
8652	90	1056	9798	timex_to_str-bin

-640	0	0	-640	ek-lm4f120xl
9380	112	2728	12220	master-bin
8740	112	2728	11580	timex_to_str-bin

-640	0	0	-640	f4vi1
10880	116	2700	13696	master-bin
10240	116	2700	13056	timex_to_str-bin

-644	0	0	-644	fox
11184	112	2704	14000	master-bin
10540	112	2704	13356	timex_to_str-bin

-644	0	0	-644	frdm-k64f
9328	1140	4820	15288	master-bin
8684	1140	4820	14644	timex_to_str-bin

-644	0	0	-644	iot-lab_M3
11212	112	2704	14028	master-bin
10568	112	2704	13384	timex_to_str-bin

-644	0	0	-644	mbed_lpc1768
9184	112	2712	12008	master-bin
8540	112	2712	11364	timex_to_str-bin

56	0	-4	52	msb-430
7996	10	1090	9096	master-bin
8052	10	1086	9148	timex_to_str-bin

56	0	-4	52	msb-430h
7874	10	1090	8974	master-bin
7930	10	1086	9026	timex_to_str-bin

-8408	0	0	-8408	msba2
48172	2232	96069	146473	master-bin
39764	2232	96069	138065	timex_to_str-bin

-644	0	0	-644	msbiot
11164	116	2724	14004	master-bin
10520	116	2724	13360	timex_to_str-bin

-644	0	0	-644	mulle
11380	1164	4564	17108	master-bin
10736	1164	4564	16464	timex_to_str-bin

0	0	0	0	native
25953	392	51752	78097	master-bin
25953	392	51752	78097	timex_to_str-bin

-660	0	0	-660	nrf51dongle
9588	112	2688	12388	master-bin
8928	112	2688	11728	timex_to_str-bin

-664	0	0	-664	nucleo-f091
12748	112	2712	15572	master-bin
12084	112	2712	14908	timex_to_str-bin

-644	0	0	-644	nucleo-f303
10840	112	2720	13672	master-bin
10196	112	2720	13028	timex_to_str-bin

-640	0	0	-640	nucleo-f334
10580	112	2696	13388	master-bin
9940	112	2696	12748	timex_to_str-bin

-644	0	0	-644	nucleo-l1
10792	112	2704	13608	master-bin
10148	112	2704	12964	timex_to_str-bin

-644	0	0	-644	openmote
9316	112	2688	12116	master-bin
8672	112	2688	11472	timex_to_str-bin

-644	0	0	-644	pba-d-01-kw2x
9396	1140	4204	14740	master-bin
8752	1140	4204	14096	timex_to_str-bin

-660	0	0	-660	pca10000
9588	112	2688	12388	master-bin
8928	112	2688	11728	timex_to_str-bin

-612	0	0	-612	pca10005
9568	112	2688	12368	master-bin
8956	112	2688	11756	timex_to_str-bin

-8408	0	0	-8408	pttu
48724	2232	96069	147025	master-bin
40316	2232	96069	138617	timex_to_str-bin

56	0	0	56	qemu-i386
128651	5464	79508	213623	master-bin
128707	5464	79508	213679	timex_to_str-bin

-8456	0	0	-8456	redbee-econotag
49728	2264	8972	60964	master-bin
41272	2264	8972	52508	timex_to_str-bin

-660	0	0	-660	saml21-xpro
9568	112	2792	12472	master-bin
8908	112	2792	11812	timex_to_str-bin

-660	0	0	-660	samr21-xpro
9736	112	2680	12528	master-bin
9076	112	2680	11868	timex_to_str-bin

-644	0	0	-644	spark-core
11240	112	2704	14056	master-bin
10596	112	2704	13412	timex_to_str-bin

-664	0	0	-664	stm32f0discovery
12752	112	2712	15576	master-bin
12088	112	2712	14912	timex_to_str-bin

-644	0	0	-644	stm32f3discovery
10844	112	2720	13676	master-bin
10200	112	2720	13032	timex_to_str-bin

-640	0	0	-640	stm32f4discovery
11044	116	2716	13876	master-bin
10404	116	2716	13236	timex_to_str-bin

56	0	-4	52	telosb
7936	6	1090	9032	master-bin
7992	6	1086	9084	timex_to_str-bin

-644	0	0	-644	udoo
9852	116	2764	12732	master-bin
9208	116	2764	12088	timex_to_str-bin

56	0	-4	52	wsn430-v1_3b
8026	10	1090	9126	master-bin
8082	10	1086	9178	timex_to_str-bin

56	0	-4	52	wsn430-v1_4
8026	10	1090	9126	master-bin
8082	10	1086	9178	timex_to_str-bin

-660	0	0	-660	yunjia-nrf51822
9552	112	2688	12352	master-bin
8892	112	2688	11692	timex_to_str-bin

36	0	-4	32	z1
7656	6	1090	8752	master-bin
7692	6	1086	8784	timex_to_str-bin
```

Since `timex_to_str()` is currently used nowhere I used a [tailor-made application](https://gist.github.com/authmillenon/b246a473811791384bcc).

I can't explain why it is bigger on some platforms (especially qemu which should be 0 as native is).

I also tried to implement itoa for the platforms it is missing, but it got bigger than the current solution