### PR TITLE
pkg: oonf_api: move source (2015.12 version)

### DIFF
--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME=oonf_api
-PKG_URL=git://olsr.org/oonf.git
+PKG_URL=http://olsr.org/git/oonf.git
 PKG_VERSION=v0.3.0
 
 ifneq ($(RIOTBOARD),)


### PR DESCRIPTION
Backport of #4591.