### PR TITLE
cpu/stm32f1/spi: add SPI peripheral 1 and 2

### DIFF
--- a/cpu/stm32f1/periph/spi.c
+++ b/cpu/stm32f1/periph/spi.c
@@ -32,7 +32,7 @@
 #include "debug.h"
 
 /* guard file in case no SPI device is defined */
-#if SPI_0_EN
+#if SPI_0_EN || SPI_1_EN || SPI_2_EN
 
 /**
  * @brief Array holding one pre-initialized mutex for each SPI device
@@ -61,6 +61,22 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
             spi = SPI_0_DEV;
             bus_div = SPI_0_BUS_DIV;
             SPI_0_CLKEN();
+            break;
+#endif
+
+#ifdef SPI_1_EN
+        case SPI_1:
+            spi = SPI_1_DEV;
+            bus_div = SPI_1_BUS_DIV;
+            SPI_1_CLKEN();
+            break;
+#endif
+
+#ifdef SPI_2_EN
+        case SPI_2:
+            spi = SPI_2_DEV;
+            bus_div = SPI_2_BUS_DIV;
+            SPI_2_CLKEN();
             break;
 #endif
         default:
@@ -119,6 +135,22 @@ int spi_conf_pins(spi_t dev)
             miso = SPI_0_MISO_PIN;
             break;
 #endif
+
+#ifdef SPI_1_EN
+        case SPI_1:
+            clk = SPI_1_CLK_PIN;
+            mosi = SPI_1_MOSI_PIN;
+            miso = SPI_1_MISO_PIN;
+            break;
+#endif
+
+#ifdef SPI_2_EN
+        case SPI_2:
+            clk = SPI_2_CLK_PIN;
+            mosi = SPI_2_MOSI_PIN;
+            miso = SPI_2_MISO_PIN;
+            break;
+#endif
         default:
             return -1;
     }
@@ -157,6 +189,18 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
 #ifdef SPI_0_EN
         case SPI_0:
             spi = SPI_0_DEV;
+            break;
+#endif
+
+#ifdef SPI_1_EN
+        case SPI_1:
+            spi = SPI_1_DEV;
+            break;
+#endif
+
+#ifdef SPI_2_EN
+        case SPI_2:
+            spi = SPI_2_DEV;
             break;
 #endif
         default:
@@ -204,6 +248,20 @@ void spi_poweron(spi_t dev)
             SPI_0_DEV->CR1 |= SPI_CR1_SPE;   /* turn SPI peripheral on */
             break;
 #endif
+
+#ifdef SPI_1_EN
+        case SPI_1:
+            SPI_1_CLKEN();
+            SPI_1_DEV->CR1 |= SPI_CR1_SPE;   /* turn SPI peripheral on */
+            break;
+#endif
+
+#ifdef SPI_2_EN
+        case SPI_2:
+            SPI_2_CLKEN();
+            SPI_2_DEV->CR1 |= SPI_CR1_SPE;   /* turn SPI peripheral on */
+            break;
+#endif
     }
 }
 
@@ -214,6 +272,20 @@ void spi_poweroff(spi_t dev)
         case SPI_0:
             SPI_0_DEV->CR1 &= ~(SPI_CR1_SPE);   /* turn SPI peripheral off */
             SPI_0_CLKDIS();
+            break;
+#endif
+
+#ifdef SPI_1_EN
+        case SPI_1:
+            SPI_1_DEV->CR1 &= ~(SPI_CR1_SPE);   /* turn SPI peripheral off */
+            SPI_1_CLKDIS();
+            break;
+#endif
+
+#ifdef SPI_2_EN
+        case SPI_2:
+            SPI_2_DEV->CR1 &= ~(SPI_CR1_SPE);   /* turn SPI peripheral off */
+            SPI_2_CLKDIS();
             break;
 #endif
     }


### PR DESCRIPTION
Add support for SPI_1 and SPI_2 to the STM32F1 family