### PR TITLE
kinetis: timer: return error if timer channel is not zero.

### DIFF
--- a/cpu/kinetis_common/timer.c
+++ b/cpu/kinetis_common/timer.c
@@ -144,7 +144,10 @@ int timer_set(tim_t dev, int channel, unsigned int timeout)
 
 int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 {
-    (void) channel; /* we only support one channel */
+    /* we only support one channel */
+    if (channel != 0) {
+        return -1;
+    }
     switch (dev) {
 #if TIMER_0_EN
 
@@ -180,7 +183,10 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 
 int timer_clear(tim_t dev, int channel)
 {
-    (void) channel; /* we only support one channel */
+    /* we only support one channel */
+    if (channel != 0) {
+        return -1;
+    }
     switch (dev) {
 #if TIMER_0_EN
 


### PR DESCRIPTION
similar to what was done in #3939 for native.

It does *not* fix the problem reported in #3941 