### PR TITLE
Update OpenMote board header file to define UPDATE_CCA

### DIFF
--- a/boards/openmote-cc2538/include/board.h
+++ b/boards/openmote-cc2538/include/board.h
@@ -72,6 +72,19 @@
 /** @} */
 
 /**
+ * @name Flash Customer Configuration Area (CCA) parameters
+ * @{
+ */
+#ifndef UPDATE_CCA
+#define UPDATE_CCA                (1)
+#endif
+
+#define CCA_BACKDOOR_ENABLE       (1)
+#define CCA_BACKDOOR_PORT_A_PIN   (6) /**< ON/SLEEP Pin */
+#define CCA_BACKDOOR_ACTIVE_LEVEL (0) /**< Active low */
+/** @} */
+
+/**
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);


### PR DESCRIPTION
This enables the cc2538's bootloader backdoor, to allow booting into the bootloader and flashing via the serial interface even when a valid image is already present. Backdoor enable is set to PORT A, PIN 6, (ON/SLEEP on the OpenBase), LOW for consistency with the default OpenMote firmware, patch based on existing code for same functionality in cc2538dk and ReMote boards.