### PR TITLE
cpu: atmega_common, msp430: misc libc fixes for fmt

### DIFF
--- a/boards/chronos/stdio.c
+++ b/boards/chronos/stdio.c
@@ -40,3 +40,8 @@ int getchar(void)
     /* dummy implementation */
     return EOF;
 }
+
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+    return -1;
+}

--- a/cpu/atmega_common/include/sys/types.h
+++ b/cpu/atmega_common/include/sys/types.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ *               2015 Kaspar Schleiser <kaspar@schleiser.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -18,6 +19,7 @@ extern "C" {
 
 typedef int16_t suseconds_t;
 typedef signed int ssize_t;
+typedef unsigned int off_t;
 
 #ifdef __cplusplus
 }

--- a/cpu/msp430-common/include/sys/types.h
+++ b/cpu/msp430-common/include/sys/types.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2014 INRIA
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef SYS_TYPES_H_
+#define SYS_TYPES_H_
+
+#include "msp430_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYS_TYPES_H_ */

--- a/cpu/msp430fxyz/msp430_stdio.c
+++ b/cpu/msp430fxyz/msp430_stdio.c
@@ -18,6 +18,9 @@
  * @}
  */
 
+#include <sys/types.h>
+#include <unistd.h>
+
 #include "uart_stdio.h"
 
 /**
@@ -37,6 +40,18 @@ int getchar(void)
 int putchar(int c)
 {
     char _c = c;
-    uart_stdio_write(&_c, 1);
-    return 1;
+    return uart_stdio_write(&_c, 1);
+}
+
+/**
+ * @brief   Write nbyte characters to the STDIO UART interface
+ */
+ssize_t write(int fildes, const void *buf, size_t nbyte)
+{
+    if (fildes == STDOUT_FILENO) {
+        return uart_stdio_write(buf, nbyte);
+    }
+    else {
+        return -1;
+    }
 }

--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -137,6 +137,10 @@ uint32_t scn_u32_dec(const char *str, size_t n)
 
 void print(const char *s, size_t n)
 {
+#ifdef __WITH_AVRLIBC__
+    /* AVR's libc doesn't offer write(), so use fwrite() instead */
+    fwrite(s, n, 1, stdout);
+#else
     while (n > 0) {
         ssize_t written = write(STDOUT_FILENO, s, n);
         if (written < 0) {
@@ -145,6 +149,7 @@ void print(const char *s, size_t n)
         n -= written;
         s += written;
     }
+#endif /* __WITH_AVRLIBC__ */
 }
 
 void print_u32_dec(uint32_t val)

--- a/tests/fmt_print/Makefile
+++ b/tests/fmt_print/Makefile
@@ -1,0 +1,6 @@
+APPLICATION = fmt_print
+include ../Makefile.tests_common
+
+USEMODULE += fmt
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/fmt_print/main.c
+++ b/tests/fmt_print/main.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       fmt print test application
+ *
+ * This test is supposed to check for "compilabilty" of the fmt print_* instructions.
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include "fmt.h"
+
+int main(void)
+{
+    print_str("If you can read this:\n");
+    print_str("Test successful.\n");
+
+    return 0;
+}


### PR DESCRIPTION
AVR & msp430 don't have write().

This PR makes fmt use fwrite() on AVR, and implements write() using uart for the msp430s.
Also includes some related libc header fixes.

Without this, fmt will not compile on those platforms.