### PR TITLE
gnrc_ipv6.c: remove padding added by lower layers

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -656,6 +656,12 @@ static void _receive(gnrc_pktsnip_t *pkt)
     /* extract header */
     hdr = (ipv6_hdr_t *)ipv6->data;
 
+    /* if available, remove any padding that was added by lower layers
+     * to fulfill their minimum size requirements (e.g. ethernet) */
+    if (byteorder_ntohs(hdr->len) < pkt->size) {
+        gnrc_pktbuf_realloc_data(pkt, byteorder_ntohs(hdr->len));
+    }
+
     DEBUG("ipv6: Received (src = %s, ",
           ipv6_addr_to_str(addr_str, &(hdr->src), sizeof(addr_str)));
     DEBUG("dst = %s, next header = %" PRIu8 ", length = %" PRIu16 ")\n",


### PR DESCRIPTION
see #3668 

My case: `pkt->size` was `10`, although the `ipv6` payload length `hdr->len` indicated `8`.

Two bytes were added by the link layer (`gnrc_netdev_eth`) to fulfill the required ethernet minimum frame size (`64`). However, the checksum calculation uses the `pktsnip`'s size, which still includes this padding on the receiving side.

This PR checks if the payload length is smaller than the `pktsnip`'s length and reallocates  `pkt` (makes it smaller) if needed.