### PR TITLE
gitignore: Add .clang_complete and YouCompleteMe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ pkg/wakaama/wakaama
 
 # clang-complete command line argument lists (Vim: clang-complete, Atom: linter-clang, autocomplete-clang addons)
 .clang_complete
+# YouCompleteMe (https://github.com/Valloric/YouCompleteMe)
+.ycm_extra_conf.py
+.ycm_extra_conf.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ pkg/wakaama/wakaama
 
 # Vagrant
 .vagrant
+
+# clang-complete command line argument lists (Vim: clang-complete, Atom: linter-clang, autocomplete-clang addons)
+.clang_complete


### PR DESCRIPTION
.clang_complete files can be used to pass the command line arguments needed to compile the sources in order to get the proper code completion using Clang with plugins for popular editors.

Vim: https://vtluug.org/wiki/Clang_Complete
Atom: 
 - Code completion: https://atom.io/packages/autocomplete-clang
 - Code linter: https://github.com/AtomLinter/linter-clang
