### PR TITLE
xtimer: Add support for arbitrary frequency hardware timers (32768 Hz support)

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -409,6 +409,7 @@ endif
 
 ifneq (,$(filter xtimer,$(USEMODULE)))
     FEATURES_REQUIRED += periph_timer
+    USEMODULE += div
 endif
 
 ifneq (,$(filter saul_reg,$(USEMODULE)))

--- a/boards/arduino-mega2560/include/board.h
+++ b/boards/arduino-mega2560/include/board.h
@@ -64,6 +64,7 @@ extern "C" {
  * @brief xtimer configuration values
  * @{
  */
+#define XTIMER_HZ                   (250000ul)
 #define XTIMER_SHIFT                (2)
 #define XTIMER_SHIFT_ON_COMPARE     (8)
 #define XTIMER_BACKOFF              (40)

--- a/boards/nucleo-f103/include/board.h
+++ b/boards/nucleo-f103/include/board.h
@@ -75,6 +75,7 @@ extern "C" {
 #define XTIMER_SHIFT        0
 #define XTIMER_MASK         0 /* llt 32-bit since combined */
 #define XTIMER_BACKOFF      5
+#define XTIMER_OVERHEAD     4
 /** @} */
 
 /**

--- a/boards/nucleo-f401/include/board.h
+++ b/boards/nucleo-f401/include/board.h
@@ -35,7 +35,7 @@ extern "C" {
 #define XTIMER              TIMER_0
 #define XTIMER_CHAN         (0)
 #define XTIMER_OVERHEAD     (6)
-#define XTIMER_BACKOFF      (5)
+#define XTIMER_BACKOFF      (7)
 /** @} */
 
 /**

--- a/boards/nucleo-l1/include/board.h
+++ b/boards/nucleo-l1/include/board.h
@@ -37,7 +37,7 @@ extern "C" {
 #define XTIMER              TIMER_DEV(0)
 #define XTIMER_CHAN         (0)
 #define XTIMER_OVERHEAD     (6)
-#define XTIMER_BACKOFF      (3)
+#define XTIMER_BACKOFF      (7)
 /** @} */
 
 /**

--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -53,7 +53,6 @@
  * @{
  */
 #define XTIMER_OVERHEAD 14
-#define XTIMER_USLEEP_UNTIL_OVERHEAD 1
 
 /* timer_set_absolute() has a high margin for possible underflow if set with
  * value not far in the future. To prevent this, we set high backoff values

--- a/sys/div/Makefile
+++ b/sys/div/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/div/div.c
+++ b/sys/div/div.c
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ * @ingroup sys_util
+ * @{
+ * @file
+ * @brief    Integer division function implementations
+ *
+ * @author   Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include "div.h"
+
+uint64_t _div_mulhi64(const uint64_t a, const uint64_t b)
+{
+    /* Handle overflow explicit because we don't have 128 bit integers on
+     * our platforms. */
+    const uint32_t a_lo = (const uint32_t)a;
+    const uint32_t a_hi = (const uint32_t)(a >> 32);
+    const uint32_t b_lo = (const uint32_t)b;
+    const uint32_t b_hi = (const uint32_t)(b >> 32);
+
+    const uint64_t a_x_b_mid = (const uint64_t)a_hi * b_lo;
+    const uint64_t b_x_a_mid = (const uint64_t)b_hi * a_lo;
+    const uint64_t a_x_b_lo =  (const uint64_t)a_lo * b_lo;
+    const uint64_t a_x_b_hi =  (const uint64_t)a_hi * b_hi;
+
+    /* We may get up to 2 carry bits from the lower part of the multiplication */
+    const uint32_t carry_bits = ((uint64_t)(uint32_t)a_x_b_mid +
+                          (uint64_t)(uint32_t)b_x_a_mid +
+                          (a_x_b_lo >> 32) ) >> 32;
+
+    const uint64_t multhi = a_x_b_hi +
+                      (a_x_b_mid >> 32) + (b_x_a_mid >> 32) +
+                      carry_bits;
+
+    return multhi;
+}

--- a/sys/include/div.h
+++ b/sys/include/div.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * Copyright (C) 2016 Eistec AB
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,7 +15,8 @@
  *
  * @file
  * @ingroup   sys_util
- * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ * @author    Kaspar Schleiser <kaspar@schleiser.de>
+ * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
  * @{
  */
 
@@ -39,7 +41,7 @@ extern "C" {
 static inline uint64_t div_u64_by_15625(uint64_t val)
 {
     /* a higher value would overflow 2^64 in the multiplication that follows */
-    assert(val <= 16383999997LLU);
+    assert(val <= 16383999997ull);
 
     return (val * 0x431bde83UL) >> (12 + 32);
 }
@@ -55,7 +57,7 @@ static inline uint64_t div_u64_by_15625(uint64_t val)
 static inline uint64_t div_u64_by_1000000(uint64_t val)
 {
     /* a higher value would overflow 2^64 in the multiplication that follows */
-    assert(val <= 1048575999808LLU);
+    assert(val <= 1048575999808ull);
 
     return div_u64_by_15625(val>>6);
 }
@@ -74,6 +76,31 @@ static inline uint64_t div_u64_by_1000000(uint64_t val)
  */
 static inline uint32_t div_u32_by_15625div512(uint32_t val)
 {
+    return ((uint64_t)(val) * 0x431bde83ul) >> (12 + 32 - 9);
+}
+
+/**
+ * @brief Divide val by (15625/512)
+ *
+ * This is used to quantize a 1MHz value to the closest 32768Hz value,
+ * e.g., for timers.
+ *
+ * The algorithm actually multiplies by 512 first, then divides by 15625,
+ * keeping the result closer to a floored floating point division.
+ *
+ * @pre val <= 16383999997
+ *
+ * @param[in]   val     dividend
+ * @return      (val / (15625/512))
+ */
+static inline uint64_t div_u64_by_15625div512(uint64_t val)
+{
+    /* a higher value would overflow 2^64 in the multiplication that follows */
+    assert(val <= 16383999997ull);
+    /*
+     * This saves around 1400 bytes of ROM on Cortex-M platforms (both ARMv6 and
+     * ARMv7) from avoiding linking against __aeabi_uldivmod and related helpers
+     */
     return ((uint64_t)(val) * 0x431bde83ul) >> (12 + 32 - 9);
 }
 

--- a/sys/include/div.h
+++ b/sys/include/div.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @brief     Provides integer division functions
+ * @brief     Integer division functions
  *
  * This header provides some integer division functions that can be used
  * to prevent linking in compiler-generated ones, which are often larger.
@@ -31,35 +31,57 @@ extern "C" {
 #endif
 
 /**
- * @brief Integer divide val by 15625
+ * @brief Approximation of (2**l)/d for d=15625, l=12, 32 bits
+ */
+#define DIV_H_INV_15625_32    0x431bde83ul
+
+/**
+ * @brief Approximation of (2**l)/d for d=15625, l=12, 64 bits
+ */
+#define DIV_H_INV_15625_64    0x431bde82d7b634dbull
+
+/**
+ * @brief Required shifts for division by 15625, l above
+ */
+#define DIV_H_INV_15625_SHIFT 12
+
+/**
+ * @brief Multiply two 64 bit integers into a 128 bit integer and return the upper half.
  *
- * @pre val <= 16383999997
+ * The implementation only uses 64 bit integers internally, no __int128 support
+ * is necessary.
+ *
+ * @see http://stackoverflow.com/questions/28868367/getting-the-high-part-of-64-bit-integer-multiplication
+
+ * @param[in]   a     operand a
+ * @param[in]   a     operand b
+ * @return      (((uint128_t)a * b) >> 64)
+ */
+uint64_t _div_mulhi64(const uint64_t a, const uint64_t b);
+
+/**
+ * @brief Integer divide val by 15625, 64 bit version
  *
  * @param[in]   val     dividend
  * @return      (val / 15625)
  */
 static inline uint64_t div_u64_by_15625(uint64_t val)
 {
-    /* a higher value would overflow 2^64 in the multiplication that follows */
-    assert(val <= 16383999997ull);
-
-    return (val * 0x431bde83UL) >> (12 + 32);
+    if (val > 16383999997ull) {
+        return (_div_mulhi64(DIV_H_INV_15625_64, val) >> DIV_H_INV_15625_SHIFT);
+    }
+    return (val * DIV_H_INV_15625_32) >> (DIV_H_INV_15625_SHIFT + 32);
 }
 
 /**
  * @brief Integer divide val by 1000000
- *
- * @pre val <= 1048575999808
  *
  * @param[in]   val     dividend
  * @return      (val / 1000000)
  */
 static inline uint64_t div_u64_by_1000000(uint64_t val)
 {
-    /* a higher value would overflow 2^64 in the multiplication that follows */
-    assert(val <= 1048575999808ull);
-
-    return div_u64_by_15625(val>>6);
+    return div_u64_by_15625(val) >> 6;
 }
 
 /**
@@ -68,15 +90,17 @@ static inline uint64_t div_u64_by_1000000(uint64_t val)
  * This is used to quantize a 1MHz value to the closest 32768Hz value,
  * e.g., for timers.
  *
- * The algorithm actually multiplies by 512 first, then divides by 15625,
- * keeping the result closer to a floored floating point division.
+ * The algorithm uses the modular multiplicative inverse of 15625 to use only
+ * multiplication and bit shifts to perform the division.
+ *
+ * The result will be equal to the mathematical expression: floor((val * 512) / 15625)
  *
  * @param[in]   val     dividend
  * @return      (val / (15625/512))
  */
 static inline uint32_t div_u32_by_15625div512(uint32_t val)
 {
-    return ((uint64_t)(val) * 0x431bde83ul) >> (12 + 32 - 9);
+    return ((uint64_t)(val) * DIV_H_INV_15625_32) >> (DIV_H_INV_15625_SHIFT + 32 - 9);
 }
 
 /**
@@ -85,23 +109,21 @@ static inline uint32_t div_u32_by_15625div512(uint32_t val)
  * This is used to quantize a 1MHz value to the closest 32768Hz value,
  * e.g., for timers.
  *
- * The algorithm actually multiplies by 512 first, then divides by 15625,
- * keeping the result closer to a floored floating point division.
- *
- * @pre val <= 16383999997
- *
  * @param[in]   val     dividend
  * @return      (val / (15625/512))
  */
 static inline uint64_t div_u64_by_15625div512(uint64_t val)
 {
-    /* a higher value would overflow 2^64 in the multiplication that follows */
-    assert(val <= 16383999997ull);
     /*
      * This saves around 1400 bytes of ROM on Cortex-M platforms (both ARMv6 and
      * ARMv7) from avoiding linking against __aeabi_uldivmod and related helpers
      */
-    return ((uint64_t)(val) * 0x431bde83ul) >> (12 + 32 - 9);
+    if (val > 16383999997ull) {
+        /* this would overflow 2^64 in the multiplication that follows, need to
+         * use the long version */
+        return (_div_mulhi64(DIV_H_INV_15625_64, val) >> (DIV_H_INV_15625_SHIFT - 9));
+    }
+    return (val * DIV_H_INV_15625_32) >> (DIV_H_INV_15625_SHIFT + 32 - 9);
 }
 
 /**

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -248,7 +248,7 @@ void xtimer_set_wakeup64(xtimer_t *timer, uint64_t offset, kernel_pid_t pid);
  * @param[in] offset    time in microseconds from now specifying that timer's
  *                      callback's execution time
  */
-void xtimer_set(xtimer_t *timer, uint32_t offset);
+static inline void xtimer_set(xtimer_t *timer, uint32_t offset);
 
 /**
  * @brief remove a timer
@@ -600,7 +600,15 @@ static inline uint32_t xtimer_now(void)
     return _xtimer_ticks_to_us(_xtimer_now_ticks());
 }
 
-static inline void _xtimer_spin_until_ticks(uint32_t target) {
+void _xtimer_set_ticks(xtimer_t *timer, uint32_t offset);
+
+static inline void xtimer_set(xtimer_t *timer, uint32_t offset)
+{
+    _xtimer_set_ticks(timer, _xtimer_us_to_ticks(offset));
+}
+
+static inline void _xtimer_spin_until_ticks(uint32_t target)
+{
 #if XTIMER_MASK
     target = _lltimer_mask(target);
 #endif
@@ -613,12 +621,14 @@ static inline void xtimer_spin_until(uint32_t target) {
     _xtimer_spin_until_ticks(target);
 }
 
-static inline void _xtimer_spin_ticks(uint32_t offset) {
+static inline void _xtimer_spin_ticks(uint32_t offset)
+{
     uint32_t start = _xtimer_now_ticks();
     while ((_xtimer_now_ticks() - start) < offset);
 }
 
-static inline void xtimer_spin(uint32_t offset) {
+static inline void xtimer_spin(uint32_t offset)
+{
     offset = _xtimer_us_to_ticks(offset);
     _xtimer_spin_ticks(offset);
 }

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -479,16 +479,12 @@ static inline void xtimer_spin_until(uint32_t target) {
 
 static inline void xtimer_spin(uint32_t offset) {
     uint32_t start = _lltimer_now();
-    uint32_t target = start + offset;
 #if XTIMER_MASK
-    target = _lltimer_mask(target);
+    offset = _lltimer_mask(offset);
+    while (_lltimer_mask(_lltimer_now() - start) < offset);
+#else
+    while ((_lltimer_now() - start) < offset);
 #endif
-    if (target < start) {
-        /* Target time is less than start time => overflow */
-        /* Spin until timer overflows */
-        while (_lltimer_now() >= start);
-    }
-    while (_lltimer_now() < target);
 }
 
 static inline void xtimer_usleep(uint32_t microseconds)

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -532,7 +532,18 @@ inline static uint32_t _xtimer_us_to_ticks_ceil(uint32_t us)
 #endif
 }
 
+/**
+ * @brief Long term counter
+ *
+ * This variable contains the upper 32 bits of the "now" tick count
+ */
+extern volatile uint32_t _long_cnt;
 #if XTIMER_MASK
+/**
+ * @brief High order bits of short term counter.
+ *
+ * This is only used when underlying hardware timer is less than 32 bits wide.
+ */
 extern volatile uint32_t _high_cnt;
 #endif
 
@@ -588,6 +599,17 @@ inline static uint32_t _xtimer_now_ticks(void) {
 }
 
 /**
+ * @brief Get both the short term and the long term ticks.
+ *
+ * This function will handle overflows to ensure that the short term and the
+ * long term ticks are synchronized before returning.
+ *
+ * @param[out] short_term  pointer to short term tick variable
+ * @param[out] long_term   pointer to long term tick variable
+ */
+void _xtimer_now_ticks64(uint32_t *short_term, uint32_t *long_term);
+
+/**
  * @brief drop bits of a value that don't fit into the low-level timer.
  */
 static inline uint32_t _lltimer_mask(uint32_t val)
@@ -597,7 +619,7 @@ static inline uint32_t _lltimer_mask(uint32_t val)
 
 static inline uint32_t xtimer_now(void)
 {
-    return _xtimer_ticks_to_us(_xtimer_now_ticks());
+    return (uint32_t)xtimer_now64();
 }
 
 void _xtimer_set_ticks(xtimer_t *timer, uint32_t offset);

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -479,7 +479,16 @@ static inline void xtimer_spin_until(uint32_t target) {
 
 static inline void xtimer_spin(uint32_t offset) {
     uint32_t start = _lltimer_now();
-    while ((_lltimer_now() - start) < offset);
+    uint32_t target = start + offset;
+#if XTIMER_MASK
+    target = _lltimer_mask(target);
+#endif
+    if (target < start) {
+        /* Target time is less than start time => overflow */
+        /* Spin until timer overflows */
+        while (_lltimer_now() >= start);
+    }
+    while (_lltimer_now() < target);
 }
 
 static inline void xtimer_usleep(uint32_t microseconds)

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -398,6 +398,15 @@ extern volatile uint32_t _high_cnt;
  */
 #define MSG_XTIMER 12345
 
+
+#if (XTIMER_BACKOFF < XTIMER_OVERHEAD)
+#warning XTIMER_BACKOFF < XTIMER_OVERHEAD will cause timer underruns on short timeouts.
+#endif
+
+#if (XTIMER_ISR_BACKOFF < XTIMER_OVERHEAD)
+#warning XTIMER_ISR_BACKOFF < XTIMER_OVERHEAD will cause timer underruns on short timeouts.
+#endif
+
 /**
  * @brief returns the (masked) low-level timer counter value.
  */

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -394,6 +394,25 @@ int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t us);
 #define XTIMER_USLEEP_UNTIL_OVERHEAD 10
 #endif
 
+#if XTIMER_MASK
+#ifndef XTIMER_SHIFT_ON_COMPARE
+/**
+ * @brief ignore some bits when comparing timer values
+ *
+ * (only relevant when XTIMER_MASK != 0, e.g., timers < 32bit.)
+ *
+ * When combining _lltimer_now_ticks() and _high_cnt, we have to get the same
+ * value in order to work around a race between overflowing _xtimer_now() and
+ * OR'ing the resulting values.
+ * But some platforms are too slow to get the same timer value twice, so we use
+ * this define to ignore some of the bits.
+ *
+ * Use tests/xtimer_shift_on_compare to find the correct value for your MCU.
+ */
+#define XTIMER_SHIFT_ON_COMPARE     (0)
+#endif
+#endif
+
 #ifndef XTIMER_HZ
 /**
  * @brief Tick rate of the underlying hardware timer.
@@ -509,33 +528,6 @@ static inline uint32_t _lltimer_mask(uint32_t val)
 {
     return val & ~XTIMER_MASK_SHIFTED;
 }
-
-
-#if XTIMER_MASK
-#ifndef XTIMER_SHIFT_ON_COMPARE
-/**
- * @brief ignore some bits when comparing timer values
- *
- * (only relevant when XTIMER_MASK != 0, e.g., timers < 32bit.)
- *
- * When combining _lltimer_now() and _high_cnt, we have to get the same value in
- * order to work around a race between overflowing _lltimer_now() and OR'ing the
- * resulting values.
- * But some platforms are too slow to get the same timer
- * value twice, so we use this define to ignore some of the bits.
- *
- * Use tests/xtimer_shift_on_compare to find the correct value for your MCU.
- */
-#define XTIMER_SHIFT_ON_COMPARE     (0)
-#endif
-#endif
-
-#ifndef XTIMER_MIN_SPIN
-/**
- * @brief Minimal value xtimer_spin() can spin
- */
-#define XTIMER_MIN_SPIN (1<<XTIMER_SHIFT)
-#endif
 
 static inline uint32_t xtimer_now(void)
 {

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -445,7 +445,7 @@ inline static uint64_t _xtimer_ticks_to_us64(uint64_t ticks) {
 #error (XTIMER_HZ << XTIMER_SHIFT) != 1000000ul
 #endif
 /* 1 MHz is a power-of-two multiple of XTIMER_HZ */
-/* e.g. ATMega2560 uses a 250 kHz timer */
+/* e.g. ATmega2560 uses a 250 kHz timer */
 inline static uint32_t _xtimer_us_to_ticks(uint32_t us) {
     return (us >> XTIMER_SHIFT); /* divide by power of two */
 }
@@ -515,6 +515,22 @@ inline static uint64_t _xtimer_ticks_to_us64(uint64_t ticks) {
 #error Unknown hardware timer frequency (XTIMER_HZ), check board.h and/or add an implementation in xtimer.h
 #endif
 #endif
+
+/**
+ * @brief Convert microseconds to underlying hardware timer ticks, rounding up
+ *
+ * Result will be rounded up to nearest integer tick equal to or longer than the
+ * given microsecond value
+ */
+inline static uint32_t _xtimer_us_to_ticks_ceil(uint32_t us)
+{
+#if XTIMER_HZ < SEC_IN_USEC
+    /* only timers slower than 1 MHz need rounding */
+    return _xtimer_us_to_ticks(us + (_xtimer_ticks_to_us(1) - 1));
+#else
+    return _xtimer_us_to_ticks(us);
+#endif
+}
 
 #if XTIMER_MASK
 extern volatile uint32_t _high_cnt;

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -287,7 +287,7 @@ int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t us);
 /**
  * @brief xtimer backoff value
  *
- * All timers that are less than XTIMER_BACKOFF microseconds in the future will
+ * All timers that are less than XTIMER_BACKOFF ticks in the future will
  * just spin.
  *
  * This is supposed to be defined per-device in e.g., periph_conf.h.

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -72,8 +72,11 @@ void xtimer_usleep_until(uint32_t *last_wakeup, uint32_t interval) {
     uint32_t last_wakeup_us = *last_wakeup;
 
     uint32_t target_us = last_wakeup_us + interval;
-    uint32_t now_ticks = _xtimer_now_ticks();
-    uint32_t now_us = _xtimer_ticks_to_us(now_ticks);
+    uint32_t now_short = 0;
+    uint32_t now_long = 0;
+    _xtimer_now_ticks64(&now_short, &now_long);
+    uint64_t now_ticks = ((uint64_t)now_long << 32) | now_short;
+    uint32_t now_us = _xtimer_ticks_to_us64(now_ticks);
     /* make sure we're not setting a value in the past */
     if (now_us < last_wakeup_us) {
         /* base timer overflowed between last_wakeup and now */

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -165,6 +165,7 @@ int _xtimer_set_absolute_ticks(xtimer_t *timer, uint32_t target)
 
     timer->next = NULL;
     if ((target >= now) && ((target - XTIMER_BACKOFF) < now)) {
+        /* TODO: Handle corner case: now = 0, target = 1, XTIMER_BACKOFF = 2 (target < XTIMER_BACKOFF) */
         /* backoff */
         _xtimer_spin_until_ticks(target + XTIMER_BACKOFF);
         _shoot(timer);

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -32,7 +32,7 @@
 
 static volatile int _in_handler = 0;
 
-static volatile uint32_t _long_cnt = 0;
+volatile uint32_t _long_cnt = 0;
 #if XTIMER_MASK
 volatile uint32_t _high_cnt = 0;
 #endif
@@ -66,7 +66,7 @@ void xtimer_init(void)
     _lltimer_set(0xFFFFFFFF);
 }
 
-inline static void _xtimer_now_ticks64(uint32_t *short_term, uint32_t *long_term)
+void _xtimer_now_ticks64(uint32_t *short_term, uint32_t *long_term)
 {
     uint32_t before, after, long_value;
 

--- a/tests/unittests/tests-div/Makefile.include
+++ b/tests/unittests/tests-div/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += div

--- a/tests/unittests/tests-div/tests-div.c
+++ b/tests/unittests/tests-div/tests-div.c
@@ -25,11 +25,13 @@ static uint32_t u32_test_values[] = {
     (15625LU*5)+1,
     0xffff,
     0xffff<<10,
-    0xffffffff
+    0xffffffff,
 };
 
 static uint64_t u64_test_values[] = {
-    0xffffffffULL+1
+    16383999997ull,
+    11111111111ull,
+    0xffffffffull+1,
 };
 
 #define N_U32_VALS (sizeof(u32_test_values)/sizeof(uint32_t))
@@ -40,15 +42,15 @@ static void test_div_u64_by_15625(void)
     for (unsigned i = 0; i < N_U32_VALS; i++) {
         DEBUG("Dividing %"PRIu32" by 15625...\n", u32_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
-                div_u64_by_15625(u32_test_values[i]),
-                u32_test_values[i]/15625);
+            u32_test_values[i] / 15625,
+            div_u64_by_15625(u32_test_values[i]));
     }
 
     for (unsigned i = 0; i < N_U64_VALS; i++) {
         DEBUG("Dividing %"PRIu64" by 15625...\n", u64_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
-                div_u64_by_15625(u64_test_values[i]),
-                u64_test_values[i]/15625);
+            (uint64_t)u64_test_values[i] / 15625,
+            div_u64_by_15625(u64_test_values[i]));
     }
 }
 
@@ -57,8 +59,8 @@ static void test_div_u32_by_15625div512(void)
     for (unsigned i = 0; i < N_U32_VALS; i++) {
         DEBUG("Dividing %"PRIu32" by (15625/512)...\n", u32_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
-                div_u32_by_15625div512(u32_test_values[i]),
-                (uint64_t)u32_test_values[i]*512LU/15625);
+            (uint64_t)u32_test_values[i] * 512lu / 15625,
+            div_u32_by_15625div512(u32_test_values[i]));
     }
 }
 
@@ -67,15 +69,32 @@ static void test_div_u64_by_1000000(void)
     for (unsigned i = 0; i < N_U32_VALS; i++) {
         DEBUG("Dividing %"PRIu32" by 1000000...\n", u32_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
-                div_u64_by_1000000(u32_test_values[i]),
-                u32_test_values[i]/1000000);
+            u32_test_values[i] / 1000000lu,
+            div_u64_by_1000000(u32_test_values[i]));
     }
 
     for (unsigned i = 0; i < N_U64_VALS; i++) {
         DEBUG("Dividing %"PRIu64" by 1000000...\n", u64_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
-                div_u64_by_1000000(u64_test_values[i]),
-                u64_test_values[i]/1000000U);
+            u64_test_values[i] / 1000000lu,
+            div_u64_by_1000000(u64_test_values[i]));
+    }
+}
+
+static void test_div_u64_by_15625div512(void)
+{
+    for (unsigned i = 0; i < N_U32_VALS; i++) {
+        DEBUG("Dividing %"PRIu32" by (15625/512)...\n", u32_test_values[i]);
+        TEST_ASSERT_EQUAL_INT(
+            (uint64_t)u32_test_values[i] * 512lu / 15625,
+            div_u64_by_15625div512(u32_test_values[i]));
+    }
+
+    for (unsigned i = 0; i < N_U64_VALS; i++) {
+        DEBUG("Dividing %"PRIu64" by (15625/512)...\n", u64_test_values[i]);
+        TEST_ASSERT_EQUAL_INT(
+            (uint64_t)u64_test_values[i] * 512lu / 15625,
+            div_u64_by_15625div512(u64_test_values[i]));
     }
 }
 
@@ -84,6 +103,7 @@ Test *tests_div_tests(void)
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_div_u64_by_15625),
         new_TestFixture(test_div_u32_by_15625div512),
+        new_TestFixture(test_div_u64_by_15625div512),
         new_TestFixture(test_div_u64_by_1000000),
     };
 

--- a/tests/unittests/tests-div/tests-div.c
+++ b/tests/unittests/tests-div/tests-div.c
@@ -15,7 +15,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static uint32_t u32_test_values[] = {
+static const uint32_t u32_test_values[] = {
     0,
     1,
     10,
@@ -28,26 +28,57 @@ static uint32_t u32_test_values[] = {
     0xffffffff,
 };
 
-static uint64_t u64_test_values[] = {
-    16383999997ull,
+static const uint64_t u64_test_values[] = {
     11111111111ull,
     0xffffffffull+1,
+    16383999997ull,
+    16383999998ull,
+    16383999999ull,
+    16384000000ull,
+    1048575999807ull,
+    1048575999808ull,
+    1048575999809ull,
+    0xffffffffffffeeull,
+    0x777777777777777ull,
+    0x1111111111111111ull,
+    0xffffffffffffffffull,
+    0x8000000000000000ull,
 };
 
-#define N_U32_VALS (sizeof(u32_test_values)/sizeof(uint32_t))
-#define N_U64_VALS (sizeof(u64_test_values)/sizeof(uint64_t))
+/* These expected values for test_div_u64_by_15625div512
+ * were computed from the expression (u64_test_values * 512) / 15625 using 128
+ * bit integers. */
+static const uint64_t u64_15625_512_expected_values[] = {
+    364088888,
+    140737488,
+    536870911,
+    536870911,
+    536870911,
+    536870912,
+    34359738361,
+    34359738361,
+    34359738361,
+    2361183241434822,
+    17630168202713342,
+    40297527320487639,
+    604462909807314587,
+    302231454903657293,
+};
+
+#define N_U32_VALS (sizeof(u32_test_values)/sizeof(u32_test_values[0]))
+#define N_U64_VALS (sizeof(u64_test_values)/sizeof(u64_test_values[0]))
 
 static void test_div_u64_by_15625(void)
 {
     for (unsigned i = 0; i < N_U32_VALS; i++) {
-        DEBUG("Dividing %"PRIu32" by 15625...\n", u32_test_values[i]);
+        DEBUG("Dividing %12"PRIu32" by 15625...\n", u32_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
-            u32_test_values[i] / 15625,
+            (uint64_t)u32_test_values[i] / 15625,
             div_u64_by_15625(u32_test_values[i]));
     }
 
     for (unsigned i = 0; i < N_U64_VALS; i++) {
-        DEBUG("Dividing %"PRIu64" by 15625...\n", u64_test_values[i]);
+        DEBUG("Dividing %12"PRIu64" by 15625...\n", u64_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
             (uint64_t)u64_test_values[i] / 15625,
             div_u64_by_15625(u64_test_values[i]));
@@ -69,7 +100,7 @@ static void test_div_u64_by_1000000(void)
     for (unsigned i = 0; i < N_U32_VALS; i++) {
         DEBUG("Dividing %"PRIu32" by 1000000...\n", u32_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
-            u32_test_values[i] / 1000000lu,
+            (uint64_t)u32_test_values[i] / 1000000lu,
             div_u64_by_1000000(u32_test_values[i]));
     }
 
@@ -93,7 +124,7 @@ static void test_div_u64_by_15625div512(void)
     for (unsigned i = 0; i < N_U64_VALS; i++) {
         DEBUG("Dividing %"PRIu64" by (15625/512)...\n", u64_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
-            (uint64_t)u64_test_values[i] * 512lu / 15625,
+            u64_15625_512_expected_values[i],
             div_u64_by_15625div512(u64_test_values[i]));
     }
 }

--- a/tests/xtimer_drift/main.c
+++ b/tests/xtimer_drift/main.c
@@ -89,6 +89,7 @@ void *worker_thread(void *arg)
     (void) arg;
     unsigned int loop_counter = 0;
     uint32_t start = 0;
+    uint32_t last = 0;
 
     printf("Starting thread %" PRIkernel_pid "\n", thread_getpid());
 
@@ -98,6 +99,9 @@ void *worker_thread(void *arg)
         uint32_t now = xtimer_now();
         if (start == 0) {
             start = now;
+            last = start;
+            ++loop_counter;
+            continue;
         }
 
         uint32_t us, sec;
@@ -108,9 +112,12 @@ void *worker_thread(void *arg)
         hr = sec / 3600;
         if ((loop_counter % TEST_HZ) == 0) {
             uint32_t expected = start + loop_counter * TEST_INTERVAL;
-            int32_t diff = now - expected;
-            printf("now=%" PRIu32 ".%06" PRIu32 " (%u hours %u min), diff=%" PRId32 "\n",
-                sec, us, hr, min, diff);
+            int32_t drift = now - expected;
+            expected = last + TEST_HZ * TEST_INTERVAL;
+            int32_t jitter = now - expected;
+            printf("now=%" PRIu32 ".%06" PRIu32 " (%u hours %u min), drift=%" PRId32 ", jitter=%" PRId32 "\n",
+                sec, us, hr, min, drift, jitter);
+            last = now;
         }
         ++loop_counter;
     }

--- a/tests/xtimer_drift/main.c
+++ b/tests/xtimer_drift/main.c
@@ -124,7 +124,7 @@ int main(void)
     puts("Make note of the PC clock when starting this test, let run for a while, "
         "compare the printed time against the expected time from the PC clock.");
     puts("The difference is the RIOT timer drift, this is likely caused by either: "
-        "Inaccurate hardware timer, or bugs in the software (xtimer or periph/timer).");
+        "an inaccurate hardware timer, or bugs in the software (xtimer or periph/timer).");
     printf("This test will run a periodic timer every %lu microseconds (%lu Hz), ",
         (unsigned long)TEST_INTERVAL, (unsigned long)TEST_HZ);
     puts("The current time will be printed once per second, along with the "

--- a/tests/xtimer_shift_on_compare/main.c
+++ b/tests/xtimer_shift_on_compare/main.c
@@ -55,8 +55,8 @@ int main(void)
                 else {
                 }
 
-                a = _lltimer_now() | _high_cnt;
-                b = _lltimer_now() | _high_cnt;
+                a = _lltimer_now_ticks() | _high_cnt;
+                b = _lltimer_now_ticks() | _high_cnt;
             } while ((a>>shift) != (b>>shift));
 
             min[shift] = i < min[shift] ? i : min[shift];


### PR DESCRIPTION
~~Depends on #4183~~

Set XTIMER_HZ in periph_conf.h to specify the xtimer hardware timer
frequency.

The xtimer system uses the hardware timer's own tick representation
internally but a thin wrapper layer is added as a shim between xtimer
core and the public xtimer API which is based around microseconds as
the time unit.

Initially supports only 32768 Hz, and 1000000 Hz (and other power-of-two multiples of 15625), but can easily be expanded by adding a new case for XTIMER_HZ inside xtimer.h

Note: Using XTIMER_HZ = 1000000 will not add any overhead as the conversion shim will be simply an inlined straight passthrough.

**TODO**:
 - Solve how to handle time `t > 16383999997` for XTIMER_HZ == 32768
 - Add settings for cc2538 (XTIMER_HZ 16000000)
 - Test on multiple platforms and with non-standard XTIMER_HZ settings

Test subjects of particular interest:
   - atmega2560 (XTIMER_HZ == 250000)
   - cc2538 (XTIMER_HZ == 16000000)
   - mulle #4065 (XTIMER_HZ == 32768)