### PR TITLE
cortexm: Attempt to reconstruct state for debugging hard faults

### DIFF
--- a/tests/fault_handler/Makefile
+++ b/tests/fault_handler/Makefile
@@ -1,0 +1,17 @@
+# name of your application
+APPLICATION = fault_handler
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+CFLAGS += -DDEVELHELP=1
+
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/fault_handler/main.c
+++ b/tests/fault_handler/main.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2015 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     test
+ * @{
+ *
+ * @file
+ * @brief       Minimal test application for triggering a hard fault or equivalent
+ *
+ * @author      Joakim Gebart <joakim.gebart@eistec.se>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <xtimer.h>
+
+#ifndef FORBIDDEN_ADDRESS
+/* Many platforms do not allow writes to address 0x00000000 */
+#define FORBIDDEN_ADDRESS (0x00000000)
+#endif /* !defined(FORBIDDEN_ADDRESS) */
+#ifndef INVALID_INSTRUCTION
+/* Random garbage may crash the program as well. */
+#define INVALID_INSTRUCTION asm volatile (".short 0xdead, 0xbeef, 0xcafe, 0xbabe\n")
+#endif /* !defined(INVALID_INSTRUCTION) */
+
+#define PRINT_MACRO(a) PRINT_MACRO2(a)
+#define PRINT_MACRO2(a) #a
+
+int main(void)
+{
+    puts("Fault handler test application");
+    printf("This application will crash by attempting to write to address 0x%08x\n", FORBIDDEN_ADDRESS);
+    puts("Waiting 1 second before crashing...");
+    xtimer_usleep(1000000);
+    puts("Write to forbidden address " PRINT_MACRO(FORBIDDEN_ADDRESS));
+    *((volatile int *) FORBIDDEN_ADDRESS) = 12345;
+    int readback = *((volatile int *) FORBIDDEN_ADDRESS);
+    printf("readback: 0x%08x\n", readback);
+    puts("We did not expect the application to survive the previous write.");
+    puts("Trying to execute an invalid instruction");
+    puts(PRINT_MACRO(INVALID_INSTRUCTION));
+    INVALID_INSTRUCTION;
+    puts("Failed to crash the program, hanging...");
+    while(1);
+    return 0;
+}


### PR DESCRIPTION
This PR improves upon #3333 by attempting to reconstruct the state as it was before the hard fault happened. All relevant fault status registers are printed to stdout before restoring the state. A short instruction is also written to stdout in order to assist developers using GDB.
This only affects code built with `-DDEVELHELP=1`

Sample output:

```
2015-08-24 10:34:51,246 - INFO # kernel_init(): This is RIOT! (Version: 2014.12-2901-g6b3a-mazarin-pr/cortexm-state-rebased)
2015-08-24 10:34:51,250 - INFO # kernel_init(): jumping into first task...
2015-08-24 10:34:51,252 - INFO # Fault handler test application
2015-08-24 10:34:51,259 - INFO # This application will crash by attempting to write to address 0x00000000
2015-08-24 10:34:51,262 - INFO # Waiting 1 second before crashing...
2015-08-24 10:34:52,278 - INFO # 
2015-08-24 10:34:52,280 - INFO # Context before hardfault:
2015-08-24 10:34:52,282 - INFO #    r0: 0x00000000
2015-08-24 10:34:52,283 - INFO #    r1: 0x1fff103c
2015-08-24 10:34:52,285 - INFO #    r2: 0x00003039
2015-08-24 10:34:52,287 - INFO #    r3: 0x00000000
2015-08-24 10:34:52,288 - INFO #   r12: 0x4004000c
2015-08-24 10:34:52,290 - INFO #    lr: 0x00000d97
2015-08-24 10:34:52,291 - INFO #    pc: 0x00000438
2015-08-24 10:34:52,293 - INFO #   psr: 0x41000000
2015-08-24 10:34:52,293 - INFO # 
2015-08-24 10:34:52,294 - INFO # FSR/FAR:
2015-08-24 10:34:52,295 - INFO #  CFSR: 0x00000400
2015-08-24 10:34:52,297 - INFO #  HFSR: 0x40000000
2015-08-24 10:34:52,298 - INFO #  DFSR: 0x00000000
2015-08-24 10:34:52,300 - INFO #  AFSR: 0x00000000
2015-08-24 10:34:52,300 - INFO # Misc
2015-08-24 10:34:52,302 - INFO # EXC_RET: 0xfffffffd
2015-08-24 10:34:52,306 - INFO # Attempting to reconstruct state for debugging...
2015-08-24 10:34:52,307 - INFO # In GDB:
2015-08-24 10:34:52,308 - INFO #   set $pc=0x438
2015-08-24 10:34:52,309 - INFO #   frame 0
2015-08-24 10:34:52,310 - INFO #   bt
```