### PR TITLE
cpu/cortexm_common: only set naked attribute on DEVELHELP hardfault handler

### DIFF
--- a/cpu/cortexm_common/include/vectors_cortexm.h
+++ b/cpu/cortexm_common/include/vectors_cortexm.h
@@ -62,7 +62,7 @@ void nmi_default(void);
  * causes of hard faults are access to un-aligned pointers on Cortex-M0 CPUs
  * and calls of function pointers that are set to NULL.
  */
-void hard_fault_default(void) __attribute__((naked));
+void hard_fault_default(void);
 
 /* The following four exceptions are only present for Cortex-M3 and -M4 CPUs */
 #if defined(CPU_ARCH_CORTEX_M3) || defined(CPU_ARCH_CORTEX_M4) || \

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -232,15 +232,15 @@ __attribute__((used)) void hard_fault_handler(uint32_t* sp, uint32_t corrupted, 
         puts("\nContext before hardfault:");
 
         /* TODO: printf in ISR context might be a bad idea */
-        printf("   r0: 0x%08lx\n"
-               "   r1: 0x%08lx\n"
-               "   r2: 0x%08lx\n"
-               "   r3: 0x%08lx\n",
+        printf("   r0: 0x%08" PRIx32 "\n"
+               "   r1: 0x%08" PRIx32 "\n"
+               "   r2: 0x%08" PRIx32 "\n"
+               "   r3: 0x%08" PRIx32 "\n",
                r0, r1, r2, r3);
-        printf("  r12: 0x%08lx\n"
-               "   lr: 0x%08lx\n"
-               "   pc: 0x%08lx\n"
-               "  psr: 0x%08lx\n\n",
+        printf("  r12: 0x%08" PRIx32 "\n"
+               "   lr: 0x%08" PRIx32 "\n"
+               "   pc: 0x%08" PRIx32 "\n"
+               "  psr: 0x%08" PRIx32 "\n\n",
                r12, lr, pc, psr);
 #if CPU_HAS_EXTENDED_FAULT_REGISTERS
         puts("FSR/FAR:");
@@ -260,7 +260,7 @@ __attribute__((used)) void hard_fault_handler(uint32_t* sp, uint32_t corrupted, 
         puts("Misc");
         printf("EXC_RET: 0x%08" PRIx32 "\n", exc_return);
         puts("Attempting to reconstruct state for debugging...");
-        printf("In GDB:\n  set $pc=0x%lx\n  frame 0\n  bt\n", pc);
+        printf("In GDB:\n  set $pc=0x%" PRIx32 "\n  frame 0\n  bt\n", pc);
         int stack_left = _stack_size_left(HARDFAULT_HANDLER_REQUIRED_STACK_SPACE);
         if(stack_left < 0) {
             printf("\nISR stack overflowed by at least %d bytes.\n", (-1 * stack_left));

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -134,7 +134,7 @@ static inline int _stack_size_left(uint32_t required)
 }
 
 /* Trampoline function to save stack pointer before calling hard fault handler */
-void hard_fault_default(void)
+__attribute__((naked)) void hard_fault_default(void)
 {
     /* Get stack pointer where exception stack frame lies */
     __ASM volatile


### PR DESCRIPTION
Fixes error on LLVM/Clang (build with `make TOOLCHAIN=llvm`)

    cpu/cortexm_common/vectors_cortexm.c:287:5: error: non-ASM statement in naked function is not supported
        core_panic(PANIC_HARD_FAULT, "HARD FAULT HANDLER");
        ^
    cpu/cortexm_common/include/vectors_cortexm.h:65:46: note: attribute is here
    void hard_fault_default(void) __attribute__((naked));
                                                 ^
    1 error generated.