### PR TITLE
mulle: Initialize xtimer early to support nvram usage in board_init

### DIFF
--- a/boards/mulle/board.c
+++ b/boards/mulle/board.c
@@ -28,6 +28,7 @@
 #include "periph/rtt.h"
 #include "periph/spi.h"
 #include "nvram-spi.h"
+#include "xtimer.h"
 
 static nvram_t mulle_nvram_dev;
 nvram_t *mulle_nvram = &mulle_nvram_dev;
@@ -119,6 +120,9 @@ void board_init(void)
     cpu_init();
 
     LED_YELLOW_ON;
+
+    /* NVRAM requires xtimer for timing */
+    xtimer_init();
 
     /* Initialize NVRAM */
     status = mulle_nvram_init();


### PR DESCRIPTION
xtimer_init is normally run by auto_init, but that runs after board_init and we want to use nvram_spi inside board_init. _Mulle is currently broken in master_, error introduced by me in #3485 (there used to be a hwtimer_init inside board_init before, but it went away during some rebase)

Tested working on mulle.