### PR TITLE
gnrc: 6lowpan: router solicitation retransmission fixes

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -495,6 +495,11 @@ void gnrc_ndp_rtr_adv_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt, ipv6_hdr_t
          * not to run out; see https://tools.ietf.org/html/rfc6775#section-5.4.3 */
         next_rtr_sol *= 3;
         next_rtr_sol >>= 2;
+        /* according to https://tools.ietf.org/html/rfc6775#section-5.3:
+         * "In all cases, the RS retransmissions are terminated when an RA is
+         *  received."
+         *  Hence, reset router solicitation counter and reset timer. */
+        &nc_entry->rtr_sol_count = 0;
         gnrc_sixlowpan_nd_rtr_sol_reschedule(nc_entry, next_rtr_sol);
         gnrc_ndp_internal_send_nbr_sol(ifs[i], &nc_entry->ipv6_addr, &nc_entry->ipv6_addr);
         vtimer_remove(&nc_entry->nbr_sol_timer);


### PR DESCRIPTION
This fixes the issue that a 6LoWPAN host would send out retransmissions of router solicitations without any delay.

Furthermore, RFC6775 can be interpreted that the minimum delay should be bigger as the the initial delay for the first three retransmissions and should be limited to maximum 60 seconds.