### PR TITLE
tests: xtimer_msg_receive_timeout: remove timer before ending scope

### DIFF
--- a/tests/xtimer_msg_receive_timeout/main.c
+++ b/tests/xtimer_msg_receive_timeout/main.c
@@ -40,5 +40,6 @@ int main(void)
         }
         offset = (offset < 0) ? 1000 : -1000;
     }
+    xtimer_remove(&t);
     return 0;
 }


### PR DESCRIPTION
Main exits with a stack allocated timer still active, which leads to a hardfault (on samr21).