### PR TITLE
gnrc_ipv6_netif: a RA source MUST be link-local	

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -111,8 +111,7 @@ static ipv6_addr_t *_add_addr_to_entry(gnrc_ipv6_netif_t *entry, const ipv6_addr
                 mutex_unlock(&entry->mutex);    /* function below relocks mutex */
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
                 if (entry->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN) {
-                    gnrc_ndp_internal_send_rtr_adv(entry->pid, &tmp_addr->addr,
-                                                   NULL, false);
+                    gnrc_ndp_internal_send_rtr_adv(entry->pid, NULL, NULL, false);
                 }
 #endif
 #ifdef MODULE_GNRC_NDP_ROUTER


### PR DESCRIPTION
Another go at fixing #3933 (and another mini-bug fixed).

[Reference](https://tools.ietf.org/html/rfc4861#section-6.1.2)