### PR TITLE
cortex_m: Add debug symbols for OpenOCD/GDB thread support

### DIFF
--- a/boards/airfy-beacon/dist/openocd.cfg
+++ b/boards/airfy-beacon/dist/openocd.cfg
@@ -3,3 +3,4 @@ transport select hla_swd
 
 set WORKAREASIZE 0x4000
 source [find target/nrf51.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/ek-lm4f120xl/dist/openocd.cfg
+++ b/boards/ek-lm4f120xl/dist/openocd.cfg
@@ -15,3 +15,4 @@ transport select hla_jtag
 set WORKAREASIZE 0x8000
 set CHIPNAME lm4f120h5qr
 source [find target/stellaris.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/fox/dist/openocd.cfg
+++ b/boards/fox/dist/openocd.cfg
@@ -13,3 +13,4 @@ jtag_ntrst_delay 100
 reset_config trst_and_srst
 
 source [find target/stm32f1x.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/frdm-k64f/dist/openocd.cfg
+++ b/boards/frdm-k64f/dist/openocd.cfg
@@ -48,3 +48,4 @@ adapter_khz 1000
 $_TARGETNAME configure -event gdb-attach {
   halt
 }
+$_TARGETNAME configure -rtos auto

--- a/boards/iotlab-a8-m3/dist/openocd.cfg
+++ b/boards/iotlab-a8-m3/dist/openocd.cfg
@@ -6,3 +6,4 @@ ftdi_layout_signal nTRST -data 0x0800
 ftdi_layout_signal nSRST -data 0x0400
 
 source [find target/stm32f1x.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/iotlab-m3/dist/openocd.cfg
+++ b/boards/iotlab-m3/dist/openocd.cfg
@@ -6,3 +6,4 @@ ftdi_layout_signal nTRST -data 0x0800
 ftdi_layout_signal nSRST -data 0x0400
 
 source [find target/stm32f1x.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/limifrog-v1/dist/openocd.cfg
+++ b/boards/limifrog-v1/dist/openocd.cfg
@@ -3,3 +3,4 @@ transport select hla_swd
 
 set WORKAREASIZE 0x2800
 source [find target/stm32l1.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/msbiot/dist/openocd.cfg
+++ b/boards/msbiot/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/stm32f4discovery.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/nucleo-f072/dist/openocd.cfg
+++ b/boards/nucleo-f072/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/st_nucleo_f0.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/nucleo-f091/dist/openocd.cfg
+++ b/boards/nucleo-f091/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/st_nucleo_f0.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/nucleo-f103/dist/openocd.cfg
+++ b/boards/nucleo-f103/dist/openocd.cfg
@@ -1,2 +1,3 @@
 #source [find board/st_nucleo_f1.cfg]
 source [find board/st_nucleo_f103rb.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/nucleo-f303/dist/openocd.cfg
+++ b/boards/nucleo-f303/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/st_nucleo_f3.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/nucleo-f334/dist/openocd.cfg
+++ b/boards/nucleo-f334/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/st_nucleo_f3.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/nucleo-f401/dist/openocd.cfg
+++ b/boards/nucleo-f401/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/st_nucleo_f4.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/nucleo-l1/dist/openocd.cfg
+++ b/boards/nucleo-l1/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/st_nucleo_l1.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/pba-d-01-kw2x/dist/openocd.cfg
+++ b/boards/pba-d-01-kw2x/dist/openocd.cfg
@@ -69,3 +69,4 @@ if {![using_hla]} {
 $_TARGETNAME configure -event reset-init {
     adapter_khz 24000
 }
+$_TARGETNAME configure -rtos auto

--- a/boards/saml21-xpro/dist/openocd.cfg
+++ b/boards/saml21-xpro/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/atmel_saml21_xplained_pro.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/samr21-xpro/dist/openocd.cfg
+++ b/boards/samr21-xpro/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/atmel_samr21_xplained_pro.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/stm32f0discovery/dist/openocd.cfg
+++ b/boards/stm32f0discovery/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/stm32f0discovery.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/stm32f3discovery/dist/openocd.cfg
+++ b/boards/stm32f3discovery/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/stm32f3discovery.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/stm32f4discovery/dist/openocd.cfg
+++ b/boards/stm32f4discovery/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/stm32f4discovery.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/yunjia-nrf51822/dist/openocd.cfg
+++ b/boards/yunjia-nrf51822/dist/openocd.cfg
@@ -3,3 +3,4 @@ transport select hla_swd
 
 set WORKAREASIZE 0x4000
 source [find target/nrf51.cfg]
+$_TARGETNAME configure -rtos auto

--- a/core/sched.c
+++ b/core/sched.c
@@ -53,6 +53,17 @@ volatile kernel_pid_t sched_active_pid = KERNEL_PID_UNDEF;
 clist_node_t sched_runqueues[SCHED_PRIO_LEVELS];
 static uint32_t runqueue_bitcache = 0;
 
+/* Needed by OpenOCD to read sched_threads */
+__attribute__((used)) __attribute__((section (".openocd")))
+uint8_t max_threads = sizeof(sched_threads) / sizeof(thread_t*);
+
+#ifdef DEVELHELP
+/* OpenOCD can't determine struct offsets and additionally this member is only
+ * available if compiled with DEVELHELP */
+__attribute__((used)) __attribute__((section (".openocd")))
+uint8_t _tcb_name_offset = offsetof(thread_t, name);
+#endif
+
 #ifdef MODULE_SCHEDSTATISTICS
 static void (*sched_cb) (uint32_t timestamp, uint32_t value) = NULL;
 schedstat sched_pidlist[KERNEL_PID_LAST + 1];

--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -117,6 +117,7 @@ SECTIONS
         _srelocate = .;
         *(.ramfunc .ramfunc.*);
         *(.data .data.*);
+        KEEP (*(.openocd .openocd.*))
         . = ALIGN(4);
         _erelocate = .;
     } > ram


### PR DESCRIPTION
GDB has the ability to inspect threads, but to use this feature with RIOT the GDB-server, in this case OpenOCD, needs to know about the thread structures and the stacking. This PR introduces 2 new symbols in order to provide support for GDB threads.

To use this feature you need my patched OpenOCD version found [here](https://github.com/daniel-k/openocd/tree/riot_patched). I'm working on getting these patches upstream to OpenOCD so that one day this will be a default feature.

I added the needed `-rtos auto` line to every board that has a `openocd.cfg` file, but only tested `stm32f4discovery` and `samr21-xpro` yet.

OpenOCD can only access symbols, no struct offsets or define macros, so I introduced `max_threads` to iterate over `sched_threads` and `_tcb_name_offset` that will only be available when compiled with `DEVELHELP` to access the thread name. Although both symbols are declared as `volatile` they will be optimized away, so that's why I added the hack in `sched_task_exit()`. I'm sure there's a better way, so please tell me :)
