### PR TITLE
uncrustify: set sp_before_unnamed_ptr_star = remove

### DIFF
--- a/uncrustify-riot.cfg
+++ b/uncrustify-riot.cfg
@@ -53,6 +53,7 @@ sp_func_proto_paren = remove    # "int foo ();" vs "int foo();"
 sp_else_brace       = add       # ignore/add/remove/force
 sp_before_ptr_star  = add       # ignore/add/remove/force
 sp_after_ptr_star   = remove    # ignore/add/remove/force
+sp_before_unnamed_ptr_star = remove # "(foo_t*) foo" vs "(foo_t *) foo"
 sp_between_ptr_star = remove    # ignore/add/remove/force
 sp_inside_paren     = remove    # remove spaces inside parens
 sp_paren_paren      = remove    # remove spaces between nested parens


### PR DESCRIPTION
This makes uncrustify change pointer casts:

``` msg_t *msg = (msg_t *) msg;``` 
-> 

``` msg_t *msg = (msg_t*) msg;```