### PR TITLE
cpu/cc2538: xtimers mostly working

### DIFF
--- a/boards/cc2538dk/include/board.h
+++ b/boards/cc2538dk/include/board.h
@@ -28,6 +28,15 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Xtimer configuration
+ * @{
+ */
+#define XTIMER                      (0)
+#define XTIMER_CHAN                 (0)
+#define XTIMER_BACKOFF              (40)
+/** @} */
+
+/**
  * @name Macros for controlling the on-board LEDs.
  * @{
  */

--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -39,7 +39,7 @@ extern "C" {
 
 /* Timer 0 configuration */
 #define TIMER_0_DEV         GPTIMER0
-#define TIMER_0_CHANNELS    NUM_CHANNELS_PER_GPTIMER
+#define TIMER_0_CHANNELS    1
 #define TIMER_0_MAX_VALUE   0xffffffff
 #define TIMER_0_IRQn_1      GPTIMER_0A_IRQn
 #define TIMER_0_IRQn_2      GPTIMER_0B_IRQn
@@ -48,7 +48,7 @@ extern "C" {
 
 /* Timer 1 configuration */
 #define TIMER_1_DEV         GPTIMER1
-#define TIMER_1_CHANNELS    NUM_CHANNELS_PER_GPTIMER
+#define TIMER_1_CHANNELS    1
 #define TIMER_1_MAX_VALUE   0xffffffff
 #define TIMER_1_IRQn_1      GPTIMER_1A_IRQn
 #define TIMER_1_IRQn_2      GPTIMER_1B_IRQn
@@ -57,7 +57,7 @@ extern "C" {
 
 /* Timer 2 configuration */
 #define TIMER_2_DEV         GPTIMER2
-#define TIMER_2_CHANNELS    NUM_CHANNELS_PER_GPTIMER
+#define TIMER_2_CHANNELS    1
 #define TIMER_2_MAX_VALUE   0xffffffff
 #define TIMER_2_IRQn_1      GPTIMER_2A_IRQn
 #define TIMER_2_IRQn_2      GPTIMER_2B_IRQn
@@ -66,7 +66,7 @@ extern "C" {
 
 /* Timer 3 configuration */
 #define TIMER_3_DEV         GPTIMER3
-#define TIMER_3_CHANNELS    NUM_CHANNELS_PER_GPTIMER
+#define TIMER_3_CHANNELS    1
 #define TIMER_3_MAX_VALUE   0xffffffff
 #define TIMER_3_IRQn_1      GPTIMER_3A_IRQn
 #define TIMER_3_IRQn_2      GPTIMER_3B_IRQn

--- a/cpu/cc2538/include/cc2538_gptimer.h
+++ b/cpu/cc2538/include/cc2538_gptimer.h
@@ -56,7 +56,7 @@ typedef struct {
         cc2538_reg_t TAMR;                  /**< GPTIMER Timer A mode */
         struct {
             cc2538_reg_t TAMR2     :  2;    /**< GPTM Timer A mode */
-            cc2538_reg_t TACRM     :  1;    /**< GPTM Timer A capture mode */
+            cc2538_reg_t TACMR     :  1;    /**< GPTM Timer A capture mode */
             cc2538_reg_t TAAMS     :  1;    /**< GPTM Timer A alternate mode */
             cc2538_reg_t TACDIR    :  1;    /**< GPTM Timer A count direction */
             cc2538_reg_t TAMIE     :  1;    /**< GPTM Timer A match interrupt enable */
@@ -77,7 +77,7 @@ typedef struct {
         cc2538_reg_t TBMR;                  /**< GPTIMER Timer B mode */
         struct {
             cc2538_reg_t TBMR2     :  2;    /**< GPTM Timer B mode */
-            cc2538_reg_t TBCRM     :  1;    /**< GPTM Timer B capture mode */
+            cc2538_reg_t TBCMR     :  1;    /**< GPTM Timer B capture mode */
             cc2538_reg_t TBAMS     :  1;    /**< GPTM Timer B alternate mode */
             cc2538_reg_t TBCDIR    :  1;    /**< GPTM Timer B count direction */
             cc2538_reg_t TBMIE     :  1;    /**< GPTM Timer B match interrupt enable */
@@ -156,6 +156,7 @@ typedef struct {
     cc2538_reg_t TBPV;                      /**< GPTIMER Timer B Prescale Value */
     cc2538_reg_t RESERVED[981];             /**< Reserved */
     cc2538_reg_t PP;                        /**< GPTIMER Peripheral Properties */
+    cc2538_reg_t RESERVED4[15];             /**< Reserved */
 } cc2538_gptimer_t;
 
 #define GPTIMER0 ( (cc2538_gptimer_t*)0x40030000 )       /**< GPTIMER0 Instance */

--- a/cpu/cc2538/include/cc2538_gptimer.h
+++ b/cpu/cc2538/include/cc2538_gptimer.h
@@ -116,7 +116,24 @@ typedef struct {
 
     cc2538_reg_t SYNC;                      /**< GPTIMER Synchronize */
     cc2538_reg_t RESERVED2;                 /**< Reserved word */
+
+    union {
     cc2538_reg_t IMR;                       /**< GPTIMER Interrupt Mask */
+        struct {
+            cc2538_reg_t TATOIM    :  1;    /**< GPTM Timer A time-out interrupt mask */
+            cc2538_reg_t CAMIM     :  1;    /**< GPTM Timer A capture match interrupt mask */
+            cc2538_reg_t CAEIM     :  1;    /**< GPTM Timer A capture event interrupt mask */
+            cc2538_reg_t RESERVED1 :  1;    /**< Reserved bits */
+            cc2538_reg_t TAMIM     :  1;    /**< GPTM Timer A match interrupt mask */
+            cc2538_reg_t RESERVED2 :  3;    /**< Reserved bits */
+            cc2538_reg_t TBTOIM    :  1;    /**< GPTM Timer B time-out interrupt mask */
+            cc2538_reg_t CBMIM     :  1;    /**< GPTM Timer B capture match interrupt mask */
+            cc2538_reg_t CBEIM     :  1;    /**< GPTM Timer B capture event interrupt mask */
+            cc2538_reg_t TBMIM     :  1;    /**< GPTM Timer B match interrupt mask */
+            cc2538_reg_t RESERVED3 : 20;    /**< Reserved bits */
+        } IMRbits;
+    };
+
     cc2538_reg_t RIS;                       /**< GPTIMER Raw Interrupt Status */
     cc2538_reg_t MIS;                       /**< GPTIMER Masked Interrupt Status */
     cc2538_reg_t ICR;                       /**< GPTIMER Interrupt Clear */

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -83,7 +83,7 @@ int timer_init(tim_t dev, unsigned int ticks_per_us, void (*callback)(int))
      * so the only frequency available is 16 MHz.
      */
     if (ticks_per_us != 16) {
-        return -1;
+        printf("%s(): Invalid ticks_per_us=%u. Using 16 instead.\n", __FUNCTION__, ticks_per_us);
     }
 
     gptimer_num = ((uintptr_t)gptimer - (uintptr_t)GPTIMER0) / 0x1000;


### PR DESCRIPTION
This switches the MCU's gptimers from two-channel 16-bit mode to single-channel 32-bit mode. I don't think the 16-bit mode ever worked right anyway. In 32-bit mode there is no prescaler so the xtimers are stuck at 16 MHz. Bummer, but it shouldn't be an issue once https://github.com/RIOT-OS/RIOT/pull/4040 is merged. For now the xtimers run too fast. This PR will also improve my I2C driver https://github.com/RIOT-OS/RIOT/pull/3765.