### PR TITLE
gnrc: null pointer checks

### DIFF
--- a/sys/net/crosslayer/ng_pktbuf_static/ng_pktbuf_static.c
+++ b/sys/net/crosslayer/ng_pktbuf_static/ng_pktbuf_static.c
@@ -429,6 +429,8 @@ static inline bool _too_small_hole(_unused_t *a, _unused_t *b)
 
 static inline _unused_t *_merge(_unused_t *a, _unused_t *b)
 {
+    assert(b != NULL);
+
     a->next = b->next;
     a->size = b->size + ((uint8_t *)b - (uint8_t *)a);
     return a;

--- a/sys/net/crosslayer/ng_pktbuf_static/ng_pktbuf_static.c
+++ b/sys/net/crosslayer/ng_pktbuf_static/ng_pktbuf_static.c
@@ -457,7 +457,7 @@ static void _pktbuf_free(void *data, size_t size)
             new = _merge(prev, new);
         }
     }
-    if (_too_small_hole(new, new->next)) {
+    if ((new->next != NULL) && (_too_small_hole(new, new->next))) {
         _merge(new, new->next);
     }
 }

--- a/sys/net/link_layer/ng_netdev_eth/ng_netdev_eth.c
+++ b/sys/net/link_layer/ng_netdev_eth/ng_netdev_eth.c
@@ -362,7 +362,7 @@ static inline void _addr_set_multicast(uint8_t *dst, ng_pktsnip_t *payload)
         case NG_NETTYPE_IPV6:
             dst[0] = 0x33;
             dst[1] = 0x33;
-            if ((payload != NULL) && (payload->data != NULL)) {
+            if (payload->data != NULL) {
                 ipv6_hdr_t *hdr = payload->data;
                 uint16_t *prefix = (uint16_t *)(&dst[2]);
                 prefix[0] = hdr->dst.u16[6].u16;
@@ -418,6 +418,12 @@ static int _marshall_ethernet(ng_netdev_eth_t *dev, uint8_t *buffer, ng_pktsnip_
         _addr_set_broadcast(hdr->dst);
     }
     else if (netif_hdr->flags & NG_NETIF_HDR_FLAGS_MULTICAST) {
+        if (payload == NULL) {
+            DEBUG("ng_netdev_eth: empty multicast packets over Ethernet are "\
+                  "not yet supported\n");
+            return -ENOTSUP;
+
+        }
         _addr_set_multicast(hdr->dst, payload);
     }
     else if (netif_hdr->dst_l2addr_len == ETHERNET_ADDR_LEN) {

--- a/sys/net/network_layer/ng_sixlowpan/iphc/ng_sixlowpan_iphc.c
+++ b/sys/net/network_layer/ng_sixlowpan/iphc/ng_sixlowpan_iphc.c
@@ -176,6 +176,9 @@ size_t ng_sixlowpan_iphc_decode(ng_pktsnip_t *ipv6, ng_pktsnip_t *pkt, size_t of
     }
 
     switch (iphc_hdr[IPHC2_IDX] & (NG_SIXLOWPAN_IPHC2_SAC | NG_SIXLOWPAN_IPHC2_SAM)) {
+        /* should be asserted by line 168 anyway */
+        assert(ctx != NULL);
+
         case IPHC_SAC_SAM_FULL:
             /* take full 128 from inline */
             memcpy(&(ipv6_hdr->src), iphc_hdr + payload_offset, 16);


### PR DESCRIPTION
fixes #3261, alternative to #3238 and fixed version of #3473.