### PR TITLE
Revert "at86rf2xx: cancel receiving when preparing for TX"

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -220,13 +220,9 @@ void at86rf2xx_tx_prepare(at86rf2xx_t *dev)
     do {
         state = at86rf2xx_get_status(dev);
     }
-    while (state == AT86RF2XX_STATE_BUSY_TX_ARET);
-
-    /* if receiving cancel */
-    if(state == AT86RF2XX_STATE_BUSY_RX_AACK) {
-        at86rf2xx_force_trx_off(dev);
-        dev->idle_state = AT86RF2XX_STATE_RX_AACK_ON;
-    } else if (state != AT86RF2XX_STATE_TX_ARET_ON) {
+    while (state == AT86RF2XX_STATE_BUSY_RX_AACK ||
+           state == AT86RF2XX_STATE_BUSY_TX_ARET);
+    if (state != AT86RF2XX_STATE_TX_ARET_ON) {
         dev->idle_state = state;
     }
     at86rf2xx_set_state(dev, AT86RF2XX_STATE_TX_ARET_ON);

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -407,6 +407,12 @@ static inline void _set_state(at86rf2xx_t *dev, uint8_t state)
     dev->state = state;
 }
 
+static inline void _force_trx_off(at86rf2xx_t *dev)
+{
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_STATE, AT86RF2XX_TRX_STATE__FORCE_TRX_OFF);
+    while (at86rf2xx_get_status(dev) != AT86RF2XX_STATE_TRX_OFF);
+}
+
 void at86rf2xx_set_state(at86rf2xx_t *dev, uint8_t state)
 {
     uint8_t old_state = at86rf2xx_get_status(dev);
@@ -437,7 +443,7 @@ void at86rf2xx_set_state(at86rf2xx_t *dev, uint8_t state)
 
     if (state == AT86RF2XX_STATE_SLEEP) {
         /* First go to TRX_OFF */
-        at86rf2xx_force_trx_off(dev);
+        _force_trx_off(dev);
         /* Discard all IRQ flags, framebuffer is lost anyway */
         at86rf2xx_reg_read(dev, AT86RF2XX_REG__IRQ_STATUS);
         /* Go to SLEEP mode from TRX_OFF */
@@ -459,5 +465,5 @@ void at86rf2xx_reset_state_machine(at86rf2xx_t *dev)
         old_state = at86rf2xx_get_status(dev);
     } while (old_state == AT86RF2XX_STATE_IN_PROGRESS);
 
-    at86rf2xx_force_trx_off(dev);
+    _force_trx_off(dev);
 }

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -135,11 +135,3 @@ void at86rf2xx_hardware_reset(at86rf2xx_t *dev)
     gpio_set(dev->reset_pin);
     xtimer_usleep(AT86RF2XX_RESET_DELAY);
 }
-
-void at86rf2xx_force_trx_off(const at86rf2xx_t *dev)
-{
-    at86rf2xx_reg_write(dev,
-                        AT86RF2XX_REG__TRX_STATE,
-                        AT86RF2XX_TRX_STATE__FORCE_TRX_OFF);
-    while (at86rf2xx_get_status(dev) != AT86RF2XX_STATE_TRX_OFF);
-}

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -108,13 +108,6 @@ void at86rf2xx_fb_read(const at86rf2xx_t *dev,
                        uint8_t *data, const size_t len);
 
 /**
- * @brief   Cancel ongoing transactions and switch to TRX_OFF state
- *
- * @param[in] dev       device to manipulate
- */
-void at86rf2xx_force_trx_off(const at86rf2xx_t *dev);
-
-/**
  * @brief   Convenience function for reading the status of the given device
  *
  * @param[in] dev       device to read the status from


### PR DESCRIPTION
This reverts commit 5aeeabf4a9eaab3f25e67aeca6e4645d7ac84da6.

Unless we find a reason what causes the problems described in #4142, I propose to revert this change.