### PR TITLE
gnrc_pkt: provide type search function

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -379,6 +379,7 @@ ifneq (,$(filter gnrc_pktbuf, $(USEMODULE)))
   ifeq (,$(filter gnrc_pktbuf_%, $(USEMODULE)))
     USEMODULE += gnrc_pktbuf_static
   endif
+  USEMODULE += gnrc_pkt
 endif
 
 ifneq (,$(filter gnrc_pktbuf_%, $(USEMODULE)))

--- a/sys/include/net/gnrc/pkt.h
+++ b/sys/include/net/gnrc/pkt.h
@@ -155,6 +155,18 @@ static inline size_t gnrc_pkt_count(const gnrc_pktsnip_t *pkt)
     return count;
 }
 
+/**
+ * @brief   Searches the packet for a packet snip of a specific type
+ *
+ * @param[in] pkt   list of packet snips
+ * @param[in] type  the type to search for
+ *
+ * @return  the packet snip in @p pkt with @ref gnrc_nettype_t @p type
+ * @return  NULL, if none of the snips in @p pkt is of @p type
+ */
+gnrc_pktsnip_t *gnrc_pktsnip_search_type(gnrc_pktsnip_t *pkt,
+                                         gnrc_nettype_t type);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -73,6 +73,9 @@ endif
 ifneq (,$(filter gnrc_nomac,$(USEMODULE)))
     DIRS += link_layer/nomac
 endif
+ifneq (,$(filter gnrc_pkt,$(USEMODULE)))
+    DIRS += pkt
+endif
 ifneq (,$(filter gnrc_pktbuf_static,$(USEMODULE)))
     DIRS += pktbuf_static
 endif

--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -598,10 +598,10 @@ tftp_state _tftp_state_processes(tftp_context_t *ctxt, msg_t *m)
     gnrc_pktsnip_t *pkt = (gnrc_pktsnip_t *)(m->content.ptr);
 
     gnrc_pktsnip_t *tmp;
-    LL_SEARCH_SCALAR(pkt, tmp, type, GNRC_NETTYPE_UDP);
+    tmp = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_UDP);
     udp_hdr_t *udp = (udp_hdr_t *)tmp->data;
 
-    LL_SEARCH_SCALAR(pkt, tmp, type, GNRC_NETTYPE_IPV6);
+    tmp = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_IPV6);
     ipv6_hdr_t *ip = (ipv6_hdr_t *)tmp->data;
     uint8_t *data = (uint8_t *)pkt->data;
 

--- a/sys/net/gnrc/conn/gnrc_conn.c
+++ b/sys/net/gnrc/conn/gnrc_conn.c
@@ -36,7 +36,7 @@ int gnrc_conn_recvfrom(conn_t *conn, void *data, size_t max_len, void *addr, siz
                 if (pkt->size > max_len) {
                     return -ENOMEM;
                 }
-                LL_SEARCH_SCALAR(pkt, l3hdr, type, conn->l3_type);
+                l3hdr = gnrc_pktsnip_search_type(pkt, conn->l3_type);
                 if (l3hdr == NULL) {
                     msg_send_to_self(&msg); /* requeue invalid messages */
                     continue;
@@ -44,7 +44,7 @@ int gnrc_conn_recvfrom(conn_t *conn, void *data, size_t max_len, void *addr, siz
 #if defined(MODULE_CONN_UDP) || defined(MODULE_CONN_TCP)
                 if ((conn->l4_type != GNRC_NETTYPE_UNDEF) && (port != NULL)) {
                     gnrc_pktsnip_t *l4hdr;
-                    LL_SEARCH_SCALAR(pkt, l4hdr, type, conn->l4_type);
+                    l4hdr = gnrc_pktsnip_search_type(pkt, conn->l4_type);
                     if (l4hdr == NULL) {
                         msg_send_to_self(&msg); /* requeue invalid messages */
                         continue;

--- a/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
+++ b/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
@@ -59,13 +59,13 @@ void gnrc_icmpv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *pkt)
     icmpv6_hdr_t *hdr;
     gnrc_netreg_entry_t *sendto;
 
-    LL_SEARCH_SCALAR(pkt, icmpv6, type, GNRC_NETTYPE_ICMPV6);
+    icmpv6 = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_ICMPV6);
 
     assert(icmpv6 != NULL);
 
     /* there can be extension headers between IPv6 and ICMPv6 header so we have
      * to search it */
-    LL_SEARCH_SCALAR(icmpv6, ipv6, type, GNRC_NETTYPE_IPV6);
+    ipv6 = gnrc_pktsnip_search_type(icmpv6, GNRC_NETTYPE_IPV6);
 
     assert(ipv6 != NULL);
 

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -710,7 +710,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
 
     assert(pkt != NULL);
 
-    LL_SEARCH_SCALAR(pkt, netif, type, GNRC_NETTYPE_NETIF);
+    netif = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
 
     if (netif != NULL) {
         iface = ((gnrc_netif_hdr_t *)netif->data)->if_pid;

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -275,7 +275,7 @@ void gnrc_ndp_nbr_adv_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
 #endif
     }
 
-    LL_SEARCH_SCALAR(pkt, netif, type, GNRC_NETTYPE_NETIF);
+    netif = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
 
     if (netif != NULL) {
         netif_hdr = netif->data;

--- a/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
+++ b/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
@@ -66,7 +66,7 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
 #ifdef MODULE_GNRC_IPV6_EXT_RH
     ipv6_hdr_t *hdr;
     gnrc_pktsnip_t *ipv6;
-    LL_SEARCH_SCALAR(pkt, ipv6, type, GNRC_NETTYPE_IPV6);
+    ipv6 = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_IPV6);
     assert(ipv6);
     hdr = ipv6->data;
     next_hop_ip = ipv6_ext_rh_next_hop(hdr);

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -84,7 +84,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
 
     pkt = payload;  /* reset pkt from temporary variable */
 
-    LL_SEARCH_SCALAR(pkt, payload, type, GNRC_NETTYPE_SIXLOWPAN);
+    payload = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_SIXLOWPAN);
 
     if ((payload == NULL) || (payload->size < 1)) {
         DEBUG("6lo: Received packet has no 6LoWPAN payload\n");

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -127,7 +127,7 @@ kernel_pid_t gnrc_sixlowpan_nd_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_
 #ifdef MODULE_GNRC_IPV6_EXT_RH
     ipv6_hdr_t *hdr;
     gnrc_pktsnip_t *ipv6;
-    LL_SEARCH_SCALAR(pkt, ipv6, type, GNRC_NETTYPE_IPV6);
+    ipv6 = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_IPV6);
     assert(ipv6);
     hdr = ipv6->data;
     next_hop = ipv6_ext_rh_next_hop(hdr);

--- a/sys/net/gnrc/pkt/Makefile
+++ b/sys/net/gnrc/pkt/Makefile
@@ -1,0 +1,3 @@
+MODULE := gnrc_pkt
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/pkt/gnrc_pkt.c
+++ b/sys/net/gnrc/pkt/gnrc_pkt.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include <assert.h>
+
+#include "net/gnrc/pkt.h"
+
+gnrc_pktsnip_t *gnrc_pktsnip_search_type(gnrc_pktsnip_t *ptr,
+                                         gnrc_nettype_t type)
+{
+    while (ptr != NULL) {
+        if (ptr->type == type) {
+            return ptr;
+        }
+        ptr = ptr->next;
+    }
+    return NULL;
+}
+
+/** @} */

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -119,7 +119,7 @@ static void _receive(gnrc_pktsnip_t *icmpv6)
     ipv6_hdr_t *ipv6_hdr = NULL;
     icmpv6_hdr_t *icmpv6_hdr = NULL;
 
-    LL_SEARCH_SCALAR(icmpv6, ipv6, type, GNRC_NETTYPE_IPV6);
+    ipv6 = gnrc_pktsnip_search_type(icmpv6, GNRC_NETTYPE_IPV6);
 
     assert(ipv6 != NULL);
 

--- a/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
+++ b/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
@@ -105,7 +105,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
     }
     pkt = udp;
 
-    LL_SEARCH_SCALAR(pkt, ipv6, type, GNRC_NETTYPE_IPV6);
+    ipv6 = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_IPV6);
 
     assert(ipv6 != NULL);
 

--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -86,8 +86,8 @@ int _handle_reply(gnrc_pktsnip_t *pkt, uint32_t time)
     icmpv6_echo_t *icmpv6_hdr;
     uint16_t seq;
 
-    LL_SEARCH_SCALAR(pkt, ipv6, type, GNRC_NETTYPE_IPV6);
-    LL_SEARCH_SCALAR(pkt, icmpv6, type, GNRC_NETTYPE_ICMPV6);
+    ipv6 = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_IPV6);
+    icmpv6 = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_ICMPV6);
 
     if ((ipv6 == NULL) || (icmpv6 == NULL)) {
         puts("error: IPv6 header or ICMPv6 header not found in reply");


### PR DESCRIPTION
Inspired by #4781, I thought about other inline functions (and macros) that are used quite frequently through-out GNRC and `LL_SEARCH_SCALAR()` came to mind. For `samr21-xpro` this saves a few bytes. More detailed size comparison will follow.