### PR TITLE
examples: fix instructions regarding tap if & bridge

### DIFF
--- a/examples/gnrc_networking/README.md
+++ b/examples/gnrc_networking/README.md
@@ -10,7 +10,7 @@ IPv6 module automatically.
 On some systems (openSUSE for example), the _firewall_ may interfere, and prevent some packets to arrive at the application (they will
 however show up in Wireshark, which can be confusing). So be sure to adjust your firewall rules, or turn it off (who needs security anyway).
 
-First, create a tap interface (to which RIOT will connect) and a bridge (to which Linux will connect):
+First, create a tap interface:
 
     sudo ip tuntap add tap0 mode tap user ${USER}
     sudo ip link set tap0 up

--- a/examples/microcoap_server/README.md
+++ b/examples/microcoap_server/README.md
@@ -4,25 +4,31 @@ microcoap server example
 This application is meant to get you started with impementing a CoAP server on RIOT.
 It uses the gnrc network stack through RIOT's conn socket API.
 
-
 Usage
 =====
 
-To try on native, compile with
+To try out the server on native, compile it with
 
 ```
-# make all
+$ make all
 ```
 
-Then run the resulting binary, e.g.,
+Then, create a tap interface (to which RIOT will connect):
 
 ```
-# make term
+$ sudo ip tuntap add tap0 mode tap user ${USER}
+$ sudo ip link set tap0 up
+```
+
+Run the resulting RIOT binary by invoking:
+
+```
+$ make term
 ```
 
 The application is now listening on all it's configured IP addresses.
 
-Now find out it's link\_layer address:
+Now find out its link\_layer address:
 
 
 ```


### PR DESCRIPTION
I found that connecting works way better when you don't forget to set up the tap interface and its bridge first, so I thought it might be useful to include that hint. :)