### PR TITLE
doc: Fix documentation for UDP

### DIFF
--- a/sys/include/net/gnrc/udp.h
+++ b/sys/include/net/gnrc/udp.h
@@ -40,7 +40,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Priority of the pktdump thread
+ * @brief   Priority of the UDP thread
  */
 #ifndef GNRC_UDP_PRIO
 #define GNRC_UDP_PRIO           (THREAD_PRIORITY_MAIN - 2)


### PR DESCRIPTION
Fix an copy-pasto from the UDP header.