### PR TITLE
posix: sockets: use correct datatypes for in6_addr

### DIFF
--- a/sys/posix/include/netinet/in.h
+++ b/sys/posix/include/netinet/in.h
@@ -257,12 +257,12 @@ struct ipv6_mreq {
 /**
  * IPv6 socket address for the wildcard address.
  */
-extern const struct sockaddr_in6 in6addr_any;
+extern const struct in6_addr in6addr_any;
 
 /**
  * IPv6 socket address for the loopback address.
  */
-extern const struct sockaddr_in6 in6addr_loopback;
+extern const struct in6_addr in6addr_loopback;
 
 #ifdef __cplusplus
 }

--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -61,10 +61,8 @@ typedef struct {
 socket_t _pool[SOCKET_POOL_SIZE];
 mutex_t _pool_mutex = MUTEX_INIT;
 
-const struct sockaddr_in6 in6addr_any = {AF_INET6, 0, 0, IN6ADDR_ANY_INIT, 0};
-const struct sockaddr_in6 in6addr_loopback = {
-    AF_INET6, 0, 0, IN6ADDR_LOOPBACK_INIT, 0
-};
+const struct in6_addr in6addr_any = IN6ADDR_ANY_INIT;
+const struct in6_addr in6addr_loopback = IN6ADDR_LOOPBACK_INIT;
 
 static socket_t *_get_free_socket(void)
 {


### PR DESCRIPTION
in6addr_any and in6addr_loopback are of type in6_addr.

Not sure if there was any intention behind making these variables of type `sockaddr_in6` instead, but this makes porting of POSIX compliant code more difficult.