### PR TITLE
netdev: missing options for Ethernet devices

### DIFF
--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -162,6 +162,12 @@ int _get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len)
         case NETOPT_IS_WIRED:
             res = 1;
             break;
+        case NETOPT_MAX_PACKET_SIZE:
+            assert(max_len >= 2);
+            uint16_t *val = (uint16_t*) value;
+            *val = ETHERNET_DATA_LEN;
+            res = sizeof(uint16_t);
+            break;
         default:
             res = -ENOTSUP;
             break;

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -426,6 +426,9 @@ int _get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len)
             break;
         case NETOPT_IPV6_IID:
             return _get_iid(dev, value, max_len);
+        case NETOPT_IS_WIRED:
+            res = 1;
+            break;
         case NETOPT_MAX_PACKET_SIZE:
             assert(max_len >= 2);
             uint16_t *val = (uint16_t*) value;

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -426,6 +426,12 @@ int _get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len)
             break;
         case NETOPT_IPV6_IID:
             return _get_iid(dev, value, max_len);
+        case NETOPT_MAX_PACKET_SIZE:
+            assert(max_len >= 2);
+            uint16_t *val = (uint16_t*) value;
+            *val = ETHERNET_DATA_LEN;
+            res = sizeof(uint16_t);
+            break;
         default:
             res = -ENOTSUP;
             break;


### PR DESCRIPTION
netdev2_tap and encx24j600 were missing the option for specifying the maximum packet size. encx24j600 was also not identify as wired interface correctly.