### PR TITLE
cpu: native: fix native timer_set_absolute()

### DIFF
--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -54,6 +54,14 @@
  */
 #define XTIMER_OVERHEAD 14
 #define XTIMER_USLEEP_UNTIL_OVERHEAD 1
+
+/* timer_set_absolute() has a high margin for possible underflow if set with
+ * value not far in the future. To prevent this, we set high backoff values
+ * here.
+ */
+#define XTIMER_BACKOFF      200
+#define XTIMER_ISR_BACKOFF  200
+
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -135,15 +135,7 @@ int timer_set(tim_t dev, int channel, unsigned int offset)
 int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 {
     uint32_t now = timer_read(dev);
-    int64_t target = (int32_t)(value - now);
-
-    DEBUG("timer_set_absolute(): delta=%lli\n", target);
-    if (target < 0 && target > -NATIVE_TIMER_MIN_RES) {
-        DEBUG("timer_set_absolute(): preventing underflow.\n");
-        target = NATIVE_TIMER_MIN_RES;
-    }
-
-    return timer_set(dev, channel, target);
+    return timer_set(dev, channel, value - now);
 }
 
 int timer_clear(tim_t dev, int channel)

--- a/tests/xtimer_now64_continuity/Makefile
+++ b/tests/xtimer_now64_continuity/Makefile
@@ -1,0 +1,8 @@
+export APPLICATION = xtimer_now64_continuity
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_timer
+
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_now64_continuity/README.md
+++ b/tests/xtimer_now64_continuity/README.md
@@ -1,0 +1,5 @@
+Description
+===========
+
+This test measures the difference of two consecutive calls to xtimer_now64() 10k times.
+Should the difference be larger then 1000us, the test fails, otherwise it succeeds.

--- a/tests/xtimer_now64_continuity/main.c
+++ b/tests/xtimer_now64_continuity/main.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       xtimer_now64 continuity test application
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include "xtimer.h"
+
+#define ITERATIONS (100000LU)
+#define MAXDIFF 1000
+
+int main(void)
+{
+    uint32_t n = ITERATIONS;
+    uint64_t now;
+    uint64_t before = xtimer_now64();
+
+    while(--n) {
+        now = xtimer_now64();
+        if ((now-before) > MAXDIFF) {
+            puts("TEST FAILED.");
+            break;
+        }
+        before = now;
+    }
+
+    if (!n) {
+        puts("TEST SUCCESSFUL.");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
In #3344 I introduced a safeguard for native's indeterministic timers which would cause a timer with a very close absolute target time to be triggered at once in order to prevent an underflow.

Turned out that xtimer triggers this safeguard when 1. initializing the timer (setting it to 0), 2. setting an absolute target of 0xFFFFFFFF for its overflow, causing the first overflow to occur 2^32 usec too early.