### PR TITLE
sixlowpan: iphc: minor optimizations

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -313,11 +313,8 @@ size_t gnrc_sixlowpan_iphc_decode(gnrc_pktsnip_t *ipv6, gnrc_pktsnip_t *pkt, siz
             ipv6_addr_set_unspecified(&ipv6_hdr->dst);
             ipv6_hdr->dst.u8[0] = 0xff;
             ipv6_hdr->dst.u8[1] = iphc_hdr[payload_offset++];
-            ipv6_hdr->dst.u8[11] = iphc_hdr[payload_offset++];
-            ipv6_hdr->dst.u8[12] = iphc_hdr[payload_offset++];
-            ipv6_hdr->dst.u8[13] = iphc_hdr[payload_offset++];
-            ipv6_hdr->dst.u8[14] = iphc_hdr[payload_offset++];
-            ipv6_hdr->dst.u8[15] = iphc_hdr[payload_offset++];
+            memcpy(ipv6_hdr->dst.u8 + 11, iphc_hdr + payload_offset, 5);
+            payload_offset += 5;
             break;
 
         case IPHC_M_DAC_DAM_M_32:
@@ -325,9 +322,8 @@ size_t gnrc_sixlowpan_iphc_decode(gnrc_pktsnip_t *ipv6, gnrc_pktsnip_t *pkt, siz
             ipv6_addr_set_unspecified(&ipv6_hdr->dst);
             ipv6_hdr->dst.u8[0] = 0xff;
             ipv6_hdr->dst.u8[1] = iphc_hdr[payload_offset++];
-            ipv6_hdr->dst.u8[13] = iphc_hdr[payload_offset++];
-            ipv6_hdr->dst.u8[14] = iphc_hdr[payload_offset++];
-            ipv6_hdr->dst.u8[15] = iphc_hdr[payload_offset++];
+            memcpy(ipv6_hdr->dst.u8 + 13, iphc_hdr + payload_offset, 3);
+            payload_offset += 3;
             break;
 
         case IPHC_M_DAC_DAM_M_8:


### PR DESCRIPTION
Some very minor optimizations. Saves ~24 bytes of ROM for a few boards only. I have no strong opinion on this however. It's your call @authmillenon 

Stats for `gnrc_networking` example.
```
text    data    bss     dec     BOARD/BINDIRBASE
0       0       0       0       arduino-due
57280   224     19896   77400   master-bin
57280   224     19896   77400   iphc-bin

0       0       0       0       arduino-mega2560
81218   10360   13750   105328  master-bin
81218   10360   13750   105328  iphc-bin

0       0       0       0       avsextrem
129268  2332    95961   227561  master-bin
129268  2332    95961   227561  iphc-bin

0       0       0       0       cc2538dk
57204   220     19872   77296   master-bin
57204   220     19872   77296   iphc-bin

0       0       0       0       ek-lm4f120xl
57092   220     19864   77176   master-bin
57092   220     19864   77176   iphc-bin

0       0       0       0       f4vi1
57156   224     19864   77244   master-bin
57156   224     19864   77244   iphc-bin

-24     0       0       -24     fox
72884   220     22944   96048   master-bin
72860   220     22944   96024   iphc-bin

0       0       0       0       frdm-k64f
59132   1248    19864   80244   master-bin
59132   1248    19864   80244   iphc-bin

-24     0       0       -24     iotlab-m3
72608   220     22944   95772   master-bin
72584   220     22944   95748   iphc-bin

0       0       0       0       limifrog-v1
58344   220     20000   78564   master-bin
58344   220     20000   78564   iphc-bin

0       0       0       0       mbed_lpc1768
56868   220     19872   76960   master-bin
56868   220     19872   76960   iphc-bin

-40     0       0       -40     msba2
156228  2332    95961   254521  master-bin
156188  2332    95961   254481  iphc-bin

0       0       0       0       msbiot
57588   224     19880   77692   master-bin
57588   224     19880   77692   iphc-bin

-24     0       0       -24     mulle
77376   1284    23224   101884  master-bin
77352   1284    23224   101860  iphc-bin

0       0       0       0       native
192318  624     114200  307142  master-bin
192318  624     114200  307142  iphc-bin

0       0       0       0       nucleo-f091
60520   220     19872   80612   master-bin
60520   220     19872   80612   iphc-bin

0       0       0       0       nucleo-f303
57252   220     19880   77352   master-bin
57252   220     19880   77352   iphc-bin

0       0       0       0       nucleo-l1
58276   220     19992   78488   master-bin
58276   220     19992   78488   iphc-bin

0       0       0       0       openmote
57112   220     19872   77204   master-bin
57112   220     19872   77204   iphc-bin

-24     0       0       -24     pba-d-01-kw2x
74464   1248    23296   99008   master-bin
74440   1248    23296   98984   iphc-bin

0       0       0       0       pttu
129476  2332    95961   227769  master-bin
129476  2332    95961   227769  iphc-bin

0       0       0       0       remote
57768   220     19872   77860   master-bin
57768   220     19872   77860   iphc-bin

0       0       0       0       saml21-xpro
60728   220     19992   80940   master-bin
60728   220     19992   80940   iphc-bin

-20     0       0       -20     samr21-xpro
77688   220     22960   100868  master-bin
77668   220     22960   100848  iphc-bin

0       0       0       0       slwstk6220a
56868   220     20000   77088   master-bin
56868   220     20000   77088   iphc-bin

0       0       0       0       stm32f3discovery
57260   220     19880   77360   master-bin
57260   220     19880   77360   iphc-bin

0       0       0       0       stm32f4discovery
57444   224     19872   77540   master-bin
57444   224     19872   77540   iphc-bin

0       0       0       0       udoo
57280   224     19896   77400   master-bin
57280   224     19896   77400   iphc-bin
```