### PR TITLE
drivers/mma8652: pba-d-01-kw2x: add support for SAUL

### DIFF
--- a/boards/pba-d-01-kw2x/Makefile.dep
+++ b/boards/pba-d-01-kw2x/Makefile.dep
@@ -2,3 +2,7 @@ ifneq (,$(filter gnrc_netif_default,$(USEMODULE)))
   USEMODULE += kw2xrf
   USEMODULE += gnrc_nomac
 endif
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += mma8652
+endif

--- a/boards/pba-d-01-kw2x/include/mma8652_params.h
+++ b/boards/pba-d-01-kw2x/include/mma8652_params.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_pba-d-01-kw2x
+ * @{
+ *
+ * @file
+ * @brief     MMA8652 board specific configuration
+ *
+ * @author    Cenk Gündoğan <mail@cgundogan.de>
+ */
+
+#ifndef MMA8652_PARAMS_H
+#define MMA8652_PARAMS_H
+
+#include "board.h"
+#include "saul_reg.h"
+#include "mma8652.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    MMA852 configuration
+ */
+static const  mma8652_params_t mma8652_params[] =
+{
+    {
+        .i2c = MMA8652_I2C,
+        .addr = MMA8652_ADDR,
+        .rate = MMA8652_DATARATE_DEFAULT,
+        .scale = MMA8652_FS_RANGE_DEFAULT,
+    },
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t mma8652_saul_info[] =
+{
+    {
+        .name = "mma8652",
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MMA8652_PARAMS_H */
+/** @} */

--- a/drivers/include/mma8652.h
+++ b/drivers/include/mma8652.h
@@ -68,6 +68,16 @@ typedef struct {
 } mma8652_t;
 
 /**
+ * @brief Data structure holding all the information needed for initialization
+ */
+typedef struct {
+    i2c_t i2c;              /**< I2C bus used */
+    uint8_t addr;           /**< accelerometer's I2C address */
+    uint8_t rate;           /**< accelerometer's sampling rate */
+    uint8_t scale;          /**< accelerometer's scale factor */
+} mma8652_params_t;
+
+/**
  * @brief MMA8652 accelerometer test.
  * This function looks for Device ID of the MMA8652 accelerometer.
  *

--- a/drivers/mma8652/mma8652_saul.c
+++ b/drivers/mma8652/mma8652_saul.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     driver_mma8652
+ * @{
+ *
+ * @file
+ * @brief       MMA8652 adaption to the RIOT actuator/sensor interface
+ *
+ * @author      Cenk Gündoğan <mail@cgundogan.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+#include <stdio.h>
+
+#include "saul.h"
+#include "mma8652.h"
+
+static int read_acc(void *dev, phydat_t *res)
+{
+    int16_t x, y, z;
+    uint8_t status;
+
+    mma8652_t *d = (mma8652_t *)dev;
+    mma8652_read(d, &x, &y, &z, &status);
+
+    res->val[0] = x;
+    res->val[1] = y;
+    res->val[2] = z;
+    res->unit = UNIT_G;
+    res->scale = -3;
+
+    return 3;
+}
+
+static int write(void *dev, phydat_t *state)
+{
+    (void) dev;
+    (void) state;
+    return -ENOTSUP;
+}
+
+const saul_driver_t mma8652_saul_driver = {
+    .read = read_acc,
+    .write = write,
+    .type = SAUL_SENSE_ACCEL,
+};

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -234,6 +234,10 @@ void auto_init(void)
     extern void auto_init_lis3dh(void);
     auto_init_lis3dh();
 #endif
+#ifdef MODULE_MMA8652
+    extern void auto_init_mma8652(void);
+    auto_init_mma8652();
+#endif
 
 #endif /* MODULE_AUTO_INIT_SAUL */
 }

--- a/sys/auto_init/saul/auto_init_mma8652.c
+++ b/sys/auto_init/saul/auto_init_mma8652.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of MMA8652 accelerometer
+ *
+ * @author      Cenk Gündoğan <mail@cgundogan.de>
+ *
+ * @}
+ */
+
+#ifdef MODULE_MMA8652
+
+#include "saul_reg.h"
+#include "mma8652.h"
+#include "mma8652_params.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define MMA8652_NUM     (sizeof(mma8652_params)/sizeof(mma8652_params[0]))
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static mma8652_t mma8652_devs[MMA8652_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[MMA8652_NUM];
+
+/**
+ * @brief   Reference the driver struct
+ * @{
+ */
+extern saul_driver_t mma8652_saul_driver;
+/** @} */
+
+void auto_init_mma8652(void)
+{
+    for (int i = 0; i < MMA8652_NUM; i++) {
+        const mma8652_params_t *p = &mma8652_params[i];
+
+        DEBUG("[auto_init_saul] initializing mma8652 acc sensor\n");
+
+        if (mma8652_init(&mma8652_devs[i], p->i2c, p->addr, p->rate, p->scale) < 0) {
+            DEBUG("[auto_init_saul] error during initialization\n");
+            return;
+        }
+
+        if (mma8652_set_active(&mma8652_devs[i]) < 0) {
+            DEBUG("[auto_init_saul] error activating mma8652\n");
+            return;
+        }
+
+        saul_entries[i].dev = &(mma8652_devs[i]);
+        saul_entries[i].name = mma8652_saul_info[i].name;
+        saul_entries[i].driver = &mma8652_saul_driver;
+        saul_reg_add(&(saul_entries[i]));
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_MMA8652 */


### PR DESCRIPTION
This PR adds SAUL support for the mma8652 accelerometer and the `pba-d-01-kw2x` board.
Can be tested with the `default` example and then call `saul 0 read`.