### PR TITLE
core/log: add @file doxygen command

### DIFF
--- a/core/include/log.h
+++ b/core/include/log.h
@@ -10,6 +10,7 @@
  * @addtogroup  core_util
  * @{
  *
+ * @file
  * @brief       System logging header
  *
  * This header offers a bunch of "LOG_*" functions that, with the default


### PR DESCRIPTION
Without this command the `log.h` documentation gets mangled with the `core_util` documentation.