### PR TITLE
rpl: reuse timer for periodic daos

### DIFF
--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -222,9 +222,7 @@ struct gnrc_rpl_dodag {
     bool dao_ack_received;          /**< flag to check for DAO-ACK */
     bool dodag_conf_requested;      /**< flag to send DODAG_CONF options */
     bool prefix_info_requested;     /**< flag to send PREFIX_INFO options */
-    msg_t dao_msg;                  /**< msg_t for firing a dao */
-    uint32_t dao_time;              /**< time to schedule the next DAO */
-    xtimer_t dao_timer;             /**< timer to schedule the next DAO */
+    uint8_t dao_time;               /**< time to schedule a DAO in seconds */
     trickle_t trickle;              /**< trickle representation */
 };
 

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -100,7 +100,6 @@ bool gnrc_rpl_instance_remove(gnrc_rpl_instance_t *inst)
     gnrc_rpl_dodag_t *dodag = &inst->dodag;
     gnrc_rpl_dodag_remove_all_parents(dodag);
     trickle_stop(&dodag->trickle);
-    xtimer_remove(&dodag->dao_timer);
     memset(inst, 0, sizeof(gnrc_rpl_instance_t));
     return true;
 }
@@ -143,8 +142,6 @@ bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, ipv6_addr_t *dodag_id)
     dodag->dtsn = 0;
     dodag->dao_ack_received = false;
     dodag->dao_counter = 0;
-    dodag->dao_msg.type = GNRC_RPL_MSG_TYPE_DAO_HANDLE;
-    dodag->dao_msg.content.ptr = (char *) instance;
     dodag->instance = instance;
 
     return true;
@@ -156,7 +153,6 @@ void gnrc_rpl_dodag_remove_all_parents(gnrc_rpl_dodag_t *dodag)
     LL_FOREACH_SAFE(dodag->parents, elt, tmp) {
         gnrc_rpl_parent_remove(elt);
     }
-    dodag->instance->cleanup = GNRC_RPL_CLEANUP_TIME;
 }
 
 bool gnrc_rpl_parent_add_by_addr(gnrc_rpl_dodag_t *dodag, ipv6_addr_t *addr,


### PR DESCRIPTION
Like in #4297:
Reuse the periodic `_lt_timer` for DAO transmission and remove the expensive `msg_t`+`xtimer_t`+`uint32_t` combination.

Saves ~80 bytes of ROM and ~32 bytes of RAM.