### PR TITLE
shell ping6: initialize netif header

### DIFF
--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -271,6 +271,7 @@ int _icmpv6_ping(int argc, char **argv)
                 continue;
             }
 
+            gnrc_netif_hdr_init(((gnrc_netif_hdr_t *)pkt->data), 0, 0);
             ((gnrc_netif_hdr_t *)pkt->data)->if_pid = src_iface;
         }
 


### PR DESCRIPTION
The netif header for ICMPv6 echo requests sent by the shell get never initialized, resulting in arbitrary results.