### PR TITLE
drivers/periph/uart: Add missing #include <stddef.h>

### DIFF
--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -44,6 +44,7 @@
 #ifndef PERIPH_UART_H
 #define PERIPH_UART_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "periph_cpu.h"


### PR DESCRIPTION
Required for size_t