### PR TITLE
at86rf2xx: mask MSB in PHR for 802.15.4 compliance

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -246,9 +246,11 @@ void at86rf2xx_tx_exec(at86rf2xx_t *dev)
 
 size_t at86rf2xx_rx_len(at86rf2xx_t *dev)
 {
-    uint8_t res;
-    at86rf2xx_fb_read(dev, &res, 1);
-    return (size_t)(res - 2);           /* extract the PHR and LQI field */
+    uint8_t phr;
+    at86rf2xx_fb_read(dev, &phr, 1);
+
+    /* ignore MSB (refer p.80) and substract length of FCS field */
+    return (size_t)((phr & 0x7f) - 2);
 }
 
 void at86rf2xx_rx_read(at86rf2xx_t *dev, uint8_t *data, size_t len,


### PR DESCRIPTION
The MSB of the PHR will not be masked by hardware which can result in a wrong payload length, that would lead to corrupted packets.

Section 8.1.1.2, p.80
> On reception, the PHR is returned as the first octet during Frame Buffer read access.
While the IEEE 802.15.4-2006 standard declares bit seven of the PHR octet as being
reserved, the AT86RF233 preserves this bit upon transmission and reception so it can
be used to carry additional information within proprietary networks. Nevertheless, this
bit is not considered to be a part of the frame length, so only frames between one and
127 octets are possible. For IEEE 802.15.4 compliant operation bit[7] has to be masked
by software.