### PR TITLE
Add a netopt for getting and setting CCA threshold

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -17,6 +17,7 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Baptiste Clenet <bapclenet@gmail.com>
  * @author      Daniel Krebs <github@daniel-krebs.net>
+ * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
  *
  * @}
  */
@@ -308,6 +309,31 @@ void at86rf2xx_set_csma_seed(at86rf2xx_t *dev, uint8_t entropy[2])
     tmp &= ~(AT86RF2XX_CSMA_SEED_1__CSMA_SEED_1);
     tmp |= entropy[1] & AT86RF2XX_CSMA_SEED_1__CSMA_SEED_1;
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__CSMA_SEED_1, tmp);
+}
+
+int8_t at86rf2xx_get_cca_threshold(at86rf2xx_t *dev)
+{
+    int8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__CCA_THRES);
+    tmp &= AT86RF2XX_CCA_THRES_MASK__CCA_ED_THRES;
+    tmp <<= 1;
+    return (RSSI_BASE_VAL + tmp);
+}
+
+void at86rf2xx_set_cca_threshold(at86rf2xx_t *dev, int8_t value)
+{
+    /* ensure the given value is negative, since a CCA threshold > 0 is
+       just impossible: thus, any positive value given is considered
+       to be the absolute value of the actually wanted threshold */
+    if (value > 0) {
+        value = -value;
+    }
+    /* transform the dBm value in the form
+       that will fit in the AT86RF2XX_REG__CCA_THRES register */
+    value -= RSSI_BASE_VAL;
+    value >>= 1;
+    value &= AT86RF2XX_CCA_THRES_MASK__CCA_ED_THRES;
+    value |= AT86RF2XX_CCA_THRES_MASK__RSVD_HI_NIBBLE;
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__CCA_THRES, value);
 }
 
 void at86rf2xx_set_option(at86rf2xx_t *dev, uint16_t option, bool state)

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -15,6 +15,7 @@
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
  *
  * @}
  */
@@ -569,6 +570,15 @@ static int _get(gnrc_netdev_t *device, netopt_t opt, void *val, size_t max_len)
             }
             break;
 
+        case NETOPT_CCA_THRESHOLD:
+            if (max_len < sizeof(int8_t)) {
+                res = -EOVERFLOW;
+            } else {
+                *((int8_t *)val) = at86rf2xx_get_cca_threshold(dev);
+                res = sizeof(int8_t);
+            }
+            break;
+
         default:
             res = -ENOTSUP;
     }
@@ -759,6 +769,15 @@ static int _set(gnrc_netdev_t *device, netopt_t opt, void *val, size_t len)
             } else {
                 at86rf2xx_set_csma_max_retries(dev, *((uint8_t *)val));
                 res = sizeof(uint8_t);
+            }
+            break;
+
+        case NETOPT_CCA_THRESHOLD:
+            if (len > sizeof(int8_t)) {
+                res = -EOVERFLOW;
+            } else {
+                at86rf2xx_set_cca_threshold(dev, *((int8_t *)val));
+                res = sizeof(int8_t);
             }
             break;
 

--- a/drivers/at86rf2xx/include/at86rf2xx_registers.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_registers.h
@@ -18,6 +18,7 @@
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
  */
 
 #ifndef AT86RF2XX_REGISTERS_H_
@@ -239,6 +240,15 @@ extern "C" {
 #define AT86RF2XX_PHY_CC_CCA_MASK__CHANNEL                      (0x1F)
 
 #define AT86RF2XX_PHY_CC_CCA_DEFAULT__CCA_MODE                  (0x20)
+/** @} */
+
+/**
+ * @brief   Bitfield definitions for the CCA_THRES register
+ * @{
+ */
+#define AT86RF2XX_CCA_THRES_MASK__CCA_ED_THRES                  (0x0F)
+
+#define AT86RF2XX_CCA_THRES_MASK__RSVD_HI_NIBBLE                (0xC0)
 /** @} */
 
 /**

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -22,6 +22,7 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Daniel Krebs <github@daniel-krebs.net>
+ * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
  */
 
 #ifndef AT86RF2XX_H_
@@ -79,6 +80,11 @@ extern "C" {
  * @brief   Default TX power (0dBm)
  */
 #define AT86RF2XX_DEFAULT_TXPOWER       (0U)
+
+/**
+ * @brief   Base (minimal) RSSI value in dBm
+ */
+#define RSSI_BASE_VAL                   (-91)
 
 /**
  * @brief   Flags for device internal states (see datasheet)
@@ -376,6 +382,23 @@ void at86rf2xx_set_csma_backoff_exp(at86rf2xx_t *dev, uint8_t min, uint8_t max);
  * @param[in] entropy       11 bit of entropy as seed for random backoff
  */
 void at86rf2xx_set_csma_seed(at86rf2xx_t *dev, uint8_t entropy[2]);
+
+/**
+ * @brief   Get the CCA threshold value
+ *
+ * @param[in] dev           device to read value from
+ *
+ * @return                  the current CCA threshold value
+ */
+int8_t at86rf2xx_get_cca_threshold(at86rf2xx_t *dev);
+
+/**
+ * @brief   Set the CCA threshold value
+ *
+ * @param[in] dev           device to write to
+ * @param[in] value         the new CCA threshold value
+ */
+void at86rf2xx_set_cca_threshold(at86rf2xx_t *dev, int8_t value);
 
 /**
  * @brief   Enable or disable driver specific options

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -182,6 +182,23 @@ typedef enum {
      */
     NETOPT_CHANNEL_PAGE,
 
+    /**
+     * @brief get/set the CCA threshold for the radio transceiver
+     *
+     * This is the value, in dBm, that the radio transceiver uses to decide
+     * if the channel is clear or not (CCA). If the current signal strength
+     * (RSSI/ED) is stronger than this CCA threshold value, the transceiver
+     * usually considers that the radio medium is busy. Otherwise, i.e.
+     * if RSSI/ED value is less than the CCA threshold value, the radio
+     * medium is supposed to be free (the possibly received weak signal
+     * is considered to be background, meaningless noise).
+     *
+     * Most transceivers allow to set this CCA threshold value.
+     * Some research work has proven that dynamically adapting it
+     * to network environment can improve QoS, especially in WSN.
+     */
+    NETOPT_CCA_THRESHOLD,
+
     /* add more options if needed */
 
     /**

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -51,6 +51,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_IS_WIRED]        = "NETOPT_IS_WIRED",
     [NETOPT_DEVICE_TYPE]     = "NETOPT_DEVICE_TYPE",
     [NETOPT_CHANNEL_PAGE]    = "NETOPT_CHANNEL_PAGE",
+    [NETOPT_CCA_THRESHOLD]   = "NETOPT_CCA_THRESHOLD",
     [NETOPT_NUMOF]           = "NETOPT_NUMOF",
 };
 

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -82,6 +82,7 @@ static void _set_usage(char *cmd_name)
          "       * \"channel\" - sets the frequency channel\n"
          "       * \"chan\" - alias for \"channel\"\n"
          "       * \"csma_retries\" - set max. number of channel access attempts\n"
+         "       * \"cca_threshold\" - set ED threshold during CCA in dBm\n"
          "       * \"nid\" - sets the network identifier (or the PAN ID)\n"
          "       * \"page\" - set the channel page (IEEE 802.15.4)\n"
          "       * \"pan\" - alias for \"nid\"\n"
@@ -103,7 +104,7 @@ static void _hl_usage(char *cmd_name)
 
 static void _flag_usage(char *cmd_name)
 {
-    printf("usage: %s <if_id> [-]{promisc|autoack|csma|autocca|preload|iphc|rtr_adv}\n", cmd_name);
+    printf("usage: %s <if_id> [-]{promisc|autoack|csma|autocca|cca_threshold|preload|iphc|rtr_adv}\n", cmd_name);
 }
 
 static void _add_usage(char *cmd_name)
@@ -151,6 +152,10 @@ static void _print_netopt(netopt_t opt)
 
         case NETOPT_CSMA_RETRIES:
             printf("CSMA retries");
+            break;
+
+        case NETOPT_CCA_THRESHOLD:
+            printf("CCA threshold [in dBm]");
             break;
 
         default:
@@ -583,6 +588,9 @@ static int _netif_set(char *cmd_name, kernel_pid_t dev, char *key, char *value)
     }
     else if (strcmp("csma_retries", key) == 0) {
         return _netif_set_u8(dev, NETOPT_CSMA_RETRIES, value);
+    }
+    else if (strcmp("cca_threshold", key) == 0) {
+        return _netif_set_u8(dev, NETOPT_CCA_THRESHOLD, value);
     }
 
     _set_usage(cmd_name);


### PR DESCRIPTION
Add a new `NETOPT_CCA_THRESHOLD` option to the `netopt_t` list, so as to allow getting/setting the CCA threshold value used by a radio transceiver.

CCA threshold is the value, in dBm, that the radio transceiver uses to decide if the channel is clear or not (CCA). If the current signal strength (RSSI/ED) is stronger than this CCA threshold value, the transceiver usually considers that the radio medium is busy. Otherwise, i.e. if RSSI/ED value is less than the CCA threshold value, the radio medium is supposed to be free (the possibly received weak signal is considered to be background, meaningless noise).

Most transceivers allow to set this CCA threshold value. Some research work has proven that dynamically adapting it to network environment can improve QoS, especially in WSN.

An implementation for this `NETOPT_CCA_THRESHOLD` for *AT86RF2xx* radio driver is also provided. I could also implement it for the *CC2420* driver, but the latter is not back yet... I don't know other radio transceivers enough to implement the option for them.
