### PR TITLE
rpl: minor cleanup

### DIFF
--- a/sys/include/net/gnrc/rpl/dodag.h
+++ b/sys/include/net/gnrc/rpl/dodag.h
@@ -193,16 +193,6 @@ gnrc_rpl_parent_t *gnrc_rpl_parent_get(gnrc_rpl_dodag_t *dodag, ipv6_addr_t *add
 void gnrc_rpl_parent_update(gnrc_rpl_dodag_t *dodag, gnrc_rpl_parent_t *parent);
 
 /**
- * @brief   Find the parent with the lowest rank and update the DODAG's preferred parent
- *
- * @param[in] dodag     Pointer to the DODAG
- *
- * @return  Pointer to the preferred parent, on success.
- * @return  NULL, otherwise.
- */
-gnrc_rpl_parent_t *gnrc_rpl_find_preferred_parent(gnrc_rpl_dodag_t *dodag);
-
-/**
  * @brief   Start a local repair.
  *
  * @param[in] dodag     Pointer to the DODAG

--- a/sys/net/gnrc/routing/rpl/of0.c
+++ b/sys/net/gnrc/routing/rpl/of0.c
@@ -86,7 +86,7 @@ gnrc_rpl_parent_t *which_parent(gnrc_rpl_parent_t *p1, gnrc_rpl_parent_t *p2)
     return p2;
 }
 
-/* Not used yet, as the implementation only makes use of one dodag for now. */
+/* Not used yet */
 gnrc_rpl_dodag_t *which_dodag(gnrc_rpl_dodag_t *d1, gnrc_rpl_dodag_t *d2)
 {
     (void) d2;


### PR DESCRIPTION
Commits:
1. reducing the scope of some functions that are only used inside of `gnrc_rpl_dodag.c`
2. there is a misleading comment that states that currently only one dodag is supported => wrong
3. a call to `gnrc_rpl_parent_remove` is unnecessary in this context, because all parents will be removed anyways after returning this function