### PR TITLE
net/gnrc/network_layer: remove timex_t

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -180,7 +180,6 @@ endif
 ifneq (,$(filter gnrc_ndp,$(USEMODULE)))
   USEMODULE += gnrc_icmpv6
   USEMODULE += random
-  USEMODULE += timex
   USEMODULE += xtimer
 endif
 

--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -331,7 +331,7 @@ typedef struct {
      *          gnrc_ipv6_netif_t::reach_time_base microseconds devided by 10.
      *          Can't be greater than 1 hour.
      */
-    timex_t reach_time;
+    uint32_t reach_time;
 
     /**
      * @brief   Time between retransmissions of neighbor solicitations to a

--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -338,7 +338,7 @@ typedef struct {
      *          neighbor.
      *          The default value is @ref GNRC_NDP_RETRANS_TIMER.
      */
-    timex_t retrans_timer;
+    uint32_t retrans_timer;
     xtimer_t rtr_sol_timer; /**< Timer for periodic router solicitations */
     msg_t rtr_sol_msg;      /**< msg_t for gnrc_ipv6_netif_t::rtr_sol_timer */
 #if defined (MODULE_GNRC_NDP_ROUTER) || defined (MODULE_GNRC_SIXLOWPAN_ND_ROUTER)

--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -243,9 +243,8 @@ gnrc_ipv6_nc_t *gnrc_ipv6_nc_still_reachable(const ipv6_addr_t *ipv6_addr)
         (gnrc_ipv6_nc_get_state(entry) != GNRC_IPV6_NC_STATE_UNMANAGED)) {
 #if defined(MODULE_GNRC_IPV6_NETIF) && defined(MODULE_VTIMER) && defined(MODULE_GNRC_IPV6)
         gnrc_ipv6_netif_t *iface = gnrc_ipv6_netif_get(entry->iface);
-        timex_t t = iface->reach_time;
 
-        gnrc_ndp_internal_reset_nbr_sol_timer(entry, (uint32_t) timex_uint64(t),
+        gnrc_ndp_internal_reset_nbr_sol_timer(entry, iface->reach_time,
                                               GNRC_NDP_MSG_NC_STATE_TIMEOUT, gnrc_ipv6_pid);
 #endif
 

--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -23,7 +23,6 @@
 #include "net/gnrc/pktbuf.h"
 #include "net/gnrc/sixlowpan/nd.h"
 #include "thread.h"
-#include "timex.h"
 #include "xtimer.h"
 
 #define ENABLE_DEBUG    (0)

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -474,8 +474,7 @@ static inline void _set_reach_time(gnrc_ipv6_netif_t *if_entry, uint32_t mean)
     /* to avoid floating point number computation and have higher value entropy, the
      * boundaries for the random value are multiplied by 10 and we need to account for that */
     reach_time = (reach_time * if_entry->reach_time_base) / 10;
-    if_entry->reach_time = timex_set(0, reach_time);
-    timex_normalize(&if_entry->reach_time);
+    if_entry->reach_time = reach_time;
 }
 
 void gnrc_ndp_rtr_adv_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt, ipv6_hdr_t *ipv6,

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -540,8 +540,7 @@ void gnrc_ndp_rtr_adv_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt, ipv6_hdr_t
     }
     /* set retransmission timer from message */
     if (rtr_adv->retrans_timer.u32 != 0) {
-        if_entry->retrans_timer = timex_set(0, byteorder_ntohl(rtr_adv->retrans_timer));
-        timex_normalize(&if_entry->retrans_timer);
+        if_entry->retrans_timer = byteorder_ntohl(rtr_adv->retrans_timer);
     }
     mutex_unlock(&if_entry->mutex);
     sicmpv6_size -= sizeof(ndp_rtr_adv_t);
@@ -673,9 +672,7 @@ void gnrc_ndp_retrans_nbr_sol(gnrc_ipv6_nc_t *nc_entry)
                 gnrc_ndp_internal_send_nbr_sol(nc_entry->iface, NULL, &nc_entry->ipv6_addr, &dst);
 
                 mutex_lock(&ipv6_iface->mutex);
-                gnrc_ndp_internal_reset_nbr_sol_timer(nc_entry, (uint32_t) timex_uint64(
-                                                       ipv6_iface->retrans_timer
-                                                      ),
+                gnrc_ndp_internal_reset_nbr_sol_timer(nc_entry, ipv6_iface->retrans_timer,
                                                       GNRC_NDP_MSG_NBR_SOL_RETRANS, gnrc_ipv6_pid);
                 mutex_unlock(&ipv6_iface->mutex);
             }
@@ -722,8 +719,7 @@ void gnrc_ndp_netif_add(gnrc_ipv6_netif_t *iface)
     /* set default values */
     mutex_lock(&iface->mutex);
     _set_reach_time(iface, GNRC_NDP_REACH_TIME);
-    iface->retrans_timer = timex_set(0, GNRC_NDP_RETRANS_TIMER);
-    timex_normalize(&iface->retrans_timer);
+    iface->retrans_timer = GNRC_NDP_RETRANS_TIMER;
     mutex_unlock(&iface->mutex);
 }
 

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -92,7 +92,7 @@ ipv6_addr_t *gnrc_ndp_internal_default_router(void)
 void gnrc_ndp_internal_set_state(gnrc_ipv6_nc_t *nc_entry, uint8_t state)
 {
     gnrc_ipv6_netif_t *ipv6_iface;
-    timex_t t = { GNRC_NDP_FIRST_PROBE_DELAY, 0 };
+    uint32_t t = GNRC_NDP_FIRST_PROBE_DELAY * SEC_IN_USEC;
 
     nc_entry->flags &= ~GNRC_IPV6_NC_STATE_MASK;
     nc_entry->flags |= state;

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -20,7 +20,6 @@
 #include "net/gnrc/sixlowpan/ctx.h"
 #include "net/gnrc/sixlowpan/nd.h"
 #include "random.h"
-#include "timex.h"
 #include "xtimer.h"
 
 #include "net/gnrc/ndp/internal.h"

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -122,18 +122,14 @@ void gnrc_ndp_internal_set_state(gnrc_ipv6_nc_t *nc_entry, uint8_t state)
             ipv6_iface = gnrc_ipv6_netif_get(nc_entry->iface);
 
             nc_entry->probes_remaining = GNRC_NDP_MAX_UC_NBR_SOL_NUMOF;
-            DEBUG("PROBE (probe with %" PRIu8 " unicast NS every %" PRIu32
-                  ".%06" PRIu32 " seconds)\n", nc_entry->probes_remaining,
-                  ipv6_iface->retrans_timer.seconds,
-                  ipv6_iface->retrans_timer.microseconds);
+            DEBUG("PROBE (probe with %" PRIu8 " unicast NS every %" PRIu32 " us)\n",
+                  nc_entry->probes_remaining, ipv6_iface->retrans_timer);
 
             gnrc_ndp_internal_send_nbr_sol(nc_entry->iface, NULL, &nc_entry->ipv6_addr,
                                            &nc_entry->ipv6_addr);
 
             mutex_lock(&ipv6_iface->mutex);
-            gnrc_ndp_internal_reset_nbr_sol_timer(nc_entry, (uint32_t) timex_uint64(
-                                                    ipv6_iface->retrans_timer
-                                                  ),
+            gnrc_ndp_internal_reset_nbr_sol_timer(nc_entry, ipv6_iface->retrans_timer,
                                                   GNRC_NDP_MSG_NBR_SOL_RETRANS, gnrc_ipv6_pid);
             mutex_unlock(&ipv6_iface->mutex);
             break;
@@ -557,11 +553,7 @@ void gnrc_ndp_internal_send_rtr_adv(kernel_pid_t iface, ipv6_addr_t *src, ipv6_a
         }
     }
     if (ipv6_iface->flags & GNRC_IPV6_NETIF_FLAGS_ADV_RETRANS_TIMER) {
-        uint64_t tmp = timex_uint64(ipv6_iface->retrans_timer) / MS_IN_USEC;
-        if (tmp > UINT32_MAX) {
-            tmp = UINT32_MAX;
-        }
-        retrans_timer = (uint32_t)tmp;
+        retrans_timer = ipv6_iface->retrans_timer / MS_IN_USEC;
     }
     if (!fin) {
         adv_ltime = ipv6_iface->adv_ltime;

--- a/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
+++ b/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
@@ -180,9 +180,7 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
             gnrc_ndp_internal_send_nbr_sol(iface, NULL, next_hop_ip, &dst_sol);
 
             mutex_lock(&ipv6_iface->mutex);
-            gnrc_ndp_internal_reset_nbr_sol_timer(nc_entry, (uint32_t) timex_uint64(
-                                                    ipv6_iface->retrans_timer
-                                                  ),
+            gnrc_ndp_internal_reset_nbr_sol_timer(nc_entry, ipv6_iface->retrans_timer,
                                                   GNRC_NDP_MSG_NBR_SOL_RETRANS, gnrc_ipv6_pid);
             mutex_unlock(&ipv6_iface->mutex);
         }

--- a/sys/net/gnrc/network_layer/ndp/router/gnrc_ndp_router.c
+++ b/sys/net/gnrc/network_layer/ndp/router/gnrc_ndp_router.c
@@ -16,7 +16,6 @@
 #include "net/gnrc/ndp.h"
 #include "net/gnrc/ndp/internal.h"
 #include "random.h"
-#include "timex.h"
 #include "xtimer.h"
 
 #include "net/gnrc/ndp/router.h"

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -23,7 +23,6 @@
 #include "net/gnrc/sixlowpan/frag.h"
 #include "net/sixlowpan.h"
 #include "thread.h"
-#include "timex.h"
 #include "xtimer.h"
 #include "utlist.h"
 

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
@@ -23,7 +23,6 @@
 
 #include "net/gnrc/netif/hdr.h"
 #include "net/gnrc/pkt.h"
-#include "timex.h"
 
 #include "net/gnrc/sixlowpan/frag.h"
 #ifdef __cplusplus

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -20,7 +20,6 @@
 #include "net/gnrc/sixlowpan.h"
 #include "net/gnrc/sixlowpan/ctx.h"
 #include "random.h"
-#include "timex.h"
 
 #include "net/gnrc/sixlowpan/nd.h"
 

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/router/gnrc_sixlowpan_nd_router.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/router/gnrc_sixlowpan_nd_router.c
@@ -192,7 +192,7 @@ void gnrc_sixlowpan_nd_opt_abr_handle(kernel_pid_t iface, ndp_rtr_adv_t *rtr_adv
     uint16_t opt_offset = 0;
     uint8_t *buf = (uint8_t *)(rtr_adv + 1);
     gnrc_sixlowpan_nd_router_abr_t *abr;
-    timex_t t = { 0, 0 };
+    uint32_t t = 0;
 
     if (_is_me(&abr_opt->braddr)) {
         return;
@@ -239,12 +239,12 @@ void gnrc_sixlowpan_nd_opt_abr_handle(kernel_pid_t iface, ndp_rtr_adv_t *rtr_adv
     memset(abr->ctxs, 0, sizeof(abr->ctxs));
     abr->prfs = NULL;
 
-    t.seconds = abr->ltime * 60;
+    t = abr->ltime * 60 * SEC_IN_USEC;
 
     xtimer_remove(&abr->ltimer);
     abr->ltimer_msg.type = GNRC_SIXLOWPAN_ND_MSG_ABR_TIMEOUT;
     abr->ltimer_msg.content.ptr = (char *) abr;
-    xtimer_set_msg(&abr->ltimer, (uint32_t) timex_uint64(t), &abr->ltimer_msg, gnrc_ipv6_pid);
+    xtimer_set_msg(&abr->ltimer, t, &abr->ltimer_msg, gnrc_ipv6_pid);
 }
 
 gnrc_pktsnip_t *gnrc_sixlowpan_nd_opt_6ctx_build(uint8_t prefix_len, uint8_t flags, uint16_t ltime,


### PR DESCRIPTION
This PR replaces `timex_t` (and corresponding functions) with `uint32_t` in the `net/gnrc/network_layer` folder.
Rationale: `timex_t` was used by vtimer. Now that all vtimer uses in the network_layer folder were replaced by xtimer calls, it makes no sense to still keep `timex_t` here.

_EDIT:_ (sizes for the `gnrc_networking` example)
```
make info-buildsizes-diff OLDBIN=master-bin NEWBIN=timex-bin

text    data    bss     dec     BOARD/BINDIRBASE

ERR     ERR     ERR     ERR     airfy-beacon
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin

-216    0       -8      -224    arduino-due
55088   224     20392   75704   master-bin
54872   224     20384   75480   timex-bin

-2036   0       -8      -2044   arduino-mega2560
80514   9450    14073   104037  master-bin
78478   9450    14065   101993  timex-bin

-280    0       0       -280    avsextrem
128512  2332    95961   226805  master-bin
128232  2332    95961   226525  timex-bin

-216    0       -8      -224    cc2538dk
54852   220     20368   75440   master-bin
54636   220     20360   75216   timex-bin

ERR     ERR     ERR     ERR     chronos
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin

-216    0       -8      -224    ek-lm4f120xl
54740   220     20360   75320   master-bin
54524   220     20352   75096   timex-bin

-208    0       -8      -216    f4vi1
54804   224     20360   75388   master-bin
54596   224     20352   75172   timex-bin

-216    0       -8      -224    fox
55344   220     20488   76052   master-bin
55128   220     20480   75828   timex-bin

-208    0       -8      -216    frdm-k64f
56780   1248    20360   78388   master-bin
56572   1248    20352   78172   timex-bin

-216    0       -8      -224    iotlab-m3
70196   220     23432   93848   master-bin
69980   220     23424   93624   timex-bin

-216    0       -8      -224    limifrog-v1
55996   220     20496   76712   master-bin
55780   220     20488   76488   timex-bin

-216    0       -8      -224    mbed_lpc1768
54512   220     20368   75100   master-bin
54296   220     20360   74876   timex-bin

ERR     ERR     ERR     ERR     msb-430
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin

ERR     ERR     ERR     ERR     msb-430h
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin

-408    0       0       -408    msba2
155816  2332    95961   254109  master-bin
155408  2332    95961   253701  timex-bin

-216    0       -8      -224    msbiot
55236   224     20376   75836   master-bin
55020   224     20368   75612   timex-bin

-216    0       -8      -224    mulle
74968   1284    23712   99964   master-bin
74752   1284    23704   99740   timex-bin

-1600   0       -32     -1632   native
189638  624     114200  304462  master-bin
188038  624     114168  302830  timex-bin

ERR     ERR     ERR     ERR     nrf51dongle
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin

ERR     ERR     ERR     ERR     nrf6310
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin

-304    0       -8      -312    nucleo-f091
57664   220     20368   78252   master-bin
57360   220     20360   77940   timex-bin

-208    0       -8      -216    nucleo-f303
54892   220     20376   75488   master-bin
54684   220     20368   75272   timex-bin

ERR     ERR     ERR     ERR     nucleo-f334
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin

-216    0       -8      -224    nucleo-l1
55924   220     20488   76632   master-bin
55708   220     20480   76408   timex-bin

-216    0       -8      -224    openmote
54760   220     20368   75348   master-bin
54544   220     20360   75124   timex-bin

-216    0       -8      -224    pba-d-01-kw2x
72020   1248    23784   97052   master-bin
71804   1248    23776   96828   timex-bin

ERR     ERR     ERR     ERR     pca10000
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin

ERR     ERR     ERR     ERR     pca10005
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin

-280    0       0       -280    pttu
128720  2332    95961   227013  master-bin
128440  2332    95961   226733  timex-bin

-216    0       -8      -224    remote
55436   220     20368   76024   master-bin
55220   220     20360   75800   timex-bin

-304    0       -8      -312    saml21-xpro
57852   220     20488   78560   master-bin
57548   220     20480   78248   timex-bin

-336    0       -8      -344    samr21-xpro
74880   220     23448   98548   master-bin
74544   220     23440   98204   timex-bin

-216    0       -8      -224    slwstk6220a
54480   220     20488   75188   master-bin
54264   220     20480   74964   timex-bin

ERR     ERR     ERR     ERR     spark-core
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin

ERR     ERR     ERR     ERR     stm32f0discovery
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin

-208    0       -8      -216    stm32f3discovery
54900   220     20376   75496   master-bin
54692   220     20368   75280   timex-bin

-216    0       -8      -224    stm32f4discovery
55084   224     20368   75676   master-bin
54868   224     20360   75452   timex-bin

ERR     ERR     ERR     ERR     telosb
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin

-216    0       -8      -224    udoo
55088   224     20392   75704   master-bin
54872   224     20384   75480   timex-bin

ERR     ERR     ERR     ERR     weio
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin

ERR     ERR     ERR     ERR     wsn430-v1_3b
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin

ERR     ERR     ERR     ERR     wsn430-v1_4
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin

ERR     ERR     ERR     ERR     yunjia-nrf51822
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin

ERR     ERR     ERR     ERR     z1
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     timex-bin
```