### PR TITLE
shell_command: only include sc_zep.c when gnrc_zep AND ipv6_addr are present

### DIFF
--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -56,8 +56,10 @@ endif
 ifneq (,$(filter gnrc_icmpv6_echo vtimer,$(USEMODULE)))
   SRC += sc_icmpv6_echo.c
 endif
-ifneq (,$(filter gnrc_zep ipv6_addr,$(USEMODULE)))
-  SRC += sc_zep.c
+ifneq (,$(filter gnrc_zep,$(USEMODULE)))
+  ifneq (,$(filter ipv6_addr,$(USEMODULE)))
+    SRC += sc_zep.c
+  endif
 endif
 ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
     SRC += sc_gnrc_rpl.c


### PR DESCRIPTION
Currently it is included when `gnrc_zep` OR `ipv6_addr` are present.