### PR TITLE
tools/openocd: check return code of flashing command

### DIFF
--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -153,7 +153,8 @@ do_flash() {
             -c 'verify_image \"${HEXFILE}\"' \
             -c 'reset run' \
             -c 'shutdown'"
-    if [ $? == "0" ]; then
+
+    if [ $? -eq "0" ]; then
         echo 'Done flashing'
     else
         echo 'Error while flashing'
@@ -188,7 +189,8 @@ do_flash_elf() {
             -c 'verify_image \"${ELFFILE}\"' \
             -c 'reset run' \
             -c 'shutdown'"
-    if [ $? == "0" ]; then
+
+    if [ $? -eq "0" ]; then
         echo 'Done flashing'
     else
         echo 'Error while flashing'

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -153,7 +153,12 @@ do_flash() {
             -c 'verify_image \"${HEXFILE}\"' \
             -c 'reset run' \
             -c 'shutdown'"
-    echo 'Done flashing'
+    if [ $? == "0" ]; then
+        echo 'Done flashing'
+    else
+        echo 'Error while flashing'
+        exit 1
+    fi
 }
 
 do_flash_elf() {
@@ -183,7 +188,12 @@ do_flash_elf() {
             -c 'verify_image \"${ELFFILE}\"' \
             -c 'reset run' \
             -c 'shutdown'"
-    echo 'Done flashing'
+    if [ $? == "0" ]; then
+        echo 'Done flashing'
+    else
+        echo 'Error while flashing'
+        exit 1
+    fi
 }
 
 do_debug() {


### PR DESCRIPTION
Up to now, `make flash` will always succeed as the return
value of the flash command is omitted. This can be confusing
when called by statements like `make flash term`.
With this change make will abort if flashing was not successful.

@Kijewski Is `$?` the right value to check?