### PR TITLE
core: mutexes memorize holding thread id

### DIFF
--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -22,7 +22,7 @@
 #define MUTEX_H_
 
 #include "priority_queue.h"
-#include "atomic.h"
+#include "kernel_types.h"
 
 #ifdef __cplusplus
  extern "C" {
@@ -38,7 +38,7 @@ typedef struct mutex_t {
      *          never be changed by the user.**
      * @internal
      */
-    atomic_int_t val;
+    kernel_pid_t val;
     /**
      * @brief   The process waiting queue of the mutex. **Must never be changed
      *          by the user.**
@@ -51,7 +51,7 @@ typedef struct mutex_t {
  * @brief Static initializer for mutex_t.
  * @details This initializer is preferable to mutex_init().
  */
-#define MUTEX_INIT { ATOMIC_INIT(0), PRIORITY_QUEUE_INIT }
+#define MUTEX_INIT { KERNEL_PID_UNDEF, PRIORITY_QUEUE_INIT }
 
 /**
  * @brief Initializes a mutex object.

--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -66,6 +66,21 @@ static inline void mutex_init(mutex_t *mutex)
 }
 
 /**
+ * @brief Lock a mutex, blocking or non-blocking.
+ *
+ * @details For commit purposes you should probably use mutex_trylock() and
+ *          mutex_lock() instead.
+ *
+ * @param[in] mutex Mutex object to lock. Has to be initialized first. Must not
+ *                  be NULL.
+ * @param[in] non_blocking Use non-blocking API.
+ *
+ * @return 1 if mutex was unlocked, now it is locked.
+ * @return 0 if the mutex was locked.
+ */
+int _mutex_lock(mutex_t *mutex, int non_blocking);
+
+/**
  * @brief Tries to get a mutex, non-blocking.
  *
  * @param[in] mutex Mutex object to lock. Has to be initialized first. Must not
@@ -74,14 +89,20 @@ static inline void mutex_init(mutex_t *mutex)
  * @return 1 if mutex was unlocked, now it is locked.
  * @return 0 if the mutex was locked.
  */
-int mutex_trylock(mutex_t *mutex);
+static inline int mutex_trylock(mutex_t *mutex)
+{
+    return _mutex_lock(mutex, 1);
+}
 
 /**
  * @brief Locks a mutex, blocking.
  *
  * @param[in] mutex Mutex object to lock. Has to be initialized first. Must not be NULL.
  */
-void mutex_lock(mutex_t *mutex);
+static inline void mutex_lock(mutex_t *mutex)
+{
+    _mutex_lock(mutex, 0);
+}
 
 /**
  * @brief Unlocks the mutex.

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -38,14 +38,15 @@ static void mutex_wait(struct mutex_t *mutex);
 
 int mutex_trylock(struct mutex_t *mutex)
 {
-    DEBUG("%s: trylocking to get mutex. val: %u\n", sched_active_thread->name, ATOMIC_VALUE(mutex->val));
+    DEBUG("mutex_trylock: pid=%" PRIkernel_pid " val=%u\n",
+          sched_active_pid, ATOMIC_VALUE(mutex->val));
     return atomic_set_to_one(&mutex->val);
 }
 
 void mutex_lock(struct mutex_t *mutex)
 {
-    DEBUG("%s: trying to get mutex. val: %u\n", sched_active_thread->name, ATOMIC_VALUE(mutex->val));
-
+    DEBUG("mutex_lock: pid=%" PRIkernel_pid " val=%u\n",
+          sched_active_pid, ATOMIC_VALUE(mutex->val));
     if (atomic_set_to_one(&mutex->val) == 0) {
         /* mutex was locked. */
         mutex_wait(mutex);
@@ -55,11 +56,11 @@ void mutex_lock(struct mutex_t *mutex)
 static void mutex_wait(struct mutex_t *mutex)
 {
     unsigned irqstate = disableIRQ();
-    DEBUG("%s: Mutex in use. %u\n", sched_active_thread->name, ATOMIC_VALUE(mutex->val));
 
     if (atomic_set_to_one(&mutex->val)) {
         /* somebody released the mutex. return. */
-        DEBUG("%s: mutex_wait early out. %u\n", sched_active_thread->name, ATOMIC_VALUE(mutex->val));
+        DEBUG("mutex_wait: early out, pid=%" PRIkernel_pid " val=%u\n",
+              sched_active_pid, ATOMIC_VALUE(mutex->val));
         restoreIRQ(irqstate);
         return;
     }
@@ -71,7 +72,9 @@ static void mutex_wait(struct mutex_t *mutex)
     n.data = (unsigned int) sched_active_thread;
     n.next = NULL;
 
-    DEBUG("%s: Adding node to mutex queue: prio: %" PRIu32 "\n", sched_active_thread->name, n.priority);
+    DEBUG("mutex_wait: add to wait queue, pid=%" PRIkernel_pid " val=%u "
+          "prio%" PRIu32 "\n", sched_active_pid, ATOMIC_VALUE(mutex->val),
+          n.priority);
 
     priority_queue_add(&(mutex->queue), &n);
 
@@ -85,7 +88,8 @@ static void mutex_wait(struct mutex_t *mutex)
 void mutex_unlock(struct mutex_t *mutex)
 {
     unsigned irqstate = disableIRQ();
-    DEBUG("mutex_unlock(): val: %u pid: %" PRIkernel_pid "\n", ATOMIC_VALUE(mutex->val), sched_active_pid);
+    DEBUG("mutex_unlock: pid=%" PRIkernel_pid " val=%u\n",
+          sched_active_pid, ATOMIC_VALUE(mutex->val));
 
     if (ATOMIC_VALUE(mutex->val) == 0) {
         /* the mutex was not locked */
@@ -102,7 +106,7 @@ void mutex_unlock(struct mutex_t *mutex)
     }
 
     tcb_t *process = (tcb_t *) next->data;
-    DEBUG("mutex_unlock: waking up waiting thread %" PRIkernel_pid "\n", process->pid);
+    DEBUG("mutex_unlock: waking up %" PRIkernel_pid "\n", process->pid);
     sched_set_status(process, STATUS_PENDING);
 
     uint16_t process_priority = process->priority;
@@ -112,21 +116,24 @@ void mutex_unlock(struct mutex_t *mutex)
 
 void mutex_unlock_and_sleep(struct mutex_t *mutex)
 {
-    DEBUG("%s: unlocking mutex. val: %u pid: %" PRIkernel_pid ", and taking a nap\n", sched_active_thread->name, ATOMIC_VALUE(mutex->val), sched_active_pid);
+    DEBUG("mutex_unlock_and_sleep: pid=%" PRIkernel_pid " val=%u\n",
+          sched_active_pid, ATOMIC_VALUE(mutex->val));
     unsigned irqstate = disableIRQ();
 
     if (ATOMIC_VALUE(mutex->val) != 0) {
         priority_queue_node_t *next = priority_queue_remove_head(&(mutex->queue));
         if (next) {
             tcb_t *process = (tcb_t *) next->data;
-            DEBUG("%s: waking up waiter.\n", process->name);
+            DEBUG("mutex_unlock_and_sleep: waking up %" PRIkernel_pid "\n",
+                  process->pid);
             sched_set_status(process, STATUS_PENDING);
         }
         else {
             ATOMIC_VALUE(mutex->val) = 0; /* This is safe, interrupts are disabled */
         }
     }
-    DEBUG("%s: going to sleep.\n", sched_active_thread->name);
+
+    DEBUG("mutex_unlock_and_sleep: going to sleep.\n");
     sched_set_status((tcb_t*) sched_active_thread, STATUS_SLEEPING);
     restoreIRQ(irqstate);
     thread_yield_higher();

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -57,7 +57,7 @@ int _mutex_lock(struct mutex_t *mutex, int non_blocking)
 
         priority_queue_node_t n;
         n.priority = (unsigned int) sched_active_thread->priority;
-        n.data = (unsigned int) sched_active_thread;
+        n.data = sched_active_pid;
         n.next = NULL;
 
         DEBUG("_mutex_wait: add to wait queue, pid=%" PRIkernel_pid " val=%u "
@@ -94,8 +94,8 @@ void mutex_unlock(struct mutex_t *mutex)
         return;
     }
 
-    tcb_t *process = (tcb_t *) next->data;
-    DEBUG("mutex_unlock: waking up %" PRIkernel_pid "\n", process->pid);
+    tcb_t *process = (tcb_t *) sched_threads[next->data];
+    DEBUG("mutex_unlock: waking up %" PRIkernel_pid "\n", next->data);
     sched_set_status(process, STATUS_PENDING);
 
     uint16_t process_priority = process->priority;
@@ -112,9 +112,9 @@ void mutex_unlock_and_sleep(struct mutex_t *mutex)
     if (ATOMIC_VALUE(mutex->val) != 0) {
         priority_queue_node_t *next = priority_queue_remove_head(&(mutex->queue));
         if (next) {
-            tcb_t *process = (tcb_t *) next->data;
+            tcb_t *process = (tcb_t *) sched_threads[next->data];
             DEBUG("mutex_unlock_and_sleep: waking up %" PRIkernel_pid "\n",
-                  process->pid);
+                  next->data);
             sched_set_status(process, STATUS_PENDING);
         }
         else {


### PR DESCRIPTION
Rationale: see #4494. Closes #4494.

examples/default:
```c
text    data    bss     dec     BOARD/BINDIRBASE

-12     0       0       -12     airfy-beacon
22912   164     10316   33392   old
22900   164     10316   33380   new

-8      0       0       -8      arduino-due
12244   168     2648    15060   old
12236   168     2648    15052   new

-32     0       0       -32     arduino-mega2560
11200   1566    719     13485   old
11168   1566    719     13453   new

-32     0       0       -32     avsextrem
60588   2356    95945   158889  old
60556   2356    95945   158857  new

-8      0       0       -8      cc2538dk
12344   164     2620    15128   old
12336   164     2620    15120   new

0       0       0       0       chronos
14838   106     1042    15986   old
14838   106     1042    15986   new

-8      0       0       -8      ek-lm4f120xl
12572   164     2620    15356   old
12564   164     2620    15348   new

-16     0       0       -16     f4vi1
14296   168     2760    17224   old
14280   168     2760    17208   new

-4      0       0       -4      fox
34364   164     11684   46212   old
34360   164     11684   46208   new

-8      0       0       -8      frdm-k64f
19808   1268    2684    23760   old
19800   1268    2684    23752   new

-4      0       0       -4      iotlab-m3
34844   164     11772   46780   old
34840   164     11772   46776   new

-8      0       0       -8      limifrog-v1
13908   164     2756    16828   old
13900   164     2756    16820   new

-8      0       0       -8      mbed_lpc1768
12336   164     2628    15128   old
12328   164     2628    15120   new

-32     0       0       -32     msb-430
20114   34      1082    21230   old
20082   34      1082    21198   new

-42     0       0       -42     msb-430h
10550   34      1056    11640   old
10508   34      1056    11598   new

-16     0       0       -16     msba2
73532   2356    93961   169849  old
73516   2356    93961   169833  new

-12     0       0       -12     msbiot
14608   168     2792    17568   old
14596   168     2792    17556   new

-4      0       0       -4      mulle
41908   1304    11896   55108   old
41904   1304    11896   55104   new

-280    0       0       -280    native
77825   612     82712   161149  old
77545   612     82712   160869  new

-12     0       0       -12     nrf51dongle
22940   164     10316   33420   old
22928   164     10316   33408   new

-12     0       0       -12     nrf6310
22912   164     10316   33392   old
22900   164     10316   33380   new

-16     0       0       -16     nucleo-f091
15624   164     2636    18424   old
15608   164     2636    18408   new

-8      0       0       -8      nucleo-f103
12468   164     2764    15396   old
12460   164     2764    15388   new

-8      0       0       -8      nucleo-f303
12676   164     2636    15476   old
12668   164     2636    15468   new

-8      0       0       -8      nucleo-f334
12288   164     2620    15072   old
12280   164     2620    15064   new

-16     0       0       -16     nucleo-f401
14304   168     2760    17232   old
14288   168     2760    17216   new

-8      0       0       -8      nucleo-l1
13780   164     2748    16692   old
13772   164     2748    16684   new

-8      0       0       -8      openmote
12252   164     2620    15036   old
12244   164     2620    15028   new

4       0       0       4       pba-d-01-kw2x
37752   1268    11948   50968   old
37756   1268    11948   50972   new

-12     0       0       -12     pca10000
22940   164     10316   33420   old
22928   164     10316   33408   new

-12     0       0       -12     pca10005
22916   164     10316   33396   old
22904   164     10316   33384   new

-32     0       0       -32     pttu
60796   2356    95945   159097  old
60764   2356    95945   159065  new

0       0       0       0       qemu-i386
132413  2340    68232   202985  old
132413  2340    68232   202985  new

-8      0       0       -8      remote
12908   164     2620    15692   old
12900   164     2620    15684   new

-12     0       0       -12     saml21-xpro
23164   164     10444   33772   old
23152   164     10444   33760   new

-12     0       0       -12     samr21-xpro
34144   168     11608   45920   old
34132   168     11608   45908   new

-8      0       0       -8      slwstk6220a
12200   164     2748    15112   old
12192   164     2748    15104   new

-4      0       0       -4      spark-core
22800   164     10444   33408   old
22796   164     10444   33404   new

-16     0       0       -16     stm32f0discovery
12536   164     2628    15328   old
12520   164     2628    15312   new

-8      0       0       -8      stm32f3discovery
12684   164     2636    15484   old
12676   164     2636    15476   new

-12     0       0       -12     stm32f4discovery
14544   168     2776    17488   old
14532   168     2776    17476   new

-42     0       0       -42     telosb
10616   30      1056    11702   old
10574   30      1056    11660   new

-8      0       0       -8      udoo
12244   168     2648    15060   old
12236   168     2648    15052   new

-16     0       0       -16     weio
12352   164     2620    15136   old
12336   164     2620    15120   new

-42     0       0       -42     wsn430-v1_3b
10624   34      1056    11714   old
10582   34      1056    11672   new

-42     0       0       -42     wsn430-v1_4
10624   34      1056    11714   old
10582   34      1056    11672   new

-12     0       0       -12     yunjia-nrf51822
22900   164     10316   33380   old
22888   164     10316   33368   new

-38     0       0       -38     z1
10160   30      1056    11246   old
10122   30      1056    11208   new
```