### PR TITLE
rpl: leaf/router node operation

### DIFF
--- a/sys/include/net/gnrc/rpl/dodag.h
+++ b/sys/include/net/gnrc/rpl/dodag.h
@@ -198,6 +198,20 @@ void gnrc_rpl_parent_update(gnrc_rpl_dodag_t *dodag, gnrc_rpl_parent_t *parent);
  * @param[in] dodag     Pointer to the DODAG
  */
 void gnrc_rpl_local_repair(gnrc_rpl_dodag_t *dodag);
+
+/**
+ * @brief   Operate as leaf.
+ *
+ * @param[in] dodag     Pointer to the DODAG
+ */
+void gnrc_rpl_leaf_operation(gnrc_rpl_dodag_t *dodag);
+
+/**
+ * @brief   Operate as router.
+ *
+ * @param[in] dodag     Pointer to the DODAG
+ */
+void gnrc_rpl_router_operation(gnrc_rpl_dodag_t *dodag);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR introduces the operation as a leaf node.

First commit:
A leaf node does not send out DIO messages periodically, but can send a DIO when requested through a unicast DIS. Furthermore, if it sends out a DIO, an INFINTE_RANK must be used. DAOs and multicast DIS should not be parsed by leaf nodes.

Second commit:
Addition of 2 new shell commands:
`rpl leaf <instance_id> <dodag_id>`
`rpl router <instance_id> <dodag_id>`

When setting a node as a leaf, 1 DIO with an INFINITE_RANK will be emitted, so that children can get a chance to choose a new parent without awaiting a parent timeout.
When setting a node as a router, the trickle timer is reset, so that the node announces its presence in the neighborhood.