### PR TITLE
shell.h: fix tiny typo in documentation

### DIFF
--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -35,7 +35,7 @@ extern "C" {
 
 /**
  * @brief           Protype of a shell callback handler.
- * @details         The functions supplied to shell_init() must use this signature.
+ * @details         The functions supplied to shell_run() must use this signature.
  *                  The argument list is terminated with a NULL, i.e ``argv[argc] == NULL`.
  *                  ``argv[0]`` is the function name.
  *


### PR DESCRIPTION
It seems to me that one mention of ``shell_init()`` in the docs got left behind... In case that wasn't intentional, this PR should fix the issue.