### PR TITLE
rpl: use GNRC_IPV6_FIB_TABLE_SIZE to query for fib entries

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -625,8 +625,8 @@ void _dao_fill_target(gnrc_rpl_opt_target_t *target, ipv6_addr_t *addr)
 
 void gnrc_rpl_send_DAO(gnrc_rpl_dodag_t *dodag, ipv6_addr_t *destination, uint8_t lifetime)
 {
-    size_t dst_size = GNRC_RPL_PARENTS_NUMOF;
-    fib_destination_set_entry_t fib_dest_set[GNRC_RPL_PARENTS_NUMOF];
+    size_t dst_size = GNRC_IPV6_FIB_TABLE_SIZE;
+    fib_destination_set_entry_t fib_dest_set[GNRC_IPV6_FIB_TABLE_SIZE];
 
     if (dodag == NULL) {
         DEBUG("RPL: Error - trying to send DAO without being part of a dodag.\n");


### PR DESCRIPTION
When a DODAG has long routes (>= 4-5 hops) then fib entries are truncated for nodes near to the root (including the root).

I didn't look much into it, but I guess that the `fib_get_destination_set()` function might return truncated entries when the buffer is full. (@BytesGalore ?)

This PR just increases the buffer size so that there is no truncation anymore. Since this is not really a fix for the underlyig problem, it is nevertheless important, because the former buffer size was not really sensible.