### PR TITLE
sys: fmt: fix converting "0" in fmt_u32_dec()

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -93,10 +93,9 @@ size_t fmt_u32_dec(char *out, uint32_t val)
 
     if (out) {
         char *ptr = out + len;
-        while(val) {
+        do {
             *--ptr = (val % 10) + '0';
-            val /= 10;
-        }
+        } while ((val /= 10));
     }
 
     return len;


### PR DESCRIPTION
```fmt_u32_dec()``` would skip printing any decimal if ```val == 0```. This PR fixes that case.