### PR TITLE
arduino_mega2560: correct uart prototypes

### DIFF
--- a/boards/arduino-mega2560/board.c
+++ b/boards/arduino-mega2560/board.c
@@ -45,8 +45,8 @@ static ringbuffer_t rx_buf;
 
 void led_init(void);
 void SystemInit(void);
-static int uart_putchar(unsigned char c, FILE *stream);
-static char uart_getchar(FILE *stream);
+static int uart_putchar(char c, FILE *stream);
+static int uart_getchar(FILE *stream);
 
 static FILE uart_stdout = FDEV_SETUP_STREAM(uart_putchar, NULL, _FDEV_SETUP_WRITE);
 static FILE uart_stdin = FDEV_SETUP_STREAM(NULL, uart_getchar, _FDEV_SETUP_READ);
@@ -124,13 +124,13 @@ void SystemInit(void)
     puts("\f");
 }
 
-static int uart_putchar(unsigned char c, FILE *stream)
+static int uart_putchar(char c, FILE *stream)
 {
     uart_write_blocking(UART_0, c);
     return 0;
 }
 
-char uart_getchar(FILE *stream)
+int uart_getchar(FILE *stream)
 {
 #ifndef MODULE_UART0
 


### PR DESCRIPTION
The newest version of the toolchain was complaining:
```
"make" -C /home/oleg/git/RIOT/boards/arduino-mega2560
In file included from /home/oleg/git/RIOT/boards/arduino-mega2560/board.c:21:0:
/home/oleg/git/RIOT/boards/arduino-mega2560/board.c:51:45: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
 static FILE uart_stdout = FDEV_SETUP_STREAM(uart_putchar, NULL, _FDEV_SETUP_WRITE);
                                             ^
/home/oleg/git/RIOT/boards/arduino-mega2560/board.c:51:45: note: (near initialization for 'uart_stdout.put')
/home/oleg/git/RIOT/boards/arduino-mega2560/board.c:52:50: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
 static FILE uart_stdin = FDEV_SETUP_STREAM(NULL, uart_getchar, _FDEV_SETUP_READ);
                                                  ^
/home/oleg/git/RIOT/boards/arduino-mega2560/board.c:52:50: note: (near initialization for 'uart_stdin.get')
```