### PR TITLE
tests: allow language extensions for fault_handler test in clang

### DIFF
--- a/tests/fault_handler/Makefile
+++ b/tests/fault_handler/Makefile
@@ -12,6 +12,10 @@ QUIET ?= 1
 
 CFLAGS += -DDEVELHELP=1
 
+ifeq ($(shell uname),Darwin)
+CFLAGS += -Wno-language-extension-token
+endif
+
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
Workaround for parts of #4560.