### PR TITLE
drivers: Optimized periph PWM interfaces [adopted]

### DIFF
--- a/boards/msba2/include/periph_conf.h
+++ b/boards/msba2/include/periph_conf.h
@@ -44,7 +44,7 @@ extern "C" {
 /**
  * @brief PWM device and pinout configuration
  */
-#define PWM_NUMOF           (1)
+#define PWM_NUMOF           (1U)
 #define PWM_0_EN            (1)
 
 /* PWM_0 device configuration */

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -120,7 +120,6 @@ static const uart_conf_t uart_config[] = {
  * @name PWM configuration
  * @{
  */
-#define PWM_NUMOF           (PWM_0_EN + PWM_1_EN)
 #define PWM_0_EN            1
 #define PWM_1_EN            1
 #define PWM_MAX_CHANNELS    2
@@ -129,7 +128,6 @@ static const uart_conf_t uart_config[] = {
 #define PWM_1_CHANNELS      PWM_MAX_CHANNELS
 
 /* PWM device configuration */
-#if PWM_NUMOF
 static const pwm_conf_t pwm_config[] = {
 #if PWM_0_EN
     {TCC1, {
@@ -146,7 +144,9 @@ static const pwm_conf_t pwm_config[] = {
     }},
 #endif
 };
-#endif
+
+/* number of devices that are actually defined */
+#define PWM_NUMOF           (2U)
 /** @} */
 
 /**

--- a/boards/stm32f3discovery/include/periph_conf.h
+++ b/boards/stm32f3discovery/include/periph_conf.h
@@ -110,7 +110,7 @@ extern "C" {
  * @brief PWM configuration
  * @{
  */
-#define PWM_NUMOF           (1U)
+#define PWM_NUMOF           (2U)
 #define PWM_0_EN            1
 #define PWM_1_EN            1
 

--- a/cpu/kinetis_common/periph/pwm.c
+++ b/cpu/kinetis_common/periph/pwm.c
@@ -31,9 +31,6 @@
 #include "periph/pwm.h"
 #include "periph_conf.h"
 
-/* ignore file in case no PWM devices are defined */
-#if PWM_NUMOF
-
 /* FTM channel look up tables */
 #if PWM_0_EN
 static const uint8_t ftm0chan[] = {
@@ -92,7 +89,7 @@ static const uint8_t ftm1chan[] = {
 };
 #endif
 
-int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int resolution)
+uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
 {
     FTM_Type *ftm;
     int channels = 0;
@@ -120,7 +117,7 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
 #endif
 
         default:
-            return -1;
+            return 0;
     }
 
     switch (mode) {
@@ -130,25 +127,25 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
             break;
 
         default:
-            return -1;
+            return 0;
     }
 
-    if (resolution > (PWM_MAX_VALUE + 1) || (resolution * frequency) > pwm_clk) {
-        return -2;
+    if ((unsigned int)res > (PWM_MAX_VALUE + 1) || (res * freq) > pwm_clk) {
+        return 0;
     }
 
     /* Try to find a good prescaler value */
     /* The prescaler divides the module clock by a power of two, between 2^0 and 2^7 */
     uint8_t prescaler = 0;
     /* (resolution * frequency) is the number of timer ticks per second */
-    while ((pwm_clk >> prescaler) > (resolution * frequency)) {
+    while ((pwm_clk >> prescaler) > (res * freq)) {
         ++prescaler;
         if (prescaler > 7) {
             /* Module clock is too fast to reach the requested frequency using the
              * hardware supported prescaler values */
             /* Note: The frequency might be reachable if the requested resolution
              * is increased. */
-            return -2;
+            return 0;
         }
     }
     /* The chosen prescaler yields a timer frequency which is the
@@ -220,7 +217,7 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
 #endif
 
         default:
-            return -1;
+            return 0;
     }
 
     /* disable write protect for changing settings */
@@ -238,7 +235,7 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
 
     /* set prescale and mod registers to matching values for resolution and frequency */
     ftm->SC = FTM_SC_PS(prescaler);
-    ftm->MOD = resolution - 1;
+    ftm->MOD = res - 1;
 
     /* set PWM mode */
     uint32_t mode_mask = 0;
@@ -268,10 +265,26 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
     pwm_start(dev);
 
     /* Return actual frequency */
-    return (pwm_clk / (1 << prescaler)) / resolution;
+    return (pwm_clk / (1 << prescaler)) / res;
 }
 
-int pwm_set(pwm_t dev, int channel, unsigned int value)
+uint8_t pwm_channels(pwm_t dev)
+{
+    switch (dev) {
+#if PWM_0_EN
+        case PWM_0:
+            return PWM_0_CHANNELS;
+#endif
+#if PWM_1_EN
+        case PWM_1:
+            return PWM_1_CHANNELS;
+#endif
+        default:
+            return 0;
+    }
+}
+
+void pwm_set(pwm_t dev, uint8_t channel, uint16_t value)
 {
     FTM_Type *ftm;
     const uint8_t *ftmchan = NULL;
@@ -281,7 +294,7 @@ int pwm_set(pwm_t dev, int channel, unsigned int value)
 
         case PWM_0:
             if (channel > PWM_0_CHANNELS) {
-                return -1;
+                return;
             }
             ftm = PWM_0_DEV;
             ftmchan = &ftm0chan[0];
@@ -291,7 +304,7 @@ int pwm_set(pwm_t dev, int channel, unsigned int value)
 
         case PWM_1:
             if (channel > PWM_1_CHANNELS) {
-                return -1;
+                return;
             }
             ftm = PWM_1_DEV;
             ftmchan = &ftm1chan[0];
@@ -299,7 +312,7 @@ int pwm_set(pwm_t dev, int channel, unsigned int value)
 #endif
 
         default:
-            return -1;
+            return;
     }
 
     /* clamp value to maximum possible value */
@@ -312,8 +325,6 @@ int pwm_set(pwm_t dev, int channel, unsigned int value)
      * this function. */
     /* cppcheck-suppress nullPointer */
     ftm->CONTROLS[ftmchan[channel]].CnV = value;
-
-    return 0;
 }
 
 void pwm_start(pwm_t dev)
@@ -387,5 +398,3 @@ void pwm_poweroff(pwm_t dev)
 #endif
     }
 }
-
-#endif /* PWM_NUMOF */

--- a/cpu/lpc2387/periph/pwm.c
+++ b/cpu/lpc2387/periph/pwm.c
@@ -20,18 +20,21 @@
 
 #include "bitarithm.h"
 #include "lpc2387.h"
-#include "periph/pwm.h"
 #include "periph_conf.h"
 
 /* guard file in case no PWM device is defined */
-#if PWM_NUMOF
+#if (PWM_0_EN || PWM_1_EN)
+
+/* pull the PWM header inside the guards for now. Guards will be removed on
+ * adapting this driver implementation... */
+#include "periph/pwm.h"
 
 /**
  * @note The PWM is always initialized with left-aligned mode.
  *
  * TODO: add center and right aligned modes
  */
-int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int resolution)
+uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
 {
     (void) mode; /* unused */
 
@@ -57,10 +60,10 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
             PWM1TCR = BIT1;
 
             /* set prescaler */
-            PWM1PR = (CLOCK_CORECLOCK / (frequency * resolution)) - 1;
+            PWM1PR = (CLOCK_CORECLOCK / (freq * res)) - 1;
 
             /* set match register */
-            PWM1MR0 = resolution;
+            PWM1MR0 = res;
             PWM_0_CH0_MR = 0;
             PWM_0_CH1_MR = 0;
             PWM_0_CH2_MR = 0;
@@ -78,12 +81,22 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
             PWM1LER = BIT0 | (1 << PWM_0_CH0) | (1 << PWM_0_CH1) | (1 << PWM_0_CH2);
             break;
 #endif
+        default:
+            return 0;
     }
 
-    return frequency;
+    return freq;
 }
 
-int pwm_set(pwm_t dev, int channel, unsigned int value)
+uint8_t pwm_channels(pwm_t dev)
+{
+    if (dev == PWM_0) {
+        return PWM_0_CHANNELS;
+    }
+    return 0;
+}
+
+void pwm_set(pwm_t dev, uint8_t channel, uint16_t value)
 {
     switch (dev) {
 #if PWM_0_EN
@@ -102,14 +115,12 @@ int pwm_set(pwm_t dev, int channel, unsigned int value)
                     PWM1LER |= (1 << PWM_0_CH2);
                     break;
                 default:
-                    return -2;
+                    return;
                     break;
             }
             break;
 #endif
     }
-
-    return 0;
 }
 
 void pwm_start(pwm_t dev)
@@ -156,4 +167,4 @@ void pwm_poweroff(pwm_t dev)
     }
 }
 
-#endif /* PWM_NUMOF */
+#endif /* (PWM_0_EN || PWM_1_EN) */

--- a/cpu/sam3/periph/pwm.c
+++ b/cpu/sam3/periph/pwm.c
@@ -19,37 +19,25 @@
  */
 #include <stdint.h>
 #include "board.h"
+#include "periph_conf.h"
+
+/* guard file in case no PWM device is defined */
+#if (PWM_0_EN || PWM_1_EN)
+
+/* pull the PWM header inside the guards for now. Guards will be removed on
+ * adapting this driver implementation... */
 #include "periph/pwm.h"
 
-/*
- * guard file in case no PWM device is defined,
- */
-#if PWM_NUMOF && PWM_0_EN
-
-#define ERR_INIT_MODE           (-1)
-#define ERR_INIT_BWTH           (-2)
-#define ERR_SET_CHAN            (-1)
 #define MCK_DIV_LB_MAX          (10U)
 
-int pwm_init(pwm_t dev, pwm_mode_t mode,
-             unsigned int frequency,
-             unsigned int resolution)
+uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
 {
-
-    int32_t retval = ERR_INIT_MODE;    /* Worst/First case */
     uint32_t pwm_clk = 0;              /* Desired/real pwm_clock */
     uint32_t diva = 1;                 /* Candidate for 8bit divider */
     uint32_t prea = 0;                 /* Candidate for clock select */
 
-    switch (dev) {
-#if PWM_0_EN
-
-        case PWM_0:
-            break;
-#endif
-
-        default:
-            return ERR_INIT_MODE;
+    if (dev != PWM_0) {
+        return 0;
     }
 
     /*
@@ -63,18 +51,18 @@ int pwm_init(pwm_t dev, pwm_mode_t mode,
         case PWM_RIGHT:
         case PWM_CENTER:
         default:
-            return ERR_INIT_MODE;
+            return 0;
     }
 
     /* Should check if "|log_2 frequency|+|log_2 resolution| <= 32" */
-    pwm_clk = frequency * resolution;
+    pwm_clk = freq * res;
 
     /*
      * The pwm provides 11 prescaled clocks with (MCK/2^prea | prea=[0,10])
      * and a divider (diva) with a denominator range [1,255] in line.
      */
     if (CLOCK_CORECLOCK < pwm_clk) {  /* Have to cut down resulting frequency. */
-        frequency = CLOCK_CORECLOCK / resolution;
+        freq = CLOCK_CORECLOCK / res;
     }
     else {   /* Estimate prescaler and divider. */
         diva = CLOCK_CORECLOCK / pwm_clk;
@@ -84,10 +72,8 @@ int pwm_init(pwm_t dev, pwm_mode_t mode,
             diva = diva >> 1;
         }
 
-        frequency = CLOCK_CORECLOCK / ((resolution * diva) << prea);
+        freq = CLOCK_CORECLOCK / ((res * diva) << prea);
     }
-
-    retval = frequency;
 
     /* Activate PWM block by enabling it's clock. */
     PMC->PMC_PCER1 = PMC_PCER1_PID36;
@@ -108,25 +94,25 @@ int pwm_init(pwm_t dev, pwm_mode_t mode,
     /* Set clock source, resolution, duty-cycle and enable */
 #if PWM_0_CHANNELS > 0
     PWM_0_DEV_CH0->PWM_CMR = PWM_CMR_CPRE_CLKA;
-    PWM_0_DEV_CH0->PWM_CPRD = resolution - 1;
+    PWM_0_DEV_CH0->PWM_CPRD = res - 1;
     PWM_0_DEV_CH0->PWM_CDTY = 0;
     PWM_0_DEV->PWM_ENA = PWM_0_ENA_CH0;
 #endif
 #if PWM_0_CHANNELS > 1
     PWM_0_DEV_CH1->PWM_CMR = PWM_CMR_CPRE_CLKA;
-    PWM_0_DEV_CH1->PWM_CPRD = resolution - 1;
+    PWM_0_DEV_CH1->PWM_CPRD = res - 1;
     PWM_0_DEV_CH1->PWM_CDTY = 0;
     PWM_0_DEV->PWM_ENA = PWM_0_ENA_CH1;
 #endif
 #if PWM_0_CHANNELS > 2
     PWM_0_DEV_CH2->PWM_CMR = PWM_CMR_CPRE_CLKA;
-    PWM_0_DEV_CH2->PWM_CPRD = resolution - 1;
+    PWM_0_DEV_CH2->PWM_CPRD = res - 1;
     PWM_0_DEV_CH2->PWM_CDTY = 0;
     PWM_0_DEV->PWM_ENA = PWM_0_ENA_CH2;
 #endif
 #if PWM_0_CHANNELS > 3
     PWM_0_DEV_CH3->PWM_CMR = PWM_CMR_CPRE_CLKA;
-    PWM_0_DEV_CH3->PWM_CPRD = resolution - 1;
+    PWM_0_DEV_CH3->PWM_CPRD = res - 1;
     PWM_0_DEV_CH3->PWM_CDTY = 0;
     PWM_0_DEV->PWM_ENA = PWM_0_ENA_CH3;
 #endif
@@ -154,17 +140,24 @@ int pwm_init(pwm_t dev, pwm_mode_t mode,
     PWM_0_PORT_CH3->PIO_ABSR |= PWM_0_PIN_CH3;
 #endif
 
-    return retval;
+    return freq;
+}
+
+uint8_t pwm_channels(pwm_t dev)
+{
+    if (dev == 0) {
+        return PWM_0_CHANNELS;
+    }
+    return 0;
 }
 
 /*
  * Update duty-cycle in channel with value.
  * If value is larger than resolution set by pwm_init() it is cropped.
  */
-int pwm_set(pwm_t dev, int channel, unsigned int value)
+void pwm_set(pwm_t dev, uint8_t channel, uint16_t value)
 {
 
-    int retval = ERR_SET_CHAN;      /* Worst case */
     uint32_t period = 0;            /* Store pwm period */
     PwmCh_num *chan = (void *)0;    /* Addressed channel. */
 
@@ -176,7 +169,7 @@ int pwm_set(pwm_t dev, int channel, unsigned int value)
 #endif
 
         default:
-            return ERR_SET_CHAN;
+            return;
     }
 
 
@@ -207,7 +200,7 @@ int pwm_set(pwm_t dev, int channel, unsigned int value)
 #endif
 
         default:
-            retval = ERR_SET_CHAN;
+            return;
     }
 
     if (chan) {
@@ -220,11 +213,7 @@ int pwm_set(pwm_t dev, int channel, unsigned int value)
         else {   /* Value Out of range. Clip silent as required by interface. */
             chan->PWM_CDTYUPD = period;
         }
-
-        retval = 0;
     }
-
-    return retval;
 }
 
 /*
@@ -288,4 +277,4 @@ void pwm_poweroff(pwm_t dev)
     }
 }
 
-#endif /* PWM_NUMOF */
+#endif /* (PWM_0_EN || PWM_1_EN) */

--- a/cpu/stm32f3/periph/pwm.c
+++ b/cpu/stm32f3/periph/pwm.c
@@ -22,13 +22,16 @@
 #include <string.h>
 
 #include "cpu.h"
-#include "periph/pwm.h"
 #include "periph_conf.h"
 
-/* ignore file in case no PWM devices are defined */
-#if PWM_0_EN || PWM_1_EN
+/* guard file in case no PWM device is defined */
+#if (PWM_0_EN || PWM_1_EN)
 
-int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int resolution)
+/* pull the PWM header inside the guards for now. Guards will be removed on
+ * adapting this driver implementation... */
+#include "periph/pwm.h"
+
+uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
 {
     TIM_TypeDef *tim = NULL;
     GPIO_TypeDef *port = NULL;
@@ -70,7 +73,7 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
 #endif
         default:
             pwm_poweroff(dev);
-            return -1;
+            return 0;
     }
 
     /* setup pins: alternate function */
@@ -94,12 +97,12 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
     tim->CCMR2 = 0;
 
     /* set prescale and auto-reload registers to matching values for resolution and frequency */
-    if ((resolution > 0xffff) || ((resolution * frequency) > pwm_clk)) {
-        return -2;
+    if ((res > 0xffff) || ((res * freq) > pwm_clk)) {
+        return 0;
     }
-    tim->PSC = (pwm_clk / (resolution * frequency)) - 1;
-    tim->ARR = resolution - 1;
-    frequency = (pwm_clk / (resolution * (tim->PSC + 1)));
+    tim->PSC = (pwm_clk / (res * freq)) - 1;
+    tim->ARR = res - 1;
+    freq = (pwm_clk / (res * (tim->PSC + 1)));
 
     /* set PWM mode */
     switch (mode) {
@@ -126,10 +129,26 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
     /* enable PWM generation */
     pwm_start(dev);
 
-    return frequency;
+    return freq;
 }
 
-int pwm_set(pwm_t dev, int channel, unsigned int value)
+uint8_t pwm_channels(pwm_t dev)
+{
+    switch (dev) {
+#if PWM_0_EN
+        case PWM_0:
+            return PWM_0_CHANNELS;
+#endif
+#if PWM_1_EN
+        case PWM_1:
+            return PWM_1_CHANNELS;
+#endif
+        default:
+            return 0;
+    }
+}
+
+void pwm_set(pwm_t dev, uint8_t channel, uint16_t value)
 {
     TIM_TypeDef *tim = NULL;
 
@@ -145,14 +164,7 @@ int pwm_set(pwm_t dev, int channel, unsigned int value)
             break;
 #endif
         default:
-            return -1;
-    }
-
-    /* norm value to maximum possible value
-     * Caution! A duty cycle exceeding the period length can lead to unexpected
-     * behaviour on other MCUs. */
-    if (value > 0xffff) {
-        value = 0xffff;
+            return;
     }
 
     switch (channel) {
@@ -169,10 +181,8 @@ int pwm_set(pwm_t dev, int channel, unsigned int value)
             tim->CCR4 = value;
             break;
         default:
-            return -2;
+            return;
     }
-
-    return 0;
 }
 
 void pwm_start(pwm_t dev)
@@ -239,4 +249,4 @@ void pwm_poweroff(pwm_t dev)
     }
 }
 
-#endif /* PWM_0_EN || PWM_1_EN */
+#endif /* (PWM_0_EN || PWM_1_EN) */

--- a/drivers/include/periph/dev_enums.h
+++ b/drivers/include/periph/dev_enums.h
@@ -198,6 +198,25 @@ enum {
     UART_UNDEFINED          /**< Deprecated symbol, use UART_UNDEF instead */
 };
 
+/**
+ * @brief   Legacy definitions of PWM devices
+ */
+enum {
+#if PWM_0_EN
+    PWM_0,              /*< 1st PWM device */
+#endif
+#if PWM_1_EN
+    PWM_1,              /*< 2nd PWM device */
+#endif
+#if PWM_2_EN
+    PWM_2,              /*< 3rd PWM device */
+#endif
+#if PWM_3_EN
+    PWM_3,              /*< 4th PWM device */
+#endif
+    PWM_UNDEFINED       /**< Deprecated symbol, use PWM_UNDEF instead */
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/periph/pwm.h
+++ b/drivers/include/periph/pwm.h
@@ -1,9 +1,9 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014-2015 Freie Universität Berlin
  *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
  */
 
 /**
@@ -18,124 +18,152 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PWM_H
-#define PWM_H
+#ifndef PERIPH_PWM_H
+#define PERIPH_PWM_H
 
+#include <stdint.h>
+
+#include "periph_cpu.h"
 #include "periph_conf.h"
+/* TODO: remove once all platforms are ported to this interface */
+#include "periph/dev_enums.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* ignore file in case no PWM devices are defined */
-#if PWM_NUMOF
+/**
+ * @brief   Make sure the number of available PWM devices is defined
+ */
+#ifndef PWM_NUMOF
+#error "PWM_NUMOF undefined for the target platform"
+#endif
 
 /**
- * @brief Definition of available PWM devices
- *
- * To this point a maximum of four PWM device is available.
+ * @brief   Default PWM access macro
+ * @{
  */
-typedef enum {
-#if PWM_0_EN
-    PWM_0,              /*< 1st PWM device */
+#ifndef PWM_DEV
+#define PWM_DEV(x)          (x)
 #endif
-#if PWM_1_EN
-    PWM_1,              /*< 2nd PWM device */
-#endif
-#if PWM_2_EN
-    PWM_2,              /*< 3rd PWM device */
-#endif
-#if PWM_3_EN
-    PWM_3,              /*< 4th PWM device */
-#endif
-} pwm_t;
+/** @} */
 
 /**
- * @brief Definition of available PWM modes
+ * @brief  Default PWM undefined value
+ * @{
  */
+#ifndef PWM_UNDEF
+#define PWM_UNDEF           (-1)
+#endif
+/** @} */
+
+/**
+ * @brief   Default PWM type definition
+ * @{
+ */
+#ifndef HAVE_PWM_T
+typedef unsigned int pwm_t;
+#endif
+/** @} */
+
+/**
+ * @brief   Default PWM mode definition
+ * @{
+ */
+#ifndef HAVE_PWM_MODE_T
 typedef enum {
     PWM_LEFT,           /*< use left aligned PWM */
     PWM_RIGHT,          /*< use right aligned PWM */
     PWM_CENTER          /*< use center aligned PWM */
 } pwm_mode_t;
+#endif
+/** @} */
 
 /**
- * @brief Initialize a PWM device
+ * @brief   Initialize a PWM device
  *
- * The PWM module is based on virtual PWM devices, which can have one or more channels.
- * The PWM devices can be configured to run with a given frequency and resolution, which
- * are always identical for the complete device, hence for every channel on a device.
+ * The PWM module is based on virtual PWM devices, which can have one or more
+ * channels. The PWM devices can be configured to run with a given frequency and
+ * resolution, which are always identical for the complete device, hence for
+ * every channel on a device.
  *
- * The desired frequency and resolution may not be possible on a given device when chosen
- * too large. In this case the PWM driver will always keep the resolution and decrease the
- * frequency if needed. To verify the correct settings compare the returned value which
- * is the actually set frequency.
+ * The desired frequency and resolution may not be possible on a given device
+ * when chosen too large. In this case the PWM driver will always keep the
+ * resolution and decrease the frequency if needed. To verify the correct
+ * settings compare the returned value which is the actually set frequency.
  *
- * @param[in] dev           PWM channel to initialize
+ * @param[in] dev           PWM device to initialize
  * @param[in] mode          PWM mode, left, right or center aligned
- * @param[in] frequency     the PWM frequency in Hz
- * @param[in] resolution    the PWM resolution
+ * @param[in] freq          PWM frequency in Hz
+ * @param[in] res           PWM resolution
  *
- * @return                  Actual PWM frequency on success
- * @return                  -1 on mode not applicable
- * @return                  -2 on frequency and resolution not applicable
+ * @return                  actual PWM frequency on success
+ * @return                  0 on error
  */
-int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int resolution);
+uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res);
 
 /**
- * @brief Set the duty-cycle for a given channel of the given PWM device
+ * @brief   Get the number of available channels
  *
- * The duty-cycle is set in relation to the chosen resolution of the given device. If
- * value > resolution, value is set to resolution.
+ * @param[in] dev           PWM device
+ *
+ * @return                  Number of channels available for the given device
+ */
+uint8_t pwm_channels(pwm_t dev);
+
+/**
+ * @brief   Set the duty-cycle for a given channel of the given PWM device
+ *
+ * The duty-cycle is set in relation to the chosen resolution of the given
+ * device. If value > resolution, value is set to resolution.
  *
  * @param[in] dev           the PWM device to set
  * @param[in] channel       the channel of the given device to set
  * @param[in] value         the desired duty-cycle to set
- *
- * @return                  0 on success
- * @return                  -1 on invalid channel
  */
-int pwm_set(pwm_t dev, int channel, unsigned int value);
+void pwm_set(pwm_t dev, uint8_t channel, uint16_t value);
 
 /**
- * @brief Start PWM generation on the given device
+ * @brief   Start PWM generation on the given device
  *
  * @param[in] dev           device to start
  */
 void pwm_start(pwm_t dev);
 
 /**
- * @brief Stop PWM generation on the given device
+ * @brief   Stop PWM generation on the given device
  *
  * @param[in] dev           device to stop
  */
 void pwm_stop(pwm_t dev);
 
 /**
- * @brief Power on the PWM device
+ * @brief   Power on the PWM device
  *
- * The PWM deice is powered on. It is dependent on the implementing platform,
- * if the previously set configuration is still available after power on.
+ * When the device is powered on the first time, not configuration is set. If
+ * the device is powered back on, after having been initialized and powered off
+ * before, the PWM device will continue its operation with the previously set
+ * configuration. So there is no need in re-initializing then.
  *
  * @param[in] dev           device to power on
  */
 void pwm_poweron(pwm_t dev);
 
 /**
- * @brief Power off the given PWM device
+ * @brief   Power off the given PWM device
  *
- * The given PWM is completely powered off. On most platform this means, that
- * the clock for the PWM device is disabled.
+ * This function will power off the given PWM device, which on most platforms
+ * means that it will be disabled using clock gating. The implementation must
+ * make sure, that any previously configuration will hold when the device is
+ * being powered back on.
  *
  * @param[in] dev           device to power off
  */
 void pwm_poweroff(pwm_t dev);
 
-#endif /* PWM_NUMOF */
-
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* PWM_H */
+#endif /* PERIPH_PWM_H */
 /** @} */

--- a/drivers/include/servo.h
+++ b/drivers/include/servo.h
@@ -82,12 +82,8 @@ int servo_init(servo_t *dev, pwm_t pwm, int pwm_channel, unsigned int min, unsig
  *
  * @param[in] dev           the servo to set
  * @param[in] pos           the position to set the servo in us
- *
- * @return                  0 on success
- * @return                  -1 on invalid configured channel
- * @return                  -2 on invalid position
  */
-int servo_set(servo_t *dev, unsigned int pos);
+void servo_set(servo_t *dev, unsigned int pos);
 
 #ifdef __cplusplus
 }

--- a/drivers/servo/servo.c
+++ b/drivers/servo/servo.c
@@ -88,7 +88,7 @@ int servo_init(servo_t *dev, pwm_t pwm, int pwm_channel, unsigned int min, unsig
     return 0;
 }
 
-int servo_set(servo_t *dev, unsigned int pos)
+void servo_set(servo_t *dev, unsigned int pos)
 {
     unsigned int raw_value;
     if (pos > dev->max) {
@@ -103,5 +103,5 @@ int servo_set(servo_t *dev, unsigned int pos)
 
     DEBUG("servo_set: pos %d -> raw %d\n", pos, raw_value);
 
-    return pwm_set(dev->device, dev->channel, raw_value);
+    pwm_set(dev->device, dev->channel, raw_value);
 }

--- a/tests/periph_pwm/main.c
+++ b/tests/periph_pwm/main.c
@@ -1,9 +1,9 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014-2015 Freie Universität Berlin
  *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
  */
 
 /**
@@ -13,10 +13,11 @@
  * @file
  * @brief       Test for low-level PWM drivers
  *
- * This test initializes the given PWM device to run at 1KHz with a 1000 step resolution.
+ * This test initializes the given PWM device to run at 1KHz with a 1000 step
+ * resolution.
  *
- * The PWM is then continuously oscillating it's duty cycle between 0% to 100% every 1s on
- * every channel.
+ * The PWM is then continuously oscillating it's duty cycle between 0% to 100%
+ * every 1s on every channel.
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
@@ -25,42 +26,44 @@
 
 #include <stdio.h>
 
-#include "cpu.h"
-#include "board.h"
 #include "xtimer.h"
 #include "periph/pwm.h"
 
-#define WAIT        (10000)
+#define INTERVAL    (10000U)
 #define STEP        (10)
 
-#define DEV         PWM_0
-#define CHANNELS    PWM_0_CHANNELS
 #define MODE        PWM_LEFT
-
 #define FREQU       (1000U)
 #define STEPS       (1000U)
 
 
 int main(void)
 {
-    int res;
     int state = 0;
     int step = STEP;
+    uint32_t last_wakeup = xtimer_now();
 
     puts("\nRIOT PWM test");
-    puts("Connect an LED or scope to PWM pins to see something");
+    puts("Connect an LED or scope to PWM pins to see something\n");
 
-    res = pwm_init(DEV, MODE, FREQU, STEPS);
-    if (res < 0) {
-        puts("Errors while initializing PWM");
-        return -1;
+    printf("Available PWM devices: %i\n", PWM_NUMOF);
+    for (int i = 0; i < PWM_NUMOF; i++) {
+        uint32_t real_f = pwm_init(PWM_DEV(i), MODE, FREQU, STEPS);
+        if (real_f == 0) {
+            printf("Error initializing PWM_%i\n", i);
+            return 1;
+        }
+        else {
+            printf("Initialized PWM_%i @ %" PRIu32 "Hz\n", i, real_f);
+        }
     }
-    puts("PWM initialized.");
-    printf("requested: %d Hz, got %d Hz\n", FREQU, res);
 
+    puts("\nLetting the PWM pins oscillate now...");
     while (1) {
-        for (int i = 0; i < CHANNELS; i++) {
-            pwm_set(DEV, i, state);
+        for (int i = 0; i < PWM_NUMOF; i++) {
+            for (uint8_t chan = 0; chan < pwm_channels(PWM_DEV(i)); chan++) {
+                pwm_set(PWM_DEV(i), chan, state);
+            }
         }
 
         state += step;
@@ -68,7 +71,7 @@ int main(void)
             step = -step;
         }
 
-        xtimer_usleep(WAIT);
+        xtimer_usleep_until(&last_wakeup, INTERVAL);
     }
 
     return 0;


### PR DESCRIPTION
This is @haukepetersen's #3644, rebased on latest master, squashed and additionally updated the servo API to return void on servo_set in order to match the API change for pwm_set.

There was a merge conflict in the STM32F4 driver stemming from #4454. The change in #4454 was copied with only the change rename the `frequency` variable `freq`