### PR TITLE
Clang: Add support for C++

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -66,7 +66,7 @@ $(OBJCXX): $(BINDIR)$(MODULE)/%.o: %.cpp
 	$(AD)$(CCACHE) $(CXX) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
-		$(CXXFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
+		$(CXXFLAGS) $(INCLUDES) $(CXXINCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
 $(ASMOBJ): $(BINDIR)$(MODULE)/%.o: %.s
 	$(AD)$(AS) $(ASFLAGS) -o $@ $(abspath $<)

--- a/cpu/Makefile.include.llvm
+++ b/cpu/Makefile.include.llvm
@@ -17,7 +17,39 @@ export DBG         = $(GDBPREFIX)gdb
 # LLVM lacks a binutils strip tool as well...
 #export STRIP      = $(LLVMPREFIX)strip
 
+# Clang on Linux uses GCC's C++ headers and libstdc++ (installed with GCC)
+# Ubuntu and Debian use /etc/alternatives/gcc-$(TARGET_ARCH)-include/c++/$(GCC_VERSION)
+# Arch uses /usr/$(TARGET_ARCH)/include/c++/$(GCC_VERSION)
+# Gentoo uses /usr/lib/gcc/$(TARGET_ARCH)/$(GCC_VERSION)/include/g++-v5
+GCC_CXX_INCLUDE_PATTERNS ?= \
+  /etc/alternatives/gcc-$(TARGET_ARCH)-include/c++/*/ \
+  /usr/$(TARGET_ARCH)/include/c++/*/ \
+  /usr/lib/gcc/$(TARGET_ARCH)/*/include/g++-v5 \
+  #
+
+# Try to find the proper multilib directory using GCC, this may fail if a cross-
+# GCC is not installed.
+ifeq ($(GCC_MULTI_DIR),)
+  GCC_MULTI_DIR := $(shell $(PREFIX)gcc -print-multi-directory $(CFLAGS) 2>/dev/null)
+endif
+
 # Tell clang to cross compile
 export CFLAGS     += -target $(TARGET_ARCH)
 export CXXFLAGS   += -target $(TARGET_ARCH)
 export LINKFLAGS  += -target $(TARGET_ARCH)
+
+# Use the wildcard Makefile function to search for existing directories matching
+# the patterns above. We use the -isystem gcc/clang argument to add the include
+# directories as system include directories, which means they will not be
+# searched until after all the project specific include directories (-I/path)
+# We sort the list of found directories and take the last one, it will likely be
+# the most recent GCC version. This avoids using old headers left over from
+# previous tool chain installations.
+GCC_CXX_INCLUDES ?= \
+    $(addprefix \
+        -isystem $(lastword $(sort \
+            $(foreach pat, $(GCC_CXX_INCLUDE_PATTERNS), $(wildcard $(pat))))), \
+        /. /$(TARGET_ARCH)/$(GCC_MULTI_DIR) /backward \
+    )
+
+export INCLUDES += $(GCC_CXX_INCLUDES)

--- a/cpu/Makefile.include.llvm
+++ b/cpu/Makefile.include.llvm
@@ -1,5 +1,12 @@
 export GDBPREFIX  ?= $(PREFIX)
 export LLVMPREFIX ?= llvm-
+# Apple XCode doesn't prefix its tools with llvm-, but manually installed LLVM
+# on OSX might have the llvm- prefix, we can't simply test against uname -s.
+# Test if llvm-ar exists
+ifeq (,$(shell command -v $(LLVMPREFIX)ar 2>/dev/null))
+# fall back to system tools
+export LLVMPREFIX :=
+endif
 export CC          = clang
 export CXX         = clang++
 export LINK        = $(CC)
@@ -52,4 +59,31 @@ GCC_CXX_INCLUDES ?= \
         /. /$(TARGET_ARCH)/$(GCC_MULTI_DIR) /backward \
     )
 
-export INCLUDES += $(GCC_CXX_INCLUDES)
+# If nothing was found we will try to fall back to searching for a cross-gcc in
+# the current PATH and use a relative path for the includes
+ifeq (,$(GCC_CXX_INCLUDES))
+  GCC_CXX_INCLUDES := $(addprefix -isystem ,$(wildcard $(dir $(shell which $(PREFIX)gcc))../$(TARGET_TRIPLE)/include))
+endif
+
+# Pass the includes to the C++ compilation rule in Makefile.base
+export CXXINCLUDES += $(GCC_CXX_INCLUDES)
+
+# Some C headers (e.g. limits.h) are located with the GCC libraries
+GCC_C_INCLUDE_PATTERNS ?= \
+  /usr/lib/gcc/$(TARGET_TRIPLE)/*/ \
+  #
+
+GCC_C_INCLUDES ?= \
+    $(addprefix -isystem ,$(wildcard $(addprefix \
+        $(lastword $(sort \
+            $(foreach pat, $(GCC_C_INCLUDE_PATTERNS), $(wildcard $(pat))))), \
+        include include-fixed) \
+    ))
+
+# If nothing was found we will try to fall back to searching for the libgcc used
+# by an installed cross-GCC and use its headers.
+ifeq (,$(GCC_C_INCLUDES))
+  GCC_C_INCLUDES := $(addprefix -isystem ,$(wildcard $(addprefix $(dir $(shell $(PREFIX)gcc -print-libgcc-file-name)), include include-fixed)))
+endif
+
+export INCLUDES += $(GCC_C_INCLUDES)

--- a/cpu/cc2538/periph/spi.c
+++ b/cpu/cc2538/periph/spi.c
@@ -55,7 +55,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
 {
     cc2538_ssi_t* ssi = spi_config[dev].dev;
 
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
 
@@ -160,7 +160,7 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
 
 int spi_conf_pins(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
 
@@ -197,7 +197,7 @@ int spi_conf_pins(spi_t dev)
 
 int spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_lock(&locks[dev]);
@@ -206,7 +206,7 @@ int spi_acquire(spi_t dev)
 
 int spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_unlock(&locks[dev]);
@@ -251,7 +251,7 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
     cc2538_ssi_t* ssi = spi_config[dev].dev;
     typeof(length) tx_n = 0, rx_n = 0;
 
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
 

--- a/cpu/cc26x0/periph/gpio.c
+++ b/cpu/cc26x0/periph/gpio.c
@@ -34,7 +34,7 @@ static gpio_isr_ctx_t gpio_chan[GPIO_ISR_CHAN_NUMOF];
 
 int gpio_init(gpio_t pin, gpio_mode_t mode)
 {
-    if ((pin < 0) || (pin > 31))
+    if ((unsigned int)pin > 31)
         return -1;
 
     /* enable GPIO clock */

--- a/cpu/cortexm_common/include/cmsis_gcc.h
+++ b/cpu/cortexm_common/include/cmsis_gcc.h
@@ -151,7 +151,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_xPSR(void)
  */
 __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, psp\n"  : "=r" (result) );
   return(result);
@@ -176,7 +176,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE void __set_PSP(uint32_t topOf
  */
 __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_MSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, msp\n" : "=r" (result) );
   return(result);

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -63,7 +63,7 @@ void cortexm_init(void);
  */
 static inline void cpu_print_last_instruction(void)
 {
-    register uint32_t *lr_ptr;
+    uint32_t *lr_ptr;
     __asm__ __volatile__("mov %0, lr" : "=r"(lr_ptr));
     printf("%p\n", (void*) lr_ptr);
 }

--- a/sys/cpp11-compat/include/riot/mutex.hpp
+++ b/sys/cpp11-compat/include/riot/mutex.hpp
@@ -44,7 +44,7 @@ class mutex {
  public:
   using native_handle_type = mutex_t*;
 
-  inline constexpr mutex() noexcept : m_mtx{0} {}
+  inline constexpr mutex() noexcept : m_mtx{{0}} {}
   ~mutex();
 
   void lock();


### PR DESCRIPTION
Added support for C++ standard headers by searching for the libstdc++ installation (part of cross GCC installation). Also included are fixes for a bunch of warnings that I found in master when building tests with Clang 3.7.
There are still some warnings left when building with Clang but most tests and examples compile cleanly on Mulle now.

I had to move the `include $(RIOTBOARD)/Makefile.include.$(TOOLCHAIN)` from the board cortexm_common makefile to the CPU cortexm_common makefile in order to get the right CFLAGS set when querying cross GCC for the multilib directory.

~~Q: Would it make sense to merge boards/Makefile.cortexm_common into cpu/Makefile.cortexm_common?~~ #4778 