### PR TITLE
sys: net: gnrc: prefer prefix list over fib

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -139,12 +139,16 @@ kernel_pid_t gnrc_sixlowpan_nd_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_
     if ((next_hop == NULL) && !ipv6_addr_is_link_local(dst)) {
         size_t next_hop_size = sizeof(ipv6_addr_t);
         uint32_t next_hop_flags = 0;
-        if ((next_hop == NULL) &&
-            (fib_get_next_hop(&gnrc_ipv6_fib_table, &fib_iface, next_hop_actual.u8, &next_hop_size,
-                              &next_hop_flags, (uint8_t *)dst,
-                              sizeof(ipv6_addr_t), 0) >= 0) &&
-            (next_hop_size == sizeof(ipv6_addr_t))) {
-            next_hop = &next_hop_actual;
+        ipv6_addr_t *prefix = NULL;
+        kernel_pid_t tmp_iface = gnrc_ipv6_netif_find_by_prefix(&prefix, dst);
+        if (tmp_iface == KERNEL_PID_UNDEF) {
+            if ((next_hop == NULL) &&
+                    (fib_get_next_hop(&gnrc_ipv6_fib_table, &iface, next_hop_actual.u8, &next_hop_size,
+                                      &next_hop_flags, (uint8_t *)dst,
+                                      sizeof(ipv6_addr_t), 0) >= 0) &&
+                    (next_hop_size == sizeof(ipv6_addr_t))) {
+                next_hop = &next_hop_actual;
+            }
         }
     }
 #endif


### PR DESCRIPTION
Currently, an entry in the fib (e.g., default route) is preferred over an entry in the prefix list.
This patch skips fib lookup if an entry in the prefix list exists.

(It is possible that the fib contains a matching entry with prefix length > 64. That would be skipped using this PR. But as that is a far more specific use case than a default route entry in the fib, I propose merging this and fixing lookup later.)