### PR TITLE
drivers/cc2420: initial netdev port for cc2420

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -40,6 +40,10 @@ ifneq (,$(filter netdev2_tap,$(USEMODULE)))
   USEMODULE += netif
 endif
 
+ifneq (,$(filter cc2420,$(USEMODULE)))
+  USEMODULE += ieee802154
+endif
+
 ifneq (,$(filter gnrc_zep,$(USEMODULE)))
   USEMODULE += hashes
   USEMODULE += ieee802154

--- a/boards/z1/Makefile.dep
+++ b/boards/z1/Makefile.dep
@@ -1,0 +1,5 @@
+ifneq (,$(filter gnrc_netif_default,$(USEMODULE)))
+  USEMODULE += xtimer
+  USEMODULE += cc2420
+  USEMODULE += gnrc_nomac
+endif

--- a/boards/z1/Makefile.include
+++ b/boards/z1/Makefile.include
@@ -8,6 +8,9 @@ PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial
 
+# setup the boards dependencies
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep
+
 # setup flash tool
 export OFLAGS = -O ihex
 export FLASHER = $(RIOTBASE)/dist/tools/goodfet/goodfet.bsl

--- a/boards/z1/include/board.h
+++ b/boards/z1/include/board.h
@@ -26,6 +26,7 @@
  *
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  *
  */
 
@@ -103,6 +104,15 @@ extern "C" {
 
 #define USER_BTN_PRESSED   ((USER_BTN_PxIN & USER_BTN_MASK) == 0)
 #define USER_BTN_RELEASED  ((USER_BTN_PxIN & USER_BTN_MASK) != 0)
+
+#define CC2420_SPI          SPI_0
+#define CC2420_RESET        GPIO(P4,6)
+#define CC2420_CS           GPIO(P3,0)
+#define CC2420_SPI_CLK      SPI_SPEED_1MHZ
+#define CC2420_FIFO_INT     GPIO(P1,3)
+#define CC2420_FIFOP_INT    GPIO(P1,2)
+#define CC2420_POWER        GPIO(P4,5)
+#define CC2420_GIO1         GPIO(P1,4)
 
 #ifdef __cplusplus
 }

--- a/boards/z1/include/cc2420_params.h
+++ b/boards/z1/include/cc2420_params.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 FU Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   board_z1
+ * @{
+ *
+ * @file
+ * @brief     cc2420 board specific configuration
+ *
+ * @author    Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ */
+
+#ifndef CC2420_PARAMS_H_
+#define CC2420_PARAMS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name cc2420 configuration
+ */
+static const  cc2420_params_t cc2420_params[] =
+    {
+        {
+            .spi = CC2420_SPI,
+            .spi_speed = CC2420_SPI_CLK,
+            .cs_pin = CC2420_CS,
+            .fifo_int_pin = CC2420_FIFO_INT,
+            .fifop_int_pin = CC2420_FIFOP_INT,
+            .power_pin = CC2420_POWER,
+            .reset_pin = CC2420_RESET,
+        },
+    };
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* CC2420_PARAMS_H_ */
+/** @} */

--- a/cpu/msp430fxyz/include/msp430_regs.h
+++ b/cpu/msp430fxyz/include/msp430_regs.h
@@ -111,6 +111,17 @@ typedef struct {
     REG8    BTXBUF;     /**< B transmit buffer */
 } msp_usci_t;
 
+typedef struct {
+    REG8    CTL0;      /**< control 0 */
+    REG8    CTL1;      /**< control 1 */
+    REG8    BR0;       /**< baud rate 0 */
+    REG8    BR1;       /**< baud rate 1 */
+    REG8    reserved;  /**< reserved */
+    REG8    STAT;      /**< status */
+    REG8    RXBUF;     /**< receive buffer */
+    REG8    TXBUF;     /**< transmit buffer */
+} msp_usci_spi_t;
+
 /**
  * @brief   USCI SPI specific registers
  */

--- a/cpu/msp430fxyz/periph/spi.c
+++ b/cpu/msp430fxyz/periph/spi.c
@@ -33,7 +33,7 @@
  */
 static mutex_t spi_lock = MUTEX_INIT;
 
-/* per default, we use the legacy MSP430 USART module for UART functionality */
+/* per default, we use the legacy MSP430 USART module for SPI functionality */
 #ifndef SPI_USE_USIC
 
 int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -46,3 +46,6 @@ endif
 ifneq (,$(filter encx24j600,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/drivers/encx24j600/include
 endif
+ifneq (,$(filter cc2420,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/cc2420/include
+endif

--- a/drivers/cc2420/Makefile
+++ b/drivers/cc2420/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_cc2420
+ * @{
+ *
+ * @file
+ * @brief       Implementation of public functions for CC2420 driver
+ *
+ * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "xtimer.h"
+#include "periph/cpuid.h"
+#include "byteorder.h"
+#include "panic.h"
+#include "net/ieee802154.h"
+#include "net/gnrc.h"
+#include "cc2420_registers.h"
+#include "cc2420_internal.h"
+#include "cc2420_netdev.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+static void _irq_handler(void *arg)
+{
+    msg_t msg;
+    cc2420_t *dev = (cc2420_t *) arg;
+
+    /* tell driver thread about the interrupt */
+    msg.type = GNRC_NETDEV_MSG_TYPE_EVENT;
+    msg_send(&msg, dev->mac_pid);
+}
+
+int cc2420_init(cc2420_t *dev, const cc2420_params_t *params)
+{
+    dev->driver = &cc2420_driver;
+
+    /* initialize device descriptor */
+    dev->spi = params->spi;
+    dev->cs_pin = params->cs_pin;
+    dev->fifo_int_pin = params->fifo_int_pin;
+    dev->fifop_int_pin = params->fifop_int_pin;
+    dev->reset_pin = params->reset_pin;
+    dev->power_pin = params->power_pin;
+    dev->idle_state = CC2420_STATE_IDLE;
+
+    /* initialise SPI */
+    spi_init_master(dev->spi, SPI_CONF_FIRST_RISING, params->spi_speed);
+
+    /* initialise GPIOs */
+    gpio_init(dev->cs_pin, GPIO_DIR_OUT, GPIO_NOPULL);
+    gpio_set(dev->cs_pin);
+    gpio_init(dev->reset_pin, GPIO_DIR_OUT, GPIO_NOPULL);
+    gpio_set(dev->reset_pin);
+    gpio_init(params->power_pin, GPIO_DIR_OUT, GPIO_NOPULL);
+    gpio_clear(params->power_pin);
+    gpio_init_int(dev->fifo_int_pin, GPIO_NOPULL, GPIO_RISING, _irq_handler, dev);
+    gpio_init_int(dev->fifop_int_pin, GPIO_NOPULL, GPIO_RISING, _irq_handler, dev);
+    gpio_set(dev->reset_pin);
+
+    cc2420_reset(dev);
+    return 0;
+}
+
+void cc2420_reset(cc2420_t *dev)
+{
+#if CPUID_ID_LEN
+    uint8_t cpuid[CPUID_ID_LEN];
+    eui64_t addr_long;
+#endif
+
+    /* Power on and toggle reset */
+    gpio_set(dev->power_pin);
+    gpio_clear(dev->reset_pin);
+    xtimer_usleep(CC2420_WAIT_TIME);
+    gpio_set(dev->reset_pin);
+
+    /* enable transceiver's crystal oscillator */
+    cc2420_strobe(dev, CC2420_STROBE_XOSCON);
+
+    /* wait for the oscillator to be stable */
+    xtimer_usleep(CC2420_WAIT_TIME);
+    if ((CC2420_STATUS_BYTE() & CC2420_STATUS_XOSC16M_STABLE) == 0) {
+        /* could not start up radio transceiver! */
+        core_panic(0x2420, "Could not start CC2420 radio transceiver");
+    }
+
+    /* discard any potential garbage in TX buffer */
+    cc2420_strobe(dev, CC2420_STROBE_FLUSHTX);
+
+    /* reset options and sequence number */
+    dev->seq_nr = 0;
+    dev->options = 0;
+    /* set short and long address */
+#if CPUID_ID_LEN
+    cpuid_get(cpuid);
+
+#if CPUID_ID_LEN < 8
+    /* in case CPUID_ID_LEN < 8, fill missing bytes with zeros */
+    for (int i = CPUID_ID_LEN; i < 8; i++) {
+        cpuid[i] = 0;
+    }
+#else
+    for (int i = 8; i < CPUID_ID_LEN; i++) {
+        cpuid[i & 0x07] ^= cpuid[i];
+    }
+#endif
+    /* make sure we mark the address as non-multicast and not globally unique */
+    cpuid[0] &= ~(0x01);
+    cpuid[0] |= 0x02;
+    /* copy and set long address */
+    memcpy(&addr_long, cpuid, 8);
+    cc2420_set_addr_long(dev, NTOHLL(addr_long.uint64.u64));
+    cc2420_set_addr_short(dev, NTOHS(addr_long.uint16[0].u16));
+#else
+    cc2420_set_addr_long(dev, CC2420_DEFAULT_ADDR_LONG);
+    cc2420_set_addr_short(dev, CC2420_DEFAULT_ADDR_SHORT);
+#endif
+    /* set default PAN id */
+    cc2420_set_pan(dev, CC2420_DEFAULT_PANID);
+    /* set default channel */
+    cc2420_set_chan(dev, CC2420_DEFAULT_CHANNEL);
+    /* set default TX power */
+    cc2420_set_txpower(dev, CC2420_DEFAULT_TXPOWER);
+    /* set default options */
+    cc2420_set_option(dev, CC2420_OPT_AUTOACK, true);
+    cc2420_set_option(dev, CC2420_OPT_CSMA, true);
+    cc2420_set_option(dev, CC2420_OPT_TELL_RX_START, false);
+    cc2420_set_option(dev, CC2420_OPT_TELL_RX_END, true);
+    /* set default protocol */
+#ifdef MODULE_NG_SIXLOWPAN
+    dev->proto = GNRC_NETTYPE_SIXLOWPAN;
+#else
+    dev->proto = GNRC_NETTYPE_UNDEF;
+#endif
+
+    /* Change default values as recomended in the data sheet, */
+    /* RX bandpass filter = 1.3uA. */
+    uint16_t reg = cc2420_reg_read(dev, CC2420_REG_RXCTRL1);
+    reg |= CC2420_RXBPF_LOCUR;
+    cc2420_reg_write(dev, CC2420_REG_RXCTRL1, reg);
+
+    /* Set the FIFOP threshold to maximum. */
+    cc2420_reg_write(dev, CC2420_REG_IOCFG0, 127);
+
+    /* Turn off "Security enable" (page 32). */
+    reg = cc2420_reg_read(dev, CC2420_REG_SECCTRL0);
+    reg &= ~CC2420_RXFIFO_PROTECTION;
+    cc2420_reg_write(dev, CC2420_REG_SECCTRL0, reg);
+
+    /* go into RX state */
+    cc2420_set_state(dev, CC2420_STATE_RX_ON);
+}
+
+bool cc2420_cca(cc2420_t *dev)
+{
+    long count = 0;
+    do {
+        count++;
+        if (count >= CC2420_WAIT_TIME) {
+            core_panic(0x2420, "cc2420_get_cca(): RSSI never valid!");
+        }
+    } while (!(CC2420_STATUS_BYTE() & CC2420_STATUS_RSSI_VALID));
+    return CC2420_GIO1;
+}
+
+size_t cc2420_send(cc2420_t *dev, uint8_t *data, size_t len)
+{
+    /* check data length */
+    if (len > CC2420_MAX_PKT_LENGTH) {
+        DEBUG("[cc2420] Error: data to send exceeds max packet size\n");
+        return 0;
+    }
+    cc2420_tx_prepare(dev);
+    cc2420_tx_load(dev, data, len);
+    cc2420_tx_exec(dev);
+    return len;
+}
+
+void cc2420_tx_prepare(cc2420_t *dev)
+{
+    /* make sure ongoing transmissions are finished */
+    while (cc2420_get_state(dev) & CC2420_STATE_TX_BUSY);
+
+    cc2420_strobe(dev, CC2420_STROBE_FLUSHTX);
+
+    cc2420_set_state(dev, CC2420_STATE_TX_PREP);
+    dev->frame_len = IEEE802154_FCS_LEN;
+}
+
+size_t cc2420_tx_load(cc2420_t *dev, uint8_t *data, size_t len)
+{
+    dev->frame_len += (uint8_t)len;
+    cc2420_fb_write(dev, (uint8_t*)&len, 1);
+    cc2420_fb_write(dev, data, len);
+    return len;
+}
+
+void cc2420_tx_exec(cc2420_t *dev)
+{
+    DEBUG("%s\n", __PRETTY_FUNCTION__);
+    /* put tranceiver in idle mode */
+    cc2420_strobe(dev, CC2420_STROBE_RFOFF);
+
+    /* begin transmission: wait for preamble to be sent */
+    cc2420_strobe(dev, CC2420_STROBE_TXON);
+}
+
+size_t cc2420_rx_len(cc2420_t *dev)
+{
+    uint8_t res;
+    cc2420_fb_read(dev, &res, 1);
+    return (size_t)(res - 2);           /* extract the PHR and LQI field */
+}
+
+void cc2420_rx_read(cc2420_t *dev, uint8_t *data, size_t len,
+                          size_t offset)
+{
+    cc2420_ram_read(dev, offset, data, len);
+}

--- a/drivers/cc2420/cc2420_getset.c
+++ b/drivers/cc2420/cc2420_getset.c
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_cc2420
+ * @{
+ *
+ * @file
+ * @brief       Getter and setter functions for the CC2420 drivers
+ *
+ * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "cc2420.h"
+#include "cc2420_internal.h"
+#include "cc2420_registers.h"
+#include "periph/spi.h"
+
+#include "panic.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+static const uint8_t DBM_TO_LEVEL[32] = {
+    31, 27, 25, 23, 21, 19, 17, 15, 13, 12, 11, 10, 9, 8, 7, 7,
+    6, 6, 5, 5, 4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3, 3
+};
+
+static const int LEVEL_TO_DBM[32] = {
+    -25, -25, -25, -24, -21, -19, -17, -15, -13, -12, -11, -10, -9, -8, -7, -7,
+    -6, -6, -5, -5, -4, -4, -3, -3, -2, -2, -1, -1, 0, 0, 0, 0
+};
+
+uint16_t cc2420_get_addr_short(cc2420_t *dev)
+{
+    return (dev->addr_short[0] << 8) | dev->addr_short[1];
+}
+
+void cc2420_set_addr_short(cc2420_t *dev, uint16_t addr)
+{
+    dev->addr_short[0] = addr >> 8;
+    dev->addr_short[1] = addr & 0xff;
+    cc2420_ram_write(dev, CC2420_RAM_SHORTADR, dev->addr_short, 2);
+    cc2420_set_addr_long(dev, 0xffff & addr);
+}
+
+uint64_t cc2420_get_addr_long(cc2420_t *dev)
+{
+    uint64_t addr;
+    uint8_t *ap = (uint8_t *)(&addr);
+    for (int i = 0; i < 8; i++) {
+        ap[i] = dev->addr_long[7 - i];
+    }
+    return addr;
+}
+
+void cc2420_set_addr_long(cc2420_t *dev, uint64_t addr)
+{
+    for (int i = 0; i < 8; i++) {
+        dev->addr_long[i] = (addr >> ((7 - i) * 8));
+    }
+    cc2420_ram_write(dev, CC2420_RAM_IEEEADR, dev->addr_long, 8);
+}
+
+uint8_t cc2420_get_chan(cc2420_t *dev)
+{
+    return dev->chan;
+}
+
+void cc2420_set_chan(cc2420_t *dev, uint8_t channel)
+{
+    if (channel < CC2420_MIN_CHANNEL
+        || channel > CC2420_MAX_CHANNEL) {
+        DEBUG("Invalid channel %i set. Valid channels are 11 through 26\n", chan);
+        return;
+    }
+    dev->chan = channel;
+    /*
+     * calculation from http://www.ti.com/lit/ds/symlink/cc2420.pdf p.50
+     */
+    uint16_t freq= cc2420_reg_read(dev, CC2420_REG_FSCTRL);
+    freq &= ~CC2420_FREQ_MASK;
+    freq |= (357 + (5 * (channel - 11)));
+    cc2420_reg_write(dev, CC2420_REG_FSCTRL, freq);
+}
+
+uint16_t cc2420_get_pan(cc2420_t *dev)
+{
+    uint8_t buf[2];
+    cc2420_ram_read(dev, CC2420_RAM_PANID, buf, 2);
+    return (buf[0]<<8 | buf[1]);
+}
+
+void cc2420_set_pan(cc2420_t *dev, uint16_t pan)
+{
+    uint8_t buf[2];
+    buf[0] = (uint8_t)(pan & 0xFF);
+    buf[1] = (uint8_t)(pan >> 8);
+    dev->pan = pan;
+    DEBUG("pan0: %u, pan1: %u\n", (uint8_t)pan, pan >> 8);
+    cc2420_ram_write(dev, CC2420_RAM_PANID, buf, 2);
+}
+
+int16_t cc2420_get_txpower(cc2420_t *dev)
+{
+    uint16_t txctrl_reg = cc2420_reg_read(dev, CC2420_REG_TXCTRL);
+    /* PA_LEVEL is in the 5 least-significant bits of TXCTRL register */
+    uint8_t level = txctrl_reg & 0x001F;
+    /* determine output power in dBm from TX level */
+    int pow = LEVEL_TO_DBM[level];
+    return pow;
+}
+
+void cc2420_set_txpower(cc2420_t *dev, int16_t txpower)
+{
+    uint16_t txctrl_reg = cc2420_reg_read(dev, CC2420_REG_TXCTRL);
+    /* reset PA_LEVEL bits */
+    txctrl_reg &= 0xFFE0;
+    /* constrain power in transceiver's acceptable set of values */
+    if (txpower > 0) {
+        txpower = 0;
+    }
+    if (txpower < -25) {
+        txpower = -25;
+    }
+    /* determine TX level from power in dBm */
+    uint8_t level = DBM_TO_LEVEL[-txpower];
+    /* put wanted value in PA_LEVEL bits, and write back register */
+    txctrl_reg |= level;
+    cc2420_reg_write(dev, CC2420_REG_TXCTRL, txctrl_reg);
+}
+
+void cc2420_set_option(cc2420_t *dev, uint16_t option, bool state)
+{
+    uint16_t tmp;
+
+    DEBUG("set option %i to %i\n", option, state);
+
+    /* set option field */
+    if (state) {
+        dev->options |= option;
+        /* trigger option specific actions */
+        switch (option) {
+            case CC2420_OPT_CSMA:
+                DEBUG("[cc2420] opt: enabling CSMA mode (NOT IMPLEMENTED)\n");
+                /* TODO: en/disable csma */
+                break;
+            case CC2420_OPT_PROMISCUOUS:
+                DEBUG("[cc2420] opt: enabling PROMISCUOUS mode\n");
+                tmp = cc2420_reg_read(dev, CC2420_REG_MDMCTRL0);
+                /* disable auto ACKs in promiscuous mode */
+                tmp &= ~CC2420_AUTOACK;
+                /* enable promiscuous mode */
+                tmp &= ~CC2420_ADR_DECODE;
+                cc2420_reg_write(dev, CC2420_REG_MDMCTRL0, tmp);
+                dev->options &= ~(CC2420_OPT_AUTOACK);
+                break;
+            case CC2420_OPT_AUTOACK:
+                DEBUG("[cc2420] opt: enabling auto ACKs\n");
+                tmp = cc2420_reg_read(dev, CC2420_REG_MDMCTRL0);
+                tmp |= CC2420_AUTOACK;
+                cc2420_reg_write(dev, CC2420_REG_MDMCTRL0, tmp);
+                break;
+            case CC2420_OPT_TELL_RX_START:
+                DEBUG("[cc2420] opt: enabling SFD IRQ (NOT IMPLEMENTED)\n");
+                /* TODO */
+                break;
+            default:
+                /* do nothing */
+                break;
+        }
+    }
+    else {
+        dev->options &= ~(option);
+        /* trigger option specific actions */
+        switch (option) {
+            case CC2420_OPT_CSMA:
+                DEBUG("[cc2420] opt: disabling CSMA mode (NOT IMPLEMENTED)\n");
+                /* TODO: en/disable csma */
+                break;
+            case CC2420_OPT_PROMISCUOUS:
+                DEBUG("[cc2420] opt: disabling PROMISCUOUS mode\n");
+                /* disable promiscuous mode */
+                tmp = cc2420_reg_read(dev, CC2420_REG_MDMCTRL0);
+                tmp |= CC2420_ADR_DECODE;
+                /* re-enable AUTOACK only if the option was set */
+                if (dev->options & CC2420_OPT_AUTOACK) {
+                    tmp |= CC2420_AUTOACK;
+                }
+                cc2420_reg_write(dev, CC2420_REG_MDMCTRL0, tmp);
+                break;
+            case CC2420_OPT_AUTOACK:
+                DEBUG("[cc2420] opt: disabling auto ACKs\n");
+                tmp = cc2420_reg_read(dev, CC2420_REG_MDMCTRL0);
+                tmp &= ~CC2420_AUTOACK;
+                cc2420_reg_write(dev, CC2420_REG_MDMCTRL0, tmp);
+                break;
+            case CC2420_OPT_TELL_RX_START:
+                DEBUG("[cc2420] opt: disabling SFD IRQ (NOT IMPLEMENTED)\n");
+                /* TODO */
+                break;
+            default:
+                /* do nothing */
+                break;
+        }
+    }
+}
+
+inline uint8_t cc2420_get_state(cc2420_t *dev)
+{
+    uint16_t state = 0;
+    state = cc2420_reg_read(dev, CC2420_REG_FSMSTATE);
+    return dev->state;
+}
+
+void cc2420_set_state(cc2420_t *dev, uint8_t state)
+{
+    switch (state) {
+        case CC2420_STATE_IDLE:
+            cc2420_strobe(dev, CC2420_STROBE_RFOFF);
+            break;
+        case CC2420_STATE_P_DOWN:
+            cc2420_strobe(dev, CC2420_STROBE_XOSCOFF);
+            break;
+        case CC2420_STATE_RX_ON:
+            cc2420_strobe(dev, CC2420_STROBE_RXON);
+            break;
+        case CC2420_STATE_TX_BUSY:
+            cc2420_strobe(dev, CC2420_STROBE_TXON);
+            break;
+        case CC2420_STATE_TX_PREP:
+        case CC2420_STATE_RX_BUSY:
+        case CC2420_STATE_IN_PROGRESS:
+            /* driver internal state, don't directly match FSM's states */
+            break;
+        default:
+            core_panic(0x2420, "Unknown state passed to state machine!");
+            break;
+    }
+    dev->state = state;
+}

--- a/drivers/cc2420/cc2420_internal.c
+++ b/drivers/cc2420/cc2420_internal.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_cc2420
+ * @{
+ *
+ * @file
+ * @brief       Implementation of driver internal functions
+ *
+ * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "periph/spi.h"
+#include "periph/gpio.h"
+#include "cc2420_internal.h"
+#include "cc2420_registers.h"
+
+void cc2420_reg_write(const cc2420_t *dev,
+                      const uint8_t addr,
+                      const uint16_t value)
+{
+    spi_acquire(dev->spi);
+    gpio_clear(dev->cs_pin);
+    spi_transfer_regs(dev->spi,
+                      CC2420_ACCESS_REG_WRITE | addr,
+                      (char *)&value, NULL, 2);
+    gpio_set(dev->cs_pin);
+    spi_release(dev->spi);
+}
+
+uint16_t cc2420_reg_read(const cc2420_t *dev, const uint8_t addr)
+{
+    uint16_t value;
+
+    spi_acquire(dev->spi);
+    gpio_clear(dev->cs_pin);
+    spi_transfer_regs(dev->spi,
+                      CC2420_ACCESS_REG_READ | addr,
+                      NULL, (char *)&value, 2);
+    gpio_set(dev->cs_pin);
+    spi_release(dev->spi);
+
+    return value;
+}
+
+uint8_t cc2420_strobe(const cc2420_t *dev, const uint8_t command)
+{
+    char result;
+
+    spi_acquire(dev->spi);
+    gpio_clear(dev->cs_pin);
+    spi_transfer_byte(dev->spi, (char)command, &result);
+    gpio_set(dev->cs_pin);
+    spi_release(dev->spi);
+
+    return (uint8_t)result;
+}
+
+void cc2420_ram_read(const cc2420_t *dev, const uint16_t address,
+                     uint8_t *data, const size_t len)
+{
+    spi_acquire(dev->spi);
+    gpio_clear(dev->cs_pin);
+    spi_transfer_byte(dev->spi, (CC2420_ACCESS_RAM | (address & 0x7f)), NULL);
+    spi_transfer_byte(dev->spi,
+                      (CC2420_ACCESS_RAM_READ | ((address >> 1) & 0xc0)),
+                      NULL);
+    spi_transfer_bytes(dev->spi, NULL, (char*)data, len);
+    gpio_set(dev->cs_pin);
+    spi_release(dev->spi);
+}
+
+void cc2420_ram_write(const cc2420_t *dev, const uint16_t address,
+                      const uint8_t *data, const size_t len)
+{
+    spi_acquire(dev->spi);
+    gpio_clear(dev->cs_pin);
+    spi_transfer_byte(dev->spi, (CC2420_ACCESS_RAM | (address & 0x7f)), NULL);
+    spi_transfer_byte(dev->spi,
+                      (CC2420_ACCESS_RAM_WRITE | ((address >> 1) & 0xc0)),
+                      NULL);
+    spi_transfer_bytes(dev->spi, (char*)data, NULL, len);
+    gpio_set(dev->cs_pin);
+    spi_release(dev->spi);
+}
+
+void cc2420_fb_read(const cc2420_t *dev, uint8_t *data, const size_t len)
+{
+    spi_acquire(dev->spi);
+    gpio_clear(dev->cs_pin);
+    spi_transfer_regs(dev->spi, CC2420_REG_RXFIFO | CC2420_ACCESS_REG_READ,
+                      NULL, (char *)data, len);
+    gpio_set(dev->cs_pin);
+    spi_release(dev->spi);
+}
+
+void cc2420_fb_write(const cc2420_t *dev,
+                       uint8_t *data,
+                       const size_t len)
+{
+    spi_acquire(dev->spi);
+    gpio_clear(dev->cs_pin);
+    spi_transfer_regs(dev->spi, CC2420_REG_TXFIFO | CC2420_ACCESS_REG_WRITE,
+                      (char *)data, NULL, len);
+    gpio_set(dev->cs_pin);
+    spi_release(dev->spi);
+}

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -1,0 +1,708 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_cc2420
+ * @{
+ *
+ * @file
+ * @brief       Netdev adaption for the CC2420 drivers
+ *
+ * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "net/eui64.h"
+#include "net/ieee802154.h"
+#include "net/gnrc.h"
+#include "cc2420.h"
+#include "cc2420_netdev.h"
+#include "cc2420_internal.h"
+#include "cc2420_registers.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#define _MAX_MHR_OVERHEAD   (25)
+
+/* TODO: generalize and move to ieee802154 */
+static size_t _make_data_frame_hdr(cc2420_t *dev, uint8_t *buf,
+                                   gnrc_netif_hdr_t *hdr)
+{
+    int pos = 0;
+
+    /* we are building a data frame here */
+    buf[0] = IEEE802154_FCF_TYPE_DATA;
+    buf[1] = IEEE802154_FCF_VERS_V1;
+
+    /* if AUTOACK is enabled, then we also expect ACKs for this packet */
+    if (!(hdr->flags & GNRC_NETIF_HDR_FLAGS_BROADCAST) &&
+        !(hdr->flags & GNRC_NETIF_HDR_FLAGS_MULTICAST) &&
+        (dev->options & CC2420_OPT_AUTOACK)) {
+        buf[0] |= IEEE802154_FCF_ACK_REQ;
+    }
+
+    /* fill in destination PAN ID */
+    pos = 3;
+    buf[pos++] = (uint8_t)((dev->pan) & 0xff);
+    buf[pos++] = (uint8_t)((dev->pan) >> 8);
+
+    /* fill in destination address */
+    if (hdr->flags &
+        (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
+        buf[1] |= IEEE802154_FCF_DST_ADDR_SHORT;
+        buf[pos++] = 0xff;
+        buf[pos++] = 0xff;
+    }
+    else if (hdr->dst_l2addr_len == 2) {
+        uint8_t *dst_addr = gnrc_netif_hdr_get_dst_addr(hdr);
+        buf[1] |= IEEE802154_FCF_DST_ADDR_SHORT;
+        buf[pos++] = dst_addr[1];
+        buf[pos++] = dst_addr[0];
+    }
+    else if (hdr->dst_l2addr_len == 8) {
+        buf[1] |= IEEE802154_FCF_DST_ADDR_LONG;
+        uint8_t *dst_addr = gnrc_netif_hdr_get_dst_addr(hdr);
+        for (int i = 7;  i >= 0; i--) {
+            buf[pos++] = dst_addr[i];
+        }
+    }
+    else {
+        /* unsupported address length */
+        return 0;
+    }
+
+    /* fill in source PAN ID (if applicable */
+    if (dev->options & CC2420_OPT_USE_SRC_PAN) {
+        buf[pos++] = (uint8_t)((dev->pan) & 0xff);
+        buf[pos++] = (uint8_t)((dev->pan) >> 8);
+    } else {
+        buf[0] |= IEEE802154_FCF_PAN_COMP;
+    }
+
+    /* fill in source address */
+    if (dev->options & CC2420_OPT_SRC_ADDR_LONG) {
+        buf[1] |= IEEE802154_FCF_SRC_ADDR_LONG;
+        memcpy(&(buf[pos]), dev->addr_long, 8);
+        pos += 8;
+    }
+    else {
+        buf[1] |= IEEE802154_FCF_SRC_ADDR_SHORT;
+        buf[pos++] = dev->addr_short[0];
+        buf[pos++] = dev->addr_short[1];
+    }
+
+    /* set sequence number */
+    buf[2] = dev->seq_nr++;
+    /* return actual header length */
+    return pos;
+}
+
+/* TODO: generalize and move to ieee802154 */
+/* TODO: include security header implications */
+static size_t _get_frame_hdr_len(uint8_t *mhr)
+{
+    uint8_t tmp;
+    size_t len = 3;
+
+    /* figure out address sizes */
+    tmp = (mhr[1] & IEEE802154_FCF_DST_ADDR_MASK);
+    if (tmp == IEEE802154_FCF_DST_ADDR_SHORT) {
+        len += 4;
+    }
+    else if (tmp == IEEE802154_FCF_DST_ADDR_LONG) {
+        len += 10;
+    }
+    else if (tmp != IEEE802154_FCF_DST_ADDR_VOID) {
+        return 0;
+    }
+    tmp = (mhr[1] & IEEE802154_FCF_SRC_ADDR_MASK);
+    if (tmp == IEEE802154_FCF_SRC_ADDR_VOID) {
+        return len;
+    }
+    else {
+        if (!(mhr[0] & IEEE802154_FCF_PAN_COMP)) {
+            len += 2;
+        }
+        if (tmp == IEEE802154_FCF_SRC_ADDR_SHORT) {
+            return (len + 2);
+        }
+        else if (tmp == IEEE802154_FCF_SRC_ADDR_LONG) {
+            return (len + 8);
+        }
+    }
+    return 0;
+}
+
+/* TODO: generalize and move to ieee802154 */
+static gnrc_pktsnip_t *_make_netif_hdr(uint8_t *mhr)
+{
+    uint8_t tmp;
+    uint8_t *addr;
+    uint8_t src_len, dst_len;
+    gnrc_pktsnip_t *snip;
+    gnrc_netif_hdr_t *hdr;
+
+    /* figure out address sizes */
+    tmp = mhr[1] & IEEE802154_FCF_SRC_ADDR_MASK;
+    if (tmp == IEEE802154_FCF_SRC_ADDR_SHORT) {
+        src_len = 2;
+    }
+    else if (tmp == IEEE802154_FCF_SRC_ADDR_LONG) {
+        src_len = 8;
+    }
+    else if (tmp == IEEE802154_FCF_SRC_ADDR_VOID) {
+        src_len = 0;
+    }
+    else {
+        return NULL;
+    }
+    tmp = mhr[1] & IEEE802154_FCF_DST_ADDR_MASK;
+    if (tmp == IEEE802154_FCF_DST_ADDR_SHORT) {
+        dst_len = 2;
+    }
+    else if (tmp == IEEE802154_FCF_DST_ADDR_LONG) {
+        dst_len = 8;
+    }
+    else if (tmp == IEEE802154_FCF_DST_ADDR_VOID) {
+        dst_len = 0;
+    }
+    else {
+        return NULL;
+    }
+    /* allocate space for header */
+    snip = gnrc_pktbuf_add(NULL, NULL, sizeof(gnrc_netif_hdr_t) + src_len + dst_len,
+                         GNRC_NETTYPE_NETIF);
+    if (snip == NULL) {
+        return NULL;
+    }
+    /* fill header */
+    hdr = (gnrc_netif_hdr_t *)snip->data;
+    gnrc_netif_hdr_init(hdr, src_len, dst_len);
+    if (dst_len > 0) {
+        tmp = 5 + dst_len;
+        addr = gnrc_netif_hdr_get_dst_addr(hdr);
+        for (int i = 0; i < dst_len; i++) {
+            addr[i] = mhr[5 + (dst_len - i) - 1];
+        }
+    }
+    else {
+        tmp = 3;
+    }
+    if (!(mhr[0] & IEEE802154_FCF_PAN_COMP)) {
+        tmp += 2;
+    }
+    if (src_len > 0) {
+        addr = gnrc_netif_hdr_get_src_addr(hdr);
+        for (int i = 0; i < src_len; i++) {
+            addr[i] = mhr[tmp + (src_len - i) - 1];
+        }
+    }
+    return snip;
+}
+
+
+static int _send(gnrc_netdev_t *netdev, gnrc_pktsnip_t *pkt)
+{
+    cc2420_t *dev = (cc2420_t *)netdev;
+    gnrc_pktsnip_t *snip;
+    uint8_t mhr[IEEE802154_MAX_HDR_LEN];
+    size_t len;
+
+    if (pkt == NULL) {
+        return -ENOMSG;
+    }
+    if (dev == NULL) {
+        gnrc_pktbuf_release(pkt);
+        return -ENODEV;
+    }
+
+    /* create 802.15.4 header */
+    len = _make_data_frame_hdr(dev, mhr, (gnrc_netif_hdr_t *)pkt->data);
+    if (len == 0) {
+        DEBUG("[cc2420] error: unable to create 802.15.4 header\n");
+        gnrc_pktbuf_release(pkt);
+        return -ENOMSG;
+    }
+    /* check if packet (header + payload + FCS) fits into FIFO */
+    snip = pkt->next;
+    if ((gnrc_pkt_len(snip) + len + 2) > CC2420_MAX_PKT_LENGTH) {
+        DEBUG("[cc2420] error: packet too large (%u byte) to be send\n",
+               gnrc_pkt_len(snip) + len + 2);
+        gnrc_pktbuf_release(pkt);
+        return -EOVERFLOW;
+    }
+
+    cc2420_tx_prepare(dev);
+    /* put header into FIFO */
+    len = cc2420_tx_load(dev, mhr, len);
+    /* load packet data into FIFO */
+    while (snip) {
+        len = cc2420_tx_load(dev, snip->data, snip->size);
+        snip = snip->next;
+    }
+    /* send data out directly if pre-loading id disabled */
+    if (!(dev->options & CC2420_OPT_PRELOADING)) {
+        cc2420_tx_exec(dev);
+    }
+    /* release packet */
+    gnrc_pktbuf_release(pkt);
+    /* return the number of bytes that were actually send out */
+    return (int)len;
+}
+
+static void _receive_data(cc2420_t *dev)
+{
+    uint8_t mhr[IEEE802154_MAX_HDR_LEN];
+    size_t pkt_len, hdr_len;
+    gnrc_pktsnip_t *hdr, *payload = NULL;
+    gnrc_netif_hdr_t *netif;
+
+    /* get the size of the received packet (unlocks frame buffer protection) */
+    pkt_len = cc2420_rx_len(dev);
+
+    /* abort here already if no event callback is registered */
+    if (!dev->event_cb) {
+        return;
+    }
+
+    /* in raw mode, just read the binary dump into the packet buffer */
+    if (dev->options & CC2420_OPT_RAWDUMP) {
+        payload = gnrc_pktbuf_add(NULL, NULL, pkt_len, GNRC_NETTYPE_UNDEF);
+        if (payload == NULL ) {
+            DEBUG("[cc2420] error: unable to allocate RAW data\n");
+            return;
+        }
+        cc2420_rx_read(dev, payload->data, pkt_len, 0);
+        dev->event_cb(NETDEV_EVENT_RX_COMPLETE, payload);
+        return;
+    }
+
+    /* get FCF field and compute 802.15.4 header length */
+    cc2420_rx_read(dev, mhr, 2, 0);
+    hdr_len = _get_frame_hdr_len(mhr);
+    if (hdr_len == 0) {
+        DEBUG("[cc2420] error: unable parse incoming frame header\n");
+        return;
+    }
+    /* read the rest of the header and parse the netif header from it */
+    cc2420_rx_read(dev, &(mhr[2]), hdr_len - 2, 2);
+    hdr = _make_netif_hdr(mhr);
+    if (hdr == NULL) {
+        DEBUG("[cc2420] error: unable to allocate netif header\n");
+        return;
+    }
+    /* fill missing fields in netif header */
+    netif = (gnrc_netif_hdr_t *)hdr->data;
+    netif->if_pid = dev->mac_pid;
+    cc2420_rx_read(dev, &(netif->lqi), 1, pkt_len);
+
+    /* TODO: query RSSI value here */
+
+    /* allocate payload */
+    payload = gnrc_pktbuf_add(hdr, NULL, (pkt_len - hdr_len), dev->proto);
+    if (payload == NULL) {
+        DEBUG("[cc2420] error: unable to allocate incoming payload\n");
+        gnrc_pktbuf_release(hdr);
+        return;
+    }
+    /* copy payload */
+    cc2420_rx_read(dev, payload->data, payload->size, hdr_len);
+    /* finish up and send data to upper layers */
+    dev->event_cb(NETDEV_EVENT_RX_COMPLETE, payload);
+}
+
+static int _set_state(cc2420_t *dev, netopt_state_t state)
+{
+    switch (state) {
+        case NETOPT_STATE_SLEEP:
+            cc2420_set_state(dev, CC2420_STATE_IDLE);
+            break;
+        case NETOPT_STATE_IDLE:
+            cc2420_set_state(dev, CC2420_STATE_RX_ON);
+            break;
+        case NETOPT_STATE_TX:
+            if (dev->options & CC2420_OPT_PRELOADING) {
+                cc2420_tx_exec(dev);
+            }
+            break;
+        case NETOPT_STATE_RESET:
+            cc2420_reset(dev);
+            break;
+        default:
+            return -ENOTSUP;
+    }
+    return sizeof(netopt_state_t);
+}
+
+netopt_state_t _get_state(cc2420_t *dev)
+{
+    switch (cc2420_get_state(dev)) {
+        case CC2420_STATE_IDLE:
+            return NETOPT_STATE_SLEEP;
+        case CC2420_STATE_RX_BUSY:
+            return NETOPT_STATE_RX;
+        case CC2420_STATE_TX_PREP:
+        case CC2420_STATE_TX_BUSY:
+            return NETOPT_STATE_TX;
+        case CC2420_STATE_RX_ON:
+        default:
+            return NETOPT_STATE_IDLE;
+    }
+}
+
+static int _get(gnrc_netdev_t *device, netopt_t opt, void *val, size_t max_len)
+{
+    if (device == NULL) {
+        return -ENODEV;
+    }
+    cc2420_t *dev = (cc2420_t *) device;
+
+    switch (opt) {
+
+        case NETOPT_ADDRESS:
+            if (max_len < sizeof(uint16_t)) {
+                return -EOVERFLOW;
+            }
+            *((uint16_t *)val) = cc2420_get_addr_short(dev);
+            return sizeof(uint16_t);
+
+        case NETOPT_ADDRESS_LONG:
+            if (max_len < sizeof(uint64_t)) {
+                return -EOVERFLOW;
+            }
+            *((uint64_t *)val) = cc2420_get_addr_long(dev);
+            return sizeof(uint64_t);
+
+        case NETOPT_ADDR_LEN:
+            if (max_len < sizeof(uint16_t)) {
+                return -EOVERFLOW;
+            }
+            *((uint16_t *)val) = 2;
+            return sizeof(uint16_t);
+
+        case NETOPT_SRC_LEN:
+            if (max_len < sizeof(uint16_t)) {
+                return -EOVERFLOW;
+            }
+            if (dev->options & CC2420_OPT_SRC_ADDR_LONG) {
+                *((uint16_t *)val) = 8;
+            }
+            else {
+                *((uint16_t *)val) = 2;
+            }
+            return sizeof(uint16_t);
+
+        case NETOPT_NID:
+            if (max_len < sizeof(uint16_t)) {
+                return -EOVERFLOW;
+            }
+            *((uint16_t *)val) = dev->pan;
+            return sizeof(uint16_t);
+
+        case NETOPT_IPV6_IID:
+            if (max_len < sizeof(eui64_t)) {
+                return -EOVERFLOW;
+            }
+            if (dev->options & CC2420_OPT_SRC_ADDR_LONG) {
+                uint64_t addr = cc2420_get_addr_long(dev);
+                ieee802154_get_iid(val, (uint8_t *)&addr, 8);
+            }
+            else {
+                uint16_t addr = cc2420_get_addr_short(dev);
+                ieee802154_get_iid(val, (uint8_t *)&addr, 2);
+            }
+            return sizeof(eui64_t);
+
+        case NETOPT_PROTO:
+            if (max_len < sizeof(gnrc_nettype_t)) {
+                return -EOVERFLOW;
+            }
+            *((gnrc_nettype_t *)val) = dev->proto;
+            return sizeof(gnrc_nettype_t);
+
+        case NETOPT_CHANNEL:
+            if (max_len < sizeof(uint16_t)) {
+                return -EOVERFLOW;
+            }
+            ((uint8_t *)val)[1] = 0;
+            ((uint8_t *)val)[0] = cc2420_get_chan(dev);
+            return sizeof(uint16_t);
+
+        case NETOPT_TX_POWER:
+            if (max_len < sizeof(int16_t)) {
+                return -EOVERFLOW;
+            }
+            *((uint16_t *)val) = cc2420_get_txpower(dev);
+            return sizeof(uint16_t);
+
+        case NETOPT_MAX_PACKET_SIZE:
+            if (max_len < sizeof(int16_t)) {
+                return -EOVERFLOW;
+            }
+            *((uint16_t *)val) = CC2420_MAX_PKT_LENGTH - _MAX_MHR_OVERHEAD;
+            return sizeof(uint16_t);
+
+        case NETOPT_STATE:
+            if (max_len < sizeof(netopt_state_t)) {
+                return -EOVERFLOW;
+            }
+            *((netopt_state_t*)val) = _get_state(dev);
+            break;
+
+        case NETOPT_PRELOADING:
+            if (dev->options & CC2420_OPT_PRELOADING) {
+                *((netopt_enable_t *)val) = NETOPT_ENABLE;
+            }
+            else {
+                *((netopt_enable_t *)val) = NETOPT_DISABLE;
+            }
+            return sizeof(netopt_enable_t);
+
+        case NETOPT_AUTOACK:
+            if (dev->options & CC2420_OPT_AUTOACK) {
+                *((netopt_enable_t *)val) = NETOPT_ENABLE;
+            }
+            else {
+                *((netopt_enable_t *)val) = NETOPT_DISABLE;
+            }
+            return sizeof(netopt_enable_t);
+
+        case NETOPT_PROMISCUOUSMODE:
+            if (dev->options & CC2420_OPT_PROMISCUOUS) {
+                *((netopt_enable_t *)val) = NETOPT_ENABLE;
+            }
+            else {
+                *((netopt_enable_t *)val) = NETOPT_DISABLE;
+            }
+            return sizeof(netopt_enable_t);
+
+        case NETOPT_RAWMODE:
+            if (dev->options & CC2420_OPT_RAWDUMP) {
+                *((netopt_enable_t *)val) = NETOPT_ENABLE;
+            }
+            else {
+                *((netopt_enable_t *)val) = NETOPT_DISABLE;
+            }
+            return sizeof(netopt_enable_t);
+
+        case NETOPT_IS_CHANNEL_CLR:
+            if (cc2420_cca(dev)) {
+                *((netopt_enable_t *)val) = NETOPT_ENABLE;
+            }
+            else {
+                *((netopt_enable_t *)val) = NETOPT_DISABLE;
+            }
+            return sizeof(netopt_enable_t);
+
+        case NETOPT_RX_START_IRQ:
+            *((netopt_enable_t *)val) =
+                !!(dev->options & CC2420_OPT_TELL_RX_START);
+            return sizeof(netopt_enable_t);
+
+        case NETOPT_RX_END_IRQ:
+            *((netopt_enable_t *)val) =
+                !!(dev->options & CC2420_OPT_TELL_RX_END);
+            return sizeof(netopt_enable_t);
+
+        case NETOPT_TX_START_IRQ:
+            *((netopt_enable_t *)val) =
+                !!(dev->options & CC2420_OPT_TELL_TX_START);
+            return sizeof(netopt_enable_t);
+
+        case NETOPT_TX_END_IRQ:
+            *((netopt_enable_t *)val) =
+                !!(dev->options & CC2420_OPT_TELL_TX_END);
+            return sizeof(netopt_enable_t);
+
+        default:
+            return -ENOTSUP;
+    }
+
+    return 0;
+}
+
+static int _set(gnrc_netdev_t *device, netopt_t opt, void *val, size_t len)
+{
+    cc2420_t *dev = (cc2420_t *) device;
+    if (dev == NULL) {
+        return -ENODEV;
+    }
+
+    switch (opt) {
+        case NETOPT_ADDRESS:
+            if (len > sizeof(uint16_t)) {
+                return -EOVERFLOW;
+            }
+            cc2420_set_addr_short(dev, *((uint16_t*)val));
+            return sizeof(uint16_t);
+
+        case NETOPT_ADDRESS_LONG:
+            if (len > sizeof(uint64_t)) {
+                return -EOVERFLOW;
+            }
+            cc2420_set_addr_long(dev, *((uint64_t*)val));
+            return sizeof(uint64_t);
+
+        case NETOPT_SRC_LEN:
+            if (len > sizeof(uint16_t)) {
+                return -EOVERFLOW;
+            }
+            if (*((uint16_t *)val) == 2) {
+                cc2420_set_option(dev, CC2420_OPT_SRC_ADDR_LONG, false);
+            }
+            else if (*((uint16_t *)val) == 8) {
+                cc2420_set_option(dev, CC2420_OPT_SRC_ADDR_LONG, true);
+            }
+            else {
+                return -ENOTSUP;
+            }
+            return sizeof(uint16_t);
+
+        case NETOPT_NID:
+            if (len > sizeof(uint16_t)) {
+                return -EOVERFLOW;
+            }
+            cc2420_set_pan(dev, *((uint16_t *)val));
+            return sizeof(uint16_t);
+
+        case NETOPT_CHANNEL:
+            if (len != sizeof(uint16_t)) {
+                return -EINVAL;
+            }
+            uint8_t chan = ((uint8_t *)val)[0];
+            if (chan < CC2420_MIN_CHANNEL ||
+                chan > CC2420_MAX_CHANNEL) {
+                return -ENOTSUP;
+            }
+            cc2420_set_chan(dev, chan);
+            return sizeof(uint16_t);
+
+        case NETOPT_TX_POWER:
+            if (len > sizeof(int16_t)) {
+                return -EOVERFLOW;
+            }
+            cc2420_set_txpower(dev, *((int16_t *)val));
+            return sizeof(uint16_t);
+
+        case NETOPT_STATE:
+            if (len > sizeof(netopt_state_t)) {
+                return -EOVERFLOW;
+            }
+            return _set_state(dev, *((netopt_state_t *)val));
+
+        case NETOPT_AUTOACK:
+            cc2420_set_option(dev, CC2420_OPT_AUTOACK,
+                                    ((bool *)val)[0]);
+            return sizeof(netopt_enable_t);
+
+        case NETOPT_PRELOADING:
+            cc2420_set_option(dev, CC2420_OPT_PRELOADING,
+                                    ((bool *)val)[0]);
+            return sizeof(netopt_enable_t);
+
+        case NETOPT_PROMISCUOUSMODE:
+            cc2420_set_option(dev, CC2420_OPT_PROMISCUOUS,
+                                    ((bool *)val)[0]);
+            return sizeof(netopt_enable_t);
+
+        case NETOPT_RAWMODE:
+            cc2420_set_option(dev, CC2420_OPT_RAWDUMP,
+                                    ((bool *)val)[0]);
+            return sizeof(netopt_enable_t);
+
+        case NETOPT_RX_START_IRQ:
+            cc2420_set_option(dev, CC2420_OPT_TELL_RX_START,
+                                    ((bool *)val)[0]);
+            return sizeof(netopt_enable_t);
+
+        case NETOPT_RX_END_IRQ:
+            cc2420_set_option(dev, CC2420_OPT_TELL_RX_END,
+                                    ((bool *)val)[0]);
+            return sizeof(netopt_enable_t);
+
+        case NETOPT_TX_START_IRQ:
+            cc2420_set_option(dev, CC2420_OPT_TELL_TX_START,
+                                    ((bool *)val)[0]);
+            return sizeof(netopt_enable_t);
+
+        case NETOPT_TX_END_IRQ:
+            cc2420_set_option(dev, CC2420_OPT_TELL_TX_END,
+                                    ((bool *)val)[0]);
+            return sizeof(netopt_enable_t);
+
+        default:
+            return -ENOTSUP;
+    }
+
+    return 0;
+}
+
+static int _add_event_cb(gnrc_netdev_t *dev, gnrc_netdev_event_cb_t cb)
+{
+    if (dev == NULL) {
+        return -ENODEV;
+    }
+    if (dev->event_cb) {
+        return -ENOBUFS;
+    }
+
+    dev->event_cb = cb;
+    return 0;
+}
+
+static int _rem_event_cb(gnrc_netdev_t *dev, gnrc_netdev_event_cb_t cb)
+{
+    if (dev == NULL) {
+        return -ENODEV;
+    }
+    if (dev->event_cb != cb) {
+        return -ENOENT;
+    }
+
+    dev->event_cb = NULL;
+    return 0;
+}
+
+static void _isr_event(gnrc_netdev_t *device, uint32_t event_type)
+{
+    cc2420_t *dev = (cc2420_t *) device;
+
+    /* Check if FIFOP signal is raising => RX interrupt */
+    if (gpio_read(dev->fifop_int_pin) != 0) {
+        DEBUG("[cc2420] EVT - RX_END\n");
+        gpio_clear(dev->fifop_int_pin);
+        if (!(dev->options & CC2420_OPT_TELL_RX_END)) {
+            return;
+        }
+        _receive_data(dev);
+    }
+    /* GIO0 (FIFO) is falling => check if FIFOP is high, indicating an RXFIFO overflow */
+    else if (gpio_read(dev->fifo_int_pin) != 0) {
+        gpio_clear(dev->fifo_int_pin);
+        if (gpio_read(dev->fifop_int_pin) != 0) {
+            DEBUG("[cc2420] EVT - RX_OVERFLOW\n");
+            /* CC2420 datasheet says to do this twice and we obey */
+            cc2420_strobe(dev, CC2420_STROBE_FLUSHRX);
+            cc2420_strobe(dev, CC2420_STROBE_FLUSHRX);
+        }
+    }
+    else {
+        DEBUG("[cc2420] unknown interrupt!\n");
+    }
+}
+
+const gnrc_netdev_driver_t cc2420_driver = {
+    .send_data = _send,
+    .add_event_callback = _add_event_cb,
+    .rem_event_callback = _rem_event_cb,
+    .get = _get,
+    .set = _set,
+    .isr_event = _isr_event,
+};

--- a/drivers/cc2420/include/cc2420_internal.h
+++ b/drivers/cc2420/include/cc2420_internal.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_cc2420
+ * @{
+ *
+ * @file
+ * @brief       Internal interfaces for CC2420 drivers
+ *
+ * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ */
+
+#ifndef CC2420_INTERNAL_H_
+#define CC2420_INTERNAL_H_
+
+#include <stdint.h>
+
+#include "cc2420.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* startup timeout (2 ms) in 16MHz-clock cycles */
+#define CC2420_STARTUP_TIMEOUT  32000U
+/* Various configuration settings for the CC2420 drivers  */
+#define CC2420_SYNC_WORD_TX_TIME 900000
+#define CC2420_RX_BUF_SIZE      3
+#define CC2420_WAIT_TIME        500
+
+/* Shortcut macro */
+#define CC2420_STATUS_BYTE() cc2420_strobe(dev, NOBYTE)
+
+uint8_t cc2420_strobe(const cc2420_t *dev, const uint8_t command);
+
+/**
+ * @brief   Read from a register at address `addr` from device `dev`.
+ *
+ * @param[in] dev       device to read from
+ * @param[in] addr      address of the register to read
+ *
+ * @return              the value of the specified register
+ */
+uint16_t cc2420_reg_read(const cc2420_t *dev, const uint8_t addr);
+
+/**
+ * @brief   Write to a register at address `addr` from device `dev`.
+ *
+ * @param[in] dev       device to write to
+ * @param[in] addr      address of the register to write
+ * @param[in] value     value to write to the given register
+ */
+void cc2420_reg_write(const cc2420_t *dev, const uint8_t addr,
+                      const uint16_t value);
+
+/**
+ * @brief   Read a chunk of data from the SRAM of the given device
+ *
+ * @param[in]  dev      device to read from
+ * @param[in]  offset   starting address to read from
+ * @param[out] data     buffer to read data into
+ * @param[in]  len      number of bytes to read from SRAM
+ */
+void cc2420_ram_read(const cc2420_t *dev,
+                     const uint16_t offset,
+                     uint8_t *data,
+                     const size_t len);
+
+/**
+ * @brief   Write a chunk of data into the SRAM of the given device
+ *
+ * @param[in] dev       device to write to
+ * @param[in] offset    address in the SRAM to write to [valid 0x00-0x7f]
+ * @param[in] data      data to copy into SRAM
+ * @param[in] len       number of bytes to write to SRAM
+ */
+void cc2420_ram_write(const cc2420_t *dev,
+                      const uint16_t offset,
+                      const uint8_t *data,
+                      const size_t len);
+
+/**
+ * @brief   Read the internal frame buffer of the given device
+ *
+ * Reading the frame buffer returns some extra bytes that are not accessible
+ * through reading the RAM directly.
+ *
+ * @param[in]  dev      device to read from
+ * @param[out] data     buffer to copy the data to
+ * @param[in]  len      number of bytes to read from the frame buffer
+ */
+void cc2420_fb_read(const cc2420_t *dev,
+                    uint8_t *data, const size_t len);
+
+/**
+ * @brief   Write the internal frame buffer of the given device
+ *
+ * Reading the frame buffer returns some extra bytes that are not accessible
+ * through reading the RAM directly.
+ *
+ * @param[in]  dev      device to read from
+ * @param[out] data     buffer to copy the data to
+ * @param[in]  len      number of bytes to read from the frame buffer
+ */
+void cc2420_fb_write(const cc2420_t *dev,
+                     uint8_t *data, const size_t len);
+
+/**
+ * @brief   Convenience function for reading the status of the given device
+ *
+ * @param[in] dev       device to read the status from
+ *
+ * @return              internal status of the given device
+ */
+// uint8_t cc2420_get_status(const cc2420_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NG_AT86RF2XX_INTERNAL_H_ */
+/** @} */

--- a/drivers/cc2420/include/cc2420_netdev.h
+++ b/drivers/cc2420/include/cc2420_netdev.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_cc2420
+ * @{
+ *
+ * @file
+ * @brief       Netdev interface to CC2420 drivers
+ *
+ * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ */
+
+#ifndef CC2420_NETDEV_H_
+#define CC2420_NETDEV_H_
+
+#include "net/gnrc/netdev.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Reference to the netdev device driver struct
+ */
+extern const gnrc_netdev_driver_t cc2420_driver;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CC2420_NETDEV_H_ */
+/** @} */

--- a/drivers/cc2420/include/cc2420_registers.h
+++ b/drivers/cc2420/include/cc2420_registers.h
@@ -1,0 +1,322 @@
+/*
+ * Copyright (C) 2014 Milan Babel <babel@inf.fu-berlin.de> and INRIA
+ * Copyright (C) 2015 FU Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+  * @ingroup CC2420
+  * @{
+  * @file
+  * @brief Definitions and settings for the CC2420
+  * @author Milan Babel <babel@inf.fu-berlin.de>
+  * @author Kévin Roussel <Kevin.Roussel@inria.fr>
+  * @author Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+  *
+  */
+#ifndef CC2420_REGISTERS_H
+#define CC2420_REGISTERS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name CC2420 access mode values.
+ * @brief Values defining the command you want to give to the CC2420:
+ *        read or write access to registers or RAM.
+ *        These values are to be OR-ed to the address you want to access.
+ * @see CC2420 datasheet section 13.2 page 31.
+ * @{
+ */
+/** @brief Read Register Mode */
+#define CC2420_ACCESS_REG_READ      0x40
+/** @brief Write Register Mode */
+#define CC2420_ACCESS_REG_WRITE     0x00
+/**
+ * @brief RAM Access Modifier (to use with @c CC2420_ACCESS_RAM_READ
+ *        or @c CC2420_ACCESS_RAM_WRITE)
+ */
+#define CC2420_ACCESS_RAM       0x80
+/** @brief Read-Memory Mode (to use with @c CC2420_ACCESS_RAM) */
+#define CC2420_ACCESS_RAM_READ  0x20
+/** @brief Write-Memory Mode (to use with @c CC2420_ACCESS_RAM) */
+#define CC2420_ACCESS_RAM_WRITE 0x00
+
+/**
+ * @}
+ */
+
+/**
+ * @name Strobe command addresses
+ * @brief Addresses of "strobe" commands in CC2420 address space.
+ * @see CC2420 datasheet section 37 pages 61--62.
+ * @{
+ */
+/** @brief NO Operation @see NOBYTE  */
+#define CC2420_STROBE_NOP       0x00
+/** @brief Turn transceiver (internal oscillator) on */
+#define CC2420_STROBE_XOSCON    0x01
+/** @brief Calibrate TX frequency, then put transceiver in wait (inactive) mode */
+#define CC2420_STROBE_TXCAL     0x02
+/** @brief Put transceiver in RX mode */
+#define CC2420_STROBE_RXON      0x03
+/** @brief Put transceiver in TX mode */
+#define CC2420_STROBE_TXON      0x04
+/** @brief Put transceiver in TX mode after checking media availability */
+#define CC2420_STROBE_TXONCCA   0x05
+/** @brief Put transceiver in idle mode */
+#define CC2420_STROBE_RFOFF     0x06
+/** @brief Turn transceiver (internal oscillator) off -> power-down mode */
+#define CC2420_STROBE_XOSCOFF   0x07
+/** @brief Flush transceiver's RX buffer */
+#define CC2420_STROBE_FLUSHRX   0x08
+/** @brief Flush transceiver's TX buffer */
+#define CC2420_STROBE_FLUSHTX   0x09
+/** @brief Send an ACK frame with pending field cleared */
+#define CC2420_STROBE_ACK       0x0A
+/** @brief Send an ACK frame with pending field set */
+#define CC2420_STROBE_ACKPEND   0x0B
+/** @brief Start RXFIFO in-line decryption/verification */
+#define CC2420_STROBE_RXDEC     0x0C
+/** @brief Start TXFIFO in-line encryption/authentication */
+#define CC2420_STROBE_TXENC     0x0D
+/** @brief Start standalone AES encryption */
+#define CC2420_STROBE_AES       0x0E
+/**
+ * @}
+ */
+
+/**
+ * @name CC2420 Configuration Register addresses.
+ * @brief Addresses of configuration registers in CC2420 address space.
+ * @see CC2420 datasheet section 37 pages 61 to 80.
+ * @{
+ */
+/** @brief Main Control Register  */
+#define CC2420_REG_MAIN         0x10
+/**
+ * @brief Modem Control Register 0
+ * @{
+ */
+#define CC2420_REG_MDMCTRL0        0x11
+/** @brief Address Decode enable flag */
+#define CC2420_ADR_DECODE          0x800
+/** @brief Reserved Frame accept enable flag */
+#define CC2420_RES_FRM_MODE        0x2000
+/** @brief PAN Coordinator mode enable flag */
+#define CC2420_PAN_COORD           0x1000
+/** @brief Automatic CRC computation/verification enable flag */
+#define CC2420_AUTOCRC             0x20
+/** @brief Automatic ACK response enable flag */
+#define CC2420_AUTOACK             0x10
+/** @} */
+
+/** @brief Modem Control Register 1 */
+#define CC2420_REG_MDMCTRL1        0x12
+
+/**
+ * @brief RSSI and CCA Status and Control Register
+ * @{
+ */
+#define CC2420_REG_RSSI            0x13
+/** @brief CCA Threshold value mask */
+#define CC2420_CCATHR_MASK         0xFF00
+/** @brief RSSI estimate value mask */
+#define CC2420_RSSI_MASK           0xFF
+/** @} */
+
+/** @brief Sync Word  */
+#define CC2420_REG_SYNCWORD        0x14
+
+/**
+ * @brief Transmit Control Register
+ * @{
+ */
+#define CC2420_REG_TXCTRL       0x15
+/** @brief Output PA Level value mask */
+#define CC2420_PALEVEL_MASK     0x1F
+/** @} */
+
+/** @brief Receive Control Register 0 */
+#define CC2420_REG_RXCTRL0      0x16
+
+/**
+ * @brief Receive Control Register 1
+ * @{
+ */
+#define CC2420_REG_RXCTRL1      0x17
+/** @brief RX BandPass Filter Bias Current mode flag */
+#define CC2420_RXBPF_LOCUR      0x2000
+/** @} */
+
+/**
+ * @brief Frequency Synthesizer Control and Status Register
+ * @{
+ */
+#define CC2420_REG_FSCTRL       0x18
+/** @brief RF Operating Frequency mask */
+#define CC2420_FREQ_MASK        0x3FF
+/** @} */
+
+/**
+ * @brief Security Control Register 0
+ * @{
+ */
+#define CC2420_REG_SECCTRL0        0x19
+/** @brief RXFIFO Protection enable flag */
+#define CC2420_RXFIFO_PROTECTION   0x200
+/** @} */
+
+/** @brief Security Control Register 1 */
+#define CC2420_REG_SECCTRL1        0x1A
+/** @brief Battery Monitor Control Register */
+#define CC2420_REG_BATTMON         0x1B
+
+/**
+ * @brief I/O Configuration Register 0
+ * @{
+ */
+#define CC2420_REG_IOCFG0       0x1C
+/** @brief FIFOP Activation Threshold mask */
+#define CC2420_FIFOPTHR_MASK    0x7F
+/** @} */
+
+/** @brief I/O Configuration Register 1 */
+#define CC2420_REG_IOCFG1       0x1D
+/** @brief Manufacturer ID (low word) */
+#define CC2420_REG_MANFIDL      0x1E
+/** @brief Manufacturer ID (high word) */
+#define CC2420_REG_MANFIDH      0x1F
+/** @brief Finite State Machine Time Constants */
+#define CC2420_REG_FSMTC        0x20
+/** @brief Manual signal AND override Register */
+#define CC2420_REG_MANAND       0x21
+/** @brief Manual signal OR override Register */
+#define CC2420_REG_MANOR        0x22
+/** @brief AGC Control Register  */
+#define CC2420_REG_AGCCTRL      0x23
+/** @brief AGC Test Register 0 */
+#define CC2420_REG_AGCTST0      0x24
+/** @brief AGC Test Register 1 */
+#define CC2420_REG_AGCTST1      0x25
+/** @brief AGC Test Register 2 */
+#define CC2420_REG_AGCTST2      0x26
+/** @brief Frequency Synthesizer Test Register 0 */
+#define CC2420_REG_FSTST0       0x27
+/** @brief Frequency Synthesizer Test Register 1 */
+#define CC2420_REG_FSTST1       0x28
+/** @brief Frequency Synthesizer Test Register 2 */
+#define CC2420_REG_FSTST2       0x29
+/** @brief Frequency Synthesizer Test Register 3 */
+#define CC2420_REG_FSTST3       0x2A
+/** @brief Receiver Bandpass Filters Test Register  */
+#define CC2420_REG_RXBPFTST     0x2B
+/** @brief Finite State Machine Information Register  */
+#define CC2420_REG_FSMSTATE     0x2C
+/** @brief ADC Test Register */
+#define CC2420_REG_ADCTST       0x2D
+/** @brief DAC Test Register */
+#define CC2420_REG_DACTST       0x2E
+/** @brief Top-level Test Register */
+#define CC2420_REG_TOPTST       0x2F
+
+/** @brief Transmit FIFO Byte Register */
+#define CC2420_REG_TXFIFO       0x3E
+/** @brief Receive FIFO Byte Register */
+#define CC2420_REG_RXFIFO       0x3F
+
+/**
+ * @}
+ */
+
+
+/**
+ * @name CC2420 Configuration RAM addresses.
+ * @brief Addresses of configuration zones in CC2420 RAM address space.
+ * @see CC2420 datasheet section 13.5 page 31.
+ * @{
+ */
+/** @brief Short (16-bit) address of the system into its current PAN. */
+#define CC2420_RAM_SHORTADR     0x16A
+/** @brief 16-bit ID of the PAN into which the system is associated. */
+#define CC2420_RAM_PANID        0x168
+/** @brief IEEE long (64-bit) address of the system. */
+#define CC2420_RAM_IEEEADR      0x160
+/**
+ * @}
+ */
+
+/**
+ * @name Status byte flags
+ * @brief Bits of the status byte returned by CC2420 adter each command.
+ * @see CC2420 datasheet section 13.3 page 29.
+ * @{
+ */
+
+/**
+ * @brief Bit XOSC16M_STABLE of the status register.
+ * @details This bit indicates whether the 16-MHz oscillator
+ *          is running (value 1), or if the transceiver
+ *          is in power-down mode (value 0).
+ */
+#define CC2420_STATUS_XOSC16M_STABLE   0x40
+/**
+ * @brief Bit TX_UNDERFLOW of the status register.
+ * @details This bit indicates whether the latest transmission has failed
+ *          because the TX buffer didn't contain enough data (error bit).
+ */
+#define CC2420_STATUS_TX_UNDERFLOW     0x20
+/**
+ * @brief Bit ENC_BUSY of the status register.
+ * @details This bit indicates whether the encryption module
+ *          is currently busy (value 1), or not (value 0).
+ */
+#define CC2420_STATUS_ENC_BUSY         0x10
+/**
+ * @brief Bit TX_ACTIVE of the status register.
+ * @details This bit indicates whether a RF transmission
+ *          is currently in progress (value 1), or not (value 0).
+ */
+#define CC2420_STATUS_TX_ACTIVE        0x08
+/**
+ * @brief Bit PLL_LOCK of the status register.
+ * @details This bit indicates whether the frequency synthesizer PLL
+ *          is currently locked (value 1), or not (value 0).
+ */
+#define CC2420_STATUS_PLL_LOCK         0x04
+/**
+ * @brief Bit RSSI_VALID of the status register.
+ * @details This bit indicates whether the RSSI value
+ *          is valid (value 1), or not (value 0).
+ *          The RSSI is always valid when the CC2420
+ *          has been in RX mode for at least 128 µs),
+ */
+#define CC2420_STATUS_RSSI_VALID       0x02
+
+/**
+ * @}
+ */
+
+/**
+ * @brief Null command strobe/parameter.
+ * @details Basically a strobe address used to perform a NOP on CC2420;
+ *          This is useful to just query the status byte, or more generally
+ *          passively receive bytes from the transceiver on its SPI link.
+ */
+#define NOBYTE 0x0
+
+/**
+ * @brief The device part number.
+ * @details CC2420 has part number 0x02.
+ */
+#define CC2420_PARTNUM                 0x02
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/drivers/include/cc2420.h
+++ b/drivers/include/cc2420.h
@@ -1,0 +1,372 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    drivers_cc2420 CC2420 driver
+ * @ingroup     drivers
+ *
+ * This module contains the driver for TI CC2420 radio devices.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for CC2420 based drivers
+ *
+ * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ */
+
+#ifndef CC2420_H_
+#define CC2420_H_
+
+#include <stdint.h>
+
+#include "board.h"
+#include "periph/spi.h"
+#include "periph/gpio.h"
+#include "net/gnrc/netdev.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Maximum possible packet size in byte
+ */
+#define CC2420_MAX_PKT_LENGTH     (127)
+
+/**
+ * @brief   Default addresses used if the CPUID module is not present
+ * @{
+ */
+#define CC2420_DEFAULT_ADDR_SHORT (0x0230)
+#define CC2420_DEFAULT_ADDR_LONG  (0x1222334455667788)
+/** @} */
+
+/**
+  * @brief   Channel configuration
+  * @{
+  */
+#define CC2420_MIN_CHANNEL        (11U)
+#define CC2420_MAX_CHANNEL        (26U)
+#define CC2420_DEFAULT_CHANNEL    (26U)
+/** @} */
+
+/**
+ * @brief   Default PAN ID
+ *
+ * TODO: Read some global network stack specific configuration value
+ */
+#define CC2420_DEFAULT_PANID      (0x0023)
+
+/**
+ * @brief   Default TX power (0dBm)
+ */
+#define CC2420_DEFAULT_TXPOWER    (0U)
+
+/**
+ * @brief   Flags for device internal states (see datasheet)
+ * @{
+ */
+#define CC2420_STATE_IDLE         (0x01)     /**< idle state -> IDLE */
+#define CC2420_STATE_P_DOWN       (0x02)     /**< power down state -> PD */
+#define CC2420_STATE_RX_ON        (0x04)     /**< ready to receive -> RX_SFD_SEARCH*/
+#define CC2420_STATE_RX_BUSY      (0x08)     /**< busy receiving data -> all other rx states */
+#define CC2420_STATE_TX_PREP      (0x10)     /**< prepare for sending data
+                                              * -> driver state for preloading */
+#define CC2420_STATE_TX_BUSY      (0x20)     /**< busy transmitting data */
+#define CC2420_STATE_IN_PROGRESS  (0x40)     /**< ongoing state change */
+/** @} */
+
+/**
+ * @brief   Internal device option flags
+ * @{
+ */
+#define CC2420_OPT_AUTOACK        (0x0001)    /**< auto ACKs active */
+#define CC2420_OPT_CSMA           (0x0002)    /**< CSMA active */
+#define CC2420_OPT_PROMISCUOUS    (0x0004)    /**< promiscuous mode
+                                               *   active */
+#define CC2420_OPT_PRELOADING     (0x0008)    /**< preloading enabled */
+#define CC2420_OPT_TELL_TX_START  (0x0010)    /**< notify MAC layer on TX
+                                               *   start */
+#define CC2420_OPT_TELL_TX_END    (0x0020)    /**< notify MAC layer on TX
+                                               *   finished */
+#define CC2420_OPT_TELL_RX_START  (0x0040)    /**< notify MAC layer on RX
+                                               *   start */
+#define CC2420_OPT_TELL_RX_END    (0x0080)    /**< notify MAC layer on RX
+                                               *   finished */
+#define CC2420_OPT_RAWDUMP        (0x0100)    /**< pass RAW frame data to
+                                               *   upper layer */
+#define CC2420_OPT_SRC_ADDR_LONG  (0x0200)    /**< send data using long
+                                               *   source address */
+#define CC2420_OPT_USE_SRC_PAN    (0x0400)    /**< do not compress source
+                                               *   PAN ID */
+/** @} */
+
+/**
+ * @brief   Device descriptor for CC2420 radio devices
+ */
+typedef struct {
+    /* netdev fields */
+    const gnrc_netdev_driver_t *driver; /**< pointer to the devices interface */
+    gnrc_netdev_event_cb_t event_cb;    /**< netdev event callback */
+    kernel_pid_t mac_pid;               /**< the driver's thread's PID */
+    /* device specific fields */
+    spi_t spi;                          /**< used SPI device */
+    gpio_t cs_pin;                      /**< chip select pin */
+    gpio_t reset_pin;                   /**< reset pin */
+    gpio_t power_pin;                   /**< reset pin */
+    gpio_t fifo_int_pin;                /**< external interrupt pin */
+    gpio_t fifop_int_pin;               /**< external interrupt pin */
+    gnrc_nettype_t proto;               /**< protocol the radio expects */
+    uint8_t state;                      /**< current state of the radio */
+    uint8_t seq_nr;                     /**< sequence number to use next */
+    uint8_t frame_len;                  /**< length of the current TX frame */
+    uint16_t pan;                       /**< currently used PAN ID */
+    uint8_t chan;                       /**< currently used channel */
+    uint8_t addr_short[2];              /**< the radio's short address */
+    uint8_t addr_long[8];               /**< the radio's long address */
+    uint16_t options;                   /**< state of used options */
+    uint8_t idle_state;                 /**< state to return to after sending */
+} cc2420_t;
+
+/**
+ * @brief struct holding all params needed for device initialization
+ */
+typedef struct cc2420_params {
+    spi_t spi;              /**< SPI bus the device is connected to */
+    spi_speed_t spi_speed;  /**< SPI speed to use */
+    gpio_t cs_pin;          /**< GPIO pin connected to chip select */
+    gpio_t reset_pin;       /**< GPIO pin connected to the reset pin */
+    gpio_t power_pin;       /**< GPIO pin connected to the vregen pin */
+    gpio_t fifo_int_pin;    /**< GPIO pin connected to the FIFO interrupt pin */
+    gpio_t fifop_int_pin;   /**< GPIO pin connected to the FIFOP interrupt pin */
+} cc2420_params_t;
+
+/**
+ * @brief   Initialize a given CC2420 device
+ *
+ * @param[out] dev          device descriptor
+ * @param[in]  params       parameters for initialization `cc2420_params_t`
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int cc2420_init(cc2420_t *dev, const cc2420_params_t *params);
+
+/**
+ * @brief   Trigger a hardware reset and configure radio with default values
+ *
+ * @param[in] dev           device to reset
+ */
+void cc2420_reset(cc2420_t *dev);
+
+/**
+ * @brief   Trigger a clear channel assessment
+ *
+ * @param[in] dev           device to use
+ *
+ * @return                  true if channel is clear
+ * @return                  false if channel is busy
+ */
+bool cc2420_cca(cc2420_t *dev);
+
+/**
+ * @brief   Get the short address of the given device
+ *
+ * @param[in] dev           device to read from
+ *
+ * @return                  the currently set (2-byte) short address
+ */
+uint16_t cc2420_get_addr_short(cc2420_t *dev);
+
+/**
+ * @brief   Set the short address of the given device
+ *
+ * @param[in] dev           device to write to
+ * @param[in] addr          (2-byte) short address to set
+ */
+void cc2420_set_addr_short(cc2420_t *dev, uint16_t addr);
+
+/**
+ * @brief   Get the configured long address of the given device
+ *
+ * @param[in] dev           device to read from
+ *
+ * @return                  the currently set (8-byte) long address
+ */
+uint64_t cc2420_get_addr_long(cc2420_t *dev);
+
+/**
+ * @brief   Set the long address of the given device
+ *
+ * @param[in] dev           device to write to
+ * @param[in] addr          (8-byte) long address to set
+ */
+void cc2420_set_addr_long(cc2420_t *dev, uint64_t addr);
+
+/**
+ * @brief   Get the configured channel of the given device
+ *
+ * @param[in] dev           device to read from
+ *
+ * @return                  the currently set channel
+ */
+uint8_t cc2420_get_chan(cc2420_t *dev);
+
+/**
+ * @brief   Set the channel of the given device
+ *
+ * @param[in] dev           device to write to
+ * @param[in] chan          channel to set
+ */
+void cc2420_set_chan(cc2420_t *dev, uint8_t chan);
+
+/**
+ * @brief   Get the configured PAN ID of the given device
+ *
+ * @param[in] dev           device to read from
+ *
+ * @return                  the currently set PAN ID
+ */
+uint16_t cc2420_get_pan(cc2420_t *dev);
+
+/**
+ * @brief   Set the PAN ID of the given device
+ *
+ * @param[in] dev           device to write to
+ * @param[in] pan           PAN ID to set
+ */
+void cc2420_set_pan(cc2420_t *dev, uint16_t pan);
+
+/**
+ * @brief   Get the configured transmission power of the given device [in dBm]
+ *
+ * @param[in] dev           device to read from
+ *
+ * @return                  configured transmission power in dBm
+ */
+int16_t cc2420_get_txpower(cc2420_t *dev);
+
+/**
+ * @brief   Set the transmission power of the given device [in dBm]
+ *
+ * If the device does not support the exact dBm value given, it will set a value
+ * as close as possible to the given value. If the given value is larger or
+ * lower then the maximal or minimal possible value, the min or max value is
+ * set, respectively.
+ *
+ * @param[in] dev           device to write to
+ * @param[in] txpower       transmission power in dBm
+ */
+void cc2420_set_txpower(cc2420_t *dev, int16_t txpower);
+
+/**
+ * @brief   Enable or disable driver specific options
+ *
+ * @param[in] dev           device to set/clear option flag for
+ * @param[in] option        option to enable/disable
+ * @param[in] state         true for enable, false for disable
+ */
+void cc2420_set_option(cc2420_t *dev, uint16_t option, bool state);
+
+/**
+ * @brief   Set the state of the given device (trigger a state change)
+ *
+ * @param[in] dev           device to change state of
+ * @param[in] state         the targeted new state
+ */
+void cc2420_set_state(cc2420_t *dev, uint8_t state);
+
+/**
+ * @brief   Get the state of the given device
+ *
+ * @param[in] dev           device to change state of
+ *
+ * @return                  the device's current state
+ */
+uint8_t cc2420_get_state(cc2420_t *dev);
+
+/**
+ * @brief   Reset the internal state machine to TRX_OFF mode.
+ *
+ * This will force a transition to TRX_OFF regardless of whether the transceiver
+ * is currently busy sending or receiving. This function is used to get back to
+ * a known state during driver initialization.
+ *
+ * @param[in] dev           device to operate on
+ */
+void cc2420_reset_state_machine(cc2420_t *dev);
+
+/**
+ * @brief   Convenience function for simply sending data
+ *
+ * @note This function ignores the PRELOADING option
+ *
+ * @param[in] dev           device to use for sending
+ * @param[in] data          data to send (must include IEEE802.15.4 header)
+ * @param[in] len           length of @p data
+ *
+ * @return                  number of bytes that were actually send
+ * @return                  0 on error
+ */
+size_t cc2420_send(cc2420_t *dev, uint8_t *data, size_t len);
+
+/**
+ * @brief   Prepare for sending of data
+ *
+ * This function puts the given device into the TX state, so no receiving of
+ * data is possible after it was called.
+ *
+ * @param[in] dev            device to prepare for sending
+ */
+void cc2420_tx_prepare(cc2420_t *dev);
+
+/**
+ * @brief   Load chunks of data into the transmit buffer of the given device
+ *
+ * @param[in] dev           device to write data to
+ * @param[in] data          buffer containing the data to load
+ * @param[in] len           number of bytes in @p buffer
+ *
+ * @return                  offset + number of bytes written
+ */
+size_t cc2420_tx_load(cc2420_t *dev, uint8_t *data, size_t len);
+
+/**
+ * @brief   Trigger sending of data previously loaded into transmit buffer
+ *
+ * @param[in] dev           device to trigger
+ */
+void cc2420_tx_exec(cc2420_t *dev);
+
+/**
+ * @brief   Read the length of a received packet
+ *
+ * @param dev               device to read from
+ *
+ * @return                  overall length of a received packet in byte
+ */
+size_t cc2420_rx_len(cc2420_t *dev);
+
+/**
+ * @brief   Read a chunk of data from the receive buffer of the given device
+ *
+ * @param[in]  dev          device to read from
+ * @param[out] data         buffer to write data to
+ * @param[in]  len          number of bytes to read from device
+ * @param[in]  offset       offset in the receive buffer
+ */
+void cc2420_rx_read(cc2420_t *dev, uint8_t *data, size_t len,
+                       size_t offset);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CC2420_H_ */
+/** @} */

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -148,6 +148,11 @@ void auto_init(void)
     auto_init_at86rf2xx();
 #endif
 
+#ifdef MODULE_CC2420
+    extern void auto_init_cc2420(void);
+    auto_init_cc2420();
+#endif
+
 #ifdef MODULE_ENCX24J600
     extern void auto_init_encx24j600(void);
     auto_init_encx24j600();

--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -97,8 +97,7 @@ gnrc_pktsnip_t *gnrc_pktbuf_mark(gnrc_pktsnip_t *pkt, size_t size, gnrc_nettype_
     if ((size == 0) || (pkt == NULL) || (size > pkt->size) || (pkt->data == NULL)) {
         DEBUG("pktbuf: size == 0 (was %u) or pkt == NULL (was %p) or "
               "size > pkt->size (was %u) or pkt->data == NULL (was %p)\n",
-              (unsigned)size, (void *)pkt, (pkt ? (unsigned)pkt->size : 0),
-              (pkt ? pkt->data : NULL));
+              (unsigned)size, (void *)pkt, (unsigned)pkt->size, pkt->data);
         mutex_unlock(&_mutex);
         return NULL;
     }


### PR DESCRIPTION
This commit provides a prototype of a cc2420 driver implementing netdev interface.
It is currently not fully tested because of issues with the msp430 platform and
thus marked as WIP at self assigned for now.