### PR TITLE
gnrc_ipv6_netif: fixed buffer overrun

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -745,7 +745,7 @@ static ipv6_addr_t *_source_address_selection(gnrc_ipv6_netif_t *iface, const ip
     }
 
     /* reset candidate set to mark winners */
-    memset(candidate_set, 0, (GNRC_IPV6_NETIF_ADDR_NUMOF / 8) + 1);
+    memset(candidate_set, 0, (GNRC_IPV6_NETIF_ADDR_NUMOF + 7) / 8);
     /* check if we have a clear winner */
     /* collect candidates with maximum points */
     for (int i = 0; i < GNRC_IPV6_NETIF_ADDR_NUMOF; i++) {


### PR DESCRIPTION
The size of a bitfield should be computed by `(bits + 7) / 8`. If `bits` is 8, `(bits / 8) + 1` is 2 instead of 1, results in buffer overrun. bitfield.h and bitfield.c use the correct formula.

Splitted from #4447.