### PR TITLE
make: enable `assert()` in `make scan-build`

### DIFF
--- a/Makefile.cflags
+++ b/Makefile.cflags
@@ -56,7 +56,9 @@ CFLAGS += -fno-common
 CFLAGS += -Wall
 
 ifeq (,$(filter -DDEVELHELP,$(CFLAGS)))
-	CFLAGS += -DNDEBUG
+  ifneq (1,$(FORCE_ASSERTS))
+    CFLAGS += -DNDEBUG
+  endif
 endif
 
 # Default ARFLAGS for platforms which do not specify it.

--- a/Makefile.scan-build
+++ b/Makefile.scan-build
@@ -70,7 +70,7 @@ scan-build-analyze: clean
 	$(AD)mkdir -p '$(SCANBUILD_OUTPUTDIR)'
 	$(AD)env -i $(ENVVARS) \
 	    scan-build -o '$(SCANBUILD_OUTPUTDIR)' $(SCANBUILD_ARGS) \
-	      make -C $(CURDIR) all $(strip $(CMDVARS));
+	      make -C $(CURDIR) all $(strip $(CMDVARS)) FORCE_ASSERTS=1;
 endif # BUILD_IN_DOCKER
 
 ifeq (1,$(INSIDE_DOCKER))


### PR DESCRIPTION
Compare scan-build's documentation: [1]

> ALWAYS analyze a project in its "debug" configuration
>
> Most projects can be built in a "debug" mode that enables assertions.
> Assertions are picked up by the static analyzer to prune infeasible
> paths, which in some cases can greatly reduce the number of false
> positives (bogus error reports) emitted by the tool.

Closes #3960.

  1: http://clang-analyzer.llvm.org/scan-build.html#recommended_debug