### PR TITLE
fix warnings/errors thrown by clang on OS X

### DIFF
--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -89,7 +89,7 @@ typedef struct {
 static uint8_t _cksum(uint8_t *buf, size_t size)
 {
     uint8_t res = 0xff;
-    for (int i = 3; i < size; i++) {
+    for (size_t i = 3; i < size; i++) {
         res -= buf[i];
     }
     return res;
@@ -136,8 +136,9 @@ static void _api_at_cmd(xbee_t *dev, uint8_t *cmd, uint8_t size, resp_t *resp)
 /*
  * Interrupt callbacks
  */
-static void _rx_cb(void *arg, char c)
+static void _rx_cb(void *arg, char _c)
 {
+    unsigned char c = _c;
     xbee_t *dev = (xbee_t *)arg;
     msg_t msg;
 

--- a/sys/auto_init/netif/auto_init_xbee.c
+++ b/sys/auto_init/netif/auto_init_xbee.c
@@ -47,7 +47,7 @@ static char _nomac_stacks[XBEE_MAC_STACKSIZE][XBEE_NUM];
 
 void auto_init_xbee(void)
 {
-    for (int i = 0; i < XBEE_NUM; i++) {
+    for (size_t i = 0; i < XBEE_NUM; i++) {
         const xbee_params_t *p = &xbee_params[i];
         DEBUG("Initializing XBee radio at UART_%i\n", p->uart);
         int res = xbee_init(&xbee_devs[i],

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_eth.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_eth.c
@@ -85,7 +85,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netdev2_t *gnrc_netdev2)
         ((gnrc_netif_hdr_t *)netif_hdr->data)->if_pid = thread_getpid();
 
         DEBUG("gnrc_netdev2_eth: received packet from %02x:%02x:%02x:%02x:%02x:%02x "
-                "of length %zu\n",
+                "of length %d\n",
                 hdr->src[0], hdr->src[1], hdr->src[2], hdr->src[3], hdr->src[4],
                 hdr->src[5], nread);
 #if defined(MODULE_OD) && ENABLE_DEBUG

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -791,7 +791,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
 
 #ifdef MODULE_GNRC_IPV6_ROUTER    /* only routers redirect */
         /* redirect to next hop */
-        DEBUG("ipv6: decrement hop limit to %" PRIu8 "\n", hdr->hl - 1);
+        DEBUG("ipv6: decrement hop limit to %" PRIu8 "\n", (uint8_t) (hdr->hl - 1));
 
         /* RFC 4291, section 2.5.6 states: "Routers must not forward any
          * packets with Link-Local source or destination addresses to other

--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -123,7 +123,7 @@ gnrc_ipv6_nc_t *gnrc_ipv6_nc_add(kernel_pid_t iface, const ipv6_addr_t *ipv6_add
     DEBUG(" with flags = 0x%0x\n", flags);
 
     if (gnrc_ipv6_nc_get_state(free_entry) == GNRC_IPV6_NC_STATE_INCOMPLETE) {
-        DEBUG("ipv6_nc: Set remaining probes to %" PRIu8 "\n", GNRC_NDP_MAX_MC_NBR_SOL_NUMOF);
+        DEBUG("ipv6_nc: Set remaining probes to %" PRIu8 "\n", (uint8_t) GNRC_NDP_MAX_MC_NBR_SOL_NUMOF);
         free_entry->probes_remaining = GNRC_NDP_MAX_MC_NBR_SOL_NUMOF;
     }
 

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -303,7 +303,7 @@ static void _send(gnrc_pktsnip_t *pkt)
     }
     else {
         DEBUG("6lo: packet too big (%u > %" PRIu16 ")\n",
-              (unsigned int)datagram_size, SIXLOWPAN_FRAG_MAX_LEN);
+              (unsigned int)datagram_size, (uint16_t)SIXLOWPAN_FRAG_MAX_LEN);
         gnrc_pktbuf_release(pkt2);
     }
 #else

--- a/sys/net/network_layer/sixlowpan/sixlowpan_print.c
+++ b/sys/net/network_layer/sixlowpan/sixlowpan_print.c
@@ -41,7 +41,7 @@ void sixlowpan_print(uint8_t *data, size_t size)
 
         puts("Fragmentation Header (first)");
         printf("datagram size: %" PRIu16 "\n",
-               byteorder_ntohs(hdr->disp_size) & SIXLOWPAN_FRAG_SIZE_MASK);
+               (uint16_t) (byteorder_ntohs(hdr->disp_size) & SIXLOWPAN_FRAG_SIZE_MASK));
         printf("tag: 0x%" PRIu16 "\n", byteorder_ntohs(hdr->tag));
 
         /* Print next dispatch */
@@ -53,7 +53,7 @@ void sixlowpan_print(uint8_t *data, size_t size)
 
         puts("Fragmentation Header (subsequent)");
         printf("datagram size: %" PRIu16 "\n",
-               byteorder_ntohs(hdr->disp_size) & SIXLOWPAN_FRAG_SIZE_MASK);
+               (uint16_t) (byteorder_ntohs(hdr->disp_size) & SIXLOWPAN_FRAG_SIZE_MASK));
         printf("tag: 0x%" PRIu16 "\n", byteorder_ntohs(hdr->tag));
         printf("offset: 0x%" PRIu8 "\n", hdr->offset);
 
@@ -240,7 +240,7 @@ void sixlowpan_print(uint8_t *data, size_t size)
         if (data[1] & SIXLOWPAN_IPHC2_CID_EXT) {
             offset += SIXLOWPAN_IPHC_CID_EXT_LEN;
             printf("SCI: 0x%" PRIx8 "; DCI: 0x%" PRIx8 "\n",
-                   data[2] >> 4, data[2] & 0xf);
+                   (uint8_t) (data[2] >> 4), (uint8_t) (data[2] & 0xf));
         }
 
         od_hex_dump(data + offset, size - offset, OD_WIDTH_DEFAULT);

--- a/sys/shell/commands/sc_gnrc_6ctx.c
+++ b/sys/shell/commands/sc_gnrc_6ctx.c
@@ -54,7 +54,7 @@ int _gnrc_6ctx_list(void)
             char addr_str[IPV6_ADDR_MAX_STR_LEN];
             printf(" %2" PRIu8 "|%39s/%-3" PRIu8 "|%" PRIx8 "|%5" PRIu16 " min\n", i,
                    ipv6_addr_to_str(addr_str, &ctx->prefix, sizeof(addr_str)), ctx->prefix_len,
-                   (ctx->flags_id & 0xf0) >> 4, ctx->ltime);
+                   (uint8_t) ((ctx->flags_id & 0xf0) >> 4), ctx->ltime);
         }
     }
     return 0;


### PR DESCRIPTION
#4444 for 2015.12-branch
