### PR TITLE
core: make assertions easier to spot

### DIFF
--- a/core/panic.c
+++ b/core/panic.c
@@ -35,7 +35,7 @@
 #include "ps.h"
 #endif
 
-const char assert_crash_message[] = "Failed assertion.";
+const char assert_crash_message[] = "FAILED ASSERTION.";
 
 /* flag preventing "recursive crash printing loop" */
 static int crashed = 0;
@@ -53,8 +53,9 @@ NORETURN void core_panic(core_panic_t crash_code, const char *message)
             cpu_print_last_instruction();
         }
 #endif
-        puts("*** RIOT kernel panic");
+        puts("*** RIOT kernel panic:");
         puts(message);
+        puts("");
 #ifdef DEVELHELP
 #ifdef MODULE_PS
         ps();


### PR DESCRIPTION
It's currently rather hard to spot if a failing assertion was causing the panic. This PR tries to make it a little bit easier without wasting ROM.