### PR TITLE
gnrc_ipv6_nc: introduce L2 address lookup function

### DIFF
--- a/sys/include/net/gnrc/ipv6/nc.h
+++ b/sys/include/net/gnrc/ipv6/nc.h
@@ -21,8 +21,10 @@
 #ifndef GNRC_IPV6_NC_H_
 #define GNRC_IPV6_NC_H_
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "kernel_types.h"
 #include "net/eui64.h"
@@ -292,6 +294,21 @@ static inline bool gnrc_ipv6_nc_is_reachable(const gnrc_ipv6_nc_t *entry)
  * @return  NULL, if none is found.
  */
 gnrc_ipv6_nc_t *gnrc_ipv6_nc_still_reachable(const ipv6_addr_t *ipv6_addr);
+
+/**
+ * @brief   Gets link-layer address from neighbor cache entry if neighbor is reachable.
+ *
+ * @pre (l2_addr != NULL) && (l2_addr_len != NULL)
+ *
+ * @param[out] l2_addr      The link layer address of @p entry. Must not be NULL.
+ * @param[out] l2_addr_len  Length of @p l2_addr. Must not be NULL.
+ * @param[in] entry         A neighbor cache entry
+ *
+ * @return  PID to the interface where the neighbor is.
+ * @return  KERNEL_PID_UNDEF, if @p entry == NULL or the neighbor is not reachable.
+ */
+kernel_pid_t gnrc_ipv6_nc_get_l2_addr(uint8_t *l2_addr, uint8_t *l2_addr_len,
+                                      const gnrc_ipv6_nc_t *entry);
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -544,12 +544,7 @@ static inline kernel_pid_t _next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len
 #elif !defined(MODULE_GNRC_SIXLOWPAN_ND) && defined(MODULE_GNRC_IPV6_NC)
     (void)pkt;
     gnrc_ipv6_nc_t *nc = gnrc_ipv6_nc_get(iface, dst);
-    if ((nc == NULL) || !gnrc_ipv6_nc_is_reachable(nc)) {
-        return KERNEL_PID_UNDEF;
-    }
-    found_iface = nc->iface;
-    *l2addr_len = nc->l2_addr_len;
-    memcpy(l2addr, nc->l2_addr, nc->l2_addr_len);
+    found_iface = gnrc_ipv6_nc_get_l2_addr(l2addr, l2addr_len, nc);
 #elif !defined(MODULE_GNRC_SIXLOWPAN_ND)
     found_iface = KERNEL_PID_UNDEF;
     (void)l2addr;

--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -263,4 +263,16 @@ gnrc_ipv6_nc_t *gnrc_ipv6_nc_still_reachable(const ipv6_addr_t *ipv6_addr)
     return entry;
 }
 
+kernel_pid_t gnrc_ipv6_nc_get_l2_addr(uint8_t *l2_addr, uint8_t *l2_addr_len,
+                                      const gnrc_ipv6_nc_t *entry)
+{
+    assert((l2_addr != NULL) && (l2_addr_len != NULL));
+    if ((entry == NULL) || !gnrc_ipv6_nc_is_reachable(entry)) {
+        return KERNEL_PID_UNDEF;
+    }
+    *l2_addr_len = entry->l2_addr_len;
+    memcpy(l2_addr, entry->l2_addr, entry->l2_addr_len);
+    return entry->iface;
+}
+
 /** @} */

--- a/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
+++ b/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
@@ -130,12 +130,7 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
         if (gnrc_ipv6_nc_get_state(nc_entry) == GNRC_IPV6_NC_STATE_STALE) {
             gnrc_ndp_internal_set_state(nc_entry, GNRC_IPV6_NC_STATE_DELAY);
         }
-        if (nc_entry->l2_addr_len > 0) {
-            memcpy(l2addr, nc_entry->l2_addr, nc_entry->l2_addr_len);
-        }
-        *l2addr_len = nc_entry->l2_addr_len;
-        /* TODO: unreachability check */
-        return nc_entry->iface;
+        return gnrc_ipv6_nc_get_l2_addr(l2addr, l2addr_len, nc_entry);
     }
     else if (nc_entry == NULL) {
         gnrc_pktqueue_t *pkt_node;

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -212,20 +212,15 @@ kernel_pid_t gnrc_sixlowpan_nd_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_
         }
         return iface;
     }
-    if ((nc_entry == NULL) || (!gnrc_ipv6_nc_is_reachable(nc_entry)) ||
-        (gnrc_ipv6_nc_get_type(nc_entry) == GNRC_IPV6_NC_TYPE_TENTATIVE)) {
+    if ((gnrc_ipv6_nc_get_type(nc_entry) == GNRC_IPV6_NC_TYPE_TENTATIVE)) {
         return KERNEL_PID_UNDEF;
     }
     else {
-        if (nc_entry->l2_addr_len > 0) {
-            memcpy(l2addr, nc_entry->l2_addr, nc_entry->l2_addr_len);
-        }
-        *l2addr_len = nc_entry->l2_addr_len;
         if (gnrc_ipv6_nc_get_state(nc_entry) == GNRC_IPV6_NC_STATE_STALE) {
             gnrc_ndp_internal_set_state(nc_entry, GNRC_IPV6_NC_STATE_DELAY);
         }
     }
-    return nc_entry->iface;
+    return gnrc_ipv6_nc_get_l2_addr(l2addr, l2addr_len, nc_entry);
 }
 
 void gnrc_sixlowpan_nd_rtr_sol_reschedule(gnrc_ipv6_nc_t *nce, uint32_t sec_delay)


### PR DESCRIPTION
Removes some code duplication.