### PR TITLE
sc_gnrc_rpl: show state of PIO transmission

### DIFF
--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -202,10 +202,11 @@ int _gnrc_rpl_dodag_show(void)
 
         cleanup = dodag->instance->cleanup < 0 ? 0 : dodag->instance->cleanup;
 
-        printf("\tdodag [%s | R: %d | OP: %s | CL: %" PRIi8 "s | "
+        printf("\tdodag [%s | R: %d | OP: %s | PIO: %s | CL: %" PRIi8 "s | "
                "TR(I=[%d,%d], k=%d, c=%d, TC=%" PRIu32 "s, TI=%" PRIu32 "s)]\n",
                ipv6_addr_to_str(addr_str, &dodag->dodag_id, sizeof(addr_str)),
                dodag->my_rank, (dodag->node_status == GNRC_RPL_LEAF_NODE ? "Leaf" : "Router"),
+               ((dodag->req_opts & GNRC_RPL_REQ_OPT_PREFIX_INFO) ? "on" : "off"),
                cleanup, (1 << dodag->dio_min), dodag->dio_interval_doubl, dodag->trickle.k,
                dodag->trickle.c, (uint32_t) (tc & 0xFFFFFFFF), (uint32_t) (ti & 0xFFFFFFFF));
 


### PR DESCRIPTION
This PR adds info to the `rpl` shell command about the state of PIO transmissions.
(see https://github.com/RIOT-OS/RIOT/pull/4732#discussion_r52676243)