### PR TITLE
boards/x86-multiboot-common/include/multiboot.h: Add missing closing brace

### DIFF
--- a/boards/x86-multiboot-common/include/multiboot.h
+++ b/boards/x86-multiboot-common/include/multiboot.h
@@ -230,4 +230,8 @@ typedef struct multiboot_mod_list multiboot_module_t;
 
 #endif  /** ! ASM_FILE */
 
-#endif  /** ! MULTIBOOT_HEADER */
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /** ! MULTIBOOT_H_ */


### PR DESCRIPTION
Separated from #4643 