### PR TITLE
New 'csma_sender' helper module

### DIFF
--- a/sys/include/net/gnrc/csma_sender.h
+++ b/sys/include/net/gnrc/csma_sender.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2015 INRIA
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_gnrc_csma_sender  Helper interface to send packets via CSMA/CA
+ * @ingroup     net_gnrc
+ * @brief       This interface allows code from layer 2 (MAC) or higher
+ *              to send packets with CSMA/CA, whatever the abilities and/or
+ *              configuration of a given radio transceiver device are.
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for the CSMA/CA helper
+ *
+ * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
+ */
+
+#ifndef GNRC_CSMA_SENDER_H_
+#define GNRC_CSMA_SENDER_H_
+
+#include "kernel.h"
+#include "net/gnrc.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * @brief Default Minimal CSMA/CA Backoff Exponent
+ */
+#define MAC_MIN_BE_DEFAULT               (3U)
+
+/**
+ * @brief Default Maximal CSMA/CA Backoff Exponent
+ */
+#define MAC_MAX_BE_DEFAULT               (5U)
+
+/**
+ * @brief Default Maximal number of retries for sending
+ *        a given packet with the CSMA/CA method
+ */
+#define MAC_MAX_CSMA_BACKOFFS_DEFAULT    (4U)
+
+/**
+ * @brief CSMA/CA backoff period, in microseconds
+ */
+#define A_UNIT_BACKOFF_PERIOD_MICROSEC   (320U)
+
+/**
+ * @brief Define a different (non-standard) value for
+ *        the CSMA macMinBE parameter.
+ *
+ * @param[in] val     new value for macMinBE
+ */
+void set_csma_mac_min_be(uint8_t val);
+
+/**
+ * @brief Define a different (non-standard) value for
+ *        the CSMA macMaxBE parameter.
+ *
+ * @param[in] val     new value for macMaxBE
+ */
+void set_csma_mac_max_be(uint8_t val);
+
+/**
+ * @brief Define a different (non-standard) value for
+ *        the CSMA macMaxCSMABackoffs parameter.
+ *
+ * @param[in] val     new value for macMaxCSMABackoffs
+ */
+void set_csma_mac_max_csma_backoffs(uint8_t val);
+
+/**
+ * @brief   Sends a 802.15.4 frame using the CSMA/CA method
+ *
+ * If the transceiver can (and is configured to) do hardware-assisted
+ * CSMA/CA, this feature is used. Otherwise, a software procedure is used.
+ *
+ * @param[in] dev       netdev device, needs to be already initialized
+ * @param[in] pkt       pointer to the data in the packet buffer;
+ *                      it must be a complete 802.15.4-compliant frame,
+ *                      ready to be sent to the radio transceiver
+ *
+ * @return              number of bytes that were actually send out
+ * @return              -ENODEV if @p dev is invalid
+ * @return              -ENOMSG if @p pkt is invalid
+ * @return              -EOVERFLOW if the payload size of @p pkt exceeds the
+ *                      payload size that can be handled by the device
+ * @return              -ECANCELED if an internal driver error occured
+ * @return              -EBUSY if radio medium never was available
+ *                      to send the given data
+ */
+int csma_ca_send(gnrc_netdev_t *dev, gnrc_pktsnip_t *pkt);
+
+/**
+ * @brief   Sends a 802.15.4 frame when medium is avaiable.
+ *
+ * This function is useful for sending packets without the whole CSMA/CA
+ * procedure, but *after* ensuring medium is available, that is :
+ * after a successful CCA. <br/>
+ * It is especially useful for broadcasting specific packets,
+ * like beacons; or for many sending packets in burst. <br/>
+ * ATTENTION: It only tries to send the given data once. If you want the
+ * complete CSMA/CA procedure with retries, use @c csma_ca_send().
+ *
+ * @param[in] dev       netdev device, needs to be already initialized
+ * @param[in] pkt       pointer to the data in the packet buffer;
+ *                      it must be a complete 802.15.4-compliant frame,
+ *                      ready to be sent to the radio transceiver
+ *
+ * @return              number of bytes that were actually send out
+ * @return              -ENODEV if @p dev is invalid
+ * @return              -ENOMSG if @p pkt is invalid
+ * @return              -EOVERFLOW if the payload size of @p pkt exceeds the
+ *                      payload size that can be handled by the device
+ * @return              -ECANCELED if an internal driver error occured
+ * @return              -EBUSY if radio medium was not available
+ *                      to send the given data
+ */
+int cca_send(gnrc_netdev_t *dev, gnrc_pktsnip_t *pkt);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GNRC_CSMA_SENDER_H_ */
+
+/** @} */

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -7,6 +7,9 @@ endif
 ifneq (,$(filter gnrc_conn_udp,$(USEMODULE)))
     DIRS += conn/udp
 endif
+ifneq (,$(filter gnrc_csma_sender,$(USEMODULE)))
+    DIRS += link_layer/csma_sender
+endif
 ifneq (,$(filter gnrc_icmpv6,$(USEMODULE)))
     DIRS += network_layer/icmpv6
 endif

--- a/sys/net/gnrc/link_layer/csma_sender/Makefile
+++ b/sys/net/gnrc/link_layer/csma_sender/Makefile
@@ -1,0 +1,6 @@
+MODULE = gnrc_csma_sender
+
+USEMODULE += xtimer
+USEMODULE += random
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/link_layer/csma_sender/gnrc_csma_sender.c
+++ b/sys/net/gnrc/link_layer/csma_sender/gnrc_csma_sender.c
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2015 INRIA
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net_csma_sender
+ * @file
+ * @brief       Implementation of the CSMA/CA helper
+ *
+ * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
+ * @}
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+
+#include "kernel.h"
+#include "xtimer.h"
+#include "random.h"
+#include "net/gnrc/csma_sender.h"
+#include "net/gnrc.h"
+#include "net/netopt.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#if ENABLE_DEBUG
+/* For PRIu16 etc. */
+#include <inttypes.h>
+#endif
+
+
+/** @brief Current value for mac_min_be parameter */
+static uint8_t mac_min_be = MAC_MIN_BE_DEFAULT;
+
+/** @brief Current value for mac_max_be parameter */
+static uint8_t mac_max_be = MAC_MAX_BE_DEFAULT;
+
+/** @brief Current value for mac_max_csma_backoffs parameter */
+static uint8_t mac_max_csma_backoffs = MAC_MAX_CSMA_BACKOFFS_DEFAULT;
+
+
+/*--------------------- "INTERNAL" UTILITY FUNCTIONS ---------------------*/
+
+/**
+ * @brief choose an adequate random backoff period in microseconds,
+ *        from the given Backoff Exponent
+ *
+ * @param[in] be        Backoff Exponent for the computation of period
+ *
+ * @return              An adequate random backoff exponent in microseconds
+ */
+static inline uint32_t choose_backoff_period(int be)
+{
+    if (be < mac_min_be) {
+        be = mac_min_be;
+    }
+    if (be > mac_max_be) {
+        be = mac_max_be;
+    }
+    uint32_t max_backoff = ((1 << be) - 1) * A_UNIT_BACKOFF_PERIOD_MICROSEC;
+
+    uint32_t period = genrand_uint32() % max_backoff;
+    if (period < A_UNIT_BACKOFF_PERIOD_MICROSEC) {
+        period = A_UNIT_BACKOFF_PERIOD_MICROSEC;
+    }
+
+    return period;
+}
+
+
+/**
+ * @brief Perform a CCA and send the given packet if medium is available
+ *
+ * @param[in] device    netdev device, needs to be already initialized
+ * @param[in] data      pointer to the data in the packet buffer;
+ *                      it must be a complete 802.15.4-compliant frame,
+ *                      ready to be sent to the radio transceiver
+ *
+ * @return              the return value of device driver's @c send_data()
+ *                      function if medium was avilable
+ * @return              -ECANCELED if an internal driver error occured
+ * @return              -EBUSY if radio medium was not available
+ *                      to send the given data
+ */
+static int send_if_cca(gnrc_netdev_t *device, gnrc_pktsnip_t *data)
+{
+    netopt_enable_t hwfeat;
+
+    /* perform a CCA */
+    DEBUG("csma: Checking radio medium availability...\n");
+    int res = device->driver->get(device,
+                                  NETOPT_IS_CHANNEL_CLR,
+                                  (void *) &hwfeat,
+                                  sizeof(netopt_enable_t));
+    if (res < 0) {
+        /* normally impossible: we got a big internal problem! */
+        DEBUG("csma: !!! DEVICE DRIVER FAILURE! TRANSMISSION ABORTED!\n");
+        return -ECANCELED;
+    }
+
+    /* if medium is clear, send the packet and return */
+    if (hwfeat == NETOPT_ENABLE) {
+        DEBUG("csma: Radio medium available: sending packet.\n");
+        return device->driver->send_data(device, data);
+    }
+
+    /* if we arrive here, medium was not available for transmission */
+    DEBUG("csma: Radio medium busy.\n");
+    return -EBUSY;
+}
+
+/*------------------------- "EXPORTED" FUNCTIONS -------------------------*/
+
+void set_csma_mac_min_be(uint8_t val)
+{
+    mac_min_be = val;
+}
+
+void set_csma_mac_max_be(uint8_t val)
+{
+    mac_max_be = val;
+}
+
+void set_csma_mac_max_csma_backoffs(uint8_t val)
+{
+    mac_max_csma_backoffs = val;
+}
+
+
+int csma_ca_send(gnrc_netdev_t *dev, gnrc_pktsnip_t *pkt)
+{
+    netopt_enable_t hwfeat;
+
+    /* Does the transceiver do automatic CSMA/CA when sending? */
+    int res = dev->driver->get(dev,
+                               NETOPT_CSMA,
+                               (void *) &hwfeat,
+                               sizeof(netopt_enable_t));
+    bool ok = false;
+    switch (res) {
+    case -ENODEV:
+        /* invalid device pointer given */
+        return -ENODEV;
+    case -ENOTSUP:
+        /* device doesn't make auto-CSMA/CA */
+        break;
+    case -EOVERFLOW:  /* (normally impossible...*/
+    case -ECANCELED:
+        DEBUG("csma: !!! DEVICE DRIVER FAILURE! TRANSMISSION ABORTED!\n");
+        /* internal driver error! */
+        return -ECANCELED;
+    default:
+        ok = (hwfeat == NETOPT_ENABLE);
+    }
+
+    if (ok) {
+        /* device does CSMA/CA all by itself: let it do its job */
+        DEBUG("csma: Network device does hardware CSMA/CA\n");
+        return dev->driver->send_data(dev, pkt);
+    }
+
+    /* if we arrive here, then we must perform the CSMA/CA procedure
+       ourselves by software */
+    genrand_init(xtimer_now());
+    DEBUG("csma: Starting software CSMA/CA....\n");
+
+    int nb = 0, be = mac_min_be;
+
+    while (nb <= mac_max_csma_backoffs) {
+        /* delay for an adequate random backoff period */
+        uint32_t bp = choose_backoff_period(be);
+        xtimer_usleep(bp);
+
+        /* try to send after a CCA */
+        res = send_if_cca(dev, pkt);
+        if (res >= 0) {
+            /* TX done */
+            return res;
+        } else if (res != -EBUSY) {
+            /* something has gone wrong, return the error code */
+            return res;
+        }
+
+        /* medium is busy: increment CSMA counters */
+        DEBUG("csma: Radio medium busy.\n");
+        be++;
+        if (be > mac_max_be) {
+            be = mac_max_be;
+        }
+        nb++;
+        /* ... and try again if we have no exceeded the retry limit */
+    }
+
+    /* if we arrive here, medium was never available for transmission */
+    DEBUG("csma: Software CSMA/CA failure: medium never available.\n");
+    return -EBUSY;
+}
+
+
+int cca_send(gnrc_netdev_t *dev, gnrc_pktsnip_t *pkt)
+{
+    netopt_enable_t hwfeat;
+
+    /* Does the transceiver do automatic CCA before sending? */
+    int res = dev->driver->get(dev,
+                               NETOPT_AUTOCCA,
+                               (void *) &hwfeat,
+                               sizeof(netopt_enable_t));
+    bool ok = false;
+    switch (res) {
+    case -ENODEV:
+        /* invalid device pointer given */
+        return -ENODEV;
+    case -ENOTSUP:
+        /* device doesn't make auto-CCA */
+        break;
+    case -EOVERFLOW:  /* (normally impossible...*/
+    case -ECANCELED:
+        /* internal driver error! */
+        DEBUG("csma: !!! DEVICE DRIVER FAILURE! TRANSMISSION ABORTED!\n");
+        return -ECANCELED;
+    default:
+        ok = (hwfeat == NETOPT_ENABLE);
+    }
+
+    if (ok) {
+        /* device does auto-CCA: let him do its job */
+        DEBUG("csma: Network device does auto-CCA checking.\n");
+        return dev->driver->send_data(dev, pkt);
+    }
+
+    /* if we arrive here, we must do CCA ourselves to see if radio medium
+       is clear before sending */
+    res = send_if_cca(dev, pkt);
+    if (res == -EBUSY) {
+        DEBUG("csma: Transmission cancelled!\n");
+    }
+
+    return res;
+}


### PR DESCRIPTION
Adding an helper `gnrc_csma_sender` module, to be able to send packets in CSMA/CA mode, without having to guess if the underlying network device does it automatically or not, and thus without having to handle with such many situations in your (higher level) code.

Even if it's still fresh (beta) code, its simplicity makes me hope that there are not (too) much bugs in it, so it could be tested and used quite rapidly.

**Note:** it only does basic, non-slotted CSMA/CA (at least for now).
