### PR TITLE
sys: xtimer: add another safeguard against setting a timer in the past

### DIFF
--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -482,6 +482,11 @@ overflow:
     if (timer_list_head) {
         /* schedule callback on next timer target time */
         next_target = timer_list_head->target - XTIMER_OVERHEAD;
+
+        /* make sure we're not setting a time in the past */
+        if (next_target < (_xtimer_now() + XTIMER_ISR_BACKOFF)) {
+            goto overflow;
+        }
     }
     else {
         /* there's no timer planned for this timer period */


### PR DESCRIPTION
In certain circumstances, xtimer would set a timer in the past, leading to a hanging system.

Fixes #4060.