### PR TITLE
cpu/cc2538/periph/timer overhaul

### DIFF
--- a/boards/cc2538dk/include/board.h
+++ b/boards/cc2538dk/include/board.h
@@ -73,6 +73,17 @@ extern "C" {
 /** @} */
 
 /**
+ * @name xtimer configuration
+ * @{
+ */
+#define XTIMER              TIMER_0
+#define XTIMER_CHAN         0
+#define XTIMER_SHIFT        -4
+#define XTIMER_BACKOFF      50
+#define XTIMER_ISR_BACKOFF  40
+/** @} */
+
+/**
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);

--- a/boards/cc2538dk/include/board.h
+++ b/boards/cc2538dk/include/board.h
@@ -77,10 +77,10 @@ extern "C" {
  * @{
  */
 #define XTIMER              TIMER_0
-#define XTIMER_CHAN         0
-#define XTIMER_SHIFT        -4
-#define XTIMER_BACKOFF      50
-#define XTIMER_ISR_BACKOFF  40
+#define XTIMER_CHAN         (0)
+#define XTIMER_SHIFT        (-4)
+#define XTIMER_BACKOFF      (50)
+#define XTIMER_ISR_BACKOFF  (40)
 /** @} */
 
 /**

--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -39,7 +39,7 @@ extern "C" {
 
 /* Timer 0 configuration */
 #define TIMER_0_DEV         GPTIMER0
-#define TIMER_0_CHANNELS    NUM_CHANNELS_PER_GPTIMER
+#define TIMER_0_CHANNELS    1
 #define TIMER_0_MAX_VALUE   0xffffffff
 #define TIMER_0_IRQn_1      GPTIMER_0A_IRQn
 #define TIMER_0_IRQn_2      GPTIMER_0B_IRQn
@@ -48,7 +48,7 @@ extern "C" {
 
 /* Timer 1 configuration */
 #define TIMER_1_DEV         GPTIMER1
-#define TIMER_1_CHANNELS    NUM_CHANNELS_PER_GPTIMER
+#define TIMER_1_CHANNELS    1
 #define TIMER_1_MAX_VALUE   0xffffffff
 #define TIMER_1_IRQn_1      GPTIMER_1A_IRQn
 #define TIMER_1_IRQn_2      GPTIMER_1B_IRQn
@@ -57,7 +57,7 @@ extern "C" {
 
 /* Timer 2 configuration */
 #define TIMER_2_DEV         GPTIMER2
-#define TIMER_2_CHANNELS    NUM_CHANNELS_PER_GPTIMER
+#define TIMER_2_CHANNELS    1
 #define TIMER_2_MAX_VALUE   0xffffffff
 #define TIMER_2_IRQn_1      GPTIMER_2A_IRQn
 #define TIMER_2_IRQn_2      GPTIMER_2B_IRQn
@@ -66,7 +66,7 @@ extern "C" {
 
 /* Timer 3 configuration */
 #define TIMER_3_DEV         GPTIMER3
-#define TIMER_3_CHANNELS    NUM_CHANNELS_PER_GPTIMER
+#define TIMER_3_CHANNELS    1
 #define TIMER_3_MAX_VALUE   0xffffffff
 #define TIMER_3_IRQn_1      GPTIMER_3A_IRQn
 #define TIMER_3_IRQn_2      GPTIMER_3B_IRQn

--- a/boards/openmote-cc2538/include/board.h
+++ b/boards/openmote-cc2538/include/board.h
@@ -61,6 +61,17 @@
 /** @} */
 
 /**
+ * @name xtimer configuration
+ * @{
+ */
+#define XTIMER              TIMER_0
+#define XTIMER_CHAN         0
+#define XTIMER_SHIFT        -4
+#define XTIMER_BACKOFF      50
+#define XTIMER_ISR_BACKOFF  40
+/** @} */
+
+/**
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);

--- a/boards/openmote-cc2538/include/board.h
+++ b/boards/openmote-cc2538/include/board.h
@@ -65,10 +65,10 @@
  * @{
  */
 #define XTIMER              TIMER_0
-#define XTIMER_CHAN         0
-#define XTIMER_SHIFT        -4
-#define XTIMER_BACKOFF      50
-#define XTIMER_ISR_BACKOFF  40
+#define XTIMER_CHAN         (0)
+#define XTIMER_SHIFT        (-4)
+#define XTIMER_BACKOFF      (50)
+#define XTIMER_ISR_BACKOFF  (40)
 /** @} */
 
 /**

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -43,7 +43,7 @@
 
 /* Timer 0 configuration */
 #define TIMER_0_DEV         GPTIMER0
-#define TIMER_0_CHANNELS    NUM_CHANNELS_PER_GPTIMER
+#define TIMER_0_CHANNELS    1
 #define TIMER_0_MAX_VALUE   0xffffffff
 #define TIMER_0_IRQn_1      GPTIMER_0A_IRQn
 #define TIMER_0_IRQn_2      GPTIMER_0B_IRQn
@@ -52,7 +52,7 @@
 
 /* Timer 1 configuration */
 #define TIMER_1_DEV         GPTIMER1
-#define TIMER_1_CHANNELS    NUM_CHANNELS_PER_GPTIMER
+#define TIMER_1_CHANNELS    1
 #define TIMER_1_MAX_VALUE   0xffffffff
 #define TIMER_1_IRQn_1      GPTIMER_1A_IRQn
 #define TIMER_1_IRQn_2      GPTIMER_1B_IRQn
@@ -61,7 +61,7 @@
 
 /* Timer 2 configuration */
 #define TIMER_2_DEV         GPTIMER2
-#define TIMER_2_CHANNELS    NUM_CHANNELS_PER_GPTIMER
+#define TIMER_2_CHANNELS    1
 #define TIMER_2_MAX_VALUE   0xffffffff
 #define TIMER_2_IRQn_1      GPTIMER_2A_IRQn
 #define TIMER_2_IRQn_2      GPTIMER_2B_IRQn
@@ -70,7 +70,7 @@
 
 /* Timer 3 configuration */
 #define TIMER_3_DEV         GPTIMER3
-#define TIMER_3_CHANNELS    NUM_CHANNELS_PER_GPTIMER
+#define TIMER_3_CHANNELS    1
 #define TIMER_3_MAX_VALUE   0xffffffff
 #define TIMER_3_IRQn_1      GPTIMER_3A_IRQn
 #define TIMER_3_IRQn_2      GPTIMER_3B_IRQn

--- a/boards/remote/include/board.h
+++ b/boards/remote/include/board.h
@@ -127,10 +127,10 @@
  * @{
  */
 #define XTIMER              TIMER_0
-#define XTIMER_CHAN         0
-#define XTIMER_SHIFT        -4
-#define XTIMER_BACKOFF      50
-#define XTIMER_ISR_BACKOFF  40
+#define XTIMER_CHAN         (0)
+#define XTIMER_SHIFT        (-4)
+#define XTIMER_BACKOFF      (50)
+#define XTIMER_ISR_BACKOFF  (40)
 /** @} */
 
 /**

--- a/boards/remote/include/board.h
+++ b/boards/remote/include/board.h
@@ -121,6 +121,18 @@
 #define RF_SWITCH_INTERNAL  (RF_SWITCH_PORT->DATA &= ~(1 << RF_SWITCH_PIN))
 #define RF_SWITCH_TOGGLE    (RF_SWITCH_PORT->DATA ^= (1 << RF_SWITCH_PIN))
 /** @} */
+
+/**
+ * @name xtimer configuration
+ * @{
+ */
+#define XTIMER              TIMER_0
+#define XTIMER_CHAN         0
+#define XTIMER_SHIFT        -4
+#define XTIMER_BACKOFF      50
+#define XTIMER_ISR_BACKOFF  40
+/** @} */
+
 /**
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */

--- a/boards/remote/include/periph_conf.h
+++ b/boards/remote/include/periph_conf.h
@@ -46,7 +46,7 @@
 
 /* Timer 0 configuration */
 #define TIMER_0_DEV         GPTIMER0
-#define TIMER_0_CHANNELS    NUM_CHANNELS_PER_GPTIMER
+#define TIMER_0_CHANNELS    1
 #define TIMER_0_MAX_VALUE   0xffffffff
 #define TIMER_0_IRQn_1      GPTIMER_0A_IRQn
 #define TIMER_0_IRQn_2      GPTIMER_0B_IRQn
@@ -55,7 +55,7 @@
 
 /* Timer 1 configuration */
 #define TIMER_1_DEV         GPTIMER1
-#define TIMER_1_CHANNELS    NUM_CHANNELS_PER_GPTIMER
+#define TIMER_1_CHANNELS    1
 #define TIMER_1_MAX_VALUE   0xffffffff
 #define TIMER_1_IRQn_1      GPTIMER_1A_IRQn
 #define TIMER_1_IRQn_2      GPTIMER_1B_IRQn
@@ -64,7 +64,7 @@
 
 /* Timer 2 configuration */
 #define TIMER_2_DEV         GPTIMER2
-#define TIMER_2_CHANNELS    NUM_CHANNELS_PER_GPTIMER
+#define TIMER_2_CHANNELS    1
 #define TIMER_2_MAX_VALUE   0xffffffff
 #define TIMER_2_IRQn_1      GPTIMER_2A_IRQn
 #define TIMER_2_IRQn_2      GPTIMER_2B_IRQn
@@ -73,7 +73,7 @@
 
 /* Timer 3 configuration */
 #define TIMER_3_DEV         GPTIMER3
-#define TIMER_3_CHANNELS    NUM_CHANNELS_PER_GPTIMER
+#define TIMER_3_CHANNELS    1
 #define TIMER_3_MAX_VALUE   0xffffffff
 #define TIMER_3_IRQn_1      GPTIMER_3A_IRQn
 #define TIMER_3_IRQn_2      GPTIMER_3B_IRQn

--- a/cpu/cc2538/include/cc2538_gptimer.h
+++ b/cpu/cc2538/include/cc2538_gptimer.h
@@ -56,7 +56,7 @@ typedef struct {
         cc2538_reg_t TAMR;                  /**< GPTIMER Timer A mode */
         struct {
             cc2538_reg_t TAMR2     :  2;    /**< GPTM Timer A mode */
-            cc2538_reg_t TACRM     :  1;    /**< GPTM Timer A capture mode */
+            cc2538_reg_t TACMR     :  1;    /**< GPTM Timer A capture mode */
             cc2538_reg_t TAAMS     :  1;    /**< GPTM Timer A alternate mode */
             cc2538_reg_t TACDIR    :  1;    /**< GPTM Timer A count direction */
             cc2538_reg_t TAMIE     :  1;    /**< GPTM Timer A match interrupt enable */
@@ -77,7 +77,7 @@ typedef struct {
         cc2538_reg_t TBMR;                  /**< GPTIMER Timer B mode */
         struct {
             cc2538_reg_t TBMR2     :  2;    /**< GPTM Timer B mode */
-            cc2538_reg_t TBCRM     :  1;    /**< GPTM Timer B capture mode */
+            cc2538_reg_t TBCMR     :  1;    /**< GPTM Timer B capture mode */
             cc2538_reg_t TBAMS     :  1;    /**< GPTM Timer B alternate mode */
             cc2538_reg_t TBCDIR    :  1;    /**< GPTM Timer B count direction */
             cc2538_reg_t TBMIE     :  1;    /**< GPTM Timer B match interrupt enable */
@@ -156,6 +156,7 @@ typedef struct {
     cc2538_reg_t TBPV;                      /**< GPTIMER Timer B Prescale Value */
     cc2538_reg_t RESERVED[981];             /**< Reserved */
     cc2538_reg_t PP;                        /**< GPTIMER Peripheral Properties */
+    cc2538_reg_t RESERVED4[15];             /**< Reserved */
 } cc2538_gptimer_t;
 
 #define GPTIMER0 ( (cc2538_gptimer_t*)0x40030000 )       /**< GPTIMER0 Instance */

--- a/cpu/cc2538/include/cc2538_gptimer.h
+++ b/cpu/cc2538/include/cc2538_gptimer.h
@@ -116,7 +116,24 @@ typedef struct {
 
     cc2538_reg_t SYNC;                      /**< GPTIMER Synchronize */
     cc2538_reg_t RESERVED2;                 /**< Reserved word */
-    cc2538_reg_t IMR;                       /**< GPTIMER Interrupt Mask */
+
+    union {
+        cc2538_reg_t IMR;                   /**< GPTIMER Interrupt Mask */
+        struct {
+            cc2538_reg_t TATOIM    :  1;    /**< GPTM Timer A time-out interrupt mask */
+            cc2538_reg_t CAMIM     :  1;    /**< GPTM Timer A capture match interrupt mask */
+            cc2538_reg_t CAEIM     :  1;    /**< GPTM Timer A capture event interrupt mask */
+            cc2538_reg_t RESERVED1 :  1;    /**< Reserved bits */
+            cc2538_reg_t TAMIM     :  1;    /**< GPTM Timer A match interrupt mask */
+            cc2538_reg_t RESERVED2 :  3;    /**< Reserved bits */
+            cc2538_reg_t TBTOIM    :  1;    /**< GPTM Timer B time-out interrupt mask */
+            cc2538_reg_t CBMIM     :  1;    /**< GPTM Timer B capture match interrupt mask */
+            cc2538_reg_t CBEIM     :  1;    /**< GPTM Timer B capture event interrupt mask */
+            cc2538_reg_t TBMIM     :  1;    /**< GPTM Timer B match interrupt mask */
+            cc2538_reg_t RESERVED3 : 20;    /**< Reserved bits */
+        } IMRbits;
+    } cc2538_gptimer_imr;
+
     cc2538_reg_t RIS;                       /**< GPTIMER Raw Interrupt Status */
     cc2538_reg_t MIS;                       /**< GPTIMER Masked Interrupt Status */
     cc2538_reg_t ICR;                       /**< GPTIMER Interrupt Clear */

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -28,12 +28,16 @@
 #include "periph/timer.h"
 #include "periph_conf.h"
 
-#define USEC_PER_SEC             1000000 /**< Conversion factor between seconds and microseconds */
+#define TIMER_A_IRQ_MASK 0x000000ff
+#define TIMER_B_IRQ_MASK 0x0000ff00
+
+#define NUM_CHANNELS     1
 
 /**
  * @brief Timer state memory
  */
 static timer_isr_ctx_t config[TIMER_NUMOF];
+static unsigned long config_freq[TIMER_NUMOF];
 
 
 /**
@@ -78,6 +82,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     /* Save the callback function: */
     config[dev].cb = cb;
     config[dev].arg = arg;
+    config_freq[dev] = freq;
 
     /* Enable the clock for this timer: */
     SYS_CTRL_RCGCGPT |= (1 << gptimer_num);
@@ -85,12 +90,10 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     /* Disable this timer before configuring it: */
     gptimer->cc2538_gptimer_ctl.CTL = 0;
 
-    gptimer->CFG  = GPTMCFG_16_BIT_TIMER;
+    gptimer->CFG  = GPTMCFG_32_BIT_TIMER;
     gptimer->cc2538_gptimer_tamr.TAMR = GPTIMER_PERIODIC_MODE;
     gptimer->cc2538_gptimer_tamr.TAMRbits.TACDIR = 1; /**< Count up */
-
-    /* Set the prescale register for the desired frequency: */
-    gptimer->TAPR = (RCOSC16M_FREQ / freq) - 1;
+    gptimer->cc2538_gptimer_tamr.TAMRbits.TAMIE  = 1; /**< Enable the Timer A Match Interrupt */
 
     /* Enable interrupts for given timer: */
     timer_irq_enable(dev);
@@ -103,12 +106,11 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 
 int timer_set(tim_t dev, int channel, unsigned int timeout)
 {
-    return timer_set_absolute(dev, channel, timer_read(dev) + timeout);
-}
-
-int timer_set_absolute(tim_t dev, int channel, unsigned int value)
-{
     cc2538_gptimer_t *gptimer;
+
+    if (channel >= NUM_CHANNELS) {
+        return -1;
+    }
 
     /* get timer base register address */
     switch (dev) {
@@ -138,18 +140,62 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
     }
 
     /* set timeout value */
-    switch (channel) {
-        case 0:
-            gptimer->TAILR = value;
-            break;
+    gptimer->ICR           = TIMER_A_IRQ_MASK; /**< Clear any pending interrupt status */
 
-        case 1:
-            gptimer->TBILR = value;
-            break;
+    uint64_t scaled_value = timeout;
+    scaled_value *= RCOSC16M_FREQ;
+    scaled_value /= config_freq[dev];
+    gptimer->TAMATCHR = gptimer->TAV + scaled_value;
 
+    gptimer->cc2538_gptimer_imr.IMRbits.TAMIM = 1; /**< Enable the Timer A Match Interrupt */
+
+    return 1;
+}
+
+int timer_set_absolute(tim_t dev, int channel, unsigned int value)
+{
+    cc2538_gptimer_t *gptimer;
+
+    if (channel >= NUM_CHANNELS) {
+        return -1;
+    }
+
+    /* get timer base register address */
+    switch (dev) {
+#if TIMER_0_EN
+        case TIMER_0:
+            gptimer = TIMER_0_DEV;
+            break;
+#endif
+#if TIMER_1_EN
+        case TIMER_1:
+            gptimer = TIMER_1_DEV;
+            break;
+#endif
+#if TIMER_2_EN
+        case TIMER_2:
+            gptimer = TIMER_2_DEV;
+            break;
+#endif
+#if TIMER_3_EN
+        case TIMER_3:
+            gptimer = TIMER_3_DEV;
+            break;
+#endif
+        case TIMER_UNDEFINED:
         default:
             return -1;
     }
+
+    /* set timeout value */
+    gptimer->ICR           = TIMER_A_IRQ_MASK; /**< Clear any pending interrupt status */
+
+    uint64_t scaled_value = value;
+    scaled_value *= config_freq[dev];
+    scaled_value /= RCOSC16M_FREQ;
+    gptimer->TAMATCHR = (scaled_value > UINT32_MAX)? UINT32_MAX : scaled_value;
+
+    gptimer->cc2538_gptimer_imr.IMRbits.TAMIM = 1; /**< Enable the Timer A Match Interrupt */
 
     return 1;
 }
@@ -157,6 +203,10 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 int timer_clear(tim_t dev, int channel)
 {
     cc2538_gptimer_t *gptimer;
+
+    if (channel >= NUM_CHANNELS) {
+        return -1;
+    }
 
     /* get timer base register address */
     switch (dev) {
@@ -186,18 +236,7 @@ int timer_clear(tim_t dev, int channel)
             return -1;
     }
 
-    switch (channel) {
-        case 0:
-            gptimer->cc2538_gptimer_ctl.CTLbits.TAEN = 0;
-            break;
-
-        case 1:
-            gptimer->cc2538_gptimer_ctl.CTLbits.TBEN = 0;
-            break;
-
-        default:
-            return -1;
-    }
+    gptimer->cc2538_gptimer_imr.IMR = 0;
 
     return 1;
 }
@@ -211,19 +250,19 @@ unsigned int timer_read(tim_t dev)
     switch (dev) {
 #if TIMER_0_EN
         case TIMER_0:
-            return TIMER_0_DEV->TAR;
+            return (uint64_t)TIMER_0_DEV->TAV * config_freq[TIMER_0] / RCOSC16M_FREQ;
 #endif
 #if TIMER_1_EN
         case TIMER_1:
-            return TIMER_1_DEV->TAR;
+            return (uint64_t)TIMER_1_DEV->TAV * config_freq[TIMER_1] / RCOSC16M_FREQ;
 #endif
 #if TIMER_2_EN
         case TIMER_2:
-            return TIMER_2_DEV->TAR;
+            return (uint64_t)TIMER_2_DEV->TAV * config_freq[TIMER_2] / RCOSC16M_FREQ;
 #endif
 #if TIMER_3_EN
         case TIMER_3:
-            return TIMER_3_DEV->TAR;
+            return (uint64_t)TIMER_3_DEV->TAV * config_freq[TIMER_3] / RCOSC16M_FREQ;
 #endif
 
         case TIMER_UNDEFINED:
@@ -241,25 +280,21 @@ void timer_stop(tim_t dev)
 #if TIMER_0_EN
         case TIMER_0:
             TIMER_0_DEV->cc2538_gptimer_ctl.CTLbits.TAEN = 0;
-            TIMER_0_DEV->cc2538_gptimer_ctl.CTLbits.TBEN = 0;
             break;
 #endif
 #if TIMER_1_EN
         case TIMER_1:
             TIMER_1_DEV->cc2538_gptimer_ctl.CTLbits.TAEN = 0;
-            TIMER_1_DEV->cc2538_gptimer_ctl.CTLbits.TBEN = 0;
             break;
 #endif
 #if TIMER_2_EN
         case TIMER_2:
             TIMER_2_DEV->cc2538_gptimer_ctl.CTLbits.TAEN = 0;
-            TIMER_2_DEV->cc2538_gptimer_ctl.CTLbits.TBEN = 0;
             break;
 #endif
 #if TIMER_3_EN
         case TIMER_3:
             TIMER_3_DEV->cc2538_gptimer_ctl.CTLbits.TAEN = 0;
-            TIMER_3_DEV->cc2538_gptimer_ctl.CTLbits.TBEN = 0;
             break;
 #endif
 
@@ -274,25 +309,21 @@ void timer_start(tim_t dev)
 #if TIMER_0_EN
         case TIMER_0:
             TIMER_0_DEV->cc2538_gptimer_ctl.CTLbits.TAEN = 1;
-            TIMER_0_DEV->cc2538_gptimer_ctl.CTLbits.TBEN = 1;
             break;
 #endif
 #if TIMER_1_EN
         case TIMER_1:
             TIMER_1_DEV->cc2538_gptimer_ctl.CTLbits.TAEN = 1;
-            TIMER_1_DEV->cc2538_gptimer_ctl.CTLbits.TBEN = 1;
             break;
 #endif
 #if TIMER_2_EN
         case TIMER_2:
             TIMER_2_DEV->cc2538_gptimer_ctl.CTLbits.TAEN = 1;
-            TIMER_2_DEV->cc2538_gptimer_ctl.CTLbits.TBEN = 1;
             break;
 #endif
 #if TIMER_3_EN
         case TIMER_3:
             TIMER_3_DEV->cc2538_gptimer_ctl.CTLbits.TAEN = 1;
-            TIMER_3_DEV->cc2538_gptimer_ctl.CTLbits.TBEN = 1;
             break;
 #endif
 
@@ -390,11 +421,13 @@ static inline void irq_handler(int tim, int chan)
 #if TIMER_0_EN
 void TIMER_0_ISR_1(void)
 {
+    TIMER_0_DEV->ICR = TIMER_A_IRQ_MASK;
     irq_handler(0, 0);
 }
 
 void TIMER_0_ISR_2(void)
 {
+    TIMER_0_DEV->ICR = TIMER_B_IRQ_MASK;
     irq_handler(0, 1);
 }
 #endif /* TIMER_0_EN */
@@ -402,11 +435,13 @@ void TIMER_0_ISR_2(void)
 #if TIMER_1_EN
 void TIMER_1_ISR_1(void)
 {
+    TIMER_1_DEV->ICR = TIMER_A_IRQ_MASK;
     irq_handler(1, 0);
 }
 
 void TIMER_1_ISR_2(void)
 {
+    TIMER_1_DEV->ICR = TIMER_B_IRQ_MASK;
     irq_handler(1, 1);
 }
 #endif /* TIMER_1_EN */
@@ -414,11 +449,13 @@ void TIMER_1_ISR_2(void)
 #if TIMER_2_EN
 void TIMER_2_ISR_1(void)
 {
+    TIMER_2_DEV->ICR = TIMER_A_IRQ_MASK;
     irq_handler(2, 0);
 }
 
 void TIMER_2_ISR_2(void)
 {
+    TIMER_2_DEV->ICR = TIMER_B_IRQ_MASK;
     irq_handler(2, 1);
 }
 #endif /* TIMER_2_EN */
@@ -426,11 +463,13 @@ void TIMER_2_ISR_2(void)
 #if TIMER_3_EN
 void TIMER_3_ISR_1(void)
 {
+    TIMER_3_DEV->ICR = TIMER_A_IRQ_MASK;
     irq_handler(3, 0);
 }
 
 void TIMER_3_ISR_2(void)
 {
+    TIMER_3_DEV->ICR = TIMER_B_IRQ_MASK;
     irq_handler(3, 1);
 }
 #endif /* TIMER_3_EN */

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -144,6 +144,7 @@ int timer_set(tim_t dev, int channel, unsigned int timeout)
 
     uint64_t scaled_value = timeout;
     scaled_value *= RCOSC16M_FREQ;
+    scaled_value += config_freq[dev] / 2;
     scaled_value /= config_freq[dev];
     gptimer->TAMATCHR = gptimer->TAV + scaled_value;
 
@@ -192,6 +193,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 
     uint64_t scaled_value = value;
     scaled_value *= config_freq[dev];
+    scaled_value += RCOSC16M_FREQ / 2;
     scaled_value /= RCOSC16M_FREQ;
     gptimer->TAMATCHR = (scaled_value > UINT32_MAX)? UINT32_MAX : scaled_value;
 

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -342,8 +342,13 @@ int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t us);
 #define XTIMER_SHIFT (0)
 #endif
 
+#if (XTIMER_SHIFT < 0)
+#define XTIMER_RSHIFT(value) ( (value) << -XTIMER_SHIFT )
+#define XTIMER_LSHIFT(value) ( (value) >> -XTIMER_SHIFT )
+#else
 #define XTIMER_RSHIFT(value) ( (value) >> XTIMER_SHIFT )
 #define XTIMER_LSHIFT(value) ( (value) << XTIMER_SHIFT )
+#endif
 
 /**
  * @brief set xtimer default timer configuration

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -343,11 +343,11 @@ int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t us);
 #endif
 
 #if (XTIMER_SHIFT < 0)
-#define XTIMER_RSHIFT(value) ( (value) << -XTIMER_SHIFT )
-#define XTIMER_LSHIFT(value) ( (value) >> -XTIMER_SHIFT )
+#define XTIMER_USEC_TO_TICKS(value) ( (value) << -XTIMER_SHIFT )
+#define XTIMER_TICKS_TO_USEC(value) ( (value) >> -XTIMER_SHIFT )
 #else
-#define XTIMER_RSHIFT(value) ( (value) >> XTIMER_SHIFT )
-#define XTIMER_LSHIFT(value) ( (value) << XTIMER_SHIFT )
+#define XTIMER_USEC_TO_TICKS(value) ( (value) >> XTIMER_SHIFT )
+#define XTIMER_TICKS_TO_USEC(value) ( (value) << XTIMER_SHIFT )
 #endif
 
 /**
@@ -383,7 +383,7 @@ int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t us);
  */
 #define XTIMER_MASK (0)
 #endif
-#define XTIMER_MASK_SHIFTED XTIMER_LSHIFT(XTIMER_MASK)
+#define XTIMER_MASK_SHIFTED XTIMER_TICKS_TO_USEC(XTIMER_MASK)
 
 #ifndef XTIMER_USLEEP_UNTIL_OVERHEAD
 /**
@@ -412,7 +412,7 @@ extern volatile uint32_t _high_cnt;
 static inline uint32_t _lltimer_now(void)
 {
 #if XTIMER_SHIFT
-    return XTIMER_LSHIFT((uint32_t)timer_read(XTIMER));
+    return XTIMER_TICKS_TO_USEC((uint32_t)timer_read(XTIMER));
 #else
     return timer_read(XTIMER);
 #endif
@@ -460,7 +460,7 @@ static inline void xtimer_spin_until(uint32_t value);
 /**
  * @brief Minimal value xtimer_spin() can spin
  */
-#define XTIMER_MIN_SPIN XTIMER_LSHIFT(1)
+#define XTIMER_MIN_SPIN XTIMER_TICKS_TO_USEC(1)
 #endif
 
 static inline uint32_t xtimer_now(void)

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -342,6 +342,9 @@ int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t us);
 #define XTIMER_SHIFT (0)
 #endif
 
+#define XTIMER_RSHIFT(value) ( (value) >> XTIMER_SHIFT )
+#define XTIMER_LSHIFT(value) ( (value) << XTIMER_SHIFT )
+
 /**
  * @brief set xtimer default timer configuration
  * @{
@@ -375,7 +378,7 @@ int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t us);
  */
 #define XTIMER_MASK (0)
 #endif
-#define XTIMER_MASK_SHIFTED (XTIMER_MASK << XTIMER_SHIFT)
+#define XTIMER_MASK_SHIFTED XTIMER_LSHIFT(XTIMER_MASK)
 
 #ifndef XTIMER_USLEEP_UNTIL_OVERHEAD
 /**
@@ -404,7 +407,7 @@ extern volatile uint32_t _high_cnt;
 static inline uint32_t _lltimer_now(void)
 {
 #if XTIMER_SHIFT
-    return ((uint32_t)timer_read(XTIMER)) << XTIMER_SHIFT;
+    return XTIMER_LSHIFT((uint32_t)timer_read(XTIMER));
 #else
     return timer_read(XTIMER);
 #endif
@@ -452,7 +455,7 @@ static inline void xtimer_spin_until(uint32_t value);
 /**
  * @brief Minimal value xtimer_spin() can spin
  */
-#define XTIMER_MIN_SPIN (1<<XTIMER_SHIFT)
+#define XTIMER_MIN_SPIN XTIMER_LSHIFT(1)
 #endif
 
 static inline uint32_t xtimer_now(void)

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -56,7 +56,7 @@ static inline int _is_set(xtimer_t *timer)
 void xtimer_init(void)
 {
     /* initialize low-level timer */
-    timer_init(XTIMER, (1000000ul >> XTIMER_SHIFT), _periph_timer_callback, NULL);
+    timer_init(XTIMER, XTIMER_RSHIFT(1000000ul), _periph_timer_callback, NULL);
 
     /* register initial overflow tick */
     _lltimer_set(0xFFFFFFFF);
@@ -150,7 +150,7 @@ static inline void _lltimer_set(uint32_t target)
     }
     DEBUG("_lltimer_set(): setting %" PRIu32 "\n", _lltimer_mask(target));
 #ifdef XTIMER_SHIFT
-    target >>= XTIMER_SHIFT;
+    target = XTIMER_RSHIFT(target);
     if (!target) {
         target++;
     }

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -56,7 +56,7 @@ static inline int _is_set(xtimer_t *timer)
 void xtimer_init(void)
 {
     /* initialize low-level timer */
-    timer_init(XTIMER, XTIMER_RSHIFT(1000000ul), _periph_timer_callback, NULL);
+    timer_init(XTIMER, XTIMER_USEC_TO_TICKS(1000000ul), _periph_timer_callback, NULL);
 
     /* register initial overflow tick */
     _lltimer_set(0xFFFFFFFF);
@@ -150,7 +150,7 @@ static inline void _lltimer_set(uint32_t target)
     }
     DEBUG("_lltimer_set(): setting %" PRIu32 "\n", _lltimer_mask(target));
 #ifdef XTIMER_SHIFT
-    target = XTIMER_RSHIFT(target);
+    target = XTIMER_USEC_TO_TICKS(target);
     if (!target) {
         target++;
     }


### PR DESCRIPTION
 * Use the 32-bit counter mode.
 * Apply frequency scaling for non-16 MHz frequencies.
 * `tests/periph_timer` works now.

Tested on `boards/cc2538dk`. The previous implementation used 16-bit counters and did not work properly.
