### PR TITLE
gnrc_ipv6/whitelist: switch assignment operation to `memcpy()`

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/whitelist/gnrc_ipv6_whitelist.c
+++ b/sys/net/gnrc/network_layer/ipv6/whitelist/gnrc_ipv6_whitelist.c
@@ -13,6 +13,7 @@
  * @author Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
+#include <string.h>
 #include "bitfield.h"
 
 #include "net/gnrc/ipv6/whitelist.h"
@@ -32,8 +33,7 @@ int gnrc_ipv6_whitelist_add(const ipv6_addr_t *addr)
     for (int i = 0; i < GNRC_IPV6_WHITELIST_SIZE; i++) {
         if (!bf_isset(gnrc_ipv6_whitelist_set, i)) {
             bf_set(gnrc_ipv6_whitelist_set, i);
-            gnrc_ipv6_whitelist[i].u64[0].u64 = addr->u64[0].u64;
-            gnrc_ipv6_whitelist[i].u64[1].u64 = addr->u64[1].u64;
+            memcpy(&gnrc_ipv6_whitelist[i], addr, sizeof(*addr));
             DEBUG("IPv6 whitelist: whitelisted %s\n",
                   ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)));
             return 0;


### PR DESCRIPTION
Rationale: @cgundogan found out that switching to `memcpy()` saves some bytes in the codeimage on several platforms in #4686.
Since the implementations are similar this is also true here.