### PR TITLE
kinetis/rtc: move rtt-to-rtc wrapper to drivers/periph_common

### DIFF
--- a/cpu/kinetis_common/Makefile.include
+++ b/cpu/kinetis_common/Makefile.include
@@ -1,6 +1,9 @@
 # include module specific includes
 export INCLUDES += -I$(RIOTCPU)/kinetis_common/include
 
+# include common peripherals module (for RTT to RTC wrapper)
+export USEMODULE += periph_common
+
 # Add search path for linker scripts
 export LINKFLAGS += -L$(RIOTCPU)/kinetis_common/ldscripts
 

--- a/cpu/kinetis_common/include/periph_cpu.h
+++ b/cpu/kinetis_common/include/periph_cpu.h
@@ -93,6 +93,11 @@ enum {
     PORT_NUMOF
 };
 
+/**
+ * @brief   Include RTT to RTC wrapper interface from common peripheral
+ */
+#define PERIPH_RTC_NEEDS_RTT_WRAPPER
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/periph_common/rtc.c
+++ b/drivers/periph_common/rtc.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     cpu_kinetis_common_rtt
+ * @ingroup     drivers
  *
  * @{
  *
@@ -21,17 +21,17 @@
 
 #include <stdint.h>
 #include <time.h>
+
+#include "board.h"
 #include "cpu.h"
 #include "periph/rtc.h"
 #include "periph/rtt.h"
-#include "periph_conf.h"
-
-#define ENABLE_DEBUG (0)
-#include "debug.h"
+#include "periph_cpu.h"
 
 #if RTC_NUMOF
+#if RTT_NUMOF
 
-
+#ifdef PERIPH_RTC_NEEDS_RTT_WRAPPER
 typedef struct {
     rtc_alarm_cb_t cb;        /**< callback called from RTC interrupt */
 } rtc_state_t;
@@ -110,5 +110,7 @@ static void rtc_cb(void* arg)
         rtc_callback.cb(arg);
     }
 }
+#endif /* PERIPH_RTC_NEEDS_RTT_WRAPPER */
 
+#endif /* RTT_NUMOF */
 #endif /* RTC_NUMOF */


### PR DESCRIPTION
This should fix #4565.

There is no change in the code. I only moved the file, changed docs and added the defines (similar to the common methods for SPI).

I don't own a kinetis board. However, I have ensured that `tests/periph_rtc` would still compile (using `frdm-k64f`). Also, I tested this code on my local EFM32 port, which works too.