### PR TITLE
drivers: optimize auto init for device drivers

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -74,6 +74,7 @@ endif
 
 ifneq (,$(filter srf02,$(USEMODULE)))
   USEMODULE += xtimer
+  FEATURES_REQUIRED = periph_i2c
 endif
 
 ifneq (,$(filter srf08,$(USEMODULE)))

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -61,3 +61,6 @@ endif
 ifneq (,$(filter bmp180,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/drivers/bmp180/include
 endif
+ifneq (,$(filter srf02,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/srf02/include
+endif

--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -87,6 +87,7 @@ enum {
     SAUL_SENSE_COLOR    = 0x88,     /**< sensor: (light) color */
     SAUL_SENSE_PRESS    = 0x89,     /**< sensor: pressure */
     SAUL_SENSE_ANALOG   = 0x8a,     /**< sensor: raw analog value */
+    SAUL_SENSE_DIST     = 0x8b,     /**< sensor: distance */
     SAUL_CLASS_ANY      = 0xff      /**< any device - wildcard */
     /* extend this list as needed... */
 };

--- a/drivers/include/srf02.h
+++ b/drivers/include/srf02.h
@@ -62,6 +62,35 @@ typedef enum {
 } srf02_mode_t;
 
 /**
+ * @brief   Device descriptor for SRF02 sensors
+ */
+typedef struct {
+    i2c_t i2c;              /**< I2C device the sensor is connected to */
+    uint8_t addr;           /**< I2C bus address of the sensor */
+} srf02_t;
+
+/**
+ * @brief   Configuration parameters for SRF02 devices
+ */
+typedef struct {
+    i2c_t i2c;              /**< I2C bus the device is connected to */
+    uint8_t addr;           /**< address on that bus */
+} srf02_params_t;
+
+/**
+ * @brief   SAUL driver interface
+ */
+#ifdef MODULE_SAUL
+extern const sauL_driver_t srf02_saul_driver;
+#endif
+
+/**
+ * @brief   Auto initialize all configured SRF02 devices using the
+ *          srf02_params.h file
+ */
+void srf02_auto_init(void);
+
+/**
  * @brief   Initialize the SRF02 ultrasonic sensor
  *
  * @param[in] dev           device descriptor of an SRF02 sensor
@@ -71,7 +100,7 @@ typedef enum {
  * @return                  0 on successful initialization
  * @return                  -1 on error
  */
-int srf02_init(srf02_t *dev, i2c_t i2c, uint8_t addr);
+int srf02_init(srf02_t *dev, const srf02_params_t *params);
 
 /**
  * @brief   Trigger a new measurement

--- a/drivers/saul/saul_str.c
+++ b/drivers/saul/saul_str.c
@@ -46,6 +46,7 @@ const char *saul_class_to_str(uint8_t class_id)
         case SAUL_SENSE_GYRO:   return "SENSE_GYRO";
         case SAUL_SENSE_COLOR:  return "SENSE_COLOR";
         case SAUL_SENSE_PRESS:  return "SENSE_PRESS";
+        case SAUL_SENSE_DIST:   return "SENSE_DIST";
         case SAUL_CLASS_ANY:    return "CLASS_ANY";
         default:                return "CLASS_UNKNOWN";
     }

--- a/drivers/srf02/include/srf02_params.h
+++ b/drivers/srf02/include/srf02_params.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   drivers_srf02
+ * @{
+ *
+ * @file
+ * @brief     Default configuration for SRF02 devices
+ *
+ * @author    Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef SRF02_PARAMS_H
+#define SRF02_PARAMS_H
+
+#include "board.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Default parameters for SRF02 devices
+ * @{
+ */
+#ifndef SRF02_PARAM_I2C
+#define SRF02_PARAM_I2C             (I2C_DEV(0))
+#endif
+#ifndef SRF02_PARAM_ADDR
+#define SRF02_PARAM_ADDR            (SRF02_DEFAULT_ADDR)
+#endif
+
+#define SRF02_PARAMS_DEFAULT        {.i2c = SRF02_PARAM_I2C, \
+                                     .addr = SRF02_PARAM_ADDR}
+/** @} */
+
+/**
+ * @brief   SRF02 configuration
+ */
+static const srf02_params_t srf02_params[] =
+{
+#ifdef SRF02_PARAMS_BOARD
+    SRF02_PARAMS_BOARD
+#else
+    SRF02_PARAMS_DEFAULT
+#endif
+};
+
+/**
+ * @brief   Get the number of configured SRF02 devices
+ */
+#define SRF02_NUMOF     (sizeof(srf02_params) / sizeof(srf02_params[0]))
+
+#ifdef MODULE_SAUL_REG
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+saul_reg_t srf02_saul_reg[] =
+{
+    {
+        .name = "srf02",
+        .driver = &srf02_saul_driver
+    }
+};
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SRF02_PARAMS_H */
+/** @} */

--- a/drivers/srf02/srf02.c
+++ b/drivers/srf02/srf02.c
@@ -68,6 +68,7 @@ int srf02_init(srf02_t *dev, i2c_t i2c, uint8_t addr)
     /* initialize i2c interface */
     if (i2c_init_master(dev->i2c, BUS_SPEED) < 0) {
         DEBUG("[srf02] error initializing I2C bus\n");
+        i2c_release(dev->i2c);
         return -1;
     }
     /* try to read the software revision (read the CMD reg) from the device */
@@ -75,6 +76,7 @@ int srf02_init(srf02_t *dev, i2c_t i2c, uint8_t addr)
     if (rev == 0 || rev == 255) {
         i2c_release(dev->i2c);
         DEBUG("[srf02] error reading the devices software revision\n");
+        i2c_release(dev->i2c);
         return -1;
     } else {
         DEBUG("[srf02] software revision: 0x%02x\n", rev);

--- a/drivers/srf02/srf02.c
+++ b/drivers/srf02/srf02.c
@@ -24,9 +24,11 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "log.h"
 #include "xtimer.h"
-#include "srf02.h"
 #include "periph/i2c.h"
+#include "srf02.h"
+#include "srf02_params.h"
 
 #define ENABLE_DEBUG        (0)
 #include "debug.h"
@@ -56,11 +58,30 @@
 #define CMD_ADDR_SEQ3       (0xa5)
 /** @} */
 
+/**
+ * @brief   Allocate memory for device descriptors
+ */
+srf02_t srf02_devs[SRF02_NUMOF];
 
-int srf02_init(srf02_t *dev, i2c_t i2c, uint8_t addr)
+
+void srf02_auto_init(void)
 {
-    dev->i2c = i2c;
-    dev->addr = (addr >> 1);    /* internally we right align the 7-bit addr */
+    for (int i = 0; i < SRF02_NUMOF; i++) {
+        if (srf02_init(&srf02_devs[i], &srf02_params[i]) < 0) {
+            LOG_ERROR("initialization of SRF02 device #%i failed", i);
+            return;
+        }
+#ifdef MODULE_SAUL_REG
+        srf02_saul_reg[i].dev = srf02_devs[i];
+        saul_reg_add(&srf02_saul_reg[i]);
+#endif
+    }
+}
+
+int srf02_init(srf02_t *dev, const srf02_params_t *params)
+{
+    dev->i2c  = params->i2c;
+    dev->addr = (params->addr >> 1);
     char rev;
 
     /* Acquire exclusive access to the bus. */
@@ -72,7 +93,7 @@ int srf02_init(srf02_t *dev, i2c_t i2c, uint8_t addr)
         return -1;
     }
     /* try to read the software revision (read the CMD reg) from the device */
-    i2c_read_reg(i2c, dev->addr, REG_CMD, &rev);
+    i2c_read_reg(dev->i2c, dev->addr, REG_CMD, &rev);
     if (rev == 0 || rev == 255) {
         i2c_release(dev->i2c);
         DEBUG("[srf02] error reading the devices software revision\n");

--- a/drivers/srf02/srf02_saul.c
+++ b/drivers/srf02/srf02_saul.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     driver_srf02
+ * @{
+ *
+ * @file
+ * @brief       SAUL interface for SRF02 devices
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "srf02.h"
+#include "saul.h"
+
+
+static int read(void *dev, phydat_t *data)
+{
+    srf02_t *d = (srf02_t *)dev;
+
+    data->val[0] = (int16_t)srf02_get_distance(d, SRF02_MODE_REAL_CM);
+    memset(&data->val[1], 0, 2 * sizeof(int16_t));
+    data->unit = UNIT_M;
+    data->scale = -2;
+    return 1;
+}
+
+const saul_driver_t srf02_saul_driver = {
+    .read = read,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_DIST
+};

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -150,7 +150,11 @@ void auto_init(void)
     extern void dht_auto_init(void);
     dht_auto_init();
 #endif
-
+#ifdef MODULE_SRF02
+    extern void srf02_auto_init(void);
+    DEBUG("Auto init SRF02 driver.\n");
+    srf02_auto_init();
+#endif
 
 /* initialize network devices */
 #ifdef MODULE_AUTO_INIT_GNRC_NETIF

--- a/tests/driver_srf02/Makefile
+++ b/tests/driver_srf02/Makefile
@@ -1,18 +1,12 @@
 APPLICATION = driver_srf02
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += xtimer
 USEMODULE += srf02
 USEMODULE += shell
 
-# set default device parameters in case they are undefined
-TEST_SRF02_I2C ?= I2C_0
-TEST_MODE      ?= SRF02_MODE_REAL_CM
-
-# export parameters
-CFLAGS += -DTEST_SRF02_I2C=$(TEST_SRF02_I2C)
-CFLAGS += -DTEST_MODE=$(TEST_MODE)
+# if you want non-default values for I2C and address, override them using the
+# CFLAGS environment variable like:
+# CFLAGS="-DSRF02_PARAM_I2C=I2C_DEV(x) -DSRF02_PARAM_ADDR=123"
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_srf02/main.c
+++ b/tests/driver_srf02/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014 Hamburg University of Applied Sciences
- *               2015 Freie Universität Berlin
+ *               2015-2016 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -37,14 +37,14 @@
 #endif
 
 #define SAMPLE_PERIOD       (100 * 1000U)
-
-static srf02_t dev;
+#define MODE                (SRF02_MODE_REAL_CM)
 
 static void sample(void)
 {
     uint16_t distance = srf02_get_distance(&dev, TEST_MODE);
     printf("distance = %3i cm\n", distance);
 }
+
 
 static int cmd_init(int argc, char **argv)
 {
@@ -79,6 +79,7 @@ static int cmd_sample(int argc, char **argv)
     while(1) {
         sample();
         xtimer_usleep_until(&wakeup, SAMPLE_PERIOD);
+
     }
 
     return 0;


### PR DESCRIPTION
I spend some more thoughts, how we could improve the auto-initialization for device drivers and came up with this proposal:
- each driver MUST supply a default `xxx_params.h` file (-> see srf02_params.h in this PR)
- each device driver MUST supply at least two init functions
```c
xxx_auto_init(void);
```
and
```c
xxx_init(xxx_t *dev, xxx_params_t *params);
```
- 

The `xxx_init` function can be used stand-alone if needed, while the `xxx_auto_init` function initializes all devices that are defined in the `xxx_params` file. 

Also the `xxx_auto_init` function can easily be expanded to integrate device abstractions as for example the SAUL registry (also done in this PR).

Open questions:
- do we see use cases, where we do not want to initialize devices using the`xxx_params` file but initialize them stand-alone of some sort
- in that case, how do we handle the allocation of device descriptors (in this proposal done in the drivers .c file)
- error handling for auto_init is harder to see, is printing a LOG_ERROR enough here?