### PR TITLE
drivers/kw2xrf: use NETOPT_STATE_RX for rcv

### DIFF
--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -193,7 +193,7 @@ void kw2xrf_set_sequence(kw2xrf_t *dev, kw2xrf_physeq_t seq)
             break;
 
         case XCVSEQ_RECEIVE:
-            dev->state = NETOPT_STATE_IDLE;
+            dev->state = NETOPT_STATE_RX;
             break;
 
         case XCVSEQ_TRANSMIT:


### PR DESCRIPTION
Just a minor bug that I encountered while looking at the code. I don't think that it had a big impact before, though.