### PR TITLE
gnrc_ndp_node: put next_hop_actual in correct scope

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
+++ b/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
@@ -71,11 +71,11 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
     next_hop_ip = ipv6_ext_rh_next_hop(hdr);
 #endif
 #ifdef MODULE_FIB
+    ipv6_addr_t next_hop_actual;    /* FIB copies address into this variable */
     /* don't look-up link local addresses in FIB */
     if (!ipv6_addr_is_link_local(dst)) {
         size_t next_hop_size = sizeof(ipv6_addr_t);
         uint32_t next_hop_flags = 0;
-        ipv6_addr_t next_hop_actual;    /* FIB copies address into this variable */
 
         if ((next_hop_ip == NULL) &&
             (fib_get_next_hop(gnrc_ipv6_fib_table, &iface, next_hop_actual.u8, &next_hop_size,


### PR DESCRIPTION
In the if-block the pointer gets free'd as soon as the if-block is
exited. This PR prevents that.