### PR TITLE
 ng_sixlowpan: make lookup in reassembly buffer more efficient

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -288,10 +288,8 @@ static rbuf_t *_rbuf_get(const void *src, size_t src_len,
 	}
 
         /* if there is a free spot: remember it */
-	else{
-            if (res == NULL) {
+	else if (res == NULL) {
                 res = &(rbuf[i]);
-            }
 	}
     }
 

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -269,11 +269,10 @@ static rbuf_t *_rbuf_get(const void *src, size_t src_len,
     uint32_t now_sec = xtimer_now() / SEC_IN_USEC;
 
     for (unsigned int i = 0; i < RBUF_SIZE; i++) {
-        /* check first if entry already available */
-	if (rbuf[i].pkt != NULL) {
-            if ((rbuf[i].pkt->size == size) &&
-                (rbuf[i].tag == tag) && (rbuf[i].src_len == src_len) &&
-                (rbuf[i].dst_len == dst_len) &&
+        /* check first if entry already available */ 
+	if (rbuf[i].pkt != NULL){
+            if ((rbuf[i].tag == tag) && (rbuf[i].pkt->size == size) &&
+                (rbuf[i].src_len == src_len) && (rbuf[i].dst_len == dst_len) &&
                 (memcmp(rbuf[i].src, src, src_len) == 0) &&
                 (memcmp(rbuf[i].dst, dst, dst_len) == 0)) {
                 DEBUG("6lo rfrag: entry %p (%s, ", (void *)(&rbuf[i]),

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -270,26 +270,30 @@ static rbuf_t *_rbuf_get(const void *src, size_t src_len,
 
     for (unsigned int i = 0; i < RBUF_SIZE; i++) {
         /* check first if entry already available */
-        if ((rbuf[i].pkt != NULL) && (rbuf[i].pkt->size == size) &&
-            (rbuf[i].tag == tag) && (rbuf[i].src_len == src_len) &&
-            (rbuf[i].dst_len == dst_len) &&
-            (memcmp(rbuf[i].src, src, src_len) == 0) &&
-            (memcmp(rbuf[i].dst, dst, dst_len) == 0)) {
-            DEBUG("6lo rfrag: entry %p (%s, ", (void *)(&rbuf[i]),
-                  gnrc_netif_addr_to_str(l2addr_str, sizeof(l2addr_str),
+	if (rbuf[i].pkt != NULL) {
+            if ((rbuf[i].pkt->size == size) &&
+                (rbuf[i].tag == tag) && (rbuf[i].src_len == src_len) &&
+                (rbuf[i].dst_len == dst_len) &&
+                (memcmp(rbuf[i].src, src, src_len) == 0) &&
+                (memcmp(rbuf[i].dst, dst, dst_len) == 0)) {
+                DEBUG("6lo rfrag: entry %p (%s, ", (void *)(&rbuf[i]),
+                    gnrc_netif_addr_to_str(l2addr_str, sizeof(l2addr_str),
                                          rbuf[i].src, rbuf[i].src_len));
-            DEBUG("%s, %u, %u) found\n",
-                  gnrc_netif_addr_to_str(l2addr_str, sizeof(l2addr_str),
+                DEBUG("%s, %u, %u) found\n",
+                    gnrc_netif_addr_to_str(l2addr_str, sizeof(l2addr_str),
                                          rbuf[i].dst, rbuf[i].dst_len),
-                  (unsigned)rbuf[i].pkt->size, rbuf[i].tag);
-            rbuf[i].arrival = now_sec;
-            return &(rbuf[i]);
-        }
+                    (unsigned)rbuf[i].pkt->size, rbuf[i].tag);
+                rbuf[i].arrival = now_sec;
+                return &(rbuf[i]);
+            }
+	}
 
         /* if there is a free spot: remember it */
-        if ((res == NULL) && (rbuf[i].pkt == NULL)) {
-            res = &(rbuf[i]);
-        }
+	else{
+            if (res == NULL) {
+                res = &(rbuf[i]);
+            }
+	}
     }
 
     if (res != NULL) { /* entry not in buffer but found empty spot */

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -270,7 +270,7 @@ static rbuf_t *_rbuf_get(const void *src, size_t src_len,
 
     for (unsigned int i = 0; i < RBUF_SIZE; i++) {
         /* check first if entry already available */ 
-	if (rbuf[i].pkt != NULL){
+	if (rbuf[i].pkt != NULL) {
             if ((rbuf[i].tag == tag) && (rbuf[i].pkt->size == size) &&
                 (rbuf[i].src_len == src_len) && (rbuf[i].dst_len == dst_len) &&
                 (memcmp(rbuf[i].src, src, src_len) == 0) &&
@@ -289,7 +289,7 @@ static rbuf_t *_rbuf_get(const void *src, size_t src_len,
 
         /* if there is a free spot: remember it */
 	else if (res == NULL) {
-                res = &(rbuf[i]);
+            res = &(rbuf[i]);
 	}
     }
 


### PR DESCRIPTION
Hi, after looking into the code, I think this should lessen a little the computing charge.
With this, the code computes fastest checks first (tag, size) and, if they pass, it computes most expensive tests (memcmp calls). It also checks first the tag as it can be a good solution to discriminate easily two different packets and then, other tests confirms that it is the right packet. 
This is really fast compared to bloom filter as it add computations when adding and removing an entry into the buffer. With the defined buffer size (4U), it does not worth it.