### PR TITLE
make: include Makefile.iotlab for iotlab-* goals

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -436,5 +436,7 @@ info-modules:
 	@for i in $(sort $(USEMODULE)); do echo $$i; done
 
 ifneq (,$(filter iotlab-m3 wsn430-v1_3b wsn430-v1_4,$(BOARD)))
-  include $(RIOTBASE)/dist/testbed-support/Makefile.iotlab
+  ifneq (,$(filter iotlab-%,$(MAKECMDGOALS)))
+    include $(RIOTBASE)/dist/testbed-support/Makefile.iotlab
+  endif
 endif


### PR DESCRIPTION
Only include `Makefile.iotlab` when one of the `iotlab-*` goals was specified.
Without this change every attempt to compile an example application for the `iotlab-m3` and `wsn430*`boards
will trigger the `experiment-cli` within the `Makefile.iotlab` unnecessarily. This results in a slow start of the compilation process and even results in an error if no `.iotlabrc` exists in the users `$HOME` or if `experiment-cli` was not installed.