### PR TITLE
fixed bug in stm32f0 uart implementation

### DIFF
--- a/cpu/stm32f0/periph/uart.c
+++ b/cpu/stm32f0/periph/uart.c
@@ -122,16 +122,16 @@ int init_base(uart_t uart, uint32_t baudrate)
         port->AFR[0] |= af << (rx_pin * 4);
     }
     else {
-        port->AFR[1] &= ~(0xf << ((rx_pin - 16) * 4));
-        port->AFR[1] |= af << ((rx_pin - 16) * 4);
+        port->AFR[1] &= ~(0xf << ((rx_pin - 8) * 4));
+        port->AFR[1] |= af << ((rx_pin - 8) * 4);
     }
     if (tx_pin < 8) {
         port->AFR[0] &= ~(0xf << (tx_pin * 4));
         port->AFR[0] |= af << (tx_pin * 4);
     }
     else {
-        port->AFR[1] &= ~(0xf << ((tx_pin - 16) * 4));
-        port->AFR[1] |= af << ((tx_pin - 16) * 4);
+        port->AFR[1] &= ~(0xf << ((tx_pin - 8) * 4));
+        port->AFR[1] |= af << ((tx_pin - 8) * 4);
     }
 
     /* configure UART to mode 8N1 with given baudrate */


### PR DESCRIPTION
Alternate function register was written incorrectly for pin numbers > 8.

Each AFRx register holds the alternate function values for 8 pins, not 16.
According to RM0091 and RM0360 this seems to be true for at least STM32F030x4/x6/x8 and STM32F0x1/STM32F0x2/STM32F0x8.