### PR TITLE
boards/nrf51-based: Refactor LED defines

### DIFF
--- a/boards/nrf51dongle/include/board.h
+++ b/boards/nrf51dongle/include/board.h
@@ -32,24 +32,24 @@ extern "C" {
  * @name    LED pin definitions
  * @{
  */
-#define LED_RED_PIN         (1 << 21)
-#define LED_GREEN_PIN       (1 << 22)
-#define LED_BLUE_PIN        (1 << 23)
+#define LED_RED_PIN         (21)
+#define LED_GREEN_PIN       (22)
+#define LED_BLUE_PIN        (23)
 /** @} */
 
 /**
  * @name    Macros for controlling the on-board LEDs
  * @{
  */
-#define LED_RED_ON          (NRF_GPIO->OUTCLR = LED_RED_PIN)
-#define LED_RED_OFF         (NRF_GPIO->OUTSET = LED_RED_PIN)
-#define LED_RED_TOGGLE      (NRF_GPIO->OUT ^= LED_RED_PIN)
-#define LED_GREEN_ON        (NRF_GPIO->OUTCLR = LED_GREEN_PIN)
-#define LED_GREEN_OFF       (NRF_GPIO->OUTSET = LED_GREEN_PIN)
-#define LED_GREEN_TOGGLE    (NRF_GPIO->OUT ^= LED_GREEN_PIN)
-#define LED_BLUE_ON         (NRF_GPIO->OUTCLR = LED_BLUE_PIN)
-#define LED_BLUE_OFF        (NRF_GPIO->OUTSET = LED_BLUE_PIN)
-#define LED_BLUE_TOGGLE     (NRF_GPIO->OUT ^= LED_BLUE_PIN)
+#define LED_RED_ON          (NRF_GPIO->OUTCLR = (1 << LED_RED_PIN))
+#define LED_RED_OFF         (NRF_GPIO->OUTSET = (1 << LED_RED_PIN))
+#define LED_RED_TOGGLE      (NRF_GPIO->OUT ^= (1 << LED_RED_PIN))
+#define LED_GREEN_ON        (NRF_GPIO->OUTCLR = (1 << LED_GREEN_PIN))
+#define LED_GREEN_OFF       (NRF_GPIO->OUTSET = (1 << LED_GREEN_PIN))
+#define LED_GREEN_TOGGLE    (NRF_GPIO->OUT ^= (1 << LED_GREEN_PIN))
+#define LED_BLUE_ON         (NRF_GPIO->OUTCLR = (1 << LED_BLUE_PIN))
+#define LED_BLUE_OFF        (NRF_GPIO->OUTSET = (1 << LED_BLUE_PIN))
+#define LED_BLUE_TOGGLE     (NRF_GPIO->OUT ^= (1 << LED_BLUE_PIN))
 /** @} */
 
 /**

--- a/boards/nrf6310/include/board.h
+++ b/boards/nrf6310/include/board.h
@@ -34,24 +34,24 @@ extern "C" {
  * @{
  */
 #define ONBOARD_LED         1
-#define LED_RED_PIN         (1 << 8)
-#define LED_GREEN_PIN       (1 << 9)
-#define LED_BLUE_PIN        (1 << 10)
+#define LED_RED_PIN         (8)
+#define LED_GREEN_PIN       (9)
+#define LED_BLUE_PIN        (10)
 /** @} */
 
 /**
  * @name Macros for controlling the on-board LEDs.
  * @{
  */
-#define LED_RED_ON          (NRF_GPIO->OUTCLR = LED_RED_PIN)
-#define LED_RED_OFF         (NRF_GPIO->OUTSET = LED_RED_PIN)
-#define LED_RED_TOGGLE      (NRF_GPIO->OUT ^= LED_RED_PIN)
-#define LED_GREEN_ON        (NRF_GPIO->OUTCLR = LED_GREEN_PIN)
-#define LED_GREEN_OFF       (NRF_GPIO->OUTSET = LED_GREEN_PIN)
-#define LED_GREEN_TOGGLE    (NRF_GPIO->OUT ^= LED_GREEN_PIN)
-#define LED_BLUE_ON         (NRF_GPIO->OUTCLR = LED_BLUE_PIN)
-#define LED_BLUE_OFF        (NRF_GPIO->OUTSET = LED_BLUE_PIN)
-#define LED_BLUE_TOGGLE     (NRF_GPIO->OUT ^= LED_BLUE_PIN)
+#define LED_RED_ON          (NRF_GPIO->OUTCLR = (1 << LED_RED_PIN))
+#define LED_RED_OFF         (NRF_GPIO->OUTSET = (1 << LED_RED_PIN))
+#define LED_RED_TOGGLE      (NRF_GPIO->OUT ^= (1 << LED_RED_PIN))
+#define LED_GREEN_ON        (NRF_GPIO->OUTCLR = (1 << LED_GREEN_PIN))
+#define LED_GREEN_OFF       (NRF_GPIO->OUTSET = (1 << LED_GREEN_PIN))
+#define LED_GREEN_TOGGLE    (NRF_GPIO->OUT ^= (1 << LED_GREEN_PIN))
+#define LED_BLUE_ON         (NRF_GPIO->OUTCLR = (1 << LED_BLUE_PIN))
+#define LED_BLUE_OFF        (NRF_GPIO->OUTSET = (1 << LED_BLUE_PIN))
+#define LED_BLUE_TOGGLE     (NRF_GPIO->OUT ^= (1 << LED_BLUE_PIN))
 /** @} */
 
 /**

--- a/boards/pca10000/include/board.h
+++ b/boards/pca10000/include/board.h
@@ -44,24 +44,24 @@ extern "C" {
  * @{
  */
 #define ONBOARD_LED         1
-#define LED_RED_PIN         (1 << 21)
-#define LED_GREEN_PIN       (1 << 22)
-#define LED_BLUE_PIN        (1 << 23)
+#define LED_RED_PIN         (21)
+#define LED_GREEN_PIN       (22)
+#define LED_BLUE_PIN        (23)
 /** @} */
 
 /**
  * @name Macros for controlling the on-board LEDs.
  * @{
  */
-#define LED_RED_ON          (NRF_GPIO->OUTCLR = LED_RED_PIN)
-#define LED_RED_OFF         (NRF_GPIO->OUTSET = LED_RED_PIN)
-#define LED_RED_TOGGLE      (NRF_GPIO->OUT ^= LED_RED_PIN)
-#define LED_GREEN_ON        (NRF_GPIO->OUTCLR = LED_GREEN_PIN)
-#define LED_GREEN_OFF       (NRF_GPIO->OUTSET = LED_GREEN_PIN)
-#define LED_GREEN_TOGGLE    (NRF_GPIO->OUT ^= LED_GREEN_PIN)
-#define LED_BLUE_ON         (NRF_GPIO->OUTCLR = LED_BLUE_PIN)
-#define LED_BLUE_OFF        (NRF_GPIO->OUTSET = LED_BLUE_PIN)
-#define LED_BLUE_TOGGLE     (NRF_GPIO->OUT ^= LED_BLUE_PIN)
+#define LED_RED_ON          (NRF_GPIO->OUTCLR = (1 << LED_RED_PIN))
+#define LED_RED_OFF         (NRF_GPIO->OUTSET = (1 << LED_RED_PIN))
+#define LED_RED_TOGGLE      (NRF_GPIO->OUT ^= (1 << LED_RED_PIN))
+#define LED_GREEN_ON        (NRF_GPIO->OUTCLR = (1 << LED_GREEN_PIN))
+#define LED_GREEN_OFF       (NRF_GPIO->OUTSET = (1 << LED_GREEN_PIN))
+#define LED_GREEN_TOGGLE    (NRF_GPIO->OUT ^= (1 << LED_GREEN_PIN))
+#define LED_BLUE_ON         (NRF_GPIO->OUTCLR = (1 << LED_BLUE_PIN))
+#define LED_BLUE_OFF        (NRF_GPIO->OUTSET = (1 << LED_BLUE_PIN))
+#define LED_BLUE_TOGGLE     (NRF_GPIO->OUT ^= (1 << LED_BLUE_PIN))
 /** @} */
 
 /**


### PR DESCRIPTION
Refactored to match other platforms with similar macros.

Fixes #4644 