### PR TITLE
gnrc netreg: make message queue mandatory

### DIFF
--- a/sys/include/net/gnrc/netreg.h
+++ b/sys/include/net/gnrc/netreg.h
@@ -79,6 +79,8 @@ void gnrc_netreg_init(void);
  * @warning Call gnrc_netreg_unregister() *before* you leave the context you
  *          allocated @p entry in. Otherwise it might get overwritten.
  *
+ * @pre The calling thread must provide a message queue.
+ *
  * @return  0 on success
  * @return  -EINVAL if @p type was < GNRC_NETTYPE_UNDEF or >= GNRC_NETTYPE_NUMOF
  */

--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -37,6 +37,9 @@ void gnrc_netreg_init(void)
 
 int gnrc_netreg_register(gnrc_nettype_t type, gnrc_netreg_entry_t *entry)
 {
+    /* only threads with a message queue are allowed to register at gnrc */
+    assert(sched_active_thread->msg_array);
+
     if (_INVALID_TYPE(type)) {
         return -EINVAL;
     }


### PR DESCRIPTION
Any thread that registers for gnrc events (i.e. incoming packets) must provide a message queue.

Depends on #4005. (Otherwise examples will be broken.)