### PR TITLE
rpl: decrease default numbers

### DIFF
--- a/sys/include/net/gnrc/rpl/dodag.h
+++ b/sys/include/net/gnrc/rpl/dodag.h
@@ -36,14 +36,14 @@ extern "C" {
  * @brief   Number of RPL instances
  */
 #ifndef GNRC_RPL_INSTANCES_NUMOF
-#define GNRC_RPL_INSTANCES_NUMOF (2)
+#define GNRC_RPL_INSTANCES_NUMOF (1)
 #endif
 
 /**
  * @brief   Number of RPL parents
  */
 #ifndef GNRC_RPL_PARENTS_NUMOF
-#define GNRC_RPL_PARENTS_NUMOF (6)
+#define GNRC_RPL_PARENTS_NUMOF (3)
 #endif
 
 /**

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -159,13 +159,10 @@ int _gnrc_rpl_dodag_show(void)
         else {
             printf("[X]");
         }
-        if (i < (GNRC_RPL_INSTANCES_NUMOF - 1)) {
-            printf("\t");
-        }
-        else {
-            printf("\n");
-        }
+        putchar('\t');
     }
+
+    putchar('\n');
 
     printf("parent table:\t");
     for (uint8_t i = 0; i < GNRC_RPL_PARENTS_NUMOF; ++i) {
@@ -175,9 +172,7 @@ int _gnrc_rpl_dodag_show(void)
         else {
             printf("[X]");
         }
-        if (i < (GNRC_RPL_PARENTS_NUMOF - 1)) {
-            putchar('\t');
-        }
+        putchar('\t');
     }
     putchar('\n');
     putchar('\n');


### PR DESCRIPTION
This PR reduces the default number of dodags/instances to `1` instead of `2` and the default number
of parents to `3` instead of `6`.

```
text    data    bss     dec     BOARD/BINDIRBASE

ERR     ERR     ERR     ERR     airfy-beacon
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin

-192    0       -432    -624    arduino-due
55352   224     20392   75968   master-bin
55160   224     19960   75344   rpl-bin

-364    0       -305    -669    arduino-mega2560
81280   9602    14085   104967  master-bin
80916   9602    13780   104298  rpl-bin

-336    0       0       -336    avsextrem
128864  2332    95961   227157  master-bin
128528  2332    95961   226821  rpl-bin

-192    0       -432    -624    cc2538dk
55116   220     20368   75704   master-bin
54924   220     19936   75080   rpl-bin

ERR     ERR     ERR     ERR     chronos
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin

-192    0       -432    -624    ek-lm4f120xl
54996   220     20360   75576   master-bin
54804   220     19928   74952   rpl-bin

-200    0       -432    -632    f4vi1
55068   224     20360   75652   master-bin
54868   224     19928   75020   rpl-bin

-184    0       -432    -616    fox
55600   220     20488   76308   master-bin
55416   220     20056   75692   rpl-bin

-200    0       -432    -632    frdm-k64f
57044   1248    20360   78652   master-bin
56844   1248    19928   78020   rpl-bin

-192    0       -432    -624    iotlab-m3
70460   220     23432   94112   master-bin
70268   220     23000   93488   rpl-bin

-192    0       -432    -624    limifrog-v1
56252   220     20496   76968   master-bin
56060   220     20064   76344   rpl-bin

-192    0       -432    -624    mbed_lpc1768
54776   220     20368   75364   master-bin
54584   220     19936   74740   rpl-bin

ERR     ERR     ERR     ERR     msb-430
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin

ERR     ERR     ERR     ERR     msb-430h
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin

-328    0       0       -328    msba2
156160  2332    95961   254453  master-bin
155832  2332    95961   254125  rpl-bin

-192    0       -432    -624    msbiot
55492   224     20376   76092   master-bin
55300   224     19944   75468   rpl-bin

-200    0       -432    -632    mulle
75232   1284    23712   100228  master-bin
75032   1284    23280   99596   rpl-bin

-16     0       -384    -400    native
190186  624     114200  305010  master-bin
190170  624     113816  304610  rpl-bin

ERR     ERR     ERR     ERR     nrf51dongle
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin

ERR     ERR     ERR     ERR     nrf6310
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin

-220    0       -432    -652    nucleo-f091
57932   220     20368   78520   master-bin
57712   220     19936   77868   rpl-bin

-200    0       -432    -632    nucleo-f303
55156   220     20376   75752   master-bin
54956   220     19944   75120   rpl-bin

ERR     ERR     ERR     ERR     nucleo-f334
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin

-192    0       -432    -624    nucleo-l1
56188   220     20488   76896   master-bin
55996   220     20056   76272   rpl-bin

-192    0       -432    -624    openmote
55024   220     20368   75612   master-bin
54832   220     19936   74988   rpl-bin

-192    0       -432    -624    pba-d-01-kw2x
72276   1248    23784   97308   master-bin
72084   1248    23352   96684   rpl-bin

ERR     ERR     ERR     ERR     pca10000
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin

ERR     ERR     ERR     ERR     pca10005
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin

-336    0       0       -336    pttu
129072  2332    95961   227365  master-bin
128736  2332    95961   227029  rpl-bin

-192    0       -432    -624    remote
55700   220     20368   76288   master-bin
55508   220     19936   75664   rpl-bin

-220    0       -432    -652    saml21-xpro
58120   220     20488   78828   master-bin
57900   220     20056   78176   rpl-bin

-220    0       -432    -652    samr21-xpro
75148   220     23448   98816   master-bin
74928   220     23016   98164   rpl-bin

-184    0       -432    -616    slwstk6220a
54736   220     20488   75444   master-bin
54552   220     20056   74828   rpl-bin

ERR     ERR     ERR     ERR     spark-core
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin

ERR     ERR     ERR     ERR     stm32f0discovery
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin

-200    0       -432    -632    stm32f3discovery
55164   220     20376   75760   master-bin
54964   220     19944   75128   rpl-bin

-192    0       -432    -624    stm32f4discovery
55340   224     20368   75932   master-bin
55148   224     19936   75308   rpl-bin

ERR     ERR     ERR     ERR     telosb
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin

-192    0       -432    -624    udoo
55352   224     20392   75968   master-bin
55160   224     19960   75344   rpl-bin

ERR     ERR     ERR     ERR     weio
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin

ERR     ERR     ERR     ERR     wsn430-v1_3b
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin

ERR     ERR     ERR     ERR     wsn430-v1_4
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin

ERR     ERR     ERR     ERR     yunjia-nrf51822
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin

ERR     ERR     ERR     ERR     z1
ERR     ERR     ERR     ERR     master-bin
ERR     ERR     ERR     ERR     rpl-bin
```