### PR TITLE
core: remove eINT/dINT

### DIFF
--- a/core/include/irq.h
+++ b/core/include/irq.h
@@ -31,8 +31,6 @@
 /**
  * @brief   This function sets the IRQ disable bit in the status register
  *
- * @note    This function should be used in favour of dINT().
- *
  * @return  Previous value of status register. The return value should not
  *          interpreted as a boolean value. The actual value is only
  *          significant for restoreIRQ().
@@ -43,8 +41,6 @@ unsigned disableIRQ(void);
 
 /**
  * @brief   This function clears the IRQ disable bit in the status register
- *
- * @note    This function should be used in favour of eINT().
  *
  * @return  Previous value of status register. The return value should not
  *          interpreted as a boolean value. The actual value is only
@@ -59,8 +55,6 @@ unsigned enableIRQ(void);
  *          to the value contained within passed state
  *
  * @param[in] state   state to restore
- *
- * @note    This function should be used in favour of eINT().
  *
  * @see     enableIRQ
  * @see     disableIRQ

--- a/cpu/msp430-common/include/cpu.h
+++ b/cpu/msp430-common/include/cpu.h
@@ -45,14 +45,6 @@ extern "C" {
 #define ISR(a,b)        void __attribute__((naked, interrupt (a))) b(void)
 
 /**
- * @brief   Deprecated interrupt control functions for backward compatibility
- * @{
- */
-#define eINT            enableIRQ
-#define dINT            disableIRQ
-/** @} */
-
-/**
  * @brief Globally disable IRQs
  */
 static inline void __attribute__((always_inline)) __disable_irq(void)

--- a/cpu/x86/include/cpu.h
+++ b/cpu/x86/include/cpu.h
@@ -51,22 +51,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Disable interrupts
- */
-static inline void __attribute__((always_inline)) dINT(void)
-{
-    asm volatile ("cli");
-}
-
-/**
- * @brief Enable interrupts
- */
-static inline void __attribute__((always_inline)) eINT(void)
-{
-    asm volatile ("sti");
-}
-
-/**
  * @brief   Disable interrupts and halt forever.
  *
  * This function is the last resort in case of an unrecoverable error.

--- a/cpu/x86/x86_threading.c
+++ b/cpu/x86/x86_threading.c
@@ -142,7 +142,7 @@ void isr_cpu_switch_context_exit(void)
 
 void cpu_switch_context_exit(void)
 {
-    dINT();
+    disableIRQ();
 
     if (!x86_in_isr) {
         x86_in_isr = true;
@@ -206,7 +206,7 @@ static void fpu_used_interrupt(uint8_t intr_num, struct x86_pushad *orig_ctx, un
 
 static void x86_thread_exit(void)
 {
-    dINT();
+    disableIRQ();
     if (fpu_owner == sched_active_pid) {
         fpu_owner = KERNEL_PID_UNDEF;
     }


### PR DESCRIPTION
```dINT()``` was used only twice in ```x86_threading.c```, ```eINT()``` only defined for x86 and msp430, but never used. So IMHO it's time to get rid of them.