### PR TITLE
shell: fix multicast pings

### DIFF
--- a/examples/gnrc_border_router/main.c
+++ b/examples/gnrc_border_router/main.c
@@ -21,9 +21,16 @@
 #include <stdio.h>
 
 #include "shell.h"
+#include "msg.h"
+
+#define MAIN_QUEUE_SIZE     (8)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
 int main(void)
 {
+    /* we need a message queue for the thread running the shell in order to
+     * receive potentially fast incoming networking packets */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
     puts("RIOT border router example application");
 
     /* start shell */

--- a/examples/gnrc_networking/main.c
+++ b/examples/gnrc_networking/main.c
@@ -21,6 +21,10 @@
 #include <stdio.h>
 
 #include "shell.h"
+#include "msg.h"
+
+#define MAIN_QUEUE_SIZE     (8)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
 extern int udp_cmd(int argc, char **argv);
 
@@ -31,6 +35,9 @@ static const shell_command_t shell_commands[] = {
 
 int main(void)
 {
+    /* we need a message queue for the thread running the shell in order to
+     * receive potentially fast incoming networking packets */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
     puts("RIOT network stack example application");
 
     /* start shell */


### PR DESCRIPTION
This PR introduces two things in order to fix pinging of multicast addresses (or more general: to be able to handle additional ICMPv6 echo replies):
* adds a message queue to the main thread for the gnrc_networking example
* checks for pending additional packets delivered to the ping shell handler after unregistering