### PR TITLE
shell: ifconfig: fixes

### DIFF
--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -97,7 +97,7 @@ static void _mtu_usage(char *cmd_name)
 
 static void _flag_usage(char *cmd_name)
 {
-    printf("usage: %s <if_id> [-]{promisc|autoack|csma|autocca|preload|6lo|iphc}\n", cmd_name);
+    printf("usage: %s <if_id> [-]{promisc|autoack|csma|autocca|preload|iphc}\n", cmd_name);
 }
 
 static void _add_usage(char *cmd_name)
@@ -588,37 +588,6 @@ static int _netif_flag(char *cmd, kernel_pid_t dev, char *flag)
     }
     else if (strcmp(flag, "autocca") == 0) {
         return _netif_set_flag(dev, NETOPT_AUTOCCA, set);
-    }
-    else if (strcmp(flag, "6lo") == 0) {
-#ifdef MODULE_GNRC_IPV6_NETIF
-        gnrc_ipv6_netif_t *entry = gnrc_ipv6_netif_get(dev);
-
-        if (entry == NULL) {
-            puts("error: unable to (un)set 6LoWPAN support");
-            return 1;
-        }
-
-        mutex_lock(&entry->mutex);
-
-        if (set) {
-            entry->flags |= GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN;
-            printf("success: set 6LoWPAN support on interface %" PRIkernel_pid
-                   "\n", dev);
-        }
-        else {
-            entry->flags &= ~GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN;
-            printf("success: unset 6LoWPAN support on interface %" PRIkernel_pid
-                   "\n", dev);
-        }
-
-        mutex_unlock(&entry->mutex);
-
-        return 0;
-#else
-        puts("error: unable to (un)set 6LoWPAN support");
-
-        return 1;
-#endif
     }
     else if (strcmp(flag, "iphc") == 0) {
 #if defined(MODULE_GNRC_SIXLOWPAN_NETIF) && defined(MODULE_GNRC_SIXLOWPAN_IPHC)

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -649,7 +649,6 @@ static int _netif_add(char *cmd_name, kernel_pid_t dev, int argc, char **argv)
     } type = _UNICAST;
     char *addr_str = argv[0];
     ipv6_addr_t addr;
-    ipv6_addr_t *assigned_address;
     uint8_t prefix_len;
 
     if (argc > 1) {
@@ -683,11 +682,9 @@ static int _netif_add(char *cmd_name, kernel_pid_t dev, int argc, char **argv)
         return 1;
     }
 
-    if ((assigned_address = gnrc_ipv6_netif_add_addr(dev, &addr, prefix_len,
-                                                    (type == _ANYCAST) ?
-                                                    GNRC_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST :
-                                                    GNRC_IPV6_NETIF_ADDR_FLAGS_UNICAST))
-                           == NULL) {
+    if (gnrc_ipv6_netif_add_addr(dev, &addr, prefix_len, (type == _ANYCAST) ?
+                                 GNRC_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST :
+                                 GNRC_IPV6_NETIF_ADDR_FLAGS_UNICAST) == NULL) {
         printf("error: unable to add IPv6 address\n");
         return 1;
     }


### PR DESCRIPTION
Two fixes to `ifconfig`:

* make 6lo flag read-only (fixes #4027)
* remove unused variable