### PR TITLE
cpu/stm32f1: fixed i2c driver

### DIFF
--- a/cpu/stm32f1/periph/i2c.c
+++ b/cpu/stm32f1/periph/i2c.c
@@ -451,6 +451,8 @@ static inline void _stop(I2C_TypeDef *dev)
     while (!(dev->SR1 & I2C_SR1_BTF));
     /* send STOP condition */
     dev->CR1 |= I2C_CR1_STOP;
+    /* wait until transmission is complete */
+    while (dev->SR2 & I2C_SR2_BUSY);
 }
 
 #if I2C_0_EN


### PR DESCRIPTION
the _stop() function now blocks until the transfer is complete. Not waiting can lead to concurrent bus access and subsequent to bus errors.