### PR TITLE
gnrc: networking minimal

### DIFF
--- a/examples/gnrc_minimal/Makefile
+++ b/examples/gnrc_minimal/Makefile
@@ -1,0 +1,37 @@
+# name of your application
+APPLICATION = gnrc_minimal
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h
+
+# Include packages that pull up and auto-init the link layer.
+# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
+USEMODULE += gnrc_netif_default
+USEMODULE += auto_init_gnrc_netif
+# Specify the minimum networking modules for IPv6
+USEMODULE += gnrc_ipv6
+USEMODULE += gnrc_ndp
+# Additional networking modules that can be dropped if not needed
+USEMODULE += gnrc_icmpv6_echo
+# Use minimal standard PRNG
+USEMODULE += prng_minstd
+
+CFLAGS += -DGNRC_IPV6_NETIF_ADDR_NUMOF=4
+# Reduce sizes for GNRC's packet buffer and neighbor cache
+# (for native we need a bigger buffer, because the tap driver temporarily
+# allocates ~1500 bytes)
+ifneq (,$(filter native,$(BOARD)))
+    CFLAGS += -DGNRC_PKTBUF_SIZE=2048 -DGNRC_IPV6_NC_SIZE=1
+else
+    CFLAGS += -DGNRC_PKTBUF_SIZE=512 -DGNRC_IPV6_NC_SIZE=0
+endif
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/gnrc_minimal/README.md
+++ b/examples/gnrc_minimal/README.md
@@ -1,0 +1,31 @@
+# gnrc_minimal example
+
+This is a minimalistic example for RIOT's gnrc network stack.
+The application will auto initialize the device's default network interface and
+the IPv6 stack and print its link-local address.
+You can ping the printed address from another device to check if the node is
+alive. Please note that you may have to disable 6LoWPAN header compression
+(IPHC), since this example does not include it. In the `gnrc_networking`
+example or any other application with GNRC and a shell, you can do so by
+calling `ifconfig <if_id> -iphc`).
+
+The example demonstrates how one can reduce the memory footprint of a `gnrc`
+application by enabling only the minimum subset of features and setting
+configuration options to smaller values than the default. In particular, this
+reduction of memory consumption in comparison to the `gnrc_networking` example
+is achieved by:
+ * Using only the `gnrc_ipv6` and `gnrc_ndp` modules (instead of
+   `gnrc_ipv6_router_default`). This configures the node as a IPv6/6LoWPAN host
+   instead of a router and disable optional features such as 6LoWPAN IPHC or
+   fragmentation.
+ * Not using `gnrc_rpl`.
+ * Disabling features meant for helping during development and debugging such
+   as the shell or setting the `DEVELHELP` flag.
+ * Using the minimal standard pseudo random number generator instead of the
+   Mersenne Twister.
+ * Reducing the number of configurable IPv6 addresses per interface to 4
+   (instead of 7 or 8).
+ * Reducing the packet buffer size from 6kB to 512 bytes.
+ * Reducing the maximum neighbor cache size from 8 to 1.
+
+Please take a look at the Makefile to see how the configuration is done.

--- a/examples/gnrc_minimal/main.c
+++ b/examples/gnrc_minimal/main.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Showing minimum memory footprint of gnrc network stack
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "msg.h"
+#include "net/ipv6/addr.h"
+#include "net/gnrc/netif.h"
+#include "net/gnrc/ipv6/netif.h"
+
+int main(void)
+{
+    kernel_pid_t ifs[GNRC_NETIF_NUMOF];
+
+    puts("RIOT network stack example application");
+
+    /* get the first IPv6 interface and prints its address */
+    size_t numof = gnrc_netif_get(ifs);
+    if (numof > 0) {
+        gnrc_ipv6_netif_t *entry = gnrc_ipv6_netif_get(ifs[0]);
+        for (int i = 0; i < GNRC_IPV6_NETIF_ADDR_NUMOF; i++) {
+            if ((ipv6_addr_is_link_local(&entry->addrs[i].addr)) && !(entry->addrs[i].flags & GNRC_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST)) {
+                char ipv6_addr[IPV6_ADDR_MAX_STR_LEN];
+                ipv6_addr_to_str(ipv6_addr, &entry->addrs[i].addr, IPV6_ADDR_MAX_STR_LEN);
+                printf("My address is %s\n", ipv6_addr);
+            }
+        }
+    }
+
+    /* main thread exits */
+    return 0;
+}


### PR DESCRIPTION
This is a minimalistic example for RIOT's gnrc network stack. It just boots and waits to be pinged. Requires less than 10kB of RAM and less than 30kB of ROM on a ARM Cortex-M platform.

~~Depends on #4282.~~