### PR TITLE
sys/shell/commands/sc_gnrc_rpl: don't calculate cleanup timer twice

### DIFF
--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -300,9 +300,8 @@ int _gnrc_rpl_dodag_show(void)
                    "TR(I=[%d,%d], k=%d, c=%d, TC=%" PRIu64 "s, TI=%" PRIu64 "s)]\n",
                     ipv6_addr_to_str(addr_str, &dodag->dodag_id, sizeof(addr_str)),
                     dodag->my_rank, (dodag->node_status == GNRC_RPL_LEAF_NODE ? "Leaf" : "Router"),
-                    (((int32_t) cleanup < 0) ? 0 : cleanup/SEC_IN_USEC),
-                    (1 << dodag->dio_min), dodag->dio_interval_doubl,
-                    dodag->trickle.k, dodag->trickle.c, tc, ti);
+                    cleanup, (1 << dodag->dio_min), dodag->dio_interval_doubl, dodag->trickle.k,
+                    dodag->trickle.c, tc, ti);
             gnrc_rpl_parent_t *parent;
             LL_FOREACH(dodag->parents, parent) {
                 printf("\t\tparent [addr: %s | rank: %d | lifetime: %" PRIu64 "s]\n",


### PR DESCRIPTION
The `cleanup` variable is calculated twice currently for the `rpl` status shell command.
This PR basically just replaces `(((int32_t) cleanup < 0) ? 0 : cleanup/SEC_IN_USEC)` with `cleanup`
and does some rearrangements of the parameters to use the full line length.