### PR TITLE
gnrc_sixlowpan.c: fix warning if GNRC_SIXLOWPAN_FRAG module not used

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -34,7 +34,9 @@
 
 static kernel_pid_t _pid = KERNEL_PID_UNDEF;
 
+#ifdef MODULE_GNRC_SIXLOWPAN_FRAG
 static gnrc_sixlowpan_msg_frag_t fragment_msg = {KERNEL_PID_UNDEF, NULL, 0, 0};
+#endif
 
 #if ENABLE_DEBUG
 static char _stack[GNRC_SIXLOWPAN_STACK_SIZE + THREAD_EXTRA_STACKSIZE_PRINTF];


### PR DESCRIPTION
fix warning if GNRC_SIXLOWPAN_FRAG module not used