### PR TITLE
periph/gpio: Add open drain as a push-pull option

### DIFF
--- a/cpu/kinetis_common/include/periph_cpu.h
+++ b/cpu/kinetis_common/include/periph_cpu.h
@@ -21,6 +21,7 @@
 
 #include <stdint.h>
 
+#include "cpu.h"
 #include "periph/dev_enums.h"
 
 #ifdef __cplusplus
@@ -53,7 +54,7 @@ typedef uint16_t gpio_t;
 /**
  * @brief   Define a CPU specific GPIO pin generator macro
  */
-#define GPIO_PIN(port, pin)          ((port << GPIO_PORT_SHIFT) | pin)
+#define GPIO_PIN(port, pin) ((port << GPIO_PORT_SHIFT) | (pin << GPIO_PIN_SHIFT))
 
 /**
  * @brief   Length of the CPU_ID in octets
@@ -66,9 +67,14 @@ typedef uint16_t gpio_t;
  */
 #define HAVE_GPIO_PP_T
 typedef enum {
-    GPIO_NOPULL = 4,        /**< do not use internal pull resistors */
-    GPIO_PULLUP = 9,        /**< enable internal pull-up resistor */
-    GPIO_PULLDOWN = 8       /**< enable internal pull-down resistor */
+    /** @brief Output: Actively driven in both directions, Input: Passive input */
+    GPIO_NOPULL = 0,
+    /** @brief Input: enable internal pull-up resistor, Output: undefined */
+    GPIO_PULLUP = (PORT_PCR_PE_MASK | PORT_PCR_PS_MASK),
+    /** @brief Input: enable internal pull-down resistor, Output: undefined */
+    GPIO_PULLDOWN = (PORT_PCR_PE_MASK),
+    /** @brief Output: Open drain, only actively driven low, Input: undefined */
+    GPIO_OPEN_DRAIN = (PORT_PCR_ODE_MASK),
 } gpio_pp_t;
 /** @} */
 

--- a/cpu/kinetis_common/periph/gpio.c
+++ b/cpu/kinetis_common/periph/gpio.c
@@ -185,18 +185,7 @@ int gpio_init(gpio_t dev, gpio_dir_t dir, gpio_pp_t pushpull)
     port->PCR[pin] = PORT_PCR_MUX(PIN_MUX_FUNCTION_ANALOG);
 
     /* set to push-pull configuration */
-    switch (pushpull) {
-        case GPIO_PULLUP:
-            port->PCR[pin] |= PORT_PCR_PE_MASK | PORT_PCR_PS_MASK; /* Pull enable, pull up */
-            break;
-
-        case GPIO_PULLDOWN:
-            port->PCR[pin] |= PORT_PCR_PE_MASK; /* Pull enable, !pull up */
-            break;
-
-        default:
-            break;
-    }
+    port->PCR[pin] |= pushpull;
 
     if (dir == GPIO_DIR_OUT) {
         BITBAND_REG32(gpio->PDDR, pin) = 1;    /* set pin to output mode */

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -98,9 +98,14 @@ typedef enum {
  */
 #ifndef HAVE_GPIO_PP_T
 typedef enum {
-    GPIO_NOPULL = 0,        /**< do not use internal pull resistors */
-    GPIO_PULLUP = 1,        /**< enable internal pull-up resistor */
-    GPIO_PULLDOWN = 2       /**< enable internal pull-down resistor */
+    /** @brief Output: Actively driven in both directions, Input: Passive input */
+    GPIO_NOPULL = 0,
+    /** @brief Input: enable internal pull-up resistor, Output: undefined */
+    GPIO_PULLUP = 1,
+    /** @brief Input: enable internal pull-down resistor, Output: undefined */
+    GPIO_PULLDOWN = 2,
+    /** @brief Output: Open drain, only actively driven low, Input: undefined */
+    GPIO_OPEN_DRAIN = 3,
 } gpio_pp_t;
 #endif
 


### PR DESCRIPTION
Added GPIO_OPEN_DRAIN for configuring outputs as open drain. This relates to the discussion in #4428 and I also needed to configure an open drain output.

Also included is a change for the kinetis family to add open drain support.