### PR TITLE
examples: gnrc_networking: vtimer to xtimer

### DIFF
--- a/examples/gnrc_networking/udp.c
+++ b/examples/gnrc_networking/udp.c
@@ -27,7 +27,7 @@
 #include "net/gnrc/udp.h"
 #include "net/gnrc/pktdump.h"
 #include "timex.h"
-#include "vtimer.h"
+#include "xtimer.h"
 
 static gnrc_netreg_entry_t server = { NULL, GNRC_NETREG_DEMUX_CTX_ALL, KERNEL_PID_UNDEF };
 
@@ -83,7 +83,7 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
         }
         printf("Success: send %u byte to [%s]:%u\n", (unsigned)payload->size,
                addr_str, tmp);
-        vtimer_usleep(delay);
+        xtimer_usleep(delay);
     }
 }
 


### PR DESCRIPTION
This PR replaces the vtimer call with an xtimer call in the `gnrc_networking` example