### PR TITLE
native: netdev2_tap: fix NETOPT_IS_WIRED flag

### DIFF
--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -159,6 +159,9 @@ int _get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len)
             break;
         case NETOPT_IPV6_IID:
             return _get_iid(dev, value, max_len);
+        case NETOPT_IS_WIRED:
+            res = 1;
+            break;
         default:
             res = -ENOTSUP;
             break;


### PR DESCRIPTION
This got somehow lost in the `gnrc_netdev` => `netdev2` transition.