### PR TITLE
gnrc_pkt: Packets => Packet

### DIFF
--- a/sys/include/net/gnrc/pkt.h
+++ b/sys/include/net/gnrc/pkt.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @defgroup    net_gnrc_pkt Packets
+ * @defgroup    net_gnrc_pkt Packet
  * @ingroup     net_gnrc_pktbuf
  * @brief       Network packet abstraction type and helper functions
  * @{


### PR DESCRIPTION
Referencing a `gnrc_pkt` in doxygen will result in the name  `Packets`. However, most (maybe all) of the times it is expected to be `Packet`.

(no need for travis)