### PR TITLE
sys/shell/shell.c: command not found in one line

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -199,8 +199,7 @@ static void handle_input_line(shell_t *shell, char *line)
             print_help(shell->command_list);
         }
         else {
-            puts("shell: command not found:");
-            puts(argv[0]);
+            printf("shell: command not found: %s\n", argv[0]);
         }
     }
 }


### PR DESCRIPTION
Just cosmetics. It bugged me that the `command not found:` message and the command that was not found were on separate lines.

IMHO, the colon after the message`command not found` implicates that the cause follows directly this message, and not one line after.