### PR TITLE
samd21: don't change priority of interrupts, this is really evil

### DIFF
--- a/cpu/samd21/periph/rtc.c
+++ b/cpu/samd21/periph/rtc.c
@@ -129,7 +129,6 @@ int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
     while (rtcMode2->STATUS.bit.SYNCBUSY);
 
     /* Setup interrupt */
-    NVIC_SetPriority(RTC_IRQn, 10);
     NVIC_EnableIRQ(RTC_IRQn);
 
     /* Enable IRQ */

--- a/cpu/samd21/periph/rtt.c
+++ b/cpu/samd21/periph/rtt.c
@@ -102,7 +102,6 @@ void rtt_init(void)
     while (rtcMode0->STATUS.bit.SYNCBUSY);
 
     /* Setup interrupt */
-    NVIC_SetPriority(RTT_IRQ, RTT_IRQ_PRIO);
     NVIC_EnableIRQ(RTT_IRQ);
 
     /* Enable RTC */


### PR DESCRIPTION
Changing interrupt priorities on cortex_m platforms has really bad consequences. RIOT assumes that there is no interrupt nesting (i.e. all IRQs have the same priority) which holds true until you change any IRQ priority.

Having low(er) priority interrupts is fine (they don't preempt e.g. the scheduler), but they can be preempted indeed (e.g. by a timer). When sending messages from within an interrupt callback with `msg_send()`, then `msg_send_int()` is used internally.

Inside [msg_send_int()](https://github.com/RIOT-OS/RIOT/blob/7bf121903a4467a2adf428283d8c895a6f481781/core/msg.c#L181) there's a call to [sched_set_status()](https://github.com/RIOT-OS/RIOT/blob/7bf121903a4467a2adf428283d8c895a6f481781/core/sched.c#L132) which assumes not to be preempted. That's where all the fun begins.

I was getting hardfaults inside `sched_run()` for some time now, but never really identified the cause. When a call to `sched_set_status()` gets preempted [here](https://github.com/RIOT-OS/RIOT/blob/7bf121903a4467a2adf428283d8c895a6f481781/core/sched.c#L147) the runqueue will be `NULL` for that process priority while `runqueue_bitcache` still indicates a non-empty runqueue. 
Back in `sched_run()` this leads to `next_thread` pointing nowhere (yes, on samd21 you can dereference NULL pointer!). Boom.

Long story short: don't ever change interrupt priorities unless you **really** know what you're doing. It's okay to have such a limitation to not call `msg_send()` inside an interrupt that has a lower priority, but I wasn't aware of this yet.

```bash
$ cd cpu/
$ ack-grep NVIC_SetPriority
```

Yields a lot hits that may also lead to bugs like this one.