### PR TITLE
make: set OBJDUMP = $(PREFIX)objdump for gnu targets.

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -316,12 +316,15 @@ reset:
 		exit 1; }
 	$(RESET) $(RESET_FLAGS)
 
+# Default OBJDUMPFLAGS for platforms which do not specify it:
+OBJDUMPFLAGS ?= -S -D -h
+
 objdump:
-	$(AD)command -v $(PREFIX)objdump >/dev/null 2>&1 || \
+	$(AD)command -v $(OBJDUMP) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \
-		'${COLOR_RED} Objdump program $(PREFIX)objdump not found. Aborting.${COLOR_RESET}'; \
+		'${COLOR_RED} Objdump program $(OBJDUMP) not found. Aborting.${COLOR_RESET}'; \
 		exit 1; }
-	$(PREFIX)objdump -S -D -h $(ELFFILE) | less
+	$(OBJDUMP) $(OBJDUMPFLAGS) $(ELFFILE) | less
 
 # Generate an XML file containing all macro definitions and include paths for
 # use in Eclipse CDT

--- a/Makefile.vars
+++ b/Makefile.vars
@@ -35,6 +35,8 @@ export LINK                  # The command used to link the files. Must take the
 export LINKFLAGS             # Flags to supply in the linking step.
 export OBJCOPY               # The command used to create the HEXFILE.
 export OFLAGS                # The parameter for OBJCOPY, e.g. to strip the debug information.
+export OBJDUMP               # The command used to create the assembly listing.
+export OBJDUMPFLAGS          # The parameter for OBJDUMP.
 export SIZE                  # The command to read to size of the ELF sections.
 export UNDEF                 # Set by the BOARD's and CPU's Makefile.include, this contains object files with must not be used in the ELFFILE even if the if no call to the functions.
 export WERROR                # Treat all compiler warnings as errors if set to 1 (see -Werror flag in GCC manual)

--- a/cpu/Makefile.include.gnu
+++ b/cpu/Makefile.include.gnu
@@ -6,4 +6,5 @@ export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
+export OBJDUMP = $(PREFIX)objdump
 export DBG = $(GDBPREFIX)gdb


### PR DESCRIPTION
Now you can generate an assembly listing using `make bin/$BOARD/$APPLICATION.lst`, whereas it would previously result in an error: `/bin/sh: 1: disassemble: not found`.