### PR TITLE
RPL: DIS modification - reference impl. of IETF draft-ietf-roll-dis-modifications

### DIFF
--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -382,6 +382,21 @@ static inline bool GNRC_RPL_COUNTER_GREATER_THAN(uint8_t A, uint8_t B)
 /** @} */
 
 /**
+ * @anchor  GNRC_RPL_DIS_FLAGS
+ * @name    DIS Flags
+ * @see     <a href="https://tools.ietf.org/html/rfc6550#section-6.2.1">
+ *              RFC 6550, section 6.2.1, Format of the DIS Base Object
+ *          </a>
+ * @see     <a href="https://tools.ietf.org/html/draft-zhong-roll-dis-modifications-00">
+ *              DIS Modifications, draft-zhong-roll-dis-modifications-00
+ *          </a>
+ * @{
+ */
+#define GNRC_RPL_DIS_N                      (1 << 1)
+#define GNRC_RPL_DIS_T                      (1 << 0)
+/**  @} */
+
+/**
  * @brief PID of the RPL thread.
  */
 extern kernel_pid_t gnrc_rpl_pid;
@@ -430,8 +445,9 @@ void gnrc_rpl_send_DIO(gnrc_rpl_instance_t *instance, ipv6_addr_t *destination);
  *
  * @param[in] instance          Pointer to the RPL instance, optional.
  * @param[in] destination       IPv6 addres of the destination.
+ * @param[in] flags             Flags of the DIS message
  */
-void gnrc_rpl_send_DIS(gnrc_rpl_instance_t *instance, ipv6_addr_t *destination);
+void gnrc_rpl_send_DIS(gnrc_rpl_instance_t *instance, ipv6_addr_t *destination, uint8_t flags);
 
 /**
  * @brief   Send a DAO of the @p dodag to the @p destination.

--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -99,7 +99,7 @@ typedef struct __attribute__((packed)) {
  *      </a>
  */
 typedef struct __attribute__((packed)) {
-    uint8_t flags;      /**< unused */
+    uint8_t flags;      /**< see @ref GNRC_RPL_DIS_FLAGS */
     uint8_t reserved;   /**< reserved */
 } gnrc_rpl_dis_t;
 

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -75,7 +75,8 @@ kernel_pid_t gnrc_rpl_init(kernel_pid_t if_pid)
     /* register all_RPL_nodes multicast address */
     gnrc_ipv6_netif_add_addr(if_pid, &ipv6_addr_all_rpl_nodes, IPV6_ADDR_BIT_LEN, 0);
 
-    gnrc_rpl_send_DIS(NULL, (ipv6_addr_t *) &ipv6_addr_all_rpl_nodes);
+    gnrc_rpl_send_DIS(NULL, (ipv6_addr_t *) &ipv6_addr_all_rpl_nodes,
+                      (GNRC_RPL_DIS_N | GNRC_RPL_DIS_T));
     return gnrc_rpl_pid;
 }
 
@@ -260,7 +261,7 @@ void _update_lifetime(void)
                 continue;
             }
             else if ((int32_t)(parent->lifetime - now_sec) <= (GNRC_RPL_LIFETIME_UPDATE_STEP * 2)) {
-                gnrc_rpl_send_DIS(parent->dodag->instance, &parent->addr);
+                gnrc_rpl_send_DIS(parent->dodag->instance, &parent->addr, 0);
             }
         }
     }

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -174,9 +174,9 @@ int _gnrc_rpl_trickle_start(char *arg1)
     return 0;
 }
 
-int _gnrc_rpl_send_dis(void)
+int _gnrc_rpl_send_dis(ipv6_addr_t *addr, uint8_t flags)
 {
-    gnrc_rpl_send_DIS(NULL, (ipv6_addr_t *) &ipv6_addr_all_rpl_nodes);
+    gnrc_rpl_send_DIS(NULL, (ipv6_addr_t *) &ipv6_addr_all_rpl_nodes, flags);
 
     puts("success: send a DIS\n");
     return 0;
@@ -348,8 +348,25 @@ int _gnrc_rpl(int argc, char **argv)
         }
     }
     else if (strcmp(argv[1], "send") == 0) {
-        if ((argc == 3) && (strcmp(argv[2], "dis") == 0)) {
-            return _gnrc_rpl_send_dis();
+        if (strcmp(argv[2], "dis") == 0) {
+            if (argc == 5) {
+                ipv6_addr_t addr;
+                if (ipv6_addr_from_str(&addr, argv[3]) == NULL) {
+                    puts("error: <addr> must be a valid IPv6 address");
+                    return 1;
+                }
+                if (ipv6_addr_is_multicast(&addr)) {
+                    puts("error: <addr> must be a unicast address");
+                    return 1;
+                }
+                return _gnrc_rpl_send_dis(&addr, atoi(argv[4]));
+            }
+            else if (argc == 4) {
+                ipv6_addr_t addr = GNRC_RPL_ALL_NODES_ADDR;
+                return _gnrc_rpl_send_dis(&addr, atoi(argv[3]));
+            }
+            puts("usage:\nunicast:  rpl send dis <unicast_addr> <flags>\n"
+                 "multicast: rpl send dis <flags>");
         }
     }
     else if (strcmp(argv[1], "leaf") == 0) {


### PR DESCRIPTION
A preliminary implementation of [draft-zhong-roll-dis-modifications-00](https://tools.ietf.org/html/draft-zhong-roll-dis-modifications-00). I will label this PR as `WIP` for now, because there are some features from the draft missing (e.g. the `Response Spreading Option`). I will also add a little bit more documentation to this in a later phase and do some further refactorings.
