### PR TITLE
cpu/stm32l1-f0/spi: Configure the SPI pins as highspeed

### DIFF
--- a/cpu/stm32f0/periph/spi.c
+++ b/cpu/stm32f0/periph/spi.c
@@ -151,6 +151,7 @@ int spi_conf_pins(spi_t dev)
     for (int i = 0; i < 3; i++) {
         port->MODER &= ~(3 << (pin[i] * 2));
         port->MODER |= (2 << (pin[i] * 2));
+        port->OSPEEDR |= (3 << (pin[i] * 2));
         int hl = (pin[i] < 8) ? 0 : 1;
         port->AFR[hl] &= ~(0xf << ((pin[i] - (hl * 8)) * 4));
         port->AFR[hl] |= (af << ((pin[i] - (hl * 8)) * 4));

--- a/cpu/stm32l1/periph/spi.c
+++ b/cpu/stm32l1/periph/spi.c
@@ -147,6 +147,7 @@ int spi_conf_pins(spi_t dev)
     for (int i = 0; i < 3; i++) {
         port->MODER &= ~(3 << (pin[i] * 2));
         port->MODER |= (2 << (pin[i] * 2));
+        port->OSPEEDR |= (3 << (pin[i] * 2));
         int hl = (pin[i] < 8) ? 0 : 1;
         port->AFR[hl] &= ~(0xf << ((pin[i] - (hl * 8)) * 4));
         port->AFR[hl] |= (af << ((pin[i] - (hl * 8)) * 4));


### PR DESCRIPTION
SPI pin's for the STM32L1 and STM32F0 series was not set to high. So if you would configure devices with to a to high clock rate, communication would fail.