### PR TITLE
netdev2: provide capability to pass up packet status information

### DIFF
--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -71,7 +71,7 @@ static void _sigio_child(netdev2_tap_t *dev);
 /* netdev2 interface */
 static int _init(netdev2_t *netdev);
 static int _send(netdev2_t *netdev, const struct iovec *vector, int n);
-static int _recv(netdev2_t *netdev, char* buf, int n);
+static int _recv(netdev2_t *netdev, char* buf, int n, void *info);
 
 static inline void _get_mac_addr(netdev2_t *netdev, uint8_t *dst)
 {
@@ -187,9 +187,10 @@ static inline bool _is_addr_multicast(uint8_t *addr)
     return (addr[0] & 0x01);
 }
 
-static int _recv(netdev2_t *netdev2, char *buf, int len)
+static int _recv(netdev2_t *netdev2, char *buf, int len, void *info)
 {
     netdev2_tap_t *dev = (netdev2_tap_t*)netdev2;
+    (void)info;
 
     if (!buf) {
         /* no way of figuring out packet size without racey buffering,

--- a/drivers/cc110x/cc110x-netdev2.c
+++ b/drivers/cc110x/cc110x-netdev2.c
@@ -47,11 +47,12 @@ static int _send(netdev2_t *dev, const struct iovec *vector, int count)
     return cc110x_send(&netdev2_cc110x->cc110x, cc110x_pkt);
 }
 
-static int _recv(netdev2_t *dev, char* buf, int len)
+static int _recv(netdev2_t *dev, char* buf, int len, void *info)
 {
     DEBUG("%s:%u\n", __func__, __LINE__);
 
     cc110x_t *cc110x = &((netdev2_cc110x_t*) dev)->cc110x;
+    netdev2_cc110x_rx_info_t *cc110x_info = info;
 
     cc110x_pkt_t *cc110x_pkt = &cc110x->pkt_buf.packet;
     if (cc110x_pkt->length > len) {
@@ -59,6 +60,8 @@ static int _recv(netdev2_t *dev, char* buf, int len)
     }
 
     memcpy(buf, (void*)cc110x_pkt, cc110x_pkt->length);
+    cc110x_info->rssi = cc110x->pkt_buf.rssi;
+    cc110x_info->lqi = cc110x->pkt_buf.lqi;
     return cc110x_pkt->length;
 }
 

--- a/drivers/cc110x/include/cc110x-netdev2.h
+++ b/drivers/cc110x/include/cc110x-netdev2.h
@@ -43,6 +43,10 @@ typedef struct netdev2_cc110x {
     cc110x_t cc110x;        /**< documentation here */
 } netdev2_cc110x_t;
 
+/**
+ * @brief   Received packet status information for cc110x radios
+ */
+typedef struct netdev2_radio_rx_info netdev2_cc110x_rx_info_t;
 
 /**
  * @brief netdev2 <-> cc110x glue code initialization function

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -243,13 +243,14 @@ static int nd_send(netdev2_t *netdev, const struct iovec *data, int count)
     return c;
 }
 
-static int nd_recv(netdev2_t *netdev, char *buf, int max_len)
+static int nd_recv(netdev2_t *netdev, char *buf, int max_len, void *info)
 {
     enc28j60_t *dev = (enc28j60_t *)netdev;
     uint8_t head[6];
     size_t size;
     uint16_t next;
 
+    (void)info;
     mutex_lock(&dev->devlock);
 
     /* set read pointer to RX read address */

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -60,7 +60,7 @@ static void _get_mac_addr(netdev2_t *dev, uint8_t* buf);
 
 /* netdev2 interface */
 static int _send(netdev2_t *netdev, const struct iovec *vector, int count);
-static int _recv(netdev2_t *netdev, char* buf, int len);
+static int _recv(netdev2_t *netdev, char* buf, int len, void *info);
 static int _init(netdev2_t *dev);
 static void _isr(netdev2_t *dev);
 int _get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len);
@@ -352,11 +352,12 @@ static void _get_mac_addr(netdev2_t *encdev, uint8_t* buf)
     unlock(dev);
 }
 
-static int _recv(netdev2_t *netdev, char* buf, int len)
+static int _recv(netdev2_t *netdev, char* buf, int len, void *info)
 {
     encx24j600_t * dev = (encx24j600_t *) netdev;
     encx24j600_frame_hdr_t hdr;
 
+    (void)info;
     lock(dev);
 
     /* read frame header */

--- a/drivers/include/net/netdev2.h
+++ b/drivers/include/net/netdev2.h
@@ -72,6 +72,16 @@ typedef enum {
 } netdev2_event_t;
 
 /**
+ * @brief   Received packet status information for most radios
+ *
+ * May be different for certain radios.
+ */
+struct netdev2_radio_rx_info {
+    uint8_t rssi;       /**< RSSI of a received packet */
+    uint8_t lqi;        /**< LQI of a received packet */
+};
+
+/**
  * @brief   Forward declaration for netdev2 struct
  */
 typedef struct netdev2 netdev2_t;
@@ -122,12 +132,15 @@ typedef struct netdev2_driver {
      * @param[in]   dev     network device descriptor
      * @param[out]  buf     buffer to write into or NULL
      * @param[in]   len     maximum nr. of bytes to read
+     * @param[out] info     status information for the received packet. Might
+     *                      be of different type for different netdev2 devices.
+     *                      May be NULL if not needed or applicable.
      *
      * @return <=0 on error
      * @return nr of bytes read if buf != NULL
      * @return packet size if buf == NULL
      */
-    int (*recv)(netdev2_t *dev, char* buf, int len);
+    int (*recv)(netdev2_t *dev, char *buf, int len, void *info);
 
     /**
      * @brief the driver's initialization function

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_eth.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_eth.c
@@ -32,7 +32,7 @@
 static gnrc_pktsnip_t *_recv(gnrc_netdev2_t *gnrc_netdev2)
 {
     netdev2_t *dev = gnrc_netdev2->dev;
-    int bytes_expected = dev->driver->recv(dev, NULL, 0);
+    int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
     gnrc_pktsnip_t *pkt = NULL;
 
     if (bytes_expected) {
@@ -45,7 +45,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netdev2_t *gnrc_netdev2)
             goto out;
         }
 
-        int nread = dev->driver->recv(dev, pkt->data, bytes_expected);
+        int nread = dev->driver->recv(dev, pkt->data, bytes_expected, NULL);
         if(nread <= 0) {
             DEBUG("_recv_ethernet_packet: read error.\n");
             goto safe_out;


### PR DESCRIPTION
This proposes an API change to pass up packet status information like RSSI or LQI to upper-layers. The CC11xx driver circumvents this problem this by (seemingly?) bypassing the netdev2 API altogether for GNRC and for my preliminary netdev2 port of IEEE 802.15.4 (#4645) I just appended this information to the packet, as most device drivers do anyway. With the last decision I'm not happy however and this PR tries to improve the overall situation.