### PR TITLE
rbuf: use bitmap for overlapping detection

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -156,7 +156,7 @@ void rbuf_add(gnrc_netif_hdr_t *netif_hdr, gnrc_pktsnip_t *pkt,
 
 static inline bool _rbuf_int_in(uint8_t *bitmap, uint16_t start, uint16_t end)
 {
-    for (int i = start / 8; i < end / 8; i++) {
+    for (int i = start / 8; i < (end + 7) / 8; i++) {
         if (bf_isset(bitmap, i)) {
             return true;
         }
@@ -174,7 +174,7 @@ static void _rbuf_update_ints(rbuf_t *entry, uint16_t offset, size_t frag_size)
 {
     uint16_t end = (uint16_t)(offset + frag_size);
 
-    for (int i = offset / 8; i < end / 8; i++) {
+    for (int i = offset / 8; i < (end + 7) / 8; i++) {
         bf_set(entry->int_bitmap, i);
     }
 

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
@@ -23,8 +23,11 @@
 
 #include "net/gnrc/netif/hdr.h"
 #include "net/gnrc/pkt.h"
+#include "net/gnrc/ipv6.h"
 
 #include "net/gnrc/sixlowpan/frag.h"
+
+#include "bitfield.h"
 #ifdef __cplusplus
 
 extern "C" {
@@ -33,24 +36,7 @@ extern "C" {
 #define RBUF_L2ADDR_MAX_LEN (8U)    /**< maximum length for link-layer addresses */
 #define RBUF_SIZE           (4U)    /**< size of the reassembly buffer */
 #define RBUF_TIMEOUT        (3U)    /**< timeout for reassembly in seconds */
-
-/**
- * @brief   Fragment intervals to identify limits of fragments.
- *
- * @note    Fragments MUST NOT overlap and overlapping fragments are to be
- *          discarded
- *
- * @see <a href="https://tools.ietf.org/html/rfc4944#section-5.3">
- *          RFC 4944, section 5.3
- *      </a>
- *
- * @internal
- */
-typedef struct rbuf_int {
-    struct rbuf_int *next;  /**< next element in interval list */
-    uint16_t start;         /**< start byte of interval */
-    uint16_t end;           /**< end byte of interval */
-} rbuf_int_t;
+#define RBUF_INT_BITMAP_SIZE (IPV6_MIN_MTU / 8) /**< size of the interval bitmap */
 
 /**
  * @brief   An entry in the 6LoWPAN reassembly buffer.
@@ -71,7 +57,6 @@ typedef struct rbuf_int {
  * @internal
  */
 typedef struct {
-    rbuf_int_t *ints;                   /**< intervals of the fragment */
     gnrc_pktsnip_t *pkt;                /**< the reassembled packet in packet buffer */
     uint32_t arrival;                   /**< time in seconds of arrival of last
                                          *   received fragment */
@@ -81,6 +66,17 @@ typedef struct {
     uint8_t dst_len;                    /**< length of destination address */
     uint16_t tag;                       /**< the datagram's tag */
     uint16_t cur_size;                  /**< the datagram's current size */
+    /**
+     * @brief   Bitmap for received intervals.
+     *
+     * @note    Fragments MUST NOT overlap and overlapping fragments are to be
+     *          discarded
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc4944#section-5.3">
+     *          RFC 4944, section 5.3
+     *      </a>
+     */
+    BITFIELD(int_bitmap, RBUF_INT_BITMAP_SIZE);
 } rbuf_t;
 
 /**

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
@@ -77,6 +77,8 @@ typedef struct {
      *      </a>
      */
     BITFIELD(int_bitmap, RBUF_INT_BITMAP_SIZE);
+    uint8_t last_offset;                /**< offset of last received fragment, divided by 8 */
+    uint8_t last_size;                  /**< size of last received fragment */
 } rbuf_t;
 
 /**


### PR DESCRIPTION
`rbuf.c`, that is, 6LoWPAN fragment reassembly buffer uses `rbuf_int_t` linked list to remember received fragment intervals to detect overlapping fragment. The intervals are allocated as follows:

```
#define RBUF_INT_SIZE   (GNRC_IPV6_NETIF_DEFAULT_MTU * RBUF_SIZE / 127)
static rbuf_int_t rbuf_int[RBUF_INT_SIZE];
```

`GNRC_IPV6_NETIF_DEFAULT_MTU` is defined as 1280, so that 10 intervals per `rbuf_t` is allocated. In contrast, IPv6 packet of 1280 bytes length may be fragmented into 14 or more pieces, so 10 intervals are insufficient, causing "no space left in rbuf interval buffer" error.

Possible Options:

- A: increase `RBUF_INT_SIZE`: easy, increases memory, still fails if MTU of lower-layer is smaller than 102 bytes
- B: merging adjacent intervals: memory efficient, still not 100% safe
- C: using bitmaps to manage intervals: memory efficient, 100% safe, simple

This patch implements the option C.

Fragment offsets and sizes are all in unit of 8 bytes, so that we need only 1280 / 8 / 8 = 20 bytes per `rbuf_t`. This is smaller than `sizeof(rbuf_int_t) * 10`, which is 80 for 32-bit address platforms.

This patch checks overlaps bit by bit. Since typical size of a fragment is 96 bytes, the routine checks 12 bits for a fragment. Using more complex byte-by-byte method would not yield performance gain for such small case.
