### PR TITLE
gnrc(_udp|_ipv6): write protect preceding headers and hand actually hand them over on send

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -519,6 +519,9 @@ static void _send(gnrc_pktsnip_t *pkt, bool prep_hdr)
     if (ipv6 != pkt) {      /* in case packet has netif header */
         pkt->next = payload;/* pkt is already write-protected so we can do that */
     }
+    else {
+        pkt = payload;      /* pkt is the IPv6 header so we just write-protected it */
+    }
     ipv6 = payload;  /* Reset ipv6 from temporary variable */
 
     hdr = ipv6->data;


### PR DESCRIPTION
Fixes #3707 by write-protecting all headers up until the relevant header. For `gnrc_ipv6` this was already the case, `pkt` just needed to be reset. For `gnrc_udp` I copied all headers up until `udp_snip` while searching for `udp_snip` and updated the packet snip chain.