### PR TITLE
gnrc sixlowpan: fix some dependencies

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -178,6 +178,12 @@ ifneq (,$(filter gnrc_ndp_%,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_ndp,$(USEMODULE)))
+  ifneq (,$(filter gnrc_sixlowpan,$(USEMODULE)))
+    USEMODULE += gnrc_sixlowpan_nd
+  else
+    USEMODULE += gnrc_ndp_node
+  endif
+  USEMODULE += gnrc_ndp_internal
   USEMODULE += gnrc_icmpv6
   USEMODULE += random
   USEMODULE += xtimer

--- a/sys/include/net/gnrc/sixlowpan/ctx.h
+++ b/sys/include/net/gnrc/sixlowpan/ctx.h
@@ -113,6 +113,7 @@ gnrc_sixlowpan_ctx_t *gnrc_sixlowpan_ctx_update(uint8_t id, const ipv6_addr_t *p
                                                 uint8_t prefix_len, uint16_t ltime,
                                                 bool comp);
 
+#ifdef MODULE_GNRC_SIXLOWPAN_CTX
 /**
  * @brief   Removes context.
  *
@@ -122,6 +123,7 @@ static inline void gnrc_sixlowpan_ctx_remove(uint8_t id)
 {
     gnrc_sixlowpan_ctx_lookup_id(id)->prefix_len = 0;
 }
+#endif
 
 #ifdef TEST_SUITES
 /**

--- a/sys/include/net/gnrc/sixlowpan/nd/router.h
+++ b/sys/include/net/gnrc/sixlowpan/nd/router.h
@@ -68,7 +68,9 @@ typedef struct {
     uint32_t version;                       /**< version of the information dissiminated by the
                                              *   BR */
     uint16_t ltime;                         /**< the time in minutes until deletion */
+#ifdef MODULE_GNRC_SIXLOWPAN_CTX
     BITFIELD(ctxs, GNRC_SIXLOWPAN_CTX_SIZE);/**< contexts associated with BR */
+#endif
     gnrc_sixlowpan_nd_router_prf_t *prfs;   /**< prefixes associated with BR */
     xtimer_t ltimer;                        /**< timer for deletion */
     msg_t ltimer_msg;                       /**< msg_t for gnrc_sixlowpan_nd_router_abr_t::ltimer */

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -24,6 +24,7 @@
 #include "net/gnrc/ndp.h"
 #include "net/gnrc/sixlowpan/ctx.h"
 #include "net/gnrc/sixlowpan/nd.h"
+#include "net/gnrc/sixlowpan/nd/router.h"
 #include "net/protnum.h"
 #include "thread.h"
 #include "utlist.h"
@@ -241,11 +242,13 @@ static void *_event_loop(void *args)
                 DEBUG("ipv6: Unicast router solicitation event received\n");
                 gnrc_sixlowpan_nd_uc_rtr_sol((gnrc_ipv6_nc_t *)msg.content.ptr);
                 break;
+#   ifdef MODULE_GNRC_SIXLOWPAN_CTX
             case GNRC_SIXLOWPAN_ND_MSG_DELETE_CTX:
                 DEBUG("ipv6: Delete 6LoWPAN context event received\n");
                 gnrc_sixlowpan_ctx_remove(((((gnrc_sixlowpan_ctx_t *)msg.content.ptr)->flags_id) &
                                            GNRC_SIXLOWPAN_CTX_FLAGS_CID_MASK));
                 break;
+#   endif
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
             case GNRC_SIXLOWPAN_ND_MSG_ABR_TIMEOUT:

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -372,6 +372,7 @@ uint8_t gnrc_sixlowpan_nd_opt_ar_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6,
 
 bool gnrc_sixlowpan_nd_opt_6ctx_handle(uint8_t icmpv6_type, sixlowpan_nd_opt_6ctx_t *ctx_opt)
 {
+#ifdef MODULE_GNRC_SIXLOWPAN_CTX
     if (((ctx_opt->ctx_len <= 64) && (ctx_opt->len != 2)) ||
         ((ctx_opt->ctx_len > 64) && (ctx_opt->len != 3))) {
         DEBUG("6lo nd: invalid 6LoWPAN context option received\n");
@@ -385,6 +386,7 @@ bool gnrc_sixlowpan_nd_opt_6ctx_handle(uint8_t icmpv6_type, sixlowpan_nd_opt_6ct
     gnrc_sixlowpan_ctx_update(sixlowpan_nd_opt_6ctx_get_cid(ctx_opt), (ipv6_addr_t *)(ctx_opt + 1),
                               ctx_opt->ctx_len, byteorder_ntohs(ctx_opt->ltime),
                               sixlowpan_nd_opt_6ctx_is_comp(ctx_opt));
+#endif
     return true;
 }
 


### PR DESCRIPTION
Without this PR one cannot build 6LoWPAN with ND but without stateful compression.