### PR TITLE
gnrc_ipv6: replace vtimer by xtimer

### DIFF
--- a/sys/include/net/gnrc/ipv6/nc.h
+++ b/sys/include/net/gnrc/ipv6/nc.h
@@ -151,7 +151,8 @@ typedef struct {
     msg_t nbr_adv_msg;                          /**< msg_t for gnrc_ipv6_nc_t::nbr_adv_timer */
 
 #ifdef MODULE_GNRC_SIXLOWPAN_ND
-    vtimer_t rtr_sol_timer; /**< Retransmission timer for unicast router solicitations */
+    xtimer_t rtr_sol_timer; /**< Retransmission timer for unicast router solicitations */
+    msg_t rtr_sol_msg;                          /**< msg_t for gnrc_ipv6_nc_t::rtr_sol_timer */
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
     vtimer_t type_timeout;                  /**< Timer for type transissions */

--- a/sys/include/net/gnrc/ipv6/nc.h
+++ b/sys/include/net/gnrc/ipv6/nc.h
@@ -147,7 +147,8 @@ typedef struct {
      *          RFC 4861, section 7.2.7
      *      </a>
      */
-    vtimer_t nbr_adv_timer;
+    xtimer_t nbr_adv_timer;
+    msg_t nbr_adv_msg;                          /**< msg_t for gnrc_ipv6_nc_t::nbr_adv_timer */
 
 #ifdef MODULE_GNRC_SIXLOWPAN_ND
     vtimer_t rtr_sol_timer; /**< Retransmission timer for unicast router solicitations */

--- a/sys/include/net/gnrc/ipv6/nc.h
+++ b/sys/include/net/gnrc/ipv6/nc.h
@@ -30,6 +30,7 @@
 #include "net/gnrc/netif.h"
 #include "net/gnrc/pktqueue.h"
 #include "vtimer.h"
+#include "xtimer.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -127,13 +128,15 @@ typedef struct {
     uint8_t l2_addr_len;                        /**< Length of gnrc_ipv6_nc_t::l2_addr */
     uint8_t flags;                              /**< Flags as defined above */
     kernel_pid_t iface;                         /**< PID to the interface where the neighbor is */
-    vtimer_t rtr_timeout;                       /**< timeout timer for router flag */
+    xtimer_t rtr_timeout;                       /**< timeout timer for router flag */
+    msg_t rtr_timeout_msg;                      /**< msg_t for gnrc_ipv6_nc_t::rtr_timeout */
 
     /**
      * @brief (Re)Transmission timer for neighbor solicitations of this entry and
      *        timeout for states.
      */
-    vtimer_t nbr_sol_timer;
+    xtimer_t nbr_sol_timer;
+    msg_t nbr_sol_msg;                          /**< msg_t for gnrc_ipv6_nc_t::nbr_sol_timer */
 
     /**
      * @brief Delay timer for neighbor advertisements of this entry.

--- a/sys/include/net/gnrc/ipv6/nc.h
+++ b/sys/include/net/gnrc/ipv6/nc.h
@@ -29,7 +29,6 @@
 #include "net/ipv6/addr.h"
 #include "net/gnrc/netif.h"
 #include "net/gnrc/pktqueue.h"
-#include "vtimer.h"
 #include "xtimer.h"
 
 #ifdef __cplusplus
@@ -155,7 +154,8 @@ typedef struct {
     msg_t rtr_sol_msg;                          /**< msg_t for gnrc_ipv6_nc_t::rtr_sol_timer */
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
-    vtimer_t type_timeout;                  /**< Timer for type transissions */
+    xtimer_t type_timeout;                  /**< Timer for type transissions */
+    msg_t type_timeout_msg;                 /**< msg_t for gnrc_ipv6_nc_t::type_timeout */
     eui64_t eui64;                          /**< the unique EUI-64 of the neighbor (might be
                                              *   different from L2 address, if l2_addr_len == 2) */
 #endif

--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -30,6 +30,7 @@
 #include "mutex.h"
 #include "net/ipv6.h"
 #include "net/ipv6/addr.h"
+#include "xtimer.h"
 #include "vtimer.h"
 
 #ifdef __cplusplus
@@ -340,7 +341,8 @@ typedef struct {
     xtimer_t rtr_sol_timer; /**< Timer for periodic router solicitations */
     msg_t rtr_sol_msg;      /**< msg_t for gnrc_ipv6_netif_t::rtr_sol_timer */
 #if defined (MODULE_GNRC_NDP_ROUTER) || defined (MODULE_GNRC_SIXLOWPAN_ND_ROUTER)
-    vtimer_t rtr_adv_timer; /**< Timer for periodic router advertisements */
+    xtimer_t rtr_adv_timer; /**< Timer for periodic router advertisements */
+    msg_t rtr_adv_msg;      /**< msg_t for gnrc_ipv6_netif_t::rtr_adv_timer */
 #endif
 } gnrc_ipv6_netif_t;
 

--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -259,7 +259,12 @@ typedef struct {
     /**
      * @brief   Validity timeout timer.
      */
-    vtimer_t valid_timeout;
+    xtimer_t valid_timeout;
+
+    /**
+     * @brief   msg_t for gnrc_ipv6_netif_addr_t::valid_timeout
+     */
+    msg_t valid_timeout_msg;
     /**
      * @}
      */

--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -337,7 +337,8 @@ typedef struct {
      *          The default value is @ref GNRC_NDP_RETRANS_TIMER.
      */
     timex_t retrans_timer;
-    vtimer_t rtr_sol_timer; /**< Timer for periodic router solicitations */
+    xtimer_t rtr_sol_timer; /**< Timer for periodic router solicitations */
+    msg_t rtr_sol_msg;      /**< msg_t for gnrc_ipv6_netif_t::rtr_sol_timer */
 #if defined (MODULE_GNRC_NDP_ROUTER) || defined (MODULE_GNRC_SIXLOWPAN_ND_ROUTER)
     vtimer_t rtr_adv_timer; /**< Timer for periodic router advertisements */
 #endif

--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -578,6 +578,25 @@ static inline bool gnrc_ipv6_netif_addr_is_non_unicast(const ipv6_addr_t *addr)
  */
 void gnrc_ipv6_netif_init_by_dev(void);
 
+/**
+ * @brief   Sets a xtimer.
+ *
+ * @param[in] timer     The pointer to a xtimer.
+ * @param[in] offset    Offset for the timer.
+ * @param[in] msg       The pointer to the msg_t of the timer.
+ * @param[in] msg_type  The type of the message.
+ * @param[in] msg_data  The data of the message.
+ * @param[in] pid       The pid that the timer will send a message to.
+ */
+static inline void gnrc_ipv6_set_timer(xtimer_t *timer, uint32_t offset, msg_t *msg,
+                                       uint16_t msg_type, char *msg_data, kernel_pid_t pid)
+{
+    xtimer_remove(timer);
+    msg->type = msg_type;
+    msg->content.ptr = msg_data;
+    xtimer_set_msg(timer, offset, msg, pid);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/gnrc/sixlowpan/nd/router.h
+++ b/sys/include/net/gnrc/sixlowpan/nd/router.h
@@ -70,7 +70,8 @@ typedef struct {
     uint16_t ltime;                         /**< the time in minutes until deletion */
     BITFIELD(ctxs, GNRC_SIXLOWPAN_CTX_SIZE);/**< contexts associated with BR */
     gnrc_sixlowpan_nd_router_prf_t *prfs;   /**< prefixes associated with BR */
-    vtimer_t ltimer;                        /**< timer for deletion */
+    xtimer_t ltimer;                        /**< timer for deletion */
+    msg_t ltimer_msg;                       /**< msg_t for gnrc_sixlowpan_nd_router_abr_t::ltimer */
 } gnrc_sixlowpan_nd_router_abr_t;
 
 /**

--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -147,7 +147,7 @@ void gnrc_ipv6_nc_remove(kernel_pid_t iface, const ipv6_addr_t *ipv6_addr)
         }
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN_ND
-        vtimer_remove(&entry->rtr_sol_timer);
+        xtimer_remove(&entry->rtr_sol_timer);
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
         vtimer_remove(&entry->type_timeout);

--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -225,13 +225,13 @@ gnrc_ipv6_nc_t *gnrc_ipv6_nc_still_reachable(const ipv6_addr_t *ipv6_addr)
 
     if ((gnrc_ipv6_nc_get_state(entry) != GNRC_IPV6_NC_STATE_INCOMPLETE) &&
         (gnrc_ipv6_nc_get_state(entry) != GNRC_IPV6_NC_STATE_UNMANAGED)) {
-#if defined(MODULE_GNRC_IPV6_NETIF) && defined(MODULE_VTIMER) && defined(MODULE_GNRC_IPV6)
+#if defined(MODULE_GNRC_IPV6_NETIF) && defined(MODULE_XTIMER) && defined(MODULE_GNRC_IPV6)
         gnrc_ipv6_netif_t *iface = gnrc_ipv6_netif_get(entry->iface);
         timex_t t = iface->reach_time;
 
-        vtimer_remove(&entry->nbr_sol_timer);
-        vtimer_set_msg(&entry->nbr_sol_timer, t, gnrc_ipv6_pid,
-                       GNRC_NDP_MSG_NC_STATE_TIMEOUT, entry);
+        gnrc_ipv6_set_timer(&entry->nbr_sol_timer, (uint32_t) timex_uint64(t),
+                            &entry->nbr_sol_msg, GNRC_NDP_MSG_NC_STATE_TIMEOUT,
+                            (char *) entry, gnrc_ipv6_pid);
 #endif
 
         DEBUG("ipv6_nc: Marking entry %s as reachable\n",

--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -23,7 +23,6 @@
 #include "net/gnrc/pktbuf.h"
 #include "thread.h"
 #include "timex.h"
-#include "vtimer.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
@@ -150,7 +149,7 @@ void gnrc_ipv6_nc_remove(kernel_pid_t iface, const ipv6_addr_t *ipv6_addr)
         xtimer_remove(&entry->rtr_sol_timer);
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
-        vtimer_remove(&entry->type_timeout);
+        xtimer_remove(&entry->type_timeout);
 #endif
 
         ipv6_addr_set_unspecified(&(entry->ipv6_addr));

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -231,7 +231,7 @@ void gnrc_ipv6_netif_remove(kernel_pid_t pid)
 #endif
 
     mutex_lock(&entry->mutex);
-    vtimer_remove(&entry->rtr_sol_timer);
+    xtimer_remove(&entry->rtr_sol_timer);
 #ifdef MODULE_GNRC_NDP_ROUTER
     vtimer_remove(&entry->rtr_adv_timer);
 #endif

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -233,7 +233,7 @@ void gnrc_ipv6_netif_remove(kernel_pid_t pid)
     mutex_lock(&entry->mutex);
     xtimer_remove(&entry->rtr_sol_timer);
 #ifdef MODULE_GNRC_NDP_ROUTER
-    vtimer_remove(&entry->rtr_adv_timer);
+    xtimer_remove(&entry->rtr_adv_timer);
 #endif
     _reset_addr_from_entry(entry);
     DEBUG("ipv6 netif: Remove IPv6 interface %" PRIkernel_pid "\n", pid);

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -614,7 +614,7 @@ void gnrc_ndp_rtr_adv_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt, ipv6_hdr_t
 #ifdef MODULE_GNRC_SIXLOWPAN_ND
     if (if_entry->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN) {
         /* stop multicast router solicitation retransmission timer */
-        vtimer_remove(&if_entry->rtr_sol_timer);
+        xtimer_remove(&if_entry->rtr_sol_timer);
         /* 3/4 of the time should be "well before" enough the respective timeout
          * not to run out; see https://tools.ietf.org/html/rfc6775#section-5.4.3 */
         next_rtr_sol *= 3;

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -431,30 +431,34 @@ void gnrc_ndp_rtr_sol_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
             }
 #endif
             delay = timex_set(0, genrand_uint32_range(0, ms));
-            vtimer_remove(&if_entry->rtr_adv_timer);
+            xtimer_remove(&if_entry->rtr_adv_timer);
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
             /* in case of a 6LBR we have to check if the interface is actually
              * the 6lo interface */
             if (if_entry->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN) {
                 gnrc_ipv6_nc_t *nc_entry = gnrc_ipv6_nc_get(iface, &ipv6->src);
                 if (nc_entry != NULL) {
-                    vtimer_set_msg(&if_entry->rtr_adv_timer, delay, gnrc_ipv6_pid,
-                            GNRC_NDP_MSG_RTR_ADV_SIXLOWPAN_DELAY, nc_entry);
+                    gnrc_ipv6_set_timer(&if_entry->rtr_adv_timer, (uint32_t) timex_uint64(delay),
+                                        &if_entry->rtr_adv_msg,
+                                        GNRC_NDP_MSG_RTR_ADV_SIXLOWPAN_DELAY,
+                                        (char *) nc_entry, gnrc_ipv6_pid);
                 }
             }
 #elif defined(MODULE_GNRC_NDP_ROUTER) || defined(MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER)
             if (ipv6_addr_is_unspecified(&ipv6->src)) {
                 /* either multicast, if source unspecified */
-                vtimer_set_msg(&if_entry->rtr_adv_timer, delay, gnrc_ipv6_pid,
-                               GNRC_NDP_MSG_RTR_ADV_RETRANS, if_entry);
+                gnrc_ipv6_set_timer(&if_entry->rtr_adv_timer, (uint32_t) timex_uint64(delay),
+                                    &if_entry->rtr_adv_msg, GNRC_NDP_MSG_RTR_ADV_RETRANS,
+                                    (char *) if_entry, gnrc_ipv6_pid);
             }
             else {
                 /* or unicast, if source is known */
                 /* XXX: can't just use GNRC_NETAPI_MSG_TYPE_SND, since the next retransmission
                  * must also be set. */
                 gnrc_ipv6_nc_t *nc_entry = gnrc_ipv6_nc_get(iface, &ipv6->src);
-                vtimer_set_msg(&if_entry->rtr_adv_timer, delay, gnrc_ipv6_pid,
-                               GNRC_NDP_MSG_RTR_ADV_DELAY, nc_entry);
+                gnrc_ipv6_set_timer(&if_entry->rtr_adv_timer, (uint32_t) timex_uint64(delay),
+                                    &if_entry->rtr_adv_msg, GNRC_NDP_MSG_RTR_ADV_DELAY,
+                                    (char *) nc_entry, gnrc_ipv6_pid);
             }
 #endif
         }

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -59,14 +59,15 @@ static void _stale_nc(kernel_pid_t iface, ipv6_addr_t *ipaddr, uint8_t *l2addr,
             gnrc_ipv6_netif_t *ipv6_iface = gnrc_ipv6_netif_get(iface);
             if ((ipv6_iface->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN) &&
                 (ipv6_iface->flags & GNRC_IPV6_NETIF_FLAGS_ROUTER)) {
-                timex_t t = { GNRC_SIXLOWPAN_ND_TENTATIVE_NCE_LIFETIME, 0 };
                 if ((nc_entry = gnrc_ipv6_nc_add(iface, ipaddr, l2addr,
                                                  (uint16_t)l2addr_len,
                                                  GNRC_IPV6_NC_STATE_STALE |
                                                  GNRC_IPV6_NC_TYPE_TENTATIVE)) != NULL) {
-                    vtimer_remove(&nc_entry->type_timeout);
-                    vtimer_set_msg(&nc_entry->type_timeout, t, gnrc_ipv6_pid,
-                                   GNRC_SIXLOWPAN_ND_MSG_AR_TIMEOUT, nc_entry);
+                    gnrc_ipv6_set_timer(&nc_entry->type_timeout,
+                                        GNRC_SIXLOWPAN_ND_TENTATIVE_NCE_LIFETIME * SEC_IN_USEC,
+                                        &nc_entry->type_timeout_msg,
+                                        GNRC_SIXLOWPAN_ND_MSG_AR_TIMEOUT,
+                                        (char *) nc_entry, gnrc_ipv6_pid);
                 }
                 return;
             }

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -519,8 +519,8 @@ void gnrc_ndp_rtr_adv_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt, ipv6_hdr_t
         next_rtr_sol = ltime;
 #endif
         gnrc_ipv6_set_timer(&nc_entry->rtr_timeout, (uint32_t) (ltime * SEC_IN_USEC),
-                               &nc_entry->rtr_timeout_msg, GNRC_NDP_MSG_RTR_TIMEOUT,
-                               (char *) nc_entry, thread_getpid());
+                            &nc_entry->rtr_timeout_msg, GNRC_NDP_MSG_RTR_TIMEOUT,
+                            (char *) nc_entry, thread_getpid());
     }
     /* set current hop limit from message if available */
     if (rtr_adv->cur_hl != 0) {

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -30,7 +30,6 @@
 #include "random.h"
 #include "utlist.h"
 #include "thread.h"
-#include "vtimer.h"
 
 #include "net/gnrc/ndp/internal.h"
 

--- a/sys/net/gnrc/network_layer/ndp/host/gnrc_ndp_host.c
+++ b/sys/net/gnrc/network_layer/ndp/host/gnrc_ndp_host.c
@@ -17,7 +17,6 @@
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/ndp.h"
 #include "net/gnrc/ndp/internal.h"
-#include "vtimer.h"
 
 #include "net/gnrc/ndp/host.h"
 
@@ -26,9 +25,9 @@
 
 static inline void _reschedule_rtr_sol(gnrc_ipv6_netif_t *iface, timex_t delay)
 {
-    vtimer_remove(&iface->rtr_sol_timer);
-    vtimer_set_msg(&iface->rtr_sol_timer, delay, gnrc_ipv6_pid, GNRC_NDP_MSG_RTR_SOL_RETRANS,
-                   iface);
+    gnrc_ipv6_set_timer(&iface->rtr_sol_timer, (uint32_t) timex_uint64(delay),
+                        &iface->rtr_sol_msg, GNRC_NDP_MSG_RTR_SOL_RETRANS,
+                        (char *) iface, gnrc_ipv6_pid);
 }
 
 void gnrc_ndp_host_init(gnrc_ipv6_netif_t *iface)

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -113,9 +113,9 @@ void gnrc_ndp_internal_set_state(gnrc_ipv6_nc_t *nc_entry, uint8_t state)
                       GNRC_NDP_FIRST_PROBE_DELAY);
             }
 #endif
-            vtimer_remove(&nc_entry->nbr_sol_timer);
-            vtimer_set_msg(&nc_entry->nbr_sol_timer, t, gnrc_ipv6_pid,
-                           GNRC_NDP_MSG_NC_STATE_TIMEOUT, nc_entry);
+            gnrc_ipv6_set_timer(&nc_entry->nbr_sol_timer, (uint32_t) timex_uint64(t),
+                                &nc_entry->nbr_sol_msg, GNRC_NDP_MSG_NC_STATE_TIMEOUT,
+                                (char *) nc_entry, gnrc_ipv6_pid);
             break;
 
         case GNRC_IPV6_NC_STATE_PROBE:
@@ -131,10 +131,10 @@ void gnrc_ndp_internal_set_state(gnrc_ipv6_nc_t *nc_entry, uint8_t state)
                                            &nc_entry->ipv6_addr);
 
             mutex_lock(&ipv6_iface->mutex);
-            vtimer_remove(&nc_entry->nbr_sol_timer);
-            vtimer_set_msg(&nc_entry->nbr_sol_timer,
-                           ipv6_iface->retrans_timer, gnrc_ipv6_pid,
-                           GNRC_NDP_MSG_NBR_SOL_RETRANS, nc_entry);
+            gnrc_ipv6_set_timer(&nc_entry->nbr_sol_timer,
+                                (uint32_t) timex_uint64(ipv6_iface->retrans_timer),
+                                &nc_entry->nbr_sol_msg, GNRC_NDP_MSG_NBR_SOL_RETRANS,
+                                (char *) nc_entry, gnrc_ipv6_pid);
             mutex_unlock(&ipv6_iface->mutex);
             break;
 

--- a/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
+++ b/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
@@ -172,9 +172,9 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
                 gnrc_ndp_internal_send_nbr_sol(ifs[i], NULL, next_hop_ip, &dst_sol);
             }
 
-            vtimer_remove(&nc_entry->nbr_sol_timer);
-            vtimer_set_msg(&nc_entry->nbr_sol_timer, t, gnrc_ipv6_pid,
-                           GNRC_NDP_MSG_NBR_SOL_RETRANS, nc_entry);
+            gnrc_ipv6_set_timer(&nc_entry->nbr_sol_timer, (uint32_t) timex_uint64(t),
+                                &nc_entry->nbr_sol_msg, GNRC_NDP_MSG_NBR_SOL_RETRANS,
+                                (char *) nc_entry, gnrc_ipv6_pid);
         }
         else {
             gnrc_ipv6_netif_t *ipv6_iface = gnrc_ipv6_netif_get(iface);
@@ -182,10 +182,10 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
             gnrc_ndp_internal_send_nbr_sol(iface, NULL, next_hop_ip, &dst_sol);
 
             mutex_lock(&ipv6_iface->mutex);
-            vtimer_remove(&nc_entry->nbr_sol_timer);
-            vtimer_set_msg(&nc_entry->nbr_sol_timer,
-                           ipv6_iface->retrans_timer, gnrc_ipv6_pid,
-                           GNRC_NDP_MSG_NBR_SOL_RETRANS, nc_entry);
+            gnrc_ipv6_set_timer(&nc_entry->nbr_sol_timer,
+                                (uint32_t) timex_uint64(ipv6_iface->retrans_timer),
+                                &nc_entry->nbr_sol_msg, GNRC_NDP_MSG_NBR_SOL_RETRANS,
+                                (char *) nc_entry, gnrc_ipv6_pid);
             mutex_unlock(&ipv6_iface->mutex);
         }
     }

--- a/sys/net/gnrc/network_layer/ndp/router/gnrc_ndp_router.c
+++ b/sys/net/gnrc/network_layer/ndp/router/gnrc_ndp_router.c
@@ -17,7 +17,6 @@
 #include "net/gnrc/ndp/internal.h"
 #include "random.h"
 #include "timex.h"
-#include "vtimer.h"
 
 #include "net/gnrc/ndp/router.h"
 
@@ -106,9 +105,9 @@ static void _send_rtr_adv(gnrc_ipv6_netif_t *iface, ipv6_addr_t *dst)
     }
     if (!fin || (iface->rtr_adv_count > 1)) {   /* regard for off-by-one-error */
         /* reset timer for next router advertisement */
-        vtimer_remove(&iface->rtr_adv_timer);
-        vtimer_set_msg(&iface->rtr_adv_timer, timex_set(interval, 0),
-                       gnrc_ipv6_pid, GNRC_NDP_MSG_RTR_ADV_RETRANS, iface);
+        gnrc_ipv6_set_timer(&iface->rtr_adv_timer, interval * SEC_IN_USEC,
+                            &iface->rtr_adv_msg, GNRC_NDP_MSG_RTR_ADV_RETRANS,
+                            (char *) iface, gnrc_ipv6_pid);
     }
     mutex_unlock(&iface->mutex);
     for (int i = 0; i < GNRC_IPV6_NETIF_ADDR_NUMOF; i++) {

--- a/sys/net/gnrc/network_layer/sixlowpan/ctx/gnrc_sixlowpan_ctx.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/ctx/gnrc_sixlowpan_ctx.c
@@ -17,7 +17,7 @@
 
 #include "mutex.h"
 #include "net/gnrc/sixlowpan/ctx.h"
-#include "vtimer.h"
+#include "xtimer.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
@@ -133,7 +133,7 @@ gnrc_sixlowpan_ctx_t *gnrc_sixlowpan_ctx_update(uint8_t id, const ipv6_addr_t *p
 static uint32_t _current_minute(void)
 {
     timex_t now;
-    vtimer_now(&now);
+    xtimer_now_timex(&now);
     return now.seconds / 60;
 }
 

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -24,7 +24,6 @@
 #include "net/sixlowpan.h"
 #include "thread.h"
 #include "timex.h"
-#include "vtimer.h"
 #include "utlist.h"
 
 #define ENABLE_DEBUG    (0)
@@ -234,7 +233,7 @@ static void _rbuf_gc(void)
     timex_t now;
     unsigned int i;
 
-    vtimer_now(&now);
+    xtimer_now_timex(&now);
 
     for (i = 0; i < RBUF_SIZE; i++) {
         if (rbuf[i].pkt == NULL) { /* leave GC early if there is still room */
@@ -271,7 +270,7 @@ static rbuf_t *_rbuf_get(const void *src, size_t src_len,
     rbuf_t *res = NULL;
     timex_t now;
 
-    vtimer_now(&now);
+    xtimer_now_timex(&now);
 
     for (unsigned int i = 0; i < RBUF_SIZE; i++) {
         /* check first if entry already available */

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -355,9 +355,10 @@ uint8_t gnrc_sixlowpan_nd_opt_ar_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6,
                 nc_entry->flags |= GNRC_IPV6_NC_TYPE_REGISTERED;
                 reg_ltime = byteorder_ntohs(ar_opt->ltime);
                 /* TODO: notify routing protocol */
-                vtimer_remove(&nc_entry->type_timeout);
-                vtimer_set_msg(&nc_entry->type_timeout, timex_set(reg_ltime * 60, 0),
-                               gnrc_ipv6_pid, GNRC_SIXLOWPAN_ND_MSG_AR_TIMEOUT, nc_entry);
+                gnrc_ipv6_set_timer(&nc_entry->type_timeout, reg_ltime * 60 * SEC_IN_USEC,
+                                    &nc_entry->type_timeout_msg,
+                                    GNRC_SIXLOWPAN_ND_MSG_AR_TIMEOUT,
+                                    (char *) nc_entry, gnrc_ipv6_pid);
             }
             break;
 #endif

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -390,7 +390,7 @@ void gnrc_sixlowpan_nd_wakeup(void)
 {
     gnrc_ipv6_nc_t *router = gnrc_ipv6_nc_get_next_router(NULL);
     while (router) {
-        vtimer_remove(&router->rtr_sol_timer);
+        xtimer_remove(&router->rtr_sol_timer);
         gnrc_sixlowpan_nd_uc_rtr_sol(router);
         gnrc_ndp_internal_send_nbr_sol(router->iface, NULL, &router->ipv6_addr, &router->ipv6_addr);
         gnrc_ipv6_set_timer(&router->nbr_sol_timer, GNRC_NDP_RETRANS_TIMER,

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -29,9 +29,9 @@
 
 static inline void _rtr_sol_reschedule(gnrc_ipv6_netif_t *iface, uint32_t sec_delay)
 {
-    vtimer_remove(&iface->rtr_sol_timer);
-    vtimer_set_msg(&iface->rtr_sol_timer, timex_set(sec_delay, 0), gnrc_ipv6_pid,
-                   GNRC_SIXLOWPAN_ND_MSG_MC_RTR_SOL, iface);
+    gnrc_ipv6_set_timer(&iface->rtr_sol_timer, sec_delay * SEC_IN_USEC,
+                        &iface->rtr_sol_msg, GNRC_SIXLOWPAN_ND_MSG_MC_RTR_SOL,
+                        (char *) iface, gnrc_ipv6_pid);
 }
 
 static inline uint32_t _binary_exp_backoff(uint32_t base_sec, unsigned int exp)
@@ -226,9 +226,9 @@ void gnrc_sixlowpan_nd_rtr_sol_reschedule(gnrc_ipv6_nc_t *nce, uint32_t sec_dela
     assert(nce != NULL);
     assert(sec_delay != 0U);
     gnrc_ipv6_netif_t *iface = gnrc_ipv6_netif_get(nce->iface);
-    vtimer_remove(&iface->rtr_sol_timer);
-    vtimer_set_msg(&iface->rtr_sol_timer, timex_set(sec_delay, 0), gnrc_ipv6_pid,
-                   GNRC_SIXLOWPAN_ND_MSG_MC_RTR_SOL, iface);
+    gnrc_ipv6_set_timer(&iface->rtr_sol_timer, sec_delay * SEC_IN_USEC,
+                        &iface->rtr_sol_msg, GNRC_SIXLOWPAN_ND_MSG_MC_RTR_SOL,
+                        (char *) iface, gnrc_ipv6_pid);
 }
 
 gnrc_pktsnip_t *gnrc_sixlowpan_nd_opt_ar_build(uint8_t status, uint16_t ltime, eui64_t *eui64,

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/router/gnrc_sixlowpan_nd_router.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/router/gnrc_sixlowpan_nd_router.c
@@ -192,8 +192,6 @@ void gnrc_sixlowpan_nd_opt_abr_handle(kernel_pid_t iface, ndp_rtr_adv_t *rtr_adv
     uint16_t opt_offset = 0;
     uint8_t *buf = (uint8_t *)(rtr_adv + 1);
     gnrc_sixlowpan_nd_router_abr_t *abr;
-    timex_t t = { 0, 0 };
-
     if (_is_me(&abr_opt->braddr)) {
         return;
     }
@@ -239,10 +237,9 @@ void gnrc_sixlowpan_nd_opt_abr_handle(kernel_pid_t iface, ndp_rtr_adv_t *rtr_adv
     memset(abr->ctxs, 0, sizeof(abr->ctxs));
     abr->prfs = NULL;
 
-    t.seconds = abr->ltime * 60;
-
-    vtimer_set_msg(&abr->ltimer, t, gnrc_ipv6_pid,
-                   GNRC_SIXLOWPAN_ND_MSG_ABR_TIMEOUT, abr);
+    gnrc_ipv6_set_timer(&abr->ltimer, abr->ltime * 60 * SEC_IN_USEC,
+                        &abr->ltimer_msg, GNRC_SIXLOWPAN_ND_MSG_ABR_TIMEOUT,
+                        (char *) abr, gnrc_ipv6_pid);
 }
 
 gnrc_pktsnip_t *gnrc_sixlowpan_nd_opt_6ctx_build(uint8_t prefix_len, uint8_t flags, uint16_t ltime,


### PR DESCRIPTION
This PR replaces some vtimer calls by xtimer calls in `gnrc_ipv6`