### PR TITLE
native: dynamically load malloc

### DIFF
--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -134,8 +134,29 @@ void _native_syscall_leave(void)
     }
 }
 
+#ifdef NATIVE_IN_MALLOC
+int _native_in_malloc = 1;
+#else
+int _native_in_malloc = 0;
+#endif
 void *malloc(size_t size)
 {
+    /* dynamically load malloc when it's needed - this is necessary to
+     * support g++ 5.2.0 as it uses malloc before startup runs */
+    if (!real_malloc) {
+        if (_native_in_malloc) {
+            /* XXX: This is a dirty hack for behaviour that came along
+             * with g++ 5.2.0.
+             * Throw it out when whatever made it necessary it is fixed. */
+            return NULL;
+        }
+        else {
+            _native_in_malloc = 1;
+            *(void **)(&real_malloc) = dlsym(RTLD_NEXT, "malloc");
+            _native_in_malloc = 0;
+        }
+    }
+
     void *r;
     _native_syscall_enter();
     r = real_malloc(size);


### PR DESCRIPTION
g++ 5.2.0 apparently requires malloc before startup is run.

Release version of #4043.