### PR TITLE
nd: remove unused gnrc_sixlowpan_nd_wakeup

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/nd.h
+++ b/sys/include/net/gnrc/sixlowpan/nd.h
@@ -220,15 +220,6 @@ uint8_t gnrc_sixlowpan_nd_opt_ar_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6,
  */
 bool gnrc_sixlowpan_nd_opt_6ctx_handle(uint8_t icmpv6_type, sixlowpan_nd_opt_6ctx_t *ctx_opt);
 
-/**
- * @brief   Handles registration calls after node-wakeup.
- *
- * @see     <a href="https://tools.ietf.org/html/rfc6775#section-5.8.2">
- *              RFC 6776, section 5.8.2
- *          </a>
- */
-void gnrc_sixlowpan_nd_wakeup(void);
-
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
 /**
  * @brief   Handles authoritative border router option.

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -391,17 +391,6 @@ bool gnrc_sixlowpan_nd_opt_6ctx_handle(uint8_t icmpv6_type, sixlowpan_nd_opt_6ct
     return true;
 }
 
-void gnrc_sixlowpan_nd_wakeup(void)
-{
-    gnrc_ipv6_nc_t *router = gnrc_ipv6_nc_get_next_router(NULL);
-    while (router) {
-        gnrc_sixlowpan_nd_uc_rtr_sol(router);
-        gnrc_ndp_internal_send_nbr_sol(router->iface, NULL, &router->ipv6_addr, &router->ipv6_addr);
-        gnrc_ndp_internal_reset_nbr_sol_timer(router, GNRC_NDP_RETRANS_TIMER,
-                                              GNRC_NDP_MSG_NBR_SOL_RETRANS, gnrc_ipv6_pid);
-    }
-}
-
 /* gnrc_sixlowpan_nd_opt_abr_handle etc. implemented in gnrc_sixlowpan_nd_router */
 
 /** @} */


### PR DESCRIPTION
`gnrc_sixlowpan_nd_wakeup()` is not used anywhere. Is this function a left-over? Does it still behave as intended when someone calls this function? After all it is exposed via our APIs.