### PR TITLE
nc: use xtimer for gnrc_ipv6_nc_t::nbr_adv_timer

### DIFF
--- a/sys/include/net/gnrc/ipv6/nc.h
+++ b/sys/include/net/gnrc/ipv6/nc.h
@@ -146,7 +146,8 @@ typedef struct {
      *          RFC 4861, section 7.2.7
      *      </a>
      */
-    vtimer_t nbr_adv_timer;
+    xtimer_t nbr_adv_timer;
+    msg_t nbr_adv_msg;                          /**< msg_t for gnrc_ipv6_nc_t::nbr_adv_timer */
 
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
     xtimer_t type_timeout;                  /**< Timer for type transmissions */


### PR DESCRIPTION
replaces vtimer by xtimer for gnrc_ipv6_nc_t::nbr_adv_timer (simplified version of #4116, better to maintain)