### PR TITLE
tests: xtimer_usleep_until: fix diff calculation

### DIFF
--- a/tests/xtimer_usleep_until/main.c
+++ b/tests/xtimer_usleep_until/main.c
@@ -37,7 +37,7 @@ int main(void)
         uint32_t last_wakeup = xtimer_now();
         uint32_t before = last_wakeup;
         xtimer_usleep_until(&last_wakeup, (unsigned)interval);
-        uint32_t diff = (last_wakeup-before)-interval;
+        uint32_t diff = (xtimer_now()-before)-interval;
         res[i] = diff;
         interval -= 1;
     }


### PR DESCRIPTION
xtimer_usleep_until's internal logic has changed, always setting
&last_wakeup to the expected instead of real value.
In order to make this test output valid values, this commit adapts it.