### PR TITLE
unittests: example for directory tree

### DIFF
--- a/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-01_init/Makefile
+++ b/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-01_init/Makefile
@@ -1,0 +1,18 @@
+APPLICATION = ipv6
+#include ../Makefile.tests_common
+BOARD ?= native
+RIOTBASE ?= $(CURDIR)/../../../../../../../../
+QUIET ?= 1
+
+USEMODULE += embunit
+
+USEMODULE += gnrc_ipv6
+
+USEMODULE += gnrc_nettest
+
+DISABLE_MODULE = auto_init
+
+CFLAGS += -DTEST_SUITES
+
+#include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.include

--- a/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-01_init/main.c
+++ b/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-01_init/main.c
@@ -22,7 +22,6 @@
 
 #include "net/gnrc/nettest.h"
 #include "embUnit.h"
-#include "msg.h"
 
 #include "../tests-ipv6.h"
 
@@ -31,8 +30,7 @@ int main(void)
 
     /* Preparing minimal runtime environment for modules using netapi. */
 
-//    if (gnrc_nettest_init() < 0) {
-    if (0) {
+    if (gnrc_nettest_init() < 0) {
         puts("Error initializing nettest thread");
         return 1;
     }

--- a/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-01_init/main.c
+++ b/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-01_init/main.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015 Andreas "Paul" Pauli <andreas.pauli@haw-hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests-ipv6
+ * @{
+ *
+ * @file
+ * @brief       Test application for gnrc_ipv6 network
+ *
+ * @author      Andreas "Paul" Pauli <andreas.pauli@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "net/gnrc/nettest.h"
+#include "embUnit.h"
+#include "msg.h"
+
+#include "../tests-ipv6.h"
+
+int main(void)
+{
+
+    /* Preparing minimal runtime environment for modules using netapi. */
+
+//    if (gnrc_nettest_init() < 0) {
+    if (0) {
+        puts("Error initializing nettest thread");
+        return 1;
+    }
+
+
+    TESTS_START();
+    TESTS_RUN(ipv6_tests());
+    TESTS_END();
+
+    return 0;
+}

--- a/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-01_init/tests-ipv6.c
+++ b/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-01_init/tests-ipv6.c
@@ -42,14 +42,11 @@ static void tear_down(void)
  */
 
 /**
- * @brief Tests normal case.
+ * @brief Tests normal case of successful init.
  *
  * @pre No IPV6 thread has been initialized.
  * @post One single IPV6 thread has been initialized.
  *
- * ENHANCE:
- *   - Provide check for existece of thread.
- *   - Provide check if pid didn't exist before..
  */
 static void test_ipv6_init__first(void)
 {
@@ -64,13 +61,11 @@ static void test_ipv6_init__first(void)
 }
 
 /**
- * @brief Tests check for error condition 2
+ * @brief Test check for prevetion of multiple module instances.
  *
  * @pre IPV6 thread has already been initialized.
  * @post No new IPV6 thread has already been initialized.
  *
- * ENHANCE:
- *   - Provide check for uniqueness of first thread.
  */
 static void test_ipv6_init__uniq(void)
 {
@@ -78,7 +73,7 @@ static void test_ipv6_init__uniq(void)
     kernel_pid_t retval = KERNEL_PID_UNDEF;
 
     /*
-     * ATM the thread has been initialized in test_*__uniq.
+     * ATM the thread has been initialized in test_ipv6_init__first.
      */
     retval = gnrc_ipv6_init();
 

--- a/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-01_init/tests-ipv6.c
+++ b/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-01_init/tests-ipv6.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2015 Andreas "Paul" Pauli <andreas.pauli@haw-hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests-ipv6
+ * @{
+ *
+ * @file
+ */
+#include <errno.h>
+#include <stdint.h>
+
+#include "embUnit/embUnit.h"
+
+#include "kernel_types.h"
+#include "byteorder.h"
+
+#include "net/gnrc/ipv6.h"
+
+#include "../tests-ipv6.h"
+
+
+static void set_up(void)
+{
+    ;
+}
+
+
+static void tear_down(void)
+{
+    ;
+}
+
+
+/*
+ * Tests for function "gnrc_ipv6_init"
+ */
+
+/**
+ * @brief Tests normal case.
+ *
+ * @pre No IPV6 thread has been initialized.
+ * @post One single IPV6 thread has been initialized.
+ *
+ * ENHANCE:
+ *   - Provide check for existece of thread.
+ *   - Provide check if pid didn't exist before..
+ */
+static void test_ipv6_init__first(void)
+{
+    const char *errstr = "IPV6 not initialized";
+    kernel_pid_t retval = KERNEL_PID_UNDEF;
+
+    retval = gnrc_ipv6_init();
+
+    TEST_ASSERT_MESSAGE((KERNEL_PID_FIRST <= retval) &&
+                        (KERNEL_PID_LAST  >= retval),
+                        errstr);
+}
+
+/**
+ * @brief Tests check for error condition 2
+ *
+ * @pre IPV6 thread has already been initialized.
+ * @post No new IPV6 thread has already been initialized.
+ *
+ * ENHANCE:
+ *   - Provide check for uniqueness of first thread.
+ */
+static void test_ipv6_init__uniq(void)
+{
+    const char *errstr = "IPV6 initialized twice";
+    kernel_pid_t retval = KERNEL_PID_UNDEF;
+
+    /*
+     * ATM the thread has been initialized in test_*__uniq.
+     */
+    retval = gnrc_ipv6_init();
+
+    TEST_ASSERT_MESSAGE( -EEXIST == retval, errstr);
+}
+
+
+Test *ipv6_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_ipv6_init__first),
+                        new_TestFixture(test_ipv6_init__uniq)
+    };
+
+    EMB_UNIT_TESTCALLER(ipv6_tests, set_up, tear_down, fixtures);
+
+    return (Test *)&ipv6_tests;
+}
+/** @} */

--- a/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-02_init/Makefile
+++ b/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-02_init/Makefile
@@ -1,0 +1,18 @@
+APPLICATION = ipv6
+#include ../Makefile.tests_common
+BOARD ?= native
+RIOTBASE ?= $(CURDIR)/../../../../../../../../
+QUIET ?= 1
+
+USEMODULE += embunit
+
+USEMODULE += gnrc_ipv6
+
+USEMODULE += gnrc_nettest
+
+DISABLE_MODULE = auto_init
+
+CFLAGS += -DTEST_SUITES
+
+#include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.include

--- a/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-02_init/main.c
+++ b/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-02_init/main.c
@@ -22,7 +22,6 @@
 
 #include "net/gnrc/nettest.h"
 #include "embUnit.h"
-#include "msg.h"
 
 #include "../tests-ipv6.h"
 

--- a/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-02_init/main.c
+++ b/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-02_init/main.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2015 Andreas "Paul" Pauli <andreas.pauli@haw-hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests-ipv6
+ * @{
+ *
+ * @file
+ * @brief       Test application for gnrc_ipv6 network
+ *
+ * @author      Andreas "Paul" Pauli <andreas.pauli@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "net/gnrc/nettest.h"
+#include "embUnit.h"
+#include "msg.h"
+
+#include "../tests-ipv6.h"
+
+int main(void)
+{
+
+    /* Preparing minimal runtime environment for modules using netapi. */
+    if (gnrc_nettest_init() < 0) {
+        puts("Error initializing nettest thread");
+        return 1;
+    }
+
+
+    TESTS_START();
+    TESTS_RUN(ipv6_tests());
+    TESTS_END();
+
+    return 0;
+}

--- a/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-02_init/tests-ipv6.c
+++ b/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-02_init/tests-ipv6.c
@@ -42,7 +42,7 @@ static void tear_down(void)
  */
 
 /**
- * Tests recognition for error condition 2.
+ * Tests check if a free pid is available for module.
  * Deferred!
  *
  * @pre: No IPV6 thread has been initialized and MAXTHREADS threads already
@@ -50,7 +50,6 @@ static void tear_down(void)
  * @post: No IPV6 thread has been initialized.
  *
  * @todo
- *   - Remove thread from former test.
  *   - Controlled creation of precondition.
  */
 static void test_ipv6_init__maxthr(void)

--- a/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-02_init/tests-ipv6.c
+++ b/tests/automated/sys/net/gnrc/network_layer/ipv6/suite-02_init/tests-ipv6.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2015 Andreas "Paul" Pauli <andreas.pauli@haw-hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests-ipv6
+ * @{
+ *
+ * @file
+ */
+#include <errno.h>
+#include <stdint.h>
+
+#include "embUnit/embUnit.h"
+
+#include "kernel_types.h"
+#include "byteorder.h"
+
+#include "net/gnrc/ipv6.h"
+
+#include "../tests-ipv6.h"
+
+
+static void set_up(void)
+{
+    ;
+}
+
+
+static void tear_down(void)
+{
+    ;
+}
+
+
+/*
+ * Tests for function "gnrc_ipv6_init"
+ */
+
+/**
+ * Tests recognition for error condition 2.
+ * Deferred!
+ *
+ * @pre: No IPV6 thread has been initialized and MAXTHREADS threads already
+ *       exist.
+ * @post: No IPV6 thread has been initialized.
+ *
+ * @todo
+ *   - Remove thread from former test.
+ *   - Controlled creation of precondition.
+ */
+static void test_ipv6_init__maxthr(void)
+{
+    const char *errstr = "!Test insufficient.!";
+    kernel_pid_t retval = KERNEL_PID_UNDEF;
+
+    retval = gnrc_ipv6_init();
+
+    TEST_ASSERT_MESSAGE(-EOVERFLOW == retval, errstr);
+}
+
+
+Test *ipv6_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_ipv6_init__maxthr),
+    };
+
+    EMB_UNIT_TESTCALLER(ipv6_tests, set_up, tear_down, fixtures);
+
+    return (Test *)&ipv6_tests;
+}
+/** @} */

--- a/tests/automated/sys/net/gnrc/network_layer/ipv6/tests-ipv6.h
+++ b/tests/automated/sys/net/gnrc/network_layer/ipv6/tests-ipv6.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2015 Andreas "Paul" Pauli <andreas.pauli@haw-hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup  tests-ipv6 Testing IPV6 module
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the `gnrc_ipv6` module
+ *
+ * @author      Andreas "Paul" Pauli <andreas.pauli@haw-hamburg.de>
+ */
+#ifndef TESTS_IPV6_H_
+#define TESTS_IPV6_H_
+
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Collects all test cases of this test suite.
+ */
+Test* ipv6_tests(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_IPV6_H_ */
+/** @} */


### PR DESCRIPTION
This PR is intended as an example for my proposal in #3363.
The main idea was to place module specific testsuites in a directory tree that mirrors the source tree.

Some remarks:
- The testfunctions are derived from #3349 where the requirement to re-init the runtime during a test suite came up. I just took those tests that document the case where different tests can't be run in the same os instance.
- The naming schemes for paths and functions under the module directory are arbitrary examples. and may be discussed. They should only show how to deal with the need of distinct testsuites (resulting in runtimes) for the same interface function just as for different functions.
- As a result of organizing the testsuites in such a structure they will be decoupled from the automated "build, flash and run" at first. @authmillenon has pointed me to #2231 and I will see if I can find synergies.
