### PR TITLE
nhdp: various fixes and vtimer -> xtimer conversion

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -7,7 +7,7 @@ endif
 
 ifneq (,$(filter nhdp,$(USEMODULE)))
   USEMODULE += conn_udp
-  USEMODULE += vtimer
+  USEMODULE += xtimer
   USEMODULE += oonf_rfc5444
 endif
 

--- a/sys/net/routing/nhdp/iib_table.c
+++ b/sys/net/routing/nhdp/iib_table.c
@@ -20,7 +20,7 @@
 
 #include "mutex.h"
 #include "timex.h"
-#include "vtimer.h"
+#include "xtimer.h"
 #include "utlist.h"
 #include "kernel_types.h"
 
@@ -118,7 +118,7 @@ iib_link_set_entry_t *iib_process_hello(kernel_pid_t if_pid, nib_entry_t *nb_elt
     }
 
     if (base_elt) {
-        vtimer_now(&now);
+        xtimer_now_timex(&now);
 
         /* Create a new link tuple for the neighbor that originated the hello */
         ls_entry = update_link_set(base_elt, nb_elt, &now, validity_time, is_sym_nb, is_lost);
@@ -143,7 +143,7 @@ void iib_fill_wr_addresses(kernel_pid_t if_pid, struct rfc5444_writer *wr)
 
     mutex_lock(&mtx_iib_access);
 
-    vtimer_now(&now);
+    xtimer_now_timex(&now);
 
     /* Before adding addresses first update the status of all link tuples */
     iib_update_lt_status(&now);
@@ -251,7 +251,7 @@ void iib_process_metric_msg(iib_link_set_entry_t *ls_entry, uint64_t int_time)
     ls_entry->hello_interval = rfc5444_timetlv_encode(int_time);
     if (ls_entry->last_seq_no == 0) {
         timex_t now, i_time;
-        vtimer_now(&now);
+        xtimer_now_timex(&now);
         i_time = timex_from_uint64(int_time * MS_IN_USEC * DAT_HELLO_TIMEOUT_FACTOR);
         ls_entry->dat_received[0]++;
         ls_entry->dat_total[0]++;
@@ -297,7 +297,7 @@ void iib_process_metric_pckt(iib_link_set_entry_t *ls_entry, uint32_t metric_out
 
     if (ls_entry->hello_interval != 0) {
         timex_t now, i_time;
-        vtimer_now(&now);
+        xtimer_now_timex(&now);
         i_time = timex_from_uint64(rfc5444_timetlv_decode(ls_entry->hello_interval)
                 * MS_IN_USEC * DAT_HELLO_TIMEOUT_FACTOR);
         ls_entry->dat_time = timex_add(now, i_time);

--- a/sys/net/routing/nhdp/nhdp.c
+++ b/sys/net/routing/nhdp/nhdp.c
@@ -286,7 +286,6 @@ static void *_nhdp_runner(void *arg)
  */
 static void *_nhdp_receiver(void *arg __attribute__((unused)))
 {
-    uint32_t fromlen;
     char nhdp_rcv_buf[NHDP_MAX_RFC5444_PACKET_SZ];
     msg_t msg_q[NHDP_MSG_QUEUE_SIZE];
 

--- a/sys/net/routing/nhdp/nhdp.c
+++ b/sys/net/routing/nhdp/nhdp.c
@@ -317,7 +317,7 @@ static void *_nhdp_receiver(void *arg __attribute__((unused)))
         }
     }
 
-    gnrc_udp_close(&conn);
+    conn_udp_close(&conn);
     return 0;
 }
 

--- a/sys/net/routing/nhdp/nhdp.c
+++ b/sys/net/routing/nhdp/nhdp.c
@@ -304,9 +304,10 @@ static void *_nhdp_receiver(void *arg __attribute__((unused)))
     while (1) {
         ipv6_addr_t rcv_addr;
         uint16_t rcv_port;
+        size_t addr_len = sizeof(rcv_addr);
         int32_t rcv_size = conn_udp_recvfrom(&conn, (void *)nhdp_rcv_buf,
                                              NHDP_MAX_RFC5444_PACKET_SZ, &rcv_addr,
-                                             sizeof(rcv_addr), &rcv_port);
+                                             &addr_len, &rcv_port);
 
         if (rcv_size > 0) {
             /* Packet received, let the reader handle it */

--- a/sys/net/routing/nhdp/nhdp.c
+++ b/sys/net/routing/nhdp/nhdp.c
@@ -18,13 +18,15 @@
  * @}
  */
 
-#include "conn/udp.h"
+#include "net/gnrc/conn.h"
+#include "net/conn/udp.h"
 #include "msg.h"
-#include "netapi.h"
+#include "net/gnrc/netapi.h"
 #include "net/gnrc/netif.h"
 #include "thread.h"
 #include "utlist.h"
 #include "mutex.h"
+#include "net/ipv6/addr.h"
 
 #include "rfc5444/rfc5444_writer.h"
 

--- a/sys/net/routing/nhdp/nhdp.h
+++ b/sys/net/routing/nhdp/nhdp.h
@@ -21,6 +21,7 @@
 #ifndef NHDP_H_
 #define NHDP_H_
 
+#include "xtimer.h"
 #include "timex.h"
 #include "kernel_types.h"
 
@@ -89,8 +90,9 @@ extern "C" {
  */
 typedef struct nhdp_if_entry_t {
     kernel_pid_t if_pid;                        /**< PID of the interface's handling thread */
-    vtimer_t if_timer;                          /**< Vtimer used for the periodic signaling */
-    timex_t hello_interval;                     /**< Interval time for periodic HELLOs */
+    xtimer_t if_timer;                          /**< xtimer used for the periodic signaling */
+    msg_t if_timer_msg;                         /**< msg_t for nhdp_if_entry_t::if_timer */
+    uint32_t hello_interval;                    /**< Interval time for periodic HELLOs in us */
     timex_t validity_time;                      /**< Validity time for propagated information */
     uint16_t seq_no;                            /**< Sequence number of last send RFC5444 packet */
     struct rfc5444_writer_target wr_target;     /**< Interface specific writer target */

--- a/sys/net/routing/nhdp/nhdp_metric.h
+++ b/sys/net/routing/nhdp/nhdp_metric.h
@@ -45,6 +45,10 @@ extern "C" {
 
 /** @brief Randomly chosen number for NHDP's metric timer event */
 #define NHDP_METRIC_TIMER           (5445)
+
+/** @brief Randomly chosen number for NHDP's sending timer event */
+#define NHDP_MSG_TIMER              (5446)
+
 /** @brief Macro controlling the start of a periodic timer event for matric computation */
 #define NHDP_METRIC_NEEDS_TIMER     (NHDP_METRIC == NHDP_LMT_DAT)
 

--- a/sys/net/routing/nhdp/nhdp_reader.c
+++ b/sys/net/routing/nhdp/nhdp_reader.c
@@ -456,7 +456,7 @@ static void process_temp_tables(void)
     nib_entry_t *nib_elt;
     timex_t now;
 
-    vtimer_now(&now);
+    xtimer_now_timex(&now);
     iib_update_lt_status(&now);
 
     nib_elt = nib_process_hello();

--- a/sys/net/routing/nhdp/nhdp_writer.c
+++ b/sys/net/routing/nhdp/nhdp_writer.c
@@ -213,8 +213,7 @@ static void _nhdp_add_message_tlvs_cb(struct rfc5444_writer *wr)
     /* Convert validity time and interval time to milliseconds */
     uint64_t val_tmp = (uint64_t) nhdp_wr_curr_if_entry->validity_time.seconds * SEC_IN_MS
                        + (nhdp_wr_curr_if_entry->validity_time.microseconds / 1000ULL);
-    uint64_t int_tmp = (uint64_t) nhdp_wr_curr_if_entry->hello_interval.seconds * SEC_IN_MS
-                       + (nhdp_wr_curr_if_entry->hello_interval.microseconds / 1000ULL);
+    uint64_t int_tmp = (uint64_t) (nhdp_wr_curr_if_entry->hello_interval / MS_IN_USEC);
 
     /* Add validity time (mandatory) and interval time to msg */
     validity_time = rfc5444_timetlv_encode(val_tmp);

--- a/sys/net/routing/nhdp/nib_table.c
+++ b/sys/net/routing/nhdp/nib_table.c
@@ -20,7 +20,7 @@
 
 #include "timex.h"
 #include "mutex.h"
-#include "vtimer.h"
+#include "xtimer.h"
 #include "utlist.h"
 
 #include "rfc5444/rfc5444_iana.h"
@@ -57,7 +57,7 @@ nib_entry_t *nib_process_hello(void)
 
     mutex_lock(&mtx_nib_access);
 
-    vtimer_now(&now);
+    xtimer_now_timex(&now);
 
     LL_FOREACH_SAFE(nib_entry_head, nib_elt, nib_tmp) {
         nhdp_addr_entry_t *list_elt;
@@ -113,7 +113,7 @@ void nib_fill_wr_addresses(struct rfc5444_writer *wr)
 
     mutex_lock(&mtx_nib_access);
 
-    vtimer_now(&now);
+    xtimer_now_timex(&now);
 
     /* Add addresses of symmetric neighbors to HELLO msg */
     LL_FOREACH(nib_entry_head, nib_elt) {


### PR DESCRIPTION
While replacing the `vtimer` with `xtimer` in `nhdp` I realized that `nhdp` is not compiling anymore on master.
This PR includes various fixes for problems I encountered during the compilation of `nhdp`, alongside the `vtimer` -> `xtimer` conversion.