### PR TITLE
drivers: add ethernet over serial driver

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -419,3 +419,7 @@ endif
 ifneq (,$(filter phydat,$(USEMODULE)))
   USEMODULE += fmt
 endif
+
+ifneq (,$(filter ethos,$(USEMODULE)))
+    USEMODULE += netdev2_eth
+endif

--- a/dist/tools/ethos/LICENSE
+++ b/dist/tools/ethos/LICENSE
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/dist/tools/ethos/Makefile
+++ b/dist/tools/ethos/Makefile
@@ -1,0 +1,4 @@
+all: ethos
+
+ethos: ethos.c
+	$(CC) -O3 -Wall ethos.c -o ethos

--- a/dist/tools/ethos/README.md
+++ b/dist/tools/ethos/README.md
@@ -1,0 +1,15 @@
+## Requirements
+
+- currently, the host side only compiles on Linux
+
+## Usage
+
+To use, add
+
+    #
+    GNRC_NETIF_NUMOF := 2
+    USEMODULE += ethos gnrc_netdev2
+    CFLAGS += '-DETHOS_UART=UART_DEV(0)' -DETHOS_BAUDRATE=115200 -DUSE_ETHOS_FOR_STDIO
+
+to app Makefile, "make clean all flash", then run this tool so follows:
+    # sudo ./ethos <tap-device> <serial>

--- a/dist/tools/ethos/ethos.c
+++ b/dist/tools/ethos/ethos.c
@@ -1,0 +1,379 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU General Public
+ * License v2. See the file LICENSE for more details.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <netinet/in.h>
+#include <linux/if.h>
+#include <linux/if_tun.h>
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <arpa/inet.h>
+#include <sys/select.h>
+#include <sys/time.h>
+#include <stdlib.h>
+
+#include <termios.h>
+
+#define MTU 9000
+
+#define TRACE(x)
+
+static void usage(void)
+{
+    fprintf(stderr, "usage: eth_over_serial <tap> <serial>\n");
+}
+
+int set_serial_attribs (int fd, int speed, int parity)
+{
+    struct termios tty;
+    memset (&tty, 0, sizeof tty);
+    if (tcgetattr (fd, &tty) != 0)
+    {
+        perror ("error in tcgetattr");
+        return -1;
+    }
+
+    cfsetospeed (&tty, speed);
+    cfsetispeed (&tty, speed);
+
+    tty.c_cflag = (tty.c_cflag & ~CSIZE) | CS8; /* 8-bit chars*/
+                                        /* disable IGNBRK for mismatched speed
+                                         * tests; otherwise receive break*/
+                                        /* as \000 chars*/
+    tty.c_iflag &= ~IGNBRK;             /* disable break processing*/
+    tty.c_lflag = 0;                    /* no signaling chars, no echo,*/
+                                        /* no canonical processing*/
+    tty.c_oflag = 0;                    /* no remapping, no delays*/
+    tty.c_cc[VMIN]  = 0;                /* read doesn't block*/
+    tty.c_cc[VTIME] = 5;                /* 0.5 seconds read timeout*/
+
+    tty.c_iflag &= ~(IXON | IXOFF | IXANY); /* shut off xon/xoff ctrl*/
+
+    tty.c_cflag |= (CLOCAL | CREAD);    /* ignore modem controls,*/
+                                        /* enable reading*/
+    tty.c_cflag &= ~(PARENB | PARODD);  /* shut off parity*/
+    tty.c_cflag |= parity;
+    tty.c_cflag &= ~CSTOPB;
+    tty.c_cflag &= ~CRTSCTS;
+    cfmakeraw(&tty);
+
+    if (tcsetattr (fd, TCSANOW, &tty) != 0)
+    {
+        perror("error from tcsetattr");
+        return -1;
+    }
+    return 0;
+}
+
+void set_blocking (int fd, int should_block)
+{
+    struct termios tty;
+    memset (&tty, 0, sizeof tty);
+    if (tcgetattr (fd, &tty) != 0)
+    {
+        perror("error from tggetattr");
+        return;
+    }
+
+    tty.c_cc[VMIN]  = should_block ? 1 : 0;
+    tty.c_cc[VTIME] = 5;            /* 0.5 seconds read timeout*/
+
+    if (tcsetattr (fd, TCSANOW, &tty) != 0)
+        perror("error setting term attributes");
+}
+
+/**
+ * @brief Escape char definitions
+ * @{
+ */
+#define LINE_FRAME_DELIMITER        (0x7E)
+#define LINE_ESC_CHAR               (0x7D)
+#define LINE_FRAME_TYPE_DATA        (0x00)
+#define LINE_FRAME_TYPE_TEXT        (0x01)
+#define LINE_FRAME_TYPE_HELLO       (0x02)
+#define LINE_FRAME_TYPE_HELLO_REPLY (0x03)
+/** @} */
+
+typedef enum {
+    WAIT_FRAMESTART,
+    IN_FRAME,
+    IN_ESCAPE
+} line_state_t;
+
+typedef struct {
+    line_state_t state;
+    int frametype;
+    size_t framebytes;
+    char frame[MTU];
+    char local_l2_addr[6];
+    char remote_l2_addr[6];
+} serial_t;
+
+/**************************************************************************
+ * tun_alloc: allocates or reconnects to a tun/tap device. The caller     *
+ *            needs to reserve enough space in *dev.                      *
+ **************************************************************************/
+int tun_alloc(char *dev, int flags) {
+
+  struct ifreq ifr;
+  int fd, err;
+
+  if( (fd = open("/dev/net/tun", O_RDWR)) < 0 ) {
+    perror("Opening /dev/net/tun");
+    return fd;
+  }
+
+  memset(&ifr, 0, sizeof(ifr));
+
+  ifr.ifr_flags = flags;
+
+  if (*dev) {
+    strncpy(ifr.ifr_name, dev, IFNAMSIZ);
+  }
+
+  if( (err = ioctl(fd, TUNSETIFF, (void *)&ifr)) < 0 ) {
+    perror("ioctl(TUNSETIFF)");
+    close(fd);
+    return err;
+  }
+
+  strcpy(dev, ifr.ifr_name);
+
+  return fd;
+}
+
+static void _handle_char(serial_t *serial, char c)
+{
+    serial->frame[serial->framebytes] = c;
+    serial->framebytes++;
+}
+
+static int _serial_handle_byte(serial_t *serial, char c)
+{
+    switch (serial->state) {
+        case WAIT_FRAMESTART:
+            if (c == LINE_FRAME_DELIMITER) {
+                TRACE("frame start");
+                serial->state = IN_FRAME;
+                serial->frametype = 0;
+                serial->framebytes = 0;
+            }
+            break;
+        case IN_FRAME:
+            if (c == LINE_ESC_CHAR) {
+                TRACE("i esc");
+                serial->state = IN_ESCAPE;
+            }
+            else if (c == LINE_FRAME_DELIMITER) {
+                if (!serial->framebytes) {
+                    TRACE("i del unexp");
+                } else {
+                    TRACE("i del");
+                    serial->state = WAIT_FRAMESTART;
+                    return serial->framebytes;
+                }
+            }
+            else {
+                _handle_char(serial, c);
+            }
+            break;
+        case IN_ESCAPE:
+            if (c == (LINE_FRAME_DELIMITER ^ 0x20)) {
+                _handle_char(serial, LINE_FRAME_DELIMITER);
+            }
+            else if (c == (LINE_ESC_CHAR ^ 0x20)) {
+                _handle_char(serial, LINE_ESC_CHAR);
+            }
+            else if (c == (LINE_FRAME_TYPE_TEXT ^ 0x20)) {
+                TRACE("esc txt");
+                serial->frametype = LINE_FRAME_TYPE_TEXT;
+            }
+            else if (c == (LINE_FRAME_TYPE_HELLO ^ 0x20)) {
+                TRACE("esc hello");
+                serial->frametype = LINE_FRAME_TYPE_HELLO;
+            }
+            else if (c == (LINE_FRAME_TYPE_HELLO_REPLY ^ 0x20)) {
+                TRACE("esc hello_reply");
+                serial->frametype = LINE_FRAME_TYPE_HELLO_REPLY;
+            }
+            else if (c == LINE_FRAME_DELIMITER) {
+                TRACE("esc -del");
+            }
+            serial->state = IN_FRAME;
+            break;
+    }
+
+    return 0;
+}
+
+static void _write_escaped(int fd, char* buf, ssize_t n)
+{
+    uint8_t out[2];
+    size_t escaped = 0;
+
+    while(n--) {
+        char c = *buf++;
+        switch(c) {
+            case LINE_FRAME_DELIMITER:
+                out[0] = LINE_ESC_CHAR;
+                out[1] = (LINE_FRAME_DELIMITER ^ 0x20);
+                write(fd, out, 2);
+                escaped++;
+                break;
+            case LINE_ESC_CHAR:
+                out[0] = LINE_ESC_CHAR;
+                out[1] = (LINE_ESC_CHAR ^ 0x20);
+                write(fd, out, 2);
+                escaped++;
+                break;
+            default:
+                write(fd, &c, 1);
+        }
+    }
+}
+
+static void _send_hello(int serial_fd, serial_t *serial, unsigned type)
+{
+    char delim = LINE_FRAME_DELIMITER;
+    char head[] = { LINE_FRAME_DELIMITER, LINE_ESC_CHAR, (type ^ 0x20) };
+    write(serial_fd, head, sizeof(head));
+    write(serial_fd, serial->local_l2_addr, 6);
+    write(serial_fd, &delim, 1);
+}
+
+static void _clear_neighbor_cache(const char *ifname)
+{
+    char tmp[20 + IFNAMSIZ];
+    snprintf(tmp, sizeof(tmp), "ip neigh flush dev %s", ifname);
+    system(tmp);
+}
+
+int main(int argc, char *argv[])
+{
+    char inbuf[MTU];
+
+    serial_t serial = {0};
+
+    if (argc < 3) {
+        usage();
+        return 1;
+    }
+
+    char ifname[IFNAMSIZ];
+    strncpy(ifname, argv[1], IFNAMSIZ);
+    int tap_fd = tun_alloc(ifname, IFF_TAP | IFF_NO_PI);
+
+    if (tap_fd < 0) {
+        return 1;
+    }
+
+    int serial_fd = open(argv[2], O_RDWR | O_NOCTTY | O_SYNC);
+
+    if (serial_fd < 0) {
+        fprintf(stderr, "Error opening serial device %s\n", argv[2]);
+        return 1;
+    }
+
+    set_serial_attribs(serial_fd, B115200, 0);
+    set_blocking(serial_fd, 1);
+
+    fd_set readfds;
+    int max_fd = (serial_fd > tap_fd) ? serial_fd : tap_fd;
+
+    fprintf(stderr, "----> ethos: sending hello.\n");
+    _send_hello(serial_fd, &serial, LINE_FRAME_TYPE_HELLO);
+
+    fprintf(stderr, "----> ethos: activating serial pass through.\n");
+    _send_hello(serial_fd, &serial, LINE_FRAME_TYPE_HELLO);
+    while(1) {
+        int activity;
+        FD_ZERO(&readfds);
+        FD_SET(STDIN_FILENO, &readfds);
+        FD_SET(tap_fd, &readfds);
+        FD_SET(serial_fd, &readfds);
+        activity = select( max_fd + 1 , &readfds , NULL , NULL , NULL);
+
+        if ((activity < 0) && (errno != EINTR))
+        {
+            perror("select error");
+        }
+
+        if (FD_ISSET(serial_fd, &readfds)) {
+            ssize_t n = read(serial_fd, inbuf, sizeof(inbuf));
+            if (n > 0) {
+                char *ptr = inbuf;
+                while (n--) {
+                    size_t res = _serial_handle_byte(&serial, *ptr++);
+                    if (res) {
+                        switch (serial.frametype) {
+                            case LINE_FRAME_TYPE_DATA:
+                                write(tap_fd, serial.frame, serial.framebytes);
+                                break;
+                            case LINE_FRAME_TYPE_TEXT:
+                                write(STDOUT_FILENO, serial.frame, serial.framebytes);
+                                break;
+                            case LINE_FRAME_TYPE_HELLO:
+                            case LINE_FRAME_TYPE_HELLO_REPLY:
+                                if (serial.framebytes == 6) {
+                                    memcpy(serial.remote_l2_addr, serial.frame, 6);
+                                    if (serial.frametype == LINE_FRAME_TYPE_HELLO) {
+                                        fprintf(stderr, "----> ethos: hello received\n");
+                                        _send_hello(serial_fd, &serial, LINE_FRAME_TYPE_HELLO_REPLY);
+                                    } else {
+                                        fprintf(stderr, "----> ethos: hello reply received\n");
+                                    }
+                                    _clear_neighbor_cache(ifname);
+                                }
+                                break;
+                        }
+                        memset(&serial, '\0', sizeof(serial));
+                    }
+                }
+            }
+            else {
+                fprintf(stderr, "lost serial connection.\n");
+                exit(1);
+            }
+        }
+
+        if (FD_ISSET(tap_fd, &readfds)) {
+            ssize_t res = read(tap_fd, inbuf, sizeof(inbuf));
+            if (res <= 0) {
+                fprintf(stderr, "error reading from tap device. res=%zi\n", res);
+                continue;
+            }
+            char delim = LINE_FRAME_DELIMITER;
+            write(serial_fd, &delim, 1);
+            _write_escaped(serial_fd, inbuf, res);
+            write(serial_fd, &delim, 1);
+        }
+
+        if (FD_ISSET(STDIN_FILENO, &readfds)) {
+            ssize_t res = read(STDIN_FILENO, inbuf, sizeof(inbuf));
+            if (res <= 0) {
+                fprintf(stderr, "error reading from stdio. res=%zi\n", res);
+                continue;
+            }
+
+            if (res) {
+                char delim = LINE_FRAME_DELIMITER;
+                char head[] = { LINE_FRAME_DELIMITER, LINE_ESC_CHAR, (LINE_FRAME_TYPE_TEXT ^ 0x20) };
+                write(serial_fd, head, sizeof(head));
+                _write_escaped(serial_fd, inbuf, res);
+                write(serial_fd, &delim, 1);
+            }
+        }
+    }
+
+    return 0;
+}

--- a/dist/tools/licenses/patterns/gplv2-short
+++ b/dist/tools/licenses/patterns/gplv2-short
@@ -1,0 +1,1 @@
+This file is subject to the terms and conditions of the GNU General Public License v2\. See the file LICENSE for more details.

--- a/drivers/ethos/Makefile
+++ b/drivers/ethos/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -1,0 +1,348 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     driver_ethos
+ * @{
+ *
+ * @file
+ * @brief       Implementation of a simple ethernet-over-serial driver
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <string.h>
+
+#include "random.h"
+#include "ethos.h"
+#include "periph/uart.h"
+#include "tsrb.h"
+
+#include "net/netdev2.h"
+#include "net/netdev2_eth.h"
+#include "net/eui64.h"
+#include "net/ethernet.h"
+
+#ifdef USE_ETHOS_FOR_STDIO
+#include "uart_stdio.h"
+#endif
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+static void _get_mac_addr(netdev2_t *dev, uint8_t* buf);
+static void ethos_isr(void *arg, char c);
+const static netdev2_driver_t netdev2_driver_ethos;
+
+static const uint8_t _esc_esc[] = {ETHOS_ESC_CHAR, (ETHOS_ESC_CHAR ^ 0x20)};
+static const uint8_t _esc_delim[] = {ETHOS_ESC_CHAR, (ETHOS_FRAME_DELIMITER ^ 0x20)};
+
+
+void ethos_setup(ethos_t *dev, uart_t uart, uint32_t baudrate, uint8_t *buf, size_t bufsize)
+{
+    dev->netdev.driver = &netdev2_driver_ethos;
+    dev->uart = uart;
+    dev->state = WAIT_FRAMESTART;
+    dev->framesize = 0;
+    dev->frametype = 0;
+    dev->last_framesize = 0;
+
+    tsrb_init(&dev->inbuf, (char*)buf, bufsize);
+    mutex_init(&dev->out_mutex);
+
+    uint32_t a = genrand_uint32();
+    memcpy(dev->mac_addr, (char*)&a, 4);
+    a = genrand_uint32();
+    memcpy(dev->mac_addr+4, (char*)&a, 2);
+
+    dev->mac_addr[0] &= (0x2);      /* unset globally unique bit */
+    dev->mac_addr[0] &= ~(0x1);     /* set unicast bit*/
+
+    uart_init(uart, baudrate, ethos_isr, (void*)dev);
+
+    uint8_t frame_delim = ETHOS_FRAME_DELIMITER;
+    uart_write(dev->uart, &frame_delim, 1);
+    ethos_send_frame(dev, dev->mac_addr, 6, ETHOS_FRAME_TYPE_HELLO);
+}
+
+static void _reset_state(ethos_t *dev)
+{
+    dev->state = WAIT_FRAMESTART;
+    dev->frametype = 0;
+    dev->framesize = 0;
+}
+
+static void _handle_char(ethos_t *dev, char c)
+{
+    switch (dev->frametype) {
+        case ETHOS_FRAME_TYPE_DATA:
+        case ETHOS_FRAME_TYPE_HELLO:
+        case ETHOS_FRAME_TYPE_HELLO_REPLY:
+             if (tsrb_add_one(&dev->inbuf, c) == 0) {
+                dev->framesize++;
+            } else {
+                //puts("lost frame");
+                dev->inbuf.reads = 0;
+                dev->inbuf.writes = 0;
+                _reset_state(dev);
+            }
+            break;
+#ifdef USE_ETHOS_FOR_STDIO
+        case ETHOS_FRAME_TYPE_TEXT:
+            dev->framesize++;
+            uart_stdio_rx_cb(NULL, c);
+#endif
+    }
+}
+
+static void _end_of_frame(ethos_t *dev)
+{
+    switch(dev->frametype) {
+        case ETHOS_FRAME_TYPE_DATA:
+            if (dev->framesize) {
+                dev->last_framesize = dev->framesize;
+                dev->netdev.event_callback((netdev2_t*) dev, NETDEV2_EVENT_ISR, NULL);
+            }
+            break;
+        case ETHOS_FRAME_TYPE_HELLO:
+            ethos_send_frame(dev, dev->mac_addr, 6, ETHOS_FRAME_TYPE_HELLO_REPLY);
+            /* fall through */
+        case ETHOS_FRAME_TYPE_HELLO_REPLY:
+            if (dev->framesize == 6) {
+                tsrb_get(&dev->inbuf, (char*)dev->remote_mac_addr, 6);
+            }
+            break;
+    }
+
+    _reset_state(dev);
+}
+
+static void ethos_isr(void *arg, char c)
+{
+    ethos_t *dev = (ethos_t *) arg;
+
+    switch (dev->state) {
+        case WAIT_FRAMESTART:
+            if (c == ETHOS_FRAME_DELIMITER) {
+                _reset_state(dev);
+                dev->state = IN_FRAME;
+            }
+            break;
+        case IN_FRAME:
+            if (c == ETHOS_ESC_CHAR) {
+                dev->state = IN_ESCAPE;
+            }
+            else if (c == ETHOS_FRAME_DELIMITER) {
+                if (dev->framesize) {
+                    _end_of_frame(dev);
+                }
+            }
+            else {
+                _handle_char(dev, c);
+            }
+            break;
+        case IN_ESCAPE:
+            switch (c) {
+                case (ETHOS_FRAME_DELIMITER ^ 0x20):
+                    _handle_char(dev, ETHOS_FRAME_DELIMITER);
+                    break;
+                case (ETHOS_ESC_CHAR ^ 0x20):
+                    _handle_char(dev, ETHOS_ESC_CHAR);
+                    break;
+                case (ETHOS_FRAME_TYPE_TEXT ^ 0x20):
+                    dev->frametype = ETHOS_FRAME_TYPE_TEXT;
+                    break;
+                case (ETHOS_FRAME_TYPE_HELLO ^ 0x20):
+                    dev->frametype = ETHOS_FRAME_TYPE_HELLO;
+                    break;
+                case (ETHOS_FRAME_TYPE_HELLO_REPLY ^ 0x20):
+                    dev->frametype = ETHOS_FRAME_TYPE_HELLO_REPLY;
+                    break;
+            }
+            dev->state = IN_FRAME;
+            break;
+    }
+}
+
+static void _isr(netdev2_t *netdev)
+{
+    ethos_t *dev = (ethos_t *) netdev;
+    dev->netdev.event_callback((netdev2_t*) dev, NETDEV2_EVENT_RX_COMPLETE, NULL);
+}
+
+static int _init(netdev2_t *encdev)
+{
+    ethos_t *dev = (ethos_t *) encdev;
+    (void)dev;
+    return 0;
+}
+
+static size_t iovec_count_total(const struct iovec *vector, int count)
+{
+    size_t result = 0;
+    while(count--) {
+        result += vector->iov_len;
+        vector++;
+    }
+    return result;
+}
+
+static void _write_escaped(uart_t uart, uint8_t c)
+{
+    uint8_t *out;
+    int n;
+
+    switch(c) {
+        case ETHOS_FRAME_DELIMITER:
+            out = (uint8_t*)_esc_delim;
+            n = 2;
+            break;
+        case ETHOS_ESC_CHAR:
+            out = (uint8_t*)_esc_esc;
+            n = 2;
+            break;
+        default:
+            out = &c;
+            n = 1;
+    }
+
+    uart_write(uart, out, n);
+}
+
+void ethos_send_frame(ethos_t *dev, const uint8_t *data, size_t len, unsigned frame_type)
+{
+    uint8_t frame_delim = ETHOS_FRAME_DELIMITER;
+
+    if (!inISR()) {
+        mutex_lock(&dev->out_mutex);
+    }
+    else {
+        /* Send frame delimiter. This cancels the current frame,
+         * but enables in-ISR writes.  */
+        uart_write(dev->uart, &frame_delim, 1);
+    }
+
+    /* send frame delimiter */
+    uart_write(dev->uart, &frame_delim, 1);
+
+    /* set frame type */
+    if (frame_type) {
+        uint8_t out[2] = { ETHOS_ESC_CHAR, (frame_type ^ 0x20) };
+        uart_write(dev->uart, out, 2);
+    }
+
+    /* send frame content */
+    while(len--) {
+        _write_escaped(dev->uart, *(uint8_t*)data++);
+    }
+
+    /* end of frame */
+    uart_write(dev->uart, &frame_delim, 1);
+
+    if (!inISR()) {
+        mutex_unlock(&dev->out_mutex);
+    }
+}
+
+static int _send(netdev2_t *netdev, const struct iovec *vector, int count)
+{
+    ethos_t * dev = (ethos_t *) netdev;
+    (void)dev;
+
+    /* count total packet length */
+    size_t pktlen = iovec_count_total(vector, count);
+
+    /* lock line in order to prevent multiple writes */
+    mutex_lock(&dev->out_mutex);
+
+    /* send start-frame-delimiter */
+    uint8_t frame_delim = ETHOS_FRAME_DELIMITER;
+    uart_write(dev->uart, &frame_delim, 1);
+
+    /* send iovec */
+    while(count--) {
+        size_t n = vector->iov_len;
+        uint8_t *ptr = vector->iov_base;
+        while(n--) {
+            _write_escaped(dev->uart, *ptr++);
+        }
+        vector++;
+    }
+
+    uart_write(dev->uart, &frame_delim, 1);
+
+    mutex_unlock(&dev->out_mutex);
+
+    return pktlen;
+}
+
+static void _get_mac_addr(netdev2_t *encdev, uint8_t* buf)
+{
+    ethos_t * dev = (ethos_t *) encdev;
+    memcpy(buf, dev->mac_addr, 6);
+}
+
+static int _recv(netdev2_t *netdev, char* buf, int len)
+{
+    ethos_t * dev = (ethos_t *) netdev;
+
+    if (buf) {
+        if (len != dev->last_framesize) {
+            DEBUG("ethos _recv(): unmatched receive buffer size.");
+            return -1;
+        }
+
+        dev->last_framesize = 0;
+
+        if ((tsrb_get(&dev->inbuf, buf, len) != len)) {
+            DEBUG("ethos _recv(): inbuf doesn't contain enough bytes.");
+            return -1;
+        }
+
+        return len;
+    }
+    else {
+        return dev->last_framesize;
+    }
+}
+
+int _get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len)
+{
+    int res = 0;
+
+    switch (opt) {
+        case NETOPT_ADDRESS:
+            if (max_len < ETHERNET_ADDR_LEN) {
+                res = -EINVAL;
+            }
+            else {
+                _get_mac_addr(dev, (uint8_t*)value);
+                res = ETHERNET_ADDR_LEN;
+            }
+            break;
+        default:
+            res = netdev2_eth_get(dev, opt, value, max_len);
+            break;
+    }
+
+    return res;
+}
+
+/* netdev2 interface */
+const static netdev2_driver_t netdev2_driver_ethos = {
+    .send = _send,
+    .recv = _recv,
+    .init = _init,
+    .isr = _isr,
+    .get = _get,
+    .set = netdev2_eth_set
+};

--- a/drivers/include/ethos.h
+++ b/drivers/include/ethos.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    drivers_ethos ethos
+ * @ingroup     drivers_netdev
+ * @brief       Driver for the ethernet-over-serial module
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for the ethernet-over-serial module
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef ETHOS_H
+#define ETHOS_H
+
+#include "kernel_types.h"
+#include "periph/uart.h"
+#include "net/netdev2.h"
+#include "tsrb.h"
+#include "mutex.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* if using ethos + stdio, use STDIO values unless overridden */
+#ifdef USE_ETHOS_FOR_STDIO
+#include "board.h"
+#ifndef ETHOS_UART
+#define ETHOS_UART  STDIO
+#endif
+#ifndef ETHOS_BAUDRATE
+#define ETHOS_BAUDRATE STDIO_BAUDRATE
+#endif
+#endif
+
+/**
+ * @name Escape char definitions
+ * @{
+ */
+#define ETHOS_FRAME_DELIMITER           (0x7E)
+#define ETHOS_ESC_CHAR                  (0x7D)
+#define ETHOS_FRAME_TYPE_DATA           (0x0)
+#define ETHOS_FRAME_TYPE_TEXT           (0x1)
+#define ETHOS_FRAME_TYPE_HELLO          (0x2)
+#define ETHOS_FRAME_TYPE_HELLO_REPLY    (0x3)
+/** @} */
+
+/**
+ * @brief   enum describing line state
+ */
+typedef enum {
+    WAIT_FRAMESTART,
+    IN_FRAME,
+    IN_ESCAPE
+} line_state_t;
+
+/**
+ * @brief ethos netdev2 device
+ * @extends netdev2_t
+ */
+typedef struct {
+    netdev2_t netdev;       /**< extended netdev2 structure */
+    uart_t uart;            /**< UART device the to use */
+    uint8_t mac_addr[6];    /**< this device's MAC address */
+    uint8_t remote_mac_addr[6]; /**< this device's MAC address */
+    tsrb_t inbuf;           /**< ringbuffer for incoming data */
+    line_state_t state;     /**< Line status variable */
+    size_t framesize;       /**< size of currently incoming frame */
+    unsigned frametype;     /**< type of currently incoming frame */
+    size_t last_framesize;  /**< size of last completed frame */
+    mutex_t out_mutex;      /**< mutex used for locking concurrent sends */
+} ethos_t;
+
+/**
+ * @brief Setup an ethos based device state.
+ *
+ * The supplied buffer *must* have a power-of-two size, and it *must* be large
+ * enough for the largest expected packet + enough buffer space to buffer
+ * bytes that arrive while one packet is being handled.
+ *
+ * E.g., if 1536b ethernet frames are expected, 2048 is probably a good size for @p buf.
+ *
+ * @param[out]  dev         handle of the device to initialize
+ * @param[in]   uart        UART device to use
+ * @param[in]   baudrate    baudrate for UART device
+ * @param[in]   buf         buffer for incoming packets
+ * @param[in]   bufsize     size of @p buf
+ */
+void ethos_setup(ethos_t *dev, uart_t uart, uint32_t baudrate, uint8_t *buf, size_t bufsize);
+
+/**
+ * @brief send frame over serial port using ethos' framing
+ *
+ * This is used by e.g., stdio over ethos to send text frames.
+ *
+ * @param[in]   dev         handle of the device to initialize
+ * @param[in]   data        ptr to data to be sent
+ * @param[in]   len         nr of bytes to send
+ * @param[in]   frame_type  frame type to use
+ */
+void ethos_send_frame(ethos_t *dev, const uint8_t *data, size_t len, unsigned frame_type);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* ETHOS_H */
+/** @} */

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -158,6 +158,11 @@ void auto_init(void)
     auto_init_enc28j60();
 #endif
 
+#ifdef MODULE_ETHOS
+    extern void auto_init_ethos(void);
+    auto_init_ethos();
+#endif
+
 #ifdef MODULE_GNRC_SLIP
     extern void auto_init_slip(void);
     auto_init_slip();

--- a/sys/auto_init/netif/auto_init_ethos.c
+++ b/sys/auto_init/netif/auto_init_ethos.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup auto_init_gnrc_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for ethernet-over-serial module
+ *
+ * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifdef MODULE_ETHOS
+
+#include "ethos.h"
+#include "periph/uart.h"
+#include "net/gnrc/netdev2/eth.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+/**
+ * @brief global ethos object, used by uart_stdio
+ */
+ethos_t ethos;
+
+/**
+ * @brief   Define stack parameters for the MAC layer thread
+ * @{
+ */
+#define MAC_STACKSIZE           (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
+#define MAC_PRIO                (THREAD_PRIORITY_MAIN - 4)
+
+/**
+ * @brief   Stacks for the MAC layer threads
+ */
+static char _netdev2_eth_stack[MAC_STACKSIZE];
+static gnrc_netdev2_t _gnrc_ethos;
+
+static uint8_t _inbuf[2048];
+
+void auto_init_ethos(void)
+{
+    DEBUG("auto_init_ethos(): initializing device...\n");
+
+    /* setup netdev2 device */
+    ethos_setup(&ethos, ETHOS_UART,
+            ETHOS_BAUDRATE, _inbuf, sizeof(_inbuf));
+
+    /* initialize netdev2<->gnrc adapter state */
+    gnrc_netdev2_eth_init(&_gnrc_ethos, (netdev2_t*)&ethos);
+
+    /* start gnrc netdev2 thread */
+    gnrc_netdev2_init(_netdev2_eth_stack, MAC_STACKSIZE,
+            MAC_PRIO, "gnrc_ethos", &_gnrc_ethos);
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_ETHOS */
+/** @} */

--- a/sys/uart_stdio/uart_stdio.c
+++ b/sys/uart_stdio/uart_stdio.c
@@ -33,6 +33,11 @@
 #include "board.h"
 #include "periph/uart.h"
 
+#ifdef USE_ETHOS_FOR_STDIO
+#include "ethos.h"
+extern ethos_t ethos;
+#endif
+
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
@@ -67,7 +72,11 @@ void uart_stdio_rx_cb(void *arg, char data)
 
 void uart_stdio_init(void)
 {
+#ifndef USE_ETHOS_FOR_STDIO
     uart_init(STDIO, STDIO_BAUDRATE, uart_stdio_rx_cb, NULL);
+#else
+    uart_init(ETHOS_UART, ETHOS_BAUDRATE, uart_stdio_rx_cb, NULL);
+#endif
 }
 
 int uart_stdio_read(char* buffer, int count)
@@ -81,6 +90,10 @@ int uart_stdio_read(char* buffer, int count)
 
 int uart_stdio_write(const char* buffer, int len)
 {
+#ifndef USE_ETHOS_FOR_STDIO
     uart_write(STDIO, (uint8_t *)buffer, (size_t)len);
+#else
+    ethos_send_frame(&ethos, (uint8_t*)buffer, len, ETHOS_FRAME_TYPE_TEXT);
+#endif
     return len;
 }


### PR DESCRIPTION
I needed a one-cable solution for connecting boards with both network and console. So I came up with this driver, which is essentially l2 SLIP and additional support for multiplexing STDIO over the same serial connection.

It is an alternative to gnrc_slip / tuntap.

Differences:
- it implements a netdev driver
- it transfers l2 ethernet frames instead of IP packets
- it enables network and stdio over just one serial cable
- it uses a slightly more robust framing
- it is more code
- it is only tested on Linux
- it uses more memory
- it has slower ping times

The last two will probably be fixed.

In order to play with it, see ```dist/tools/ethos/README.md``` for what to add to your makefiles.