### PR TITLE
gnrc_ndp_internal: add capability to add external options to NAs

### DIFF
--- a/sys/include/net/gnrc/ndp/internal.h
+++ b/sys/include/net/gnrc/ndp/internal.h
@@ -80,9 +80,13 @@ void gnrc_ndp_internal_send_nbr_sol(kernel_pid_t iface, ipv6_addr_t *tgt,
  *                          not be NULL.
  * @param[in] supply_tl2a   Add target link-layer address option to neighbor
  *                          advertisement if link-layer has addresses.
+ * @param[in] ext_opts      External options for the neighbor advertisement. Leave NULL for none.
+ *                          **Warning:** these are not tested if they are suitable for a
+ *                          neighbor advertisement so be sure to check that.
+ *                          **Will be released** in an error case.
  */
-void gnrc_ndp_internal_send_nbr_adv(kernel_pid_t iface, ipv6_addr_t *tgt,
-                                    ipv6_addr_t *dst, bool supply_tl2a);
+void gnrc_ndp_internal_send_nbr_adv(kernel_pid_t iface, ipv6_addr_t *tgt, ipv6_addr_t *dst,
+                                    bool supply_tl2a, gnrc_pktsnip_t *ext_opts);
 
 /**
  * @brief   Handles a SL2A option.

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -101,8 +101,8 @@ void gnrc_ndp_nbr_sol_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
         sicmpv6_size -= (opt->len * 8);
     }
 
-    gnrc_ndp_internal_send_nbr_adv(iface, tgt, &ipv6->src,
-                                   ipv6_addr_is_multicast(&ipv6->dst));
+    gnrc_ndp_internal_send_nbr_adv(iface, tgt, &ipv6->src, ipv6_addr_is_multicast(&ipv6->dst),
+                                   NULL);
 
     return;
 }

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -149,10 +149,10 @@ void gnrc_ndp_internal_set_state(gnrc_ipv6_nc_t *nc_entry, uint8_t state)
     }
 }
 
-void gnrc_ndp_internal_send_nbr_adv(kernel_pid_t iface, ipv6_addr_t *tgt,
-                                    ipv6_addr_t *dst, bool supply_tl2a)
+void gnrc_ndp_internal_send_nbr_adv(kernel_pid_t iface, ipv6_addr_t *tgt, ipv6_addr_t *dst,
+                                    bool supply_tl2a, gnrc_pktsnip_t *ext_opts)
 {
-    gnrc_pktsnip_t *hdr, *pkt = NULL;
+    gnrc_pktsnip_t *hdr, *pkt = ext_opts;
     uint8_t adv_flags = 0;
 
     DEBUG("ndp internal: send neighbor advertisement (iface: %" PRIkernel_pid ", tgt: %s, ",
@@ -179,11 +179,11 @@ void gnrc_ndp_internal_send_nbr_adv(kernel_pid_t iface, ipv6_addr_t *tgt,
 
         if (l2src_len > 0) {
             /* add target address link-layer address option */
-            pkt = gnrc_ndp_opt_tl2a_build(l2src, l2src_len, NULL);
+            pkt = gnrc_ndp_opt_tl2a_build(l2src, l2src_len, pkt);
 
             if (pkt == NULL) {
                 DEBUG("ndp internal: error allocating Target Link-layer address option.\n");
-                gnrc_pktbuf_release(pkt);
+                gnrc_pktbuf_release(ext_opts);
                 return;
             }
         }


### PR DESCRIPTION
6LoWPAN-ND adds the [address registration option](https://tools.ietf.org/html/rfc6775#section-4.1) (ARO) which can be part of either Neighbor Solicitations (NSs) or Neighbor Advertisements (NAs). The value of the status field in the advertised ARO is dependent on the ARO provided by an NS, so the value of the option must be set out of the scope of the send function. This API change allows for that in the least intrusive way, by allowing to add preallocated options to the send function.