### PR TITLE
make: actually make use of APPDEPS for building

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -192,6 +192,7 @@ endif
 # the binaries to link
 BASELIBS += $(BINDIR)${APPLICATION}.a
 BASELIBS += $(USEPKG:%=${BINDIR}%.a)
+BASELIBS += $(APPDEPS)
 
 .PHONY: all clean flash term doc debug debug-server reset objdump help info-modules
 .PHONY: ..in-docker-container


### PR DESCRIPTION
Apparently the `APPDEPS` variable in the build system was not used to actually compile and link.