### PR TITLE
stm32f1/i2c: Disable I2C module before initialization

### DIFF
--- a/cpu/stm32f1/periph/i2c.c
+++ b/cpu/stm32f1/periph/i2c.c
@@ -98,6 +98,9 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
             return -1;
     }
 
+    /* disable peripheral */
+    i2c->CR1 &= ~I2C_CR1_PE;
+
     /* configure pins */
     _pin_config(pin_scl, pin_sda);
     /* configure device */


### PR DESCRIPTION
When initializing multiple drivers connected to the same
I2C bus, the bus should be disabled before pin toggeling
and reinitialisation. Fixes #4197 