### PR TITLE
cpu/cortex-m: add all-debug target

### DIFF
--- a/cpu/cortexm_common/Makefile.include
+++ b/cpu/cortexm_common/Makefile.include
@@ -1,2 +1,4 @@
 # include module specific includes
 export INCLUDES += -I$(RIOTCPU)/cortexm_common/include
+
+all-debug: all


### PR DESCRIPTION
Request to include the Makefile target `all-debug` for the cortex-m serie CPU's.