### PR TITLE
sys: xtimer: fix some race conditions

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -251,11 +251,8 @@ void xtimer_set(xtimer_t *timer, uint32_t offset);
  * @note this function runs in O(n) with n being the number of active timers
  *
  * @param[in] timer ptr to timer structure that will be removed
- *
- * @return  1 on success
- * @return  0 when timer was not active
  */
-int xtimer_remove(xtimer_t *timer);
+void xtimer_remove(xtimer_t *timer);
 
 /**
  * @brief receive a message blocking but with timeout


### PR DESCRIPTION
This PR (hopefully) fixes two issues:

#4902:
previously, _xtimer_set_absolute() would determine the current _long_cnt outside of a critical section, then determine using _this_high_period() whether the timer shoots in current or next period. If the overflow interrupt occurs in between, long_target is too low (and thus not in _this_high_period()), causing the timer to wrongly be added to the long list. This PR moves the critical section over initial _long_cnt determination.

#4841:
Previously, xtimer_set() would remove a timer outside of a critical section, then call _xtimer_set_absolute(). If the same timer would be set in between, it could end up twice in a timer list, causing xtimer to hang.
This PR refactors xtimer_remove into a safe and unsafe variant and adds a second check using the unsafe variant in _xtimer_set_absolute()'s critical section.