### PR TITLE
ieee802154: remove ng_ prefix

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -12,26 +12,26 @@ endif
 
 ifneq (,$(filter ng_at86rf2%,$(USEMODULE)))
   USEMODULE += ng_at86rf2xx
-  USEMODULE += ng_ieee802154
+  USEMODULE += ieee802154
 endif
 
 ifneq (,$(filter kw2xrf,$(USEMODULE)))
-  USEMODULE += ng_ieee802154
+  USEMODULE += ieee802154
 endif
 
 ifneq (,$(filter xbee,$(USEMODULE)))
-  USEMODULE += ng_ieee802154
+  USEMODULE += ieee802154
 endif
 
 ifneq (,$(filter ng_zep,$(USEMODULE)))
   USEMODULE += hashes
-  USEMODULE += ng_ieee802154
+  USEMODULE += ieee802154
   USEMODULE += ng_udp
   USEMODULE += random
   USEMODULE += vtimer
 endif
 
-ifneq (,$(filter ng_ieee802154,$(USEMODULE)))
+ifneq (,$(filter ieee802154,$(USEMODULE)))
   ifneq (,$(filter ng_ipv6, $(USEMODULE)))
     USEMODULE += ng_sixlowpan
   endif

--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -1,5 +1,5 @@
 PSEUDOMODULES += ng_netif_default
-PSEUDOMODULES += ng_ieee802154
+PSEUDOMODULES += ieee802154
 PSEUDOMODULES += ng_ipv6_default
 PSEUDOMODULES += ng_ipv6_router
 PSEUDOMODULES += ng_ipv6_router_default

--- a/drivers/include/xbee.h
+++ b/drivers/include/xbee.h
@@ -30,7 +30,7 @@
 #include "periph/uart.h"
 #include "periph/gpio.h"
 #include "net/ng_netbase.h"
-#include "net/ng_ieee802154.h"
+#include "net/ieee802154.h"
 
 #ifdef __cplusplus
  extern "C" {

--- a/drivers/include/xbee.h
+++ b/drivers/include/xbee.h
@@ -33,7 +33,7 @@
 #include "net/ieee802154.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -216,8 +216,8 @@ void kw2xrf_set_sequence(kw2xrf_t *dev, kw2xrf_physeq_t seq)
     /* TODO: This should only used in combination with
      *       an CSMA-MAC layer. Currently not working
      */
-    /*if((seq == XCVSEQ_TRANSMIT) || (seq == XCVSEQ_TX_RX)) {
-        if((dev->option) & KW2XRF_OPT_AUTOACK) {
+    /*if ((seq == XCVSEQ_TRANSMIT) || (seq == XCVSEQ_TX_RX)) {
+        if ((dev->option) & KW2XRF_OPT_AUTOACK) {
             seq = XCVSEQ_TX_RX;
         }
         else {
@@ -1060,7 +1060,7 @@ int _assemble_tx_buf(kw2xrf_t *dev, ng_pktsnip_t *pkt)
      * since this is a soft_mac device this has to be
      * handled in a upcoming CSMA-MAC layer.
      */
-    /*if(dev->option & KW2XRF_OPT_AUTOACK) {
+    /*if (dev->option & KW2XRF_OPT_AUTOACK) {
         dev->buf[1] = 0x61;
     }
     else {

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -25,7 +25,7 @@
 #include "periph/gpio.h"
 #include "periph/cpuid.h"
 #include "net/ng_netbase.h"
-#include "net/ng_ieee802154.h"
+#include "net/ieee802154.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
@@ -807,7 +807,7 @@ int kw2xrf_set(ng_netdev_t *netdev, netopt_t opt, void *value, size_t value_len)
     }
 }
 
-/* TODO: generalize and move to ng_ieee802154 */
+/* TODO: generalize and move to ieee802154 */
 /* TODO: include security header implications */
 static size_t _get_frame_hdr_len(uint8_t *mhr)
 {
@@ -815,32 +815,32 @@ static size_t _get_frame_hdr_len(uint8_t *mhr)
     size_t len = 3;
 
     /* figure out address sizes */
-    tmp = (mhr[1] & NG_IEEE802154_FCF_DST_ADDR_MASK);
+    tmp = (mhr[1] & IEEE802154_FCF_DST_ADDR_MASK);
 
-    if (tmp == NG_IEEE802154_FCF_DST_ADDR_SHORT) {
+    if (tmp == IEEE802154_FCF_DST_ADDR_SHORT) {
         len += 4;
     }
-    else if (tmp == NG_IEEE802154_FCF_DST_ADDR_LONG) {
+    else if (tmp == IEEE802154_FCF_DST_ADDR_LONG) {
         len += 10;
     }
-    else if (tmp != NG_IEEE802154_FCF_DST_ADDR_VOID) {
+    else if (tmp != IEEE802154_FCF_DST_ADDR_VOID) {
         return 0;
     }
 
-    tmp = (mhr[1] & NG_IEEE802154_FCF_SRC_ADDR_MASK);
+    tmp = (mhr[1] & IEEE802154_FCF_SRC_ADDR_MASK);
 
-    if (tmp == NG_IEEE802154_FCF_SRC_ADDR_VOID) {
+    if (tmp == IEEE802154_FCF_SRC_ADDR_VOID) {
         return len;
     }
     else {
-        if (!(mhr[0] & NG_IEEE802154_FCF_PAN_COMP)) {
+        if (!(mhr[0] & IEEE802154_FCF_PAN_COMP)) {
             len += 2;
         }
 
-        if (tmp == NG_IEEE802154_FCF_SRC_ADDR_SHORT) {
+        if (tmp == IEEE802154_FCF_SRC_ADDR_SHORT) {
             return (len + 2);
         }
-        else if (tmp == NG_IEEE802154_FCF_SRC_ADDR_LONG) {
+        else if (tmp == IEEE802154_FCF_SRC_ADDR_LONG) {
             return (len + 8);
         }
     }
@@ -848,7 +848,7 @@ static size_t _get_frame_hdr_len(uint8_t *mhr)
     return 0;
 }
 
-/* TODO: generalize and move to ng_ieee802154 */
+/* TODO: generalize and move to (gnrc_)ieee802154 */
 static ng_pktsnip_t *_make_netif_hdr(uint8_t *mhr)
 {
     uint8_t tmp;
@@ -858,12 +858,12 @@ static ng_pktsnip_t *_make_netif_hdr(uint8_t *mhr)
     ng_netif_hdr_t *hdr;
 
     /* figure out address sizes */
-    tmp = mhr[1] & NG_IEEE802154_FCF_SRC_ADDR_MASK;
+    tmp = mhr[1] & IEEE802154_FCF_SRC_ADDR_MASK;
 
-    if (tmp == NG_IEEE802154_FCF_SRC_ADDR_SHORT) {
+    if (tmp == IEEE802154_FCF_SRC_ADDR_SHORT) {
         src_len = 2;
     }
-    else if (tmp == NG_IEEE802154_FCF_SRC_ADDR_LONG) {
+    else if (tmp == IEEE802154_FCF_SRC_ADDR_LONG) {
         src_len = 8;
     }
     else if (tmp == 0) {
@@ -873,12 +873,12 @@ static ng_pktsnip_t *_make_netif_hdr(uint8_t *mhr)
         return NULL;
     }
 
-    tmp = mhr[1] & NG_IEEE802154_FCF_DST_ADDR_MASK;
+    tmp = mhr[1] & IEEE802154_FCF_DST_ADDR_MASK;
 
-    if (tmp == NG_IEEE802154_FCF_DST_ADDR_SHORT) {
+    if (tmp == IEEE802154_FCF_DST_ADDR_SHORT) {
         dst_len = 2;
     }
-    else if (tmp == NG_IEEE802154_FCF_DST_ADDR_LONG) {
+    else if (tmp == IEEE802154_FCF_DST_ADDR_LONG) {
         dst_len = 8;
     }
     else if (tmp == 0) {
@@ -912,7 +912,7 @@ static ng_pktsnip_t *_make_netif_hdr(uint8_t *mhr)
         tmp = 3;
     }
 
-    if (!(mhr[0] & NG_IEEE802154_FCF_PAN_COMP)) {
+    if (!(mhr[0] & IEEE802154_FCF_PAN_COMP)) {
         tmp += 2;
     }
 

--- a/drivers/ng_at86rf2xx/ng_at86rf2xx.c
+++ b/drivers/ng_at86rf2xx/ng_at86rf2xx.c
@@ -26,7 +26,7 @@
 #include "hwtimer.h"
 #include "periph/cpuid.h"
 #include "byteorder.h"
-#include "net/ng_ieee802154.h"
+#include "net/ieee802154.h"
 #include "net/ng_netbase.h"
 #include "ng_at86rf2xx_registers.h"
 #include "ng_at86rf2xx_internal.h"
@@ -221,7 +221,7 @@ void ng_at86rf2xx_tx_prepare(ng_at86rf2xx_t *dev)
         dev->idle_state = state;
     }
     ng_at86rf2xx_set_state(dev, NG_AT86RF2XX_STATE_TX_ARET_ON);
-    dev->frame_len = NG_IEEE802154_FCS_LEN;
+    dev->frame_len = IEEE802154_FCS_LEN;
 }
 
 size_t ng_at86rf2xx_tx_load(ng_at86rf2xx_t *dev, uint8_t *data,

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -458,7 +458,7 @@ int xbee_init(xbee_t *dev, uart_t uart, uint32_t baudrate,
         hwtimer_wait(HWTIMER_TICKS(RESET_DELAY));
         gpio_set(reset_pin);
     }
-     /* put the XBee device into command mode */
+    /* put the XBee device into command mode */
     hwtimer_wait(HWTIMER_TICKS(ENTER_CMD_MODE_DELAY));
     _at_cmd(dev, "+++");
     hwtimer_wait(HWTIMER_TICKS(ENTER_CMD_MODE_DELAY));
@@ -487,7 +487,8 @@ int xbee_init(xbee_t *dev, uart_t uart, uint32_t baudrate,
     return 0;
 }
 
-static inline bool _is_broadcast(ng_netif_hdr_t *hdr) {
+static inline bool _is_broadcast(ng_netif_hdr_t *hdr)
+{
     /* IEEE 802.15.4 does not support multicast so we need to check both flags */
     return (bool)(hdr->flags & (NG_NETIF_HDR_FLAGS_BROADCAST |
                                 NG_NETIF_HDR_FLAGS_MULTICAST));
@@ -544,7 +545,8 @@ static int _send(ng_netdev_t *netdev, ng_pktsnip_t *pkt)
         dev->tx_buf[3] = API_ID_TX_SHORT_ADDR;
         memcpy(dev->tx_buf + 5, ng_netif_hdr_get_dst_addr(hdr), 2);
         pos = 7;
-    } else {
+    }
+    else {
         dev->tx_buf[1] = (uint8_t)((size + 11) >> 8);
         dev->tx_buf[2] = (uint8_t)(size + 11);
         dev->tx_buf[3] = API_ID_TX_LONG_ADDR;

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -26,7 +26,7 @@
 #include "hwtimer.h"
 #include "msg.h"
 #include "net/eui64.h"
-#include "net/ng_ieee802154.h"
+#include "net/ieee802154.h"
 #include "periph/cpuid.h"
 
 #define ENABLE_DEBUG    (0)
@@ -626,10 +626,10 @@ static int _get(ng_netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
                 return -EOVERFLOW;
             }
             if (dev->addr_flags & XBEE_ADDR_FLAGS_LONG) {
-                ng_ieee802154_get_iid(value, (uint8_t *)&dev->addr_long, 8);
+                ieee802154_get_iid(value, (uint8_t *)&dev->addr_long, 8);
             }
             else {
-                ng_ieee802154_get_iid(value, (uint8_t *)&dev->addr_short, 2);
+                ieee802154_get_iid(value, (uint8_t *)&dev->addr_short, 2);
             }
 
             return sizeof(eui64_t);

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -81,7 +81,7 @@ extern "C" {
  * @return NULL, if @p addr_len was of illegal length.
  */
 static inline eui64_t *ieee802154_get_iid(eui64_t *eui64, uint8_t *addr,
-                                             size_t addr_len)
+        size_t addr_len)
 {
     int i = 0;
 

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    net_ng_ieee802154 IEEE802.15.4
+ * @defgroup    net_ieee802154 IEEE802.15.4
  * @ingroup     net
  * @brief       IEEE802.15.4 header definitions and utility functions
  * @{
@@ -18,8 +18,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef NG_IEEE802154_H_
-#define NG_IEEE802154_H_
+#ifndef IEEE802154_H_
+#define IEEE802154_H_
 
 #include <stdlib.h>
 
@@ -33,33 +33,33 @@ extern "C" {
  * @brief IEEE802.15.4 FCF field definitions
  * @{
  */
-#define NG_IEEE802154_MAX_HDR_LEN           (23U)
-#define NG_IEEE802154_FCF_LEN               (2U)
-#define NG_IEEE802154_FCS_LEN               (2U)
+#define IEEE802154_MAX_HDR_LEN              (23U)
+#define IEEE802154_FCF_LEN                  (2U)
+#define IEEE802154_FCS_LEN                  (2U)
 
-#define NG_IEEE802154_FCF_TYPE_MASK         (0x07)
-#define NG_IEEE802154_FCF_TYPE_BEACON       (0x00)
-#define NG_IEEE802154_FCF_TYPE_DATA         (0x01)
-#define NG_IEEE802154_FCF_TYPE_ACK          (0x02)
-#define NG_IEEE802154_FCF_TYPE_MACCMD       (0x03)
+#define IEEE802154_FCF_TYPE_MASK            (0x07)
+#define IEEE802154_FCF_TYPE_BEACON          (0x00)
+#define IEEE802154_FCF_TYPE_DATA            (0x01)
+#define IEEE802154_FCF_TYPE_ACK             (0x02)
+#define IEEE802154_FCF_TYPE_MACCMD          (0x03)
 
-#define NG_IEEE802154_FCF_SECURITY_EN       (0x08)
-#define NG_IEEE802154_FCF_FRAME_PEND        (0x10)
-#define NG_IEEE802154_FCF_ACK_REQ           (0x20)
-#define NG_IEEE802154_FCF_PAN_COMP          (0x40)
+#define IEEE802154_FCF_SECURITY_EN          (0x08)
+#define IEEE802154_FCF_FRAME_PEND           (0x10)
+#define IEEE802154_FCF_ACK_REQ              (0x20)
+#define IEEE802154_FCF_PAN_COMP             (0x40)
 
-#define NG_IEEE802154_FCF_DST_ADDR_MASK     (0x0c)
-#define NG_IEEE802154_FCF_DST_ADDR_VOID     (0x00)
-#define NG_IEEE802154_FCF_DST_ADDR_SHORT    (0x08)
-#define NG_IEEE802154_FCF_DST_ADDR_LONG     (0x0c)
+#define IEEE802154_FCF_DST_ADDR_MASK        (0x0c)
+#define IEEE802154_FCF_DST_ADDR_VOID        (0x00)
+#define IEEE802154_FCF_DST_ADDR_SHORT       (0x08)
+#define IEEE802154_FCF_DST_ADDR_LONG        (0x0c)
 
-#define NG_IEEE802154_FCF_VERS_V0           (0x00)
-#define NG_IEEE802154_FCF_VERS_V1           (0x10)
+#define IEEE802154_FCF_VERS_V0              (0x00)
+#define IEEE802154_FCF_VERS_V1              (0x10)
 
-#define NG_IEEE802154_FCF_SRC_ADDR_MASK     (0xc0)
-#define NG_IEEE802154_FCF_SRC_ADDR_VOID     (0x00)
-#define NG_IEEE802154_FCF_SRC_ADDR_SHORT    (0x80)
-#define NG_IEEE802154_FCF_SRC_ADDR_LONG     (0xc0)
+#define IEEE802154_FCF_SRC_ADDR_MASK        (0xc0)
+#define IEEE802154_FCF_SRC_ADDR_VOID        (0x00)
+#define IEEE802154_FCF_SRC_ADDR_SHORT       (0x80)
+#define IEEE802154_FCF_SRC_ADDR_LONG        (0xc0)
 /** @} */
 
 /**
@@ -80,7 +80,7 @@ extern "C" {
  * @return Copy of @p eui64 on success.
  * @return NULL, if @p addr_len was of illegal length.
  */
-static inline eui64_t *ng_ieee802154_get_iid(eui64_t *eui64, uint8_t *addr,
+static inline eui64_t *ieee802154_get_iid(eui64_t *eui64, uint8_t *addr,
                                              size_t addr_len)
 {
     int i = 0;
@@ -124,5 +124,5 @@ static inline eui64_t *ng_ieee802154_get_iid(eui64_t *eui64, uint8_t *addr,
 }
 #endif
 
-#endif /* NG_IEEE802154_H_ */
+#endif /* IEEE802154_H_ */
 /** @} */

--- a/sys/net/network_layer/ng_sixlowpan/iphc/ng_sixlowpan_iphc.c
+++ b/sys/net/network_layer/ng_sixlowpan/iphc/ng_sixlowpan_iphc.c
@@ -202,8 +202,8 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
 
         case IPHC_SAC_SAM_L2:
             ieee802154_get_iid((eui64_t *)(&ipv6_hdr->src.u64[1]),
-                                  ng_netif_hdr_get_src_addr(netif_hdr),
-                                  netif_hdr->src_l2addr_len);
+                               ng_netif_hdr_get_src_addr(netif_hdr),
+                               netif_hdr->src_l2addr_len);
             ng_ipv6_addr_set_link_local_prefix(&ipv6_hdr->src);
             break;
 
@@ -229,8 +229,8 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
 
         case IPHC_SAC_SAM_CTX_L2:
             ieee802154_get_iid((eui64_t *)(&ipv6_hdr->src.u64[1]),
-                                  ng_netif_hdr_get_src_addr(netif_hdr),
-                                  netif_hdr->src_l2addr_len);
+                               ng_netif_hdr_get_src_addr(netif_hdr),
+                               netif_hdr->src_l2addr_len);
             ng_ipv6_addr_init_prefix(&ipv6_hdr->src, &ctx->prefix,
                                      ctx->prefix_len);
             break;
@@ -277,8 +277,8 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
 
         case IPHC_M_DAC_DAM_U_L2:
             ieee802154_get_iid((eui64_t *)(&ipv6_hdr->dst.u64[1]),
-                                  ng_netif_hdr_get_dst_addr(netif_hdr),
-                                  netif_hdr->dst_l2addr_len);
+                               ng_netif_hdr_get_dst_addr(netif_hdr),
+                               netif_hdr->dst_l2addr_len);
             ng_ipv6_addr_set_link_local_prefix(&ipv6_hdr->dst);
             break;
 
@@ -300,8 +300,8 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
 
         case IPHC_M_DAC_DAM_U_CTX_L2:
             ieee802154_get_iid((eui64_t *)(&ipv6_hdr->dst.u64[1]),
-                                  ng_netif_hdr_get_dst_addr(netif_hdr),
-                                  netif_hdr->dst_l2addr_len);
+                               ng_netif_hdr_get_dst_addr(netif_hdr),
+                               netif_hdr->dst_l2addr_len);
             ng_ipv6_addr_init_prefix(&ipv6_hdr->dst, &ctx->prefix,
                                      ctx->prefix_len);
             break;
@@ -511,7 +511,7 @@ bool ng_sixlowpan_iphc_encode(ng_pktsnip_t *pkt)
                 (netif_hdr->src_l2addr_len == 8)) {
                 /* prefer to create IID from netif header if available */
                 ieee802154_get_iid(&iid, ng_netif_hdr_get_src_addr(netif_hdr),
-                                      netif_hdr->src_l2addr_len);
+                                   netif_hdr->src_l2addr_len);
             }
             else {
                 /* but take from driver otherwise */
@@ -620,7 +620,7 @@ bool ng_sixlowpan_iphc_encode(ng_pktsnip_t *pkt)
         eui64_t iid;
 
         ieee802154_get_iid(&iid, ng_netif_hdr_get_dst_addr(netif_hdr),
-                              netif_hdr->dst_l2addr_len);
+                           netif_hdr->dst_l2addr_len);
 
         if ((ipv6_hdr->dst.u64[1].u64 == iid.uint64.u64) ||
             _context_overlaps_iid(dst_ctx, &(ipv6_hdr->dst), &iid)) {

--- a/sys/net/network_layer/ng_sixlowpan/iphc/ng_sixlowpan_iphc.c
+++ b/sys/net/network_layer/ng_sixlowpan/iphc/ng_sixlowpan_iphc.c
@@ -15,7 +15,7 @@
 #include <stdbool.h>
 
 #include "byteorder.h"
-#include "net/ng_ieee802154.h"
+#include "net/ieee802154.h"
 #include "net/ng_ipv6/hdr.h"
 #include "net/ng_netbase.h"
 #include "net/ng_sixlowpan/ctx.h"
@@ -201,7 +201,7 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
             break;
 
         case IPHC_SAC_SAM_L2:
-            ng_ieee802154_get_iid((eui64_t *)(&ipv6_hdr->src.u64[1]),
+            ieee802154_get_iid((eui64_t *)(&ipv6_hdr->src.u64[1]),
                                   ng_netif_hdr_get_src_addr(netif_hdr),
                                   netif_hdr->src_l2addr_len);
             ng_ipv6_addr_set_link_local_prefix(&ipv6_hdr->src);
@@ -228,7 +228,7 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
             break;
 
         case IPHC_SAC_SAM_CTX_L2:
-            ng_ieee802154_get_iid((eui64_t *)(&ipv6_hdr->src.u64[1]),
+            ieee802154_get_iid((eui64_t *)(&ipv6_hdr->src.u64[1]),
                                   ng_netif_hdr_get_src_addr(netif_hdr),
                                   netif_hdr->src_l2addr_len);
             ng_ipv6_addr_init_prefix(&ipv6_hdr->src, &ctx->prefix,
@@ -276,7 +276,7 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
             break;
 
         case IPHC_M_DAC_DAM_U_L2:
-            ng_ieee802154_get_iid((eui64_t *)(&ipv6_hdr->dst.u64[1]),
+            ieee802154_get_iid((eui64_t *)(&ipv6_hdr->dst.u64[1]),
                                   ng_netif_hdr_get_dst_addr(netif_hdr),
                                   netif_hdr->dst_l2addr_len);
             ng_ipv6_addr_set_link_local_prefix(&ipv6_hdr->dst);
@@ -299,7 +299,7 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
             break;
 
         case IPHC_M_DAC_DAM_U_CTX_L2:
-            ng_ieee802154_get_iid((eui64_t *)(&ipv6_hdr->dst.u64[1]),
+            ieee802154_get_iid((eui64_t *)(&ipv6_hdr->dst.u64[1]),
                                   ng_netif_hdr_get_dst_addr(netif_hdr),
                                   netif_hdr->dst_l2addr_len);
             ng_ipv6_addr_init_prefix(&ipv6_hdr->dst, &ctx->prefix,
@@ -510,7 +510,7 @@ bool ng_sixlowpan_iphc_encode(ng_pktsnip_t *pkt)
                 (netif_hdr->src_l2addr_len == 4) ||
                 (netif_hdr->src_l2addr_len == 8)) {
                 /* prefer to create IID from netif header if available */
-                ng_ieee802154_get_iid(&iid, ng_netif_hdr_get_src_addr(netif_hdr),
+                ieee802154_get_iid(&iid, ng_netif_hdr_get_src_addr(netif_hdr),
                                       netif_hdr->src_l2addr_len);
             }
             else {
@@ -619,7 +619,7 @@ bool ng_sixlowpan_iphc_encode(ng_pktsnip_t *pkt)
               ng_ipv6_addr_is_link_local(&ipv6_hdr->dst)) && (netif_hdr->dst_l2addr_len > 0)) {
         eui64_t iid;
 
-        ng_ieee802154_get_iid(&iid, ng_netif_hdr_get_dst_addr(netif_hdr),
+        ieee802154_get_iid(&iid, ng_netif_hdr_get_dst_addr(netif_hdr),
                               netif_hdr->dst_l2addr_len);
 
         if ((ipv6_hdr->dst.u64[1].u64 == iid.uint64.u64) ||


### PR DESCRIPTION
Another step to get general networking stuff and gnrc seperated.

```bash
git mv sys/include/net/ng_ieee802154.h sys/include/net/ieee802154.h
git grep --name-only -i 'ng_ieee802154' | xargs sed -i -e 's/ng_\(ieee802154\)\(.\+\)\( \+\/.*\)/\1\2   \3/gI' -e 's/\(#define *\)ng_\(ieee802154\)\([^ ]\+\)\( \+\)/\1\2\3   \4/gI' -e 's/ng_\(ieee802154\)/\1/gI'
```

was my tool.