### PR TITLE
ndp/internal: add assert and use dst instead of tgt to determine nc_entry

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -221,6 +221,8 @@ void gnrc_ndp_internal_send_nbr_adv(kernel_pid_t iface, ipv6_addr_t *tgt, ipv6_a
               delay.seconds);
 
         /* nc_entry must be set so no need to check it */
+        assert(nc_entry);
+
         _send_delayed(&nc_entry->nbr_adv_timer, delay, hdr);
     }
     else if (gnrc_netapi_send(gnrc_ipv6_pid, hdr) < 1) {

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -216,7 +216,7 @@ void gnrc_ndp_internal_send_nbr_adv(kernel_pid_t iface, ipv6_addr_t *tgt, ipv6_a
          * (see https://tools.ietf.org/html/rfc4861#section-7.2.7) */
         timex_t delay = { 0, genrand_uint32_range(0, GNRC_NDP_MAX_AC_TGT_DELAY * SEC_IN_USEC) };
         timex_normalize(&delay);
-        gnrc_ipv6_nc_t *nc_entry = gnrc_ipv6_nc_get(iface, tgt);
+        gnrc_ipv6_nc_t *nc_entry = gnrc_ipv6_nc_get(iface, dst);
         DEBUG("ndp internal: delay neighbor advertisement for %" PRIu32 " sec.",
               delay.seconds);
 


### PR DESCRIPTION
~~Not~~ a solution to https://github.com/RIOT-OS/RIOT/pull/4122#issuecomment-151087285 ~~, but still very useful.~~

FYI, currently the assert fails on master.

EDIT: using `dst` instead of `tgt` fixes the bug