### PR TITLE
SAMR21 [ADC]

### DIFF
--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -17,6 +17,7 @@
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ * @author      Mark Solters <msolters@driblet.io>
  */
 
 #ifndef PERIPH_CONF_H_
@@ -269,11 +270,6 @@ static const pwm_conf_t pwm_config[] = {
  * @ ADC Configuration
  * @{
  */
-typedef struct {
-    PortGroup *port;
-    uint8_t pin;
-    uint8_t muxpos;                 /* see datasheet sec 30.8.8 */
-} adc_conf_t;
 
 #define ADC_NUMOF                          (1U)
 #define ADC_0_EN                           1
@@ -284,6 +280,12 @@ typedef struct {
 #define ADC_0_PORT                         (PORT->Group[0])
 #define ADC_0_IRQ                          ADC_IRQn
 #define ADC_0_CHANNELS                     6 // ignore PA04 & PA05 due to EDBG UART conflict
+
+typedef struct {
+  PortGroup *port;
+  uint8_t pin;
+  uint8_t muxpos;                 /* see datasheet sec 30.8.8 */
+} adc_channel_t;
 
 /* ADC 0 Default values */
 #define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
@@ -321,7 +323,7 @@ typedef struct {
  *  ADC positive input pins the SAMR21-XPRO provides.  Each pin is
  *  a separate ADC "channel".
  */
-static const adc_conf_t adc_config[] = {
+static const adc_channel_t adc_channels[] = {
     /* port, pin, muxpos */
     //{&PORT->Group[0], 4, 0x4}, // we cannot use these as well as use EDBG serial TX/RX
     //{&PORT->Group[0], 5, 0x5}, // because PA04 & PA05 read/write directly to EDBG serial port.
@@ -334,7 +336,6 @@ static const adc_conf_t adc_config[] = {
 };
 #endif
 #endif
-
 
 /* ADC 0 Gain Factor */
 #define ADC_0_GAIN_FACTOR_1X               ADC_INPUTCTRL_GAIN_1X
@@ -371,7 +372,7 @@ static const adc_conf_t adc_config[] = {
 #define ADC_0_ACCUM_512                    ADC_AVGCTRL_SAMPLENUM_512
 #define ADC_0_ACCUM_1024                   ADC_AVGCTRL_SAMPLENUM_1024
 /* Use this to define the value used */
-#define ADC_0_ACCUM_DEFAULT                ADC_0_ACCUM_DISABLE
+#define ADC_0_ACCUM_DEFAULT                ADC_0_ACCUM_4//DISABLE
 
 /* ADC 0 DIVIDE RESULT */
 #define ADC_0_DIV_RES_DISABLE              0
@@ -383,7 +384,8 @@ static const adc_conf_t adc_config[] = {
 #define ADC_0_DIV_RES_64                   6
 #define ADC_0_DIV_RES_128                  7
 /* Use this to define the value used */
-#define ADC_0_DIV_RES_DEFAULT             ADC_0_DIV_RES_DISABLE
+#define ADC_0_DIV_RES_DEFAULT             ADC_0_DIV_RES_4//DISABLE
+
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -349,7 +349,12 @@ static const adc_channel_t adc_channels[] = {
 #define ADC_0_RES_12BIT                    ADC_CTRLB_RESSEL_12BIT
 #define ADC_0_RES_16BIT                    ADC_CTRLB_RESSEL_16BIT
 
-/* ADC 0 Voltage reference */
+/* ADC 0 Voltage reference
+ * Note: ADC_0_REF_EXT_B is PA04 on the SAMR21-xpro.
+ *       PA04 is also hardwired to the USB EDBG serial.
+ *       If you use ADC_0_REF_EXT_B while also using
+ *       EDBG serial, the serial connection will freeze.
+ */
 #define ADC_0_REF_INT_1V                   ADC_REFCTRL_REFSEL_INT1V
 #define ADC_0_REF_EXT_B                    ADC_REFCTRL_REFSEL_AREFB
 #define ADC_0_REF_COM_EN                   0
@@ -391,6 +396,7 @@ typedef struct {
   uint32_t gain;
   uint32_t accumulate;
   uint8_t  divide;
+  int vref;
   int differential_mode;
   int run_in_standby;
 } adc_conf_t;

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -289,7 +289,7 @@ typedef struct {
 
 /* ADC 0 Default values */
 #define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
+#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV4
 #define ADC_0_WINDOW_MODE                  ADC_WINCTRL_WINMODE_DISABLE
 #define ADC_0_WINDOW_LOWER                 0
 #define ADC_0_WINDOW_HIGHER                0
@@ -312,16 +312,8 @@ typedef struct {
 #define ADC_0_STATUS_OVERRUN               (1UL << 2)
 
 #if ADC_0_CHANNELS
-#if ADC_0_DIFFERENTIAL_MODE
-/*  In differential mode, we can only pick one positive
- *  and one negative input.
- */
-#define ADC_0_POS_INPUT                    ADC_INPUTCTRL_MUXPOS_PIN6
-#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_IOGND
-#else
-/*  If we're not in differential mode, we can use any of
- *  ADC positive input pins the SAMR21-XPRO provides.  Each pin is
- *  a separate ADC "channel".
+/*  An array listing all possible positive input
+ *  ADC channels for the SAMR21-XPRO.
  */
 static const adc_channel_t adc_channels[] = {
     /* port, pin, muxpos */
@@ -334,7 +326,12 @@ static const adc_channel_t adc_channels[] = {
     {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN10, 0xA},    // PB02
     {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN11, 0xB},    // PB03
 };
-#endif
+
+/*  In differential mode, we can only pick one positive
+ *  and one negative input.  These are the default values.
+ */
+#define ADC_0_POS_INPUT                    ADC_INPUTCTRL_MUXPOS_PIN6
+#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_IOGND
 #endif
 
 /* ADC 0 Gain Factor */
@@ -372,7 +369,7 @@ static const adc_channel_t adc_channels[] = {
 #define ADC_0_ACCUM_512                    ADC_AVGCTRL_SAMPLENUM_512
 #define ADC_0_ACCUM_1024                   ADC_AVGCTRL_SAMPLENUM_1024
 /* Use this to define the value used */
-#define ADC_0_ACCUM_DEFAULT                ADC_0_ACCUM_4//DISABLE
+#define ADC_0_ACCUM_DEFAULT                ADC_0_ACCUM_DISABLE
 
 /* ADC 0 DIVIDE RESULT */
 #define ADC_0_DIV_RES_DISABLE              0
@@ -384,7 +381,19 @@ static const adc_channel_t adc_channels[] = {
 #define ADC_0_DIV_RES_64                   6
 #define ADC_0_DIV_RES_128                  7
 /* Use this to define the value used */
-#define ADC_0_DIV_RES_DEFAULT             ADC_0_DIV_RES_4//DISABLE
+#define ADC_0_DIV_RES_DEFAULT             ADC_0_DIV_RES_DISABLE
+
+/*  Declare ADC Configuration object */
+#define ADC_CONF_TYPE_DEFINED 1
+typedef struct {
+  uint32_t precision;
+  uint32_t prescaler;
+  uint32_t gain;
+  uint32_t accumulate;
+  uint8_t  divide;
+  int differential_mode;
+  int run_in_standby;
+} adc_conf_t;
 
 /** @} */
 

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -314,17 +314,20 @@ typedef struct {
 #if ADC_0_CHANNELS
 /*  An array listing all possible positive input
  *  ADC channels for the SAMR21-XPRO.
+ *
+ *  Note: Enabling PA04/PA05 will cause EDBG serial communication
+ *  to freeze, so they are disabled by default!
  */
 static const adc_channel_t adc_channels[] = {
     /* port, pin, muxpos */
-    //{&PORT->Group[0], 4, 0x4}, // we cannot use these as well as use EDBG serial TX/RX
-    //{&PORT->Group[0], 5, 0x5}, // because PA04 & PA05 read/write directly to EDBG serial port.
-    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN6, 0x6},    // PA06
-    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN7, 0x7},    // PA07
-    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN16, 0x10},   // PA08
-    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN17, 0x11},   // PA09
-    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN10, 0xA},    // PB02
-    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN11, 0xB},    // PB03
+    //{&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN4, 0x4},      // PA04
+    //{&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN5, 0x5},      // PA05
+    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN6, 0x6},      // PA06
+    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN7, 0x7},      // PA07
+    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN16, 0x10},    // PA08
+    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN17, 0x11},    // PA09
+    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN10, 0xA},     // PB02
+    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN11, 0xB},     // PB03
 };
 
 /*  In differential mode, we can only pick one positive
@@ -350,6 +353,7 @@ static const adc_channel_t adc_channels[] = {
 #define ADC_0_RES_16BIT                    ADC_CTRLB_RESSEL_16BIT
 
 /* ADC 0 Voltage reference
+ *
  * Note: ADC_0_REF_EXT_B is PA04 on the SAMR21-xpro.
  *       PA04 is also hardwired to the USB EDBG serial.
  *       If you use ADC_0_REF_EXT_B while also using

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -276,25 +276,46 @@ static const pwm_conf_t pwm_config[] = {
 /* ADC 0 device configuration */
 #define ADC_0_DEV                          ADC
 #define ADC_0_PORT                         (PORT->Group[0])
-#define ADC_0_IRQ                          ADC_IRQn     
-#define ADC_0_CHANNELS                     8
+#define ADC_0_IRQ                          ADC_IRQn
+#define ADC_0_CHANNELS                     6 // ignore PA04 & PA05 due to EDBG UART conflict
+
+typedef struct {
+    PortGroup *port;
+    uint8_t pin;
+    uint8_t muxpos;                 /* see datasheet sec 30.8.8 */
+} adc_conf_t;
+
+#if ADC_0_CHANNELS
+static const adc_conf_t adc_config[] = {
+    /* port, pin, muxpos */
+    //{&PORT->Group[0], 4, 0x4}, // we cannot use these as well as use EDBG serial TX/RX
+    //{&PORT->Group[0], 5, 0x5}, // because PA04 & PA05 read/write directly to EDBG serial port.
+    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN6, 0x6},    // PA06
+    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN7, 0x7},    // PA07
+    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN16, 0x10},   // PA08
+    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN17, 0x11},   // PA09
+    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN10, 0xA},    // PB02
+    {&PORT->Group[0], ADC_INPUTCTRL_MUXPOS_PIN11, 0xB},    // PB03
+};
+#endif
+
 /* ADC 0 Default values */
 #define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV4
+#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
 #define ADC_0_WINDOW_MODE                  ADC_WINCTRL_WINMODE_DISABLE
 #define ADC_0_WINDOW_LOWER                 0
-#define ADC_0_WINDOW_HIGHER                0     
+#define ADC_0_WINDOW_HIGHER                0
 
 #define ADC_0_CORRECTION_EN                0 /* disabled */
 #define ADC_0_GAIN_CORRECTION              ADC_GAINCORR_RESETVALUE
 #define ADC_0_OFFSET_CORRECTION            ADC_OFFSETCORR_RESETVALUE
 #define ADC_0_SAMPLE_LENGTH                0
 #define ADC_0_PIN_SCAN_OFFSET_START        0 /* disabled */
-#define ADC_0_PIN_SCAN_INPUT_TO_SCAN       0 /* disabled */    
+#define ADC_0_PIN_SCAN_INPUT_TO_SCAN       0 /* disabled */
 #define ADC_0_LEFT_ADJUST                  0 /* disabled */
 #define ADC_0_DIFFERENTIAL_MODE            0 /* disabled */
 #define ADC_0_FREE_RUNNING                 0 /* disabled */
-#define ADC_0_EVENT_ACTION                 0 /* disabled */    
+#define ADC_0_EVENT_ACTION                 0 /* disabled */
 #define ADC_0_RUN_IN_STANDBY               0 /* disabled */
 
 /* ADC 0 Module Status flags */
@@ -303,10 +324,10 @@ static const pwm_conf_t pwm_config[] = {
 #define ADC_0_STATUS_OVERRUN               (1UL << 2)
 
 /* ADC 0 Positive Input Pins */
-#define ADC_0_POS_INPUT                    ADC_INPUTCTRL_MUXPOS_PIN6
+//#define ADC_0_POS_INPUT                    ADC_INPUTCTRL_MUXPOS_PIN6
 
-/* ADC 0 Negative Input Pins */     
-#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
+/* ADC 0 Negative Input Pins */
+//#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
 
 /* ADC 0 Gain Factor */
 #define ADC_0_GAIN_FACTOR_1X               ADC_INPUTCTRL_GAIN_1X
@@ -317,17 +338,17 @@ static const pwm_conf_t pwm_config[] = {
 /* Use this to define the value used */
 #define ADC_0_GAIN_FACTOR_DEFAULT          ADC_0_GAIN_FACTOR_1X
 
-/* ADC 0 Resolutions */    
+/* ADC 0 Resolutions */
 #define ADC_0_RES_8BIT                     ADC_CTRLB_RESSEL_8BIT
 #define ADC_0_RES_10BIT                    ADC_CTRLB_RESSEL_10BIT
 #define ADC_0_RES_12BIT                    ADC_CTRLB_RESSEL_12BIT
-#define ADC_0_RES_16BIT                    ADC_CTRLB_RESSEL_16BIT 
+#define ADC_0_RES_16BIT                    ADC_CTRLB_RESSEL_16BIT
 
 /* ADC 0 Voltage reference */
 #define ADC_0_REF_INT_1V                   ADC_REFCTRL_REFSEL_INT1V
 #define ADC_0_REF_EXT_B                    ADC_REFCTRL_REFSEL_AREFB
 #define ADC_0_REF_COM_EN                   0
-/* Use this to define the value used */ 
+/* Use this to define the value used */
 #define ADC_0_REF_DEFAULT                  ADC_0_REF_INT_1V
 
 /* ADC 0 ACCUMULATE */
@@ -343,9 +364,9 @@ static const pwm_conf_t pwm_config[] = {
 #define ADC_0_ACCUM_512                    ADC_AVGCTRL_SAMPLENUM_512
 #define ADC_0_ACCUM_1024                   ADC_AVGCTRL_SAMPLENUM_1024
 /* Use this to define the value used */
-#define ADC_0_ACCUM_DEFAULT                ADC_0_ACCUM_DISABLE 
+#define ADC_0_ACCUM_DEFAULT                ADC_0_ACCUM_DISABLE
 
-/* ADC 0 DEVIDE RESULT */
+/* ADC 0 DIVIDE RESULT */
 #define ADC_0_DIV_RES_DISABLE              0
 #define ADC_0_DIV_RES_2                    1
 #define ADC_0_DIV_RES_4                    2
@@ -355,7 +376,7 @@ static const pwm_conf_t pwm_config[] = {
 #define ADC_0_DIV_RES_64                   6
 #define ADC_0_DIV_RES_128                  7
 /* Use this to define the value used */
-#define ADC_0_DIV_RES_DEFAULT             ADC_0_DIV_RES_DISABLE 
+#define ADC_0_DIV_RES_DEFAULT             ADC_0_DIV_RES_DISABLE
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -315,7 +315,7 @@ typedef struct {
  *  and one negative input.
  */
 #define ADC_0_POS_INPUT                    ADC_INPUTCTRL_MUXPOS_PIN6
-#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_PIN7
+#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_IOGND
 #else
 /*  If we're not in differential mode, we can use any of
  *  ADC positive input pins the SAMR21-XPRO provides.  Each pin is

--- a/cpu/samd21/periph/adc.c
+++ b/cpu/samd21/periph/adc.c
@@ -193,29 +193,32 @@ int adc_configure_with_resolution(Adc* adc, uint32_t precision)
 
     /* Pin Muxing */
     #if ADC_0_DIFFERENTIAL_MODE
-    ADC_0_PORT.PINCFG[ ADC_0_POS_INPUT ].bit.PMUXEN = 1;
-    ADC_0_PORT.PMUX[ ADC_0_POS_INPUT / 2].bit.PMUXE = 1;
+      /*  Configure ADC_0_POS_INPUT and ADC_0_NEG_INPUT */
+      ADC_0_PORT.PINCFG[ ADC_0_POS_INPUT ].bit.PMUXEN = 1;
+      ADC_0_PORT.PMUX[ ADC_0_POS_INPUT / 2].bit.PMUXE = 1;
 
-    /* ADC_0_POS_INPUT Input */
-    ADC_0_PORT.DIRCLR.reg = (1 << ADC_0_POS_INPUT);
-    ADC_0_PORT.PINCFG[ADC_0_POS_INPUT].bit.INEN = true;
-    ADC_0_PORT.PINCFG[ADC_0_POS_INPUT].bit.PULLEN = false;
+      /* ADC_0_POS_INPUT Input */
+      ADC_0_PORT.DIRCLR.reg = (1UL << ADC_0_POS_INPUT);
+      ADC_0_PORT.PINCFG[ADC_0_POS_INPUT].bit.INEN = true;
+      ADC_0_PORT.PINCFG[ADC_0_POS_INPUT].bit.PULLEN = false;
 
-    if(ADC_0_NEG_INPUT != ADC_INPUTCTRL_MUXNEG_GND)
-    {
-        ADC_0_PORT.DIRCLR.reg = (1 << ADC_0_NEG_INPUT);
-        ADC_0_PORT.PINCFG[ADC_0_NEG_INPUT].bit.INEN = true;
-        ADC_0_PORT.PINCFG[ADC_0_NEG_INPUT].bit.PULLEN = false;
-    }
+      /* ADC_0_NEG_INPUT Input */
+      if(ADC_0_NEG_INPUT != ADC_INPUTCTRL_MUXNEG_GND)
+      {
+          ADC_0_PORT.DIRCLR.reg = (1UL << ADC_0_NEG_INPUT);
+          ADC_0_PORT.PINCFG[ADC_0_NEG_INPUT].bit.INEN = true;
+          ADC_0_PORT.PINCFG[ADC_0_NEG_INPUT].bit.PULLEN = false;
+      }
     #else
-    for (int i = 0; i < ADC_0_CHANNELS; i++) {
-       PortGroup *port = adc_config[i].port;
-       int pin = adc_config[i].pin;
-       port->DIRCLR.reg = (1 << pin);
-       port->PINCFG[pin].reg = (PORT_PINCFG_PMUXEN | PORT_PINCFG_INEN);
-       port->PMUX[pin >> 1].reg = ~(0xf << (4 * (pin & 0x1)));
-       port->PMUX[pin >> 1].reg =  (1 << (4 * (pin & 0x1)));
-    }
+      /*  Configure all positive inputs enumerated in adc_config  */
+      for (int i = 0; i < ADC_0_CHANNELS; i++) {
+         PortGroup *port = adc_config[i].port;
+         int pin = adc_config[i].pin;
+         port->DIRCLR.reg = (1 << pin);
+         port->PINCFG[pin].reg = (PORT_PINCFG_PMUXEN | PORT_PINCFG_INEN);
+         port->PMUX[pin >> 1].reg = ~(0xf << (4 * (pin & 0x1)));
+         port->PMUX[pin >> 1].reg =  (1 << (4 * (pin & 0x1)));
+      }
     #endif
 
 
@@ -257,7 +260,7 @@ int adc_configure_with_resolution(Adc* adc, uint32_t precision)
         return -1;
     }
 
-    /* Set the accumlation and devide result */
+    /* Set the accumlation and divide result */
     adc->AVGCTRL.reg = ADC_AVGCTRL_ADJRES(divideResult) | accumulate;
 
     /* Set Sample length */
@@ -336,8 +339,7 @@ int adc_configure_with_resolution(Adc* adc, uint32_t precision)
 
     /* Load the fixed device calibration constants*/
     adc->CALIB.reg = ADC_CALIB_BIAS_CAL((*(uint32_t*)ADC_FUSES_BIASCAL_ADDR >> ADC_FUSES_BIASCAL_Pos))
-                    |
-                    ADC_CALIB_LINEARITY_CAL((*(uint64_t*)ADC_FUSES_LINEARITY_0_ADDR >> ADC_FUSES_LINEARITY_0_Pos));
+                    | ADC_CALIB_LINEARITY_CAL((*(uint64_t*)ADC_FUSES_LINEARITY_0_ADDR >> ADC_FUSES_LINEARITY_0_Pos));
 
     return 1;
 }

--- a/cpu/samd21/periph/adc.c
+++ b/cpu/samd21/periph/adc.c
@@ -30,65 +30,69 @@
 /* guard in case that no ADC device is defined */
 #if ADC_NUMOF
 
-/*  Declare ADC Configuration object */
-typedef struct {
-  adc_precision_t precision;
-} adc_conf_t;
-adc_conf_t adc_conf;
+/*  Declare ADC configuration object  */
+adc_conf_t adc_config;
 
 /* Prototypes */
 bool adc_syncing(Adc*);
 void adc_clear_status(Adc*, uint32_t);
 uint32_t adc_get_status(Adc*);
-int adc_configure_with_resolution(Adc*, uint32_t);
 
 int adc_init(adc_t dev, adc_precision_t precision)
 {
-    //adc_poweron(dev);
-    Adc *adc = 0;
-    int init = 0;
-    switch (dev) {
-    #if ADC_0_EN
-        case ADC_0:
-            adc = ADC_0_DEV;
-            while(adc_syncing(adc));
-            /*Disable adc before init*/
-            adc->CTRLA.reg &= ~ADC_CTRLA_ENABLE;
-            adc_conf.precision = precision;
-            switch (precision)
-            {
-                case ADC_RES_8BIT:
-                    init = adc_configure_with_resolution(adc, ADC_0_RES_8BIT);
-                    break;
-                case ADC_RES_10BIT:
-                    init = adc_configure_with_resolution(adc, ADC_0_RES_10BIT);
-                    break;
-                case ADC_RES_12BIT:
-                    init = adc_configure_with_resolution(adc, ADC_0_RES_12BIT);
-                    break;
-                case ADC_RES_16BIT:
-                    init = adc_configure_with_resolution(adc, ADC_0_RES_16BIT);
-                    DEBUG("Init switch DONE\n");
-                    break;
-                default:
-                    return -1;
-            }
-            while(adc_syncing(adc));
-            if(init == -1)
-                return -1;
-            /* Enable bandgap if internal ref 1 volt */
-            if(ADC_0_REF_DEFAULT == ADC_0_REF_INT_1V)
-            {
-                SYSCTRL->VREF.reg |= SYSCTRL_VREF_BGOUTEN;
-            }
-            /* Enable */
-            adc->CTRLA.reg |= ADC_CTRLA_ENABLE;
-        break;
-    #endif
-        default:
+  //Adc *adc = 0;
+  int init = 0;
+  switch (dev) {
+#if ADC_0_EN
+    case ADC_0:
+      //  Define ADC device.
+      //adc = ADC_0_DEV;
+
+      //  Initialize adc_config defaults.
+      if (!adc_config.prescaler)
+        adc_config.prescaler = ADC_0_PRESCALER;
+      if (!adc_config.gain)
+        adc_config.gain = ADC_0_GAIN_FACTOR_DEFAULT;
+      if (!adc_config.accumulate)
+        adc_config.accumulate = ADC_0_ACCUM_DEFAULT;
+      if (!adc_config.divide)
+        adc_config.divide = ADC_0_DIV_RES_DEFAULT;
+      if (!adc_config.differential_mode)
+        adc_config.differential_mode = ADC_0_DIFFERENTIAL_MODE;
+      if (!adc_config.run_in_standby)
+        adc_config.run_in_standby = ADC_0_RUN_IN_STANDBY;
+      if (!adc_config.precision)
+      {
+        switch (precision)
+        {
+          case ADC_RES_8BIT:
+            adc_config.precision = ADC_0_RES_8BIT;
+            break;
+          case ADC_RES_10BIT:
+            adc_config.precision = ADC_0_RES_10BIT;
+            break;
+          case ADC_RES_12BIT:
+            adc_config.precision = ADC_0_RES_12BIT;
+            break;
+          case ADC_RES_16BIT:
+            adc_config.precision = ADC_0_RES_16BIT;
+          default:
+            DEBUG("Invalid precision");
             return -1;
-    }
-    return 0;
+        }
+      }
+
+      //  Configure ADC Module with adc_config.
+      init = adc_configure(dev);
+      if(init == -1)
+        return -1;
+
+      break;
+#endif
+    default:
+      return -1;
+  }
+  return 0;
 }
 
 int adc_sample(adc_t dev, int channel)
@@ -101,22 +105,24 @@ int adc_sample(adc_t dev, int channel)
   }
 
   // Select the inputs.
-  #if ADC_0_DIFFERENTIAL_MODE
+  if (adc_config.differential_mode)
+  {
     /*  In differential mode, use ADC_0_POS_INPUT & ADC_0_NEG_INPUT
      */
-    ADC->INPUTCTRL.reg = ADC_0_GAIN_FACTOR_DEFAULT
+    ADC->INPUTCTRL.reg = adc_config.gain
                           /*| (ADC_0_PIN_SCAN_OFFSET_START << ADC_INPUTCTRL_INPUTOFFSET_Pos)
                           | (ADC_0_PIN_SCAN_INPUT_TO_SCAN << ADC_INPUTCTRL_INPUTSCAN_Pos)*/
                           | ADC_0_NEG_INPUT
                           | ADC_0_POS_INPUT;
-  #else
+  } else
+  {
     /*  Otherwise, use the positive input corresponding to the provided arg
      *  "channel", and use GND as the negative input.
      */
-    ADC->INPUTCTRL.reg = ADC_0_GAIN_FACTOR_DEFAULT
+    ADC->INPUTCTRL.reg = adc_config.gain
                           | adc_channels[channel].muxpos
                           | ADC_INPUTCTRL_MUXNEG_IOGND;
-  #endif
+  }
 
   // Wait for sync.
   while (ADC->STATUS.reg & ADC_STATUS_SYNCBUSY);
@@ -133,242 +139,271 @@ int adc_sample(adc_t dev, int channel)
 
 void adc_poweron(adc_t dev)
 {
-    switch (dev)
-    {
-    #if ADC_0_EN
-        case ADC_0:
-            /* Setup generic clock mask for adc */
-            PM->APBCMASK.reg |= PM_APBCMASK_ADC;
-            break;
-    #endif
-        default:
-            break;
-    }
+  switch (dev)
+  {
+#if ADC_0_EN
+    case ADC_0:
+      /* Setup generic clock mask for adc */
+      PM->APBCMASK.reg |= PM_APBCMASK_ADC;
+      break;
+#endif
+    default:
+        break;
+  }
 }
 
 void adc_poweroff(adc_t dev)
 {
-    Adc *adc = 0;
+  Adc *adc = 0;
 
-    switch (dev)
-    {
-    #if ADC_0_EN
-        case ADC_0:
-            adc = ADC_0_DEV;
-            while(adc_syncing(adc));
-            /* Disable */
-            adc->CTRLA.reg &= ~ADC_CTRLA_ENABLE;
-            break;
-    #endif
-        default:
-            break;
-    }
+  switch (dev)
+  {
+#if ADC_0_EN
+    case ADC_0:
+      adc = ADC_0_DEV;
+      while(adc_syncing(adc));
+      /* Disable */
+      adc->CTRLA.reg &= ~ADC_CTRLA_ENABLE;
+      break;
+#endif
+    default:
+      break;
+  }
 }
 
 int adc_map(adc_t dev, int value, int min, int max)
 {
-    return (int)adc_mapf(dev, value, (float)min, (float)max);
+  return (int)adc_mapf(dev, value, (float)min, (float)max);
 }
 
 float adc_mapf(adc_t dev, int value, float min, float max)
 {
-    int resolution_bits;
-    switch (adc_conf.precision)
-    {
-        case ADC_RES_8BIT:
-            resolution_bits = 8;
-            break;
-        case ADC_RES_10BIT:
-            resolution_bits = 10;
-            break;
-        case ADC_RES_12BIT:
-            resolution_bits = 12;
-            break;
-        case ADC_RES_16BIT:
-            resolution_bits = 16;
-            break;
-        default:
-            return -1;
-    }
-    return ((max - min) / ((float)(1 << resolution_bits) - 1)) * value;
+  int resolution_bits;
+  switch (adc_config.precision)
+  {
+    case ADC_0_RES_8BIT:
+      resolution_bits = 8;
+      break;
+    case ADC_0_RES_10BIT:
+      resolution_bits = 10;
+      break;
+    case ADC_0_RES_12BIT:
+      resolution_bits = 12;
+      break;
+    case ADC_0_RES_16BIT:
+      resolution_bits = 16;
+      break;
+    default:
+      return -1;
+  }
+  return ((max - min) / ((float)(1 << resolution_bits) - 1)) * value;
 }
 
 bool adc_syncing(Adc* adc)
 {
-    if(adc->STATUS.reg & ADC_STATUS_SYNCBUSY){
-        return true;
-    }
-    return false;
+  if(adc->STATUS.reg & ADC_STATUS_SYNCBUSY){
+    return true;
+  }
+  return false;
 }
 
-/* Configure ADC with defined Resolution */
-int adc_configure_with_resolution(Adc* adc, uint32_t precision)
+adc_conf_t* adc_get_configuration(adc_t dev)
 {
-    adc_poweron(ADC_0);
-    uint8_t  divideResult = ADC_0_DIV_RES_DEFAULT;
-    uint32_t resolution = ADC_0_RES_16BIT;
-    uint32_t accumulate = ADC_0_ACCUM_DEFAULT;
-    if(adc->CTRLA.reg & ADC_CTRLA_SWRST)
-        return -1;
-    if(adc->CTRLA.reg & ADC_CTRLA_ENABLE)
-        return -1;
+  return &adc_config;
+}
 
-    /* GCLK Setup*/
-    GCLK->CLKCTRL.reg = (uint32_t)((GCLK_CLKCTRL_CLKEN
-                          | GCLK_CLKCTRL_GEN_GCLK0
-                          | (ADC_GCLK_ID << GCLK_CLKCTRL_ID_Pos)));
+int adc_test(void)
+{
+  printf("%lu", adc_config.accumulate);
+  return 0;
+}
 
-    /* Pin Muxing */
-    #if ADC_0_DIFFERENTIAL_MODE
-      /*  Configure ADC_0_POS_INPUT and ADC_0_NEG_INPUT */
-      ADC_0_PORT.PINCFG[ ADC_0_POS_INPUT ].bit.PMUXEN = 1;
-      ADC_0_PORT.PMUX[ ADC_0_POS_INPUT / 2].bit.PMUXE = 1;
+/* Configure ADC with parameters set in adc_conf */
+int adc_configure(adc_t dev)
+{
 
-      /* ADC_0_POS_INPUT Input */
-      ADC_0_PORT.DIRCLR.reg = (1UL << ADC_0_POS_INPUT);
-      ADC_0_PORT.PINCFG[ADC_0_POS_INPUT].bit.INEN = true;
-      ADC_0_PORT.PINCFG[ADC_0_POS_INPUT].bit.PULLEN = false;
-
-      /* ADC_0_NEG_INPUT Input */
-      if(ADC_0_NEG_INPUT != ADC_INPUTCTRL_MUXNEG_GND)
-      {
-          ADC_0_PORT.DIRCLR.reg = (1UL << ADC_0_NEG_INPUT);
-          ADC_0_PORT.PINCFG[ADC_0_NEG_INPUT].bit.INEN = true;
-          ADC_0_PORT.PINCFG[ADC_0_NEG_INPUT].bit.PULLEN = false;
-      }
-    #else
-      /*  Configure all positive inputs enumerated in adc_channels  */
-      for (int i = 0; i < ADC_0_CHANNELS; i++) {
-         PortGroup *port = adc_channels[i].port;
-         int pin = adc_channels[i].pin;
-         port->DIRCLR.reg = (1 << pin);
-         port->PINCFG[pin].reg = (PORT_PINCFG_PMUXEN | PORT_PINCFG_INEN);
-         port->PMUX[pin >> 1].reg = ~(0xf << (4 * (pin & 0x1)));
-         port->PMUX[pin >> 1].reg =  (1 << (4 * (pin & 0x1)));
-      }
-    #endif
-
-
-    /* Set RUN_IN_STANDBY */
-    adc->CTRLA.reg = (ADC_0_RUN_IN_STANDBY << ADC_CTRLA_RUNSTDBY_Pos);
-
-    /* Set Voltage Reference */
-    adc->REFCTRL.reg = (ADC_0_REF_COM_EN << ADC_REFCTRL_REFCOMP_Pos) | ADC_0_REF_DEFAULT;
-
-    switch (precision)
-    {
-    case ADC_0_RES_8BIT:
-        resolution = ADC_0_RES_8BIT;
-        break;
-    case ADC_0_RES_10BIT:
-        resolution = ADC_0_RES_10BIT;
-        break;
-    case ADC_0_RES_12BIT:
-        resolution = ADC_0_RES_12BIT;
-        break;
-    case ADC_0_RES_16BIT:
-        divideResult = ADC_0_DIV_RES_DISABLE;
-        switch(ADC_0_ACCUM_DEFAULT)
-        {
-            case ADC_0_ACCUM_512:
-                accumulate = ADC_0_ACCUM_512;
-                break;
-            case ADC_0_ACCUM_1024:
-                accumulate = ADC_0_ACCUM_1024;
-                break;
-            default:
-                accumulate = ADC_0_ACCUM_256;
-                break;
-        }
-        resolution = ADC_0_RES_16BIT;
-        break;
+  //  Define ADC device corresponding to dev.
+  Adc *adc = 0;
+  switch (dev)
+  {
+#if ADC_0_EN
+    case ADC_0:
+      adc = ADC_0_DEV;
+      break;
+#endif
     default:
-        DEBUG("Invalid precision");
-        return -1;
-    }
+      break;
+  }
 
-    /* Set the accumlation and divide result */
-    adc->AVGCTRL.reg = ADC_AVGCTRL_ADJRES(divideResult) | accumulate;
+  //  Wait for sync.
+  while(adc_syncing(adc));
 
-    /* Set Sample length */
-    adc->SAMPCTRL.reg = ADC_SAMPCTRL_SAMPLEN(ADC_0_SAMPLE_LENGTH);//(ADC_0_SAMPLE_LENGTH << ADC_SAMPCTRL_SAMPLEN_Pos);
-    while(adc_syncing(adc));
+  //  Disable ADC Module before init.
+  adc->CTRLA.reg &= ~ADC_CTRLA_ENABLE;
 
-    /* If external vref. Pin setup */
-    if(ADC_0_REF_DEFAULT == ADC_0_REF_EXT_B)
+  /* Power On */
+  adc_poweron(ADC_0);
+
+  if(adc->CTRLA.reg & ADC_CTRLA_SWRST)
+    return -1;
+  if(adc->CTRLA.reg & ADC_CTRLA_ENABLE)
+    return -1;
+
+  /* GCLK Setup*/
+  GCLK->CLKCTRL.reg = (uint32_t)((GCLK_CLKCTRL_CLKEN
+                        | GCLK_CLKCTRL_GEN_GCLK0
+                        | (ADC_GCLK_ID << GCLK_CLKCTRL_ID_Pos)));
+
+  /* Pin Muxing */
+  if (adc_config.differential_mode)
+  {
+    /*
+    //  Configure ADC_0_POS_INPUT and ADC_0_NEG_INPUT
+    ADC_0_PORT.PINCFG[ ADC_0_POS_INPUT ].bit.PMUXEN = 1;
+    ADC_0_PORT.PMUX[ ADC_0_POS_INPUT / 2].bit.PMUXE = 1;
+
+    //  ADC_0_POS_INPUT Input
+    ADC_0_PORT.DIRCLR.reg = (1UL << ADC_0_POS_INPUT);
+    ADC_0_PORT.PINCFG[ADC_0_POS_INPUT].bit.INEN = true;
+    ADC_0_PORT.PINCFG[ADC_0_POS_INPUT].bit.PULLEN = false;
+
+    //  ADC_0_NEG_INPUT Input
+    if(ADC_0_NEG_INPUT != ADC_INPUTCTRL_MUXNEG_GND)
     {
-        ADC_0_PORT.DIRCLR.reg = (1 << ADC_0_REF_DEFAULT);
-        ADC_0_PORT.PINCFG[ADC_0_REF_DEFAULT].bit.INEN = true;
-        ADC_0_PORT.PINCFG[ADC_0_REF_DEFAULT].bit.PULLEN = false;
+      ADC_0_PORT.DIRCLR.reg = (1UL << ADC_0_NEG_INPUT);
+      ADC_0_PORT.PINCFG[ADC_0_NEG_INPUT].bit.INEN = true;
+      ADC_0_PORT.PINCFG[ADC_0_NEG_INPUT].bit.PULLEN = false;
     }
+    */
+  } else
+  {
+    /*  Configure all positive inputs enumerated in adc_channels  */
+    for (int i = 0; i < ADC_0_CHANNELS; i++) {
+      PortGroup *port = adc_channels[i].port;
+      int pin = adc_channels[i].pin;
+      port->DIRCLR.reg = (1 << pin);
+      port->PINCFG[pin].reg = (PORT_PINCFG_PMUXEN | PORT_PINCFG_INEN);
+      port->PMUX[pin >> 1].reg = ~(0xf << (4 * (pin & 0x1)));
+      port->PMUX[pin >> 1].reg =  (1 << (4 * (pin & 0x1)));
+    }
+  }
 
-    /* Configure CTRLB Register HERE IS THE RESOLUTION SET!*/
-    adc->CTRLB.reg =
-        ADC_0_PRESCALER |
-        resolution |
-        (ADC_0_CORRECTION_EN << ADC_CTRLB_CORREN_Pos) |
-        (ADC_0_FREE_RUNNING << ADC_CTRLB_FREERUN_Pos) |
-        (ADC_0_LEFT_ADJUST << ADC_CTRLB_LEFTADJ_Pos) |
-        (ADC_0_DIFFERENTIAL_MODE << ADC_CTRLB_DIFFMODE_Pos);
+  /* Set RUN_IN_STANDBY */
+  adc->CTRLA.reg = (adc_config.run_in_standby << ADC_CTRLA_RUNSTDBY_Pos);
 
+  /* Set Voltage Reference */
+  adc->REFCTRL.reg = (ADC_0_REF_COM_EN << ADC_REFCTRL_REFCOMP_Pos) | ADC_0_REF_DEFAULT;
 
-    /* Configure Window Mode Register */
-    /*adc->WINCTRL.reg = ADC_0_WINDOW_MODE;
-    while(adc_syncing(adc));*/
-
-    /* Configure lower threshold */
-    adc->WINLT.reg = ADC_0_WINDOW_LOWER << ADC_WINLT_WINLT_Pos;
-    while(adc_syncing(adc));
-
-    /* Configure lower threshold */
-    adc->WINUT.reg = ADC_0_WINDOW_HIGHER << ADC_WINUT_WINUT_Pos;
-    while(adc_syncing(adc));
-
-    /* Configure PIN SCAN MODE & positive & Negative Input Pins */
-    /*adc->INPUTCTRL.reg =
-        ADC_0_GAIN_FACTOR_DEFAULT |
-        (ADC_0_PIN_SCAN_OFFSET_START << ADC_INPUTCTRL_INPUTOFFSET_Pos) |
-        (ADC_0_PIN_SCAN_INPUT_TO_SCAN << ADC_INPUTCTRL_INPUTSCAN_Pos) |
-        ADC_0_NEG_INPUT |
-        ADC_0_POS_INPUT;*/
-
-    /* Configure event action */
-    adc->EVCTRL.reg = ADC_0_EVENT_ACTION;
-
-    if (ADC_0_CORRECTION_EN)
+  /* Configure Hardware Averaging */
+  uint32_t resolution = adc_config.precision;
+  uint32_t accumulate = adc_config.accumulate;
+  uint8_t  divideResult = adc_config.divide;
+  if (ADC_0_RES_16BIT == resolution)
+  {
+    // In the subcase of 16-bit resolution,
+    // handle the edge case of overflow-by-
+    // division.
+    divideResult = ADC_0_DIV_RES_DISABLE;
+    switch(accumulate)
     {
-        if (ADC_0_GAIN_CORRECTION > ADC_GAINCORR_GAINCORR_Msk)
-        {
-            DEBUG("Invalid gain correction\n");
-            return -1;
-        }
-        else
-        {
-            /* Set gain correction value */
-            adc->GAINCORR.reg = (ADC_0_GAIN_CORRECTION << ADC_GAINCORR_GAINCORR_Pos);
-        }
-        if (ADC_0_OFFSET_CORRECTION > 2047 || ADC_0_OFFSET_CORRECTION < -2048)
-        {
-            DEBUG("Invalid offset correction\n");
-            return -1;
-        }
-        else
-        {
-            /* Set offset correction value */
-            adc->OFFSETCORR.reg = (ADC_0_OFFSET_CORRECTION << ADC_OFFSETCORR_OFFSETCORR_Pos);
-        }
+      case ADC_0_ACCUM_512:
+        accumulate = ADC_0_ACCUM_512;
+        break;
+      case ADC_0_ACCUM_1024:
+        accumulate = ADC_0_ACCUM_1024;
+        break;
+      default:
+        accumulate = ADC_0_ACCUM_256;
+        break;
     }
+    resolution = ADC_0_RES_16BIT;
+  }
 
-    /* Disable all interrupts */
-    adc->INTENCLR.reg =
-        (1 << ADC_INTENCLR_SYNCRDY_Pos) | (1 << ADC_INTENCLR_WINMON_Pos) |
-        (1 << ADC_INTENCLR_OVERRUN_Pos) | (1 << ADC_INTENCLR_RESRDY_Pos);
+  /* Set the accumulation and divide result */
+  adc->AVGCTRL.reg = ADC_AVGCTRL_ADJRES(divideResult) | accumulate;
 
-    /* Load the fixed device calibration constants*/
-    adc->CALIB.reg = ADC_CALIB_BIAS_CAL((*(uint32_t*)ADC_FUSES_BIASCAL_ADDR >> ADC_FUSES_BIASCAL_Pos))
-                    | ADC_CALIB_LINEARITY_CAL((*(uint64_t*)ADC_FUSES_LINEARITY_0_ADDR >> ADC_FUSES_LINEARITY_0_Pos));
+  /* Set Sample length */
+  adc->SAMPCTRL.reg = ADC_SAMPCTRL_SAMPLEN(ADC_0_SAMPLE_LENGTH);//(ADC_0_SAMPLE_LENGTH << ADC_SAMPCTRL_SAMPLEN_Pos);
+  while(adc_syncing(adc));
 
-    return 1;
+  /* If external vref. Pin setup */
+  if(ADC_0_REF_DEFAULT == ADC_0_REF_EXT_B)
+  {
+    ADC_0_PORT.DIRCLR.reg = (1 << ADC_0_REF_DEFAULT);
+    ADC_0_PORT.PINCFG[ADC_0_REF_DEFAULT].bit.INEN = true;
+    ADC_0_PORT.PINCFG[ADC_0_REF_DEFAULT].bit.PULLEN = false;
+  }
+
+  /* Configure CTRLB Register HERE IS THE RESOLUTION SET!*/
+  adc->CTRLB.reg =
+      adc_config.prescaler |
+      resolution |
+      (ADC_0_CORRECTION_EN << ADC_CTRLB_CORREN_Pos) |
+      (ADC_0_FREE_RUNNING << ADC_CTRLB_FREERUN_Pos) |
+      (ADC_0_LEFT_ADJUST << ADC_CTRLB_LEFTADJ_Pos) |
+      (adc_config.differential_mode << ADC_CTRLB_DIFFMODE_Pos);
+
+
+  /* Configure Window Mode Register */
+  /*adc->WINCTRL.reg = ADC_0_WINDOW_MODE;
+  while(adc_syncing(adc));*/
+
+  /* Configure lower threshold */
+  adc->WINLT.reg = ADC_0_WINDOW_LOWER << ADC_WINLT_WINLT_Pos;
+  while(adc_syncing(adc));
+
+  /* Configure lower threshold */
+  adc->WINUT.reg = ADC_0_WINDOW_HIGHER << ADC_WINUT_WINUT_Pos;
+  while(adc_syncing(adc));
+
+  /* Configure event action */
+  adc->EVCTRL.reg = ADC_0_EVENT_ACTION;
+
+  if (ADC_0_CORRECTION_EN)
+  {
+    if (ADC_0_GAIN_CORRECTION > ADC_GAINCORR_GAINCORR_Msk)
+    {
+      DEBUG("Invalid gain correction\n");
+      return -1;
+    }
+    else
+    {
+      /* Set gain correction value */
+      adc->GAINCORR.reg = (ADC_0_GAIN_CORRECTION << ADC_GAINCORR_GAINCORR_Pos);
+    }
+    if (ADC_0_OFFSET_CORRECTION > 2047 || ADC_0_OFFSET_CORRECTION < -2048)
+    {
+      DEBUG("Invalid offset correction\n");
+      return -1;
+    }
+    else
+    {
+      /* Set offset correction value */
+      adc->OFFSETCORR.reg = (ADC_0_OFFSET_CORRECTION << ADC_OFFSETCORR_OFFSETCORR_Pos);
+    }
+  }
+
+  /* Disable all interrupts */
+  adc->INTENCLR.reg =
+      (1 << ADC_INTENCLR_SYNCRDY_Pos) | (1 << ADC_INTENCLR_WINMON_Pos) |
+      (1 << ADC_INTENCLR_OVERRUN_Pos) | (1 << ADC_INTENCLR_RESRDY_Pos);
+
+  /* Load the fixed device calibration constants*/
+  adc->CALIB.reg = ADC_CALIB_BIAS_CAL((*(uint32_t*)ADC_FUSES_BIASCAL_ADDR >> ADC_FUSES_BIASCAL_Pos))
+                  | ADC_CALIB_LINEARITY_CAL((*(uint64_t*)ADC_FUSES_LINEARITY_0_ADDR >> ADC_FUSES_LINEARITY_0_Pos));
+
+  while(adc_syncing(adc));
+
+  //  Enable bandgap if VREF is internal 1V.
+  if(ADC_0_REF_DEFAULT == ADC_0_REF_INT_1V)
+  {
+    SYSCTRL->VREF.reg |= SYSCTRL_VREF_BGOUTEN;
+  }
+
+  //  Enable ADC Module.
+  adc->CTRLA.reg |= ADC_CTRLA_ENABLE;
+
+  return 1;
 }
 
 /* Clear interrupt status flags */
@@ -377,11 +412,11 @@ void adc_clear_status(Adc* adc, uint32_t status_flag)
     uint32_t interrupt_flags = 0;
 
     if(status_flag & ADC_0_STATUS_RESULT_READY)
-        interrupt_flags |= ADC_INTFLAG_RESRDY;
+      interrupt_flags |= ADC_INTFLAG_RESRDY;
     if(status_flag & ADC_0_STATUS_WINDOW)
-        interrupt_flags |= ADC_INTFLAG_WINMON;
+      interrupt_flags |= ADC_INTFLAG_WINMON;
     if(status_flag & ADC_0_STATUS_OVERRUN)
-        interrupt_flags |= ADC_INTFLAG_OVERRUN;
+      interrupt_flags |= ADC_INTFLAG_OVERRUN;
     /* Clear interrupt flag*/
     adc->INTFLAG.reg = interrupt_flags;
 }
@@ -393,11 +428,11 @@ uint32_t adc_get_status(Adc* adc)
     uint32_t status_flags = 0;
 
     if(interrupt_flags & ADC_INTFLAG_RESRDY)
-        status_flags |= ADC_0_STATUS_RESULT_READY;
+      status_flags |= ADC_0_STATUS_RESULT_READY;
     if(interrupt_flags & ADC_INTFLAG_WINMON)
-        status_flags |= ADC_0_STATUS_WINDOW;
+      status_flags |= ADC_0_STATUS_WINDOW;
     if(interrupt_flags & ADC_INTFLAG_OVERRUN)
-        status_flags |= ADC_0_STATUS_OVERRUN;
+      status_flags |= ADC_0_STATUS_OVERRUN;
     return status_flags;
 }
 

--- a/cpu/samd21/periph/adc.c
+++ b/cpu/samd21/periph/adc.c
@@ -40,14 +40,10 @@ uint32_t adc_get_status(Adc*);
 
 int adc_init(adc_t dev, adc_precision_t precision)
 {
-  //Adc *adc = 0;
   int init = 0;
   switch (dev) {
 #if ADC_0_EN
     case ADC_0:
-      //  Define ADC device.
-      //adc = ADC_0_DEV;
-
       //  Initialize adc_config defaults.
       if (!adc_config.prescaler)
         adc_config.prescaler = ADC_0_PRESCALER;
@@ -57,6 +53,8 @@ int adc_init(adc_t dev, adc_precision_t precision)
         adc_config.accumulate = ADC_0_ACCUM_DEFAULT;
       if (!adc_config.divide)
         adc_config.divide = ADC_0_DIV_RES_DEFAULT;
+      if (!adc_config.vref)
+        adc_config.vref = ADC_0_REF_DEFAULT;
       if (!adc_config.differential_mode)
         adc_config.differential_mode = ADC_0_DIFFERENTIAL_MODE;
       if (!adc_config.run_in_standby)
@@ -292,7 +290,7 @@ int adc_configure(adc_t dev)
   adc->CTRLA.reg = (adc_config.run_in_standby << ADC_CTRLA_RUNSTDBY_Pos);
 
   /* Set Voltage Reference */
-  adc->REFCTRL.reg = (ADC_0_REF_COM_EN << ADC_REFCTRL_REFCOMP_Pos) | ADC_0_REF_DEFAULT;
+  adc->REFCTRL.reg = (ADC_0_REF_COM_EN << ADC_REFCTRL_REFCOMP_Pos) | adc_config.vref;
 
   /* Configure Hardware Averaging */
   uint32_t resolution = adc_config.precision;
@@ -327,11 +325,11 @@ int adc_configure(adc_t dev)
   while(adc_syncing(adc));
 
   /* If external vref. Pin setup */
-  if(ADC_0_REF_DEFAULT == ADC_0_REF_EXT_B)
+  if(adc_config.vref == ADC_0_REF_EXT_B)
   {
-    ADC_0_PORT.DIRCLR.reg = (1 << ADC_0_REF_DEFAULT);
-    ADC_0_PORT.PINCFG[ADC_0_REF_DEFAULT].bit.INEN = true;
-    ADC_0_PORT.PINCFG[ADC_0_REF_DEFAULT].bit.PULLEN = false;
+    ADC_0_PORT.DIRCLR.reg = (1 << adc_config.vref);
+    ADC_0_PORT.PINCFG[adc_config.vref].bit.INEN = true;
+    ADC_0_PORT.PINCFG[adc_config.vref].bit.PULLEN = false;
   }
 
   /* Configure CTRLB Register HERE IS THE RESOLUTION SET!*/
@@ -395,7 +393,7 @@ int adc_configure(adc_t dev)
   while(adc_syncing(adc));
 
   //  Enable bandgap if VREF is internal 1V.
-  if(ADC_0_REF_DEFAULT == ADC_0_REF_INT_1V)
+  if(adc_config.vref == ADC_0_REF_INT_1V)
   {
     SYSCTRL->VREF.reg |= SYSCTRL_VREF_BGOUTEN;
   }

--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -51,6 +51,11 @@ typedef enum {
 #endif
 } adc_t;
 
+#ifndef ADC_CONF_TYPE_DEFINED
+#define ADC_CONF_TYPE_DEFINED 1
+typedef struct {} adc_conf_t;
+#endif
+
 /**
  * @brief Possible ADC precision settings
  */
@@ -77,6 +82,35 @@ typedef enum {
  * @return                  -1 on precision not available
  */
 int adc_init(adc_t dev, adc_precision_t precision);
+
+/**
+ * @brief Updates the hardware settings of a given ADC device.
+ *
+ * This will disable the ADC device, and then reconfigure the hardware according to the parameters
+ * currently set inside adc_config.  The adc_config object can be changed by acquiring a pointer to it
+ * from adc_conf_t adc_get_configuration(adc_t dev).
+ *
+ * @param[in] dev           the device to initialize
+ *
+ * @return                  0 on success
+ * @return                  -1 on error
+ */
+int adc_configure(adc_t dev);
+
+/**
+ * @brief Return the configuration of a given ADC device.
+ *
+ * A pointer to the ADC's configuration object will be returned, which may be then used to configured
+ * directly from the application code.  This can be done prior to adc_init.  If adc_config is modified
+ * after adc_init, adc_configure(adc_t dev) can be called to apply the new parameters.  The available
+ * parameters for adc_conf_t differ by board, are enumerated in periph_conf.h if available.  Some boards
+ * have no parameters available, and adc_conf will be null.
+ *
+ * @param[in] dev           the device to initialize
+ *
+ * @return                  Pointer to ADC configuration object
+ */
+adc_conf_t* adc_get_configuration(adc_t dev);
 
 /**
  * @brief Start a new conversion by using the given channel.


### PR DESCRIPTION
Analog-to-Digital Converter for the SAMR21-xpro board.

A continuation of @wiredsource and @haukepetersen (https://github.com/RIOT-OS/RIOT/pull/2063).
- [x] Multiple positive input channels (PA06, PA07, PA08, PA09, PB02, PB03)
- [ ] Differential mode (add a `.positive_input` and `.negative_input` to the newly refactored `adc_config` object)
- [x] Result mapping (`adc_map`, `adc_mapf`)
- [x] Gain
- [x] Clock prescaler
- [x] External voltage reference (~~this should work with VREFB -- untested~~ works)
- [ ] Window mode
- [x] Hardware averaging: accumulation & division
- [ ] Sample Length
- [ ] Pin scan (is there even any demand for this?)
- [x] PA04 & PA05 - UART conflict w/ EDBG.  ~~Enable these pins by default or not?  Would make life for developers hell.~~ Disabled by default, `periph_conf.h` includes note explaining why.
