### PR TITLE
cpu: atmega2560: misc fixes

### DIFF
--- a/boards/arduino-mega2560/include/periph_conf.h
+++ b/boards/arduino-mega2560/include/periph_conf.h
@@ -64,6 +64,8 @@ extern "C" {
 #define TIMER0_COMP_B_EN    OCIE1B
 #define TIMER0_COMP_C_EN    OCIE1C
 #define TIMER0_FREQ_16MHZ   (0 << CS12) | (0 << CS11) | (1 << CS10)
+#define TIMER0_FREQ_2MHZ    (0 << CS12) | (1 << CS11) | (0 << CS10)
+#define TIMER0_FREQ_250KHZ  (0 << CS12) | (1 << CS11) | (1 << CS10)
 #define TIMER0_FREQ_DISABLE (0 << CS12) | (0 << CS11) | (0 << CS10)
 #define TIMER0_COMPA_ISR    TIMER1_COMPA_vect
 #define TIMER0_COMPB_ISR    TIMER1_COMPB_vect
@@ -90,6 +92,8 @@ extern "C" {
 #define TIMER1_COMP_B_EN    OCIE3B
 #define TIMER1_COMP_C_EN    OCIE3C
 #define TIMER1_FREQ_16MHZ   (0 << CS32) | (0 << CS31) | (1 << CS30)
+#define TIMER1_FREQ_2MHZ    (0 << CS32) | (1 << CS31) | (0 << CS30)
+#define TIMER1_FREQ_250KHZ  (0 << CS32) | (1 << CS31) | (1 << CS30)
 #define TIMER1_FREQ_DISABLE (0 << CS32) | (0 << CS31) | (0 << CS30)
 #define TIMER1_COMPA_ISR    TIMER3_COMPA_vect
 #define TIMER1_COMPB_ISR    TIMER3_COMPB_vect
@@ -116,6 +120,8 @@ extern "C" {
 #define TIMER2_COMP_B_EN    OCIE4B
 #define TIMER2_COMP_C_EN    OCIE4C
 #define TIMER2_FREQ_16MHZ   (0 << CS42) | (0 << CS41) | (1 << CS40)
+#define TIMER2_FREQ_2MHZ    (0 << CS42) | (1 << CS41) | (0 << CS40)
+#define TIMER2_FREQ_250KHZ  (0 << CS42) | (1 << CS41) | (1 << CS40)
 #define TIMER2_FREQ_DISABLE (0 << CS42) | (0 << CS41) | (0 << CS40)
 #define TIMER2_COMPA_ISR    TIMER4_COMPA_vect
 #define TIMER2_COMPB_ISR    TIMER4_COMPB_vect

--- a/cpu/atmega2560/periph/gpio.c
+++ b/cpu/atmega2560/periph/gpio.c
@@ -215,7 +215,9 @@ void gpio_write(gpio_t pin, int value)
 
 static inline void irq_handler(uint8_t pin_num)
 {
+    __enter_isr();
     config[pin_num].cb(config[pin_num].arg);
+    __exit_isr();
 }
 
 ISR(INT0_vect, ISR_BLOCK)

--- a/cpu/atmega2560/periph/uart.c
+++ b/cpu/atmega2560/periph/uart.c
@@ -276,44 +276,52 @@ int uart_write_blocking(uart_t uart, char data)
 #if UART_0_EN
 ISR(USART0_RX_vect, ISR_BLOCK)
 {
+    __enter_isr();
     config[UART_0].rx_cb(config[UART_0].arg, UART0_DATA_REGISTER);
 
     if (sched_context_switch_request) {
         thread_yield();
     }
+    __exit_isr();
 }
 #endif /* UART_0_EN */
 
 #if UART_1_EN
 ISR(USART1_RX_vect, ISR_BLOCK)
 {
+    __enter_isr();
     config[UART_1].rx_cb(config[UART_1].arg, UART0_DATA_REGISTER);
 
     if (sched_context_switch_request) {
         thread_yield();
     }
+    __exit_isr();
 }
 #endif /* UART_1_EN */
 
 #if UART_1_EN
 ISR(USART2_RX_vect, ISR_BLOCK)
 {
+    __enter_isr();
     config[UART_2].rx_cb(config[UART_2].arg, UART0_DATA_REGISTER);
 
     if (sched_context_switch_request) {
         thread_yield();
     }
+    __exit_isr();
 }
 #endif /* UART_2_EN */
 
 #if UART_2_EN
 ISR(USART2_RX_vect, ISR_BLOCK)
 {
+    __enter_isr();
     config[UART_3].rx_cb(config[UART_3].arg, UART0_DATA_REGISTER);
 
     if (sched_context_switch_request) {
         thread_yield();
     }
+    __exit_isr();
 }
 #endif /* UART_3_EN */
 #endif /* UART_0_EN || UART_1_EN |UART_2_EN| UART3 */

--- a/cpu/atmega_common/include/cpu.h
+++ b/cpu/atmega_common/include/cpu.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2014 Freie Universität Berlin, Hinnerk van Bruinehsen
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -20,14 +21,16 @@
  * @author      Stefan Pfeiffer <stefan.pfeiffer@fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
 #ifndef __ATMEGA_COMMON_H
 #define __ATMEGA_COMMON_H
 
 #include <stdio.h>
-#include <avr/interrupt.h>
+#include <stdint.h>
 
+#include <avr/interrupt.h>
 #include "cpu_conf.h"
 
 /**
@@ -42,6 +45,27 @@ extern "C" {
 
 #define eINT            enableIRQ
 #define dINT            disableIRQ
+
+/**
+ * @brief global in-ISR state variable
+ */
+extern volatile uint8_t __in_isr;
+
+/**
+ * @brief Flag entering of an ISR
+ */
+static inline void __enter_isr(void)
+{
+    __in_isr = 1;
+}
+
+/**
+ * @brief Flag exiting of an ISR
+ */
+static inline void __exit_isr(void)
+{
+    __in_isr = 0;
+}
 
 /**
  * @brief Initialization of the CPU

--- a/cpu/atmega_common/irq_arch.c
+++ b/cpu/atmega_common/irq_arch.c
@@ -20,6 +20,7 @@
  */
 
 #include <stdint.h>
+#include <stdio.h>
 #include "arch/irq_arch.h"
 #include "cpu.h"
 
@@ -28,6 +29,8 @@
  */
 static uint8_t __get_interrupt_state(void);
 static void __set_interrupt_state(uint8_t state);
+
+volatile uint8_t __in_isr = 0;
 
 __attribute__((always_inline)) static inline uint8_t  __get_interrupt_state(void)
 {
@@ -84,9 +87,5 @@ void irq_arch_restore(unsigned int state)
  */
 int irq_arch_in(void)
 {
-    /*
-     * TODO: find a way to implement this function (e.g. a static variable dis- or
-     * set and unset in each ISR)
-     */
-    return 0;
+    return __in_isr;
 }


### PR DESCRIPTION
The atmega was missing an implementation for ```inISR()```, causing lots of trouble wherever that was needed. This PR fixes inISR by manually setting a flag in each ISR.

Also, atmega's timers where using complicated logic in order to implement arbitrary timer prescalers. This PR simplifies the timer implementation and fixes it to 250KHz.

In combination, this PR makes #3525 work for the atmega2560.