### PR TITLE
sc_random: use a default seed if no xtimer is present

### DIFF
--- a/sys/shell/commands/sc_random.c
+++ b/sys/shell/commands/sc_random.c
@@ -40,7 +40,9 @@ int _random_init(int argc, char **argv)
         printf("PRNG initialized to current time: %d\n", initval);
 #else
         (void)initval;
-        printf("xtimer module not compiled in, can't initialize by time.\n");
+        puts("xtimer module not compiled in, can't initialize by time.\n"
+             "Please provide a seed.\n");
+        return 1;
 #endif
     }
     else {


### PR DESCRIPTION
Use a default seed if no `xtimer` is present and no seed is passed to `random_init`

fixes #4639