### PR TITLE
6lowpan: do garbage collect unreachable NCEs

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -678,19 +678,17 @@ void gnrc_ndp_retrans_nbr_sol(gnrc_ipv6_nc_t *nc_entry)
             }
         }
         else if (nc_entry->probes_remaining <= 1) {
-#ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
-            if (nc_entry->iface != KERNEL_PID_UNDEF) {
-                gnrc_ipv6_netif_t *ipv6_iface = gnrc_ipv6_netif_get(nc_entry->iface);
-                if ((ipv6_iface->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN) &&
-                    (ipv6_iface->flags & GNRC_IPV6_NETIF_FLAGS_ROUTER) &&
-                    (gnrc_ipv6_nc_get_type(nc_entry) != GNRC_IPV6_NC_TYPE_GC)) {
-                    /* don't remove non-gc entrys on 6LRs:
-                     * https://tools.ietf.org/html/rfc6775#section-6 */
-                    gnrc_ndp_internal_set_state(nc_entry, GNRC_IPV6_NC_STATE_UNREACHABLE);
-                    return;
-                }
-            }
-#endif
+
+            /* For a 6LoWPAN router entries may be set to UNREACHABLE instead
+             * of removing them, since RFC6775, section 6
+             * (https://tools.ietf.org/html/rfc6775#section-6) says: "if NUD on
+             * the router determines that the host is UNREACHABLE (based on the
+             * logic in [RFC4861]), the NCE SHOULD NOT be deleted but rather
+             * retained until the Registration Lifetime expires." However, this
+             * "SHOULD NOT" is not implemented to circumvent NCEs going into
+             * UNREACHABLE forever and in order to save some memory in the
+             * neighbor cache. */
+
             DEBUG("ndp: Remove nc entry %s for interface %" PRIkernel_pid "\n",
                   ipv6_addr_to_str(addr_str, &nc_entry->ipv6_addr, sizeof(addr_str)),
                   nc_entry->iface);


### PR DESCRIPTION
RFC6775 says "if NUD on the router determines that the host is UNREACHABLE (based on the logic in [RFC4861]), the NCE SHOULD NOT be deleted but rather retained until the Registration Lifetime expires." Since this is a "SHOULD NOT" and not a "MUST NOT", we can still remove these NCEs to circumvent NCEs going into UNREACHABLE and never leave this state again. Actually removing these entries from the cache seems also be the better choice for a memory constrained device.

Fixes #3933.