### PR TITLE
drivers/timer: added callback argument

### DIFF
--- a/cpu/atmega2560/periph/timer.c
+++ b/cpu/atmega2560/periph/timer.c
@@ -33,20 +33,16 @@
 
 #define IRQ_DISABLED 0x00
 
-typedef struct {
-    void (*cb)(int);
-} timer_conf_t;
-
 /**
  * @brief Timer state memory
  */
-timer_conf_t config[TIMER_NUMOF];
+static timer_isr_ctx_t config[TIMER_NUMOF];
 
 /**
  * @brief Setup the given timer
  *
  */
-int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     /* reject impossible freq values
      * todo: Add support for 2 MHz and 16 MHz */
@@ -85,7 +81,8 @@ int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
     }
 
     /* save callback */
-    config[dev].cb = callback;
+    config[dev].cb = cb;
+    config[dev].arg = arg;
 
     return 0;
 }
@@ -422,7 +419,7 @@ static inline void _isr(int timer, int chan)
     __enter_isr();
     timer_clear(timer, chan);
 
-    config[timer].cb(chan);
+    config[timer].cb(config[timer].arg, chan);
 
     if (sched_context_switch_request) {
         thread_yield();

--- a/cpu/ezr32wg/periph/timer.c
+++ b/cpu/ezr32wg/periph/timer.c
@@ -38,7 +38,7 @@
 static timer_isr_ctx_t isr_ctx[TIMER_NUMOF];
 
 
-int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     TIMER_TypeDef *pre, *tim;
 
@@ -48,7 +48,8 @@ int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
     }
 
     /* save callback */
-    isr_ctx[dev].cb = callback;
+    isr_ctx[dev].cb = cb;
+    isr_ctx[dev].arg = arg;
 
     /* get timers */
     pre = timer_config[dev].prescaler;
@@ -152,7 +153,7 @@ void TIMER_0_ISR(void)
         if (tim->IF & (TIMER_IF_CC0 << i)) {
             tim->CC[i].CTRL = _TIMER_CC_CTRL_MODE_OFF;
             tim->IFC = (TIMER_IFC_CC0 << i);
-            isr_ctx[0].cb(i);
+            isr_ctx[0].cb(isr_ctx[0].arg, i);
         }
     }
     if (sched_context_switch_request) {

--- a/cpu/lm4f120/periph/timer.c
+++ b/cpu/lm4f120/periph/timer.c
@@ -38,7 +38,8 @@
  * @{
  */
 typedef struct {
-    void (*cb)(int);        /**< timeout callback */
+    timer_cb_t cb;          /**< timeout callback */
+    void *arg;              /**< argument to the callback */
     unsigned int divisor;   /**< software clock divisor */
 } timer_conf_t;
 
@@ -66,13 +67,14 @@ static inline unsigned int _llvalue_to_scaled_value(unsigned long long corrected
     return scaledv;
 }
 
-int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     if (dev >= TIMER_NUMOF){
         return -1;
     }
 
-    config[dev].cb = callback;                          /* User Function */
+    config[dev].cb = cb;
+    config[dev].arg = arg;
     config[dev].divisor = ROM_SysCtlClockGet() / freq;
 
     unsigned int sysctl_timer;
@@ -368,7 +370,7 @@ void isr_wtimer0a(void)
 {
     /* Clears both IT */
     ROM_TimerIntClear(WTIMER0_BASE, TIMER_TIMA_TIMEOUT | TIMER_TIMA_MATCH);
-    config[TIMER_0].cb(0);
+    config[TIMER_0].cb(config[TIMER_0].arg, 0);
     if (sched_context_switch_request){
         thread_yield();
     }
@@ -380,7 +382,7 @@ void isr_wtimer1a(void)
 {
     ROM_TimerIntClear(WTIMER1_BASE, TIMER_TIMA_TIMEOUT | TIMER_TIMA_MATCH);
 
-    config[TIMER_1].cb(0);
+    config[TIMER_1].cb(config[TIMER_0].arg, 0);
     if (sched_context_switch_request){
         thread_yield();
     }

--- a/cpu/lpc11u34/periph/timer.c
+++ b/cpu/lpc11u34/periph/timer.c
@@ -39,22 +39,16 @@
 /** @} */
 
 /**
- * @brief Struct holding the configuration data for a UART device
- */
-typedef struct {
-    void (*cb)(int);            /**< timeout callback */
-} timer_conf_t;
-
-/**
  * @brief UART device configurations
  */
-static timer_conf_t config[TIMER_NUMOF];
+static timer_isr_ctx_t config[TIMER_NUMOF];
 
-int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     if (dev == TIMER_0) {
         /* save callback */
-        config[TIMER_0].cb = callback;
+        config[TIMER_0].cb = cb;
+        config[TIMER_0].arg = arg;
         /* enable power for timer */
         TIMER_0_CLKEN();
         /* set to timer mode */
@@ -155,22 +149,22 @@ void TIMER_0_ISR(void)
     if (TIMER_0_DEV->IR & MR0_FLAG) {
         TIMER_0_DEV->IR |= (MR0_FLAG);
         TIMER_0_DEV->MCR &= ~(1 << 0);
-        config[TIMER_0].cb(0);
+        config[TIMER_0].cb(config[TIMER_0].arg, 0);
     }
     if (TIMER_0_DEV->IR & MR1_FLAG) {
         TIMER_0_DEV->IR |= (MR1_FLAG);
         TIMER_0_DEV->MCR &= ~(1 << 3);
-        config[TIMER_0].cb(1);
+        config[TIMER_0].cb(config[TIMER_0].arg, 1);
     }
     if (TIMER_0_DEV->IR & MR2_FLAG) {
         TIMER_0_DEV->IR |= (MR2_FLAG);
         TIMER_0_DEV->MCR &= ~(1 << 6);
-        config[TIMER_0].cb(2);
+        config[TIMER_0].cb(config[TIMER_0].arg, 2);
     }
     if (TIMER_0_DEV->IR & MR3_FLAG) {
         TIMER_0_DEV->IR |= (MR3_FLAG);
         TIMER_0_DEV->MCR &= ~(1 << 9);
-        config[TIMER_0].cb(3);
+        config[TIMER_0].cb(config[TIMER_0].arg, 3);
     }
     if (sched_context_switch_request) {
         thread_yield();

--- a/cpu/lpc1768/periph/timer.c
+++ b/cpu/lpc1768/periph/timer.c
@@ -39,22 +39,16 @@
 /** @} */
 
 /**
- * @brief Struct holding the configuration data for a UART device
- */
-typedef struct {
-    void (*cb)(int);            /**< timeout callback */
-} timer_conf_t;
-
-/**
  * @brief UART device configurations
  */
-static timer_conf_t config[TIMER_NUMOF];
+static timer_isr_ctx_t config[TIMER_NUMOF];
 
-int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     if (dev == TIMER_0) {
         /* save callback */
-        config[TIMER_0].cb = callback;
+        config[TIMER_0].cb = cb;
+        config[TIMER_0].arg = arg;
         /* enable power for timer */
         TIMER_0_CLKEN();
         /* let timer run with full frequency */
@@ -158,22 +152,22 @@ void TIMER_0_ISR(void)
     if (TIMER_0_DEV->IR & MR0_FLAG) {
         TIMER_0_DEV->IR |= (MR0_FLAG);
         TIMER_0_DEV->MCR &= ~(1 << 0);
-        config[TIMER_0].cb(0);
+        config[TIMER_0].cb(config[TIMER_0].arg, 0);
     }
     if (TIMER_0_DEV->IR & MR1_FLAG) {
         TIMER_0_DEV->IR |= (MR1_FLAG);
         TIMER_0_DEV->MCR &= ~(1 << 3);
-        config[TIMER_0].cb(1);
+        config[TIMER_0].cb(config[TIMER_0].arg, 1);
     }
     if (TIMER_0_DEV->IR & MR2_FLAG) {
         TIMER_0_DEV->IR |= (MR2_FLAG);
         TIMER_0_DEV->MCR &= ~(1 << 6);
-        config[TIMER_0].cb(2);
+        config[TIMER_0].cb(config[TIMER_0].arg, 2);
     }
     if (TIMER_0_DEV->IR & MR3_FLAG) {
         TIMER_0_DEV->IR |= (MR3_FLAG);
         TIMER_0_DEV->MCR &= ~(1 << 9);
-        config[TIMER_0].cb(3);
+        config[TIMER_0].cb(config[TIMER_0].arg, 3);
     }
     if (sched_context_switch_request) {
         thread_yield();

--- a/cpu/lpc2387/periph/timer.c
+++ b/cpu/lpc2387/periph/timer.c
@@ -108,7 +108,7 @@ static inline void pwr_clk_and_isr(tim_t tim)
     }
 }
 
-int timer_init(tim_t tim, unsigned long freq, void (*callback)(int))
+int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 {
     /* get the timers base register */
     lpc23xx_timer_t *dev = get_dev(tim);
@@ -119,7 +119,8 @@ int timer_init(tim_t tim, unsigned long freq, void (*callback)(int))
     }
 
     /* save the callback */
-    isr_ctx[tim].cb = callback;
+    isr_ctx[tim].cb = cb;
+    isr_ctx[tim].arg = arg;
     /* enable power, config periph clock and install ISR vector */
     pwr_clk_and_isr(tim);
     /* reset timer configuration (sets the timer to timer mode) */
@@ -192,7 +193,7 @@ static inline void isr_handler(lpc23xx_timer_t *dev, int tim_num)
         if (dev->IR & (1 << i)) {
             dev->IR |= (1 << i);
             dev->MCR &= ~(1 << (i * 3));
-            isr_ctx[tim_num].cb(i);
+            isr_ctx[tim_num].cb(isr_ctx[tim_num].arg, i);
         }
     }
     /* we must not forget to acknowledge the handling of the interrupt */

--- a/cpu/msp430fxyz/periph/timer.c
+++ b/cpu/msp430fxyz/periph/timer.c
@@ -32,10 +32,15 @@
 /**
  * @brief   Save reference to the timer callback
  */
-static void (*isr_cb)(int chan);
+static timer_cb_t isr_cb;
+
+/**
+ * @brief    Save argument for the ISR callback
+ */
+static void *isr_arg;
 
 
-int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     /* using fixed TIMER_BASE for now */
     if (dev != 0) {
@@ -49,7 +54,8 @@ int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
     /* reset the timer A configuration */
     TIMER_BASE->CTL = TIMER_CTL_CLR;
     /* save callback */
-    isr_cb = callback;
+    isr_cb = cb;
+    isr_arg = arg;
     /* configure timer to use the SMCLK with prescaler of 8 */
     TIMER_BASE->CTL = (TIMER_CTL_TASSEL_SMCLK | TIMER_CTL_ID_DIV8);
     /* configure CC channels */
@@ -124,7 +130,7 @@ ISR(TIMER_ISR_CC0, isr_timer_a_cc0)
     __enter_isr();
 
     TIMER_BASE->CCTL[0] &= ~(TIMER_CCTL_CCIE);
-    isr_cb(0);
+    isr_cb(isr_arg, 0);
 
     __exit_isr();
 }
@@ -135,7 +141,7 @@ ISR(TIMER_ISR_CCX, isr_timer_a_ccx)
 
     int chan = (int)(TIMER_IVEC->TAIV >> 1);
     TIMER_BASE->CCTL[chan] &= ~(TIMER_CCTL_CCIE);
-    isr_cb(chan);
+    isr_cb(isr_arg, chan);
 
     __exit_isr();
 }

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -49,7 +49,8 @@
 
 static unsigned long time_null;
 
-static void (*_callback)(int);
+static timer_cb_t _callback;
+static void *_cb_arg;
 
 static struct itimerval itv;
 
@@ -71,10 +72,10 @@ void native_isr_timer(void)
 {
     DEBUG("%s\n", __func__);
 
-    _callback(0);
+    _callback(_cb_arg, 0);
 }
 
-int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     (void)freq;
     DEBUG("%s\n", __func__);
@@ -90,7 +91,8 @@ int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
     time_null = timer_read(0);
 
     timer_irq_disable(dev);
-    _callback = callback;
+    _callback = cb;
+    _cb_arg = arg;
     timer_irq_enable(dev);
 
     return 0;

--- a/cpu/nrf51/periph/timer.c
+++ b/cpu/nrf51/periph/timer.c
@@ -40,7 +40,8 @@
  * @brief struct for keeping track of a timer's state
  */
 typedef struct {
-    void (*cb)(int);
+    timer_cb_t cb;
+    void *arg;
     uint8_t flags;
 } timer_conf_t;
 
@@ -64,14 +65,15 @@ static NRF_TIMER_Type *const timer[] = {
 #endif
 };
 
-int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     if (dev >= TIMER_NUMOF) {
         return -1;
     }
 
     /* save callback */
-    timer_config[dev].cb = callback;
+    timer_config[dev].cb = cb;
+    timer_config[dev].arg = arg;
     /* power on timer */
     timer[dev]->POWER = 1;
 
@@ -285,7 +287,7 @@ void TIMER_0_ISR(void)
             if (timer_config[TIMER_0].flags & (1 << i)) {
                 timer_config[TIMER_0].flags &= ~(1 << i);
                 TIMER_0_DEV->INTENCLR = (1 << (16 + i));
-                timer_config[TIMER_0].cb(i);
+                timer_config[TIMER_0].cb(timer_config[TIMER_0].arg, i);
             }
         }
     }
@@ -304,7 +306,7 @@ void TIMER_1_ISR(void)
             if (timer_config[TIMER_1].flags & (1 << i)) {
                 timer_config[TIMER_1].flags &= ~(1 << i);
                 TIMER_1_DEV->INTENCLR = (1 << (16 + i));
-                timer_config[TIMER_1].cb(i);
+                timer_config[TIMER_1].cb(timer_config[TIMER_1].arg, i);
             }
         }
     }
@@ -323,7 +325,7 @@ void TIMER_2_ISR(void)
             if (timer_config[TIMER_2].flags & (1 << i)) {
                 timer_config[TIMER_2].flags &= ~(1 << i);
                 TIMER_2_DEV->INTENCLR = (1 << (16 + i));
-                timer_config[TIMER_2].cb(i);
+                timer_config[TIMER_2].cb(timer_config[TIMER_2].arg, i);
             }
         }
     }

--- a/cpu/nrf52/periph/timer.c
+++ b/cpu/nrf52/periph/timer.c
@@ -40,7 +40,8 @@
  * @brief struct for keeping track of a timer's state
  */
 typedef struct {
-    void (*cb)(int);
+    timer_cb_t cb;
+    void *arg;
     uint8_t flags;
 } timer_conf_t;
 
@@ -64,14 +65,15 @@ static NRF_TIMER_Type *const timer[] = {
 #endif
 };
 
-int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     if (dev >= TIMER_NUMOF) {
         return -1;
     }
 
     /* save callback */
-    timer_config[dev].cb = callback;
+    timer_config[dev].cb = cb;
+    timer_config[dev].arg = arg;
     /* power on timer */
     /* timer[dev]->POWER = 1; */
 
@@ -308,7 +310,7 @@ void TIMER_0_ISR(void)
             if (timer_config[TIMER_0].flags & (1 << i)) {
                 timer_config[TIMER_0].flags &= ~(1 << i);
                 TIMER_0_DEV->INTENCLR = (1 << (16 + i));
-                timer_config[TIMER_0].cb(i);
+                timer_config[TIMER_0].cb(timer_config[TIMER_0].arg, i);
             }
         }
     }
@@ -329,7 +331,7 @@ void TIMER_1_ISR(void)
             if (timer_config[TIMER_1].flags & (1 << i)) {
                 timer_config[TIMER_1].flags &= ~(1 << i);
                 TIMER_1_DEV->INTENCLR = (1 << (16 + i));
-                timer_config[TIMER_1].cb(i);
+                timer_config[TIMER_1].cb(timer_config[TIMER_1].arg, i);
             }
         }
     }
@@ -350,7 +352,7 @@ void TIMER_2_ISR(void)
             if (timer_config[TIMER_2].flags & (1 << i)) {
                 timer_config[TIMER_2].flags &= ~(1 << i);
                 TIMER_2_DEV->INTENCLR = (1 << (16 + i));
-                timer_config[TIMER_2].cb(i);
+                timer_config[TIMER_2].cb(timer_config[TIMER_2].arg, i);
             }
         }
     }

--- a/cpu/samd21/periph/timer.c
+++ b/cpu/samd21/periph/timer.c
@@ -32,21 +32,16 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-
-typedef struct {
-    void (*cb)(int);
-} timer_conf_t;
-
 /**
  * @brief Timer state memory
  */
-timer_conf_t config[TIMER_NUMOF];
+static timer_isr_ctx_t config[TIMER_NUMOF];
 
 
 /**
  * @brief Setup the given timer
  */
-int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     /* at the moment, the timer can only run at 1MHz */
     if (freq != 1000000ul) {
@@ -123,7 +118,8 @@ int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
     }
 
     /* save callback */
-    config[dev].cb = callback;
+    config[dev].cb = cb;
+    config[dev].arg = arg;
 
     /* enable interrupts for given timer */
     timer_irq_enable(dev);
@@ -339,14 +335,14 @@ void TIMER_0_ISR(void)
         if(config[TIMER_0].cb) {
             TIMER_0_DEV.INTFLAG.bit.MC0 = 1;
             TIMER_0_DEV.INTENCLR.reg = TC_INTENCLR_MC0;
-            config[TIMER_0].cb(0);
+            config[TIMER_0].cb(config[TIMER_0].arg, 0);
         }
     }
     else if (TIMER_0_DEV.INTFLAG.bit.MC1 && TIMER_0_DEV.INTENSET.bit.MC1) {
         if(config[TIMER_0].cb) {
             TIMER_0_DEV.INTFLAG.bit.MC1 = 1;
             TIMER_0_DEV.INTENCLR.reg = TC_INTENCLR_MC1;
-            config[TIMER_0].cb(1);
+            config[TIMER_0].cb(config[TIMER_0].arg, 1);
         }
     }
 
@@ -364,14 +360,14 @@ void TIMER_1_ISR(void)
         if (config[TIMER_1].cb) {
             TIMER_1_DEV.INTFLAG.bit.MC0 = 1;
             TIMER_1_DEV.INTENCLR.reg = TC_INTENCLR_MC0;
-            config[TIMER_1].cb(0);
+            config[TIMER_1].cb(config[TIMER_1].arg, 0);
         }
     }
     else if (TIMER_1_DEV.INTFLAG.bit.MC1 && TIMER_1_DEV.INTENSET.bit.MC1) {
         if(config[TIMER_1].cb) {
             TIMER_1_DEV.INTFLAG.bit.MC1 = 1;
             TIMER_1_DEV.INTENCLR.reg = TC_INTENCLR_MC1;
-            config[TIMER_1].cb(1);
+            config[TIMER_1].cb(config[TIMER_1].arg, 1);
         }
 
     }

--- a/cpu/saml21/periph/timer.c
+++ b/cpu/saml21/periph/timer.c
@@ -36,19 +36,15 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-typedef struct {
-    void (*cb)(int);
-} timer_conf_t;
-
 /**
  * @brief Timer state memory
  */
-timer_conf_t config[TIMER_NUMOF];
+static timer_isr_ctx_t config[TIMER_NUMOF];
 
 /**
  * @brief Setup the given timer
  */
-int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     /* configure GCLK0 to feed TC0 & TC1*/;
     GCLK->PCHCTRL[TC0_GCLK_ID].reg |= GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN_GCLK0;
@@ -79,7 +75,8 @@ int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
     }
 
     /* save callback */
-    config[dev].cb = callback;
+    config[dev].cb = cb;
+    config[dev].arg = arg;
 
     /* enable interrupts for given timer */
     timer_irq_enable(dev);
@@ -232,14 +229,14 @@ void TIMER_0_ISR(void)
         if(config[TIMER_0].cb) {
             TIMER_0_DEV.INTFLAG.bit.MC0 = 1;
             TIMER_0_DEV.INTENCLR.reg = TC_INTENCLR_MC0;
-            config[TIMER_0].cb(0);
+            config[TIMER_0].cb(config[TIMER_0].arg, 0);
         }
     }
     else if (TIMER_0_DEV.INTFLAG.bit.MC1 && TIMER_0_DEV.INTENSET.bit.MC1) {
         if(config[TIMER_0].cb) {
             TIMER_0_DEV.INTFLAG.bit.MC1 = 1;
             TIMER_0_DEV.INTENCLR.reg = TC_INTENCLR_MC1;
-            config[TIMER_0].cb(1);
+            config[TIMER_0].cb(config[TIMER_0].arg, 1);
         }
     }
 

--- a/cpu/stm32f0/periph/timer.c
+++ b/cpu/stm32f0/periph/timer.c
@@ -32,17 +32,13 @@
 
 static inline void irq_handler(tim_t timer, TIM_TypeDef *dev);
 
-typedef struct {
-    void (*cb)(int);
-} timer_conf_t;
-
 /**
  * Timer state memory
  */
-static timer_conf_t config[TIMER_NUMOF];
+static timer_isr_ctx_t config[TIMER_NUMOF];
 
 
-int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     TIM_TypeDef *timer;
 
@@ -73,7 +69,8 @@ int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
     }
 
     /* set callback function */
-    config[dev].cb = callback;
+    config[dev].cb = cb;
+    config[dev].arg = arg;
 
     /* set timer to run in counter mode */
     timer->CR1 |= TIM_CR1_URS;
@@ -292,22 +289,22 @@ static inline void irq_handler(tim_t timer, TIM_TypeDef *dev)
     if (dev->SR & TIM_SR_CC1IF) {
         dev->DIER &= ~TIM_DIER_CC1IE;
         dev->SR &= ~TIM_SR_CC1IF;
-        config[timer].cb(0);
+        config[timer].cb(config[timer].arg, 0);
     }
     else if (dev->SR & TIM_SR_CC2IF) {
         dev->DIER &= ~TIM_DIER_CC2IE;
         dev->SR &= ~TIM_SR_CC2IF;
-        config[timer].cb(1);
+        config[timer].cb(config[timer].arg, 1);
     }
     else if (dev->SR & TIM_SR_CC3IF) {
         dev->DIER &= ~TIM_DIER_CC3IE;
         dev->SR &= ~TIM_SR_CC3IF;
-        config[timer].cb(2);
+        config[timer].cb(config[timer].arg, 2);
     }
     else if (dev->SR & TIM_SR_CC4IF) {
         dev->DIER &= ~TIM_DIER_CC4IE;
         dev->SR &= ~TIM_SR_CC4IF;
-        config[timer].cb(3);
+        config[timer].cb(config[timer].arg, 3);
     }
     if (sched_context_switch_request) {
         thread_yield();

--- a/cpu/stm32f3/periph/timer.c
+++ b/cpu/stm32f3/periph/timer.c
@@ -30,16 +30,11 @@
 /** Unified IRQ handler for all timers */
 static inline void irq_handler(tim_t timer, TIM_TypeDef *dev);
 
-/** Type for timer state */
-typedef struct {
-    void (*cb)(int);
-} timer_conf_t;
-
 /** Timer state memory */
-timer_conf_t config[TIMER_NUMOF];
+static timer_isr_ctx_t config[TIMER_NUMOF];
 
 
-int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     TIM_TypeDef *timer;
 
@@ -60,7 +55,8 @@ int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
     }
 
     /* set callback function */
-    config[dev].cb = callback;
+    config[dev].cb = cb;
+    config[dev].arg = arg;
 
     /* set timer to run in counter mode */
     timer->CR1 = 0;
@@ -240,22 +236,22 @@ static inline void irq_handler(tim_t timer, TIM_TypeDef *dev)
     if (dev->SR & TIM_SR_CC1IF) {
         dev->DIER &= ~TIM_DIER_CC1IE;
         dev->SR &= ~TIM_SR_CC1IF;
-        config[timer].cb(0);
+        config[timer].cb(config[timer].arg, 0);
     }
     else if (dev->SR & TIM_SR_CC2IF) {
         dev->DIER &= ~TIM_DIER_CC2IE;
         dev->SR &= ~TIM_SR_CC2IF;
-        config[timer].cb(1);
+        config[timer].cb(config[timer].arg, 1);
     }
     else if (dev->SR & TIM_SR_CC3IF) {
         dev->DIER &= ~TIM_DIER_CC3IE;
         dev->SR &= ~TIM_SR_CC3IF;
-        config[timer].cb(2);
+        config[timer].cb(config[timer].arg, 2);
     }
     else if (dev->SR & TIM_SR_CC4IF) {
         dev->DIER &= ~TIM_DIER_CC4IE;
         dev->SR &= ~TIM_SR_CC4IF;
-        config[timer].cb(3);
+        config[timer].cb(config[timer].arg, 3);
     }
     if (sched_context_switch_request) {
         thread_yield();

--- a/cpu/stm32f4/periph/timer.c
+++ b/cpu/stm32f4/periph/timer.c
@@ -30,16 +30,11 @@
 /** Unified IRQ handler for all timers */
 static inline void irq_handler(tim_t timer, TIM_TypeDef *dev);
 
-/** Type for timer state */
-typedef struct {
-    void (*cb)(int);
-} timer_conf_t;
-
 /** Timer state memory */
-timer_conf_t config[TIMER_NUMOF];
+static timer_isr_ctx_t config[TIMER_NUMOF];
 
 
-int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     TIM_TypeDef *timer;
 
@@ -72,7 +67,8 @@ int timer_init(tim_t dev, unsigned long freq, void (*callback)(int))
     }
 
     /* set callback function */
-    config[dev].cb = callback;
+    config[dev].cb = cb;
+    config[dev].arg = arg;
 
     /* set timer to run in counter mode */
     timer->CR1 = 0;
@@ -290,22 +286,22 @@ static inline void irq_handler(tim_t timer, TIM_TypeDef *dev)
     if (dev->SR & TIM_SR_CC1IF) {
         dev->DIER &= ~TIM_DIER_CC1IE;
         dev->SR &= ~TIM_SR_CC1IF;
-        config[timer].cb(0);
+        config[timer].cb(config[timer].arg, 0);
     }
     else if (dev->SR & TIM_SR_CC2IF) {
         dev->DIER &= ~TIM_DIER_CC2IE;
         dev->SR &= ~TIM_SR_CC2IF;
-        config[timer].cb(1);
+        config[timer].cb(config[timer].arg, 1);
     }
     else if (dev->SR & TIM_SR_CC3IF) {
         dev->DIER &= ~TIM_DIER_CC3IE;
         dev->SR &= ~TIM_SR_CC3IF;
-        config[timer].cb(2);
+        config[timer].cb(config[timer].arg, 2);
     }
     else if (dev->SR & TIM_SR_CC4IF) {
         dev->DIER &= ~TIM_DIER_CC4IE;
         dev->SR &= ~TIM_SR_CC4IF;
-        config[timer].cb(3);
+        config[timer].cb(config[timer].arg, 3);
     }
     if (sched_context_switch_request) {
         thread_yield();

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -56,12 +56,20 @@ typedef unsigned int tim_t;
 #endif
 
 /**
+ * @brief   Signature of event callback functions triggered from interrupts
+ *
+ * @param[in] arg       optional context for the callback
+ * @param[in] channel   timer channel that triggered the interrupt
+ */
+typedef void (*timer_cb_t)(void *arg, int channel);
+
+/**
  * @brief   Default interrupt context entry holding callback and argument
  * @{
  */
 #ifndef HAVE_TIMER_ISR_CTX_T
 typedef struct {
-    void (*cb)(int);        /**< callback executed from timer interrupt */
+    timer_cb_t cb;          /**< callback executed from timer interrupt */
     void *arg;              /**< optional argument given to that callback */
 } timer_isr_ctx_t;
 #endif
@@ -82,11 +90,12 @@ typedef struct {
  * @param[in] freq          requested number of ticks per second
  * @param[in] callback      this callback is called in interrupt context, the
  *                          emitting channel is passed as argument
+ * @param[in] arg           argument to the callback
  *
  * @return                  0 on success
  * @return                  -1 if speed not applicable or unknown device given
  */
-int timer_init(tim_t dev, unsigned long freq, void (*callback)(int));
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg);
 
 /**
  * @brief Set a given timer channel for the given timer device

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -44,7 +44,7 @@ static inline void _lltimer_set(uint32_t target);
 static uint32_t _time_left(uint32_t target, uint32_t reference);
 
 static void _timer_callback(void);
-static void _periph_timer_callback(int chan);
+static void _periph_timer_callback(void *arg, int chan);
 
 static inline int _this_high_period(uint32_t target);
 
@@ -56,7 +56,7 @@ static inline int _is_set(xtimer_t *timer)
 void xtimer_init(void)
 {
     /* initialize low-level timer */
-    timer_init(XTIMER, (1000000ul >> XTIMER_SHIFT), _periph_timer_callback);
+    timer_init(XTIMER, (1000000ul >> XTIMER_SHIFT), _periph_timer_callback, NULL);
 
     /* register initial overflow tick */
     _lltimer_set(0xFFFFFFFF);
@@ -131,8 +131,9 @@ void xtimer_set(xtimer_t *timer, uint32_t offset)
     }
 }
 
-static void _periph_timer_callback(int chan)
+static void _periph_timer_callback(void *arg, int chan)
 {
+    (void)arg;
     (void)chan;
     _timer_callback();
 }

--- a/tests/periph_timer/main.c
+++ b/tests/periph_timer/main.c
@@ -39,8 +39,9 @@ static volatile int fired;
 static volatile uint32_t sw_count;
 static volatile uint32_t timeouts[MAX_CHANNELS];
 
-static void cb(int chan)
+static void cb(void *arg, int chan)
 {
+    (void)arg;
     timeouts[chan] = sw_count;
     fired++;
 }
@@ -57,7 +58,7 @@ static int test_timer(unsigned num)
     }
 
     /* initialize and halt timer */
-    if (timer_init(TIMER_DEV(num), TIM_SPEED, cb) < 0) {
+    if (timer_init(TIMER_DEV(num), TIM_SPEED, cb, NULL) < 0) {
         printf("TIMER_%u: ERROR on initialization - skipping\n\n", num);
         return 0;
     }


### PR DESCRIPTION
The callback argument was already prepared, but not used/implemented. This PR fixes this and makes the periph timer interface behave as the other periph interfaces regarding their callbacks.