### PR TITLE
ethernet/ethertype: remove ng_ prefix

### DIFF
--- a/cpu/native/include/dev_eth_tap.h
+++ b/cpu/native/include/dev_eth_tap.h
@@ -36,7 +36,7 @@ typedef struct dev_eth_tap {
     dev_eth_t ethdev;                   /**< dev_eth internal member */
     char tap_name[IFNAMSIZ];            /**< host dev file name */
     int tap_fd;                         /**< host file descriptor for the TAP */
-    uint8_t addr[NG_ETHERNET_ADDR_LEN]; /**< The MAC address of the TAP */
+    uint8_t addr[ETHERNET_ADDR_LEN];    /**< The MAC address of the TAP */
     uint8_t promiscous;                 /**< Flag for promiscous mode */
 } dev_eth_tap_t;
 

--- a/cpu/native/ng_net/dev_eth_tap.c
+++ b/cpu/native/ng_net/dev_eth_tap.c
@@ -63,7 +63,7 @@ static int _recv(dev_eth_t *ethdev, char* buf, int n);
 
 static inline void _get_mac_addr(dev_eth_t *ethdev, uint8_t *dst) {
     dev_eth_tap_t *dev = (dev_eth_tap_t*)ethdev;
-    memcpy(dst, dev->addr, NG_ETHERNET_ADDR_LEN);
+    memcpy(dst, dev->addr, ETHERNET_ADDR_LEN);
 }
 
 static inline int _get_promiscous(dev_eth_t *ethdev) {
@@ -112,10 +112,10 @@ static int _recv(dev_eth_t *dev_eth, char *buf, int len) {
     DEBUG("ng_tapnet: read %d bytes\n", nread);
 
     if (nread > 0) {
-        ng_ethernet_hdr_t *hdr = (ng_ethernet_hdr_t *)buf;
+        ethernet_hdr_t *hdr = (ethernet_hdr_t *)buf;
         if (!(dev->promiscous) && !_is_addr_multicast(hdr->dst) &&
             !_is_addr_broadcast(hdr->dst) &&
-            (memcmp(hdr->dst, dev->addr, NG_ETHERNET_ADDR_LEN) != 0)) {
+            (memcmp(hdr->dst, dev->addr, ETHERNET_ADDR_LEN) != 0)) {
             DEBUG("ng_eth_dev: received for %02x:%02x:%02x:%02x:%02x:%02x\n"
                   "That's not me => Dropped\n",
                   hdr->dst[0], hdr->dst[1], hdr->dst[2],
@@ -250,7 +250,7 @@ static int _init(dev_eth_t *ethdev)
         }
         real_exit(EXIT_FAILURE);
     }
-    memcpy(dev->addr, ifr.ifr_hwaddr.sa_data, NG_ETHERNET_ADDR_LEN);
+    memcpy(dev->addr, ifr.ifr_hwaddr.sa_data, ETHERNET_ADDR_LEN);
 
     /* change mac addr so it differs from what the host is using */
     dev->addr[5]++;

--- a/sys/include/dev_eth_autoinit.h
+++ b/sys/include/dev_eth_autoinit.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    sys_net_dev_eth dev_eth auto setup
- * @ingroup     net_ng_ethernet
+ * @ingroup     net_ethernet
  * @file
  * @brief       Automatically setup available ethernet devices
  * @{

--- a/sys/include/net/dev_eth.h
+++ b/sys/include/net/dev_eth.h
@@ -9,7 +9,7 @@
 
 /**
  * @defgroup    net_dev_eth_ll Low-Level Driver Inteface
- * @ingroup     net_ng_ethernet
+ * @ingroup     net_ethernet
  * @file
  * @brief       Low-level ethernet driver interface
  * @{
@@ -58,7 +58,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
-#include "ng_ethernet/hdr.h"
+#include "ethernet/hdr.h"
 
 /**
  * @brief Structure to hold driver state

--- a/sys/include/net/ethernet.h
+++ b/sys/include/net/ethernet.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    net_ng_ethernet Ethernet
+ * @defgroup    net_ethernet Ethernet
  * @ingroup     net
  * @brief       Ethernet implementation
  * @{
@@ -19,35 +19,33 @@
  */
 
 
-#ifndef NG_ETHERNET_H_
-#define NG_ETHERNET_H_
+#ifndef ETHERNET_H_
+#define ETHERNET_H_
 
 #include <stdint.h>
 
-#include "net/ng_ethernet/hdr.h"
+#include "net/ethernet/hdr.h"
 #include "net/eui64.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define NG_ETHERNET_DATA_LEN    (1500)  /**< maximum number of bytes in payload */
-#define NG_ETHERNET_FCS_LEN     (4)     /**< number of bytes in the FCS
+#define ETHERNET_DATA_LEN       (1500)  /**< maximum number of bytes in payload */
+#define ETHERNET_FCS_LEN        (4)     /**< number of bytes in the FCS
                                          *  (frame check sequence) */
 
 /**
  * @brief maximum number of bytes in an ethernet frame (without FCS)
  */
-#define NG_ETHERNET_FRAME_LEN   (NG_ETHERNET_DATA_LEN + \
-                                 sizeof(ng_ethernet_hdr_t))
-#define NG_ETHERNET_MIN_LEN     (64)    /**< minimum number of bytes in an
+#define ETHERNET_FRAME_LEN      (ETHERNET_DATA_LEN + sizeof(ethernet_hdr_t))
+#define ETHERNET_MIN_LEN        (64)    /**< minimum number of bytes in an
                                          * ethernet frame (with FCF) */
 
 /**
  * @brief maximum number of bytes in an ethernet frame (with FCF)
  */
-#define NG_ETHERNET_MAX_LEN     (NG_ETHERNET_FRAME_LEN + \
-                                 NG_ETHERNET_FCS_LEN)
+#define ETHERNET_MAX_LEN        (ETHERNET_FRAME_LEN + ETHERNET_FCS_LEN)
 
 /**
  * @brief   Generates an IPv6 interface identifier from a 48-bit MAC address.
@@ -58,9 +56,9 @@ extern "C" {
  *
  * @param[out] eui64    The resulting EUI-64.
  * @param[in] mac       A 48-bit MAC address. Is expected to be at least
- *                      @ref NG_ETHERNET_ADDR_LEN long.
+ *                      @ref ETHERNET_ADDR_LEN long.
  */
-static inline void ng_ethernet_get_iid(eui64_t *eui64, uint8_t *mac)
+static inline void ethernet_get_iid(eui64_t *eui64, uint8_t *mac)
 {
     eui64->uint8[0] = mac[0] ^ 0x02;
     eui64->uint8[1] = mac[1];
@@ -76,7 +74,7 @@ static inline void ng_ethernet_get_iid(eui64_t *eui64, uint8_t *mac)
 }
 #endif
 
-#endif /* NG_ETHERNET_H_ */
+#endif /* ETHERNET_H_ */
 /**
  * @}
  */

--- a/sys/include/net/ethernet/hdr.h
+++ b/sys/include/net/ethernet/hdr.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    net_ng_ethernet_hdr Ethernet header
- * @ingroup     net_ng_ethernet
+ * @defgroup    net_ethernet_hdr Ethernet header
+ * @ingroup     net_ethernet
  * @brief       Ethernet header
  * @{
  *
@@ -19,8 +19,8 @@
  */
 
 
-#ifndef NG_ETHERNET_HDR_H_
-#define NG_ETHERNET_HDR_H_
+#ifndef ETHERNET_HDR_H_
+#define ETHERNET_HDR_H_
 
 #include <inttypes.h>
 
@@ -30,22 +30,22 @@
 extern "C" {
 #endif
 
-#define NG_ETHERNET_ADDR_LEN    (6)     /**< Length of an Ethernet address */
+#define ETHERNET_ADDR_LEN       (6)     /**< Length of an Ethernet address */
 
 /**
  * @brief   Ethernet header
  */
 typedef struct __attribute__((packed)) {
-    uint8_t dst[NG_ETHERNET_ADDR_LEN];  /**< destination address */
-    uint8_t src[NG_ETHERNET_ADDR_LEN];  /**< source address */
-    network_uint16_t type;              /**< ether type (see @ref net_ng_ethertype) */
-} ng_ethernet_hdr_t;
+    uint8_t dst[ETHERNET_ADDR_LEN];     /**< destination address */
+    uint8_t src[ETHERNET_ADDR_LEN];     /**< source address */
+    network_uint16_t type;              /**< ether type (see @ref net_ethertype) */
+} ethernet_hdr_t;
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* NG_ETHERNET_HDR_H_ */
+#endif /* ETHERNET_HDR_H_ */
 /**
  * @}
  */

--- a/sys/include/net/ethertype.h
+++ b/sys/include/net/ethertype.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    net_ng_ethertype Ether types
+ * @defgroup    net_ethertype Ether types
  * @ingroup     net
  * @brief       Ether types
  * @see         <a href="http://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml#ieee-802-numbers-1">
@@ -23,25 +23,25 @@
  */
 
 
-#ifndef NG_ETHERTYPE_H_
-#define NG_ETHERTYPE_H_
+#ifndef ETHERTYPE_H_
+#define ETHERTYPE_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* expand at will ;-) */
-#define NG_ETHERTYPE_RESERVED   (0x0000)    /**< Reserved */
-#define NG_ETHERTYPE_IPV4       (0x0800)    /**< Internet protocol version 4 */
-#define NG_ETHERTYPE_ARP        (0x0806)    /**< Address resolution protocol */
-#define NG_ETHERTYPE_IPV6       (0x86dd)    /**< Internet protocol version 6 */
-#define NG_ETHERTYPE_UNKNOWN    (0xffff)    /**< Reserved (no protocol specified) */
+#define ETHERTYPE_RESERVED      (0x0000)    /**< Reserved */
+#define ETHERTYPE_IPV4          (0x0800)    /**< Internet protocol version 4 */
+#define ETHERTYPE_ARP           (0x0806)    /**< Address resolution protocol */
+#define ETHERTYPE_IPV6          (0x86dd)    /**< Internet protocol version 6 */
+#define ETHERTYPE_UNKNOWN       (0xffff)    /**< Reserved (no protocol specified) */
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* NG_ETHERTYPE_H_ */
+#endif /* ETHERTYPE_H_ */
 /**
  * @}
  */

--- a/sys/include/net/ng_netdev_eth.h
+++ b/sys/include/net/ng_netdev_eth.h
@@ -31,7 +31,7 @@
 
 #include "kernel_types.h"
 #include "net/ng_netdev.h"
-#include "net/ng_ethernet/hdr.h"
+#include "net/ethernet/hdr.h"
 #include "net/dev_eth.h"
 
 #ifdef __cplusplus

--- a/sys/include/net/ng_nettype.h
+++ b/sys/include/net/ng_nettype.h
@@ -24,7 +24,7 @@
 
 #include <inttypes.h>
 
-#include "net/ng_ethertype.h"
+#include "net/ethertype.h"
 #include "net/protnum.h"
 
 #ifdef __cplusplus
@@ -103,7 +103,7 @@ static inline ng_nettype_t ng_nettype_from_ethertype(uint16_t type)
 {
     switch (type) {
 #ifdef MODULE_NG_IPV6
-        case NG_ETHERTYPE_IPV6:
+        case ETHERTYPE_IPV6:
             return NG_NETTYPE_IPV6;
 #endif
         default:
@@ -120,17 +120,17 @@ static inline ng_nettype_t ng_nettype_from_ethertype(uint16_t type)
  * @param[in] type  A protocol type
  *
  * @return  The corresponding Ether Type number to @p type.
- * @return  @ref NG_ETHERTYPE_RESERVED if @p type not translatable.
+ * @return  @ref ETHERTYPE_RESERVED if @p type not translatable.
  */
 static inline uint16_t ng_nettype_to_ethertype(ng_nettype_t type)
 {
     switch (type) {
 #ifdef MODULE_NG_IPV6
         case NG_NETTYPE_IPV6:
-            return NG_ETHERTYPE_IPV6;
+            return ETHERTYPE_IPV6;
 #endif
         default:
-            return NG_ETHERTYPE_UNKNOWN;
+            return ETHERTYPE_UNKNOWN;
     }
 }
 


### PR DESCRIPTION
I used

```bash
git mv sys/include/net/ng_ethertype.h sys/include/net/ethertype.h
git mv sys/include/net/ng_ethernet.h sys/include/net/ethernet.h
git mv sys/include/net/ng_ethernet/ sys/include/net/ethernet/
git grep --name-only -i 'ng_ether' | xargs sed -i -e 's/ng_\(ether\)\([^ ]\+\)\( \+[/(].*\)/\1\2   \3/gI' -e 's/ng_\(ether\)/\1/gI'
```

to convert