### PR TITLE
USB device stack

### DIFF
--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -23,3 +23,5 @@ PSEUDOMODULES += netif
 # include variants of the AT86RF2xx drivers as pseudo modules
 PSEUDOMODULES += at86rf23%
 PSEUDOMODULES += at86rf21%
+
+PSEUDOMODULES += usbdev-acm

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -37,12 +37,12 @@ extern "C"
 #define KINETIS_MCG_USE_PLL          1
 #define KINETIS_MCG_DCO_RANGE        (24000000U)
 #define KINETIS_MCG_ERC_OSCILLATOR   0
-#define KINETIS_MCG_ERC_FRDIV        6           /* ERC devider = 1280 */
+#define KINETIS_MCG_ERC_FRDIV        7           /* ERC devider = 1536 */
 #define KINETIS_MCG_ERC_RANGE        2
 #define KINETIS_MCG_ERC_FREQ         50000000
 #define KINETIS_MCG_PLL_PRDIV        19          /* divide factor = 20 */
-#define KINETIS_MCG_PLL_VDIV0        0           /* multiply factor = 24 */
-#define KINETIS_MCG_PLL_FREQ         60000000
+#define KINETIS_MCG_PLL_VDIV0        24          /* multiply factor = 48 */
+#define KINETIS_MCG_PLL_FREQ         120000000
 
 #define CLOCK_CORECLOCK              KINETIS_MCG_PLL_FREQ
 /** @} */

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -78,7 +78,12 @@ extern "C"
 * @name UART configuration
 * @{
 */
+#if MODULE_USBDEV
+#define UART_NUMOF                   (2U)
+#define UART_ACM_0_EN                1
+#else
 #define UART_NUMOF                   (1U)
+#endif
 #define UART_0_EN                    1
 #define UART_IRQ_PRIO                1
 #define UART_CLK                     CLOCK_CORECLOCK

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -81,7 +81,12 @@ extern "C"
  * @name UART configuration
  * @{
  */
+#if MODULE_USBDEV
+#define UART_NUMOF          (2U)
+#define UART_ACM_0_EN       1
+#else
 #define UART_NUMOF          (1U)
+#endif
 #define UART_0_EN           1
 #define UART_1_EN           0
 #define UART_IRQ_PRIO       1

--- a/core/include/init.h
+++ b/core/include/init.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  core_util
+ * @{
+ *
+ * @file
+ * @brief       Macros for initialisation of subsystem and drivers
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ */
+
+#ifndef INIT_H_
+#define INIT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define INIT_ORDER_CORE         0
+#define INIT_ORDER_DRIVER       1
+#define INIT_ORDER_SUBMOD       2
+#define INIT_ORDER_MODULE       3
+
+typedef int (*initcall_t)(void);
+
+#define __system_initcall(name, fp, order) static initcall_t __initcall_##fp##order \
+                                           __attribute__((__used__)) \
+                                           __attribute__((section(".preinit_array." #order "." name))) \
+                                           __attribute__((aligned(sizeof(void*)))) = fp
+
+#define core_init(fp) __system_initcall("core", fp, 0)
+
+#define driver_init(fp) __system_initcall("driver", fp, 1)
+
+#define submod_init(fp) __system_initcall("submod", fp, 2)
+
+#define module_init(fp) __system_initcall("module", fp, 3)
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INIT_H_ */
+/** @} */

--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -54,15 +54,18 @@ SECTIONS
         . = ALIGN(4);
         KEEP(*(.init))
         . = ALIGN(4);
-        __preinit_array_start = .;
-        KEEP (*(.preinit_array))
-        __preinit_array_end = .;
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(SORT(.preinit_array.*)))
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
 
         . = ALIGN(4);
-        __init_array_start = .;
-        KEEP (*(SORT(.init_array.*)))
-        KEEP (*(.init_array))
-        __init_array_end = .;
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
 
         . = ALIGN(0x4);
         KEEP (*crtbegin.o(.ctors))
@@ -74,10 +77,11 @@ SECTIONS
         KEEP(*(.fini))
 
         . = ALIGN(4);
-        __fini_array_start = .;
-        KEEP (*(.fini_array))
-        KEEP (*(SORT(.fini_array.*)))
-        __fini_array_end = .;
+        /* fini data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP (*crtbegin.o(.dtors))
         KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))

--- a/cpu/kinetis_common/Makefile.include
+++ b/cpu/kinetis_common/Makefile.include
@@ -7,6 +7,7 @@ export LINKFLAGS += -L$(RIOTCPU)/kinetis_common/ldscripts
 # add the CPU specific code for the linker
 export UNDEF += $(BINDIR)kinetis_common/uart.o
 export UNDEF += $(BINDIR)kinetis_common/fcfield.o
+export UNDEF += $(BINDIR)kinetis_common/usbdev_driver.o
 
 # Define a recipe to build the watchdog disable binary, used when flashing
 $(RIOTCPU)/kinetis_common/dist/wdog-disable.bin: $(RIOTCPU)/kinetis_common/dist/wdog-disable.s

--- a/cpu/kinetis_common/Makefile.include
+++ b/cpu/kinetis_common/Makefile.include
@@ -5,6 +5,7 @@ export INCLUDES += -I$(RIOTCPU)/kinetis_common/include
 export LINKFLAGS += -L$(RIOTCPU)/kinetis_common/ldscripts
 
 # add the CPU specific code for the linker
+export UNDEF += $(BINDIR)kinetis_common/uart.o
 export UNDEF += $(BINDIR)kinetis_common/fcfield.o
 
 # Define a recipe to build the watchdog disable binary, used when flashing

--- a/cpu/kinetis_common/usbdev_driver.c
+++ b/cpu/kinetis_common/usbdev_driver.c
@@ -1,0 +1,537 @@
+/*
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_kinetis_common_usbdev
+ *
+ * @note        This driver only implements USB device mode.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Low-level USB device driver implementation
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "kernel.h"
+#include "msg.h"
+#include "cpu.h"
+#include "init.h"
+#include "board.h"
+
+#include "usbdev.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#define USBDEV_MAX_PACKET_SIZE          64
+
+#ifndef USBDEV_MAX_ENDPOINT_NUM
+#define USBDEV_MAX_ENDPOINT_NUM         16
+#endif
+
+#ifndef USBDEV_EP0_MAX_PACKET
+#define USBDEV_EP0_MAX_PACKET           8
+#endif
+
+#if (USBDEV_MAX_ENDPOINT_NUM > 16)
+#error Kinetis USB Device driver supports maximum 16 endpoints!
+#endif
+
+#define KINETIS_USB_EPIDX_MAX           0x0f
+
+#define BD_IDX_EP0RX_ODD                0
+#define BD_IDX_EP0RX_EVEN               1
+#define BD_IDX_EP0TX_ODD                2
+#define BD_IDX_EP0TX_EVEN               3
+
+#define BD_OWN_MASK                     (1 << 7)
+#define BD_DATA01_MASK                  (1 << 6)
+#define BD_DATA01_SHIFT                 6
+#define BD_KEEP_MASK                    (1 << 5)
+#define BD_NINC_MASK                    (1 << 4)
+#define BD_DTS_MASK                     (1 << 3)
+#define BD_STALL_MASK                   (1 << 2)
+#define BD_TOK_PID_SHIFT                2
+
+#define KINETIS_SETUP_TOKEN             0x0d
+#define KINETIS_IN_TOKEN                0x09
+#define KINETIS_OUT_TOKEN               0x01
+
+#define KINETIS_USB_SUPPORTED_PERID     0x04
+#define KINETIS_USB_SUPPORTED_REV       0x33
+
+usbdev_ops_t kinetis_usb_driver;
+
+typedef struct  __attribute__((packed))
+{
+    uint8_t    stat;
+    uint8_t    reserved;
+    uint16_t   bc;
+    uint32_t   buf_addr;
+} bd_table_t;
+
+bd_table_t __attribute__((aligned(512))) bd_table[(USBDEV_MAX_ENDPOINT_NUM) * 2 * 2];
+
+uint8_t __attribute__((aligned(4))) ep0_buf[4][USBDEV_EP0_MAX_PACKET];
+
+uint8_t ep_out_size[USBDEV_MAX_ENDPOINT_NUM];
+
+uint32_t toggle_bits = 0;
+
+inline static uint8_t get_bdt_idx(uint8_t ep, uint8_t even)
+{
+    if (ep & ENDPOINT_IN_MASK) {
+        return ((((ENDPOINT_NUM(ep)) * 4) + 2  + (even & 1)));
+    }
+    return ((((ENDPOINT_NUM(ep)) * 4) + (even & 1)));
+}
+
+inline static uint8_t get_token_pid(uint8_t idx)
+{
+    return (bd_table[idx].stat >> BD_TOK_PID_SHIFT) & 0x0f;
+}
+
+inline static void protected_and(uint32_t *addr, uint32_t val)
+{
+    while (__STREXW((__LDREXW(addr) & val), addr));
+}
+
+inline static void protected_or(uint32_t *addr, uint32_t val)
+{
+    while (__STREXW((__LDREXW(addr) | val), addr));
+}
+
+inline static void protected_xor(uint32_t *addr, uint32_t val)
+{
+    while (__STREXW((__LDREXW(addr) ^ val), addr));
+}
+
+inline static void kinetis_usb_init_clock(void)
+{
+    SIM->SCGC4 |= SIM_SCGC4_USBOTG_MASK;
+}
+
+usbdev_ops_t* kinetis_usb_init(usbdev_t *dev)
+{
+    ep_out_size[0] = USBDEV_EP0_MAX_PACKET;
+
+    kinetis_usb_init_clock();
+
+    SIM->SOPT1 |= SIM_SOPT1_USBREGEN_MASK;
+    /* USB0->USBTRC0 |= 0x40; */
+
+    USB0->USBTRC0 |= USB_USBTRC0_USBRESET_MASK;
+    __ASM volatile ("nop");
+    __ASM volatile ("nop");
+    __ASM volatile ("nop");
+
+    USB0->CTL = 0;
+    /* enable USB module, AKA USBEN bit in CTL1 register */
+    USB0->CTL |= USB_CTL_USBENSOFEN_MASK;
+
+    if ((USB0->PERID != KINETIS_USB_SUPPORTED_PERID) ||
+	(USB0->REV !=KINETIS_USB_SUPPORTED_REV)) {
+        return NULL;
+    }
+
+    USB0->BDTPAGE1 = (uint8_t)((uint32_t) bd_table >> 8);
+    USB0->BDTPAGE2 = (uint8_t)((uint32_t) bd_table >> 16);
+    USB0->BDTPAGE3 = (uint8_t)((uint32_t) bd_table >> 24);
+
+    /* clear interrupt flags */
+    USB0->ISTAT = 0xFF;
+
+    /* enable interrupts */
+    USB0->INTEN = USB_INTEN_USBRSTEN_MASK;
+
+    USB0->USBCTRL = USB_USBCTRL_PDE_MASK;
+
+    NVIC_EnableIRQ(USB0_IRQn);
+
+    kinetis_usb_driver.dev = dev;
+
+    return &kinetis_usb_driver;
+}
+
+static inline void kinetis_usb_set_data1(uint8_t idx)
+{
+    protected_or(&toggle_bits, (1 << (idx / 2)));
+}
+
+static inline void kinetis_usb_clr_data1(uint8_t idx)
+{
+    protected_and(&toggle_bits, ~(1 << (idx / 2)));
+}
+
+static inline void kinetis_usb_toggle_data1(uint8_t idx)
+{
+    protected_xor(&toggle_bits, (1 << (idx / 2)));
+}
+
+static inline uint8_t kinetis_usb_get_data1(uint8_t idx)
+{
+    return (uint8_t)((toggle_bits >> (idx / 2)) & 1);
+}
+
+static inline int kinetis_usb_set_ep_enable(usb_ep_t ep)
+{
+    if (ep & ENDPOINT_IN_MASK) {
+        USB0->ENDPOINT[ENDPOINT_NUM(ep)].ENDPT |= USB_ENDPT_EPTXEN_MASK;
+    }
+    else {
+        USB0->ENDPOINT[ENDPOINT_NUM(ep)].ENDPT |= USB_ENDPT_EPRXEN_MASK;
+    }
+
+    /* enable handshaking */
+    USB0->ENDPOINT[ENDPOINT_NUM(ep)].ENDPT |= USB_ENDPT_EPHSHK_MASK;
+
+    return 0;
+}
+
+static inline int kinetis_usb_set_ep_disable(usb_ep_t ep)
+{
+    USB0->ENDPOINT[ENDPOINT_NUM(ep)].ENDPT &= ~(USB_ENDPT_EPHSHK_MASK |
+                                                USB_ENDPT_EPTXEN_MASK |
+                                                USB_ENDPT_EPRXEN_MASK);
+    return 0;
+}
+
+static inline int kinetis_usb_set_ep_reset(usb_ep_t ep)
+{
+    uint8_t idx_odd = get_bdt_idx(ep, 0);
+
+    if (ep & ENDPOINT_IN_MASK) {
+        kinetis_usb_clr_data1(idx_odd);
+        bd_table[idx_odd].stat = 0;
+    }
+    else {
+        kinetis_usb_clr_data1(idx_odd);
+        bd_table[idx_odd].stat = BD_OWN_MASK | BD_DTS_MASK;
+    }
+    return 0;
+}
+
+static inline int kinetis_usb_set_ep_stall(usb_ep_t ep)
+{
+    USB0->ENDPOINT[ENDPOINT_NUM(ep)].ENDPT |= USB_ENDPT_EPSTALL_MASK;
+    return 0;
+}
+
+static inline int kinetis_usb_set_ep_clr_stall(usb_ep_t ep)
+{
+    USB0->ENDPOINT[ENDPOINT_NUM(ep)].ENDPT &= ~USB_ENDPT_EPSTALL_MASK;
+    kinetis_usb_set_ep_reset(ep);
+    return 0;
+}
+
+static inline void kinetis_usb_disable_all_eps(void)
+{
+    for (uint8_t i = 0; i < 16; i++) {
+        USB0->ENDPOINT[i].ENDPT = 0;
+    }
+    memset(bd_table, 0, sizeof(bd_table));
+
+    toggle_bits = 0;
+}
+
+static inline int kinetis_usb_set_reset(void)
+{
+    kinetis_usb_disable_all_eps();
+    /* TODO add free for ep buffers */
+    
+    /* configure BDT for ep0 */
+    bd_table[BD_IDX_EP0RX_ODD].bc = USBDEV_EP0_MAX_PACKET;
+    bd_table[BD_IDX_EP0RX_ODD].buf_addr = (uint32_t)(&(ep0_buf[BD_IDX_EP0RX_ODD][0]));
+    bd_table[BD_IDX_EP0RX_ODD].stat = BD_OWN_MASK | BD_DTS_MASK;
+    bd_table[BD_IDX_EP0RX_EVEN].stat = 0;
+
+    bd_table[BD_IDX_EP0TX_ODD].buf_addr = (uint32_t)(&(ep0_buf[BD_IDX_EP0TX_ODD][0]));
+    bd_table[BD_IDX_EP0TX_EVEN].buf_addr = 0;
+
+    /* enable ep0 */
+    USB0->ENDPOINT[0].ENDPT = USB_ENDPT_EPHSHK_MASK
+                            | USB_ENDPT_EPTXEN_MASK
+                            | USB_ENDPT_EPRXEN_MASK;
+
+    /* set all BDT ODDs to 1, which then specifies the ODD BDT bank (single buffer mode) */
+    USB0->CTL |= USB_CTL_ODDRST_MASK;
+
+    /* clear interrupt status flags */
+    USB0->ISTAT   =  0xFF;
+    /* clear error flags */
+    USB0->ERRSTAT =  0xFF;
+    /* enable all error interrupt sources */
+    USB0->ERREN   =  0xFF;
+    /* set default address */
+    USB0->ADDR    =  0x00;
+
+    USB0->INTEN = USB_INTEN_USBRSTEN_MASK |
+                  USB_INTEN_TOKDNEEN_MASK |
+                  USB_INTEN_SLEEPEN_MASK  |
+                  USB_INTEN_SOFTOKEN_MASK |
+                  USB_INTEN_ERROREN_MASK;
+
+    return 0;
+}
+
+static inline int kinetis_usb_set_connect(void)
+{
+    /* non-OTG device mode, enable DP Pullup */
+    USB0->CONTROL = USB_CONTROL_DPPULLUPNONOTG_MASK;
+    /* enable USB module, AKA USBEN bit in CTL1 register */
+    //USB0->CTL  |= USB_CTL_USBENSOFEN_MASK;
+    return 0;
+}
+
+static inline int kinetis_usb_set_disconnect(void)
+{
+    /* disable USB and DP Pullup */
+    USB0->CTL  &= ~USB_CTL_USBENSOFEN_MASK;
+    USB0->CONTROL &= ~USB_CONTROL_DPPULLUPNONOTG_MASK;
+    return 0;
+}
+
+static inline void kinetis_usb_enable_resume(void)
+{
+    USB0->INTEN |= USB_INTEN_RESUMEEN_MASK;
+}
+
+static inline void kinetis_usb_disable_resume(void)
+{
+    USB0->INTEN &= ~USB_INTEN_RESUMEEN_MASK;
+}
+
+int kinetis_set_address(uint8_t address)
+{
+    USB0->ADDR = address & 0x7f;
+    return 0;
+}
+
+int kinetis_configure_ep(usb_ep_t ep, size_t size)
+{
+    uint8_t idx_odd = get_bdt_idx(ep, 0);
+    uint8_t idx_even = get_bdt_idx(ep, 1);
+
+    if (size > USBDEV_MAX_PACKET_SIZE) {
+        return -ENOMEM;
+    }
+
+    ep_out_size[ENDPOINT_NUM(ep)] = size;
+    bd_table[idx_odd].bc = size;
+    bd_table[idx_odd].buf_addr = (uint32_t)malloc(size);
+    bd_table[idx_even].buf_addr = 0;
+
+    return kinetis_usb_set_ep_reset(ep);
+}
+
+int kinetis_set_toggle_bit(usb_ep_t ep)
+{
+    uint8_t idx_odd = get_bdt_idx(ep, 0);
+
+    kinetis_usb_set_data1(idx_odd);
+    return 0;
+}
+
+int kinetis_clr_toggle_bit(usb_ep_t ep)
+{
+    uint8_t idx_odd = get_bdt_idx(ep, 0);
+
+    kinetis_usb_clr_data1(idx_odd);
+    return 0;
+}
+
+int kinetis_read_ep(usb_ep_t ep, uint8_t *data, size_t size)
+{
+    ep &= ~ENDPOINT_IN_MASK;
+    uint8_t idx_odd = get_bdt_idx(ep, 0);
+    size_t sz  = bd_table[idx_odd].bc;
+    uint8_t *bufp = (uint8_t*)bd_table[idx_odd].buf_addr;
+
+    if (sz > size) {
+        sz = size;
+    }
+
+    for (uint32_t i = 0; i < sz; i++) {
+        data[i] = bufp[i];
+    }
+
+    /* Update next toggle bit */
+    kinetis_usb_toggle_data1(idx_odd);
+
+    /* Reset buffer descriptor data and fields, set next toggle bit  */
+    bd_table[idx_odd].bc = ep_out_size[ENDPOINT_NUM(ep)];
+    if (kinetis_usb_get_data1(idx_odd)) {
+        bd_table[idx_odd].stat = BD_DTS_MASK | BD_DATA01_MASK;
+    }
+    else {
+        bd_table[idx_odd].stat = BD_DTS_MASK;
+    }
+    bd_table[idx_odd].stat |= BD_OWN_MASK;
+
+    /* Resume TX toke processing, see USBx_CTL field descriptions */
+    USB0->CTL &= ~USB_CTL_TXSUSPENDTOKENBUSY_MASK;
+
+    return sz;
+}
+
+int kinetis_write_ep(usb_ep_t ep, uint8_t *data, size_t data_len)
+{
+    uint8_t idx_odd = get_bdt_idx(ep, 0);
+    uint8_t *bufp = (uint8_t*)bd_table[idx_odd].buf_addr;
+
+    while (bd_table[idx_odd].stat & BD_OWN_MASK) {
+        LED_R_TOGGLE;
+    }
+
+    bd_table[idx_odd].bc = data_len;
+
+    for (uint32_t n = 0; n < data_len; n++) {
+        bufp[n] = data[n];
+    }
+
+    if (kinetis_usb_get_data1(idx_odd)) {
+        bd_table[idx_odd].stat = BD_DTS_MASK | BD_DATA01_MASK;
+    }
+    else {
+        bd_table[idx_odd].stat = BD_DTS_MASK;
+    }
+
+    bd_table[idx_odd].stat |= BD_OWN_MASK;
+
+    kinetis_usb_toggle_data1(idx_odd);
+
+    return data_len;
+}
+
+int kinetis_usb_ioctl(usbdev_cmd_t cmd, uint32_t arg)
+{
+    switch (cmd) {
+        case USBDEV_SET_CONNECT:
+            return kinetis_usb_set_connect();
+        case USBDEV_SET_DISCONNECT:
+            return kinetis_usb_set_disconnect();
+        case USBDEV_SET_ADDRESS:
+            return kinetis_set_address(arg);
+        case USBDEV_OPT_EP_RESET:
+            return kinetis_usb_set_ep_reset(arg);
+        case USBDEV_SET_EP_ENABLE:
+            return kinetis_usb_set_ep_enable(arg);
+        case USBDEV_SET_EP_DISABLE:
+            return kinetis_usb_set_ep_disable(arg);
+        case USBDEV_SET_EP_STALL:
+            return kinetis_usb_set_ep_stall(arg);
+        case USBDEV_SET_EP_CLR_STALL:
+            return kinetis_usb_set_ep_clr_stall(arg);
+        default:
+            return -ENOTSUP;
+    }
+}
+
+void isr_usb0(void)
+{
+    uint32_t istatus  = USB0->ISTAT;
+    uint32_t status  = USB0->STAT;
+
+    /* clear interrupt status bits */
+    USB0->ISTAT = istatus;
+    
+    if (istatus & USB_ISTAT_USBRST_MASK) {
+        kinetis_usb_set_reset();
+        kinetis_usb_driver.dev->irq_ep_event(kinetis_usb_driver.dev,
+                                             USBDEV_CTRL_EP, USBDEV_EVENT_RESET);
+        kinetis_usb_driver.dev->irq_bc_event(kinetis_usb_driver.dev,
+                                              USBDEV_EVENT_RESET);
+    }
+
+    if (istatus == USB_ISTAT_ERROR_MASK) {
+        USB0->ERRSTAT = 0xFF;
+        kinetis_usb_driver.dev->irq_ep_event(kinetis_usb_driver.dev,
+                                             USBDEV_CTRL_EP, USBDEV_EVENT_ERROR);
+    }
+
+    if (istatus & USB_ISTAT_SOFTOK_MASK) {
+        kinetis_usb_driver.dev->irq_bc_event(kinetis_usb_driver.dev,
+                                              USBDEV_EVENT_SOF);
+    }
+
+    if (istatus & USB_ISTAT_TOKDNE_MASK) {
+
+        uint32_t ep_num = status >> USB_STAT_ENDP_SHIFT;
+        usb_ep_t ep = ((status << 4) & ENDPOINT_IN_MASK) | ep_num;
+        uint8_t idx_odd = get_bdt_idx(ep, 0);
+        uint8_t token_pid = get_token_pid(idx_odd);
+
+        switch (token_pid) {
+            case KINETIS_SETUP_TOKEN:
+                kinetis_usb_driver.dev->irq_ep_event(kinetis_usb_driver.dev,
+                                                     USBDEV_CTRL_EP, USBDEV_EVENT_SETUP);
+                break;
+
+            case KINETIS_OUT_TOKEN:
+                kinetis_usb_driver.dev->irq_ep_event(kinetis_usb_driver.dev,
+                                                     ep, USBDEV_EVENT_OUT);
+                break;
+
+            case KINETIS_IN_TOKEN:
+                kinetis_usb_driver.dev->irq_ep_event(kinetis_usb_driver.dev,
+                                                     ep, USBDEV_EVENT_IN);
+                break;
+            default:
+                break;
+        }
+    }
+
+    if (istatus & USB_ISTAT_SLEEP_MASK) {
+        kinetis_usb_enable_resume();
+        kinetis_usb_driver.dev->irq_ep_event(kinetis_usb_driver.dev,
+                                             USBDEV_CTRL_EP, USBDEV_EVENT_SUSPEND);
+    }
+
+    if (istatus & USB_ISTAT_RESUME_MASK) {
+        kinetis_usb_disable_resume();
+        kinetis_usb_driver.dev->irq_ep_event(kinetis_usb_driver.dev,
+                                             USBDEV_CTRL_EP, USBDEV_EVENT_RESUME);
+    }
+
+    /*
+    if (istatus & USB_ISTAT_STALL_MASK) {
+        kinetis_usb_driver.dev->irq_bc_event(kinetis_usb_driver.dev,
+                                              USBDEV_EVENT_STALL);
+    }
+    */
+
+    if (sched_context_switch_request) {
+        thread_yield();
+    }
+}
+
+/* implementation of the usbdev driver interface */
+usbdev_ops_t kinetis_usb_driver = {
+    .dev = NULL,
+    .configure_ep = kinetis_configure_ep,
+    .set_ep_toggle_bit = kinetis_set_toggle_bit,
+    .clr_ep_toggle_bit = kinetis_clr_toggle_bit,
+    .write_ep = kinetis_write_ep,
+    .read_ep = kinetis_read_ep,
+    .ioctl = kinetis_usb_ioctl,
+};
+
+int kinetis_usb_register(void)
+{
+    usbdev_register_driver(kinetis_usb_init);
+    return 0;
+}
+
+driver_init(kinetis_usb_register);

--- a/cpu/kw2x/cpu.c
+++ b/cpu/kw2x/cpu.c
@@ -73,4 +73,15 @@ static void cpu_clock_init(void)
 
     modem_clock_init();
     kinetis_mcg_set_mode(KINETIS_MCG_PEE);
+
+    /*
+     * Setup USBFSOTG clock
+     * USB clock should be 48 MHz, use MCGPLLCLK as clock source
+     * usb_clk = (pll_clk * 1 / 1) = 48MHz * 1 / 1 = 48MHz
+     */
+#if MODULE_USBDEV
+    SIM->SOPT2 &= ~(SIM_SOPT2_USBSRC_MASK | SIM_SOPT2_PLLFLLSEL_MASK);
+    SIM->SOPT2 |= SIM_SOPT2_USBSRC_MASK | SIM_SOPT2_PLLFLLSEL_MASK;
+    SIM->CLKDIV2 = 0;
+#endif
 }

--- a/drivers/include/periph/dev_enums.h
+++ b/drivers/include/periph/dev_enums.h
@@ -195,6 +195,12 @@ enum {
 #if UART_6_EN
     UART_6,                 /**< UART 6 */
 #endif
+#if UART_ACM_0_EN
+    UART_ACM_0,             /**< UART 0 over USB */
+#endif
+#if UART_ACM_1_EN
+    UART_ACM_1,             /**< UART 1 over USB */
+#endif
     UART_UNDEFINED          /**< Deprecated symbol, use UART_UNDEF instead */
 };
 

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -138,6 +138,25 @@ void uart_poweron(uart_t uart);
  */
 void uart_poweroff(uart_t uart);
 
+/**
+ * @brief   uart device extended API definition.
+ *
+ * @details This is a set of functions that must be implemented by any driver.
+ */
+typedef struct {
+    uart_t dev;
+
+    int (*uart_init)(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg);
+
+    void (*uart_write)(uart_t uart, const uint8_t *data, size_t len);
+
+    void (*uart_poweron)(uart_t uart);
+
+    void (*uart_poweroff)(uart_t uart);
+} uartdev_ops_t;
+
+int uartdev_register_driver(uartdev_ops_t *uart_ops);
+
 #ifdef __cplusplus
 }
 #endif

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -2,7 +2,7 @@
 APPLICATION = gnrc_border_router
 
 # If no BOARD is found in the environment, use this default:
-BOARD ?= samr21-xpro
+BOARD ?= pba-d-01-kw2x
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
@@ -42,6 +42,9 @@ USEMODULE += gnrc_icmpv6_echo
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
+USEMODULE += uart
+USEMODULE += usbdev
+USEMODULE += usbdev-acm
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -75,6 +75,10 @@ ifneq (,$(filter sem,$(USEMODULE)))
     DIRS += sem
 endif
 
+ifneq (,$(filter uart,$(USEMODULE)))
+    DIRS += uart
+endif
+
 DIRS += $(dir $(wildcard $(addsuffix /Makefile, ${USEMODULE})))
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -65,4 +65,11 @@ ifneq (,$(filter newlib,$(USEMODULE)))
     include $(RIOTBASE)/sys/newlib/Makefile.include
 endif
 
+ifneq (,$(filter usbdev,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/sys/usbdev/include
+    ifneq (,$(filter usbdev-acm,$(USEMODULE)))
+        export UNDEF += $(BINDIR)usbdev/usbdev_acm.o
+    endif
+endif
+
 INCLUDES += -I$(RIOTBASE)/sys/libc/include

--- a/sys/uart/Makefile
+++ b/sys/uart/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/uart/uart.c
+++ b/sys/uart/uart.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    driver_periph_extended_uart UART
+ * @ingroup     driver_periph
+ * @brief       Low-level extended UART peripheral driver
+ *
+ * @{
+ *
+ * @file
+ * @brief       Low-level UART driver implementation
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "periph/uart.h"
+
+
+static uartdev_ops_t *uartdev_lt[UART_NUMOF];
+
+int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
+{
+    if (uartdev_lt[uart]) {
+       return uartdev_lt[uart]->uart_init(uart, baudrate, rx_cb, arg);
+    }
+    return -1;
+}
+
+void uart_write(uart_t uart, const uint8_t *data, size_t len)
+{
+    if (uartdev_lt[uart]) {
+        uartdev_lt[uart]->uart_write(uart, data, len);
+    }
+}
+
+void uart_poweron(uart_t uart)
+{
+    if (uartdev_lt[uart]) {
+        uartdev_lt[uart]->uart_poweron(uart);
+    }
+}
+
+
+void uart_poweroff(uart_t uart)
+{
+    if (uartdev_lt[uart]) {
+        uartdev_lt[uart]->uart_poweroff(uart);
+    }
+}
+
+
+int uartdev_register_driver(uartdev_ops_t *uart_ops)
+{
+    if (uart_ops->dev > UART_NUMOF) {
+        return -1;
+    }
+
+    if (uartdev_lt[uart_ops->dev] == NULL) {
+        uartdev_lt[uart_ops->dev] = uart_ops;
+        return 0;
+    }
+    return -1;
+}

--- a/sys/usbdev/Makefile
+++ b/sys/usbdev/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/usbdev/include/usb_datatypes.h
+++ b/sys/usbdev/include/usb_datatypes.h
@@ -1,0 +1,502 @@
+/*
+ * Copyright (C) 2015 Phytec Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     usbdev_stack
+ * @{
+ *
+ * @file
+ * @brief       Data types for the USB device stack
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ */
+
+#ifndef USB_DATATYPES_H
+#define USB_DATATYPES_H
+
+#include <stdint.h>
+
+/* --- USB Common Descriptors and Codes --- */
+
+/**
+ * @brief USB Device Requests
+ * Request data transfer direction
+ * @note usb_20.pdf, 9.3, Table 9-2
+ */
+#define REQUEST_HOST_TO_DEVICE          0
+#define REQUEST_DEVICE_TO_HOST          1
+#define REQUEST_DIR_SHIFT               7
+#define REQUEST_DIR_MASK                1
+#define REQUEST_DIR(request)            (((request) >> REQUEST_DIR_SHIFT) & REQUEST_DIR_MASK)
+
+/**
+ * @brief USB Device Requests
+ * Request Type
+ * @note usb_20.pdf, 9.3, Table 9-2
+ */
+#define REQUEST_STANDARD                0
+#define REQUEST_CLASS                   1
+#define REQUEST_VENDOR                  2
+#define REQUEST_RESERVED                3
+#define REQUEST_TYPE_SHIFT              5
+#define REQUEST_TYPE_MASK               3
+#define REQUEST_TYPE(request)           (((request) >> REQUEST_TYPE_SHIFT) & REQUEST_TYPE_MASK)
+
+/**
+ * @brief USB Device Requests
+ * Request Recipient
+ * @note usb_20.pdf, 9.3, Table 9-2
+ */
+#define REQUEST_TO_DEVICE               0
+#define REQUEST_TO_INTERFACE            1
+#define REQUEST_TO_ENDPOINT             2
+#define REQUEST_TO_OTHER                3
+#define REQUEST_RECIPIENT_SHIFT         0
+#define REQUEST_RECIPIENT_MASK          0x1f
+#define REQUEST_RECIPIENT(request)      ((request) & REQUEST_RECIPIENT_MASK)
+
+/**
+ * @brief Standard Request Codes
+ * @note usb_20.pdf, 9.3, Table 9-4
+ */
+#define REQUEST_GET_STATUS              0
+#define REQUEST_CLEAR_FEATURE           1
+#define REQUEST_RESERVED_2              2
+#define REQUEST_SET_FEATURE             3
+#define REQUEST_RESERVED_4              4
+#define REQUEST_SET_ADDRESS             5
+#define REQUEST_GET_DESCRIPTOR          6
+#define REQUEST_SET_DESCRIPTOR          7
+#define REQUEST_GET_CONFIGURATION       8
+#define REQUEST_SET_CONFIGURATION       9
+#define REQUEST_GET_INTERFACE           10
+#define REQUEST_SET_INTERFACE           11
+#define REQUEST_SYNC_FRAME              12
+#define REQUEST_RESERVED_13             13
+#define REQUEST_RESERVED_14             14
+#define REQUEST_RESERVED_15             15
+
+/**
+ * @brief Information Returned by a GetStatus Request
+ * @note usb_20.pdf, 9.4.4, Figure 9-4, Figure 9-6
+ */
+/* USB GET_STATUS Bit Values */
+#define DEVICE_STATUS_SELF_POWERED      1
+#define DEVICE_STATUS_REMOTE_WAKEUP     2
+#define ENDPOINT_STATUS_ENDPOINT_HALT   1
+
+/**
+ * @brief Standard Feature Selectors
+ * @note usb_20.pdf, 9.4.1, Table 9-6
+ */
+#define FEATURE_ENDPOINT_HALT           0
+#define FEATURE_DEVICE_REMOTE_WAKEUP    1
+#define FEATURE_TEST_MODE               2
+
+#define REQUEST_TO_HOST(type, recipient)    (REQUEST_DIR_MASK | \
+                                            (((type) & REQUEST_DIR_MASK) << REQUEST_TYPE_SHIFT) | \
+                                            ((recipient) & REQUEST_RECIPIENT_MASK))
+
+/**
+ * @brief USB Device Requests
+ * Format of Setup Data
+ * @note usb_20.pdf, 9.3, Table 9-2
+ */
+typedef struct __attribute__((packed))
+{
+    uint8_t bmRequestType;
+    uint8_t bRequest;
+    __attribute__((packed)) union {
+        uint16_t wValue;
+        __attribute__((packed)) struct {
+            uint8_t wValueL;
+            uint8_t wValueH;
+        };
+    };
+   __attribute__((packed)) union {
+        uint16_t wIndex;
+        __attribute__((packed)) struct {
+            uint8_t wIndexL;
+            uint8_t wIndexH;
+        };
+    };
+    uint16_t wLength;
+} usb_device_request_t;
+
+
+/**
+ * @brief Descriptor Types
+ * @note usb_20.pdf, 9.4, Table 9-5
+ */
+#define DESCRIPTOR_TYPE_DEVICE                  1
+#define DESCRIPTOR_TYPE_CONFIGURATION           2
+#define DESCRIPTOR_TYPE_STRING                  3
+#define DESCRIPTOR_TYPE_INTERFACE               4
+#define DESCRIPTOR_TYPE_ENDPOINT                5
+#define DESCRIPTOR_TYPE_DEVICE_QUALIFIER        6
+#define DESCRIPTOR_TYPE_OTHER_SPEED_CONFIG      7
+#define DESCRIPTOR_TYPE_INTERFACE_POWER         8
+#define DESCRIPTOR_TYPE_OTG                     9
+#define DESCRIPTOR_TYPE_DEBUG                   10
+
+/**
+ * @brief Generic Device Descriptor
+ */
+typedef struct __attribute__((packed))
+{
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+}
+usb_generic_descriptor_t;
+
+/**
+ * @brief Standard Device Descriptor
+ * @note PSTN120.pdf, 9.6, Table 9-8
+ */
+typedef struct __attribute__((packed))
+{
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint16_t bcdUSB;
+    uint8_t bDeviceClass;
+    uint8_t bDeviceSubClass;
+    uint8_t bDeviceProtocol;
+    uint8_t bMaxPacketSize0;
+    uint16_t idVendor;
+    uint16_t idProduct;
+    uint16_t bcdDevice;
+    uint8_t iManufacturer;
+    uint8_t iProduct;
+    uint8_t iSerialNumber;
+    uint8_t bNumConfigurations;
+}
+usb_device_descriptor_t;
+
+/**
+ * @brief Standard Configuration Descriptor
+ * @note PSTN120.pdf, 9.6, Table 9-10
+ * Configuration characteristics
+ */
+#define CONFIG_BUS_POWERED                      (1 << 7)
+#define CONFIG_SELF_POWERED                     (1 << 7 | 1 << 6)
+#define CONFIG_SELF_POWERED_MASK                (1 << 6)
+#define CONFIG_REMOTE_WAKEUP                    (1 << 7 | 1 << 5)
+#define CONFIG_REMOTE_WAKEUP_MASK               (1 << 5)
+
+/**
+ * @brief Standard Configuration Descriptor
+ * @note PSTN120.pdf, 9.6, Table 9-10
+ * Maximum power consumption
+ * Expressed in 2 mA units (e.g. 50 = 100 mA).
+ */
+#define CONFIG_POWER_MA(p)                      ((p)/2)
+
+/**
+ * @brief Standard Configuration Descriptor
+ * @note PSTN120.pdf, 9.6, Table 9-10
+ */
+typedef struct __attribute__((packed))
+{
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint16_t wTotalLength;
+    uint8_t bNumInterfaces;
+    uint8_t bConfigurationValue;
+    uint8_t iConfiguration;
+    uint8_t bmAttributes;
+    uint8_t bMaxPower;
+}
+usb_cfg_descriptor_t;
+
+/**
+ * @brief Standard Interface Descriptor
+ * @note PSTN120.pdf, 9.6, Table 9-12
+ */
+typedef struct __attribute__((packed))
+{
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint8_t bInterfaceNumber;
+    uint8_t bAlternateSetting;
+    uint8_t bNumEndpoints;
+    uint8_t bInterfaceClass;
+    uint8_t bInterfaceSubClass;
+    uint8_t bInterfaceProtocol;
+    uint8_t iInterface;
+}
+usb_if_descriptor_t;
+
+/**
+ * @brief Standard Endpoint Descriptor
+ * @note PSTN120.pdf, 9.6, Table 9-13
+ * bEndpointAddress description
+ */
+#define ENDPOINT_ADDR_DIRECTION_MASK            (1 << 7)
+#define ENDPOINT_IN_MASK                        (1 << 7)
+#define ENDPOINT_NUMBER_MASK                    0xf
+
+#define ENDPOINT_ADDR_OUT(num)                  ((num) & ENDPOINT_NUMBER_MASK)
+#define ENDPOINT_ADDR_IN(num)                   (((num) & ENDPOINT_NUMBER_MASK) \
+                                                | ENDPOINT_ADDR_DIRECTION_MASK)
+#define ENDPOINT_ADDR(n)                        ((n) & (ENDPOINT_ADDR_DIRECTION_MASK \
+                                                | ENDPOINT_NUMBER_MASK))
+#define ENDPOINT_NUM(addr)                      ((addr) & (ENDPOINT_NUMBER_MASK))
+
+/**
+ * @brief Standard Endpoint Descriptor
+ * @note PSTN120.pdf, 9.6, Table 9-13
+ * bmAttributes description
+ */
+#define ENDPOINT_TRANSFER_TYPE_CONTROL          (0 << 0)
+#define ENDPOINT_TRANSFER_TYPE_ISOCHRONOUS      (1 << 0)
+#define ENDPOINT_TRANSFER_TYPE_BULK             (2 << 0)
+#define ENDPOINT_TRANSFER_TYPE_INTERRUPT        (3 << 0)
+#define ENDPOINT_SYNC_TYPE_NO_SYNCHRONIZATION   (0 << 2)
+#define ENDPOINT_SYNC_TYPE_ASYNCHRONOUS         (1 << 2)
+#define ENDPOINT_SYNC_TYPE_ADAPTIVE             (2 << 2)
+#define ENDPOINT_SYNC_TYPE_SYNCHRONOUS          (3 << 2)
+#define ENDPOINT_USAGE_TYPE_DATA                (0 << 4)
+#define ENDPOINT_USAGE_TYPE_FEEDBACK            (1 << 4)
+#define ENDPOINT_USAGE_TYPE_IMPLICIT_FEEDBACK   (2 << 4)
+
+/**
+ * @brief Standard Endpoint Descriptor
+ * @note PSTN120.pdf, 9.6, Table 9-13
+ */
+typedef struct __attribute__((packed))
+{
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint8_t bEndpointAddress;
+    uint8_t bmAttributes;
+    uint16_t wMaxPacketSize;
+    uint8_t bInterval;
+}
+usb_ep_descriptor_t;
+
+/**
+ * @brief UNICODE String Descriptor
+ * @note PSTN120.pdf, 9.7, Table 9-16
+ */
+typedef struct __attribute__((packed))
+{
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint16_t bString;
+}
+usb_string_descriptor_t;
+
+
+
+/* --- CDC Functional Descriptors and Codes --- */
+
+/**
+ * @brief Communications Devices Specification release number in BCD format.
+ */
+#define CDC_SRN_1_20                    0x0120
+
+/**
+ * @brief Communications Device Class Code
+ * @note CDC120-20101103-track.pdf, 4.2, Table 2
+ */
+#define COMMUNICATION_DEVICE_CLASS      0x02
+
+/**
+ * @brief Communications Interface Class Code
+ * @note CDC120-20101103-track.pdf, 4.2, Table 3
+ */
+#define COMMUNICATION_INTERFACE_CLASS   0x02
+
+/**
+ * @brief Communications Class Subclass Codes
+ * @note CDC120-20101103-track.pdf, 4.2, Table 4
+ */
+#define DIRECT_LINE_CONTROL_MODEL       0x01
+#define ABSTRACT_CONTROL_MODEL          0x02
+#define TELEPHONE_CONTROL_MODEL         0x03
+
+/**
+ * @brief Values for the bDescriptorType Field
+ * @note CDC120-20101103-track.pdf, 5.2.3, Table 12
+ */
+#define CS_INTERFACE                    0x24
+#define CS_ENDPOINT                     0x25
+
+/**
+ * @brief bDescriptor SubType in Communications Class Functional Descriptors
+ * @note CDC120-20101103-track.pdf, 5.2.3, Table 13
+ */
+#define HEADER_FUNC_DESCRIPTOR                      0x00
+#define CALL_MANAGEMENT_FUNC_DESCRIPTOR             0x01
+#define ABSTRACT_CONTROL_MANAGEMENT_FUNC_DESCRIPTOR 0x02
+#define UNION_FUNC_DESCRIPTOR                       0x06
+
+/**
+ * @brief Data Class Interface Codes
+ * @note PSTN120.pdf, 4.5, Table 6
+ */
+#define DATA_INTERFACE_CLASS            0x0A
+
+/**
+ * @brief Header Functional Descriptor
+ * CDC120-20101103-track.pdf, 5.2.3.1
+ */
+typedef struct __attribute__((packed))
+{
+    uint8_t bFunctionLength;
+    uint8_t bDescriptorType;
+    uint8_t bDescriptorSubtype;
+    uint16_t bcdCDC;
+}
+cdc_header_descriptor_t;
+
+/**
+ * @brief Union Interface Functional Descriptor
+ * @note CDC120-20101103-track.pdf, 5.2.3.2
+ */
+typedef struct __attribute__((packed))
+{
+    uint8_t bFunctionLength;
+    uint8_t bDescriptorType;            /**< CS_INTERFACE */
+    uint8_t bDescriptorSubtype;
+    uint8_t bControlInterface;
+    uint8_t bSubordinateInterface0;
+}
+cdc_union_descriptor_t;
+
+/**
+ * @brief Call Management Functional Descriptor
+ * @note PSTN120.pdf, 5.3.1
+ */
+typedef struct __attribute__((packed))
+{
+    uint8_t bFunctionLength;
+    uint8_t bDescriptorType;            /**< CS_INTERFACE */
+    uint8_t bDescriptorSubtype;
+    uint8_t bmCapabilities;
+    uint8_t bDataInterface;
+}
+cdc_cm_descriptor_t;
+
+/**
+ * @brief Abstract Control Management Functional Descriptor
+ * @note PSTN120.pdf, 5.3.2
+ */
+typedef struct __attribute__((packed))
+{
+    uint8_t bFunctionLength;
+    uint8_t bDescriptorType;
+    uint8_t bDescriptorSubtype;
+    uint8_t bmCapabilities;
+}
+cdc_acm_descriptor_t;
+
+/**
+ * @brief PSTN Subclass Specific Requests
+ * Class-Specific Request Codes
+ * @note PSTN120.pdf, 6.3, Table 13
+ */
+#define SET_COMM_FEATURE                0x02
+#define GET_COMM_FEATURE                0x03
+#define CLEAR_COMM_FEATURE              0x04
+#define SET_AUX_LINE_STATE              0x10
+#define SET_HOOK_STATE                  0x11
+#define PULSE_SETUP                     0x12
+#define SEND_PULSE                      0x13
+#define SET_PULSE_TIME                  0x14
+#define RING_AUX_JACK                   0x15
+#define SET_LINE_CODING                 0x20
+#define GET_LINE_CODING                 0x21
+#define SET_CONTROL_LINE_STATE          0x22
+#define SEND_BREAK                      0x23
+#define SET_RINGER_PARMS                0x30
+#define GET_RINGER_PARMS                0x31
+#define SET_OPERATION_PARMS             0x32
+#define GET_OPERATION_PARMS             0x33
+#define SET_LINE_PARMS                  0x34
+#define GET_LINE_PARMS                  0x35
+#define DIAL_DIGITS                     0x36
+
+/**
+ * @brief PSTN Subclass Specific Request
+ * @note PSTN120.pdf, 6.3
+ */
+typedef struct __attribute__((packed))
+{
+    uint8_t bmRequestType;
+    uint8_t bRequestCode;               /**< Class-Specific Request Code */
+    uint16_t wValue;
+    uint16_t wIndex;
+    uint16_t wLength;
+    uint16_t Data;                      /**< e.g. State or Line Coding Structure */
+}
+usb_cdc_request_t;
+
+/**
+ * @brief Line Coding Structure
+ * @note PSTN120.pdf, 6.3.10, Set/Get Line Coding
+ */
+typedef struct __attribute__((packed))
+{
+    uint32_t dwDTERate;
+    uint8_t bCharFormat;
+    uint8_t bParityType;
+    uint8_t bDataBits;
+}
+cdc_line_coding_t;
+
+/**
+ * @brief PSTN Subclass Specific Notifications
+ * Class-Specific Notification Codes
+ * @note PSTN120.pdf, 6.5, Table 30
+ */
+#define NETWORK_CONNECTION              0x00
+#define RESPONSE_AVAILABLE              0x01
+#define AUX_JACK_HOOK_STATE             0x08
+#define RING_DETECT                     0x09
+#define SERIAL_STATE                    0x20
+#define LINE_STATE_CHANGE               0x23
+#define CALL_STATE_CHANGE               0x28
+
+/**
+ * @brief PSTN Subclass Specific Notifications
+ * UART State Bitmap Values
+ * @note PSTN120.pdf, 6.5.4, Table 31
+ */
+#define SERIAL_STATE_OVERRUN            6
+#define SERIAL_STATE_OVERRUN_MASK       (1 << SERIAL_STATE_OVERRUN)
+#define SERIAL_STATE_PARITY             5
+#define SERIAL_STATE_PARITY_MASK        (1 << SERIAL_STATE_PARITY)
+#define SERIAL_STATE_FRAMING            4
+#define SERIAL_STATE_FRAMING_MASK       (1 << SERIAL_STATE_FRAMING)
+#define SERIAL_STATE_RING               3
+#define SERIAL_STATE_RING_MASK          (1 << SERIAL_STATE_RING)
+#define SERIAL_STATE_BREAK              2
+#define SERIAL_STATE_BREAK_MASK         (1 << SERIAL_STATE_BREAK)
+#define SERIAL_STATE_TX_CARRIER         1
+#define SERIAL_STATE_TX_CARRIER_MASK    (1 << SERIAL_STATE_TX_CARRIER)
+#define SERIAL_STATE_RX_CARRIER         0
+#define SERIAL_STATE_RX_CARRIER_MASK    (1 << SERIAL_STATE_RX_CARRIER)
+
+/**
+ * @brief PSTN Subclass Specific Notification
+ * @note PSTN120.pdf, 6.5.4
+ */
+typedef struct __attribute__((packed))
+{
+    uint8_t bmRequestType;
+    uint8_t bNotification;              /**< Class-Specific Notification Code */
+    uint16_t wValue;
+    uint16_t wIndex;
+    uint16_t wLength;
+    uint16_t Data;                      /**< UART State Bitmap Value */
+}
+usb_cdc_notification_t;
+
+#endif
+/** @} */

--- a/sys/usbdev/include/usbdev.h
+++ b/sys/usbdev/include/usbdev.h
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2015 Phytec Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  usbdev_stack
+ * @{
+ *
+ * @file
+ * @brief       USB device driver interface definitions.
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ */
+
+#ifndef USBDEV_DRIVER_H
+#define USBDEV_DRIVER_H
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include "thread.h"
+#include "usbdev_config.h"
+#include "usb_datatypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    USBDEV_STRING_IDX_MFR = 1,
+    USBDEV_STRING_IDX_PRODUCT,
+    USBDEV_STRING_IDX_SN,
+    USBDEV_STRING_IDX_CIF,
+    USBDEV_STRING_IDX_DIF,
+} usbdev_string_idx_t;
+
+typedef enum {
+    USBDEV_STAGE_IDLE = 0,
+    USBDEV_STAGE_STATUS_IN,
+    USBDEV_STAGE_DATA_IN,
+    USBDEV_STAGE_DATA_OUT,
+    USBDEV_STAGE_STALL,
+} usbdev_stage_t;
+
+typedef uint32_t usb_ep_t;
+
+typedef enum {
+    USBDEV_EVENT_SETUP = 0,
+    USBDEV_EVENT_OUT,
+    USBDEV_EVENT_IN,
+    USBDEV_EVENT_REQUEST_CLASS_SETUP,
+    USBDEV_EVENT_REQUEST_CLASS_OUT,
+    USBDEV_EVENT_STALL,
+    USBDEV_EVENT_RESET,
+    USBDEV_EVENT_WAKEUP,
+    USBDEV_EVENT_SUSPEND,
+    USBDEV_EVENT_RESUME,
+    USBDEV_EVENT_SOF,
+    USBDEV_EVENT_ERROR,
+} usbdev_event_t;
+
+/**
+ * @brief   Definition of basic usb device options.
+ */
+typedef enum {
+    USBDEV_SET_CONNECT,             /**< Connect the USB device */
+    USBDEV_SET_DISCONNECT,          /**< Disconnect the USB device */
+    USBDEV_SET_ADDRESS,             /**< Set USB device address */
+    USBDEV_OPT_EP_RESET,            /**< Reset USB device endpoint */
+    USBDEV_SET_EP_ENABLE,           /**< Enable an endpoint */
+    USBDEV_SET_EP_DISABLE,          /**< Disable an endpoint */
+    USBDEV_SET_EP_STALL,            /**< Set STALL for an endpoint */
+    USBDEV_SET_EP_CLR_STALL,        /**< Clear STALL for an endpoint */
+} usbdev_cmd_t;
+
+/**
+ * @brief   Definition of the usb device type
+ *
+ * @see     struct usbdev_t
+ *
+ * @note    Forward definition to use in @ref usbdev_ops_t
+ */
+typedef struct usbdev_t usbdev_t;
+
+/**
+ * @brief   usb device API definition.
+ *
+ * @details This is a set of functions that must be implemented by any driver
+ *           for a usb device.
+ */
+typedef struct {
+    usbdev_t *dev;
+    /**
+     * @brief Initialize a usb device.
+     *
+     * @return  0 on success
+     */
+    int (*init)(void);
+
+    /**
+     * @brief Configure a given usb device endpoint
+     *
+     * @param[in] ep                the usb device endpoint number
+     * @param[in] size              the enpoint packet size
+     * @return  a error
+     */
+    int (*configure_ep)(usb_ep_t ep, size_t size);
+
+    /**
+     * @brief Set Toggle Bit
+     *
+     * @param[in] ep                the usb device endpoint number
+     * @return  a error
+     */
+    int (*set_ep_toggle_bit)(usb_ep_t ep);
+
+    /**
+     * @brief Clear Toggle Bit
+     *
+     * @param[in] ep                the usb device endpoint number
+     * @return  a error
+     */
+    int (*clr_ep_toggle_bit)(usb_ep_t ep);
+
+    /**
+     * @brief Write data to a given usb device endpoint buffer
+     *
+     * @param[in] ep                the usb endpoint
+     * @param[in] data              the data to write
+     * @param[in] data_len          the length of *data* in byte
+     * @return  a error
+     */
+    int (*write_ep)(usb_ep_t ep, uint8_t * data, size_t data_len);
+
+    /**
+     * @brief Read data from a given usb device endpoint buffer
+     *
+     * @param[in] ep                the usb endpoint
+     * @param[in] data              the data to read
+     * @param[in] data_len          the length of *data* in byte
+     * @return  a error
+     */
+    int (*read_ep)(usb_ep_t ep, uint8_t *data, size_t size);
+
+    /**
+     * @brief   Set an option value for a given usb device.
+     *
+     * @param[in] opt           the option type
+     * @param[in] value         the value to set
+     * @return  a error
+     */
+    int (*ioctl)(usbdev_cmd_t cmd, uint32_t arg);
+
+} usbdev_ops_t;
+
+typedef int (* usbdev_iface_init_t)(usbdev_t *dev);
+
+/**
+ * @brief   Definition of the usb device type
+ *
+ */
+struct usbdev_t {
+    usbdev_ops_t *driver;      /**< The driver for this device */
+    void (*irq_ep_event)(usbdev_t *dev, usb_ep_t ep, uint16_t event_type);
+    void (*irq_mon_event)(usbdev_t *dev, uint16_t event_type);
+
+    uint8_t *string_descriptor;
+    usb_device_descriptor_t *device_descriptor;
+
+    uint8_t *sdescr_tab[USBDEV_DESCRIPTOR_IDX_MAX];
+    uint8_t *cfgdescr_tab[USBDEV_DESCRIPTOR_IDX_MAX];
+
+    kernel_pid_t monitor_pid;
+    kernel_pid_t ep_in_pid[USBDEV_MAX_ENDPOINT_IN];
+    kernel_pid_t ep_out_pid[USBDEV_MAX_ENDPOINT_OUT];
+
+    usb_device_request_t setup_pkt;
+
+    uint8_t *ep0_data_ptr;
+    uint16_t ep0_data_cnt_tx;
+    uint16_t ep0_data_cnt_rx;
+    uint8_t ep0_buf[USBDEV_EP0_MAX_PACKET];
+    uint8_t zero_pkt;
+
+    uint8_t address;
+    uint16_t status;
+    uint8_t configuration;
+    uint32_t ep_configured;
+    uint32_t ep_halted;
+    uint32_t ep_stalled;
+    uint8_t n_interfaces;
+
+    uint8_t alt_setting[USBDEV_MAX_INTERFACES];
+
+    usbdev_stage_t stage;
+};
+
+usbdev_t *usbdev_register(usbdev_ops_t *driver);
+int usbdev_register_iface(usbdev_iface_init_t init);
+int usbdev_add_string_descriptor(usbdev_t *dev, uint8_t index, char *string);
+int usbdev_add_cfg_descriptor(usbdev_t *dev, uint8_t *descriptor);
+int usbdev_remove(usbdev_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* USBDEV_DRIVER_H */
+/**
+ * @}
+ */

--- a/sys/usbdev/include/usbdev.h
+++ b/sys/usbdev/include/usbdev.h
@@ -30,6 +30,8 @@
 extern "C" {
 #endif
 
+#define USBDEV_CTRL_EP              0
+
 typedef enum {
     USBDEV_STRING_IDX_MFR = 1,
     USBDEV_STRING_IDX_PRODUCT,
@@ -158,6 +160,7 @@ typedef struct {
 } usbdev_ops_t;
 
 typedef int (* usbdev_iface_init_t)(usbdev_t *dev);
+typedef usbdev_ops_t *(* usbdev_driver_init_t)(usbdev_t *dev);
 
 /**
  * @brief   Definition of the usb device type
@@ -166,7 +169,7 @@ typedef int (* usbdev_iface_init_t)(usbdev_t *dev);
 struct usbdev_t {
     usbdev_ops_t *driver;      /**< The driver for this device */
     void (*irq_ep_event)(usbdev_t *dev, usb_ep_t ep, uint16_t event_type);
-    void (*irq_mon_event)(usbdev_t *dev, uint16_t event_type);
+    void (*irq_bc_event)(usbdev_t *dev, uint16_t event_type);
 
     uint8_t *string_descriptor;
     usb_device_descriptor_t *device_descriptor;
@@ -174,7 +177,6 @@ struct usbdev_t {
     uint8_t *sdescr_tab[USBDEV_DESCRIPTOR_IDX_MAX];
     uint8_t *cfgdescr_tab[USBDEV_DESCRIPTOR_IDX_MAX];
 
-    kernel_pid_t monitor_pid;
     kernel_pid_t ep_in_pid[USBDEV_MAX_ENDPOINT_IN];
     kernel_pid_t ep_out_pid[USBDEV_MAX_ENDPOINT_OUT];
 
@@ -199,11 +201,12 @@ struct usbdev_t {
     usbdev_stage_t stage;
 };
 
-usbdev_t *usbdev_register(usbdev_ops_t *driver);
 int usbdev_register_iface(usbdev_iface_init_t init);
+int usbdev_register_driver(usbdev_driver_init_t init);
 int usbdev_add_string_descriptor(usbdev_t *dev, uint8_t index, char *string);
 int usbdev_add_cfg_descriptor(usbdev_t *dev, uint8_t *descriptor);
 int usbdev_remove(usbdev_t *dev);
+uint32_t ep_configured(usbdev_t *dev, usb_ep_t ep);
 
 #ifdef __cplusplus
 }

--- a/sys/usbdev/include/usbdev_config.h
+++ b/sys/usbdev/include/usbdev_config.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 Phytec Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  usbdev_stack
+ * @{
+ *
+ * @file
+ * @brief       USB device stack configuration.
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ */
+
+#ifndef USBDEV_CONFIG_H
+#define USBDEV_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define USBDEV_IDVENDOR                 0xDEAD
+#define USBDEV_IDPRODUCT                0xBEEF
+#define USBDEV_BCDDEVICE                0x0100
+#define USBDEV_STRDESC_LANGID           0x0409
+
+#define USBDEV_MAX_USER_ENDPOINTS       4
+
+#define USBDEV_MAX_ENDPOINTS            (USBDEV_MAX_USER_ENDPOINTS + 1)
+
+#define USBDEV_MAX_ENDPOINT_IN          (USBDEV_MAX_ENDPOINTS)
+#define USBDEV_MAX_ENDPOINT_OUT         (USBDEV_MAX_ENDPOINTS)
+#define USBDEV_MAX_ENDPOINT_NUM         (USBDEV_MAX_ENDPOINT_IN + USBDEV_MAX_ENDPOINT_OUT)
+
+#define USBDEV_MAX_INTERFACES           8
+
+#define USBDEV_EP0_MAX_PACKET           8
+
+#define USBDEV_DESCRIPTOR_IDX_MAX       16
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+/**
+ * @}
+ */

--- a/sys/usbdev/usbdev.c
+++ b/sys/usbdev/usbdev.c
@@ -1,0 +1,1141 @@
+/*
+ * Copyright (C) 2015 Phytec Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  usbdev
+ * @{
+ *
+ * @file
+ * @brief       USB device stack.
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ */
+
+
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "kernel.h"
+#include "thread.h"
+#include "msg.h"
+#include "init.h"
+#include "board.h"
+
+#include "usbdev.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#define STATUS_MASK_OUT(ep)             (1 << ENDPOINT_NUM(ep))
+#define STATUS_MASK_IN(ep)              (1 << (16 + ENDPOINT_NUM(ep)))
+
+#define STATUS_MASK_EP0_OUT             STATUS_MASK_OUT(0)
+#define STATUS_MASK_EP0_IN              STATUS_MASK_IN(0)
+
+typedef int (* usbdev_srq_t)(usbdev_t *dev);
+
+usb_device_descriptor_t usbdev_def_descriptor = {
+    .bLength = sizeof(usb_device_descriptor_t),
+    .bDescriptorType = DESCRIPTOR_TYPE_DEVICE,
+    .bcdUSB = 0x0110,
+    .bDeviceClass = 0,
+    .bDeviceSubClass = 0,
+    .bDeviceProtocol = 0,
+    .bMaxPacketSize0 = USBDEV_EP0_MAX_PACKET,
+    .idVendor = USBDEV_IDVENDOR,
+    .idProduct = USBDEV_IDPRODUCT,
+    .bcdDevice = USBDEV_BCDDEVICE,
+    .iManufacturer = 0,
+    .iProduct = 0,
+    .iSerialNumber = 0,
+    .bNumConfigurations = 0x01,
+};
+
+usb_string_descriptor_t usbdev_def_string_descriptor = {
+    .bLength = sizeof(usb_string_descriptor_t),
+    .bDescriptorType = DESCRIPTOR_TYPE_STRING,
+    .bString = USBDEV_STRDESC_LANGID,
+};
+
+//inline static void usbdev_broadcast_event(usbdev_t *dev, msg_t *msg);
+
+inline static void usbdev_broadcast_class(usbdev_t *dev, msg_t *msg);
+
+static void usbdev_data_in_prepare(usbdev_t *dev, size_t l);
+
+static inline usb_ep_t srq_get_ep_addr(usbdev_t *dev)
+{
+    return (usb_ep_t)ENDPOINT_ADDR(dev->setup_pkt.wIndexL);
+}
+
+uint32_t ep_configured(usbdev_t *dev, usb_ep_t ep)
+{
+    if (ep & ENDPOINT_IN_MASK) {
+        return dev->ep_configured & STATUS_MASK_IN(ep);
+    }
+    return dev->ep_configured & STATUS_MASK_OUT(ep);
+}
+
+static inline void ep_set_configured(usbdev_t *dev, usb_ep_t ep)
+{
+    if (ep & ENDPOINT_IN_MASK) {
+        dev->ep_configured |= STATUS_MASK_IN(ep);
+    }
+    else {
+        dev->ep_configured |= STATUS_MASK_OUT(ep);
+    }
+}
+
+static inline void ep_clear_configured(usbdev_t *dev, usb_ep_t ep)
+{
+    if (ep & ENDPOINT_IN_MASK) {
+        dev->ep_configured &= ~STATUS_MASK_IN(ep);
+    }
+    else {
+        dev->ep_configured &= ~STATUS_MASK_OUT(ep);
+    }
+}
+
+static inline uint32_t ep_halted(usbdev_t *dev, usb_ep_t ep)
+{
+    if (ep & ENDPOINT_IN_MASK) {
+        return dev->ep_halted & STATUS_MASK_IN(ep);
+    }
+    return dev->ep_halted & STATUS_MASK_OUT(ep);
+}
+
+static inline void ep_set_halted(usbdev_t *dev, usb_ep_t ep)
+{
+    if (ep & ENDPOINT_IN_MASK) {
+        dev->ep_halted |= STATUS_MASK_IN(ep);
+    }
+    else {
+        dev->ep_halted |= STATUS_MASK_OUT(ep);
+    }
+}
+
+static inline void ep_clear_halted(usbdev_t *dev, usb_ep_t ep)
+{
+    if (ep & ENDPOINT_IN_MASK) {
+        dev->ep_halted &= ~STATUS_MASK_IN(ep);
+    }
+    else {
+        dev->ep_halted &= ~STATUS_MASK_OUT(ep);
+    }
+}
+
+static inline uint32_t ep_stalled(usbdev_t *dev, usb_ep_t ep)
+{
+    if (ep & ENDPOINT_IN_MASK) {
+        return dev->ep_stalled & STATUS_MASK_IN(ep);
+    }
+    return dev->ep_stalled & STATUS_MASK_OUT(ep);
+}
+
+static inline void ep_set_stalled(usbdev_t *dev, usb_ep_t ep)
+{
+    if (ep & ENDPOINT_IN_MASK) {
+        dev->ep_stalled |= STATUS_MASK_IN(ep);
+    }
+    else {
+        dev->ep_stalled |= STATUS_MASK_OUT(ep);
+    }
+}
+
+static inline void ep_clear_stalled(usbdev_t *dev, usb_ep_t ep)
+{
+    if (ep & ENDPOINT_IN_MASK) {
+        dev->ep_stalled &= ~STATUS_MASK_IN(ep);
+    }
+    else {
+        dev->ep_stalled &= ~STATUS_MASK_OUT(ep);
+    }
+}
+
+static inline void reset_ep_status(usbdev_t *dev)
+{
+    usbdev_ops_t *driver = dev->driver;
+    dev->ep_configured  = STATUS_MASK_EP0_IN | STATUS_MASK_EP0_OUT;
+    dev->ep_halted  = 0;
+    dev->ep_stalled = 0;
+    for (uint8_t n = 1; n < 16; n++) {
+        if (ep_configured(dev, ENDPOINT_ADDR_OUT(n))) {
+            driver->ioctl(USBDEV_SET_EP_DISABLE, ENDPOINT_ADDR_OUT(n));
+        }
+
+        if (ep_configured(dev, ENDPOINT_ADDR_IN(n))) {
+            driver->ioctl(USBDEV_SET_EP_DISABLE, ENDPOINT_ADDR_IN(n));
+        }
+    }
+}
+
+static inline void set_ep_configuration(usbdev_t *dev, usb_ep_descriptor_t *ep_dsc)
+{
+    usbdev_ops_t *driver = dev->driver;
+    usb_ep_t ep = ENDPOINT_ADDR(ep_dsc->bEndpointAddress);
+    size_t size = ep_dsc->wMaxPacketSize;
+
+    driver->configure_ep(ep, size);
+    driver->ioctl(USBDEV_SET_EP_ENABLE, ep);
+    driver->ioctl(USBDEV_OPT_EP_RESET, ep);
+    ep_set_configured(dev, ep);
+}
+
+inline static int usbdev_get_string_descriptor(usbdev_t *dev, uint8_t index, uint8_t **buf)
+{
+    if (index >= USBDEV_DESCRIPTOR_IDX_MAX) {
+        *buf = NULL;
+        return 0;
+    }
+
+    uint8_t *sdescr = dev->sdescr_tab[index];
+    if (sdescr == NULL) {
+        *buf = NULL;
+        return 0;
+    }
+
+    *buf = sdescr;
+    return ((usb_string_descriptor_t *)sdescr)->bLength;
+}
+
+inline static int usbdev_get_cfg_descriptor(usbdev_t *dev, uint8_t index, uint8_t **buf)
+{
+    uint8_t *ptr = (uint8_t *)dev->cfgdescr_tab[index];
+
+    for (uint8_t n = 0; n != index; n++) {
+        if (((usb_cfg_descriptor_t *)ptr)->bLength != 0) {
+            ptr += ((usb_cfg_descriptor_t *)ptr)->wTotalLength;
+        }
+    }
+
+    *buf = ptr;
+    return ((usb_cfg_descriptor_t *)ptr)->wTotalLength;
+}
+
+/**
+ * @brief Get Status Device
+ * This request returns status for the device.
+ * @note usb_20.pdf, 9.4.5
+ * The device should pass back the status of Self Powered (D0) and 
+ * Remote Wakeup (D1) bits during Data In stage.
+ *
+ * wLength : 2
+ *
+ * @param[out] dev          usb device stack descriptor
+ *
+ * @return                  usbdev_stage_t
+ */
+static int srq_get_status_dev(usbdev_t *dev)
+{
+    dev->ep0_data_ptr = (uint8_t *)&dev->status;
+    return USBDEV_STAGE_DATA_IN;
+}
+
+/**
+ * @brief Get Status Interface
+ * This request returns status for a interface.
+ * @note usb_20.pdf, 9.4.5
+ * The device should pass back the zero value during Data In stage
+ * or Request Error if specified interface does not exist.
+ *
+ * wLength : 2
+ *
+ * @param[out] dev          usb device stack descriptor
+ *
+ * @return                  usbdev_stage_t
+ */
+static int srq_get_status_if(usbdev_t *dev)
+{
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+    dev->ep0_data_ptr = dev->ep0_buf;
+    uint16_t *val = (uint16_t*)dev->ep0_buf;
+
+    if ((dev->configuration == 0) && (dev->address == 0)) {
+        /* Device is in Default state */
+        return USBDEV_STAGE_STALL;
+    }
+
+    if ((dev->configuration == 0) && (dev->address)) {
+        /* Device is in Address state */
+        return USBDEV_STAGE_STALL;
+    }
+
+    if (setup_pkt->wIndexL >= dev->n_interfaces) {
+        /* Index too high */
+        return USBDEV_STAGE_STALL;
+    }
+
+    *val = 0;
+    return USBDEV_STAGE_DATA_IN;
+}
+
+/**
+ * @brief Get Status Endpoing
+ * This request returns status for a endpoint.
+ * @note usb_20.pdf, 9.4.5
+ * The device should pass back the status of Halt (D0) bit
+ * during Data In stage. The Halt bit is set to one, if the
+ * the endpoint is halted.
+ *
+ * wLength : 2
+ *
+ * @param[out] dev          usb device stack descriptor
+ *
+ * @return                  usbdev_stage_t
+ */
+static int srq_get_status_ep(usbdev_t *dev)
+{
+    usb_ep_t ep = srq_get_ep_addr(dev);
+    dev->ep0_data_ptr = dev->ep0_buf;
+    uint16_t *val = (uint16_t*)dev->ep0_buf;
+
+    if ((dev->configuration == 0) && (dev->address == 0)) {
+        /* Device is in Default state */
+        return USBDEV_STAGE_STALL;
+    }
+
+    if ((dev->configuration == 0) && (dev->address)) {
+        /* Device is in Address state */
+        if (ENDPOINT_NUM(ep) != 0) {
+            return USBDEV_STAGE_STALL;
+        }
+    }
+
+    if (!ep_configured(dev, ep)) {
+        /* Unconfigured Endpoint */
+        return USBDEV_STAGE_STALL;
+    }
+
+    *val = ep_halted(dev, ep) ? 1 : 0;
+    return USBDEV_STAGE_DATA_IN;
+}
+
+/**
+ * @brief Set Feature Device
+ * This request is used to set the Remote Wakeup feature for
+ * the device.
+ * @note usb_20.pdf, 9.4.9
+ * The device should pass back a STALL during Status stage
+ * if the feature cannot be set or not exist.
+ *
+ * @param[out] dev          usb device stack descriptor
+ *
+ * @return                  usbdev_stage_t
+ */
+static int srq_set_feature_dev(usbdev_t *dev)
+{
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+
+    if (setup_pkt->wValue == FEATURE_DEVICE_REMOTE_WAKEUP) {
+        dev->status |=  DEVICE_STATUS_REMOTE_WAKEUP;
+        return USBDEV_STAGE_STATUS_IN;
+    }
+
+    return USBDEV_STAGE_STALL;
+}
+
+/**
+ * @brief Set Feature Endpoint
+ * This request is used to set the Halt feature for
+ * a endpoing.
+ * @note usb_20.pdf, 9.4.9
+ * The device should pass back a STALL during Status stage
+ * if the feature cannot be set.
+ *
+ * @param[out] dev          usb device stack descriptor
+ *
+ * @return                  usbdev_stage_t
+ */
+static int srq_set_feature_ep(usbdev_t *dev)
+{
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+    usbdev_ops_t *driver = dev->driver;
+    usb_ep_t ep = srq_get_ep_addr(dev);
+
+    if (dev->configuration == 0) {
+        return USBDEV_STAGE_STALL;
+    }
+
+    if (ENDPOINT_NUM(ep) == 0) {
+        return USBDEV_STAGE_STALL;
+    }
+
+    if (!ep_configured(dev, ep)) {
+        return USBDEV_STAGE_STALL;
+    }
+
+    if (setup_pkt->wValue != FEATURE_ENDPOINT_HALT) {
+        return USBDEV_STAGE_STALL;
+    }
+
+    driver->ioctl(USBDEV_SET_EP_STALL, ep);
+    ep_set_halted(dev, ep);
+    return USBDEV_STAGE_STATUS_IN;
+}
+
+/**
+ * @brief Clear Feature Device
+ * This request is used to clear the Remote Wakeup feature for
+ * the device.
+ * @note usb_20.pdf, 9.4.1
+ * The device should pass back a STALL during Status stage
+ * if the feature cannot be clear or not exist.
+ *
+ * @param[out] dev          usb device stack descriptor
+ *
+ * @return                  usbdev_stage_t
+ */
+static int srq_clear_feature_dev(usbdev_t *dev)
+{
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+
+    if (setup_pkt->wValue == FEATURE_DEVICE_REMOTE_WAKEUP) {
+        dev->status &= ~DEVICE_STATUS_REMOTE_WAKEUP;
+        return USBDEV_STAGE_STATUS_IN;
+    }
+
+    return USBDEV_STAGE_STALL;
+}
+
+/**
+ * @brief Clear Feature Endpoint
+ * This request is used to clear the Halt feature for
+ * a endpoing.
+ * @note usb_20.pdf, 9.4.9
+ * The device should pass back a STALL during Status stage
+ * if the feature cannot be clear. The endpoing should
+ * reinitialized the data toggle bit to DATA0.
+ *
+ * @param[out] dev          usb device stack descriptor
+ *
+ * @return                  usbdev_stage_t
+ */
+static int srq_clear_feature_ep(usbdev_t *dev)
+{
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+    usbdev_ops_t *driver = dev->driver;
+    usb_ep_t ep = srq_get_ep_addr(dev);
+
+    if (dev->configuration == 0) {
+        return USBDEV_STAGE_STALL;
+    }
+
+    if (ENDPOINT_NUM(ep) == 0) {
+        return USBDEV_STAGE_STALL;
+    }
+
+    if (!ep_configured(dev, ep)) {
+        return USBDEV_STAGE_STALL;
+    }
+
+    if (setup_pkt->wValue != FEATURE_ENDPOINT_HALT) {
+        return USBDEV_STAGE_STALL;
+    }
+
+    if (ep_stalled(dev, ep)) {
+        /* The enpoint has been stalled by the hardware driver. */
+        return USBDEV_STAGE_STALL;
+    }
+
+    driver->ioctl(USBDEV_SET_EP_CLR_STALL, ep);
+    ep_clear_halted(dev, ep);
+    return USBDEV_STAGE_STATUS_IN;
+}
+
+/**
+ * @brief Set Address 
+ * This request is used to set the address of the device.
+ * @note usb_20.pdf, 9.4.6
+ * The device should not change the device address until
+ * the Status stage is completed succesfully.
+ *
+ * @param[out] dev          usb device stack descriptor
+ *
+ * @return                  usbdev_stage_t
+ */
+static int srq_set_address_dev(usbdev_t *dev)
+{
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+
+    if ((dev->configuration) && (dev->address)) {
+        /* Device is in Configured state */
+        return USBDEV_STAGE_STALL;
+    }
+
+    /* Device is in Default or Address state */
+    dev->address = setup_pkt->wValueL;
+    return USBDEV_STAGE_STATUS_IN;
+}
+
+/**
+ * @brief Get Descriptor Device
+ * This request returns the device descriptor.
+ * @note usb_20.pdf, 9.4.3
+ * 
+ * wValueH field specifies the descriptor type and
+ * wValueL field the descriptor index.
+ * wLength field specifies the number of bytes to
+ * pass back during the Data In stage
+ *
+ * The request is valid for all device states.
+ *
+ * wLength : Descriptor Length
+ *
+ * @param[out] dev          usb device stack descriptor
+ *
+ * @return                  usbdev_stage_t
+ */
+static int srq_get_descriptor_dev(usbdev_t *dev)
+{
+    uint8_t n = 0;
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+
+    switch (setup_pkt->wValueH) {
+        case DESCRIPTOR_TYPE_DEVICE:
+            dev->ep0_data_ptr = (uint8_t*)dev->device_descriptor;
+            n = sizeof(usb_device_descriptor_t);
+            break;
+
+        case DESCRIPTOR_TYPE_CONFIGURATION:
+            n = usbdev_get_cfg_descriptor(dev, setup_pkt->wValueL, &dev->ep0_data_ptr);
+            break;
+
+        case DESCRIPTOR_TYPE_STRING:
+            n = usbdev_get_string_descriptor(dev, setup_pkt->wValueL, &dev->ep0_data_ptr);
+            break;
+
+        case DESCRIPTOR_TYPE_DEVICE_QUALIFIER:
+        default:
+            return USBDEV_STAGE_STALL;
+    }
+
+    if (n == 0) {
+        return USBDEV_STAGE_STALL;
+    }
+
+    usbdev_data_in_prepare(dev, n);
+    return USBDEV_STAGE_DATA_IN;
+}
+
+/**
+ * @brief Get Configuration Device
+ * @note usb_20.pdf, 9.4.2
+ * The device should pass back the current configuration
+ * value during Data In stage.
+ *
+ * @param[out] dev          usb device stack descriptor
+ *
+ * @return                  usbdev_stage_t
+ */
+static int srq_get_config_dev(usbdev_t *dev)
+{
+    dev->ep0_data_ptr = &dev->configuration;
+    return USBDEV_STAGE_DATA_IN;
+}
+
+/**
+ * @brief Set Configuration Device
+ * This request sets the device configuration.
+ * @note usb_20.pdf, 9.4.7
+ * 
+ * wValueL field specifies the configuration value.
+ *
+ * The device should pass back a STALL during Status stage
+ * if the configuration value is invalid.
+ *
+ * @param[out] dev          usb device stack descriptor
+ *
+ * @return                  0 on success
+ */
+static int srq_set_config_dev(usbdev_t *dev)
+{
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+    uint8_t *dsc_p;
+    uint8_t alternate = 0;
+
+    if (setup_pkt->wValueL == 0) {
+        /* Device enters or remains in the Address state. */
+        dev->configuration = 0;
+        reset_ep_status(dev);
+        return USBDEV_STAGE_STATUS_IN;
+    }
+
+    usbdev_get_cfg_descriptor(dev, 0, &dsc_p);
+
+    while (((usb_generic_descriptor_t *)dsc_p)->bLength) {
+
+        usb_cfg_descriptor_t *cfg_dsc = (usb_cfg_descriptor_t *)dsc_p;
+        usb_if_descriptor_t *iface_dsc = (usb_if_descriptor_t *)dsc_p;
+        usb_ep_descriptor_t *ep_dsc = (usb_ep_descriptor_t *)dsc_p;
+
+        if (cfg_dsc->bDescriptorType == DESCRIPTOR_TYPE_CONFIGURATION) {
+            if (cfg_dsc->bConfigurationValue != setup_pkt->wValueL) {
+                dsc_p += cfg_dsc->wTotalLength;
+                continue;
+            }
+            dev->configuration = setup_pkt->wValueL;
+            dev->n_interfaces = cfg_dsc->bNumInterfaces;
+            dev->status = 0;
+            reset_ep_status(dev);
+            if (cfg_dsc->bmAttributes & CONFIG_SELF_POWERED) {
+                dev->status |= DEVICE_STATUS_SELF_POWERED;
+            }
+        }
+
+        if (iface_dsc->bDescriptorType == DESCRIPTOR_TYPE_INTERFACE) {
+            alternate = iface_dsc->bAlternateSetting;
+        }
+
+        if ((ep_dsc->bDescriptorType == DESCRIPTOR_TYPE_ENDPOINT) && (alternate == 0)) {
+            set_ep_configuration(dev, ep_dsc);
+        }
+        dsc_p += ((usb_generic_descriptor_t *)dsc_p)->bLength;
+    }
+
+    if (dev->configuration == setup_pkt->wValueL) {
+        return USBDEV_STAGE_STATUS_IN;
+    }
+
+    return USBDEV_STAGE_STALL;
+}
+
+/**
+ * @brief Get Interface
+ * @note usb_20.pdf, 9.4.4
+ * The device should pass back the selected alternate setting
+ * for the specified interface during Data In stage.
+ *
+ * wIndex field specifies the interface.
+ *
+ * @param[out] dev          usb device stack descriptor
+ *
+ * @return                  0 on success
+ */
+static int srq_get_interface_if(usbdev_t *dev)
+{
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+
+    if (dev->configuration == 0) {
+        return USBDEV_STAGE_STALL;
+    }
+
+    if (setup_pkt->wIndexL >= dev->n_interfaces) {
+        return USBDEV_STAGE_STALL;
+    }
+
+    dev->ep0_data_ptr = dev->alt_setting + setup_pkt->wIndexL;
+    return USBDEV_STAGE_DATA_IN;
+}
+
+
+/**
+ * @brief Set Interface
+ * This request sets the interface alternate setting.
+ * @note usb_20.pdf, 9.4.10
+ * 
+ * wValue field specifies the alternate setting.
+ * wIndex field specifies the interface.
+ *
+ * The device should pass back a STALL during Status stage
+ * if the device only supports a default setting.
+ *
+ * @param[out] dev          usb device stack descriptor
+ *
+ * @return                  0 on success
+ */
+static int srq_set_interface_if(usbdev_t *dev)
+{
+    usbdev_ops_t *driver = dev->driver;
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+    uint8_t *dsc_p;
+    uint8_t alternate = 0;
+    uint8_t interface = 0;
+    int retval = USBDEV_STAGE_STALL;
+
+    if (dev->configuration == 0) {
+        return retval;
+    }
+
+    if (setup_pkt->wIndexL > USBDEV_MAX_INTERFACES) {
+        return retval;
+    }
+
+    usbdev_get_cfg_descriptor(dev, 0, &dsc_p);
+
+    while (((usb_generic_descriptor_t *)dsc_p)->bLength) {
+
+        usb_cfg_descriptor_t *cfg_dsc = (usb_cfg_descriptor_t *)dsc_p;
+        usb_if_descriptor_t *iface_dsc = (usb_if_descriptor_t *)dsc_p;
+        usb_ep_descriptor_t *ep_dsc = (usb_ep_descriptor_t *)dsc_p;
+
+        if (cfg_dsc->bDescriptorType == DESCRIPTOR_TYPE_CONFIGURATION) {
+            if (cfg_dsc->bConfigurationValue != dev->configuration) {
+                dsc_p += cfg_dsc->wTotalLength;
+                continue;
+            }
+        }
+
+        if (iface_dsc->bDescriptorType == DESCRIPTOR_TYPE_INTERFACE) {
+            interface = iface_dsc->bInterfaceNumber;
+            alternate = iface_dsc->bAlternateSetting;
+        }
+
+        if (ep_dsc->bDescriptorType == DESCRIPTOR_TYPE_ENDPOINT) {
+            if (interface == setup_pkt->wIndexL) {
+                if (alternate == setup_pkt->wValueL) {
+                    if (ENDPOINT_NUM(ep_dsc->bEndpointAddress) != 0) {
+                        if (ep_configured(dev, ep_dsc->bEndpointAddress)) {
+                            ep_clear_halted(dev, ep_dsc->bEndpointAddress);
+                            ep_clear_stalled(dev, ep_dsc->bEndpointAddress);
+                            driver->ioctl(USBDEV_SET_EP_DISABLE, ep_dsc->bEndpointAddress);
+                            ep_clear_configured(dev, ep_dsc->bEndpointAddress);
+                        }
+
+                        set_ep_configuration(dev, ep_dsc);
+                        dev->alt_setting[interface] = alternate;
+                        retval = USBDEV_STAGE_STATUS_IN;;
+                    }
+                }
+            }
+        }
+        dsc_p += ((usb_generic_descriptor_t *)dsc_p)->bLength;
+    }
+
+    return retval; 
+}
+
+static int srq_error(usbdev_t *dev)
+{
+    return USBDEV_STAGE_STALL;
+}
+
+/* TODO: lookup table can be downsized to 12 x 3 
+ *
+ * lookup table over bRequest + Recipient
+ *     ((4 bit for Request Codes) << 2) | (2 bit for Recipient)
+ */
+usbdev_srq_t srq_lt[64] = {
+    /*  Device      ,      Interface      ,     Endpoing      ,     Other  */
+    srq_get_status_dev, srq_get_status_if, srq_get_status_ep, srq_error,
+    srq_clear_feature_dev, srq_error, srq_clear_feature_ep, srq_error,
+    srq_error, srq_error, srq_error, srq_error, /* reserved */
+    srq_set_feature_dev, srq_error, srq_set_feature_ep, srq_error,
+    srq_error, srq_error, srq_error, srq_error, /* reserved */
+    srq_set_address_dev, srq_error, srq_error, srq_error,
+    srq_get_descriptor_dev, srq_error, srq_error, srq_error,
+    srq_error, srq_error, srq_error, srq_error, /* not supported */
+    srq_get_config_dev, srq_error, srq_error, srq_error,
+    srq_set_config_dev, srq_error, srq_error, srq_error,
+    srq_error, srq_get_interface_if, srq_error, srq_error,
+    srq_error, srq_set_interface_if, srq_error, srq_error,
+    srq_error, srq_error, srq_error, srq_error, /* not supported */
+    srq_error, srq_error, srq_error, srq_error, /* reserved */
+    srq_error, srq_error, srq_error, srq_error, /* reserved */
+    srq_error, srq_error, srq_error, srq_error, /* reserved */
+};
+
+static inline int usbdev_ep0_setup(usbdev_t *dev)
+{
+    msg_t msg;
+    usbdev_ops_t *driver = dev->driver;
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+
+    driver->read_ep(0, (uint8_t *)setup_pkt, USBDEV_EP0_MAX_PACKET);
+
+    if (REQUEST_DIR(setup_pkt->bmRequestType) == REQUEST_DEVICE_TO_HOST) {
+        dev->ep0_data_cnt_tx = setup_pkt->wLength;
+    }
+    else {
+        dev->ep0_data_cnt_rx = setup_pkt->wLength;
+    }
+
+    driver->set_ep_toggle_bit(ENDPOINT_ADDR_IN(0));
+
+    uint8_t srq_idx = ((setup_pkt->bRequest & 0xf) << 2)
+                      | (REQUEST_RECIPIENT(setup_pkt->bmRequestType) & 0x3);
+
+    switch (REQUEST_TYPE(setup_pkt->bmRequestType)) {
+
+        case REQUEST_STANDARD:
+            return srq_lt[srq_idx](dev);
+
+        case REQUEST_CLASS:
+            dev->ep0_data_ptr = dev->ep0_buf;
+            msg.type = USBDEV_EVENT_REQUEST_CLASS_SETUP;
+            usbdev_broadcast_class(dev, &msg);
+            return msg.content.value;
+
+        default:
+            break;
+    }
+
+    return USBDEV_STAGE_STALL;
+}
+
+static inline int usbdev_ep0_out(usbdev_t *dev)
+{
+    msg_t msg;
+    usbdev_ops_t *driver = dev->driver;
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+
+    if (REQUEST_DIR(setup_pkt->bmRequestType) == REQUEST_DEVICE_TO_HOST) {
+        /* 3-Stage-Control-Transfer, receive ZDP */
+        driver->read_ep(0, dev->ep0_buf, USBDEV_EP0_MAX_PACKET);
+        return USBDEV_STAGE_IDLE;
+    }
+
+    /* REQUEST_HOST_TO_DEVICE */
+    if (dev->ep0_data_cnt_rx) {
+        /* Data Out stage, receive data */
+        size_t n = driver->read_ep(0, dev->ep0_data_ptr, USBDEV_EP0_MAX_PACKET);
+        dev->ep0_data_cnt_rx -= n;
+        dev->ep0_data_ptr += n;
+
+        if (dev->ep0_data_cnt_rx != 0) {
+            /* Data Out stage, wait for the next packet */
+            return USBDEV_STAGE_IDLE;
+        }
+
+        /* Host to device transfer complete */
+        switch (REQUEST_TYPE(setup_pkt->bmRequestType)) {
+
+            case REQUEST_STANDARD:
+                return USBDEV_STAGE_STALL;
+
+            case REQUEST_CLASS:
+                msg.type = USBDEV_EVENT_REQUEST_CLASS_OUT;
+                usbdev_broadcast_class(dev, &msg);
+                return msg.content.value;
+
+            default:
+                return USBDEV_STAGE_STALL;
+        }
+    }
+    return USBDEV_STAGE_IDLE;
+}
+
+static void usbdev_data_in_prepare(usbdev_t *dev, size_t l)
+{
+    if (dev->ep0_data_cnt_tx > l) {
+        dev->ep0_data_cnt_tx = l;
+    }
+
+    /* 
+     * Send ZLP at the end of transmission if the length is equal to or
+     * a multiple of a maximum length.
+     */
+    if (!(dev->ep0_data_cnt_tx % USBDEV_EP0_MAX_PACKET)) {
+        dev->zero_pkt = 1;
+    }
+}
+
+static void usbdev_data_in_stage(usbdev_t *dev)
+{
+    usbdev_ops_t *driver = dev->driver;
+    size_t n;
+
+    if (dev->ep0_data_cnt_tx > USBDEV_EP0_MAX_PACKET) {
+        n = driver->write_ep(ENDPOINT_ADDR_IN(0), dev->ep0_data_ptr, USBDEV_EP0_MAX_PACKET);
+    }
+    else if (dev->ep0_data_cnt_tx == 0) {
+        dev->zero_pkt = 0;
+        n = driver->write_ep(ENDPOINT_ADDR_IN(0), dev->ep0_data_ptr, 0);
+    }
+    else {
+        n = driver->write_ep(ENDPOINT_ADDR_IN(0), dev->ep0_data_ptr, dev->ep0_data_cnt_tx);
+    }
+
+    dev->ep0_data_cnt_tx -= n;
+    dev->ep0_data_ptr += n;
+}
+
+static inline int usbdev_ep0_in(usbdev_t *dev)
+{
+    usbdev_ops_t *driver = dev->driver;
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+
+    if (REQUEST_DIR(setup_pkt->bmRequestType) == REQUEST_DEVICE_TO_HOST) {
+        if (dev->ep0_data_cnt_tx || dev->zero_pkt) {
+            return USBDEV_STAGE_DATA_IN;
+        }
+    }
+    else if (dev->configuration == 0) {
+        driver->ioctl(USBDEV_SET_ADDRESS, (uint32_t)dev->address);
+    }
+    return USBDEV_STAGE_IDLE;
+}
+
+static inline void usbdev_status_in_stage(usbdev_t *dev)
+{
+    usbdev_ops_t *driver = dev->driver;
+    driver->write_ep(ENDPOINT_ADDR_IN(0), NULL, 0);
+}
+
+static inline void usbdev_ep0_stall_in(usbdev_t *dev)
+{
+    usbdev_ops_t *driver = dev->driver;
+    driver->ioctl(USBDEV_SET_EP_STALL, 0x80);
+    dev->ep0_data_cnt_tx = 0;
+}
+
+static inline void usbdev_ep0_stall_out(usbdev_t *dev)
+{
+    usbdev_ops_t *driver = dev->driver;
+    driver->ioctl(USBDEV_SET_EP_STALL, 0);
+    dev->ep0_data_cnt_rx = 0;
+}
+
+static inline void usbdev_ep0_stall(usbdev_t *dev)
+{
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+
+    if (REQUEST_DIR(setup_pkt->bmRequestType) == REQUEST_DEVICE_TO_HOST) {
+        usbdev_ep0_stall_in(dev);
+    }
+    else if (setup_pkt->wLength) {
+        usbdev_ep0_stall_out(dev);
+    }
+}
+
+static void *usbdev_ep0(void *arg)
+{
+    //msg_t msg;
+    msg_t msg, msg_q[4];
+    msg_init_queue(msg_q, 4);
+    usbdev_t *dev = arg;
+
+    while (true) {
+        msg_receive(&msg);
+
+        switch (msg.type) {
+            case USBDEV_EVENT_SETUP:
+                dev->stage = usbdev_ep0_setup(dev);
+                break;
+
+            case USBDEV_EVENT_OUT:
+                dev->stage = usbdev_ep0_out(dev);
+                break;
+
+            case USBDEV_EVENT_IN:
+                dev->stage = usbdev_ep0_in(dev);
+                break;
+
+            case USBDEV_EVENT_RESET:
+                dev->status  = 0;
+                dev->address = 0;
+                dev->configuration = 0;
+                dev->stage = USBDEV_STAGE_IDLE;
+                reset_ep_status(dev);
+                break;
+
+            case USBDEV_EVENT_ERROR:
+                /* TODO */
+                break;
+
+            case USBDEV_EVENT_SUSPEND:
+                /* TODO */
+                break;
+
+            case USBDEV_EVENT_RESUME:
+                /* TODO */
+                break;
+
+            case USBDEV_EVENT_SOF:
+	    default:
+                continue;
+        }
+
+        if (dev->stage == USBDEV_STAGE_DATA_IN) {
+            usbdev_data_in_stage(dev);
+        }
+        else if (dev->stage == USBDEV_STAGE_STATUS_IN) {
+            usbdev_status_in_stage(dev);
+        }
+        else if (dev->stage == USBDEV_STAGE_STALL) {
+            usbdev_ep0_stall(dev);
+        }
+    }
+
+    return NULL;
+}
+
+inline static void usbdev_broadcast_class(usbdev_t *dev, msg_t *msg)
+{
+    kernel_pid_t tmp = NULL;
+
+    tmp = dev->ep_in_pid[1];
+    if (tmp != dev->ep_out_pid[0]) {
+        msg_send_receive(msg, msg, tmp);
+    }
+
+    /*
+    for (uint8_t i = 1; i < 4; i++) {
+        tmp = dev->ep_out_pid[i];
+        if (tmp != dev->monitor_pid) {
+	    msg_send_receive(msg, msg, tmp);
+	}
+    }
+    */
+}
+
+void usbdev_irq_ep_event(usbdev_t *dev, usb_ep_t ep, uint16_t type)
+{
+    kernel_pid_t tmp = NULL;
+    msg_t msg;
+    msg.type = type;
+    msg.content.value = ep;
+
+    if (ep & ENDPOINT_IN_MASK) {
+        tmp = dev->ep_in_pid[ep & 0x0f];
+    }
+    else {
+        tmp = dev->ep_out_pid[ep & 0x0f];
+    }
+    msg_send_int(&msg, tmp);
+}
+
+void usbdev_irq_bc_event(usbdev_t *dev, uint16_t type)
+{
+    kernel_pid_t tmp = 0;
+    msg_t msg;
+    msg.type = type;
+    msg.content.value = 0;
+
+    for (uint8_t i = 1; i < USBDEV_MAX_ENDPOINT_OUT; i++) {
+        tmp = dev->ep_out_pid[i];
+        if (tmp != dev->ep_out_pid[0]) {
+	    msg_send_int(&msg, tmp);
+	}
+    }
+}
+
+int usbdev_add_string_descriptor (usbdev_t *dev, uint8_t index, char *string)
+{
+    uint8_t *sdescr = NULL;
+    uint8_t n = 0;
+
+    if (!index) {
+         return ENOTEMPTY;
+    }
+
+    unsigned int l = strlen(string) * 2;
+    l = l > (UINT8_MAX - 2) ? (UINT8_MAX - 2): l;
+
+    if (!l) {
+         dev->sdescr_tab[index] = NULL;
+         return ENODATA;
+    }
+
+    sdescr = malloc(l + 2);
+    if (sdescr == NULL) {
+        return ENOMEM;
+    }
+
+    sdescr[n++] = (uint8_t)l + 2;
+    sdescr[n++] = DESCRIPTOR_TYPE_STRING;
+
+    for (int j = 0; j < l / 2; j++) {
+        sdescr[n++] = string[j];
+        sdescr[n++] = 0;
+    }
+
+    dev->sdescr_tab[index] = sdescr;
+
+    if (index == USBDEV_STRING_IDX_MFR) {
+        dev->device_descriptor->iManufacturer = USBDEV_STRING_IDX_MFR;
+    }
+    else if (index == USBDEV_STRING_IDX_PRODUCT) {
+        dev->device_descriptor->iProduct = USBDEV_STRING_IDX_PRODUCT;
+    }
+    else if (index == USBDEV_STRING_IDX_SN) {
+        dev->device_descriptor->iSerialNumber = USBDEV_STRING_IDX_SN;
+    }
+    return 0;
+}
+
+int usbdev_add_cfg_descriptor(usbdev_t *dev, uint8_t *descriptor)
+{
+    for (int j = 0; j < USBDEV_DESCRIPTOR_IDX_MAX; j++) {
+        if (dev->cfgdescr_tab[j] == NULL) {
+            dev->cfgdescr_tab[j] = descriptor;
+	    return 0;
+        }
+    }
+    return -1;
+}
+
+static usbdev_iface_init_t iface_init[4] = { NULL, NULL, NULL, NULL, };
+static usbdev_driver_init_t usb_driver_init = NULL;
+
+int usbdev_register_iface(usbdev_iface_init_t init)
+{
+    iface_init[0] = init;
+    return 0;
+}
+
+int usbdev_register_driver(usbdev_driver_init_t init)
+{
+    usb_driver_init = init;
+    return 0;
+}
+
+static char usbdev_stack_ep0[512];
+usbdev_t dev;
+
+int usbdev_init(void)
+{
+    dev.driver = usb_driver_init(&dev);
+    if (dev.driver == NULL) {
+	return 0;
+    }
+    dev.irq_ep_event = usbdev_irq_ep_event;
+    dev.irq_bc_event = usbdev_irq_bc_event;
+
+    dev.ep_out_pid[0] = thread_create(usbdev_stack_ep0,
+                                sizeof(usbdev_stack_ep0),
+                                1,//THREAD_PRIORITY_MAIN,
+                                CREATE_STACKTEST | CREATE_WOUT_YIELD,
+                                usbdev_ep0, &dev,
+                                "usb-ep0");
+    dev.ep_in_pid[0] = dev.ep_out_pid[0];
+
+    for (uint8_t i = 1; i < USBDEV_MAX_ENDPOINT_IN; i++) {
+        dev.ep_in_pid[i] = dev.ep_out_pid[0];
+    }
+    for (uint8_t i = 1; i < USBDEV_MAX_ENDPOINT_OUT; i++) {
+        dev.ep_out_pid[i] = dev.ep_out_pid[0];
+    }
+
+    dev.device_descriptor = &usbdev_def_descriptor;
+    memset(dev.cfgdescr_tab, (int)NULL, USBDEV_DESCRIPTOR_IDX_MAX);
+    dev.sdescr_tab[0] = (uint8_t*)&usbdev_def_string_descriptor;
+    usbdev_add_string_descriptor(&dev, USBDEV_STRING_IDX_MFR, "JOHN");
+    usbdev_add_string_descriptor(&dev, USBDEV_STRING_IDX_PRODUCT, "USB-TEST");
+    usbdev_add_string_descriptor(&dev, USBDEV_STRING_IDX_SN, "0123");
+    
+    if (iface_init[0]) {
+        iface_init[0](&dev);
+    }
+
+    dev.driver->ioctl(USBDEV_SET_CONNECT, 1);
+
+    return 0;
+}
+
+int usbdev_remove(usbdev_t *dev)
+{
+    for (int j = 1; j < USBDEV_DESCRIPTOR_IDX_MAX; j++) {
+        if (dev->cfgdescr_tab[j] != NULL) {
+            free(dev->cfgdescr_tab[j]);
+        }
+    }
+    return 0;
+}
+
+module_init(usbdev_init);

--- a/sys/usbdev/usbdev_acm.c
+++ b/sys/usbdev/usbdev_acm.c
@@ -1,0 +1,515 @@
+/*
+ * Copyright (C) 2015 Phytec Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     usbdev_cdcacm
+ * @{
+ *
+ * @file
+ * @brief       CDC ACM Class
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ *
+ * @}
+ */
+#include <string.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "ringbuffer.h"
+#include "thread.h"
+#include "init.h"
+#include "board.h"
+#include "mutex.h"
+
+#include "usb_datatypes.h"
+#include "usbdev.h"
+
+#define UART_ACM_0_EN                   1
+#include "periph/uart.h"
+
+#define USBDEV_ACM_EP_PACKET_SIZE       64
+#define USBDEV_ACM_EP_INTIN             1
+#define USBDEV_ACM_POLL_IVAL            32
+#define USBDEV_ACM_EP_BULKIN            2
+#define USBDEV_ACM_EP_BULKOUT           2
+
+#ifndef USBDEV_MAX_POWER
+#define USBDEV_MAX_POWER                200
+#endif
+
+#if (USBDEV_ACM_EP_INTIN >= USBDEV_MAX_ENDPOINT_IN)
+#error "USBDEV_ACM_EP_INTIN exceeds the maximum number of IN endpoints."
+#endif
+
+#if (USBDEV_ACM_EP_BULKIN >= USBDEV_MAX_ENDPOINT_IN)
+#error "USBDEV_ACM_EP_BULKIN exceeds the maximum number of IN endpoints."
+#endif
+
+#if (USBDEV_ACM_EP_BULKOUT >= USBDEV_MAX_ENDPOINT_OUT)
+#error "USBDEV_ACM_EP_BULKOUT exceeds the maximum number of OUT endpoints."
+#endif
+
+void usbdev_acm_evt_in(usbdev_t *dev);
+
+#ifndef CDCACM_BUFSIZE
+#define CDCACM_BUFSIZE                  128
+#endif
+
+static mutex_t tx_rb_lock = MUTEX_INIT;
+static char rx_buffer[CDCACM_BUFSIZE];
+static char tx_buffer[CDCACM_BUFSIZE];
+ringbuffer_t cdcacm_rx_rb = RINGBUFFER_INIT(rx_buffer);
+ringbuffer_t cdcacm_tx_rb = RINGBUFFER_INIT(tx_buffer);
+
+uint8_t rec_buffer[USBDEV_ACM_EP_PACKET_SIZE];
+uint8_t send_buffer[USBDEV_ACM_EP_PACKET_SIZE];
+
+static uart_isr_ctx_t ucb_config;
+
+typedef struct __attribute__((packed))
+{
+    usb_cfg_descriptor_t cfg;
+
+    usb_if_descriptor_t if0;
+    cdc_header_descriptor_t if0_header;
+    cdc_cm_descriptor_t if0_cm;
+    cdc_acm_descriptor_t if0_acm;
+    cdc_union_descriptor_t if0_union;
+    usb_ep_descriptor_t if0_ep_int_in;
+
+    usb_if_descriptor_t if1;
+    usb_ep_descriptor_t if1_ep_bulk_out;
+    usb_ep_descriptor_t if1_ep_bulk_in;
+
+    usb_generic_descriptor_t terminator;
+}
+usb_cdc_acm_config_t;
+
+usb_cdc_acm_config_t usb_cdc_acm_config = {
+    .cfg = {
+        .bLength = sizeof(usb_cfg_descriptor_t),
+        .bDescriptorType = DESCRIPTOR_TYPE_CONFIGURATION,
+        .wTotalLength = sizeof(usb_cdc_acm_config_t) - sizeof(usb_generic_descriptor_t),
+        .bNumInterfaces = 2,
+        .bConfigurationValue = 1,
+        .iConfiguration = 0,
+        .bmAttributes = CONFIG_BUS_POWERED,
+        .bMaxPower = CONFIG_POWER_MA(USBDEV_MAX_POWER),
+    },
+
+    .if0 = {
+        .bLength = sizeof(usb_if_descriptor_t),
+        .bDescriptorType = DESCRIPTOR_TYPE_INTERFACE,
+        .bInterfaceNumber = 0,
+        .bAlternateSetting = 0,
+        .bNumEndpoints = 1,
+        .bInterfaceClass = COMMUNICATION_INTERFACE_CLASS,
+        .bInterfaceSubClass = ABSTRACT_CONTROL_MODEL,
+        .bInterfaceProtocol = 1, /* TODO: fix AT-commands (v.25ter) */
+        .iInterface = USBDEV_STRING_IDX_CIF,
+    },
+
+    .if0_header = {
+        .bFunctionLength = 5,
+        .bDescriptorType = CS_INTERFACE,
+        .bDescriptorSubtype = HEADER_FUNC_DESCRIPTOR,
+        .bcdCDC = CDC_SRN_1_20,
+    },
+
+    .if0_cm = {
+        .bFunctionLength = 5,
+        .bDescriptorType = CS_INTERFACE,
+        .bDescriptorSubtype = CALL_MANAGEMENT_FUNC_DESCRIPTOR,
+        .bmCapabilities = 3,
+        .bDataInterface = 2,
+    },
+
+    .if0_acm = {
+        .bFunctionLength = 4,
+        .bDescriptorType = CS_INTERFACE,
+        .bDescriptorSubtype = ABSTRACT_CONTROL_MANAGEMENT_FUNC_DESCRIPTOR,
+        .bmCapabilities = 0,    /* TODO: add set/get line coding ... */
+    },
+
+    .if0_union = {
+        .bFunctionLength = 5,
+        .bDescriptorType = CS_INTERFACE,
+        .bDescriptorSubtype = UNION_FUNC_DESCRIPTOR,
+        .bControlInterface = 0,
+        .bSubordinateInterface0 = 1,
+    },
+
+    .if0_ep_int_in = {
+        .bLength = sizeof(usb_ep_descriptor_t),
+        .bDescriptorType = DESCRIPTOR_TYPE_ENDPOINT,
+        .bEndpointAddress = ENDPOINT_ADDR_IN(USBDEV_ACM_EP_INTIN),
+        .bmAttributes = ENDPOINT_TRANSFER_TYPE_INTERRUPT,
+        .wMaxPacketSize = USBDEV_ACM_EP_PACKET_SIZE,
+        .bInterval = USBDEV_ACM_POLL_IVAL,
+    },
+
+    .if1 = {
+        .bLength = sizeof(usb_if_descriptor_t),
+        .bDescriptorType = DESCRIPTOR_TYPE_INTERFACE,
+        .bInterfaceNumber = 1,
+        .bAlternateSetting = 0,
+        .bNumEndpoints = 2,
+        .bInterfaceClass = DATA_INTERFACE_CLASS,
+        .bInterfaceSubClass = 0,
+        .bInterfaceProtocol = 0,
+        .iInterface = USBDEV_STRING_IDX_DIF,
+    },
+
+    .if1_ep_bulk_out = {
+        .bLength = sizeof(usb_ep_descriptor_t),
+        .bDescriptorType = DESCRIPTOR_TYPE_ENDPOINT,
+        .bEndpointAddress = ENDPOINT_ADDR_OUT(USBDEV_ACM_EP_BULKOUT),
+        .bmAttributes = ENDPOINT_TRANSFER_TYPE_BULK,
+        .wMaxPacketSize = USBDEV_ACM_EP_PACKET_SIZE,
+        .bInterval = 0x00,
+    },
+
+    .if1_ep_bulk_in = {
+        .bLength = sizeof(usb_ep_descriptor_t),
+        .bDescriptorType = DESCRIPTOR_TYPE_ENDPOINT,
+        .bEndpointAddress = ENDPOINT_ADDR_IN(USBDEV_ACM_EP_BULKIN),
+        .bmAttributes = ENDPOINT_TRANSFER_TYPE_BULK,
+        .wMaxPacketSize = USBDEV_ACM_EP_PACKET_SIZE,
+        .bInterval = 0x00,
+    },
+
+    .terminator = {
+        .bLength = 0,
+        .bDescriptorType = 0,
+    }
+};
+
+inline static int usbdev_cdc_wrong_iface(usbdev_t *dev)
+{
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+
+    if (setup_pkt->wIndexL == usb_cdc_acm_config.if0.bInterfaceNumber) {
+        return 0;
+    }
+    if (setup_pkt->wIndexL == usb_cdc_acm_config.if1.bInterfaceNumber) {
+        return 0;
+    }
+    return -1;
+};
+
+inline static int usbdev_cdc_request_class_if(usbdev_t *dev)
+{
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+
+    if (usbdev_cdc_wrong_iface(dev)) {
+        return -1;
+    }
+
+    switch (setup_pkt->bRequest) {
+        case SET_LINE_CODING: //0x20 (32)
+            //dev->ep0_data_ptr = dev->ep0_buf;
+            return USBDEV_STAGE_STATUS_IN;
+
+        case SET_CONTROL_LINE_STATE: //0x22 (34)
+            return USBDEV_STAGE_STATUS_IN;
+
+        case SET_COMM_FEATURE:
+        case SET_LINE_PARMS:
+        case GET_COMM_FEATURE:
+        case CLEAR_COMM_FEATURE:
+        case GET_LINE_CODING:
+        case SEND_BREAK:
+        default:
+            break;
+    }
+
+    return USBDEV_STAGE_STALL;
+}
+
+inline static int usbdev_cdc_out_class_if(usbdev_t *dev)
+{
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+
+    if (usbdev_cdc_wrong_iface(dev)) {
+        return -1;
+    }
+
+    switch (setup_pkt->bRequest) {
+        case SET_LINE_CODING:
+            return USBDEV_STAGE_STATUS_IN;
+
+        case SET_COMM_FEATURE:
+        default:
+            break;
+    }
+
+    return USBDEV_STAGE_STALL;
+}
+
+inline static void usbdev_acm_reset(void)
+{
+    ringbuffer_init(&cdcacm_tx_rb, tx_buffer, CDCACM_BUFSIZE);
+    ringbuffer_init(&cdcacm_rx_rb, rx_buffer, CDCACM_BUFSIZE);
+    /* TODO: reset data_send_zlp .... */
+    return;
+}
+
+/* TODO */
+/*
+static int usbdev_acm_notify_host(usbdev_t *dev, uint16_t stat)
+{
+    usb_cdc_notification_t notification;
+    usbdev_ops_t *driver = dev->driver;
+
+    if (!dev->configuration) {
+        return 1;
+    }
+
+    notification.bmRequestType = REQUEST_TO_HOST(REQUEST_CLASS, REQUEST_TO_INTERFACE);
+    notification.bNotification = SERIAL_STATE;
+    notification.wValue = 0;
+    notification.wIndex = 0;
+    notification.wLength = 2;
+    notification.Data = stat;
+
+    driver->write_ep(ENDPOINT_ADDR_IN(USBDEV_ACM_EP_INTIN),
+                     (uint8_t*)&notification, sizeof(notification));
+    return 0;
+
+}
+*/
+
+volatile static uint32_t acm_error_log;
+volatile static uint32_t start_tx;
+
+inline static void usbdev_acm_sof_event(usbdev_t *dev)
+{
+    LED_B_TOGGLE;
+    if (mutex_trylock(&tx_rb_lock)) {
+        acm_error_log = cdcacm_tx_rb.avail;
+        //if (!ringbuffer_empty(&cdcacm_tx_rb)) {
+        if (cdcacm_tx_rb.avail) {
+            start_tx = 42;
+            mutex_unlock(&tx_rb_lock);
+            usbdev_acm_evt_in(dev);
+	    return;
+        }
+        start_tx = 0;
+        mutex_unlock(&tx_rb_lock);
+    }
+}
+
+void usbdev_acm_evt_out(usbdev_t *dev)
+{
+    usbdev_ops_t *driver = dev->driver;
+
+    size_t l = driver->read_ep(ENDPOINT_ADDR_OUT(USBDEV_ACM_EP_BULKOUT),
+                               rec_buffer, USBDEV_ACM_EP_PACKET_SIZE);
+
+    ringbuffer_add(&cdcacm_rx_rb, (char*)rec_buffer, l);
+
+    if (ucb_config.rx_cb != NULL) {
+        int retval = ringbuffer_get_one(&cdcacm_rx_rb);
+        while (retval != -1) {
+            ucb_config.rx_cb(ucb_config.arg, (char)retval);
+            retval = ringbuffer_get_one(&cdcacm_rx_rb);
+        }
+    }
+}
+
+void usbdev_acm_evt_in(usbdev_t *dev)
+{
+    usbdev_ops_t *driver = dev->driver;
+    static int32_t data_send_zlp = 0;
+
+    if (!start_tx) {
+        return;
+    }
+
+    if (!mutex_trylock(&tx_rb_lock)) {
+        return;
+    }
+
+    size_t len_to_send = ringbuffer_get(&cdcacm_tx_rb, (char*)send_buffer,
+                                        USBDEV_ACM_EP_PACKET_SIZE);
+
+    if (len_to_send == 0) {
+        start_tx = 0;
+        if (data_send_zlp == 0) {
+            mutex_unlock(&tx_rb_lock);
+            return;
+        }
+        data_send_zlp = 0;
+    }
+
+    size_t len_sent = driver->write_ep(ENDPOINT_ADDR_IN(USBDEV_ACM_EP_BULKIN),
+                                       send_buffer, len_to_send);
+
+
+    unsigned retval = ringbuffer_empty(&cdcacm_tx_rb);
+    if (retval && (len_sent == USBDEV_ACM_EP_PACKET_SIZE)) {
+        data_send_zlp = 1;
+    }
+    else {
+        data_send_zlp = 0;
+    }
+    mutex_unlock(&tx_rb_lock);
+}
+
+static inline int usbdev_setup_request_class(usbdev_t *dev)
+{
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+
+    switch (REQUEST_RECIPIENT(setup_pkt->bmRequestType)) {
+
+        case REQUEST_TO_INTERFACE:
+            return usbdev_cdc_request_class_if(dev);
+
+        case REQUEST_TO_DEVICE:
+        case REQUEST_TO_ENDPOINT:
+        default:
+            break;
+    }
+    return USBDEV_STAGE_STALL;
+}
+
+static inline int usbdev_request_class_out(usbdev_t *dev)
+{
+    usb_device_request_t *setup_pkt = &dev->setup_pkt;
+
+    switch (REQUEST_RECIPIENT(setup_pkt->bmRequestType)) {
+
+        case REQUEST_TO_INTERFACE:
+            return usbdev_cdc_out_class_if(dev);
+
+        case REQUEST_TO_DEVICE:
+        case REQUEST_TO_ENDPOINT:
+        default:
+            break;
+    }
+    return USBDEV_STAGE_STALL;
+}
+
+static void *usbdev_cdc_acm(void *arg)
+{
+    msg_t msg, reply, msg_q[8];
+    msg_init_queue(msg_q, 8);
+    usbdev_t *dev = arg;
+
+    while (true) {
+        msg_receive(&msg);
+        reply.type = msg.type;
+        usb_ep_t ep = msg.content.value;
+
+        switch (msg.type) {
+            case USBDEV_EVENT_OUT:
+                usbdev_acm_evt_out(dev);
+                break;
+
+            case USBDEV_EVENT_IN:
+		if (ep == ENDPOINT_ADDR_IN(USBDEV_ACM_EP_BULKIN)) {
+                    usbdev_acm_evt_in(dev);
+		}
+                break;
+
+            case USBDEV_EVENT_SOF:
+                if (ep_configured(dev, ENDPOINT_ADDR_IN(USBDEV_ACM_EP_BULKIN))) {
+                    usbdev_acm_sof_event(dev);
+		}
+                break;
+
+            case USBDEV_EVENT_REQUEST_CLASS_SETUP:
+                reply.content.value = usbdev_setup_request_class(dev);
+                msg_reply(&msg, &reply);
+                break;
+
+            case USBDEV_EVENT_REQUEST_CLASS_OUT:
+                reply.content.value = usbdev_request_class_out(dev);
+                msg_reply(&msg, &reply);
+                break;
+
+            case USBDEV_EVENT_RESET:
+                usbdev_acm_reset();
+                break;
+
+	    default:
+                break;
+        }
+    }
+
+    return NULL;
+}
+
+int acm_uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
+{
+    usbdev_acm_reset();
+
+    ucb_config.rx_cb = rx_cb;
+    ucb_config.arg = arg;
+
+    return 0;
+}
+
+void acm_uart_write(uart_t uart, const uint8_t *data, size_t len)
+{
+    mutex_lock(&tx_rb_lock);
+    ringbuffer_add(&cdcacm_tx_rb, (char*)data, len);
+    mutex_unlock(&tx_rb_lock);
+}
+
+uartdev_ops_t acm_uart_ops = {
+    .dev = UART_ACM_0,
+    .uart_init = acm_uart_init,
+    .uart_write = acm_uart_write,
+    .uart_poweron = NULL,
+    .uart_poweroff = NULL,
+};
+
+int usbdev_acm_uart_init (void)
+{
+    uartdev_register_driver(&acm_uart_ops);
+    return 0;
+}
+
+static char usbdev_stack_acm[512];
+
+int usbdev_acm_init(usbdev_t *dev)
+{
+    usbdev_add_string_descriptor(dev, USBDEV_STRING_IDX_CIF, "USB-CDC");
+    usbdev_add_string_descriptor(dev, USBDEV_STRING_IDX_DIF, "CDC-ACM");
+    usbdev_add_cfg_descriptor(dev, (uint8_t*)(&usb_cdc_acm_config));
+
+    dev->device_descriptor->bDeviceClass = COMMUNICATION_DEVICE_CLASS;
+    dev->device_descriptor->bDeviceSubClass = 0;
+    dev->device_descriptor->bDeviceProtocol = 0;
+
+    usbdev_acm_reset();
+
+    kernel_pid_t tmp = thread_create(usbdev_stack_acm,
+                                sizeof(usbdev_stack_acm),
+                                THREAD_PRIORITY_MAIN / 2,
+                                CREATE_STACKTEST | CREATE_WOUT_YIELD,
+                                usbdev_cdc_acm, dev,
+                                "cdcacm");
+
+    dev->ep_in_pid[USBDEV_ACM_EP_INTIN] = tmp;
+    dev->ep_in_pid[USBDEV_ACM_EP_BULKIN] = tmp;
+    dev->ep_out_pid[USBDEV_ACM_EP_BULKOUT] = tmp;
+    return 0;
+}
+
+int usbdev_acm_register(void)
+{
+    usbdev_register_iface(usbdev_acm_init);
+    return 0;
+}
+
+submod_init(usbdev_acm_register);
+driver_init(usbdev_acm_uart_init);

--- a/tests/init/Makefile
+++ b/tests/init/Makefile
@@ -1,0 +1,12 @@
+APPLICATION = init_test
+include ../Makefile.tests_common
+
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+USEMODULE += xtimer
+
+# chronos is missing a getchar implementation
+BOARD_BLACKLIST += chronos
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/init/main.c
+++ b/tests/init/main.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @file
+ * @brief       Init Test
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ *
+ */
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "shell_commands.h"
+#include "shell.h"
+#include "init.h"
+
+volatile static uint32_t init_pattern;
+
+int core_init_test(void)
+{
+    init_pattern |= (1 << INIT_ORDER_CORE);
+    return 0;
+}
+
+int driver_init_test(void)
+{
+    init_pattern |= (1 << INIT_ORDER_DRIVER);
+    return 0;
+}
+
+int module_init_test(void)
+{
+    init_pattern |= (1 << INIT_ORDER_MODULE);
+    return 0;
+}
+
+int submod_init_test(void)
+{
+    init_pattern |= (1 << INIT_ORDER_SUBMOD);
+    return 0;
+}
+
+core_init(core_init_test);
+driver_init(driver_init_test);
+module_init(module_init_test);
+submod_init(submod_init_test);
+
+int main(void)
+{
+    puts("RIOT init test application");
+
+    printf("init_pattern: 0x%08" PRIx32 "\n", init_pattern);
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/usbdev/Makefile
+++ b/tests/usbdev/Makefile
@@ -1,0 +1,28 @@
+APPLICATION = usbtest
+include ../Makefile.tests_common
+
+# If no BOARD is found in the environment, use this default:
+BOARD = pba-d-01-kw2x
+#BOARD = frdm-k64f
+
+CFLAGS += -I$(CURDIR)
+
+# Uncomment this to enable scheduler statistics for ps:
+#CFLAGS += -DSCHEDSTATISTICS
+
+# Uncomment this to enable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+CFLAGS += -DDEVELHELP
+
+# Change this to 0 show compiler invocation lines by default:
+export QUIET = 0
+
+# Modules to include:
+USEMODULE += uart
+USEMODULE += shell
+USEMODULE += usbdev
+USEMODULE += usbdev-acm
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/usbdev/main.c
+++ b/tests/usbdev/main.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Manual test application for UART peripheral drivers
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "board.h"
+#include "shell.h"
+#include "periph/uart.h"
+
+#define SHELL_BUFSIZE       (128U)
+#define UART_BUFSIZE        (128U)
+
+#ifndef STDIO
+#define STDIO               (UART_UNDEF)
+#endif
+
+static int parse_dev(char *arg)
+{
+    int dev = atoi(arg);
+    if (dev == STDIO) {
+        printf("Error: The selected UART_DEV(%i) is used for the shell!\n", dev);
+        return -2;
+    }
+    if (dev < UART_ACM_0 || dev >= UART_NUMOF) {
+        printf("Error: Invalid UART_DEV device specified (%i).\n", dev);
+        return -1;
+    }
+    return dev;
+}
+
+static void rx_cb(void *arg, char data)
+{
+    int dev = (int)arg;
+    uart_write(UART_DEV(dev), (uint8_t*)&data, 1);
+}
+
+static int cmd_init_acm(int argc, char **argv)
+{
+    int dev, res;
+    uint32_t baud;
+
+    if (argc < 3) {
+        printf("usage: %s <dev> <baudrate>\n", argv[0]);
+        return 1;
+    }
+    /* parse parameters */
+    dev = parse_dev(argv[1]);
+    if (dev < 0) {
+        return 1;
+    }
+    baud = (uint32_t)atoi(argv[2]);
+
+    /* initialize UART */
+    res = uart_init(UART_DEV(dev), baud, rx_cb, (void *)dev);
+    if (res == -1) {
+        printf("Error: Given baudrate (%u) not possible\n", (unsigned int)baud);
+        return 1;
+    }
+    else if (res < -1) {
+        puts("Error: Unable to initialize UART device\n");
+        return 1;
+    }
+    printf("Successfully initialized UART_DEV(%i)\n", dev);
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "init-acm", "Initialize a UART device with a given baudrate", cmd_init_acm },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("\nUSB device stack test application");
+    puts("===================================");
+    puts("This application is intended for testing USB interfaces.\n"
+         );
+
+    puts("UART INFO:");
+    printf("Available devices:               %i\n", UART_NUMOF);
+    printf("UART used for STDIO (the shell): UART_DEV(%i)\n\n", STDIO);
+
+    /* run the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    return 0;
+}


### PR DESCRIPTION
USB Device stack implementation for RIOT.

Description:
It's all still WIP but it works. As it says in the title, it is a USB Device stack. It means that a RIOT board with this stack can communicate with the USB host.

For now, only the Kinetis Driver (8bef8ab) exists. It would be great if someone would add a different platform. Possibly the interface between driver and stack needs to be expanded.

Hardware Driver and Stack use few macros and need only few changes in Makefile. The Driver uses a "driver_init" macro to register at the stack, similar to module_init in Linux. It (dc8a7c9) still needs a little fine-tuning. And I hope you find it useful (I do not like the RIOTs autostart).

To be continued....

Supported and boards (SoCs):
- Freescale Kinetis (tested with kw22d512 and k64f)
- Boards pba-d-01 and frdm-k64f

How to test:
- pba-d-01 : The board needs to be slightly modified, a bridge and a capacitor. Instructions follow. The board should be populated with the kw22d512
- frdm-k64f should work without problems

Under test/usbdev (8db566c) is the appropriate Makefile. For testing you can either do
./dist/tools/pyterm/pyterm --port /dev/ttyACM1

Depends on ~~#4114~~, #4163 and serves as an example for #4155 
