### PR TITLE
rpl: uint32_t is sufficient for the DAO timer

### DIFF
--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -223,7 +223,7 @@ struct gnrc_rpl_dodag {
     bool dodag_conf_requested;      /**< flag to send DODAG_CONF options */
     bool prefix_info_requested;     /**< flag to send PREFIX_INFO options */
     msg_t dao_msg;                  /**< msg_t for firing a dao */
-    uint64_t dao_time;              /**< time to schedule the next DAO */
+    uint32_t dao_time;              /**< time to schedule the next DAO */
     xtimer_t dao_timer;             /**< timer to schedule the next DAO */
     msg_t cleanup_msg;              /**< msg_t for firing a cleanup */
     uint32_t cleanup_time;          /**< time to schedula a DODAG cleanup */

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -256,7 +256,7 @@ void gnrc_rpl_delay_dao(gnrc_rpl_dodag_t *dodag)
     dodag->dao_time = GNRC_RPL_DEFAULT_DAO_DELAY * SEC_IN_USEC;
     dodag->dao_counter = 0;
     dodag->dao_ack_received = false;
-    xtimer_set_msg64(&dodag->dao_timer, dodag->dao_time, &dodag->dao_msg, gnrc_rpl_pid);
+    xtimer_set_msg(&dodag->dao_timer, dodag->dao_time, &dodag->dao_msg, gnrc_rpl_pid);
 }
 
 void gnrc_rpl_long_delay_dao(gnrc_rpl_dodag_t *dodag)
@@ -264,7 +264,7 @@ void gnrc_rpl_long_delay_dao(gnrc_rpl_dodag_t *dodag)
     dodag->dao_time = GNRC_RPL_REGULAR_DAO_INTERVAL * SEC_IN_USEC;
     dodag->dao_counter = 0;
     dodag->dao_ack_received = false;
-    xtimer_set_msg64(&dodag->dao_timer, dodag->dao_time, &dodag->dao_msg, gnrc_rpl_pid);
+    xtimer_set_msg(&dodag->dao_timer, dodag->dao_time, &dodag->dao_msg, gnrc_rpl_pid);
 }
 
 void _dao_handle_send(gnrc_rpl_dodag_t *dodag)
@@ -273,7 +273,7 @@ void _dao_handle_send(gnrc_rpl_dodag_t *dodag)
         dodag->dao_counter++;
         gnrc_rpl_send_DAO(dodag->instance, NULL, dodag->default_lifetime);
         dodag->dao_time = GNRC_RPL_DEFAULT_WAIT_FOR_DAO_ACK * SEC_IN_USEC;
-        xtimer_set_msg64(&dodag->dao_timer, dodag->dao_time, &dodag->dao_msg, gnrc_rpl_pid);
+        xtimer_set_msg(&dodag->dao_timer, dodag->dao_time, &dodag->dao_msg, gnrc_rpl_pid);
     }
     else if (dodag->dao_ack_received == false) {
         gnrc_rpl_long_delay_dao(dodag);


### PR DESCRIPTION
This change saves some bytes on the ROM that are effectively not needed.
12 Bytes are saved with this change regarding pahole [1]

[1] http://linux.die.net/man/1/pahole