### PR TITLE
conn: provide API support for asynchronous IO

### DIFF
--- a/sys/include/net/conn/ip.h
+++ b/sys/include/net/conn/ip.h
@@ -42,6 +42,15 @@ struct conn_ip;
 typedef struct conn_ip conn_ip_t;
 
 /**
+ * @brief   Event callback for asynchronous communication
+ *
+ * @param[in] conn  A raw IPv4/IPv6 connection object.
+ * @param[in] event Event type.
+ * @param[in] len   Length of event related data.
+ */
+typedef void (*conn_ip_cb_t)(conn_ip_t *conn, conn_event_t event, unsigned int len);
+
+/**
  * @brief   Creates a new raw IPv4/IPv6 connection object
  *
  * @param[out] conn     Preallocated connection object. Must fill the size of the stack-specific
@@ -56,6 +65,14 @@ typedef struct conn_ip conn_ip_t;
  *          draw inspiration of the errno values from the POSIX' bind() function specification.
  */
 int conn_ip_create(conn_ip_t *conn, const void *addr, size_t addr_len, int family, int proto);
+
+/**
+ * @brief   Sets an event callback for a raw IPv4/IPv6 connection
+ *
+ * @param[in] conn  A raw IPv4/IPv6 connection object.
+ * @param[in] cb    Externally defined event callback. May be NULL to unset.
+ */
+void conn_ip_set_cb(conn_ip_t *conn, conn_ip_cb_t *cb);
 
 /**
  * @brief   Closes a raw IPv4/IPv6 connection

--- a/sys/include/net/conn/tcp.h
+++ b/sys/include/net/conn/tcp.h
@@ -23,6 +23,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "net/conn/types.h"
+
 #ifdef MODULE_GNRC_CONN_TCP
 #include "net/gnrc/conn.h"
 #endif
@@ -42,6 +44,15 @@ struct conn_tcp;
 typedef struct conn_tcp conn_tcp_t;
 
 /**
+ * @brief   Event callback for asynchronous communication
+ *
+ * @param[in] conn  TCP connection object.
+ * @param[in] event Event type.
+ * @param[in] len   Length of event related data.
+ */
+typedef void (*conn_tcp_cb_t)(conn_tcp_t *conn, conn_event_t event, unsigned int len);
+
+/**
  * @brief   Creates a new TCP connection object
  *
  * @param[out] conn     Preallocated connection object. Must fill the size of the stack-specific
@@ -57,6 +68,14 @@ typedef struct conn_tcp conn_tcp_t;
  */
 int conn_tcp_create(conn_tcp_t *conn, const void *addr, size_t addr_len, int family,
                     uint16_t port);
+
+/**
+ * @brief   Sets an event callback for a TCP connection
+ *
+ * @param[in] conn  A TCP connection object.
+ * @param[in] cb    Externally defined event callback. May be NULL to unset.
+ */
+void conn_tcp_set_cb(conn_ip_t *conn, conn_ip_cb_t *cb);
 
 /**
  * @brief   Closes a TCP connection

--- a/sys/include/net/conn/types.h
+++ b/sys/include/net/conn/types.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup conn
+ * @{
+ *
+ * @file
+ * @brief   Generic types for @ref conn.
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+#ifndef CONN_TYPES_H_
+#define CONN_TYPES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Events to signal to asynchronous callbacks.
+ */
+typedef conn_event {
+    CONN_EVENT_RECV = 0,    /**< data received */
+} conn_event_t;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONN_TYPES_H_ */
+/** @} */

--- a/sys/include/net/conn/udp.h
+++ b/sys/include/net/conn/udp.h
@@ -23,6 +23,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "net/conn/types.h"
+
 #ifdef MODULE_GNRC_CONN_UDP
 #include "net/gnrc/conn.h"
 #endif
@@ -42,6 +44,15 @@ struct conn_udp;
 typedef struct conn_udp conn_udp_t;
 
 /**
+ * @brief   Event callback for asynchronous communication
+ *
+ * @param[in] conn  A UDP connection object.
+ * @param[in] event Event type.
+ * @param[in] len   Length of event related data.
+ */
+typedef void (*conn_udp_cb_t)(conn_udp_t *conn, conn_event_t event, unsigned int len);
+
+/**
  * @brief   Creates a new UDP connection object
  *
  * @param[out] conn     Preallocated connection object. Must fill the size of the stack-specific
@@ -57,6 +68,14 @@ typedef struct conn_udp conn_udp_t;
  */
 int conn_udp_create(conn_udp_t *conn, const void *addr, size_t addr_len, int family,
                     uint16_t port);
+
+/**
+ * @brief   Sets an event callback for a UDP connection
+ *
+ * @param[in] conn  A UDP connection object.
+ * @param[in] cb    Externally defined event callback. May be NULL to unset.
+ */
+void conn_udp_set_cb(conn_ip_t *conn, conn_ip_cb_t *cb);
 
 /**
  * @brief   Closes a UDP connection


### PR DESCRIPTION
Feel free to comment on this.

The main reason for the event type is that I expect TCP to be a lot more complicated then needing just a receive callback so I wanted to cover my bases (the parameters should now suffice, lwIP was able to do it with these three parameters too ;-))