### PR TITLE
core: adapt msg to use thread flags

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -22,7 +22,6 @@
 #ifndef THREAD_H
 #define THREAD_H
 
-#include "priority_queue.h"
 #include "clist.h"
 #include "cib.h"
 #include "msg.h"
@@ -89,7 +88,7 @@ struct _thread {
     void *wait_data;                /**< used by msg and thread flags   */
 #endif
 #if defined(MODULE_CORE_MSG)
-    priority_queue_t msg_waiters;   /**< threads waiting on message     */
+    list_node_t msg_waiters;        /**< threads waiting on message     */
     cib_t msg_queue;                /**< message queue                  */
     msg_t *msg_array;               /**< memory holding messages        */
 #endif

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -30,9 +30,7 @@
 #include "sched.h"
 #include "clist.h"
 
-#ifdef MODULE_CORE_THREAD_FLAGS
 #include "thread_flags.h"
-#endif
 
 #ifdef __cplusplus
  extern "C" {
@@ -78,9 +76,7 @@ struct _thread {
 
     kernel_pid_t pid;               /**< thread's process id            */
 
-#ifdef MODULE_CORE_THREAD_FLAGS
     thread_flags_t flags;           /**< currently set flags            */
-#endif
 
     clist_node_t rq_entry;          /**< run queue entry                */
 

--- a/core/msg.c
+++ b/core/msg.c
@@ -25,7 +25,7 @@
 #include <assert.h>
 #include "sched.h"
 #include "msg.h"
-#include "priority_queue.h"
+#include "list.h"
 #include "thread.h"
 #include "irq.h"
 #include "cib.h"
@@ -93,10 +93,12 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block, unsigned sta
         return -1;
     }
 
+    thread_t *me = (thread_t *) sched_active_thread;
+
     DEBUG("msg_send() %s:%i: Sending from %" PRIkernel_pid " to %" PRIkernel_pid
           ". block=%i src->state=%i target->state=%i\n", RIOT_FILE_RELATIVE,
           __LINE__, sched_active_pid, target_pid,
-          block, sched_active_thread->status, target->status);
+          block, me->status, target->status);
 
     if (target->status != STATUS_RECEIVE_BLOCKED) {
         DEBUG("msg_send() %s:%i: Target %" PRIkernel_pid " is not RECEIVE_BLOCKED.\n",
@@ -107,7 +109,7 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block, unsigned sta
                   " has a msg_queue. Queueing message.\n", RIOT_FILE_RELATIVE,
                   __LINE__, target_pid);
             irq_restore(state);
-            if (sched_active_thread->status == STATUS_REPLY_BLOCKED) {
+            if (me->status == STATUS_REPLY_BLOCKED) {
                 thread_yield_higher();
             }
             return 1;
@@ -115,45 +117,39 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block, unsigned sta
 
         if (!block) {
             DEBUG("msg_send: %" PRIkernel_pid ": Receiver not waiting, block=%u\n",
-                  sched_active_thread->pid, block);
+                  me->pid, block);
             irq_restore(state);
             return 0;
         }
 
-        DEBUG("msg_send: %" PRIkernel_pid ": send_blocked.\n",
-              sched_active_thread->pid);
-        priority_queue_node_t n;
-        n.priority = sched_active_thread->priority;
-        n.data = (unsigned int) sched_active_thread;
-        n.next = NULL;
-        DEBUG("msg_send: %" PRIkernel_pid ": Adding node to msg_waiters:\n",
-              sched_active_thread->pid);
+        DEBUG("msg_send: %" PRIkernel_pid ": going send blocked.\n",
+              me->pid);
 
-        priority_queue_add(&(target->msg_waiters), &n);
-
-        sched_active_thread->wait_data = (void*) m;
+        me->wait_data = (void*) m;
 
         int newstatus;
 
-        if (sched_active_thread->status == STATUS_REPLY_BLOCKED) {
+        if (me->status == STATUS_REPLY_BLOCKED) {
             newstatus = STATUS_REPLY_BLOCKED;
         }
         else {
             newstatus = STATUS_SEND_BLOCKED;
         }
 
-        sched_set_status((thread_t*) sched_active_thread, newstatus);
+        sched_set_status((thread_t*) me, newstatus);
 
-        DEBUG("msg_send: %" PRIkernel_pid ": Back from send block.\n",
-              sched_active_thread->pid);
+        thread_add_to_list(&(target->msg_waiters), me);
 
         irq_restore(state);
         thread_yield_higher();
+
+        DEBUG("msg_send: %" PRIkernel_pid ": Back from send block.\n",
+              me->pid);
     }
     else {
         DEBUG("msg_send: %" PRIkernel_pid ": Direct msg copy from %"
               PRIkernel_pid " to %" PRIkernel_pid ".\n",
-              sched_active_thread->pid, thread_getpid(), target_pid);
+              me->pid, thread_getpid(), target_pid);
         /* copy msg to target */
         msg_t *target_message = (msg_t*) target->wait_data;
         *target_message = *m;
@@ -293,7 +289,7 @@ static int _msg_receive(msg_t *m, int block)
     }
 
     /* no message, fail */
-    if ((!block) && ((!me->msg_waiters.first) && (queue_index == -1))) {
+    if ((!block) && ((!me->msg_waiters.next) && (queue_index == -1))) {
         irq_restore(state);
         return -1;
     }
@@ -307,9 +303,9 @@ static int _msg_receive(msg_t *m, int block)
         me->wait_data = (void *) m;
     }
 
-    priority_queue_node_t *node = priority_queue_remove_head(&(me->msg_waiters));
+    list_node_t *next = list_remove_head(&me->msg_waiters);
 
-    if (node == NULL) {
+    if (next == NULL) {
         DEBUG("_msg_receive: %" PRIkernel_pid ": _msg_receive(): No thread in waiting list.\n",
               sched_active_thread->pid);
 
@@ -332,7 +328,8 @@ static int _msg_receive(msg_t *m, int block)
     else {
         DEBUG("_msg_receive: %" PRIkernel_pid ": _msg_receive(): Waking up waiting thread.\n",
               sched_active_thread->pid);
-        thread_t *sender = (thread_t*) node->data;
+
+        thread_t *sender = container_of((clist_node_t*)next, thread_t, rq_entry);
 
         if (queue_index >= 0) {
             /* We've already got a message from the queue. As there is a

--- a/core/msg.c
+++ b/core/msg.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2014 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -27,6 +28,7 @@
 #include "msg.h"
 #include "list.h"
 #include "thread.h"
+#include "thread_flags.h"
 #include "irq.h"
 #include "cib.h"
 
@@ -36,7 +38,6 @@
 
 #ifdef MODULE_CORE_MSG
 
-static int _msg_receive(msg_t *m, int block);
 static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block, unsigned state);
 
 static int queue_msg(thread_t *target, const msg_t *m)
@@ -50,6 +51,7 @@ static int queue_msg(thread_t *target, const msg_t *m)
     DEBUG("queue_msg(): queuing message\n");
     msg_t *dest = &target->msg_array[n];
     *dest = *m;
+    target->flags |= THREAD_FLAG_MSG_WAITING;
     return 1;
 }
 
@@ -108,8 +110,14 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block, unsigned sta
             DEBUG("msg_send() %s:%i: Target %" PRIkernel_pid
                   " has a msg_queue. Queueing message.\n", RIOT_FILE_RELATIVE,
                   __LINE__, target_pid);
+
+#ifdef MODULE_CORE_THREAD_FLAGS
+            int wakeup = thread_flags_wake(target);
+#else
+            int wakeup = 0;
+#endif
             irq_restore(state);
-            if (me->status == STATUS_REPLY_BLOCKED) {
+            if (wakeup || me->status == STATUS_REPLY_BLOCKED) {
                 thread_yield_higher();
             }
             return 1;
@@ -139,6 +147,11 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block, unsigned sta
         sched_set_status((thread_t*) me, newstatus);
 
         thread_add_to_list(&(target->msg_waiters), me);
+
+        target->flags |= THREAD_FLAG_MSG_WAITING;
+#ifdef MODULE_CORE_THREAD_FLAGS
+        thread_flags_wake(target);
+#endif
 
         irq_restore(state);
         thread_yield_higher();
@@ -197,6 +210,7 @@ int msg_send_int(msg_t *m, kernel_pid_t target_pid)
         /* copy msg to target */
         msg_t *target_message = (msg_t*) target->wait_data;
         *target_message = *m;
+        target->flags |= THREAD_FLAG_MSG_WAITING;
         sched_set_status(target, STATUS_PENDING);
 
         sched_context_switch_request = 1;
@@ -204,7 +218,17 @@ int msg_send_int(msg_t *m, kernel_pid_t target_pid)
     }
     else {
         DEBUG("msg_send_int: Receiver not waiting.\n");
+#if MODULE_CORE_THREAD_FLAGS
+        if (queue_msg(target, m)) {
+            thread_flags_wake(target);
+            return 1;
+        }
+        else {
+            return -1;
+        }
+#else
         return (queue_msg(target, m));
+#endif
     }
 }
 
@@ -264,23 +288,30 @@ int msg_reply_int(msg_t *m, msg_t *reply)
     return 1;
 }
 
-int msg_try_receive(msg_t *m)
+static int _msg_avail(thread_t *thread)
 {
-    return _msg_receive(m, 0);
+    return (thread->msg_waiters.next) ||
+        (thread->msg_array && cib_avail(&thread->msg_queue));
+}
+
+static void _update_flag(thread_t *thread)
+{
+    if (_msg_avail(thread)) {
+        thread->flags |= THREAD_FLAG_MSG_WAITING;
+    }
 }
 
 int msg_receive(msg_t *m)
 {
-    return _msg_receive(m, 1);
-}
-
-static int _msg_receive(msg_t *m, int block)
-{
-    unsigned state = irq_disable();
-    DEBUG("_msg_receive: %" PRIkernel_pid ": _msg_receive.\n",
+    DEBUG("msg_receive(): %" PRIkernel_pid "\n",
           sched_active_thread->pid);
 
+    unsigned state = irq_disable();
+
     thread_t *me = (thread_t*) sched_threads[sched_active_pid];
+
+    /* clear new message flag */
+    me->flags &= ~THREAD_FLAG_MSG_WAITING;
 
     int queue_index = -1;
 
@@ -288,14 +319,8 @@ static int _msg_receive(msg_t *m, int block)
         queue_index = cib_get(&(me->msg_queue));
     }
 
-    /* no message, fail */
-    if ((!block) && ((!me->msg_waiters.next) && (queue_index == -1))) {
-        irq_restore(state);
-        return -1;
-    }
-
     if (queue_index >= 0) {
-        DEBUG("_msg_receive: %" PRIkernel_pid ": _msg_receive(): We've got a queued message.\n",
+        DEBUG("msg_receive(): %" PRIkernel_pid ": We've got a queued message.\n",
               sched_active_thread->pid);
         *m = me->msg_array[queue_index];
     }
@@ -306,27 +331,40 @@ static int _msg_receive(msg_t *m, int block)
     list_node_t *next = list_remove_head(&me->msg_waiters);
 
     if (next == NULL) {
-        DEBUG("_msg_receive: %" PRIkernel_pid ": _msg_receive(): No thread in waiting list.\n",
+        DEBUG("msg_receive(): %" PRIkernel_pid ": No thread in waiting list.\n",
               sched_active_thread->pid);
 
         if (queue_index < 0) {
-            DEBUG("_msg_receive(): %" PRIkernel_pid ": No msg in queue. Going blocked.\n",
+            DEBUG("msg_receive(): %" PRIkernel_pid ": No msg in queue. Going blocked.\n",
                   sched_active_thread->pid);
             sched_set_status(me, STATUS_RECEIVE_BLOCKED);
 
             irq_restore(state);
             thread_yield_higher();
 
-            /* sender copied message */
+            /* either sender copied message and set the new message flag,
+             * or the thread was woken up for another reason (e.g., timeout) */
+            DEBUG("msg_receive(): %" PRIkernel_pid ": woke up. new message: %s\n",
+                    sched_active_thread->pid,
+                    me->flags & THREAD_FLAG_MSG_WAITING ? "yes" : "no");
+
+            if (me->flags & THREAD_FLAG_MSG_WAITING) {
+                state = irq_disable();
+                _update_flag(me);
+                irq_restore(state);
+            }
+            else {
+                return -1;
+            }
+
         }
         else {
+            _update_flag(me);
             irq_restore(state);
         }
-
-        return 1;
     }
     else {
-        DEBUG("_msg_receive: %" PRIkernel_pid ": _msg_receive(): Waking up waiting thread.\n",
+        DEBUG("msg_receive(): %" PRIkernel_pid ": Waking up waiting thread.\n",
               sched_active_thread->pid);
 
         thread_t *sender = container_of((clist_node_t*)next, thread_t, rq_entry);
@@ -350,14 +388,27 @@ static int _msg_receive(msg_t *m, int block)
             sender_prio = sender->priority;
         }
 
+        _update_flag(me);
+
         irq_restore(state);
         if (sender_prio < THREAD_PRIORITY_IDLE) {
             sched_switch(sender_prio);
         }
-        return 1;
     }
 
-    DEBUG("This should have never been reached!\n");
+    return 1;
+}
+
+int msg_try_receive(msg_t *msg)
+{
+    if (sched_active_thread->flags & THREAD_FLAG_MSG_WAITING) {
+        DEBUG("msg_try_receive(): msg available.\n");
+        return msg_receive(msg);
+    }
+    else {
+        DEBUG("msg_try_receive(): no msg available.\n");
+        return -1;
+    }
 }
 
 int msg_avail(void)

--- a/core/thread.c
+++ b/core/thread.c
@@ -227,7 +227,7 @@ kernel_pid_t thread_create(char *stack, int stacksize, char priority, int flags,
 
 #ifdef MODULE_CORE_MSG
     cb->wait_data = NULL;
-    cb->msg_waiters.first = NULL;
+    cb->msg_waiters.next = NULL;
     cib_init(&(cb->msg_queue), 0);
     cb->msg_array = NULL;
 #endif


### PR DESCRIPTION
This PR changes msg.c so sending and receiving updates the target thread's THREAD_MSG_WAITING flag.

If the thread_flags module is compiled in, sending a message will also wake up a thread waiting for the flag with thread_flags_wait_*().

~~Waiting for #4103.~~
~~Waiting for #5283.~~
