### PR TITLE
boards: cleaned up entries in Makefile.features

### DIFF
--- a/boards/airfy-beacon/Makefile.features
+++ b/boards/airfy-beacon/Makefile.features
@@ -1,10 +1,15 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += radio_nrfmin
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_random
 FEATURES_PROVIDED += periph_rtt
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += radio_nrfmin
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0

--- a/boards/arduino-due/Makefile.features
+++ b/boards/arduino-due/Makefile.features
@@ -1,8 +1,13 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm
-FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_random
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/arduino-mega2560/Makefile.features
+++ b/boards/arduino-mega2560/Makefile.features
@@ -1,4 +1,9 @@
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = avr8

--- a/boards/avsextrem/Makefile.features
+++ b/boards/avsextrem/Makefile.features
@@ -1,5 +1,10 @@
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
+
+# Various other features (if any)
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = arm7

--- a/boards/cc2538dk/Makefile.features
+++ b/boards/cc2538dk/Makefile.features
@@ -1,7 +1,12 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_random
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/chronos/Makefile.features
+++ b/boards/chronos/Makefile.features
@@ -1,3 +1,8 @@
-FEATURES_PROVIDED += periph_rtc
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_rtc
+
+# Various other features (if any)
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = msp430

--- a/boards/ek-lm4f120xl/Makefile.features
+++ b/boards/ek-lm4f120xl/Makefile.features
@@ -1,5 +1,10 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4

--- a/boards/f4vi1/Makefile.features
+++ b/boards/f4vi1/Makefile.features
@@ -1,4 +1,9 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4

--- a/boards/fox/Makefile.features
+++ b/boards/fox/Makefile.features
@@ -1,9 +1,14 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_uart
-FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
 FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/frdm-k64f/Makefile.features
+++ b/boards/frdm-k64f/Makefile.features
@@ -1,13 +1,18 @@
-FEATURES_PROVIDED += cpp
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_uart
-FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
-FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_rtt
-FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_random
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4

--- a/boards/iotlab-m3/Makefile.features
+++ b/boards/iotlab-m3/Makefile.features
@@ -1,9 +1,14 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_uart
-FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
 FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/limifrog-v1/Makefile.features
+++ b/boards/limifrog-v1/Makefile.features
@@ -1,8 +1,13 @@
-FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_uart
-FEATURES_PROVIDED += periph_spi
-FEATURES_PROVIDED += periph_i2c
-FEATURES_PROVIDED += periph_timer
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
 FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/mbed_lpc1768/Makefile.features
+++ b/boards/mbed_lpc1768/Makefile.features
@@ -1,4 +1,9 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/msb-430/Makefile.features
+++ b/boards/msb-430/Makefile.features
@@ -1,3 +1,8 @@
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
+
+# Various other features (if any)
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = msp430

--- a/boards/msb-430h/Makefile.features
+++ b/boards/msb-430h/Makefile.features
@@ -1,5 +1,10 @@
-FEATURES_PROVIDED += config
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
+
+# Various other features (if any)
+FEATURES_PROVIDED += config
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = msp430

--- a/boards/msba2/Makefile.features
+++ b/boards/msba2/Makefile.features
@@ -1,8 +1,13 @@
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
+
+# Various other features (if any)
 FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += config
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = arm7

--- a/boards/msbiot/Makefile.features
+++ b/boards/msbiot/Makefile.features
@@ -1,11 +1,16 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_random
-FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_dac
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4

--- a/boards/mulle/Makefile.features
+++ b/boards/mulle/Makefile.features
@@ -1,4 +1,4 @@
-FEATURES_PROVIDED += cpp
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
@@ -10,4 +10,9 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4

--- a/boards/native/Makefile.features
+++ b/boards/native/Makefile.features
@@ -1,8 +1,13 @@
-FEATURES_PROVIDED += ethernet
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += config
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += periph_random
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
+
+# Various other features (if any)
+FEATURES_PROVIDED += config
+FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += ethernet
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = x86

--- a/boards/nrf51dongle/Makefile.features
+++ b/boards/nrf51dongle/Makefile.features
@@ -1,9 +1,14 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += radio_nrfmin
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_random
 FEATURES_PROVIDED += periph_rtt
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += radio_nrfmin
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0

--- a/boards/nrf6310/Makefile.features
+++ b/boards/nrf6310/Makefile.features
@@ -1,10 +1,15 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += radio_nrfmin
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_random
 FEATURES_PROVIDED += periph_rtt
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += radio_nrfmin
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0

--- a/boards/nucleo-f091/Makefile.features
+++ b/boards/nucleo-f091/Makefile.features
@@ -1,7 +1,12 @@
-FEATURES_PROVIDED += cpp
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_rtc
-FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0

--- a/boards/nucleo-f303/Makefile.features
+++ b/boards/nucleo-f303/Makefile.features
@@ -1,9 +1,14 @@
-FEATURES_PROVIDED += cpp
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_pwm
-FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4

--- a/boards/nucleo-f334/Makefile.features
+++ b/boards/nucleo-f334/Makefile.features
@@ -1,7 +1,12 @@
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
 FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4

--- a/boards/nucleo-l1/Makefile.features
+++ b/boards/nucleo-l1/Makefile.features
@@ -1,8 +1,13 @@
-FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_uart
-FEATURES_PROVIDED += periph_spi
-FEATURES_PROVIDED += periph_i2c
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
 FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/openmote/Makefile.features
+++ b/boards/openmote/Makefile.features
@@ -1,7 +1,12 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_random
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/pba-d-01-kw2x/Makefile.features
+++ b/boards/pba-d-01-kw2x/Makefile.features
@@ -1,12 +1,17 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_uart
-FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
-FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_rtt
-FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_random
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4

--- a/boards/pca10000/Makefile.features
+++ b/boards/pca10000/Makefile.features
@@ -1,9 +1,14 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += radio_nrfmin
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_random
 FEATURES_PROVIDED += periph_rtt
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += radio_nrfmin
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0

--- a/boards/pca10005/Makefile.features
+++ b/boards/pca10005/Makefile.features
@@ -1,10 +1,15 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += radio_nrfmin
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_random
 FEATURES_PROVIDED += periph_rtt
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += radio_nrfmin
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0

--- a/boards/pttu/Makefile.features
+++ b/boards/pttu/Makefile.features
@@ -1,5 +1,10 @@
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
+
+# Various other features (if any)
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = arm7

--- a/boards/qemu-i386/Makefile.features
+++ b/boards/qemu-i386/Makefile.features
@@ -1,1 +1,6 @@
+# Put defined MCU peripherals here (in alphabetical order)
+
+# Various other features (if any)
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = x86

--- a/boards/remote/Makefile.features
+++ b/boards/remote/Makefile.features
@@ -1,7 +1,12 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_random
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/saml21-xpro/Makefile.features
+++ b/boards/saml21-xpro/Makefile.features
@@ -1,7 +1,12 @@
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_spi
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0

--- a/boards/samr21-xpro/Makefile.features
+++ b/boards/samr21-xpro/Makefile.features
@@ -1,13 +1,16 @@
-FEATURES_PROVIDED += cpp
-
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-FEATURES_PROVIDED += periph_i2c
-FEATURES_PROVIDED += periph_rtc
-FEATURES_PROVIDED += periph_rtt
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_pwm
 
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0

--- a/boards/spark-core/Makefile.features
+++ b/boards/spark-core/Makefile.features
@@ -1,5 +1,10 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/stm32f0discovery/Makefile.features
+++ b/boards/stm32f0discovery/Makefile.features
@@ -1,8 +1,13 @@
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_spi
-FEATURES_PROVIDED += periph_uart
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0

--- a/boards/stm32f3discovery/Makefile.features
+++ b/boards/stm32f3discovery/Makefile.features
@@ -1,9 +1,14 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart
-FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_pwm
-FEATURES_PROVIDED += periph_i2c
-FEATURES_PROVIDED += periph_spi
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4

--- a/boards/stm32f4discovery/Makefile.features
+++ b/boards/stm32f4discovery/Makefile.features
@@ -1,16 +1,21 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_random
-FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_dac
-FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4
 
+# TODO: re-think concept for conflicts based on actual used peripherals...
 FEATURES_CONFLICT += periph_spi:periph_dac
-
 FEATURES_CONFLICT_MSG += "On stm32f4discovery boards there are the same pins for the DAC and/or SPI_0."

--- a/boards/telosb/Makefile.features
+++ b/boards/telosb/Makefile.features
@@ -1,3 +1,8 @@
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
+
+# Various other features (if any)
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = msp430

--- a/boards/udoo/Makefile.features
+++ b/boards/udoo/Makefile.features
@@ -1,7 +1,12 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_random
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/weio/Makefile.features
+++ b/boards/weio/Makefile.features
@@ -1,9 +1,14 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += periph_uart
-FEATURES_PROVIDED += periph_spi
-FEATURES_PROVIDED += periph_timer
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0

--- a/boards/wsn430-v1_3b/Makefile.features
+++ b/boards/wsn430-v1_3b/Makefile.features
@@ -1,4 +1,9 @@
-FEATURES_PROVIDED += config
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
+
+# Various other features (if any)
+FEATURES_PROVIDED += config
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = msp430

--- a/boards/wsn430-v1_4/Makefile.features
+++ b/boards/wsn430-v1_4/Makefile.features
@@ -1,4 +1,9 @@
-FEATURES_PROVIDED += config
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
+
+# Various other features (if any)
+FEATURES_PROVIDED += config
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = msp430

--- a/boards/yunjia-nrf51822/Makefile.features
+++ b/boards/yunjia-nrf51822/Makefile.features
@@ -1,10 +1,15 @@
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += radio_nrfmin
-FEATURES_PROVIDED += periph_uart
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_random
 FEATURES_PROVIDED += periph_rtt
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += radio_nrfmin
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0

--- a/boards/z1/Makefile.features
+++ b/boards/z1/Makefile.features
@@ -1,4 +1,9 @@
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
+
+# Various other features (if any)
+
+# The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = msp430


### PR DESCRIPTION
Also taken partly from #3420

Having the periph features in (alphabetical) order makes it much simpler to quickly see if a certain feature is present...