### PR TITLE
tests/periph_gpio: Fix mixed up command descriptions

### DIFF
--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -220,9 +220,9 @@ static int toggle(int argc, char **argv)
 }
 
 static const shell_command_t shell_commands[] = {
-    { "init_in", "initialize pin as output", init_in },
-    { "init_out", "initialize pin as input", init_out },
-    { "init_int", "initialize pin as EXTI", init_int },
+    { "init_in", "initialize pin as input", init_in },
+    { "init_out", "initialize pin as output", init_out },
+    { "init_int", "initialize pin as input with interrupt", init_int },
     { "read", "read pin status", read },
     { "set", "set pin to HIGH", set },
     { "clear", "set pin to LOW", clear },


### PR DESCRIPTION
input and output texts were switched