### PR TITLE
netdev2: remove const modifier from vector in send method

### DIFF
--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -70,7 +70,7 @@ static void _sigio_child(netdev2_tap_t *dev);
 
 /* netdev2 interface */
 static int _init(netdev2_t *netdev);
-static int _send(netdev2_t *netdev, const struct iovec *vector, int n);
+static int _send(netdev2_t *netdev, struct iovec *vector, int n);
 static int _recv(netdev2_t *netdev, char* buf, int n);
 
 static inline void _get_mac_addr(netdev2_t *netdev, uint8_t *dst)
@@ -258,7 +258,7 @@ static int _recv(netdev2_t *netdev2, char *buf, int len)
     return -1;
 }
 
-static int _send(netdev2_t *netdev, const struct iovec *vector, int n)
+static int _send(netdev2_t *netdev, struct iovec *vector, int n)
 {
     netdev2_tap_t *dev = (netdev2_tap_t*)netdev;
     return _native_writev(dev->tap_fd, vector, n);

--- a/drivers/cc110x/cc110x-netdev2.c
+++ b/drivers/cc110x/cc110x-netdev2.c
@@ -37,7 +37,7 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-static int _send(netdev2_t *dev, const struct iovec *vector, int count)
+static int _send(netdev2_t *dev, struct iovec *vector, int count)
 {
     DEBUG("%s:%u\n", __func__, __LINE__);
 

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -218,7 +218,7 @@ static void on_int(void *arg)
     netdev->event_callback(arg, NETDEV2_EVENT_ISR, NULL);
 }
 
-static int nd_send(netdev2_t *netdev, const struct iovec *data, int count)
+static int nd_send(netdev2_t *netdev, struct iovec *data, int count)
 {
     enc28j60_t *dev = (enc28j60_t *)netdev;
     uint8_t ctrl = 0;

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -301,7 +301,7 @@ static int _init(netdev2_t *encdev)
     return 0;
 }
 
-static int _send(netdev2_t *netdev, const struct iovec *vector, int count) {
+static int _send(netdev2_t *netdev, struct iovec *vector, int count) {
     encx24j600_t * dev = (encx24j600_t *) netdev;
     lock(dev);
 

--- a/drivers/include/net/netdev2.h
+++ b/drivers/include/net/netdev2.h
@@ -112,7 +112,7 @@ typedef struct netdev2_driver {
      *
      * @return nr of bytes sent, or <=0 on error
      */
-    int (*send)(netdev2_t *dev, const struct iovec *vector, int count);
+    int (*send)(netdev2_t *dev, struct iovec *vector, int count);
 
     /**
      * @brief Get a received frame


### PR DESCRIPTION
The `const` modifier hurts in this instance more than it does good IMHO. There might be a need to change parts of the vector. E.g. sequence numbers of frame headers are better updated in the send method, since the actual device type can store the current sequence number, while `netdev2_t` doesn't.