### PR TITLE
posix socket: align size of sa_family_t with Linux

### DIFF
--- a/sys/posix/include/sys/socket.h
+++ b/sys/posix/include/sys/socket.h
@@ -94,7 +94,7 @@ extern "C" {
 #define SO_TYPE         (15)    /**< Socket type. */
 /** @} */
 
-typedef unsigned int sa_family_t;   /**< address family type */
+typedef unsigned short sa_family_t;   /**< address family type */
 
 /**
  * @brief   Used to define the socket address.


### PR DESCRIPTION
Linux defines `sa_family_t` as `unsigned short int`. In order to be compatible with Linux code, RIOT should define it the same way.