### PR TITLE
tests: fib: remove redundant write

### DIFF
--- a/tests/unittests/tests-fib/tests-fib.c
+++ b/tests/unittests/tests-fib/tests-fib.c
@@ -668,7 +668,6 @@ static void test_fib_17_get_entry_set(void)
     TEST_ASSERT_EQUAL_INT(10, arr_size);
     arr_size = 20;
 
-    memset(prefix,0, addr_buf_size);
     snprintf(prefix, addr_buf_size, "Test address 0");
 
     ret = fib_get_destination_set((uint8_t *)prefix, addr_buf_size-1, &arr_dst[0], &arr_size);
@@ -678,7 +677,6 @@ static void test_fib_17_get_entry_set(void)
     TEST_ASSERT_EQUAL_INT(20, arr_size);
     arr_size = 20;
 
-    memset(prefix,0, addr_buf_size);
     snprintf(prefix, addr_buf_size, "Test address");
 
     ret = fib_get_destination_set((uint8_t *)prefix, addr_buf_size-1, &arr_dst[0], &arr_size);


### PR DESCRIPTION
Found this with `cppcheck`. Not sure if this is correct, but it looks to me like it is since the following usages always bound it to at most `addr_buf_size` so zeroing the bytes before hand is redundant.