### PR TITLE
netdev2_tap: set maximum buffer size correctly

### DIFF
--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -224,7 +224,7 @@ static int _recv(netdev2_t *netdev2, char *buf, int len)
     if (!buf) {
         /* no way of figuring out packet size without racey buffering,
          * so we return the maximum possible size */
-        return 576;
+        return ETHERNET_FRAME_LEN;
     }
 
     int nread = real_read(dev->tap_fd, buf, len);


### PR DESCRIPTION
@kaspar030, I didn't get the rationale for `576` in the first place, but this results in broken pinging with a payload bigger than 514 bytes.