### PR TITLE
netif: use xtimer for gnrc_ipv6_netif_addr_t::valid_timeout

### DIFF
--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -31,6 +31,7 @@
 #include "net/ipv6.h"
 #include "net/ipv6/addr.h"
 #include "vtimer.h"
+#include "xtimer.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -258,7 +259,8 @@ typedef struct {
     /**
      * @brief   Validity timeout timer.
      */
-    vtimer_t valid_timeout;
+    xtimer_t valid_timeout;
+    msg_t valid_timeout_msg;    /**< msg_t for gnrc_ipv6_netif_addr_t::valid_timeout */
     /**
      * @}
      */

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -151,6 +151,9 @@ static ipv6_addr_t *_add_addr_to_entry(gnrc_ipv6_netif_t *entry, const ipv6_addr
          *       source address. */
     }
 
+    tmp_addr->valid_timeout_msg.type = GNRC_NDP_MSG_ADDR_TIMEOUT;
+    tmp_addr->valid_timeout_msg.content.ptr = (char *) &tmp_addr->addr;
+
     return &(tmp_addr->addr);
 }
 

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -750,11 +750,10 @@ bool gnrc_ndp_internal_pi_opt_handle(kernel_pid_t iface, uint8_t icmpv6_type,
     }
     netif_addr->valid = byteorder_ntohl(pi_opt->valid_ltime);
     netif_addr->preferred = byteorder_ntohl(pi_opt->pref_ltime);
-    vtimer_remove(&netif_addr->valid_timeout);
     if (netif_addr->valid != UINT32_MAX) {
-        vtimer_set_msg(&netif_addr->valid_timeout,
-                       timex_set(byteorder_ntohl(pi_opt->valid_ltime), 0),
-                       thread_getpid(), GNRC_NDP_MSG_ADDR_TIMEOUT, &netif_addr->addr);
+        xtimer_set_msg(&netif_addr->valid_timeout,
+                       (byteorder_ntohl(pi_opt->valid_ltime) * SEC_IN_USEC),
+                       &netif_addr->valid_timeout_msg, thread_getpid());
     }
     /* TODO: preferred lifetime for address auto configuration */
     /* on-link flag MUST stay set if it was */


### PR DESCRIPTION
replaces vtimer by xtimer for gnrc_ipv6_netif_addr_t::valid_timeout (simplified version of #4116, better to maintain)