### PR TITLE
kinetis: Add DMA support to UART driver

### DIFF
--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -92,11 +92,10 @@ extern "C"
 #define UART_0_IRQ_CHAN              UART0_RX_TX_IRQn
 #define UART_0_ISR                   isr_uart0_rx_tx
 /* UART 0 pin configuration */
-#define UART_0_PORT_CLKEN()          (SIM->SCGC5 |= (SIM_SCGC5_PORTB_MASK))
-#define UART_0_PORT                  PORTB
-#define UART_0_RX_PIN                16
-#define UART_0_TX_PIN                17
-#define UART_0_AF                    3
+#define UART_0_RX_GPIO               GPIO_PIN(PORT_B, 16)
+#define UART_0_RX_AF                 GPIO_AF_3
+#define UART_0_TX_GPIO               GPIO_PIN(PORT_B, 17)
+#define UART_0_TX_AF                 GPIO_AF_3
 /** @} */
 
 /**

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -1,11 +1,10 @@
 /*
- * Copyright (C) 2015 Eistec AB
+ * Copyright (C) 2015-2016 Eistec AB
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
  * details.
  */
-
 
 /**
  * @ingroup     board_mulle
@@ -84,7 +83,6 @@ extern "C"
 
 /** @} */
 
-
 /**
  * @name UART configuration
  * @{
@@ -105,15 +103,10 @@ extern "C"
 #define UART_0_IRQ_CHAN     UART1_RX_TX_IRQn
 #define UART_0_ISR          isr_uart1_status
 /* UART 0 pin configuration */
-#define UART_0_PORT_CLKEN() (BITBAND_REG32(SIM->SCGC5, SIM_SCGC5_PORTC_SHIFT) = 1)
-#define UART_0_PORT         PORTC
-#define UART_0_TX_PIN       4
-#define UART_0_RX_PIN       3
-/* Function number in pin multiplex, see K60 Sub-Family Reference Manual,
- * section 10.3.1 K60 Signal Multiplexing and Pin Assignments */
-#define UART_0_AF           3
-#define UART_0_TX_PCR_MUX   3
-#define UART_0_RX_PCR_MUX   3
+#define UART_0_TX_GPIO      GPIO_PIN(PORT_C, 4)
+#define UART_0_TX_AF        GPIO_AF_3
+#define UART_0_RX_GPIO      GPIO_PIN(PORT_C, 3)
+#define UART_0_RX_AF        GPIO_AF_3
 
 /* UART 1 device configuration */
 #define UART_1_DEV          UART0
@@ -123,15 +116,10 @@ extern "C"
 #define UART_1_IRQ_CHAN     UART0_RX_TX_IRQn
 #define UART_1_ISR          isr_uart0_status
 /* UART 1 pin configuration */
-#define UART_1_PORT_CLKEN() (BITBAND_REG32(SIM->SCGC5, SIM_SCGC5_PORTA_SHIFT) = 1)
-#define UART_1_PORT         PORTA
-#define UART_1_TX_PIN       14
-#define UART_1_RX_PIN       15
-/* Function number in pin multiplex, see K60 Sub-Family Reference Manual,
- * section 10.3.1 K60 Signal Multiplexing and Pin Assignments */
-#define UART_1_AF           3
-#define UART_1_TX_PCR_MUX   3
-#define UART_1_RX_PCR_MUX   3
+#define UART_1_TX_GPIO      GPIO_PIN(PORT_A, 14)
+#define UART_1_TX_AF        GPIO_AF_3
+#define UART_1_RX_GPIO      GPIO_PIN(PORT_A, 15)
+#define UART_1_RX_AF        GPIO_AF_3
 
 /** @} */
 
@@ -364,7 +352,6 @@ static const adc_conf_t adc_config[] = {
 
 /** @} */
 
-
 /**
  * @name I2C configuration
  * @{
@@ -414,7 +401,6 @@ static const adc_conf_t adc_config[] = {
  */
 #define GPIO_IRQ_PRIO       CPU_DEFAULT_IRQ_PRIO
 /** @} */
-
 
 /**
  * @name RTC configuration

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -120,6 +120,10 @@ extern "C"
 #define UART_1_CLK          (SystemSysClock)
 #define UART_1_IRQ_CHAN     UART1_RX_TX_IRQn
 #define UART_1_ISR          isr_uart1_status
+#define UART_1_DMA_CHAN     15
+#define UART_1_DMA_SOURCE   DMA_SOURCE_UART1_TX
+#define UART_1_DMA_IRQ      DMA15_IRQn
+#define UART_1_DMA_ISR      isr_dma15_complete
 /* UART 1 pin configuration */
 /* The chosen pins are normally connected to RX/TX on the USB to UART adapter on
  * the programmer board */

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -87,39 +87,72 @@ extern "C"
  * @name UART configuration
  * @{
  */
-#define UART_NUMOF          (2U)
+#define UART_NUMOF          (5U)
 #define UART_0_EN           1
 #define UART_1_EN           1
+/* The UART2 hardware module on the MK60D10 is only muxable to the pins used for
+ * SPI_0 on Mulle and are not available on the expansion port */
 #define UART_2_EN           0
-#define UART_3_EN           0
-#define UART_4_EN           0
+#define UART_3_EN           1
+#define UART_4_EN           1
 #define UART_IRQ_PRIO       CPU_DEFAULT_IRQ_PRIO
 
+/* Use UART1 for standard I/O */
+#define UART_STDIO_DEV      UART_DEV(1)
+
 /* UART 0 device configuration */
-#define UART_0_DEV          UART1
-#define UART_0_CLKEN()      (BITBAND_REG32(SIM->SCGC4, SIM_SCGC4_UART1_SHIFT) = 1)
-#define UART_0_CLKDIS()     (BITBAND_REG32(SIM->SCGC4, SIM_SCGC4_UART1_SHIFT) = 0)
+#define UART_0_DEV          UART0
+#define UART_0_CLKEN()      (BITBAND_REG32(SIM->SCGC4, SIM_SCGC4_UART0_SHIFT) = 1)
+#define UART_0_CLKDIS()     (BITBAND_REG32(SIM->SCGC4, SIM_SCGC4_UART0_SHIFT) = 0)
 #define UART_0_CLK          (SystemSysClock)
-#define UART_0_IRQ_CHAN     UART1_RX_TX_IRQn
-#define UART_0_ISR          isr_uart1_status
+#define UART_0_IRQ_CHAN     UART0_RX_TX_IRQn
+#define UART_0_ISR          isr_uart0_status
 /* UART 0 pin configuration */
-#define UART_0_TX_GPIO      GPIO_PIN(PORT_C, 4)
+#define UART_0_TX_GPIO      GPIO_PIN(PORT_A, 14)
 #define UART_0_TX_AF        GPIO_AF_3
-#define UART_0_RX_GPIO      GPIO_PIN(PORT_C, 3)
+#define UART_0_RX_GPIO      GPIO_PIN(PORT_A, 15)
 #define UART_0_RX_AF        GPIO_AF_3
 
 /* UART 1 device configuration */
-#define UART_1_DEV          UART0
-#define UART_1_CLKEN()      (BITBAND_REG32(SIM->SCGC4, SIM_SCGC4_UART0_SHIFT) = 1)
-#define UART_1_CLKDIS()     (BITBAND_REG32(SIM->SCGC4, SIM_SCGC4_UART0_SHIFT) = 0)
+#define UART_1_DEV          UART1
+#define UART_1_CLKEN()      (BITBAND_REG32(SIM->SCGC4, SIM_SCGC4_UART1_SHIFT) = 1)
+#define UART_1_CLKDIS()     (BITBAND_REG32(SIM->SCGC4, SIM_SCGC4_UART1_SHIFT) = 0)
 #define UART_1_CLK          (SystemSysClock)
-#define UART_1_IRQ_CHAN     UART0_RX_TX_IRQn
-#define UART_1_ISR          isr_uart0_status
+#define UART_1_IRQ_CHAN     UART1_RX_TX_IRQn
+#define UART_1_ISR          isr_uart1_status
 /* UART 1 pin configuration */
-#define UART_1_TX_GPIO      GPIO_PIN(PORT_A, 14)
+/* The chosen pins are normally connected to RX/TX on the USB to UART adapter on
+ * the programmer board */
+#define UART_1_TX_GPIO      GPIO_PIN(PORT_C, 4)
 #define UART_1_TX_AF        GPIO_AF_3
-#define UART_1_RX_GPIO      GPIO_PIN(PORT_A, 15)
+#define UART_1_RX_GPIO      GPIO_PIN(PORT_C, 3)
 #define UART_1_RX_AF        GPIO_AF_3
+
+/* UART 3 device configuration */
+#define UART_3_DEV          UART3
+#define UART_3_CLKEN()      (BITBAND_REG32(SIM->SCGC4, SIM_SCGC4_UART3_SHIFT) = 1)
+#define UART_3_CLKDIS()     (BITBAND_REG32(SIM->SCGC4, SIM_SCGC4_UART3_SHIFT) = 0)
+#define UART_3_CLK          (SystemBusClock)
+#define UART_3_IRQ_CHAN     UART3_RX_TX_IRQn
+#define UART_3_ISR          isr_uart3_status
+/* UART 3 pin configuration */
+#define UART_3_TX_GPIO      GPIO_PIN(PORT_B, 11)
+#define UART_3_TX_AF        GPIO_AF_3
+#define UART_3_RX_GPIO      GPIO_PIN(PORT_B, 10)
+#define UART_3_RX_AF        GPIO_AF_3
+
+/* UART 4 device configuration */
+#define UART_4_DEV          UART4
+#define UART_4_CLKEN()      (BITBAND_REG32(SIM->SCGC1, SIM_SCGC1_UART4_SHIFT) = 1)
+#define UART_4_CLKDIS()     (BITBAND_REG32(SIM->SCGC1, SIM_SCGC1_UART4_SHIFT) = 0)
+#define UART_4_CLK          (SystemBusClock)
+#define UART_4_IRQ_CHAN     UART4_RX_TX_IRQn
+#define UART_4_ISR          isr_uart4_status
+/* UART 4 pin configuration */
+#define UART_4_TX_GPIO      GPIO_PIN(PORT_E, 24)
+#define UART_4_TX_AF        GPIO_AF_3
+#define UART_4_RX_GPIO      GPIO_PIN(PORT_E, 25)
+#define UART_4_RX_AF        GPIO_AF_3
 
 /** @} */
 

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -96,11 +96,10 @@ extern "C"
 #define UART_0_IRQ_CHAN     UART2_RX_TX_IRQn
 #define UART_0_ISR          isr_uart2_rx_tx
 /* UART 0 pin configuration */
-#define UART_0_PORT_CLKEN() (SIM->SCGC5 |= (SIM_SCGC5_PORTD_MASK))
-#define UART_0_PORT         PORTD
-#define UART_0_RX_PIN       2
-#define UART_0_TX_PIN       3
-#define UART_0_AF           3
+#define UART_0_RX_GPIO      GPIO_PIN(PORT_D, 2)
+#define UART_0_RX_AF        GPIO_AF_3
+#define UART_0_TX_GPIO      GPIO_PIN(PORT_D, 3)
+#define UART_0_TX_AF        GPIO_AF_3
 
 /* UART 1 device configuration */
 #define UART_1_DEV          UART0
@@ -109,11 +108,10 @@ extern "C"
 #define UART_1_IRQ_CHAN     UART0_RX_TX_IRQn
 #define UART_1_ISR          isr_uart0_rx_tx
 /* UART 1 pin configuration */
-#define UART_1_PORT_CLKEN() (SIM->SCGC5 |= (SIM_SCGC5_PORTD_MASK))
-#define UART_1_PORT         PORTD
-#define UART_1_RX_PIN       6
-#define UART_1_TX_PIN       7
-#define UART_1_AF           3
+#define UART_1_RX_GPIO      GPIO_PIN(PORT_D, 6)
+#define UART_1_RX_AF        GPIO_AF_3
+#define UART_1_TX_GPIO      GPIO_PIN(PORT_D, 7)
+#define UART_1_TX_AF        GPIO_AF_3
 /** @} */
 
 /**

--- a/cpu/k60/include/cpu_conf.h
+++ b/cpu/k60/include/cpu_conf.h
@@ -97,6 +97,84 @@ extern "C"
 #define PORTE_CLOCK_GATE (BITBAND_REG32(SIM->SCGC5, SIM_SCGC5_PORTE_SHIFT))
 /** @} */
 
+/** @brief DMA module clock gate */
+#define DMA_CLOCK_GATE (BITBAND_REG32(SIM->SCGC7, SIM_SCGC7_DMA_SHIFT))
+/** @brief DMA multiplexer clock gate */
+#define DMAMUX_CLOCK_GATE (BITBAND_REG32(SIM->SCGC6, SIM_SCGC6_DMAMUX_SHIFT))
+
+/** @brief DMA multiplexer source numbers */
+typedef enum {
+    DMA_SOURCE_DISABLED        =  0,
+    DMA_SOURCE_RESERVED1       =  1,
+    DMA_SOURCE_UART0_RX        =  2,
+    DMA_SOURCE_UART0_TX        =  3,
+    DMA_SOURCE_UART1_RX        =  4,
+    DMA_SOURCE_UART1_TX        =  5,
+    DMA_SOURCE_UART2_RX        =  6,
+    DMA_SOURCE_UART2_TX        =  7,
+    DMA_SOURCE_UART3_RX        =  8,
+    DMA_SOURCE_UART3_TX        =  9,
+    DMA_SOURCE_UART4_RX        = 10,
+    DMA_SOURCE_UART4_TX        = 11,
+    DMA_SOURCE_RESERVED12      = 12,
+    DMA_SOURCE_RESERVED13      = 13,
+    DMA_SOURCE_I2S0_RX         = 14,
+    DMA_SOURCE_I2S0_TX         = 15,
+    DMA_SOURCE_SPI0_RX         = 16,
+    DMA_SOURCE_SPI0_TX         = 17,
+    DMA_SOURCE_SPI1_RX         = 18,
+    DMA_SOURCE_SPI1_TX         = 19,
+    DMA_SOURCE_SPI2_RX         = 20,
+    DMA_SOURCE_SPI2_TX         = 21,
+    DMA_SOURCE_I2C0            = 22,
+    DMA_SOURCE_I2C1            = 23,
+    DMA_SOURCE_FTM0CH0         = 24,
+    DMA_SOURCE_FTM0CH1         = 25,
+    DMA_SOURCE_FTM0CH2         = 26,
+    DMA_SOURCE_FTM0CH3         = 27,
+    DMA_SOURCE_FTM0CH4         = 28,
+    DMA_SOURCE_FTM0CH5         = 29,
+    DMA_SOURCE_FTM0CH6         = 30,
+    DMA_SOURCE_FTM0CH7         = 31,
+    DMA_SOURCE_FTM1CH0         = 32,
+    DMA_SOURCE_FTM1CH1         = 33,
+    DMA_SOURCE_FTM2CH0         = 34,
+    DMA_SOURCE_FTM2CH1         = 35,
+    DMA_SOURCE_IEEE1588_TIMER0 = 36,
+    DMA_SOURCE_IEEE1588_TIMER1 = 37,
+    DMA_SOURCE_IEEE1588_TIMER2 = 38,
+    DMA_SOURCE_IEEE1588_TIMER3 = 39,
+    DMA_SOURCE_ADC0            = 40,
+    DMA_SOURCE_ADC1            = 41,
+    DMA_SOURCE_CMP0            = 42,
+    DMA_SOURCE_CMP1            = 43,
+    DMA_SOURCE_CMP2            = 44,
+    DMA_SOURCE_DAC0            = 45,
+    DMA_SOURCE_RESERVED46      = 46,
+    DMA_SOURCE_CMT             = 47,
+    DMA_SOURCE_PDB             = 48,
+    DMA_SOURCE_PORT_A          = 49,
+    DMA_SOURCE_PORT_B          = 50,
+    DMA_SOURCE_PORT_C          = 51,
+    DMA_SOURCE_PORT_D          = 52,
+    DMA_SOURCE_PORT_E          = 53,
+    DMA_SOURCE_DMAMUX_ALWAYS0  = 54,
+    DMA_SOURCE_DMAMUX_ALWAYS1  = 55,
+    DMA_SOURCE_DMAMUX_ALWAYS2  = 56,
+    DMA_SOURCE_DMAMUX_ALWAYS3  = 57,
+    DMA_SOURCE_DMAMUX_ALWAYS4  = 58,
+    DMA_SOURCE_DMAMUX_ALWAYS5  = 59,
+    DMA_SOURCE_DMAMUX_ALWAYS6  = 60,
+    DMA_SOURCE_DMAMUX_ALWAYS7  = 61,
+    DMA_SOURCE_DMAMUX_ALWAYS8  = 62,
+    DMA_SOURCE_DMAMUX_ALWAYS9  = 63,
+} dma_source_t;
+
+/**
+ * @brief Number of DMA channels available in hardware
+ */
+#define DMA_NUMOF 16
+
 /**
  * @name UART driver settings
  */

--- a/cpu/k64f/include/cpu_conf.h
+++ b/cpu/k64f/include/cpu_conf.h
@@ -71,6 +71,22 @@ extern "C"
 #define PORTE_CLOCK_GATE (BITBAND_REG32(SIM->SCGC5, SIM_SCGC5_PORTE_SHIFT))
 /** @} */
 
+/** @brief DMA module clock gate */
+#define DMA_CLOCK_GATE (BITBAND_REG32(SIM->SCGC7, SIM_SCGC7_DMA_SHIFT))
+/** @brief DMA multiplexer clock gate */
+#define DMAMUX_CLOCK_GATE (BITBAND_REG32(SIM->SCGC6, SIM_SCGC6_DMAMUX_SHIFT))
+
+/** @brief DMA multiplexer source numbers */
+/* TODO: Copy numbers from reference manual. */
+typedef enum {
+    DMA_SOURCE_DISABLED        =  0,
+} dma_source_t;
+
+/**
+ * @brief Number of DMA channels available in hardware
+ */
+#define DMA_NUMOF 16
+
 /**
  * @brief MCU specific Low Power Timer settings.
  */

--- a/cpu/kinetis_common/include/dma.h
+++ b/cpu/kinetis_common/include/dma.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    cpu_kinetis_common_dma Kinetis DMA
+ * @ingroup     cpu_kinetis_common
+ * @brief       Driver for Freescale Kinetis DMA module
+ *
+ * @{
+
+ * @file
+ * @brief       Interface definition for the Kinetis DMA driver
+ *
+ * This is for internal use in the Kinetis drivers. The API allows for detailed
+ * control over DMA transfers. Users of this driver are expected to be familiar
+ * with Cortex-M and the Kinetis processor internals as well as its DMA module.
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ */
+
+#ifndef KINETIS_COMMON_DMA_H
+#define KINETIS_COMMON_DMA_H
+
+#include "cpu.h"
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @brief   DMA device to use
+ */
+#define DMA_DEV DMA0
+
+/**
+ * @brief   DMA access width settings
+ */
+typedef enum {
+    DMA_ACCESS_SIZE_8BIT       = 0,
+    DMA_ACCESS_SIZE_16BIT      = 1,
+    DMA_ACCESS_SIZE_32BIT      = 2,
+    DMA_ACCESS_SIZE_RESERVED3  = 3,
+    DMA_ACCESS_SIZE_16BYTE     = 4,
+    DMA_ACCESS_SIZE_32BYTE     = 5,
+    DMA_ACCESS_SIZE_RESERVED6  = 6,
+    DMA_ACCESS_SIZE_RESERVED7  = 7,
+} dma_access_size_t;
+
+/**
+ * @brief   Initialize the DMA hardware module and set up the given channel
+ *
+ * @param[in]  channel  The channel to configure
+ * @param[in]  source   DMA channel activation source
+ *
+ * @return 0  on success
+ * @return <0 on error
+ */
+int dma_init(const uint8_t channel, const dma_source_t source);
+
+/**
+ * @brief   Enable a configured DMA channel
+ *
+ * @param[in]  channel  The channel to enable
+ */
+static inline void dma_channel_enable(const uint8_t channel)
+{
+    DMA_DEV->SERQ = DMA_SERQ_SERQ(channel);
+}
+
+/**
+ * @brief   Disable a configured DMA channel
+ *
+ * @param[in]  channel  The channel to enable
+ */
+static inline void dma_channel_disable(const uint8_t channel)
+{
+    DMA_DEV->CERQ = DMA_CERQ_CERQ(channel);
+}
+
+/**
+ * @brief   Clear the interrupt flag for the given channel
+ *
+ * @param[in]  channel  The DMA channel interrupt to clear
+ */
+static inline void dma_clear_irq(const uint8_t channel)
+{
+    DMA_DEV->CINT = DMA_CINT_CINT(channel);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* KINETIS_COMMON_DMA_H */
+/** @} */

--- a/cpu/kinetis_common/periph/dma.c
+++ b/cpu/kinetis_common/periph/dma.c
@@ -41,6 +41,10 @@ int dma_init(const uint8_t channel, const dma_source_t source)
     }
 
     DMA_CLOCK_GATE = 1;
+
+    /* Set Halt on Error, enable minor loop linking, pause transfers during debug */
+    DMA_DEV->CR = DMA_CR_HOE_MASK | DMA_CR_EMLM_MASK | DMA_CR_EDBG_MASK;
+
     DMAMUX_CLOCK_GATE = 1;
 
     /* Disable the channel completely */

--- a/cpu/kinetis_common/periph/dma.c
+++ b/cpu/kinetis_common/periph/dma.c
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_kinetis_common_dma
+ *
+ * @{
+ *
+ * @file
+ * @brief       Low-level DMA driver implementation
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+
+#if DEVELHELP
+#include <stdio.h>
+#include <inttypes.h>
+#endif
+
+#include "cpu.h"
+#include "periph_conf.h"
+#include "dma.h"
+
+#ifndef DMA_NUMOF
+#error DMA_NUMOF is undefined!
+#endif
+
+int dma_init(const uint8_t channel, const dma_source_t source)
+{
+    if (channel >= DMA_NUMOF) {
+        return -1;
+    }
+
+    DMA_CLOCK_GATE = 1;
+    DMAMUX_CLOCK_GATE = 1;
+
+    /* Disable the channel completely */
+    DMAMUX->CHCFG[channel] = 0;
+
+    /* Enable DMA transfer complete IRQs */
+    /* Refactor the line below if the DMA IRQs are not sequential in numbering... */
+    NVIC_EnableIRQ(DMA0_IRQn + channel);
+
+    /* Disable requests on the chosen DMA channel */
+    dma_channel_disable(channel);
+
+    DMAMUX->CHCFG[channel] = DMAMUX_CHCFG_ENBL_MASK | DMAMUX_CHCFG_SOURCE(source);
+
+    /* Enable error interrupts for the channel in order to easier detect program errors */
+    DMA_DEV->SEEI = DMA_SEEI_SEEI(channel);
+    NVIC_EnableIRQ(DMA_Error_IRQn);
+
+    return 0;
+}
+
+#if DEVELHELP
+/** @brief Provide verbose error reporting when DEVELHELP is set */
+void dma_error_verbose(void)
+{
+    uint32_t reg_cr  = DMA_DEV->CR;  /* Cached copy of control register */
+    uint32_t reg_es  = DMA_DEV->ES;  /* Cached copy of error status register */
+    uint16_t reg_err = DMA_DEV->ERR; /* Cached copy of error request register */
+    uint16_t reg_int = DMA_DEV->INT; /* Cached copy of interrupt request register */
+    uint16_t reg_hrs = DMA_DEV->HRS; /* Cached copy of hardware request register */
+    uint8_t channel = (reg_es & DMA_ES_ERRCHN_MASK) >> DMA_ES_ERRCHN_SHIFT;
+
+    /* Stop the channel from further activation */
+    dma_channel_disable(channel);
+
+    printf("DMA error on channel %" PRIu8 "!\n", channel);
+    printf("DMA_CR:     0x%08" PRIx32 "\n", reg_cr);
+    printf("DMA_ES:     0x%08" PRIx32 "\n", reg_es);
+    printf("     flags: ");
+    if (reg_es & DMA_ES_VLD_MASK) {
+        printf("VLD ");
+    }
+    if (reg_es & DMA_ES_ECX_MASK) {
+        printf("ECX ");
+    }
+    if (reg_es & DMA_ES_CPE_MASK) {
+        printf("CPE ");
+    }
+    if (reg_es & DMA_ES_SAE_MASK) {
+        printf("SAE ");
+    }
+    if (reg_es & DMA_ES_SOE_MASK) {
+        printf("SOE ");
+    }
+    if (reg_es & DMA_ES_DAE_MASK) {
+        printf("DAE ");
+    }
+    if (reg_es & DMA_ES_DOE_MASK) {
+        printf("DOE ");
+    }
+    if (reg_es & DMA_ES_NCE_MASK) {
+        printf("NCE ");
+    }
+    if (reg_es & DMA_ES_SGE_MASK) {
+        printf("SGE ");
+    }
+    if (reg_es & DMA_ES_SBE_MASK) {
+        printf("SBE ");
+    }
+    if (reg_es & DMA_ES_DBE_MASK) {
+        printf("DBE ");
+    }
+    puts("");
+    printf("DMA_ERR:        0x%04" PRIx16 "\n", reg_err);
+    printf("DMA_INT:        0x%04" PRIx16 "\n", reg_int);
+    printf("DMA_HRS:        0x%04" PRIx16 "\n", reg_hrs);
+    printf("TCD%" PRIu8 ":\n", channel);
+    printf("     SADDR: 0x%08" PRIx32 "\n",     DMA_DEV->TCD[channel].SADDR);
+    printf("      SOFF:     0x%04" PRIx16 "\n", DMA_DEV->TCD[channel].SOFF);
+    printf("      ATTR:     0x%04" PRIx16 "\n", DMA_DEV->TCD[channel].ATTR);
+    printf("    NBYTES: 0x%08" PRIx32 "\n",     DMA_DEV->TCD[channel].NBYTES_MLNO);
+    printf("     SLAST: 0x%08" PRIx32 "\n",     DMA_DEV->TCD[channel].SLAST);
+    printf("     DADDR: 0x%08" PRIx32 "\n",     DMA_DEV->TCD[channel].DADDR);
+    printf("      DOFF:     0x%04" PRIx16 "\n", DMA_DEV->TCD[channel].DOFF);
+    printf("     CITER:     0x%04" PRIx16 "\n", DMA_DEV->TCD[channel].CITER_ELINKNO);
+    printf(" DLAST_SGA: 0x%08" PRIx32 "\n",     DMA_DEV->TCD[channel].DLAST_SGA);
+    printf("       CSR:     0x%04" PRIx16 "\n", DMA_DEV->TCD[channel].CSR);
+    printf("     BITER:     0x%04" PRIx16 "\n", DMA_DEV->TCD[channel].BITER_ELINKNO);
+}
+
+void isr_dma_error(void)
+{
+    dma_error_verbose();
+    while(1) {}
+}
+#endif

--- a/cpu/kinetis_common/periph/gpio.c
+++ b/cpu/kinetis_common/periph/gpio.c
@@ -24,6 +24,8 @@
  * @}
  */
 
+#include <stdint.h>
+#include <stddef.h>
 #include "sched.h"
 #include "thread.h"
 #include "cpu.h"

--- a/cpu/kinetis_common/periph/uart.c
+++ b/cpu/kinetis_common/periph/uart.c
@@ -340,9 +340,10 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
             /* Set source and destination width to 1 byte */
             DMA_DEV->TCD[channel].ATTR = DMA_ATTR_DSIZE(DMA_ACCESS_SIZE_8BIT) | DMA_ATTR_SSIZE(DMA_ACCESS_SIZE_8BIT);
             /* Set minor loop count */
-            DMA_DEV->TCD[channel].NBYTES_MLNO = DMA_NBYTES_MLNO_NBYTES(1);
+            DMA_DEV->TCD[channel].NBYTES_MLOFFNO = DMA_NBYTES_MLOFFNO_NBYTES(1);
             /* Set major loop count */
-            /* Note: This breaks if len > 32767 */
+            /* The DMA engine can only handle up to 2**15 major loop iterations */
+            assert(len <= (DMA_CITER_ELINKNO_CITER_MASK >> DMA_CITER_ELINKNO_CITER_SHIFT));
             DMA_DEV->TCD[channel].CITER_ELINKNO = DMA_CITER_ELINKNO_CITER(len);
             DMA_DEV->TCD[channel].BITER_ELINKNO = DMA_BITER_ELINKNO_BITER(len);
             /* Set control register */

--- a/cpu/kinetis_common/periph/uart.c
+++ b/cpu/kinetis_common/periph/uart.c
@@ -87,6 +87,24 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
             NVIC_EnableIRQ(UART_1_IRQ_CHAN);
             break;
 #endif
+#if UART_2_EN
+        case UART_DEV(2):
+            NVIC_SetPriority(UART_2_IRQ_CHAN, UART_IRQ_PRIO);
+            NVIC_EnableIRQ(UART_2_IRQ_CHAN);
+            break;
+#endif
+#if UART_3_EN
+        case UART_DEV(3):
+            NVIC_SetPriority(UART_3_IRQ_CHAN, UART_IRQ_PRIO);
+            NVIC_EnableIRQ(UART_3_IRQ_CHAN);
+            break;
+#endif
+#if UART_4_EN
+        case UART_DEV(4):
+            NVIC_SetPriority(UART_4_IRQ_CHAN, UART_IRQ_PRIO);
+            NVIC_EnableIRQ(UART_4_IRQ_CHAN);
+            break;
+#endif
         default:
             return -2;
     }
@@ -120,6 +138,30 @@ static int init_base(uart_t uart, uint32_t baudrate)
             gpio_init_port(UART_1_RX_GPIO, UART_1_RX_AF);
             clk = UART_1_CLK;
             UART_1_CLKEN();
+            break;
+#endif
+#if UART_2_EN
+        case UART_DEV(2):
+            gpio_init_port(UART_2_TX_GPIO, UART_2_TX_AF);
+            gpio_init_port(UART_2_RX_GPIO, UART_2_RX_AF);
+            clk = UART_2_CLK;
+            UART_2_CLKEN();
+            break;
+#endif
+#if UART_3_EN
+        case UART_DEV(3):
+            gpio_init_port(UART_3_TX_GPIO, UART_3_TX_AF);
+            gpio_init_port(UART_3_RX_GPIO, UART_3_RX_AF);
+            clk = UART_3_CLK;
+            UART_3_CLKEN();
+            break;
+#endif
+#if UART_4_EN
+        case UART_DEV(4):
+            gpio_init_port(UART_4_TX_GPIO, UART_4_TX_AF);
+            gpio_init_port(UART_4_RX_GPIO, UART_4_RX_AF);
+            clk = UART_4_CLK;
+            UART_4_CLKEN();
             break;
 #endif
         default:
@@ -216,7 +258,6 @@ static inline void irq_handler(uart_t uartnum, KINETIS_UART *dev)
     if (sched_context_switch_request) {
         thread_yield();
     }
-
 }
 
 #if UART_0_EN
@@ -230,5 +271,26 @@ void UART_0_ISR(void)
 void UART_1_ISR(void)
 {
     irq_handler(UART_DEV(1), UART_1_DEV);
+}
+#endif
+
+#if UART_2_EN
+void UART_2_ISR(void)
+{
+    irq_handler(UART_DEV(2), UART_2_DEV);
+}
+#endif
+
+#if UART_3_EN
+void UART_3_ISR(void)
+{
+    irq_handler(UART_DEV(3), UART_3_DEV);
+}
+#endif
+
+#if UART_4_EN
+void UART_4_ISR(void)
+{
+    irq_handler(UART_DEV(4), UART_4_DEV);
 }
 #endif

--- a/cpu/kinetis_common/periph/uart.c
+++ b/cpu/kinetis_common/periph/uart.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014 PHYTEC Messtechnik GmbH
  * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2016 Eistec AB
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -17,6 +18,7 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Johann Fischer <j.fischer@phytec.de>
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  *
  * @}
  */
@@ -98,24 +100,17 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 static int init_base(uart_t uart, uint32_t baudrate)
 {
     KINETIS_UART *dev;
-    PORT_Type *port;
     uint32_t clk;
     uint16_t ubd;
-    uint8_t tx_pin = 0;
-    uint8_t rx_pin = 0;
-    uint8_t af;
 
     switch (uart) {
 #if UART_0_EN
 
         case UART_0:
             dev = UART_0_DEV;
-            port = UART_0_PORT;
+            gpio_init_port(UART_0_TX_GPIO, UART_0_TX_AF);
+            gpio_init_port(UART_0_RX_GPIO, UART_0_RX_AF);
             clk = UART_0_CLK;
-            tx_pin = UART_0_TX_PIN;
-            rx_pin = UART_0_RX_PIN;
-            af = UART_0_AF;
-            UART_0_PORT_CLKEN();
             UART_0_CLKEN();
             break;
 #endif
@@ -123,12 +118,9 @@ static int init_base(uart_t uart, uint32_t baudrate)
 
         case UART_1:
             dev = UART_1_DEV;
-            port = UART_1_PORT;
+            gpio_init_port(UART_1_TX_GPIO, UART_1_TX_AF);
+            gpio_init_port(UART_1_RX_GPIO, UART_1_RX_AF);
             clk = UART_1_CLK;
-            tx_pin = UART_1_TX_PIN;
-            rx_pin = UART_1_RX_PIN;
-            af = UART_1_AF;
-            UART_1_PORT_CLKEN();
             UART_1_CLKEN();
             break;
 #endif
@@ -136,10 +128,6 @@ static int init_base(uart_t uart, uint32_t baudrate)
         default:
             return -1;
     }
-
-    /* configure RX and TX pins, set pin to use alternative function mode */
-    port->PCR[rx_pin] = PORT_PCR_MUX(af);
-    port->PCR[tx_pin] = PORT_PCR_MUX(af);
 
     /* disable transmitter and receiver */
     dev->C2 &= ~(UART_C2_TE_MASK | UART_C2_RE_MASK);

--- a/cpu/kw2x/include/cpu_conf.h
+++ b/cpu/kw2x/include/cpu_conf.h
@@ -76,6 +76,22 @@ extern "C"
 #define PORTE_CLOCK_GATE (BITBAND_REG32(SIM->SCGC5, SIM_SCGC5_PORTE_SHIFT))
 /** @} */
 
+/** @brief DMA module clock gate */
+#define DMA_CLOCK_GATE (BITBAND_REG32(SIM->SCGC7, SIM_SCGC7_DMA_SHIFT))
+/** @brief DMA multiplexer clock gate */
+#define DMAMUX_CLOCK_GATE (BITBAND_REG32(SIM->SCGC6, SIM_SCGC6_DMAMUX_SHIFT))
+
+/** @brief DMA multiplexer source numbers */
+/* TODO: Copy numbers from reference manual. */
+typedef enum {
+    DMA_SOURCE_DISABLED        =  0,
+} dma_source_t;
+
+/**
+ * @brief Number of DMA channels available in hardware
+ */
+#define DMA_NUMOF 16
+
 /**
  * @brief MCU specific Low Power Timer settings.
  */


### PR DESCRIPTION
This is a refactoring of the UART driver on Kinetis platforms, including:
- Use `gpio_init_af` to select pin alternate function (introduced in #4830).
- Protect `uart_write` with a per device mutex
- Add support for up to 5 UART modules (was: 2)
- Add option to use DMA for UART TX

The DMA usage is similar to how the implementation works on STM32F4: Using a mutex to suspend the calling thread until the DMA ISR is called.
