### PR TITLE
shell: uart0 newlib distinction (workaround)

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -185,6 +185,15 @@ ifneq (,$(filter gnrc_pktbuf_%, $(USEMODULE)))
   USEMODULE += gnrc_pktbuf # make MODULE_GNRC_PKTBUF macro available for all implementations
 endif
 
+ifneq (,$(filter newlib,$(USEMODULE)))
+  USEMODULE += uart_stdio
+else
+  ifneq (,$(filter shell,$(USEMODULE)))
+    USEMODULE += uart0
+  endif
+endif
+
+
 ifneq (,$(filter uart0,$(USEMODULE)))
   USEMODULE += posix
 endif
@@ -237,10 +246,6 @@ ifneq (,$(filter cpp11-compat,$(USEMODULE)))
   USEMODULE += vtimer
   USEMODULE += timex
   FEATURES_REQUIRED += cpp
-endif
-
-ifneq (,$(filter newlib,$(USEMODULE)))
-  USEMODULE += uart_stdio
 endif
 
 ifneq (,$(filter gnrc_netdev_eth,$(USEMODULE)))

--- a/examples/default/main.c
+++ b/examples/default/main.c
@@ -26,10 +26,14 @@
 #include <string.h>
 
 #include "thread.h"
-#include "posix_io.h"
+#ifdef MODULE_NEWLIB
+#   include "uart_stdio.h"
+#else
+#   include "posix_io.h"
+#   include "board_uart0.h"
+#endif
 #include "shell.h"
 #include "shell_commands.h"
-#include "board_uart0.h"
 
 #if FEATURE_PERIPH_RTC
 #include "periph/rtc.h"
@@ -42,7 +46,6 @@
 int main(void)
 {
     shell_t shell;
-    (void) posix_open(uart0_handler_pid, 0);
 
 #ifdef MODULE_LTC4150
     ltc4150_start();
@@ -54,7 +57,12 @@ int main(void)
 
     (void) puts("Welcome to RIOT!");
 
+#ifndef MODULE_NEWLIB
+    (void) posix_open(uart0_handler_pid, 0);
     shell_init(&shell, NULL, UART0_BUFSIZE, uart0_readc, uart0_putc);
+#else
+    shell_init(&shell, NULL, UART0_BUFSIZE, getchar, putchar);
+#endif
 
     shell_run(&shell);
     return 0;

--- a/examples/gnrc_networking/main.c
+++ b/examples/gnrc_networking/main.c
@@ -20,9 +20,14 @@
 
 #include <stdio.h>
 
+#include "kernel.h"
 #include "shell.h"
-#include "board_uart0.h"
-#include "posix_io.h"
+#ifdef MODULE_NEWLIB
+#   include "uart_stdio.h"
+#else
+#   include "posix_io.h"
+#   include "board_uart0.h"
+#endif
 
 extern int udp_cmd(int argc, char **argv);
 
@@ -39,8 +44,12 @@ int main(void)
 
     /* start shell */
     puts("All up, running the shell now");
-    posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, shell_commands, UART0_BUFSIZE, uart0_readc, uart0_putc);
+#ifndef MODULE_NEWLIB
+    (void) posix_open(uart0_handler_pid, 0);
+    shell_init(&shell, NULL, UART0_BUFSIZE, uart0_readc, uart0_putc);
+#else
+    shell_init(&shell, NULL, UART0_BUFSIZE, getchar, putchar);
+#endif
     shell_run(&shell);
 
     /* should be never reached */

--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -22,8 +22,12 @@
 
 #include "shell.h"
 #include "shell_commands.h"
-#include "posix_io.h"
-#include "board_uart0.h"
+#ifdef MODULE_NEWLIB
+#   include "uart_stdio.h"
+#else
+#   include "posix_io.h"
+#   include "board_uart0.h"
+#endif
 #include "net/gnrc/pktdump.h"
 #include "net/gnrc.h"
 
@@ -50,8 +54,12 @@ int main(void)
 
     /* start the shell */
     puts("Initialization successful - starting the shell now");
+#ifndef MODULE_NEWLIB
     (void) posix_open(uart0_handler_pid, 0);
     shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
+#else
+    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
+#endif
     shell_run(&shell);
 
     return 0;

--- a/tests/driver_kw2xrf/main.c
+++ b/tests/driver_kw2xrf/main.c
@@ -21,8 +21,12 @@
 
 #include "shell.h"
 #include "shell_commands.h"
-#include "posix_io.h"
-#include "board_uart0.h"
+#ifdef MODULE_NEWLIB
+#   include "uart_stdio.h"
+#else
+#   include "posix_io.h"
+#   include "board_uart0.h"
+#endif
 #include "net/gnrc.h"
 #include "net/gnrc/pktdump.h"
 
@@ -46,9 +50,13 @@ int main(void)
 
     /* start the shell */
     puts("Initialization successful - starting the shell now");
+#ifndef MODULE_NEWLIB
     (void) posix_open(uart0_handler_pid, 0);
     shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
-    shell_run(&shell);
+#else
+    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
+#endif
+        shell_run(&shell);
 
     return 0;
 }

--- a/tests/driver_nrfmin/main.c
+++ b/tests/driver_nrfmin/main.c
@@ -21,8 +21,12 @@
 #include <stdio.h>
 
 #include "shell.h"
-#include "posix_io.h"
-#include "board_uart0.h"
+#ifdef MODULE_NEWLIB
+#   include "uart_stdio.h"
+#else
+#   include "posix_io.h"
+#   include "board_uart0.h"
+#endif
 #include "nrfmin.h"
 #include "net/gnrc.h"
 #include "net/gnrc/nomac.h"
@@ -51,9 +55,13 @@ int main(void)
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &netobj);
 
     /* initialize and run the shell */
+#ifndef MODULE_NEWLIB
     board_uart0_init();
-    posix_open(uart0_handler_pid, 0);
+    (void) posix_open(uart0_handler_pid, 0);
     shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
+#else
+    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
+#endif
     shell_run(&shell);
 
     return 0;

--- a/tests/driver_pcd8544/main.c
+++ b/tests/driver_pcd8544/main.c
@@ -35,8 +35,12 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include "posix_io.h"
-#include "board_uart0.h"
+#ifdef MODULE_NEWLIB
+#   include "uart_stdio.h"
+#else
+#   include "posix_io.h"
+#   include "board_uart0.h"
+#endif
 #include "shell.h"
 #include "pcd8544.h"
 
@@ -170,8 +174,12 @@ int main(void)
 
     /* run shell */
     puts("All OK, running shell now");
+#ifndef MODULE_NEWLIB
     (void) posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, shell_commands, SHELL_BUFSIZE, uart0_readc, uart0_putc);
+    shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
+#else
+    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
+#endif
     shell_run(&shell);
 
     return 0;

--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -22,8 +22,12 @@
 #include <stdlib.h>
 
 #include "shell.h"
-#include "posix_io.h"
-#include "board_uart0.h"
+#ifdef MODULE_NEWLIB
+#   include "uart_stdio.h"
+#else
+#   include "posix_io.h"
+#   include "board_uart0.h"
+#endif
 #include "periph/gpio.h"
 #include "hwtimer.h"
 
@@ -247,8 +251,12 @@ int main(void)
          "      behavior for not existing ports/pins is not defined!");
 
     /* start the shell */
+#ifndef MODULE_NEWLIB
     (void) posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, shell_commands, SHELL_BUFSIZE, uart0_readc, uart0_putc);
+    shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
+#else
+    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
+#endif
     shell_run(&shell);
 
     return 0;


### PR DESCRIPTION
Replaces #3555 to fix #3550 for now.

I agree that #3164 and #3402 are the much cleaner solution, but since it will still take a while to get them merged and working with Cortex platforms is currently annoying, I would vote for merging this ASAP. The changes can be easily reverted once #3402 is ready.