### PR TITLE
6lowpan: make SLAAC work

### DIFF
--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -120,7 +120,6 @@ extern "C" {
  */
 #define GNRC_IPV6_NETIF_ADDR_FLAGS_UNICAST      (0x00)  /**< unicast address */
 #define GNRC_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST  (0x01)  /**< non-unicast address */
-#define GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE    (0x02)  /**< address is not fully registered yet */
 
 /**
  * @brief   A prefix information option that propagates the prefix of this

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -106,6 +106,13 @@ static ipv6_addr_t *_add_addr_to_entry(gnrc_ipv6_netif_t *entry, const ipv6_addr
     }
     else {
         if (!ipv6_addr_is_link_local(addr)) {
+#ifdef MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER
+            tmp_addr->valid = 0xFFFF;
+            gnrc_sixlowpan_nd_router_abr_t *abr = gnrc_sixlowpan_nd_router_abr_get();
+            if (gnrc_sixlowpan_nd_router_abr_add_prf(abr, entry, tmp_addr) < 0) {
+                DEBUG("ipv6_netif: error adding prefix to 6LoWPAN-ND management\n");
+            }
+#endif
 #if defined(MODULE_GNRC_NDP_ROUTER) || defined(MODULE_GNRC_SIXLOWPAN_ND_ROUTER)
             if ((entry->flags & GNRC_IPV6_NETIF_FLAGS_ROUTER) &&
                 (entry->flags & GNRC_IPV6_NETIF_FLAGS_RTR_ADV)) {
@@ -125,13 +132,6 @@ static ipv6_addr_t *_add_addr_to_entry(gnrc_ipv6_netif_t *entry, const ipv6_addr
                 }
 #endif
                 mutex_lock(&entry->mutex);      /* relock mutex */
-            }
-#endif
-#ifdef MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER
-            tmp_addr->valid = 0xFFFF;
-            gnrc_sixlowpan_nd_router_abr_t *abr = gnrc_sixlowpan_nd_router_abr_get();
-            if (gnrc_sixlowpan_nd_router_abr_add_prf(abr, entry, tmp_addr) < 0) {
-                DEBUG("ipv6_netif: error adding prefix to 6LoWPAN-ND management\n");
             }
 #endif
         }

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -92,7 +92,6 @@ static ipv6_addr_t *_add_addr_to_entry(gnrc_ipv6_netif_t *entry, const ipv6_addr
         (entry->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN)) {
         ipv6_addr_t *router = gnrc_ndp_internal_default_router();
         if (router != NULL) {
-            tmp_addr->flags |= GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE;
             mutex_unlock(&entry->mutex);    /* function below relocks mutex */
             gnrc_ndp_internal_send_nbr_sol(entry->pid, &tmp_addr->addr, router, router);
             mutex_lock(&entry->mutex);      /* relock mutex */
@@ -415,9 +414,6 @@ ipv6_addr_t *gnrc_ipv6_netif_find_addr(kernel_pid_t pid, const ipv6_addr_t *addr
     mutex_lock(&entry->mutex);
 
     for (int i = 0; i < GNRC_IPV6_NETIF_ADDR_NUMOF; i++) {
-        if (entry->addrs[i].flags & GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE) {
-            continue;
-        }
         if (ipv6_addr_equal(&(entry->addrs[i].addr), addr)) {
             mutex_unlock(&entry->mutex);
             DEBUG("ipv6 netif: Found %s on interface %" PRIkernel_pid "\n",
@@ -450,9 +446,6 @@ static uint8_t _find_by_prefix_unsafe(ipv6_addr_t **res, gnrc_ipv6_netif_t *ifac
             continue;
         }
 
-        if (iface->addrs[i].flags & GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE) {
-            continue;
-        }
         match = ipv6_addr_match_prefix(&(iface->addrs[i].addr), addr);
 
         if ((only == NULL) && !ipv6_addr_is_multicast(addr) &&
@@ -573,8 +566,7 @@ static int _create_candidate_set(gnrc_ipv6_netif_t *iface, const ipv6_addr_t *ds
         /* "In any case, multicast addresses and the unspecified address MUST NOT
          *  be included in a candidate set."
          */
-        if ((iter->flags & GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE) ||
-            ipv6_addr_is_multicast(&(iter->addr)) ||
+        if (ipv6_addr_is_multicast(&(iter->addr)) ||
             ipv6_addr_is_unspecified(&(iter->addr))) {
             continue;
         }

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -243,7 +243,7 @@ void gnrc_ndp_internal_send_nbr_sol(kernel_pid_t iface, ipv6_addr_t *src, ipv6_a
     size_t l2src_len = 0;
 
     DEBUG("ndp internal: send neighbor solicitation (iface: %" PRIkernel_pid ", src: %s, ",
-           ipv6_addr_to_str(addr_str, src, sizeof(addr_str)));
+           iface, ipv6_addr_to_str(addr_str, src, sizeof(addr_str)));
     DEBUG(" tgt: %s, ", ipv6_addr_to_str(addr_str, tgt, sizeof(addr_str)));
     DEBUG("dst: %s)\n", ipv6_addr_to_str(addr_str, dst, sizeof(addr_str)));
 

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -288,10 +288,7 @@ uint8_t gnrc_sixlowpan_nd_opt_ar_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6,
             switch (ar_opt->status) {
                 case SIXLOWPAN_ND_STATUS_SUCCESS:
                     DEBUG("6lo nd: address registration successful\n");
-                    ipv6_addr_t *netif_addr_entry = gnrc_ipv6_netif_find_addr(iface, &(ipv6->dst));
-                    gnrc_ipv6_netif_addr_t *netif_addr = gnrc_ipv6_netif_addr_get(netif_addr_entry);
                     mutex_lock(&ipv6_iface->mutex);
-                    netif_addr->flags &= ~GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE;
                     /* reschedule 1 minute before lifetime expires */
                     timex_t t = { (uint32_t)(byteorder_ntohs(ar_opt->ltime) - 1) * 60, 0 };
                     vtimer_remove(&nc_entry->nbr_sol_timer);

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -722,8 +722,6 @@ static int _netif_add(char *cmd_name, kernel_pid_t dev, int argc, char **argv)
         printf("error: unable to add IPv6 address\n");
         return 1;
     }
-    gnrc_ipv6_netif_addr_t *netif_addr = gnrc_ipv6_netif_addr_get(assigned_address);
-    netif_addr->flags &= ~GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE;
 
     printf("success: added %s/%d to interface %" PRIkernel_pid "\n", addr_str,
            prefix_len, dev);


### PR DESCRIPTION
I'm not quite sure about the initial purpose of the `GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE`, but I couldn't find a real use for it, while it causes trouble if a node tries to register a new address.