### PR TITLE
rpl: reduce poisoning timer to clean dodags faster

### DIFF
--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -241,7 +241,7 @@ static inline bool GNRC_RPL_COUNTER_GREATER_THAN(uint8_t A, uint8_t B)
 /**
  * @brief Cleanup timeout in seconds
  */
-#define GNRC_RPL_CLEANUP_TIME (30)
+#define GNRC_RPL_CLEANUP_TIME (5)
 
 /**
  * @name Node Status

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -189,7 +189,8 @@ static void *_event_loop(void *args)
             case GNRC_RPL_MSG_TYPE_CLEANUP_HANDLE:
                 DEBUG("RPL: GNRC_RPL_MSG_TYPE_CLEANUP received\n");
                 dodag = (gnrc_rpl_dodag_t *) msg.content.ptr;
-                if (dodag && (dodag->state != 0) && (dodag->parents == NULL)) {
+                if (dodag && (dodag->state != 0) && (dodag->parents == NULL)
+                    && (dodag->my_rank == GNRC_RPL_INFINITE_RANK)) {
                     /* no parents - delete this DODAG */
                     gnrc_rpl_dodag_remove(dodag);
                 }


### PR DESCRIPTION
The change to `GNRC_RPL_CLEANUP_TIME` reduces the time in seconds when a dodag should get deleted, and thus the memory freed for other potential dodags.

I think 5 seconds of poisoning (sending out DIOs with INFINITE_RANK) is enough. If no parent answeres to such poisoning within this 5 seconds, then this dodag will be deleted.

The second change is just extending the condition when a dodag should get deleted.
Actually, it is not becoming stricter, as the rank should be `INFINITE_RANK` anyway, if no parent is available. However, to be on the safe side, I added the check to compare the rank to `INFINITE_RANK`.