### PR TITLE
make: Enable the all-debug build target to be available for all boards

### DIFF
--- a/Makefile.cflags
+++ b/Makefile.cflags
@@ -66,3 +66,20 @@ endif
 ifeq ($(origin ARFLAGS),default)
   ARFLAGS = rcs
 endif
+
+# check if we want to make a build without any optimization
+ifeq (1,$(ALL_DEBUG_BUILD))
+  CFLAGS += -g3 -gdwarf-3
+
+  # we may only disable optimization if it's not prohibited
+  ifneq (1,$(MUST_OPTIMIZE))
+    # check if the compiler supports optimize for debug
+    ifeq ($(shell $(CC) -Og -E - 2>/dev/null >/dev/null </dev/null; echo $$?),0)
+      CFLAGS += -Og
+      LINKFLAGS += -Og
+    else
+      CFLAGS += -O0
+      LINKFLAGS += -O0
+    endif
+  endif
+endif

--- a/Makefile.include
+++ b/Makefile.include
@@ -3,8 +3,8 @@
 
 all:
 
-all-debug: export ALL_DEBUG_BUILD=1
 all-debug: all
+    ALL_DEBUG_BUILD=1
 
 # set undefined variables
 RIOTBASE ?= $(shell dirname "$(lastword $(MAKEFILE_LIST))")

--- a/Makefile.include
+++ b/Makefile.include
@@ -3,6 +3,9 @@
 
 all:
 
+all-debug: export ALL_DEBUG_BUILD=1
+all-debug: all
+
 # set undefined variables
 RIOTBASE ?= $(shell dirname "$(lastword $(MAKEFILE_LIST))")
 RIOTBASE := $(abspath $(RIOTBASE))

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -95,7 +95,6 @@ term-cachegrind: export CACHEGRIND_FLAGS += --tool=cachegrind
 term-gprof: export TERMPROG = GMON_OUT_PREFIX=gmon.out $(ELF)
 all-valgrind: export CFLAGS += -DHAVE_VALGRIND_H -g
 all-valgrind: export NATIVEINCLUDES += $(shell pkg-config valgrind --cflags)
-all-debug: export CFLAGS += -g
 all-cachegrind: export CFLAGS += -g
 all-gprof: export CFLAGS += -pg
 all-gprof: export LINKFLAGS += -pg
@@ -128,8 +127,6 @@ endif
 endif
 
 all: # do not override first target
-
-all-debug: all
 
 all-gprof: all
 

--- a/boards/x86-multiboot-common/Makefile.include
+++ b/boards/x86-multiboot-common/Makefile.include
@@ -53,5 +53,4 @@ BASELIBS += $(NEWLIB_BASE)/lib/libc.a \
 
 all:
 
-all-debug: export CFLAGS += -ggdb3 -O0
-all-debug: all
+all-debug: export CFLAGS += -ggdb3

--- a/cpu/Makefile.include.cortexm_common
+++ b/cpu/Makefile.include.cortexm_common
@@ -10,7 +10,9 @@ export CFLAGS_CPU  += -mno-thumb-interwork
 endif
 export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
 export CFLAGS_DBG   = -ggdb -g3
-export CFLAGS_OPT  ?= -Os
+ifneq ($(ALL_DEBUG_BUILD),1)
+  export CFLAGS_OPT  ?= -Os
+endif
 
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 

--- a/cpu/Makefile.include.msp430_common
+++ b/cpu/Makefile.include.msp430_common
@@ -2,10 +2,11 @@
 export TARGET_ARCH ?= msp430
 
 # define build specific options
-CFLAGS_CPU   = -mmcu=$(CPU_MODEL)
-CFLAGS_LINK  =
-CFLAGS_DBG   = -gdwarf-2
-CFLAGS_OPT  ?= -Os
+CFLAGS_CPU    = -mmcu=$(CPU_MODEL)
+CFLAGS_LINK   =
+CFLAGS_DBG    = -gdwarf-2
+CFLAGS_OPT   ?= -Os
+MUST_OPTIMIZE = 1
 # export compiler flags
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 # export assmebly flags


### PR DESCRIPTION
Followup for #4188, make the `all-debug` target available to all boards so the build targets are consistent on all targets.
