### PR TITLE
samr21-xpro: connect to correct tty when given SERIAL with make term

### DIFF
--- a/boards/samr21-xpro/Makefile.include
+++ b/boards/samr21-xpro/Makefile.include
@@ -17,6 +17,7 @@ include $(RIOTBOARD)/Makefile.include.serial
 #   Usage: SERIAL="ATML..." BOARD="samr21-xpro" make flash
 ifneq (,$(SERIAL))
 export OPENOCD_EXTRA_INIT += "-c cmsis_dap_serial $(SERIAL)"
+PORT_LINUX := $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh $(SERIAL))
 endif
 
 # this board uses openocd


### PR DESCRIPTION
When opening the builtin terminal via

```bash
$ SERIAL="ATMLxxxxxx" make term
```

actually use the associated tty device instead of `/dev/ttyACM0` (default).