### PR TITLE
make: Use unique module name for cpu_common periph

### DIFF
--- a/cpu/kinetis_common/Makefile.include
+++ b/cpu/kinetis_common/Makefile.include
@@ -7,6 +7,9 @@ export LINKFLAGS += -L$(RIOTCPU)/kinetis_common/ldscripts
 # add the CPU specific code for the linker
 export UNDEF += $(BINDIR)kinetis_common/fcfield.o
 
+# include kinetis common periph drivers
+export USEMODULE += kinetis_common_periph
+
 # Define a recipe to build the watchdog disable binary, used when flashing
 $(RIOTCPU)/kinetis_common/dist/wdog-disable.bin: $(RIOTCPU)/kinetis_common/dist/wdog-disable.s
 	$(AD)$(MAKE) -C $(RIOTCPU)/kinetis_common/dist/ $(notdir $@)

--- a/cpu/kinetis_common/periph/Makefile
+++ b/cpu/kinetis_common/periph/Makefile
@@ -1,3 +1,3 @@
-MODULE = periph
+MODULE = kinetis_common_periph
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/nrf5x_common/Makefile.include
+++ b/cpu/nrf5x_common/Makefile.include
@@ -2,5 +2,11 @@
 FAM = $(shell echo $(CPU_FAM) | tr 'a-z-' 'A-Z_')
 export CFLAGS += -DCPU_FAM_$(FAM)
 
+# use common periph functions
+USEMODULE += periph_common
+
+# include nrf5x common periph drivers
+USEMODULE += nrf5x_common_periph
+
 # export the common include directory
 export INCLUDES += -I$(RIOTCPU)/nrf5x_common/include

--- a/cpu/nrf5x_common/periph/Makefile
+++ b/cpu/nrf5x_common/periph/Makefile
@@ -1,3 +1,3 @@
-MODULE = periph
+MODULE = nrf5x_common_periph
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/sam21_common/Makefile.include
+++ b/cpu/sam21_common/Makefile.include
@@ -8,5 +8,8 @@ export CFLAGS += -DDONT_USE_CMSIS_INIT
 # use common periph functions
 USEMODULE += periph_common
 
+# include sam21 common periph drivers
+USEMODULE += sam21_common_periph
+
 # export the common include directory
 export INCLUDES += -I$(RIOTCPU)/sam21_common/include

--- a/cpu/sam21_common/periph/Makefile
+++ b/cpu/sam21_common/periph/Makefile
@@ -1,3 +1,3 @@
-MODULE = periph
+MODULE = sam21_common_periph
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/stm32_common/Makefile.include
+++ b/cpu/stm32_common/Makefile.include
@@ -2,8 +2,11 @@
 FAM = $(shell echo $(CPU_FAM) | tr 'a-z-' 'A-Z_')
 export CFLAGS += -DCPU_FAM_$(FAM)
 
-# includ common periph module
+# include common periph module
 USEMODULE += periph_common
+
+# include stm32 common periph drivers
+USEMODULE += stm32_common_periph
 
 # export the common include directory
 export INCLUDES += -I$(RIOTCPU)/stm32_common/include

--- a/cpu/stm32_common/periph/Makefile
+++ b/cpu/stm32_common/periph/Makefile
@@ -1,3 +1,3 @@
-MODULE = periph
+MODULE = stm32_common_periph
 
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
Hopefully fixes the random Travis failures we have seen since #4762 was merged.

For the nrf51, there are files in both nrf5x_common/periph and nrf51/periph which are both built and put in periph.a before linking. My theory is that the random Travis failures we have been experiencing have been caused by a race between builds of these two directories, possibly overwriting each others' output file (static library).