### PR TITLE
drivers/i2c: removed init_slave for now

### DIFF
--- a/cpu/kinetis_common/i2c.c
+++ b/cpu/kinetis_common/i2c.c
@@ -154,14 +154,6 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
     return 0;
 }
 
-int i2c_init_slave(i2c_t dev, uint8_t address)
-{
-    /* TODO: implement slave mode */
-    (void) dev;
-    (void) address;
-    return -1;
-}
-
 /*
  * Check for bus master arbitration lost.
  * Arbitration is lost in the following circumstances:

--- a/cpu/samd21/periph/i2c.c
+++ b/cpu/samd21/periph/i2c.c
@@ -204,12 +204,6 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
     return 0;
 }
 
-int i2c_init_slave(i2c_t dev, uint8_t address)
-{
-    /* TODO */
-    return 0;
-}
-
 int i2c_acquire(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {

--- a/cpu/stm32f1/periph/i2c.c
+++ b/cpu/stm32f1/periph/i2c.c
@@ -152,12 +152,6 @@ static void _pin_config(gpio_t scl, gpio_t sda)
     gpio_init_af(sda, GPIO_AF_OUT_OD);
 }
 
-int i2c_init_slave(i2c_t dev, uint8_t address)
-{
-    /* TODO: implement slave mode */
-    return -1;
-}
-
 int i2c_acquire(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {

--- a/cpu/stm32f3/periph/i2c.c
+++ b/cpu/stm32f3/periph/i2c.c
@@ -227,12 +227,6 @@ static void _pin_config(GPIO_TypeDef *port_scl, GPIO_TypeDef *port_sda,
     }
 }
 
-int i2c_init_slave(i2c_t dev, uint8_t address)
-{
-    /* TODO: implement slave mode */
-    return -1;
-}
-
 int i2c_acquire(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {

--- a/cpu/stm32f4/periph/i2c.c
+++ b/cpu/stm32f4/periph/i2c.c
@@ -215,14 +215,6 @@ static void _toggle_pins(GPIO_TypeDef *port_scl, GPIO_TypeDef *port_sda, int pin
     port_sda->ODR |= (1 << pin_sda);
 }
 
-int i2c_init_slave(i2c_t dev, uint8_t address)
-{
-    /* TODO: implement slave mode */
-    (void) dev;
-    (void) address;
-    return -1;
-}
-
 int i2c_acquire(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {

--- a/cpu/stm32l1/periph/i2c.c
+++ b/cpu/stm32l1/periph/i2c.c
@@ -213,12 +213,6 @@ static void _toggle_pins(GPIO_TypeDef *port, int pin_scl, int pin_sda)
     port->ODR |= (1 << pin_sda);
 }
 
-int i2c_init_slave(i2c_t dev, uint8_t address)
-{
-    /* TODO: implement slave mode */
-    return -1;
-}
-
 int i2c_acquire(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -132,17 +132,6 @@ typedef enum {
 int i2c_init_master(i2c_t dev, i2c_speed_t speed);
 
 /**
- * @brief   Initialize an I2C device to run in slave mode
- *
- * @param[in] dev           the device to initialize
- * @param[in] address       the devices I2C address
- *
- * @return                  0 on success
- * @return                  -1 on undefined device given
- */
-int i2c_init_slave(i2c_t dev, uint8_t address);
-
-/**
  * @brief   Get mutually exclusive access to the given I2C bus
  *
  * In case the I2C device is busy, this function will block until the bus is

--- a/tests/periph_i2c/main.c
+++ b/tests/periph_i2c/main.c
@@ -69,41 +69,6 @@ int cmd_init_master(int argc, char **argv)
     return 0;
 }
 
-int cmd_init_slave(int argc, char **argv)
-{
-    int dev, addr, res;
-
-    if (argc != 3) {
-        puts("Error: Invalid number of arguments!");
-        printf("Usage:\n%s: [DEVICE] [ADDRESS]\n", argv[0]);
-        puts("    with DEVICE:");
-        for (int i = 0; i < I2C_NUMOF; i++) {
-            printf("          %i -> I2C_%i\n", i, i);
-        }
-        puts("         ADDRESS: value between 0 and 127");
-        return 1;
-    }
-
-    dev = atoi(argv[1]);
-    addr = atoi(argv[1]);
-
-    res = i2c_init_slave(dev, addr);
-    if (res == -1) {
-        puts("Error: Init: Given device not available");
-        return 1;
-    }
-    else if (res == -2) {
-        puts("Error: Init: Invalid address given");
-        return 1;
-    }
-    else {
-        printf("I2C_%i successfully initialized as slave with address %i!\n", dev, addr);
-        i2c_dev = dev;
-    }
-
-    return 0;
-}
-
 int cmd_write(int argc, char **argv)
 {
     int res;
@@ -294,7 +259,6 @@ int cmd_read_reg(int argc, char **argv)
 
 static const shell_command_t shell_commands[] = {
     { "init_master", "Initialize I2C as master", cmd_init_master },
-    { "init_slave", "Initialize I2C as slave", cmd_init_slave },
     { "w", "write bytes to given address", cmd_write },
     { "wr", "write to register ", cmd_write_reg },
     { "r", "read bytes from given address", cmd_read },


### PR DESCRIPTION
Motivation: The I2C interface for using devices in slave mode is neither usable nor implemented for any board at the moment. Though you can initialize a device as slave, the interface contains no means of controlling the data written or read by it -> useless :-)

So for better clarity I propose to remove the function for now. We can just reintroduce it together with a working implementation for at least one CPU.