### PR TITLE
gnrc_udp: no need to copy pkt chain

### DIFF
--- a/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
+++ b/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
@@ -139,40 +139,12 @@ static void _receive(gnrc_pktsnip_t *pkt)
 static void _send(gnrc_pktsnip_t *pkt)
 {
     udp_hdr_t *hdr;
-    gnrc_pktsnip_t *udp_snip, *tmp;
+    gnrc_pktsnip_t *udp_snip;
 
-    /* write protect first header */
-    tmp = gnrc_pktbuf_start_write(pkt);
-    if (tmp == NULL) {
-        DEBUG("udp: cannot send packet: unable to allocate packet\n");
-        gnrc_pktbuf_release(pkt);
-        return;
-    }
-    pkt = tmp;
-    udp_snip = tmp->next;
-
-    /* get and write protect until udp snip */
-    while ((udp_snip != NULL) && (udp_snip->type != GNRC_NETTYPE_UDP)) {
-        udp_snip = gnrc_pktbuf_start_write(udp_snip);
-        if (udp_snip == NULL) {
-            DEBUG("udp: cannot send packet: unable to allocate packet\n");
-            gnrc_pktbuf_release(pkt);
-            return;
-        }
-        tmp->next = udp_snip;
-        tmp = udp_snip;
-        udp_snip = udp_snip->next;
-    }
+    LL_SEARCH_SCALAR(pkt, udp_snip, type, GNRC_NETTYPE_UDP);
 
     assert(udp_snip != NULL);
 
-    /* write protect UDP snip */
-    udp_snip = gnrc_pktbuf_start_write(udp_snip);
-    if (udp_snip == NULL) {
-        DEBUG("udp: cannot send packet: unable to allocate packet\n");
-        gnrc_pktbuf_release(pkt);
-        return;
-    }
     hdr = (udp_hdr_t *)udp_snip->data;
     /* fill in size field */
     hdr->length = byteorder_htons(gnrc_pkt_len(udp_snip));


### PR DESCRIPTION
IMO, there is no need to use `gnrc_pktbuf_start_write()` for the full pkt chain. I assume there will be only **one** active udp thread and reusing a pkt that is dispatched away in upper layers is also not something that should land in the best practices. So why not keep it simple?