### PR TITLE
gitignore: add ccn-lite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ _sketches.cpp
 Makefile.local
 
 # downloaded package sources
+pkg/ccn-lite/ccn-lite
 pkg/cmsis-dsp/cmsis-dsp
 pkg/libcoap/libcoap
 pkg/libfixmath/libfixmath


### PR DESCRIPTION
This adds `ccn-lite` to the `.gitignore` file.

#4401 may take this into consideration ( @authmillenon )