### PR TITLE
netif: use xtimer for gnrc_ipv6_netif_t::rtr_adv_timer

### DIFF
--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -342,7 +342,8 @@ typedef struct {
     xtimer_t rtr_sol_timer; /**< Timer for periodic router solicitations */
     msg_t rtr_sol_msg;      /**< msg_t for gnrc_ipv6_netif_t::rtr_sol_timer */
 #if defined (MODULE_GNRC_NDP_ROUTER) || defined (MODULE_GNRC_SIXLOWPAN_ND_ROUTER)
-    vtimer_t rtr_adv_timer; /**< Timer for periodic router advertisements */
+    xtimer_t rtr_adv_timer; /**< Timer for periodic router advertisements */
+    msg_t rtr_adv_msg;      /**< msg_t for gnrc_ipv6_netif_t::rtr_adv_timer */
 #endif
 } gnrc_ipv6_netif_t;
 

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -236,7 +236,7 @@ void gnrc_ipv6_netif_remove(kernel_pid_t pid)
     mutex_lock(&entry->mutex);
     xtimer_remove(&entry->rtr_sol_timer);
 #ifdef MODULE_GNRC_NDP_ROUTER
-    vtimer_remove(&entry->rtr_adv_timer);
+    xtimer_remove(&entry->rtr_adv_timer);
 #endif
     _reset_addr_from_entry(entry);
     DEBUG("ipv6 netif: Remove IPv6 interface %" PRIkernel_pid "\n", pid);

--- a/sys/net/gnrc/network_layer/ndp/router/gnrc_ndp_router.c
+++ b/sys/net/gnrc/network_layer/ndp/router/gnrc_ndp_router.c
@@ -106,9 +106,11 @@ static void _send_rtr_adv(gnrc_ipv6_netif_t *iface, ipv6_addr_t *dst)
     }
     if (!fin || (iface->rtr_adv_count > 1)) {   /* regard for off-by-one-error */
         /* reset timer for next router advertisement */
-        vtimer_remove(&iface->rtr_adv_timer);
-        vtimer_set_msg(&iface->rtr_adv_timer, timex_set(interval, 0),
-                       gnrc_ipv6_pid, GNRC_NDP_MSG_RTR_ADV_RETRANS, iface);
+        xtimer_remove(&iface->rtr_adv_timer);
+        iface->rtr_adv_msg.type = GNRC_NDP_MSG_RTR_ADV_RETRANS;
+        iface->rtr_adv_msg.content.ptr = (char *) iface;
+        xtimer_set_msg(&iface->rtr_adv_timer, interval * SEC_IN_USEC, &iface->rtr_adv_msg,
+                       gnrc_ipv6_pid);
     }
     mutex_unlock(&iface->mutex);
     for (int i = 0; i < GNRC_IPV6_NETIF_ADDR_NUMOF; i++) {


### PR DESCRIPTION
replaces vtimer by xtimer for gnrc_ipv6_netif_t::rtr_adv_timer