### PR TITLE
boards: use default values for STDIO defines

### DIFF
--- a/boards/airfy-beacon/include/board.h
+++ b/boards/airfy-beacon/include/board.h
@@ -44,15 +44,6 @@
 /** @} */
 
 /**
- * @name Define the boards stdio
- * @{
- */
-#define STDIO               UART_DEV(0)
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name Macros for controlling the on-board LEDs.
  * @{
  */

--- a/boards/arduino-due/include/board.h
+++ b/boards/arduino-due/include/board.h
@@ -34,15 +34,6 @@ extern "C" {
 #define F_CPU               (84000000UL)
 
 /**
- * @name Define UART device and baudrate for stdio
- * @{
- */
-#define STDIO               UART_DEV(0)
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/arduino-mega2560/include/board.h
+++ b/boards/arduino-mega2560/include/board.h
@@ -34,13 +34,10 @@ extern "C" {
 #define F_CPU               (16000000L)
 
 /**
-* @name Define UART device and baudrate for stdio
-* @{
+* @brief As the CPU is too slow to handle 115200 baud, we set the default
+*        baudrate to 9600 for this board
 */
-#define STDIO               UART_0
 #define STDIO_BAUDRATE      (9600U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
 
 /**
  * @name LED pin definitions

--- a/boards/avsextrem/include/board.h
+++ b/boards/avsextrem/include/board.h
@@ -48,15 +48,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name Define UART device and baudrate for stdio
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @brief Initialize the board's clock system
  */
 void init_clks1(void);

--- a/boards/cc2538dk/include/board.h
+++ b/boards/cc2538dk/include/board.h
@@ -33,15 +33,6 @@ extern "C" {
 #define F_CPU               XOSC32M_FREQ
 
 /**
- * @name Define UART device and baudrate for stdio
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      115200
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name Macros for controlling the on-board LEDs.
  * @{
  */

--- a/boards/chronos/include/board.h
+++ b/boards/chronos/include/board.h
@@ -42,18 +42,6 @@ extern "C" {
 #define XTIMER_SHIFT_ON_COMPARE     (4)
 /** @} */
 
-/**
- * @brief   Standard input/output device configuration
- *
- * This defines are for compatibility with the CPU implementation but they are
- * not used for this board (as it has no UART interface accessible...)
- * @{
- */
-#define STDIO                       (0)
-#define STDIO_BAUDRATE              (115200U)
-#define STDIO_RX_BUFSIZE            (64U)
-/** @} */
-
 #define MSP430_INITIAL_CPU_SPEED    7372800uL
 #define F_CPU                       MSP430_INITIAL_CPU_SPEED
 #define F_RC_OSCILLATOR             32768

--- a/boards/ek-lm4f120xl/include/board.h
+++ b/boards/ek-lm4f120xl/include/board.h
@@ -30,15 +30,6 @@ extern "C" {
 #endif
 
 /**
- * @name Define the boards stdio
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name Macros for controlling the on-board LEDs.
  * @{
  */

--- a/boards/f4vi1/include/board.h
+++ b/boards/f4vi1/include/board.h
@@ -35,15 +35,6 @@ extern "C" {
 #define F_CPU               CLOCK_CORECLOCK
 
 /**
- * @name Define UART device and baudrate for stdio
- * @{
- */
-#define STDIO               UART_DEV(0)
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/fox/include/board.h
+++ b/boards/fox/include/board.h
@@ -39,15 +39,6 @@ extern "C" {
 #define F_CPU               CLOCK_CORECLOCK
 
 /**
- * @name Define the UART to be used as stdio and its baudrate
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name Define the interface to the AT86RF231 radio
  *
  * {spi bus, spi speed, cs pin, int pin, reset pin, sleep pin}

--- a/boards/frdm-k64f/include/board.h
+++ b/boards/frdm-k64f/include/board.h
@@ -36,15 +36,6 @@ extern "C"
 #define F_CPU               CLOCK_CORECLOCK
 
 /**
- * @name Define UART device and baudrate for stdio
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_RX_BUFSIZE    (64U)
-#define STDIO_BAUDRATE      (115200U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/iotlab-m3/include/board.h
+++ b/boards/iotlab-m3/include/board.h
@@ -39,17 +39,12 @@ extern "C" {
 #define F_CPU               CLOCK_CORECLOCK
 
 /**
- * @name Define the UART to be used as stdio, its baudrate, and the size of
- *       receiving ringbuffer
+ * @name Set the default baudrate to 500K for this board
  * @{
  */
-#define STDIO               UART_0
-
 #ifndef STDIO_BAUDRATE
 #   define STDIO_BAUDRATE   (500000U)
 #endif
-
-#define STDIO_RX_BUFSIZE    (64U)
 /** @} */
 
 /**

--- a/boards/limifrog-v1/include/board.h
+++ b/boards/limifrog-v1/include/board.h
@@ -37,15 +37,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name Define the UART to be used as stdio and its baudrate
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/mbed_lpc1768/include/board.h
+++ b/boards/mbed_lpc1768/include/board.h
@@ -38,15 +38,6 @@ extern "C" {
 #define F_CPU               (96000000)
 
 /**
- * @name Assign the UART interface to be used for stdio
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/msb-430/include/board.h
+++ b/boards/msb-430/include/board.h
@@ -48,15 +48,6 @@ extern "C" {
 #define XTIMER_BACKOFF              (40)
 /** @} */
 
-/**
- * @brief   Standard input/output device configuration
- * @{
- */
-#define STDIO                       (0)
-#define STDIO_BAUDRATE              (115200U)
-#define STDIO_RX_BUFSIZE            (64U)
-/** @} */
-
 /* MSB430 core */
 #define MSP430_INITIAL_CPU_SPEED    2457600uL
 #define F_CPU                       MSP430_INITIAL_CPU_SPEED

--- a/boards/msb-430h/include/board.h
+++ b/boards/msb-430h/include/board.h
@@ -42,15 +42,6 @@ extern "C" {
 #define XTIMER_BACKOFF              (40)
 /** @} */
 
-/**
- * @brief   Standard input/output device configuration
- * @{
- */
-#define STDIO                       (0)
-#define STDIO_BAUDRATE              (115200U)
-#define STDIO_RX_BUFSIZE            (64U)
-/** @} */
-
 //MSB430 core
 #define MSP430_INITIAL_CPU_SPEED    7372800uL
 #define F_CPU                       MSP430_INITIAL_CPU_SPEED

--- a/boards/msba2/include/board.h
+++ b/boards/msba2/include/board.h
@@ -45,15 +45,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name Define UART device and baudrate for stdio
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name xtimer tuning values
  * @{
  */

--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -54,15 +54,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name Define UART device and baudrate for stdio
- * @{
- */
-#define STDIO               UART_DEV(0)
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/mulle/include/board.h
+++ b/boards/mulle/include/board.h
@@ -34,15 +34,6 @@
 #define DISABLE_WDOG    1
 
 /**
- * @name Define UART device and baudrate for stdio
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LEDs configuration
  * @{
  */

--- a/boards/nrf51dongle/include/board.h
+++ b/boards/nrf51dongle/include/board.h
@@ -34,15 +34,6 @@ extern "C" {
 #define F_CPU               (CLOCK_CORECLOCK)
 
 /**
- * @name    Define the boards STDIO
- * @{
- */
-#define STDIO               UART_DEV(0)
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name    LED pin definitions
  * @{
  */

--- a/boards/nrf6310/include/board.h
+++ b/boards/nrf6310/include/board.h
@@ -35,15 +35,6 @@ extern "C" {
 #define F_CPU               (16000000UL)
 
 /**
- * @name Define the boards stdio
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name    LED pin definitions
  * @{
  */

--- a/boards/nucleo-f091/include/board.h
+++ b/boards/nucleo-f091/include/board.h
@@ -36,15 +36,6 @@ extern "C" {
 #define F_CPU               CLOCK_CORECLOCK
 
 /**
- * @name Define the UART to be used as stdio and its baudrate
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/nucleo-f103/include/board.h
+++ b/boards/nucleo-f103/include/board.h
@@ -36,13 +36,9 @@ extern "C" {
 #define F_CPU               CLOCK_CORECLOCK
 
 /**
- * @name Define the UART to be used as stdio and its baudrate
- * @{
+ * @brief Use the 2nd UART for STDIO on this board
  */
 #define STDIO               UART_1
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
 
 /**
  * @name LED pin definitions

--- a/boards/nucleo-f303/include/board.h
+++ b/boards/nucleo-f303/include/board.h
@@ -38,15 +38,6 @@ extern "C" {
 #define F_CPU               CLOCK_CORECLOCK
 
 /**
- * @name Define the UART to be used as stdio and its baudrate
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/nucleo-f334/include/board.h
+++ b/boards/nucleo-f334/include/board.h
@@ -36,15 +36,6 @@ extern "C" {
 #define F_CPU               CLOCK_CORECLOCK
 
 /**
- * @name Define the UART to be used as stdio and its baudrate
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/nucleo-f401/include/board.h
+++ b/boards/nucleo-f401/include/board.h
@@ -44,15 +44,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name Define UART device and baudrate for stdio
- * @{
- */
-#define STDIO               UART_DEV(0)
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/nucleo-l1/include/board.h
+++ b/boards/nucleo-l1/include/board.h
@@ -46,15 +46,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name Define the UART to be used as stdio and its baudrate
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/openmote/include/board.h
+++ b/boards/openmote/include/board.h
@@ -34,15 +34,6 @@
 #define F_CPU               (32000000UL)
 
 /**
- * @name Assign the UART interface to be used for stdio
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/pba-d-01-kw2x/include/board.h
+++ b/boards/pba-d-01-kw2x/include/board.h
@@ -36,15 +36,6 @@ extern "C"
 #define F_CPU               CLOCK_CORECLOCK
 
 /**
- * @name Define UART device and baudrate for stdio
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_RX_BUFSIZE    (64U)
-#define STDIO_BAUDRATE      (115200U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/pca10000/include/board.h
+++ b/boards/pca10000/include/board.h
@@ -45,15 +45,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name    Define the boards stdio
- * @{
- */
-#define STDIO               UART_DEV(0)
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name    LED pin definitions
  * @{
  */

--- a/boards/pca10005/include/board.h
+++ b/boards/pca10005/include/board.h
@@ -45,15 +45,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name Define the boards stdio
- * @{
- */
-#define STDIO               UART_DEV(0)
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name Macros for controlling the on-board LEDs.
  * @{
  */

--- a/boards/pttu/include/board.h
+++ b/boards/pttu/include/board.h
@@ -51,15 +51,6 @@ void init_clks2(void);
 void bl_init_clks(void);
 
 /**
- * @name Define UART device and baudrate for stdio
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name dummy-defines for LEDs
  * @{
  */

--- a/boards/remote/include/board.h
+++ b/boards/remote/include/board.h
@@ -36,14 +36,6 @@
 #define F_CPU               (32000000UL)
 
 /**
- * @name Assign the UART interface to be used for stdio
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/saml21-xpro/include/board.h
+++ b/boards/saml21-xpro/include/board.h
@@ -32,16 +32,6 @@ extern "C" {
  */
 #define F_CPU               (16000000UL)
 
-/** @}*/
-/**
- * @name Define UART device and baudrate for stdio
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
 /**
  * @name LED pin definitions
  * @{

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -42,15 +42,6 @@ extern "C" {
 #define XTIMER_CHAN         (0)
 
 /**
- * @name Define UART device and baudrate for stdio
- * @{
- */
-#define STDIO               UART_DEV(0)
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name AT86RF233 configuration
  *
  * {spi bus, spi speed, cs pin, int pin, reset pin, sleep pin}

--- a/boards/slwstk6220a/include/board.h
+++ b/boards/slwstk6220a/include/board.h
@@ -41,15 +41,6 @@ extern "C" {
 #define HW_TIMER            TIMER_DEV(0)
 
 /**
- * @brief   Define UART device and baudrate for STDIO
- * @{
- */
-#define STDIO               UART_DEV(0)
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @brief   Connection to the on-board temperature/humidity sensor (Si7021)
  * @{
  */

--- a/boards/spark-core/include/board.h
+++ b/boards/spark-core/include/board.h
@@ -41,15 +41,6 @@
 #define LOCATION_VTABLE     (0x08005000)
 
 /**
- * @name Define the UART to be used as stdio and its baudrate
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/stm32f0discovery/include/board.h
+++ b/boards/stm32f0discovery/include/board.h
@@ -33,13 +33,6 @@ extern "C" {
 #define F_CPU               (48000000UL)
 
 /**
- * @name Assign the UART interface to be used for stdio
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/stm32f3discovery/include/board.h
+++ b/boards/stm32f3discovery/include/board.h
@@ -33,15 +33,6 @@ extern "C" {
 #define F_CPU               (72000000UL)
 
 /**
- * @name Define the UART used for stdio
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/stm32f4discovery/include/board.h
+++ b/boards/stm32f4discovery/include/board.h
@@ -44,15 +44,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name Define UART device and baudrate for stdio
- * @{
- */
-#define STDIO               UART_DEV(0)
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/telosb/include/board.h
+++ b/boards/telosb/include/board.h
@@ -48,15 +48,6 @@ extern "C" {
 #define XTIMER_BACKOFF              (40)
 /** @} */
 
-/**
- * @brief   Standard input/output device configuration
- * @{
- */
-#define STDIO                       (0)
-#define STDIO_BAUDRATE              (115200U)
-#define STDIO_RX_BUFSIZE            (64U)
-/** @} */
-
 /* TelosB core */
 #define MSP430_INITIAL_CPU_SPEED    2457600uL
 #define F_CPU                       MSP430_INITIAL_CPU_SPEED

--- a/boards/udoo/include/board.h
+++ b/boards/udoo/include/board.h
@@ -34,15 +34,6 @@ extern "C" {
 #define F_CPU               (84000000UL)
 
 /**
- * @name Define UART device and baudrate for stdio
- * @{
- */
-#define STDIO               UART_DEV(0)
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/weio/include/board.h
+++ b/boards/weio/include/board.h
@@ -36,15 +36,6 @@ extern "C" {
 #define F_CPU               (48000000)
 
 /**
- * @name Assign the UART interface to be used for stdio
- * @{
- */
-#define STDIO               UART_0
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/wsn430-v1_3b/include/board.h
+++ b/boards/wsn430-v1_3b/include/board.h
@@ -50,15 +50,6 @@ extern "C" {
 #define XTIMER_BACKOFF              (40)
 /** @} */
 
-/**
- * @brief   Standard input/output device configuration
- * @{
- */
-#define STDIO                       (0)
-#define STDIO_BAUDRATE              (115200U)
-#define STDIO_RX_BUFSIZE            (64U)
-/** @} */
-
 //MSB430 core
 #define MSP430_INITIAL_CPU_SPEED    800000uL
 #define F_CPU                       MSP430_INITIAL_CPU_SPEED

--- a/boards/wsn430-v1_4/include/board.h
+++ b/boards/wsn430-v1_4/include/board.h
@@ -50,15 +50,6 @@ extern "C" {
 #define XTIMER_BACKOFF              (40)
 /** @} */
 
-/**
- * @brief   Standard input/output device configuration
- * @{
- */
-#define STDIO                       (0)
-#define STDIO_BAUDRATE              (115200U)
-#define STDIO_RX_BUFSIZE            (64U)
-/** @} */
-
 /* MSB430 core */
 #define MSP430_INITIAL_CPU_SPEED    800000uL
 #define F_CPU                       MSP430_INITIAL_CPU_SPEED

--- a/boards/yunjia-nrf51822/include/board.h
+++ b/boards/yunjia-nrf51822/include/board.h
@@ -44,15 +44,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name Define the boards stdio
- * @{
- */
-#define STDIO               UART_DEV(0)
-#define STDIO_BAUDRATE      (115200U)
-#define STDIO_RX_BUFSIZE    (64U)
-/** @} */
-
-/**
  * @name Macros for controlling the on-board LEDs.
  * @{
  */

--- a/boards/z1/include/board.h
+++ b/boards/z1/include/board.h
@@ -59,15 +59,6 @@ extern "C" {
 #define STDIO_RX_BUFSIZE            (64U)
 /** @} */
 
-/**
- * @brief   Standard input/output device configuration
- * @{
- */
-#define STDIO                       (0)
-#define STDIO_BAUDRATE              (115200U)
-#define STDIO_RX_BUFSIZE            (64U)
-/** @} */
-
 /*  MSP430 core */
 #define MSP430_INITIAL_CPU_SPEED    8000000uL
 #ifndef F_CPU

--- a/sys/uart_stdio/uart_stdio.c
+++ b/sys/uart_stdio/uart_stdio.c
@@ -25,13 +25,10 @@
 
 #include <stdio.h>
 
-#include "cpu_conf.h"
 #include "tsrb.h"
 #include "thread.h"
 #include "mutex.h"
 #include "irq.h"
-
-#include "periph/uart.h"
 
 #include "board.h"
 #include "periph/uart.h"
@@ -40,7 +37,7 @@
 #include "debug.h"
 
 #ifndef STDIO
-#define STDIO               (0)
+#define STDIO               UART_DEV(0)
 #endif
 
 #ifndef STDIO_BAUDRATE


### PR DESCRIPTION
The `uart_stdio` module gives us default values for the STDIO mapping ('UART_DEV(0)', '115200', '64'). So it is not necessary for the boards, to define these values anymore. We just need to define something if the values used differ from the defaults...