### PR TITLE
gnrc_pktbuf_static: fix order of calling

### DIFF
--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -313,8 +313,8 @@ void gnrc_pktbuf_stats(void)
         }
         _print_chunk(chunk, size, count++);
         chunk += (size + ptr->size);
-        ptr = ptr->next;
         _print_unused(ptr);
+        ptr = ptr->next;
     }
 
     if (chunk <= &_pktbuf[GNRC_PKTBUF_SIZE - 1]) {


### PR DESCRIPTION
Getting the next one before outputting the previous one makes no sense (especially if `pkt->next` is `NULL` ;-)).

(Release version of #3985)