### PR TITLE
Add clock source selection based on CLOCK_HSE or CLOCK_HSI for STM32L1 family

### DIFF
--- a/boards/limifrog-v1/include/periph_conf.h
+++ b/boards/limifrog-v1/include/periph_conf.h
@@ -27,13 +27,13 @@ extern "C" {
  * @name Clock system configuration
  * @{
  **/
-#define CLOCK_HSE           (16000000U)         /* external oscillator */
+#define CLOCK_HSI           (16000000U)         /* internal oscillator */
 #define CLOCK_CORECLOCK     (32000000U)         /* desired core clock frequency */
 
 /* configuration of PLL prescaler and multiply values */
-/* CORECLOCK := HSI / PLL_HSI_DIV * PLL_HSI_MUL */
-#define CLOCK_PLL_HSE_DIV   RCC_CFGR_PLLDIV2
-#define CLOCK_PLL_HSE_MUL   RCC_CFGR_PLLMUL4
+/* CORECLOCK := HSI / CLOCK_PLL_DIV * CLOCK_PLL_MUL */
+#define CLOCK_PLL_DIV       RCC_CFGR_PLLDIV2
+#define CLOCK_PLL_MUL       RCC_CFGR_PLLMUL4
 /* configuration of peripheral bus clock prescalers */
 #define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1      /* AHB clock -> 32MHz */
 #define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* APB2 clock -> 32MHz */

--- a/boards/nucleo-l1/include/periph_conf.h
+++ b/boards/nucleo-l1/include/periph_conf.h
@@ -27,12 +27,12 @@ extern "C" {
  * @name Clock system configuration
  * @{
  **/
-#define CLOCK_HSI           (16000000U)             /* frequency of external oscillator */
+#define CLOCK_HSI           (16000000U)             /* frequency of internal oscillator */
 #define CLOCK_CORECLOCK     (32000000U)             /* targeted core clock frequency */
 /* configuration of PLL prescaler and multiply values */
-/* CORECLOCK := HSI / PLL_HSI_DIV * PLL_HSI_MUL */
-#define CLOCK_PLL_HSE_DIV   RCC_CFGR_PLLDIV2
-#define CLOCK_PLL_HSE_MUL   RCC_CFGR_PLLMUL4
+/* CORECLOCK := HSI / CLOCK_PLL_DIV * CLOCK_PLL_MUL */
+#define CLOCK_PLL_DIV       RCC_CFGR_PLLDIV2
+#define CLOCK_PLL_MUL       RCC_CFGR_PLLMUL4
 /* configuration of peripheral bus clock prescalers */
 #define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1      /* AHB clock -> 32MHz */
 #define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* APB2 clock -> 32MHz */


### PR DESCRIPTION
Propose to configure the STM32L1 PLL clock source with the CLOCK_HSE or CLOCK_HSI define in the `includes\periph_conf.h` from the BSP

This can be ported to the STM32Fx familie to.