### PR TITLE
make: automatic pull in transitive dependencies

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1,30 +1,130 @@
+ifneq (,$(filter at86rf2%,$(USEMODULE)))
+  USEMODULE += at86rf2xx
+  USEMODULE += ieee802154
+endif
+
+ifneq (,$(filter cbor,$(USEMODULE)))
+  USEMODULE += net_help
+endif
+
+ifneq (,$(filter cpp11-compat,$(USEMODULE)))
+  USEMODULE += vtimer
+  USEMODULE += timex
+  FEATURES_REQUIRED += cpp
+endif
+
+ifneq (,$(filter fib,$(USEMODULE)))
+  USEMODULE += universal_address
+  USEMODULE += timex
+  USEMODULE += vtimer
+  USEMODULE += net_help
+endif
+
+ifneq (,$(filter gnrc,$(USEMODULE)))
+  USEMODULE += gnrc_netapi
+  USEMODULE += gnrc_netreg
+  USEMODULE += gnrc_netif
+  USEMODULE += gnrc_netif_hdr
+  USEMODULE += gnrc_pktbuf
+endif
+
 ifneq (,$(filter gnrc_%,$(filter-out gnrc_netapi gnrc_netreg gnrc_netif% gnrc_pktbuf,$(USEMODULE))))
   USEMODULE += gnrc
+endif
+
+ifneq (,$(filter gnrc_icmpv6,$(USEMODULE)))
+  USEMODULE += inet_csum
+  USEMODULE += gnrc_ipv6
+endif
+
+ifneq (,$(filter gnrc_icmpv6_echo,$(USEMODULE)))
+  USEMODULE += gnrc_icmpv6
+endif
+
+ifneq (,$(filter gnrc_ipv6,$(USEMODULE)))
+  USEMODULE += inet_csum
+  USEMODULE += ipv6_addr
+  USEMODULE += gnrc_ipv6_hdr
+  USEMODULE += gnrc_ipv6_nc
+  USEMODULE += gnrc_ipv6_netif
+endif
+
+ifneq (,$(filter gnrc_ipv6_default,$(USEMODULE)))
+  USEMODULE += gnrc_ipv6
+  USEMODULE += gnrc_icmpv6
+  USEMODULE += gnrc_ndp
+  USEMODULE += gnrc_ndp_internal
+  USEMODULE += gnrc_ndp_node
+endif
+
+ifneq (,$(filter gnrc_ipv6_ext,$(USEMODULE)))
+  USEMODULE += ipv6_ext
+  USEMODULE += gnrc_ipv6
+endif
+
+ifneq (,$(filter gnrc_ipv6_hdr,$(USEMODULE)))
+  USEMODULE += ipv6_hdr
+  USEMODULE += gnrc_pktbuf
+endif
+
+ifneq (,$(filter gnrc_ipv6_nc,$(USEMODULE)))
+  USEMODULE += ipv6_addr
+endif
+
+ifneq (,$(filter gnrc_ipv6_netif,$(USEMODULE)))
+  USEMODULE += ipv6_addr
+  USEMODULE += gnrc_netif
+  USEMODULE += bitfield
+endif
+
+ifneq (,$(filter gnrc_ipv6_router,$(USEMODULE)))
+  USEMODULE += gnrc_ipv6
+endif
+
+ifneq (,$(filter gnrc_ipv6_router_default,$(USEMODULE)))
+  USEMODULE += gnrc_ipv6_router
+  USEMODULE += gnrc_icmpv6
+  USEMODULE += gnrc_ndp
+  USEMODULE += gnrc_ndp_internal
+  USEMODULE += gnrc_ndp_node
+endif
+
+ifneq (,$(filter gnrc_ndp,$(USEMODULE)))
+  USEMODULE += gnrc_icmpv6
+  USEMODULE += random
+  USEMODULE += timex
+  USEMODULE += vtimer
+endif
+
+ifneq (,$(filter gnrc_netdev_eth,$(USEMODULE)))
+  USEMODULE += gnrc_pktbuf
 endif
 
 ifneq (,$(filter gnrc_netif_default,$(USEMODULE)))
   USEMODULE += gnrc_netif
 endif
 
-ifneq (,$(filter at86rf2%,$(USEMODULE)))
-  USEMODULE += at86rf2xx
-  USEMODULE += ieee802154
-endif
-
-ifneq (,$(filter kw2xrf,$(USEMODULE)))
-  USEMODULE += ieee802154
-endif
-
-ifneq (,$(filter xbee,$(USEMODULE)))
-  USEMODULE += ieee802154
-endif
-
-ifneq (,$(filter gnrc_zep,$(USEMODULE)))
-  USEMODULE += hashes
-  USEMODULE += ieee802154
-  USEMODULE += gnrc_udp
-  USEMODULE += random
+ifneq (,$(filter gnrc_nettest,$(USEMODULE)))
+  USEMODULE += gnrc_netapi
+  USEMODULE += gnrc_netreg
+  USEMODULE += gnrc_netif
+  USEMODULE += gnrc_pktbuf
   USEMODULE += vtimer
+endif
+
+ifneq (,$(filter gnrc_pktbuf, $(USEMODULE)))
+  ifeq (,$(filter gnrc_pktbuf_%, $(USEMODULE)))
+    USEMODULE += gnrc_pktbuf_static
+  endif
+endif
+
+ifneq (,$(filter gnrc_pktbuf_%, $(USEMODULE)))
+  USEMODULE += gnrc_pktbuf # make MODULE_GNRC_PKTBUF macro available for all implementations
+endif
+
+ifneq (,$(filter gnrc_pktdump,$(USEMODULE)))
+  USEMODULE += gnrc_pktbuf
+  USEMODULE += od
 endif
 
 ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
@@ -34,19 +134,19 @@ ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
   USEMODULE += vtimer
 endif
 
-ifneq (,$(filter ieee802154,$(USEMODULE)))
-  ifneq (,$(filter gnrc_ipv6, $(USEMODULE)))
-    USEMODULE += gnrc_sixlowpan
-  endif
-  ifneq (,$(filter gnrc_ipv6_router, $(USEMODULE)))
-    USEMODULE += gnrc_sixlowpan   # TODO: replace with gnrc_sixlowpan_router
-  endif
-  ifneq (,$(filter gnrc_ipv6_default, $(USEMODULE)))
-    USEMODULE += gnrc_sixlowpan_default
-  endif
-  ifneq (,$(filter gnrc_ipv6_router_default, $(USEMODULE)))
-    USEMODULE += gnrc_sixlowpan_default   # TODO: replace with gnrc_sixlowpan_router_default
-  endif
+ifneq (,$(filter gnrc_rpl_srh,$(USEMODULE)))
+  USEMODULE += ipv6_ext_rh
+endif
+
+ifneq (,$(filter gnrc_sixlowpan,$(USEMODULE)))
+  USEMODULE += gnrc_ipv6
+  USEMODULE += gnrc_sixlowpan_netif
+  USEMODULE += sixlowpan
+endif
+
+ifneq (,$(filter gnrc_sixlowpan_ctx,$(USEMODULE)))
+  USEMODULE += ipv6_addr
+  USEMODULE += vtimer
 endif
 
 ifneq (,$(filter gnrc_sixlowpan_default,$(USEMODULE)))
@@ -66,123 +166,57 @@ ifneq (,$(filter gnrc_sixlowpan_iphc,$(USEMODULE)))
   USEMODULE += gnrc_sixlowpan_ctx
 endif
 
-ifneq (,$(filter gnrc_sixlowpan,$(USEMODULE)))
-  USEMODULE += gnrc_ipv6
-  USEMODULE += gnrc_sixlowpan_netif
-  USEMODULE += sixlowpan
-endif
-
-ifneq (,$(filter gnrc_sixlowpan_ctx,$(USEMODULE)))
-  USEMODULE += ipv6_addr
-  USEMODULE += vtimer
-endif
-
-ifneq (,$(filter gnrc_ipv6_default,$(USEMODULE)))
-  USEMODULE += gnrc_ipv6
-  USEMODULE += gnrc_icmpv6
-  USEMODULE += gnrc_ndp
-  USEMODULE += gnrc_ndp_internal
-  USEMODULE += gnrc_ndp_node
-endif
-
-ifneq (,$(filter gnrc_ipv6_router_default,$(USEMODULE)))
-  USEMODULE += gnrc_ipv6_router
-  USEMODULE += gnrc_icmpv6
-  USEMODULE += gnrc_ndp
-  USEMODULE += gnrc_ndp_internal
-  USEMODULE += gnrc_ndp_node
-endif
-
-ifneq (,$(filter gnrc_ndp,$(USEMODULE)))
-  USEMODULE += gnrc_icmpv6
-  USEMODULE += random
-  USEMODULE += timex
-  USEMODULE += vtimer
-endif
-
-ifneq (,$(filter gnrc_icmpv6_echo,$(USEMODULE)))
-  USEMODULE += gnrc_icmpv6
-endif
-
-ifneq (,$(filter gnrc_icmpv6,$(USEMODULE)))
+ifneq (,$(filter gnrc_udp,$(USEMODULE)))
   USEMODULE += inet_csum
-  USEMODULE += gnrc_ipv6
+  USEMODULE += udp
 endif
 
-ifneq (,$(filter gnrc_rpl_srh,$(USEMODULE)))
-  USEMODULE += ipv6_ext_rh
+ifneq (,$(filter gnrc_zep,$(USEMODULE)))
+  USEMODULE += hashes
+  USEMODULE += ieee802154
+  USEMODULE += gnrc_udp
+  USEMODULE += random
+  USEMODULE += vtimer
+endif
+
+ifneq (,$(filter hih6130,$(USEMODULE)))
+  USEMODULE += vtimer
+endif
+
+ifneq (,$(filter ieee802154,$(USEMODULE)))
+  ifneq (,$(filter gnrc_ipv6, $(USEMODULE)))
+    USEMODULE += gnrc_sixlowpan
+  endif
+  ifneq (,$(filter gnrc_ipv6_router, $(USEMODULE)))
+    USEMODULE += gnrc_sixlowpan   # TODO: replace with gnrc_sixlowpan_router
+  endif
+  ifneq (,$(filter gnrc_ipv6_default, $(USEMODULE)))
+    USEMODULE += gnrc_sixlowpan_default
+  endif
+  ifneq (,$(filter gnrc_ipv6_router_default, $(USEMODULE)))
+    USEMODULE += gnrc_sixlowpan_default   # TODO: replace with gnrc_sixlowpan_router_default
+  endif
 endif
 
 ifneq (,$(filter ipv6_ext_rh,$(USEMODULE)))
   USEMODULE += ipv6_ext
 endif
 
-ifneq (,$(filter gnrc_ipv6_ext,$(USEMODULE)))
-  USEMODULE += ipv6_ext
-  USEMODULE += gnrc_ipv6
-endif
-
-ifneq (,$(filter gnrc_ipv6_router,$(USEMODULE)))
-  USEMODULE += gnrc_ipv6
-endif
-
-ifneq (,$(filter gnrc_ipv6,$(USEMODULE)))
-  USEMODULE += inet_csum
-  USEMODULE += ipv6_addr
-  USEMODULE += gnrc_ipv6_hdr
-  USEMODULE += gnrc_ipv6_nc
-  USEMODULE += gnrc_ipv6_netif
-endif
-
-ifneq (,$(filter gnrc_ipv6_hdr,$(USEMODULE)))
-  USEMODULE += ipv6_hdr
-  USEMODULE += gnrc_pktbuf
-endif
-
-ifneq (,$(filter sixlowpan,$(USEMODULE)))
-  USEMODULE += ipv6_hdr
-endif
-
 ifneq (,$(filter ipv6_hdr,$(USEMODULE)))
   USEMODULE += inet_csum
 endif
 
-ifneq (,$(filter gnrc_ipv6_nc,$(USEMODULE)))
-  USEMODULE += ipv6_addr
+ifneq (,$(filter kw2xrf,$(USEMODULE)))
+  USEMODULE += ieee802154
 endif
 
-ifneq (,$(filter gnrc_ipv6_netif,$(USEMODULE)))
-  USEMODULE += ipv6_addr
-  USEMODULE += gnrc_netif
-  USEMODULE += bitfield
+ifneq (,$(filter libfixmath-unittests,$(USEMODULE)))
+  USEPKG += libfixmath
 endif
 
-ifneq (,$(filter gnrc_udp,$(USEMODULE)))
-  USEMODULE += inet_csum
-  USEMODULE += udp
-endif
-
-ifneq (,$(filter gnrc_nettest,$(USEMODULE)))
-  USEMODULE += gnrc_netapi
-  USEMODULE += gnrc_netreg
-  USEMODULE += gnrc_netif
-  USEMODULE += gnrc_pktbuf
-  USEMODULE += vtimer
-endif
-
-ifneq (,$(filter gnrc_pktdump,$(USEMODULE)))
-  USEMODULE += gnrc_pktbuf
-  USEMODULE += od
-endif
-
-ifneq (,$(filter gnrc_pktbuf, $(USEMODULE)))
-  ifeq (,$(filter gnrc_pktbuf_%, $(USEMODULE)))
-    USEMODULE += gnrc_pktbuf_static
-  endif
-endif
-
-ifneq (,$(filter gnrc_pktbuf_%, $(USEMODULE)))
-  USEMODULE += gnrc_pktbuf # make MODULE_GNRC_PKTBUF macro available for all implementations
+# if any log_* is used, also use LOG pseudomodule
+ifneq (,$(filter log_%,$(USEMODULE)))
+  USEMODULE += log
 endif
 
 ifneq (,$(filter newlib,$(USEMODULE)))
@@ -193,43 +227,10 @@ else
   endif
 endif
 
-
-ifneq (,$(filter uart0,$(USEMODULE)))
-  USEMODULE += posix
-endif
-
-ifneq (,$(filter posix,$(USEMODULE)))
-  USEMODULE += timex
-  USEMODULE += vtimer
-endif
-
-ifneq (,$(filter cbor,$(USEMODULE)))
-  USEMODULE += net_help
-endif
-
-ifneq (,$(filter vtimer,$(USEMODULE)))
-  USEMODULE += timex
-endif
-
-ifneq (,$(filter rgbled,$(USEMODULE)))
-  USEMODULE += color
-endif
-
-ifneq (,$(filter libfixmath-unittests,$(USEMODULE)))
-  USEPKG += libfixmath
-endif
-
 ifneq (,$(filter nhdp,$(USEMODULE)))
   USEMODULE += vtimer
   USEMODULE += oonf_common
   USEMODULE += oonf_rfc5444
-endif
-
-ifneq (,$(filter fib,$(USEMODULE)))
-  USEMODULE += universal_address
-  USEMODULE += timex
-  USEMODULE += vtimer
-  USEMODULE += net_help
 endif
 
 ifneq (,$(filter oonf_common,$(USEMODULE)))
@@ -237,29 +238,27 @@ ifneq (,$(filter oonf_common,$(USEMODULE)))
   USEMODULE += socket_base
 endif
 
-# if any log_* is used, also use LOG pseudomodule
-ifneq (,$(filter log_%,$(USEMODULE)))
-  USEMODULE += log
-endif
-
-ifneq (,$(filter cpp11-compat,$(USEMODULE)))
-  USEMODULE += vtimer
+ifneq (,$(filter posix,$(USEMODULE)))
   USEMODULE += timex
-  FEATURES_REQUIRED += cpp
-endif
-
-ifneq (,$(filter gnrc_netdev_eth,$(USEMODULE)))
-  USEMODULE += gnrc_pktbuf
-endif
-
-ifneq (,$(filter gnrc,$(USEMODULE)))
-  USEMODULE += gnrc_netapi
-  USEMODULE += gnrc_netreg
-  USEMODULE += gnrc_netif
-  USEMODULE += gnrc_netif_hdr
-  USEMODULE += gnrc_pktbuf
-endif
-
-ifneq (,$(filter hih6130,$(USEMODULE)))
   USEMODULE += vtimer
+endif
+
+ifneq (,$(filter rgbled,$(USEMODULE)))
+  USEMODULE += color
+endif
+
+ifneq (,$(filter sixlowpan,$(USEMODULE)))
+  USEMODULE += ipv6_hdr
+endif
+
+ifneq (,$(filter uart0,$(USEMODULE)))
+  USEMODULE += posix
+endif
+
+ifneq (,$(filter vtimer,$(USEMODULE)))
+  USEMODULE += timex
+endif
+
+ifneq (,$(filter xbee,$(USEMODULE)))
+  USEMODULE += ieee802154
 endif

--- a/Makefile.include
+++ b/Makefile.include
@@ -140,12 +140,27 @@ ifneq ($(GNRC_NETIF_NUMOF),1)
   CFLAGS += -DGNRC_NETIF_NUMOF=$(GNRC_NETIF_NUMOF)
 endif
 
-include $(RIOTBASE)/Makefile.dep
+# Add (transitive) dependencies to USEMODULE
+define __FILL_DEPENDENCIES_LOOP
+  __USEMODULE_BEFORE := $${USEMODULE}
+
+  include $(RIOTBASE)/Makefile.dep
+
+  USEMODULE := $$(sort $${USEMODULE})
+
+  ifneq ($${__USEMODULE_BEFORE},$${USEMODULE})
+    $$(eval $$(__FILL_DEPENDENCIES_LOOP))
+  endif
+endef
+
+USEMODULE := $(sort ${USEMODULE})
+$(eval $(__FILL_DEPENDENCIES_LOOP))
+
 
 USEMODULE += $(filter-out $(DISABLE_MODULE), $(DEFAULT_MODULE))
 
 ifeq ($(strip $(MCU)),)
-	MCU = $(CPU)
+  MCU = $(CPU)
 endif
 
 # if you want to publish the board into the sources as an uppercase #define

--- a/sort_Makefile_dep.py
+++ b/sort_Makefile_dep.py
@@ -1,0 +1,20 @@
+import re
+
+if __name__ == '__main__':
+    with open('Makefile.dep', 'rt', 1) as f:
+        s = list(str.rstrip(s) for s in f)
+
+    lines = [[]]
+    for s in s:
+        if s:
+            lines[-1].append(s)
+        elif lines[-1]:
+            lines.append([])
+
+    lines = map('\n'.join, lines)
+    lines = { re.findall(r'filter ([^,]+),', s)[0]: s for s in lines }
+    lines = sorted(lines.items())
+    lines = '\n\n'.join(s[1] for s in lines)
+
+    with open('Makefile.dep', 'wt', 1) as f:
+        f.write(lines + '\n')


### PR DESCRIPTION
This diff makes Makefile.dep loop as long as there are more transitive
dependencies. This makes the file harder on the eyes (`$` → `$$`), but
you can add the `ifneq (,filter(blub,$(USEMODULE))` in an arbitrary
order.