### PR TITLE
cpu: stm32l1 peripheral driver fix for cpuid

### DIFF
--- a/cpu/stm32l1/ldscripts/stm32l151rba.ld
+++ b/cpu/stm32l1/ldscripts/stm32l151rba.ld
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Hamburg University of Applied Sciences
+ * Copyright (C) 2015 Engineering-Spirit
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -11,24 +11,24 @@
  * @{
  *
  * @file
- * @brief           Memory definitions for the STM32L151RC
+ * @brief           Memory definitions for the STM32L151RB-A
  *
- * @author          Katja Kirstein <katja.kirstein@haw-hamburg.de>
+ * @author          Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
  *
  * @}
  */
 
 MEMORY
 {
-    rom (rx)        : ORIGIN = 0x08000000, LENGTH = 256K
-    ram (xrw)       : ORIGIN = 0x20000000, LENGTH = 32K
+    rom (rx)        : ORIGIN = 0x08000000, LENGTH = 128K
+    ram (rw)        : ORIGIN = 0x20000000, LENGTH = 32K
 
     /* see STM32L1 Reference Manual (31.2 Unique device ID registers (96 bits))
      *    Base address:
      *      - 0x1FF80050 for Cat.1 and Cat.2 devices
      *      - 0x1FF800D0 for Cat.3, Cat.4, Cat.5 and Cat.6 devices
      */
-    cpuid (r)       : ORIGIN = 0x1ff800d0, LENGTH = 12
+    cpuid (r)       : ORIGIN = 0x1ff80050, LENGTH = 12
 }
 
 _cpuid_address = ORIGIN(cpuid);

--- a/cpu/stm32l1/ldscripts/stm32l152ret6.ld
+++ b/cpu/stm32l1/ldscripts/stm32l152ret6.ld
@@ -22,6 +22,15 @@ MEMORY
 {
     rom (rx)        : ORIGIN = 0x08000000, LENGTH = 512K
     ram (xrw)       : ORIGIN = 0x20000000, LENGTH = 80K
+
+    /* see STM32L1 Reference Manual (31.2 Unique device ID registers (96 bits))
+     *    Base address:
+     *      - 0x1FF80050 for Cat.1 and Cat.2 devices
+     *      - 0x1FF800D0 for Cat.3, Cat.4, Cat.5 and Cat.6 devices
+     */
+    cpuid (r)       : ORIGIN = 0x1ff800d0, LENGTH = 12
 }
+
+_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32l1/periph/cpuid.c
+++ b/cpu/stm32l1/periph/cpuid.c
@@ -20,11 +20,11 @@
 
 #include "periph/cpuid.h"
 
-#define STM32L1_CPUID_ADDR  (0x1ff800d0)
+extern volatile uint32_t _cpuid_address[3];
 
 void cpuid_get(void *id)
 {
-    memcpy(id, (void *)(STM32L1_CPUID_ADDR), CPUID_ID_LEN);
+    memcpy(id, (void *)(&_cpuid_address), CPUID_ID_LEN);
 }
 
 /** @} */


### PR DESCRIPTION
This fix is done via the linker script, so you will always remember if you port a new device.