### PR TITLE
gnrc: ndp: fix calculation of L2 address length

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -621,7 +621,7 @@ int gnrc_ndp_internal_sl2a_opt_handle(gnrc_pktsnip_t *pkt, ipv6_hdr_t *ipv6, uin
         case ICMPV6_RTR_ADV:
         case ICMPV6_NBR_SOL:
             if (sl2a_len == 0) {  /* in case there was no source address in l2 */
-                sl2a_len = (sl2a_opt->len / 8) - sizeof(ndp_opt_t);
+                sl2a_len = (sl2a_opt->len * 8) - sizeof(ndp_opt_t);
 
                 /* ignore all zeroes at the end for length */
                 for (; sl2a[sl2a_len - 1] == 0x00; sl2a_len--);


### PR DESCRIPTION
If no source address was provided by layer 2 or someone removed it, the calculation of its length is done using the length field from the Source/Target Link-layer Address option (https://tools.ietf.org/html/rfc4861#section-4.6.1). The length is specified as units of 8 octets. Hence, it should be multiplied by 8, not divided.