### PR TITLE
nhdp: various fixes

### DIFF
--- a/sys/net/routing/nhdp/nhdp.c
+++ b/sys/net/routing/nhdp/nhdp.c
@@ -286,7 +286,6 @@ static void *_nhdp_runner(void *arg)
  */
 static void *_nhdp_receiver(void *arg __attribute__((unused)))
 {
-    uint32_t fromlen;
     char nhdp_rcv_buf[NHDP_MAX_RFC5444_PACKET_SZ];
     msg_t msg_q[NHDP_MSG_QUEUE_SIZE];
 

--- a/sys/net/routing/nhdp/nhdp.c
+++ b/sys/net/routing/nhdp/nhdp.c
@@ -317,7 +317,7 @@ static void *_nhdp_receiver(void *arg __attribute__((unused)))
         }
     }
 
-    gnrc_udp_close(&conn);
+    conn_udp_close(&conn);
     return 0;
 }
 

--- a/sys/net/routing/nhdp/nhdp.c
+++ b/sys/net/routing/nhdp/nhdp.c
@@ -304,9 +304,10 @@ static void *_nhdp_receiver(void *arg __attribute__((unused)))
     while (1) {
         ipv6_addr_t rcv_addr;
         uint16_t rcv_port;
+        size_t addr_len = sizeof(rcv_addr);
         int32_t rcv_size = conn_udp_recvfrom(&conn, (void *)nhdp_rcv_buf,
                                              NHDP_MAX_RFC5444_PACKET_SZ, &rcv_addr,
-                                             sizeof(rcv_addr), &rcv_port);
+                                             &addr_len, &rcv_port);
 
         if (rcv_size > 0) {
             /* Packet received, let the reader handle it */

--- a/sys/net/routing/nhdp/nhdp.c
+++ b/sys/net/routing/nhdp/nhdp.c
@@ -18,13 +18,15 @@
  * @}
  */
 
-#include "conn/udp.h"
+#include "net/gnrc/conn.h"
+#include "net/conn/udp.h"
 #include "msg.h"
-#include "netapi.h"
+#include "net/gnrc/netapi.h"
 #include "net/gnrc/netif.h"
 #include "thread.h"
 #include "utlist.h"
 #include "mutex.h"
+#include "net/ipv6/addr.h"
 
 #include "rfc5444/rfc5444_writer.h"
 

--- a/sys/net/routing/nhdp/nhdp.h
+++ b/sys/net/routing/nhdp/nhdp.h
@@ -22,6 +22,7 @@
 #define NHDP_H_
 
 #include "timex.h"
+#include "vtimer.h"
 #include "kernel_types.h"
 
 #include "nhdp_metric.h"


### PR DESCRIPTION
This is an alternative to #4259.
It is basically the same PR, but without the `vtimer` replacement.

I will open a separate PR only for the `vtimer` -> `xtimer` conversion once `nhdp` compiles again.

~~Depends on #4261~~
~~Depends on #4331~~