### PR TITLE
tests: Adding test for thread_create

### DIFF
--- a/tests/thread_flood/Makefile
+++ b/tests/thread_flood/Makefile
@@ -1,0 +1,6 @@
+APPLICATION = thread_flood
+include ../Makefile.tests_common
+
+DISABLE_MODULE += auto_init
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/thread_flood/main.c
+++ b/tests/thread_flood/main.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief Thread flooding test.
+ *
+ * Spawns sleeping threads till the scheduler's capacity is exhausted.
+ *
+ * @author  Andreas "Paul" Pauli <andreas.pauli@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include "thread.h"
+#include "lpm.h"
+
+/* One stack for all threads. DON'T TRY THIS AT HOME!! */
+static char dummy_stack[THREAD_STACKSIZE_DEFAULT];
+
+static void *thread_func(void *arg)
+{
+    return arg;
+}
+
+int main(void)
+{
+    kernel_pid_t thr_id = KERNEL_PID_UNDEF;
+
+    puts("Start spawning\n");
+    do {
+        thr_id = thread_create(
+            dummy_stack, sizeof(dummy_stack),
+            THREAD_PRIORITY_MAIN - 1,
+            THREAD_CREATE_SLEEPING | THREAD_CREATE_STACKTEST,
+            thread_func, NULL, "dummy");
+    } while (-EOVERFLOW != thr_id);
+
+    if (-EOVERFLOW == thr_id) {
+        puts("Thread creation successful aborted\n");
+    }
+    lpm_set(LPM_OFF);
+    return 0;
+}

--- a/tests/thread_flood/tests/test_thread.py
+++ b/tests/thread_flood/tests/test_thread.py
@@ -1,0 +1,8 @@
+#!/usr/bin/python
+
+import pexpect
+
+term = pexpect.spawn("make term")
+
+term.expect('Start spawning\r\n')
+term.expect('Thread creation successful aborted\r\n')


### PR DESCRIPTION
Adding a test for thread creation.
More precise, for prevent thread creation if maximum of possible threads is reached.
I needed this saturation for creating test conditions in other black-box tests. I thought this also might be an useful *stand alone* test.

The shared use of stack memory for all dummy threads is intentionally, just to keep memory usage low and keep things simple.
Because the threads are just there to sleep after creation and drive the pid counter up this should do no harm in this "sandbox".