### PR TITLE
cpu: kinetis_common: remove vtimer include from spi.c

### DIFF
--- a/cpu/kinetis_common/spi.c
+++ b/cpu/kinetis_common/spi.c
@@ -16,7 +16,6 @@
 #include "periph_conf.h"
 #include "thread.h"
 #include "sched.h"
-#include "vtimer.h"
 #include "mutex.h"
 
 #define ENABLE_DEBUG (0)


### PR DESCRIPTION
I overlooked this vtimer include in `kinetis_common`.
There is no vtimer/xtimer functionality used in `spi.c`, hence the include can be removed.