### PR TITLE
sys: random: rename genrand_* to random_*

### DIFF
--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -59,9 +59,9 @@ void ethos_setup(ethos_t *dev, uart_t uart, uint32_t baudrate, uint8_t *buf, siz
     tsrb_init(&dev->inbuf, (char*)buf, bufsize);
     mutex_init(&dev->out_mutex);
 
-    uint32_t a = genrand_uint32();
+    uint32_t a = random_uint32();
     memcpy(dev->mac_addr, (char*)&a, 4);
-    a = genrand_uint32();
+    a = random_uint32();
     memcpy(dev->mac_addr+4, (char*)&a, 2);
 
     dev->mac_addr[0] &= (0x2);      /* unset globally unique bit */

--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=ccn-lite
-PKG_URL=https://github.com/cn-uofbasel/ccn-lite/
-PKG_VERSION=57be9b1985dc501b26f861b24448b54db37f73f1
+PKG_URL=https://github.com/OlegHahm/ccn-lite/
+PKG_VERSION=39b1406c11de9de364220909488eebabe7e81613
 PKG_DIR=$(CURDIR)/$(PKG_NAME)
 
 ifneq ($(RIOTBOARD),)

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -95,7 +95,7 @@ void auto_init(void)
 #endif
 
 #ifdef MODULE_TINYMT32
-    genrand_init(0);
+    random_init(0);
 #endif
 #ifdef MODULE_XTIMER
     DEBUG("Auto init xtimer module.\n");

--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -35,7 +35,7 @@ extern "C" {
  *
  * @param s seed for the PRNG
  */
-void genrand_init(uint32_t s);
+void random_init(uint32_t s);
 
 /**
  * @brief initialize by an array with array-length
@@ -46,13 +46,13 @@ void genrand_init(uint32_t s);
  * @param init_key array of keys (seeds) to initialize the PRNG
  * @param key_length number of lements in init_key
  */
-void genrand_init_by_array(uint32_t init_key[], int key_length);
+void random_init_by_array(uint32_t init_key[], int key_length);
 
 /**
  * @brief generates a random number on [0,0xffffffff]-interval
  * @return a random number on [0,0xffffffff]-interval
  */
-uint32_t genrand_uint32(void);
+uint32_t random_uint32(void);
 
 /**
  * @brief   generates a random number r with a <= r < b.
@@ -64,9 +64,9 @@ uint32_t genrand_uint32(void);
  *
  * @return  a random number on [a,b)-interval
  */
-static inline uint32_t genrand_uint32_range(uint32_t a, uint32_t b)
+static inline uint32_t random_uint32_range(uint32_t a, uint32_t b)
 {
-    return (genrand_uint32() % (b - a)) + a;
+    return (random_uint32() % (b - a)) + a;
 }
 
 #if PRNG_FLOAT
@@ -76,25 +76,25 @@ static inline uint32_t genrand_uint32_range(uint32_t a, uint32_t b)
  * @brief generates a random number on [0,1)-real-interval
  * @return a random number on [0,1)-real-interval
  */
-double genrand_real(void);
+double random_real(void);
 
 /**
  * @brief generates a random number on [0,1]-real-interval
  * @return a random number on [0,1]-real-interval
  */
-double genrand_real_inclusive(void);
+double random_real_inclusive(void);
 
 /**
  * @brief generates a random number on (0,1)-real-interval
  * @return a random number on (0,1)-real-interval
  */
-double genrand_real_exclusive(void);
+double random_real_exclusive(void);
 
 /**
  * @brief generates a random number on [0,1) with 53-bit resolution
  * @return a random number on [0,1) with 53-bit resolution
  */
-double genrand_res53(void);
+double random_res53(void);
 
 #endif /* PRNG_FLOAT */
 

--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -364,7 +364,7 @@ int _tftp_init_ctxt(ipv6_addr_t *addr, const char *file_name,
 
     /* generate a random source UDP source port */
     do {
-        ctxt->src_port = (genrand_uint32() & 0xff) + GNRC_TFTP_DEFAULT_SRC_PORT;
+        ctxt->src_port = (random_uint32() & 0xff) + GNRC_TFTP_DEFAULT_SRC_PORT;
     } while (gnrc_netreg_num(GNRC_NETTYPE_UDP, ctxt->src_port));
 
     return TS_FINISHED;

--- a/sys/net/gnrc/application_layer/zep/gnrc_zep.c
+++ b/sys/net/gnrc/application_layer/zep/gnrc_zep.c
@@ -154,7 +154,7 @@ kernel_pid_t gnrc_zep_init(gnrc_zep_t *dev, uint16_t src_port, ipv6_addr_t *dst,
     dev->proto = GNRC_NETTYPE_UNDEF;
 #endif
 
-    dev->seq = genrand_uint32();
+    dev->seq = random_uint32();
     dev->src_port = src_port;
     dev->dst.u64[0] = dst->u64[0];
     dev->dst.u64[1] = dst->u64[1];

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -432,7 +432,7 @@ void gnrc_ndp_rtr_sol_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
                 ms = GNRC_SIXLOWPAN_ND_MAX_RTR_ADV_DELAY;
             }
 #endif
-            delay = genrand_uint32_range(0, ms);
+            delay = random_uint32_range(0, ms);
             xtimer_remove(&if_entry->rtr_adv_timer);
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
             /* in case of a 6LBR we have to check if the interface is actually
@@ -471,7 +471,7 @@ void gnrc_ndp_rtr_sol_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
 
 static inline void _set_reach_time(gnrc_ipv6_netif_t *if_entry, uint32_t mean)
 {
-    uint32_t reach_time = genrand_uint32_range(GNRC_NDP_MIN_RAND, GNRC_NDP_MAX_RAND);
+    uint32_t reach_time = random_uint32_range(GNRC_NDP_MIN_RAND, GNRC_NDP_MAX_RAND);
 
     if_entry->reach_time_base = mean;
     /* to avoid floating point number computation and have higher value entropy, the

--- a/sys/net/gnrc/network_layer/ndp/host/gnrc_ndp_host.c
+++ b/sys/net/gnrc/network_layer/ndp/host/gnrc_ndp_host.c
@@ -34,7 +34,7 @@ static inline void _reschedule_rtr_sol(gnrc_ipv6_netif_t *iface, uint32_t delay)
 
 void gnrc_ndp_host_init(gnrc_ipv6_netif_t *iface)
 {
-    uint32_t interval = genrand_uint32_range(0, GNRC_NDP_MAX_RTR_SOL_DELAY * SEC_IN_USEC);
+    uint32_t interval = random_uint32_range(0, GNRC_NDP_MAX_RTR_SOL_DELAY * SEC_IN_USEC);
     mutex_lock(&iface->mutex);
     iface->rtr_sol_count = GNRC_NDP_MAX_RTR_SOL_NUMOF;
     DEBUG("ndp host: delayed initial router solicitation by %" PRIu32 " usec.\n", interval);

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -209,7 +209,7 @@ void gnrc_ndp_internal_send_nbr_adv(kernel_pid_t iface, ipv6_addr_t *tgt, ipv6_a
     if (gnrc_ipv6_netif_addr_is_non_unicast(tgt)) {
         /* avoid collision for anycast addresses
          * (see https://tools.ietf.org/html/rfc4861#section-7.2.7) */
-        uint32_t delay = genrand_uint32_range(0, GNRC_NDP_MAX_AC_TGT_DELAY * SEC_IN_USEC);
+        uint32_t delay = random_uint32_range(0, GNRC_NDP_MAX_AC_TGT_DELAY * SEC_IN_USEC);
         gnrc_ipv6_nc_t *nc_entry = gnrc_ipv6_nc_get(iface, dst);
         DEBUG("ndp internal: delay neighbor advertisement for %" PRIu32 " sec.",
               (delay / SEC_IN_USEC));

--- a/sys/net/gnrc/network_layer/ndp/router/gnrc_ndp_router.c
+++ b/sys/net/gnrc/network_layer/ndp/router/gnrc_ndp_router.c
@@ -90,7 +90,7 @@ static void _send_rtr_adv(gnrc_ipv6_netif_t *iface, ipv6_addr_t *dst)
     mutex_lock(&iface->mutex);
     fin = (iface->adv_ltime == 0);
     assert((iface->min_adv_int != 0) && (iface->max_adv_int != 0));
-    interval = genrand_uint32_range(iface->min_adv_int, iface->max_adv_int);
+    interval = random_uint32_range(iface->min_adv_int, iface->max_adv_int);
     if (!fin && !((iface->flags | GNRC_IPV6_NETIF_FLAGS_ROUTER) &&
                   (iface->flags | GNRC_IPV6_NETIF_FLAGS_RTR_ADV))) {
         DEBUG("ndp rtr: interface %" PRIkernel_pid " is not an advertising interface\n",

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -37,7 +37,7 @@ static inline void _rtr_sol_reschedule(gnrc_ipv6_netif_t *iface, uint32_t sec_de
 
 static inline uint32_t _binary_exp_backoff(uint32_t base_sec, unsigned int exp)
 {
-    return genrand_uint32_range(0, (1 << exp)) * base_sec;
+    return random_uint32_range(0, (1 << exp)) * base_sec;
 }
 
 static inline void _revert_iid(uint8_t *iid)

--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -198,7 +198,7 @@ static int _implicit_bind(socket_t *s, void *addr)
     int res;
 
     /* TODO: ensure that this port hasn't been used yet */
-    s->src_port = (uint16_t)genrand_uint32_range(1LU << 10U, 1LU << 16U);
+    s->src_port = (uint16_t)random_uint32_range(1LU << 10U, 1LU << 16U);
 
     /* find the best matching source address */
     if ((best_match = conn_find_best_source(addr)) == NULL) {

--- a/sys/random/mersenne.c
+++ b/sys/random/mersenne.c
@@ -55,7 +55,7 @@
 static uint32_t mt[N]; /** the array for the state vector  */
 static uint16_t mti = MTI_UNINITIALIZED;
 
-void genrand_init(uint32_t s)
+void random_init(uint32_t s)
 {
     mt[0] = s;
     for (int i = 1; i < N; ++i) {
@@ -69,9 +69,9 @@ void genrand_init(uint32_t s)
     mti = N;
 }
 
-void genrand_init_by_array(uint32_t *init_key, int key_length)
+void random_init_by_array(uint32_t *init_key, int key_length)
 {
-    genrand_init(19650218UL);
+    random_init(19650218UL);
     int i = 1;
     int j = 0;
     for (int k = N > key_length ? N : key_length; k; --k) {
@@ -104,7 +104,7 @@ static void generate_numbers(void)
 {
     if (mti == MTI_UNINITIALIZED) {
         /* if init_genrand() has not been called, a default initial seed is used */
-        genrand_init(5489UL);
+        random_init(5489UL);
     }
 
     for (int k = 0; k < N; ++k) {
@@ -118,7 +118,7 @@ static void generate_numbers(void)
     mti = 0;
 }
 
-uint32_t genrand_uint32(void)
+uint32_t random_uint32(void)
 {
     if (mti >= N) {
         generate_numbers();
@@ -140,25 +140,25 @@ uint32_t genrand_uint32(void)
 #define TWO_POW_32 4294967296.0
 #define TWO_POW_53 9007199254740992.0
 
-double genrand_real(void)
+double random_real(void)
 {
-    return genrand_uint32() * (1.0 / TWO_POW_32);
+    return random_uint32() * (1.0 / TWO_POW_32);
 }
 
-double genrand_real_inclusive(void)
+double random_real_inclusive(void)
 {
-    return genrand_uint32() * (1.0 / TWO_POW_32_M1);
+    return random_uint32() * (1.0 / TWO_POW_32_M1);
 }
 
-double genrand_real_exclusive(void)
+double random_real_exclusive(void)
 {
-    return ((double) genrand_uint32() + 0.5) * (1.0 / TWO_POW_32);
+    return ((double) random_uint32() + 0.5) * (1.0 / TWO_POW_32);
 }
 
-double genrand_res53(void)
+double random_res53(void)
 {
-    double a = genrand_uint32() * TWO_POW_26;
-    double b = genrand_uint32() * (1.0 / TWO_POW_6);
+    double a = random_uint32() * TWO_POW_26;
+    double b = random_uint32() * (1.0 / TWO_POW_6);
     return (a + b) * (1.0 / TWO_POW_53);
 }
 

--- a/sys/random/minstd.c
+++ b/sys/random/minstd.c
@@ -55,7 +55,7 @@ int rand_minstd(void)
     return _seed;
 }
 
-uint32_t genrand_uint32(void)
+uint32_t random_uint32(void)
 {
     /* minstd as implemented returns only values from 1 to 2147483647,
      * so run it two times to get 32bits */
@@ -64,7 +64,7 @@ uint32_t genrand_uint32(void)
     return  (((uint32_t)A) << 16) | B;
 }
 
-void genrand_init(uint32_t val)
+void random_init(uint32_t val)
 {
     if (!val) {
         val = 1;

--- a/sys/random/musl_lcg.c
+++ b/sys/random/musl_lcg.c
@@ -33,12 +33,12 @@
 
 static uint64_t _seed;
 
-void genrand_init(uint32_t s)
+void random_init(uint32_t s)
 {
     _seed = s-1;
 }
 
-uint32_t genrand_uint32(void)
+uint32_t random_uint32(void)
 {
     _seed = 6364136223846793005ULL*_seed + 1;
     return _seed>>32;

--- a/sys/random/prng_tinymt32.c
+++ b/sys/random/prng_tinymt32.c
@@ -25,12 +25,12 @@
 
 static tinymt32_t _random;
 
-void genrand_init(uint32_t seed)
+void random_init(uint32_t seed)
 {
     tinymt32_init(&_random, seed);
 }
 
-uint32_t genrand_uint32(void)
+uint32_t random_uint32(void)
 {
     return tinymt32_generate_uint32(&_random);
 }

--- a/sys/shell/commands/sc_random.c
+++ b/sys/shell/commands/sc_random.c
@@ -50,7 +50,7 @@ int _random_init(int argc, char **argv)
         printf("PRNG initialized given value: %d\n", initval);
     }
 
-    genrand_init(initval);
+    random_init(initval);
 
     return 0;
 }
@@ -60,7 +60,7 @@ int _random_get(int argc, char **argv)
     (void) argc;
     (void) argv;
 
-    printf("%" PRIu32 "\n", genrand_uint32());
+    printf("%" PRIu32 "\n", random_uint32());
 
     return 0;
 }

--- a/tests/bloom_bytes/main.c
+++ b/tests/bloom_bytes/main.c
@@ -52,7 +52,7 @@ hashfp_t hashes[BLOOM_HASHF] = {
 static void buf_fill(uint32_t *buf, int len)
 {
     for (int k = 0; k < len; k++) {
-        buf[k] = genrand_uint32();
+        buf[k] = random_uint32();
     }
 }
 
@@ -66,7 +66,7 @@ int main(void)
     printf("m: %" PRIu32 " k: %" PRIu32 "\n\n", (uint32_t) bloom.m,
            (uint32_t) bloom.k);
 
-    genrand_init(myseed);
+    random_init(myseed);
 
     unsigned long t1 = xtimer_now();
 

--- a/tests/pthread_barrier/main.c
+++ b/tests/pthread_barrier/main.c
@@ -43,7 +43,7 @@ static void *run(void *id_)
         }
         pthread_barrier_wait(&barrier);
 
-        uint32_t timeout_us = genrand_uint32() % 2500000;
+        uint32_t timeout_us = random_uint32() % 2500000;
         printf("Child %i sleeps for %8" PRIu32 " µs.\n", id, timeout_us);
         xtimer_usleep(timeout_us);
     }
@@ -54,7 +54,7 @@ static void *run(void *id_)
 
 int main(void)
 {
-    genrand_init(RAND_SEED);
+    random_init(RAND_SEED);
 
     puts("Start.\n");
     pthread_barrier_init(&barrier, NULL, NUM_CHILDREN);

--- a/tests/pthread_rwlock/main.c
+++ b/tests/pthread_rwlock/main.c
@@ -58,7 +58,7 @@ static volatile unsigned counter;
 
 static void do_sleep(int factor)
 {
-    uint32_t timeout_us = (genrand_uint32() % 100000) * factor;
+    uint32_t timeout_us = (random_uint32() % 100000) * factor;
     /* PRINTF("sleep for % 8i µs.", timeout_us); */
     xtimer_usleep(timeout_us);
 }


### PR DESCRIPTION
Now that the periph driver has a different name...

Files modified by ```find . -name '*.[hc]' -exec grep -l 'genrand_' \{\} \; | xargs -n 1 sed -i 's/genrand_/random_/g'```

