### PR TITLE
Subsystem for different uart implementations (e.g. peripheral UART and one over USB)

### DIFF
--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -79,7 +79,12 @@ extern "C"
 * @name UART configuration
 * @{
 */
+#if MODULE_USBDEV
+#define UART_NUMOF                   (2U)
+#define UART_ACM_0_EN                1
+#else
 #define UART_NUMOF                   (1U)
+#endif
 #define UART_0_EN                    1
 #define UART_IRQ_PRIO                1
 #define UART_CLK                     CLOCK_CORECLOCK

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -82,7 +82,12 @@ extern "C"
  * @name UART configuration
  * @{
  */
+#if MODULE_USBDEV
+#define UART_NUMOF          (2U)
+#define UART_ACM_0_EN       1
+#else
 #define UART_NUMOF          (1U)
+#endif
 #define UART_0_EN           1
 #define UART_1_EN           0
 #define UART_IRQ_PRIO       1

--- a/core/include/init.h
+++ b/core/include/init.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  core_util
+ * @{
+ *
+ * @file
+ * @brief       Macros for initialisation of subsystem and drivers
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ */
+
+#ifndef INIT_H_
+#define INIT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define INIT_ORDER_CORE         0
+#define INIT_ORDER_DRIVER       1
+#define INIT_ORDER_SUBMOD       2
+#define INIT_ORDER_MODULE       3
+
+typedef int (*initcall_t)(void);
+
+#define __system_initcall(name, fp, order) static initcall_t __initcall_##fp##order \
+                                           __attribute__((__used__)) \
+                                           __attribute__((section(".preinit_array." #order "." name))) \
+                                           __attribute__((aligned(sizeof(void*)))) = fp
+
+#define core_init(fp) __system_initcall("core", fp, 0)
+
+#define driver_init(fp) __system_initcall("driver", fp, 1)
+
+#define submod_init(fp) __system_initcall("submod", fp, 2)
+
+#define module_init(fp) __system_initcall("module", fp, 3)
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INIT_H_ */
+/** @} */

--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -49,15 +49,18 @@ SECTIONS
         . = ALIGN(4);
         KEEP(*(.init))
         . = ALIGN(4);
-        __preinit_array_start = .;
-        KEEP (*(.preinit_array))
-        __preinit_array_end = .;
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(SORT(.preinit_array.*)))
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
 
         . = ALIGN(4);
-        __init_array_start = .;
-        KEEP (*(SORT(.init_array.*)))
-        KEEP (*(.init_array))
-        __init_array_end = .;
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
 
         . = ALIGN(0x4);
         KEEP (*crtbegin.o(.ctors))
@@ -69,10 +72,11 @@ SECTIONS
         KEEP(*(.fini))
 
         . = ALIGN(4);
-        __fini_array_start = .;
-        KEEP (*(.fini_array))
-        KEEP (*(SORT(.fini_array.*)))
-        __fini_array_end = .;
+        /* fini data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP (*crtbegin.o(.dtors))
         KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))

--- a/cpu/kinetis_common/Makefile.include
+++ b/cpu/kinetis_common/Makefile.include
@@ -5,6 +5,7 @@ export INCLUDES += -I$(RIOTCPU)/kinetis_common/include
 export LINKFLAGS += -L$(RIOTCPU)/kinetis_common/ldscripts
 
 # add the CPU specific code for the linker
+export UNDEF += $(BINDIR)kinetis_common/uart.o
 export UNDEF += $(BINDIR)kinetis_common/fcfield.o
 
 # include kinetis common periph drivers

--- a/drivers/include/periph/dev_enums.h
+++ b/drivers/include/periph/dev_enums.h
@@ -195,6 +195,12 @@ enum {
 #if UART_6_EN
     UART_6,                 /**< UART 6 */
 #endif
+#if UART_ACM_0_EN
+    UART_ACM_0,             /**< UART 0 over USB */
+#endif
+#if UART_ACM_1_EN
+    UART_ACM_1,             /**< UART 1 over USB */
+#endif
     UART_UNDEFINED          /**< Deprecated symbol, use UART_UNDEF instead */
 };
 

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -163,6 +163,25 @@ void uart_poweron(uart_t uart);
  */
 void uart_poweroff(uart_t uart);
 
+/**
+ * @brief   uart device extended API definition.
+ *
+ * @details This is a set of functions that must be implemented by any driver.
+ */
+typedef struct {
+    uart_t dev;
+
+    int (*uart_init)(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg);
+
+    void (*uart_write)(uart_t uart, const uint8_t *data, size_t len);
+
+    void (*uart_poweron)(uart_t uart);
+
+    void (*uart_poweroff)(uart_t uart);
+} uartdev_ops_t;
+
+int uartdev_register_driver(uartdev_ops_t *uart_ops);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -93,6 +93,10 @@ ifneq (,$(filter sema,$(USEMODULE)))
     DIRS += sema
 endif
 
+ifneq (,$(filter uart,$(USEMODULE)))
+    DIRS += uart
+endif
+
 DIRS += $(dir $(wildcard $(addsuffix /Makefile, ${USEMODULE})))
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/uart/Makefile
+++ b/sys/uart/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/uart/uart.c
+++ b/sys/uart/uart.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    driver_periph_extended_uart UART
+ * @ingroup     driver_periph
+ * @brief       Low-level extended UART peripheral driver
+ *
+ * @{
+ *
+ * @file
+ * @brief       Low-level UART driver implementation
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "periph/uart.h"
+
+
+static uartdev_ops_t *uartdev_lt[UART_NUMOF];
+
+int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
+{
+    if (uartdev_lt[uart]) {
+       return uartdev_lt[uart]->uart_init(uart, baudrate, rx_cb, arg);
+    }
+    return -1;
+}
+
+void uart_write(uart_t uart, const uint8_t *data, size_t len)
+{
+    if (uartdev_lt[uart]) {
+        uartdev_lt[uart]->uart_write(uart, data, len);
+    }
+}
+
+void uart_poweron(uart_t uart)
+{
+    if (uartdev_lt[uart]) {
+        uartdev_lt[uart]->uart_poweron(uart);
+    }
+}
+
+
+void uart_poweroff(uart_t uart)
+{
+    if (uartdev_lt[uart]) {
+        uartdev_lt[uart]->uart_poweroff(uart);
+    }
+}
+
+
+int uartdev_register_driver(uartdev_ops_t *uart_ops)
+{
+    if (uart_ops->dev > UART_NUMOF) {
+        return -1;
+    }
+
+    if (uartdev_lt[uart_ops->dev] == NULL) {
+        uartdev_lt[uart_ops->dev] = uart_ops;
+        return 0;
+    }
+    return -1;
+}

--- a/tests/init/Makefile
+++ b/tests/init/Makefile
@@ -1,0 +1,12 @@
+APPLICATION = init_test
+include ../Makefile.tests_common
+
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+USEMODULE += xtimer
+
+# chronos is missing a getchar implementation
+BOARD_BLACKLIST += chronos
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/init/main.c
+++ b/tests/init/main.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @file
+ * @brief       Init Test
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ *
+ */
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "shell_commands.h"
+#include "shell.h"
+#include "init.h"
+
+volatile static uint32_t init_pattern;
+
+int core_init_test(void)
+{
+    init_pattern |= (1 << INIT_ORDER_CORE);
+    return 0;
+}
+
+int driver_init_test(void)
+{
+    init_pattern |= (1 << INIT_ORDER_DRIVER);
+    return 0;
+}
+
+int module_init_test(void)
+{
+    init_pattern |= (1 << INIT_ORDER_MODULE);
+    return 0;
+}
+
+int submod_init_test(void)
+{
+    init_pattern |= (1 << INIT_ORDER_SUBMOD);
+    return 0;
+}
+
+core_init(core_init_test);
+driver_init(driver_init_test);
+module_init(module_init_test);
+submod_init(submod_init_test);
+
+int main(void)
+{
+    puts("RIOT init test application");
+
+    printf("init_pattern: 0x%08" PRIx32 "\n", init_pattern);
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}


### PR DESCRIPTION
This PR allows the use of different uart implementations (e.g. peripheral UART and one over USB).
~~Depends on #4114~~ and serves as an example for #4155 . WIP
