### PR TITLE
pba-01-d-kw2x: add sensors to board.h

### DIFF
--- a/boards/pba-d-01-kw2x/include/board.h
+++ b/boards/pba-d-01-kw2x/include/board.h
@@ -83,6 +83,54 @@ extern "C"
 /** @}*/
 
 /**
+ * @name Define the interface for the HDC1000 humidity sensor
+ * @{
+ */
+#define HDC1000_I2C         (I2C_0)
+#define HDC1000_ADDR        (0x43)
+/** @} */
+
+/**
+ * @name Define the interface for the MAG3110 magnetometer sensor
+ * @{
+ */
+#define MAG3110_I2C         (I2C_0)
+#define MAG3110_ADDR        (0x0E)
+/** @} */
+
+/**
+ * @name Define the interface for the MMA8652 tri-axis accelerometer sensor
+ * @{
+ */
+#define MMA8652_I2C         (I2C_0)
+#define MMA8652_ADDR        (0x1D)
+/** @} */
+
+/**
+ * @name Define the interface for the MPL3115A2 pressure sensor
+ * @{
+ */
+#define MPL3115A2_I2C       (I2C_0)
+#define MPL3115A2_ADDR      (0x60)
+/** @} */
+
+/**
+ * @name Define the interface for the TCS3772 light sensor
+ * @{
+ */
+#define TCS37727_I2C        (I2C_0)
+#define TCS37727_ADDR       (0x29)
+/** @} */
+
+/**
+ * @name Define the interface for the TMP006 IR-Termopile sensor
+ * @{
+ */
+#define TMP006_I2C          (I2C_0)
+#define TMP006_ADDR         (0x41)
+/** @} */
+
+/**
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);


### PR DESCRIPTION
`board.h` of the phyNode was missing the information about the sensors (I2C address, etc)