### PR TITLE
Support flashing OpenMote via serial interface with 'make flash'

### DIFF
--- a/boards/openmote-cc2538/Makefile.include
+++ b/boards/openmote-cc2538/Makefile.include
@@ -6,11 +6,21 @@ export CPU_MODEL = cc2538sf53
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbserial-* | head -n 1)
 
-# setup JLink for flashing
-export JLINK_DEVICE := cc2538sf53
-export JLINK_FLASH_ADDR := 200000
-export JLINK_IF := JTAG
-include $(RIOTBOARD)/Makefile.include.jlink
+# Set default flash tool
+export PROGRAMMER ?= cc2538-bsl
+
+ifeq ($(PROGRAMMER),jlink)
+  # setup JLink for flashing
+  export JLINK_DEVICE := cc2538sf53
+  export JLINK_FLASH_ADDR := 200000
+  export JLINK_IF := JTAG
+  include $(RIOTBOARD)/Makefile.include.jlink
+else
+  export OFLAGS = -O binary
+  export HEXFILE = $(ELFFILE:.elf=.bin)
+  export FLASHER = python $(RIOTBASE)/dist/tools/cc2538-bsl/cc2538-bsl.py
+  export FFLAGS  = -p "$(PORT)" -e -w -v -b 460800 $(HEXFILE)
+endif
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial


### PR DESCRIPTION
Support flashing openmote-cc2538 board via cc2538-bsl script directly from Makefile target 'flash', and make this the default flashing method for this platform.

Fixes issue #4434.

TODO: Update wiki, which currently suggests that only JTAG flashing is supported.