### PR TITLE
dns: Review for DNS implementation

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -83,6 +83,12 @@ ifneq (,$(filter gnrc_tftp,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter gnrc_dns,$(USEMODULE)))
+  USEMODULE += gnrc_udp
+  USEMODULE += xtimer
+  USEMODULE += timex
+endif
+
 ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
   USEMODULE += fib
   USEMODULE += gnrc_ipv6_router_default

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -25,6 +25,7 @@ USEMODULE += gnrc_rpl
 USEMODULE += gnrc_pktdump
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
+USEMODULE += gnrc_dns
 # Add also the shell, some shell commands
 USEMODULE += shell
 USEMODULE += shell_commands

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -76,6 +76,10 @@
 #include "net/gnrc/udp.h"
 #endif
 
+#ifdef MODULE_GNRC_DNS
+#include "net/gnrc/dns.h"
+#endif
+
 #ifdef MODULE_FIB
 #include "net/fib.h"
 #endif
@@ -150,7 +154,10 @@ void auto_init(void)
     extern void dht_auto_init(void);
     dht_auto_init();
 #endif
-
+#ifdef MODULE_GNRC_DNS
+    DEBUG("Auto init DNS module.\n");
+    gnrc_dns_init();
+#endif
 
 /* initialize network devices */
 #ifdef MODULE_AUTO_INIT_GNRC_NETIF

--- a/sys/include/net/gnrc/dns.h
+++ b/sys/include/net/gnrc/dns.h
@@ -1,0 +1,274 @@
+/*
+ * Copyright (C) 2015 Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @defgroup    net_dns DNS
+ * @ingroup     net
+ * @brief       Provides DNS header and helper functions
+ * @{
+ *
+ * @file
+ * @brief       DNS client implementation
+ *
+ * The DNS module get's it's DNS server configuration from the NDP
+ * Router Advertisement message. The implementation loosely follows the
+ * following RFC's:
+ *
+ *  - https://www.ietf.org/rfc/rfc1035.txt
+ *     (RFC1035 Domain Names - Implementation and Specifications)
+ *       - Only implemented A, CNAME, TXT records querying
+ *       - No cache support
+ *  - https://www.rfc-editor.org/rfc/rfc2782.txt
+ *     (RFC2782 A DNS RR for specifying the location of services)
+ *       - Fully
+ *  - https://www.ietf.org/rfc/rfc3596.txt
+ *     (RFC3596 DNS Extensions to Support IPv6)
+ *       - Fully
+ *  - https://tools.ietf.org/html/rfc6106
+ *     (RFC6106 IPv6 Router Advertisement Options for DNS Configuration)
+ *       - Only RDNSS, no DNSSL
+ *
+ * @author      Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ */
+
+#ifndef GNRC_DNS_H_
+#define GNRC_DNS_H_
+
+#include <stdint.h>
+
+#include "net/gnrc/ipv6/netif.h"
+#include "net/ipv6/addr.h"
+#include "net/ipv4/addr.h"
+#include "byteorder.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @def GNRC_DNS_SERVERS_SUPPORT
+ *
+ * @brief   Number of DNS servers that are supported per interface
+ */
+#ifndef GNRC_DNS_SERVERS_SUPPORT
+#define GNRC_DNS_SERVERS_SUPPORT             (3)
+#endif
+
+/**
+ * @def GNRC_DNS_MSG_QUEUE_SIZE
+ *
+ * @brief   Default message queue size for the DNS thread
+ */
+#ifndef GNRC_DNS_MSG_QUEUE_SIZE
+#define GNRC_DNS_MSG_QUEUE_SIZE              (8U)
+#endif
+
+/**
+ * @def GNRC_DNS_PRIO
+ *
+ * @brief   Priority of the DNS thread
+ */
+#ifndef GNRC_DNS_PRIO
+#define GNRC_DNS_PRIO                        (THREAD_PRIORITY_MAIN - 2)
+#endif
+
+/**
+ * @def GNRC_DNS_STACK_SIZE
+ *
+ * @brief   Default stack size to use for the DNS thread
+ */
+#ifndef GNRC_DNS_STACK_SIZE
+#define GNRC_DNS_STACK_SIZE                  (THREAD_STACKSIZE_DEFAULT + 1024)
+#endif
+
+/**
+ * @def GNRC_DNS_RESOLVE_SRC_PORT
+ *
+ * @brief   Default DNS send request port
+ */
+#ifndef GNRC_DNS_RESOLVE_SRC_PORT
+#define GNRC_DNS_RESOLVE_SRC_PORT            (53053)
+#endif
+
+/**
+ * @def GNRC_DNS_RESOLVE_DST_PORT
+ *
+ * @brief   Default DNS send request port
+ */
+#ifndef GNRC_DNS_RESOLVE_DST_PORT
+#define GNRC_DNS_RESOLVE_DST_PORT            (53)
+#endif
+
+/**
+ * @def GNRC_DNS_MAX_QUERY_STR_LEN
+ *
+ * @brief   The maximum length of the DNS query string
+ */
+#ifndef GNRC_DNS_MAX_QUERY_STR_LEN
+#define GNRC_DNS_MAX_QUERY_STR_LEN           (100)
+#endif
+
+/**
+ * @def GNRC_DNS_MAX_RESPONSE_ADDRESSES
+ *
+ * @brief   The maximum number of IP address to be processed
+ *          from the response
+ */
+#ifndef GNRC_DNS_MAX_RESPONSE_ADDRESSES
+#define GNRC_DNS_MAX_RESPONSE_ADDRESSES      (6)
+#endif
+
+/**
+ * @def GNRC_DNS_MAX_SIMULTANEOUS_REQUESTS
+ *
+ * @brief   The maximum number of simultaneous DNS requests
+ */
+#ifndef GNRC_DNS_MAX_SIMULTANEOUS_REQUESTS
+#define GNRC_DNS_MAX_SIMULTANEOUS_REQUESTS   (3)
+#endif
+
+/**
+ * @def GNRC_DNS_MAX_RETRIES
+ *
+ * @brief   The maximum number of DNS retries that should be made
+ */
+#ifndef GNRC_DNS_MAX_RETRIES
+#define GNRC_DNS_MAX_RETRIES                 (3)
+#endif
+
+/**
+ * @def GNRC_DNS_MAX_SRV_RECORDS_SUPPORTED
+ *
+ * @brief   The maximum number of SRV records there are placed in the DNS response struct
+ */
+#ifndef GNRC_DNS_MAX_SRV_RECORDS_SUPPORTED
+#define GNRC_DNS_MAX_SRV_RECORDS_SUPPORTED  (5)
+#endif
+
+/**
+ * @def GNRC_DNS_RESPONSE_TIMEOUT
+ *
+ * @brief   The maximum milliseconds the DNS client must wait for a response
+ */
+#ifndef GNRC_DNS_RESPONSE_TIMEOUT
+#define GNRC_DNS_RESPONSE_TIMEOUT            (2000)
+#endif
+
+/**
+ * @brief   Request types and error responses
+ */
+typedef enum {
+    GNRC_DNS_TYPE_A,
+    GNRC_DNS_TYPE_AAAA,
+    GNRC_DNS_TYPE_TXT,
+    GNRC_DNS_TYPE_SRV,
+    GNRC_DNS_ERROR_TIMEDOUT = 0x80,
+    GNRC_DNS_ERROR_NO_ENTRY = 0x90,
+    GNRC_DNS_ERROR_MSG      = 0xa0,
+
+    GNRC_DNS_ERROR_MASK     = 0xf0,
+} gnrc_dns_type_t;
+
+/**
+ * @brief   DNS response structure
+ */
+typedef struct {
+    char full_name[GNRC_DNS_MAX_QUERY_STR_LEN];                 /**< FQDN of the request */
+    gnrc_dns_type_t type;                                       /**< type which is stored in the data element */
+    uint8_t responses;                                          /**< number of responses in the data element */
+    union {
+        ipv6_addr_t aaaa[GNRC_DNS_MAX_RESPONSE_ADDRESSES];      /**< array of IPv6 addresses */
+        ipv4_addr_t a[GNRC_DNS_MAX_RESPONSE_ADDRESSES];         /**< array of IPv4 addresses */
+        char txt[GNRC_DNS_MAX_QUERY_STR_LEN];                   /**< TXT record data */
+        struct {
+            char target[GNRC_DNS_MAX_QUERY_STR_LEN];            /**< FQDN of the server */
+            uint16_t priority;                                  /**< priority of the server */
+            uint16_t weight;                                    /**< weight of the server */
+            uint16_t port;                                      /**< port on the server */
+        } srv[GNRC_DNS_MAX_SRV_RECORDS_SUPPORTED];              /**< server responses */
+    } data;                                                     /**< data of the DNS response */
+} gnrc_dns_response_t;
+
+/**
+ * @brief   DNS server information
+ */
+typedef struct {
+    uint32_t ttl;                                               /**< the time to live of the server */
+    ipv6_addr_t ip;                                             /**< the IPv6 address of the server */
+} gnrc_dns_server_info_t;
+
+/**
+ * @brief   Initialize the DNS service
+ *
+ * @return  PID of the DNS thread
+ * @return  negative value on error
+ */
+int gnrc_dns_init(void);
+
+/**
+ * @brief   Update IP addresses of the DNS server list
+ *
+ * @param[in] lifetime      lifetime the DNS server entries
+ * @param[in] items         number of items in the servers array
+ * @param[in] servers       array of DNS servers available
+ *
+ * @return                  the number of DNS servers stored
+ * @return                  -EINVAL, when on of the arguments was not valid
+ */
+int gnrc_dns_update_entries(uint32_t lifetime, uint8_t items,
+                            ipv6_addr_t *servers);
+
+/**
+ * @brief   Add the given IP address to the DNS server list
+ *
+ * @param[in] server        The DNS server to add to the DNS server list
+ *
+ * @return                  0 on success
+ * @return                  -EINVAL, when on of the arguments was not valid
+ */
+int gnrc_dns_add_server(ipv6_addr_t *server);
+
+/**
+ * @brief   Remove the given IP address from the DNS server list
+ *
+ * @param[in] server        The DNS server to remove from the DNS server list
+ *
+ * @return                  0 on success
+ * @return                  -EINVAL, when on of the arguments was not valid
+ */
+int gnrc_dns_del_server(ipv6_addr_t *server);
+
+/**
+ * @brief   Get the information of the given DNS server
+ *
+ * @param[in] index         the index of the server to get the info of
+ * @param[out] info         DNS server info will be stored here
+ *
+ * @return                  true if the server index exists and the info is filled
+ * @returns                 false if the server index doesn't exist
+ */
+bool gnrc_dns_get_server(int index, gnrc_dns_server_info_t *info);
+
+/**
+ * @brief   Resolve the given URL to the given request type and place the response in response
+ *
+ * @param[in] url           domain name to request
+ * @param[in] request       request type to make (DNS_A, DNS_AAAA, etc.)
+ * @param[out] response     location where the response can be stored
+ *
+ * @returns                 true if the the request was successful
+ * @returns                 false if an error occurred
+ */
+bool gnrc_dns_resolve(const char *url, gnrc_dns_type_t request,
+                      gnrc_dns_response_t *response);
+
+#endif /* GNRC_DNS_H_ */
+
+/**
+ * @}
+ */

--- a/sys/include/net/gnrc/dns/internal.h
+++ b/sys/include/net/gnrc/dns/internal.h
@@ -1,0 +1,297 @@
+/*
+ * Copyright (C) 2015 Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @defgroup    net_dns DNS
+ * @ingroup     net
+ * @brief       Provides DNS header and helper functions
+ * @{
+ *
+ * @file
+ * @brief       Definitions for DNS
+ *
+ * @author      Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ */
+
+#ifndef GNRC_DNS_INTERNALS_H_
+#define GNRC_DNS_INTERNALS_H_
+
+#include <errno.h>
+#include <string.h>
+#include <time.h>
+
+#include "net/gnrc/dns.h"
+#include "net/gnrc/ipv6.h"
+#include "net/gnrc/netapi.h"
+#include "net/gnrc/netreg.h"
+#include "net/gnrc/pktbuf.h"
+#include "net/gnrc/udp.h"
+#include "xtimer.h"
+
+/**
+ * @brief   Enable/Disable debug trace support
+ */
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Thread ID of the DNS server
+ */
+extern kernel_pid_t _dns_pid;
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+/**
+ * @brief   Compile time byte-order swapping for short constants
+ */
+#define CT_HTONS(x)         ((uint16_t)(          \
+                                 ((uint16_t)x >> 8) & 0x00FF) | \
+                             (((uint16_t)x << 8) & 0xFF00))
+
+/**
+ * @brief   Compile time byte-order swapping for integers constants
+ */
+#define CT_HTONL(x)         ((uint32_t)(          \
+                                 ((uint32_t)x >> 24) & 0x000000FF) | \
+                             (((uint32_t)x >> 8) & 0x0000FF00) | \
+                             (((uint32_t)x << 8) & 0x00FF0000) | \
+                             (((uint32_t)x << 24) & 0xFF000000))
+#else
+/**
+ * @brief   Compile time byte-order swapping for short constants
+ */
+#define CT_HTONS(x)    ((uint16_t)x)
+
+/**
+ * @brief   Compile time byte-order swapping for integers constants
+ */
+#define CT_HTONL(x)    ((uint32_t)x)
+#endif
+
+/**
+ * @brief   Get the lowest value of a and b
+ */
+#define MIN(a, b)            ((a) > (b) ? (b) : (a))
+
+/**
+ * @brief   DNS types
+ * @{
+ */
+typedef uint16_t dns_query_type;
+
+#define DNS_A                   CT_HTONS(0x0001)    /**< IPv4 */
+#define DNS_CNAME               CT_HTONS(0x0005)    /**< CNAME */
+#define DNS_TXT                 CT_HTONS(0x0010)    /**< Text */
+#define DNS_AAAA                CT_HTONS(0x001C)    /**< IPv6 */
+#define DNS_SRV                 CT_HTONS(0x0021)    /**< Service Query */
+/**
+ * @}
+ */
+
+/**
+ * @brief   DNS classes
+ * @{
+ */
+typedef uint16_t dns_query_class;
+
+#define DNS_SQ_IN               CT_HTONS(0x0001) /**< Service Query */
+/**
+ * @}
+ */
+
+/**
+ * @brief   DNS flags
+ * @{
+ */
+#define HDR_FLAGS_QR            CT_HTONS(0x8000)    /**< Query (0), Response (1)*/
+#define HDR_FLAGS_AA            CT_HTONS(0x0400)    /**< Authoritative Answer. */
+#define HDR_FLAGS_TC            CT_HTONS(0x0200)    /**< TrunCation. */
+#define HDR_FLAGS_RD            CT_HTONS(0x0100)    /**< Recursion Desired. */
+#define HDR_FLAGS_RA            CT_HTONS(0x0080)    /**< Recursion Available. */
+/**
+ * @}
+ */
+
+/**
+ * @brief   DNS thread messages
+ */
+typedef enum {
+    GNRC_DNS_MSG_RESPONSE_TIMEDOUT          = 0x0300,   /**< Send by the timeout timer if no response is received */
+    GNRC_DNS_MSG_RESOLVE_A                  = 0x0301,   /**< Request an IPv4 address */
+    GNRC_DNS_MSG_RESOLVE_AAAA               = 0x0302,   /**< Request an IPv6 address */
+    GNRC_DNS_MSG_RESOLVE_TXT                = 0x0303,   /**< Request an TXT record */
+    GNRC_DNS_MSG_RESOLVE_SRV                = 0x0304,   /**< Request an SRV record */
+    GNRC_DNS_MSG_SERVER_LIFETIME_EXPIRED    = 0x0305,   /**< Send by the lifetime expired timer if the DNS servers aren't updated in time */
+    GNRC_DNS_MSG_QUERY_RESPONSE             = 0x0306,   /**< Send by the DNS thread if a valid response has been received */
+    GNRC_DNS_MSG_QUERY_TIMEDOUT             = 0x0307,   /**< Send by the DNS thread if a valid response has been received */
+
+    GNRC_DNS_MSG_MAX
+} gnrc_dns_msg;
+
+/**
+ * @brief   DNS header
+ */
+typedef struct __attribute__((packed)) {
+    uint16_t id;                        /**< ID of the DNS request */
+    uint16_t flags;                     /**< Flags associated with the DNS request */
+    uint16_t qd_count;                  /**< Number of questions in the packet */
+    uint16_t an_count;                  /**< Number of answers in the packet */
+    uint16_t ns_count;                  /**< Number of authorities in the packet */
+    uint16_t ar_count;                  /**< Number of additional records in the packet */
+} dns_header_t;
+
+/**
+ * @brief   DNS question footer
+ */
+typedef struct __attribute__((packed)) {
+    dns_query_type type;                /**< DNS Query type */
+    dns_query_class class;              /**< DNS Query class */
+} dns_qdata_footer_t;
+
+/**
+ * @brief   DNS answer section header
+ */
+typedef struct __attribute__((packed)) {
+    network_uint16_t compressed;        /**< If compressed the first byte is 0xc0 */
+    dns_query_type type;                /**< Type of response */
+    dns_query_class val;                /**< Type of class */
+    network_uint32_t ttl;               /**< Time-To-Life on this entry */
+    network_uint16_t data_len;          /**< Length of the data section */
+    uint8_t data[];                     /**< The data of this response entry */
+} dns_query_respones_t;
+
+/**
+ * @brief   DNS SRV response
+ */
+typedef struct __attribute__((packed)) {
+    network_uint16_t priority;          /**< Priority of the SRV entry, lower is more preferred */
+    network_uint16_t weight;            /**< Weight of the SRV entry, lower weight on equal priority has preferrence */
+    network_uint16_t port;              /**< Port to find the service on */
+    uint8_t target[];                   /**< The domain name to find the service on */
+} dns_srv_response_t;
+
+/**
+ * @brief   DNS request information used during the request
+ */
+typedef struct {
+    uint32_t tries_left;                /**< The number of tries left on this request */
+    const char *query_str;              /**< A pointer to the query string send to the server */
+    kernel_pid_t request_thread;        /**< The thread requesting the DNS query */
+    xtimer_t timeout_timer;             /**< The timeout timer used to catch a DNS response timeout */
+    msg_t timeout_msg;                  /**< The message send by the timeout timer */
+    uint16_t request_id;                /**< The request ID of this DNS query */
+    dns_query_type query_type;          /**< Type of DNS query we are processing */
+    gnrc_dns_response_t *response;      /**< Pointer to where the DNS response may be stored */
+} gnrc_dns_request_t;
+
+/**
+ * @brief   DNS server information
+ */
+typedef struct {
+    kernel_pid_t owner;                 /**< The owner of this DNS server entry */
+    uint32_t expires;                   /**< The lifetime on the current DNS server entries */
+    ipv6_addr_t addr;                   /**< DNS server address */
+} gnrc_dns_server_t;
+
+/**
+ * @brief   DNS server advertise information
+ */
+typedef struct {
+    mutex_t mutex;                                          /**< DNS mutex */
+    xtimer_t ttl;                                           /**< DNS lifetime timeout timer */
+    msg_t ttl_msg;                                          /**< MSG send by the TTL timeout timer */
+    gnrc_dns_server_t servers[GNRC_DNS_SERVERS_SUPPORT];    /**< DNS server information */
+    uint8_t count;                                          /**< The number of DNS servers available */
+} gnrc_dns_servers_t;
+
+/**
+ * @brief The context of the DNS server
+ */
+extern gnrc_dns_servers_t _dns_context;
+
+/**
+ * @brief Calculate the length of the DNS snippet for the given request.
+ *
+ * @param[in] req           the request to calculate the data length of
+ *
+ * @returns                 the length of the packet
+ */
+size_t _gnrc_dns_calc_snippet_len(gnrc_dns_request_t *req);
+
+/**
+ * @brief Build an DNS request from the given type and request information and store it in buffer
+ *
+ * @param[in] req           the request information for this query
+ * @param[out] buf          the buffer where the query snippet can be placed
+ * @param[in,out] length    in: maximum length of the buffer / out: size of the DNS snippet
+ *
+ * @returns                 true on success, otherwise false
+ */
+bool _gnrc_dns_build_request(gnrc_dns_request_t *req, uint8_t *buf,
+                             size_t *length);
+
+/**
+ * @brief Send an request for the given message
+ *
+ * @param[in] m             a message where the `content.ptr` is set to the gnrc_dns_request_t
+ */
+extern void _gnrc_dns_send_request(msg_t *m);
+
+/**
+ * @brief Handle the DNS request timeout and act accordingly.
+ *
+ * @param[in] m             the message received from the timeout callback
+ * @param[in] error         the error why the query must be retried
+ *
+ * @returns                 true when the request is retied
+ * @returns                 false when it's dropped (and must be removed from the active requests)
+ */
+extern bool _gnrc_dns_handle_request_retry(msg_t *m, gnrc_dns_type_t error);
+
+/**
+ * @brief Send the given DNS data to the first available DNS server
+ *
+ * @param[in] req           the DNS request being handled
+ * @param[in] packet        data that represents the DNS packet
+ * @param[in] length        the length of the DNS snippet
+ */
+extern void _gnrc_dns_send_packet(gnrc_dns_request_t *req, uint8_t *packet,
+                                  size_t length);
+
+/**
+ * @brief Parse the domain query string (pascal string types) to .'ed zero terminated notation.
+ *
+ * @param[in] packet_start  pointer to the start location of the packet
+ * @param[in] data          pointer to the start location of the name
+ * @param[in] domain        location where the zero terminated domain name can be placed, NULL can be \
+ *                          given to parse the string and find the end of the domain name in the packet
+ *
+ * @returns                 the first byte pointer after the domain name
+ * @returns                 NULL on error
+ */
+extern uint8_t *_gnrc_dns_parse_name(uint8_t *packet_start, uint8_t *data, char *domain);
+
+/**
+ * @brief Update the lifetime timeout callback timer
+ *
+ * @param[in] min_lifetime  the time the first DNS server will expire
+ */
+extern void _gnrc_update_server_lifetime(uint32_t min_lifetime);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif /* GNRC_DNS_INTERNALS_H_ */
+
+/**
+ * @}
+ */

--- a/sys/include/net/gnrc/ndp/internal.h
+++ b/sys/include/net/gnrc/ndp/internal.h
@@ -175,6 +175,22 @@ bool gnrc_ndp_internal_mtu_opt_handle(kernel_pid_t iface, uint8_t icmpv6_type,
                                       ndp_opt_mtu_t *mtu_opt);
 
 /**
+ * @brief   Handles a RDNSS option.
+ *
+ * @internal
+ *
+ * @param[in] iface         Interface the MTU option was received on.
+ * @param[in] icmpv6_type   ICMPv6 type of the message carrying the option.
+ * @param[in] rndss_opt     A RDNSS option.
+ *
+ * @return  number of DNS servers added to the DNS cache
+ * @return  -EINVAL, the RDNSS option was not valid
+ * @return  -ENOTSUP, if node should silently ignore the option.
+ */
+int gnrc_ndp_internal_rdnss_opt_handle(kernel_pid_t iface, uint8_t icmpv6_type,
+                                       ndp_opt_rdnss_t *rdnss_opt);
+
+/**
  * @brief   Handles a PI option.
  *
  * @internal

--- a/sys/include/net/ndp.h
+++ b/sys/include/net/ndp.h
@@ -69,6 +69,7 @@ extern "C" {
 #define NDP_OPT_PI                  (3)     /**< prefix information option */
 #define NDP_OPT_RH                  (4)     /**< redirected option */
 #define NDP_OPT_MTU                 (5)     /**< MTU option */
+#define NDP_OPT_RDNSS               (25)    /**< RDNSS option */
 #define NDP_OPT_AR                  (33)    /**< address registration option */
 #define NDP_OPT_6CTX                (34)    /**< 6LoWPAN context option */
 #define NDP_OPT_ABR                 (35)    /**< authoritative border router option */
@@ -244,6 +245,21 @@ typedef struct __attribute__((packed)) {
     network_uint32_t mtu;   /**< MTU */
 } ndp_opt_mtu_t;
 
+/**
+ * @brief   RDNSS option format
+ * @extends ndp_opt_t
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc6106#section-5.1">
+ *          RFC 6106, section 5.1
+ *      </a>
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t type;                   /**< option type */
+    uint8_t len;                    /**< length in units of 8 octets */
+    uint16_t reserved;              /**< reserved field */
+    network_uint32_t lifetime;      /**< lifetime the servers may be used */
+    ipv6_addr_t dns_servers[];      /**< DNS servers (array length calculated by (len - 1) / 2 */
+} ndp_opt_rdnss_t;
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -118,5 +118,8 @@ endif
 ifneq (,$(filter gnrc_tftp,$(USEMODULE)))
     DIRS += application_layer/tftp
 endif
+ifneq (,$(filter gnrc_dns,$(USEMODULE)))
+    DIRS += application_layer/dns
+endif
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/application_layer/dns/Makefile
+++ b/sys/net/gnrc/application_layer/dns/Makefile
@@ -1,0 +1,3 @@
+MODULE = gnrc_dns
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/application_layer/dns/gnrc_dns.c
+++ b/sys/net/gnrc/application_layer/dns/gnrc_dns.c
@@ -1,0 +1,537 @@
+/*
+ * Copyright (C) 2015 Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @ingroup net_gnrc_dns
+ * @{
+ *
+ * @file
+ *
+ * @author      Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <time.h>
+#include <inttypes.h>
+
+#include "net/gnrc/dns/internal.h"
+#include "net/gnrc/netapi.h"
+#include "net/gnrc/netreg.h"
+#include "net/gnrc/pktbuf.h"
+#include "net/gnrc/udp.h"
+
+/**
+ * @brief   Allocate memory for the DNS thread's stack
+ */
+#if ENABLE_DEBUG
+static char _stack[GNRC_DNS_STACK_SIZE + THREAD_EXTRA_STACKSIZE_PRINTF];
+#else
+static char _stack[GNRC_DNS_STACK_SIZE];
+#endif
+
+static void *_event_loop(void *args);
+
+kernel_pid_t _dns_pid = KERNEL_PID_UNDEF;
+static gnrc_dns_request_t *_dns_requests[GNRC_DNS_MAX_SIMULTANEOUS_REQUESTS];
+gnrc_dns_servers_t _dns_context; /**< DNS servers object (TODO currently only one, because we only have one interface) */
+static uint16_t _request_id;
+
+/* free the request from the running DNS requests */
+static void _gnrc_dns_delete_request(gnrc_dns_request_t *req)
+{
+    for (int idx = 0; idx < GNRC_DNS_MAX_SIMULTANEOUS_REQUESTS; ++idx) {
+        if (_dns_requests[idx] == req) {
+            _dns_requests[idx] = NULL;
+            return;
+        }
+    }
+}
+
+/* free the request from the running DNS requests */
+static bool _gnrc_dns_add_request(gnrc_dns_request_t *req)
+{
+    for (int idx = 0; idx < GNRC_DNS_MAX_SIMULTANEOUS_REQUESTS; ++idx) {
+        if (!_dns_requests[idx]) {
+            _dns_requests[idx] = req;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/* free the request from the running DNS requests */
+static bool _gnrc_dns_get_request(uint16_t id, gnrc_dns_request_t **req)
+{
+    for (int idx = 0; idx < GNRC_DNS_MAX_SIMULTANEOUS_REQUESTS; ++idx) {
+        if (_dns_requests[idx] && _dns_requests[idx]->request_id == id) {
+            *req = _dns_requests[idx];
+            return true;
+        }
+    }
+
+    return false;
+}
+
+int gnrc_dns_init(void)
+{
+    /* check if thread is already running */
+    if (_dns_pid == KERNEL_PID_UNDEF) {
+        /* start DNS thread */
+        _dns_pid = thread_create(_stack, sizeof(_stack), GNRC_DNS_PRIO,
+                                 THREAD_CREATE_STACKTEST, _event_loop, NULL, "dns");
+    }
+    return _dns_pid;
+}
+
+bool gnrc_dns_get_server(int index, gnrc_dns_server_info_t *info)
+{
+    timex_t time;
+    gnrc_dns_server_t *server = _dns_context.servers + index;
+
+    if (_dns_pid == KERNEL_PID_UNDEF || !info) {
+        return false;
+    }
+
+    mutex_lock(&_dns_context.mutex);
+
+    /* check if the server exists */
+    if (_dns_context.count <= index) {
+        mutex_unlock(&_dns_context.mutex);
+        return false;
+    }
+
+    /* fill the server information object */
+    memcpy(info->ip.u8, server->addr.u8, sizeof(ipv6_addr_t));
+
+    /* calculate the expiration time */
+    time = timex_from_uint64(xtimer_now64());
+    if (server->expires != UINT32_MAX) {
+        info->ttl = (time.seconds < server->expires)
+                    ? (server->expires - time.seconds)
+                    : 0;
+    }
+    else {
+        info->ttl = 0;
+    }
+
+    mutex_unlock(&_dns_context.mutex);
+
+    return true;
+}
+
+int gnrc_dns_update_entries(uint32_t lifetime, uint8_t items, ipv6_addr_t *servers)
+{
+    kernel_pid_t owner = thread_getpid();
+    uint32_t first_expires, expires, count = 0;
+    int write_index = 0;
+    timex_t time;
+
+    if (_dns_pid == KERNEL_PID_UNDEF) {
+        return -EINVAL;
+    }
+
+    /* remove the DNS ttl timer */
+    xtimer_remove(&(_dns_context.ttl));
+
+    /* check if we can hold this many DNS servers */
+    if (items > GNRC_DNS_SERVERS_SUPPORT) {
+        DEBUG("dns: To many servers to be added to the collection.\n");
+        items = GNRC_DNS_SERVERS_SUPPORT;
+    }
+
+    /* check if the lifetime is not set to 0 */
+    if (!lifetime) {
+        DEBUG("dns: The lifetime of the DNS entries is not valid.\n");
+        items = 0;
+    }
+
+    DEBUG("dns: Update DNS server entries.\n");
+
+    /* update our DNS entries */
+    mutex_lock(&_dns_context.mutex);
+
+    /* calculate own expire time */
+    time = timex_from_uint64(xtimer_now64());
+    if (lifetime != 0 && lifetime != UINT32_MAX) {
+        expires = (time.seconds + lifetime);
+    }
+    else {
+        expires = UINT32_MAX;
+    }
+
+    first_expires = expires;
+
+    /* update the entries from the current calling thread */
+    for (int idx = 0; idx < GNRC_DNS_SERVERS_SUPPORT; ++idx) {
+        /* check if server entry is free */
+        if (_dns_context.servers[idx].owner != KERNEL_PID_UNDEF
+            && _dns_context.servers[idx].owner != owner) {
+            first_expires = MIN(first_expires, _dns_context.servers[idx].expires);
+            ++count;
+            continue;
+        }
+
+        /* update the entry with the new entry */
+        if (write_index < items) {
+            ++count;
+
+            _dns_context.servers[idx].owner = owner;
+            _dns_context.servers[idx].expires = expires;
+            memcpy(_dns_context.servers[idx].addr.u8, servers + write_index, sizeof(ipv6_addr_t));
+
+            ++write_index;
+        }
+        else {
+            memset(_dns_context.servers + idx, 0, sizeof(gnrc_dns_server_t));
+        }
+    }
+
+    _dns_context.count = count;
+
+    mutex_unlock(&_dns_context.mutex);
+
+    /* calculate back the first expired lifetime */
+    if (first_expires > 0) {
+        first_expires -= time.seconds;
+        _dns_context.ttl_msg.type = GNRC_DNS_MSG_SERVER_LIFETIME_EXPIRED;
+        xtimer_set_msg(&(_dns_context.ttl), first_expires, &(_dns_context.ttl_msg), _dns_pid);
+    }
+
+    return write_index;
+}
+
+int gnrc_dns_add_server(ipv6_addr_t *server)
+{
+    int idx;
+
+    /* validate parameters and arguments */
+    if (_dns_pid == KERNEL_PID_UNDEF || !server
+        || _dns_context.count >= GNRC_DNS_SERVERS_SUPPORT) {
+        return -EINVAL;
+    }
+
+    mutex_lock(&_dns_context.mutex);
+
+    /* find a spot where we can add this server */
+    for (idx = 0; idx < GNRC_DNS_SERVERS_SUPPORT; ++idx) {
+        if (!_dns_context.servers[idx].expires) {
+            _dns_context.servers[idx].expires = UINT32_MAX;
+            _dns_context.servers[idx].owner = thread_getpid();
+            memcpy(_dns_context.servers[idx].addr.u8, server, sizeof(ipv6_addr_t));
+
+            ++(_dns_context.count);
+
+            break;
+        }
+    }
+
+    mutex_unlock(&_dns_context.mutex);
+
+    return idx < GNRC_DNS_SERVERS_SUPPORT
+           ? idx
+           : -EINVAL;
+}
+
+int gnrc_dns_del_server(ipv6_addr_t *server)
+{
+    kernel_pid_t owner = thread_getpid();
+    int idx;
+
+    /* validate parameters and arguments */
+    if (_dns_pid == KERNEL_PID_UNDEF || !server) {
+        return -EINVAL;
+    }
+
+    mutex_lock(&_dns_context.mutex);
+
+    /* find a spot where we can add this server */
+    for (idx = 0; idx < GNRC_DNS_SERVERS_SUPPORT; ++idx) {
+        if (_dns_context.servers[idx].expires
+            && _dns_context.servers[idx].owner == owner
+            && ipv6_addr_equal(&(_dns_context.servers[idx].addr), server)) {
+
+            if ((_dns_context.count - 1) > idx) {
+                /* if this is the last entry in the list set it to zero */
+                memcpy(_dns_context.servers + idx, _dns_context.servers + _dns_context.count - 1, sizeof(gnrc_dns_server_t));
+                memset(_dns_context.servers + _dns_context.count - 1,  0, sizeof(gnrc_dns_server_t));
+            }
+            else {
+                /* else copy the last entry over this entry */
+                memset(_dns_context.servers + idx, 0, sizeof(gnrc_dns_server_t));
+            }
+
+            --(_dns_context.count);
+
+            break;
+        }
+    }
+
+    mutex_unlock(&_dns_context.mutex);
+
+    return idx < GNRC_DNS_SERVERS_SUPPORT
+           ? idx
+           : -EINVAL;
+}
+
+bool gnrc_dns_resolve(const char *url, gnrc_dns_type_t request,
+                      gnrc_dns_response_t *response)
+{
+    msg_t snd, recv;
+
+    /* check if we have an DNS server */
+    if (!_dns_context.count) {
+        return false;
+    }
+
+    /* check if the query string is not to long */
+    if (strlen(url) > (GNRC_DNS_MAX_QUERY_STR_LEN - 1)) {
+        return false;
+    }
+
+    /* place the arguments in an request */
+    gnrc_dns_request_t req;
+    req.query_str = url;
+    req.query_type = request;
+    req.tries_left = GNRC_DNS_MAX_RETRIES;
+    req.response = response;
+
+    /* build request */
+    snd.type = ((int) (GNRC_DNS_MSG_RESOLVE_A - GNRC_DNS_TYPE_A)) + request;
+    snd.content.ptr = (void *) &req;
+    snd.sender_pid = thread_getpid();
+
+    /* resolve DNS entry in the DNS thread */
+    if (!msg_send_receive(&snd, &recv, _dns_pid)) {
+        response->type = GNRC_DNS_ERROR_MSG;
+        return false;
+    }
+
+    /* response is valid if the response doesn't have an error */
+    return !(response->type & GNRC_DNS_ERROR_MASK);
+}
+
+static void _received_reponse(gnrc_pktsnip_t *pkt)
+{
+    gnrc_dns_request_t *req = NULL;
+    dns_header_t *header = (dns_header_t *) pkt->data;
+    uint8_t *data;
+
+    /* process the DNS header */
+    uint16_t id = NTOHS(header->id);
+    uint16_t queries = NTOHS(header->qd_count);
+    uint16_t answeres = NTOHS(header->an_count);
+
+    /* search the matching DNS request */
+    if (!_gnrc_dns_get_request(id, &req)) {
+        return;
+    }
+
+    /* remove our timeout timer */
+    xtimer_remove(&req->timeout_timer);
+
+    DEBUG("dns: received DNS response");
+
+    /* process the DNS question sections */
+    data = (uint8_t *) (header + 1);
+    for (int idx = 0; idx < queries; ++idx) {
+        data = _gnrc_dns_parse_name(pkt->data, data, req->response->full_name);
+
+        /* stop processing on an error */
+        if (!data) {
+            answeres = 0;
+            break;
+        }
+
+        data += sizeof(dns_qdata_footer_t);
+    }
+
+    /* process the DNS answer sections */
+    int answere_idx = 0;
+    req->response->responses = answeres;
+    for (int idx = 0; idx < answeres && data; ++idx) {
+        dns_query_respones_t *resp = (dns_query_respones_t *) data;
+
+        if (resp->compressed.u8[0] != 0xc0) {
+            /* new domain name found, decode the string back to a domain name */
+
+            /* TODO maybe store this somewhere ? */
+            resp = (dns_query_respones_t *)(_gnrc_dns_parse_name(pkt->data, data, NULL) - sizeof(resp->compressed));
+
+            /* stop processing on an error */
+            if (!resp) {
+                data = NULL;
+                break;
+            }
+        }
+        else if (resp->compressed.u8[1] != sizeof(dns_header_t)) {
+            /* compressed domain name found, but not the one in the query */
+
+            /* TODO maybe store this somewhere ? _parse_query_domain(data + resp->compressed.u8[1], NULL); */
+        }
+
+        switch (resp->type) {
+            case DNS_A:
+                req->response->type = GNRC_DNS_TYPE_A;
+                memcpy(req->response->data.a[answere_idx++].u8, resp->data,
+                       HTONS(resp->data_len.u16));
+                break;
+
+            case DNS_AAAA:
+                req->response->type = GNRC_DNS_TYPE_AAAA;
+                memcpy(req->response->data.aaaa[answere_idx++].u8, resp->data,
+                       HTONS(resp->data_len.u16));
+                break;
+
+            case DNS_TXT:
+                req->response->type = GNRC_DNS_TYPE_TXT;
+                memcpy(req->response->data.txt, resp->data + 1, *(resp->data));
+                *((req->response->data.txt) + *(resp->data)) = 0;
+                break;
+
+            case DNS_SRV:
+            {
+                dns_srv_response_t *srv_resp = (dns_srv_response_t *)resp->data;
+
+                req->response->type = GNRC_DNS_TYPE_SRV;
+
+                /* process the SRV part in the response */
+                req->response->data.srv[answere_idx].priority  = byteorder_ntohs(srv_resp->priority);
+                req->response->data.srv[answere_idx].weight = byteorder_ntohs(srv_resp->weight);
+                req->response->data.srv[answere_idx].port = byteorder_ntohs(srv_resp->port);
+                data = _gnrc_dns_parse_name(pkt->data, srv_resp->target, req->response->data.srv[answere_idx].target);
+                ++answere_idx;
+            } break;
+
+            case DNS_CNAME:
+                --req->response->responses;
+                data = _gnrc_dns_parse_name(pkt->data, resp->data, req->response->full_name);
+                break;
+        }
+    }
+
+    if (answeres && data) {
+        msg_t m;
+        m.sender_pid = req->request_thread;
+
+        /* free the request from the running DNS requests */
+        _gnrc_dns_delete_request(req);
+
+        /* create the reply message */
+        msg_t r;
+        r.sender_pid = thread_getpid();
+        r.content.value = 1;
+        r.type = GNRC_DNS_MSG_QUERY_RESPONSE;
+
+        msg_reply(&m, &r);
+    }
+    else {
+        msg_t msg;
+        msg.content.ptr = (void *) req;
+        if (!_gnrc_dns_handle_request_retry(&msg, GNRC_DNS_ERROR_MSG)) {
+            _gnrc_dns_delete_request(req);
+        }
+    }
+}
+
+static void _gnrc_dns_handle_request_message(msg_t *m, dns_query_type t)
+{
+    gnrc_dns_request_t *req = (gnrc_dns_request_t *) m->content.ptr;
+
+    /* search place for the DNS request */
+    if (!_gnrc_dns_add_request(req)) {
+        msg_t r;
+        r.type = GNRC_DNS_MSG_SERVER_LIFETIME_EXPIRED;
+        msg_reply(m, &r);
+        return;
+    }
+
+    /* fill the rest of the DNS request object */
+    req->request_thread = m->sender_pid;
+    req->query_type = t;
+    req->request_id = ++_request_id;
+
+    _gnrc_dns_send_request(m);
+}
+
+/* Function for the DNS thread */
+void *_event_loop(void *args)
+{
+    msg_t msg;
+
+    (void) args;
+
+    /* create our netreg entry to register our listening port */
+    gnrc_netreg_entry_t entry;
+    entry.next = NULL;
+    entry.pid = thread_getpid();
+    entry.demux_ctx = GNRC_DNS_RESOLVE_SRC_PORT;
+
+    /* register our DNS response listener */
+    if (gnrc_netreg_register(GNRC_NETTYPE_UDP, &entry)) {
+        DEBUG("dns: error starting server.");
+        return NULL;
+    }
+
+    /* main processing loop */
+    for (;; ) {
+        /* wait for a message */
+        msg_receive(&msg);
+
+        /* process the received message */
+        switch (msg.type) {
+            case GNRC_DNS_MSG_RESOLVE_A:
+                DEBUG("GNRC_DNS_MSG_RESOLVE_A\n");
+                _gnrc_dns_handle_request_message(&msg, DNS_A);
+                break;
+
+            case GNRC_DNS_MSG_RESOLVE_AAAA:
+                DEBUG("GNRC_DNS_MSG_RESOLVE_AAAA\n");
+                _gnrc_dns_handle_request_message(&msg, DNS_AAAA);
+                break;
+
+            case GNRC_DNS_MSG_RESOLVE_TXT:
+                DEBUG("GNRC_DNS_MSG_RESOLVE_TXT\n");
+                _gnrc_dns_handle_request_message(&msg, DNS_TXT);
+                break;
+
+            case GNRC_DNS_MSG_RESOLVE_SRV:
+                DEBUG("GNRC_DNS_MSG_RESOLVE_SRV\n");
+                _gnrc_dns_handle_request_message(&msg, DNS_SRV);
+                break;
+
+            case GNRC_DNS_MSG_RESPONSE_TIMEDOUT:
+                DEBUG("GNRC_DNS_MSG_RESPONSE_TIMEDOUT\n");
+                if (!_gnrc_dns_handle_request_retry(&msg, GNRC_DNS_ERROR_TIMEDOUT)) {
+                    _gnrc_dns_delete_request((gnrc_dns_request_t *) msg.content.ptr);
+                }
+                break;
+
+            case GNRC_DNS_MSG_SERVER_LIFETIME_EXPIRED:
+                DEBUG("dns: server lifetime's expired, removing DNS servers.\n");
+                gnrc_dns_update_entries(0, 0, NULL);
+                break;
+
+            case GNRC_NETAPI_MSG_TYPE_RCV:
+                DEBUG("dns: GNRC_NETAPI_MSG_TYPE_RCV\n");
+                _received_reponse((gnrc_pktsnip_t *) msg.content.ptr);
+                break;
+
+            default:
+                DEBUG("dns: Received un-recognized message.\n");
+                break;
+        }
+    }
+
+    return NULL;
+}
+
+/**
+ * @}
+ */

--- a/sys/net/gnrc/application_layer/dns/gnrc_dns_internals.c
+++ b/sys/net/gnrc/application_layer/dns/gnrc_dns_internals.c
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) 2015 Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @ingroup net_gnrc_dns
+ * @{
+ *
+ * @file
+ *
+ * @author      Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <time.h>
+
+#include "net/gnrc/dns/internal.h"
+#include "net/gnrc/dns.h"
+#include "net/gnrc/ipv6.h"
+#include "net/gnrc/netapi.h"
+#include "net/gnrc/netreg.h"
+#include "net/gnrc/pktbuf.h"
+#include "net/gnrc/udp.h"
+
+#define DNS_COMP_MASK               0xc0
+#define DNS_COMPRESSED(x)           (((x) & DNS_COMP_MASK) == DNS_COMP_MASK)
+#define DNS_COMP_OFFSET(a, b)       (((uint16_t)(a & ~(DNS_COMP_MASK)) << 8) + (uint16_t)b)
+
+#if ENABLE_DEBUG
+/* For PRIu16 etc. */
+#include <inttypes.h>
+#endif
+
+size_t _gnrc_dns_calc_snippet_len(gnrc_dns_request_t *req)
+{
+    /* calculate the length of the UDP snippet for the given query request */
+    return strlen(req->query_str) + sizeof(dns_header_t)
+           + sizeof(dns_qdata_footer_t) + 2;
+}
+
+bool _gnrc_dns_build_request(gnrc_dns_request_t *req, uint8_t *buf,
+                             size_t *length)
+{
+    dns_header_t *header = (dns_header_t *) buf;
+
+    /* validate the packet length */
+    if (_gnrc_dns_calc_snippet_len(req) > *length) {
+        return false;
+    }
+
+    /* fill the DNS header */
+    memset(header, 0, sizeof(*header));
+    header->id = HTONS(req->request_id);
+    header->qd_count = CT_HTONS(1);
+    header->flags = HDR_FLAGS_RD;
+
+    /* fill the query part */
+    char *data = (char *) (header + 1);
+
+    /* copy the string to the query buffer */
+    strcpy(data + 1, req->query_str);
+
+    /* start converting all domain name parts to pascal strings */
+    /* eg. replace all dots with the length of the next part */
+    char *end;
+    char *start = data + 1;
+    while ((end = strchr(start, '.')) != NULL) {
+        *data = end - start;
+        data = end;
+        start = end + 1;
+    }
+
+    /* finalize the domain name strings */
+    *data = strlen(start);
+    data += (*data) + 1;
+    *data++ = 0;
+
+    /* fill query footer */
+    dns_qdata_footer_t *ftr = (dns_qdata_footer_t *) data;
+    ftr->type = req->query_type;
+    ftr->class = DNS_SQ_IN;
+
+    /* get the pointer after the footer */
+    data += sizeof(*ftr);
+
+    /* calculate the total length of the packet */
+    if ((size_t)(data - (char *)buf) > *length) {
+        DEBUG("ERROR: DNS snippet overflowed buffer!\n");
+    }
+
+    *length = ((uint8_t *) data - buf);
+    return buf;
+}
+
+void _gnrc_dns_send_request(msg_t *m)
+{
+    gnrc_dns_request_t *req = (gnrc_dns_request_t *) m->content.ptr;
+
+    size_t len = _gnrc_dns_calc_snippet_len(req);
+    uint8_t buffer[len];
+
+    /* build the query and send it to the destination */
+    _gnrc_dns_build_request(req, buffer, (size_t *) &len);
+    _gnrc_dns_send_packet(req, buffer, len);
+
+    /* start the timeout timer for the transaction */
+    req->timeout_msg.content.ptr = (void *)req;
+    req->timeout_msg.type = GNRC_DNS_MSG_RESPONSE_TIMEDOUT;
+    xtimer_set_msg(&req->timeout_timer, GNRC_DNS_RESPONSE_TIMEOUT * 1000, &(req->timeout_msg), _dns_pid);
+}
+
+void _gnrc_dns_send_packet(gnrc_dns_request_t *req, uint8_t *packet,
+                           size_t length)
+{
+    gnrc_pktsnip_t *payload, *udp, *ip;
+
+    /* allocate payload */
+    payload = gnrc_pktbuf_add(NULL, packet, length, GNRC_NETTYPE_UNDEF);
+    if (payload == NULL) {
+        DEBUG("dns: error unable to copy data to packet buffer");
+        return;
+    }
+
+    /* allocate UDP header, set source port := destination port */
+    network_uint16_t src_port, dst_port;
+    src_port.u16 = GNRC_DNS_RESOLVE_SRC_PORT;
+    dst_port.u16 = GNRC_DNS_RESOLVE_DST_PORT;
+    udp = gnrc_udp_hdr_build(payload, src_port.u8, sizeof(src_port),
+                             dst_port.u8, sizeof(dst_port));
+    if (udp == NULL) {
+        DEBUG("dns: error unable to allocate UDP header");
+        gnrc_pktbuf_release(payload);
+        return;
+    }
+
+    /* allocate IPv6 header */
+    mutex_lock(&(_dns_context.mutex));
+    /* iterate over the available DNS servers from primary to last */
+    int dns_server = (GNRC_DNS_MAX_RETRIES - req->tries_left) % _dns_context.count;
+    ip = gnrc_ipv6_hdr_build(udp, NULL, 0,
+                             _dns_context.servers[dns_server].addr.u8,
+                             sizeof(ipv6_addr_t));
+    mutex_unlock(&(_dns_context.mutex));
+
+    if (ip == NULL) {
+        DEBUG("dns: error unable to allocate IPv6 header");
+        gnrc_pktbuf_release(udp);
+        return;
+    }
+
+    /* send packet */
+    if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_UDP, GNRC_NETREG_DEMUX_CTX_ALL,
+                                   ip)) {
+        DEBUG("dns: error unable to locate UDP thread");
+        gnrc_pktbuf_release(ip);
+        return;
+    }
+}
+
+bool _gnrc_dns_handle_request_retry(msg_t *m, gnrc_dns_type_t error)
+{
+    msg_t r;
+    gnrc_dns_request_t *req = (gnrc_dns_request_t *) m->content.ptr;
+
+    /* check if we must retry the transaction */
+    if (!--(req->tries_left)) {
+        msg_t om;
+        om.sender_pid = req->request_thread;
+
+        DEBUG("dns: inform requester that the request timed out.\n");
+
+        /* inform that the request timed out */
+        req->response->type = error;
+
+        /* prepare the reply message */
+        r.type = GNRC_DNS_MSG_QUERY_RESPONSE;
+        r.content.value = 1;
+
+        /* send the reply message */
+        msg_reply(&om, &r);
+
+        return false;
+    }
+    else {
+        DEBUG("dns: DNS query timed out, retrying.\n");
+
+        /* retry the DNS query */
+        _gnrc_dns_send_request(m);
+
+        return true;
+    }
+}
+
+uint8_t *_gnrc_dns_parse_name(uint8_t *packet_start, uint8_t *data, char *domain)
+{
+    uint8_t *ret = NULL;
+    int offset = 0;
+    int seglen = *data++;
+
+    /* check if the arguments are valid */
+    if (!packet_start || !data) {
+        return NULL;
+    }
+
+    /* parse the domain name and turn back to . separated string */
+    while (seglen) {
+
+        /* process compressed string if seglen is equal to 0xc0 */
+        if (DNS_COMPRESSED(seglen)) {
+            /* string finishes after next byte */
+            ret = data + 1;
+
+            /* continue processing in a previous part of the packet */
+            data = packet_start + DNS_COMP_OFFSET(seglen, *data);
+            seglen = *data++;
+
+            continue;
+        }
+
+        if (domain) {
+            /* check if the string is not longer than the maximum query length */
+            if ((offset + seglen) > GNRC_DNS_MAX_QUERY_STR_LEN) {
+                return NULL;
+            }
+
+            memcpy(domain + offset, data, seglen);
+        }
+
+        offset += seglen;
+        data += seglen;
+
+        if (domain) {
+            *(domain + offset) = '.';
+        }
+
+        seglen = *data++;
+
+        if (seglen) {
+            ++offset;
+        }
+    }
+
+    /* zero terminate our string */
+    if (domain) {
+        *(domain + offset) = 0;
+    }
+
+    return ret
+           ? ret
+           : data;
+}
+
+/**
+ * @}
+ */

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -597,6 +597,14 @@ void gnrc_ndp_rtr_adv_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt, ipv6_hdr_t
                                                  (sixlowpan_nd_opt_abr_t *)opt);
                 break;
 #endif
+#ifdef MODULE_GNRC_DNS
+            case NDP_OPT_RDNSS:
+                if (gnrc_ndp_internal_rdnss_opt_handle(iface, rtr_adv->type, (ndp_opt_rdnss_t *)opt) <= 0) {
+                    /* invalid RDNSS option */
+                    return;
+                }
+                break;
+#endif
         }
 
         opt_offset += (opt->len * 8);

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -69,6 +69,9 @@ endif
 ifneq (,$(filter ccn-lite-utils,$(USEMODULE)))
   SRC += sc_ccnl.c
 endif
+ifneq (,$(filter gnrc_dns,$(USEMODULE)))
+    SRC += sc_gnrc_dns.c
+endif
 
 # TODO
 # Conditional building not possible at the moment due to

--- a/sys/shell/commands/sc_gnrc_dns.c
+++ b/sys/shell/commands/sc_gnrc_dns.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2015 Nick van IJzendoorn <nijzendoorn@engineernig-spirit.nl>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @ingroup     sys_shell_commands.h
+ * @{
+ *
+ * @file
+ *
+ * @author      Nick van IJzendoorn <nijzednoorn@engineering-spirit.nl>
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include "net/gnrc/ipv6/netif.h"
+#include "net/gnrc/dns.h"
+
+typedef enum {
+    Add,
+    Remove
+} dns_mod_action_t;
+
+int _gnrc_dns_resolve(const char *arg1, const char *arg2) {
+    gnrc_dns_type_t type = GNRC_DNS_TYPE_AAAA;
+    gnrc_dns_response_t response;
+
+    /* check request type */
+    if (!arg2 || strcasecmp(arg2, "AAAA") == 0) {
+        type = GNRC_DNS_TYPE_AAAA;
+    } else if (strcasecmp(arg2, "A") == 0) {
+        type = GNRC_DNS_TYPE_A;
+    } else if (strcasecmp(arg2, "SRV") == 0) {
+        type = GNRC_DNS_TYPE_SRV;
+    } else if (strcasecmp(arg2, "TXT") == 0) {
+        type = GNRC_DNS_TYPE_TXT;
+    }
+
+    /* resolve the given domain name */
+    if (gnrc_dns_resolve(arg1, type, &response)) {
+        char ip_buffer[IPV6_ADDR_MAX_STR_LEN];
+
+        printf("successfully resolved domain: %s\n", arg1);
+
+        printf(" - full name: %s\n\n", response.full_name);
+
+        switch (response.type) {
+        case GNRC_DNS_TYPE_A:
+            for (int idx = 0; idx < response.responses; ++idx)
+#ifdef MODULE_IPV4
+                printf(" - %s\n",
+                        ipv4_addr_to_str(ip_buffer, response.data.a + idx,
+                        sizeof(ip_buffer)));
+#else
+                puts(" - no IPv4 support");
+#endif
+            break;
+
+        case GNRC_DNS_TYPE_AAAA:
+            for (int idx = 0; idx < response.responses; ++idx)
+                printf(" - %s\n",
+                        ipv6_addr_to_str(ip_buffer, response.data.aaaa + idx,
+                        sizeof(ip_buffer)));
+            break;
+
+        case GNRC_DNS_TYPE_TXT:
+            printf("%s\n", response.data.txt);
+            break;
+
+        case GNRC_DNS_TYPE_SRV:
+            for (int idx = 0; idx < response.responses; ++idx)
+                printf(" - p:%02" PRIu16 " w:%02" PRIu16 ": %s:%" PRIu16 "\n",
+                        response.data.srv[idx].priority,
+                        response.data.srv[idx].weight,
+                        response.data.srv[idx].target,
+                        response.data.srv[idx].port);
+            break;
+
+        default:
+            break;
+        }
+    } else {
+        switch (response.type) {
+        case GNRC_DNS_ERROR_TIMEDOUT:
+            puts("error: request timed out.");
+            break;
+
+        case GNRC_DNS_ERROR_NO_ENTRY:
+            puts("error: domain name does not exist.");
+            break;
+
+        case GNRC_DNS_ERROR_MSG:
+            puts("error: error message received.");
+            break;
+
+        default:
+            break;
+        }
+
+        puts("error: failed to resolve DNS name.");
+    }
+
+    return 0;
+}
+
+static int _gnrc_dns_print(void) {
+    int idx = 0;
+    gnrc_dns_server_info_t info;
+    char _ipv6_addr[IPV6_ADDR_MAX_STR_LEN];
+
+    /* print the information header */
+    puts("Available DNS servers:");
+    printf("# | %-*s | ttl\n", IPV6_ADDR_MAX_STR_LEN, "address");
+    puts("---------------------------------------------------------------");
+
+    /* print all DNS servers */
+    while (gnrc_dns_get_server(idx, &info)) {
+        printf("%d | %-*s | %" PRIu32 "\n", idx, IPV6_ADDR_MAX_STR_LEN,
+                ipv6_addr_to_str(_ipv6_addr, &info.ip, sizeof(_ipv6_addr)),
+                info.ttl);
+
+        ++idx;
+    }
+
+    puts("");
+
+    return 0;
+}
+
+static int _gnrc_dns_modify(const char *arg, dns_mod_action_t action) {
+    ipv6_addr_t addr;
+
+    /* check if we can parse the IP address */
+    if (!ipv6_addr_from_str(&addr, arg)) {
+        puts("error: couldn't parse IP address");
+    }
+
+    /* add or remove the given IP addres from the server collectiond */
+    if (action == Add) {
+        gnrc_dns_add_server(&addr);
+    } else if (action == Remove) {
+        gnrc_dns_del_server(&addr);
+    } else {
+        puts("error: unknown DNS server action");
+    }
+
+    return 0;
+}
+
+int _gnrc_dns_handler(int argc, char **argv) {
+    if ((argc < 2) || (strcmp(argv[1], "show") == 0)) {
+        return _gnrc_dns_print();
+    } else if ((argc == 3) && strcmp(argv[1], "add") == 0) {
+        return _gnrc_dns_modify(argv[2], Add);
+    } else if ((argc == 3) && strcmp(argv[1], "del") == 0) {
+        return _gnrc_dns_modify(argv[2], Remove);
+    } else if ((argc >= 3) && strcmp(argv[1], "res") == 0) {
+        return _gnrc_dns_resolve(argv[2], argv[3]);
+    }
+
+    printf("usage: %s [show|add|del|resolve]\n", argv[0]);
+    puts("* help\t\t\t- show usage");
+    puts("* show\t\t\t- show the current available DNS servers");
+    puts("* add <addr>\t- add the DNS server to the list");
+    puts("* del <addr>\t- remove the DNS server form the list");
+    puts("* res <addr> <type:AAAA>\t\t- resolve the given domain name");
+    return 0;
+}
+
+/**
+ * @}
+ */

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -121,6 +121,9 @@ extern int _gnrc_rpl(int argc, char **argv);
 extern int _gnrc_6ctx(int argc, char **argv);
 #endif
 #endif
+#ifdef MODULE_GNRC_DNS
+extern int _gnrc_dns_handler(int argc, char **argv);
+#endif
 
 #ifdef MODULE_CCN_LITE_UTILS
 extern int _ccnl_open(int argc, char **argv);
@@ -207,6 +210,9 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_SAUL_REG
     {"saul", "interact with sensors and actuators using SAUL", _saul },
+#endif
+#ifdef MODULE_GNRC_DNS
+    {"dns", "dns configuration tool [show|add|del|resolve]", _gnrc_dns_handler },
 #endif
 #ifdef MODULE_CCN_LITE_UTILS
     { "ccnl_open", "opens an interface or socket", _ccnl_open},


### PR DESCRIPTION
Can someone please review my DNS implementation?

Re-Write to use `conn` API depends on #3921 
Re-Writing to `conn` loses the capability of zero-copy since I now could allocate the packet buffer at maximum size and reallocate it to the size that it actually is after filling it.
