### PR TITLE
boards: changed module name to 'board'

### DIFF
--- a/Makefile.defaultmodules
+++ b/Makefile.defaultmodules
@@ -1,3 +1,3 @@
-DEFAULT_MODULE += cpu core sys
+DEFAULT_MODULE += board cpu core sys
 
 DEFAULT_MODULE += auto_init

--- a/Makefile.include
+++ b/Makefile.include
@@ -190,7 +190,6 @@ export CFLAGS += -DRIOT_VERSION=\"$(RIOT_VERSION)\"
 endif
 
 # the binaries to link
-BASELIBS += $(BINDIR)$(BOARD)_base.a
 BASELIBS += $(BINDIR)${APPLICATION}.a
 BASELIBS += $(USEPKG:%=${BINDIR}%.a)
 

--- a/boards/airfy-beacon/Makefile
+++ b/boards/airfy-beacon/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/arduino-due/Makefile
+++ b/boards/arduino-due/Makefile
@@ -1,8 +1,3 @@
-
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
-
-# add a list of board specific subdirectories that should also be build
-DIRS =
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/arduino-mega2560/Makefile
+++ b/boards/arduino-mega2560/Makefile
@@ -1,3 +1,3 @@
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/avsextrem/Makefile
+++ b/boards/avsextrem/Makefile
@@ -1,4 +1,4 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 DIRS = drivers $(RIOTBOARD)/msba2-common
 

--- a/boards/avsextrem/drivers/Makefile
+++ b/boards/avsextrem/drivers/Makefile
@@ -1,4 +1,4 @@
-MODULE =avsextrem_base
+MODULE = board
 include $(RIOTBOARD)/$(BOARD)/Makefile.include
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/cc2538dk/Makefile
+++ b/boards/cc2538dk/Makefile
@@ -1,4 +1,3 @@
-# Tell the Makefile.base which module to build:
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/chronos/Makefile
+++ b/boards/chronos/Makefile
@@ -1,4 +1,4 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 INCLUDES += -I$(RIOTBOARD)/$(BOARD)/drivers/include
 DIRS = drivers

--- a/boards/chronos/drivers/Makefile
+++ b/boards/chronos/drivers/Makefile
@@ -1,3 +1,3 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/ek-lm4f120xl/Makefile
+++ b/boards/ek-lm4f120xl/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/f4vi1/Makefile
+++ b/boards/f4vi1/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/fox/Makefile
+++ b/boards/fox/Makefile
@@ -1,3 +1,3 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/frdm-k64f/Makefile
+++ b/boards/frdm-k64f/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/iotlab-m3/Makefile
+++ b/boards/iotlab-m3/Makefile
@@ -1,3 +1,3 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/limifrog-v1/Makefile
+++ b/boards/limifrog-v1/Makefile
@@ -1,3 +1,3 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/mbed_lpc1768/Makefile
+++ b/boards/mbed_lpc1768/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/msb-430-common/Makefile
+++ b/boards/msb-430-common/Makefile
@@ -1,4 +1,4 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 DIRS = drivers
 

--- a/boards/msb-430-common/drivers/Makefile
+++ b/boards/msb-430-common/drivers/Makefile
@@ -1,4 +1,4 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 include $(RIOTBOARD)/$(BOARD)/Makefile.include
 

--- a/boards/msb-430/Makefile
+++ b/boards/msb-430/Makefile
@@ -1,4 +1,4 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 DIRS = $(RIOTBOARD)/msb-430-common
 

--- a/boards/msb-430h/Makefile
+++ b/boards/msb-430h/Makefile
@@ -1,4 +1,4 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 DIRS = $(RIOTBOARD)/msb-430-common
 

--- a/boards/msba2-common/Makefile
+++ b/boards/msba2-common/Makefile
@@ -1,4 +1,4 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 DIRS = drivers
 

--- a/boards/msba2-common/drivers/Makefile
+++ b/boards/msba2-common/drivers/Makefile
@@ -1,4 +1,4 @@
-MODULE =$(BOARD)_base
+MODULE = board
 include $(RIOTBOARD)/$(BOARD)/Makefile.include
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/msba2/Makefile
+++ b/boards/msba2/Makefile
@@ -1,4 +1,4 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 DIRS = $(RIOTBOARD)/msba2-common
 

--- a/boards/msbiot/Makefile
+++ b/boards/msbiot/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/mulle/Makefile
+++ b/boards/mulle/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/native/Makefile
+++ b/boards/native/Makefile
@@ -1,4 +1,4 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 DIRS = drivers
 

--- a/boards/native/drivers/Makefile
+++ b/boards/native/drivers/Makefile
@@ -1,4 +1,4 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base
 

--- a/boards/nrf51dongle/Makefile
+++ b/boards/nrf51dongle/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/nrf6310/Makefile
+++ b/boards/nrf6310/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/nucleo-f091/Makefile
+++ b/boards/nucleo-f091/Makefile
@@ -1,3 +1,3 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/nucleo-f303/Makefile
+++ b/boards/nucleo-f303/Makefile
@@ -1,3 +1,3 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/nucleo-f334/Makefile
+++ b/boards/nucleo-f334/Makefile
@@ -1,3 +1,3 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/nucleo-f401/Makefile
+++ b/boards/nucleo-f401/Makefile
@@ -1,3 +1,3 @@
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/nucleo-l1/Makefile
+++ b/boards/nucleo-l1/Makefile
@@ -1,3 +1,3 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/openmote/Makefile
+++ b/boards/openmote/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/pba-d-01-kw2x/Makefile
+++ b/boards/pba-d-01-kw2x/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/pca10000/Makefile
+++ b/boards/pca10000/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/pca10005/Makefile
+++ b/boards/pca10005/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/pttu/Makefile
+++ b/boards/pttu/Makefile
@@ -1,4 +1,4 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 DIRS = $(RIOTBOARD)/msba2-common
 

--- a/boards/qemu-i386/Makefile
+++ b/boards/qemu-i386/Makefile
@@ -1,4 +1,4 @@
-MODULE = qemu-i386_base
+MODULE = board
 
 DIRS = $(RIOTBOARD)/x86-multiboot-common
 

--- a/boards/remote/Makefile
+++ b/boards/remote/Makefile
@@ -1,4 +1,3 @@
-# Tell the Makefile.base which module to build:
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/saml21-xpro/Makefile
+++ b/boards/saml21-xpro/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/samr21-xpro/Makefile
+++ b/boards/samr21-xpro/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/slwstk6220a/Makefile
+++ b/boards/slwstk6220a/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/spark-core/Makefile
+++ b/boards/spark-core/Makefile
@@ -1,3 +1,3 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/stm32f0discovery/Makefile
+++ b/boards/stm32f0discovery/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/stm32f3discovery/Makefile
+++ b/boards/stm32f3discovery/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/stm32f4discovery/Makefile
+++ b/boards/stm32f4discovery/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/telosb/Makefile
+++ b/boards/telosb/Makefile
@@ -1,3 +1,3 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/udoo/Makefile
+++ b/boards/udoo/Makefile
@@ -1,7 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
-
-# add a list of board specific subdirectories that should also be build
-DIRS =
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/weio/Makefile
+++ b/boards/weio/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/wsn430-common/Makefile
+++ b/boards/wsn430-common/Makefile
@@ -1,4 +1,4 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 DIRS = drivers
 

--- a/boards/wsn430-common/drivers/Makefile
+++ b/boards/wsn430-common/drivers/Makefile
@@ -1,4 +1,4 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 include $(RIOTBOARD)/$(BOARD)/Makefile.include
 

--- a/boards/wsn430-v1_3b/Makefile
+++ b/boards/wsn430-v1_3b/Makefile
@@ -1,4 +1,4 @@
-MODULE =$(BOARD)_base
+MODULE = board
 
 DIRS = $(RIOTBOARD)/wsn430-common
 

--- a/boards/wsn430-v1_4/Makefile
+++ b/boards/wsn430-v1_4/Makefile
@@ -1,4 +1,4 @@
-MODULE = $(BOARD)_base
+MODULE = board
 
 DIRS = $(RIOTBOARD)/wsn430-common
 

--- a/boards/x86-multiboot-common/Makefile
+++ b/boards/x86-multiboot-common/Makefile
@@ -1,3 +1,3 @@
-MODULE = x86-multiboot-common_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/x86-multiboot-common/Makefile.include
+++ b/boards/x86-multiboot-common/Makefile.include
@@ -46,7 +46,7 @@ LINKFLAGS += -m32 -nostdlib -nostdinc -nostartfiles -nodefaultlibs \
              --prefix=$(NEWLIB_BASE) \
              -Wl,-rpath,$(NEWLIB_BASE)/lib \
              -T$(RIOTBASE)/boards/x86-multiboot-common/linker.ld
-UNDEF += $(BINDIR)x86-multiboot-common_base/startup.o
+UNDEF += $(BINDIR)board/startup.o
 
 BASELIBS += $(NEWLIB_BASE)/lib/libc.a \
             $(NEWLIB_BASE)/lib/libm.a

--- a/boards/yunjia-nrf51822/Makefile
+++ b/boards/yunjia-nrf51822/Makefile
@@ -1,4 +1,3 @@
-# tell the Makefile.base which module to build
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/z1/Makefile
+++ b/boards/z1/Makefile
@@ -1,3 +1,3 @@
-MODULE = $(BOARD)_base
+MODULE = board
 
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
All CPUs are compiled into `cpu.a`, all boards into `xxx_base.a`. This PR unifies this behavior in compiling the board stuff into `board.a`.

This simplifies code size comparisons between platforms, as all modules have the same name now.