### PR TITLE
drivers/dht: numerous improvements

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -22,6 +22,7 @@ endif
 
 ifneq (,$(filter dht,$(USEMODULE)))
     USEMODULE += xtimer
+    FEATURES_REQUIRED = periph_gpio
 endif
 
 ifneq (,$(filter enc28j60,$(USEMODULE)))

--- a/drivers/dht/include/dht_params.h
+++ b/drivers/dht/include/dht_params.h
@@ -35,9 +35,13 @@ extern "C" {
 #ifndef DHT_PARAM_TYPE
 #define DHT_PARAM_TYPE              (DHT11)
 #endif
+#ifndef DHT_PARAM_PULL
+#define DHT_PARAM_PULL              (GPIO_PULLUP)
+#endif
 
 #define DHT_PARAMS_DEFAULT          {.pin = DHT_PARAM_PIN, \
-                                     .type = DHT_PARAM_TYPE}
+                                     .type = DHT_PARAM_TYPE, \
+                                     .pull = DHT_PARAM_PULL}
 /**@}*/
 
 /**

--- a/drivers/dht/include/dht_params.h
+++ b/drivers/dht/include/dht_params.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_dht
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for DHT devices
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef DHT_PARAMS_H
+#define DHT_PARAMS_H
+
+#include "board.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Set default configuration parameters for the DHT devices
+ * @{
+ */
+#ifndef DHT_PARAM_PIN
+#define DHT_PARAM_PIN               (GPIO_PIN(0, 0))
+#endif
+#ifndef DHT_PARAM_TYPE
+#define DHT_PARAM_TYPE              (DHT11)
+#endif
+
+#define DHT_PARAMS_DEFAULT          {.pin = DHT_PARAM_PIN, \
+                                     .type = DHT_PARAM_TYPE}
+/**@}*/
+
+/**
+ * @brief   Configure DHT devices
+ */
+static const dht_params_t dht_params[] =
+{
+#ifdef DHT_PARAMS_BOARD
+    DHT_PARAMS_BOARD,
+#else
+    DHT_PARAMS_DEFAULT,
+#endif
+};
+
+/**
+ * @brief   Get the number of configured DHT devices
+ */
+#define DHT_NUMOF       (sizeof(dht_params) / sizeof(dht_params[0]))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DHT_PARAMS_H */
+/** @} */

--- a/drivers/include/dht.h
+++ b/drivers/include/dht.h
@@ -1,5 +1,7 @@
 /*
- * Copyright 2015 Ludwig Knüpfer, Christian Mehlis
+ * Copyright 2015 Ludwig Knüpfer,
+ *           2015 Christian Mehlis
+ *           2016 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -20,6 +22,7 @@
  *
  * @author      Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
 #ifndef DHT_H
@@ -54,21 +57,30 @@ typedef enum {
  * @brief device descriptor for DHT sensor devices
  */
 typedef struct {
-    gpio_t gpio;            /**< GPIO pin of the device's data pin */
+    gpio_t pin;             /**< GPIO pin of the device's data pin */
     dht_type_t type;        /**< type of the DHT device */
 } dht_t;
 
 /**
+ * @brief configuration parameters for DHT devices
+ */
+typedef dht_t dht_params_t;
+
+/**
+ * @brief auto-initialize all configured DHT devices
+ */
+void dht_auto_init(void);
+
+/**
  * @brief initialize a new DHT device
  *
- * @param[in] dev       device descriptor of a DHT device
- * @param[in] type      type of the DHT device
- * @param[in] gpio      GPIO pin the device's data pin is connected to
+ * @param[out] dev      device descriptor of a DHT device
+ * @param[in]  params   configuration parameters
  *
  * @return              0 on success
  * @return              -1 on error
  */
-int dht_init(dht_t *dev, dht_type_t type, gpio_t gpio);
+int dht_init(dht_t *dev, const dht_params_t *params);
 
  /**
  * @brief   read sensor data from device

--- a/drivers/include/dht.h
+++ b/drivers/include/dht.h
@@ -84,41 +84,21 @@ void dht_auto_init(void);
  */
 int dht_init(dht_t *dev, const dht_params_t *params);
 
- /**
- * @brief   read sensor data from device
+/**
+ * @brief   get a new temperature and humidity value from the device
+ *
+ * @note    if reading fails or checksum is invalid, no new values will be
+ *          written into the result values
  *
  * @param[in]  dev      device descriptor of a DHT device
- * @param[out] relhum   pointer to relative humidity in g/m^3
- * @param[out] temp     pointer to temperature in degrees Celsius
- *
- * @return              0 on success
- * @return              -1 on error
- */
-int dht_read(dht_t *dev, float *relhum, float *temp);
-
- /**
- * @brief   read sensor data from device
- *
- * @note    When reading fails and the function indicates an error,
- *          data will contain garbage.
- *
- * @param[in] dev       device descriptor of a DHT device
- * @param[in] data      pointer to DHT data object
+ * @param[out] temp     temperature value [in °C * 10^-1]
+ * @param[out] hum      relative humidity value [in percent * 10^-1]
  *
  * @return              0 on success
  * @return              -1 on checksum error
+ * @return              -2 on parsing error
  */
-int dht_read_raw(dht_t *dev, dht_data_t *data);
-
-/**
- * @brief   parse raw sensor data into relative humidity and Celsius
- *
- * @param[in]   dev     device descriptor of a DHT device
- * @param[in]   data    sensor data
- * @param[out]  relhum  pointer to relative humidity in g/m^3
- * @param[out]  temp    pointer to temperature in degrees Celsius
- */
-void dht_parse(dht_t *dev, dht_data_t *data, float *relhum, float *temp);
+int dht_read(dht_t *dev, int16_t *temp, int16_t *hum);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/dht.h
+++ b/drivers/include/dht.h
@@ -59,6 +59,8 @@ typedef enum {
 typedef struct {
     gpio_t pin;             /**< GPIO pin of the device's data pin */
     dht_type_t type;        /**< type of the DHT device */
+    gpio_pp_t pull;         /**< internal pull resistor configuration, set to
+                             *   GPIO_NOPULL when using an external pull-up */
 } dht_t;
 
 /**

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -138,6 +138,11 @@ void auto_init(void)
     DEBUG("Auto init UDP module.\n");
     gnrc_udp_init();
 #endif
+#ifdef MODULE_DHT
+    DEBUG("Auto init DHT devices.\n");
+    extern void dht_auto_init(void);
+    dht_auto_init();
+#endif
 
 
 /* initialize network devices */

--- a/tests/driver_dht/Makefile
+++ b/tests/driver_dht/Makefile
@@ -1,22 +1,7 @@
 APPLICATION = driver_dht
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_gpio
-
 USEMODULE += dht
 USEMODULE += xtimer
-
-# define parameters for selected boards
-ifneq (,$(filter stm32f4discovery,$(BOARD)))
-  DHT_GPIO ?= GPIO_PIN\(4,3\)
-endif
-
-# set default device parameters in case they are undefined
-DHT_GPIO ?= GPIO_PIN\(0,0\)
-DHT_TYPE ?= DHT11
-
-# export parameters
-CFLAGS += -DDHT_TYPE=$(DHT_TYPE)
-CFLAGS += -DDHT_GPIO=$(DHT_GPIO)
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_dht/main.c
+++ b/tests/driver_dht/main.c
@@ -19,46 +19,34 @@
  * @}
  */
 
-#ifndef DHT_TYPE
-#error "DHT_TYPE not defined"
-#endif
-
-#ifndef DHT_GPIO
-#error "DHT_GPIO not defined"
-#endif
-
 #include <stdio.h>
 
 #include "xtimer.h"
-
 #include "dht.h"
+#include "dht_params.h"
+
+extern dht_t dht_devs[];
 
 int main(void)
 {
-    dht_t dev;
+    dht_data_t data;
+    float temp, hum;
 
     puts("DHT temperature and humidity sensor test application\n");
 
-    printf("Initializing DHT sensor at GPIO_%ld... ", (long)DHT_GPIO);
-    if (dht_init(&dev, DHT_TYPE, DHT_GPIO) == 0) {
-        puts("[OK]\n");
-    }
-    else {
-        puts("[Failed]");
-        return 1;
-    }
-
-    dht_data_t data;
-    float temp, hum;
+    /* periodically read temp and humidity values */
     while (1) {
+        for (unsigned i = 0; i < DHT_NUMOF; i++) {
+            dht_t *dev = &dht_devs[i];
 
-        if (dht_read_raw(&dev, &data) == -1) {
-            puts("error reading data");
+            if (dht_read_raw(dev, &data) == -1) {
+                puts("error reading data");
+            }
+            dht_parse(dev, &data, &hum, &temp);
+            printf("raw relative humidity: %i\nraw temperature: %i C\n", data.humidity, data.temperature);
+            printf("relative humidity: %i\ntemperature: %i C\n", (int) hum, (int) temp);
+            xtimer_usleep(2000 * MS_IN_USEC);
         }
-        dht_parse(&dev, &data, &hum, &temp);
-        printf("raw relative humidity: %i\nraw temperature: %i C\n", data.humidity, data.temperature);
-        printf("relative humidity: %i\ntemperature: %i C\n", (int) hum, (int) temp);
-        xtimer_usleep(2000 * MS_IN_USEC);
     }
 
     return 0;

--- a/tests/driver_dht/main.c
+++ b/tests/driver_dht/main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Ludwig Knüpfer, Christian Mehlis
+ *               2016 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,6 +16,7 @@
  *
  * @author      Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
  * @}
  */
@@ -29,22 +31,32 @@ extern dht_t dht_devs[];
 
 int main(void)
 {
-    dht_data_t data;
-    float temp, hum;
-
     puts("DHT temperature and humidity sensor test application\n");
 
     /* periodically read temp and humidity values */
     while (1) {
         for (unsigned i = 0; i < DHT_NUMOF; i++) {
             dht_t *dev = &dht_devs[i];
+            int16_t temp, hum;
+            int16_t dec_temp, dec_hum, int_temp, int_hum;
 
-            if (dht_read_raw(dev, &data) == -1) {
+            if (dht_read(dev, &temp, &hum) == -1) {
                 puts("error reading data");
+                continue;
             }
-            dht_parse(dev, &data, &hum, &temp);
-            printf("raw relative humidity: %i\nraw temperature: %i C\n", data.humidity, data.temperature);
-            printf("relative humidity: %i\ntemperature: %i C\n", (int) hum, (int) temp);
+
+            /* split up values into integral and fractional parts for nicer
+             * printing
+             * TODO: this should be done in some kind of library... */
+            int_temp = temp / 10;
+            dec_temp = temp  - (int_temp * 10);
+            int_hum = hum / 10;
+            dec_hum = hum - (int_hum * 10);
+
+            printf("DHT device #%i - ", i);
+            printf("temp: %i.%i°C, ", int_temp, dec_temp);
+            printf("relative humidity: %i.%i%%\n", int_hum, dec_hum);
+
             xtimer_usleep(2000 * MS_IN_USEC);
         }
     }


### PR DESCRIPTION
This was supposed to be an alternative to #4649, but once at it, I touched some more things in the driver:
- added default `dht_params.h` file
- added auto initialization capabilities
- made pull resistor configurable (to allow for external pull resistors)
- changed signature of the init function to `xxx_init(dev, params);` (-> see #4658)
- removed `read_raw` and `parse` functions in favor of a single `dht_read()` (see motivation below)
- got rid of any floating point numbers in favor of fixed point
- simplified the code
- some style fixes here and there

Tested only with a `DHT11` device, as I don't have access to a `DHT22`.

About the interface changes: In my opinion, there is no need for any functions that return RAW values for sensors in general. As user of the driver, I am only interested in actual physical values that actually have semantics to them. And the argument "I am only interested in relative changes so I take the RAW values for efficiency reasons" is not really valid, as the overhead for converting the values is extremely low... So for this reason I think a single `read` function that returns converted values is sufficient.