### PR TITLE
cpu: let spi_init_slave() stubs return error codes

### DIFF
--- a/cpu/lpc2387/periph/spi.c
+++ b/cpu/lpc2387/periph/spi.c
@@ -141,7 +141,7 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char))
     (void)cb;
     printf("%s:%s(): stub\n", RIOT_FILE_RELATIVE, __func__);
     /* TODO */
-    return 0;
+    return -1;
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)

--- a/cpu/samd21/periph/spi.c
+++ b/cpu/samd21/periph/spi.c
@@ -200,7 +200,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
 int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char))
 {
     /* TODO */
-    return 0;
+    return -1;
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)

--- a/cpu/saml21/periph/spi.c
+++ b/cpu/saml21/periph/spi.c
@@ -173,7 +173,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
 int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char))
 {
     /* TODO */
-    return 0;
+    return -1;
 }
 
 void spi_transmission_begin(spi_t dev, char reset_val)


### PR DESCRIPTION
When you think your samr21 is a slave but is actually doing nothing...