### PR TITLE
periph/timer: Change timer_init API to support arbitrary (integer) frequencies

### DIFF
--- a/boards/f4vi1/include/periph_conf.h
+++ b/boards/f4vi1/include/periph_conf.h
@@ -62,7 +62,7 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV         TIM2
 #define TIMER_0_CHANNELS    4
-#define TIMER_0_PRESCALER   (83U)
+#define TIMER_0_FREQ        (CLOCK_CORECLOCK / 2)
 #define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_CLKEN()     (RCC->APB1ENR |= RCC_APB1ENR_TIM2EN)
 #define TIMER_0_ISR         isr_tim2
@@ -71,7 +71,7 @@ extern "C" {
 /* Timer 1 configuration */
 #define TIMER_1_DEV         TIM5
 #define TIMER_1_CHANNELS    4
-#define TIMER_1_PRESCALER   (83U)
+#define TIMER_1_FREQ        (CLOCK_CORECLOCK / 2)
 #define TIMER_1_MAX_VALUE   (0xffffffff)
 #define TIMER_1_CLKEN()     (RCC->APB1ENR |= RCC_APB1ENR_TIM5EN)
 #define TIMER_1_ISR         isr_tim5

--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -53,7 +53,7 @@ extern "C" {
 #define TIMER_0_DEV_0       TIM2
 #define TIMER_0_DEV_1       TIM3
 #define TIMER_0_CHANNELS    4
-#define TIMER_0_PRESCALER   (72U)
+#define TIMER_0_FREQ        (CLOCK_CORECLOCK)
 #define TIMER_0_MAX_VALUE   (0xffff)
 #define TIMER_0_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM2EN | RCC_APB1ENR_TIM3EN))
 #define TIMER_0_ISR_0       isr_tim2
@@ -67,7 +67,7 @@ extern "C" {
 #define TIMER_1_DEV_0       TIM4
 #define TIMER_1_DEV_1       TIM5
 #define TIMER_1_CHANNELS    4
-#define TIMER_1_PRESCALER   (72U)
+#define TIMER_1_FREQ        (CLOCK_CORECLOCK)
 #define TIMER_1_MAX_VALUE   (0xffff)
 #define TIMER_1_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM4EN | RCC_APB1ENR_TIM5EN))
 #define TIMER_1_ISR_0       isr_tim4

--- a/boards/iotlab-m3/include/periph_conf.h
+++ b/boards/iotlab-m3/include/periph_conf.h
@@ -54,7 +54,7 @@ extern "C" {
 #define TIMER_0_DEV_0       TIM2
 #define TIMER_0_DEV_1       TIM3
 #define TIMER_0_CHANNELS    4
-#define TIMER_0_PRESCALER   (72U)
+#define TIMER_0_FREQ        (CLOCK_CORECLOCK)
 #define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM2EN | RCC_APB1ENR_TIM3EN))
 #define TIMER_0_ISR_0       isr_tim2
@@ -68,7 +68,7 @@ extern "C" {
 #define TIMER_1_DEV_0       TIM4
 #define TIMER_1_DEV_1       TIM5
 #define TIMER_1_CHANNELS    4
-#define TIMER_1_PRESCALER   (72U)
+#define TIMER_1_FREQ        (CLOCK_CORECLOCK)
 #define TIMER_1_MAX_VALUE   (0xffffffff)
 #define TIMER_1_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM4EN | RCC_APB1ENR_TIM5EN))
 #define TIMER_1_ISR_0       isr_tim4

--- a/boards/mbed_lpc1768/include/periph_conf.h
+++ b/boards/mbed_lpc1768/include/periph_conf.h
@@ -34,7 +34,7 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV         LPC_TIM0
 #define TIMER_0_CHANNELS    4
-#define TIMER_0_PRESCALER   (95U)
+#define TIMER_0_FREQ        (96000000ul)
 #define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_CLKEN()     (LPC_SC->PCONP |= (1 << 1))
 #define TIMER_0_CLKDIS()    (LPC_SC->PCONP &= ~(1 << 1))

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -61,7 +61,7 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV         TIM2
 #define TIMER_0_CHANNELS    4
-#define TIMER_0_PRESCALER   (83U)
+#define TIMER_0_FREQ        (84000000U)
 #define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_CLKEN()     (RCC->APB1ENR |= RCC_APB1ENR_TIM2EN)
 #define TIMER_0_ISR         isr_tim2
@@ -70,7 +70,7 @@ extern "C" {
 /* Timer 1 configuration */
 #define TIMER_1_DEV         TIM5
 #define TIMER_1_CHANNELS    4
-#define TIMER_1_PRESCALER   (83U)
+#define TIMER_1_FREQ        (84000000U)
 #define TIMER_1_MAX_VALUE   (0xffffffff)
 #define TIMER_1_CLKEN()     (RCC->APB1ENR |= RCC_APB1ENR_TIM5EN)
 #define TIMER_1_ISR         isr_tim5

--- a/boards/nucleo-f091/include/periph_conf.h
+++ b/boards/nucleo-f091/include/periph_conf.h
@@ -45,7 +45,7 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV         TIM2
 #define TIMER_0_CHANNELS    4
-#define TIMER_0_PRESCALER   (47U)
+#define TIMER_0_FREQ        (CLOCK_CORECLOCK)
 #define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_CLKEN()     (RCC->APB1ENR |= RCC_APB1ENR_TIM2EN)
 #define TIMER_0_IRQ_CHAN    TIM2_IRQn

--- a/boards/nucleo-f103/include/periph_conf.h
+++ b/boards/nucleo-f103/include/periph_conf.h
@@ -54,7 +54,7 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV_0       TIM2
 #define TIMER_0_DEV_1       TIM3
-#define TIMER_0_PRESCALER   (CLOCK_CORECLOCK / 1000000U)
+#define TIMER_0_FREQ        (CLOCK_CORECLOCK)
 #define TIMER_0_MAX_VALUE   (0xffff)
 #define TIMER_0_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM2EN | RCC_APB1ENR_TIM3EN))
 #define TIMER_0_ISR_0       isr_tim2
@@ -67,7 +67,7 @@ extern "C" {
 /* Timer 1 configuration */
 #define TIMER_1_DEV_0       TIM4
 #define TIMER_1_DEV_1       TIM5
-#define TIMER_1_PRESCALER   (36000U)
+#define TIMER_1_FREQ        (CLOCK_CORECLOCK)
 #define TIMER_1_MAX_VALUE   (0xffff)
 #define TIMER_1_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM4EN | RCC_APB1ENR_TIM5EN))
 #define TIMER_1_ISR_0       isr_tim4

--- a/boards/nucleo-f303/include/periph_conf.h
+++ b/boards/nucleo-f303/include/periph_conf.h
@@ -51,7 +51,7 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV         TIM2
 #define TIMER_0_CHANNELS    4
-#define TIMER_0_PRESCALER   (71U)
+#define TIMER_0_FREQ        (CLOCK_CORECLOCK)
 #define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_CLKEN()     (RCC->APB1ENR |= RCC_APB1ENR_TIM2EN)
 #define TIMER_0_IRQ_CHAN    TIM2_IRQn

--- a/boards/nucleo-f334/include/periph_conf.h
+++ b/boards/nucleo-f334/include/periph_conf.h
@@ -50,7 +50,7 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV         TIM2
 #define TIMER_0_CHANNELS    4
-#define TIMER_0_PRESCALER   (71U)
+#define TIMER_0_FREQ        (CLOCK_CORECLOCK)
 #define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_CLKEN()     (RCC->APB1ENR |= RCC_APB1ENR_TIM2EN)
 #define TIMER_0_ISR         isr_tim2

--- a/boards/nucleo-f401/include/periph_conf.h
+++ b/boards/nucleo-f401/include/periph_conf.h
@@ -60,7 +60,7 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV         TIM2
 #define TIMER_0_CHANNELS    4
-#define TIMER_0_PRESCALER   (83U)
+#define TIMER_0_FREQ        (CLOCK_CORECLOCK)
 #define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_CLKEN()     (RCC->APB1ENR |= RCC_APB1ENR_TIM2EN)
 #define TIMER_0_ISR         isr_tim2
@@ -69,7 +69,7 @@ extern "C" {
 /* Timer 1 configuration */
 #define TIMER_1_DEV         TIM5
 #define TIMER_1_CHANNELS    4
-#define TIMER_1_PRESCALER   (83U)
+#define TIMER_1_FREQ        (CLOCK_CORECLOCK)
 #define TIMER_1_MAX_VALUE   (0xffffffff)
 #define TIMER_1_CLKEN()     (RCC->APB1ENR |= RCC_APB1ENR_TIM5EN)
 #define TIMER_1_ISR         isr_tim5

--- a/boards/spark-core/include/periph_conf.h
+++ b/boards/spark-core/include/periph_conf.h
@@ -52,7 +52,7 @@
 #define TIMER_0_DEV_0       TIM2
 #define TIMER_0_DEV_1       TIM3
 #define TIMER_0_CHANNELS    4
-#define TIMER_0_PRESCALER   (72U)
+#define TIMER_0_FREQ        (CLOCK_CORECLOCK)
 #define TIMER_0_MAX_VALUE   (0xffff)
 #define TIMER_0_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM2EN | RCC_APB1ENR_TIM3EN))
 #define TIMER_0_ISR_0       isr_tim2

--- a/boards/stm32f0discovery/include/periph_conf.h
+++ b/boards/stm32f0discovery/include/periph_conf.h
@@ -45,7 +45,7 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV         TIM2
 #define TIMER_0_CHANNELS    4
-#define TIMER_0_PRESCALER   (47U)
+#define TIMER_0_FREQ        (CLOCK_CORECLOCK)
 #define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_CLKEN()     (RCC->APB1ENR |= RCC_APB1ENR_TIM2EN)
 #define TIMER_0_ISR         isr_tim2

--- a/boards/stm32f3discovery/include/periph_conf.h
+++ b/boards/stm32f3discovery/include/periph_conf.h
@@ -49,7 +49,7 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV         TIM2
 #define TIMER_0_CHANNELS    4
-#define TIMER_0_PRESCALER   (71U)
+#define TIMER_0_FREQ        (CLOCK_CORECLOCK)
 #define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_CLKEN()     (RCC->APB1ENR |= RCC_APB1ENR_TIM2EN)
 #define TIMER_0_ISR         isr_tim2

--- a/boards/stm32f4discovery/include/board.h
+++ b/boards/stm32f4discovery/include/board.h
@@ -35,7 +35,7 @@ extern "C" {
 #define XTIMER              TIMER_0
 #define XTIMER_CHAN         (0)
 #define XTIMER_OVERHEAD     (6)
-#define XTIMER_BACKOFF      (5)
+#define XTIMER_BACKOFF      (10)
 /** @} */
 
 /**

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -61,7 +61,7 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV         TIM2
 #define TIMER_0_CHANNELS    4
-#define TIMER_0_PRESCALER   (83U)
+#define TIMER_0_FREQ        (CLOCK_CORECLOCK / 2)
 #define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_CLKEN()     (RCC->APB1ENR |= RCC_APB1ENR_TIM2EN)
 #define TIMER_0_ISR         isr_tim2
@@ -70,7 +70,7 @@ extern "C" {
 /* Timer 1 configuration */
 #define TIMER_1_DEV         TIM5
 #define TIMER_1_CHANNELS    4
-#define TIMER_1_PRESCALER   (83U)
+#define TIMER_1_FREQ        (CLOCK_CORECLOCK / 2)
 #define TIMER_1_MAX_VALUE   (0xffffffff)
 #define TIMER_1_CLKEN()     (RCC->APB1ENR |= RCC_APB1ENR_TIM5EN)
 #define TIMER_1_ISR         isr_tim5

--- a/boards/weio/include/periph_conf.h
+++ b/boards/weio/include/periph_conf.h
@@ -42,7 +42,7 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV         LPC_CT32B1
 #define TIMER_0_CHANNELS    4
-#define TIMER_0_PRESCALER   (48U)
+#define TIMER_0_FREQ        (48000000ul)
 #define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_CLKEN()     (LPC_SYSCON->SYSAHBCLKCTRL |= (1 << 10))
 #define TIMER_0_CLKDIS()    (LPC_SYSCON->SYSAHBCLKCTRL &= ~(1 << 10))

--- a/cpu/atmega2560/periph/timer.c
+++ b/cpu/atmega2560/periph/timer.c
@@ -46,10 +46,11 @@ timer_conf_t config[TIMER_NUMOF];
  * @brief Setup the given timer
  *
  */
-int timer_init(tim_t dev, unsigned int us_per_ticks, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
-    /* reject impossible us_per_ticks values */
-    if ((us_per_ticks != 4)) {
+    /* reject impossible freq values
+     * todo: Add support for 2 MHz and 16 MHz */
+    if ((freq != 250000ul)) {
         return -1;
     }
 
@@ -279,7 +280,7 @@ int timer_clear(tim_t dev, int channel)
 unsigned int timer_read(tim_t dev)
 {
     uint16_t a;
-    uint32_t b;
+    uint16_t b;
     /*
      * Disabling interrupts globally because read from 16 Bit register can
      * otherwise be messed up
@@ -317,6 +318,7 @@ unsigned int timer_read(tim_t dev)
 
         case TIMER_UNDEFINED:
         default:
+            (void)b;
             a = 0;
     }
 

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -44,7 +44,7 @@ timer_conf_t config[TIMER_NUMOF];
  * @brief Setup the given timer
  *
  */
-int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     cc2538_gptimer_t *gptimer;
     unsigned int gptimer_num;
@@ -93,7 +93,7 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
     gptimer->cc2538_gptimer_tamr.TAMRbits.TACDIR = 1; /**< Count up */
 
     /* Set the prescale register for the desired frequency: */
-    gptimer->TAPR = RCOSC16M_FREQ / (ticks_per_us * USEC_PER_SEC) - 1;
+    gptimer->TAPR = (RCOSC16M_FREQ / freq) - 1;
 
     /* Enable interrupts for given timer: */
     timer_irq_enable(dev);

--- a/cpu/cc430/periph/timer.c
+++ b/cpu/cc430/periph/timer.c
@@ -35,14 +35,14 @@
 static void (*isr_cb)(int chan);
 
 
-int timer_init(tim_t dev, unsigned int us_per_tick, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     /* using fixed TIMER_BASE for now */
     if (dev != 0) {
         return -1;
     }
-    /* TODO: configure time-base depending on us_per_tick value */
-    if (us_per_tick != 1) {
+    /* TODO: configure time-base depending on freq value */
+    if (freq != 1000000ul) {
         return -1;
     }
 

--- a/cpu/ezr32wg/periph/timer.c
+++ b/cpu/ezr32wg/periph/timer.c
@@ -38,7 +38,7 @@
 static timer_isr_ctx_t isr_ctx[TIMER_NUMOF];
 
 
-int timer_init(tim_t dev, unsigned int us_per_tick, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     TIMER_TypeDef *pre, *tim;
 
@@ -63,7 +63,7 @@ int timer_init(tim_t dev, unsigned int us_per_tick, void (*callback)(int))
      * configure it up-counting, driven by the HFPER clock and we set the TOP
      * register depending on the specified timer speed value */
     pre->CTRL = 0;
-    pre->TOP = ((CLOCK_HFPERCLK / 1000000) - 1) * us_per_tick;
+    pre->TOP = ((CLOCK_HFPERCLK / freq) - 1);
     pre->CNT = 0;
     pre->IEN = 0;
 

--- a/cpu/kinetis_common/periph/timer.c
+++ b/cpu/kinetis_common/periph/timer.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin
- * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ * Copyright (C) 2014-2015 PHYTEC Messtechnik GmbH
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -57,10 +57,10 @@ inline static void pit_timer_stop(uint8_t ch)
 }
 
 /** use channel n-1 as prescaler */
-inline static void timer_set_prescaler(uint8_t ch, unsigned int ticks_per_us)
+inline static void timer_set_prescaler(uint8_t ch, unsigned long freq)
 {
     TIMER_BASE->CHANNEL[ch].TCTRL = 0x0;
-    TIMER_BASE->CHANNEL[ch].LDVAL = (TIMER_CLOCK / 1e6) / ticks_per_us - 1;
+    TIMER_BASE->CHANNEL[ch].LDVAL = (TIMER_CLOCK / freq) - 1;
     TIMER_BASE->CHANNEL[ch].TCTRL = (PIT_TCTRL_TEN_MASK);
 }
 
@@ -84,7 +84,7 @@ inline static void pit_timer_set_max(uint8_t ch)
     pit_timer_start(ch);
 }
 
-int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     /* enable timer peripheral clock */
     TIMER_CLKEN();
@@ -97,7 +97,7 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
 
         case TIMER_0:
             NVIC_SetPriority(TIMER_0_IRQ_CHAN, TIMER_IRQ_PRIO);
-            timer_set_prescaler(TIMER_0_PRESCALER_CH, ticks_per_us);
+            timer_set_prescaler(TIMER_0_PRESCALER_CH, freq);
             timer_set_counter(TIMER_0_COUNTER_CH);
             break;
 #endif
@@ -105,7 +105,7 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
 
         case TIMER_1:
             NVIC_SetPriority(TIMER_1_IRQ_CHAN, TIMER_IRQ_PRIO);
-            timer_set_prescaler(TIMER_1_PRESCALER_CH, ticks_per_us);
+            timer_set_prescaler(TIMER_1_PRESCALER_CH, freq);
             timer_set_counter(TIMER_1_COUNTER_CH);
             break;
 #endif

--- a/cpu/lm4f120/periph/timer.c
+++ b/cpu/lm4f120/periph/timer.c
@@ -66,14 +66,14 @@ static inline unsigned int _llvalue_to_scaled_value(unsigned long long corrected
     return scaledv;
 }
 
-int timer_init(tim_t dev, unsigned int us_per_tick, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     if (dev >= TIMER_NUMOF){
         return -1;
     }
 
     config[dev].cb = callback;                          /* User Function */
-    config[dev].divisor = us_per_tick * ROM_SysCtlClockGet()/1000000;
+    config[dev].divisor = ROM_SysCtlClockGet() / freq;
 
     unsigned int sysctl_timer;
     unsigned int timer_base;

--- a/cpu/lpc11u34/periph/timer.c
+++ b/cpu/lpc11u34/periph/timer.c
@@ -50,7 +50,7 @@ typedef struct {
  */
 static timer_conf_t config[TIMER_NUMOF];
 
-int timer_init(tim_t dev, unsigned int us_per_tick, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     if (dev == TIMER_0) {
         /* save callback */
@@ -60,7 +60,7 @@ int timer_init(tim_t dev, unsigned int us_per_tick, void (*callback)(int))
         /* set to timer mode */
         TIMER_0_DEV->CTCR = 0;
         /* configure prescaler */
-        TIMER_0_DEV->PR = (us_per_tick * TIMER_0_PRESCALER);
+        TIMER_0_DEV->PR = (TIMER_0_FREQ / freq) - 1;
         /* configure and enable timer interrupts */
         NVIC_SetPriority(TIMER_0_IRQ, TIMER_IRQ_PRIO);
         NVIC_EnableIRQ(TIMER_0_IRQ);

--- a/cpu/lpc1768/periph/timer.c
+++ b/cpu/lpc1768/periph/timer.c
@@ -50,7 +50,7 @@ typedef struct {
  */
 static timer_conf_t config[TIMER_NUMOF];
 
-int timer_init(tim_t dev, unsigned int us_per_tick, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     if (dev == TIMER_0) {
         /* save callback */
@@ -62,7 +62,7 @@ int timer_init(tim_t dev, unsigned int us_per_tick, void (*callback)(int))
         /* set to timer mode */
         TIMER_0_DEV->CTCR = 0;
         /* configure prescaler */
-        TIMER_0_DEV->PR = (us_per_tick * TIMER_0_PRESCALER);
+        TIMER_0_DEV->PR = (TIMER_0_FREQ / freq) - 1;
         /* configure and enable timer interrupts */
         NVIC_SetPriority(TIMER_0_IRQ, TIMER_IRQ_PRIO);
         NVIC_EnableIRQ(TIMER_0_IRQ);

--- a/cpu/lpc2387/periph/timer.c
+++ b/cpu/lpc2387/periph/timer.c
@@ -108,7 +108,7 @@ static inline void pwr_clk_and_isr(tim_t tim)
     }
 }
 
-int timer_init(tim_t tim, unsigned int us_per_tick, void (*callback)(int))
+int timer_init(tim_t tim, unsigned long freq, void (*callback)(int))
 {
     /* get the timers base register */
     lpc23xx_timer_t *dev = get_dev(tim);
@@ -126,7 +126,7 @@ int timer_init(tim_t tim, unsigned int us_per_tick, void (*callback)(int))
     dev->TCR = 0;
     dev->CTCR = 0;
     /* configure the prescaler */
-    dev->PR = (us_per_tick * ((CLOCK_PCLK / 1000000) - 1));
+    dev->PR = (CLOCK_PCLK / freq) - 1;
     /* enable timer */
     dev->TCR = 1;
     return 0;

--- a/cpu/msp430fxyz/periph/timer.c
+++ b/cpu/msp430fxyz/periph/timer.c
@@ -35,14 +35,14 @@
 static void (*isr_cb)(int chan);
 
 
-int timer_init(tim_t dev, unsigned int us_per_tick, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     /* using fixed TIMER_BASE for now */
     if (dev != 0) {
         return -1;
     }
-    /* TODO: configure time-base depending on us_per_tick value */
-    if (us_per_tick != 1) {
+    /* TODO: configure time-base depending on freq value */
+    if (freq != 1000000ul) {
         return -1;
     }
 

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -74,11 +74,14 @@ void native_isr_timer(void)
     _callback(0);
 }
 
-int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
-    (void)ticks_per_us;
+    (void)freq;
     DEBUG("%s\n", __func__);
     if (dev >= TIMER_NUMOF) {
+        return -1;
+    }
+    if (freq != NATIVE_TIMER_SPEED) {
         return -1;
     }
 

--- a/cpu/nrf51/periph/timer.c
+++ b/cpu/nrf51/periph/timer.c
@@ -64,7 +64,7 @@ static NRF_TIMER_Type *const timer[] = {
 #endif
 };
 
-int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     if (dev >= TIMER_NUMOF) {
         return -1;
@@ -105,21 +105,30 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
     timer[dev]->MODE = TIMER_MODE_MODE_Timer;        /* set the timer in Timer Mode. */
     timer[dev]->TASKS_CLEAR    = 1;                  /* clear the task first to be usable for later. */
 
-    switch (ticks_per_us) {
-        case 1:
-            timer[dev]->PRESCALER = 4;
-            break;
-        case 2:
-            timer[dev]->PRESCALER = 5;
-            break;
-        case 4:
-            timer[dev]->PRESCALER = 6;
-            break;
-        case 8:
+    switch (freq) {
+        case 125000ul:
             timer[dev]->PRESCALER = 7;
             break;
-        case 16:
-            timer[dev]->PRESCALER = 8;
+        case 250000ul:
+            timer[dev]->PRESCALER = 6;
+            break;
+        case 500000ul:
+            timer[dev]->PRESCALER = 5;
+            break;
+        case 1000000ul:
+            timer[dev]->PRESCALER = 4;
+            break;
+        case 2000000ul:
+            timer[dev]->PRESCALER = 3;
+            break;
+        case 4000000ul:
+            timer[dev]->PRESCALER = 2;
+            break;
+        case 8000000ul:
+            timer[dev]->PRESCALER = 1;
+            break;
+        case 16000000ul:
+            timer[dev]->PRESCALER = 0;
             break;
         default:
             return -1;

--- a/cpu/nrf52/periph/timer.c
+++ b/cpu/nrf52/periph/timer.c
@@ -64,7 +64,7 @@ static NRF_TIMER_Type *const timer[] = {
 #endif
 };
 
-int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     if (dev >= TIMER_NUMOF) {
         return -1;
@@ -106,27 +106,31 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
     timer[dev]->MODE = TIMER_MODE_MODE_Timer;        /* set the timer in Timer Mode. */
     timer[dev]->TASKS_CLEAR    = 1;                  /* clear the task first to be usable for later. */
 
-    switch (ticks_per_us) {
-        case 1:
-            timer[dev]->PRESCALER = 4;
-            break;
-
-        case 2:
-            timer[dev]->PRESCALER = 5;
-            break;
-
-        case 4:
-            timer[dev]->PRESCALER = 6;
-            break;
-
-        case 8:
+    switch (freq) {
+        case 125000ul:
             timer[dev]->PRESCALER = 7;
             break;
-
-        case 16:
-            timer[dev]->PRESCALER = 8;
+        case 250000ul:
+            timer[dev]->PRESCALER = 6;
             break;
-
+        case 500000ul:
+            timer[dev]->PRESCALER = 5;
+            break;
+        case 1000000ul:
+            timer[dev]->PRESCALER = 4;
+            break;
+        case 2000000ul:
+            timer[dev]->PRESCALER = 3;
+            break;
+        case 4000000ul:
+            timer[dev]->PRESCALER = 2;
+            break;
+        case 8000000ul:
+            timer[dev]->PRESCALER = 1;
+            break;
+        case 16000000ul:
+            timer[dev]->PRESCALER = 0;
+            break;
         default:
             return -1;
     }

--- a/cpu/sam3/periph/timer.c
+++ b/cpu/sam3/periph/timer.c
@@ -60,7 +60,7 @@ static timer_conf_t timer_config[TIMER_NUMOF];
  * For each timer, channel 0 is used to implement a prescaler. Channel 0 is
  * driven by the MCK / 2 (42MHz) (TIMER_CLOCK1).
  */
-int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     Tc *tim;
 
@@ -111,13 +111,13 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
     tim->TC_CHANNEL[2].TC_CMR = TC_CMR_TCCLKS_TIMER_CLOCK1 | TC_CMR_WAVE
                               | TC_CMR_WAVSEL_UP_RC | TC_CMR_ACPC_TOGGLE;
 
-    /* configure the frequency of channel 2 to 1us * ticks_per_us
+    /* configure the frequency of channel 2 to freq * 4
      *
      * note: as channels 0 and 1 are only incremented on rising edges of TIOA2 line and
      * channel 2 toggles this line on each timer tick, the actual frequency driving ch0/1
-     * is f_ch2 / 2 --> f_ch0/1 = (MCK / 2 / 2 / 1000000) * ticks_per_us.
+     * is f_ch2 / 2 --> f_ch0/1 = (MCK / 2) / 2 / freq.
      */
-    tim->TC_CHANNEL[2].TC_RC = ((CLOCK_CORECLOCK / 1000000) / 4) * ticks_per_us;
+    tim->TC_CHANNEL[2].TC_RC = (CLOCK_CORECLOCK / 4) / freq;
 
     /* start channel 2 */
     tim->TC_CHANNEL[2].TC_CCR = TC_CCR_CLKEN | TC_CCR_SWTRG;

--- a/cpu/samd21/periph/timer.c
+++ b/cpu/samd21/periph/timer.c
@@ -46,10 +46,10 @@ timer_conf_t config[TIMER_NUMOF];
 /**
  * @brief Setup the given timer
  */
-int timer_init(tim_t dev, unsigned int us_per_ticks, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     /* at the moment, the timer can only run at 1MHz */
-    if (us_per_ticks != 1) {
+    if (freq != 1000000ul) {
         return -1;
     }
 

--- a/cpu/saml21/periph/timer.c
+++ b/cpu/saml21/periph/timer.c
@@ -48,7 +48,7 @@ timer_conf_t config[TIMER_NUMOF];
 /**
  * @brief Setup the given timer
  */
-int timer_init(tim_t dev, unsigned int us_per_ticks, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     /* configure GCLK0 to feed TC0 & TC1*/;
     GCLK->PCHCTRL[TC0_GCLK_ID].reg |= GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN_GCLK0;

--- a/cpu/stm32f0/periph/timer.c
+++ b/cpu/stm32f0/periph/timer.c
@@ -42,7 +42,7 @@ typedef struct {
 static timer_conf_t config[TIMER_NUMOF];
 
 
-int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     TIM_TypeDef *timer;
 
@@ -80,7 +80,7 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
 
     /* set auto-reload and prescaler values and load new values */
     timer->ARR = TIMER_0_MAX_VALUE;
-    timer->PSC = TIMER_0_PRESCALER * ticks_per_us;
+    timer->PSC = (TIMER_0_FREQ / freq) - 1;
     timer->EGR |= TIM_EGR_UG;
 
     /* enable the timer's interrupt */

--- a/cpu/stm32f1/periph/timer.c
+++ b/cpu/stm32f1/periph/timer.c
@@ -45,7 +45,7 @@ typedef struct {
  */
 static timer_conf_t config[TIMER_NUMOF];
 
-int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     TIM_TypeDef *timer0;
     TIM_TypeDef *timer1;
@@ -95,7 +95,7 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
     timer0->CR2 |= TIM_CR2_MMS_1;
     /* set auto-reload and prescaler values and load new values */
     timer0->ARR = 0xFFFF;
-    timer0->PSC = TIMER_0_PRESCALER * ticks_per_us;
+    timer0->PSC = (TIMER_0_FREQ / freq) - 1;
     // timer->EGR |= TIM_EGR_UG;
 
     /* configure slave timer1 */

--- a/cpu/stm32f3/periph/timer.c
+++ b/cpu/stm32f3/periph/timer.c
@@ -39,7 +39,7 @@ typedef struct {
 timer_conf_t config[TIMER_NUMOF];
 
 
-int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     TIM_TypeDef *timer;
 
@@ -67,7 +67,7 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
     timer->CR2 = 0;
 
     /* set auto-reload and prescaler values and load new values */
-    timer->PSC = TIMER_0_PRESCALER * ticks_per_us;
+    timer->PSC = (TIMER_0_FREQ / freq) - 1;
     timer->EGR |= TIM_EGR_UG;
 
     /* enable the timer's interrupt */

--- a/cpu/stm32f4/periph/timer.c
+++ b/cpu/stm32f4/periph/timer.c
@@ -39,7 +39,7 @@ typedef struct {
 timer_conf_t config[TIMER_NUMOF];
 
 
-int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     TIM_TypeDef *timer;
 
@@ -52,7 +52,7 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
             NVIC_SetPriority(TIMER_0_IRQ_CHAN, TIMER_IRQ_PRIO);
             /* select timer */
             timer = TIMER_0_DEV;
-            timer->PSC = TIMER_0_PRESCALER * ticks_per_us;
+            timer->PSC = (TIMER_0_FREQ / freq) - 1;
             break;
 #endif
 #if TIMER_1_EN
@@ -63,7 +63,7 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
             NVIC_SetPriority(TIMER_1_IRQ_CHAN, TIMER_IRQ_PRIO);
             /* select timer */
             timer = TIMER_1_DEV;
-            timer->PSC = TIMER_1_PRESCALER * ticks_per_us;
+            timer->PSC = (TIMER_1_FREQ / freq) - 1;
             break;
 #endif
         case TIMER_UNDEFINED:

--- a/cpu/stm32l1/periph/timer.c
+++ b/cpu/stm32l1/periph/timer.c
@@ -43,7 +43,7 @@ static inline TIM_TypeDef *_tim(tim_t dev)
     return timer_config[dev].dev;
 }
 
-int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
 {
     TIM_TypeDef *tim;
 
@@ -64,7 +64,7 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
     tim->SR = 0;
     /* configure reload and pre-scaler values */
     tim->ARR = 0xffffffff;
-    tim->PSC = (((CLOCK_CORECLOCK / 1000000) * ticks_per_us) - 1);
+    tim->PSC = (CLOCK_CORECLOCK / freq) - 1;
     /* trigger update event to make pre-scaler value effective */
     tim->EGR = TIM_EGR_UG;
     /* enable interrupts and start the timer */

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -79,14 +79,14 @@ typedef struct {
  * enabled.
  *
  * @param[in] dev           the timer to initialize
- * @param[in] us_per_tick   number of us passed for one timer tick
+ * @param[in] freq          requested number of ticks per second
  * @param[in] callback      this callback is called in interrupt context, the
  *                          emitting channel is passed as argument
  *
  * @return                  0 on success
  * @return                  -1 if speed not applicable or unknown device given
  */
-int timer_init(tim_t dev, unsigned int us_per_tick, void (*callback)(int));
+int timer_init(tim_t dev, unsigned long freq, void (*callback)(int));
 
 /**
  * @brief Set a given timer channel for the given timer device

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -56,7 +56,7 @@ static inline int _is_set(xtimer_t *timer)
 void xtimer_init(void)
 {
     /* initialize low-level timer */
-    timer_init(XTIMER, (1 << XTIMER_SHIFT) /* us_per_tick */, _periph_timer_callback);
+    timer_init(XTIMER, (1000000ul >> XTIMER_SHIFT), _periph_timer_callback);
 
     /* register initial overflow tick */
     _lltimer_set(0xFFFFFFFF);

--- a/tests/periph_timer/main.c
+++ b/tests/periph_timer/main.c
@@ -32,7 +32,7 @@
 #endif
 
 #define MAX_CHANNELS        (10U)
-#define TIM_SPEED           (1U)        /* try to run with 1MHz */
+#define TIM_SPEED           (1000000ul) /* try to run with 1MHz */
 #define CHAN_OFFSET         (5000U)     /* fire every 5ms */
 
 static volatile int fired;


### PR DESCRIPTION
This PR modifies the timer_init function to take a frequency parameter instead of another mostly unused us per tick or tick per us parameter.

The rationale is that with the previous API there is no way to request a 32768 Hz timer, which is a common frequency for RTC crystals.

The new timer_init function has the following declaration:

```c
int timer_init(tim_t dev, unsigned long freq, void (*callback)(int));
```

Needs testing on all boards... *sigh*

Use tests/xtimer_msg, tests/xtimer_usleep_until etc for testing.
Things to look out for: 
 - Timers running too fast/slow, it should be enough to run tests/xtimer_msg for couple of minutes.
 - Timers stopping after some time, it should be enough to run tests/xtimer_msg for a couple of minutes.
 - Make sure tests/xtimer_usleep_until can run to finish, the text `Test complete.` should be printed at the end if all goes well)

Testing checklist:now=253.098701 (0 hours 4 min), diff=0


 - [ ] airfy-beacon
 - [x] arduino-due (repeated O.K.)
 - [ ] arduino-mega2560
 - [ ] avsextrem
 - [ ] cc2538dk (FAIL)
 - [ ] chronos
 - [ ] ek-lm4f120xl
 - [ ] f4vi1
 - [ ] fox
 - [ ] frdm-k64f
 - [x] iotlab-m3
 - [ ] limifrog-v1
 - [ ] mbed_lpc1768
 - [ ] msb-430
 - [ ] msb-430h
 - [ ] msba2
 - [ ] msbiot
 - [x] mulle
 - [x] native
 - [ ] nrf51dongle
 - [ ] nrf52dk
 - [ ] nrf6310
 - [x] nucleo-f091
 - [x] nucleo-f303
 - [ ] nucleo-f334
 - [ ] nucleo-l1 , *xtimer_usleep_until*,  *xtimer_msg_receive_timeout* ?
 - [ ] openmote
 - [x] pba-d-01-kw2x
 - [ ] pca10000
 - [ ] pca10005
 - [ ] pttu
 - [ ] remote
 - [ ] saml21-xpro
 - [x] samr21-xpro (repeated O.K.)
 - [ ] slwstk6220a
 - [ ] spark-core
 - [ ] stm32f0discovery, *xtimer_drift*, *xtimer_msg_receive_timeout* ?
 - [ ] stm32f3discovery
 - [ ] stm32f4discovery, *xtimer_drift*, *xtimer_msg*, *xtimer_msg_receive_timeout* ? - ~~#4716~~
 - [ ] telosb
 - [ ] udoo
 - [ ] weio
 - [ ] wsn430-v1_3b
 - [ ] wsn430-v1_4
 - [ ] yunjia-nrf51822
 - [ ] z1
