### PR TITLE
cpu/stm32l1: optimized baudrate calculation

### DIFF
--- a/cpu/stm32l1/periph/uart.c
+++ b/cpu/stm32l1/periph/uart.c
@@ -98,8 +98,7 @@ int uart_init_blocking(uart_t uart, uint32_t baudrate)
     uint32_t tx_pin = 0;
     uint32_t rx_pin = 0;
     uint8_t af = 0;
-    float clk = 0;
-    float divider;
+    uint32_t clk = 0;
     uint16_t mantissa;
     uint8_t fraction;
 
@@ -166,9 +165,9 @@ int uart_init_blocking(uart_t uart, uint32_t baudrate)
     }
 
     /* uart_configure UART to mode 8N1 with given baudrate */
-    divider = clk / (16 * baudrate);
-    mantissa = (uint16_t)divider;
-    fraction = (uint8_t)((divider - mantissa) * 16);
+    clk /= baudrate;
+    mantissa = (uint16_t)(clk / 16);
+    fraction = (uint8_t)(clk - (mantissa * 16));
     dev->BRR = ((mantissa & 0x0fff) << 4) | (0x0f & fraction);
 
     /* enable receive and transmit mode */


### PR DESCRIPTION
and the last CPU of the family...

Again: `hello-world` on `nucleo-l1`:
```
BEFORE:
   text	   data	    bss	    dec	    hex	filename
   8672	    112	   2640	  11424	   2ca0

AFTER:
   text	   data	    bss	    dec	    hex	filename
   7356	    112	   2640	  10108	   277c
```