### PR TITLE
Flash device emulation w/ MCI driver for native

### DIFF
--- a/cpu/native/Makefile
+++ b/cpu/native/Makefile
@@ -6,6 +6,10 @@ ifneq (,$(filter netdev2_tap,$(USEMODULE)))
 	DIRS += netdev2_tap
 endif
 
+ifneq (,$(filter mci,$(USEMODULE)))
+	DIRS += mci
+endif
+
 include $(RIOTBASE)/Makefile.base
 
 INCLUDES = $(NATIVEINCLUDES)

--- a/cpu/native/mci/Makefile
+++ b/cpu/native/mci/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/cpu/native/mci/native-mci.c
+++ b/cpu/native/mci/native-mci.c
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) Lucas Jenß
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup native
+ * @{
+ */
+
+/**
+ * @file
+ * @brief   Emulates the MCI storage driver by providing an in-memory
+ *          backend. It is 8MiB by default and its size can be increased
+ *          using `NATIVE_MCI_SIZE_MULTIPLIER` which gets multiplied by
+ *          one MiB, resulting in the actual size of the virtual disk.
+ *          Additional parameters are:
+ *
+ *              Sector (page) size: 512B
+ *              Eerase Block size: 512KiB (524288 Bytes)
+ *
+ * @author  Lucas Jenß <lucas@x3ro.de>
+ *
+ */
+
+#include <string.h>
+#include <stdbool.h>
+#include "diskio.h"
+
+#include "storage/flash_sim.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#ifndef NATIVE_MCI_SIZE_MULTIPLIER
+#define NATIVE_MCI_SIZE_MULTIPLIER 8
+#endif
+
+#define NATIVE_MCI_SIZE (1024 * 1024 * NATIVE_MCI_SIZE_MULTIPLIER)
+#define NATIVE_MCI_SECTOR_SIZE (512)
+#define NATIVE_MCI_BLOCK_SIZE (512 * 1024)
+#define NATIVE_MCI_SECTOR_COUNT (NATIVE_MCI_SIZE / NATIVE_MCI_SECTOR_SIZE)
+
+flash_sim fs;
+
+bool _validate_parameters(unsigned long sector, unsigned char count) {
+    if(count < 1) {
+        return false;
+    }
+
+    if(sector + count > NATIVE_MCI_SECTOR_COUNT) {
+        return false;
+    }
+
+    return true;
+}
+
+DSTATUS MCI_initialize(void) {
+    fs.page_size = NATIVE_MCI_SECTOR_SIZE;
+    fs.block_size = NATIVE_MCI_BLOCK_SIZE;
+    fs.storage_size = NATIVE_MCI_SIZE;
+    flash_sim_init(&fs);
+
+    return RES_OK;
+}
+
+DSTATUS MCI_status(void) {
+    return RES_OK;
+}
+
+/* Read |count| sectors starting at |sector| (LBA) */
+DRESULT MCI_read(unsigned char *buff, unsigned long sector, unsigned char count) {
+    if(!_validate_parameters(sector, count)) {
+        return RES_PARERR;
+    }
+
+    for(unsigned int i=0; i<count; i++) {
+        unsigned char *page_buffer = buff + (i * NATIVE_MCI_SECTOR_SIZE);
+        flash_sim_read(&fs, page_buffer, sector + i);
+    }
+
+    return RES_OK;
+}
+
+/* Write |count| sectors starting at |sector| (LBA) */
+DRESULT MCI_write(const unsigned char *buff, unsigned long sector, unsigned char count) {
+    if(!_validate_parameters(sector, count)) {
+        return RES_PARERR;
+    }
+
+    for(unsigned int i=0; i<count; i++) {
+        unsigned char *page_buffer = ((unsigned char*) buff) + (i * NATIVE_MCI_SECTOR_SIZE);
+        flash_sim_write(&fs, page_buffer, sector + i);
+    }
+
+    return RES_OK;
+}
+
+DRESULT MCI_ioctl(
+    unsigned char ctrl,     /* Control code */
+    void *buff              /* Buffer to send/receive data block */
+) {
+    DRESULT res = RES_ERROR;
+    unsigned long block;
+
+    switch(ctrl) {
+
+        /* Get number of sectors on the disk (unsigned long) */
+        case GET_SECTOR_COUNT:
+            *(unsigned long *) buff = NATIVE_MCI_SECTOR_COUNT;
+            res = RES_OK;
+            break;
+
+        /* Get sector (page) size (unsigned short) */
+        case GET_SECTOR_SIZE:
+            *(unsigned short *) buff = NATIVE_MCI_SECTOR_SIZE;
+            res = RES_OK;
+            break;
+
+        /* Get erase block size (unsigned long) */
+        case GET_BLOCK_SIZE:
+            *(unsigned long *) buff = NATIVE_MCI_BLOCK_SIZE;
+            res = RES_OK;
+            break;
+
+        /* Erase a block of sectors */
+        case CTRL_ERASE_SECTOR:
+            block = *(unsigned long *)buff;
+
+            if(!_validate_parameters(block, 1)) {
+                return RES_PARERR;
+            }
+
+            flash_sim_erase(&fs, block);
+            res = RES_OK;
+            break;
+
+        /* Get card type flags (1 byte) */
+        case MMC_GET_TYPE:
+            // Not implemented
+            break;
+
+        /* Get CSD (16 bytes) */
+        case MMC_GET_CSD:
+            // Not implemented
+            break;
+
+        /* Get CID (16 bytes) */
+        case MMC_GET_CID:
+            // Not implemented
+            break;
+
+        /* Get OCR (4 bytes) */
+        case MMC_GET_OCR:
+            // Not implemented
+            break;
+
+        /* Receive SD status as a data block (64 bytes) */
+        case MMC_GET_SDSTAT:
+            // Not implemented
+            break;
+
+        /* No-Ops for virtual MCI */
+        case CTRL_SYNC: /* Make sure that all data has been written on the media */
+        case CTRL_POWER: /* Power on/off */
+            res = RES_OK;
+            break;
+
+        default:
+            res = RES_PARERR;
+    }
+
+    return res;
+}

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -67,6 +67,9 @@ endif
 ifneq (,$(filter udp,$(USEMODULE)))
     DIRS += net/transport_layer/udp
 endif
+ifneq (,$(filter flash_sim,$(USEMODULE)))
+    DIRS += storage/flash_sim
+endif
 
 ifneq (,$(filter hamming256,$(USEMODULE)))
     DIRS += ecc/hamming256

--- a/sys/include/storage/flash_sim.h
+++ b/sys/include/storage/flash_sim.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2015 Lucas Jenß
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_storage
+ * @brief
+ * @{
+ *
+ * @brief       Simulates flash memory for easier testing of storage subsystems
+ * @author      Lucas Jenß <lucas@x3ro.de>
+ */
+
+#ifndef _FS_FLASH_SIM_H
+#define _FS_FLASH_SIM_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Configuration for the flash simulation layer
+ */
+typedef struct flash_sim {
+    uint32_t page_size;         //!< Page size to be emulated
+    uint32_t block_size;        //!< Block size (must be a multiple of the page size)
+    uint64_t storage_size;      //!< Total amount of storage to be made available
+
+    uint32_t pages;             //!< Number of pages (computed from the above)
+    FILE *_fp;                  //!< File descriptor for the file simulating the flash device
+} flash_sim;
+
+
+/**
+ * @brief Initialize the flash simulation layer with the given configuration struct
+ * @param  fs Configuration
+ * @return    0 on success
+ * @return    -EINVAL if the given configuration struct was invalid
+ * @return    -EBADFD if there was an error with the file used for simulated storage
+ * @return    Any error #flash_sim_format may return
+ */
+int flash_sim_init(flash_sim *fs);
+
+/**
+ * @brief Erases all blocks of the simulated flash device
+ * @param  fs Configuration
+ *
+ * @return    0 on success
+ * @return    -ENODEV if device has not been initialized
+ * @return    -EBADFD if there was an error with the file used for simulated storage
+ */
+int flash_sim_format(flash_sim *fs);
+
+/**
+ * @brief Reads the given page into the provided buffer
+ * @param  fs     Configuration
+ * @param  buffer Target buffer (must be >= the size of a page)
+ * @param  page   Absolute page index to be read
+ *
+ * @return        0 on success
+ * @return        -ENODEV if device has not been initialized
+ * @return        -EFAULT if given page was out of range
+ */
+int flash_sim_read(const flash_sim *fs, void *buffer, uint32_t page);
+
+/**
+ * @brief Partially reads data from the given page into the target buffer
+ * @param  fs     Configuration
+ * @param  buffer Target buffer (must be >= the provided length)
+ * @param  page   Absolute page index to be read
+ * @param  offset Offset inside the page from which to start reading
+ * @param  length Amount of bytes to read
+ *
+ * @return        0 on success
+ * @return        Any error #flash_sim_read may return
+ */
+int flash_sim_read_partial(const flash_sim *fs,
+                                         void *buffer,
+                                         uint32_t page,
+                                         uint32_t offset,
+                                         uint32_t length);
+
+/**
+ * @brief Writes the provided buffer to the given page
+ * @param  fs     Configuration
+ * @param  buffer Source buffer (must be >= the size of a page)
+ * @param  page   Absolute page index to be written to
+ *
+ * @return        0 on success
+ * @return        -ENODEV if device has not been initialized
+ * @return        -EIO if trying to perform an invalid write operation (e.g., setting bits
+ *                back to 1 without erasing first)
+ * @return        -EBADFD if there was an error with the file used for simulated storage
+ * @return        -EFAULT if given page was out of range
+ * @return        Any error #flash_sim_read may return
+ */
+int flash_sim_write(const flash_sim *fs, const void *buffer, uint32_t page);
+
+/**
+ * @brief Partially writes data from the provided buffer to the given page
+ * @param  fs     Configuration
+ * @param  buffer Target buffer (must be >= the provided length)
+ * @param  page   Absolute page index to be written to
+ * @param  offset Offset inside the page indicating where to start writing
+ * @param  length Amount of bytes to write
+ *
+ * @return        0 on success
+ * @return        Any error #flash_sim_read may return
+ * @return        Any error #flash_sim_write may return
+ */
+int flash_sim_write_partial(const flash_sim *fs,
+                                          const void *buffer,
+                                          uint32_t page,
+                                          uint32_t offset,
+                                          uint32_t length);
+
+/**
+ * @brief Erase the given block
+ * @param  fs    Configuration
+ * @param  block Absolute block index
+ *
+ * @return       0 on success
+ * @return       -ENODEV if device has not been initialized
+ * @return       -EBADFD if there was an error with the file used for simulated storage
+ * @return       -EFAULT if given page was out of range
+ */
+int flash_sim_erase(const flash_sim *fs, uint32_t block);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+/** @} */

--- a/sys/storage/doc.txt
+++ b/sys/storage/doc.txt
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2015 Lucas Jenß
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_storage Data Storage
+ * @ingroup     sys
+ *
+ * @brief       RIOT's data storage subsystem
+ */

--- a/sys/storage/flash_sim/Makefile
+++ b/sys/storage/flash_sim/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/storage/flash_sim/README.md
+++ b/sys/storage/flash_sim/README.md
@@ -1,0 +1,7 @@
+# flash_sim
+
+Implements an emulation of flash memory with its common properties:
+
+* Per-page read
+* Per-page write-once
+* Per-sector erase

--- a/sys/storage/flash_sim/flash_sim.c
+++ b/sys/storage/flash_sim/flash_sim.c
@@ -1,0 +1,218 @@
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <errno.h>
+
+#include "storage/flash_sim.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#define MYDEBUG(...) DEBUG("%s: ", __FUNCTION__); \
+                     DEBUG(__VA_ARGS__)
+
+#define FLASH_SIM_FILENAME "flash_sim.dat"
+
+bool _valid_struct_params(flash_sim *fs) {
+    return fs->page_size > 0 &&
+           fs->block_size > 0 &&
+           fs->storage_size > 0 &&
+           (fs->block_size % fs->page_size) == 0 &&
+           (fs->storage_size & fs->block_size) == 0;
+}
+
+int flash_sim_init(flash_sim *fs) {
+    if(!_valid_struct_params(fs)) {
+        return -EINVAL;
+    }
+
+    fs->pages = fs->storage_size / fs->page_size;
+    struct stat buffer;
+    if(stat(FLASH_SIM_FILENAME, &buffer) == 0) {
+        fs->_fp = fopen(FLASH_SIM_FILENAME, "r+");
+    } else {
+        fs->_fp = fopen(FLASH_SIM_FILENAME, "w+");
+    }
+
+    if(fs->_fp == NULL) {
+        MYDEBUG("failed opening file %s\n", FLASH_SIM_FILENAME);
+        return -EBADFD;
+    }
+
+    // Make sure that the file has exactly the right size
+    fseek(fs->_fp, 0, SEEK_END);
+    long size = ftell(fs->_fp);
+
+    if(size == (long) fs->storage_size) {
+        return 0;
+    } else {
+        return flash_sim_format(fs);
+    }
+}
+
+int flash_sim_format(flash_sim *fs) {
+    if(fs->_fp == NULL) {
+        MYDEBUG("struct was not initialized\n");
+        return -ENODEV;
+    }
+
+    int ret = fclose(fs->_fp);
+    if(ret != 0) {
+        MYDEBUG("could not close file\n");
+        return -EBADFD;
+    }
+
+    fs->_fp = fopen(FLASH_SIM_FILENAME, "w+");
+    if(fs->_fp == NULL) {
+        MYDEBUG("failed opening file %s\n", FLASH_SIM_FILENAME);
+        return -EBADFD;
+    }
+
+    unsigned char *buffer = malloc(fs->storage_size);
+    memset(buffer, 0xFF, fs->storage_size);
+    fwrite(buffer, fs->storage_size, 1, fs->_fp);
+
+    return 0;
+}
+
+int flash_sim_read(const flash_sim *fs, void *buffer, uint32_t page) {
+    MYDEBUG("page = %u\n", page);
+
+    if(fs->_fp == NULL) {
+        MYDEBUG("struct was not initialized\n");
+        return -ENODEV;
+    }
+
+    int ret = fseek(fs->_fp, page * fs->page_size, SEEK_SET);
+    if(ret != 0) {
+        MYDEBUG("seek failed: out of range\n");
+        return -EFAULT;
+    }
+
+    ret = fread(buffer, fs->page_size, 1, fs->_fp);
+    if(ret != 1) {
+        MYDEBUG("read failed: out of range\n");
+        return -EFAULT;
+    }
+
+    return 0;
+}
+
+int flash_sim_read_partial(const flash_sim *fs, void *buffer, uint32_t page, uint32_t offset, uint32_t length) {
+    unsigned char *page_buffer = malloc(fs->page_size);
+
+    int ret = flash_sim_read(fs, page_buffer, page);
+    if(ret != 0) {
+        free(page_buffer);
+        return ret;
+    }
+
+    memcpy(buffer, page_buffer + offset, length);
+    free(page_buffer);
+    return 0;
+}
+
+int flash_sim_write_partial(const flash_sim *fs, const void *buffer, uint32_t page, uint32_t offset, uint32_t length) {
+    unsigned char *page_buffer = malloc(fs->page_size);
+    int ret = flash_sim_read(fs, page_buffer, page);
+    if(ret != 0) {
+        MYDEBUG("read failed page = %u\n", page);
+        free(page_buffer);
+        return ret;
+    }
+
+    memcpy(page_buffer+offset, buffer, length);
+    ret = flash_sim_write(fs, page_buffer, page);
+    if(ret != 0) {
+        MYDEBUG("write failed page = %u\n", page);
+        free(page_buffer);
+        return ret;
+    }
+
+    return 0;
+}
+
+int flash_sim_write(const flash_sim *fs, const void *buffer, uint32_t page) {
+    MYDEBUG("page = %u\n", page);
+
+    if(fs->_fp == NULL) {
+        MYDEBUG("struct was not initialized\n");
+        return -ENODEV;
+    }
+
+    bool valid_write = true;
+    unsigned char *page_buffer = malloc(fs->page_size);
+    int ret = flash_sim_read(fs, page_buffer, page);
+    if(ret != 0) {
+        MYDEBUG("read failed page = %u\n", page);
+        free(page_buffer);
+        return ret;
+    }
+    // Make sure that its impossible to set bits back to 1 without erasing
+    for(unsigned int i=0; i<fs->page_size; i++) {
+        if((((unsigned char*) buffer)[i] | page_buffer[i]) > page_buffer[i]) {
+            valid_write = false;
+            break;
+        }
+    }
+    free(page_buffer);
+
+    if(!valid_write) {
+        MYDEBUG("write failed - would have set bits back to 1\n");
+        return -EIO;
+    }
+
+    ret = fseek(fs->_fp, page * fs->page_size, SEEK_SET);
+    if(ret != 0) {
+        MYDEBUG("seek failed: out of range\n");
+        return -EFAULT;
+    }
+
+#if ENABLE_DEBUG
+    long pos = ftell(fs->_fp);
+    MYDEBUG("writing to offset %ld\n", pos);
+#endif
+
+    ret = fwrite(buffer, fs->page_size, 1, fs->_fp);
+    if(ret != 1) {
+        MYDEBUG("write failed\n");
+        return -EBADFD;
+    }
+
+    fflush(fs->_fp);
+    return 0;
+}
+
+int flash_sim_erase(const flash_sim *fs, uint32_t block) {
+    MYDEBUG("block = %u\n", block);
+
+    if(fs->_fp == NULL) {
+        MYDEBUG("struct was not initialized\n");
+        return -ENODEV;
+    }
+
+    unsigned char *buffer = malloc(fs->block_size);
+    memset(buffer, 0xff, fs->block_size);
+
+    int ret = fseek(fs->_fp, block * fs->block_size, SEEK_SET);
+    if(ret != 0) {
+        free(buffer);
+        MYDEBUG("seek failed: out of range\n");
+        return -EFAULT;
+    }
+
+    ret = fwrite(buffer, fs->block_size, 1, fs->_fp);
+    if(ret != 1) {
+        free(buffer);
+        MYDEBUG("write failed\n");
+        return -EBADFD;
+    }
+
+    free(buffer);
+    return 0;
+}
+

--- a/tests/mci/Makefile
+++ b/tests/mci/Makefile
@@ -1,0 +1,11 @@
+APPLICATION = $(shell basename $(shell pwd))
+include ../Makefile.tests_common
+
+USEMODULE += mci
+USEMODULE += flash_sim
+USEMODULE += xtimer
+USEMODULE += embunit
+
+CFLAGS += -g
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/mci/README.md
+++ b/tests/mci/README.md
@@ -1,0 +1,1 @@
+Tests the MCI interface, implemented at least for the MSBA2 and native. If running on hardware, an SD card should be inserted for testing.

--- a/tests/mci/main.c
+++ b/tests/mci/main.c
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2015 Lucas Jenß
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Tests the MCI interface
+ *
+ * @author      Lucas Jenß <lucas@x3ro.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <diskio.h>
+#include <math.h>
+
+#include "embUnit.h"
+#include "xtimer.h"
+#include "lpm.h"
+
+#define SECTOR_SIZE 512
+
+unsigned char teststring1[SECTOR_SIZE + 1];
+unsigned char teststring2[SECTOR_SIZE + 1];
+unsigned char read_buffer[SECTOR_SIZE + 1];
+
+void _zero_end_strings(void) {
+    teststring1[SECTOR_SIZE] = '\0';
+    teststring2[SECTOR_SIZE] = '\0';
+    read_buffer[SECTOR_SIZE] = '\0';
+}
+
+void fill_test_strings(void) {
+    for(int i=0; i<SECTOR_SIZE; i++) {
+        sprintf((char*)teststring1 + i, "%d", i%10);
+    }
+    for(int i=0; i<SECTOR_SIZE; i++) {
+        sprintf((char*)teststring2 + i, "%d", i%2);
+    }
+
+    teststring1[SECTOR_SIZE] = teststring2[SECTOR_SIZE] = '\0';
+}
+
+// Probably the worst way to convert a double to string, but some
+// platforms don't have that (*cough* msba2 *cough*)
+void sprint_double(char *buffer, double x, int precision) {
+    if(precision > 10) {
+        printf("Precision > 10 not supported");
+        precision = 10;
+    }
+
+    long integral_part = (long) x;
+
+    char buf[11];
+    int i = 0;
+    while(precision > 0) {
+        x *= 10;
+        short current_decimal = (short) x;
+        sprintf(buf+i, "%d", current_decimal);
+        i++;
+        precision--;
+    }
+
+    buf[i] = '\0';
+    sprintf(buffer, "%ld.%s", integral_part, buf);
+}
+
+static void main_test(void)
+{
+    DSTATUS status = MCI_initialize();
+    printf("MCI status: 0x%hhx\n", status);
+
+    if(status == STA_NOINIT) {
+        printf("Could not initialize MCI interface :(\n");
+    } else if(status == STA_NODISK) {
+        printf("NO SDCard detected. Aborting\n");
+    } else if(status == STA_PROTECT) {
+        printf("SDCard is in read-only mode\n");
+    }
+
+    TEST_ASSERT_EQUAL_INT(0, status);
+
+    unsigned long sector_count = 0;
+    MCI_ioctl(GET_SECTOR_COUNT, &sector_count);
+    printf("sector_count: %lu\n", sector_count);
+
+    unsigned short sector_size = 0;
+    MCI_ioctl(GET_SECTOR_SIZE, &sector_size);
+    printf("sector_size: %hu\n", sector_size);
+
+    unsigned long block_size = 0;
+    MCI_ioctl(GET_BLOCK_SIZE, &block_size);
+    printf("block_size: %lu\n", block_size);
+
+    double capacity = (1.0 * sector_size * sector_count) / (1024 * 1024 * 1024);
+    char capacity_buffer[8];
+    sprint_double(capacity_buffer, capacity, 2);
+    printf("SDcard capacity: %sGiB\n", capacity_buffer);
+
+#ifdef BOARD_NATIVE
+    // Test virtual MCI parameters
+    TEST_ASSERT_EQUAL_INT(16384, sector_count);
+    TEST_ASSERT_EQUAL_INT(512, sector_size);
+    TEST_ASSERT_EQUAL_INT(524288, block_size);
+#endif
+
+    /*
+     * Perform a read-write check on the SDCard
+     */
+
+    if(sector_size > SECTOR_SIZE) {
+        printf("Does not support a sector size larger than %d, write test aborted.\n", SECTOR_SIZE);
+        return;
+    }
+
+    unsigned char op_sector_count = 1; // Read/write single sector
+
+    printf("About to write the following sector 0:\n%s\n", teststring1);
+    status = MCI_write(teststring1, 0, op_sector_count);
+    printf("MCI write status: 0x%hhx\n", status);
+    TEST_ASSERT_EQUAL_INT(0, status);
+
+    printf("About to write the following to sector 1:\n%s\n", teststring2);
+    status = MCI_write(teststring2, 1, op_sector_count);
+    printf("MCI write status: 0x%hhx\n", status);
+    TEST_ASSERT_EQUAL_INT(0, status);
+
+    printf("About to read from SDCard sector 0\n");
+    status = MCI_read(read_buffer, 0, op_sector_count);
+    _zero_end_strings();
+    printf("MCI read status: 0x%hhx\n", status);
+    printf("Read the following:\n'%s'\n", read_buffer);
+    TEST_ASSERT_EQUAL_INT(0, status);
+    _zero_end_strings();
+    TEST_ASSERT(strcmp((char*) read_buffer, (char*)teststring1) == 0);
+
+    printf("About to read from SDCard sector 1\n");
+    status = MCI_read(read_buffer, 1, op_sector_count);
+    _zero_end_strings();
+    printf("MCI read status: 0x%hhx\n", status);
+    printf("Read the following:\n'%s'\n", read_buffer);
+    TEST_ASSERT_EQUAL_INT(0, status);
+    _zero_end_strings();
+    TEST_ASSERT(strcmp((char*) read_buffer, (char*)teststring2) == 0);
+
+    printf("About to erase sector 0\n");
+    unsigned long block_to_erase = 0;
+    status = MCI_ioctl(CTRL_ERASE_SECTOR, &block_to_erase);
+    TEST_ASSERT_EQUAL_INT(0, status);
+    printf("MCI read status: 0x%hhx\n", status);
+
+    printf("About to read from SDCard sector 1\n");
+    status = MCI_read(read_buffer, 1, op_sector_count);
+    _zero_end_strings();
+    printf("MCI read status: 0x%hhx\n", status);
+    printf("Read the following:\n'%s'\n", read_buffer);
+    printf("Byte 0 was:'%x'\n", read_buffer[0]);
+    TEST_ASSERT(strcmp((char*) read_buffer, (char*)teststring2) != 0);
+}
+
+
+Test *tests(void) {
+    fill_test_strings();
+
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(main_test),
+    };
+
+    EMB_UNIT_TESTCALLER(results, NULL, NULL, fixtures);
+    return (Test *)&results;
+}
+
+
+int main(void)
+{
+#ifdef OUTPUT
+    TextUIRunner_setOutputter(OUTPUTTER);
+#endif
+
+    TESTS_START();
+    TESTS_RUN(tests());
+    TESTS_END();
+
+    puts("xtimer_wait()");
+    xtimer_usleep(100000);
+
+    lpm_set(LPM_POWERDOWN);
+    return 0;
+}

--- a/tests/storage_flash_sim/Makefile
+++ b/tests/storage_flash_sim/Makefile
@@ -1,0 +1,11 @@
+APPLICATION = $(shell basename $(shell pwd))
+include ../Makefile.tests_common
+
+USEMODULE += embunit
+USEMODULE += xtimer
+USEMODULE += flash_sim
+
+INCLUDES += -I$(shell pwd)
+CFLAGS += -DDEVELHELP -g
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/storage_flash_sim/main.c
+++ b/tests/storage_flash_sim/main.c
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) Lucas Jenß
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for flash memory simulation
+ *
+ * @author      Lucas Jenß <lucas@x3ro.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <limits.h>
+#include <errno.h>
+
+#include "embUnit.h"
+#include "xtimer.h"
+#include "lpm.h"
+#include "storage/flash_sim.h"
+
+flash_sim fs;
+int ret;
+char read_buffer[512];
+char write_buffer[512];
+char expect_buffer[512];
+
+void _reset(void) {
+    memset(read_buffer, 0x0, 512);
+    memset(write_buffer, 0x0, 512);
+    memset(expect_buffer, 0x0, 512);
+}
+
+static void test_uninitialized(void) {
+    ret = flash_sim_format(&fs);
+    TEST_ASSERT_EQUAL_INT(-ENODEV, ret);
+
+    ret = flash_sim_read(&fs, read_buffer, 0);
+    TEST_ASSERT_EQUAL_INT(-ENODEV, ret);
+
+    ret = flash_sim_write(&fs, write_buffer, 0);
+    TEST_ASSERT_EQUAL_INT(-ENODEV, ret);
+}
+
+static void test_init(void)
+{
+    _reset();
+
+    ret = flash_sim_init(&fs);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, ret);
+
+    fs.page_size = 512;
+    fs.block_size = 1024*512; // 512 KiB
+    fs.storage_size = 1024*1024*64; // 64MiB
+
+    ret = flash_sim_init(&fs);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+    TEST_ASSERT_EQUAL_INT(131072, fs.pages);
+}
+
+
+
+
+static void test_format(void) {
+    ret = flash_sim_format(&fs);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+
+
+static void test_basic_read_write(void) {
+    _reset();
+
+    ret = flash_sim_read(&fs, read_buffer, 0);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+    memset(expect_buffer, 0xFF, 512);
+    TEST_ASSERT_EQUAL_INT(0, strncmp(read_buffer, expect_buffer, 512));
+
+    memset(write_buffer, 0xAB, 512);
+    ret = flash_sim_write(&fs, write_buffer, 0);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    _reset();
+    memset(expect_buffer, 0xAB, 512);
+    ret = flash_sim_read(&fs, read_buffer, 0);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+    TEST_ASSERT_EQUAL_INT(0, strncmp(read_buffer, expect_buffer, 512));
+}
+
+
+static void test_erase(void) {
+    _reset();
+
+    ret = flash_sim_erase(&fs, 0);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    ret = flash_sim_read(&fs, read_buffer, 0);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+    memset(expect_buffer, 0xFF, 512);
+    TEST_ASSERT_EQUAL_INT(0, strncmp(read_buffer, expect_buffer, 512));
+}
+
+
+static void test_multiple_writes(void) {
+    _reset();
+
+    memset(write_buffer, 0xAB, 512);
+    ret = flash_sim_write(&fs, write_buffer, 0);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    // Issuing the same write twice is valid because no bits in the page are changed
+    ret = flash_sim_write(&fs, write_buffer, 0);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    // Setting any bits back from 0 -> 1 is invalid, though
+    memset(write_buffer, 0xFF, 1);
+    ret = flash_sim_write(&fs, write_buffer, 0);
+    TEST_ASSERT_EQUAL_INT(-EIO, ret);
+}
+
+
+static void test_multiple_writes_to_zero(void) {
+    _reset();
+
+    memset(write_buffer, 0xAB, 512);
+    memset(expect_buffer, 0xAB, 512);
+    ret = flash_sim_write(&fs, write_buffer, 0);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    // Settings bit from 1 -> 0 is valid even if page is not erased first
+    write_buffer[0] = 0x00;
+    ret = flash_sim_write(&fs, write_buffer, 0);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    expect_buffer[0] = 0x00;
+    ret = flash_sim_read(&fs, read_buffer, 0);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+    TEST_ASSERT_EQUAL_INT(0, strncmp(read_buffer, expect_buffer, 512));
+}
+
+static void test_partial_read_write(void) {
+    _reset();
+
+    uint64_t write_test = 0x1234ABCD1234ABCD;
+    uint64_t read_test = 0;
+
+    uint32_t page = 24;
+    flash_sim_erase(&fs, 0);
+
+    // offset=8, length=8
+    ret = flash_sim_write_partial(&fs, (char*)&write_test, page, 8, 8);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    ret = flash_sim_read_partial(&fs, (char*)&read_test, page, 8, 8);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    printf("%llu <- read | write -> %llu\n", read_test, write_test);
+    TEST_ASSERT(read_test == 0x1234ABCD1234ABCD);
+
+    memset(expect_buffer, 0xFF, 512);
+    *((uint64_t*)expect_buffer+1) = 0x1234ABCD1234ABCD;
+    ret = flash_sim_read(&fs, read_buffer, page);
+    TEST_ASSERT_EQUAL_INT(0, strncmp(read_buffer, expect_buffer, 512));
+}
+
+
+static void test_erroneous_reads(void) {
+    ret = flash_sim_read(&fs, read_buffer, 999999);
+    TEST_ASSERT_EQUAL_INT(-EFAULT, ret);
+}
+
+static void test_erroneous_writes(void) {
+    ret = flash_sim_write(&fs, write_buffer, 999999);
+    TEST_ASSERT_EQUAL_INT(-EFAULT, ret);
+}
+
+
+Test *testsrunner(void) {
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_uninitialized),
+        new_TestFixture(test_init),
+        new_TestFixture(test_format),
+        new_TestFixture(test_basic_read_write),
+        new_TestFixture(test_erase),
+        new_TestFixture(test_multiple_writes),
+        new_TestFixture(test_multiple_writes_to_zero),
+        new_TestFixture(test_partial_read_write),
+        new_TestFixture(test_erroneous_reads),
+        new_TestFixture(test_erroneous_writes),
+    };
+
+    EMB_UNIT_TESTCALLER(tests, NULL, NULL, fixtures);
+    return (Test *)&tests;
+}
+
+int main(void)
+{
+#ifdef OUTPUT
+    TextUIRunner_setOutputter(OUTPUTTER);
+#endif
+
+    TESTS_START();
+    TESTS_RUN(testsrunner());
+    TESTS_END();
+
+    puts("xtimer_wait()");
+    xtimer_usleep(100000);
+
+    lpm_set(LPM_POWERDOWN);
+    return 0;
+}


### PR DESCRIPTION
Supersedes #4033
Depends on #4220 

I propose the following "flash simulation layer" for developing/testing RIOT applications, intended to access flash-based storage, on native. It emulates the following characteristics of flash storage:
- Structured as blocks containing pages
- Pages are the smallest unit that can be written to
- Blocks are the smallest unit that can be erased
- Pages cannot be re-written without erasing the parent block first

Also included is an implementation, based on the flash simulation layer, for the existing MCI storage interface (implemented e.g. for the MSBA2 board). 
