### PR TITLE
tests: fix clang missing field error

### DIFF
--- a/tests/vtimer_msg_diff/main.c
+++ b/tests/vtimer_msg_diff/main.c
@@ -46,12 +46,12 @@ struct timer_msg {
 
 timex_t now;
 
-struct timer_msg timer_msgs[] = { { .interval = { .seconds = 0, .microseconds = 100000}, .msg = "T1", .start={0}, .count=0 },
-                                  { .interval = { .seconds = 0, .microseconds = 200000}, .msg = "T2", .start={0}, .count=0 },
-                                  { .interval = { .seconds = 0, .microseconds = 300000}, .msg = "T3", .start={0}, .count=0 },
-                                  { .interval = { .seconds = 0, .microseconds = 500000}, .msg = "T4", .start={0}, .count=0 },
-                                  { .interval = { .seconds = 0, .microseconds = 700000}, .msg = "T5", .start={0}, .count=0 },
-                                  { .interval = { .seconds = 1, .microseconds = 100000}, .msg = "T6", .start={0}, .count=0 },
+struct timer_msg timer_msgs[] = { { .interval = { .seconds = 0, .microseconds = 100000}, .msg = "T1", .start={0, 0}, .count=0 },
+                                  { .interval = { .seconds = 0, .microseconds = 200000}, .msg = "T2", .start={0, 0}, .count=0 },
+                                  { .interval = { .seconds = 0, .microseconds = 300000}, .msg = "T3", .start={0, 0}, .count=0 },
+                                  { .interval = { .seconds = 0, .microseconds = 500000}, .msg = "T4", .start={0, 0}, .count=0 },
+                                  { .interval = { .seconds = 0, .microseconds = 700000}, .msg = "T5", .start={0, 0}, .count=0 },
+                                  { .interval = { .seconds = 1, .microseconds = 100000}, .msg = "T6", .start={0, 0}, .count=0 },
 };
 
 void *timer_thread(void *arg)


### PR DESCRIPTION
Without this clang complains about missing initializers.
`error: missing field 'microseconds' initializer [-Werror,-Wmissing-field-initializers]`