### PR TITLE
sys: net: gnrc: ndp: consider all interfaces for on-link targets

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
+++ b/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
@@ -90,14 +90,8 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
 
     if (next_hop_ip == NULL) {            /* no route to host */
         if (!dst_link_local) {
-            if (iface == KERNEL_PID_UNDEF) {
-                /* gnrc_ipv6_netif_t doubles as prefix list */
-                iface = gnrc_ipv6_netif_find_by_prefix(&prefix, dst);
-            }
-            else {
-                /* gnrc_ipv6_netif_t doubles as prefix list */
-                prefix = gnrc_ipv6_netif_match_prefix(iface, dst);
-            }
+            /* gnrc_ipv6_netif_t doubles as prefix list */
+            iface = gnrc_ipv6_netif_find_by_prefix(&prefix, dst);
         }
 
         if (dst_link_local || ((prefix != NULL) &&


### PR DESCRIPTION
I stumbled over this in the following setup:

```
Linux (beef::2/64) <-> (beef::1) 6lr (dead::1) <->(dead::blah)
```

**edit** I'm using ethernet (ethos) between linux and 6lr and both RIOT's are samr21 xpro.

Without this patch, when trying to ping dead::1 from Linux host, RIOT tries to only consider prefixes from it's sixlowpan interface, so communication doesn't work.

With this patch, RIOT considers all configured prefixes for the best match.
