### PR TITLE
sixlowpan: iphc: remove dispatch and assign result to pkt (backport)

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -151,7 +151,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
         }
 
         /* Remove IPHC dispatches */
-        gnrc_pktbuf_remove_snip(pkt, sixlowpan);
+        pkt = gnrc_pktbuf_remove_snip(pkt, sixlowpan);
         /* Insert decoded header instead */
         LL_SEARCH_SCALAR(dec_hdr, tmp, next, NULL); /* search last decoded header */
         tmp->next = pkt->next;


### PR DESCRIPTION
backport version of #4539