### PR TITLE
Revert "stm32l1/i2c.c: adapt for new periph driver interface"

### DIFF
--- a/boards/limifrog-v1/include/periph_conf.h
+++ b/boards/limifrog-v1/include/periph_conf.h
@@ -131,30 +131,45 @@ static const timer_conf_t timer_config[] = {
 
 /**
  * @name I2C configuration
- * @{
+  * @{
  */
 #define I2C_NUMOF           (2U)
 #define I2C_0_EN            1
 #define I2C_1_EN            1
-
-static const i2c_conf_t i2c_cfg[] = {
-    /* Device, SCL-, SDA-Pin, AF, Event-, Error-IRQ, Clock enable */
-    {I2C1, GPIO_PIN(PORT_B, 8), GPIO_PIN(PORT_B, 9), 4,
-     I2C1_EV_IRQn, I2C1_ER_IRQn, RCC_APB1ENR_I2C1EN},
-    {I2C2, GPIO_PIN(PORT_B, 10), GPIO_PIN(PORT_B, 11), 4,
-     I2C2_EV_IRQn, I2C2_ER_IRQn, RCC_APB1ENR_I2C2EN},
-};
-
 #define I2C_IRQ_PRIO        1
 #define I2C_APBCLK          (36000000U)
 
 /* I2C 0 device configuration */
+#define I2C_0_DEV           I2C1
+#define I2C_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C1EN)
+#define I2C_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
+#define I2C_0_EVT_IRQ       I2C1_EV_IRQn
 #define I2C_0_EVT_ISR       isr_i2c1_ev
+#define I2C_0_ERR_IRQ       I2C1_ER_IRQn
 #define I2C_0_ERR_ISR       isr_i2c1_er
+/* I2C 0 pin configuration */
+#define I2C_0_PORT_CLKEN()  (RCC->AHBENR |= RCC_AHBENR_GPIOBEN)
+#define I2C_0_PORT          GPIOB
+#define I2C_0_SCL_PIN       8
+#define I2C_0_SCL_AF        4
+#define I2C_0_SDA_PIN       9
+#define I2C_0_SDA_AF        4
 
-/* I2C 1 device configuration [ST VL6180X, ST LSM6DS3, ST LIS3MDL, ST SLPS25H]*/
+/* I2C 1 device configuration */
+#define I2C_1_DEV           I2C2         /* ST VL6180X, ST LSM6DS3, ST LIS3MDL, ST SLPS25H */
+#define I2C_1_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C2EN)
+#define I2C_1_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C2EN))
+#define I2C_1_EVT_IRQ       I2C2_EV_IRQn
 #define I2C_1_EVT_ISR       isr_i2c2_ev
+#define I2C_1_ERR_IRQ       I2C2_ER_IRQn
 #define I2C_1_ERR_ISR       isr_i2c2_er
+/* I2C 1 pin configuration */
+#define I2C_1_PORT_CLKEN()  (RCC->AHBENR |= RCC_AHBENR_GPIOBEN)
+#define I2C_1_PORT          GPIOB
+#define I2C_1_SCL_PIN       10
+#define I2C_1_SCL_AF        4
+#define I2C_1_SDA_PIN       11
+#define I2C_1_SDA_AF        4
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-l1/include/periph_conf.h
+++ b/boards/nucleo-l1/include/periph_conf.h
@@ -236,30 +236,28 @@ static const timer_conf_t timer_config[] = {
 
 /**
  * @name I2C configuration
- * @{
+  * @{
  */
-#define I2C_NUMOF           (2U)
+#define I2C_NUMOF           (1U)
 #define I2C_0_EN            1
-#define I2C_1_EN            1
-
-static const i2c_conf_t i2c_cfg[] = {
-    /* Device, SCL-, SDA-Pin, AF, Event-, Error-IRQ, Clock enable */
-    {I2C1, GPIO_PIN(PORT_B, 8), GPIO_PIN(PORT_B, 9), 4,
-     I2C1_EV_IRQn, I2C1_ER_IRQn, RCC_APB1ENR_I2C1EN},
-    {I2C2, GPIO_PIN(PORT_B, 10), GPIO_PIN(PORT_B, 11), 4,
-     I2C2_EV_IRQn, I2C2_ER_IRQn, RCC_APB1ENR_I2C2EN},
-};
-
 #define I2C_IRQ_PRIO        1
 #define I2C_APBCLK          (36000000U)
 
 /* I2C 0 device configuration */
+#define I2C_0_DEV           I2C1
+#define I2C_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C1EN)
+#define I2C_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
+#define I2C_0_EVT_IRQ       I2C1_EV_IRQn
 #define I2C_0_EVT_ISR       isr_i2c1_ev
+#define I2C_0_ERR_IRQ       I2C1_ER_IRQn
 #define I2C_0_ERR_ISR       isr_i2c1_er
-
-/* I2C 1 device configuration */
-#define I2C_1_EVT_ISR       isr_i2c2_ev
-#define I2C_1_ERR_ISR       isr_i2c2_er
+/* I2C 0 pin configuration */
+#define I2C_0_PORT_CLKEN()  (RCC->AHBENR |= RCC_AHBENR_GPIOBEN)
+#define I2C_0_PORT          GPIOB
+#define I2C_0_SCL_PIN       8
+#define I2C_0_SCL_AF        4
+#define I2C_0_SDA_PIN       9
+#define I2C_0_SDA_AF        4
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/stm32l1/include/periph_cpu.h
+++ b/cpu/stm32l1/include/periph_cpu.h
@@ -100,26 +100,13 @@ typedef struct {
 } timer_conf_t;
 
 /**
- * @brief   declare needed generic SPI functions
+ * @brief declare needed generic SPI functions
  * @{
  */
 #define PERIPH_SPI_NEEDS_TRANSFER_BYTES
 #define PERIPH_SPI_NEEDS_TRANSFER_REG
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS
 /** @} */
-
-/**
- * @brief   I2C device configuration
- */
-typedef struct {
-    I2C_TypeDef *dev;       /**< Pointer to the used I2C device */
-    gpio_t scl_pin;         /**< Pin used for SCL */
-    gpio_t sda_pin;         /**< Pin used for SDA */
-    uint8_t af_scl_sda;     /**< SCL or SDA AF */
-    uint8_t ev_irqn;        /**< I2C device Event Interrupt */
-    uint8_t er_irqn;        /**< I2C device Error Interrupt */
-    uint32_t clk_en;        /**< Clock enable register */
-} i2c_conf_t;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This reverts commit e9215a6cc130ea0957aa7f143c30c9667237047c.

It turned out that #4096 did not work correctly. The i2c driver can also be optimized by using the gpio API. Unluckily there is one feature missing for the usage in i2c: the possibility to configure outputs as open drain, as needed for i2c buses. I will discuss this offline and come along with a PR which recovers the wanted improvement of #4096 again then.