### PR TITLE
drivers: netdev2: factor out common netdev ethernet code

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -33,6 +33,7 @@ endif
 
 ifneq (,$(filter netdev2_tap,$(USEMODULE)))
   USEMODULE += netif
+  USEMODULE += netdev2_eth
 endif
 
 ifneq (,$(filter gnrc_zep,$(USEMODULE)))

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -20,6 +20,7 @@ ifneq (,$(filter dht,$(USEMODULE)))
 endif
 
 ifneq (,$(filter encx24j600,$(USEMODULE)))
+  USEMODULE += netdev2_eth
   USEMODULE += xtimer
 endif
 

--- a/drivers/include/net/netdev2_eth.h
+++ b/drivers/include/net/netdev2_eth.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @ingroup     drivers_netdev_netdev2
+ * @{
+ *
+ * @file
+ * @brief       Definitions for netdev2 common ethernet code
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef NETDEV2_ETH_H
+#define NETDEV2_ETH_H
+
+#include <stdint.h>
+
+#include "netdev2.h"
+#include "net/netopt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Fallback function for netdev2 ethernet devices' _get function
+ *
+ * Supposed to be used by netdev2 drivers as default case.
+ *
+ * @warning Driver *MUST* implement NETOPT_ADDRESS case!
+ *
+ * @param[in]   dev     network device descriptor
+ * @param[in]   opt     option type
+ * @param[out]  value   pointer to store the option's value in
+ * @param[in]   max_len maximal amount of byte that fit into @p value
+ *
+ * @return              number of bytes written to @p value
+ * @return              <0 on error
+ */
+int netdev2_eth_get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len);
+
+/**
+ * @brief   Fallback function for netdev2 ethernet devices' _set function
+ *
+ * @param[in] dev       network device descriptor
+ * @param[in] opt       option type
+ * @param[in] value     value to set
+ * @param[in] value_len the length of @p value
+ *
+ * @return              number of bytes used from @p value
+ * @return              <0 on error
+ */
+int netdev2_eth_set(netdev2_t *dev, netopt_t opt, void *value, size_t value_len);
+
+#ifdef __cplusplus
+}
+#endif
+/** @} */
+#endif /* NETDEV2_ETH_H */

--- a/drivers/netdev2_eth/Makefile
+++ b/drivers/netdev2_eth/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/netdev2_eth/netdev2_eth.c
+++ b/drivers/netdev2_eth/netdev2_eth.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     driver_netdev2_eth
+ * @{
+ *
+ * @file
+ * @brief       Common code for netdev2 ethernet drivers
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <assert.h>
+#include <errno.h>
+
+#include "net/netdev2.h"
+#include "net/eui64.h"
+#include "net/ethernet.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+static int _get_iid(netdev2_t *netdev, eui64_t *value, size_t max_len)
+{
+    if (max_len < sizeof(eui64_t)) {
+        return -EOVERFLOW;
+    }
+
+    uint8_t addr[ETHERNET_ADDR_LEN];
+    netdev->driver->get(netdev, NETOPT_ADDRESS, addr, ETHERNET_ADDR_LEN);
+    ethernet_get_iid(value, addr);
+
+    return sizeof(eui64_t);
+}
+
+int netdev2_eth_get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len)
+{
+    int res = 0;
+
+    switch (opt) {
+        case NETOPT_DEVICE_TYPE:
+            {
+                uint16_t *tgt = (uint16_t *)value;
+                *tgt = NETDEV2_TYPE_ETHERNET;
+                res = 2;
+                break;
+            }
+        case NETOPT_ADDR_LEN:
+        case NETOPT_SRC_LEN:
+            {
+                assert(max_len == 2);
+                uint16_t *tgt = (uint16_t*)value;
+                *tgt=6;
+                res = sizeof(uint16_t);
+                break;
+            }
+        case NETOPT_MAX_PACKET_SIZE:
+            {
+                assert(max_len >= 2);
+                uint16_t *val = (uint16_t*) value;
+                *val = ETHERNET_DATA_LEN;
+                res = sizeof(uint16_t);
+                break;
+            }
+        case NETOPT_IS_WIRED:
+            {
+                res = 1;
+                break;
+            }
+        case NETOPT_IPV6_IID:
+            {
+                return _get_iid(dev, value, max_len);
+            }
+        default:
+            {
+                res = -ENOTSUP;
+                break;
+            }
+    }
+
+    return res;
+}
+
+int netdev2_eth_set(netdev2_t *dev, netopt_t opt, void *value, size_t value_len)
+{
+    (void)dev;
+    (void)value;
+    (void)value_len;
+
+    int res = 0;
+
+    switch (opt) {
+        default:
+            return -ENOTSUP;
+    }
+
+    return res;
+}


### PR DESCRIPTION
Reviewing #4200, I realized that some code was duplicated for the 3rd time. This PR creates a module to factor out the common code of netdev2 ethernet drivers (some get() replies like IS_WIRED or ADDRESS_LEN can be shared).