### PR TITLE
cpu: Cast enum to unsigned int before comparing against DEV_NUMOF

### DIFF
--- a/cpu/lpc11u34/periph/spi.c
+++ b/cpu/lpc11u34/periph/spi.c
@@ -139,7 +139,7 @@ int spi_conf_pins(spi_t dev)
 
 int spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_lock(&locks[dev]);
@@ -148,7 +148,7 @@ int spi_acquire(spi_t dev)
 
 int spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_unlock(&locks[dev]);

--- a/cpu/nrf51/periph/spi.c
+++ b/cpu/nrf51/periph/spi.c
@@ -51,10 +51,6 @@ static mutex_t locks[] =  {
 
 int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
-
     spi_poweron(dev);
 
     /* disable the device -> nRF51822 reference 3.0 26.1.1 and 27.1*/
@@ -132,10 +128,6 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data))
 
 int spi_conf_pins(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
-        return -1;
-    }
-
     switch (dev) {
 #if SPI_0_EN
         case SPI_0:
@@ -159,13 +151,15 @@ int spi_conf_pins(spi_t dev)
             spi[dev]->PSELSCK = SPI_1_PIN_SCK;
             break;
 #endif
+        default:
+            return -1;
     }
     return 0;
 }
 
 int spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_lock(&locks[dev]);
@@ -174,7 +168,7 @@ int spi_acquire(spi_t dev)
 
 int spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_unlock(&locks[dev]);
@@ -188,7 +182,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
 
 int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
 
@@ -227,14 +221,14 @@ void spi_transmission_begin(spi_t dev, char reset_val)
 
 void spi_poweron(spi_t dev)
 {
-    if (dev < SPI_NUMOF) {
+    if ((unsigned int)dev < SPI_NUMOF) {
         spi[dev]->POWER = 1;
     }
 }
 
 void spi_poweroff(spi_t dev)
 {
-    if (dev < SPI_NUMOF) {
+    if ((unsigned int)dev < SPI_NUMOF) {
         spi[dev]->POWER = 0;
     }
 }

--- a/cpu/sam3/periph/spi.c
+++ b/cpu/sam3/periph/spi.c
@@ -294,7 +294,7 @@ int spi_conf_pins(spi_t dev)
 
 int spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_lock(&locks[dev]);
@@ -303,7 +303,7 @@ int spi_acquire(spi_t dev)
 
 int spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_unlock(&locks[dev]);

--- a/cpu/samd21/periph/pwm.c
+++ b/cpu/samd21/periph/pwm.c
@@ -93,7 +93,7 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
     int scale = 1;
     uint32_t f_real;
 
-    if (dev >= PWM_NUMOF) {
+    if ((unsigned int)dev >= PWM_NUMOF) {
         return 0;
     }
 

--- a/cpu/samd21/periph/spi.c
+++ b/cpu/samd21/periph/spi.c
@@ -210,7 +210,7 @@ void spi_transmission_begin(spi_t dev, char reset_val)
 
 int spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_lock(&locks[dev]);
@@ -219,7 +219,7 @@ int spi_acquire(spi_t dev)
 
 int spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_unlock(&locks[dev]);

--- a/cpu/samd21/periph/uart.c
+++ b/cpu/samd21/periph/uart.c
@@ -68,7 +68,7 @@ static int init_base(uart_t uart, uint32_t baudrate)
     uint32_t baud;
     SercomUsart *dev;
 
-    if (uart < 0 || uart >= UART_NUMOF) {
+    if ((unsigned int)uart >= UART_NUMOF) {
         return -1;
     }
 

--- a/cpu/saml21/periph/spi.c
+++ b/cpu/saml21/periph/spi.c
@@ -183,7 +183,7 @@ void spi_transmission_begin(spi_t dev, char reset_val)
 
 int spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_lock(&locks[dev]);
@@ -192,7 +192,7 @@ int spi_acquire(spi_t dev)
 
 int spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_unlock(&locks[dev]);

--- a/cpu/stm32f0/periph/spi.c
+++ b/cpu/stm32f0/periph/spi.c
@@ -162,7 +162,7 @@ int spi_conf_pins(spi_t dev)
 
 int spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_lock(&locks[dev]);
@@ -171,7 +171,7 @@ int spi_acquire(spi_t dev)
 
 int spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_unlock(&locks[dev]);

--- a/cpu/stm32f1/periph/spi.c
+++ b/cpu/stm32f1/periph/spi.c
@@ -167,7 +167,7 @@ int spi_conf_pins(spi_t dev)
 
 int spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_lock(&locks[dev]);
@@ -176,7 +176,7 @@ int spi_acquire(spi_t dev)
 
 int spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_unlock(&locks[dev]);

--- a/cpu/stm32f3/periph/spi.c
+++ b/cpu/stm32f3/periph/spi.c
@@ -290,7 +290,7 @@ int spi_conf_pins(spi_t dev)
 
 int spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_lock(&locks[dev]);
@@ -299,7 +299,7 @@ int spi_acquire(spi_t dev)
 
 int spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_unlock(&locks[dev]);
@@ -335,7 +335,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
 
 void spi_transmission_begin(spi_t dev, char reset_val)
 {
-    if (dev < SPI_NUMOF) {
+    if ((unsigned int)dev < SPI_NUMOF) {
         spi[dev]->DR = reset_val;
     }
 }

--- a/cpu/stm32f4/periph/spi.c
+++ b/cpu/stm32f4/periph/spi.c
@@ -294,7 +294,7 @@ int spi_conf_pins(spi_t dev)
 
 int spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_lock(&locks[dev]);
@@ -303,7 +303,7 @@ int spi_acquire(spi_t dev)
 
 int spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_unlock(&locks[dev]);

--- a/cpu/stm32f4/periph/uart.c
+++ b/cpu/stm32f4/periph/uart.c
@@ -65,7 +65,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     uint8_t fraction;
 
     /* check if given UART device does exist */
-    if (uart < 0 || uart >= UART_NUMOF) {
+    if ((unsigned int)uart >= UART_NUMOF) {
         return -1;
     }
 

--- a/cpu/stm32l1/periph/i2c.c
+++ b/cpu/stm32l1/periph/i2c.c
@@ -66,16 +66,14 @@ static mutex_t locks[] =  {
 
 int i2c_init_master(i2c_t dev, i2c_speed_t speed)
 {
-    I2C_TypeDef *i2c = i2c_config[dev].dev;
     int ccr;
 
-    if (dev >= I2C_NUMOF) {
+    if ((unsigned int)dev >= I2C_NUMOF) {
         return -1;
     }
 
     /* read speed configuration */
     switch (speed) {
-
         case I2C_SPEED_NORMAL:
             ccr = I2C_APBCLK / 200000;
             break;
@@ -87,6 +85,7 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
         default:
             return -2;
     }
+    I2C_TypeDef *i2c = i2c_config[dev].dev;
 
     /* enable I2C clock */
     i2c_poweron(dev);
@@ -148,14 +147,14 @@ int i2c_read_byte(i2c_t dev, uint8_t address, char *data)
 
 int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
 {
-    I2C_TypeDef *i2c = i2c_config[dev].dev;
     unsigned int state;
     int i = 0;
 
-    if (dev >= I2C_NUMOF) {
+    if ((unsigned int)dev >= I2C_NUMOF) {
         return -1;
     }
 
+    I2C_TypeDef *i2c = i2c_config[dev].dev;
     switch (length) {
         case 1:
             DEBUG("Send Slave address and wait for ADDR == 1\n");
@@ -272,11 +271,11 @@ int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, char *data)
 
 int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int length)
 {
-    I2C_TypeDef *i2c = i2c_config[dev].dev;
-
-    if (dev >= I2C_NUMOF) {
+    if ((unsigned int)dev >= I2C_NUMOF) {
         return -1;
     }
+
+    I2C_TypeDef *i2c = i2c_config[dev].dev;
 
     /* send start condition and slave address */
     DEBUG("Send slave address and clear ADDR flag\n");
@@ -296,11 +295,11 @@ int i2c_write_byte(i2c_t dev, uint8_t address, char data)
 
 int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
 {
-    I2C_TypeDef *i2c = i2c_config[dev].dev;
-
-    if (dev >= I2C_NUMOF) {
+    if ((unsigned int)dev >= I2C_NUMOF) {
         return -1;
     }
+
+    I2C_TypeDef *i2c = i2c_config[dev].dev;
 
     /* start transmission and send slave address */
     DEBUG("sending start sequence\n");
@@ -322,11 +321,11 @@ int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, char data)
 
 int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int length)
 {
-    I2C_TypeDef *i2c = i2c_config[dev].dev;
-
-    if (dev >= I2C_NUMOF) {
+    if ((unsigned int)dev >= I2C_NUMOF) {
         return -1;
     }
+
+    I2C_TypeDef *i2c = i2c_config[dev].dev;
 
     /* start transmission and send slave address */
     _start(i2c, address, I2C_FLAG_WRITE);
@@ -343,14 +342,14 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int leng
 
 void i2c_poweron(i2c_t dev)
 {
-    if (dev < I2C_NUMOF) {
+    if ((unsigned int)dev < I2C_NUMOF) {
         RCC->APB1ENR |= (RCC_APB1ENR_I2C1EN << dev);
     }
 }
 
 void i2c_poweroff(i2c_t dev)
 {
-    if (dev < I2C_NUMOF) {
+    if ((unsigned int)dev < I2C_NUMOF) {
         while (i2c_config[dev].dev->SR2 & I2C_SR2_BUSY);
         RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN << dev);
     }

--- a/cpu/stm32l1/periph/spi.c
+++ b/cpu/stm32l1/periph/spi.c
@@ -158,7 +158,7 @@ int spi_conf_pins(spi_t dev)
 
 int spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_lock(&locks[dev]);
@@ -167,7 +167,7 @@ int spi_acquire(spi_t dev)
 
 int spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_unlock(&locks[dev]);


### PR DESCRIPTION
This PR changes all less than comparisons of enums against DEV_NUMOF in the periph drivers to prevent https://llvm.org/bugs/show_bug.cgi?id=16154 from biting us when compiling with `TOOLCHAIN=llvm`.

Also fixed some small mistakes in the periph drivers (missing default case in nrf51, array out of bounds read in stm32l1. 

Separated from #4643 