### PR TITLE
tests: rename BOARD_INSUFFICIENT_RAM => BOARD_INSUFFICIENT_MEMORY

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -40,7 +40,7 @@ buildtest:
 	APP_RETRY=0; \
 	rm -rf "$$BINDIRBASE"; \
 	for BOARD in $$($(MAKE) -s info-boards-supported); do \
-		RIOTNOLINK=$$(echo $(BOARD_INSUFFICIENT_RAM) | grep $${BOARD} 2>&1 >/dev/null && echo 1); \
+		RIOTNOLINK=$$(echo $(BOARD_INSUFFICIENT_MEMORY) | grep $${BOARD} 2>&1 >/dev/null && echo 1); \
 		${COLOR_ECHO} -n "Building for $${BOARD} "; \
 		[ -n "$${RIOTNOLINK}" ] && ${COLOR_ECHO} -n "(no linking) "; \
 		for NTH_TRY in 1 2 3; do \

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -7,7 +7,7 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_RAM := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
                           nrf6310 nucleo-f334 pca10000 pca10005 redbee-econotag \
                           stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 \
                           yunjia-nrf51822 z1

--- a/examples/riot_and_cpp/Makefile
+++ b/examples/riot_and_cpp/Makefile
@@ -6,7 +6,7 @@ BOARD ?= native
 
 # stm32f0discovery objects are too big with ARM Embedded Toolchain v4.9.3 20141119
 # (used currently by travis)
-BOARD_INSUFFICIENT_RAM=stm32f0discovery
+BOARD_INSUFFICIENT_MEMORY=stm32f0discovery
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..

--- a/tests/coap/Makefile
+++ b/tests/coap/Makefile
@@ -5,7 +5,7 @@ include ../Makefile.tests_common
 BOARD_BLACKLIST := arduino-mega2560 chronos msb-430 msb-430h telosb \
                    wsn430-v1_3b wsn430-v1_4 z1
 
-BOARD_INSUFFICIENT_RAM := redbee-econotag
+BOARD_INSUFFICIENT_MEMORY := redbee-econotag
 
 USEPKG += libcoap
 

--- a/tests/cpp11_condition_variable/Makefile
+++ b/tests/cpp11_condition_variable/Makefile
@@ -10,7 +10,7 @@ BOARD ?= native
 # Debian jessie libstdc++-arm-none-eabi-newlib-4.8.3-9+4 works fine, though.
 # Remove this line if Travis is upgraded to a different toolchain which does
 # not pull in all C++ locale code whenever exceptions are used.
-BOARD_INSUFFICIENT_RAM := stm32f0discovery spark-core nucleo-f334
+BOARD_INSUFFICIENT_MEMORY := stm32f0discovery spark-core nucleo-f334
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..

--- a/tests/cpp11_mutex/Makefile
+++ b/tests/cpp11_mutex/Makefile
@@ -10,7 +10,7 @@ BOARD ?= native
 # Debian jessie libstdc++-arm-none-eabi-newlib-4.8.3-9+4 works fine, though.
 # Remove this line if Travis is upgraded to a different toolchain which does
 # not pull in all C++ locale code whenever exceptions are used.
-BOARD_INSUFFICIENT_RAM := stm32f0discovery spark-core nucleo-f334
+BOARD_INSUFFICIENT_MEMORY := stm32f0discovery spark-core nucleo-f334
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..

--- a/tests/cpp11_thread/Makefile
+++ b/tests/cpp11_thread/Makefile
@@ -10,7 +10,7 @@ BOARD ?= native
 # Debian jessie libstdc++-arm-none-eabi-newlib-4.8.3-9+4 works fine, though.
 # Remove this line if Travis is upgraded to a different toolchain which does
 # not pull in all C++ locale code whenever exceptions are used.
-BOARD_INSUFFICIENT_RAM := stm32f0discovery spark-core nucleo-f334
+BOARD_INSUFFICIENT_MEMORY := stm32f0discovery spark-core nucleo-f334
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..

--- a/tests/driver_at86rf2xx/Makefile
+++ b/tests/driver_at86rf2xx/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi periph_gpio
 
-BOARD_INSUFFICIENT_RAM := stm32f0discovery
+BOARD_INSUFFICIENT_MEMORY := stm32f0discovery
 BOARD_BLACKLIST        := nucleo-f334
 # nucleo-f334:  not enough GPIO pins defined
 

--- a/tests/driver_kw2xrf/Makefile
+++ b/tests/driver_kw2xrf/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi periph_gpio
 
-BOARD_INSUFFICIENT_RAM := stm32f0discovery nucleo-f334
+BOARD_INSUFFICIENT_MEMORY := stm32f0discovery nucleo-f334
 
 ifneq (,$(filter pba-d-01-kw2x,$(BOARD)))
   DRIVER ?= kw2xrf

--- a/tests/driver_xbee/Makefile
+++ b/tests/driver_xbee/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_uart periph_gpio
 
-BOARD_INSUFFICIENT_RAM := stm32f0discovery
+BOARD_INSUFFICIENT_MEMORY := stm32f0discovery
 
 # Define default pin mappings for some boards:
 ifneq (,$(filter stm32f0discovery,$(BOARD)))

--- a/tests/posix_semaphore/Makefile
+++ b/tests/posix_semaphore/Makefile
@@ -1,7 +1,7 @@
 APPLICATION = posix_semaphore
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_RAM := msb-430 msb-430h mbed_lpc1768 redbee-econotag chronos stm32f0discovery \
+BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h mbed_lpc1768 redbee-econotag chronos stm32f0discovery \
                           pca10000 pca10005 yunjia-nrf51822 nrf6310 spark-core
 
 USEMODULE += posix

--- a/tests/pthread_barrier/Makefile
+++ b/tests/pthread_barrier/Makefile
@@ -5,8 +5,8 @@ include ../Makefile.tests_common
 BOARD_BLACKLIST := arduino-mega2560
 # arduino-mega2560: unknown type name: clockid_t
 
-# exclude boards with insufficient RAM
-BOARD_INSUFFICIENT_RAM :=  stm32f0discovery
+# exclude boards with insufficient memory
+BOARD_INSUFFICIENT_MEMORY :=  stm32f0discovery
 
 # Modules to include.
 USEMODULE += pthread

--- a/tests/pthread_condition_variable/Makefile
+++ b/tests/pthread_condition_variable/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.tests_common
 BOARD_BLACKLIST := arduino-mega2560
 # arduino-mega2560: unknown type name: clockid_t
 
-BOARD_INSUFFICIENT_RAM := stm32f0discovery
+BOARD_INSUFFICIENT_MEMORY := stm32f0discovery
 
 USEMODULE += posix
 USEMODULE += pthread

--- a/tests/pthread_rwlock/Makefile
+++ b/tests/pthread_rwlock/Makefile
@@ -12,7 +12,7 @@ DISABLE_MODULE += auto_init
 
 CFLAGS += -DNATIVE_AUTO_EXIT
 
-BOARD_INSUFFICIENT_RAM += chronos mbed_lpc1768 msb-430 msb-430h stm32f0discovery \
+BOARD_INSUFFICIENT_MEMORY += chronos mbed_lpc1768 msb-430 msb-430h stm32f0discovery \
                           pca10000 pca10005 yunjia-nrf51822 spark-core nucleo-f334 \
                           airfy-beacon nrf51dongle nrf6310
 

--- a/tests/slip/Makefile
+++ b/tests/slip/Makefile
@@ -1,7 +1,7 @@
 APPLICATION = driver_slip
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_RAM := stm32f0discovery
+BOARD_INSUFFICIENT_MEMORY := stm32f0discovery
 
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -1,7 +1,7 @@
 APPLICATION = thread_cooperation
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_RAM := chronos msb-430 msb-430h mbed_lpc1768 \
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h mbed_lpc1768 \
                           redbee-econotag stm32f0discovery pca10000 pca10005 \
                           yunjia-nrf51822 spark-core airfy-beacon nucleo-f334 \
                           nrf51dongle nrf6310

--- a/tests/thread_msg/Makefile
+++ b/tests/thread_msg/Makefile
@@ -1,7 +1,7 @@
 APPLICATION = thread_msg
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_RAM := stm32f0discovery
+BOARD_INSUFFICIENT_MEMORY := stm32f0discovery
 
 DISABLE_MODULE += auto_init
 

--- a/tests/thread_msg_seq/Makefile
+++ b/tests/thread_msg_seq/Makefile
@@ -1,7 +1,7 @@
 APPLICATION = thread_msg_seq
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_RAM := stm32f0discovery
+BOARD_INSUFFICIENT_MEMORY := stm32f0discovery
 
 DISABLE_MODULE += auto_init
 

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -1,7 +1,7 @@
 APPLICATION = unittests
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_RAM := airfy-beacon chronos msb-430 msb-430h pca10000 \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h pca10000 \
                           pca10005 redbee-econotag spark-core stm32f0discovery \
                           telosb wsn430-v1_3b wsn430-v1_4 z1 nucleo-f334 \
                           yunjia-nrf51822 samr21-xpro arduino-mega2560 \

--- a/tests/vtimer_msg_diff/Makefile
+++ b/tests/vtimer_msg_diff/Makefile
@@ -1,7 +1,7 @@
 APPLICATION = vtimer_msg_diff
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_RAM := mbed_lpc1768 stm32f0discovery nrf6310 pca10000 pca10005
+BOARD_INSUFFICIENT_MEMORY := mbed_lpc1768 stm32f0discovery nrf6310 pca10000 pca10005
 
 USEMODULE += vtimer
 


### PR DESCRIPTION
This PR renames all occurences of `BOARD_INSUFFICIENT_RAM` to `BOARD_INSUFFICIENT_MEMORY`. See the discussion here: fixes #3065 