### PR TITLE
tests: add buildtest for nhdp

### DIFF
--- a/tests/nhdp/Makefile
+++ b/tests/nhdp/Makefile
@@ -1,0 +1,11 @@
+APPLICATION = nhdp
+include ../Makefile.tests_common
+
+BOARD_BLACKLIST := arduino-mega2560 msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := nucleo-f334 stm32f0discovery weio
+
+USEMODULE += gnrc_ipv6
+USEMODULE += gnrc_conn_udp
+USEMODULE += nhdp
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/nhdp/main.c
+++ b/tests/nhdp/main.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2015 Cenk Gündoğan <cnkgndgn@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @file
+ * @brief       Check if the nhdp module builds.
+ *
+ * @author      Cenk Gündoğan <cnkgndgn@gmail.com>
+ *
+ */
+
+#include <stdio.h>
+
+int main(void)
+{
+    printf("NHDP compiled!");
+    return 0;
+}


### PR DESCRIPTION
This PR adds a buildtest for the `nhdp` module.
Currently, with this PR merged, travis will fail because `nhdp` does not build on master.

see #4259 
~~Depends on #4277~~