### PR TITLE
tftp: fix formatting warnings/errors

### DIFF
--- a/examples/gnrc_tftp/tftp_client.c
+++ b/examples/gnrc_tftp/tftp_client.c
@@ -59,7 +59,7 @@ static bool _tftp_client_start_cb(tftp_action_t action, tftp_mode_t mode,
     }
 
     /* display the action being performed */
-    printf("tftp_client: %s %s %s:%u\n", str_mode, str_action, file_name, *len);
+    printf("tftp_client: %s %s %s:%lu\n", str_mode, str_action, file_name, (unsigned long)*len);
 
     /* return the length of the text, if this is an read action */
     if (action == TFTP_READ) {
@@ -92,7 +92,7 @@ static int _tftp_client_data_cb(uint32_t offset, void *data, size_t data_len)
     }
     else {
         /* we received a data block which we output to the console */
-        printf("\n -- CLIENT DATA --\n%.*s\n -- CLIENT DATA --\n", data_len, c);
+        printf("\n -- CLIENT DATA --\n%.*s\n -- CLIENT DATA --\n", (int)data_len, c);
     }
 
     /* return the length of the data block */

--- a/examples/gnrc_tftp/tftp_server.c
+++ b/examples/gnrc_tftp/tftp_server.c
@@ -65,7 +65,7 @@ static bool _tftp_server_start_cb(tftp_action_t action, tftp_mode_t mode,
     }
 
     /* display the action being performed */
-    printf("tftp_server: %s %s %s:%u\n", str_mode, str_action, file_name, *len);
+    printf("tftp_server: %s %s %s:%lu\n", str_mode, str_action, file_name, (unsigned long)*len);
 
     /* return the length of the text, if this is an read action */
     if (action == TFTP_READ) {
@@ -98,7 +98,7 @@ static int _tftp_server_data_cb(uint32_t offset, void *data, size_t data_len)
     }
     else {
         /* we received a data block which we output to the console */
-        printf("\n -- SERVER DATA --\n%.*s\n -- SERVER DATA --\n", data_len, c);
+        printf("\n -- SERVER DATA --\n%.*s\n -- SERVER DATA --\n", (int)data_len, c);
     }
 
     /* return the length of the data block */

--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -1055,9 +1055,9 @@ int _tftp_decode_options(tftp_context_t *ctxt, gnrc_pktsnip_t *buf, uint32_t sta
     size_t offset = start;
 
     DEBUG("tftp: decode options\n");
-    DEBUG("tftp:   buffer size = %d\n", buf->size);
+    DEBUG("tftp:   buffer size = %lu\n", (unsigned long)buf->size);
     while ((offset + sizeof(uint16_t)) < (buf->size)) {
-        DEBUG("tftp:   offset = %d\n", offset);
+        DEBUG("tftp:   offset = %lu\n", (unsigned long)offset);
         /* get the option name */
         const char *name = (const char *)(pkt->data + offset);
         offset += strlen(name) + 1;
@@ -1095,7 +1095,7 @@ int _tftp_decode_options(tftp_context_t *ctxt, gnrc_pktsnip_t *buf, uint32_t sta
         }
     }
 
-    DEBUG("tftp:   return %d\n", offset);
+    DEBUG("tftp:   return %lu\n", (unsigned long)offset);
     return offset;
 }
 


### PR DESCRIPTION
Fixes compiler formatting errors thrown by OS X clang compiler.