### PR TITLE
make: prng modules require random header

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -406,3 +406,7 @@ endif
 ifneq (,$(filter phydat,$(USEMODULE)))
   USEMODULE += fmt
 endif
+
+ifneq (,$(filter prng_%,$(USEMODULE)))
+  USEMODULE += random 
+endif


### PR DESCRIPTION
prng_* only chooses the implementation, but doesn't pull in the module.