### PR TITLE
schedstatistics: removed redundant dependency entry

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -23,10 +23,6 @@ ifneq (,$(filter gnrc_conn_udp,$(USEMODULE)))
   USEMODULE += gnrc_udp
 endif
 
-ifneq (,$(filter schedstatistics,$(USEMODULE)))
-  USEMODULE += xtimer
-endif
-
 ifneq (,$(filter gnrc_netif_default,$(USEMODULE)))
   USEMODULE += gnrc_netif
 endif


### PR DESCRIPTION
Just as the description says.
The redundant entry is in [`Makefile.dep:385`](https://github.com/BytesGalore/RIOT/blob/195a57e3c93321310997c3900d79800fc5652968/Makefile.dep#L385)