### PR TITLE
gnrc_ndp_host: Initial import of host behavior of router discovery

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -80,17 +80,27 @@ endif
 ifneq (,$(filter gnrc_ipv6_default,$(USEMODULE)))
   USEMODULE += gnrc_ipv6
   USEMODULE += gnrc_icmpv6
-  USEMODULE += gnrc_ndp
-  USEMODULE += gnrc_ndp_internal
-  USEMODULE += gnrc_ndp_node
+  USEMODULE += gnrc_ndp_host
 endif
 
 ifneq (,$(filter gnrc_ipv6_router_default,$(USEMODULE)))
   USEMODULE += gnrc_ipv6_router
   USEMODULE += gnrc_icmpv6
-  USEMODULE += gnrc_ndp
-  USEMODULE += gnrc_ndp_internal
   USEMODULE += gnrc_ndp_node
+endif
+
+ifneq (,$(filter gnrc_ndp_host,$(USEMODULE)))
+  USEMODULE += gnrc_ndp_node
+  USEMODULE += random
+  USEMODULE += vtimer
+endif
+
+ifneq (,$(filter gnrc_ndp_node,$(USEMODULE)))
+  USEMODULE += gnrc_ndp_internal
+endif
+
+ifneq (,$(filter gnrc_ndp_%,$(USEMODULE)))
+  USEMODULE += gnrc_ndp
 endif
 
 ifneq (,$(filter gnrc_ndp,$(USEMODULE)))

--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -195,6 +195,18 @@ extern "C" {
 #define GNRC_IPV6_NETIF_FLAGS_IS_WIRED          (0x0080)
 
 /**
+ * @brief   Offset of the router advertisement flags compared to the position in router
+ *          advertisements.
+ */
+#define GNRC_IPV6_NETIF_FLAGS_RTR_ADV_POS       (8U)
+
+/**
+ * @brief   Mask for flags intended for router advertisements.
+ * @note    Please expand if more router advertisement flags are introduced.
+ */
+#define GNRC_IPV6_NETIF_FLAGS_RTR_ADV_MASK      (0xc000)
+
+/**
  * @brief   Flag to indicate that the interface has other address
  *          configuration.
  */

--- a/sys/include/net/gnrc/ndp/host.h
+++ b/sys/include/net/gnrc/ndp/host.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_gnrc_ndp_host Host-specific part of router discovery.
+ * @ingroup     net_gnrc_ndp
+ * @brief       Host-specific part for the router discovery in IPv6
+ *              neighbor discovery.
+ * @{
+ *
+ * @file
+ * @brief   Host-specific router discovery definitions
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+#ifndef GNRC_NDP_HOST_H_
+#define GNRC_NDP_HOST_H_
+
+#include "net/gnrc/ipv6/netif.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Initializes interface @p iface as host.
+ *
+ * @pre iface != NULL
+ *
+ * @param[in] iface An IPv6 interface
+ */
+void gnrc_ndp_host_init(gnrc_ipv6_netif_t *iface);
+
+/**
+ * @brief   Sends a router solicitation over interface @p iface
+ *          and reset the timer for the next one.
+ *
+ * @pre iface != NULL
+ *
+ * @param[in] iface An IPv6 interface
+ */
+void gnrc_ndp_host_retrans_rtr_sol(gnrc_ipv6_netif_t *iface);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GNRC_NDP_HOST_H_ */
+/** @} */

--- a/sys/include/net/gnrc/ndp/internal.h
+++ b/sys/include/net/gnrc/ndp/internal.h
@@ -22,6 +22,7 @@
 #ifndef GNRC_NDP_INTERNAL_H_
 #define GNRC_NDP_INTERNAL_H_
 
+#include "kernel_types.h"
 #include "net/ipv6/addr.h"
 #include "net/ipv6/hdr.h"
 #include "net/ndp.h"
@@ -89,6 +90,16 @@ void gnrc_ndp_internal_send_nbr_adv(kernel_pid_t iface, ipv6_addr_t *tgt, ipv6_a
                                     bool supply_tl2a, gnrc_pktsnip_t *ext_opts);
 
 /**
+ * @brief   Send precompiled router solicitation to @p dst.
+ *
+ * @internal
+ *
+ * @param[in] iface Interface to send over. May not be KERNEL_PID_UNDEF.
+ * @param[in] dst   Destination for the router solicitation. ff02::2 if NULL.
+ */
+void gnrc_ndp_internal_send_rtr_sol(kernel_pid_t iface, ipv6_addr_t *dst);
+
+/**
  * @brief   Handles a SL2A option.
  *
  * @param[in] pkt           Packet the option was received in.
@@ -120,6 +131,36 @@ int gnrc_ndp_internal_sl2a_opt_handle(gnrc_pktsnip_t *pkt, ipv6_hdr_t *ipv6, uin
 int gnrc_ndp_internal_tl2a_opt_handle(gnrc_pktsnip_t *pkt, ipv6_hdr_t *ipv6,
                                       uint8_t icmpv6_type, ndp_opt_t *tl2a_opt,
                                       uint8_t *l2addr);
+
+/**
+ * @brief   Handles a MTU option.
+ *
+ * @internal
+ *
+ * @param[in] iface         Interface the MTU option was received on.
+ * @param[in] icmpv6_type   ICMPv6 type of the message carrying the option.
+ * @param[in] mtu_opt       A MTU option.
+ *
+ * @return  true, on success (or if the node should silently ignore the option).
+ * @return  false, if MTU option was not valid.
+ */
+bool gnrc_ndp_internal_mtu_opt_handle(kernel_pid_t iface, uint8_t icmpv6_type,
+                                      ndp_opt_mtu_t *mtu_opt);
+
+/**
+ * @brief   Handles a PI option.
+ *
+ * @internal
+ *
+ * @param[in] iface         Interface the PI option was received on.
+ * @param[in] icmpv6_type   ICMPv6 type of the message carrying the option.
+ * @param[in] pi_opt        A PI option.
+ *
+ * @return  true, on success (or if the node should silently ignore the option).
+ * @return  false, if PIO was not valid.
+ */
+bool gnrc_ndp_internal_pi_opt_handle(kernel_pid_t iface, uint8_t icmpv6_type,
+                                     ndp_opt_pi_t *pi_opt);
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -25,6 +25,9 @@ endif
 ifneq (,$(filter gnrc_ndp_internal,$(USEMODULE)))
     DIRS += network_layer/ndp/internal
 endif
+ifneq (,$(filter gnrc_ndp_host,$(USEMODULE)))
+    DIRS += network_layer/ndp/host
+endif
 ifneq (,$(filter gnrc_ndp_node,$(USEMODULE)))
     DIRS += network_layer/ndp/node
 endif

--- a/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
+++ b/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
@@ -92,9 +92,11 @@ void gnrc_icmpv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *pkt)
             /* TODO */
             break;
 
+#ifdef MODULE_GNRC_NDP
         case ICMPV6_RTR_ADV:
             DEBUG("icmpv6: router advertisement received\n");
-            /* TODO */
+            gnrc_ndp_rtr_adv_handle(iface, pkt, ipv6->data, (ndp_rtr_adv_t *)hdr,
+                                    icmpv6->size);
             break;
 
         case ICMPV6_NBR_SOL:
@@ -108,6 +110,7 @@ void gnrc_icmpv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *pkt)
             gnrc_ndp_nbr_adv_handle(iface, pkt, ipv6->data, (ndp_nbr_adv_t *)hdr,
                                     icmpv6->size);
             break;
+#endif
 
         case ICMPV6_REDIRECT:
             DEBUG("icmpv6: redirect message received\n");

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -190,6 +190,7 @@ static void *_event_loop(void *args)
                 msg_reply(&msg, &reply);
                 break;
 
+#ifdef MODULE_GNRC_NDP
             case GNRC_NDP_MSG_RTR_TIMEOUT:
                 DEBUG("ipv6: Router timeout received\n");
                 ((gnrc_ipv6_nc_t *)msg.content.ptr)->flags &= ~GNRC_IPV6_NC_IS_ROUTER;
@@ -201,7 +202,6 @@ static void *_event_loop(void *args)
                                             (ipv6_addr_t *)msg.content.ptr);
                 break;
 
-#ifdef MODULE_GNRC_NDP
             case GNRC_NDP_MSG_NBR_SOL_RETRANS:
                 DEBUG("ipv6: Neigbor solicitation retransmission timer event received\n");
                 gnrc_ndp_retrans_nbr_sol((gnrc_ipv6_nc_t *)msg.content.ptr);
@@ -210,6 +210,12 @@ static void *_event_loop(void *args)
             case GNRC_NDP_MSG_NC_STATE_TIMEOUT:
                 DEBUG("ipv6: Neigbor cache state timeout received\n");
                 gnrc_ndp_state_timeout((gnrc_ipv6_nc_t *)msg.content.ptr);
+                break;
+#endif
+#ifdef MODULE_GNRC_NDP_HOST
+            case GNRC_NDP_MSG_RTR_SOL_RETRANS:
+                DEBUG("ipv6: Router solicitation retransmission event received\n");
+                gnrc_ndp_host_retrans_rtr_sol((gnrc_ipv6_netif_t *)msg.content.ptr);
                 break;
 #endif
 

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -763,6 +763,10 @@ void gnrc_ipv6_netif_init_by_dev(void)
         }
 
         mutex_unlock(&ipv6_if->mutex);
+#ifdef MODULE_GNRC_NDP_HOST
+        /* start periodic router solicitations */
+        gnrc_ndp_host_init(ipv6_if);
+#endif
     }
 }
 

--- a/sys/net/gnrc/network_layer/ndp/host/Makefile
+++ b/sys/net/gnrc/network_layer/ndp/host/Makefile
@@ -1,0 +1,3 @@
+MODULE = gnrc_ndp_host
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/network_layer/ndp/host/gnrc_ndp_host.c
+++ b/sys/net/gnrc/network_layer/ndp/host/gnrc_ndp_host.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+
+#include <inttypes.h>
+#include "random.h"
+#include "net/gnrc/ipv6.h"
+#include "net/gnrc/ndp.h"
+#include "net/gnrc/ndp/internal.h"
+#include "vtimer.h"
+
+#include "net/gnrc/ndp/host.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+static inline void _reschedule_rtr_sol(gnrc_ipv6_netif_t *iface, timex_t delay)
+{
+    vtimer_remove(&iface->rtr_sol_timer);
+    vtimer_set_msg(&iface->rtr_sol_timer, delay, gnrc_ipv6_pid, GNRC_NDP_MSG_RTR_SOL_RETRANS,
+                   iface);
+}
+
+void gnrc_ndp_host_init(gnrc_ipv6_netif_t *iface)
+{
+    uint32_t interval = genrand_uint32_range(0, GNRC_NDP_MAX_RTR_SOL_DELAY * SEC_IN_USEC);
+    mutex_lock(&iface->mutex);
+    iface->rtr_sol_count = GNRC_NDP_MAX_RTR_SOL_NUMOF;
+    DEBUG("ndp host: delayed initial router solicitation by %" PRIu32 " usec.\n", interval);
+    _reschedule_rtr_sol(iface, timex_set(0, interval));
+    mutex_unlock(&iface->mutex);
+}
+
+void gnrc_ndp_host_retrans_rtr_sol(gnrc_ipv6_netif_t *iface)
+{
+    mutex_lock(&iface->mutex);
+    if (iface->rtr_sol_count > 1) { /* regard off-by-one error */
+        DEBUG("ndp hst: retransmit rtr sol in %d sec\n", GNRC_NDP_MAX_RTR_SOL_INT);
+        iface->rtr_sol_count--;
+        _reschedule_rtr_sol(iface, timex_set(GNRC_NDP_MAX_RTR_SOL_INT, 0));
+    }
+    mutex_unlock(&iface->mutex);
+    gnrc_ndp_internal_send_rtr_sol(iface->pid, NULL);
+}
+
+/** @} */


### PR DESCRIPTION
This imports [host behavior](https://tools.ietf.org/html/rfc4861#section-6.3) for [NDP router discovery](https://tools.ietf.org/html/rfc4861#section-6). This encompasses:

* building and sending of (semi-periodic) router solicitations (including all available options specified in [RFC 4861](https://tools.ietf.org/html/rfc4861))
* handling of router advertisements and their options

Depends on:
* ~~#3628: address-less link-layer handling for NDP~~
* ~~#3745: `gnrc_ipv6_netif` adaptations for router discovery~~ (merged)