### PR TITLE
vagrant: change the default mount point and include vim

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,7 @@ Vagrant.configure(2) do |config|
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder ".", "/home/vagrant/RIOT"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
@@ -29,7 +30,7 @@ Vagrant.configure(2) do |config|
   #   vb.gui = true
   #
   #   # Set name of the VM
-    vb.name = "RIOT-OS VM"
+    vb.name = "RIOT VM"
   #
   #   # Customize the amount of memory on the VM:
   #   vb.memory = "1024"

--- a/dist/tools/vagrant/bootstrap.sh
+++ b/dist/tools/vagrant/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 apt-get update
-apt-get install -y pcregrep libpcre3 python3 git gcc-arm-none-eabi gcc-msp430 unzip \
+apt-get install -y pcregrep libpcre3 python3 git gcc-arm-none-eabi gcc-msp430 unzip vim \
     qemu-system-x86 g++-multilib gcc-multilib build-essential gcc-avr binutils-avr avr-libc \
     avrdude doxygen cppcheck python-setuptools libusb-1.0-0 libusb-1.0-0-dev libftdi1 libftdi-dev \
     libftdipp1-dev libftdipp1-2v5 libhidapi-dev libhidapi-hidraw0 libhidapi-libusb0 make cmake \

--- a/dist/tools/vagrant/bootstrap.sh
+++ b/dist/tools/vagrant/bootstrap.sh
@@ -22,14 +22,8 @@ if ! hash experiment-cli 2>/dev/null; then
     cd cli-tools-1.6.0 && python setup.py install && cd .. && rm -rf cli-tools-1.6.0
 fi
 
-# create a symbolic link to the RIOT-OS directory
-if ! [ -L /home/vagrant/RIOT-OS ]; then
-    ln -fs /vagrant /home/vagrant/RIOT-OS
-    chown -h vagrant:vagrant /home/vagrant/RIOT-OS
-fi
-
 # copy udev rules
-cp -f RIOT-OS/dist/tools/vagrant/udev_rules/*.rules /etc/udev/rules.d/
+cp -f RIOT/dist/tools/vagrant/udev_rules/*.rules /etc/udev/rules.d/
 udevadm control --reload-rules ; udevadm trigger
 
 # cleanup


### PR DESCRIPTION
This PR renames all occurences of `RIOT-OS` to `RIOT`. In addition I changed the default mount point from `/vagrant` to `/home/vagrant/RIOT`. The second commit adds `vim` to the VM.