### PR TITLE
samd21/gpio: check if interrupt is enabled in isr, fixes #4087

### DIFF
--- a/cpu/samd21/periph/gpio.c
+++ b/cpu/samd21/periph/gpio.c
@@ -225,7 +225,9 @@ void isr_eic(void)
     for (int i = 0; i < NUMOF_IRQS; i++) {
         if (EIC->INTFLAG.reg & (1 << i)) {
             EIC->INTFLAG.reg = (1 << i);
-            gpio_config[i].cb(gpio_config[i].arg);
+            if(EIC->INTENSET.reg & (1 << i)) {
+                gpio_config[i].cb(gpio_config[i].arg);
+            }
         }
     }
     if (sched_context_switch_request) {


### PR DESCRIPTION
The interrupt flag for a previously configured external gpio interrupt
will be set regardless of the actual configuration. So when another source
causes an interrupt, the callback of a disabled gpio interrupt will be serviced
although it was disabled if the interrupt occured in the meantime.