### PR TITLE
net/fib: shell: fix warnings/errors thrown by clang on OS X

### DIFF
--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -1283,7 +1283,7 @@ int fib_sr_get_route(fib_table_t *table, uint8_t *dst, size_t dst_size, kernel_p
         }
 
         if( skip ) {
-            if((*fib_sr == &table->data.source_routes->headers[i])) {
+            if(*fib_sr == &table->data.source_routes->headers[i]) {
                 skip = false;
             }
             /* we skip all entries upon the consecutive one to start search */

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -892,7 +892,7 @@ int _netif_config(int argc, char **argv)
                 gnrc_ipv6_netif_t *entry;
                 if (((hl = atoi(argv[3])) < 0) || (hl > UINT8_MAX)) {
                     printf("error: Hop limit must be between %" PRIu16 " and %" PRIu16 "\n",
-                            0, UINT16_MAX);
+                            (uint16_t)0, (uint16_t)UINT16_MAX);
                     return 1;
                 }
                 if ((entry = gnrc_ipv6_netif_get(dev)) == NULL) {


### PR DESCRIPTION
Get RIOT compiling again for OS X.