### PR TITLE
ndp: Default router selection

### DIFF
--- a/sys/include/net/ng_ndp/internal.h
+++ b/sys/include/net/ng_ndp/internal.h
@@ -38,10 +38,10 @@ extern "C" {
  *          RFC 4861, section 6.3.6
  *      </a>
  *
- * @return  Address to a default router.
- * @return  NULL, if the default router list is empty.
+ * @param[out] default_router  Pointer to store the address of a default router,
+ *                             may be NULL, if no default router was found.
  */
-ipv6_addr_t *ng_ndp_internal_default_router(void);
+void ng_ndp_internal_default_router(ipv6_addr_t *default_router);
 
 /**
  * @brief   Sets state of a neighbor cache entry and triggers required actions.

--- a/sys/net/network_layer/ng_ndp/internal/ng_ndp_internal.c
+++ b/sys/net/network_layer/ng_ndp/internal/ng_ndp_internal.c
@@ -53,7 +53,7 @@ static inline void _send_delayed(vtimer_t *t, timex_t interval, ng_pktsnip_t *pk
 }
 
 
-ipv6_addr_t *ng_ndp_internal_default_router(void)
+void ng_ndp_internal_default_router(ipv6_addr_t *default_router)
 {
     ng_ipv6_nc_t *router = ng_ipv6_nc_get_next_router(NULL);
 
@@ -63,7 +63,7 @@ ipv6_addr_t *ng_ndp_internal_default_router(void)
             (ng_ipv6_nc_get_state(router) != NG_IPV6_NC_STATE_UNREACHABLE)) {
             _last_router = NULL;
 
-            return &router->ipv6_addr;
+            memcpy(default_router, &(router->ipv6_addr), sizeof(ipv6_addr_t));
         }
 
         router = ng_ipv6_nc_get_next_router(router);
@@ -76,13 +76,14 @@ ipv6_addr_t *ng_ndp_internal_default_router(void)
         router = ng_ipv6_nc_get_next_router(router);
 
         if (router == NULL) {   /* still nothing found => no router in list */
-            return NULL;
+            default_router = NULL;
+            return;
         }
     }
 
     _last_router = router;
 
-    return &router->ipv6_addr;
+    memcpy(default_router, &(router->ipv6_addr), sizeof(ipv6_addr_t));
 }
 
 void ng_ndp_internal_set_state(ng_ipv6_nc_t *nc_entry, uint8_t state)

--- a/sys/net/network_layer/ng_ndp/node/ng_ndp_node.c
+++ b/sys/net/network_layer/ng_ndp/node/ng_ndp_node.c
@@ -101,7 +101,7 @@ kernel_pid_t ng_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
 
     /* dst has not an on-link prefix  */
     if (next_hop_ip == NULL) {
-        next_hop_ip = ng_ndp_internal_default_router();
+        ng_ndp_internal_default_router(next_hop_ip);
     }
 
 


### PR DESCRIPTION
A default router that has been configured manually or by a routing protocol should be preferred over potential others.

However, only after finishing this PR I realized this is probably unnecessary, if the function is only called from places where a FIB lookup is done anyway before. Close and forget this one, @authmillenon?