### PR TITLE
oonf_api: adapt for new sockets

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -5,7 +5,6 @@ endif
 ifneq (,$(filter nhdp,$(USEMODULE)))
   USEMODULE += conn_udp
   USEMODULE += vtimer
-  USEMODULE += oonf_common
   USEMODULE += oonf_rfc5444
 endif
 
@@ -307,9 +306,13 @@ ifneq (,$(filter fib,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter oonf_rfc5444,$(USEMODULE)))
+  USEMODULE += oonf_common
+endif
+
 ifneq (,$(filter oonf_common,$(USEMODULE)))
   USEPKG += oonf_api
-  USEMODULE += socket_base
+  USEMODULE += posix_sockets
 endif
 
 ifneq (,$(filter %_conn_ip,$(USEMODULE)))

--- a/pkg/oonf_api/0001-add-RIOT-support.patch
+++ b/pkg/oonf_api/0001-add-RIOT-support.patch
@@ -1,21 +1,20 @@
-From b7ed6eeb4f970bf603da8ec90f4f7e8b862dcdb6 Mon Sep 17 00:00:00 2001
+From 9e99bc8ed9f4e4d326a14589ad29607fef89e3a5 Mon Sep 17 00:00:00 2001
 From: Benjamin Valentin <benpicco@zedat.fu-berlin.de>
 Date: Wed, 5 Feb 2014 20:01:41 +0100
 Subject: [PATCH 01/10] add RIOT support
 
 ---
- Makefile                             | 29 ++++++++++++++
- external/regex/Makefile              |  4 ++
- src-api/common/Makefile              |  3 ++
- src-api/common/autobuf.c             |  6 +++
- src-api/common/common_types.h        |  5 +++
+ Makefile                             | 29 ++++++++++++++++++++
+ external/regex/Makefile              |  4 +++
+ src-api/common/Makefile              |  3 +++
+ src-api/common/autobuf.c             |  6 +++++
+ src-api/common/common_types.h        |  5 ++++
  src-api/common/daemonize.c           |  2 +-
- src-api/common/netaddr.c             | 74 +++++++++++++++++++++---------------
- src-api/common/netaddr.h             | 22 +++++++----
- src-api/rfc5444/Makefile             |  3 ++
- src-api/rfc5444/rfc5444_api_config.h | 51 +++++++++++++++++++++++++
- src-api/rfc5444/rfc5444_print.c      |  5 +++
- 11 files changed, 165 insertions(+), 39 deletions(-)
+ src-api/common/netaddr.c             | 11 +++++++-
+ src-api/common/netaddr.h             |  2 ++
+ src-api/rfc5444/Makefile             |  3 +++
+ src-api/rfc5444/rfc5444_api_config.h | 51 ++++++++++++++++++++++++++++++++++++
+ 10 files changed, 114 insertions(+), 2 deletions(-)
  create mode 100644 Makefile
  create mode 100644 external/regex/Makefile
  create mode 100644 src-api/common/Makefile
@@ -83,7 +82,7 @@ index 77c519b..37e77ac 100644
 @@ -51,6 +51,12 @@
  #include <winsock2.h>
  #endif
- 
+
 +#ifdef RIOT_VERSION
 +int getpagesize(void) {
 +	return 512;
@@ -91,7 +90,7 @@ index 77c519b..37e77ac 100644
 +#endif
 +
  #include "common/autobuf.h"
- 
+
  /**
 diff --git a/src-api/common/common_types.h b/src-api/common/common_types.h
 index c90cf46..b5f170a 100644
@@ -116,145 +115,48 @@ index 103c88f..8a6cd2b 100644
 @@ -48,7 +48,7 @@
  #include "common/common_types.h"
  #include "common/daemonize.h"
- 
+
 -#ifndef WIN32
 +#if (!defined(_WIN32)) && (!defined(RIOT_VERSION))
  /**
   * Prepare the start of a daemon. Fork into background,
   * but keep stdin/out/err open and a pipe connected to
 diff --git a/src-api/common/netaddr.c b/src-api/common/netaddr.c
-index dedab2c..1b602ec 100644
+index dedab2c..6b214ee 100644
 --- a/src-api/common/netaddr.c
 +++ b/src-api/common/netaddr.c
-@@ -43,7 +43,14 @@
+@@ -43,7 +43,11 @@
  #include <stdio.h>
  #include <stdlib.h>
  #include <string.h>
 +#ifndef RIOT_VERSION
  #include <net/if.h>
 +#else
-+#include <arpa/inet.h>
-+#include "net/af.h"
 +#define DONT_HAVE_SIN6_SCOPE_ID
 +#endif
- 
+
  #include "common/common_types.h"
  #include "common/string.h"
-@@ -175,12 +182,12 @@ netaddr_to_binary(void *dst, const struct netaddr *src, size_t len) {
- int
- netaddr_from_socket(struct netaddr *dst, const union netaddr_socket *src) {
-   memset(dst->_addr, 0, sizeof(dst->_addr));
--  if (src->std.sa_family == AF_INET) {
-+  if (src->std.sin6_family == AF_INET) {
-     /* ipv4 */
--    memcpy(dst->_addr, &src->v4.sin_addr, 4);
-+    memcpy(dst->_addr, &src->v4.sin6_addr, 4);
-     dst->_prefix_len = 32;
-   }
--  else if (src->std.sa_family == AF_INET6){
-+  else if (src->std.sin6_family == AF_INET6){
-     /* ipv6 */
-     memcpy(dst->_addr, &src->v6.sin6_addr, 16);
-     dst->_prefix_len = 128;
-@@ -190,7 +197,7 @@ netaddr_from_socket(struct netaddr *dst, const union netaddr_socket *src) {
-     dst->_type = AF_UNSPEC;
-     return -1;
-   }
--  dst->_type = (uint8_t)src->std.sa_family;
-+  dst->_type = (uint8_t)src->std.sin6_family;
-   return 0;
- }
- 
-@@ -204,12 +211,12 @@ netaddr_from_socket(struct netaddr *dst, const union netaddr_socket *src) {
- int
- netaddr_to_socket(union netaddr_socket *dst, const struct netaddr *src) {
-   /* copy address type */
--  dst->std.sa_family = src->_type;
-+  dst->std.sin6_family = src->_type;
- 
-   switch (src->_type) {
-     case AF_INET:
-       /* ipv4 */
--      memcpy(&dst->v4.sin_addr, src->_addr, 4);
-+      memcpy(&dst->v4.sin6_addr, src->_addr, 4);
-       break;
-     case AF_INET6:
-       /* ipv6 */
-@@ -221,7 +228,7 @@ netaddr_to_socket(union netaddr_socket *dst, const struct netaddr *src) {
-   }
- 
-   /* copy address type */
--  dst->std.sa_family= src->_type;
-+  dst->std.sin6_family= src->_type;
-   return 0;
- }
- 
-@@ -319,14 +326,16 @@ netaddr_socket_init(union netaddr_socket *combined, const struct netaddr *addr,
-   switch (addr->_type) {
-     case AF_INET:
-       /* ipv4 */
--      memcpy(&combined->v4.sin_addr, addr->_addr, 4);
--      combined->v4.sin_port = htons(port);
-+      memcpy(&combined->v4.sin6_addr, addr->_addr, 4);
-+      combined->v4.sin6_port = HTONS(port);
-       break;
-     case AF_INET6:
+@@ -326,7 +330,9 @@ netaddr_socket_init(union netaddr_socket *combined, const struct netaddr *addr,
        /* ipv6 */
        memcpy(&combined->v6.sin6_addr, addr->_addr, 16);
--      combined->v6.sin6_port = htons(port);
-+      combined->v6.sin6_port = HTONS(port);
+       combined->v6.sin6_port = htons(port);
 +#ifndef DONT_HAVE_SIN6_SCOPE_ID
        combined->v6.sin6_scope_id = if_index;
 +#endif
        break;
      default:
        /* unknown address type */
-@@ -334,7 +343,7 @@ netaddr_socket_init(union netaddr_socket *combined, const struct netaddr *addr,
+@@ -561,6 +567,7 @@ netaddr_socket_to_string(struct netaddr_str *dst, const union netaddr_socket *sr
+         ntohs(src->v4.sin_port));
    }
- 
-   /* copy address type */
--  combined->std.sa_family = addr->_type;
-+  combined->std.sin6_family = addr->_type;
-   return 0;
- }
- 
-@@ -344,11 +353,11 @@ netaddr_socket_init(union netaddr_socket *combined, const struct netaddr *addr,
-  */
- uint16_t
- netaddr_socket_get_port(const union netaddr_socket *sock) {
--  switch (sock->std.sa_family) {
-+  switch (sock->std.sin6_family) {
-     case AF_INET:
--      return ntohs(sock->v4.sin_port);
-+      return NTOHS(sock->v4.sin6_port);
-     case AF_INET6:
--      return ntohs(sock->v6.sin6_port);
-+      return NTOHS(sock->v6.sin6_port);
-     default:
-       return 0;
-   }
-@@ -555,28 +564,31 @@ const char *
- netaddr_socket_to_string(struct netaddr_str *dst, const union netaddr_socket *src) {
-   struct netaddr_str buf;
- 
--  if (src->std.sa_family == AF_INET) {
-+  if (src->std.sin6_family == AF_INET) {
-     snprintf(dst->buf, sizeof(*dst), "%s:%d",
--        inet_ntop(AF_INET, &src->v4.sin_addr, buf.buf, sizeof(buf)),
--        ntohs(src->v4.sin_port));
-+        inet_ntop(AF_INET, &src->v4.sin6_addr, buf.buf, sizeof(buf)),
-+        NTOHS(src->v4.sin6_port));
-   }
--  else if (src->std.sa_family == AF_INET6) {
-+  else if (src->std.sin6_family == AF_INET6) {
+   else if (src->std.sa_family == AF_INET6) {
 +#ifndef DONT_HAVE_SIN6_SCOPE_ID
      if (src->v6.sin6_scope_id) {
        char scope_buf[IF_NAMESIZE];
- 
-       snprintf(dst->buf, sizeof(*dst), "[%s]:%d%%%s",
-           inet_ntop(AF_INET6, &src->v6.sin6_addr, buf.buf, sizeof(buf)),
--          ntohs(src->v6.sin6_port),
-+          NTOHS(src->v6.sin6_port),
+
+@@ -569,7 +576,9 @@ netaddr_socket_to_string(struct netaddr_str *dst, const union netaddr_socket *sr
+           ntohs(src->v6.sin6_port),
            if_indextoname(src->v6.sin6_scope_id, scope_buf));
      }
 -    else {
@@ -263,133 +165,23 @@ index dedab2c..1b602ec 100644
 +    {
        snprintf(dst->buf, sizeof(*dst), "[%s]:%d",
            inet_ntop(AF_INET6, &src->v6.sin6_addr, buf.buf, sizeof(buf)),
--          ntohs(src->v6.sin6_port));
-+          NTOHS(src->v6.sin6_port));
-     }
-   }
-   else {
--    snprintf(dst->buf, sizeof(*dst), "\"Unknown socket type: %d\"", src->std.sa_family);
-+    snprintf(dst->buf, sizeof(*dst), "\"Unknown socket type: %d\"", src->std.sin6_family);
-   }
- 
-   return dst->buf;
-@@ -622,13 +634,13 @@ int
- netaddr_cmp_to_socket(const struct netaddr *a1, const union netaddr_socket *a2) {
-   int result = 0;
- 
--  result = (int)a1->_type - (int)a2->std.sa_family;
-+  result = (int)a1->_type - (int)a2->std.sin6_family;
-   if (result) {
-     return result;
-   }
- 
-   if (a1->_type == AF_INET) {
--    result = memcmp(a1->_addr, &a2->v4.sin_addr, 4);
-+    result = memcmp(a1->_addr, &a2->v4.sin6_addr, 4);
-   }
-   else if (a1->_type == AF_INET6) {
-     /* ipv6 */
-@@ -741,20 +753,20 @@ const char *
- inet_ntop(int af, const void *src, char *dst, socklen_t cnt)
- {
-   if (af == AF_INET) {
--    struct sockaddr_in in;
-+    sockaddr6_t in;
-     memset(&in, 0, sizeof(in));
-     in.sin_family = AF_INET;
--    memcpy(&in.sin_addr, src, sizeof(struct in_addr));
--    getnameinfo((struct sockaddr *)&in, sizeof(struct sockaddr_in),
-+    memcpy(&in.sin6_addr, src, sizeof(struct in_addr));
-+    getnameinfo((sockaddr6_t *)&in, sizeof(sockaddr6_t),
-         dst, cnt, NULL, 0, NI_NUMERICHOST);
-     return dst;
-   }
-   else if (af == AF_INET6) {
--    struct sockaddr_in6 in;
-+    sockaddr6_t in;
-     memset(&in, 0, sizeof(in));
-     in.sin6_family = AF_INET6;
-     memcpy(&in.sin6_addr, src, sizeof(struct in_addr6));
--    getnameinfo((struct sockaddr *)&in, sizeof(struct sockaddr_in6),
-+    getnameinfo((sockaddr6_t *)&in, sizeof(sockaddr6_t),
-         dst, cnt, NULL, 0, NI_NUMERICHOST);
-     return dst;
-   }
-@@ -795,7 +807,7 @@ inet_pton(int af, const char *src, void *dst)
- 
-   sock = (union netaddr_socket *)res->ai_addr;
-   if (af == AF_INET) {
--    memcpy(dst, &sock->v4.sin_addr, 4);
-+    memcpy(dst, &sock->v4.sin6_addr, 4);
-   }
-   else {
-     memcpy(dst, &sock->v6.sin6_addr, 16);
-@@ -928,7 +940,7 @@ _subnetmask_to_prefixlen(const char *src) {
-   }
- 
-   /* transform into host byte order */
--  v4 = ntohl(v4);
-+  v4 = NTOHL(v4);
- 
-   shift = 0xffffffff;
-   for (len = 31; len >= 0; len--) {
+           ntohs(src->v6.sin6_port));
 diff --git a/src-api/common/netaddr.h b/src-api/common/netaddr.h
-index 78fd5b4..e65bf94 100644
+index 78fd5b4..cc8189c 100644
 --- a/src-api/common/netaddr.h
 +++ b/src-api/common/netaddr.h
-@@ -43,18 +43,26 @@
- #define NETADDR_H_
- 
- 
--#ifndef _WIN32
-+#if (!defined(_WIN32)) && (!defined(RIOT_VERSION))
+@@ -45,9 +45,11 @@
+
+ #ifndef _WIN32
  #include <arpa/inet.h>
++#ifndef RIOT_VERSION
  #include <netinet/if_ether.h>
  #include <netinet/ip.h>
  #include <net/if.h>
--#else
 +#endif
-+
-+#ifdef _WIN32
+ #else
  #include <winsock2.h>
  #include <ws2tcpip.h>
- 
- #define IF_NAMESIZE 16
- #endif
- 
-+#ifdef RIOT_VERSION
-+#include "socket_base/socket.h"
-+#define INET_ADDRSTRLEN		(16)
-+#define INET6_ADDRSTRLEN	(48)
-+#endif
-+
- #include <assert.h>
- #include <string.h>
- 
-@@ -97,10 +105,10 @@ struct netaddr {
-  * to all variants without casting and compiler warnings.
-  */
- union netaddr_socket {
--  struct sockaddr_in v4;
--  struct sockaddr_in6 v6;
--  struct sockaddr std;
--  struct sockaddr_storage storage;
-+  sockaddr6_t v4;
-+  sockaddr6_t v6;
-+  sockaddr6_t std;
-+  sockaddr6_t storage;
- };
- 
- /**
-@@ -337,7 +345,7 @@ netaddr_set_prefix_length(struct netaddr *n, uint8_t prefix_len) {
-  */
- static INLINE sa_family_t
- netaddr_socket_get_addressfamily(const union netaddr_socket *s) {
--  return s->std.sa_family;
-+  return s->std.sin6_family;
- }
- 
- #endif /* NETADDR_H_ */
 diff --git a/src-api/rfc5444/Makefile b/src-api/rfc5444/Makefile
 new file mode 100644
 index 0000000..5e0046d
@@ -456,24 +248,5 @@ index 0000000..9bf6622
 +#define CLEAR_ADDRESS_POSTFIX false
 +
 +#endif /* RFC5444_API_CONFIG_H_ */
-diff --git a/src-api/rfc5444/rfc5444_print.c b/src-api/rfc5444/rfc5444_print.c
-index 4b3e04d..7b9a308 100644
---- a/src-api/rfc5444/rfc5444_print.c
-+++ b/src-api/rfc5444/rfc5444_print.c
-@@ -41,8 +41,13 @@
- #include <assert.h>
- #include <stdio.h>
- #include <stdlib.h>
-+#ifdef RIOT_VERSION
-+#include "socket_base/socket.h"
-+#include "inet_ntop.h"
-+#else
- #include <sys/socket.h>
- #include <arpa/inet.h>
-+#endif
- 
- #include "common/netaddr.h"
- #include "rfc5444/rfc5444_reader.h"
--- 
+--
 1.9.1
-

--- a/pkg/oonf_api/0002-port-tests-to-riot.patch
+++ b/pkg/oonf_api/0002-port-tests-to-riot.patch
@@ -1,19 +1,18 @@
-From 2c8298434b94506140893c540c49760ad7eb636f Mon Sep 17 00:00:00 2001
+From ccb37ece1a21325bbc1f3efba7d3f0ec0d6b26ac Mon Sep 17 00:00:00 2001
 From: Benjamin Valentin <benpicco@zedat.fu-berlin.de>
 Date: Tue, 23 Jul 2013 21:08:31 +0200
-Subject: [PATCH 2/3] port tests to riot
+Subject: [PATCH 02/10] port tests to riot
 
 ---
- tests/common/.Makefile.template                 | 45 +++++++++++++++++++++++++
- tests/common/bin/.gitignore                     |  0
- tests/common/generate_makefiles.sh              |  8 +++++
- tests/common/test_common_avl.c                  | 10 +++---
- tests/cunit/Makefile                            |  3 ++
- tests/rfc5444/.Makefile.template                | 39 +++++++++++++++++++++
- tests/rfc5444/bin/.gitignore                    |  0
- tests/rfc5444/generate_makefiles.sh             |  8 +++++
- tests/rfc5444/test_rfc5444_reader_dropcontext.c |  2 +-
- 9 files changed, 109 insertions(+), 6 deletions(-)
+ tests/common/.Makefile.template     | 37 +++++++++++++++++++++++++++++++++++++
+ tests/common/bin/.gitignore         |  0
+ tests/common/generate_makefiles.sh  |  8 ++++++++
+ tests/common/test_common_avl.c      | 10 +++++-----
+ tests/cunit/Makefile                |  3 +++
+ tests/rfc5444/.Makefile.template    | 30 ++++++++++++++++++++++++++++++
+ tests/rfc5444/bin/.gitignore        |  0
+ tests/rfc5444/generate_makefiles.sh |  8 ++++++++
+ 8 files changed, 91 insertions(+), 5 deletions(-)
  create mode 100644 tests/common/.Makefile.template
  create mode 100644 tests/common/bin/.gitignore
  create mode 100755 tests/common/generate_makefiles.sh
@@ -24,10 +23,10 @@ Subject: [PATCH 2/3] port tests to riot
 
 diff --git a/tests/common/.Makefile.template b/tests/common/.Makefile.template
 new file mode 100644
-index 0000000..c286ad3
+index 0000000..afbaf0f
 --- /dev/null
 +++ b/tests/common/.Makefile.template
-@@ -0,0 +1,45 @@
+@@ -0,0 +1,37 @@
 +####
 +#### Sample Makefile for building apps with the RIOT OS
 +####
@@ -41,9 +40,7 @@ index 0000000..c286ad3
 +export APPLICATION = %TESTNAME%
 +
 +# for easy switching of boards
-+ifeq ($(strip $(BOARD)),)
-+	export BOARD = native
-+endif
++export BOARD ?= native
 +
 +# this has to be the absolute path of the RIOT-base dir
 +export RIOTBASE =$(CURDIR)/../../../../../..
@@ -52,12 +49,6 @@ index 0000000..c286ad3
 +
 +## Modules to include.
 +
-+USEMODULE += auto_init
-+USEMODULE += config
-+USEMODULE += uart0
-+USEMODULE += posix
-+
-+USEMODULE += net_help
 +USEMODULE += oonf_cunit
 +ifneq (,$(findstring regex,$(APPLICATION)))
 +	USEMODULE += oonf_regex
@@ -68,9 +59,9 @@ index 0000000..c286ad3
 +	error daemonize is not supported on RIOT
 +endif
 +
-+USEPKG += oonf_api
++export INCLUDES += -I$(CURDIR)/../..
 +
-+export INCLUDES += -I$(CURDIR)/../.. -I$(RIOTBASE)/sys/net/include
++QUIET ?= 1
 +
 +include $(RIOTBASE)/Makefile.include
 diff --git a/tests/common/bin/.gitignore b/tests/common/bin/.gitignore
@@ -128,10 +119,10 @@ index 0000000..5e0046d
 +include $(RIOTBASE)/Makefile.base
 diff --git a/tests/rfc5444/.Makefile.template b/tests/rfc5444/.Makefile.template
 new file mode 100644
-index 0000000..8a0452d
+index 0000000..e472545
 --- /dev/null
 +++ b/tests/rfc5444/.Makefile.template
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,30 @@
 +####
 +#### Sample Makefile for building apps with the RIOT OS
 +####
@@ -145,9 +136,7 @@ index 0000000..8a0452d
 +export APPLICATION = %TESTNAME%
 +
 +# for easy switching of boards
-+ifeq ($(strip $(BOARD)),)
-+	export BOARD = native
-+endif
++export BOARD ?= native
 +
 +# this has to be the absolute path of the RIOT-base dir
 +export RIOTBASE =$(CURDIR)/../../../../../..
@@ -155,20 +144,13 @@ index 0000000..8a0452d
 +export CFLAGS = -DOONF_LOG_INFO -DOONF_LOG_DEBUG_INFO
 +
 +## Modules to include.
-+
-+USEMODULE += auto_init
-+USEMODULE += config
-+USEMODULE += uart0
-+USEMODULE += posix
-+
-+USEMODULE += net_help
 +USEMODULE += oonf_cunit
 +USEMODULE += oonf_common
 +USEMODULE += oonf_rfc5444
 +
-+USEPKG += oonf_api
++export INCLUDES += -I$(CURDIR)/../..
 +
-+export INCLUDES += -I$(CURDIR)/../.. -I$(RIOTBASE)/sys/net/include
++QUIET ?= 1
 +
 +include $(RIOTBASE)/Makefile.include
 diff --git a/tests/rfc5444/bin/.gitignore b/tests/rfc5444/bin/.gitignore
@@ -188,19 +170,5 @@ index 0000000..8bf9faa
 +	sed s/%TESTNAME%/$test/ .Makefile.template > $test/Makefile
 +	cp $test\.c $test
 +done
-diff --git a/tests/rfc5444/test_rfc5444_reader_dropcontext.c b/tests/rfc5444/test_rfc5444_reader_dropcontext.c
-index df203fd..29daff6 100644
---- a/tests/rfc5444/test_rfc5444_reader_dropcontext.c
-+++ b/tests/rfc5444/test_rfc5444_reader_dropcontext.c
-@@ -38,7 +38,7 @@
-  * the copyright holders.
-  *
-  */
--#include <arpa/inet.h>
-+
- #include <assert.h>
- #include <stdio.h>
-
 --
-1.8.3.2
-
+1.9.1

--- a/pkg/oonf_api/0003-port-example-to-riot.patch
+++ b/pkg/oonf_api/0003-port-example-to-riot.patch
@@ -1,21 +1,19 @@
-From 329910e5c6942a70aa258907c887c6fa162266a4 Mon Sep 17 00:00:00 2001
+From 1eb568357ba8e0679ad8d9a4cc3be0ad54cfc955 Mon Sep 17 00:00:00 2001
 From: Benjamin Valentin <benpicco@zedat.fu-berlin.de>
 Date: Tue, 1 Oct 2013 17:39:03 +0200
-Subject: [PATCH 3/3] port example to riot
+Subject: [PATCH 03/10] port example to riot
 
 ---
- examples/rfc5444_reader_writer/Makefile | 37 +++++++++++++++++++++++++++++++++
- examples/rfc5444_reader_writer/reader.c |  5 +++++
- examples/rfc5444_reader_writer/writer.c |  5 +++++
- 3 files changed, 47 insertions(+)
+ examples/rfc5444_reader_writer/Makefile | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
  create mode 100644 examples/rfc5444_reader_writer/Makefile
 
 diff --git a/examples/rfc5444_reader_writer/Makefile b/examples/rfc5444_reader_writer/Makefile
 new file mode 100644
-index 0000000..42f9a55
+index 0000000..9d5653d
 --- /dev/null
 +++ b/examples/rfc5444_reader_writer/Makefile
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,28 @@
 +####
 +#### Sample Makefile for building apps with the RIOT OS
 +####
@@ -28,9 +26,7 @@ index 0000000..42f9a55
 +export APPLICATION := $(shell basename $(CURDIR))
 +
 +# for easy switching of boards
-+ifeq ($(strip $(BOARD)),)
-+	export BOARD = native
-+endif
++export BOARD ?= native
 +
 +# this has to be the absolute path of the RIOT-base dir
 +export RIOTBASE =$(CURDIR)/../../../../..
@@ -39,52 +35,12 @@ index 0000000..42f9a55
 +
 +## Modules to include.
 +
-+USEMODULE += auto_init
-+USEMODULE += config
-+USEMODULE += uart0
-+USEMODULE += posix
-+
-+USEMODULE += net_help
-+USEMODULE += oonf_common
 +USEMODULE += oonf_rfc5444
 +
-+USEPKG += oonf_api
++INCLUDES += -I$(CURDIR)/..
 +
-+INCLUDES += -I$(RIOTBASE)/sys/net/include -I$(CURDIR)/..
++QUIET ?= 1
 +
 +include $(RIOTBASE)/Makefile.include
-diff --git a/examples/rfc5444_reader_writer/reader.c b/examples/rfc5444_reader_writer/reader.c
-index 9cca869..c786d19 100644
---- a/examples/rfc5444_reader_writer/reader.c
-+++ b/examples/rfc5444_reader_writer/reader.c
-@@ -42,6 +42,11 @@
- #include <string.h>
- #include <stdio.h>
-
-+#ifdef RIOT_VERSION
-+#include "net_help.h"
-+#define ntohl(val)	NTOHL(val)
-+#endif
-+
- #include "common/common_types.h"
- #include "common/netaddr.h"
- #include "rfc5444/rfc5444_reader.h"
-diff --git a/examples/rfc5444_reader_writer/writer.c b/examples/rfc5444_reader_writer/writer.c
-index 59bb741..d05c48c 100644
---- a/examples/rfc5444_reader_writer/writer.c
-+++ b/examples/rfc5444_reader_writer/writer.c
-@@ -42,6 +42,11 @@
- #include <string.h>
- #include <stdio.h>
-
-+#ifdef RIOT_VERSION
-+#include "net_help.h"
-+#define htonl(val)	HTONL(val)
-+#endif
-+
- #include "common/common_types.h"
- #include "common/netaddr.h"
- #include "rfc5444/rfc5444_writer.h"
 --
-1.8.3.2
-
+1.9.1

--- a/pkg/oonf_api/0004-fix-conflicting-types.patch
+++ b/pkg/oonf_api/0004-fix-conflicting-types.patch
@@ -1,7 +1,7 @@
-From 67f5a991886c09b652848a97017b4bb6cfcaa7e2 Mon Sep 17 00:00:00 2001
+From 228ac53093365c7c02feeb420fa6189e932e5a9f Mon Sep 17 00:00:00 2001
 From: Benjamin Valentin <benpicco@zedat.fu-berlin.de>
 Date: Sun, 18 May 2014 22:48:40 +0200
-Subject: [PATCH] fix conflicting types
+Subject: [PATCH 04/10] fix conflicting types
 
 ---
  src-api/rfc5444/rfc5444_reader.c | 10 +++++-----
@@ -40,12 +40,11 @@ index 6962741..c1ca7f6 100644
 @@ -309,7 +309,7 @@ EXPORT void rfc5444_reader_remove_packet_consumer(
  EXPORT void rfc5444_reader_remove_message_consumer(
      struct rfc5444_reader *, struct rfc5444_reader_tlvblock_consumer *);
- 
+
 -EXPORT int rfc5444_reader_handle_packet(
 +EXPORT enum rfc5444_result rfc5444_reader_handle_packet(
      struct rfc5444_reader *parser, uint8_t *buffer, size_t length);
- 
- EXPORT uint8_t *rfc5444_reader_get_tlv_value(
--- 
-1.9.1
 
+ EXPORT uint8_t *rfc5444_reader_get_tlv_value(
+--
+1.9.1

--- a/pkg/oonf_api/0005-only-define-container_of-when-necessary.patch
+++ b/pkg/oonf_api/0005-only-define-container_of-when-necessary.patch
@@ -1,7 +1,7 @@
-From d81d24b9d4c897c508799cb390b13cb018758709 Mon Sep 17 00:00:00 2001
+From 4bcf115c22297af231b5d3d2873996a5a0695cf2 Mon Sep 17 00:00:00 2001
 From: Benjamin Valentin <benpicco@zedat.fu-berlin.de>
 Date: Fri, 10 Oct 2014 02:05:01 +0200
-Subject: [PATCH] only define container_of when necessary
+Subject: [PATCH 05/10] only define container_of when necessary
 
 ---
  src-api/common/container_of.h | 2 ++

--- a/pkg/oonf_api/0006-if_index-is-not-used.patch
+++ b/pkg/oonf_api/0006-if_index-is-not-used.patch
@@ -1,22 +1,21 @@
-From 40651f114bd6e1b4b2ebc89bdf8fb06d1243eb55 Mon Sep 17 00:00:00 2001
+From 67549da2f1f5e22e7789443f23c6a8bb470bc3f9 Mon Sep 17 00:00:00 2001
 From: Benjamin Valentin <benpicco@zedat.fu-berlin.de>
 Date: Fri, 10 Oct 2014 02:08:32 +0200
-Subject: [PATCH] if_index is not used
+Subject: [PATCH 06/10] if_index is not used
 
 ---
- src-api/common/netaddr.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ src-api/common/netaddr.c | 1 +
+ 1 file changed, 1 insertion(+)
 
 diff --git a/src-api/common/netaddr.c b/src-api/common/netaddr.c
-index ed44341..fa528ca 100644
+index 6b214ee..0b8fc1d 100644
 --- a/src-api/common/netaddr.c
 +++ b/src-api/common/netaddr.c
-@@ -319,7 +319,7 @@ netaddr_create_host_bin(struct netaddr *host, const struct netaddr *netmask,
-  */
+@@ -317,6 +317,7 @@ netaddr_create_host_bin(struct netaddr *host, const struct netaddr *netmask,
  int
  netaddr_socket_init(union netaddr_socket *combined, const struct netaddr *addr,
--    uint16_t port, unsigned if_index) {
-+    uint16_t port, unsigned if_index __attribute__((unused))) {
+     uint16_t port, unsigned if_index) {
++  (void)if_index;
    /* initialize memory block */
    memset(combined, 0, sizeof(*combined));
 

--- a/pkg/oonf_api/0007-Use-RIOT-s-container_of-implementation.patch
+++ b/pkg/oonf_api/0007-Use-RIOT-s-container_of-implementation.patch
@@ -1,7 +1,7 @@
-From b2ad2073ac282f1bc6315e47ffbd12c3f6a9ae1a Mon Sep 17 00:00:00 2001
+From 8395cf4c5753569ed964794ab98ba2fcb8af250b Mon Sep 17 00:00:00 2001
 From: Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
 Date: Wed, 29 Oct 2014 11:37:05 +0100
-Subject: [PATCH] Use RIOT's container_of implementation
+Subject: [PATCH 07/10] Use RIOT's container_of implementation
 
 ---
  src-api/common/container_of.h | 22 ++++++++++++++++++----
@@ -41,4 +41,4 @@ index fcb38fe..b49d836 100644
 
  /**
 --
-2.1.2
+1.9.1

--- a/pkg/oonf_api/0008-Dissolve-enum-into-single-defines.patch
+++ b/pkg/oonf_api/0008-Dissolve-enum-into-single-defines.patch
@@ -1,7 +1,7 @@
-From e590e6f26b115da34a943fd4ed6d4c93fd2c64d0 Mon Sep 17 00:00:00 2001
+From d02b58b3cdd26c92f01e812cc1f6cf25703b7431 Mon Sep 17 00:00:00 2001
 From: Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
 Date: Wed, 29 Oct 2014 12:05:11 +0100
-Subject: [PATCH] Dissolve enum into single defines
+Subject: [PATCH 08/10] Dissolve enum into single defines
 
 ---
  src-api/rfc5444/rfc5444.h | 26 ++++++++++++--------------
@@ -50,4 +50,4 @@ index c5d6420..6b5576e 100644
  EXPORT uint8_t rfc5444_timetlv_get_from_vector(
      uint8_t *vector, size_t vector_length, uint8_t hopcount);
 --
-2.1.2
+1.9.1

--- a/pkg/oonf_api/0009-Add-missing-include.patch
+++ b/pkg/oonf_api/0009-Add-missing-include.patch
@@ -1,7 +1,7 @@
-From 21202804f26b194607a412476a96f03d3df30688 Mon Sep 17 00:00:00 2001
+From 998e5800bedae1d1fb3fddd369ae92ae915ec7fa Mon Sep 17 00:00:00 2001
 From: Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
 Date: Wed, 29 Oct 2014 12:11:29 +0100
-Subject: [PATCH 9/9] Add missing include
+Subject: [PATCH 09/10] Add missing include
 
 ---
  src-api/rfc5444/rfc5444_tlv_writer.h | 1 +
@@ -20,4 +20,4 @@ index ace7313..8d0ce3a 100644
  struct rfc5444_tlv_writer_data {
    uint8_t *buffer;
 --
-2.1.2
+1.9.1

--- a/pkg/oonf_api/0010-Change-index-of-array-from-0-to-1.patch
+++ b/pkg/oonf_api/0010-Change-index-of-array-from-0-to-1.patch
@@ -1,4 +1,4 @@
-From 0ecbb8a8b896ac4aff57d94d678a4a95084a095c Mon Sep 17 00:00:00 2001
+From eef1038b2f96c6e83fad3a2b7beaa0439190d8a6 Mon Sep 17 00:00:00 2001
 From: Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
 Date: Wed, 29 Oct 2014 12:13:27 +0100
 Subject: [PATCH 10/10] Change index of array from 0 to 1
@@ -21,4 +21,4 @@ index d98fe77..7ca75a8 100644
 
  EXPORT struct abuf_template_storage *abuf_template_init (
 --
-2.1.2
+1.9.1


### PR DESCRIPTION
Adapts `oonf_api` to use `posix_sockets` instead of `pnet` (in `pkg/oonf_api/0001-add-RIOT-support.patch`) and updates the following patches accordingly.

~~Depends on #3646~~ (merged) for functionality, but should also compile without it.