### PR TITLE
native/timer: fix return value for invalid channel

### DIFF
--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -117,8 +117,11 @@ static void do_timer_set(unsigned int offset)
 int timer_set(tim_t dev, int channel, unsigned int offset)
 {
     (void)dev;
-    (void)channel;
     DEBUG("%s\n", __func__);
+
+    if (channel != 0) {
+        return -1;
+    }
 
     if (!offset) {
         offset = NATIVE_TIMER_MIN_RES;
@@ -140,9 +143,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
         target = NATIVE_TIMER_MIN_RES;
     }
 
-    timer_set(dev, channel, target);
-
-    return 1;
+    return timer_set(dev, channel, target);
 }
 
 int timer_clear(tim_t dev, int channel)


### PR DESCRIPTION
Now `tests/periph_timer` is working as expected...