### PR TITLE
drivers/periph/gpio: fixed includes

### DIFF
--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -22,6 +22,9 @@
 #define GPIO_H
 
 #include "periph_cpu.h"
+#include "periph_conf.h"
+/* TODO: remove once all platforms are ported to this interface */
+#include "periph/dev_enums.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
the includes of `periph_conf.h` and `periph/dev_enums.h` were missing in the gpio driver interface. Including these allows for a more consistent use of the gpio driver, as this interface file already pulls in all needed dependencies...

These includes should be used with each peripheral driver, so they are consistent...