### PR TITLE
shell: updated `fibroute` command to support prefix route

### DIFF
--- a/sys/include/net/ipv4/addr.h
+++ b/sys/include/net/ipv4/addr.h
@@ -30,6 +30,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Length of an IPv4 address in bit.
+ */
+#define IPV4_ADDR_BIT_LEN           (32)
+
+/**
  * @brief   Maximum length of an IPv4 address as string.
  */
 #define IPV4_ADDR_MAX_STR_LEN       (sizeof("255.255.255.255"))
@@ -82,6 +87,22 @@ char *ipv4_addr_to_str(char *result, const ipv4_addr_t *addr, uint8_t result_len
  * @return  NULL, if @p result or @p addr was NULL
  */
 ipv4_addr_t *ipv4_addr_from_str(ipv4_addr_t *result, const char *addr);
+
+/**
+ * @brief   Extract prefix length from prefix string
+ *          "ip-address/prefix-length"
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc4632">
+ *          RFC 4632
+ *      </a>
+ *
+ * @param[in] addr      An IPv4 prefix string representation
+ *
+ * @return  prefix length
+ * @return  -1, if @p addr was malformed
+ * @return  -1, if @p addr was NULL
+ */
+int ipv4_prefix_length_from_str(const char *addr);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/ipv6/addr.h
+++ b/sys/include/net/ipv6/addr.h
@@ -669,6 +669,22 @@ char *ipv6_addr_to_str(char *result, const ipv6_addr_t *addr, uint8_t result_len
  */
 ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr);
 
+/**
+ * @brief   Extract prefix length from prefix string
+ *          "ip-address/prefix-length"
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc4291#section-2.3">
+ *          RFC 4291 Section 2.3
+ *      </a>
+ *
+ * @param[in] addr      An IPv6 prefix string representation
+ *
+ * @return  prefix length
+ * @return  -1, if @p addr was malformed
+ * @return  -1, if @p addr was NULL
+ */
+int ipv6_prefix_length_from_str(const char *addr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/network_layer/ipv4/addr/ipv4_addr_from_str.c
+++ b/sys/net/network_layer/ipv4/addr/ipv4_addr_from_str.c
@@ -33,7 +33,7 @@ ipv4_addr_t *ipv4_addr_from_str(ipv4_addr_t *result, const char *addr)
     octets = 0;
     *(tp = tmp) = 0;
 
-    while ((ch = *addr++) != '\0') {
+    while ((ch = *addr++) != '\0' && ch != '/') {
         const char *pch;
 
         if ((pch = strchr(DEC, ch)) != NULL) {
@@ -74,5 +74,23 @@ ipv4_addr_t *ipv4_addr_from_str(ipv4_addr_t *result, const char *addr)
     return result;
 }
 
+
+int ipv4_prefix_length_from_str(const char *addr) {
+    while ((*addr != '/') && (*addr != '\0')) {
+        addr++;
+    }
+
+    if (*addr == '/') {
+        int prefix_len = atoi(addr + 1);
+
+        if ((prefix_len < 0) || (prefix_len > IPV4_ADDR_BIT_LEN)) {
+            return -1;
+        } else {
+            return prefix_len;
+        }
+    } else {
+        return -1;
+    }
+}
 
 /** @} */

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr_from_str.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr_from_str.c
@@ -62,7 +62,7 @@ ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr)
         }
     }
 
-    while ((ch = *addr++) != '\0') {
+    while ((ch = *addr++) != '\0' && ch != '/') {
         const char *pch;
         const char *xdigits;
 
@@ -149,6 +149,24 @@ ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr)
     }
 
     return result;
+}
+
+int ipv6_prefix_length_from_str(const char *addr) {
+    while ((*addr != '/') && (*addr != '\0')) {
+        addr++;
+    }
+
+    if (*addr == '/') {
+        int prefix_len = atoi(addr + 1);
+
+        if ((prefix_len < 0) || (prefix_len > IPV6_ADDR_BIT_LEN)) {
+            return -1;
+        } else {
+            return prefix_len;
+        }
+    } else {
+        return -1;
+    }
 }
 
 /**

--- a/sys/shell/commands/sc_fib.c
+++ b/sys/shell/commands/sc_fib.c
@@ -80,15 +80,22 @@ static void _fib_add(const char *dest, const char *next, kernel_pid_t pid, uint3
     unsigned char *nxt = (unsigned char *)next;
     size_t nxt_size = (strlen(next));
     uint32_t nxt_flags = 0;
+    int prefix_len = -1;
 
     /* determine destination address */
     if (inet_pton(AF_INET6, dest, tmp_ipv6_dst)) {
         dst = tmp_ipv6_dst;
         dst_size = IN6ADDRSZ;
+        prefix_len = ipv6_prefix_length_from_str(dest);
     }
     else if (inet_pton(AF_INET, dest, tmp_ipv4_dst)) {
         dst = tmp_ipv4_dst;
         dst_size = INADDRSZ;
+        prefix_len = ipv6_prefix_length_from_str(dest);
+    }
+
+    if (prefix_len >= 0) {
+        dst_flags |= FIB_FLAG_NET_PREFIX;
     }
 
     /* determine next-hop address */

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -679,22 +679,13 @@ static int _netif_flag(char *cmd, kernel_pid_t dev, char *flag)
 #ifdef MODULE_GNRC_IPV6_NETIF
 static uint8_t _get_prefix_len(char *addr)
 {
-    int prefix_len = SC_NETIF_IPV6_DEFAULT_PREFIX_LEN;
+    int prefix_len = ipv6_prefix_length_from_str(addr);
 
-    while ((*addr != '/') && (*addr != '\0')) {
-        addr++;
+    if (prefix_len < 1) {
+        return SC_NETIF_IPV6_DEFAULT_PREFIX_LEN;
+    } else {
+        return prefix_len;
     }
-
-    if (*addr == '/') {
-        *addr = '\0';
-        prefix_len = atoi(addr + 1);
-
-        if ((prefix_len < 1) || (prefix_len > IPV6_ADDR_BIT_LEN)) {
-            prefix_len = SC_NETIF_IPV6_DEFAULT_PREFIX_LEN;
-        }
-    }
-
-    return prefix_len;
 }
 #endif
 


### PR DESCRIPTION
For example, `fibroute add ::/0 via fe80::1 dev 7` adds a default route via `fe80::1` on device `7`.

Unfortunately, current FIB does not store prefix length, so that the prefix length is ignored and only `FIB_FLAG_NET_PREFIX` is set.
