### PR TITLE
add *.patch to .gitignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 # when the heading is exactly 7 characters long.
 *.md conflict-marker-size=100
 *.txt conflict-marker-size=100
+*.patch binary


### PR DESCRIPTION
Adding patch files to the repository makes our git-based whitespace error checker choke.

This PR adds *.patch files to .gitignore, telling git to tread them as binary files. That way, it doesn't complain about whitespace errors in patch files.