### PR TITLE
fixes several bugs on GNRC network stack

### DIFF
--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -484,6 +484,8 @@ ipv6_addr_t *gnrc_ipv6_netif_find_addr(kernel_pid_t pid, const ipv6_addr_t *addr
  *
  * @param[in] prefix    The prefix you want to search for.
  *
+ * @pre     @p out must not be NULL.
+ *
  * @return  The PID to the interface the address is registered to.
  * @return  KERNEL_PID_UNDEF, if no matching address can not be found on any
  *          interface.

--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -163,6 +163,13 @@ void gnrc_ipv6_nc_remove(kernel_pid_t iface, const ipv6_addr_t *ipv6_addr)
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
         xtimer_remove(&entry->type_timeout);
+
+        gnrc_ipv6_netif_t *if_entry = gnrc_ipv6_netif_get(iface);
+
+        if ((if_entry != NULL) && (if_entry->rtr_adv_msg.content.ptr == (char *) entry)) {
+            /* cancel timer set by gnrc_ndp_rtr_sol_handle */
+            xtimer_remove(&if_entry->rtr_adv_timer);
+        }
 #endif
 #if defined(MODULE_GNRC_NDP_ROUTER) || defined(MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER)
         xtimer_remove(&entry->rtr_adv_timer);

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -502,10 +502,7 @@ kernel_pid_t gnrc_ipv6_netif_find_by_prefix(ipv6_addr_t **out, const ipv6_addr_t
         match = _find_by_prefix_unsafe(&tmp_res, ipv6_ifs + i, prefix, NULL);
 
         if (match > best_match) {
-            if (out != NULL) {
-                *out = tmp_res;
-            }
-
+            *out = tmp_res;
             res = ipv6_ifs[i].pid;
             best_match = match;
         }

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -154,10 +154,11 @@ kernel_pid_t gnrc_sixlowpan_nd_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_
     if (nc_entry != NULL) {
         gnrc_ipv6_netif_t *ipv6_if = gnrc_ipv6_netif_get(nc_entry->iface);
         /* and interface is not 6LoWPAN */
-        if (!(ipv6_if->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN) ||
+        if (!((ipv6_if == NULL) ||
+                (ipv6_if->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN)) ||
                 /* or entry is registered */
-                (gnrc_ipv6_nc_get_type(nc_entry) == GNRC_IPV6_NC_TYPE_REGISTERED)) {
-        next_hop = dst;
+              (gnrc_ipv6_nc_get_type(nc_entry) == GNRC_IPV6_NC_TYPE_REGISTERED)) {
+            next_hop = dst;
         }
     }
 #endif

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -430,7 +430,8 @@ bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt_t *opt
             case (GNRC_RPL_OPT_TARGET):
                 DEBUG("RPL: RPL TARGET DAO option parsed\n");
                 *included_opts |= ((uint32_t) 1) << GNRC_RPL_OPT_TARGET;
-                if_id = gnrc_ipv6_netif_find_by_prefix(NULL, &dodag->dodag_id);
+                ipv6_addr_t *prefix = NULL;
+                if_id = gnrc_ipv6_netif_find_by_prefix(&prefix, &dodag->dodag_id);
                 if (if_id == KERNEL_PID_UNDEF) {
                     DEBUG("RPL: no interface found for the configured DODAG id\n");
                     return false;

--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -88,6 +88,14 @@ static int fib_find_entry(fib_table_t *table, uint8_t *dst, size_t dst_size,
     int ret = -EHOSTUNREACH;
     bool is_all_zeros_addr = true;
 
+#if ENABLE_DEBUG
+    DEBUG("[fib_find_entry] dst =");
+    for (size_t i = 0; i < dst_size; i++) {
+        DEBUG(" %02x", dst[i]);
+    }
+    DEBUG("\n");
+#endif
+
     for (size_t i = 0; i < dst_size; ++i) {
         if (dst[i] != 0) {
             is_all_zeros_addr = false;
@@ -125,6 +133,7 @@ static int fib_find_entry(fib_table_t *table, uint8_t *dst, size_t dst_size,
             int ret_comp = universal_address_compare(table->data.entries[i].global, dst, &match_size);
             /* If we found an exact match */
             if (ret_comp == 0 || (is_all_zeros_addr && match_size == 0)) {
+                DEBUG("[fib_find_entry] found an exact match");
                 entry_arr[0] = &(table->data.entries[i]);
                 *entry_arr_size = 1;
                 /* we will not find a better one so we return */
@@ -147,6 +156,16 @@ static int fib_find_entry(fib_table_t *table, uint8_t *dst, size_t dst_size,
             }
         }
     }
+
+#if ENABLE_DEBUG
+    if (count > 0) {
+        DEBUG("[fib_find_entry] found prefix on interface %d:", entry_arr[0]->iface_id);
+        for (size_t i = 0; i < entry_arr[0]->global->address_size; i++) {
+            DEBUG(" %02x", entry_arr[0]->global->address[i]);
+        }
+        DEBUG("\n");
+    }
+#endif
 
     *entry_arr_size = count;
     return ret;


### PR DESCRIPTION
This PR fixes several bugs in GNRC network stack.

- fixed buffer overrun results from off-by-one error
- fixed crash when there are no 6LoWPAN routers
- fixed crash when both 6LoWPAN network and convensional IPv6 network are enabled
- fixed infinite loop in managing network prefixes
- fixed crash in debug output code
- fixed crash by cancelling timer no longer needed
- adds extra debug outputs for FIB

See commit messages for details.

This PR may or may not be broken by #3622. I will investigate later.

Tested on OS X with modifications of #4443, #4444, #4445, and #4446.
