### PR TITLE
gnrc_rpl: fix dependencies

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -35,6 +35,14 @@ ifneq (,$(filter ng_zep,$(USEMODULE)))
   USEMODULE += vtimer
 endif
 
+ifneq (,$(filter ng_rpl,$(USEMODULE)))
+  USEMODULE += fib
+  USEMODULE += gnrc
+  USEMODULE += ng_ipv6_router_default
+  USEMODULE += trickle
+  USEMODULE += vtimer
+endif
+
 ifneq (,$(filter ieee802154,$(USEMODULE)))
   ifneq (,$(filter ng_ipv6, $(USEMODULE)))
     USEMODULE += ng_sixlowpan
@@ -261,14 +269,4 @@ endif
 
 ifneq (,$(filter hih6130,$(USEMODULE)))
   USEMODULE += vtimer
-endif
-
-ifneq (,$(filter ng_rpl,$(USEMODULE)))
-  USEMODULE += timex
-  USEMODULE += vtimer
-  USEMODULE += ng_ipv6_router_default
-  USEMODULE += trickle
-  USEMODULE += net_help
-  USEMODULE += universal_address
-  USEMODULE += fib
 endif

--- a/sys/include/net/ng_rpl.h
+++ b/sys/include/net/ng_rpl.h
@@ -36,7 +36,6 @@
 #include "net/ng_rpl/structs.h"
 #include "net/ng_rpl/dodag.h"
 #include "net/ng_rpl/of_manager.h"
-#include "inet_ntop.h"
 #include "net/fib.h"
 #include "vtimer.h"
 #include "trickle.h"

--- a/sys/net/routing/ng_rpl/ng_rpl_dodag.c
+++ b/sys/net/routing/ng_rpl/ng_rpl_dodag.c
@@ -16,6 +16,7 @@
  */
 
 #include <stdbool.h>
+#include "inet_pton.h"
 #include "net/ng_rpl/dodag.h"
 #include "net/ng_rpl/structs.h"
 #include "utlist.h"


### PR DESCRIPTION
Follow-up to #3050.

The dependency conditional for RPL was at the very end of `Makefile.dep`, giving depending modules no chance to pull in their dependencies (rpl just lists them as dependencies too).

Also it pulled in the deprecated module `net_help`, though it did not use any of it's functions (it just included `inet_pton.h` for `AF_INET6`).