### PR TITLE
gnrc_pktbuf_static: possible fix for gnrc_pktbuf_mark

### DIFF
--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -90,9 +90,6 @@ gnrc_pktsnip_t *gnrc_pktbuf_add(gnrc_pktsnip_t *next, void *data, size_t size,
 gnrc_pktsnip_t *gnrc_pktbuf_mark(gnrc_pktsnip_t *pkt, size_t size, gnrc_nettype_t type)
 {
     gnrc_pktsnip_t *marked_snip;
-    /* size required for chunk */
-    size_t required_new_size = (size < sizeof(_unused_t)) ?
-                               _align(sizeof(_unused_t)) : _align(size);
     mutex_lock(&_mutex);
     if ((size == 0) || (pkt == NULL) || (size > pkt->size) || (pkt->data == NULL)) {
         DEBUG("pktbuf: size == 0 (was %u) or pkt == NULL (was %p) or "
@@ -112,7 +109,7 @@ gnrc_pktsnip_t *gnrc_pktbuf_mark(gnrc_pktsnip_t *pkt, size_t size, gnrc_nettype_
         mutex_unlock(&_mutex);
         return NULL;
     }
-    if (size < required_new_size) { /* would not fit unused marker => move data around */
+    if (pkt->size < size) { /* would not fit unused marker => move data around */
         void *new_data_marked, *new_data_rest;
         new_data_marked = _pktbuf_alloc(size);
         if (new_data_marked == NULL) {

--- a/tests/unittests/tests-pktbuf/tests-pktbuf.c
+++ b/tests/unittests/tests-pktbuf/tests-pktbuf.c
@@ -323,7 +323,7 @@ static void test_pktbuf_mark__success_large(void)
 
     /* check if slightly larger packet would override data */
     gnrc_pktbuf_remove_snip(pkt1, pkt2);
-    pkt2 = gnrc_pktbuf_add(NULL, TEST_STRING12, 12, GNRC_NETTYPE_TEST);
+    pkt2 = gnrc_pktbuf_add(NULL, TEST_STRING12, sizeof(TEST_STRING12), GNRC_NETTYPE_TEST);
     TEST_ASSERT(gnrc_pktbuf_is_sane());
     TEST_ASSERT_NOT_NULL(pkt1->data);
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp_data1, pkt1->data, pkt1->size));


### PR DESCRIPTION
I noticed that the `gnrc_pktbuf_mark()` function would check on `size < _align(size)`, which is `true` for most of the times. Checking for `pkt->size < size` is IMO the right way, but this seems to break something else in `gnrc_pktbuf_release()`, because the tests in `tests-pktbuf` are failing now. @authmillenon any ideas?