### PR TITLE
drivers/gpio: renamed GPIO(x,y) macro to GPIO_PIN

### DIFF
--- a/boards/fox/include/board.h
+++ b/boards/fox/include/board.h
@@ -57,10 +57,10 @@ extern "C" {
  * @{
  */
 #define AT86RF231_SPI       SPI_0
-#define AT86RF231_CS        GPIO(PORT_A,1)
-#define AT86RF231_INT       GPIO(PORT_C,2)
-#define AT86RF231_RESET     GPIO(PORT_C,1)
-#define AT86RF231_SLEEP     GPIO(PORT_A,0)
+#define AT86RF231_CS        GPIO_PIN(PORT_A,1)
+#define AT86RF231_INT       GPIO_PIN(PORT_C,2)
+#define AT86RF231_RESET     GPIO_PIN(PORT_C,1)
+#define AT86RF231_SLEEP     GPIO_PIN(PORT_A,0)
 /** @} */
 
 /**
@@ -77,8 +77,8 @@ extern "C" {
  */
 #define L3G4200D_I2C        I2C_0
 #define L3G4200D_ADDR       0x68
-#define L3G4200D_DRDY       GPIO(PORT_B,8)
-#define L3G4200D_INT        GPIO(PORT_B,11)
+#define L3G4200D_DRDY       GPIO_PIN(PORT_B,8)
+#define L3G4200D_INT        GPIO_PIN(PORT_B,11)
 /** @} */
 
 /**
@@ -88,9 +88,9 @@ extern "C" {
 #define LSM303DLHC_I2C      I2C_0
 #define LSM303DLHC_ACC_ADDR (25)
 #define LSM303DLHC_MAG_ADDR (30)
-#define LSM303DLHC_INT1     GPIO(PORT_B,9)
-#define LSM303DLHC_INT2     GPIO(PORT_B,5)
-#define LSM303DLHC_DRDY     GPIO(PORT_A,9)
+#define LSM303DLHC_INT1     GPIO_PIN(PORT_B,9)
+#define LSM303DLHC_INT2     GPIO_PIN(PORT_B,5)
+#define LSM303DLHC_DRDY     GPIO_PIN(PORT_A,9)
 /** @} */
 
 /**
@@ -99,10 +99,10 @@ extern "C" {
  */
 #define LED_RED_PORT        (GPIOB)
 #define LED_RED_PIN         (10)
-#define LED_RED_GPIO        GPIO(PORT_B,10)
+#define LED_RED_GPIO        GPIO_PIN(PORT_B,10)
 #define LED_GREEN_PORT      (GPIOB)
 #define LED_GREEN_PIN       (12)
-#define LED_GREEN_GPIO      GPIO(PORT_B,12)
+#define LED_GREEN_GPIO      GPIO_PIN(PORT_B,12)
 /** @} */
 
 /**

--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -94,8 +94,8 @@ extern "C" {
 #define UART_0_ISR          isr_usart2
 #define UART_0_BUS_FREQ     36000000
 /* UART 0 pin configuration */
-#define UART_0_RX_PIN       GPIO(PORT_A,3)
-#define UART_0_TX_PIN       GPIO(PORT_A,2)
+#define UART_0_RX_PIN       GPIO_PIN(PORT_A,3)
+#define UART_0_TX_PIN       GPIO_PIN(PORT_A,2)
 
 /* UART 1 device configuration */
 #define UART_1_DEV          USART1
@@ -104,8 +104,8 @@ extern "C" {
 #define UART_1_ISR          isr_usart1
 #define UART_1_BUS_FREQ     72000000
 /* UART 1 pin configuration */
-#define UART_1_RX_PIN       GPIO(PORT_A,10)
-#define UART_1_TX_PIN       GPIO(PORT_A,9)
+#define UART_1_RX_PIN       GPIO_PIN(PORT_A,10)
+#define UART_1_TX_PIN       GPIO_PIN(PORT_A,9)
 /** @} */
 
 /**
@@ -116,14 +116,14 @@ extern "C" {
 #define SPI_0_EN            1
 
 /* SPI 0 device configuration */
-#define SPI_0_DEV               SPI2
-#define SPI_0_CLKEN()           (RCC->APB1ENR |= RCC_APB1ENR_SPI2EN)
-#define SPI_0_CLKDIS()          (RCC->APB1ENR &= ~(RCC_APB1ENR_SPI2EN))
-#define SPI_0_BUS_DIV           0   /* 1 -> SPI runs with full CPU clock, 0 -> half CPU clock */
+#define SPI_0_DEV           SPI2
+#define SPI_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_SPI2EN)
+#define SPI_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_SPI2EN))
+#define SPI_0_BUS_DIV       0   /* 1 -> SPI runs with full CPU clock, 0 -> half CPU clock */
 /* SPI 0 pin configuration */
-#define SPI_0_CLK_PIN           GPIO(PORT_B,13)
-#define SPI_0_MOSI_PIN          GPIO(PORT_B,15)
-#define SPI_0_MISO_PIN          GPIO(PORT_B,14)
+#define SPI_0_CLK_PIN       GPIO_PIN(PORT_B,13)
+#define SPI_0_MOSI_PIN      GPIO_PIN(PORT_B,15)
+#define SPI_0_MISO_PIN      GPIO_PIN(PORT_B,14)
 /** @} */
 
 /**
@@ -159,8 +159,8 @@ extern "C" {
 #define I2C_0_ERR_IRQ       I2C1_ER_IRQn
 #define I2C_0_ERR_ISR       isr_i2c1_er
 /* I2C 0 pin configuration */
-#define I2C_0_SCL_PIN       GPIO(PORT_B,6)
-#define I2C_0_SDA_PIN       GPIO(PORT_B,7)
+#define I2C_0_SCL_PIN       GPIO_PIN(PORT_B,6)
+#define I2C_0_SDA_PIN       GPIO_PIN(PORT_B,7)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/iotlab-m3/include/board.h
+++ b/boards/iotlab-m3/include/board.h
@@ -64,10 +64,10 @@ extern "C" {
  * @{
  */
 #define AT86RF231_SPI       SPI_0
-#define AT86RF231_CS        GPIO(PORT_A,4)
-#define AT86RF231_INT       GPIO(PORT_C,4)
-#define AT86RF231_RESET     GPIO(PORT_C,1)
-#define AT86RF231_SLEEP     GPIO(PORT_A,2)
+#define AT86RF231_CS        GPIO_PIN(PORT_A,4)
+#define AT86RF231_INT       GPIO_PIN(PORT_C,4)
+#define AT86RF231_RESET     GPIO_PIN(PORT_C,1)
+#define AT86RF231_SLEEP     GPIO_PIN(PORT_A,2)
 #define AT86RF231_SPI_CLK   SPI_SPEED_5MHZ
 /** @} */
 
@@ -76,9 +76,9 @@ extern "C" {
  * @{
  */
 #define EXTFLASH_SPI        SPI_1
-#define EXTFLASH_CS         GPIO(PORT_A,11)
-#define EXTFLASH_WRITE      GPIO(PORT_C,6)
-#define EXTFLASH_HOLD       GPIO(PORT_C,9)
+#define EXTFLASH_CS         GPIO_PIN(PORT_A,11)
+#define EXTFLASH_WRITE      GPIO_PIN(PORT_C,6)
+#define EXTFLASH_HOLD       GPIO_PIN(PORT_C,9)
 /** @} */
 
 /**
@@ -103,8 +103,8 @@ extern "C" {
  */
 #define L3G4200D_I2C        I2C_0
 #define L3G4200D_ADDR       0x68
-#define L3G4200D_DRDY       GPIO(PORT_C,0)
-#define L3G4200D_INT        GPIO(PORT_C,5)
+#define L3G4200D_DRDY       GPIO_PIN(PORT_C,0)
+#define L3G4200D_INT        GPIO_PIN(PORT_C,5)
 /** @} */
 
 /**
@@ -114,9 +114,9 @@ extern "C" {
 #define LSM303DLHC_I2C      I2C_0
 #define LSM303DLHC_ACC_ADDR (0x19)
 #define LSM303DLHC_MAG_ADDR (0x1e)
-#define LSM303DLHC_INT1     GPIO(PORT_B,12)
-#define LSM303DLHC_INT2     GPIO(PORT_B,1)
-#define LSM303DLHC_DRDY     GPIO(PORT_B,2)
+#define LSM303DLHC_INT1     GPIO_PIN(PORT_B,12)
+#define LSM303DLHC_INT2     GPIO_PIN(PORT_B,1)
+#define LSM303DLHC_DRDY     GPIO_PIN(PORT_B,2)
 /** @} */
 
 /**
@@ -125,13 +125,13 @@ extern "C" {
  */
 #define LED_RED_PORT        (GPIOD)
 #define LED_RED_PIN         (2)
-#define LED_RED_GPIO        GPIO(PORT_D,2)
+#define LED_RED_GPIO        GPIO_PIN(PORT_D,2)
 #define LED_GREEN_PORT      (GPIOB)
 #define LED_GREEN_PIN       (5)
-#define LED_GREEN_GPIO      GPIO(PORT_B,5)
+#define LED_GREEN_GPIO      GPIO_PIN(PORT_B,5)
 #define LED_ORANGE_PORT     (GPIOC)
 #define LED_ORANGE_PIN      (10)
-#define LED_ORANGE_GPIO     GPIO(PORT_C,10)
+#define LED_ORANGE_GPIO     GPIO_PIN(PORT_C,10)
 /** @} */
 
 /**

--- a/boards/iotlab-m3/include/periph_conf.h
+++ b/boards/iotlab-m3/include/periph_conf.h
@@ -95,8 +95,8 @@ extern "C" {
 #define UART_0_ISR          isr_usart1
 #define UART_0_BUS_FREQ     72000000
 /* UART 0 pin configuration */
-#define UART_0_RX_PIN       GPIO(PORT_A,10)
-#define UART_0_TX_PIN       GPIO(PORT_A,9)
+#define UART_0_RX_PIN       GPIO_PIN(PORT_A,10)
+#define UART_0_TX_PIN       GPIO_PIN(PORT_A,9)
 
 /* UART 1 device configuration */
 #define UART_1_DEV          USART2
@@ -105,8 +105,8 @@ extern "C" {
 #define UART_1_ISR          isr_usart2
 #define UART_1_BUS_FREQ     36000000
 /* UART 1 pin configuration */
-#define UART_1_RX_PIN       GPIO(PORT_A,3)
-#define UART_1_TX_PIN       GPIO(PORT_A,2)
+#define UART_1_RX_PIN       GPIO_PIN(PORT_A,3)
+#define UART_1_TX_PIN       GPIO_PIN(PORT_A,2)
 /** @} */
 
 /**
@@ -117,14 +117,14 @@ extern "C" {
 #define SPI_0_EN            1
 
 /* SPI 0 device configuration */
-#define SPI_0_DEV               SPI1
-#define SPI_0_CLKEN()           (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()          (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI1EN))
-#define SPI_0_BUS_DIV           1   /* 1 -> SPI runs with full CPU clock, 0 -> half CPU clock */
+#define SPI_0_DEV           SPI1
+#define SPI_0_CLKEN()       (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
+#define SPI_0_CLKDIS()      (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI1EN))
+#define SPI_0_BUS_DIV       1   /* 1 -> SPI runs with full CPU clock, 0 -> half CPU clock */
 /* SPI 0 pin configuration */
-#define SPI_0_CLK_PIN           GPIO(PORT_A,5)
-#define SPI_0_MOSI_PIN          GPIO(PORT_A,7)
-#define SPI_0_MISO_PIN          GPIO(PORT_A,6)
+#define SPI_0_CLK_PIN       GPIO_PIN(PORT_A,5)
+#define SPI_0_MOSI_PIN      GPIO_PIN(PORT_A,7)
+#define SPI_0_MISO_PIN      GPIO_PIN(PORT_A,6)
 /** @} */
 
 /**
@@ -160,8 +160,8 @@ extern "C" {
 #define I2C_0_ERR_IRQ       I2C1_ER_IRQn
 #define I2C_0_ERR_ISR       isr_i2c1_er
 /* I2C 0 pin configuration */
-#define I2C_0_SCL_PIN       GPIO(PORT_B,6)
-#define I2C_0_SDA_PIN       GPIO(PORT_B,7)
+#define I2C_0_SCL_PIN       GPIO_PIN(PORT_B,6)
+#define I2C_0_SDA_PIN       GPIO_PIN(PORT_B,7)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/limifrog-v1/include/board.h
+++ b/boards/limifrog-v1/include/board.h
@@ -54,9 +54,9 @@ extern "C" {
  * @name LED pin definitions
  * @{
  */
-#define LED_RED_PORT      (GPIOC)
-#define LED_RED_PIN       (3)
-#define LED_RED_GPIO GPIO(PORT_C,3)
+#define LED_RED_PORT        (GPIOC)
+#define LED_RED_PIN         (3)
+#define LED_RED_GPIO        GPIO_PIN(PORT_C,3)
 /** @} */
 
 /**

--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -45,10 +45,10 @@ extern "C" {
  * @{
  */
 #define CC110X_SPI          SPI_0
-#define CC110X_CS           GPIO(PORT_B, 12)
-#define CC110X_GDO0         GPIO(PORT_C, 4)
-#define CC110X_GDO1         GPIO(PORT_A, 6)
-#define CC110X_GDO2         GPIO(PORT_C, 5)
+#define CC110X_CS           GPIO_PIN(PORT_B, 12)
+#define CC110X_GDO0         GPIO_PIN(PORT_C, 4)
+#define CC110X_GDO1         GPIO_PIN(PORT_A, 6)
+#define CC110X_GDO2         GPIO_PIN(PORT_C, 5)
 /** @} */
 
 /**

--- a/boards/saml21-xpro/board.c
+++ b/boards/saml21-xpro/board.c
@@ -44,5 +44,5 @@ void board_init(void)
  */
 void led_init(void)
 {
-    gpio_init(GPIO(PB,10), GPIO_DIR_OUT, GPIO_NOPULL);
+    gpio_init(GPIO_PIN(PB,10), GPIO_DIR_OUT, GPIO_NOPULL);
 }

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -44,23 +44,23 @@ extern "C" {
 * @name AT86RF233 configuration
 * @{
 */
-#define AT86RF233_SPI        (SPI_0)
-#define AT86RF233_CS         GPIO(PB, 31)
-#define AT86RF233_INT        GPIO(PB, 0)
-#define AT86RF233_RESET      GPIO(PB, 15)
-#define AT86RF233_SLEEP      GPIO(PA, 20)
-#define AT86RF233_SPI_CLK    (SPI_SPEED_1MHZ)
+#define AT86RF233_SPI       (SPI_0)
+#define AT86RF233_CS        GPIO_PIN(PB, 31)
+#define AT86RF233_INT       GPIO_PIN(PB, 0)
+#define AT86RF233_RESET     GPIO_PIN(PB, 15)
+#define AT86RF233_SLEEP     GPIO_PIN(PA, 20)
+#define AT86RF233_SPI_CLK   (SPI_SPEED_1MHZ)
 /** @}*/
 
 /**
 * @name AT86RF231 config
 * @{
 */
-#define AT86RF231_SPI      SPI_0
-#define AT86RF231_CS       GPIO(PB, 31)
-#define AT86RF231_INT      GPIO(PB, 0)
-#define AT86RF231_RESET    GPIO(PB, 15)
-#define AT86RF231_SLEEP    GPIO(PA, 20)
+#define AT86RF231_SPI       SPI_0
+#define AT86RF231_CS        GPIO_PIN(PB, 31)
+#define AT86RF231_INT       GPIO_PIN(PB, 0)
+#define AT86RF231_RESET     GPIO_PIN(PB, 15)
+#define AT86RF231_SLEEP     GPIO_PIN(PA, 20)
 
 #define AT86RF231_SPI_SPEED SPI_SPEED_1MHZ
 /** @} */

--- a/boards/spark-core/include/board.h
+++ b/boards/spark-core/include/board.h
@@ -86,16 +86,16 @@
 /**
  * @name User button configuration
  */
-#define BUTTON1             GPIO(PORT_B,2)
+#define BUTTON1             GPIO_PIN(PORT_B,2)
 
 /**
  * @name CC3000 pin configuration
  * @{
  */
 #define CC3000_SPI          SPI_0
-#define CC3000_CS           GPIO(PORT_B,12)
-#define CC3000_EN           GPIO(PORT_B,8)
-#define CC3000_INT          GPIO(PORT_B,11)
+#define CC3000_CS           GPIO_PIN(PORT_B,12)
+#define CC3000_EN           GPIO_PIN(PORT_B,8)
+#define CC3000_INT          GPIO_PIN(PORT_B,11)
 /** @} */
 
 /**
@@ -103,7 +103,7 @@
  * @{
  */
 #define EXTFLASH_SPI        SPI_0
-#define EXTFLASH            GPIO(PORT_B,9)
+#define EXTFLASH            GPIO_PIN(PORT_B,9)
 /** @} */
 
 /**

--- a/boards/spark-core/include/periph_conf.h
+++ b/boards/spark-core/include/periph_conf.h
@@ -93,26 +93,26 @@
 #define UART_0_ISR          isr_usart2
 #define UART_0_BUS_FREQ     (CLOCK_CORECLOCK/2)
 /* UART 0 pin configuration */
-#define UART_0_RX_PIN       GPIO(PORT_A,3)
-#define UART_0_TX_PIN       GPIO(PORT_A,2)
+#define UART_0_RX_PIN       GPIO_PIN(PORT_A,3)
+#define UART_0_TX_PIN       GPIO_PIN(PORT_A,2)
 /** @} */
 
 /**
  * @brief SPI configuration
  * @{
  */
-#define SPI_NUMOF               (1U)
-#define SPI_0_EN                1
+#define SPI_NUMOF           (1U)
+#define SPI_0_EN            1
 
 /* SPI 0 device configuration */
-#define SPI_0_DEV               SPI1
-#define SPI_0_CLKEN()           (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()          (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI1EN))
-#define SPI_0_BUS_DIV           0   /* 1 -> SPI runs with full CPU clock, 0 -> half CPU clock */
+#define SPI_0_DEV           SPI1
+#define SPI_0_CLKEN()       (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
+#define SPI_0_CLKDIS()      (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI1EN))
+#define SPI_0_BUS_DIV       0   /* 1 -> SPI runs with full CPU clock, 0 -> half CPU clock */
 /* SPI 0 pin configuration */
-#define SPI_0_CLK_PIN           GPIO(PORT_B,15)
-#define SPI_0_MOSI_PIN          GPIO(PORT_B,17)
-#define SPI_0_MISO_PIN          GPIO(PORT_B,16)
+#define SPI_0_CLK_PIN       GPIO_PIN(PORT_B,15)
+#define SPI_0_MOSI_PIN      GPIO_PIN(PORT_B,17)
+#define SPI_0_MISO_PIN      GPIO_PIN(PORT_B,16)
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/atmega2560/include/periph_cpu.h
+++ b/cpu/atmega2560/include/periph_cpu.h
@@ -29,7 +29,7 @@ extern "C" {
 /**
  * @brief   Define a CPU specific GPIO pin generator macro
  */
-#define GPIO(x, y)          ((x << 4) | y)
+#define GPIO_PIN(x, y)          ((x << 4) | y)
 
 /**
  * @brief   Available ports on the ATmega2560 family

--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -54,7 +54,7 @@ typedef struct {
 int gpio_init_mux(unsigned pin, unsigned mux);
 void gpio_init_states(void);
 
-#define GPIO(port, pin) (port*32 + pin)
+#define GPIO_PIN(port, pin) (port*32 + pin)
 
 #define HAVE_GPIO_PP_T
 typedef enum {

--- a/cpu/msp430fxyz/include/periph_cpu.h
+++ b/cpu/msp430fxyz/include/periph_cpu.h
@@ -43,7 +43,7 @@ typedef uint16_t gpio_t;
  * @brief   Mandatory function for defining a GPIO pins
  * @{
  */
-#define GPIO(x, y)          ((gpio_t)(((x & 0xff) << 8) | (1 << (y & 0xff))))
+#define GPIO_PIN(x, y)      ((gpio_t)(((x & 0xff) << 8) | (1 << (y & 0xff))))
 
 /**
  * @brief   Override direction values

--- a/cpu/nrf51/include/periph_cpu.h
+++ b/cpu/nrf51/include/periph_cpu.h
@@ -54,7 +54,7 @@ typedef enum {
  *
  * The port definition is used (and zeroed) to suppress compiler warnings
  */
-#define GPIO(x,y)           ((x & 0) | y)
+#define GPIO_PIN(x,y)       ((x & 0) | y)
 
 #ifdef __cplusplus
 }

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -43,7 +43,7 @@ typedef uint32_t gpio_t;
  * @brief   Mandatory function for defining a GPIO pins
  * @{
  */
-#define GPIO(x, y)          (((gpio_t)(&PORT->Group[x])) | y)
+#define GPIO_PIN(x, y)      (((gpio_t)(&PORT->Group[x])) | y)
 
 /**
  * @brief   Available ports on the SAMD21

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -43,7 +43,7 @@ typedef uint32_t gpio_t;
  * @brief   Mandatory function for defining a GPIO pins
  * @{
  */
-#define GPIO(x, y)          (((gpio_t)(&PORT->Group[x])) | y)
+#define GPIO_PIN(x, y)      (((gpio_t)(&PORT->Group[x])) | y)
 
 /**
  * @brief   Available ports on the SAML21 for convenient access

--- a/cpu/saml21/periph/spi.c
+++ b/cpu/saml21/periph/spi.c
@@ -72,7 +72,7 @@ typedef struct spi_saml21 {
 static const spi_saml21_t spi[] = {
 #if SPI_0_EN
     /* SPI device */   /* MCLK flag */        /* GLCK id */         /* SCLK */  /* MISO */  /* MOSI */ /* dipo+dopo */
-    { &(SERCOM0->SPI), MCLK_APBCMASK_SERCOM0, SERCOM0_GCLK_ID_CORE, { GPIO(PA,7), 3 }, { GPIO(PA,4), 3 }, { GPIO(PA,6), 3 }, 0, 1 }
+    { &(SERCOM0->SPI), MCLK_APBCMASK_SERCOM0, SERCOM0_GCLK_ID_CORE, { GPIO_PIN(PA,7), 3 }, { GPIO_PIN(PA,4), 3 }, { GPIO_PIN(PA,6), 3 }, 0, 1 }
 #endif
 };
 

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -42,7 +42,7 @@ typedef uint32_t gpio_t;
 /**
  * @brief   Define a CPU specific GPIO pin generator macro
  */
-#define GPIO(x, y)          ((GPIOA_BASE + (x << 10)) | y)
+#define GPIO_PIN(x, y)      ((GPIOA_BASE + (x << 10)) | y)
 
 /**
  * @brief   Override values for pull register configuration

--- a/cpu/stm32f3/include/periph_cpu.h
+++ b/cpu/stm32f3/include/periph_cpu.h
@@ -42,7 +42,7 @@ typedef uint32_t gpio_t;
 /**
  * @brief   Define a CPU specific GPIO pin generator macro
  */
-#define GPIO(x, y)          ((GPIOA_BASE + (x << 10)) | y)
+#define GPIO_PIN(x, y)      ((GPIOA_BASE + (x << 10)) | y)
 
 /**
  * @brief   Available ports on the STM32F3 family

--- a/cpu/stm32f4/include/periph_cpu.h
+++ b/cpu/stm32f4/include/periph_cpu.h
@@ -42,7 +42,7 @@ typedef uint32_t gpio_t;
 /**
  * @brief   Define a CPU specific GPIO pin generator macro
  */
-#define GPIO(x, y)          ((GPIOA_BASE + (x << 10)) | y)
+#define GPIO_PIN(x, y)      ((GPIOA_BASE + (x << 10)) | y)
 
 /**
  * @brief   Available ports on the STM32F4 family

--- a/cpu/stm32l1/include/periph_cpu.h
+++ b/cpu/stm32l1/include/periph_cpu.h
@@ -44,7 +44,7 @@ typedef uint32_t gpio_t;
 /**
  * @brief   Define a CPU specific GPIO pin generator macro
  */
-#define GPIO(x, y)          ((GPIOA_BASE + (x << 10)) | y)
+#define GPIO_PIN(x, y)      ((GPIOA_BASE + (x << 10)) | y)
 
 /**
  * @brief   Available ports on the STM32L1 family

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -30,8 +30,8 @@ extern "C" {
 /**
  * @brief   Default GPIO macro maps port-pin tuples to the pin value
  */
-#ifndef GPIO
-#define GPIO(x,y)       ((x & 0) | y)
+#ifndef GPIO_PIN
+#define GPIO_PIN(x,y)       ((x & 0) | y)
 #endif
 
 /**

--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -67,7 +67,7 @@ static int init_out(int argc, char **argv)
     else {
         pull = GPIO_NOPULL;
     }
-    if (gpio_init(GPIO(port, pin), GPIO_DIR_OUT, pull) < 0) {
+    if (gpio_init(GPIO_PIN(port, pin), GPIO_DIR_OUT, pull) < 0) {
         printf("Error while initializing  PORT_%i.%i as output\n", port, pin);
         return 1;
     }
@@ -98,7 +98,7 @@ static int init_in(int argc, char **argv)
     else {
         pull = GPIO_NOPULL;
     }
-    if (gpio_init(GPIO(port, pin), GPIO_DIR_IN, pull) < 0) {
+    if (gpio_init(GPIO_PIN(port, pin), GPIO_DIR_IN, pull) < 0) {
         printf("Error while initializing  PORT_%i.%02i as input\n", port, pin);
         return 1;
     }
@@ -147,7 +147,7 @@ static int init_int(int argc, char **argv)
     else {
         pull = GPIO_NOPULL;
     }
-    if (gpio_init_int(GPIO(port, pin), pull, flank, cb, (void *)pin) < 0) {
+    if (gpio_init_int(GPIO_PIN(port, pin), pull, flank, cb, (void *)pin) < 0) {
         printf("Error while initializing  PORT_%i.%02i as external interrupt\n",
                port, pin);
         return 1;
@@ -168,7 +168,7 @@ static int read(int argc, char **argv)
     }
     port = atoi(argv[1]);
     pin = atoi(argv[2]);
-    if (gpio_read(GPIO(port, pin))) {
+    if (gpio_read(GPIO_PIN(port, pin))) {
         printf("PORT_%i.%02i is HIGH\n", port, pin);
     }
     else {
@@ -188,7 +188,7 @@ static int set(int argc, char **argv)
     port = atoi(argv[1]);
     pin = atoi(argv[2]);
 
-    gpio_set(GPIO(port, pin));
+    gpio_set(GPIO_PIN(port, pin));
     return 0;
 }
 
@@ -202,7 +202,7 @@ static int clear(int argc, char **argv)
     }
     port = atoi(argv[1]);
     pin = atoi(argv[2]);
-    gpio_clear(GPIO(port, pin));
+    gpio_clear(GPIO_PIN(port, pin));
     return 0;
 }
 
@@ -216,7 +216,7 @@ static int toggle(int argc, char **argv)
     }
     port = atoi(argv[1]);
     pin = atoi(argv[2]);
-    gpio_toggle(GPIO(port, pin));
+    gpio_toggle(GPIO_PIN(port, pin));
     return 0;
 }
 

--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -87,7 +87,7 @@ int parse_spi_dev(int argc, char **argv)
     }
     port = atoi(argv[2]);
     pin = atoi(argv[3]);
-    spi_cs = GPIO(port,pin);
+    spi_cs = GPIO_PIN(port,pin);
     if (argc >= 5) {
         spi_mode = argv[4][0] - '0';
         if (spi_mode < 0 || spi_mode > 3) {


### PR DESCRIPTION
I almost forgot to do this: due to naming conflicts on some (future) platforms, the plain name of `GPIO` leads to problems. The new name does also fit the scheme with other periph drivers, as `UART_DEV()`, `TIMER_DEV()`, and so on. I just figured, that for GPIOs, the name `GPIO_PIN` is easier to grasp than `GPIO_DEV`....