### PR TITLE
sc_ipv6_nc: Use more letters for type

### DIFF
--- a/sys/shell/commands/sc_ipv6_nc.c
+++ b/sys/shell/commands/sc_ipv6_nc.c
@@ -72,11 +72,11 @@ static void _print_nc_type(gnrc_ipv6_nc_t *entry)
             break;
 
         case GNRC_IPV6_NC_TYPE_TENTATIVE:
-            printf("T");
+            printf("TENT");
             break;
 
         case GNRC_IPV6_NC_TYPE_REGISTERED:
-            printf("R");
+            printf("REG");
             break;
 
         default:


### PR DESCRIPTION
I was myself a little confused when I saw `R` for a registered address,
since I interpreted it as "router" (though the node wasn't supposed to
be a router). After a wild goose chase for wrongly set flags through the
code I found that `R` stands for "REGISTERED". To prevent such a thing
in the future I opted for fixing this in the output.