### PR TITLE
examples: unblacklist boards in gnrc_networking

### DIFF
--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -8,12 +8,9 @@ BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
-                          nrf6310 nucleo-f334 pca10000 pca10005 \
+                          nrf6310 nucleo-f334 pca10000 pca10005 spark-core \
                           stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 \
                           yunjia-nrf51822 z1
-
-BOARD_BLACKLIST        := spark-core
-# arduino-mega2560: unknown error types (e.g. -EBADMSG)
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present


### PR DESCRIPTION
The issue with `arduino-mega2560` was fixed in #3710 and with #3905 all the other issues are gone, too.
`spark-core` just has insufficient memory (but come on guys 472 bytes is something we can squeeze for the next release, right?).