### PR TITLE
make: ccache: set ccache basedir to RIOTBASE

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -86,6 +86,7 @@ DOCKER_ENVIRONMENT_CMDLINE := $(strip $(DOCKER_ENVIRONMENT_CMDLINE))
 	    -v '$(RIOTPROJECT):$(DOCKER_BUILD_ROOT)/riotproject' \
 	    -v /etc/localtime:/etc/localtime:ro \
 	    -e 'RIOTBASE=$(DOCKER_BUILD_ROOT)/riotbase' \
+	    -e 'CCACHE_BASEDIR=$(DOCKER_BUILD_ROOT)/riotbase' \
 	    -e 'RIOTCPU=$(DOCKER_BUILD_ROOT)/riotcpu' \
 	    -e 'RIOTBOARD=$(DOCKER_BUILD_ROOT)/riotboard' \
 	    -e 'RIOTPROJECT=$(DOCKER_BUILD_ROOT)/riotproject' \

--- a/Makefile.include
+++ b/Makefile.include
@@ -4,6 +4,8 @@ all:
 RIOTBASE ?= $(shell dirname "$(lastword $(MAKEFILE_LIST))")
 RIOTBASE := $(abspath $(RIOTBASE))
 
+CCACHE_BASEDIR := $(RIOTBASE)
+
 RIOTCPU ?= $(RIOTBASE)/cpu
 RIOTCPU := $(abspath $(RIOTCPU))
 

--- a/Makefile.vars
+++ b/Makefile.vars
@@ -53,6 +53,9 @@ export DEBUGSERVER_FLAGS     # The parameters to supply to DEBUGSERVER.
 export RESET                 # The command to call on "make reset", this command resets/reboots the target.
 export RESET_FLAGS           # The parameters to supply to RESET.
 
+export CCACHE_BASEDIR        # ccache basedir, allows multiple riot build
+                             # directories to share a ccache directory
+
 export DOWNLOAD_TO_FILE      # Use `$(DOWNLOAD_TO_FILE) $(DESTINATION) $(URL)` to download `$(URL)` to `$(DESTINATION)`.
 export DOWNLOAD_TO_STDOUT    # Use `$(DOWNLOAD_TO_STDOUT) $(URL)` to download `$(URL)` output `$(URL)` to stdout, e.g. to be piped into `tar xz`.
 export UNZIP_HERE            # Use `cd $(SOME_FOLDER) && $(UNZIP_HERE) $(SOME_FILE)` to extract the contents of the zip file `$(SOME_FILE)` into `$(SOME_FOLDER)`.


### PR DESCRIPTION
Without setting CCACHE_BASEDIR, even when compiling the same revision but in different RIOT base directories (source checkouts), ccache could not share the cache because it includes the full path in it's hashes.

Setting CCACHE_BASEDIR to RIOTBASE, multiple build directories can share the same cache.