### PR TITLE
gnrc 6lowpan: configure destination address mode

### DIFF
--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -148,6 +148,7 @@ int _get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len)
             break;
         case NETOPT_ADDR_LEN:
         case NETOPT_SRC_LEN:
+        case NETOPT_DST_LEN:
             assert(max_len == 2);
             uint16_t *tgt = (uint16_t*)value;
             *tgt=6;

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -405,6 +405,18 @@ static int _get(gnrc_netdev_t *device, netopt_t opt, void *val, size_t max_len)
             }
             return sizeof(uint16_t);
 
+        case NETOPT_DST_LEN:
+            if (max_len < sizeof(uint16_t)) {
+                return -EOVERFLOW;
+            }
+            if (dev->options & AT86RF2XX_OPT_DST_ADDR_LONG) {
+                *((uint16_t *)val) = 8;
+            }
+            else {
+                *((uint16_t *)val) = 2;
+            }
+            return sizeof(uint16_t);
+
         case NETOPT_NID:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
@@ -625,6 +637,26 @@ static int _set(gnrc_netdev_t *device, netopt_t opt, void *val, size_t len)
                 }
                 else if (*((uint16_t *)val) == 8) {
                     at86rf2xx_set_option(dev, AT86RF2XX_OPT_SRC_ADDR_LONG,
+                                         true);
+                }
+                else {
+                    res = -ENOTSUP;
+                    break;
+                }
+                res = sizeof(uint16_t);
+            }
+            break;
+
+        case NETOPT_DST_LEN:
+            if (len > sizeof(uint16_t)) {
+                res = -EOVERFLOW;
+            } else {
+                if (*((uint16_t *)val) == 2) {
+                    at86rf2xx_set_option(dev, AT86RF2XX_OPT_DST_ADDR_LONG,
+                                         false);
+                }
+                else if (*((uint16_t *)val) == 8) {
+                    at86rf2xx_set_option(dev, AT86RF2XX_OPT_DST_ADDR_LONG,
                                          true);
                 }
                 else {

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -419,6 +419,7 @@ int _get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len)
             break;
         case NETOPT_ADDR_LEN:
         case NETOPT_SRC_LEN:
+        case NETOPT_DST_LEN:
             assert(max_len == 2);
             uint16_t *tgt = (uint16_t*)value;
             *tgt=6;

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -115,7 +115,9 @@ extern "C" {
                                                      *   upper layer */
 #define AT86RF2XX_OPT_SRC_ADDR_LONG  (0x0200)       /**< send data using long
                                                      *   source address */
-#define AT86RF2XX_OPT_USE_SRC_PAN    (0x0400)       /**< do not compress source
+#define AT86RF2XX_OPT_DST_ADDR_LONG  (0x0400)       /**< send data using long
+                                                     *   destination address */
+#define AT86RF2XX_OPT_USE_SRC_PAN    (0x0800)       /**< do not compress source
                                                      *   PAN ID */
 /** @} */
 

--- a/drivers/include/kw2xrf.h
+++ b/drivers/include/kw2xrf.h
@@ -96,6 +96,7 @@ extern "C" {
 #define KW2XRF_OPT_TELL_RX_END   (0x0080)  /**< notify MAC layer on RX finished */
 #define KW2XRF_OPT_RAWDUMP       (0x0100)  /**< pass RAW frame data to upper layer */
 #define KW2XRF_OPT_SRC_ADDR_LONG (0x0200)  /**< send data using long source address */
+#define KW2XRF_OPT_DST_ADDR_LONG (0x0400)  /**< send data using long destination address */
 #define KW2XRF_OPT_USE_SRC_PAN   (0x0400)  /**< do not compress source PAN ID */
 /** @} */
 

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -561,6 +561,20 @@ int kw2xrf_get(gnrc_netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
 
             return sizeof(uint16_t);
 
+        case NETOPT_DST_LEN:
+            if (max_len < sizeof(uint16_t)) {
+                return -EOVERFLOW;
+            }
+
+            if (dev->option & KW2XRF_OPT_DST_ADDR_LONG) {
+                *((uint16_t *)value) = 8;
+            }
+            else {
+                *((uint16_t *)value) = 2;
+            }
+
+            return sizeof(uint16_t);
+
         case NETOPT_NID:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
@@ -760,6 +774,25 @@ int kw2xrf_set(gnrc_netdev_t *netdev, netopt_t opt, void *value, size_t value_le
             }
 
             return sizeof(uint16_t);
+
+        case NETOPT_DST_LEN:
+            if (len > sizeof(uint16_t)) {
+                res = -EOVERFLOW;
+            } else {
+                if (*((uint16_t *)val) == 2) {
+                    kw2xrf_set_option(dev, KW2XRF_OPT_DST_ADDR_LONG, false);
+                }
+                else if (*((uint16_t *)val) == 8) {
+                    kw2xrf_set_option(dev, KW2XRF_OPT_DST_ADDR_LONG, true);
+                }
+                else {
+                    res = -ENOTSUP;
+                    break;
+                }
+                res = sizeof(uint16_t);
+            }
+            break;
+
 
         case NETOPT_NID:
             if (value_len > sizeof(uint16_t)) {

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -592,6 +592,7 @@ static int _get(gnrc_netdev_t *netdev, netopt_t opt, void *value, size_t max_len
             return _get_addr_long(dev, (uint8_t *)value, max_len);
         case NETOPT_ADDR_LEN:
         case NETOPT_SRC_LEN:
+        case NETOPT_DST_LEN:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }
@@ -643,6 +644,7 @@ static int _set(gnrc_netdev_t *netdev, netopt_t opt, void *value, size_t value_l
             return _set_addr(dev, (uint8_t *)value, value_len);
         case NETOPT_ADDR_LEN:
         case NETOPT_SRC_LEN:
+        case NETOPT_DST_LEN:
             return _set_addr_len(dev, value, value_len);
         case NETOPT_CHANNEL:
             return _set_channel(dev, (uint8_t *)value, value_len);

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -51,6 +51,9 @@ typedef enum {
     NETOPT_SRC_LEN,             /**< get/set the address length to choose
                                  *   for the network device's source address
                                  *   as uint16_t in host byte order */
+    NETOPT_DST_LEN,             /**< get/set the address length to choose
+                                 *   for the network device's destination address
+                                 *   as uint16_t in host byte order */
     /**
      * @brief    get/set the network ID as uint16_t in host byte order
      *

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -30,6 +30,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_ADDRESS_LONG]    = "NETOPT_ADDRESS_LONG",
     [NETOPT_ADDR_LEN]        = "NETOPT_ADDR_LEN",
     [NETOPT_SRC_LEN]         = "NETOPT_SRC_LEN",
+    [NETOPT_DST_LEN]         = "NETOPT_DST_LEN",
     [NETOPT_NID]             = "NETOPT_NID",
     [NETOPT_IPV6_IID]        = "NETOPT_IPV6_IID",
     [NETOPT_TX_POWER]        = "NETOPT_TX_POWER",

--- a/sys/net/gnrc/application_layer/zep/gnrc_zep.c
+++ b/sys/net/gnrc/application_layer/zep/gnrc_zep.c
@@ -482,7 +482,7 @@ static int _set(gnrc_netdev_t *netdev, netopt_t opt, void *value, size_t value_l
                 return sizeof(be_uint64_t);
             }
 
-        case NETOPT_ADDR_LEN:
+        case NETOPT_DST_LEN:
             if (value_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;
             }

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -806,7 +806,7 @@ void gnrc_ipv6_netif_init_by_dev(void)
         if ((gnrc_netapi_get(ifs[i], NETOPT_PROTO, 0, &if_type,
                              sizeof(if_type)) != -ENOTSUP) &&
             (if_type == GNRC_NETTYPE_SIXLOWPAN)) {
-            uint16_t src_len = 8;
+            uint16_t src_dst_len = 8;
             uint16_t max_frag_size = UINT16_MAX;
 
             DEBUG("ipv6 netif: Set 6LoWPAN flag\n");
@@ -823,8 +823,10 @@ void gnrc_ipv6_netif_init_by_dev(void)
 #endif
             /* use EUI-64 (8-byte address) for IID generation and for sending
              * packets */
-            gnrc_netapi_set(ifs[i], NETOPT_SRC_LEN, 0, &src_len,
-                            sizeof(src_len)); /* don't care for result */
+            gnrc_netapi_set(ifs[i], NETOPT_SRC_LEN, 0, &src_dst_len,
+                            sizeof(src_dst_len)); /* don't care for result */
+            gnrc_netapi_set(ifs[i], NETOPT_DST_LEN, 0, &src_dst_len,
+                            sizeof(src_dst_len)); /* don't care for result */
 
             if (gnrc_netapi_get(ifs[i], NETOPT_MAX_PACKET_SIZE,
                                 0, &max_frag_size, sizeof(max_frag_size)) < 0) {

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -88,6 +88,7 @@ static void _set_usage(char *cmd_name)
          "       * \"pan_id\" - alias for \"nid\"\n"
          "       * \"power\" - TX power in dBm\n"
          "       * \"src_len\" - sets the source address length in byte\n"
+         "       * \"dst_len\" - sets the destination address length in byte\n"
          "       * \"state\" - set the device state\n");
 }
 
@@ -131,6 +132,10 @@ static void _print_netopt(netopt_t opt)
 
         case NETOPT_SRC_LEN:
             printf("source address length");
+            break;
+
+        case NETOPT_DST_LEN:
+            printf("destination address length");
             break;
 
         case NETOPT_CHANNEL:
@@ -341,6 +346,12 @@ static void _netif_list(kernel_pid_t dev)
 
     if (res >= 0) {
         printf("Source address length: %" PRIu16 "\n           ", u16);
+    }
+
+    res = gnrc_netapi_get(dev, NETOPT_DST_LEN, 0, &u16, sizeof(u16));
+
+    if (res >= 0) {
+        printf("Destination address length: %" PRIu16 "\n           ", u16);
     }
 
 #ifdef MODULE_GNRC_IPV6_NETIF
@@ -571,6 +582,9 @@ static int _netif_set(char *cmd_name, kernel_pid_t dev, char *key, char *value)
     }
     else if (strcmp("src_len", key) == 0) {
         return _netif_set_u16(dev, NETOPT_SRC_LEN, value);
+    }
+    else if (strcmp("dst_len", key) == 0) {
+        return _netif_set_u16(dev, NETOPT_DST_LEN, value);
     }
     else if (strcmp("state", key) == 0) {
         return _netif_set_state(dev, value);


### PR DESCRIPTION
For the [ETSI 6lo plugtests]() I had to configure the destination address mode to either use 16-bit short addresses or 64-bit long addresses on IEEE 802.15.4. While implementing this I stumbled across the fact, that RIOT currently defines `NETOPT_ADDR_LEN` and `NETOPT_SRC_LEN`. I implemented the missing feature by adding a `NETOPT_DST_LEN`.