### PR TITLE
6lowpan nd: tentative NCE is like no NCE

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -170,9 +170,11 @@ kernel_pid_t gnrc_sixlowpan_nd_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_
         /* get if not gotten from previous check */
         nc_entry = gnrc_ipv6_nc_get(iface, next_hop);
     }
-    /* If a NCE for this destination exist, we can use even for link-local
-     * addresses. This should be only the case for 6LBRs. */
-    if ((ipv6_addr_is_link_local(next_hop)) && (nc_entry == NULL)) {
+    /* If a (non-tentative) NCE for this destination exist, we can use even for
+     * link-local addresses. This should be only the case for 6LBRs. */
+    if ((ipv6_addr_is_link_local(next_hop)) &&
+        ((nc_entry == NULL) ||
+         (gnrc_ipv6_nc_get_type(nc_entry) == GNRC_IPV6_NC_TYPE_TENTATIVE))) {
 /* in case of a border router there is no sensible way for address resolution
  * if the interface is not given */
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER


### PR DESCRIPTION
Amendment to #3846. If the NCE is marked as tentative, we should fall back to usual 6LoWPAN address resolution. Otherwise not even RAs get sent out.