### PR TITLE
stm32f1 i2c fixes

### DIFF
--- a/cpu/stm32f1/periph/i2c.c
+++ b/cpu/stm32f1/periph/i2c.c
@@ -252,6 +252,7 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
             DEBUG("Send Slave address and wait for ADDR == 1\n");
             _start(i2c, address, I2C_FLAG_READ);
             _clear_addr(i2c);
+            i2c->CR1 |= (I2C_CR1_ACK);
 
             while (i < (length - 3)) {
                 DEBUG("Wait until byte was received\n");

--- a/cpu/stm32f1/periph/i2c.c
+++ b/cpu/stm32f1/periph/i2c.c
@@ -437,13 +437,13 @@ void i2c_poweroff(i2c_t dev)
     switch (dev) {
 #if I2C_0_EN
         case I2C_0:
-            while (I2C_0_DEV->SR2 & I2C_SR2_BUSY);
+            while (I2C_0_DEV->SR2 & I2C_SR2_BUSY) ;
             I2C_0_CLKDIS();
             break;
 #endif
 #if I2C_1_EN
         case I2C_1:
-            while (I2C_1_DEV->SR2 & I2C_SR2_BUSY);
+            while (I2C_1_DEV->SR2 & I2C_SR2_BUSY) ;
             I2C_1_CLKDIS();
             break;
 #endif


### PR DESCRIPTION
Here is some work on the `i2c` peripheral for the `stm32f1xx`. The issues / changes are separated by commits. Follows a brief description of them:

- be3279f multi byte reading was not working as the ACK flag was not set
- da5b03d the `i2c_read_bytes` method used a switch statement for 1, 2 and N bytes case. This caused many code to be duplicated. The code has been extracted and tested with 3 different i2c peripherals for 1, 2 and N bytes case. It also saves some bytes :-)
- a477d6f toggling the pins (implemented due to stm32f1 errata) caused some i2c peripherals not to respond to the first message. However, thy seem to behave correctly on the second message. The implementation in RIOT only gave one chance due to the blocking operations (busy waits). The situation could hence not be recovered. This commit implements the possibility that the i2c methods return negative codes in case of faulty behaviour (e.g. NACKed message) but do not hang allowing the application/driver to handle this situations. 
- 57e2094 `i2c2` peripheral is also present in some of the family MCUs
- b40cb6b uncrusitification of code I didn't touch (mostly inserting space after parenthesis and before semicolon)