### PR TITLE
gnrc_ipv6_netif: IS_WIRED flag collides with Home Agent flag

### DIFF
--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -146,7 +146,7 @@ extern "C" {
 /**
  * @brief   Flag to indicate if the interface is operating over a wired link
  */
-#define GNRC_IPV6_NETIF_FLAGS_IS_WIRED          (0x2000)
+#define GNRC_IPV6_NETIF_FLAGS_IS_WIRED          (0x0080)
 
 /**
  * @brief   Flag to indicate that the interface has other address


### PR DESCRIPTION
The most-significant byte of the flag field for `gnrc_ipv6_netif`s is supposed to be used for the flag field of Router advertisements. Given that we might want to support Mobile IPv6 at some point `IS_WIRED` collides with the `H` (Home Agent) flag of [RFC 6275](https://tools.ietf.org/html/rfc6275#section-7.1).