### PR TITLE
travis: pass the proper branch to compile_test.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
         sudo apt-get install $(./dist/tools/travis-scripts/get-pkg-list.py)
     - git config --global user.email "travis@example.com"
     - git config --global user.name "Travis CI"
+    - test "$TRAVIS_BRANCH" = "master" || git fetch origin $TRAVIS_BRANCH:$TRAVIS_BRANCH
 
 script:
     - ./dist/tools/travis-scripts/build_and_test.sh

--- a/dist/tools/travis-scripts/build_and_test.sh
+++ b/dist/tools/travis-scripts/build_and_test.sh
@@ -70,5 +70,5 @@ then
         #   resolved:
         #   - make -C ./tests/unittests all test BOARD=qemu-i386 || exit
     fi
-    ./dist/tools/compile_test/compile_test.py master
+    ./dist/tools/compile_test/compile_test.py $TRAVIS_BRANCH
 fi


### PR DESCRIPTION
Without this fix Travis-Builds for backporting PRs take a long time, because our build script cannot determine the correct diff of files to decide whether an application test can be skipped or not.

E.g. the script should diff against the 2015.12 branch instead of the master branch for backporting PRs.

`$TRAVIS_BRANCH` evaluates to the branch name that the PR targets [1]

[1] https://docs.travis-ci.com/user/environment-variables/