### PR TITLE
IEEE 802.15.4 drivers: set first bit to 0 in short addresses for 6LoWPAN

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -85,7 +85,7 @@ uint16_t at86rf2xx_get_addr_short(at86rf2xx_t *dev)
 void at86rf2xx_set_addr_short(at86rf2xx_t *dev, uint16_t addr)
 {
     dev->addr_short[0] = addr >> 8;
-    dev->addr_short[1] = addr & 0xff;
+    dev->addr_short[1] = addr;
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__SHORT_ADDR_0,
                         dev->addr_short[0]);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__SHORT_ADDR_1,

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -86,6 +86,11 @@ void at86rf2xx_set_addr_short(at86rf2xx_t *dev, uint16_t addr)
 {
     dev->addr_short[0] = addr >> 8;
     dev->addr_short[1] = addr;
+#ifdef MODULE_SIXLOWPAN
+    /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit to
+     * 0 for unicast addresses */
+    dev->addr_short[1] &= 0x7F;
+#endif
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__SHORT_ADDR_0,
                         dev->addr_short[0]);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__SHORT_ADDR_1,

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -364,6 +364,11 @@ int kw2xrf_set_addr(kw2xrf_t *dev, uint16_t addr)
     val_ar[1] = (uint8_t)addr;
     dev->addr_short[0] = val_ar[0];
     dev->addr_short[1] = val_ar[1];
+#ifdef MODULE_SIXLOWPAN
+    /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit to
+     * 0 for unicast addresses */
+    dev->addr_short[1] &= 0x7F;
+#endif
     kw2xrf_write_iregs(MKW2XDMI_MACSHORTADDRS0_LSB, val_ar, 2);
     return sizeof(uint16_t);
 }

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -264,6 +264,13 @@ static int _set_addr(xbee_t *dev, uint8_t *val, size_t len)
     cmd[1] = 'Y';
     cmd[2] = val[0];
     cmd[3] = val[1];
+
+#ifdef MODULE_SIXLOWPAN
+    /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit to
+     * 0 for unicast addresses */
+    val[1] &= 0x7F;
+#endif
+
     _api_at_cmd(dev, cmd, 4, &resp);
     if (resp.status == 0) {
         memcpy(dev->addr_short, val, 2);


### PR DESCRIPTION
The first bit is required to be 0 for short addresses when used with 6LoWPAN  by https://tools.ietf.org/html/rfc4944#section-12.