### PR TITLE
core: reduce types of tcb->status and tcb->priority

### DIFF
--- a/core/include/tcb.h
+++ b/core/include/tcb.h
@@ -61,10 +61,10 @@
  */
 typedef struct tcb_t {
     char *sp;                   /**< thread's stack pointer         */
-    uint16_t status;            /**< thread's status                */
+    uint8_t status;             /**< thread's status                */
+    uint8_t priority;           /**< thread's priority              */
 
     kernel_pid_t pid;           /**< thread's process id            */
-    uint16_t priority;          /**< thread's priority              */
 
     clist_node_t rq_entry;      /**< run queue entry                */
 

--- a/tests/sizeof_tcb/main.c
+++ b/tests/sizeof_tcb/main.c
@@ -33,8 +33,8 @@ int main(void)
 
     P(sp);
     P(status);
-    P(pid);
     P(priority);
+    P(pid);
     P(rq_entry);
     P(wait_data);
     P(msg_waiters);


### PR DESCRIPTION
This PR changes the types of tcb->status and tcb->priority to uint8_t.

Together with #4557, #4923 and #3851, sizeof(tcb_t) is down from 44 to 12 bytes.