### PR TITLE
core: optimized output on kernel-init

### DIFF
--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -51,6 +51,8 @@ static void *main_trampoline(void *arg)
     auto_init();
 #endif
 
+    LOG_INFO("main(): This is RIOT! (Version: " RIOT_VERSION ")\n");
+
     main();
     return NULL;
 }
@@ -82,7 +84,6 @@ static char idle_stack[THREAD_STACKSIZE_IDLE];
 void kernel_init(void)
 {
     (void) disableIRQ();
-    LOG_INFO("kernel_init(): This is RIOT! (Version: %s)\n", RIOT_VERSION);
 
     hwtimer_init();
 
@@ -95,8 +96,6 @@ void kernel_init(void)
             THREAD_PRIORITY_MAIN,
             CREATE_WOUT_YIELD | CREATE_STACKTEST,
             main_trampoline, NULL, main_name);
-
-    LOG_INFO("kernel_init(): jumping into first task...\n");
 
     cpu_switch_context_exit();
 }


### PR DESCRIPTION
This PR saves some memory by ommiting redundant output. The printing
of "jumpint into first task..." is obsolete, as the thread_create
calls are not checked for errors anymore.

Further the version print is moved into the main_trampoline. This
prevents the STDLIB from using precious stack space on the ISR
stack, on which it is running before jumping into main - hence
opening the option to decrease the stacksize for the ISR stack.

Savings:
```
`--> make info-buildsizes-diff OLDBIN=master-bin NEWBIN=hauke-bin                                                                                                                [13:56:18][0]
text	data	bss	dec	BOARD/BINDIRBASE

-64	0	0	-64	airfy-beacon
8284	112	2688	11084	master-bin
8220	112	2688	11020	hauke-bin

-60	0	0	-60	arduino-due
8780	116	2764	11660	master-bin
8720	116	2764	11600	hauke-bin

0	-50	0	-50	arduino-mega2560
8358	436	770	9564	master-bin
8358	386	770	9514	hauke-bin

-56	0	0	-56	avsextrem
40068	2224	96073	138365	master-bin
40012	2224	96073	138309	hauke-bin

-60	0	0	-60	cc2538dk
8356	112	2688	11156	master-bin
8296	112	2688	11096	hauke-bin

-58	0	0	-58	chronos
8496	90	1038	9624	master-bin
8438	90	1038	9566	hauke-bin

-64	0	0	-64	ek-lm4f120xl
8384	112	2664	11160	master-bin
8320	112	2664	11096	hauke-bin

-60	0	0	-60	f4vi1
9788	116	2700	12604	master-bin
9728	116	2700	12544	hauke-bin

-60	0	0	-60	fox
10280	112	2832	13224	master-bin
10220	112	2832	13164	hauke-bin

-60	0	0	-60	frdm-k64f
8280	1140	4820	14240	master-bin
8220	1140	4820	14180	hauke-bin

-64	0	0	-64	iotlab-m3
10316	112	2832	13260	master-bin
10252	112	2832	13196	hauke-bin

-60	0	0	-60	limifrog-v1
9648	112	2712	12472	master-bin
9588	112	2712	12412	hauke-bin

-60	0	0	-60	mbed_lpc1768
8164	112	2712	10988	master-bin
8104	112	2712	10928	hauke-bin

-58	0	0	-58	msb-430
8172	10	1086	9268	master-bin
8114	10	1086	9210	hauke-bin

-58	0	0	-58	msb-430h
8052	10	1086	9148	master-bin
7994	10	1086	9090	hauke-bin

-64	0	0	-64	msba2
39748	2224	96073	138045	master-bin
39684	2224	96073	137981	hauke-bin

-60	0	0	-60	msbiot
10100	116	2724	12940	master-bin
10040	116	2724	12880	hauke-bin

-60	0	0	-60	mulle
10324	1164	4564	16052	master-bin
10264	1164	4564	15992	hauke-bin

-64	0	0	-64	native
30630	400	47648	78678	master-bin
30566	400	47648	78614	hauke-bin

-60	0	0	-60	nrf51dongle
8304	112	2688	11104	master-bin
8244	112	2688	11044	hauke-bin

-60	0	0	-60	nrf6310
8276	112	2688	11076	master-bin
8216	112	2688	11016	hauke-bin

-64	0	0	-64	nucleo-f091
10952	112	2712	13776	master-bin
10888	112	2712	13712	hauke-bin

-60	0	0	-60	nucleo-f303
9780	112	2720	12612	master-bin
9720	112	2720	12552	hauke-bin

-64	0	0	-64	nucleo-f334
9516	112	2696	12324	master-bin
9452	112	2696	12260	hauke-bin

-64	0	0	-64	nucleo-l1
9624	112	2704	12440	master-bin
9560	112	2704	12376	hauke-bin

-60	0	0	-60	openmote
8264	112	2688	11064	master-bin
8204	112	2688	11004	hauke-bin

-60	0	0	-60	pba-d-01-kw2x
8352	1140	4204	13696	master-bin
8292	1140	4204	13636	hauke-bin

-64	0	0	-64	pca10000
8304	112	2688	11104	master-bin
8240	112	2688	11040	hauke-bin

-64	0	0	-64	pca10005
8284	112	2688	11084	master-bin
8220	112	2688	11020	hauke-bin

-64	0	0	-64	pttu
40276	2224	96073	138573	master-bin
40212	2224	96073	138509	hauke-bin

-60	0	0	-60	qemu-i386
128977	5468	76436	210881	master-bin
128917	5468	76436	210821	hauke-bin

-64	0	0	-64	remote
8940	112	2688	11740	master-bin
8876	112	2688	11676	hauke-bin

-64	0	0	-64	saml21-xpro
8508	112	2792	11412	master-bin
8444	112	2792	11348	hauke-bin

-60	0	0	-60	samr21-xpro
8432	112	2680	11224	master-bin
8372	112	2680	11164	hauke-bin

-64	0	0	-64	spark-core
10344	112	2832	13288	master-bin
10280	112	2832	13224	hauke-bin

-64	0	0	-64	stm32f0discovery
10964	112	2712	13788	master-bin
10900	112	2712	13724	hauke-bin

-60	0	0	-60	stm32f3discovery
9792	112	2720	12624	master-bin
9732	112	2720	12564	hauke-bin

-64	0	0	-64	stm32f4discovery
9980	116	2716	12812	master-bin
9916	116	2716	12748	hauke-bin

-58	0	0	-58	telosb
8190	6	1086	9282	master-bin
8132	6	1086	9224	hauke-bin

-64	0	0	-64	udoo
8776	116	2764	11656	master-bin
8712	116	2764	11592	hauke-bin

-58	0	0	-58	wsn430-v1_3b
8200	10	1086	9296	master-bin
8142	10	1086	9238	hauke-bin

-58	0	0	-58	wsn430-v1_4
8200	10	1086	9296	master-bin
8142	10	1086	9238	hauke-bin

-60	0	0	-60	yunjia-nrf51822
8272	112	2688	11072	master-bin
8212	112	2688	11012	hauke-bin

-58	0	0	-58	z1
7818	6	1086	8910	master-bin
7760	6	1086	8852	hauke-bin
```