### PR TITLE
rpl: allow 0 as instance id

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -435,11 +435,6 @@ gnrc_rpl_dodag_t *gnrc_rpl_root_dodag_init(uint8_t instance_id, ipv6_addr_t *dod
     gnrc_rpl_instance_t *inst = NULL;
     gnrc_rpl_dodag_t *dodag = NULL;
 
-    if (instance_id == 0) {
-        DEBUG("RPL: instance id (%d) must be a positive number greater than zero\n", instance_id);
-        return NULL;
-    }
-
     if (gnrc_ipv6_netif_find_by_addr(&configured_addr, dodag_id) == KERNEL_PID_UNDEF) {
         DEBUG("RPL: no IPv6 address configured to match the given dodag id: %s\n",
               ipv6_addr_to_str(addr_str, dodag_id, sizeof(addr_str)));

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -45,11 +45,6 @@ int _gnrc_rpl_dodag_root(char *arg1, char *arg2)
     uint8_t instance_id = (uint8_t) atoi(arg1);
     ipv6_addr_t dodag_id;
 
-    if (instance_id == 0) {
-        puts("<instance_id> must be a positive number greater than zero");
-        return 1;
-    }
-
     if (ipv6_addr_from_str(&dodag_id, arg2) == NULL) {
         puts("<dodag_id> must be a valid IPv6 address");
         return 1;


### PR DESCRIPTION
This PR makes `0` possible as an instance id.
I have no idea, why I prohibited this before..