### PR TITLE
cpp11: vtimer->xtimer

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -341,7 +341,7 @@ ifneq (,$(filter log_%,$(USEMODULE)))
 endif
 
 ifneq (,$(filter cpp11-compat,$(USEMODULE)))
-  USEMODULE += vtimer
+  USEMODULE += xtimer
   USEMODULE += timex
   FEATURES_REQUIRED += cpp
 endif

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -30,7 +30,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
-#ifdef MODULE_VTIMER
+#ifdef MODULE_XTIMER
 #include <sys/time.h>
 #endif
 #include <ifaddrs.h>
@@ -39,7 +39,7 @@
 #include "kernel.h"
 #include "cpu.h"
 #include "irq.h"
-#include "vtimer.h"
+#include "xtimer.h"
 
 #include "native_internal.h"
 
@@ -402,7 +402,10 @@ int getpid(void)
 int _gettimeofday(struct timeval *tp, void *restrict tzp)
 {
     (void) tzp;
-    vtimer_gettimeofday(tp);
+    timex_t now;
+    xtimer_now_timex(&now);
+    tp->tv_sec = now.seconds;
+    tp->tv_usec = now.microseconds;
     return 0;
 }
 #endif

--- a/sys/cpp11-compat/condition_variable.cpp
+++ b/sys/cpp11-compat/condition_variable.cpp
@@ -24,7 +24,7 @@
 #include "irq.h"
 #include "sched.h"
 #include "timex.h"
-#include "vtimer.h"
+#include "xtimer.h"
 #include "priority_queue.h"
 
 #include "riot/condition_variable.hpp"
@@ -103,16 +103,16 @@ void condition_variable::wait(unique_lock<mutex>& lock) noexcept {
 
 cv_status condition_variable::wait_until(unique_lock<mutex>& lock,
                                          const time_point& timeout_time) {
-  vtimer_t timer;
+  xtimer_t timer;
   // todo: use function to wait for absolute timepoint once available
   timex_t before;
-  vtimer_now(&before);
+  xtimer_now_timex(&before);
   auto diff = timex_sub(timeout_time.native_handle(), before);
-  vtimer_set_wakeup(&timer, diff, sched_active_pid);
+  xtimer_set_wakeup(&timer, timex_uint64(diff), sched_active_pid);
   wait(lock);
   timex_t after;
-  vtimer_now(&after);
-  vtimer_remove(&timer);
+  xtimer_now_timex(&after);
+  xtimer_remove(&timer);
   auto cmp = timex_cmp(after, timeout_time.native_handle());
   return cmp < 1 ? cv_status::no_timeout : cv_status::timeout;
 }

--- a/sys/cpp11-compat/include/riot/chrono.hpp
+++ b/sys/cpp11-compat/include/riot/chrono.hpp
@@ -29,7 +29,7 @@
 #include <algorithm>
 
 #include "time.h"
-#include "vtimer.h"
+#include "xtimer.h"
 
 namespace riot {
 
@@ -99,7 +99,7 @@ class time_point {
  */
 inline time_point now() {
   timex_t tp;
-  vtimer_now(&tp);
+  xtimer_now_timex(&tp);
   return time_point(std::move(tp));
 }
 

--- a/sys/cpp11-compat/include/riot/condition_variable.hpp
+++ b/sys/cpp11-compat/include/riot/condition_variable.hpp
@@ -25,7 +25,7 @@
 #define RIOT_CONDITION_VARIABLE_HPP
 
 #include "sched.h"
-#include "vtimer.h"
+#include "xtimer.h"
 
 #include "riot/mutex.hpp"
 #include "riot/chrono.hpp"
@@ -114,12 +114,12 @@ cv_status condition_variable::wait_for(unique_lock<mutex>& lock,
   timeout.seconds = s.count();
   timeout.microseconds
     = (duration_cast<microseconds>(timeout_duration - s)).count();
-  vtimer_now(&before);
-  vtimer_t timer;
-  vtimer_set_wakeup(&timer, timeout, sched_active_pid);
+  xtimer_now_timex(&before);
+  xtimer_t timer;
+  xtimer_set_wakeup(&timer, timex_uint64(timeout), sched_active_pid);
   wait(lock);
-  vtimer_now(&after);
-  vtimer_remove(&timer);
+  xtimer_now_timex(&after);
+  xtimer_remove(&timer);
   auto passed = timex_sub(after, before);
   auto cmp = timex_cmp(passed, timeout);
   return cmp < 1 ? cv_status::no_timeout : cv_status::timeout;

--- a/sys/cpp11-compat/thread.cpp
+++ b/sys/cpp11-compat/thread.cpp
@@ -18,7 +18,7 @@
  * @}
  */
 
-#include "vtimer.h"
+#include "xtimer.h"
 
 #include <cerrno>
 #include <system_error>
@@ -73,23 +73,7 @@ namespace this_thread {
 void sleep_for(const chrono::nanoseconds& ns) {
   using namespace chrono;
   if (ns > nanoseconds::zero()) {
-    seconds s = duration_cast<seconds>(ns);
-    timespec ts;
-    using ts_sec = decltype(ts.tv_sec);
-    constexpr ts_sec ts_sec_max = numeric_limits<ts_sec>::max();
-    if (s.count() < ts_sec_max) {
-      ts.tv_sec = static_cast<ts_sec>(s.count());
-      ts.tv_nsec = static_cast<decltype(ts.tv_nsec)>((ns - s).count());
-    } else {
-      ts.tv_sec = ts_sec_max;
-      ts.tv_nsec = giga::num - 1;
-    }
-    timex_t reltime;
-    reltime.seconds = ts.tv_sec;
-    reltime.microseconds = ts.tv_nsec / 1000u;
-    vtimer_t timer;
-    vtimer_set_wakeup(&timer, reltime, sched_active_pid);
-    thread_sleep();
+    xtimer_usleep64(static_cast<uint64_t>(duration_cast<microseconds>(ns).count()));
   }
 }
 


### PR DESCRIPTION
The cpp11 compatibility layer now uses `xtimer`.

In conjunction I also changed to use `xtimer` in `syscalls.c` of `native`.
The reason for the companion change is that the `_gettimeofday(...)` function is used indirectly in cpp11.

~~depends on #4286~~ (merged)