### PR TITLE
gnrc_ipv6_nc: leave UNMANAGED entries UNMANAGED

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -223,7 +223,8 @@ gnrc_ipv6_nc_t *gnrc_ipv6_nc_still_reachable(const ipv6_addr_t *ipv6_addr)
         return NULL;
     }
 
-    if (gnrc_ipv6_nc_get_state(entry) != GNRC_IPV6_NC_STATE_INCOMPLETE) {
+    if ((gnrc_ipv6_nc_get_state(entry) != GNRC_IPV6_NC_STATE_INCOMPLETE) &&
+        (gnrc_ipv6_nc_get_state(entry) != GNRC_IPV6_NC_STATE_UNMANAGED)) {
 #if defined(MODULE_GNRC_IPV6_NETIF) && defined(MODULE_VTIMER) && defined(MODULE_GNRC_IPV6)
         gnrc_ipv6_netif_t *iface = gnrc_ipv6_netif_get(entry->iface);
         timex_t t = iface->reach_time;


### PR DESCRIPTION
`gnrc_ipv6_nc_still_reachable()` shouldn't set an UNMANAGED entry to REACHABLE. Otherwise it enters the NDP state machine and a border router might never be reachable again (since Linux doesn't answer to NSs over SLIP).