### PR TITLE
cpu/cortexm_common: add used attributes for LTO

### DIFF
--- a/cpu/cortexm_common/irq_arch.c
+++ b/cpu/cortexm_common/irq_arch.c
@@ -35,7 +35,7 @@ unsigned int irq_arch_disable(void)
 /**
  * @brief Enable all maskable interrupts
  */
-unsigned int irq_arch_enable(void)
+__attribute__((used)) unsigned int irq_arch_enable(void)
 {
     __enable_irq();
     return __get_PRIMASK();

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -179,7 +179,7 @@ void hard_fault_default(void)
 #define CPU_HAS_EXTENDED_FAULT_REGISTERS 1
 #endif
 
-void hard_fault_handler(uint32_t* sp, uint32_t corrupted, uint32_t exc_return, uint32_t* r4_to_r11_stack)
+__attribute__((used)) void hard_fault_handler(uint32_t* sp, uint32_t corrupted, uint32_t exc_return, uint32_t* r4_to_r11_stack)
 {
 
     /* Sanity check stack pointer and give additional feedback about hard fault */


### PR DESCRIPTION
When compiling with link time optimization (LTO=yes) linking currently fails because `irq_arch_enable()` and `hard_fault_handler(..)` are called from asm blocks only and will be dropped. This adds `__attribute__((used))` to both functions.

