### PR TITLE
ndp: move type definitions out of ng_ context

### DIFF
--- a/sys/include/net/ndp.h
+++ b/sys/include/net/ndp.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    net_ng_ndp_types    Types for IPv6 neighbor discovery
- * @ingroup     net_ng_ndp
- * @brief       IPv6 neighbor discovery message types
+ * @defgroup    net_ndp IPv6 neighbor discovery messages
+ * @ingroup     net_ipv6
+ * @brief       Provides IPv6 neighbor discovery message types
  * @{
  *
  * @file
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NG_NDP_TYPES_H_
-#define NG_NDP_TYPES_H_
+#ifndef NDP_H_
+#define NDP_H_
 
 #include <stdint.h>
 
@@ -29,46 +29,46 @@ extern "C" {
 #endif
 
 /**
- * @{
- * @name    Flags for router advertisement messages
+ * @name    Router advertisement flags
  * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.2">
  *          RFC 4861, section 4.2
  *      </a>
+ * @{
  */
-#define NG_NDP_RTR_ADV_FLAGS_MASK   (0xc0)
-#define NG_NDP_RTR_ADV_FLAGS_M      (0x80)  /**< managed address configuration */
-#define NG_NDP_RTR_ADV_FLAGS_O      (0x40)  /**< other configuration */
+#define NDP_RTR_ADV_FLAGS_MASK      (0xc0)
+#define NDP_RTR_ADV_FLAGS_M         (0x80)  /**< managed address configuration */
+#define NDP_RTR_ADV_FLAGS_O         (0x40)  /**< other configuration */
 /**
  * @}
  */
 
 /**
- * @{
- * @name    Flags for neighbor advertisement messages
+ * @name    Neighbor advertisement flags
  * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.4">
  *          RFC 4861, section 4.2
  *      </a>
+ * @{
  */
-#define NG_NDP_NBR_ADV_FLAGS_MASK   (0xe0)
-#define NG_NDP_NBR_ADV_FLAGS_R      (0x80)  /**< router */
-#define NG_NDP_NBR_ADV_FLAGS_S      (0x40)  /**< solicited */
-#define NG_NDP_NBR_ADV_FLAGS_O      (0x20)  /**< override */
+#define NDP_NBR_ADV_FLAGS_MASK      (0xe0)
+#define NDP_NBR_ADV_FLAGS_R         (0x80)  /**< router */
+#define NDP_NBR_ADV_FLAGS_S         (0x40)  /**< solicited */
+#define NDP_NBR_ADV_FLAGS_O         (0x20)  /**< override */
 /**
  * @}
  */
 
 /**
- * @{
  * @name    NDP option types
+ * @{
  * @see <a href="http://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml#icmpv6-parameters-5">
  *          IANA, IPv6 Neighbor Discovery Option Formats
  *      </a>
  */
-#define NG_NDP_OPT_SL2A             (1)     /**< source link-layer address option */
-#define NG_NDP_OPT_TL2A             (2)     /**< target link-layer address option */
-#define NG_NDP_OPT_PI               (3)     /**< prefix information option */
-#define NG_NDP_OPT_RH               (4)     /**< redirected option */
-#define NG_NDP_OPT_MTU              (5)     /**< MTU option */
+#define NDP_OPT_SL2A                (1)     /**< source link-layer address option */
+#define NDP_OPT_TL2A                (2)     /**< target link-layer address option */
+#define NDP_OPT_PI                  (3)     /**< prefix information option */
+#define NDP_OPT_RH                  (4)     /**< redirected option */
+#define NDP_OPT_MTU                 (5)     /**< MTU option */
 /**
  * @}
  */
@@ -77,9 +77,9 @@ extern "C" {
  * @{
  * @name    Flags for prefix information option
  */
-#define NG_NDP_OPT_PI_FLAGS_MASK    (0xc0)
-#define NG_NDP_OPT_PI_FLAGS_L       (0x80)  /**< on-link */
-#define NG_NDP_OPT_PI_FLAGS_A       (0x40)  /**< autonomous address configuration */
+#define NDP_OPT_PI_FLAGS_MASK       (0xc0)
+#define NDP_OPT_PI_FLAGS_L          (0x80)  /**< on-link */
+#define NDP_OPT_PI_FLAGS_A          (0x40)  /**< autonomous address configuration */
 /**
  * @}
  */
@@ -89,8 +89,8 @@ extern "C" {
  * @name    Lengths for fixed length options
  * @brief   Options don't use bytes as their length unit, but 8 bytes.
  */
-#define NG_NDP_OPT_PI_LEN           (4U)
-#define NG_NDP_OPT_MTU_LEN          (1U)
+#define NDP_OPT_PI_LEN              (4U)
+#define NDP_OPT_MTU_LEN             (1U)
 /**
  * @}
  */
@@ -108,7 +108,7 @@ typedef struct __attribute__((packed)) {
     uint8_t code;           /**< message code */
     network_uint16_t csum;  /**< checksum */
     network_uint32_t resv;  /**< reserved field */
-} ng_ndp_rtr_sol_t;
+} ndp_rtr_sol_t;
 
 /**
  * @brief   Router advertisement message format.
@@ -127,7 +127,7 @@ typedef struct __attribute__((packed)) {
     network_uint16_t ltime;             /**< router lifetime */
     network_uint32_t reach_time;        /**< reachable time */
     network_uint32_t retrans_timer;     /**< retransmission timer */
-} ng_ndp_rtr_adv_t;
+} ndp_rtr_adv_t;
 
 /**
  * @brief   Neighbor solicitation message format.
@@ -143,7 +143,7 @@ typedef struct __attribute__((packed)) {
     network_uint16_t csum;  /**< checksum */
     network_uint32_t resv;  /**< reserved field */
     ipv6_addr_t tgt;        /**< target address */
-} ng_ndp_nbr_sol_t;
+} ndp_nbr_sol_t;
 
 /**
  * @brief   Neighbor advertisement message format.
@@ -160,7 +160,7 @@ typedef struct __attribute__((packed)) {
     uint8_t flags;          /**< flags */
     uint8_t resv[3];        /**< reserved fields */
     ipv6_addr_t tgt;        /**< target address */
-} ng_ndp_nbr_adv_t;
+} ndp_nbr_adv_t;
 
 /**
  * @brief   Neighbor advertisement message format.
@@ -177,7 +177,7 @@ typedef struct __attribute__((packed)) {
     network_uint32_t resv;  /**< reserved field */
     ipv6_addr_t tgt;        /**< target address */
     ipv6_addr_t dst;        /**< destination address */
-} ng_ndp_redirect_t;
+} ndp_redirect_t;
 
 /**
  * @brief   General NDP option format
@@ -188,14 +188,14 @@ typedef struct __attribute__((packed)) {
 typedef struct __attribute__((packed)) {
     uint8_t type;   /**< option type */
     uint8_t len;    /**< length in units of 8 octets */
-} ng_ndp_opt_t;
+} ndp_opt_t;
 
-/* XXX: slla and tlla are just ng_ndp_opt_t with variable link layer address
+/* XXX: slla and tlla are just ndp_opt_t with variable link layer address
  * appended */
 
 /**
  * @brief   Prefix information option format
- * @extends ng_ndp_opt_t
+ * @extends ndp_opt_t
  *
  * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.6.2">
  *          RFC 4861, section 4.6.2
@@ -210,11 +210,11 @@ typedef struct __attribute__((packed)) {
     network_uint32_t pref_ltime;    /**< preferred lifetime */
     network_uint32_t resv;          /**< reserved field */
     ipv6_addr_t prefix;             /**< prefix */
-} ng_ndp_opt_pi_t;
+} ndp_opt_pi_t;
 
 /**
  * @brief   Redirected header option format
- * @extends ng_ndp_opt_t
+ * @extends ndp_opt_t
  *
  * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.6.3">
  *          RFC 4861, section 4.6.3
@@ -224,11 +224,11 @@ typedef struct __attribute__((packed)) {
     uint8_t type;           /**< option type */
     uint8_t len;            /**< length in units of 8 octets */
     uint8_t resv[6];        /**< reserved field */
-} ng_ndp_opt_rh_t;
+} ndp_opt_rh_t;
 
 /**
  * @brief   MTU option format
- * @extends ng_ndp_opt_t
+ * @extends ndp_opt_t
  *
  * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.6.4">
  *          RFC 4861, section 4.6.4
@@ -239,12 +239,12 @@ typedef struct __attribute__((packed)) {
     uint8_t len;            /**< length in units of 8 octets */
     network_uint16_t resv;  /**< reserved field */
     network_uint32_t mtu;   /**< MTU */
-} ng_ndp_opt_mtu_t;
+} ndp_opt_mtu_t;
 
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* NG_NDP_TYPES_H_ */
+#endif /* NDP_H_ */
 /** @} */

--- a/sys/include/net/ng_ndp/internal.h
+++ b/sys/include/net/ng_ndp/internal.h
@@ -24,7 +24,7 @@
 
 #include "net/ipv6/addr.h"
 #include "net/ipv6/hdr.h"
-#include "net/ng_ndp/types.h"
+#include "net/ndp.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -98,7 +98,7 @@ void ng_ndp_internal_send_nbr_adv(kernel_pid_t iface, ipv6_addr_t *tgt,
  */
 bool ng_ndp_internal_sl2a_opt_handle(kernel_pid_t iface, ng_pktsnip_t *pkt,
                                      ipv6_hdr_t *ipv6, uint8_t icmpv6_type,
-                                     ng_ndp_opt_t *sl2a_opt);
+                                     ndp_opt_t *sl2a_opt);
 
 /**
  * @brief   Handles a TL2A option.
@@ -114,7 +114,7 @@ bool ng_ndp_internal_sl2a_opt_handle(kernel_pid_t iface, ng_pktsnip_t *pkt,
  * @return  -EINVAL, if TL2A was not valid.
  */
 int ng_ndp_internal_tl2a_opt_handle(ng_pktsnip_t *pkt, ipv6_hdr_t *ipv6,
-                                    uint8_t icmpv6_type, ng_ndp_opt_t *tl2a_opt,
+                                    uint8_t icmpv6_type, ndp_opt_t *tl2a_opt,
                                     uint8_t *l2addr);
 
 #ifdef __cplusplus

--- a/sys/net/network_layer/ng_icmpv6/ng_icmpv6.c
+++ b/sys/net/network_layer/ng_icmpv6/ng_icmpv6.c
@@ -99,13 +99,13 @@ void ng_icmpv6_demux(kernel_pid_t iface, ng_pktsnip_t *pkt)
 
         case ICMPV6_NBR_SOL:
             DEBUG("icmpv6: neighbor solicitation received\n");
-            ng_ndp_nbr_sol_handle(iface, pkt, ipv6->data, (ng_ndp_nbr_sol_t *)hdr,
+            ng_ndp_nbr_sol_handle(iface, pkt, ipv6->data, (ndp_nbr_sol_t *)hdr,
                                   icmpv6->size);
             break;
 
         case ICMPV6_NBR_ADV:
             DEBUG("icmpv6: neighbor advertisement received\n");
-            ng_ndp_nbr_adv_handle(iface, pkt, ipv6->data, (ng_ndp_nbr_adv_t *)hdr,
+            ng_ndp_nbr_adv_handle(iface, pkt, ipv6->data, (ndp_nbr_adv_t *)hdr,
                                   icmpv6->size);
             break;
 

--- a/sys/net/network_layer/ng_ndp/internal/ng_ndp_internal.c
+++ b/sys/net/network_layer/ng_ndp/internal/ng_ndp_internal.c
@@ -161,14 +161,14 @@ void ng_ndp_internal_send_nbr_adv(kernel_pid_t iface, ipv6_addr_t *tgt,
           ipv6_addr_to_str(addr_str, dst, sizeof(addr_str)), supply_tl2a);
 
     if (ng_ipv6_netif_get(iface)->flags & NG_IPV6_NETIF_FLAGS_ROUTER) {
-        adv_flags |= NG_NDP_NBR_ADV_FLAGS_R;
+        adv_flags |= NDP_NBR_ADV_FLAGS_R;
     }
 
     if (ipv6_addr_is_unspecified(dst)) {
         ipv6_addr_set_all_nodes_multicast(dst, IPV6_ADDR_MCAST_SCP_LINK_LOCAL);
     }
     else {
-        adv_flags |= NG_NDP_NBR_ADV_FLAGS_S;
+        adv_flags |= NDP_NBR_ADV_FLAGS_S;
     }
 
     if (supply_tl2a) {
@@ -192,7 +192,7 @@ void ng_ndp_internal_send_nbr_adv(kernel_pid_t iface, ipv6_addr_t *tgt,
     /* TODO: also check if the node provides proxy servies for tgt */
     if ((pkt != NULL) && !ng_ipv6_netif_addr_is_non_unicast(tgt)) {
         /* TL2A is not supplied and tgt is not anycast */
-        adv_flags |= NG_NDP_NBR_ADV_FLAGS_O;
+        adv_flags |= NDP_NBR_ADV_FLAGS_O;
     }
 
     hdr = ng_ndp_nbr_adv_build(adv_flags, tgt, pkt);
@@ -313,7 +313,7 @@ void ng_ndp_internal_send_nbr_sol(kernel_pid_t iface, ipv6_addr_t *tgt,
 
 bool ng_ndp_internal_sl2a_opt_handle(kernel_pid_t iface, ng_pktsnip_t *pkt,
                                      ipv6_hdr_t *ipv6, uint8_t icmpv6_type,
-                                     ng_ndp_opt_t *sl2a_opt)
+                                     ndp_opt_t *sl2a_opt)
 {
     ng_ipv6_nc_t *nc_entry = NULL;
     uint8_t sl2a_len = 0;
@@ -334,7 +334,7 @@ bool ng_ndp_internal_sl2a_opt_handle(kernel_pid_t iface, ng_pktsnip_t *pkt,
     }
 
     if (sl2a_len == 0) {  /* in case there was no source address in l2 */
-        sl2a_len = (sl2a_opt->len / 8) - sizeof(ng_ndp_opt_t);
+        sl2a_len = (sl2a_opt->len / 8) - sizeof(ndp_opt_t);
 
         /* ignore all zeroes at the end for length */
         for (; sl2a[sl2a_len - 1] == 0x00; sl2a_len--);
@@ -372,7 +372,7 @@ bool ng_ndp_internal_sl2a_opt_handle(kernel_pid_t iface, ng_pktsnip_t *pkt,
 }
 
 int ng_ndp_internal_tl2a_opt_handle(ng_pktsnip_t *pkt, ipv6_hdr_t *ipv6,
-                                    uint8_t icmpv6_type, ng_ndp_opt_t *tl2a_opt,
+                                    uint8_t icmpv6_type, ndp_opt_t *tl2a_opt,
                                     uint8_t *l2addr)
 {
     uint8_t tl2a_len = 0;
@@ -395,7 +395,7 @@ int ng_ndp_internal_tl2a_opt_handle(ng_pktsnip_t *pkt, ipv6_hdr_t *ipv6,
             }
 
             if (tl2a_len == 0) {  /* in case there was no source address in l2 */
-                tl2a_len = (tl2a_opt->len / 8) - sizeof(ng_ndp_opt_t);
+                tl2a_len = (tl2a_opt->len / 8) - sizeof(ndp_opt_t);
 
                 /* ignore all zeroes at the end for length */
                 for (; tl2a[tl2a_len - 1] == 0x00; tl2a_len--);


### PR DESCRIPTION
Depends on #3599 and all its dependencies.