### PR TITLE
Fix UDP/ICMPv6 checksum for a sliced/accumulated payload.

### DIFF
--- a/sys/include/net/inet_csum.h
+++ b/sys/include/net/inet_csum.h
@@ -21,13 +21,15 @@
 #define INET_CSUM_H_
 
 #include <inttypes.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @brief   Calculates the unnormalized Internet Checksum of @p buf.
+ * @brief   Calculates the unnormalized Internet Checksum of @p buf, where the
+ *          buffer provides a slice of the full checksum domain, calculated in order.
  *
  * @see <a href="https://tools.ietf.org/html/rfc1071">
  *          RFC 1071
@@ -35,14 +37,41 @@ extern "C" {
  *
  * @details The Internet Checksum is not normalized (i. e. its 1's complement
  *          was not taken of the result) to use it for further calculation.
+ *          This function handles padding an odd number of bytes across the full domain.
  *
- * @param[in] sum   An initial value for the checksum.
- * @param[in] buf   A buffer.
- * @param[in] len   Length of @p buf in byte.
+ * @param[in] sum       An initial value for the checksum.
+ * @param[in] buf       A buffer.
+ * @param[in] len       Length of @p buf in byte.
+ * @param[in] accum_len Accumulated length of checksum domain that has already
+ *                      been checksummed.
  *
  * @return  The unnormalized Internet Checksum of @p buf.
  */
-uint16_t inet_csum(uint16_t sum, const uint8_t *buf, uint16_t len);
+uint16_t inet_csum_slice(uint16_t sum, const uint8_t *buf, uint16_t len, size_t accum_len);
+
+/**
+ * @brief   Calculates the unnormalized Internet Checksum of @p buf, where the
+ *          buffer provides a standalone domain for the checksum.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc1071">
+ *          RFC 1071
+ *      </a>
+ *
+ * @details The Internet Checksum is not normalized (i. e. its 1's complement
+ *          was not taken of the result) to use it for further calculation.
+ *          This function, rather than inet_csum_slice(), has been used historically
+ *          when we are not concerned with padding for an odd number of bytes.
+ *
+ *
+ * @param[in] sum       An initial value for the checksum.
+ * @param[in] buf       A buffer.
+ * @param[in] len       Length of @p buf in byte.
+ *
+ * @return  The unnormalized Internet Checksum of @p buf.
+ */
+static inline uint16_t inet_csum(uint16_t sum, const uint8_t *buf, uint16_t len) {
+    return inet_csum_slice(sum, buf, len, 0);
+}
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
+++ b/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
@@ -42,7 +42,7 @@ static inline uint16_t _calc_csum(gnrc_pktsnip_t *hdr,
     uint16_t len = (uint16_t)hdr->size;
 
     while (payload && (payload != hdr)) {
-        csum = inet_csum(csum, payload->data, payload->size);
+        csum = inet_csum_slice(csum, payload->data, payload->size, len);
         len += (uint16_t)payload->size;
         payload = payload->next;
     }

--- a/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
+++ b/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
@@ -69,7 +69,7 @@ static uint16_t _calc_csum(gnrc_pktsnip_t *hdr, gnrc_pktsnip_t *pseudo_hdr,
 
     /* process the payload */
     while (payload && payload != hdr) {
-        csum = inet_csum(csum, (uint8_t *)(payload->data), payload->size);
+        csum = inet_csum_slice(csum, (uint8_t *)(payload->data), payload->size, len);
         len += (uint16_t)payload->size;
         payload = payload->next;
     }


### PR DESCRIPTION
The checksum calculation for UDP and ICMPv6 allows for looping through multiple payload snips. However, inet_csum() always zero-padded on an odd number of bytes, even if not the last snip in the payload.

I have not yet looked into unit testing in RIOT, but I plan to create a test case for this situation. First, I wanted to confirm my solution is reasonable.

You might ask why someone would need multiple payload snips. Well, a [GNRC CoAP implementation](https://github.com/kb2ma/RIOT/tree/gcoap/client) might use such a thing. :-) First things first.