### PR TITLE
pktbuf: do not inline gnrc_pktbuf_remove_snip

### DIFF
--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -202,15 +202,7 @@ gnrc_pktsnip_t *gnrc_pktbuf_get_iovec(gnrc_pktsnip_t *pkt, size_t *len);
  *
  * @return  The new reference to @p pkt.
  */
-static inline gnrc_pktsnip_t *gnrc_pktbuf_remove_snip(gnrc_pktsnip_t *pkt,
-                                                      gnrc_pktsnip_t *snip)
-{
-    LL_DELETE(pkt, snip);
-    snip->next = NULL;
-    gnrc_pktbuf_release(snip);
-
-    return pkt;
-}
+gnrc_pktsnip_t *gnrc_pktbuf_remove_snip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *snip);
 
 #ifdef DEVELHELP
 /**

--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -493,4 +493,14 @@ static void _pktbuf_free(void *data, size_t size)
     }
 }
 
+
+gnrc_pktsnip_t *gnrc_pktbuf_remove_snip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *snip)
+{
+    LL_DELETE(pkt, snip);
+    snip->next = NULL;
+    gnrc_pktbuf_release(snip);
+
+    return pkt;
+}
+
 /** @} */


### PR DESCRIPTION
Not inlining `gnrc_pktbuf_remove_snip` saves a little ROM for some boards.
Diff for `gnrc_networking`:
```
text    data    bss     dec     BOARD/BINDIRBASE

0       0       0       0       arduino-due
57724   224     19896   77844   master-bin
57724   224     19896   77844   not_inline-bin

4       0       0       4       arduino-mega2560
81274   10926   13752   105952  master-bin
81278   10926   13752   105956  not_inline-bin

-24     0       0       -24     avsextrem
132656  2332    95965   230953  master-bin
132632  2332    95965   230929  not_inline-bin

0       0       0       0       cc2538dk
57664   220     19872   77756   master-bin
57664   220     19872   77756   not_inline-bin

0       0       0       0       ek-lm4f120xl
58004   220     19872   78096   master-bin
58004   220     19872   78096   not_inline-bin

0       0       0       0       f4vi1
59640   224     20008   79872   master-bin
59640   224     20008   79872   not_inline-bin

-68     0       0       -68     fox
73300   220     22968   96488   master-bin
73232   220     22968   96420   not_inline-bin

0       0       0       0       frdm-k64f
59756   1248    19864   80868   master-bin
59756   1248    19864   80868   not_inline-bin

-68     0       0       -68     iotlab-m3
73028   220     22968   96216   master-bin
72960   220     22968   96148   not_inline-bin

0       0       0       0       limifrog-v1
58852   220     20000   79072   master-bin
58852   220     20000   79072   not_inline-bin

0       0       0       0       mbed_lpc1768
57324   220     19872   77416   master-bin
57324   220     19872   77416   not_inline-bin

-184    0       0       -184    msba2
159920  2332    95965   258217  master-bin
159736  2332    95965   258033  not_inline-bin

0       0       0       0       msbiot
59952   224     20056   80232   master-bin
59952   224     20056   80232   not_inline-bin

-64     0       0       -64     mulle
78040   1284    23248   102572  master-bin
77976   1284    23248   102508  not_inline-bin

0       0       0       0       nrf52dk
57364   220     19864   77448   master-bin
57364   220     19864   77448   not_inline-bin

0       0       0       0       nucleo-f091
60356   220     19872   80448   master-bin
60356   220     19872   80448   not_inline-bin

0       0       0       0       nucleo-f303
57860   220     19880   77960   master-bin
57860   220     19880   77960   not_inline-bin

0       0       0       0       nucleo-f401
59640   224     20008   79872   master-bin
59640   224     20008   79872   not_inline-bin

0       0       0       0       nucleo-l1
58736   220     19992   78948   master-bin
58736   220     19992   78948   not_inline-bin

0       0       0       0       openmote-cc2538
57572   220     19872   77664   master-bin
57572   220     19872   77664   not_inline-bin

-64     0       0       -64     pba-d-01-kw2x
75264   1248    23312   99824   master-bin
75200   1248    23312   99760   not_inline-bin

-24     0       0       -24     pttu
132864  2332    95965   231161  master-bin
132840  2332    95965   231137  not_inline-bin

0       0       0       0       remote
58248   220     19872   78340   master-bin
58248   220     19872   78340   not_inline-bin

0       0       0       0       saml21-xpro
60552   220     19992   80764   master-bin
60552   220     19992   80764   not_inline-bin

-76     0       0       -76     samr21-xpro
77548   220     22984   100752  master-bin
77472   220     22984   100676  not_inline-bin

0       0       0       0       slwstk6220a
57504   220     20000   77724   master-bin
57504   220     20000   77724   not_inline-bin

0       0       0       0       stm32f3discovery
57876   220     19880   77976   master-bin
57876   220     19880   77976   not_inline-bin

0       0       0       0       stm32f4discovery
59884   224     20032   80140   master-bin
59884   224     20032   80140   not_inline-bin

0       0       0       0       udoo
57724   224     19896   77844   master-bin
57724   224     19896   77844   not_inline-bin
```