### PR TITLE
gnrc_sixlowpan: Fix IPHC/NHC packet order problem

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/iphc.h
+++ b/sys/include/net/gnrc/sixlowpan/iphc.h
@@ -32,11 +32,11 @@ extern "C" {
 /**
  * @brief   Decompresses a received 6LoWPAN IPHC frame.
  *
- * @pre (ipv6 != NULL) && (ipv6->size >= sizeof(gnrc_ipv6_hdr_t))
+ * @pre (dec_hdr != NULL) && (*dec_hdr != NULL) && ((*dec_hdr)->size >= sizeof(gnrc_ipv6_hdr_t))
  *
- * @param[out] ipv6         A pre-allocated IPv6 header. Will not be inserted into
- *                          @p pkt
- * @param[in,out] pkt       A received 6LoWPAN IPHC frame. IPHC dispatch will not
+ * @param[out] dec_hdr      A pre-allocated IPv6 header. Will not be inserted into
+ *                          @p pkt. May change due to next headers being added in NHC.
+ * @param[in] pkt           A received 6LoWPAN IPHC frame. IPHC dispatch will not
  *                          be marked.
  * @param[in] datagram_size Size of the full uncompressed IPv6 datagram. May be 0, if @p pkt
  *                          contains the full (unfragmented) IPv6 datagram.
@@ -45,8 +45,8 @@ extern "C" {
  * @return  length of the HC dispatches + inline values on success.
  * @return  0 on error.
  */
-size_t gnrc_sixlowpan_iphc_decode(gnrc_pktsnip_t *ipv6, gnrc_pktsnip_t *pkt, size_t datagram_size,
-                                  size_t offset);
+size_t gnrc_sixlowpan_iphc_decode(gnrc_pktsnip_t **dec_hdr, gnrc_pktsnip_t *pkt,
+                                  size_t datagram_size, size_t offset);
 
 /**
  * @brief   Compresses a 6LoWPAN for IPHC.

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -92,7 +92,7 @@ void rbuf_add(gnrc_netif_hdr_t *netif_hdr, gnrc_pktsnip_t *pkt,
 #ifdef MODULE_GNRC_SIXLOWPAN_IPHC
         else if (sixlowpan_iphc_is(data)) {
             size_t iphc_len;
-            iphc_len = gnrc_sixlowpan_iphc_decode(entry->pkt, pkt, entry->pkt->size,
+            iphc_len = gnrc_sixlowpan_iphc_decode(&entry->pkt, pkt, entry->pkt->size,
                                                   sizeof(sixlowpan_frag_t));
             if (iphc_len == 0) {
                 DEBUG("6lo rfrag: could not decode IPHC dispatch\n");

--- a/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
+++ b/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
@@ -109,10 +109,10 @@ static void _receive(gnrc_pktsnip_t *pkt)
 
     assert(ipv6 != NULL);
 
-    if ((ipv6->next != NULL) && (ipv6->next->type == GNRC_NETTYPE_UDP) &&
-        (ipv6->next->size == sizeof(udp_hdr_t))) {
+    if ((pkt->next != NULL) && (pkt->next->type == GNRC_NETTYPE_UDP) &&
+        (pkt->next->size == sizeof(udp_hdr_t))) {
         /* UDP header was already marked. Take it. */
-        udp = ipv6->next;
+        udp = pkt->next;
     }
     else {
         udp = gnrc_pktbuf_mark(pkt, sizeof(udp_hdr_t), GNRC_NETTYPE_UDP);


### PR DESCRIPTION
Fixes #4397 (and maybe #4462). Could not test because for some reason I can't send anything right now (even with `txtsnd`).

Here is the general idea of this fix: the `ipv6` parameter of `gnrc_sixlowpan_iphc_decode()` is replaced with the out-parameter `dec_hdr`. While `gnrc_sixlowpan_iphc_decode()` handles the dereferenced pointer the same as it used to handle `ipv6` `iphc_nhc_udp_decode()` sets it to the UDP header and appends the IPv6 header (the old value of `dec_hdr`) to the UDP header. This way the correct header order should be preserved.

Depends on ~~#4507~~ (merged).