### PR TITLE
rpl: function + shell command to ignore RPL messages from a given address

### DIFF
--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -482,6 +482,15 @@ void gnrc_rpl_send(gnrc_pktsnip_t *pkt, ipv6_addr_t *src, ipv6_addr_t *dst, ipv6
  * @return  Global instance id, otherwise.
  */
 uint8_t gnrc_rpl_gen_instance_id(bool local);
+
+/**
+ * @brief set an address of which received messages should be ignored
+ * 
+ * @param[in] node the address of the ignored node
+ */
+void gnrc_rpl_ignore_node(const ipv6_addr_t *node);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -241,10 +241,29 @@ int _gnrc_rpl_operation(bool leaf, char *arg1)
     return 0;
 }
 
+int _gnrc_rpl_ignore_node(char *arg1)
+{
+    ipv6_addr_t addr;
+    char addr_str[IPV6_ADDR_MAX_STR_LEN];
+
+    if (ipv6_addr_from_str(&addr, arg1) == NULL) {
+        puts("error: <addr> must be a valid IPv6 address");
+        return 1;
+    }
+    gnrc_rpl_ignore_node(&addr);
+
+    printf("success: RPL messages from node (%s) will be ignored\n",
+           ipv6_addr_to_str(addr_str, &addr, sizeof(addr_str)));
+    return 0;
+}
+
 int _gnrc_rpl(int argc, char **argv)
 {
     if ((argc < 2) || (strcmp(argv[1], "show") == 0)) {
         return _gnrc_rpl_dodag_show();
+    }
+    else if ((argc == 3) && strcmp(argv[1], "ignore") == 0) {
+        return _gnrc_rpl_ignore_node(argv[2]);
     }
     else if ((argc == 3) && strcmp(argv[1], "init") == 0) {
         return _gnrc_rpl_init(argv[2]);
@@ -295,6 +314,7 @@ int _gnrc_rpl(int argc, char **argv)
     puts("* router <instance_id>\t\t- operate as router in the instance");
     puts("* send dis\t\t\t- send a multicast DIS");
     puts("* show\t\t\t\t- show instance and dodag tables");
+    puts("* ignore <addr>\t\t\t- set a node address to ignore received RPL messages");
     return 0;
 }
 /**


### PR DESCRIPTION
Rationale: testing multihop RPL Scenarios in office can become cumbersome when the range of the tranceivers of the used boards always reaches all other boards.

With the proposed function it is possible to ignore one address on a node and steer the DODAG shape, e.g. ignoring the root node enforces the node to choose an ancestor node of the root node as parent.

This PR should just give an idea, I want to ask if this is something we want/should to have.