### PR TITLE
shell: commands: fix selective outputs for nano specs

### DIFF
--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -102,10 +102,10 @@ int _handle_reply(gnrc_pktsnip_t *pkt, uint32_t time)
             min_seq_expected++;
         }
 
-        printf("%u bytes from %s: id=%" PRIu16 " seq=%" PRIu16 " hop limit=%" PRIu8
-               " time = %" PRIu32 ".%03" PRIu32 " ms\n", (unsigned) icmpv6->size,
+        printf("%u bytes from %s: id=%" PRIu16 " seq=%" PRIu16 " hop limit=%u time = %"
+               PRIu32 ".%03" PRIu32 " ms\n", (unsigned) icmpv6->size,
                ipv6_addr_to_str(ipv6_str, &(ipv6_hdr->src), sizeof(ipv6_str)),
-               byteorder_ntohs(icmpv6_hdr->id), seq, ipv6_hdr->hl,
+               byteorder_ntohs(icmpv6_hdr->id), seq, (unsigned)ipv6_hdr->hl,
                time / MS_IN_USEC, time % MS_IN_USEC);
         gnrc_ipv6_nc_still_reachable(&ipv6_hdr->src);
     }

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -201,6 +201,7 @@ static void _netif_list(kernel_pid_t dev)
     netopt_state_t state;
     netopt_enable_t enable;
     bool linebreak = false;
+
 #ifdef MODULE_GNRC_IPV6_NETIF
     gnrc_ipv6_netif_t *entry = gnrc_ipv6_netif_get(dev);
     char ipv6_addr[IPV6_ADDR_MAX_STR_LEN];
@@ -255,7 +256,7 @@ static void _netif_list(kernel_pid_t dev)
     if (res >= 0) {
         res = gnrc_netapi_get(dev, NETOPT_CSMA, 0, &enable, sizeof(enable));
         if ((res >= 0) && (enable == NETOPT_ENABLE)) {
-            printf(" CSMA Retries: %" PRIu8 " ", *((uint8_t *) &u8));
+            printf(" CSMA Retries: %u ", (unsigned)u8);
         }
     }
 
@@ -320,7 +321,7 @@ static void _netif_list(kernel_pid_t dev)
 #ifdef MODULE_GNRC_IPV6_NETIF
     if (entry != NULL) {
         printf("MTU:%" PRIu16 "  ", entry->mtu);
-        printf("HL:%" PRIu8 "  ", entry->cur_hl);
+        printf("HL:%u  ", (unsigned)entry->cur_hl);
         if (entry->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN) {
             printf("6LO  ");
         }
@@ -370,8 +371,7 @@ static void _netif_list(kernel_pid_t dev)
 
             if (ipv6_addr_to_str(ipv6_addr, &entry->addrs[i].addr,
                                  IPV6_ADDR_MAX_STR_LEN)) {
-                printf("%s/%" PRIu8 "  scope: ", ipv6_addr,
-                       entry->addrs[i].prefix_len);
+                printf("%s/%u  scope: ", ipv6_addr, (unsigned)entry->addrs[i].prefix_len);
 
                 if ((ipv6_addr_is_link_local(&entry->addrs[i].addr))) {
                     printf("local");
@@ -526,6 +526,7 @@ static int _netif_set_addr(kernel_pid_t dev, netopt_t opt, char *addr_str)
 static int _netif_set_state(kernel_pid_t dev, char *state_str)
 {
     netopt_state_t state;
+
     if ((strcmp("off", state_str) == 0) || (strcmp("OFF", state_str) == 0)) {
         state = NETOPT_STATE_OFF;
     }
@@ -930,7 +931,7 @@ int _netif_config(int argc, char **argv)
                 gnrc_ipv6_netif_t *entry;
                 if (((hl = atoi(argv[3])) < 0) || (hl > UINT8_MAX)) {
                     printf("error: Hop limit must be between %" PRIu16 " and %" PRIu16 "\n",
-                            (uint16_t)0, (uint16_t)UINT16_MAX);
+                           (uint16_t)0, (uint16_t)UINT16_MAX);
                     return 1;
                 }
                 if ((entry = gnrc_ipv6_netif_get(dev)) == NULL) {


### PR DESCRIPTION
E.g.

```
108 bytes from fe80::3432:4833:46d5:aa16: id=84 seq=8892 hop limit=hu time = 64.019 ms
```

vs

```
108 bytes from fe80::3432:4833:46d5:aa16: id=84 seq=8892 hop limit=64 time = 19.346 ms
```