### PR TITLE
gnrc_ipv6_nc: interface in neighbor cache may be undefined but legal

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -161,14 +161,14 @@ void gnrc_ipv6_nc_remove(kernel_pid_t iface, const ipv6_addr_t *ipv6_addr)
 
 gnrc_ipv6_nc_t *gnrc_ipv6_nc_get(kernel_pid_t iface, const ipv6_addr_t *ipv6_addr)
 {
-    if (ipv6_addr == NULL) {
-        DEBUG("ipv6_nc: address was NULL\n");
+    if ((ipv6_addr == NULL) || (ipv6_addr_is_unspecified(ipv6_addr))) {
+        DEBUG("ipv6_nc: address was NULL or ::\n");
         return NULL;
     }
 
     for (int i = 0; i < GNRC_IPV6_NC_SIZE; i++) {
-        if (((iface == KERNEL_PID_UNDEF) || (iface == ncache[i].iface)) &&
-            ipv6_addr_equal(&(ncache[i].ipv6_addr), ipv6_addr)) {
+        if (((ncache[i].iface == KERNEL_PID_UNDEF) || (iface == KERNEL_PID_UNDEF) ||
+             (iface == ncache[i].iface)) && ipv6_addr_equal(&(ncache[i].ipv6_addr), ipv6_addr)) {
             DEBUG("ipv6_nc: Found entry for %s on interface %" PRIkernel_pid
                   " (0 = all interfaces) [%p]\n",
                   ipv6_addr_to_str(addr_str, ipv6_addr, sizeof(addr_str)),


### PR DESCRIPTION
In some cases it was observed, that a first ping wasn't answered (because the NA wasn't handled by the host). This was due to a bug in the neighbor cache, that did not recognize `entry->iface == KERNEL_PID_UNDEF` as a legal entry (which may be the case if the state is e.g. INCOMPLETE). This PR fixes that.

(This is the release version of #3987)