### PR TITLE
buildtest: Pass TOOLCHAIN variable to build workers

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -60,6 +60,7 @@ buildtest:
 					RIOT_VERSION=$${RIOT_VERSION} \
 					WERROR=$${WERROR} \
 					LTO=$${LTO} \
+					TOOLCHAIN=$${TOOLCHAIN} \
 					$(MAKE) -j$(NPROC) 2>&1) ; \
 			if [ "$${?}" = "0" ]; then \
 				${COLOR_ECHO} "${COLOR_GREEN}success${COLOR_RESET}"; \

--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -40,60 +40,60 @@ buildtest:
 	APP_RETRY=0; \
 	rm -rf "$$BINDIRBASE"; \
 	for BOARD in $$($(MAKE) -s info-boards-supported); do \
-		RIOTNOLINK=$$(echo $(BOARD_INSUFFICIENT_MEMORY) | grep $${BOARD} 2>&1 >/dev/null && echo 1); \
-		${COLOR_ECHO} -n "Building for $${BOARD} "; \
-		[ -n "$${RIOTNOLINK}" ] && ${COLOR_ECHO} -n "(no linking) "; \
-		for NTH_TRY in 1 2 3; do \
-			${COLOR_ECHO} -n ".. "; \
-			LOG=$$(env -i \
-					HOME=$${HOME} \
-					PATH=$${PATH} \
-					BOARD=$${BOARD} \
-					CCACHE=$${CCACHE} \
-					CCACHE_DIR=$${CCACHE_DIR} \
-					CCACHE_BASEDIR=$${CCACHE_BASEDIR} \
-					RIOTBASE=$${RIOTBASE} \
-					RIOTBOARD=$${RIOTBOARD} \
-					RIOTCPU=$${RIOTCPU} \
-					BINDIRBASE=$${BINDIRBASE} \
-					RIOTNOLINK=$${RIOTNOLINK} \
-					RIOT_VERSION=$${RIOT_VERSION} \
-					WERROR=$${WERROR} \
-					LTO=$${LTO} \
-					TOOLCHAIN=$${TOOLCHAIN} \
-					$(MAKE) -j$(NPROC) 2>&1) ; \
-			if [ "$${?}" = "0" ]; then \
-				${COLOR_ECHO} "${COLOR_GREEN}success${COLOR_RESET}"; \
-				if [ -n "$${BUILDTEST_VERBOSE}" ]; then \
-					echo "$${LOG}" | tail -n +2 | head -n -2 | grep -v -E '^Building application|^\"make|^patching' | awk 'NF'; \
-				fi; \
-			elif [ -n "$${RIOT_DO_RETRY}" ] && [ "$${APP_RETRY}" -lt "3" ] && [ $${NTH_TRY} != 3 ]; then \
-				${COLOR_ECHO} -n "${COLOR_PURPLE}retrying${COLOR_RESET} "; \
-				continue; \
-			else \
-				${COLOR_ECHO} "${COLOR_RED}failed${COLOR_RESET}"; \
-				if [ -n "$${BUILDTEST_VERBOSE}" ]; then \
-					echo "$${LOG}" | grep -v -E '^\"make'; \
-				fi; \
-				APP_RETRY=`expr $${APP_RETRY} + 1`; \
-				BUILDTESTOK=false; \
-			fi; \
-			break; \
-		done; \
-		env -i \
-			HOME=$${HOME} \
-			PATH=$${PATH} \
-			BOARD=$${BOARD} \
-			CCACHE=$${CCACHE} \
-			CCACHE_DIR=$${CCACHE_DIR} \
-			CCACHE_BASEDIR=$${CCACHE_BASEDIR} \
-			RIOTBASE=$${RIOTBASE} \
-			RIOTBOARD=$${RIOTBOARD} \
-			RIOTCPU=$${RIOTCPU} \
-			BINDIRBASE=$${BINDIRBASE} \
-			RIOTNOLINK=$${RIOTNOLINK} \
-			RIOT_VERSION=$${RIOT_VERSION} \
-			$(MAKE) clean-intermediates 2>&1 >/dev/null || true; \
+	  RIOTNOLINK=$$(echo $(BOARD_INSUFFICIENT_MEMORY) | grep $${BOARD} 2>&1 >/dev/null && echo 1); \
+	  ${COLOR_ECHO} -n "Building for $${BOARD} "; \
+	  [ -n "$${RIOTNOLINK}" ] && ${COLOR_ECHO} -n "(no linking) "; \
+	  for NTH_TRY in 1 2 3; do \
+	    ${COLOR_ECHO} -n ".. "; \
+	    LOG=$$(env -i \
+	        HOME=$${HOME} \
+	        PATH=$${PATH} \
+	        BOARD=$${BOARD} \
+	        CCACHE=$${CCACHE} \
+	        CCACHE_DIR=$${CCACHE_DIR} \
+	        CCACHE_BASEDIR=$${CCACHE_BASEDIR} \
+	        RIOTBASE=$${RIOTBASE} \
+	        RIOTBOARD=$${RIOTBOARD} \
+	        RIOTCPU=$${RIOTCPU} \
+	        BINDIRBASE=$${BINDIRBASE} \
+	        RIOTNOLINK=$${RIOTNOLINK} \
+	        RIOT_VERSION=$${RIOT_VERSION} \
+	        WERROR=$${WERROR} \
+	        LTO=$${LTO} \
+	        TOOLCHAIN=$${TOOLCHAIN} \
+	        $(MAKE) -j$(NPROC) 2>&1) ; \
+	    if [ "$${?}" = "0" ]; then \
+	      ${COLOR_ECHO} "${COLOR_GREEN}success${COLOR_RESET}"; \
+	      if [ -n "$${BUILDTEST_VERBOSE}" ]; then \
+	        echo "$${LOG}" | tail -n +2 | head -n -2 | grep -v -E '^Building application|^\"make|^patching' | awk 'NF'; \
+	      fi; \
+	    elif [ -n "$${RIOT_DO_RETRY}" ] && [ "$${APP_RETRY}" -lt "3" ] && [ $${NTH_TRY} != 3 ]; then \
+	      ${COLOR_ECHO} -n "${COLOR_PURPLE}retrying${COLOR_RESET} "; \
+	      continue; \
+	    else \
+	      ${COLOR_ECHO} "${COLOR_RED}failed${COLOR_RESET}"; \
+	      if [ -n "$${BUILDTEST_VERBOSE}" ]; then \
+	        echo "$${LOG}" | grep -v -E '^\"make'; \
+	      fi; \
+	      APP_RETRY=`expr $${APP_RETRY} + 1`; \
+	      BUILDTESTOK=false; \
+	    fi; \
+	    break; \
+	  done; \
+	  env -i \
+	    HOME=$${HOME} \
+	    PATH=$${PATH} \
+	    BOARD=$${BOARD} \
+	    CCACHE=$${CCACHE} \
+	    CCACHE_DIR=$${CCACHE_DIR} \
+	    CCACHE_BASEDIR=$${CCACHE_BASEDIR} \
+	    RIOTBASE=$${RIOTBASE} \
+	    RIOTBOARD=$${RIOTBOARD} \
+	    RIOTCPU=$${RIOTCPU} \
+	    BINDIRBASE=$${BINDIRBASE} \
+	    RIOTNOLINK=$${RIOTNOLINK} \
+	    RIOT_VERSION=$${RIOT_VERSION} \
+	    $(MAKE) clean-intermediates 2>&1 >/dev/null || true; \
 	done; \
 	$${BUILDTESTOK}
 endif # BUILD_IN_DOCKER


### PR DESCRIPTION
This PR adds the TOOLCHAIN to the list of variables passed on to sub-makes called by `make buildtest`

Bonus commit: Cleaned up indentation in Makefile.buildtests to be coherent with the rest of the file