### PR TITLE
cpu: provide link-time random value, use as fake cpuid

### DIFF
--- a/Makefile.cflags
+++ b/Makefile.cflags
@@ -64,3 +64,6 @@ endif
 ifeq ($(origin ARFLAGS),default)
   ARFLAGS = rcs
 endif
+
+# define random number at link stage
+LINKFLAGS += -Wl,--defsym=RANDOM=$(RANDOM)

--- a/Makefile.include
+++ b/Makefile.include
@@ -72,6 +72,14 @@ else
   AD=
 endif
 
+# get a random value
+ifeq ($(OS),Darwin)
+  RANDOM ?= 0x$(shell jot -r -w%08x 1 0 0xffffffff)
+else
+  RANDOM ?= 0x$(shell </dev/urandom tr -dc 0-9a-f | dd bs=8 count=1 status=none)
+endif
+export RANDOM
+
 # Fail on warnings. Can be overridden by `make WERROR=0`.
 WERROR ?= 1
 export WERROR

--- a/boards/Makefile.include.msp430_common
+++ b/boards/Makefile.include.msp430_common
@@ -17,5 +17,8 @@ export LINKFLAGS += $(CFLAGS_CPU) -lgcc
 # Import all toolchain settings
 include $(RIOTBOARD)/Makefile.include.gnu
 
+# as msp430 is 16bit only, cut the 32bit wide random number
+RANDOM := $(shell echo $(RANDOM) | cut -c -6)
+
 # export board specific includes to the global includes-listing
 export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include

--- a/drivers/include/periph/cpuid.h
+++ b/drivers/include/periph/cpuid.h
@@ -45,7 +45,14 @@ extern "C" {
  *                  defined in the CPU's cpu_conf.h)
  */
 void cpuid_get(void *id);
-#endif /* CPUID_ID_LEN */
+#else
+extern unsigned *RANDOM;
+#define CPUID_ID_LEN (sizeof(&RANDOM))
+static inline void cpuid_get(void* id)
+{
+    *(unsigned*)id = (unsigned) &RANDOM;
+}
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR makes the linker define a symbol with a random value.
Also, it makes cpuid use it if no cpuid implementation is available.

As our boards always relink when flashing, as long "make flash" is used for flashing, all boards using this get a random cpuid.

FEATURE_PERIPH_CPUID is not changed in order to differentiate this fake from "real" cpuids.