### PR TITLE
sys/xtimer: Avoid race incrementing multiple periods in _timer_callback

### DIFF
--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -499,7 +499,7 @@ overflow:
             /* check if the end of this period is very soon */
             if (_mask(now + XTIMER_ISR_BACKOFF) < now) {
                 /* spin until next period, then advance */
-                while (_xtimer_now() > now);
+                while (_xtimer_now() >= now);
                 _next_period();
                 reference = 0;
                 goto overflow;


### PR DESCRIPTION
2015.09 release version of #3998 

On a fast CPU with a slow timer (e.g. XTIMER_SHIFT > 0) it is possible
that now == _xtimer_now() when spinning for the overflow. In the extreme
case When this happens _next_period() will be called more than once
until the timer overflows for real.

Fault observed in real life when running on a 32.768 kHz timer on a
~96 MHz clocked mulle (Kinetis K60, Cortex-M4). _next_period() was
called 9 times during the same ISR call before the 32 kHz timer
overflowed.