### PR TITLE
fix@nhc-on-br

### DIFF
--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -179,8 +179,10 @@ int gnrc_pktbuf_realloc_data(gnrc_pktsnip_t *pkt, size_t size)
         pkt->data = new_data;
     }
     else {
-        _pktbuf_free(((uint8_t *)pkt->data) + aligned_size,
-                     pkt->size - aligned_size);
+        if (_align(pkt->size) > aligned_size) {
+            _pktbuf_free(((uint8_t *)pkt->data) + aligned_size,
+                         pkt->size - aligned_size);
+        }
     }
     pkt->size = size;
     mutex_unlock(&_mutex);


### PR DESCRIPTION
This PR fixes the UDP transmission from a RIOT-br to a RIOT-node.
The problem is that the forwarded packet has no nested structure (such as a packet generated on the node, for example, pkt->next-> next-> type == GNRC_NETTYPE_UDP).

fix for testing, see  #4462
Tested on PhyNode(pba-d-01-kw2x) as BR and PhyNode as node (microcoap_server).