### PR TITLE
gnrc_ipv6_whitelist: initial import

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -225,6 +225,10 @@ ifneq (,$(filter gnrc_ipv6_ext,$(USEMODULE)))
   USEMODULE += gnrc_ipv6
 endif
 
+ifneq (,$(filter gnrc_ipv6_whitelist,$(USEMODULE)))
+  USEMODULE += ipv6_addr
+endif
+
 ifneq (,$(filter gnrc_ipv6_router,$(USEMODULE)))
   USEMODULE += gnrc_ipv6
 endif

--- a/sys/include/net/gnrc/ipv6/whitelist.h
+++ b/sys/include/net/gnrc/ipv6/whitelist.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    gnrc_ipv6_whitelist Allows to whitelist certain IPv6 source addresses for
+ *                                  reception.
+ * @ingroup     gnrc_ipv6
+ * @brief       This allows you to only accept IPv6 addresses that are defined in this list.
+ * @{
+ *
+ * @file
+ * @brief   IPv6 whitelist definitions
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+#ifndef GNRC_IPV6_WHITELIST_H_
+#define GNRC_IPV6_WHITELIST_H_
+
+#include <stdbool.h>
+
+#include "net/ipv6/addr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Maximum size of the whitelist.
+ */
+#ifndef GNRC_IPV6_WHITELIST_SIZE
+#define GNRC_IPV6_WHITELIST_SIZE    (8)
+#endif
+
+/**
+ * @brief   Adds an IPv6 address to the whitelist.
+ *
+ * @param[in] addr  An IPv6 address.
+ *
+ * @return  0, on success.
+ * @return  -1, if whitelist is full.
+ */
+int gnrc_ipv6_whitelist_add(const ipv6_addr_t *addr);
+
+/**
+ * @brief   Removes an IPv6 address from the whitelist.
+ *
+ * Addresses not in the whitelist will be ignored.
+ *
+ * @param[in] addr  An IPv6 address.
+ */
+void gnrc_ipv6_whitelist_del(const ipv6_addr_t *addr);
+
+/**
+ * @brief   Checks if an IPv6 address is whitelisted.
+ *
+ * @param[in] addr  An IPv6 address.
+ *
+ * @return  true, if @p addr is whitelisted.
+ * @return  false, if @p addr is not whitelisted.
+ */
+bool gnrc_ipv6_whitelisted(const ipv6_addr_t *addr);
+
+/**
+ * @brief   Prints the whitelist.
+ */
+void gnrc_ipv6_whitelist_print(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GNRC_IPV6_WHITELIST_H_ */
+/** @} */

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -28,6 +28,9 @@ endif
 ifneq (,$(filter gnrc_ipv6_netif,$(USEMODULE)))
     DIRS += network_layer/ipv6/netif
 endif
+ifneq (,$(filter gnrc_ipv6_whitelist,$(USEMODULE)))
+    DIRS += network_layer/ipv6/whitelist
+endif
 ifneq (,$(filter gnrc_ndp,$(USEMODULE)))
     DIRS += network_layer/ndp
 endif

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -30,6 +30,7 @@
 
 #include "net/gnrc/ipv6/nc.h"
 #include "net/gnrc/ipv6/netif.h"
+#include "net/gnrc/ipv6/whitelist.h"
 
 #include "net/gnrc/ipv6.h"
 
@@ -706,6 +707,13 @@ static void _receive(gnrc_pktsnip_t *pkt)
             gnrc_pktbuf_release(pkt);
             return;
         }
+#ifdef MODULE_GNRC_IPV6_WHITELIST
+        if (!gnrc_ipv6_whitelisted(&((ipv6_hdr_t *)(ipv6->data))->src)) {
+            DEBUG("ipv6: Source address not whitelisted, dropping packet\n");
+            gnrc_pktbuf_release(pkt);
+            return;
+        }
+#endif
     }
     else {
         if (!ipv6_hdr_is(pkt->data)) {
@@ -713,7 +721,13 @@ static void _receive(gnrc_pktsnip_t *pkt)
             gnrc_pktbuf_release(pkt);
             return;
         }
-
+#ifdef MODULE_GNRC_IPV6_WHITELIST
+        if (!gnrc_ipv6_whitelisted(&((ipv6_hdr_t *)(pkt->data))->src)) {
+            DEBUG("ipv6: Source address not whitelisted, dropping packet\n");
+            gnrc_pktbuf_release(pkt);
+            return;
+        }
+#endif
         /* seize ipv6 as a temporary variable */
         ipv6 = gnrc_pktbuf_start_write(pkt);
 

--- a/sys/net/gnrc/network_layer/ipv6/whitelist/Makefile
+++ b/sys/net/gnrc/network_layer/ipv6/whitelist/Makefile
@@ -1,0 +1,3 @@
+MODULE = gnrc_ipv6_whitelist
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/network_layer/ipv6/whitelist/gnrc_ipv6_whitelist.c
+++ b/sys/net/gnrc/network_layer/ipv6/whitelist/gnrc_ipv6_whitelist.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include "bitfield.h"
+
+#include "net/gnrc/ipv6/whitelist.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+ipv6_addr_t gnrc_ipv6_whitelist[GNRC_IPV6_WHITELIST_SIZE];
+BITFIELD(gnrc_ipv6_whitelist_set, GNRC_IPV6_WHITELIST_SIZE);
+
+#if ENABLE_DEBUG
+static char addr_str[IPV6_ADDR_MAX_STR_LEN];
+#endif
+
+int gnrc_ipv6_whitelist_add(const ipv6_addr_t *addr)
+{
+    for (int i = 0; i < GNRC_IPV6_WHITELIST_SIZE; i++) {
+        if (!bf_isset(gnrc_ipv6_whitelist_set, i)) {
+            bf_set(gnrc_ipv6_whitelist_set, i);
+            gnrc_ipv6_whitelist[i].u64[0].u64 = addr->u64[0].u64;
+            gnrc_ipv6_whitelist[i].u64[1].u64 = addr->u64[1].u64;
+            DEBUG("IPv6 whitelist: whitelisted %s\n",
+                  ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)));
+            return 0;
+        }
+    }
+    return -1;
+}
+
+void gnrc_ipv6_whitelist_del(const ipv6_addr_t *addr)
+{
+    for (int i = 0; i < GNRC_IPV6_WHITELIST_SIZE; i++) {
+        if (ipv6_addr_equal(addr, &gnrc_ipv6_whitelist[i])) {
+            bf_unset(gnrc_ipv6_whitelist_set, i);
+            DEBUG("IPv6 whitelist: unwhitelisted %s\n",
+                  ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)));
+        }
+    }
+}
+
+bool gnrc_ipv6_whitelisted(const ipv6_addr_t *addr)
+{
+    for (int i = 0; i < GNRC_IPV6_WHITELIST_SIZE; i++) {
+        if (bf_isset(gnrc_ipv6_whitelist_set, i) &&
+            ipv6_addr_equal(addr, &gnrc_ipv6_whitelist[i])) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/** @} */

--- a/sys/net/gnrc/network_layer/ipv6/whitelist/gnrc_ipv6_whitelist_print.c
+++ b/sys/net/gnrc/network_layer/ipv6/whitelist/gnrc_ipv6_whitelist_print.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include <stdio.h>
+
+#include "bitfield.h"
+#include "net/ipv6/addr.h"
+
+#include "net/gnrc/ipv6/whitelist.h"
+
+extern ipv6_addr_t gnrc_ipv6_whitelist[GNRC_IPV6_WHITELIST_SIZE];
+extern BITFIELD(gnrc_ipv6_whitelist_set, GNRC_IPV6_WHITELIST_SIZE);
+
+void gnrc_ipv6_whitelist_print(void)
+{
+    char addr_str[IPV6_ADDR_MAX_STR_LEN];
+    for (int i = 0; i < GNRC_IPV6_WHITELIST_SIZE; i++) {
+        if (bf_isset(gnrc_ipv6_whitelist_set, i)) {
+            puts(ipv6_addr_to_str(addr_str, &gnrc_ipv6_whitelist[i], sizeof(addr_str)));
+        }
+    }
+}
+
+/** @} */

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -47,6 +47,9 @@ endif
 ifneq (,$(filter gnrc_ipv6_nc,$(USEMODULE)))
   SRC += sc_ipv6_nc.c
 endif
+ifneq (,$(filter gnrc_ipv6_whitelist,$(USEMODULE)))
+  SRC += sc_whitelist.c
+endif
 ifneq (,$(filter gnrc_icmpv6_echo vtimer,$(USEMODULE)))
   SRC += sc_icmpv6_echo.c
 endif

--- a/sys/shell/commands/sc_whitelist.c
+++ b/sys/shell/commands/sc_whitelist.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "net/gnrc/ipv6/whitelist.h"
+
+static void _usage(char *cmd)
+{
+    printf("usage: * %s\n", cmd);
+    puts("         Lists all addresses in the whitelist.");
+    printf("       * %s add <addr>\n", cmd);
+    puts("         Adds <addr> to the whitelist.");
+    printf("       * %s del <addr>\n", cmd);
+    puts("         Deletes <addr> from the whitelist.");
+    printf("       * %s help\n", cmd);
+    puts("         Print this.");
+}
+
+int _whitelist(int argc, char **argv)
+{
+    ipv6_addr_t addr;
+    if (argc < 2) {
+        gnrc_ipv6_whitelist_print();
+        return 0;
+    }
+    else if (argc > 2) {
+        if (ipv6_addr_from_str(&addr, argv[2]) == NULL) {
+            _usage(argv[0]);
+            return 1;
+        }
+    }
+    if (strcmp("add", argv[1]) == 0) {
+        gnrc_ipv6_whitelist_add(&addr);
+    }
+    else if (strcmp("del", argv[1]) == 0) {
+        gnrc_ipv6_whitelist_del(&addr);
+    }
+    else if (strcmp("help", argv[1]) == 0) {
+        _usage(argv[0]);
+    }
+    else {
+        _usage(argv[0]);
+        return 1;
+    }
+    return 0;
+}
+
+/** @} */

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -110,6 +110,10 @@ extern int _ipv6_nc_manage(int argc, char **argv);
 extern int _ipv6_nc_routers(int argc, char **argv);
 #endif
 
+#ifdef MODULE_GNRC_IPV6_WHITELIST
+extern int _whitelist(int argc, char **argv);
+#endif
+
 #ifdef MODULE_GNRC_ZEP
 #ifdef MODULE_IPV6_ADDR
 extern int _zep_init(int argc, char **argv);
@@ -195,6 +199,9 @@ const shell_command_t _shell_command_list[] = {
 #ifdef MODULE_GNRC_IPV6_NC
     {"ncache", "manage neighbor cache by hand", _ipv6_nc_manage },
     {"routers", "IPv6 default router list", _ipv6_nc_routers },
+#endif
+#ifdef MODULE_GNRC_IPV6_WHITELIST
+    {"whitelist", "whitelists an address for receival ('whitelist [add|del|help]')", _whitelist },
 #endif
 #ifdef MODULE_GNRC_ZEP
 #ifdef MODULE_IPV6_ADDR


### PR DESCRIPTION
This provides the capability to emulate non-reachability between nodes. This can be helpful for testing routing protocols e.g.