### PR TITLE
gnrc slip: use blocking uart writing

### DIFF
--- a/sys/include/net/gnrc/slip.h
+++ b/sys/include/net/gnrc/slip.h
@@ -52,7 +52,6 @@ typedef struct {
     ringbuffer_t in_buf;            /**< RX buffer */
     ringbuffer_t out_buf;           /**< TX buffer */
     char rx_mem[GNRC_SLIP_BUFSIZE]; /**< memory used by RX buffer */
-    char tx_mem[GNRC_SLIP_BUFSIZE]; /**< memory used by TX buffer */
     uint32_t in_bytes;              /**< the number of bytes received of a
                                      *   currently incoming packet */
     uint16_t in_esc;                /**< receiver is in escape mode */


### PR DESCRIPTION
I'm not sure what was the original reason for not using the blocking API, but without the fix it doesn't work for me on SAMR21-xpro. @haukepetersen, do you have additional insights here?