### PR TITLE
gnrc_ipv6: get l2addr from NC if no ND present

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -537,6 +537,15 @@ static inline kernel_pid_t _next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len
 #endif
 #if defined(MODULE_GNRC_NDP_NODE)
     found_iface = gnrc_ndp_node_next_hop_l2addr(l2addr, l2addr_len, iface, dst, pkt);
+#elif !defined(MODULE_GNRC_SIXLOWPAN_ND) && defined(MODULE_GNRC_IPV6_NC)
+    (void)pkt;
+    gnrc_ipv6_nc_t *nc = gnrc_ipv6_nc_get(iface, dst);
+    if ((nc == NULL) || !gnrc_ipv6_nc_is_reachable(nc)) {
+        return KERNEL_PID_UNDEF;
+    }
+    found_iface = nc->iface;
+    *l2addr_len = nc->l2_addr_len;
+    memcpy(l2addr, nc->l2_addr, nc->l2_addr_len);
 #elif !defined(MODULE_GNRC_SIXLOWPAN_ND)
     found_iface = KERNEL_PID_UNDEF;
     (void)l2addr;


### PR DESCRIPTION
This enables `gnrc_ipv6` to work even without ND. If neither NDP nor 6Lo-ND are present, but `gnrc_ipv6_nc` is compiled in, `gnrc_ipv6` will lookup the destination in the neighbor cache. This way very simple, manually administrated 1-hop networks are still possible.