### PR TITLE
net/gnrc/ipv6: de-inlined ipv6_addr_equal

### DIFF
--- a/sys/include/net/ipv6/addr.h
+++ b/sys/include/net/ipv6/addr.h
@@ -229,21 +229,6 @@ typedef union {
 /** @} */
 
 /**
- * @brief   Checks if two IPv6 addresses are equal.
- *
- * @param[in] a     An IPv6 address.
- * @param[in] b     Another IPv6 address.
- *
- * @return  true, if @p a and @p b are equal
- * @return  false, otherwise.
- */
-static inline bool ipv6_addr_equal(const ipv6_addr_t *a, const ipv6_addr_t *b)
-{
-    return (a->u64[0].u64 == b->u64[0].u64) &&
-           (a->u64[1].u64 == b->u64[1].u64);
-}
-
-/**
  * @brief   Checks if @p addr is unspecified (all zero).
  *
  * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.2">
@@ -447,6 +432,17 @@ static inline bool ipv6_addr_is_solicited_node(const ipv6_addr_t *addr)
            (addr->u8[12] == 0xff);
 }
 
+
+/**
+ * @brief   Checks if two IPv6 addresses are equal.
+ *
+ * @param[in] a     An IPv6 address.
+ * @param[in] b     Another IPv6 address.
+ *
+ * @return  true, if @p a and @p b are equal
+ * @return  false, otherwise.
+ */
+bool ipv6_addr_equal(const ipv6_addr_t *a, const ipv6_addr_t *b);
 
 /**
  * @brief   Checks up to which bit-count two IPv6 addresses match in their

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr.c
@@ -19,6 +19,12 @@
 
 #include "net/ipv6/addr.h"
 
+bool ipv6_addr_equal(const ipv6_addr_t *a, const ipv6_addr_t *b)
+{
+    return (a->u64[0].u64 == b->u64[0].u64) &&
+           (a->u64[1].u64 == b->u64[1].u64);
+}
+
 uint8_t ipv6_addr_match_prefix(const ipv6_addr_t *a, const ipv6_addr_t *b)
 {
     uint8_t prefix_len = 0;


### PR DESCRIPTION
While working on a tool for in-depth code size analysis, I found this one (numbers for `gnrc_networking` example:

iotlab-m3:
```
before:
   text	   data	    bss	    dec	    hex	
  73312	    220	  22944	  96476	  178dc	
after:
   text	   data	    bss	    dec	    hex	
  73056	    220	  22944	  96220	  177dc	
```
--> saved 256 byte ROM

samr21-xpro:
```
before:
   text	   data	    bss	    dec	    hex	
  78936	    220	  22960	 102116	  18ee4	
after:
   text	   data	    bss	    dec	    hex
  78072	    220	  22960	 101252	  18b84   
```
--> **saved 864 byte ROM!!!**

Of course we have a runtime overhead of 1 function call with this PR - the question if we can live with this.

I marked this a RFC, as I wondered if i makes sense, to create some general guidelines for inlining -> do so only if you really know what you are doing and if you are 100% sure the size overhead is justified?!

Further this PR is only one quick try - there might be many more inline functions in RIOT which could be de-inlined to save some significant amount of flash...