### PR TITLE
tests: periph_gpio: fix usage of shell_commands

### DIFF
--- a/tests/driver_pcd8544/main.c
+++ b/tests/driver_pcd8544/main.c
@@ -176,9 +176,9 @@ int main(void)
     puts("All OK, running shell now");
 #ifndef MODULE_NEWLIB
     (void) posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
+    shell_init(&shell, shell_commands, SHELL_BUFSIZE, uart0_readc, uart0_putc);
 #else
-    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
+    shell_init(&shell, shell_commands, SHELL_BUFSIZE, getchar, putchar);
 #endif
     shell_run(&shell);
 

--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -253,9 +253,9 @@ int main(void)
     /* start the shell */
 #ifndef MODULE_NEWLIB
     (void) posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, NULL, SHELL_BUFSIZE, uart0_readc, uart0_putc);
+    shell_init(&shell, shell_commands, SHELL_BUFSIZE, uart0_readc, uart0_putc);
 #else
-    shell_init(&shell, NULL, SHELL_BUFSIZE, getchar, putchar);
+    shell_init(&shell, shell_commands, SHELL_BUFSIZE, getchar, putchar);
 #endif
     shell_run(&shell);
 

--- a/tests/periph_i2c/main.c
+++ b/tests/periph_i2c/main.c
@@ -319,9 +319,9 @@ int main(void)
     /* prepare I/O for shell */
     board_uart0_init();
     (void) posix_open(uart0_handler_pid, 0);
-    shell_init(&shell, NULL, UART0_BUFSIZE, uart0_readc, uart0_putc);
+    shell_init(&shell, shell_commands, UART0_BUFSIZE, uart0_readc, uart0_putc);
 #else
-    shell_init(&shell, NULL, UART0_BUFSIZE, getchar, putchar);
+    shell_init(&shell, shell_commands, UART0_BUFSIZE, getchar, putchar);
 #endif
 
     /* define own shell commands */


### PR DESCRIPTION
tests/periph_gpio doesn't show it's custom shell handlers anymore. Fix in this PR.
Reported in #3735. Introduced by #3690.