### PR TITLE
shell: remove vtimer internals from rpl shell cmd

### DIFF
--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -303,7 +303,7 @@ int _gnrc_rpl_dodag_show(void)
 
     gnrc_rpl_dodag_t *dodag = NULL;
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
-    timex_t now, tc, ti, cleanup;
+    timex_t now;
     vtimer_now(&now);
     for (uint8_t i = 0; i < GNRC_RPL_INSTANCES_NUMOF; ++i) {
         if (gnrc_rpl_instances[i].state == 0) {
@@ -313,20 +313,12 @@ int _gnrc_rpl_dodag_show(void)
                 gnrc_rpl_instances[i].mop, gnrc_rpl_instances[i].of->ocp,
                 gnrc_rpl_instances[i].min_hop_rank_inc, gnrc_rpl_instances[i].max_rank_inc);
         LL_FOREACH(gnrc_rpl_instances[i].dodags, dodag) {
-            tc = timex_sub(dodag->trickle.msg_callback_timer.absolute, now);
-            ti = timex_sub(dodag->trickle.msg_interval_timer.absolute, now);
-            cleanup = timex_sub(dodag->cleanup_timer.absolute, now);
-            timex_normalize(&tc);
-            timex_normalize(&ti);
-            timex_normalize(&cleanup);
-            printf("\tdodag [%s | R: %d | CL: %" PRIu32 "s | \
-TR(I=[%d,%d], k=%d, c=%d, TC=%" PRIu32 "s, TI=%" PRIu32 "s)]\n",
+            printf("\tdodag [%s | R: %d | TR(I=[%d,%d], k=%d, c=%d]\n",
                     ipv6_addr_to_str(addr_str, &dodag->dodag_id, sizeof(addr_str)),
-                    dodag->my_rank, ((int32_t) cleanup.seconds) > 0 ? cleanup.seconds : 0,
-                    (1 << dodag->dio_min), dodag->dio_interval_doubl,
-                    dodag->trickle.k, dodag->trickle.c,
-                    ((int32_t) tc.seconds) > 0 ? tc.seconds : 0,
-                    ((int32_t) ti.seconds) > 0 ? ti.seconds : 0);
+                    dodag->my_rank, (1 << dodag->dio_min),
+                    dodag->dio_interval_doubl, dodag->trickle.k,
+                    dodag->trickle.c);
+;
             gnrc_rpl_parent_t *parent;
             LL_FOREACH(dodag->parents, parent) {
                 printf("\t\tparent [addr: %s | rank: %d | lifetime: %" PRIu32 "s]\n",


### PR DESCRIPTION
Apparently someone had difficulties to read the [documentation](http://doc.riot-os.org/structvtimer__t.html#details). ;-)

Without this #3525 won't work.