### PR TITLE
ipv6_addr: make IPv4 compatible addresses optional

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -243,10 +243,6 @@ ifneq (,$(filter newlib,$(USEMODULE)))
   USEMODULE += uart_stdio
 endif
 
-ifneq (,$(filter ipv6_addr,$(USEMODULE)))
-  USEMODULE += ipv4_addr
-endif
-
 ifneq (,$(filter posix,$(USEMODULE)))
   USEMODULE += timex
   USEMODULE += vtimer

--- a/sys/include/net/ipv6/addr.h
+++ b/sys/include/net/ipv6/addr.h
@@ -40,11 +40,18 @@ extern "C" {
  */
 #define IPV6_ADDR_BIT_LEN           (128)
 
+#ifdef MODULE_IPV4_ADDR
 /**
  * @brief   Maximum length of an IPv6 address as string.
  */
-#define IPV6_ADDR_MAX_STR_LEN       (sizeof("ffff:ffff:ffff:ffff:" \
-                                            "ffff:ffff:255.255.255.255"))
+#define IPV6_ADDR_MAX_STR_LEN       (sizeof("ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255"))
+#else
+/**
+ * @brief   Maximum length of an IPv6 address as string.
+ */
+#define IPV6_ADDR_MAX_STR_LEN       (sizeof("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"))
+#endif
+
 
 /**
  * @brief The first 10 bits of a site-local IPv6 unicast address

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr_from_str.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr_from_str.c
@@ -41,7 +41,9 @@
 ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr)
 {
     uint8_t *colonp = 0;
+#ifdef MODULE_IPV4_ADDR
     const char *curtok = addr;
+#endif
     uint32_t val = 0;
     char ch;
     uint8_t saw_xdigit = 0;
@@ -81,7 +83,9 @@ ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr)
         }
 
         if (ch == ':') {
+#ifdef MODULE_IPV4_ADDR
             curtok = addr;
+#endif
 
             if (!saw_xdigit) {
                 if (colonp != NULL) {
@@ -103,6 +107,7 @@ ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr)
             continue;
         }
 
+#ifdef MODULE_IPV4_ADDR
         if (ch == '.' && (i <= sizeof(ipv6_addr_t)) &&
             ipv4_addr_from_str((ipv4_addr_t *)(&(result->u8[i])),
                                curtok) != NULL) {
@@ -110,6 +115,7 @@ ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr)
             saw_xdigit = 0;
             break;  /* '\0' was seen by ipv4_addr_from_str(). */
         }
+#endif
 
         return NULL;
     }

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr_to_str.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr_to_str.c
@@ -103,6 +103,7 @@ char *ipv6_addr_to_str(char *result, const ipv6_addr_t *addr, uint8_t result_len
             *tp++ = ':';
         }
 
+#ifdef MODULE_IPV4_ADDR
         /* Is this address an encapsulated IPv4? */
         if (i == 6 && best.base == 0 &&
             (best.len == 6 || (best.len == 5 && addr->u16[5].u16 == 0xffff))) {
@@ -114,6 +115,7 @@ char *ipv6_addr_to_str(char *result, const ipv6_addr_t *addr, uint8_t result_len
             tp += strlen(tp);
             break;
         }
+#endif
 
         if ((addr->u16[i].u8[0] & 0xf0) != 0x00) {
             *tp++ = HEX_L[addr->u16[i].u8[0] >> 4];

--- a/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
+++ b/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
@@ -862,8 +862,11 @@ static void test_ipv6_addr_to_str__success5(void)
     };
     char result[IPV6_ADDR_MAX_STR_LEN];
 
-    TEST_ASSERT_EQUAL_STRING("::ffff:192.168.0.1",
-                             ipv6_addr_to_str(result, &a, sizeof(result)));
+#ifdef MODULE_IPV4_ADDR
+    TEST_ASSERT_EQUAL_STRING("::ffff:192.168.0.1", ipv6_addr_to_str(result, &a, sizeof(result)));
+#else
+    TEST_ASSERT_EQUAL_STRING("::ffff:c0a8:1", ipv6_addr_to_str(result, &a, sizeof(result)));
+#endif
 }
 
 static void test_ipv6_addr_from_str__one_colon_start(void)
@@ -980,7 +983,11 @@ static void test_ipv6_addr_from_str__success6(void)
     };
     ipv6_addr_t result;
 
+#ifdef MODULE_IPV4_ADDR
     TEST_ASSERT_NOT_NULL(ipv6_addr_from_str(&result, "ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255"));
+#else
+    TEST_ASSERT_NOT_NULL(ipv6_addr_from_str(&result, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"));
+#endif
     TEST_ASSERT(ipv6_addr_equal(&a, &result));
 }
 


### PR DESCRIPTION
Asked by @haukepetersen and @cgundogan (and others) in #3608, now delivered

~~Depends on #3608.~~