### PR TITLE
core/panic: call cpu_print_last_instruction before printing other things

### DIFF
--- a/core/panic.c
+++ b/core/panic.c
@@ -48,13 +48,13 @@ NORETURN void core_panic(core_panic_t crash_code, const char *message)
     if (crashed == 0) {
         /* print panic message to console (if possible) */
         crashed = 1;
-        puts("*** RIOT kernel panic");
-        puts(message);
 #ifndef NDEBUG
         if (crash_code == PANIC_ASSERT_FAIL) {
             cpu_print_last_instruction();
         }
 #endif
+        puts("*** RIOT kernel panic");
+        puts(message);
 #ifdef DEVELHELP
 #ifdef MODULE_PS
         ps();


### PR DESCRIPTION
The compiler (at least for the iotlab-m3) is clever enough to not change the link register for subsequent calls to puts/printf. This will however result in a false link register reported to the user/developer when an assert fails.
By moving `cpu_print_last_instruction()` up and make it the first function to be called bypasses this.

fixes #3920 