### PR TITLE
iotlab: add capability to create and connect to debug server

### DIFF
--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -8,6 +8,7 @@ IOTLAB_AUTH         ?= $(HOME)/.iotlabrc
 IOTLAB_USER         ?= $(shell cut -f1 -d: $(IOTLAB_AUTH))
 IOTLAB_EXP_ID       ?= $(shell experiment-cli get -l --state Running | grep -m 1 '"id"' | grep -Eo '[[:digit:]]+')
 IOTLAB_EXP_NAME     ?= RIOT_EXP
+IOTLAB_DEBUG_PORT   ?= 3333
 
 IOTLAB_AUTHORITY    := "$(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info"
 
@@ -42,6 +43,16 @@ iotlab-flash: $(IOTLAB_AUTH) all
 
 iotlab-reset: $(IOTLAB_AUTH)
 	$(AD)node-cli --reset -i $(IOTLAB_EXP_ID)
+
+ifeq (,$(IOTLAB_DEBUG_NODE))
+iotlab-debug-server: IOTLAB_DEBUG_NODE := $(shell experiment-cli get -i $(IOTLAB_EXP_ID) --resources | \
+                                            grep -m 1 "network_address" | \
+                                            sed 's/.*: "\(.*\)".*/\1/')
+endif
+iotlab-debug-server: $(IOTLAB_AUTH)
+	$(AD)node-cli --debug-start -i $(IOTLAB_EXP_ID)
+	@echo "Debug on node $(IOTLAB_DEBUG_NODE)"
+	$(AD)ssh -N -L $(IOTLAB_DEBUG_PORT):$(IOTLAB_DEBUG_NODE):3333 $(IOTLAB_AUTHORITY)
 
 iotlab-term:
 	$(AD)ssh -t $(IOTLAB_AUTHORITY) "test -f ~/.iotlabrc || auth-cli -u $(IOTLAB_USER)"

--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -1,13 +1,15 @@
 .PHONY: iotlab-auth iotlab-exp iotlab-flash iotlab-reset iotlab-term
 
-IOTLAB_NODES    ?= 5
-IOTLAB_DURATION ?= 30
-IOTLAB_SITE     ?= grenoble
-IOTLAB_TYPE     ?= m3:at86rf231
-IOTLAB_AUTH     ?= $(HOME)/.iotlabrc
-IOTLAB_USER     ?= $(shell cut -f1 -d: $(IOTLAB_AUTH))
-IOTLAB_EXP_ID   ?= $(shell experiment-cli get -l --state Running | grep -m 1 '"id"' | grep -Eo '[[:digit:]]+')
-IOTLAB_EXP_NAME ?= RIOT_EXP
+IOTLAB_NODES        ?= 5
+IOTLAB_DURATION     ?= 30
+IOTLAB_SITE         ?= grenoble
+IOTLAB_TYPE         ?= m3:at86rf231
+IOTLAB_AUTH         ?= $(HOME)/.iotlabrc
+IOTLAB_USER         ?= $(shell cut -f1 -d: $(IOTLAB_AUTH))
+IOTLAB_EXP_ID       ?= $(shell experiment-cli get -l --state Running | grep -m 1 '"id"' | grep -Eo '[[:digit:]]+')
+IOTLAB_EXP_NAME     ?= RIOT_EXP
+
+IOTLAB_AUTHORITY    := "$(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info"
 
 ifneq (,$(findstring m3,$(IOTLAB_TYPE)))
 	BINARY := $(ELFFILE)
@@ -42,5 +44,5 @@ iotlab-reset: $(IOTLAB_AUTH)
 	$(AD)node-cli --reset -i $(IOTLAB_EXP_ID)
 
 iotlab-term:
-	$(AD)ssh -t $(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info "test -f ~/.iotlabrc || auth-cli -u $(IOTLAB_USER)"
-	$(AD)ssh -t $(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info "serial_aggregator -i $(IOTLAB_EXP_ID)"
+	$(AD)ssh -t $(IOTLAB_AUTHORITY) "test -f ~/.iotlabrc || auth-cli -u $(IOTLAB_USER)"
+	$(AD)ssh -t $(IOTLAB_AUTHORITY) "serial_aggregator -i $(IOTLAB_EXP_ID)"


### PR DESCRIPTION
~~It's a little bit hacky, since I did not manage to find out how to get a easily parsable list of the nodes of an experiment~~ (nvm found one), but here's my proposal for the usage of `--debug-start` in Makefile.iotlab.