### PR TITLE
kw2xrf: wait for previous transmissions to end

### DIFF
--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -1192,6 +1192,10 @@ int kw2xrf_send(gnrc_netdev_t *netdev, gnrc_pktsnip_t *pkt)
     int index = 0;
     kw2xrf_t *dev = (kw2xrf_t *) netdev;
 
+    if ((dev->option & KW2XRF_OPT_PRELOADING) == NETOPT_DISABLE) {
+        kw2xrf_set_sequence(dev, XCVSEQ_TRANSMIT);
+    }
+
     if (pkt == NULL) {
         return -ENOMSG;
     }


### PR DESCRIPTION
I noticed that `kw2xrf` cannot handle packets that get fragmented through 6lowpan. In the current state, the driver will try to transmit packets although the state is still in transmission from previous fragments.
I am not sure whether this approach presented in this PR is the right way to go, but with this change I am able to receive packets that get fragmented and sent by the `kw2xrf` and reassambled again by the other side.

see #4822