### PR TITLE
boards: samr21-xpro: remove obsolete auto_init_ng_netif/Makefile

### DIFF
--- a/boards/samr21-xpro/auto_init_ng_netif/Makefile
+++ b/boards/samr21-xpro/auto_init_ng_netif/Makefile
@@ -1,1 +1,0 @@
-include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
Per-board netif initialization is not used anymore.