### PR TITLE
rpl: reuse _lt_timer for cleanup

### DIFF
--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -97,11 +97,6 @@ extern "C" {
 #define GNRC_RPL_MSG_TYPE_DAO_HANDLE  (0x0903)
 
 /**
- * @brief   Message type for handling DODAG cleanup
- */
-#define GNRC_RPL_MSG_TYPE_CLEANUP_HANDLE  (0x0904)
-
-/**
  * @brief   Infinite rank
  * @see <a href="https://tools.ietf.org/html/rfc6550#section-17">
  *          RFC 6550, section 17

--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -225,9 +225,6 @@ struct gnrc_rpl_dodag {
     msg_t dao_msg;                  /**< msg_t for firing a dao */
     uint32_t dao_time;              /**< time to schedule the next DAO */
     xtimer_t dao_timer;             /**< timer to schedule the next DAO */
-    msg_t cleanup_msg;              /**< msg_t for firing a cleanup */
-    uint32_t cleanup_time;          /**< time to schedula a DODAG cleanup */
-    xtimer_t cleanup_timer;         /**< timer to schedula a DODAG cleanup */
     trickle_t trickle;              /**< trickle representation */
 };
 
@@ -242,6 +239,7 @@ struct gnrc_rpl_instance {
     gnrc_rpl_of_t *of;              /**< configured Objective Function */
     uint16_t min_hop_rank_inc;      /**< minimum hop rank increase */
     uint16_t max_rank_inc;          /**< max increase in the rank */
+    int8_t cleanup;                 /**< cleanup time in seconds */
 };
 
 #ifdef __cplusplus

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -179,7 +179,7 @@ int _gnrc_rpl_dodag_show(void)
 
     gnrc_rpl_dodag_t *dodag = NULL;
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
-    uint32_t cleanup;
+    int8_t cleanup;
     uint64_t tc, ti, xnow = xtimer_now64();
 
     for (uint8_t i = 0; i < GNRC_RPL_INSTANCES_NUMOF; ++i) {
@@ -200,10 +200,9 @@ int _gnrc_rpl_dodag_show(void)
                 | dodag->trickle.msg_interval_timer.target) - xnow;
         ti = (int64_t) ti < 0 ? 0 : ti / SEC_IN_USEC;
 
-        cleanup = dodag->cleanup_timer.target - xtimer_now();
-        cleanup = (int32_t) cleanup < 0 ? 0 : cleanup / SEC_IN_USEC;
+        cleanup = dodag->instance->cleanup < 0 ? 0 : dodag->instance->cleanup;
 
-        printf("\tdodag [%s | R: %d | OP: %s | CL: %" PRIu32 "s | "
+        printf("\tdodag [%s | R: %d | OP: %s | CL: %" PRIi8 "s | "
                "TR(I=[%d,%d], k=%d, c=%d, TC=%" PRIu64 "s, TI=%" PRIu64 "s)]\n",
                ipv6_addr_to_str(addr_str, &dodag->dodag_id, sizeof(addr_str)),
                dodag->my_rank, (dodag->node_status == GNRC_RPL_LEAF_NODE ? "Leaf" : "Router"),


### PR DESCRIPTION
An extra `xtimer` + `msg_t` is too expensive for a simple cleanup routine. This PR reuses the periodic `_lt_timer` to also handle the cleanup.

Saves ~120 bytes of ROM and ~32 bytes of RAM.