### PR TITLE
netif: use xtimer for gnrc_ipv6_netif_t::rtr_sol_timer

### DIFF
--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -339,7 +339,8 @@ typedef struct {
      *          The default value is @ref GNRC_NDP_RETRANS_TIMER.
      */
     timex_t retrans_timer;
-    vtimer_t rtr_sol_timer; /**< Timer for periodic router solicitations */
+    xtimer_t rtr_sol_timer; /**< Timer for periodic router solicitations */
+    msg_t rtr_sol_msg;      /**< msg_t for gnrc_ipv6_netif_t::rtr_sol_timer */
 #if defined (MODULE_GNRC_NDP_ROUTER) || defined (MODULE_GNRC_SIXLOWPAN_ND_ROUTER)
     vtimer_t rtr_adv_timer; /**< Timer for periodic router advertisements */
 #endif

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -234,7 +234,7 @@ void gnrc_ipv6_netif_remove(kernel_pid_t pid)
 #endif
 
     mutex_lock(&entry->mutex);
-    vtimer_remove(&entry->rtr_sol_timer);
+    xtimer_remove(&entry->rtr_sol_timer);
 #ifdef MODULE_GNRC_NDP_ROUTER
     vtimer_remove(&entry->rtr_adv_timer);
 #endif

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -612,7 +612,7 @@ void gnrc_ndp_rtr_adv_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt, ipv6_hdr_t
 #ifdef MODULE_GNRC_SIXLOWPAN_ND
     if (if_entry->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN) {
         /* stop multicast router solicitation retransmission timer */
-        vtimer_remove(&if_entry->rtr_sol_timer);
+        xtimer_remove(&if_entry->rtr_sol_timer);
         /* 3/4 of the time should be "well before" enough the respective timeout
          * not to run out; see https://tools.ietf.org/html/rfc6775#section-5.4.3 */
         next_rtr_sol *= 3;

--- a/sys/net/gnrc/network_layer/ndp/host/gnrc_ndp_host.c
+++ b/sys/net/gnrc/network_layer/ndp/host/gnrc_ndp_host.c
@@ -26,9 +26,11 @@
 
 static inline void _reschedule_rtr_sol(gnrc_ipv6_netif_t *iface, timex_t delay)
 {
-    vtimer_remove(&iface->rtr_sol_timer);
-    vtimer_set_msg(&iface->rtr_sol_timer, delay, gnrc_ipv6_pid, GNRC_NDP_MSG_RTR_SOL_RETRANS,
-                   iface);
+    xtimer_remove(&iface->rtr_sol_timer);
+    iface->rtr_sol_msg.type = GNRC_NDP_MSG_RTR_SOL_RETRANS;
+    iface->rtr_sol_msg.content.ptr = (char *) iface;
+    xtimer_set_msg(&iface->rtr_sol_timer, (uint32_t) timex_uint64(delay), &iface->rtr_sol_msg,
+                   gnrc_ipv6_pid);
 }
 
 void gnrc_ndp_host_init(gnrc_ipv6_netif_t *iface)

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -29,9 +29,11 @@
 
 static inline void _rtr_sol_reschedule(gnrc_ipv6_netif_t *iface, uint32_t sec_delay)
 {
-    vtimer_remove(&iface->rtr_sol_timer);
-    vtimer_set_msg(&iface->rtr_sol_timer, timex_set(sec_delay, 0), gnrc_ipv6_pid,
-                   GNRC_SIXLOWPAN_ND_MSG_MC_RTR_SOL, iface);
+    xtimer_remove(&iface->rtr_sol_timer);
+    iface->rtr_sol_msg.type = GNRC_SIXLOWPAN_ND_MSG_MC_RTR_SOL;
+    iface->rtr_sol_msg.content.ptr = (char *) iface;
+    xtimer_set_msg(&iface->rtr_sol_timer, sec_delay * SEC_IN_USEC, &iface->rtr_sol_msg,
+                   gnrc_ipv6_pid);
 }
 
 static inline uint32_t _binary_exp_backoff(uint32_t base_sec, unsigned int exp)
@@ -226,9 +228,11 @@ void gnrc_sixlowpan_nd_rtr_sol_reschedule(gnrc_ipv6_nc_t *nce, uint32_t sec_dela
     assert(nce != NULL);
     assert(sec_delay != 0U);
     gnrc_ipv6_netif_t *iface = gnrc_ipv6_netif_get(nce->iface);
-    vtimer_remove(&iface->rtr_sol_timer);
-    vtimer_set_msg(&iface->rtr_sol_timer, timex_set(sec_delay, 0), gnrc_ipv6_pid,
-                   GNRC_SIXLOWPAN_ND_MSG_MC_RTR_SOL, iface);
+    xtimer_remove(&iface->rtr_sol_timer);
+    iface->rtr_sol_msg.type = GNRC_SIXLOWPAN_ND_MSG_MC_RTR_SOL;
+    iface->rtr_sol_msg.content.ptr = (char *) iface;
+    xtimer_set_msg(&iface->rtr_sol_timer, sec_delay * SEC_IN_USEC, &iface->rtr_sol_msg,
+                   gnrc_ipv6_pid);
 }
 
 gnrc_pktsnip_t *gnrc_sixlowpan_nd_opt_ar_build(uint8_t status, uint16_t ltime, eui64_t *eui64,


### PR DESCRIPTION
replaces vtimer by xtimer for gnrc_ipv6_netif_t::rtr_sol_timer.