### PR TITLE
cpu/cortexm_common: moved ISR stack definition

### DIFF
--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -65,6 +65,15 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief   Stack size used for the exception (ISR) stack
+ * @{
+ */
+#ifndef ISR_STACKSIZE
+#define ISR_STACKSIZE                   (512U)
+#endif
+/** @} */
+
+/**
  * @brief   Some members of the Cortex-M family have architecture specific
  *          atomic operations in atomic_arch.c
  */

--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -31,11 +31,6 @@ OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
 OUTPUT_ARCH(arm)
 SEARCH_DIR(.)
 
-/* Define the default stack size for interrupt mode. As no context is
-   saved on this stack and ISRs are supposed to be short, it can be fairly
-   small. 512 byte should be a save assumption here */
-STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x200; /* 512 byte */
-
 /* Section Definitions */
 SECTIONS
 {
@@ -134,7 +129,7 @@ SECTIONS
     {
         . = ALIGN(8);
         _sstack = .;
-        . = . + STACK_SIZE;
+        KEEP (*(.isr_stack))
         . = ALIGN(8);
         _estack = .;
     } > ram

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -56,6 +56,11 @@ extern uint32_t _eram;
 #define STACK_CANARY_WORD 0xE7FEE7FEu
 
 /**
+ * @brief   Allocation of the interrupt stack
+ */
+__attribute__((used,section(".isr_stack"))) uint8_t isr_stack[ISR_STACKSIZE];
+
+/**
  * @brief   Pre-start routine for CPU-specific settings
  */
 __attribute__((weak)) void pre_startup (void)


### PR DESCRIPTION
A little less linkerscript magic: I moved the defintion/allocation of the interrupt/exception stack from the linkerscript into the `cortexm_common` code. This has some advantages:
- the stack size is defined in the same place than the default/main/idle stacksizes (-> `cpu/cortexm_common/include/cpu.h`), now people can actually find it...
- the stack size can be defined through the make system `CFLAGS=-DISR_STACKSIZE=xx make...`
- the used memory actually shows up when analyzing memory usage before linking (e.g. `arm-none-eabi-size bin/xxx/*.a` or similar)
- this PR saves some lines of code :-)