### PR TITLE
at86rf2xx: cancel receiving when preparing for TX

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -215,9 +215,13 @@ void at86rf2xx_tx_prepare(at86rf2xx_t *dev)
     do {
         state = at86rf2xx_get_status(dev);
     }
-    while (state == AT86RF2XX_STATE_BUSY_RX_AACK ||
-           state == AT86RF2XX_STATE_BUSY_TX_ARET);
-    if (state != AT86RF2XX_STATE_TX_ARET_ON) {
+    while (state == AT86RF2XX_STATE_BUSY_TX_ARET);
+
+    /* if receiving cancel */
+    if(state == AT86RF2XX_STATE_BUSY_RX_AACK) {
+        at86rf2xx_force_trx_off(dev);
+        dev->idle_state = AT86RF2XX_STATE_RX_AACK_ON;
+    } else if (state != AT86RF2XX_STATE_TX_ARET_ON) {
         dev->idle_state = state;
     }
     at86rf2xx_set_state(dev, AT86RF2XX_STATE_TX_ARET_ON);

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -401,12 +401,6 @@ static inline void _set_state(at86rf2xx_t *dev, uint8_t state)
     while (at86rf2xx_get_status(dev) != state);
 }
 
-static inline void _force_trx_off(at86rf2xx_t *dev)
-{
-    at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_STATE, AT86RF2XX_TRX_STATE__FORCE_TRX_OFF);
-    while (at86rf2xx_get_status(dev) != AT86RF2XX_STATE_TRX_OFF);
-}
-
 void at86rf2xx_set_state(at86rf2xx_t *dev, uint8_t state)
 {
     uint8_t old_state = at86rf2xx_get_status(dev);
@@ -438,7 +432,7 @@ void at86rf2xx_set_state(at86rf2xx_t *dev, uint8_t state)
 
     if (state == AT86RF2XX_STATE_SLEEP) {
         /* First go to TRX_OFF */
-        _force_trx_off(dev);
+        at86rf2xx_force_trx_off(dev);
         /* Go to SLEEP mode from TRX_OFF */
         gpio_set(dev->sleep_pin);
     } else {
@@ -458,5 +452,5 @@ void at86rf2xx_reset_state_machine(at86rf2xx_t *dev)
         old_state = at86rf2xx_get_status(dev);
     } while (old_state == AT86RF2XX_STATE_IN_PROGRESS);
 
-    _force_trx_off(dev);
+    at86rf2xx_force_trx_off(dev);
 }

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -104,3 +104,11 @@ uint8_t at86rf2xx_get_status(const at86rf2xx_t *dev)
     return (at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS)
             & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS);
 }
+
+void at86rf2xx_force_trx_off(const at86rf2xx_t *dev)
+{
+    at86rf2xx_reg_write(dev,
+                        AT86RF2XX_REG__TRX_STATE,
+                        AT86RF2XX_TRX_STATE__FORCE_TRX_OFF);
+    while (at86rf2xx_get_status(dev) != AT86RF2XX_STATE_TRX_OFF);
+}

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -91,6 +91,13 @@ void at86rf2xx_fb_read(const at86rf2xx_t *dev,
                        uint8_t *data, const size_t len);
 
 /**
+ * @brief   Cancel ongoing transactions and switch to TRX_OFF state
+ *
+ * @param[in] dev       device to manipulate
+ */
+void at86rf2xx_force_trx_off(const at86rf2xx_t *dev);
+
+/**
  * @brief   Convenience function for reading the status of the given device
  *
  * @param[in] dev       device to read the status from


### PR DESCRIPTION
When preparing the device for TX, i.e. switching to the right state, the driver busy waits until an RX operation is finished. According to the usage of this internal function, the frame buffer will be overwritten with the frame to send anyway, so waiting only wastes time.

Additionally when canceling an ongoing RX operation, sending an ACK is also prevented so that the sender won't assume a successful transmission.