### PR TITLE
native: add -t <port> option to native again

### DIFF
--- a/cpu/native/include/netdev2_tap.h
+++ b/cpu/native/include/netdev2_tap.h
@@ -66,6 +66,11 @@ void netdev2_tap_setup(netdev2_tap_t *dev, const char *name);
  */
 void netdev2_tap_cleanup(netdev2_tap_t *dev);
 
+/**
+ * @brief Interrupt handler for any IO on the tap socket
+ */
+void native_tap_isr(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -299,7 +299,7 @@ void netdev2_tap_setup(netdev2_tap_t *dev, const char *name) {
     strncpy(dev->tap_name, name, IFNAMSIZ);
 }
 
-static void _tap_isr(void) {
+void native_tap_isr(void) {
     netdev2_t *netdev = (netdev2_t *)&netdev2_tap;
 
     if (netdev->event_callback) {
@@ -380,8 +380,6 @@ static int _init(netdev2_t *netdev)
     DEBUG("gnrc_tapnet_init(): dev->addr = %02x:%02x:%02x:%02x:%02x:%02x\n",
             dev->addr[0], dev->addr[1], dev->addr[2],
             dev->addr[3], dev->addr[4], dev->addr[5]);
-    /* configure signal handler for fds */
-    register_interrupt(SIGIO, _tap_isr);
 #ifdef __MACH__
     /* tuntap signalled IO is not working in OSX,
      * * check http://sourceforge.net/p/tuntaposx/bugs/17/ */

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -71,6 +71,13 @@ void _native_null_in(char *stdiotype)
     }
 }
 
+void _sigio_handler(void)
+{
+#ifdef MODULE_NETDEV2_TAP
+    native_tap_isr();
+#endif
+}
+
 /**
  * set up stdout redirection
  *
@@ -312,6 +319,10 @@ __attribute__((constructor)) static void startup(int argc, char **argv)
 
     native_cpu_init();
     native_interrupt_init();
+
+    /* configure signal handler for fds */
+    register_interrupt(SIGIO, _sigio_handler);
+
 #ifdef MODULE_NETDEV2_TAP
     netdev2_tap_setup(&netdev2_tap, argv[1]);
 #endif

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -45,11 +45,76 @@ pid_t _native_id;
 unsigned _native_rng_seed = 0;
 int _native_rng_mode = 0;
 const char *_native_unix_socket_path = NULL;
+static int _native_fd = -1, _native_socket = -1;
+static fd_set _native_fds;
 
 #ifdef MODULE_NETDEV2_TAP
 #include "netdev2_tap.h"
 extern netdev2_tap_t netdev2_tap;
 #endif
+
+static void _native_init_socket(char *port)
+{
+    struct addrinfo hints, *info, *p;
+    int i;
+
+    memset(&hints, 0, sizeof hints);
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+
+    _native_syscall_enter();
+
+    if ((i = real_getaddrinfo(NULL, port, &hints, &info)) != 0) {
+        errx(EXIT_FAILURE, "native: getaddrinfo: %s", real_gai_strerror(i));
+    }
+
+    for (p = info; p != NULL; p = p->ai_next) {
+        if ((_native_socket = real_socket(p->ai_family, p->ai_socktype, p->ai_protocol)) == -1) {
+            continue;
+        }
+
+        i = 1;
+        if (real_setsockopt(_native_socket, SOL_SOCKET, SO_REUSEADDR, &i, sizeof(int)) == -1) {
+            err(EXIT_FAILURE, "native: setsockopt");
+        }
+
+        if (real_bind(_native_socket, p->ai_addr, p->ai_addrlen) == -1) {
+            real_close(_native_socket);
+            continue;
+        }
+
+        break;
+    }
+
+    if (p == NULL)  {
+        errx(EXIT_FAILURE, "native: failed to bind\n");
+    }
+
+    real_freeaddrinfo(info);
+
+    if (real_listen(_native_socket, 1) == -1) {
+        err(EXIT_FAILURE, "native: listen");
+    }
+
+    FD_ZERO(&_native_fds);
+    FD_SET(_native_socket, &_native_fds);
+
+    int flags = 0;
+    if (fcntl(_native_socket, F_SETOWN, _native_pid) < 0) {
+        err(EXIT_FAILURE, "native: F_SETOWN");
+    }
+
+    if ((flags = fcntl(_native_socket, F_GETFL)) == -1) {
+        err(EXIT_FAILURE, "native: F_GETFL");
+    }
+
+    if (fcntl(_native_socket, F_SETFL, flags | FNDELAY | FASYNC) == -1) {
+        err(EXIT_FAILURE, "native: F_SETFL");
+    }
+
+    _native_syscall_leave();
+}
 
 /**
  * initialize _native_null_in_pipe to allow for reading from stdin
@@ -71,11 +136,38 @@ void _native_null_in(char *stdiotype)
     }
 }
 
-void _sigio_handler(void)
+static void _native_incoming_conn(void)
+{
+    struct sockaddr remote;
+    socklen_t t = sizeof(remote);
+    fd_set read_fds = _native_fds;
+
+    struct timeval ti;
+    memset(&ti, 0, sizeof(ti));
+    if (real_select(FD_SETSIZE, &read_fds, NULL, NULL, &ti) > 0) {
+        if (FD_ISSET(_native_socket, &read_fds)) {
+            if ((_native_fd = real_accept(_native_socket, &remote, &t)) > -1) {
+                FD_SET(_native_fd, &_native_fds);
+                if (real_dup2(_native_fd, STDOUT_FILENO) == -1) {
+                    err(EXIT_FAILURE, "native: dup2");
+                }
+                if (real_dup2(_native_fd, STDIN_FILENO) == -1) {
+                    err(EXIT_FAILURE, "native: dup2");
+                }
+            }
+        }
+    }
+}
+
+static void _sigio_handler(void)
 {
 #ifdef MODULE_NETDEV2_TAP
     native_tap_isr();
 #endif
+
+    if (_native_socket > -1) {
+        _native_incoming_conn();
+    }
 }
 
 /**
@@ -184,6 +276,7 @@ void usage_exit(void)
     real_printf(" <tap interface>");
 #endif
 
+    real_printf(" [-t <port>]");
     real_printf(" [-i <id>] [-d] [-e|-E] [-o]\n");
 
     real_printf(" help: %s -h\n", _progname);
@@ -192,6 +285,7 @@ void usage_exit(void)
 -h          help\n");
 
     real_printf("\
+-t <port>   redirect stdio to TCP socket listening on <port> (implies -d)\n\
 -i <id>     specify instance id (set by config module)\n\
 -s <seed>   specify srandom(3) seed (/dev/random is used instead of\n\
             random(3) if the option is omitted)\n\
@@ -223,6 +317,7 @@ __attribute__((constructor)) static void startup(int argc, char **argv)
     char *stderrtype = "stdio";
     char *stdouttype = "stdio";
     char *stdiotype = "stdio";
+    char *_tcpport = NULL;
     bool daemonize_flag = false;
 
 #if defined(MODULE_NETDEV2_TAP)
@@ -305,6 +400,10 @@ __attribute__((constructor)) static void startup(int argc, char **argv)
     _native_log_stderr(stderrtype);
     _native_log_stdout(stdouttype);
     _native_null_in(stdiotype);
+
+    if (strcmp("tcp", stdiotype) == 0) {
+        _native_init_socket(_tcpport);
+    }
 
     native_cpu_init();
     native_interrupt_init();


### PR DESCRIPTION
This PR brings back the option to set a port and daemonize native in order to use it with desvirt or netcat.
Can be tested with  `./bin/native/gnrc_networking -t 12107` and then `nc localhost 12107`.

@emmanuelsearch @thomaseichinger can anyone of you test this on OS X?