### PR TITLE
Introduce RPL awareness to fib entries

### DIFF
--- a/sys/include/net/fib.h
+++ b/sys/include/net/fib.h
@@ -63,6 +63,11 @@ typedef struct fib_destination_set_entry_t {
 #define FIB_LIFETIME_NO_EXPIRE (0xFFFFFFFFffffffff)
 
 /**
+ * @brief flag to identify if a route was set by RPL
+ */
+#define FIB_FLAG_RPL_ROUTE (1UL << 0)
+
+/**
  * @brief initializes all FIB entries with 0
  *
  * @param[in] table         the fib instance to initialize

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -37,6 +37,7 @@ static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 #define GNRC_RPL_OPT_DODAG_CONF_LEN         (14)
 #define GNRC_RPL_OPT_PREFIX_INFO_LEN        (30)
 #define GNRC_RPL_OPT_TARGET_LEN             (18)
+#define GNRC_RPL_OPT_TRANSIT_E_FLAG         (1 << 7)
 #define GNRC_RPL_OPT_TRANSIT_INFO_LEN       (4)
 #define GNRC_RPL_SHIFTED_MOP_MASK           (0x7)
 #define GNRC_RPL_PRF_MASK                   (0x7)
@@ -415,8 +416,8 @@ bool _parse_options(int msg_type, gnrc_rpl_dodag_t *dodag, gnrc_rpl_opt_t *opt, 
                 }
 
                 fib_add_entry(&gnrc_ipv6_fib_table, if_id, target->target.u8,
-                              sizeof(ipv6_addr_t), AF_INET6, src->u8,
-                              sizeof(ipv6_addr_t), AF_INET6,
+                              sizeof(ipv6_addr_t), 0x0, src->u8,
+                              sizeof(ipv6_addr_t), FIB_FLAG_RPL_ROUTE,
                               (dodag->default_lifetime * dodag->lifetime_unit) *
                               SEC_IN_MS);
                 break;
@@ -435,7 +436,9 @@ a preceding RPL TARGET DAO option\n");
                     fib_update_entry(&gnrc_ipv6_fib_table,
                                      first_target->target.u8,
                                      sizeof(ipv6_addr_t), src->u8,
-                                     sizeof(ipv6_addr_t), AF_INET6,
+                                     sizeof(ipv6_addr_t),
+                                     ((transit->e_flags & GNRC_RPL_OPT_TRANSIT_E_FLAG) ?
+                                      0x0 : FIB_FLAG_RPL_ROUTE),
                                      (transit->path_lifetime *
                                       dodag->lifetime_unit * SEC_IN_MS));
                     first_target = (gnrc_rpl_opt_target_t *) (((uint8_t *) (first_target)) +

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -274,9 +274,9 @@ bool gnrc_rpl_parent_add_by_addr(gnrc_rpl_dodag_t *dodag, ipv6_addr_t *addr, gnr
                 return false;
             }
             if (fib_add_entry(&gnrc_ipv6_fib_table, if_id, def.u8,
-                              sizeof(ipv6_addr_t), AF_INET6,
+                              sizeof(ipv6_addr_t), 0x0,
                               dodag->parents->addr.u8, sizeof(ipv6_addr_t),
-                              AF_INET6, (dodag->default_lifetime *
+                              FIB_FLAG_RPL_ROUTE, (dodag->default_lifetime *
                                          dodag->lifetime_unit) * SEC_IN_MS) != 0) {
                 DEBUG("RPL: error adding parent to FIB\n");
                 gnrc_rpl_parent_remove(*parent);
@@ -355,9 +355,9 @@ void gnrc_rpl_parent_update(gnrc_rpl_dodag_t *dodag, gnrc_rpl_parent_t *parent)
             kernel_pid_t if_id;
             if ((if_id = gnrc_ipv6_netif_find_by_addr(NULL, &all_RPL_nodes)) != KERNEL_PID_UNDEF) {
                 fib_add_entry(&gnrc_ipv6_fib_table, if_id, def.u8,
-                              sizeof(ipv6_addr_t), AF_INET6,
+                              sizeof(ipv6_addr_t), 0x0,
                               dodag->parents->addr.u8, sizeof(ipv6_addr_t),
-                              AF_INET6, (dodag->default_lifetime *
+                              FIB_FLAG_RPL_ROUTE, (dodag->default_lifetime *
                                          dodag->lifetime_unit) * SEC_IN_MS);
             }
         }
@@ -422,8 +422,8 @@ static gnrc_rpl_parent_t *_gnrc_rpl_find_preferred_parent(gnrc_rpl_dodag_t *doda
         }
 
         fib_add_entry(&gnrc_ipv6_fib_table, if_id, def.u8, sizeof(ipv6_addr_t),
-                      AF_INET6, dodag->parents->addr.u8, sizeof(ipv6_addr_t),
-                      AF_INET6, (dodag->default_lifetime *
+                      0x0, dodag->parents->addr.u8, sizeof(ipv6_addr_t),
+                      FIB_FLAG_RPL_ROUTE, (dodag->default_lifetime *
                                  dodag->lifetime_unit) * SEC_IN_MS);
     }
 


### PR DESCRIPTION
This PR introduces a new flag `FIB_FLAG_RPL_ROUTE` to mark fib entries as entries that were added by RPL.
The rationale is, that RPL must be able to distinguish between routes that were found by RPL and routes that were configured externally in follow-up PRs.