### PR TITLE
sys: net: ipv6: add some ipv6 utility functions

### DIFF
--- a/sys/include/net/ipv6/addr.h
+++ b/sys/include/net/ipv6/addr.h
@@ -669,6 +669,46 @@ char *ipv6_addr_to_str(char *result, const ipv6_addr_t *addr, uint8_t result_len
  */
 ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr);
 
+/**
+ * @brief split IPv6 address string representation
+ *
+ * @note Will change @p seperator position in @p addr_str to '\0'
+ *
+ * @param[in,out]   addr_str    Address to split
+ * @param[in]       seperator   Seperator char to use
+ * @param[in]       _default    Default value
+ *
+ * @return      atoi(string after split)
+ * @return      @p _default if no string after @p seperator
+ */
+int ipv6_addr_split(char *addr_str, char seperator, int _default);
+
+/**
+ * @brief split IPv6 prefix string representation
+ *
+ * E.g., "2001:db8::1/64" returns "64", changes @p addr_str to "2001:db8::1"
+ *
+ * @param[in,out]   addr_str    Address to split
+ * @return          prefix length or 128 if none specified
+ */
+static inline int ipv6_addr_split_prefix(char *addr_str)
+{
+    return ipv6_addr_split(addr_str, '/', 128);
+}
+
+/**
+ * @brief split IPv6 address + interface specifier
+ *
+ * E.g., "fe80::1%5" returns "5", changes @p addr_str to "fe80::1"
+ *
+ * @param[in,out]   addr_str Address to split
+ * @return          interface number or -1 if none specified
+ */
+static inline int ipv6_addr_split_iface(char *addr_str)
+{
+    return ipv6_addr_split(addr_str, '%', -1);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/ipv6/addr.h
+++ b/sys/include/net/ipv6/addr.h
@@ -709,6 +709,13 @@ static inline int ipv6_addr_split_iface(char *addr_str)
     return ipv6_addr_split(addr_str, '%', -1);
 }
 
+/**
+ * @brief Print IPv6 address to stdout
+ *
+ * @param[in]   addr  Pointer to ipv6_addr_t to print
+ */
+void ipv6_addr_print(const ipv6_addr_t *addr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr.c
@@ -14,10 +14,17 @@
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "net/ipv6/addr.h"
+
+#ifdef MODULE_FMT
+#include "fmt.h"
+#else
+#include <stdio.h>
+#endif
 
 bool ipv6_addr_equal(const ipv6_addr_t *a, const ipv6_addr_t *b)
 {
@@ -120,6 +127,18 @@ int ipv6_addr_split(char *addr_str, char seperator, int _default)
     }
 
     return _default;
+}
+
+void ipv6_addr_print(const ipv6_addr_t *addr)
+{
+    assert(addr);
+    char addr_str[IPV6_ADDR_MAX_STR_LEN];
+    ipv6_addr_to_str(addr_str, addr, sizeof(addr_str));
+#ifdef MODULE_FMT
+    print_str(addr_str);
+#else
+    printf("%s", addr_str);
+#endif
 }
 
 /**

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr.c
@@ -106,6 +106,22 @@ void ipv6_addr_init_iid(ipv6_addr_t *out, const uint8_t *iid, uint8_t bits)
     memcpy(&(out->u8[pos]), iid, bytes);
 }
 
+int ipv6_addr_split(char *addr_str, char seperator, int _default)
+{
+    char *sep = addr_str;
+    while(*++sep) {
+        if (*sep == seperator) {
+            *sep++ = '\0';
+            if (*sep) {
+                _default = atoi(sep);
+            }
+            break;
+        }
+    }
+
+    return _default;
+}
+
 /**
  * @}
  */


### PR DESCRIPTION
This PR adds the following functions:

1. print_ipv6_address(): uses fmt and ipv6_addr_to_str() to just print an address with intermediate buffer on stack.

2. ipv6_split_address() plus helpers: simple function to split either "/nnn" prefix or "%N" interface specifier from ipv6 address string