### PR TITLE
netopt: Add support for selecting IEEE802.15.4 channel page

### DIFF
--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -177,6 +177,11 @@ typedef enum {
      */
     NETOPT_DEVICE_TYPE,
 
+    /**
+     * @brief get/set the channel page as defined by IEEE 802.15.4
+     */
+    NETOPT_CHANNEL_PAGE,
+
     /* add more options if needed */
 
     /**

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -50,6 +50,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_CSMA_RETRIES]    = "NETOPT_CSMA_RETRIES",
     [NETOPT_IS_WIRED]        = "NETOPT_IS_WIRED",
     [NETOPT_DEVICE_TYPE]     = "NETOPT_DEVICE_TYPE",
+    [NETOPT_CHANNEL_PAGE]    = "NETOPT_CHANNEL_PAGE",
     [NETOPT_NUMOF]           = "NETOPT_NUMOF",
 };
 

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -83,6 +83,7 @@ static void _set_usage(char *cmd_name)
          "       * \"chan\" - alias for \"channel\"\n"
          "       * \"csma_retries\" - set max. number of channel access attempts\n"
          "       * \"nid\" - sets the network identifier (or the PAN ID)\n"
+         "       * \"page\" - set the channel page (IEEE 802.15.4)\n"
          "       * \"pan\" - alias for \"nid\"\n"
          "       * \"pan_id\" - alias for \"nid\"\n"
          "       * \"power\" - TX power in dBm\n"
@@ -129,6 +130,10 @@ static void _print_netopt(netopt_t opt)
 
         case NETOPT_CHANNEL:
             printf("channel");
+            break;
+
+        case NETOPT_CHANNEL_PAGE:
+            printf("page");
             break;
 
         case NETOPT_NID:
@@ -208,6 +213,12 @@ static void _netif_list(kernel_pid_t dev)
 
     if (res >= 0) {
         printf(" Channel: %" PRIu16 " ", u16);
+    }
+
+    res = gnrc_netapi_get(dev, NETOPT_CHANNEL_PAGE, 0, &u16, sizeof(u16));
+
+    if (res >= 0) {
+        printf(" Page: %" PRIu16 " ", u16);
     }
 
     res = gnrc_netapi_get(dev, NETOPT_NID, 0, &u16, sizeof(u16));
@@ -540,6 +551,9 @@ static int _netif_set(char *cmd_name, kernel_pid_t dev, char *key, char *value)
     }
     else if ((strcmp("channel", key) == 0) || (strcmp("chan", key) == 0)) {
         return _netif_set_u16(dev, NETOPT_CHANNEL, value);
+    }
+    else if (strcmp("page", key) == 0) {
+        return _netif_set_u16(dev, NETOPT_CHANNEL_PAGE, value);
     }
     else if ((strcmp("nid", key) == 0) || (strcmp("pan", key) == 0) ||
              (strcmp("pan_id", key) == 0)) {


### PR DESCRIPTION
This adds a new netopt option for selecting the 802.15.4 channel page number as defined by the standards documents.

See also https://github.com/RIOT-OS/RIOT/issues/3452#issuecomment-141781600