### PR TITLE
sys: net: fix GNRC_IPV6_NETIF_FLAGS_IS_WIRED assignment

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -756,10 +756,10 @@ void gnrc_ipv6_netif_init_by_dev(void)
         }
 
         if (gnrc_netapi_get(ifs[i], NETOPT_IS_WIRED, 0, &tmp, sizeof(int)) > 0) {
-            ipv6_if->flags = GNRC_IPV6_NETIF_FLAGS_IS_WIRED;
+            ipv6_if->flags |= GNRC_IPV6_NETIF_FLAGS_IS_WIRED;
         }
         else {
-            ipv6_if->flags = 0;
+            ipv6_if->flags &= ~GNRC_IPV6_NETIF_FLAGS_IS_WIRED;
         }
 
         mutex_unlock(&ipv6_if->mutex);


### PR DESCRIPTION
Previously, if ```gnrc_netapi_get(..., NETOPT_IS_WIRED, ...)``` returned a non-positive result, the interfaces "flags" field got zeroed, possibly overwriting previously set flags.

This commit just negates the corresponding IS_WIRED bit.