### PR TITLE
doc: atomic: provide explanation about why atomic_int_t is struct

### DIFF
--- a/core/include/atomic.h
+++ b/core/include/atomic.h
@@ -27,6 +27,9 @@ extern "C" {
 
 /**
  * @brief Integer variable for use in atomic counters.
+ *
+ * @note    This type is a struct for hard type checking (let the compiler warn
+ *          if int is assigned regularly).
  */
 typedef struct atomic_int {
     volatile int value;         /**< the actual value */


### PR DESCRIPTION
I was always a bit puzzled about this fact, but I found an answer: See https://github.com/RIOT-OS/RIOT/pull/2321#issuecomment-72088818