### PR TITLE
kernel_init: Remove unnecessary code

### DIFF
--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -69,16 +69,8 @@ static void *idle_thread(void *arg)
 {
     (void) arg;
 
-    while (1) {
-        if (lpm_prevent_sleep) {
-            lpm_set(LPM_IDLE);
-        }
-        else {
-            lpm_set(LPM_IDLE);
-            /* lpm_set(LPM_SLEEP); */
-            /* lpm_set(LPM_POWERDOWN); */
-        }
-    }
+    while (1)
+        lpm_set(LPM_IDLE);
 
     return NULL;
 }


### PR DESCRIPTION
The current idle_thread function calls lpm_set(LPM_IDLE) in both
if and else loop, removed unnecessary code