### PR TITLE
cpu/cortexm_common: enable custom newlib syscalls w/ newlib_syscalls_X

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -270,6 +270,11 @@ ifneq (,$(filter gnrc_pktdump,$(USEMODULE)))
 endif
 
 ifneq (,$(filter newlib,$(USEMODULE)))
+  # allow custom newlib syscalls implementations by adding
+  # newlib_syscalls_XXX to USEMODULE
+  ifeq (,$(filter newlib_syscalls_%,$(USEMODULE)))
+    USEMODULE += newlib_syscalls_default
+  endif
   USEMODULE += uart_stdio
 endif
 

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -61,7 +61,7 @@ ifneq (,$(filter log_%,$(USEMODULE)))
     include $(RIOTBASE)/sys/log/Makefile.include
 endif
 
-ifneq (,$(filter newlib,$(USEMODULE)))
+ifneq (,$(filter newlib_syscalls_default,$(USEMODULE)))
     include $(RIOTBASE)/sys/newlib/Makefile.include
 endif
 

--- a/sys/newlib/Makefile
+++ b/sys/newlib/Makefile
@@ -1,1 +1,3 @@
+MODULE = newlib_syscalls_default
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/newlib/Makefile.include
+++ b/sys/newlib/Makefile.include
@@ -1,4 +1,4 @@
-UNDEF := $(BINDIR)newlib/syscalls.o $(UNDEF)
+UNDEF := $(BINDIR)newlib_syscalls_default/syscalls.o $(UNDEF)
 
 # Search for Newlib include directories
 


### PR DESCRIPTION
This change lets downstream developers provide a custom syscalls.c for newlib by providing a `HAVE_NEWLIB_SYSCALLS` make variable. I'm currently using this in my WIP implementation of [VFS](https://github.com/marshall/kubos-core/tree/vfs/modules/fs) and FatFs RIOT modules for [KubOS](https://github.com/openkosmosorg/kubos-core)

An alternative approach would be to make a pluggable driver that is called from the existing `newlib` module, which I'm open to doing as well :)