### PR TITLE
wakaama: fixed errors for bootstrap mode

### DIFF
--- a/pkg/wakaama/0007-fixed-warnings-in-bootstrap.c.patch
+++ b/pkg/wakaama/0007-fixed-warnings-in-bootstrap.c.patch
@@ -1,0 +1,33 @@
+From ed834183706e55f505d52299c434ef948d7fe22f Mon Sep 17 00:00:00 2001
+From: Darredevil <alex.darredevil@gmail.com>
+Date: Tue, 18 Aug 2015 11:43:15 +0100
+Subject: [PATCH 1/4] fixed warnings in bootstrap.c
+
+---
+ core/bootstrap.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/core/bootstrap.c b/core/bootstrap.c
+index 2bd6d82..282bc11 100644
+--- a/core/bootstrap.c
++++ b/core/bootstrap.c
+@@ -97,6 +97,8 @@ void handle_bootstrap_response(lwm2m_context_t * context,
+         coap_packet_t * message,
+         void * fromSessionH)
+ {
++    (void)fromSessionH;
++
+     if (COAP_204_CHANGED == message->code)
+     {
+         context->bsState = BOOTSTRAP_PENDING;
+@@ -221,6 +223,8 @@ void update_bootstrap_state(lwm2m_context_t * context,
+ coap_status_t handle_bootstrap_finish(lwm2m_context_t * context,
+                                       void * fromSessionH)
+ {
++    (void)fromSessionH;
++
+     if (context->bsState == BOOTSTRAP_PENDING)
+     {
+         context->bsState = BOOTSTRAP_FINISHED;
+--
+1.9.1

--- a/pkg/wakaama/0008-fixed-warnings-in-objects.c.patch
+++ b/pkg/wakaama/0008-fixed-warnings-in-objects.c.patch
@@ -1,0 +1,51 @@
+From 7e378684d09226d699e566f30bd190acaab05e10 Mon Sep 17 00:00:00 2001
+From: Darredevil <alex.darredevil@gmail.com>
+Date: Tue, 18 Aug 2015 11:46:44 +0100
+Subject: [PATCH 2/4] fixed warnings in objects.c
+
+---
+ core/objects.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/core/objects.c b/core/objects.c
+index cb22444..95e093e 100644
+--- a/core/objects.c
++++ b/core/objects.c
+@@ -17,7 +17,7 @@
+  *    Benjamin Cabé - Please refer to git log
+  *    Bosch Software Innovations GmbH - Please refer to git log
+  *    Pascal Rieux - Please refer to git log
+- *
++ *
+  *******************************************************************************/
+
+ /*
+@@ -380,7 +380,7 @@ int prv_getRegisterPayload(lwm2m_context_t * contextP,
+      && (contextP->altPath[0] != 0))
+     {
+         result = snprintf((char *)buffer, length, REG_ALT_PATH_LINK, contextP->altPath);
+-        if (result > 0 && result <= length)
++        if (result > 0 && (size_t)result <= length)
+         {
+             index = result;
+         }
+@@ -398,7 +398,7 @@ int prv_getRegisterPayload(lwm2m_context_t * contextP,
+             result = snprintf((char *)buffer + index, length - index,
+                               REG_OBJECT_PATH,
+                               contextP->altPath?contextP->altPath:"", contextP->objectList[i]->objID);
+-            if (result > 0 && result <= length - index)
++            if (result > 0 && (size_t)result <= length - index)
+             {
+                 index += result;
+             }
+@@ -415,7 +415,7 @@ int prv_getRegisterPayload(lwm2m_context_t * contextP,
+                 result = snprintf((char *)buffer + index, length - index,
+                                   REG_OBJECT_INSTANCE_PATH,
+                                   contextP->altPath?contextP->altPath:"", contextP->objectList[i]->objID, targetP->id);
+-                if (result > 0 && result <= length - index)
++                if (result > 0 && (size_t)result <= length - index)
+                 {
+                     index += result;
+                 }
+--
+1.9.1

--- a/pkg/wakaama/0009-fixed-errors-in-internals.h.patch
+++ b/pkg/wakaama/0009-fixed-errors-in-internals.h.patch
@@ -1,0 +1,32 @@
+From 913baf8fb537fc8a4d5d01b9ad96829df3a43ebe Mon Sep 17 00:00:00 2001
+From: Darredevil <alex.darredevil@gmail.com>
+Date: Tue, 18 Aug 2015 11:57:23 +0100
+Subject: [PATCH 3/4] fixed errors in internals.h
+
+---
+ core/internals.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/core/internals.h b/core/internals.h
+index 36d7d12..d924481 100644
+--- a/core/internals.h
++++ b/core/internals.h
+@@ -16,7 +16,7 @@
+  *    Toby Jaffey - Please refer to git log
+  *    Bosch Software Innovations GmbH - Please refer to git log
+  *    Pascal Rieux - Please refer to git log
+- *
++ *
+  *******************************************************************************/
+ /*
+  Copyright (c) 2013, 2014 Intel Corporation
+@@ -178,6 +178,7 @@ void reset_bootstrap_timer(lwm2m_context_t * context);
+ void update_bootstrap_state(lwm2m_context_t * contextP, uint32_t currentTime, time_t* timeoutP);
+ void delete_bootstrap_server_list(lwm2m_context_t * contextP);
+ uint8_t handle_bootstrap_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
++coap_status_t handle_bootstrap_finish(lwm2m_context_t * context, void * fromSessionH);
+
+ // defined in liblwm2m.c
+ void delete_transaction_list(lwm2m_context_t * context);
+--
+1.9.1

--- a/pkg/wakaama/0010-fixed-warnings-in-registration.c.patch
+++ b/pkg/wakaama/0010-fixed-warnings-in-registration.c.patch
@@ -1,0 +1,32 @@
+From 13a55d7a07fbfb4af77d51825633bd5e30661023 Mon Sep 17 00:00:00 2001
+From: Darredevil <alex.darredevil@gmail.com>
+Date: Tue, 18 Aug 2015 12:00:23 +0100
+Subject: [PATCH 4/4] fixed warnings in registration.c
+
+---
+ core/registration.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/core/registration.c b/core/registration.c
+index 2ec7295..abdad48 100644
+--- a/core/registration.c
++++ b/core/registration.c
+@@ -389,6 +389,7 @@ void registration_update(lwm2m_context_t * contextP,
+ static void prv_handleDeregistrationReply(lwm2m_transaction_t * transacP,
+                                         void * message)
+ {
++    (void)message;
+     lwm2m_server_t * targetP;
+
+     targetP = (lwm2m_server_t *)(transacP->peerP);
+@@ -529,7 +530,7 @@ static int prv_getId(uint8_t * data,
+     {
+         data++;
+         length-=2;
+-    }
++    }
+     else
+     {
+         return 0;
+--
+1.9.1


### PR DESCRIPTION
Apparently there were still some warnings when running in bootstrap mode, all fixed now.