### PR TITLE
sys: net: gnrc_netreg: check for msg queue of registered thread, not …

### DIFF
--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -38,7 +38,7 @@ void gnrc_netreg_init(void)
 int gnrc_netreg_register(gnrc_nettype_t type, gnrc_netreg_entry_t *entry)
 {
     /* only threads with a message queue are allowed to register at gnrc */
-    assert(sched_active_thread->msg_array);
+    assert(sched_threads[entry->pid]->msg_array);
 
     if (_INVALID_TYPE(type)) {
         return -EINVAL;


### PR DESCRIPTION
…registering one. #4010 Introduced the assert, but always checks the calling thread's msg queue, not the queue of the thread that is going to be registered.

E.g., in examples/default the main thread registers pktdump, causing the assertion to fail even though pktdump has a msg queue.