### PR TITLE
posix_sockets: fix overflowing fd in close()

### DIFF
--- a/sys/net/gnrc/conn/udp/gnrc_conn_udp.c
+++ b/sys/net/gnrc/conn/udp/gnrc_conn_udp.c
@@ -56,6 +56,7 @@ void conn_udp_close(conn_udp_t *conn)
     assert(conn->l4_type == GNRC_NETTYPE_UDP);
     if (conn->netreg_entry.pid != KERNEL_PID_UNDEF) {
         gnrc_netreg_unregister(GNRC_NETTYPE_UDP, &conn->netreg_entry);
+        conn->netreg_entry.pid = KERNEL_PID_UNDEF;
     }
 }
 

--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -255,6 +255,7 @@ static int socket_close(int socket)
                         res = -1;
                         break;
                 }
+                break;
             default:
                 res = -1;
                 break;


### PR DESCRIPTION
The missing `break;` statement lead to the case of not freeing the `fd`. Several invocations of `sendto` would then count up the file handler until the limit is reached and when this happens, it won't be possible to create a new socket.

The change to `conn->netreg_entry.pid` is only slightly related. Without this addition `gnrc_netreg_unregister` will be called for every `conn_udp_create()` call (`conn_udp_close` checks for `KERNEL_PID_UNDEF` before executing `gnrc_netreg_unregister`. However, `conn->netreg_entry.pid` is still set from the last run)