### PR TITLE
make: use code style CFLAGS from Makefile.cflags

### DIFF
--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -43,9 +43,13 @@ ifeq ($(PROGRAMMER), stk500v2)
 endif
 
 # define build specific options
-export CPU_USAGE = -mmcu=atmega2560
-export CFLAGS += -ggdb -g3 -Os $(CPU_USAGE)
-export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE)
-export LINKFLAGS += -g3 -ggdb $(CPU_USAGE) $(FPU_USAGE) -static -lgcc -e reset_handler
+export CFLAGS_CPU   = -mmcu=atmega2560  $(CFLAGS_FPU)
+export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
+export CFLAGS_DBG   = -ggdb -g3
+export CFLAGS_OPT  ?= -Os
+
+export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
+export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
+export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -e reset_handler
 export OFLAGS += -j .text -j .data -O ihex
 export FFLAGS += -p m2560 -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -U flash:w:bin/$(BOARD)/$(PROJECT)$(APPLICATION).hex

--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -44,8 +44,8 @@ endif
 
 # define build specific options
 export CPU_USAGE = -mmcu=atmega2560
-export CFLAGS += -ggdb -g3 -std=gnu99 -Os -Wall -Wstrict-prototypes $(CPU_USAGE)
+export CFLAGS += -ggdb -g3 -Os $(CPU_USAGE)
 export ASFLAGS += -ggdb -g3 $(CPU_USAGE) $(FPU_USAGE)
-export LINKFLAGS += -g3 -ggdb -std=gnu99 $(CPU_USAGE) $(FPU_USAGE) -static -lgcc -e reset_handler
+export LINKFLAGS += -g3 -ggdb $(CPU_USAGE) $(FPU_USAGE) -static -lgcc -e reset_handler
 export OFLAGS += -j .text -j .data -O ihex
 export FFLAGS += -p m2560 -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -U flash:w:bin/$(BOARD)/$(PROJECT)$(APPLICATION).hex

--- a/boards/msba2-common/Makefile.include
+++ b/boards/msba2-common/Makefile.include
@@ -10,21 +10,30 @@ export PREFIX = $(if $(TARGET_TRIPLE),$(TARGET_TRIPLE)-)
 export CC = $(PREFIX)gcc
 export CXX = $(PREFIX)g++
 export AR = $(PREFIX)ar
-export CFLAGS += -O2 -Wall -Wstrict-prototypes -mcpu=arm7tdmi-s -gdwarf-2 -fdata-sections -ffunction-sections
-export ASFLAGS = -gdwarf-2 -mcpu=arm7tdmi-s
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
 FLASHER = lpc2k_pgm
 TERMPROG ?= $(RIOTBASE)/dist/tools/pyterm/pyterm
-LINKFLAGS += -gdwarf-2 -mcpu=arm7tdmi-s -static -lgcc -nostartfiles -T$(RIOTBASE)/cpu/$(CPU)/ldscripts/$(CPU).ld -Wl,--gc-sections
 
-# unwanted (CXXUWFLAGS) and extra (CXXEXFLAGS) flags for c++
-export CXXUWFLAGS +=
-export CXXEXFLAGS +=
+export CFLAGS_CPU   = -mcpu=arm7tdmi-s
+export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
+export CFLAGS_DBG   = -ggdb -g3
+export CFLAGS_OPT  ?= -Os
 
-ifeq ($(strip $(PORT)),)
+export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
+export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
+export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU).ld
+export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -nostartfiles
+export LINKFLAGS += -Wl,--gc-sections
+
+# use the nano-specs of Newlib when available
+ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+export LINKFLAGS += -specs=nano.specs -lc -lnosys
+endif
+
+ifeq ($(PORT),)
 	export PORT = /dev/ttyUSB0
 endif
 export FFLAGS = $(PORT) $(HEXFILE)

--- a/cpu/Makefile.include.cortexm_common
+++ b/cpu/Makefile.include.cortexm_common
@@ -44,7 +44,7 @@ export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
 export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts -L$(RIOTCPU)/cortexm_common/ldscripts
 export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL).ld -Wl,--fatal-warnings
-export LINKFLAGS += $(CFLAGS_DBG) $(CFLAGS_CPU) -static -lgcc -nostartfiles
+export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -nostartfiles
 export LINKFLAGS += -Wl,--gc-sections
 
 # This CPU implementation is using the new core/CPU interface:

--- a/cpu/Makefile.include.cortexm_common
+++ b/cpu/Makefile.include.cortexm_common
@@ -35,17 +35,16 @@ ifneq (llvm,$(TOOLCHAIN))
 # not building with LLVM
 export CFLAGS_CPU  += -mno-thumb-interwork
 endif
-export CFLAGS_STYLE = -std=gnu99 -Wall -Wstrict-prototypes -Werror=implicit-function-declaration
 export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
 export CFLAGS_DBG   = -ggdb -g3
 export CFLAGS_OPT  ?= -Os
 
-export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_STYLE) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
+export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 
 export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DEBUG)
 export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts -L$(RIOTCPU)/cortexm_common/ldscripts
 export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL).ld -Wl,--fatal-warnings
-export LINKFLAGS += $(CFLAGS_DEBUG) $(CFLAGS_CPU) $(CFLAGS_STYLE) -static -lgcc -nostartfiles
+export LINKFLAGS += $(CFLAGS_DEBUG) $(CFLAGS_CPU) -static -lgcc -nostartfiles
 export LINKFLAGS += -Wl,--gc-sections
 
 # This CPU implementation is using the new core/CPU interface:

--- a/cpu/Makefile.include.cortexm_common
+++ b/cpu/Makefile.include.cortexm_common
@@ -41,10 +41,10 @@ export CFLAGS_OPT  ?= -Os
 
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 
-export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DEBUG)
+export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
 export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts -L$(RIOTCPU)/cortexm_common/ldscripts
 export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL).ld -Wl,--fatal-warnings
-export LINKFLAGS += $(CFLAGS_DEBUG) $(CFLAGS_CPU) -static -lgcc -nostartfiles
+export LINKFLAGS += $(CFLAGS_DBG) $(CFLAGS_CPU) -static -lgcc -nostartfiles
 export LINKFLAGS += -Wl,--gc-sections
 
 # This CPU implementation is using the new core/CPU interface:

--- a/cpu/Makefile.include.msp430_common
+++ b/cpu/Makefile.include.msp430_common
@@ -9,7 +9,7 @@ CFLAGS_OPT  ?= -Os
 # export compiler flags
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 # export assmebly flags
-export ASFLAGS += $(CFLAGS_CPU) --defsym $(CPU_MODEL)=1 $(CFLAGS_DEBUG)
+export ASFLAGS += $(CFLAGS_CPU) --defsym $(CPU_MODEL)=1 $(CFLAGS_DBG)
 # export linker flags
 export LINKFLAGS += $(CFLAGS_CPU) -lgcc
 

--- a/cpu/Makefile.include.msp430_common
+++ b/cpu/Makefile.include.msp430_common
@@ -3,12 +3,11 @@ export PREFIX ?= msp430-
 
 # define build specific options
 CFLAGS_CPU   = -mmcu=$(CPU_MODEL)
-CFLAGS_STYLE = -std=gnu99 -Wall -Wstrict-prototypes
 CFLAGS_LINK  =
 CFLAGS_DBG   = -gdwarf-2
 CFLAGS_OPT  ?= -Os
 # export compiler flags
-export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_STYLE) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
+export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 # export assmebly flags
 export ASFLAGS += $(CFLAGS_CPU) --defsym $(CPU_MODEL)=1 $(CFLAGS_DEBUG)
 # export linker flags

--- a/cpu/Makefile.include.msp430_common
+++ b/cpu/Makefile.include.msp430_common
@@ -11,7 +11,7 @@ export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 # export assmebly flags
 export ASFLAGS += $(CFLAGS_CPU) --defsym $(CPU_MODEL)=1 $(CFLAGS_DBG)
 # export linker flags
-export LINKFLAGS += $(CFLAGS_CPU) -lgcc
+export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc
 
 # Import all toolchain settings
 include $(RIOTCPU)/Makefile.include.gnu


### PR DESCRIPTION
Since these flags are defined unconditionally in Makefile.cflags there's no reason to add them a second time in the board specific Makefiles.