### PR TITLE
stm32f3: periph: uart: add misssing uart overrun handling

### DIFF
--- a/cpu/stm32f3/periph/uart.c
+++ b/cpu/stm32f3/periph/uart.c
@@ -190,6 +190,10 @@ static inline void irq_handler(uint8_t uartnum, USART_TypeDef *dev)
         char data = (char)dev->RDR;
         uart_config[uartnum].rx_cb(uart_config[uartnum].arg, data);
     }
+    else if (dev->ISR & USART_ISR_ORE) {
+        /* do nothing on overrun */
+        dev->ICR |= USART_ICR_ORECF;
+    }
     if (sched_context_switch_request) {
         thread_yield();
     }


### PR DESCRIPTION
On overrung the ORE bit in the ORECF register is set.
An overrun error occurs when a character is received when RXNE has not been reset. Data
can not be transferred from the shift register to the RDR register until the RXNE bit is
cleared. The ORE bit is reset by setting the ORECF bit in the ICR register.

In case the ORE bit isn't cleared, the isr_handler() routine is called
continuously. Which prevents the system from normal scheduling.