### PR TITLE
Make pyterm fails gracefully if no port is available

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -210,7 +210,12 @@ class SerCmd(cmd.Cmd):
         # otherwise go for the serial port
         elif self.port:
             self.logger.info("Connect to serial port %s" % self.port)
-            self.serial_connect()
+            try:
+                self.serial_connect()
+            except OSError as e:
+                self.logger.error("Cannot connect to serial port {}: {}"
+                                  .format(self.port, e.strerror))
+                sys.exit(1)
 
         # wait until connection is established and fire startup
         # commands to the node


### PR DESCRIPTION
Hi,
I tried `make term BOARD=arduino-due` with no board plugged and had the following error message:
```
...
FileNotFoundError: [Errno 2] No such file or directory: '/dev/ttyUSB0'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./dist/tools/pyterm/pyterm", line 739, in <module>
    myshell.cmdloop("Welcome to pyterm!\nType '/exit' to exit.")
  File "/home/aabadie/anaconda3/lib/python3.4/cmd.py", line 105, in cmdloop
    self.preloop()
  File "./dist/tools/pyterm/pyterm", line 214, in preloop
    self.serial_connect()
  File "./dist/tools/pyterm/pyterm", line 572, in serial_connect
    self.ser = serial.Serial(port=self.port, dsrdtr=0, rtscts=0)
  File "/home/aabadie/anaconda3/lib/python3.4/site-packages/serial/serialutil.py", line 282, in __init__
    self.open()
  File "/home/aabadie/anaconda3/lib/python3.4/site-packages/serial/serialposix.py", line 292, in open
    raise SerialException(msg.errno, "could not open port %s: %s" % (self._port, msg))
serial.serialutil.SerialException: [Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
```
The purpose of this small PR is just to catch the exception raised, print a meaningful message containing the error and exit gracefully.
I know it's minor but I hope this helps.