### PR TITLE
drivers/l3g4200d: fixed initialization

### DIFF
--- a/drivers/l3g4200d/l3g4200d.c
+++ b/drivers/l3g4200d/l3g4200d.c
@@ -39,16 +39,6 @@ int l3g4200d_init(l3g4200d_t *dev, i2c_t i2c, uint8_t address,
 {
     char tmp;
 
-    /* Acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
-    /* initialize the I2C bus */
-    if (i2c_init_master(i2c, I2C_SPEED) < 0) {
-        /* Release the bus for other threads. */
-        i2c_release(dev->i2c);
-        return -1;
-    }
-    i2c_release(dev->i2c);
-
     /* write device descriptor */
     dev->i2c = i2c;
     dev->addr = address;
@@ -71,9 +61,16 @@ int l3g4200d_init(l3g4200d_t *dev, i2c_t i2c, uint8_t address,
             break;
     }
 
+    /* acquire exclusive access to the bus. */
+    i2c_acquire(dev->i2c);
+    /* initialize the I2C bus */
+    if (i2c_init_master(i2c, I2C_SPEED) < 0) {
+        /* Release the bus for other threads. */
+        i2c_release(dev->i2c);
+        return -1;
+    }
     /* configure CTRL_REG1 */
     tmp = ((mode & 0xf) << L3G4200D_CTRL1_MODE_POS) | L3G4200D_CTRL1_ALLON;
-    i2c_acquire(dev->i2c);
     if (i2c_write_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL1, tmp) != 1) {
         i2c_release(dev->i2c);
         return -1;


### PR DESCRIPTION
Calling `i2c_acquire(dev-i2c);` when `dev->i2c` is not yet initialized might not be the best idea we ever had :-)