### PR TITLE
cc110x: only set info values if != NULL

### DIFF
--- a/drivers/cc110x/cc110x-netdev2.c
+++ b/drivers/cc110x/cc110x-netdev2.c
@@ -52,7 +52,6 @@ static int _recv(netdev2_t *dev, char* buf, int len, void *info)
     DEBUG("%s:%u\n", __func__, __LINE__);
 
     cc110x_t *cc110x = &((netdev2_cc110x_t*) dev)->cc110x;
-    netdev2_cc110x_rx_info_t *cc110x_info = info;
 
     cc110x_pkt_t *cc110x_pkt = &cc110x->pkt_buf.packet;
     if (cc110x_pkt->length > len) {
@@ -60,8 +59,12 @@ static int _recv(netdev2_t *dev, char* buf, int len, void *info)
     }
 
     memcpy(buf, (void*)cc110x_pkt, cc110x_pkt->length);
-    cc110x_info->rssi = cc110x->pkt_buf.rssi;
-    cc110x_info->lqi = cc110x->pkt_buf.lqi;
+    if (info != NULL) {
+        netdev2_cc110x_rx_info_t *cc110x_info = info;
+
+        cc110x_info->rssi = cc110x->pkt_buf.rssi;
+        cc110x_info->lqi = cc110x->pkt_buf.lqi;
+    }
     return cc110x_pkt->length;
 }
 


### PR DESCRIPTION
This was somehow not done right in #4648.