### PR TITLE
posix sockets: recvfrom on connectionless transports

### DIFF
--- a/examples/posix_sockets/main.c
+++ b/examples/posix_sockets/main.c
@@ -20,9 +20,11 @@
 
 #include <stdio.h>
 
+#include "msg.h"
 #include "shell.h"
 
-#define MAIN_MSG_QUEUE_SIZE (1)
+#define MAIN_MSG_QUEUE_SIZE (4)
+static msg_t main_msg_queue[MAIN_MSG_QUEUE_SIZE];
 
 extern int udp_cmd(int argc, char **argv);
 
@@ -33,6 +35,9 @@ static const shell_command_t shell_commands[] = {
 
 int main(void)
 {
+    /* a sendto() call performs an implicit bind(), hence, a message queue is
+     * required for the thread executing the shell */
+    msg_init_queue(main_msg_queue, MAIN_MSG_QUEUE_SIZE);
     puts("RIOT socket example application");
     /* start shell */
     puts("All up, running the shell now");

--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -120,11 +120,6 @@ static inline int _choose_ipproto(int type, int protocol)
     return -1;
 }
 
-static inline void _htons_port(uint16_t *port)
-{
-    *port = htons(*port);
-}
-
 static inline ipv4_addr_t *_in_addr_ptr(struct sockaddr_storage *addr)
 {
     return (ipv4_addr_t *)(&((struct sockaddr_in *)addr)->sin_addr);
@@ -366,8 +361,8 @@ int accept(int socket, struct sockaddr *restrict address,
                     res = -1;
                     break;
                 }
-                _htons_port(port);  /* XXX: sin(6)_port is supposed to be network byte
-                                     *      order */
+                *port = htons(*port); /* XXX: sin(6)_port is supposed to be
+                                         network byte order */
                 *address_len = _addr_truncate(address, *address_len, &tmp, tmp_len);
             }
             break;
@@ -542,8 +537,8 @@ int getpeername(int socket, struct sockaddr *__restrict address,
             return -1;
     }
     tmp.ss_family = s->domain;
-    _htons_port(port);  /* XXX: sin(6)_port is supposed to be network byte
-                         *      order */
+    *port = htons(*port); /* XXX: sin(6)_port is supposed to be network byte
+                             order */
     *address_len = _addr_truncate(address, *address_len, &tmp, tmp_len);
     return 0;
 }
@@ -626,8 +621,8 @@ int getsockname(int socket, struct sockaddr *__restrict address,
             return -1;
     }
     tmp.ss_family = AF_INET;
-    _htons_port(port);  /* XXX: sin(6)_port is supposed to be network byte
-                         *      order */
+    *port = htons(*port); /* XXX: sin(6)_port is supposed to be network byte
+                             order */
     *address_len = _addr_truncate(address, *address_len, &tmp, tmp_len);
     return 0;
 }
@@ -762,8 +757,8 @@ ssize_t recvfrom(int socket, void *restrict buffer, size_t length, int flags,
     }
     if ((address != NULL) && (address_len != NULL)) {
         tmp.ss_family = s->domain;
-        _htons_port(port);  /* XXX: sin_port is supposed to be network byte
-                             *      order */
+        *port = htons(*port); /* XXX: sin(6)_port is supposed to be network
+                                 byte order */
         *address_len = _addr_truncate(address, *address_len, &tmp, tmp_len);
     }
     return res;

--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -728,12 +728,11 @@ ssize_t recvfrom(int socket, void *restrict buffer, size_t length, int flags,
     switch (s->type) {
 #ifdef MODULE_CONN_UDP
         case SOCK_DGRAM:
-            if ((res = conn_udp_recvfrom(&s->conn.udp, buffer, length, addr, &addr_len,
-                                         port)) < 0) {
+            if ((res = conn_udp_recvfrom(&s->conn.udp, buffer, length, addr,
+                                         &addr_len, port)) < 0) {
                 errno = -res;
                 return -1;
             }
-
             break;
 #endif
 #ifdef MODULE_CONN_IP


### PR DESCRIPTION
`recvfrom()` should work on connectionless transports without an explicit `bind()`. As for other POSIX socket implementations, the implicit bind is now performed within the `sendto()` call. ~~Another solution would be to do the (implicit) bind during the `sendto()` call, but IMO it's preferable to do this as late as possible.~~