### PR TITLE
6low_frag: Fix RSSI, LQI and flags dropping in fragmentation reassembly

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
@@ -85,7 +85,9 @@ typedef struct {
 } rbuf_t;
 
 /**
- * @brief   Adds a new fragment to the reassembly buffer.
+ * @brief   Adds a new fragment to the reassembly buffer. If the packet is
+ *          complete, dispatch the packet with the transmit information of
+ *          the last fragment.
  *
  * @param[in] netif_hdr     The interface header of the fragment, with
  *                          gnrc_netif_hdr_t::if_pid and its source and


### PR DESCRIPTION
When 6LowPAN when 6Lo reassembly is applied the RSSI, LQI and Flags weren't copied to the new `netif_hdr_t`