### PR TITLE
fib: shell, added custom `pton` to remove dependency to `net_help`

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -217,7 +217,6 @@ ifneq (,$(filter fib,$(USEMODULE)))
   USEMODULE += universal_address
   USEMODULE += timex
   USEMODULE += vtimer
-  USEMODULE += net_help
 endif
 
 ifneq (,$(filter oonf_common,$(USEMODULE)))


### PR DESCRIPTION
Rationale:
added a custom `pton` conversion function to make the fib independent from the network stack implementations. 

Finally this enables remove the deprecated `net_help` module and closing #3574.
