### PR TITLE
sys: Serial Number Arithmetic (RFC1982)

### DIFF
--- a/sys/include/seq.h
+++ b/sys/include/seq.h
@@ -1,0 +1,396 @@
+/*
+ * Copyright (C) 2015 Cenk Gündoğan <cnkgndgn@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_seq     Serial Number Arithmetic
+ * @ingroup     sys
+ * @brief       Serial Number Arithmetic (RFC 1982)
+ * @{
+ *
+ * @file
+ * @brief       Serial Number Arithmetic (RFC 1982)
+ * @see         <a href="https://tools.ietf.org/html/rfc1982">
+ *                  RFC 1982 - Serial Number Arithmetic
+ *              </a>
+ *
+ * @author      Cenk Gündoğan <cnkgndgn@gmail.com>
+ */
+
+#ifndef SEQ_H
+#define SEQ_H
+
+#include <stdint.h>
+#include <errno.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief       Maximum for the addition of a positive integer. X denotes the size of the space
+ */
+#define SEQ_LIMIT(X)            (X >> 1)
+
+/**
+ * @brief       A 8 bit sequence number
+ */
+typedef uint8_t seq8_t;
+
+/**
+ * @brief       A 16 bit sequence number
+ */
+typedef uint16_t seq16_t;
+
+/**
+ * @brief       A 32 bit sequence number
+ */
+typedef uint32_t seq32_t;
+
+/**
+ * @brief       A 64 bit sequence number
+ */
+typedef uint64_t seq64_t;
+
+/**
+ * @brief           Addition of a 8 bit sequence number @p s and a positive integer @p n
+ *                  in the serial number @p space
+ * @see             <a href="https://tools.ietf.org/html/rfc1982#section-3.1">
+ *                      3.1. Addition
+ *                  </a>
+ * @param[in]       s       sequence number
+ * @param[in]       n       positive integer in the range of [0 .. ((@p space / 2) - 1)]
+ * @param[in]       space   serial number space must be a power of 2 minus 1
+ * @return          s + n, if valid
+ * @return          s, if n is out of range
+ */
+seq8_t seq8_adds(seq8_t s, uint8_t n, uint8_t space);
+
+/**
+ * @brief           Addition of a 8 bit sequence number @p s and a positive integer @p n
+ *                  in the serial number space UINT8_MAX
+ * @see             <a href="https://tools.ietf.org/html/rfc1982#section-3.1">
+ *                      3.1. Addition
+ *                  </a>
+ * @param[in]       s       sequence number
+ * @param[in]       n       positive integer in the range of [0 .. 127]
+ * @return          s + n, if valid
+ * @return          s, if n is out of range
+ */
+static inline seq8_t seq8_add(seq8_t s, uint8_t n)
+{
+    return seq8_adds(s, n, UINT8_MAX);
+}
+
+/**
+ * @brief           Increment a sequence number @p s by 1 in the serial number @p space
+ * @param[in]       s       sequence number
+ * @param[in]       space   serial number space must be a power of 2 minus 1
+ * @return          s + 1
+ */
+static inline seq8_t seq8_incs(seq8_t s, uint8_t space)
+{
+    return seq8_adds(s, 1, space);
+}
+
+/**
+ * @brief           Increment a sequence number @p s by 1 in the serial number space UINT8_MAX
+ * @param[in]       s       sequence number
+ * @return          s + 1
+ */
+static inline seq8_t seq8_inc(seq8_t s)
+{
+    return seq8_adds(s, 1, UINT8_MAX);
+}
+
+/**
+ * @brief           Compare sequence numbers @p s1, @p s2 in the serial number @p space
+ * @see             <a href="https://tools.ietf.org/html/rfc1982#section-3.2">
+ *                      3.2. Comparison
+ *                  </a>
+ * @param[in]       s1      first sequence number
+ * @param[in]       s2      second sequence number
+ * @param[in]       space   serial number space must be a power of 2 minus 1
+ * @return          -1, if s1 < s2
+ * @return          0, if s1 == s2
+ * @return          1, if s1 > s2
+ * @return          -EINVAL, if comparison of the pair (s1,s2) is undefined
+ */
+int seq8_compares(seq8_t s1, seq8_t s2, uint8_t space);
+
+/**
+ * @brief           Compare sequence numbers @p s1, @p s2 in the serial number space UINT8_MAX
+ * @see             <a href="https://tools.ietf.org/html/rfc1982#section-3.2">
+ *                      3.2. Comparison
+ *                  </a>
+ * @param[in]       s1      first sequence number
+ * @param[in]       s2      second sequence number
+ * @return          -1, if s1 < s2
+ * @return          0, if s1 == s2
+ * @return          1, if s1 > s2
+ * @return          -EINVAL, if comparison of the pair (s1,s2) is undefined
+ */
+static inline int seq8_compare(seq8_t s1, seq8_t s2)
+{
+    return seq8_compares(s1, s2, UINT8_MAX);
+}
+
+/**
+ * @brief           Addition of a 16 bit sequence number @p s and a positive integer @p n
+ *                  in the serial number @p space
+ * @see             <a href="https://tools.ietf.org/html/rfc1982#section-3.1">
+ *                      3.1. Addition
+ *                  </a>
+ * @param[in]       s       sequence number
+ * @param[in]       n       positive integer in the range of [0 .. ((@p space / 2) - 1)]
+ * @param[in]       space   serial number space must be a power of 2 minus 1
+ * @return          s + n, if valid
+ * @return          s, if n is out of range
+ */
+seq16_t seq16_adds(seq16_t s, uint16_t n, uint16_t space);
+
+/**
+ * @brief           Addition of a 16 bit sequence number @p s and a positive integer @p n
+ *                  in the serial number space UINT16_MAX
+ * @see             <a href="https://tools.ietf.org/html/rfc1982#section-3.1">
+ *                      3.1. Addition
+ *                  </a>
+ * @param[in]       s       sequence number
+ * @param[in]       n       positive integer in the range of [0 .. 127]
+ * @return          s + n, if valid
+ * @return          s, if n is out of range
+ */
+static inline seq16_t seq16_add(seq16_t s, uint16_t n)
+{
+    return seq16_adds(s, n, UINT16_MAX);
+}
+
+/**
+ * @brief           Increment a sequence number @p s by 1 in the serial number @p space
+ * @param[in]       s       sequence number
+ * @param[in]       space   serial number space must be a power of 2 minus 1
+ * @return          s + 1
+ */
+static inline seq16_t seq16_incs(seq16_t s, uint16_t space)
+{
+    return seq16_adds(s, 1, space);
+}
+
+/**
+ * @brief           Increment a sequence number @p s by 1 in the serial number space UINT16_MAX
+ * @param[in]       s       sequence number
+ * @return          s + 1
+ */
+static inline seq16_t seq16_inc(seq16_t s)
+{
+    return seq16_adds(s, 1, UINT16_MAX);
+}
+
+/**
+ * @brief           Compare sequence numbers @p s1, @p s2 in the serial number @p space
+ * @see             <a href="https://tools.ietf.org/html/rfc1982#section-3.2">
+ *                      3.2. Comparison
+ *                  </a>
+ * @param[in]       s1      first sequence number
+ * @param[in]       s2      second sequence number
+ * @param[in]       space   serial number space must be a power of 2 minus 1
+ * @return          -1, if s1 < s2
+ * @return          0, if s1 == s2
+ * @return          1, if s1 > s2
+ * @return          -EINVAL, if comparison of the pair (s1,s2) is undefined
+ */
+int seq16_compares(seq16_t s1, seq16_t s2, uint16_t space);
+
+/**
+ * @brief           Compare sequence numbers @p s1, @p s2 in the serial number space UINT16_MAX
+ * @see             <a href="https://tools.ietf.org/html/rfc1982#section-3.2">
+ *                      3.2. Comparison
+ *                  </a>
+ * @param[in]       s1      first sequence number
+ * @param[in]       s2      second sequence number
+ * @return          -1, if s1 < s2
+ * @return          0, if s1 == s2
+ * @return          1, if s1 > s2
+ * @return          -EINVAL, if comparison of the pair (s1,s2) is undefined
+ */
+static inline int seq16_compare(seq16_t s1, seq16_t s2)
+{
+    return seq16_compares(s1, s2, UINT16_MAX);
+}
+
+/**
+ * @brief           Addition of a 32 bit sequence number @p s and a positive integer @p n
+ *                  in the serial number @p space
+ * @see             <a href="https://tools.ietf.org/html/rfc1982#section-3.1">
+ *                      3.1. Addition
+ *                  </a>
+ * @param[in]       s       sequence number
+ * @param[in]       n       positive integer in the range of [0 .. ((@p space / 2) - 1)]
+ * @param[in]       space   serial number space must be a power of 2 minus 1
+ * @return          s + n, if valid
+ * @return          s, if n is out of range
+ */
+seq32_t seq32_adds(seq32_t s, uint32_t n, uint32_t space);
+
+/**
+ * @brief           Addition of a 32 bit sequence number @p s and a positive integer @p n
+ *                  in the serial number space UINT32_MAX
+ * @see             <a href="https://tools.ietf.org/html/rfc1982#section-3.1">
+ *                      3.1. Addition
+ *                  </a>
+ * @param[in]       s       sequence number
+ * @param[in]       n       positive integer in the range of [0 .. 127]
+ * @return          s + n, if valid
+ * @return          s, if n is out of range
+ */
+static inline seq32_t seq32_add(seq32_t s, uint32_t n)
+{
+    return seq32_adds(s, n, UINT32_MAX);
+}
+
+/**
+ * @brief           Increment a sequence number @p s by 1 in the serial number @p space
+ * @param[in]       s       sequence number
+ * @param[in]       space   serial number space must be a power of 2 minus 1
+ * @return          s + 1
+ */
+static inline seq32_t seq32_incs(seq32_t s, uint32_t space)
+{
+    return seq32_adds(s, 1, space);
+}
+
+/**
+ * @brief           Increment a sequence number @p s by 1 in the serial number space UINT32_MAX
+ * @param[in]       s       sequence number
+ * @return          s + 1
+ */
+static inline seq32_t seq32_inc(seq32_t s)
+{
+    return seq32_adds(s, 1, UINT32_MAX);
+}
+
+/**
+ * @brief           Compare sequence numbers @p s1, @p s2 in the serial number @p space
+ * @see             <a href="https://tools.ietf.org/html/rfc1982#section-3.2">
+ *                      3.2. Comparison
+ *                  </a>
+ * @param[in]       s1      first sequence number
+ * @param[in]       s2      second sequence number
+ * @param[in]       space   serial number space must be a power of 2 minus 1
+ * @return          -1, if s1 < s2
+ * @return          0, if s1 == s2
+ * @return          1, if s1 > s2
+ * @return          -EINVAL, if comparison of the pair (s1,s2) is undefined
+ */
+int seq32_compares(seq32_t s1, seq32_t s2, uint32_t space);
+
+/**
+ * @brief           Compare sequence numbers @p s1, @p s2 in the serial number space UINT32_MAX
+ * @see             <a href="https://tools.ietf.org/html/rfc1982#section-3.2">
+ *                      3.2. Comparison
+ *                  </a>
+ * @param[in]       s1      first sequence number
+ * @param[in]       s2      second sequence number
+ * @return          -1, if s1 < s2
+ * @return          0, if s1 == s2
+ * @return          1, if s1 > s2
+ * @return          -EINVAL, if comparison of the pair (s1,s2) is undefined
+ */
+static inline int seq32_compare(seq32_t s1, seq32_t s2)
+{
+    return seq32_compares(s1, s2, UINT32_MAX);
+}
+
+/**
+ * @brief           Addition of a 64 bit sequence number @p s and a positive integer @p n
+ *                  in the serial number @p space
+ * @see             <a href="https://tools.ietf.org/html/rfc1982#section-3.1">
+ *                      3.1. Addition
+ *                  </a>
+ * @param[in]       s       sequence number
+ * @param[in]       n       positive integer in the range of [0 .. ((@p space / 2) - 1)]
+ * @param[in]       space   serial number space must be a power of 2 minus 1
+ * @return          s + n, if valid
+ * @return          s, if n is out of range
+ */
+seq64_t seq64_adds(seq64_t s, uint64_t n, uint64_t space);
+
+/**
+ * @brief           Addition of a 64 bit sequence number @p s and a positive integer @p n
+ *                  in the serial number space UINT64_MAX
+ * @see             <a href="https://tools.ietf.org/html/rfc1982#section-3.1">
+ *                      3.1. Addition
+ *                  </a>
+ * @param[in]       s       sequence number
+ * @param[in]       n       positive integer in the range of [0 .. 127]
+ * @return          s + n, if valid
+ * @return          s, if n is out of range
+ */
+static inline seq64_t seq64_add(seq64_t s, uint64_t n)
+{
+    return seq64_adds(s, n, UINT64_MAX);
+}
+
+/**
+ * @brief           Increment a sequence number @p s by 1 in the serial number @p space
+ * @param[in]       s       sequence number
+ * @param[in]       space   serial number space must be a power of 2 minus 1
+ * @return          s + 1
+ */
+static inline seq64_t seq64_incs(seq64_t s, uint64_t space)
+{
+    return seq64_adds(s, 1, space);
+}
+
+/**
+ * @brief           Increment a sequence number @p s by 1 in the serial number space UINT64_MAX
+ * @param[in]       s       sequence number
+ * @return          s + 1
+ */
+static inline seq64_t seq64_inc(seq64_t s)
+{
+    return seq64_adds(s, 1, UINT64_MAX);
+}
+
+/**
+ * @brief           Compare sequence numbers @p s1, @p s2 in the serial number @p space
+ * @see             <a href="https://tools.ietf.org/html/rfc1982#section-3.2">
+ *                      3.2. Comparison
+ *                  </a>
+ * @param[in]       s1      first sequence number
+ * @param[in]       s2      second sequence number
+ * @param[in]       space   serial number space must be a power of 2 minus 1
+ * @return          -1, if s1 < s2
+ * @return          0, if s1 == s2
+ * @return          1, if s1 > s2
+ * @return          -EINVAL, if comparison of the pair (s1,s2) is undefined
+ */
+int seq64_compares(seq64_t s1, seq64_t s2, uint64_t space);
+
+/**
+ * @brief           Compare sequence numbers @p s1, @p s2 in the serial number space UINT64_MAX
+ * @see             <a href="https://tools.ietf.org/html/rfc1982#section-3.2">
+ *                      3.2. Comparison
+ *                  </a>
+ * @param[in]       s1      first sequence number
+ * @param[in]       s2      second sequence number
+ * @return          -1, if s1 < s2
+ * @return          0, if s1 == s2
+ * @return          1, if s1 > s2
+ * @return          -EINVAL, if comparison of the pair (s1,s2) is undefined
+ */
+static inline int seq64_compare(seq64_t s1, seq64_t s2)
+{
+    return seq64_compares(s1, s2, UINT64_MAX);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* SEQ_H */

--- a/sys/seq/Makefile
+++ b/sys/seq/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/seq/seq.c
+++ b/sys/seq/seq.c
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2015 Cenk Gündoğan <cnkgndgn@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_seq
+ * @{
+ *
+ * @file
+ * @brief       Serial Number Arithmetic (RFC 1982)
+ *
+ * @author      Cenk Gündoğan <cnkgndgn@gmail.com>
+ *
+ * @}
+ */
+
+#include <assert.h>
+#include "seq.h"
+
+seq8_t seq8_adds(seq8_t s, uint8_t n, uint8_t space)
+{
+    /* check if space is a power of 2 minus 1 */
+    assert((space != 0) && ((space & (space + 1)) == 0));
+
+    if (n > SEQ_LIMIT(space)) {
+        return s;
+    }
+
+    return (space == UINT8_MAX) ? (s + n) : (s + n) % (space + 1);
+}
+
+int seq8_compares(seq8_t s1, seq8_t s2, uint8_t space)
+{
+    /* check if space is a power of 2 minus 1 */
+    assert((space != 0) && ((space & (space + 1)) == 0));
+
+    if (s1 == s2) {
+        return 0;
+    }
+
+    if (((s1 < s2) && ((uint8_t)(s2 - s1) < (SEQ_LIMIT(space) + 1))) ||
+            ((s1 > s2) && ((uint8_t)(s1 - s2) > (SEQ_LIMIT(space) + 1)))) {
+        return -1;
+    }
+
+    if (((s1 < s2) && ((uint8_t)(s2 - s1) > (SEQ_LIMIT(space) + 1))) ||
+            ((s1 > s2) && ((uint8_t)(s1 - s2) < (SEQ_LIMIT(space) + 1)))) {
+        return 1;
+    }
+
+    return -EINVAL;
+}
+
+seq16_t seq16_adds(seq16_t s, uint16_t n, uint16_t space)
+{
+    /* check if space is a power of 2 minus 1 */
+    assert((space != 0) && ((space & (space + 1)) == 0));
+
+    if (n > SEQ_LIMIT(space)) {
+        return s;
+    }
+
+    return (space == UINT16_MAX) ? (s + n) : (s + n) % (space + 1);
+}
+
+int seq16_compares(seq16_t s1, seq16_t s2, uint16_t space)
+{
+    /* check if space is a power of 2 minus 1 */
+    assert((space != 0) && ((space & (space + 1)) == 0));
+
+    if (s1 == s2) {
+        return 0;
+    }
+
+    if (((s1 < s2) && ((uint16_t)(s2 - s1) < (SEQ_LIMIT(space) + 1))) ||
+            ((s1 > s2) && ((uint16_t)(s1 - s2) > (SEQ_LIMIT(space) + 1)))) {
+        return -1;
+    }
+
+    if (((s1 < s2) && ((uint16_t)(s2 - s1) > (SEQ_LIMIT(space) + 1))) ||
+            ((s1 > s2) && ((uint16_t)(s1 - s2) < (SEQ_LIMIT(space) + 1)))) {
+        return 1;
+    }
+
+    return -EINVAL;
+}
+
+seq32_t seq32_adds(seq32_t s, uint32_t n, uint32_t space)
+{
+    /* check if space is a power of 2 minus 1 */
+    assert((space != 0) && ((space & (space + 1)) == 0));
+
+    if (n > SEQ_LIMIT(space)) {
+        return s;
+    }
+
+    return (space == UINT32_MAX) ? (s + n) : (s + n) % (space + 1);
+}
+
+int seq32_compares(seq32_t s1, seq32_t s2, uint32_t space)
+{
+    /* check if space is a power of 2 minus 1 */
+    assert((space != 0) && ((space & (space + 1)) == 0));
+
+    if (s1 == s2) {
+        return 0;
+    }
+
+    if (((s1 < s2) && ((uint32_t)(s2 - s1) < (SEQ_LIMIT(space) + 1))) ||
+            ((s1 > s2) && ((uint32_t)(s1 - s2) > (SEQ_LIMIT(space) + 1)))) {
+        return -1;
+    }
+
+    if (((s1 < s2) && ((uint32_t)(s2 - s1) > (SEQ_LIMIT(space) + 1))) ||
+            ((s1 > s2) && ((uint32_t)(s1 - s2) < (SEQ_LIMIT(space) + 1)))) {
+        return 1;
+    }
+
+    return -EINVAL;
+}
+
+seq64_t seq64_adds(seq64_t s, uint64_t n, uint64_t space)
+{
+    /* check if space is a power of 2 minus 1 */
+    assert((space != 0) && ((space & (space + 1)) == 0));
+
+    if (n > SEQ_LIMIT(space)) {
+        return s;
+    }
+
+    return (space == UINT64_MAX) ? (s + n) : (s + n) % (space + 1);
+}
+
+int seq64_compares(seq64_t s1, seq64_t s2, uint64_t space)
+{
+    /* check if space is a power of 2 minus 1 */
+    assert((space != 0) && ((space & (space + 1)) == 0));
+
+    if (s1 == s2) {
+        return 0;
+    }
+
+    if (((s1 < s2) && ((uint64_t)(s2 - s1) < (SEQ_LIMIT(space) + 1))) ||
+            ((s1 > s2) && ((uint64_t)(s1 - s2) > (SEQ_LIMIT(space) + 1)))) {
+        return -1;
+    }
+
+    if (((s1 < s2) && ((uint64_t)(s2 - s1) > (SEQ_LIMIT(space) + 1))) ||
+            ((s1 > s2) && ((uint64_t)(s1 - s2) < (SEQ_LIMIT(space) + 1)))) {
+        return 1;
+    }
+
+    return -EINVAL;
+}

--- a/tests/unittests/tests-seq/Makefile
+++ b/tests/unittests/tests-seq/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-seq/Makefile.include
+++ b/tests/unittests/tests-seq/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += seq

--- a/tests/unittests/tests-seq/tests-seq.c
+++ b/tests/unittests/tests-seq/tests-seq.c
@@ -1,0 +1,472 @@
+/*
+ * Copyright (C) 2015 Cenk Gündoğan <cnkgndgn@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+#include <errno.h>
+#include <stdint.h>
+
+#include "embUnit/embUnit.h"
+
+#include "unittests-constants.h"
+#include "seq.h"
+#include "tests-seq.h"
+
+seq8_t s8_1, s8_2;
+seq16_t s16_1, s16_2;
+seq32_t s32_1, s32_2;
+seq64_t s64_1, s64_2;
+
+static void set_up(void)
+{
+    s8_1 = 0; s8_2 = 0;
+    s16_1 = 0; s16_2 = 0;
+    s32_1 = 0; s32_2 = 0;
+    s64_1 = 0; s64_2 = 0;
+}
+
+/* --------------------------------------- seq8_t tests --------------------------------------- */
+static void test_seq8_equal(void)
+{
+    s8_1 = 0; s8_2 = 0;
+    TEST_ASSERT_EQUAL_INT(0, seq8_compare(s8_1, s8_2));
+    s8_1 = TEST_UINT8; s8_2 = TEST_UINT8;
+    TEST_ASSERT_EQUAL_INT(0, seq8_compare(s8_1, s8_2));
+}
+
+static void test_seq8_custom_space_equal(void)
+{
+    s8_1 = 0; s8_2 = 0;
+    TEST_ASSERT_EQUAL_INT(0, seq8_compares(s8_1, s8_2, 127));
+    s8_1 = 42; s8_2 = 42;
+    TEST_ASSERT_EQUAL_INT(0, seq8_compares(s8_1, s8_2, 127));
+}
+
+static void test_seq8_less_than(void)
+{
+    s8_1 = 0; s8_2 = 0;
+    s8_2 = seq8_inc(s8_2);
+    TEST_ASSERT_EQUAL_INT(-1, seq8_compare(s8_1, s8_2));
+    s8_1 = UINT8_MAX; s8_2 = UINT8_MAX;
+    s8_2 = seq8_add(s8_2, SEQ_LIMIT(UINT8_MAX));
+    TEST_ASSERT_EQUAL_INT(-1, seq8_compare(s8_1, s8_2));
+}
+
+static void test_seq8_custom_space_less_than(void)
+{
+    s8_1 = 0; s8_2 = 0;
+    s8_2 = seq8_incs(s8_2, 127);
+    TEST_ASSERT_EQUAL_INT(-1, seq8_compares(s8_1, s8_2, 127));
+    s8_1 = 127; s8_2 = 127;
+    s8_2 = seq8_adds(s8_2, SEQ_LIMIT(127), 127);
+    TEST_ASSERT_EQUAL_INT(-1, seq8_compares(s8_1, s8_2, 127));
+}
+
+static void test_seq8_greater_than(void)
+{
+    s8_1 = 0; s8_2 = 0;
+    s8_2 = seq8_add(s8_2, (SEQ_LIMIT(UINT8_MAX)));
+    s8_2 = seq8_add(s8_2, 2);
+    TEST_ASSERT_EQUAL_INT(1, seq8_compare(s8_1, s8_2));
+}
+
+static void test_seq8_custom_space_greater_than(void)
+{
+    s8_1 = 0; s8_2 = 0;
+    s8_2 = seq8_adds(s8_2, SEQ_LIMIT(127), 127);
+    s8_2 = seq8_adds(s8_2, 2, 127);
+    TEST_ASSERT_EQUAL_INT(1, seq8_compares(s8_1, s8_2, 127));
+}
+
+static void test_seq8_add(void)
+{
+    s8_1 = 0; s8_2 = 0;
+    TEST_ASSERT_EQUAL_INT(0, seq8_add(s8_1, 0));
+    s8_1 = seq8_add(s8_1, 0);
+    TEST_ASSERT_EQUAL_INT(0, seq8_compare(s8_1, s8_2));
+    TEST_ASSERT_EQUAL_INT(s8_2, seq8_add(s8_2, SEQ_LIMIT(UINT8_MAX) + 1));
+    s8_1 = UINT8_MAX; s8_2 = UINT8_MAX;
+    TEST_ASSERT_EQUAL_INT((seq8_t)(s8_1 + SEQ_LIMIT(UINT8_MAX)),
+            seq8_add(s8_1, SEQ_LIMIT(UINT8_MAX)));
+}
+
+static void test_seq8_custom_space_add(void)
+{
+    s8_1 = 0; s8_2 = 0;
+    TEST_ASSERT_EQUAL_INT(0, seq8_adds(s8_1, 0, 127));
+    s8_1 = seq8_adds(s8_1, 0, 127);
+    TEST_ASSERT_EQUAL_INT(0, seq8_compares(s8_1, s8_2, 127));
+    TEST_ASSERT_EQUAL_INT(s8_2, seq8_adds(s8_2, SEQ_LIMIT(127) + 1, 127));
+    s8_1 = 127; s8_2 = 127;
+    TEST_ASSERT_EQUAL_INT((s8_1 + SEQ_LIMIT(127)) % (127 + 1),
+            seq8_adds(s8_1, SEQ_LIMIT(127), 127));
+}
+
+static void test_seq8_compare_undefined(void)
+{
+    s8_1 = 0; s8_2 = SEQ_LIMIT(UINT8_MAX) + 1;
+    TEST_ASSERT_EQUAL_INT(-EINVAL, seq8_compare(s8_1, s8_2));
+
+    s8_1 = (0 + 2); s8_2 = (SEQ_LIMIT(UINT8_MAX) + 1 + 2);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, seq8_compare(s8_1, s8_2));
+}
+
+static void test_seq8_custom_space_compare_undefined(void)
+{
+    s8_1 = 0; s8_2 = SEQ_LIMIT(127) + 1;
+    TEST_ASSERT_EQUAL_INT(-EINVAL, seq8_compares(s8_1, s8_2, 127));
+
+    s8_1 = (0 + 2); s8_2 = (SEQ_LIMIT(127) + 1 + 2);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, seq8_compares(s8_1, s8_2, 127));
+}
+
+/* --------------------------------------- seq16_t tests --------------------------------------- */
+static void test_seq16_equal(void)
+{
+    s16_1 = 0; s16_2 = 0;
+    TEST_ASSERT_EQUAL_INT(0, seq16_compare(s16_1, s16_2));
+    s16_1 = TEST_UINT16; s16_2 = TEST_UINT16;
+    TEST_ASSERT_EQUAL_INT(0, seq16_compare(s16_1, s16_2));
+}
+
+static void test_seq16_custom_space_equal(void)
+{
+    s16_1 = 0; s16_2 = 0;
+    TEST_ASSERT_EQUAL_INT(0, seq16_compares(s16_1, s16_2, 1023));
+    s16_1 = 42; s16_2 = 42;
+    TEST_ASSERT_EQUAL_INT(0, seq16_compares(s16_1, s16_2, 1023));
+}
+
+static void test_seq16_less_than(void)
+{
+    s16_1 = 0; s16_2 = 0;
+    s16_2 = seq16_inc(s16_2);
+    TEST_ASSERT_EQUAL_INT(-1, seq16_compare(s16_1, s16_2));
+    s16_1 = UINT16_MAX; s16_2 = UINT16_MAX;
+    s16_2 = seq16_add(s16_2, SEQ_LIMIT(UINT16_MAX));
+    TEST_ASSERT_EQUAL_INT(-1, seq16_compare(s16_1, s16_2));
+}
+
+static void test_seq16_custom_space_less_than(void)
+{
+    s16_1 = 0; s16_2 = 0;
+    s16_2 = seq16_incs(s16_2, 1023);
+    TEST_ASSERT_EQUAL_INT(-1, seq16_compares(s16_1, s16_2, 1023));
+    s16_1 = 1023; s16_2 = 1023;
+    s16_2 = seq16_adds(s16_2, SEQ_LIMIT(1023), 1023);
+    TEST_ASSERT_EQUAL_INT(-1, seq16_compares(s16_1, s16_2, 1023));
+}
+
+static void test_seq16_greater_than(void)
+{
+    s16_1 = 0; s16_2 = 0;
+    s16_2 = seq16_add(s16_2, (SEQ_LIMIT(UINT16_MAX)));
+    s16_2 = seq16_add(s16_2, 2);
+    TEST_ASSERT_EQUAL_INT(1, seq16_compare(s16_1, s16_2));
+}
+
+static void test_seq16_custom_space_greater_than(void)
+{
+    s16_1 = 0; s16_2 = 0;
+    s16_2 = seq16_adds(s16_2, SEQ_LIMIT(1023), 1023);
+    s16_2 = seq16_adds(s16_2, 2, 1023);
+    TEST_ASSERT_EQUAL_INT(1, seq16_compares(s16_1, s16_2, 1023));
+}
+
+static void test_seq16_add(void)
+{
+    s16_1 = 0; s16_2 = 0;
+    TEST_ASSERT_EQUAL_INT(0, seq16_add(s16_1, 0));
+    s16_1 = seq16_add(s16_1, 0);
+    TEST_ASSERT_EQUAL_INT(0, seq16_compare(s16_1, s16_2));
+    TEST_ASSERT_EQUAL_INT(s16_2, seq16_add(s16_2, SEQ_LIMIT(UINT16_MAX) + 1));
+    s16_1 = UINT16_MAX; s16_2 = UINT16_MAX;
+    TEST_ASSERT_EQUAL_INT((seq16_t)(s16_1 + SEQ_LIMIT(UINT16_MAX)),
+            seq16_add(s16_1, SEQ_LIMIT(UINT16_MAX)));
+}
+
+static void test_seq16_custom_space_add(void)
+{
+    s16_1 = 0; s16_2 = 0;
+    TEST_ASSERT_EQUAL_INT(0, seq16_adds(s16_1, 0, 1023));
+    s16_1 = seq16_adds(s16_1, 0, 1023);
+    TEST_ASSERT_EQUAL_INT(0, seq16_compares(s16_1, s16_2, 1023));
+    TEST_ASSERT_EQUAL_INT(s16_2, seq16_adds(s16_2, SEQ_LIMIT(1023) + 1, 1023));
+    s16_1 = 1023; s16_2 = 1023;
+    TEST_ASSERT_EQUAL_INT((s16_1 + SEQ_LIMIT(1023)) % (1023 + 1),
+            seq16_adds(s16_1, SEQ_LIMIT(1023), 1023));
+}
+
+static void test_seq16_compare_undefined(void)
+{
+    s16_1 = 0; s16_2 = SEQ_LIMIT(UINT16_MAX) + 1;
+    TEST_ASSERT_EQUAL_INT(-EINVAL, seq16_compare(s16_1, s16_2));
+
+    s16_1 = (0 + 2); s16_2 = (SEQ_LIMIT(UINT16_MAX) + 1 + 2);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, seq16_compare(s16_1, s16_2));
+}
+
+static void test_seq16_custom_space_compare_undefined(void)
+{
+    s16_1 = 0; s16_2 = SEQ_LIMIT(1023) + 1;
+    TEST_ASSERT_EQUAL_INT(-EINVAL, seq16_compares(s16_1, s16_2, 1023));
+
+    s16_1 = (0 + 2); s16_2 = (SEQ_LIMIT(1023) + 1 + 2);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, seq16_compares(s16_1, s16_2, 1023));
+}
+
+/* --------------------------------------- seq32_t tests --------------------------------------- */
+static void test_seq32_equal(void)
+{
+    s32_1 = 0; s32_2 = 0;
+    TEST_ASSERT_EQUAL_INT(0, seq32_compare(s32_1, s32_2));
+    s32_1 = TEST_UINT32; s32_2 = TEST_UINT32;
+    TEST_ASSERT_EQUAL_INT(0, seq32_compare(s32_1, s32_2));
+}
+
+static void test_seq32_custom_space_equal(void)
+{
+    s32_1 = 0; s32_2 = 0;
+    TEST_ASSERT_EQUAL_INT(0, seq32_compares(s32_1, s32_2, ((1ULL << 20) - 1)));
+    s32_1 = 42; s32_2 = 42;
+    TEST_ASSERT_EQUAL_INT(0, seq32_compares(s32_1, s32_2, ((1ULL << 20) - 1)));
+}
+
+static void test_seq32_less_than(void)
+{
+    s32_1 = 0; s32_2 = 0;
+    s32_2 = seq32_inc(s32_2);
+    TEST_ASSERT_EQUAL_INT(-1, seq32_compare(s32_1, s32_2));
+    s32_1 = UINT32_MAX; s32_2 = UINT32_MAX;
+    s32_2 = seq32_add(s32_2, SEQ_LIMIT(UINT32_MAX));
+    TEST_ASSERT_EQUAL_INT(-1, seq32_compare(s32_1, s32_2));
+}
+
+static void test_seq32_custom_space_less_than(void)
+{
+    s32_1 = 0; s32_2 = 0;
+    s32_2 = seq32_incs(s32_2, ((1ULL << 20) - 1));
+    TEST_ASSERT_EQUAL_INT(-1, seq32_compares(s32_1, s32_2, ((1ULL << 20) - 1)));
+    s32_1 = ((1ULL << 20) - 1); s32_2 = ((1ULL << 20) - 1);
+    s32_2 = seq32_adds(s32_2, SEQ_LIMIT(((1ULL << 20) - 1)), ((1ULL << 20) - 1));
+    TEST_ASSERT_EQUAL_INT(-1, seq32_compares(s32_1, s32_2, ((1ULL << 20) - 1)));
+}
+
+static void test_seq32_greater_than(void)
+{
+    s32_1 = 0; s32_2 = 0;
+    s32_2 = seq32_add(s32_2, (SEQ_LIMIT(UINT32_MAX)));
+    s32_2 = seq32_add(s32_2, 2);
+    TEST_ASSERT_EQUAL_INT(1, seq32_compare(s32_1, s32_2));
+}
+
+static void test_seq32_custom_space_greater_than(void)
+{
+    s32_1 = 0; s32_2 = 0;
+    s32_2 = seq32_adds(s32_2, SEQ_LIMIT(((1ULL << 20) - 1)), ((1ULL << 20) - 1));
+    s32_2 = seq32_adds(s32_2, 2, ((1ULL << 20) - 1));
+    TEST_ASSERT_EQUAL_INT(1, seq32_compares(s32_1, s32_2, ((1ULL << 20) - 1)));
+}
+
+static void test_seq32_add(void)
+{
+    s32_1 = 0; s32_2 = 0;
+    TEST_ASSERT_EQUAL_INT(0, seq32_add(s32_1, 0));
+    s32_1 = seq32_add(s32_1, 0);
+    TEST_ASSERT_EQUAL_INT(0, seq32_compare(s32_1, s32_2));
+    TEST_ASSERT_EQUAL_INT(s32_2, seq32_add(s32_2, SEQ_LIMIT(UINT32_MAX) + 1));
+    s32_1 = UINT32_MAX; s32_2 = UINT32_MAX;
+    TEST_ASSERT_EQUAL_INT((seq32_t)(s32_1 + SEQ_LIMIT(UINT32_MAX)),
+                    seq32_add(s32_1, SEQ_LIMIT(UINT32_MAX)));
+}
+
+static void test_seq32_custom_space_add(void)
+{
+    s32_1 = 0; s32_2 = 0;
+    TEST_ASSERT_EQUAL_INT(0, seq32_adds(s32_1, 0, ((1ULL << 20) - 1)));
+    s32_1 = seq32_adds(s32_1, 0, ((1ULL << 20) - 1));
+    TEST_ASSERT_EQUAL_INT(0, seq32_compares(s32_1, s32_2, ((1ULL << 20) - 1)));
+    TEST_ASSERT_EQUAL_INT(s32_2, seq32_adds(s32_2, SEQ_LIMIT(((1ULL << 20) - 1)) + 1,
+                            ((1ULL << 20) - 1)));
+    s32_1 = ((1ULL << 20) - 1); s32_2 = ((1ULL << 20) - 1);
+    TEST_ASSERT_EQUAL_INT((s32_1 + SEQ_LIMIT(((1ULL << 20) - 1))) % (((1ULL << 20) - 1) + 1),
+            seq32_adds(s32_1, SEQ_LIMIT(((1ULL << 20) - 1)), ((1ULL << 20) - 1)));
+}
+
+static void test_seq32_compare_undefined(void)
+{
+    s32_1 = 0; s32_2 = SEQ_LIMIT(UINT32_MAX) + 1;
+    TEST_ASSERT_EQUAL_INT(-EINVAL, seq32_compare(s32_1, s32_2));
+
+    s32_1 = (0 + 2); s32_2 = (SEQ_LIMIT(UINT32_MAX) + 1 + 2);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, seq32_compare(s32_1, s32_2));
+}
+
+static void test_seq32_custom_space_compare_undefined(void)
+{
+    s32_1 = 0; s32_2 = SEQ_LIMIT(((1ULL << 20) - 1)) + 1;
+    TEST_ASSERT_EQUAL_INT(-EINVAL, seq32_compares(s32_1, s32_2, ((1ULL << 20) - 1)));
+
+    s32_1 = (0 + 2); s32_2 = (SEQ_LIMIT(((1ULL << 20) - 1)) + 1 + 2);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, seq32_compares(s32_1, s32_2, ((1ULL << 20) - 1)));
+}
+
+/* --------------------------------------- seq64_t tests --------------------------------------- */
+static void test_seq64_equal(void)
+{
+    s64_1 = 0; s64_2 = 0;
+    TEST_ASSERT_EQUAL_INT(0, seq64_compare(s64_1, s64_2));
+    s64_1 = TEST_UINT64; s64_2 = TEST_UINT64;
+    TEST_ASSERT_EQUAL_INT(0, seq64_compare(s64_1, s64_2));
+}
+
+static void test_seq64_custom_space_equal(void)
+{
+    s64_1 = 0; s64_2 = 0;
+    TEST_ASSERT_EQUAL_INT(0, seq64_compares(s64_1, s64_2, ((1ULL << 50) - 1)));
+    s64_1 = 42; s64_2 = 42;
+    TEST_ASSERT_EQUAL_INT(0, seq64_compares(s64_1, s64_2, ((1ULL << 50) - 1)));
+}
+
+static void test_seq64_less_than(void)
+{
+    s64_1 = 0; s64_2 = 0;
+    s64_2 = seq64_inc(s64_2);
+    TEST_ASSERT_EQUAL_INT(-1, seq64_compare(s64_1, s64_2));
+    s64_1 = UINT64_MAX; s64_2 = UINT64_MAX;
+    s64_2 = seq64_add(s64_2, SEQ_LIMIT(UINT64_MAX));
+    TEST_ASSERT_EQUAL_INT(-1, seq64_compare(s64_1, s64_2));
+}
+
+static void test_seq64_custom_space_less_than(void)
+{
+    s64_1 = 0; s64_2 = 0;
+    s64_2 = seq64_incs(s64_2, ((1ULL << 50) - 1));
+    TEST_ASSERT_EQUAL_INT(-1, seq64_compares(s64_1, s64_2, ((1ULL << 50) - 1)));
+    s64_1 = ((1ULL << 50) - 1); s64_2 = ((1ULL << 50) - 1);
+    s64_2 = seq64_adds(s64_2, SEQ_LIMIT(((1ULL << 50) - 1)), ((1ULL << 50) - 1));
+    TEST_ASSERT_EQUAL_INT(-1, seq64_compares(s64_1, s64_2, ((1ULL << 50) - 1)));
+}
+
+static void test_seq64_greater_than(void)
+{
+    s64_1 = 0; s64_2 = 0;
+    s64_2 = seq64_add(s64_2, (SEQ_LIMIT(UINT64_MAX)));
+    s64_2 = seq64_add(s64_2, 2);
+    TEST_ASSERT_EQUAL_INT(1, seq64_compare(s64_1, s64_2));
+}
+
+static void test_seq64_custom_space_greater_than(void)
+{
+    s64_1 = 0; s64_2 = 0;
+    s64_2 = seq64_adds(s64_2, SEQ_LIMIT(((1ULL << 50) - 1)), ((1ULL << 50) - 1));
+    s64_2 = seq64_adds(s64_2, 2, ((1ULL << 50) - 1));
+    TEST_ASSERT_EQUAL_INT(1, seq64_compares(s64_1, s64_2, ((1ULL << 50) - 1)));
+}
+
+static void test_seq64_add(void)
+{
+    s64_1 = 0; s64_2 = 0;
+    TEST_ASSERT_EQUAL_INT(0, seq64_add(s64_1, 0));
+    s64_1 = seq64_add(s64_1, 0);
+    TEST_ASSERT_EQUAL_INT(0, seq64_compare(s64_1, s64_2));
+    TEST_ASSERT_EQUAL_INT(s64_2, seq64_add(s64_2, SEQ_LIMIT(UINT64_MAX) + 1));
+    s64_1 = UINT64_MAX; s64_2 = UINT64_MAX;
+    TEST_ASSERT_EQUAL_INT((seq64_t)(s64_1 + SEQ_LIMIT(UINT64_MAX)),
+                    seq64_add(s64_1, SEQ_LIMIT(UINT64_MAX)));
+}
+
+static void test_seq64_custom_space_add(void)
+{
+    s64_1 = 0; s64_2 = 0;
+    TEST_ASSERT_EQUAL_INT(0, seq64_adds(s64_1, 0, ((1ULL << 50) - 1)));
+    s64_1 = seq64_adds(s64_1, 0, ((1ULL << 50) - 1));
+    TEST_ASSERT_EQUAL_INT(0, seq64_compares(s64_1, s64_2, ((1ULL << 50) - 1)));
+    TEST_ASSERT_EQUAL_INT(s64_2, seq64_adds(s64_2, SEQ_LIMIT(((1ULL << 50) - 1)) + 1,
+                            ((1ULL << 50) - 1)));
+    s64_1 = ((1ULL << 50) - 1); s64_2 = ((1ULL << 50) - 1);
+    TEST_ASSERT_EQUAL_INT((s64_1 + SEQ_LIMIT(((1ULL << 50) - 1))) % (((1ULL << 50) - 1) + 1),
+            seq64_adds(s64_1, SEQ_LIMIT(((1ULL << 50) - 1)), ((1ULL << 50) - 1)));
+}
+
+static void test_seq64_compare_undefined(void)
+{
+    s64_1 = 0; s64_2 = SEQ_LIMIT(UINT64_MAX) + 1;
+    TEST_ASSERT_EQUAL_INT(-EINVAL, seq64_compare(s64_1, s64_2));
+
+    s64_1 = (0 + 2); s64_2 = (SEQ_LIMIT(UINT64_MAX) + 1 + 2);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, seq64_compare(s64_1, s64_2));
+}
+
+static void test_seq64_custom_space_compare_undefined(void)
+{
+    s64_1 = 0; s64_2 = SEQ_LIMIT(((1ULL << 50) - 1)) + 1;
+    TEST_ASSERT_EQUAL_INT(-EINVAL, seq64_compares(s64_1, s64_2, ((1ULL << 50) - 1)));
+
+    s64_1 = (0 + 2); s64_2 = (SEQ_LIMIT(((1ULL << 50) - 1)) + 1 + 2);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, seq64_compares(s64_1, s64_2, ((1ULL << 50) - 1)));
+}
+
+Test *tests_seq_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_seq8_equal),
+        new_TestFixture(test_seq8_custom_space_equal),
+        new_TestFixture(test_seq8_less_than),
+        new_TestFixture(test_seq8_custom_space_less_than),
+        new_TestFixture(test_seq8_greater_than),
+        new_TestFixture(test_seq8_custom_space_greater_than),
+        new_TestFixture(test_seq8_add),
+        new_TestFixture(test_seq8_custom_space_add),
+        new_TestFixture(test_seq8_compare_undefined),
+        new_TestFixture(test_seq8_custom_space_compare_undefined),
+        new_TestFixture(test_seq16_equal),
+        new_TestFixture(test_seq16_custom_space_equal),
+        new_TestFixture(test_seq16_less_than),
+        new_TestFixture(test_seq16_custom_space_less_than),
+        new_TestFixture(test_seq16_greater_than),
+        new_TestFixture(test_seq16_custom_space_greater_than),
+        new_TestFixture(test_seq16_add),
+        new_TestFixture(test_seq16_custom_space_add),
+        new_TestFixture(test_seq16_compare_undefined),
+        new_TestFixture(test_seq16_custom_space_compare_undefined),
+        new_TestFixture(test_seq32_equal),
+        new_TestFixture(test_seq32_custom_space_equal),
+        new_TestFixture(test_seq32_less_than),
+        new_TestFixture(test_seq32_custom_space_less_than),
+        new_TestFixture(test_seq32_greater_than),
+        new_TestFixture(test_seq32_custom_space_greater_than),
+        new_TestFixture(test_seq32_add),
+        new_TestFixture(test_seq32_custom_space_add),
+        new_TestFixture(test_seq32_compare_undefined),
+        new_TestFixture(test_seq32_custom_space_compare_undefined),
+        new_TestFixture(test_seq64_equal),
+        new_TestFixture(test_seq64_custom_space_equal),
+        new_TestFixture(test_seq64_less_than),
+        new_TestFixture(test_seq64_custom_space_less_than),
+        new_TestFixture(test_seq64_greater_than),
+        new_TestFixture(test_seq64_custom_space_greater_than),
+        new_TestFixture(test_seq64_add),
+        new_TestFixture(test_seq64_custom_space_add),
+        new_TestFixture(test_seq64_compare_undefined),
+        new_TestFixture(test_seq64_custom_space_compare_undefined),
+    };
+
+    EMB_UNIT_TESTCALLER(seq_tests, set_up, NULL, fixtures);
+
+    return (Test *)&seq_tests;
+}
+
+void tests_seq(void)
+{
+    TESTS_RUN(tests_seq_tests());
+}
+/** @} */

--- a/tests/unittests/tests-seq/tests-seq.h
+++ b/tests/unittests/tests-seq/tests-seq.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2015 Cenk Gündoğan <cnkgndgn@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for Serial Number Arthmetics
+ *
+ * @author      Cenk Gündoğan <cnkgndgn@gmail.com>
+ */
+#ifndef TESTS_SEQ_H_
+#define TESTS_SEQ_H_
+
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Entry point of the test suite
+ */
+void tests_seq(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_SEQ_H_ */
+/** @} */


### PR DESCRIPTION
This PR introduces serial number arithmetic as described in [RFC1982](https://tools.ietf.org/html/rfc1982).

While [RFC1982](https://tools.ietf.org/html/rfc1982) deals with sequence numbers of any size, I concentrate more on the "natural" cases, which include 8-bit, 16-bit, 32-bit and 64-bit. Therefore, and to have a type-safe arithmetic, `seqno[8,16,32,64]_t` and the appropriate `compare` and `addition` operations have been defined.

Do you think this handling of sequence numbers is too over-engineered?

RPL is using this kind of sequence number operations and the old implementation did use macros like in the following:
```
#define NG_RPL_COUNTER_MAX                 (255)
#define NG_RPL_COUNTER_LOWER_REGION        (127)
#define NG_RPL_COUNTER_SEQ_WINDOW          (16)
#define NG_RPL_COUNTER_INIT                (NG_RPL_COUNTER_MAX - NG_RPL_COUNTER_SEQ_WINDOW + 1)

static inline uint8_t NG_RPL_COUNTER_INCREMENT(uint8_t counter)
{
    return ((counter > NG_RPL_COUNTER_LOWER_REGION) ?
            ((counter == NG_RPL_COUNTER_MAX) ? counter = 0 : ++counter) :
            ((counter == NG_RPL_COUNTER_LOWER_REGION) ? counter = 0 : ++counter));
}

static inline bool NG_RPL_COUNTER_IS_INIT(uint8_t counter)
{
    return (counter > NG_RPL_COUNTER_LOWER_REGION);
}

static inline bool NG_RPL_COUNTER_GREATER_THAN_LOCAL(uint8_t A, uint8_t B)
{
    return (((A < B) && (NG_RPL_COUNTER_LOWER_REGION + 1 - B + A < NG_RPL_COUNTER_SEQ_WINDOW))
            || ((A > B) && (A - B < NG_RPL_COUNTER_SEQ_WINDOW)));
}

static inline bool NG_RPL_COUNTER_GREATER_THAN(uint8_t A, uint8_t B)
{
    return ((A > NG_RPL_COUNTER_LOWER_REGION) ? ((B > NG_RPL_COUNTER_LOWER_REGION) ?
                NG_RPL_COUNTER_GREATER_THAN_LOCAL(A, B) : 0) :
            ((B > NG_RPL_COUNTER_LOWER_REGION) ? 1 : NG_RPL_COUNTER_GREATER_THAN_LOCAL(A, B)));
}
```

I believing extracting the logic into a separate header file (like proposed in this PR) and making things type-safe is actually the way to go..