### PR TITLE
ipv6: more efficient check for global addresses

### DIFF
--- a/sys/include/net/ng_ipv6/addr.h
+++ b/sys/include/net/ng_ipv6/addr.h
@@ -256,20 +256,6 @@ static inline bool ng_ipv6_addr_is_loopback(const ng_ipv6_addr_t *addr)
 }
 
 /**
- * @brief   Check if @p addr is global unicast address.
- *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.4">
- *          RFC 4291, section 2.5.4
- *      </a>
- *
- * @param[in] addr  An IPv6 address.
- *
- * @return  true, if @p addr is global unicast address,
- * @return  false, otherwise.
- */
-bool ng_ipv6_addr_is_global_unicast(const ng_ipv6_addr_t *addr);
-
-/**
  * @brief   Checks if @p addr is a IPv4-compatible IPv6 address.
  *
  * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.5.1">
@@ -385,6 +371,38 @@ static inline bool ng_ipv6_addr_is_unique_local_unicast(const ng_ipv6_addr_t *ad
 {
     return ((addr->u8[0] == 0xfc) || (addr->u8[0] == 0xfd));
 }
+
+/**
+ * @brief   Check if @p addr is global unicast address.
+ *
+ * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.4">
+ *          RFC 4291, section 2.5.4
+ *      </a>
+ *
+ * @param[in] addr  An IPv6 address.
+ *
+ * @return  true, if @p addr is global unicast address,
+ * @return  false, otherwise.
+ */
+static inline bool ng_ipv6_addr_is_global(const ng_ipv6_addr_t *addr)
+{
+    /* first check for multicast with global scope */
+    if (ng_ipv6_addr_is_multicast(addr)) {
+        return ((addr->u8[1] & 0x0f) == NG_IPV6_ADDR_MCAST_SCP_GLOBAL);
+    }
+    else {
+        /* for unicast check if: */
+        /* - not unspecific or loopback */
+        return (!((addr->u64[0].u64 == 0) &&
+                    ((byteorder_ntohll(addr->u64[1]) & (0xfffffffffffffffe)) == 0)) &&
+                /* - not link-local */
+                (byteorder_ntohll(addr->u64[0]) != 0xfe80000000000000) &&
+                /* - not site-local */
+                ((byteorder_ntohs(addr->u16[0]) & 0xffc0) !=
+                 NG_IPV6_ADDR_SITE_LOCAL_PREFIX));
+    }
+}
+
 
 /**
  * @brief   Check if @p addr is solicited-node multicast address.

--- a/sys/net/network_layer/ng_ipv6/addr/ng_ipv6_addr.c
+++ b/sys/net/network_layer/ng_ipv6/addr/ng_ipv6_addr.c
@@ -77,20 +77,6 @@ void ng_ipv6_addr_init_prefix(ng_ipv6_addr_t *out, const ng_ipv6_addr_t *prefix,
         out->u8[bytes] |= (prefix->u8[bytes] & mask);
     }
 }
-
-
-bool ng_ipv6_addr_is_global_unicast(const ng_ipv6_addr_t *addr)
-{
-    return (!(ng_ipv6_addr_is_unique_local_unicast(addr)) &&
-            !(ng_ipv6_addr_is_unspecified(addr)) &&
-            !(ng_ipv6_addr_is_loopback(addr)) &&
-            !(ng_ipv6_addr_is_ipv4_compat(addr)) &&
-            !(ng_ipv6_addr_is_ipv4_mapped(addr)) &&
-            !(ng_ipv6_addr_is_site_local(addr)) &&
-            !(ng_ipv6_addr_is_link_local(addr)) &&
-            !(ng_ipv6_addr_is_multicast(addr)));
-}
-
 /**
  * @}
  */

--- a/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
+++ b/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
@@ -115,17 +115,17 @@ static void test_ipv6_addr_is_unspecified_unspecified(void)
     TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_unspecified(&a));
 }
 
-static void test_ipv6_addr_is_global_unicast_is_link_local(void)
+static void test_ipv6_addr_is_global_is_link_local(void)
 {
     ng_ipv6_addr_t a = { {
             0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_global_unicast(&a));
+    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_global(&a));
 }
 
-static void test_ipv6_addr_is_global_unicast1(void)
+static void test_ipv6_addr_is_global1(void)
 {
     /* riot-os.org has IPv6 address 2a01:4f8:151:64::11 */
     ng_ipv6_addr_t a = { {
@@ -133,17 +133,37 @@ static void test_ipv6_addr_is_global_unicast1(void)
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11
     }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_global_unicast(&a));
+    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_global(&a));
 }
 
-static void test_ipv6_addr_is_global_unicast2(void)
+static void test_ipv6_addr_is_global2(void)
 {
     ng_ipv6_addr_t a = { {
             0xaf, 0xfe, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xbe, 0xef, 0xca, 0xfe, 0x12, 0x34, 0xab, 0xcd
     }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_global_unicast(&a));
+    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_global(&a));
+}
+
+static void test_ipv6_addr_is_global_multicast_not_global(void)
+{
+    ng_ipv6_addr_t a = { {
+            0xff, 0x15, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+            0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+        }
+    };
+    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_global(&a));
+}
+
+static void test_ipv6_addr_is_global_multicast(void)
+{
+    ng_ipv6_addr_t a = { {
+            0xff, 0x1e, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+            0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+        }
+    };
+    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_global(&a));
 }
 
 static void test_ipv6_addr_is_ipv4_compat_not_ipv4_compat1(void)
@@ -974,9 +994,11 @@ Test *tests_ipv6_addr_tests(void)
         new_TestFixture(test_ipv6_addr_equal_equal),
         new_TestFixture(test_ipv6_addr_is_unspecified_not_unspecified),
         new_TestFixture(test_ipv6_addr_is_unspecified_unspecified),
-        new_TestFixture(test_ipv6_addr_is_global_unicast_is_link_local),
-        new_TestFixture(test_ipv6_addr_is_global_unicast1),
-        new_TestFixture(test_ipv6_addr_is_global_unicast2),
+        new_TestFixture(test_ipv6_addr_is_global_is_link_local),
+        new_TestFixture(test_ipv6_addr_is_global1),
+        new_TestFixture(test_ipv6_addr_is_global2),
+        new_TestFixture(test_ipv6_addr_is_global_multicast_not_global),
+        new_TestFixture(test_ipv6_addr_is_global_multicast),
         new_TestFixture(test_ipv6_addr_is_ipv4_compat_not_ipv4_compat1),
         new_TestFixture(test_ipv6_addr_is_ipv4_compat_not_ipv4_compat2),
         new_TestFixture(test_ipv6_addr_is_ipv4_compat_ipv4_compat),


### PR DESCRIPTION
Changed the purpose of the function to check for address of global scope in general, not limited to unicast any more. Also removed the unnecessary checks for embedded IPv4 address and ULAs (RFC 4291 says: "Some special-purpose subtypes of Global Unicast addresses that contain embedded IPv4 addresses (for the purposes of IPv4-IPv6 interoperation) are described in Section 2.5.5." and RFC 4193 says "By default, the scope of these addresses [ULAs] is global.")