### PR TITLE
shell ping: improved duplicate dropping

### DIFF
--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -272,6 +272,14 @@ int _icmpv6_ping(int argc, char **argv)
             puts("ping timeout");
         }
 
+        while(msg_try_receive(&msg) > 0) {
+            if (msg.type == GNRC_NETAPI_MSG_TYPE_RCV) {
+                printf("dropping additional response packet (probably caused by duplicates)\n");
+                gnrc_pktsnip_t *pkt = (gnrc_pktsnip_t *)msg.content.ptr;
+                gnrc_pktbuf_release(pkt);
+            }
+        }
+
         if (remaining > 0) {
             vtimer_sleep(delay);
         }

--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -213,7 +213,7 @@ int _icmpv6_ping(int argc, char **argv)
 
     while ((remaining--) > 0) {
         gnrc_pktsnip_t *pkt;
-        timex_t start, stop, timeout = { 5, 0 };
+        timex_t start, stop, timeout = { 1, 0 };
 
         pkt = gnrc_icmpv6_echo_req_build(id, ++max_seq_expected, NULL,
                                          payload_len);


### PR DESCRIPTION
With this PR at least the memory leaks on sender side seems to disappear.