### PR TITLE
drivers: various doxygen fixes

### DIFF
--- a/drivers/doc.txt
+++ b/drivers/doc.txt
@@ -28,3 +28,12 @@
  * Most of these drivers will be connected over some bus or serial connection
  * to the MCU.
  */
+
+/**
+ * @defgroup    drivers_actuators Actuator Device Drivers
+ * @ingroup     drivers
+ * @brief       Drivers for actuating devices
+ *
+ * The group of actuators includes all kind of devices that can actively
+ * interact with the physical world, as e.g. motors, lights, sound devices, etc.
+ */

--- a/drivers/include/adc_legacy.h
+++ b/drivers/include/adc_legacy.h
@@ -10,17 +10,19 @@
  * @defgroup    drivers_adc ADC
  * @ingroup     drivers
  * @brief       Generic interface for ADC drivers
+ *
  * @deprecated  This interface is obsolete. Use the @ref drivers_periph_adc
  *              interface in @ref drivers_periph instead.
+ * @{
+ *
+ * @file
+ * @brief       Legacy ADC driver interface
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
- *
- * @{
- * @file
  */
 
-#ifndef ADC_H
-#define ADC_H
+#ifndef ADC_LEGACY_H
+#define ADC_LEGACY_H
 
 #include <stdint.h>
 
@@ -46,5 +48,5 @@ uint16_t adc_read(uint8_t channel);
 }
 #endif
 
+#endif /* ADC_LEGACY_H */
 /** @} */
-#endif /* ADC_H */

--- a/drivers/include/at30tse75x.h
+++ b/drivers/include/at30tse75x.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    at30tse75x AT30TSE75x temperature sensor with EEPROM
- * @ingroup     drivers
+ * @defgroup    drivers_at30tse75x AT30TSE75x temperature sensor with EEPROM
+ * @ingroup     drivers_sensors
  *
  * The connection between the MCU and the AT30TSE75x is based on the
  * I2C-interface. There are 3 versions of this IC, with either 2/4/8 Kb of

--- a/drivers/include/dht.h
+++ b/drivers/include/dht.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_dht DHT Family of Humidity and Temperature Sensors
+ * @defgroup    drivers_dht DHT Family of Humidity and Temperature Sensors
  * @ingroup     drivers_sensors
  * @brief       Device driver for the DHT Family of humidity
  *              and temperature sensors

--- a/drivers/include/diskio.h
+++ b/drivers/include/diskio.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    diskio Disk IO Driver
+ * @defgroup    drivers_diskio Disk IO Driver
  * @ingroup     drivers
  * @brief       Low level disk interface
  *

--- a/drivers/include/encx24j600.h
+++ b/drivers/include/encx24j600.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_encx24j600 ENCX24J600
+ * @defgroup    drivers_encx24j600 ENCX24J600
  * @ingroup     drivers_netdev
  * @brief       Driver for the ENCX24J600 Ethernet Adapter
  * @{

--- a/drivers/include/flashrom.h
+++ b/drivers/include/flashrom.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    flashrom Flash memory driver
+ * @defgroup    drivers_flashrom Flash memory driver
  * @ingroup     drivers
  * @brief       Generic flash memory driver
  * @{

--- a/drivers/include/gpioint.h
+++ b/drivers/include/gpioint.h
@@ -6,9 +6,6 @@
  * directory for more details.
  */
 
-#ifndef GPIOINT_H_
-#define GPIOINT_H_
-
 /**
  * @defgroup    drivers_gpioint GPIO IRQ Multiplexer
  * @ingroup     drivers
@@ -24,6 +21,9 @@
  * @author      Michael Baar <michael.baar@fu-berlin.de>
  */
 
+#ifndef GPIOINT_H_
+#define GPIOINT_H_
+
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -32,19 +32,21 @@ extern "C" {
 #endif
 
 /*
- * gpioint_flags:
- * Note: - We rely on the exact values for the edges.
- *       - These flags are extended in hal/drivers/device-gpio.h
+ * @brief   GPIO IRQ multiplexer flags
+ *
+ * @note    We rely on the exact values for the edges.
+ * @note    These flags are extended in hal/drivers/device-gpio.h
+ *
+ * @{
  */
-#define GPIOINT_DISABLE         0x00
-#define GPIOINT_RISING_EDGE     0x01            ///< interrupt is generated on rising edge
-#define GPIOINT_FALLING_EDGE    0x02            ///< interrupt is generated on falling edge
-#define GPIOINT_DEBOUNCE        0x04            ///< debounce this interrupt
+#define GPIOINT_DISABLE         0x00    /**< disable interrupt */
+#define GPIOINT_RISING_EDGE     0x01    /**< interrupt is generated on rising edge */
+#define GPIOINT_FALLING_EDGE    0x02    /**< interrupt is generated on falling edge */
+#define GPIOINT_DEBOUNCE        0x04    /**< debounce this interrupt */
+/** @} */
 
 /**
  * @brief   GPIO IRQ callback function type
- * @param[in]       data        User defined callback data passed through gpioint_set
- * @param[in]       edge        A combination of GPIOINT_RISING_EDGE and GPIOINT_FALLING_EDGE
  */
 typedef void(*fp_irqcb)(void);
 
@@ -62,6 +64,9 @@ typedef void(*fp_irqcb)(void);
  */
 bool gpioint_set(int port, uint32_t bitmask, int flags, fp_irqcb callback);
 
+/**
+ * @brief   Initialize the multiplexer
+ */
 void gpioint_init(void);
 
 #ifdef __cplusplus

--- a/drivers/include/hih6130.h
+++ b/drivers/include/hih6130.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_hih6130 HIH6130 humidity and temperature sensor
+ * @defgroup    drivers_hih6130 HIH6130 humidity and temperature sensor
  * @ingroup     drivers_sensors
  * @brief       Device driver for Honeywell HumidIcon Digital
  *              Humidity/Temperature Sensors: HIH-6130/6131 Series

--- a/drivers/include/ina220.h
+++ b/drivers/include/ina220.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_ina220 INA220 current/power monitor
+ * @defgroup    drivers_ina220 INA220 current/power monitor
  * @ingroup     drivers_sensors
  * @brief       Device driver for Texas Instruments INA220 High or Low Side,
  *              Bi-Directional CURRENT/POWER MONITOR with Two-Wire Interface

--- a/drivers/include/isl29020.h
+++ b/drivers/include/isl29020.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_isl29020 ISL29020 light sensor
+ * @defgroup    drivers_isl29020 ISL29020 light sensor
  * @ingroup     drivers_sensors
  * @brief       Device driver for the ISL29020 light sensor
  * @{

--- a/drivers/include/isl29125.h
+++ b/drivers/include/isl29125.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_isl29125 ISL29125 RGB light sensor
+ * @defgroup    drivers_isl29125 ISL29125 RGB light sensor
  * @ingroup     drivers_sensors
  * @brief       Device driver for the ISL29125 RGB light sensor
  *

--- a/drivers/include/l3g4200d.h
+++ b/drivers/include/l3g4200d.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_l3g4200d L3G4200D gyroscope
+ * @defgroup    drivers_l3g4200d L3G4200D gyroscope
  * @ingroup     drivers_sensors
  * @brief       Device driver for the L3G4200D gyroscope
  * @{

--- a/drivers/include/lis3dh.h
+++ b/drivers/include/lis3dh.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_lis3dh LIS3DH accelerometer
+ * @defgroup    drivers_lis3dh LIS3DH accelerometer
  * @ingroup     drivers_sensors
  * @brief       Device driver for the LIS3DH accelerometer
  * @{

--- a/drivers/include/lm75a-temp-sensor.h
+++ b/drivers/include/lm75a-temp-sensor.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    lm75a LM75A
+ * @defgroup    drivers_lm75a LM75A
  * @ingroup     drivers_sensors
  * @brief       Driver for the LM75A digital temperature sensor and thermal watchdog
  *

--- a/drivers/include/lps331ap.h
+++ b/drivers/include/lps331ap.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_lps331ap LPS331AP Pressure Sensor Driver
+ * @defgroup    drivers_lps331ap LPS331AP Pressure Sensor Driver
  * @ingroup     drivers_sensors
  * @brief       Device driver for the LPS331AP pressure sensor
  * @{

--- a/drivers/include/lsm303dlhc.h
+++ b/drivers/include/lsm303dlhc.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_lsm303dlhc LSM303DLHC 3D accelerometer/magnetometer
+ * @defgroup    drivers_lsm303dlhc LSM303DLHC 3D accelerometer/magnetometer
  * @ingroup     drivers_sensors
  * @brief       Device driver for the LSM303DLHC 3D accelerometer/magnetometer
  * @{

--- a/drivers/include/ltc4150.h
+++ b/drivers/include/ltc4150.h
@@ -6,6 +6,23 @@
  * directory for more details.
  */
 
+/**
+ * @defgroup    drivers_ltc4150 LTC4150 Coulomb Counter
+ * @ingroup     drivers_sensors
+ * @brief       Device driver for LTC4150 coulomb counters
+ *
+ * @deprecated  This driver should be ported to the peripheral driver interface
+ *              (@ref drivers_periph)
+ *
+ * @{
+ *
+ * @file
+ * @brief       Driver interface for the LTC4150 driver
+ *
+ * @author      Heiko Will <heiko.will@fu-berlin.de>
+ */
+
+
 #ifndef LTC4150_H
 #define LTC4150_H
 
@@ -15,15 +32,61 @@
 extern "C" {
 #endif
 
+/**
+ * @brief   Initialize the counter
+ */
 void ltc4150_init(void);
+
+/**
+ * @brief   Start a measurement
+ */
 void ltc4150_start(void);
+
+/**
+ * @brief   End the ongoing measurement
+ */
 void ltc4150_stop(void);
 
+/**
+ * @brief   Get the current electrical current
+ *
+ * @return  electrical current in mA
+ */
 double ltc4150_get_current_mA(void);
+
+/**
+ * @brief   Get the total power used since @p ltc4150_start was called
+ *
+ * @return  power used in mAh
+ */
 double ltc4150_get_total_mAh(void);
+
+/**
+ * @brief   Get the total energy used since @p ltc4150_start was called
+ *
+ * @return  energy used in Joule
+ */
 double ltc4150_get_total_Joule(void);
+
+/**
+ * @brief   Get the average electrical current sine @p ltc4150_start was called
+ *
+ * @return  average current in mA
+ */
 double ltc4150_get_avg_mA(void);
+
+/**
+ * @brief   Get the time the current measurement is going on
+ *
+ * @return  time
+ */
 int ltc4150_get_interval(void);
+
+/**
+ * @brief   Get the number of samples taken
+ *
+ * @return  number of samples in the current interval
+ */
 long ltc4150_get_intcount(void);
 
 #ifdef __cplusplus
@@ -31,3 +94,4 @@ long ltc4150_get_intcount(void);
 #endif
 
 #endif /* LTC4150_H */
+/** @} */

--- a/drivers/include/ltc4150_arch.h
+++ b/drivers/include/ltc4150_arch.h
@@ -6,6 +6,18 @@
  * directory for more details.
  */
 
+/**
+ * @defgroup    drivers_ltc4150 LTC4150
+ * @ingroup     drivers_sensors
+ * @brief       Driver for the Linear Technology LTC4150 Coulomb Counter
+ * @{
+ *
+ * @file
+ * @brief       LTC4150 Coulomb Counter
+ *
+ * @author      Heiko Will <heiko.will@fu-berlin.de>
+ */
+
 #ifndef LTC4150_ARCH_H
 #define LTC4150_ARCH_H
 
@@ -14,34 +26,39 @@ extern "C" {
 #endif
 
 /**
- * @defgroup    ltc4150 LTC4150
- * @ingroup     drivers_sensors
- * @brief       Driver for the Linear Technology LTC4150 Coulomb Counter
+ * @brief   Constants used by the driver
  * @{
- *
- * @file
- * @brief       LTC4150 Coulomb Counter
- *
- * @author      Heiko Will
  */
-
 #define _GFH (double)32.631375
 #define _R_SENSE (double)0.330
 #define SUPPLY_VOLTAGE  (5)
+/** @} */
 
-/** board specific ltc4150 interrupt disable */
+/**
+ * @brief   Board specific ltc4150 interrupt disable
+ **/
 void ltc4150_disable_int(void);
-/** board specific ltc4150 interrupt enable */
+
+/**
+ * @brief   Board specific ltc4150 interrupt enable
+ **/
 void ltc4150_enable_int(void);
-/** board specific synchronization of ltc4150 */
+
+/**
+ * @brief   Board specific synchronization of ltc4150
+ **/
 void ltc4150_sync_blocking(void);
-/** board specific ltc4150 initialization */
+
+/**
+ * @brief   Board specific ltc4150 initialization
+ **/
 void ltc4150_arch_init(void);
 
 /**
- * ltc4150 interrupt handler,
- * shall be called on ltc4150 interrupt,
- * implemented in driver
+ * @brief   Ltc4150 interrupt handler
+ *
+ * This handler shall be called on ltc4150 interrupt, it is implemented in the
+ * driver.
  */
 void ltc4150_interrupt(void);
 

--- a/drivers/include/nvram-spi.h
+++ b/drivers/include/nvram-spi.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     nvram
+ * @ingroup     drivers_nvram
  * @{
  *
  * @file

--- a/drivers/include/nvram.h
+++ b/drivers/include/nvram.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    nvram Non-volatile RAM
+ * @defgroup    drivers_nvram Non-volatile RAM
  * @ingroup     drivers
  * @brief       Non-volatile RAM interface
  *

--- a/drivers/include/pcd8544.h
+++ b/drivers/include/pcd8544.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    driver_pcd8544 PCD8544 LCD driver
- * @ingroup     drivers
+ * @ingroup     drivers_actuators
  * @brief       Driver for PCD8544 LCD displays
  *
  * @{

--- a/drivers/include/rgbled.h
+++ b/drivers/include/rgbled.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    driver_rgbled RGB-LED driver
- * @ingroup     drivers
+ * @ingroup     drivers_actuators
  * @brief       High-level driver for RGB-LEDs
  * @{
  *

--- a/drivers/include/servo.h
+++ b/drivers/include/servo.h
@@ -9,7 +9,7 @@
 
 /**
  * @defgroup    driver_servo Servo Motor Driver
- * @ingroup     drivers
+ * @ingroup     drivers_actuators
  * @brief       High-level driver for servo motors
  * @{
  *

--- a/drivers/include/sht11.h
+++ b/drivers/include/sht11.h
@@ -10,9 +10,9 @@
 #define SHT11_H_
 
 /**
- * @defgroup    sht11   SHT11
- * @brief       Driver for Sensirion SHT11 Humidity and Temperature Sensor
+ * @defgroup    drivers_sht11   SHT11
  * @ingroup     drivers_sensors
+ * @brief       Driver for Sensirion SHT11 Humidity and Temperature Sensor
  * @{
  *
  * @file

--- a/drivers/include/tcs37727.h
+++ b/drivers/include/tcs37727.h
@@ -8,8 +8,7 @@
 
 /**
  * @defgroup    drivers_tcs37727 TCS37727 Light-To-Digital Converter
- *
- * @ingroup     drivers
+ * @ingroup     drivers_sensors
  * @brief       Driver for the AMS TCS37727 Color Light-To-Digital Converter
  *
  *


### PR DESCRIPTION
- fixed group naming scheme to 'drivers_xx'
- introduced a group for actuators (analog to the sensors)
- added missing doxygen to ltc4150 driver

My first approach was to remove all doxygen warnings related to drivers, but that would have been too much for one PR, will commit more fixes separately.