### PR TITLE
kinetis_common: use cortexm_common ldscript

### DIFF
--- a/cpu/k60/Makefile.include
+++ b/cpu/k60/Makefile.include
@@ -9,10 +9,6 @@ export KINETIS_COMMON = $(RIOTCPU)/kinetis_common/
 # CPU depends on the kinetis module, so include it
 include $(KINETIS_COMMON)Makefile.include
 
-export LINKFLAGS += -L$(RIOTCPU)/kinetis_common/ldscripts
-# define the linker script to use for this CPU
-export LINKERSCRIPT = $(CPU_MODEL).ld
-
 #export the CPU model and architecture
 MODEL = $(shell echo $(CPU_MODEL)|tr 'a-z' 'A-Z')
 export CFLAGS += -DCPU_MODEL_$(MODEL)

--- a/cpu/k60/ldscripts/K60DN256VLL10.ld
+++ b/cpu/k60/ldscripts/K60DN256VLL10.ld
@@ -5,8 +5,8 @@ MEMORY
 {
     vectors (rx)   : ORIGIN = 0x00000000,       LENGTH = 0x400
     flashsec (rx)  : ORIGIN = 0x00000400,       LENGTH = 0x10
-    flash (rx)     : ORIGIN = 0x00000410,       LENGTH = 256K - 0x410
-    sram (rwx)     : ORIGIN = 0x20000000 - 32K, LENGTH = 64K
+    rom (rx)       : ORIGIN = 0x00000410,       LENGTH = 256K - 0x410
+    ram (rwx)      : ORIGIN = 0x20000000 - 32K, LENGTH = 64K
 }
 
 INCLUDE kinetis.ld

--- a/cpu/k60/ldscripts/K60DN512VLL10.ld
+++ b/cpu/k60/ldscripts/K60DN512VLL10.ld
@@ -5,8 +5,8 @@ MEMORY
 {
     vectors (rx)   : ORIGIN = 0x00000000,       LENGTH = 0x400
     flashsec (rx)  : ORIGIN = 0x00000400,       LENGTH = 0x10
-    flash (rx)     : ORIGIN = 0x00000410,       LENGTH = 512K - 0x410
-    sram (rwx)     : ORIGIN = 0x20000000 - 64K, LENGTH = 128K
+    rom (rx)       : ORIGIN = 0x00000410,       LENGTH = 512K - 0x410
+    ram (rwx)      : ORIGIN = 0x20000000 - 64K, LENGTH = 128K
 }
 
 INCLUDE kinetis.ld

--- a/cpu/k64f/Makefile.include
+++ b/cpu/k64f/Makefile.include
@@ -9,8 +9,6 @@ export KINETIS_COMMON = $(RIOTCPU)/kinetis_common/
 # CPU depends on the kinetis module, so include it
 include $(KINETIS_COMMON)Makefile.include
 
-export LINKFLAGS += -L$(RIOTCPU)/kinetis_common/ldscripts
-
 #export the CPU model
 MODEL = $(shell echo $(CPU_MODEL)|tr 'a-z' 'A-Z')
 export CFLAGS += -DCPU_MODEL_$(MODEL)

--- a/cpu/k64f/ldscripts/mk64fn1m0vll12.ld
+++ b/cpu/k64f/ldscripts/mk64fn1m0vll12.ld
@@ -4,9 +4,9 @@ OUTPUT_ARCH(arm)
 MEMORY
 {
     vectors (rx) : ORIGIN = 0x00000000, LENGTH = 0x400
-    flashsec (rx) : ORIGIN = 0x00000400, LENGTH = 0x10
-    flash (rx)    : ORIGIN = 0x00000410, LENGTH = 1024K - 0x410
-    sram (rwx)   : ORIGIN = 0x1fff0198, LENGTH = 256K-0x198
+    flashsec (rx): ORIGIN = 0x00000400, LENGTH = 0x10
+    rom (rx)     : ORIGIN = 0x00000410, LENGTH = 1024K - 0x410
+    ram (rwx)    : ORIGIN = 0x1fff0198, LENGTH = 256K-0x198
 }
 
 INCLUDE kinetis.ld

--- a/cpu/kinetis_common/ldscripts/kinetis.ld
+++ b/cpu/kinetis_common/ldscripts/kinetis.ld
@@ -1,12 +1,24 @@
-/* RAM limits */
-__sram_start  = ORIGIN(sram);
-__sram_length = LENGTH(sram);
-__sram_end    = __sram_start + __sram_length;
+/*
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ * Copyright (C) 2015 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
 
-/* Define the default stack size for interrupt mode. */
-STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 2048;
-
-RAMVECT_SIZE = DEFINED(RAMVECT_SIZE) ? RAMVECT_SIZE : 0;
+/**
+ * @addtogroup      cpu_kinetis
+ * @{
+ *
+ * @file
+ * @brief           Sections definitions for the Freescale Kinetis MCUs
+ *
+ * @author          Johann Fischer <j.fischer@phytec.de>
+ * @author          Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
 
 SECTIONS
 {
@@ -31,220 +43,6 @@ SECTIONS
     ASSERT (SIZEOF(.fcfield) == 0x10, "Flash configuration field of invalid size (linker-script error?)")
     ASSERT (ADDR(.fcfield) == 0x400, "Flash configuration field at invalid position (linker-script error?)")
     ASSERT (LOADADDR(.fcfield) == 0x400, "Flash configuration field at invalid position (linker-script error?)")
-
-    /* Program code 0x410-. */
-    .text :
-    {
-        . = ALIGN(4);
-        _text_load = LOADADDR(.text);
-        _text_start = .;
-        /* preinit data */
-        PROVIDE_HIDDEN (__preinit_array_start = .);
-        KEEP(*(SORT(.preinit_array.*)))
-        KEEP(*(.preinit_array))
-        PROVIDE_HIDDEN (__preinit_array_end = .);
-        . = ALIGN(4);
-
-        /* init data */
-        PROVIDE_HIDDEN (__init_array_start = .);
-        KEEP(*(SORT(.init_array.*)))
-        KEEP(*(.init_array))
-        PROVIDE_HIDDEN (__init_array_end = .);
-        . = ALIGN(4);
-
-        /* fini data */
-        PROVIDE_HIDDEN (__fini_array_start = .);
-        KEEP(*(SORT(.fini_array.*)))
-        KEEP(*(.fini_array))
-        PROVIDE_HIDDEN (__fini_array_end = .);
-        . = ALIGN(4);
-
-        KEEP (*(SORT_NONE(.init)))
-        KEEP (*(SORT_NONE(.fini)))
-        /* Default ISR handlers */
-        KEEP(*(.default_handlers))
-        *(.text.unlikely .text.*_unlikely .text.unlikely.*)
-        *(.text.exit .text.exit.*)
-        *(.text.startup .text.startup.*)
-        *(.text.hot .text.hot.*)
-        *(.text .stub .text.* .gnu.linkonce.t.*)
-
-        /* gcc uses crtbegin.o to find the start of
-           the constructors, so we make sure it is
-           first.  Because this is a wildcard, it
-           doesn't matter if the user does not
-           actually link against crtbegin.o; the
-           linker won't look for a file to match a
-           wildcard.  The wildcard also means that it
-           doesn't matter which directory crtbegin.o
-           is in.  */
-        KEEP (*crtbegin.o(.ctors))
-        KEEP (*crtbegin?.o(.ctors))
-        KEEP (*crtbeginTS.o(.ctors))
-        /* We don't want to include the .ctor section from
-           the crtend.o file until after the sorted ctors.
-           The .ctor section from the crtend file contains the
-           end of ctors marker and it must be last */
-        KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .ctors))
-        KEEP (*(SORT(.ctors.*)))
-        KEEP (*(.ctors))
-
-        KEEP (*crtbegin.o(.dtors))
-        KEEP (*crtbegin?.o(.dtors))
-        KEEP (*crtbeginTS.o(.dtors))
-        KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .dtors))
-        KEEP (*(SORT(.dtors.*)))
-        KEEP (*(.dtors))
-        . = ALIGN(4);
-        _rodata_start = .;
-        *(.rodata .rodata* .gnu.linkonce.r.*)
-        . = ALIGN(4);
-        _rodata_end = .;
-        _text_end = .;
-    } > flash
-
-    /* The .extab, .exidx sections are used for C++ exception handling */
-    .ARM.extab :
-    {
-        *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } > flash
-
-    PROVIDE_HIDDEN (__exidx_start = .);
-    .ARM.exidx :
-    {
-        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
-    } > flash
-    PROVIDE_HIDDEN (__exidx_end = .);
-
-    .eh_frame_hdr :
-    {
-        *(.eh_frame_hdr)
-    } > flash
-
-    .eh_frame : ONLY_IF_RO
-    {
-        KEEP (*(.eh_frame))
-    } > flash
-
-    .gcc_except_table : ONLY_IF_RO
-    {
-        *(.gcc_except_table .gcc_except_table.*)
-    } > flash
-
-    . = ALIGN(4);
-    _etext = .;
-
-    /*
-     * Allocate space for interrupt vector in RAM
-     */
-    .ramvect :
-    {
-        . = ALIGN(1024);
-        _vector_ram_start = .;
-        . = _vector_ram_start + RAMVECT_SIZE;
-        . = ALIGN(4);
-        _vector_ram_end = .;
-    } > sram
-
-    /* Program data, values stored in flash and loaded upon init. */
-    .relocate : AT (_etext)
-    {
-        . = ALIGN(4);
-        _data_load  = LOADADDR(.relocate);
-        _data_start = .;
-        _srelocate = .;
-        *(.ramfunc .ramfunc.*);
-        *(.data .data.*);
-        . = ALIGN(4);
-        _erelocate = .;
-        _data_end = .;
-    } > sram
-
-    /* .bss section, zeroed out during init. */
-    .bss (NOLOAD) :
-    {
-        . = ALIGN(4);
-        _sbss = . ;
-        __bss_start = .;
-        _szero = .;
-        *(.bss .bss.*)
-        *(COMMON)
-        . = ALIGN(4);
-        _ebss = . ;
-        __bss_end = .;
-        _ezero = .;
-    } > sram
-
-    /* stack section */
-    .stack (NOLOAD):
-    {
-        . = ALIGN(8);
-        _sstack = .;
-        . = . + STACK_SIZE;
-        . = ALIGN(8);
-        _estack = .;
-    } > sram
-
-    /* heap section */
-    . = ALIGN(8);
-
-    /* end is used by newlib's default sbrk_r implementations to find the start
-     * of the heap */
-    _end = .;
-    __end = .;
-    __end__ = .;
-    PROVIDE(end = .);
-
-    /* _sheap and _eheap is used by RIOT's sbrk_r implementation */
-    _sheap = . ;
-    _eheap = ORIGIN(sram) + LENGTH(sram);
-
-    /* Populate information abour ram size */
-    _sram = ORIGIN(sram);
-    _eram = ORIGIN(sram) + LENGTH(sram);
-
-    /* Any debugging sections */
-    /* Stabs debugging sections.  */
-    .stab          0 : { *(.stab) }
-    .stabstr       0 : { *(.stabstr) }
-    .stab.excl     0 : { *(.stab.excl) }
-    .stab.exclstr  0 : { *(.stab.exclstr) }
-    .stab.index    0 : { *(.stab.index) }
-    .stab.indexstr 0 : { *(.stab.indexstr) }
-    .comment       0 : { *(.comment) }
-    /* DWARF debug sections.
-       Symbols in the DWARF debugging sections are relative to the beginning
-       of the section so we begin them at 0.  */
-    /* DWARF 1 */
-    .debug          0 : { *(.debug) }
-    .line           0 : { *(.line) }
-    /* GNU DWARF 1 extensions */
-    .debug_srcinfo  0 : { *(.debug_srcinfo) }
-    .debug_sfnames  0 : { *(.debug_sfnames) }
-    /* DWARF 1.1 and DWARF 2 */
-    .debug_aranges  0 : { *(.debug_aranges) }
-    .debug_pubnames 0 : { *(.debug_pubnames) }
-    /* DWARF 2 */
-    .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
-    .debug_abbrev   0 : { *(.debug_abbrev) }
-    .debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end ) }
-    .debug_frame    0 : { *(.debug_frame) }
-    .debug_str      0 : { *(.debug_str) }
-    .debug_loc      0 : { *(.debug_loc) }
-    .debug_macinfo  0 : { *(.debug_macinfo) }
-    /* SGI/MIPS DWARF 2 extensions */
-    .debug_weaknames 0 : { *(.debug_weaknames) }
-    .debug_funcnames 0 : { *(.debug_funcnames) }
-    .debug_typenames 0 : { *(.debug_typenames) }
-    .debug_varnames  0 : { *(.debug_varnames) }
-    /* DWARF 3 */
-    .debug_pubtypes 0 : { *(.debug_pubtypes) }
-    .debug_ranges   0 : { *(.debug_ranges) }
-    /* DWARF Extension.  */
-    .debug_macro    0 : { *(.debug_macro) }
-
-    /* XXX: what is the purpose of these sections? */
-    .ARM.attributes 0 : { KEEP (*(.ARM.attributes)) KEEP (*(.gnu.attributes)) }
-    .note.gnu.arm.ident 0 : { KEEP (*(.note.gnu.arm.ident)) }
-    /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }
 }
+
+INCLUDE cortexm_base.ld

--- a/cpu/kw2x/Makefile.include
+++ b/cpu/kw2x/Makefile.include
@@ -9,10 +9,6 @@ export KINETIS_COMMON = $(RIOTCPU)/kinetis_common/
 # CPU depends on the kinetis module, so include it
 include $(KINETIS_COMMON)Makefile.include
 
-export LINKFLAGS += -L$(RIOTCPU)/kinetis_common/ldscripts
-# define the linker script to use for this CPU
-export LINKERSCRIPT = $(CPU_MODEL).ld
-
 #export the CPU model
 MODEL = $(shell echo $(CPU_MODEL)|tr 'a-z' 'A-Z')
 export CFLAGS += -DCPU_MODEL_$(MODEL)

--- a/cpu/kw2x/ldscripts/kw21d256.ld
+++ b/cpu/kw2x/ldscripts/kw21d256.ld
@@ -4,9 +4,9 @@ OUTPUT_ARCH(arm)
 MEMORY
 {
     vectors (rx) : ORIGIN = 0x00000000, LENGTH = 0x400
-    flashsec (rx) : ORIGIN = 0x00000400, LENGTH = 0x10
-    flash (rx)    : ORIGIN = 0x00000410, LENGTH = 256K - 0x410
-    sram (rwx)   : ORIGIN = 0x1fffc000, LENGTH = 32K
+    flashsec (rx): ORIGIN = 0x00000400, LENGTH = 0x10
+    rom (rx)     : ORIGIN = 0x00000410, LENGTH = 256K - 0x410
+    ram (rwx)    : ORIGIN = 0x1fffc000, LENGTH = 32K
 }
 
 INCLUDE kinetis.ld

--- a/cpu/kw2x/ldscripts/kw21d512.ld
+++ b/cpu/kw2x/ldscripts/kw21d512.ld
@@ -4,9 +4,9 @@ OUTPUT_ARCH(arm)
 MEMORY
 {
     vectors (rx) : ORIGIN = 0x00000000, LENGTH = 0x400
-    flashsec (rx) : ORIGIN = 0x00000400, LENGTH = 0x10
-    flash (rx)    : ORIGIN = 0x00000410, LENGTH = 512K - 0x410
-    sram (rwx)   : ORIGIN = 0x1fff8000, LENGTH = 64K
+    flashsec (rx): ORIGIN = 0x00000400, LENGTH = 0x10
+    rom (rx)     : ORIGIN = 0x00000410, LENGTH = 512K - 0x410
+    ram (rwx)    : ORIGIN = 0x1fff8000, LENGTH = 64K
 }
 
 INCLUDE kinetis.ld

--- a/cpu/kw2x/ldscripts/kw22d512.ld
+++ b/cpu/kw2x/ldscripts/kw22d512.ld
@@ -4,9 +4,9 @@ OUTPUT_ARCH(arm)
 MEMORY
 {
     vectors (rx) : ORIGIN = 0x00000000, LENGTH = 0x400
-    flashsec (rx) : ORIGIN = 0x00000400, LENGTH = 0x10
-    flash (rx)    : ORIGIN = 0x00000410, LENGTH = 512K - 0x410
-    sram (rwx)   : ORIGIN = 0x1fff8000, LENGTH = 64K
+    flashsec (rx): ORIGIN = 0x00000400, LENGTH = 0x10
+    rom (rx)     : ORIGIN = 0x00000410, LENGTH = 512K - 0x410
+    ram (rwx)    : ORIGIN = 0x1fff8000, LENGTH = 64K
 }
 
 INCLUDE kinetis.ld


### PR DESCRIPTION
kinetis.ld includes cortexm_common ldscript, the fields for the
isr vectors and fcfield remain in kinetis.ld.