### PR TITLE
boards/cc2538dk: autodetect PORT_LINUX.

### DIFF
--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -3,7 +3,7 @@ export CPU        = cc2538
 export CPU_MODEL ?= cc2538nf53
 
 # setup serial terminal
-export PORT      ?= /dev/ttyUSB1
+PORT_LINUX ?= $(firstword $(wildcard /dev/serial/by-id/*XDS100v3*if01* /dev/ttyUSB1))
 include $(RIOTBOARD)/Makefile.include.serial
 
 # debugger config


### PR DESCRIPTION
First it looks in `/dev/serial/by-id/` for a matching id, for example `pci-TI_Texas_Instruments_XDS100v3_06EB1210090F-if01-port0`. Then falls back on `/dev/ttyUSB1`, if it exists, then falls back on any `/dev/ttyUSB*`. Tested on Ubuntu 15.10.
