### PR TITLE
color: add hex2color, color2hex, rgb2str, str2rgb

### DIFF
--- a/sys/color/color.c
+++ b/sys/color/color.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014 - 2016 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -14,12 +14,15 @@
  * @brief       Implementation of color module
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Cenk Gündoğan <mail@cgundogan.de>
  *
  * @}
  */
 
 #include "color.h"
 
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
 
 void color_rgb2hsv(color_rgb_t *rgb, color_hsv_t *hsv)
 {
@@ -126,4 +129,49 @@ void color_hsv2rgb(color_hsv_t *hsv, color_rgb_t *rgb)
             rgb->b = (uint8_t)(bb * 255.0f);
             break;
     }
+}
+
+void color_hex2rgb(const uint32_t hex, color_rgb_t *rgb)
+{
+    rgb->r = ((hex >> 16UL) & 0xFF);
+    rgb->g = ((hex >> 8UL) & 0xFF);
+    rgb->b = (hex & 0xFF);
+}
+
+void color_rgb2hex(const color_rgb_t *rgb, uint32_t *hex)
+{
+    *hex = (((uint32_t) rgb->r) << 16UL) | (rgb->g << 8UL) | (rgb->b);
+}
+
+void color_str2rgb(const char* str, color_rgb_t *rgb)
+{
+    rgb->r = (((str[0] > '9') ? (str[0] &~ 0x20) - 'A' + 10 : (str[0] - '0')) << 4) | /* R */
+             (((str[1] > '9') ? (str[1] &~ 0x20) - 'A' + 10 : (str[1] - '0')) << 0) ; /* R */
+    rgb->g = (((str[2] > '9') ? (str[2] &~ 0x20) - 'A' + 10 : (str[2] - '0')) << 4) | /* G */
+             (((str[3] > '9') ? (str[3] &~ 0x20) - 'A' + 10 : (str[3] - '0')) << 0) ; /* G */
+    rgb->b = (((str[4] > '9') ? (str[4] &~ 0x20) - 'A' + 10 : (str[4] - '0')) << 4) | /* B */
+             (((str[5] > '9') ? (str[5] &~ 0x20) - 'A' + 10 : (str[5] - '0')) << 0) ; /* B */
+}
+
+void color_rgb2str(const color_rgb_t *rgb, char* str)
+{
+    uint8_t tmp;
+
+    /* RR */
+    tmp = rgb->r >> 4;
+    str[0] = (tmp > 9) ? ('A' - 10 + tmp) : ('0' + tmp);
+    tmp = rgb->r & 0x0F;
+    str[1] = (tmp > 9) ? ('A' - 10 + tmp) : ('0' + tmp);
+
+    /* GG */
+    tmp = rgb->g >> 4;
+    str[2] = (tmp > 9) ? ('A' - 10 + tmp) : ('0' + tmp);
+    tmp = rgb->g & 0x0F;
+    str[3] = (tmp > 9) ? ('A' - 10 + tmp) : ('0' + tmp);
+
+    /* BB */
+    tmp = rgb->b >> 4;
+    str[4] = (tmp > 9) ? ('A' - 10 + tmp) : ('0' + tmp);
+    tmp = rgb->b & 0x0F;
+    str[5] = (tmp > 9) ? ('A' - 10 + tmp) : ('0' + tmp);
 }

--- a/sys/include/color.h
+++ b/sys/include/color.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014 - 2016 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -16,6 +16,7 @@
  * @brief       Headers for the color handling module
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Cenk Gündoğan <mail@cgundogan.de>
  */
 
 #ifndef __COLOR_H
@@ -61,6 +62,47 @@ void color_rgb2hsv(color_rgb_t *rgb, color_hsv_t *hsv);
  * @param[out] rgb      Output color encoded in RGB space
  */
 void color_hsv2rgb(color_hsv_t *hsv, color_rgb_t *rgb);
+
+/**
+ * @brief Convert a @p hex value of the form 0x00RRGGBB to an RGB color struct
+ *
+ * @note                the two most significant bytes of @p hex will be ignored
+ *
+ * @param[in] hex       Input color encoded in hex
+ * @param[out] rgb      Output color encoded in RGB space
+ */
+void color_hex2rgb(const uint32_t hex, color_rgb_t *rgb);
+
+/**
+ * @brief Convert a @p rgb struct to a @p hex value of the form 0x00RRGGBB
+ *
+ * @note                the two most significant bytes of @p hex will be 0
+ *
+ * @param[in] rgb       Input color encoded in RGB space
+ * @param[out] hex      Output color encoded in hex
+ */
+void color_rgb2hex(const color_rgb_t *rgb, uint32_t *hex);
+
+/**
+ * @brief Convert a hex color string of the form 'RRGGBB' to a color_rgb_t struct
+ *
+ * @note                @p str MUST contain only hexadecimal digits.
+ *                      Expect unexpected behaviour, otherwise.
+ *
+ * @param[in] str       Input color encoded as string of the form 'RRGGBB'
+ * @param[out] rgb      Output color encoded in RGB space
+ */
+void color_str2rgb(const char *str, color_rgb_t *color);
+
+/**
+ * @brief Convert a color_rgb_t struct to a hex color string of the form 'RRGGBB'
+ *
+ * @note                @p str MUST be big enough to hold 6 characters
+ *
+ * @param[in] rgb       Input color encoded in RGB space
+ * @param[out] str      Output color encoded as string of the form 'RRGGBB'
+ */
+void color_rgb2str(const color_rgb_t *rgb, char *str);
 
 #ifdef __cplusplus
 }

--- a/tests/unittests/tests-color/Makefile
+++ b/tests/unittests/tests-color/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-color/Makefile.include
+++ b/tests/unittests/tests-color/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += color

--- a/tests/unittests/tests-color/tests-color.c
+++ b/tests/unittests/tests-color/tests-color.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2016 Cenk Gündoğan <mail@cgundogan.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+#include <errno.h>
+#include <stdint.h>
+
+#include "embUnit/embUnit.h"
+
+#include "color.h"
+
+#include "tests-color.h"
+
+static void test_str2rgb_upper_case__success(void)
+{
+    const char *color_str = "F09A1D";
+    color_rgb_t rgb;
+
+    color_str2rgb(color_str, &rgb);
+    TEST_ASSERT_EQUAL_INT(0xF0, rgb.r);
+    TEST_ASSERT_EQUAL_INT(0x9A, rgb.g);
+    TEST_ASSERT_EQUAL_INT(0x1D, rgb.b);
+}
+
+static void test_str2rgb_lower_case__success(void)
+{
+    const char *color_str = "f09a1d";
+    color_rgb_t rgb;
+
+    color_str2rgb(color_str, &rgb);
+    TEST_ASSERT_EQUAL_INT(0xF0, rgb.r);
+    TEST_ASSERT_EQUAL_INT(0x9A, rgb.g);
+    TEST_ASSERT_EQUAL_INT(0x1D, rgb.b);
+}
+
+static void test_rgb2str__success(void)
+{
+    char color_str[7] = { 0 };
+    const color_rgb_t rgb = { .r = 0x0A, .g = 0xB1, .b = 0x3C };
+
+    color_rgb2str(&rgb, color_str);
+
+    TEST_ASSERT_EQUAL_STRING("0AB13C", (char *) color_str);
+}
+
+static void test_hex2rgb__success(void)
+{
+    const uint32_t hex = 0x8Fa1b9;
+    color_rgb_t rgb;
+
+    color_hex2rgb(hex, &rgb);
+    TEST_ASSERT_EQUAL_INT(0x8F, rgb.r);
+    TEST_ASSERT_EQUAL_INT(0xA1, rgb.g);
+    TEST_ASSERT_EQUAL_INT(0xB9, rgb.b);
+}
+
+static void test_rgb2hex__success(void)
+{
+    uint32_t hex = 0x0;
+    const color_rgb_t rgb = { .r = 0x0A, .g = 0xB1, .b = 0x3C };
+
+    color_rgb2hex(&rgb, &hex);
+
+    TEST_ASSERT_EQUAL_INT(0x000AB13C, hex);
+}
+
+Test *tests_color_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_str2rgb_upper_case__success),
+        new_TestFixture(test_str2rgb_lower_case__success),
+        new_TestFixture(test_hex2rgb__success),
+        new_TestFixture(test_rgb2hex__success),
+        new_TestFixture(test_rgb2str__success),
+    };
+
+    EMB_UNIT_TESTCALLER(color_tests, NULL, NULL, fixtures);
+
+    return (Test *)&color_tests;
+}
+
+void tests_color(void)
+{
+    TESTS_RUN(tests_color_tests());
+}
+/** @} */

--- a/tests/unittests/tests-color/tests-color.h
+++ b/tests/unittests/tests-color/tests-color.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016 Cenk Gündoğan <mail@cgundogan.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the ``color`` module
+ *
+ * @author      Cenk Gündoğan <mail@cgundogan.de>
+ */
+#ifndef TESTS_COLOR_H
+#define TESTS_COLOR_H
+
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The entry point of this test suite.
+ */
+void tests_color(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_COLOR_H */
+/** @} */


### PR DESCRIPTION
I needed some conversions between colors given in hex code (string) and the `rgb_color_t` or `uint32_t` forms.
I thought sharing this might be a good idea.