### PR TITLE
gnrc_ndp: add support for address-less link-layers

### DIFF
--- a/sys/include/net/gnrc/ndp/internal.h
+++ b/sys/include/net/gnrc/ndp/internal.h
@@ -19,8 +19,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef INTERNAL_H_
-#define INTERNAL_H_
+#ifndef GNRC_NDP_INTERNAL_H_
+#define GNRC_NDP_INTERNAL_H_
 
 #include "net/ipv6/addr.h"
 #include "net/ipv6/hdr.h"
@@ -91,23 +91,22 @@ void gnrc_ndp_internal_send_nbr_adv(kernel_pid_t iface, ipv6_addr_t *tgt, ipv6_a
 /**
  * @brief   Handles a SL2A option.
  *
- * @param[in] iface         Interface the option was received on.
  * @param[in] pkt           Packet the option was received in.
  * @param[in] ipv6          IPv6 header of @p pkt
  * @param[in] icmpv6_type   ICMPv6 type of the message carrying the option.
- * @param[in] sl2a_opt      The SL2A option.
+ * @param[in] tl2a_opt      The TL2A option.
+ * @param[out] l2addr       The L2 address carried in the SL2A option.
  *
- * @return  true, on success.
- * @return  false, if SL2A was not valid.
+ * @return  length of the L2 address, on success.
+ * @return  -EINVAL, if SL2A was not valid.
+ * @return  -ENOTSUP, if node should silently ignore the option.
  */
-bool gnrc_ndp_internal_sl2a_opt_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
-                                       ipv6_hdr_t *ipv6, uint8_t icmpv6_type,
-                                       ndp_opt_t *sl2a_opt);
+int gnrc_ndp_internal_sl2a_opt_handle(gnrc_pktsnip_t *pkt, ipv6_hdr_t *ipv6, uint8_t icmpv6_type,
+                                      ndp_opt_t *sl2a_opt, uint8_t *l2addr);
 
 /**
  * @brief   Handles a TL2A option.
  *
- * @param[in] iface         Interface the option was received on.
  * @param[in] pkt           Packet the option was received in.
  * @param[in] ipv6          IPv6 header of @p pkt
  * @param[in] icmpv6_type   ICMPv6 type of the message carrying the option.
@@ -116,6 +115,7 @@ bool gnrc_ndp_internal_sl2a_opt_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
  *
  * @return  length of the L2 address, on success.
  * @return  -EINVAL, if TL2A was not valid.
+ * @return  -ENOTSUP, if node should silently ignore the option.
  */
 int gnrc_ndp_internal_tl2a_opt_handle(gnrc_pktsnip_t *pkt, ipv6_hdr_t *ipv6,
                                       uint8_t icmpv6_type, ndp_opt_t *tl2a_opt,
@@ -125,5 +125,5 @@ int gnrc_ndp_internal_tl2a_opt_handle(gnrc_pktsnip_t *pkt, ipv6_hdr_t *ipv6,
 }
 #endif
 
-#endif /* INTERNAL_H_ */
+#endif /* GNRC_NDP_INTERNAL_H_ */
 /** @} */

--- a/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
+++ b/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
@@ -109,7 +109,6 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
         next_hop_ip = gnrc_ndp_internal_default_router();
     }
 
-
     if (next_hop_ip == NULL) {
         next_hop_ip = dst;      /* Just look if it's in the neighbor cache
                                  * (aka on-link but not registered in prefix list as such) */
@@ -128,8 +127,9 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
         if (gnrc_ipv6_nc_get_state(nc_entry) == GNRC_IPV6_NC_STATE_STALE) {
             gnrc_ndp_internal_set_state(nc_entry, GNRC_IPV6_NC_STATE_DELAY);
         }
-
-        memcpy(l2addr, nc_entry->l2_addr, nc_entry->l2_addr_len);
+        if (nc_entry->l2_addr_len > 0) {
+            memcpy(l2addr, nc_entry->l2_addr, nc_entry->l2_addr_len);
+        }
         *l2addr_len = nc_entry->l2_addr_len;
         /* TODO: unreachability check */
         return nc_entry->iface;


### PR DESCRIPTION
Allows NDP to handle link-layers without addresses. This is achieved by handling the updating of the neighbor cache outside the context of the SL2A handle function and giving that function a numerical return value that states the length of the link-layer address (or negative for an error)