### PR TITLE
ipv6_hdr: add ipv6_addr as dependency

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -245,6 +245,7 @@ endif
 
 ifneq (,$(filter ipv6_hdr,$(USEMODULE)))
   USEMODULE += inet_csum
+  USEMODULE += ipv6_addr
 endif
 
 ifneq (,$(filter gnrc_ipv6_nc,$(USEMODULE)))


### PR DESCRIPTION
https://github.com/RIOT-OS/RIOT/pull/4373 moved `ipv6_addr_equal()` to the C file. Since `ipv6_hdr` uses this function, builds that pull in `ipv6_hdr` but not `ipv6_addr` (like individual unittests) fail.