### PR TITLE
unittests: deactivate relic tests for all but native

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -15,11 +15,30 @@ else
     UNIT_TESTS := $(filter tests-%, $(MAKECMDGOALS))
 endif
 
+ARM7_BOARDS := msba2 avrextrem
+DISABLE_TEST_FOR_ARM7 := tests-relic
+
+ARM_CORTEX_M_BOARDS := airfy-beacon arduino-due cc2538dk ek-lm4f120xl f4vi1 fox frdm-k64f \
+                       iotlab-m3 limifrog-v1 mbed_lpc1768 msbiot mulle nrf51dongle nrf6310 \
+                       nucleo-f091 nucleo-f303 nucleo-f334 nucleo-f401 nucleo-l1 openmote \
+                       pba-d-01-kw2x pca10000 pca10005 remote saml21-xpro samr21-xpro slwstk6220a \
+                       spark-core stm32f0discovery stm32f3discovery stm32f4discovery udoo weio \
+                       yunjia-nrf51822
+DISABLE_TEST_FOR_ARM_CORTEX_M := tests-relic
+
 AVR_BOARDS := arduino-mega2560
 DISABLE_TEST_FOR_AVR := tests-relic
 
 MSP430_BOARDS :=  chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
 DISABLE_TEST_FOR_MSP430 := tests-relic
+
+ifneq (, $(filter $(ARM7_BOARDS), $(BOARD)))
+UNIT_TESTS := $(filter-out $(DISABLE_TEST_FOR_ARM7), $(UNIT_TESTS))
+endif
+
+ifneq (, $(filter $(ARM_CORTEX_M_BOARDS), $(BOARD)))
+UNIT_TESTS := $(filter-out $(DISABLE_TEST_FOR_ARM_CORTEX_M), $(UNIT_TESTS))
+endif
 
 ifneq (, $(filter $(AVR_BOARDS), $(BOARD)))
 UNIT_TESTS := $(filter-out $(DISABLE_TEST_FOR_AVR), $(UNIT_TESTS))


### PR DESCRIPTION
Temporary fix for https://github.com/RIOT-OS/RIOT/issues/4512.