### PR TITLE
pkg: ccn-lite: pin to upstream commit

### DIFF
--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=ccn-lite
-PKG_URL=https://github.com/OlegHahm/ccn-lite/
-PKG_VERSION=riot_integration_preparation
+PKG_URL=https://github.com/cn-uofbasel/ccn-lite/
+PKG_VERSION=57be9b1985dc501b26f861b24448b54db37f73f1
 PKG_DIR=$(CURDIR)/$(PKG_NAME)
 
 ifneq ($(RIOTBOARD),)


### PR DESCRIPTION
fixes #4568