### PR TITLE
periph/rtt: add macros for ticks to time conversion

### DIFF
--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -39,31 +39,59 @@ extern "C" {
 
 /**
  * @brief       Convert microseconds to rtt ticks
- * @param[in]   us number of microseconds
- * @return      rtt ticks
+ * @param[in]   us      number of microseconds
+ * @return              rtt ticks
  */
 #define RTT_US_TO_TICKS(us)     ((uint32_t)((uint64_t)(us) * RTT_FREQUENCY / 1000000UL))
 
 /**
  * @brief       Convert milliseconds to rtt ticks
- * @param[in]   ms number of milliseconds
- * @return      rtt ticks
+ * @param[in]   ms      number of milliseconds
+ * @return              rtt ticks
  */
 #define RTT_MS_TO_TICKS(ms)     ( RTT_US_TO_TICKS((ms) * 1000) )
 
 /**
  * @brief       Convert seconds to rtt ticks
- * @param[in]   sec number of seconds
- * @return      rtt ticks
+ * @param[in]   sec     number of seconds
+ * @return              rtt ticks
  */
 #define RTT_SEC_TO_TICKS(sec)   ( RTT_MS_TO_TICKS((sec) * 1000) )
 
 /**
  * @brief       Convert minutes to rtt ticks
- * @param[in]   min number of minutes
- * @return      rtt ticks
+ * @param[in]   min     number of minutes
+ * @return              rtt ticks
  */
 #define RTT_MIN_TO_TICKS(min)   ( RTT_SEC_TO_TICKS((min) * 60) )
+
+/**
+ * @brief       Convert rtt ticks to microseconds
+ * @param[in]   ticks   rtt ticks
+ * @return              number of microseconds
+ */
+#define RTT_TICKS_TO_US(ticks)  ((uint32_t)((uint64_t)(ticks) * 1000000UL / RTT_FREQUENCY))
+
+/**
+ * @brief       Convert rtt ticks to milliseconds
+ * @param[in]   ticks   rtt ticks
+ * @return              number of milliseconds
+ */
+#define RTT_TICKS_TO_MS(ticks)  (RTT_TICKS_TO_US(ticks) / 1000)
+
+/**
+ * @brief       Convert rtt ticks to seconds
+ * @param[in]   ticks   rtt ticks
+ * @return              number of seconds
+ */
+#define RTT_TICKS_TO_SEC(ticks)  (RTT_TICKS_TO_MS(ticks) / 1000)
+
+/**
+ * @brief       Convert rtt ticks to minutes
+ * @param[in]   ticks   rtt ticks
+ * @return              number of minutes
+ */
+#define RTT_TICKS_TO_MIN(ticks)  (RTT_TICKS_TO_SEC(ticks) / 60)
 
 /**
  * @brief Signature for the alarm callback


### PR DESCRIPTION
Already added macros for the other conversion direction in #3174. Now the same for ticks to time.

Piggy backed some nicer formatting of the old PR, but I'm not really sure if it fits coding conventions.