### PR TITLE
nc: use xtimer for gnrc_ipv6_nc_t::type_timeout

### DIFF
--- a/sys/include/net/gnrc/ipv6/nc.h
+++ b/sys/include/net/gnrc/ipv6/nc.h
@@ -30,6 +30,7 @@
 #include "net/gnrc/netif.h"
 #include "net/gnrc/pktqueue.h"
 #include "vtimer.h"
+#include "xtimer.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -147,7 +148,8 @@ typedef struct {
     vtimer_t nbr_adv_timer;
 
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
-    vtimer_t type_timeout;                  /**< Timer for type transmissions */
+    xtimer_t type_timeout;                  /**< Timer for type transmissions */
+    msg_t type_timeout_msg;                 /**< msg_t for gnrc_ipv6_nc_t::type_timeout */
     eui64_t eui64;                          /**< the unique EUI-64 of the neighbor (might be
                                              *   different from L2 address, if l2_addr_len == 2) */
 #endif

--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -21,6 +21,7 @@
 #include "net/gnrc/ipv6/netif.h"
 #include "net/gnrc/ndp.h"
 #include "net/gnrc/pktbuf.h"
+#include "net/gnrc/sixlowpan/nd.h"
 #include "thread.h"
 #include "timex.h"
 #include "vtimer.h"
@@ -127,6 +128,11 @@ gnrc_ipv6_nc_t *gnrc_ipv6_nc_add(kernel_pid_t iface, const ipv6_addr_t *ipv6_add
         free_entry->probes_remaining = GNRC_NDP_MAX_MC_NBR_SOL_NUMOF;
     }
 
+#ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
+    free_entry->type_timeout_msg.type = GNRC_SIXLOWPAN_ND_MSG_AR_TIMEOUT;
+    free_entry->type_timeout_msg.content.ptr = (char *) free_entry;
+#endif
+
     return free_entry;
 }
 
@@ -147,7 +153,7 @@ void gnrc_ipv6_nc_remove(kernel_pid_t iface, const ipv6_addr_t *ipv6_addr)
         }
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
-        vtimer_remove(&entry->type_timeout);
+        xtimer_remove(&entry->type_timeout);
 #endif
 
         ipv6_addr_set_unspecified(&(entry->ipv6_addr));

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -59,14 +59,14 @@ static void _stale_nc(kernel_pid_t iface, ipv6_addr_t *ipaddr, uint8_t *l2addr,
             gnrc_ipv6_netif_t *ipv6_iface = gnrc_ipv6_netif_get(iface);
             if ((ipv6_iface->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN) &&
                 (ipv6_iface->flags & GNRC_IPV6_NETIF_FLAGS_ROUTER)) {
-                timex_t t = { GNRC_SIXLOWPAN_ND_TENTATIVE_NCE_LIFETIME, 0 };
                 if ((nc_entry = gnrc_ipv6_nc_add(iface, ipaddr, l2addr,
                                                  (uint16_t)l2addr_len,
                                                  GNRC_IPV6_NC_STATE_STALE |
                                                  GNRC_IPV6_NC_TYPE_TENTATIVE)) != NULL) {
-                    vtimer_remove(&nc_entry->type_timeout);
-                    vtimer_set_msg(&nc_entry->type_timeout, t, gnrc_ipv6_pid,
-                                   GNRC_SIXLOWPAN_ND_MSG_AR_TIMEOUT, nc_entry);
+                    xtimer_set_msg(&nc_entry->type_timeout,
+                                   (GNRC_SIXLOWPAN_ND_TENTATIVE_NCE_LIFETIME * SEC_IN_USEC),
+                                   &nc_entry->type_timeout_msg,
+                                   gnrc_ipv6_pid);
                 }
                 return;
             }

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -354,9 +354,8 @@ uint8_t gnrc_sixlowpan_nd_opt_ar_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6,
                 nc_entry->flags |= GNRC_IPV6_NC_TYPE_REGISTERED;
                 reg_ltime = byteorder_ntohs(ar_opt->ltime);
                 /* TODO: notify routing protocol */
-                vtimer_remove(&nc_entry->type_timeout);
-                vtimer_set_msg(&nc_entry->type_timeout, timex_set(reg_ltime * 60, 0),
-                               gnrc_ipv6_pid, GNRC_SIXLOWPAN_ND_MSG_AR_TIMEOUT, nc_entry);
+                xtimer_set_msg(&nc_entry->type_timeout, (reg_ltime * 60 * SEC_IN_USEC),
+                               &nc_entry->type_timeout_msg, gnrc_ipv6_pid);
             }
             break;
 #endif


### PR DESCRIPTION
replaces vtimer by xtimer for `gnrc_ipv6_nc_t::type_timeout`  (simplified version of #4116, better to maintain)