### PR TITLE
boards/samr21-xpro: define serial port for OS X

### DIFF
--- a/boards/samr21-xpro/Makefile.include
+++ b/boards/samr21-xpro/Makefile.include
@@ -4,6 +4,7 @@ export CPU_MODEL = samr21g18a
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* | head -n 1)
 
 # setup the boards dependencies
 include $(RIOTBOARD)/$(BOARD)/Makefile.dep


### PR DESCRIPTION
Define missing `PORT_DARWIN` variable to work with OS X.