### PR TITLE
netdev: introduce additional flags

### DIFF
--- a/cpu/nrf51/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf51/radio/nrfmin/nrfmin.c
@@ -522,6 +522,7 @@ int nrfmin_init(ng_netdev_t *dev)
     dev->driver = &nrfmin_driver;
     dev->event_cb = NULL;
     dev->mac_pid = KERNEL_PID_UNDEF;
+    dev->flags |= NG_NETDEV_FLAG_WIRELESS;
     /* keep a pointer for future reference */
     _netdev = dev;
 

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -54,6 +54,7 @@ int at86rf2xx_init(at86rf2xx_t *dev, spi_t spi, spi_speed_t spi_speed,
                    gpio_t sleep_pin, gpio_t reset_pin)
 {
     dev->driver = &at86rf2xx_driver;
+    dev->flags |= NG_NETDEV_FLAG_WIRELESS;
 
     /* initialize device descriptor */
     dev->spi = spi;

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -136,6 +136,8 @@ typedef struct {
     const ng_netdev_driver_t *driver;   /**< pointer to the devices interface */
     ng_netdev_event_cb_t event_cb;      /**< netdev event callback */
     kernel_pid_t mac_pid;               /**< the driver's thread's PID */
+    uint8_t flags;                      /**< additional information about the
+                                             interface */
     /* device specific fields */
     spi_t spi;                          /**< used SPI device */
     gpio_t cs_pin;                      /**< chip select pin */

--- a/drivers/include/kw2xrf.h
+++ b/drivers/include/kw2xrf.h
@@ -107,6 +107,8 @@ typedef struct {
     ng_netdev_driver_t const *driver;     /**< Pointer to the devices interface */
     ng_netdev_event_cb_t event_cb;        /**< Netdev event callback */
     kernel_pid_t mac_pid;                 /**< The driver's thread's PID */
+    uint8_t flags;                        /**< additional information about the
+                                             interface */
     /* driver specific fields */
     uint8_t buf[KW2XRF_MAX_PKT_LENGTH];   /**< Buffer for incoming or outgoing packets */
     netopt_state_t state;                 /**< Variable to keep radio driver's state */

--- a/drivers/include/xbee.h
+++ b/drivers/include/xbee.h
@@ -111,6 +111,8 @@ typedef struct {
     ng_netdev_driver_t const *driver;   /**< pointer to the devices interface */
     ng_netdev_event_cb_t event_cb;      /**< netdev event callback */
     kernel_pid_t mac_pid;               /**< the driver's thread's PID */
+    uint8_t flags;                      /**< additional information about the
+                                             interface */
     /* device driver specific fields */
     uart_t uart;                        /**< UART interfaced used */
     gpio_t reset_pin;                   /**< GPIO pin connected to RESET */

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -407,6 +407,8 @@ int kw2xrf_init(kw2xrf_t *dev, spi_t spi, spi_speed_t spi_speed,
 
     /* set device driver */
     dev->driver = &kw2xrf_driver;
+    /* configure the device as wireless */
+    dev->flags |= NG_NETDEV_FLAG_WIRELESS;
     /* set default option */
     dev->proto = KW2XRF_DEFAULT_PROTOCOL;
     dev->option = 0;

--- a/sys/include/net/ng_netdev.h
+++ b/sys/include/net/ng_netdev.h
@@ -40,6 +40,11 @@ extern "C" {
 #define NG_NETDEV_MSG_TYPE_EVENT    (0x0100)
 
 /**
+ * @brief   Flag for indicating a wireless network interface
+ */
+#define NG_NETDEV_FLAG_WIRELESS     (0x01)
+
+/**
  * @brief   Possible event types that are send from the device driver to the
  *          MAC layer
  */
@@ -169,6 +174,8 @@ struct ng_netdev {
     ng_netdev_driver_t const *driver;   /**< pointer to the devices interface */
     ng_netdev_event_cb_t event_cb;      /**< netdev event callback */
     kernel_pid_t mac_pid;               /**< the driver's thread's PID */
+    uint8_t flags;                      /**< additional information about the
+                                             device */
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
A first use of these flags is introduced to indicate the interface as being wireless which might be a useful information for upper layers.