### PR TITLE
unittests: initialize xtimer if present

### DIFF
--- a/tests/unittests/main.c
+++ b/tests/unittests/main.c
@@ -10,6 +10,7 @@
 
 #include "embUnit.h"
 #include "lpm.h"
+#include "xtimer.h"
 
 #define UNCURRY(FUN, ARGS) FUN(ARGS)
 #define RUN_TEST_SUITES(...) MAP(RUN_TEST_SUITE, __VA_ARGS__)
@@ -21,6 +22,11 @@
 
 int main(void)
 {
+#ifdef MODULE_XTIMER
+    /* auto_init is disabled, but some modules depends on this module being initialized */
+    xtimer_init();
+#endif
+
 #ifdef OUTPUT
     TextUIRunner_setOutputter(OUTPUTTER);
 #endif


### PR DESCRIPTION
Fixes #4095.