### PR TITLE
cpu/lpc11u34 : Add CPU ID support and added this capability to board/weio

### DIFF
--- a/boards/weio/Makefile.features
+++ b/boards/weio/Makefile.features
@@ -3,4 +3,5 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_MCU_GROUP = cortex_m0

--- a/cpu/lpc11u34/include/cpu_conf.h
+++ b/cpu/lpc11u34/include/cpu_conf.h
@@ -36,6 +36,13 @@ extern "C" {
 #define CPU_FLASH_BASE                  LPC_FLASH_BASE
 /** @} */
 
+/**
+ * @brief   CPU ID configuration
+ * @{
+ */
+#define CPUID_ID_LEN                    (16U)
+/* @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/lpc11u34/periph/cpuid.c
+++ b/cpu/lpc11u34/periph/cpuid.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_lpc11u34
+ * @{
+ *
+ * @file
+ * @brief       Low-level CPUID driver implementation
+ *
+ * @author      Paul RATHGEB <paul.rathgeb@skynet.be>
+ */
+
+#include <string.h>
+#include "periph/cpuid.h"
+
+/* IAP base address */
+#define IAP_ADDRESS 0x1FFF1FF1
+
+void cpuid_get(void *id)
+{
+    uint32_t result[5];
+    /* IAP command for UUID : 58 (UM10462 page 409) */
+    uint32_t command = 58;
+    /* Define pointer to function type */
+    void (*iap)(uint32_t[], uint32_t[]);
+    /* Set the function pointer */
+    iap = (void (*)(uint32_t[], uint32_t[])) IAP_ADDRESS;
+    /* Read UUID */
+    iap(&command, result);
+    memcpy(id, &result[1], CPUID_ID_LEN);
+}
+/** @} */


### PR DESCRIPTION
This PR adds the CPU ID support, as explained in the LPC11U3x [user manual](http://www.nxp.com/documents/user_manual/UM10462.pdf), Chapter 20.14 at page 408