### PR TITLE
drivers/periph: reworked I2C driver

### DIFF
--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -244,28 +244,24 @@ static const uart_conf_t uart_config[] = {
  * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF           (1U)
-#define I2C_0_EN            1
-#define I2C_IRQ_PRIO        1
-#define I2C_APBCLK          (42000000U)
+static const i2c_conf_t i2c_config[] = {
+    /* device, SDA pin, SCL pin, SDA AF, SCL AF, bus speed, rcc_bit, irqn */
+    {
+        I2C1,
+        GPIO_PIN(PORT_B, 6),
+        GPIO_PIN(PORT_B, 7)},
+        4,
+        4,
+        I2C_SPEED_NORMAL,
+        RCC_APB1ENR_I2C1EN,
+        isr_i2c1_ev,
+    }
+};
 
-/* I2C 0 device configuration */
-#define I2C_0_DEV           I2C1
-#define I2C_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C1EN)
-#define I2C_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
-#define I2C_0_EVT_IRQ       I2C1_EV_IRQn
 #define I2C_0_EVT_ISR       isr_i2c1_ev
-#define I2C_0_ERR_IRQ       I2C1_ER_IRQn
 #define I2C_0_ERR_ISR       isr_i2c1_er
-/* I2C 0 pin configuration */
-#define I2C_0_SCL_PORT      GPIOB
-#define I2C_0_SCL_PIN       6
-#define I2C_0_SCL_AF        4
-#define I2C_0_SCL_CLKEN()   (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
-#define I2C_0_SDA_PORT      GPIOB
-#define I2C_0_SDA_PIN       7
-#define I2C_0_SDA_AF        4
-#define I2C_0_SDA_CLKEN()   (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0])
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -241,20 +241,19 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @name I2C configuration
+ * @brief   I2C configuration
  * @{
  */
 static const i2c_conf_t i2c_config[] = {
-    /* device, SDA pin, SCL pin, SDA AF, SCL AF, bus speed, rcc_bit, irqn */
     {
-        I2C1,
-        GPIO_PIN(PORT_B, 6),
-        GPIO_PIN(PORT_B, 7)},
-        4,
-        4,
-        I2C_SPEED_NORMAL,
-        RCC_APB1ENR_I2C1EN,
-        isr_i2c1_ev,
+        .dev      = I2C1,
+        .scl_pin  = GPIO_PIN(PORT_B, 6),
+        .sda_pin  = GPIO_PIN(PORT_B, 7),
+        .scl_af   = 4,
+        .sda_af   = 4,
+        .speed    = I2C_SPEED(I2C_SPEED_NORMAL),
+        .rcc_mask = RCC_APB1ENR_I2C1EN,
+        .irqn     = I2C1_EV_IRQn,
     }
 };
 

--- a/cpu/stm32f4/include/periph_cpu.h
+++ b/cpu/stm32f4/include/periph_cpu.h
@@ -88,16 +88,21 @@ typedef enum {
 #endif /* ndef DOXYGEN */
 
 /**
+ * @brief   Calculate the I2C speed value
+ */
+#define I2C_SPEED(mode)         ((mode << 15) | (CLOCK_APB1 / (2 << (2 * mode) * 10000))
+
+/**
  * @brief   Override I2C speed options
  * @{
  */
 #define HAVE_I2C_SPEED_T
 typedef enum {
-    I2C_SPEED_LOW = 0,      /**< low speed mode:    ~10kbit/s */
-    I2C_SPEED_NORMAL,       /**< normal mode:       ~100kbit/s */
-    I2C_SPEED_FAST,         /**< fast mode:         ~400kbit/sj */
-    I2C_SPEED_FAST_PLUS,    /**< fast plus mode:    ~1Mbit/s */
-    I2C_SPEED_HIGH,         /**< high speed mode:   ~3.4Mbit/s */
+    I2C_SPEED_LOW       = -1,   /**< low speed mode:    ~10kbit/s */
+    I2C_SPEED_NORMAL    =  0,   /**< normal mode:       ~100kbit/s */
+    I2C_SPEED_FAST      =  1,   /**< fast mode:         ~400kbit/sj */
+    I2C_SPEED_FAST_PLUS = -1,   /**< fast plus mode:    ~1Mbit/s */
+    I2C_SPEED_HIGH      = -1,   /**< high speed mode:   ~3.4Mbit/s */
 } i2c_speed_t;
 /** @} */
 
@@ -173,8 +178,9 @@ typedef struct {
     gpio_t sda_pin;         /**< data pin */
     uint8_t scl_af;         /**< SCL pin alternate function */
     uint8_t sda_af;         /**< SDA pin alternate function */
+    gpio_mode_t pin_mode;   /**< OD with or without pull resistor */
     i2c_speed_t speed;      /**< I2C bus speed */
-    uint8_t rcc_bit;        /**< bit in the rcc register */
+    uint8_t rcc_mask;       /**< bit mask for the RCC register */
     uint8_t irqn;           /**< IRQ channel */
 } i2c_conf_t;
 

--- a/cpu/stm32f4/include/periph_cpu.h
+++ b/cpu/stm32f4/include/periph_cpu.h
@@ -88,6 +88,20 @@ typedef enum {
 #endif /* ndef DOXYGEN */
 
 /**
+ * @brief   Override I2C speed options
+ * @{
+ */
+#define HAVE_I2C_SPEED_T
+typedef enum {
+    I2C_SPEED_LOW = 0,      /**< low speed mode:    ~10kbit/s */
+    I2C_SPEED_NORMAL,       /**< normal mode:       ~100kbit/s */
+    I2C_SPEED_FAST,         /**< fast mode:         ~400kbit/sj */
+    I2C_SPEED_FAST_PLUS,    /**< fast plus mode:    ~1Mbit/s */
+    I2C_SPEED_HIGH,         /**< high speed mode:   ~3.4Mbit/s */
+} i2c_speed_t;
+/** @} */
+
+/**
  * @brief   Available ports on the STM32F4 family
  */
 enum {
@@ -148,6 +162,21 @@ typedef struct {
     uint8_t dev;            /**< ADCx - 1 device used for the channel */
     uint8_t chan;           /**< CPU ADC channel connected to the pin */
 } adc_conf_t;
+/** @} */
+
+/**
+ * @brief   I2C configuration options
+ */
+typedef struct {
+    I2C_TypeDef *dev;       /**< I2C device */
+    gpio_t scl_pin;         /**< clock pin */
+    gpio_t sda_pin;         /**< data pin */
+    uint8_t scl_af;         /**< SCL pin alternate function */
+    uint8_t sda_af;         /**< SDA pin alternate function */
+    i2c_speed_t speed;      /**< I2C bus speed */
+    uint8_t rcc_bit;        /**< bit in the rcc register */
+    uint8_t irqn;           /**< IRQ channel */
+} i2c_conf_t;
 
 /**
  * @brief   DAC line configuration data

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -219,7 +219,7 @@ int i2c_read_reg(i2c_t dev, uint8_t addr, uint8_t reg,
  *
  * @return                  I2C_ACK on successful transfer of @p data
  * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_DATA_NACK if response to any data byte was NACK
+ * @return                  I2C_DATA_NACK if response to the data byte was NACK
  * @return                  I2C_ERR for any other error
  */
 int i2c_write_byte(i2c_t dev, uint8_t addr, uint8_t data);
@@ -249,7 +249,8 @@ int i2c_write_bytes(i2c_t dev, uint8_t addr, uint8_t *data, size_t len);
  *
  * @return                  I2C_ACK on successful transfer of @p data to @p reg
  * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_DATA_NACK if response to any data byte was NACK
+ * @return                  I2C_DATA_NACK if response to the addr or the data
+ *                          byte was NACK
  * @return                  I2C_ERR for any other error
  */
 int i2c_write_reg(i2c_t dev, uint8_t addr, uint8_t reg, uint8_t data);
@@ -267,7 +268,8 @@ int i2c_write_reg(i2c_t dev, uint8_t addr, uint8_t reg, uint8_t data);
  * @return                  I2C_ACK on successful transfer of @p len byte
  *                          to @p reg
  * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_DATA_NACK if response to any data byte was NACK
+ * @return                  I2C_DATA_NACK if response to the addr or to any data
+ *                          byte was NACK
  * @return                  I2C_ERR for any other error
  */
 int i2c_write_regs(i2c_t dev, uint8_t addr, uint8_t reg,

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -137,7 +137,7 @@ enum {
      *
      * The slave responded to a data byte written to it with a NACK.
      */
-    I2C_NACK_DATA = -2       /**< data error */
+    I2C_DATA_NACK = -2       /**< data error */
      /**
       * @brief   Internal error
       *
@@ -219,7 +219,7 @@ int i2c_read_reg(i2c_t dev, uint8_t addr, uint8_t reg,
  *
  * @return                  I2C_ACK on successful transfer of @p data
  * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_NACK_DATA if response to any data byte was NACK
+ * @return                  I2C_DATA_NACK if response to any data byte was NACK
  * @return                  I2C_ERR for any other error
  */
 int i2c_write_byte(i2c_t dev, uint8_t addr, uint8_t data);
@@ -234,7 +234,7 @@ int i2c_write_byte(i2c_t dev, uint8_t addr, uint8_t data);
  *
  * @return                  I2C_ACK on successful transfer of @p len byte
  * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_NACK_DATA if response to any data byte was NACK
+ * @return                  I2C_DATA_NACK if response to any data byte was NACK
  * @return                  I2C_ERR for any other error
  */
 int i2c_write_bytes(i2c_t dev, uint8_t addr, uint8_t *data, size_t len);
@@ -249,7 +249,7 @@ int i2c_write_bytes(i2c_t dev, uint8_t addr, uint8_t *data, size_t len);
  *
  * @return                  I2C_ACK on successful transfer of @p data to @p reg
  * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_NACK_DATA if response to any data byte was NACK
+ * @return                  I2C_DATA_NACK if response to any data byte was NACK
  * @return                  I2C_ERR for any other error
  */
 int i2c_write_reg(i2c_t dev, uint8_t addr, uint8_t reg, uint8_t data);
@@ -267,7 +267,7 @@ int i2c_write_reg(i2c_t dev, uint8_t addr, uint8_t reg, uint8_t data);
  * @return                  I2C_ACK on successful transfer of @p len byte
  *                          to @p reg
  * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_NACK_DATA if response to any data byte was NACK
+ * @return                  I2C_DATA_NACK if response to any data byte was NACK
  * @return                  I2C_ERR for any other error
  */
 int i2c_write_regs(i2c_t dev, uint8_t addr, uint8_t reg,

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -101,16 +101,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Flag signaling a write operation on the bus
- */
-#define I2C_FLAG_WRITE      0
-
-/**
- * @brief   Flag signaling a read operation on the bus
- */
-#define I2C_FLAG_READ       1
-
-/**
  * @brief   Default I2C device access macro
  * @{
  */
@@ -158,8 +148,10 @@ typedef enum {
  */
 #ifndef HAVE_I2C_FLAGS_T
 enum {
-    I2C_ADDR10 = 0x01,      /**< use 10-bit device addressing */
-    I2C_NOSTOP = 0x02       /**< do not issue a STOP condition after transfer */
+    I2C_WRITE  = 0x00,      /**< write data to the device */
+    I2C_READ   = 0x01,      /**< read data from the device */
+    I2C_ADDR10 = 0x02,      /**< use 10-bit device addressing */
+    I2C_NOSTOP = 0x04       /**< do not issue a STOP condition after transfer */
 };
 #endif
 /** @} */
@@ -232,35 +224,20 @@ int i2c_acquire(i2c_t dev);
 void i2c_release(i2c_t dev);
 
 /**
- * @brief   Read data from an I2C device with the given address
+ * @brief   Read or write data from/to the given I2C device
  *
  * @param[in]  dev          I2C peripheral device
  * @param[in]  addr         7-bit or 10-bit device address (right-aligned)
  * @param[out] data         array holding the received bytes
  * @param[in]  len          the number of bytes to read into @p data
- * @param[in]  flags        optional flags (see I2C_ADDR10 and I2C_NOSTOP)
+ * @param[in]  flags        flags to specify read/write, no stop or addr width
  *
  * @return                  I2C_ACK on successful transfer of @p len byte
  * @return                  I2C_ADDR_NACK if response to address byte was NACK
  * @return                  I2C_ERR for any other error
  */
-int i2c_read(i2c_t dev, uint16_t addr, uint8_t *data, size_t len, uint8_t flags);
-
-/**
- * @brief   Write multiple bytes to an I2C device with the given address
- *
- * @param[in] dev           I2C peripheral device
- * @param[in] addr          7-bit or 10-bit device address (right-aligned)
- * @param[in] data          array with bytes to write to the target device
- * @param[in] len           number of bytes to write to the target device
- * @param[in] flags         optional flags (see I2C_ADDR10 and I2C_NOSTOP)
- *
- * @return                  I2C_ACK on successful transfer of @p len byte
- * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_DATA_NACK if response to any data byte was NACK
- * @return                  I2C_ERR for any other error
- */
-int i2c_write(i2c_t dev, uint16_t addr, uint8_t *data, size_t len, uint8_t flags);
+int i2c_transfer(i2c_t dev, uint16_t addr,
+                 uint8_t *data, size_t len, uint8_t flags);
 
 /**
  * @brief   Convenience function for writing a single byte to the bus
@@ -278,6 +255,10 @@ int i2c_write(i2c_t dev, uint16_t addr, uint8_t *data, size_t len, uint8_t flags
  * @return                  I2C_ERR for any other error
  */
 int i2c_write_byte(i2c_t dev, uint16_t addr, uint8_t data, uint8_t flags);
+
+
+/* TODO: re-add read/write reg convenience functions */
+
 
 #ifdef __cplusplus
 }

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -242,7 +242,7 @@ void i2c_release(i2c_t dev);
  * @return                  I2C_ADDR_NACK if response to address byte was NACK
  * @return                  I2C_ERR for any other error
  */
-int i2c_read(i2c_t dev, uint16_t addr, uint8_t *data, size_t len, uint8_t flags);
+int i2c_read(i2c_t dev, uint16_t addr, void *data, size_t len, uint8_t flags);
 
 /**
  * @brief   Convenience function for reading data from a given register address
@@ -263,7 +263,7 @@ int i2c_read(i2c_t dev, uint16_t addr, uint8_t *data, size_t len, uint8_t flags)
  * @return                  I2C_ERR for any other error
  */
 int i2c_read_reg(ic2_t dev, uint16_t addr, uint16_t reg,
-                 uint8_t *data, size_t len, uint8_t flags);
+                 void *data, size_t len, uint8_t flags);
 
 /**
  * @brief   Write data from/to the given I2C device
@@ -279,7 +279,7 @@ int i2c_read_reg(ic2_t dev, uint16_t addr, uint16_t reg,
  * @return                  I2C_ERR for any other error
  */
 int i2c_write(i2c_t dev, uint16_t addr,
-              const uint8_t *data, size_t len, uint8_t flags);
+              const void *data, size_t len, uint8_t flags);
 
 /**
  * @brief   Convenience function for writing a single byte onto the bus
@@ -316,7 +316,7 @@ int i2c_write_byte(i2c_t dev, uint16_t addr, uint8_t data, uint8_t flags);
  * @return                  I2C_ERR for any other error
  */
 int i2c_write_reg(i2c_t dev, uint16_t addr, uint16_t reg,
-                  const uint8_t *data, size_t len, uint8_t flags);
+                  const void *data, size_t len, uint8_t flags);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 Freie Universität Berlin
+ * Copyright (C) 2014-2016 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -51,17 +51,15 @@
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  */
 
-#ifndef I2C_H
-#define I2C_H
+#ifndef PERIPH_I2C_H
+#define PERIPH_I2C_H
 
 #include <stdint.h>
 #include <limits.h>
 
+#include "periph_conf.h"
 #include "periph_cpu.h"
-/**
- * @todo    Remove dev_enums.h include once all platforms are ported to the
- *          updated periph interface
- */
+/* TODO: remove once all platforms are ported to this interface */
 #include "periph/dev_enums.h"
 
 #ifdef __cplusplus
@@ -121,16 +119,39 @@ typedef enum {
 /** @} */
 
 /**
- * @brief   Initialize an I2C device to run as bus master
+ * @brief   I2C error codes
+ */
+enum {
+    I2C_OK       = 0,       /**< everything went fine */
+    /**
+     * @brief   Address error
+     *
+     * After the address + the read/write bit were send, the addressed slave did
+     * not respond with an ACK. This means that either the address was wrong or
+     * that the slave is not connected correctly.
+     */
+    I2C_ERR_ADDR = -1
+    /**
+     * @brief   Data error
+     *
+     * An error occurred while transferring the data from/to the slave. Possible
+     * reasons are overrun errors, NACKs when writing to the slave, or similar.
+     */
+    I2C_ERR_DATA = -2       /**< data error */
+};
+
+/**
+ * @brief   Initialize the given I2C bus
+ *
+ * The given I2C device will be initialized with the parameters as specified in
+ * the boards periph_conf.h, using the pins and the speed value given there.
  *
  * @param[in] dev           the device to initialize
- * @param[in] speed         the selected bus speed
  *
  * @return                  0 on successful initialization
  * @return                  -1 on undefined device given
- * @return                  -2 on unsupported speed value
  */
-int i2c_init_master(i2c_t dev, i2c_speed_t speed);
+int i2c_init(i2c_t dev);
 
 /**
  * @brief   Get mutually exclusive access to the given I2C bus
@@ -141,7 +162,8 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed);
  * @param[in] dev       I2C device to access
  *
  * @return              0 on success
- * @return              -1 on error
+ * @return              -1 on invalid device
+ * @return              -2 on unsupported speed value
  */
 int i2c_acquire(i2c_t dev);
 
@@ -149,139 +171,102 @@ int i2c_acquire(i2c_t dev);
  * @brief   Release the given I2C device to be used by others
  *
  * @param[in] dev       I2C device to release
- *
- * @return              0 on success
- * @return              -1 on error
  */
-int i2c_release(i2c_t dev);
+void i2c_release(i2c_t dev);
 
 /**
- * @brief   Read one byte from an I2C device with the given address
+ * @brief   Read data from an I2C device with the given address
  *
  * @param[in]  dev          I2C peripheral device
- * @param[in]  address      bus address of the target device
- * @param[out] data         the result that was read
- *
- * @return                  the number of bytes that were read
- * @return                  -1 on undefined device given
- * @return                  -2 on invalid address
- */
-int i2c_read_byte(i2c_t dev, uint8_t address, char *data);
-
-/**
- * @brief   Read multiple bytes from an I2C device with the given address
- *
- * @param[in]  dev          I2C peripheral device
- * @param[in]  address      bus address of the target device
+ * @param[in]  addr         7-bit device address (right-aligned)
  * @param[out] data         array holding the received bytes
  * @param[in]  length       the number of bytes to read into `data`
  *
- * @return                  the number of bytes that were read
- * @return                  -1 on undefined device given
+ * @return                  I2C_OK on successful transfer of @p len byte
+ * @return                  I2C_ERR_ADDR on address error
+ * @return                  I2C_ERR_DATA on data error
  */
-int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length);
+int i2c_read(i2c_t dev, uint8_t addr, uint8_t *data, size_t len);
 
 /**
- * @brief   Read one byte from a register at the I2C slave with the given
- *          address
+ * @brief   Read data from a specified register
  *
  * @param[in]  dev          I2C peripheral device
- * @param[in]  address      bus address of the target device
- * @param[in]  reg          the register address on the targeted I2C device
- * @param[out] data         the result that was read
- *
- * @return                  the number of bytes that were read
- * @return                  -1 on undefined device given
- */
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, char *data);
-
-/**
- * @brief   Read multiple bytes from a register at the I2C slave with the given
- *          address
- *
- * @param[in]  dev          I2C peripheral device
- * @param[in]  address      bus address of the target device
+ * @param[in]  addr         7-bit device address (right-aligned)
  * @param[in]  reg          the register address on the targeted I2C device
  * @param[out] data         array holding the received bytes
- * @param[in]  length       the number of bytes to read into `data`
+ * @param[in]  len          number of bytes to read into `data
  *
- * @return                  the number of bytes that were read
- * @return                  -1 on undefined device given
+ * @return                  I2C_OK on successful transfer of @p len byte
+ *                          to @p reg
+ * @return                  I2C_ERR_ADDR on address error
+ * @return                  I2C_ERR_DATA on data error
  */
-int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg,
-                  char *data, int length);
+int i2c_read_reg(i2c_t dev, uint8_t addr, uint8_t reg,
+                 uint8_t *data, size_t len);
 
 /**
  * @brief   Write one byte to an I2C device with the given address
  *
  * @param[in] dev           I2C peripheral device
- * @param[in] address       bus address of the target device
+ * @param[in] addr          7-bit device address (right-aligned)
  * @param[in] data          byte to write to the device
  *
- * @return                  the number of bytes that were written
- * @return                  -1 on undefined device given
+ * @return                  I2C_OK on successful transfer of @p data
+ * @return                  I2C_ERR_ADDR on address error
+ * @return                  I2C_ERR_DATA on data error
  */
-int i2c_write_byte(i2c_t dev, uint8_t address, char data);
+int i2c_write_byte(i2c_t dev, uint8_t addr, uint8_t data);
 
 /**
  * @brief   Write multiple bytes to an I2C device with the given address
  *
  * @param[in] dev           I2C peripheral device
- * @param[in] address       bus address of the target device
+ * @param[in] addr          7-bit device address (right-aligned)
  * @param[in] data          array with bytes to write to the target device
- * @param[in] length        number of bytes to write to the target device
+ * @param[in] len           number of bytes to write to the target device
  *
- * @return                  the number of bytes that were written
- * @return                  -1 on undefined device given
+ * @return                  I2C_OK on successful transfer of @p len byte
+ * @return                  I2C_ERR_ADDR on address error
+ * @return                  I2C_ERR_DATA on data error
  */
-int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length);
+int i2c_write_bytes(i2c_t dev, uint8_t addr, uint8_t *data, size_t len);
 
 /**
  * @brief   Write one byte to a register at the I2C slave with the given address
  *
  * @param[in] dev           I2C peripheral device
- * @param[in] address       bus address of the target device
+ * @param[in] addr          7-bit device address (right-aligned)
  * @param[in] reg           the register address on the targeted I2C device
  * @param[in] data          byte to write to the device
  *
- * @return                  the number of bytes that were written
- * @return                  -1 on undefined device given
+ * @return                  I2C_OK on successful transfer of @p data to @p reg
+ * @return                  I2C_ERR_ADDR on address error
+ * @return                  I2C_ERR_DATA on data error
  */
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, char data);
+int i2c_write_reg(i2c_t dev, uint8_t addr, uint8_t reg, uint8_t data);
 
 /**
  * @brief   Write multiple bytes to a register at the I2C slave with the given
  *          address
  *
  * @param[in] dev           I2C peripheral device
- * @param[in] address       bus address of the target device
+ * @param[in] addr          7-bit device address (right-aligned)
  * @param[in] reg           the register address on the targeted I2C device
  * @param[in] data          array with bytes to write to the target device
- * @param[in] length        number of bytes to write to the target device
+ * @param[in] len           number of bytes to write to the target device
  *
- * @return                  the number of bytes that were written
- * @return                  -1 on undefined device given
+ * @return                  I2C_OK on successful transfer of @p len byte
+ *                          to @p reg
+ * @return                  I2C_ERR_ADDR on address error
+ * @return                  I2C_ERR_DATA on data error
  */
-int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg,
-                   char *data, int length);
-
-/**
- * @brief   Power on the given I2C peripheral
- *
- * @param[in] dev           the I2C device to power on
- */
-void i2c_poweron(i2c_t dev);
-
-/**
- * @brief   Power off the given I2C peripheral
- *
- * @param[in] dev           the I2C device to power off
- */
-void i2c_poweroff(i2c_t dev);
+int i2c_write_regs(i2c_t dev, uint8_t addr, uint8_t reg,
+                   uint8_t *data, size_t len);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* I2C_H */
+#endif /* PERIPH_I2C_H */
 /** @} */

--- a/drivers/isl29020/isl29020.c
+++ b/drivers/isl29020/isl29020.c
@@ -30,87 +30,78 @@ int isl29020_init(isl29020_t *dev, i2c_t i2c, uint8_t address,
                   isl29020_range_t range, isl29020_mode_t mode)
 {
     int res;
-    char tmp;
+    uint8_t tmp[] = {ISL29020_REG_CMD, 0};
 
     /* initialize device descriptor */
     dev->i2c = i2c;
     dev->address = address;
     dev->lux_fac = (float)((1 << (10 + (2 * range))) - 1) / 0xffff;
 
-    /* acquire exclusive access to the bus */
-    i2c_acquire(dev->i2c);
-    /* initialize the I2C bus */
-    i2c_init_master(i2c, I2C_SPEED_NORMAL);
+    /* initialize the I2C bus -> TODO: move to auto-init? */
+    if (i2c_init_master(i2c, I2C_SPEED_NORMAL) < 0) {
+        DEBUG("[isl29020] error when initializing the I2C bus\n");
+    }
 
     /* configure and enable the sensor */
-    tmp = ISL29020_CMD_EN | ISL29020_CMD_MODE | ISL29020_RES_INT_16 | range | (mode << 5);
-    res = i2c_write_reg(dev->i2c, address, ISL29020_REG_CMD, tmp);
-    /* release the bus for other threads */
+    tmp[1] = (ISL29020_CMD_EN | ISL29020_CMD_MODE |
+              ISL29020_RES_INT_16 | range | (mode << 5));
+    i2c_acquire(dev_i2c);
+    res = i2c_write(dev->i2c, address, tmp, 2, 0);
     i2c_release(dev->i2c);
-    if (res < 1) {
+
+    /* make sure the write was successful */
+    if (res != I2C_ACK) {
+        DEBUG("[isl29020] error while enabling the sensor\n");
         return -1;
     }
+
     return 0;
 }
 
 int isl29020_read(isl29020_t *dev)
 {
-    char low, high;
+    uint8_t low, high;
     uint16_t res;
-    int ret;
 
-    i2c_acquire(dev->i2c);
     /* read lighting value */
-    ret = i2c_read_reg(dev->i2c, dev->address, ISL29020_REG_LDATA, &low);
-    ret += i2c_read_reg(dev->i2c, dev->address, ISL29020_REG_HDATA, &high);
+    i2c_acquire(dev->i2c);
+    i2c_write_byte(dev->i2c, &dev->address, ISL29020_REG_LDATA, I2C_NOSTOP);
+    i2c_read(dev->i2c, dev->address, &low, 1, 0);
+    i2c_write_byte(dev->i2c, &dev->address, ISL29020_REG_LDATA, I2C_NOSTOP);
+    i2c_read(dev->i2c, dev->address, &high, 1, 0);
     i2c_release(dev->i2c);
-    if (ret < 2) {
-        return -1;
-    }
+
     res = (high << 8) | low;
     DEBUG("ISL29020: Raw value: %i - high: %i, low: %i\n", res, high, low);
+
     /* calculate and return the actual lux value */
     return (int)(dev->lux_fac * res);
 }
 
 int isl29020_enable(isl29020_t *dev)
 {
-    int res;
-    char tmp;
+    uint8_t tmp[] = {ISL29020_REG_CMD, 0};
 
     i2c_acquire(dev->i2c);
-    res = i2c_read_reg(dev->i2c, dev->address, ISL29020_REG_CMD, &tmp);
-    if (res < 1) {
-        i2c_release(dev->i2c);
-        return -1;
-    }
-    tmp |= ISL29020_CMD_EN;
-    res = i2c_write_reg(dev->i2c, dev->address, ISL29020_REG_CMD, tmp);
-    if (res < 1) {
-        i2c_release(dev->i2c);
-        return -1;
-    }
+    i2c_write_byte(dev->i2c, &dev->address, tmp[0], I2C_NOSTOP);
+    i2c_read(dev->i2c, dev->address, &tmp[1], 1, 0);
+    tmp[1] |= ISL29020_CMD_EN;
+    i2c_write(dev->i2c, &dev->address, tmp, 2, 0);
     i2c_release(dev->i2c);
+
     return 0;
 }
 
 int isl29020_disable(isl29020_t *dev)
 {
-    int res;
-    char tmp;
+    uint8_t tmp[] = {ISL29020_REG_CMD, 0};
 
     i2c_acquire(dev->i2c);
-    res = i2c_read_reg(dev->i2c, dev->address, ISL29020_REG_CMD, &tmp);
-    if (res < 1) {
-        i2c_release(dev->i2c);
-        return -1;
-    }
-    tmp &= ~(ISL29020_CMD_EN);
-    res = i2c_write_reg(dev->i2c, dev->address, ISL29020_REG_CMD, tmp);
-    if (res < 1) {
-        i2c_release(dev->i2c);
-        return -1;
-    }
+    i2c_write_byte(dev->i2c, &dev->address, tmp[0], I2C_NOSTOP);
+    i2c_read(dev->i2c, dev->address, &tmp[1], 1, 0);
+    tmp[1] &= ~(ISL29020_CMD_EN);
+    i2c_write(dev->i2c, &dev->address, tmp, 2, 0);
     i2c_release(dev->i2c);
+
     return 0;
 }

--- a/drivers/periph_common/i2c.c
+++ b/drivers/periph_common/i2c.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_periph_i2c
+ * @{
+ *
+ * @file
+ * @brief       Common I2C fallback implementations
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "cpu.h"
+#include "periph/i2c.h"
+
+#ifdef PERIPH_I2C_NEEDS_READ_REG
+int i2c_read_reg(ic2_t dev, uint16_t addr, uint16_t reg,
+                 uint8_t *data, size_t len, uint8_t flags)
+{
+    int res;
+
+    /* NOSTART invalid for this function */
+    flags &= ~(I2C_NOSTART);
+
+    /* write register address */
+    if (flags & I2C_REG16) {
+        uint8_t r = (addr & 0xff);
+        res = i2c_write(dev, addr, &r, 1, (flags | I2C_NOSTOP));
+    } else {
+        res = i2c_write(dev, addr, &addr, 2, (flags | I2C_NOSTOP));
+    }
+
+    /* check for errors */
+    if (res != I2C_ACK) {
+        return res;
+    }
+
+    /* read actual data */
+    return i2c_read(dev, addr, data, len, flags);
+}
+#endif
+
+#ifdef PERIPH_I2C_NEEDS_WRITE_BYTE
+int i2c_write_byte(i2c_t dev, uint16_t addr, uint8_t data, uint8_t flags)
+{
+    return i2c_write(dev, addr, &data, 1, flags);
+}
+#endif
+
+#ifdef PERIPH_I2C_NEEDS_WRITE_REG
+int i2c_write_reg(i2c_t dev, uint16_t addr, uint16_t reg,
+                  const uint8_t *data, size_t len, uint8_t flags)
+{
+    int res;
+
+    /* NOSTART invalid for this function */
+    flags &= ~(I2C_NOSTART);
+
+    /* write register address */
+    if (flags & I2C_REG16) {
+        uint8_t r = (addr & 0xff);
+        res = i2c_write(dev, addr, &r, 1, (flags | I2C_NOSTOP));
+    } else {
+        res = i2c_write(dev, addr, &addr, 2, (flags | I2C_NOSTOP));
+    }
+
+    /* check for errors */
+    if (res != I2C_ACK) {
+        return res;
+    }
+
+    /* write data */
+    return i2c_write(dev, addr, data, len, flags);
+}
+#endif


### PR DESCRIPTION
Analog to #4780: This PR brings the I2C driver up-to-date with our current discussions. But as in #4780, we need to agree on this concept until it makes sense to touch the existing implementations...

As analyzed in #4758: the `i2c` peripheral is a shared bus allowing atomic access, implying that it needs to be acquired/released before/after usage and should be powered off when not in use.

Main changes:
- removed read_byte and read_reg
- moved bus speed parameter to i2c_acquire
- made parameters overridable
- added fixed return codes
- added default type
- removed (unused) slave mode (-> should go into its own interface)

TODO: 
- doxygen needs to be updated, e.g. describe that devices are powered on/off when calling `acquire/release` and more
- adapt all existing implementations
