### PR TITLE
sys: random: add entropy collector

### DIFF
--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -23,3 +23,6 @@ PSEUDOMODULES += netif
 # include variants of the AT86RF2xx drivers as pseudo modules
 PSEUDOMODULES += at86rf23%
 PSEUDOMODULES += at86rf21%
+
+# add all pseudo random number generator variants as pseudomodules
+PSEUDOMODULES += prng_%

--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -2,6 +2,7 @@ PSEUDOMODULES += conn
 PSEUDOMODULES += conn_ip
 PSEUDOMODULES += conn_tcp
 PSEUDOMODULES += conn_udp
+PSEUDOMODULES += entropy
 PSEUDOMODULES += gnrc_netif_default
 PSEUDOMODULES += gnrc_ipv6_default
 PSEUDOMODULES += gnrc_ipv6_router

--- a/dist/tools/test_random/Makefile
+++ b/dist/tools/test_random/Makefile
@@ -1,0 +1,34 @@
+RIOTBASE := ../../..
+INCLUDES := $(RIOTBASE)/sys/include
+
+CFLAGS += $(patsubst %,-I%,$(INCLUDES))
+CFLAGS += -Wall -O3
+
+PRNGS := mersenne minstd musl_lcg
+
+comma:= ,
+empty:=
+space:= $(empty) $(empty)
+PRNGS_CSV:= $(subst $(space),$(comma),$(PRNGS))
+
+all: $(PRNGS:%=test_%) $(PRNGS:%=test_%_entropy)
+
+clean:
+	rm -f test_*_entropy
+	rm -f test_{$(PRNGS_CSV)}
+
+test_%: test_random.c $(RIOTBASE)/sys/random/%.c
+	$(CC) $(CFLAGS) $^ -o $@$(SUFFIX)
+
+test_%_entropy: test_random.c $(RIOTBASE)/sys/random/%.c $(RIOTBASE)/sys/random/entropy.c
+	$(CC) $(CFLAGS) -DMODULE_ENTROPY -DURANDOM $^ -o $@$(SUFFIX)
+
+run_tests: all
+	for prng in $(PRNGS) ; do \
+		./test_$${prng} > test_$${prng}_out ; \
+		ent test_$${prng}_out > test_$${prng}.ent.txt ; \
+		for freq in 1024 4096 16384 65536 262144 1048576 4194304 16777216; do \
+			./test_$${prng}_entropy $${freq}> test_$${prng}_entropy_freq_$${freq}_out ; \
+			ent test_$${prng}_entropy_freq_$${freq}_out > test_$${prng}_entropy_freq_$${freq}.ent.txt; \
+			done ; \
+		done

--- a/dist/tools/test_random/Makefile
+++ b/dist/tools/test_random/Makefile
@@ -4,7 +4,7 @@ INCLUDES := $(RIOTBASE)/sys/include
 CFLAGS += $(patsubst %,-I%,$(INCLUDES))
 CFLAGS += -Wall -O3
 
-PRNGS := mersenne minstd musl_lcg
+PRNGS ?= mersenne minstd musl_lcg
 
 comma:= ,
 empty:=
@@ -23,12 +23,15 @@ test_%: test_random.c $(RIOTBASE)/sys/random/%.c
 test_%_entropy: test_random.c $(RIOTBASE)/sys/random/%.c $(RIOTBASE)/sys/random/entropy.c
 	$(CC) $(CFLAGS) -DMODULE_ENTROPY -DURANDOM $^ -o $@$(SUFFIX)
 
+MODIFIED_ENT:=""#"Chi-percent,"
+
 run_tests: all
+	echo "prng,Entropy_injection_freq,unused,File-bytes,Entropy,Chi-square,$(MODIFIED_ENT)Mean,Monte-Carlo-Pi,Serial-Correlation" > ent_results.txt
 	for prng in $(PRNGS) ; do \
 		./test_$${prng} > test_$${prng}_out ; \
-		ent test_$${prng}_out > test_$${prng}.ent.txt ; \
+		echo $${prng},-1,$$(ent -t test_$${prng}_out | tail -n 1) >> ent_results.txt; \
 		for freq in 1024 4096 16384 65536 262144 1048576 4194304 16777216; do \
 			./test_$${prng}_entropy $${freq}> test_$${prng}_entropy_freq_$${freq}_out ; \
-			ent test_$${prng}_entropy_freq_$${freq}_out > test_$${prng}_entropy_freq_$${freq}.ent.txt; \
+			echo $${prng},$${freq},$$(ent -t test_$${prng}_entropy_freq_$${freq}_out | tail -n 1) >> ent_results.txt; \
 			done ; \
 		done

--- a/dist/tools/test_random/test_random.c
+++ b/dist/tools/test_random/test_random.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+#ifdef MODULE_ENTROPY
+#include "entropy.h"
+#define ENTROPY_FREQ_DEFAULT 1024
+#endif
+
+uint32_t genrand_uint32(void);
+void genrand_init(uint32_t s);
+
+#define N_WORDS (2<<24)
+
+int main(int argc, char *argv[]) {
+    uint32_t random;
+    uint32_t n = N_WORDS;
+
+#ifdef MODULE_ENTROPY
+    uint32_t entropy_freq;
+
+    if (argc>1) {
+        entropy_freq = atoi(argv[1]);
+    } else {
+        entropy_freq = ENTROPY_FREQ_DEFAULT;
+    }
+
+    fprintf(stderr, "Injecting a random byte every %u times.\n", entropy_freq);
+#endif
+
+    while(n--) {
+
+#ifdef MODULE_ENTROPY
+        if (! (n % entropy_freq)) {
+            fprintf(stderr, "Collecting entropy... %u\n", n);
+            entropy_collect();
+        }
+#endif
+
+        random = genrand_uint32();
+        write(STDOUT_FILENO, &random, 4);
+    }
+
+    return 0;
+}

--- a/sys/include/div.h
+++ b/sys/include/div.h
@@ -77,6 +77,28 @@ static inline uint32_t div_u32_by_15625div512(uint32_t val)
     return ((uint64_t)(val) * 0x431bde83ul) >> (12 + 32 - 9);
 }
 
+/**
+ * @brief Integer divide val by 44488
+ *
+ * @param[in]   val     dividend
+ * @return      (val / 44488)
+ */
+static inline uint32_t div_u32_by_44488(uint32_t val)
+{
+    return ((uint64_t)val * 0xBC8F1391UL) >> (15 + 32);
+}
+
+/**
+ * @brief Modulo 44488
+ *
+ * @param[in]   val     dividend
+ * @return      (val % 44488)
+ */
+static inline uint32_t div_u32_mod_44488(uint32_t val)
+{
+    return val - (div_u32_by_44488(val)*44488); 
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/entropy.h
+++ b/sys/include/entropy.h
@@ -1,0 +1,9 @@
+#ifndef ENTROPY_H
+#define ENTROPY_H
+
+#include <stdint.h>
+
+extern uint32_t entropy;
+void entropy_collect(void);
+
+#endif /* ENTROPY_H */

--- a/sys/random/Makefile
+++ b/sys/random/Makefile
@@ -1,1 +1,14 @@
+ifeq (,$(filter prng_%,$(USEMODULE)))
+    USEMODULE += prng_mersenne
+endif
+ifneq (,$(filter prng_mersenne,$(USEMODULE)))
+    SRC += mersenne.c
+endif
+ifneq (,$(filter prng_minstd,$(USEMODULE)))
+    SRC += minstd.c
+endif
+ifneq (,$(filter prng_musl_lcg,$(USEMODULE)))
+    SRC += musl_lcg.c
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/random/entropy.c
+++ b/sys/random/entropy.c
@@ -1,0 +1,24 @@
+#include <stdint.h>
+
+#ifdef MODULE_XTIMER
+#include "xtimer.h"
+#endif
+
+uint32_t entropy;
+static unsigned _n = 0;
+static uint32_t _last_event;
+
+#ifndef ENTROPY_OP
+#define ENTROPY_OP(x) (x & 0xFF)
+#endif
+
+void entropy_collect(void)
+{
+#ifdef MODULE_XTIMER
+    uint32_t now = _lltimer_now();
+    uint32_t diff = now - _last_event;
+    _last_event = now;
+
+    entropy += entropy ^ ((ENTROPY_OP(diff)) << ((_n++ & 0x3) * 8));
+#endif
+}

--- a/sys/random/mersenne.c
+++ b/sys/random/mersenne.c
@@ -55,6 +55,10 @@
 static uint32_t mt[N]; /** the array for the state vector  */
 static uint16_t mti = MTI_UNINITIALIZED;
 
+#ifdef MODULE_ENTROPY
+#include "entropy.h"
+#endif
+
 void genrand_init(uint32_t s)
 {
     mt[0] = s;
@@ -129,7 +133,12 @@ uint32_t genrand_uint32(void)
     y ^= (y << 7) & 0x9d2c5680UL;
     y ^= (y << 15) & 0xefc60000UL;
     y ^= y >> 18;
+
+#ifdef MODULE_ENTROPY
+    return y + entropy;
+#else
     return y;
+#endif
 }
 
 #if PRNG_FLOAT

--- a/sys/random/minstd.c
+++ b/sys/random/minstd.c
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ * Code taken from C FAQ (http://c-faq.com/lib/rand.html).
+ */
+
+ /**
+ * @ingroup sys_random
+ * @{
+ * @file
+ *
+ * @brief Simple Park & Miller "minimal standard" PRNG
+ *
+ * This file contains a simple Park-Miller pseudo random number generator.
+ *
+ * While not very random when considering crypto requirements, this is probably
+ * random enough anywhere where pseudo-randomness is sufficient, e.g., when
+ * provided with a sensible seed source, for MAC algorithms.
+ *
+ * The implementation is taken from the C FAQ, but modified to use magic number
+ * division and adapted to RIOT's coding conventions..
+ *
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
+ * @}
+ */
+
+#include <stdint.h>
+
+#include "div.h"
+
+#define a 48271
+#define m 2147483647
+#define q (m / a) /* 44488 */
+#define r (m % a) /* 3399 */
+
+static uint32_t _seed = 1;
+
+int rand_minstd(void)
+{
+    uint32_t hi = div_u32_by_44488(_seed);
+    uint32_t lo = div_u32_mod_44488(_seed);
+    uint32_t test = (a * lo) - (r * hi);
+
+    if(test > 0) {
+        _seed = test;
+    }
+    else {
+        _seed = test + m;
+    }
+
+    return _seed;
+}
+
+uint32_t genrand_uint32(void)
+{
+    /* minstd as implemented returns only values from 1 to 2147483647,
+     * so run it two times to get 32bits */
+    uint16_t A = (rand_minstd() >> 15);
+    uint16_t B = (rand_minstd() >> 15);
+    return  (((uint32_t)A) << 16) | B;
+}
+
+void genrand_init(uint32_t val)
+{
+    if (!val) {
+        val = 1;
+    }
+    _seed = val;
+}

--- a/sys/random/minstd.c
+++ b/sys/random/minstd.c
@@ -32,6 +32,10 @@
 
 #include "div.h"
 
+#ifdef MODULE_ENTROPY
+#include "entropy.h"
+#endif
+
 #define a 48271
 #define m 2147483647
 #define q (m / a) /* 44488 */
@@ -61,7 +65,14 @@ uint32_t genrand_uint32(void)
      * so run it two times to get 32bits */
     uint16_t A = (rand_minstd() >> 15);
     uint16_t B = (rand_minstd() >> 15);
-    return  (((uint32_t)A) << 16) | B;
+
+    uint32_t res = (((uint32_t)A) << 16) | B;
+
+#ifdef MODULE_ENTROPY
+    return res + entropy;
+#else
+    return res;
+#endif
 }
 
 void genrand_init(uint32_t val)

--- a/sys/random/minstd.c
+++ b/sys/random/minstd.c
@@ -69,7 +69,7 @@ uint32_t genrand_uint32(void)
     uint32_t res = (((uint32_t)A) << 16) | B;
 
 #ifdef MODULE_ENTROPY
-    return res + entropy;
+    return res ^ entropy;
 #else
     return res;
 #endif

--- a/sys/random/musl_lcg.c
+++ b/sys/random/musl_lcg.c
@@ -46,7 +46,7 @@ uint32_t genrand_uint32(void)
 {
     _seed = 6364136223846793005ULL*_seed + 1;
 #ifdef MODULE_ENTROPY
-    return (_seed>>31) + entropy;
+    return (_seed>>31) ^ entropy;
 #else
     return _seed>>31;
 #endif

--- a/sys/random/musl_lcg.c
+++ b/sys/random/musl_lcg.c
@@ -31,6 +31,10 @@
 
 #include <stdint.h>
 
+#ifdef MODULE_ENTROPY
+#include "entropy.h"
+#endif
+
 static uint64_t _seed;
 
 void genrand_init(uint32_t s)
@@ -41,5 +45,9 @@ void genrand_init(uint32_t s)
 uint32_t genrand_uint32(void)
 {
     _seed = 6364136223846793005ULL*_seed + 1;
+#ifdef MODULE_ENTROPY
+    return (_seed>>31) + entropy;
+#else
     return _seed>>31;
+#endif
 }

--- a/sys/random/musl_lcg.c
+++ b/sys/random/musl_lcg.c
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ * Code taken from Musl C library. Original copyright notice:
+ *
+ * Copyright © 2005-2014 Rich Felker, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdint.h>
+
+static uint64_t _seed;
+
+void genrand_init(uint32_t s)
+{
+    _seed = s-1;
+}
+
+uint32_t genrand_uint32(void)
+{
+    _seed = 6364136223846793005ULL*_seed + 1;
+    return _seed>>31;
+}

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -21,7 +21,7 @@ ifneq (,$(filter lpc2387,$(USEMODULE)))
   SRC += sc_heap.c
 endif
 ifneq (,$(filter random,$(USEMODULE)))
-  SRC += sc_mersenne.c
+  SRC += sc_random.c
 endif
 ifeq ($(CPU),x86)
   SRC += sc_x86_lspci.c

--- a/sys/shell/commands/sc_random.c
+++ b/sys/shell/commands/sc_random.c
@@ -12,7 +12,7 @@
  * @{
  *
  * @file
- * @brief       Shell commands for mersenne twister
+ * @brief       Shell commands for random generators
  *
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
@@ -30,7 +30,7 @@
 
 #include "random.h"
 
-int _mersenne_init(int argc, char **argv)
+int _random_init(int argc, char **argv)
 {
     int initval;
 
@@ -53,7 +53,7 @@ int _mersenne_init(int argc, char **argv)
     return 0;
 }
 
-int _mersenne_get(int argc, char **argv)
+int _random_get(int argc, char **argv)
 {
     (void) argc;
     (void) argv;

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -96,8 +96,8 @@ extern int _icmpv6_ping(int argc, char **argv);
 #endif
 
 #ifdef MODULE_RANDOM
-extern int _mersenne_init(int argc, char **argv);
-extern int _mersenne_get(int argc, char **argv);
+extern int _random_init(int argc, char **argv);
+extern int _random_get(int argc, char **argv);
 #endif
 
 #ifdef MODULE_GNRC_NETIF
@@ -187,8 +187,8 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #endif
 #ifdef MODULE_RANDOM
-    { "mersenne_init", "initializes the PRNG", _mersenne_init },
-    { "mersenne_get", "returns 32 bit of pseudo randomness", _mersenne_get },
+    { "random_init", "initializes the PRNG", _random_init },
+    { "random_get", "returns 32 bit of pseudo randomness", _random_get },
 #endif
 #if FEATURE_PERIPH_RTC
     {"rtc", "control RTC peripheral interface",  _rtc_handler},


### PR DESCRIPTION
I tried to find a way to harvest natural random events for random entropy, so I came up with this module.

Whenever something supposedly random happens (e.g., a user button press or a ping result from an internet host), any part of the system can call "entropy_collect()".

The module then takes the time difference between the time of the function call and the last time (which is supposed to be normal distributed) and XOR's it with one byte of a saved "entropy value", rotating over the bytes.

I've modified mersenne twister to add the current "entropy" to the random value it would return.
