### PR TITLE
make: Add -pipe to CFLAGS

### DIFF
--- a/Makefile.cflags
+++ b/Makefile.cflags
@@ -55,6 +55,9 @@ CFLAGS += -fno-common
 # Enable all default warnings
 CFLAGS += -Wall
 
+# Use pipes between GCC stages
+CFLAGS += -pipe
+
 ifeq (,$(filter -DDEVELHELP,$(CFLAGS)))
   ifneq (1,$(FORCE_ASSERTS))
     CFLAGS += -DNDEBUG


### PR DESCRIPTION
This may or may not affect Travis speed. Most likely not, but it doesn't hurt to try it.

>`-pipe`
Use pipes rather than temporary files for communication between the various stages of compilation. This fails to work on some systems where the assembler is unable to read from a pipe; but the GNU assembler has no trouble.
