### PR TITLE
stm32: copy the value at cpuid_address

### DIFF
--- a/cpu/stm32_common/periph/cpuid.c
+++ b/cpu/stm32_common/periph/cpuid.c
@@ -26,9 +26,9 @@
 
 #include "periph/cpuid.h"
 
-extern uint32_t *_cpuid_address;
+extern uint32_t _cpuid_address;
 
 void cpuid_get(void *id)
 {
-    memcpy(id, _cpuid_address, CPUID_LEN);
+    memcpy(id, &_cpuid_address, CPUID_LEN);
 }


### PR DESCRIPTION
Fixes what ea8db10524c846a846c0750f9ba2b2e121baf6bb broke in #4769.

Please review and merge asap.