### PR TITLE
cpu: msp430-common: fix context save/restore

### DIFF
--- a/cpu/msp430-common/cpu.c
+++ b/cpu/msp430-common/cpu.c
@@ -21,18 +21,15 @@
  */
 __attribute__((naked)) void thread_yield_higher(void)
 {
-    /*
-     * disable IRQ, remembering if they are
-     * to be reactivated after context switch
-     */
-    unsigned int irqen = disableIRQ();
+    __asm__("push r2"); /* save SR */
+    __disable_irq();
 
     __save_context();
 
     /* have sched_active_thread point to the next thread */
     sched_run();
 
-    __restore_context(irqen);
+    __restore_context();
 
     UNREACHABLE();
 }
@@ -42,7 +39,7 @@ NORETURN void cpu_switch_context_exit(void)
     sched_active_thread = sched_threads[0];
     sched_run();
 
-    __restore_context(GIE);
+    __restore_context();
 
     UNREACHABLE();
 }

--- a/cpu/msp430-common/irq.c
+++ b/cpu/msp430-common/irq.c
@@ -33,11 +33,7 @@ unsigned int disableIRQ(void)
     state &= GIE;
 
     if (state) {
-        /*    puts("-"); */
-        __asm__ __volatile__("bic  %0, r2" : : "i"(GIE));
-       /* this NOP is needed to handle a "delay slot" that all MSP430 MCUs
-          impose silently after messing with the GIE bit, DO NOT REMOVE IT! */
-        __asm__ __volatile__("nop");
+        __disable_irq();
     }
 
     return state;
@@ -50,10 +46,7 @@ unsigned int enableIRQ(void)
     state &= GIE;
 
     if (!state) {
-        __asm__ __volatile__("bis  %0, r2" : : "i"(GIE));
-        /* this NOP is needed to handle a "delay slot" that all MSP430 MCUs
-           impose silently after messing with the GIE bit, DO NOT REMOVE IT! */
-        __asm__ __volatile__("nop");
+        __enable_irq();
     }
 
     return state;
@@ -62,10 +55,7 @@ unsigned int enableIRQ(void)
 void restoreIRQ(unsigned int state)
 {
     if (state) {
-        __asm__ __volatile__("bis  %0, r2" : : "i"(GIE));
-        /* this NOP is needed to handle a "delay slot" that all MSP430 MCUs
-           impose silently after messing with the GIE bit, DO NOT REMOVE IT! */
-        __asm__ __volatile__("nop");
+        __enable_irq();
     }
 }
 


### PR DESCRIPTION
Previously, __restore_context was meddling with the to-be-restored
context SR on the stack, not correctly restoring GIE.
Now, we let the CPU restore the correct status register as saved in
__save_context.

Contains some simplification of the context save/restore logic.