### PR TITLE
make: get the git directory from RIOTBASE

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -167,9 +167,9 @@ include $(RIOTBASE)/Makefile.cflags
 
 # make the RIOT version available to the program
 ifeq ($(origin RIOT_VERSION), undefined)
-  GIT_STRING := $(shell git describe --always --abbrev=4 --dirty=-`hostname` 2> /dev/null)
+  GIT_STRING := $(shell git --git-dir="$(RIOTBASE)/.git" describe --always --abbrev=4 --dirty=-`hostname` 2> /dev/null)
   ifneq (,$(GIT_STRING))
-    GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+    GIT_BRANCH := $(shell git --git-dir="$(RIOTBASE)/.git" rev-parse --abbrev-ref HEAD)
     ifeq ($(strip $(GIT_BRANCH)),master)
       RIOT_VERSION := $(GIT_STRING)
     else


### PR DESCRIPTION
This allows having applications outside of RIOT's own git directory and
still get the correct branch information for the build.