### PR TITLE
rpl: make dodag_conf and prefix_info options requestable

### DIFF
--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -235,7 +235,8 @@ struct gnrc_rpl_dodag {
     uint8_t dao_seq;                /**< dao sequence number */
     uint8_t dao_counter;            /**< amount of retried DAOs */
     bool dao_ack_received;          /**< flag to check for DAO-ACK */
-    uint8_t dodag_conf_counter;     /**< limitation of the sending of DODAG_CONF options */
+    bool dodag_conf_requested;      /**< flag to send DODAG_CONF options */
+    bool prefix_info_requested;     /**< flag to send PREFIX_INFO options */
     msg_t dao_msg;                  /**< msg_t for firing a dao */
     uint64_t dao_time;              /**< time to schedule the next DAO */
     xtimer_t dao_timer;             /**< timer to schedule the next DAO */

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -94,6 +94,8 @@ gnrc_rpl_dodag_t *gnrc_rpl_root_init(uint8_t instance_id, ipv6_addr_t *dodag_id)
     dodag->grounded = GNRC_RPL_GROUNDED;
     dodag->node_status = GNRC_RPL_ROOT_NODE;
     dodag->my_rank = GNRC_RPL_ROOT_RANK;
+    dodag->dodag_conf_requested = true;
+    dodag->prefix_info_requested = true;
 
     trickle_start(gnrc_rpl_pid, &dodag->trickle, GNRC_RPL_MSG_TYPE_TRICKLE_INTERVAL,
                   GNRC_RPL_MSG_TYPE_TRICKLE_CALLBACK, (1 << dodag->dio_min),


### PR DESCRIPTION
Currently, the `DODAG_CONF` and `PREFIX_INFO` `DIO` options are sent out after every two `DIO`s.

This PR changes this to:
* If the very first `DIO` that would lead to a node joining the DODAG has no `DODAG_CONF` and `PREFIX_INFO` `DIO` option included, then this `DIO` will be dropped and a unicast `DIS` will be sent to the sender of the incoming `DIO`.
* A unicast `DIS` forces a node to include the `DODAG_CONF` and `PREFIX_INFO` options within the `DIO`.
* The very first `DIO` that a node sends out after joining a DODAG includes the `DODAG_CONF` and `PREFIX_INFO` `DIO` option.

~~depends on #3718~~ <- merged
