### PR TITLE
cpu: stm32f[34]: remove unused vtimer include

### DIFF
--- a/cpu/stm32f3/periph/spi.c
+++ b/cpu/stm32f3/periph/spi.c
@@ -32,7 +32,6 @@
 #include "periph_conf.h"
 #include "thread.h"
 #include "sched.h"
-#include "vtimer.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"

--- a/cpu/stm32f4/periph/spi.c
+++ b/cpu/stm32f4/periph/spi.c
@@ -28,7 +28,6 @@
 #include "periph_conf.h"
 #include "thread.h"
 #include "sched.h"
-#include "vtimer.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"


### PR DESCRIPTION
This PR removes superfluous `vtimer.h` includes in `spi.c` for `stm32f3` and `stm32f4`.