### PR TITLE
gnrc nettype: always include all nettypes

### DIFF
--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -52,20 +52,14 @@ typedef enum {
     GNRC_NETTYPE_NETIF = -1,
     GNRC_NETTYPE_UNDEF = 0,     /**< Protocol is undefined */
 
-#ifdef MODULE_GNRC_SIXLOWPAN
     GNRC_NETTYPE_SIXLOWPAN,     /**< Protocol is 6LoWPAN */
-#endif
 
     /**
      * @{
      * @name Network layer
      */
-#ifdef MODULE_GNRC_IPV6
     GNRC_NETTYPE_IPV6,          /**< Protocol is IPv6 */
-#endif
-#ifdef MODULE_GNRC_ICMPV6
     GNRC_NETTYPE_ICMPV6,        /**< Protocol is ICMPv6 */
-#endif
     /**
      * @}
      */
@@ -74,12 +68,8 @@ typedef enum {
      * @{
      * @name Transport layer
      */
-#ifdef MODULE_GNRC_TCP
     GNRC_NETTYPE_TCP,           /**< Protocol is TCP */
-#endif
-#ifdef MODULE_GNRC_UDP
     GNRC_NETTYPE_UDP,           /**< Protocol is UDP */
-#endif
     /**
      * @}
      */
@@ -110,10 +100,8 @@ typedef enum {
 static inline gnrc_nettype_t gnrc_nettype_from_ethertype(uint16_t type)
 {
     switch (type) {
-#ifdef MODULE_GNRC_IPV6
         case ETHERTYPE_IPV6:
             return GNRC_NETTYPE_IPV6;
-#endif
         default:
             return GNRC_NETTYPE_UNDEF;
     }
@@ -133,10 +121,8 @@ static inline gnrc_nettype_t gnrc_nettype_from_ethertype(uint16_t type)
 static inline uint16_t gnrc_nettype_to_ethertype(gnrc_nettype_t type)
 {
     switch (type) {
-#ifdef MODULE_GNRC_IPV6
         case GNRC_NETTYPE_IPV6:
             return ETHERTYPE_IPV6;
-#endif
         default:
             return ETHERTYPE_UNKNOWN;
     }
@@ -156,22 +142,14 @@ static inline uint16_t gnrc_nettype_to_ethertype(gnrc_nettype_t type)
 static inline gnrc_nettype_t gnrc_nettype_from_protnum(uint8_t num)
 {
     switch (num) {
-#ifdef MODULE_GNRC_ICMPV6
         case PROTNUM_ICMPV6:
             return GNRC_NETTYPE_ICMPV6;
-#endif
-#ifdef MODULE_GNRC_IPV6
         case PROTNUM_IPV6:
             return GNRC_NETTYPE_IPV6;
-#endif
-#ifdef MODULE_GNRC_TCP
         case PROTNUM_TCP:
             return GNRC_NETTYPE_TCP;
-#endif
-#ifdef MODULE_GNRC_UDP
         case PROTNUM_UDP:
             return GNRC_NETTYPE_UDP;
-#endif
         default:
             return GNRC_NETTYPE_UNDEF;
     }
@@ -191,22 +169,14 @@ static inline gnrc_nettype_t gnrc_nettype_from_protnum(uint8_t num)
 static inline uint8_t gnrc_nettype_to_protnum(gnrc_nettype_t type)
 {
     switch (type) {
-#ifdef MODULE_GNRC_ICMPV6
         case GNRC_NETTYPE_ICMPV6:
             return PROTNUM_ICMPV6;
-#endif
-#ifdef MODULE_GNRC_IPV6
         case GNRC_NETTYPE_IPV6:
             return PROTNUM_IPV6;
-#endif
-#ifdef MODULE_GNRC_TCP
         case GNRC_NETTYPE_TCP:
             return PROTNUM_TCP;
-#endif
-#ifdef MODULE_GNRC_UDP
         case GNRC_NETTYPE_UDP:
             return PROTNUM_UDP;
-#endif
         default:
             return PROTNUM_RESERVED;
     }


### PR DESCRIPTION
Even if an application cannot process a certain protocol, it might be able to handle it somehow.