### PR TITLE
tests: swap thread priorities in msg_snd_rcv test (release version)

### DIFF
--- a/tests/msg_send_receive/Makefile
+++ b/tests/msg_send_receive/Makefile
@@ -1,8 +1,6 @@
 # name of your application
 APPLICATION = msg_send_receive
 
-USEMODULE += xtimer
-
 include ../Makefile.tests_common
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/msg_send_receive/main.c
+++ b/tests/msg_send_receive/main.c
@@ -24,7 +24,6 @@
 
 #include "cpu_conf.h"
 #include "thread.h"
-#include "xtimer.h"
 
 #define THREAD1_STACKSIZE   (THREAD_STACKSIZE_MAIN)
 #define THREAD2_STACKSIZE   (THREAD_STACKSIZE_MAIN)
@@ -58,7 +57,6 @@ static void *thread1(void *args)
             success = 0;
             break;
         }
-        xtimer_usleep(200);
     }
 
     if (success) {
@@ -96,9 +94,9 @@ static void *thread2(void *args)
 
 int main(void)
 {
-    thread2_pid = thread_create(thread2_stack, THREAD2_STACKSIZE, THREAD_PRIORITY_MAIN - 1,
+    thread2_pid = thread_create(thread2_stack, THREAD2_STACKSIZE, THREAD_PRIORITY_MAIN - 2,
                                 0, thread2, NULL, "thread2");
-    thread1_pid = thread_create(thread1_stack, THREAD1_STACKSIZE, THREAD_PRIORITY_MAIN - 2,
+    thread1_pid = thread_create(thread1_stack, THREAD1_STACKSIZE, THREAD_PRIORITY_MAIN - 1,
                                 0, thread1, NULL, "thread1");
     return 0;
 }


### PR DESCRIPTION
c3f7925c1ca786215448ad34fec845792e408274 was the wrong fix for the described problem. The replying thread 2 needs a higher priority because otherwise the sender thread 1 may send before 2 is in receiving mode again.

Release version of #4619.