### PR TITLE
samd21: tidy up peripheral clocks and fix potential bugs

### DIFF
--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -83,6 +83,12 @@ static void clk_init(void)
 
     /* make sure we synchronize clock generator 0 before we go on */
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY);
+
+    /* redirect all peripherals to a disabled clock generator (7) by default */
+    for (int i = 0x3; i <= 0x22; i++) {
+        GCLK->CLKCTRL.reg = ( GCLK_CLKCTRL_ID(i) | GCLK_CLKCTRL_GEN_GCLK7 );
+        while (GCLK->STATUS.bit.SYNCBUSY);
+    }
 }
 
 void cpu_init(void)

--- a/cpu/samd21/periph/gpio.c
+++ b/cpu/samd21/periph/gpio.c
@@ -146,7 +146,10 @@ int gpio_init_int(gpio_t pin, gpio_pp_t pullup, gpio_flank_t flank,
     gpio_init_mux(pin, GPIO_MUX_A);
     /* enable clocks for the EIC module */
     PM->APBAMASK.reg |= PM_APBAMASK_EIC;
-    GCLK->CLKCTRL.reg = (EIC_GCLK_ID | GCLK_CLKCTRL_CLKEN);
+    GCLK->CLKCTRL.reg = (EIC_GCLK_ID |
+                         GCLK_CLKCTRL_CLKEN |
+                         GCLK_CLKCTRL_GEN_GCLK0);
+    while (GCLK->STATUS.bit.SYNCBUSY);
     /* configure the active flank */
     EIC->CONFIG[exti >> 3].reg &= ~(0xf << ((exti & 0x7) * 4));
     EIC->CONFIG[exti >> 3].reg |=  (flank << ((exti & 0x7) * 4));

--- a/cpu/samd21/periph/i2c.c
+++ b/cpu/samd21/periph/i2c.c
@@ -102,14 +102,14 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
     PM->APBCMASK.reg |= (PM_APBCMASK_SERCOM0 << (sercom_core - 20));
 
     /* I2C using CLK GEN 0 */
-    GCLK->CLKCTRL.reg = (uint32_t)(GCLK_CLKCTRL_CLKEN
-                                   | GCLK_CLKCTRL_GEN_GCLK0 << GCLK_CLKCTRL_GEN_Pos
-                                   | (sercom_core << GCLK_CLKCTRL_ID_Pos));
+    GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_CLKEN |
+                         GCLK_CLKCTRL_GEN_GCLK0 |
+                         GCLK_CLKCTRL_ID(sercom_core));
     while (GCLK->STATUS.bit.SYNCBUSY);
 
-    GCLK->CLKCTRL.reg = (uint16_t)(GCLK_CLKCTRL_CLKEN
-                                   | GCLK_CLKCTRL_GEN_GCLK0 << GCLK_CLKCTRL_GEN_Pos
-                                   | (sercom_gclk_id_slow << GCLK_CLKCTRL_ID_Pos));
+    GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_CLKEN |
+                         GCLK_CLKCTRL_GEN_GCLK0 |
+                         GCLK_CLKCTRL_ID(sercom_gclk_id_slow));
     while (GCLK->STATUS.bit.SYNCBUSY);
 
 


### PR DESCRIPTION
While revising some clock setups I stumbled upon 2 potential bugs and eliminated some implicit options (`GCLK_CLKCTRL_GEN_GCLK0` evaluates to `0` but it's nice to see it if you don't know).

Additionally I redirect all peripherals to a disabled clock generator at the end of the cpu clock initialization. That saves approx. 1mA while MCU is executing, depending on the enabled peripherals. See [reference](http://atmel.force.com/support/articles/en_US/FAQ/Reducing-power-consumption-of-SAM-D21)