### PR TITLE
native: make use of TLSF malloc and co

### DIFF
--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -134,6 +134,10 @@ void _native_syscall_leave(void)
     }
 }
 
+/* make use of TLSF if it is included, except when building with valgrind
+ * support, where one probably wants to make use of valgrind's memory leak
+ * detection abilities*/
+#if !(defined MODULE_TLSF) || (defined(HAVE_VALGRIND_H))
 int _native_in_malloc = 0;
 void *malloc(size_t size)
 {
@@ -204,6 +208,7 @@ void *realloc(void *ptr, size_t size)
     _native_syscall_leave();
     return r;
 }
+#endif /* !(defined MODULE_TLSF) || (defined(HAVE_VALGRIND_H)) */
 
 ssize_t _native_read(int fd, void *buf, size_t count)
 {


### PR DESCRIPTION
In order to make native behave more similar to other platforms, it should also use TLSF's dynamic memory allocation if included. It will still fall back to the system's malloc implementation when building for use with valgrind, to leverage its memory leak detection mechanisms.