### PR TITLE
Pass LTO flags to sub-environments buildtest and Docker

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -59,6 +59,7 @@ buildtest:
 					RIOTNOLINK=$${RIOTNOLINK} \
 					RIOT_VERSION=$${RIOT_VERSION} \
 					WERROR=$${WERROR} \
+					LTO=$${LTO} \
 					$(MAKE) -j$(NPROC) 2>&1) ; \
 			if [ "$${?}" = "0" ]; then \
 				${COLOR_ECHO} "${COLOR_GREEN}success${COLOR_RESET}"; \

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -46,6 +46,7 @@ export DOCKER_ENV_VARS = \
   LINK \
   LINKFLAGPREFIX \
   LINKFLAGS \
+  LTO \
   OBJCOPY \
   OFLAGS \
   PREFIX \


### PR DESCRIPTION
(This is an attempt to make #3361 easier to review)
Pass the LTO variable to Docker container and to buildtest sub-make