### PR TITLE
6lowpan IPHC: set dest context to DCI field not SCI

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -607,8 +607,7 @@ bool gnrc_sixlowpan_iphc_encode(gnrc_pktsnip_t *pkt)
                  * for unicast prefix -> context based compression */
                 iphc_hdr[IPHC2_IDX] |= SIXLOWPAN_IPHC2_DAC;
                 if ((ctx->flags_id & GNRC_SIXLOWPAN_CTX_FLAGS_CID_MASK) != 0) {
-                    iphc_hdr[CID_EXT_IDX] |= ((ctx->flags_id & GNRC_SIXLOWPAN_CTX_FLAGS_CID_MASK)
-                                              << 4);
+                    iphc_hdr[CID_EXT_IDX] |= (ctx->flags_id & GNRC_SIXLOWPAN_CTX_FLAGS_CID_MASK);
                 }
                 iphc_hdr[inline_pos++] = ipv6_hdr->dst.u8[1];
                 iphc_hdr[inline_pos++] = ipv6_hdr->dst.u8[2];
@@ -627,7 +626,7 @@ bool gnrc_sixlowpan_iphc_encode(gnrc_pktsnip_t *pkt)
             iphc_hdr[IPHC2_IDX] |= SIXLOWPAN_IPHC2_DAC;
 
             if (((dst_ctx->flags_id & GNRC_SIXLOWPAN_CTX_FLAGS_CID_MASK) != 0)) {
-                iphc_hdr[CID_EXT_IDX] |= ((dst_ctx->flags_id & GNRC_SIXLOWPAN_CTX_FLAGS_CID_MASK) << 4);
+                iphc_hdr[CID_EXT_IDX] |= (dst_ctx->flags_id & GNRC_SIXLOWPAN_CTX_FLAGS_CID_MASK);
             }
         }
 


### PR DESCRIPTION
The destination context is supposed to go to the 4 LSB of the CID_EXT.