### PR TITLE
conn: extend API with timeout support

### DIFF
--- a/sys/include/net/conn/ip.h
+++ b/sys/include/net/conn/ip.h
@@ -99,6 +99,28 @@ int conn_ip_getlocaladdr(conn_ip_t *conn, void *addr);
 int conn_ip_recvfrom(conn_ip_t *conn, void *data, size_t max_len, void *addr, size_t *addr_len);
 
 /**
+ * @brief   Receives a message over IPv4/IPv6
+ *
+ * @param[in] conn      A raw IPv4/IPv6 connection object.
+ * @param[out] data     Pointer where the received data should be stored.
+ * @param[in] max_len   Maximum space available at @p data.
+ * @param[out] addr     NULL pointer or the sender's IP address. Must have space for any address
+ *                      of the connection's family.
+ * @param[out] addr_len Length of @p addr. Can be NULL if @p addr is NULL.
+ * @param[in] timeout   The timeout in milliseconds the receive should wait, 0 if the function
+ *                      should never block and CONN_NO_TIMEOUT if the function should never timeout.
+ *
+ * @note    Function may block.
+ *
+ * @return  The number of bytes received on success.
+ * @return  0, if no received data is available, but everything is in order.
+ * @return  any other negative number in case of an error. For portability, implementations should
+ *          draw inspiration of the errno values from the POSIX' recv(), recvfrom(), or recvmsg()
+ *          function specification.
+ */
+int conn_ip_recvfrom_timeout(conn_ip_t *conn, void *data, size_t max_len, void *addr, size_t *addr_len, uint32_t timeout);
+
+/**
  * @brief   Sends a message over IPv4/IPv6
  *
  * @param[in] data      Pointer where the received data should be stored.

--- a/sys/include/net/conn/tcp.h
+++ b/sys/include/net/conn/tcp.h
@@ -154,6 +154,25 @@ int conn_tcp_accept(conn_tcp_t *conn, conn_tcp_t *out_conn);
 int conn_tcp_recv(conn_tcp_t *conn, void *data, size_t max_len);
 
 /**
+ * @brief   Receives a TCP message
+ *
+ * @param[in] conn      A TCP connection object.
+ * @param[out] data     Pointer where the received data should be stored.
+ * @param[in] max_len   Maximum space available at @p data.
+ * @param[in] timeout   The timeout in milliseconds the receive should wait, 0 if the function
+ *                      should never block and CONN_NO_TIMEOUT if the function should never timeout.
+ *
+ * @note    Function may block.
+ *
+ * @return  The number of bytes received on success.
+ * @return  0, if no received data is available, but everything is in order.
+ * @return  any other negative number in case of an error. For portability, implementations should
+ *          draw inspiration of the errno values from the POSIX' recv(), recvfrom(), or recvmsg()
+ *          function specification.
+ */
+int conn_tcp_recv_timeout(conn_tcp_t *conn, void *data, size_t max_len, uint32_t timeout);
+
+/**
  * @brief   Sends a TCP message
  *
  * @param[in] conn  A TCP connection object.

--- a/sys/include/net/conn/udp.h
+++ b/sys/include/net/conn/udp.h
@@ -103,6 +103,30 @@ int conn_udp_recvfrom(conn_udp_t *conn, void *data, size_t max_len, void *addr, 
                       uint16_t *port);
 
 /**
+ * @brief   Receives a UDP message
+ *
+ * @param[in] conn      A UDP connection object.
+ * @param[out] data     Pointer where the received data should be stored.
+ * @param[in] max_len   Maximum space available at @p data.
+ * @param[out] addr     NULL pointer or the sender's network layer address. Must have space
+ *                      for any address of the connection's family.
+ * @param[out] addr_len Length of @p addr. Can be NULL if @p addr is NULL.
+ * @param[out] port     NULL pointer or the sender's UDP port.
+ * @param[in] timeout   The timeout in milliseconds the receive should wait, 0 if the function
+ *                      should never block and CONN_NO_TIMEOUT if the function should never timeout.
+ *
+ * @note    Function may block.
+ *
+ * @return  The number of bytes received on success.
+ * @return  0, if no received data is available, but everything is in order.
+ * @return  any other negative number in case of an error. For portability, implementations should
+ *          draw inspiration of the errno values from the POSIX' recv(), recvfrom(), or recvmsg()
+ *          function specification.
+ */
+int conn_udp_recvfrom_timeout(conn_udp_t *conn, void *data, size_t max_len, void *addr, size_t *addr_len,
+                              uint16_t *port, uint32_t timeout);
+
+/**
  * @brief   Sends a UDP message
  *
  * @param[in] data      Pointer where the received data should be stored.

--- a/sys/include/net/gnrc/conn.h
+++ b/sys/include/net/gnrc/conn.h
@@ -32,6 +32,8 @@
 extern "C" {
 #endif
 
+#define CONN_NO_TIMEOUT                         (UINT32_MAX)
+
 /**
  * @brief   Connection base class
  * @internal
@@ -118,11 +120,36 @@ bool gnrc_conn6_set_local_addr(uint8_t *conn_addr, const ipv6_addr_t *addr);
  * @return  The number of bytes received on success.
  * @return  0, if no received data is available, but everything is in order.
  * @return  -ENOMEM, if received data was more than max_len.
- * @returne -ETIMEDOUT, if more than 3 IPC messages were not @ref net_ng_netapi receive commands
+ * @return  -ETIMEDOUT, if more than 3 IPC messages were not @ref net_ng_netapi receive commands
  *          with the required headers in the packet
  */
 int gnrc_conn_recvfrom(conn_t *conn, void *data, size_t max_len, void *addr, size_t *addr_len,
                        uint16_t *port);
+
+/**
+ * @brief   Generic recvfrom
+ *
+ * @internal
+ *
+ * @param[in] conn      Connection object.
+ * @param[out] data     Pointer where the received data should be stored.
+ * @param[in] max_len   Maximum space available at @p data.
+ * @param[out] addr     NULL pointer or the sender's IP address. Must fit address of connection's
+ *                      family if not NULL.
+ * @param[out] addr_len Length of @p addr. May be NULL if @p addr is NULL.
+ * @param[out] port     NULL pointer or the sender's port.
+ * @param[in] timeout   The timeout in milliseconds the receive should wait, 0 if the function
+ *                      should never block and CONN_NO_TIMEOUT if the function should never timeout.
+ *
+ * @return  The number of bytes received on success.
+ * @return  0, if no received data is available, but everything is in order.
+ * @return  -ENOMEM, if received data was more than max_len.
+ * @return  -ETIMEDOUT, if more than 3 IPC messages were not @ref net_ng_netapi receive commands
+ *           with the required headers in the packet
+ * @return  -EWOULDBLOCK, if a timeout of 0 is given and there is no message available
+ */
+int gnrc_conn_recvfrom_timeout(conn_t *conn, void *data, size_t max_len, void *addr, size_t *addr_len,
+                               uint16_t *port, uint32_t timeout);
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/conn/ip/gnrc_conn_ip.c
+++ b/sys/net/gnrc/conn/ip/gnrc_conn_ip.c
@@ -66,11 +66,16 @@ int conn_ip_getlocaladdr(conn_ip_t *conn, void *addr)
 
 int conn_ip_recvfrom(conn_ip_t *conn, void *data, size_t max_len, void *addr, size_t *addr_len)
 {
+    return conn_ip_recvfrom_timeout(conn, data, max_len, addr, addr_len, CONN_NO_TIMEOUT);
+}
+
+int conn_ip_recvfrom_timeout(conn_ip_t *conn, void *data, size_t max_len, void *addr, size_t *addr_len, uint32_t timeout)
+{
     assert(conn->l4_type == GNRC_NETTYPE_UNDEF);
     switch (conn->l3_type) {
 #ifdef MODULE_GNRC_IPV6
         case GNRC_NETTYPE_IPV6:
-            return gnrc_conn_recvfrom((conn_t *)conn, data, max_len, addr, addr_len, NULL);
+            return gnrc_conn_recvfrom_timeout((conn_t *)conn, data, max_len, addr, addr_len, NULL, timeout);
 #endif
         default:
             (void)data;

--- a/sys/net/gnrc/conn/udp/gnrc_conn_udp.c
+++ b/sys/net/gnrc/conn/udp/gnrc_conn_udp.c
@@ -70,11 +70,17 @@ int conn_udp_getlocaladdr(conn_udp_t *conn, void *addr, uint16_t *port)
 int conn_udp_recvfrom(conn_udp_t *conn, void *data, size_t max_len, void *addr, size_t *addr_len,
                       uint16_t *port)
 {
+    return conn_udp_recvfrom_timeout(conn, data, max_len, addr, addr_len, port, CONN_NO_TIMEOUT);
+}
+
+int conn_udp_recvfrom_timeout(conn_udp_t *conn, void *data, size_t max_len, void *addr, size_t *addr_len,
+                      uint16_t *port, uint32_t timeout)
+{
     assert(conn->l4_type == GNRC_NETTYPE_UDP);
     switch (conn->l3_type) {
 #ifdef MODULE_GNRC_IPV6
         case GNRC_NETTYPE_IPV6:
-            return gnrc_conn_recvfrom((conn_t *)conn, data, max_len, addr, addr_len, port);
+            return gnrc_conn_recvfrom_timeout((conn_t *)conn, data, max_len, addr, addr_len, port, timeout);
 #endif
         default:
             (void)data;


### PR DESCRIPTION
Extending the `conn` API to support timeouts.

This PR depends on #3997 to implement `-EWOULDBLOCK`