### PR TITLE
drivers: Add missing depedency for encx24j600

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -20,6 +20,7 @@ ifneq (,$(filter dht,$(USEMODULE)))
 endif
 
 ifneq (,$(filter encx24j600,$(USEMODULE)))
+  USEMODULE += gnrc_netdev2
   USEMODULE += xtimer
 endif
 


### PR DESCRIPTION
The auto initialization of encx24j600 driver requires gnrc_netdev2 module.

https://github.com/RIOT-OS/RIOT/blob/master/sys/auto_init/netif/auto_init_encx24j600.c#L50#L54


