### PR TITLE
boards: removed F_CPU defines

### DIFF
--- a/boards/airfy-beacon/include/board.h
+++ b/boards/airfy-beacon/include/board.h
@@ -28,11 +28,6 @@
 #endif
 
 /**
- * @name Define the nominal CPU core clock in this board
- */
-#define F_CPU               (16000000UL)
-
-/**
  * @brief   Xtimer configuration
  * @{
  */

--- a/boards/arduino-due/include/board.h
+++ b/boards/arduino-due/include/board.h
@@ -29,11 +29,6 @@ extern "C" {
 #endif
 
 /**
- * Define the nominal CPU core clock in this board
- */
-#define F_CPU               (84000000UL)
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/arduino-due/include/periph_conf.h
+++ b/boards/arduino-due/include/periph_conf.h
@@ -28,6 +28,13 @@ extern "C" {
 #endif
 
 /**
+ * @name Clock configuration
+ * @{
+ */
+#define CLOCK_CORECLOCK     (84000000U)
+/** @} */
+
+/**
  * @name Timer peripheral configuration
  * @{
  */

--- a/boards/arduino-mega2560/include/board.h
+++ b/boards/arduino-mega2560/include/board.h
@@ -29,11 +29,6 @@ extern "C" {
 #endif
 
 /**
- * Define the nominal CPU core clock in this board
- */
-#define F_CPU               (16000000L)
-
-/**
 * @brief As the CPU is too slow to handle 115200 baud, we set the default
 *        baudrate to 9600 for this board
 */

--- a/boards/arduino-mega2560/include/periph_conf.h
+++ b/boards/arduino-mega2560/include/periph_conf.h
@@ -24,6 +24,13 @@ extern "C" {
 #endif
 
 /**
+ * @name        Clock configuration
+ * @{
+ */
+#define CLOCK_CORECLOCK     (16000000L)
+/** @} */
+
+/**
  * @name        Timer peripheral configuration
  * @brief       The ATmega2560 has 6 timers. Timer0 and Timer2 are 8 Bit Timers,
  *              Timer0 has special uses too and therefore we'll avoid using it.

--- a/boards/avsextrem/drivers/avsextrem-ssp0.c
+++ b/boards/avsextrem/drivers/avsextrem-ssp0.c
@@ -23,6 +23,7 @@
 #include "lpc23xx.h"   /* LPC23XX/24xx Peripheral Registers */
 #include "cpu.h"
 #include "VIC.h"
+#include "periph_conf.h"
 #include "ssp0-board.h"
 #include "smb380-board.h"
 //#include "mma7455l-board.h"
@@ -192,7 +193,7 @@ uint8_t SSP0Prepare(uint8_t chip, uint8_t datasize, uint8_t cpol, uint8_t cpha,
     // Clock Setup
     uint32_t pclksel;
     uint32_t cpsr;
-    lpc2387_pclk_scale(F_CPU / 1000, freq, &pclksel, &cpsr);
+    lpc2387_pclk_scale(CLOCK_CORECLOCK / 1000, freq, &pclksel, &cpsr);
     PCLKSEL1 &= ~(BIT10 | BIT11); // CCLK to PCLK divider ???
     PCLKSEL1 |= pclksel << 10;
     SSP0CPSR = cpsr;

--- a/boards/cc2538dk/include/board.h
+++ b/boards/cc2538dk/include/board.h
@@ -28,11 +28,6 @@ extern "C" {
 #endif
 
 /**
- * Define the nominal CPU core clock in this board
- */
-#define F_CPU               XOSC32M_FREQ
-
-/**
  * @name Macros for controlling the on-board LEDs.
  * @{
  */

--- a/boards/ek-lm4f120xl/include/periph_conf.h
+++ b/boards/ek-lm4f120xl/include/periph_conf.h
@@ -27,7 +27,6 @@ extern "C" {
  * @name Define the nominal CPU core clock in this board
  * @{
  */
-#define F_CPU                           1000000
 #define CLK80                           1
 #define CLK50                           2
 #define CLK40                           3

--- a/boards/f4vi1/include/board.h
+++ b/boards/f4vi1/include/board.h
@@ -30,11 +30,6 @@ extern "C" {
 #endif
 
 /**
- * Define the nominal CPU core clock in this board
- */
-#define F_CPU               CLOCK_CORECLOCK
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/fox/include/board.h
+++ b/boards/fox/include/board.h
@@ -34,11 +34,6 @@ extern "C" {
 #endif
 
 /**
- * Define the nominal CPU core clock in this board
- */
-#define F_CPU               CLOCK_CORECLOCK
-
-/**
  * @name Define the interface to the AT86RF231 radio
  *
  * {spi bus, spi speed, cs pin, int pin, reset pin, sleep pin}

--- a/boards/frdm-k64f/include/board.h
+++ b/boards/frdm-k64f/include/board.h
@@ -31,11 +31,6 @@ extern "C"
 #endif
 
 /**
- * Define the nominal CPU core clock in this board
- */
-#define F_CPU               CLOCK_CORECLOCK
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/iotlab-m3/include/board.h
+++ b/boards/iotlab-m3/include/board.h
@@ -34,11 +34,6 @@ extern "C" {
 #endif
 
 /**
- * @name Define the nominal CPU core clock in this board
- */
-#define F_CPU               CLOCK_CORECLOCK
-
-/**
  * @name Set the default baudrate to 500K for this board
  * @{
  */

--- a/boards/limifrog-v1/include/board.h
+++ b/boards/limifrog-v1/include/board.h
@@ -31,12 +31,6 @@ extern "C" {
 #endif
 
 /**
- * @name Define the nominal CPU core clock in this board
- */
-#define F_CPU               CLOCK_CORECLOCK
-/** @} */
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/mbed_lpc1768/include/board.h
+++ b/boards/mbed_lpc1768/include/board.h
@@ -33,11 +33,6 @@ extern "C" {
 #endif
 
 /**
- * @brief The nominal CPU core clock in this board
- */
-#define F_CPU               (96000000)
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -29,11 +29,6 @@ extern "C" {
 #endif
 
 /**
- * Define the nominal CPU core clock in this board
- */
-#define F_CPU               CLOCK_CORECLOCK
-
-/**
  * @name Configure connected CC1101 (radio) device
  * @{
  */

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -50,10 +50,6 @@ extern "C"
 #define CPU_INT_FAST_CLK_HZ             4000000u
 /** Default System clock value */
 #define DEFAULT_SYSTEM_CLOCK            (CPU_XTAL32k_CLK_HZ * 2929u)
-
-/** @todo Investigate the side effects of making F_CPU run-time variable */
-#define F_CPU DEFAULT_SYSTEM_CLOCK
-
 /** @} */
 
 /**

--- a/boards/native/include/board.h
+++ b/boards/native/include/board.h
@@ -30,8 +30,6 @@
 extern "C" {
 #endif
 
-#define F_CPU 1000000
-
 void _native_LED_GREEN_OFF(void);
 #define LED_GREEN_OFF (_native_LED_GREEN_OFF())
 void _native_LED_GREEN_ON(void);

--- a/boards/nrf51dongle/include/board.h
+++ b/boards/nrf51dongle/include/board.h
@@ -29,11 +29,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Define the nominal CPU core clock in this board
- */
-#define F_CPU               (CLOCK_CORECLOCK)
-
-/**
  * @name    LED pin definitions
  * @{
  */

--- a/boards/nrf6310/include/board.h
+++ b/boards/nrf6310/include/board.h
@@ -30,11 +30,6 @@ extern "C" {
 #endif
 
 /**
- * @name Define the nominal CPU core clock in this board
- */
-#define F_CPU               (16000000UL)
-
-/**
  * @name    LED pin definitions
  * @{
  */

--- a/boards/nucleo-f091/include/board.h
+++ b/boards/nucleo-f091/include/board.h
@@ -31,11 +31,6 @@ extern "C" {
 #endif
 
 /**
- * @name Define the nominal CPU core clock in this board
- */
-#define F_CPU               CLOCK_CORECLOCK
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/nucleo-f103/include/board.h
+++ b/boards/nucleo-f103/include/board.h
@@ -31,14 +31,9 @@ extern "C" {
 #endif
 
 /**
- * @name Define the nominal CPU core clock in this board
- */
-#define F_CPU               CLOCK_CORECLOCK
-
-/**
  * @brief Use the 2nd UART for STDIO on this board
  */
-#define STDIO               UART_1
+#define STDIO               UART_DEV(1)
 
 /**
  * @name LED pin definitions

--- a/boards/nucleo-f303/include/board.h
+++ b/boards/nucleo-f303/include/board.h
@@ -33,11 +33,6 @@ extern "C" {
 #endif
 
 /**
- * @name Define the nominal CPU core clock in this board
- */
-#define F_CPU               CLOCK_CORECLOCK
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/nucleo-f334/include/board.h
+++ b/boards/nucleo-f334/include/board.h
@@ -31,11 +31,6 @@ extern "C" {
 #endif
 
 /**
- * @name Define the nominal CPU core clock in this board
- */
-#define F_CPU               CLOCK_CORECLOCK
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/nucleo-f401/include/board.h
+++ b/boards/nucleo-f401/include/board.h
@@ -29,11 +29,6 @@ extern "C" {
 #endif
 
 /**
- * @name Define the nominal CPU core clock in this board
- */
-#define F_CPU               CLOCK_CORECLOCK
-
-/**
  * @name xtimer configuration
  * @{
  */

--- a/boards/nucleo-l1/include/board.h
+++ b/boards/nucleo-l1/include/board.h
@@ -31,11 +31,6 @@ extern "C" {
 #endif
 
 /**
- * @name Define the nominal CPU core clock in this board
- */
-#define F_CPU               CLOCK_CORECLOCK
-
-/**
  * @name xtimer configuration
  * @{
  */

--- a/boards/openmote-cc2538/include/board.h
+++ b/boards/openmote-cc2538/include/board.h
@@ -29,11 +29,6 @@
 #endif
 
 /**
- * @name The nominal CPU core clock in this board
- */
-#define F_CPU               (32000000UL)
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/pba-d-01-kw2x/include/board.h
+++ b/boards/pba-d-01-kw2x/include/board.h
@@ -31,11 +31,6 @@ extern "C"
 #endif
 
 /**
- * Define the nominal CPU core clock in this board
- */
-#define F_CPU               CLOCK_CORECLOCK
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/pca10000/include/board.h
+++ b/boards/pca10000/include/board.h
@@ -29,11 +29,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Define the nominal CPU core clock in this board
- */
-#define F_CPU               (16000000UL)
-
-/**
  * @brief   Xtimer configuration
  * @{
  */

--- a/boards/pca10005/include/board.h
+++ b/boards/pca10005/include/board.h
@@ -29,11 +29,6 @@ extern "C" {
 #endif
 
 /**
- * @name Define the nominal CPU core clock in this board
- */
-#define F_CPU               (16000000UL)
-
-/**
  * @brief   Xtimer configuration
  * @{
  */

--- a/boards/qemu-i386/include/cpu_conf.h
+++ b/boards/qemu-i386/include/cpu_conf.h
@@ -31,8 +31,6 @@ extern "C" {
 #define THREAD_EXTRA_STACKSIZE_PRINTF_FLOAT      (8192)
 #define THREAD_STACKSIZE_MINIMUM                 (8192)
 
-#define F_CPU (1000000) /* This value is unused in x86 */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/remote/include/board.h
+++ b/boards/remote/include/board.h
@@ -31,11 +31,6 @@
 #endif
 
 /**
- * @name The nominal CPU core clock in this board
- */
-#define F_CPU               (32000000UL)
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/saml21-xpro/include/board.h
+++ b/boards/saml21-xpro/include/board.h
@@ -28,11 +28,6 @@ extern "C" {
 #endif
 
 /**
- * Define the nominal CPU core clock in this board
- */
-#define F_CPU               (16000000UL)
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -31,11 +31,6 @@ extern "C" {
 #endif
 
 /**
- * Define the nominal CPU core clock in this board
- */
-#define F_CPU               (CLOCK_CORECLOCK)
-
-/**
  * Assign the hardware timer
  */
 #define XTIMER              TIMER_1

--- a/boards/slwstk6220a/include/board.h
+++ b/boards/slwstk6220a/include/board.h
@@ -31,11 +31,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Define the nominal CPU core clock in this board
- */
-#define F_CPU               (CLOCK_CORECLOCK)
-
-/**
  * @brief   Assign the hardware timer
  */
 #define HW_TIMER            TIMER_DEV(0)

--- a/boards/spark-core/include/board.h
+++ b/boards/spark-core/include/board.h
@@ -31,11 +31,6 @@
 #endif
 
 /**
- * @name Define the nominal CPU core clock in this board
- */
-#define F_CPU               CLOCK_CORECLOCK
-
-/**
  * @name Define the location of the RIOT image in flash
  */
 #define LOCATION_VTABLE     (0x08005000)

--- a/boards/stm32f0discovery/include/board.h
+++ b/boards/stm32f0discovery/include/board.h
@@ -28,11 +28,6 @@ extern "C" {
 #endif
 
 /**
- * @name The nominal CPU core clock in this board
- */
-#define F_CPU               (48000000UL)
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/stm32f3discovery/include/board.h
+++ b/boards/stm32f3discovery/include/board.h
@@ -28,11 +28,6 @@ extern "C" {
 #endif
 
 /**
- * Define the nominal CPU core clock in this board
- */
-#define F_CPU               (72000000UL)
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/stm32f4discovery/include/board.h
+++ b/boards/stm32f4discovery/include/board.h
@@ -29,11 +29,6 @@ extern "C" {
 #endif
 
 /**
- * Define the nominal CPU core clock in this board
- */
-#define F_CPU               CLOCK_CORECLOCK
-
-/**
  * @name xtimer configuration
  * @{
  */

--- a/boards/udoo/include/board.h
+++ b/boards/udoo/include/board.h
@@ -29,11 +29,6 @@ extern "C" {
 #endif
 
 /**
- * Define the nominal CPU core clock in this board
- */
-#define F_CPU               (84000000UL)
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/udoo/include/periph_conf.h
+++ b/boards/udoo/include/periph_conf.h
@@ -26,6 +26,13 @@ extern "C" {
 #endif
 
 /**
+ * @name Clock configuration
+ * @{
+ */
+#define CLOCK_CORECLOCK     (84000000U)
+/** @} */
+
+/**
  * @name Timer peripheral configuration
  * @{
  */

--- a/boards/weio/include/board.h
+++ b/boards/weio/include/board.h
@@ -31,11 +31,6 @@ extern "C" {
 #endif
 
 /**
- * @brief The nominal CPU core clock in this board
- */
-#define F_CPU               (48000000)
-
-/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/weio/include/periph_conf.h
+++ b/boards/weio/include/periph_conf.h
@@ -25,6 +25,13 @@ extern "C" {
 #endif
 
 /**
+ * @brief Clock configuration
+ * @{
+ */
+#define CLOCK_CORECLOCK     (48000000U)
+/** @} */
+
+/**
  * @brief Timer configuration
  * @{
  */

--- a/boards/yunjia-nrf51822/include/board.h
+++ b/boards/yunjia-nrf51822/include/board.h
@@ -28,11 +28,6 @@ extern "C" {
 #endif
 
 /**
- * @name Define the nominal CPU core clock in this board
- */
-#define F_CPU               (16000000UL)
-
-/**
  * @brief   Xtimer configuration
  * @{
  */

--- a/cpu/atmega2560/periph/uart.c
+++ b/cpu/atmega2560/periph/uart.c
@@ -80,7 +80,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 
 static int init_base(uart_t uart, uint32_t baudrate)
 {
-    uint16_t clock_divider = F_CPU / (16 * baudrate);
+    uint16_t clock_divider = CLOCK_CORECLOCK / (16 * baudrate);
 
     switch (uart) {
 #if UART_0_EN

--- a/cpu/atmega2560/startup.c
+++ b/cpu/atmega2560/startup.c
@@ -24,8 +24,6 @@
 
 /* For Catchall-Loop */
 #include "board.h"
-#include <util/delay.h>
-#include <stdio.h>
 
 
 /**

--- a/cpu/lpc11u34/periph/pwm.c
+++ b/cpu/lpc11u34/periph/pwm.c
@@ -40,7 +40,7 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
                 return -1;
             }
             /* Check if the frequency and resolution is applicable */
-            if (F_CPU/(resolution*frequency) <= 0) {
+            if (CLOCK_CORECLOCK/(resolution*frequency) <= 0) {
                 return -2;
             }
 #if PWM_0_CH0_EN
@@ -56,8 +56,8 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
             pwm_poweron(dev);
             /* Enable timer and keep it in reset state */
             PWM_0_DEV->TCR = BIT0 | BIT1;
-            /* Set the prescaler (F_CPU / resolution) */
-            PWM_0_DEV->PR = (F_CPU/(resolution*frequency));
+            /* Set the prescaler (CLOCK_CORECLOCK / resolution) */
+            PWM_0_DEV->PR = (CLOCK_CORECLOCK/(resolution*frequency));
             /* Reset timer on MR3 */
             PWM_0_DEV->MCR = BIT10;
 
@@ -82,7 +82,7 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
                 return -1;
             }
             /* Check if the frequency and resolution is applicable */
-            if (F_CPU/(resolution*frequency) <= 0) {
+            if (CLOCK_CORECLOCK/(resolution*frequency) <= 0) {
                 return -2;
             }
 #if PWM_1_CH0_EN
@@ -98,8 +98,8 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
             pwm_poweron(dev);
             /* Enable timer and keep it in reset state */
             PWM_1_DEV->TCR = BIT0 | BIT1;
-            /* Set the prescaler (F_CPU / resolution) */
-            PWM_1_DEV->PR = (F_CPU/(resolution*frequency));
+            /* Set the prescaler (CLOCK_CORECLOCK / resolution) */
+            PWM_1_DEV->PR = (CLOCK_CORECLOCK/(resolution*frequency));
             /* Reset timer on MR3 */
             PWM_1_DEV->MCR = BIT10;
 

--- a/cpu/lpc2387/i2c/i2c.c
+++ b/cpu/lpc2387/i2c/i2c.c
@@ -258,7 +258,7 @@ void i2c_set_baud_rate(uint8_t i2c_interface, uint32_t baud_rate)
 {
     uint32_t pclksel = 0;
     uint32_t prescale = 0;
-    lpc2387_pclk_scale(F_CPU, baud_rate, &pclksel, &prescale);
+    lpc2387_pclk_scale(CLOCK_CORECLOCK, baud_rate, &pclksel, &prescale);
 
     switch (i2c_interface) {
         case I2C0:

--- a/cpu/lpc2387/include/lpc2387.h
+++ b/cpu/lpc2387/include/lpc2387.h
@@ -21,7 +21,6 @@ extern "C" {
 
 #define F_CCO                   288000000
 #define CL_CPU_DIV              4                                   ///< CPU clock divider
-#define F_CPU                   (F_CCO / CL_CPU_DIV)                ///< CPU target speed in Hz
 #define F_RC_OSCILLATOR         4000000                             ///< Frequency of internal RC oscillator
 #define F_RTC_OSCILLATOR        32767                               ///< Frequency of RTC oscillator
 

--- a/cpu/lpc2387/periph/pwm.c
+++ b/cpu/lpc2387/periph/pwm.c
@@ -57,7 +57,7 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
             PWM1TCR = BIT1;
 
             /* set prescaler */
-            PWM1PR = (F_CPU / (frequency * resolution)) - 1;
+            PWM1PR = (CLOCK_CORECLOCK / (frequency * resolution)) - 1;
 
             /* set match register */
             PWM1MR0 = resolution;

--- a/cpu/lpc2387/periph/spi.c
+++ b/cpu/lpc2387/periph/spi.c
@@ -114,7 +114,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     /* Clock Setup*/
     uint32_t pclksel;
     uint32_t cpsr;
-    lpc2387_pclk_scale(F_CPU / 1000, f_baud, &pclksel, &cpsr);
+    lpc2387_pclk_scale(CLOCK_CORECLOCK / 1000, f_baud, &pclksel, &cpsr);
     PCLKSEL1 &= ~(BIT10 | BIT11);   /* CCLK to PCLK divider*/
     PCLKSEL1 |= pclksel << 10;
     SSP0CPSR = cpsr;

--- a/cpu/sam3/periph/pwm.c
+++ b/cpu/sam3/periph/pwm.c
@@ -73,18 +73,18 @@ int pwm_init(pwm_t dev, pwm_mode_t mode,
      * The pwm provides 11 prescaled clocks with (MCK/2^prea | prea=[0,10])
      * and a divider (diva) with a denominator range [1,255] in line.
      */
-    if (F_CPU < pwm_clk) {  /* Have to cut down resulting frequency. */
-        frequency = F_CPU / resolution;
+    if (CLOCK_CORECLOCK < pwm_clk) {  /* Have to cut down resulting frequency. */
+        frequency = CLOCK_CORECLOCK / resolution;
     }
     else {   /* Estimate prescaler and divider. */
-        diva = F_CPU / pwm_clk;
+        diva = CLOCK_CORECLOCK / pwm_clk;
 
         while ((prea < MCK_DIV_LB_MAX) && (~0xff & diva)) {
             prea = prea + 1;
             diva = diva >> 1;
         }
 
-        frequency = F_CPU / ((resolution * diva) << prea);
+        frequency = CLOCK_CORECLOCK / ((resolution * diva) << prea);
     }
 
     retval = frequency;

--- a/cpu/sam3/periph/timer.c
+++ b/cpu/sam3/periph/timer.c
@@ -117,7 +117,7 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
      * channel 2 toggles this line on each timer tick, the actual frequency driving ch0/1
      * is f_ch2 / 2 --> f_ch0/1 = (MCK / 2 / 2 / 1000000) * ticks_per_us.
      */
-    tim->TC_CHANNEL[2].TC_RC = ((F_CPU / 1000000) / 4) * ticks_per_us;
+    tim->TC_CHANNEL[2].TC_RC = ((CLOCK_CORECLOCK / 1000000) / 4) * ticks_per_us;
 
     /* start channel 2 */
     tim->TC_CHANNEL[2].TC_CCR = TC_CCR_CLKEN | TC_CCR_SWTRG;

--- a/cpu/sam3/periph/uart.c
+++ b/cpu/sam3/periph/uart.c
@@ -63,7 +63,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
                                              uart_config[uart].tx_pin);
 
     /* configure baud rate and set mode to 8N1 */
-    dev->UART_BRGR = (F_CPU / (16 * baudrate));
+    dev->UART_BRGR = (CLOCK_CORECLOCK / (16 * baudrate));
     dev->UART_MR = UART_MR_PAR_NO | US_MR_CHRL_8_BIT;
     dev->UART_CR = UART_CR_RXEN | UART_CR_TXEN | UART_CR_RSTSTA;
 

--- a/cpu/samd21/periph/pwm.c
+++ b/cpu/samd21/periph/pwm.c
@@ -102,11 +102,11 @@ int pwm_init(pwm_t dev, pwm_mode_t mode,
     }
 
     /* calculate the closest possible clock presacler */
-    prescaler = get_prescaler(F_CPU / (frequency * resolution), &scale);
+    prescaler = get_prescaler(CLOCK_CORECLOCK / (frequency * resolution), &scale);
     if (prescaler == 0xff) {
         return -2;
     }
-    f_real = (F_CPU / (scale * resolution));
+    f_real = (CLOCK_CORECLOCK / (scale * resolution));
 
     /* configure the used pins */
     for (int i = 0; i < PWM_MAX_CHANNELS; i++) {


### PR DESCRIPTION
Since the `hwtimer` was removed, RIOT is not using the F_CPU define anymore, so this PR removes most occurrences of this define. 

The `F_CPU` define was a duplicate to the `CLOCK_CORECLOCK` define on many platforms anyway.  CPU's that need the clock speed now use the `CLOCK_CORECLOCK' instead, so this should now be the default way in RIOT.

I only left the 'F_CPU' for MSP430 based boards, as for them the clock initialization code is still due for cleanup...