### PR TITLE
Kinetis: Add __attribute__((used)) to interrupt vector to fix LTO error

### DIFF
--- a/cpu/k60/vector.c
+++ b/cpu/k60/vector.c
@@ -157,7 +157,7 @@ WEAK_DEFAULT void isr_software(void);
 /**
  * @brief Interrupt vector definition
  */
-__attribute__((section(".vector_table")))
+__attribute__((used, section(".vector_table")))
 const void *interrupt_vector[] = {
     /* Stack pointer */
     (void *)(&_estack),             /* pointer to the top of the empty stack */

--- a/cpu/k64f/vectors.c
+++ b/cpu/k64f/vectors.c
@@ -132,7 +132,7 @@ WEAK_DEFAULT void isr_enet_receive(void);
 WEAK_DEFAULT void isr_enet_error(void);
 
 /* interrupt vector table */
-__attribute__((section(".vector_table")))
+__attribute__((used, section(".vector_table")))
 const void *interrupt_vector[] = {
     /* Stack pointer */
     (void *)(&_estack),             /* pointer to the top of the empty stack */

--- a/cpu/kinetis_common/fcfield.c
+++ b/cpu/kinetis_common/fcfield.c
@@ -23,7 +23,7 @@
 #include <stdint.h>
 
 /* fcfield table */
-__attribute__((weak, section(".fcfield")))
+__attribute__((weak, used, section(".fcfield")))
 const uint8_t flash_configuration_field[] = {
     0xff,    /* backdoor comparison key 3., offset: 0x0 */
     0xff,    /* backdoor comparison key 2., offset: 0x1 */

--- a/cpu/kw2x/vector.c
+++ b/cpu/kw2x/vector.c
@@ -108,7 +108,7 @@ WEAK_DEFAULT void isr_porte(void);
 WEAK_DEFAULT void isr_swi(void);
 
 /* interrupt vector table */
-__attribute__((section(".vector_table")))
+__attribute__((used, section(".vector_table")))
 const void *interrupt_vector[] = {
     /* Stack pointer */
     (void *)(&_estack),             /* pointer to the top of the empty stack */


### PR DESCRIPTION
(This is an attempt to make #3361 easier to review)

This fixes the following build errors when building with LTO=yes on Kinetis platforms:
```
/usr/libexec/gcc/arm-none-eabi/ld: Interrupt vector table of invalid size.
/usr/libexec/gcc/arm-none-eabi/ld: Flash configuration field of invalid size (linker-script error?)
collect2: error: ld returned 1 exit status
```