### PR TITLE
cpu/samd21: optimized and extended UART impl.

### DIFF
--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -23,7 +23,9 @@
 #define PERIPH_CONF_H_
 
 #include <stdint.h>
+
 #include "cpu.h"
+#include "periph_cpu.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -101,19 +103,21 @@ extern "C" {
  * @name UART configuration
  * @{
  */
-#define UART_NUMOF          (1U)
+/* deprecated UART enable defines (to be removed) */
+#define UART_NUMOF          (2U)
 #define UART_0_EN           1
-#define UART_IRQ_PRIO       1
+#define UART_1_EN           1
 
-/* UART 0 device configuration */
-#define UART_0_DEV          SERCOM0->USART
-#define UART_0_IRQ          SERCOM0_IRQn
+/* UART device configuration */
+static const uart_conf_t uart_config[] = {
+    /* device, RX pin, TX pin, mux */
+    {&SERCOM0->USART, GPIO(PA,5), GPIO(PA,4), GPIO_MUX_D},
+    {&SERCOM5->USART, GPIO(PA,23), GPIO(PA,22), GPIO_MUX_D},
+};
+
+/* interrupt function name mapping */
 #define UART_0_ISR          isr_sercom0
-/* UART 0 pin configuration */
-#define UART_0_PORT         (PORT->Group[0])
-#define UART_0_TX_PIN       (4)
-#define UART_0_RX_PIN       (5)
-#define UART_0_PINS         (PORT_PA04 | PORT_PA05)
+#define UART_1_ISR          isr_sercom5
 /** @} */
 
 /**

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -20,7 +20,6 @@
 #define CPU_PERIPH_H_
 
 #include "cpu.h"
-#include "periph/dev_enums.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -79,6 +78,28 @@ typedef enum {
     GPIO_MUX_G = 0x6,       /**< select peripheral function G */
     GPIO_MUX_H = 0x7,       /**< select peripheral function H */
 } gpio_mux_t;
+
+/**
+ * @brief   UART device configuration
+ */
+typedef struct {
+    SercomUsart *dev;       /**< pointer to the used UART device */
+    gpio_t rx_pin;          /**< pin used for RX */
+    gpio_t tx_pin;          /**< pin used for TX */
+    gpio_mux_t mux;         /**< alternative function for pins */
+} uart_conf_t;
+
+/**
+ * @brief   Return the numeric id of a SERCOM device derived from its address
+ *
+ * @param[in] sercom    SERCOM device
+ *
+ * @return              numeric id of the given SERCOM device
+ */
+static inline int _sercom_id(SercomUsart *sercom)
+{
+    return ((((uint32_t)sercom) >> 10) & 0x7) - 2;
+}
 
 /**
  * @brief   Set up alternate function (PMUX setting) for a PORT pin


### PR DESCRIPTION
This is needed for a border router example using the samr21-xpro:

I optimized the samd21's UART driver quite a bit and defined a second UART interface for the samr21-xpro board (RX: PA23, TX: PA22) -> also documented [here](https://docs.google.com/spreadsheets/d/1350pEm6-6vR7L_JGR5rHhaNbMrZgzkCgA-OS0akPH6U/edit#gid=1766063117)

This PR also saves quite some memory:
```
examples/default - master:
   text	   data	    bss	    dec	    hex
  14664	    156	   2884	  17704	   4528	

examples/default - this branch:
   text	   data	    bss	    dec	    hex
  14360	    156	   2740	  17256	   4368
```
-> Saves 304 byte ROM. I am not sure though, where the 144 byte of RAM savings are coming from...

EDIT: forgot to state, the implementation is basically taken from #3265 and ported back to the current UART interface...