### PR TITLE
xbee: fixed several bugs

### DIFF
--- a/drivers/include/xbee.h
+++ b/drivers/include/xbee.h
@@ -68,7 +68,7 @@ extern "C" {
  * @brief   Default channel used after initialization
  */
 #ifndef XBEE_DEFAULT_CHANNEL
-#define XBEE_DEFAULT_CHANNEL        (26U)
+#define XBEE_DEFAULT_CHANNEL        (23U)
 #endif
 
 /**

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -538,10 +538,11 @@ static int _send(gnrc_netdev_t *netdev, gnrc_pktsnip_t *pkt)
         dev->tx_buf[1] = (uint8_t)((size + 5) >> 8);
         dev->tx_buf[2] = (uint8_t)(size + 5);
         dev->tx_buf[3] = API_ID_TX_SHORT_ADDR;
-        dev->tx_buf[4] = 0xff;
         dev->tx_buf[5] = 0xff;
+        dev->tx_buf[6] = 0xff;
+        pos = 7;
     }
-    if (hdr->dst_l2addr_len == IEEE802154_SHORT_ADDRESS_LEN) {
+    else if (hdr->dst_l2addr_len == IEEE802154_SHORT_ADDRESS_LEN) {
         dev->tx_buf[1] = (uint8_t)((size + 5) >> 8);
         dev->tx_buf[2] = (uint8_t)(size + 5);
         dev->tx_buf[3] = API_ID_TX_SHORT_ADDR;

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -131,6 +131,7 @@ static void _api_at_cmd(xbee_t *dev, uint8_t *cmd, uint8_t size, resp_t *resp)
     if (resp->data_len > 0) {
         memcpy(resp->data, &(dev->resp_buf[4]), resp->data_len);
     }
+    mutex_unlock(&(dev->tx_lock));
 }
 
 /*
@@ -569,6 +570,8 @@ static int _send(gnrc_netdev_t *netdev, gnrc_pktsnip_t *pkt)
     uart_write(dev->uart, dev->tx_buf, pos + 1);
     /* release data */
     gnrc_pktbuf_release(pkt);
+    /* release TX lock */
+    mutex_unlock(&(dev->tx_lock));
     /* return number of payload byte */
     return (int)size;
 }

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -268,21 +268,26 @@ static int _set_short_addr(xbee_t *dev, uint8_t *address)
 
 static int _set_addr(xbee_t *dev, uint8_t *val, size_t len)
 {
+    uint8_t addr[2];
+
     /* device only supports setting the short address */
     if (len != 2) {
         return -ENOTSUP;
     }
 
-    if (dev->addr_flags & XBEE_ADDR_FLAGS_LONG ||
-          _set_short_addr(dev, val) == 0) {
+    addr[0] = val[0];
+    addr[1] = val[1];
 
 #ifdef MODULE_SIXLOWPAN
-        /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit
-         * to 0 for unicast addresses */
-        val[1] &= 0x7F;
+    /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit
+     * to 0 for unicast addresses */
+    addr[1] &= 0x7F;
 #endif
 
-        memcpy(dev->addr_short, val, 2);
+    if (dev->addr_flags & XBEE_ADDR_FLAGS_LONG ||
+          _set_short_addr(dev, addr) == 0) {
+
+        memcpy(dev->addr_short, addr, 2);
 
         return 2;
     }

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -731,6 +731,23 @@ static void _isr_event(gnrc_netdev_t *netdev, uint32_t event_type)
         addr_len = IEEE802154_LONG_ADDRESS_LEN;
     }
 
+#ifdef XBEE_DENIED_ADDRESSES
+    if (addr_len == 8) {
+        uint8_t denied_addresses[] = XBEE_DENIED_ADDRESSES;
+        for (size_t i = 0; i < sizeof(denied_addresses) / 8; i++) {
+            if (memcmp(&(dev->rx_buf[1]),
+                       &denied_addresses[i * 8],
+                       addr_len) == 0) {
+                dev->rx_count = 0;
+
+                DEBUG("xbee: dropping denied packet\n");
+
+                return;
+            }
+        }
+    }
+#endif
+
     /* check checksum for correctness */
     for (int i = 0; i < dev->rx_limit; i++) {
         cksum += dev->rx_buf[i];

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -729,7 +729,7 @@ static void _isr_event(gnrc_netdev_t *netdev, uint32_t event_type)
     hdr->src_l2addr_len = (uint8_t)addr_len;
     hdr->dst_l2addr_len = (uint8_t)addr_len;
     hdr->if_pid = dev->mac_pid;
-    hdr->rssi = dev->rx_buf[2 + addr_len];
+    hdr->rssi = dev->rx_buf[1 + addr_len]; /* API ID + source address */
     hdr->lqi = 0;
     gnrc_netif_hdr_set_src_addr(hdr, &(dev->rx_buf[1]), addr_len);
     if (addr_len == 2) {


### PR DESCRIPTION
This PR fixes several bugs in XBee driver.

- `tx_lock` is not unlocked
- destination address field for broadcast packet is wrong
- RSSI header field is incorrectly parsed
- adds debug output of incoming/outgoing packets
- short address should be disabled when long address is enabled
- channel 0x1A is not supported by XBee-PRO
- `_set_addr` destructs long address in memory
- adds packet filtering functionality for debugging to emulate non-transitive network

See commit messages for details.

Tested on OS X with modifications of #4443 and #4444.
