### PR TITLE
gnrc: various fixes

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -92,14 +92,6 @@ static ipv6_addr_t *_add_addr_to_entry(gnrc_ipv6_netif_t *entry, const ipv6_addr
     }
     else {
         if (!ipv6_addr_is_link_local(addr)) {
-            /* add also corresponding link-local address */
-            ipv6_addr_t ll_addr;
-
-            ll_addr.u64[1] = addr->u64[1];
-            ipv6_addr_set_link_local_prefix(&ll_addr);
-
-            _add_addr_to_entry(entry, &ll_addr, 64,
-                               flags | GNRC_IPV6_NETIF_ADDR_FLAGS_NDP_ON_LINK);
 #ifdef MODULE_GNRC_NDP_ROUTER
             /* New prefixes MAY allow the router to retransmit up to
              * GNRC_NDP_MAX_INIT_RTR_ADV_NUMOF unsolicited RA

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -295,6 +295,7 @@ uint8_t gnrc_sixlowpan_nd_opt_ar_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6, ui
                     DEBUG("6lo nd: unknown status for registration received\n");
                     break;
             }
+            break;
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
         case ICMPV6_NBR_SOL:
             if (!(ipv6_iface->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN) &&
@@ -339,6 +340,7 @@ uint8_t gnrc_sixlowpan_nd_opt_ar_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6, ui
                 vtimer_set_msg(&nc_entry->type_timeout, timex_set(reg_ltime * 60, 0),
                                gnrc_ipv6_pid, GNRC_SIXLOWPAN_ND_MSG_AR_TIMEOUT, nc_entry);
             }
+            break;
 #endif
         default:
             break;

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -312,7 +312,8 @@ uint8_t gnrc_sixlowpan_nd_opt_ar_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6, ui
             if ((nc_entry != NULL) &&
                 ((gnrc_ipv6_nc_get_type(nc_entry) == GNRC_IPV6_NC_TYPE_REGISTERED) ||
                  (gnrc_ipv6_nc_get_type(nc_entry) == GNRC_IPV6_NC_TYPE_TENTATIVE)) &&
-                (ar_opt->eui64.uint64.u64 != nc_entry->eui64.uint64.u64)) {
+                ((nc_entry->eui64.uint64.u64 != 0) &&
+                 (ar_opt->eui64.uint64.u64 != nc_entry->eui64.uint64.u64))) {
                 /* there is already another node with this address */
                 DEBUG("6lo nd: duplicate address detected\n");
                 status = SIXLOWPAN_ND_STATUS_DUP;

--- a/tests/unittests/tests-ipv6_nc/Makefile.include
+++ b/tests/unittests/tests-ipv6_nc/Makefile.include
@@ -1,1 +1,2 @@
 USEMODULE += gnrc_ipv6_nc
+USEMODULE += gnrc_ipv6_netif

--- a/tests/unittests/tests-ipv6_nc/tests-ipv6_nc.c
+++ b/tests/unittests/tests-ipv6_nc/tests-ipv6_nc.c
@@ -18,6 +18,7 @@
 
 #include "net/ipv6/addr.h"
 #include "net/gnrc/ipv6/nc.h"
+#include "net/gnrc/ipv6/netif.h"
 
 #include "unittests-constants.h"
 #include "tests-ipv6_nc.h"
@@ -50,6 +51,7 @@
 static void set_up(void)
 {
     gnrc_ipv6_nc_init();
+    gnrc_ipv6_netif_add(DEFAULT_TEST_NETIF);
 }
 
 static void test_ipv6_nc_add__address_registered(void)

--- a/tests/unittests/tests-ipv6_netif/Makefile.include
+++ b/tests/unittests/tests-ipv6_netif/Makefile.include
@@ -1,5 +1,6 @@
 USEMODULE += ipv6_addr
 USEMODULE += gnrc_ipv6_netif
 USEMODULE += gnrc_netif
+USEMODULE += gnrc_ndp_node
 
 CFLAGS += -DGNRC_NETIF_NUMOF=3

--- a/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
+++ b/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
@@ -195,7 +195,7 @@ static void test_ipv6_netif_add_addr__despite_free_entry(void)
     ipv6_addr_t *entry_2;
 
     ipv6_addr_t default_addr = DEFAULT_TEST_IPV6_ADDR;
-    ipv6_addr_t ll_addr;
+    ipv6_addr_t sol_addr;
 
     test_ipv6_netif_add__success(); /* adds DEFAULT_TEST_NETIF as interface */
 
@@ -203,15 +203,14 @@ static void test_ipv6_netif_add_addr__despite_free_entry(void)
     TEST_ASSERT_NOT_NULL((entry_1 = gnrc_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &default_addr,
                                                              DEFAULT_TEST_PREFIX_LEN, 0)));
 
-    /* remove default_addr, but not the others (corresponding lla, solicited-node addr)
-     * that came with it */
+    /* remove default_addr, but not the corresponding solicited-node addr that
+     * came with it */
     gnrc_ipv6_netif_remove_addr(DEFAULT_TEST_NETIF, &default_addr);
 
-    /* create and re-add corresponding lla and check that it hasn't taken
-     * the old place of default_addr*/
-    ll_addr.u64[1] = default_addr.u64[1];
-    ipv6_addr_set_link_local_prefix(&ll_addr);
-    TEST_ASSERT_NOT_NULL((entry_2 = gnrc_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &ll_addr,
+    /* create and re-add corresponding solicited node address and check that it
+     * hasn't taken the old place of default_addr*/
+    ipv6_addr_set_solicited_nodes(&sol_addr, &default_addr);
+    TEST_ASSERT_NOT_NULL((entry_2 = gnrc_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &sol_addr,
                                                              DEFAULT_TEST_PREFIX_LEN, 0)));
 
     TEST_ASSERT(entry_1 != entry_2);
@@ -318,7 +317,7 @@ static void test_ipv6_netif_find_addr__success(void)
     TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(out, &addr));
 
     /* also test for link local address */
-    ipv6_addr_set_link_local_prefix(&addr);
+    ipv6_addr_set_solicited_nodes(&addr, &addr);
     TEST_ASSERT_NOT_NULL((out = gnrc_ipv6_netif_find_addr(DEFAULT_TEST_NETIF, &addr)));
     TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(out, &addr));
 }


### PR DESCRIPTION
* I don't see a reason for adding a link local address for every non-link local address. Linux also doesn't do so.
* 6LoWPAN routers were bit overzealous with detecting and removing false duplicates.