### PR TITLE
pkg/driver: native random fix for micro-ecc

### DIFF
--- a/cpu/native/periph/random.c
+++ b/cpu/native/periph/random.c
@@ -137,9 +137,12 @@ void _native_rng_init_hq(void)
 {
     DEBUG("_native_rng_init_hq\n");
     _native_syscall_enter();
-    dev_random = real_open("/dev/random", O_RDONLY);
+    dev_random = real_open("/dev/urandom", O_RDONLY | O_CLOEXEC);
     if (dev_random == -1) {
-        err(EXIT_FAILURE, "_native_rng_init_hq: open(/dev/random)");
+        dev_random = real_open("/dev/random", O_RDONLY | O_CLOEXEC);
+        if (dev_random == -1) {
+            err(EXIT_FAILURE, "_native_rng_init_hq: open(/dev/urandom|/dev/random)");
+        }
     }
     _native_syscall_leave();
 }


### PR DESCRIPTION
This should fix https://github.com/RIOT-OS/RIOT/issues/4621

Original micro-ecc random function accessing /dev/urandom. More to read about random/urandom: http://www.2uo.de/myths-about-urandom/ 

@cgundogan https://github.com/RIOT-OS/RIOT/pull/4676
