### PR TITLE
network_layer: remove last occurences of vtimer

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -98,7 +98,7 @@ endif
 
 ifneq (,$(filter gnrc_sixlowpan_frag,$(USEMODULE)))
   USEMODULE += gnrc_sixlowpan
-  USEMODULE += vtimer
+  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter gnrc_sixlowpan_iphc,$(USEMODULE)))
@@ -114,7 +114,7 @@ endif
 
 ifneq (,$(filter gnrc_sixlowpan_ctx,$(USEMODULE)))
   USEMODULE += ipv6_addr
-  USEMODULE += vtimer
+  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter gnrc_sixlowpan_nd_border_router,$(USEMODULE)))
@@ -130,7 +130,7 @@ ifneq (,$(filter gnrc_sixlowpan_nd,$(USEMODULE)))
   USEMODULE += gnrc_ndp_internal
   USEMODULE += gnrc_sixlowpan_ctx
   USEMODULE += random
-  USEMODULE += vtimer
+  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter gnrc_ipv6_default,$(USEMODULE)))
@@ -160,13 +160,13 @@ endif
 ifneq (,$(filter gnrc_ndp_host,$(USEMODULE)))
   USEMODULE += gnrc_ndp_node
   USEMODULE += random
-  USEMODULE += vtimer
+  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter gnrc_ndp_router,$(USEMODULE)))
   USEMODULE += gnrc_ndp_node
   USEMODULE += random
-  USEMODULE += vtimer
+  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter gnrc_ndp_node,$(USEMODULE)))
@@ -181,7 +181,7 @@ ifneq (,$(filter gnrc_ndp,$(USEMODULE)))
   USEMODULE += gnrc_icmpv6
   USEMODULE += random
   USEMODULE += timex
-  USEMODULE += vtimer
+  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter gnrc_icmpv6_echo,$(USEMODULE)))
@@ -243,7 +243,7 @@ ifneq (,$(filter gnrc_ipv6_netif,$(USEMODULE)))
   USEMODULE += ipv6_addr
   USEMODULE += gnrc_netif
   USEMODULE += bitfield
-  USEMODULE += vtimer
+  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter gnrc_udp,$(USEMODULE)))

--- a/sys/include/net/gnrc/sixlowpan/nd/router.h
+++ b/sys/include/net/gnrc/sixlowpan/nd/router.h
@@ -70,7 +70,8 @@ typedef struct {
     uint16_t ltime;                         /**< the time in minutes until deletion */
     BITFIELD(ctxs, GNRC_SIXLOWPAN_CTX_SIZE);/**< contexts associated with BR */
     gnrc_sixlowpan_nd_router_prf_t *prfs;   /**< prefixes associated with BR */
-    vtimer_t ltimer;                        /**< timer for deletion */
+    xtimer_t ltimer;                        /**< timer for deletion */
+    msg_t ltimer_msg;                       /**< msg_t for gnrc_sixlowpan_nd_router_abr_t::ltimer */
 } gnrc_sixlowpan_nd_router_abr_t;
 
 /**

--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -24,7 +24,7 @@
 #include "net/gnrc/sixlowpan/nd.h"
 #include "thread.h"
 #include "timex.h"
-#include "vtimer.h"
+#include "xtimer.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -30,7 +30,7 @@
 #include "random.h"
 #include "utlist.h"
 #include "thread.h"
-#include "vtimer.h"
+#include "xtimer.h"
 
 #include "net/gnrc/ndp/internal.h"
 

--- a/sys/net/gnrc/network_layer/ndp/host/gnrc_ndp_host.c
+++ b/sys/net/gnrc/network_layer/ndp/host/gnrc_ndp_host.c
@@ -17,7 +17,7 @@
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/ndp.h"
 #include "net/gnrc/ndp/internal.h"
-#include "vtimer.h"
+#include "xtimer.h"
 
 #include "net/gnrc/ndp/host.h"
 

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -21,7 +21,7 @@
 #include "net/gnrc/sixlowpan/nd.h"
 #include "random.h"
 #include "timex.h"
-#include "vtimer.h"
+#include "xtimer.h"
 
 #include "net/gnrc/ndp/internal.h"
 

--- a/sys/net/gnrc/network_layer/ndp/router/gnrc_ndp_router.c
+++ b/sys/net/gnrc/network_layer/ndp/router/gnrc_ndp_router.c
@@ -17,7 +17,7 @@
 #include "net/gnrc/ndp/internal.h"
 #include "random.h"
 #include "timex.h"
-#include "vtimer.h"
+#include "xtimer.h"
 
 #include "net/gnrc/ndp/router.h"
 

--- a/sys/net/gnrc/network_layer/sixlowpan/ctx/gnrc_sixlowpan_ctx.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/ctx/gnrc_sixlowpan_ctx.c
@@ -17,7 +17,6 @@
 
 #include "mutex.h"
 #include "net/gnrc/sixlowpan/ctx.h"
-#include "vtimer.h"
 #include "xtimer.h"
 
 #define ENABLE_DEBUG    (0)

--- a/sys/net/gnrc/network_layer/sixlowpan/ctx/gnrc_sixlowpan_ctx.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/ctx/gnrc_sixlowpan_ctx.c
@@ -18,6 +18,7 @@
 #include "mutex.h"
 #include "net/gnrc/sixlowpan/ctx.h"
 #include "vtimer.h"
+#include "xtimer.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
@@ -132,9 +133,7 @@ gnrc_sixlowpan_ctx_t *gnrc_sixlowpan_ctx_update(uint8_t id, const ipv6_addr_t *p
 
 static uint32_t _current_minute(void)
 {
-    timex_t now;
-    vtimer_now(&now);
-    return now.seconds / 60;
+    return xtimer_now() / (SEC_IN_USEC * 60);
 }
 
 static void _update_lifetime(uint8_t id)

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -24,7 +24,7 @@
 #include "net/sixlowpan.h"
 #include "thread.h"
 #include "timex.h"
-#include "vtimer.h"
+#include "xtimer.h"
 #include "utlist.h"
 
 #define ENABLE_DEBUG    (0)

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/router/gnrc_sixlowpan_nd_router.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/router/gnrc_sixlowpan_nd_router.c
@@ -241,8 +241,10 @@ void gnrc_sixlowpan_nd_opt_abr_handle(kernel_pid_t iface, ndp_rtr_adv_t *rtr_adv
 
     t.seconds = abr->ltime * 60;
 
-    vtimer_set_msg(&abr->ltimer, t, gnrc_ipv6_pid,
-                   GNRC_SIXLOWPAN_ND_MSG_ABR_TIMEOUT, abr);
+    xtimer_remove(&abr->ltimer);
+    abr->ltimer_msg.type = GNRC_SIXLOWPAN_ND_MSG_ABR_TIMEOUT;
+    abr->ltimer_msg.content.ptr = (char *) abr;
+    xtimer_set_msg(&abr->ltimer, (uint32_t) timex_uint64(t), &abr->ltimer_msg, gnrc_ipv6_pid);
 }
 
 gnrc_pktsnip_t *gnrc_sixlowpan_nd_opt_6ctx_build(uint8_t prefix_len, uint8_t flags, uint16_t ltime,


### PR DESCRIPTION
This PR removes further occurences of vtimer by replacing them with xtimer in `gnrc_icmpv6`, `gnrc_ipv6`, `gnrc_ndp` and `gnrc_sixlowpan`