### PR TITLE
core: mutex: don't use atomic function whith ISR's disabled

### DIFF
--- a/core/mutex.c
+++ b/core/mutex.c
@@ -57,8 +57,10 @@ static void mutex_wait(struct mutex_t *mutex)
     unsigned irqstate = disableIRQ();
     DEBUG("%s: Mutex in use. %u\n", sched_active_thread->name, ATOMIC_VALUE(mutex->val));
 
-    if (atomic_set_to_one(&mutex->val)) {
-        /* somebody released the mutex. return. */
+    if (ATOMIC_VALUE(mutex->val) == 0) {
+        /* somebody released the mutex. lock it and return. */
+        ATOMIC_VALUE(mutex->val) = 1;
+
         DEBUG("%s: mutex_wait early out. %u\n", sched_active_thread->name, ATOMIC_VALUE(mutex->val));
         restoreIRQ(irqstate);
         return;


### PR DESCRIPTION
Just stumbled over this: In mutex_wait, IRQ's are disabled. Still, we use atomic_set_to_one() instead of just reading/writing the value.

(Speeds up mutex ping pong by 1.7 percent on SAM R21).