### PR TITLE
trickle: switch to xtimer

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -34,6 +34,10 @@ ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
   USEMODULE += vtimer
 endif
 
+ifneq (,$(filter trickle,$(USEMODULE)))
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter ieee802154,$(USEMODULE)))
   ifneq (,$(filter gnrc_ipv6, $(USEMODULE)))
     USEMODULE += gnrc_sixlowpan

--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -28,6 +28,7 @@ extern "C" {
 #endif
 
 #include "net/ipv6/addr.h"
+#include "vtimer.h"
 #include "trickle.h"
 
 /**

--- a/sys/include/trickle.h
+++ b/sys/include/trickle.h
@@ -29,7 +29,7 @@
  extern "C" {
 #endif
 
-#include "vtimer.h"
+#include "xtimer.h"
 #include "thread.h"
 
 /** @brief a generic callback function with arguments that is called by trickle periodically */
@@ -41,20 +41,22 @@ typedef struct {
 /** @brief all state variables for a trickle timer */
 typedef struct {
     uint8_t k;                      /**< redundancy constant */
+    uint8_t Imax;                   /**< maximum interval size, described as doublings */
+    uint16_t c;                     /**< counter */
     uint32_t Imin;                  /**< minimum interval size */
-    uint8_t Imax;                   /**< maximum interval size, described as a number of doublings */
     uint32_t I;                     /**< current interval size */
     uint32_t t;                     /**< time within the current interval */
-    uint16_t c;                     /**< counter */
     kernel_pid_t pid;               /**< pid of trickles target thread */
     trickle_callback_t callback;    /**< the callback function and parameter that trickle is calling
                                          after each interval */
-    uint16_t interval_msg_type;     /**< the msg_t.type that trickle should use after an interval */
-    timex_t msg_interval_time;      /**< interval represented as timex_t */
-    vtimer_t msg_interval_timer;    /**< vtimer to send a msg_t to the target thread for a new interval */
-    uint16_t callback_msg_type;     /**< the msg_t.type that trickle should use after a callback */
-    timex_t msg_callback_time;      /**< callback interval represented as timex_t */
-    vtimer_t msg_callback_timer;    /**< vtimer to send a msg_t to the target thread for a callback */
+    msg_t msg_interval;             /**< the msg_t to use for intervals */
+    uint64_t msg_interval_time;     /**< interval in ms */
+    xtimer_t msg_interval_timer;    /**< xtimer to send a msg_t to the target thread
+                                         for a new interval */
+    msg_t msg_callback;             /**< the msg_t to use for callbacks */
+    uint64_t msg_callback_time;     /**< callback interval in ms */
+    xtimer_t msg_callback_timer;    /**< xtimer to send a msg_t to the target thread
+                                         for a callback */
 } trickle_t;
 
 /**

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -303,7 +303,8 @@ int _gnrc_rpl_dodag_show(void)
 
     gnrc_rpl_dodag_t *dodag = NULL;
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
-    timex_t now, tc, ti, cleanup;
+    timex_t now, cleanup;
+    uint64_t tc, ti, xnow = xtimer_now64();
     vtimer_now(&now);
     for (uint8_t i = 0; i < GNRC_RPL_INSTANCES_NUMOF; ++i) {
         if (gnrc_rpl_instances[i].state == 0) {
@@ -313,20 +314,23 @@ int _gnrc_rpl_dodag_show(void)
                 gnrc_rpl_instances[i].mop, gnrc_rpl_instances[i].of->ocp,
                 gnrc_rpl_instances[i].min_hop_rank_inc, gnrc_rpl_instances[i].max_rank_inc);
         LL_FOREACH(gnrc_rpl_instances[i].dodags, dodag) {
-            tc = timex_sub(dodag->trickle.msg_callback_timer.absolute, now);
-            ti = timex_sub(dodag->trickle.msg_interval_timer.absolute, now);
+
+            tc = (((uint64_t) dodag->trickle.msg_callback_timer.long_target << 32)
+                    | dodag->trickle.msg_callback_timer.target) - xnow;
+            tc = (int64_t) tc < 0 ? 0 : tc / SEC_IN_USEC;
+
+            ti = (((uint64_t) dodag->trickle.msg_interval_timer.long_target << 32)
+                    | dodag->trickle.msg_interval_timer.target) - xnow;
+            ti = (int64_t) ti < 0 ? 0 : ti / SEC_IN_USEC;
+
             cleanup = timex_sub(dodag->cleanup_timer.absolute, now);
-            timex_normalize(&tc);
-            timex_normalize(&ti);
             timex_normalize(&cleanup);
             printf("\tdodag [%s | R: %d | CL: %" PRIu32 "s | \
-TR(I=[%d,%d], k=%d, c=%d, TC=%" PRIu32 "s, TI=%" PRIu32 "s)]\n",
+TR(I=[%d,%d], k=%d, c=%d, TC=%" PRIu64 "s, TI=%" PRIu64 "s)]\n",
                     ipv6_addr_to_str(addr_str, &dodag->dodag_id, sizeof(addr_str)),
                     dodag->my_rank, ((int32_t) cleanup.seconds) > 0 ? cleanup.seconds : 0,
                     (1 << dodag->dio_min), dodag->dio_interval_doubl,
-                    dodag->trickle.k, dodag->trickle.c,
-                    ((int32_t) tc.seconds) > 0 ? tc.seconds : 0,
-                    ((int32_t) ti.seconds) > 0 ? ti.seconds : 0);
+                    dodag->trickle.k, dodag->trickle.c, tc, ti);
             gnrc_rpl_parent_t *parent;
             LL_FOREACH(dodag->parents, parent) {
                 printf("\t\tparent [addr: %s | rank: %d | lifetime: %" PRIu32 "s]\n",

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -170,19 +170,17 @@ int _xtimer_set_absolute(xtimer_t *timer, uint32_t target)
     }
 
     timer->target = target;
+    timer->long_target = _long_cnt;
+    if (target < now) {
+        timer->long_target++;
+    }
 
     unsigned state = disableIRQ();
     if ( !_this_high_period(target) ) {
         DEBUG("xtimer_set_absolute(): the timer doesn't fit into the low-level timer's mask.\n");
-        timer->long_target = _long_cnt;
         _add_timer_to_long_list(&long_list_head, timer);
     }
     else {
-        if (!target) {
-            /* set long_target != 0 so _is_set() can work */
-            timer->long_target = 1;
-        }
-
         if (_mask(now) >= target) {
             DEBUG("xtimer_set_absolute(): the timer will expire in the next timer period\n");
             _add_timer_to_list(&overflow_list_head, timer);


### PR DESCRIPTION
This PR replaces vtimer with xtimer for trickle and in some parts of RPL (where trickle is used).