### PR TITLE
ipv6_addr: remove ng_ prefix

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -70,7 +70,7 @@ ifneq (,$(filter ng_sixlowpan,$(USEMODULE)))
 endif
 
 ifneq (,$(filter ng_sixlowpan_ctx,$(USEMODULE)))
-  USEMODULE += ng_ipv6_addr
+  USEMODULE += ipv6_addr
   USEMODULE += vtimer
 endif
 
@@ -130,7 +130,7 @@ endif
 
 ifneq (,$(filter ng_ipv6,$(USEMODULE)))
   USEMODULE += inet_csum
-  USEMODULE += ng_ipv6_addr
+  USEMODULE += ipv6_addr
   USEMODULE += ng_ipv6_hdr
   USEMODULE += ng_ipv6_nc
   USEMODULE += ng_ipv6_netif
@@ -138,11 +138,11 @@ ifneq (,$(filter ng_ipv6,$(USEMODULE)))
 endif
 
 ifneq (,$(filter ng_ipv6_nc,$(USEMODULE)))
-  USEMODULE += ng_ipv6_addr
+  USEMODULE += ipv6_addr
 endif
 
 ifneq (,$(filter ng_ipv6_netif,$(USEMODULE)))
-  USEMODULE += ng_ipv6_addr
+  USEMODULE += ipv6_addr
   USEMODULE += ng_netif
 endif
 

--- a/examples/ng_networking/udp.c
+++ b/examples/ng_networking/udp.c
@@ -36,11 +36,11 @@ static void send(char *addr_str, char *port_str, char *data)
     uint8_t port[2];
     uint16_t tmp;
     ng_pktsnip_t *payload, *udp, *ip;
-    ng_ipv6_addr_t addr;
+    ipv6_addr_t addr;
     ng_netreg_entry_t *sendto;
 
     /* parse destination address */
-    if (ng_ipv6_addr_from_str(&addr, addr_str) == NULL) {
+    if (ipv6_addr_from_str(&addr, addr_str) == NULL) {
         puts("Error: unable to parse destination address");
         return;
     }

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -25,8 +25,8 @@ endif
 ifneq (,$(filter ng_ipv6,$(USEMODULE)))
     DIRS += net/network_layer/ng_ipv6
 endif
-ifneq (,$(filter ng_ipv6_addr,$(USEMODULE)))
-    DIRS += net/network_layer/ng_ipv6/addr
+ifneq (,$(filter ipv6_addr,$(USEMODULE)))
+    DIRS += net/network_layer/ipv6/addr
 endif
 ifneq (,$(filter ng_ipv6_ext,$(USEMODULE)))
     DIRS += net/network_layer/ng_ipv6/ext

--- a/sys/include/net/ipv6.h
+++ b/sys/include/net/ipv6.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_ipv6    IPv6
+ * @ingroup     net
+ * @brief       Provides types and helper functions related to Internet Protocol
+ *              version 6 (IPv6)
+ * @see <a href="http://tools.ietf.org/html/rfc2460">
+ *          RFC 2460
+ *      </a> et al.
+ * @{
+ *
+ * @file
+ * @brief   IPv6 include gathering header.
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+#ifndef IPV6_H_
+#define IPV6_H_
+
+#include "ipv6/addr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* IPV6_H_ */
+/** @} */

--- a/sys/include/net/ipv6/addr.h
+++ b/sys/include/net/ipv6/addr.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    net_ng_ipv6_addr    IPv6 addresses
- * @ingroup     net_ng_ipv6
+ * @defgroup    net_ipv6_addr    IPv6 addresses
+ * @ingroup     net_ipv6
  * @brief       IPv6 address architecture
  *
  * @see <a href="http://tools.ietf.org/html/rfc4291">
@@ -24,8 +24,8 @@
  */
 
 
-#ifndef NG_IPV6_ADDR_H_
-#define NG_IPV6_ADDR_H_
+#ifndef IPV6_ADDR_H_
+#define IPV6_ADDR_H_
 
 #include <stdbool.h>
 
@@ -38,12 +38,12 @@ extern "C" {
 /**
  * @brief   Length of an IPv6 address in bit.
  */
-#define NG_IPV6_ADDR_BIT_LEN        (128)
+#define IPV6_ADDR_BIT_LEN           (128)
 
 /**
  * @brief   Maximum length of an IPv6 address as string.
  */
-#define NG_IPV6_ADDR_MAX_STR_LEN    (sizeof("ffff:ffff:ffff:ffff:" \
+#define IPV6_ADDR_MAX_STR_LEN       (sizeof("ffff:ffff:ffff:ffff:" \
                                             "ffff:ffff:255.255.255.255"))
 
 /**
@@ -57,7 +57,7 @@ extern "C" {
  *       href="http://tools.ietf.org/html/rfc3879">SLDEP</a>. They are only
  *       defined here for the distinction of global unicast addresses.
  */
-#define NG_IPV6_ADDR_SITE_LOCAL_PREFIX  (0xFEC0)
+#define IPV6_ADDR_SITE_LOCAL_PREFIX (0xfec0)
 
 /**
  * @brief Data type to represent an IPv6 address.
@@ -67,7 +67,7 @@ typedef union {
     network_uint16_t u16[8];    /**< divided by 8 16-bit words. */
     network_uint32_t u32[4];    /**< divided by 4 32-bit words. */
     network_uint64_t u64[2];    /**< divided by 2 64-bit words. */
-} ng_ipv6_addr_t;
+} ipv6_addr_t;
 
 /**
  * @brief   Static initializer for the unspecified IPv6 address (::)
@@ -76,7 +76,10 @@ typedef union {
  *          RFC 4291, section 2.5.2
  *      </a>
  */
-#define NG_IPV6_ADDR_UNSPECIFIED {{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }}
+#define IPV6_ADDR_UNSPECIFIED               {{ 0x00, 0x00, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x00 }}
 
 /**
  * @brief   Static initializer for the loopback IPv6 address (::1)
@@ -85,8 +88,10 @@ typedef union {
  *          RFC 4291, section 2.5.3
  *      </a>
  */
-#define NG_IPV6_ADDR_LOOPBACK {{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }}
-
+#define IPV6_ADDR_LOOPBACK                  {{ 0x00, 0x00, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x01 }}
 /**
  * @brief   Static initializer for the interface-local all nodes multicast IPv6
  *          address (ff01::1)
@@ -95,8 +100,10 @@ typedef union {
  *          RFC 4291, section 2.7
  *      </a>
  */
-#define NG_IPV6_ADDR_ALL_NODES_IF_LOCAL {{ 0xff, 0x01, 0, 0, 0, 0, 0, 0, \
-                                           0, 0, 0, 0, 0, 0, 0, 1 }}
+#define IPV6_ADDR_ALL_NODES_IF_LOCAL        {{ 0xff, 0x01, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x01 }}
 
 /**
  * @brief   Static initializer for the link-local all nodes multicast IPv6
@@ -106,8 +113,10 @@ typedef union {
  *          RFC 4291, section 2.7
  *      </a>
  */
-#define NG_IPV6_ADDR_ALL_NODES_LINK_LOCAL {{ 0xff, 0x02, 0, 0, 0, 0, 0, 0, \
-                                             0, 0, 0, 0, 0, 0, 0, 1 }}
+#define IPV6_ADDR_ALL_NODES_LINK_LOCAL      {{ 0xff, 0x02, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x01 }}
 
 /**
  * @brief   Static initializer for the interface-local all routers multicast IPv6
@@ -117,8 +126,10 @@ typedef union {
  *          RFC 4291, section 2.7
  *      </a>
  */
-#define NG_IPV6_ADDR_ALL_ROUTERS_IF_LOCAL {{ 0xff, 0x01, 0, 0, 0, 0, 0, 0, \
-                                             0, 0, 0, 0, 0, 0, 0, 2 }}
+#define IPV6_ADDR_ALL_ROUTERS_IF_LOCAL      {{ 0xff, 0x01, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x02 }}
 
 /**
  * @brief   Static initializer for the link-local all routers multicast IPv6
@@ -128,8 +139,10 @@ typedef union {
  *          RFC 4291, section 2.7
  *      </a>
  */
-#define NG_IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL {{ 0xff, 0x02, 0, 0, 0, 0, 0, 0, \
-                                               0, 0, 0, 0, 0, 0, 0, 2 }}
+#define IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL    {{ 0xff, 0x02, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x02 }}
 
 
 /**
@@ -140,68 +153,73 @@ typedef union {
  *          RFC 4291, section 2.7
  *      </a>
  */
-#define NG_IPV6_ADDR_ALL_ROUTERS_SITE_LOCAL {{ 0xff, 0x05, 0, 0, 0, 0, 0, 0, \
-                                               0, 0, 0, 0, 0, 0, 0, 2 }}
+#define IPV6_ADDR_ALL_ROUTERS_SITE_LOCAL    {{ 0xff, 0x05, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x00, \
+                                               0x00, 0x00, 0x00, 0x02 }}
 
 /**
+ * @name    Multicast address flags
  * @brief   Values for the flag field in multicast addresses.
+ * @{
  *
  * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7">
  *          RFC 4291, section 2.7
  *      </a>
  */
-typedef enum {
-    /**
-     * @brief   The address is transient, i.e. not well-known, permanantly
-     *          assigned address by IANA.
-     */
-    NG_IPV6_ADDR_MCAST_FLAG_TRANSIENT = 0x01,
-
-    /**
-     * @brief   The address is based on a network prefix
-     *
-     * @see <a href="http://tools.ietf.org/html/rfc3306#section-4">
-     *          RFC 3306, section 4
-     *      </a>
-     */
-    NG_IPV6_ADDR_MCAST_FLAG_PREFIX_BASED = 0x02,
-
-    /**
-     * @brief   The address embeds the address on the rendezvous point
-     *
-     * @see <a href="http://tools.ietf.org/html/rfc3956#section-3">
-     *          RFC 3956, section 3
-     *      </a>
-     */
-    NG_IPV6_ADDR_MCAST_FLAG_EMBED_ON_RP = 0x04,
-} ng_ipv6_addr_mcast_flag_t;
+/**
+ * @brief   The address is transient, i.e. not well-known, permanantly
+ *          assigned address by IANA.
+ */
+#define IPV6_ADDR_MCAST_FLAG_TRANSIENT      (0x01)
 
 /**
+ * @brief   The address is based on a network prefix
+ *
+ * @see <a href="http://tools.ietf.org/html/rfc3306#section-4">
+ *          RFC 3306, section 4
+ *      </a>
+ */
+#define IPV6_ADDR_MCAST_FLAG_PREFIX_BASED   (0x02)
+
+/**
+ * @brief   The address embeds the address on the rendezvous point
+ *
+ * @see <a href="http://tools.ietf.org/html/rfc3956#section-3">
+ *          RFC 3956, section 3
+ *      </a>
+ */
+#define IPV6_ADDR_MCAST_FLAG_EMBED_ON_RP    (0x04)
+/** @} */
+
+/**
+ * @name    Multicast address scopes
  * @brief   Values for the scope field in multicast addresses.
+ * @{
  *
  * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7">
  *          RFC 4291, section 2.7
  *      </a>
  */
-typedef enum {
-    NG_IPV6_ADDR_MCAST_SCP_IF_LOCAL    = 0x1,      /**< interface-local scope */
-    NG_IPV6_ADDR_MCAST_SCP_LINK_LOCAL  = 0x2,      /**< link-local scope */
-    /**
-     * @brief realm-local scope
-     *
-     * @see <a href="http://tools.ietf.org/html/rfc7346#section-3">
-     *          RFC 7346, section 3
-     *      </a> and
-     *      <a href="http://tools.ietf.org/html/rfc7346#section-5">
-     *          RFC 7346, section 5
-     *      </a> and
-     */
-    NG_IPV6_ADDR_MCAST_SCP_REALM_LOCAL = 0x3,
-    NG_IPV6_ADDR_MCAST_SCP_ADMIN_LOCAL = 0x4,      /**< admin-local scope */
-    NG_IPV6_ADDR_MCAST_SCP_SITE_LOCAL  = 0x5,      /**< site-local scope */
-    NG_IPV6_ADDR_MCAST_SCP_ORG_LOCAL   = 0x8,      /**< organization-local scope */
-    NG_IPV6_ADDR_MCAST_SCP_GLOBAL      = 0xe,      /**< global scope */
-} ng_ipv6_addr_mcast_scp_t;
+#define IPV6_ADDR_MCAST_SCP_IF_LOCAL        (0x1)   /**< interface-local scope */
+#define IPV6_ADDR_MCAST_SCP_LINK_LOCAL      (0x2)   /**< link-local scope */
+
+/**
+ * @brief realm-local scope
+ *
+ * @see <a href="http://tools.ietf.org/html/rfc7346#section-3">
+ *          RFC 7346, section 3
+ *      </a> and
+ *      <a href="http://tools.ietf.org/html/rfc7346#section-5">
+ *          RFC 7346, section 5
+ *      </a> and
+ */
+#define IPV6_ADDR_MCAST_SCP_REALM_LOCAL (0x3)
+#define IPV6_ADDR_MCAST_SCP_ADMIN_LOCAL (0x4)      /**< admin-local scope */
+#define IPV6_ADDR_MCAST_SCP_SITE_LOCAL  (0x5)      /**< site-local scope */
+#define IPV6_ADDR_MCAST_SCP_ORG_LOCAL   (0x8)      /**< organization-local scope */
+#define IPV6_ADDR_MCAST_SCP_GLOBAL      (0xe)      /**< global scope */
+/** @} */
 
 /**
  * @brief   Checks if two IPv6 addresses are equal.
@@ -212,8 +230,7 @@ typedef enum {
  * @return  true, if @p a and @p b are equal
  * @return  false, otherwise.
  */
-static inline bool ng_ipv6_addr_equal(const ng_ipv6_addr_t *a,
-                                      const ng_ipv6_addr_t *b)
+static inline bool ipv6_addr_equal(const ipv6_addr_t *a, const ipv6_addr_t *b)
 {
     return (a->u64[0].u64 == b->u64[0].u64) &&
            (a->u64[1].u64 == b->u64[1].u64);
@@ -231,7 +248,7 @@ static inline bool ng_ipv6_addr_equal(const ng_ipv6_addr_t *a,
  * @return  true, if @p addr is unspecified address
  * @return  false, otherwise.
  */
-static inline bool ng_ipv6_addr_is_unspecified(const ng_ipv6_addr_t *addr)
+static inline bool ipv6_addr_is_unspecified(const ipv6_addr_t *addr)
 {
     return (addr->u64[0].u64 == 0) &&
            (addr->u64[1].u64 == 0);
@@ -249,7 +266,7 @@ static inline bool ng_ipv6_addr_is_unspecified(const ng_ipv6_addr_t *addr)
  * @return  true, if @p addr is loopback address,
  * @return  false, otherwise.
  */
-static inline bool ng_ipv6_addr_is_loopback(const ng_ipv6_addr_t *addr)
+static inline bool ipv6_addr_is_loopback(const ipv6_addr_t *addr)
 {
     return (addr->u64[0].u64 == 0) &&
            (byteorder_ntohll(addr->u64[1]) == 1);
@@ -267,7 +284,7 @@ static inline bool ng_ipv6_addr_is_loopback(const ng_ipv6_addr_t *addr)
  * @return  true, if @p addr is an IPv4-compatible IPv6 address,
  * @return  false, otherwise.
  */
-static inline bool ng_ipv6_addr_is_ipv4_compat(const ng_ipv6_addr_t *addr)
+static inline bool ipv6_addr_is_ipv4_compat(const ipv6_addr_t *addr)
 {
     return (addr->u64[0].u64 == 0) &&
            (addr->u32[2].u32 == 0);
@@ -285,11 +302,11 @@ static inline bool ng_ipv6_addr_is_ipv4_compat(const ng_ipv6_addr_t *addr)
  * @return  true, if @p addr is an IPv4-compatible IPv6 address,
  * @return  false, otherwise.
  */
-static inline bool ng_ipv6_addr_is_ipv4_mapped(const ng_ipv6_addr_t *addr)
+static inline bool ipv6_addr_is_ipv4_mapped(const ipv6_addr_t *addr)
 {
     return ((addr->u64[0].u64 == 0) &&
             (addr->u16[4].u16 == 0) &&
-            (addr->u16[5].u16 == 0xFFFF));
+            (addr->u16[5].u16 == 0xffff));
 }
 
 /**
@@ -304,7 +321,7 @@ static inline bool ng_ipv6_addr_is_ipv4_mapped(const ng_ipv6_addr_t *addr)
  * @return  true, if @p addr is multicast address,
  * @return  false, otherwise.
  */
-static inline bool ng_ipv6_addr_is_multicast(const ng_ipv6_addr_t *addr)
+static inline bool ipv6_addr_is_multicast(const ipv6_addr_t *addr)
 {
     return (addr->u8[0] == 0xff);
 }
@@ -324,11 +341,11 @@ static inline bool ng_ipv6_addr_is_multicast(const ng_ipv6_addr_t *addr)
  * @return  true, if @p addr is link-local address,
  * @return  false, otherwise.
  */
-static inline bool ng_ipv6_addr_is_link_local(const ng_ipv6_addr_t *addr)
+static inline bool ipv6_addr_is_link_local(const ipv6_addr_t *addr)
 {
     return (byteorder_ntohll(addr->u64[0]) == 0xfe80000000000000) ||
-           (ng_ipv6_addr_is_multicast(addr) &&
-            (addr->u8[1] & 0x0f) == NG_IPV6_ADDR_MCAST_SCP_LINK_LOCAL);
+           (ipv6_addr_is_multicast(addr) &&
+            (addr->u8[1] & 0x0f) == IPV6_ADDR_MCAST_SCP_LINK_LOCAL);
 }
 
 /**
@@ -347,12 +364,12 @@ static inline bool ng_ipv6_addr_is_link_local(const ng_ipv6_addr_t *addr)
  * @return  true, if @p addr is a site-local unicast address,
  * @return  false, otherwise.
  */
-static inline bool ng_ipv6_addr_is_site_local(const ng_ipv6_addr_t *addr)
+static inline bool ipv6_addr_is_site_local(const ipv6_addr_t *addr)
 {
-    return (((byteorder_ntohs(addr->u16[0]) & 0xFFC0) ==
-             NG_IPV6_ADDR_SITE_LOCAL_PREFIX) ||
-            (ng_ipv6_addr_is_multicast(addr) &&
-            (addr->u8[1] & 0x0f) == NG_IPV6_ADDR_MCAST_SCP_SITE_LOCAL));
+    return (((byteorder_ntohs(addr->u16[0]) & 0xffc0) ==
+             IPV6_ADDR_SITE_LOCAL_PREFIX) ||
+            (ipv6_addr_is_multicast(addr) &&
+             (addr->u8[1] & 0x0f) == IPV6_ADDR_MCAST_SCP_SITE_LOCAL));
 }
 
 /**
@@ -367,7 +384,7 @@ static inline bool ng_ipv6_addr_is_site_local(const ng_ipv6_addr_t *addr)
  * @return  true, if @p addr is unique local unicast address,
  * @return  false, otherwise.
  */
-static inline bool ng_ipv6_addr_is_unique_local_unicast(const ng_ipv6_addr_t *addr)
+static inline bool ipv6_addr_is_unique_local_unicast(const ipv6_addr_t *addr)
 {
     return ((addr->u8[0] == 0xfc) || (addr->u8[0] == 0xfd));
 }
@@ -384,22 +401,22 @@ static inline bool ng_ipv6_addr_is_unique_local_unicast(const ng_ipv6_addr_t *ad
  * @return  true, if @p addr is global unicast address,
  * @return  false, otherwise.
  */
-static inline bool ng_ipv6_addr_is_global(const ng_ipv6_addr_t *addr)
+static inline bool ipv6_addr_is_global(const ipv6_addr_t *addr)
 {
     /* first check for multicast with global scope */
-    if (ng_ipv6_addr_is_multicast(addr)) {
-        return ((addr->u8[1] & 0x0f) == NG_IPV6_ADDR_MCAST_SCP_GLOBAL);
+    if (ipv6_addr_is_multicast(addr)) {
+        return ((addr->u8[1] & 0x0f) == IPV6_ADDR_MCAST_SCP_GLOBAL);
     }
     else {
         /* for unicast check if: */
         /* - not unspecific or loopback */
         return (!((addr->u64[0].u64 == 0) &&
-                    ((byteorder_ntohll(addr->u64[1]) & (0xfffffffffffffffe)) == 0)) &&
+                  ((byteorder_ntohll(addr->u64[1]) & (0xfffffffffffffffe)) == 0)) &&
                 /* - not link-local */
                 (byteorder_ntohll(addr->u64[0]) != 0xfe80000000000000) &&
                 /* - not site-local */
                 ((byteorder_ntohs(addr->u16[0]) & 0xffc0) !=
-                 NG_IPV6_ADDR_SITE_LOCAL_PREFIX));
+                 IPV6_ADDR_SITE_LOCAL_PREFIX));
     }
 }
 
@@ -416,7 +433,7 @@ static inline bool ng_ipv6_addr_is_global(const ng_ipv6_addr_t *addr)
  * @return  true, if @p addr is solicited-node multicast address,
  * @return  false, otherwise.
  */
-static inline bool ng_ipv6_addr_is_solicited_node(const ng_ipv6_addr_t *addr)
+static inline bool ipv6_addr_is_solicited_node(const ipv6_addr_t *addr)
 {
     return (byteorder_ntohll(addr->u64[0]) == 0xff02000000000000) &&
            (byteorder_ntohl(addr->u32[2]) == 1) &&
@@ -433,7 +450,7 @@ static inline bool ng_ipv6_addr_is_solicited_node(const ng_ipv6_addr_t *addr)
  *
  * @return  The number of bits @p a and @p b match in their prefix
  */
-uint8_t ng_ipv6_addr_match_prefix(const ng_ipv6_addr_t *a, const ng_ipv6_addr_t *b);
+uint8_t ipv6_addr_match_prefix(const ipv6_addr_t *a, const ipv6_addr_t *b);
 
 /**
  * @brief   Sets IPv6 address @p out with the first @p bits taken
@@ -444,8 +461,7 @@ uint8_t ng_ipv6_addr_match_prefix(const ng_ipv6_addr_t *a, const ng_ipv6_addr_t 
  * @param[in]   bits    Bits to be copied from @p prefix to @p out
  *                      (set to 128 when greater than 128).
  */
-void ng_ipv6_addr_init_prefix(ng_ipv6_addr_t *out, const ng_ipv6_addr_t *prefix,
-                              uint8_t bits);
+void ipv6_addr_init_prefix(ipv6_addr_t *out, const ipv6_addr_t *prefix, uint8_t bits);
 
 /**
  * @brief   Sets @p addr dynamically to the unspecified IPv6 address (::).
@@ -456,7 +472,7 @@ void ng_ipv6_addr_init_prefix(ng_ipv6_addr_t *out, const ng_ipv6_addr_t *prefix,
  *
  * @param[in,out] addr  The address to set.
  */
-static inline void ng_ipv6_addr_set_unspecified(ng_ipv6_addr_t *addr)
+static inline void ipv6_addr_set_unspecified(ipv6_addr_t *addr)
 {
     addr->u64[0].u64 = 0;
     addr->u64[1].u64 = 0;
@@ -471,7 +487,7 @@ static inline void ng_ipv6_addr_set_unspecified(ng_ipv6_addr_t *addr)
  *
  * @param[in,out] addr  The address to set.
  */
-static inline void ng_ipv6_addr_set_loopback(ng_ipv6_addr_t *addr)
+static inline void ipv6_addr_set_loopback(ipv6_addr_t *addr)
 {
     addr->u64[0].u64 = 0;
     addr->u64[1] = byteorder_htonll(1);
@@ -486,7 +502,7 @@ static inline void ng_ipv6_addr_set_loopback(ng_ipv6_addr_t *addr)
  *
  * @param[in,out] addr  The address to set.
  */
-static inline void ng_ipv6_addr_set_link_local_prefix(ng_ipv6_addr_t *addr)
+static inline void ipv6_addr_set_link_local_prefix(ipv6_addr_t *addr)
 {
     addr->u64[0] = byteorder_htonll(0xfe80000000000000);
 }
@@ -502,7 +518,7 @@ static inline void ng_ipv6_addr_set_link_local_prefix(ng_ipv6_addr_t *addr)
  * @param[in,out] addr  The address to set.
  * @param[in] iid       The interface ID as integer to set.
  */
-static inline void ng_ipv6_addr_set_iid(ng_ipv6_addr_t *addr, uint64_t iid)
+static inline void ipv6_addr_set_iid(ipv6_addr_t *addr, uint64_t iid)
 {
     addr->u64[1] = byteorder_htonll(iid);
 }
@@ -518,7 +534,7 @@ static inline void ng_ipv6_addr_set_iid(ng_ipv6_addr_t *addr, uint64_t iid)
  * @param[in,out] addr  The address to set.
  * @param[in] iid       The interface ID as array of at least length 8 to set.
  */
-static inline void ng_ipv6_addr_set_aiid(ng_ipv6_addr_t *addr, uint8_t *iid)
+static inline void ipv6_addr_set_aiid(ipv6_addr_t *addr, uint8_t *iid)
 {
     addr->u8[8]  = iid[0];
     addr->u8[9]  = iid[1];
@@ -541,9 +557,8 @@ static inline void ng_ipv6_addr_set_aiid(ng_ipv6_addr_t *addr, uint8_t *iid)
  * @param[in] flags     The multicast address' flags.
  * @param[in] scope     The multicast address' scope.
  */
-static inline void ng_ipv6_addr_set_multicast(ng_ipv6_addr_t *addr,
-        ng_ipv6_addr_mcast_flag_t flags,
-        ng_ipv6_addr_mcast_scp_t scope)
+static inline void ipv6_addr_set_multicast(ipv6_addr_t *addr, unsigned int flags,
+                                           unsigned int scope)
 {
     addr->u8[0] = 0xff;
     addr->u8[1] = (((uint8_t)flags) << 4) | (((uint8_t) scope) & 0x0f);
@@ -560,8 +575,7 @@ static inline void ng_ipv6_addr_set_multicast(ng_ipv6_addr_t *addr,
  * @param[in,out] addr  The address to set.
  * @param[in] scope     The multicast address' scope.
  */
-static inline void ng_ipv6_addr_set_all_nodes_multicast(ng_ipv6_addr_t *addr,
-        ng_ipv6_addr_mcast_scp_t scope)
+static inline void ipv6_addr_set_all_nodes_multicast(ipv6_addr_t *addr, unsigned int scope)
 {
     addr->u64[0] = byteorder_htonll(0xff00000000000000);
     addr->u8[1] = (uint8_t)scope;
@@ -579,8 +593,7 @@ static inline void ng_ipv6_addr_set_all_nodes_multicast(ng_ipv6_addr_t *addr,
  * @param[in,out] addr  The address to set.
  * @param[in] scope     The multicast address' scope.
  */
-static inline void ng_ipv6_addr_set_all_routers_multicast(ng_ipv6_addr_t *addr,
-        ng_ipv6_addr_mcast_scp_t scope)
+static inline void ipv6_addr_set_all_routers_multicast(ipv6_addr_t *addr, unsigned int scope)
 {
     addr->u64[0] = byteorder_htonll(0xff00000000000000);
     addr->u8[1] = (uint8_t)scope;
@@ -598,8 +611,7 @@ static inline void ng_ipv6_addr_set_all_routers_multicast(ng_ipv6_addr_t *addr,
  * @param[out]  out   Is set to solicited-node address of this node.
  * @param[in]   in    The IPv6 address the solicited-node address.
  */
-static inline void ng_ipv6_addr_set_solicited_nodes(ng_ipv6_addr_t *out,
-        const ng_ipv6_addr_t *in)
+static inline void ipv6_addr_set_solicited_nodes(ipv6_addr_t *out, const ipv6_addr_t *in)
 {
     out->u64[0] = byteorder_htonll(0xff02000000000000);
     out->u32[2] = byteorder_htonl(1);
@@ -623,8 +635,7 @@ static inline void ng_ipv6_addr_set_solicited_nodes(ng_ipv6_addr_t *out,
  * @return  NULL, if @p result_len was smaller than needed
  * @return  NULL, if @p result or @p addr was NULL
  */
-char *ng_ipv6_addr_to_str(char *result, const ng_ipv6_addr_t *addr,
-                          uint8_t result_len);
+char *ipv6_addr_to_str(char *result, const ipv6_addr_t *addr, uint8_t result_len);
 
 /**
  * @brief   Converts an IPv6 address string representation to a byte-represented
@@ -641,13 +652,13 @@ char *ng_ipv6_addr_to_str(char *result, const ng_ipv6_addr_t *addr,
  * @return  NULL, if @p addr was malformed
  * @return  NULL, if @p result or @p addr was NULL
  */
-ng_ipv6_addr_t *ng_ipv6_addr_from_str(ng_ipv6_addr_t *result, const char *addr);
+ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* NG_IPV6_ADDR_H_ */
+#endif /* IPV6_ADDR_H_ */
 /**
  * @}
  */

--- a/sys/include/net/ng_ipv6.h
+++ b/sys/include/net/ng_ipv6.h
@@ -32,7 +32,7 @@
 #include "net/ng_netbase.h"
 #include "thread.h"
 
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6.h"
 #include "net/ng_ipv6/ext.h"
 #include "net/ng_ipv6/hdr.h"
 #include "net/ng_ipv6/nc.h"

--- a/sys/include/net/ng_ipv6/ext/rh.h
+++ b/sys/include/net/ng_ipv6/ext/rh.h
@@ -20,7 +20,7 @@
 #ifndef NG_IPV6_EXT_RH_H_
 #define NG_IPV6_EXT_RH_H_
 
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/ng_ipv6/hdr.h"
 
 #ifdef __cplusplus
@@ -51,7 +51,7 @@ typedef struct __attribute__((packed)) {
  * @return  next hop on success, on success
  * @return  NULL, if not found.
  */
-ng_ipv6_addr_t *ng_ipv6_ext_rh_next_hop(ng_ipv6_hdr_t *ipv6);
+ipv6_addr_t *ng_ipv6_ext_rh_next_hop(ng_ipv6_hdr_t *ipv6);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/ng_ipv6/hdr.h
+++ b/sys/include/net/ng_ipv6/hdr.h
@@ -23,7 +23,7 @@
 #include <stdbool.h>
 
 #include "byteorder.h"
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/inet_csum.h"
 #include "net/ng_pkt.h"
 
@@ -92,8 +92,8 @@ typedef struct __attribute__((packed)) {
     network_uint16_t len;   /**< payload length of this packet. */
     uint8_t nh;             /**< type of next header in this packet. */
     uint8_t hl;             /**< hop limit for this packet. */
-    ng_ipv6_addr_t src;     /**< source address of this packet. */
-    ng_ipv6_addr_t dst;     /**< destination address of this packet. */
+    ipv6_addr_t src;        /**< source address of this packet. */
+    ipv6_addr_t dst;        /**< destination address of this packet. */
 } ng_ipv6_hdr_t;
 
 /**
@@ -295,7 +295,7 @@ static inline uint16_t ng_ipv6_hdr_inet_csum(uint16_t sum, ng_ipv6_hdr_t *hdr,
     }
 
     return inet_csum(sum + len + prot_num, hdr->src.u8,
-                     (2 * sizeof(ng_ipv6_addr_t)));
+                     (2 * sizeof(ipv6_addr_t)));
 }
 
 /**
@@ -308,11 +308,11 @@ static inline uint16_t ng_ipv6_hdr_inet_csum(uint16_t sum, ng_ipv6_hdr_t *hdr,
  * @param[in] src       Source address for the header. Can be NULL if not
  *                      known or required.
  * @param[in] src_len   Length of @p src. Can be 0 if not known or required or
- *                      must be `sizeof(ng_ipv6_addr_t)`.
+ *                      must be `sizeof(ipv6_addr_t)`.
  * @param[in] dst       Destination address for the header. Can be NULL if not
  *                      known or required.
  * @param[in] dst_len   Length of @p dst. Can be 0 if not known or required or
- *                      must be `sizeof(ng_ipv6_addr_t)`.
+ *                      must be `sizeof(ipv6_addr_t)`.
  *
  * @return  The an IPv6 header in packet buffer on success.
  * @return  NULL on error.

--- a/sys/include/net/ng_ipv6/nc.h
+++ b/sys/include/net/ng_ipv6/nc.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 
 #include "kernel_types.h"
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/ng_netif.h"
 #include "net/ng_pktqueue.h"
 #include "vtimer.h"
@@ -119,7 +119,7 @@ extern "C" {
  */
 typedef struct {
     ng_pktqueue_t *pkts;                    /**< Packets waiting for address resolution */
-    ng_ipv6_addr_t ipv6_addr;               /**< IPv6 address of the neighbor */
+    ipv6_addr_t ipv6_addr;                  /**< IPv6 address of the neighbor */
     uint8_t l2_addr[NG_IPV6_NC_L2_ADDR_MAX];/**< Link layer address of the neighbor */
     uint8_t l2_addr_len;                    /**< Length of ng_ipv6_nc_t::l2_addr */
     uint8_t flags;                          /**< Flags as defined above */
@@ -167,7 +167,7 @@ void ng_ipv6_nc_init(void);
  * @return  Pointer to new neighbor cache entry on success
  * @return  NULL, on failure
  */
-ng_ipv6_nc_t *ng_ipv6_nc_add(kernel_pid_t iface, const ng_ipv6_addr_t *ipv6_addr,
+ng_ipv6_nc_t *ng_ipv6_nc_add(kernel_pid_t iface, const ipv6_addr_t *ipv6_addr,
                              const void *l2_addr, size_t l2_addr_len, uint8_t flags);
 
 /**
@@ -178,7 +178,7 @@ ng_ipv6_nc_t *ng_ipv6_nc_add(kernel_pid_t iface, const ng_ipv6_addr_t *ipv6_addr
  *                          interfaces.
  * @param[in] ipv6_addr     IPv6 address of the neighbor
  */
-void ng_ipv6_nc_remove(kernel_pid_t iface, const ng_ipv6_addr_t *ipv6_addr);
+void ng_ipv6_nc_remove(kernel_pid_t iface, const ipv6_addr_t *ipv6_addr);
 
 /**
  * @brief   Searches for any neighbor cache entry fitting the @p ipv6_addr.
@@ -191,7 +191,7 @@ void ng_ipv6_nc_remove(kernel_pid_t iface, const ng_ipv6_addr_t *ipv6_addr);
  * @return  The neighbor cache entry, if one is found.
  * @return  NULL, if none is found.
  */
-ng_ipv6_nc_t *ng_ipv6_nc_get(kernel_pid_t iface, const ng_ipv6_addr_t *ipv6_addr);
+ng_ipv6_nc_t *ng_ipv6_nc_get(kernel_pid_t iface, const ipv6_addr_t *ipv6_addr);
 
 /**
  * @brief   Gets next entry in neighbor cache after @p prev.
@@ -273,7 +273,7 @@ static inline bool ng_ipv6_nc_is_reachable(const ng_ipv6_nc_t *entry)
  * @return  The neighbor cache entry, if one is found.
  * @return  NULL, if none is found.
  */
-ng_ipv6_nc_t *ng_ipv6_nc_still_reachable(const ng_ipv6_addr_t *ipv6_addr);
+ng_ipv6_nc_t *ng_ipv6_nc_still_reachable(const ipv6_addr_t *ipv6_addr);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/ng_ipv6/netif.h
+++ b/sys/include/net/ng_ipv6/netif.h
@@ -28,7 +28,7 @@
 #include "kernel_macros.h"
 #include "kernel_types.h"
 #include "mutex.h"
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "vtimer.h"
 
 #ifdef __cplusplus
@@ -153,7 +153,7 @@ extern "C" {
  * @brief   Type to represent an IPv6 address registered to an interface.
  */
 typedef struct {
-    ng_ipv6_addr_t addr;    /**< The address data */
+    ipv6_addr_t addr;       /**< The address data */
     uint8_t flags;          /**< flags */
     uint8_t prefix_len;     /**< length of the prefix of the address */
     /**
@@ -290,10 +290,9 @@ static inline void ng_ipv6_netif_set_rtr_adv(ng_ipv6_netif_t *netif, bool enable
  *
  * @param[in] netif The interface.
  * @param[in] dst   The address of the neighboring router.
- *                  May be NULL for @ref NG_IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL.
+ *                  May be NULL for @ref IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL.
  */
-static inline void ng_ipv6_netif_sol_router(ng_ipv6_netif_t *netif,
-        ng_ipv6_addr_t *dst)
+static inline void ng_ipv6_netif_sol_router(ng_ipv6_netif_t *netif, ipv6_addr_t *dst)
 {
     (void)netif;    /* TODO */
     (void)dst;
@@ -321,8 +320,8 @@ static inline void ng_ipv6_netif_sol_router(ng_ipv6_netif_t *netif,
  * @return  The address on the interface, on success.
  * @return  NULL, on failure
  */
-ng_ipv6_addr_t *ng_ipv6_netif_add_addr(kernel_pid_t pid, const ng_ipv6_addr_t *addr,
-                                       uint8_t prefix_len, uint8_t flags);
+ipv6_addr_t *ng_ipv6_netif_add_addr(kernel_pid_t pid, const ipv6_addr_t *addr, uint8_t prefix_len,
+                                    uint8_t flags);
 
 /**
  * @brief   Remove an address from the interface.
@@ -331,7 +330,7 @@ ng_ipv6_addr_t *ng_ipv6_netif_add_addr(kernel_pid_t pid, const ng_ipv6_addr_t *a
  *                      it will be removed from all interfaces.
  * @param[in] addr      An address you want to remove from interface.
  */
-void ng_ipv6_netif_remove_addr(kernel_pid_t pid, ng_ipv6_addr_t *addr);
+void ng_ipv6_netif_remove_addr(kernel_pid_t pid, ipv6_addr_t *addr);
 
 /**
  * @brief   Removes all addresses from the interface.
@@ -349,8 +348,7 @@ void ng_ipv6_netif_reset_addr(kernel_pid_t pid);
  * @return  The PID to the interface the address is registered to.
  * @return  KERNEL_PID_UNDEF, if the address can not be found on any interface.
  */
-kernel_pid_t ng_ipv6_netif_find_by_addr(ng_ipv6_addr_t **out,
-                                        const ng_ipv6_addr_t *addr);
+kernel_pid_t ng_ipv6_netif_find_by_addr(ipv6_addr_t **out, const ipv6_addr_t *addr);
 
 /**
  * @brief   Searches for an address on an interface.
@@ -362,8 +360,7 @@ kernel_pid_t ng_ipv6_netif_find_by_addr(ng_ipv6_addr_t **out,
  * @return  NULL, if the address can not be found on the interface.
  * @return  NULL, if @p pid is no interface.
  */
-ng_ipv6_addr_t *ng_ipv6_netif_find_addr(kernel_pid_t pid,
-                                        const ng_ipv6_addr_t *addr);
+ipv6_addr_t *ng_ipv6_netif_find_addr(kernel_pid_t pid, const ipv6_addr_t *addr);
 
 /**
  * @brief   Searches for the first address matching a prefix best on all
@@ -376,8 +373,7 @@ ng_ipv6_addr_t *ng_ipv6_netif_find_addr(kernel_pid_t pid,
  * @return  KERNEL_PID_UNDEF, if no matching address can not be found on any
  *          interface.
  */
-kernel_pid_t ng_ipv6_netif_find_by_prefix(ng_ipv6_addr_t **out,
-        const ng_ipv6_addr_t *prefix);
+kernel_pid_t ng_ipv6_netif_find_by_prefix(ipv6_addr_t **out, const ipv6_addr_t *prefix);
 
 /**
  * @brief   Searches for the first address matching a prefix best on an
@@ -390,8 +386,7 @@ kernel_pid_t ng_ipv6_netif_find_by_prefix(ng_ipv6_addr_t **out,
  * @return  NULL, if no matching address can be found on the interface.
  * @return  NULL, if @p pid is no interface.
  */
-ng_ipv6_addr_t *ng_ipv6_netif_match_prefix(kernel_pid_t pid,
-        const ng_ipv6_addr_t *prefix);
+ipv6_addr_t *ng_ipv6_netif_match_prefix(kernel_pid_t pid, const ipv6_addr_t *prefix);
 
 /**
  * @brief   Searches for the best address on an interface usable as a
@@ -405,7 +400,7 @@ ng_ipv6_addr_t *ng_ipv6_netif_match_prefix(kernel_pid_t pid,
  * @return  NULL, if no matching address can be found on the interface.
  * @return  NULL, if @p pid is no interface.
  */
-ng_ipv6_addr_t *ng_ipv6_netif_find_best_src_addr(kernel_pid_t pid, const ng_ipv6_addr_t *dest);
+ipv6_addr_t *ng_ipv6_netif_find_best_src_addr(kernel_pid_t pid, const ipv6_addr_t *dest);
 
 /**
  * @brief   Get interface specific meta-information on an address
@@ -426,7 +421,7 @@ ng_ipv6_addr_t *ng_ipv6_netif_find_best_src_addr(kernel_pid_t pid, const ng_ipv6
  *
  * @return  Interface specific meta-information on @p addr
  */
-static inline ng_ipv6_netif_addr_t *ng_ipv6_netif_addr_get(const ng_ipv6_addr_t *addr)
+static inline ng_ipv6_netif_addr_t *ng_ipv6_netif_addr_get(const ipv6_addr_t *addr)
 {
     return container_of(addr, ng_ipv6_netif_addr_t, addr);
 }
@@ -451,7 +446,7 @@ static inline ng_ipv6_netif_addr_t *ng_ipv6_netif_addr_get(const ng_ipv6_addr_t 
  * @return true, if address is anycast or multicast.
  * @return false, if address is unicast.
  */
-static inline bool ng_ipv6_netif_addr_is_non_unicast(const ng_ipv6_addr_t *addr)
+static inline bool ng_ipv6_netif_addr_is_non_unicast(const ipv6_addr_t *addr)
 {
     return (bool)(container_of(addr, ng_ipv6_netif_addr_t, addr)->flags &
                   NG_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST);

--- a/sys/include/net/ng_ndp.h
+++ b/sys/include/net/ng_ndp.h
@@ -23,7 +23,7 @@
 #include "byteorder.h"
 #include "net/ng_pkt.h"
 #include "net/ng_icmpv6.h"
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/ng_ipv6/nc.h"
 #include "net/ng_ipv6/netif.h"
 
@@ -181,7 +181,7 @@ void ng_ndp_netif_remove(ng_ipv6_netif_t *iface);
  * @return  The resulting ICMPv6 packet on success.
  * @return  NULL, on failure.
  */
-ng_pktsnip_t *ng_ndp_nbr_sol_build(ng_ipv6_addr_t *tgt, ng_pktsnip_t *options);
+ng_pktsnip_t *ng_ndp_nbr_sol_build(ipv6_addr_t *tgt, ng_pktsnip_t *options);
 
 /**
  * @brief   Builds a neighbor advertisement message for sending.
@@ -209,7 +209,7 @@ ng_pktsnip_t *ng_ndp_nbr_sol_build(ng_ipv6_addr_t *tgt, ng_pktsnip_t *options);
  * @return  The resulting ICMPv6 packet on success.
  * @return  NULL, on failure.
  */
-ng_pktsnip_t *ng_ndp_nbr_adv_build(uint8_t flags, ng_ipv6_addr_t *tgt,
+ng_pktsnip_t *ng_ndp_nbr_adv_build(uint8_t flags, ipv6_addr_t *tgt,
                                    ng_pktsnip_t *options);
 
 /**

--- a/sys/include/net/ng_ndp/internal.h
+++ b/sys/include/net/ng_ndp/internal.h
@@ -22,7 +22,7 @@
 #ifndef INTERNAL_H_
 #define INTERNAL_H_
 
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/ng_ndp/types.h"
 
 #ifdef __cplusplus
@@ -41,7 +41,7 @@ extern "C" {
  * @return  Address to a default router.
  * @return  NULL, if the default router list is empty.
  */
-ng_ipv6_addr_t *ng_ndp_internal_default_router(void);
+ipv6_addr_t *ng_ndp_internal_default_router(void);
 
 /**
  * @brief   Sets state of a neighbor cache entry and triggers required actions.
@@ -64,8 +64,8 @@ void ng_ndp_internal_set_state(ng_ipv6_nc_t *nc_entry, uint8_t state);
  * @param[in] dst   Destination address for neighbor solicitation. May not be
  *                  NULL.
  */
-void ng_ndp_internal_send_nbr_sol(kernel_pid_t iface, ng_ipv6_addr_t *tgt,
-                                  ng_ipv6_addr_t *dst);
+void ng_ndp_internal_send_nbr_sol(kernel_pid_t iface, ipv6_addr_t *tgt,
+                                  ipv6_addr_t *dst);
 
 /**
  * @brief   Send precompiled neighbor advertisement.
@@ -80,8 +80,8 @@ void ng_ndp_internal_send_nbr_sol(kernel_pid_t iface, ng_ipv6_addr_t *tgt,
  * @param[in] supply_tl2a   Add target link-layer address option to neighbor
  *                          advertisement if link-layer has addresses.
  */
-void ng_ndp_internal_send_nbr_adv(kernel_pid_t iface, ng_ipv6_addr_t *tgt,
-                                  ng_ipv6_addr_t *dst, bool supply_tl2a);
+void ng_ndp_internal_send_nbr_adv(kernel_pid_t iface, ipv6_addr_t *tgt,
+                                  ipv6_addr_t *dst, bool supply_tl2a);
 
 /**
  * @brief   Handles a SL2A option.

--- a/sys/include/net/ng_ndp/node.h
+++ b/sys/include/net/ng_ndp/node.h
@@ -42,7 +42,7 @@ extern "C" {
  *          would be long.
  */
 kernel_pid_t ng_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
-                                         kernel_pid_t iface, ng_ipv6_addr_t *dst,
+                                         kernel_pid_t iface, ipv6_addr_t *dst,
                                          ng_pktsnip_t *pkt);
 
 #ifdef __cplusplus

--- a/sys/include/net/ng_ndp/types.h
+++ b/sys/include/net/ng_ndp/types.h
@@ -142,7 +142,7 @@ typedef struct __attribute__((packed)) {
     uint8_t code;           /**< message code */
     network_uint16_t csum;  /**< checksum */
     network_uint32_t resv;  /**< reserved field */
-    ng_ipv6_addr_t tgt;     /**< target address */
+    ipv6_addr_t tgt;        /**< target address */
 } ng_ndp_nbr_sol_t;
 
 /**
@@ -159,7 +159,7 @@ typedef struct __attribute__((packed)) {
     network_uint16_t csum;  /**< checksum */
     uint8_t flags;          /**< flags */
     uint8_t resv[3];        /**< reserved fields */
-    ng_ipv6_addr_t tgt;     /**< target address */
+    ipv6_addr_t tgt;        /**< target address */
 } ng_ndp_nbr_adv_t;
 
 /**
@@ -175,8 +175,8 @@ typedef struct __attribute__((packed)) {
     uint8_t code;           /**< message code */
     network_uint16_t csum;  /**< checksum */
     network_uint32_t resv;  /**< reserved field */
-    ng_ipv6_addr_t tgt;     /**< target address */
-    ng_ipv6_addr_t dst;     /**< destination address */
+    ipv6_addr_t tgt;        /**< target address */
+    ipv6_addr_t dst;        /**< destination address */
 } ng_ndp_redirect_t;
 
 /**
@@ -209,7 +209,7 @@ typedef struct __attribute__((packed)) {
     network_uint32_t valid_ltime;   /**< valid lifetime */
     network_uint32_t pref_ltime;    /**< preferred lifetime */
     network_uint32_t resv;          /**< reserved field */
-    ng_ipv6_addr_t prefix;          /**< prefix */
+    ipv6_addr_t prefix;             /**< prefix */
 } ng_ndp_opt_pi_t;
 
 /**

--- a/sys/include/net/ng_rpl/srh.h
+++ b/sys/include/net/ng_rpl/srh.h
@@ -23,7 +23,7 @@
 #ifndef NG_RPL_SRH_H_
 #define NG_RPL_SRH_H_
 
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/ng_ipv6/ext.h"
 
 #ifdef __cplusplus
@@ -59,7 +59,7 @@ typedef struct __attribute__((packed)) {
  * @return  next hop, on success
  * @return  NULL, if not found.
  */
-ng_ipv6_addr_t *ng_rpl_srh_next_hop(ng_rpl_srh_t *rh);
+ipv6_addr_t *ng_rpl_srh_next_hop(ng_rpl_srh_t *rh);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/ng_sixlowpan/ctx.h
+++ b/sys/include/net/ng_sixlowpan/ctx.h
@@ -32,7 +32,7 @@
 #include <inttypes.h>
 #include <stdbool.h>
 
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,7 +56,7 @@ extern "C" {
  * @brief   Entry in the 6LoWPAN context buffer.
  */
 typedef struct {
-    ng_ipv6_addr_t prefix;  /**< The prefix associated to this context. */
+    ipv6_addr_t prefix;     /**< The prefix associated to this context. */
     uint8_t prefix_len;     /**< Length of ng_sixlowpan_ctx_t::prefix in bit. */
     /**
      * @brief   4-bit flags, 4-bit Context ID.
@@ -85,7 +85,7 @@ typedef struct {
  * @return  The context associated with the best prefix for @p addr.
  * @return  NULL if there is no such context.
  */
-ng_sixlowpan_ctx_t *ng_sixlowpan_ctx_lookup_addr(const ng_ipv6_addr_t *addr);
+ng_sixlowpan_ctx_t *ng_sixlowpan_ctx_lookup_addr(const ipv6_addr_t *addr);
 
 /**
  * @brief   Gets context by ID.
@@ -112,7 +112,7 @@ ng_sixlowpan_ctx_t *ng_sixlowpan_ctx_lookup_id(uint8_t id);
  * @return  The new context on success.
  * @return  NULL, on error or on removal.
  */
-ng_sixlowpan_ctx_t *ng_sixlowpan_ctx_update(uint8_t id, const ng_ipv6_addr_t *prefix,
+ng_sixlowpan_ctx_t *ng_sixlowpan_ctx_update(uint8_t id, const ipv6_addr_t *prefix,
                                             uint8_t prefix_len, uint16_t ltime,
                                             bool comp);
 

--- a/sys/include/net/ng_zep.h
+++ b/sys/include/net/ng_zep.h
@@ -34,7 +34,7 @@
 
 #include "byteorder.h"
 #include "kernel_types.h"
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/ng_nettype.h"
 #include "thread.h"
 
@@ -198,7 +198,7 @@ typedef struct {
     le_uint16_t pan;                /**< the device's PAN ID */
     uint16_t flags;                 /**< the device's option flags */
     uint32_t seq;                   /**< the current sequence number for frames */
-    ng_ipv6_addr_t dst;             /**< destination IPv6 address */
+    ipv6_addr_t dst;                /**< destination IPv6 address */
     uint16_t src_port;              /**< source UDP port */
     uint16_t dst_port;              /**< destination UDP port */
     ng_nettype_t proto;             /**< the target protocol for received packets */
@@ -229,7 +229,7 @@ typedef struct {
  * @return  -ENOTSUP, if @p dst is NULL or unspecified address (::).
  * @return  -EOVERFLOW, if there are too many threads running already
  */
-kernel_pid_t ng_zep_init(ng_zep_t *dev, uint16_t src_port, ng_ipv6_addr_t *dst,
+kernel_pid_t ng_zep_init(ng_zep_t *dev, uint16_t src_port, ipv6_addr_t *dst,
                          uint16_t dst_port);
 
 #ifdef __cplusplus

--- a/sys/include/universal_address.h
+++ b/sys/include/universal_address.h
@@ -113,7 +113,7 @@ int universal_address_compare(universal_address_container_t *entry,
 * @param[in] prefix      pointer to the address for compare
 * @param[in] prefix_size_in_bits the number of bits used for the prefix entry.
 *                                This size MUST be the full address size including trailing '0's,
-*                                e.g. for an ng_ipv6_addr_t it would be sizeof(ng_ipv6_addr_t)
+*                                e.g. for an ipv6_addr_t it would be sizeof(ipv6_addr_t)
 *                                regardless if the stored prefix is < ::/128
 *
 * @return 0 if the entries are equal

--- a/sys/net/application_layer/ng_zep/ng_zep.c
+++ b/sys/net/application_layer/ng_zep/ng_zep.c
@@ -24,7 +24,7 @@
 #include "kernel.h"
 #include "msg.h"
 #include "net/ieee802154.h"
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/ng_ipv6/hdr.h"
 #include "net/ng_netbase.h"
 #include "net/ng_udp.h"
@@ -89,7 +89,7 @@ static size_t _get_frame_hdr_len(uint8_t *mhr);
 ng_pktsnip_t *_make_netif_hdr(uint8_t *mhr);
 static uint16_t _calc_fcs(uint16_t fcs, const uint8_t *frame, uint8_t frame_len);
 
-kernel_pid_t ng_zep_init(ng_zep_t *dev, uint16_t src_port, ng_ipv6_addr_t *dst,
+kernel_pid_t ng_zep_init(ng_zep_t *dev, uint16_t src_port, ipv6_addr_t *dst,
                          uint16_t dst_port)
 {
 #if CPUID_ID_LEN
@@ -107,7 +107,7 @@ kernel_pid_t ng_zep_init(ng_zep_t *dev, uint16_t src_port, ng_ipv6_addr_t *dst,
         return -ENODEV;
     }
 
-    if ((dst == NULL) || (ng_ipv6_addr_is_unspecified(dst))) {
+    if ((dst == NULL) || (ipv6_addr_is_unspecified(dst))) {
         DEBUG("zep: dst (%s) was NULL or unspecified\n", dst);
         return -ENOTSUP;
     }
@@ -250,7 +250,7 @@ static int _send(ng_netdev_t *netdev, ng_pktsnip_t *pkt)
     new_pkt = hdr;
 
     hdr = ng_ipv6_hdr_build(new_pkt, NULL, 0, (uint8_t *) &(dev->dst),
-                            sizeof(ng_ipv6_addr_t));
+                            sizeof(ipv6_addr_t));
 
     if (hdr == NULL) {
         DEBUG("zep: could not allocate IPv6 header in pktbuf\n");

--- a/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
+++ b/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
@@ -28,7 +28,7 @@
 #include "kernel.h"
 #include "net/ng_pktdump.h"
 #include "net/ng_netbase.h"
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/ng_ipv6/hdr.h"
 #include "net/ng_sixlowpan.h"
 #include "net/ng_udp.h"

--- a/sys/net/include/socket_base/socket.h
+++ b/sys/net/include/socket_base/socket.h
@@ -182,7 +182,7 @@ typedef struct __attribute__((packed)) {
     uint8_t     sin6_family;    ///< set to AF_INET6
     uint16_t    sin6_port;      ///< transport layer port number
     uint32_t    sin6_flowinfo;  ///< IPv6 flow information
-    ng_ipv6_addr_t sin6_addr;      ///< IPv6 address
+    ipv6_addr_t sin6_addr;      ///< IPv6 address
 } sockaddr6_t;
 
 /**

--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -33,12 +33,12 @@
 #include "net/fib.h"
 #include "net/fib/table.h"
 
-#ifdef MODULE_NG_IPV6_ADDR
-#include "net/ng_ipv6/addr.h"
-static char addr_str[NG_IPV6_ADDR_MAX_STR_LEN];
+#ifdef MODULE_IPV6_ADDR
+#include "net/ipv6/addr.h"
+static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 #endif
 
-#ifdef MODULE_NG_IPV6_ADDR
+#ifdef MODULE_IPV6_ADDR
     #define NG_FIB_ADDR_PRINT_LEN       39
 #else
     #define NG_FIB_ADDR_PRINT_LEN       32
@@ -646,10 +646,10 @@ static void fib_print_address(universal_address_container_t *entry)
     uint8_t *ret = universal_address_get_address(entry, address, &addr_size);
 
     if (ret == address) {
-#ifdef MODULE_NG_IPV6_ADDR
-        if (addr_size == sizeof(ng_ipv6_addr_t)) {
+#ifdef MODULE_IPV6_ADDR
+        if (addr_size == sizeof(ipv6_addr_t)) {
             printf("%-" NG_FIB_ADDR_PRINT_LENS "s",
-                    ng_ipv6_addr_to_str(addr_str, (ng_ipv6_addr_t *) address, sizeof(addr_str)));
+                    ipv6_addr_to_str(addr_str, (ipv6_addr_t *) address, sizeof(addr_str)));
             return;
         }
 #endif
@@ -661,7 +661,7 @@ static void fib_print_address(universal_address_container_t *entry)
                 printf("  ");
             }
         }
-#ifdef MODULE_NG_IPV6_ADDR
+#ifdef MODULE_IPV6_ADDR
         /* print trailing whitespaces */
         for (size_t i = 0; i < NG_FIB_ADDR_PRINT_LEN - (UNIVERSAL_ADDRESS_SIZE * 2); ++i) {
             printf(" ");

--- a/sys/net/network_layer/ipv6/addr/Makefile
+++ b/sys/net/network_layer/ipv6/addr/Makefile
@@ -1,3 +1,3 @@
-MODULE = ng_ipv6_addr
+MODULE = ipv6_addr
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr.c
@@ -17,9 +17,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 
-uint8_t ng_ipv6_addr_match_prefix(const ng_ipv6_addr_t *a, const ng_ipv6_addr_t *b)
+uint8_t ipv6_addr_match_prefix(const ipv6_addr_t *a, const ipv6_addr_t *b)
 {
     uint8_t prefix_len = 0;
 
@@ -57,8 +57,8 @@ uint8_t ng_ipv6_addr_match_prefix(const ng_ipv6_addr_t *a, const ng_ipv6_addr_t 
     return prefix_len;
 }
 
-void ng_ipv6_addr_init_prefix(ng_ipv6_addr_t *out, const ng_ipv6_addr_t *prefix,
-                              uint8_t bits)
+void ipv6_addr_init_prefix(ipv6_addr_t *out, const ipv6_addr_t *prefix,
+                           uint8_t bits)
 {
     uint8_t bytes;
 

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr_from_str.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr_from_str.c
@@ -31,7 +31,7 @@
 #include <string.h>
 
 #include "byteorder.h"
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 
 #define DEC     "0123456789"
 #define HEX_L   "0123456789abcdef"
@@ -91,7 +91,7 @@ static network_uint32_t *ipv4_addr_from_str(network_uint32_t *result,
 }
 
 /* based on inet_pton6() by Paul Vixie */
-ng_ipv6_addr_t *ng_ipv6_addr_from_str(ng_ipv6_addr_t *result, const char *addr)
+ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr)
 {
     uint8_t *colonp = 0;
     const char *curtok = addr;
@@ -104,7 +104,7 @@ ng_ipv6_addr_t *ng_ipv6_addr_from_str(ng_ipv6_addr_t *result, const char *addr)
         return NULL;
     }
 
-    ng_ipv6_addr_set_unspecified(result);
+    ipv6_addr_set_unspecified(result);
 
     /* Leading :: requires some special handling. */
     if (*addr == ':') {
@@ -145,7 +145,7 @@ ng_ipv6_addr_t *ng_ipv6_addr_from_str(ng_ipv6_addr_t *result, const char *addr)
                 continue;
             }
 
-            if (i > sizeof(ng_ipv6_addr_t)) {
+            if (i > sizeof(ipv6_addr_t)) {
                 return NULL;
             }
 
@@ -156,7 +156,7 @@ ng_ipv6_addr_t *ng_ipv6_addr_from_str(ng_ipv6_addr_t *result, const char *addr)
             continue;
         }
 
-        if (ch == '.' && (i <= sizeof(ng_ipv6_addr_t)) &&
+        if (ch == '.' && (i <= sizeof(ipv6_addr_t)) &&
             ipv4_addr_from_str((network_uint32_t *)(&(result->u8[i])),
                                curtok) != NULL) {
             i += sizeof(network_uint32_t);
@@ -168,7 +168,7 @@ ng_ipv6_addr_t *ng_ipv6_addr_from_str(ng_ipv6_addr_t *result, const char *addr)
     }
 
     if (saw_xdigit) {
-        if (i + sizeof(uint16_t) > sizeof(ng_ipv6_addr_t)) {
+        if (i + sizeof(uint16_t) > sizeof(ipv6_addr_t)) {
             return NULL;
         }
 
@@ -184,14 +184,14 @@ ng_ipv6_addr_t *ng_ipv6_addr_from_str(ng_ipv6_addr_t *result, const char *addr)
         const int32_t n = &(result->u8[i++]) - colonp;
 
         for (int32_t j = 1; j <= n; j++) {
-            result->u8[sizeof(ng_ipv6_addr_t) - j] = colonp[n - j];
+            result->u8[sizeof(ipv6_addr_t) - j] = colonp[n - j];
             colonp[n - j] = 0;
         }
 
-        i = sizeof(ng_ipv6_addr_t);
+        i = sizeof(ipv6_addr_t);
     }
 
-    if (i != sizeof(ng_ipv6_addr_t)) {
+    if (i != sizeof(ipv6_addr_t)) {
         return NULL;
     }
 

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr_to_str.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr_to_str.c
@@ -30,10 +30,10 @@
 #include <string.h>
 
 #include "byteorder.h"
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 
 /* Length of an IPv6 address in 16-bit words */
-#define IPV6_ADDR_WORD_LEN  (sizeof(ng_ipv6_addr_t) / sizeof(uint16_t))
+#define IPV6_ADDR_WORD_LEN  (sizeof(ipv6_addr_t) / sizeof(uint16_t))
 
 #define IPV4_ADDR_MIN_STR_LEN   (sizeof("255.255.255.255"))
 
@@ -75,10 +75,9 @@ static char *ipv4_addr_to_str(char *result, const network_uint32_t *addr,
 }
 
 /* based on inet_ntop6() by Paul Vixie */
-char *ng_ipv6_addr_to_str(char *result, const ng_ipv6_addr_t *addr,
-                          uint8_t result_len)
+char *ipv6_addr_to_str(char *result, const ipv6_addr_t *addr, uint8_t result_len)
 {
-    char tmp[NG_IPV6_ADDR_MAX_STR_LEN], *tp;
+    char tmp[IPV6_ADDR_MAX_STR_LEN], *tp;
     struct {
         int16_t base, len;
     } best = { -1, 0}, cur = { -1, 0};

--- a/sys/net/network_layer/ng_icmpv6/echo/ng_icmpv6_echo.c
+++ b/sys/net/network_layer/ng_icmpv6/echo/ng_icmpv6_echo.c
@@ -82,14 +82,14 @@ void ng_icmpv6_echo_req_handle(kernel_pid_t iface, ng_ipv6_hdr_t *ipv6_hdr,
         return;
     }
 
-    if (ng_ipv6_addr_is_multicast(&ipv6_hdr->dst)) {
+    if (ipv6_addr_is_multicast(&ipv6_hdr->dst)) {
         hdr = ng_ipv6_hdr_build(pkt, NULL, 0, (uint8_t *)&ipv6_hdr->src,
-                                sizeof(ng_ipv6_addr_t));
+                                sizeof(ipv6_addr_t));
     }
     else {
         hdr = ng_ipv6_hdr_build(pkt, (uint8_t *)&ipv6_hdr->dst,
-                                sizeof(ng_ipv6_addr_t), (uint8_t *)&ipv6_hdr->src,
-                                sizeof(ng_ipv6_addr_t));
+                                sizeof(ipv6_addr_t), (uint8_t *)&ipv6_hdr->src,
+                                sizeof(ipv6_addr_t));
     }
 
     if (hdr == NULL) {

--- a/sys/net/network_layer/ng_ipv6/ext/rh/ng_ipv6_ext_rh.c
+++ b/sys/net/network_layer/ng_ipv6/ext/rh/ng_ipv6_ext_rh.c
@@ -18,7 +18,7 @@
 #include "net/ng_rpl/srh.h"
 #include "net/ng_ipv6/ext/rh.h"
 
-ng_ipv6_addr_t *ng_ipv6_ext_rh_next_hop(ng_ipv6_hdr_t *ipv6)
+ipv6_addr_t *ng_ipv6_ext_rh_next_hop(ng_ipv6_hdr_t *ipv6)
 {
     ng_ipv6_ext_rh_t *ext = (ng_ipv6_ext_rh_t *)(ipv6 + 1);
     bool c = true;

--- a/sys/net/network_layer/ng_ipv6/hdr/ng_ipv6_hdr.c
+++ b/sys/net/network_layer/ng_ipv6/hdr/ng_ipv6_hdr.c
@@ -12,7 +12,7 @@
  * @file
  */
 
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/ng_ipv6/hdr.h"
 #include "net/ng_nettype.h"
 #include "net/ng_pktbuf.h"
@@ -21,8 +21,8 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#if ENABLE_DEBUG && defined(MODULE_NG_IPV6_ADDR)
-static char addr_str[NG_IPV6_ADDR_MAX_STR_LEN];
+#if ENABLE_DEBUG && defined(MODULE_IPV6_ADDR)
+static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 #endif
 
 /* For independent testing */
@@ -39,10 +39,10 @@ ng_pktsnip_t *ng_ipv6_hdr_build(ng_pktsnip_t *payload,
     ng_pktsnip_t *ipv6;
     ng_ipv6_hdr_t *hdr;
 
-    if (((src_len != 0) && (src_len != sizeof(ng_ipv6_addr_t))) ||
-        ((dst_len != 0) && (dst_len != sizeof(ng_ipv6_addr_t)))) {
+    if (((src_len != 0) && (src_len != sizeof(ipv6_addr_t))) ||
+        ((dst_len != 0) && (dst_len != sizeof(ipv6_addr_t)))) {
         DEBUG("ipv6_hdr: Address length was not 0 or %zu byte.\n",
-              sizeof(ng_ipv6_addr_t));
+              sizeof(ipv6_addr_t));
         return NULL;
     }
 
@@ -56,31 +56,31 @@ ng_pktsnip_t *ng_ipv6_hdr_build(ng_pktsnip_t *payload,
     hdr = (ng_ipv6_hdr_t *)ipv6->data;
 
     if ((src != NULL) && (src_len != 0)) {
-#ifdef MODULE_NG_IPV6_ADDR
+#ifdef MODULE_IPV6_ADDR
         DEBUG("ipv6_hdr: set packet source to %s\n",
-              ng_ipv6_addr_to_str(addr_str, (ng_ipv6_addr_t *)src,
-                                  sizeof(addr_str)));
+              ipv6_addr_to_str(addr_str, (ipv6_addr_t *)src,
+                               sizeof(addr_str)));
 #endif
         memcpy(&hdr->src, src, src_len);
     }
     else {
         DEBUG("ipv6_hdr: set packet source to ::\n");
-        ng_ipv6_addr_set_unspecified(&hdr->src);
+        ipv6_addr_set_unspecified(&hdr->src);
     }
 
-    memset(&hdr->dst + dst_len, 0, sizeof(ng_ipv6_addr_t) - dst_len);
+    memset(&hdr->dst + dst_len, 0, sizeof(ipv6_addr_t) - dst_len);
 
     if ((dst != NULL) && (dst_len != 0)) {
-#ifdef MODULE_NG_IPV6_ADDR
+#ifdef MODULE_IPV6_ADDR
         DEBUG("ipv6_hdr: set packet destination to %s\n",
-              ng_ipv6_addr_to_str(addr_str, (ng_ipv6_addr_t *)dst,
-                                  sizeof(addr_str)));
+              ipv6_addr_to_str(addr_str, (ipv6_addr_t *)dst,
+                               sizeof(addr_str)));
 #endif
         memcpy(&hdr->dst, dst, dst_len);
     }
     else {
         DEBUG("ipv6_hdr: set packet destination to ::1\n");
-        ng_ipv6_addr_set_loopback(&hdr->dst);
+        ipv6_addr_set_loopback(&hdr->dst);
     }
 
     hdr->v_tc_fl = byteorder_htonl(0x60000000); /* set version, tc and fl in one go*/

--- a/sys/net/network_layer/ng_ipv6/hdr/ng_ipv6_hdr_print.c
+++ b/sys/net/network_layer/ng_ipv6/hdr/ng_ipv6_hdr_print.c
@@ -19,7 +19,7 @@
 
 void ng_ipv6_hdr_print(ng_ipv6_hdr_t *hdr)
 {
-    char addr_str[NG_IPV6_ADDR_MAX_STR_LEN];
+    char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
     if (!ng_ipv6_hdr_is(hdr)) {
         printf("illegal version field: %" PRIu8 "\n", ng_ipv6_hdr_get_version(hdr));
@@ -31,9 +31,9 @@ void ng_ipv6_hdr_print(ng_ipv6_hdr_t *hdr)
     printf("flow label: 0x%05" PRIx32 "\n", ng_ipv6_hdr_get_fl(hdr));
     printf("length: %" PRIu16 "  next header: %" PRIu8 "  hop limit: %" PRIu8 "\n",
            byteorder_ntohs(hdr->len), hdr->nh, hdr->hl);
-    printf("source address: %s\n", ng_ipv6_addr_to_str(addr_str, &hdr->src,
+    printf("source address: %s\n", ipv6_addr_to_str(addr_str, &hdr->src,
             sizeof(addr_str)));
-    printf("destination address: %s\n", ng_ipv6_addr_to_str(addr_str, &hdr->dst,
+    printf("destination address: %s\n", ipv6_addr_to_str(addr_str, &hdr->dst,
             sizeof(addr_str)));
 
 }

--- a/sys/net/network_layer/ng_ndp/node/ng_ndp_node.c
+++ b/sys/net/network_layer/ng_ndp/node/ng_ndp_node.c
@@ -30,7 +30,7 @@
 #include "debug.h"
 
 #if ENABLE_DEBUG
-static char addr_str[NG_IPV6_ADDR_MAX_STR_LEN];
+static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 #endif
 
 static ng_pktqueue_t _pkt_nodes[NG_IPV6_NC_SIZE * 2];
@@ -56,10 +56,10 @@ static ng_pktqueue_t *_alloc_pkt_node(ng_pktsnip_t *pkt)
 }
 
 kernel_pid_t ng_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
-                                         kernel_pid_t iface, ng_ipv6_addr_t *dst,
+                                         kernel_pid_t iface, ipv6_addr_t *dst,
                                          ng_pktsnip_t *pkt)
 {
-    ng_ipv6_addr_t *next_hop_ip = NULL, *prefix = NULL;
+    ipv6_addr_t *next_hop_ip = NULL, *prefix = NULL;
 
 #ifdef MODULE_NG_IPV6_EXT_RH
     next_hop_ip = ng_ipv6_ext_rh_next_hop(hdr);
@@ -67,13 +67,13 @@ kernel_pid_t ng_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
 #ifdef MODULE_FIB
     size_t next_hop_size;
     uint32_t next_hop_flags = 0;
-    ng_ipv6_addr_t next_hop_actual; /* FIB copies address into this variable */
+    ipv6_addr_t next_hop_actual;    /* FIB copies address into this variable */
 
     if ((next_hop_ip == NULL) &&
         (fib_get_next_hop(&iface, next_hop_actual.u8, &next_hop_size,
                           &next_hop_flags, (uint8_t *)dst,
-                          sizeof(ng_ipv6_addr_t), 0) >= 0) &&
-        (next_hop_size == sizeof(ng_ipv6_addr_t))) {
+                          sizeof(ipv6_addr_t), 0) >= 0) &&
+        (next_hop_size == sizeof(ipv6_addr_t))) {
         next_hop_ip = &next_hop_actual;
     }
 
@@ -96,8 +96,8 @@ kernel_pid_t ng_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
 #ifdef MODULE_FIB
             /* We don't care if FIB is full, this is just for efficiency
              * for later sends */
-            fib_add_entry(iface, (uint8_t *)dst, sizeof(ng_ipv6_addr_t), 0,
-                          (uint8_t *)next_hop_ip, sizeof(ng_ipv6_addr_t), 0,
+            fib_add_entry(iface, (uint8_t *)dst, sizeof(ipv6_addr_t), 0,
+                          (uint8_t *)next_hop_ip, sizeof(ipv6_addr_t), 0,
                           FIB_LIFETIME_NO_EXPIRE);
 #endif
         }
@@ -108,8 +108,8 @@ kernel_pid_t ng_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
 #ifdef MODULE_FIB
         /* We don't care if FIB is full, this is just for efficiency for later
          * sends */
-        fib_add_entry(iface, (uint8_t *)dst, sizeof(ng_ipv6_addr_t), 0,
-                      (uint8_t *)next_hop_ip, sizeof(ng_ipv6_addr_t), 0,
+        fib_add_entry(iface, (uint8_t *)dst, sizeof(ipv6_addr_t), 0,
+                      (uint8_t *)next_hop_ip, sizeof(ipv6_addr_t), 0,
                       FIB_LIFETIME_NO_EXPIRE);
 #endif
     }
@@ -119,7 +119,7 @@ kernel_pid_t ng_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
 
         if ((nc_entry != NULL) && ng_ipv6_nc_is_reachable(nc_entry)) {
             DEBUG("ndp node: found reachable neighbor (%s => ",
-                  ng_ipv6_addr_to_str(addr_str, &nc_entry->ipv6_addr, sizeof(addr_str)));
+                  ipv6_addr_to_str(addr_str, &nc_entry->ipv6_addr, sizeof(addr_str)));
             DEBUG("%s)\n",
                   ng_netif_addr_to_str(addr_str, sizeof(addr_str),
                                        nc_entry->l2_addr, nc_entry->l2_addr_len));
@@ -135,7 +135,7 @@ kernel_pid_t ng_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
         }
         else if (nc_entry == NULL) {
             ng_pktqueue_t *pkt_node;
-            ng_ipv6_addr_t dst_sol;
+            ipv6_addr_t dst_sol;
 
             nc_entry = ng_ipv6_nc_add(iface, next_hop_ip, NULL, 0,
                                       NG_IPV6_NC_STATE_INCOMPLETE << NG_IPV6_NC_STATE_POS);
@@ -157,7 +157,7 @@ kernel_pid_t ng_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
             }
 
             /* address resolution */
-            ng_ipv6_addr_set_solicited_nodes(&dst_sol, next_hop_ip);
+            ipv6_addr_set_solicited_nodes(&dst_sol, next_hop_ip);
 
             if (iface == KERNEL_PID_UNDEF) {
                 timex_t t = { 0, NG_NDP_RETRANS_TIMER };

--- a/sys/net/network_layer/ng_sixlowpan/ctx/ng_sixlowpan_ctx.c
+++ b/sys/net/network_layer/ng_sixlowpan/ctx/ng_sixlowpan_ctx.c
@@ -30,7 +30,7 @@ static uint32_t _current_minute(void);
 static void _update_lifetime(uint8_t id);
 
 #if ENABLE_DEBUG
-static char ipv6str[NG_IPV6_ADDR_MAX_STR_LEN];
+static char ipv6str[IPV6_ADDR_MAX_STR_LEN];
 #endif
 
 static inline bool _valid(uint8_t id)
@@ -39,7 +39,7 @@ static inline bool _valid(uint8_t id)
     return (_ctxs[id].prefix_len > 0);
 }
 
-ng_sixlowpan_ctx_t *ng_sixlowpan_ctx_lookup_addr(const ng_ipv6_addr_t *addr)
+ng_sixlowpan_ctx_t *ng_sixlowpan_ctx_lookup_addr(const ipv6_addr_t *addr)
 {
     uint8_t best = 0;
     ng_sixlowpan_ctx_t *res = NULL;
@@ -48,7 +48,7 @@ ng_sixlowpan_ctx_t *ng_sixlowpan_ctx_lookup_addr(const ng_ipv6_addr_t *addr)
 
     for (unsigned int id = 0; id < NG_SIXLOWPAN_CTX_SIZE; id++) {
         if (_valid(id)) {
-            uint8_t match = ng_ipv6_addr_match_prefix(&_ctxs[id].prefix, addr);
+            uint8_t match = ipv6_addr_match_prefix(&_ctxs[id].prefix, addr);
 
             if ((_ctxs[id].prefix_len <= match) && (match > best)) {
                 best = match;
@@ -62,9 +62,9 @@ ng_sixlowpan_ctx_t *ng_sixlowpan_ctx_lookup_addr(const ng_ipv6_addr_t *addr)
 #if ENABLE_DEBUG
     if (res != NULL) {
         DEBUG("6lo ctx: found context (%u, %s/%" PRIu8 ") ", res->id,
-              ng_ipv6_addr_to_str(ipv6str, &res->prefix, sizeof(ipv6str)),
+              ipv6_addr_to_str(ipv6str, &res->prefix, sizeof(ipv6str)),
               res->prefix_len);
-        DEBUG("for address %s\n", ng_ipv6_addr_to_str(ipv6str, addr, sizeof(ipv6str)));
+        DEBUG("for address %s\n", ipv6_addr_to_str(ipv6str, addr, sizeof(ipv6str)));
     }
 #endif
 
@@ -81,7 +81,7 @@ ng_sixlowpan_ctx_t *ng_sixlowpan_ctx_lookup_id(uint8_t id)
 
     if (_valid(id)) {
         DEBUG("6lo ctx: found context (%u, %s/%" PRIu8 ")\n", id,
-              ng_ipv6_addr_to_str(ipv6str, &_ctxs[id].prefix, sizeof(ipv6str)),
+              ipv6_addr_to_str(ipv6str, &_ctxs[id].prefix, sizeof(ipv6str)),
               _ctxs[id].prefix_len);
         mutex_unlock(&_ctx_mutex);
         return &(_ctxs[id]);
@@ -92,7 +92,7 @@ ng_sixlowpan_ctx_t *ng_sixlowpan_ctx_lookup_id(uint8_t id)
     return NULL;
 }
 
-ng_sixlowpan_ctx_t *ng_sixlowpan_ctx_update(uint8_t id, const ng_ipv6_addr_t *prefix,
+ng_sixlowpan_ctx_t *ng_sixlowpan_ctx_update(uint8_t id, const ipv6_addr_t *prefix,
                                             uint8_t prefix_len, uint16_t ltime,
                                             bool comp)
 {
@@ -108,8 +108,8 @@ ng_sixlowpan_ctx_t *ng_sixlowpan_ctx_update(uint8_t id, const ng_ipv6_addr_t *pr
         comp = false;
     }
 
-    if (prefix_len > NG_IPV6_ADDR_BIT_LEN) {
-        _ctxs[id].prefix_len = NG_IPV6_ADDR_BIT_LEN;
+    if (prefix_len > IPV6_ADDR_BIT_LEN) {
+        _ctxs[id].prefix_len = IPV6_ADDR_BIT_LEN;
     }
     else {
         _ctxs[id].prefix_len = prefix_len;
@@ -117,13 +117,12 @@ ng_sixlowpan_ctx_t *ng_sixlowpan_ctx_update(uint8_t id, const ng_ipv6_addr_t *pr
 
     _ctxs[id].flags_id = (comp) ? (NG_SIXLOWPAN_CTX_FLAGS_COMP | id) : id;
 
-    if (!ng_ipv6_addr_equal(&(_ctxs[id].prefix), prefix)) {
-        ng_ipv6_addr_set_unspecified(&(_ctxs[id].prefix));
-        ng_ipv6_addr_init_prefix(&(_ctxs[id].prefix), prefix,
-                                 _ctxs[id].prefix_len);
+    if (!ipv6_addr_equal(&(_ctxs[id].prefix), prefix)) {
+        ipv6_addr_set_unspecified(&(_ctxs[id].prefix));
+        ipv6_addr_init_prefix(&(_ctxs[id].prefix), prefix, _ctxs[id].prefix_len);
     }
     DEBUG("6lo ctx: update context (%u, %s/%" PRIu8 "), lifetime: %" PRIu16 " min\n",
-          id, ng_ipv6_addr_to_str(ipv6str, &_ctxs[id].prefix, sizeof(ipv6str)),
+          id, ipv6_addr_to_str(ipv6str, &_ctxs[id].prefix, sizeof(ipv6str)),
           _ctxs[id].prefix_len, _ctxs[id].ltime);
     _ctx_inval_times[id] = ltime + _current_minute();
 

--- a/sys/net/network_layer/ng_sixlowpan/iphc/ng_sixlowpan_iphc.c
+++ b/sys/net/network_layer/ng_sixlowpan/iphc/ng_sixlowpan_iphc.c
@@ -69,7 +69,7 @@
 #define IPHC_M_DAC_DAM_M_UC_PREFIX  (0x0c)
 
 static inline bool _context_overlaps_iid(ng_sixlowpan_ctx_t *ctx,
-                                         ng_ipv6_addr_t *addr,
+                                         ipv6_addr_t *addr,
                                          eui64_t *iid)
 {
     uint8_t byte_mask[] = {0xff, 0x7f, 0x3f, 0x1f, 0x0f, 0x07, 0x03, 0x01};
@@ -187,13 +187,13 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
             break;
 
         case IPHC_SAC_SAM_64:
-            ng_ipv6_addr_set_link_local_prefix(&ipv6_hdr->src);
+            ipv6_addr_set_link_local_prefix(&ipv6_hdr->src);
             memcpy(ipv6_hdr->src.u8 + 8, iphc_hdr + payload_offset, 8);
             payload_offset += 8;
             break;
 
         case IPHC_SAC_SAM_16:
-            ng_ipv6_addr_set_link_local_prefix(&ipv6_hdr->src);
+            ipv6_addr_set_link_local_prefix(&ipv6_hdr->src);
             ipv6_hdr->src.u32[2] = byteorder_htonl(0x000000ff);
             ipv6_hdr->src.u16[6] = byteorder_htons(0xfe00);
             memcpy(ipv6_hdr->src.u8 + 14, iphc_hdr + payload_offset, 2);
@@ -204,17 +204,17 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
             ieee802154_get_iid((eui64_t *)(&ipv6_hdr->src.u64[1]),
                                ng_netif_hdr_get_src_addr(netif_hdr),
                                netif_hdr->src_l2addr_len);
-            ng_ipv6_addr_set_link_local_prefix(&ipv6_hdr->src);
+            ipv6_addr_set_link_local_prefix(&ipv6_hdr->src);
             break;
 
         case IPHC_SAC_SAM_UNSPEC:
-            ng_ipv6_addr_set_unspecified(&ipv6_hdr->src);
+            ipv6_addr_set_unspecified(&ipv6_hdr->src);
             break;
 
         case IPHC_SAC_SAM_CTX_64:
             memcpy(ipv6_hdr->src.u8 + 8, iphc_hdr + payload_offset, 8);
-            ng_ipv6_addr_init_prefix(&ipv6_hdr->src, &ctx->prefix,
-                                     ctx->prefix_len);
+            ipv6_addr_init_prefix(&ipv6_hdr->src, &ctx->prefix,
+                                  ctx->prefix_len);
             payload_offset += 8;
             break;
 
@@ -222,8 +222,8 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
             ipv6_hdr->src.u32[2] = byteorder_htonl(0x000000ff);
             ipv6_hdr->src.u16[6] = byteorder_htons(0xfe00);
             memcpy(ipv6_hdr->src.u8 + 14, iphc_hdr + payload_offset, 2);
-            ng_ipv6_addr_init_prefix(&ipv6_hdr->src, &ctx->prefix,
-                                     ctx->prefix_len);
+            ipv6_addr_init_prefix(&ipv6_hdr->src, &ctx->prefix,
+                                  ctx->prefix_len);
             payload_offset += 2;
             break;
 
@@ -231,8 +231,8 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
             ieee802154_get_iid((eui64_t *)(&ipv6_hdr->src.u64[1]),
                                ng_netif_hdr_get_src_addr(netif_hdr),
                                netif_hdr->src_l2addr_len);
-            ng_ipv6_addr_init_prefix(&ipv6_hdr->src, &ctx->prefix,
-                                     ctx->prefix_len);
+            ipv6_addr_init_prefix(&ipv6_hdr->src, &ctx->prefix,
+                                  ctx->prefix_len);
             break;
     }
 
@@ -262,13 +262,13 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
             break;
 
         case IPHC_M_DAC_DAM_U_64:
-            ng_ipv6_addr_set_link_local_prefix(&ipv6_hdr->dst);
+            ipv6_addr_set_link_local_prefix(&ipv6_hdr->dst);
             memcpy(ipv6_hdr->dst.u8 + 8, iphc_hdr + payload_offset, 8);
             payload_offset += 8;
             break;
 
         case IPHC_M_DAC_DAM_U_16:
-            ng_ipv6_addr_set_link_local_prefix(&ipv6_hdr->dst);
+            ipv6_addr_set_link_local_prefix(&ipv6_hdr->dst);
             ipv6_hdr->dst.u32[2] = byteorder_htonl(0x000000ff);
             ipv6_hdr->dst.u16[6] = byteorder_htons(0xfe00);
             memcpy(ipv6_hdr->dst.u8 + 14, iphc_hdr + payload_offset, 2);
@@ -279,13 +279,13 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
             ieee802154_get_iid((eui64_t *)(&ipv6_hdr->dst.u64[1]),
                                ng_netif_hdr_get_dst_addr(netif_hdr),
                                netif_hdr->dst_l2addr_len);
-            ng_ipv6_addr_set_link_local_prefix(&ipv6_hdr->dst);
+            ipv6_addr_set_link_local_prefix(&ipv6_hdr->dst);
             break;
 
         case IPHC_M_DAC_DAM_U_CTX_64:
             memcpy(ipv6_hdr->dst.u8 + 8, iphc_hdr + payload_offset, 8);
-            ng_ipv6_addr_init_prefix(&ipv6_hdr->dst, &ctx->prefix,
-                                     ctx->prefix_len);
+            ipv6_addr_init_prefix(&ipv6_hdr->dst, &ctx->prefix,
+                                  ctx->prefix_len);
             payload_offset += 8;
             break;
 
@@ -293,8 +293,8 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
             ipv6_hdr->dst.u32[2] = byteorder_htonl(0x000000ff);
             ipv6_hdr->dst.u16[6] = byteorder_htons(0xfe00);
             memcpy(ipv6_hdr->dst.u8 + 14, iphc_hdr + payload_offset, 2);
-            ng_ipv6_addr_init_prefix(&ipv6_hdr->dst, &ctx->prefix,
-                                     ctx->prefix_len);
+            ipv6_addr_init_prefix(&ipv6_hdr->dst, &ctx->prefix,
+                                  ctx->prefix_len);
             payload_offset += 2;
             break;
 
@@ -302,13 +302,13 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
             ieee802154_get_iid((eui64_t *)(&ipv6_hdr->dst.u64[1]),
                                ng_netif_hdr_get_dst_addr(netif_hdr),
                                netif_hdr->dst_l2addr_len);
-            ng_ipv6_addr_init_prefix(&ipv6_hdr->dst, &ctx->prefix,
-                                     ctx->prefix_len);
+            ipv6_addr_init_prefix(&ipv6_hdr->dst, &ctx->prefix,
+                                  ctx->prefix_len);
             break;
 
         case IPHC_M_DAC_DAM_M_48:
             /* ffXX::00XX:XXXX:XXXX */
-            ng_ipv6_addr_set_unspecified(&ipv6_hdr->dst);
+            ipv6_addr_set_unspecified(&ipv6_hdr->dst);
             ipv6_hdr->dst.u8[0] = 0xff;
             ipv6_hdr->dst.u8[1] = iphc_hdr[payload_offset++];
             ipv6_hdr->dst.u8[11] = iphc_hdr[payload_offset++];
@@ -320,7 +320,7 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
 
         case IPHC_M_DAC_DAM_M_32:
             /* ffXX::00XX:XXXX */
-            ng_ipv6_addr_set_unspecified(&ipv6_hdr->dst);
+            ipv6_addr_set_unspecified(&ipv6_hdr->dst);
             ipv6_hdr->dst.u8[0] = 0xff;
             ipv6_hdr->dst.u8[1] = iphc_hdr[payload_offset++];
             ipv6_hdr->dst.u8[13] = iphc_hdr[payload_offset++];
@@ -330,7 +330,7 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
 
         case IPHC_M_DAC_DAM_M_8:
             /* ff02::XX: */
-            ng_ipv6_addr_set_unspecified(&ipv6_hdr->dst);
+            ipv6_addr_set_unspecified(&ipv6_hdr->dst);
             ipv6_hdr->dst.u8[0] = 0xff;
             ipv6_hdr->dst.u8[1] = 0x02;
             ipv6_hdr->dst.u8[15] = iphc_hdr[payload_offset++];
@@ -340,7 +340,7 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
             do {
                 uint8_t orig_ctx_len = ctx->prefix_len;
 
-                ng_ipv6_addr_set_unspecified(&ipv6_hdr->dst);
+                ipv6_addr_set_unspecified(&ipv6_hdr->dst);
 
                 if (ctx->prefix_len > 64) {
                     ctx->prefix_len = 64;
@@ -350,8 +350,8 @@ bool ng_sixlowpan_iphc_decode(ng_pktsnip_t *pkt)
                 ipv6_hdr->dst.u8[1] = iphc_hdr[payload_offset++];
                 ipv6_hdr->dst.u8[2] = iphc_hdr[payload_offset++];
                 ipv6_hdr->dst.u8[3] = ctx->prefix_len;
-                ng_ipv6_addr_init_prefix((ng_ipv6_addr_t *)ipv6_hdr->dst.u8 + 4,
-                                         &ctx->prefix, ctx->prefix_len);
+                ipv6_addr_init_prefix((ipv6_addr_t *)ipv6_hdr->dst.u8 + 4,
+                                      &ctx->prefix, ctx->prefix_len);
                 memcpy(ipv6_hdr->dst.u8 + 12, iphc_hdr + payload_offset + 2, 4);
 
                 payload_offset += 4;
@@ -406,11 +406,11 @@ bool ng_sixlowpan_iphc_encode(ng_pktsnip_t *pkt)
     iphc_hdr[IPHC2_IDX] = 0;
 
     /* check for available contexts */
-    if (!ng_ipv6_addr_is_unspecified(&(ipv6_hdr->src))) {
+    if (!ipv6_addr_is_unspecified(&(ipv6_hdr->src))) {
         src_ctx = ng_sixlowpan_ctx_lookup_addr(&(ipv6_hdr->src));
     }
 
-    if (!ng_ipv6_addr_is_multicast(&ipv6_hdr->dst)) {
+    if (!ipv6_addr_is_multicast(&ipv6_hdr->dst)) {
         dst_ctx = ng_sixlowpan_ctx_lookup_addr(&(ipv6_hdr->dst));
     }
 
@@ -489,7 +489,7 @@ bool ng_sixlowpan_iphc_encode(ng_pktsnip_t *pkt)
             break;
     }
 
-    if (ng_ipv6_addr_is_unspecified(&(ipv6_hdr->src))) {
+    if (ipv6_addr_is_unspecified(&(ipv6_hdr->src))) {
         iphc_hdr[IPHC2_IDX] |= IPHC_SAC_SAM_UNSPEC;
     }
     else {
@@ -502,7 +502,7 @@ bool ng_sixlowpan_iphc_encode(ng_pktsnip_t *pkt)
             }
         }
 
-        if ((src_ctx != NULL) || ng_ipv6_addr_is_link_local(&(ipv6_hdr->src))) {
+        if ((src_ctx != NULL) || ipv6_addr_is_link_local(&(ipv6_hdr->src))) {
             eui64_t iid;
             iid.uint64.u64 = 0;
 
@@ -553,7 +553,7 @@ bool ng_sixlowpan_iphc_encode(ng_pktsnip_t *pkt)
     addr_comp = false;
 
     /* M: Multicast compression */
-    if (ng_ipv6_addr_is_multicast(&(ipv6_hdr->dst))) {
+    if (ipv6_addr_is_multicast(&(ipv6_hdr->dst))) {
         iphc_hdr[IPHC2_IDX] |= NG_SIXLOWPAN_IPHC2_M;
 
         /* if multicast address is of format ffXX::XXXX:XXXX:XXXX */
@@ -593,7 +593,7 @@ bool ng_sixlowpan_iphc_encode(ng_pktsnip_t *pkt)
         /* try unicast prefix based compression */
         else {
             ng_sixlowpan_ctx_t *ctx;
-            ng_ipv6_addr_t unicast_prefix;
+            ipv6_addr_t unicast_prefix;
             unicast_prefix.u16[0] = ipv6_hdr->dst.u16[2];
             unicast_prefix.u16[1] = ipv6_hdr->dst.u16[3];
             unicast_prefix.u16[2] = ipv6_hdr->dst.u16[4];
@@ -616,7 +616,7 @@ bool ng_sixlowpan_iphc_encode(ng_pktsnip_t *pkt)
         }
     }
     else if ((((dst_ctx != NULL) && (dst_ctx->flags_id & NG_SIXLOWPAN_CTX_FLAGS_COMP)) ||
-              ng_ipv6_addr_is_link_local(&ipv6_hdr->dst)) && (netif_hdr->dst_l2addr_len > 0)) {
+              ipv6_addr_is_link_local(&ipv6_hdr->dst)) && (netif_hdr->dst_l2addr_len > 0)) {
         eui64_t iid;
 
         ieee802154_get_iid(&iid, ng_netif_hdr_get_dst_addr(netif_hdr),

--- a/sys/net/routing/ng_rpl/srh/ng_rpl_srh.c
+++ b/sys/net/routing/ng_rpl/srh/ng_rpl_srh.c
@@ -14,7 +14,7 @@
 
 #include "net/ng_rpl/srh.h"
 
-ng_ipv6_addr_t *ng_rpl_srh_next_hop(ng_rpl_srh_t *rh)
+ipv6_addr_t *ng_rpl_srh_next_hop(ng_rpl_srh_t *rh)
 {
     /* TODO */
 

--- a/sys/posix/pnet/include/netinet/in.h
+++ b/sys/posix/pnet/include/netinet/in.h
@@ -49,7 +49,7 @@ struct in6_addr {
     /**
      * Private RIOT-internal data, needs not to be touched by the user.
      */
-    ng_ipv6_addr_t     __in6_u;
+    ipv6_addr_t     __in6_u;
 
     /**
      * IPv6 Address represented as sequence of 8-bit numbers. Member of

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -50,7 +50,7 @@ endif
 ifneq (,$(filter ng_icmpv6_echo vtimer,$(USEMODULE)))
   SRC += sc_icmpv6_echo.c
 endif
-ifneq (,$(filter ng_zep ng_ipv6_addr,$(USEMODULE)))
+ifneq (,$(filter ng_zep ipv6_addr,$(USEMODULE)))
   SRC += sc_zep.c
 endif
 

--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -23,7 +23,7 @@
 
 #include "byteorder.h"
 #include "net/ng_icmpv6.h"
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/ng_ipv6/nc.h"
 #include "net/ng_ipv6/hdr.h"
 #include "net/ng_netbase.h"
@@ -34,7 +34,7 @@
 static uint16_t id = 0x53;
 static uint16_t min_seq_expected = 0;
 static uint16_t max_seq_expected = 0;
-static char ipv6_str[NG_IPV6_ADDR_MAX_STR_LEN];
+static char ipv6_str[IPV6_ADDR_MAX_STR_LEN];
 
 static void usage(char **argv)
 {
@@ -104,7 +104,7 @@ int _handle_reply(ng_pktsnip_t *pkt, uint64_t time)
         timex_t rt = timex_from_uint64(time);
         printf("%u bytes from %s: id=%" PRIu16 " seq=%" PRIu16 " hop limit=%" PRIu8
                " time = %" PRIu32 ".%03" PRIu32 " ms\n", (unsigned) icmpv6->size,
-               ng_ipv6_addr_to_str(ipv6_str, &(ipv6_hdr->src), sizeof(ipv6_str)),
+               ipv6_addr_to_str(ipv6_str, &(ipv6_hdr->src), sizeof(ipv6_str)),
                byteorder_ntohs(icmpv6_hdr->id), seq, ipv6_hdr->hl,
                (rt.seconds * SEC_IN_MS) + (rt.microseconds / MS_IN_USEC),
                rt.microseconds % MS_IN_USEC);
@@ -135,7 +135,7 @@ int _icmpv6_ping(int argc, char **argv)
     size_t payload_len = 4;
     timex_t delay = { 1, 0 };
     char *addr_str;
-    ng_ipv6_addr_t addr;
+    ipv6_addr_t addr;
     ng_netreg_entry_t *ipv6_entry, my_entry = { NULL, NG_ICMPV6_ECHO_REP,
                                                 thread_getpid()
                                               };
@@ -189,7 +189,7 @@ int _icmpv6_ping(int argc, char **argv)
             break;
     }
 
-    if ((ng_ipv6_addr_from_str(&addr, addr_str) == NULL) || (((int)payload_len) < 0)) {
+    if ((ipv6_addr_from_str(&addr, addr_str) == NULL) || (((int)payload_len) < 0)) {
         usage(argv);
         return 1;
     }
@@ -226,7 +226,7 @@ int _icmpv6_ping(int argc, char **argv)
         _set_payload(pkt->data, payload_len);
 
         pkt = ng_netreg_hdr_build(NG_NETTYPE_IPV6, pkt, NULL, 0, addr.u8,
-                                  sizeof(ng_ipv6_addr_t));
+                                  sizeof(ipv6_addr_t));
 
         if (pkt == NULL) {
             puts("error: packet buffer full");

--- a/sys/shell/commands/sc_ipv6_nc.c
+++ b/sys/shell/commands/sc_ipv6_nc.c
@@ -19,7 +19,7 @@
 #include <string.h>
 
 #include "kernel_types.h"
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/ng_ipv6/nc.h"
 #include "net/ng_netif.h"
 #include "thread.h"
@@ -105,7 +105,7 @@ static bool _is_iface(kernel_pid_t iface)
 
 static int _ipv6_nc_list(void)
 {
-    char ipv6_str[NG_IPV6_ADDR_MAX_STR_LEN];
+    char ipv6_str[IPV6_ADDR_MAX_STR_LEN];
     char l2addr_str[3 * MAX_L2_ADDR_LEN];
 
     puts("IPv6 address                    if  L2 address                state       type");
@@ -115,7 +115,7 @@ static int _ipv6_nc_list(void)
          entry != NULL;
          entry = ng_ipv6_nc_get_next(entry)) {
         printf("%-30s  %2" PRIkernel_pid "  %-24s  ",
-               ng_ipv6_addr_to_str(ipv6_str, &entry->ipv6_addr, sizeof(ipv6_str)),
+               ipv6_addr_to_str(ipv6_str, &entry->ipv6_addr, sizeof(ipv6_str)),
                entry->iface,
                ng_netif_addr_to_str(l2addr_str, sizeof(l2addr_str),
                                     entry->l2_addr, entry->l2_addr_len));
@@ -130,11 +130,11 @@ static int _ipv6_nc_list(void)
 static int _ipv6_nc_add(kernel_pid_t iface, char *ipv6_addr_str,
                         char *l2_addr_str)
 {
-    ng_ipv6_addr_t ipv6_addr;
+    ipv6_addr_t ipv6_addr;
     uint8_t l2_addr[MAX_L2_ADDR_LEN];
     size_t l2_addr_len;
 
-    if (ng_ipv6_addr_from_str(&ipv6_addr, ipv6_addr_str) == NULL) {
+    if (ipv6_addr_from_str(&ipv6_addr, ipv6_addr_str) == NULL) {
         puts("error: unable to parse IPv6 address.");
         return 1;
     }
@@ -156,9 +156,9 @@ static int _ipv6_nc_add(kernel_pid_t iface, char *ipv6_addr_str,
 
 static int _ipv6_nc_del(char *ipv6_addr_str)
 {
-    ng_ipv6_addr_t ipv6_addr;
+    ipv6_addr_t ipv6_addr;
 
-    if (ng_ipv6_addr_from_str(&ipv6_addr, ipv6_addr_str) == NULL) {
+    if (ipv6_addr_from_str(&ipv6_addr, ipv6_addr_str) == NULL) {
         puts("error: unable to parse IPv6 address.");
         return 1;
     }
@@ -239,7 +239,7 @@ int _ipv6_nc_manage(int argc, char **argv)
 int _ipv6_nc_routers(int argc, char **argv)
 {
     kernel_pid_t iface = KERNEL_PID_UNDEF;
-    char ipv6_str[NG_IPV6_ADDR_MAX_STR_LEN];
+    char ipv6_str[IPV6_ADDR_MAX_STR_LEN];
 
     if (argc > 1) {
         iface = atoi(argv[1]);
@@ -261,7 +261,7 @@ int _ipv6_nc_routers(int argc, char **argv)
         }
 
         printf("%2" PRIkernel_pid "  %-30s  ", entry->iface,
-               ng_ipv6_addr_to_str(ipv6_str, &entry->ipv6_addr, sizeof(ipv6_str)));
+               ipv6_addr_to_str(ipv6_str, &entry->ipv6_addr, sizeof(ipv6_str)));
         _print_nc_state(entry);
         _print_nc_type(entry);
         puts("");

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -25,7 +25,7 @@
 #include <inttypes.h>
 
 #include "thread.h"
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/ng_ipv6/netif.h"
 #include "net/ng_netif.h"
 #include "net/ng_netapi.h"
@@ -177,7 +177,7 @@ static void _netif_list(kernel_pid_t dev)
     bool linebreak = false;
 #ifdef MODULE_NG_IPV6_NETIF
     ng_ipv6_netif_t *entry = ng_ipv6_netif_get(dev);
-    char ipv6_addr[NG_IPV6_ADDR_MAX_STR_LEN];
+    char ipv6_addr[IPV6_ADDR_MAX_STR_LEN];
 #endif
 
 
@@ -286,15 +286,15 @@ static void _netif_list(kernel_pid_t dev)
 
 #ifdef MODULE_NG_IPV6_NETIF
     for (int i = 0; i < NG_IPV6_NETIF_ADDR_NUMOF; i++) {
-        if (!ng_ipv6_addr_is_unspecified(&entry->addrs[i].addr)) {
+        if (!ipv6_addr_is_unspecified(&entry->addrs[i].addr)) {
             printf("inet6 addr: ");
 
-            if (ng_ipv6_addr_to_str(ipv6_addr, &entry->addrs[i].addr,
-                                    NG_IPV6_ADDR_MAX_STR_LEN)) {
+            if (ipv6_addr_to_str(ipv6_addr, &entry->addrs[i].addr,
+                                 IPV6_ADDR_MAX_STR_LEN)) {
                 printf("%s/%" PRIu8 "  scope: ", ipv6_addr,
                        entry->addrs[i].prefix_len);
 
-                if ((ng_ipv6_addr_is_link_local(&entry->addrs[i].addr))) {
+                if ((ipv6_addr_is_link_local(&entry->addrs[i].addr))) {
                     printf("local");
                 }
                 else {
@@ -302,7 +302,7 @@ static void _netif_list(kernel_pid_t dev)
                 }
 
                 if (entry->addrs[i].flags & NG_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST) {
-                    if (ng_ipv6_addr_is_multicast(&entry->addrs[i].addr)) {
+                    if (ipv6_addr_is_multicast(&entry->addrs[i].addr)) {
                         printf(" [multicast]");
                     }
                     else {
@@ -584,7 +584,7 @@ static uint8_t _get_prefix_len(char *addr)
         *addr = '\0';
         prefix_len = atoi(addr + 1);
 
-        if ((prefix_len < 1) || (prefix_len > NG_IPV6_ADDR_BIT_LEN)) {
+        if ((prefix_len < 1) || (prefix_len > IPV6_ADDR_BIT_LEN)) {
             prefix_len = SC_NETIF_IPV6_DEFAULT_PREFIX_LEN;
         }
     }
@@ -602,7 +602,7 @@ static int _netif_add(char *cmd_name, kernel_pid_t dev, int argc, char **argv)
         _ANYCAST
     } type = _UNICAST;
     char *addr_str = argv[0];
-    ng_ipv6_addr_t addr;
+    ipv6_addr_t addr;
     uint8_t prefix_len;
 
     if (argc > 1) {
@@ -626,12 +626,12 @@ static int _netif_add(char *cmd_name, kernel_pid_t dev, int argc, char **argv)
 
     prefix_len = _get_prefix_len(addr_str);
 
-    if (ng_ipv6_addr_from_str(&addr, addr_str) == NULL) {
+    if (ipv6_addr_from_str(&addr, addr_str) == NULL) {
         puts("error: unable to parse IPv6 address.");
         return 1;
     }
 
-    if ((argc > 1) && (ng_ipv6_addr_is_multicast(&addr)) && (type != _MULTICAST)) {
+    if ((argc > 1) && (ipv6_addr_is_multicast(&addr)) && (type != _MULTICAST)) {
         puts("error: address was not a multicast address.");
         return 1;
     }
@@ -662,9 +662,9 @@ static int _netif_add(char *cmd_name, kernel_pid_t dev, int argc, char **argv)
 static int _netif_del(kernel_pid_t dev, char *addr_str)
 {
 #ifdef MODULE_NG_IPV6_NETIF
-    ng_ipv6_addr_t addr;
+    ipv6_addr_t addr;
 
-    if (ng_ipv6_addr_from_str(&addr, addr_str) == NULL) {
+    if (ipv6_addr_from_str(&addr, addr_str) == NULL) {
         puts("error: unable to parse IPv6 address.");
         return 1;
     }

--- a/sys/shell/commands/sc_zep.c
+++ b/sys/shell/commands/sc_zep.c
@@ -17,7 +17,7 @@
 #include <stdlib.h>
 #include <inttypes.h>
 
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/ng_ipv6/netif.h"
 #include "net/ng_nomac.h"
 #include "net/ng_zep.h"
@@ -30,7 +30,7 @@ int _zep_init(int argc, char **argv)
 {
     uint16_t src_port = NG_ZEP_DEFAULT_PORT;
     uint16_t dst_port = NG_ZEP_DEFAULT_PORT;
-    ng_ipv6_addr_t dst_addr;
+    ipv6_addr_t dst_addr;
     int res;
 
     if (argc < 2) {
@@ -46,7 +46,7 @@ int _zep_init(int argc, char **argv)
         dst_port = (uint16_t)atoi(argv[3]);
     }
 
-    ng_ipv6_addr_from_str(&dst_addr, argv[1]);
+    ipv6_addr_from_str(&dst_addr, argv[1]);
 
     if ((res = ng_zep_init(&zep, src_port, &dst_addr, dst_port)) < 0) {
         switch (res) {

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -111,7 +111,7 @@ extern int _ipv6_nc_routers(int argc, char **argv);
 #endif
 
 #ifdef MODULE_NG_ZEP
-#ifdef MODULE_NG_IPV6_ADDR
+#ifdef MODULE_IPV6_ADDR
 extern int _zep_init(int argc, char **argv);
 #endif
 #endif
@@ -187,7 +187,7 @@ const shell_command_t _shell_command_list[] = {
     {"routers", "IPv6 default router list", _ipv6_nc_routers },
 #endif
 #ifdef MODULE_NG_ZEP
-#ifdef MODULE_NG_IPV6_ADDR
+#ifdef MODULE_IPV6_ADDR
     {"zep_init", "initializes ZEP (Zigbee Encapsulation Protocol)", _zep_init },
 #endif
 #endif

--- a/tests/unittests/tests-ipv6_addr/Makefile.include
+++ b/tests/unittests/tests-ipv6_addr/Makefile.include
@@ -1,1 +1,1 @@
-USEMODULE += ng_ipv6_addr
+USEMODULE += ipv6_addr

--- a/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
+++ b/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
@@ -17,653 +17,653 @@
 #include "embUnit/embUnit.h"
 
 #include "byteorder.h"
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 
 #include "tests-ipv6_addr.h"
 
 static void test_ipv6_addr_equal_not_equal(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t b = { {
             0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
             0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_equal(&a, &b));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_equal(&a, &b));
 }
 
 static void test_ipv6_addr_equal_not_equal2(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t b = { {
             0x80, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_equal(&a, &b));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_equal(&a, &b));
 }
 
 static void test_ipv6_addr_equal_not_equal3(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t b = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0e
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_equal(&a, &b));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_equal(&a, &b));
 }
 
 static void test_ipv6_addr_equal_not_equal4(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t b = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x25, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_equal(&a, &b));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_equal(&a, &b));
 }
 
 static void test_ipv6_addr_equal_equal(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t b = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(&a, &b));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &b));
 }
 
 static void test_ipv6_addr_is_unspecified_not_unspecified(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_unspecified(&a));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_unspecified(&a));
 }
 
 static void test_ipv6_addr_is_unspecified_unspecified(void)
 {
-    ng_ipv6_addr_t a = NG_IPV6_ADDR_UNSPECIFIED;
+    ipv6_addr_t a = IPV6_ADDR_UNSPECIFIED;
 
     TEST_ASSERT_EQUAL_INT(0, a.u64[0].u64); /* Don't trust the macro ;) */
     TEST_ASSERT_EQUAL_INT(0, a.u64[1].u64);
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_unspecified(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_unspecified(&a));
 }
 
 static void test_ipv6_addr_is_global_is_link_local(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_global(&a));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_global(&a));
 }
 
 static void test_ipv6_addr_is_global1(void)
 {
     /* riot-os.org has IPv6 address 2a01:4f8:151:64::11 */
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x2a, 0x01, 0x04, 0xf8, 0x01, 0x51, 0x00, 0x64,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11
-    }
+        }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_global(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_global(&a));
 }
 
 static void test_ipv6_addr_is_global2(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xaf, 0xfe, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xbe, 0xef, 0xca, 0xfe, 0x12, 0x34, 0xab, 0xcd
-    }
+        }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_global(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_global(&a));
 }
 
 static void test_ipv6_addr_is_global_multicast_not_global(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xff, 0x15, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_global(&a));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_global(&a));
 }
 
 static void test_ipv6_addr_is_global_multicast(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xff, 0x1e, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_global(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_global(&a));
 }
 
 static void test_ipv6_addr_is_ipv4_compat_not_ipv4_compat1(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0xff, 0xff, 0xc0, 0xa8, 0x00, 0x01
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_ipv4_compat(&a));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_ipv4_compat(&a));
 }
 
 static void test_ipv6_addr_is_ipv4_compat_not_ipv4_compat2(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x01, 0xc0, 0xa8, 0x00, 0x01
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_ipv4_compat(&a));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_ipv4_compat(&a));
 }
 
 static void test_ipv6_addr_is_ipv4_compat_ipv4_compat(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0xc0, 0xa8, 0x00, 0x01
         }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_ipv4_compat(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_ipv4_compat(&a));
 }
 
 static void test_ipv6_addr_is_ipv4_mapped_not_ipv4_mapped1(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0xc0, 0xa8, 0x00, 0x01
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_ipv4_mapped(&a));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_ipv4_mapped(&a));
 }
 
 static void test_ipv6_addr_is_ipv4_mapped_not_ipv4_mapped2(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x01, 0xff, 0xff, 0xc0, 0xa8, 0x00, 0x01
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_ipv4_mapped(&a));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_ipv4_mapped(&a));
 }
 
 static void test_ipv6_addr_is_ipv4_mapped_ipv4_mapped(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0xff, 0xff, 0xc0, 0xa8, 0x00, 0x01
         }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_ipv4_mapped(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_ipv4_mapped(&a));
 }
 
 static void test_ipv6_addr_is_site_local_is_link_local(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_site_local(&a));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_site_local(&a));
 }
 
 static void test_ipv6_addr_is_site_local_not_site_local(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xff, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_site_local(&a));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_site_local(&a));
 }
 
 static void test_ipv6_addr_is_site_local_site_local_multicast(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xff, 0x15, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_site_local(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_site_local(&a));
 }
 
 
 static void test_ipv6_addr_is_site_local(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xfe, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_site_local(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_site_local(&a));
 }
 
 static void test_ipv6_addr_is_multicast_not_multicast(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x01, 0xff,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_multicast(&a));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_multicast(&a));
 }
 
 static void test_ipv6_addr_is_multicast_multicast(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xff, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_multicast(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_multicast(&a));
 }
 
 static void test_ipv6_addr_is_loopback_not_loopback(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_loopback(&a));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_loopback(&a));
 }
 
 static void test_ipv6_addr_is_loopback_loopback(void)
 {
-    ng_ipv6_addr_t a = NG_IPV6_ADDR_LOOPBACK;
+    ipv6_addr_t a = IPV6_ADDR_LOOPBACK;
 
     TEST_ASSERT_EQUAL_INT(0, a.u64[0].u64); /* Don't trust the macro ;) */
     TEST_ASSERT_EQUAL_INT(1, byteorder_ntohll(a.u64[1]));
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_loopback(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_loopback(&a));
 }
 
 static void test_ipv6_addr_is_link_local_not_link_local(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_link_local(&a));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_link_local(&a));
 }
 
 static void test_ipv6_addr_is_link_local_nearly_link_local(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_link_local(&a));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_link_local(&a));
 }
 
 static void test_ipv6_addr_is_link_local_link_local_unicast(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_link_local(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_link_local(&a));
 }
 
 static void test_ipv6_addr_is_link_local_link_local_multicast1(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xff, 0x12, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_link_local(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_link_local(&a));
 }
 
 static void test_ipv6_addr_is_link_local_link_local_multicasta(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xff, 0xa2, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_link_local(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_link_local(&a));
 }
 
 static void test_ipv6_addr_is_unique_local_unicast_not_unique_local_unicast(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_unique_local_unicast(&a));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_unique_local_unicast(&a));
 }
 
 static void test_ipv6_addr_is_unique_local_unicast_unique_local_unicast_locally_assigned(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xfd, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_unique_local_unicast(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_unique_local_unicast(&a));
 }
 
 static void test_ipv6_addr_is_unique_local_unicast_unique_local_unicast_not_locally_assigned(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xfc, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_unique_local_unicast(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_unique_local_unicast(&a));
 }
 
 static void test_ipv6_addr_is_solicited_node_no_solicited_node_multicast(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_solicited_node(&a));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_solicited_node(&a));
 }
 
 static void test_ipv6_addr_is_solicited_node_multicast_but_no_solicited_node(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_solicited_node(&a));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_solicited_node(&a));
 }
 
 static void test_ipv6_addr_is_solicited_node_solicited_node_multicast(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x01, 0xff, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_solicited_node(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_solicited_node(&a));
 }
 
 static void test_ipv6_addr_match_prefix_first_NULL(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_addr_match_prefix(NULL, &a));
+    TEST_ASSERT_EQUAL_INT(0, ipv6_addr_match_prefix(NULL, &a));
 }
 
 static void test_ipv6_addr_match_prefix_second_NULL(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_addr_match_prefix(&a, NULL));
+    TEST_ASSERT_EQUAL_INT(0, ipv6_addr_match_prefix(&a, NULL));
 }
 
 static void test_ipv6_addr_match_prefix_no_match(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t b = { {
             0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8,
             0xf7, 0xf6, 0xf5, 0xf4, 0xf3, 0xf2, 0xf1, 0xf0
         }
     };
-    TEST_ASSERT_EQUAL_INT(0, ng_ipv6_addr_match_prefix(&a, &b));
+    TEST_ASSERT_EQUAL_INT(0, ipv6_addr_match_prefix(&a, &b));
 }
 
 static void test_ipv6_addr_match_prefix_match_1(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t b = { {
             0x40, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(1, ng_ipv6_addr_match_prefix(&a, &b));
+    TEST_ASSERT_EQUAL_INT(1, ipv6_addr_match_prefix(&a, &b));
 }
 
 static void test_ipv6_addr_match_prefix_match_2(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t b = { {
             0x20, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(2, ng_ipv6_addr_match_prefix(&a, &b));
+    TEST_ASSERT_EQUAL_INT(2, ipv6_addr_match_prefix(&a, &b));
 }
 
 static void test_ipv6_addr_match_prefix_match_3(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t b = { {
             0x10, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(3, ng_ipv6_addr_match_prefix(&a, &b));
+    TEST_ASSERT_EQUAL_INT(3, ipv6_addr_match_prefix(&a, &b));
 }
 
 static void test_ipv6_addr_match_prefix_match_6(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t b = { {
             0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(6, ng_ipv6_addr_match_prefix(&a, &b));
+    TEST_ASSERT_EQUAL_INT(6, ipv6_addr_match_prefix(&a, &b));
 }
 
 static void test_ipv6_addr_match_prefix_match_127(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t b = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0e
         }
     };
-    TEST_ASSERT_EQUAL_INT(127, ng_ipv6_addr_match_prefix(&a, &b));
+    TEST_ASSERT_EQUAL_INT(127, ipv6_addr_match_prefix(&a, &b));
 }
 
 static void test_ipv6_addr_match_prefix_match_128(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t b = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
 
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(&a, &b));
-    TEST_ASSERT_EQUAL_INT(128, ng_ipv6_addr_match_prefix(&a, &b));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &b));
+    TEST_ASSERT_EQUAL_INT(128, ipv6_addr_match_prefix(&a, &b));
 }
 
 static void test_ipv6_addr_match_prefix_same_pointer(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    TEST_ASSERT_EQUAL_INT(128, ng_ipv6_addr_match_prefix(&a, &a));
+    TEST_ASSERT_EQUAL_INT(128, ipv6_addr_match_prefix(&a, &a));
 }
 
 static void test_ipv6_addr_init_prefix(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x02, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t b = { {
             0x00, 0x01, 0x02, 0x03, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
         }
     };
-    ng_ipv6_addr_t c =  { {
+    ipv6_addr_t c =  { {
             0xff, 0xfe, 0xfd, 0xfe, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
 
-    ng_ipv6_addr_init_prefix(&c, &b, 31);
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(&a, &c));
+    ipv6_addr_init_prefix(&c, &b, 31);
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &c));
 }
 
 static void test_ipv6_addr_set_unspecified(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
 
-    ng_ipv6_addr_set_unspecified(&a);
+    ipv6_addr_set_unspecified(&a);
 
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_unspecified(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_unspecified(&a));
 }
 
 static void test_ipv6_addr_set_loopback(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
 
-    ng_ipv6_addr_set_loopback(&a);
+    ipv6_addr_set_loopback(&a);
 
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_is_loopback(&a));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_loopback(&a));
 }
 
 static void test_ipv6_addr_set_link_local_prefix(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
 
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t b = { {
             0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff
         }
     };
 
-    ng_ipv6_addr_set_link_local_prefix(&a);
+    ipv6_addr_set_link_local_prefix(&a);
 
-    TEST_ASSERT_EQUAL_INT(64, ng_ipv6_addr_match_prefix(&a, &b));
+    TEST_ASSERT_EQUAL_INT(64, ipv6_addr_match_prefix(&a, &b));
 }
 
 static void test_ipv6_addr_set_iid(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
 
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t b = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff
         }
     };
 
-    ng_ipv6_addr_set_iid(&a, byteorder_ntohll(b.u64[1]));
+    ipv6_addr_set_iid(&a, byteorder_ntohll(b.u64[1]));
 
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(&a, &b));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &b));
 }
 
 static void test_ipv6_addr_set_aiid(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
 
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t b = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff
         }
     };
 
-    ng_ipv6_addr_set_aiid(&a, &(b.u8[8]));
+    ipv6_addr_set_aiid(&a, &(b.u8[8]));
 
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(&a, &b));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &b));
 }
 
 static void test_ipv6_addr_set_multicast(void)
 {
-    ng_ipv6_addr_t a;
-    ng_ipv6_addr_mcast_flag_t flags = (ng_ipv6_addr_mcast_flag_t)5;
-    ng_ipv6_addr_mcast_scp_t scope = NG_IPV6_ADDR_MCAST_SCP_REALM_LOCAL;
+    ipv6_addr_t a;
+    unsigned int flags = 5U;
+    unsigned int scope = IPV6_ADDR_MCAST_SCP_REALM_LOCAL;
 
-    ng_ipv6_addr_set_multicast(&a, flags, scope);
+    ipv6_addr_set_multicast(&a, flags, scope);
 
     TEST_ASSERT_EQUAL_INT(0xff, a.u8[0]);
     TEST_ASSERT_EQUAL_INT((flags << 4) | scope, a.u8[1]);
@@ -671,40 +671,40 @@ static void test_ipv6_addr_set_multicast(void)
 
 static void test_ipv6_addr_set_all_nodes_multicast_if_local(void)
 {
-    ng_ipv6_addr_t a = NG_IPV6_ADDR_UNSPECIFIED;
-    ng_ipv6_addr_t b = NG_IPV6_ADDR_ALL_NODES_IF_LOCAL;
-    ng_ipv6_addr_mcast_scp_t scope = NG_IPV6_ADDR_MCAST_SCP_IF_LOCAL;
+    ipv6_addr_t a = IPV6_ADDR_UNSPECIFIED;
+    ipv6_addr_t b = IPV6_ADDR_ALL_NODES_IF_LOCAL;
+    unsigned int scope = IPV6_ADDR_MCAST_SCP_IF_LOCAL;
 
     TEST_ASSERT_EQUAL_INT(0xff010000, byteorder_ntohl(b.u32[0])); /* Don't trust the macro ;) */
     TEST_ASSERT_EQUAL_INT(0, b.u32[1].u32);
     TEST_ASSERT_EQUAL_INT(1, byteorder_ntohll(b.u64[1]));
 
-    ng_ipv6_addr_set_all_nodes_multicast(&a, scope);
+    ipv6_addr_set_all_nodes_multicast(&a, scope);
 
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(&a, &b));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &b));
 }
 
 static void test_ipv6_addr_set_all_nodes_multicast_link_local(void)
 {
-    ng_ipv6_addr_t a = NG_IPV6_ADDR_UNSPECIFIED;
-    ng_ipv6_addr_t b = NG_IPV6_ADDR_ALL_NODES_LINK_LOCAL;
-    ng_ipv6_addr_mcast_scp_t scope = NG_IPV6_ADDR_MCAST_SCP_LINK_LOCAL;
+    ipv6_addr_t a = IPV6_ADDR_UNSPECIFIED;
+    ipv6_addr_t b = IPV6_ADDR_ALL_NODES_LINK_LOCAL;
+    unsigned int scope = IPV6_ADDR_MCAST_SCP_LINK_LOCAL;
 
     TEST_ASSERT_EQUAL_INT(0xff020000, byteorder_ntohl(b.u32[0])); /* Don't trust the macro ;) */
     TEST_ASSERT_EQUAL_INT(0, b.u32[1].u32);
     TEST_ASSERT_EQUAL_INT(1, byteorder_ntohll(b.u64[1]));
 
-    ng_ipv6_addr_set_all_nodes_multicast(&a, scope);
+    ipv6_addr_set_all_nodes_multicast(&a, scope);
 
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(&a, &b));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &b));
 }
 
 static void test_ipv6_addr_set_all_nodes_multicast_unusual(void)
 {
-    ng_ipv6_addr_t a;
-    ng_ipv6_addr_mcast_scp_t scope = NG_IPV6_ADDR_MCAST_SCP_REALM_LOCAL;
+    ipv6_addr_t a;
+    unsigned int scope = IPV6_ADDR_MCAST_SCP_REALM_LOCAL;
 
-    ng_ipv6_addr_set_all_nodes_multicast(&a, scope);
+    ipv6_addr_set_all_nodes_multicast(&a, scope);
 
     TEST_ASSERT_EQUAL_INT(0xff030000, byteorder_ntohl(a.u32[0]));
     TEST_ASSERT_EQUAL_INT(0, a.u32[1].u32);
@@ -713,55 +713,55 @@ static void test_ipv6_addr_set_all_nodes_multicast_unusual(void)
 
 static void test_ipv6_addr_set_all_routers_multicast_if_local(void)
 {
-    ng_ipv6_addr_t a = NG_IPV6_ADDR_UNSPECIFIED;
-    ng_ipv6_addr_t b = NG_IPV6_ADDR_ALL_ROUTERS_IF_LOCAL;
-    ng_ipv6_addr_mcast_scp_t scope = NG_IPV6_ADDR_MCAST_SCP_IF_LOCAL;
+    ipv6_addr_t a = IPV6_ADDR_UNSPECIFIED;
+    ipv6_addr_t b = IPV6_ADDR_ALL_ROUTERS_IF_LOCAL;
+    unsigned int scope = IPV6_ADDR_MCAST_SCP_IF_LOCAL;
 
     TEST_ASSERT_EQUAL_INT(0xff010000, byteorder_ntohl(b.u32[0])); /* Don't trust the macro ;) */
     TEST_ASSERT_EQUAL_INT(0, b.u32[1].u32);
     TEST_ASSERT_EQUAL_INT(2, byteorder_ntohll(b.u64[1]));
 
-    ng_ipv6_addr_set_all_routers_multicast(&a, scope);
+    ipv6_addr_set_all_routers_multicast(&a, scope);
 
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(&a, &b));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &b));
 }
 
 static void test_ipv6_addr_set_all_routers_multicast_link_local(void)
 {
-    ng_ipv6_addr_t a = NG_IPV6_ADDR_UNSPECIFIED;
-    ng_ipv6_addr_t b = NG_IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL;
-    ng_ipv6_addr_mcast_scp_t scope = NG_IPV6_ADDR_MCAST_SCP_LINK_LOCAL;
+    ipv6_addr_t a = IPV6_ADDR_UNSPECIFIED;
+    ipv6_addr_t b = IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL;
+    unsigned int scope = IPV6_ADDR_MCAST_SCP_LINK_LOCAL;
 
     TEST_ASSERT_EQUAL_INT(0xff020000, byteorder_ntohl(b.u32[0])); /* Don't trust the macro ;) */
     TEST_ASSERT_EQUAL_INT(0, b.u32[1].u32);
     TEST_ASSERT_EQUAL_INT(2, byteorder_ntohll(b.u64[1]));
 
-    ng_ipv6_addr_set_all_routers_multicast(&a, scope);
+    ipv6_addr_set_all_routers_multicast(&a, scope);
 
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(&a, &b));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &b));
 }
 
 static void test_ipv6_addr_set_all_routers_multicast_site_local(void)
 {
-    ng_ipv6_addr_t a = NG_IPV6_ADDR_UNSPECIFIED;
-    ng_ipv6_addr_t b = NG_IPV6_ADDR_ALL_ROUTERS_SITE_LOCAL;
-    ng_ipv6_addr_mcast_scp_t scope = NG_IPV6_ADDR_MCAST_SCP_SITE_LOCAL;
+    ipv6_addr_t a = IPV6_ADDR_UNSPECIFIED;
+    ipv6_addr_t b = IPV6_ADDR_ALL_ROUTERS_SITE_LOCAL;
+    unsigned int scope = IPV6_ADDR_MCAST_SCP_SITE_LOCAL;
 
     TEST_ASSERT_EQUAL_INT(0xff050000, byteorder_ntohl(b.u32[0])); /* Don't trust the macro ;) */
     TEST_ASSERT_EQUAL_INT(0, b.u32[1].u32);
     TEST_ASSERT_EQUAL_INT(2, byteorder_ntohll(b.u64[1]));
 
-    ng_ipv6_addr_set_all_routers_multicast(&a, scope);
+    ipv6_addr_set_all_routers_multicast(&a, scope);
 
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(&a, &b));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &b));
 }
 
 static void test_ipv6_addr_set_all_routers_multicast_unusual(void)
 {
-    ng_ipv6_addr_t a;
-    ng_ipv6_addr_mcast_scp_t scope = NG_IPV6_ADDR_MCAST_SCP_ORG_LOCAL;
+    ipv6_addr_t a;
+    unsigned int scope = IPV6_ADDR_MCAST_SCP_ORG_LOCAL;
 
-    ng_ipv6_addr_set_all_routers_multicast(&a, scope);
+    ipv6_addr_set_all_routers_multicast(&a, scope);
 
     TEST_ASSERT_EQUAL_INT(0xff080000, byteorder_ntohl(a.u32[0]));
     TEST_ASSERT_EQUAL_INT(0, a.u32[1].u32);
@@ -770,14 +770,14 @@ static void test_ipv6_addr_set_all_routers_multicast_unusual(void)
 
 static void test_ipv6_addr_set_solicited_nodes(void)
 {
-    ng_ipv6_addr_t a = NG_IPV6_ADDR_UNSPECIFIED;
-    ng_ipv6_addr_t b = { {
+    ipv6_addr_t a = IPV6_ADDR_UNSPECIFIED;
+    ipv6_addr_t b = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
 
-    ng_ipv6_addr_set_solicited_nodes(&a, &b);
+    ipv6_addr_set_solicited_nodes(&a, &b);
 
     TEST_ASSERT_EQUAL_INT(0xff020000, byteorder_ntohl(a.u32[0]));
     TEST_ASSERT_EQUAL_INT(0, a.u32[1].u32);
@@ -787,201 +787,201 @@ static void test_ipv6_addr_set_solicited_nodes(void)
 
 static void test_ipv6_addr_to_str__string_too_short(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
     char result[1];
 
-    TEST_ASSERT_NULL(ng_ipv6_addr_to_str(result, &a, sizeof(result)));
+    TEST_ASSERT_NULL(ipv6_addr_to_str(result, &a, sizeof(result)));
 }
 
 static void test_ipv6_addr_to_str__addr_NULL(void)
 {
-    char result[NG_IPV6_ADDR_MAX_STR_LEN];
+    char result[IPV6_ADDR_MAX_STR_LEN];
 
-    TEST_ASSERT_NULL(ng_ipv6_addr_to_str(result, NULL, sizeof(result)));
+    TEST_ASSERT_NULL(ipv6_addr_to_str(result, NULL, sizeof(result)));
 }
 
 static void test_ipv6_addr_to_str__result_NULL(void)
 {
-    ng_ipv6_addr_t a;
+    ipv6_addr_t a;
 
-    TEST_ASSERT_NULL(ng_ipv6_addr_to_str(NULL, &a, NG_IPV6_ADDR_MAX_STR_LEN));
+    TEST_ASSERT_NULL(ipv6_addr_to_str(NULL, &a, IPV6_ADDR_MAX_STR_LEN));
 }
 
 static void test_ipv6_addr_to_str__success(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    char result[NG_IPV6_ADDR_MAX_STR_LEN];
+    char result[IPV6_ADDR_MAX_STR_LEN];
 
     TEST_ASSERT_EQUAL_STRING("1:203:405:607:809:a0b:c0d:e0f",
-                             ng_ipv6_addr_to_str(result, &a, sizeof(result)));
+                             ipv6_addr_to_str(result, &a, sizeof(result)));
 }
 
 static void test_ipv6_addr_to_str__success2(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff
         }
     };
-    char result[NG_IPV6_ADDR_MAX_STR_LEN];
+    char result[IPV6_ADDR_MAX_STR_LEN];
 
     TEST_ASSERT_EQUAL_STRING("fe80::f8f9:fafb:fcfd:feff",
-                             ng_ipv6_addr_to_str(result, &a, sizeof(result)));
+                             ipv6_addr_to_str(result, &a, sizeof(result)));
 }
 
 static void test_ipv6_addr_to_str__success3(void)
 {
-    ng_ipv6_addr_t a = NG_IPV6_ADDR_UNSPECIFIED;
+    ipv6_addr_t a = IPV6_ADDR_UNSPECIFIED;
     char result[sizeof("::")];
 
-    TEST_ASSERT_EQUAL_STRING("::", ng_ipv6_addr_to_str(result, &a, sizeof(result)));
+    TEST_ASSERT_EQUAL_STRING("::", ipv6_addr_to_str(result, &a, sizeof(result)));
 }
 
 static void test_ipv6_addr_to_str__success4(void)
 {
-    ng_ipv6_addr_t a = NG_IPV6_ADDR_LOOPBACK;
+    ipv6_addr_t a = IPV6_ADDR_LOOPBACK;
     char result[sizeof("::1")];
 
-    TEST_ASSERT_EQUAL_STRING("::1", ng_ipv6_addr_to_str(result, &a, sizeof(result)));
+    TEST_ASSERT_EQUAL_STRING("::1", ipv6_addr_to_str(result, &a, sizeof(result)));
 }
 
 static void test_ipv6_addr_to_str__success5(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0xff, 0xff, 192, 168, 0, 1
         }
     };
-    char result[NG_IPV6_ADDR_MAX_STR_LEN];
+    char result[IPV6_ADDR_MAX_STR_LEN];
 
     TEST_ASSERT_EQUAL_STRING("::ffff:192.168.0.1",
-                             ng_ipv6_addr_to_str(result, &a, sizeof(result)));
+                             ipv6_addr_to_str(result, &a, sizeof(result)));
 }
 
 static void test_ipv6_addr_from_str__one_colon_start(void)
 {
-    ng_ipv6_addr_t result;
+    ipv6_addr_t result;
 
-    TEST_ASSERT_NULL(ng_ipv6_addr_from_str(&result, ":ff::1"));
+    TEST_ASSERT_NULL(ipv6_addr_from_str(&result, ":ff::1"));
 }
 
 static void test_ipv6_addr_from_str__three_colons(void)
 {
-    ng_ipv6_addr_t result;
+    ipv6_addr_t result;
 
-    TEST_ASSERT_NULL(ng_ipv6_addr_from_str(&result, "ff02:::1"));
+    TEST_ASSERT_NULL(ipv6_addr_from_str(&result, "ff02:::1"));
 }
 
 static void test_ipv6_addr_from_str__string_too_long(void)
 {
-    ng_ipv6_addr_t result;
+    ipv6_addr_t result;
 
-    TEST_ASSERT_NULL(ng_ipv6_addr_from_str(&result, "ffff:ffff:ffff:ffff:"
-                                           "ffff:ffff:ffff:ffff:ffff"));
+    TEST_ASSERT_NULL(ipv6_addr_from_str(&result, "ffff:ffff:ffff:ffff:"
+                                        "ffff:ffff:ffff:ffff:ffff"));
 }
 
 static void test_ipv6_addr_from_str__illegal_chars(void)
 {
-    ng_ipv6_addr_t result;
+    ipv6_addr_t result;
 
-    TEST_ASSERT_NULL(ng_ipv6_addr_from_str(&result, ":-)"));
+    TEST_ASSERT_NULL(ipv6_addr_from_str(&result, ":-)"));
 }
 
 static void test_ipv6_addr_from_str__illegal_encapsulated_ipv4(void)
 {
-    ng_ipv6_addr_t result;
+    ipv6_addr_t result;
 
-    TEST_ASSERT_NULL(ng_ipv6_addr_from_str(&result, "192.168.0.1"));
+    TEST_ASSERT_NULL(ipv6_addr_from_str(&result, "192.168.0.1"));
 }
 
 static void test_ipv6_addr_from_str__addr_NULL(void)
 {
-    ng_ipv6_addr_t result;
+    ipv6_addr_t result;
 
-    TEST_ASSERT_NULL(ng_ipv6_addr_from_str(&result, NULL));
+    TEST_ASSERT_NULL(ipv6_addr_from_str(&result, NULL));
 }
 
 static void test_ipv6_addr_from_str__result_NULL(void)
 {
-    TEST_ASSERT_NULL(ng_ipv6_addr_from_str(NULL, "::"));
+    TEST_ASSERT_NULL(ipv6_addr_from_str(NULL, "::"));
 }
 
 static void test_ipv6_addr_from_str__success(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
-    ng_ipv6_addr_t result;
+    ipv6_addr_t result;
 
-    TEST_ASSERT_NOT_NULL(ng_ipv6_addr_from_str(&result, "1:203:405:607:809:a0b:c0d:e0f"));
-    TEST_ASSERT(ng_ipv6_addr_equal(&a, &result));
+    TEST_ASSERT_NOT_NULL(ipv6_addr_from_str(&result, "1:203:405:607:809:a0b:c0d:e0f"));
+    TEST_ASSERT(ipv6_addr_equal(&a, &result));
 }
 
 static void test_ipv6_addr_from_str__success2(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff
         }
     };
-    ng_ipv6_addr_t result;
+    ipv6_addr_t result;
 
-    TEST_ASSERT_NOT_NULL(ng_ipv6_addr_from_str(&result, "fe80::f8f9:fafb:fcfd:feff"));
-    TEST_ASSERT(ng_ipv6_addr_equal(&a, &result));
+    TEST_ASSERT_NOT_NULL(ipv6_addr_from_str(&result, "fe80::f8f9:fafb:fcfd:feff"));
+    TEST_ASSERT(ipv6_addr_equal(&a, &result));
 }
 
 static void test_ipv6_addr_from_str__success3(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff
         }
     };
-    ng_ipv6_addr_t result;
+    ipv6_addr_t result;
 
-    TEST_ASSERT_NOT_NULL(ng_ipv6_addr_from_str(&result, "FE80::F8F9:FAFB:FCFD:FEFF"));
-    TEST_ASSERT(ng_ipv6_addr_equal(&a, &result));
+    TEST_ASSERT_NOT_NULL(ipv6_addr_from_str(&result, "FE80::F8F9:FAFB:FCFD:FEFF"));
+    TEST_ASSERT(ipv6_addr_equal(&a, &result));
 }
 
 static void test_ipv6_addr_from_str__success4(void)
 {
-    ng_ipv6_addr_t a = NG_IPV6_ADDR_UNSPECIFIED;
-    ng_ipv6_addr_t result;
+    ipv6_addr_t a = IPV6_ADDR_UNSPECIFIED;
+    ipv6_addr_t result;
 
-    TEST_ASSERT_NOT_NULL(ng_ipv6_addr_from_str(&result, "::"));
-    TEST_ASSERT(ng_ipv6_addr_equal(&a, &result));
+    TEST_ASSERT_NOT_NULL(ipv6_addr_from_str(&result, "::"));
+    TEST_ASSERT(ipv6_addr_equal(&a, &result));
 }
 
 static void test_ipv6_addr_from_str__success5(void)
 {
-    ng_ipv6_addr_t a = NG_IPV6_ADDR_LOOPBACK;
-    ng_ipv6_addr_t result;
+    ipv6_addr_t a = IPV6_ADDR_LOOPBACK;
+    ipv6_addr_t result;
 
-    TEST_ASSERT_NOT_NULL(ng_ipv6_addr_from_str(&result, "::1"));
-    TEST_ASSERT(ng_ipv6_addr_equal(&a, &result));
+    TEST_ASSERT_NOT_NULL(ipv6_addr_from_str(&result, "::1"));
+    TEST_ASSERT(ipv6_addr_equal(&a, &result));
 }
 
 static void test_ipv6_addr_from_str__success6(void)
 {
-    ng_ipv6_addr_t a = { {
+    ipv6_addr_t a = { {
             0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
             0xff, 0xff, 0xff, 0xff, 255, 255, 255, 255
         }
     };
-    ng_ipv6_addr_t result;
+    ipv6_addr_t result;
 
-    TEST_ASSERT_NOT_NULL(ng_ipv6_addr_from_str(&result, "ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255"));
-    TEST_ASSERT(ng_ipv6_addr_equal(&a, &result));
+    TEST_ASSERT_NOT_NULL(ipv6_addr_from_str(&result, "ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255"));
+    TEST_ASSERT(ipv6_addr_equal(&a, &result));
 }
 
 Test *tests_ipv6_addr_tests(void)

--- a/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.h
+++ b/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.h
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief       Unittests for the ``ng_ipv6_addr`` module
+ * @brief       Unittests for the ``ipv6_addr`` module
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */

--- a/tests/unittests/tests-ipv6_hdr/tests-ipv6_hdr.c
+++ b/tests/unittests/tests-ipv6_hdr/tests-ipv6_hdr.c
@@ -16,7 +16,7 @@
 
 #include "embUnit.h"
 
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/ng_ipv6/hdr.h"
 #include "net/ng_pktbuf.h"
 #include "net/protnum.h"
@@ -301,39 +301,39 @@ static void test_ipv6_hdr_inet_csum__initial_sum_0(void)
 
 static void test_ipv6_hdr_build__wrong_src_len(void)
 {
-    ng_ipv6_addr_t src = DEFAULT_TEST_SRC;
-    ng_ipv6_addr_t dst = DEFAULT_TEST_DST;
+    ipv6_addr_t src = DEFAULT_TEST_SRC;
+    ipv6_addr_t dst = DEFAULT_TEST_DST;
 
     ng_pktbuf_init();
     TEST_ASSERT_NULL(ng_ipv6_hdr_build(NULL, (uint8_t *)&src,
-                                       sizeof(ng_ipv6_addr_t) + TEST_UINT8,
+                                       sizeof(ipv6_addr_t) + TEST_UINT8,
                                        (uint8_t *)&dst,
-                                       sizeof(ng_ipv6_addr_t)));
+                                       sizeof(ipv6_addr_t)));
     TEST_ASSERT(ng_pktbuf_is_empty());
 }
 
 static void test_ipv6_hdr_build__wrong_dst_len(void)
 {
-    ng_ipv6_addr_t src = DEFAULT_TEST_SRC;
-    ng_ipv6_addr_t dst = DEFAULT_TEST_DST;
+    ipv6_addr_t src = DEFAULT_TEST_SRC;
+    ipv6_addr_t dst = DEFAULT_TEST_DST;
 
     ng_pktbuf_init();
     TEST_ASSERT_NULL(ng_ipv6_hdr_build(NULL, (uint8_t *)&src,
-                                       sizeof(ng_ipv6_addr_t),
+                                       sizeof(ipv6_addr_t),
                                        (uint8_t *)&dst,
-                                       sizeof(ng_ipv6_addr_t) + TEST_UINT8));
+                                       sizeof(ipv6_addr_t) + TEST_UINT8));
     TEST_ASSERT(ng_pktbuf_is_empty());
 }
 
 static void test_ipv6_hdr_build__src_NULL(void)
 {
-    ng_ipv6_addr_t dst = DEFAULT_TEST_DST;
+    ipv6_addr_t dst = DEFAULT_TEST_DST;
     ng_pktsnip_t *pkt;
     ng_ipv6_hdr_t *hdr;
 
     ng_pktbuf_init();
     TEST_ASSERT_NOT_NULL((pkt = ng_ipv6_hdr_build(NULL, NULL, 0, (uint8_t *)&dst,
-                                sizeof(ng_ipv6_addr_t))));
+                                sizeof(ipv6_addr_t))));
     hdr = pkt->data;
     TEST_ASSERT_NOT_NULL(hdr);
     TEST_ASSERT(ng_ipv6_hdr_is(hdr));
@@ -341,19 +341,19 @@ static void test_ipv6_hdr_build__src_NULL(void)
     TEST_ASSERT_EQUAL_INT(0, ng_ipv6_hdr_get_fl(hdr));
     TEST_ASSERT_EQUAL_INT(PROTNUM_RESERVED, hdr->nh);
     TEST_ASSERT_EQUAL_INT(0, hdr->hl);
-    TEST_ASSERT(ng_ipv6_addr_equal(&dst, &hdr->dst));
+    TEST_ASSERT(ipv6_addr_equal(&dst, &hdr->dst));
     TEST_ASSERT(!ng_pktbuf_is_empty());
 }
 
 static void test_ipv6_hdr_build__dst_NULL(void)
 {
-    ng_ipv6_addr_t src = DEFAULT_TEST_SRC;
+    ipv6_addr_t src = DEFAULT_TEST_SRC;
     ng_pktsnip_t *pkt;
     ng_ipv6_hdr_t *hdr;
 
     ng_pktbuf_init();
     TEST_ASSERT_NOT_NULL((pkt = ng_ipv6_hdr_build(NULL, (uint8_t *)&src,
-                                sizeof(ng_ipv6_addr_t),
+                                sizeof(ipv6_addr_t),
                                 NULL, 0)));
     hdr = pkt->data;
     TEST_ASSERT_NOT_NULL(hdr);
@@ -362,22 +362,22 @@ static void test_ipv6_hdr_build__dst_NULL(void)
     TEST_ASSERT_EQUAL_INT(0, ng_ipv6_hdr_get_fl(hdr));
     TEST_ASSERT_EQUAL_INT(PROTNUM_RESERVED, hdr->nh);
     TEST_ASSERT_EQUAL_INT(0, hdr->hl);
-    TEST_ASSERT(ng_ipv6_addr_equal(&src, &hdr->src));
+    TEST_ASSERT(ipv6_addr_equal(&src, &hdr->src));
     TEST_ASSERT(!ng_pktbuf_is_empty());
 }
 
 static void test_ipv6_hdr_build__complete(void)
 {
-    ng_ipv6_addr_t src = DEFAULT_TEST_SRC;
-    ng_ipv6_addr_t dst = DEFAULT_TEST_DST;
+    ipv6_addr_t src = DEFAULT_TEST_SRC;
+    ipv6_addr_t dst = DEFAULT_TEST_DST;
     ng_pktsnip_t *pkt;
     ng_ipv6_hdr_t *hdr;
 
     ng_pktbuf_init();
     TEST_ASSERT_NOT_NULL((pkt = ng_ipv6_hdr_build(NULL, (uint8_t *)&src,
-                                sizeof(ng_ipv6_addr_t),
+                                sizeof(ipv6_addr_t),
                                 (uint8_t *)&dst,
-                                sizeof(ng_ipv6_addr_t))));
+                                sizeof(ipv6_addr_t))));
     hdr = pkt->data;
     TEST_ASSERT_NOT_NULL(hdr);
     TEST_ASSERT(ng_ipv6_hdr_is(hdr));
@@ -385,8 +385,8 @@ static void test_ipv6_hdr_build__complete(void)
     TEST_ASSERT_EQUAL_INT(0, ng_ipv6_hdr_get_fl(hdr));
     TEST_ASSERT_EQUAL_INT(PROTNUM_RESERVED, hdr->nh);
     TEST_ASSERT_EQUAL_INT(0, hdr->hl);
-    TEST_ASSERT(ng_ipv6_addr_equal(&src, &hdr->src));
-    TEST_ASSERT(ng_ipv6_addr_equal(&dst, &hdr->dst));
+    TEST_ASSERT(ipv6_addr_equal(&src, &hdr->src));
+    TEST_ASSERT(ipv6_addr_equal(&dst, &hdr->dst));
     TEST_ASSERT(!ng_pktbuf_is_empty());
 }
 

--- a/tests/unittests/tests-ipv6_nc/tests-ipv6_nc.c
+++ b/tests/unittests/tests-ipv6_nc/tests-ipv6_nc.c
@@ -16,7 +16,7 @@
 
 #include "embUnit.h"
 
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/ng_ipv6/nc.h"
 
 #include "unittests-constants.h"
@@ -54,7 +54,7 @@ static void set_up(void)
 
 static void test_ipv6_nc_add__address_registered(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
     ng_ipv6_nc_t *entry1, *entry2;
 
     TEST_ASSERT_NOT_NULL((entry1 = ng_ipv6_nc_add(DEFAULT_TEST_NETIF, &addr,
@@ -74,7 +74,7 @@ static void test_ipv6_nc_add__address_NULL(void)
 
 static void test_ipv6_nc_add__iface_KERNEL_PID_UNDEF(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
 
     TEST_ASSERT_NOT_NULL(ng_ipv6_nc_add(KERNEL_PID_UNDEF, &addr, TEST_STRING4,
                                         sizeof(TEST_STRING4), 0));
@@ -82,7 +82,7 @@ static void test_ipv6_nc_add__iface_KERNEL_PID_UNDEF(void)
 
 static void test_ipv6_nc_add__addr_unspecified(void)
 {
-    ng_ipv6_addr_t addr = NG_IPV6_ADDR_UNSPECIFIED;
+    ipv6_addr_t addr = IPV6_ADDR_UNSPECIFIED;
 
     TEST_ASSERT_NULL(ng_ipv6_nc_add(DEFAULT_TEST_NETIF, &addr, TEST_STRING4,
                                     sizeof(TEST_STRING4), 0));
@@ -90,7 +90,7 @@ static void test_ipv6_nc_add__addr_unspecified(void)
 
 static void test_ipv6_nc_add__l2addr_too_long(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
 
     TEST_ASSERT_NULL(ng_ipv6_nc_add(DEFAULT_TEST_NETIF, &addr, TEST_STRING4,
                                     NG_IPV6_NC_L2_ADDR_MAX + TEST_UINT8, 0));
@@ -98,7 +98,7 @@ static void test_ipv6_nc_add__l2addr_too_long(void)
 
 static void test_ipv6_nc_add__full(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
 
     for (int i = 0; i < NG_IPV6_NC_SIZE; i++) {
         TEST_ASSERT_NOT_NULL(ng_ipv6_nc_add(DEFAULT_TEST_NETIF, &addr, TEST_STRING4,
@@ -112,7 +112,7 @@ static void test_ipv6_nc_add__full(void)
 
 static void test_ipv6_nc_add__success(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
     ng_ipv6_nc_t *entry1, *entry2;
 
     TEST_ASSERT_NOT_NULL((entry1 = ng_ipv6_nc_add(DEFAULT_TEST_NETIF, &addr,
@@ -125,8 +125,8 @@ static void test_ipv6_nc_add__success(void)
 
 static void test_ipv6_nc_add__address_update_despite_free_entry(void)
 {
-    ng_ipv6_addr_t default_addr = DEFAULT_TEST_IPV6_ADDR;
-    ng_ipv6_addr_t other_addr = OTHER_TEST_IPV6_ADDR;
+    ipv6_addr_t default_addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t other_addr = OTHER_TEST_IPV6_ADDR;
     ng_ipv6_nc_t *entry1, *entry2;
 
     TEST_ASSERT_NOT_NULL(ng_ipv6_nc_add(OTHER_TEST_NETIF, &other_addr,
@@ -146,7 +146,7 @@ static void test_ipv6_nc_add__address_update_despite_free_entry(void)
 
 static void test_ipv6_nc_remove__no_entry_pid(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
 
     test_ipv6_nc_add__success(); /* adds DEFAULT_TEST_IPV6_ADDR to DEFAULT_TEST_NETIF */
     ng_ipv6_nc_remove(OTHER_TEST_NETIF, &addr);
@@ -156,8 +156,8 @@ static void test_ipv6_nc_remove__no_entry_pid(void)
 
 static void test_ipv6_nc_remove__no_entry_addr1(void)
 {
-    ng_ipv6_addr_t addr = OTHER_TEST_IPV6_ADDR;
-    ng_ipv6_addr_t exp_addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = OTHER_TEST_IPV6_ADDR;
+    ipv6_addr_t exp_addr = DEFAULT_TEST_IPV6_ADDR;
 
     test_ipv6_nc_add__success(); /* adds DEFAULT_TEST_IPV6_ADDR to DEFAULT_TEST_NETIF */
     ng_ipv6_nc_remove(DEFAULT_TEST_NETIF, &addr);
@@ -167,8 +167,8 @@ static void test_ipv6_nc_remove__no_entry_addr1(void)
 
 static void test_ipv6_nc_remove__no_entry_addr2(void)
 {
-    ng_ipv6_addr_t addr = NG_IPV6_ADDR_UNSPECIFIED;
-    ng_ipv6_addr_t exp_addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = IPV6_ADDR_UNSPECIFIED;
+    ipv6_addr_t exp_addr = DEFAULT_TEST_IPV6_ADDR;
 
     test_ipv6_nc_add__success(); /* adds DEFAULT_TEST_IPV6_ADDR to DEFAULT_TEST_NETIF */
     ng_ipv6_nc_remove(DEFAULT_TEST_NETIF, &addr);
@@ -178,7 +178,7 @@ static void test_ipv6_nc_remove__no_entry_addr2(void)
 
 static void test_ipv6_nc_remove__success(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
 
     test_ipv6_nc_add__success(); /* adds DEFAULT_TEST_IPV6_ADDR to DEFAULT_TEST_NETIF */
     TEST_ASSERT_NOT_NULL(ng_ipv6_nc_get(DEFAULT_TEST_NETIF, &addr));
@@ -188,14 +188,14 @@ static void test_ipv6_nc_remove__success(void)
 
 static void test_ipv6_nc_get__empty(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
 
     TEST_ASSERT_NULL(ng_ipv6_nc_get(DEFAULT_TEST_NETIF, &addr));
 }
 
 static void test_ipv6_nc_get__different_if(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
 
     test_ipv6_nc_add__success(); /* adds DEFAULT_TEST_IPV6_ADDR to DEFAULT_TEST_NETIF */
 
@@ -204,7 +204,7 @@ static void test_ipv6_nc_get__different_if(void)
 
 static void test_ipv6_nc_get__different_addr(void)
 {
-    ng_ipv6_addr_t addr = OTHER_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = OTHER_TEST_IPV6_ADDR;
 
     test_ipv6_nc_add__success(); /* adds DEFAULT_TEST_IPV6_ADDR to DEFAULT_TEST_NETIF */
 
@@ -213,14 +213,14 @@ static void test_ipv6_nc_get__different_addr(void)
 
 static void test_ipv6_nc_get__success_if_local(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
     ng_ipv6_nc_t *entry = NULL;
 
     test_ipv6_nc_add__success(); /* adds DEFAULT_TEST_IPV6_ADDR to DEFAULT_TEST_NETIF */
 
     TEST_ASSERT_NOT_NULL((entry = ng_ipv6_nc_get(DEFAULT_TEST_NETIF, &addr)));
     TEST_ASSERT_EQUAL_INT(DEFAULT_TEST_NETIF, entry->iface);
-    TEST_ASSERT(ng_ipv6_addr_equal(&(entry->ipv6_addr), &addr));
+    TEST_ASSERT(ipv6_addr_equal(&(entry->ipv6_addr), &addr));
     TEST_ASSERT_EQUAL_STRING(TEST_STRING4, (char *)entry->l2_addr);
     TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING4), entry->l2_addr_len);
     TEST_ASSERT_EQUAL_INT(0, entry->flags);
@@ -228,14 +228,14 @@ static void test_ipv6_nc_get__success_if_local(void)
 
 static void test_ipv6_nc_get__success_if_global(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
     ng_ipv6_nc_t *entry = NULL;
 
     test_ipv6_nc_add__success(); /* adds DEFAULT_TEST_IPV6_ADDR to DEFAULT_TEST_NETIF */
 
     TEST_ASSERT_NOT_NULL((entry = ng_ipv6_nc_get(KERNEL_PID_UNDEF, &addr)));
     TEST_ASSERT_EQUAL_INT(DEFAULT_TEST_NETIF, entry->iface);
-    TEST_ASSERT(ng_ipv6_addr_equal(&(entry->ipv6_addr), &addr));
+    TEST_ASSERT(ipv6_addr_equal(&(entry->ipv6_addr), &addr));
     TEST_ASSERT_EQUAL_STRING(TEST_STRING4, (char *)entry->l2_addr);
     TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING4), entry->l2_addr_len);
     TEST_ASSERT_EQUAL_INT(0, entry->flags);
@@ -258,7 +258,7 @@ static void test_ipv6_nc_get_next__1_entry(void)
 
 static void test_ipv6_nc_get_next__2_entries(void)
 {
-    ng_ipv6_addr_t addr = OTHER_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = OTHER_TEST_IPV6_ADDR;
     ng_ipv6_nc_t *entry = NULL;
 
     test_ipv6_nc_add__success(); /* adds DEFAULT_TEST_IPV6_ADDR to DEFAULT_TEST_NETIF */
@@ -273,8 +273,8 @@ static void test_ipv6_nc_get_next__2_entries(void)
 
 static void test_ipv6_nc_get_next__holey(void)
 {
-    ng_ipv6_addr_t addr1 = OTHER_TEST_IPV6_ADDR;
-    ng_ipv6_addr_t addr2 = THIRD_TEST_IPV6_ADDR;
+    ipv6_addr_t addr1 = OTHER_TEST_IPV6_ADDR;
+    ipv6_addr_t addr2 = THIRD_TEST_IPV6_ADDR;
     ng_ipv6_nc_t *entry = NULL, *exp_entry = NULL;
 
     /* adds DEFAULT_TEST_IPV6_ADDR and OTHER_TEST_IPV6_ADDR to DEFAULT_TEST_NETIF */
@@ -327,7 +327,7 @@ static void test_ipv6_nc_get_next_router__second_entry(void)
 
 static void test_ipv6_nc_is_reachable__incomplete(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
     ng_ipv6_nc_t *entry = NULL;
 
     test_ipv6_nc_add__success(); /* adds DEFAULT_TEST_IPV6_ADDR to DEFAULT_TEST_NETIF */
@@ -339,7 +339,7 @@ static void test_ipv6_nc_is_reachable__incomplete(void)
 
 static void test_ipv6_nc_is_reachable__reachable(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
     ng_ipv6_nc_t *entry = NULL;
 
     test_ipv6_nc_add__success(); /* adds DEFAULT_TEST_IPV6_ADDR to DEFAULT_TEST_NETIF */
@@ -351,7 +351,7 @@ static void test_ipv6_nc_is_reachable__reachable(void)
 
 static void test_ipv6_nc_still_reachable__incomplete(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
     ng_ipv6_nc_t *entry = NULL;
 
     /* adds DEFAULT_TEST_IPV6_ADDR to DEFAULT_TEST_NETIF and sets flags to
@@ -366,7 +366,7 @@ static void test_ipv6_nc_still_reachable__incomplete(void)
 
 static void test_ipv6_nc_still_reachable__success(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
     ng_ipv6_nc_t *entry = NULL;
 
     /* adds DEFAULT_TEST_IPV6_ADDR to DEFAULT_TEST_NETIF and sets flags to

--- a/tests/unittests/tests-ipv6_netif/Makefile.include
+++ b/tests/unittests/tests-ipv6_netif/Makefile.include
@@ -1,4 +1,4 @@
-USEMODULE += ng_ipv6_addr
+USEMODULE += ipv6_addr
 USEMODULE += ng_ipv6_netif
 USEMODULE += ng_netif
 

--- a/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
+++ b/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
@@ -83,7 +83,7 @@ static void test_netif_add__success_with_ipv6(void)
     kernel_pid_t pids[NG_NETIF_NUMOF];
     size_t pid_num;
     ng_ipv6_netif_t *entry;
-    ng_ipv6_addr_t exp_addr = NG_IPV6_ADDR_ALL_NODES_LINK_LOCAL;
+    ipv6_addr_t exp_addr = IPV6_ADDR_ALL_NODES_LINK_LOCAL;
 
     ng_netif_add(DEFAULT_TEST_NETIF);
 
@@ -137,7 +137,7 @@ static void test_ipv6_netif_get__empty(void)
 
 static void test_ipv6_netif_add_addr__no_iface1(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
 
     TEST_ASSERT_NULL(ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr, DEFAULT_TEST_PREFIX_LEN, 0));
 }
@@ -156,7 +156,7 @@ static void test_ipv6_netif_add_addr__addr_NULL(void)
 
 static void test_ipv6_netif_add_addr__addr_unspecified(void)
 {
-    ng_ipv6_addr_t addr = NG_IPV6_ADDR_UNSPECIFIED;
+    ipv6_addr_t addr = IPV6_ADDR_UNSPECIFIED;
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
@@ -165,11 +165,11 @@ static void test_ipv6_netif_add_addr__addr_unspecified(void)
 
 static void test_ipv6_netif_add_addr__full(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR, *res = &addr;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR, *res = &addr;
     int i;
 
     /* make link local to avoid automatic link local adding */
-    ng_ipv6_addr_set_link_local_prefix(&addr);
+    ipv6_addr_set_link_local_prefix(&addr);
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
@@ -180,7 +180,7 @@ static void test_ipv6_netif_add_addr__full(void)
 
 static void test_ipv6_netif_add_addr__success(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
@@ -190,11 +190,11 @@ static void test_ipv6_netif_add_addr__success(void)
 static void test_ipv6_netif_add_addr__despite_free_entry(void)
 {
     /* Tests for possible duplicates as described in http://github.com/RIOT-OS/RIOT/issues/2965 */
-    ng_ipv6_addr_t *entry_1;
-    ng_ipv6_addr_t *entry_2;
+    ipv6_addr_t *entry_1;
+    ipv6_addr_t *entry_2;
 
-    ng_ipv6_addr_t default_addr = DEFAULT_TEST_IPV6_ADDR;
-    ng_ipv6_addr_t ll_addr;
+    ipv6_addr_t default_addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t ll_addr;
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
@@ -208,7 +208,7 @@ static void test_ipv6_netif_add_addr__despite_free_entry(void)
     /* create and re-add corresponding lla and check that it hasn't taken
      * the old place of default_addr*/
     ll_addr.u64[1] = default_addr.u64[1];
-    ng_ipv6_addr_set_link_local_prefix(&ll_addr);
+    ipv6_addr_set_link_local_prefix(&ll_addr);
     TEST_ASSERT_NOT_NULL((entry_2 = ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &ll_addr, DEFAULT_TEST_PREFIX_LEN, 0)));
 
     TEST_ASSERT(entry_1 != entry_2);
@@ -216,8 +216,8 @@ static void test_ipv6_netif_add_addr__despite_free_entry(void)
 
 static void test_ipv6_netif_remove_addr__not_allocated(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
-    ng_ipv6_addr_t other_addr = OTHER_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t other_addr = OTHER_TEST_IPV6_ADDR;
 
     test_ipv6_netif_add_addr__success(); /* adds DEFAULT_TEST_IPV6_ADDR to
                                           * DEFAULT_TEST_NETIF */
@@ -230,7 +230,7 @@ static void test_ipv6_netif_remove_addr__not_allocated(void)
 
 static void test_ipv6_netif_remove_addr__success(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
 
     test_ipv6_netif_add_addr__success(); /* adds DEFAULT_TEST_IPV6_ADDR to
                                           * DEFAULT_TEST_NETIF */
@@ -242,7 +242,7 @@ static void test_ipv6_netif_remove_addr__success(void)
 
 static void test_ipv6_netif_reset_addr__success(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
 
     test_ipv6_netif_add_addr__success(); /* adds DEFAULT_TEST_IPV6_ADDR to
                                           * DEFAULT_TEST_NETIF */
@@ -254,8 +254,8 @@ static void test_ipv6_netif_reset_addr__success(void)
 
 static void test_ipv6_netif_find_by_addr__empty(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
-    ng_ipv6_addr_t *out = NULL;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t *out = NULL;
 
     TEST_ASSERT_EQUAL_INT(KERNEL_PID_UNDEF, ng_ipv6_netif_find_by_addr(&out, &addr));
     TEST_ASSERT_NULL(out);
@@ -263,8 +263,8 @@ static void test_ipv6_netif_find_by_addr__empty(void)
 
 static void test_ipv6_netif_find_by_addr__success(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
-    ng_ipv6_addr_t *out = NULL;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t *out = NULL;
 
     test_ipv6_netif_add_addr__success(); /* adds DEFAULT_TEST_IPV6_ADDR to
                                           * DEFAULT_TEST_NETIF */
@@ -272,19 +272,19 @@ static void test_ipv6_netif_find_by_addr__success(void)
     TEST_ASSERT_EQUAL_INT(DEFAULT_TEST_NETIF, ng_ipv6_netif_find_by_addr(&out, &addr));
     TEST_ASSERT_NOT_NULL(out);
     TEST_ASSERT(out != &addr);
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(out, &addr));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(out, &addr));
 }
 
 static void test_ipv6_netif_find_addr__no_iface(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
 
     TEST_ASSERT_NULL(ng_ipv6_netif_find_addr(DEFAULT_TEST_NETIF, &addr));
 }
 
 static void test_ipv6_netif_find_addr__wrong_iface(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
 
     test_ipv6_netif_add_addr__success(); /* adds DEFAULT_TEST_IPV6_ADDR to
                                           * DEFAULT_TEST_NETIF */
@@ -294,7 +294,7 @@ static void test_ipv6_netif_find_addr__wrong_iface(void)
 
 static void test_ipv6_netif_find_addr__wrong_addr(void)
 {
-    ng_ipv6_addr_t addr = OTHER_TEST_IPV6_ADDR;
+    ipv6_addr_t addr = OTHER_TEST_IPV6_ADDR;
 
     test_ipv6_netif_add_addr__success(); /* adds DEFAULT_TEST_IPV6_ADDR to
                                           * DEFAULT_TEST_NETIF */
@@ -304,26 +304,26 @@ static void test_ipv6_netif_find_addr__wrong_addr(void)
 
 static void test_ipv6_netif_find_addr__success(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
-    ng_ipv6_addr_t *out = NULL;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t *out = NULL;
 
     test_ipv6_netif_add_addr__success(); /* adds DEFAULT_TEST_IPV6_ADDR to
                                           * DEFAULT_TEST_NETIF */
 
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_find_addr(DEFAULT_TEST_NETIF, &addr)));
     TEST_ASSERT(out != &addr);
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(out, &addr));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(out, &addr));
 
     /* also test for link local address */
-    ng_ipv6_addr_set_link_local_prefix(&addr);
+    ipv6_addr_set_link_local_prefix(&addr);
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_find_addr(DEFAULT_TEST_NETIF, &addr)));
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(out, &addr));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(out, &addr));
 }
 
 static void test_ipv6_netif_find_by_prefix__success1(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_PREFIX23;
-    ng_ipv6_addr_t *out = NULL;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_PREFIX23;
+    ipv6_addr_t *out = NULL;
 
     test_ipv6_netif_add_addr__success(); /* adds DEFAULT_TEST_IPV6_ADDR to
                                           * DEFAULT_TEST_NETIF */
@@ -331,13 +331,13 @@ static void test_ipv6_netif_find_by_prefix__success1(void)
     TEST_ASSERT_EQUAL_INT(DEFAULT_TEST_NETIF, ng_ipv6_netif_find_by_prefix(&out, &addr));
     TEST_ASSERT_NOT_NULL(out);
     TEST_ASSERT(out != &addr);
-    TEST_ASSERT_EQUAL_INT(23, ng_ipv6_addr_match_prefix(out, &addr));
+    TEST_ASSERT_EQUAL_INT(23, ipv6_addr_match_prefix(out, &addr));
 }
 
 static void test_ipv6_netif_find_by_prefix__success2(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_PREFIX18;
-    ng_ipv6_addr_t *out = NULL;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_PREFIX18;
+    ipv6_addr_t *out = NULL;
 
     test_ipv6_netif_add_addr__success(); /* adds DEFAULT_TEST_IPV6_ADDR to
                                           * DEFAULT_TEST_NETIF */
@@ -345,13 +345,13 @@ static void test_ipv6_netif_find_by_prefix__success2(void)
     TEST_ASSERT_EQUAL_INT(DEFAULT_TEST_NETIF, ng_ipv6_netif_find_by_prefix(&out, &addr));
     TEST_ASSERT_NOT_NULL(out);
     TEST_ASSERT(out != &addr);
-    TEST_ASSERT_EQUAL_INT(18, ng_ipv6_addr_match_prefix(out, &addr));
+    TEST_ASSERT_EQUAL_INT(18, ipv6_addr_match_prefix(out, &addr));
 }
 
 static void test_ipv6_netif_find_by_prefix__success3(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_PREFIX64;
-    ng_ipv6_addr_t *out = NULL;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_PREFIX64;
+    ipv6_addr_t *out = NULL;
 
     test_ipv6_netif_add_addr__success(); /* adds DEFAULT_TEST_IPV6_ADDR to
                                           * DEFAULT_TEST_NETIF */
@@ -359,60 +359,60 @@ static void test_ipv6_netif_find_by_prefix__success3(void)
     TEST_ASSERT_EQUAL_INT(DEFAULT_TEST_NETIF, ng_ipv6_netif_find_by_prefix(&out, &addr));
     TEST_ASSERT_NOT_NULL(out);
     TEST_ASSERT(out != &addr);
-    TEST_ASSERT_EQUAL_INT(64, ng_ipv6_addr_match_prefix(out, &addr));
+    TEST_ASSERT_EQUAL_INT(64, ipv6_addr_match_prefix(out, &addr));
 }
 
 static void test_ipv6_netif_match_prefix__success1(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_PREFIX23;
-    ng_ipv6_addr_t *out = NULL;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_PREFIX23;
+    ipv6_addr_t *out = NULL;
 
     test_ipv6_netif_add_addr__success(); /* adds DEFAULT_TEST_IPV6_ADDR to
                                           * DEFAULT_TEST_NETIF */
 
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_match_prefix(DEFAULT_TEST_NETIF, &addr)));
     TEST_ASSERT(out != &addr);
-    TEST_ASSERT_EQUAL_INT(23, ng_ipv6_addr_match_prefix(out, &addr));
+    TEST_ASSERT_EQUAL_INT(23, ipv6_addr_match_prefix(out, &addr));
 }
 
 static void test_ipv6_netif_match_prefix__success2(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_PREFIX18;
-    ng_ipv6_addr_t *out = NULL;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_PREFIX18;
+    ipv6_addr_t *out = NULL;
 
     test_ipv6_netif_add_addr__success(); /* adds DEFAULT_TEST_IPV6_ADDR to
                                           * DEFAULT_TEST_NETIF */
 
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_match_prefix(DEFAULT_TEST_NETIF, &addr)));
     TEST_ASSERT(out != &addr);
-    TEST_ASSERT_EQUAL_INT(18, ng_ipv6_addr_match_prefix(out, &addr));
+    TEST_ASSERT_EQUAL_INT(18, ipv6_addr_match_prefix(out, &addr));
 }
 
 static void test_ipv6_netif_match_prefix__success3(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_PREFIX64;
-    ng_ipv6_addr_t *out = NULL;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_PREFIX64;
+    ipv6_addr_t *out = NULL;
 
     test_ipv6_netif_add_addr__success(); /* adds DEFAULT_TEST_IPV6_ADDR to
                                           * DEFAULT_TEST_NETIF */
 
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_match_prefix(DEFAULT_TEST_NETIF, &addr)));
     TEST_ASSERT(out != &addr);
-    TEST_ASSERT_EQUAL_INT(64, ng_ipv6_addr_match_prefix(out, &addr));
+    TEST_ASSERT_EQUAL_INT(64, ipv6_addr_match_prefix(out, &addr));
 }
 
 static void test_ipv6_netif_find_best_src_addr__no_unicast(void)
 {
-    ng_ipv6_addr_t ll_addr1 = NG_IPV6_ADDR_UNSPECIFIED;
-    ng_ipv6_addr_t ll_addr2 = NG_IPV6_ADDR_UNSPECIFIED;
-    ng_ipv6_addr_t mc_addr = NG_IPV6_ADDR_ALL_NODES_LINK_LOCAL;
+    ipv6_addr_t ll_addr1 = IPV6_ADDR_UNSPECIFIED;
+    ipv6_addr_t ll_addr2 = IPV6_ADDR_UNSPECIFIED;
+    ipv6_addr_t mc_addr = IPV6_ADDR_ALL_NODES_LINK_LOCAL;
 
     ll_addr1.u8[15] = 1;
-    ng_ipv6_addr_set_link_local_prefix(&ll_addr1);
+    ipv6_addr_set_link_local_prefix(&ll_addr1);
     ll_addr2.u8[15] = 2;
-    ng_ipv6_addr_set_link_local_prefix(&ll_addr2);
+    ipv6_addr_set_link_local_prefix(&ll_addr2);
 
-    TEST_ASSERT_EQUAL_INT(126, ng_ipv6_addr_match_prefix(&ll_addr2, &ll_addr1));
+    TEST_ASSERT_EQUAL_INT(126, ipv6_addr_match_prefix(&ll_addr2, &ll_addr1));
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
     TEST_ASSERT_NOT_NULL(ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &mc_addr, DEFAULT_TEST_PREFIX_LEN,
@@ -425,17 +425,17 @@ static void test_ipv6_netif_find_best_src_addr__no_unicast(void)
 
 static void test_ipv6_netif_find_best_src_addr__success(void)
 {
-    ng_ipv6_addr_t ll_addr1 = NG_IPV6_ADDR_UNSPECIFIED;
-    ng_ipv6_addr_t ll_addr2 = NG_IPV6_ADDR_UNSPECIFIED;
-    ng_ipv6_addr_t mc_addr = NG_IPV6_ADDR_ALL_NODES_LINK_LOCAL;
-    ng_ipv6_addr_t *out = NULL;
+    ipv6_addr_t ll_addr1 = IPV6_ADDR_UNSPECIFIED;
+    ipv6_addr_t ll_addr2 = IPV6_ADDR_UNSPECIFIED;
+    ipv6_addr_t mc_addr = IPV6_ADDR_ALL_NODES_LINK_LOCAL;
+    ipv6_addr_t *out = NULL;
 
     ll_addr1.u8[15] = 1;
-    ng_ipv6_addr_set_link_local_prefix(&ll_addr1);
+    ipv6_addr_set_link_local_prefix(&ll_addr1);
     ll_addr2.u8[15] = 2;
-    ng_ipv6_addr_set_link_local_prefix(&ll_addr2);
+    ipv6_addr_set_link_local_prefix(&ll_addr2);
 
-    TEST_ASSERT_EQUAL_INT(126, ng_ipv6_addr_match_prefix(&ll_addr2, &ll_addr1));
+    TEST_ASSERT_EQUAL_INT(126, ipv6_addr_match_prefix(&ll_addr2, &ll_addr1));
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
     TEST_ASSERT_NOT_NULL(ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &mc_addr, DEFAULT_TEST_PREFIX_LEN,
@@ -446,28 +446,28 @@ static void test_ipv6_netif_find_best_src_addr__success(void)
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_find_best_src_addr(DEFAULT_TEST_NETIF, &ll_addr2)));
     TEST_ASSERT(out != &ll_addr1);
     TEST_ASSERT(out != &ll_addr2);
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(out, &ll_addr1));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(out, &ll_addr1));
 }
 
 static void test_ipv6_netif_find_best_src_addr__multicast_input(void)
 {
-    ng_ipv6_addr_t mc_addr = NG_IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL;
-    ng_ipv6_addr_t *out = NULL;
+    ipv6_addr_t mc_addr = IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL;
+    ipv6_addr_t *out = NULL;
 
     /* Adds DEFAULT_TEST_NETIF as interface and to it fe80::1, fe80::2 and ff02::1 */
     test_ipv6_netif_find_best_src_addr__success();
 
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_find_best_src_addr(DEFAULT_TEST_NETIF, &mc_addr)));
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_equal(&mc_addr, out));
-    TEST_ASSERT_EQUAL_INT(false, ng_ipv6_addr_is_unspecified(out));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_equal(&mc_addr, out));
+    TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_unspecified(out));
 }
 
 static void test_ipv6_netif_find_best_src_addr__other_subnet(void)
 {
-    ng_ipv6_addr_t addr1 = DEFAULT_TEST_IPV6_ADDR;
-    ng_ipv6_addr_t addr2 = OTHER_TEST_IPV6_ADDR;
+    ipv6_addr_t addr1 = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t addr2 = OTHER_TEST_IPV6_ADDR;
 
-    ng_ipv6_addr_t *out = NULL;
+    ipv6_addr_t *out = NULL;
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
     TEST_ASSERT_NOT_NULL(ng_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr1, DEFAULT_TEST_PREFIX_LEN,
@@ -475,13 +475,13 @@ static void test_ipv6_netif_find_best_src_addr__other_subnet(void)
 
     TEST_ASSERT_NOT_NULL((out = ng_ipv6_netif_find_best_src_addr(DEFAULT_TEST_NETIF, &addr2)));
     TEST_ASSERT(out != &addr1);
-    TEST_ASSERT_EQUAL_INT(true, ng_ipv6_addr_equal(out, &addr1));
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(out, &addr1));
 }
 
 static void test_ipv6_netif_addr_is_non_unicast__unicast(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
-    ng_ipv6_addr_t *out = NULL;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t *out = NULL;
 
     test_ipv6_netif_add_addr__success(); /* adds DEFAULT_TEST_IPV6_ADDR to
                                           * DEFAULT_TEST_NETIF */
@@ -492,8 +492,8 @@ static void test_ipv6_netif_addr_is_non_unicast__unicast(void)
 
 static void test_ipv6_netif_addr_is_non_unicast__anycast(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
-    ng_ipv6_addr_t *out = NULL;
+    ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
+    ipv6_addr_t *out = NULL;
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
@@ -506,8 +506,8 @@ static void test_ipv6_netif_addr_is_non_unicast__anycast(void)
 
 static void test_ipv6_netif_addr_is_non_unicast__multicast1(void)
 {
-    ng_ipv6_addr_t addr = NG_IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL;
-    ng_ipv6_addr_t *out = NULL;
+    ipv6_addr_t addr = IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL;
+    ipv6_addr_t *out = NULL;
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
@@ -519,8 +519,8 @@ static void test_ipv6_netif_addr_is_non_unicast__multicast1(void)
 
 static void test_ipv6_netif_addr_is_non_unicast__multicast2(void)
 {
-    ng_ipv6_addr_t addr = NG_IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL;
-    ng_ipv6_addr_t *out = NULL;
+    ipv6_addr_t addr = IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL;
+    ipv6_addr_t *out = NULL;
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 

--- a/tests/unittests/tests-sixlowpan_ctx/tests-sixlowpan_ctx.c
+++ b/tests/unittests/tests-sixlowpan_ctx/tests-sixlowpan_ctx.c
@@ -17,7 +17,7 @@
 
 #include "embUnit.h"
 
-#include "net/ng_ipv6/addr.h"
+#include "net/ipv6/addr.h"
 #include "net/ng_sixlowpan/ctx.h"
 
 #include "unittests-constants.h"
@@ -50,7 +50,7 @@ static void tear_down(void)
 
 static void test_sixlowpan_ctx_update__success(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
+    ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
 
     TEST_ASSERT_NOT_NULL(ng_sixlowpan_ctx_update(DEFAULT_TEST_ID, &addr,
                                                  DEFAULT_TEST_PREFIX_LEN,
@@ -60,7 +60,7 @@ static void test_sixlowpan_ctx_update__success(void)
 
 static void test_sixlowpan_ctx_update__ltime0(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
+    ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
 
     TEST_ASSERT_NOT_NULL(ng_sixlowpan_ctx_update(DEFAULT_TEST_ID, &addr,
                                                  DEFAULT_TEST_PREFIX_LEN,
@@ -71,7 +71,7 @@ static void test_sixlowpan_ctx_update__ltime0(void)
 
 static void test_sixlowpan_ctx_update__wrong_id1(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
+    ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
 
     /* add context DEFAULT_TEST_PREFIX to DEFAULT_TEST_ID */
     test_sixlowpan_ctx_update__success();
@@ -90,7 +90,7 @@ static void test_sixlowpan_ctx_update__wrong_id1(void)
 
 static void test_sixlowpan_ctx_update__wrong_id2(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
+    ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
 
     /* add context DEFAULT_TEST_PREFIX to DEFAULT_TEST_ID */
     test_sixlowpan_ctx_update__success();
@@ -109,7 +109,7 @@ static void test_sixlowpan_ctx_update__wrong_id2(void)
 
 static void test_sixlowpan_ctx_update__wrong_prefix_len(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
+    ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
 
     TEST_ASSERT_NULL(ng_sixlowpan_ctx_update(DEFAULT_TEST_ID, &addr,
                                              0, TEST_UINT16, true));
@@ -118,14 +118,14 @@ static void test_sixlowpan_ctx_update__wrong_prefix_len(void)
 
 static void test_sixlowpan_ctx_lookup_addr__empty(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
+    ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
 
     TEST_ASSERT_NULL(ng_sixlowpan_ctx_lookup_addr(&addr));
 }
 
 static void test_sixlowpan_ctx_lookup_addr__same_addr(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
+    ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
     ng_sixlowpan_ctx_t *ctx;
 
     /* add context DEFAULT_TEST_PREFIX to DEFAULT_TEST_ID */
@@ -134,13 +134,13 @@ static void test_sixlowpan_ctx_lookup_addr__same_addr(void)
     TEST_ASSERT_EQUAL_INT(NG_SIXLOWPAN_CTX_FLAGS_COMP | DEFAULT_TEST_ID, ctx->flags_id);
     TEST_ASSERT_EQUAL_INT(DEFAULT_TEST_PREFIX_LEN, ctx->prefix_len);
     TEST_ASSERT(TEST_UINT16 >= ctx->ltime);
-    TEST_ASSERT(DEFAULT_TEST_PREFIX_LEN >= ng_ipv6_addr_match_prefix(&addr, &ctx->prefix));
+    TEST_ASSERT(DEFAULT_TEST_PREFIX_LEN >= ipv6_addr_match_prefix(&addr, &ctx->prefix));
 }
 
 static void test_sixlowpan_ctx_lookup_addr__other_addr_same_prefix(void)
 {
-    ng_ipv6_addr_t addr1 = DEFAULT_TEST_PREFIX;
-    ng_ipv6_addr_t addr2 = OTHER_TEST_PREFIX;
+    ipv6_addr_t addr1 = DEFAULT_TEST_PREFIX;
+    ipv6_addr_t addr2 = OTHER_TEST_PREFIX;
     ng_sixlowpan_ctx_t *ctx;
 
     /* add context DEFAULT_TEST_PREFIX to DEFAULT_TEST_ID */
@@ -149,12 +149,12 @@ static void test_sixlowpan_ctx_lookup_addr__other_addr_same_prefix(void)
     TEST_ASSERT_EQUAL_INT(NG_SIXLOWPAN_CTX_FLAGS_COMP | DEFAULT_TEST_ID, ctx->flags_id);
     TEST_ASSERT_EQUAL_INT(DEFAULT_TEST_PREFIX_LEN, ctx->prefix_len);
     TEST_ASSERT(TEST_UINT16 >= ctx->ltime);
-    TEST_ASSERT(DEFAULT_TEST_PREFIX_LEN >= ng_ipv6_addr_match_prefix(&addr1, &ctx->prefix));
+    TEST_ASSERT(DEFAULT_TEST_PREFIX_LEN >= ipv6_addr_match_prefix(&addr1, &ctx->prefix));
 }
 
 static void test_sixlowpan_ctx_lookup_addr__other_addr_other_prefix(void)
 {
-    ng_ipv6_addr_t addr = WRONG_TEST_PREFIX;
+    ipv6_addr_t addr = WRONG_TEST_PREFIX;
 
     /* add context DEFAULT_TEST_PREFIX to DEFAULT_TEST_ID */
     test_sixlowpan_ctx_update__success();
@@ -175,7 +175,7 @@ static void test_sixlowpan_ctx_lookup_id__wrong_id(void)
 
 static void test_sixlowpan_ctx_lookup_id__success(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
+    ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
     ng_sixlowpan_ctx_t *ctx;
 
     /* add context DEFAULT_TEST_PREFIX to DEFAULT_TEST_ID */
@@ -184,12 +184,12 @@ static void test_sixlowpan_ctx_lookup_id__success(void)
     TEST_ASSERT_EQUAL_INT(NG_SIXLOWPAN_CTX_FLAGS_COMP | DEFAULT_TEST_ID, ctx->flags_id);
     TEST_ASSERT_EQUAL_INT(DEFAULT_TEST_PREFIX_LEN, ctx->prefix_len);
     TEST_ASSERT(TEST_UINT16 >= ctx->ltime);
-    TEST_ASSERT(DEFAULT_TEST_PREFIX_LEN >= ng_ipv6_addr_match_prefix(&addr, &ctx->prefix));
+    TEST_ASSERT(DEFAULT_TEST_PREFIX_LEN >= ipv6_addr_match_prefix(&addr, &ctx->prefix));
 }
 
 static void test_sixlowpan_ctx_remove(void)
 {
-    ng_ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
+    ipv6_addr_t addr = DEFAULT_TEST_PREFIX;
 
     /* add context DEFAULT_TEST_PREFIX to DEFAULT_TEST_ID */
     test_sixlowpan_ctx_update__success();


### PR DESCRIPTION
```sh
mkdir -p sys/include/net/ipv6/
git mv sys/include/net/ng_ipv6/addr.h sys/include/net/ipv6/addr.h
git grep --name-only -i 'ng_ipv6[_/]addr' | \
    xargs sed -i -e 's/ng_\(ipv6[_/]addr\)\(.\+\)\( \+\/.*\)/\1\2   \3/gI' \
        -e 's/\(#define *\)ng_\(ipv6[_/]addr\)\([^ ]\+\)\( \+\)/\1\2\3   \4/gI' \
        -e 's/ng_\(ipv6[_/]addr\)/\1/gI'
```

+ some hand-edits to `net/ipv6/addr.h` and a new file `net/ipv6.h`