### PR TITLE
gnrc_sixlowpan_nd: register new addresses for AAC

### DIFF
--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -120,6 +120,7 @@ extern "C" {
  */
 #define GNRC_IPV6_NETIF_ADDR_FLAGS_UNICAST      (0x00)  /**< unicast address */
 #define GNRC_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST  (0x01)  /**< non-unicast address */
+#define GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE    (0x02)  /**< address is not fully registered yet */
 
 /**
  * @brief   A prefix information option that propagates the prefix of this

--- a/sys/include/net/gnrc/ndp/internal.h
+++ b/sys/include/net/gnrc/ndp/internal.h
@@ -61,12 +61,14 @@ void gnrc_ndp_internal_set_state(gnrc_ipv6_nc_t *nc_entry, uint8_t state);
  * @internal
  *
  * @param[in] iface Interface to send over. May not be KERNEL_PID_UNDEF.
+ * @param[in] src   Source address for the neighbor solicitation. Will be chosen from the
+ *                  interface according to @p dst, if NULL.
  * @param[in] tgt   Target address for the neighbor solicitation. May not be
  *                  NULL.
  * @param[in] dst   Destination address for neighbor solicitation. May not be
  *                  NULL.
  */
-void gnrc_ndp_internal_send_nbr_sol(kernel_pid_t iface, ipv6_addr_t *tgt,
+void gnrc_ndp_internal_send_nbr_sol(kernel_pid_t iface, ipv6_addr_t *src, ipv6_addr_t *tgt,
                                     ipv6_addr_t *dst);
 
 /**

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -87,6 +87,19 @@ static ipv6_addr_t *_add_addr_to_entry(gnrc_ipv6_netif_t *entry, const ipv6_addr
     tmp_addr->prefix_len = prefix_len;
     tmp_addr->flags = flags;
 
+#ifdef MODULE_GNRC_SIXLOWPAN_ND
+    if (entry->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN) {
+        ipv6_addr_t *router = gnrc_ndp_internal_default_router();
+        if (router != NULL) {
+            tmp_addr->flags |= GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE;
+            mutex_unlock(&entry->mutex);    /* function below relocks mutex */
+            gnrc_ndp_internal_send_nbr_sol(entry->pid, &tmp_addr->addr, router, router);
+            mutex_lock(&entry->mutex);      /* relock mutex */
+        }
+        /* otherwise there is no default router to register to */
+    }
+#endif
+
     if (ipv6_addr_is_multicast(addr)) {
         tmp_addr->flags |= GNRC_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST;
     }
@@ -391,6 +404,9 @@ ipv6_addr_t *gnrc_ipv6_netif_find_addr(kernel_pid_t pid, const ipv6_addr_t *addr
     mutex_lock(&entry->mutex);
 
     for (int i = 0; i < GNRC_IPV6_NETIF_ADDR_NUMOF; i++) {
+        if (entry->addrs[i].flags & GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE) {
+            continue;
+        }
         if (ipv6_addr_equal(&(entry->addrs[i].addr), addr)) {
             mutex_unlock(&entry->mutex);
             DEBUG("ipv6 netif: Found %s on interface %" PRIkernel_pid "\n",
@@ -423,6 +439,9 @@ static uint8_t _find_by_prefix_unsafe(ipv6_addr_t **res, gnrc_ipv6_netif_t *ifac
             continue;
         }
 
+        if (iface->addrs[i].flags & GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE) {
+            continue;
+        }
         match = ipv6_addr_match_prefix(&(iface->addrs[i].addr), addr);
 
         if ((only == NULL) && !ipv6_addr_is_multicast(addr) &&
@@ -543,7 +562,8 @@ static int _create_candidate_set(gnrc_ipv6_netif_t *iface, const ipv6_addr_t *ds
         /* "In any case, multicast addresses and the unspecified address MUST NOT
          *  be included in a candidate set."
          */
-        if (ipv6_addr_is_multicast(&(iter->addr)) ||
+        if ((iter->flags & GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE) ||
+            ipv6_addr_is_multicast(&(iter->addr)) ||
             ipv6_addr_is_unspecified(&(iter->addr))) {
             continue;
         }

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -611,7 +611,8 @@ void gnrc_ndp_rtr_adv_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt, ipv6_hdr_t
          *  Hence, reset router solicitation counter and reset timer. */
         if_entry->rtr_sol_count = 0;
         gnrc_sixlowpan_nd_rtr_sol_reschedule(nc_entry, next_rtr_sol);
-        gnrc_ndp_internal_send_nbr_sol(nc_entry->iface, &nc_entry->ipv6_addr, &nc_entry->ipv6_addr);
+        gnrc_ndp_internal_send_nbr_sol(nc_entry->iface, NULL, &nc_entry->ipv6_addr,
+                                       &nc_entry->ipv6_addr);
     }
 #endif
 }
@@ -643,7 +644,7 @@ void gnrc_ndp_retrans_nbr_sol(gnrc_ipv6_nc_t *nc_entry)
                 size_t ifnum = gnrc_netif_get(ifs);
 
                 for (size_t i = 0; i < ifnum; i++) {
-                    gnrc_ndp_internal_send_nbr_sol(ifs[i], &nc_entry->ipv6_addr, &dst);
+                    gnrc_ndp_internal_send_nbr_sol(ifs[i], NULL, &nc_entry->ipv6_addr, &dst);
                 }
 
                 vtimer_remove(&nc_entry->nbr_sol_timer);
@@ -653,7 +654,7 @@ void gnrc_ndp_retrans_nbr_sol(gnrc_ipv6_nc_t *nc_entry)
             else {
                 gnrc_ipv6_netif_t *ipv6_iface = gnrc_ipv6_netif_get(nc_entry->iface);
 
-                gnrc_ndp_internal_send_nbr_sol(nc_entry->iface, &nc_entry->ipv6_addr, &dst);
+                gnrc_ndp_internal_send_nbr_sol(nc_entry->iface, NULL, &nc_entry->ipv6_addr, &dst);
 
                 mutex_lock(&ipv6_iface->mutex);
                 vtimer_remove(&nc_entry->nbr_sol_timer);

--- a/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
+++ b/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
@@ -166,7 +166,7 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
             size_t ifnum = gnrc_netif_get(ifs);
 
             for (size_t i = 0; i < ifnum; i++) {
-                gnrc_ndp_internal_send_nbr_sol(ifs[i], next_hop_ip, &dst_sol);
+                gnrc_ndp_internal_send_nbr_sol(ifs[i], NULL, next_hop_ip, &dst_sol);
             }
 
             vtimer_remove(&nc_entry->nbr_sol_timer);
@@ -176,7 +176,7 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
         else {
             gnrc_ipv6_netif_t *ipv6_iface = gnrc_ipv6_netif_get(iface);
 
-            gnrc_ndp_internal_send_nbr_sol(iface, next_hop_ip, &dst_sol);
+            gnrc_ndp_internal_send_nbr_sol(iface, NULL, next_hop_ip, &dst_sol);
 
             mutex_lock(&ipv6_iface->mutex);
             vtimer_remove(&nc_entry->nbr_sol_timer);

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -377,7 +377,7 @@ void gnrc_sixlowpan_nd_wakeup(void)
         timex_t t = { 0, GNRC_NDP_RETRANS_TIMER };
         vtimer_remove(&router->rtr_sol_timer);
         gnrc_sixlowpan_nd_uc_rtr_sol(router);
-        gnrc_ndp_internal_send_nbr_sol(router->iface, &router->ipv6_addr, &router->ipv6_addr);
+        gnrc_ndp_internal_send_nbr_sol(router->iface, NULL, &router->ipv6_addr, &router->ipv6_addr);
         vtimer_remove(&router->nbr_sol_timer);
         vtimer_set_msg(&router->nbr_sol_timer, t, gnrc_ipv6_pid, GNRC_NDP_MSG_NBR_SOL_RETRANS,
                        router);

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -273,7 +273,10 @@ uint8_t gnrc_sixlowpan_nd_opt_ar_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6, ui
             switch (ar_opt->status) {
                 case SIXLOWPAN_ND_STATUS_SUCCESS:
                     DEBUG("6lo nd: address registration successful\n");
+                    ipv6_addr_t *netif_addr_entry = gnrc_ipv6_netif_find_addr(iface, &(ipv6->dst));
+                    gnrc_ipv6_netif_addr_t *netif_addr = gnrc_ipv6_netif_addr_get(netif_addr_entry);
                     mutex_lock(&ipv6_iface->mutex);
+                    netif_addr->flags &= ~GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE;
                     /* reschedule 1 minute before lifetime expires */
                     timex_t t = { (uint32_t)(byteorder_ntohs(ar_opt->ltime) - 1) * 60, 0 };
                     vtimer_remove(&nc_entry->nbr_sol_timer);

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -680,6 +680,7 @@ static int _netif_add(char *cmd_name, kernel_pid_t dev, int argc, char **argv)
     } type = _UNICAST;
     char *addr_str = argv[0];
     ipv6_addr_t addr;
+    ipv6_addr_t *assigned_address;
     uint8_t prefix_len;
 
     if (argc > 1) {
@@ -713,13 +714,16 @@ static int _netif_add(char *cmd_name, kernel_pid_t dev, int argc, char **argv)
         return 1;
     }
 
-    if (gnrc_ipv6_netif_add_addr(dev, &addr, prefix_len,
-                                 (type == _ANYCAST) ?
-                                 GNRC_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST :
-                                 GNRC_IPV6_NETIF_ADDR_FLAGS_UNICAST) == NULL) {
+    if ((assigned_address = gnrc_ipv6_netif_add_addr(dev, &addr, prefix_len,
+                                                    (type == _ANYCAST) ?
+                                                    GNRC_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST :
+                                                    GNRC_IPV6_NETIF_ADDR_FLAGS_UNICAST))
+                           == NULL) {
         printf("error: unable to add IPv6 address\n");
         return 1;
     }
+    gnrc_ipv6_netif_addr_t *netif_addr = gnrc_ipv6_netif_addr_get(assigned_address);
+    netif_addr->flags &= ~GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE;
 
     printf("success: added %s/%d to interface %" PRIkernel_pid "\n", addr_str,
            prefix_len, dev);


### PR DESCRIPTION
New addresses are are not registered for auto-address configuration in a LoWPAN. This fixes that.