### PR TITLE
drivers/cpuid: fixed and unified CPUID driver implementations

### DIFF
--- a/cpu/cc2538/include/cpu_conf.h
+++ b/cpu/cc2538/include/cpu_conf.h
@@ -41,13 +41,6 @@ extern "C" {
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
-/**
- * @brief   length of CPU ID for @ref cpuid_get() in @ref periph/cpuid.h
- */
-#ifndef CPUID_ID_LEN
-#define CPUID_ID_LEN                    8
-#endif
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -25,7 +25,10 @@
 extern "C" {
 #endif
 
-/* nothing to do here, yet */
+/**
+ * @brief   Length of the CPU_ID in octets
+ */
+#define CPUID_LEN           (8U)
 
 #ifdef __cplusplus
 }

--- a/cpu/cc2538/periph/cpuid.c
+++ b/cpu/cc2538/periph/cpuid.c
@@ -20,12 +20,11 @@
  * @}
  */
 
+#include <stdint.h>
 #include <string.h>
 
 #include "cpu.h"
 #include "periph/cpuid.h"
-
-#define BITS_PER_BYTE 8
 
 void cpuid_get(void *id)
 {
@@ -35,13 +34,12 @@ void cpuid_get(void *id)
      * The byte-order is big-endian but the word order is little endian.
      * Make some sense of it:
      */
-    dest[0] = IEEE_ADDR_MSWORD >> (3 * BITS_PER_BYTE);
-    dest[1] = IEEE_ADDR_MSWORD >> (2 * BITS_PER_BYTE);
-    dest[2] = IEEE_ADDR_MSWORD >> (1 * BITS_PER_BYTE);
-    dest[3] = IEEE_ADDR_MSWORD >> (0 * BITS_PER_BYTE);
-    dest[4] = IEEE_ADDR_LSWORD >> (3 * BITS_PER_BYTE);
-    dest[5] = IEEE_ADDR_LSWORD >> (2 * BITS_PER_BYTE);
-    dest[6] = IEEE_ADDR_LSWORD >> (1 * BITS_PER_BYTE);
-    dest[7] = IEEE_ADDR_LSWORD >> (0 * BITS_PER_BYTE);
+    dest[0] = IEEE_ADDR_MSWORD >> (3 * sizeof(uint8_t));
+    dest[1] = IEEE_ADDR_MSWORD >> (2 * sizeof(uint8_t));
+    dest[2] = IEEE_ADDR_MSWORD >> (1 * sizeof(uint8_t));
+    dest[3] = IEEE_ADDR_MSWORD >> (0 * sizeof(uint8_t));
+    dest[4] = IEEE_ADDR_LSWORD >> (3 * sizeof(uint8_t));
+    dest[5] = IEEE_ADDR_LSWORD >> (2 * sizeof(uint8_t));
+    dest[6] = IEEE_ADDR_LSWORD >> (1 * sizeof(uint8_t));
+    dest[7] = IEEE_ADDR_LSWORD >> (0 * sizeof(uint8_t));
 }
-/** @} */

--- a/cpu/ezr32wg/include/cpu_conf.h
+++ b/cpu/ezr32wg/include/cpu_conf.h
@@ -40,11 +40,6 @@ extern "C" {
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
-/**
- * @brief   CPUID_ID_LEN length of cpuid in bytes
- */
-#define CPUID_ID_LEN                    (8U)    /* 64-bit unique ID */
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/ezr32wg/include/periph_cpu.h
+++ b/cpu/ezr32wg/include/periph_cpu.h
@@ -39,6 +39,11 @@ typedef uint32_t tim_t;
 /** @} */
 
 /**
+ * @brief   Length of the CPU_ID in octets
+ */
+#define CPUID_LEN           (8U)
+
+/**
  * @brief   Define timer configuration values
  *
  * @note    The two timers must be adjacent to each other (e.g. TIMER0 and

--- a/cpu/ezr32wg/periph/cpuid.c
+++ b/cpu/ezr32wg/periph/cpuid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014-2016 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -7,15 +7,18 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @addtogroup  cpu_ezr32wg
  * @{
  *
  * @file
  * @brief       Low-level CPUID driver implementation
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
  */
 
+#include <stdint.h>
 #include <string.h>
 
 #include "periph/cpuid.h"

--- a/cpu/k60/include/cpu_conf.h
+++ b/cpu/k60/include/cpu_conf.h
@@ -71,14 +71,6 @@ extern "C"
 /** @} */
 
 /**
- * @name Length and address for reading CPU_ID (named UID in Freescale documents)
- * @{
- */
-#define CPUID_ID_LEN                    (16)
-#define CPUID_ID_PTR                    ((void *)(&(SIM->UIDH)))
-/** @} */
-
-/**
  * @name GPIO pin mux function numbers
  */
 /** @{ */

--- a/cpu/k64f/include/cpu_conf.h
+++ b/cpu/k64f/include/cpu_conf.h
@@ -47,16 +47,6 @@ extern "C"
 /** @} */
 
 /**
- * @brief Length for reading CPU_ID in octets
- */
-#define CPUID_ID_LEN                     (16)
-
-/**
- * @brief Pointer to CPU_ID
- */
-#define CPUID_ID_PTR                     ((void *)(&(SIM_UIDH)))
-
-/**
  * @name GPIO pin mux function numbers
  */
 /** @{ */

--- a/cpu/kinetis_common/cpuid.c
+++ b/cpu/kinetis_common/cpuid.c
@@ -20,11 +20,11 @@
  */
 
 #include <string.h>
-#include "cpu_conf.h"
 
+#include "cpu.h"
 #include "periph/cpuid.h"
 
 void cpuid_get(void *id)
 {
-    memcpy(id, CPUID_ID_PTR, CPUID_ID_LEN);
+    memcpy(id, (void *)&(SIM_UIDH), CPUID_LEN);
 }

--- a/cpu/kinetis_common/include/periph_cpu.h
+++ b/cpu/kinetis_common/include/periph_cpu.h
@@ -19,6 +19,8 @@
 #ifndef PERIPH_CPU_H_
 #define PERIPH_CPU_H_
 
+#include <stdint.h>
+
 #include "periph/dev_enums.h"
 
 #ifdef __cplusplus
@@ -52,6 +54,11 @@ typedef uint16_t gpio_t;
  * @brief   Define a CPU specific GPIO pin generator macro
  */
 #define GPIO_PIN(port, pin)          ((port << GPIO_PORT_SHIFT) | pin)
+
+/**
+ * @brief   Length of the CPU_ID in octets
+ */
+#define CPUID_LEN           (16U)
 
 /**
  * @brief   Override values for pull register configuration

--- a/cpu/kw2x/include/cpu_conf.h
+++ b/cpu/kw2x/include/cpu_conf.h
@@ -52,16 +52,6 @@ extern "C"
 /** @} */
 
 /**
- * @brief Length for reading CPU_ID in octets
- */
-#define CPUID_ID_LEN                     (16)
-
-/**
- * @brief Pointer to CPU_ID
- */
-#define CPUID_ID_PTR                     ((void *)(&(SIM_UIDH)))
-
-/**
  * @name GPIO pin mux function numbers
  */
 /** @{ */

--- a/cpu/lm4f120/include/cpu_conf.h
+++ b/cpu/lm4f120/include/cpu_conf.h
@@ -60,14 +60,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Length for reading CPU_ID
- * @{
- */
-#define CPUID_ID_LEN                    (12)
-#define CPUID_ADDR                      NVIC_CPUID
-/** @} */
-
-/**
  * @name cpu functions
  * @{
  */

--- a/cpu/lm4f120/include/periph_cpu.h
+++ b/cpu/lm4f120/include/periph_cpu.h
@@ -25,7 +25,11 @@
 extern "C" {
 #endif
 
-/* nothing to do here, yet */
+/**
+ * @brief   Length of the CPU_ID in octets
+ */
+#define CPUID_LEN           (12U)
+
 
 #ifdef __cplusplus
 }

--- a/cpu/lm4f120/periph/cpuid.c
+++ b/cpu/lm4f120/periph/cpuid.c
@@ -7,22 +7,23 @@
  */
 
 /**
- * @addtogroup      driver_periph
- * @ingroup         cpu_lm4f120
+ * @addtogroup      cpu_lm4f120
  * @{
  *
- * @file            cpuid.c
+ * @file
  * @brief           Low-level CPUID driver implementation
  *
  * @author          Rakendra Thapa <rakendrathapa@gmail.com>
+ *
+ * @}
  */
 
 #include <string.h>
-#include "cpu_conf.h"
+
+#include "cpu.h"
 #include "periph/cpuid.h"
 
 void cpuid_get(void *id)
 {
-    memcpy(id, (void *)(CPUID_ADDR), CPUID_ID_LEN);
+    memcpy(id, (void *)(NVIC_CPUID), CPUID_LEN);
 }
-/** @} */

--- a/cpu/lpc11u34/include/cpu_conf.h
+++ b/cpu/lpc11u34/include/cpu_conf.h
@@ -36,13 +36,6 @@ extern "C" {
 #define CPU_FLASH_BASE                  LPC_FLASH_BASE
 /** @} */
 
-/**
- * @brief   CPU ID configuration
- * @{
- */
-#define CPUID_ID_LEN                    (16U)
-/* @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/lpc11u34/include/periph_cpu.h
+++ b/cpu/lpc11u34/include/periph_cpu.h
@@ -34,6 +34,11 @@ extern "C" {
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS
 /** @} */
 
+/**
+ * @brief   Length of the CPU_ID in octets
+ */
+#define CPUID_LEN           (16U)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/lpc11u34/periph/cpuid.c
+++ b/cpu/lpc11u34/periph/cpuid.c
@@ -1,9 +1,9 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
+ * Copyright (C) 2015-2016 Freie Universität Berlin
  *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
  */
 
 /**
@@ -14,9 +14,13 @@
  * @brief       Low-level CPUID driver implementation
  *
  * @author      Paul RATHGEB <paul.rathgeb@skynet.be>
+ *
+ * @}
  */
 
+#include <stdint.h>
 #include <string.h>
+
 #include "periph/cpuid.h"
 
 /* IAP base address */
@@ -33,6 +37,5 @@ void cpuid_get(void *id)
     iap = (void (*)(uint32_t[], uint32_t[])) IAP_ADDRESS;
     /* Read UUID */
     iap(&command, result);
-    memcpy(id, &result[1], CPUID_ID_LEN);
+    memcpy(id, &result[1], CPUID_LEN);
 }
-/** @} */

--- a/cpu/native/include/cpu_conf.h
+++ b/cpu/native/include/cpu_conf.h
@@ -55,13 +55,6 @@ extern "C" {
  */
 #define NATIVE_ETH_PROTO 0x1234
 
-/**
- * @brief   Length of CPU ID for @ref cpu_id_get() in @ref periph/cpuid.h
- */
-#ifndef CPUID_ID_LEN
-#define CPUID_ID_LEN                    (4)
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/native/include/periph_cpu.h
+++ b/cpu/native/include/periph_cpu.h
@@ -25,7 +25,12 @@
 extern "C" {
 #endif
 
-/* nothing defined here so far... */
+/**
+ * @brief   Length of the CPU_ID in octets
+ */
+#ifndef CPUID_LEN
+#define CPUID_LEN           (4U)
+#endif
 
 #ifdef __cplusplus
 }

--- a/cpu/native/periph/cpuid.c
+++ b/cpu/native/periph/cpuid.c
@@ -7,13 +7,15 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @addtogroup  cpu_native
  * @{
  *
  * @file
  * @brief       Implementation
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * @}
  */
 
 #include <string.h>
@@ -26,16 +28,12 @@
 
 void cpuid_get(void *id)
 {
-    /* Just in case _native_id is shorter than CPUID_ID_LEN: */
-    size_t len = CPUID_ID_LEN;
-    if (sizeof(_native_id) < CPUID_ID_LEN) {
+    /* Just in case _native_id is shorter than CPUID_LEN: */
+    size_t len = CPUID_LEN;
+    if (sizeof(_native_id) < CPUID_LEN) {
         memset(((char*)id) + sizeof(_native_id), 0xff,
-                CPUID_ID_LEN - sizeof(_native_id));
+                CPUID_LEN - sizeof(_native_id));
         len = sizeof(_native_id);
     }
     memcpy(id, &(_native_id), len);
 }
-
-/**
- * @}
- */

--- a/cpu/nrf51/include/cpu_conf.h
+++ b/cpu/nrf51/include/cpu_conf.h
@@ -34,11 +34,6 @@ extern "C" {
 #define CPU_IRQ_NUMOF                   (26U)
 /** @} */
 
-/**
- * @name Length in bytes for reading CPU_ID
- */
-#define CPUID_ID_LEN                    (8)
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/nrf51/include/periph_cpu.h
+++ b/cpu/nrf51/include/periph_cpu.h
@@ -26,6 +26,18 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Mandatory macro for defining GPIO pins
+ *
+ * The port definition is used (and zeroed) to suppress compiler warnings
+ */
+#define GPIO_PIN(x,y)       ((x & 0) | y)
+
+/**
+ * @brief   Length of the CPU_ID in octets
+ */
+#define CPUID_LEN           (8U)
+
+/**
  * @brief   Override GPIO pull register select values
  * @{
  */
@@ -48,13 +60,6 @@ typedef enum {
     GPIO_BOTH    = 3        /**< emit interrupt on both flanks */
 } gpio_flank_t;
 /** @} */
-
-/**
- * @brief   Mandatory macro for defining GPIO pins
- *
- * The port definition is used (and zeroed) to suppress compiler warnings
- */
-#define GPIO_PIN(x,y)       ((x & 0) | y)
 
 #ifdef __cplusplus
 }

--- a/cpu/nrf51/periph/cpuid.c
+++ b/cpu/nrf51/periph/cpuid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014-2016 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -7,13 +7,14 @@
  */
 
 /**
- * @ingroup     cpu_nrf51822
+ * @ingroup     cpu_nrf51
  * @{
  *
  * @file
  * @brief       CPU-ID driver implementation
  *
- * The NRF51822 provides a 64-bit unique identifier, that is unique for each shipped unit.
+ * The NRF51822 provides a 64-bit unique identifier, that is unique for each
+ * shipped unit.
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
@@ -27,5 +28,5 @@
 
 void cpuid_get(void *id)
 {
-    memcpy(id, (void*)NRF_FICR->DEVICEID, CPUID_ID_LEN);
+    memcpy(id, (void*)NRF_FICR->DEVICEID, CPUID_LEN);
 }

--- a/cpu/nrf51/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf51/radio/nrfmin/nrfmin.c
@@ -510,7 +510,7 @@ static void _receive_data(void)
  */
 int nrfmin_init(gnrc_netdev_t *dev)
 {
-    uint8_t cpuid[CPUID_ID_LEN];
+    uint8_t cpuid[CPUID_LEN];
     uint8_t tmp;
     int i;
 
@@ -535,12 +535,12 @@ int nrfmin_init(gnrc_netdev_t *dev)
     /* get default address from CPU ID */
     cpuid_get(cpuid);
     tmp = 0;
-    for (i = 0; i < (CPUID_ID_LEN / 2); i++) {
+    for (i = 0; i < (CPUID_LEN / 2); i++) {
         tmp ^= cpuid[i];
     }
     _addr = ((uint16_t)tmp) << 8;
     tmp = 0;
-    for (; i < CPUID_ID_LEN; i++) {
+    for (; i < CPUID_LEN; i++) {
         tmp ^= cpuid[i];
     }
     _addr |= tmp;

--- a/cpu/nrf52/include/cpu_conf.h
+++ b/cpu/nrf52/include/cpu_conf.h
@@ -36,11 +36,6 @@ extern "C" {
 #define CPU_FLASH_BASE                  (0x00000000)
 /** @} */
 
-/**
- * @brief   CPU_ID length in octets
- */
-#define CPUID_ID_LEN                    (8)
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -56,6 +56,11 @@ typedef enum {
  */
 #define GPIO_PIN(x,y)       ((x & 0) | y)
 
+/**
+ * @brief   Length of the CPU_ID in octets
+ */
+#define CPUID_LEN           (8U)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/nrf52/periph/cpuid.c
+++ b/cpu/nrf52/periph/cpuid.c
@@ -26,9 +26,9 @@
 #include <string.h>
 
 #include "cpu.h"
-#include "cpu_conf.h"
+#include "periph/cpuid.h"
 
 void cpuid_get(void *id)
 {
-    memcpy(id, (void *)NRF_FICR->DEVICEID, CPUID_ID_LEN);
+    memcpy(id, (void *)NRF_FICR->DEVICEID, CPUID_LEN);
 }

--- a/cpu/sam3/include/cpu_conf.h
+++ b/cpu/sam3/include/cpu_conf.h
@@ -36,11 +36,6 @@ extern "C" {
 #define CPU_FLASH_BASE                  IFLASH0_ADDR
 /** @} */
 
-/**
- * @brief CPUID_ID_LEN length of cpuid in bytes
- */
-#define CPUID_ID_LEN (16) /* 128 bits long, 16 bytes long */
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/sam3/include/periph_cpu.h
+++ b/cpu/sam3/include/periph_cpu.h
@@ -56,6 +56,11 @@ typedef uint32_t gpio_t;
 /** @} */
 
 /**
+ * @brief   Length of the CPU_ID in octets
+ */
+#define CPUID_LEN           (16U)
+
+/**
  * @brief Override values for pull register configuration
  * @{
  */

--- a/cpu/sam3/periph/cpuid.c
+++ b/cpu/sam3/periph/cpuid.c
@@ -7,10 +7,10 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @addtogroup  cpu_sam3
  * @{
  *
- * @file        cpuid.c
+ * @file
  * @brief       Low-level CPUID driver implementation
  *
  * @author      Dinh Nguyen <nqdinhddt@gmail.com>
@@ -18,9 +18,9 @@
  * @}
  */
 
+#include <stdint.h>
 #include <string.h>
 
-#include "cpu_conf.h"
 #include "periph/cpuid.h"
 
 #define EFC_FCMD_STUI    0x0E   /* Start unique ID */
@@ -67,5 +67,5 @@ void cpuid_get(void *id)
     /* Wait for FRDY bit rises. */
     while (0 == (EFC1->EEFC_FSR & EEFC_FSR_FRDY));
 
-    memcpy(id, (void*)cpuid, CPUID_ID_LEN);
+    memcpy(id, (void*)cpuid, CPUID_LEN);
 }

--- a/cpu/samd21/include/cpu_conf.h
+++ b/cpu/samd21/include/cpu_conf.h
@@ -33,11 +33,6 @@ extern "C" {
 #define CPU_FLASH_BASE                  FLASH_ADDR
 /** @} */
 
-/**
- * @brief CPUID_ID_LEN length of cpuid in bytes
- */
-#define CPUID_ID_LEN                    (16) /* 128 bits long, 16 bytes long */
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -45,6 +45,11 @@ typedef uint32_t gpio_t;
 #define GPIO_PIN(x, y)      (((gpio_t)(&PORT->Group[x])) | y)
 
 /**
+ * @brief   Length of the CPU_ID in octets
+ */
+#define CPUID_LEN           (16U)
+
+/**
  * @brief   Available ports on the SAMD21
  */
 enum {

--- a/cpu/samd21/periph/cpuid.c
+++ b/cpu/samd21/periph/cpuid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014-2016 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -7,15 +7,18 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @addtogroup  cpu_samd21
  * @{
  *
  * @file
  * @brief       Low-level CPUID driver implementation
  *
  * @author      Troels Hoffmeyer <troels.d.hoffmeyer@gmail.com>
+ *
+ * @}
  */
 
+#include <stdint.h>
 #include <string.h>
 
 #include "periph/cpuid.h"
@@ -32,5 +35,5 @@ void cpuid_get(void *id)
                                   SAMD21_CPUID_WORD1,
                                   SAMD21_CPUID_WORD2,
                                   SAMD21_CPUID_WORD3};
-    memcpy(id, (void*) source_address, CPUID_ID_LEN);
+    memcpy(id, (void*) source_address, CPUID_LEN);
 }

--- a/cpu/saml21/include/cpu_conf.h
+++ b/cpu/saml21/include/cpu_conf.h
@@ -33,11 +33,6 @@ extern "C" {
 #define CPU_FLASH_BASE                  FLASH_ADDR
 /** @} */
 
-/**
- * @brief CPUID_ID_LEN length of cpuid in bytes
- */
-#define CPUID_ID_LEN (16) /* 128 bits long, 16 bytes long */
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -46,6 +46,11 @@ typedef uint32_t gpio_t;
 #define GPIO_PIN(x, y)      (((gpio_t)(&PORT->Group[x])) | y)
 
 /**
+ * @brief   Length of the CPU_ID in octets
+ */
+#define CPUID_LEN           (16U)
+
+/**
  * @brief   Available ports on the SAML21 for convenient access
  */
 enum {

--- a/cpu/saml21/periph/cpuid.c
+++ b/cpu/saml21/periph/cpuid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014-2016 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -7,18 +7,20 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @addtogroup  cpu_saml21
  * @{
  *
- * @file        cpuid.c
+ * @file
  * @brief       Low-level CPUID driver implementation
  *
  * @author      Troels Hoffmeyer <troels.d.hoffmeyer@gmail.com>
+ *
+ * @}
  */
 
+#include <stdint.h>
 #include <string.h>
 
-#include "cpu_conf.h"
 #include "periph/cpuid.h"
 
 #define SAML21_CPUID_WORD0 (*(volatile uint32_t *)0x0080A00C)
@@ -33,5 +35,5 @@ void cpuid_get(void *id)
                                   SAML21_CPUID_WORD1,
                                   SAML21_CPUID_WORD2,
                                   SAML21_CPUID_WORD3};
-    memcpy(id, (void*) source_address, CPUID_ID_LEN);
+    memcpy(id, (void*) source_address, CPUID_LEN);
 }

--- a/cpu/stm32f0/include/cpu_conf.h
+++ b/cpu/stm32f0/include/cpu_conf.h
@@ -40,11 +40,6 @@ extern "C" {
 #define CPU_IRQ_NUMOF                   (31U)
 /** @} */
 
-/**
- * @brief Length for reading CPU_ID
- */
-#define CPUID_ID_LEN                    (12)
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32f0/include/periph_cpu.h
+++ b/cpu/stm32f0/include/periph_cpu.h
@@ -26,6 +26,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Length of the CPU_ID in octets
+ */
+#define CPUID_LEN           (12U)
+
+/**
  * @brief declare needed generic SPI functions
  * @{
  */

--- a/cpu/stm32f0/periph/cpuid.c
+++ b/cpu/stm32f0/periph/cpuid.c
@@ -7,24 +7,24 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @addtogroup  cpu_stm32f0
  * @{
  *
  * @file
  * @brief       Low-level CPUID driver implementation
  *
  * @author      James Hollister <jhollisterjr@gmail.com>
+ *
+ * @}
  */
 
 #include <string.h>
 
 #include "periph/cpuid.h"
 
-#define STM32F0_CPUID_ADDR (0x1ffff7ac)
+#define STM32F0_CPUID_ADDR      (0x1ffff7ac)
 
 void cpuid_get(void *id)
 {
-    memcpy(id, (void *)(STM32F0_CPUID_ADDR), CPUID_ID_LEN);
+    memcpy(id, (void *)(STM32F0_CPUID_ADDR), CPUID_LEN);
 }
-
-/** @} */

--- a/cpu/stm32f1/include/cpu_conf.h
+++ b/cpu/stm32f1/include/cpu_conf.h
@@ -43,11 +43,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Length for reading CPU_ID
- */
-#define CPUID_ID_LEN                    (12)
-
-/**
  * @brief Configure the CPU's clock system
  *
  * @param[in] source    source clock frequency

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -45,6 +45,11 @@ typedef uint32_t gpio_t;
 #define GPIO_PIN(x, y)      ((GPIOA_BASE + (x << 10)) | y)
 
 /**
+ * @brief   Length of the CPU_ID in octets
+ */
+#define CPUID_LEN           (12U)
+
+/**
  * @brief   Override values for pull register configuration
  * @{
  */

--- a/cpu/stm32f1/periph/cpuid.c
+++ b/cpu/stm32f1/periph/cpuid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 FU Berlin
+ * Copyright (C) 2014-2016 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -7,13 +7,15 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @addtogroup  cpu_stm32f1
  * @{
  *
  * @file
  * @brief       Low-level CPUID driver implementation
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ *
+ * @}
  */
 
 #include <string.h>
@@ -22,7 +24,5 @@
 
 void cpuid_get(void *id)
 {
-    memcpy(id, (void *)(0x1ffff7e8), CPUID_ID_LEN);
+    memcpy(id, (void *)(0x1ffff7e8), CPUID_LEN);
 }
-
-/** @} */

--- a/cpu/stm32f3/include/cpu_conf.h
+++ b/cpu/stm32f3/include/cpu_conf.h
@@ -45,11 +45,6 @@ extern "C" {
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
-/**
- * @brief Length for reading CPU_ID
- */
-#define CPUID_ID_LEN                    (12)
-
 
 #ifdef __cplusplus
 }

--- a/cpu/stm32f3/include/periph_cpu.h
+++ b/cpu/stm32f3/include/periph_cpu.h
@@ -45,6 +45,11 @@ typedef uint32_t gpio_t;
 #define GPIO_PIN(x, y)      ((GPIOA_BASE + (x << 10)) | y)
 
 /**
+ * @brief   Length of the CPU_ID in octets
+ */
+#define CPUID_LEN           (12U)
+
+/**
  * @brief   Available ports on the STM32F3 family
  */
 enum {

--- a/cpu/stm32f3/periph/cpuid.c
+++ b/cpu/stm32f3/periph/cpuid.c
@@ -7,13 +7,15 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @addtogroup  cpu_stm32f3
  * @{
  *
  * @file
  * @brief       Low-level CPUID driver implementation
  *
  * @author      James Hollister <jhollisterjr@gmail.com>
+ *
+ * @}
  */
 
 #include <string.h>
@@ -24,7 +26,5 @@
 
 void cpuid_get(void *id)
 {
-    memcpy(id, (void *)(STM32F3_CPUID_ADDR), CPUID_ID_LEN);
+    memcpy(id, (void *)(STM32F3_CPUID_ADDR), CPUID_LEN);
 }
-
-/** @} */

--- a/cpu/stm32f4/include/cpu_conf.h
+++ b/cpu/stm32f4/include/cpu_conf.h
@@ -42,11 +42,6 @@ extern "C" {
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
-/**
- * @brief Length for reading CPU_ID
- */
-#define CPUID_ID_LEN                    (12)
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32f4/include/periph_cpu.h
+++ b/cpu/stm32f4/include/periph_cpu.h
@@ -53,6 +53,11 @@ typedef uint32_t gpio_t;
 /** @} */
 
 /**
+ * @brief   Length of the CPU_ID in octets
+ */
+#define CPUID_LEN           (12U)
+
+/**
  * @brief   Available ports on the STM32F4 family
  */
 enum {

--- a/cpu/stm32f4/periph/cpuid.c
+++ b/cpu/stm32f4/periph/cpuid.c
@@ -7,13 +7,15 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @addtogroup  cpu_stm32f4
  * @{
  *
  * @file
  * @brief       Low-level CPUID driver implementation
  *
  * @author      James Hollister <jhollisterjr@gmail.com>
+ *
+ * @}
  */
 
 #include <string.h>
@@ -24,7 +26,5 @@
 
 void cpuid_get(void *id)
 {
-    memcpy(id, (void *)(STM32F4_CPUID_ADDR), CPUID_ID_LEN);
+    memcpy(id, (void *)(STM32F4_CPUID_ADDR), CPUID_LEN);
 }
-
-/** @} */

--- a/cpu/stm32l1/include/cpu_conf.h
+++ b/cpu/stm32l1/include/cpu_conf.h
@@ -36,11 +36,6 @@ extern "C" {
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
-/**
- * @name Length for reading CPU_ID
- */
-#define CPUID_ID_LEN                      (12)
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32l1/include/periph_cpu.h
+++ b/cpu/stm32l1/include/periph_cpu.h
@@ -46,6 +46,11 @@ typedef uint32_t gpio_t;
 #define GPIO_PIN(x, y)      ((GPIOA_BASE + (x << 10)) | y)
 
 /**
+ * @brief   Length of the CPU_ID in octets
+ */
+#define CPUID_LEN           (12U)
+
+/**
  * @brief   Available ports on the STM32L1 family
  */
 enum {

--- a/cpu/stm32l1/periph/cpuid.c
+++ b/cpu/stm32l1/periph/cpuid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 FU Berlin
+ * Copyright (C) 2014-2016 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -7,13 +7,15 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @addtogroup  cpu_stm32l1
  * @{
  *
  * @file
  * @brief       Low-level CPUID driver implementation
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ *
+ * @}
  */
 
 #include <string.h>
@@ -24,7 +26,5 @@ extern volatile uint32_t _cpuid_address[3];
 
 void cpuid_get(void *id)
 {
-    memcpy(id, (void *)(&_cpuid_address), CPUID_ID_LEN);
+    memcpy(id, (void *)(&_cpuid_address), CPUID_LEN);
 }
-
-/** @} */

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -1997,7 +1997,7 @@ INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = DOXYGEN \
                          __attribute__(x)= \
                          ADC_NUMOF \
-                         CPUID_ID_LEN \
+                         CPUID_LEN \
                          DAC_NUMOF \
                          GPIO_NUMOF \
                          I2C_NUMOF \

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -89,8 +89,8 @@ int at86rf2xx_init(at86rf2xx_t *dev, spi_t spi, spi_speed_t spi_speed,
 
 void at86rf2xx_reset(at86rf2xx_t *dev)
 {
-#if CPUID_ID_LEN
-    uint8_t cpuid[CPUID_ID_LEN];
+#if CPUID_LEN
+    uint8_t cpuid[CPUID_LEN];
     eui64_t addr_long;
 #endif
 
@@ -103,16 +103,16 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     dev->seq_nr = 0;
     dev->options = 0;
     /* set short and long address */
-#if CPUID_ID_LEN
+#if CPUID_LEN
     cpuid_get(cpuid);
 
-#if CPUID_ID_LEN < 8
-    /* in case CPUID_ID_LEN < 8, fill missing bytes with zeros */
-    for (int i = CPUID_ID_LEN; i < 8; i++) {
+#if CPUID_LEN < 8
+    /* in case CPUID_LEN < 8, fill missing bytes with zeros */
+    for (int i = CPUID_LEN; i < 8; i++) {
         cpuid[i] = 0;
     }
 #else
-    for (int i = 8; i < CPUID_ID_LEN; i++) {
+    for (int i = 8; i < CPUID_LEN; i++) {
         cpuid[i & 0x07] ^= cpuid[i];
     }
 #endif

--- a/drivers/cc110x/cc110x-netdev2.c
+++ b/drivers/cc110x/cc110x-netdev2.c
@@ -69,12 +69,12 @@ static inline int _get_iid(netdev2_t *netdev, eui64_t *value, size_t max_len)
     }
 
     uint8_t *eui64 = (uint8_t*) value;
-#ifdef CPUID_ID_LEN
-    int n = (CPUID_ID_LEN < sizeof(eui64_t))
-        ? CPUID_ID_LEN
+#ifdef CPUID_LEN
+    int n = (CPUID_LEN < sizeof(eui64_t))
+        ? CPUID_LEN
         : sizeof(eui64_t);
 
-    char cpuid[CPUID_ID_LEN];
+    char cpuid[CPUID_LEN];
     cpuid_get(cpuid);
 
     memcpy(eui64 + 8 - n, cpuid, n);

--- a/drivers/cc110x/cc110x.c
+++ b/drivers/cc110x/cc110x.c
@@ -87,11 +87,11 @@ int cc110x_setup(cc110x_t *dev, const cc110x_params_t *params)
     cc110x_set_channel(dev, CC110X_DEFAULT_CHANNEL);
 
     /* set default node id */
-#ifdef CPUID_ID_LEN
-    if (CPUID_ID_LEN>0) {
-        char cpuid[CPUID_ID_LEN];
+#ifdef CPUID_LEN
+    if (CPUID_LEN>0) {
+        char cpuid[CPUID_LEN];
         cpuid_get(cpuid);
-        cc110x_set_address(dev, (uint8_t) cpuid[CPUID_ID_LEN-1]);
+        cc110x_set_address(dev, (uint8_t) cpuid[CPUID_LEN-1]);
     }
 #endif
 

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -29,7 +29,7 @@
 #include "enc28j60.h"
 #include "enc28j60_regs.h"
 
-#if CPUID_ID_LEN
+#if CPUID_LEN
 #include "periph/cpuid.h"
 #endif
 
@@ -344,8 +344,8 @@ static int nd_init(netdev2_t *netdev)
     /* set non-back-to-back inter packet gap -> 0x12 is default */
     cmd_wcr(dev, REG_B2_MAIPGL, 2, MAIPGL_FD);
     /* set default MAC address */
-#if CPUID_ID_LEN
-    uint8_t macbuf[CPUID_ID_LEN];
+#if CPUID_LEN
+    uint8_t macbuf[CPUID_LEN];
     cpuid_get(&macbuf);     /* we get the full ID but use only parts of it */
     macbuf[0] |= 0x02;      /* locally administered address */
     macbuf[0] &= ~0x01;     /* unicast address */

--- a/drivers/include/periph/cpuid.h
+++ b/drivers/include/periph/cpuid.h
@@ -23,21 +23,21 @@
 #ifndef PERIPH_CPUID_H_
 #define PERIPH_CPUID_H_
 
-#include "cpu_conf.h"
+#include "periph_cpu.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @def CPUID_ID_LEN
+ * @def CPUID_LEN
  *
  * @brief   The length in byte of the CPU's serial number.
  *
  * @note    Must be defined in the CPU's @ref cpu_conf.h
  */
+#if CPUID_LEN
 
-#if CPUID_ID_LEN
 /**
  * @brief   Gets the serial number of the CPU.
  *
@@ -45,7 +45,7 @@ extern "C" {
  *                  defined in the CPU's cpu_conf.h)
  */
 void cpuid_get(void *id);
-#endif /* CPUID_ID_LEN */
+#endif /* CPUID_LEN */
 
 #ifdef __cplusplus
 }

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -392,8 +392,8 @@ int kw2xrf_init(kw2xrf_t *dev, spi_t spi, spi_speed_t spi_speed,
     uint8_t reg = 0;
     uint8_t tmp[2];
     kw2xrf_gpio_int = int_pin;
-#if CPUID_ID_LEN
-    uint8_t cpuid[CPUID_ID_LEN];
+#if CPUID_LEN
+    uint8_t cpuid[CPUID_LEN];
     eui64_t addr_long;
 #endif
 
@@ -419,19 +419,19 @@ int kw2xrf_init(kw2xrf_t *dev, spi_t spi, spi_speed_t spi_speed,
     dev->proto = KW2XRF_DEFAULT_PROTOCOL;
     dev->option = 0;
 
-#if CPUID_ID_LEN
+#if CPUID_LEN
     cpuid_get(cpuid);
 
-#if CPUID_ID_LEN < 8
+#if CPUID_LEN < 8
 
-    /* in case CPUID_ID_LEN < 8, fill missing bytes with zeros */
-    for (int i = CPUID_ID_LEN; i < 8; i++) {
+    /* in case CPUID_LEN < 8, fill missing bytes with zeros */
+    for (int i = CPUID_LEN; i < 8; i++) {
         cpuid[i] = 0;
     }
 
 #else
 
-    for (int i = 8; i < CPUID_ID_LEN; i++) {
+    for (int i = 8; i < CPUID_LEN; i++) {
         cpuid[i & 0x07] ^= cpuid[i];
     }
 

--- a/sys/net/gnrc/application_layer/zep/gnrc_zep.c
+++ b/sys/net/gnrc/application_layer/zep/gnrc_zep.c
@@ -91,8 +91,8 @@ static uint16_t _calc_fcs(uint16_t fcs, const uint8_t *frame, uint8_t frame_len)
 kernel_pid_t gnrc_zep_init(gnrc_zep_t *dev, uint16_t src_port, ipv6_addr_t *dst,
                            uint16_t dst_port)
 {
-#if CPUID_ID_LEN
-    uint8_t cpuid[CPUID_ID_LEN];
+#if CPUID_LEN
+    uint8_t cpuid[CPUID_LEN];
     uint32_t hash1, hash2;
 #endif
 
@@ -120,18 +120,18 @@ kernel_pid_t gnrc_zep_init(gnrc_zep_t *dev, uint16_t src_port, ipv6_addr_t *dst,
     dev->chan = GNRC_ZEP_DEFAULT_CHANNEL;
     dev->pan = byteorder_btols(byteorder_htons(GNRC_ZEP_DEFAULT_PANID));
     dev->flags = GNRC_ZEP_FLAGS_USE_SRC_PAN;
-#if CPUID_ID_LEN
+#if CPUID_LEN
     /* initialize dev->addr and dev->eui64 from cpuid if available */
     cpuid_get(cpuid);
 
-    hash1 = djb2_hash(cpuid, CPUID_ID_LEN / 2);
+    hash1 = djb2_hash(cpuid, CPUID_LEN / 2);
     dev->addr.u16 = (uint16_t)((hash1 >> 16) ^ (hash1 & 0xffff));
 
-    if (CPUID_ID_LEN % 2) {
-        hash2 = djb2_hash(cpuid + (CPUID_ID_LEN / 2), (CPUID_ID_LEN / 2) - 1);
+    if (CPUID_LEN % 2) {
+        hash2 = djb2_hash(cpuid + (CPUID_LEN / 2), (CPUID_LEN / 2) - 1);
     }
     else {
-        hash2 = djb2_hash(cpuid + (CPUID_ID_LEN / 2), CPUID_ID_LEN / 2);
+        hash2 = djb2_hash(cpuid + (CPUID_LEN / 2), CPUID_LEN / 2);
     }
 
     dev->eui64.u32[0] = hash1;

--- a/tests/periph_cpuid/main.c
+++ b/tests/periph_cpuid/main.c
@@ -27,7 +27,7 @@
 
 int main(void)
 {
-    uint8_t id[CPUID_ID_LEN];
+    uint8_t id[CPUID_LEN];
 
     puts("Test for the CPUID driver");
     puts("This test is reading out the CPUID of the platforms CPU\n");
@@ -37,7 +37,7 @@ int main(void)
 
     /* print the CPUID */
     printf("CPUID:");
-    for (unsigned int i = 0; i < CPUID_ID_LEN; i++) {
+    for (unsigned int i = 0; i < CPUID_LEN; i++) {
         printf(" 0x%02x", id[i]);
     }
     printf("\n");


### PR DESCRIPTION
Besides some minor cleanup, this introduces two major things:
- renamed the `CPUID_ID_LEN` to `CPUID_LEN`, which should be slightly easier to read and just looks nicer :-)
- moved the per CPU definition of `CPUID_LEN` from `cpu_conf.h` to `periph_cpu.h`. This is more consistent, as the CPU specific properties regarding vendor peripherals are all in this file.