### PR TITLE
Simple duty cycling 802.15.4 MAC protocol

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -504,16 +504,17 @@ ifneq (,$(filter gnrc_pktbuf_%, $(USEMODULE)))
   USEMODULE += gnrc_pktbuf # make MODULE_GNRC_PKTBUF macro available for all implementations
 endif
 
-ifneq (,$(filter gnrc_netdev2,$(USEMODULE)))
-  USEMODULE += netopt
-endif
-
 ifneq (,$(filter netstats_%, $(USEMODULE)))
   USEMODULE += netstats
 endif
 
 ifneq (,$(filter gnrc_lwmac,$(USEMODULE)))
   USEMODULE += xtimer
+  USEMODULE += gnrc_netdev2
+endif
+
+ifneq (,$(filter gnrc_netdev2,$(USEMODULE)))
+  USEMODULE += netopt
 endif
 
 ifneq (,$(filter pthread,$(USEMODULE)))

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -512,6 +512,10 @@ ifneq (,$(filter netstats_%, $(USEMODULE)))
   USEMODULE += netstats
 endif
 
+ifneq (,$(filter gnrc_lwmac,$(USEMODULE)))
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter pthread,$(USEMODULE)))
     USEMODULE += xtimer
     USEMODULE += timex

--- a/boards/airfy-beacon/dist/openocd.cfg
+++ b/boards/airfy-beacon/dist/openocd.cfg
@@ -3,3 +3,4 @@ transport select hla_swd
 
 set WORKAREASIZE 0x4000
 source [find target/nrf51.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/ek-lm4f120xl/dist/openocd.cfg
+++ b/boards/ek-lm4f120xl/dist/openocd.cfg
@@ -15,3 +15,4 @@ transport select hla_jtag
 set WORKAREASIZE 0x8000
 set CHIPNAME lm4f120h5qr
 source [find target/stellaris.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/fox/dist/openocd.cfg
+++ b/boards/fox/dist/openocd.cfg
@@ -13,3 +13,4 @@ jtag_ntrst_delay 100
 reset_config trst_and_srst
 
 source [find target/stm32f1x.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/frdm-k64f/dist/openocd.cfg
+++ b/boards/frdm-k64f/dist/openocd.cfg
@@ -48,3 +48,4 @@ adapter_khz 1000
 $_TARGETNAME configure -event gdb-attach {
   halt
 }
+$_TARGETNAME configure -rtos auto

--- a/boards/iotlab-m3/dist/openocd.cfg
+++ b/boards/iotlab-m3/dist/openocd.cfg
@@ -6,3 +6,4 @@ ftdi_layout_signal nTRST -data 0x0800
 ftdi_layout_signal nSRST -data 0x0400
 
 source [find target/stm32f1x.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/limifrog-v1/dist/openocd.cfg
+++ b/boards/limifrog-v1/dist/openocd.cfg
@@ -3,3 +3,4 @@ transport select hla_swd
 
 set WORKAREASIZE 0x2800
 source [find target/stm32l1.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/msbiot/dist/openocd.cfg
+++ b/boards/msbiot/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/stm32f4discovery.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/nucleo-f091/dist/openocd.cfg
+++ b/boards/nucleo-f091/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/st_nucleo_f0.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/nucleo-f303/dist/openocd.cfg
+++ b/boards/nucleo-f303/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/st_nucleo_f3.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/nucleo-f334/dist/openocd.cfg
+++ b/boards/nucleo-f334/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/st_nucleo_f3.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/nucleo-l1/dist/openocd.cfg
+++ b/boards/nucleo-l1/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/st_nucleo_l1.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/pba-d-01-kw2x/dist/openocd.cfg
+++ b/boards/pba-d-01-kw2x/dist/openocd.cfg
@@ -69,3 +69,4 @@ if {![using_hla]} {
 $_TARGETNAME configure -event reset-init {
     adapter_khz 24000
 }
+$_TARGETNAME configure -rtos auto

--- a/boards/saml21-xpro/dist/openocd.cfg
+++ b/boards/saml21-xpro/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/atmel_saml21_xplained_pro.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/samr21-xpro/Makefile.dep
+++ b/boards/samr21-xpro/Makefile.dep
@@ -1,5 +1,6 @@
 ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
   USEMODULE += at86rf233
+  USEMODULE += random
   USEMODULE += gnrc_lwmac
 endif
 

--- a/boards/samr21-xpro/Makefile.dep
+++ b/boards/samr21-xpro/Makefile.dep
@@ -1,5 +1,6 @@
 ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
   USEMODULE += at86rf233
+  USEMODULE += gnrc_lwmac
 endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))

--- a/boards/samr21-xpro/dist/openocd.cfg
+++ b/boards/samr21-xpro/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/atmel_samr21_xplained_pro.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/stm32f0discovery/dist/openocd.cfg
+++ b/boards/stm32f0discovery/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/stm32f0discovery.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/stm32f3discovery/dist/openocd.cfg
+++ b/boards/stm32f3discovery/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/stm32f3discovery.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/stm32f4discovery/dist/openocd.cfg
+++ b/boards/stm32f4discovery/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/stm32f4discovery.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/yunjia-nrf51822/dist/openocd.cfg
+++ b/boards/yunjia-nrf51822/dist/openocd.cfg
@@ -3,3 +3,4 @@ transport select hla_swd
 
 set WORKAREASIZE 0x4000
 source [find target/nrf51.cfg]
+$_TARGETNAME configure -rtos auto

--- a/core/sched.c
+++ b/core/sched.c
@@ -53,6 +53,17 @@ volatile kernel_pid_t sched_active_pid = KERNEL_PID_UNDEF;
 clist_node_t sched_runqueues[SCHED_PRIO_LEVELS];
 static uint32_t runqueue_bitcache = 0;
 
+/* Needed by OpenOCD to read sched_threads */
+__attribute__((used)) __attribute__((section (".openocd")))
+uint8_t max_threads = sizeof(sched_threads) / sizeof(thread_t*);
+
+#ifdef DEVELHELP
+/* OpenOCD can't determine struct offsets and additionally this member is only
+ * available if compiled with DEVELHELP */
+__attribute__((used)) __attribute__((section (".openocd")))
+uint8_t _tcb_name_offset = offsetof(thread_t, name);
+#endif
+
 #ifdef MODULE_SCHEDSTATISTICS
 static void (*sched_cb) (uint32_t timestamp, uint32_t value) = NULL;
 schedstat sched_pidlist[KERNEL_PID_LAST + 1];

--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -117,6 +117,7 @@ SECTIONS
         _srelocate = .;
         *(.ramfunc .ramfunc.*);
         *(.data .data.*);
+        KEEP (*(.openocd .openocd.*))
         . = ALIGN(4);
         _erelocate = .;
     } > ram

--- a/cpu/samd21/lpm_arch.c
+++ b/cpu/samd21/lpm_arch.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 Saurabh Singh
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,40 +15,112 @@
  * @brief       Implementation of the kernels power management interface
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ * @author      Saurabh Singh <saurabh@cezy.co>
  *
  * @}
  */
-
+#include "cpu.h"
 #include "arch/lpm_arch.h"
+
+enum system_sleepmode {
+    /**
+     *  Idle 0 mode.
+     *  Potential Wake Up sources: Synchronous(APB, AHB), asynchronous.
+     */
+    SYSTEM_SLEEPMODE_IDLE_0,
+    /**
+     *  Idle 1 mode.
+     *  Potential Wake Up sources: Synchronous (APB), asynchronous
+     */
+    SYSTEM_SLEEPMODE_IDLE_1,
+    /**
+     *  Idle 2 mode.
+     *  Potential Wake Up sources: Asynchronous
+     */
+    SYSTEM_SLEEPMODE_IDLE_2,
+    /**
+     * Standby mode.
+     * Potential Wake Up sources: Asynchronous
+     */
+    SYSTEM_SLEEPMODE_STANDBY,
+};
+
+static enum lpm_mode current_mode;
+
+static void start_lpm(void);
+
 
 void lpm_arch_init(void)
 {
-    // TODO
+    current_mode = LPM_ON;
 }
 
 enum lpm_mode lpm_arch_set(enum lpm_mode target)
 {
-    // TODO
-    return 0;
+enum lpm_mode last_mode = current_mode;
+
+    switch (target) {
+        case LPM_ON:                    /* Run mode */
+            current_mode = LPM_ON;
+            break;
+        case LPM_IDLE:                  /* Sleep mode Idle 0 */
+            current_mode = LPM_IDLE;
+            /* Idle Mode 0 */
+            SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
+            PM->SLEEP.reg = SYSTEM_SLEEPMODE_IDLE_0;
+            start_lpm();
+            break;
+        case LPM_SLEEP:                 /* Sleep mode Idle 1 */
+            current_mode = LPM_SLEEP;
+             /* Idle Mode 1 */
+            SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
+            PM->SLEEP.reg = SYSTEM_SLEEPMODE_IDLE_1;
+            start_lpm();
+            break;
+        case LPM_POWERDOWN:             /* Sleep mode Idle 2 */
+            /* Idle Mode 2 */
+            current_mode = LPM_POWERDOWN;
+            SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
+            PM->SLEEP.reg = SYSTEM_SLEEPMODE_IDLE_2;
+            start_lpm();
+            break;
+        case LPM_OFF:                   /* Standby Mode - Potential Wake Up sources: Asynchronous */
+            current_mode = LPM_OFF;
+            /* Standby Mode */
+            SCB->SCR |=  SCB_SCR_SLEEPDEEP_Msk;
+            start_lpm();
+            break;
+        default:
+            break;
+    }
+
+    return last_mode;
+}
+
+static void start_lpm(void)
+{
+    /* Executes a device DSB (Data Synchronization Barrier) */
+    __DSB();
+    /* Enter standby mode */
+    __WFI();
 }
 
 enum lpm_mode lpm_arch_get(void)
 {
-    // TODO
-    return 0;
+    return current_mode;
 }
 
 void lpm_arch_awake(void)
 {
-    // TODO
+    if (current_mode == LPM_SLEEP) {
+        /* Re-init */
+        cpu_init();
+    }
+    current_mode = LPM_ON;
 }
 
-void lpm_arch_begin_awake(void)
-{
-    // TODO
-}
+/** Not needed */
+void lpm_arch_begin_awake(void){ }
 
-void lpm_arch_end_awake(void)
-{
-    // TODO
-}
+/** Not needed */
+void lpm_arch_end_awake(void){ }

--- a/dist/tools/wireshark-lwmac-dissector/README.md
+++ b/dist/tools/wireshark-lwmac-dissector/README.md
@@ -1,0 +1,10 @@
+Wireshark Dissector for LwMAC protocol
+======================================
+
+Usually dissectors are stored in `/usr/share/wireshark`, so copy `lwmac.lua` and append
+
+```lua
+dofile(DATA_DIR.."lwmac.lua")
+```
+
+to `init.lua`. Make sure that Lua scripts are not disabled: `disable_lua = false`

--- a/dist/tools/wireshark-lwmac-dissector/lwmac.lua
+++ b/dist/tools/wireshark-lwmac-dissector/lwmac.lua
@@ -1,0 +1,105 @@
+-- Author: Daniel Krebs <github@daniel-krebs.net>
+-- Date: 2016-01-18
+--
+
+local lwmac = Proto("lwmac", "LwMAC dissector")
+
+local FRAME_WR          = 0x01
+local FRAME_WA          = 0x02
+local FRAME_DATA        = 0x03
+local FRAME_BROADCAST   = 0x04
+
+local frame_str = {
+    [FRAME_WR]          = "Wakeup Request (WR)",
+    [FRAME_WA]          = "Wakeup Acknowledge (WA)",
+    [FRAME_DATA]        = "Unicast data (DATA)",
+    [FRAME_BROADCAST]   = "Broadcast data (BROADCAST)"
+}
+
+function dissector(tvb, pinfo, tree)
+    
+    if tvb:len() < 1 then
+        print("Packet too short (0 Byte)\n")
+        return
+    end
+
+    -- Index in buffer for next field to parse
+    index = 0
+
+    -- Length of next field to parse
+    count = 0
+
+    
+    subtree = tree:add(lwmac, tvb(), "LwMAC protocol")
+
+    -- Parse header (currently only frame type)
+    count = 1
+    frame_type = tvb(index, count):uint()
+
+    subtree:add(tvb(index, count), "Type: " .. frame_str[frame_type])
+    index = index + count
+
+    -- Display frame type in 'info' field    
+    pinfo.cols.info = frame_str[frame_type]
+
+
+    if frame_type == FRAME_WR then 
+        -- This is WR, nothing to do
+    elseif frame_type == FRAME_WA then
+        -- Parse L2 address
+        count = 8
+        l2_addr = tvb(index, count):bytes()
+
+        -- assemble L2 address string
+        out = ""
+        for i = 0, l2_addr:len()-1 do
+            out = out .. tostring(l2_addr:subset(i, 1))
+            if i < (l2_addr:len()-1) then
+                out = out .. ":"
+            end
+        end
+
+        subtree:add(tvb(index, count), "Destination: " .. out)        
+        index = index + count
+    elseif frame_type == FRAME_DATA then
+        -- This is DATA, nothing to do
+    elseif frame_type == FRAME_BROADCAST then
+        -- Parse sequence number                
+        count = 1
+        seq = tvb(index, count)
+
+        subtree:add(seq, string.format("Sequence number: %d", seq:uint()))
+        index = index + count
+    else
+        print("Unsupported frame type: " .. frame_type)
+    end
+    
+    subtree:set_len(index)
+    pinfo.cols.protocol = "LwMAC"
+
+    if frame_type == FRAME_DATA or frame_type == FRAME_BROADCAST then
+        -- Call dissectors for nested payload
+        local dis = Dissector.get("6lowpan")
+        dis(tvb(index):tvb(), pinfo, tree)
+    end
+    
+    return index
+end
+lwmac.dissector = dissector
+
+-- Register as a heuristic dissector, that gets called for all wpan
+-- packets. We'd want to pass foo.dissector here, but it turns out
+-- register_heuristic needs an actual function. Passing a lambda
+-- doesn't work (since calling foo.dissector(...) discards the
+-- return value), so instead we define the dissector function in two
+-- steps above, so we can directly access the real function here.
+-- See also https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=10695
+lwmac:register_heuristic("wpan", dissector)
+
+-- Register as the dissector for panid 3. Will be automatically
+-- called for packets with panid 3 (picking a panid is mandatory,
+-- see https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=10696).
+-- Can additionally be manually selected using the "Decode as..."
+-- option.
+table = DissectorTable.get("wpan.panid")
+table:add(26, lwmac)

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -58,7 +58,7 @@ ifneq (,$(filter $(BOARD),$(BOARD_PROVIDES_NETIF)))
 endif
 
 FEATURES_OPTIONAL += config
-FEATURES_OPTIONAL += periph_rtc
+#FEATURES_OPTIONAL += periph_rtc
 
 ifneq (,$(filter msb-430,$(BOARD)))
   USEMODULE += sht11

--- a/sys/auto_init/netif/auto_init_at86rf2xx.c
+++ b/sys/auto_init/netif/auto_init_at86rf2xx.c
@@ -22,6 +22,7 @@
 #include "board.h"
 #include "net/gnrc/netdev2.h"
 #include "net/gnrc/netdev2/ieee802154.h"
+#include "net/gnrc/lwmac/lwmac.h"
 #include "net/gnrc.h"
 
 #include "at86rf2xx.h"
@@ -58,10 +59,10 @@ void auto_init_at86rf2xx(void)
             DEBUG("Error initializing AT86RF2xx radio device!\n");
         }
         else {
-            gnrc_netdev2_init(_at86rf2xx_stacks[i],
+			gnrc_lwmac_init(_at86rf2xx_stacks[i],
                               AT86RF2XX_MAC_STACKSIZE,
                               AT86RF2XX_MAC_PRIO,
-                              "at86rf2xx",
+							  "at86rf2xx-lwmac",
                               &gnrc_adpt[i]);
         }
     }

--- a/sys/include/net/gnrc/lwmac/hdr.h
+++ b/sys/include/net/gnrc/lwmac/hdr.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2015 Daniel Krebs
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_lwmac Simplest possible MAC layer
+ * @ingroup     net
+ * @{
+ *
+ * @file
+ * @brief       Header definition LWMAC
+ *
+ * @author      Daniel Krebs <github@daniel-krebs.net>
+ */
+
+#ifndef GNRC_LWMAC_HDR_H_
+#define GNRC_LWMAC_HDR_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <net/gnrc/lwmac/lwmac.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/******************************************************************************/
+
+typedef struct {
+    uint8_t  addr[LWMAC_MAX_L2_ADDR_LEN];
+    uint8_t  len;
+} l2_addr_t;
+#define LWMAC_L2_ADDR_INIT      { {0}, 0 }
+
+/******************************************************************************/
+
+typedef enum {
+    FRAMETYPE_WR = 1,
+    FRAMETYPE_WA,
+    FRAMETYPE_DATA,
+    FRAMETYPE_BROADCAST,
+} lwmac_frame_type_t;
+
+/******************************************************************************/
+
+/**
+ * @brief   lwMAC header
+ */
+typedef struct __attribute__((packed)) {
+    lwmac_frame_type_t type; /**< type of frame */
+} lwmac_hdr_t;
+
+/**
+ * @brief   lwMAC WR frame
+ */
+typedef struct __attribute__((packed)) {
+    lwmac_hdr_t header;
+} lwmac_frame_wr_t;
+
+/**
+ * @brief   lwMAC WA frame
+ */
+typedef struct __attribute__((packed)) {
+    lwmac_hdr_t header;
+    l2_addr_t dst_addr; /**< WA is broadcast, so destination address needed */
+} lwmac_frame_wa_t;
+
+/**
+ * @brief   lwMAC broadcast data frame
+ */
+typedef struct __attribute__((packed)) {
+    lwmac_hdr_t header;
+    uint8_t seq_nr;
+} lwmac_frame_broadcast_t;
+
+/**
+ * @brief   lwMAC unicast data frame
+ */
+typedef struct __attribute__((packed)) {
+    lwmac_hdr_t header;
+} lwmac_frame_data_t;
+
+
+void lwmac_print_hdr(lwmac_hdr_t* hdr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GNRC_LWMAC_HDR_H_ */
+/** @} */

--- a/sys/include/net/gnrc/lwmac/hdr.h
+++ b/sys/include/net/gnrc/lwmac/hdr.h
@@ -31,7 +31,7 @@ extern "C" {
 /******************************************************************************/
 
 typedef struct {
-    uint8_t  addr[LWMAC_MAX_L2_ADDR_LEN];
+    uint8_t  addr[LWMAC_MAX_L2_ADDR_LEN] __attribute__ ((aligned (LWMAC_MAX_L2_ADDR_LEN)));
     uint8_t  len;
 } l2_addr_t;
 #define LWMAC_L2_ADDR_INIT      { {0}, 0 }

--- a/sys/include/net/gnrc/lwmac/hdr.h
+++ b/sys/include/net/gnrc/lwmac/hdr.h
@@ -31,7 +31,7 @@ extern "C" {
 /******************************************************************************/
 
 typedef struct {
-    uint8_t  addr[LWMAC_MAX_L2_ADDR_LEN] __attribute__ ((aligned (LWMAC_MAX_L2_ADDR_LEN)));
+    uint8_t  addr[LWMAC_MAX_L2_ADDR_LEN];// __attribute__ ((aligned (LWMAC_MAX_L2_ADDR_LEN)));
     uint8_t  len;
 } l2_addr_t;
 #define LWMAC_L2_ADDR_INIT      { {0}, 0 }
@@ -59,6 +59,7 @@ typedef struct __attribute__((packed)) {
  */
 typedef struct __attribute__((packed)) {
     lwmac_hdr_t header;
+    l2_addr_t dst_addr; /**< WR is broadcast, so destination address needed */
 } lwmac_frame_wr_t;
 
 /**
@@ -67,6 +68,7 @@ typedef struct __attribute__((packed)) {
 typedef struct __attribute__((packed)) {
     lwmac_hdr_t header;
     l2_addr_t dst_addr; /**< WA is broadcast, so destination address needed */
+    uint32_t current_phase;
 } lwmac_frame_wa_t;
 
 /**

--- a/sys/include/net/gnrc/lwmac/lwmac.h
+++ b/sys/include/net/gnrc/lwmac/lwmac.h
@@ -23,7 +23,7 @@
 #define GNRC_LWMAC_H
 
 #include <kernel_types.h>
-#include <net/gnrc/netdev.h>
+#include <net/gnrc/netdev2.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -168,7 +168,7 @@ extern "C" {
  * @return                  -ENODEV if *dev* is invalid
  */
 kernel_pid_t gnrc_lwmac_init(char *stack, int stacksize, char priority,
-                           const char *name, gnrc_netdev_t *dev);
+						   const char *name, gnrc_netdev2_t *dev);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/lwmac/lwmac.h
+++ b/sys/include/net/gnrc/lwmac/lwmac.h
@@ -89,6 +89,11 @@ extern "C" {
 #define LWMAC_BROADCAST_DURATION_US     ((LWMAC_WAKEUP_INTERVAL_US * 1100) / 1000)
 #endif
 
+/* Max link layer address length in bytes */
+#ifndef LWMAC_MAX_L2_ADDR_LEN
+#define LWMAC_MAX_L2_ADDR_LEN           (8U)
+#endif
+
 /* CSMA retries for DATA packet after WR->WA was successful. Too many retries
  * may timeout the receiver, refer LWMAC_DATA_DELAY_US */
 #ifndef LWMAC_DATA_CSMA_RETRIES
@@ -142,12 +147,6 @@ extern "C" {
 #ifndef LWMAC_RX_QUEUE_SIZE
 #define LWMAC_RX_QUEUE_SIZE             (8U)
 #endif
-
-/* Max link layer address length in bytes */
-#ifndef LWMAC_MAX_L2_ADDR_LEN
-#define LWMAC_MAX_L2_ADDR_LEN           (2U)
-#endif
-
 
 #define LWMAC_LPM_MASK					(1 << 17)
 

--- a/sys/include/net/gnrc/lwmac/lwmac.h
+++ b/sys/include/net/gnrc/lwmac/lwmac.h
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2015 Daniel Krebs
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_lwmac Simplest possible MAC layer
+ * @ingroup     net
+ * @brief       Lightweight MAC protocol that allows for duty cycling to save
+ *              energy.
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for the LWMAC protocol
+ *
+ * @author      Daniel Krebs <github@daniel-krebs.net>
+ */
+
+#ifndef GNRC_LWMAC_H
+#define GNRC_LWMAC_H
+
+#include <kernel_types.h>
+#include <net/gnrc/netdev.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Time between consecutive wakeups. This parameter governs power consumption,
+ * latency and throughput! */
+#ifndef LWMAC_WAKEUP_INTERVAL_US
+#define LWMAC_WAKEUP_INTERVAL_US        (100U * 1000)
+#endif
+
+/* Timeout to send the next WR in case no WA has been received during that
+ * time. It is referenced to the beginning of both WRs, but due to internal
+ * overhead, the exact spacing is slightly higher.
+ * The minimum possible value depends on the time it takes to completely
+ * send a WR with the given hardware (including processor) and data rate. */
+#ifndef LWMAC_TIME_BETWEEN_WR_US
+#define LWMAC_TIME_BETWEEN_WR_US        (7000U)
+#endif
+
+/* Time to idle between two successive BROADCAST packets, referenced to the
+ * start of the packet. The same limitation as for time-between-WR apply here. */
+#ifndef LWMAC_TIME_BETWEEN_BROADCAST_US
+#define LWMAC_TIME_BETWEEN_BROADCAST_US (LWMAC_TIME_BETWEEN_WR_US)
+#endif
+
+/* Receiver needs to support RX_START event in order to use time-between-WR
+ * as a sensible default here. Otherwise the duration of WRs as well as longest
+ * possible data broadcasts need to be taken into account. */
+#ifndef LWMAC_WAKEUP_DURATION_US
+#define LWMAC_WAKEUP_DURATION_US        (LWMAC_TIME_BETWEEN_WR_US * 2)
+#endif
+
+/* Start sending earlier then known phase. Therefore advance to beginning edge
+ * of destinations wakeup phase over time.
+ * Note: * RTT tick is ~30us @ 32 kHz timer
+ *       * there is a certain overhead from dispatching driver call until WR
+ *         will be really sent that may depend on hardware and driver
+ *         implementation
+ */
+#ifndef LWMAC_WR_BEFORE_PHASE_US
+#define LWMAC_WR_BEFORE_PHASE_US        (500U)
+#endif
+
+/* WR preparation overhead before it can be sent (higher with debugging output).
+ * LwMAC will wakeup earlier to prepare for synced WR sending. When preparation
+ * is done, it will busy wait (block the whole system) until the WR has been
+ * dispatched to the driver. */
+#ifndef LWMAC_WR_PREPARATION_US
+#define LWMAC_WR_PREPARATION_US         (7000U + LWMAC_WR_BEFORE_PHASE_US)
+#endif
+
+/* How long to wait after a WA for data to come in. It's enough to catch the
+ * beginning of the packet if the transceiver supports RX_STARTED event (this
+ * can be important for big packets). */
+#ifndef LWMAC_DATA_DELAY_US
+#define LWMAC_DATA_DELAY_US             (5000U)
+#endif
+
+/* How long BROADCAST packets will be sent to make sure every participant has
+ * received at least one packet. */
+#ifndef LWMAC_BROADCAST_DURATION_US
+#define LWMAC_BROADCAST_DURATION_US     ((LWMAC_WAKEUP_INTERVAL_US * 1100) / 1000)
+#endif
+
+/* CSMA retries for DATA packet after WR->WA was successful. Too many retries
+ * may timeout the receiver, refer LWMAC_DATA_DELAY_US */
+#ifndef LWMAC_DATA_CSMA_RETRIES
+#define LWMAC_DATA_CSMA_RETRIES         (3U)
+#endif
+
+/* CSMA retries for BROADCAST packet, too many may lead to running out of
+ * destinations wakup period. */
+#ifndef LWMAC_BROADCAST_CSMA_RETRIES
+#define LWMAC_BROADCAST_CSMA_RETRIES    (3U)
+#endif
+
+/* Store incoming BROADCAST packets until unicast transaction has finished.
+ * This buffer will also store the received DATA packets at the same time. */
+#ifndef LWMAC_DISPATCH_BUFFER_SIZE
+#define LWMAC_DISPATCH_BUFFER_SIZE      (4U)
+#endif
+
+
+/**
+ * @brief   Set the default message queue size for LWMAC layer
+ */
+#ifndef LWMAC_IPC_MSG_QUEUE_SIZE
+#define LWMAC_IPC_MSG_QUEUE_SIZE        (8U)
+#endif
+
+/**
+ * @brief   Count of parallel timeouts. Shouldn't needed to be changed.
+ */
+#ifndef LWMAC_TIMEOUT_COUNT
+#define LWMAC_TIMEOUT_COUNT             (3U)
+#endif
+
+/**
+ * @brief   Count of nodes in one-hop distance whose wakeup phase is tracked
+ */
+#ifndef LWMAC_NEIGHBOUR_COUNT
+#define LWMAC_NEIGHBOUR_COUNT           (8U)
+#endif
+
+/**
+ * @brief   Set the default queue size for packets coming from higher layers
+ */
+#ifndef LWMAC_TX_QUEUE_SIZE
+#define LWMAC_TX_QUEUE_SIZE             (8U)
+#endif
+
+/**
+ * @brief   Set the default queue size for incoming packets
+ */
+#ifndef LWMAC_RX_QUEUE_SIZE
+#define LWMAC_RX_QUEUE_SIZE             (8U)
+#endif
+
+/* Max link layer address length in bytes */
+#ifndef LWMAC_MAX_L2_ADDR_LEN
+#define LWMAC_MAX_L2_ADDR_LEN           (2U)
+#endif
+
+
+#define LWMAC_LPM_MASK					(1 << 17)
+
+/**
+ * @brief   Initialize an instance of the LWMAC layer
+ *
+ * The initialization starts a new thread that connects to the given netdev
+ * device and starts a link layer event loop.
+ *
+ * @param[in] stack         stack for the control thread
+ * @param[in] stacksize     size of *stack*
+ * @param[in] priority      priority for the thread housing the LWMAC instance
+ * @param[in] name          name of the thread housing the LWMAC instance
+ * @param[in] dev           netdev device, needs to be already initialized
+ *
+ * @return                  PID of LWMAC thread on success
+ * @return                  -EINVAL if creation of thread fails
+ * @return                  -ENODEV if *dev* is invalid
+ */
+kernel_pid_t gnrc_lwmac_init(char *stack, int stacksize, char priority,
+                           const char *name, gnrc_netdev_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GNRC_LWMAC_H */
+/** @} */

--- a/sys/include/net/gnrc/lwmac/lwmac.h
+++ b/sys/include/net/gnrc/lwmac/lwmac.h
@@ -35,6 +35,15 @@ extern "C" {
 #define LWMAC_WAKEUP_INTERVAL_US        (100U * 1000)
 #endif
 
+/* The Maximum WR duration time */
+#ifndef LWMAC_PREAMBLE_DURATION_US
+#define LWMAC_PREAMBLE_DURATION_US      ((21*LWMAC_WAKEUP_INTERVAL_US)/10)
+#endif
+
+#ifndef LWMAC_RANDOM_BEFORE_WR_US
+#define LWMAC_RANDOM_BEFORE_WR_US        (1000U)
+#endif
+
 /* Timeout to send the next WR in case no WA has been received during that
  * time. It is referenced to the beginning of both WRs, but due to internal
  * overhead, the exact spacing is slightly higher.
@@ -65,7 +74,7 @@ extern "C" {
  *         implementation
  */
 #ifndef LWMAC_WR_BEFORE_PHASE_US
-#define LWMAC_WR_BEFORE_PHASE_US        (500U)
+#define LWMAC_WR_BEFORE_PHASE_US        (1300U)
 #endif
 
 /* WR preparation overhead before it can be sent (higher with debugging output).

--- a/sys/include/net/gnrc/lwmac/packet_queue.h
+++ b/sys/include/net/gnrc/lwmac/packet_queue.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015 Daniel Krebs
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net_lwmac
+ * @file
+ * @brief       Wrapper for priority_queue that holds gnrc_pktsnip_t* and is
+ *              aware of it's length.
+ *
+ * @author      Daniel Krebs <github@daniel-krebs.net>
+ * @}
+ */
+
+#ifndef LWMAC_PACKET_QUEUE_H
+#define LWMAC_PACKET_QUEUE_H
+
+#include <stdint.h>
+#include <priority_queue.h>
+#include <net/gnrc/pkt.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef priority_queue_node_t packet_queue_node_t;
+
+/* TODO: Description */
+typedef struct {
+    priority_queue_t queue;
+    uint32_t length;
+    packet_queue_node_t* buffer;
+    size_t buffer_size;
+} packet_queue_t;
+
+
+static inline uint32_t packet_queue_length(packet_queue_t *q)
+{
+    return (q ? q->length : 0);
+}
+
+void packet_queue_flush(packet_queue_t* q);
+
+/* Get first element and remove it from queue */
+gnrc_pktsnip_t* packet_queue_pop(packet_queue_t* q);
+
+/* Get first element without removing */
+gnrc_pktsnip_t* packet_queue_head(packet_queue_t* q);
+
+packet_queue_node_t* packet_queue_push(packet_queue_t* q,
+                                       gnrc_pktsnip_t* snip,
+                                       uint32_t priority);
+
+void packet_queue_init(packet_queue_t* q,
+                       packet_queue_node_t buffer[],
+                       size_t buffer_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LWMAC_PACKET_QUEUE_H */

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -58,6 +58,17 @@ typedef enum {
 
     /**
      * @{
+     * @name Link layer
+     */
+#ifdef MODULE_GNRC_LWMAC
+    GNRC_NETTYPE_LWMAC,         /**< Protocol is lwMAC */
+#endif
+    /**
+     * @}
+     */
+
+    /**
+     * @{
      * @name Network layer
      */
 #ifdef MODULE_GNRC_IPV6

--- a/sys/include/net/gnrc/pktqueue.h
+++ b/sys/include/net/gnrc/pktqueue.h
@@ -85,6 +85,16 @@ static inline gnrc_pktqueue_t *gnrc_pktqueue_remove_head(gnrc_pktqueue_t **queue
     return gnrc_pktqueue_remove(queue, *queue);
 }
 
+/**
+ * @brief flush the packet queue
+ *
+ * @param[in]  queue    the queue, may not be NULL
+ */
+static inline void gnrc_pktqueue_flush(gnrc_pktqueue_t **queue)
+{
+    while(gnrc_pktqueue_remove_head(queue));
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -76,6 +76,9 @@ endif
 ifneq (,$(filter gnrc_pkt,$(USEMODULE)))
     DIRS += pkt
 endif
+ifneq (,$(filter gnrc_lwmac,$(USEMODULE)))
+    DIRS += link_layer/lwmac
+endif
 ifneq (,$(filter gnrc_pktbuf_static,$(USEMODULE)))
     DIRS += pktbuf_static
 endif

--- a/sys/net/gnrc/link_layer/lwmac/Makefile
+++ b/sys/net/gnrc/link_layer/lwmac/Makefile
@@ -1,0 +1,3 @@
+MODULE = gnrc_lwmac
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/link_layer/lwmac/README.md
+++ b/sys/net/gnrc/link_layer/lwmac/README.md
@@ -1,0 +1,18 @@
+LwMAC implementation
+====================
+
+
+# Duty cycling
+
+LwMAC interfaces LPM at the moement by setting `lpm_prevent_sleep` to 0 when
+it idles (NETDEV put to NETOPT_STATE_SLEEP). To wake up it schedules an RTT
+alarm. Therefore RTT has to be configured to be able to wake up the system.
+
+## RX
+
+Incoming packets will be queued to `lwmac.rx.queue`. When LwMAC is in the
+`LISTENING` state and the queue is not empty a receive transaction is started.
+This disables duty cycling as long as the transaction is in progress. In case
+of success it changes back to `SLEEPING` state and resumes duty cycling. If
+the reception has failed (e.g. packet for other node) it goes back to the
+`LISTENING` state until a successful transaction or timeout has occured.

--- a/sys/net/gnrc/link_layer/lwmac/include/lwmac_internal.h
+++ b/sys/net/gnrc/link_layer/lwmac/include/lwmac_internal.h
@@ -101,7 +101,7 @@ static inline bool _packet_is_broadcast(gnrc_pktsnip_t* pkt)
 {
     gnrc_netif_hdr_t* netif_hdr = _gnrc_pktbuf_find(pkt, GNRC_NETTYPE_NETIF);
     return ( (netif_hdr == NULL) ? false :
-                              (netif_hdr->flags & GNRC_NETIF_HDR_FLAGS_BROADCAST) );
+                              (netif_hdr->flags & (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) );
 }
 
 /* TX queue handling */

--- a/sys/net/gnrc/link_layer/lwmac/include/lwmac_internal.h
+++ b/sys/net/gnrc/link_layer/lwmac/include/lwmac_internal.h
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2015 Daniel Krebs
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_lwmac Simplest possible MAC layer
+ * @ingroup     net
+ * @brief       Internal functions if LWMAC
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for internal functions of LWMAC protocol
+ *
+ * @author      Daniel Krebs <github@daniel-krebs.net>
+ */
+
+#ifndef GNRC_LWMAC_INTERNAL_H_
+#define GNRC_LWMAC_INTERNAL_H_
+
+#include <stdint.h>
+#include "periph/rtt.h"
+#include "lwmac_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* @brief   Type to pass information about parsing */
+typedef struct {
+    lwmac_hdr_t* header;    /**< lwmac header of packet */
+    l2_addr_t  src_addr;    /**< copied source address of packet  */
+    l2_addr_t  dst_addr;    /**< copied destination address of packet */
+} lwmac_packet_info_t;
+
+/* @brief   Next RTT event must be at least this far in the future
+ *
+ * When setting an RTT alarm to short in the future it could be possible that
+ * the counter already passed the calculated alarm before it could be set. This
+ * margin will be applied when using `_next_inphase_event()`.
+ */
+#define LWMAC_RTT_EVENT_MARGIN_TICKS    ( RTT_MS_TO_TICKS(2) )
+
+/* @brief Extract the destination address out of an GNRC_NETTYPE_NETIF pktsnip
+ *
+ * @param[in]   pkt                 pktsnip from whom to extract
+ * @param[out]  pointer_to_addr     pointer to address will be stored here
+ *
+ * @return                          length of destination address
+ */
+int _get_dest_address(gnrc_pktsnip_t* pkt, uint8_t* pointer_to_addr[]);
+
+/* @brief Find the first pktsnip of @p type
+ *
+ * Will search linearly through the packet buffer @p pkt and yield
+ * gnrc_pktsnip_t::data of the first pktsnip match the type @p type.
+ *
+ * @param[in]   pkt     pktsnip that will be searched
+ * @param[in]   type    type to search for
+ *
+ * @return              pointer to data, NULL is not found
+ */
+void* _gnrc_pktbuf_find(gnrc_pktsnip_t* pkt, gnrc_nettype_t type);
+
+/* @brief Parse an incoming packet and extract important information
+ *
+ * Copies addresses into @p info, but header points inside @p pkt.
+ *
+ * @param[in]   pkt             packet that will be parsed
+ * @param[out]  info            structure that will hold parsed information
+ *
+ * @return                      0 if correctly parsed
+ * @return                      <0 on error
+ */
+int _parse_packet(gnrc_pktsnip_t* pkt, lwmac_packet_info_t* info);
+
+
+/* @brief Shortcut to get the state of netdev
+ *
+ * @param[in]   lwmac           lwmac state that stores netdev pointer
+ *
+ * @return                      state of netdev
+ */
+netopt_state_t _get_netdev_state(lwmac_t* lwmac);
+
+/* @brief Shortcut to set the state of netdev
+ *
+ * @param[in]   lwmac           lwmac state that stores netdev pointer
+ * @param[in]   devstate        new state for netdev
+ */
+void _set_netdev_state(lwmac_t* lwmac, netopt_state_t devstate);
+
+/* @brief Check if packet is broadcast
+ *
+ * @param[in]   pkt             packet to check
+ */
+static inline bool _packet_is_broadcast(gnrc_pktsnip_t* pkt)
+{
+    gnrc_netif_hdr_t* netif_hdr = _gnrc_pktbuf_find(pkt, GNRC_NETTYPE_NETIF);
+    return ( (netif_hdr == NULL) ? false :
+                              (netif_hdr->flags & GNRC_NETIF_HDR_FLAGS_BROADCAST) );
+}
+
+/* TX queue handling */
+int _find_neighbour(lwmac_t* lwmac, uint8_t* dst_addr, int addr_len);
+int _free_neighbour(lwmac_t* lwmac);
+int _alloc_neighbour(lwmac_t* lwmac);
+void _init_neighbour(lwmac_tx_neighbour_t* neighbour, uint8_t* addr, int len);
+
+static inline lwmac_tx_neighbour_t* _get_neighbour(lwmac_t* lwmac, unsigned int id)
+{
+    return &(lwmac->tx.neighbours[id]);
+}
+
+/* RTT phase calculation */
+uint32_t _ticks_to_phase(uint32_t ticks);
+uint32_t _phase_to_ticks(uint32_t phase);
+uint32_t _phase_now(void);
+uint32_t _ticks_until_phase(uint32_t phase);
+
+lwmac_tx_neighbour_t* _next_tx_neighbour(lwmac_t* lwmac);
+int _time_until_tx_us(lwmac_t* lwmac);
+bool _queue_tx_packet(lwmac_t* lwmac,  gnrc_pktsnip_t* pkt);
+uint32_t _next_inphase_event(uint32_t last, uint32_t interval);
+
+int _dispatch_defer(gnrc_pktsnip_t* buffer[], gnrc_pktsnip_t* pkt);
+
+void _dispatch(gnrc_pktsnip_t* buffer[]);
+
+static inline bool _addr_match(l2_addr_t* addr1, l2_addr_t* addr2)
+{
+    assert(addr1);
+    assert(addr2);
+
+    if(addr1->len != addr2->len)
+        return false;
+
+    return (memcmp(addr1->addr, addr2->addr, addr1->len) == 0);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GNRC_LWMAC_INTERNAL_H_ */
+/** @} */

--- a/sys/net/gnrc/link_layer/lwmac/include/lwmac_internal.h
+++ b/sys/net/gnrc/link_layer/lwmac/include/lwmac_internal.h
@@ -130,6 +130,7 @@ int _dispatch_defer(gnrc_pktsnip_t* buffer[], gnrc_pktsnip_t* pkt);
 
 void _dispatch(gnrc_pktsnip_t* buffer[]);
 
+
 static inline bool _addr_match(l2_addr_t* addr1, l2_addr_t* addr2)
 {
     assert(addr1);

--- a/sys/net/gnrc/link_layer/lwmac/include/lwmac_types.h
+++ b/sys/net/gnrc/link_layer/lwmac/include/lwmac_types.h
@@ -25,6 +25,8 @@
 #include <stdbool.h>
 #include <kernel_types.h>
 #include <xtimer.h>
+#include <net/netdev2.h>
+#include <net/gnrc/netdev2.h>
 #include <net/gnrc.h>
 #include <net/gnrc/lwmac/lwmac.h>
 #include <net/gnrc/lwmac/hdr.h>
@@ -172,7 +174,8 @@ typedef struct lwmac {
     /* PID of lwMAC thread */
     kernel_pid_t pid;
     /* NETDEV device used by lwMAC */
-    gnrc_netdev_t* netdev;
+	gnrc_netdev2_t* netdev;
+	const netdev2_driver_t* netdev2_driver;
     /* Internal state of MAC layer */
     lwmac_state_t state;
     /* Track if a transmission might have corrupted a received packet */
@@ -197,6 +200,7 @@ typedef struct lwmac {
 #define LWMAC_INIT { \
 /* pid */                   KERNEL_PID_UNDEF,  \
 /* netdev */                NULL, \
+/* netdev2_driver */		NULL, \
 /* state */                 UNDEF, \
 /* rx_in_progress */        false, \
 /* l2_addr */               LWMAC_L2_ADDR_INIT, \

--- a/sys/net/gnrc/link_layer/lwmac/include/lwmac_types.h
+++ b/sys/net/gnrc/link_layer/lwmac/include/lwmac_types.h
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2015 Daniel Krebs
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_lwmac Simplest possible MAC layer
+ * @ingroup     net
+ * @brief       Internal types of LWMAC
+ * @{
+ *
+ * @file
+ * @brief       Internal types used by the LWMAC protocol
+ *
+ * @author      Daniel Krebs <github@daniel-krebs.net>
+ */
+
+#ifndef GNRC_LWMAC_TYPES_H_
+#define GNRC_LWMAC_TYPES_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <kernel_types.h>
+#include <xtimer.h>
+#include <net/gnrc.h>
+#include <net/gnrc/lwmac/lwmac.h>
+#include <net/gnrc/lwmac/hdr.h>
+#include <net/gnrc/lwmac/packet_queue.h>
+#include "timeout.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/******************************************************************************/
+
+#define LWMAC_EVENT_RTT_TYPE            (0x4300)
+#define LWMAC_EVENT_RTT_START           (0x4301)
+#define LWMAC_EVENT_RTT_STOP            (0x4302)
+#define LWMAC_EVENT_RTT_PAUSE           (0x4303)
+#define LWMAC_EVENT_RTT_RESUME          (0x4304)
+#define LWMAC_EVENT_RTT_WAKEUP_PENDING  (0x4305)
+#define LWMAC_EVENT_RTT_SLEEP_PENDING   (0x4306)
+#define LWMAC_EVENT_TIMEOUT_TYPE        (0x4400)
+
+/******************************************************************************/
+
+typedef enum {
+    UNDEF = -1,
+    STOPPED,
+    START,
+    STOP,
+    RESET,
+    LISTENING,
+    RECEIVING,      /* RX is handled in own state machine */
+    TRANSMITTING,   /* TX is handled in own state machine */
+    SLEEPING,
+    STATE_COUNT
+} lwmac_state_t;
+
+/******************************************************************************/
+
+typedef enum {
+    TX_STATE_STOPPED = 0,
+    TX_STATE_INIT,          /**< Initiate transmission */
+    TX_STATE_SEND_BROADCAST,/**< directly goes to SUCCESSFUL or FAILED when finished */
+    TX_STATE_SEND_WR,       /**< Send a wakeup request */
+    TX_STATE_WAIT_WR_SENT,  /**< Wait until WR sent to set timeout */
+    TX_STATE_WAIT_FOR_WA,   /**< Wait for dest node's wakeup ackknowledge */
+    TX_STATE_SEND_DATA,     /**< Send the actual payload data */
+    TX_STATE_WAIT_FEEDBACK, /**< Wait if packet was ACKed */
+    TX_STATE_SUCCESSFUL,    /**< Transmission has finished successfully */
+    TX_STATE_FAILED         /**< Payload data couldn't be delivered to dest */
+} lwmac_tx_state_t;
+#define LWMAC_TX_STATE_INIT TX_STATE_STOPPED
+
+/******************************************************************************/
+
+typedef enum {
+    RX_STATE_STOPPED = 0,
+    RX_STATE_INIT,          /**< Initiate reception */
+    RX_STATE_WAIT_FOR_WR,   /**< Wait for a wakeup request */
+    RX_STATE_SEND_WA,       /**< Send wakeup ackknowledge to requesting node */
+    RX_STATE_WAIT_WA_SENT,  /**< Wait until WA sent to set timeout */
+    RX_STATE_WAIT_FOR_DATA, /**< Wait for actual payload data */
+    RX_STATE_SUCCESSFUL,    /**< Recption has finished successfully */
+    RX_STATE_FAILED         /**< Reception over, but nothing received */
+} lwmac_rx_state_t;
+#define LWMAC_RX_STATE_INIT RX_STATE_STOPPED
+
+/******************************************************************************/
+
+typedef enum {
+    TX_FEEDBACK_UNDEF = -1,
+    TX_FEEDBACK_SUCCESS,
+    TX_FEEDBACK_NOACK,
+    TX_FEEDBACK_BUSY
+} lwmac_tx_feedback_t;
+#define LWMAC_TX_FEEDBACK_INIT TX_FEEDBACK_UNDEF
+
+/******************************************************************************/
+
+typedef struct {
+    /* Internal state of reception state machine */
+    lwmac_rx_state_t state;
+    packet_queue_t queue;
+    packet_queue_node_t _queue_nodes[LWMAC_RX_QUEUE_SIZE];
+    l2_addr_t l2_addr;
+    gnrc_pktsnip_t* dispatch_buffer[LWMAC_DISPATCH_BUFFER_SIZE];
+} lwmac_rx_t;
+
+#define LWMAC_RX_INIT { \
+/* rx::state */             LWMAC_RX_STATE_INIT, \
+/* rx::queue */             {}, \
+/* rx::_queue_nodes */      {}, \
+/* rx::l2_addr */           LWMAC_L2_ADDR_INIT, \
+/* rx::dispatch_buffer */   {}, \
+}
+
+/******************************************************************************/
+
+typedef struct {
+    /* Address of neighbour node */
+    l2_addr_t l2_addr;
+    /* TX queue for this particular node */
+    packet_queue_t queue;
+    /* Phase relative to lwmac::last_wakeup */
+    uint32_t phase;
+} lwmac_tx_neighbour_t;
+#define LWMAX_NEIGHBOUR_INIT        { LWMAC_L2_ADDR_INIT, {}, 0 }
+
+#define LWMAC_PHASE_UNINITIALIZED   (0)
+#define LWMAC_PHASE_MAX             (-1)
+
+/******************************************************************************/
+
+typedef struct {
+    /* Internal state of transmission state machine */
+    lwmac_tx_state_t state;
+    /* TX queues for neighbouring nodes. First queue is broadcast (+1) */
+    lwmac_tx_neighbour_t neighbours[LWMAC_NEIGHBOUR_COUNT + 1];
+    /* Shared buffer for TX queue nodes */
+    packet_queue_node_t _queue_nodes[LWMAC_TX_QUEUE_SIZE];
+    /* Count how many WRs were sent until WA received */
+    uint32_t wr_sent;
+    /* Packet that is currently scheduled to be sent */
+    gnrc_pktsnip_t* packet;
+    /* Queue of destination node to which the current packet will be sent */
+    lwmac_tx_neighbour_t* current_neighbour;
+    uint32_t timestamp;
+    /* Sequence number for broadcast data to filter at receiver */
+    uint8_t bcast_seqnr;
+} lwmac_tx_t;
+
+#define LWMAC_TX_INIT { \
+/* tx::state */             LWMAC_TX_STATE_INIT, \
+/* tx::neighbours */        { LWMAX_NEIGHBOUR_INIT }, \
+/* tx::_queue_nodes */      {}, \
+/* tx::wr_sent */           0, \
+/* tx::packet */            NULL, \
+/* tx::current_neighbour */ NULL, \
+/* tx::timestamp */         0, \
+/* tx:bcast_seqnr */        0, \
+}
+
+/******************************************************************************/
+
+typedef struct lwmac {
+    /* PID of lwMAC thread */
+    kernel_pid_t pid;
+    /* NETDEV device used by lwMAC */
+    gnrc_netdev_t* netdev;
+    /* Internal state of MAC layer */
+    lwmac_state_t state;
+    /* Track if a transmission might have corrupted a received packet */
+    bool rx_started;
+    /* Own address */
+    l2_addr_t l2_addr;
+    lwmac_rx_t rx;
+    lwmac_tx_t tx;
+    /* Feedback of last packet that was sent */
+    lwmac_tx_feedback_t tx_feedback;
+    /* Store timeouts used for protocol */
+    lwmac_timeout_t timeouts[LWMAC_TIMEOUT_COUNT];
+    /* Used to calculate wakeup times */
+    uint32_t last_wakeup;
+    /* Keep track of duty cycling to avoid late RTT events after stopping */
+    bool dutycycling_active;
+    /* Used internally for rescheduling state machine update, e.g. after state
+     * transition caused in update */
+    bool needs_rescheduling;
+} lwmac_t;
+
+#define LWMAC_INIT { \
+/* pid */                   KERNEL_PID_UNDEF,  \
+/* netdev */                NULL, \
+/* state */                 UNDEF, \
+/* rx_in_progress */        false, \
+/* l2_addr */               LWMAC_L2_ADDR_INIT, \
+/* rx */                    LWMAC_RX_INIT, \
+/* tx */                    LWMAC_TX_INIT, \
+/* tx_feedback */           LWMAC_TX_FEEDBACK_INIT, \
+/* timeouts */              { LWMAC_TIMEOUT_INIT }, \
+/* last_wakeup */           0, \
+/* dutycycling_active */    false, \
+/* needs_rescheduling */    false \
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GNRC_LWMAC_TYPES_H_ */
+/** @} */

--- a/sys/net/gnrc/link_layer/lwmac/include/rx_state_machine.h
+++ b/sys/net/gnrc/link_layer/lwmac/include/rx_state_machine.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2015 Daniel Krebs
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net_lwmac
+ * @file
+ * @brief       Implementation of RX state machine
+ *
+ * @author      Daniel Krebs <github@daniel-krebs.net>
+ * @}
+ */
+
+#ifndef LWMAC_RX_STATE_MACHINE_H_
+#define LWMAC_RX_STATE_MACHINE_H_
+
+#include "net/gnrc/pkt.h"
+#include "lwmac_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void lwmac_rx_start(lwmac_t* lwmac);
+
+void lwmac_rx_stop(lwmac_t* lwmac);
+
+void lwmac_rx_update(lwmac_t* lwmac);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LWMAC_RX_STATE_MACHINE_H_ */

--- a/sys/net/gnrc/link_layer/lwmac/include/timeout.h
+++ b/sys/net/gnrc/link_layer/lwmac/include/timeout.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2015 Daniel Krebs
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net_lwmac
+ * @file
+ * @brief       Timeout handling.
+ *
+ * @author      Daniel Krebs <github@daniel-krebs.net>
+ * @}
+ */
+
+#ifndef LWMAC_TIMEOUT_H
+#define LWMAC_TIMEOUT_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <msg.h>
+#include <xtimer.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Foward declaration */
+typedef struct lwmac lwmac_t;
+
+typedef enum {
+    TIMEOUT_DISABLED = 0,
+    TIMEOUT_WR,
+    TIMEOUT_NO_RESPONSE,
+    TIMEOUT_WA,
+    TIMEOUT_DATA,
+    TIMEOUT_WAIT_FOR_DEST_WAKEUP,
+    TIMEOUT_WAKEUP_PERIOD,
+    TIMEOUT_NEXT_BROADCAST,
+    TIMEOUT_BROADCAST_END,
+} lwmac_timeout_type_t;
+
+typedef struct {
+    xtimer_t timer;
+    msg_t msg;
+    /* If type != DISABLED, this indicates if timeout has expired */
+    bool expired;
+    lwmac_timeout_type_t type;
+} lwmac_timeout_t;
+#define LWMAC_TIMEOUT_INIT  { {}, {}, false, TIMEOUT_DISABLED }
+
+void lwmac_set_timeout(lwmac_t* lwmac, lwmac_timeout_type_t type, uint32_t offset);
+
+void lwmac_clear_timeout(lwmac_t* lwmac, lwmac_timeout_type_t type);
+
+bool lwmac_timeout_is_running(lwmac_t* lwmac, lwmac_timeout_type_t type);
+
+bool lwmac_timeout_is_expired(lwmac_t* lwmac, lwmac_timeout_type_t type);
+
+void lwmac_reset_timeouts(lwmac_t* lwmac);
+
+void lwmac_timeout_make_expire(lwmac_timeout_t* timeout);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LWMAC_TIMEOUT_H */

--- a/sys/net/gnrc/link_layer/lwmac/include/tx_state_machine.h
+++ b/sys/net/gnrc/link_layer/lwmac/include/tx_state_machine.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2015 Daniel Krebs
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net_lwmac
+ * @file
+ * @brief       Implementation of TX state machine
+ *
+ * @author      Daniel Krebs <github@daniel-krebs.net>
+ * @}
+ */
+
+#ifndef LWMAC_TX_STATE_MACHINE_H_
+#define LWMAC_TX_STATE_MACHINE_H_
+
+#include "net/gnrc/pkt.h"
+#include "lwmac_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void lwmac_tx_start(lwmac_t* lwmac, gnrc_pktsnip_t* pkt, lwmac_tx_neighbour_t* neighbour);
+
+void lwmac_tx_stop(lwmac_t* lwmac);
+
+void lwmac_tx_update(lwmac_t* lwmac);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LWMAC_TX_STATE_MACHINE_H_ */

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -564,8 +564,11 @@ static void *_lwmac_thread(void *args)
      * set to NETOPT_STATE_TX */
     dev->driver->set(dev, NETOPT_PRELOADING, &enable, sizeof(enable));
 
+    uint16_t src_len = 8;
+    dev->driver->set(dev, NETOPT_SRC_LEN, &src_len, sizeof(src_len));
+
     /* Get own address from netdev */
-    lwmac.l2_addr.len = dev->driver->get(dev, NETOPT_ADDRESS, &lwmac.l2_addr.addr, sizeof(lwmac.l2_addr.addr));
+    lwmac.l2_addr.len = dev->driver->get(dev, NETOPT_ADDRESS_LONG, &lwmac.l2_addr.addr, sizeof(lwmac.l2_addr.addr));
     assert(lwmac.l2_addr.len > 0);
 
     /* Initialize broadcast sequence number. This at least differs from board

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -1,0 +1,713 @@
+/*
+ * Copyright (C) 2015 Daniel Krebs
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net_lwmac
+ * @file
+ * @brief       Implementation of the LWMAC protocol
+ *
+ * @author      Daniel Krebs <github@daniel-krebs.net>
+ * @}
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <kernel_types.h>
+#include <lpm.h>
+#include <msg.h>
+#include <thread.h>
+#include <timex.h>
+#include <periph/rtt.h>
+#include <net/gnrc.h>
+#include <net/gnrc/lwmac/lwmac.h>
+#include <net/gnrc/lwmac/packet_queue.h>
+
+#include "include/tx_state_machine.h"
+#include "include/rx_state_machine.h"
+#include "include/lwmac_internal.h"
+#include "include/lwmac_types.h"
+#include "include/timeout.h"
+
+#define ENABLE_DEBUG    (1)
+#include "debug.h"
+
+#define LOG_LEVEL LOG_WARNING
+#include "log.h"
+
+#undef LOG_ERROR
+#undef LOG_WARNING
+#undef LOG_INFO
+#undef LOG_DEBUG
+
+#define LOG_ERROR(...) LOG(LOG_ERROR, "ERROR: [lwmac] " __VA_ARGS__)
+#define LOG_WARNING(...) LOG(LOG_WARNING, "WARNING: [lwmac] " __VA_ARGS__)
+#define LOG_INFO(...) LOG(LOG_INFO, "[lwmac] " __VA_ARGS__)
+#define LOG_DEBUG(...) LOG(LOG_DEBUG, "[lwmac] " __VA_ARGS__)
+
+/******************************************************************************/
+
+/* Internal state of lwMAC */
+static lwmac_t lwmac = LWMAC_INIT;
+
+/******************************************************************************/
+
+static bool lwmac_update(void);
+static void lwmac_set_state(lwmac_state_t newstate);
+static void lwmac_schedule_update(void);
+static bool lwmac_needs_update(void);
+static void rtt_handler(uint32_t event);
+
+/******************************************************************************/
+
+// TODO: Don't use global variables
+inline void lwmac_schedule_update(void)
+{
+    lwmac.needs_rescheduling = true;
+}
+
+/******************************************************************************/
+
+// TODO: Don't use global variables
+inline bool lwmac_needs_update(void)
+{
+    return lwmac.needs_rescheduling;
+}
+
+/******************************************************************************/
+
+// TODO: Don't use global variables
+void lwmac_set_state(lwmac_state_t newstate)
+{
+    lwmac_state_t oldstate = lwmac.state;
+
+    if(newstate == oldstate)
+        return;
+
+    if(newstate >= STATE_COUNT) {
+        LOG_ERROR("Trying to set invalid state %u\n", newstate);
+        return;
+    }
+
+    /* Already change state, but might be reverted to oldstate when needed */
+    lwmac.state = newstate;
+
+    /* Actions when leaving old state */
+    switch(oldstate)
+    {
+    case RECEIVING:
+    case TRANSMITTING:
+        /* Enable duty cycling again */
+        rtt_handler(LWMAC_EVENT_RTT_RESUME);
+        break;
+
+    case SLEEPING:
+        lwmac_clear_timeout(&lwmac, TIMEOUT_WAKEUP_PERIOD);
+        break;
+
+    default:
+        break;
+    }
+
+    /* Actions when entering new state */
+    switch(newstate)
+    {
+    /*********************** Operation states *********************************/
+    case LISTENING:
+        _set_netdev_state(&lwmac, NETOPT_STATE_IDLE);
+        break;
+
+    case SLEEPING:
+        /* Put transceiver to sleep */
+        _set_netdev_state(&lwmac, NETOPT_STATE_SLEEP);
+        /* We may have come here through RTT handler, so timeout may still be active */
+        lwmac_clear_timeout(&lwmac, TIMEOUT_WAKEUP_PERIOD);
+        /* Return immediately, so no rescheduling */
+        return;
+
+    /* Trying to send data */
+    case TRANSMITTING:
+        rtt_handler(LWMAC_EVENT_RTT_PAUSE); /* No duty cycling while RXing */
+        _set_netdev_state(&lwmac, NETOPT_STATE_IDLE);  /* Power up netdev */
+        break;
+
+    /* Receiving incoming data */
+    case RECEIVING:
+        rtt_handler(LWMAC_EVENT_RTT_PAUSE); /* No duty cycling while TXing */
+        _set_netdev_state(&lwmac, NETOPT_STATE_IDLE);  /* Power up netdev */
+        break;
+
+    case STOPPED:
+        _set_netdev_state(&lwmac, NETOPT_STATE_OFF);
+        break;
+
+    /*********************** Control states ***********************************/
+    case START:
+        rtt_handler(LWMAC_EVENT_RTT_START);
+        lwmac_set_state(LISTENING);
+        break;
+
+    case STOP:
+        rtt_handler(LWMAC_EVENT_RTT_STOP);
+        lwmac_set_state(STOPPED);
+        break;
+
+    case RESET:
+        LOG_WARNING("Reset not yet implemented\n");
+        lwmac_set_state(STOP);
+        lwmac_set_state(START);
+        break;
+
+    /**************************************************************************/
+    default:
+        LOG_DEBUG("No actions for entering state %u\n", newstate);
+        return;
+    }
+
+    lwmac_schedule_update();
+}
+
+/******************************************************************************/
+
+/* Main state machine. Call whenever something happens */
+// TODO: Don't use global variables
+bool lwmac_update(void)
+{
+    lwmac.needs_rescheduling = false;
+
+    switch(lwmac.state)
+    {
+    case SLEEPING:
+
+        /* If a packet is scheduled, no other (possible earlier) packet can be
+         * sent before the first one is handled, even no broadcast
+         */
+        if( !lwmac_timeout_is_running(&lwmac, TIMEOUT_WAIT_FOR_DEST_WAKEUP) ) {
+
+            /* Check if there are broadcasts to send and transmit immediately */
+            if(packet_queue_length(&(lwmac.tx.neighbours[0].queue)) > 0) {
+                lwmac.tx.current_neighbour = &(lwmac.tx.neighbours[0]);
+                lwmac_set_state(TRANSMITTING);
+                break;
+            }
+
+            lwmac_tx_neighbour_t* neighbour = _next_tx_neighbour(&lwmac);
+
+            if(neighbour != NULL) {
+                /* Offset in microseconds when the earliest (phase) destination
+                 * node wakes up that we have packets for. */
+                int time_until_tx = RTT_TICKS_TO_US(_ticks_until_phase(neighbour->phase));
+
+                /* If there's not enough time to prepare a WR to catch the phase
+                 * postpone to next interval */
+                if (time_until_tx < LWMAC_WR_PREPARATION_US) {
+                    time_until_tx += LWMAC_WAKEUP_INTERVAL_US;
+                }
+
+                time_until_tx -= LWMAC_WR_PREPARATION_US;
+                lwmac_set_timeout(&lwmac, TIMEOUT_WAIT_FOR_DEST_WAKEUP, time_until_tx);
+
+                /* Register neighbour to be the next */
+                lwmac.tx.current_neighbour = neighbour;
+
+                /* Stop dutycycling, we're preparing to send. This prevents the
+                 * timeout arriving late, so that the destination phase would
+                 * be missed. */
+                // TODO: bad for power savings
+                rtt_handler(LWMAC_EVENT_RTT_PAUSE);
+            } else {
+                /* LOG_WARNING("Nothing to send, why did we get called?\n"); */
+            }
+        } else {
+            if(lwmac_timeout_is_expired(&lwmac, TIMEOUT_WAIT_FOR_DEST_WAKEUP)) {
+                LOG_DEBUG("Got timeout for dest wakeup, ticks: %"PRIu32"\n", rtt_get_counter());
+                lwmac_set_state(TRANSMITTING);
+            } else {
+                /* LOG_DEBUG("Nothing to do, why did we get called?\n"); */
+            }
+        }
+        break;
+
+    case LISTENING:
+        /* Set timeout for if there's no successful rx transaction that will
+         * change state to SLEEPING. */
+        if(!lwmac_timeout_is_running(&lwmac, TIMEOUT_WAKEUP_PERIOD)) {
+            lwmac_set_timeout(&lwmac, TIMEOUT_WAKEUP_PERIOD, LWMAC_WAKEUP_DURATION_US);
+        } else if(lwmac_timeout_is_expired(&lwmac, TIMEOUT_WAKEUP_PERIOD)) {
+            /* Dispatch first as there still may be broadcast packets. */
+            _dispatch(lwmac.rx.dispatch_buffer);
+            lwmac_set_state(SLEEPING);
+        }
+
+        if(packet_queue_length(&lwmac.rx.queue) > 0) {
+            lwmac_set_state(RECEIVING);
+        }
+        break;
+
+    case RECEIVING:
+    {
+        lwmac_rx_state_t state_rx = lwmac.rx.state;
+
+        switch(state_rx)
+        {
+        case RX_STATE_STOPPED:
+        {
+            lwmac_rx_start(&lwmac);
+            lwmac_rx_update(&lwmac);
+            break;
+        }
+        case RX_STATE_FAILED:
+            /* This may happen frequently because we'll receive WA from
+             * every node in range. */
+            LOG_DEBUG("Reception was NOT successful\n");
+            lwmac_rx_stop(&lwmac);
+            /* Restart */
+            lwmac_set_state(LISTENING);
+            break;
+        case RX_STATE_SUCCESSFUL:
+            LOG_INFO("Reception was successful\n");
+            lwmac_rx_stop(&lwmac);
+            /* Dispatch received packets, timing is not critical anymore */
+            _dispatch(lwmac.rx.dispatch_buffer);
+            /* Go back to sleep after successful transaction */
+            lwmac_set_state(SLEEPING);
+            break;
+        default:
+            lwmac_rx_update(&lwmac);
+        }
+
+        /* If state has changed, reschedule main state machine */
+        if(state_rx != lwmac.rx.state)
+        {
+            lwmac_schedule_update();
+        }
+        break;
+    }
+    case TRANSMITTING:
+    {
+        char* tx_success = "";
+        lwmac_tx_state_t state_tx = lwmac.tx.state;
+
+        switch(state_tx)
+        {
+        case TX_STATE_STOPPED:
+        {
+            gnrc_pktsnip_t* pkt;
+
+//            assert(lwmac.tx.current_neighbour);
+
+            if( (pkt = packet_queue_pop(&lwmac.tx.current_neighbour->queue)) )
+            {
+                lwmac_tx_start(&lwmac, pkt, lwmac.tx.current_neighbour);
+                lwmac_tx_update(&lwmac);
+            } else {
+                /* Shouldn't happen, but never observed this case */
+                int id = (lwmac.tx.current_neighbour - lwmac.tx.neighbours);
+                id /= sizeof(lwmac.tx.current_neighbour);
+                LOG_ERROR("Packet from neighbour's queue (#%d) invalid\n", id);
+                lwmac_schedule_update();
+            }
+            break;
+        }
+
+        case TX_STATE_FAILED:
+            tx_success = "NOT ";
+            /* Intended fall-through, TX packet will therefore be dropped. No
+             * automatic resending here, we did our best.
+             */
+        case TX_STATE_SUCCESSFUL:
+            if(lwmac.tx.current_neighbour == &(lwmac.tx.neighbours[0])) {
+                LOG_INFO("Broadcast transmission done\n");
+            } else {
+                LOG_INFO("Transmission was %ssuccessful (%"PRIu32" WRs sent)\n",
+                         tx_success, lwmac.tx.wr_sent);
+            }
+            lwmac_tx_stop(&lwmac);
+            lwmac_set_state(SLEEPING);
+            break;
+        default:
+            lwmac_tx_update(&lwmac);
+        }
+
+        /* If state has changed, reschedule main state machine */
+        if(state_tx != lwmac.tx.state)
+        {
+            lwmac_schedule_update();
+        }
+        break;
+    }
+    default:
+        LOG_DEBUG("No actions in state %u\n", lwmac.state);
+    }
+
+    return lwmac.needs_rescheduling;
+}
+
+/******************************************************************************/
+
+static void rtt_cb(void* arg)
+{
+    msg_t msg;
+    msg.content.value = ((uint32_t) arg ) & 0xffff;
+    msg.type = LWMAC_EVENT_RTT_TYPE;
+    msg_send(&msg, lwmac.pid);
+
+    if (sched_context_switch_request) {
+        thread_yield();
+    }
+}
+
+/******************************************************************************/
+
+// TODO: Don't use global variables
+void rtt_handler(uint32_t event)
+{
+    uint32_t alarm;
+    switch(event & 0xffff)
+    {
+    case LWMAC_EVENT_RTT_WAKEUP_PENDING:
+        lwmac.last_wakeup = rtt_get_alarm();
+        alarm = _next_inphase_event(lwmac.last_wakeup, RTT_US_TO_TICKS(LWMAC_WAKEUP_DURATION_US));
+        rtt_set_alarm(alarm, rtt_cb, (void*) LWMAC_EVENT_RTT_SLEEP_PENDING);
+        lpm_prevent_sleep |= LWMAC_LPM_MASK;
+        lwmac_set_state(LISTENING);
+        break;
+
+    case LWMAC_EVENT_RTT_SLEEP_PENDING:
+        alarm = _next_inphase_event(lwmac.last_wakeup, RTT_US_TO_TICKS(LWMAC_WAKEUP_INTERVAL_US));
+        rtt_set_alarm(alarm, rtt_cb, (void*) LWMAC_EVENT_RTT_WAKEUP_PENDING);
+        lpm_prevent_sleep &= ~(LWMAC_LPM_MASK);
+        lwmac_set_state(SLEEPING);
+        break;
+
+    /* Set initial wakeup alarm that starts the cycle */
+    case LWMAC_EVENT_RTT_START:
+        LOG_DEBUG("RTT: Initialize duty cycling\n");
+        alarm = rtt_get_counter() + RTT_US_TO_TICKS(LWMAC_WAKEUP_DURATION_US);
+        rtt_set_alarm(alarm, rtt_cb, (void*) LWMAC_EVENT_RTT_SLEEP_PENDING);
+        lpm_prevent_sleep |= LWMAC_LPM_MASK;
+        lwmac.dutycycling_active = true;
+        break;
+
+    case LWMAC_EVENT_RTT_STOP:
+    case LWMAC_EVENT_RTT_PAUSE:
+        rtt_clear_alarm();
+        LOG_DEBUG("RTT: Stop duty cycling, now in state %u\n", lwmac.state);
+        lpm_prevent_sleep |= LWMAC_LPM_MASK;
+        lwmac.dutycycling_active = false;
+        break;
+
+    case LWMAC_EVENT_RTT_RESUME:
+        LOG_DEBUG("RTT: Resume duty cycling\n");
+        alarm = _next_inphase_event(lwmac.last_wakeup, RTT_US_TO_TICKS(LWMAC_WAKEUP_INTERVAL_US));
+        rtt_set_alarm(alarm, rtt_cb, (void*) LWMAC_EVENT_RTT_WAKEUP_PENDING);
+        lpm_prevent_sleep &= ~(LWMAC_LPM_MASK);
+        lwmac.dutycycling_active = true;
+        break;
+    }
+}
+
+/******************************************************************************/
+
+/**
+ * @brief   Function called by the device driver on device events
+ *
+ * @param[in] event         type of event
+ * @param[in] data          optional parameter
+ */
+// TODO: Don't use global variables
+static void _event_cb(gnrc_netdev_event_t event, void *data)
+{
+    switch(event)
+    {
+    case NETDEV_EVENT_RX_STARTED:
+        LOG_DEBUG("NETDEV_EVENT_RX_STARTED\n");
+        lwmac.rx_started = true;
+        break;
+    case NETDEV_EVENT_RX_COMPLETE:
+    {
+        LOG_DEBUG("NETDEV_EVENT_RX_COMPLETE\n");
+
+        gnrc_pktsnip_t* pkt = (gnrc_pktsnip_t *) data;
+
+        /* Prevent packet corruption when a packet is sent before the previous
+         * received packet has been downloaded. This happens e.g. when a timeout
+         * expires that causes the tx state machine to send a packet. When a
+         * packet arrives after the timeout, the notification is queued but the
+         * tx state machine continues to send and then destroys the received
+         * packet in the frame buffer. After completion, the queued notification
+         * will be handled a corrupted packet will be downloaded. Therefore
+         * keep track that RX_STARTED is followed by RX_COMPLETE.
+         *
+         * TODO: transceivers might have 2 frame buffers, so make this optional
+         */
+        if(!lwmac.rx_started) {
+            LOG_WARNING("Maybe sending kicked in and frame buffer is now corrupted\n");
+            gnrc_pktbuf_release(pkt);
+            lwmac.rx_started = false;
+            break;
+        }
+
+        lwmac.rx_started = false;
+
+        if(!packet_queue_push(&lwmac.rx.queue, pkt, 0))
+        {
+            LOG_ERROR("Can't push RX packet @ %p, memory full?\n", pkt);
+            gnrc_pktbuf_release(pkt);
+            break;
+        }
+        lwmac_schedule_update();
+        break;
+    }
+    case NETDEV_EVENT_TX_STARTED:
+        lwmac.tx_feedback = TX_FEEDBACK_UNDEF;
+        lwmac.rx_started = false;
+//        lwmac_schedule_update();
+        break;
+    case NETDEV_EVENT_TX_COMPLETE:
+        lwmac.tx_feedback = TX_FEEDBACK_SUCCESS;
+        lwmac.rx_started = false;
+        lwmac_schedule_update();
+        break;
+    case NETDEV_EVENT_TX_NOACK:
+        lwmac.tx_feedback = TX_FEEDBACK_NOACK;
+        lwmac.rx_started = false;
+        lwmac_schedule_update();
+        break;
+    case NETDEV_EVENT_TX_MEDIUM_BUSY:
+        lwmac.tx_feedback = TX_FEEDBACK_BUSY;
+        lwmac.rx_started = false;
+        lwmac_schedule_update();
+        break;
+
+    default:
+        LOG_WARNING("Unhandled netdev event: %u\n", event);
+    }
+}
+
+/**
+ * @brief   Startup code and event loop of the LWMAC layer
+ *
+ * @param[in] args          expects a pointer to the underlying netdev device
+ *
+ * @return                  never returns
+ */
+// TODO: Don't use global variables
+static void *_lwmac_thread(void *args)
+{
+    gnrc_netdev_t* dev = lwmac.netdev = (gnrc_netdev_t *)args;
+    gnrc_netapi_opt_t* opt;
+    int res;
+    msg_t msg, reply, msg_queue[LWMAC_IPC_MSG_QUEUE_SIZE];
+
+    LOG_INFO("Starting lwMAC\n");
+
+    /* RTT is used for scheduling wakeup */
+    rtt_init();
+
+    /* Store pid globally, so that IRQ can use it to send msg */
+    lwmac.pid = thread_getpid();
+
+    /* setup the MAC layers message queue */
+    msg_init_queue(msg_queue, LWMAC_IPC_MSG_QUEUE_SIZE);
+    /* save the PID to the device descriptor and register the device */
+    dev->mac_pid = lwmac.pid;
+    gnrc_netif_add(lwmac.pid);
+    /* register the event callback with the device driver */
+    dev->driver->add_event_callback(dev, _event_cb);
+
+    /* Enable RX- and TX-started interrupts  */
+    netopt_enable_t enable = NETOPT_ENABLE;
+    dev->driver->set(dev, NETOPT_RX_START_IRQ, &enable, sizeof(enable));
+    dev->driver->set(dev, NETOPT_TX_START_IRQ, &enable, sizeof(enable));
+    dev->driver->set(dev, NETOPT_TX_END_IRQ, &enable, sizeof(enable));
+
+    /* Enable preloading, so packet will only be sent when netdev state will be
+     * set to NETOPT_STATE_TX */
+    dev->driver->set(dev, NETOPT_PRELOADING, &enable, sizeof(enable));
+
+    /* Get own address from netdev */
+    lwmac.l2_addr.len = dev->driver->get(dev, NETOPT_ADDRESS, &lwmac.l2_addr.addr, sizeof(lwmac.l2_addr.addr));
+    assert(lwmac.l2_addr.len > 0);
+
+    /* Initialize broadcast sequence number. This at least differs from board
+     * to board */
+    lwmac.tx.bcast_seqnr = lwmac.l2_addr.addr[0];
+
+    /* Initialize receive packet queue */
+    packet_queue_init(&lwmac.rx.queue,
+                      lwmac.rx._queue_nodes,
+                      (sizeof(lwmac.rx._queue_nodes) / sizeof(packet_queue_node_t)));
+
+    /* First neighbour queue is supposed to be broadcast queue */
+    int broadcast_queue_id = _alloc_neighbour(&lwmac);
+    assert(broadcast_queue_id == 0);
+
+    /* Setup broadcast tx queue */
+    uint8_t broadcast_addr[] = {0xff, 0xff};
+    _init_neighbour(_get_neighbour(&lwmac, 0), broadcast_addr, sizeof(broadcast_addr));
+
+    /* Reset all timeouts just to be sure */
+    lwmac_reset_timeouts(&lwmac);
+
+    /* Start duty cycling */
+    lwmac_set_state(START);
+
+    /* start the event loop */
+    while (1) {
+
+        msg_receive(&msg);
+
+        /* Handle NETDEV, NETAPI, RTT and TIMEOUT messages */
+        switch (msg.type) {
+
+        /* RTT raised an interrupt */
+        case LWMAC_EVENT_RTT_TYPE:
+            if(lwmac.dutycycling_active) {
+                rtt_handler(msg.content.value);
+                lwmac_schedule_update();
+            } else {
+                LOG_DEBUG("Ignoring late RTT event while dutycycling is off\n");
+            }
+            break;
+
+        /* An lwmac timeout occured */
+        case LWMAC_EVENT_TIMEOUT_TYPE:
+        {
+            lwmac_timeout_make_expire((lwmac_timeout_t*) msg.content.ptr);
+            lwmac_schedule_update();
+            break;
+        }
+
+        /* Transceiver raised an interrupt */
+        case GNRC_NETDEV_MSG_TYPE_EVENT:
+            LOG_DEBUG("GNRC_NETDEV_MSG_TYPE_EVENT received\n");
+            /* Forward event back to driver */
+            dev->driver->isr_event(dev, msg.content.value);
+            break;
+
+        /* TX: Queue for sending */
+        case GNRC_NETAPI_MSG_TYPE_SND:
+        {
+            // TODO: how to announce failure to upper layers?
+
+            LOG_DEBUG("GNRC_NETAPI_MSG_TYPE_SND received\n");
+            gnrc_pktsnip_t* pkt = (gnrc_pktsnip_t*) msg.content.ptr;
+
+            _queue_tx_packet(&lwmac, pkt);
+
+            lwmac_schedule_update();
+            break;
+        }
+        /* NETAPI set/get. Can't this be refactored away from here? */
+        case GNRC_NETAPI_MSG_TYPE_SET:
+        {
+            LOG_DEBUG("GNRC_NETAPI_MSG_TYPE_SET received\n");
+            opt = (gnrc_netapi_opt_t *)msg.content.ptr;
+
+            /* Depending on option forward to NETDEV or handle here */
+            switch(opt->opt)
+            {
+            /* Handle state change requests */
+            case NETOPT_STATE:
+            {
+                netopt_state_t* state = (netopt_state_t*) opt->data;
+                res = opt->data_len;
+                switch(*state)
+                {
+                case NETOPT_STATE_OFF:
+                    lwmac_set_state(STOP);
+                    break;
+                case NETOPT_STATE_IDLE:
+                    lwmac_set_state(START);
+                    break;
+                case NETOPT_STATE_RESET:
+                    lwmac_set_state(RESET);
+                    break;
+                default:
+                    res = -EINVAL;
+                    LOG_ERROR("NETAPI tries to set unsupported state %u\n",
+                          *state);
+                }
+                lwmac_schedule_update();
+                break;
+            }
+            /* Forward to netdev by default*/
+            default:
+                /* set option for device driver */
+                res = dev->driver->set(dev, opt->opt, opt->data, opt->data_len);
+                LOG_DEBUG("Response of netdev->set: %i\n", res);
+            }
+
+            /* send reply to calling thread */
+            reply.type = GNRC_NETAPI_MSG_TYPE_ACK;
+            reply.content.value = (uint32_t)res;
+            msg_reply(&msg, &reply);
+            break;
+        }
+        case GNRC_NETAPI_MSG_TYPE_GET:
+            /* TODO: filter out MAC layer options -> for now forward
+                     everything to the device driver */
+            LOG_DEBUG("GNRC_NETAPI_MSG_TYPE_GET received\n");
+            /* read incoming options */
+            opt = (gnrc_netapi_opt_t *)msg.content.ptr;
+            /* get option from device driver */
+            res = dev->driver->get(dev, opt->opt, opt->data, opt->data_len);
+            LOG_DEBUG("Response of netdev->get: %i\n", res);
+            /* send reply to calling thread */
+            reply.type = GNRC_NETAPI_MSG_TYPE_ACK;
+            reply.content.value = (uint32_t)res;
+            msg_reply(&msg, &reply);
+            break;
+
+        default:
+            LOG_ERROR("Unknown command %" PRIu16 "\n", msg.type);
+            break;
+        }
+
+        /* Execute main state machine because something just happend*/
+        while(lwmac_needs_update()) {
+            lwmac_update();
+        }
+    }
+
+    LOG_ERROR("terminated\n");
+
+    /* never reached */
+    return NULL;
+}
+
+kernel_pid_t gnrc_lwmac_init(char *stack, int stacksize, char priority,
+                        const char *name, gnrc_netdev_t *dev)
+{
+    kernel_pid_t res;
+
+    /* check if given netdev device is defined and the driver is set */
+    if (dev == NULL || dev->driver == NULL) {
+        LOG_ERROR("No netdev supplied or driver not set\n");
+        return -ENODEV;
+    }
+
+    /* Prevent sleeping until first RTT alarm is set */
+    lpm_prevent_sleep |= LWMAC_LPM_MASK;
+
+    /* create new LWMAC thread */
+    res = thread_create(stack, stacksize, priority, THREAD_CREATE_STACKTEST,
+                         _lwmac_thread, (void *)dev, name);
+    if (res <= 0) {
+        LOG_ERROR("Couldn't create thread\n");
+        lpm_prevent_sleep &= ~(LWMAC_LPM_MASK);
+        return -EINVAL;
+    }
+
+    return res;
+}

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -280,8 +280,8 @@ bool lwmac_update(void)
             lwmac_rx_stop(&lwmac);
             /* Dispatch received packets, timing is not critical anymore */
             _dispatch(lwmac.rx.dispatch_buffer);
-            /* Go back to sleep after successful transaction */
-            lwmac_set_state(SLEEPING);
+            /* Go back to Listen after successful transaction */
+            lwmac_set_state(LISTENING);
             break;
         default:
             lwmac_rx_update(&lwmac);
@@ -466,6 +466,11 @@ static void _event_cb(netdev2_t* dev, netdev2_event_t event)
 			 *
 			 * TODO: transceivers might have 2 frame buffers, so make this optional
 			 */
+            if(pkt == NULL){
+                lwmac.rx_started = false;
+                break;
+            }
+
 			if(!lwmac.rx_started) {
 				LOG_WARNING("Maybe sending kicked in and frame buffer is now corrupted\n");
 				gnrc_pktbuf_release(pkt);

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -427,11 +427,9 @@ void rtt_handler(uint32_t event)
  * @param[in] data          optional parameter
  */
 // TODO: Don't use global variables
-//static void _event_cb(gnrc_netdev_event_t event, void *data)
-static void _event_cb(netdev2_t* dev, netdev2_event_t event, void *data)
+static void _event_cb(netdev2_t* dev, netdev2_event_t event)
 {
-	(void) data;
-	gnrc_netdev2_t *gnrc_netdev2 = (gnrc_netdev2_t*) dev->isr_arg;
+	gnrc_netdev2_t *gnrc_netdev2 = (gnrc_netdev2_t*) dev->context;
 
 	if (event == NETDEV2_EVENT_ISR) {
 		msg_t msg;
@@ -552,7 +550,7 @@ static void *_lwmac_thread(void *args)
 
 	/* register the event callback with the device driver */
 	dev->event_callback = _event_cb;
-	dev->isr_arg = (void*) gnrc_netdev2;
+	dev->context = (void*) gnrc_netdev2;
 
     /* Enable RX- and TX-started interrupts  */
     netopt_enable_t enable = NETOPT_ENABLE;

--- a/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
@@ -1,0 +1,527 @@
+/*
+ * Copyright (C) 2015 Daniel Krebs
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net_lwmac
+ * @file
+ * @brief       Internal functions of LWMAC
+ *
+ * @author      Daniel Krebs <github@daniel-krebs.net>
+ * @}
+ */
+
+#include <stdbool.h>
+#include <periph/rtt.h>
+#include <net/gnrc.h>
+#include <net/gnrc/lwmac/lwmac.h>
+#include <net/gnrc/lwmac/packet_queue.h>
+
+#include "include/lwmac_internal.h"
+#include "include/lwmac_types.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/******************************************************************************/
+
+int _get_dest_address(gnrc_pktsnip_t* pkt, uint8_t* pointer_to_addr[])
+{
+    int res;
+    gnrc_netif_hdr_t* netif_hdr;
+
+    if(!pkt)
+        return -ENODEV;
+
+    netif_hdr = (gnrc_netif_hdr_t*) pkt->data;
+    if( (res = netif_hdr->dst_l2addr_len) <= 0)
+        return -ENOENT;
+
+    *pointer_to_addr = gnrc_netif_hdr_get_dst_addr(netif_hdr);
+    return res;
+}
+
+/******************************************************************************/
+
+/* Find a payload based on it's protocol type */
+void* _gnrc_pktbuf_find(gnrc_pktsnip_t* pkt, gnrc_nettype_t type)
+{
+    while(pkt != NULL)
+    {
+        if(pkt->type == type) {
+            return pkt->data;
+        }
+        pkt = pkt->next;
+    }
+    return NULL;
+}
+
+/******************************************************************************/
+
+int _find_neighbour(lwmac_t* lwmac, uint8_t* dst_addr, int addr_len)
+{
+    lwmac_tx_neighbour_t* neighbours = lwmac->tx.neighbours;
+
+    for(int i = 0; i < LWMAC_NEIGHBOUR_COUNT; i++) {
+        if(neighbours[i].l2_addr.len == addr_len) {
+            if(memcmp(&(neighbours[i].l2_addr.addr), dst_addr, addr_len) == 0) {
+                return i;
+            }
+        }
+    }
+    return -1;
+}
+
+/******************************************************************************/
+
+/* Free first empty queue that is not active */
+int _free_neighbour(lwmac_t* lwmac)
+{
+    lwmac_tx_neighbour_t* neighbours = lwmac->tx.neighbours;
+
+    for(int i = 0; i < LWMAC_NEIGHBOUR_COUNT; i++) {
+        if( (packet_queue_length(&(neighbours[i].queue)) == 0) &&
+            (&neighbours[i] != lwmac->tx.current_neighbour) ) {
+            /* Mark as free */
+            neighbours[i].l2_addr.len = 0;
+            return i;
+        }
+    }
+    return -1;
+}
+
+/******************************************************************************/
+
+int _alloc_neighbour(lwmac_t* lwmac)
+{
+    lwmac_tx_neighbour_t* neighbours = lwmac->tx.neighbours;
+
+    for(int i = 0; i < LWMAC_NEIGHBOUR_COUNT; i++) {
+        if(neighbours[i].l2_addr.len == 0) {
+            packet_queue_init(&(neighbours[i].queue),
+                              lwmac->tx._queue_nodes,
+                              (sizeof(lwmac->tx._queue_nodes) / sizeof(packet_queue_node_t)));
+            return i;
+        }
+    }
+    return -1;
+}
+
+/******************************************************************************/
+
+void _init_neighbour(lwmac_tx_neighbour_t* neighbour, uint8_t* addr, int len)
+{
+    assert(neighbour != NULL);
+    assert(addr  != NULL);
+    assert(len > 0);
+
+    neighbour->l2_addr.len = len;
+    neighbour->phase = LWMAC_PHASE_UNINITIALIZED;
+    memcpy(&(neighbour->l2_addr.addr), addr, len);
+}
+
+/******************************************************************************/
+
+//static bool _tx_packet_present(lwmac_t* lwmac)
+//{
+//    for(int i = 0; i < LWMAC_NEIGHBOUR_COUNT; i++) {
+//        if( (lwmac->tx.queues[i].addr_len > 0) &&
+//            (packet_queue_length(&lwmac->tx.queues[i].queue) > 0) ) {
+//            return true;
+//        }
+//    }
+//    return false;
+//}
+
+/******************************************************************************/
+/* TODO: maybe static inline */
+uint32_t _ticks_to_phase(uint32_t ticks)
+{
+    return (ticks % RTT_US_TO_TICKS(LWMAC_WAKEUP_INTERVAL_US));
+}
+
+/******************************************************************************/
+/* TODO: maybe static inline */
+uint32_t _phase_to_ticks(uint32_t phase)
+{
+    uint32_t rtt_now = rtt_get_counter();
+    uint32_t phase_now = _ticks_to_phase(rtt_now);
+
+    /* Start of current interval */
+    rtt_now -= phase_now;
+
+    /* Phase only in next interval */
+    if(phase < phase_now) {
+        rtt_now += RTT_US_TO_TICKS(LWMAC_WAKEUP_INTERVAL_US);
+    }
+
+    /* Advance to phase */
+    return (rtt_now + phase);
+}
+
+/******************************************************************************/
+/* TODO: maybe static inline */
+uint32_t _phase_now(void)
+{
+    return _ticks_to_phase(rtt_get_counter());
+}
+
+/******************************************************************************/
+/* TODO: maybe static inline */
+uint32_t _ticks_until_phase(uint32_t phase)
+{
+    long int tmp = phase - _phase_now();
+    if(tmp < 0) {
+        /* Phase in next interval */
+        tmp += RTT_US_TO_TICKS(LWMAC_WAKEUP_INTERVAL_US);
+    }
+
+    return (uint32_t)tmp;
+}
+
+/******************************************************************************/
+
+/* Find the neighbour that has a packet queued and is next for sending */
+lwmac_tx_neighbour_t* _next_tx_neighbour(lwmac_t* lwmac)
+{
+    int next = -1;
+
+    uint32_t phase_check;
+    uint32_t phase_nearest = LWMAC_PHASE_MAX;
+
+    for(int i = 0; i < LWMAC_NEIGHBOUR_COUNT; i++) {
+
+        if(packet_queue_length(&(_get_neighbour(lwmac, i)->queue)) > 0) {
+
+            /* Unknown destinations are initialized with their phase at the end
+             * of the local interval, so known destinations that still wakeup
+             * in this interval will be preferred. */
+            phase_check = _ticks_until_phase(_get_neighbour(lwmac, i)->phase);
+
+            if(phase_check <= phase_nearest) {
+                next = i;
+                phase_nearest = phase_check;
+                DEBUG("[lwmac-int] Advancing queue #%d\n", i);
+            }
+        }
+    }
+
+    return (next < 0) ? NULL : &(lwmac->tx.neighbours[next]);
+}
+
+/******************************************************************************/
+
+int _time_until_tx_us(lwmac_t* lwmac)
+{
+    lwmac_tx_neighbour_t* neighbour = _next_tx_neighbour(lwmac);
+
+    if(neighbour == NULL) {
+        return -1;
+    }
+    return RTT_TICKS_TO_US(_ticks_until_phase(neighbour->phase));
+}
+
+/******************************************************************************/
+
+bool _queue_tx_packet(lwmac_t* lwmac,  gnrc_pktsnip_t* pkt)
+{
+
+    lwmac_tx_neighbour_t* neighbour;
+    int neighbour_id;
+
+    if(_packet_is_broadcast(pkt)) {
+        /* Broadcast queue is neighbour 0 by definition */
+        neighbour_id = 0;
+        neighbour = _get_neighbour(lwmac, neighbour_id);
+
+    } else {
+        uint8_t* addr;
+        int addr_len;
+        bool neighbour_known = true;
+
+        /* Get destination address of packet */
+        addr_len = _get_dest_address(pkt, &addr);
+        if(addr_len <= 0) {
+            DEBUG("[lwmac-int] Packet has no destination address\n");
+            gnrc_pktbuf_release(pkt);
+            return false;
+        }
+
+        /* Search for existing queue for destination */
+        neighbour_id = _find_neighbour(lwmac, addr, addr_len);
+
+        /* Neighbour node doesn't have a queue yet */
+        if(neighbour_id < 0) {
+            neighbour_known = false;
+
+            /* Try to allocate neighbour entry */
+            neighbour_id = _alloc_neighbour(lwmac);
+
+            /* No neighbour entries left */
+            if(neighbour_id < 0) {
+                DEBUG("[lwmac-int] No neighbour entries left, maybe increase "
+                      "LWMAC_NEIGHBOUR_COUNT for better performance\n");
+
+                /* Try to free an unused queue */
+                neighbour_id = _free_neighbour(lwmac);
+
+                /* All queues are in use, so reject */
+                if(neighbour_id < 0) {
+                    DEBUG("[lwmac-int] Couldn't allocate tx queue for packet\n");
+                    gnrc_pktbuf_release(pkt);
+                    return false;
+                }
+            }
+        }
+
+        neighbour = _get_neighbour(lwmac, neighbour_id);
+
+        if(!neighbour_known) {
+            _init_neighbour(neighbour, addr, addr_len);
+        }
+
+    }
+
+    if(packet_queue_push(&(neighbour->queue), pkt, 0) == NULL) {
+        DEBUG("[lwmac-int] Can't push to neighbour #%d's queue, no entries left\n",
+                neighbour_id);
+        gnrc_pktbuf_release(pkt);
+        return false;
+    }
+
+    DEBUG("[lwmac-int] Queuing pkt to neighbour #%d\n", neighbour_id);
+
+    return true;
+}
+
+/******************************************************************************/
+
+int _parse_packet(gnrc_pktsnip_t* pkt, lwmac_packet_info_t* info)
+{
+    gnrc_netif_hdr_t* netif_hdr;
+    gnrc_pktsnip_t* lwmac_snip;
+    lwmac_hdr_t* lwmac_hdr;
+
+    assert(info != NULL);
+    assert(pkt != NULL);
+
+    netif_hdr = _gnrc_pktbuf_find(pkt, GNRC_NETTYPE_NETIF);
+    if(netif_hdr == NULL) {
+        return -1;
+    }
+
+    /* Dissect lwMAC header */
+
+    /* every frame has header as first member */
+    lwmac_hdr = (lwmac_hdr_t*) pkt->data;
+    switch(lwmac_hdr->type) {
+    case FRAMETYPE_WR:
+        lwmac_snip = gnrc_pktbuf_mark(pkt, sizeof(lwmac_frame_wr_t), GNRC_NETTYPE_LWMAC);
+        break;
+    case FRAMETYPE_WA:
+        lwmac_snip = gnrc_pktbuf_mark(pkt, sizeof(lwmac_frame_wa_t), GNRC_NETTYPE_LWMAC);
+        break;
+    case FRAMETYPE_DATA:
+        lwmac_snip = gnrc_pktbuf_mark(pkt, sizeof(lwmac_frame_data_t), GNRC_NETTYPE_LWMAC);
+        break;
+    case FRAMETYPE_BROADCAST:
+        lwmac_snip = gnrc_pktbuf_mark(pkt, sizeof(lwmac_frame_broadcast_t), GNRC_NETTYPE_LWMAC);
+        break;
+    default:
+        return -2;
+    }
+
+    /* Memory location may have changed while marking */
+    lwmac_hdr = lwmac_snip->data;
+
+    if(netif_hdr->dst_l2addr_len > sizeof(info->dst_addr)) {
+        return -3;
+    }
+
+    if(netif_hdr->src_l2addr_len > sizeof(info->src_addr)) {
+        return -4;
+    }
+
+    if(lwmac_hdr->type == FRAMETYPE_WA) {
+        /* WA is broadcast, so get dst address out of header instead of netif */
+        info->dst_addr = ((lwmac_frame_wa_t*)lwmac_hdr)->dst_addr;
+    } else {
+        if(netif_hdr->dst_l2addr_len) {
+            info->dst_addr.len = netif_hdr->dst_l2addr_len;
+            memcpy(info->dst_addr.addr,
+                   gnrc_netif_hdr_get_dst_addr(netif_hdr),
+                   netif_hdr->dst_l2addr_len);
+        }
+    }
+
+    if(netif_hdr->src_l2addr_len) {
+        info->src_addr.len = netif_hdr->src_l2addr_len;
+        memcpy(info->src_addr.addr,
+               gnrc_netif_hdr_get_src_addr(netif_hdr),
+               netif_hdr->src_l2addr_len);
+    }
+
+    info->header = lwmac_hdr;
+
+    return 0;
+}
+
+/******************************************************************************/
+
+// TODO: Don't use global variables
+void _set_netdev_state(lwmac_t* lwmac, netopt_state_t devstate)
+{
+    lwmac->netdev->driver->set(lwmac->netdev,
+                               NETOPT_STATE,
+                               &devstate,
+                               sizeof(devstate));
+}
+
+/******************************************************************************/
+
+netopt_state_t _get_netdev_state(lwmac_t* lwmac)
+{
+    netopt_state_t state;
+    if (0 < lwmac->netdev->driver->get(lwmac->netdev,
+                                       NETOPT_STATE,
+                                       &state,
+                                       sizeof(state))) {
+        return state;
+    }
+    return -1;
+}
+
+/******************************************************************************/
+
+/* Parameters in rtt timer ticks */
+uint32_t _next_inphase_event(uint32_t last, uint32_t interval)
+{
+    /* Counter did overflow since last wakeup */
+    if(rtt_get_counter() < last)
+    {
+        /* TODO: Not sure if this was tested :) */
+        uint32_t tmp = -last;
+        tmp /= interval;
+        tmp++;
+        last += tmp * interval;
+    }
+
+    /* Add margin to next wakeup so that it will be at least 2ms in the future */
+    while(last < (rtt_get_counter() + LWMAC_RTT_EVENT_MARGIN_TICKS))
+    {
+        last += interval;
+    }
+
+    return last;
+}
+
+/******************************************************************************/
+
+void lwmac_print_hdr(lwmac_hdr_t* hdr)
+{
+    assert(hdr != NULL);
+
+    printf("LwMAC header:\n  Type: ");
+    switch(hdr->type) {
+    case FRAMETYPE_WR:
+        puts("Wakeup request (WR)");
+        break;
+    case FRAMETYPE_WA:
+    {
+        puts("Wakeup acknowledge (WA)");
+        printf("  Src addr:");
+        lwmac_frame_wa_t* wa = (lwmac_frame_wa_t*) hdr;
+        for(int i = 0; i < wa->dst_addr.len; i++) {
+            printf("0x%02x", wa->dst_addr.addr[i]);
+            if(i < (wa->dst_addr.len - 1)) {
+                printf(":");
+            }
+        }
+        break;
+    }
+    case FRAMETYPE_DATA:
+        puts("User data");
+        break;
+    case FRAMETYPE_BROADCAST:
+        puts("Broadcast user data");
+        printf("  Sequence number: %d\n", ((lwmac_frame_broadcast_t*)hdr)->seq_nr);
+        break;
+    default:
+        puts("Unkown type");
+        printf("  Raw:  0x%02x\n", hdr->type);
+    }
+}
+
+/******************************************************************************/
+
+int _dispatch_defer(gnrc_pktsnip_t* buffer[], gnrc_pktsnip_t* pkt)
+{
+    assert(buffer != NULL);
+    assert(pkt != NULL);
+
+    /* We care about speed here, so assume packet structure */
+    assert(pkt->next->type == GNRC_NETTYPE_LWMAC);
+    assert(pkt->next->next->type == GNRC_NETTYPE_NETIF);
+
+    lwmac_frame_broadcast_t* bcast = NULL;
+    if(((lwmac_hdr_t*)pkt->next->data)->type == FRAMETYPE_BROADCAST) {
+        bcast = pkt->next->data;
+    }
+
+    for(unsigned i = 0; i < LWMAC_DISPATCH_BUFFER_SIZE; i++) {
+        /* Buffer will be filled bottom-up and emptied completely so no holes */
+        if(buffer[i] == NULL) {
+            buffer[i] = pkt;
+            return 0;
+        } else {
+            /* Filter same broadcasts, compare sequence number */
+            if(bcast &&
+               (((lwmac_hdr_t*)buffer[i]->next->data)->type == FRAMETYPE_BROADCAST) &&
+               (bcast->seq_nr == ((lwmac_frame_broadcast_t*)buffer[i]->next->data)->seq_nr))
+            {
+                gnrc_netif_hdr_t *hdr_queued, *hdr_new;
+                hdr_new = pkt->next->next->data;
+                hdr_queued = buffer[i]->next->next->data;
+
+                /* Sequence numbers match, compare source addresses */
+                if(hdr_new->src_l2addr_len == hdr_queued->src_l2addr_len) {
+                    if(memcmp(gnrc_netif_hdr_get_src_addr(hdr_new),
+                              gnrc_netif_hdr_get_src_addr(hdr_queued),
+                              hdr_new->src_l2addr_len) == 0) {
+                        /* Source addresses match, same packet */
+                        DEBUG("[lwmac] Found duplicate broadcast packet, dropping\n");
+                        gnrc_pktbuf_release(pkt);
+                        return -2;
+                    }
+                }
+            }
+        }
+    }
+
+    DEBUG("[lwmac] Dispatch buffer full, dropping packet\n");
+    gnrc_pktbuf_release(pkt);
+
+    return -1;
+}
+
+/******************************************************************************/
+
+void _dispatch(gnrc_pktsnip_t* buffer[])
+{
+    assert(buffer != NULL);
+
+    for(unsigned i = 0; i < LWMAC_DISPATCH_BUFFER_SIZE; i++) {
+        if(buffer[i]) {
+            if (!gnrc_netapi_dispatch_receive(buffer[i]->type, GNRC_NETREG_DEMUX_CTX_ALL, buffer[i])) {
+                DEBUG("Unable to forward packet of type %i\n", buffer[i]->type);
+                gnrc_pktbuf_release(buffer[i]);
+            }
+            buffer[i] = NULL;
+        }
+    }
+}

--- a/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
@@ -376,7 +376,7 @@ int _parse_packet(gnrc_pktsnip_t* pkt, lwmac_packet_info_t* info)
 // TODO: Don't use global variables
 void _set_netdev_state(lwmac_t* lwmac, netopt_state_t devstate)
 {
-    lwmac->netdev->driver->set(lwmac->netdev,
+	lwmac->netdev2_driver->set(lwmac->netdev->dev,
                                NETOPT_STATE,
                                &devstate,
                                sizeof(devstate));
@@ -387,7 +387,7 @@ void _set_netdev_state(lwmac_t* lwmac, netopt_state_t devstate)
 netopt_state_t _get_netdev_state(lwmac_t* lwmac)
 {
     netopt_state_t state;
-    if (0 < lwmac->netdev->driver->get(lwmac->netdev,
+	if (0 < lwmac->netdev2_driver->get(lwmac->netdev->dev,
                                        NETOPT_STATE,
                                        &state,
                                        sizeof(state))) {

--- a/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
@@ -517,6 +517,17 @@ void _dispatch(gnrc_pktsnip_t* buffer[])
 
     for(unsigned i = 0; i < LWMAC_DISPATCH_BUFFER_SIZE; i++) {
         if(buffer[i]) {
+
+            /* save pointer to netif header */
+            gnrc_pktsnip_t* netif = buffer[i]->next->next;
+
+            /* remove lwmac header */
+            buffer[i]->next->next = NULL;
+            gnrc_pktbuf_release(buffer[i]->next);
+
+            /* make append netif header after payload again */
+            buffer[i]->next = netif;
+
             if (!gnrc_netapi_dispatch_receive(buffer[i]->type, GNRC_NETREG_DEMUX_CTX_ALL, buffer[i])) {
                 DEBUG("Unable to forward packet of type %i\n", buffer[i]->type);
                 gnrc_pktbuf_release(buffer[i]);

--- a/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
@@ -67,7 +67,7 @@ int _find_neighbour(lwmac_t* lwmac, uint8_t* dst_addr, int addr_len)
 {
     lwmac_tx_neighbour_t* neighbours = lwmac->tx.neighbours;
 
-    for(int i = 0; i < LWMAC_NEIGHBOUR_COUNT; i++) {
+	for(int i = 0; i <= LWMAC_NEIGHBOUR_COUNT; i++) {
         if(neighbours[i].l2_addr.len == addr_len) {
             if(memcmp(&(neighbours[i].l2_addr.addr), dst_addr, addr_len) == 0) {
                 return i;
@@ -83,15 +83,18 @@ int _find_neighbour(lwmac_t* lwmac, uint8_t* dst_addr, int addr_len)
 int _free_neighbour(lwmac_t* lwmac)
 {
     lwmac_tx_neighbour_t* neighbours = lwmac->tx.neighbours;
+	const size_t neighbour_count = sizeof(lwmac->tx.neighbours) /
+	                              sizeof(lwmac->tx.neighbours[0]);
 
-    for(int i = 0; i < LWMAC_NEIGHBOUR_COUNT; i++) {
+	/* Don't attempt to free broadcast neighbour, so start at index 1 */
+	for(int i = 1; i < neighbour_count; i++) {
         if( (packet_queue_length(&(neighbours[i].queue)) == 0) &&
             (&neighbours[i] != lwmac->tx.current_neighbour) ) {
             /* Mark as free */
             neighbours[i].l2_addr.len = 0;
             return i;
         }
-    }
+	}
     return -1;
 }
 
@@ -105,7 +108,7 @@ int _alloc_neighbour(lwmac_t* lwmac)
         if(neighbours[i].l2_addr.len == 0) {
             packet_queue_init(&(neighbours[i].queue),
                               lwmac->tx._queue_nodes,
-                              (sizeof(lwmac->tx._queue_nodes) / sizeof(packet_queue_node_t)));
+			                  LWMAC_TX_QUEUE_SIZE);
             return i;
         }
     }

--- a/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
@@ -353,7 +353,10 @@ int _parse_packet(gnrc_pktsnip_t* pkt, lwmac_packet_info_t* info)
     if(lwmac_hdr->type == FRAMETYPE_WA) {
         /* WA is broadcast, so get dst address out of header instead of netif */
         info->dst_addr = ((lwmac_frame_wa_t*)lwmac_hdr)->dst_addr;
-    } else {
+    }else if(lwmac_hdr->type == FRAMETYPE_WR){
+        /* WR is broadcast, so get dst address out of header instead of netif */
+        info->dst_addr = ((lwmac_frame_wr_t*)lwmac_hdr)->dst_addr;
+    }else {
         if(netif_hdr->dst_l2addr_len) {
             info->dst_addr.len = netif_hdr->dst_l2addr_len;
             memcpy(info->dst_addr.addr,

--- a/sys/net/gnrc/link_layer/lwmac/packet_queue.c
+++ b/sys/net/gnrc/link_layer/lwmac/packet_queue.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2015 Daniel Krebs
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net_lwmac
+ * @file
+ * @brief       Wrapper for priority_queue that holds gnrc_pktsnip_t* and is
+ *              aware of it's length.
+ *
+ * @author      Daniel Krebs <github@daniel-krebs.net>
+ * @}
+ */
+
+#include <net/gnrc.h>
+#include <net/gnrc/lwmac/lwmac.h>
+#include <net/gnrc/lwmac/packet_queue.h>
+
+/******************************************************************************/
+
+static packet_queue_node_t* _alloc_node(packet_queue_t* q, gnrc_pktsnip_t *pkt)
+{
+    assert(q != NULL);
+    assert(q->buffer != NULL);
+    assert(q->buffer_size > 0);
+    assert(sizeof(unsigned int) == sizeof(gnrc_pktsnip_t*));
+
+    for (size_t i = 0; i < q->buffer_size; i++) {
+        if( (q->buffer[i].data == 0) &&
+            (q->buffer[i].next == NULL))
+        {
+            q->buffer[i].data = (unsigned int) pkt;
+            return &(q->buffer[i]);
+        }
+    }
+
+    return NULL;
+}
+
+/******************************************************************************/
+
+static inline void _free_node(packet_queue_node_t *node)
+{
+    assert(node != NULL);
+
+    node->data = 0;
+    node->next = NULL;
+}
+
+/******************************************************************************/
+
+void packet_queue_init(packet_queue_t* q, packet_queue_node_t buffer[], size_t buffer_size)
+{
+    assert(q != NULL);
+    assert(buffer != NULL);
+    assert(buffer_size > 0);
+
+    q->buffer = buffer;
+    q->buffer_size = buffer_size;
+    q->queue.first = NULL;
+}
+
+/******************************************************************************/
+
+gnrc_pktsnip_t* packet_queue_pop(packet_queue_t* q)
+{
+    if(!q || (q->length == 0))
+        return NULL;
+    packet_queue_node_t* head = priority_queue_remove_head(&(q->queue));
+    gnrc_pktsnip_t* pkt = (gnrc_pktsnip_t*) head->data;
+    _free_node(head);
+    q->length--;
+    return pkt;
+}
+
+/******************************************************************************/
+
+gnrc_pktsnip_t* packet_queue_head(packet_queue_t* q)
+{
+    if(!q || (q->length == 0))
+        return NULL;
+    return (gnrc_pktsnip_t*) q->queue.first->data;
+}
+/******************************************************************************/
+
+packet_queue_node_t*
+packet_queue_push(packet_queue_t* q, gnrc_pktsnip_t* snip, uint32_t priority)
+{
+    assert(q != NULL);
+    assert(snip != NULL);
+
+    packet_queue_node_t* node = _alloc_node(q, snip);
+
+    if(node)
+    {
+        node->priority = priority;
+        priority_queue_add(&(q->queue), node);
+        q->length++;
+    }
+    return node;
+}
+
+/******************************************************************************/
+
+void packet_queue_flush(packet_queue_t* q)
+{
+    if(q->length == 0)
+        return;
+
+    packet_queue_node_t* node;
+    while( (node = priority_queue_remove_head(&(q->queue))) )
+    {
+        gnrc_pktbuf_release((gnrc_pktsnip_t*) node->data);
+        _free_node(node);
+    }
+    q->length = 0;
+}

--- a/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
@@ -58,7 +58,7 @@ void lwmac_rx_start(lwmac_t* lwmac)
 
     /* Don't attempt to send a WA if channel is busy to get timings right */
     netopt_enable_t csma_disable = NETOPT_DISABLE;
-    lwmac->netdev->driver->set(lwmac->netdev, NETOPT_CSMA, &csma_disable, sizeof(csma_disable));
+	lwmac->netdev2_driver->set(lwmac->netdev->dev, NETOPT_CSMA, &csma_disable, sizeof(csma_disable));
 
     lwmac->rx.state = RX_STATE_INIT;
 }
@@ -191,7 +191,7 @@ static bool _lwmac_rx_update(lwmac_t* lwmac)
 
         /* Disable Auto ACK */
         netopt_enable_t autoack = NETOPT_DISABLE;
-        lwmac->netdev->driver->set(lwmac->netdev, NETOPT_AUTOACK, &autoack, sizeof(autoack));
+		lwmac->netdev2_driver->set(lwmac->netdev->dev, NETOPT_AUTOACK, &autoack, sizeof(autoack));
 
         /* We might have taken too long to answer the WR so we're receiving the
          * next one already. Don't send WA yet and go back to WR reception.
@@ -207,12 +207,12 @@ static bool _lwmac_rx_update(lwmac_t* lwmac)
 //        }
 
         /* Send WA */
-        lwmac->netdev->driver->send_data(lwmac->netdev, pkt);
+		lwmac->netdev->send(lwmac->netdev, pkt);
         _set_netdev_state(lwmac, NETOPT_STATE_TX);
 
         /* Enable Auto ACK again for data reception */
         autoack = NETOPT_ENABLE;
-        lwmac->netdev->driver->set(lwmac->netdev, NETOPT_AUTOACK, &autoack, sizeof(autoack));
+		lwmac->netdev2_driver->set(lwmac->netdev->dev, NETOPT_AUTOACK, &autoack, sizeof(autoack));
 
         GOTO_RX_STATE(RX_STATE_WAIT_WA_SENT, false);
     }

--- a/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
@@ -1,0 +1,349 @@
+/*
+ * Copyright (C) 2015 Daniel Krebs
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net_lwmac
+ * @file
+ * @brief       Implementation of RX state machine
+ *
+ * @author      Daniel Krebs <github@daniel-krebs.net>
+ * @}
+ */
+
+#include <net/gnrc.h>
+#include <net/gnrc/lwmac/lwmac.h>
+#include <net/gnrc/lwmac/packet_queue.h>
+
+#include "include/rx_state_machine.h"
+#include "include/timeout.h"
+#include "include/lwmac_internal.h"
+#include "include/lwmac_types.h"
+
+#define ENABLE_DEBUG    (1)
+#include "debug.h"
+
+#define LOG_LEVEL LOG_WARNING
+#include "log.h"
+
+#undef LOG_ERROR
+#undef LOG_WARNING
+#undef LOG_INFO
+#undef LOG_DEBUG
+
+#define LOG_ERROR(...) LOG(LOG_ERROR, "ERROR: [lwmac-rx] " __VA_ARGS__)
+#define LOG_WARNING(...) LOG(LOG_WARNING, "WARNING: [lwmac-rx] " __VA_ARGS__)
+#define LOG_INFO(...) LOG(LOG_INFO, "[lwmac-rx] " __VA_ARGS__)
+#define LOG_DEBUG(...) LOG(LOG_DEBUG, "[lwmac-rx] " __VA_ARGS__)
+
+/* Break out of switch and mark the need for rescheduling */
+#define GOTO_RX_STATE(rx_state, do_resched) lwmac->rx.state = rx_state; \
+                                reschedule = do_resched; \
+                                break
+
+/******************************************************************************/
+
+void lwmac_rx_start(lwmac_t* lwmac)
+{
+    if(lwmac == NULL)
+        return;
+
+    /* RX address should have been reset, probably not stopped then */
+    assert(lwmac->rx.l2_addr.len == 0);
+
+    /* Don't attempt to send a WA if channel is busy to get timings right */
+    netopt_enable_t csma_disable = NETOPT_DISABLE;
+    lwmac->netdev->driver->set(lwmac->netdev, NETOPT_CSMA, &csma_disable, sizeof(csma_disable));
+
+    lwmac->rx.state = RX_STATE_INIT;
+}
+
+/******************************************************************************/
+
+void lwmac_rx_stop(lwmac_t* lwmac)
+{
+    if(!lwmac)
+        return;
+
+    lwmac_clear_timeout(lwmac, TIMEOUT_DATA);
+    lwmac->rx.state = RX_STATE_STOPPED;
+    lwmac->rx.l2_addr.len = 0;
+}
+
+/******************************************************************************/
+
+/* Returns whether rescheduling is needed or not */
+static bool _lwmac_rx_update(lwmac_t* lwmac)
+{
+    bool reschedule = false;
+
+    if(!lwmac)
+        return reschedule;
+
+    switch(lwmac->rx.state)
+    {
+    case RX_STATE_INIT:
+        lwmac_clear_timeout(lwmac, TIMEOUT_DATA);
+        GOTO_RX_STATE(RX_STATE_WAIT_FOR_WR, true);
+
+    case RX_STATE_WAIT_FOR_WR:
+    {
+        LOG_DEBUG("RX_STATE_WAIT_FOR_WR\n");
+
+        gnrc_pktsnip_t* pkt;
+        bool found_wr = false;
+
+        while( (pkt = packet_queue_pop(&lwmac->rx.queue)) != NULL ) {
+            LOG_DEBUG("Inspecting pkt @ %p\n", pkt);
+
+            /* Parse packet */
+            lwmac_packet_info_t info;
+            int ret = _parse_packet(pkt, &info);
+
+            if(ret != 0) {
+                LOG_DEBUG("Packet could not be parsed: %i\n", ret);
+                gnrc_pktbuf_release(pkt);
+                continue;
+            }
+
+            if(info.header->type == FRAMETYPE_BROADCAST) {
+                _dispatch_defer(lwmac->rx.dispatch_buffer, pkt);
+                continue;
+            }
+
+            /* TODO:
+             * If we see a WA here we have a rough clue about the wakeup phase
+             * of this node. But there is no timestamping of incoming frames yet
+             * so maybe add a timestamp to every frame in event callback. */
+
+            if(info.header->type != FRAMETYPE_WR) {
+                LOG_DEBUG("Packet is not WR: 0x%02x\n", info.header->type);
+                gnrc_pktbuf_release(pkt);
+                continue;
+            }
+
+            /* No need to keep pkt anymore */
+            gnrc_pktbuf_release(pkt);
+
+            if(!_addr_match(&lwmac->l2_addr, &info.dst_addr)) {
+                LOG_DEBUG("Packet is WR but not for us\n");
+                continue;
+            }
+
+            /* Save source address for later addressing */
+            lwmac->rx.l2_addr = info.src_addr;
+
+            found_wr = true;
+            break;
+        }
+
+        if(!found_wr) {
+            LOG_DEBUG("No WR found, stop RX\n");
+            GOTO_RX_STATE(RX_STATE_FAILED, true);
+        }
+
+        // TODO: don't flush queue
+        packet_queue_flush(&lwmac->rx.queue);
+
+        GOTO_RX_STATE(RX_STATE_SEND_WA, true);
+    }
+    case RX_STATE_SEND_WA:
+    {
+        LOG_DEBUG("RX_STATE_SEND_WA\n");
+
+        gnrc_pktsnip_t* pkt;
+        gnrc_netif_hdr_t* nethdr_wa;
+
+        assert(lwmac->rx.l2_addr.len != 0);
+
+        /* Assemble WA packet */
+        lwmac_frame_wa_t lwmac_hdr;
+        lwmac_hdr.header.type = FRAMETYPE_WA;
+        lwmac_hdr.dst_addr = lwmac->rx.l2_addr;
+
+        pkt = gnrc_pktbuf_add(NULL, &lwmac_hdr, sizeof(lwmac_hdr), GNRC_NETTYPE_LWMAC);
+        if(pkt == NULL) {
+            LOG_ERROR("Cannot allocate pktbuf of type GNRC_NETTYPE_LWMAC\n");
+            GOTO_RX_STATE(RX_STATE_FAILED, true);
+        }
+
+        pkt = gnrc_pktbuf_add(pkt, NULL, sizeof(gnrc_netif_hdr_t) + lwmac->rx.l2_addr.len, GNRC_NETTYPE_NETIF);
+        if(pkt == NULL) {
+            LOG_ERROR("Cannot allocate pktbuf of type GNRC_NETTYPE_NETIF\n");
+            GOTO_RX_STATE(RX_STATE_FAILED, true);
+        }
+
+        /* We wouldn't get here if add the NETIF header had failed, so no
+           sanity checks needed */
+        nethdr_wa = (gnrc_netif_hdr_t*) _gnrc_pktbuf_find(pkt, GNRC_NETTYPE_NETIF);
+
+        /* Construct NETIF header and insert address for WA packet */
+        gnrc_netif_hdr_init(nethdr_wa, 0, lwmac->rx.l2_addr.len);
+        gnrc_netif_hdr_set_dst_addr(nethdr_wa, lwmac->rx.l2_addr.addr, lwmac->rx.l2_addr.len);
+
+        /* Send WA as broadcast*/
+        nethdr_wa->flags |= GNRC_NETIF_HDR_FLAGS_BROADCAST;
+
+        /* Disable Auto ACK */
+        netopt_enable_t autoack = NETOPT_DISABLE;
+        lwmac->netdev->driver->set(lwmac->netdev, NETOPT_AUTOACK, &autoack, sizeof(autoack));
+
+        /* We might have taken too long to answer the WR so we're receiving the
+         * next one already. Don't send WA yet and go back to WR reception.
+         * TODO: Is this really neccessary?
+         *
+         * This should not happen for WRs if the timing has been determined
+         * correctly.
+         */
+//        if(_get_netdev_state(lwmac) == NETOPT_STATE_RX) {
+//            LOG_WARNING("Receiving now, so cancel sending WA\n");
+//            gnrc_pktbuf_release(pkt);
+//            GOTO_RX_STATE(RX_STATE_WAIT_FOR_WR, false);
+//        }
+
+        /* Send WA */
+        lwmac->netdev->driver->send_data(lwmac->netdev, pkt);
+        _set_netdev_state(lwmac, NETOPT_STATE_TX);
+
+        /* Enable Auto ACK again for data reception */
+        autoack = NETOPT_ENABLE;
+        lwmac->netdev->driver->set(lwmac->netdev, NETOPT_AUTOACK, &autoack, sizeof(autoack));
+
+        GOTO_RX_STATE(RX_STATE_WAIT_WA_SENT, false);
+    }
+    case RX_STATE_WAIT_WA_SENT:
+    {
+        LOG_DEBUG("RX_STATE_WAIT_WA_SENT\n");
+
+        if(lwmac->tx_feedback == TX_FEEDBACK_UNDEF) {
+            LOG_DEBUG("WA not yet completely sent\n");
+            break;
+        }
+
+        /* This is not needed anymore, because WAs are sent without CSMA/CA */
+//        /* WA wasn't sent, so restart state machine */
+//        if(lwmac->tx_feedback == TX_FEEDBACK_BUSY) {
+//            LOG_WARNING("WA could not be sent. Wait for next WR\n");
+//            GOTO_RX_STATE(RX_STATE_FAILED, true);
+//        }
+
+        /* Set timeout for expected data arrival */
+        lwmac_set_timeout(lwmac, TIMEOUT_DATA, LWMAC_DATA_DELAY_US);
+
+        GOTO_RX_STATE(RX_STATE_WAIT_FOR_DATA, false);
+    }
+    case RX_STATE_WAIT_FOR_DATA:
+    {
+        LOG_DEBUG("RX_STATE_WAIT_FOR_DATA\n");
+
+        gnrc_pktsnip_t* pkt;
+        bool found_data = false;
+        bool found_wr = false;
+
+        while( (pkt = packet_queue_pop(&lwmac->rx.queue)) != NULL ) {
+            LOG_DEBUG("Inspecting pkt @ %p\n", pkt);
+
+            /* Parse packet */
+            lwmac_packet_info_t info;
+            int ret = _parse_packet(pkt, &info);
+
+            if(ret != 0) {
+                LOG_DEBUG("Packet could not be parsed: %i\n", ret);
+                gnrc_pktbuf_release(pkt);
+                continue;
+            }
+
+            if(info.header->type == FRAMETYPE_BROADCAST) {
+                _dispatch_defer(lwmac->rx.dispatch_buffer, pkt);
+                continue;
+            }
+
+            if(!_addr_match(&lwmac->rx.l2_addr, &info.src_addr)) {
+                LOG_DEBUG("Packet is not from destination\n");
+                gnrc_pktbuf_release(pkt);
+                continue;
+            }
+
+            if(!_addr_match(&lwmac->l2_addr, &info.dst_addr)) {
+                LOG_DEBUG("Packet is not for us\n");
+                gnrc_pktbuf_release(pkt);
+                continue;
+            }
+
+            /* Sender maybe didn't get the WA */
+            if(info.header->type == FRAMETYPE_WR) {
+                LOG_INFO("Found a WR while waiting for DATA\n");
+                lwmac_clear_timeout(lwmac, TIMEOUT_DATA);
+                found_wr = true;
+                break;
+            }
+
+            if(info.header->type == FRAMETYPE_DATA) {
+                LOG_DEBUG("Found DATA!\n");
+                lwmac_clear_timeout(lwmac, TIMEOUT_DATA);
+                found_data = true;
+                break;
+            }
+        }
+
+        /* If WA got lost we wait for data but we will be hammered with WR
+         * packets. So a WR indicates a lost WA => reset RX state machine.
+         *
+         * TODO: Destination may assume a wrong wakeup phase then. Maybe send a
+         *       delta time to get the timing right again.
+         */
+        if(found_wr) {
+            LOG_INFO("WA probably got lost, reset RX state machine\n");
+            /* Push WR back to rx queue */
+            packet_queue_push(&lwmac->rx.queue, pkt, 0);
+            /* Start over again */
+            GOTO_RX_STATE(RX_STATE_INIT, true);
+        }
+
+        /* Only timeout if no packet (presumably the expected data) is being
+         * received. This won't be blocked by WRs as they restart the state
+         * machine (see above).
+         *
+         * TODO: Checking for expiration only works once and clears the timeout.
+         *       If this is a false positive (other packet than DATA), we're
+         *       stuck. */
+        if( (lwmac_timeout_is_expired(lwmac, TIMEOUT_DATA)) &&
+            (!lwmac->rx_started) ) {
+            LOG_INFO("DATA timed out\n");
+            gnrc_pktbuf_release(pkt);
+            GOTO_RX_STATE(RX_STATE_FAILED, true);
+        }
+
+        if(!found_data) {
+            LOG_DEBUG("No DATA yet\n");
+            break;
+        }
+
+        _dispatch_defer(lwmac->rx.dispatch_buffer, pkt);
+
+        GOTO_RX_STATE(RX_STATE_SUCCESSFUL, true);
+    }
+    case RX_STATE_SUCCESSFUL:
+    case RX_STATE_FAILED:
+        break;
+    case RX_STATE_STOPPED:
+        LOG_DEBUG("Reception state machine is stopped\n");
+    }
+
+    return reschedule;
+}
+
+/******************************************************************************/
+
+void lwmac_rx_update(lwmac_t* lwmac)
+{
+    /* Update until no rescheduling needed */
+    while(_lwmac_rx_update(lwmac));
+}
+
+/******************************************************************************/

--- a/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
@@ -184,7 +184,6 @@ static bool _lwmac_rx_update(lwmac_t* lwmac)
 
         /* Construct NETIF header and insert address for WA packet */
         gnrc_netif_hdr_init(nethdr_wa, 0, lwmac->rx.l2_addr.len);
-        gnrc_netif_hdr_set_dst_addr(nethdr_wa, lwmac->rx.l2_addr.addr, lwmac->rx.l2_addr.len);
 
         /* Send WA as broadcast*/
         nethdr_wa->flags |= GNRC_NETIF_HDR_FLAGS_BROADCAST;

--- a/sys/net/gnrc/link_layer/lwmac/timeout.c
+++ b/sys/net/gnrc/link_layer/lwmac/timeout.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2015 Daniel Krebs
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net_lwmac
+ * @file
+ * @brief       Timeout handling.
+ *
+ * @author      Daniel Krebs <github@daniel-krebs.net>
+ * @}
+ */
+
+#include <xtimer.h>
+#include <net/gnrc/lwmac/lwmac.h>
+
+#include "include/timeout.h"
+#include "include/lwmac_types.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/******************************************************************************/
+
+#if ENABLE_DEBUG
+char* lwmac_timeout_names[] = {
+    [TIMEOUT_DISABLED]              = "DISABLED",
+    [TIMEOUT_WR]                    = "WR",
+    [TIMEOUT_NO_RESPONSE]           = "NO_RESPONSE",
+    [TIMEOUT_WA]                    = "WA",
+    [TIMEOUT_DATA]                  = "DATA",
+    [TIMEOUT_WAIT_FOR_DEST_WAKEUP]  = "WAIT_FOR_DEST_WAKEUP",
+    [TIMEOUT_WAKEUP_PERIOD]         = "WAKEUP_PERIOD",
+};
+#endif
+
+/******************************************************************************/
+
+static inline void _lwmac_clear_timeout(lwmac_timeout_t* timeout)
+{
+    assert(timeout);
+
+    xtimer_remove(&(timeout->timer));
+    timeout->type = TIMEOUT_DISABLED;
+}
+
+/******************************************************************************/
+
+/* Return index >= 0 if found, -ENONENT if not found */
+static int _lwmac_find_timeout(lwmac_t* lwmac, lwmac_timeout_type_t type)
+{
+    assert(lwmac);
+
+    for(unsigned i = 0; i < LWMAC_TIMEOUT_COUNT; i++)
+    {
+        if(lwmac->timeouts[i].type == type)
+            return i;
+    }
+    return -ENOENT;
+}
+
+/******************************************************************************/
+
+inline bool lwmac_timeout_is_running(lwmac_t* lwmac, lwmac_timeout_type_t type)
+{
+    assert(lwmac);
+    return (_lwmac_find_timeout(lwmac, type) >= 0);
+}
+
+/******************************************************************************/
+
+bool lwmac_timeout_is_expired(lwmac_t* lwmac, lwmac_timeout_type_t type)
+{
+    assert(lwmac);
+
+    int index = _lwmac_find_timeout(lwmac, type);
+    if(index >= 0) {
+        if(lwmac->timeouts[index].expired)
+            _lwmac_clear_timeout(&lwmac->timeouts[index]);
+        return lwmac->timeouts[index].expired;
+    }
+    return false;
+}
+
+/******************************************************************************/
+
+lwmac_timeout_t* _lwmac_acquire_timeout(lwmac_t* lwmac, lwmac_timeout_type_t type)
+{
+    assert(lwmac);
+
+    if(lwmac_timeout_is_running(lwmac, type))
+        return NULL;
+
+    for(unsigned i = 0; i < LWMAC_TIMEOUT_COUNT; i++)
+    {
+        if(lwmac->timeouts[i].type == TIMEOUT_DISABLED)
+        {
+            lwmac->timeouts[i].type = type;
+            return &lwmac->timeouts[i];
+        }
+    }
+    return NULL;
+}
+
+/******************************************************************************/
+
+void lwmac_timeout_make_expire(lwmac_timeout_t* timeout)
+{
+    assert(timeout);
+
+    DEBUG("[lwmac] Timeout %s expired\n", lwmac_timeout_names[timeout->type]);
+    timeout->expired = true;
+}
+
+/******************************************************************************/
+
+void lwmac_clear_timeout(lwmac_t* lwmac, lwmac_timeout_type_t type)
+{
+    assert(lwmac);
+
+    int index = _lwmac_find_timeout(lwmac, type);
+    if(index >= 0)
+        _lwmac_clear_timeout(&lwmac->timeouts[index]);
+}
+
+/******************************************************************************/
+
+void lwmac_set_timeout(lwmac_t* lwmac, lwmac_timeout_type_t type, uint32_t offset)
+{
+    assert(lwmac);
+
+    lwmac_timeout_t* timeout;
+    if( (timeout = _lwmac_acquire_timeout(lwmac, type)) )
+    {
+        DEBUG("[lwmac] Set timeout %s in %"PRIu32" us\n",
+                lwmac_timeout_names[type], offset);
+        timeout->expired = false;
+        timeout->msg.type = LWMAC_EVENT_TIMEOUT_TYPE;
+        timeout->msg.content.ptr = (void*) timeout;
+        xtimer_set_msg(&(timeout->timer), offset,
+                       &(timeout->msg), lwmac->pid);
+    } else {
+        DEBUG("[lwmac] Cannot set timeout %s, too many concurrent timeouts\n",
+                lwmac_timeout_names[type]);
+    }
+}
+
+/******************************************************************************/
+
+void lwmac_reset_timeouts(lwmac_t* lwmac)
+{
+    assert(lwmac);
+
+    for(unsigned i = 0; i < LWMAC_TIMEOUT_COUNT; i++)
+    {
+        if(lwmac->timeouts[i].type != TIMEOUT_DISABLED)
+            _lwmac_clear_timeout(&lwmac->timeouts[i]);
+    }
+}

--- a/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
@@ -1,0 +1,457 @@
+/*
+ * Copyright (C) 2015 Daniel Krebs
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net_lwmac
+ * @file
+ * @brief       Implementation of TX state machine
+ *
+ * @author      Daniel Krebs <github@daniel-krebs.net>
+ * @}
+ */
+
+#include <periph/rtt.h>
+#include <net/gnrc.h>
+#include <net/gnrc/lwmac/lwmac.h>
+#include <net/gnrc/lwmac/packet_queue.h>
+
+#include "include/tx_state_machine.h"
+#include "include/timeout.h"
+#include "include/lwmac_internal.h"
+#include "include/lwmac_types.h"
+
+#define ENABLE_DEBUG    (1)
+#include "debug.h"
+
+#define LOG_LEVEL LOG_WARNING
+#include "log.h"
+
+#undef LOG_ERROR
+#undef LOG_WARNING
+#undef LOG_INFO
+#undef LOG_DEBUG
+
+#define LOG_ERROR(...) LOG(LOG_ERROR, "ERROR: [lwmac-tx] " __VA_ARGS__)
+#define LOG_WARNING(...) LOG(LOG_WARNING, "WARNING: [lwmac-tx] " __VA_ARGS__)
+#define LOG_INFO(...) LOG(LOG_INFO, "[lwmac-tx] " __VA_ARGS__)
+#define LOG_DEBUG(...) LOG(LOG_DEBUG, "[lwmac-tx] " __VA_ARGS__)
+
+/* Break out of switch and mark the need for rescheduling */
+#define GOTO_TX_STATE(tx_state, do_resched) lwmac->tx.state = tx_state; \
+                                reschedule = do_resched; \
+                                break
+
+/******************************************************************************/
+
+void lwmac_tx_start(lwmac_t* lwmac, gnrc_pktsnip_t* pkt, lwmac_tx_neighbour_t* neighbour)
+{
+    assert(lwmac != NULL);
+    assert(pkt != NULL);
+    assert(neighbour != NULL);
+
+    if(lwmac->tx.packet) {
+        LOG_WARNING("Starting but tx.packet is still set\n");
+        gnrc_pktbuf_release(lwmac->tx.packet);
+    }
+
+    lwmac->tx.packet = pkt;
+    lwmac->tx.current_neighbour = neighbour;
+    lwmac->tx.state = TX_STATE_INIT;
+    lwmac->tx.wr_sent = 0;
+}
+
+/******************************************************************************/
+
+void lwmac_tx_stop(lwmac_t* lwmac)
+{
+    if(!lwmac)
+        return;
+
+    lwmac_clear_timeout(lwmac, TIMEOUT_WR);
+    lwmac_clear_timeout(lwmac, TIMEOUT_NO_RESPONSE);
+    lwmac_clear_timeout(lwmac, TIMEOUT_NEXT_BROADCAST);
+    lwmac_clear_timeout(lwmac, TIMEOUT_BROADCAST_END);
+    lwmac->tx.state = TX_STATE_STOPPED;
+
+    /* Release packet in case of failure */
+    if(lwmac->tx.packet) {
+        gnrc_pktbuf_release(lwmac->tx.packet);
+        lwmac->tx.packet = NULL;
+    }
+    lwmac->tx.current_neighbour = NULL;
+}
+
+/******************************************************************************/
+
+/* Returns whether rescheduling is needed or not */
+static bool _lwmac_tx_update(lwmac_t* lwmac)
+{
+    bool reschedule = false;
+
+    if(!lwmac)
+        return reschedule;
+
+    switch(lwmac->tx.state)
+    {
+    case TX_STATE_INIT:
+    {
+        lwmac_clear_timeout(lwmac, TIMEOUT_WR);
+        lwmac_clear_timeout(lwmac, TIMEOUT_NO_RESPONSE);
+        lwmac_clear_timeout(lwmac, TIMEOUT_NEXT_BROADCAST);
+        lwmac_clear_timeout(lwmac, TIMEOUT_BROADCAST_END);
+
+        if(_packet_is_broadcast(lwmac->tx.packet)) {
+            /* Set CSMA retries as configured and enable */
+            uint8_t csma_retries = LWMAC_BROADCAST_CSMA_RETRIES;
+            lwmac->netdev->driver->set(lwmac->netdev, NETOPT_CSMA_RETRIES,
+                                        &csma_retries, sizeof(csma_retries));
+            netopt_enable_t csma_enable = NETOPT_ENABLE;
+            lwmac->netdev->driver->set(lwmac->netdev, NETOPT_CSMA, &csma_enable, sizeof(csma_enable));
+
+            GOTO_TX_STATE(TX_STATE_SEND_BROADCAST, true);
+        } else {
+            /* Don't attempt to send a WR if channel is busy to get timings
+             * right, will be changed for sending DATA packet */
+            netopt_enable_t csma_disable = NETOPT_DISABLE;
+            lwmac->netdev->driver->set(lwmac->netdev, NETOPT_CSMA, &csma_disable, sizeof(csma_disable));
+
+            GOTO_TX_STATE(TX_STATE_SEND_WR, true);
+        }
+    }
+    case TX_STATE_SEND_BROADCAST:
+    {
+        gnrc_pktsnip_t* pkt = lwmac->tx.packet;
+        bool first = false;
+
+        if(lwmac_timeout_is_running(lwmac, TIMEOUT_BROADCAST_END)) {
+            if(lwmac_timeout_is_expired(lwmac, TIMEOUT_BROADCAST_END)) {
+                lwmac_clear_timeout(lwmac, TIMEOUT_NEXT_BROADCAST);
+                gnrc_pktbuf_release(pkt);
+                lwmac->tx.packet = NULL;
+                GOTO_TX_STATE(TX_STATE_SUCCESSFUL, true);
+            }
+        } else {
+            LOG_INFO("Initialize broadcasting\n");
+            lwmac_set_timeout(lwmac, TIMEOUT_BROADCAST_END, LWMAC_BROADCAST_DURATION_US);
+
+            /* Prepare packet with LwMAC header*/
+            lwmac_frame_broadcast_t hdr = {};
+            hdr.header.type = FRAMETYPE_BROADCAST;
+            hdr.seq_nr = lwmac->tx.bcast_seqnr++;
+
+            pkt->next = gnrc_pktbuf_add(pkt->next, &hdr, sizeof(hdr), GNRC_NETTYPE_LWMAC);
+
+            /* No Auto-ACK for broadcast packets */
+            netopt_enable_t autoack = NETOPT_DISABLE;
+            lwmac->netdev->driver->set(lwmac->netdev, NETOPT_AUTOACK, &autoack, sizeof(autoack));
+
+            first = true;
+        }
+
+        if( lwmac_timeout_is_expired(lwmac, TIMEOUT_NEXT_BROADCAST) ||
+            first ) {
+            /* Don't let the packet be released yet, we want to send it again */
+            gnrc_pktbuf_hold(pkt, 1);
+
+            lwmac->netdev->driver->send_data(lwmac->netdev, pkt);
+            _set_netdev_state(lwmac, NETOPT_STATE_TX);
+
+            lwmac_set_timeout(lwmac, TIMEOUT_NEXT_BROADCAST, LWMAC_TIME_BETWEEN_BROADCAST_US);
+            LOG_INFO("Broadcast sent\n");
+        }
+
+        break;
+    }
+    case TX_STATE_SEND_WR:
+    {
+        LOG_DEBUG("TX_STATE_SEND_WR\n");
+
+        gnrc_pktsnip_t* pkt;
+        gnrc_netif_hdr_t *nethdr;
+        uint8_t* dst_addr = NULL;
+        int addr_len;
+
+        /* Get destination address */
+        addr_len = _get_dest_address(lwmac->tx.packet, &dst_addr);
+        if(addr_len <= 0 || addr_len > 8) {
+            LOG_ERROR("Invalid address length: %i\n", addr_len);
+            GOTO_TX_STATE(TX_STATE_FAILED, true);
+        }
+
+        /* Assemble WR */
+        lwmac_frame_wr_t wr_hdr = {};
+        wr_hdr.header.type = FRAMETYPE_WR;
+
+        pkt = gnrc_pktbuf_add(NULL, &wr_hdr, sizeof(wr_hdr), GNRC_NETTYPE_LWMAC);
+        if(pkt == NULL) {
+            LOG_ERROR("Cannot allocate pktbuf of type GNRC_NETTYPE_LWMAC\n");
+            GOTO_TX_STATE(TX_STATE_FAILED, true);
+        }
+
+        pkt = gnrc_pktbuf_add(pkt, NULL, sizeof(gnrc_netif_hdr_t) + addr_len, GNRC_NETTYPE_NETIF);
+        if(pkt == NULL) {
+            LOG_ERROR("Cannot allocate pktbuf of type GNRC_NETTYPE_NETIF\n");
+            GOTO_TX_STATE(TX_STATE_FAILED, true);
+        }
+
+        /* We wouldn't get here if adding the NETIF header had failed, so no
+           sanity checks needed */
+        nethdr = (gnrc_netif_hdr_t*) _gnrc_pktbuf_find(pkt, GNRC_NETTYPE_NETIF);
+
+        /* Construct NETIF header and insert address for WR packet */
+        gnrc_netif_hdr_init(nethdr, 0, addr_len);
+        gnrc_netif_hdr_set_dst_addr(nethdr, dst_addr, addr_len);
+
+        /* Disable Auto ACK */
+        netopt_enable_t autoack = NETOPT_DISABLE;
+        lwmac->netdev->driver->set(lwmac->netdev, NETOPT_AUTOACK, &autoack, sizeof(autoack));
+
+        /* Prepare WR, this will discard any frame in the transceiver that has
+         * possibly arrived in the meantime but we don't care at this point. */
+        lwmac->netdev->driver->send_data(lwmac->netdev, pkt);
+
+        /* First WR, try to catch wakeup phase */
+        if(lwmac->tx.wr_sent == 0) {
+
+            /* Calculate wakeup time */
+            uint32_t wait_until;
+            wait_until  = _phase_to_ticks(lwmac->tx.current_neighbour->phase);
+            wait_until -= RTT_US_TO_TICKS(LWMAC_WR_BEFORE_PHASE_US);
+
+            /* This output blocks a long time and can prevent correct timing */
+            LOG_DEBUG("Phase length:  %"PRIu32"\n", RTT_US_TO_TICKS(LWMAC_WAKEUP_INTERVAL_US));
+            LOG_DEBUG("Wait until:    %"PRIu32"\n", wait_until);
+            LOG_DEBUG("     phase:    %"PRIu32"\n", _ticks_to_phase(wait_until));
+            LOG_DEBUG("Ticks to wait: %"PRIu32"\n", (long int)wait_until - rtt_get_counter());
+
+            /* Wait until calculated wakeup time of destination */
+            while(rtt_get_counter() < wait_until);
+        }
+
+        /* Save timestamp in case this WR reaches the destination node so that
+         * we know it's wakeup phase relative to ours for the next time. This
+         * is not exactly the time the WR was completely sent, but the timing
+         * we can reproduce here. */
+        lwmac->tx.timestamp = rtt_get_counter();
+
+        /* Trigger sending frame */
+        _set_netdev_state(lwmac, NETOPT_STATE_TX);
+
+        /* Flush RX queue, TODO: maybe find a way without loosing RX packets */
+        packet_queue_flush(&lwmac->rx.queue);
+
+        GOTO_TX_STATE(TX_STATE_WAIT_WR_SENT, false);
+    }
+    case TX_STATE_WAIT_WR_SENT:
+    {
+        LOG_DEBUG("TX_STATE_WAIT_WR_SENT\n");
+
+        if(lwmac->tx_feedback == TX_FEEDBACK_UNDEF) {
+            LOG_DEBUG("WR not yet completely sent\n");
+            break;
+        }
+
+        if(lwmac->tx.wr_sent == 0) {
+            lwmac_set_timeout(lwmac, TIMEOUT_NO_RESPONSE, LWMAC_WAKEUP_INTERVAL_US);
+        }
+
+        lwmac->tx.wr_sent++;
+
+        /* This is not needed anymore, because WRs are sent without CSMA/CA */
+//        if(lwmac->tx_feedback == TX_FEEDBACK_BUSY) {
+//            LOG_DEBUG("WR could not be sent, retry\n");
+//            GOTO_TX_STATE(TX_STATE_SEND_WR, true);
+//        }
+
+        /* Set timeout for next WR in case no WA will be received */
+        lwmac_set_timeout(lwmac, TIMEOUT_WR, LWMAC_TIME_BETWEEN_WR_US);
+
+        /* Debug WR timing */
+        LOG_DEBUG("Destination phase was: %"PRIu32"\n", lwmac->tx.current_neighbour->phase);
+        LOG_DEBUG("Phase when sent was:   %"PRIu32"\n", _ticks_to_phase(lwmac->tx.timestamp));
+        LOG_DEBUG("Ticks when sent was:   %"PRIu32"\n", lwmac->tx.timestamp);
+
+        GOTO_TX_STATE(TX_STATE_WAIT_FOR_WA, false);
+    }
+    case TX_STATE_WAIT_FOR_WA:
+    {
+        LOG_DEBUG("TX_STATE_WAIT_FOR_WA\n");
+
+        gnrc_pktsnip_t* pkt;
+        bool found_wa = false;
+        bool postponed = false;
+        bool from_expected_destination = false;
+
+        if(lwmac_timeout_is_expired(lwmac, TIMEOUT_NO_RESPONSE)) {
+            LOG_DEBUG("No response from destination\n");
+            GOTO_TX_STATE(TX_STATE_FAILED, true);
+        }
+
+        if(lwmac_timeout_is_expired(lwmac, TIMEOUT_WR)) {
+            GOTO_TX_STATE(TX_STATE_SEND_WR, true);
+        }
+
+        if(_get_netdev_state(lwmac) == NETOPT_STATE_RX) {
+            LOG_WARNING("Wait for completion of frame reception\n");
+            break;
+        }
+
+        while( (pkt = packet_queue_pop(&lwmac->rx.queue)) != NULL )
+        {
+            LOG_DEBUG("Inspecting pkt @ %p\n", pkt);
+
+            /* Parse packet */
+            lwmac_packet_info_t info;
+            int ret = _parse_packet(pkt, &info);
+
+            if(ret != 0) {
+                LOG_DEBUG("Packet could not be parsed: %i\n", ret);
+                gnrc_pktbuf_release(pkt);
+                continue;
+            }
+
+            if(_addr_match(&info.src_addr, &lwmac->tx.current_neighbour->l2_addr)) {
+                from_expected_destination = true;
+            }
+
+            if(info.header->type == FRAMETYPE_BROADCAST) {
+                _dispatch_defer(lwmac->rx.dispatch_buffer, pkt);
+                /* Drop pointer to it can't get released */
+                pkt = NULL;
+            }
+
+            /* Check if destination is talking to another node. It will sleep
+             * after a finished transaction so there's no point in trying any
+             * further now. */
+            if( !_addr_match(&info.dst_addr, &lwmac->l2_addr) &&
+                 from_expected_destination) {
+                _queue_tx_packet(lwmac, lwmac->tx.packet);
+                /* drop pointer so it wont be free'd */
+                lwmac->tx.packet = NULL;
+                postponed = true;
+                gnrc_pktbuf_release(pkt);
+                break;
+            }
+
+            if(info.header->type == FRAMETYPE_BROADCAST) {
+                continue;
+            }
+
+            if(info.header->type != FRAMETYPE_WA) {
+                LOG_DEBUG("Packet is not WA: 0x%02x\n", info.header->type);
+                gnrc_pktbuf_release(pkt);
+                continue;
+            }
+
+            /* No need to keep pkt anymore */
+            gnrc_pktbuf_release(pkt);
+
+            if(!from_expected_destination) {
+                LOG_DEBUG("Packet is not from expected destination\n");
+                break;
+            }
+
+            /* All checks passed so this must be a valid WA */
+            lwmac_clear_timeout(lwmac, TIMEOUT_WR);
+            lwmac_clear_timeout(lwmac, TIMEOUT_NO_RESPONSE);
+            found_wa = true;
+            break;
+        }
+
+        if(postponed) {
+            LOG_INFO("Destination is talking to another node, postpone\n");
+            GOTO_TX_STATE(TX_STATE_FAILED, true);
+        }
+
+        if(!found_wa) {
+            LOG_DEBUG("No WA yet\n");
+            break;
+        }
+
+        /* WR arrived at destination, so calculate destination wakeup phase
+         * based on the timestamp of the WR we sent */
+         uint32_t new_phase = _ticks_to_phase(lwmac->tx.timestamp);
+
+        /* Save newly calculated phase for destination */
+        lwmac->tx.current_neighbour->phase = new_phase;
+        LOG_INFO("New phase: %"PRIu32"\n", new_phase);
+
+        /* We've got our WA, so discard the rest, TODO: no flushing */
+        packet_queue_flush(&lwmac->rx.queue);
+
+        GOTO_TX_STATE(TX_STATE_SEND_DATA, true);
+    }
+    case TX_STATE_SEND_DATA:
+    {
+        LOG_DEBUG("TX_STATE_SEND_DATA\n");
+
+        gnrc_pktsnip_t* pkt = lwmac->tx.packet;
+
+        /* Enable Auto ACK again */
+        netopt_enable_t autoack = NETOPT_ENABLE;
+        lwmac->netdev->driver->set(lwmac->netdev, NETOPT_AUTOACK, &autoack, sizeof(autoack));
+
+        /* It's okay to retry sending DATA. Timing doesn't matter anymore and
+         * destination is waiting for a certain amount of time. */
+        uint8_t csma_retries = LWMAC_DATA_CSMA_RETRIES;
+        lwmac->netdev->driver->set(lwmac->netdev, NETOPT_CSMA_RETRIES, &csma_retries, sizeof(csma_retries));
+
+        netopt_enable_t csma_enable = NETOPT_ENABLE;
+        lwmac->netdev->driver->set(lwmac->netdev, NETOPT_CSMA, &csma_enable, sizeof(csma_enable));
+
+        /* Insert lwMAC header above NETIF header */
+        lwmac_hdr_t hdr = {FRAMETYPE_DATA};
+        pkt->next = gnrc_pktbuf_add(pkt->next, &hdr, sizeof(hdr), GNRC_NETTYPE_LWMAC);
+
+        /* Send data */
+        lwmac->netdev->driver->send_data(lwmac->netdev, pkt);
+        _set_netdev_state(lwmac, NETOPT_STATE_TX);
+
+        /* Packet has been released by netdev, so drop pointer */
+        lwmac->tx.packet = NULL;
+
+        GOTO_TX_STATE(TX_STATE_WAIT_FEEDBACK, false);
+    }
+    case TX_STATE_WAIT_FEEDBACK:
+    {
+        LOG_DEBUG("TX_STATE_WAIT_FEEDBACK\n");
+        if(lwmac->tx_feedback == TX_FEEDBACK_UNDEF) {
+            break;
+        } else if(lwmac->tx_feedback == TX_FEEDBACK_SUCCESS) {
+            GOTO_TX_STATE(TX_STATE_SUCCESSFUL, true);
+        } else if(lwmac->tx_feedback == TX_FEEDBACK_NOACK) {
+            LOG_ERROR("Not ACKED\n");
+            GOTO_TX_STATE(TX_STATE_FAILED, true);
+        } else if(lwmac->tx_feedback == TX_FEEDBACK_BUSY) {
+            LOG_ERROR("Channel busy \n");
+            GOTO_TX_STATE(TX_STATE_FAILED, true);
+        }
+
+        LOG_ERROR("Tx feedback unhandled: %i\n", lwmac->tx_feedback);
+        GOTO_TX_STATE(TX_STATE_FAILED, true);
+    }
+    case TX_STATE_SUCCESSFUL:
+    case TX_STATE_FAILED:
+        break;
+    case TX_STATE_STOPPED:
+        LOG_DEBUG("Transmission state machine is stopped\n");
+    }
+
+    return reschedule;
+}
+
+/******************************************************************************/
+
+void lwmac_tx_update(lwmac_t* lwmac)
+{
+    /* Update until no rescheduling needed */
+    while(_lwmac_tx_update(lwmac));
+}
+
+/******************************************************************************/

--- a/sys/net/gnrc/pktdump/gnrc_pktdump.c
+++ b/sys/net/gnrc/pktdump/gnrc_pktdump.c
@@ -31,6 +31,7 @@
 #include "net/ipv6/hdr.h"
 #include "net/udp.h"
 #include "net/sixlowpan.h"
+#include "net/gnrc/lwmac/hdr.h"
 #include "od.h"
 
 /**
@@ -54,6 +55,12 @@ static void _dump_snip(gnrc_pktsnip_t *pkt)
         case GNRC_NETTYPE_NETIF:
             printf("NETTYPE_NETIF (%i)\n", pkt->type);
             gnrc_netif_hdr_print(pkt->data);
+            break;
+#endif
+#ifdef MODULE_GNRC_LWMAC
+        case GNRC_NETTYPE_LWMAC:
+            printf("GNRC_NETTYPE_LWMAC (%i)\n", pkt->type);
+            lwmac_print_hdr(pkt->data);
             break;
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN

--- a/tests/driver_at86rf2xx/Makefile
+++ b/tests/driver_at86rf2xx/Makefile
@@ -1,32 +1,77 @@
 APPLICATION = driver_at86rf2xx
 include ../Makefile.tests_common
 
+BOARD=samr21-xpro
+
 FEATURES_REQUIRED = periph_spi periph_gpio
 
-DISABLE_MODULE += auto_init
+BOARD_INSUFFICIENT_MEMORY := stm32f0discovery
+BOARD_BLACKLIST        := nucleo-f334
+# nucleo-f334:  not enough GPIO pins defined
 
-USEMODULE += od
+ifneq (,$(filter samr21-xpro,$(BOARD)))
+  DRIVER ?= at86rf233
+  USE_BOARD_PARAMETERS:=false
+endif
+ifneq (,$(filter iotlab-m3,$(BOARD)))
+  DRIVER ?= at86rf231
+  USE_BOARD_PARAMETERS:=true
+endif
+
+ifneq (,$(DRIVER))
+  USEMODULE += $(DRIVER)
+else
+  # default to at86rf231
+  USEMODULE += at86rf231
+endif
+
+ifneq (true,$(USE_BOARD_PARAMETERS))
+  # This adds . to include path so generic at86rf2xx_params.h gets picked
+  # up.  All boards actually having such a device on board should define
+  # USE_BOARD_PARAMETERS=true above to skip this step, as the board provides
+  # this header.
+  CFLAGS += -I$(CURDIR)
+
+ifneq (,$(ATRF_SPI))
+  CFLAGS += -DATRF_SPI=$(ATRF_SPI)
+else
+  CFLAGS += -DATRF_SPI=SPI_0                # set default
+endif
+ifneq (,$(ATRF_CS))
+  CFLAGS += -DATRF_CS=$(ATRF_CS)
+else
+  CFLAGS += -DATRF_CS="GPIO_PIN(PB, 31)"           # set default
+endif
+ifneq (,$(ATRF_INT))
+  CFLAGS += -DATRF_INT=$(ATRF_INT)
+else
+  CFLAGS += -DATRF_INT="GPIO_PIN(PB, 0)"          # set default
+endif
+ifneq (,$(ATRF_SLEEP))
+  CFLAGS += -DATRF_SLEEP=$(ATRF_SLEEP)
+else
+  CFLAGS += -DATRF_SLEEP="GPIO_PIN(PA, 20)"        # set default
+endif
+ifneq (,$(ATRF_RESET))
+  CFLAGS += -DATRF_RESET=$(ATRF_RESET)
+else
+  CFLAGS += -DATRF_RESET="GPIO_PIN(PB, 15)"        # set default
+endif
+ifneq (,$(ATRF_SPI_SPEED))
+  CFLAGS += -DATRF_SPI_SPEED=$(ATRF_SPI_SPEED)
+endif
+
+endif # USE_BOARD_PARAMETERS=false
+
+USEMODULE += auto_init_gnrc_netif
+USEMODULE += gnrc_netif
+USEMODULE += gnrc_lwmac
+USEMODULE += gnrc_pktdump
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
-# define the driver to be used for selected boards
-ifneq (,$(filter samr21-xpro,$(BOARD)))
-  DRIVER := at86rf233
-endif
-ifneq (,$(filter iotlab-m3 fox,$(BOARD)))
-  DRIVER := at86rf231
-endif
-ifneq (,$(filter mulle,$(BOARD)))
-  DRIVER := at86rf212b
-endif
-
-# use the at86rf231 as fallback device
-DRIVER ?= at86rf231
-
-# include the selected driver
-USEMODULE += $(DRIVER)
-
 CFLAGS += -DDEVELHELP
+CFLAGS += -fdiagnostics-color=auto
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
I have developed a (not so) simple (anymore) duty cycling MAC protocol focused for IEEE 802.15.4 transceiver. It has the working title "LwMAC" which stands for "lightweight MAC", I really didn't have a better idea. This is still work-in-progress but has reached a point where maybe someone else might want to try it or comment on it's future development.

In the current state it behaves like the ~~`LPEA`~~ `LPEAS` protocol described in [this paper](http://ieeexplore.ieee.org/xpls/abs_all.jsp?arnumber=4539479) (sorry, there doesn't seem to be a free source). This is quite similiar to [ContikiMAC](http://dunkels.com/adam/dunkels11contikimac.pdf), but doesn't provide compatibility (yet). ~~Later it's planned to add implicit synchronization with neighbor nodes, i.e. extent to `LPEAS`.~~ Done

I created a quick [overview](http://docdro.id/sbNzH7D) of the overall structure. Maybe this helps to better understand all the moving parts. Yet there is no overview over the RX or TX state machines.

It still has bugs and TODOs, so I want to use this PR as my TODO list.

Currently this depends on ~~#3138~~ ~~#3619~~ ~~#3729~~ ~~#4078~~ ~~#3867~~ ~~#4081~~ ~~#2309~~  
Incorporates, but not critical: ~~#3993~~ ~~#3868~~ ~~#3887~~ ~~#4015~~ #4058  ~~#3954~~ 
# TODOs
- ~~use gnrc pktqueue~~
- ~~implement broadcast~~
- ~~verify duty cycling~~
- ~~implement implicit sync~~
- use xtimer instead of RTT peripheral when low power timer source is implemented (#3990 et al.)
- update documentation, make clear what's supposed to be changed by the user
- rework error logging
- integrate properly and implement selection of mac layer
- review and address inline TODOs
- major cleanup
# How to test

Currently you should use the `samr21-xpro` board to test this, because certain features (see depending PRs) are only available on that platform. And it's the only I can test :-)

Flash to board with the at86rf2xx driver test:

``` bash
$ cd tests/driver_at86rf2xx
$ BOARD=samr21-xpro make flash term
```

Then manually send packet from one board to the other via interactive shell(~~**note:** baudrate is 921600~~) 

```
txtsnd 4 xx:xx Helloxx
```

or even as broadcast:

```
txtsnd 4 bcast aReallyBroadCast
```

You can use a packet sniffer to verify the communication or just check if packets arrive at the destination by flashing the same test.
