### PR TITLE
drivers: make default radio channel configurable at compile time

### DIFF
--- a/drivers/cc110x/include/cc110x-internal.h
+++ b/drivers/cc110x/include/cc110x-internal.h
@@ -56,7 +56,9 @@ extern "C" {
                                                  after CS */
 #define CC110X_GDO1_LOW_RETRY       (100)   /**< Max. retries for SO to go low
                                                  after CS */
+#ifndef CC100X_DEFAULT_CHANNEL
 #define CC110X_DEFAULT_CHANNEL      (0)     /**< The default channel number */
+#endif
 #define CC110X_MIN_CHANNR           (0)     /**< lowest possible channel number */
 #define CC110X_MAX_CHANNR           (0)     /**< highest possible channel number */
 

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -61,11 +61,15 @@ extern "C" {
 /* the AT86RF212B has a sub-1GHz radio */
 #define AT86RF2XX_MIN_CHANNEL           (0)
 #define AT86RF2XX_MAX_CHANNEL           (10)
+#ifndef AT86RF2XX_DEFAULT_CHANNEL
 #define AT86RF2XX_DEFAULT_CHANNEL       (5)
+#endif
 #else
 #define AT86RF2XX_MIN_CHANNEL           (11U)
 #define AT86RF2XX_MAX_CHANNEL           (26U)
+#ifndef AT86RF2XX_DEFAULT_CHANNEL
 #define AT86RF2XX_DEFAULT_CHANNEL       (26U)
+#endif
 #endif
 /** @} */
 

--- a/drivers/include/kw2xrf.h
+++ b/drivers/include/kw2xrf.h
@@ -65,7 +65,9 @@ extern "C" {
 /**
  * @brief   Default channel used after initialization
  */
+#ifndef KW2XRF_DEFAULT_CHANNEL
 #define KW2XRF_DEFAULT_CHANNEL        (26U)
+#endif
 
 /**
  * @brief   Default TX_POWER in dbm used after initialization

--- a/drivers/include/xbee.h
+++ b/drivers/include/xbee.h
@@ -68,7 +68,9 @@ extern "C" {
 /**
  * @brief   Default channel used after initialization
  */
+#ifndef XBEE_DEFAULT_CHANNEL
 #define XBEE_DEFAULT_CHANNEL        (26U)
+#endif
 
 /**
  * @name    Address flags

--- a/drivers/nrf24l01p/include/nrf24l01p_settings.h
+++ b/drivers/nrf24l01p/include/nrf24l01p_settings.h
@@ -28,7 +28,9 @@ extern "C" {
 
 #define INITIAL_ADDRESS_WIDTH       5
 #define NRF24L01P_MAX_DATA_LENGTH   32
+#ifndef INITIAL_RF_CHANNEL
 #define INITIAL_RF_CHANNEL          5
+#endif
 #define INITIAL_RX_POWER_0dB        0
 
 #define DELAY_CS_TOGGLE_TICKS       2


### PR DESCRIPTION
This PR makes the default radio channel configurable at compile time. Without this change, it is only possible to change the channel programmatically or with the `ifconfig` shell command.

Can be tested by compiling the `gnrc_networking` example with `CFLAGS+="-DAT86RF2XX_DEFAULT_CHANNEL=12" BOARD=samr21-xpro make all flash term`