### PR TITLE
rpl: Remove unused variable when building with ENABLE_DEBUG=1

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -24,10 +24,6 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#if ENABLE_DEBUG && defined(MODULE_IPV6_ADDR)
-static char addr_str[IPV6_ADDR_MAX_STR_LEN];
-#endif
-
 static char _stack[GNRC_RPL_STACK_SIZE];
 kernel_pid_t gnrc_rpl_pid = KERNEL_PID_UNDEF;
 static uint32_t _lt_time = GNRC_RPL_LIFETIME_UPDATE_STEP * SEC_IN_USEC;


### PR DESCRIPTION
Fixes
    /data/riotbuild/riotbase/sys/net/gnrc/routing/rpl/gnrc_rpl.c:28:13: error: 'addr_str' defined but not used [-Werror=unused-variable]
     static char addr_str[IPV6_ADDR_MAX_STR_LEN];
                  ^
when building with #define ENABLE_DEBUG (1)