### PR TITLE
boards/mulle: Add SAUL GPIO parameters for onboard LEDs

### DIFF
--- a/boards/mulle/Makefile.dep
+++ b/boards/mulle/Makefile.dep
@@ -13,3 +13,7 @@ FEATURES_REQUIRED += periph_rtt
 # The Mulle uses NVRAM to store persistent variables, such as boot count.
 USEMODULE += nvram_spi
 FEATURES_REQUIRED += periph_spi
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/mulle/include/gpio_params.h
+++ b/boards/mulle/include/gpio_params.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_mulle
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED(yellow)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED(green)",
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */


### PR DESCRIPTION
Adds configuration for SAUL to use the onboard LEDs, similar to what is configured on iotlab-m3.

Untested on actual hardware, I will test the configuration tomorrow or monday when I have a mulle board nearby.