### PR TITLE
gnrc_ipv6: check link MTU before sending

### DIFF
--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -28,6 +28,7 @@
 #include "kernel_macros.h"
 #include "kernel_types.h"
 #include "mutex.h"
+#include "net/ipv6.h"
 #include "net/ipv6/addr.h"
 #include "vtimer.h"
 
@@ -51,11 +52,19 @@ extern "C" {
 /**
  * @brief   Default MTU
  *
- * @see <a href="https://tools.ietf.org/html/rfc2460#section-5">
- *          RFC 2460, section 5
- *      </a>
+ * An interface will choose this MTU if the link-layer's maximum packet size
+ * (see @ref NETOPT_MAX_PACKET_SIZE) is lesser than the @ref IPV6_MIN_MTU or if it just not
+ * provide it. For RFC-compatible communication it must be at least @ref IPV6_MIN_MTU.
+ *
+ * @note    If the scenario the node is used in allows for it and the packet size is predictable,
+ *          a user might choose to set @ref GNRC_IPV6_NETIF_DEFAULT_MTU to a lesser value than
+ *          @ref IPV6_MIN_MTU to optimize for code size (e.g. because it is then possible to omit
+ *          @ref net_gnrc_sixlowpan_frag) and memory usage (e.g. because @ref GNRC_PKTBUF_SIZE
+ *          can be much smaller).
  */
-#define GNRC_IPV6_NETIF_DEFAULT_MTU (1280)
+#ifndef GNRC_IPV6_NETIF_DEFAULT_MTU
+#define GNRC_IPV6_NETIF_DEFAULT_MTU (IPV6_MIN_MTU)
+#endif
 
 /**
  * @brief   Default hop limit

--- a/sys/include/net/ipv6.h
+++ b/sys/include/net/ipv6.h
@@ -32,6 +32,15 @@
 extern "C" {
 #endif
 
+/**
+ * @brief   minimum **M**aximum **T**ransition **U**nit
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc4944#section-5.3">
+ *          RFC 2460, section 5.3
+ *      </a>
+ */
+#define IPV6_MIN_MTU    (1280)
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/link_layer/netdev_eth/gnrc_netdev_eth.c
+++ b/sys/net/gnrc/link_layer/netdev_eth/gnrc_netdev_eth.c
@@ -223,7 +223,7 @@ static inline int _get_max_pkt_sz(uint16_t *value, size_t max_len)
         return -EOVERFLOW;
     }
 
-    *value = ETHERNET_MAX_LEN;
+    *value = ETHERNET_DATA_LEN;
 
     return sizeof(uint16_t);
 }

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -11,6 +11,7 @@
  *
  * @file
  */
+#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>
@@ -192,31 +193,29 @@ static void *_event_loop(void *args)
     return NULL;
 }
 
-#ifdef MODULE_GNRC_SIXLOWPAN
 static void _send_to_iface(kernel_pid_t iface, gnrc_pktsnip_t *pkt)
 {
+    ((gnrc_netif_hdr_t *)pkt->data)->if_pid = iface;
     gnrc_ipv6_netif_t *if_entry = gnrc_ipv6_netif_get(iface);
 
-    ((gnrc_netif_hdr_t *)pkt->data)->if_pid = iface;
-
+    assert(if_entry != NULL);
+    if (gnrc_pkt_len(pkt->next) > if_entry->mtu) {
+        DEBUG("ipv6: packet too big\n");
+        gnrc_pktbuf_release(pkt);
+        return;
+    }
+#ifdef MODULE_GNRC_SIXLOWPAN
     if ((if_entry != NULL) && (if_entry->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN)) {
         DEBUG("ipv6: send to 6LoWPAN instead\n");
         if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_SIXLOWPAN, GNRC_NETREG_DEMUX_CTX_ALL, pkt)) {
             DEBUG("ipv6: no 6LoWPAN thread found");
             gnrc_pktbuf_release(pkt);
         }
+        return;
     }
-    else {
-        gnrc_netapi_send(iface, pkt);
-    }
-}
-#else
-static inline void _send_to_iface(kernel_pid_t iface, gnrc_pktsnip_t *pkt)
-{
-    ((gnrc_netif_hdr_t *)pkt->data)->if_pid = iface;
+#endif
     gnrc_netapi_send(iface, pkt);
 }
-#endif
 
 /* functions for sending */
 static void _send_unicast(kernel_pid_t iface, uint8_t *dst_l2addr,


### PR DESCRIPTION
Companion PR to #3663. Now a device (and 6LoWPAN) don't even get packets that don't they can't transmit.