### PR TITLE
saul: make pull-up/pull-down mode configurable

### DIFF
--- a/boards/iotlab-m3/include/gpio_params.h
+++ b/boards/iotlab-m3/include/gpio_params.h
@@ -35,16 +35,19 @@ static const  saul_gpio_params_t saul_gpio_params[] =
         .name = "LED(red)",
         .pin = LED_RED_GPIO,
         .dir = GPIO_DIR_OUT,
+        .pull = GPIO_NOPULL,
     },
     {
         .name = "LED(green)",
         .pin = LED_GREEN_GPIO,
         .dir = GPIO_DIR_OUT,
+        .pull = GPIO_NOPULL,
     },
     {
         .name = "LED(orange)",
         .pin = LED_ORANGE_GPIO,
         .dir = GPIO_DIR_OUT,
+        .pull = GPIO_NOPULL,
     },
 };
 

--- a/boards/samr21-xpro/include/gpio_params.h
+++ b/boards/samr21-xpro/include/gpio_params.h
@@ -37,6 +37,7 @@ static const  saul_gpio_params_t saul_gpio_params[] =
         .name = "LED(orange)",
         .pin = LED_GPIO,
         .dir = GPIO_DIR_OUT,
+        .pull = GPIO_NOPULL,
     },
 };
 

--- a/drivers/include/saul/periph.h
+++ b/drivers/include/saul/periph.h
@@ -32,6 +32,7 @@ typedef struct {
     const char *name;       /**< name of the device connected to this pin */
     gpio_t pin;             /**< GPIO pin to initialize and expose */
     gpio_dir_t dir;         /**< use GPIO as input or output */
+    gpio_pp_t pull;         /**< define the pull-up/pull-down mode */
 } saul_gpio_params_t;
 
 #ifdef __cplusplus

--- a/sys/auto_init/saul/auto_init_gpio.c
+++ b/sys/auto_init/saul/auto_init_gpio.c
@@ -62,7 +62,7 @@ void auto_init_gpio(void)
         saul_reg_entries[i].name = p->name;
         saul_reg_entries[i].driver = &gpio_saul_driver;
         /* initialize the GPIO pin */
-        gpio_init(p->pin, p->dir, GPIO_NOPULL);
+        gpio_init(p->pin, p->dir, p->pull);
         /* add to registry */
         saul_reg_add(&(saul_reg_entries[i]));
     }


### PR DESCRIPTION
This PR makes the pull-up/pull-down mode configurable for saul driven gpios