### PR TITLE
net/fib: removed any ng_'s from the FIB

### DIFF
--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -24,10 +24,6 @@ ifneq (,$(filter oneway_malloc,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/sys/oneway-malloc/include
 endif
 
-ifneq (,$(filter fib,$(USEMODULE)))
-    USEMODULE_INCLUDES += $(RIOTBASE)/sys/include/net
-endif
-
 ifneq (,$(filter cpp11-compat,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/sys/cpp11-compat/include
 endif

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -86,7 +86,7 @@
 #endif
 
 #ifdef MODULE_FIB
-#include "net/ng_fib.h"
+#include "net/fib.h"
 #endif
 
 #define ENABLE_DEBUG (0)

--- a/sys/include/net/fib.h
+++ b/sys/include/net/fib.h
@@ -15,7 +15,8 @@
  *
  * @file
  * @brief       Types and functions for FIB
- * @author      Martin Landsmann
+ *
+ * @author      Martin Landsmann <martin.landsmann@haw-hamburg.de>
  */
 
 #ifndef FIB_H_

--- a/sys/include/net/fib/table.h
+++ b/sys/include/net/fib/table.h
@@ -7,14 +7,13 @@
  */
 
 /**
- * @brief       forwarding table structs
  * @ingroup     net_fib
- *
  * @{
  *
  * @file
  * @brief       Types and functions for operating fib tables
- * @author      Martin Landsmann
+ *
+ * @author      Martin Landsmann <martin.landsmann@haw-hamburg.de>
  */
 
 #ifndef FIB_TABLE_H_

--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -1,17 +1,20 @@
 /**
- * FIB implementation
- *
  * Copyright (C) 2014 Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
- *
- * @ingroup fib
+ */
+
+/**
+ * @ingroup     net_fib
  * @{
+ *
  * @file
- * @brief   Functions to manage FIB entries
- * @author  Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ * @brief       Functions to manage FIB entries
+ *
+ * @author      Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ *
  * @}
  */
 
@@ -27,8 +30,8 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-#include "ng_fib.h"
-#include "ng_fib/ng_fib_table.h"
+#include "net/fib.h"
+#include "net/fib/table.h"
 
 #ifdef MODULE_NG_IPV6_ADDR
 #include "net/ng_ipv6/addr.h"

--- a/sys/net/network_layer/ng_ndp/ng_ndp.c
+++ b/sys/net/network_layer/ng_ndp/ng_ndp.c
@@ -29,7 +29,7 @@
 #include "vtimer.h"
 
 #include "net/ng_ndp.h"
-#include "net/ng_fib.h"
+#include "net/fib.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"

--- a/sys/shell/commands/sc_fib.c
+++ b/sys/shell/commands/sc_fib.c
@@ -24,10 +24,10 @@
 #include <stdlib.h>
 #include "thread.h"
 #include "inet_pton.h"
-#include "ng_fib.h"
 #ifdef MODULE_NG_NETIF
-#include "ng_netif.h"
+#include "net/ng_netif.h"
 #endif
+#include "net/fib.h"
 
 #define INFO1_TXT "fibroute add <destination> via <next hop> [dev <device>]"
 #define INFO2_TXT " [lifetime <lifetime>]"

--- a/tests/unittests/tests-fib/tests-fib.c
+++ b/tests/unittests/tests-fib/tests-fib.c
@@ -16,7 +16,7 @@
 #include "vtimer.h"
 
 #include "thread.h"
-#include "ng_fib.h"
+#include "net/fib.h"
 #include "universal_address.h"
 
 /*


### PR DESCRIPTION
EDIT: replacing ~~based on~~ #3565
~~and waiting for #3566~~

~~As the header is already name ng_fib.h, it makes sense to name the module using the same scheme~~

As the FIB is completely independent from the GNRC stack and the old network stack files are almost out, I think it makes sense to drop the ng prefix for the FIB