### PR TITLE
ipv6: initialize iid

### DIFF
--- a/sys/include/net/ipv6/addr.h
+++ b/sys/include/net/ipv6/addr.h
@@ -471,6 +471,17 @@ uint8_t ipv6_addr_match_prefix(const ipv6_addr_t *a, const ipv6_addr_t *b);
 void ipv6_addr_init_prefix(ipv6_addr_t *out, const ipv6_addr_t *prefix, uint8_t bits);
 
 /**
+ * @brief   Sets the last @p bits of IPv6 address @p out to @p iid.
+ *          Leading bits of @p out stay untouched.
+ *
+ * @param[out]  out     IPv6 address to be set.
+ * @param[in]   iid     buffer representing the iid.
+ * @param[in]   bits    Bits to be copied from @p iid to @p out
+ *                      (set to 128 when greater than 128).
+ */
+void ipv6_addr_init_iid(ipv6_addr_t *out, const uint8_t *iid, uint8_t bits);
+
+/**
  * @brief   Sets @p addr dynamically to the unspecified IPv6 address (::).
  *
  * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.2">

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr.c
@@ -77,6 +77,29 @@ void ipv6_addr_init_prefix(ipv6_addr_t *out, const ipv6_addr_t *prefix,
         out->u8[bytes] |= (prefix->u8[bytes] & mask);
     }
 }
+
+void ipv6_addr_init_iid(ipv6_addr_t *out, const uint8_t *iid, uint8_t bits)
+{
+    uint8_t unaligned_bits, bytes, pos;
+
+    if (bits > 128) {
+        bits = 128;
+    }
+
+    unaligned_bits = bits % 8;
+    bytes = bits / 8;
+    pos = (IPV6_ADDR_BIT_LEN / 8) - bytes;
+
+    if (unaligned_bits) {
+        uint8_t mask = 0xff << unaligned_bits;
+        out->u8[pos - 1] &= mask;
+        out->u8[pos - 1] |= (*iid & ~mask);
+        iid++;
+    }
+
+    memcpy(&(out->u8[pos]), iid, bytes);
+}
+
 /**
  * @}
  */

--- a/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
+++ b/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
@@ -574,6 +574,26 @@ static void test_ipv6_addr_init_prefix(void)
     TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &c));
 }
 
+static void test_ipv6_addr_init_iid(void)
+{
+    ipv6_addr_t a = { {
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+            0x08, 0x09, 0x0a, 0x0b, 0xff, 0x0d, 0x0e, 0x0f
+        }
+    };
+
+    const uint8_t iid[] = { 0x13, 0x02, 0x01, 0x00 };
+
+    ipv6_addr_t c =  { {
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+            0x08, 0x09, 0x0a, 0x0b, 0x93, 0x02, 0x01, 0x00
+        }
+    };
+
+    ipv6_addr_init_iid(&a, iid, 31);
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &c));
+}
+
 static void test_ipv6_addr_set_unspecified(void)
 {
     ipv6_addr_t a = { {
@@ -1042,6 +1062,7 @@ Test *tests_ipv6_addr_tests(void)
         new_TestFixture(test_ipv6_addr_match_prefix_match_128),
         new_TestFixture(test_ipv6_addr_match_prefix_same_pointer),
         new_TestFixture(test_ipv6_addr_init_prefix),
+        new_TestFixture(test_ipv6_addr_init_iid),
         new_TestFixture(test_ipv6_addr_set_unspecified),
         new_TestFixture(test_ipv6_addr_set_loopback),
         new_TestFixture(test_ipv6_addr_set_link_local_prefix),


### PR DESCRIPTION
This is the suffix version of  `ipv6_addr_init_prefix()` to initialize the iid part only.