### PR TITLE
core/msg: add missing irq restoration in msg_reply()

### DIFF
--- a/core/msg.c
+++ b/core/msg.c
@@ -228,13 +228,7 @@ int msg_reply(msg_t *m, msg_t *reply)
     unsigned state = disableIRQ();
 
     tcb_t *target = (tcb_t*) sched_threads[m->sender_pid];
-
-    if (!target) {
-        DEBUG("msg_reply(): %" PRIkernel_pid ": Target \"%" PRIkernel_pid
-              "\" not existing...dropping msg!\n", sched_active_thread->pid,
-              m->sender_pid);
-        return -1;
-    }
+    assert(target != NULL);
 
     if (target->status != STATUS_REPLY_BLOCKED) {
         DEBUG("msg_reply(): %" PRIkernel_pid ": Target \"%" PRIkernel_pid


### PR DESCRIPTION
As far as I understand the code in `msg_reply()` there is a missing restoration of IRQs when `target == NULL`. Please correct me if I'm wrong, found this while investigating for #4081.