### PR TITLE
sys: xtimer: make xtimer_msg_receive_timeout() use thread flags

### DIFF
--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -23,6 +23,7 @@ PSEUDOMODULES += schedstatistics
 PSEUDOMODULES += netif
 PSEUDOMODULES += saul_default
 PSEUDOMODULES += saul_gpio
+PSEUDOMODULES += thread_flags
 
 # include variants of the AT86RF2xx drivers as pseudo modules
 PSEUDOMODULES += at86rf23%

--- a/core/include/tcb.h
+++ b/core/include/tcb.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013 Freie Universität Berlin
  *
- * This file is subject to the terms and conditions of the GNU Lesser
+ * This file is subject to the terms and thread_conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
@@ -24,6 +24,7 @@
 #include "priority_queue.h"
 #include "clist.h"
 #include "cib.h"
+#include "thread_flags.h"
 #include "msg.h"
 
 #ifdef __cplusplus
@@ -38,33 +39,37 @@
  * @brief Blocked states.
  * @{
  */
-#define STATUS_STOPPED          0               /**< has terminated                     */
-#define STATUS_SLEEPING         1               /**< sleeping                           */
-#define STATUS_MUTEX_BLOCKED    2               /**< waiting for a locked mutex         */
-#define STATUS_RECEIVE_BLOCKED  3               /**< waiting for a message              */
-#define STATUS_SEND_BLOCKED     4               /**< waiting for message to be delivered*/
-#define STATUS_REPLY_BLOCKED    5               /**< waiting for a message response     */
+#define STATUS_STOPPED              0   /**< has terminated                     */
+#define STATUS_SLEEPING             1   /**< sleeping                           */
+#define STATUS_MUTEX_BLOCKED        2   /**< waiting for a locked mutex         */
+#define STATUS_RECEIVE_BLOCKED      3   /**< waiting for a message              */
+#define STATUS_SEND_BLOCKED         4   /**< waiting for message to be delivered*/
+#define STATUS_REPLY_BLOCKED        5   /**< waiting for a message response     */
+#define STATUS_FLAG_BLOCKED_ANY     6   /**< waiting for any flag from flag_mask*/
+#define STATUS_FLAG_BLOCKED_ALL     7   /**< waiting for all flags in flag_mask */
 /** @} */
 
 /**
  * @brief These have to be on a run queue.
  * @{*/
 #define STATUS_ON_RUNQUEUE      STATUS_RUNNING  /**< to check if on run queue:
-                                                 `st >= STATUS_ON_RUNQUEUE`             */
-#define STATUS_RUNNING          6               /**< currently running                  */
-#define STATUS_PENDING          7               /**< waiting to be scheduled to run     */
+                                                 `st >= STATUS_ON_RUNQUEUE`         */
+#define STATUS_RUNNING          9               /**< currently running              */
+#define STATUS_PENDING          10              /**< waiting to be scheduled to run */
 /** @} */
 /** @} */
 
 /**
  * @brief @c tcb_t holds thread's context data.
  */
-typedef struct tcb_t {
+struct tcb {
     char *sp;                   /**< thread's stack pointer         */
     uint16_t status;            /**< thread's status                */
 
     kernel_pid_t pid;           /**< thread's process id            */
     uint16_t priority;          /**< thread's priority              */
+
+    thread_flags_t flags;       /**< currently set flags            */
 
     clist_node_t rq_entry;      /**< run queue entry                */
 
@@ -81,7 +86,7 @@ typedef struct tcb_t {
     const char *name;           /**< thread's name                  */
     int stack_size;             /**< thread's stack size            */
 #endif
-} tcb_t;
+};
 
 #ifdef __cplusplus
 }

--- a/core/include/thread_flags.h
+++ b/core/include/thread_flags.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     core_thread
+ * @brief       Thread flags
+ * @{
+ *
+ * @file
+ * @brief       Thread flags API
+ *
+ * This API can be used to notify threads of conditions in a race-free
+ * and allocation-less way.
+ *
+ * Each thread has a number boolean flags (usually 16) in it's tcb, stored in
+ * it's flags field. Those flags can be set or unset, using thread_flags_set(),
+ * from ISR's, other threads or even by the thread itself.
+ *
+ * A thread can wait for any combination of it's flags to become set, using
+ * thread_flags_wait_any() or thread_flags_wait_all().
+ * Those functions clear flags that caused them to return.
+ * It is not possible to wait for flags to become unset.
+ *
+ * Thread flags, apart from being very efficient, have certain properties
+ * that make them the preferred choice over messages or mutexes in some
+ * circumstances:
+ *
+ * - setting thread flags cannot fail
+ *   If messages are used to notify a thread of a condition from within an ISR,
+ *   and the receiving thread is not waiting, has no queue or the queue is
+ *   full, the ISR cannot deliver the message. A thread flag can always be set.
+ *
+ * - thread flags are very flexible
+ *   With thread flags it is possible to wait for multiple conditions and
+ *   messages at the same time. When mutexes are used to notify about events,
+ *   only one event can be waited for.
+ *
+ * Note that some flags (currently the three most significant bits) are used by
+ * core functions and should not be set by the user. They can be waited for.
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+#ifndef THREAD_FLAG_H
+#define THREAD_FLAG_H
+
+#include "kernel_types.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * @name reserved thread flags
+ * @{
+ */
+#define THREAD_FLAG_MSG_WAITING      (0x1<<15)
+#define THREAD_FLAG_MUTEX_UNLOCKED   (0x1<<14)
+#define THREAD_FLAG_TIMEOUT          (0x1<<13)
+/** @} */
+
+typedef uint16_t thread_flags_t;
+typedef struct tcb tcb_t;
+
+/**
+ * @brief Set thread flags, possibly waking it up
+ *
+ * @param[in]   tcb     thread to work on
+ * @param[in]   mask    flags to OR with thread's current flags
+ */
+void thread_flags_set(tcb_t *tcb, thread_flags_t mask);
+
+/**
+ * @brief Clear current thread's flags
+ *
+ * @param[in]   mask    mask to ~& with thread's current flags
+ *
+ * @returns     flags that have actually been cleared (mask & tcb->flags before clear)
+ */
+thread_flags_t thread_flags_clear(thread_flags_t mask);
+
+/**
+ * @brief Wait for any flag in mask to become set (blocking)
+ *
+ * If any of the flags in mask are already set, this function will return
+ * immediately, otherwise, it will suspend the thread (as
+ * THREAD_STATUS_WAIT_ANY) until any of the flags in mask get set.
+ *
+ * Both ways, it will clear and return (sched_active_thread-flags & mask).
+ *
+ * @param[in]   mask    mask of flags to wait for
+ *
+ * @returns     flags that caused return/wakeup ((sched_active_thread-flags & mask).
+ */
+thread_flags_t thread_flags_wait_any(thread_flags_t mask);
+
+/**
+ * @brief Wait for all flags in mask to become set (blocking)
+ 
+ * If all the flags in mask are already set, this function will return
+ * immediately, otherwise, it will suspend the thread (as
+ * THREAD_STATUS_WAIT_ALL) until all of the flags in mask have been set.
+ *
+ * Both ways, it will clear and return (sched_active_thread-flags & mask).
+ *
+ * @param[in]   mask    mask of flags to wait for
+ *
+ * @returns     mask
+ */
+thread_flags_t thread_flags_wait_all(thread_flags_t mask);
+
+/**
+ * @brief Wait for any flags in mask to become set (blocking), one at a time
+ *
+ * This function is like thread_flags_wait_any(), but will only clear and return
+ * one flag at a time.
+ *
+ * @param[in]   mask    mask of flags to wait for
+ *
+ * @returns     flag that triggered the return / wait
+ */
+thread_flags_t thread_flags_wait_one(thread_flags_t mask);
+
+/**
+ * @brief Possibly wake up thread
+ *
+ * Has to be called with interrupts disabled.
+ * Does not trigger yield.
+ *
+ * @param[in]   thread  thread to possibly wake up
+ * @return      1       if thread has been woken up
+ *              0       otherwise
+ */
+int thread_flags_wake(tcb_t *thread);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* THREAD_FLAG_H */

--- a/core/thread_flags.c
+++ b/core/thread_flags.c
@@ -1,0 +1,115 @@
+#include "bitarithm.h"
+#include "thread_flags.h"
+#include "irq.h"
+#include "thread.h"
+#include "tcb.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#ifdef MODULE_THREAD_FLAGS
+static thread_flags_t _thread_flags_clear_atomic(tcb_t *tcb, thread_flags_t mask)
+{
+    unsigned state = disableIRQ();
+    mask &= tcb->flags;
+    tcb->flags &= ~mask;
+    restoreIRQ(state);
+    return mask;
+}
+
+static void _thread_flags_wait(thread_flags_t mask, tcb_t *tcb, unsigned threadstate, unsigned irqstate)
+{
+    DEBUG("_thread_flags_wait: me->flags=0x%08x me->mask=0x%08x. going blocked.\n",
+            (unsigned)tcb->flags, (unsigned)mask);
+
+    tcb->wait_data = (void *)(unsigned)mask;
+    sched_set_status(tcb, threadstate);
+    restoreIRQ(irqstate);
+    thread_yield_higher();
+}
+
+thread_flags_t thread_flags_clear(thread_flags_t mask)
+{
+    tcb_t *me = (tcb_t*) sched_active_thread;
+    mask = _thread_flags_clear_atomic(me, mask);
+    DEBUG("thread_flags_clear(): pid %"PRIkernel_pid" clearing 0x%08x\n", thread_getpid(), mask);
+    return mask;
+}
+
+static void _thread_flags_wait_any(thread_flags_t mask)
+{
+    tcb_t *me = (tcb_t*) sched_active_thread;
+    unsigned state = disableIRQ();
+    if (!(me->flags & mask)) {
+        _thread_flags_wait(mask, me, STATUS_FLAG_BLOCKED_ANY, state);
+    }
+    else {
+        restoreIRQ(state);
+    }
+}
+
+thread_flags_t thread_flags_wait_any(thread_flags_t mask)
+{
+    tcb_t *me = (tcb_t*) sched_active_thread;
+    _thread_flags_wait_any(mask);
+    return _thread_flags_clear_atomic(me, mask);
+}
+
+thread_flags_t thread_flags_wait_one(thread_flags_t mask)
+{
+    _thread_flags_wait_any(mask);
+    tcb_t *me = (tcb_t*) sched_active_thread;
+    unsigned tmp = me->flags & mask;
+    return _thread_flags_clear_atomic(me, thread_flags_clear(1 << bitarithm_lsb(tmp)));
+}
+
+thread_flags_t thread_flags_wait_all(thread_flags_t mask)
+{
+    unsigned state = disableIRQ();
+    tcb_t *me = (tcb_t*) sched_active_thread;
+    if (!((me->flags & mask) == mask)) {
+        DEBUG("thread_flags_wait_all(): pid %"PRIkernel_pid" waiting for %08x\n", thread_getpid(), (unsigned)mask);
+        _thread_flags_wait(mask, me, STATUS_FLAG_BLOCKED_ALL, state);
+    }
+    else {
+        restoreIRQ(state);
+    }
+
+    return _thread_flags_clear_atomic(me, mask);
+}
+
+inline int __attribute__((always_inline)) thread_flags_wake(tcb_t *tcb)
+{
+    unsigned wakeup = 0;
+    thread_flags_t mask = (uint16_t)(unsigned)tcb->wait_data;
+    switch(tcb->status) {
+        case STATUS_FLAG_BLOCKED_ANY:
+            wakeup = (tcb->flags & mask);
+            break;
+        case STATUS_FLAG_BLOCKED_ALL:
+            wakeup = ((tcb->flags & mask) == mask);
+            break;
+    }
+
+    if (wakeup) {
+        DEBUG("_thread_flags_wake(): wakeing up pid %"PRIkernel_pid"\n", tcb->pid);
+        sched_set_status(tcb, STATUS_RUNNING);
+    }
+
+    return wakeup;
+}
+
+void thread_flags_set(tcb_t *tcb, thread_flags_t mask)
+{
+    DEBUG("thread_flags_set(): setting 0x%08x for pid %"PRIkernel_pid"\n", mask, tcb->pid);
+    unsigned state = disableIRQ();
+    tcb->flags |= mask;
+    if (thread_flags_wake(tcb)) {
+        restoreIRQ(state);
+        thread_yield_higher();
+    }
+    else {
+        restoreIRQ(state);
+    }
+}
+#endif /* MODULE_THREAD_FLAGS */

--- a/tests/sizeof_tcb/main.c
+++ b/tests/sizeof_tcb/main.c
@@ -35,6 +35,7 @@ int main(void)
     P(status);
     P(pid);
     P(priority);
+    P(flags);
     P(rq_entry);
     P(wait_data);
     P(msg_waiters);

--- a/tests/thread_flags/Makefile
+++ b/tests/thread_flags/Makefile
@@ -1,0 +1,7 @@
+APPLICATION = thread_flags
+include ../Makefile.tests_common
+
+USEMODULE += xtimer
+USEMODULE += thread_flags
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/thread_flags/main.c
+++ b/tests/thread_flags/main.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief   simple thread flags test application
+ *
+ * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include "thread.h"
+
+static char stack[THREAD_STACKSIZE_MAIN];
+
+static void *_thread(void *arg)
+{
+    (void) arg;
+
+    thread_flags_t flags;
+
+    flags = thread_flags_wait_any(0x1);
+    printf("received flags: 0x%04x\n", (unsigned)flags & 0xFFFF);
+    flags = thread_flags_wait_any(0x1 | 0x64);
+    printf("received flags: 0x%04x\n", (unsigned)flags & 0xFFFF);
+    flags = thread_flags_wait_all(0x2 | 0x4);
+    printf("received flags: 0x%04x\n", (unsigned)flags & 0xFFFF);
+
+    return NULL;
+}
+
+static void _set(tcb_t *tcb, thread_flags_t flags)
+{
+    printf("main(): setting flag 0x%04x\n", (unsigned)flags & 0xFFFF);
+    thread_flags_set(tcb, flags);
+}
+
+int main(void)
+{
+    printf("main starting\n");
+
+    kernel_pid_t pid = thread_create(stack,
+                  sizeof(stack),
+                  THREAD_PRIORITY_MAIN - 1,
+                  THREAD_CREATE_STACKTEST,
+                  _thread,
+                  NULL,
+                  "second_thread");
+
+    tcb_t *tcb = (tcb_t*) thread_get(pid);
+    _set(tcb, 0x1);
+    _set(tcb, 0x64);
+    _set(tcb, 0x1);
+    _set(tcb, 0x2);
+    _set(tcb, 0x4);
+
+    while(1);
+    return 0;
+}


### PR DESCRIPTION
This PR adapts xtimer_msg_receive_timeout() to use the thread flag capabilities of msg.c.

It removes a race condition currently present:
" currently in xtimer_receive_msg_timeout, there's a race between receiving the message and deleting the timer, and if the thread has a message queue, that might lead to the timer message to be queued right after the actual received message.

This PR's xtimer_receive_msg_timeout() implementation uses a thread flag to pass the timeout information, solving the race problem."

Waiting for #4895.
