### PR TITLE
core: msg: fix msg_try_receive()

### DIFF
--- a/core/msg.c
+++ b/core/msg.c
@@ -298,7 +298,7 @@ static int _msg_receive(msg_t *m, int block)
     }
 
     /* no message, fail */
-    if ((!block) && (queue_index == -1)) {
+    if ((!block) && ((!me->msg_waiters.first) && (queue_index == -1))) {
         restoreIRQ(state);
         return -1;
     }

--- a/tests/msg_try_receive/Makefile
+++ b/tests/msg_try_receive/Makefile
@@ -1,0 +1,4 @@
+APPLICATION = msg_try_receive
+include ../Makefile.tests_common
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/msg_try_receive/main.c
+++ b/tests/msg_try_receive/main.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief   msg_try_receive regression test application
+ *
+ * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include "thread.h"
+
+#include "msg.h"
+
+static kernel_pid_t _main_pid;
+
+static char stack[THREAD_STACKSIZE_MAIN];
+static void *second_thread(void *arg)
+{
+    (void) arg;
+    msg_t test;
+    puts("sending message...");
+    msg_send(&test, _main_pid);
+
+    return NULL;
+}
+
+int main(void)
+{
+    printf("main starting\n");
+
+    _main_pid = thread_getpid();
+
+    thread_create(stack,
+                  sizeof(stack),
+                  THREAD_PRIORITY_MAIN - 1,
+                  0,
+                  second_thread,
+                  NULL,
+                  "second_thread");
+
+    msg_t m;
+    printf("msg available: %i (should be 1!)\n", msg_try_receive(&m));
+
+    return 0;
+}


### PR DESCRIPTION
Incredible, but after all these years I found a bug in the core msg semantics:

msg_try_receive() only considered the message queue, ignoring possibly send blocked threads.

This PR includes a test case. IMHO we could drop that commit before merging, as the small bugfix doesn't deserve a test. Too bad we don't have unittests for messaging...