### PR TITLE
ipv6_addr: optimize for size

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -200,7 +200,6 @@ void gnrc_ipv6_netif_add(kernel_pid_t pid)
 
     /* Otherwise, fill the free entry */
 
-    ipv6_addr_t addr = IPV6_ADDR_ALL_NODES_LINK_LOCAL;
     mutex_lock(&free_entry->mutex);
 
     DEBUG("ipv6 netif: Add IPv6 interface %" PRIkernel_pid " (i = %d)\n", pid,
@@ -210,7 +209,8 @@ void gnrc_ipv6_netif_add(kernel_pid_t pid)
     free_entry->cur_hl = GNRC_IPV6_NETIF_DEFAULT_HL;
     free_entry->flags = 0;
 
-    _add_addr_to_entry(free_entry, &addr, IPV6_ADDR_BIT_LEN, 0);
+    _add_addr_to_entry(free_entry, &ipv6_addr_all_nodes_link_local,
+                       IPV6_ADDR_BIT_LEN, 0);
 
     mutex_unlock(&free_entry->mutex);
 

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -307,11 +307,12 @@ void gnrc_ndp_internal_send_nbr_sol(kernel_pid_t iface, ipv6_addr_t *src, ipv6_a
 void gnrc_ndp_internal_send_rtr_sol(kernel_pid_t iface, ipv6_addr_t *dst)
 {
     gnrc_pktsnip_t *hdr, *pkt = NULL;
-    ipv6_addr_t *src = NULL, all_routers = IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL;
+    ipv6_addr_t *src = NULL;
     DEBUG("ndp internal: send router solicitation (iface: %" PRIkernel_pid ", dst: ff02::2)\n",
           iface);
     if (dst == NULL) {
-        dst = &all_routers;
+        /* isn't changed afterwards so discarding const should be alright */
+        dst = (ipv6_addr_t *)&ipv6_addr_all_routers_link_local;
     }
     /* check if there is a fitting source address to target */
     if ((src = gnrc_ipv6_netif_find_best_src_addr(iface, dst)) != NULL) {
@@ -422,14 +423,14 @@ void gnrc_ndp_internal_send_rtr_adv(kernel_pid_t iface, ipv6_addr_t *src, ipv6_a
                                     bool fin)
 {
     gnrc_pktsnip_t *hdr = NULL, *pkt = NULL;
-    ipv6_addr_t all_nodes = IPV6_ADDR_ALL_NODES_LINK_LOCAL;
     gnrc_ipv6_netif_t *ipv6_iface = gnrc_ipv6_netif_get(iface);
     uint32_t reach_time = 0, retrans_timer = 0;
     uint16_t adv_ltime = 0;
     uint8_t cur_hl = 0;
 
     if (dst == NULL) {
-        dst = &all_nodes;
+        /* isn't changed afterwards so discarding const should be fine */
+        dst = (ipv6_addr_t *)&ipv6_addr_all_nodes_link_local;
     }
     DEBUG("ndp internal: send router advertisement (iface: %" PRIkernel_pid ", dst: %s%s\n",
           iface, ipv6_addr_to_str(addr_str, dst, sizeof(addr_str)), fin ? ", final" : "");

--- a/sys/net/gnrc/network_layer/ndp/router/gnrc_ndp_router.c
+++ b/sys/net/gnrc/network_layer/ndp/router/gnrc_ndp_router.c
@@ -27,10 +27,9 @@ static void _send_rtr_adv(gnrc_ipv6_netif_t *iface, ipv6_addr_t *dst);
 
 void gnrc_ndp_router_set_router(gnrc_ipv6_netif_t *iface, bool enable)
 {
-    ipv6_addr_t all_routers = IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL;
     if (enable && !(iface->flags & GNRC_IPV6_NETIF_FLAGS_ROUTER)) {
-        gnrc_ipv6_netif_add_addr(iface->pid, &all_routers, 128,
-                                 GNRC_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST);
+        gnrc_ipv6_netif_add_addr(iface->pid, &ipv6_addr_all_routers_link_local,
+                                 128, GNRC_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST);
         mutex_lock(&iface->mutex);
         iface->flags |= GNRC_IPV6_NETIF_FLAGS_ROUTER;
         iface->max_adv_int = GNRC_IPV6_NETIF_DEFAULT_MAX_ADV_INT;
@@ -40,7 +39,7 @@ void gnrc_ndp_router_set_router(gnrc_ipv6_netif_t *iface, bool enable)
         gnrc_ndp_router_set_rtr_adv(iface, enable);
     }
     else if (!enable && (iface->flags & GNRC_IPV6_NETIF_FLAGS_ROUTER)) {
-        gnrc_ipv6_netif_remove_addr(iface->pid, &all_routers);
+        gnrc_ipv6_netif_remove_addr(iface->pid, (ipv6_addr_t *)&ipv6_addr_all_routers_link_local);
         gnrc_ndp_router_set_rtr_adv(iface, enable);
     }
 }

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/router/gnrc_sixlowpan_nd_router.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/router/gnrc_sixlowpan_nd_router.c
@@ -112,9 +112,7 @@ static inline bool _is_me(ipv6_addr_t *addr)
 
 void gnrc_sixlowpan_nd_router_set_rtr_adv(gnrc_ipv6_netif_t *netif, bool enable)
 {
-    ipv6_addr_t all_routers = IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL;
-
-    if (enable && (gnrc_ipv6_netif_add_addr(netif->pid, &all_routers, 128,
+    if (enable && (gnrc_ipv6_netif_add_addr(netif->pid, &ipv6_addr_all_routers_link_local, 128,
                                             GNRC_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST) != NULL)) {
         mutex_lock(&netif->mutex);
         netif->flags |= GNRC_IPV6_NETIF_FLAGS_RTR_ADV;
@@ -128,7 +126,7 @@ void gnrc_sixlowpan_nd_router_set_rtr_adv(gnrc_ipv6_netif_t *netif, bool enable)
     }
     else {
         netif->flags &= ~GNRC_IPV6_NETIF_FLAGS_RTR_ADV;
-        gnrc_ipv6_netif_remove_addr(netif->pid, &all_routers);
+        gnrc_ipv6_netif_remove_addr(netif->pid, (ipv6_addr_t *)&ipv6_addr_all_routers_link_local);
     }
 }
 

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr.c
@@ -26,6 +26,16 @@
 #include <stdio.h>
 #endif
 
+const ipv6_addr_t ipv6_addr_unspecified = IPV6_ADDR_UNSPECIFIED;
+const ipv6_addr_t ipv6_addr_loopback = IPV6_ADDR_LOOPBACK;
+const ipv6_addr_t ipv6_addr_link_local_prefix = IPV6_ADDR_LINK_LOCAL_PREFIX;
+const ipv6_addr_t ipv6_addr_solicited_node_prefix = IPV6_ADDR_SOLICITED_NODE_PREFIX;
+const ipv6_addr_t ipv6_addr_all_nodes_if_local = IPV6_ADDR_ALL_NODES_IF_LOCAL;
+const ipv6_addr_t ipv6_addr_all_nodes_link_local = IPV6_ADDR_ALL_NODES_LINK_LOCAL;
+const ipv6_addr_t ipv6_addr_all_routers_if_local = IPV6_ADDR_ALL_ROUTERS_IF_LOCAL;
+const ipv6_addr_t ipv6_addr_all_routers_link_local = IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL;
+const ipv6_addr_t ipv6_addr_all_routers_site_local = IPV6_ADDR_ALL_ROUTERS_SITE_LOCAL;
+
 bool ipv6_addr_equal(const ipv6_addr_t *a, const ipv6_addr_t *b)
 {
     return (a->u64[0].u64 == b->u64[0].u64) &&


### PR DESCRIPTION
Here is an interesting one:

```
text    data    bss     dec     BOARD/BINDIRBASE

56      0       0       56      arduino-due
58308   224     19896   78428   master-bin
58364   224     19896   78484   ipv6_addr-opt-bin

-90     16      0       -74     arduino-mega2560
81508   11194   13751   106453  master-bin
81418   11210   13751   106379  ipv6_addr-opt-bin

-1648   0       0       -1648   avsextrem
87996   220     98077   186293  master-bin
86348   220     98077   184645  ipv6_addr-opt-bin

56      0       0       56      cc2538dk
58236   220     19872   78328   master-bin
58292   220     19872   78384   ipv6_addr-opt-bin

48      0       0       48      ek-lm4f120xl
58576   220     19872   78668   master-bin
58624   220     19872   78716   ipv6_addr-opt-bin

48      0       0       48      f4vi1
60260   224     20008   80492   master-bin
60308   224     20008   80540   ipv6_addr-opt-bin

-168    0       0       -168    fox
73824   220     22968   97012   master-bin
73656   220     22968   96844   ipv6_addr-opt-bin

64      0       0       64      frdm-k64f
58280   1248    19864   79392   master-bin
58344   1248    19864   79456   ipv6_addr-opt-bin

-168    0       0       -168    iotlab-m3
73564   220     22968   96752   master-bin
73396   220     22968   96584   ipv6_addr-opt-bin

56      0       0       56      limifrog-v1
59448   220     20000   79668   master-bin
59504   220     20000   79724   ipv6_addr-opt-bin

56      0       0       56      mbed_lpc1768
57912   220     19872   78004   master-bin
57968   220     19872   78060   ipv6_addr-opt-bin

-2284   0       0       -2284   msba2
110704  220     98077   209001  master-bin
108420  220     98077   206717  ipv6_addr-opt-bin

48      0       0       48      msbiot
60572   224     20056   80852   master-bin
60620   224     20056   80900   ipv6_addr-opt-bin

-144    0       0       -144    mulle
76468   1284    23248   101000  master-bin
76324   1284    23248   100856  ipv6_addr-opt-bin

-1988   0       0       -1988   native
197574  624     105560  303758  master-bin
195586  624     105560  301770  ipv6_addr-opt-bin

48      0       0       48      nrf52dk
58032   220     19864   78116   master-bin
58080   220     19864   78164   ipv6_addr-opt-bin

-1336   0       0       -1336   nucleo-f091
60860   220     19872   80952   master-bin
59524   220     19872   79616   ipv6_addr-opt-bin

48      0       0       48      nucleo-f303
58448   220     19880   78548   master-bin
58496   220     19880   78596   ipv6_addr-opt-bin

48      0       0       48      nucleo-f401
60260   224     20008   80492   master-bin
60308   224     20008   80540   ipv6_addr-opt-bin

56      0       0       56      nucleo-l1
59332   220     19992   79544   master-bin
59388   220     19992   79600   ipv6_addr-opt-bin

56      0       0       56      openmote-cc2538
58144   220     19872   78236   master-bin
58200   220     19872   78292   ipv6_addr-opt-bin

-160    0       0       -160    pba-d-01-kw2x
75752   1248    23304   100304  master-bin
75592   1248    23304   100144  ipv6_addr-opt-bin

-1648   0       0       -1648   pttu
88204   220     98077   186501  master-bin
86556   220     98077   184853  ipv6_addr-opt-bin

56      0       0       56      remote
58820   220     19872   78912   master-bin
58876   220     19872   78968   ipv6_addr-opt-bin

-1336   0       0       -1336   saml21-xpro
61048   220     19992   81260   master-bin
59712   220     19992   79924   ipv6_addr-opt-bin

-1956   0       0       -1956   samr21-xpro
77960   220     22984   101164  master-bin
76004   220     22984   99208   ipv6_addr-opt-bin

48      0       0       48      slwstk6220a
58092   220     20000   78312   master-bin
58140   220     20000   78360   ipv6_addr-opt-bin

48      0       0       48      stm32f3discovery
58464   220     19880   78564   master-bin
58512   220     19880   78612   ipv6_addr-opt-bin

48      0       0       48      stm32f4discovery
60504   224     20032   80760   master-bin
60552   224     20032   80808   ipv6_addr-opt-bin

56      0       0       56      udoo
58308   224     19896   78428   master-bin
58364   224     19896   78484   ipv6_addr-opt-bin
```

On some boards it goes up a little on some it goes down significantly.

I checked the size on `samr21-xpro` with each optimization step to make sure every step there was an optimization.