### PR TITLE
core: Add compile time byte swapping

### DIFF
--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -303,36 +303,6 @@ static inline uint64_t NTOHLL(uint64_t v);
                              (((uint64_t)(x) << 40) & 0x00FF000000000000) | \
                              (((uint64_t)(x) << 56) & 0xFF00000000000000))
 
-/**
- * @brief          Constant from little endian to big endian, 16 bit.
- */
-#define CONST_LTOBS(x)       CONST_BSWAP16(x)
-
-/**
- * @brief          Constant from little endian to big endian, 32 bit.
- */
-#define CONST_LTOBL(x)       CONST_BSWAP32(x)
-
-/**
- * @brief          Constant from little endian to big endian, 64 bit.
- */
-#define CONST_LTOBLL(x)      CONST_BSWAP64(x)
-
-/**
- * @brief          Constant from bit endian to little endian, 16 bit.
- */
-#define CONST_BTOLS(x)       CONST_BSWAP16(x)
-
-/**
- * @brief          Constant from big endian to little endian, 32 bit.
- */
-#define CONST_BTOLL(x)       CONST_BSWAP32(x)
-
-/**
- * @brief          Constant from big endian to little endian, 64 bit.
- */
-#define CONST_BTOLLL(x)      CONST_BSWAP64(x)
-
 #ifndef __BYTE_ORDER__
 #error "__BYTE_ORDER__ macro not defined by the compiler"
 #endif
@@ -378,32 +348,32 @@ static inline uint64_t NTOHLL(uint64_t v);
 /**
  * @brief          Constant big endian, 16 bit.
  */
-#define CONST_TOBS(x)        CONST_BSWAP16(x)
+#define CONST_TOBES(x)       CONST_BSWAP16(x)
 
 /**
  * @brief          Constant to big endian, 32 bit.
  */
-#define CONST_TOBL(x)        CONST_BSWAP32(x)
+#define CONST_TOBEL(x)       CONST_BSWAP32(x)
 
 /**
  * @brief          Constant to big endian, 64 bit.
  */
-#define CONST_TOBLL(x)       CONST_BSWAP64(x)
+#define CONST_TOBELL(x)      CONST_BSWAP64(x)
 
 /**
  * @brief          Constant to little endian, 16 bit.
  */
-#define CONST_TOLS(x)        ((uint16_t)(x))
+#define CONST_TOLES(x)       ((uint16_t)(x))
 
 /**
  * @brief          Constant to little endian, 32 bit.
  */
-#define CONST_TOLL(x)        ((uint32_t)(x))
+#define CONST_TOLEL(x)       ((uint32_t)(x))
 
 /**
  * @brief          Constant to little endian, 64 bit.
  */
-#define CONST_TOLLL(x)       ((uint64_t)(x))
+#define CONST_TOLELL(x)      ((uint64_t)(x))
 
 #else
 
@@ -446,32 +416,32 @@ static inline uint64_t NTOHLL(uint64_t v);
 /**
  * @brief          Constant big endian, 16 bit.
  */
-#define CONST_TOBS(x)        ((uint16_t)(x))
+#define CONST_TOBES(x)       ((uint16_t)(x))
 
 /**
  * @brief          Constant to big endian, 32 bit.
  */
-#define CONST_TOBL(x)        ((uint32_t)(x))
+#define CONST_TOBEL(x)       ((uint32_t)(x))
 
 /**
  * @brief          Constant to big endian, 64 bit.
  */
-#define CONST_TOBLL(x)       ((uint64_t)(x))
+#define CONST_TOBELL(x)      ((uint64_t)(x))
 
 /**
  * @brief          Constant to little endian, 16 bit.
  */
-#define CONST_TOLS(x)        CONST_BSWAP16(x)
+#define CONST_TOLES(x)       CONST_BSWAP16(x)
 
 /**
  * @brief          Constant to little endian, 32 bit.
  */
-#define CONST_TOLL(x)        CONST_BSWAP32(x)
+#define CONST_TOLEL(x)       CONST_BSWAP32(x)
 
 /**
  * @brief          Constant to little endian, 64 bit.
  */
-#define CONST_TOLLL(x)       CONST_BSWAP64(x)
+#define CONST_TOLELL(x)      CONST_BSWAP64(x)
 
 #endif
 

--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -275,6 +275,56 @@ static inline uint64_t NTOHLL(uint64_t v);
 
 /* **************************** IMPLEMENTATION ***************************** */
 
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+
+/**
+ * @brief   Compile time byte-order swapping for short constants
+ */
+#define CONST_HTONS(x)       ((uint16_t)                         \
+                             (((uint16_t)x >> 8) & 0x00FF)     | \
+                             (((uint16_t)x << 8) & 0xFF00))
+
+/**
+ * @brief   Compile time byte-order swapping for integers constants
+ */
+#define CONST_HTONL(x)       ((uint32_t)                            \
+                             (((uint32_t)x >> 24) & 0x000000FF)   | \
+                             (((uint32_t)x >> 8)  & 0x0000FF00)   | \
+                             (((uint32_t)x << 8)  & 0x00FF0000)   | \
+                             (((uint32_t)x << 24) & 0xFF000000))
+
+/**
+ * @brief   Compile time byte-order swapping for long constants
+ */
+#define CONST_HTONLL(x)      ((uint64_t)                                  \
+                             (((uint64_t)x >> 56) & 0x00000000000000FF) | \
+                             (((uint64_t)x >> 40) & 0x000000000000FF00) | \
+                             (((uint64_t)x >> 24) & 0x0000000000FF0000) | \
+                             (((uint64_t)x >> 8)  & 0x00000000FF000000) | \
+                             (((uint64_t)x << 8)  & 0x000000FF00000000) | \
+                             (((uint64_t)x << 24) & 0x0000FF0000000000) | \
+                             (((uint64_t)x << 40) & 0x00FF000000000000) | \
+                             (((uint64_t)x << 56) & 0xFF00000000000000))
+
+#else
+
+/**
+ * @brief   Compile time byte-order swapping for short constants
+ */
+#define CONST_HTONS(x)       ((uint16_t)x)
+
+/**
+ * @brief   Compile time byte-order swapping for integers constants
+ */
+#define CONST_HTONL(x)       ((uint32_t)x)
+
+/**
+ * @brief   Compile time byte-order swapping for integers constants
+ */
+#define CONST_HTONLL(x)      ((uint64_t)x)
+
+#endif
+
 #ifdef HAVE_NO_BUILTIN_BSWAP16
 static inline unsigned short __builtin_bswap16(unsigned short a)
 {

--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -277,23 +277,23 @@ static inline uint64_t NTOHLL(uint64_t v);
 /**
  * @brief   Compile time byte-order swapping for 16 bit constants
  */
-#define CONST_BSWAP16(x)     ((uint16_t)                         \
+#define CONST_BSWAP16(x)     ((uint16_t)(                        \
                              (((uint16_t)(x) >> 8) & 0x00FF)   | \
-                             (((uint16_t)(x) << 8) & 0xFF00))
+                             (((uint16_t)(x) << 8) & 0xFF00)))
 
 /**
  * @brief   Compile time byte-order swapping for 32 bit constants
  */
-#define CONST_BSWAP32(x)     ((uint32_t)                              \
+#define CONST_BSWAP32(x)     ((uint32_t)(                             \
                              (((uint32_t)(x) >> 24) & 0x000000FF)   | \
                              (((uint32_t)(x) >> 8)  & 0x0000FF00)   | \
                              (((uint32_t)(x) << 8)  & 0x00FF0000)   | \
-                             (((uint32_t)(x) << 24) & 0xFF000000))
+                             (((uint32_t)(x) << 24) & 0xFF000000)))
 
 /**
  * @brief   Compile time byte-order swapping for 64 bit constants
  */
-#define CONST_BSWAP64(x)     ((uint64_t)                                    \
+#define CONST_BSWAP64(x)     ((uint64_t)(                                   \
                              (((uint64_t)(x) >> 56) & 0x00000000000000FF) | \
                              (((uint64_t)(x) >> 40) & 0x000000000000FF00) | \
                              (((uint64_t)(x) >> 24) & 0x0000000000FF0000) | \
@@ -301,7 +301,7 @@ static inline uint64_t NTOHLL(uint64_t v);
                              (((uint64_t)(x) << 8)  & 0x000000FF00000000) | \
                              (((uint64_t)(x) << 24) & 0x0000FF0000000000) | \
                              (((uint64_t)(x) << 40) & 0x00FF000000000000) | \
-                             (((uint64_t)(x) << 56) & 0xFF00000000000000))
+                             (((uint64_t)(x) << 56) & 0xFF00000000000000)))
 
 #ifndef __BYTE_ORDER__
 #error "__BYTE_ORDER__ macro not defined by the compiler"
@@ -313,67 +313,67 @@ static inline uint64_t NTOHLL(uint64_t v);
  * @brief   Convert a constant from host byte order to network byte
  *          order, 16 bit.
  */
-#define CONST_HTONS(x)       CONST_BSWAP16(x)
+#define CONST_HTONS(x)       ((network_uint16_t) CONST_BSWAP16(x))
 
 /**
  * @brief   Convert a constant from host byte order to network byte
  *          order, 32 bit.
  */
-#define CONST_HTONL(x)       CONST_BSWAP32(x)
+#define CONST_HTONL(x)       ((network_uint32_t) CONST_BSWAP32(x))
 
 /**
  * @brief   Convert a constant from host byte order to network byte
  *          order, 64 bit.
  */
-#define CONST_HTONLL(x)      CONST_BSWAP64(x)
+#define CONST_HTONLL(x)      ((network_uint64_t) CONST_BSWAP64(x))
 
 /**
  * @brief   Convert a constant from network byte order to host byte
  *          order, 16 bit.
  */
-#define CONST_NTOHS(x)       CONST_BSWAP16(x)
+#define CONST_NTOHS(x)       CONST_BSWAP16(((network_uint16_t) (x)).u16)
 
 /**
  * @brief   Convert a constant from network byte order to host byte
  *          order, 32 bit.
  */
-#define CONST_NTOHL(x)       CONST_BSWAP32(x)
+#define CONST_NTOHL(x)       CONST_BSWAP32(((network_uint32_t) (x)).u32)
 
 /**
  * @brief   Convert a constant from network byte order to host byte
  *          order, 64 bit.
  */
-#define CONST_NTOHLL(x)      CONST_BSWAP64(x)
+#define CONST_NTOHLL(x)      CONST_BSWAP64(((network_uint64_t) (x)).u64)
 
 /**
  * @brief          Constant big endian, 16 bit.
  */
-#define CONST_TOBES(x)       CONST_BSWAP16(x)
+#define CONST_TOBES(x)       ((be_uint16_t) CONST_BSWAP16(((le_uint16_t) (x)).u16))
 
 /**
  * @brief          Constant to big endian, 32 bit.
  */
-#define CONST_TOBEL(x)       CONST_BSWAP32(x)
+#define CONST_TOBEL(x)       ((be_uint32_t) CONST_BSWAP32(((le_uint32_t) (x)).u32))
 
 /**
  * @brief          Constant to big endian, 64 bit.
  */
-#define CONST_TOBELL(x)      CONST_BSWAP64(x)
+#define CONST_TOBELL(x)      ((be_uint64_t) CONST_BSWAP64(((le_uint64_t) (x)).u64))
 
 /**
  * @brief          Constant to little endian, 16 bit.
  */
-#define CONST_TOLES(x)       ((uint16_t)(x))
+#define CONST_TOLES(x)       ((le_uint16_t) (x))
 
 /**
  * @brief          Constant to little endian, 32 bit.
  */
-#define CONST_TOLEL(x)       ((uint32_t)(x))
+#define CONST_TOLEL(x)       ((le_uint32_t) (x))
 
 /**
  * @brief          Constant to little endian, 64 bit.
  */
-#define CONST_TOLELL(x)      ((uint64_t)(x))
+#define CONST_TOLELL(x)      ((le_uint64_t) (x))
 
 #else
 
@@ -381,67 +381,67 @@ static inline uint64_t NTOHLL(uint64_t v);
  * @brief   Convert a constant from host byte order to network byte
  *          order, 16 bit.
  */
-#define CONST_HTONS(x)       ((uint16_t)(x))
+#define CONST_HTONS(x)       ((network_uint16_t) (x))
 
 /**
  * @brief   Convert a constant from host byte order to network byte
  *          order, 32 bit.
  */
-#define CONST_HTONL(x)       ((uint32_t)(x))
+#define CONST_HTONL(x)       ((network_uint32_t) (x))
 
 /**
  * @brief   Convert a constant from host byte order to network byte
  *          order, 64 bit.
  */
-#define CONST_HTONLL(x)      ((uint64_t)(x))
+#define CONST_HTONLL(x)      ((network_uint64_t) (x))
 
 /**
  * @brief   Convert a constant from network byte order to host byte
  *          order, 16 bit.
  */
-#define CONST_NTOHS(x)       ((uint16_t)(x))
+#define CONST_NTOHS(x)       ((uint16_t) (network_uint16_t) (x))
 
 /**
  * @brief   Convert a constant from network byte order to host byte
  *          order, 32 bit.
  */
-#define CONST_NTOHL(x)       ((uint32_t)(x))
+#define CONST_NTOHL(x)       ((uint32_t) (network_uint32_t) (x))
 
 /**
  * @brief   Convert a constant from network byte order to host byte
  *          order, 64 bit.
  */
-#define CONST_NTOHLL(x)      ((uint64_t)(x))
+#define CONST_NTOHLL(x)      ((uint64_t) (network_uint64_t) (x))
 
 /**
  * @brief          Constant big endian, 16 bit.
  */
-#define CONST_TOBES(x)       ((uint16_t)(x))
+#define CONST_TOBES(x)       ((be_uint16_t) (x))
 
 /**
  * @brief          Constant to big endian, 32 bit.
  */
-#define CONST_TOBEL(x)       ((uint32_t)(x))
+#define CONST_TOBEL(x)       ((be_uint32_t) (x))
 
 /**
  * @brief          Constant to big endian, 64 bit.
  */
-#define CONST_TOBELL(x)      ((uint64_t)(x))
+#define CONST_TOBELL(x)      ((be_uint64_t) (x))
 
 /**
  * @brief          Constant to little endian, 16 bit.
  */
-#define CONST_TOLES(x)       CONST_BSWAP16(x)
+#define CONST_TOLES(x)       ((le_uint16_t) CONST_BSWAP16(((be_uint16_t) (x)).u16))
 
 /**
  * @brief          Constant to little endian, 32 bit.
  */
-#define CONST_TOLEL(x)       CONST_BSWAP32(x)
+#define CONST_TOLEL(x)       ((le_uint32_t) CONST_BSWAP32(((be_uint32_t) (x)).u32))
 
 /**
  * @brief          Constant to little endian, 64 bit.
  */
-#define CONST_TOLELL(x)      CONST_BSWAP64(x)
+#define CONST_TOLELL(x)      ((le_uint64_t) CONST_BSWAP64(((le_uint64_t) (x)).u64))
 
 #endif
 

--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -274,29 +274,26 @@ static inline uint64_t NTOHLL(uint64_t v);
 
 
 /* **************************** IMPLEMENTATION ***************************** */
-
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-
 /**
- * @brief   Compile time byte-order swapping for short constants
+ * @brief   Compile time byte-order swapping for 16 bit constants
  */
-#define CONST_HTONS(x)       ((uint16_t)                         \
+#define CONST_BSWAP16(x)     ((uint16_t)                         \
                              (((uint16_t)(x) >> 8) & 0x00FF)   | \
                              (((uint16_t)(x) << 8) & 0xFF00))
 
 /**
- * @brief   Compile time byte-order swapping for integers constants
+ * @brief   Compile time byte-order swapping for 32 bit constants
  */
-#define CONST_HTONL(x)       ((uint32_t)                              \
+#define CONST_BSWAP32(x)     ((uint32_t)                              \
                              (((uint32_t)(x) >> 24) & 0x000000FF)   | \
                              (((uint32_t)(x) >> 8)  & 0x0000FF00)   | \
                              (((uint32_t)(x) << 8)  & 0x00FF0000)   | \
                              (((uint32_t)(x) << 24) & 0xFF000000))
 
 /**
- * @brief   Compile time byte-order swapping for long constants
+ * @brief   Compile time byte-order swapping for 64 bit constants
  */
-#define CONST_HTONLL(x)      ((uint64_t)                                    \
+#define CONST_BSWAP64(x)     ((uint64_t)                                    \
                              (((uint64_t)(x) >> 56) & 0x00000000000000FF) | \
                              (((uint64_t)(x) >> 40) & 0x000000000000FF00) | \
                              (((uint64_t)(x) >> 24) & 0x0000000000FF0000) | \
@@ -306,22 +303,115 @@ static inline uint64_t NTOHLL(uint64_t v);
                              (((uint64_t)(x) << 40) & 0x00FF000000000000) | \
                              (((uint64_t)(x) << 56) & 0xFF00000000000000))
 
+/**
+ * @brief          Constant from little endian to big endian, 16 bit.
+ */
+#define CONST_LTOBS(x)       CONST_BSWAP16(x)
+
+/**
+ * @brief          Constant from little endian to big endian, 32 bit.
+ */
+#define CONST_LTOBL(x)       CONST_BSWAP32(x)
+
+/**
+ * @brief          Constant from little endian to big endian, 64 bit.
+ */
+#define CONST_LTOBLL(x)      CONST_BSWAP64(x)
+
+/**
+ * @brief          Constant from bit endian to little endian, 16 bit.
+ */
+#define CONST_BTOLS(x)       CONST_BSWAP16(x)
+
+/**
+ * @brief          Constant from big endian to little endian, 32 bit.
+ */
+#define CONST_BTOLL(x)       CONST_BSWAP32(x)
+
+/**
+ * @brief          Constant from big endian to little endian, 64 bit.
+ */
+#define CONST_BTOLLL(x)      CONST_BSWAP64(x)
+
+#ifndef __BYTE_ORDER__
+#error "__BYTE_ORDER__ macro not defined by the compiler"
+#endif
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+
+/**
+ * @brief   Convert a constant from host byte order to network byte
+ *          order, 16 bit.
+ */
+#define CONST_HTONS(x)       CONST_BSWAP16(x)
+
+/**
+ * @brief   Convert a constant from host byte order to network byte
+ *          order, 32 bit.
+ */
+#define CONST_HTONL(x)       CONST_BSWAP32(x)
+
+/**
+ * @brief   Convert a constant from host byte order to network byte
+ *          order, 64 bit.
+ */
+#define CONST_HTONLL(x)      CONST_BSWAP64(x)
+
+/**
+ * @brief   Convert a constant from network byte order to host byte
+ *          order, 16 bit.
+ */
+#define CONST_NTOHS(x)       CONST_BSWAP16(x)
+
+/**
+ * @brief   Convert a constant from network byte order to host byte
+ *          order, 32 bit.
+ */
+#define CONST_NTOHL(x)       CONST_BSWAP32(x)
+
+/**
+ * @brief   Convert a constant from network byte order to host byte
+ *          order, 64 bit.
+ */
+#define CONST_NTOHLL(x)      CONST_BSWAP64(x)
+
 #else
 
 /**
- * @brief   Compile time byte-order swapping for short constants
+ * @brief   Convert a constant from host byte order to network byte
+ *          order, 16 bit.
  */
 #define CONST_HTONS(x)       ((uint16_t)(x))
 
 /**
- * @brief   Compile time byte-order swapping for integers constants
+ * @brief   Convert a constant from host byte order to network byte
+ *          order, 32 bit.
  */
 #define CONST_HTONL(x)       ((uint32_t)(x))
 
 /**
- * @brief   Compile time byte-order swapping for integers constants
+ * @brief   Convert a constant from host byte order to network byte
+ *          order, 64 bit.
  */
 #define CONST_HTONLL(x)      ((uint64_t)(x))
+
+/**
+ * @brief   Convert a constant from network byte order to host byte
+ *          order, 16 bit.
+ */
+#define CONST_NTOHS(x)       ((uint16_t)(x))
+
+/**
+ * @brief   Convert a constant from network byte order to host byte
+ *          order, 32 bit.
+ */
+#define CONST_NTOHL(x)       ((uint32_t)(x))
+
+/**
+ * @brief   Convert a constant from network byte order to host byte
+ *          order, 64 bit.
+ */
+#define CONST_NTOHLL(x)      ((uint64_t)(x))
 
 #endif
 

--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -375,6 +375,36 @@ static inline uint64_t NTOHLL(uint64_t v);
  */
 #define CONST_NTOHLL(x)      CONST_BSWAP64(x)
 
+/**
+ * @brief          Constant big endian, 16 bit.
+ */
+#define CONST_TOBS(x)        CONST_BSWAP16(x)
+
+/**
+ * @brief          Constant to big endian, 32 bit.
+ */
+#define CONST_TOBL(x)        CONST_BSWAP32(x)
+
+/**
+ * @brief          Constant to big endian, 64 bit.
+ */
+#define CONST_TOBLL(x)       CONST_BSWAP64(x)
+
+/**
+ * @brief          Constant to little endian, 16 bit.
+ */
+#define CONST_TOLS(x)        ((uint16_t)(x))
+
+/**
+ * @brief          Constant to little endian, 32 bit.
+ */
+#define CONST_TOLL(x)        ((uint32_t)(x))
+
+/**
+ * @brief          Constant to little endian, 64 bit.
+ */
+#define CONST_TOLLL(x)       ((uint64_t)(x))
+
 #else
 
 /**
@@ -412,6 +442,36 @@ static inline uint64_t NTOHLL(uint64_t v);
  *          order, 64 bit.
  */
 #define CONST_NTOHLL(x)      ((uint64_t)(x))
+
+/**
+ * @brief          Constant big endian, 16 bit.
+ */
+#define CONST_TOBS(x)        ((uint16_t)(x))
+
+/**
+ * @brief          Constant to big endian, 32 bit.
+ */
+#define CONST_TOBL(x)        ((uint32_t)(x))
+
+/**
+ * @brief          Constant to big endian, 64 bit.
+ */
+#define CONST_TOBLL(x)       ((uint64_t)(x))
+
+/**
+ * @brief          Constant to little endian, 16 bit.
+ */
+#define CONST_TOLS(x)        CONST_BSWAP16(x)
+
+/**
+ * @brief          Constant to little endian, 32 bit.
+ */
+#define CONST_TOLL(x)        CONST_BSWAP32(x)
+
+/**
+ * @brief          Constant to little endian, 64 bit.
+ */
+#define CONST_TOLLL(x)       CONST_BSWAP64(x)
 
 #endif
 

--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -281,47 +281,47 @@ static inline uint64_t NTOHLL(uint64_t v);
  * @brief   Compile time byte-order swapping for short constants
  */
 #define CONST_HTONS(x)       ((uint16_t)                         \
-                             (((uint16_t)x >> 8) & 0x00FF)     | \
-                             (((uint16_t)x << 8) & 0xFF00))
+                             (((uint16_t)(x) >> 8) & 0x00FF)   | \
+                             (((uint16_t)(x) << 8) & 0xFF00))
 
 /**
  * @brief   Compile time byte-order swapping for integers constants
  */
-#define CONST_HTONL(x)       ((uint32_t)                            \
-                             (((uint32_t)x >> 24) & 0x000000FF)   | \
-                             (((uint32_t)x >> 8)  & 0x0000FF00)   | \
-                             (((uint32_t)x << 8)  & 0x00FF0000)   | \
-                             (((uint32_t)x << 24) & 0xFF000000))
+#define CONST_HTONL(x)       ((uint32_t)                              \
+                             (((uint32_t)(x) >> 24) & 0x000000FF)   | \
+                             (((uint32_t)(x) >> 8)  & 0x0000FF00)   | \
+                             (((uint32_t)(x) << 8)  & 0x00FF0000)   | \
+                             (((uint32_t)(x) << 24) & 0xFF000000))
 
 /**
  * @brief   Compile time byte-order swapping for long constants
  */
-#define CONST_HTONLL(x)      ((uint64_t)                                  \
-                             (((uint64_t)x >> 56) & 0x00000000000000FF) | \
-                             (((uint64_t)x >> 40) & 0x000000000000FF00) | \
-                             (((uint64_t)x >> 24) & 0x0000000000FF0000) | \
-                             (((uint64_t)x >> 8)  & 0x00000000FF000000) | \
-                             (((uint64_t)x << 8)  & 0x000000FF00000000) | \
-                             (((uint64_t)x << 24) & 0x0000FF0000000000) | \
-                             (((uint64_t)x << 40) & 0x00FF000000000000) | \
-                             (((uint64_t)x << 56) & 0xFF00000000000000))
+#define CONST_HTONLL(x)      ((uint64_t)                                    \
+                             (((uint64_t)(x) >> 56) & 0x00000000000000FF) | \
+                             (((uint64_t)(x) >> 40) & 0x000000000000FF00) | \
+                             (((uint64_t)(x) >> 24) & 0x0000000000FF0000) | \
+                             (((uint64_t)(x) >> 8)  & 0x00000000FF000000) | \
+                             (((uint64_t)(x) << 8)  & 0x000000FF00000000) | \
+                             (((uint64_t)(x) << 24) & 0x0000FF0000000000) | \
+                             (((uint64_t)(x) << 40) & 0x00FF000000000000) | \
+                             (((uint64_t)(x) << 56) & 0xFF00000000000000))
 
 #else
 
 /**
  * @brief   Compile time byte-order swapping for short constants
  */
-#define CONST_HTONS(x)       ((uint16_t)x)
+#define CONST_HTONS(x)       ((uint16_t)(x))
 
 /**
  * @brief   Compile time byte-order swapping for integers constants
  */
-#define CONST_HTONL(x)       ((uint32_t)x)
+#define CONST_HTONL(x)       ((uint32_t)(x))
 
 /**
  * @brief   Compile time byte-order swapping for integers constants
  */
-#define CONST_HTONLL(x)      ((uint64_t)x)
+#define CONST_HTONLL(x)      ((uint64_t)(x))
 
 #endif
 

--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -224,54 +224,6 @@ static inline uint32_t byteorder_swapl(uint32_t v);
  */
 static inline uint64_t byteorder_swapll(uint64_t v);
 
-/**
- * @brief          Convert from host byte order to network byte order, 16 bit.
- * @see            byteorder_htons()
- * @param[in]      v   The integer to convert.
- * @returns        Converted integer.
- */
-static inline uint16_t HTONS(uint16_t v);
-
-/**
- * @brief          Convert from host byte order to network byte order, 32 bit.
- * @see            byteorder_htonl()
- * @param[in]      v   The integer to convert.
- * @returns        Converted integer.
- */
-static inline uint32_t HTONL(uint32_t v);
-
-/**
- * @brief          Convert from host byte order to network byte order, 64 bit.
- * @see            byteorder_htonll()
- * @param[in]      v   The integer to convert.
- * @returns        Converted integer.
- */
-static inline uint64_t HTONLL(uint64_t v);
-
-/**
- * @brief          Convert from network byte order to host byte order, 16 bit.
- * @see            byteorder_ntohs()
- * @param[in]      v   The integer to convert.
- * @returns        Converted integer.
- */
-static inline uint16_t NTOHS(uint16_t v);
-
-/**
- * @brief          Convert from network byte order to host byte order, 32 bit.
- * @see            byteorder_ntohl()
- * @param[in]      v   The integer to convert.
- * @returns        Converted integer.
- */
-static inline uint32_t NTOHL(uint32_t v);
-
-/**
- * @brief          Convert from network byte order to host byte order, 64 bit.
- * @see            byteorder_ntohll()
- * @param[in]      v   The integer to convert.
- * @returns        Converted integer.
- */
-static inline uint64_t NTOHLL(uint64_t v);
-
 
 /* **************************** IMPLEMENTATION ***************************** */
 /**
@@ -555,38 +507,35 @@ static inline uint64_t byteorder_ntohll(network_uint64_t v)
     return _byteorder_swap(v.u64, ll);
 }
 
-static inline uint16_t HTONS(uint16_t v)
-{
-    return byteorder_htons(v).u16;
-}
+/**
+ * @brief          Convert from host byte order to network byte order, 16 bit.
+ */
+#define HTONS(x)             CONST_HTONS(x)
 
-static inline uint32_t HTONL(uint32_t v)
-{
-    return byteorder_htonl(v).u32;
-}
+/**
+ * @brief          Convert from host byte order to network byte order, 32 bit.
+ */
+#define HTONL(x)             CONST_HTONL(x)
 
-static inline uint64_t HTONLL(uint64_t v)
-{
-    return byteorder_htonll(v).u64;
-}
+/**
+ * @brief          Convert from host byte order to network byte order, 64 bit.
+ */
+#define HTONLL(x)            CONST_HTONLL(x)
 
-static inline uint16_t NTOHS(uint16_t v)
-{
-    network_uint16_t input = { v };
-    return byteorder_ntohs(input);
-}
+/**
+ * @brief          Convert from network byte order to host byte order, 16 bit.
+ */
+#define NTOHS(x)             CONST_NTOHS(x)
 
-static inline uint32_t NTOHL(uint32_t v)
-{
-    network_uint32_t input = { v };
-    return byteorder_ntohl(input);
-}
+/**
+ * @brief          Convert from network byte order to host byte order, 32 bit.
+ */
+#define NTOHL(x)             CONST_NTOHL(x)
 
-static inline uint64_t NTOHLL(uint64_t v)
-{
-    network_uint64_t input = { v };
-    return byteorder_ntohll(input);
-}
+/**
+ * @brief          Convert from network byte order to host byte order, 64 bit.
+ */
+#define NTOHLL(x)            CONST_NTOHLL(x)
 
 #ifdef __cplusplus
 }

--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -331,34 +331,34 @@ static inline uint64_t NTOHLL(uint64_t v);
  * @brief   Convert a constant from network byte order to host byte
  *          order, 16 bit.
  */
-#define CONST_NTOHS(x)       CONST_BSWAP16(((network_uint16_t) (x)).u16)
+#define CONST_NTOHS(x)       CONST_BSWAP16(x)
 
 /**
  * @brief   Convert a constant from network byte order to host byte
  *          order, 32 bit.
  */
-#define CONST_NTOHL(x)       CONST_BSWAP32(((network_uint32_t) (x)).u32)
+#define CONST_NTOHL(x)       CONST_BSWAP32(x)
 
 /**
  * @brief   Convert a constant from network byte order to host byte
  *          order, 64 bit.
  */
-#define CONST_NTOHLL(x)      CONST_BSWAP64(((network_uint64_t) (x)).u64)
+#define CONST_NTOHLL(x)      CONST_BSWAP64(x)
 
 /**
  * @brief          Constant big endian, 16 bit.
  */
-#define CONST_TOBES(x)       ((be_uint16_t) CONST_BSWAP16(((le_uint16_t) (x)).u16))
+#define CONST_TOBES(x)       ((be_uint16_t) CONST_BSWAP16(x))
 
 /**
  * @brief          Constant to big endian, 32 bit.
  */
-#define CONST_TOBEL(x)       ((be_uint32_t) CONST_BSWAP32(((le_uint32_t) (x)).u32))
+#define CONST_TOBEL(x)       ((be_uint32_t) CONST_BSWAP32(x))
 
 /**
  * @brief          Constant to big endian, 64 bit.
  */
-#define CONST_TOBELL(x)      ((be_uint64_t) CONST_BSWAP64(((le_uint64_t) (x)).u64))
+#define CONST_TOBELL(x)      ((be_uint64_t) CONST_BSWAP64(x))
 
 /**
  * @brief          Constant to little endian, 16 bit.
@@ -399,19 +399,19 @@ static inline uint64_t NTOHLL(uint64_t v);
  * @brief   Convert a constant from network byte order to host byte
  *          order, 16 bit.
  */
-#define CONST_NTOHS(x)       ((uint16_t) (network_uint16_t) (x))
+#define CONST_NTOHS(x)       (((network_uint16_t) (x)).u16)
 
 /**
  * @brief   Convert a constant from network byte order to host byte
  *          order, 32 bit.
  */
-#define CONST_NTOHL(x)       ((uint32_t) (network_uint32_t) (x))
+#define CONST_NTOHL(x)       (((network_uint32_t) (x)).u32)
 
 /**
  * @brief   Convert a constant from network byte order to host byte
  *          order, 64 bit.
  */
-#define CONST_NTOHLL(x)      ((uint64_t) (network_uint64_t) (x))
+#define CONST_NTOHLL(x)      (((network_uint64_t) (x)).u64)
 
 /**
  * @brief          Constant big endian, 16 bit.
@@ -431,17 +431,17 @@ static inline uint64_t NTOHLL(uint64_t v);
 /**
  * @brief          Constant to little endian, 16 bit.
  */
-#define CONST_TOLES(x)       ((le_uint16_t) CONST_BSWAP16(((be_uint16_t) (x)).u16))
+#define CONST_TOLES(x)       ((le_uint16_t) CONST_BSWAP16(x))
 
 /**
  * @brief          Constant to little endian, 32 bit.
  */
-#define CONST_TOLEL(x)       ((le_uint32_t) CONST_BSWAP32(((be_uint32_t) (x)).u32))
+#define CONST_TOLEL(x)       ((le_uint32_t) CONST_BSWAP32(x))
 
 /**
  * @brief          Constant to little endian, 64 bit.
  */
-#define CONST_TOLELL(x)      ((le_uint64_t) CONST_BSWAP64(((le_uint64_t) (x)).u64))
+#define CONST_TOLELL(x)      ((le_uint64_t) CONST_BSWAP64(x))
 
 #endif
 

--- a/tests/unittests/tests-core/tests-core-byteorder.c
+++ b/tests/unittests/tests-core/tests-core-byteorder.c
@@ -78,9 +78,76 @@ static void test_byteorder_host_to_network_64(void)
     TEST_ASSERT_EQUAL_INT(host, byteorder_ntohll(network));
 }
 
+static void test_const_byteorder_little_to_big_16(void)
+{
+	static const le_uint16_t little = CONST_TOLES(0x1234);
+    static const be_uint16_t big    = CONST_TOBES(0x1234);
+    TEST_ASSERT_EQUAL_INT(big.u16, byteorder_ltobs(little).u16);
+}
+
+static void test_const_byteorder_big_to_little_16(void)
+{
+	static const le_uint16_t little = CONST_TOLES(0x1234);
+    static const be_uint16_t big    = CONST_TOBES(0x1234);
+    TEST_ASSERT_EQUAL_INT(little.u16, byteorder_btols(big).u16);
+}
+
+static void test_const_byteorder_little_to_big_32(void)
+{
+	static const le_uint32_t little = CONST_TOLEL(0x12345678);
+    static const be_uint32_t big    = CONST_TOBEL(0x12345678);
+    TEST_ASSERT_EQUAL_INT(big.u32, byteorder_ltobl(little).u32);
+}
+
+static void test_const_byteorder_big_to_little_32(void)
+{
+	static const le_uint32_t little = CONST_TOLEL(0x12345678);
+    static const be_uint32_t big    = CONST_TOBEL(0x12345678);
+    TEST_ASSERT_EQUAL_INT(little.u32, byteorder_btoll(big).u32);
+}
+
+static void test_const_byteorder_little_to_big_64(void)
+{
+    static const le_uint64_t little = CONST_TOLELL(0x123456789abcdef0);
+    static const be_uint64_t big    = CONST_TOBELL(0x123456789abcdef0);
+    TEST_ASSERT_EQUAL_INT(big.u64, byteorder_ltobll(little).u64);
+}
+
+static void test_const_byteorder_big_to_little_64(void)
+{
+    static const le_uint64_t little = CONST_TOLELL(0x123456789abcdef0);
+    static const be_uint64_t big    = CONST_TOBELL(0x123456789abcdef0);
+    TEST_ASSERT_EQUAL_INT(little.u64, byteorder_btolll(big).u64);
+}
+
+static void test_const_byteorder_host_to_network_16(void)
+{
+    static const uint16_t host = 0x1234;
+    static const network_uint16_t network = CONST_HTONS(0x1234);
+    TEST_ASSERT_EQUAL_INT(network.u16, byteorder_htons(host).u16);
+    TEST_ASSERT_EQUAL_INT(host, byteorder_ntohs(network));
+}
+
+static void test_const_byteorder_host_to_network_32(void)
+{
+    static const uint32_t host = 0x12345678ul;
+    static const network_uint32_t network = CONST_HTONL(0x12345678);
+    TEST_ASSERT_EQUAL_INT(network.u32, byteorder_htonl(host).u32);
+    TEST_ASSERT_EQUAL_INT(host, byteorder_ntohl(network));
+}
+
+static void test_const_byteorder_host_to_network_64(void)
+{
+    static const uint64_t host = 0x123456789abcdef0ull;
+    static const network_uint64_t network = CONST_HTONLL(0x123456789abcdef0);
+    TEST_ASSERT_EQUAL_INT(network.u64, byteorder_htonll(host).u64);
+    TEST_ASSERT_EQUAL_INT(host, byteorder_ntohll(network));
+}
+
 Test *tests_core_byteorder_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
+        /* run time byte order functions */
         new_TestFixture(test_byteorder_little_to_big_16),
         new_TestFixture(test_byteorder_big_to_little_16),
         new_TestFixture(test_byteorder_little_to_big_32),
@@ -90,6 +157,17 @@ Test *tests_core_byteorder_tests(void)
         new_TestFixture(test_byteorder_host_to_network_16),
         new_TestFixture(test_byteorder_host_to_network_32),
         new_TestFixture(test_byteorder_host_to_network_64),
+
+        /* compile time byte order functions */
+        new_TestFixture(test_const_byteorder_little_to_big_16),
+        new_TestFixture(test_const_byteorder_big_to_little_16),
+        new_TestFixture(test_const_byteorder_little_to_big_32),
+        new_TestFixture(test_const_byteorder_big_to_little_32),
+        new_TestFixture(test_const_byteorder_little_to_big_64),
+        new_TestFixture(test_const_byteorder_big_to_little_64),
+        new_TestFixture(test_const_byteorder_host_to_network_16),
+        new_TestFixture(test_const_byteorder_host_to_network_32),
+        new_TestFixture(test_const_byteorder_host_to_network_64),
     };
 
     EMB_UNIT_TESTCALLER(core_byteorder_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
Since the compiler can't pre-compile the static inline functions `HTONS HTONL HTONLL` into constants I would propose this PR.
