### PR TITLE
sys: newlib: use xtimer_now64() for gettimeofday()

### DIFF
--- a/sys/newlib/syscalls.c
+++ b/sys/newlib/syscalls.c
@@ -38,6 +38,12 @@
 
 #include "uart_stdio.h"
 
+#ifdef MODULE_XTIMER
+#include <sys/time.h>
+#include "div.h"
+#include "xtimer.h"
+#endif
+
 /**
  * @brief manage the heap
  */
@@ -322,3 +328,14 @@ int _kill(pid_t pid, int sig)
     errno = ESRCH;                         /* not implemented yet */
     return -1;
 }
+
+#ifdef MODULE_XTIMER
+int _gettimeofday_r(struct _reent *r, struct timeval *restrict tp, void *restrict tzp)
+{
+    (void)tzp;
+    uint64_t now = xtimer_now64();
+    tp->tv_sec = div_u64_by_1000000(now);
+    tp->tv_usec = now - (tp->tv_sec * SEC_IN_USEC);
+    return 0;
+}
+#endif


### PR DESCRIPTION
No idea where newlib got it's values for gettimeofday() before. It seemed to be random static values to me.

With this change, newlib uses xtimer_now64() for gettimeofday(), but only if xtimer is actually compiled in.

This is done by conditionally defining newlibs _gettimeofday_r() stub.