### PR TITLE
rpl: refactor send_dao to use pktbuf properly

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -799,6 +799,7 @@ void gnrc_rpl_send_DAO(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination, uint
     if ((tmp = gnrc_icmpv6_build(pkt, ICMPV6_RPL_CTRL, GNRC_RPL_ICMPV6_CODE_DAO,
                                  sizeof(icmpv6_hdr_t))) == NULL) {
         DEBUG("RPL: Send DAO - no space left in packet buffer\n");
+        gnrc_pktbuf_release(pkt);
         return;
     }
     pkt = tmp;


### PR DESCRIPTION
The first commit refactors the sending DIO code to make proper use of the pktbuf API instead of pointer arithmetic.
The second commit adds a missing pktbuf release in the sending DAO code.