### PR TITLE
sys/auto_init: fix stack size for encx24j600 stack

### DIFF
--- a/sys/auto_init/netif/auto_init_encx24j600.c
+++ b/sys/auto_init/netif/auto_init_encx24j600.c
@@ -37,7 +37,7 @@ static encx24j600_t encx24j600;
 /**
  * @brief   Stacks for the MAC layer threads
  */
-static char _netdev2_eth_stack[MAC_STACKSIZE + DEBUG_EXTRA_STACKSIZE];
+static char _netdev2_eth_stack[MAC_STACKSIZE];
 static gnrc_netdev2_t _gnrc_encx24j600;
 
 void auto_init_encx24j600(void)


### PR DESCRIPTION
I think `THREAD_STACKSIZE_DEFAULT` should be sufficient here. But it is definitely not default + 2*extra...

