### PR TITLE
msp430: various fixes to time.h

### DIFF
--- a/cpu/msp430-common/include/time.h
+++ b/cpu/msp430-common/include/time.h
@@ -9,6 +9,9 @@
 #ifndef MSPGCC_TIME_H
 #define MSPGCC_TIME_H
 
+#include <sys/types.h>
+#include "msp430_types.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/msp430-common/include/time.h
+++ b/cpu/msp430-common/include/time.h
@@ -6,6 +6,17 @@
  * directory for more details.
  */
 
+/**
+ * @ingroup     cpu_msp430_common
+ * @{
+ *
+ * @file
+ * @brief       time.h for msp430
+ * @see http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/assert.h.html
+ *
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
 #ifndef MSPGCC_TIME_H
 #define MSPGCC_TIME_H
 
@@ -16,16 +27,20 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Datatype to represent time.
+ */
 struct tm {
-    int tm_sec;                   /* Seconds after the minute [0, 60] */
-    int tm_min;                   /* Minutes after the hour [0, 59] */
-    int tm_hour;                  /* Hours since midnight [0, 23] */
-    int tm_mday;                  /* Day of the month [1, 31] */
-    int tm_mon;                   /* Months since January [0, 11] */
-    int tm_year;                  /* Years since 1900 */
-    int tm_wday;                  /* Days since Sunday [0, 6] */
-    int tm_yday;                  /* Days since January 1st [0, 365] */
-    int tm_isdst;                 /* Daylight saving time is in effect */
+    int tm_sec;     /**< Seconds after the minute [0, 60] */
+    int tm_min;     /**< Minutes after the hour [0, 59] */
+    int tm_hour;    /**< Hours since midnight [0, 23] */
+    int tm_mday;    /**< Day of the month [1, 31] */
+    int tm_mon;     /**< Months since January [0, 11] */
+    int tm_year;    /**< Years since 1900 */
+    int tm_wday;    /**< Days since Sunday [0, 6] */
+    int tm_yday;    /**< Days since January 1st [0, 365] */
+    int tm_isdst;   /**< Daylight saving time is in effect
+                     *   (positive if true, 0 if not, negative if n/a) */
 };
 
 #ifdef __cplusplus
@@ -33,3 +48,4 @@ struct tm {
 #endif
 
 #endif
+/** @} */


### PR DESCRIPTION
Some datatypes required in the header `time.h` are defined in `msp430_types.h`. This PR includes it and updates the documentation to `time.h`.