### PR TITLE
gnrc: link-type flag

### DIFF
--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -144,6 +144,11 @@ extern "C" {
 #define GNRC_IPV6_NETIF_FLAGS_ADV_CUR_HL        (0x0010)
 
 /**
+ * @brief   Flag to indicate if the interface is operating over a wired link
+ */
+#define GNRC_IPV6_NETIF_FLAGS_IS_WIRED          (0x2000)
+
+/**
  * @brief   Flag to indicate that the interface has other address
  *          configuration.
  */

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -139,6 +139,17 @@ typedef enum {
     NETOPT_TX_END_IRQ,
     NETOPT_AUTOCCA,             /**< en/disable to check automatically
                                  *   before sending the channel is clear. */
+
+    /**
+     * @brief read-only check for a wired interface.
+     *
+     * If the interface is wireless this function will return -ENOTSUP, a
+     * positive value otherwise.
+     *
+     * @note Setting this option will always return -EONOTSUP.
+     */
+    NETOPT_IS_WIRED,
+
     /* add more options if needed */
 
     /**

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -46,6 +46,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_TX_START_IRQ]    = "NETOPT_TX_START_IRQ",
     [NETOPT_TX_END_IRQ]      = "NETOPT_TX_END_IRQ",
     [NETOPT_AUTOCCA]         = "NETOPT_AUTOCCA",
+    [NETOPT_IS_WIRED]        = "NETOPT_IS_WIRED",
     [NETOPT_NUMOF]           = "NETOPT_NUMOF",
 };
 

--- a/sys/net/gnrc/link_layer/netdev_eth/gnrc_netdev_eth.c
+++ b/sys/net/gnrc/link_layer/netdev_eth/gnrc_netdev_eth.c
@@ -273,6 +273,10 @@ static int _get(gnrc_netdev_t *dev, netopt_t opt, void *value, size_t max_len)
             DEBUG("promiscous mode\n");
             return _get_promiscousmode((gnrc_netdev_eth_t *)dev, value, max_len);
 
+        case NETOPT_IS_WIRED:
+            DEBUG("is wired\n");
+            return 1;
+
         default:
             DEBUG("[not supported: %d]\n", opt);
             return -ENOTSUP;

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -695,7 +695,7 @@ void gnrc_ipv6_netif_init_by_dev(void)
     for (size_t i = 0; i < ifnum; i++) {
         ipv6_addr_t addr;
         eui64_t iid;
-        uint16_t mtu;
+        uint16_t tmp;
         gnrc_ipv6_netif_t *ipv6_if = gnrc_ipv6_netif_get(ifs[i]);
 
         if (ipv6_if == NULL) {
@@ -743,13 +743,20 @@ void gnrc_ipv6_netif_init_by_dev(void)
         _add_addr_to_entry(ipv6_if, &addr, 64, 0);
 
         /* set link MTU */
-        if ((gnrc_netapi_get(ifs[i], NETOPT_MAX_PACKET_SIZE, 0, &mtu,
+        if ((gnrc_netapi_get(ifs[i], NETOPT_MAX_PACKET_SIZE, 0, &tmp,
                              sizeof(uint16_t)) >= 0)) {
-            if (mtu >= IPV6_MIN_MTU) {
-                ipv6_if->mtu = mtu;
+            if (tmp >= IPV6_MIN_MTU) {
+                ipv6_if->mtu = tmp;
             }
             /* otherwise leave at GNRC_IPV6_NETIF_DEFAULT_MTU as initialized in
              * gnrc_ipv6_netif_add() */
+        }
+
+        if (gnrc_netapi_get(ifs[i], NETOPT_IS_WIRED, 0, &tmp, sizeof(int)) > 0) {
+            ipv6_if->flags = GNRC_IPV6_NETIF_FLAGS_IS_WIRED;
+        }
+        else {
+            ipv6_if->flags = 0;
         }
 
         mutex_unlock(&ipv6_if->mutex);

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -293,6 +293,10 @@ static void _netif_list(kernel_pid_t dev)
     }
 
 #ifdef MODULE_GNRC_IPV6_NETIF
+    printf("Link type: %s", (entry->flags & GNRC_IPV6_NETIF_FLAGS_IS_WIRED) ?
+            "wired" : "wireless");
+    printf("\n           ");
+
     for (int i = 0; i < GNRC_IPV6_NETIF_ADDR_NUMOF; i++) {
         if (!ipv6_addr_is_unspecified(&entry->addrs[i].addr)) {
             printf("inet6 addr: ");


### PR DESCRIPTION
Alternative to #3632.

Introduces a netopt type to indicate a wired link. To save code-lines for the default case (aka wireless tranceivers) a non-wired interface can just return `-ENOTSUP`. A corresponding flag is set on an IPv6 interface.