### PR TITLE
pkg: oonf_api: move source

### DIFF
--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME=oonf_api
-PKG_URL=git://olsr.org/oonf.git
+PKG_URL=http://olsr.org/git/oonf.git
 PKG_VERSION=v0.3.0
 
 ifneq ($(RIOTBOARD),)


### PR DESCRIPTION
Apparently the URL for oonf changed a [while back](http://www.olsr.org/mediawiki/index.php/OLSR.org_Network_Framework#Compile_by_hand) and now the old one isn't reachable anymore.