### PR TITLE
drivers/periph/spi: add 4MHZ to available speeds

### DIFF
--- a/cpu/lpc11u34/periph/spi.c
+++ b/cpu/lpc11u34/periph/spi.c
@@ -80,6 +80,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
         case SPI_SPEED_1MHZ:
             spi->CR0 |= (11 << 8);
             break;
+        case SPI_SPEED_4MHZ:
         case SPI_SPEED_5MHZ:
             spi->CR0 |= (2 << 8); /* Actual : 4MHz */
             break;

--- a/cpu/lpc2387/periph/spi.c
+++ b/cpu/lpc2387/periph/spi.c
@@ -73,6 +73,8 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     case SPI_SPEED_10MHZ:
         f_baud = 10000;
         break;
+    default:
+        return -1;
     }
 
 #if 0

--- a/cpu/nrf51/periph/spi.c
+++ b/cpu/nrf51/periph/spi.c
@@ -114,6 +114,8 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
         case SPI_SPEED_10MHZ:           /* 8 MHz for this device */
             spi[dev]->FREQUENCY = SPI_FREQUENCY_FREQUENCY_M8;
             break;
+       default:
+            return -1;
     }
 
     /* finally enable the device */

--- a/cpu/nrf52/periph/spi.c
+++ b/cpu/nrf52/periph/spi.c
@@ -127,6 +127,8 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
         case SPI_SPEED_10MHZ:           /* 8 MHz for this device */
             spi[dev]->FREQUENCY = SPI_FREQUENCY_FREQUENCY_M8;
             break;
+        default:
+            return -1;
     }
 
     /* finally enable the device */

--- a/cpu/samd21/periph/spi.c
+++ b/cpu/samd21/periph/spi.c
@@ -65,6 +65,8 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     case SPI_SPEED_1MHZ:
         f_baud = 1000000;
         break;
+    case SPI_SPEED_4MHZ:
+        return -1;
     case SPI_SPEED_5MHZ:
 #if CLOCK_CORECLOCK >= 5000000
         f_baud = 5000000;
@@ -79,6 +81,8 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
 #else
         return -1;
 #endif
+    default:
+        return -1;
     }
     switch(conf)
     {

--- a/cpu/saml21/periph/spi.c
+++ b/cpu/saml21/periph/spi.c
@@ -97,6 +97,8 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
         case SPI_SPEED_1MHZ:
             f_baud = 1000000;
             break;
+        case SPI_SPEED_4MHZ:
+            return -1;
         case SPI_SPEED_5MHZ:
             return -1;
         case SPI_SPEED_10MHZ:

--- a/cpu/stm32f0/periph/spi.c
+++ b/cpu/stm32f0/periph/spi.c
@@ -95,6 +95,8 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
             break;
         case SPI_SPEED_10MHZ:
             spi->CR1 |= (1 << 3);       /* actual clock 12MHz */
+        default:
+            return -1;
     }
 
     /* select clock polarity and clock phase */

--- a/cpu/stm32l1/periph/spi.c
+++ b/cpu/stm32l1/periph/spi.c
@@ -95,6 +95,8 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
             break;
         case SPI_SPEED_10MHZ:
             spi->CR1 |= (1 << 3);       /* actual clock 8MHz */
+        default:
+            return -1;
     }
 
     /* select clock polarity and clock phase */

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -95,6 +95,7 @@ typedef enum {
     SPI_SPEED_100KHZ = 0,       /**< drive the SPI bus with 100KHz */
     SPI_SPEED_400KHZ,           /**< drive the SPI bus with 400KHz */
     SPI_SPEED_1MHZ,             /**< drive the SPI bus with 1MHz */
+    SPI_SPEED_4MHZ,             /**< drive the SPI bus with 4MHz */
     SPI_SPEED_5MHZ,             /**< drive the SPI bus with 5MHz */
     SPI_SPEED_10MHZ             /**< drive the SPI bus with 10MHz */
 } spi_speed_t;


### PR DESCRIPTION
This follows a previous exchange on the mailing-list.

Allows for SPI to be driven at 4Mhz.