### PR TITLE
netdev2_tap: fix strange event_callback argument

### DIFF
--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -101,7 +101,7 @@ static inline int _set_promiscous(netdev2_t *netdev, int value)
 static inline void _isr(netdev2_t *netdev)
 {
     if (netdev->event_callback) {
-        netdev->event_callback(netdev, NETDEV2_EVENT_RX_COMPLETE, (void*)NETDEV2_TYPE_ETHERNET);
+        netdev->event_callback(netdev, NETDEV2_EVENT_RX_COMPLETE, netdev->isr_arg);
     }
 #if DEVELHELP
     else {


### PR DESCRIPTION
Occurrences like this make me wonder if this value if ever checked for `NETDEV2_EVENT_RX_COMPLETE`. Some other drivers set it to `netdev->isr_arg` as this fix does, some leave it NULL.