### PR TITLE
nc: use xtimer for gnrc_ipv6_nc_t::nbr_sol_timer

### DIFF
--- a/sys/include/net/gnrc/ipv6/nc.h
+++ b/sys/include/net/gnrc/ipv6/nc.h
@@ -29,7 +29,6 @@
 #include "net/ipv6/addr.h"
 #include "net/gnrc/netif.h"
 #include "net/gnrc/pktqueue.h"
-#include "vtimer.h"
 #include "xtimer.h"
 
 #ifdef __cplusplus
@@ -135,7 +134,8 @@ typedef struct {
      * @brief (Re)Transmission timer for neighbor solicitations of this entry and
      *        timeout for states.
      */
-    vtimer_t nbr_sol_timer;
+    xtimer_t nbr_sol_timer;
+    msg_t nbr_sol_msg;                          /**< msg_t for gnrc_ipv6_nc_t::nbr_sol_timer */
 
     /**
      * @brief Delay timer for neighbor advertisements of this entry.

--- a/sys/include/net/gnrc/ndp/internal.h
+++ b/sys/include/net/gnrc/ndp/internal.h
@@ -189,6 +189,24 @@ bool gnrc_ndp_internal_mtu_opt_handle(kernel_pid_t iface, uint8_t icmpv6_type,
 bool gnrc_ndp_internal_pi_opt_handle(kernel_pid_t iface, uint8_t icmpv6_type,
                                      ndp_opt_pi_t *pi_opt);
 
+/**
+ * @brief   Resets the gnrc_ipv6_nc_t::nbr_sol_timer.
+ *
+ * @internal
+ *
+ * @param[in] nc_entry      A neighbor cache entry.
+ * @param[in] delay         The delay when the timer should fire.
+ * @param[in] type          The msg_t::type for the timer.
+ * @param[in] pid           The pid of the receiver thread of the msg_t
+ */
+static inline void gnrc_ndp_internal_reset_nbr_sol_timer(gnrc_ipv6_nc_t *nc_entry, uint32_t delay,
+                                                         uint16_t type, kernel_pid_t pid)
+{
+    xtimer_remove(&nc_entry->nbr_sol_timer);
+    nc_entry->nbr_sol_msg.type = type;
+    xtimer_set_msg(&nc_entry->nbr_sol_timer, delay, &nc_entry->nbr_sol_msg, pid);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -141,6 +141,8 @@ gnrc_ipv6_nc_t *gnrc_ipv6_nc_add(kernel_pid_t iface, const ipv6_addr_t *ipv6_add
     free_entry->rtr_adv_msg.content.ptr = (char *) free_entry;
 #endif
 
+    free_entry->nbr_sol_msg.content.ptr = (char *) free_entry;
+
     return free_entry;
 }
 
@@ -243,9 +245,8 @@ gnrc_ipv6_nc_t *gnrc_ipv6_nc_still_reachable(const ipv6_addr_t *ipv6_addr)
         gnrc_ipv6_netif_t *iface = gnrc_ipv6_netif_get(entry->iface);
         timex_t t = iface->reach_time;
 
-        vtimer_remove(&entry->nbr_sol_timer);
-        vtimer_set_msg(&entry->nbr_sol_timer, t, gnrc_ipv6_pid,
-                       GNRC_NDP_MSG_NC_STATE_TIMEOUT, entry);
+        gnrc_ndp_internal_reset_nbr_sol_timer(entry, (uint32_t) timex_uint64(t),
+                                              GNRC_NDP_MSG_NC_STATE_TIMEOUT, gnrc_ipv6_pid);
 #endif
 
         DEBUG("ipv6_nc: Marking entry %s as reachable\n",

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -654,7 +654,6 @@ void gnrc_ndp_retrans_nbr_sol(gnrc_ipv6_nc_t *nc_entry)
             nc_entry->probes_remaining--;
 
             if (nc_entry->iface == KERNEL_PID_UNDEF) {
-                timex_t t = { 0, GNRC_NDP_RETRANS_TIMER };
                 kernel_pid_t ifs[GNRC_NETIF_NUMOF];
                 size_t ifnum = gnrc_netif_get(ifs);
 
@@ -662,9 +661,8 @@ void gnrc_ndp_retrans_nbr_sol(gnrc_ipv6_nc_t *nc_entry)
                     gnrc_ndp_internal_send_nbr_sol(ifs[i], NULL, &nc_entry->ipv6_addr, &dst);
                 }
 
-                vtimer_remove(&nc_entry->nbr_sol_timer);
-                vtimer_set_msg(&nc_entry->nbr_sol_timer, t, gnrc_ipv6_pid,
-                               GNRC_NDP_MSG_NBR_SOL_RETRANS, nc_entry);
+                gnrc_ndp_internal_reset_nbr_sol_timer(nc_entry, GNRC_NDP_RETRANS_TIMER,
+                                                      GNRC_NDP_MSG_NBR_SOL_RETRANS, gnrc_ipv6_pid);
             }
             else {
                 gnrc_ipv6_netif_t *ipv6_iface = gnrc_ipv6_netif_get(nc_entry->iface);
@@ -672,10 +670,10 @@ void gnrc_ndp_retrans_nbr_sol(gnrc_ipv6_nc_t *nc_entry)
                 gnrc_ndp_internal_send_nbr_sol(nc_entry->iface, NULL, &nc_entry->ipv6_addr, &dst);
 
                 mutex_lock(&ipv6_iface->mutex);
-                vtimer_remove(&nc_entry->nbr_sol_timer);
-                vtimer_set_msg(&nc_entry->nbr_sol_timer,
-                               ipv6_iface->retrans_timer, gnrc_ipv6_pid,
-                               GNRC_NDP_MSG_NBR_SOL_RETRANS, nc_entry);
+                gnrc_ndp_internal_reset_nbr_sol_timer(nc_entry, (uint32_t) timex_uint64(
+                                                       ipv6_iface->retrans_timer
+                                                      ),
+                                                      GNRC_NDP_MSG_NBR_SOL_RETRANS, gnrc_ipv6_pid);
                 mutex_unlock(&ipv6_iface->mutex);
             }
         }

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -116,9 +116,8 @@ void gnrc_ndp_internal_set_state(gnrc_ipv6_nc_t *nc_entry, uint8_t state)
                       GNRC_NDP_FIRST_PROBE_DELAY);
             }
 #endif
-            vtimer_remove(&nc_entry->nbr_sol_timer);
-            vtimer_set_msg(&nc_entry->nbr_sol_timer, t, gnrc_ipv6_pid,
-                           GNRC_NDP_MSG_NC_STATE_TIMEOUT, nc_entry);
+            gnrc_ndp_internal_reset_nbr_sol_timer(nc_entry, (uint32_t) timex_uint64(t),
+                                                  GNRC_NDP_MSG_NC_STATE_TIMEOUT, gnrc_ipv6_pid);
             break;
 
         case GNRC_IPV6_NC_STATE_PROBE:
@@ -134,10 +133,10 @@ void gnrc_ndp_internal_set_state(gnrc_ipv6_nc_t *nc_entry, uint8_t state)
                                            &nc_entry->ipv6_addr);
 
             mutex_lock(&ipv6_iface->mutex);
-            vtimer_remove(&nc_entry->nbr_sol_timer);
-            vtimer_set_msg(&nc_entry->nbr_sol_timer,
-                           ipv6_iface->retrans_timer, gnrc_ipv6_pid,
-                           GNRC_NDP_MSG_NBR_SOL_RETRANS, nc_entry);
+            gnrc_ndp_internal_reset_nbr_sol_timer(nc_entry, (uint32_t) timex_uint64(
+                                                    ipv6_iface->retrans_timer
+                                                  ),
+                                                  GNRC_NDP_MSG_NBR_SOL_RETRANS, gnrc_ipv6_pid);
             mutex_unlock(&ipv6_iface->mutex);
             break;
 

--- a/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
+++ b/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
@@ -164,7 +164,6 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
         ipv6_addr_set_solicited_nodes(&dst_sol, next_hop_ip);
 
         if (iface == KERNEL_PID_UNDEF) {
-            timex_t t = { 0, GNRC_NDP_RETRANS_TIMER };
             kernel_pid_t ifs[GNRC_NETIF_NUMOF];
             size_t ifnum = gnrc_netif_get(ifs);
 
@@ -172,9 +171,8 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
                 gnrc_ndp_internal_send_nbr_sol(ifs[i], NULL, next_hop_ip, &dst_sol);
             }
 
-            vtimer_remove(&nc_entry->nbr_sol_timer);
-            vtimer_set_msg(&nc_entry->nbr_sol_timer, t, gnrc_ipv6_pid,
-                           GNRC_NDP_MSG_NBR_SOL_RETRANS, nc_entry);
+            gnrc_ndp_internal_reset_nbr_sol_timer(nc_entry, GNRC_NDP_RETRANS_TIMER,
+                                                  GNRC_NDP_MSG_NBR_SOL_RETRANS, gnrc_ipv6_pid);
         }
         else {
             gnrc_ipv6_netif_t *ipv6_iface = gnrc_ipv6_netif_get(iface);
@@ -182,10 +180,10 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
             gnrc_ndp_internal_send_nbr_sol(iface, NULL, next_hop_ip, &dst_sol);
 
             mutex_lock(&ipv6_iface->mutex);
-            vtimer_remove(&nc_entry->nbr_sol_timer);
-            vtimer_set_msg(&nc_entry->nbr_sol_timer,
-                           ipv6_iface->retrans_timer, gnrc_ipv6_pid,
-                           GNRC_NDP_MSG_NBR_SOL_RETRANS, nc_entry);
+            gnrc_ndp_internal_reset_nbr_sol_timer(nc_entry, (uint32_t) timex_uint64(
+                                                    ipv6_iface->retrans_timer
+                                                  ),
+                                                  GNRC_NDP_MSG_NBR_SOL_RETRANS, gnrc_ipv6_pid);
             mutex_unlock(&ipv6_iface->mutex);
         }
     }

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -294,10 +294,11 @@ uint8_t gnrc_sixlowpan_nd_opt_ar_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6,
                     DEBUG("6lo nd: address registration successful\n");
                     mutex_lock(&ipv6_iface->mutex);
                     /* reschedule 1 minute before lifetime expires */
-                    timex_t t = { (uint32_t)(byteorder_ntohs(ar_opt->ltime) - 1) * 60, 0 };
-                    vtimer_remove(&nc_entry->nbr_sol_timer);
-                    vtimer_set_msg(&nc_entry->nbr_sol_timer, t, gnrc_ipv6_pid,
-                                   GNRC_NDP_MSG_NBR_SOL_RETRANS, nc_entry);
+                    gnrc_ndp_internal_reset_nbr_sol_timer(nc_entry, SEC_IN_USEC * 60 *
+                                                          (uint32_t)(byteorder_ntohs(ar_opt->ltime)
+                                                          -1),
+                                                          GNRC_NDP_MSG_NBR_SOL_RETRANS,
+                                                          gnrc_ipv6_pid);
                     mutex_unlock(&ipv6_iface->mutex);
                     break;
                 case SIXLOWPAN_ND_STATUS_DUP:
@@ -392,12 +393,10 @@ void gnrc_sixlowpan_nd_wakeup(void)
 {
     gnrc_ipv6_nc_t *router = gnrc_ipv6_nc_get_next_router(NULL);
     while (router) {
-        timex_t t = { 0, GNRC_NDP_RETRANS_TIMER };
         gnrc_sixlowpan_nd_uc_rtr_sol(router);
         gnrc_ndp_internal_send_nbr_sol(router->iface, NULL, &router->ipv6_addr, &router->ipv6_addr);
-        vtimer_remove(&router->nbr_sol_timer);
-        vtimer_set_msg(&router->nbr_sol_timer, t, gnrc_ipv6_pid, GNRC_NDP_MSG_NBR_SOL_RETRANS,
-                       router);
+        gnrc_ndp_internal_reset_nbr_sol_timer(router, GNRC_NDP_RETRANS_TIMER,
+                                              GNRC_NDP_MSG_NBR_SOL_RETRANS, gnrc_ipv6_pid);
     }
 }
 


### PR DESCRIPTION
replaces vtimer by xtimer for gnrc_ipv6_nc_t::nbr_sol_timer.