### PR TITLE
cpu/kinetis_common: periph/timer, read PIT value before stopping

### DIFF
--- a/cpu/kinetis_common/timer.c
+++ b/cpu/kinetis_common/timer.c
@@ -149,8 +149,8 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 #if TIMER_0_EN
 
         case TIMER_0:
-            pit_timer_stop(TIMER_0_COUNTER_CH);
             cu_timer[dev].counter32b = pit_timer_read(dev, TIMER_0_COUNTER_CH);
+            pit_timer_stop(TIMER_0_COUNTER_CH);
             cu_timer[dev].diff = value - cu_timer[dev].counter32b;
             TIMER_DEV->CHANNEL[TIMER_0_COUNTER_CH].LDVAL = cu_timer[dev].diff;
             pit_timer_start(TIMER_0_COUNTER_CH);
@@ -159,8 +159,8 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 #if TIMER_1_EN
 
         case TIMER_1:
-            pit_timer_stop(TIMER_1_COUNTER_CH);
             cu_timer[dev].counter32b = pit_timer_read(dev, TIMER_1_COUNTER_CH);
+            pit_timer_stop(TIMER_1_COUNTER_CH);
             cu_timer[dev].diff = value - cu_timer[dev].counter32b;
             TIMER_DEV->CHANNEL[TIMER_1_COUNTER_CH].LDVAL = cu_timer[dev].diff;
             pit_timer_start(TIMER_1_COUNTER_CH);


### PR DESCRIPTION
Reading CVAL after stopping timer seem to return zero.
Ref. manual states: "The counter period can be restarted, by first
disabling, and then enabling the timer with TCTRLn[TEN]", but does not
state whether the reset of CVAL happens on TEN 0->1 transition, or 1->0
transtion. Empirical evidence suggests the latter is the implemented behaviour.

This change makes the k60 behave like the native platform does in the xtimer tests when debugging the problems described in https://github.com/RIOT-OS/RIOT/pull/2926#issuecomment-130782261.

```
2015-08-13 21:10:23,236 - INFO # running hwtimer_wait(HWTIMER_TICKS(100000))
2015-08-13 21:10:23,332 - INFO #  xtimer counted   101682 us
2015-08-13 21:10:23,335 - INFO # hwtimer counted   101715 us (3333 ticks)
2015-08-13 21:10:23,338 - INFO # running xtimer_usleep(100000)
2015-08-13 21:10:23,440 - INFO #  xtimer counted   100014 us
2015-08-13 21:10:23,444 - INFO # hwtimer counted   100036 us (3278 ticks)
2015-08-13 21:10:23,448 - INFO # running hwtimer_wait(HWTIMER_TICKS(100000))
2015-08-13 21:10:23,550 - INFO #  xtimer counted   101695 us
2015-08-13 21:10:23,554 - INFO # hwtimer counted   101715 us (3333 ticks)
2015-08-13 21:10:23,557 - INFO # running xtimer_usleep(100000)
2015-08-13 21:10:23,659 - INFO #  xtimer counted   100014 us
2015-08-13 21:10:23,663 - INFO # hwtimer counted   100036 us (3278 ticks)
```