### PR TITLE
ndp: assertify pio prefix len check and include 0 and 128

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -346,8 +346,9 @@ void gnrc_ndp_internal_send_rtr_sol(kernel_pid_t iface, ipv6_addr_t *dst)
 static bool _pio_from_iface_addr(gnrc_pktsnip_t **res, gnrc_ipv6_netif_addr_t *addr,
                                  gnrc_pktsnip_t *next)
 {
-    if (((addr->prefix_len - 1U) < 127U) && /* 0 < prefix_len < 128 */
-        !ipv6_addr_is_unspecified(&addr->addr) &&
+    assert(((uint8_t) addr->prefix_len) <= 128U);
+
+    if (!ipv6_addr_is_unspecified(&addr->addr) &&
         !ipv6_addr_is_link_local(&addr->addr) &&
         !gnrc_ipv6_netif_addr_is_non_unicast(&addr->addr)) {
         DEBUG(" - PIO for %s/%" PRIu8 "\n", ipv6_addr_to_str(addr_str, &addr->addr,


### PR DESCRIPTION
Rationale:
1. checking the prefix validity everytime is not necessary here, because the prefix validity is checked when adding addresses to the interface via the given API calls. Therefore, I converted the check to an assert instead to save some cpu cycles on production builds.
2. I also included 0 and 128 as valid values for the prefix.
See [rfc4861#section-4.6.2](https://tools.ietf.org/html/rfc4861#section-4.6.2)
>Prefix Length: 
                     8-bit unsigned integer.  The number of leading bits
                     in the Prefix that are valid.  The value ranges
                     from 0 to 128.  The prefix length field provides
                     necessary information for on-link determination
                     (when combined with the L flag in the prefix
                     information option).  It also assists with address
                     autoconfiguration as specified in [ADDRCONF], for
                     which there may be more restrictions on the prefix
                     length.