### PR TITLE
rpl: make PIOs in DIOs configurable and send them out always or never

### DIFF
--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -12,6 +12,26 @@
  * @defgroup    net_gnrc_rpl  RPL
  * @ingroup     net_gnrc
  * @brief       RPL implementation for GNRC
+ *
+ * Configuration
+ * =============
+ *
+ * USEMODULE
+ * ---------
+ *
+ * - RPL (Storing Mode)
+ *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
+ *   USEMODULE += gnrc_rpl
+ *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * CFLAGS
+ * ------
+ *
+ *  - Exclude Prefix Information Options from DIOs
+ *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
+ *   CFLAGS += -DGNRC_RPL_WITHOUT_PIO
+ *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
  * @{
  *
  * @file

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -483,6 +483,7 @@ void gnrc_rpl_send(gnrc_pktsnip_t *pkt, ipv6_addr_t *src, ipv6_addr_t *dst, ipv6
  */
 uint8_t gnrc_rpl_gen_instance_id(bool local);
 
+#ifndef GNRC_RPL_WITHOUT_PIO
 /**
  * @brief (De-)Activate the transmission of Prefix Information Options within DIOs
  *        for a particular DODAG
@@ -495,6 +496,8 @@ static inline void gnrc_rpl_config_pio(gnrc_rpl_dodag_t *dodag, bool status)
     dodag->req_opts = (dodag->req_opts & ~GNRC_RPL_REQ_OPT_PREFIX_INFO) |
                       (status << GNRC_RPL_REQ_OPT_PREFIX_INFO_SHIFT);
 }
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -482,6 +482,19 @@ void gnrc_rpl_send(gnrc_pktsnip_t *pkt, ipv6_addr_t *src, ipv6_addr_t *dst, ipv6
  * @return  Global instance id, otherwise.
  */
 uint8_t gnrc_rpl_gen_instance_id(bool local);
+
+/**
+ * @brief (De-)Activate the transmission of Prefix Information Options within DIOs
+ *        for a particular DODAG
+ *
+ * @param[in] dodag             Pointer to the DODAG
+ * @param[in] status            true for activating PIOs and false for deactivating them
+ */
+static inline void gnrc_rpl_config_pio(gnrc_rpl_dodag_t *dodag, bool status)
+{
+    dodag->req_opts = (dodag->req_opts & ~GNRC_RPL_REQ_OPT_PREFIX_INFO) |
+                      (status << GNRC_RPL_REQ_OPT_PREFIX_INFO_SHIFT);
+}
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -32,6 +32,16 @@ extern "C" {
 #include "trickle.h"
 
 /**
+ * @name Bit positions and shifts for gnrc_rpl_dodag_t::req_opts
+ * @{
+ */
+#define GNRC_RPL_REQ_OPT_DODAG_CONF_SHIFT       (0)
+#define GNRC_RPL_REQ_OPT_DODAG_CONF             (1 << GNRC_RPL_REQ_OPT_DODAG_CONF_SHIFT)
+#define GNRC_RPL_REQ_OPT_PREFIX_INFO_SHIFT      (1)
+#define GNRC_RPL_REQ_OPT_PREFIX_INFO            (1 << GNRC_RPL_REQ_OPT_PREFIX_INFO_SHIFT)
+/** @} */
+
+/**
  * @brief RPL-Option Generic Format
  * @see <a href="https://tools.ietf.org/html/rfc6550#section-6.7.1">
  *          RFC6550, section 6.7.1, RPL Control Message Option Generic Format
@@ -220,8 +230,7 @@ struct gnrc_rpl_dodag {
     uint8_t dao_seq;                /**< dao sequence number */
     uint8_t dao_counter;            /**< amount of retried DAOs */
     bool dao_ack_received;          /**< flag to check for DAO-ACK */
-    bool dodag_conf_requested;      /**< flag to send DODAG_CONF options */
-    bool prefix_info_requested;     /**< flag to send PREFIX_INFO options */
+    uint8_t req_opts;               /**< flags that represent option requests */
     uint8_t dao_time;               /**< time to schedule a DAO in seconds */
     trickle_t trickle;              /**< trickle representation */
 };

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -104,7 +104,9 @@ gnrc_rpl_instance_t *gnrc_rpl_root_init(uint8_t instance_id, ipv6_addr_t *dodag_
     dodag->node_status = GNRC_RPL_ROOT_NODE;
     dodag->my_rank = GNRC_RPL_ROOT_RANK;
     dodag->req_opts |= GNRC_RPL_REQ_OPT_DODAG_CONF;
+#ifndef GNRC_RPL_WITHOUT_PIO
     dodag->req_opts |= GNRC_RPL_REQ_OPT_PREFIX_INFO;
+#endif
 
     trickle_start(gnrc_rpl_pid, &dodag->trickle, GNRC_RPL_MSG_TYPE_TRICKLE_INTERVAL,
                   GNRC_RPL_MSG_TYPE_TRICKLE_CALLBACK, (1 << dodag->dio_min),

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -103,8 +103,8 @@ gnrc_rpl_instance_t *gnrc_rpl_root_init(uint8_t instance_id, ipv6_addr_t *dodag_
     dodag->grounded = GNRC_RPL_GROUNDED;
     dodag->node_status = GNRC_RPL_ROOT_NODE;
     dodag->my_rank = GNRC_RPL_ROOT_RANK;
-    dodag->dodag_conf_requested = true;
-    dodag->prefix_info_requested = true;
+    dodag->req_opts |= GNRC_RPL_REQ_OPT_DODAG_CONF;
+    dodag->req_opts |= GNRC_RPL_REQ_OPT_PREFIX_INFO;
 
     trickle_start(gnrc_rpl_pid, &dodag->trickle, GNRC_RPL_MSG_TYPE_TRICKLE_INTERVAL,
                   GNRC_RPL_MSG_TYPE_TRICKLE_CALLBACK, (1 << dodag->dio_min),

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -156,7 +156,6 @@ void gnrc_rpl_send_DIO(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination)
         if ((pkt = _dio_prefix_info_build(pkt, dodag)) == NULL) {
             return;
         }
-        dodag->req_opts &= ~GNRC_RPL_REQ_OPT_PREFIX_INFO;
     }
 
     if (dodag->req_opts & GNRC_RPL_REQ_OPT_DODAG_CONF) {
@@ -263,7 +262,6 @@ void gnrc_rpl_recv_DIS(gnrc_rpl_dis_t *dis, ipv6_addr_t *src, ipv6_addr_t *dst, 
         for (uint8_t i = 0; i < GNRC_RPL_INSTANCES_NUMOF; ++i) {
             if (gnrc_rpl_instances[i].state != 0) {
                 gnrc_rpl_instances[i].dodag.req_opts |= GNRC_RPL_REQ_OPT_DODAG_CONF;
-                gnrc_rpl_instances[i].dodag.req_opts |= GNRC_RPL_REQ_OPT_PREFIX_INFO;
                 gnrc_rpl_send_DIO(&gnrc_rpl_instances[i], src);
             }
         }

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -152,18 +152,18 @@ void gnrc_rpl_send_DIO(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination)
     gnrc_pktsnip_t *pkt = NULL, *tmp = NULL;
     gnrc_rpl_dio_t *dio;
 
-    if (dodag->prefix_info_requested) {
+    if (dodag->req_opts & GNRC_RPL_REQ_OPT_PREFIX_INFO) {
         if ((pkt = _dio_prefix_info_build(pkt, dodag)) == NULL) {
             return;
         }
-        dodag->prefix_info_requested = false;
+        dodag->req_opts &= ~GNRC_RPL_REQ_OPT_PREFIX_INFO;
     }
 
-    if (dodag->dodag_conf_requested) {
+    if (dodag->req_opts & GNRC_RPL_REQ_OPT_DODAG_CONF) {
         if ((pkt = _dio_dodag_conf_build(pkt, dodag)) == NULL) {
             return;
         }
-        dodag->dodag_conf_requested = false;
+        dodag->req_opts &= ~GNRC_RPL_REQ_OPT_DODAG_CONF;
     }
 
     if ((tmp = gnrc_pktbuf_add(pkt, NULL, sizeof(gnrc_rpl_dio_t), GNRC_NETTYPE_UNDEF)) == NULL) {
@@ -262,8 +262,8 @@ void gnrc_rpl_recv_DIS(gnrc_rpl_dis_t *dis, ipv6_addr_t *src, ipv6_addr_t *dst, 
     else {
         for (uint8_t i = 0; i < GNRC_RPL_INSTANCES_NUMOF; ++i) {
             if (gnrc_rpl_instances[i].state != 0) {
-                gnrc_rpl_instances[i].dodag.dodag_conf_requested = true;
-                gnrc_rpl_instances[i].dodag.prefix_info_requested = true;
+                gnrc_rpl_instances[i].dodag.req_opts |= GNRC_RPL_REQ_OPT_DODAG_CONF;
+                gnrc_rpl_instances[i].dodag.req_opts |= GNRC_RPL_REQ_OPT_PREFIX_INFO;
                 gnrc_rpl_send_DIO(&gnrc_rpl_instances[i], src);
             }
         }
@@ -388,7 +388,7 @@ bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt_t *opt
             case (GNRC_RPL_OPT_DODAG_CONF):
                 DEBUG("RPL: DODAG CONF DIO option parsed\n");
                 *included_opts |= ((uint32_t) 1) << GNRC_RPL_OPT_DODAG_CONF;
-                dodag->dodag_conf_requested = true;
+                dodag->req_opts |= GNRC_RPL_REQ_OPT_DODAG_CONF;
                 gnrc_rpl_opt_dodag_conf_t *dc = (gnrc_rpl_opt_dodag_conf_t *) opt;
                 gnrc_rpl_of_t *of = gnrc_rpl_get_of_for_ocp(byteorder_ntohs(dc->ocp));
                 if (of != NULL) {
@@ -413,7 +413,7 @@ bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt_t *opt
             case (GNRC_RPL_OPT_PREFIX_INFO):
                 DEBUG("RPL: Prefix Information DIO option parsed\n");
                 *included_opts |= ((uint32_t) 1) << GNRC_RPL_OPT_PREFIX_INFO;
-                dodag->prefix_info_requested = true;
+                dodag->req_opts |= GNRC_RPL_REQ_OPT_PREFIX_INFO;
                 gnrc_rpl_opt_prefix_info_t *pi = (gnrc_rpl_opt_prefix_info_t *) opt;
                 ipv6_addr_t all_RPL_nodes = GNRC_RPL_ALL_NODES_ADDR;
                 if_id = gnrc_ipv6_netif_find_by_addr(NULL, &all_RPL_nodes);

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -116,6 +116,7 @@ gnrc_pktsnip_t *_dio_dodag_conf_build(gnrc_pktsnip_t *pkt, gnrc_rpl_dodag_t *dod
     return opt_snip;
 }
 
+#ifndef GNRC_RPL_WITHOUT_PIO
 gnrc_pktsnip_t *_dio_prefix_info_build(gnrc_pktsnip_t *pkt, gnrc_rpl_dodag_t *dodag)
 {
     gnrc_rpl_opt_prefix_info_t *prefix_info;
@@ -140,6 +141,7 @@ gnrc_pktsnip_t *_dio_prefix_info_build(gnrc_pktsnip_t *pkt, gnrc_rpl_dodag_t *do
     ipv6_addr_init_prefix(&prefix_info->prefix, &dodag->dodag_id, dodag->prefix_len);
     return opt_snip;
 }
+#endif
 
 void gnrc_rpl_send_DIO(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination)
 {
@@ -152,11 +154,13 @@ void gnrc_rpl_send_DIO(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination)
     gnrc_pktsnip_t *pkt = NULL, *tmp = NULL;
     gnrc_rpl_dio_t *dio;
 
+#ifndef GNRC_RPL_WITHOUT_PIO
     if (dodag->req_opts & GNRC_RPL_REQ_OPT_PREFIX_INFO) {
         if ((pkt = _dio_prefix_info_build(pkt, dodag)) == NULL) {
             return;
         }
     }
+#endif
 
     if (dodag->req_opts & GNRC_RPL_REQ_OPT_DODAG_CONF) {
         if ((pkt = _dio_dodag_conf_build(pkt, dodag)) == NULL) {
@@ -411,7 +415,9 @@ bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt_t *opt
             case (GNRC_RPL_OPT_PREFIX_INFO):
                 DEBUG("RPL: Prefix Information DIO option parsed\n");
                 *included_opts |= ((uint32_t) 1) << GNRC_RPL_OPT_PREFIX_INFO;
+#ifndef GNRC_RPL_WITHOUT_PIO
                 dodag->req_opts |= GNRC_RPL_REQ_OPT_PREFIX_INFO;
+#endif
                 gnrc_rpl_opt_prefix_info_t *pi = (gnrc_rpl_opt_prefix_info_t *) opt;
                 ipv6_addr_t all_RPL_nodes = GNRC_RPL_ALL_NODES_ADDR;
                 if_id = gnrc_ipv6_netif_find_by_addr(NULL, &all_RPL_nodes);

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -316,20 +316,20 @@ int _gnrc_rpl(int argc, char **argv)
         }
     }
 
-    puts("* help\t\t\t\t- show usage");
-    puts("* init <if_id>\t\t\t- initialize RPL on the given interface");
-    puts("* leaf <instance_id>\t\t- operate as leaf in the instance");
-    puts("* trickle reset <instance_id>\t- reset the trickle timer");
-    puts("* trickle start <instance_id>\t- start the trickle timer");
-    puts("* trickle stop <instance_id>\t- stop the trickle timer");
-    puts("* rm <instance_id>\t\t- delete the given instance and related dodag");
-    puts("* root <inst_id> <dodag_id>\t- add a dodag to a new or existing instance");
-    puts("* router <instance_id>\t\t- operate as router in the instance");
-    puts("* send dis\t\t\t- send a multicast DIS");
+    puts("* help\t\t\t\t\t- show usage");
+    puts("* init <if_id>\t\t\t\t- initialize RPL on the given interface");
+    puts("* leaf <instance_id>\t\t\t- operate as leaf in the instance");
+    puts("* trickle reset <instance_id>\t\t- reset the trickle timer");
+    puts("* trickle start <instance_id>\t\t- start the trickle timer");
+    puts("* trickle stop <instance_id>\t\t- stop the trickle timer");
+    puts("* rm <instance_id>\t\t\t- delete the given instance and related dodag");
+    puts("* root <inst_id> <dodag_id>\t\t- add a dodag to a new or existing instance");
+    puts("* router <instance_id>\t\t\t- operate as router in the instance");
+    puts("* send dis\t\t\t\t- send a multicast DIS");
 #ifndef GNRC_RPL_WITHOUT_PIO
-    puts("* set pio <on/off> <instance_id>- (de-)activate PIO transmissions in DIOs");
+    puts("* set pio <on/off> <instance_id>\t- (de-)activate PIO transmissions in DIOs");
 #endif
-    puts("* show\t\t\t\t- show instance and dodag tables");
+    puts("* show\t\t\t\t\t- show instance and dodag tables");
     return 0;
 }
 /**

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -241,6 +241,22 @@ int _gnrc_rpl_operation(bool leaf, char *arg1)
     return 0;
 }
 
+int _gnrc_rpl_set_pio(char *inst_id, bool status)
+{
+    uint8_t instance_id = (uint8_t) atoi(inst_id);
+    gnrc_rpl_instance_t *inst;
+
+    if ((inst = gnrc_rpl_instance_get(instance_id)) == NULL) {
+        printf("error: could not find the instance (%d)\n", instance_id);
+        return 1;
+    }
+
+    gnrc_rpl_config_pio(&inst->dodag, status);
+
+    printf("success: %sactivated PIO transmissions\n", status ? "" : "de");
+    return 0;
+}
+
 int _gnrc_rpl(int argc, char **argv)
 {
     if ((argc < 2) || (strcmp(argv[1], "show") == 0)) {
@@ -283,6 +299,18 @@ int _gnrc_rpl(int argc, char **argv)
             return _gnrc_rpl_operation(false, argv[2]);
         }
     }
+    else if (strcmp(argv[1], "set") == 0) {
+        if (argc > 2) {
+            if (strcmp(argv[2], "pio") == 0) {
+                if ((argc == 5) && (strcmp(argv[3], "on") == 0)) {
+                    return _gnrc_rpl_set_pio(argv[4], true);
+                }
+                else if ((argc == 5) && (strcmp(argv[3], "off") == 0)) {
+                    return _gnrc_rpl_set_pio(argv[4], false);
+                }
+            }
+        }
+    }
 
     puts("* help\t\t\t\t- show usage");
     puts("* init <if_id>\t\t\t- initialize RPL on the given interface");
@@ -294,6 +322,7 @@ int _gnrc_rpl(int argc, char **argv)
     puts("* root <inst_id> <dodag_id>\t- add a dodag to a new or existing instance");
     puts("* router <instance_id>\t\t- operate as router in the instance");
     puts("* send dis\t\t\t- send a multicast DIS");
+    puts("* set pio <on/off> <instance_id>- (de-)activate PIO transmissions in DIOs");
     puts("* show\t\t\t\t- show instance and dodag tables");
     return 0;
 }

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -241,6 +241,7 @@ int _gnrc_rpl_operation(bool leaf, char *arg1)
     return 0;
 }
 
+#ifndef GNRC_RPL_WITHOUT_PIO
 int _gnrc_rpl_set_pio(char *inst_id, bool status)
 {
     uint8_t instance_id = (uint8_t) atoi(inst_id);
@@ -256,6 +257,7 @@ int _gnrc_rpl_set_pio(char *inst_id, bool status)
     printf("success: %sactivated PIO transmissions\n", status ? "" : "de");
     return 0;
 }
+#endif
 
 int _gnrc_rpl(int argc, char **argv)
 {
@@ -301,6 +303,7 @@ int _gnrc_rpl(int argc, char **argv)
     }
     else if (strcmp(argv[1], "set") == 0) {
         if (argc > 2) {
+#ifndef GNRC_RPL_WITHOUT_PIO
             if (strcmp(argv[2], "pio") == 0) {
                 if ((argc == 5) && (strcmp(argv[3], "on") == 0)) {
                     return _gnrc_rpl_set_pio(argv[4], true);
@@ -309,6 +312,7 @@ int _gnrc_rpl(int argc, char **argv)
                     return _gnrc_rpl_set_pio(argv[4], false);
                 }
             }
+#endif
         }
     }
 
@@ -322,7 +326,9 @@ int _gnrc_rpl(int argc, char **argv)
     puts("* root <inst_id> <dodag_id>\t- add a dodag to a new or existing instance");
     puts("* router <instance_id>\t\t- operate as router in the instance");
     puts("* send dis\t\t\t- send a multicast DIS");
+#ifndef GNRC_RPL_WITHOUT_PIO
     puts("* set pio <on/off> <instance_id>- (de-)activate PIO transmissions in DIOs");
+#endif
     puts("* show\t\t\t\t- show instance and dodag tables");
     return 0;
 }


### PR DESCRIPTION
Currently, the RPL implementation sends out PIOs within DIOs only for the first DIO after joining/creating a DODAG.

This PR changes the behaviour in the way that PIOs are always sent out within DIOs. I also added a way to configure the transmission of PIOs (always or never) either via the shell command `rpl set pio <on/off> <instance_id>` or by excluding the code with `CFLAGS += -DGNRC_RPL_WITHOUT_PIO`.

It is not necessary to have PIOs in DIOs when a border router is providing PIOs in RAs.