### PR TITLE
stm32l1 allow open drain

### DIFF
--- a/cpu/stm32l1/include/periph_cpu.h
+++ b/cpu/stm32l1/include/periph_cpu.h
@@ -81,6 +81,21 @@ typedef enum {
 } gpio_af_t;
 
 /**
+ * @brief   Override values for pull register configuration
+ * @{
+ */
+#define HAVE_GPIO_PP_T
+typedef enum {
+    GPIO_NOPULL = 0,        /**< do not use internal pull resistors */
+    GPIO_PULLUP = 1,        /**< enable internal pull-up resistor */
+    GPIO_PULLDOWN = 2,      /**< enable internal pull-down resistor */
+    GPIO_NOPULL_OD = 4,     /**< do not use internal pull resistors (open drain) */
+    GPIO_PULLUP_OD = 5,     /**< enable internal pull-up resistor (open drain) */
+    GPIO_PULLDOWN_OD = 6    /**< enable internal pull-down resistor (open drain) */
+} gpio_pp_t;
+/** @} */
+
+/**
  * @brief   Configure the alternate function for the given pin
  *
  * @note    This is meant for internal use in STM32L1 peripheral drivers only

--- a/cpu/stm32l1/periph/gpio.c
+++ b/cpu/stm32l1/periph/gpio.c
@@ -72,12 +72,14 @@ int gpio_init(gpio_t pin, gpio_dir_t dir, gpio_pp_t pullup)
     RCC->AHBENR |= (RCC_AHBENR_GPIOAEN << _port_num(pin));
     /* configure pull register */
     port->PUPDR &= ~(3 << (2 * pin_num));
-    port->PUPDR |= (pullup << (2 * pin_num));
+    port->PUPDR |= ((pullup & 0x03) << (2 * pin_num));
     /* set direction */
     if (dir == GPIO_DIR_OUT) {
         port->MODER &= ~(3 << (2 * pin_num));   /* set pin to output mode */
         port->MODER |= (1 << (2 * pin_num));
-        port->OTYPER &= ~(1 << pin_num);        /* set to push-pull */
+        /* set to push-pull or open-drain */
+        port->OTYPER &= ~(1 << pin_num);
+        port->OTYPER |= ((pullup >> 2) << pin_num);
         port->OSPEEDR |= (3 << (2 * pin_num));  /* set to high speed */
         port->ODR &= ~(1 << pin_num);           /* set pin to low signal */
     }

--- a/cpu/stm32l1/periph/gpio.c
+++ b/cpu/stm32l1/periph/gpio.c
@@ -90,8 +90,8 @@ int gpio_init(gpio_t pin, gpio_dir_t dir, gpio_pp_t pullup)
 }
 
 int gpio_init_int(gpio_t pin,
-                   gpio_pp_t pullup, gpio_flank_t flank,
-                   gpio_cb_t cb, void *arg)
+                  gpio_pp_t pullup, gpio_flank_t flank,
+                  gpio_cb_t cb, void *arg)
 {
     int pin_num = _pin_num(pin);
     int port_num = _port_num(pin);

--- a/cpu/stm32l1/periph/i2c.c
+++ b/cpu/stm32l1/periph/i2c.c
@@ -98,9 +98,9 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
     NVIC_EnableIRQ(i2c_config[dev].er_irqn);
 
     /* configure pins */
-    gpio_init(i2c_config[dev].scl, GPIO_DIR_OUT, GPIO_PULLUP);
+    gpio_init(i2c_config[dev].scl, GPIO_DIR_OUT, GPIO_NOPULL_OD);
     gpio_init_af(i2c_config[dev].scl, i2c_config[dev].af);
-    gpio_init(i2c_config[dev].sda, GPIO_DIR_OUT, GPIO_PULLUP);
+    gpio_init(i2c_config[dev].sda, GPIO_DIR_OUT, GPIO_NOPULL_OD);
     gpio_init_af(i2c_config[dev].sda, i2c_config[dev].af);
 
     /* configure device */


### PR DESCRIPTION
The current API configuration does not allow open-drain to be configured in the GPIOs. However, the i2c needs to be configured as open-drain otherwise the output is corrupted. 

In the following image you can see the output of the pins with not configured as open-drain. This effect is also observed by [others](https://my.st.com/public/STe2ecommunities/mcu/Lists/cortex_mx_stm32/Flat.aspx?RootFolder=https%3a%2f%2fmy%2est%2ecom%2fpublic%2fSTe2ecommunities%2fmcu%2fLists%2fcortex_mx_stm32%2fSTM32L-Discovery%20communicate%20in%20I2C%20with%20M24LR64&FolderCTID=0x01200200770978C69A1141439FE559EB459D7580009C4E14902C3CDE46A77F0FFD06506F5B&currentviews=2824)
![stm32l1_opendrain](https://cloud.githubusercontent.com/assets/1437538/13183375/ebf033f0-d736-11e5-902e-463ee9932f7b.png)

The patch just extends the behaviour and does not modify the existing one.