### PR TITLE
Bug: code to reproduce xtimer hang with concurrent xtimer_usleep() 

### DIFF
--- a/boards/airfy-beacon/dist/openocd.cfg
+++ b/boards/airfy-beacon/dist/openocd.cfg
@@ -3,3 +3,4 @@ transport select hla_swd
 
 set WORKAREASIZE 0x4000
 source [find target/nrf51.cfg]
+$_TARGETNAME configure -rtos RIOT

--- a/boards/ek-lm4f120xl/dist/openocd.cfg
+++ b/boards/ek-lm4f120xl/dist/openocd.cfg
@@ -15,3 +15,4 @@ transport select hla_jtag
 set WORKAREASIZE 0x8000
 set CHIPNAME lm4f120h5qr
 source [find target/stellaris.cfg]
+$_TARGETNAME configure -rtos RIOT

--- a/boards/fox/dist/openocd.cfg
+++ b/boards/fox/dist/openocd.cfg
@@ -13,3 +13,4 @@ jtag_ntrst_delay 100
 reset_config trst_and_srst
 
 source [find target/stm32f1x.cfg]
+$_TARGETNAME configure -rtos RIOT

--- a/boards/frdm-k64f/dist/openocd.cfg
+++ b/boards/frdm-k64f/dist/openocd.cfg
@@ -48,3 +48,4 @@ adapter_khz 1000
 $_TARGETNAME configure -event gdb-attach {
   halt
 }
+$_TARGETNAME configure -rtos RIOT

--- a/boards/iotlab-m3/dist/openocd.cfg
+++ b/boards/iotlab-m3/dist/openocd.cfg
@@ -6,3 +6,4 @@ ftdi_layout_signal nTRST -data 0x0800
 ftdi_layout_signal nSRST -data 0x0400
 
 source [find target/stm32f1x.cfg]
+$_TARGETNAME configure -rtos RIOT

--- a/boards/limifrog-v1/dist/openocd.cfg
+++ b/boards/limifrog-v1/dist/openocd.cfg
@@ -3,3 +3,4 @@ transport select hla_swd
 
 set WORKAREASIZE 0x2800
 source [find target/stm32l1.cfg]
+$_TARGETNAME configure -rtos RIOT

--- a/boards/msbiot/dist/openocd.cfg
+++ b/boards/msbiot/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/stm32f4discovery.cfg]
+$_TARGETNAME configure -rtos RIOT

--- a/boards/nucleo-f091/dist/openocd.cfg
+++ b/boards/nucleo-f091/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/st_nucleo_f0.cfg]
+$_TARGETNAME configure -rtos RIOT

--- a/boards/nucleo-f303/dist/openocd.cfg
+++ b/boards/nucleo-f303/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/st_nucleo_f3.cfg]
+$_TARGETNAME configure -rtos RIOT

--- a/boards/nucleo-f334/dist/openocd.cfg
+++ b/boards/nucleo-f334/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/st_nucleo_f3.cfg]
+$_TARGETNAME configure -rtos RIOT

--- a/boards/nucleo-l1/dist/openocd.cfg
+++ b/boards/nucleo-l1/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/st_nucleo_l1.cfg]
+$_TARGETNAME configure -rtos RIOT

--- a/boards/pba-d-01-kw2x/dist/openocd.cfg
+++ b/boards/pba-d-01-kw2x/dist/openocd.cfg
@@ -69,3 +69,4 @@ if {![using_hla]} {
 $_TARGETNAME configure -event reset-init {
     adapter_khz 24000
 }
+$_TARGETNAME configure -rtos RIOT

--- a/boards/saml21-xpro/dist/openocd.cfg
+++ b/boards/saml21-xpro/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/atmel_saml21_xplained_pro.cfg]
+$_TARGETNAME configure -rtos RIOT

--- a/boards/samr21-xpro/dist/openocd.cfg
+++ b/boards/samr21-xpro/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/atmel_samr21_xplained_pro.cfg]
+$_TARGETNAME configure -rtos RIOT

--- a/boards/stm32f0discovery/dist/openocd.cfg
+++ b/boards/stm32f0discovery/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/stm32f0discovery.cfg]
+$_TARGETNAME configure -rtos RIOT

--- a/boards/stm32f3discovery/dist/openocd.cfg
+++ b/boards/stm32f3discovery/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/stm32f3discovery.cfg]
+$_TARGETNAME configure -rtos RIOT

--- a/boards/stm32f4discovery/dist/openocd.cfg
+++ b/boards/stm32f4discovery/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find board/stm32f4discovery.cfg]
+$_TARGETNAME configure -rtos RIOT

--- a/boards/yunjia-nrf51822/dist/openocd.cfg
+++ b/boards/yunjia-nrf51822/dist/openocd.cfg
@@ -3,3 +3,4 @@ transport select hla_swd
 
 set WORKAREASIZE 0x4000
 source [find target/nrf51.cfg]
+$_TARGETNAME configure -rtos RIOT

--- a/tests/xtimer_hang/Makefile
+++ b/tests/xtimer_hang/Makefile
@@ -1,0 +1,11 @@
+APPLICATION = xtimer_hangup
+include ../Makefile.tests_common
+
+BOARD=samr21-xpro
+
+CFLAGS += -DDEVELHELP
+
+FEATURES_REQUIRED += periph_timer
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_hang/main.c
+++ b/tests/xtimer_hang/main.c
@@ -1,0 +1,64 @@
+#include <stdio.h>
+
+#include "unistd.h"
+#include "xtimer.h"
+#include "thread.h"
+
+
+#define STACKSIZE_TIMER     (1024)
+
+char stack_timer1[STACKSIZE_TIMER];
+char stack_timer2[STACKSIZE_TIMER];
+
+long unsigned int count = 0;
+
+void* timer_func1(void* arg)
+{
+    while(1)
+    {
+        xtimer_usleep(1000);
+        puts("+");
+    }
+}
+
+void* timer_func2(void* arg)
+{
+    while(1)
+    {
+        xtimer_usleep(1100);
+        puts("-");
+    }
+}
+
+int main(void)
+{
+
+    puts("xTimer hangup\n");
+
+    thread_create(stack_timer1,
+                  STACKSIZE_TIMER,
+                  2,
+                  CREATE_STACKTEST,
+                  timer_func1,
+                  NULL,
+                  "timer1");
+
+    thread_create(stack_timer2,
+                  STACKSIZE_TIMER,
+                  3,
+                  CREATE_STACKTEST,
+                  timer_func2,
+                  NULL,
+                  "timer2");
+
+    while(1)
+    {
+        printf("Ping %lu\n", count);
+        count++;
+        xtimer_usleep(100 * 1000);
+        printf("Pong %lu\n", count);
+        count++;
+        xtimer_usleep(100 * 1000);
+    }
+    return 0;
+}


### PR DESCRIPTION
This is a bugreport. I wanted to add code to reproduce, therefore a PR.

This test should reproduce a hangup for concurrent threads that use `xtimer_usleep()`. I'm experiencing this in my project and finally can reproduce it. I'm not really sure why it happens, but my investigations indicate that xtimer calls `_lltimer_set()` with a target in the past, so every xtimer_sleep hangs.

Maybe I only misused xtimer somehow or this can be fixed by those xtimer tuning variables. Just wanted to escalate this now, as I've already spent too much time on this without really having a clue :)

I based this on #4058 so that you can easily verify that it's the `xtimer_usleep()` calls that hang and facilitate debugging. For further instructions see #4058.

This behaviour is observed on `samr21-xpro`, last lines before hang on terminal:
```
[...]
2015-10-07 15:49:08,366 - INFO # -
2015-10-07 15:49:08,366 - INFO # +
2015-10-07 15:49:08,366 - INFO # -
2015-10-07 15:49:08,367 - INFO # +
2015-10-07 15:49:08,367 - INFO # -
2015-10-07 15:49:08,367 - INFO # +
2015-10-07 15:49:08,367 - INFO # -
2015-10-07 15:49:08,367 - INFO # Pong 3
```

Active threads:
```
(gdb) info threads
  Id   Target Id         Frame 
  4    Thread 4 (timer2 :  : Blocked mutex) mutex_lock (mutex=mutex@entry=0x200010d4 <stack_timer2+908>) at /home/daniel/Entwicklung/RIOT/core/mutex.c:53
  3    Thread 3 (timer1 :  : Blocked mutex) mutex_lock (mutex=mutex@entry=0x20000cd4 <stack_timer1+908>) at /home/daniel/Entwicklung/RIOT/core/mutex.c:53
  2    Thread 2 (main :  : Blocked mutex) mutex_lock (mutex=mutex@entry=0x2000081c <main_stack+1400>) at /home/daniel/Entwicklung/RIOT/core/mutex.c:53
* 1    Thread 1 (idle :  : Running) idle_thread (arg=<optimized out>) at /home/daniel/Entwicklung/RIOT/core/kernel_init.c:73
```

Thread 2 (main)
```
(gdb) bt
#0  mutex_lock (mutex=mutex@entry=0x2000081c <main_stack+1400>) at /home/daniel/Entwicklung/RIOT/core/mutex.c:53
#1  0x00000ec2 in _xtimer_sleep (offset=offset@entry=100000, long_offset=long_offset@entry=0) at /home/daniel/Entwicklung/RIOT/sys/xtimer/xtimer.c:52
#2  0x00000dc0 in xtimer_usleep (offset=100000) at /home/daniel/Entwicklung/RIOT/sys/include/xtimer.h:487
#3  main () at /home/daniel/Entwicklung/RIOT/tests/xtimer_hang/main.c:61
```

Thread 3 (timer1)
```
(gdb) bt
#0  mutex_lock (mutex=mutex@entry=0x20000cd4 <stack_timer1+908>) at /home/daniel/Entwicklung/RIOT/core/mutex.c:53
#1  0x00000ec2 in _xtimer_sleep (offset=offset@entry=1000, long_offset=long_offset@entry=0) at /home/daniel/Entwicklung/RIOT/sys/xtimer/xtimer.c:52
#2  0x00000d4c in xtimer_usleep (offset=1000) at /home/daniel/Entwicklung/RIOT/sys/include/xtimer.h:487
#3  timer_func1 (arg=<optimized out>) at /home/daniel/Entwicklung/RIOT/tests/xtimer_hang/main.c:19
#4  0x0000022c in sched_switch (other_prio=<optimized out>) at /home/daniel/Entwicklung/RIOT/core/sched.c:189
```

Thread 4 (timer2)
```
(gdb) bt
#0  mutex_lock (mutex=mutex@entry=0x200010d4 <stack_timer2+908>) at /home/daniel/Entwicklung/RIOT/core/mutex.c:53
#1  0x00000ec2 in _xtimer_sleep (offset=offset@entry=1100, long_offset=long_offset@entry=0) at /home/daniel/Entwicklung/RIOT/sys/xtimer/xtimer.c:52
#2  0x00000d2e in xtimer_usleep (offset=1100) at /home/daniel/Entwicklung/RIOT/sys/include/xtimer.h:487
#3  timer_func2 (arg=<optimized out>) at /home/daniel/Entwicklung/RIOT/tests/xtimer_hang/main.c:28
#4  0x0000022c in sched_switch (other_prio=<optimized out>) at /home/daniel/Entwicklung/RIOT/core/sched.c:189
```