### PR TITLE
gnrc_netdev2: fix documentation

### DIFF
--- a/sys/include/net/gnrc/netdev2.h
+++ b/sys/include/net/gnrc/netdev2.h
@@ -39,8 +39,6 @@ extern "C" {
 
 #define NETDEV2_MSG_TYPE_EVENT 0x1234
 
-typedef struct gnrc_netdev2 gnrc_netdev2_t;
-
 /**
  * @brief Structure holding gnrc netdev2 adapter state
  *
@@ -49,14 +47,14 @@ typedef struct gnrc_netdev2 gnrc_netdev2_t;
  *
  * It can be extended
  */
-struct gnrc_netdev2 {
+typedef struct gnrc_netdev2 {
     /**
      * @brief Send a pktsnip using this device
      *
      * This function should convert the pktsnip into a format
      * the underlying device understands and send it.
      */
-    int (*send)(gnrc_netdev2_t *dev, gnrc_pktsnip_t *snip);
+    int (*send)(struct gnrc_netdev2 *dev, gnrc_pktsnip_t *snip);
 
     /**
      * @brief Receive a pktsnip from this device
@@ -65,7 +63,7 @@ struct gnrc_netdev2 {
      * device and convert it into a pktsnip while adding a netif header
      * and possibly marking out higher-layer headers.
      */
-    gnrc_pktsnip_t * (*recv)(gnrc_netdev2_t *dev);
+    gnrc_pktsnip_t * (*recv)(struct gnrc_netdev2 *dev);
 
     /**
      * @brief netdev2 handle this adapter is working with
@@ -76,7 +74,7 @@ struct gnrc_netdev2 {
      * @brief PID of this adapter for netapi messages
      */
     kernel_pid_t pid;
-};
+} gnrc_netdev2_t;
 
 /**
  * @brief Initialize gnrc netdev2 handler thread

--- a/sys/include/net/gnrc/netdev2.h
+++ b/sys/include/net/gnrc/netdev2.h
@@ -9,14 +9,14 @@
 /**
  * @defgroup  net_gnrc_netdev2   Adaption layer for GNRC on top of Netdev2
  * @ingroup   net_gnrc
- * @brief     Provides the glue code for @ref gnrc on top of @ref drivers_netdev_netdev2
+ * @brief     Provides the glue code for @ref net_gnrc on top of @ref drivers_netdev_netdev2
  * @{
  *
  * @file
- * @brief     netdev2 gnrc glue code interface
+ * @brief     netdev2-GNRC glue code interface
  *
  * This interface is supposed to provide common adaption code between the
- * low-level network device interface "netdev2" and the gnrc network stack.
+ * low-level network device interface "netdev2" and the GNRC network stack.
  *
  * GNRC sends around "gnrc_pktsnip_t" structures, but netdev can only handle
  * "struct iovec" structures when sending, or a flat buffer when receiving.
@@ -37,13 +37,16 @@
 extern "C" {
 #endif
 
+/**
+ * @brief   Type for @ref msg_t if device fired an event
+ */
 #define NETDEV2_MSG_TYPE_EVENT 0x1234
 
 /**
- * @brief Structure holding gnrc netdev2 adapter state
+ * @brief Structure holding GNRC netdev2 adapter state
  *
  * This structure is supposed to hold any state parameters needed
- * to use a netdev2 device from gnrc.
+ * to use a netdev2 device from GNRC.
  *
  * It can be extended
  */
@@ -77,7 +80,7 @@ typedef struct gnrc_netdev2 {
 } gnrc_netdev2_t;
 
 /**
- * @brief Initialize gnrc netdev2 handler thread
+ * @brief Initialize GNRC netdev2 handler thread
  *
  * @param[in] stack         ptr to preallocated stack buffer
  * @param[in] stacksize     size of stack buffer
@@ -89,7 +92,7 @@ typedef struct gnrc_netdev2 {
  * @return KERNEL_PID_UNDEF on error
  */
 kernel_pid_t gnrc_netdev2_init(char *stack, int stacksize, char priority,
-                        const char *name, gnrc_netdev2_t *gnrc_netdev2);
+                               const char *name, gnrc_netdev2_t *gnrc_netdev2);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes some documentation issues in `gnrc_netdev2`. (The forward declaration was throwing an error in doxygen but is not really needed)