### PR TITLE
shell: xtimerfy sc_icmpv6

### DIFF
--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -53,7 +53,7 @@ endif
 ifneq (,$(filter gnrc_ipv6_whitelist,$(USEMODULE)))
   SRC += sc_whitelist.c
 endif
-ifneq (,$(filter gnrc_icmpv6_echo vtimer,$(USEMODULE)))
+ifneq (,$(filter gnrc_icmpv6_echo xtimer,$(USEMODULE)))
   SRC += sc_icmpv6_echo.c
 endif
 ifneq (,$(filter gnrc_zep ipv6_addr,$(USEMODULE)))

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -90,7 +90,7 @@ extern int _read_bytes(int argc, char **argv);
 #endif
 
 #ifdef MODULE_GNRC_ICMPV6_ECHO
-#ifdef MODULE_VTIMER
+#ifdef MODULE_XTIMER
 extern int _icmpv6_ping(int argc, char **argv);
 #endif
 #endif
@@ -182,7 +182,7 @@ const shell_command_t _shell_command_list[] = {
     {DISK_GET_BLOCK_SIZE, "Get the block size of inserted memory card", _get_blocksize},
 #endif
 #ifdef MODULE_GNRC_ICMPV6_ECHO
-#ifdef MODULE_VTIMER
+#ifdef MODULE_XTIMER
     { "ping6", "Ping via ICMPv6", _icmpv6_ping },
 #endif
 #endif


### PR DESCRIPTION
Replaces vtimer by xtimer in the ping6 shell command