### PR TITLE
core: make core dependency on *printf optional

### DIFF
--- a/core/panic.c
+++ b/core/panic.c
@@ -32,6 +32,7 @@
 #include "panic.h"
 #include "arch/panic_arch.h"
 #include "reboot.h"
+#include "log.h"
 
 #if defined(DEVELHELP) && defined(MODULE_PS)
 #include "ps.h"
@@ -55,18 +56,16 @@ NORETURN void core_panic(core_panic_t crash_code, const char *message)
             cpu_print_last_instruction();
         }
 #endif
-        puts("*** RIOT kernel panic:");
-        puts(message);
-        puts("");
+        LOG_ERROR("*** RIOT kernel panic:\n%s\n\n", message);
 #ifdef DEVELHELP
 #ifdef MODULE_PS
         ps();
-        puts("");
+        LOG_ERROR("\n");
 #endif
 
-        puts("*** halted.\n");
+        LOG_ERROR("*** halted.\n\n");
 #else
-        puts("*** rebooting...\n\n");
+        LOG_ERROR("*** rebooting...\n\n");
 #endif
     }
     /* disable watchdog and all possible sources of interrupts */


### PR DESCRIPTION
We do have the log module in place, but it's true strength shows when it is used everywhere.

This PR replaces all occurences of puts and printf in core *edit* ~~and cortexm_common~~ with LOG_ERROR.

When compiling with ```-DLOG_LEVEL=LOG_NONE```, this saves >4k code and >100b RAM on Cortex-M platforms, bringing the minimal example <3k.