### PR TITLE
gnrc_ndp: add external routers to FIB when RPL is enabled

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -715,9 +715,7 @@ void gnrc_ndp_rtr_adv_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt, ipv6_hdr_t
 
 #if defined(MODULE_GNRC_RPL) && defined(MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER)
     if (!(if_entry->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN)) {
-        ipv6_addr_t default_route_prefix;
-
-        memset(default_route_prefix.u8, 0, sizeof(ipv6_addr_t));
+        ipv6_addr_t default_route_prefix = IPV6_ADDR_UNSPECIFIED;
 
         _add_prefix_route(iface,
                           default_route_prefix.u8,

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -779,7 +779,7 @@ void gnrc_rpl_send_DAO(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination, uint
             }
             addr = (ipv6_addr_t *) fentry->global->address;
             if (ipv6_addr_is_global(addr)) {
-                size_t prefix_length = IPV6_ADDR_BIT_LEN;
+                size_t prefix_length;
 
                 if (fentry->global_flags & FIB_FLAG_NET_PREFIX) {
                     universal_address_compare(fentry->global,


### PR DESCRIPTION
# Summary

This patch adds FIB entries when a 6LoWPAN border router received Router Advertisements from external network.
# What I want to do

![page_006](https://cloud.githubusercontent.com/assets/3772478/11923457/3e7172ee-a7e7-11e5-8983-57e30dda1463.png)

Suppose a 6LoWPAN network with RPL routing. The root is connected to the internet and a leaf node is connected a intranet. I want exchange packets between the intranet and the internet via the 6LoWPAN network.

I don't want to do manual network settings as much as possible. It should be configured by IPv6 Router Advertisement and/or RPL.
# What we need

![page_007](https://cloud.githubusercontent.com/assets/3772478/11923466/5610811a-a7e7-11e5-9f3b-d0a9e476d04f.png)

The FIB of the root node should forward all packets addressed to the intranet or 6LoWPAN nodes to the 6LoWPAN network, and all other packets to the upstream router given by Router Advertisements.

The FIB of the leaf node should forward all packets addressed to the intranet to the intranet router given by Router Advertisements, and all other packets to the RPL parent.

The current FIB implementation only stores internal entries for 6LoWPAN (and manually configured external nodes, but not prefixes).
# How to achieve this

When the RPL root received a Router Advertisement from non-6LoWPAN network, register it as a upstream gateway.
When the RPL leaf received a Router Advertisement with Prefix Information from non-6LoWPAN network, register the prefix as a external network. Propagate it with RPL DAO message up to the root.

Changes on `gnrc_ndp.c` register routers to FIB. Changes on `gnrc_rpl_control_messages.c` propagate them up to the root node.

This patch guess prefix lengths of FIB entries with `universal_address_compare`. It should be updated when #4279 is merged.
# Usage

Tested on two OS X machines and three XBees using `examples/gnrc_xbee_border_router` (#4448). Use https://github.com/Yonezawa-T2/RIOT/tree/xbee_border_router branch, which contains several fixes of other Pull Requests, for testing.

RIOT 1 (examples/gnrc_xbee_border_router on OS X 1):

```
ifconfig 6 add unicast fd00::2/64
ifconfig 7 add unicast fd01::2/64
rpl init 6
rpl root 0 fd00::2
```

OS X 1:

```
sudo ifconfig tap0 inet6 fd01::1/64 up
sudo route -n add -inet6 -prefixlen 64 fd00:: fd01::2
sudo route -n add -inet6 -prefixlen 64 fd02:: fd01::2
sudo sysctl -w net.inet6.ip6.forwarding=1
sudo rtadvd -d -D -f tap0
```

RIOT 2 (examples/gnrc_xbee_router, not a border router, on OS X 1):

```
rpl init 6
rpl router 0
```

RIOT 3 (examples/gnrc_xbee_border_router on OS X 2):

```
ifconfig 7 add unicast fd02::2/64
rpl init 6
rpl leaf 0
```

OS X 2:

```
sudo ifconfig tap0 inet6 fd02::1/64 up
sudo route -n add -inet6 -prefixlen 64 fd01:: fd02::2
sudo sysctl -w net.inet6.ip6.forwarding=1
sudo rtadvd -d -D -f tap0

ping6 fd01::1
```

Change `XBEE_DENIED_ADDRESSES` in Makefile to prohibit direct communication between RIOT 1 and RIOT 3.
