### PR TITLE
pkg: initial import of emb6 stack

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -357,6 +357,10 @@ ifneq (,$(filter posix_semaphore,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter emb6_conn_udp,$(USEMODULE)))
+  USEMODULE += emb6_sock
+endif
+
 ifneq (,$(filter emb6_%,$(USEMODULE)))
   USEMODULE += emb6
 endif
@@ -428,6 +432,25 @@ endif
 
 ifneq (,$(filter lwip_contrib,$(USEMODULE)))
   USEMODULE += sema
+endif
+
+ifneq (,$(filter emb6_%,$(USEMODULE)))
+  USEMODULE += emb6
+endif
+
+ifneq (,$(filter emb6,$(USEMODULE)))
+  USEPKG += emb6
+  USEMODULE += emb6_bsp
+  USEMODULE += emb6_common
+  USEMODULE += emb6_contrib
+  USEMODULE += emb6_ipv6
+  USEMODULE += emb6_ipv6_multicast
+  USEMODULE += emb6_llsec
+  USEMODULE += emb6_mac
+  USEMODULE += emb6_netdev2
+  USEMODULE += emb6_rpl
+  USEMODULE += emb6_sicslowpan
+  USEMODULE += emb6_utils
 endif
 
 ifneq (,$(filter sema,$(USEMODULE)))

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -370,6 +370,7 @@ ifneq (,$(filter emb6,$(USEMODULE)))
   USEMODULE += emb6_ipv6_multicast
   USEMODULE += emb6_llsec
   USEMODULE += emb6_mac
+  USEMODULE += emb6_netdev2
   USEMODULE += emb6_rpl
   USEMODULE += emb6_sicslowpan
   USEMODULE += emb6_utils

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -365,6 +365,7 @@ ifneq (,$(filter emb6,$(USEMODULE)))
   USEPKG += emb6
   USEMODULE += emb6_bsp
   USEMODULE += emb6_common
+  USEMODULE += emb6_contrib
   USEMODULE += emb6_ipv6
   USEMODULE += emb6_ipv6_multicast
   USEMODULE += emb6_llsec

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -357,6 +357,23 @@ ifneq (,$(filter posix_semaphore,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter emb6_%,$(USEMODULE)))
+  USEMODULE += emb6
+endif
+
+ifneq (,$(filter emb6,$(USEMODULE)))
+  USEPKG += emb6
+  USEMODULE += emb6_bsp
+  USEMODULE += emb6_common
+  USEMODULE += emb6_ipv6
+  USEMODULE += emb6_ipv6_multicast
+  USEMODULE += emb6_llsec
+  USEMODULE += emb6_mac
+  USEMODULE += emb6_rpl
+  USEMODULE += emb6_sicslowpan
+  USEMODULE += emb6_utils
+endif
+
 ifneq (,$(filter lwip_sixlowpan,$(USEMODULE)))
   USEMODULE += lwip_ipv6_autoconfig
 endif

--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -3,6 +3,7 @@ PSEUDOMODULES += conn_ip
 PSEUDOMODULES += conn_tcp
 PSEUDOMODULES += conn_udp
 PSEUDOMODULES += core_thread_flags
+PSEUDOMODULES += emb6_router
 PSEUDOMODULES += gnrc_netdev_default
 PSEUDOMODULES += gnrc_ipv6_default
 PSEUDOMODULES += gnrc_ipv6_router

--- a/pkg/emb6/Makefile
+++ b/pkg/emb6/Makefile
@@ -1,0 +1,11 @@
+PKG_NAME=emb6
+PKG_URL=https://github.com/hso-esk/emb6.git
+PKG_VERSION=14e4a3cfff01644e078870e14e16a1fe60dcc895
+PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
+
+.PHONY: all
+
+all: git-download
+	"$(MAKE)" -C $(PKG_BUILDDIR)
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/emb6/Makefile.include
+++ b/pkg/emb6/Makefile.include
@@ -42,6 +42,10 @@ ifneq (,$(filter emb6_mac,$(USEMODULE)))
   INCLUDES += -I$(EMB6_DIR)/emb6/inc/mac
 endif
 
+ifneq (,$(filter emb6_netdev2,$(USEMODULE)))
+  DIRS += $(EMB6_CONTRIB)/netdev2
+endif
+
 ifneq (,$(filter emb6_rpl,$(USEMODULE)))
   DIRS += $(EMB6_DIR)/emb6/src/net/rpl
   INCLUDES += -I$(EMB6_DIR)/emb6/inc/net/rpl

--- a/pkg/emb6/Makefile.include
+++ b/pkg/emb6/Makefile.include
@@ -22,6 +22,10 @@ ifneq (,$(filter emb6_contrib,$(USEMODULE)))
   DIRS += $(EMB6_CONTRIB)
 endif
 
+ifneq (,$(filter emb6_conn_udp,$(USEMODULE)))
+  DIRS += $(EMB6_CONTRIB)/conn/udp
+endif
+
 ifneq (,$(filter emb6_ipv6,$(USEMODULE)))
   DIRS += $(EMB6_DIR)/emb6/src/net/ipv6
   INCLUDES += -I$(EMB6_DIR)/emb6/inc/net/ipv6

--- a/pkg/emb6/Makefile.include
+++ b/pkg/emb6/Makefile.include
@@ -1,7 +1,9 @@
 PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/emb6
 EMB6_DIR := $(PKG_BUILDDIR)
+EMB6_CONTRIB := $(RIOTBASE)/pkg/emb6/contrib
 
-INCLUDES += -I$(EMB6_DIR)/target
+INCLUDES += -I$(PKG_BUILDDIR)/target
+INCLUDES += -I$(RIOTBASE)/pkg/emb6/include
 
 ifeq (,$(filter emb6_router,$(USEMODULE)))
   CFLAGS += -DEMB6_CONF_ROUTER=FALSE
@@ -14,6 +16,10 @@ endif
 ifneq (,$(filter emb6_common,$(USEMODULE)))
   DIRS += $(EMB6_DIR)/emb6
   INCLUDES += -I$(EMB6_DIR)/emb6
+endif
+
+ifneq (,$(filter emb6_contrib,$(USEMODULE)))
+  DIRS += $(EMB6_CONTRIB)
 endif
 
 ifneq (,$(filter emb6_ipv6,$(USEMODULE)))

--- a/pkg/emb6/Makefile.include
+++ b/pkg/emb6/Makefile.include
@@ -1,0 +1,57 @@
+PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/emb6
+EMB6_DIR := $(PKG_BUILDDIR)
+
+INCLUDES += -I$(EMB6_DIR)/target
+
+ifeq (,$(filter emb6_router,$(USEMODULE)))
+  CFLAGS += -DEMB6_CONF_ROUTER=FALSE
+endif
+
+ifneq (,$(filter emb6_bsp,$(USEMODULE)))
+  DIRS += $(EMB6_DIR)/target/bsp
+endif
+
+ifneq (,$(filter emb6_common,$(USEMODULE)))
+  DIRS += $(EMB6_DIR)/emb6
+  INCLUDES += -I$(EMB6_DIR)/emb6
+endif
+
+ifneq (,$(filter emb6_ipv6,$(USEMODULE)))
+  DIRS += $(EMB6_DIR)/emb6/src/net/ipv6
+  INCLUDES += -I$(EMB6_DIR)/emb6/inc/net/ipv6
+endif
+
+ifneq (,$(filter emb6_ipv6_multicast,$(USEMODULE)))
+  DIRS += $(EMB6_DIR)/emb6/src/net/ipv6/multicast
+  INCLUDES += -I$(EMB6_DIR)/emb6/inc/net/ipv6/multicast
+endif
+
+ifneq (,$(filter emb6_llsec,$(USEMODULE)))
+  DIRS += $(EMB6_DIR)/emb6/src/mac/llsec
+  INCLUDES += -I$(EMB6_DIR)/emb6/inc/mac/llsec
+endif
+
+ifneq (,$(filter emb6_mac,$(USEMODULE)))
+  DIRS += $(EMB6_DIR)/emb6/src/mac
+  INCLUDES += -I$(EMB6_DIR)/emb6/inc/mac
+endif
+
+ifneq (,$(filter emb6_rpl,$(USEMODULE)))
+  DIRS += $(EMB6_DIR)/emb6/src/net/rpl
+  INCLUDES += -I$(EMB6_DIR)/emb6/inc/net/rpl
+endif
+
+ifneq (,$(filter emb6_sicslowpan,$(USEMODULE)))
+  DIRS += $(EMB6_DIR)/emb6/src/net/sicslowpan
+  INCLUDES += -I$(EMB6_DIR)/emb6/inc/net/sicslowpan
+endif
+
+ifneq (,$(filter emb6_sock,$(USEMODULE)))
+  DIRS += $(EMB6_DIR)/emb6/src/tport
+  INCLUDES += -I$(EMB6_DIR)/emb6/inc/tport
+endif
+
+ifneq (,$(filter emb6_utils,$(USEMODULE)))
+  DIRS += $(EMB6_DIR)/utils/src
+  INCLUDES += -I$(EMB6_DIR)/utils/inc
+endif

--- a/pkg/emb6/contrib/Makefile
+++ b/pkg/emb6/contrib/Makefile
@@ -1,0 +1,3 @@
+MODULE = emb6_contrib
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/emb6/contrib/board_conf.c
+++ b/pkg/emb6/contrib/board_conf.c
@@ -13,6 +13,8 @@
  * @author Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
+#include "emb6/netdev2.h"
+
 #include "etimer.h"
 #include "board_conf.h"
 
@@ -22,6 +24,7 @@
 uint8_t board_conf(s_ns_t *ps_nStack)
 {
     if (ps_nStack != NULL) {
+        ps_nStack->inif = &emb6_netdev2_driver;
         etimer_init();
         return ps_nStack->inif->init(ps_nStack);
     }

--- a/pkg/emb6/contrib/board_conf.c
+++ b/pkg/emb6/contrib/board_conf.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include "etimer.h"
+#include "board_conf.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+uint8_t board_conf(s_ns_t *ps_nStack)
+{
+    if (ps_nStack != NULL) {
+        etimer_init();
+        return ps_nStack->inif->init(ps_nStack);
+    }
+    else {
+        DEBUG("Network stack pointer is NULL");
+        return 0;
+    }
+}
+
+/** @} */

--- a/pkg/emb6/contrib/conn/udp/Makefile
+++ b/pkg/emb6/contrib/conn/udp/Makefile
@@ -1,0 +1,3 @@
+MODULE = emb6_conn_udp
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/emb6/contrib/conn/udp/emb6_conn_udp.c
+++ b/pkg/emb6/contrib/conn/udp/emb6_conn_udp.c
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+
+#include "evproc.h"
+#include "msg.h"
+#include "mutex.h"
+#include "net/af.h"
+#include "net/conn/udp.h"
+#include "net/ipv6/hdr.h"
+#include "sched.h"
+#include "uip.h"
+
+#define _MSG_TYPE_CLOSE     (0x4123)
+#define _MSG_TYPE_RCV       (0x4124)
+
+/* struct to describe a sendto command for emb6 thread */
+typedef struct {
+    struct udp_socket sock;
+    mutex_t mutex;
+    const void *data;
+    int res;
+    uint16_t data_len;
+} _send_cmd_t;
+
+extern uint16_t uip_slen;
+
+static bool send_registered = false;
+
+static void _input_callback(struct udp_socket *c, void *ptr,
+                            const uip_ipaddr_t *src_addr, uint16_t src_port,
+                            const uip_ipaddr_t *dst_addr, uint16_t dst_port,
+                            const uint8_t *data, uint16_t datalen);
+static void _output_callback(c_event_t c_event, p_data_t p_data);
+
+static int _reg_and_bind(struct udp_socket *c, void *ptr,
+                         udp_socket_input_callback_t cb, uint16_t port)
+{
+    if (udp_socket_register(c, ptr, cb) < 0) {
+        return -EMFILE;
+    }
+    if (udp_socket_bind(c, port) < 0) {
+        udp_socket_close(c);
+        return -EALREADY;
+    }
+    return 0;
+}
+
+int conn_udp_create(conn_udp_t *conn, const void *addr, size_t addr_len,
+                    int family, uint16_t port)
+{
+    int res;
+
+    (void)addr;
+    (void)addr_len;
+    if (family != AF_INET6) {
+        return -EAFNOSUPPORT;
+    }
+    if (conn->sock.input_callback != NULL) {
+        return -EINVAL;
+    }
+    mutex_init(&conn->mutex);
+    mutex_lock(&conn->mutex);
+    if ((res = _reg_and_bind(&conn->sock, conn, _input_callback, port)) < 0) {
+        conn->sock.input_callback = NULL;
+        mutex_unlock(&conn->mutex);
+        return res;
+    }
+    conn->waiting_thread = KERNEL_PID_UNDEF;
+    mutex_unlock(&conn->mutex);
+    return 0;
+}
+
+void conn_udp_close(conn_udp_t *conn)
+{
+    if (conn->sock.input_callback != NULL) {
+        mutex_lock(&conn->mutex);
+        if (conn->waiting_thread != KERNEL_PID_UNDEF) {
+            msg_t msg;
+            msg.type = _MSG_TYPE_CLOSE;
+            msg.content.ptr = (char *)conn;
+            mutex_unlock(&conn->mutex);
+            msg_send(&msg, conn->waiting_thread);
+            mutex_lock(&conn->mutex);
+        }
+        udp_socket_close(&conn->sock);
+        conn->sock.input_callback = NULL;
+        mutex_unlock(&conn->mutex);
+    }
+}
+
+int conn_udp_getlocaladdr(conn_udp_t *conn, void *addr, uint16_t *port)
+{
+    if (conn->sock.input_callback != NULL) {
+        mutex_lock(&conn->mutex);
+        memset(addr, 0, sizeof(ipv6_addr_t));
+        *port = NTOHS(conn->sock.udp_conn->lport);
+        mutex_unlock(&conn->mutex);
+        return sizeof(ipv6_addr_t);
+    }
+    return -EBADF;
+}
+
+int conn_udp_recvfrom(conn_udp_t *conn, void *data, size_t max_len, void *addr,
+                      size_t *addr_len, uint16_t *port)
+{
+    int res = -EIO;
+    msg_t msg;
+
+    if (conn->sock.input_callback == NULL) {
+        return -ENOTSOCK;
+    }
+    mutex_lock(&conn->mutex);
+    if (conn->waiting_thread != KERNEL_PID_UNDEF) {
+        mutex_unlock(&conn->mutex);
+        return -EALREADY;
+    }
+    conn->waiting_thread = sched_active_pid;
+    mutex_unlock(&conn->mutex);
+    msg_receive(&msg);
+    if (msg.type == _MSG_TYPE_CLOSE) {
+        conn->waiting_thread = KERNEL_PID_UNDEF;
+        return -EINTR;
+    }
+    else if (msg.type == _MSG_TYPE_RCV) {
+        mutex_lock(&conn->mutex);
+        if (msg.content.ptr == (char *)conn) {
+            if (max_len < conn->recv_info.datalen) {
+                conn->waiting_thread = KERNEL_PID_UNDEF;
+                mutex_unlock(&conn->mutex);
+                return -ENOBUFS;
+            }
+            memcpy(data, conn->recv_info.data, conn->recv_info.datalen);
+            memcpy(addr, conn->recv_info.src, sizeof(ipv6_addr_t));
+            *addr_len = sizeof(ipv6_addr_t);
+            *port = conn->recv_info.src_port;
+            res = (int)conn->recv_info.datalen;
+        }
+        conn->waiting_thread = KERNEL_PID_UNDEF;
+        mutex_unlock(&conn->mutex);
+    }
+    return res;
+}
+
+int conn_udp_sendto(const void *data, size_t len, const void *src, size_t src_len,
+                    const void *dst, size_t dst_len, int family, uint16_t sport,
+                    uint16_t dport)
+{
+    int res;
+    _send_cmd_t send_cmd;
+
+    if (!send_registered) {
+        if (evproc_regCallback(EVENT_TYPE_CONN_SEND, _output_callback) != E_SUCCESS) {
+            return -EIO;
+        }
+        else {
+            send_registered = true;
+        }
+    }
+    mutex_init(&send_cmd.mutex);
+    if ((len > (UIP_BUFSIZE - (UIP_LLH_LEN + UIP_IPUDPH_LEN))) ||
+        (len > UINT16_MAX)) {
+        return -EMSGSIZE;
+    }
+    if ((dst_len > sizeof(ipv6_addr_t)) || (family != AF_INET6)) {
+        return -EAFNOSUPPORT;
+    }
+    mutex_lock(&send_cmd.mutex);
+    send_cmd.data = data;
+    send_cmd.data_len = (uint16_t)len;
+    if ((res = _reg_and_bind(&send_cmd.sock, NULL, NULL, sport)) < 0) {
+        mutex_unlock(&send_cmd.mutex);
+        return res;
+    }
+    udp_socket_connect(&send_cmd.sock, (uip_ipaddr_t *)dst, dport); /* can't fail at this point */
+    /* change to emb6 thread context */
+    if (evproc_putEvent(E_EVPROC_TAIL, EVENT_TYPE_CONN_SEND, &send_cmd) != E_SUCCESS) {
+        udp_socket_close(&send_cmd.sock);
+        mutex_unlock(&send_cmd.mutex);
+        return -EIO;
+    }
+    /* block thread until data was send */
+    mutex_lock(&send_cmd.mutex);
+    udp_socket_close(&send_cmd.sock);
+    mutex_unlock(&send_cmd.mutex);
+
+    return send_cmd.res;
+}
+
+static void _input_callback(struct udp_socket *c, void *ptr,
+                            const uip_ipaddr_t *src_addr, uint16_t src_port,
+                            const uip_ipaddr_t *dst_addr, uint16_t dst_port,
+                            const uint8_t *data, uint16_t datalen)
+{
+    conn_udp_t *conn = ptr;
+
+    (void)dst_addr;
+    (void)dst_port;
+    mutex_lock(&conn->mutex);
+    if (conn->waiting_thread != KERNEL_PID_UNDEF) {
+        msg_t msg;
+        conn->recv_info.src_port = src_port;
+        conn->recv_info.src = (const ipv6_addr_t *)src_addr;
+        conn->recv_info.data = data;
+        conn->recv_info.datalen = datalen - sizeof(ipv6_hdr_t);
+        msg.type = _MSG_TYPE_RCV;
+        msg.content.ptr = (char *)conn;
+        mutex_unlock(&conn->mutex);
+        msg_send(&msg, conn->waiting_thread);
+    }
+    else {
+        mutex_unlock(&conn->mutex);
+    }
+}
+
+static void _output_callback(c_event_t c_event, p_data_t p_data)
+{
+    _send_cmd_t *send_cmd = (_send_cmd_t *)p_data;
+
+    if ((c_event != EVENT_TYPE_CONN_SEND) || (p_data == NULL)) {
+        return;
+    }
+    if ((send_cmd->res = udp_socket_send(&send_cmd->sock, send_cmd->data, send_cmd->data_len)) < 0) {
+        send_cmd->res = -EHOSTUNREACH;
+    }
+    mutex_unlock(&send_cmd->mutex);
+}
+
+/** @} */

--- a/pkg/emb6/contrib/netdev2/Makefile
+++ b/pkg/emb6/contrib/netdev2/Makefile
@@ -1,0 +1,3 @@
+MODULE = emb6_netdev2
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/emb6/contrib/netdev2/emb6_netdev2.c
+++ b/pkg/emb6/contrib/netdev2/emb6_netdev2.c
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <sys/uio.h>
+
+#include "msg.h"
+#include "net/netdev2.h"
+
+#include "evproc.h"
+#include "emb6.h"
+#include "linkaddr.h"
+#include "packetbuf.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+extern uip_lladdr_t uip_lladdr;
+
+static netdev2_t *_dev = NULL;
+static s_nsLowMac_t *_lowmac = NULL;
+static int8_t _rssi_base_value = -100;
+static uint8_t _last_rssi;
+
+static int8_t _netdev2_init(s_ns_t *p_ns);
+static int8_t _netdev2_send(const void *pr_payload, uint8_t c_len);
+static int8_t _netdev2_on(void);
+static int8_t _netdev2_off(void);
+static void _netdev2_set_txpower(int8_t power);
+static int8_t _netdev2_get_txpower(void);
+static void _netdev2_set_sensitivity(int8_t sens);
+static int8_t _netdev2_get_sensitivity(void);
+static int8_t _netdev2_get_rssi(void);
+static void _netdev2_set_promisc(uint8_t c_on_off);
+
+const s_nsIf_t emb6_netdev2_driver = {
+    .name               = "netdev2",
+    .init               = &_netdev2_init,
+    .send               = &_netdev2_send,
+    .on                 = &_netdev2_on,
+    .off                = &_netdev2_off,
+    .set_txpower        = &_netdev2_set_txpower,
+    .get_txpower        = &_netdev2_get_txpower,
+    .set_sensitivity    = &_netdev2_set_sensitivity,
+    .get_sensitivity    = &_netdev2_get_sensitivity,
+    .get_rssi           = &_netdev2_get_rssi,
+    .ant_div            = NULL,
+    .ant_rf_switch      = NULL,
+    .set_promisc        = &_netdev2_set_promisc,
+};
+
+static void _get_recv_pkt(void)
+{
+    char *dataptr;
+    struct netdev2_radio_rx_info rx_info;
+    int8_t len;
+
+    packetbuf_clear();
+
+    dataptr = packetbuf_dataptr();
+    len = _dev->driver->recv(_dev, dataptr, PACKETBUF_SIZE, &rx_info);
+    _last_rssi = rx_info.rssi;
+
+    if ((len > 0) && (_lowmac != NULL)) {
+        packetbuf_set_datalen(len);
+        _lowmac->input();
+    }
+}
+
+static void _event_cb(netdev2_t *dev, netdev2_event_t event, void *arg)
+{
+    (void)arg;
+    if (event == NETDEV2_EVENT_ISR) {
+        /* EVENT_TYPE_PCK_LL is supposed to be used by drivers, so use it
+         * (though NETDEV2_EVENT_ISR technically doesn't only signify
+         * incoming packets) */
+        evproc_putEvent(E_EVPROC_HEAD, EVENT_TYPE_PCK_LL, NULL);
+    }
+    else {
+        switch (event) {
+            case NETDEV2_EVENT_RX_COMPLETE: {
+                _get_recv_pkt();
+            }
+            break;
+            default:
+                break;
+        }
+    }
+}
+
+static void _emb6_netdev2_callback(c_event_t c_event, p_data_t p_data)
+{
+    (void)p_data;
+    if (c_event == EVENT_TYPE_PCK_LL) {
+        _dev->driver->isr(_dev);
+    }
+}
+
+int emb6_netdev2_setup(netdev2_t *dev)
+{
+    if (_dev == NULL) {
+        _dev = dev;
+        return 0;
+    }
+    return -1;
+}
+
+static int8_t _netdev2_init(s_ns_t *p_ns)
+{
+    if ((_dev != NULL) && (p_ns != NULL) && (p_ns->lmac != NULL)) {
+        _dev->event_callback = _event_cb;
+        _dev->driver->get(_dev, NETOPT_ADDRESS_LONG, &mac_phy_config.mac_address,
+                          sizeof(mac_phy_config.mac_address));
+        memcpy(&uip_lladdr, mac_phy_config.mac_address,
+               sizeof(mac_phy_config.mac_address));
+        _dev->driver->get(_dev, NETOPT_NID, &mac_phy_config.pan_id,
+                          sizeof(mac_phy_config.pan_id));
+        linkaddr_set_node_addr((linkaddr_t *)&uip_lladdr);
+        _lowmac = p_ns->lmac;
+        evproc_regCallback(EVENT_TYPE_PCK_LL, _emb6_netdev2_callback);
+        return 1;
+    }
+    return 0;
+}
+
+static int8_t _netdev2_send(const void *pr_payload, uint8_t c_len)
+{
+    if (_dev != NULL) {
+        const struct iovec vector = {
+            .iov_base = (void *)pr_payload,
+            .iov_len = c_len
+        };
+        if (_dev->driver->send(_dev, &vector, 1) < 0) {
+            DEBUG("Error on send\n");
+            return RADIO_TX_ERR;
+        }
+        DEBUG("Packet of length %u was transmitted\n", (unsigned)c_len);
+        return RADIO_TX_OK;
+    }
+    DEBUG("Device was not initialized\n");
+    return RADIO_TX_ERR;
+}
+
+static int8_t _netdev2_on(void)
+{
+    /* TODO: turn netdev2 on */
+    return 1;
+}
+
+static int8_t _netdev2_off(void)
+{
+    /* TODO: turn netdev2 off */
+    return 1;
+}
+
+static void _netdev2_set_txpower(int8_t power)
+{
+    int16_t pwr = power;
+
+    _dev->driver->set(_dev, NETOPT_TX_POWER, &pwr, sizeof(pwr));
+}
+
+static int8_t _netdev2_get_txpower(void)
+{
+    int16_t power = 0;
+
+    _dev->driver->get(_dev, NETOPT_TX_POWER, &power, sizeof(power));
+    return (int8_t)power;
+}
+
+static void _netdev2_set_sensitivity(int8_t sens)
+{
+    /* TODO: set sensitivity */
+}
+
+static int8_t _netdev2_get_sensitivity(void)
+{
+    /* TODO: get sensitivity */
+    return 0;
+}
+
+static int8_t _netdev2_get_rssi(void)
+{
+    return (int8_t)(_rssi_base_value + 1.03 * _last_rssi);
+}
+
+static void _netdev2_set_promisc(uint8_t c_on_off)
+{
+    netopt_enable_t en = (c_on_off) ? NETOPT_ENABLE : NETOPT_DISABLE;
+
+    _dev->driver->set(_dev, NETOPT_PROMISCUOUSMODE, &en, sizeof(en));
+}
+
+/** @} */

--- a/pkg/emb6/contrib/target.c
+++ b/pkg/emb6/contrib/target.c
@@ -1,0 +1,213 @@
+/*
+ * Copyright (C) Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include <inttypes.h>
+
+#include "cpu.h"
+#include "led.h"
+#include "mutex.h"
+#include "periph/gpio.h"
+#include "periph/hwrng.h"
+#include "xtimer.h"
+
+#include "target.h"
+#include "bsp.h"
+
+static mutex_t critical_mutex = MUTEX_INIT;
+
+void hal_enterCritical(void)
+{
+    mutex_lock(&critical_mutex);
+}
+
+void hal_exitCritical(void)
+{
+    mutex_unlock(&critical_mutex);
+}
+
+int8_t hal_init(void)
+{
+    /* Should have happened long before emb6 started, so nothing to do */
+    return 1;
+}
+
+uint8_t hal_getrand(void)
+{
+#if RANDOM_NUMOF
+    uint8_t res;
+    hwnrg_read((char *)&res, sizeof(res));
+    return res;
+#elif defined(MODULE_RANDOM)
+    return (uint8_t)(genrand_uint32() % UINT8_MAX);
+#else
+    return 4;   /* keeping the meme alive ;-) */
+#endif
+}
+
+void hal_ledOn(uint16_t ui_led)
+{
+    switch (ui_led) {
+        case E_BSP_LED_RED:
+            LED0_ON;
+            break;
+        case E_BSP_LED_YELLOW:
+            LED1_ON;
+            break;
+        case E_BSP_LED_GREEN:
+            LED2_ON;
+            break;
+        default:
+            break;
+    }
+}
+
+void hal_ledOff(uint16_t ui_led)
+{
+    switch (ui_led) {
+        case E_BSP_LED_RED:
+            LED0_OFF;
+            break;
+        case E_BSP_LED_YELLOW:
+            LED1_OFF;
+            break;
+        case E_BSP_LED_GREEN:
+            LED2_OFF;
+            break;
+        default:
+            break;
+    }
+}
+
+uint8_t hal_extIntInit(en_targetExtInt_t e_extInt, pfn_intCallb_t pfn_intCallback)
+{
+    /* RIOT does this in netdev2 initialization so nothing to do here. */
+    return 0;
+}
+
+void hal_delay_us(uint32_t i_delay)
+{
+    xtimer_usleep(i_delay);
+}
+
+uint8_t hal_gpioPinInit(uint8_t c_pin, uint8_t c_dir, uint8_t c_initState)
+{
+    /* Only used in board init code => not needed */
+    (void)c_pin;
+    (void)c_dir;
+    (void)c_initState;
+    return 0;
+}
+
+void *hal_ctrlPinInit(en_targetExtPin_t e_pinType)
+{
+    (void)e_pinType;
+    return NULL;
+}
+
+void hal_pinSet(void *p_pin)
+{
+    /* Only used in board/driver-related code code => not needed */
+}
+
+void hal_pinClr(void *p_pin)
+{
+    /* Only used in board/driver-related code code => not needed */
+}
+
+uint8_t hal_pinGet(void *p_pin)
+{
+    /* Only used in board/driver-related code code => not needed */
+    return 0;
+}
+
+void *hal_spiInit(void)
+{
+    /* Only used in board/driver-related code code => not needed */
+    return 0;
+}
+
+/*----------------------------------------------------------------------------*/
+/** \brief  This function selects slave with which we will work
+ *  \param         p_spi    Pointer to spi description entity
+ *  \param        action    true or false
+ *
+ *  \return        0 if failed, 1 id ok
+ */
+/*---------------------------------------------------------------------------*/
+uint8_t hal_spiSlaveSel(void *p_spi, bool action)
+{
+    /* Only used in board/driver-related code code => not needed */
+    return 0;
+}
+
+uint8_t hal_spiTransceive( uint8_t *txData, uint8_t *p_reg)
+{
+    /* Only used in board/driver-related code code => not needed */
+    return 0;
+}
+
+uint8_t hal_spiRead(uint8_t *p_reg, uint16_t i_length)
+{
+    /* Only used in board/driver-related code code => not needed */
+    return 0;
+}
+
+
+/*----------------------------------------------------------------------------*/
+/** \brief  This function writes a new value via given SPI interface
+ *          registers.
+ *
+ *
+ *  \param  value         Pointer to a value.
+ *  \param  i_length     Length of a data to be received
+ */
+/*----------------------------------------------------------------------------*/
+void hal_spiWrite(uint8_t *value, uint16_t i_length)
+{
+    /* Only used in board/driver-related code code => not needed */
+}
+
+void hal_watchdogReset(void)
+{
+    /* WDT and tick-less scheduling don't make much sense */
+}
+
+void hal_watchdogStart(void)
+{
+    /* WDT and tick-less scheduling don't make much sense */
+}
+
+void     hal_watchdogStop(void)
+{
+    /* WDT and tick-less scheduling don't make much sense */
+}
+
+clock_time_t hal_getTick(void)
+{
+    return (clock_time_t)xtimer_now();
+}
+
+clock_time_t hal_getSec(void)
+{
+    return (clock_time_t)xtimer_now() / SEC_IN_USEC;
+}
+
+
+clock_time_t hal_getTRes(void)
+{
+    return SEC_IN_USEC;
+}
+
+/** @} */

--- a/pkg/emb6/doc.txt
+++ b/pkg/emb6/doc.txt
@@ -1,0 +1,9 @@
+/**
+ * @defgroup pkg_emb6 emb6 network stack
+ * @ingroup pkg
+ * @brief   emb6 network stack
+ * @see     https://github.com/hso-esk/emb6/raw/develop/doc/pdf/emb6.pdf
+ *
+ * emb6 is a fork of Contiki's uIP network stack without its usage of
+ * proto-threads. It uses periodic event polling instead.
+ */

--- a/pkg/emb6/include/board_conf.h
+++ b/pkg/emb6/include/board_conf.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    emb6    emb6 network stack
+ * @ingroup pkg
+ * @brief
+ * @{
+ *
+ * @file
+ * @brief   "Board" configuration for emb6
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#ifndef EMB6_BOARD_CONF_H_
+#define EMB6_BOARD_CONF_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "emb6.h"
+
+/**
+ * @brief    emb6 board configuration function
+ *
+ * @param[in]   ps_nStack pointer to global netstack struct
+ *
+ * @return  success 1
+ * @return  failure 0
+ */
+uint8_t board_conf(s_ns_t *ps_nStack);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EMB6_BOARD_CONF_H_ */
+/** @} */
+/** @} */

--- a/pkg/emb6/include/emb6/conn/udp.h
+++ b/pkg/emb6/include/emb6/conn/udp.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    emb6_conn_udp   udp_conn wrapper for emb6
+ * @ingroup     emb6
+ * @brief       UDP conn for emb6
+ *
+ * For this implementation to receive with an open connection only with one
+ * thread at once. If you use @ref conn_udp_recvfrom() with more than one thread
+ * simultaneously, it will return `-EALREADY`.
+ *
+ * @{
+ *
+ * @file
+ * @brief   UDP conn definitions
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+#ifndef EMB6_CONN_UDP_H_
+#define EMB6_CONN_UDP_H_
+
+#include <stdint.h>
+
+#include "kernel_types.h"
+#include "mutex.h"
+#include "net/ipv6/addr.h"
+
+#include "uip.h"
+#include "udp-socket.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief @ref net_conn_udp definition for emb6
+ */
+struct conn_udp {
+    struct udp_socket sock;         /**< emb6 internal socket */
+    mutex_t mutex;                  /**< mutex for the connection */
+    kernel_pid_t waiting_thread;    /**< thread waiting for an incoming packet
+                                     *   on this connection */
+    struct {
+        uint16_t src_port;          /**< source port */
+        const ipv6_addr_t *src;     /**< source address */
+        const void *data;           /**< data of received packet */
+        size_t datalen;             /**< length of received packet data */
+    } recv_info;                    /**< info on received packet */
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EMB6_CONN_UDP_H_ */
+/** @} */

--- a/pkg/emb6/include/emb6/netdev2.h
+++ b/pkg/emb6/include/emb6/netdev2.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup pkgemb6_netdev2    netdev2 wrapper for emb6
+ * @ingroup pkg_emb6
+ * @brief
+ * @{
+ *
+ * @file
+ * @brief
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+#ifndef EMB6_NETDEV2_H_
+#define EMB6_NETDEV2_H_
+
+#include "net/netdev2.h"
+
+#include "emb6.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The emb6 network interface.
+ *
+ * @note    emb6 only supports one network interface.
+ *
+ * This variable is used by @ref board_conf() to set the interface for the
+ * stack.
+ */
+extern const s_nsIf_t emb6_netdev2_driver;
+
+/**
+ * @brief   Setup a network device as the emb6 interface.
+ *
+ * @param[in] dev   The network device for the interface
+ *
+ * @return 0 on success.
+ * @return <= 0 on error.
+ */
+int emb6_netdev2_setup(netdev2_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EMB6_NETDEV2_H_ */
+/** @} */

--- a/pkg/emb6/patches/0001-Add-RIOT-Makefiles.patch
+++ b/pkg/emb6/patches/0001-Add-RIOT-Makefiles.patch
@@ -1,0 +1,130 @@
+From 4b417436908a6823e631519f794a20644a467f19 Mon Sep 17 00:00:00 2001
+From: Martine Lenders <mail@martine-lenders.eu>
+Date: Mon, 11 Jan 2016 15:09:34 +0100
+Subject: [PATCH 1/4] Add RIOT Makefiles
+
+---
+ Makefile                             | 1 +
+ emb6/Makefile                        | 3 +++
+ emb6/src/mac/Makefile                | 3 +++
+ emb6/src/mac/llsec/Makefile          | 3 +++
+ emb6/src/net/ipv6/Makefile           | 3 +++
+ emb6/src/net/ipv6/multicast/Makefile | 3 +++
+ emb6/src/net/rpl/Makefile            | 3 +++
+ emb6/src/net/sicslowpan/Makefile     | 3 +++
+ emb6/src/tport/Makefile              | 3 +++
+ target/bsp/Makefile                  | 3 +++
+ utils/src/Makefile                   | 3 +++
+ 11 files changed, 31 insertions(+)
+ create mode 100644 Makefile
+ create mode 100644 emb6/Makefile
+ create mode 100644 emb6/src/mac/Makefile
+ create mode 100644 emb6/src/mac/llsec/Makefile
+ create mode 100644 emb6/src/net/ipv6/Makefile
+ create mode 100644 emb6/src/net/ipv6/multicast/Makefile
+ create mode 100644 emb6/src/net/rpl/Makefile
+ create mode 100644 emb6/src/net/sicslowpan/Makefile
+ create mode 100644 emb6/src/tport/Makefile
+ create mode 100644 target/bsp/Makefile
+ create mode 100644 utils/src/Makefile
+
+diff --git a/Makefile b/Makefile
+new file mode 100644
+index 0000000..48422e9
+--- /dev/null
++++ b/Makefile
+@@ -0,0 +1 @@
++include $(RIOTBASE)/Makefile.base
+diff --git a/emb6/Makefile b/emb6/Makefile
+new file mode 100644
+index 0000000..c2ec39f
+--- /dev/null
++++ b/emb6/Makefile
+@@ -0,0 +1,3 @@
++MODULE := emb6_common
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/emb6/src/mac/Makefile b/emb6/src/mac/Makefile
+new file mode 100644
+index 0000000..d0472d8
+--- /dev/null
++++ b/emb6/src/mac/Makefile
+@@ -0,0 +1,3 @@
++MODULE := emb6_mac
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/emb6/src/mac/llsec/Makefile b/emb6/src/mac/llsec/Makefile
+new file mode 100644
+index 0000000..e13ee7f
+--- /dev/null
++++ b/emb6/src/mac/llsec/Makefile
+@@ -0,0 +1,3 @@
++MODULE := emb6_llsec
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/emb6/src/net/ipv6/Makefile b/emb6/src/net/ipv6/Makefile
+new file mode 100644
+index 0000000..844e39c
+--- /dev/null
++++ b/emb6/src/net/ipv6/Makefile
+@@ -0,0 +1,3 @@
++MODULE := emb6_ipv6
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/emb6/src/net/ipv6/multicast/Makefile b/emb6/src/net/ipv6/multicast/Makefile
+new file mode 100644
+index 0000000..f1c3f1e
+--- /dev/null
++++ b/emb6/src/net/ipv6/multicast/Makefile
+@@ -0,0 +1,3 @@
++MODULE := emb6_ipv6_multicast
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/emb6/src/net/rpl/Makefile b/emb6/src/net/rpl/Makefile
+new file mode 100644
+index 0000000..2fd941c
+--- /dev/null
++++ b/emb6/src/net/rpl/Makefile
+@@ -0,0 +1,3 @@
++MODULE := emb6_rpl
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/emb6/src/net/sicslowpan/Makefile b/emb6/src/net/sicslowpan/Makefile
+new file mode 100644
+index 0000000..9e14df3
+--- /dev/null
++++ b/emb6/src/net/sicslowpan/Makefile
+@@ -0,0 +1,3 @@
++MODULE := emb6_sicslowpan
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/emb6/src/tport/Makefile b/emb6/src/tport/Makefile
+new file mode 100644
+index 0000000..1b0ca7c
+--- /dev/null
++++ b/emb6/src/tport/Makefile
+@@ -0,0 +1,3 @@
++MODULE := emb6_sock
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/target/bsp/Makefile b/target/bsp/Makefile
+new file mode 100644
+index 0000000..ce548bd
+--- /dev/null
++++ b/target/bsp/Makefile
+@@ -0,0 +1,3 @@
++MODULE := emb6_bsp
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/utils/src/Makefile b/utils/src/Makefile
+new file mode 100644
+index 0000000..c9aa897
+--- /dev/null
++++ b/utils/src/Makefile
+@@ -0,0 +1,3 @@
++MODULE := emb6_utils
++
++include $(RIOTBASE)/Makefile.base
+--
+1.9.1
+

--- a/pkg/emb6/patches/0002-Rename-colliding-files-and-functions.patch
+++ b/pkg/emb6/patches/0002-Rename-colliding-files-and-functions.patch
@@ -1,0 +1,1553 @@
+From de750156c6f7f9d69f6974203b27aa22d5695bbb Mon Sep 17 00:00:00 2001
+From: Martine Lenders <mail@martine-lenders.eu>
+Date: Thu, 4 Feb 2016 22:15:23 +0100
+Subject: [PATCH 2/4] Rename colliding files and functions
+
+---
+ emb6/emb6.c                                    |   2 +-
+ emb6/inc/apl/rest-engine/rest-engine.h         |   2 +-
+ emb6/inc/net/ipv6/uip-ds6-route.h              |   2 +-
+ emb6/inc/net/rpl/rpl-private.h                 |   2 +-
+ emb6/inc/net/rpl/rpl.h                         |   2 +-
+ emb6/src/apl/er-coap/er-coap-observe.c         |   2 +-
+ emb6/src/apl/er-coap/er-coap-transactions.c    |   4 +-
+ emb6/src/apl/er-coap/er-coap.c                 |   2 +-
+ emb6/src/apl/rest-engine/rest-engine.c         |   4 +-
+ emb6/src/mac/framer-802154.c                   |   2 +-
+ emb6/src/mac/sicslowmac.c                      |   2 +-
+ emb6/src/net/ipv6/multicast/roll-tm.c          |   2 +-
+ emb6/src/net/ipv6/multicast/smrf.c             |   2 +-
+ emb6/src/net/ipv6/multicast/uip-mcast6-route.c |   4 +-
+ emb6/src/net/ipv6/nbr-table.c                  |   4 +-
+ emb6/src/net/ipv6/uip-ds6-nbr.c                |   2 +-
+ emb6/src/net/ipv6/uip-ds6-route.c              |   6 +-
+ emb6/src/net/ipv6/uip-ds6.c                    |   6 +-
+ emb6/src/net/ipv6/uip-icmp6.c                  |   4 +-
+ emb6/src/net/ipv6/uip-nameserver.c             |   4 +-
+ emb6/src/net/ipv6/uip-nd6.c                    |   2 +-
+ emb6/src/net/rpl/rpl-dag.c                     |   2 +-
+ emb6/src/net/rpl/rpl-timers.c                  |   2 +-
+ emb6/src/net/sicslowpan/sicslowpan.c           |   2 +-
+ emb6/src/tport/tcp-socket.c                    |   4 +-
+ emb6/src/tport/udp-socket.c                    |   2 +-
+ target/bsp/bsp.c                               |   2 +-
+ target/if/at86rf212b/at86rf212b.c              |   2 +-
+ utils/inc/clist.h                              | 163 -------------------------
+ utils/inc/emb6_clist.h                         | 163 +++++++++++++++++++++++++
+ utils/inc/emb6_random.h                        |  57 +++++++++
+ utils/inc/emb6_ringbuffer.h                    | 162 ++++++++++++++++++++++++
+ utils/inc/random.h                             |  57 ---------
+ utils/inc/ringbuffer.h                         | 162 ------------------------
+ utils/inc/timer.h                              |   4 +-
+ utils/src/ctimer.c                             |   8 +-
+ utils/src/etimer.c                             |   6 +-
+ utils/src/evproc.c                             |   2 +-
+ utils/src/list.c                               |   4 +-
+ utils/src/mmem.c                               |   4 +-
+ utils/src/queuebuf.c                           |   4 +-
+ utils/src/random.c                             |   2 +-
+ utils/src/ringbuffer.c                         |   2 +-
+ utils/src/timer.c                              |   6 +-
+ 44 files changed, 442 insertions(+), 442 deletions(-)
+ delete mode 100644 utils/inc/clist.h
+ create mode 100644 utils/inc/emb6_clist.h
+ create mode 100644 utils/inc/emb6_random.h
+ create mode 100644 utils/inc/emb6_ringbuffer.h
+ delete mode 100644 utils/inc/random.h
+ delete mode 100644 utils/inc/ringbuffer.h
+
+diff --git a/emb6/emb6.c b/emb6/emb6.c
+index 2912049..682b7c2 100644
+--- a/emb6/emb6.c
++++ b/emb6/emb6.c
+@@ -64,7 +64,7 @@
+ #include "queuebuf.h"
+ #include "linkaddr.h"
+ #include "ctimer.h"
+-#include "random.h"
++#include "emb6_random.h"
+
+ #if NETSTACK_CONF_WITH_IPV6
+ #include "uip-ds6.h"
+diff --git a/emb6/inc/apl/rest-engine/rest-engine.h b/emb6/inc/apl/rest-engine/rest-engine.h
+index 2c16c2b..fc0dca5 100644
+--- a/emb6/inc/apl/rest-engine/rest-engine.h
++++ b/emb6/inc/apl/rest-engine/rest-engine.h
+@@ -41,7 +41,7 @@
+ #define REST_ENGINE_H_
+
+
+-#include "clist.h"
++#include "emb6_clist.h"
+ #include "etimer.h"
+
+
+diff --git a/emb6/inc/net/ipv6/uip-ds6-route.h b/emb6/inc/net/ipv6/uip-ds6-route.h
+index 000b327..31ed0e9 100644
+--- a/emb6/inc/net/ipv6/uip-ds6-route.h
++++ b/emb6/inc/net/ipv6/uip-ds6-route.h
+@@ -42,7 +42,7 @@
+ #define UIP_DS6_ROUTE_H
+
+ #include "stimer.h"
+-#include "clist.h"
++#include "emb6_clist.h"
+
+ void uip_ds6_route_init(void);
+
+diff --git a/emb6/inc/net/rpl/rpl-private.h b/emb6/inc/net/rpl/rpl-private.h
+index 9da5744..5ded041 100644
+--- a/emb6/inc/net/rpl/rpl-private.h
++++ b/emb6/inc/net/rpl/rpl-private.h
+@@ -39,7 +39,7 @@
+
+ #include "rpl.h"
+
+-#include "clist.h"
++#include "emb6_clist.h"
+ #include "uip.h"
+ #include "bsp.h"
+ #include "ctimer.h"
+diff --git a/emb6/inc/net/rpl/rpl.h b/emb6/inc/net/rpl/rpl.h
+index 574ca5e..7269948 100644
+--- a/emb6/inc/net/rpl/rpl.h
++++ b/emb6/inc/net/rpl/rpl.h
+@@ -41,7 +41,7 @@
+ #include "emb6_conf.h"
+ #include "emb6.h"
+
+-#include "clist.h"
++#include "emb6_clist.h"
+ #include "uip.h"
+ #include "uip-ds6.h"
+ #include "ctimer.h"
+diff --git a/emb6/src/apl/er-coap/er-coap-observe.c b/emb6/src/apl/er-coap/er-coap-observe.c
+index 57754ac..6be690e 100644
+--- a/emb6/src/apl/er-coap/er-coap-observe.c
++++ b/emb6/src/apl/er-coap/er-coap-observe.c
+@@ -80,7 +80,7 @@ coap_add_observer(uip_ipaddr_t *addr, uint16_t port, const uint8_t *token,
+     PRINTF("Adding observer (%u/%u) for /%s [0x%02X%02X]\n",
+            list_length(observers_list) + 1, COAP_MAX_OBSERVERS,
+            o->url, o->token[0], o->token[1]);
+-    list_add(observers_list, o);
++    emb6_list_add(observers_list, o);
+   }
+
+   return o;
+diff --git a/emb6/src/apl/er-coap/er-coap-transactions.c b/emb6/src/apl/er-coap/er-coap-transactions.c
+index e40f4c9..4b3ffe1 100644
+--- a/emb6/src/apl/er-coap/er-coap-transactions.c
++++ b/emb6/src/apl/er-coap/er-coap-transactions.c
+@@ -43,7 +43,7 @@
+ #include "timer.h"
+ #include "evproc.h"
+ #include "memb.h"
+-#include "random.h"
++#include "emb6_random.h"
+
+ #include "tcpip.h"
+
+@@ -84,7 +84,7 @@ coap_new_transaction(uint16_t mid, uip_ipaddr_t *addr, uint16_t port)
+     t->addr = *addr;
+     t->port = port;
+
+-    list_add(transactions_list, t); /* list itself makes sure same element is not added twice */
++    emb6_list_add(transactions_list, t); /* list itself makes sure same element is not added twice */
+   }
+
+   return t;
+diff --git a/emb6/src/apl/er-coap/er-coap.c b/emb6/src/apl/er-coap/er-coap.c
+index 40f6874..a8125a2 100644
+--- a/emb6/src/apl/er-coap/er-coap.c
++++ b/emb6/src/apl/er-coap/er-coap.c
+@@ -39,7 +39,7 @@
+ #include <string.h>
+ #include <stdio.h>
+
+-#include "random.h"
++#include "emb6_random.h"
+
+ #include "er-coap.h"
+ #include "er-coap-transactions.h"
+diff --git a/emb6/src/apl/rest-engine/rest-engine.c b/emb6/src/apl/rest-engine/rest-engine.c
+index fd8d1ba..818f326 100644
+--- a/emb6/src/apl/rest-engine/rest-engine.c
++++ b/emb6/src/apl/rest-engine/rest-engine.c
+@@ -104,7 +104,7 @@ rest_activate_resource(resource_t *resource, char *path)
+ {
+   resource->url = path;
+   struct periodic_resource_s * periodic = resource->un_handler.periodic;
+-  list_add(restful_services, resource);
++  emb6_list_add(restful_services, resource);
+
+   PRINTF("Activating: %s\n\r", resource->url);
+
+@@ -112,7 +112,7 @@ rest_activate_resource(resource_t *resource, char *path)
+   if((resource->flags & IS_PERIODIC) && periodic->periodic_handler
+      && periodic->period) {
+     PRINTF("Periodic resource: %p (%s)\n", periodic,periodic->resource->url);
+-    list_add(restful_periodic_services, periodic);
++    emb6_list_add(restful_periodic_services, periodic);
+   }
+
+   for(periodic_resource =
+diff --git a/emb6/src/mac/framer-802154.c b/emb6/src/mac/framer-802154.c
+index f99486d..359ee6b 100644
+--- a/emb6/src/mac/framer-802154.c
++++ b/emb6/src/mac/framer-802154.c
+@@ -45,7 +45,7 @@
+ #include "frame802154.h"
+ #include "llsec802154.h"
+ #include "packetbuf.h"
+-#include "random.h"
++#include "emb6_random.h"
+
+
+
+diff --git a/emb6/src/mac/sicslowmac.c b/emb6/src/mac/sicslowmac.c
+index 7219fa8..c741131 100644
+--- a/emb6/src/mac/sicslowmac.c
++++ b/emb6/src/mac/sicslowmac.c
+@@ -51,7 +51,7 @@
+ #include "frame802154.h"
+ #include "packetbuf.h"
+ #include "queuebuf.h"
+-#include "random.h"
++#include "emb6_random.h"
+
+ #define DEBUG DEBUG_NONE
+
+diff --git a/emb6/src/net/ipv6/multicast/roll-tm.c b/emb6/src/net/ipv6/multicast/roll-tm.c
+index 8fb1717..8b36300 100644
+--- a/emb6/src/net/ipv6/multicast/roll-tm.c
++++ b/emb6/src/net/ipv6/multicast/roll-tm.c
+@@ -51,7 +51,7 @@
+ #include "roll-tm.h"
+ #include "bsp.h"
+ #include "ctimer.h"
+-#include "random.h"
++#include "emb6_random.h"
+ //#include "dev/watchdog.h"
+ //#include <string.h>
+
+diff --git a/emb6/src/net/ipv6/multicast/smrf.c b/emb6/src/net/ipv6/multicast/smrf.c
+index 474c41d..9b4a3a5 100644
+--- a/emb6/src/net/ipv6/multicast/smrf.c
++++ b/emb6/src/net/ipv6/multicast/smrf.c
+@@ -52,7 +52,7 @@
+ #include "smrf.h"
+ #include "rpl.h"
+ #include "packetbuf.h"
+-#include "random.h"
++#include "emb6_random.h"
+ //#include "net/netstack.h"
+
+ #define DEBUG DEBUG_NONE
+diff --git a/emb6/src/net/ipv6/multicast/uip-mcast6-route.c b/emb6/src/net/ipv6/multicast/uip-mcast6-route.c
+index aa0caff..55d245d 100644
+--- a/emb6/src/net/ipv6/multicast/uip-mcast6-route.c
++++ b/emb6/src/net/ipv6/multicast/uip-mcast6-route.c
+@@ -43,7 +43,7 @@
+ //#include "contiki.h"
+ #include "emb6_conf.h"
+ #include "emb6.h"
+-#include "clist.h"
++#include "emb6_clist.h"
+ #include "memb.h"
+ #include "uip.h"
+ #include "uip-mcast6-route.h"
+@@ -88,7 +88,7 @@ uip_mcast6_route_add(uip_ipaddr_t *group)
+     if(locmcastrt == NULL) {
+       return NULL;
+     }
+-    list_add(mcast_route_list, locmcastrt);
++    emb6_list_add(mcast_route_list, locmcastrt);
+   }
+
+   /* Reaching here means we either found the prefix or allocated a new one */
+diff --git a/emb6/src/net/ipv6/nbr-table.c b/emb6/src/net/ipv6/nbr-table.c
+index 7dedece..3719135 100644
+--- a/emb6/src/net/ipv6/nbr-table.c
++++ b/emb6/src/net/ipv6/nbr-table.c
+@@ -41,7 +41,7 @@
+ #include <stddef.h>
+ #include <string.h>
+ #include "memb.h"
+-#include "clist.h"
++#include "emb6_clist.h"
+ #include "nbr-table.h"
+
+ /* List of link-layer addresses of the neighbors, used as key in the tables */
+@@ -295,7 +295,7 @@ nbr_table_add_lladdr(nbr_table_t *table, const linkaddr_t *lladdr)
+     }
+
+     /* Add neighbor to list */
+-    list_add(nbr_table_keys, key);
++    emb6_list_add(nbr_table_keys, key);
+
+     /* Get index from newly allocated neighbor */
+     index = index_from_key(key);
+diff --git a/emb6/src/net/ipv6/uip-ds6-nbr.c b/emb6/src/net/ipv6/uip-ds6-nbr.c
+index 360fdbc..53ad8da 100644
+--- a/emb6/src/net/ipv6/uip-ds6-nbr.c
++++ b/emb6/src/net/ipv6/uip-ds6-nbr.c
+@@ -46,7 +46,7 @@
+ #include <string.h>
+ #include <stdlib.h>
+ #include <stddef.h>
+-#include "clist.h"
++#include "emb6_clist.h"
+ #include "linkaddr.h"
+ #include "packetbuf.h"
+ #include "uip-ds6-nbr.h"
+diff --git a/emb6/src/net/ipv6/uip-ds6-route.c b/emb6/src/net/ipv6/uip-ds6-route.c
+index c732f78..0bd1da5 100644
+--- a/emb6/src/net/ipv6/uip-ds6-route.c
++++ b/emb6/src/net/ipv6/uip-ds6-route.c
+@@ -42,7 +42,7 @@
+ #include "uip-ds6.h"
+ #include "uip.h"
+
+-#include "clist.h"
++#include "emb6_clist.h"
+ #include "memb.h"
+ #include "nbr-table.h"
+
+@@ -133,7 +133,7 @@ uip_ds6_notification_add(struct uip_ds6_notification *n,
+ {
+   if(n != NULL && c != NULL) {
+     n->callback = c;
+-    list_add(notificationlist, n);
++    emb6_list_add(notificationlist, n);
+   }
+ }
+ /*---------------------------------------------------------------------------*/
+@@ -375,7 +375,7 @@ uip_ds6_route_add(uip_ipaddr_t *ipaddr, uint8_t length,
+
+     nbrr->route = r;
+     /* Add the route to this neighbor */
+-    list_add(routes->route_list, nbrr);
++    emb6_list_add(routes->route_list, nbrr);
+     r->neighbor_routes = routes;
+     num_routes++;
+
+diff --git a/emb6/src/net/ipv6/uip-ds6.c b/emb6/src/net/ipv6/uip-ds6.c
+index 0e2f16a..ad3f4cd 100644
+--- a/emb6/src/net/ipv6/uip-ds6.c
++++ b/emb6/src/net/ipv6/uip-ds6.c
+@@ -49,7 +49,7 @@
+ #include <string.h>
+ #include <stdlib.h>
+ #include <stddef.h>
+-#include "random.h"
++#include "emb6_random.h"
+ #include "uip-nd6.h"
+ #include "uip-ds6.h"
+ #include "uip-packetqueue.h"
+@@ -343,7 +343,7 @@ uip_ds6_addr_add(uip_ipaddr_t *ipaddr, unsigned long vlifetime, uint8_t type)
+     }
+ #if UIP_ND6_DEF_MAXDADNS > 0
+     locaddr->state = ADDR_TENTATIVE;
+-    timer_set(&locaddr->dadtimer,
++    timer_emb6_set(&locaddr->dadtimer,
+               random_rand() % (UIP_ND6_MAX_RTR_SOLICITATION_DELAY *
+                       bsp_get(E_BSP_GET_TRES)));
+     locaddr->dadnscount = 0;
+@@ -591,7 +591,7 @@ uip_ds6_dad(uip_ds6_addr_t *addr)
+   if(addr->dadnscount < uip_ds6_if.maxdadns) {
+     uip_nd6_ns_output(NULL, NULL, &addr->ipaddr);
+     addr->dadnscount++;
+-    timer_set(&addr->dadtimer,
++    timer_emb6_set(&addr->dadtimer,
+               uip_ds6_if.retrans_timer / 1000 * bsp_get(E_BSP_GET_TRES));
+     return;
+   }
+diff --git a/emb6/src/net/ipv6/uip-icmp6.c b/emb6/src/net/ipv6/uip-icmp6.c
+index 00828a3..484d0bf 100644
+--- a/emb6/src/net/ipv6/uip-icmp6.c
++++ b/emb6/src/net/ipv6/uip-icmp6.c
+@@ -114,7 +114,7 @@ uip_icmp6_input(uint8_t type, uint8_t icode)
+ void
+ uip_icmp6_register_input_handler(uip_icmp6_input_handler_t *handler)
+ {
+-  list_add(input_handler_list, handler);
++  emb6_list_add(input_handler_list, handler);
+ }
+ /*---------------------------------------------------------------------------*/
+ static void
+@@ -393,7 +393,7 @@ uip_icmp6_echo_reply_callback_add(struct uip_icmp6_echo_reply_notification *n,
+ {
+     if(n != NULL && c != NULL) {
+         n->callback = c;
+-        list_add(echo_reply_callback_list, n);
++        emb6_list_add(echo_reply_callback_list, n);
+     }
+ }
+ /*---------------------------------------------------------------------------*/
+diff --git a/emb6/src/net/ipv6/uip-nameserver.c b/emb6/src/net/ipv6/uip-nameserver.c
+index 9701b26..175e2be 100644
+--- a/emb6/src/net/ipv6/uip-nameserver.c
++++ b/emb6/src/net/ipv6/uip-nameserver.c
+@@ -46,7 +46,7 @@
+ #include "uip.h"
+ #include "uip-nameserver.h"
+ #include "bsp.h"
+-#include "clist.h"
++#include "emb6_clist.h"
+ #include "memb.h"
+
+ #include <string.h>
+@@ -113,7 +113,7 @@ uip_nameserver_update(uip_ipaddr_t *nameserver, uint32_t lifetime)
+
+   if(e == NULL) {
+     if((e = memb_alloc(&dnsmemb)) != NULL) {
+-      list_add(dns, e);
++      emb6_list_add(dns, e);
+     } else {
+       uip_nameserver_record *p;
+       for(e = list_head(dns), p = list_head(dns); p != NULL;
+diff --git a/emb6/src/net/ipv6/uip-nd6.c b/emb6/src/net/ipv6/uip-nd6.c
+index 8758a8f..f04b6b3 100644
+--- a/emb6/src/net/ipv6/uip-nd6.c
++++ b/emb6/src/net/ipv6/uip-nd6.c
+@@ -78,7 +78,7 @@
+ #include "uip-ds6.h"
+ #include "uip-nameserver.h"
+ #include "bsp.h"
+-#include "random.h"
++#include "emb6_random.h"
+
+ /*------------------------------------------------------------------*/
+ #define DEBUG DEBUG_NONE
+diff --git a/emb6/src/net/rpl/rpl-dag.c b/emb6/src/net/rpl/rpl-dag.c
+index cc11eab..4a85b70 100644
+--- a/emb6/src/net/rpl/rpl-dag.c
++++ b/emb6/src/net/rpl/rpl-dag.c
+@@ -50,7 +50,7 @@
+ #if UIP_CONF_IPV6_MULTICAST
+ #include "uip-mcast6.h"
+ #endif
+-#include "clist.h"
++#include "emb6_clist.h"
+ #include "memb.h"
+ #include "ctimer.h"
+
+diff --git a/emb6/src/net/rpl/rpl-timers.c b/emb6/src/net/rpl/rpl-timers.c
+index 9b235d4..439b45d 100644
+--- a/emb6/src/net/rpl/rpl-timers.c
++++ b/emb6/src/net/rpl/rpl-timers.c
+@@ -47,7 +47,7 @@
+ #if UIP_CONF_IPV6_MULTICAST
+ #include "uip-mcast6.h"
+ #endif
+-#include "random.h"
++#include "emb6_random.h"
+ #include "ctimer.h"
+
+ #define DEBUG DEBUG_NONE
+diff --git a/emb6/src/net/sicslowpan/sicslowpan.c b/emb6/src/net/sicslowpan/sicslowpan.c
+index 8c909cf..79afefe 100644
+--- a/emb6/src/net/sicslowpan/sicslowpan.c
++++ b/emb6/src/net/sicslowpan/sicslowpan.c
+@@ -1738,7 +1738,7 @@ input(void)
+
+       sicslowpan_len = frag_size;
+       reass_tag = frag_tag;
+-      timer_set(&reass_timer, SICSLOWPAN_REASS_MAXAGE * bsp_get(E_BSP_GET_TRES));
++      timer_emb6_set(&reass_timer, SICSLOWPAN_REASS_MAXAGE * bsp_get(E_BSP_GET_TRES));
+       PRINTFI("sicslowpan input: INIT FRAGMENTATION (len %d, tag %d)\n\r",
+              sicslowpan_len, reass_tag);
+       linkaddr_copy(&frag_sender, packetbuf_addr(PACKETBUF_ADDR_SENDER));
+diff --git a/emb6/src/tport/tcp-socket.c b/emb6/src/tport/tcp-socket.c
+index 3974bad..e5702a6 100644
+--- a/emb6/src/tport/tcp-socket.c
++++ b/emb6/src/tport/tcp-socket.c
+@@ -31,7 +31,7 @@
+
+ #include "emb6.h"
+ #include "bsp.h"
+-#include "clist.h"
++#include "emb6_clist.h"
+ #include "etimer.h"
+
+ #include "tcp-socket.h"
+@@ -276,7 +276,7 @@ tcp_socket_register(struct tcp_socket *s, void *ptr,
+   s->output_data_maxlen = output_databuf_len;
+   s->input_callback = input_callback;
+   s->event_callback = event_callback;
+-  list_add(socketlist, s);
++  emb6_list_add(socketlist, s);
+
+   s->listen_port = 0;
+   s->flags = TCP_SOCKET_FLAGS_NONE;
+diff --git a/emb6/src/tport/udp-socket.c b/emb6/src/tport/udp-socket.c
+index be27a5f..545f6bd 100644
+--- a/emb6/src/tport/udp-socket.c
++++ b/emb6/src/tport/udp-socket.c
+@@ -31,7 +31,7 @@
+
+ #include "emb6.h"
+ #include "bsp.h"
+-#include "clist.h"
++#include "emb6_clist.h"
+ #include "etimer.h"
+ #include "emb6_conf.h"
+ #include "tcpip.h"
+diff --git a/target/bsp/bsp.c b/target/bsp/bsp.c
+index 85c9976..bf266b8 100644
+--- a/target/bsp/bsp.c
++++ b/target/bsp/bsp.c
+@@ -63,7 +63,7 @@
+ #include "board_conf.h"
+
+ #include "etimer.h"
+-#include "random.h"
++#include "emb6_random.h"
+ #include "evproc.h"
+ /*==============================================================================
+                                      MACROS
+diff --git a/target/if/at86rf212b/at86rf212b.c b/target/if/at86rf212b/at86rf212b.c
+index aba87d5..c059568 100644
+--- a/target/if/at86rf212b/at86rf212b.c
++++ b/target/if/at86rf212b/at86rf212b.c
+@@ -67,7 +67,7 @@
+ #include "ctimer.h"
+ #include "packetbuf.h"
+
+-#include "ringbuffer.h"
++#include "emb6_ringbuffer.h"
+
+ /*==============================================================================
+                                      MACROS
+diff --git a/utils/inc/clist.h b/utils/inc/clist.h
+deleted file mode 100644
+index 0e26be8..0000000
+--- a/utils/inc/clist.h
++++ /dev/null
+@@ -1,163 +0,0 @@
+-/*
+- * Copyright (c) 2004, Swedish Institute of Computer Science.
+- * All rights reserved.
+- *
+- * Redistribution and use in source and binary forms, with or without
+- * modification, are permitted provided that the following conditions
+- * are met:
+- * 1. Redistributions of source code must retain the above copyright
+- *    notice, this list of conditions and the following disclaimer.
+- * 2. Redistributions in binary form must reproduce the above copyright
+- *    notice, this list of conditions and the following disclaimer in the
+- *    documentation and/or other materials provided with the distribution.
+- * 3. Neither the name of the Institute nor the names of its contributors
+- *    may be used to endorse or promote products derived from this software
+- *    without specific prior written permission.
+- *
+- * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+- * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+- * SUCH DAMAGE.
+- *
+- * This file is part of the Contiki operating system.
+- *
+- * Author: Adam Dunkels <adam@sics.se>
+- *
+- * $Id: clist.h,v 1.5 2010/09/13 13:31:00 adamdunkels Exp $
+- */
+-
+-/**
+- *   \addtogroup utils
+- *   @{ */
+-/** \addtogroup lib
+-    @{ */
+-/**
+- * \defgroup list Linked list library
+- *
+- * The linked list library provides a set of functions for
+- * manipulating linked lists.
+- *
+- * A linked list is made up of elements where the first element \b
+- * must be a pointer. This pointer is used by the linked list library
+- * to form lists of the elements.
+- *
+- * Lists are declared with the LIST() macro. The declaration specifies
+- * the name of the list that later is used with all list functions.
+- *
+- * Lists can be manipulated by inserting or removing elements from
+- * either sides of the list (list_push(), list_add(), list_pop(),
+- * list_chop()). A specified element can also be removed from inside a
+- * list with list_remove(). The head and tail of a list can be
+- * extracted using list_head() and list_tail(), respectively.
+- *
+- * @{
+- */
+-
+-/**
+- * \file
+- * Linked list manipulation routines.
+- * \author Adam Dunkels <adam@sics.se>
+- *
+- *
+- */
+-
+-#ifndef LIST_H_
+-#define LIST_H_
+-
+-#define LIST_CONCAT2(s1, s2) s1##s2
+-#define LIST_CONCAT(s1, s2) LIST_CONCAT2(s1, s2)
+-
+-/**
+- * Declare a linked list.
+- *
+- * This macro declares a linked list with the specified \c type. The
+- * type \b must be a structure (\c struct) with its first element
+- * being a pointer. This pointer is used by the linked list library to
+- * form the linked lists.
+- *
+- * The list variable is declared as static to make it easy to use in a
+- * single C module without unnecessarily exporting the name to other
+- * modules.
+- *
+- * \param name The name of the list.
+- */
+-#define LIST(name) \
+-         static void *LIST_CONCAT(name,_list) = NULL; \
+-         static list_t name = (list_t)&LIST_CONCAT(name,_list)
+-
+-/**
+- * Declare a linked list inside a structure declaraction.
+- *
+- * This macro declares a linked list with the specified \c type. The
+- * type \b must be a structure (\c struct) with its first element
+- * being a pointer. This pointer is used by the linked list library to
+- * form the linked lists.
+- *
+- * Internally, the list is defined as two items: the list itself and a
+- * pointer to the list. The pointer has the name of the parameter to
+- * the macro and the name of the list is a concatenation of the name
+- * and the suffix "_list". The pointer must point to the list for the
+- * list to work. Thus the list must be initialized before using.
+- *
+- * The list is initialized with the LIST_STRUCT_INIT() macro.
+- *
+- * \param name The name of the list.
+- */
+-#define LIST_STRUCT(name) \
+-         void *LIST_CONCAT(name,_list); \
+-         list_t name
+-
+-/**
+- * Initialize a linked list that is part of a structure.
+- *
+- * This macro sets up the internal pointers in a list that has been
+- * defined as part of a struct. This macro must be called before using
+- * the list.
+- *
+- * \param struct_ptr A pointer to the struct
+- * \param name The name of the list.
+- */
+-#define LIST_STRUCT_INIT(struct_ptr, name)                              \
+-    do {                                                                \
+-       (struct_ptr)->name = &((struct_ptr)->LIST_CONCAT(name,_list));   \
+-       (struct_ptr)->LIST_CONCAT(name,_list) = NULL;                    \
+-       list_init((struct_ptr)->name);                                   \
+-    } while(0)
+-
+-/**
+- * The linked list type.
+- *
+- */
+-typedef void ** list_t;
+-
+-void   list_init(list_t list);
+-void * list_head(list_t list);
+-void * list_tail(list_t list);
+-void * list_pop (list_t list);
+-void   list_push(list_t list, void *item);
+-
+-void * list_chop(list_t list);
+-
+-void   list_add(list_t list, void *item);
+-void   list_remove(list_t list, void *item);
+-
+-int    list_length(list_t list);
+-
+-void   list_copy(list_t dest, list_t src);
+-
+-void   list_insert(list_t list, void *previtem, void *newitem);
+-
+-void * list_item_next(void *item);
+-
+-#endif /* LIST_H_ */
+-
+-/** @} */
+-/** @} */
+-/** @} */
+diff --git a/utils/inc/emb6_clist.h b/utils/inc/emb6_clist.h
+new file mode 100644
+index 0000000..f65f01e
+--- /dev/null
++++ b/utils/inc/emb6_clist.h
+@@ -0,0 +1,163 @@
++/*
++ * Copyright (c) 2004, Swedish Institute of Computer Science.
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 3. Neither the name of the Institute nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ *
++ * This file is part of the Contiki operating system.
++ *
++ * Author: Adam Dunkels <adam@sics.se>
++ *
++ * $Id: emb6_clist.h,v 1.5 2010/09/13 13:31:00 adamdunkels Exp $
++ */
++
++/**
++ *   \addtogroup utils
++ *   @{ */
++/** \addtogroup lib
++    @{ */
++/**
++ * \defgroup list Linked list library
++ *
++ * The linked list library provides a set of functions for
++ * manipulating linked lists.
++ *
++ * A linked list is made up of elements where the first element \b
++ * must be a pointer. This pointer is used by the linked list library
++ * to form lists of the elements.
++ *
++ * Lists are declared with the LIST() macro. The declaration specifies
++ * the name of the list that later is used with all list functions.
++ *
++ * Lists can be manipulated by inserting or removing elements from
++ * either sides of the list (list_push(), emb6_list_add(), list_pop(),
++ * list_chop()). A specified element can also be removed from inside a
++ * list with list_remove(). The head and tail of a list can be
++ * extracted using list_head() and list_tail(), respectively.
++ *
++ * @{
++ */
++
++/**
++ * \file
++ * Linked list manipulation routines.
++ * \author Adam Dunkels <adam@sics.se>
++ *
++ *
++ */
++
++#ifndef LIST_H_
++#define LIST_H_
++
++#define LIST_CONCAT2(s1, s2) s1##s2
++#define LIST_CONCAT(s1, s2) LIST_CONCAT2(s1, s2)
++
++/**
++ * Declare a linked list.
++ *
++ * This macro declares a linked list with the specified \c type. The
++ * type \b must be a structure (\c struct) with its first element
++ * being a pointer. This pointer is used by the linked list library to
++ * form the linked lists.
++ *
++ * The list variable is declared as static to make it easy to use in a
++ * single C module without unnecessarily exporting the name to other
++ * modules.
++ *
++ * \param name The name of the list.
++ */
++#define LIST(name) \
++         static void *LIST_CONCAT(name,_list) = NULL; \
++         static list_t name = (list_t)&LIST_CONCAT(name,_list)
++
++/**
++ * Declare a linked list inside a structure declaraction.
++ *
++ * This macro declares a linked list with the specified \c type. The
++ * type \b must be a structure (\c struct) with its first element
++ * being a pointer. This pointer is used by the linked list library to
++ * form the linked lists.
++ *
++ * Internally, the list is defined as two items: the list itself and a
++ * pointer to the list. The pointer has the name of the parameter to
++ * the macro and the name of the list is a concatenation of the name
++ * and the suffix "_list". The pointer must point to the list for the
++ * list to work. Thus the list must be initialized before using.
++ *
++ * The list is initialized with the LIST_STRUCT_INIT() macro.
++ *
++ * \param name The name of the list.
++ */
++#define LIST_STRUCT(name) \
++         void *LIST_CONCAT(name,_list); \
++         list_t name
++
++/**
++ * Initialize a linked list that is part of a structure.
++ *
++ * This macro sets up the internal pointers in a list that has been
++ * defined as part of a struct. This macro must be called before using
++ * the list.
++ *
++ * \param struct_ptr A pointer to the struct
++ * \param name The name of the list.
++ */
++#define LIST_STRUCT_INIT(struct_ptr, name)                              \
++    do {                                                                \
++       (struct_ptr)->name = &((struct_ptr)->LIST_CONCAT(name,_list));   \
++       (struct_ptr)->LIST_CONCAT(name,_list) = NULL;                    \
++       list_init((struct_ptr)->name);                                   \
++    } while(0)
++
++/**
++ * The linked list type.
++ *
++ */
++typedef void ** list_t;
++
++void   list_init(list_t list);
++void * list_head(list_t list);
++void * list_tail(list_t list);
++void * list_pop (list_t list);
++void   list_push(list_t list, void *item);
++
++void * list_chop(list_t list);
++
++void   emb6_list_add(list_t list, void *item);
++void   list_remove(list_t list, void *item);
++
++int    list_length(list_t list);
++
++void   list_copy(list_t dest, list_t src);
++
++void   list_insert(list_t list, void *previtem, void *newitem);
++
++void * list_item_next(void *item);
++
++#endif /* LIST_H_ */
++
++/** @} */
++/** @} */
++/** @} */
+diff --git a/utils/inc/emb6_random.h b/utils/inc/emb6_random.h
+new file mode 100644
+index 0000000..e59a500
+--- /dev/null
++++ b/utils/inc/emb6_random.h
+@@ -0,0 +1,57 @@
++/*
++ * Copyright (c) 2005, Swedish Institute of Computer Science
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 3. Neither the name of the Institute nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ *
++ * This file is part of the Contiki operating system.
++ *
++ * @(#)$Id: emb6_random.h,v 1.2 2010/12/13 16:52:02 dak664 Exp $
++ */
++/**
++ * \file
++ *         A brief description the file
++ */
++#ifndef RANDOM_H_
++#define RANDOM_H_
++
++/*
++ * Initialize the pseudo-random generator.
++ *
++ */
++void random_init(unsigned short seed);
++
++/*
++ * Calculate a pseudo random number between 0 and 65535.
++ *
++ * \return A pseudo-random number between 0 and 65535.
++ */
++unsigned short random_rand(void);
++
++/* In gcc int rand() uses RAND_MAX and long random() uses RANDOM_MAX */
++/* Since random_rand casts to unsigned short, we'll use this maxmimum */
++#define RANDOM_RAND_MAX 65535U
++
++#endif /* RANDOM_H_ */
+diff --git a/utils/inc/emb6_ringbuffer.h b/utils/inc/emb6_ringbuffer.h
+new file mode 100644
+index 0000000..8b29730
+--- /dev/null
++++ b/utils/inc/emb6_ringbuffer.h
+@@ -0,0 +1,162 @@
++/*============================================================================*/
++/*
++ * The MIT License (MIT)
++ *
++ * Copyright (c) 2014 Anders Kalør
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to deal
++ * in the Software without restriction, including without limitation the rights
++ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++ * copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in all
++ * copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++ * SOFTWARE.
++ */
++/*============================================================================*/
++#include <inttypes.h>
++
++/**
++ * @file
++ * Prototypes and structures for the ring buffer module.
++ */
++
++#ifndef RINGBUFFER_H
++#define RINGBUFFER_H
++
++/**
++ * The size of a ring buffer.
++ * Due to the design only <tt> RB_SIZE-1 </tt> items
++ * can be contained in the buffer.
++ * The buffer size must be a power of two.
++ */
++#define RB_BLOCKS       8
++#define RB_CLOCK_SIZE   128
++#define RB_SIZE         RB_BLOCKS * RB_CLOCK_SIZE
++
++#if (RB_SIZE & (RB_SIZE - 1)) != 0
++#error "RB_SIZE must be a power of two"
++#endif
++
++/**
++ * The type which is used to hold the size and the indicies of the buffer.
++ * Must be able to fit \c RB_SIZE .
++ */
++typedef uint16_t ringb_size_t;
++
++/**
++ * The type which is used to hold atomic size of the ring buffer.
++ * Usually it's int8_t
++ */
++typedef uint8_t ringb_atom_t;
++
++/**
++ * Used as a modulo operator as <tt> a % b = (a & (b − 1)) </tt>
++ * where \c a is a positive index in the buffer and b is the (power of two)
++ * size of the buffer.
++ */
++#define RB_MASK (RB_SIZE-1)
++
++/**
++ * Structure which holds a ring buffer. The buffer contains a buffer array
++ * as well as metadata for the ring buffer.
++ */
++typedef struct s_ringb
++{
++    /** Buffer memory. */
++    ringb_atom_t a_buf[RB_SIZE];
++    /** Index of tail. */
++    ringb_size_t sz_tail;
++    /** Index of head. */
++    ringb_size_t sz_head;
++} s_ringb_t;
++
++/**
++ * Initializes the ring buffer pointed to by <em>buffer</em>.
++ * This function can also be used to empty/reset the buffer.
++ * @param ps_buf The ring buffer to initialize.
++ */
++void ringb_init( s_ringb_t *ps_rb );
++
++/**
++ * Adds a atomic to a ring buffer.
++ * @param ps_buf    The buffer in which the data should be placed.
++ * @param data      The atomic to place.
++ */
++void ringb_pusha( s_ringb_t *ps_rb, ringb_atom_t data );
++
++/**
++ * Adds an array of atomics to a ring buffer.
++ * @param ps_buf    The buffer in which the data should be placed.
++ * @param p_data    A pointer to the array of atomics to place in the queue.
++ * @param sz_len    The size of the array.
++ */
++void ringb_push( s_ringb_t *ps_rb, const ringb_atom_t* p_data,
++        ringb_size_t sz_len );
++
++/**
++ * Returns the oldest atomic in a ring buffer.
++ * @param ps_buf The buffer from which the data should be returned.
++ * @param p_data A pointer to the location at which the data should be placed.
++ * @return 1 if data was returned; 0 otherwise.
++ */
++uint8_t ringb_pulla( s_ringb_t *ps_rb, ringb_atom_t* p_data );
++
++/**
++ * Returns the <em>len</em> oldest atomics from a ring buffer.
++ * @param ps_buf The buffer from which the data should be returned.
++ * @param p_data A pointer to the array at which the data should be placed.
++ * @param sz_len The maximum number of atomics to return.
++ * @return The number of atomics returned.
++ */
++ringb_size_t ringb_pull( s_ringb_t *ps_rb, ringb_atom_t* p_data,
++                         ringb_size_t sz_len );
++/**
++ * Peeks a ring buffer, i.e. returns an element without removing it.
++ * @param ps_buf The buffer from which the data should be returned.
++ * @param p_data A pointer to the location at which the data should be placed.
++ * @param index The index to peek.
++ * @return 1 if data was returned; 0 otherwise.
++ */
++uint8_t ringb_peek( s_ringb_t *ps_rb, ringb_atom_t *data, ringb_size_t index );
++
++/**
++ * Returns whether a ring buffer is empty.
++ * @param ps_buf The buffer for which it should be returned whether it is empty.
++ * @return 1 if empty; 0 otherwise.
++ */
++inline uint8_t ringb_empty( s_ringb_t* ps_rb )
++{
++    return ( ps_rb->sz_head == ps_rb->sz_tail );
++}
++
++/**
++ * Returns the number of items in a ring buffer.
++ * @param ps_buf The buffer for which the number of items should be returned.
++ * @return The number of items in the ring buffer.
++ */
++inline uint8_t ringb_full( s_ringb_t* ps_rb )
++{
++    return ( ( ps_rb->sz_head - ps_rb->sz_tail ) & RB_MASK ) == RB_MASK;
++}
++
++/**
++ * Returns whether a ring buffer is full.
++ * @param ps_buf The buffer for which it should be returned whether it is full.
++ * @return 1 if full; 0 otherwise.
++ */
++inline uint8_t ringb_items( s_ringb_t* ps_rb )
++{
++    return ( ( ps_rb->sz_head - ps_rb->sz_tail ) & RB_MASK );
++}
++
++#endif /* RINGBUFFER_H */
+diff --git a/utils/inc/random.h b/utils/inc/random.h
+deleted file mode 100644
+index 3bab934..0000000
+--- a/utils/inc/random.h
++++ /dev/null
+@@ -1,57 +0,0 @@
+-/*
+- * Copyright (c) 2005, Swedish Institute of Computer Science
+- * All rights reserved.
+- *
+- * Redistribution and use in source and binary forms, with or without
+- * modification, are permitted provided that the following conditions
+- * are met:
+- * 1. Redistributions of source code must retain the above copyright
+- *    notice, this list of conditions and the following disclaimer.
+- * 2. Redistributions in binary form must reproduce the above copyright
+- *    notice, this list of conditions and the following disclaimer in the
+- *    documentation and/or other materials provided with the distribution.
+- * 3. Neither the name of the Institute nor the names of its contributors
+- *    may be used to endorse or promote products derived from this software
+- *    without specific prior written permission.
+- *
+- * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+- * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+- * SUCH DAMAGE.
+- *
+- * This file is part of the Contiki operating system.
+- *
+- * @(#)$Id: random.h,v 1.2 2010/12/13 16:52:02 dak664 Exp $
+- */
+-/**
+- * \file
+- *         A brief description the file
+- */
+-#ifndef RANDOM_H_
+-#define RANDOM_H_
+-
+-/*
+- * Initialize the pseudo-random generator.
+- *
+- */
+-void random_init(unsigned short seed);
+-
+-/*
+- * Calculate a pseudo random number between 0 and 65535.
+- *
+- * \return A pseudo-random number between 0 and 65535.
+- */
+-unsigned short random_rand(void);
+-
+-/* In gcc int rand() uses RAND_MAX and long random() uses RANDOM_MAX */
+-/* Since random_rand casts to unsigned short, we'll use this maxmimum */
+-#define RANDOM_RAND_MAX 65535U
+-
+-#endif /* RANDOM_H_ */
+diff --git a/utils/inc/ringbuffer.h b/utils/inc/ringbuffer.h
+deleted file mode 100644
+index 8b29730..0000000
+--- a/utils/inc/ringbuffer.h
++++ /dev/null
+@@ -1,162 +0,0 @@
+-/*============================================================================*/
+-/*
+- * The MIT License (MIT)
+- *
+- * Copyright (c) 2014 Anders Kalør
+- *
+- * Permission is hereby granted, free of charge, to any person obtaining a copy
+- * of this software and associated documentation files (the "Software"), to deal
+- * in the Software without restriction, including without limitation the rights
+- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+- * copies of the Software, and to permit persons to whom the Software is
+- * furnished to do so, subject to the following conditions:
+- *
+- * The above copyright notice and this permission notice shall be included in all
+- * copies or substantial portions of the Software.
+- *
+- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+- * SOFTWARE.
+- */
+-/*============================================================================*/
+-#include <inttypes.h>
+-
+-/**
+- * @file
+- * Prototypes and structures for the ring buffer module.
+- */
+-
+-#ifndef RINGBUFFER_H
+-#define RINGBUFFER_H
+-
+-/**
+- * The size of a ring buffer.
+- * Due to the design only <tt> RB_SIZE-1 </tt> items
+- * can be contained in the buffer.
+- * The buffer size must be a power of two.
+- */
+-#define RB_BLOCKS       8
+-#define RB_CLOCK_SIZE   128
+-#define RB_SIZE         RB_BLOCKS * RB_CLOCK_SIZE
+-
+-#if (RB_SIZE & (RB_SIZE - 1)) != 0
+-#error "RB_SIZE must be a power of two"
+-#endif
+-
+-/**
+- * The type which is used to hold the size and the indicies of the buffer.
+- * Must be able to fit \c RB_SIZE .
+- */
+-typedef uint16_t ringb_size_t;
+-
+-/**
+- * The type which is used to hold atomic size of the ring buffer.
+- * Usually it's int8_t
+- */
+-typedef uint8_t ringb_atom_t;
+-
+-/**
+- * Used as a modulo operator as <tt> a % b = (a & (b − 1)) </tt>
+- * where \c a is a positive index in the buffer and b is the (power of two)
+- * size of the buffer.
+- */
+-#define RB_MASK (RB_SIZE-1)
+-
+-/**
+- * Structure which holds a ring buffer. The buffer contains a buffer array
+- * as well as metadata for the ring buffer.
+- */
+-typedef struct s_ringb
+-{
+-    /** Buffer memory. */
+-    ringb_atom_t a_buf[RB_SIZE];
+-    /** Index of tail. */
+-    ringb_size_t sz_tail;
+-    /** Index of head. */
+-    ringb_size_t sz_head;
+-} s_ringb_t;
+-
+-/**
+- * Initializes the ring buffer pointed to by <em>buffer</em>.
+- * This function can also be used to empty/reset the buffer.
+- * @param ps_buf The ring buffer to initialize.
+- */
+-void ringb_init( s_ringb_t *ps_rb );
+-
+-/**
+- * Adds a atomic to a ring buffer.
+- * @param ps_buf    The buffer in which the data should be placed.
+- * @param data      The atomic to place.
+- */
+-void ringb_pusha( s_ringb_t *ps_rb, ringb_atom_t data );
+-
+-/**
+- * Adds an array of atomics to a ring buffer.
+- * @param ps_buf    The buffer in which the data should be placed.
+- * @param p_data    A pointer to the array of atomics to place in the queue.
+- * @param sz_len    The size of the array.
+- */
+-void ringb_push( s_ringb_t *ps_rb, const ringb_atom_t* p_data,
+-        ringb_size_t sz_len );
+-
+-/**
+- * Returns the oldest atomic in a ring buffer.
+- * @param ps_buf The buffer from which the data should be returned.
+- * @param p_data A pointer to the location at which the data should be placed.
+- * @return 1 if data was returned; 0 otherwise.
+- */
+-uint8_t ringb_pulla( s_ringb_t *ps_rb, ringb_atom_t* p_data );
+-
+-/**
+- * Returns the <em>len</em> oldest atomics from a ring buffer.
+- * @param ps_buf The buffer from which the data should be returned.
+- * @param p_data A pointer to the array at which the data should be placed.
+- * @param sz_len The maximum number of atomics to return.
+- * @return The number of atomics returned.
+- */
+-ringb_size_t ringb_pull( s_ringb_t *ps_rb, ringb_atom_t* p_data,
+-                         ringb_size_t sz_len );
+-/**
+- * Peeks a ring buffer, i.e. returns an element without removing it.
+- * @param ps_buf The buffer from which the data should be returned.
+- * @param p_data A pointer to the location at which the data should be placed.
+- * @param index The index to peek.
+- * @return 1 if data was returned; 0 otherwise.
+- */
+-uint8_t ringb_peek( s_ringb_t *ps_rb, ringb_atom_t *data, ringb_size_t index );
+-
+-/**
+- * Returns whether a ring buffer is empty.
+- * @param ps_buf The buffer for which it should be returned whether it is empty.
+- * @return 1 if empty; 0 otherwise.
+- */
+-inline uint8_t ringb_empty( s_ringb_t* ps_rb )
+-{
+-    return ( ps_rb->sz_head == ps_rb->sz_tail );
+-}
+-
+-/**
+- * Returns the number of items in a ring buffer.
+- * @param ps_buf The buffer for which the number of items should be returned.
+- * @return The number of items in the ring buffer.
+- */
+-inline uint8_t ringb_full( s_ringb_t* ps_rb )
+-{
+-    return ( ( ps_rb->sz_head - ps_rb->sz_tail ) & RB_MASK ) == RB_MASK;
+-}
+-
+-/**
+- * Returns whether a ring buffer is full.
+- * @param ps_buf The buffer for which it should be returned whether it is full.
+- * @return 1 if full; 0 otherwise.
+- */
+-inline uint8_t ringb_items( s_ringb_t* ps_rb )
+-{
+-    return ( ( ps_rb->sz_head - ps_rb->sz_tail ) & RB_MASK );
+-}
+-
+-#endif /* RINGBUFFER_H */
+diff --git a/utils/inc/timer.h b/utils/inc/timer.h
+index ca34bf5..ac1e354 100644
+--- a/utils/inc/timer.h
++++ b/utils/inc/timer.h
+@@ -84,7 +84,7 @@
+  * A timer.
+  *
+  * This structure is used for declaring a timer. The timer must be set
+- * with timer_set() before it can be used.
++ * with timer_emb6_set() before it can be used.
+  *
+  * \hideinitializer
+  */
+@@ -93,7 +93,7 @@ struct timer {
+   clock_time_t interval;
+ };
+
+-void timer_set(struct timer *t, clock_time_t interval);
++void timer_emb6_set(struct timer *t, clock_time_t interval);
+ void timer_reset(struct timer *t);
+ void timer_restart(struct timer *t);
+ int timer_expired(struct timer *t);
+diff --git a/utils/src/ctimer.c b/utils/src/ctimer.c
+index 9ef215e..9e0f465 100644
+--- a/utils/src/ctimer.c
++++ b/utils/src/ctimer.c
+@@ -66,7 +66,7 @@
+ #include "evproc.h"
+ #include "ctimer.h"
+ #include "timer.h"
+-#include "clist.h"
++#include "emb6_clist.h"
+
+ /*==============================================================================
+                              LOCAL MACROS
+@@ -143,7 +143,7 @@ void ctimer_set(struct ctimer *c, clock_time_t t,
+         c->etimer.timer.interval = t;
+     }
+
+-    list_add(gp_ctimList, c);
++    emb6_list_add(gp_ctimList, c);
+ }
+ /*============================================================================*/
+ /*  ctimer_reset()                                                     */
+@@ -155,7 +155,7 @@ void ctimer_reset(struct ctimer *c)
+   }
+
+   list_remove(gp_ctimList, c);
+-  list_add(gp_ctimList, c);
++  emb6_list_add(gp_ctimList, c);
+ }
+ /*============================================================================*/
+ /*  ctimer_restart()                                                     */
+@@ -167,7 +167,7 @@ void ctimer_restart(struct ctimer *c)
+   }
+
+   list_remove(gp_ctimList, c);
+-  list_add(gp_ctimList, c);
++  emb6_list_add(gp_ctimList, c);
+ }
+ /*============================================================================*/
+ /*  ctimer_stop()                                                     */
+diff --git a/utils/src/etimer.c b/utils/src/etimer.c
+index e29c533..4661ab0 100644
+--- a/utils/src/etimer.c
++++ b/utils/src/etimer.c
+@@ -62,7 +62,7 @@
+ ==============================================================================*/
+
+ #include "etimer.h"
+-#include "clist.h"
++#include "emb6_clist.h"
+
+ #include "emb6_conf.h"
+ #include "emb6.h"
+@@ -98,7 +98,7 @@ static     char         gc_init = 0;
+ static void _etimer_addTimer(struct etimer *pst_timer)
+ {
+     list_remove(gp_etimList, pst_timer);
+-    list_add(gp_etimList, pst_timer);
++    emb6_list_add(gp_etimList, pst_timer);
+     pst_timer->active = TMR_ACTIVE;
+ }
+
+@@ -164,7 +164,7 @@ void etimer_request_poll(void)
+ /*============================================================================*/
+ void etimer_set(struct etimer *pst_et, clock_time_t l_interval, pfn_callback_t pfn_callback)
+ {
+-    timer_set(&pst_et->timer, l_interval);
++    timer_emb6_set(&pst_et->timer, l_interval);
+     _etimer_addTimer(pst_et);
+     evproc_regCallback(EVENT_TYPE_TIMER_EXP, pfn_callback);
+     LOG_INFO("add new timer %p\n\r",pst_et);
+diff --git a/utils/src/evproc.c b/utils/src/evproc.c
+index 585b027..9544f0f 100644
+--- a/utils/src/evproc.c
++++ b/utils/src/evproc.c
+@@ -62,7 +62,7 @@
+
+ #include "bsp.h"
+ #include "evproc.h"
+-#include "clist.h"
++#include "emb6_clist.h"
+ #include "logger.h"
+
+ /*==============================================================================
+diff --git a/utils/src/list.c b/utils/src/list.c
+index 38d006f..d6fedd8 100644
+--- a/utils/src/list.c
++++ b/utils/src/list.c
+@@ -46,7 +46,7 @@
+  *
+  */
+
+-#include "clist.h"
++#include "emb6_clist.h"
+
+ #define NULL 0
+
+@@ -141,7 +141,7 @@ list_tail(list_t list)
+  *
+  */
+ void
+-list_add(list_t list, void *item)
++emb6_list_add(list_t list, void *item)
+ {
+   struct list *l;
+
+diff --git a/utils/src/mmem.c b/utils/src/mmem.c
+index 795af1d..f2e3ddc 100644
+--- a/utils/src/mmem.c
++++ b/utils/src/mmem.c
+@@ -45,7 +45,7 @@
+
+
+ #include "mmem.h"
+-#include "clist.h"
++#include "emb6_clist.h"
+ //#include "lib_conf.h"
+ #include <string.h>
+
+@@ -89,7 +89,7 @@ mmem_alloc(struct mmem *m, unsigned int size)
+
+   /* We had enough memory so we add this memory block to the end of
+      the list of allocated memory blocks. */
+-  list_add(mmemlist, m);
++  emb6_list_add(mmemlist, m);
+
+   /* Set up the pointer so that it points to the first available byte
+      in the memory block. */
+diff --git a/utils/src/queuebuf.c b/utils/src/queuebuf.c
+index 7a9f13f..8b96816 100644
+--- a/utils/src/queuebuf.c
++++ b/utils/src/queuebuf.c
+@@ -128,7 +128,7 @@ static struct ctimer renew_timer;
+ #endif
+
+ #if QUEUEBUF_DEBUG
+-#include "clist.h"
++#include "emb6_clist.h"
+ LIST(queuebuf_list);
+ #endif /* QUEUEBUF_DEBUG */
+
+@@ -349,7 +349,7 @@ queuebuf_new_from_packetbuf(void)
+     buf = memb_alloc(&bufmem);
+     if(buf != NULL) {
+ #if QUEUEBUF_DEBUG
+-      list_add(queuebuf_list, buf);
++      emb6_list_add(queuebuf_list, buf);
+       buf->file = file;
+       buf->line = line;
+       buf->time = clock_time();
+diff --git a/utils/src/random.c b/utils/src/random.c
+index 72f5d12..00aed18 100644
+--- a/utils/src/random.c
++++ b/utils/src/random.c
+@@ -36,7 +36,7 @@
+  */
+
+
+-#include "random.h"
++#include "emb6_random.h"
+
+ #include <stdlib.h>
+
+diff --git a/utils/src/ringbuffer.c b/utils/src/ringbuffer.c
+index 5736f8f..52216c5 100644
+--- a/utils/src/ringbuffer.c
++++ b/utils/src/ringbuffer.c
+@@ -24,7 +24,7 @@
+  */
+ /*============================================================================*/
+
+-#include "ringbuffer.h"
++#include "emb6_ringbuffer.h"
+ /**
+  * @file
+  * Implementation of ring ac_buf functions.
+diff --git a/utils/src/timer.c b/utils/src/timer.c
+index 95c8426..a774c09 100644
+--- a/utils/src/timer.c
++++ b/utils/src/timer.c
+@@ -61,7 +61,7 @@
+  * \param interval The interval before the timer expires.
+  *
+  */
+-void timer_set(struct timer *t, clock_time_t interval)
++void timer_emb6_set(struct timer *t, clock_time_t interval)
+ {
+     t->interval = interval;
+     t->start = bsp_getTick();
+@@ -71,7 +71,7 @@ void timer_set(struct timer *t, clock_time_t interval)
+  * Reset the timer with the same interval.
+  *
+  * This function resets the timer with the same interval that was
+- * given to the timer_set() function. The start point of the interval
++ * given to the timer_emb6_set() function. The start point of the interval
+  * is the exact time that the timer last expired. Therefore, this
+  * function will cause the timer to be stable over time, unlike the
+  * timer_restart() function.
+@@ -89,7 +89,7 @@ void timer_reset(struct timer *t)
+  * Restart the timer from the current point in time
+  *
+  * This function restarts a timer with the same interval that was
+- * given to the timer_set() function. The timer will start at the
++ * given to the timer_emb6_set() function. The timer will start at the
+  * current time.
+  *
+  * \note A periodic timer will drift if this function is used to reset
+--
+1.9.1
+

--- a/pkg/emb6/patches/0003-Fix-warnings.patch
+++ b/pkg/emb6/patches/0003-Fix-warnings.patch
@@ -1,0 +1,757 @@
+From cb47e0b69b747833322a83b7396878a631add116 Mon Sep 17 00:00:00 2001
+From: Martine Lenders <mail@martine-lenders.eu>
+Date: Fri, 5 Feb 2016 00:46:31 +0100
+Subject: [PATCH 3/4] Fix warnings
+
+---
+ emb6/src/net/ipv6/multicast/roll-tm.c          | 82 ++++++++++++++++++------
+ emb6/src/net/ipv6/multicast/smrf.c             | 12 +++-
+ emb6/src/net/ipv6/multicast/uip-mcast6-route.c |  2 +-
+ emb6/src/net/ipv6/tcpip.c                      | 25 ++++++--
+ emb6/src/net/ipv6/uip-icmp6.c                  | 35 +++++++++--
+ emb6/src/net/ipv6/uip-nd6.c                    | 74 ++++++++++++++++++----
+ emb6/src/net/ipv6/uip6.c                       | 86 +++++++++++++++++++++-----
+ emb6/src/net/rpl/rpl-ext-header.c              | 50 ++++++++++++---
+ emb6/src/net/rpl/rpl-icmp6.c                   | 24 +++++--
+ emb6/src/net/sicslowpan/sicslowpan.c           | 45 +++++++++++---
+ emb6/src/tport/udp-socket.c                    |  7 ++-
+ 11 files changed, 365 insertions(+), 77 deletions(-)
+
+diff --git a/emb6/src/net/ipv6/multicast/roll-tm.c b/emb6/src/net/ipv6/multicast/roll-tm.c
+index 8b36300..96f4f47 100644
+--- a/emb6/src/net/ipv6/multicast/roll-tm.c
++++ b/emb6/src/net/ipv6/multicast/roll-tm.c
+@@ -290,12 +290,17 @@ struct mcast_packet {
+ #define MCAST_PACKET_S_BIT       0x20   /* Must Send Next Pass */
+ #define MCAST_PACKET_L_BIT       0x10   /* Is listed in ICMP message */
+
++static inline struct uip_ip_hdr *_to_ip_hdr(void *ptr)
++{
++    return (struct uip_ip_hdr *)ptr;
++}
++
+ /* Fetch a pointer to the Seed ID of a buffered message p */
+ #if ROLL_TM_SHORT_SEEDS
+ #define MCAST_PACKET_GET_SEED(p) ((seed_id_t *)&((p)->seed_id))
+ #else
+ #define MCAST_PACKET_GET_SEED(p) \
+-    ((seed_id_t *)&((struct uip_ip_hdr *)&(p)->buff[UIP_LLH_LEN])->srcipaddr)
++    ((seed_id_t *)&(((struct uip_ip_hdr *)&(p))->buff[UIP_LLH_LEN])->srcipaddr)
+ #endif
+
+ /**
+@@ -303,7 +308,7 @@ struct mcast_packet {
+  * p: pointer to a packet buffer
+  */
+ #define MCAST_PACKET_TTL(p) \
+-    (((struct uip_ip_hdr *)(p)->buff)->ttl)
++    (_to_ip_hdr((p)->buff)->ttl)
+
+ /**
+  * \brief Set 'Is Used' bit for packet p
+@@ -462,14 +467,55 @@ static uint16_t last_seq;
+ /*---------------------------------------------------------------------------*/
+ /* uIPv6 Pointers */
+ /*---------------------------------------------------------------------------*/
+-#define UIP_DATA_BUF      ((uint8_t *)&uip_buf[uip_l2_l3_hdr_len + UIP_UDPH_LEN])
+-#define UIP_UDP_BUF       ((struct uip_udp_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+-#define UIP_EXT_BUF       ((struct uip_ext_hdr *)&uip_buf[UIP_LLH_LEN + UIP_IPH_LEN])
+-#define UIP_EXT_BUF_NEXT  ((uint8_t *)&uip_buf[UIP_LLH_LEN + UIP_IPH_LEN + HBHO_TOTAL_LEN])
+-#define UIP_EXT_OPT_FIRST ((struct hbho_mcast *)&uip_buf[UIP_LLH_LEN + UIP_IPH_LEN + 2])
+-#define UIP_IP_BUF        ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
+-#define UIP_ICMP_BUF      ((struct uip_icmp_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+-#define UIP_ICMP_PAYLOAD  ((unsigned char *)&uip_buf[uip_l2_l3_icmp_hdr_len])
++/* least intrusive way to prevent -Wstrict-aliasing from firing */
++static inline uint8_t *uip_data_buf(void)
++{
++    return ((uint8_t *)&uip_buf[uip_l2_l3_hdr_len + UIP_UDPH_LEN]);
++}
++
++static inline struct uip_udp_hdr *uip_udp_buf(void)
++{
++    return ((struct uip_udp_hdr *)&uip_buf[uip_l2_l3_hdr_len]);
++}
++
++static inline struct uip_ext_hdr *uip_ext_buf(void)
++{
++    return ((struct uip_ext_hdr *)&uip_buf[UIP_LLH_LEN + UIP_IPH_LEN]);
++}
++
++uint8_t *uip_ext_buf_next(void)
++{
++    return ((uint8_t *)&uip_buf[UIP_LLH_LEN + UIP_IPH_LEN + HBHO_TOTAL_LEN]);
++}
++
++static inline struct hbho_mcast *uip_ext_opt_first(void)
++{
++    return ((struct hbho_mcast *)&uip_buf[UIP_LLH_LEN + UIP_IPH_LEN + 2]);
++}
++
++static inline struct uip_ip_hdr *uip_ip_buf(void)
++{
++    return ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN]);
++}
++
++static inline struct uip_icmp_hdr *uip_icmp_buf(void)
++{
++    return ((struct uip_icmp_hdr *)&uip_buf[uip_l2_l3_hdr_len]);
++}
++
++static inline unsigned char *uip_icmp_payload(void)
++{
++    return ((unsigned char *)&uip_buf[uip_l2_l3_icmp_hdr_len]);
++}
++
++#define UIP_DATA_BUF      (uip_data_buf())
++#define UIP_UDP_BUF       (uip_udp_buf())
++#define UIP_EXT_BUF       (uip_ext_buf())
++#define UIP_EXT_BUF_NEXT  (uip_ext_buf_next())
++#define UIP_EXT_OPT_FIRST (uip_ext_opt_first())
++#define UIP_IP_BUF        (uip_ip_buf())
++#define UIP_ICMP_BUF      (uip_icmp_buf())
++#define UIP_ICMP_PAYLOAD  (uip_icmp_payload())
+ extern uint16_t uip_slen;
+ /*---------------------------------------------------------------------------*/
+ /* Local function prototypes */
+@@ -689,7 +735,7 @@ reset_trickle_timer(uint8_t index)
+ }
+ /*---------------------------------------------------------------------------*/
+ static struct sliding_window *
+-window_allocate()
++window_allocate(void)
+ {
+   for(iterswptr = &windows[ROLL_TM_WINS - 1]; iterswptr >= windows;
+       iterswptr--) {
+@@ -721,7 +767,7 @@ window_lookup(seed_id_t *s, uint8_t m)
+ }
+ /*---------------------------------------------------------------------------*/
+ static void
+-window_update_bounds()
++window_update_bounds(void)
+ {
+   for(iterswptr = &windows[ROLL_TM_WINS - 1]; iterswptr >= windows;
+       iterswptr--) {
+@@ -748,7 +794,7 @@ window_update_bounds()
+ }
+ /*---------------------------------------------------------------------------*/
+ static struct mcast_packet *
+-buffer_reclaim()
++buffer_reclaim(void)
+ {
+   struct sliding_window *largest = windows;
+   struct mcast_packet *rv;
+@@ -790,7 +836,7 @@ buffer_reclaim()
+ }
+ /*---------------------------------------------------------------------------*/
+ static struct mcast_packet *
+-buffer_allocate()
++buffer_allocate(void)
+ {
+   for(locmpptr = &buffered_msgs[ROLL_TM_BUFF_NUM - 1];
+       locmpptr >= buffered_msgs; locmpptr--) {
+@@ -802,7 +848,7 @@ buffer_allocate()
+ }
+ /*---------------------------------------------------------------------------*/
+ static void
+-icmp_output()
++icmp_output(void)
+ {
+   struct sequence_list_header *sl;
+   uint8_t *buffer;
+@@ -1098,7 +1144,7 @@ accept(uint8_t in)
+ /*---------------------------------------------------------------------------*/
+ /* ROLL TM ICMPv6 Input Handler */
+ static void
+-icmp_input()
++icmp_input(void)
+ {
+   uint8_t inconsistency;
+   uint16_t *seq_ptr;
+@@ -1321,7 +1367,7 @@ drop:
+ }
+ /*---------------------------------------------------------------------------*/
+ static void
+-out()
++out(void)
+ {
+
+   if(uip_len + HBHO_TOTAL_LEN > UIP_BUFSIZE) {
+@@ -1391,7 +1437,7 @@ drop:
+ }
+ /*---------------------------------------------------------------------------*/
+ static uint8_t
+-in()
++in(void)
+ {
+   /*
+    * We call accept() which will sort out caching and forwarding. Depending
+diff --git a/emb6/src/net/ipv6/multicast/smrf.c b/emb6/src/net/ipv6/multicast/smrf.c
+index 9b4a3a5..38d31cd 100644
+--- a/emb6/src/net/ipv6/multicast/smrf.c
++++ b/emb6/src/net/ipv6/multicast/smrf.c
+@@ -77,7 +77,13 @@ static uint8_t fwd_spread;
+ /*---------------------------------------------------------------------------*/
+ /* uIPv6 Pointers */
+ /*---------------------------------------------------------------------------*/
+-#define UIP_IP_BUF        ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
++/* least intrusive way to prevent -Wstrict-aliasing from firing */
++static inline struct uip_ip_hdr *uip_ip_buf(void)
++{
++    return ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN]);
++}
++
++#define UIP_IP_BUF        (uip_ip_buf())
+ /*---------------------------------------------------------------------------*/
+ static void
+ mcast_fwd(void *p)
+@@ -90,7 +96,7 @@ mcast_fwd(void *p)
+ }
+ /*---------------------------------------------------------------------------*/
+ static uint8_t
+-in()
++in(void)
+ {
+   rpl_dag_t *d;                 /* Our DODAG */
+   uip_ipaddr_t *parent_ipaddr;  /* Our pref. parent's IPv6 address */
+@@ -201,7 +207,7 @@ init(void)
+ }
+ /*---------------------------------------------------------------------------*/
+ static void
+-out()
++out(void)
+ {
+   return;
+ }
+diff --git a/emb6/src/net/ipv6/multicast/uip-mcast6-route.c b/emb6/src/net/ipv6/multicast/uip-mcast6-route.c
+index 55d245d..75443a5 100644
+--- a/emb6/src/net/ipv6/multicast/uip-mcast6-route.c
++++ b/emb6/src/net/ipv6/multicast/uip-mcast6-route.c
+@@ -126,7 +126,7 @@ uip_mcast6_route_count(void)
+ }
+ /*---------------------------------------------------------------------------*/
+ void
+-uip_mcast6_route_init()
++uip_mcast6_route_init(void)
+ {
+   memb_init(&mcast_route_memb);
+   list_init(mcast_route_list);
+diff --git a/emb6/src/net/ipv6/tcpip.c b/emb6/src/net/ipv6/tcpip.c
+index 9c76bed..1901d9e 100644
+--- a/emb6/src/net/ipv6/tcpip.c
++++ b/emb6/src/net/ipv6/tcpip.c
+@@ -72,9 +72,24 @@ void uip_log(char *msg);
+ #define UIP_LOG(m)
+ #endif
+
+-#define UIP_ICMP_BUF ((struct uip_icmp_hdr *)&uip_buf[UIP_LLIPH_LEN + uip_ext_len])
+-#define UIP_IP_BUF ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
+-#define UIP_TCP_BUF ((struct uip_tcpip_hdr *)&uip_buf[UIP_LLH_LEN])
++static inline struct uip_icmp_hdr *uip_icmp_buf(void)
++{
++    return ((struct uip_icmp_hdr *)&uip_buf[UIP_LLIPH_LEN + uip_ext_len]);
++}
++
++static inline struct uip_ip_hdr *uip_ip_buf(void)
++{
++    return ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN]);
++}
++
++static inline struct uip_tcpip_hdr *uip_tcp_buf(void)
++{
++    return ((struct uip_tcpip_hdr *)&uip_buf[UIP_LLH_LEN]);
++}
++
++#define UIP_ICMP_BUF (uip_icmp_buf())
++#define UIP_IP_BUF (uip_ip_buf())
++#define UIP_TCP_BUF (uip_tcp_buf())
+
+ #ifdef UIP_FALLBACK_INTERFACE
+ extern struct uip_fallback_interface UIP_FALLBACK_INTERFACE;
+@@ -165,15 +180,15 @@ unsigned char tcpip_is_forwarding; /* Forwarding right now? */
+ //PROCESS(tcpip_process, "TCP/IP stack");
+
+ /*---------------------------------------------------------------------------*/
++#if UIP_TCP
+ static void
+ start_periodic_tcp_timer(void)
+ {
+-#if UIP_TCP
+   if(etimer_expired(&periodic)) {
+     etimer_restart(&periodic);
+   }
+-#endif /* UIP_TCP */
+ }
++#endif /* UIP_TCP */
+ /*---------------------------------------------------------------------------*/
+ static void
+ check_for_tcp_syn(void)
+diff --git a/emb6/src/net/ipv6/uip-icmp6.c b/emb6/src/net/ipv6/uip-icmp6.c
+index 484d0bf..6f53d12 100644
+--- a/emb6/src/net/ipv6/uip-icmp6.c
++++ b/emb6/src/net/ipv6/uip-icmp6.c
+@@ -59,11 +59,34 @@
+ #define PRINT6ADDR(addr)
+ #endif
+
+-#define UIP_IP_BUF                ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
+-#define UIP_ICMP_BUF            ((struct uip_icmp_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+-#define UIP_ICMP6_ERROR_BUF  ((struct uip_icmp6_error *)&uip_buf[uip_l2_l3_icmp_hdr_len])
+-#define UIP_EXT_BUF              ((struct uip_ext_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+-#define UIP_FIRST_EXT_BUF        ((struct uip_ext_hdr *)&uip_buf[UIP_LLIPH_LEN])
++/* least intrusive way to prevent -Wstrict-aliasing from firing */
++static inline struct uip_ip_hdr *uip_ip_buf(void)
++{
++    return ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN]);
++}
++
++static inline struct uip_icmp_hdr *uip_icmp_buf(void)
++{
++    return ((struct uip_icmp_hdr *)&uip_buf[uip_l2_l3_hdr_len]);
++}
++
++static inline struct uip_icmp6_error *uip_icmp6_error_buf(void) {
++    return ((struct uip_icmp6_error *)&uip_buf[uip_l2_l3_icmp_hdr_len]);
++}
++
++static inline struct uip_ext_hdr *uip_ext_buf(void) {
++    return ((struct uip_ext_hdr *)&uip_buf[uip_l2_l3_hdr_len]);
++}
++
++static inline struct uip_ext_hdr *uip_first_ext_buf(void) {
++    return ((struct uip_ext_hdr *)&uip_buf[UIP_LLIPH_LEN]);
++}
++
++#define UIP_IP_BUF                (uip_ip_buf())
++#define UIP_ICMP_BUF            (uip_icmp_buf())
++#define UIP_ICMP6_ERROR_BUF  (uip_icmp6_error_buf())
++#define UIP_EXT_BUF              (uip_ext_buf())
++#define UIP_FIRST_EXT_BUF        (uip_first_ext_buf())
+
+ /** \brief temporary IP address */
+ static uip_ipaddr_t tmp_ipaddr;
+@@ -409,7 +432,7 @@ UIP_ICMP6_HANDLER(echo_reply_handler, ICMP6_ECHO_REPLY,
+                   UIP_ICMP6_HANDLER_CODE_ANY, echo_reply_input);
+ /*---------------------------------------------------------------------------*/
+ void
+-uip_icmp6_init()
++uip_icmp6_init(void)
+ {
+   /* Register Echo Request and Reply handlers */
+   uip_icmp6_register_input_handler(&echo_request_handler);
+diff --git a/emb6/src/net/ipv6/uip-nd6.c b/emb6/src/net/ipv6/uip-nd6.c
+index f04b6b3..26ed214 100644
+--- a/emb6/src/net/ipv6/uip-nd6.c
++++ b/emb6/src/net/ipv6/uip-nd6.c
+@@ -93,6 +93,37 @@ void uip_log(char *msg);
+ #define UIP_LOG(m)
+ #endif /* UIP_LOGGING == 1 */
+
++/* least intrusive way to prevent -Wstrict-aliasing from firing */
++static inline struct uip_ip_hdr *uip_ip_buf(void)
++{
++    return ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])  /**< Pointer to IP header */;
++}
++
++static inline struct uip_icmp_hdr *uip_icmp_buf(void)
++{
++    return ((struct uip_icmp_hdr *)&uip_buf[uip_l2_l3_hdr_len])  /**< Pointer to ICMP header*/;
++}
++
++static inline uip_nd6_rs *uip_nd6_rs_buf(void)
++{
++    return ((uip_nd6_rs *)&uip_buf[uip_l2_l3_icmp_hdr_len]);
++}
++
++static inline uip_nd6_ra *uip_nd6_ra_buf(void)
++{
++    return ((uip_nd6_ra *)&uip_buf[uip_l2_l3_icmp_hdr_len]);
++}
++
++static inline uip_nd6_ns *uip_nd6_ns_buf(void)
++{
++    return ((uip_nd6_ns *)&uip_buf[uip_l2_l3_icmp_hdr_len]);
++}
++
++static inline uip_nd6_na *uip_nd6_na_buf(void)
++{
++    return ((uip_nd6_na *)&uip_buf[uip_l2_l3_icmp_hdr_len]);
++}
++
+ /*------------------------------------------------------------------*/
+ /** @{ */
+ /** \name Pointers to the header structures.
+@@ -106,19 +137,19 @@ void uip_log(char *msg);
+  *  value of these length variables
+  */
+
+-#define UIP_IP_BUF                ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])  /**< Pointer to IP header */
+-#define UIP_ICMP_BUF            ((struct uip_icmp_hdr *)&uip_buf[uip_l2_l3_hdr_len])  /**< Pointer to ICMP header*/
++#define UIP_IP_BUF                (uip_ip_buf())  /**< Pointer to IP header */
++#define UIP_ICMP_BUF            (uip_icmp_buf())  /**< Pointer to ICMP header*/
+ /**@{  Pointers to messages just after icmp header */
+-#define UIP_ND6_RS_BUF            ((uip_nd6_rs *)&uip_buf[uip_l2_l3_icmp_hdr_len])
+-#define UIP_ND6_RA_BUF            ((uip_nd6_ra *)&uip_buf[uip_l2_l3_icmp_hdr_len])
+-#define UIP_ND6_NS_BUF            ((uip_nd6_ns *)&uip_buf[uip_l2_l3_icmp_hdr_len])
+-#define UIP_ND6_NA_BUF            ((uip_nd6_na *)&uip_buf[uip_l2_l3_icmp_hdr_len])
++#define UIP_ND6_RS_BUF            (uip_nd6_rs_buf())
++#define UIP_ND6_RA_BUF            (uip_nd6_ra_buf())
++#define UIP_ND6_NS_BUF            (uip_nd6_ns_buf())
++#define UIP_ND6_NA_BUF            (uip_nd6_na_buf())
+ /** @} */
+ /** Pointer to ND option */
+-#define UIP_ND6_OPT_HDR_BUF  ((uip_nd6_opt_hdr *)&uip_buf[uip_l2_l3_icmp_hdr_len + nd6_opt_offset])
+-#define UIP_ND6_OPT_PREFIX_BUF ((uip_nd6_opt_prefix_info *)&uip_buf[uip_l2_l3_icmp_hdr_len + nd6_opt_offset])
+-#define UIP_ND6_OPT_MTU_BUF ((uip_nd6_opt_mtu *)&uip_buf[uip_l2_l3_icmp_hdr_len + nd6_opt_offset])
+-#define UIP_ND6_OPT_RDNSS_BUF ((uip_nd6_opt_dns *)&uip_buf[uip_l2_l3_icmp_hdr_len + nd6_opt_offset])
++#define UIP_ND6_OPT_HDR_BUF  (uip_nd6_opt_hdr_buf())
++#define UIP_ND6_OPT_PREFIX_BUF (uip_nd6_opt_prefix_buf())
++#define UIP_ND6_OPT_MTU_BUF (uip_nd6_opt_mtu_buf())
++#define UIP_ND6_OPT_RDNSS_BUF (uip_nd6_opt_rdnss_buf())
+ /** @} */
+
+ static uint8_t nd6_opt_offset;                     /** Offset from the end of the icmpv6 header to the option in uip_buf*/
+@@ -132,6 +163,27 @@ static uip_ds6_prefix_t *prefix; /**  Pointer to a prefix list entry */
+ static uip_ds6_nbr_t *nbr; /**  Pointer to a nbr cache entry*/
+ static uip_ds6_defrt_t *defrt; /**  Pointer to a router list entry */
+ static uip_ds6_addr_t *addr; /**  Pointer to an interface address */
++
++static inline uip_nd6_opt_hdr *uip_nd6_opt_hdr_buf(void)
++{
++    return ((uip_nd6_opt_hdr *)&uip_buf[uip_l2_l3_icmp_hdr_len + nd6_opt_offset]);
++}
++
++static inline uip_nd6_opt_prefix_info *uip_nd6_opt_prefix_buf(void)
++{
++    return ((uip_nd6_opt_prefix_info *)&uip_buf[uip_l2_l3_icmp_hdr_len + nd6_opt_offset]);
++}
++
++static inline uip_nd6_opt_mtu *uip_nd6_opt_mtu_buf(void)
++{
++    return ((uip_nd6_opt_mtu *)&uip_buf[uip_l2_l3_icmp_hdr_len + nd6_opt_offset]);
++}
++
++static inline uip_nd6_opt_dns *uip_nd6_opt_rdnss_buf(void)
++{
++    return ((uip_nd6_opt_dns *)&uip_buf[uip_l2_l3_icmp_hdr_len + nd6_opt_offset]);
++}
++
+ /*------------------------------------------------------------------*/
+ /* create a llao */
+ static void
+@@ -1054,7 +1106,7 @@ UIP_ICMP6_HANDLER(ra_input_handler, ICMP6_RA, UIP_ICMP6_HANDLER_CODE_ANY,
+ #endif
+ /*---------------------------------------------------------------------------*/
+ void
+-uip_nd6_init()
++uip_nd6_init(void)
+ {
+
+ #if UIP_ND6_SEND_NA
+diff --git a/emb6/src/net/ipv6/uip6.c b/emb6/src/net/ipv6/uip6.c
+index 89edb73..281c8d9 100644
+--- a/emb6/src/net/ipv6/uip6.c
++++ b/emb6/src/net/ipv6/uip6.c
+@@ -152,6 +152,61 @@ uint8_t uip_ext_len = 0;
+ uint8_t uip_ext_opt_offset = 0;
+ /** @} */
+
++/* least intrusive way to prevent -Wstrict-aliasing from firing */
++static inline struct uip_ip_hdr *uip_ip_buf(void) {
++    return ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN]);
++}
++
++static inline struct uip_icmp_hdr *uip_icmp_buf(void) {
++    return ((struct uip_icmp_hdr *)&uip_buf[uip_l2_l3_hdr_len]);
++}
++
++static inline struct uip_udp_hdr *uip_udp_buf(void) {
++    return ((struct uip_udp_hdr *)&uip_buf[UIP_LLH_LEN + UIP_IPH_LEN]);
++}
++
++static inline struct uip_tcp_hdr *uip_tcp_buf(void) {
++    return ((struct uip_tcp_hdr *)&uip_buf[UIP_LLH_LEN + UIP_IPH_LEN]);
++}
++
++static inline struct uip_ext_hdr *uip_ext_buf(void) {
++    return ((struct uip_ext_hdr *)&uip_buf[uip_l2_l3_hdr_len]);
++}
++
++static inline struct uip_routing_hdr *uip_routing_buf(void) {
++    return ((struct uip_routing_hdr *)&uip_buf[uip_l2_l3_hdr_len]);
++}
++
++static inline struct uip_frag_hdr *uip_frag_buf(void) {
++    return ((struct uip_frag_hdr *)&uip_buf[uip_l2_l3_hdr_len]);
++}
++
++static inline struct uip_hbho_hdr *uip_hbho_buf(void) {
++    return ((struct uip_hbho_hdr *)&uip_buf[uip_l2_l3_hdr_len]);
++}
++
++static inline struct uip_desto_hdr *uip_desto_buf(void) {
++    return ((struct uip_desto_hdr *)&uip_buf[uip_l2_l3_hdr_len]);
++}
++
++static inline struct uip_ext_hdr_opt *uip_ext_hdr_opt_buf(void) {
++    return ((struct uip_ext_hdr_opt *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset]);
++}
++
++static inline struct uip_ext_hdr_opt_padn *uip_ext_hdr_opt_padn_buf(void) {
++    return ((struct uip_ext_hdr_opt_padn *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset]);
++}
++
++#if UIP_CONF_IPV6_RPL
++static inline struct uip_ext_hdr_opt_rpl *uip_ext_hdr_opt_rpl_buf(void) {
++    return ((struct uip_ext_hdr_opt_rpl *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset]);
++}
++#endif /* UIP_CONF_IPV6_RPL */
++
++static inline struct uip_icmp6_error *uip_icmp6_error_buf(void) {
++    return ((struct uip_icmp6_error *)&uip_buf[uip_l2_l3_icmp_hdr_len]);
++}
++
+ /*---------------------------------------------------------------------------*/
+ /* Buffers                                                                   */
+ /*---------------------------------------------------------------------------*/
+@@ -159,22 +214,22 @@ uint8_t uip_ext_opt_offset = 0;
+  * \name Buffer defines
+  *  @{
+  */
+-#define FBUF                             ((struct uip_tcpip_hdr *)&uip_reassbuf[0])
+-#define UIP_IP_BUF                          ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
+-#define UIP_ICMP_BUF                      ((struct uip_icmp_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+-#define UIP_UDP_BUF                        ((struct uip_udp_hdr *)&uip_buf[UIP_LLH_LEN + UIP_IPH_LEN])
+-#define UIP_TCP_BUF                        ((struct uip_tcp_hdr *)&uip_buf[UIP_LLH_LEN + UIP_IPH_LEN])
+-#define UIP_EXT_BUF                        ((struct uip_ext_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+-#define UIP_ROUTING_BUF                ((struct uip_routing_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+-#define UIP_FRAG_BUF                      ((struct uip_frag_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+-#define UIP_HBHO_BUF                      ((struct uip_hbho_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+-#define UIP_DESTO_BUF                    ((struct uip_desto_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+-#define UIP_EXT_HDR_OPT_BUF            ((struct uip_ext_hdr_opt *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset])
+-#define UIP_EXT_HDR_OPT_PADN_BUF  ((struct uip_ext_hdr_opt_padn *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset])
++#define FBUF                             (fbuf())
++#define UIP_IP_BUF                          (uip_ip_buf())
++#define UIP_ICMP_BUF                      (uip_icmp_buf())
++#define UIP_UDP_BUF                        (uip_udp_buf())
++#define UIP_TCP_BUF                        (uip_tcp_buf())
++#define UIP_EXT_BUF                        (uip_ext_buf())
++#define UIP_ROUTING_BUF                (uip_routing_buf())
++#define UIP_FRAG_BUF                      (uip_frag_buf())
++#define UIP_HBHO_BUF                      (uip_hbho_buf())
++#define UIP_DESTO_BUF                    (uip_desto_buf())
++#define UIP_EXT_HDR_OPT_BUF            (uip_ext_hdr_opt_buf())
++#define UIP_EXT_HDR_OPT_PADN_BUF  (uip_ext_hdr_opt_padn_buf())
+ #if UIP_CONF_IPV6_RPL
+-#define UIP_EXT_HDR_OPT_RPL_BUF    ((struct uip_ext_hdr_opt_rpl *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset])
++#define UIP_EXT_HDR_OPT_RPL_BUF    (uip_ext_hdr_opt_rpl_buf())
+ #endif /* UIP_CONF_IPV6_RPL */
+-#define UIP_ICMP6_ERROR_BUF            ((struct uip_icmp6_error *)&uip_buf[uip_l2_l3_icmp_hdr_len])
++#define UIP_ICMP6_ERROR_BUF            (uip_icmp6_error_buf())
+ /** @} */
+ /**
+  * \name Buffer variables
+@@ -647,6 +702,9 @@ static uint8_t uip_reassflags;
+ #define UIP_REASS_FLAG_FIRSTFRAG 0x02
+ #define UIP_REASS_FLAG_ERROR_MSG 0x04
+
++static inline struct uip_tcpip_hdr *fbuf(void) {
++    return ((struct uip_tcpip_hdr *)&uip_reassbuf[0]);
++}
+
+ /*
+  * See RFC 2460 for a description of fragmentation in IPv6
+diff --git a/emb6/src/net/rpl/rpl-ext-header.c b/emb6/src/net/rpl/rpl-ext-header.c
+index 8bf1fe1..a680d52 100644
+--- a/emb6/src/net/rpl/rpl-ext-header.c
++++ b/emb6/src/net/rpl/rpl-ext-header.c
+@@ -56,13 +56,49 @@
+ #include <string.h>
+
+ /*---------------------------------------------------------------------------*/
+-#define UIP_IP_BUF                ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
+-#define UIP_EXT_BUF               ((struct uip_ext_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+-#define UIP_HBHO_BUF              ((struct uip_hbho_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+-#define UIP_HBHO_NEXT_BUF         ((struct uip_ext_hdr *)&uip_buf[uip_l2_l3_hdr_len + RPL_HOP_BY_HOP_LEN])
+-#define UIP_EXT_HDR_OPT_BUF       ((struct uip_ext_hdr_opt *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset])
+-#define UIP_EXT_HDR_OPT_PADN_BUF  ((struct uip_ext_hdr_opt_padn *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset])
+-#define UIP_EXT_HDR_OPT_RPL_BUF   ((struct uip_ext_hdr_opt_rpl *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset])
++/* least intrusive way to prevent -Wstrict-aliasing from firing */
++static inline struct uip_ip_hdr *uip_ip_buf(void)
++{
++    return ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN]);
++}
++
++static inline struct uip_ext_hdr *uip_ext_buf(void)
++{
++    return ((struct uip_ext_hdr *)&uip_buf[uip_l2_l3_hdr_len]);
++}
++
++static inline struct uip_hbho_hdr *uip_hbho_buf(void)
++{
++    return ((struct uip_hbho_hdr *)&uip_buf[uip_l2_l3_hdr_len]);
++}
++
++static inline struct uip_ext_hdr *uip_hbho_next_buf(void)
++{
++    return ((struct uip_ext_hdr *)&uip_buf[uip_l2_l3_hdr_len + RPL_HOP_BY_HOP_LEN]);
++}
++
++static inline struct uip_ext_hdr_opt *uip_ext_hdr_opt_buf(int uip_ext_opt_offset)
++{
++    return ((struct uip_ext_hdr_opt *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset]);
++}
++
++static inline struct uip_ext_hdr_opt_padn *uip_ext_hdr_opt_padn_buf(int uip_ext_opt_offset)
++{
++    return ((struct uip_ext_hdr_opt_padn *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset]);
++}
++
++static inline struct uip_ext_hdr_opt_rpl *uip_ext_hdr_opt_rpl_buf(int uip_ext_opt_offset)
++{
++    return ((struct uip_ext_hdr_opt_rpl *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset]);
++}
++
++#define UIP_IP_BUF                (uip_ip_buf())
++#define UIP_EXT_BUF               (uip_ext_buf())
++#define UIP_HBHO_BUF              (uip_hbho_buf())
++#define UIP_HBHO_NEXT_BUF         (uip_hbho_next_buf())
++#define UIP_EXT_HDR_OPT_BUF       (uip_ext_hdr_opt_buf(uip_ext_opt_offset))
++#define UIP_EXT_HDR_OPT_PADN_BUF  (uip_ext_hdr_opt_padn_buf(uip_ext_opt_offset))
++#define UIP_EXT_HDR_OPT_RPL_BUF   (uip_ext_hdr_opt_rpl_buf(uip_ext_opt_offset))
+ /*---------------------------------------------------------------------------*/
+ int
+ rpl_verify_header(int uip_ext_opt_offset)
+diff --git a/emb6/src/net/rpl/rpl-icmp6.c b/emb6/src/net/rpl/rpl-icmp6.c
+index 0675e63..84eb5bd 100644
+--- a/emb6/src/net/rpl/rpl-icmp6.c
++++ b/emb6/src/net/rpl/rpl-icmp6.c
+@@ -68,9 +68,25 @@
+ #define RPL_DIO_MOP_MASK                 0x38
+ #define RPL_DIO_PREFERENCE_MASK          0x07
+
+-#define UIP_IP_BUF       ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
+-#define UIP_ICMP_BUF     ((struct uip_icmp_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+-#define UIP_ICMP_PAYLOAD ((unsigned char *)&uip_buf[uip_l2_l3_icmp_hdr_len])
++/* least intrusive way to prevent -Wstrict-aliasing from firing */
++static inline struct uip_ip_hdr *uip_ip_buf(void)
++{
++    return ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN]);
++}
++
++static inline struct uip_icmp_hdr *uip_icmp_buf(void)
++{
++    return ((struct uip_icmp_hdr *)&uip_buf[uip_l2_l3_hdr_len]);
++}
++
++static inline unsigned char *uip_icmp_payload(void)
++{
++    return ((unsigned char *)&uip_buf[uip_l2_l3_icmp_hdr_len]);
++}
++
++#define UIP_IP_BUF       (uip_ip_buf())
++#define UIP_ICMP_BUF     (uip_icmp_buf())
++#define UIP_ICMP_PAYLOAD (uip_icmp_payload())
+ /*---------------------------------------------------------------------------*/
+ static void dis_input(void);
+ static void dio_input(void);
+@@ -950,7 +966,7 @@ dao_ack_output(rpl_instance_t *instance, uip_ipaddr_t *dest, uint8_t sequence)
+ }
+ /*---------------------------------------------------------------------------*/
+ void
+-rpl_icmp6_register_handlers()
++rpl_icmp6_register_handlers(void)
+ {
+     uip_icmp6_register_input_handler(&dis_handler);
+     uip_icmp6_register_input_handler(&dio_handler);
+diff --git a/emb6/src/net/sicslowpan/sicslowpan.c b/emb6/src/net/sicslowpan/sicslowpan.c
+index 79afefe..529c6f4 100644
+--- a/emb6/src/net/sicslowpan/sicslowpan.c
++++ b/emb6/src/net/sicslowpan/sicslowpan.c
+@@ -161,13 +161,34 @@ void uip_log(char *msg);
+ /** \name Pointers in the sicslowpan and uip buffer
+  *  @{
+  */
+-#define SICSLOWPAN_IP_BUF   ((struct uip_ip_hdr *)&sicslowpan_buf[UIP_LLH_LEN])
+-#define SICSLOWPAN_UDP_BUF ((struct uip_udp_hdr *)&sicslowpan_buf[UIP_LLIPH_LEN])
++/* least intrusive way to prevent -Wstrict-aliasing from firing */
++struct uip_ip_hdr *uip_ip_buf(void)
++{
++    return ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN]);
++}
++
++struct uip_udp_hdr *uip_udp_buf(void)
++{
++    return ((struct uip_udp_hdr *)&uip_buf[UIP_LLIPH_LEN]);
++}
++
++struct uip_tcp_hdr *uip_tcp_buf(void)
++{
++    return ((struct uip_tcp_hdr *)&uip_buf[UIP_LLIPH_LEN]);
++}
++
++struct uip_icmp_hdr *uip_icmp_buf(void)
++{
++    return ((struct uip_icmp_hdr *)&uip_buf[UIP_LLIPH_LEN]);
++}
++
++#define SICSLOWPAN_IP_BUF   (sicslowpan_ip_buf())
++#define SICSLOWPAN_UDP_BUF (sicslowpan_udp_buf())
+
+-#define UIP_IP_BUF          ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
+-#define UIP_UDP_BUF          ((struct uip_udp_hdr *)&uip_buf[UIP_LLIPH_LEN])
+-#define UIP_TCP_BUF          ((struct uip_tcp_hdr *)&uip_buf[UIP_LLIPH_LEN])
+-#define UIP_ICMP_BUF          ((struct uip_icmp_hdr *)&uip_buf[UIP_LLIPH_LEN])
++#define UIP_IP_BUF          (uip_ip_buf())
++#define UIP_UDP_BUF          (uip_udp_buf())
++#define UIP_TCP_BUF          (uip_tcp_buf())
++#define UIP_ICMP_BUF          (uip_icmp_buf())
+ /** @} */
+
+
+@@ -282,6 +303,16 @@ static s_ns_t*        p_ns = NULL;
+ /*-------------------------------------------------------------------------*/
+ static struct rime_sniffer *callback = NULL;
+
++struct uip_ip_hdr *sicslowpan_ip_buf(void)
++{
++    return ((struct uip_ip_hdr *)&sicslowpan_buf[UIP_LLH_LEN]);
++}
++
++struct uip_udp_hdr *sicslowpan_udp_buf(void)
++{
++    return ((struct uip_udp_hdr *)&sicslowpan_buf[UIP_LLIPH_LEN]);
++}
++
+ void
+ rime_sniffer_add(struct rime_sniffer *s)
+ {
+@@ -295,7 +326,7 @@ rime_sniffer_remove(struct rime_sniffer *s)
+ }
+
+ static void
+-set_packet_attrs()
++set_packet_attrs(void)
+ {
+   int c = 0;
+   /* set protocol in NETWORK_ID */
+diff --git a/emb6/src/tport/udp-socket.c b/emb6/src/tport/udp-socket.c
+index 545f6bd..3980716 100644
+--- a/emb6/src/tport/udp-socket.c
++++ b/emb6/src/tport/udp-socket.c
+@@ -44,7 +44,12 @@ void _udp_sock_callback(c_event_t c_event, p_data_t p_data);
+
+ static uint8_t buf[UIP_BUFSIZE];
+
+-#define UIP_IP_BUF   ((struct uip_udpip_hdr *)&uip_buf[UIP_LLH_LEN])
++/* least intrusive way to prevent -Wstrict-aliasing from firing */
++static inline struct uip_udpip_hdr *uip_ip_buf(void) {
++    return ((struct uip_udpip_hdr *)&uip_buf[UIP_LLH_LEN]);
++}
++
++#define UIP_IP_BUF   (uip_ip_buf())
+
+ #define     LOGGER_ENABLE        LOGGER_CORE
+ #if            LOGGER_ENABLE     ==     TRUE
+--
+1.9.1
+

--- a/pkg/emb6/patches/0004-Provide-event-type-for-RIOT-s-conn_.-_send.patch
+++ b/pkg/emb6/patches/0004-Provide-event-type-for-RIOT-s-conn_.-_send.patch
@@ -1,0 +1,38 @@
+From 6b0721c0d546652238c139f0d41790cb77996442 Mon Sep 17 00:00:00 2001
+From: Martine Lenders <mail@martine-lenders.eu>
+Date: Fri, 26 Feb 2016 12:35:52 +0100
+Subject: [PATCH 4/4] Provide event type for RIOT's conn_.*_send
+
+---
+ utils/inc/evproc.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/utils/inc/evproc.h b/utils/inc/evproc.h
+index 5316a67..78153be 100644
+--- a/utils/inc/evproc.h
++++ b/utils/inc/evproc.h
+@@ -79,6 +79,7 @@
+                             EVENT_TYPE_ICMP6, \
+                             EVENT_TYPE_TCPIP, \
+                             EVENT_TYPE_SLIP_POLL, \
++                            EVENT_TYPE_CONN_SEND, \
+                             EVENT_TYPE_PCK_LL }
+
+ #define EVENT_TYPE_NONE             0x00    ///< No event
+@@ -89,11 +90,12 @@
+ #define EVENT_TYPE_ICMP6            0x05    ///< New icmp6 packet event
+ #define EVENT_TYPE_TCPIP            0x06    ///< New tcpip event
+ #define EVENT_TYPE_SLIP_POLL        0x07    ///< Process slip handler
++#define EVENT_TYPE_CONN_SEND        0x08    ///< Send command from conn layer
+ #define OBLIG_EVENT_PRIOR           0x0a
+ #define EVENT_TYPE_PCK_LL           0x0a    ///< New low level packet received
+
+
+-#define EVENT_TYPES_COUNT           8       ///< Counter of events in /ref EVENT_TYPES macro
++#define EVENT_TYPES_COUNT           9       ///< Counter of events in /ref EVENT_TYPES macro
+ #define MAX_CALLBACK_COUNT          7       ///< Maximal amount of callbacks in /ref st_funcRegList_t list
+ #define EVPROC_QUEUE_SIZE           20      ///< Maximal amount of events in /ref pst_evList queue
+ /*=============================================================================
+--
+1.9.1
+

--- a/sys/include/net/conn/udp.h
+++ b/sys/include/net/conn/udp.h
@@ -31,6 +31,10 @@
 #include "lwip/conn.h"
 #endif
 
+#ifdef MODULE_EMB6_CONN_UDP
+#include "emb6/conn/udp.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -1,0 +1,38 @@
+APPLICATION = emb6
+
+FEATURES_REQUIRED = periph_gpio periph_spi  # for at86rf231
+
+BOARD ?= samr21-xpro
+
+RIOTBASE ?= $(CURDIR)/../..
+
+BOARD_INSUFFICIENT_MEMORY := msb-430h stm32f0discovery weio z1
+
+USEMODULE += emb6_router
+USEMODULE += emb6_conn_udp
+USEMODULE += ipv6_addr
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+USEMODULE += od
+
+# define the driver to be used for selected boards
+ifneq (,$(filter samr21-xpro,$(BOARD)))
+  DRIVER := at86rf233
+endif
+ifneq (,$(filter iotlab-m3 fox,$(BOARD)))
+  DRIVER := at86rf231
+endif
+ifneq (,$(filter mulle,$(BOARD)))
+  DRIVER := at86rf212b
+endif
+
+# use the at86rf231 as fallback device
+DRIVER ?= at86rf231
+
+# include the selected driver
+USEMODULE += $(DRIVER)
+
+QUIET ?= 1
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/emb6/common.c
+++ b/tests/emb6/common.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include <stdbool.h>
+
+#include "common.h"
+
+size_t hex2ints(uint8_t *out, const char *in)
+{
+    bool upper = true;
+    size_t out_size = 0;
+
+    while (*in != '\0') {
+        char c;
+        if ((*in >= '0') && (*in <= '9')) {
+            c = '0';
+        }
+        else if ((*in >= 'a') && (*in <= 'f')) {
+            c = 'a' - 10;
+        }
+        else if ((*in >= 'A') && (*in <= 'F')) {
+            c = 'A' - 10;
+        }
+        else {
+            in++;
+            continue;
+        }
+        if (upper) {
+            *out = (char)(*in - c) << 4;
+        }
+        else {
+            *out |= (char)(*in - c);
+            out++;
+            out_size++;
+        }
+        upper = !upper;
+        in++;
+    }
+    if (!upper) {
+        out_size++;
+    }
+    return out_size;
+}
+
+/** @} */

--- a/tests/emb6/common.h
+++ b/tests/emb6/common.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2016 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief   Definitions for tests/lwip/
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+#ifndef MAIN_H_
+#define MAIN_H_
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Application configuration
+ * @{
+ */
+#define CONN_INBUF_SIZE         (256)
+#define SERVER_MSG_QUEUE_SIZE   (8)
+#define SERVER_BUFFER_SIZE      (64)
+/**
+ * @}
+ */
+
+/**
+ * @brief   Converts hex string to byte array.
+ *
+ * @param[out] out  Resulting byte array
+ * @param[in] in    `\0` terminated string. Non-hex characters (all except 0-9, a-f, A-F)
+ *                  will be ignored.
+ *
+ * @return  Length of @p out.
+ */
+size_t hex2ints(uint8_t *out, const char *in);
+
+/**
+ * @brief   Ping shell command
+ *
+ * @param[in] argc  number of arguments
+ * @param[in] argv  array of arguments
+ *
+ * @return  0 on success
+ * @return  other on error
+ */
+int ping_cmd(int argc, char **argv);
+
+#ifdef MODULE_CONN_UDP
+/**
+ * @brief   UDP IP shell command
+ *
+ * @param[in] argc  number of arguments
+ * @param[in] argv  array of arguments
+ *
+ * @return  0 on success
+ * @return  other on error
+ */
+int udp_cmd(int argc, char **argv);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MAIN_H_ */
+/** @} */

--- a/tests/emb6/main.c
+++ b/tests/emb6/main.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Test for raw IPv6 connections
+ *
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This test application tests the gnrc_conn_ip module. If you select protocol 58 you can also
+ * test if gnrc is able to deal with multiple subscribers to ICMPv6 (gnrc_icmpv6 and this
+ * application).
+ *
+ * @}
+ */
+
+#include <errno.h>
+#include <stdio.h>
+
+#include "at86rf2xx.h"
+#include "at86rf2xx_params.h"
+#include "common.h"
+#include "emb6.h"
+#include "emb6/netdev2.h"
+#include "uip-ds6.h"
+#include "net/ipv6/addr.h"
+#include "shell.h"
+#include "thread.h"
+#include "xtimer.h"
+
+#define EMB6_STACKSIZE  (THREAD_STACKSIZE_DEFAULT)
+#define EMB6_PRIO       (THREAD_PRIORITY_MAIN - 3)
+#define EMB6_DELAY      (500)
+
+static at86rf2xx_t at86rf2xx;
+static s_ns_t emb6 = {
+    .hc = &sicslowpan_driver,
+    .llsec = &nullsec_driver,
+    .hmac = &nullmac_driver,
+    .lmac = &sicslowmac_driver,
+    .frame = &framer_802154,
+    .c_configured = 1,
+};
+static char emb6_stack[EMB6_STACKSIZE];
+
+static int ifconfig(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    char addrstr[IPV6_ADDR_MAX_STR_LEN];
+    printf("0:  ");
+    for (int i = 0; i < UIP_DS6_ADDR_NB; i++) {
+        if (uip_ds6_if.addr_list[i].isused) {
+            printf("inet6 %s\n",
+                   ipv6_addr_to_str(addrstr,
+                                    (ipv6_addr_t *)&uip_ds6_if.addr_list[i].ipaddr,
+                                    sizeof(addrstr)));
+            if (i != 0) {
+                printf("    ");
+            }
+        }
+    }
+    puts("");
+    return 0;
+}
+
+static void *_emb6_thread(void *args)
+{
+    emb6_process(500);  /* never stops */
+    return NULL;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "ping6", "Send pings and receive pongs", ping_cmd },
+#ifdef MODULE_CONN_UDP
+    { "udp", "Send UDP messages and listen for messages on UDP port", udp_cmd },
+#endif
+    { "ifconfig", "Shows assigned IPv6 addresses", ifconfig },
+    { NULL, NULL, NULL }
+};
+static char line_buf[SHELL_DEFAULT_BUFSIZE];
+
+char conn_inbuf[CONN_INBUF_SIZE];
+
+int main(void)
+{
+    netdev2_t *netdev = (netdev2_t *)&at86rf2xx;
+
+    puts("RIOT lwip test application");
+
+    at86rf2xx_setup(&at86rf2xx, at86rf2xx_params);
+    netdev->driver->init((netdev2_t *)&at86rf2xx);
+    emb6_netdev2_setup(netdev);
+    emb6_init(&emb6);
+    thread_create(emb6_stack, sizeof(emb6_stack), EMB6_PRIO,
+                  THREAD_CREATE_STACKTEST, _emb6_thread, NULL, "emb6");
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    /* should be never reached */
+    return 0;
+}

--- a/tests/emb6/ping.c
+++ b/tests/emb6/ping.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Demonstrating the sending and receiving of UDP data over POSIX sockets.
+ *
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdbool.h>
+#include <inttypes.h>
+#include <stdio.h>
+
+#include "atomic.h"
+#include "byteorder.h"
+#include "net/icmpv6.h"
+#include "net/ipv6.h"
+#include "xtimer.h"
+
+#include "uip.h"
+#include "uip-icmp6.h"
+
+#include "common.h"
+
+#define ECHO_ID     (0xd1e9)
+
+static struct uip_icmp6_echo_reply_notification recv_ntfy = { NULL, NULL };
+static uint16_t seq = 0;
+static atomic_int_t received, num;
+
+static bool _waiting = true;
+
+static inline icmpv6_echo_t *uip_icmp_buf(void)
+{
+    return ((icmpv6_echo_t *)&uip_buf[uip_l2_l3_hdr_len]);
+}
+
+static inline int max_len(void)
+{
+    return UIP_BUFSIZE - (((uint8_t *)uip_icmp_buf()) - uip_buf) -
+           sizeof(icmpv6_echo_t);
+}
+
+static int ping_send(const uip_ipaddr_t *dst, int payload_len)
+{
+    int len = payload_len;
+    icmpv6_echo_t *ping = uip_icmp_buf();
+
+    ping->id = byteorder_htons(ECHO_ID);
+
+    if (payload_len > max_len()) {
+        puts("Payload too long for buffer.");
+        return -1;
+    }
+
+    for (network_uint16_t *payload = (network_uint16_t *)(ping + 1);
+         len >= 0;
+         payload++, len -= 2) {
+        *payload = byteorder_htons(seq);
+    }
+
+    ping->seq = byteorder_htons(seq++);
+
+    uip_icmp6_send((const uip_ipaddr_t *)dst, ICMPV6_ECHO_REQ, 0,
+                   payload_len + (sizeof(icmpv6_echo_t) - sizeof(icmpv6_hdr_t)));
+
+    return 0;
+}
+
+static void handle_reply(uip_ipaddr_t *source, uint8_t ttl, uint8_t *data,
+                         uint16_t datalen)
+{
+    char addr_str[IPV6_ADDR_MAX_STR_LEN];
+    icmpv6_echo_t *ping = (icmpv6_echo_t *)data;
+
+    _waiting = false;
+
+    ipv6_addr_to_str(addr_str, (ipv6_addr_t *)source, sizeof(addr_str));
+
+    atomic_inc(&received);
+    printf("%" PRIu16 " bytes from %s: icmp_seq=%" PRIu16 " ttl=%u quota=%i/%i\n",
+           datalen, addr_str, byteorder_ntohs(ping->seq), (unsigned)ttl,
+           ATOMIC_VALUE(received), ATOMIC_VALUE(num));
+}
+
+void usage(char *cmd)
+{
+    printf("usage: %s <dst> [<num>] [<payload_len>]\n", cmd);
+}
+
+int ping_cmd(int argc, char **argv)
+{
+    ipv6_addr_t dst;
+    int payload_len, _num;
+
+    if ((argc < 2) || (ipv6_addr_from_str(&dst, argv[1]) == NULL)) {
+        usage(argv[0]);
+        return 1;
+    }
+    if ((argc < 3) || ((_num = atoi(argv[2])) == 0)) {
+        _num = 3;
+    }
+    if ((argc < 4) || ((payload_len = atoi(argv[3])) == 0)) {
+        payload_len = 16;
+    }
+    atomic_set_to_zero(&num);
+    atomic_cas(&num, 0, _num);
+    atomic_set_to_zero(&received);
+    seq = 0;
+    if (recv_ntfy.callback == NULL) {
+        uip_icmp6_echo_reply_callback_add(&recv_ntfy, handle_reply);
+    }
+    for (uint16_t i = 0; i < _num; i++) {
+        _waiting = true;
+        ping_send((uip_ipaddr_t *)&dst, payload_len);
+        xtimer_usleep(1000000);
+        if (_waiting) {
+            puts("Timeout");
+        }
+    }
+
+    return 0;
+}
+
+/** @} */

--- a/tests/emb6/udp.c
+++ b/tests/emb6/udp.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Demonstrating the sending and receiving of UDP data over POSIX sockets.
+ *
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "common.h"
+#include "od.h"
+#include "net/af.h"
+#include "net/conn/udp.h"
+#include "net/ipv6.h"
+#include "thread.h"
+#include "xtimer.h"
+
+#ifdef MODULE_CONN_UDP
+static char conn_inbuf[CONN_INBUF_SIZE];
+static bool server_running;
+static conn_udp_t server_conn;
+static char server_stack[THREAD_STACKSIZE_DEFAULT];
+static msg_t server_msg_queue[SERVER_MSG_QUEUE_SIZE];
+
+static void *_server_thread(void *args)
+{
+    ipv6_addr_t server_addr = IPV6_ADDR_UNSPECIFIED;
+    uint16_t port;
+    int res;
+
+    msg_init_queue(server_msg_queue, SERVER_MSG_QUEUE_SIZE);
+    /* parse port */
+    port = (uint16_t)atoi((char *)args);
+    if ((res = conn_udp_create(&server_conn, &server_addr,
+                               sizeof(server_addr), AF_INET6, port)) < 0) {
+        printf("Unable to open UDP server on port %" PRIu16 " (error code %d)\n",
+               port, -res);
+        return NULL;
+    }
+    server_running = true;
+    printf("Success: started UDP server on port %" PRIu16 "\n", port);
+    while (1) {
+        int res;
+        ipv6_addr_t src;
+        size_t src_len = sizeof(ipv6_addr_t);
+        uint16_t sport;
+        if ((res = conn_udp_recvfrom(&server_conn, conn_inbuf, sizeof(conn_inbuf), &src,
+                                     &src_len, &sport)) < 0) {
+            puts("Error on receive");
+        }
+        else if (res == 0) {
+            puts("No data received");
+        }
+        else {
+            char addrstr[IPV6_ADDR_MAX_STR_LEN];
+            printf("Received from [%s]:%" PRIu16 ":\n", ipv6_addr_to_str(addrstr, &src,
+                                                                         sizeof(addrstr)), sport);
+            od_hex_dump(conn_inbuf, res, 0);
+        }
+    }
+    return NULL;
+}
+
+static int udp_send(char *addr_str, char *port_str, char *data, unsigned int num,
+                    unsigned int delay)
+{
+    ipv6_addr_t src = IPV6_ADDR_UNSPECIFIED, dst;
+    uint16_t port;
+    uint8_t byte_data[strlen(data) / 2];
+    size_t data_len;
+
+    /* parse destination address */
+    if (ipv6_addr_from_str(&dst, addr_str) == NULL) {
+        puts("Error: unable to parse destination address");
+        return 1;
+    }
+    /* parse port */
+    port = (uint16_t)atoi(port_str);
+    data_len = hex2ints(byte_data, data);
+    for (unsigned int i = 0; i < num; i++) {
+        if (conn_udp_sendto(byte_data, data_len, &src, sizeof(src), (struct sockaddr *)&dst,
+                            sizeof(dst), AF_INET6, port, port) < 0) {
+            puts("could not send");
+        }
+        else {
+            printf("Success: send %u byte to [%s]:%" PRIu16 ")\n",
+                   (unsigned)data_len, addr_str, port);
+        }
+        xtimer_usleep(delay);
+    }
+    return 0;
+}
+
+static int udp_start_server(char *port_str)
+{
+    if (thread_create(server_stack, sizeof(server_stack), THREAD_PRIORITY_MAIN - 1,
+                      THREAD_CREATE_STACKTEST, _server_thread, port_str,
+                      "UDP server") <= KERNEL_PID_UNDEF) {
+        return 1;
+    }
+    return 0;
+}
+
+int udp_cmd(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("usage: %s [send|server]\n", argv[0]);
+        return 1;
+    }
+
+    if (strcmp(argv[1], "send") == 0) {
+        uint32_t num = 1;
+        uint32_t delay = 1000000;
+        if (argc < 5) {
+            printf("usage: %s send <addr> <port> <hex data> [<num> [<delay in us>]]\n",
+                   argv[0]);
+            return 1;
+        }
+        if (argc > 5) {
+            num = (uint32_t)atoi(argv[5]);
+        }
+        if (argc > 6) {
+            delay = (uint32_t)atoi(argv[6]);
+        }
+        return udp_send(argv[2], argv[3], argv[4], num, delay);
+    }
+    else if (strcmp(argv[1], "server") == 0) {
+        if (argc < 3) {
+            printf("usage: %s server [start|stop]\n", argv[0]);
+            return 1;
+        }
+        if (strcmp(argv[2], "start") == 0) {
+            if (argc < 4) {
+                printf("usage %s server start <port>\n", argv[0]);
+                return 1;
+            }
+            return udp_start_server(argv[3]);
+        }
+        else {
+            puts("error: invalid command");
+            return 1;
+        }
+    }
+    else {
+        puts("error: invalid command");
+        return 1;
+    }
+}
+#else
+typedef int dont_be_pedantic;
+#endif
+
+/** @} */


### PR DESCRIPTION
[emb6](https://github.com/hso-esk/emb6) is a fork of Contiki's uIP without the requirement for proto-threads. As with #3551 this is import is mainly for benchmarking, but maybe some of you are interested in a smaller 6LoWPAN stack.

Still WIP.

- [x] `netdev2` wrapper
- [x] `conn`
  - ~~`conn_ip` wrapper~~ (not done because not simple).
  - [x] `conn_udp` wrapper

Depends on ~~#4646~~ (merged).