### PR TITLE
uncrustify: don't use tabs for alignment and don't align struct initializations

### DIFF
--- a/uncrustify-riot.cfg
+++ b/uncrustify-riot.cfg
@@ -62,7 +62,7 @@ sp_inside_sparen    = remove    # remove spaces inside parens for if, while and 
 # Aligning stuff
 #
 
-align_with_tabs     = TRUE      # use tabs to align
+align_with_tabs     = FALSE     # use tabs to align
 align_on_tabstop    = TRUE      # align on tabstops
 align_enum_equ_span = 4         # '=' in enum definition
 align_struct_init_span  = 3     # align stuff in a structure init '= { }'

--- a/uncrustify-riot.cfg
+++ b/uncrustify-riot.cfg
@@ -65,5 +65,5 @@ sp_inside_sparen    = remove    # remove spaces inside parens for if, while and 
 align_with_tabs     = FALSE     # use tabs to align
 align_on_tabstop    = TRUE      # align on tabstops
 align_enum_equ_span = 4         # '=' in enum definition
-align_struct_init_span  = 3     # align stuff in a structure init '= { }'
+align_struct_init_span  = 0     # align stuff in a structure init '= { }'
 align_right_cmt_span    = 3


### PR DESCRIPTION
More fixes to uncrustify config.