### PR TITLE
core: RIOT's own assert macro

### DIFF
--- a/core/include/assert.h
+++ b/core/include/assert.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 INRIA
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  core_util
+ *
+ * @{
+ * @file
+ * @brief       POSIX.1-2008 compliant version of the assert macro
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ */
+
+#ifndef ASSERT_H
+#define ASSERT_H
+
+#include "panic.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    abort the program if assertion is false
+ *
+ * If the macro NDEBUG was defined at the moment <assert.h> was last included,
+ * the macro assert() generates no code, and hence does nothing at all.
+ *
+ * Otherwise, the macro assert() prints an error message to standard error and
+ * terminates the application by calling core_panic().
+ *
+ * The purpose of this macro is to help programmers find bugs in their
+ * programs.
+ */
+
+#ifdef NDEBUG
+#define assert(ignore)((void) 0)
+#else
+#define assert(cond) ((cond) ? (void)0 : core_panic(PANIC_ASSERT_FAIL, "assert"))
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASSERT_H */
+/** @} */

--- a/core/include/assert.h
+++ b/core/include/assert.h
@@ -25,6 +25,8 @@
 extern "C" {
 #endif
 
+extern const char assert_crash_message[];
+
 /**
  * @brief    abort the program if assertion is false
  *
@@ -41,7 +43,7 @@ extern "C" {
 #ifdef NDEBUG
 #define assert(ignore)((void) 0)
 #else
-#define assert(cond) ((cond) ? (void)0 : core_panic(PANIC_ASSERT_FAIL, "assert"))
+#define assert(cond) ((cond) ? (void)0 : core_panic(PANIC_ASSERT_FAIL, assert_crash_message))
 #endif
 
 #ifdef __cplusplus

--- a/core/include/panic.h
+++ b/core/include/panic.h
@@ -29,6 +29,29 @@
 #endif
 
 /**
+ * @brief Definition of available panic modes
+ */
+typedef enum {
+    PANIC_GENERAL_ERROR,
+    PANIC_SOFT_REBOOT,
+    PANIC_HARD_REBOOT,
+    PANIC_ASSERT_FAIL,
+#ifdef MODULE_CORTEXM_COMMON
+    PANIC_NMI_HANDLER,       /**< non maskable interrupt */
+    PANIC_HARD_FAULT,        /**< hard fault */
+#if defined(CPU_ARCH_CORTEX_M3) || defined(CPU_ARCH_CORTEX_M4) || \
+    defined(CPU_ARCH_CORTEX_M4F)
+    PANIC_MEM_MANAGE,        /**< memory controller interrupt */
+    PANIC_BUS_FAULT,         /**< bus fault */
+    PANIC_USAGE_FAULT,       /**< undefined instruction or unaligned access */
+    PANIC_DEBUG_MON,         /**< debug interrupt */
+#endif
+    PANIC_DUMMY_HANDLER,     /**< unhandled interrupt */
+#endif
+    PANIC_UNDEFINED
+} core_panic_t;
+
+/**
  * @brief Handle an unrecoverable error by halting or rebooting the system
  *
  * A numeric code indicating the failure reason can be given
@@ -48,7 +71,7 @@
  *
  * @return                  this function never returns
  * */
-NORETURN void core_panic(int crash_code, const char *message);
+NORETURN void core_panic(core_panic_t crash_code, const char *message);
 
 #ifdef __cplusplus
 }

--- a/core/panic.c
+++ b/core/panic.c
@@ -38,7 +38,7 @@
 static int crashed = 0;
 
 /* WARNING: this function NEVER returns! */
-NORETURN void core_panic(int crash_code, const char *message)
+NORETURN void core_panic(core_panic_t crash_code, const char *message)
 {
     (void) crash_code;
 

--- a/core/panic.c
+++ b/core/panic.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <stdio.h>
 
+#include "assert.h"
 #include "cpu.h"
 #include "irq.h"
 #include "lpm.h"
@@ -33,6 +34,8 @@
 #if DEVELHELP && defined MODULE_PS
 #include "ps.h"
 #endif
+
+const char assert_crash_message[] = "Failed assertion.";
 
 /* flag preventing "recursive crash printing loop" */
 static int crashed = 0;
@@ -47,6 +50,12 @@ NORETURN void core_panic(core_panic_t crash_code, const char *message)
         crashed = 1;
         puts("*** RIOT kernel panic");
         puts(message);
+#ifndef NDEBUG
+        if (crash_code == PANIC_ASSERT_FAIL) {
+            cpu_print_last_instruction();
+            puts("");
+        }
+#endif
 #if DEVELHELP
 #ifdef MODULE_PS
         ps();

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -91,22 +91,6 @@ extern "C" {
 #endif
 
 /**
- * @brief Definition of available panic modes
- */
-typedef enum {
-    PANIC_NMI_HANDLER,       /**< non maskable interrupt */
-    PANIC_HARD_FAULT,        /**< hard fault */
-#if defined(CPU_ARCH_CORTEX_M3) || defined(CPU_ARCH_CORTEX_M4) || \
-    defined(CPU_ARCH_CORTEX_M4F)
-    PANIC_MEM_MANAGE,        /**< memory controller interrupt */
-    PANIC_BUS_FAULT,         /**< bus fault */
-    PANIC_USAGE_FAULT,       /**< undefined instruction or unaligned access */
-    PANIC_DEBUG_MON,         /**< debug interrupt */
-#endif
-    PANIC_DUMMY_HANDLER,     /**< unhandled interrupt */
-} panic_t;
-
-/**
  * @brief   Initialization of the CPU
  */
 void cpu_init(void);

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -103,7 +103,7 @@ void cpu_init(void);
 void cortexm_init(void);
 
 /**
- * @brief   Returns the current content of the link register (lr)
+ * @brief   Prints the current content of the link register (lr)
  */
 static inline void cpu_print_last_instruction(void)
 {

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -30,6 +30,8 @@
 #ifndef CPU_H_
 #define CPU_H_
 
+#include <stdio.h>
+
 #include "cpu_conf.h"
 #include "irq.h"
 
@@ -99,6 +101,16 @@ void cpu_init(void);
  * @brief   Initialize Cortex-M specific core parts of the CPU
  */
 void cortexm_init(void);
+
+/**
+ * @brief   Returns the current content of the link register (lr)
+ */
+static inline void cpu_print_last_instruction(void)
+{
+    register uint32_t *lr_ptr;
+    __asm__ __volatile__("mov %0, lr" : "=r"(lr_ptr));
+    printf("%p", lr_ptr);
+}
 
 #ifdef __cplusplus
 }

--- a/cpu/lpc2387/include/cpu.h
+++ b/cpu/lpc2387/include/cpu.h
@@ -16,6 +16,7 @@
  * @{
  */
 
+#include <stdio.h>
 #include <stdbool.h>
 #include "lpc2387.h"
 #include "arm_cpu.h"
@@ -40,6 +41,16 @@ bool install_irq(int IntNumber, void (*HandlerAddr)(void), int Priority);
 #ifdef MODULE_PERIPH
 void gpio_init_ports(void);
 #endif
+
+/**
+ * @brief   Returns the current content of the link register (lr)
+ */
+static inline void cpu_print_last_instruction(void)
+{
+    register uint32_t *lr_ptr;
+    __asm__ __volatile__("mov %0, lr" : "=r"(lr_ptr));
+    printf("%p", lr_ptr);
+}
 
 #ifdef __cplusplus
 }

--- a/cpu/lpc2387/include/cpu.h
+++ b/cpu/lpc2387/include/cpu.h
@@ -43,7 +43,7 @@ void gpio_init_ports(void);
 #endif
 
 /**
- * @brief   Returns the current content of the link register (lr)
+ * @brief   Prints the current content of the link register (lr)
  */
 static inline void cpu_print_last_instruction(void)
 {

--- a/cpu/msp430-common/include/cpu.h
+++ b/cpu/msp430-common/include/cpu.h
@@ -167,6 +167,16 @@ inline void __restore_context(unsigned int irqen)
  */
 void msp430_cpu_init(void);
 
+/**
+ * @brief   Returns the current content of the link register (lr)
+ *
+ * @todo:   Not supported
+ */
+static inline void cpu_print_last_instruction(void)
+{
+    printf("n/a");
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/msp430-common/include/cpu.h
+++ b/cpu/msp430-common/include/cpu.h
@@ -168,7 +168,7 @@ inline void __restore_context(unsigned int irqen)
 void msp430_cpu_init(void);
 
 /**
- * @brief   Returns the current content of the link register (lr)
+ * @brief   Print the last instruction's address
  *
  * @todo:   Not supported
  */

--- a/cpu/native/include/cpu.h
+++ b/cpu/native/include/cpu.h
@@ -20,6 +20,8 @@
 #ifndef _CPU_H
 #define _CPU_H
 
+#include <stdio.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -27,6 +29,16 @@ extern "C" {
 /* TODO: remove once these have been removed from RIOT: */
 void dINT(void);
 void eINT(void);
+
+/**
+ * @brief   Returns the current content of the link register (lr)
+ */
+static inline void cpu_print_last_instruction(void)
+{
+    void *p;
+    __asm__("1: mov 1b, %0" : "=r" (p));
+    printf("%p", p);
+}
 
 #ifdef __cplusplus
 }

--- a/cpu/native/include/cpu.h
+++ b/cpu/native/include/cpu.h
@@ -31,7 +31,7 @@ void dINT(void);
 void eINT(void);
 
 /**
- * @brief   Returns the current content of the link register (lr)
+ * @brief   Prints the last instruction's address
  */
 static inline void cpu_print_last_instruction(void)
 {

--- a/cpu/stm32f3/periph/i2c.c
+++ b/cpu/stm32f3/periph/i2c.c
@@ -539,7 +539,7 @@ void I2C_0_ERR_ISR(void)
     if (state & I2C_ISR_ALERT) {
         DEBUG("SMBALERT\n");
     }
-    core_panic(0x0,"I2C FAULT");
+    core_panic(PANIC_GENERAL_ERROR, "I2C FAULT");
 }
 #endif /* I2C_0_EN */
 

--- a/cpu/x86/include/cpu.h
+++ b/cpu/x86/include/cpu.h
@@ -133,6 +133,16 @@ void x86_init_board(void);
  */
 bool x86_get_memory_region(uint64_t *start, uint64_t *len, unsigned long *cnt);
 
+/**
+ * @brief   Returns the current content of the link register (lr)
+ *
+ * @todo:   Not supported
+ */
+static inline void cpu_print_last_instruction(void)
+{
+    printf("n/a");
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/x86/include/cpu.h
+++ b/cpu/x86/include/cpu.h
@@ -134,7 +134,7 @@ void x86_init_board(void);
 bool x86_get_memory_region(uint64_t *start, uint64_t *len, unsigned long *cnt);
 
 /**
- * @brief   Returns the current content of the link register (lr)
+ * @brief   Prints the last instruction's address
  *
  * @todo:   Not supported
  */

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -170,7 +170,7 @@ void kw2xrf_set_sequence(kw2xrf_t *dev, kw2xrf_physeq_t seq)
         /* At 10MHz SPI-Clock, 40000 should be in the magnitue of 0.1s */
         if (max_tries == 40000) {
             DEBUG("kw2xrf_error: device does not finish sequence\n");
-            core_panic(-EBUSY, "kw2xrf_error: device does not finish sequence");
+            core_panic(PANIC_GENERAL_ERROR, "kw2xrf_error: device does not finish sequence");
         }
 
 #endif
@@ -397,7 +397,7 @@ int kw2xrf_init(kw2xrf_t *dev, spi_t spi, spi_speed_t spi_speed,
     kw2xrf_spi_init(spi, spi_speed, cs_pin);
 
     if (kw2xrf_on(dev) != 0) {
-        core_panic(0x42, "Could not start MKW2XD radio transceiver");
+        core_panic(PANIC_GENERAL_ERROR, "Could not start MKW2XD radio transceiver");
     }
 
     /* General initialization of interrupt sources.

--- a/sys/cpp11-compat/cppsupport.cpp
+++ b/sys/cpp11-compat/cppsupport.cpp
@@ -42,7 +42,7 @@ void *__dso_handle __attribute__((weak)) = NULL;
  */
 extern "C" void __cxa_pure_virtual ()
 {
-    core_panic(123, "PURE VIRTUAL CALL");
+    core_panic(PANIC_GENERAL_ERROR, "PURE VIRTUAL CALL");
 }
 
 /**
@@ -81,7 +81,7 @@ namespace __gnu_cxx {
  */
 void __verbose_terminate_handler()
 {
-    core_panic(123, "UNHANDLED C++ EXCEPTION");
+    core_panic(PANIC_GENERAL_ERROR, "UNHANDLED C++ EXCEPTION");
 }
 } /* namespace __gnu_cxx */
 


### PR DESCRIPTION
How about saving some memory for assertions? This PR saves about 1.4kB ROM with `DEVELHELP` enabled on iotlab-m3 building gnrc_networking example.

Additionally this PR unifies the panic values in a header within core.