### PR TITLE
cpu/Makefile.include.cortexm_common: don't use cortex-m0plus for clang if unsupported

### DIFF
--- a/cpu/Makefile.include.cortexm_common
+++ b/cpu/Makefile.include.cortexm_common
@@ -11,6 +11,19 @@ export USEMODULE += newlib
 # set default for CPU_MODEL
 export CPU_MODEL ?= $(CPU)
 
+# Temporary LLVM/Clang Workaround:
+# report cortex-m0 instead of cortex-m0plus if llvm/clang (<= 3.6.2) is used
+# llvm/clang version 3.6.2 still does not support the cortex-m0plus mcpu type
+ifeq (llvm,$(TOOLCHAIN))
+ifeq (cortex-m0plus,$(CPU_ARCH))
+LLVM_UNSUP = $(shell clang -target arm-none-eabi -mcpu=$(CPU_ARCH) -c -x c /dev/null -o /dev/null \
+                     > /dev/null 2>&1 || echo 1 )
+ifeq (1,$(LLVM_UNSUP))
+CPU_ARCH = cortex-m0
+endif
+endif
+endif
+
 # export the CPU model and architecture
 MODEL = $(shell echo $(CPU_MODEL) | tr 'a-z' 'A-Z')
 export CFLAGS += -DCPU_MODEL_$(MODEL)


### PR DESCRIPTION
My clang version (3.6.2) does not support the `cortex-m0plus` mcpu type. I have no idea in which version they ~~will/~~have include/**ed** this, but building any application for the `samr21-xpro` with llvm/clang breaks for me:

```
~/r/R/e/gnrc_networking >>> TOOLCHAIN=clang BOARD=samr21-xpro make -B clean all
Building application "gnrc_networking" for "samr21-xpro" with MCU "samd21".

error: unknown target CPU 'cortex-m0plus'
```

**NOTE: I am currently building llvm/clang 3.8 from source and it appears that the m0plus is supported there. So I will just PR this and look what your opinion is on this matter. Close if necessary.**