### PR TITLE
sys: shell: work around inlined putchar

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -32,6 +32,16 @@
 #include "shell.h"
 #include "shell_commands.h"
 
+#ifdef MODULE_NEWLIB
+/* use local copy of putchar, as it seems to be inlined,
+ * enlarging code by 50% */
+static void _putchar(int c) {
+    putchar(c);
+}
+#else
+#define _putchar putchar
+#endif
+
 static shell_command_handler_t find_handler(const shell_command_t *command_list, char *command)
 {
     const shell_command_t *command_lists[] = {
@@ -224,8 +234,8 @@ static int readline(char *buf, size_t size)
         /* DOS newlines are handled like hitting enter twice, but empty lines are ignored. */
         if (c == '\r' || c == '\n') {
             *line_buf_ptr = '\0';
-            putchar('\r');
-            putchar('\n');
+            _putchar('\r');
+            _putchar('\n');
 
             /* return 1 if line is empty, 0 otherwise */
             return line_buf_ptr == buf;
@@ -239,21 +249,21 @@ static int readline(char *buf, size_t size)
 
             *--line_buf_ptr = '\0';
             /* white-tape the character */
-            putchar('\b');
-            putchar(' ');
-            putchar('\b');
+            _putchar('\b');
+            _putchar(' ');
+            _putchar('\b');
         }
         else {
             *line_buf_ptr++ = c;
-            putchar(c);
+            _putchar(c);
         }
     }
 }
 
 static inline void print_prompt(void)
 {
-    putchar('>');
-    putchar(' ');
+    _putchar('>');
+    _putchar(' ');
 
 #ifdef MODULE_NEWLIB
     fflush(stdout);


### PR DESCRIPTION
Using putchar as-is, as introduced by the shell simplification PR, shell.o gets 40% bigger.
So this PR creates a local function as workaround, if newlib is used.

(oldbin is master, newbin is with this PR):

```
text	data	bss	dec	BOARD/BINDIRBASE

-384	0	0	-384	airfy-beacon
11772	148	2748	14668	oldbin
11388	148	2748	14284	newbin

-432	0	0	-432	arduino-due
12028	152	2824	15004	oldbin
11596	152	2824	14572	newbin

0	0	0	0	arduino-mega2560
14740	818	808	16366	oldbin
14740	818	808	16366	newbin

-1032	0	0	-1032	avsextrem
51532	2324	95977	149833	oldbin
50500	2324	95977	148801	newbin

-432	0	0	-432	cc2538dk
11576	148	2740	14464	oldbin
11144	148	2740	14032	newbin

ERR	ERR	ERR	ERR	chronos
ERR	ERR	ERR	ERR	oldbin
ERR	ERR	ERR	ERR	newbin

-432	0	0	-432	ek-lm4f120xl
11492	148	2724	14364	oldbin
11060	148	2724	13932	newbin

-432	0	0	-432	f4vi1
13044	152	2760	15956	oldbin
12612	152	2760	15524	newbin

-432	0	0	-432	fox
17784	148	2924	20856	oldbin
17352	148	2924	20424	newbin

-432	0	0	-432	frdm-k64f
15928	1244	4900	22072	oldbin
15496	1244	4900	21640	newbin

-432	0	0	-432	iotlab-m3
18452	148	2932	21532	oldbin
18020	148	2932	21100	newbin

-432	0	0	-432	limifrog-v1
12960	148	2764	15872	oldbin
12528	148	2764	15440	newbin

-432	0	0	-432	mbed_lpc1768
11312	148	2764	14224	oldbin
10880	148	2764	13792	newbin

ERR	ERR	ERR	ERR	msb-430
ERR	ERR	ERR	ERR	oldbin
ERR	ERR	ERR	ERR	newbin

ERR	ERR	ERR	ERR	msb-430h
ERR	ERR	ERR	ERR	oldbin
ERR	ERR	ERR	ERR	newbin

-1032	0	0	-1032	msba2
62108	2332	93981	158421	oldbin
61076	2332	93981	157389	newbin

-432	0	0	-432	msbiot
13324	152	2784	16260	oldbin
12892	152	2784	15828	newbin

-432	0	0	-432	mulle
17808	1268	4628	23704	oldbin
17376	1268	4628	23272	newbin

0	0	0	0	native
46506	536	52020	99062	oldbin
46506	536	52020	99062	newbin

-384	0	0	-384	nrf51dongle
11796	148	2748	14692	oldbin
11412	148	2748	14308	newbin

-384	0	0	-384	nrf6310
11772	148	2748	14668	oldbin
11388	148	2748	14284	newbin

-384	0	0	-384	nucleo-f091
18568	152	2776	21496	oldbin
18184	152	2776	21112	newbin

-432	0	0	-432	nucleo-f303
13000	148	2780	15928	oldbin
12568	148	2780	15496	newbin

-432	0	0	-432	nucleo-f334
12744	148	2756	15648	oldbin
12312	148	2756	15216	newbin

-432	0	0	-432	nucleo-l1
12960	148	2756	15864	oldbin
12528	148	2756	15432	newbin

-432	0	0	-432	openmote
11484	148	2740	14372	oldbin
11052	148	2740	13940	newbin

-432	0	0	-432	pba-d-01-kw2x
15996	1244	4284	21524	oldbin
15564	1244	4284	21092	newbin

-384	0	0	-384	pca10000
11796	148	2748	14692	oldbin
11412	148	2748	14308	newbin

-384	0	0	-384	pca10005
11776	148	2748	14672	oldbin
11392	148	2748	14288	newbin

-1032	0	0	-1032	pttu
51740	2324	95977	150041	oldbin
50708	2324	95977	149009	newbin

0	0	0	0	qemu-i386
135994	5528	76528	218050	oldbin
135994	5528	76528	218050	newbin

-432	0	0	-432	remote
12140	148	2740	15028	oldbin
11708	148	2740	14596	newbin

-384	0	0	-384	saml21-xpro
11872	148	2844	14864	oldbin
11488	148	2844	14480	newbin

-384	0	0	-384	samr21-xpro
15224	156	2740	18120	oldbin
14840	156	2740	17736	newbin

-432	0	0	-432	spark-core
13668	148	2884	16700	oldbin
13236	148	2884	16268	newbin

-384	0	0	-384	stm32f0discovery
14904	148	2764	17816	oldbin
14520	148	2764	17432	newbin

-432	0	0	-432	stm32f3discovery
13004	148	2780	15932	oldbin
12572	148	2780	15500	newbin

-432	0	0	-432	stm32f4discovery
13208	152	2768	16128	oldbin
12776	152	2768	15696	newbin

ERR	ERR	ERR	ERR	telosb
ERR	ERR	ERR	ERR	oldbin
ERR	ERR	ERR	ERR	newbin

-432	0	0	-432	udoo
12028	152	2824	15004	oldbin
11596	152	2824	14572	newbin

ERR	ERR	ERR	ERR	wsn430-v1_3b
ERR	ERR	ERR	ERR	oldbin
ERR	ERR	ERR	ERR	newbin

ERR	ERR	ERR	ERR	wsn430-v1_4
ERR	ERR	ERR	ERR	oldbin
ERR	ERR	ERR	ERR	newbin

-384	0	0	-384	yunjia-nrf51822
11760	148	2748	14656	oldbin
11376	148	2748	14272	newbin

ERR	ERR	ERR	ERR	z1
ERR	ERR	ERR	ERR	oldbin
ERR	ERR	ERR	ERR	newbin
```