### PR TITLE
cpu/msp430: added periph GPIO driver implementation

### DIFF
--- a/boards/msb-430/Makefile.features
+++ b/boards/msb-430/Makefile.features
@@ -1,2 +1,3 @@
+FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_MCU_GROUP = msp430

--- a/boards/msb-430h/Makefile.features
+++ b/boards/msb-430h/Makefile.features
@@ -1,3 +1,4 @@
 FEATURES_PROVIDED += config
+FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_MCU_GROUP = msp430

--- a/boards/telosb/Makefile.features
+++ b/boards/telosb/Makefile.features
@@ -1,2 +1,3 @@
+FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_MCU_GROUP = msp430

--- a/boards/wsn430-v1_3b/Makefile.features
+++ b/boards/wsn430-v1_3b/Makefile.features
@@ -1,3 +1,4 @@
 FEATURES_PROVIDED += config
+FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_MCU_GROUP = msp430

--- a/boards/wsn430-v1_4/Makefile.features
+++ b/boards/wsn430-v1_4/Makefile.features
@@ -1,3 +1,4 @@
 FEATURES_PROVIDED += config
+FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_MCU_GROUP = msp430

--- a/boards/z1/Makefile.features
+++ b/boards/z1/Makefile.features
@@ -1,2 +1,3 @@
+FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_MCU_GROUP = msp430

--- a/cpu/msp430fxyz/include/periph_cpu.h
+++ b/cpu/msp430fxyz/include/periph_cpu.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup         cpu_msp430-common
+ * @ingroup         cpu_msp430fxyz
  * @{
  *
  * @file
@@ -26,7 +26,68 @@
 extern "C" {
 #endif
 
-/* more to come here... */
+/**
+ * @brief   Define a custom type for GPIO pins
+ * @{
+ */
+#define HAVE_GPIO_T
+typedef uint16_t gpio_t;
+/** @} */
+
+/**
+ * @brief   Definition of a fitting UNDEF value
+ */
+#define GPIO_UNDEF          (0xffff)
+
+/**
+ * @brief   Mandatory function for defining a GPIO pins
+ * @{
+ */
+#define GPIO(x, y)          ((gpio_t)(((x & 0xff) << 8) | (1 << (y & 0xff))))
+
+/**
+ * @brief   Override direction values
+ * @{
+ */
+#define HAVE_GPIO_DIR_T
+typedef enum {
+    GPIO_DIR_IN =  0x00,    /**< configure pin as input */
+    GPIO_DIR_OUT = 0xff,    /**< configure pin as output */
+} gpio_dir_t;
+/** @} */
+
+/**
+ * @brief   Override flank selection values
+ * @{
+ */
+#define HAVE_GPIO_FLANK_T
+typedef enum {
+    GPIO_FALLING = 0xff,        /**< emit interrupt on falling flank */
+    GPIO_RISING  = 0x00,        /**< emit interrupt on rising flank */
+    GPIO_BOTH    = 0xab         /**< not supported -> random value*/
+} gpio_flank_t;
+/** @} */
+
+/**
+ * @brief   Available ports on MSP430 platforms
+ */
+enum {
+    P1 = 1,                 /**< PORT 1 */
+    P2 = 2,                 /**< PORT 2 */
+    P3 = 3,                 /**< PORT 3 */
+    P4 = 4,                 /**< PORT 4 */
+    P5 = 5,                 /**< PORT 5 */
+    P6 = 6,                 /**< PORT 6 */
+};
+
+/**
+ * @brief   Enable or disable a pin to be used by peripheral modules
+ *
+ * @param[in] pin       pin to (de-)select
+ * @param[in] enable    true for enabling peripheral use, false for disabling it
+ */
+void gpio_periph_mode(gpio_t pin, bool enable);
+
 
 #ifdef __cplusplus
 }

--- a/cpu/msp430fxyz/periph/gpio.c
+++ b/cpu/msp430fxyz/periph/gpio.c
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_msp430fxyz
+ * @{
+ *
+ * @file
+ * @brief       Low-level GPIO driver implementation
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "bitarithm.h"
+#include "periph/gpio.h"
+
+/**
+ * @brief   Number of possible interrupt lines: 2 ports * 8 pins
+ */
+#define ISR_NUMOF           (16U)
+
+/**
+ * @brief   Number of pins on each port
+ */
+#define PINS_PER_PORT       (8U)
+
+/**
+ * @brief   Datatype to use for saving the interrupt contexts
+ */
+typedef struct {
+    gpio_cb_t cb;       /**< callback to call on GPIO interrupt */
+    void *arg;          /**< argument passed to the callback */
+} isr_ctx_t;
+
+/**
+ * @brief   Interrupt context for each interrupt line
+ */
+static isr_ctx_t isr_ctx[ISR_NUMOF];
+
+
+static msp_port_t *_port(gpio_t pin)
+{
+    switch (pin >> 8) {
+        case 1:
+            return PORT_1;
+        case 2:
+            return PORT_2;
+        case 3:
+            return PORT_3;
+        case 4:
+            return PORT_4;
+        case 5:
+            return PORT_5;
+        case 6:
+            return PORT_6;
+        default:
+            return NULL;
+    }
+}
+
+static inline msp_port_isr_t *_isr_port(gpio_t pin)
+{
+    msp_port_t *p = _port(pin);
+    if ((p == PORT_1) || (p == PORT_2)) {
+        return (msp_port_isr_t *)p;
+    }
+    return NULL;
+}
+
+static inline uint8_t _pin(gpio_t pin)
+{
+    return (uint8_t)(pin & 0xff);
+}
+
+static int _ctx(gpio_t pin)
+{
+    int i = bitarithm_lsb(_pin(pin));
+    return (_port(pin) == PORT_1) ? i : (i + 8);
+}
+
+int gpio_init(gpio_t pin, gpio_dir_t dir, gpio_pp_t pullup)
+{
+    msp_port_t *port = _port(pin);
+    /* check if port is valid and pull resistor are valid */
+    if ((port == NULL) || (pullup != GPIO_NOPULL)) {
+        return -1;
+    }
+    /* set pin direction */
+    port->DIR &= ~(_pin(pin));
+    port->DIR |= (dir & _pin(pin));
+    /* reset output value */
+    port->OD &= ~(_pin(pin));
+    return 0;
+}
+
+int gpio_init_int(gpio_t pin, gpio_pp_t pullup, gpio_flank_t flank,
+                    gpio_cb_t cb, void *arg)
+{
+    msp_port_isr_t *port = _isr_port(pin);
+
+    /* check if port, pull resistor and flank configuration are valid */
+    if ((port == NULL) || (pullup != GPIO_NOPULL) || (flank == GPIO_BOTH)) {
+        return -1;
+    }
+
+    /* disable any activated interrupt */
+    port->IE &= ~(_pin(pin));
+    /* configure as input */
+    gpio_init(pin, GPIO_DIR_IN, GPIO_NOPULL);
+    /* save ISR context */
+    isr_ctx[_ctx(pin)].cb = cb;
+    isr_ctx[_ctx(pin)].arg = arg;
+    /* configure flank */
+    port->IES &= ~(_pin(pin));
+    port->IES |= (flank & _pin(pin));
+    /* clear pending interrupts and enable the IRQ */
+    port->IFG &= ~(_pin(pin));
+    gpio_irq_enable(pin);
+    return 0;
+}
+
+void gpio_periph_mode(gpio_t pin, bool enable)
+{
+    REG8 *sel;
+    msp_port_isr_t *isrport = _isr_port(pin);
+    if (isrport) {
+        sel = &(isrport->SEL);
+    }
+    else {
+        msp_port_t *port = _port(pin);
+        if (port) {
+            sel = &(port->SEL);
+        }
+        else {
+            return;
+        }
+    }
+    if (enable) {
+        *sel |= _pin(pin);
+    }
+    else {
+        *sel &= ~(_pin(pin));
+    }
+}
+
+void gpio_irq_enable(gpio_t pin)
+{
+    msp_port_isr_t *port = _isr_port(pin);
+    if (port) {
+        port->IE |= _pin(pin);
+    }
+}
+
+void gpio_irq_disable(gpio_t pin)
+{
+    msp_port_isr_t *port = _isr_port(pin);
+    if (port) {
+        port->IE &= ~(_pin(pin));
+    }
+}
+
+int gpio_read(gpio_t pin)
+{
+    msp_port_t *port = _port(pin);
+    if (port->DIR & _pin(pin)) {
+        return (int)(port->OD & _pin(pin));
+    }
+    else {
+        return (int)(port->IN & _pin(pin));
+    }
+}
+
+void gpio_set(gpio_t pin)
+{
+    _port(pin)->OD |= _pin(pin);
+}
+
+void gpio_clear(gpio_t pin)
+{
+    _port(pin)->OD &= ~(_pin(pin));
+}
+
+void gpio_toggle(gpio_t pin)
+{
+    _port(pin)->OD ^= _pin(pin);
+}
+
+void gpio_write(gpio_t pin, int value)
+{
+    if (value) {
+        _port(pin)->OD |= _pin(pin);
+    }
+    else {
+        _port(pin)->OD &= ~(_pin(pin));
+    }
+}
+
+static inline void isr_handler(msp_port_isr_t *port, int ctx)
+{
+    for (int i = 0; i < PINS_PER_PORT; i++) {
+        if ((port->IE & (1 << i)) && (port->IFG & (1 << i))) {
+            port->IFG &= ~(1 << i);
+            isr_ctx[i + ctx].cb(isr_ctx[i + ctx].arg);
+        }
+    }
+}
+
+ISR(PORT1_VECTOR, isr_port1)
+{
+    __enter_isr();
+    isr_handler((msp_port_isr_t *)PORT_1, 0);
+    __exit_isr();
+}
+
+ISR(PORT2_VECTOR, isr_port2)
+{
+    __enter_isr();
+    isr_handler((msp_port_isr_t *)PORT_2, 8);
+    __exit_isr();
+}


### PR DESCRIPTION
EDIT
~~Based on #3724~~

And here is also the GPIO driver.

EDIT
~~Known issue: When configuring a pin as external interrupt source, the system crashes after 2-3 interrupt events. The behavior is pretty similar to the crashing on UART RX (-> see #3742). My first guess is that there is something wrong with the context switching on the MSP430, but not sure yet... Will keep looking into this.~~