### PR TITLE
conn: make conn_*_sendto require a conn object

### DIFF
--- a/sys/include/net/conn/ip.h
+++ b/sys/include/net/conn/ip.h
@@ -101,14 +101,12 @@ int conn_ip_recvfrom(conn_ip_t *conn, void *data, size_t max_len, void *addr, si
 /**
  * @brief   Sends a message over IPv4/IPv6
  *
- * @param[in] data      Pointer where the received data should be stored.
- * @param[in] len       Maximum space available at @p data.
- * @param[in] src       The source address. May be NULL for all any interface address.
- * @param[in] src_len   Length of @p src.
+ * @param[in] conn      A raw IPv4/IPv6 connection object.
+ * @param[in] data      Data to send.
+ * @param[in] len       Length of @p data.
+ * @param[in] max_len   Maximum space available at @p data.
  * @param[in] dst       The receiver's network address.
  * @param[in] dst_len   Length of @p dst.
- * @param[in] family    The family of @p src and @p dst (see @ref net_af).
- * @param[in] proto     @ref net_protnum for the IPv6 packets to set.
  *
  * @note    Function may block.
  *
@@ -117,8 +115,7 @@ int conn_ip_recvfrom(conn_ip_t *conn, void *data, size_t max_len, void *addr, si
  *          draw inspiration of the errno values from the POSIX' send(), sendfrom(), or sendmsg()
  *          function specification.
  */
-int conn_ip_sendto(const void *data, size_t len, const void *src, size_t src_len,
-                   void *dst, size_t dst_len, int family, int proto);
+int conn_ip_sendto(conn_ip_t *conn, const void *data, size_t len, void *dst, size_t dst_len);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/conn/udp.h
+++ b/sys/include/net/conn/udp.h
@@ -105,15 +105,12 @@ int conn_udp_recvfrom(conn_udp_t *conn, void *data, size_t max_len, void *addr, 
 /**
  * @brief   Sends a UDP message
  *
- * @param[in] data      Pointer where the received data should be stored.
- * @param[in] len       Maximum space available at @p data.
- * @param[in] src       The source address. May be NULL for all any interface address.
- * @param[in] src_len   Length of @p src. May be 0 if @p src is NULL
+ * @param[in] conn      A raw IPv4/IPv6 connection object.
+ * @param[in] data      Data to send.
+ * @param[in] len       Length of @p data.
  * @param[in] dst       The receiver's network address.
  * @param[in] dst_len   Length of @p dst.
- * @param[in] family    The family of @p src and @p dst (see @ref net_af).
- * @param[in] sport     The source UDP port.
- * @param[in] dport     The receiver's UDP port.
+ * @param[in] port      The receiver's UDP port.
  *
  * @note    Function may block.
  *
@@ -122,9 +119,7 @@ int conn_udp_recvfrom(conn_udp_t *conn, void *data, size_t max_len, void *addr, 
  *          draw inspiration of the errno values from the POSIX' send(), sendfrom(), or sendmsg()
  *          function specification.
  */
-int conn_udp_sendto(const void *data, size_t len, const void *src, size_t src_len,
-                    const void *dst, size_t dst_len, int family, uint16_t sport,
-                    uint16_t dport);
+int conn_udp_sendto(conn_udp_t *conn, size_t len, const void *dst, size_t dst_len, uint16_t port);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Though GNRC (and afaik @kaspar030's stack to) are perfectly capable to send connection-less transport data without a connection most other stack APIs don't. While opening a connection object in `sendto` could be an alternative (though to me this defies the lightweight aspect of `conn`), stack internal checks make it impossible to send from a port where already a connection is open. To demonstrate the problem, here is a little echo server, that fails for both lwIP and emb6 due to this API incompatibility:

```C
conn_udp_t conn;
conn_udp_create(&conn, s_addr, s_addr_len, AF_INET6, s_port);
conn_udp_recvfrom(&conn, data, &len, c_addr, c_addr_len, c_port);
/* following call fails for both lwIP and emb6, since there is
 * already a connection on `s_port` open and their APIs require
 * opening a connection and port was already bound above. */
conn_udp_sendto(data, len, s_addr, s_addr_len, c_addr, c_addr_len,
                AF_INET6, s_port, c_port);
```

Partly related #4474.