### PR TITLE
gnrc: rename ng_netbase to gnrc

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1,13 +1,17 @@
+ifneq (,$(filter gnrc_%,$(filter-out gnrc_netapi gnrc_netreg gnrc_netif% gnrc_pktbuf,$(USEMODULE))))
+  USEMODULE += gnrc
+endif
+
 ifneq (,$(filter ng_netif_default,$(USEMODULE)))
   USEMODULE += ng_netif
 endif
 
 ifneq (,$(filter ng_netif,$(USEMODULE)))
-  USEMODULE += ng_netbase
+  USEMODULE += gnrc
 endif
 
 ifneq (,$(filter ng_nomac,$(USEMODULE)))
-  USEMODULE += ng_netbase
+  USEMODULE += gnrc
 endif
 
 ifneq (,$(filter at86rf2%,$(USEMODULE)))
@@ -66,7 +70,7 @@ endif
 ifneq (,$(filter ng_sixlowpan,$(USEMODULE)))
   USEMODULE += ng_ipv6
   USEMODULE += ng_sixlowpan_netif
-  USEMODULE += ng_netbase
+  USEMODULE += gnrc
 endif
 
 ifneq (,$(filter ng_sixlowpan_ctx,$(USEMODULE)))
@@ -99,7 +103,7 @@ endif
 
 ifneq (,$(filter ng_icmpv6_echo,$(USEMODULE)))
   USEMODULE += ng_icmpv6
-  USEMODULE += ng_netbase
+  USEMODULE += gnrc
 endif
 
 ifneq (,$(filter ng_icmpv6,$(USEMODULE)))
@@ -130,7 +134,7 @@ ifneq (,$(filter ng_ipv6,$(USEMODULE)))
   USEMODULE += ng_ipv6_hdr
   USEMODULE += ng_ipv6_nc
   USEMODULE += ng_ipv6_netif
-  USEMODULE += ng_netbase
+  USEMODULE += gnrc
 endif
 
 ifneq (,$(filter ng_ipv6_hdr,$(USEMODULE)))
@@ -152,7 +156,7 @@ ifneq (,$(filter ng_ipv6_netif,$(USEMODULE)))
 endif
 
 ifneq (,$(filter ng_udp,$(USEMODULE)))
-  USEMODULE += ng_netbase
+  USEMODULE += gnrc
   USEMODULE += inet_csum
   USEMODULE += udp
 endif
@@ -165,7 +169,7 @@ ifneq (,$(filter ng_nettest,$(USEMODULE)))
   USEMODULE += vtimer
 endif
 
-ifneq (,$(filter ng_netbase,$(USEMODULE)))
+ifneq (,$(filter gnrc,$(USEMODULE)))
   USEMODULE += ng_netapi
   USEMODULE += ng_netreg
   USEMODULE += ng_netif
@@ -189,7 +193,7 @@ ifneq (,$(filter ng_pktbuf_%, $(USEMODULE)))
 endif
 
 ifneq (,$(filter ng_slip,$(USEMODULE)))
-  USEMODULE += ng_netbase
+  USEMODULE += gnrc
 endif
 
 ifneq (,$(filter uart0,$(USEMODULE)))

--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -4,7 +4,6 @@ PSEUDOMODULES += ng_ipv6_default
 PSEUDOMODULES += ng_ipv6_router
 PSEUDOMODULES += ng_ipv6_router_default
 PSEUDOMODULES += pktqueue
-PSEUDOMODULES += ng_netbase
 PSEUDOMODULES += ng_pktbuf
 PSEUDOMODULES += newlib
 PSEUDOMODULES += ng_sixlowpan_default

--- a/cpu/nrf51/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf51/radio/nrfmin/nrfmin.c
@@ -26,7 +26,7 @@
 #include "periph_conf.h"
 #include "periph/cpuid.h"
 #include "nrfmin.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -27,7 +27,7 @@
 #include "periph/cpuid.h"
 #include "byteorder.h"
 #include "net/ieee802154.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "at86rf2xx_registers.h"
 #include "at86rf2xx_internal.h"
 #include "at86rf2xx_netdev.h"

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -21,7 +21,7 @@
 
 #include "net/eui64.h"
 #include "net/ieee802154.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "at86rf2xx.h"
 #include "at86rf2xx_netdev.h"
 #include "at86rf2xx_internal.h"

--- a/drivers/include/xbee.h
+++ b/drivers/include/xbee.h
@@ -29,7 +29,7 @@
 #include "mutex.h"
 #include "periph/uart.h"
 #include "periph/gpio.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/ieee802154.h"
 
 #ifdef __cplusplus

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -24,7 +24,7 @@
 #include "msg.h"
 #include "periph/gpio.h"
 #include "periph/cpuid.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/ieee802154.h"
 
 #define ENABLE_DEBUG    (0)

--- a/examples/gnrc_networking/udp.c
+++ b/examples/gnrc_networking/udp.c
@@ -22,7 +22,7 @@
 #include <inttypes.h>
 
 #include "kernel.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/ng_ipv6.h"
 #include "net/ng_udp.h"
 #include "net/ng_pktdump.h"

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -28,6 +28,9 @@ endif
 ifneq (,$(filter ipv6_hdr,$(USEMODULE)))
     DIRS += net/network_layer/ipv6/hdr
 endif
+ifneq (,$(filter gnrc gnrc_%,$(USEMODULE)))
+    DIRS += net/gnrc
+endif
 ifneq (,$(filter ng_icmpv6,$(USEMODULE)))
     DIRS += net/network_layer/ng_icmpv6
 endif

--- a/sys/auto_init/netif/auto_init_at86rf2xx.c
+++ b/sys/auto_init/netif/auto_init_at86rf2xx.c
@@ -21,7 +21,7 @@
 
 #include "board.h"
 #include "net/ng_nomac.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 
 #include "at86rf2xx.h"
 #include "at86rf2xx_params.h"

--- a/sys/auto_init/netif/auto_init_kw2xrf.c
+++ b/sys/auto_init/netif/auto_init_kw2xrf.c
@@ -23,7 +23,7 @@
 
 #include "board.h"
 #include "net/ng_nomac.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 
 #include "kw2xrf.h"
 #include "kw2xrf_params.h"

--- a/sys/auto_init/netif/auto_init_ng_netdev_eth.c
+++ b/sys/auto_init/netif/auto_init_ng_netdev_eth.c
@@ -22,7 +22,7 @@
 
 #include "board.h"
 #include "net/ng_nomac.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 
 #include "net/ng_netdev_eth.h"
 #include "net/dev_eth.h"

--- a/sys/auto_init/netif/auto_init_slip.c
+++ b/sys/auto_init/netif/auto_init_slip.c
@@ -21,7 +21,7 @@
 
 #include "board.h"
 #include "net/ng_nomac.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 
 #include "slip.h"
 #include "slip_params.h"

--- a/sys/auto_init/netif/auto_init_xbee.c
+++ b/sys/auto_init/netif/auto_init_xbee.c
@@ -21,7 +21,7 @@
 
 #include "board.h"
 #include "net/ng_nomac.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 
 #include "xbee.h"
 #include "xbee_params.h"

--- a/sys/include/net/gnrc.h
+++ b/sys/include/net/gnrc.h
@@ -7,12 +7,13 @@
  */
 
 /**
- * @defgroup    net_ng_netbase  Network Stack Pseudo Header
+ * @defgroup    net_gnrc    Generic (gnrc) network stack.
  * @ingroup     net
+ * @brief       RIOT's modular default IP network stack.
  * @{
  *
  * @file
- * @brief       Pseudo header that includes all network stack base modules
+ * @brief       Pseudo header that includes all gnrc network stack base modules
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */

--- a/sys/include/net/ng_ipv6.h
+++ b/sys/include/net/ng_ipv6.h
@@ -29,7 +29,7 @@
 #define NG_IPV6_H_
 
 #include "kernel_types.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "thread.h"
 
 #include "net/ipv6.h"

--- a/sys/include/net/ng_slip.h
+++ b/sys/include/net/ng_slip.h
@@ -26,7 +26,7 @@
 
 #include <inttypes.h>
 
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "periph/uart.h"
 #include "ringbuffer.h"
 

--- a/sys/include/net/ng_udp.h
+++ b/sys/include/net/ng_udp.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 
 #include "byteorder.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/udp.h"
 
 #ifdef __cplusplus

--- a/sys/net/application_layer/ng_zep/ng_zep.c
+++ b/sys/net/application_layer/ng_zep/ng_zep.c
@@ -26,7 +26,7 @@
 #include "net/ieee802154.h"
 #include "net/ipv6/addr.h"
 #include "net/ng_ipv6/hdr.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/ng_udp.h"
 #include "periph/cpuid.h"
 #include "random.h"

--- a/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
+++ b/sys/net/crosslayer/ng_pktdump/ng_pktdump.c
@@ -27,7 +27,7 @@
 #include "msg.h"
 #include "kernel.h"
 #include "net/ng_pktdump.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/ipv6/addr.h"
 #include "net/ipv6/hdr.h"
 #include "net/ng_sixlowpan.h"

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/link_layer/ng_nomac/ng_nomac.c
+++ b/sys/net/link_layer/ng_nomac/ng_nomac.c
@@ -22,7 +22,7 @@
 #include "msg.h"
 #include "thread.h"
 #include "net/ng_nomac.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"

--- a/sys/net/link_layer/ng_slip/ng_slip.c
+++ b/sys/net/link_layer/ng_slip/ng_slip.c
@@ -27,7 +27,7 @@
 #include "kernel.h"
 #include "kernel_types.h"
 #include "msg.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "periph/uart.h"
 #include "ringbuffer.h"
 #include "thread.h"

--- a/sys/net/network_layer/ng_icmpv6/echo/ng_icmpv6_echo.c
+++ b/sys/net/network_layer/ng_icmpv6/echo/ng_icmpv6_echo.c
@@ -12,7 +12,7 @@
  * @file
  */
 
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 
 #include "od.h"
 #include "net/ng_icmpv6.h"

--- a/sys/net/network_layer/ng_icmpv6/ng_icmpv6.c
+++ b/sys/net/network_layer/ng_icmpv6/ng_icmpv6.c
@@ -22,7 +22,7 @@
 #include "byteorder.h"
 #include "kernel_types.h"
 #include "net/ipv6/hdr.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/ng_ndp.h"
 #include "net/protnum.h"
 #include "od.h"

--- a/sys/net/network_layer/ng_ipv6/ng_ipv6.c
+++ b/sys/net/network_layer/ng_ipv6/ng_ipv6.c
@@ -19,7 +19,7 @@
 #include "cpu_conf.h"
 #include "kernel_types.h"
 #include "net/ng_icmpv6.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/ng_ndp.h"
 #include "net/protnum.h"
 #include "thread.h"

--- a/sys/net/network_layer/ng_ndp/ng_ndp.c
+++ b/sys/net/network_layer/ng_ndp/ng_ndp.c
@@ -23,7 +23,7 @@
 #include "net/ipv6/ext/rh.h"
 #include "net/ng_icmpv6.h"
 #include "net/ng_ipv6.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "random.h"
 #include "utlist.h"
 #include "thread.h"

--- a/sys/net/network_layer/ng_sixlowpan/frag/rbuf.c
+++ b/sys/net/network_layer/ng_sixlowpan/frag/rbuf.c
@@ -16,7 +16,7 @@
 #include <stdbool.h>
 
 #include "rbuf.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/ng_ipv6/hdr.h"
 #include "net/ng_ipv6/netif.h"
 #include "net/ng_sixlowpan.h"

--- a/sys/net/network_layer/ng_sixlowpan/iphc/ng_sixlowpan_iphc.c
+++ b/sys/net/network_layer/ng_sixlowpan/iphc/ng_sixlowpan_iphc.c
@@ -17,7 +17,7 @@
 #include "byteorder.h"
 #include "net/ieee802154.h"
 #include "net/ipv6/hdr.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/ng_sixlowpan/ctx.h"
 #include "utlist.h"
 

--- a/sys/net/network_layer/ng_sixlowpan/ng_sixlowpan.c
+++ b/sys/net/network_layer/ng_sixlowpan/ng_sixlowpan.c
@@ -13,7 +13,7 @@
  */
 
 #include "kernel_types.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "thread.h"
 #include "utlist.h"
 

--- a/sys/net/transport_layer/ng_udp/ng_udp.c
+++ b/sys/net/transport_layer/ng_udp/ng_udp.c
@@ -27,7 +27,7 @@
 #include "utlist.h"
 #include "net/ipv6/hdr.h"
 #include "net/ng_udp.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/inet_csum.h"
 
 

--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -26,7 +26,7 @@
 #include "net/ipv6/addr.h"
 #include "net/ng_ipv6/nc.h"
 #include "net/ng_ipv6/hdr.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "thread.h"
 #include "utlist.h"
 #include "vtimer.h"

--- a/tests/driver_at86rf2xx/auto_init_ng_netif/netif_app.c
+++ b/tests/driver_at86rf2xx/auto_init_ng_netif/netif_app.c
@@ -23,7 +23,7 @@
 #include "kernel.h"
 #include "at86rf2xx.h"
 #include "net/ng_nomac.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 
 /* make sure the SPI port and the needed GPIO pins are defined */
 #ifndef ATRF_SPI

--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -25,7 +25,7 @@
 #include "posix_io.h"
 #include "board_uart0.h"
 #include "net/ng_pktdump.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 
 /**
  * @brief   Buffer size used by the shell

--- a/tests/driver_kw2xrf/auto_init_ng_netif/netif_app.c
+++ b/tests/driver_kw2xrf/auto_init_ng_netif/netif_app.c
@@ -25,7 +25,7 @@
 #include "kernel.h"
 #include "kw2xrf.h"
 #include "net/ng_nomac.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 
 /* make sure the SPI port and the needed GPIO pins are defined */
 #ifndef KWRF_SPI

--- a/tests/driver_kw2xrf/main.c
+++ b/tests/driver_kw2xrf/main.c
@@ -23,7 +23,7 @@
 #include "shell_commands.h"
 #include "posix_io.h"
 #include "board_uart0.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/ng_pktdump.h"
 
 /**

--- a/tests/driver_netdev_eth/Makefile
+++ b/tests/driver_netdev_eth/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.tests_common
 BOARD_WHITELIST := native
 
 USEMODULE += dev_eth_tap
-USEMODULE += ng_netbase
+USEMODULE += gnrc
 USEMODULE += ng_nomac
 USEMODULE += ng_pktdump
 USEMODULE += ng_netdev_eth

--- a/tests/driver_netdev_eth/main.c
+++ b/tests/driver_netdev_eth/main.c
@@ -26,7 +26,7 @@
 #include "kernel.h"
 #include "shell.h"
 #include "shell_commands.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/ng_nomac.h"
 #include "net/ng_pktdump.h"
 #include "net/ng_netdev_eth.h"

--- a/tests/driver_nrfmin/Makefile
+++ b/tests/driver_nrfmin/Makefile
@@ -8,7 +8,7 @@ USEMODULE += shell_commands
 USEMODULE += ps
 USEMODULE += uart0
 USEMODULE += radio_nrfmin
-USEMODULE += ng_netbase
+USEMODULE += gnrc
 USEMODULE += ng_nomac
 USEMODULE += ng_pktdump
 

--- a/tests/driver_nrfmin/main.c
+++ b/tests/driver_nrfmin/main.c
@@ -24,7 +24,7 @@
 #include "posix_io.h"
 #include "board_uart0.h"
 #include "nrfmin.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/ng_nomac.h"
 #include "net/ng_pktdump.h"
 

--- a/tests/driver_xbee/main.c
+++ b/tests/driver_xbee/main.c
@@ -22,7 +22,7 @@
 
 #include "shell.h"
 #include "shell_commands.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/ng_pktdump.h"
 
 /**

--- a/tests/slip/Makefile
+++ b/tests/slip/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_RAM := stm32f0discovery
 
-USEMODULE += ng_netbase
+USEMODULE += gnrc
 USEMODULE += ng_pktdump
 USEMODULE += ng_slip
 USEMODULE += shell

--- a/tests/slip/main.c
+++ b/tests/slip/main.c
@@ -22,7 +22,7 @@
 
 #include "shell.h"
 #include "shell_commands.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/ng_pktdump.h"
 
 /**

--- a/tests/zep/main.c
+++ b/tests/zep/main.c
@@ -22,7 +22,7 @@
 
 #include "shell.h"
 #include "shell_commands.h"
-#include "net/ng_netbase.h"
+#include "net/gnrc.h"
 #include "net/ng_pktdump.h"
 
 /**


### PR DESCRIPTION
Renames `ng_netbase` to `gnrc` and adds `gnrc` as a factual module rather than a pseudo module. The reasoning is to add the path to `gnrc`'s submodules to its Makefile (in a similar fassion to `sys/Makefile` currently) as soon as they are moved into it.

Steps I took:

```bash
git mv sys/include/net/ng_netbase.h sys/include/net/gnrc.h
git grep --name-only "ng_netbase" | xargs sed -i 's/ng_netbase/gnrc/g'
```

After that I added the `gnrc` module as an empty directory with a preliminary Makefile, added it as dependency for all `gnrc` submodules except `gnrc_netapi`, `gnrc_netif`, `gnrc_netif_hdr`, `gnrc_netreg`, and `gnrc_pktbuf` (the module `gnrc` is build upon itself) and made `sys/gnrc` the build path for `gnrc` an all its submodules in `sys/Makefile`.