### PR TITLE
gnrc_ipv6_nc: adapt neighbor cache for different ND implementations

### DIFF
--- a/sys/include/net/gnrc/ipv6/nc.h
+++ b/sys/include/net/gnrc/ipv6/nc.h
@@ -25,6 +25,7 @@
 #include <stdint.h>
 
 #include "kernel_types.h"
+#include "net/eui64.h"
 #include "net/ipv6/addr.h"
 #include "net/gnrc/netif.h"
 #include "net/gnrc/pktqueue.h"
@@ -118,7 +119,9 @@ extern "C" {
  *          </a>.
  */
 typedef struct {
+#ifdef MODULE_GNRC_NDP_NODE
     gnrc_pktqueue_t *pkts;                      /**< Packets waiting for address resolution */
+#endif
     ipv6_addr_t ipv6_addr;                      /**< IPv6 address of the neighbor */
     uint8_t l2_addr[GNRC_IPV6_NC_L2_ADDR_MAX];  /**< Link layer address of the neighbor */
     uint8_t l2_addr_len;                        /**< Length of gnrc_ipv6_nc_t::l2_addr */
@@ -142,6 +145,15 @@ typedef struct {
      *      </a>
      */
     vtimer_t nbr_adv_timer;
+
+#ifdef MODULE_GNRC_SIXLOWPAN_ND
+    vtimer_t rtr_sol_timer; /**< Retransmission timer for unicast router solicitations */
+#endif
+#ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
+    vtimer_t type_timeout;                  /**< Timer for type transissions */
+    eui64_t eui64;                          /**< the unique EUI-64 of the neighbor (might be
+                                             *   different from L2 address, if l2_addr_len == 2) */
+#endif
 
     uint8_t probes_remaining;               /**< remaining number of unanswered probes */
     /**


### PR DESCRIPTION
Preparation PR for #3748 and follow-ups

~~Depends on #3628, since that one changes a lot in `gnrc_ndp.c` (including lines that the adaptations for this PR are touching) and I want to have as few as possible merge conflicts when rebasing #3134.~~ (merged)

* `gnrc_ipv6_nc_t::pkts` is made option, [6LoWPAN-ND does not require](https://tools.ietf.org/html/rfc6775#page-27) queueing packets
* Introduction of `gnrc_ipv6_nc_t::rtr_sol_timer`: for unicast router solicitations to neighboring routers to [re-acquire information that is about to be invalidated](https://tools.ietf.org/html/rfc6775#section-5.4.3).
* Introduction of `gnrc_ipv6_nc_t::type_timeout`: for the timed transition of NCE types ([REGISTERED -> DELETE](https://tools.ietf.org/html/rfc6775#section-6.5.3) and [TENTATIVE -> delete](https://tools.ietf.org/html/rfc6775#section-6.3)).
* Introduction of `gnrc_ipv6_nc_t::eui64`: 6LoWPAN-ND uses [the neighbor's EUI-64 to uniquely identify it](https://tools.ietf.org/html/rfc6775#section-1.3), even if it uses the 16-bit short address for link-layer addressing.