### PR TITLE
msp430: Add newlib support

### DIFF
--- a/boards/chronos/drivers/display.c
+++ b/boards/chronos/drivers/display.c
@@ -50,6 +50,7 @@
  */
 
 #include <string.h>
+#include <stdint.h>
 #include <cc430f6137.h>
 
 #include "display.h"

--- a/boards/chronos/stdio.c
+++ b/boards/chronos/stdio.c
@@ -21,6 +21,8 @@
  *
  */
 
+#if !(MODULE_NEWLIB)
+
 #include <stdio.h>
 
 static void _dummy(int c)
@@ -45,3 +47,5 @@ ssize_t write(int fildes, const void *buf, size_t nbyte)
 {
     return -1;
 }
+
+#endif

--- a/cpu/Makefile.include.msp430_common
+++ b/cpu/Makefile.include.msp430_common
@@ -14,4 +14,42 @@ export ASFLAGS += $(CFLAGS_CPU) --defsym $(CPU_MODEL)=1 $(CFLAGS_DBG)
 export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc
 
 # Import all toolchain settings
-include $(RIOTCPU)/Makefile.include.gnu
+include $(RIOTCPU)/Makefile.include.$(TOOLCHAIN)
+
+# Test that the compiler exists, try to adjust PREFIX otherwise
+ifeq (,$(shell sh -c 'command -v $(CC)'))
+export PREFIX:=$(PREFIX)elf-
+endif
+
+ifeq (,$(MSP430_USE_NEWLIB))
+# MSPGCC (the old compiler) is usually used with msp-libc, while the new
+# upstream GCC msp430 port (sometimes referred to as the Red Hat MSP430
+# compiler) is usually accompanied by newlib.
+# The new msp430 port started with version 4.9.x, the latest release of the old
+# mspgcc is 4.6.3 from the beginning of 2012 and doesn't look like it will receive
+# any updates. We use the numbers to decide if we use newlib by default.
+CC_VERSION := $(shell $(CC) -dumpversion 2>&1)
+
+ifeq (4.9, $(firstword $(sort 4.9 $(CC_VERSION))))
+# CC_VERSION is at least 4.9
+MSP430_USE_NEWLIB := 1
+else
+MSP430_USE_NEWLIB := 0
+endif
+endif
+
+ifeq (1,$(MSP430_USE_NEWLIB))
+
+# use newlib as libc
+export USEMODULE += newlib
+
+# Some compatibility definitions for using the TI provided ldscripts with RIOT's
+# newlib syscalls.c
+CFLAGS_MEMMAP = -D_sheap=end -D_eheap=__stack -D_end=end
+
+# use the nano-specs of Newlib when available
+ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+export LINKFLAGS += -specs=nano.specs -lc -lnosys
+endif
+
+endif

--- a/cpu/Makefile.include.msp430_common
+++ b/cpu/Makefile.include.msp430_common
@@ -13,12 +13,15 @@ export ASFLAGS += $(CFLAGS_CPU) --defsym $(CPU_MODEL)=1 $(CFLAGS_DBG)
 # export linker flags
 export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc
 
+export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts -L$(RIOTCPU)/msp430-common/ldscripts
+export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL).ld -Wl,--fatal-warnings
+
 # Import all toolchain settings
 include $(RIOTCPU)/Makefile.include.$(TOOLCHAIN)
 
-# Test that the compiler exists, try to adjust PREFIX otherwise
+# Test that the compiler exists, try to adjust TARGET_ARCH otherwise
 ifeq (,$(shell sh -c 'command -v $(CC)'))
-export PREFIX:=$(PREFIX)elf-
+export TARGET_ARCH:=$(TARGET_ARCH)-elf
 endif
 
 ifeq (,$(MSP430_USE_NEWLIB))

--- a/cpu/Makefile.include.msp430_common
+++ b/cpu/Makefile.include.msp430_common
@@ -13,9 +13,6 @@ export ASFLAGS += $(CFLAGS_CPU) --defsym $(CPU_MODEL)=1 $(CFLAGS_DBG)
 # export linker flags
 export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc
 
-export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts -L$(RIOTCPU)/msp430-common/ldscripts
-export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL).ld -Wl,--fatal-warnings
-
 # Import all toolchain settings
 include $(RIOTCPU)/Makefile.include.$(TOOLCHAIN)
 
@@ -46,9 +43,8 @@ ifeq (1,$(MSP430_USE_NEWLIB))
 # use newlib as libc
 export USEMODULE += newlib
 
-# Some compatibility definitions for using the TI provided ldscripts with RIOT's
-# newlib syscalls.c
-CFLAGS_MEMMAP = -D_sheap=end -D_eheap=__stack -D_end=end
+export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts -L$(RIOTCPU)/msp430-common/ldscripts
+export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL).ld -Wl,--fatal-warnings
 
 # use the nano-specs of Newlib when available
 ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)

--- a/cpu/cc430/cc430-adc.c
+++ b/cpu/cc430/cc430-adc.c
@@ -47,7 +47,6 @@
  */
 
 
-#include <legacymsp430.h>
 #include "irq.h"
 #include "cpu.h"
 #include "cc430-adc.h"
@@ -110,7 +109,7 @@ uint16_t adc12_single_conversion(uint16_t ref, uint16_t sht, uint16_t channel)
  * @param       none
  * @return      none
  *************************************************************************************************/
-interrupt(ADC12_VECTOR) __attribute__((naked)) adc_isr(void)
+__attribute__((interrupt(ADC12_VECTOR))) __attribute__((naked)) void adc_isr(void)
 {
     __enter_isr();
 

--- a/cpu/cc430/cc430-gpioint.c
+++ b/cpu/cc430/cc430-gpioint.c
@@ -15,7 +15,6 @@
  */
 
 #include <stdlib.h>
-#include <legacymsp430.h>
 #include "gpioint.h"
 #include "bitarithm.h"
 #include "cpu.h"
@@ -143,7 +142,7 @@ bool gpioint_set(int port, uint32_t bitmask, int flags, fp_irqcb callback)
     return 1;
 }
 
-interrupt(PORT1_VECTOR) __attribute__((naked)) port1_isr(void)
+__attribute__((interrupt(PORT1_VECTOR))) __attribute__((naked)) void port1_isr(void)
 {
     uint8_t int_enable, ifg_num, p1ifg;
     uint16_t p1iv;
@@ -188,7 +187,7 @@ interrupt(PORT1_VECTOR) __attribute__((naked)) port1_isr(void)
     __exit_isr();
 }
 
-interrupt(PORT2_VECTOR) __attribute__((naked)) port2_isr(void)
+__attribute__((interrupt(PORT2_VECTOR))) __attribute__((naked)) void port2_isr(void)
 {
     uint8_t int_enable, ifg_num, p2ifg;
     uint16_t p2iv;

--- a/cpu/cc430/flashrom.c
+++ b/cpu/cc430/flashrom.c
@@ -69,6 +69,6 @@ static inline void busy_wait(void)
 {
     /* Wait for BUSY = 0, not needed unless run from RAM */
     while (FCTL3 & 0x0001) {
-        nop();
+        __nop();
     }
 }

--- a/cpu/cc430/include/cc430_regs.h
+++ b/cpu/cc430/include/cc430_regs.h
@@ -103,8 +103,12 @@ typedef struct {
  * @brief   Base register address definitions
  * @{
  */
+#ifndef TIMER_A0_BASE
 #define TIMER_A0_BASE           ((uint16_t)0x0340)
+#endif
+#ifndef TIMER_A1_BASE
 #define TIMER_A1_BASE           ((uint16_t)0x0380)
+#endif
 /** @} */
 
 /**

--- a/cpu/cc430/periph/rtc.c
+++ b/cpu/cc430/periph/rtc.c
@@ -15,7 +15,6 @@
  */
 
 #include <string.h>
-#include <legacymsp430.h>
 #include "irq.h"
 #include "cpu.h"
 #include "cc430-rtc.h"
@@ -182,7 +181,7 @@ void rtc_clear_alarm(void)
     RTCCTL0 &= ~RTCAIE;
 }
 
-interrupt(RTC_VECTOR) __attribute__((naked)) rtc_isr(void)
+__attribute__((interrupt(RTC_VECTOR))) __attribute__((naked)) void rtc_isr(void)
 {
     __enter_isr();
 

--- a/cpu/msp430-common/cpu.c
+++ b/cpu/msp430-common/cpu.c
@@ -50,6 +50,7 @@ NORETURN void cpu_switch_context_exit(void)
     UNREACHABLE();
 }
 
+#if !(MODULE_NEWLIB)
 /**
  * mspgcc handles main specially - it does not return but falls
  * through to section .fini9.
@@ -57,6 +58,7 @@ NORETURN void cpu_switch_context_exit(void)
  * behave like a regular function. This enables a common
  * thread_stack_init behavior. */
 __attribute__((section (".fini9"))) void __main_epilogue(void) { __asm__("ret"); }
+#endif
 
 //----------------------------------------------------------------------------
 // Processor specific routine - here for MSP

--- a/cpu/msp430-common/include/cpu.h
+++ b/cpu/msp430-common/include/cpu.h
@@ -23,6 +23,13 @@
 
 #include <stdio.h>
 
+#if ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5) && (__GNUC_MINOR__ < 9))
+#include <intrinsics.h>   /* MSP430-gcc compiler instrinsics */
+#define __get_SR_register __read_status_register
+#elif ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9)) || (__GNUC__ >= 5)
+#include <in430.h>
+#endif
+
 #include <msp430.h>
 #include "board.h"
 

--- a/cpu/msp430-common/include/msp430_types.h
+++ b/cpu/msp430-common/include/msp430_types.h
@@ -19,6 +19,8 @@
 extern "C" {
 #endif
 
+#if !(MODULE_NEWLIB)
+
 #ifndef EINVAL
 /**
  * @brief defines EINVAL if MSP430 toolchain is too old to provide it itself
@@ -35,7 +37,7 @@ extern "C" {
 #define EOVERFLOW   (65)
 #endif
 
-typedef unsigned long time_t;
+typedef long time_t;
 
 struct timespec {
     time_t  tv_sec;   /* Seconds */
@@ -49,7 +51,9 @@ struct timeval {
 };
 
 /* TODO: remove once msp430 libc supports clockid_t */
-typedef int clockid_t;
+typedef unsigned long clockid_t;
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/cpu/msp430-common/include/stdio.h
+++ b/cpu/msp430-common/include/stdio.h
@@ -21,13 +21,13 @@
 #define RIOT_MSP430_STDIO_H_
 
 /*
- * The MSP430 toolchain does not provide getchar in stdio.h.
- * As a workaround, we include the system stdio.h here and then add getchar.
+ * msp430-libc does not provide getchar in stdio.h, but newlib does.
+ * As a workaround, we declare getchar separately and include the system stdio.h
  */
 
-#include_next <stdio.h>
-
 int getchar(void);
+
+#include_next <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/msp430-common/include/sys/time.h
+++ b/cpu/msp430-common/include/sys/time.h
@@ -9,7 +9,11 @@
 #ifndef TIME_H
 #define TIME_H
 
+#if MODULE_NEWLIB
+#include_next <sys/time.h>
+#else
 #include "msp430_types.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/msp430-common/include/sys/types.h
+++ b/cpu/msp430-common/include/sys/types.h
@@ -9,7 +9,11 @@
 #ifndef SYS_TYPES_H_
 #define SYS_TYPES_H_
 
+#if MODULE_NEWLIB
+#include_next <sys/types.h>
+#else
 #include "msp430_types.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/msp430-common/ldscripts/msp430_base.ld
+++ b/cpu/msp430-common/ldscripts/msp430_base.ld
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/* Section Definitions */
+SECTIONS
+{
+    /* This is just for crt0.S and interrupt handlers.  */
+    .lowtext           :
+    {
+        PROVIDE (_start = .);
+        . = ALIGN(2);
+        KEEP (*(SORT(.crt_*)))
+        KEEP (*(.lowtext))
+    } > ROM
+
+    .text :
+    {
+        . = ALIGN(4);
+        _sfixed = .;
+        KEEP(*(.vectors .vectors.*))
+        . = ALIGN(2);
+        *(.lower.text.* .lower.text)
+
+        . = ALIGN(2);
+        *(.text .stub .text.* .gnu.linkonce.t.* .text:*)
+        KEEP (*(.text.*personality*))
+        *(.rodata .rodata* .gnu.linkonce.r.* .const .const:*)
+
+        *(.eh_frame_hdr)
+        KEEP (*(.eh_frame))
+        KEEP (*(.gcc_except_table)) *(.gcc_except_table.*)
+        /* Support C constructors, and C destructors in both user code
+           and the C library. This also provides support for C++ code. */
+        . = ALIGN(4);
+        KEEP(*(.init))
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP (*(.preinit_array))
+        __preinit_array_end = .;
+
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        __init_array_end = .;
+
+        . = ALIGN(4);
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+
+        . = ALIGN(4);
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        __fini_array_start = .;
+        KEEP (*(.fini_array))
+        KEEP (*(SORT(.fini_array.*)))
+        __fini_array_end = .;
+
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+
+        . = ALIGN(4);
+        _efixed = .;            /* End of text section */
+    } > ROM
+
+    _etext = .;
+
+    /* stack section */
+    .stack (NOLOAD):
+    {
+        . = ALIGN(8);
+        PROVIDE (__stack = .);
+        _sstack = .;
+        KEEP (*(.isr_stack))
+        . = ALIGN(8);
+        _estack = .;
+    } > RAM
+
+    .relocate : AT (_etext)
+    {
+        . = ALIGN(4);
+        _srelocate = .;
+        PROVIDE(__datastart = .);
+        *(.ramfunc .ramfunc.*);
+        *(.lower.data.* .lower.data)
+        *(.either.data.* .either.data)
+        . = ALIGN(2);
+        KEEP (*(.jcr))
+        *(.data.rel.ro.local) *(.data.rel.ro*)
+        *(.dynamic)
+        . = ALIGN(2);
+        *(.data .data.* .gnu.linkonce.d.*)
+        KEEP (*(.gnu.linkonce.d.*personality*))
+        SORT(CONSTRUCTORS)
+        *(.data1)
+        *(.got.plt) *(.got)
+        . = ALIGN(4);
+        /* We want the small data sections together, so single-instruction offsets
+           can access them all, and initialized data all before uninitialized, so
+           we can shorten the on-disk segment size.  */
+        . = ALIGN(2);
+        *(.sdata .sdata.* .gnu.linkonce.s.* D_2 D_1)
+
+        . = ALIGN(2);
+        _erelocate = .;
+    } > RAM
+
+    /* MSPGCC libc compatibility  */
+    PROVIDE(__romdatastart = LOADADDR(.relocate));
+    PROVIDE (__romdatacopysize = SIZEOF(.relocate));
+
+    /* .bss section which is used for uninitialized data */
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        _sbss = . ;
+        _szero = .;
+        PROVIDE(__bssstart = .);
+        *(.lower.bss.* .lower.bss)
+        . = ALIGN(2);
+        *(.either.bss.* .either.bss)
+        *(.dynbss)
+        *(.sbss .sbss.*)
+        *(.bss .bss.* .gnu.linkonce.b.*)
+        . = ALIGN(2);
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = . ;
+        _ezero = .;
+    } > RAM
+    PROVIDE (__bsssize = SIZEOF(.bss));
+
+    /* heap section */
+    . = ALIGN(4);
+    _sheap = . ;
+    _eheap = ORIGIN(RAM) + LENGTH(RAM);
+
+    /* Populate information abour RAM size */
+    _sram = ORIGIN(RAM);
+    _eram = ORIGIN(RAM) + LENGTH(RAM);
+
+    .infoA     : {} > INFOA              /* MSP430 INFO FLASH MEMORY SEGMENTS */
+    .infoB     : {} > INFOB
+
+    /* Make sure that upper data sections are not used.  */
+    .upper :
+    {
+        *(.upper.bss.* .upper.bss)
+        *(.upper.data.* .upper.data)
+        ASSERT (SIZEOF(.upper) == 0, "This MCU does not support placing read/write data into high memory");
+    }
+
+    /* The rest are all not normally part of the runtime image.  */
+
+    .MP430.attributes 0 :
+    {
+      KEEP (*(.MSP430.attributes))
+      KEEP (*(.gnu.attributes))
+      KEEP (*(__TI_build_attributes))
+    }
+
+    /* Stabs debugging sections.  */
+    .stab          0 : { *(.stab) }
+    .stabstr       0 : { *(.stabstr) }
+    .stab.excl     0 : { *(.stab.excl) }
+    .stab.exclstr  0 : { *(.stab.exclstr) }
+    .stab.index    0 : { *(.stab.index) }
+    .stab.indexstr 0 : { *(.stab.indexstr) }
+    .comment       0 : { *(.comment) }
+    /* DWARF debug sections.
+       Symbols in the DWARF debugging sections are relative to the beginning
+       of the section so we begin them at 0.  */
+    /* DWARF 1.  */
+    .debug          0 : { *(.debug) }
+    .line           0 : { *(.line) }
+    /* GNU DWARF 1 extensions.  */
+    .debug_srcinfo  0 : { *(.debug_srcinfo) }
+    .debug_sfnames  0 : { *(.debug_sfnames) }
+    /* DWARF 1.1 and DWARF 2.  */
+    .debug_aranges  0 : { *(.debug_aranges) }
+    .debug_pubnames 0 : { *(.debug_pubnames) }
+    /* DWARF 2.  */
+    .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+    .debug_abbrev   0 : { *(.debug_abbrev) }
+    .debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end ) }
+    .debug_frame    0 : { *(.debug_frame) }
+    .debug_str      0 : { *(.debug_str) }
+    .debug_loc      0 : { *(.debug_loc) }
+    .debug_macinfo  0 : { *(.debug_macinfo) }
+    /* SGI/MIPS DWARF 2 extensions.  */
+    .debug_weaknames 0 : { *(.debug_weaknames) }
+    .debug_funcnames 0 : { *(.debug_funcnames) }
+    .debug_typenames 0 : { *(.debug_typenames) }
+    .debug_varnames  0 : { *(.debug_varnames) }
+    /* DWARF 3 */
+    .debug_pubtypes 0 : { *(.debug_pubtypes) }
+    .debug_ranges   0 : { *(.debug_ranges) }
+    /* DWARF Extension.  */
+    .debug_macro    0 : { *(.debug_macro) }
+
+    /DISCARD/ : { *(.note.GNU-stack) }
+}

--- a/cpu/msp430-common/ldscripts/msp430_hirom.ld
+++ b/cpu/msp430-common/ldscripts/msp430_hirom.ld
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/* Section Definitions */
+SECTIONS
+{
+    .upper.text :
+    {
+        . = ALIGN(4);
+        *(.upper.text.* .upper.text)
+    } > HIROM
+
+    .upper.rodata :
+    {
+        . = ALIGN(4);
+        *(.upper.rodata.* .upper.rodata)
+    } > HIROM
+
+    .infoC     : {} > INFOC
+    .infoD     : {} > INFOD
+}

--- a/cpu/msp430-common/lpm_cpu.c
+++ b/cpu/msp430-common/lpm_cpu.c
@@ -20,14 +20,11 @@
  * @}
  */
 
-#include <assert.h>
 #include <stdio.h>
-#if (__GNUC__ >= 4) && (__GNUC_MINOR__ > 5)
-#include <intrinsics.h>   // MSP430-gcc compiler instrinsics
-#endif
 
+#include <assert.h>
+#include "cpu.h"
 #include "board.h"
-#include <msp430.h>
 
 #include "lpm.h"
 
@@ -48,34 +45,34 @@ enum lpm_mode lpm_set(enum lpm_mode target)
 
     /* ensure that interrupts are enabled before going to sleep,
        or we're bound to hang our MCU! */
-    assert((target == LPM_ON) || (__read_status_register() & GIE));
+    assert((target == LPM_ON) || (__get_SR_register() & GIE));
 
     switch (target) {
     case LPM_ON:
         /* fully running MCU */
-        __bic_status_register(CPUOFF | OSCOFF | SCG0 | SCG1);
+        __bic_SR_register(CPUOFF | OSCOFF | SCG0 | SCG1);
         break;
     case LPM_IDLE:
         /* lightest mode => LPM0 mode of MSP430 */
-        __bic_status_register(OSCOFF | SCG0 | SCG1);
+        __bic_SR_register(OSCOFF | SCG0 | SCG1);
         /* only stops CPU block */
-        __bis_status_register(CPUOFF);
+        __bis_SR_register(CPUOFF);
         break;
     case LPM_SLEEP:
         /* mid-level mode => LPM1 mode of MSP430 */
-        __bic_status_register(OSCOFF | SCG1);
+        __bic_SR_register(OSCOFF | SCG1);
         /* stops CPU and master clock blocks */
-        __bis_status_register(CPUOFF | SCG0);
+        __bis_SR_register(CPUOFF | SCG0);
         break;
     case LPM_POWERDOWN:
         /* deep-level mode => LPM3 mode of MSP430 */
-        __bic_status_register(OSCOFF);
+        __bic_SR_register(OSCOFF);
         /* stops all blocks except auxiliary clock (timers) */
-        __bis_status_register(CPUOFF | SCG0 | SCG1);
+        __bis_SR_register(CPUOFF | SCG0 | SCG1);
         break;
     case LPM_OFF:
         /* MCU totally down (LPM4), only RESET or NMI can resume execution */
-        __bis_status_register(CPUOFF | OSCOFF | SCG0 | SCG1);
+        __bis_SR_register(CPUOFF | OSCOFF | SCG0 | SCG1);
                                /* all blocks off */
         break;
     default:
@@ -93,7 +90,7 @@ enum lpm_mode lpm_get(void)
 {
     enum lpm_mode current_mode = LPM_UNKNOWN;
 
-    unsigned int current_sr = __read_status_register();
+    unsigned int current_sr = __get_SR_register();
     switch (current_sr & LPM_MASK_SR) {
     case CPUOFF + OSCOFF + SCG0 + SCG1:   /* MSP430's LPM4 */
         current_mode = LPM_OFF;
@@ -120,7 +117,7 @@ enum lpm_mode lpm_get(void)
 inline void lpm_awake(void)
 {
     /* disable all power savings mechanisms */
-    __bic_status_register(CPUOFF | OSCOFF | SCG0 | SCG1);
+    __bic_SR_register(CPUOFF | OSCOFF | SCG0 | SCG1);
 }
 
 /* the following two functions have no actual role to play MSP430s */

--- a/cpu/msp430-common/msp430-main.c
+++ b/cpu/msp430-common/msp430-main.c
@@ -104,9 +104,11 @@ init_ports(void)
 }
 
 /*---------------------------------------------------------------------------*/
+#if !(MODULE_NEWLIB)
 /* msp430-ld may align _end incorrectly. Workaround in cpu_init. */
 extern int _end;        /* Not in sys/unistd.h */
 static char *cur_break = (char *) &_end;
+#endif
 
 void msp430_cpu_init(void)
 {
@@ -115,15 +117,18 @@ void msp430_cpu_init(void)
     //  lpm_init();
     irq_enable();
 
+#if !(MODULE_NEWLIB)
     if ((uintptr_t)cur_break & 1) { /* Workaround for msp430-ld bug!*/
         cur_break++;
     }
+#endif
 }
 /*---------------------------------------------------------------------------*/
 #define asmv(arg) __asm__ __volatile__(arg)
 
-#define STACK_EXTRA 32
+#if !(MODULE_NEWLIB)
 
+#define STACK_EXTRA 32
 
 /*
  * Allocate memory from the heap. Check that we don't collide with the
@@ -150,6 +155,7 @@ void *sbrk(int incr)
     */
     return old_break;
 }
+#endif
 /*---------------------------------------------------------------------------*/
 /*
  * Mask all interrupts that can be masked.

--- a/cpu/msp430fxyz/flashrom.c
+++ b/cpu/msp430fxyz/flashrom.c
@@ -18,9 +18,9 @@
  * @}
  */
 
-#include "irq.h"
 #include <stddef.h>
 #include <stdint.h>
+
 #include "cpu.h"
 #include "irq.h"
 
@@ -57,7 +57,7 @@ uint8_t flashrom_write(uint8_t *dst, const uint8_t *src, size_t size)
         *(dst++) = *(src++);                /* program Flash word */
 
         while (!(FCTL3 & WAIT)) {
-            nop();
+            __nop();
         }
     }
 
@@ -105,6 +105,6 @@ static inline void busy_wait(void)
 {
     /* Wait for BUSY = 0, not needed unless run from RAM */
     while (FCTL3 & 0x0001) {
-        nop();
+        __nop();
     }
 }

--- a/cpu/msp430fxyz/ldscripts/msp430f1611.ld
+++ b/cpu/msp430fxyz/ldscripts/msp430f1611.ld
@@ -1,0 +1,96 @@
+/* ============================================================================ */
+/* Copyright (c) 2015, Texas Instruments Incorporated                           */
+/*  All rights reserved.                                                        */
+/*                                                                              */
+/*  Redistribution and use in source and binary forms, with or without          */
+/*  modification, are permitted provided that the following conditions          */
+/*  are met:                                                                    */
+/*                                                                              */
+/*  *  Redistributions of source code must retain the above copyright           */
+/*     notice, this list of conditions and the following disclaimer.            */
+/*                                                                              */
+/*  *  Redistributions in binary form must reproduce the above copyright        */
+/*     notice, this list of conditions and the following disclaimer in the      */
+/*     documentation and/or other materials provided with the distribution.     */
+/*                                                                              */
+/*  *  Neither the name of Texas Instruments Incorporated nor the names of      */
+/*     its contributors may be used to endorse or promote products derived      */
+/*     from this software without specific prior written permission.            */
+/*                                                                              */
+/*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,       */
+/*  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR      */
+/*  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR            */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,       */
+/*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,         */
+/*  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; */
+/*  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,    */
+/*  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR     */
+/*  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,              */
+/*  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                          */
+/* ============================================================================ */
+
+/* This file supports MSP430F2617 devices. */
+/* Version: 1.173 */
+/* Default linker script, for normal executables */
+
+OUTPUT_FORMAT("elf32-msp430", "elf32-msp430", "elf32-msp430")
+OUTPUT_ARCH(msp430)
+ENTRY(_start)
+SEARCH_DIR(.)
+
+
+MEMORY {
+  SFR              : ORIGIN = 0x0000, LENGTH = 0x0010 /* END=0x0010, size 16 */
+  PERIPHERAL_8BIT  : ORIGIN = 0x0010, LENGTH = 0x00F0 /* END=0x0100, size 240 */
+  PERIPHERAL_16BIT : ORIGIN = 0x0100, LENGTH = 0x0100 /* END=0x0200, size 256 */
+  RAM              : ORIGIN = 0x1100, LENGTH = 0x2800 /* END=0x38FF, size 10240 */
+  INFOMEM          : ORIGIN = 0x1000, LENGTH = 0x0100 /* END=0x10FF, size 256 as 2 128-byte segments */
+  INFOA            : ORIGIN = 0x1080, LENGTH = 0x0080 /* END=0x10FF, size 128 */
+  INFOB            : ORIGIN = 0x1000, LENGTH = 0x0080 /* END=0x107F, size 128 */
+  ROM (rx)         : ORIGIN = 0x4000, LENGTH = 0xBFE0 /* END=0xFFDF, size 49120 */
+  VECT1            : ORIGIN = 0xFFE0, LENGTH = 0x0002
+  VECT2            : ORIGIN = 0xFFE2, LENGTH = 0x0002
+  VECT3            : ORIGIN = 0xFFE4, LENGTH = 0x0002
+  VECT4            : ORIGIN = 0xFFE6, LENGTH = 0x0002
+  VECT5            : ORIGIN = 0xFFE8, LENGTH = 0x0002
+  VECT6            : ORIGIN = 0xFFEA, LENGTH = 0x0002
+  VECT7            : ORIGIN = 0xFFEC, LENGTH = 0x0002
+  VECT8            : ORIGIN = 0xFFEE, LENGTH = 0x0002
+  VECT9            : ORIGIN = 0xFFF0, LENGTH = 0x0002
+  VECT10           : ORIGIN = 0xFFF2, LENGTH = 0x0002
+  VECT11           : ORIGIN = 0xFFF4, LENGTH = 0x0002
+  VECT12           : ORIGIN = 0xFFF6, LENGTH = 0x0002
+  VECT13           : ORIGIN = 0xFFF8, LENGTH = 0x0002
+  VECT14           : ORIGIN = 0xFFFA, LENGTH = 0x0002
+  VECT15           : ORIGIN = 0xFFFC, LENGTH = 0x0002
+  RESETVEC         : ORIGIN = 0xFFFE, LENGTH = 0x0002
+  RAM_MIRROR       : ORIGIN = 0x0200, LENGTH = 0x0800
+}
+
+SECTIONS
+{
+  __interrupt_vector_1   : { KEEP (*(__interrupt_vector_1 )) KEEP (*(__interrupt_vector_dacdma)) } > VECT1
+  __interrupt_vector_2   : { KEEP (*(__interrupt_vector_2 )) KEEP (*(__interrupt_vector_port2)) } > VECT2
+  __interrupt_vector_3   : { KEEP (*(__interrupt_vector_3 )) KEEP (*(__interrupt_vector_usart1tx)) } > VECT3
+  __interrupt_vector_4   : { KEEP (*(__interrupt_vector_4 )) KEEP (*(__interrupt_vector_usart1rx)) } > VECT4
+  __interrupt_vector_5   : { KEEP (*(__interrupt_vector_5 )) KEEP (*(__interrupt_vector_port1)) } > VECT5
+  __interrupt_vector_6   : { KEEP (*(__interrupt_vector_6 )) KEEP (*(__interrupt_vector_timera1)) } > VECT6
+  __interrupt_vector_7   : { KEEP (*(__interrupt_vector_7 )) KEEP (*(__interrupt_vector_timera0)) } > VECT7
+  __interrupt_vector_8   : { KEEP (*(__interrupt_vector_8 )) KEEP (*(__interrupt_vector_adc12)) } > VECT8
+  __interrupt_vector_9   : { KEEP (*(__interrupt_vector_9 )) KEEP (*(__interrupt_vector_usart0tx)) } > VECT9
+  __interrupt_vector_10  : { KEEP (*(__interrupt_vector_10)) KEEP (*(__interrupt_vector_usart0rx)) } > VECT10
+  __interrupt_vector_11  : { KEEP (*(__interrupt_vector_11)) KEEP (*(__interrupt_vector_wdt)) } > VECT11
+  __interrupt_vector_12  : { KEEP (*(__interrupt_vector_12)) KEEP (*(__interrupt_vector_comparatora)) } > VECT12
+  __interrupt_vector_13  : { KEEP (*(__interrupt_vector_13)) KEEP (*(__interrupt_vector_timerb1)) } > VECT13
+  __interrupt_vector_14  : { KEEP (*(__interrupt_vector_14)) KEEP (*(__interrupt_vector_timerb0)) } > VECT14
+  __interrupt_vector_15  : { KEEP (*(__interrupt_vector_15)) KEEP (*(__interrupt_vector_nmi)) } > VECT15
+  __reset_vector :
+  {
+    KEEP (*(__interrupt_vector_16))
+    KEEP (*(__interrupt_vector_reset))
+    KEEP (*(.resetvec))
+  } > RESETVEC
+}
+
+INCLUDE msp430_base.ld

--- a/cpu/msp430fxyz/ldscripts/msp430f1612.ld
+++ b/cpu/msp430fxyz/ldscripts/msp430f1612.ld
@@ -1,0 +1,95 @@
+/* ============================================================================ */
+/* Copyright (c) 2015, Texas Instruments Incorporated                           */
+/*  All rights reserved.                                                        */
+/*                                                                              */
+/*  Redistribution and use in source and binary forms, with or without          */
+/*  modification, are permitted provided that the following conditions          */
+/*  are met:                                                                    */
+/*                                                                              */
+/*  *  Redistributions of source code must retain the above copyright           */
+/*     notice, this list of conditions and the following disclaimer.            */
+/*                                                                              */
+/*  *  Redistributions in binary form must reproduce the above copyright        */
+/*     notice, this list of conditions and the following disclaimer in the      */
+/*     documentation and/or other materials provided with the distribution.     */
+/*                                                                              */
+/*  *  Neither the name of Texas Instruments Incorporated nor the names of      */
+/*     its contributors may be used to endorse or promote products derived      */
+/*     from this software without specific prior written permission.            */
+/*                                                                              */
+/*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,       */
+/*  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR      */
+/*  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR            */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,       */
+/*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,         */
+/*  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; */
+/*  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,    */
+/*  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR     */
+/*  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,              */
+/*  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                          */
+/* ============================================================================ */
+
+/* This file supports MSP430F2617 devices. */
+/* Version: 1.173 */
+/* Default linker script, for normal executables */
+
+OUTPUT_FORMAT("elf32-msp430", "elf32-msp430", "elf32-msp430")
+OUTPUT_ARCH(msp430)
+ENTRY(_start)
+SEARCH_DIR(.)
+
+MEMORY {
+  SFR              : ORIGIN = 0x0000, LENGTH = 0x0010 /* END=0x0010, size 16 */
+  PERIPHERAL_8BIT  : ORIGIN = 0x0010, LENGTH = 0x00F0 /* END=0x0100, size 240 */
+  PERIPHERAL_16BIT : ORIGIN = 0x0100, LENGTH = 0x0100 /* END=0x0200, size 256 */
+  RAM              : ORIGIN = 0x1100, LENGTH = 0x1400 /* END=0x24FF, size 5120 */
+  INFOMEM          : ORIGIN = 0x1000, LENGTH = 0x0100 /* END=0x10FF, size 256 as 2 128-byte segments */
+  INFOA            : ORIGIN = 0x1080, LENGTH = 0x0080 /* END=0x10FF, size 128 */
+  INFOB            : ORIGIN = 0x1000, LENGTH = 0x0080 /* END=0x107F, size 128 */
+  ROM (rx)         : ORIGIN = 0x2500, LENGTH = 0xDAE0 /* END=0xFFDF, size 56032 */
+  VECT1            : ORIGIN = 0xFFE0, LENGTH = 0x0002
+  VECT2            : ORIGIN = 0xFFE2, LENGTH = 0x0002
+  VECT3            : ORIGIN = 0xFFE4, LENGTH = 0x0002
+  VECT4            : ORIGIN = 0xFFE6, LENGTH = 0x0002
+  VECT5            : ORIGIN = 0xFFE8, LENGTH = 0x0002
+  VECT6            : ORIGIN = 0xFFEA, LENGTH = 0x0002
+  VECT7            : ORIGIN = 0xFFEC, LENGTH = 0x0002
+  VECT8            : ORIGIN = 0xFFEE, LENGTH = 0x0002
+  VECT9            : ORIGIN = 0xFFF0, LENGTH = 0x0002
+  VECT10           : ORIGIN = 0xFFF2, LENGTH = 0x0002
+  VECT11           : ORIGIN = 0xFFF4, LENGTH = 0x0002
+  VECT12           : ORIGIN = 0xFFF6, LENGTH = 0x0002
+  VECT13           : ORIGIN = 0xFFF8, LENGTH = 0x0002
+  VECT14           : ORIGIN = 0xFFFA, LENGTH = 0x0002
+  VECT15           : ORIGIN = 0xFFFC, LENGTH = 0x0002
+  RESETVEC         : ORIGIN = 0xFFFE, LENGTH = 0x0002
+  RAM_MIRROR       : ORIGIN = 0x0200, LENGTH = 0x0800
+}
+
+SECTIONS
+{
+  __interrupt_vector_1   : { KEEP (*(__interrupt_vector_1 )) KEEP (*(__interrupt_vector_dacdma)) } > VECT1
+  __interrupt_vector_2   : { KEEP (*(__interrupt_vector_2 )) KEEP (*(__interrupt_vector_port2)) } > VECT2
+  __interrupt_vector_3   : { KEEP (*(__interrupt_vector_3 )) KEEP (*(__interrupt_vector_usart1tx)) } > VECT3
+  __interrupt_vector_4   : { KEEP (*(__interrupt_vector_4 )) KEEP (*(__interrupt_vector_usart1rx)) } > VECT4
+  __interrupt_vector_5   : { KEEP (*(__interrupt_vector_5 )) KEEP (*(__interrupt_vector_port1)) } > VECT5
+  __interrupt_vector_6   : { KEEP (*(__interrupt_vector_6 )) KEEP (*(__interrupt_vector_timera1)) } > VECT6
+  __interrupt_vector_7   : { KEEP (*(__interrupt_vector_7 )) KEEP (*(__interrupt_vector_timera0)) } > VECT7
+  __interrupt_vector_8   : { KEEP (*(__interrupt_vector_8 )) KEEP (*(__interrupt_vector_adc12)) } > VECT8
+  __interrupt_vector_9   : { KEEP (*(__interrupt_vector_9 )) KEEP (*(__interrupt_vector_usart0tx)) } > VECT9
+  __interrupt_vector_10  : { KEEP (*(__interrupt_vector_10)) KEEP (*(__interrupt_vector_usart0rx)) } > VECT10
+  __interrupt_vector_11  : { KEEP (*(__interrupt_vector_11)) KEEP (*(__interrupt_vector_wdt)) } > VECT11
+  __interrupt_vector_12  : { KEEP (*(__interrupt_vector_12)) KEEP (*(__interrupt_vector_comparatora)) } > VECT12
+  __interrupt_vector_13  : { KEEP (*(__interrupt_vector_13)) KEEP (*(__interrupt_vector_timerb1)) } > VECT13
+  __interrupt_vector_14  : { KEEP (*(__interrupt_vector_14)) KEEP (*(__interrupt_vector_timerb0)) } > VECT14
+  __interrupt_vector_15  : { KEEP (*(__interrupt_vector_15)) KEEP (*(__interrupt_vector_nmi)) } > VECT15
+  __reset_vector :
+  {
+    KEEP (*(__interrupt_vector_16))
+    KEEP (*(__interrupt_vector_reset))
+    KEEP (*(.resetvec))
+  } > RESETVEC
+}
+
+INCLUDE msp430_base.ld

--- a/cpu/msp430fxyz/ldscripts/msp430f2617.ld
+++ b/cpu/msp430fxyz/ldscripts/msp430f2617.ld
@@ -1,0 +1,131 @@
+/* ============================================================================ */
+/* Copyright (c) 2015, Texas Instruments Incorporated                           */
+/*  All rights reserved.                                                        */
+/*                                                                              */
+/*  Redistribution and use in source and binary forms, with or without          */
+/*  modification, are permitted provided that the following conditions          */
+/*  are met:                                                                    */
+/*                                                                              */
+/*  *  Redistributions of source code must retain the above copyright           */
+/*     notice, this list of conditions and the following disclaimer.            */
+/*                                                                              */
+/*  *  Redistributions in binary form must reproduce the above copyright        */
+/*     notice, this list of conditions and the following disclaimer in the      */
+/*     documentation and/or other materials provided with the distribution.     */
+/*                                                                              */
+/*  *  Neither the name of Texas Instruments Incorporated nor the names of      */
+/*     its contributors may be used to endorse or promote products derived      */
+/*     from this software without specific prior written permission.            */
+/*                                                                              */
+/*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,       */
+/*  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR      */
+/*  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR            */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,       */
+/*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,         */
+/*  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; */
+/*  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,    */
+/*  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR     */
+/*  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,              */
+/*  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                          */
+/* ============================================================================ */
+
+/* This file supports MSP430F2617 devices. */
+/* Version: 1.173 */
+/* Default linker script, for normal executables */
+
+OUTPUT_FORMAT("elf32-msp430", "elf32-msp430", "elf32-msp430")
+OUTPUT_ARCH(msp430)
+ENTRY(_start)
+SEARCH_DIR(.)
+
+MEMORY {
+  SFR              : ORIGIN = 0x0000, LENGTH = 0x0010 /* END=0x0010, size 16 */
+  PERIPHERAL_8BIT  : ORIGIN = 0x0010, LENGTH = 0x00F0 /* END=0x0100, size 240 */
+  PERIPHERAL_16BIT : ORIGIN = 0x0100, LENGTH = 0x0100 /* END=0x0200, size 256 */
+  RAM              : ORIGIN = 0x1100, LENGTH = 0x2000 /* END=0x30FF, size 8192 */
+  INFOMEM          : ORIGIN = 0x1000, LENGTH = 0x0100 /* END=0x10FF, size 256 as 4 64-byte segments */
+  INFOA            : ORIGIN = 0x10C0, LENGTH = 0x0040 /* END=0x10FF, size 64 */
+  INFOB            : ORIGIN = 0x1080, LENGTH = 0x0040 /* END=0x10BF, size 64 */
+  INFOC            : ORIGIN = 0x1040, LENGTH = 0x0040 /* END=0x107F, size 64 */
+  INFOD            : ORIGIN = 0x1000, LENGTH = 0x0040 /* END=0x103F, size 64 */
+  ROM (rx)         : ORIGIN = 0x3100, LENGTH = 0xCEBE /* END=0xFFBD, size 52926 */
+  VECT1            : ORIGIN = 0xFFC0, LENGTH = 0x0002
+  VECT2            : ORIGIN = 0xFFC2, LENGTH = 0x0002
+  VECT3            : ORIGIN = 0xFFC4, LENGTH = 0x0002
+  VECT4            : ORIGIN = 0xFFC6, LENGTH = 0x0002
+  VECT5            : ORIGIN = 0xFFC8, LENGTH = 0x0002
+  VECT6            : ORIGIN = 0xFFCA, LENGTH = 0x0002
+  VECT7            : ORIGIN = 0xFFCC, LENGTH = 0x0002
+  VECT8            : ORIGIN = 0xFFCE, LENGTH = 0x0002
+  VECT9            : ORIGIN = 0xFFD0, LENGTH = 0x0002
+  VECT10           : ORIGIN = 0xFFD2, LENGTH = 0x0002
+  VECT11           : ORIGIN = 0xFFD4, LENGTH = 0x0002
+  VECT12           : ORIGIN = 0xFFD6, LENGTH = 0x0002
+  VECT13           : ORIGIN = 0xFFD8, LENGTH = 0x0002
+  VECT14           : ORIGIN = 0xFFDA, LENGTH = 0x0002
+  VECT15           : ORIGIN = 0xFFDC, LENGTH = 0x0002
+  VECT16           : ORIGIN = 0xFFDE, LENGTH = 0x0002
+  VECT17           : ORIGIN = 0xFFE0, LENGTH = 0x0002
+  VECT18           : ORIGIN = 0xFFE2, LENGTH = 0x0002
+  VECT19           : ORIGIN = 0xFFE4, LENGTH = 0x0002
+  VECT20           : ORIGIN = 0xFFE6, LENGTH = 0x0002
+  VECT21           : ORIGIN = 0xFFE8, LENGTH = 0x0002
+  VECT22           : ORIGIN = 0xFFEA, LENGTH = 0x0002
+  VECT23           : ORIGIN = 0xFFEC, LENGTH = 0x0002
+  VECT24           : ORIGIN = 0xFFEE, LENGTH = 0x0002
+  VECT25           : ORIGIN = 0xFFF0, LENGTH = 0x0002
+  VECT26           : ORIGIN = 0xFFF2, LENGTH = 0x0002
+  VECT27           : ORIGIN = 0xFFF4, LENGTH = 0x0002
+  VECT28           : ORIGIN = 0xFFF6, LENGTH = 0x0002
+  VECT29           : ORIGIN = 0xFFF8, LENGTH = 0x0002
+  VECT30           : ORIGIN = 0xFFFA, LENGTH = 0x0002
+  VECT31           : ORIGIN = 0xFFFC, LENGTH = 0x0002
+  RESETVEC         : ORIGIN = 0xFFFE, LENGTH = 0x0002
+  RAM_MIRROR       : ORIGIN = 0x0200, LENGTH = 0x0800
+  HIROM (rx)       : ORIGIN = 0x00010000, LENGTH = 0x00009FFF
+}
+
+SECTIONS
+{
+  __interrupt_vector_1   : { KEEP (*(__interrupt_vector_1 )) KEEP (*(__interrupt_vector_reserved0)) } > VECT1
+  __interrupt_vector_2   : { KEEP (*(__interrupt_vector_2 )) KEEP (*(__interrupt_vector_reserved1)) } > VECT2
+  __interrupt_vector_3   : { KEEP (*(__interrupt_vector_3 )) KEEP (*(__interrupt_vector_reserved2)) } > VECT3
+  __interrupt_vector_4   : { KEEP (*(__interrupt_vector_4 )) KEEP (*(__interrupt_vector_reserved3)) } > VECT4
+  __interrupt_vector_5   : { KEEP (*(__interrupt_vector_5 )) KEEP (*(__interrupt_vector_reserved4)) } > VECT5
+  __interrupt_vector_6   : { KEEP (*(__interrupt_vector_6 )) KEEP (*(__interrupt_vector_reserved5)) } > VECT6
+  __interrupt_vector_7   : { KEEP (*(__interrupt_vector_7 )) KEEP (*(__interrupt_vector_reserved6)) } > VECT7
+  __interrupt_vector_8   : { KEEP (*(__interrupt_vector_8 )) KEEP (*(__interrupt_vector_reserved7)) } > VECT8
+  __interrupt_vector_9   : { KEEP (*(__interrupt_vector_9 )) KEEP (*(__interrupt_vector_reserved8)) } > VECT9
+  __interrupt_vector_10  : { KEEP (*(__interrupt_vector_10)) KEEP (*(__interrupt_vector_reserved9)) } > VECT10
+  __interrupt_vector_11  : { KEEP (*(__interrupt_vector_11)) KEEP (*(__interrupt_vector_reserved10)) } > VECT11
+  __interrupt_vector_12  : { KEEP (*(__interrupt_vector_12)) KEEP (*(__interrupt_vector_reserved11)) } > VECT12
+  __interrupt_vector_13  : { KEEP (*(__interrupt_vector_13)) KEEP (*(__interrupt_vector_reserved12)) } > VECT13
+  __interrupt_vector_14  : { KEEP (*(__interrupt_vector_14)) KEEP (*(__interrupt_vector_reserved13)) } > VECT14
+  __interrupt_vector_15  : { KEEP (*(__interrupt_vector_15)) KEEP (*(__interrupt_vector_dac12)) } > VECT15
+  __interrupt_vector_16  : { KEEP (*(__interrupt_vector_16)) KEEP (*(__interrupt_vector_dma)) } > VECT16
+  __interrupt_vector_17  : { KEEP (*(__interrupt_vector_17)) KEEP (*(__interrupt_vector_usciab1tx)) } > VECT17
+  __interrupt_vector_18  : { KEEP (*(__interrupt_vector_18)) KEEP (*(__interrupt_vector_usciab1rx)) } > VECT18
+  __interrupt_vector_19  : { KEEP (*(__interrupt_vector_19)) KEEP (*(__interrupt_vector_port1)) } > VECT19
+  __interrupt_vector_20  : { KEEP (*(__interrupt_vector_20)) KEEP (*(__interrupt_vector_port2)) } > VECT20
+  __interrupt_vector_21  : { KEEP (*(__interrupt_vector_21)) KEEP (*(__interrupt_vector_reserved20)) } > VECT21
+  __interrupt_vector_22  : { KEEP (*(__interrupt_vector_22)) KEEP (*(__interrupt_vector_adc12)) } > VECT22
+  __interrupt_vector_23  : { KEEP (*(__interrupt_vector_23)) KEEP (*(__interrupt_vector_usciab0tx)) } > VECT23
+  __interrupt_vector_24  : { KEEP (*(__interrupt_vector_24)) KEEP (*(__interrupt_vector_usciab0rx)) } > VECT24
+  __interrupt_vector_25  : { KEEP (*(__interrupt_vector_25)) KEEP (*(__interrupt_vector_timera1)) } > VECT25
+  __interrupt_vector_26  : { KEEP (*(__interrupt_vector_26)) KEEP (*(__interrupt_vector_timera0)) } > VECT26
+  __interrupt_vector_27  : { KEEP (*(__interrupt_vector_27)) KEEP (*(__interrupt_vector_wdt)) } > VECT27
+  __interrupt_vector_28  : { KEEP (*(__interrupt_vector_28)) KEEP (*(__interrupt_vector_comparatora)) } > VECT28
+  __interrupt_vector_29  : { KEEP (*(__interrupt_vector_29)) KEEP (*(__interrupt_vector_timerb1)) } > VECT29
+  __interrupt_vector_30  : { KEEP (*(__interrupt_vector_30)) KEEP (*(__interrupt_vector_timerb0)) } > VECT30
+  __interrupt_vector_31  : { KEEP (*(__interrupt_vector_31)) KEEP (*(__interrupt_vector_nmi)) } > VECT31
+  __reset_vector :
+  {
+    KEEP (*(__interrupt_vector_32))
+    KEEP (*(__interrupt_vector_reset))
+    KEEP (*(.resetvec))
+  } > RESETVEC
+}
+
+INCLUDE msp430_base.ld
+INCLUDE msp430_hirom.ld

--- a/cpu/msp430fxyz/msp430_stdio.c
+++ b/cpu/msp430fxyz/msp430_stdio.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#if !(MODULE_NEWLIB)
+
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -55,3 +57,5 @@ ssize_t write(int fildes, const void *buf, size_t nbyte)
         return -1;
     }
 }
+
+#endif

--- a/sys/newlib/Makefile.include
+++ b/sys/newlib/Makefile.include
@@ -47,6 +47,10 @@ ifeq (,$(NEWLIB_INCLUDE_DIR))
   NEWLIB_INCLUDE_DIR := $(abspath $(wildcard $(dir $(shell which $(PREFIX)gcc))../$(TARGET_ARCH)/include))
 endif
 
+ifeq (,$(NEWLIB_INCLUDE_DIR))
+  $(error Could not determine newlib include path!)
+endif
+
 NEWLIB_INCLUDES := -isystem $(NEWLIB_INCLUDE_DIR)
 
 ifeq (1,$(USE_NEWLIB_NANO))


### PR DESCRIPTION
MSPGCC (the old compiler) is usually used with msp-libc, while the new upstream GCC msp430 port (sometimes referred to as the Red Hat MSP430 compiler) is usually accompanied by newlib.
The new msp430 port started with version 4.9.x, the latest release of the old mspgcc is 4.6.3 in the beginning of 2012 and doesn't look like it will receive any updates.

Untested on actual hardware since I don't have access to any msp430 boards.
