### PR TITLE
board: ek-lm4f120xl modify default port on OS X

### DIFF
--- a/boards/ek-lm4f120xl/Makefile.include
+++ b/boards/ek-lm4f120xl/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = LM4F120H5QR
 
 #define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* | head -n 1)
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial


### PR DESCRIPTION
modification of the default port to be able to flash and term on OS X for the TI LaunchPad ek-lm4f120xl