### PR TITLE
make: add support for additional local Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ tags
 # Eclipse symbol file (output from make eclipsesym)
 eclipsesym.xml
 /toolchain
+
+# local override files
+Makefile.local

--- a/Makefile.include
+++ b/Makefile.include
@@ -1,3 +1,6 @@
+# include Makefile.local if it exists
+-include Makefile.local
+
 all:
 
 # set undefined variables


### PR DESCRIPTION
I was tired of local tweaks to application's Makefiles...

This PR makes it possible to drop a Makefile.local into any application's directory, which will be included right at the beginning of Makefile.include. I also added it to .gitignore.

I use this to, e.g., add or disable some modules, tweak gnrc settings, ..., without having to modify the in-repo main application makefile. Also handy for symlinking one file into multiple application directories.

What do you think?