### PR TITLE
sys: div: remove div_u32_by_10() (and _mod_10())

### DIFF
--- a/sys/include/div.h
+++ b/sys/include/div.h
@@ -77,34 +77,6 @@ static inline uint32_t div_u32_by_15625div512(uint32_t val)
     return ((uint64_t)(val) * 0x431bde83ul) >> (12 + 32 - 9);
 }
 
-/**
- * @brief Integer divide val by 10
- *
- * @param[in]   n     dividend
- * @return      (n / 10)
- */
-static inline uint32_t div_u32_by_10(uint32_t n) {
-    uint32_t q, r;
-    q = (n >> 1) + (n >> 2);
-    q = q + (q >> 4);
-    q = q + (q >> 8);
-    q = q + (q >> 16);
-    q = q >> 3;
-    r = n - (((q << 2) + q) << 1);
-    return q + (r > 9);
-}
-
-/**
- * @brief Modulo 10
- *
- * @param[in]   n     dividend
- * @return      (n % 10)
- */
-static inline uint32_t div_u32_mod_10(uint32_t n)
-{
-    return n - (div_u32_by_10(n)*10);
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/tests/unittests/tests-div/tests-div.c
+++ b/tests/unittests/tests-div/tests-div.c
@@ -79,34 +79,12 @@ static void test_div_u64_by_1000000(void)
     }
 }
 
-static void test_div_u32_by_10(void)
-{
-    for (unsigned i = 0; i < N_U32_VALS; i++) {
-        DEBUG("Dividing %"PRIu32" by 10...\n", u32_test_values[i]);
-        TEST_ASSERT_EQUAL_INT(
-                div_u32_by_10(u32_test_values[i]),
-                u32_test_values[i]/10);
-    }
-}
-
-static void test_div_u32_mod_10(void)
-{
-    for (unsigned i = 0; i < N_U32_VALS; i++) {
-        DEBUG("Calculating %"PRIu32" % 10...\n", u32_test_values[i]);
-        TEST_ASSERT_EQUAL_INT(
-                div_u32_mod_10(u32_test_values[i]),
-                u32_test_values[i]%10);
-    }
-}
-
 Test *tests_div_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_div_u64_by_15625),
         new_TestFixture(test_div_u32_by_15625div512),
         new_TestFixture(test_div_u64_by_1000000),
-        new_TestFixture(test_div_u32_by_10),
-        new_TestFixture(test_div_u32_mod_10),
     };
 
     EMB_UNIT_TESTCALLER(div_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
When introducing div.h in order to make some 64bit integer divisions not pull in the libgcc dependencies, I went too far. This kind of "optimization" is not needed for 32bit integer divisions, fmt using div_u32_by_10() is ~40 bytes larger on Cortex-M* and 240bytes larger on AVR 8bit (compared to using "/10" and "%10" operators).

The function was only used in unittests and fmt. The latter has been fixed with #4306, the former are updated in this PR, too.