### PR TITLE
doc: Some doxygen ammendments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ doc-man:
 doc-latex:
 	"$(MAKE)" -BC doc/doxygen latex
 
+doc-xml:
+	"$(MAKE)" -BC doc/doxygen xml
+
 docclean:
 	"$(MAKE)" -BC doc/doxygen clean
 

--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -10,6 +10,10 @@ html:
 man:
 	( cat riot.doxyfile ; echo "GENERATE_MAN = yes" ) | doxygen -
 
+.PHONY: xml
+xml:
+	( cat riot.doxyfile ; echo "GENERATE_XML = yes" ) | doxygen -
+
 .PHONY:
 latex:
 	( cat riot.doxyfile ; echo "GENERATE_LATEX= yes" ) | doxygen -

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -815,27 +815,44 @@ EXCLUDE_SYMLINKS       = NO
 # exclude all test directories for example use the pattern */test/*
 
 EXCLUDE_PATTERNS       = */board/*/tools/* \
+                         */boards/*/include/arduino_pinmap.h \
+                         */boards/chronos/drivers/include/display.h \
+                         */boards/*/include/periph_conf.h \
+                         */boards/*/include/board.h \
                          */cpu/*/include/component/* \
                          */cpu/*/include/instance/* \
                          */cpu/*/include/pio/* \
                          */cpu/*/include/atmel/* \
                          */cpu/sam3/include/sam3* \
                          */cpu/sam3/include/system_sam*.h \
+                         */cpu/arm7_common/include/arm7_common.h \
+                         */cpu/arm7_common/include/VIC.h \
                          */cpu/lpc*/include/core_cm*.h \
                          */cpu/cortexm_common/include/core_cm*.h \
+                         */cpu/stellaris_common/include/* \
                          */cpu/stm32f*/include/stm32f* \
-                         */drivers/nrf24l01p/include/nrf24l01p_settings.h \
                          */cpu/nrf51/include/nrf51*.h \
                          */cpu/lpc1768/include/LPC17xx.h \
                          */cpu/lpc11u34/include/LPC11Uxx.h \
-                         */boards/*/include/periph_conf.h \
+                         */cpu/lpc2387/include/lpc23xx.h \
+                         */cpu/lpc2387/include/lpc2387.h \
                          */cpu/x86/include/x86_pci.h \
+                         */cpu/x86/include/x86_registers.h \
                          */cpu/stm32l1/include/stm32l1xx.h \
+                         */cpu/stm32f0/include/stm32f091xc.h \
                          */cpu/k60/include/MK60D10.h \
                          */cpu/k60/include/MK60DZ10.h \
                          */cpu/kw2x/include/MKW22D5.h \
                          */cpu/k64f/include/MK64F12.h \
                          */cpu/ezr32wg/include/ezr* \
+                         */cpu/*/include/*[_-]regs.h \
+                         */cpu/native/include/native_internal.h \
+                         */drivers/nrf24l01p/include/nrf24l01p_settings.h \
+                         */drivers/at86rf2xx/include/at86rf2xx_registers.h \
+                         */drivers/*/include/*[_-]internal.h \
+                         */drivers/*/include/*[_-]reg.h \
+                         */drivers/*/include/*[_-]regs.h \
+                         */drivers/encx24j600/include/encx24j600_defines.h \
 
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names


### PR DESCRIPTION
Mostly exclude some more vendor provided and register defining headers. Also adds a doc-xml target to be used with https://github.com/alobbs/doxy-coverage.