### PR TITLE
unittests: native: fixes for OS X

### DIFF
--- a/sys/cbor/cbor.c
+++ b/sys/cbor/cbor.c
@@ -81,6 +81,9 @@
 /* Extra defines not related to the protocol itself */
 #define CBOR_STREAM_PRINT_BUFFERSIZE 1024 /* bytes */
 
+/* Array size */
+#define MAX_TIMESTRING_LENGTH   (21)
+
 #ifndef INFINITY
 #define INFINITY (1.0/0.0)
 #endif
@@ -694,7 +697,6 @@ size_t cbor_deserialize_date_time(const cbor_stream_t *stream, size_t offset, st
 
 size_t cbor_serialize_date_time(cbor_stream_t *stream, struct tm *val)
 {
-    static const int MAX_TIMESTRING_LENGTH = 21;
     CBOR_ENSURE_SIZE(stream, MAX_TIMESTRING_LENGTH + 1); /* + 1 tag byte */
 
     char time_str[MAX_TIMESTRING_LENGTH];

--- a/sys/include/ubjson.h
+++ b/sys/include/ubjson.h
@@ -38,7 +38,7 @@
 
 #if defined(MODULE_MSP430_COMMON)
 #   include "msp430_types.h"
-#elif !defined(CPU_NATIVE)
+#elif !defined(__linux__)
 #   include <sys/types.h>
 #endif
 

--- a/tests/unittests/tests-fib/tests-fib.c
+++ b/tests/unittests/tests-fib/tests-fib.c
@@ -37,7 +37,7 @@ static void _fill_FIB_unique(size_t entries)
     for (size_t i = 0; i < entries; ++i) {
         /* construct "addresses" for the FIB */
         snprintf(addr_dst, add_buf_size, "Test address %02d", (int)i);
-        snprintf(addr_nxt, add_buf_size, "Test address %02d", entries + i);
+        snprintf(addr_nxt, add_buf_size, "Test address %02d", (int)(entries + i));
         /* the terminating \0 is unnecessary here */
         fib_add_entry(&test_fib_table, 42,
                       (uint8_t *)addr_dst, add_buf_size - 1, addr_dst_flags,
@@ -61,7 +61,7 @@ static void _fill_FIB_multiple(size_t entries, size_t modulus)
     for (size_t i = 0; i < entries; ++i) {
         /* construct "addresses" for the FIB */
         snprintf(addr_dst, add_buf_size, "Test address %02d", (int)i);
-        snprintf(addr_nxt, add_buf_size, "Test address %02d", i % modulus);
+        snprintf(addr_nxt, add_buf_size, "Test address %02d", (int)(i % modulus));
         fib_add_entry(&test_fib_table, 42,
                       (uint8_t *)addr_dst, add_buf_size - 1, addr_dst_flags,
                       (uint8_t *)addr_nxt, add_buf_size - 1, addr_nxt_flags,
@@ -190,7 +190,7 @@ static void test_fib_05_remove_upper_half(void)
 
     for (size_t i = 0; i < entries / 2; ++i) {
         /* construct "addresses" to remove */
-        snprintf(addr_dst, add_buf_size, "Test address %02d", ((entries / 2) + i));
+        snprintf(addr_dst, add_buf_size, "Test address %02d", (int)((entries / 2) + i));
         fib_remove_entry(&test_fib_table, (uint8_t *)addr_dst, add_buf_size - 1);
     }
 
@@ -673,7 +673,7 @@ static void test_fib_17_get_entry_set(void)
     for (size_t i = 0; i < 20; ++i) {
         /* construct "addresses" for the FIB */
         snprintf(addr_dst, addr_buf_size, "Test address %02d", (int)i);
-        snprintf(addr_nxt, addr_buf_size, "Test address %02d", i % 11);
+        snprintf(addr_nxt, addr_buf_size, "Test address %02d", (int)(i % 11));
         fib_add_entry(&test_fib_table, 42,
                       (uint8_t *)addr_dst, addr_buf_size - 1, 0x0,
                       (uint8_t *)addr_nxt, addr_buf_size - 1, 0x0, 100000);


### PR DESCRIPTION
Several fixes to get unittests compile on OS X