### PR TITLE
nc: user xtimer for gnrc_ipv6_nc_t::rtr_timeout

### DIFF
--- a/sys/include/net/gnrc/ipv6/nc.h
+++ b/sys/include/net/gnrc/ipv6/nc.h
@@ -128,7 +128,8 @@ typedef struct {
     uint8_t l2_addr_len;                        /**< Length of gnrc_ipv6_nc_t::l2_addr */
     uint8_t flags;                              /**< Flags as defined above */
     kernel_pid_t iface;                         /**< PID to the interface where the neighbor is */
-    vtimer_t rtr_timeout;                       /**< timeout timer for router flag */
+    xtimer_t rtr_timeout;                       /**< timeout timer for router flag */
+    msg_t rtr_timeout_msg;                      /**< msg_t for gnrc_ipv6_nc_t::rtr_timeout */
 
     /**
      * @brief (Re)Transmission timer for neighbor solicitations of this entry and

--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -133,6 +133,9 @@ gnrc_ipv6_nc_t *gnrc_ipv6_nc_add(kernel_pid_t iface, const ipv6_addr_t *ipv6_add
     free_entry->type_timeout_msg.content.ptr = (char *) free_entry;
 #endif
 
+    free_entry->rtr_timeout_msg.type = GNRC_NDP_MSG_RTR_TIMEOUT;
+    free_entry->rtr_timeout_msg.content.ptr = (char *) free_entry;
+
     return free_entry;
 }
 

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -518,9 +518,8 @@ void gnrc_ndp_rtr_adv_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt, ipv6_hdr_t
 #ifdef MODULE_GNRC_SIXLOWPAN_ND
         next_rtr_sol = ltime;
 #endif
-        vtimer_remove(&nc_entry->rtr_timeout);
-        vtimer_set_msg(&nc_entry->rtr_timeout, timex_set(ltime, 0),
-                       thread_getpid(), GNRC_NDP_MSG_RTR_TIMEOUT, nc_entry);
+        xtimer_set_msg(&nc_entry->rtr_timeout, (ltime * SEC_IN_USEC),
+                       &nc_entry->rtr_timeout_msg, thread_getpid());
     }
     /* set current hop limit from message if available */
     if (rtr_adv->cur_hl != 0) {


### PR DESCRIPTION
replaces vtimer by xtimer for gnrc_ipv6_nc_t::rtr_timeout (simplified version of #4116, better to maintain)