### PR TITLE
doc: various fixes related to 'periph'

### DIFF
--- a/cpu/kinetis_common/include/periph_cpu.h
+++ b/cpu/kinetis_common/include/periph_cpu.h
@@ -38,10 +38,15 @@ typedef uint16_t gpio_t;
  */
 #define GPIO_UNDEF          (0xffff)
 
+/**
+ * @brief   Definition of pin and port positions in the gpio_t type
+ * @{
+ */
 #define GPIO_PORT_SHIFT     (8)
 #define GPIO_PORT_MASK      (0xff << (GPIO_PORT_SHIFT))
 #define GPIO_PIN_SHIFT      (0)
 #define GPIO_PIN_MASK       (0xff << (GPIO_PIN_SHIFT))
+/** @} */
 
 /**
  * @brief   Define a CPU specific GPIO pin generator macro

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -92,7 +92,7 @@ typedef struct {
  * @brief   PWM device configuration data structure
  */
 typedef struct {
-    Tcc *dev;                   /*< TCC device to use */
+    Tcc *dev;                   /**< TCC device to use */
     pwm_conf_chan_t chan[2];    /**< channel configuration */
 } pwm_conf_t;
 

--- a/doc/doxygen/src/mainpage.md
+++ b/doc/doxygen/src/mainpage.md
@@ -138,7 +138,7 @@ switching) code. For most CPUs you will also find the linker scripts in the
 `ldscripts` sub-directory.
 
 In the `periph` sub-directory of each CPU you can find the implementations of
-the CPU's peripheral drivers like SPI, UART, GPIO, etc.  See @ref driver_periph
+the CPU's peripheral drivers like SPI, UART, GPIO, etc.  See @ref drivers_periph
 for their API documentation.
 
 Many CPUs share a certain amount of their code (e.g. all ARM Cortex-M based

--- a/drivers/include/adc_legacy.h
+++ b/drivers/include/adc_legacy.h
@@ -10,8 +10,8 @@
  * @defgroup    drivers_adc ADC
  * @ingroup     drivers
  * @brief       Generic interface for ADC drivers
- * @deprecated  This interface is obsolete. Use the @ref driver_periph_adc
- *              interface in @ref driver_periph instead.
+ * @deprecated  This interface is obsolete. Use the @ref drivers_periph_adc
+ *              interface in @ref drivers_periph instead.
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  *

--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    driver_periph_adc ADC
- * @ingroup     driver_periph
+ * @defgroup    drivers_periph_adc ADC
+ * @ingroup     drivers_periph
  * @brief       Low-level ADC peripheral driver
  * @{
  *

--- a/drivers/include/periph/cpuid.h
+++ b/drivers/include/periph/cpuid.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    driver_periph_cpuid CPUID
- * @ingroup     driver_periph
+ * @defgroup    drivers_periph_cpuid CPUID
+ * @ingroup     drivers_periph
  * @brief       Low-level CPU ID peripheral driver
  *
  * Provides access the CPU's serial number

--- a/drivers/include/periph/dac.h
+++ b/drivers/include/periph/dac.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    driver_periph_dac DAC
- * @ingroup     driver_periph
+ * @defgroup    drivers_periph_dac DAC
+ * @ingroup     drivers_periph
  * @brief       Low-level DAC peripheral driver
  *
  * @{

--- a/drivers/include/periph/dev_enums.h
+++ b/drivers/include/periph/dev_enums.h
@@ -7,15 +7,15 @@
  */
 
 /**
- * @ingroup     driver_periph
+ * @ingroup     drivers_periph
  *
  * @{
  * @file
  * @brief       Device enumerations for backward compatibility with existing
  *              peripheral driver implementations
  *
- * TODO: Remove this file once all peripheral drivers are ported to the more
- *       efficient implementations style
+ * @todo        Remove this file once all peripheral drivers are ported to the
+ *              more efficient implementations style
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */

--- a/drivers/include/periph/doc.txt
+++ b/drivers/include/periph/doc.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin
+ * Copyright (C) 2013-2015 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -7,11 +7,17 @@
  */
 
 /**
- * @defgroup    driver_periph   Peripheral drivers
+ * @defgroup    drivers_periph Peripheral Driver Interface
  * @ingroup     drivers
- * @brief       Low-level peripheral drivers
+ * @brief       Low-level peripheral driver interface for vendor and platform
+ *              independent access to MCU peripherals as UART, SPI, etc
  *
- * The module contains the low-level peripheral driver layer. It consists of a set
- * of platform independent interface definitions and cpu specific implementations
- * for every targeted platform.
+ * The module contains the low-level peripheral driver interface. This interface
+ * defines a standardized interface to access MCU peripherals that is not tied
+ * to any specific vendor, platform or architecture.
+ *
+ * @todo        describe concept in detail
+ * @todo        link to driver model
+ * @todo        describe/link implementation guide
+ * @todo        list best practices
  */

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    driver_periph_gpio GPIO
- * @ingroup     driver_periph
+ * @defgroup    drivers_periph_gpio GPIO
+ * @ingroup     drivers_periph
  * @brief       Low-level GPIO peripheral driver
  *
  * @{

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    driver_periph_i2c I2C
- * @ingroup     driver_periph
+ * @defgroup    drivers_periph_i2c I2C
+ * @ingroup     drivers_periph
  * @brief       Low-level I2C peripheral driver
  *
  * @{

--- a/drivers/include/periph/pwm.h
+++ b/drivers/include/periph/pwm.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    driver_periph_pwm PWM
- * @ingroup     driver_periph
+ * @defgroup    drivers_periph_pwm PWM
+ * @ingroup     drivers_periph
  * @brief       Low-level PWM peripheral driver
  *
  * @{

--- a/drivers/include/periph/random.h
+++ b/drivers/include/periph/random.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    driver_periph_random Random
- * @ingroup     driver_periph
+ * @defgroup    drivers_periph_random Random
+ * @ingroup     drivers_periph
  * @brief       Low-level (pseudo) random number generator driver
  *
  * The quality of the random data read from this interface is highly

--- a/drivers/include/periph/rtc.h
+++ b/drivers/include/periph/rtc.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    driver_periph_rtc RTC
- * @ingroup     driver_periph
+ * @defgroup    drivers_periph_rtc RTC
+ * @ingroup     drivers_periph
  * @brief       Low-level RTC (Real Time Clock) peripheral driver
  *
  * @note

--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    driver_periph_rtt RTT
- * @ingroup     driver_periph
+ * @defgroup    drivers_periph_rtt RTT
+ * @ingroup     drivers_periph
  * @brief       Low-level RTT (Real Time Timer) peripheral driver
  *
  * @{

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    driver_periph_spi SPI
- * @ingroup     driver_periph
+ * @defgroup    drivers_periph_spi SPI
+ * @ingroup     drivers_periph
  * @brief       Low-level SPI peripheral driver
  *
  * The current design of this interface targets implementations that use the SPI in blocking mode.

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    driver_periph_timer Timer
- * @ingroup     driver_periph
+ * @defgroup    drivers_periph_timer Timer
+ * @ingroup     drivers_periph
  * @brief       Low-level timer peripheral driver
  * @{
  *

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    driver_periph_uart UART
- * @ingroup     driver_periph
+ * @defgroup    drivers_periph_uart UART
+ * @ingroup     drivers_periph
  * @brief       Low-level UART peripheral driver
  * @{
  *

--- a/sys/include/net/gnrc/slip.h
+++ b/sys/include/net/gnrc/slip.h
@@ -10,7 +10,7 @@
  * @defgroup    net_gnrc_slip SLIP
  * @ingroup     net_gnrc
  * @brief       Provides a SLIP interface over UART utilizing
- *              @ref driver_periph_uart.
+ *              @ref drivers_periph_uart.
  * @see         <a href="https://www.ietf.org/rfc/rfc1055">RFC 1055</a>
  * @{
  *


### PR DESCRIPTION
- repaired the periph driver group name
- fixed two warnings concerning undocumented macros/members in `cpu/kinetis-common` and `cpu/samd21`
- added some todos to the `drivers_periph` group description -> PR to fix them will follow...