### PR TITLE
sixlowpan: iphc: remove dispatch and assign result to pkt

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -151,7 +151,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
         }
 
         /* Remove IPHC dispatches */
-        gnrc_pktbuf_remove_snip(pkt, sixlowpan);
+        pkt = gnrc_pktbuf_remove_snip(pkt, sixlowpan);
         /* Insert decoded header instead */
         LL_SEARCH_SCALAR(dec_hdr, tmp, next, NULL); /* search last decoded header */
         tmp->next = pkt->next;


### PR DESCRIPTION
the result of `gnrc_pktbuf_remove_snip()` needs to be assigned to `pkt`. Otherwise, I receive a hard fault as described in https://github.com/RIOT-OS/RIOT/issues/4462#issuecomment-166701112