### PR TITLE
make: OSX: send stderr for not connected boards to /dev/null

### DIFF
--- a/boards/airfy-beacon/Makefile.include
+++ b/boards/airfy-beacon/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = nrf51x22xxaa
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/arduino-due/Makefile.include
+++ b/boards/arduino-due/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = sam3x8e
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* 2> /dev/null | head -n 1)
 
 # define board specific flasher options
 export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh

--- a/boards/ek-lm4f120xl/Makefile.include
+++ b/boards/ek-lm4f120xl/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = LM4F120H5QR
 
 #define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/f4vi1/Makefile.include
+++ b/boards/f4vi1/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = stm32f415rg
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/fox/Makefile.include
+++ b/boards/fox/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = stm32f103re
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB1
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbserial* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbserial* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/iotlab-m3/Makefile.include
+++ b/boards/iotlab-m3/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = stm32f103re
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB1
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbserial* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbserial* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 export BAUD = 500000

--- a/boards/limifrog-v1/Makefile.include
+++ b/boards/limifrog-v1/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = stm32l151rc
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -12,7 +12,7 @@ export DEBUGGER_FLAGS =
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/msb-430-common/Makefile.include
+++ b/boards/msb-430-common/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = msp430f1612
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial
 

--- a/boards/msbiot/Makefile.include
+++ b/boards/msbiot/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = stm32f415rg
 
 #define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -82,7 +82,7 @@ ifeq ($(PORT),)
       PORT := $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh)
   endif
   else ifeq ($(OS),Darwin)
-    PORT := $(shell ls -1 /dev/tty.usbserial* | head -n 1)
+    PORT := $(shell ls -1 /dev/tty.usbserial* 2> /dev/null | head -n 1)
   endif
 endif
 ifeq ($(PORT),)

--- a/boards/nrf51dongle/Makefile.include
+++ b/boards/nrf51dongle/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = nrf51x22xxab
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 
 # define flash and debugging environment
 export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh

--- a/boards/nrf6310/Makefile.include
+++ b/boards/nrf6310/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = nrf51x22xxaa
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 
 # define flash and debugging environment
 export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh

--- a/boards/nucleo-f091/Makefile.include
+++ b/boards/nucleo-f091/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = stm32f091rc
 
 #define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/nucleo-f303/Makefile.include
+++ b/boards/nucleo-f303/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = stm32f303re
 
 #define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/nucleo-f334/Makefile.include
+++ b/boards/nucleo-f334/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = stm32f334r8
 
 #define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/nucleo-f401/Makefile.include
+++ b/boards/nucleo-f401/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = stm32f401re
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/nucleo-l1/Makefile.include
+++ b/boards/nucleo-l1/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = stm32l152ret6
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/openmote/Makefile.include
+++ b/boards/openmote/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = cc2538sf53
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbserial-* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbserial-* 2> /dev/null | head -n 1)
 
 #
 export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh

--- a/boards/pca10000/Makefile.include
+++ b/boards/pca10000/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = nrf51x22xxaa
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 
 # define flash and debugging environment
 export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh

--- a/boards/pca10005/Makefile.include
+++ b/boards/pca10005/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = nrf51x22xxaa
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 
 # define flash and debugging environment
 export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh

--- a/boards/samr21-xpro/Makefile.include
+++ b/boards/samr21-xpro/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = samr21g18a
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* 2> /dev/null | head -n 1)
 
 # setup the boards dependencies
 include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/slwstk6220a/Makefile.include
+++ b/boards/slwstk6220a/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = ezr32wg330f256r60
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* 2> /dev/null | head -n 1)
 
 # setup the boards dependencies
 include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/stm32f0discovery/Makefile.include
+++ b/boards/stm32f0discovery/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = stm32f051r8
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/stm32f3discovery/Makefile.include
+++ b/boards/stm32f3discovery/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = stm32f303vc
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/stm32f4discovery/Makefile.include
+++ b/boards/stm32f4discovery/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = stm32f407vg
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = msp430f1611
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbserial-MXV* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbserial-MXV* 2> /dev/null | head -n 1)
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial
 

--- a/boards/weio/Makefile.include
+++ b/boards/weio/Makefile.include
@@ -12,7 +12,7 @@ export DEBUGGER_FLAGS =
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/wsn430-common/Makefile.include
+++ b/boards/wsn430-common/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = msp430f1611
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial
 

--- a/boards/yunjia-nrf51822/Makefile.include
+++ b/boards/yunjia-nrf51822/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = nrf51x22xxaa
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/z1/Makefile.include
+++ b/boards/z1/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = msp430f2617
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* 2> /dev/null | head -n 1)
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial
 


### PR DESCRIPTION
When no board is connected, looking up the right serial port polutes
the build output on OS X. This pr sends stderr to /dev/null, the
warning message is still displayed.