### PR TITLE
doc: provide include path list for doxyfile

### DIFF
--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -1,3 +1,10 @@
+RIOTBASE=$(shell git rev-parse --show-toplevel)
+# Generate list of quoted absolute include paths. Evaluated in riot.doxyfile.
+export STRIP_FROM_INC_PATH_LIST=$(shell \
+    git ls-tree -dr --full-tree --name-only HEAD |\
+    grep '/include$$' |\
+    sed 's/.*/\"$(subst /,\/,${RIOTBASE})\/\0\"/')
+
 .PHONY: doc
 doc: html
 

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -161,7 +161,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    =
+STRIP_FROM_INC_PATH    = $(STRIP_FROM_INC_PATH_LIST) # Exported from Makefile.
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't


### PR DESCRIPTION
Intended as a solution to #4794.
The effective goal is: Provide the doxygen tag *STRIP_FROM_INC_PATH* with a list of **all** actual riot include paths.
This is a first approach. Though it works as intended, improvements are welcome.
