### PR TITLE
Reorder struct members to remove padding

### DIFF
--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -138,6 +138,7 @@ typedef struct {
     gnrc_netdev_event_cb_t event_cb;    /**< netdev event callback */
     kernel_pid_t mac_pid;               /**< the driver's thread's PID */
     /* device specific fields */
+    uint8_t idle_state;                 /**< state to return to after sending */
     spi_t spi;                          /**< used SPI device */
     gpio_t cs_pin;                      /**< chip select pin */
     gpio_t sleep_pin;                   /**< sleep pin */
@@ -155,7 +156,6 @@ typedef struct {
     uint8_t addr_short[2];              /**< the radio's short address */
     uint8_t addr_long[8];               /**< the radio's long address */
     uint16_t options;                   /**< state of used options */
-    uint8_t idle_state;                 /**< state to return to after sending */
 } at86rf2xx_t;
 
 /**

--- a/sys/include/net/fib/table.h
+++ b/sys/include/net/fib/table.h
@@ -113,26 +113,26 @@ typedef struct {
         /** array holding the FIB entries for source routes */
         fib_sr_meta_t *source_routes;
     }data;
-    /** the kind of this FIB table, single hop or source route.
-    *   This value indicates what is stored in `data` of this table
-    */
-    uint8_t table_type;
-    /** the maximim number of entries in this FIB table */
-    size_t size;
     /** table access mutex to grant exclusive operations on calls */
     mutex_t mtx_access;
+    /** the maximim number of entries in this FIB table */
+    size_t size;
     /** current number of registered RPs. */
     size_t notify_rp_pos;
-    /** the kernel_pid_t of the registered RPs.
-    *   Used to notify the RPs by the FIB on certain conditions,
-    *   e.g. when a destination is unreachable
-    */
-    kernel_pid_t notify_rp[FIB_MAX_REGISTERED_RP];
     /** the prefix handled by each registered RP.
     *   Used to dispatch if the RP is responsible for the condition,
     *   e.g. when the unreachable destination is covered by the prefix
     */
     universal_address_container_t* prefix_rp[FIB_MAX_REGISTERED_RP];
+    /** the kernel_pid_t of the registered RPs.
+    *   Used to notify the RPs by the FIB on certain conditions,
+    *   e.g. when a destination is unreachable
+    */
+    kernel_pid_t notify_rp[FIB_MAX_REGISTERED_RP];
+    /** the kind of this FIB table, single hop or source route.
+    *   This value indicates what is stored in `data` of this table
+    */
+    uint8_t table_type;
 } fib_table_t;
 
 #ifdef __cplusplus

--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -237,11 +237,11 @@ struct gnrc_rpl_dodag {
 struct gnrc_rpl_instance {
     uint8_t id;                     /**< id of the instance */
     uint8_t state;                  /**< 0 for unused, 1 for used */
-    gnrc_rpl_dodag_t dodag;         /**< DODAG of this instance */
     uint8_t mop;                    /**< configured Mode of Operation */
-    gnrc_rpl_of_t *of;              /**< configured Objective Function */
     uint16_t min_hop_rank_inc;      /**< minimum hop rank increase */
     uint16_t max_rank_inc;          /**< max increase in the rank */
+    gnrc_rpl_of_t *of;              /**< configured Objective Function */
+    gnrc_rpl_dodag_t dodag;         /**< DODAG of this instance */
 };
 
 #ifdef __cplusplus

--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -204,6 +204,9 @@ struct gnrc_rpl_dodag {
     gnrc_rpl_parent_t *parents;     /**< pointer to the parents list of this DODAG */
     gnrc_rpl_instance_t *instance;  /**< pointer to the instance that this dodag is part of */
     uint8_t prefix_len;             /**< length of the prefix for the DODAG id */
+    bool prefix_info_requested;     /**< flag to send PREFIX_INFO options */
+    bool dodag_conf_requested;      /**< flag to send DODAG_CONF options */
+    bool dao_ack_received;          /**< flag to check for DAO-ACK */
     uint32_t addr_preferred;        /**< time in seconds the DODAG id is preferred */
     uint32_t addr_valid;            /**< time in seconds the DODAG id is valid */
     uint8_t dtsn;                   /**< DAO Trigger Sequence Number */
@@ -219,9 +222,6 @@ struct gnrc_rpl_dodag {
     uint8_t node_status;            /**< leaf, normal, or root node */
     uint8_t dao_seq;                /**< dao sequence number */
     uint8_t dao_counter;            /**< amount of retried DAOs */
-    bool dao_ack_received;          /**< flag to check for DAO-ACK */
-    bool dodag_conf_requested;      /**< flag to send DODAG_CONF options */
-    bool prefix_info_requested;     /**< flag to send PREFIX_INFO options */
     msg_t dao_msg;                  /**< msg_t for firing a dao */
     uint32_t dao_time;              /**< time to schedule the next DAO */
     xtimer_t dao_timer;             /**< timer to schedule the next DAO */

--- a/sys/include/trickle.h
+++ b/sys/include/trickle.h
@@ -40,6 +40,16 @@ typedef struct {
 
 /** @brief all state variables for a trickle timer */
 typedef struct {
+    xtimer_t msg_callback_timer;    /**< xtimer to send a msg_t to the target thread
+                                         for a callback */
+    xtimer_t msg_interval_timer;    /**< xtimer to send a msg_t to the target thread
+                                         for a new interval */
+    msg_t msg_callback;             /**< the msg_t to use for callbacks */
+    msg_t msg_interval;             /**< the msg_t to use for intervals */
+    uint64_t msg_callback_time;     /**< callback interval in ms */
+    uint64_t msg_interval_time;     /**< interval in ms */
+    trickle_callback_t callback;    /**< the callback function and parameter that trickle is calling
+                                         after each interval */
     uint8_t k;                      /**< redundancy constant */
     uint8_t Imax;                   /**< maximum interval size, described as doublings */
     uint16_t c;                     /**< counter */
@@ -47,16 +57,6 @@ typedef struct {
     uint32_t I;                     /**< current interval size */
     uint32_t t;                     /**< time within the current interval */
     kernel_pid_t pid;               /**< pid of trickles target thread */
-    trickle_callback_t callback;    /**< the callback function and parameter that trickle is calling
-                                         after each interval */
-    msg_t msg_interval;             /**< the msg_t to use for intervals */
-    uint64_t msg_interval_time;     /**< interval in ms */
-    xtimer_t msg_interval_timer;    /**< xtimer to send a msg_t to the target thread
-                                         for a new interval */
-    msg_t msg_callback;             /**< the msg_t to use for callbacks */
-    uint64_t msg_callback_time;     /**< callback interval in ms */
-    xtimer_t msg_callback_timer;    /**< xtimer to send a msg_t to the target thread
-                                         for a callback */
 } trickle_t;
 
 /**


### PR DESCRIPTION
This PR reorders some struct members in order to remove padding due to alignment.

For `gnrc_networking`:
```
text    data    bss     dec     BOARD/BINDIRBASE

-52     0       -24     -76     arduino-due
57540   224     19960   77724   master-bin
57488   224     19936   77648   reorder-bin

134     0       0       134     arduino-mega2560
81240   10362   13800   105402  master-bin
81374   10362   13800   105536  reorder-bin

0       0       0       0       avsextrem
129500  2332    95961   227793  master-bin
129500  2332    95961   227793  reorder-bin

-52     0       -16     -68     cc2538dk
57464   220     19936   77620   master-bin
57412   220     19920   77552   reorder-bin

-56     0       -16     -72     ek-lm4f120xl
57352   220     19928   77500   master-bin
57296   220     19912   77428   reorder-bin

-56     0       -16     -72     f4vi1
57416   224     19928   77568   master-bin
57360   224     19912   77496   reorder-bin

-52     0       -24     -76     fox
58024   220     20064   78308   master-bin
57972   220     20040   78232   reorder-bin

-56     0       -16     -72     frdm-k64f
59392   1248    19928   80568   master-bin
59336   1248    19912   80496   reorder-bin

-56     0       -24     -80     iotlab-m3
72864   220     23008   96092   master-bin
72808   220     22984   96012   reorder-bin

-52     0       -16     -68     limifrog-v1
58604   220     20064   78888   master-bin
58552   220     20048   78820   reorder-bin

-52     0       -24     -76     mbed_lpc1768
57128   220     19936   77284   master-bin
57076   220     19912   77208   reorder-bin

0       0       0       0       msba2
156468  2332    95961   254761  master-bin
156468  2332    95961   254761  reorder-bin

-56     0       -16     -72     msbiot
57848   224     19944   78016   master-bin
57792   224     19928   77944   reorder-bin

-60     0       -24     -84     mulle
77632   1284    23288   102204  master-bin
77572   1284    23264   102120  reorder-bin

-80     0       0       -80     native
192546  624     114264  307434  master-bin
192466  624     114264  307354  reorder-bin

-40     0       -24     -64     nucleo-f091
60680   220     19936   80836   master-bin
60640   220     19912   80772   reorder-bin

-56     0       -24     -80     nucleo-f303
57512   220     19944   77676   master-bin
57456   220     19920   77596   reorder-bin

-52     0       -16     -68     nucleo-l1
58536   220     20056   78812   master-bin
58484   220     20040   78744   reorder-bin

-52     0       -16     -68     openmote
57372   220     19936   77528   master-bin
57320   220     19920   77460   reorder-bin

-56     0       -16     -72     pba-d-01-kw2x
74724   1248    23360   99332   master-bin
74668   1248    23344   99260   reorder-bin

0       0       0       0       pttu
129708  2332    95961   228001  master-bin
129708  2332    95961   228001  reorder-bin

-52     0       -16     -68     remote
58028   220     19936   78184   master-bin
57976   220     19920   78116   reorder-bin

-40     0       -24     -64     saml21-xpro
60888   220     20056   81164   master-bin
60848   220     20032   81100   reorder-bin

-52     0       -24     -76     samr21-xpro
77844   220     23024   101088  master-bin
77792   220     23000   101012  reorder-bin

-56     0       -24     -80     slwstk6220a
57156   220     20064   77440   master-bin
57100   220     20040   77360   reorder-bin

-56     0       -24     -80     stm32f3discovery
57520   220     19944   77684   master-bin
57464   220     19920   77604   reorder-bin

-56     0       -16     -72     stm32f4discovery
57704   224     19936   77864   master-bin
57648   224     19920   77792   reorder-bin

-52     0       -24     -76     udoo
57540   224     19960   77724   master-bin
57488   224     19936   77648   reorder-bin
```