### PR TITLE
ndp: separate & clean next hop & l2 determination

### DIFF
--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -144,6 +144,11 @@ extern "C" {
 #define GNRC_IPV6_NETIF_FLAGS_ADV_CUR_HL        (0x0010)
 
 /**
+ * @brief   Flag to indicate if the interface is operating over a wired link
+ */
+#define GNRC_IPV6_NETIF_FLAGS_IS_WIRED          (0x2000)
+
+/**
  * @brief   Flag to indicate that the interface has other address
  *          configuration.
  */

--- a/sys/include/net/gnrc/ndp/node.h
+++ b/sys/include/net/gnrc/ndp/node.h
@@ -25,14 +25,33 @@ extern "C" {
 #endif
 
 /**
- * @brief   Get link-layer address and interface for next hop to destination
- *          IPv6 address.
+ * @brief Next hop determination for a destination address that is not on-link.
  *
- * @param[out] l2addr           The link-layer for the next hop to @p dst.
+ * @see <a href="https://tools.ietf.org/html/rfc4861#section-3">
+ * RFC 4861, section 3
+ * </a>
+ *
+ * @param[out] next_hop_ip  Will be filled with IPv6 address of the next hop
+ *                          or NULL if no next hop could be determined.
+ * @param[in,out] iface     Will be filled with the interface id that has to be
+ *                          used for reaching the next hop.
+ * @param[in] dst           The destination IPv6 address.
+ *
+ * @return true, if a next hop could be determined.
+ * @return false otherwise
+ */
+bool ng_ndp_node_next_hop_ipv6_addr(ipv6_addr_t *next_hop_ip,
+                                    kernel_pid_t *iface, ipv6_addr_t *dst);
+
+/**
+ * @brief   Get link-layer address a given IPv6 address.
+ *
+ * @param[out] l2addr           The link-layer of @p dst.
  * @param[out] l2addr_len       Length of @p l2addr.
  * @param[in] iface             The interface to search the next hop on.
  *                              May be @ref KERNEL_PID_UNDEF if not specified.
- * @param[in] dst               An IPv6 address to search the next hop for.
+ * @param[in] dst               The IPv6 address to search the link-layer
+ *                              address hop for.
  * @param[in] pkt               Packet to send to @p dst. Leave NULL if you
  *                              just want to get the addresses.
  *

--- a/sys/include/net/gnrc/ndp/node.h
+++ b/sys/include/net/gnrc/ndp/node.h
@@ -40,8 +40,8 @@ extern "C" {
  * @return true, if a next hop could be determined.
  * @return false otherwise
  */
-bool ng_ndp_node_next_hop_ipv6_addr(ipv6_addr_t *next_hop_ip,
-                                    kernel_pid_t *iface, ipv6_addr_t *dst);
+bool gnrc_ndp_node_next_hop_ipv6_addr(ipv6_addr_t *next_hop_ip,
+                                      kernel_pid_t *iface, ipv6_addr_t *dst);
 
 /**
  * @brief   Get link-layer address a given IPv6 address.

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -139,6 +139,17 @@ typedef enum {
     NETOPT_TX_END_IRQ,
     NETOPT_AUTOCCA,             /**< en/disable to check automatically
                                  *   before sending the channel is clear. */
+
+    /**
+     * @brief read-only check for a wired interface.
+     *
+     * If the interface is wireless this function will return -ENOTSUP, a
+     * positive value otherwise.
+     *
+     * @note Setting this option will always return -EONOTSUP.
+     */
+    NETOPT_IS_WIRED,
+
     /* add more options if needed */
 
     /**

--- a/sys/net/gnrc/link_layer/netdev_eth/gnrc_netdev_eth.c
+++ b/sys/net/gnrc/link_layer/netdev_eth/gnrc_netdev_eth.c
@@ -273,6 +273,10 @@ static int _get(gnrc_netdev_t *dev, netopt_t opt, void *value, size_t max_len)
             DEBUG("promiscous mode\n");
             return _get_promiscousmode((gnrc_netdev_eth_t *)dev, value, max_len);
 
+        case NETOPT_IS_WIRED:
+            DEBUG("is wired\n");
+            return 1;
+
         default:
             DEBUG("[not supported: %d]\n", opt);
             return -ENOTSUP;

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -570,10 +570,23 @@ static void _send(gnrc_pktsnip_t *pkt, bool prep_hdr)
         gnrc_netapi_receive(gnrc_ipv6_pid, rcv_pkt);
     }
     else {
+        /* forwarding packet */
+        ipv6_addr_t next_hop_ip;
+        /* determining next hop's IP address */
+        if (ipv6_addr_is_link_local(&(hdr->dst))) {
+            memcpy(&next_hop_ip, &(hdr->dst), sizeof(ipv6_addr_t));
+        }
+        else if (!gnrc_ndp_node_next_hop_ipv6_addr(&next_hop_ip, &iface,
+                  &(hdr->dst))) {
+            DEBUG("ipv6: error determining next hop's IPv6 address\n");
+            return;
+        }
+
+        /* determining next hop's layer 2 address */
         uint8_t l2addr_len = GNRC_IPV6_NC_L2_ADDR_MAX;
         uint8_t l2addr[l2addr_len];
 
-        iface = _next_hop_l2addr(l2addr, &l2addr_len, iface, &hdr->dst, pkt);
+        iface = _next_hop_l2addr(l2addr, &l2addr_len, iface, &next_hop_ip, pkt);
 
         if (iface == KERNEL_PID_UNDEF) {
             DEBUG("ipv6: error determining next hop's link layer address\n");

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -695,7 +695,7 @@ void gnrc_ipv6_netif_init_by_dev(void)
     for (size_t i = 0; i < ifnum; i++) {
         ipv6_addr_t addr;
         eui64_t iid;
-        uint16_t mtu;
+        uint16_t tmp;
         gnrc_ipv6_netif_t *ipv6_if = gnrc_ipv6_netif_get(ifs[i]);
 
         if (ipv6_if == NULL) {
@@ -743,13 +743,20 @@ void gnrc_ipv6_netif_init_by_dev(void)
         _add_addr_to_entry(ipv6_if, &addr, 64, 0);
 
         /* set link MTU */
-        if ((gnrc_netapi_get(ifs[i], NETOPT_MAX_PACKET_SIZE, 0, &mtu,
+        if ((gnrc_netapi_get(ifs[i], NETOPT_MAX_PACKET_SIZE, 0, &tmp,
                              sizeof(uint16_t)) >= 0)) {
-            if (mtu >= IPV6_MIN_MTU) {
-                ipv6_if->mtu = mtu;
+            if (tmp >= IPV6_MIN_MTU) {
+                ipv6_if->mtu = tmp;
             }
             /* otherwise leave at GNRC_IPV6_NETIF_DEFAULT_MTU as initialized in
              * gnrc_ipv6_netif_add() */
+        }
+
+        if (gnrc_netapi_get(ifs[i], NETOPT_IS_WIRED, 0, &tmp, sizeof(int)) > 0) {
+            ipv6_if->flags = GNRC_IPV6_NETIF_FLAGS_IS_WIRED;
+        }
+        else {
+            ipv6_if->flags = 0;
         }
 
         mutex_unlock(&ipv6_if->mutex);

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -33,7 +33,7 @@
 
 #include "net/gnrc/ndp.h"
 
-#define ENABLE_DEBUG    (0)
+#define ENABLE_DEBUG    (1)
 #include "debug.h"
 
 #if ENABLE_DEBUG

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -33,7 +33,7 @@
 
 #include "net/gnrc/ndp.h"
 
-#define ENABLE_DEBUG    (1)
+#define ENABLE_DEBUG    (0)
 #include "debug.h"
 
 #if ENABLE_DEBUG

--- a/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
+++ b/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
@@ -56,8 +56,8 @@ static gnrc_pktqueue_t *_alloc_pkt_node(gnrc_pktsnip_t *pkt)
 }
 
 bool gnrc_ndp_node_next_hop_ipv6_addr(ipv6_addr_t *next_hop_ip,
-                                    kernel_pid_t *iface,
-                                    ipv6_addr_t *dst)
+                                      kernel_pid_t *iface,
+                                      ipv6_addr_t *dst)
 {
 #ifdef MODULE_GNRC_IPV6_EXT_RH
     next_hop_ip = gnrc_ipv6_ext_rh_next_hop(hdr);

--- a/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
+++ b/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
@@ -114,7 +114,7 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
         ipv6_addr_t dst_sol;
 
         nc_entry = gnrc_ipv6_nc_add(iface, dst, NULL, 0,
-                GNRC_IPV6_NC_STATE_INCOMPLETE << GNRC_IPV6_NC_STATE_POS);
+                                    GNRC_IPV6_NC_STATE_INCOMPLETE << GNRC_IPV6_NC_STATE_POS);
 
         if (nc_entry == NULL) {
             DEBUG("ndp node: could not create neighbor cache entry\n");
@@ -160,9 +160,9 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
                            GNRC_NDP_MSG_NBR_SOL_RETRANS, nc_entry);
             mutex_unlock(&ipv6_iface->mutex);
         }
-}
+    }
 
-return KERNEL_PID_UNDEF;
+    return KERNEL_PID_UNDEF;
 }
 
 

--- a/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
+++ b/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
@@ -74,7 +74,7 @@ bool gnrc_ndp_node_next_hop_ipv6_addr(ipv6_addr_t *next_hop_ip,
                           &next_hop_flags, (uint8_t *)dst,
                           sizeof(ipv6_addr_t), 0) >= 0) &&
         (next_hop_size == sizeof(ipv6_addr_t))) {
-            next_hop_ip = &next_hop_actual;
+            memcpy(next_hop_ip, &next_hop_actual, sizeof(ipv6_addr_t));
             return true;
     }
 #endif

--- a/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
+++ b/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
@@ -70,8 +70,8 @@ bool gnrc_ndp_node_next_hop_ipv6_addr(ipv6_addr_t *next_hop_ip,
     uint32_t next_hop_flags = 0;
     ipv6_addr_t next_hop_actual;
 
-    if ((fib_get_next_hop(iface, next_hop_actual.u8, &next_hop_size,
-                          &next_hop_flags, (uint8_t *)dst,
+    if ((fib_get_next_hop(gnrc_ipv6_fib_table, iface, next_hop_actual.u8,
+                          &next_hop_size, &next_hop_flags, (uint8_t *)dst,
                           sizeof(ipv6_addr_t), 0) >= 0) &&
         (next_hop_size == sizeof(ipv6_addr_t))) {
             memcpy(next_hop_ip, &next_hop_actual, sizeof(ipv6_addr_t));

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -270,6 +270,10 @@ static void _netif_list(kernel_pid_t dev)
             printf("6LO  ");
         }
         linebreak = true;
+
+        printf("Link type: %s  ", (entry->flags & GNRC_IPV6_NETIF_FLAGS_IS_WIRED) ?
+                "wired" : "wireless");
+        linebreak= true;
     }
 #endif
 


### PR DESCRIPTION
Determining the next hop and the corresponding L2 address are split up
in two steps. No next hop look up is performed for link-local addresses
any more. Destination cache has been disabled.