### PR TITLE
atmega_common: give distinct numbers to errnos

### DIFF
--- a/cpu/atmega_common/avr-libc-extra/errno.h
+++ b/cpu/atmega_common/avr-libc-extra/errno.h
@@ -62,92 +62,91 @@ extern int errno;
 #endif
 
 /**
-    @def EDOM
-
-    Domain error. */
-#define EDOM       33
-
-/**
-    @def ERANGE
-
-    Range error. */
-#define ERANGE     34
-
-/* ((((('E'-64)*26+('N'-64))*26+('O'-64))*26+('S'-64))*26+('Y'-64))*26+'S'-64 */
-#define ENOSYS ((int)(66081697 & 0x7fff))
-
-/* (((('E'-64)*26+('I'-64))*26+('N'-64))*26+('T'-64))*26+('R'-64) */
-#define EINTR ((int)(2453066 & 0x7fff))
-
-#define E2BIG ENOERR
-#define EACCES ENOERR
-#define EADDRINUSE ENOERR
-#define EADDRNOTAVAIL ENOERR
-#define EAFNOSUPPORT ENOERR
-#define EAGAIN ENOERR
-#define EALREADY ENOERR
-#define EBADF ENOERR
-/* #define EBUSY ENOERR */
-#define ECANCELED ENOERR
-#define ECHILD ENOERR
-#define ECONNABORTED ENOERR
-#define ECONNREFUSED ENOERR
-#define ECONNRESET ENOERR
-#define EDEADLK ENOERR
-#define EDESTADDRREQ ENOERR
-#define EEXIST ENOERR
-#define EFAULT ENOERR
-#define EFBIG ENOERR
-#define EHOSTUNREACH ENOERR
-#define EILSEQ ENOERR
-#define EINPROGRESS ENOERR
-/* #define EINVAL ENOERR */
-#define EIO ENOERR
-#define EISCONN ENOERR
-#define EISDIR ENOERR
-#define ELOOP ENOERR
-#define EMFILE ENOERR
-#define EMLINK ENOERR
-#define EMSGSIZE ENOERR
-#define ENAMETOOLONG ENOERR
-#define ENETDOWN ENOERR
-#define ENETRESET ENOERR
-#define ENETUNREACH ENOERR
-#define ENFILE ENOERR
-#define ENOBUFS ENOERR
-#define ENODEV ENOERR
-#define ENOENT ENOERR
-#define ENOEXEC ENOERR
-#define ENOLCK ENOERR
-#define ENOMEM ENOERR
-#define ENOMSG ENOERR
-#define ENOPROTOOPT ENOERR
-#define ENOSPC ENOERR
-#define ENOTCONN ENOERR
-#define ENOTDIR ENOERR
-#define ENOTEMPTY ENOERR
-#define ENOTSOCK ENOERR
-#define ENOTTY ENOERR
-#define ENXIO ENOERR
-#define EOPNOTSUPP ENOERR
-#define ENOTSUP    EOPNOTSUPP
-#define EPERM ENOERR
-#define EPIPE ENOERR
-#define EPROTONOSUPPORT ENOERR
-#define EPROTOTYPE ENOERR
-#define EROFS ENOERR
-#define ESPIPE ENOERR
-#define ESRCH ENOERR
-#define ETIMEDOUT ENOERR
-#define EWOULDBLOCK ENOERR
-#define EXDEV ENOERR
-
-/* ((((('E'-64)*26+('N'-64))*26+('O'-64))*26+('E'-64))*26+('R'-64))*26+'R'-64 */
-#define ENOERR ((int)(66072050 & 0xffff))
-
-#define EBUSY 16 /* Device or resource busy */
-#define EINVAL 22 /* Invalid argument */
-#define EOVERFLOW 75 /* Value too large for defined data type */
+ * @name    Error numbers
+ * @{
+ */
+#define E2BIG           (1)     /**< Argument list too long. */
+#define EACCES          (2)     /**< Permission denied. */
+#define EADDRINUSE      (3)     /**< Address in use. */
+#define EADDRNOTAVAIL   (4)     /**< Address not available. */
+#define EAFNOSUPPORT    (5)     /**< Address family not supported. */
+#define EAGAIN          (6)     /**< Resource unavailable, try again (may be the same value as [EWOULDBLOCK]). */
+#define EALREADY        (7)     /**< Connection already in progress. */
+#define EBADF           (8)     /**< Bad file descriptor. */
+#define EBADMSG         (9)     /**< Bad message. */
+#define EBUSY           (10)    /**< Device or resource busy. */
+#define ECANCELED       (11)    /**< Operation canceled. */
+#define ECHILD          (12)    /**< No child processes. */
+#define ECONNABORTED    (13)    /**< Connection aborted. */
+#define ECONNREFUSED    (14)    /**< Connection refused. */
+#define ECONNRESET      (15)    /**< Connection reset. */
+#define EDEADLK         (16)    /**< Resource deadlock would occur. */
+#define EDESTADDRREQ    (17)    /**< Destination address required. */
+#define EDOM            (18)    /**< Mathematics argument out of domain of function. */
+#define EDQUOT          (19)    /**< Reserved. */
+#define EEXIST          (20)    /**< File exists. */
+#define EFAULT          (21)    /**< Bad address. */
+#define EFBIG           (22)    /**< File too large. */
+#define EHOSTUNREACH    (23)    /**< Host is unreachable. */
+#define EIDRM           (24)    /**< Identifier removed. */
+#define EILSEQ          (25)    /**< Illegal byte sequence. */
+#define EINPROGRESS     (26)    /**< Operation in progress. */
+#define EINTR           (27)    /**< Interrupted function. */
+#define EINVAL          (28)    /**< Invalid argument. */
+#define EIO             (29)    /**< I/O error. */
+#define EISCONN         (30)    /**< Socket is connected. */
+#define EISDIR          (31)    /**< Is a directory. */
+#define ELOOP           (32)    /**< Too many levels of symbolic links. */
+#define EMFILE          (33)    /**< File descriptor value too large. */
+#define EMLINK          (34)    /**< Too many links. */
+#define EMSGSIZE        (35)    /**< Message too large. */
+#define EMULTIHOP       (36)    /**< Reserved. */
+#define ENAMETOOLONG    (37)    /**< Filename too long. */
+#define ENETDOWN        (38)    /**< Network is down. */
+#define ENETRESET       (39)    /**< Connection aborted by network. */
+#define ENETUNREACH     (40)    /**< Network unreachable. */
+#define ENFILE          (41)    /**< Too many files open in system. */
+#define ENOBUFS         (42)    /**< No buffer space available. */
+#define ENODATA         (43)    /**< [OB XSR] [Option Start] No message is available on the STREAM head read queue. [Option End] */
+#define ENODEV          (44)    /**< No such device. */
+#define ENOENT          (45)    /**< No such file or directory. */
+#define ENOEXEC         (46)    /**< Executable file format error. */
+#define ENOLCK          (47)    /**< No locks available. */
+#define ENOLINK         (48)    /**< Reserved. */
+#define ENOMEM          (49)    /**< Not enough space. */
+#define ENOMSG          (50)    /**< No message of the desired type. */
+#define ENOPROTOOPT     (51)    /**< Protocol not available. */
+#define ENOSPC          (52)    /**< No space left on device. */
+#define ENOSR           (53)    /**< [OB XSR] [Option Start] No STREAM resources. [Option End] */
+#define ENOSTR          (54)    /**< [OB XSR] [Option Start] Not a STREAM. [Option End] */
+#define ENOSYS          (55)    /**< Function not supported. */
+#define ENOTCONN        (56)    /**< The socket is not connected. */
+#define ENOTDIR         (57)    /**< Not a directory or a symbolic link to a directory. */
+#define ENOTEMPTY       (58)    /**< Directory not empty. */
+#define ENOTRECOVERABLE (59)    /**< State not recoverable. */
+#define ENOTSOCK        (60)    /**< Not a socket. */
+#define ENOTSUP         (61)    /**< Not supported (may be the same value as [EOPNOTSUPP]). */
+#define ENOTTY          (62)    /**< Inappropriate I/O control operation. */
+#define ENXIO           (63)    /**< No such device or address. */
+#define EOPNOTSUPP      (64)    /**< Operation not supported on socket (may be the same value as [ENOTSUP]). */
+#define EOVERFLOW       (65)    /**< Value too large to be stored in data type. */
+#define EOWNERDEAD      (66)    /**< Previous owner died. */
+#define EPERM           (67)    /**< Operation not permitted. */
+#define EPIPE           (68)    /**< Broken pipe. */
+#define EPROTO          (69)    /**< Protocol error. */
+#define EPROTONOSUPPORT (70)    /**< Protocol not supported. */
+#define EPROTOTYPE      (71)    /**< Protocol wrong type for socket. */
+#define ERANGE          (72)    /**< Result too large. */
+#define EROFS           (73)    /**< Read-only file system. */
+#define ESPIPE          (74)    /**< Invalid seek. */
+#define ESRCH           (75)    /**< No such process. */
+#define ESTALE          (76)    /**< Reserved. */
+#define ETIME           (77)    /**< [OB XSR] [Option Start] Stream ioctl() timeout. [Option End] */
+#define ETIMEDOUT       (78)    /**< Connection timed out. */
+#define ETXTBSY         (79)    /**< Text file busy. */
+#define EWOULDBLOCK     (80)    /**< Operation would block (may be the same value as [EAGAIN]). */
+#define EXDEV           (81)    /**< Cross-device link. */
+/** @} */
 
 /** @} */
 


### PR DESCRIPTION
This replaces the errno numbers currently defined to the same for atmega CPUs with a version, that gives them distinct values as specified in http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/errno.h.html.