### PR TITLE
sys: net: gnrc_netdev2_eth: fix ethernet multicast MAC address creation

### DIFF
--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_eth.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_eth.c
@@ -20,6 +20,10 @@
 #include "net/gnrc/netdev2.h"
 #include "net/ethernet/hdr.h"
 
+#ifdef MODULE_GNRC_IPV6
+#include "net/ipv6/hdr.h"
+#endif
+
 #include "od.h"
 
 #define ENABLE_DEBUG (0)
@@ -109,17 +113,16 @@ static inline void _addr_set_broadcast(uint8_t *dst)
     memset(dst, 0xff, ETHERNET_ADDR_LEN);
 }
 
-#define _IPV6_DST_OFFSET    (36)    /* sizeof(ipv6_hdr_t) - 4  */
-
 static inline void _addr_set_multicast(uint8_t *dst, gnrc_pktsnip_t *payload)
 {
     switch (payload->type) {
-#ifdef MODULE_IPV6
+#ifdef MODULE_GNRC_IPV6
         case GNRC_NETTYPE_IPV6:
+            /* https://tools.ietf.org/html/rfc2464#section-7 */
             dst[0] = 0x33;
             dst[1] = 0x33;
-            memcpy(dst + 2, ((uint8_t *)payload->data) + _IPV6_DST_OFFSET, 4);
-            /* TODO change to proper types when gnrc_ipv6_hdr_t got merged */
+            ipv6_hdr_t *ipv6 = payload->data;
+            memcpy(dst + 2, ipv6->dst.u8 + 12, 4);
             break;
 #endif
         default:


### PR DESCRIPTION
The module define was wrong (MODULE_IPV6 vs MODULE_GNRC_IPV6), causing ipv6 multicast packets to be sent to ff:ff:ff:ff:ff:ff.