### PR TITLE
core: assertion not to add twice to priority_queue

### DIFF
--- a/core/include/priority_queue.h
+++ b/core/include/priority_queue.h
@@ -98,6 +98,8 @@ priority_queue_node_t *priority_queue_remove_head(priority_queue_t *root);
  *
  * @param[in,out]   root    the queue's root
  * @param[in]       new_obj the object to prepend
+ *
+ * @pre The queue does not already contain @p new_obj.
  */
 void priority_queue_add(priority_queue_t *root, priority_queue_node_t *new_obj);
 

--- a/core/priority_queue.c
+++ b/core/priority_queue.c
@@ -18,6 +18,7 @@
  */
 
 #include <inttypes.h>
+#include <assert.h>
 
 #include "priority_queue.h"
 
@@ -55,6 +56,8 @@ void priority_queue_add(priority_queue_t *root, priority_queue_node_t *new_obj)
     priority_queue_node_t *node = (priority_queue_node_t *) root;
 
     while (node->next != NULL) {
+        /* not trying to add the same node twice */
+        assert(node->next != new_obj);
         if (node->next->priority > new_obj->priority) {
             new_obj->next = node->next;
             node->next = new_obj;


### PR DESCRIPTION
Alternative to #3132. Following @kaspar030's proposal.

*Edit:* This PR adds an assertion to make sure that a node is not added twice to the priority queue, causing the node to stuck in an infinite loop, and adds this as precondition to the documentation.