### PR TITLE
periph/timer: Fix Doxygen module grouping

### DIFF
--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -37,7 +37,6 @@ extern "C" {
 #ifndef TIMER_DEV
 #define TIMER_DEV(x)        (x)
 #endif
-/** @} */
 
 /**
  * @brief   Default value for timer not defined


### PR DESCRIPTION
There was a stray Doxygen closing brace which messed up the module assignment