### PR TITLE
gnrc_netdev2: link-layer retransmissions outside the transceiver driver

### DIFF
--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -35,6 +35,7 @@ PSEUDOMODULES += lwip_tcp
 PSEUDOMODULES += lwip_udp
 PSEUDOMODULES += lwip_udplite
 PSEUDOMODULES += netdev_default
+PSEUDOMODULES += netdev_retrans
 PSEUDOMODULES += netif
 PSEUDOMODULES += netstats
 PSEUDOMODULES += netstats_l2

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -105,10 +105,12 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_CSMA, true);
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_RX_START, false);
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_RX_END, true);
-#ifdef MODULE_NETSTATS_L2
+#if defined(MODULE_NETSTATS) || defined(MODULE_NETDEV_RETRANS)
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_TX_END, true);
 #endif
+#ifdef MODULE_NETDEV_RETRANS
     at86rf2xx_set_max_retries(dev, 0);
+#endif
     /* set default protocol */
 #ifdef MODULE_GNRC_SIXLOWPAN
     dev->netdev.proto = GNRC_NETTYPE_SIXLOWPAN;

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -108,6 +108,7 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
 #ifdef MODULE_NETSTATS_L2
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_TX_END, true);
 #endif
+    at86rf2xx_set_max_retries(dev, 0);
     /* set default protocol */
 #ifdef MODULE_GNRC_SIXLOWPAN
     dev->netdev.proto = GNRC_NETTYPE_SIXLOWPAN;

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -105,7 +105,7 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_CSMA, true);
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_RX_START, false);
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_RX_END, true);
-#if defined(MODULE_NETSTATS) || defined(MODULE_NETDEV_RETRANS)
+#if defined(MODULE_NETSTATS_L2) || defined(MODULE_NETDEV_RETRANS)
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_TX_END, true);
 #endif
 #ifdef MODULE_NETDEV_RETRANS

--- a/sys/include/net/gnrc/netdev2.h
+++ b/sys/include/net/gnrc/netdev2.h
@@ -24,6 +24,7 @@
  * The purpose of gnrc_netdev is to bring these two interfaces together.
  *
  * @author    Kaspar Schleiser <kaspar@schleiser.de>
+ * @author    Oliver Hahm <oliver.hahm@inria.fr>
  */
 
 #ifndef GNRC_NETDEV2_H
@@ -41,6 +42,15 @@ extern "C" {
  * @brief   Type for @ref msg_t if device fired an event
  */
 #define NETDEV2_MSG_TYPE_EVENT 0x1234
+
+/**
+ * @brief   Queue of packets for link-layer retransmissions
+ */
+typedef struct {
+    struct gnrc_pktqueue *next; /**< next node in queue */
+    gnrc_pktsnip_t *pkt;        /**< pointer to the packet */
+    uint8_t cnt;                /**< remaining number of max. retransmissions */
+} netdev2_retrans_queue_t;
 
 /**
  * @brief Structure holding GNRC netdev2 adapter state
@@ -77,6 +87,8 @@ typedef struct gnrc_netdev2 {
      * @brief PID of this adapter for netapi messages
      */
     kernel_pid_t pid;
+
+    netdev2_retrans_queue_t *retrans_head;
 } gnrc_netdev2_t;
 
 /**

--- a/sys/include/net/gnrc/netdev2.h
+++ b/sys/include/net/gnrc/netdev2.h
@@ -116,7 +116,12 @@ typedef struct gnrc_netdev2 {
      */
     kernel_pid_t pid;
 
+#ifdef MODULE_NETDEV_RETRANS
+    /**
+     * @brief head of queue for link-layer retransmissions
+     */
     netdev2_retrans_queue_t *retrans_head;
+#endif
 } gnrc_netdev2_t;
 
 /**

--- a/sys/include/net/gnrc/netdev2.h
+++ b/sys/include/net/gnrc/netdev2.h
@@ -79,6 +79,34 @@ typedef struct gnrc_netdev2 {
     gnrc_pktsnip_t * (*recv)(struct gnrc_netdev2 *dev);
 
     /**
+     * @brief   Get an option value from a given network device
+     *
+     * @param[in]   dev     network device descriptor
+     * @param[in]   opt     option type
+     * @param[out]  value   pointer to store the option's value in
+     * @param[in]   max_len maximal amount of byte that fit into @p value
+     *
+     * @return              number of bytes written to @p value
+     * @return              <0 on error
+     */
+    int (*get)(struct gnrc_netdev2 *dev, netopt_t opt,
+               void *value, size_t max_len);
+
+    /**
+     * @brief   Set an option value for a given network device
+     *
+     * @param[in] dev       network device descriptor
+     * @param[in] opt       option type
+     * @param[in] value     value to set
+     * @param[in] value_len the length of @p value
+     *
+     * @return              number of bytes used from @p value
+     * @return              <0 on error
+     */
+    int (*set)(struct gnrc_netdev2 *dev, netopt_t opt,
+               void *value, size_t value_len);
+
+    /**
      * @brief netdev2 handle this adapter is working with
      */
     netdev2_t *dev;

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
@@ -87,7 +87,7 @@ static void _event_cb(netdev2_t *dev, netdev2_event_t event)
                     DEBUG("\n!!! gnrc_netdev2: queue is empty while retransmitting, this shouldn't happen!\n\n");
                 }
                 else if (gnrc_netdev2->retrans_head->cnt-- <= 0) {
-                    DEBUG("packet sent, removing from buffer and queue: %p\n", gnrc_netdev2->retrans_head->pkt);
+                    DEBUG("giving up sending, removing from buffer and queue: %p\n", gnrc_netdev2->retrans_head->pkt);
                     gnrc_pktbuf_release(gnrc_netdev2->retrans_head->pkt);
                     gnrc_netdev2->retrans_head->pkt = NULL;
                     gnrc_pktqueue_remove_head((gnrc_pktqueue_t**)&(gnrc_netdev2->retrans_head));

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
@@ -75,6 +75,7 @@ static void _event_cb(netdev2_t *dev, netdev2_event_t event)
 
                     break;
                 }
+#ifdef MODULE_NETDEV_RETRANS
             case NETDEV2_EVENT_TX_MEDIUM_BUSY:
 #ifdef MODULE_NETSTATS_L2
                 dev->stats.tx_failed++;
@@ -114,6 +115,7 @@ static void _event_cb(netdev2_t *dev, netdev2_event_t event)
                     gnrc_pktqueue_remove_head((gnrc_pktqueue_t**)&(gnrc_netdev2->retrans_head));
                 }
                 break;
+#endif
             default:
                 DEBUG("gnrc_netdev2: warning: unhandled event %u.\n", event);
         }

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
@@ -85,6 +85,7 @@ static void _event_cb(netdev2_t *dev, netdev2_event_t event)
                 DEBUG("gnrc_netdev2: no ACK received or medium busy: retrans count is = %u\n", (unsigned) gnrc_netdev2->retrans_head->cnt);
                 if (!gnrc_netdev2->retrans_head) {
                     DEBUG("\n!!! gnrc_netdev2: queue is empty while retransmitting, this shouldn't happen!\n\n");
+                    break;
                 }
                 else if (gnrc_netdev2->retrans_head->cnt-- <= 0) {
                     DEBUG("giving up sending, removing from buffer and queue: %p\n", gnrc_netdev2->retrans_head->pkt);
@@ -92,7 +93,8 @@ static void _event_cb(netdev2_t *dev, netdev2_event_t event)
                     gnrc_netdev2->retrans_head->pkt = NULL;
                     gnrc_pktqueue_remove_head((gnrc_pktqueue_t**)&(gnrc_netdev2->retrans_head));
                 }
-                else {
+                /* if there are still packets queued, send them now */
+                if (gnrc_netdev2->retrans_head) {
                     gnrc_netdev2->send(gnrc_netdev2, gnrc_netdev2->retrans_head->pkt);
                 }
             case NETDEV2_EVENT_TX_COMPLETE:
@@ -101,6 +103,7 @@ static void _event_cb(netdev2_t *dev, netdev2_event_t event)
 #endif
                 if (!gnrc_netdev2->retrans_head) {
                     DEBUG("\n!!! gnrc_netdev2: queue is empty while handling ACK, this shouldn't happen!\n\n");
+                    break;
                 }
                 else {
 #ifdef MODULE_NETSTATS
@@ -113,6 +116,10 @@ static void _event_cb(netdev2_t *dev, netdev2_event_t event)
                     gnrc_pktbuf_release(gnrc_netdev2->retrans_head->pkt);
                     gnrc_netdev2->retrans_head->pkt = NULL;
                     gnrc_pktqueue_remove_head((gnrc_pktqueue_t**)&(gnrc_netdev2->retrans_head));
+                }
+                /* if there are more packets queued, send them now */
+                if (gnrc_netdev2->retrans_head) {
+                    gnrc_netdev2->send(gnrc_netdev2, gnrc_netdev2->retrans_head->pkt);
                 }
                 break;
 #endif

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
@@ -88,7 +88,7 @@ static void _event_cb(netdev2_t *dev, netdev2_event_t event)
                     break;
                 }
                 else if (gnrc_netdev2->retrans_head->cnt-- <= 0) {
-                    DEBUG("giving up sending, removing from buffer and queue: %p\n", gnrc_netdev2->retrans_head->pkt);
+                    DEBUG("giving up sending, removing from buffer and queue: %p\n", (void*)gnrc_netdev2->retrans_head->pkt);
                     gnrc_pktbuf_release(gnrc_netdev2->retrans_head->pkt);
                     gnrc_netdev2->retrans_head->pkt = NULL;
                     gnrc_pktqueue_remove_head((gnrc_pktqueue_t**)&(gnrc_netdev2->retrans_head));
@@ -106,7 +106,7 @@ static void _event_cb(netdev2_t *dev, netdev2_event_t event)
                     break;
                 }
                 else {
-                    DEBUG("packet sent, removing from buffer and queue: %p\n", gnrc_netdev2->retrans_head->pkt);
+                    DEBUG("packet sent, removing from buffer and queue: %p\n", (void*) gnrc_netdev2->retrans_head->pkt);
                     gnrc_pktbuf_release(gnrc_netdev2->retrans_head->pkt);
                     gnrc_netdev2->retrans_head->pkt = NULL;
                     gnrc_pktqueue_remove_head((gnrc_pktqueue_t**)&(gnrc_netdev2->retrans_head));

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
@@ -184,7 +184,7 @@ static void *_gnrc_netdev2_thread(void *args)
                 DEBUG("gnrc_netdev2: GNRC_NETAPI_MSG_TYPE_SET received. opt=%s\n",
                         netopt2str(opt->opt));
                 /* set option for device driver */
-                res = dev->driver->set(dev, opt->opt, opt->data, opt->data_len);
+                res = gnrc_netdev2->set(gnrc_netdev2, opt->opt, opt->data, opt->data_len);
                 DEBUG("gnrc_netdev2: response of netdev->set: %i\n", res);
                 /* send reply to calling thread */
                 reply.type = GNRC_NETAPI_MSG_TYPE_ACK;
@@ -197,7 +197,7 @@ static void *_gnrc_netdev2_thread(void *args)
                 DEBUG("gnrc_netdev2: GNRC_NETAPI_MSG_TYPE_GET received. opt=%s\n",
                         netopt2str(opt->opt));
                 /* get option from device driver */
-                res = dev->driver->get(dev, opt->opt, opt->data, opt->data_len);
+                res = gnrc_netdev2->get(gnrc_netdev2, opt->opt, opt->data, opt->data_len);
                 DEBUG("gnrc_netdev2: response of netdev->get: %i\n", res);
                 /* send reply to calling thread */
                 reply.type = GNRC_NETAPI_MSG_TYPE_ACK;

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
@@ -106,12 +106,6 @@ static void _event_cb(netdev2_t *dev, netdev2_event_t event)
                     break;
                 }
                 else {
-#ifdef MODULE_NETSTATS
-                    if (!(((gnrc_netif_hdr_t*)gnrc_netdev2->retrans_head->pkt->data)->flags &
-                                (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST))) {
-                        dev->stats.acks_count++;
-                    }
-#endif
                     DEBUG("packet sent, removing from buffer and queue: %p\n", gnrc_netdev2->retrans_head->pkt);
                     gnrc_pktbuf_release(gnrc_netdev2->retrans_head->pkt);
                     gnrc_netdev2->retrans_head->pkt = NULL;

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
@@ -250,11 +250,6 @@ static int _send(gnrc_netdev2_t *gnrc_netdev2, gnrc_pktsnip_t *pkt)
         return -ENOBUFS;
     }
 #ifdef MODULE_NETDEV_RETRANS
-    if ((!gnrc_netdev2->retrans_head) || (gnrc_netdev2->retrans_head->pkt == pkt)) {
-#endif
-        dev->driver->send((netdev2_t *)dev, vector, n);
-#ifdef MODULE_NETDEV_RETRANS
-    }
     /* queue the packet for potential retransmissions */
     if (gnrc_netdev2->retrans_head->pkt != pkt) {
         netdev2_retrans_queue_t *pkt_node = _alloc_pkt_node(pkt);

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
@@ -255,7 +255,6 @@ static int _send(gnrc_netdev2_t *gnrc_netdev2, gnrc_pktsnip_t *pkt)
         netdev2_retrans_queue_t *pkt_node = _alloc_pkt_node(pkt);
         if (pkt_node == NULL) {
             DEBUG("_send_ieee802154: could not add packet to packet queue\n");
-            gnrc_pktbuf_release(pkt);
         }
         else {
             gnrc_pktqueue_add((gnrc_pktqueue_t**) &(gnrc_netdev2->retrans_head), (gnrc_pktqueue_t*) pkt_node);

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
@@ -250,6 +250,11 @@ static int _send(gnrc_netdev2_t *gnrc_netdev2, gnrc_pktsnip_t *pkt)
         return -ENOBUFS;
     }
 #ifdef MODULE_NETDEV_RETRANS
+    if ((!gnrc_netdev2->retrans_head) || (gnrc_netdev2->retrans_head->pkt == pkt)) {
+#endif
+        dev->driver->send((netdev2_t *)dev, vector, n);
+#ifdef MODULE_NETDEV_RETRANS
+    }
     /* queue the packet for potential retransmissions */
     if (gnrc_netdev2->retrans_head->pkt != pkt) {
         netdev2_retrans_queue_t *pkt_node = _alloc_pkt_node(pkt);

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
@@ -26,6 +26,7 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+#ifdef MODULE_NETDEV_RETRANS
 #define _RETRANS_QUEUE_LEN  (16)
 #define _RETRANS_COUNT      (3)
 
@@ -52,6 +53,7 @@ static netdev2_retrans_queue_t *_alloc_pkt_node(gnrc_pktsnip_t *pkt)
 
     return NULL;
 }
+#endif
 
 static gnrc_pktsnip_t *_recv(gnrc_netdev2_t *gnrc_netdev2);
 static int _send(gnrc_netdev2_t *gnrc_netdev2, gnrc_pktsnip_t *pkt);
@@ -66,7 +68,9 @@ int gnrc_netdev2_ieee802154_init(gnrc_netdev2_t *gnrc_netdev2,
     gnrc_netdev2->set = _set;
     gnrc_netdev2->get = _get;
     gnrc_netdev2->dev = (netdev2_t *)dev;
+#ifdef MODULE_NETDEV_RETRANS
     gnrc_netdev2->retrans_head = NULL;
+#endif
 
     return 0;
 }
@@ -245,6 +249,7 @@ static int _send(gnrc_netdev2_t *gnrc_netdev2, gnrc_pktsnip_t *pkt)
     else {
         return -ENOBUFS;
     }
+#ifdef MODULE_NETDEV_RETRANS
     /* queue the packet for potential retransmissions */
     if (gnrc_netdev2->retrans_head->pkt != pkt) {
         netdev2_retrans_queue_t *pkt_node = _alloc_pkt_node(pkt);
@@ -257,6 +262,7 @@ static int _send(gnrc_netdev2_t *gnrc_netdev2, gnrc_pktsnip_t *pkt)
         }
     }
     gnrc_pktbuf_hold(pkt, 1);
+#endif
     /* release old data */
     gnrc_pktbuf_release(pkt);
     return res;
@@ -271,6 +277,7 @@ static int _set(gnrc_netdev2_t *gnrc_netdev2, netopt_t opt, void *val, size_t le
         return -ENODEV;
     }
 
+#ifdef MODULE_NETDEV_RETRANS
     if (opt == NETOPT_RETRANS) {
         if (len > sizeof(uint8_t)) {
             res = -EOVERFLOW;
@@ -281,8 +288,11 @@ static int _set(gnrc_netdev2_t *gnrc_netdev2, netopt_t opt, void *val, size_t le
         }
     }
     else {
+#endif
         res = dev->driver->set((netdev2_t *)dev, opt, val, len);
+#ifdef MODULE_NETDEV_RETRANS
     }
+#endif
 
     return res;
 }
@@ -295,6 +305,7 @@ static int _get(gnrc_netdev2_t *gnrc_netdev2, netopt_t opt, void *val, size_t ma
     if (dev == NULL) {
         return -ENODEV;
     }
+#ifdef MODULE_NETDEV_RETRANS
     if (opt == NETOPT_RETRANS) {
         if (max_len < sizeof(uint8_t)) {
             res = -EOVERFLOW;
@@ -305,8 +316,11 @@ static int _get(gnrc_netdev2_t *gnrc_netdev2, netopt_t opt, void *val, size_t ma
         }
     }
     else {
+#endif
         res = dev->driver->get((netdev2_t *)dev, opt, val, max_len);
+#ifdef MODULE_NETDEV_RETRANS
     }
+#endif
 
     return res;
 }

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
@@ -289,7 +289,7 @@ static int _set(gnrc_netdev2_t *gnrc_netdev2, netopt_t opt, void *val, size_t le
     }
     else {
 #endif
-        res = dev->driver->set((netdev2_t *)dev, opt, val, len);
+        res = dev->netdev.driver->set((netdev2_t *)dev, opt, val, len);
 #ifdef MODULE_NETDEV_RETRANS
     }
 #endif
@@ -317,7 +317,7 @@ static int _get(gnrc_netdev2_t *gnrc_netdev2, netopt_t opt, void *val, size_t ma
     }
     else {
 #endif
-        res = dev->driver->get((netdev2_t *)dev, opt, val, max_len);
+        res = dev->netdev.driver->get((netdev2_t *)dev, opt, val, max_len);
 #ifdef MODULE_NETDEV_RETRANS
     }
 #endif


### PR DESCRIPTION
This PR introduces two features:
1.) Link layer retransmissions inside netdev2. Therefore, link layer retransmissions are disabled in the driver.
2.) netstats as a mostly generic module to collect statistics per layer. A first implementation for at86rf2xx's netdev2 driver is added.

Depends on https://github.com/RIOT-OS/RIOT/pull/4645
