### PR TITLE
native: add debug-valgrind target

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -86,6 +86,11 @@ term-valgrind: export VALGRIND_FLAGS ?= \
 	--track-origins=yes \
 	--fullpath-after=$(RIOTBASE)/ \
 	--read-var-info=yes
+debug-valgrind-server: export VALGRIND_FLAGS ?= --vgdb=yes --vgdb-error=0 -v \
+	--leak-check=full --track-origins=yes --fullpath-after=${RIOTBASE} \
+	--read-var-info=yes
+debug-valgrind: export VALGRIND_PID ?= $(shell pgrep -n memcheck-x86-li -u ${USER} | cut -d" " -f1)
+debug-valgrind: export DEBUGGER_FLAGS := -ex "target remote | vgdb --pid=${VALGRIND_PID}" $(DEBUGGER_FLAGS)
 term-cachegrind: export CACHEGRIND_FLAGS += --tool=cachegrind
 term-gprof: export TERMPROG = GMON_OUT_PREFIX=gmon.out $(ELF)
 all-valgrind: export CFLAGS += -DHAVE_VALGRIND_H -g
@@ -135,10 +140,14 @@ all-valgrind: all
 all-cachegrind: all
 
 term-valgrind:
-# use this if you want to attach gdb from valgrind:
-#	echo 0 > /proc/sys/kernel/yama/ptrace_scope
-#	VALGRIND_FLAGS += --db-attach=yes
 	$(VALGRIND) $(VALGRIND_FLAGS) $(ELF) $(PORT)
+
+debug-valgrind-server:
+	$(VALGRIND) $(VALGRIND_FLAGS) $(ELF) $(PORT)
+
+debug-valgrind:
+	@echo $(VALGRIND_PID)
+	$(DEBUGGER) $(DEBUGGER_FLAGS)
 
 term-cachegrind:
 	$(VALGRIND) $(CACHEGRIND_FLAGS) $(ELF) $(PORT)

--- a/cpu/native/README.md
+++ b/cpu/native/README.md
@@ -18,20 +18,18 @@ All this does is run your application under Valgrind.
 Now Valgrind will print some information whenever it detects an
 invalid memory access.
 
-In order to debug the program when this occurs you can pass the
---db-attach parameter to Valgrind. E.g:
+In order to debug the program when this occurs you can use the targets
+debug-valgrind-server and debug-valgrind. Therefore, you need to open two
+terminals and run:
 
-    valgrind --db-attach=yes ./bin/native/default.elf tap0
+    make debug-valgrind-server
 
-Now, you will be asked whether you would like to attach the running
-process to gdb whenever a problem occurs.
+in the first one and run:
 
-In order for this to work under Linux 3.4 or newer, you might need to
-disable the ptrace access restrictions:
-As root call:
+    make debug-valgrind
 
-    echo 0 > /proc/sys/kernel/yama/ptrace_scope
-
+in the seconde one. This starts per default gdb attached to valgrinds gdb
+server (vgdb).
 
 Network Support
 ===============


### PR DESCRIPTION
Starts valgrind in background and connect gdb to valgrind gdb-server.