### PR TITLE
zep: remove superfluous vtimer include

### DIFF
--- a/sys/net/gnrc/application_layer/zep/gnrc_zep.c
+++ b/sys/net/gnrc/application_layer/zep/gnrc_zep.c
@@ -30,7 +30,6 @@
 #include "net/gnrc/udp.h"
 #include "periph/cpuid.h"
 #include "random.h"
-#include "vtimer.h"
 
 #include "net/gnrc/zep.h"
 


### PR DESCRIPTION
`vtimer` is never used in `gnrc_zep.c`. Thus, including `vtimer.h` is unnecessary here.