### PR TITLE
nc: ndp: add/use gnrc_ipv6_nc_t::rtr_adv_timer in gnrc_ndp_rtr_sol_handle

### DIFF
--- a/sys/include/net/gnrc/ipv6/nc.h
+++ b/sys/include/net/gnrc/ipv6/nc.h
@@ -149,6 +149,11 @@ typedef struct {
     xtimer_t nbr_adv_timer;
     msg_t nbr_adv_msg;                          /**< msg_t for gnrc_ipv6_nc_t::nbr_adv_timer */
 
+#if defined(MODULE_GNRC_NDP_ROUTER) || defined(MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER)
+    xtimer_t rtr_adv_timer;                     /**< Timer for periodic router advertisements */
+    msg_t rtr_adv_msg;                          /**< msg_t for gnrc_ipv6_nc_t::rtr_adv_timer */
+#endif
+
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
     xtimer_t type_timeout;                  /**< Timer for type transmissions */
     msg_t type_timeout_msg;                 /**< msg_t for gnrc_ipv6_nc_t::type_timeout */

--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -136,6 +136,11 @@ gnrc_ipv6_nc_t *gnrc_ipv6_nc_add(kernel_pid_t iface, const ipv6_addr_t *ipv6_add
     free_entry->rtr_timeout_msg.type = GNRC_NDP_MSG_RTR_TIMEOUT;
     free_entry->rtr_timeout_msg.content.ptr = (char *) free_entry;
 
+#if defined(MODULE_GNRC_NDP_ROUTER) || defined(MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER)
+    free_entry->rtr_adv_msg.type = GNRC_NDP_MSG_RTR_ADV_DELAY;
+    free_entry->rtr_adv_msg.content.ptr = (char *) free_entry;
+#endif
+
     return free_entry;
 }
 
@@ -157,6 +162,9 @@ void gnrc_ipv6_nc_remove(kernel_pid_t iface, const ipv6_addr_t *ipv6_addr)
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
         xtimer_remove(&entry->type_timeout);
+#endif
+#if defined(MODULE_GNRC_NDP_ROUTER) || defined(MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER)
+        xtimer_remove(&entry->rtr_adv_timer);
 #endif
 
         ipv6_addr_set_unspecified(&(entry->ipv6_addr));

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -452,8 +452,8 @@ void gnrc_ndp_rtr_sol_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
                 /* XXX: can't just use GNRC_NETAPI_MSG_TYPE_SND, since the next retransmission
                  * must also be set. */
                 gnrc_ipv6_nc_t *nc_entry = gnrc_ipv6_nc_get(iface, &ipv6->src);
-                vtimer_set_msg(&if_entry->rtr_adv_timer, delay, gnrc_ipv6_pid,
-                               GNRC_NDP_MSG_RTR_ADV_DELAY, nc_entry);
+                xtimer_set_msg(&nc_entry->rtr_adv_timer, (uint32_t) timex_uint64(delay),
+                               &nc_entry->rtr_adv_msg, gnrc_ipv6_pid);
             }
 #endif
         }


### PR DESCRIPTION
Use a separate timer of the `nc_entry` within the `gnrc_ndp_rtr_sol_handle()` function in the unicast case