### PR TITLE
Added documentation to cib.h

### DIFF
--- a/core/include/cib.h
+++ b/core/include/cib.h
@@ -44,7 +44,7 @@ typedef struct {
  *
  * @param[out] cib      Buffer to initialize.
  *                      Must not be NULL.
- * @param[in]  size     Size of the buffer, must not exceed MAXINT/2.
+ * @param[in]  size     Size of the buffer, must not exceed MAXINT/2. Should be equal to 0 or 2^n.
  */
 static inline void cib_init(cib_t *__restrict cib, unsigned int size)
 {

--- a/core/include/cib.h
+++ b/core/include/cib.h
@@ -48,6 +48,9 @@ typedef struct {
  */
 static inline void cib_init(cib_t *__restrict cib, unsigned int size)
 {
+    /* check if size is a power of 2 by comparing it to its complement */
+    assert(!(size & (size - 1)));
+    
     cib_t c = CIB_INIT(size);
     *cib = c;
 }


### PR DESCRIPTION
size can be equal 0 or 2^n only. Because else mask won't consist of consecutive '1' only (e.g., 0b00111111) and functions cib_get() and cib_put() will return wrong values.