### PR TITLE
Add and configure Vagrant for RIOT-OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ pkg/openwsn/openwsn
 pkg/relic/relic
 pkg/tlsf/tlsf
 pkg/wakaama/wakaama
+
+# Vagrant
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,57 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "boxcutter/ubuntu1510"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  config.vm.network "forwarded_port", guest: 4242, host: 4242
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Set name of the VM
+    vb.name = "RIOT-OS VM"
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  #   # enable usb passthrough
+    vb.customize ["modifyvm", :id, "--usb", "on"]
+    vb.customize ["modifyvm", :id, "--usbxhci", "on"]
+    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'FTDI USB-TTL',
+                  '--vendorid', '0x0403', '--productid',  '0x6001']
+    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'CP2102 USB to UART',
+                  '--vendorid', '0x10c4', '--productid',  '0xea60']
+    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'STM32 STLink',
+                  '--vendorid', '0x0483', '--productid',  '0x3748']
+    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'USBasp',
+                  '--vendorid', '0x16c0', '--productid',  '0x05dc']
+    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'iotlab-m3',
+                  '--vendorid', '0x0403', '--productid',  '0x6010']
+    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'samr21-xpro',
+                  '--vendorid', '0x03eb', '--productid',  '0x2111']
+    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'Arduino Mega 2560',
+                  '--vendorid', '0x2341', '--productid',  '0x0042']
+  end
+
+  config.vm.provision "file", source: "~/.gitconfig", destination: ".gitconfig"
+  config.vm.provision "shell", path: "dist/tools/vagrant/bootstrap.sh"
+end

--- a/dist/tools/vagrant/README.md
+++ b/dist/tools/vagrant/README.md
@@ -1,0 +1,56 @@
+# RIOT VM
+
+
+## About
+This repository includes a [Vagrantfile](https://github.com/RIOT-OS/RIOT/blob/master/Vagrantfile)
+to create and control a Linux virtual machine based on an Ubuntu Trusty (64-bit) image that contains
+all necessary toolchains and dependencies to build and flash compatible devices with RIOT-OS.
+The advantage of using this VM is to have a reproducable, portable and even disposable environment
+that can be used to develop for RIOT-OS with decreased setup times and without the requirement of
+making changes to the underlying host system.
+
+## Requirements
+Make sure your system satisfies the latest version of all following dependencies:
+* [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+* [VirtualBox Exntension Pack](https://www.virtualbox.org/wiki/Downloads)
+* [Vagrant](https://www.vagrantup.com/downloads.html)
+
+## Usage
+The following commands must be run from the RIOT-OS root directory on the host system.
+
+```
+vagrant up
+```
+This will start up the virtual machine and download the Ubuntu image as well as all necessary toolchains.
+```
+vagrant ssh
+```
+This will logs you in to the VM as the vagrant user.
+```
+vagrant halt
+```
+This will shut down the VM gracefully.
+```
+vagrant destroy
+```
+This will reset your VM to the default state. All modifications made to the VM by the
+[provisioning script](https://github.com/RIOT-OS/RIOT/tree/master/dist/tools/vagrant/bootstrap.sh)
+and by you will be removed.
+```
+vagrant provision
+```
+This will re-run the [provisioning script](https://github.com/RIOT-OS/RIOT/tree/master/dist/tools/vagrant/bootstrap.sh).
+
+## Inside the VM
+Once logged in to the VM via `vagrant ssh` you can find the RIOT-OS root directory in your
+working directory. This is a shared directory and stays synchronized with your RIOT-OS directory
+on the host system. All changes made will be mirrored from the host system to the guest system
+and vice versa.
+
+This feature allows you to conveniently develop code for RIOT-OS with your preferred IDE on
+your host system and use the VM for compiling, flashing devices and running the native port of RIOT-OS.
+
+## Additional Information
+For new boards it is necessary to add new udev rules to `dist/tools/vagrant/udev_rules` and
+additional usb filters to the Vagrantfile so that VirtualBox is able to capture the devices.
+The needed `vendor id` and `product id` can be obtained by running `vboxmanage list usbhost`.

--- a/dist/tools/vagrant/bootstrap.sh
+++ b/dist/tools/vagrant/bootstrap.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+apt-get update
+apt-get install -y pcregrep libpcre3 python3 git gcc-arm-none-eabi gcc-msp430 unzip \
+    qemu-system-x86 g++-multilib gcc-multilib build-essential gcc-avr binutils-avr avr-libc \
+    avrdude doxygen cppcheck python-setuptools libusb-1.0-0 libusb-1.0-0-dev libftdi1 libftdi-dev \
+    libftdipp1-dev libftdipp1-2v5 libhidapi-dev libhidapi-hidraw0 libhidapi-libusb0 make cmake \
+    autotools-dev autoconf pkg-config jimsh libtool valgrind openocd python-serial python3-serial
+
+# give permissions for serial ports
+adduser vagrant dialout
+
+if ! hash st-util 2>/dev/null; then
+    git clone --depth 1 https://github.com/texane/stlink stlink.git && cd stlink.git
+    ./autogen.sh && ./configure && make && make install
+    cd .. && rm -rf stlink.git
+fi
+
+# install cli-tools
+if ! hash experiment-cli 2>/dev/null; then
+    wget -qO - https://github.com/iot-lab/cli-tools/archive/1.6.0.tar.gz | tar xz
+    cd cli-tools-1.6.0 && python setup.py install && cd .. && rm -rf cli-tools-1.6.0
+fi
+
+# create a symbolic link to the RIOT-OS directory
+if ! [ -L /home/vagrant/RIOT-OS ]; then
+    ln -fs /vagrant /home/vagrant/RIOT-OS
+    chown -h vagrant:vagrant /home/vagrant/RIOT-OS
+fi
+
+# copy udev rules
+cp -f RIOT-OS/dist/tools/vagrant/udev_rules/*.rules /etc/udev/rules.d/
+udevadm control --reload-rules ; udevadm trigger
+
+# cleanup
+apt-get -y autoremove

--- a/dist/tools/vagrant/udev_rules/45-usb-stlink-v2.rules
+++ b/dist/tools/vagrant/udev_rules/45-usb-stlink-v2.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="3748", MODE="0666", OWNER="vagrant"

--- a/dist/tools/vagrant/udev_rules/52-usbasp.rules
+++ b/dist/tools/vagrant/udev_rules/52-usbasp.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="16c0", ATTR{idProduct}=="05dc", MODE="0666", OWNER="vagrant"

--- a/dist/tools/vagrant/udev_rules/53-usbttl.rules
+++ b/dist/tools/vagrant/udev_rules/53-usbttl.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="0403", ATTR{idProduct}=="6001", MODE="0666", OWNER="vagrant"

--- a/dist/tools/vagrant/udev_rules/99-atmega2560.rules
+++ b/dist/tools/vagrant/udev_rules/99-atmega2560.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="2341", ATTR{idProduct}=="0042", MODE="0666", OWNER="vagrant"

--- a/dist/tools/vagrant/udev_rules/99-hidraw.rules
+++ b/dist/tools/vagrant/udev_rules/99-hidraw.rules
@@ -1,0 +1,1 @@
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0666", OWNER="vagrant"

--- a/dist/tools/vagrant/udev_rules/99-iotlab-m3.rules
+++ b/dist/tools/vagrant/udev_rules/99-iotlab-m3.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="0403", ATTR{idProduct}=="6010", MODE="0666", OWNER="vagrant"

--- a/dist/tools/vagrant/udev_rules/99-samr21-xpro.rules
+++ b/dist/tools/vagrant/udev_rules/99-samr21-xpro.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="03eb", ATTR{idProduct}=="2111", MODE="0666", OWNER="vagrant"


### PR DESCRIPTION
Resulting from an offline discussion with @OlegHahm regarding virtual machines and possibly using vagrant, I compiled this PR that adds a Vagrantfile driving an ubuntu/trusty virtualbox image.

To use this image it is necessary to install vagrant [1], virtualbox **and** the extension pack either from [2] or if available from your package manager.

To start the image, call `vagrant up` from the RIOT root directory.
This will download (only once) the ubuntu/trusty image and then installs all toolchains, the cli-tools
and openocd (0.9.0). This process can take several minutes especially for the first-time call.
If you have more than one network device then you will be prompted to choose the correct one for bridging to have internet connectivity from within the virtual machine.

Calling `vagrant ssh` will enter the virtual machine. In the home directory is a symbolic link `RIOT-OS`, which is a synchronized directory. Thus, every change that will be made to this directory either from the host system or from the guest system will be synchronized immediately **(don't delete anything)**.
This means: It is still possible to develop for RIOT with your favorite editor in your host system and just use
the vagrant machine for building, flashing and running native.

For now, I included just a couple of udev rules (st-link, ftdi, usbasp). Feel free to add more udev rules, but keep in mind that the Vagrantfile has to be extended to include the right usbfilters (exposing the usb devices to the guest system).

`vagrant halt` powers off the virtual machine gracefully.
`vagrant destroy` deletes all changes to the image and resets it to the default state.
`vagrant up` starts the virtual machine and (if not done before, or if destroyed before) installs all toolchains etc.
`vagrant ssh` logs in to the guest system.

I only have a `stm32f4discovery` board at hand right now and I was able to compile the `default` example and flash the board from within the virtual machine.

@emmanuelsearch @thomaseichinger can you try if running the machine and flashing boards do also work on OS X?

Can anybody try with Windows?

[1] https://www.vagrantup.com/
[2] https://www.virtualbox.org/wiki/Downloads