### PR TITLE
dist: iotlab-testbed: add possibility to exclude nodes

### DIFF
--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -15,6 +15,14 @@ else
 	BINARY := $(HEXFILE)
 endif
 
+ifdef IOTLAB_PHY_NODES
+    NODES_PARAM := "-l$(IOTLAB_SITE),$(firstword $(subst :, ,$(IOTLAB_TYPE))),$(IOTLAB_PHY_NODES),$(BINARY),$(IOTLAB_PROFILE)"
+endif
+
+ifdef IOTLAB_EXCLUDE_NODES
+    EXCLUDE_PARAM := "-e$(IOTLAB_SITE),$(firstword $(subst :, ,$(IOTLAB_TYPE))),$(IOTLAB_EXCLUDE_NODES)"
+endif
+
 $(IOTLAB_AUTH):
 	auth-cli -u $(IOTLAB_USER)
 
@@ -23,23 +31,21 @@ iotlab-exp: $(IOTLAB_AUTH) all
 	    $(eval IOTLAB_EXP_NAME := RIOT_EXP_$(IOTLAB_EXP_NAME))
     endif
 
-    ifndef IOTLAB_PHY_NODES
-	    $(eval NODES_LIST := "$(IOTLAB_NODES),archi=$(IOTLAB_TYPE)+site=$(IOTLAB_SITE),$(BINARY),$(IOTLAB_PROFILE)")
-    else
-	    $(eval NODES_LIST := "$(IOTLAB_SITE),$(firstword $(subst :, ,$(IOTLAB_TYPE))),$(IOTLAB_PHY_NODES),$(BINARY),$(IOTLAB_PROFILE)")
+    ifndef NODES_PARAM
+	    $(eval NODES_PARAM := "-l$(IOTLAB_NODES),archi=$(IOTLAB_TYPE)+site=$(IOTLAB_SITE),$(BINARY),$(IOTLAB_PROFILE)")
     endif
 
     ifeq (,$(AD))
-	    @echo "experiment-cli submit -d $(IOTLAB_DURATION) -l $(NODES_LIST) -n $(IOTLAB_EXP_NAME)"
+	    @echo "experiment-cli submit -d $(IOTLAB_DURATION) $(NODES_PARAM) -n $(IOTLAB_EXP_NAME)"
     endif
-	$(eval NEW_ID := $(shell experiment-cli submit -d $(IOTLAB_DURATION) -l $(NODES_LIST) -n $(IOTLAB_EXP_NAME) | grep -Eo '[[:digit:]]+'))
+	$(eval NEW_ID := $(shell experiment-cli submit -d $(IOTLAB_DURATION) $(NODES_PARAM) -n $(IOTLAB_EXP_NAME) | grep -Eo '[[:digit:]]+'))
 	$(AD)experiment-cli wait -i $(NEW_ID)
 
 iotlab-flash: $(IOTLAB_AUTH) all
-	$(AD)node-cli --update $(BINARY) -i $(IOTLAB_EXP_ID)
+	$(AD)node-cli --update $(BINARY) -i $(IOTLAB_EXP_ID) $(NODES_PARAM) $(EXCLUDE_PARAM)
 
 iotlab-reset: $(IOTLAB_AUTH)
-	$(AD)node-cli --reset -i $(IOTLAB_EXP_ID)
+	$(AD)node-cli --reset -i $(IOTLAB_EXP_ID) $(NODES_PARAM) $(EXCLUDE_PARAM)
 
 iotlab-term:
 	$(AD)ssh -t $(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info "test -f ~/.iotlabrc || auth-cli -u $(IOTLAB_USER)"

--- a/dist/testbed-support/README.iotlab.md
+++ b/dist/testbed-support/README.iotlab.md
@@ -33,6 +33,12 @@ brackets):
  * IOTLAB_EXP_ID (taken from first experiment in running state)
  * IOTLAB_EXP_NAME (RIOT_EXP)
  * IOTLAB_PHY_NODES
+ * IOTLAB_EXCLUDE_NODES
+
+### Format of a Resource ID
+Both variables `IOTLAB_PHY_NODES` and `IOTLAB_EXCLUDE_NODES` use the resource id
+string format as specified in the output of `experiment-cli submit --help`.
+An example would be: 1-3+7+10-13
 
 ### Targets
 
@@ -51,8 +57,8 @@ if `IOTLAB_EXP_ID` is not set.
 This schedules a new experiment on the FIT IoT-LAB and waits until it enters
 "Running" state. It will request `IOTLAB_NODES` nodes of type `IOTLAB_TYPE`
 for `IOTLAB_DURATION` minutes at site `IOTLAB_SITE`. With `IOTLAB_PHY_NODES`
-it is possible to choose specific nodes for this experiment by using the resourceid
-string format defined in `experiment-cli submit --help` (example: 1-3+7+10-13).
+it is possible to choose specific nodes for this experiment by using the resource id
+string format as described above.
 Note that the usage of `IOTLAB_PHY_NODES` ignores `IOTLAB_NODES`. It will also flash the
 binary of the current application to all registered nodes. The name of the
 experiment is set to "RIOT_EXP" or "RIOT_EXP_$(IOTLAB_EXP_NAME)"
@@ -62,10 +68,16 @@ if `IOTLAB_EXP_NAME` is defined.
 
 This target updates the application on all registered nodes of the given
 experiment to the current version of the application.
+Certain nodes can be excluded by listing them in the `IOTLAB_EXCLUDE_NODES` variable
+using the resource id string format as described above. If you do not use the default site,
+then you must specify the site with `IOTLAB_SITE`.
 
 #### iotlab-reset
 
 This target resets all registered nodes of the given experiment.
+Certain nodes can be excluded by listing them in the `IOTLAB_EXCLUDE_NODES` variable
+using the resource id string format as described above. If you do not use the default site,
+then you must specify the site with `IOTLAB_SITE`.
 
 #### iotlab-term
 


### PR DESCRIPTION
This PR adds a new variable called `IOTLAB_EXCLUDE_NODES`. This variable will be used to exclude
certain nodes from the flash and/or reset target.

Example:
```
IOTLAB_USER=<user> IOTLAB_EXCLUDE_NODES=11+15 BOARD=iotlab-m3 make iotlab-reset
iotlab-term -I ../../dist/testbed-support
```
This will reset all nodes that are used in the current experiment, but not node 11 and node 15.
`iotlab-flash` works the same.

This exclusion is particularly helpful when sniffers are used for certain nodes that should not be reset/flashed with another application.