### PR TITLE
doc: fix and update net and net_gnrc documentation

### DIFF
--- a/sys/include/net/ethernet.h
+++ b/sys/include/net/ethernet.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    net_ethernet Ethernet
  * @ingroup     net
- * @brief       Ethernet implementation
+ * @brief       Provides Ethernet header and helper functions
  * @{
  *
  * @file

--- a/sys/include/net/gnrc.h
+++ b/sys/include/net/gnrc.h
@@ -13,7 +13,7 @@
  * @{
  *
  * @file
- * @brief       Pseudo header that includes all gnrc network stack base modules
+ * @brief       Includes all essential GNRC network stack base modules
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */

--- a/sys/include/net/gnrc/icmpv6.h
+++ b/sys/include/net/gnrc/icmpv6.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    net_gnrc__icmpv6  Internet Control Message Protocol for IPv6
- * @ingroup     net_gnrc__ipv6
- * @brief       Basic implementation of ICMPv6
+ * @defgroup    net_gnrc_icmpv6  ICMPv6
+ * @ingroup     net_gnrc_ipv6
+ * @brief       GNRC's implementation of ICMPv6
  *
  * @see <a href="https://tools.ietf.org/html/rfc4443">
  *          RFC 4443
@@ -17,7 +17,7 @@
  * @{
  *
  * @file
- * @brief       Definitions for ICMPv6
+ * @brief       Definitions for GNRC's ICMPv6 implementation
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  *

--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -8,8 +8,8 @@
 
 /**
  * @defgroup    net_gnrc_ipv6 IPv6
- * @ingroup     net
- * @brief       New IPv6 implementation
+ * @ingroup     net_gnrc
+ * @brief       GNRC's IPv6 implementation
  *
  * The IPv6 control thread understands messages of type
  *
@@ -19,7 +19,7 @@
  * @{
  *
  * @file
- * @brief       Definitions for IPv6
+ * @brief       Definitions for GNRC's IPv6 implementation
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */

--- a/sys/include/net/gnrc/ndp.h
+++ b/sys/include/net/gnrc/ndp.h
@@ -9,11 +9,11 @@
 /**
  * @defgroup    net_gnrc_ndp  IPv6 Neighbor discovery
  * @ingroup     net_gnrc_icmpv6
- * @brief       IPv6 Neighbor Discovery Implementation
+ * @brief       GNRC's IPv6 Neighbor Discovery implementation
  * @{
  *
  * @file
- * @brief       Neighbor Discovery definitions
+ * @brief       Definitions for GNRC's IPv6 Neighbor Discovery
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */

--- a/sys/include/net/gnrc/netapi.h
+++ b/sys/include/net/gnrc/netapi.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    net_gnrc_netapi   Generic network module interface
- * @ingroup     net
- * @brief       Generic interface for IPC communication between network modules
+ * @defgroup    net_gnrc_netapi   GNRC communication interface
+ * @ingroup     net_gnrc
+ * @brief       Generic interface for IPC communication between GNRC modules
  *
  * @details     The idea of this interface is that it provides every network
  *              module with a basic set of commands to communicate with its
@@ -19,7 +19,7 @@
  * @{
  *
  * @file
- * @brief       Generic interface to communicate with network modules
+ * @brief       Generic interface to communicate with GNRC modules
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/sys/include/net/gnrc/netdev.h
+++ b/sys/include/net/gnrc/netdev.h
@@ -9,7 +9,8 @@
 
 /**
  * @defgroup    net_gnrc_netdev   Network device driver interface
- * @ingroup     net
+ * @ingroup     net_gnrc
+ * @brief       Common network device interface
  * @{
  *
  * @file

--- a/sys/include/net/gnrc/netdev_eth.h
+++ b/sys/include/net/gnrc/netdev_eth.h
@@ -9,11 +9,10 @@
  */
 
 /**
- * @defgroup gnrc_netdev_eth dev_eth ethernet interface as netdev device.
- * @ingroup net
+ * @defgroup    net_gnrc_netdev_eth dev_eth as netdev device.
+ * @ingroup     net_gnrc_netdev
  *
- * @brief Allows for usage of dev_eth ethernet interfaces as ethernet netdev
- * devices.
+ * @brief Allows for usage of @p dev_eth as ethernet netdev devices.
  *
  * @{
  *

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -8,16 +8,16 @@
 
 /**
  * @defgroup    net_gnrc_netif    Network interfaces
- * @ingroup     net
- * @brief       Abstraction layer for network interfaces
+ * @ingroup     net_gnrc
+ * @brief       Abstraction layer for GNRC's network interfaces
  *
- * Network interfaces in this context are threads for protocols that are
+ * Network interfaces in the context of GNRC are threads for protocols that are
  * below the network layer.
  *
  * @{
  *
  * @file
- * @brief   Definitions for network interfaces
+ * @brief   Definitions for GNRC's network interfaces
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */

--- a/sys/include/net/gnrc/netreg.h
+++ b/sys/include/net/gnrc/netreg.h
@@ -8,7 +8,8 @@
 
 /**
  * @defgroup    net_gnrc_netreg  Network protocol registry
- * @ingroup     net
+ * @ingroup     net_gnrc
+ * @brief       Registry to receive messages of a specified protocol type by GNRC.
  * @{
  *
  * @file

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    net_gnrc_nettype  Protocol type
- * @ingroup     net
+ * @ingroup     net_gnrc
  * @brief       Protocol type definitions to be used with the @ref net_gnrc_netapi,
  *              the @ref net_gnrc_netdev, the @ref net_gnrc_netreg, and
  *              the @ref net_gnrc_pkt

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -9,9 +9,12 @@
 /**
  * @defgroup    net_gnrc_nettype  Protocol type
  * @ingroup     net_gnrc
- * @brief       Protocol type definitions to be used with the @ref net_gnrc_netapi,
- *              the @ref net_gnrc_netdev, the @ref net_gnrc_netreg, and
- *              the @ref net_gnrc_pkt
+ * @brief       Protocol type definitions and helper functions
+ *
+ * The protocol types are used with the @ref net_gnrc_netapi, the @ref net_gnrc_netdev,
+ * the @ref net_gnrc_netreg, and the @ref net_gnrc_pkt to identify network protocols
+ * throughout the network stack.
+ *
  * @{
  *
  * @file

--- a/sys/include/net/gnrc/nomac.h
+++ b/sys/include/net/gnrc/nomac.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    net_nomac Simplest possible MAC layer
- * @ingroup     net
+ * @defgroup    net_gnrc_nomac  Simplest possible MAC layer
+ * @ingroup     net_gnrc
  * @brief       Simplest possible MAC protocol that sends without considering
  *              the state of the medium
  * @{

--- a/sys/include/net/gnrc/pkt.h
+++ b/sys/include/net/gnrc/pkt.h
@@ -8,13 +8,13 @@
  */
 
 /**
- * @defgroup    net_gnrc_pkt Packet
- * @brief       Network packet abstraction types
- * @ingroup     net
+ * @defgroup    net_gnrc_pkt Packets
+ * @ingroup     net_gnrc_pktbuf
+ * @brief       Network packet abstraction type and helper functions
  * @{
  *
  * @file
- * @brief   General definitions for network packets
+ * @brief   General definitions for network packets and their helper functions
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -9,7 +9,7 @@
 
 /**
  * @defgroup    net_gnrc_pktbuf   Packet buffer
- * @ingroup     net
+ * @ingroup     net_gnrc
  * @brief       A global network packet buffer.
  *
  * @note    **WARNING!!** Do not store data structures that are not packed

--- a/sys/include/net/gnrc/pktdump.h
+++ b/sys/include/net/gnrc/pktdump.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    net_pktdump Dump Network Packets
- * @ingroup     net
+ * @defgroup    net_gnrc_pktdump Dump Network Packets
+ * @ingroup     net_gnrc
  * @brief       Dump network packets to STDOUT for debugging
  *
  * @{

--- a/sys/include/net/gnrc/pktqueue.h
+++ b/sys/include/net/gnrc/pktqueue.h
@@ -8,8 +8,8 @@
 
 /**
  * @defgroup    net_gnrc_pktqueue Packet Queue
+ * @ingroup     net_gnrc
  * @brief       Packet wrapper for the Priority Queue
- * @ingroup     net
  * @{
  *
  * @file

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -9,8 +9,9 @@
  */
 
 /**
- * @defgroup    net_gnrc_rpl  New RPL
- * @ingroup     net
+ * @defgroup    net_gnrc_rpl  RPL
+ * @ingroup     net_gnrc
+ * @brief       RPL implementation for GNRC
  * @{
  *
  * @file

--- a/sys/include/net/gnrc/sixlowpan.h
+++ b/sys/include/net/gnrc/sixlowpan.h
@@ -8,8 +8,8 @@
 
 /**
  * @defgroup    net_gnrc_sixlowpan    6LoWPAN
- * @ingroup     net
- * @brief       6LoWPAN implementation
+ * @ingroup     net_gnrc
+ * @brief       GNRC's 6LoWPAN implementation
  * @{
  *
  * @file

--- a/sys/include/net/gnrc/sixlowpan/ctx.h
+++ b/sys/include/net/gnrc/sixlowpan/ctx.h
@@ -7,9 +7,6 @@
  */
 
 /**
- * @defgroup    net_gnrc_sixlowpan    6LoWPAN
- * @ingroup     net
- *
  * @defgroup    net_gnrc_sixlowpan_ctx    Contexts for 6LoWPAN address compression
  * @ingroup     net_gnrc_sixlowpan
  * @brief       Context buffer for stateful 6LoWPAN address compression

--- a/sys/include/net/gnrc/slip.h
+++ b/sys/include/net/gnrc/slip.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    net_gnrc_slip SLIP
- * @ingroup     net
+ * @ingroup     net_gnrc
  * @brief       Provides a SLIP interface over UART utilizing
  *              @ref driver_periph_uart.
  * @see         <a href="https://www.ietf.org/rfc/rfc1055">RFC 1055</a>

--- a/sys/include/net/gnrc/udp.h
+++ b/sys/include/net/gnrc/udp.h
@@ -7,14 +7,14 @@
  */
 
 /**
- * @defgroup    sys_net_udp UDP
- * @ingroup     net
- * @brief       RIOT's implementation of the UDP protocol
+ * @defgroup    net_gnrc_udp UDP
+ * @ingroup     net_gnrc
+ * @brief       GNRC's implementation of the UDP protocol
  *
  * @{
  *
  * @file
- * @brief       UDP interface definition
+ * @brief       UDP GNRC definition
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */

--- a/sys/include/net/gnrc/zep.h
+++ b/sys/include/net/gnrc/zep.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    net_gnrc_zep  Zigbee Encapsulation Protocol
- * @ingroup     net
+ * @ingroup     net_gnrc
  * @brief       Transports IEEE 802.15.4 frames over UDP (can be parsed by
  *              Wireshark)
  * @note        Stability uncertain

--- a/sys/include/net/ndp.h
+++ b/sys/include/net/ndp.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    net_ndp IPv6 neighbor discovery messages
+ * @defgroup    net_ndp IPv6 neighbor discovery
  * @ingroup     net_ipv6
  * @brief       Provides IPv6 neighbor discovery message types
  * @{

--- a/sys/include/net/sixlowpan.h
+++ b/sys/include/net/sixlowpan.h
@@ -9,11 +9,11 @@
 /**
  * @defgroup    net_sixlowpan   6LoWPAN
  * @ingroup     net
- * @brief       Generic 6LoWPAN types and helper functions
+ * @brief       Provides 6LoWPAN dispatch types and helper functions
  * @{
  *
  * @file
- * @brief   6LoWPAN type and helper function definitons.
+ * @brief   6LoWPAN dispatch type and helper function definitons.
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */

--- a/sys/include/net/udp.h
+++ b/sys/include/net/udp.h
@@ -9,14 +9,14 @@
 /**
  * @defgroup    net_udp UDP
  * @ingroup     net
- * @brief       UDP header definition
+ * @brief       Provides UDP header and helper functions
  * @see         <a href="https://tools.ietf.org/html/rfc768">
  *                  RFC 768
  *              </a>
  * @{
  *
  * @file
- * @brief   UDP header definition
+ * @brief   UDP header and helper functions definition
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */


### PR DESCRIPTION
The restructuring of GNRC destroyed the documentation a bit. This should get everything in order again.