### PR TITLE
gnrc_icmpv6: fix debug outputs

### DIFF
--- a/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
+++ b/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
@@ -121,7 +121,7 @@ void gnrc_icmpv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *pkt)
             break;
 
         default:
-            DEBUG("icmpv6: unknown type field %" PRIu8 "\n", hdr->type);
+            DEBUG("icmpv6: unknown type field %u\n", hdr->type);
             break;
     }
 
@@ -131,7 +131,7 @@ void gnrc_icmpv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *pkt)
     sendto = gnrc_netreg_lookup(GNRC_NETTYPE_ICMPV6, hdr->type);
 
     if (sendto == NULL) {
-        DEBUG("icmpv6: no receivers for ICMPv6 type %" PRIu8 "\n", hdr->type);
+        DEBUG("icmpv6: no receivers for ICMPv6 type %u\n", hdr->type);
         /* don't release: IPv6 does this */
         return;
     }
@@ -161,7 +161,7 @@ gnrc_pktsnip_t *gnrc_icmpv6_build(gnrc_pktsnip_t *next, uint8_t type, uint8_t co
         return NULL;
     }
 
-    DEBUG("icmpv6: Building ICMPv6 message with type=%" PRIu8 ", code=%" PRIu8 "\n",
+    DEBUG("icmpv6: Building ICMPv6 message with type=%u, code=%u\n",
           type, code);
     icmpv6 = (icmpv6_hdr_t *)pkt->data;
     icmpv6->type = type;


### PR DESCRIPTION
change `PRIu8` to `%u`