### PR TITLE
gnrc_netif_hdr: un-inline build function

### DIFF
--- a/sys/include/net/gnrc/netif/hdr.h
+++ b/sys/include/net/gnrc/netif/hdr.h
@@ -190,29 +190,7 @@ static inline void gnrc_netif_hdr_set_dst_addr(gnrc_netif_hdr_t *hdr, uint8_t *a
  * @return  The generic network layer header on success.
  * @return  NULL on error.
  */
-static inline gnrc_pktsnip_t *gnrc_netif_hdr_build(uint8_t *src, uint8_t src_len,
-                                                   uint8_t *dst, uint8_t dst_len)
-{
-    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, NULL,
-                                          sizeof(gnrc_netif_hdr_t) + src_len + dst_len,
-                                          GNRC_NETTYPE_NETIF);
-
-    if (pkt == NULL) {
-        return NULL;
-    }
-
-    gnrc_netif_hdr_init(pkt->data, src_len, dst_len);
-
-    if (src != NULL && src_len > 0) {
-        gnrc_netif_hdr_set_src_addr(pkt->data, src, src_len);
-    }
-
-    if (dst != NULL && dst_len > 0) {
-        gnrc_netif_hdr_set_dst_addr(pkt->data, dst, dst_len);
-    }
-
-    return pkt;
-}
+gnrc_pktsnip_t *gnrc_netif_hdr_build(uint8_t *src, uint8_t src_len, uint8_t *dst, uint8_t dst_len);
 
 /**
  * @brief   Outputs a generic interface header to stdout.

--- a/sys/net/gnrc/netif/hdr/gnrc_netif_hdr.c
+++ b/sys/net/gnrc/netif/hdr/gnrc_netif_hdr.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include "net/gnrc/netif/hdr.h"
+
+gnrc_pktsnip_t *gnrc_netif_hdr_build(uint8_t *src, uint8_t src_len, uint8_t *dst, uint8_t dst_len)
+{
+    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, NULL,
+                                          sizeof(gnrc_netif_hdr_t) + src_len + dst_len,
+                                          GNRC_NETTYPE_NETIF);
+
+    if (pkt == NULL) {
+        return NULL;
+    }
+
+    gnrc_netif_hdr_init(pkt->data, src_len, dst_len);
+
+    if (src != NULL && src_len > 0) {
+        gnrc_netif_hdr_set_src_addr(pkt->data, src, src_len);
+    }
+
+    if (dst != NULL && dst_len > 0) {
+        gnrc_netif_hdr_set_dst_addr(pkt->data, dst, dst_len);
+    }
+
+    return pkt;
+}
+
+/** @} */


### PR DESCRIPTION
First of a few optimization steps I planned for GNRC. I think the some of the inline functions in GNRC are way to big.

```
-180	0	0	-180	iotlab-m3
73032	220	23008	96260	master-bin
72852	220	23008	96080	new-bin

-176	0	0	-176	msba2
156592	2332	95965	254889	master-bin
156416	2332	95965	254713	new-bin

-1400	0	0	-1400	native
194816	616	113784	309216	master-bin
193416	616	113784	307816	new-bin

-156	0	0	-156	samr21-xpro
78020	220	23024	101264	master-bin
77864	220	23024	101108	new-bin
```