### PR TITLE
sys: net: gnrc: ndp: fix type used for NETOPT_SRC_LEN

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -610,7 +610,7 @@ static size_t _get_l2src(kernel_pid_t iface, uint8_t *l2src, size_t l2src_maxlen
 {
     bool try_long = false;
     int res;
-    size_t l2src_len;
+    uint16_t l2src_len;
     /* maximum address length that fits into a minimum length (8) S/TL2A option */
     const uint16_t max_short_len = 6;
 


### PR DESCRIPTION
netopt.h clearly states that the result is "uint16_t".