### PR TITLE
core: eliminate SCHED_TEST_STACK in favor of DEVELHELP

### DIFF
--- a/core/include/tcb.h
+++ b/core/include/tcb.h
@@ -74,10 +74,8 @@ typedef struct tcb_t {
     cib_t msg_queue;            /**< message queue                  */
     msg_t *msg_array;           /**< memory holding messages        */
 
-#if defined DEVELHELP || defined(SCHED_TEST_STACK)
-    char *stack_start;          /**< thread's stack start address   */
-#endif
 #ifdef DEVELHELP
+    char *stack_start;          /**< thread's stack start address   */
     const char *name;           /**< thread's name                  */
     int stack_size;             /**< thread's stack size            */
 #endif

--- a/core/sched.c
+++ b/core/sched.c
@@ -90,7 +90,7 @@ int sched_run(void)
             active_thread->status = STATUS_PENDING;
         }
 
-#ifdef SCHED_TEST_STACK
+#ifdef DEVELHELP
         if (*((uintptr_t *) active_thread->stack_start) != (uintptr_t) active_thread->stack_start) {
             LOG_WARNING("scheduler(): stack overflow detected, pid=%" PRIkernel_pid "\n", active_thread->pid);
         }

--- a/tests/sizeof_tcb/main.c
+++ b/tests/sizeof_tcb/main.c
@@ -42,12 +42,7 @@ int main(void)
     P(msg_array);
 #ifdef DEVELHELP
     P(name);
-#endif
-#if defined(DEVELHELP) || defined(SCHED_TEST_STACK)
     P(stack_start);
-#endif
-
-#ifdef DEVELHELP
     P(stack_size);
 #endif
 


### PR DESCRIPTION
Due to the logic in `thread_create()`, `SCHED_TEST_STACK` currently doesn't work unless `DEVELHELP=1`. But it would seem unwise to ever have `SCHED_TEST_STACK=0` if `DEVELHELP=1`. Hence I propose eliminating `SCHED_TEST_STACK` in favor of `DEVELHELP`.