### PR TITLE
sys/bloom: Pass buffer to bloom instead of using m/calloc

### DIFF
--- a/sys/include/bloom.h
+++ b/sys/include/bloom.h
@@ -151,18 +151,19 @@ typedef struct {
 } bloom_t;
 
 /**
- * @brief Allocate and return a pointer to a new Bloom filter.
+ * @brief Initialize a Bloom Filter.
  *
- * For best results, make 'size' a power of 2.
+ * @note For best results, make 'size' a power of 2.
  *
- * @param size        size of the bit array of the filter in bits
- * @param num_hashes  the number of hash functions
- * @param ...         varg function pointers, use hashfp_t
+ * @param bloom             bloom_t to initialize
+ * @param size              size of the bloom filter in bits
+ * @param bitfield          underlying bitfield of the bloom filter
+ * @param hashes            array of hashes
+ * @param hashes_numof      number of elements in hashes
  *
- * @return An allocated bloom filter
- *
+ * @pre     @p bitfield MUST be large enough to hold @p size bits.
  */
-bloom_t *bloom_new(size_t size, size_t num_hashes, ...);
+void bloom_init(bloom_t *bloom, size_t size, uint8_t *bitfield, hashfp_t *hashes, int hashes_numof);
 
 /**
  * @brief Delete a Bloom filter.

--- a/tests/bloom_bytes/Makefile
+++ b/tests/bloom_bytes/Makefile
@@ -1,6 +1,8 @@
 APPLICATION = bloom_bytes
 include ../Makefile.tests_common
 
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
+
 USEMODULE += hashes
 USEMODULE += bloom
 USEMODULE += random


### PR DESCRIPTION
Currently, the bloom implementation makes heavy use of m/calloc and free.

This PR changes the API to expect a buffer from the user, which is then used as a base for the bloom filter.
Furthermore, I removed some defines, that can also be found in `bitfield.h`.