### PR TITLE
ndp: fix NCE creation on RA reception

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -506,7 +506,7 @@ void gnrc_ndp_rtr_adv_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt, ipv6_hdr_t
     if (nc_entry == NULL) { /* not in default router list */
         /* create default router list entry */
         nc_entry = gnrc_ipv6_nc_add(iface, &ipv6->src, NULL, 0,
-                                    GNRC_IPV6_NC_IS_ROUTER);
+                                    GNRC_IPV6_NC_STATE_STALE | GNRC_IPV6_NC_IS_ROUTER);
         if (nc_entry == NULL) {
             DEBUG("ndp: error on default router list entry creation\n");
             return;


### PR DESCRIPTION
RFC4861 says: "If a Neighbor Cache entry is created for the router
[while processing route advertisements], its reachability state MUST be
set to STALE as specified in Section 7.3.3."