### PR TITLE
driver: Add the MCP320x ADC driver

### DIFF
--- a/drivers/include/mcp320x.h
+++ b/drivers/include/mcp320x.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2015 Engineering-Spirit
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_mcp320x MCP3204/MCP3208 12-Bit A/D Converter
+ * @ingroup     drivers_sensors
+ * @brief       Driver for the Microchip MCP320x ADC.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for the MCP320x ADC driver.
+ *
+ * @author      Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ */
+
+#ifndef MCP320X_H
+#define MCP320X_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "periph/spi.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @brief Device type that is connected
+ */
+typedef enum {
+    MCP3204                 = 4,
+    MCP3208                 = 8
+} mcp320x_chip_t;
+
+/**
+ * @brief Device descriptor for MCP320x ADC.
+ */
+typedef struct {
+    spi_t spi;              /**< SPI device, the ADC is connected to */
+    gpio_t cs;              /**< chip select line to the ADC */
+    bool initialized;       /**< ADC status, true if ADC is initialized */
+    mcp320x_chip_t type;    /**< defining if we use the MCP3204 or MCP3208 */
+} mcp320x_t;
+
+/**
+ * @brief The differential modes of the MCP320x
+ */
+typedef enum {
+    CH0_MIN_CH1,
+    CH1_MIN_CH0,
+    CH2_MIN_CH3,
+    CH3_MIN_CH2,
+    CH4_MIN_CH5,
+    CH5_MIN_CH4,
+    CH6_MIN_CH7,
+    CH7_MIN_CH6
+} mcp320x_diff_mode_t;
+
+/**
+ * @brief Initialize the MCP320x ADC driver.
+ *
+ * @param[out] dev          device descriptor of ADC to initialize
+ * @param[in]  spi          SPI bus the ADC is connected to
+ * @param[in]  cs           chip select gpio to the ADC
+ * @param[in]  type         the MCP320x type
+ *
+ * @return                  0 on success
+ * @return                  -1 on failure
+ */
+int mcp320x_init(mcp320x_t *dev, spi_t spi, gpio_t cs, mcp320x_chip_t type);
+
+/**
+ * @brief Get the measured value at the given channel in counts
+ *
+ * @param[in] dev           device descriptor of the ADC to read
+ * @param[in] channel       the channel to measure
+ *
+ * @return                  >= 0 on success, counts on the input
+ * @return                  -1 on failure
+ */
+int mcp320x_read_single(mcp320x_t *dev, int channel);
+
+/**
+ * @brief Measure differential between two inputs
+ *
+ * @param[in] dev           device descriptor of the ADC to read
+ * @param[in] mode          the channels we want to differentiate
+ *
+ * @return                  >= 0 on success, counts between the two inputs
+ * @return                  -1 on failure
+ */
+int mcp320x_read_differential(mcp320x_t *dev, mcp320x_diff_mode_t mode);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+/** @} */

--- a/drivers/mcp320x/Makefile
+++ b/drivers/mcp320x/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/mcp320x/mcp320x.c
+++ b/drivers/mcp320x/mcp320x.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2015 Engineering-Spirit
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_mcp320x MCP3204/MCP3208 12-Bit A/D Converter
+ * @ingroup     drivers_sensors
+ * @brief       Driver for the Microchip MCP320x ADC.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for the MCP320x ADC driver.
+ *
+ * @author      Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "periph/gpio.h"
+#include "periph/spi.h"
+
+#include "mcp320x.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#define SPI_SPEED                  SPI_SPEED_5MHZ
+
+/**
+ * @brief enum representation of the available modes
+ */
+typedef enum {
+    Single = 0x2,
+    Diff = 0x00
+} _mcp320x_mt_t;
+
+int mcp320x_init(mcp320x_t *dev, spi_t spi, gpio_t cs, mcp320x_chip_t type)
+{
+    /* fill the device descriptor */
+    dev->spi = spi;
+    dev->cs = cs;
+    dev->initialized = true;
+    dev->type = type;
+
+
+    /* initialize the chip select line */
+    gpio_init(cs, GPIO_DIR_OUT, GPIO_NOPULL);
+    gpio_set(cs);
+
+    /* initialize the SPI peripheral */
+    return spi_init_master(spi, SPI_CONF_FIRST_RISING, SPI_SPEED);
+}
+
+static int _mcp320x_read(mcp320x_t *dev, uint8_t type, uint16_t channel)
+{
+    uint8_t packet[3] = {
+        0x4 | (uint8_t)type | ((channel & 0x04) ? 1 : 0),
+        (uint8_t)((channel << 6) & 0xff),
+        0x00
+    };
+
+    /* acquire exclusive bus access */
+    spi_acquire(dev->spi);
+
+    /* select the CS of the MCP320x */
+    gpio_clear(dev->cs);
+
+    /* write command and address */
+    int status = spi_transfer_bytes(dev->spi, (char *)packet, (char *)packet, sizeof(packet));
+    if (status < 0) {
+        return status;
+    }
+
+    /* release the CS of the MCP320x */
+    gpio_set(dev->cs);
+
+    /* release exclusive bus access */
+    spi_release(dev->spi);
+
+    return ((uint16_t)(packet[1] & 0x0f)) << 8 | packet[2];
+}
+
+int mcp320x_read_single(mcp320x_t *dev, int channel)
+{
+    /* validate arguments */
+    if (!dev || channel >= (int)dev->type) {
+        return -1;
+    }
+
+    /* read a single ADC channel */
+    return _mcp320x_read(dev, Single, channel);
+}
+
+int mcp320x_read_differential(mcp320x_t *dev, mcp320x_diff_mode_t mode)
+{
+    /* validate arguments */
+    if (!dev || mode >= (int)dev->type) {
+        return -1;
+    }
+
+    /* make an differential ADC readout in the given mode */
+    return _mcp320x_read(dev, Diff, mode);
+}

--- a/drivers/mcp320x/mcp320x.c
+++ b/drivers/mcp320x/mcp320x.c
@@ -36,8 +36,8 @@
  * @brief enum representation of the available modes
  */
 typedef enum {
-    Single = 0x2,
-    Diff = 0x00
+    single = 0x2,
+    diff = 0x00
 } _mcp320x_mt_t;
 
 int mcp320x_init(mcp320x_t *dev, spi_t spi, gpio_t cs, mcp320x_chip_t type)
@@ -94,7 +94,7 @@ int mcp320x_read_single(mcp320x_t *dev, int channel)
     }
 
     /* read a single ADC channel */
-    return _mcp320x_read(dev, Single, channel);
+    return _mcp320x_read(dev, single, channel);
 }
 
 int mcp320x_read_differential(mcp320x_t *dev, mcp320x_diff_mode_t mode)
@@ -105,5 +105,5 @@ int mcp320x_read_differential(mcp320x_t *dev, mcp320x_diff_mode_t mode)
     }
 
     /* make an differential ADC readout in the given mode */
-    return _mcp320x_read(dev, Diff, mode);
+    return _mcp320x_read(dev, diff, mode);
 }


### PR DESCRIPTION
Add a device driver for the Microchip MCP320x SPI ADC.
