### PR TITLE
rename NG_ to GNRC_

### DIFF
--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -319,10 +319,10 @@ static inline bool GNRC_RPL_COUNTER_GREATER_THAN(uint8_t A, uint8_t B)
  *      </a>
  *  @{
  */
-#define NG_RPL_INSTANCE_ID_MSB      (1 << 7)
-#define NG_RPL_GLOBAL_INSTANCE_MASK (0x7F)
-#define NG_RPL_LOCAL_INSTANCE_MASK  (0x3F)
-#define NG_RPL_INSTANCE_D_FLAG_MASK (1 << 6)
+#define GNRC_RPL_INSTANCE_ID_MSB      (1 << 7)
+#define GNRC_RPL_GLOBAL_INSTANCE_MASK (0x7F)
+#define GNRC_RPL_LOCAL_INSTANCE_MASK  (0x3F)
+#define GNRC_RPL_INSTANCE_D_FLAG_MASK (1 << 6)
 /** @} */
 
 /**

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -535,7 +535,7 @@ void gnrc_rpl_send_DAO(gnrc_rpl_dodag_t *dodag, ipv6_addr_t *destination, uint8_
     int size = sizeof(icmpv6_hdr_t) + sizeof(gnrc_rpl_dao_t) +
         (sizeof(gnrc_rpl_opt_target_t) * (dst_size + 1)) + sizeof(gnrc_rpl_opt_transit_t);
 
-    bool local_instance = (dodag->instance->id & NG_RPL_INSTANCE_ID_MSB) ? true : false;
+    bool local_instance = (dodag->instance->id & GNRC_RPL_INSTANCE_ID_MSB) ? true : false;
 
     if (local_instance) {
         size += sizeof(ipv6_addr_t);
@@ -600,7 +600,7 @@ void gnrc_rpl_send_DAO_ACK(gnrc_rpl_dodag_t *dodag, ipv6_addr_t *destination, ui
     icmpv6_hdr_t *icmp;
     gnrc_rpl_dao_ack_t *dao_ack;
     int size = sizeof(icmpv6_hdr_t) + sizeof(gnrc_rpl_dao_ack_t);
-    bool local_instance = (dodag->instance->id & NG_RPL_INSTANCE_ID_MSB) ? true : false;
+    bool local_instance = (dodag->instance->id & GNRC_RPL_INSTANCE_ID_MSB) ? true : false;
 
     if (local_instance) {
         size += sizeof(ipv6_addr_t);

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -205,7 +205,7 @@ gnrc_rpl_dodag_t *gnrc_rpl_dodag_get(gnrc_rpl_instance_t *instance, ipv6_addr_t 
     }
 
     /* check if global instance id */
-    if ((dodag_id == NULL) && ((instance->id & NG_RPL_INSTANCE_ID_MSB) == 0)) {
+    if ((dodag_id == NULL) && ((instance->id & GNRC_RPL_INSTANCE_ID_MSB) == 0)) {
 #if defined(DEVELHELP) && defined(ENABLE_DEBUG)
         if ((instance->dodags != NULL) && (instance->dodags->next != NULL)) {
             DEBUG("RPL: More than one DODAG available for the global instance (%d)", instance->id);


### PR DESCRIPTION
When I introduced these defines, I used the wrong prefix `NG_`, instead of using `GNRC_`.
This PR renames them to `GNRC_`.