### PR TITLE
pkg/libcoap: delete unused function check_opt_size

### DIFF
--- a/pkg/libcoap/0001-Add-RIOT-Makefile.patch
+++ b/pkg/libcoap/0001-Add-RIOT-Makefile.patch
@@ -1,7 +1,7 @@
 From bc86f013bbfc1eca7151d4faa2bb9ca33987115c Mon Sep 17 00:00:00 2001
 From: Martine Lenders <mlenders@inf.fu-berlin.de>
 Date: Thu, 31 Oct 2013 13:36:10 +0100
-Subject: [PATCH 1/8] Add RIOT Makefile
+Subject: [PATCH 1/9] Add RIOT Makefile
 
 ---
  Makefile | 4 ++++

--- a/pkg/libcoap/0002-Add-config.h.patch
+++ b/pkg/libcoap/0002-Add-config.h.patch
@@ -1,7 +1,7 @@
 From 8be22676f13bd7d254378e2c04119e1632ed55d7 Mon Sep 17 00:00:00 2001
 From: Martine Lenders <mlenders@inf.fu-berlin.de>
 Date: Thu, 31 Oct 2013 14:02:07 +0100
-Subject: [PATCH 2/8] Add config.h
+Subject: [PATCH 2/9] Add config.h
 
 ---
  config.h | 131 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/pkg/libcoap/0003-Remove-two-example-programs-in-root.patch
+++ b/pkg/libcoap/0003-Remove-two-example-programs-in-root.patch
@@ -1,7 +1,7 @@
 From e53472f0a5f15d2459bf9a9ef40d2b302bb80f8b Mon Sep 17 00:00:00 2001
 From: Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
 Date: Tue, 15 Jul 2014 16:57:07 +0200
-Subject: [PATCH 3/8] Remove two example programs in root
+Subject: [PATCH 3/9] Remove two example programs in root
 
 ---
  coap-observer.c | 185 -----------------------------------------------

--- a/pkg/libcoap/0004-Eliminate-some-compiler-warnings-and-errors.patch
+++ b/pkg/libcoap/0004-Eliminate-some-compiler-warnings-and-errors.patch
@@ -1,7 +1,7 @@
 From 48906fde395dc05c18606ddf3abce5947ab6a1c6 Mon Sep 17 00:00:00 2001
 From: Martine Lenders <mlenders@inf.fu-berlin.de>
 Date: Wed, 19 Feb 2014 02:24:50 +0100
-Subject: [PATCH 4/5] Eliminate some compiler warnings and errors
+Subject: [PATCH 4/9] Eliminate some compiler warnings and errors
 
 ---
  address.h | 4 ++++

--- a/pkg/libcoap/0005-fix-old-style-function-declarations.patch
+++ b/pkg/libcoap/0005-fix-old-style-function-declarations.patch
@@ -1,7 +1,7 @@
 From e6d36f466b2c1568cb4cfc3a3f1f9348e71db037 Mon Sep 17 00:00:00 2001
 From: Ludwig Ortmann <ludwig.ortmann@fu-berlin.de>
 Date: Tue, 15 Jul 2014 17:06:51 +0200
-Subject: [PATCH 5/8] fix old-style function declarations
+Subject: [PATCH 5/9] fix old-style function declarations
 
 ---
  async.c | 2 +-

--- a/pkg/libcoap/0006-debug-do-not-misuse-NDEBUG.patch
+++ b/pkg/libcoap/0006-debug-do-not-misuse-NDEBUG.patch
@@ -1,7 +1,7 @@
 From ca876797dbe6ba05f75a451e8724495a0770fe86 Mon Sep 17 00:00:00 2001
 From: Oleg Hahm <oleg@hobbykeller.org>
 Date: Thu, 23 Jul 2015 10:20:38 +0200
-Subject: [PATCH 6/8] debug: do not misuse NDEBUG
+Subject: [PATCH 6/9] debug: do not misuse NDEBUG
 
 ---
  coap_list.c       |  2 +-

--- a/pkg/libcoap/0007-fix-option-parsing-with-debug-enabled.patch
+++ b/pkg/libcoap/0007-fix-option-parsing-with-debug-enabled.patch
@@ -1,7 +1,7 @@
 From e5adb25f18ff979b2777f7161b1038611c84a450 Mon Sep 17 00:00:00 2001
 From: Oleg Hahm <oleg@hobbykeller.org>
 Date: Tue, 4 Aug 2015 23:07:24 +0200
-Subject: [PATCH 7/8] fix option parsing with debug enabled
+Subject: [PATCH 7/9] fix option parsing with debug enabled
 
 ---
  option.c | 3 ++-

--- a/pkg/libcoap/0008-fix-debug-out-in-PDU-parsing.patch
+++ b/pkg/libcoap/0008-fix-debug-out-in-PDU-parsing.patch
@@ -1,7 +1,7 @@
 From 3409c3834022c9e7cd73ac69e34dfaa101947cf0 Mon Sep 17 00:00:00 2001
 From: Oleg Hahm <oleg@hobbykeller.org>
 Date: Tue, 4 Aug 2015 23:09:27 +0200
-Subject: [PATCH 8/8] fix debug out in PDU parsing
+Subject: [PATCH 8/9] fix debug out in PDU parsing
 
 ---
  net.c | 3 ++-

--- a/pkg/libcoap/0009-delete-unused-function-check_opt_size.patch
+++ b/pkg/libcoap/0009-delete-unused-function-check_opt_size.patch
@@ -1,0 +1,36 @@
+From 4e065c420056a5416d9d4b00439042d7adcefddb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Cenk=20G=C3=BCndo=C4=9Fan?= <cnkgndgn@gmail.com>
+Date: Wed, 16 Sep 2015 19:02:09 +0200
+Subject: [PATCH 9/9] delete unused function check_opt_size
+
+---
+ net.c | 14 --------------
+ 1 file changed, 14 deletions(-)
+
+diff --git a/net.c b/net.c
+index 0b8c99e..18f39a7 100644
+--- a/net.c
++++ b/net.c
+@@ -817,20 +817,6 @@ coap_retransmit( coap_context_t *context, coap_queue_t *node ) {
+   return COAP_INVALID_TID;
+ }
+
+-/**
+- * Checks if @p opt fits into the message that ends with @p maxpos.
+- * This function returns @c 1 on success, or @c 0 if the option @p opt
+- * would exceed @p maxpos.
+- */
+-static inline int
+-check_opt_size(coap_opt_t *opt, unsigned char *maxpos) {
+-  if (opt && opt < maxpos) {
+-    if (((*opt & 0x0f) < 0x0f) || (opt + 1 < maxpos))
+-      return opt + COAP_OPT_SIZE(opt) < maxpos;
+-  }
+-  return 0;
+-}
+-
+ int
+ coap_read( coap_context_t *ctx ) {
+ #ifdef WITH_POSIX
+--
+2.5.2


### PR DESCRIPTION
This PR adds a patch to delete the unused function and updates all other patches to have a correct commit message numbering