### PR TITLE
Fix JLink flash scripts

### DIFF
--- a/boards/cc2538dk/dist/flash.sh
+++ b/boards/cc2538dk/dist/flash.sh
@@ -12,7 +12,7 @@ HEXFILE=$2
 FLASHADDR=200000
 
 # setup JLink command file
-echo "speed 1000" >> $BINDIR/burn.seg
+echo "speed 1000" > $BINDIR/burn.seg
 echo "loadbin $HEXFILE $FLASHADDR" >> $BINDIR/burn.seg
 echo "r" >> $BINDIR/burn.seg
 echo "g" >> $BINDIR/burn.seg

--- a/boards/remote/dist/flash.sh
+++ b/boards/remote/dist/flash.sh
@@ -12,7 +12,7 @@ HEXFILE=$2
 FLASHADDR=200000
 
 # setup JLink command file
-echo "speed 1000" >> $BINDIR/burn.seg
+echo "speed 1000" > $BINDIR/burn.seg
 echo "loadbin $HEXFILE $FLASHADDR" >> $BINDIR/burn.seg
 echo "r" >> $BINDIR/burn.seg
 echo "g" >> $BINDIR/burn.seg


### PR DESCRIPTION
By always appending to burn.seg instead of clobbering it, you not only grow the file indefinitely, but if you ever move or copy an application, BINDIR and HEXFILE will be out of date in the jlink script causing weird problems (which is how I found this).