### PR TITLE
drivers: renamed further remaining *NG_* macros

### DIFF
--- a/boards/samr21-xpro/include/at86rf2xx_params.h
+++ b/boards/samr21-xpro/include/at86rf2xx_params.h
@@ -29,12 +29,12 @@ extern "C" {
 static const  at86rf2xx_params_t at86rf2xx_params[] =
     {
         {
-            .spi = NG_AT86RF233_SPI,
-            .spi_speed = NG_AT86RF233_SPI_CLK,
-            .cs_pin = NG_AT86RF233_CS,
-            .int_pin = NG_AT86RF233_INT,
-            .sleep_pin = NG_AT86RF233_SLEEP,
-            .reset_pin = NG_AT86RF233_RESET,
+            .spi = AT86RF233_SPI,
+            .spi_speed = AT86RF233_SPI_CLK,
+            .cs_pin = AT86RF233_CS,
+            .int_pin = AT86RF233_INT,
+            .sleep_pin = AT86RF233_SLEEP,
+            .reset_pin = AT86RF233_RESET,
         },
     };
 /** @} */

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -41,15 +41,15 @@ extern "C" {
 #define HW_TIMER            TIMER_1
 
 /**
-* @name NG_AT86RF233 configuration
+* @name AT86RF233 configuration
 * @{
 */
-#define NG_AT86RF233_SPI        (SPI_0)
-#define NG_AT86RF233_CS         GPIO(PB, 31)
-#define NG_AT86RF233_INT        GPIO(PB, 0)
-#define NG_AT86RF233_RESET      GPIO(PB, 15)
-#define NG_AT86RF233_SLEEP      GPIO(PA, 20)
-#define NG_AT86RF233_SPI_CLK    (SPI_SPEED_1MHZ)
+#define AT86RF233_SPI        (SPI_0)
+#define AT86RF233_CS         GPIO(PB, 31)
+#define AT86RF233_INT        GPIO(PB, 0)
+#define AT86RF233_RESET      GPIO(PB, 15)
+#define AT86RF233_SLEEP      GPIO(PA, 20)
+#define AT86RF233_SPI_CLK    (SPI_SPEED_1MHZ)
 /** @}*/
 
 /**

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -151,7 +151,7 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     /* enable safe mode (protect RX FIFO until reading data starts) */
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2,
                         AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE);
-#ifdef MODULE_NG_AT86RF212B
+#ifdef MODULE_AT86RF212B
     at86rf2xx_set_freq(dev, AT86RF2XX_FREQ_915MHZ);
 #endif
 
@@ -261,7 +261,7 @@ void at86rf2xx_rx_read(at86rf2xx_t *dev, uint8_t *data, size_t len,
      * The AT86RF231 does not return the PHR field and return
      * the first data byte at position 0.
      */
-#ifndef MODULE_NG_AT86RF231
+#ifndef MODULE_AT86RF231
     at86rf2xx_sram_read(dev, offset + 1, data, len);
 #else
     at86rf2xx_sram_read(dev, offset, data, len);

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -28,7 +28,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-#ifdef MODULE_NG_AT86RF212B
+#ifdef MODULE_AT86RF212B
 /* See: Table 9-15. Recommended Mapping of TX Power, Frequency Band, and
  * PHY_TX_PWR (register 0x05), AT86RF212B data sheet. */
 static const uint8_t dbm_to_tx_pow_868[] = {0x1d, 0x1c, 0x1b, 0x1a, 0x19, 0x18,
@@ -60,7 +60,7 @@ int16_t tx_pow_to_dbm(at86rf2xx_freq_t freq, uint8_t reg) {
     return 0;
 }
 
-#elif MODULE_NG_AT86RF233
+#elif MODULE_AT86RF233
 static const int16_t tx_pow_to_dbm[] = {4, 4, 3, 3, 2, 2, 1,
                                         0, -1, -2, -3, -4, -6, -8, -12, -17};
 static const uint8_t dbm_to_tx_pow[] = {0x0f, 0x0f, 0x0f, 0x0e, 0x0e, 0x0e,
@@ -130,7 +130,7 @@ void at86rf2xx_set_chan(at86rf2xx_t *dev, uint8_t channel)
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__PHY_CC_CCA, tmp);
 }
 
-#ifdef MODULE_NG_AT86RF212B
+#ifdef MODULE_AT86RF212B
 at86rf2xx_freq_t at86rf2xx_get_freq(at86rf2xx_t *dev)
 {
     return dev->freq;
@@ -188,7 +188,7 @@ void at86rf2xx_set_pan(at86rf2xx_t *dev, uint16_t pan)
 
 int16_t at86rf2xx_get_txpower(at86rf2xx_t *dev)
 {
-#ifdef MODULE_NG_AT86RF212B
+#ifdef MODULE_AT86RF212B
     uint8_t txpower = at86rf2xx_reg_read(dev, AT86RF2XX_REG__PHY_TX_PWR);
     DEBUG("txpower value: %x\n", txpower);
     return tx_pow_to_dbm(dev->freq, txpower);
@@ -201,18 +201,18 @@ int16_t at86rf2xx_get_txpower(at86rf2xx_t *dev)
 
 void at86rf2xx_set_txpower(at86rf2xx_t *dev, int16_t txpower)
 {
-#ifdef MODULE_NG_AT86RF212B
+#ifdef MODULE_AT86RF212B
     txpower += 25;
 #else
     txpower += 17;
 #endif
     if (txpower < 0) {
         txpower = 0;
-#ifdef MODULE_NG_AT86RF212B
+#ifdef MODULE_AT86RF212B
     }
     else if (txpower > 36) {
         txpower = 36;
-#elif MODULE_NG_AT86RF233
+#elif MODULE_AT86RF233
     }
     else if (txpower > 21) {
         txpower = 21;
@@ -222,7 +222,7 @@ void at86rf2xx_set_txpower(at86rf2xx_t *dev, int16_t txpower)
         txpower = 20;
 #endif
     }
-#ifdef MODULE_NG_AT86RF212B
+#ifdef MODULE_AT86RF212B
     if (dev->freq == AT86RF2XX_FREQ_915MHZ) {
         at86rf2xx_reg_write(dev, AT86RF2XX_REG__PHY_TX_PWR,
                             dbm_to_tx_pow_915[txpower]);

--- a/drivers/at86rf2xx/include/at86rf2xx_registers.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_registers.h
@@ -31,24 +31,24 @@ extern "C" {
  * @brief   Constant part numbers of the AT86RF2xx device family
  * @{
  */
-#define NG_AT86RF212B_PARTNUM       (0x07)
-#define NG_AT86RF231_PARTNUM        (0x03)
-#define NG_AT86RF232_PARTNUM        (0x0a)
-#define NG_AT86RF233_PARTNUM        (0x0b)
+#define AT86RF212B_PARTNUM       (0x07)
+#define AT86RF231_PARTNUM        (0x03)
+#define AT86RF232_PARTNUM        (0x0a)
+#define AT86RF233_PARTNUM        (0x0b)
 /** @} */
 
 /**
  * @brief   Assign the part number for the device we are building the driver for
  * @{
  */
-#ifdef MODULE_NG_AT86RF212B
-#define AT86RF2XX_PARTNUM           NG_AT86RF212B_PARTNUM
-#elif MODULE_NG_AT86RF232
-#define AT86RF2XX_PARTNUM           NG_AT86RF232_PARTNUM
-#elif MODULE_NG_AT86RF233
-#define AT86RF2XX_PARTNUM           NG_AT86RF233_PARTNUM
-#else /* MODULE_NG_AT86RF231 as default device */
-#define AT86RF2XX_PARTNUM           NG_AT86RF231_PARTNUM
+#ifdef MODULE_AT86RF212B
+#define AT86RF2XX_PARTNUM           AT86RF212B_PARTNUM
+#elif MODULE_AT86RF232
+#define AT86RF2XX_PARTNUM           AT86RF232_PARTNUM
+#elif MODULE_AT86RF233
+#define AT86RF2XX_PARTNUM           AT86RF233_PARTNUM
+#else /* MODULE_AT86RF231 as default device */
+#define AT86RF2XX_PARTNUM           AT86RF231_PARTNUM
 #endif
 /** @} */
 
@@ -87,7 +87,7 @@ extern "C" {
 #define AT86RF2XX_REG__XOSC_CTRL                                (0x12)
 #define AT86RF2XX_REG__CC_CTRL_1                                (0x14)
 #define AT86RF2XX_REG__RX_SYN                                   (0x15)
-#ifdef MODULE_NG_AT86RF212B
+#ifdef MODULE_AT86RF212B
 #define AT86RF2XX_REG__RF_CTRL_0                                (0x16)
 #endif
 #define AT86RF2XX_REG__XAH_CTRL_1                               (0x17)
@@ -245,11 +245,11 @@ extern "C" {
  * @brief   Bitfield definitions for the PHY_TX_PWR register
  * @{
  */
-#ifdef MODULE_NG_AT86RF212B
+#ifdef MODULE_AT86RF212B
 #define AT86RF2XX_PHY_TX_PWR_MASK__PA_BOOST                     (0x80)
 #define AT86RF2XX_PHY_TX_PWR_MASK__GC_PA                        (0x60)
 #define AT86RF2XX_PHY_TX_PWR_MASK__TX_PWR                       (0x1F)
-#elif  MODULE_NG_AT86RF231
+#elif  MODULE_AT86RF231
 #define AT86RF2XX_PHY_TX_PWR_MASK__PA_BUF_LT                    (0xC0)
 #define AT86RF2XX_PHY_TX_PWR_MASK__PA_LT                        (0x30)
 #define AT86RF2XX_PHY_TX_PWR_MASK__TX_PWR                       (0x0F)
@@ -323,7 +323,7 @@ extern "C" {
  * @brief   Bitfield definitions for the RF_CTRL_0 register
  * @{
  */
-#ifdef MODULE_NG_AT86RF212B
+#ifdef MODULE_AT86RF212B
 #define AT86RF2XX_RF_CTRL_0_MASK__PA_LT                         (0xC0)
 #define AT86RF2XX_RF_CTRL_0_MASK__GC_TX_OFFS                    (0x03)
 

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -55,7 +55,7 @@ extern "C" {
   * @brief   Channel configuration
   * @{
   */
-#ifdef MODULE_NG_AT86RF212B
+#ifdef MODULE_AT86RF212B
 /* the AT86RF212B has a sub-1GHz radio */
 #define AT86RF2XX_MIN_CHANNEL           (0)
 #define AT86RF2XX_MAX_CHANNEL           (10)
@@ -148,7 +148,7 @@ typedef struct {
     uint8_t frame_len;                  /**< length of the current TX frame */
     uint16_t pan;                       /**< currently used PAN ID */
     uint8_t chan;                       /**< currently used channel */
-#ifdef MODULE_NG_AT86RF212B
+#ifdef MODULE_AT86RF212B
     at86rf2xx_freq_t freq;              /**< currently used frequency */
 #endif
     uint8_t addr_short[2];              /**< the radio's short address */
@@ -255,7 +255,7 @@ uint8_t at86rf2xx_get_chan(at86rf2xx_t *dev);
  */
 void at86rf2xx_set_chan(at86rf2xx_t *dev, uint8_t chan);
 
-#ifdef MODULE_NG_AT86RF212B
+#ifdef MODULE_AT86RF212B
 /**
  * @brief   Get the configured frequency of the given device
  *


### PR DESCRIPTION
some macros for the `at86rf*` transceivers had still `NG_` pre-/mid- fixes which prevented to init the transceiver, e.g. on the `samr21-xpro`.

now they are history.