### PR TITLE
gnrc_sixlowpan: don't send packets that exceed maximum datagram size

### DIFF
--- a/sys/include/net/sixlowpan.h
+++ b/sys/include/net/sixlowpan.h
@@ -39,6 +39,8 @@ extern "C" {
 #define SIXLOWPAN_FRAG_1_DISP       (0xc0)      /**< dispatch for 1st fragment */
 #define SIXLOWPAN_FRAG_N_DISP       (0xe0)      /**< dispatch for subsequent
                                                  *   fragments */
+#define SIXLOWPAN_FRAG_MAX_LEN      (2047)      /**< Maximum datagram size @f$ (2^{11} - 1) @f$ */
+
 /**
  * @brief   Dispatch mask for LOWPAN_IPHC.
  * @see     <a href="https://tools.ietf.org/html/rfc6282#section-3.1">

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -265,15 +265,20 @@ static void _send(gnrc_pktsnip_t *pkt)
         return;
     }
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG
-    else {
+    else if (datagram_size <= SIXLOWPAN_FRAG_MAX_LEN) {
         DEBUG("6lo: Send fragmented (%u > %" PRIu16 ")\n",
               (unsigned int)datagram_size, iface->max_frag_size);
         gnrc_sixlowpan_frag_send(hdr->if_pid, pkt2, datagram_size);
     }
+    else {
+        DEBUG("6lo: packet too big (%u > %" PRIu16 ")\n",
+              (unsigned int)datagram_size, SIXLOWPAN_FRAG_MAX_LEN);
+        gnrc_pktbuf_release(pkt2);
+    }
 #else
-    (void)datagram_size;
-    DEBUG("6lo: packet too big (%u> %" PRIu16 ")\n",
+    DEBUG("6lo: packet too big (%u > %" PRIu16 ")\n",
           (unsigned int)datagram_size, iface->max_frag_size);
+    gnrc_pktbuf_release(pkt2);
 #endif
 }
 


### PR DESCRIPTION
The datagram size field 6LoWPAN fragmentation only can handle values up to 2047. This PR ensures that a sender does not exceed this maximum packet length.

Fixes #3672.