### PR TITLE
mbox: initial import of a thread-independent IPC

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -310,6 +310,10 @@ ifneq (,$(filter posix_semaphore,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter mbox,$(USEMODULE)))
+  USEMODULE += sema
+endif
+
 ifneq (,$(filter sema,$(USEMODULE)))
   USEMODULE += xtimer
 endif

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -78,6 +78,9 @@ endif
 ifneq (,$(filter sema,$(USEMODULE)))
     DIRS += sema
 endif
+ifneq (,$(filter mbox,$(USEMODULE)))
+    DIRS += mbox
+endif
 
 DIRS += $(dir $(wildcard $(addsuffix /Makefile, ${USEMODULE})))
 

--- a/sys/include/mbox.h
+++ b/sys/include/mbox.h
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    mbox    Message box
+ * @ingroup     sys
+ * @brief       Allows sending of @ref msg_t without a specific target thread
+ * @{
+ *
+ * @file
+ * @brief   Message box definitions
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+#ifndef MBOX_H_
+#define MBOX_H_
+
+#include <stdbool.h>
+
+#include "cib.h"
+#include "msg.h"
+#include "mutex.h"
+#include "sema.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Message box type
+ */
+typedef struct {
+    msg_t *msgs;            /**< memory holding messages */
+    cib_t msgs_queue;       /**< queue of the message box */
+    mutex_t mutex;          /**< mutex for the message box */
+    sema_t not_empty;       /**< semaphore to signal that message box is not empty anymore */
+    sema_t not_full;        /**< semaphore to signal that message box is not full anymore */
+
+    /**
+     * @brief counter for messages waiting to be added to the message box (if full)
+     */
+    volatile int waiting;
+} mbox_t;
+
+/**
+ * @brief   Static initializer for message box.
+ *
+ * @pre (@p array != NULL) && (@p num must be power of two) && (@p num <= MAX_INT/2)
+ *
+ * @param[in] array Pointer to preallocated array of @ref msg_t structures.
+ * @param[in] num   Number of @p msg_t structures in @p array.
+ *
+ * @return  Statically initialized message box
+ */
+#define MBOX_CREATE(array, num) { array, CIB_INIT(num), MUTEX_INIT, \
+                                  SEMA_CREATE(1), SEMA_CREATE(0), 0 }
+
+/**
+ * @brief   Static initializer for message box.
+ *
+ * @pre (@pre mbox != NULL) && (@p array != NULL) &&
+ *      (@p num must be power of two) && (@p num <= (INT_MAX / 2))
+ *
+ * @param[out] mbox The initialized message box.
+ * @param[in] array Pointer to preallocated array of @ref msg_t structures.
+ * @param[in] num   Number of @p msg_t structures in @p array.
+ */
+void mbox_create(mbox_t *mbox, msg_t *array, int num);
+
+/**
+ * @brief   Destroys a message box
+ *
+ * @pre (mbox != NULL)
+ *
+ * It empties the semaphore so waiting threads get signalized about the message box's destruction.
+ * A destroyed message box must not be used.
+ *
+ * @param[in] mbox Message box to destroy.
+ */
+void mbox_destroy(mbox_t *mbox);
+
+/**
+ * @brief   Checks (not thread-safe), if a message box is empty
+ *
+ * @param[in] mbox  A message box.
+ *
+ * @return  true, if message box is empty
+ * @return  false, if message box is not empty
+ */
+static inline bool mbox_is_empty(const mbox_t *mbox)
+{
+    /* cib_avail() does not change cib */
+    return (cib_avail((cib_t *)&mbox->msgs_queue) == 0);
+}
+
+/**
+ * @brief   Checks (not thread-safe), if a message box is full
+ *
+ * @param[in] mbox  A message box.
+ *
+ * @return  true, if message box is full
+ * @return  false, if message box is not full
+ */
+static inline bool mbox_is_full(const mbox_t *mbox)
+{
+    /* cib_avail() does not change cib */
+    return (cib_avail((cib_t *)&mbox->msgs_queue) == (mbox->msgs_queue.mask + 1));
+}
+
+/**
+ * @brief   Put message into message box blocking.
+ *
+ * @pre (mbox != NULL) && (msg != NULL)
+ *
+ * This function will always succeed in putting the message into the message box (unless there is
+ * an error as reported through the return value). If the message box is full it will block.
+ *
+ * @param[in] mbox  The message box to put the message into.
+ * @param[in] msg   A message.
+ *
+ * @return  0, on success.
+ * @return  -ECANCELED, when @p mbox was destroyed during execution.
+ * @return  -EOVERFLOW, if one of the mbox::not_empty semaphores would overflow.
+ */
+int mbox_put(mbox_t *mbox, msg_t *msg);
+
+/**
+ * @brief   Put message into message box non-blocking.
+ *
+ * @pre (mbox != NULL) && (msg != NULL)
+ *
+ * This function will not block if @p mbox is full, but signal this fact through its return value.
+ *
+ * @param[in] mbox  The message box to put the message into.
+ * @param[in] msg   A message.
+ *
+ * @return  0, on success.
+ * @return  -EAGAIN, if @p mbox was full.
+ * @return  -EOVERFLOW, if one of the mbox::not_empty would overflow.
+ */
+int mbox_tryput(mbox_t *mbox, msg_t *msg);
+
+/**
+ * @brief   Get message from message box blocking with timeout.
+ *
+ * @pre (mbox != NULL) && (msg != NULL)
+ *
+ * This function gets a message from the message box. If the message box is empty it will block
+ * for @b timeout microseconds.
+ *
+ * @param[in] mbox      The message box to get the message from
+ * @param[out] msg      The message received.
+ * @param[in] timeout   Time in microseconds until getting of message times out.
+ *
+ * @return  0, on success.
+ * @return  -ECANCELED, when @p mbox was destroyed during execution.
+ * @return  -EOVERFLOW, if one of the mbox::not_full semaphores would overflow.
+ * @return  -ETIMEDOUT, when getting of message timed out.
+ */
+int mbox_get_timed(mbox_t *mbox, msg_t *msg, uint64_t timeout);
+
+/**
+ * @brief   Get message from message box blocking with timeout.
+ *
+ * @pre (mbox != NULL) && (msg != NULL)
+ *
+ * This function gets a message from the message box. If the message box is empty it will block.
+ *
+ * @param[in] mbox      The message box to get the message from
+ * @param[out] msg      The message received.
+ *
+ * @return  0, on success.
+ * @return  -ECANCELED, when @p mbox was destroyed during execution.
+ * @return  -EOVERFLOW, if one of the mbox::not_full semaphores would overflow.
+ */
+static inline int mbox_get(mbox_t *mbox, msg_t *msg)
+{
+    return mbox_get_timed(mbox, msg, 0);
+}
+
+/**
+ * @brief   Get message from message box non-blocking.
+ *
+ * @pre (mbox != NULL) && (msg != NULL)
+ *
+ * This function will not block if @p mbox is empty, but signal this fact through its return value.
+ *
+ * @param[in] mbox      The message box to get the message from
+ * @param[out] msg      The message received.
+ *
+ * @return  0, on success.
+ * @return  -EAGAIN, if @p mbox was empty.
+ * @return  -ECANCELED, when @p mbox was destroyed during execution.
+ * @return  -EOVERFLOW, if one of the mbox::not_full semaphores would overflow.
+ */
+int mbox_tryget(mbox_t *mbox, msg_t *msg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBOX_H_ */
+/** @} */

--- a/sys/mbox/Makefile
+++ b/sys/mbox/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/mbox/mbox.c
+++ b/sys/mbox/mbox.c
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <string.h>
+
+#include "sched.h"
+
+#include "mbox.h"
+
+void mbox_create(mbox_t *mbox, msg_t *array, int num)
+{
+    assert((array != NULL) && (num <= (INT_MAX / 2)));
+    mbox->msgs = array;                 /* Initialize all members */
+    cib_init(&mbox->msgs_queue, num);
+    mutex_init(&mbox->mutex);
+    sema_create(&mbox->not_empty, 1);
+    sema_create(&mbox->not_full, 0);
+    mbox->waiting = 0;
+}
+
+void mbox_destroy(mbox_t *mbox)
+{
+    mutex_lock(&mbox->mutex);
+    sema_destroy(&mbox->not_empty);     /* destroy semaphore to signal waiting threads */
+    sema_destroy(&mbox->not_full);
+    mbox->msgs = NULL;
+    mutex_unlock(&mbox->mutex);
+}
+
+static int _mbox_put(mbox_t *mbox, msg_t *msg, int idx)
+{
+    msg_t *dst = &mbox->msgs[idx];
+
+    msg->sender_pid = sched_active_pid;         /* set current thread as sender */
+    *dst = *msg;                                /* copy message into queue */
+    if (cib_avail(&mbox->msgs_queue) == 1) {    /* when queue was empty before */
+        return sema_post(&mbox->not_empty);     /* signal to waiting threads */
+    }
+    return 0;
+}
+
+int mbox_put(mbox_t *mbox, msg_t *msg)
+{
+    int idx, res;
+
+    assert((mbox != NULL) && (msg != NULL));
+    mutex_lock(&mbox->mutex);
+    if (mbox->msgs == NULL) {                       /* if no message queue => mbox was destroyed */
+        mutex_unlock(&mbox->mutex);
+        return -ECANCELED;
+    }
+    while ((idx = cib_put(&mbox->msgs_queue)) < 0) {    /* get next free index in message queue */
+        mbox->waiting++;                                /* no free index in queue */
+        mutex_unlock(&mbox->mutex);
+        res = sema_wait(&mbox->not_full);               /* => wait for mbox not to be full */
+        if (res < 0) {
+            return res;
+        }
+        mutex_lock(&mbox->mutex);
+        mbox->waiting--;
+    }
+    res = _mbox_put(mbox, msg, idx);
+    mutex_unlock(&mbox->mutex);
+    return res;
+}
+
+int mbox_tryput(mbox_t *mbox, msg_t *msg)
+{
+    int idx, res;
+
+    assert((mbox != NULL) && (msg != NULL));
+    mutex_lock(&mbox->mutex);
+    if (mbox->msgs == NULL) {                       /* if no message queue => mbox was destroyed */
+        mutex_unlock(&mbox->mutex);
+        return -ECANCELED;
+    }
+    if ((idx = cib_put(&mbox->msgs_queue)) < 0) {   /* try to get free index in message queue */
+        mutex_unlock(&mbox->mutex);                 /* no free index in queue */
+        return -EAGAIN;                             /* return with error code */
+    }
+    res = _mbox_put(mbox, msg, idx);
+    mutex_unlock(&mbox->mutex);
+    return res;
+}
+
+static int _mbox_get(mbox_t *mbox, msg_t *msg)
+{
+    unsigned int idx = cib_get(&mbox->msgs_queue);  /* get next entry in queue */
+
+    *msg = mbox->msgs[idx];
+    if (mbox->waiting) {                            /* if there are messages waiting to be added
+                                                     * to queue */
+        return sema_post(&mbox->not_full);          /* signal their putters that queue isn't full
+                                                     * anymore */
+    }
+    return 0;
+}
+
+int mbox_get_timed(mbox_t *mbox, msg_t *msg, uint64_t timeout)
+{
+    int res;
+
+    assert((mbox != NULL) && (msg != NULL));
+    mutex_lock(&mbox->mutex);
+    if (mbox->msgs == NULL) {                       /* if no message queue => mbox was destroyed */
+        mutex_unlock(&mbox->mutex);
+        return -ECANCELED;
+    }
+    /* semaphore might not lock immediately, due to tryget not
+     * locking and thus not cleaning up semaphore, so we loop
+     * over semaphore lock, until we hit it */
+    while (cib_avail(&mbox->msgs_queue) == 0) { /* wait until message queue isn't empty */
+        mutex_unlock(&mbox->mutex);
+        /* timeout == 0 => no timeout */
+        res = sema_wait_timed(&mbox->not_empty, timeout);
+        if (res < 0) {
+            return res;
+        }
+        mutex_lock(&mbox->mutex);
+    }
+    res = _mbox_get(mbox, msg);
+    mutex_unlock(&mbox->mutex);
+    return res;
+}
+
+int mbox_tryget(mbox_t *mbox, msg_t *msg)
+{
+    int res;
+
+    assert((mbox != NULL) && (msg != NULL));
+    mutex_lock(&mbox->mutex);
+    if (mbox->msgs == NULL) {                       /* if no message queue => mbox was destroyed */
+        mutex_unlock(&mbox->mutex);
+        return -ECANCELED;
+    }
+    if (cib_avail(&mbox->msgs_queue) == 0) {    /* no message in queue */
+        mutex_unlock(&mbox->mutex);
+        return -EAGAIN;                         /* => don't block */
+    }
+    res = _mbox_get(mbox, msg);
+    mutex_unlock(&mbox->mutex);
+    return res;
+}
+
+/** @} */

--- a/tests/mbox/Makefile
+++ b/tests/mbox/Makefile
@@ -1,0 +1,16 @@
+APPLICATION = mbox
+include ../Makefile.tests_common
+
+BOARD_INSUFFICIENT_MEMORY := 
+
+USEMODULE += mbox
+USEMODULE += sema
+
+DISABLE_MODULE += auto_init
+
+CFLAGS = -DDEVELHELP
+
+include $(RIOTBASE)/Makefile.include
+
+test:
+	python tests/01-run.py

--- a/tests/mbox/main.c
+++ b/tests/mbox/main.c
@@ -1,0 +1,284 @@
+/*
+ * Copyright (C) Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include "mbox.h"
+#include "sema.h"
+#include "thread.h"
+#include "xtimer.h"
+
+#define ASSERT(x)   if (!(x)) { \
+        printf("%s:%d: ASSERTION (" # x ") FAILED\n", RIOT_FILE_RELATIVE, \
+               __LINE__); \
+        core_panic(PANIC_ASSERT_FAIL, assert_crash_message); \
+}
+
+
+#define MBOX_QUEUE_SIZE     (8)
+#define THREAD_PRIO         (THREAD_PRIORITY_MAIN)
+#define MSG_TYPE            (0xf212)
+
+static kernel_pid_t thread_pid, main_pid;
+static char thread_stack[THREAD_STACKSIZE_DEFAULT + THREAD_EXTRA_STACKSIZE_PRINTF];
+static sema_t sync = SEMA_CREATE(0);    /* Synchronisation semaphore */
+static msg_t mbox_queue[MBOX_QUEUE_SIZE];
+static mbox_t mbox = MBOX_CREATE(mbox_queue, MBOX_QUEUE_SIZE);
+
+static void test_put1(void)
+{
+    msg_t m;
+    int res;
+
+    m.type = MSG_TYPE;
+    m.content.value = 1234U;
+    res = mbox_put(&mbox, &m);
+    ASSERT(res == 0);
+    printf("%" PRIu16 ": test_put1: mbox_put() => mbox_get() passed\n",
+           sched_active_thread->pid);
+}
+
+static void test_get1(void)
+{
+    msg_t m;
+    int res = mbox_get(&mbox, &m);
+
+    ASSERT((res == 0) && (m.type == MSG_TYPE) && (m.content.value == 1234U));
+    printf("%" PRIu16 ": test_get1: mbox_put() => mbox_get() passed\n",
+           sched_active_thread->pid);
+}
+
+static void test_put2(void)
+{
+    mbox_destroy(&mbox);
+    printf("%" PRIu16 ": test_put2: destroy message box\n", sched_active_thread->pid);
+}
+
+static void test_get2(void)
+{
+    msg_t m;
+    int res = mbox_get(&mbox, &m);
+
+    ASSERT(res == -ECANCELED);
+    printf("%" PRIu16 ": test_get2: mbox_get() message box was destroyed\n",
+           sched_active_thread->pid);
+}
+
+static void test_put3(void)
+{
+    msg_t m;
+
+    m.type = MSG_TYPE;
+    for (uint32_t i = 0; i < (MBOX_QUEUE_SIZE * 2); i++) {
+        int res;
+        m.content.value = i;
+        res = mbox_put(&mbox, &m);
+        ASSERT(res == 0);
+        printf("%" PRIu16 ": test_put3: mbox_put() (i == %" PRIu32 ") => mbox_get() passed\n",
+               sched_active_thread->pid, i);
+    }
+}
+
+static void test_get3(void)
+{
+    for (uint32_t i = 0; i < (MBOX_QUEUE_SIZE * 2); i++) {
+        msg_t m;
+        int res = mbox_get(&mbox, &m);
+        ASSERT((res == 0) && (m.type == MSG_TYPE) && (m.content.value == i));
+        printf("%" PRIu16 ": test_get3: mbox_put() => mbox_get() (i == %" PRIu32 ") passed\n",
+               sched_active_thread->pid, i);
+    }
+    ASSERT(mbox_is_empty(&mbox));
+    printf("%" PRIu16 ": test_get3: mbox is empty as expected\n", sched_active_thread->pid);
+}
+
+static void test_put4(void)
+{
+    msg_t m;
+
+    m.type = MSG_TYPE;
+    for (uint32_t i = 0; i < MBOX_QUEUE_SIZE + 1; i++) {
+        int res;
+        m.content.value = i;
+        res = mbox_tryput(&mbox, &m);
+        if (res == 0) {
+            printf("%" PRIu16 ": test_put4: mbox_tryput() (i == %" PRIu32 ") => mbox_get() passed\n",
+                   sched_active_thread->pid, i);
+        }
+        else if (res == -EAGAIN) {
+            ASSERT(mbox_is_full(&mbox));
+            printf("%" PRIu16 ": test_put4: mbox_tryput() (i == %"
+                   PRIu32 ") failed with EAGAIN as expected\n",
+                   sched_active_thread->pid, i);
+            break;
+        }
+        else {
+            printf("%" PRIu16 ": test_put4: unexpected behavior\n", sched_active_thread->pid);
+            ASSERT(false);
+        }
+    }
+}
+
+static void test_get4(void)
+{
+    for (uint32_t i = 0; i < MBOX_QUEUE_SIZE; i++) {
+        msg_t m;
+        int res = mbox_get(&mbox, &m);
+        ASSERT((res == 0) && (m.type == MSG_TYPE) && (m.content.value == i));
+        printf("%" PRIu16 ": test_get4: mbox_tryput() => mbox_get() (i == %" PRIu32 ") passed\n",
+               sched_active_thread->pid, i);
+    }
+    ASSERT(mbox_is_empty(&mbox));
+    printf("%" PRIu16 ": test_get4: mbox is empty as expected\n", sched_active_thread->pid);
+}
+
+static void test_put5(void)
+{
+    msg_t m;
+    int res;
+
+    m.type = MSG_TYPE;
+    m.content.value = 1234U;
+    res = mbox_put(&mbox, &m);
+    ASSERT(res == 0);
+    printf("%" PRIu16 ": test_put5: mbox_put() => mbox_tryget() passed\n",
+           sched_active_thread->pid);
+}
+
+static void test_get5(void)
+{
+    msg_t m;
+    int res = mbox_tryget(&mbox, &m);
+
+    ASSERT((res == 0) && (m.type == MSG_TYPE) && (m.content.value == 1234U));
+    printf("%" PRIu16 ": test_get5: mbox_put() => mbox_tryget() passed\n",
+           sched_active_thread->pid);
+    res = mbox_tryget(&mbox, &m);
+    ASSERT(res == -EAGAIN);
+    printf("%" PRIu16 ": test_get5: second mbox_tryget() failed as expected\n",
+           sched_active_thread->pid);
+}
+
+static void test_put6(void)
+{
+    msg_t m;
+    int res;
+
+    m.type = MSG_TYPE;
+    m.content.value = 1234U;
+    res = mbox_put(&mbox, &m);
+    ASSERT(res == 0);
+    printf("%" PRIu16 ": test_put6: mbox_put() => mbox_get_timed() passed\n",
+           sched_active_thread->pid);
+}
+
+static void test_get6(void)
+{
+    msg_t m;
+    uint32_t time;
+    int res;
+
+    time = xtimer_now();
+    res = mbox_get_timed(&mbox, &m, 100);
+    time = xtimer_now() - time;
+    ASSERT((res == 0) && (m.type == MSG_TYPE) && (m.content.value == 1234U) &&
+           (time < 100));
+    printf("%" PRIu16 ": test_get6: mbox_put() => mbox_get_timed() passed\n",
+           sched_active_thread->pid);
+}
+
+static void test_put7(void)
+{
+    printf("%" PRIu16 ": test_put7: waiting for getter to time out\n",
+           sched_active_thread->pid);
+}
+
+static void test_get7(void)
+{
+    msg_t m;
+    uint32_t time;
+    int res;
+
+    time = xtimer_now();
+    res = mbox_get_timed(&mbox, &m, 100);
+    time = xtimer_now() - time;
+    ASSERT((res == -ETIMEDOUT) && (time >= 100));
+    printf("%" PRIu16 ": test_get7: mbox_put() => mbox_get_timed() timed out\n",
+           sched_active_thread->pid);
+}
+
+static void test_put(void)
+{
+    test_put1();
+    sema_wait(&sync);
+    test_put2();
+    sema_wait(&sync);
+    /* was destroyed in test_put2() */
+    mbox_create(&mbox, mbox_queue, MBOX_QUEUE_SIZE);
+    printf("%" PRIu16 ": create new message box\n", sched_active_thread->pid);
+    test_put3();
+    sema_wait(&sync);
+    test_put4();
+    sema_wait(&sync);
+    test_put5();
+    sema_wait(&sync);
+    test_put6();
+    sema_wait(&sync);
+    test_put7();
+    printf("%" PRIu16 ": put tests successful\n", sched_active_thread->pid);
+    sema_wait(&sync);
+}
+
+static void test_get(void)
+{
+    test_get1();
+    sema_post(&sync);
+    test_get2();
+    sema_post(&sync);
+    test_get3();
+    sema_post(&sync);
+    test_get4();
+    sema_post(&sync);
+    test_get5();
+    sema_post(&sync);
+    test_get6();
+    sema_post(&sync);
+    test_get7();
+    printf("%" PRIu16 ": get tests successful\n", sched_active_thread->pid);
+    sema_post(&sync);
+}
+
+static void *thread(void *arg)
+{
+    (void)arg;
+    test_get();
+    return NULL;
+}
+
+int main(void)
+{
+    xtimer_init();
+    main_pid = sched_active_pid;
+    thread_pid = thread_create(thread_stack, sizeof(thread_stack), THREAD_PRIO + 1,
+                               THREAD_CREATE_STACKTEST, thread, NULL, "thread");
+    ASSERT(thread_pid > KERNEL_PID_UNDEF);
+    test_put();
+    puts("All tests successful");
+    return 0;
+}
+
+/** @} */

--- a/tests/mbox/tests/01-run.py
+++ b/tests/mbox/tests/01-run.py
@@ -1,0 +1,106 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+#
+# Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+import pexpect
+
+def init():
+    if sys.version >= (3,):
+        term = pexpect.spawnu("make term", timeout=0.5)
+    else:
+        term = pexpect.spawn("make term", timeout=0.5)
+    term.logfile = sys.stdout
+    return term
+
+def test1(term):
+    term.expect_exact('2: test_put1: mbox_put() => mbox_get() passed')
+    term.expect_exact('3: test_get1: mbox_put() => mbox_get() passed')
+
+def test2(term):
+    term.expect_exact('2: test_put2: destroy message box')
+    term.expect_exact('3: test_get2: mbox_get() message box was destroyed')
+
+def test3(term):
+    term.expect_exact('2: create new message box')
+    term.expect_exact('2: test_put3: mbox_put() (i == 0) => mbox_get() passed')
+    term.expect_exact('2: test_put3: mbox_put() (i == 1) => mbox_get() passed')
+    term.expect_exact('2: test_put3: mbox_put() (i == 2) => mbox_get() passed')
+    term.expect_exact('2: test_put3: mbox_put() (i == 3) => mbox_get() passed')
+    term.expect_exact('2: test_put3: mbox_put() (i == 4) => mbox_get() passed')
+    term.expect_exact('2: test_put3: mbox_put() (i == 5) => mbox_get() passed')
+    term.expect_exact('2: test_put3: mbox_put() (i == 6) => mbox_get() passed')
+    term.expect_exact('2: test_put3: mbox_put() (i == 7) => mbox_get() passed')
+    term.expect_exact('2: test_put3: mbox_put() (i == 8) => mbox_get() passed')
+    term.expect_exact('3: test_get3: mbox_put() => mbox_get() (i == 0) passed')
+    term.expect_exact('2: test_put3: mbox_put() (i == 9) => mbox_get() passed')
+    term.expect_exact('3: test_get3: mbox_put() => mbox_get() (i == 1) passed')
+    term.expect_exact('2: test_put3: mbox_put() (i == 10) => mbox_get() passed')
+    term.expect_exact('3: test_get3: mbox_put() => mbox_get() (i == 2) passed')
+    term.expect_exact('2: test_put3: mbox_put() (i == 11) => mbox_get() passed')
+    term.expect_exact('3: test_get3: mbox_put() => mbox_get() (i == 3) passed')
+    term.expect_exact('2: test_put3: mbox_put() (i == 12) => mbox_get() passed')
+    term.expect_exact('3: test_get3: mbox_put() => mbox_get() (i == 4) passed')
+    term.expect_exact('2: test_put3: mbox_put() (i == 13) => mbox_get() passed')
+    term.expect_exact('3: test_get3: mbox_put() => mbox_get() (i == 5) passed')
+    term.expect_exact('2: test_put3: mbox_put() (i == 14) => mbox_get() passed')
+    term.expect_exact('3: test_get3: mbox_put() => mbox_get() (i == 6) passed')
+    term.expect_exact('2: test_put3: mbox_put() (i == 15) => mbox_get() passed')
+    term.expect_exact('3: test_get3: mbox_put() => mbox_get() (i == 7) passed')
+    term.expect_exact('3: test_get3: mbox_put() => mbox_get() (i == 8) passed')
+    term.expect_exact('3: test_get3: mbox_put() => mbox_get() (i == 9) passed')
+    term.expect_exact('3: test_get3: mbox_put() => mbox_get() (i == 10) passed')
+    term.expect_exact('3: test_get3: mbox_put() => mbox_get() (i == 11) passed')
+    term.expect_exact('3: test_get3: mbox_put() => mbox_get() (i == 12) passed')
+    term.expect_exact('3: test_get3: mbox_put() => mbox_get() (i == 13) passed')
+    term.expect_exact('3: test_get3: mbox_put() => mbox_get() (i == 14) passed')
+    term.expect_exact('3: test_get3: mbox_put() => mbox_get() (i == 15) passed')
+    term.expect_exact('3: test_get3: mbox is empty as expected')
+
+def test4(term):
+    term.expect_exact('2: test_put4: mbox_tryput() (i == 0) => mbox_get() passed')
+    term.expect_exact('2: test_put4: mbox_tryput() (i == 1) => mbox_get() passed')
+    term.expect_exact('2: test_put4: mbox_tryput() (i == 2) => mbox_get() passed')
+    term.expect_exact('2: test_put4: mbox_tryput() (i == 3) => mbox_get() passed')
+    term.expect_exact('2: test_put4: mbox_tryput() (i == 4) => mbox_get() passed')
+    term.expect_exact('2: test_put4: mbox_tryput() (i == 5) => mbox_get() passed')
+    term.expect_exact('2: test_put4: mbox_tryput() (i == 6) => mbox_get() passed')
+    term.expect_exact('2: test_put4: mbox_tryput() (i == 7) => mbox_get() passed')
+    term.expect_exact('2: test_put4: mbox_tryput() (i == 8) failed with EAGAIN as expected')
+    term.expect_exact('3: test_get4: mbox_tryput() => mbox_get() (i == 0) passed')
+    term.expect_exact('3: test_get4: mbox_tryput() => mbox_get() (i == 1) passed')
+    term.expect_exact('3: test_get4: mbox_tryput() => mbox_get() (i == 2) passed')
+    term.expect_exact('3: test_get4: mbox_tryput() => mbox_get() (i == 3) passed')
+    term.expect_exact('3: test_get4: mbox_tryput() => mbox_get() (i == 4) passed')
+    term.expect_exact('3: test_get4: mbox_tryput() => mbox_get() (i == 5) passed')
+    term.expect_exact('3: test_get4: mbox_tryput() => mbox_get() (i == 6) passed')
+    term.expect_exact('3: test_get4: mbox_tryput() => mbox_get() (i == 7) passed')
+    term.expect_exact('3: test_get4: mbox is empty as expected')
+
+def test5(term):
+    term.expect_exact('2: test_put5: mbox_put() => mbox_tryget() passed')
+    term.expect_exact('3: test_get5: mbox_put() => mbox_tryget() passed')
+    term.expect_exact('3: test_get5: second mbox_tryget() failed as expected')
+
+def test6(term):
+    term.expect_exact('2: test_put6: mbox_put() => mbox_get_timed() passed')
+    term.expect_exact('3: test_get6: mbox_put() => mbox_get_timed() passed')
+
+def test7(term):
+    term.expect_exact('2: test_put7: waiting for getter to time out')
+    term.expect_exact('3: test_get7: mbox_put() => mbox_get_timed() timed out')
+
+
+if __name__ == "__main__":
+    TERM = init()
+    test1(TERM)
+    test2(TERM)
+    test3(TERM)
+    test4(TERM)
+    TERM.expect_exact('All tests successful')


### PR DESCRIPTION
Introduction
=========
I know @kaspar030 is working on something like this too, but when I was working with lwIP again, I decided to port out the messaging layer I implemented for it, to better test it and to give it as an alternative to @kaspar030's work (and since it was already laying around in my repo it took me only half a day and some hours of boredom on Christmas to port it to `msg_t`).

`mbox` is thought to be an alternative - not a replacement - to standard-IPC. There are probably many ways to make it a little bit smaller in memory consumption, but I based it on the [unix support for mbox of lwIP](http://git.savannah.gnu.org/cgit/lwip/lwip-contrib.git/tree/ports/unix/sys_arch.c) (with many adaptations to make it more RIOT-y) so it is quite stable.

Summary
=======
`mbox` is a datatype with two base operations (of that there are some variations - more on that later):
 - `mbox_put()` and
 - `mbox_get()`

Blocking IPC
-----------------
`mbox_put()` allows a user to put a `msg_t` in the `mbox`. If the `mbox` is full the thread will block and be signaled through the `mbox::not_full` semaphore, when there is space in the `mbox` again.

`mbox_get()` allows a user to get a `msg_t` from the `mbox`. If the `mbox` is empty the thread will block and be signaled through the `mbox::not_empty` semaphore, when another thread puts something in the `mbox`.

Non-blocking IPC
-----------------------
There is a non-blocking variant `mbox_tryget()` and `mbox_tryput()` for both operations, that just returns `-EAGAIN` when the normal operations would block (they don't require the semaphores, though they both post them, so the blocking variants are woken up).

mbox and time
-------------------
Since the blocking mechanism is based on semaphores there is also a timeout-variant of `mbox_get()`: `mbox_get_timed()`. If we make this optional for semaphores we also can make it optional here.

Dependencies
==========
Depends on #4551 and maybe #4374 (though I did not run into any problems during tests, regarding this bug).