### PR TITLE
core: bitarithm: use lookup table for bitarithm_lsb()

### DIFF
--- a/core/bitarithm.c
+++ b/core/bitarithm.c
@@ -20,6 +20,7 @@
  */
 
 #include <stdio.h>
+#include <stdint.h>
 
 unsigned bitarithm_msb(unsigned v)
 {
@@ -43,18 +44,13 @@ unsigned bitarithm_msb(unsigned v)
 
     return r;
 }
-/*---------------------------------------------------------------------------*/
-unsigned bitarithm_lsb(register unsigned v)
+
+const uint8_t MultiplyDeBruijnBitPosition[32] =
 {
-    register unsigned r = 0;
+      0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,
+        31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9
+};
 
-    while ((v & 0x01) == 0) {
-        v >>= 1;
-        r++;
-    };
-
-    return r;
-}
 /*---------------------------------------------------------------------------*/
 unsigned bitarithm_bits_set(unsigned v)
 {

--- a/core/include/bitarithm.h
+++ b/core/include/bitarithm.h
@@ -20,6 +20,8 @@
 #ifndef BITARITHM_H_
 #define BITARITHM_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
  extern "C" {
 #endif
@@ -90,6 +92,9 @@
 
 #define ARCH_32_BIT   (__INT_MAX__ == 2147483647) /**< 1 for 32 bit architectures, 0 otherwise */
 
+/** @brief lookup table used by @ref bitarithm_lsb */
+extern const uint8_t MultiplyDeBruijnBitPosition[32];
+
 /**
  * @brief   Returns the number of the highest '1' bit in a value
  * @param[in]   v   Input value
@@ -101,13 +106,16 @@ unsigned bitarithm_msb(unsigned v);
 
 /**
  * @brief   Returns the number of the lowest '1' bit in a value
- * @param[in]   v   Input value - must be unequal to '0', otherwise the
- *                  function will produce an infinite loop
- * @return          Bit Number
+ * @param[in]   v   Input value
  *
- * Source: http://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious
+ * @return          Bit Number (or 0 if input was 0)
+ *
+ * Source: http://graphics.stanford.edu/~seander/bithacks.html#ZerosOnRightMultLookup
  */
-unsigned bitarithm_lsb(register unsigned v);
+static inline unsigned bitarithm_lsb(unsigned v)
+{
+    return MultiplyDeBruijnBitPosition[((uint32_t)((v & -v) * 0x077CB531U)) >> 27];
+}
 
 /**
  * @brief   Returns the number of bits set in a value


### PR DESCRIPTION
This PR makes ```bitarithm_lsb()``` use a lookup table plus multiplication instead of a simple loop.

While results of tests/bitarithm_timings is just slightly faster on average (<1% on SAM R21), now all input values take the same computation time compared to being dependent on input value's trailing zeroes.

With our scheduler being the most prominent user of that function, the net result is >15% higher context switching speed and >10% higher message throughput with only two threads active, plus more determinism.

Downside is 68byte more code for default on Cortex-M.