### PR TITLE
core: disallow msg_send_receive() on same thread

### DIFF
--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -184,6 +184,9 @@ int msg_try_receive(msg_t *m);
  *
  * @note    CAUTION! Use this function only when receiver is already waiting.
  *          If not use simple msg_send()
+ *
+ * @pre     @p target_pid is not the PID of the current thread.
+ *
  * @param[in] m             Pointer to preallocated ``msg_t`` structure with
  *                          the message to send, must not be NULL.
  * @param[out] reply        Pointer to preallocated msg. Reply will be written

--- a/core/msg.c
+++ b/core/msg.c
@@ -22,6 +22,7 @@
 
 #include <stddef.h>
 #include <inttypes.h>
+#include <assert.h>
 #include "kernel.h"
 #include "sched.h"
 #include "msg.h"
@@ -214,6 +215,7 @@ int msg_send_int(msg_t *m, kernel_pid_t target_pid)
 
 int msg_send_receive(msg_t *m, msg_t *reply, kernel_pid_t target_pid)
 {
+    assert(sched_active_pid != target_pid);
     unsigned state = disableIRQ();
     tcb_t *me = (tcb_t*) sched_threads[sched_active_pid];
     sched_set_status(me, STATUS_REPLY_BLOCKED);


### PR DESCRIPTION
Calling `msg_send_receive()` on the same thread will fail, because the thread is set to `STATUS_REPLY_BLOCKED` and thus removed from the runqueue. Hence, it won't get the chance to call `msg_receive()` and stuck forever.