### PR TITLE
Standard IEEE 802.15.4 basic MAC layer for RIOT "gnrc" netstack

### DIFF
--- a/boards/iotlab-m3/Makefile.dep
+++ b/boards/iotlab-m3/Makefile.dep
@@ -1,5 +1,12 @@
 ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
   USEMODULE += at86rf231
+  ifeq ($(filter gnrc_802154_basic_mac,$(USEMODULE)),)
+  USEMODULE += gnrc_nomac
+  endif
+endif
+ifneq (,$(filter gnrc_802154_basic_mac,$(USEMODULE)))
+    USEMODULE += gnrc_csma_sender
+    USEMODULE += random
 endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))

--- a/boards/samr21-xpro/Makefile.dep
+++ b/boards/samr21-xpro/Makefile.dep
@@ -1,7 +1,15 @@
 ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
   USEMODULE += at86rf233
+  ifeq ($(filter gnrc_802154_basic_mac,$(USEMODULE)),)
+  USEMODULE += gnrc_nomac
+  endif
 endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+endif
+
+ifneq (,$(filter gnrc_802154_basic_mac,$(USEMODULE)))
+    USEMODULE += gnrc_csma_sender
+    USEMODULE += random
 endif

--- a/sys/auto_init/netif/auto_init_at86rf2xx.c
+++ b/sys/auto_init/netif/auto_init_at86rf2xx.c
@@ -22,6 +22,11 @@
 #include "board.h"
 #include "net/gnrc/netdev2.h"
 #include "net/gnrc/netdev2/ieee802154.h"
+#ifdef MODULE_GNRC_802154_BASIC_MAC
+#include "net/gnrc/ieee_802154_basic_mac.h"
+#else
+#include "net/gnrc/nomac.h"
+#endif
 #include "net/gnrc.h"
 
 #include "at86rf2xx.h"
@@ -63,6 +68,20 @@ void auto_init_at86rf2xx(void)
                               AT86RF2XX_MAC_PRIO,
                               "at86rf2xx",
                               &gnrc_adpt[i]);
+#ifdef MODULE_GNRC_802154_BASIC_MAC
+            /* start the 'gnrc_802154_basic_mac' module */
+            gnrc_802154_basic_mac_init(_at86rf2xx_stacks[i],
+                                       AT86RF2XX_MAC_STACKSIZE,
+                                       AT86RF2XX_MAC_PRIO,
+                                       "at86rfxx",
+                                       (gnrc_netdev_t *)&at86rf2xx_devs[i]);
+#else
+            gnrc_nomac_init(_at86rf2xx_stacks[i],
+                            AT86RF2XX_MAC_STACKSIZE,
+                            AT86RF2XX_MAC_PRIO,
+                            "at86rfxx",
+                            (gnrc_netdev_t *)&at86rf2xx_devs[i]);
+#endif
         }
     }
 }

--- a/sys/auto_init/netif/auto_init_kw2xrf.c
+++ b/sys/auto_init/netif/auto_init_kw2xrf.c
@@ -22,7 +22,11 @@
 #ifdef MODULE_KW2XRF
 
 #include "board.h"
+#ifdef MODULE_GNRC_802154_BASIC_MAC
+#include "net/gnrc/ieee_802154_basic_mac.h"
+#else
 #include "net/gnrc/nomac.h"
+#endif
 #include "net/gnrc.h"
 
 #include "kw2xrf.h"
@@ -41,7 +45,7 @@
 #define KW2XRF_NUM (sizeof(kw2xrf_params)/sizeof(kw2xrf_params[0]))
 
 static kw2xrf_t kw2xrf_devs[KW2XRF_NUM];
-static char _nomac_stacks[KW2XRF_MAC_STACKSIZE][KW2XRF_NUM];
+static char _mac_stacks[KW2XRF_MAC_STACKSIZE][KW2XRF_NUM];
 
 void auto_init_kw2xrf(void)
 {
@@ -59,9 +63,16 @@ void auto_init_kw2xrf(void)
             DEBUG("Error initializing KW2xrf radio device!");
         }
         else {
-            gnrc_nomac_init(_nomac_stacks[i],
+#ifdef MODULE_GNRC_802154_BASIC_MAC
+            /* start the 'gnrc_802154_basic_mac' module */
+            gnrc_802154_basic_mac_init(_mac_stacks[i],
                             KW2XRF_MAC_STACKSIZE, KW2XRF_MAC_PRIO,
                             "kw2xrf", (gnrc_netdev_t *)&kw2xrf_devs[i]);
+#else
+            gnrc_nomac_init(_mac_stacks[i],
+                            KW2XRF_MAC_STACKSIZE, KW2XRF_MAC_PRIO,
+                            "kw2xrf", (gnrc_netdev_t *)&kw2xrf_devs[i]);
+#endif
         }
     }
 }

--- a/sys/auto_init/netif/auto_init_xbee.c
+++ b/sys/auto_init/netif/auto_init_xbee.c
@@ -20,7 +20,11 @@
 #ifdef MODULE_XBEE
 
 #include "board.h"
+#ifdef MODULE_GNRC_802154_BASIC_MAC
+#include "net/gnrc/ieee_802154_basic_mac.h"
+#else
 #include "net/gnrc/nomac.h"
+#endif
 #include "net/gnrc.h"
 
 #include "xbee.h"
@@ -43,7 +47,7 @@ static xbee_t xbee_devs[XBEE_NUM];
 /**
  * @brief   Stacks for the MAC layer threads
  */
-static char _nomac_stacks[XBEE_MAC_STACKSIZE][XBEE_NUM];
+static char _mac_stacks[XBEE_MAC_STACKSIZE][XBEE_NUM];
 
 void auto_init_xbee(void)
 {
@@ -56,9 +60,16 @@ void auto_init_xbee(void)
             DEBUG("Error initializing XBee radio device!");
         }
         else {
-            gnrc_nomac_init(_nomac_stacks[i],
-                            XBEE_MAC_STACKSIZE, XBEE_MAC_PRIO, "xbee",
-                            (gnrc_netdev_t *)&xbee_devs[i]);
+#ifdef MODULE_GNRC_802154_BASIC_MAC
+            /* start the 'gnrc_802154_basic_mac' module */
+            gnrc_802154_basic_mac_init(_mac_stacks[i],
+                            XBEE_MAC_STACKSIZE, XBEE_MAC_PRIO,
+                            "xbee", (gnrc_netdev_t *)&xbee_devs[i]);
+#else
+            gnrc_nomac_init(_mac_stacks[i],
+                            XBEE_MAC_STACKSIZE, XBEE_MAC_PRIO,
+                            "xbee", (gnrc_netdev_t *)&xbee_devs[i]);
+#endif
         }
     }
 }

--- a/sys/include/net/gnrc/ieee_802154_basic_mac.h
+++ b/sys/include/net/gnrc/ieee_802154_basic_mac.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2015 INRIA
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_gnrc_802154_basic_mac  IEEE 802.15.4 basic
+ *                                         (i.e.: non-slotted) MAC layer
+ * @ingroup     net_gnrc
+ * @brief       Basic MAC protocol of the IEEE 802.15.4 standard,
+ *              that sends packets using only non slotted CSMA/CA procedure
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for the IEEE 802.15.4 basic MAC layer
+ *
+ * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
+ */
+
+#ifndef GNRC_802154_BASIC_MAC_H_
+#define GNRC_802154_BASIC_MAC_H_
+
+#include "kernel.h"
+#include "net/gnrc/netdev.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Set the default message queue size for 802.15.4 basic MAC layer
+ */
+#ifndef GNRC_802154_BASIC_MAC_QUEUE_SIZE
+#define GNRC_802154_BASIC_MAC_QUEUE_SIZE       (8U)
+#endif
+
+
+/**
+ * @brief   Initialize an instance of the 802.15.4 basic MAC layer
+ *
+ * The initialization starts a new thread that connects to the given netdev
+ * device and starts a link layer event loop.
+ *
+ * @param[in] stack         stack for the control thread
+ * @param[in] stacksize     size of *stack*
+ * @param[in] priority      priority for the thread housing the MAC layer
+ * @param[in] name          name of the thread housing the MAC layer
+ * @param[in] dev           netdev device, needs to be already initialized
+ *
+ * @return                  PID of the 802.15.4 MAC layer thread on success
+ * @return                  -EINVAL if creation of thread fails
+ * @return                  -ENODEV if *dev* is invalid
+ */
+kernel_pid_t gnrc_802154_basic_mac_init(char *stack,
+                                        int stacksize,
+                                        char priority,
+                                        const char *name,
+                                        gnrc_netdev_t *dev);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GNRC_802154_BASIC_MAC_H_ */
+/** @} */

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -1,3 +1,6 @@
+ifneq (,$(filter gnrc_802154_basic_mac,$(USEMODULE)))
+    DIRS += link_layer/ieee_802154_basic_mac
+endif
 ifneq (,$(filter gnrc_conn,$(USEMODULE)))
     DIRS += conn
 endif

--- a/sys/net/gnrc/link_layer/ieee_802154_basic_mac/Makefile
+++ b/sys/net/gnrc/link_layer/ieee_802154_basic_mac/Makefile
@@ -1,0 +1,5 @@
+MODULE = gnrc_802154_basic_mac
+
+USEMODULE += gnrc_csma_sender
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/link_layer/ieee_802154_basic_mac/gnrc_802154_basic_mac.c
+++ b/sys/net/gnrc/link_layer/ieee_802154_basic_mac/gnrc_802154_basic_mac.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2015 INRIA
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net_80215
+ * @file
+ * @brief       Implementation of the IEEE 802.15.4 basic MAC layer
+ *
+ * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
+ * @}
+ */
+
+#include <errno.h>
+
+#include "kernel.h"
+#include "msg.h"
+#include "thread.h"
+#include "panic.h"
+#include "net/gnrc/ieee_802154_basic_mac.h"
+#include "net/gnrc/csma_sender.h"
+#include "net/gnrc.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#if ENABLE_DEBUG
+/* For PRIu16 etc. */
+#include <inttypes.h>
+#endif
+
+/**
+ * @brief   Function called by the device driver on device events
+ *
+ * @param[in] event         type of event
+ * @param[in] data          optional parameter
+ */
+static void _event_cb(gnrc_netdev_event_t event, void *data)
+{
+    DEBUG("802154_basic_mac: event triggered -> %i\n", event);
+    /* The 802.15.4 basic MAC only understands the RX_COMPLETE event... */
+    if (event == NETDEV_EVENT_RX_COMPLETE) {
+        gnrc_pktsnip_t *pkt;
+
+        /* get pointer to the received packet */
+        pkt = (gnrc_pktsnip_t *)data;
+        /* send the packet to everyone interested in it's type */
+        if (!gnrc_netapi_dispatch_receive(pkt->type,
+                                          GNRC_NETREG_DEMUX_CTX_ALL,
+                                          pkt))
+        {
+            DEBUG("802154_basic_mac: unable to forward packet of type %i\n",
+                  pkt->type);
+            gnrc_pktbuf_release(pkt);
+        }
+    }
+}
+
+/**
+ * @brief   Startup code and event loop of the 802.15.4 basic MAC layer
+ *
+ * @param[in] args          expects a pointer to the underlying netdev device
+ *
+ * @return                  never returns
+ */
+static void *_802154_basic_mac_thread(void *args)
+{
+    gnrc_netdev_t *dev = (gnrc_netdev_t *)args;
+    gnrc_netreg_entry_t regentry;
+    gnrc_netapi_opt_t *opt;
+    int res;
+    msg_t msg, reply, msg_queue[GNRC_802154_BASIC_MAC_QUEUE_SIZE];
+
+    /* setup the MAC layers message queue */
+    msg_init_queue(msg_queue, GNRC_802154_BASIC_MAC_QUEUE_SIZE);
+    /* save the PID to the device descriptor and register the device */
+    dev->mac_pid = thread_getpid();
+    gnrc_netif_add(dev->mac_pid);
+    /* register the event callback with the device driver */
+    dev->driver->add_event_callback(dev, _event_cb);
+
+    /* register our thread to receive the wanted events from the netstack */
+    regentry.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
+    regentry.pid = thread_getpid();
+    /* we want the raw 802.15.4 frames => GNRC_NETTYPE_UNDEF */
+    res = gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &regentry);
+    if (res < 0) {
+        core_panic(PANIC_ASSERT_FAIL,
+                   "Could not register 802.15.4 basic MAC thread to netreg");
+    }
+
+    /* start the event loop */
+    while (1) {
+        DEBUG("802154_basic_mac: waiting for incoming messages\n");
+        msg_receive(&msg);
+        /* dispatch NETDEV and NETAPI messages */
+        switch (msg.type) {
+            case GNRC_NETDEV_MSG_TYPE_EVENT:
+                DEBUG("802154_basic_mac: GNRC_NETDEV_MSG_TYPE_EVENT received\n");
+                dev->driver->isr_event(dev, msg.content.value);
+                break;
+            case GNRC_NETAPI_MSG_TYPE_SND:
+                DEBUG("802154_basic_mac: GNRC_NETAPI_MSG_TYPE_SND received\n");
+                /* send the packet with CSMA/CA method */
+                res = csma_ca_send(dev, (gnrc_pktsnip_t *) msg.content.ptr);
+                DEBUG("802154_basic_mac: TX operation result: %i\n", res);
+                /* send the result of TX to calling thread */  //XXX is that useful, harmful?...
+                reply.type = GNRC_NETAPI_MSG_TYPE_ACK;
+                reply.content.value = (uint32_t) res;
+                msg_reply(&msg, &reply);
+                break;
+            case GNRC_NETAPI_MSG_TYPE_SET:
+                /* TODO: filter out MAC layer options -> for now forward
+                         everything to the device driver */
+                DEBUG("802154_basic_mac: GNRC_NETAPI_MSG_TYPE_SET received\n");
+                /* read incoming options */
+                opt = (gnrc_netapi_opt_t *)msg.content.ptr;
+                /* set option for device driver */
+                res = dev->driver->set(dev, opt->opt, opt->data, opt->data_len);
+                DEBUG("802154_basic_mac: response of netdev->set: %i\n", res);
+                /* send reply to calling thread */
+                reply.type = GNRC_NETAPI_MSG_TYPE_ACK;
+                reply.content.value = (uint32_t)res;
+                msg_reply(&msg, &reply);
+                break;
+            case GNRC_NETAPI_MSG_TYPE_GET:
+                /* TODO: filter out MAC layer options -> for now forward
+                         everything to the device driver */
+                DEBUG("802154_basic_mac: GNRC_NETAPI_MSG_TYPE_GET received\n");
+                /* read incoming options */
+                opt = (gnrc_netapi_opt_t *)msg.content.ptr;
+                /* get option from device driver */
+                res = dev->driver->get(dev, opt->opt, opt->data, opt->data_len);
+                DEBUG("802154_basic_mac: response of netdev->get: %i\n", res);
+                /* send reply to calling thread */
+                reply.type = GNRC_NETAPI_MSG_TYPE_ACK;
+                reply.content.value = (uint32_t)res;
+                msg_reply(&msg, &reply);
+                break;
+            default:
+                DEBUG("802154_basic_mac: Unknown command %" PRIu16 "\n",
+                      msg.type);
+                break;
+        }
+    }
+    /* never reached */
+    return NULL;
+}
+
+kernel_pid_t gnrc_802154_basic_mac_init(char *stack,
+                                        int stacksize,
+                                        char priority,
+                                        const char *name,
+                                        gnrc_netdev_t *dev)
+{
+    kernel_pid_t res;
+
+    /* check if given netdev device is defined and the driver is set */
+    if (dev == NULL || dev->driver == NULL) {
+        return -ENODEV;
+    }
+
+    /* create new 802.15.4 basic MAC thread */
+    res = thread_create(stack,
+                        stacksize,
+                        priority,
+                        THREAD_CREATE_STACKTEST,
+                        _802154_basic_mac_thread,
+                        (void *)dev,
+                        name);
+    if (res <= 0) {
+        return -EINVAL;
+    }
+
+    return res;
+}


### PR DESCRIPTION
As the title says, this is a simple implementation of the standard IEEE 802.15.4 basic (i.e.: non-slotted) MAC layer for RIOT "gnrc" netstack.

As one will see the code is almost the same than for the `nomac` module of Hauke Petersen; but it uses the CSMA/CA helper module ~~(PR #4178)~~ to send the packets. This simple change makes it enough to have a simple, but standard-compliant MAC layer (the bulk of the job is done by the said CSMA/CA helper module).

As being standard-compliant never hurts, I thus propose this contribution. Plus, since it is simple, we can hope there won't be (much) bugs.

~~Of course, this PR depends totally on #4178.~~ (merged)
