### PR TITLE
xtimer-core: Use xtimer_now as reference time instead of future timer target

### DIFF
--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -444,8 +444,8 @@ static void _timer_callback(void)
         /* we ended up in _timer_callback and there is
          * a timer waiting.
          */
-        /* set our period reference to that timer's target time. */
-        reference = _mask(timer_list_head->target);
+        /* set our period reference to the current time. */
+        reference = _xtimer_now();
     }
 
 overflow:


### PR DESCRIPTION
Fixes #3941 for me.

I believe this should fix the problem with firing remaining timers immediately when the first timer fires.

The function `_timer_callback` in xtimer-core.c will be called before the actual time (depending on the setting `XTIMER_OVERHEAD`). If we set the reference to the timer target instead of `xtimer_now` the `_time_left` function believes that we have wrapped around to the next long period, resulting in firing of all timers queued for the current period as well as a long term tick increment.