### PR TITLE
gnrc_netapi: recover from message send errors

### DIFF
--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
@@ -84,24 +84,11 @@ static void _event_cb(netdev2_t *dev, netdev2_event_t event, void *data)
 
 static void _pass_on_packet(gnrc_pktsnip_t *pkt)
 {
-    gnrc_netreg_entry_t *sendto;
-
-    /* find out, who to send the packet to */
-    sendto = gnrc_netreg_lookup(pkt->type, GNRC_NETREG_DEMUX_CTX_ALL);
-
     /* throw away packet if no one is interested */
-    if (sendto == NULL) {
+    if (!gnrc_netapi_dispatch_receive(pkt->type, GNRC_NETREG_DEMUX_CTX_ALL, pkt)) {
         DEBUG("gnrc_netdev2: unable to forward packet of type %i\n", pkt->type);
         gnrc_pktbuf_release(pkt);
         return;
-    }
-
-    /* send the packet to everyone interested in it's type */
-    gnrc_pktbuf_hold(pkt, gnrc_netreg_num(pkt->type, GNRC_NETREG_DEMUX_CTX_ALL) - 1);
-    while (sendto != NULL) {
-        DEBUG("gnrc_netdev2: sending pkt %p to PID %u\n", (void*)pkt, sendto->pid);
-        gnrc_netapi_receive(sendto->pid, pkt);
-        sendto = gnrc_netreg_getnext(sendto);
     }
 }
 

--- a/sys/net/gnrc/netapi/gnrc_netapi.c
+++ b/sys/net/gnrc/netapi/gnrc_netapi.c
@@ -77,7 +77,10 @@ int gnrc_netapi_dispatch(gnrc_nettype_t type, uint32_t demux_ctx,
         gnrc_pktbuf_hold(pkt, numof - 1);
 
         while (sendto) {
-            _snd_rcv(sendto->pid, cmd, pkt);
+            if (_snd_rcv(sendto->pid, cmd, pkt) < 1) {
+                /* unable to dispatch packet */
+                gnrc_pktbuf_release(pkt);
+            }
             sendto = gnrc_netreg_getnext(sendto);
         }
     }

--- a/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
+++ b/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
@@ -118,7 +118,10 @@ void gnrc_icmpv6_echo_req_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6_hdr,
     gnrc_pktbuf_hold(pkt, gnrc_netreg_num(GNRC_NETTYPE_IPV6, GNRC_NETREG_DEMUX_CTX_ALL) - 1);
 
     while (sendto != NULL) {
-        gnrc_netapi_send(sendto->pid, pkt);
+        if (gnrc_netapi_send(sendto->pid, pkt) < 1) {
+            DEBUG("icmpv6_echo: unable to send packet\n");
+            gnrc_pktbuf_release(pkt);
+        }
         sendto = gnrc_netreg_getnext(sendto);
     }
 }

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -317,7 +317,10 @@ void gnrc_ndp_nbr_adv_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
 #ifdef MODULE_GNRC_NDP_NODE
             gnrc_pktqueue_t *queued_pkt;
             while ((queued_pkt = gnrc_pktqueue_remove_head(&nc_entry->pkts)) != NULL) {
-                gnrc_netapi_send(gnrc_ipv6_pid, queued_pkt->pkt);
+                if (gnrc_netapi_send(gnrc_ipv6_pid, queued_pkt->pkt) < 1) {
+                    DEBUG("ndp: unable to send queued packet\n");
+                    gnrc_pktbuf_release(queued_pkt->pkt);
+                }
                 queued_pkt->pkt = NULL;
             }
 #endif

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -223,8 +223,9 @@ void gnrc_ndp_internal_send_nbr_adv(kernel_pid_t iface, ipv6_addr_t *tgt, ipv6_a
         /* nc_entry must be set so no need to check it */
         _send_delayed(&nc_entry->nbr_adv_timer, delay, hdr);
     }
-    else {
-        gnrc_netapi_send(gnrc_ipv6_pid, hdr);
+    else if (gnrc_netapi_send(gnrc_ipv6_pid, hdr) < 1) {
+        DEBUG("ndp internal: unable to send neighbor advertisement\n");
+        gnrc_pktbuf_release(hdr);
     }
 }
 
@@ -301,7 +302,10 @@ void gnrc_ndp_internal_send_nbr_sol(kernel_pid_t iface, ipv6_addr_t *src, ipv6_a
         gnrc_pktbuf_release(pkt);
         return;
     }
-    gnrc_netapi_send(gnrc_ipv6_pid, hdr);
+    else if (gnrc_netapi_send(gnrc_ipv6_pid, hdr) < 1) {
+        DEBUG("ndp internal: unable to send neighbor solicitation\n");
+        gnrc_pktbuf_release(hdr);
+    }
 }
 
 void gnrc_ndp_internal_send_rtr_sol(kernel_pid_t iface, ipv6_addr_t *dst)
@@ -342,7 +346,10 @@ void gnrc_ndp_internal_send_rtr_sol(kernel_pid_t iface, ipv6_addr_t *dst)
         gnrc_pktbuf_release(pkt);
         return;
     }
-    gnrc_netapi_send(gnrc_ipv6_pid, hdr);
+    else if (gnrc_netapi_send(gnrc_ipv6_pid, hdr) < 1) {
+        DEBUG("ndp internal: unable to send router solicitation\n");
+        gnrc_pktbuf_release(hdr);
+    }
 }
 
 #if (defined(MODULE_GNRC_NDP_ROUTER) || defined(MODULE_GNRC_SIXLOWPAN_ND_ROUTER))
@@ -575,7 +582,10 @@ void gnrc_ndp_internal_send_rtr_adv(kernel_pid_t iface, ipv6_addr_t *src, ipv6_a
         gnrc_pktbuf_release(pkt);
         return;
     }
-    gnrc_netapi_send(gnrc_ipv6_pid, hdr);
+    else if (gnrc_netapi_send(gnrc_ipv6_pid, hdr) < 1) {
+        DEBUG("ndp internal: unable to send router advertisement\n");
+        gnrc_pktbuf_release(hdr);
+    }
 }
 #endif
 

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -126,7 +126,10 @@ static uint16_t _send_1st_fragment(gnrc_sixlowpan_netif_t *iface, gnrc_pktsnip_t
     DEBUG("6lo frag: send first fragment (datagram size: %u, "
           "datagram tag: %" PRIu16 ", fragment size: %" PRIu16 ")\n",
           (unsigned int)datagram_size, _tag, local_offset);
-    gnrc_netapi_send(iface->pid, frag);
+    if (gnrc_netapi_send(iface->pid, frag) < 1) {
+        DEBUG("6lo frag: unable to send first fragment\n");
+        gnrc_pktbuf_release(frag);
+    }
 
     return local_offset;
 }
@@ -201,7 +204,10 @@ static uint16_t _send_nth_fragment(gnrc_sixlowpan_netif_t *iface, gnrc_pktsnip_t
           "fragment size: %" PRIu16 ")\n",
           (unsigned int)datagram_size, _tag, hdr->offset, hdr->offset << 3,
           local_offset);
-    gnrc_netapi_send(iface->pid, frag);
+    if (gnrc_netapi_send(iface->pid, frag) < 1) {
+        DEBUG("6lo frag: unable to send subsequent fragment\n");
+        gnrc_pktbuf_release(frag);
+    }
 
     return local_offset;
 }

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -262,7 +262,10 @@ static void _send(gnrc_pktsnip_t *pkt)
     if (gnrc_pkt_len(pkt2->next) <= iface->max_frag_size) {
         DEBUG("6lo: Send SND command for %p to %" PRIu16 "\n",
               (void *)pkt2, hdr->if_pid);
-        gnrc_netapi_send(hdr->if_pid, pkt2);
+        if (gnrc_netapi_send(hdr->if_pid, pkt2) < 1) {
+            DEBUG("6lo: unable to send %p over %" PRIu16 "\n", (void *)pkt, hdr->if_pid);
+            gnrc_pktbuf_release(pkt2);
+        }
 
         return;
     }

--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -234,7 +234,11 @@ int _icmpv6_ping(int argc, char **argv)
         }
 
         vtimer_now(&start);
-        gnrc_netapi_send(ipv6_entry->pid, pkt);
+        if (gnrc_netapi_send(ipv6_entry->pid, pkt) < 1) {
+            puts("error: unable to send ICMPv6 echo request\n");
+            gnrc_pktbuf_release(pkt);
+            continue;
+        }
 
         if (vtimer_msg_receive_timeout(&msg, timeout) >= 0) {
             switch (msg.type) {

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -834,7 +834,11 @@ int _netif_send(int argc, char **argv)
     gnrc_netif_hdr_set_dst_addr(nethdr, addr, addr_len);
     nethdr->flags = flags;
     /* and send it */
-    gnrc_netapi_send(dev, pkt);
+    if (gnrc_netapi_send(dev, pkt) < 1) {
+        puts("error: unable to send\n");
+        gnrc_pktbuf_release(pkt);
+        return 1;
+    }
 
     return 0;
 }


### PR DESCRIPTION
Nobody ever checked, if a message was actually send in GNRC. This led to some memory leaks in the packet buffer. E.g. test with

```
ping6 ff02::1
```

and check the packet buffer afterwards.

(This is the release version of #3991)