### PR TITLE
pkg tlsf: use pkg directory for sources

### DIFF
--- a/pkg/tlsf/Makefile
+++ b/pkg/tlsf/Makefile
@@ -2,15 +2,16 @@ PKG_NAME = tlsf
 PKG_VERSION = 3.0
 PKG_FILE = tlsf-$(PKG_VERSION).zip
 PKG_URL = http://download.riot-os.org/$(PKG_FILE)
+PKG_DIR=$(CURDIR)/$(PKG_NAME)
 
 .PHONY: all clean distclean
 
-all: $(BINDIR)$(PKG_NAME).a
+all: $(PKG_DIR)/$(PKG_NAME).a
 
-$(BINDIR)$(PKG_NAME).a: $(BINDIR)$(PKG_NAME)-src/Makefile
+$(PKG_DIR)/$(PKG_NAME).a: $(PKG_DIR)/Makefile
 	$(AD)make -C $(<D)
 
-$(BINDIR)$(PKG_NAME)-src/Makefile: $(CURDIR)/$(PKG_FILE) $(CURDIR)/patch.txt
+$(PKG_DIR)/Makefile: $(CURDIR)/$(PKG_FILE) $(CURDIR)/patch.txt
 	@rm -rf $(@D)
 	@mkdir -p $(@D)
 	$(AD)cd $(@D) && $(UNZIP_HERE) $(CURDIR)/$(PKG_FILE)
@@ -20,7 +21,7 @@ $(CURDIR)/$(PKG_FILE):
 	$(AD)$(DOWNLOAD_TO_FILE) $@ $(PKG_URL)
 
 clean::
-	rm -rf $(BINDIR)$(PKG_NAME)-src/
+	rm -rf $(PKG_DIR)/
 
 distclean:: clean
 	rm -f $(CURDIR)/$(PKG_FILE)

--- a/pkg/tlsf/Makefile.include
+++ b/pkg/tlsf/Makefile.include
@@ -1,1 +1,1 @@
-INCLUDES += -I$(BINDIR)tlsf-src
+INCLUDES += -I$(RIOTBASE)/pkg/tlsf/tlsf


### PR DESCRIPTION
The TLSF package was the only one using the $(BINDIR) instead of a subdirectory of pkg/. This commit changes this.

Fixes #4442.