### PR TITLE
nc: remove unused rtr_sol_timer

### DIFF
--- a/sys/include/net/gnrc/ipv6/nc.h
+++ b/sys/include/net/gnrc/ipv6/nc.h
@@ -146,9 +146,6 @@ typedef struct {
      */
     vtimer_t nbr_adv_timer;
 
-#ifdef MODULE_GNRC_SIXLOWPAN_ND
-    vtimer_t rtr_sol_timer; /**< Retransmission timer for unicast router solicitations */
-#endif
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
     vtimer_t type_timeout;                  /**< Timer for type transissions */
     eui64_t eui64;                          /**< the unique EUI-64 of the neighbor (might be

--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -146,9 +146,6 @@ void gnrc_ipv6_nc_remove(kernel_pid_t iface, const ipv6_addr_t *ipv6_addr)
             gnrc_pktqueue_remove_head(&entry->pkts);
         }
 #endif
-#ifdef MODULE_GNRC_SIXLOWPAN_ND
-        vtimer_remove(&entry->rtr_sol_timer);
-#endif
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
         vtimer_remove(&entry->type_timeout);
 #endif

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -390,7 +390,6 @@ void gnrc_sixlowpan_nd_wakeup(void)
     gnrc_ipv6_nc_t *router = gnrc_ipv6_nc_get_next_router(NULL);
     while (router) {
         timex_t t = { 0, GNRC_NDP_RETRANS_TIMER };
-        vtimer_remove(&router->rtr_sol_timer);
         gnrc_sixlowpan_nd_uc_rtr_sol(router);
         gnrc_ndp_internal_send_nbr_sol(router->iface, NULL, &router->ipv6_addr, &router->ipv6_addr);
         vtimer_remove(&router->nbr_sol_timer);


### PR DESCRIPTION
`gnrc_ipv6_nc_t` has a member called `rtr_sol_timer`. But this timer isn't really used anywhere and since `gnrc_ipv6_netif_t` has a timer with the same name I believe it may have been superseded some time ago with that one. @authmillenon ?