### PR TITLE
af: initial import of global AF_ definition header

### DIFF
--- a/pkg/oonf_api/0001-add-RIOT-support.patch
+++ b/pkg/oonf_api/0001-add-RIOT-support.patch
@@ -1,7 +1,7 @@
-From 012da8d41806ae98adab8cb4e88e52c2e675ab4f Mon Sep 17 00:00:00 2001
+From b7ed6eeb4f970bf603da8ec90f4f7e8b862dcdb6 Mon Sep 17 00:00:00 2001
 From: Benjamin Valentin <benpicco@zedat.fu-berlin.de>
 Date: Wed, 5 Feb 2014 20:01:41 +0100
-Subject: [PATCH 1/3] add RIOT support
+Subject: [PATCH 01/10] add RIOT support
 
 ---
  Makefile                             | 29 ++++++++++++++
@@ -24,7 +24,7 @@ Subject: [PATCH 1/3] add RIOT support
 
 diff --git a/Makefile b/Makefile
 new file mode 100644
-index 0000000..cf66baa
+index 0000000..1f1cd9c
 --- /dev/null
 +++ b/Makefile
 @@ -0,0 +1,29 @@
@@ -77,13 +77,13 @@ index 0000000..5e0046d
 +
 +include $(RIOTBASE)/Makefile.base
 diff --git a/src-api/common/autobuf.c b/src-api/common/autobuf.c
-index 77c519b..e09c0c9 100644
+index 77c519b..37e77ac 100644
 --- a/src-api/common/autobuf.c
 +++ b/src-api/common/autobuf.c
 @@ -51,6 +51,12 @@
  #include <winsock2.h>
  #endif
-
+ 
 +#ifdef RIOT_VERSION
 +int getpagesize(void) {
 +	return 512;
@@ -91,10 +91,10 @@ index 77c519b..e09c0c9 100644
 +#endif
 +
  #include "common/autobuf.h"
-
+ 
  /**
 diff --git a/src-api/common/common_types.h b/src-api/common/common_types.h
-index c90cf46..54ce281 100644
+index c90cf46..b5f170a 100644
 --- a/src-api/common/common_types.h
 +++ b/src-api/common/common_types.h
 @@ -77,6 +77,11 @@
@@ -110,20 +110,20 @@ index c90cf46..54ce281 100644
    #define PRINTF_SIZE_T_SPECIFIER     "zu"
    #define PRINTF_SIZE_T_HEX_SPECIFIER "zx"
 diff --git a/src-api/common/daemonize.c b/src-api/common/daemonize.c
-index 103c88f..6ea603d 100644
+index 103c88f..8a6cd2b 100644
 --- a/src-api/common/daemonize.c
 +++ b/src-api/common/daemonize.c
 @@ -48,7 +48,7 @@
  #include "common/common_types.h"
  #include "common/daemonize.h"
-
+ 
 -#ifndef WIN32
 +#if (!defined(_WIN32)) && (!defined(RIOT_VERSION))
  /**
   * Prepare the start of a daemon. Fork into background,
   * but keep stdin/out/err open and a pipe connected to
 diff --git a/src-api/common/netaddr.c b/src-api/common/netaddr.c
-index dedab2c..fdc3e82 100644
+index dedab2c..1b602ec 100644
 --- a/src-api/common/netaddr.c
 +++ b/src-api/common/netaddr.c
 @@ -43,7 +43,14 @@
@@ -133,12 +133,12 @@ index dedab2c..fdc3e82 100644
 +#ifndef RIOT_VERSION
  #include <net/if.h>
 +#else
-+#include "net_help.h"
++#include "net/af.h"
 +#include "inet_ntop.h"
 +#include "inet_pton.h"
 +#define DONT_HAVE_SIN6_SCOPE_ID
 +#endif
-
+ 
  #include "common/common_types.h"
  #include "common/string.h"
 @@ -175,12 +182,12 @@ netaddr_to_binary(void *dst, const struct netaddr *src, size_t len) {
@@ -165,14 +165,14 @@ index dedab2c..fdc3e82 100644
 +  dst->_type = (uint8_t)src->std.sin6_family;
    return 0;
  }
-
+ 
 @@ -204,12 +211,12 @@ netaddr_from_socket(struct netaddr *dst, const union netaddr_socket *src) {
  int
  netaddr_to_socket(union netaddr_socket *dst, const struct netaddr *src) {
    /* copy address type */
 -  dst->std.sa_family = src->_type;
 +  dst->std.sin6_family = src->_type;
-
+ 
    switch (src->_type) {
      case AF_INET:
        /* ipv4 */
@@ -183,13 +183,13 @@ index dedab2c..fdc3e82 100644
        /* ipv6 */
 @@ -221,7 +228,7 @@ netaddr_to_socket(union netaddr_socket *dst, const struct netaddr *src) {
    }
-
+ 
    /* copy address type */
 -  dst->std.sa_family= src->_type;
 +  dst->std.sin6_family= src->_type;
    return 0;
  }
-
+ 
 @@ -319,14 +326,16 @@ netaddr_socket_init(union netaddr_socket *combined, const struct netaddr *addr,
    switch (addr->_type) {
      case AF_INET:
@@ -212,13 +212,13 @@ index dedab2c..fdc3e82 100644
        /* unknown address type */
 @@ -334,7 +343,7 @@ netaddr_socket_init(union netaddr_socket *combined, const struct netaddr *addr,
    }
-
+ 
    /* copy address type */
 -  combined->std.sa_family = addr->_type;
 +  combined->std.sin6_family = addr->_type;
    return 0;
  }
-
+ 
 @@ -344,11 +353,11 @@ netaddr_socket_init(union netaddr_socket *combined, const struct netaddr *addr,
   */
  uint16_t
@@ -237,7 +237,7 @@ index dedab2c..fdc3e82 100644
 @@ -555,28 +564,31 @@ const char *
  netaddr_socket_to_string(struct netaddr_str *dst, const union netaddr_socket *src) {
    struct netaddr_str buf;
-
+ 
 -  if (src->std.sa_family == AF_INET) {
 +  if (src->std.sin6_family == AF_INET) {
      snprintf(dst->buf, sizeof(*dst), "%s:%d",
@@ -251,7 +251,7 @@ index dedab2c..fdc3e82 100644
 +#ifndef DONT_HAVE_SIN6_SCOPE_ID
      if (src->v6.sin6_scope_id) {
        char scope_buf[IF_NAMESIZE];
-
+ 
        snprintf(dst->buf, sizeof(*dst), "[%s]:%d%%%s",
            inet_ntop(AF_INET6, &src->v6.sin6_addr, buf.buf, sizeof(buf)),
 -          ntohs(src->v6.sin6_port),
@@ -272,18 +272,18 @@ index dedab2c..fdc3e82 100644
 -    snprintf(dst->buf, sizeof(*dst), "\"Unknown socket type: %d\"", src->std.sa_family);
 +    snprintf(dst->buf, sizeof(*dst), "\"Unknown socket type: %d\"", src->std.sin6_family);
    }
-
+ 
    return dst->buf;
 @@ -622,13 +634,13 @@ int
  netaddr_cmp_to_socket(const struct netaddr *a1, const union netaddr_socket *a2) {
    int result = 0;
-
+ 
 -  result = (int)a1->_type - (int)a2->std.sa_family;
 +  result = (int)a1->_type - (int)a2->std.sin6_family;
    if (result) {
      return result;
    }
-
+ 
    if (a1->_type == AF_INET) {
 -    result = memcmp(a1->_addr, &a2->v4.sin_addr, 4);
 +    result = memcmp(a1->_addr, &a2->v4.sin6_addr, 4);
@@ -317,7 +317,7 @@ index dedab2c..fdc3e82 100644
      return dst;
    }
 @@ -795,7 +807,7 @@ inet_pton(int af, const char *src, void *dst)
-
+ 
    sock = (union netaddr_socket *)res->ai_addr;
    if (af == AF_INET) {
 -    memcpy(dst, &sock->v4.sin_addr, 4);
@@ -327,21 +327,21 @@ index dedab2c..fdc3e82 100644
      memcpy(dst, &sock->v6.sin6_addr, 16);
 @@ -928,7 +940,7 @@ _subnetmask_to_prefixlen(const char *src) {
    }
-
+ 
    /* transform into host byte order */
 -  v4 = ntohl(v4);
 +  v4 = NTOHL(v4);
-
+ 
    shift = 0xffffffff;
    for (len = 31; len >= 0; len--) {
 diff --git a/src-api/common/netaddr.h b/src-api/common/netaddr.h
-index 78fd5b4..cfba7a9 100644
+index 78fd5b4..e65bf94 100644
 --- a/src-api/common/netaddr.h
 +++ b/src-api/common/netaddr.h
 @@ -43,18 +43,26 @@
  #define NETADDR_H_
-
-
+ 
+ 
 -#ifndef _WIN32
 +#if (!defined(_WIN32)) && (!defined(RIOT_VERSION))
  #include <arpa/inet.h>
@@ -354,10 +354,10 @@ index 78fd5b4..cfba7a9 100644
 +#ifdef _WIN32
  #include <winsock2.h>
  #include <ws2tcpip.h>
-
+ 
  #define IF_NAMESIZE 16
  #endif
-
+ 
 +#ifdef RIOT_VERSION
 +#include "socket_base/socket.h"
 +#define INET_ADDRSTRLEN		(16)
@@ -366,7 +366,7 @@ index 78fd5b4..cfba7a9 100644
 +
  #include <assert.h>
  #include <string.h>
-
+ 
 @@ -97,10 +105,10 @@ struct netaddr {
   * to all variants without casting and compiler warnings.
   */
@@ -380,7 +380,7 @@ index 78fd5b4..cfba7a9 100644
 +  sockaddr6_t std;
 +  sockaddr6_t storage;
  };
-
+ 
  /**
 @@ -337,7 +345,7 @@ netaddr_set_prefix_length(struct netaddr *n, uint8_t prefix_len) {
   */
@@ -389,7 +389,7 @@ index 78fd5b4..cfba7a9 100644
 -  return s->std.sa_family;
 +  return s->std.sin6_family;
  }
-
+ 
  #endif /* NETADDR_H_ */
 diff --git a/src-api/rfc5444/Makefile b/src-api/rfc5444/Makefile
 new file mode 100644
@@ -458,7 +458,7 @@ index 0000000..9bf6622
 +
 +#endif /* RFC5444_API_CONFIG_H_ */
 diff --git a/src-api/rfc5444/rfc5444_print.c b/src-api/rfc5444/rfc5444_print.c
-index 4b3e04d..6b52f72 100644
+index 4b3e04d..7b9a308 100644
 --- a/src-api/rfc5444/rfc5444_print.c
 +++ b/src-api/rfc5444/rfc5444_print.c
 @@ -41,8 +41,13 @@
@@ -472,9 +472,9 @@ index 4b3e04d..6b52f72 100644
  #include <sys/socket.h>
  #include <arpa/inet.h>
 +#endif
-
+ 
  #include "common/netaddr.h"
  #include "rfc5444/rfc5444_reader.h"
---
-1.8.3.2
+-- 
+1.9.1
 

--- a/sys/include/net/af.h
+++ b/sys/include/net/af.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_af  UNIX address families
+ * @ingroup     net
+ * @brief       Global UNIX address family definitions
+ * @{
+ *
+ * @file
+ * @brief   Global UNIX address family definitions
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+#ifndef AF_H_
+#define AF_H_
+
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    AF_UNSPEC = 0,              /**< unspecified address family */
+#define AF_UNSPEC   AF_UNSPEC   /**< unspecified address family (as macro) */
+    AF_UNIX,                    /**< local to host (pipes, portals) address family. */
+#define AF_UNIX     AF_UNIX     /**< unspecified address family (as macro) */
+    AF_INET,                    /**< internetwork address family: UDP, TCP, etc. */
+#define AF_INET     AF_INET     /**< internetwork address family: UDP, TCP, etc. (as macro) */
+    AF_INET6,                   /**< internetwork address family with IPv6: UDP, TCP, etc. */
+#define AF_INET6    AF_INET6    /**< internetwork address family with IPv6: UDP, TCP, etc.
+                                 *    (as macro) */
+    AF_NUMOF,                   /**< maximum number of address families on this system */
+#define AF_NUMOF    AF_NUMOF    /**< maximum number of address families on this system (as macro) */
+#define AF_MAX      AF_NUMOF    /**< alias for @ref AF_NUMOF */
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AF_H_ */
+/** @} */

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -15,12 +15,12 @@
  * @author  Cenk Gündoğan <cnkgndgn@gmail.com>
  */
 
+#include "net/af.h"
 #include "net/icmpv6.h"
 #include "net/ipv6/hdr.h"
 #include "net/gnrc/icmpv6.h"
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc.h"
-#include "inet_ntop.h"
 #include "net/eui64.h"
 
 #include "net/gnrc/rpl.h"

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -16,7 +16,7 @@
  */
 
 #include <stdbool.h>
-#include "inet_pton.h"
+#include "net/af.h"
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/ipv6/netif.h"
 #include "net/gnrc/rpl/dodag.h"

--- a/sys/net/include/inet_ntop.h
+++ b/sys/net/include/inet_ntop.h
@@ -18,21 +18,10 @@
 #ifndef INET_NTOP_H_
 #define INET_NTOP_H_
 #include <stdlib.h>
+#include "net/af.h"
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef AF_INET
-#define AF_INET             2           ///< internetwork address family: UDP, TCP, etc.
-#endif
-#ifndef AF_INET6
-/**
- * IPv6 address family.
- *
- * @see AF_INET
- */
-#define AF_INET6            28
 #endif
 
 #ifndef IN6ADDRSZ

--- a/sys/net/include/inet_pton.h
+++ b/sys/net/include/inet_pton.h
@@ -18,21 +18,10 @@
 #ifndef INET_PTON_H_
 #define INET_PTON_H_
 #include <stdlib.h>
+#include "net/af.h"
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef AF_INET
-#define AF_INET             2           ///< internetwork address family: UDP, TCP, etc.
-#endif
-#ifndef AF_INET6
-/**
- * IPv6 address family.
- *
- * @see AF_INET
- */
-#define AF_INET6            28
 #endif
 
 #ifndef IN6ADDRSZ

--- a/sys/net/include/socket_base/socket.h
+++ b/sys/net/include/socket_base/socket.h
@@ -24,7 +24,8 @@
 
 #include <stdint.h>
 
-#include "net/gnrc/ipv6.h"
+#include "net/af.h"
+#include "net/ipv6/addr.h"
 
 #include "socket_base/in.h"
 
@@ -41,127 +42,6 @@ typedef uint32_t  socklen_t;    ///< POSIX compatible type for address length.
 #define SOCK_RAW        3   ///< POSIX compatible raw-protocol interface type.
 #define SOCK_RDM        4   ///< POSIX compatible reliably-delivered message type.
 #define SOCK_SEQPACKET  5   ///< POSIX compatible sequenced packet stream type.
-
-#define AF_UNSPEC           0           ///< unspecified address family.
-#define AF_LOCAL            1           ///< local to host (pipes, portals) address family.
-#define AF_UNIX             AF_LOCAL    ///< alias for AF_LOCAL for backward compatibility.
-#ifndef AF_INET
-#define AF_INET             2           ///< internetwork address family: UDP, TCP, etc.
-#endif
-#define AF_IMPLINK          3           ///< ARPAnet IMP address family.
-#define AF_PUP              4           ///< PUP protocols address family: e.g. BSP
-#define AF_CHAOS            5           ///< MIT CHAOS protocols address family
-#define AF_NS               6           ///< XEROX NS protocols address family
-#define AF_ISO              7           ///< ISO protocols address family
-#define AF_OSI              AF_ISO      ///< alias for AF_ISO
-#define AF_ECMA             8           ///< European computer manufacturers address family
-#define AF_DATAKIT          9           ///< datakit protocols address family
-#define AF_CCITT            10          ///< CCITT protocols address family, X.25 etc
-#define AF_SNA              11          ///< IBM SNA address family
-#define AF_DECnet           12          ///< DECnet address family
-#define AF_DLI              13          ///< DEC Direct data link interface address family
-#define AF_LAT              14          ///< LAT address family
-#define AF_HYLINK           15          ///< NSC Hyperchannel address family
-#define AF_APPLETALK        16          ///< Apple Talk address family
-#define AF_ROUTE            17          ///< Internal Routing Protocol address family
-#define AF_LINK             18          ///< Link layer interface address family
-#define pseudo_AF_XTP       19          ///< eXpress Transfer Protocol (no AF)
-#define AF_COIP             20          ///< connection-oriented IP, aka ST II address family.
-#define AF_CNT              21          ///< Computer Network Technology address family
-#define pseudo_AF_RTIP      22          ///< Help Identify RTIP packets address family
-#define AF_IPX              23          ///< Novell Internet Protocol (no AF)
-#define AF_SIP              24          ///< Simple Internet Protocol address family
-#define pseudo_AF_PIP       25          ///< Help Identify PIP packets (no AF)
-#define AF_ISDN             26          ///< Integrated Services Digital Network address family
-#define AF_E164             AF_ISDN     ///< CCITT E.164 recommendation
-#define pseudo_AF_KEY       27          ///< Internal key-management function (no AF)
-#ifndef AF_INET6
-/**
- * IPv6 address family.
- *
- * @see AF_INET
- */
-#define AF_INET6            28
-#endif
-#define AF_NATM             29          ///< native ATM access address family
-#define AF_ATM              30          ///< ATM address family
-#define pseudo_AF_HDRCMPLT  31          ///< Used by BPF to not rewrite headers in interface output routine
-#define AF_NETGRAPH         32          ///< Netgraph sockets address family
-#define AF_MAX              33          ///< Maximum for address families
-
-/*
- * Protocol families, same as address families for now.
- */
-#define PF_UNSPEC       AF_UNSPEC       ///< protocol family
-                                        ///< @see AF_UNSPEC
-#define PF_LOCAL        AF_LOCAL        ///< protocol family
-                                        ///< @see AF_LOCAL
-#define PF_UNIX         PF_LOCAL        ///< alias for PF_LOCAL for backward compatibility
-#define PF_INET         AF_INET         ///< protocol family
-                                        ///< @see AF_INET
-#define PF_IMPLINK      AF_IMPLINK      ///< protocol family
-                                        ///< @see AF_IMPLINK
-#define PF_PUP          AF_PUP          ///< protocol family
-                                        ///< @see AF_PUP
-#define PF_CHAOS        AF_CHAOS        ///< protocol family
-                                        ///< @see AF_CHAOS
-#define PF_NS           AF_NS           ///< protocol family
-                                        ///< @see AF_NS
-#define PF_ISO          AF_ISO          ///< protocol family
-                                        ///< @see AF_ISO
-#define PF_OSI          AF_OSI          ///< protocol family
-                                        ///< @see AF_OSI
-#define PF_ECMA         AF_ECMA         ///< protocol family
-                                        ///< @see AF_ECMA
-#define PF_DATAKIT      AF_DATAKIT      ///< protocol family
-                                        ///< @see AF_DATAKIT
-#define PF_CCITT        AF_CCITT        ///< protocol family
-                                        ///< @see AF_CCITT
-#define PF_SNA          AF_SNA          ///< protocol family
-                                        ///< @see AF_SNA
-#define PF_DECnet       AF_DECnet       ///< protocol family
-                                        ///< @see AF_DECnet
-#define PF_DLI          AF_DLI          ///< protocol family
-                                        ///< @see AF_DLI
-#define PF_LAT          AF_LAT          ///< protocol family
-                                        ///< @see AF_LAT
-#define PF_HYLINK       AF_HYLINK       ///< protocol family
-                                        ///< @see AF_HYLINK
-#define PF_APPLETALK    AF_APPLETALK    ///< protocol family
-                                        ///< @see AF_APPLETALK
-#define PF_ROUTE        AF_ROUTE        ///< protocol family
-                                        ///< @see AF_ROUTE
-#define PF_LINK         AF_LINK         ///< protocol family
-                                        ///< @see AF_LINK
-#define PF_XTP          pseudo_AF_XTP   ///< protocol family (no address family defined, only PF)
-                                        ///< @see pseudo_AF_XTP
-#define PF_COIP         AF_COIP         ///< protocol family
-                                        ///< @see AF_COIP
-#define PF_CNT          AF_CNT          ///< protocol family
-                                        ///< @see AF_CNT
-#define PF_SIP          AF_SIP          ///< protocol family
-                                        ///< @see AF_SIP
-#define PF_IPX          AF_IPX          ///< protocol family (same format as AF_NS)
-                                        ///< @see AF_IPX
-                                        ///< @see AF_NS
-#define PF_RTIP         pseudo_AF_RTIP  ///< protocol family (same format as AF_INET)
-                                        ///< @see pseudo_AF_RTIP
-#define PF_PIP          pseudo_AF_PIP   ///< protocol family
-                                        ///< @see pseudo_AF_PIP
-#define PF_ISDN         AF_ISDN         ///< protocol family
-                                        ///< @see AF_ISDN
-#define PF_KEY          pseudo_AF_KEY   ///< protocol family
-                                        ///< @see pseudo_AF_KEY
-#define PF_INET6        AF_INET6        ///< protocol family
-                                        ///< @see AF_INET6
-#define PF_NATM         AF_NATM         ///< protocol family
-                                        ///< @see AF_NATM
-#define PF_ATM          AF_ATM          ///< protocol family
-                                        ///< @see AF_ATM
-#define PF_NETGRAPH     AF_NETGRAPH     ///< protocol family
-                                        ///< @see AF_NETGRAPH
-#define PF_MAX          AF_MAX          ///< maximum of protocol families
-                                        ///< @see AF_MAX
 
 #define TRANSPORT_LAYER_SOCKET_STATIC_MSS       48  ///< Static TCP maxmimum segment size.
 

--- a/sys/net/routing/nhdp/nhdp.c
+++ b/sys/net/routing/nhdp/nhdp.c
@@ -90,7 +90,7 @@ kernel_pid_t nhdp_start(void)
         ipv6_addr_set_all_nodes_addr(&sa_bcast.sin6_addr);
 
         /* Configure sending/receiving UDP socket */
-        sock_rcv = socket_base_socket(PF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+        sock_rcv = socket_base_socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
 
         /* Start the NHDP thread */
         nhdp_pid = thread_create(nhdp_stack, sizeof(nhdp_stack), THREAD_PRIORITY_MAIN - 1,

--- a/sys/posix/pnet/include/sys/socket.h
+++ b/sys/posix/pnet/include/sys/socket.h
@@ -35,6 +35,7 @@
 #include <sys/types.h>
 
 #include "cpu.h"
+#include "net/af.h"
 
 #include "socket_base/socket.h"
 

--- a/sys/shell/commands/sc_fib.c
+++ b/sys/shell/commands/sc_fib.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include "thread.h"
 #include "inet_pton.h"
+#include "net/af.h"
 #ifdef MODULE_GNRC_NETIF
 #include "net/gnrc/netif.h"
 #endif


### PR DESCRIPTION
There are a lot of redefinitions of the `AF_` macros. This PR once and for all defines them all in a central place that is not dependent from POSIX. I chose to define them in a similar fashion as they are defined in Linux: as an `enum`, that is also exposed to the preprocessor. This way the arbitrary numbering is left to the compiler, while the predecessor also can access these constants (and as a bonus can simply convert them to strings with the `#` operand).