### PR TITLE
gnrc_sixlowpan: compare with actual packet size for fragmentation

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -257,7 +257,7 @@ static void _send(gnrc_pktsnip_t *pkt)
 
     /* IP should not send anything here if it is not a 6LoWPAN interface,
      * so we don't need to check for NULL pointers */
-    if (datagram_size <= iface->max_frag_size) {
+    if (gnrc_pkt_len(pkt2->next) <= iface->max_frag_size) {
         DEBUG("6lo: Send SND command for %p to %" PRIu16 "\n",
               (void *)pkt2, hdr->if_pid);
         gnrc_netapi_send(hdr->if_pid, pkt2);


### PR DESCRIPTION
Not with the uncompressed version.

@PeterKietzmann noted, that small packets with IPHC suddenly slow down transmission way before the maximum fragment size. Unsurprisingly, the 6LoWPAN implementation compares the uncompressed datagram size with the maximum fragment size instead of the actual packet size after compression. This resulted in highly compressed datagrams being fragmented though it wasn't necessary yet.