### PR TITLE
gnrc: remove dot from name

### DIFF
--- a/sys/include/net/gnrc.h
+++ b/sys/include/net/gnrc.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    net_gnrc    Generic (gnrc) network stack.
+ * @defgroup    net_gnrc    Generic (gnrc) network stack
  * @ingroup     net
  * @brief       RIOT's modular default IP network stack.
  * @{


### PR DESCRIPTION
Having a dot after the name each time `net_gnrc` is referenced in doxygen looks ridiculous.
Especially if it is in the middle of a sentence.