### PR TITLE
gnrc_sixlowpan_frag: Make fragmentation non-blocking

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/frag.h
+++ b/sys/include/net/gnrc/sixlowpan/frag.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ * Copyright (C) 2015 Hamburg University of Applied Sciences
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -19,6 +20,7 @@
  * @brief   6LoWPAN Fragmentation definitions
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author  Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  */
 #ifndef GNRC_SIXLOWPAN_FRAG_H_
 #define GNRC_SIXLOWPAN_FRAG_H_
@@ -36,16 +38,28 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Message type for passing one 6LoWPAN fragment down the network stack
+ */
+#define GNRC_SIXLOWPAN_MSG_FRAG_SND    (0x0225)
+
+/**
+ * @brief   Definition of 6LoWPAN fragmentation type.
+ */
+typedef struct {
+    kernel_pid_t pid;       /**< PID of the interface */
+    gnrc_pktsnip_t *pkt;    /**< Pointer to the IPv6 packet to be fragmented */
+    size_t datagram_size;   /**< Length of just the IPv6 packet to be fragmented */
+    uint16_t offset;        /**< Offset of the Nth fragment from the beginning of the
+                             *   payload datagram */
+} gnrc_sixlowpan_msg_frag_t;
+
+/**
  * @brief   Sends a packet fragmented.
  *
- * @param[in] pid           The interface to send the packet over.
- * @param[in] pkt           The packet to send.
- * @param[in] datagram_size The length of just the IPv6 packet. It is the value
- *                          that the gnrc_sixlowpan_frag_t::disp_size field will be
- *                          set to.
+ * @param[in] fragment_msg    Message containing status of the 6LoWPAN
+ *                            fragmentation progress
  */
-void gnrc_sixlowpan_frag_send(kernel_pid_t pid, gnrc_pktsnip_t *pkt,
-                              size_t datagram_size);
+void gnrc_sixlowpan_frag_send(gnrc_sixlowpan_msg_frag_t *fragment_msg);
 
 /**
  * @brief   Handles a packet containing a fragment header.

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -34,6 +34,8 @@
 
 static kernel_pid_t _pid = KERNEL_PID_UNDEF;
 
+static gnrc_sixlowpan_msg_frag_t fragment_msg = {KERNEL_PID_UNDEF, NULL, 0, 0};
+
 #if ENABLE_DEBUG
 static char _stack[GNRC_SIXLOWPAN_STACK_SIZE + THREAD_EXTRA_STACKSIZE_PRINTF];
 #else
@@ -270,10 +272,27 @@ static void _send(gnrc_pktsnip_t *pkt)
         return;
     }
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG
+    else if (fragment_msg.pkt != NULL) {
+        DEBUG("6lo: Fragmentation already ongoing. Dropping packet\n");
+        gnrc_pktbuf_release(pkt2);
+        return;
+    }
     else if (datagram_size <= SIXLOWPAN_FRAG_MAX_LEN) {
         DEBUG("6lo: Send fragmented (%u > %" PRIu16 ")\n",
               (unsigned int)datagram_size, iface->max_frag_size);
-        gnrc_sixlowpan_frag_send(hdr->if_pid, pkt2, datagram_size);
+        msg_t msg;
+
+        fragment_msg.pid = hdr->if_pid;
+        fragment_msg.pkt = pkt2;
+        fragment_msg.datagram_size = datagram_size;
+        /* Sending the first fragment has an offset==0 */
+        fragment_msg.offset = 0;
+
+        /* set the outgoing message's fields */
+        msg.type = GNRC_SIXLOWPAN_MSG_FRAG_SND;
+        msg.content.ptr = (void *)&fragment_msg;
+        /* send message to self */
+        msg_send_to_self(&msg);
     }
     else {
         DEBUG("6lo: packet too big (%u > %" PRIu16 ")\n",
@@ -327,6 +346,12 @@ static void *_event_loop(void *args)
                 reply.content.value = -ENOTSUP;
                 msg_reply(&msg, &reply);
                 break;
+#ifdef MODULE_GNRC_SIXLOWPAN_FRAG
+            case GNRC_SIXLOWPAN_MSG_FRAG_SND:
+                DEBUG("6lo: send fragmented event received\n");
+                gnrc_sixlowpan_frag_send((gnrc_sixlowpan_msg_frag_t *)msg.content.ptr);
+                break;
+#endif
 
             default:
                 DEBUG("6lo: operation not supported\n");


### PR DESCRIPTION
It turned out that the implementation for 6LoWPAN fragmentation has a blocking behaviour (compare #3008). That means, as long has there are fragments to send, it is impossible to do something else in the 6LoWPAN thread, even not receiving packets. This PR tries to fix that. The main idea behind it: The 6LoWPAN thread sends a message to itself for each fragment that has to be send. This way it should be possible to process other messages in between, even if the fragmentation did not finish.

Here is some code that I used for testing. But the more important thing would be an evaluation of not so special scenarios like mine:

A link layer reflector driver that shorts the link. Note that you need to have the same *scr* and *dst* address when doing such kind of loopback. To avoid running into the IPv6 loopback, there is a small workaround in that branch which takes out some loopback checks if `LOOPBACK_MODE` is not defined 
[l2_reflector branch](https://github.com/PeterKietzmann/RIOT/tree/add_l2_reflector_driver)

A manual application that sends UDP packets of different payloads (this is adjustable at the top of main.c)
[plain_udp_test](https://github.com/PeterKietzmann/applications/tree/plain_udp_test/test_for_sixlo_frag)

Attention! Using the above application might cause hard faults on a board. In that case you might want to apply the following patch to increase the stack size of the main thread
[patch file](https://github.com/PeterKietzmann/applications/blob/plain_udp_test/test_for_sixlo_frag/0001-increased-main-stacksize-for-test-app.patch)