### PR TITLE
tests:xtimer_hang: use THREAD_STACKSIZE_DEFAULT instead of literal.

### DIFF
--- a/tests/xtimer_hang/main.c
+++ b/tests/xtimer_hang/main.c
@@ -28,7 +28,7 @@
 
 #define TEST_SECONDS        (10U)
 #define TEST_TIME           (TEST_SECONDS * SEC_IN_USEC)
-#define STACKSIZE_TIMER     (1024)
+#define STACKSIZE_TIMER     (THREAD_STACKSIZE_DEFAULT)
 
 char stack_timer1[STACKSIZE_TIMER];
 char stack_timer2[STACKSIZE_TIMER];


### PR DESCRIPTION
Without this, `xtimer_hang` segfaults using clang
```
Apple LLVM version 7.0.0 (clang-700.0.72)
Target: x86_64-apple-darwin15.2.0
Thread model: posix
```

Please test for gcc versions <5.*

Fixes #4597.