### PR TITLE
timex: introduce USEC_IN_NS constant

### DIFF
--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -44,6 +44,11 @@ extern "C" {
 #define MS_IN_USEC  (1000U)
 
 /**
+ * @brief The number of nanoseconds per microsecond
+ */
+#define USEC_IN_NS  (1000)
+
+/**
  * @brief The maximum length of the string representation of a timex timestamp
  */
 #define TIMEX_MAX_STR_LEN   (20)

--- a/sys/posix/semaphore/posix_semaphore.c
+++ b/sys/posix/semaphore/posix_semaphore.c
@@ -32,8 +32,6 @@
 
 #include "semaphore.h"
 
-#define USEC_IN_NS  (1000)
-
 int sem_timedwait(sem_t *sem, const struct timespec *abstime)
 {
     timex_t now, timeout = { abstime->tv_sec, abstime->tv_nsec / USEC_IN_NS };


### PR DESCRIPTION
Though the `timex_t` structure does not support nanosecond resolution, many POSIX API functions expect nanosecond parameters. This is why I think it is a good idea to add this constant here.

Based on https://github.com/RIOT-OS/RIOT/pull/3549#discussion_r42090814.