### PR TITLE
gitignore: add ctags index file and gdb initialization script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ cachegrind.out*
 *.kdev4
 # Codelite (among others) project files
 *.project
+# ctags index files
+tags
+# GDB initialization scripts
+.gdbinit
 
 # Eclipse symbol file (output from make eclipsesym)
 eclipsesym.xml


### PR DESCRIPTION
This PR adds ctags index and gdb initialization script files to gitignore.