### PR TITLE
drivers: netdev2: remove netdev2 event_callback isr_arg

### DIFF
--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -98,7 +98,7 @@ static inline int _set_promiscous(netdev2_t *netdev, int value)
 static inline void _isr(netdev2_t *netdev)
 {
     if (netdev->event_callback) {
-        netdev->event_callback(netdev, NETDEV2_EVENT_RX_COMPLETE, NULL);
+        netdev->event_callback(netdev, NETDEV2_EVENT_RX_COMPLETE);
     }
 #if DEVELHELP
     else {
@@ -297,7 +297,7 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, int n)
     netdev->stats.tx_bytes += bytes;
 #endif
     if (netdev->event_callback) {
-        netdev->event_callback(netdev, NETDEV2_EVENT_TX_COMPLETE, NULL);
+        netdev->event_callback(netdev, NETDEV2_EVENT_TX_COMPLETE);
     }
     return res;
 }
@@ -313,7 +313,7 @@ static void _tap_isr(int fd) {
     netdev2_t *netdev = (netdev2_t *)&netdev2_tap;
 
     if (netdev->event_callback) {
-        netdev->event_callback(netdev, NETDEV2_EVENT_ISR, netdev->isr_arg);
+        netdev->event_callback(netdev, NETDEV2_EVENT_ISR);
     }
     else {
         puts("netdev2_tap: _isr: no event callback.");

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -218,6 +218,6 @@ void at86rf2xx_tx_exec(at86rf2xx_t *dev)
                         AT86RF2XX_TRX_STATE__TX_START);
     if (netdev->event_callback &&
         (dev->netdev.flags & AT86RF2XX_OPT_TELL_TX_START)) {
-        netdev->event_callback(netdev, NETDEV2_EVENT_TX_STARTED, NULL);
+        netdev->event_callback(netdev, NETDEV2_EVENT_TX_STARTED);
     }
 }

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -61,7 +61,7 @@ static void _irq_handler(void *arg)
     netdev2_t *dev = (netdev2_t *) arg;
 
     if (dev->event_callback) {
-        dev->event_callback(dev, NETDEV2_EVENT_ISR, NULL);
+        dev->event_callback(dev, NETDEV2_EVENT_ISR);
     }
 }
 
@@ -606,7 +606,7 @@ static void _isr(netdev2_t *netdev)
                   AT86RF2XX_TRX_STATE_MASK__TRAC;
 
     if (irq_mask & AT86RF2XX_IRQ_STATUS_MASK__RX_START) {
-        netdev->event_callback(netdev, NETDEV2_EVENT_RX_STARTED, NULL);
+        netdev->event_callback(netdev, NETDEV2_EVENT_RX_STARTED);
         DEBUG("[at86rf2xx] EVT - RX_START\n");
     }
 
@@ -617,7 +617,7 @@ static void _isr(netdev2_t *netdev)
             if (!(dev->netdev.flags & AT86RF2XX_OPT_TELL_RX_END)) {
                 return;
             }
-            netdev->event_callback(netdev, NETDEV2_EVENT_RX_COMPLETE, NULL);
+            netdev->event_callback(netdev, NETDEV2_EVENT_RX_COMPLETE);
         }
         else if (state == AT86RF2XX_STATE_TX_ARET_ON ||
                  state == AT86RF2XX_STATE_BUSY_TX_ARET) {
@@ -635,15 +635,15 @@ static void _isr(netdev2_t *netdev)
                 switch (trac_status) {
                     case AT86RF2XX_TRX_STATE__TRAC_SUCCESS:
                     case AT86RF2XX_TRX_STATE__TRAC_SUCCESS_DATA_PENDING:
-                        netdev->event_callback(netdev, NETDEV2_EVENT_TX_COMPLETE, NULL);
+                        netdev->event_callback(netdev, NETDEV2_EVENT_TX_COMPLETE);
                         DEBUG("[at86rf2xx] TX SUCCESS\n");
                         break;
                     case AT86RF2XX_TRX_STATE__TRAC_NO_ACK:
-                        netdev->event_callback(netdev, NETDEV2_EVENT_TX_NOACK, NULL);
+                        netdev->event_callback(netdev, NETDEV2_EVENT_TX_NOACK);
                         DEBUG("[at86rf2xx] TX NO_ACK\n");
                         break;
                     case AT86RF2XX_TRX_STATE__TRAC_CHANNEL_ACCESS_FAILURE:
-                        netdev->event_callback(netdev, NETDEV2_EVENT_TX_MEDIUM_BUSY, NULL);
+                        netdev->event_callback(netdev, NETDEV2_EVENT_TX_MEDIUM_BUSY);
                         DEBUG("[at86rf2xx] TX_CHANNEL_ACCESS_FAILURE\n");
                         break;
                     default:

--- a/drivers/cc110x/cc110x-netdev2.c
+++ b/drivers/cc110x/cc110x-netdev2.c
@@ -164,7 +164,7 @@ static int _set(netdev2_t *dev, netopt_t opt, void *value, size_t value_len)
 static void _netdev2_cc110x_isr(void *arg)
 {
     netdev2_t *netdev2 = (netdev2_t*) arg;
-    netdev2->event_callback(netdev2, NETDEV2_EVENT_ISR, netdev2->isr_arg);
+    netdev2->event_callback(netdev2, NETDEV2_EVENT_ISR);
 }
 
 static void _netdev2_cc110x_rx_callback(void *arg)
@@ -172,7 +172,7 @@ static void _netdev2_cc110x_rx_callback(void *arg)
     netdev2_t *netdev2 = (netdev2_t*) arg;
     cc110x_t *cc110x = &((netdev2_cc110x_t*) arg)->cc110x;
     gpio_irq_disable(cc110x->params.gdo2);
-    netdev2->event_callback(netdev2, NETDEV2_EVENT_RX_COMPLETE, NULL);
+    netdev2->event_callback(netdev2, NETDEV2_EVENT_RX_COMPLETE);
 }
 
 static void _isr(netdev2_t *dev)

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -216,7 +216,7 @@ static void mac_set(enc28j60_t *dev, uint8_t *mac)
 static void on_int(void *arg)
 {
     netdev2_t *netdev = (netdev2_t *)arg;
-    netdev->event_callback(arg, NETDEV2_EVENT_ISR, netdev->isr_arg);
+    netdev->event_callback(arg, NETDEV2_EVENT_ISR);
 }
 
 static int nd_send(netdev2_t *netdev, const struct iovec *data, int count)
@@ -400,17 +400,17 @@ static void nd_isr(netdev2_t *netdev)
             /* go and tell the new link layer state to upper layers */
             if (cmd_r_phy(dev, REG_PHY_PHSTAT2) & PHSTAT2_LSTAT) {
                 DEBUG("[enc28j60] isr: link up!\n");
-                netdev->event_callback(netdev, NETDEV2_EVENT_LINK_UP, NULL);
+                netdev->event_callback(netdev, NETDEV2_EVENT_LINK_UP);
             }
             else {
                 DEBUG("[enc28j60] isr: link down!\n");
-                netdev->event_callback(netdev, NETDEV2_EVENT_LINK_DOWN, NULL);
+                netdev->event_callback(netdev, NETDEV2_EVENT_LINK_DOWN);
             }
         }
         if (eir & EIR_PKTIF) {
             do {
                 DEBUG("[enc28j60] isr: packet received\n");
-                netdev->event_callback(netdev, NETDEV2_EVENT_RX_COMPLETE, NULL);
+                netdev->event_callback(netdev, NETDEV2_EVENT_RX_COMPLETE);
             } while (cmd_rcr(dev, REG_B1_EPKTCNT, 1) > 0);
         }
         if (eir & EIR_RXERIF) {
@@ -419,7 +419,7 @@ static void nd_isr(netdev2_t *netdev)
         }
         if (eir & EIR_TXIF) {
             DEBUG("[enc28j60] isr: packet transmitted\n");
-            netdev->event_callback(netdev, NETDEV2_EVENT_TX_COMPLETE, NULL);
+            netdev->event_callback(netdev, NETDEV2_EVENT_TX_COMPLETE);
             cmd_bfc(dev, REG_EIR, -1, EIR_TXIF);
         }
         if (eir & EIR_TXERIF) {

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -96,13 +96,12 @@ void encx24j600_setup(encx24j600_t *dev, const encx24j600_params_t *params)
 static void encx24j600_isr(void *arg)
 {
     encx24j600_t *dev = (encx24j600_t *) arg;
-    netdev2_t *netdev = (netdev2_t *) arg;
 
     /* disable interrupt line */
     gpio_irq_disable(dev->int_pin);
 
     /* call netdev2 hook */
-    dev->netdev.event_callback((netdev2_t*) dev, NETDEV2_EVENT_ISR, netdev->isr_arg);
+    dev->netdev.event_callback((netdev2_t*) dev, NETDEV2_EVENT_ISR);
 }
 
 static void _isr(netdev2_t *netdev)
@@ -124,15 +123,14 @@ static void _isr(netdev2_t *netdev)
             NETDEV2_EVENT_LINK_DOWN :
             NETDEV2_EVENT_LINK_UP;
 
-        netdev->event_callback(netdev, event, NULL);
+        netdev->event_callback(netdev, event);
     }
 
     /* check & handle available packets */
     if (eir & ENC_PKTIF) {
         while (_packets_available(dev)) {
             unlock(dev);
-            netdev->event_callback(netdev, NETDEV2_EVENT_RX_COMPLETE,
-                    NULL);
+            netdev->event_callback(netdev, NETDEV2_EVENT_RX_COMPLETE);
             lock(dev);
         }
     }

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -111,7 +111,7 @@ static void _end_of_frame(ethos_t *dev)
         case ETHOS_FRAME_TYPE_DATA:
             if (dev->framesize) {
                 dev->last_framesize = dev->framesize;
-                dev->netdev.event_callback((netdev2_t*) dev, NETDEV2_EVENT_ISR, dev->netdev.isr_arg);
+                dev->netdev.event_callback((netdev2_t*) dev, NETDEV2_EVENT_ISR);
             }
             break;
         case ETHOS_FRAME_TYPE_HELLO:
@@ -177,7 +177,7 @@ static void ethos_isr(void *arg, uint8_t c)
 static void _isr(netdev2_t *netdev)
 {
     ethos_t *dev = (ethos_t *) netdev;
-    dev->netdev.event_callback((netdev2_t*) dev, NETDEV2_EVENT_RX_COMPLETE, NULL);
+    dev->netdev.event_callback((netdev2_t*) dev, NETDEV2_EVENT_RX_COMPLETE);
 }
 
 static int _init(netdev2_t *encdev)

--- a/drivers/include/net/netdev2.h
+++ b/drivers/include/net/netdev2.h
@@ -93,9 +93,8 @@ typedef struct netdev2 netdev2_t;
  * @brief   Event callback for signaling event to upper layers
  *
  * @param[in] type          type of the event
- * @param[in] arg           event argument
  */
-typedef void (*netdev2_event_cb_t)(netdev2_t *dev, netdev2_event_t event, void *arg);
+typedef void (*netdev2_event_cb_t)(netdev2_t *dev, netdev2_event_t event);
 
 /**
  * @brief Structure to hold driver state

--- a/drivers/include/net/netdev2.h
+++ b/drivers/include/net/netdev2.h
@@ -101,11 +101,14 @@ typedef void (*netdev2_event_cb_t)(netdev2_t *dev, netdev2_event_t event);
  *
  * Supposed to be extended by driver implementations.
  * The extended structure should contain all variable driver state.
+ *
+ * Contains a field @p context which is not used by the drivers, but supposed to
+ * be used by upper layers to store reference information.
  */
 struct netdev2 {
     const struct netdev2_driver *driver;    /**< ptr to that driver's interface. */
     netdev2_event_cb_t event_callback;      /**< callback for device events */
-    void *isr_arg;                          /**< argument to pass on isr event */
+    void* context;                          /**< ptr to network stack context */
 #ifdef MODULE_NETSTATS_L2
     netstats_t stats;                       /**< transceiver's statistics */
 #endif

--- a/pkg/emb6/contrib/netdev2/emb6_netdev2.c
+++ b/pkg/emb6/contrib/netdev2/emb6_netdev2.c
@@ -80,9 +80,8 @@ static void _get_recv_pkt(void)
     }
 }
 
-static void _event_cb(netdev2_t *dev, netdev2_event_t event, void *arg)
+static void _event_cb(netdev2_t *dev, netdev2_event_t event)
 {
-    (void)arg;
     if (event == NETDEV2_EVENT_ISR) {
         /* EVENT_TYPE_PCK_LL is supposed to be used by drivers, so use it
          * (though NETDEV2_EVENT_ISR technically doesn't only signify

--- a/pkg/lwip/contrib/netdev2/lwip_netdev2.c
+++ b/pkg/lwip/contrib/netdev2/lwip_netdev2.c
@@ -57,7 +57,7 @@ static err_t _eth_link_output(struct netif *netif, struct pbuf *p);
 #ifdef MODULE_LWIP_SIXLOWPAN
 static err_t _ieee802154_link_output(struct netif *netif, struct pbuf *p);
 #endif
-static void _event_cb(netdev2_t *dev, netdev2_event_t event, void *arg);
+static void _event_cb(netdev2_t *dev, netdev2_event_t event);
 static void *_event_loop(void *arg);
 
 err_t lwip_netdev2_init(struct netif *netif)
@@ -209,9 +209,8 @@ static struct pbuf *_get_recv_pkt(netdev2_t *dev)
     return p;
 }
 
-static void _event_cb(netdev2_t *dev, netdev2_event_t event, void *arg)
+static void _event_cb(netdev2_t *dev, netdev2_event_t event)
 {
-    (void)arg;
     if (event == NETDEV2_EVENT_ISR) {
         assert(_pid != KERNEL_PID_UNDEF);
         msg_t msg;

--- a/pkg/lwip/contrib/netdev2/lwip_netdev2.c
+++ b/pkg/lwip/contrib/netdev2/lwip_netdev2.c
@@ -148,7 +148,7 @@ err_t lwip_netdev2_init(struct netif *netif)
     netif->flags |= NETIF_FLAG_LINK_UP;
     netif->flags |= NETIF_FLAG_IGMP;
     netif->flags |= NETIF_FLAG_MLD6;
-    netdev->isr_arg = netif;
+    netdev->context = netif;
     netdev->event_callback = _event_cb;
 #if LWIP_IPV6_AUTOCONFIG
     netif->ip6_autoconfig_enabled = 1;
@@ -224,7 +224,7 @@ static void _event_cb(netdev2_t *dev, netdev2_event_t event, void *arg)
         }
     }
     else {
-        struct netif *netif = dev->isr_arg;
+        struct netif *netif = dev->context;
         switch (event) {
             case NETDEV2_EVENT_RX_COMPLETE: {
                 struct pbuf *p = _get_recv_pkt(dev);

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
@@ -45,11 +45,9 @@ static void _pass_on_packet(gnrc_pktsnip_t *pkt);
  * @brief   Function called by the device driver on device events
  *
  * @param[in] event     type of event
- * @param[in] data      optional parameter
  */
-static void _event_cb(netdev2_t *dev, netdev2_event_t event, void *data)
+static void _event_cb(netdev2_t *dev, netdev2_event_t event)
 {
-    (void) data;
     gnrc_netdev2_t *gnrc_netdev2 = (gnrc_netdev2_t*) dev->isr_arg;
 
     if (event == NETDEV2_EVENT_ISR) {

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
@@ -48,7 +48,7 @@ static void _pass_on_packet(gnrc_pktsnip_t *pkt);
  */
 static void _event_cb(netdev2_t *dev, netdev2_event_t event)
 {
-    gnrc_netdev2_t *gnrc_netdev2 = (gnrc_netdev2_t*) dev->isr_arg;
+    gnrc_netdev2_t *gnrc_netdev2 = (gnrc_netdev2_t*) dev->context;
 
     if (event == NETDEV2_EVENT_ISR) {
         msg_t msg;
@@ -122,7 +122,7 @@ static void *_gnrc_netdev2_thread(void *args)
 
     /* register the event callback with the device driver */
     dev->event_callback = _event_cb;
-    dev->isr_arg = (void*) gnrc_netdev2;
+    dev->context = (void*) gnrc_netdev2;
 
     /* register the device to the network stack*/
     gnrc_netif_add(thread_getpid());

--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -42,10 +42,8 @@ static const shell_command_t shell_commands[] = {
     { NULL, NULL, NULL }
 };
 
-static void _event_cb(netdev2_t *dev, netdev2_event_t event, void *data)
+static void _event_cb(netdev2_t *dev, netdev2_event_t event)
 {
-    (void) data;
-
     if (event == NETDEV2_EVENT_ISR) {
         msg_t msg;
 

--- a/tests/netdev2_test/main.c
+++ b/tests/netdev2_test/main.c
@@ -153,8 +153,7 @@ static int test_receive(void)
     /* register for GNRC_NETTYPE_UNDEF */
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &me);
     /* fire ISR event */
-    _dev.netdev.event_callback((netdev2_t *)&_dev.netdev, NETDEV2_EVENT_ISR,
-                               &_dev.netdev.isr_arg);
+    _dev.netdev.event_callback((netdev2_t *)&_dev.netdev, NETDEV2_EVENT_ISR);
     /* wait for packet from MAC layer*/
     msg_receive(&msg);
     /* check message */
@@ -289,7 +288,7 @@ static void _dev_isr(netdev2_t *dev)
 {
     (void)dev;
     if (dev->event_callback) {
-        dev->event_callback(dev, NETDEV2_EVENT_RX_COMPLETE, dev->isr_arg);
+        dev->event_callback(dev, NETDEV2_EVENT_RX_COMPLETE);
     }
 }
 


### PR DESCRIPTION
See #4864.

This PR removes event_callback's extra argument, as it is currently completely unused.

PR marked WIP as I didn't test yet, let's discuss first if we need the argument.