### PR TITLE
pktbuf: release correct snip in error case

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -634,7 +634,7 @@ static void _send(gnrc_pktsnip_t *pkt, bool prep_hdr)
 
         if (gnrc_netapi_receive(gnrc_ipv6_pid, rcv_pkt) < 1) {
             DEBUG("ipv6: unable to deliver packet\n");
-            gnrc_pktbuf_release(pkt);
+            gnrc_pktbuf_release(rcv_pkt);
         }
     }
     else {

--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -395,7 +395,7 @@ static void *_pktbuf_alloc(size_t size)
 {
     _unused_t *prev = NULL, *ptr = _first_unused;
     size = (size < sizeof(_unused_t)) ? _align(sizeof(_unused_t)) : _align(size);
-    while (ptr && size > ptr->size) {
+    while (ptr && (size > ptr->size)) {
         prev = ptr;
         ptr = ptr->next;
     }


### PR DESCRIPTION
In the loopback case, the wrong snip was released in an error case.