### PR TITLE
gnrc/ipv6: add blacklisting of IPv6 addresses

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -223,6 +223,10 @@ ifneq (,$(filter gnrc_ipv6_whitelist,$(USEMODULE)))
   USEMODULE += ipv6_addr
 endif
 
+ifneq (,$(filter gnrc_ipv6_blacklist,$(USEMODULE)))
+  USEMODULE += ipv6_addr
+endif
+
 ifneq (,$(filter gnrc_ipv6_router,$(USEMODULE)))
   USEMODULE += gnrc_ipv6
 endif

--- a/sys/include/net/gnrc/ipv6/blacklist.h
+++ b/sys/include/net/gnrc/ipv6/blacklist.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ * Copyright (C) 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_gnrc_ipv6_blacklist IPv6 address blacklist
+ * @ingroup     net_gnrc_ipv6
+ * @brief       This refuses IPv6 addresses that are defined in this list.
+ * @{
+ *
+ * @file
+ * @brief   IPv6 blacklist definitions
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author  Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ */
+#ifndef GNRC_IPV6_BLACKLIST_H_
+#define GNRC_IPV6_BLACKLIST_H_
+
+#include <stdbool.h>
+
+#include "net/ipv6/addr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Maximum size of the blacklist.
+ */
+#ifndef GNRC_IPV6_BLACKLIST_SIZE
+#define GNRC_IPV6_BLACKLIST_SIZE    (8)
+#endif
+
+/**
+ * @brief   Adds an IPv6 address to the blacklist.
+ *
+ * @param[in] addr  An IPv6 address.
+ *
+ * @return  0, on success.
+ * @return  -1, if blacklist is full.
+ */
+int gnrc_ipv6_blacklist_add(const ipv6_addr_t *addr);
+
+/**
+ * @brief   Removes an IPv6 address from the blacklist.
+ *
+ * Addresses not in the blacklist will be ignored.
+ *
+ * @param[in] addr  An IPv6 address.
+ */
+void gnrc_ipv6_blacklist_del(const ipv6_addr_t *addr);
+
+/**
+ * @brief   Checks if an IPv6 address is blacklisted.
+ *
+ * @param[in] addr  An IPv6 address.
+ *
+ * @return  true, if @p addr is blacklisted.
+ * @return  false, if @p addr is not blacklisted.
+ */
+bool gnrc_ipv6_blacklisted(const ipv6_addr_t *addr);
+
+/**
+ * @brief   Prints the blacklist.
+ */
+void gnrc_ipv6_blacklist_print(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GNRC_IPV6_BLACKLIST_H_ */
+/** @} */

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -34,6 +34,9 @@ endif
 ifneq (,$(filter gnrc_ipv6_whitelist,$(USEMODULE)))
     DIRS += network_layer/ipv6/whitelist
 endif
+ifneq (,$(filter gnrc_ipv6_blacklist,$(USEMODULE)))
+    DIRS += network_layer/ipv6/blacklist
+endif
 ifneq (,$(filter gnrc_ndp,$(USEMODULE)))
     DIRS += network_layer/ndp
 endif

--- a/sys/net/gnrc/network_layer/ipv6/blacklist/Makefile
+++ b/sys/net/gnrc/network_layer/ipv6/blacklist/Makefile
@@ -1,0 +1,3 @@
+MODULE = gnrc_ipv6_blacklist
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist.c
+++ b/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ */
+
+#include <string.h>
+#include "bitfield.h"
+
+#include "net/gnrc/ipv6/blacklist.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+ipv6_addr_t gnrc_ipv6_blacklist[GNRC_IPV6_BLACKLIST_SIZE];
+BITFIELD(gnrc_ipv6_blacklist_set, GNRC_IPV6_BLACKLIST_SIZE);
+
+#if ENABLE_DEBUG
+static char addr_str[IPV6_ADDR_MAX_STR_LEN];
+#endif
+
+int gnrc_ipv6_blacklist_add(const ipv6_addr_t *addr)
+{
+    for (int i = 0; i < GNRC_IPV6_BLACKLIST_SIZE; i++) {
+        if (!bf_isset(gnrc_ipv6_blacklist_set, i)) {
+            bf_set(gnrc_ipv6_blacklist_set, i);
+            memcpy(&gnrc_ipv6_blacklist[i], addr, sizeof(*addr));
+            DEBUG("IPv6 blacklist: blacklisted %s\n",
+                  ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)));
+            return 0;
+        }
+    }
+    return -1;
+}
+
+void gnrc_ipv6_blacklist_del(const ipv6_addr_t *addr)
+{
+    for (int i = 0; i < GNRC_IPV6_BLACKLIST_SIZE; i++) {
+        if (ipv6_addr_equal(addr, &gnrc_ipv6_blacklist[i])) {
+            bf_unset(gnrc_ipv6_blacklist_set, i);
+            DEBUG("IPv6 blacklist: unblacklisted %s\n",
+                  ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)));
+        }
+    }
+}
+
+bool gnrc_ipv6_blacklisted(const ipv6_addr_t *addr)
+{
+    for (int i = 0; i < GNRC_IPV6_BLACKLIST_SIZE; i++) {
+        if (bf_isset(gnrc_ipv6_blacklist_set, i) &&
+            ipv6_addr_equal(addr, &gnrc_ipv6_blacklist[i])) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/** @} */

--- a/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist_print.c
+++ b/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist_print.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ */
+
+#include <stdio.h>
+
+#include "bitfield.h"
+#include "net/ipv6/addr.h"
+
+#include "net/gnrc/ipv6/blacklist.h"
+
+extern ipv6_addr_t gnrc_ipv6_blacklist[GNRC_IPV6_BLACKLIST_SIZE];
+extern BITFIELD(gnrc_ipv6_blacklist_set, GNRC_IPV6_BLACKLIST_SIZE);
+
+void gnrc_ipv6_blacklist_print(void)
+{
+    char addr_str[IPV6_ADDR_MAX_STR_LEN];
+    for (int i = 0; i < GNRC_IPV6_BLACKLIST_SIZE; i++) {
+        if (bf_isset(gnrc_ipv6_blacklist_set, i)) {
+            puts(ipv6_addr_to_str(addr_str, &gnrc_ipv6_blacklist[i], sizeof(addr_str)));
+        }
+    }
+}
+
+/** @} */

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -32,6 +32,7 @@
 #include "net/gnrc/ipv6/nc.h"
 #include "net/gnrc/ipv6/netif.h"
 #include "net/gnrc/ipv6/whitelist.h"
+#include "net/gnrc/ipv6/blacklist.h"
 
 #include "net/gnrc/ipv6.h"
 
@@ -735,6 +736,13 @@ static void _receive(gnrc_pktsnip_t *pkt)
             return;
         }
 #endif
+#ifdef MODULE_GNRC_IPV6_BLACKLIST
+        if (gnrc_ipv6_blacklisted(&((ipv6_hdr_t *)(pkt->data))->src)) {
+            DEBUG("ipv6: Source address blacklisted, dropping packet\n");
+            gnrc_pktbuf_release(pkt);
+            return;
+        }
+#endif
         /* seize ipv6 as a temporary variable */
         ipv6 = gnrc_pktbuf_start_write(pkt);
 
@@ -758,6 +766,14 @@ static void _receive(gnrc_pktsnip_t *pkt)
     else if (!gnrc_ipv6_whitelisted(&((ipv6_hdr_t *)(ipv6->data))->src)) {
         /* if ipv6 header already marked*/
         DEBUG("ipv6: Source address not whitelisted, dropping packet\n");
+        gnrc_pktbuf_release(pkt);
+        return;
+    }
+#endif
+#ifdef MODULE_GNRC_IPV6_BLACKLIST
+    else if (gnrc_ipv6_blacklisted(&((ipv6_hdr_t *)(ipv6->data))->src)) {
+        /* if ipv6 header already marked*/
+        DEBUG("ipv6: Source address blacklisted, dropping packet\n");
         gnrc_pktbuf_release(pkt);
         return;
     }

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -41,6 +41,9 @@ endif
 ifneq (,$(filter gnrc_ipv6_whitelist,$(USEMODULE)))
   SRC += sc_whitelist.c
 endif
+ifneq (,$(filter gnrc_ipv6_blacklist,$(USEMODULE)))
+  SRC += sc_blacklist.c
+endif
 ifneq (,$(filter gnrc_icmpv6_echo xtimer,$(USEMODULE)))
   SRC += sc_icmpv6_echo.c
 endif

--- a/sys/shell/commands/sc_blacklist.c
+++ b/sys/shell/commands/sc_blacklist.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "net/gnrc/ipv6/blacklist.h"
+
+static void _usage(char *cmd)
+{
+    printf("usage: * %s\n", cmd);
+    puts("         Lists all addresses in the blacklist.");
+    printf("       * %s add <addr>\n", cmd);
+    puts("         Adds <addr> to the blacklist.");
+    printf("       * %s del <addr>\n", cmd);
+    puts("         Deletes <addr> from the blacklist.");
+    printf("       * %s help\n", cmd);
+    puts("         Print this.");
+}
+
+int _blacklist(int argc, char **argv)
+{
+    ipv6_addr_t addr;
+    if (argc < 2) {
+        gnrc_ipv6_blacklist_print();
+        return 0;
+    }
+    else if (argc > 2) {
+        if (ipv6_addr_from_str(&addr, argv[2]) == NULL) {
+            _usage(argv[0]);
+            return 1;
+        }
+    }
+    if (strcmp("add", argv[1]) == 0) {
+        gnrc_ipv6_blacklist_add(&addr);
+    }
+    else if (strcmp("del", argv[1]) == 0) {
+        gnrc_ipv6_blacklist_del(&addr);
+    }
+    else if (strcmp("help", argv[1]) == 0) {
+        _usage(argv[0]);
+    }
+    else {
+        _usage(argv[0]);
+        return 1;
+    }
+    return 0;
+}
+
+/** @} */

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -102,6 +102,10 @@ extern int _ipv6_nc_routers(int argc, char **argv);
 extern int _whitelist(int argc, char **argv);
 #endif
 
+#ifdef MODULE_GNRC_IPV6_BLACKLIST
+extern int _blacklist(int argc, char **argv);
+#endif
+
 #ifdef MODULE_GNRC_ZEP
 #ifdef MODULE_IPV6_ADDR
 extern int _zep_init(int argc, char **argv);
@@ -183,6 +187,9 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_GNRC_IPV6_WHITELIST
     {"whitelist", "whitelists an address for receival ('whitelist [add|del|help]')", _whitelist },
+#endif
+#ifdef MODULE_GNRC_IPV6_BLACKLIST
+    {"blacklist", "blacklists an address for receival ('blacklist [add|del|help]')", _blacklist },
 #endif
 #ifdef MODULE_GNRC_ZEP
 #ifdef MODULE_IPV6_ADDR


### PR DESCRIPTION
Rationale: testing multihop RPL Scenarios in office can become cumbersome when you need to whitelist all boards up to a few that should be ignored. 
This adds the possibility to use a blacklist for refusing IPv6 addresses.

I placed the blacklisting below the whitelisting, so using both modules enforces the whitlist decision first.