### PR TITLE
drivers/srf02: made device address reprogrammable

### DIFF
--- a/drivers/include/srf02.h
+++ b/drivers/include/srf02.h
@@ -34,7 +34,7 @@ extern "C" {
 /**
  * @brief   Default I2C address of SRF02 sensors
  */
-#define SRF02_DEFAULT_ADDR                  112
+#define SRF02_DEFAULT_ADDR                  (0xe0)
 
 /**
  * @brief   Device descriptor for SRF02 sensors
@@ -84,6 +84,14 @@ int srf02_init(srf02_t *dev, i2c_t i2c, uint8_t addr);
  *
  */
 uint16_t srf02_get_distance(srf02_t *dev, srf02_mode_t mode);
+
+/**
+ * @brief   Program the given device with a new bus address
+ *
+ * @param[in] dev           device to program
+ * @param[in] new_addr      new address to program the given device to
+ */
+void srf02_set_addr(srf02_t *dev, uint8_t new_addr);
 
 #ifdef __cplusplus
 }

--- a/drivers/srf02/srf02.c
+++ b/drivers/srf02/srf02.c
@@ -28,7 +28,7 @@
 #include "srf02.h"
 #include "periph/i2c.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG        (0)
 #include "debug.h"
 
 /**
@@ -52,10 +52,20 @@
 #define REG_AUTO_LOW        (0x05)
 /** @} */
 
+/**
+ * @brief   Some additional SRF02 commands
+ * @{
+ */
+#define CMD_ADDR_SEQ1       (0xa0)
+#define CMD_ADDR_SEQ2       (0xaa)
+#define CMD_ADDR_SEQ3       (0xa5)
+/** @} */
+
+
 int srf02_init(srf02_t *dev, i2c_t i2c, uint8_t addr)
 {
     dev->i2c = i2c;
-    dev->addr = addr;
+    dev->addr = (addr >> 1);    /* internally we right align the 7-bit addr */
     char rev;
 
     /* Acquire exclusive access to the bus. */
@@ -66,7 +76,7 @@ int srf02_init(srf02_t *dev, i2c_t i2c, uint8_t addr)
         return -1;
     }
     /* try to read the software revision (read the CMD reg) from the device */
-    i2c_read_reg(i2c, addr, REG_CMD, &rev);
+    i2c_read_reg(i2c, dev->addr, REG_CMD, &rev);
     if (rev == 0 || rev == 255) {
         DEBUG("[srf02] error reading the devices software revision\n");
         return -1;
@@ -101,4 +111,22 @@ uint16_t srf02_get_distance(srf02_t *dev, srf02_mode_t mode)
 
     /* compile result - TODO: fix for different host byte order other than LE */
     return ((((uint16_t)res[0]) << 8) | (res[1] & 0xff));
+}
+
+void srf02_set_addr(srf02_t *dev, uint8_t new_addr)
+{
+    /* get access to the bus */
+    i2c_acquire(dev->i2c);
+
+    DEBUG("[srf02] reprogramming device address to 0x%02x\n", (int)new_addr);
+
+    /* write the new address, for this we need to follow a certain sequence */
+    i2c_write_reg(dev->i2c, dev->addr, REG_CMD, CMD_ADDR_SEQ1);
+    i2c_write_reg(dev->i2c, dev->addr, REG_CMD, CMD_ADDR_SEQ2);
+    i2c_write_reg(dev->i2c, dev->addr, REG_CMD, CMD_ADDR_SEQ3);
+    i2c_write_reg(dev->i2c, dev->addr, REG_CMD, new_addr);
+    dev->addr = (new_addr >> 1);
+
+    /* release the bus */
+    i2c_release(dev->i2c);
 }

--- a/tests/driver_srf02/Makefile
+++ b/tests/driver_srf02/Makefile
@@ -5,6 +5,7 @@ FEATURES_REQUIRED = periph_i2c
 
 USEMODULE += xtimer
 USEMODULE += srf02
+USEMODULE += shell
 
 # set default device parameters in case they are undefined
 TEST_SRF02_I2C ?= I2C_0


### PR DESCRIPTION
this is needed if you have more than 1 device on the same bus...

While at this, I changed the address handling of the driver slightly, now it accepts the 7-bit i2c addresses in left aligned format, which is used in the datasheet. So now you just take the addresses as given in the datasheet to interact with the device.