### PR TITLE
gnrc_ipv6_netif: prepare for router discovery

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -1999,7 +1999,8 @@ PREDEFINED             = DOXYGEN \
                          UART_NUMOF \
                          DEVELHELP \
                          ENABLE_DEBUG \
-                         TEST_SUITES
+                         TEST_SUITES \
+                         MODULE_GNRC_NDP_ROUTER
 
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -190,7 +190,10 @@ void gnrc_ipv6_netif_remove(kernel_pid_t pid)
 #endif
 
     mutex_lock(&entry->mutex);
-
+    vtimer_remove(&entry->rtr_sol_timer);
+#ifdef MODULE_GNRC_NDP_ROUTER
+    vtimer_remove(&entry->rtr_adv_timer);
+#endif
     _reset_addr_from_entry(entry);
     DEBUG("ipv6 netif: Remove IPv6 interface %" PRIkernel_pid "\n", pid);
     entry->pid = KERNEL_PID_UNDEF;


### PR DESCRIPTION
Adds some new flags and fields to the IPv6 interfaces required for router discovery (and also makes some functions private, that turned out to be a little bit more complicated there).