### PR TITLE
tests: nrf24l01p: use xtimer in Makefile

### DIFF
--- a/tests/driver_nrf24l01p_lowlevel/Makefile
+++ b/tests/driver_nrf24l01p_lowlevel/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.tests_common
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
-USEMODULE += vtimer
+USEMODULE += xtimer
 USEMODULE += nrf24l01p
 
 FEATURES_REQUIRED = periph_spi


### PR DESCRIPTION
While the test itself was adjusted to use `xtimer`, the `Makefile` was still using `vtimer`.
This PR replaces that with `xtimer`.