### PR TITLE
Makefile.buildtests: Fix output of info-objsize

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -105,7 +105,7 @@ info-objsize:
 	  "") SORTROW=4 ;; \
 	  *) echo "Usage: $(MAKE) info-objsize SORTROW=[text|data|bss|dec]" ; return ;; \
 	esac; \
-	echo '   text\t   data\t    bss\t    dec\t    hex\tfilename'; \
+	echo -e '   text\t   data\t    bss\t    dec\t    hex\tfilename'; \
 	$(SIZE) -dB $(BASELIBS) | \
 	  tail -n+2 | \
 	  sed -e 's#$(BINDIR)##' | \


### PR DESCRIPTION
Without the `-e` flag to echo, the tabs will be printed as `\t` instead of proper tabs.