### PR TITLE
STM32 GPIO: Fix exti_isr handling to only call callbacks of lines with there IRQ enabled

### DIFF
--- a/cpu/stm32f0/periph/gpio.c
+++ b/cpu/stm32f0/periph/gpio.c
@@ -199,8 +199,10 @@ void gpio_write(gpio_t pin, int value)
 
 void isr_exti(void)
 {
+    /* only generate interrupts against lines which have their IMR set */
+    uint32_t pending_isr = (EXTI->PR & EXTI->IMR);
     for (size_t i = 0; i < EXTI_NUMOF; i++) {
-        if (EXTI->PR & (1 << i)) {
+        if (pending_isr & (1 << i)) {
             EXTI->PR = (1 << i);        /* clear by writing a 1 */
             isr_ctx[i].cb(isr_ctx[i].arg);
         }

--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -207,8 +207,10 @@ void gpio_write(gpio_t pin, int value)
 
 void isr_exti(void)
 {
+    /* only generate interrupts against lines which have their IMR set */
+    uint32_t pending_isr = (EXTI->PR & EXTI->IMR);
     for (unsigned i = 0; i < GPIO_ISR_CHAN_NUMOF; i++) {
-        if (EXTI->PR & (1 << i)) {
+        if (pending_isr & (1 << i)) {
             EXTI->PR = (1 << i);        /* clear by writing a 1 */
             exti_ctx[i].cb(exti_ctx[i].arg);
         }

--- a/cpu/stm32f3/periph/gpio.c
+++ b/cpu/stm32f3/periph/gpio.c
@@ -203,8 +203,10 @@ void gpio_write(gpio_t pin, int value)
 
 void isr_exti(void)
 {
+    /* only generate interrupts against lines which have their IMR set */
+    uint32_t pending_isr = (EXTI->PR & EXTI->IMR);
     for (int i = 0; i < EXTI_NUMOF; i++) {
-        if (EXTI->PR & (1 << i)) {
+        if (pending_isr & (1 << i)) {
             EXTI->PR |= (1 << i);               /* clear by writing a 1 */
             exti_chan[i].cb(exti_chan[i].arg);
         }

--- a/cpu/stm32f4/periph/gpio.c
+++ b/cpu/stm32f4/periph/gpio.c
@@ -200,8 +200,10 @@ void gpio_write(gpio_t pin, int value)
 
 void isr_exti(void)
 {
+    /* only generate interrupts against lines which have their IMR set */
+    uint32_t pending_isr = (EXTI->PR & EXTI->IMR);
     for (unsigned i = 0; i < GPIO_ISR_CHAN_NUMOF; i++) {
-        if (EXTI->PR & (1 << i)) {
+        if (pending_isr & (1 << i)) {
             EXTI->PR |= (1 << i);               /* clear by writing a 1 */
             exti_chan[i].cb(exti_chan[i].arg);
         }

--- a/cpu/stm32l1/periph/gpio.c
+++ b/cpu/stm32l1/periph/gpio.c
@@ -204,8 +204,10 @@ void gpio_write(gpio_t pin, int value)
 
 void isr_exti(void)
 {
+    /* only generate interrupts against lines which have their IMR set */
+    uint32_t pending_isr = (EXTI->PR & EXTI->IMR);
     for (int i = 0; i < GPIO_ISR_CHAN_NUMOF; i++) {
-        if (EXTI->PR & (1 << i)) {
+        if (pending_isr & (1 << i)) {
             EXTI->PR |= (1 << i);               /* clear by writing a 1 */
             exti_chan[i].cb(exti_chan[i].arg);
         }


### PR DESCRIPTION
The STM32 EXTI handlers called ISR handlers of all pending EXTI events instead of only the once with there IRQ enabled.