### PR TITLE
Makefile.iotlab: accept custom resource id list for experiment-cli

### DIFF
--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -3,7 +3,7 @@
 IOTLAB_NODES    ?= 5
 IOTLAB_DURATION ?= 30
 IOTLAB_SITE     ?= grenoble
-IOTLAB_TYPE     ?= "m3:at86rf231"
+IOTLAB_TYPE     ?= m3:at86rf231
 IOTLAB_AUTH     ?= $(HOME)/.iotlabrc
 IOTLAB_USER     ?= $(shell cut -f1 -d: $(IOTLAB_AUTH))
 IOTLAB_EXP_ID   ?= $(shell experiment-cli get -l --state Running | grep -m 1 '"id"' | grep -Eo '[[:digit:]]+')
@@ -22,10 +22,17 @@ iotlab-exp: $(IOTLAB_AUTH) all
     ifneq (RIOT_EXP,$(IOTLAB_EXP_NAME))
 	    $(eval IOTLAB_EXP_NAME := RIOT_EXP_$(IOTLAB_EXP_NAME))
     endif
-    ifeq (,$(AD))
-	    @echo "experiment-cli submit -d $(IOTLAB_DURATION) -l $(IOTLAB_NODES),archi=$(IOTLAB_TYPE)+site=$(IOTLAB_SITE),$(BINARY),$(IOTLAB_PROFILE) -n $(IOTLAB_EXP_NAME)"
+
+    ifndef IOTLAB_PHY_NODES
+	    $(eval NODES_LIST := "$(IOTLAB_NODES),archi=$(IOTLAB_TYPE)+site=$(IOTLAB_SITE),$(BINARY),$(IOTLAB_PROFILE)")
+    else
+	    $(eval NODES_LIST := "$(IOTLAB_SITE),$(firstword $(subst :, ,$(IOTLAB_TYPE))),$(IOTLAB_PHY_NODES),$(BINARY),$(IOTLAB_PROFILE)")
     endif
-	$(eval NEW_ID := $(shell experiment-cli submit -d $(IOTLAB_DURATION) -l $(IOTLAB_NODES),archi=$(IOTLAB_TYPE)+site=$(IOTLAB_SITE),$(BINARY),$(IOTLAB_PROFILE) -n $(IOTLAB_EXP_NAME) | grep -Eo '[[:digit:]]+'))
+
+    ifeq (,$(AD))
+	    @echo "experiment-cli submit -d $(IOTLAB_DURATION) -l $(NODES_LIST) -n $(IOTLAB_EXP_NAME)"
+    endif
+	$(eval NEW_ID := $(shell experiment-cli submit -d $(IOTLAB_DURATION) -l $(NODES_LIST) -n $(IOTLAB_EXP_NAME) | grep -Eo '[[:digit:]]+'))
 	$(AD)experiment-cli wait -i $(NEW_ID)
 
 iotlab-flash: $(IOTLAB_AUTH) all

--- a/dist/testbed-support/README.iotlab.md
+++ b/dist/testbed-support/README.iotlab.md
@@ -31,6 +31,8 @@ brackets):
  * IOTLAB_AUTH ($HOME/.iotlabrc)
  * IOTLAB_USER (taken from $IOTLAB_AUTH)
  * IOTLAB_EXP_ID (taken from first experiment in running state)
+ * IOTLAB_EXP_NAME (RIOT_EXP)
+ * IOTLAB_PHY_NODES
 
 ### Targets
 
@@ -48,9 +50,13 @@ if `IOTLAB_EXP_ID` is not set.
 
 This schedules a new experiment on the FIT IoT-LAB and waits until it enters
 "Running" state. It will request `IOTLAB_NODES` nodes of type `IOTLAB_TYPE`
-for `IOTLAB_DURATION` minutes at site `IOTLAB_SITE`. It will also flash the
+for `IOTLAB_DURATION` minutes at site `IOTLAB_SITE`. With `IOTLAB_PHY_NODES`
+it is possible to choose specific nodes for this experiment by using the resourceid
+string format defined in `experiment-cli submit --help` (example: 1-3+7+10-13).
+Note that the usage of `IOTLAB_PHY_NODES` ignores `IOTLAB_NODES`. It will also flash the
 binary of the current application to all registered nodes. The name of the
-experiment is set to "riot_makefile_experiment"
+experiment is set to "RIOT_EXP" or "RIOT_EXP_$(IOTLAB_EXP_NAME)"
+if `IOTLAB_EXP_NAME` is defined.
 
 #### iotlab-flash
 


### PR DESCRIPTION
This PR introduces the possibility to specify custom nodes for the experiment on the iotlab-testbed.
Hence, it will be possible to start an experiment with: `IOTLAB_PHY_NODES=1-3+6+9-11 ... make ... iotlab-exp`.
When one or more nodes are not available for this experiment, the make target will fail and state the nodes that could not be allocated.

EDIT:
Rationale: By using the alias experiment type (when only submitting the amount of nodes, but not **which** nodes), then the testbed tends to choose nodes that are adjacent. This may however not be desired, if multiple hops are required. By using the physical experiment type (submitting the specific nodes), it is possible choose nodes that are further apart from each other.