### PR TITLE
rpl: switch to xtimer

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -34,6 +34,10 @@ ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
   USEMODULE += vtimer
 endif
 
+ifneq (,$(filter trickle,$(USEMODULE)))
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter ieee802154,$(USEMODULE)))
   ifneq (,$(filter gnrc_ipv6, $(USEMODULE)))
     USEMODULE += gnrc_sixlowpan

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -31,7 +31,7 @@ ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
   USEMODULE += fib
   USEMODULE += gnrc_ipv6_router_default
   USEMODULE += trickle
-  USEMODULE += vtimer
+  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter trickle,$(USEMODULE)))

--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -28,6 +28,7 @@ extern "C" {
 #endif
 
 #include "net/ipv6/addr.h"
+#include "vtimer.h"
 #include "trickle.h"
 
 /**

--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 #include "net/ipv6/addr.h"
-#include "vtimer.h"
+#include "xtimer.h"
 #include "trickle.h"
 
 /**
@@ -170,13 +170,13 @@ typedef struct gnrc_rpl_parent gnrc_rpl_parent_t;
  * @brief Parent representation
  */
 struct gnrc_rpl_parent {
-    gnrc_rpl_parent_t *next;          /**< pointer to the next parent */
+    gnrc_rpl_parent_t *next;        /**< pointer to the next parent */
     uint8_t state;                  /**< 0 for unsued, 1 for used */
     ipv6_addr_t addr;               /**< link-local IPv6 address of this parent */
     uint16_t rank;                  /**< rank of the parent */
     uint8_t dtsn;                   /**< last seen dtsn of this parent */
-    gnrc_rpl_dodag_t *dodag;          /**< DODAG the parent belongs to */
-    timex_t lifetime;               /**< lifetime of this parent */
+    gnrc_rpl_dodag_t *dodag;        /**< DODAG the parent belongs to */
+    uint64_t lifetime;              /**< lifetime of this parent */
     double  link_metric;            /**< metric of the link */
     uint8_t link_metric_type;       /**< type of the metric */
 };
@@ -236,10 +236,12 @@ struct gnrc_rpl_dodag {
     uint8_t dao_counter;            /**< amount of retried DAOs */
     bool dao_ack_received;          /**< flag to check for DAO-ACK */
     uint8_t dodag_conf_counter;     /**< limitation of the sending of DODAG_CONF options */
-    timex_t dao_time;               /**< time to schedule the next DAO */
-    vtimer_t dao_timer;             /**< timer to schedule the next DAO */
-    timex_t cleanup_time;           /**< time to schedula a DODAG cleanup */
-    vtimer_t cleanup_timer;         /**< timer to schedula a DODAG cleanup */
+    msg_t dao_msg;                  /**< msg_t for firing a dao */
+    uint64_t dao_time;              /**< time to schedule the next DAO */
+    xtimer_t dao_timer;             /**< timer to schedule the next DAO */
+    msg_t cleanup_msg;              /**< msg_t for firing a cleanup */
+    uint32_t cleanup_time;          /**< time to schedula a DODAG cleanup */
+    xtimer_t cleanup_timer;         /**< timer to schedula a DODAG cleanup */
     trickle_t trickle;              /**< trickle representation */
 };
 

--- a/sys/include/trickle.h
+++ b/sys/include/trickle.h
@@ -29,7 +29,7 @@
  extern "C" {
 #endif
 
-#include "vtimer.h"
+#include "xtimer.h"
 #include "thread.h"
 
 /** @brief a generic callback function with arguments that is called by trickle periodically */
@@ -41,20 +41,22 @@ typedef struct {
 /** @brief all state variables for a trickle timer */
 typedef struct {
     uint8_t k;                      /**< redundancy constant */
+    uint8_t Imax;                   /**< maximum interval size, described as doublings */
+    uint16_t c;                     /**< counter */
     uint32_t Imin;                  /**< minimum interval size */
-    uint8_t Imax;                   /**< maximum interval size, described as a number of doublings */
     uint32_t I;                     /**< current interval size */
     uint32_t t;                     /**< time within the current interval */
-    uint16_t c;                     /**< counter */
     kernel_pid_t pid;               /**< pid of trickles target thread */
     trickle_callback_t callback;    /**< the callback function and parameter that trickle is calling
                                          after each interval */
-    uint16_t interval_msg_type;     /**< the msg_t.type that trickle should use after an interval */
-    timex_t msg_interval_time;      /**< interval represented as timex_t */
-    vtimer_t msg_interval_timer;    /**< vtimer to send a msg_t to the target thread for a new interval */
-    uint16_t callback_msg_type;     /**< the msg_t.type that trickle should use after a callback */
-    timex_t msg_callback_time;      /**< callback interval represented as timex_t */
-    vtimer_t msg_callback_timer;    /**< vtimer to send a msg_t to the target thread for a callback */
+    msg_t msg_interval;             /**< the msg_t to use for intervals */
+    uint64_t msg_interval_time;     /**< interval in ms */
+    xtimer_t msg_interval_timer;    /**< xtimer to send a msg_t to the target thread
+                                         for a new interval */
+    msg_t msg_callback;             /**< the msg_t to use for callbacks */
+    uint64_t msg_callback_time;     /**< callback interval in ms */
+    xtimer_t msg_callback_timer;    /**< xtimer to send a msg_t to the target thread
+                                         for a callback */
 } trickle_t;
 
 /**

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -229,8 +229,8 @@ void _update_lifetime(void)
                 gnrc_rpl_parent_update(dodag, NULL);
                 continue;
             }
-            else if ((int64_t)(parent->lifetime - now) <= (int64_t) (GNRC_RPL_LIFETIME_UPDATE_STEP
-                     * SEC_IN_USEC * 2)) {
+            else if ((int64_t)(parent->lifetime - now) <=
+                     (int64_t) (GNRC_RPL_LIFETIME_UPDATE_STEP * SEC_IN_USEC * 2)) {
                 gnrc_rpl_send_DIS(parent->dodag, &parent->addr);
             }
         }

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -161,7 +161,11 @@ bool gnrc_rpl_dodag_add(gnrc_rpl_instance_t *instance, ipv6_addr_t *dodag_id, gn
         (*dodag)->dao_ack_received = false;
         (*dodag)->dao_counter = 0;
         (*dodag)->parents = NULL;
-        (*dodag)->cleanup_time = timex_set(GNRC_RPL_CLEANUP_TIME, 0);
+        (*dodag)->dao_msg.type = GNRC_RPL_MSG_TYPE_DAO_HANDLE;
+        (*dodag)->dao_msg.content.ptr = (char *) (*dodag);
+        (*dodag)->cleanup_time = GNRC_RPL_CLEANUP_TIME * SEC_IN_USEC;
+        (*dodag)->cleanup_msg.type = GNRC_RPL_MSG_TYPE_CLEANUP_HANDLE;
+        (*dodag)->cleanup_msg.content.ptr = (char *) (*dodag);
         return true;
     }
 
@@ -177,8 +181,8 @@ bool gnrc_rpl_dodag_remove(gnrc_rpl_dodag_t *dodag)
     gnrc_rpl_instance_t *inst = dodag->instance;
     LL_DELETE(inst->dodags, dodag);
     trickle_stop(&dodag->trickle);
-    vtimer_remove(&dodag->dao_timer);
-    vtimer_remove(&dodag->cleanup_timer);
+    xtimer_remove(&dodag->dao_timer);
+    xtimer_remove(&dodag->cleanup_timer);
     memset(dodag, 0, sizeof(gnrc_rpl_dodag_t));
     if (inst->dodags == NULL) {
         gnrc_rpl_instance_remove(inst);
@@ -192,9 +196,7 @@ void gnrc_rpl_dodag_remove_all_parents(gnrc_rpl_dodag_t *dodag)
     LL_FOREACH_SAFE(dodag->parents, elt, tmp) {
         gnrc_rpl_parent_remove(elt);
     }
-    vtimer_remove(&dodag->cleanup_timer);
-    vtimer_set_msg(&dodag->cleanup_timer, dodag->cleanup_time, gnrc_rpl_pid,
-            GNRC_RPL_MSG_TYPE_CLEANUP_HANDLE, dodag);
+    xtimer_set_msg(&dodag->cleanup_timer, dodag->cleanup_time, &dodag->cleanup_msg, gnrc_rpl_pid);
 }
 
 gnrc_rpl_dodag_t *gnrc_rpl_dodag_get(gnrc_rpl_instance_t *instance, ipv6_addr_t *dodag_id)
@@ -325,9 +327,8 @@ void gnrc_rpl_local_repair(gnrc_rpl_dodag_t *dodag)
 
     if (dodag->my_rank != GNRC_RPL_INFINITE_RANK) {
         trickle_reset_timer(&dodag->trickle);
-        vtimer_remove(&dodag->cleanup_timer);
-        vtimer_set_msg(&dodag->cleanup_timer, dodag->cleanup_time, gnrc_rpl_pid,
-            GNRC_RPL_MSG_TYPE_CLEANUP_HANDLE, dodag);
+        xtimer_set_msg(&dodag->cleanup_timer, dodag->cleanup_time, &dodag->cleanup_msg,
+                       gnrc_rpl_pid);
     }
 
     dodag->my_rank = GNRC_RPL_INFINITE_RANK;
@@ -336,14 +337,12 @@ void gnrc_rpl_local_repair(gnrc_rpl_dodag_t *dodag)
 void gnrc_rpl_parent_update(gnrc_rpl_dodag_t *dodag, gnrc_rpl_parent_t *parent)
 {
     uint16_t old_rank = dodag->my_rank;
-    timex_t now;
-    vtimer_now(&now);
+    uint64_t now = xtimer_now64();
     ipv6_addr_t def = IPV6_ADDR_UNSPECIFIED;
 
     /* update Parent lifetime */
     if (parent != NULL) {
-        parent->lifetime.seconds = now.seconds + (dodag->default_lifetime * dodag->lifetime_unit);
-        parent->lifetime.microseconds = 0;
+        parent->lifetime = now + ((dodag->default_lifetime * dodag->lifetime_unit) * SEC_IN_USEC);
         if (parent == dodag->parents) {
             ipv6_addr_t all_RPL_nodes = GNRC_RPL_ALL_NODES_ADDR;
             kernel_pid_t if_id;

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -303,7 +303,8 @@ int _gnrc_rpl_dodag_show(void)
 
     gnrc_rpl_dodag_t *dodag = NULL;
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
-    timex_t now, tc, ti, cleanup;
+    timex_t now, cleanup;
+    uint64_t tc, ti, xnow = xtimer_now64();
     vtimer_now(&now);
     for (uint8_t i = 0; i < GNRC_RPL_INSTANCES_NUMOF; ++i) {
         if (gnrc_rpl_instances[i].state == 0) {
@@ -313,20 +314,23 @@ int _gnrc_rpl_dodag_show(void)
                 gnrc_rpl_instances[i].mop, gnrc_rpl_instances[i].of->ocp,
                 gnrc_rpl_instances[i].min_hop_rank_inc, gnrc_rpl_instances[i].max_rank_inc);
         LL_FOREACH(gnrc_rpl_instances[i].dodags, dodag) {
-            tc = timex_sub(dodag->trickle.msg_callback_timer.absolute, now);
-            ti = timex_sub(dodag->trickle.msg_interval_timer.absolute, now);
+
+            tc = (((uint64_t) dodag->trickle.msg_callback_timer.long_target << 32)
+                    | dodag->trickle.msg_callback_timer.target) - xnow;
+            tc = (int64_t) tc < 0 ? 0 : tc / SEC_IN_USEC;
+
+            ti = (((uint64_t) dodag->trickle.msg_interval_timer.long_target << 32)
+                    | dodag->trickle.msg_interval_timer.target) - xnow;
+            ti = (int64_t) ti < 0 ? 0 : ti / SEC_IN_USEC;
+
             cleanup = timex_sub(dodag->cleanup_timer.absolute, now);
-            timex_normalize(&tc);
-            timex_normalize(&ti);
             timex_normalize(&cleanup);
             printf("\tdodag [%s | R: %d | CL: %" PRIu32 "s | \
-TR(I=[%d,%d], k=%d, c=%d, TC=%" PRIu32 "s, TI=%" PRIu32 "s)]\n",
+TR(I=[%d,%d], k=%d, c=%d, TC=%" PRIu64 "s, TI=%" PRIu64 "s)]\n",
                     ipv6_addr_to_str(addr_str, &dodag->dodag_id, sizeof(addr_str)),
                     dodag->my_rank, ((int32_t) cleanup.seconds) > 0 ? cleanup.seconds : 0,
                     (1 << dodag->dio_min), dodag->dio_interval_doubl,
-                    dodag->trickle.k, dodag->trickle.c,
-                    ((int32_t) tc.seconds) > 0 ? tc.seconds : 0,
-                    ((int32_t) ti.seconds) > 0 ? ti.seconds : 0);
+                    dodag->trickle.k, dodag->trickle.c, tc, ti);
             gnrc_rpl_parent_t *parent;
             LL_FOREACH(dodag->parents, parent) {
                 printf("\t\tparent [addr: %s | rank: %d | lifetime: %" PRIu32 "s]\n",

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -303,9 +303,9 @@ int _gnrc_rpl_dodag_show(void)
 
     gnrc_rpl_dodag_t *dodag = NULL;
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
-    timex_t now, cleanup;
+    uint32_t cleanup;
     uint64_t tc, ti, xnow = xtimer_now64();
-    vtimer_now(&now);
+
     for (uint8_t i = 0; i < GNRC_RPL_INSTANCES_NUMOF; ++i) {
         if (gnrc_rpl_instances[i].state == 0) {
             continue;
@@ -323,19 +323,21 @@ int _gnrc_rpl_dodag_show(void)
                     | dodag->trickle.msg_interval_timer.target) - xnow;
             ti = (int64_t) ti < 0 ? 0 : ti / SEC_IN_USEC;
 
-            cleanup = timex_sub(dodag->cleanup_timer.absolute, now);
-            timex_normalize(&cleanup);
-            printf("\tdodag [%s | R: %d | CL: %" PRIu32 "s | \
-TR(I=[%d,%d], k=%d, c=%d, TC=%" PRIu64 "s, TI=%" PRIu64 "s)]\n",
+            cleanup = dodag->cleanup_timer.target - xtimer_now();
+            cleanup = (int32_t) cleanup < 0 ? 0 : cleanup / SEC_IN_USEC;
+
+            printf("\tdodag [%s | R: %d | CL: %" PRIu32 "s | "
+                   "TR(I=[%d,%d], k=%d, c=%d, TC=%" PRIu64 "s, TI=%" PRIu64 "s)]\n",
                     ipv6_addr_to_str(addr_str, &dodag->dodag_id, sizeof(addr_str)),
-                    dodag->my_rank, ((int32_t) cleanup.seconds) > 0 ? cleanup.seconds : 0,
+                    dodag->my_rank, (((int32_t) cleanup < 0) ? 0 : cleanup/SEC_IN_USEC),
                     (1 << dodag->dio_min), dodag->dio_interval_doubl,
                     dodag->trickle.k, dodag->trickle.c, tc, ti);
             gnrc_rpl_parent_t *parent;
             LL_FOREACH(dodag->parents, parent) {
-                printf("\t\tparent [addr: %s | rank: %d | lifetime: %" PRIu32 "s]\n",
+                printf("\t\tparent [addr: %s | rank: %d | lifetime: %" PRIu64 "s]\n",
                         ipv6_addr_to_str(addr_str, &parent->addr, sizeof(addr_str)),
-                        parent->rank, (parent->lifetime.seconds - now.seconds));
+                        parent->rank, ((int64_t) (parent->lifetime - xnow) < 0 ? 0
+                                       : (parent->lifetime - xnow) / SEC_IN_USEC));
             }
         }
     }

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -170,19 +170,17 @@ int _xtimer_set_absolute(xtimer_t *timer, uint32_t target)
     }
 
     timer->target = target;
+    timer->long_target = _long_cnt;
+    if (target < now) {
+        timer->long_target++;
+    }
 
     unsigned state = disableIRQ();
     if ( !_this_high_period(target) ) {
         DEBUG("xtimer_set_absolute(): the timer doesn't fit into the low-level timer's mask.\n");
-        timer->long_target = _long_cnt;
         _add_timer_to_long_list(&long_list_head, timer);
     }
     else {
-        if (!target) {
-            /* set long_target != 0 so _is_set() can work */
-            timer->long_target = 1;
-        }
-
         if (_mask(now) >= target) {
             DEBUG("xtimer_set_absolute(): the timer will expire in the next timer period\n");
             _add_timer_to_list(&overflow_list_head, timer);


### PR DESCRIPTION
This PR replaces the vtimer with xtimer in RPL.

**EDIT:**
Rationale: without this switch, strange `enableIRQ` warnings occure on native when initializing rpl.
Furthermore, this is an alternative to #3775, without dropping existing features.

~~depends on: #3776~~