### PR TITLE
Added a colored outputter to embUnit.

### DIFF
--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -81,5 +81,9 @@ ifneq (,$(filter embunit,$(USEMODULE)))
         CFLAGS += -DOUTPUT=OUTPUT_TEXT
     else ifeq ($(OUTPUT),COMPILER)
         CFLAGS += -DOUTPUT=OUTPUT_COMPILER
+    else ifeq ($(OUTPUT),COLORTEXT)
+        CFLAGS += -DOUTPUT=OUTPUT_COLORTEXT
+    else ifeq ($(OUTPUT),COLOR)
+        CFLAGS += -DOUTPUT=OUTPUT_COLOR
     endif
 endif

--- a/sys/embunit/ColorOutputter.c
+++ b/sys/embunit/ColorOutputter.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer <noshky@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <stdio.h>
+#include "ColorOutputter.h"
+#include "ColorTextColors.h"
+
+static void ColorOutputter_printHeader(OutputterRef self)
+{
+    (void) self;
+}
+
+static void ColorOutputter_printStartTest(OutputterRef self, TestRef test)
+{
+    (void) self;
+    (void) test;
+}
+
+static void ColorOutputter_printEndTest(OutputterRef self, TestRef test)
+{
+    (void) self;
+    (void) test;
+}
+
+static void ColorOutputter_printSuccessful(OutputterRef self, TestRef test, int runCount)
+{
+    (void) self;
+    (void) test;
+    (void) runCount;
+    printf(CGREEN "." CDEFAULT);
+}
+
+static void ColorOutputter_printFailure(OutputterRef self, TestRef test, char *msg, int line,
+        char *file, int runCount)
+{
+    (void) self;
+    (void) runCount;
+    printf("\n" CRED "FAILED %s (%s:%d) %s" CDEFAULT "\n", Test_name(test), file, line, msg);
+}
+
+void ColorOutputter_printStatistics(OutputterRef self, TestResultRef result)
+{
+    (void) self;
+    if (result->failureCount) {
+        printf("\n" BGRED SBOLD "FAILED" SDEFAULT " (%d of %d failed)", result->failureCount,
+                result->runCount);
+    }
+    else {
+        printf("\n" BGGREEN SBOLD "OK" SDEFAULT " (%d tests)", result->runCount);
+    }
+    printf(LINEFILL BGDEFAULT "\n");
+}
+
+static const OutputterImplement ColorOutputterImplement = {
+    (OutputterPrintHeaderFunction) ColorOutputter_printHeader,
+    (OutputterPrintStartTestFunction) ColorOutputter_printStartTest,
+    (OutputterPrintEndTestFunction) ColorOutputter_printEndTest,
+    (OutputterPrintSuccessfulFunction) ColorOutputter_printSuccessful,
+    (OutputterPrintFailureFunction) ColorOutputter_printFailure,
+    (OutputterPrintStatisticsFunction) ColorOutputter_printStatistics
+};
+
+static const Outputter ColorOutputter = {
+    (OutputterImplementRef) &ColorOutputterImplement
+};
+
+OutputterRef ColorOutputter_outputter(void)
+{
+    return (OutputterRef) &ColorOutputter;
+}

--- a/sys/embunit/ColorTextColors.h
+++ b/sys/embunit/ColorTextColors.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer <noshky@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ *
+ * @author Janos Kutscherauer <noshky@gmail.com>
+ */
+#ifndef __COLORTEXTCOLORS_H__
+#define __COLORTEXTCOLORS_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Terminal color definitions
+ * C<color>:    text color
+ *
+ * CDEFAULT:    default text color
+ *
+ * BG<color>:   background color
+ *
+ * BGDEFAULT:   default background color
+ *
+ * S<style>:    text style
+ *
+ * SDEFAULT:    default text style
+ * @{
+ */
+#define CRED        "\033[31m"
+#define CGREEN      "\033[32m"
+#define CDEFAULT    "\033[39m"
+#define BGRED       "\033[41m"
+#define BGGREEN     "\033[42m"
+#define BGDEFAULT   "\033[49m"
+#define SBOLD       "\033[1m"
+#define SDEFAULT    "\033[21m"
+#define LINEFILL    "\033[K"
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif/*__COLORTEXTCOLORS_H__*/
+/** @} */

--- a/sys/embunit/ColorTextOutputter.c
+++ b/sys/embunit/ColorTextOutputter.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer <noshky@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <stdio.h>
+#include "ColorTextOutputter.h"
+#include "ColorOutputter.h"
+#include "ColorTextColors.h"
+
+static void ColorTextOutputter_printHeader(OutputterRef self)
+{
+    (void)self;
+}
+
+static void ColorTextOutputter_printStartTest(OutputterRef self,TestRef test)
+{
+    (void)self;
+    printf("- %s\n",Test_name(test));
+}
+
+static void ColorTextOutputter_printEndTest(OutputterRef self,TestRef test)
+{
+    (void)self;
+    (void)test;
+}
+
+static void ColorTextOutputter_printSuccessful(OutputterRef self,TestRef test,int runCount)
+{
+    (void)self;
+    printf(CGREEN "%d) OK %s" CDEFAULT "\n", runCount, Test_name(test));
+}
+
+static void ColorTextOutputter_printFailure(OutputterRef self,TestRef test,char *msg,int line,char *file,int runCount)
+{
+    (void)self;
+    printf(CRED "%d) NG %s" CDEFAULT " (%s:%d) %s\n", runCount, Test_name(test), file, line, msg);
+}
+
+void ColorTextOutputter_printStatistics(OutputterRef self,TestResultRef result)
+{
+    ColorOutputter_printStatistics(self, result);
+}
+
+static const OutputterImplement ColorTextOutputterImplement = {
+    (OutputterPrintHeaderFunction)      ColorTextOutputter_printHeader,
+    (OutputterPrintStartTestFunction)   ColorTextOutputter_printStartTest,
+    (OutputterPrintEndTestFunction)     ColorTextOutputter_printEndTest,
+    (OutputterPrintSuccessfulFunction)  ColorTextOutputter_printSuccessful,
+    (OutputterPrintFailureFunction)     ColorTextOutputter_printFailure,
+    (OutputterPrintStatisticsFunction)  ColorTextOutputter_printStatistics,
+};
+
+static const Outputter ColorTextOutputter = {
+    (OutputterImplementRef)&ColorTextOutputterImplement,
+};
+
+OutputterRef ColorTextOutputter_outputter(void)
+{
+    return (OutputterRef)&ColorTextOutputter;
+}

--- a/sys/include/embUnit.h
+++ b/sys/include/embUnit.h
@@ -22,9 +22,11 @@
 #include "embUnit/embUnit.h"
 
 #ifdef OUTPUT
-#   define OUTPUT_XML      (1)
-#   define OUTPUT_TEXT     (2)
-#   define OUTPUT_COMPILER (4)
+#   define OUTPUT_XML       (1)
+#   define OUTPUT_TEXT      (2)
+#   define OUTPUT_COMPILER  (4)
+#   define OUTPUT_COLORTEXT (8)
+#   define OUTPUT_COLOR     (16)
 
 #   if (OUTPUT==OUTPUT_XML)
 #       include "embUnit/XMLOutputter.h"
@@ -35,6 +37,12 @@
 #   elif (OUTPUT==OUTPUT_COMPILER)
 #       include "embUnit/CompilerOutputter.h"
 #       define OUTPUTTER   (CompilerOutputter_outputter())
+#   elif (OUTPUT==OUTPUT_COLORTEXT)
+#       include "embUnit/ColorTextOutputter.h"
+#       define OUTPUTTER   (ColorTextOutputter_outputter())
+#   elif (OUTPUT==OUTPUT_COLOR)
+#       include "embUnit/ColorOutputter.h"
+#       define OUTPUTTER   (ColorOutputter_outputter())
 #   endif
 
 #   include "embUnit/TextUIRunner.h"

--- a/sys/include/embUnit/ColorOutputter.h
+++ b/sys/include/embUnit/ColorOutputter.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer <noshky@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ *
+ * @author Janos Kutscherauer <noshky@gmail.com>
+ */
+#ifndef __COLOROUTPUTTER_H__
+#define __COLOROUTPUTTER_H__
+
+#include "Outputter.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief embUnit coloured output formatter
+ *
+ * @return pointer to the OutputterImplement struct for this outputter
+ */
+OutputterRef ColorOutputter_outputter(void);
+
+/**
+ * @brief coloured output formatter for test statistics
+ *
+ * @param[in] self      pointer to the used OutputterImplement
+ * @param[in] result    the test results to print
+ */
+void ColorOutputter_printStatistics(OutputterRef self, TestResultRef result);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif/*__COLOROUTPUTTER_H__*/
+/** @} */

--- a/sys/include/embUnit/ColorTextOutputter.h
+++ b/sys/include/embUnit/ColorTextOutputter.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2015 Janos Kutscherauer <noshky@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file    ColorTextOutputter.h
+ */
+#ifndef __COLORTEXTOUTPUTTER_H__
+#define __COLORTEXTOUTPUTTER_H__
+
+#include "Outputter.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+OutputterRef ColorTextOutputter_outputter(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif/*__COLORTEXTOUTPUTTER_H__*/
+/** @} */

--- a/tests/unittests/README.md
+++ b/tests/unittests/README.md
@@ -30,6 +30,8 @@ Other output formats using [*embUnit*](http://embunit.sourceforge.net/)'s ``text
 * Compiler: ``OUTPUT="COMPILER"``
 * Text: ``OUTPUT="TEXT"``
 * XML: ``OUTPUT="XML"``
+* Color: ``OUTPUT="COLOR"`` (like default, but with red/green output)
+* Colored-Text: ``OUTPUT="COLORTEXT"`` (like ``TEXT``, but with red/green output)
 
 #### Compile example
 ```bash


### PR DESCRIPTION
The outputter is called ColorTextOutputter and can be enabled by defining OUTPUT=COLORTEXT.
The colored outputter behaves just like the TextOutputter, but displays successful tests in GREEN and failed tests in RED. The summary message is also in GREEN/RED, but is slightly different from the TextOutputter.

Also:
* Added fancy simple none-verbose color-outputter for EmbUnit. The outputter outputs a simple statistics line in GREEN or RED, according to the test success or failure. (Also, the ColorTextOutputter was adjusted to use the statistics output of this new ColorOutputter.) The new outputter can be activated with OUTPUT=COLOR.
* Added a single character "." output for the simple color outputter and replaced the color codes by macros.