### PR TITLE
Add linker file for Atmel SAMR21E18A

### DIFF
--- a/boards/samr21-xpro/Makefile.include
+++ b/boards/samr21-xpro/Makefile.include
@@ -1,6 +1,6 @@
 # define the cpu used by SAMR21 Xplained Pro board
 export CPU = samd21
-export CPU_MODEL = samr21g18a
+export CPU_MODEL = samr21x18a
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0

--- a/cpu/samd21/ldscripts/samr21x18a.ld
+++ b/cpu/samd21/ldscripts/samr21x18a.ld
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
+ * Copyright (C) 2015, 2016 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief           Memory definitions for the SAMR21G18A
+ * @brief           Memory definitions for the SAMR21E18A and SAMR21G18A
  *
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  *


### PR DESCRIPTION
This file is identical to the existing SAMR21G18A. The chips differ only in their physical packaging. It is used by a new platform we are developing for RIOT, and I thought instead of waiting until the end and dropping a massive pull request on you, I would try give a sequence of small PR's that are easy to review.