### PR TITLE
at86rf2xx: dereference NETOPT_PROTO option

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -659,7 +659,7 @@ static int _set(gnrc_netdev_t *device, netopt_t opt, void *val, size_t len)
                 res = -EINVAL;
             }
             else {
-                dev->proto = (gnrc_nettype_t) val;
+                dev->proto = *((gnrc_nettype_t*) val);
                 res = sizeof(gnrc_nettype_t);
             }
             break;


### PR DESCRIPTION
netopt_t options are passed as pointers to the driver.