### PR TITLE
tests: unblacklist some boards

### DIFF
--- a/tests/bloom_bytes/Makefile
+++ b/tests/bloom_bytes/Makefile
@@ -1,8 +1,6 @@
 APPLICATION = bloom_bytes
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_RAM := stm32f0discovery
-
 USEMODULE += hashes
 USEMODULE += bloom
 USEMODULE += random

--- a/tests/libfixmath_unittests/Makefile
+++ b/tests/libfixmath_unittests/Makefile
@@ -8,9 +8,6 @@ BOARD_BLACKLIST := arduino-mega2560
 # The MSP boards don't feature round(), exp(), and log(), which are used in the unittests
 BOARD_BLACKLIST += chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
 
-# Insufficient RAM / ROM
-BOARD_INSUFFICIENT_RAM += redbee-econotag stm32f0discovery
-
 USEMODULE += libfixmath-unittests
 
 ifneq (,$(filter native qemu-i386,$(BOARD)))

--- a/tests/pipe/Makefile
+++ b/tests/pipe/Makefile
@@ -1,8 +1,6 @@
 APPLICATION = pipe
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_RAM := stm32f0discovery
-
 USEMODULE += pipe
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/struct_tm_utility/Makefile
+++ b/tests/struct_tm_utility/Makefile
@@ -1,8 +1,6 @@
 APPLICATION = struct_tm_utility
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_RAM := stm32f0discovery
-
 DISABLE_MODULE += auto_init
 
 USEMODULE += shell

--- a/tests/thread_exit/Makefile
+++ b/tests/thread_exit/Makefile
@@ -1,8 +1,6 @@
 APPLICATION = thread_exit
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_RAM := stm32f0discovery
-
 DISABLE_MODULE += auto_init
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/vtimer_msg/Makefile
+++ b/tests/vtimer_msg/Makefile
@@ -1,8 +1,6 @@
 APPLICATION = vtimer_msg
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_RAM := stm32f0discovery
-
 USEMODULE += vtimer
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
in reviewing #2926 it was discovered that the RAM/ROM blacklist of the stm32f0discovery board was no longer needed in `tests/vtimer_msg`. This PR removes the blacklist from the tests which build correctly on my machine. Travis is using a different toolchain so it might give a different result though.