### PR TITLE
nhdp: use conn instead of socket_base

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -6,6 +6,13 @@ ifneq (,$(filter pnet,$(USEMODULE)))
     USEMODULE += vtimer
 endif
 
+ifneq (,$(filter nhdp,$(USEMODULE)))
+  USEMODULE += conn_udp
+  USEMODULE += vtimer
+  USEMODULE += oonf_common
+  USEMODULE += oonf_rfc5444
+endif
+
 ifneq (,$(filter gnrc_%,$(filter-out gnrc_netapi gnrc_netreg gnrc_netif% gnrc_pktbuf,$(USEMODULE))))
   USEMODULE += gnrc
 endif
@@ -292,12 +299,6 @@ endif
 
 ifneq (,$(filter libfixmath-unittests,$(USEMODULE)))
   USEPKG += libfixmath
-endif
-
-ifneq (,$(filter nhdp,$(USEMODULE)))
-  USEMODULE += vtimer
-  USEMODULE += oonf_common
-  USEMODULE += oonf_rfc5444
 endif
 
 ifneq (,$(filter fib,$(USEMODULE)))

--- a/sys/net/routing/nhdp/nhdp.h
+++ b/sys/net/routing/nhdp/nhdp.h
@@ -23,7 +23,6 @@
 
 #include "timex.h"
 #include "kernel_types.h"
-#include "socket_base/socket.h"
 
 #include "nhdp_metric.h"
 #include "rfc5444/rfc5444_writer.h"


### PR DESCRIPTION
Rework NHDP to use `conn` instead of the deprecated `socket_base`.

Depends on #3615