### PR TITLE
stdio: remove superfluous mutex_lock in init

### DIFF
--- a/sys/uart_stdio/uart_stdio.c
+++ b/sys/uart_stdio/uart_stdio.c
@@ -70,7 +70,6 @@ void uart_stdio_rx_cb(void *arg, char data)
 
 void uart_stdio_init(void)
 {
-    mutex_lock(&_rx_mutex);
     uart_init(STDIO, STDIO_BAUDRATE, uart_stdio_rx_cb, NULL);
 }
 


### PR DESCRIPTION
Stumbled across this while trying to debug mutexes - which are used inside this module...