### PR TITLE
gnrc conn: enqueue packets if noone's waiting

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -76,6 +76,10 @@
 #include "net/gnrc/udp.h"
 #endif
 
+#ifdef MODULE_GNRC_CONN
+#include "net/gnrc/conn.h"
+#endif
+
 #ifdef MODULE_FIB
 #include "net/fib.h"
 #endif
@@ -137,6 +141,10 @@ void auto_init(void)
 #ifdef MODULE_GNRC_UDP
     DEBUG("Auto init UDP module.\n");
     gnrc_udp_init();
+#endif
+#ifdef MODULE_GNRC_CONN
+    DEBUG("Auto init gnrc_conn module.\n");
+    gnrc_conn_init();
 #endif
 
 

--- a/sys/include/net/gnrc/conn.h
+++ b/sys/include/net/gnrc/conn.h
@@ -72,6 +72,11 @@ struct conn_udp {
 };
 
 /**
+ * @brief  Initialize conn's queue
+ */
+void gnrc_conn_init(void);
+
+/**
  * @brief  Bind connection to demux context
  *
  * @internal
@@ -123,6 +128,20 @@ bool gnrc_conn6_set_local_addr(uint8_t *conn_addr, const ipv6_addr_t *addr);
  */
 int gnrc_conn_recvfrom(conn_t *conn, void *data, size_t max_len, void *addr, size_t *addr_len,
                        uint16_t *port);
+
+/**
+ * @brief   Enqueue a new receiption message
+ *
+ * If a packet is received, but currently no application is waiting for it,
+ * the packet can be enqueued in conn. This is required for APIs like POSIX
+ * sockets (e.g., @ref recvfrom()).
+ *
+ * @param[in] m Pointer to message to be queued.
+ *
+ * @return -1 if the buffer is full
+ * @return position of queued item
+ */
+int gnrc_conn_enqueue(msg_t *m);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/conn.h
+++ b/sys/include/net/gnrc/conn.h
@@ -136,6 +136,10 @@ int gnrc_conn_recvfrom(conn_t *conn, void *data, size_t max_len, void *addr, siz
  * the packet can be enqueued in conn. This is required for APIs like POSIX
  * sockets (e.g., @ref recvfrom()).
  *
+ * @todo This is a workaround and creates the risk of starvation if there are
+ * multiple open connections. In order to have a better solution, a more
+ * fundamental change, e.g. an IPC with various endpoints, is required.
+ *
  * @param[in] m Pointer to message to be queued.
  *
  * @return -1 if the buffer is full

--- a/sys/net/gnrc/conn/gnrc_conn.c
+++ b/sys/net/gnrc/conn/gnrc_conn.c
@@ -41,7 +41,7 @@ int gnrc_conn_recvfrom(conn_t *conn, void *data, size_t max_len, void *addr, siz
                        uint16_t *port)
 {
     msg_t msg;
-    /* TODO: this is a rather arbirtrary value and creates the risk of starvation. */
+    /* TODO: this is a rather arbitrary value and creates the risk of starvation. */
     int timeout = 3;
     unsigned enqueued_msgs = cib_avail(&_conn_buf_cib);
     while ((timeout--) > 0) {

--- a/sys/net/gnrc/conn/gnrc_conn.c
+++ b/sys/net/gnrc/conn/gnrc_conn.c
@@ -87,6 +87,15 @@ int gnrc_conn_recvfrom(conn_t *conn, void *data, size_t max_len, void *addr, siz
                     *port = byteorder_ntohs(((udp_hdr_t *)l4hdr->data)->src_port);
                 }
 #endif  /* defined(MODULE_CONN_UDP) */
+                if (((ipv6_hdr_t *)l3hdr->data)->nh != (uint8_t)conn->netreg_entry.demux_ctx) {
+                    /* if the packet in the queue does not match protocol
+                     * number, we enqueue it again */
+                    gnrc_conn_enqueue(&msg);
+                    /* reset the timeout value to the previous one */
+                    timeout++;
+                    continue;
+                }
+
                 if (addr != NULL) {
                     memcpy(addr, &((ipv6_hdr_t *)l3hdr->data)->src, sizeof(ipv6_addr_t));
                     *addr_len = sizeof(ipv6_addr_t);

--- a/sys/net/gnrc/conn/gnrc_conn.c
+++ b/sys/net/gnrc/conn/gnrc_conn.c
@@ -41,6 +41,7 @@ int gnrc_conn_recvfrom(conn_t *conn, void *data, size_t max_len, void *addr, siz
                        uint16_t *port)
 {
     msg_t msg;
+    /* TODO: this is a rather arbirtrary value and creates the risk of starvation. */
     int timeout = 3;
     unsigned enqueued_msgs = cib_avail(&_conn_buf_cib);
     while ((timeout--) > 0) {


### PR DESCRIPTION
Currently gnrc in combination with POSIX sockets will discard packets if `recvfrom()` is not called before.

Another part for fixing #4320.