### PR TITLE
kinetis: Abstraction for PORT module

### DIFF
--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -160,28 +160,22 @@ extern "C"
 #define PWM_0_CLK                    CLOCK_CORECLOCK
 #define PWM_0_CLKEN()                (SIM->SCGC6 |= (SIM_SCGC6_FTM0_MASK))
 #define PWM_0_CLKDIS()               (SIM->SCGC6 &= ~(SIM_SCGC6_FTM0_MASK))
-/* PWM 0 pin configuration */
-#define PWM_0_PORT_CLKEN()           (SIM->SCGC5 |= (SIM_SCGC5_PORTA_MASK | SIM_SCGC5_PORTC_MASK))
 /* Arduino Connector D3 */
-#define PWM_0_PORT_CH0               PORTA
-#define PWM_0_PIN_CH0                1
-#define PWM_0_FTMCHAN_CH0            6
-#define PWM_0_PIN_AF_CH0             3
+#define PWM_0_CH0_GPIO               GPIO_PIN(PORT_A, 1)
+#define PWM_0_CH0_FTMCHAN            6
+#define PWM_0_CH0_AF                 3
 /* Arduino Connector D5 */
-#define PWM_0_PORT_CH1               PORTA
-#define PWM_0_PIN_CH1                2
-#define PWM_0_FTMCHAN_CH1            7
-#define PWM_0_PIN_AF_CH1             3
+#define PWM_0_CH1_GPIO               GPIO_PIN(PORT_A, 2)
+#define PWM_0_CH1_FTMCHAN            7
+#define PWM_0_CH1_AF                 3
 /* Arduino Connector D6 */
-#define PWM_0_PORT_CH2               PORTC
-#define PWM_0_PIN_CH2                2
-#define PWM_0_FTMCHAN_CH2            1
-#define PWM_0_PIN_AF_CH2             4
+#define PWM_0_CH2_GPIO               GPIO_PIN(PORT_C, 2)
+#define PWM_0_CH2_FTMCHAN            1
+#define PWM_0_CH2_AF                 4
 /* Arduino Connector D7 */
-#define PWM_0_PORT_CH3               PORTC
-#define PWM_0_PIN_CH3                3
-#define PWM_0_FTMCHAN_CH3            2
-#define PWM_0_PIN_AF_CH3             4
+#define PWM_0_CH3_GPIO               GPIO_PIN(PORT_C, 3)
+#define PWM_0_CH3_FTMCHAN            2
+#define PWM_0_CH3_AF                 4
 /** @} */
 
 

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -236,17 +236,13 @@ extern "C"
 #define PWM_0_CLKDIS()      (BITBAND_REG32(SIM->SCGC6, SIM_SCGC6_FTM0_SHIFT) = 0)
 
 /* PWM 0 pin configuration */
-#define PWM_0_PORT_CLKEN()  (BITBAND_REG32(SIM->SCGC5, SIM_SCGC5_PORTC_SHIFT) = 1)
+#define PWM_0_CH0_GPIO      GPIO_PIN(PORT_C, 1)
+#define PWM_0_CH0_FTMCHAN   0
+#define PWM_0_CH0_AF        4
 
-#define PWM_0_PIN_CH0       1
-#define PWM_0_FTMCHAN_CH0   0
-#define PWM_0_PORT_CH0      PORTC
-#define PWM_0_PIN_AF_CH0    4
-
-#define PWM_0_PIN_CH1       2
-#define PWM_0_FTMCHAN_CH1   1
-#define PWM_0_PORT_CH1      PORTC
-#define PWM_0_PIN_AF_CH1    4
+#define PWM_0_CH1_GPIO      GPIO_PIN(PORT_C, 2)
+#define PWM_0_CH1_FTMCHAN   1
+#define PWM_0_CH1_AF        4
 
 /* PWM 1 device configuration */
 #define PWM_1_DEV           FTM1
@@ -256,20 +252,15 @@ extern "C"
 #define PWM_1_CLKDIS()      (BITBAND_REG32(SIM->SCGC6, SIM_SCGC6_FTM1_SHIFT) = 0)
 
 /* PWM 1 pin configuration */
-#define PWM_1_PORT_CLKEN()  (BITBAND_REG32(SIM->SCGC5, SIM_SCGC5_PORTA_SHIFT) = 1)
+#define PWM_1_CH0_GPIO      GPIO_PIN(PORT_A, 12)
+#define PWM_1_CH0_FTMCHAN   0
+#define PWM_1_CH0_AF        3
 
-#define PWM_1_PIN_CH0       12
-#define PWM_1_FTMCHAN_CH0   0
-#define PWM_1_PORT_CH0      PORTA
-#define PWM_1_PIN_AF_CH0    3
-
-#define PWM_1_PIN_CH1       13
-#define PWM_1_FTMCHAN_CH1   1
-#define PWM_1_PORT_CH1      PORTA
-#define PWM_1_PIN_AF_CH1    3
+#define PWM_1_CH1_GPIO      GPIO_PIN(PORT_A, 13)
+#define PWM_1_CH1_FTMCHAN   1
+#define PWM_1_CH1_AF        3
 
 /** @} */
-
 
 /**
  * @name SPI configuration

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -180,27 +180,22 @@ extern "C"
 #define PWM_0_CLKEN()       (SIM->SCGC6 |= (SIM_SCGC6_FTM0_MASK))
 #define PWM_0_CLKDIS()      (SIM->SCGC6 &= ~(SIM_SCGC6_FTM0_MASK))
 /* PWM 0 pin configuration */
-#define PWM_0_PORT_CLKEN()  (SIM->SCGC5 |= (SIM_SCGC5_PORTD_MASK | SIM_SCGC5_PORTA_MASK))
 
-#define PWM_0_PIN_CH0       4
-#define PWM_0_FTMCHAN_CH0   1
-#define PWM_0_PORT_CH0      PORTA
-#define PWM_0_PIN_AF_CH0    3
+#define PWM_0_CH0_GPIO      GPIO_PIN(PORT_A, 4)
+#define PWM_0_CH0_FTMCHAN   1
+#define PWM_0_CH0_AF        3
 
-#define PWM_0_PIN_CH1       4
-#define PWM_0_FTMCHAN_CH1   4
-#define PWM_0_PORT_CH1      PORTD
-#define PWM_0_PIN_AF_CH1    4
+#define PWM_0_CH1_GPIO      GPIO_PIN(PORT_D, 4)
+#define PWM_0_CH1_FTMCHAN   4
+#define PWM_0_CH1_AF        4
 
-#define PWM_0_PIN_CH2       6
-#define PWM_0_FTMCHAN_CH2   6
-#define PWM_0_PORT_CH2      PORTD
-#define PWM_0_PIN_AF_CH2    4
+#define PWM_0_CH2_GPIO      GPIO_PIN(PORT_D, 6)
+#define PWM_0_CH2_FTMCHAN   6
+#define PWM_0_CH2_AF        4
 
-#define PWM_0_PIN_CH3       1
-#define PWM_0_FTMCHAN_CH3   1
-#define PWM_0_PORT_CH3      PORTA
-#define PWM_0_PIN_AF_CH3    3
+#define PWM_0_CH3_GPIO      GPIO_PIN(PORT_A, 1)
+#define PWM_0_CH3_FTMCHAN   1
+#define PWM_0_CH3_AF        3
 /** @} */
 
 

--- a/cpu/kinetis_common/include/periph_cpu.h
+++ b/cpu/kinetis_common/include/periph_cpu.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 
 #include "periph/dev_enums.h"
+#include "cpu.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,7 +54,7 @@ typedef uint16_t gpio_t;
 /**
  * @brief   Define a CPU specific GPIO pin generator macro
  */
-#define GPIO_PIN(port, pin)          ((port << GPIO_PORT_SHIFT) | pin)
+#define GPIO_PIN(port, pin) ((port << GPIO_PORT_SHIFT) | (pin << GPIO_PIN_SHIFT))
 
 /**
  * @brief   Length of the CPU_ID in octets
@@ -66,9 +67,10 @@ typedef uint16_t gpio_t;
  */
 #define HAVE_GPIO_PP_T
 typedef enum {
-    GPIO_NOPULL = 4,        /**< do not use internal pull resistors */
-    GPIO_PULLUP = 9,        /**< enable internal pull-up resistor */
-    GPIO_PULLDOWN = 8       /**< enable internal pull-down resistor */
+    GPIO_NOPULL = 0,                    /**< Normal push-pull (actively driven in both directions) */
+    GPIO_OPEN_DRAIN = (PORT_PCR_ODE_MASK), /**< open drain without any pull resistors */
+    GPIO_PULLUP = (PORT_PCR_PE_MASK | PORT_PCR_PS_MASK), /**< enable internal pull-up resistor */
+    GPIO_PULLDOWN = (PORT_PCR_PE_MASK),  /**< enable internal pull-down resistor */
 } gpio_pp_t;
 /** @} */
 
@@ -89,7 +91,7 @@ typedef enum {
 /**
  * @brief   Available ports on the Kinetis family
  */
-enum {
+typedef enum {
     PORT_A = 0,             /**< port A */
     PORT_B = 1,             /**< port B */
     PORT_C = 2,             /**< port C */
@@ -98,7 +100,42 @@ enum {
     PORT_F = 5,             /**< port F */
     PORT_G = 6,             /**< port G */
     PORT_NUMOF
-};
+} port_t;
+
+/**
+ * @brief   Available MUX values for configuring a pin's alternate function
+ */
+typedef enum {
+    PORT_AF0 = 0, /**< use alternate function 0 */
+    PORT_AF1 = 1, /**< use alternate function 1 */
+    PORT_AF2 = 2, /**< use alternate function 2 */
+    PORT_AF3 = 3, /**< use alternate function 3 */
+    PORT_AF4 = 4, /**< use alternate function 4 */
+    PORT_AF5 = 5, /**< use alternate function 5 */
+    PORT_AF6 = 6, /**< use alternate function 6 */
+    PORT_AF7 = 7, /**< use alternate function 7 */
+} port_af_t;
+
+#ifndef PORT_AF_ANALOG
+#define PORT_AF_ANALOG     PORT_AF0
+#endif
+
+/**
+ * @brief Array of all PORT module base pointers
+ */
+extern PORT_Type * const kinetis_port_ptrs[];
+
+static inline uint32_t gpio_port_num(gpio_t dev) {
+    return (uint32_t)((dev & GPIO_PORT_MASK) >> GPIO_PORT_SHIFT);
+}
+
+static inline uint8_t gpio_pin_num(gpio_t dev) {
+    return (uint8_t)((dev & GPIO_PIN_MASK) >> GPIO_PIN_SHIFT);
+}
+
+static inline PORT_Type *gpio_port(gpio_t dev) {
+    return kinetis_port_ptrs[gpio_port_num(dev)];
+}
 
 #ifdef __cplusplus
 }

--- a/cpu/kinetis_common/include/port.h
+++ b/cpu/kinetis_common/include/port.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    cpu_kinetis_common_port Kinetis PORT
+ * @ingroup     cpu_kinetis_common
+ * @brief       Driver for Freescale Kinetis PORT module
+ *
+ * @{
+
+ * @file
+ * @brief       Interface definition for the Kinetis PORT driver.
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ */
+
+#ifndef KINETIS_COMMON_PORT_H
+#define KINETIS_COMMON_PORT_H
+
+#include "cpu.h"
+#include "periph_cpu.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @brief   Configure the alternate function for the given pin
+ *
+ * @note    This is meant for internal use in Kinetis peripheral drivers only
+ *
+ * @param[in] dev       pin to configure
+ * @param[in] pushpull  pull functionality configuration
+ * @param[in] af        alternate function to use
+ */
+int port_init(gpio_t dev, gpio_pp_t pushpull, port_af_t af);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* KINETIS_COMMON_PORT_H */
+/** @} */

--- a/cpu/kinetis_common/periph/gpio.c
+++ b/cpu/kinetis_common/periph/gpio.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin
  * Copyright (C) 2014 PHYTEC Messtechnik GmbH
- * Copyright (C) 2014 Eistec AB
+ * Copyright (C) 2014-2016 Eistec AB
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -24,6 +24,8 @@
  * @}
  */
 
+#include <stdint.h>
+#include <stddef.h>
 #include "cpu.h"
 #include "sched.h"
 #include "thread.h"

--- a/cpu/kinetis_common/periph/gpio.c
+++ b/cpu/kinetis_common/periph/gpio.c
@@ -33,16 +33,13 @@
 #include "mutex.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
+#include "port.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#ifndef PIN_MUX_FUNCTION_ANALOG
-#define PIN_MUX_FUNCTION_ANALOG     0
-#endif
-
-#ifndef PIN_MUX_FUNCTION_GPIO
-#define PIN_MUX_FUNCTION_GPIO       1
+#ifndef PORT_AF_GPIO
+#define PORT_AF_GPIO       PORT_AF1
 #endif
 
 /**
@@ -75,33 +72,23 @@ static mutex_t int_config_lock = MUTEX_INIT;
  * Rationale: Avoid dynamic memory inside low level periph drivers. */
 gpio_int_config_entry_t config_pool[GPIO_INT_POOL_SIZE];
 
-static PORT_Type * const _port_ptrs[] = PORT_BASE_PTRS;
+/**
+ * @brief Array of all GPIO module base pointers
+ */
 static GPIO_Type * const _gpio_ptrs[] = GPIO_BASE_PTRS;
 
-static inline uint32_t _port_num(gpio_t dev) {
-    return (uint32_t)((dev & GPIO_PORT_MASK) >> GPIO_PORT_SHIFT);
-}
-
-static inline uint8_t _pin_num(gpio_t dev) {
-    return (uint8_t)((dev & GPIO_PIN_MASK) >> GPIO_PIN_SHIFT);
-}
-
-static inline PORT_Type *_port(gpio_t dev) {
-    return _port_ptrs[_port_num(dev)];
-}
-
 static inline GPIO_Type *_gpio(gpio_t dev) {
-    return _gpio_ptrs[_port_num(dev)];
+    return _gpio_ptrs[gpio_port_num(dev)];
 }
 
 static void _clear_interrupt_config(gpio_t dev) {
     gpio_int_config_entry_t* entry = NULL;
-    uint8_t pin_number = _pin_num(dev);
+    uint8_t pin_number = gpio_pin_num(dev);
     mutex_lock(&int_config_lock);
     /* Search for the given pin in the port's interrupt configuration */
-    LL_SEARCH_SCALAR(gpio_interrupts[_port_num(dev)], entry, pin, pin_number);
+    LL_SEARCH_SCALAR(gpio_interrupts[gpio_port_num(dev)], entry, pin, pin_number);
     if (entry != NULL) {
-        LL_DELETE(gpio_interrupts[_port_num(dev)], entry);
+        LL_DELETE(gpio_interrupts[gpio_port_num(dev)], entry);
         /* pin == 0 means the entry is available */
         entry->pin = 0;
     }
@@ -129,76 +116,11 @@ static gpio_int_config_entry_t* _allocate_interrupt_config(uint8_t port) {
 
 int gpio_init(gpio_t dev, gpio_dir_t dir, gpio_pp_t pushpull)
 {
-    switch (_port_num(dev)) {
-#ifdef PORTA_BASE
-        case PORT_A:
-            PORTA_CLOCK_GATE = 1;
-            break;
-#endif
-
-#ifdef PORTB_BASE
-        case PORT_B:
-            PORTB_CLOCK_GATE = 1;
-            break;
-#endif
-
-#ifdef PORTC_BASE
-        case PORT_C:
-            PORTC_CLOCK_GATE = 1;
-            break;
-#endif
-
-#ifdef PORTD_BASE
-        case PORT_D:
-            PORTD_CLOCK_GATE = 1;
-            break;
-#endif
-
-#ifdef PORTE_BASE
-        case PORT_E:
-            PORTE_CLOCK_GATE = 1;
-            break;
-#endif
-
-#ifdef PORTF_BASE
-        case PORT_F:
-            PORTF_CLOCK_GATE = 1;
-            break;
-#endif
-
-#ifdef PORTG_BASE
-        case PORT_G:
-            PORTG_CLOCK_GATE = 1;
-            break;
-#endif
-
-        default:
-            return -1;
-    }
-
-    uint8_t pin = _pin_num(dev);
-    PORT_Type *port = _port(dev);
-    GPIO_Type *gpio = _gpio(dev);
-
     _clear_interrupt_config(dev);
 
-    /* Reset all pin control settings for the pin */
-    /* Switch to analog input function while fiddling with the settings, to be safe. */
-    port->PCR[pin] = PORT_PCR_MUX(PIN_MUX_FUNCTION_ANALOG);
-
-    /* set to push-pull configuration */
-    switch (pushpull) {
-        case GPIO_PULLUP:
-            port->PCR[pin] |= PORT_PCR_PE_MASK | PORT_PCR_PS_MASK; /* Pull enable, pull up */
-            break;
-
-        case GPIO_PULLDOWN:
-            port->PCR[pin] |= PORT_PCR_PE_MASK; /* Pull enable, !pull up */
-            break;
-
-        default:
-            break;
-    }
+    port_init(dev, pushpull, PORT_AF_GPIO);
+    uint8_t pin = gpio_pin_num(dev);
+    GPIO_Type *gpio = _gpio(dev);
 
     if (dir == GPIO_DIR_OUT) {
         BITBAND_REG32(gpio->PDDR, pin) = 1;    /* set pin to output mode */
@@ -207,9 +129,6 @@ int gpio_init(gpio_t dev, gpio_dir_t dir, gpio_pp_t pushpull)
     else {
         BITBAND_REG32(gpio->PDDR, pin) = 0;    /* set pin to input mode */
     }
-
-    /* Select GPIO function for the pin */
-    port->PCR[pin] |= PORT_PCR_MUX(PIN_MUX_FUNCTION_GPIO);
 
     return 0;
 }
@@ -225,7 +144,7 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
         return res;
     }
 
-    switch (_port_num(dev)) {
+    switch (gpio_port_num(dev)) {
 #ifdef PORTA_BASE
         case PORT_A:
             irqn = PORTA_IRQn;
@@ -275,16 +194,12 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
     uint32_t irqc;
     /* configure the active edges */
     switch (flank) {
+        case GPIO_LOGIC_ZERO:
         case GPIO_RISING:
-            irqc = PORT_PCR_IRQC(PIN_INTERRUPT_RISING);
-            break;
-
         case GPIO_FALLING:
-            irqc = PORT_PCR_IRQC(PIN_INTERRUPT_FALLING);
-            break;
-
         case GPIO_BOTH:
-            irqc = PORT_PCR_IRQC(PIN_INTERRUPT_EDGE);
+        case GPIO_LOGIC_ONE:
+            irqc = PORT_PCR_IRQC(flank);
             break;
 
         default:
@@ -292,7 +207,7 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
             return -1;
     }
 
-    gpio_int_config_entry_t* config = _allocate_interrupt_config(_port_num(dev));
+    gpio_int_config_entry_t* config = _allocate_interrupt_config(gpio_port_num(dev));
     if (config == NULL) {
         /* No free interrupt config entries */
         return -1;
@@ -302,8 +217,8 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
     NVIC_SetPriority(irqn, GPIO_IRQ_PRIO);
     NVIC_EnableIRQ(irqn);
 
-    uint8_t pin = _pin_num(dev);
-    PORT_Type *port = _port(dev);
+    uint8_t pin = gpio_pin_num(dev);
+    PORT_Type *port = gpio_port(dev);
 
     config->cb = cb;
     config->arg = arg;
@@ -322,12 +237,12 @@ int gpio_init_int(gpio_t dev, gpio_pp_t pushpull, gpio_flank_t flank, gpio_cb_t 
 void gpio_irq_enable(gpio_t dev)
 {
     /* Restore saved state */
-    PORT_Type *port = _port(dev);
+    PORT_Type *port = gpio_port(dev);
     gpio_int_config_entry_t* entry = NULL;
-    uint8_t pin_number = _pin_num(dev);
+    uint8_t pin_number = gpio_pin_num(dev);
     mutex_lock(&int_config_lock);
     /* Search for the given pin in the port's interrupt configuration */
-    LL_SEARCH_SCALAR(gpio_interrupts[_port_num(dev)], entry, pin, pin_number);
+    LL_SEARCH_SCALAR(gpio_interrupts[gpio_port_num(dev)], entry, pin, pin_number);
     mutex_unlock(&int_config_lock);
     if (entry == NULL) {
         /* Pin has not been configured for interrupts */
@@ -342,13 +257,13 @@ void gpio_irq_disable(gpio_t dev)
 {
     /* Save irqc state before disabling to allow enabling with the same trigger
      * settings later. */
-    PORT_Type *port = _port(dev);
-    uint8_t pin_number = _pin_num(dev);
+    PORT_Type *port = gpio_port(dev);
+    uint8_t pin_number = gpio_pin_num(dev);
     uint32_t irqc = PORT_PCR_IRQC_MASK & port->PCR[pin_number];
     gpio_int_config_entry_t* entry = NULL;
     mutex_lock(&int_config_lock);
     /* Search for the given pin in the port's interrupt configuration */
-    LL_SEARCH_SCALAR(gpio_interrupts[_port_num(dev)], entry, pin, pin_number);
+    LL_SEARCH_SCALAR(gpio_interrupts[gpio_port_num(dev)], entry, pin, pin_number);
     if (entry == NULL) {
         /* Pin has not been configured for interrupts */
         mutex_unlock(&int_config_lock);
@@ -361,38 +276,38 @@ void gpio_irq_disable(gpio_t dev)
 
 int gpio_read(gpio_t dev)
 {
-    return ((_gpio(dev)->PDIR & GPIO_PDIR_PDI(1 << _pin_num(dev))) ? 1 : 0);
+    return ((_gpio(dev)->PDIR & GPIO_PDIR_PDI(1 << gpio_pin_num(dev))) ? 1 : 0);
 }
 
 void gpio_set(gpio_t dev)
 {
-    _gpio(dev)->PSOR = (1 << _pin_num(dev));
+    _gpio(dev)->PSOR = (1 << gpio_pin_num(dev));
 }
 
 void gpio_clear(gpio_t dev)
 {
-    _gpio(dev)->PCOR = (1 << _pin_num(dev));
+    _gpio(dev)->PCOR = (1 << gpio_pin_num(dev));
 }
 
 void gpio_toggle(gpio_t dev)
 {
-    _gpio(dev)->PTOR = (1 << _pin_num(dev));
+    _gpio(dev)->PTOR = (1 << gpio_pin_num(dev));
 }
 
 void gpio_write(gpio_t dev, int value)
 {
     if (value) {
-        _gpio(dev)->PSOR = (1 << _pin_num(dev));
+        _gpio(dev)->PSOR = (1 << gpio_pin_num(dev));
     }
     else {
-        _gpio(dev)->PCOR = (1 << _pin_num(dev));
+        _gpio(dev)->PCOR = (1 << gpio_pin_num(dev));
     }
 }
 
 static inline void irq_handler(uint8_t port_num)
 {
     gpio_int_config_entry_t *entry;
-    PORT_Type *port = _port_ptrs[port_num];
+    PORT_Type *port = kinetis_port_ptrs[port_num];
     uint32_t isf = port->ISFR; /* Interrupt status flags */
     LL_FOREACH(gpio_interrupts[port_num], entry) {
         if (isf & (1 << entry->pin)) {

--- a/cpu/kinetis_common/periph/pwm.c
+++ b/cpu/kinetis_common/periph/pwm.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin
  * Copyright (C) 2014 PHYTEC Messtechnik GmbH
- * Copyright (C) 2015 Eistec AB
+ * Copyright (C) 2015-2016 Eistec AB
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -30,61 +30,62 @@
 #include "cpu.h"
 #include "periph/pwm.h"
 #include "periph_conf.h"
+#include "port.h"
 
 /* FTM channel look up tables */
 #if PWM_0_EN
 static const uint8_t ftm0chan[] = {
 #if PWM_0_CHANNELS > 0
-    PWM_0_FTMCHAN_CH0,
+    PWM_0_CH0_FTMCHAN,
 #endif
 #if PWM_0_CHANNELS > 1
-    PWM_0_FTMCHAN_CH1,
+    PWM_0_CH1_FTMCHAN,
 #endif
 #if PWM_0_CHANNELS > 2
-    PWM_0_FTMCHAN_CH2,
+    PWM_0_CH2_FTMCHAN,
 #endif
 #if PWM_0_CHANNELS > 3
-    PWM_0_FTMCHAN_CH3,
+    PWM_0_CH3_FTMCHAN,
 #endif
 #if PWM_0_CHANNELS > 4
-    PWM_0_FTMCHAN_CH4,
+    PWM_0_CH4_FTMCHAN,
 #endif
 #if PWM_0_CHANNELS > 5
-    PWM_0_FTMCHAN_CH5,
+    PWM_0_CH5_FTMCHAN,
 #endif
 #if PWM_0_CHANNELS > 6
-    PWM_0_FTMCHAN_CH6,
+    PWM_0_CH6_FTMCHAN,
 #endif
 #if PWM_0_CHANNELS > 7
-    PWM_0_FTMCHAN_CH7,
+    PWM_0_CH7_FTMCHAN,
 #endif
 };
 #endif
 #if PWM_1_EN
 static const uint8_t ftm1chan[] = {
 #if PWM_1_CHANNELS > 0
-    PWM_1_FTMCHAN_CH0,
+    PWM_1_CH0_FTMCHAN,
 #endif
 #if PWM_1_CHANNELS > 1
-    PWM_1_FTMCHAN_CH1,
+    PWM_1_CH1_FTMCHAN,
 #endif
 #if PWM_1_CHANNELS > 2
-    PWM_1_FTMCHAN_CH2,
+    PWM_1_CH2_FTMCHAN,
 #endif
 #if PWM_1_CHANNELS > 3
-    PWM_1_FTMCHAN_CH3,
+    PWM_1_CH3_FTMCHAN,
 #endif
 #if PWM_1_CHANNELS > 4
-    PWM_1_FTMCHAN_CH4,
+    PWM_1_CH4_FTMCHAN,
 #endif
 #if PWM_1_CHANNELS > 5
-    PWM_1_FTMCHAN_CH5,
+    PWM_1_CH5_FTMCHAN,
 #endif
 #if PWM_1_CHANNELS > 6
-    PWM_1_FTMCHAN_CH6,
+    PWM_1_CH6_FTMCHAN,
 #endif
 #if PWM_1_CHANNELS > 7
-    PWM_1_FTMCHAN_CH7,
+    PWM_1_CH7_FTMCHAN,
 #endif
 };
 #endif
@@ -158,60 +159,58 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
 #if PWM_0_EN
 
         case PWM_0:
-            PWM_0_PORT_CLKEN();
             #if PWM_0_CHANNELS > 0
-                PWM_0_PORT_CH0->PCR[PWM_0_PIN_CH0] = PORT_PCR_MUX(PWM_0_PIN_AF_CH0);
+                port_init(PWM_0_CH0_GPIO, GPIO_NOPULL, PWM_0_CH0_AF);
             #endif
             #if PWM_0_CHANNELS > 1
-                PWM_0_PORT_CH1->PCR[PWM_0_PIN_CH1] = PORT_PCR_MUX(PWM_0_PIN_AF_CH1);
+                port_init(PWM_0_CH1_GPIO, GPIO_NOPULL, PWM_0_CH1_AF);
             #endif
             #if PWM_0_CHANNELS > 2
-                PWM_0_PORT_CH2->PCR[PWM_0_PIN_CH2] = PORT_PCR_MUX(PWM_0_PIN_AF_CH2);
+                port_init(PWM_0_CH2_GPIO, GPIO_NOPULL, PWM_0_CH2_AF);
             #endif
             #if PWM_0_CHANNELS > 3
-                PWM_0_PORT_CH3->PCR[PWM_0_PIN_CH3] = PORT_PCR_MUX(PWM_0_PIN_AF_CH3);
+                port_init(PWM_0_CH3_GPIO, GPIO_NOPULL, PWM_0_CH3_AF);
             #endif
             #if PWM_0_CHANNELS > 4
-                PWM_0_PORT_CH4->PCR[PWM_0_PIN_CH4] = PORT_PCR_MUX(PWM_0_PIN_AF_CH4);
+                port_init(PWM_0_CH4_GPIO, GPIO_NOPULL, PWM_0_CH4_AF);
             #endif
             #if PWM_0_CHANNELS > 5
-                PWM_0_PORT_CH5->PCR[PWM_0_PIN_CH5] = PORT_PCR_MUX(PWM_0_PIN_AF_CH5);
+                port_init(PWM_0_CH5_GPIO, GPIO_NOPULL, PWM_0_CH5_AF);
             #endif
             #if PWM_0_CHANNELS > 6
-                PWM_0_PORT_CH6->PCR[PWM_0_PIN_CH6] = PORT_PCR_MUX(PWM_0_PIN_AF_CH6);
+                port_init(PWM_0_CH6_GPIO, GPIO_NOPULL, PWM_0_CH6_AF);
             #endif
             #if PWM_0_CHANNELS > 7
-                PWM_0_PORT_CH7->PCR[PWM_0_PIN_CH7] = PORT_PCR_MUX(PWM_0_PIN_AF_CH7);
+                port_init(PWM_0_CH7_GPIO, GPIO_NOPULL, PWM_0_CH7_AF);
             #endif
             break;
 #endif
 #if PWM_1_EN
 
         case PWM_1:
-            PWM_1_PORT_CLKEN();
             #if PWM_1_CHANNELS > 0
-                PWM_1_PORT_CH0->PCR[PWM_1_PIN_CH0] = PORT_PCR_MUX(PWM_1_PIN_AF_CH0);
+                port_init(PWM_1_CH0_GPIO, GPIO_NOPULL, PWM_1_CH0_AF);
             #endif
             #if PWM_1_CHANNELS > 1
-                PWM_1_PORT_CH1->PCR[PWM_1_PIN_CH1] = PORT_PCR_MUX(PWM_1_PIN_AF_CH1);
+                port_init(PWM_1_CH1_GPIO, GPIO_NOPULL, PWM_1_CH1_AF);
             #endif
             #if PWM_1_CHANNELS > 2
-                PWM_1_PORT_CH2->PCR[PWM_1_PIN_CH2] = PORT_PCR_MUX(PWM_1_PIN_AF_CH2);
+                port_init(PWM_1_CH2_GPIO, GPIO_NOPULL, PWM_1_CH2_AF);
             #endif
             #if PWM_1_CHANNELS > 3
-                PWM_1_PORT_CH3->PCR[PWM_1_PIN_CH3] = PORT_PCR_MUX(PWM_1_PIN_AF_CH3);
+                port_init(PWM_1_CH3_GPIO, GPIO_NOPULL, PWM_1_CH3_AF);
             #endif
             #if PWM_1_CHANNELS > 4
-                PWM_1_PORT_CH4->PCR[PWM_1_PIN_CH4] = PORT_PCR_MUX(PWM_1_PIN_AF_CH4);
+                port_init(PWM_1_CH4_GPIO, GPIO_NOPULL, PWM_1_CH4_AF);
             #endif
             #if PWM_1_CHANNELS > 5
-                PWM_1_PORT_CH5->PCR[PWM_1_PIN_CH5] = PORT_PCR_MUX(PWM_1_PIN_AF_CH5);
+                port_init(PWM_1_CH5_GPIO, GPIO_NOPULL, PWM_1_CH5_AF);
             #endif
             #if PWM_1_CHANNELS > 6
-                PWM_1_PORT_CH6->PCR[PWM_1_PIN_CH6] = PORT_PCR_MUX(PWM_1_PIN_AF_CH6);
+                port_init(PWM_1_CH6_GPIO, GPIO_NOPULL, PWM_1_CH6_AF);
             #endif
             #if PWM_1_CHANNELS > 7
-                PWM_1_PORT_CH7->PCR[PWM_1_PIN_CH7] = PORT_PCR_MUX(PWM_1_PIN_AF_CH7);
+                port_init(PWM_1_CH7_GPIO, GPIO_NOPULL, PWM_1_CH7_AF);
             #endif
             break;
 #endif

--- a/cpu/kinetis_common/port.c
+++ b/cpu/kinetis_common/port.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_kinetis_common_port
+ *
+ * @{
+ *
+ * @file
+ * @brief       Low-level PORT driver implementation
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include "cpu.h"
+#include "port.h"
+#include "periph/gpio.h"
+
+PORT_Type * const kinetis_port_ptrs[] = PORT_BASE_PTRS;
+
+int port_init(gpio_t dev, gpio_pp_t pushpull, port_af_t af)
+{
+    switch (gpio_port_num(dev)) {
+#ifdef PORTA_BASE
+        case PORT_A:
+            PORTA_CLOCK_GATE = 1;
+            break;
+#endif
+
+#ifdef PORTB_BASE
+        case PORT_B:
+            PORTB_CLOCK_GATE = 1;
+            break;
+#endif
+
+#ifdef PORTC_BASE
+        case PORT_C:
+            PORTC_CLOCK_GATE = 1;
+            break;
+#endif
+
+#ifdef PORTD_BASE
+        case PORT_D:
+            PORTD_CLOCK_GATE = 1;
+            break;
+#endif
+
+#ifdef PORTE_BASE
+        case PORT_E:
+            PORTE_CLOCK_GATE = 1;
+            break;
+#endif
+
+#ifdef PORTF_BASE
+        case PORT_F:
+            PORTF_CLOCK_GATE = 1;
+            break;
+#endif
+
+#ifdef PORTG_BASE
+        case PORT_G:
+            PORTG_CLOCK_GATE = 1;
+            break;
+#endif
+
+        default:
+            return -1;
+    }
+
+    uint8_t pin = gpio_pin_num(dev);
+    PORT_Type *port = gpio_port(dev);
+
+    /* Reset all pin control settings for the pin */
+    /* Switch to analog input function while fiddling with the settings, to be safe. */
+    port->PCR[pin] = PORT_PCR_MUX(PORT_AF_ANALOG);
+
+    /* set to push-pull configuration */
+    port->PCR[pin] |= pushpull;
+
+    /* Set alternate function */
+    port->PCR[pin] &= ~(PORT_PCR_MUX_MASK);
+    port->PCR[pin] |= PORT_PCR_MUX(af);
+
+    return 0;
+}


### PR DESCRIPTION
Pin configuration and alternate function handling driver for internal periph driver use, similar to stm32f0's gpio_init_af.

This PR only updates the GPIO component. I have prepared the other periph drivers as well, but need to rebase on top of the periph API changes.

@haukepetersen can we merge this first and rebase the periph changes in #4780, #4431, #4430 on top? It will save us work on the kinetis periph drivers in those PRs.