### PR TITLE
doc: add net to sys group

### DIFF
--- a/sys/net/doc.txt
+++ b/sys/net/doc.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin
+ * Copyright (C) 2013-15 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -7,6 +7,6 @@
  */
 
 /**
- * @defgroup    net Net
+ * @defgroup    net Networking
  * @brief       Networking libraries
  */


### PR DESCRIPTION
This updates the `sys/net/doc.txt` for `net` to be a sub-group of `sys`.