### PR TITLE
cpu/stm32f1: reworked timer implementation

### DIFF
--- a/boards/fox/include/board.h
+++ b/boards/fox/include/board.h
@@ -34,6 +34,11 @@ extern "C" {
 #endif
 
 /**
+ * @name Tell the xtimer that we use a 16-bit peripheral timer
+ */
+#define XTIMER_MASK         (0xffff0000)
+
+/**
  * @name Define the interface to the AT86RF231 radio
  *
  * {spi bus, spi speed, cs pin, int pin, reset pin, sleep pin}

--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -19,6 +19,8 @@
 #ifndef PERIPH_CONF_H_
 #define PERIPH_CONF_H_
 
+#include "periph_cpu.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -45,37 +47,16 @@ extern "C" {
  * @brief Timer configuration
  * @{
  */
-#define TIMER_NUMOF         (2U)
-#define TIMER_0_EN          1
-#define TIMER_1_EN          1
+static const timer_conf_t timer_config[] = {
+    /* device, APB bus, rcc_bit */
+    { TIM2, APB1, RCC_APB1ENR_TIM2EN, TIM2_IRQn },
+    { TIM3, APB1, RCC_APB1ENR_TIM3EN, TIM3_IRQn }
+};
 
-/* Timer 0 configuration */
-#define TIMER_0_DEV_0       TIM2
-#define TIMER_0_DEV_1       TIM3
-#define TIMER_0_CHANNELS    4
-#define TIMER_0_FREQ        (CLOCK_CORECLOCK)
-#define TIMER_0_MAX_VALUE   (0xffff)
-#define TIMER_0_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM2EN | RCC_APB1ENR_TIM3EN))
-#define TIMER_0_ISR_0       isr_tim2
-#define TIMER_0_ISR_1       isr_tim3
-#define TIMER_0_IRQ_CHAN_0  TIM2_IRQn
-#define TIMER_0_IRQ_CHAN_1  TIM3_IRQn
-#define TIMER_0_IRQ_PRIO    1
-#define TIMER_0_TRIG_SEL    TIM_SMCR_TS_0
+#define TIMER_0_ISR         isr_tim2
+#define TIMER_1_ISR         isr_tim3
 
-/* Timer 1 configuration */
-#define TIMER_1_DEV_0       TIM4
-#define TIMER_1_DEV_1       TIM5
-#define TIMER_1_CHANNELS    4
-#define TIMER_1_FREQ        (CLOCK_CORECLOCK)
-#define TIMER_1_MAX_VALUE   (0xffff)
-#define TIMER_1_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM4EN | RCC_APB1ENR_TIM5EN))
-#define TIMER_1_ISR_0       isr_tim4
-#define TIMER_1_ISR_1       isr_tim5
-#define TIMER_1_IRQ_CHAN_0  TIM4_IRQn
-#define TIMER_1_IRQ_CHAN_1  TIM5_IRQn
-#define TIMER_1_IRQ_PRIO    1
-#define TIMER_1_TRIG_SEL    TIM_SMCR_TS_1
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 /** @} */
 
 /**

--- a/boards/iotlab-m3/include/board.h
+++ b/boards/iotlab-m3/include/board.h
@@ -43,6 +43,11 @@ extern "C" {
 /** @} */
 
 /**
+ * @name Tell the xtimer that we use a 16-bit peripheral timer
+ */
+#define XTIMER_MASK         (0xffff0000)
+
+/**
  * @name Define the interface to the AT86RF231 radio
  *
  * {spi bus, spi speed, cs pin, int pin, reset pin, sleep pin}

--- a/boards/iotlab-m3/include/periph_conf.h
+++ b/boards/iotlab-m3/include/periph_conf.h
@@ -20,6 +20,8 @@
 #ifndef PERIPH_CONF_H_
 #define PERIPH_CONF_H_
 
+#include "periph_cpu.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -46,37 +48,16 @@ extern "C" {
  * @brief Timer configuration
  * @{
  */
-#define TIMER_NUMOF         (2U)
-#define TIMER_0_EN          1
-#define TIMER_1_EN          1
+static const timer_conf_t timer_config[] = {
+    /* device, APB bus, rcc_bit */
+    { TIM2, APB1, RCC_APB1ENR_TIM2EN, TIM2_IRQn },
+    { TIM3, APB1, RCC_APB1ENR_TIM3EN, TIM3_IRQn }
+};
 
-/* Timer 0 configuration */
-#define TIMER_0_DEV_0       TIM2
-#define TIMER_0_DEV_1       TIM3
-#define TIMER_0_CHANNELS    4
-#define TIMER_0_FREQ        (CLOCK_CORECLOCK)
-#define TIMER_0_MAX_VALUE   (0xffffffff)
-#define TIMER_0_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM2EN | RCC_APB1ENR_TIM3EN))
-#define TIMER_0_ISR_0       isr_tim2
-#define TIMER_0_ISR_1       isr_tim3
-#define TIMER_0_IRQ_CHAN_0  TIM2_IRQn
-#define TIMER_0_IRQ_CHAN_1  TIM3_IRQn
-#define TIMER_0_IRQ_PRIO    1
-#define TIMER_0_TRIG_SEL    TIM_SMCR_TS_0
+#define TIMER_0_ISR         isr_tim2
+#define TIMER_1_ISR         isr_tim3
 
-/* Timer 1 configuration */
-#define TIMER_1_DEV_0       TIM4
-#define TIMER_1_DEV_1       TIM5
-#define TIMER_1_CHANNELS    4
-#define TIMER_1_FREQ        (CLOCK_CORECLOCK)
-#define TIMER_1_MAX_VALUE   (0xffffffff)
-#define TIMER_1_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM4EN | RCC_APB1ENR_TIM5EN))
-#define TIMER_1_ISR_0       isr_tim4
-#define TIMER_1_ISR_1       isr_tim5
-#define TIMER_1_IRQ_CHAN_0  TIM4_IRQn
-#define TIMER_1_IRQ_CHAN_1  TIM5_IRQn
-#define TIMER_1_IRQ_PRIO    1
-#define TIMER_1_TRIG_SEL    TIM_SMCR_TS_1
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 /** @} */
 
 /**

--- a/boards/nucleo-f103/include/board.h
+++ b/boards/nucleo-f103/include/board.h
@@ -36,6 +36,13 @@ extern "C" {
 #define STDIO               UART_DEV(1)
 
 /**
+ * @name xtimer configuration
+ */
+#define XTIMER_MASK         (0xffff0000)
+#define XTIMER_BACKOFF      5
+/** @} */
+
+/**
  * @name LED pin definitions
  * @{
  */
@@ -64,17 +71,6 @@ extern "C" {
  * @{
  */
 #define BUTTON_USER_GPIO    GPIO_PIN(PORT_C, 13)
-/** @} */
-
-/**
- * @name xtimer configuration
- * @{
- */
-#define XTIMER              TIMER_0
-#define XTIMER_CHAN         0
-#define XTIMER_SHIFT        0
-#define XTIMER_MASK         0 /* llt 32-bit since combined */
-#define XTIMER_BACKOFF      5
 /** @} */
 
 /**

--- a/boards/nucleo-f103/include/periph_conf.h
+++ b/boards/nucleo-f103/include/periph_conf.h
@@ -19,6 +19,8 @@
 #ifndef PERIPH_CONF_H_
 #define PERIPH_CONF_H_
 
+#include "periph_cpu.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,35 +49,16 @@ extern "C" {
  * @brief Timer configuration
  * @{
  */
-#define TIMER_NUMOF         (1U)
-#define TIMER_0_EN          1
-#define TIMER_1_EN          0
+static const timer_conf_t timer_config[] = {
+    /* device, APB bus, rcc_bit */
+    { TIM2, APB1, RCC_APB1ENR_TIM2EN, TIM2_IRQn },
+    { TIM3, APB1, RCC_APB1ENR_TIM3EN, TIM3_IRQn }
+};
 
-/* Timer 0 configuration */
-#define TIMER_0_DEV_0       TIM2
-#define TIMER_0_DEV_1       TIM3
-#define TIMER_0_FREQ        (CLOCK_CORECLOCK)
-#define TIMER_0_MAX_VALUE   (0xffff)
-#define TIMER_0_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM2EN | RCC_APB1ENR_TIM3EN))
-#define TIMER_0_ISR_0       isr_tim2
-#define TIMER_0_ISR_1       isr_tim3
-#define TIMER_0_IRQ_CHAN_0  TIM2_IRQn
-#define TIMER_0_IRQ_CHAN_1  TIM3_IRQn
-#define TIMER_0_IRQ_PRIO    1
-#define TIMER_0_TRIG_SEL    TIM_SMCR_TS_0
+#define TIMER_0_ISR         isr_tim2
+#define TIMER_1_ISR         isr_tim3
 
-/* Timer 1 configuration */
-#define TIMER_1_DEV_0       TIM4
-#define TIMER_1_DEV_1       TIM5
-#define TIMER_1_FREQ        (CLOCK_CORECLOCK)
-#define TIMER_1_MAX_VALUE   (0xffff)
-#define TIMER_1_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM4EN | RCC_APB1ENR_TIM5EN))
-#define TIMER_1_ISR_0       isr_tim4
-#define TIMER_1_ISR_1       isr_tim5
-#define TIMER_1_IRQ_CHAN_0  TIM4_IRQn
-#define TIMER_1_IRQ_CHAN_1  TIM5_IRQn
-#define TIMER_1_IRQ_PRIO    1
-#define TIMER_1_TRIG_SEL    TIM_SMCR_TS_1
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 /** @} */
 
 /**

--- a/boards/spark-core/include/board.h
+++ b/boards/spark-core/include/board.h
@@ -36,6 +36,11 @@
 #define LOCATION_VTABLE     (0x08005000)
 
 /**
+ * @name Tell the xtimer that we use a 16-bit peripheral timer
+ */
+#define XTIMER_MASK         (0xffff0000)
+
+/**
  * @name LED pin definitions
  * @{
  */

--- a/boards/spark-core/include/periph_conf.h
+++ b/boards/spark-core/include/periph_conf.h
@@ -19,6 +19,8 @@
 #ifndef PERIPH_CONF_H_
 #define PERIPH_CONF_H_
 
+#include "periph_cpu.h"
+
 #ifdef __cplusplus
  extern "C" {
 #endif
@@ -45,22 +47,16 @@
  * @brief Timer configuration
  * @{
  */
-#define TIMER_NUMOF         (1U)
-#define TIMER_0_EN          1
+static const timer_conf_t timer_config[] = {
+    /* device, APB bus, rcc_bit */
+    { TIM2, APB1, RCC_APB1ENR_TIM2EN, TIM2_IRQn },
+    { TIM3, APB1, RCC_APB1ENR_TIM3EN, TIM3_IRQn }
+};
 
-/* Timer 0 configuration */
-#define TIMER_0_DEV_0       TIM2
-#define TIMER_0_DEV_1       TIM3
-#define TIMER_0_CHANNELS    4
-#define TIMER_0_FREQ        (CLOCK_CORECLOCK)
-#define TIMER_0_MAX_VALUE   (0xffff)
-#define TIMER_0_CLKEN()     (RCC->APB1ENR |= (RCC_APB1ENR_TIM2EN | RCC_APB1ENR_TIM3EN))
-#define TIMER_0_ISR_0       isr_tim2
-#define TIMER_0_ISR_1       isr_tim3
-#define TIMER_0_IRQ_CHAN_0  TIM2_IRQn
-#define TIMER_0_IRQ_CHAN_1  TIM3_IRQn
-#define TIMER_0_IRQ_PRIO    1
-#define TIMER_0_TRIG_SEL    TIM_SMCR_TS_0
+#define TIMER_0_ISR         isr_tim2
+#define TIMER_1_ISR         isr_tim3
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 /** @} */
 
 /**

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -39,6 +39,14 @@ extern "C" {
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS
 /** @} */
 
+/**
+ * @brief   Available peripheral buses
+ */
+enum {
+    APB1,
+    APB2
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -44,6 +44,16 @@ typedef uint32_t gpio_t;
 #define GPIO_PIN(x, y)      ((GPIOA_BASE + (x << 10)) | y)
 
 /**
+ * @brief   All timers for the STM32F1 have 4 CC channels
+ */
+#define TIMER_CHANNELS      (4U)
+
+/**
+ * @brief   All timers have a width of 16-bit
+ */
+#define TIMER_MAXVAL        (0xffff)
+
+/**
  * @brief   Override values for pull register configuration
  * @{
  */
@@ -90,6 +100,16 @@ typedef enum {
     GPIO_AF_OUT_PP = 0xb,   /**< alternate function output - push-pull */
     GPIO_AF_OUT_OD = 0xf,   /**< alternate function output - open-drain */
 } gpio_af_out_t;
+
+/**
+ * @brief   Timer configuration
+ */
+typedef struct {
+    TIM_TypeDef *dev;       /**< timer device */
+    uint8_t bus;            /**< APBx bus the timer is clock from */
+    uint8_t rcc_bit;        /**< corresponding bit in the RCC register */
+    uint8_t irqn;           /**< global IRQ channel */
+} timer_conf_t;
 
 /**
  * @brief   Configure the alternate function for the given pin

--- a/cpu/stm32f1/include/stm32f103xb.h
+++ b/cpu/stm32f1/include/stm32f103xb.h
@@ -531,10 +531,7 @@ typedef struct
   __IO uint32_t PSC;             /*!< TIM prescaler register,                      Address offset: 0x28 */
   __IO uint32_t ARR;             /*!< TIM auto-reload register,                    Address offset: 0x2C */
   __IO uint32_t RCR;             /*!< TIM  repetition counter register,            Address offset: 0x30 */
-  __IO uint32_t CCR1;            /*!< TIM capture/compare register 1,              Address offset: 0x34 */
-  __IO uint32_t CCR2;            /*!< TIM capture/compare register 2,              Address offset: 0x38 */
-  __IO uint32_t CCR3;            /*!< TIM capture/compare register 3,              Address offset: 0x3C */
-  __IO uint32_t CCR4;            /*!< TIM capture/compare register 4,              Address offset: 0x40 */
+  __IO uint32_t CCR[4];          /*!< TIM capture/compare register 1-4,            Address offset: 0x34 */
   __IO uint32_t BDTR;            /*!< TIM break and dead-time register,            Address offset: 0x44 */
   __IO uint32_t DCR;             /*!< TIM DMA control register,                    Address offset: 0x48 */
   __IO uint32_t DMAR;            /*!< TIM DMA address for full transfer register,  Address offset: 0x4C */

--- a/cpu/stm32f1/include/stm32f103xe.h
+++ b/cpu/stm32f1/include/stm32f103xe.h
@@ -655,10 +655,7 @@ typedef struct
   __IO uint32_t PSC;             /*!< TIM prescaler register,                      Address offset: 0x28 */
   __IO uint32_t ARR;             /*!< TIM auto-reload register,                    Address offset: 0x2C */
   __IO uint32_t RCR;             /*!< TIM  repetition counter register,            Address offset: 0x30 */
-  __IO uint32_t CCR1;            /*!< TIM capture/compare register 1,              Address offset: 0x34 */
-  __IO uint32_t CCR2;            /*!< TIM capture/compare register 2,              Address offset: 0x38 */
-  __IO uint32_t CCR3;            /*!< TIM capture/compare register 3,              Address offset: 0x3C */
-  __IO uint32_t CCR4;            /*!< TIM capture/compare register 4,              Address offset: 0x40 */
+  __IO uint32_t CCR[4];          /*!< TIM capture/compare register 1-4,            Address offset: 0x34 */
   __IO uint32_t BDTR;            /*!< TIM break and dead-time register,            Address offset: 0x44 */
   __IO uint32_t DCR;             /*!< TIM DMA control register,                    Address offset: 0x48 */
   __IO uint32_t DMAR;            /*!< TIM DMA address for full transfer register,  Address offset: 0x4C */

--- a/cpu/stm32f1/periph/timer.c
+++ b/cpu/stm32f1/periph/timer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014-2016 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -19,386 +19,169 @@
  * @}
  */
 
-#include <stdlib.h>
-
 #include "cpu.h"
-#include "board.h"
-#include "periph_conf.h"
+#include "sched.h"
+#include "thread.h"
 #include "periph/timer.h"
 
-#include "thread.h"
-
-#define ENABLE_DEBUG (0)
-#include "debug.h"
-
-/* guard file in case no TIMER device is defined */
-#if TIMER_0_EN || TIMER_1_EN
-
-static inline void irq_handler(tim_t timer, TIM_TypeDef *dev0, TIM_TypeDef *dev1);
+/**
+ * @brief   Interrupt context for each configured timer
+ */
+static timer_isr_ctx_t isr_ctx[TIMER_NUMOF];
 
 /**
- * Timer state memory
+ * @brief   Get the timer device
  */
-static timer_isr_ctx_t config[TIMER_NUMOF];
-
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+static inline TIM_TypeDef *dev(tim_t tim)
 {
-    TIM_TypeDef *timer0;
-    TIM_TypeDef *timer1;
-    uint8_t     trigger_selector;
-
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            /* enable timer peripheral clock */
-            TIMER_0_CLKEN();
-            /* set timer's IRQ priority */
-            NVIC_SetPriority(TIMER_0_IRQ_CHAN_0, TIMER_0_IRQ_PRIO);
-            NVIC_SetPriority(TIMER_0_IRQ_CHAN_1, TIMER_0_IRQ_PRIO);
-            /* select timer */
-            timer0 = TIMER_0_DEV_0;
-            timer1 = TIMER_0_DEV_1;
-            trigger_selector = TIMER_0_TRIG_SEL;
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            /* enable timer peripheral clock */
-            TIMER_1_CLKEN();
-            /* set timer's IRQ priority */
-            NVIC_SetPriority(TIMER_1_IRQ_CHAN_0, TIMER_1_IRQ_PRIO);
-            NVIC_SetPriority(TIMER_1_IRQ_CHAN_1, TIMER_1_IRQ_PRIO);
-            /* select timer */
-            timer0 = TIMER_1_DEV_0;
-            timer1 = TIMER_1_DEV_1;
-            trigger_selector = TIMER_1_TRIG_SEL;
-            break;
-#endif
-        case TIMER_UNDEFINED:
-        default:
-            return -1;
-    }
-
-    /* set callback function */
-    config[dev].cb = cb;
-    config[dev].arg = arg;
-
-    /* set timer to run in counter mode */
-    timer0->CR1 = (TIM_CR1_ARPE | TIM_CR1_URS);
-    timer1->CR1 = TIM_CR1_URS;
-
-    /* configure master timer0 */
-    /* send update event as trigger output */
-    timer0->CR2 |= TIM_CR2_MMS_1;
-    /* set auto-reload and prescaler values and load new values */
-    timer0->ARR = 0xFFFF;
-    timer0->PSC = (TIMER_0_FREQ / freq) - 1;
-    // timer->EGR |= TIM_EGR_UG;
-
-    /* configure slave timer1 */
-    /* get input trigger */
-    timer1->SMCR |= trigger_selector;
-    /* external clock mode 1 */
-    timer1->SMCR |= TIM_SMCR_SMS;
-
-    /* enable the timer's interrupt */
-    timer_irq_enable(dev);
-
-    /* start the timer */
-    timer_start(dev);
-
-    return 0;
+    return timer_config[tim].dev;
 }
 
-int timer_set(tim_t dev, int channel, unsigned int timeout)
+/**
+ * @brief   Enable the peripheral clock for the given timer
+ */
+static void clk_en(tim_t tim)
 {
-    int now = timer_read(dev);
-    return timer_set_absolute(dev, channel, now + timeout - 1);
-}
-
-int timer_set_absolute(tim_t dev, int channel, unsigned int value)
-{
-    TIM_TypeDef *timer0;
-    TIM_TypeDef *timer1;
-
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            /* select timer */
-            timer0 = TIMER_0_DEV_0;
-            timer1 = TIMER_0_DEV_1;
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            /* select timer */
-            timer0 = TIMER_1_DEV_0;
-            timer1 = TIMER_1_DEV_1;
-            break;
-#endif
-        case TIMER_UNDEFINED:
-        default:
-            return -1;
-    }
-
-    timer0->DIER &= ~TIM_DIER_UIE;
-
-    switch (channel) {
-        case 0:
-            timer0->CCR1  = (0xffff & value);
-            timer1->CCR1  = (value >> 16);
-            timer0->SR   &= ~TIM_SR_CC1IF;
-            timer0->DIER |= TIM_DIER_CC1IE;
-            DEBUG("Channel 1 set to %x\n", value);
-            break;
-        case 1:
-            timer0->CCR2  = (0xffff & value);
-            timer1->CCR2  = (value >> 16);
-            timer0->SR   &= ~TIM_SR_CC2IF;
-            timer0->DIER |= TIM_DIER_CC2IE;
-            DEBUG("Channel 2 set to %x\n", value);
-            break;
-        case 2:
-            timer0->CCR3  = (0xffff & value);
-            timer1->CCR3  = (value >> 16);
-            timer0->SR   &= ~TIM_SR_CC3IF;
-            timer0->DIER |= TIM_DIER_CC3IE;
-            DEBUG("Channel 3 set to %x\n", value);
-            break;
-        case 3:
-            timer0->CCR4  = (0xffff & value);
-            timer1->CCR4  = (value >> 16);
-            timer0->SR   &= ~TIM_SR_CC4IF;
-            timer0->DIER |= TIM_DIER_CC4IE;
-            DEBUG("Channel 4 set to %x\n", value);
-            break;
-        default:
-            return -1;
-    }
-    return 0;
-}
-
-int timer_clear(tim_t dev, int channel)
-{
-    TIM_TypeDef *timer0;
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            timer0 = TIMER_0_DEV_0;
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            timer0 = TIMER_1_DEV_0;
-            break;
-#endif
-        case TIMER_UNDEFINED:
-        default:
-            return -1;
-    }
-    switch (channel) {
-        case 0:
-            timer0->DIER &= ~TIM_DIER_CC1IE;
-            break;
-        case 1:
-            timer0->DIER &= ~TIM_DIER_CC2IE;
-            break;
-        case 2:
-            timer0->DIER &= ~TIM_DIER_CC3IE;
-            break;
-        case 3:
-            timer0->DIER &= ~TIM_DIER_CC4IE;
-            break;
-        default:
-            return -1;
-    }
-    return 0;
-}
-
-unsigned int timer_read(tim_t dev)
-{
-    unsigned a, b;
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            /* do OR'ing two times and only use value if results are equal.
-             * otherwise, the lower 16bit counter could overflow while the
-             * upper counter is read, leading to an incorrect result. */
-            do {
-                a = (((unsigned int)(0xffff & TIMER_0_DEV_0->CNT)) |
-                        (TIMER_0_DEV_1->CNT<<16));
-                b = (((unsigned int)(0xffff & TIMER_0_DEV_0->CNT)) |
-                        (TIMER_0_DEV_1->CNT<<16));
-            } while (a!=b);
-
-            return a;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-             /* see above about why loop is needed */
-            do {
-                a = (((unsigned int)(0xffff & TIMER_1_DEV_0->CNT)) |
-                        (TIMER_1_DEV_1->CNT<<16));
-                b = (((unsigned int)(0xffff & TIMER_1_DEV_0->CNT)) |
-                        (TIMER_1_DEV_1->CNT<<16));
-            } while (a!=b);
-
-            return a;
-#endif
-        case TIMER_UNDEFINED:
-        default:
-            return 0;
-    }
-}
-
-void timer_start(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            /* slave has to be enabled first */
-            TIMER_0_DEV_1->CR1 |= TIM_CR1_CEN;
-            TIMER_0_DEV_0->CR1 |= TIM_CR1_CEN;
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            /* slave has to be enabled first */
-            TIMER_1_DEV_1->CR1 |= TIM_CR1_CEN;
-            TIMER_1_DEV_0->CR1 |= TIM_CR1_CEN;
-            break;
-#endif
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-void timer_stop(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            TIMER_0_DEV_0->CR1 &= ~TIM_CR1_CEN;
-            TIMER_0_DEV_1->CR1 &= ~TIM_CR1_CEN;
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            TIMER_1_DEV_0->CR1 &= ~TIM_CR1_CEN;
-            TIMER_1_DEV_1->CR1 &= ~TIM_CR1_CEN;
-            break;
-#endif
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-void timer_irq_enable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            NVIC_EnableIRQ(TIMER_0_IRQ_CHAN_0);
-            NVIC_EnableIRQ(TIMER_0_IRQ_CHAN_1);
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            NVIC_EnableIRQ(TIMER_1_IRQ_CHAN_0);
-            NVIC_EnableIRQ(TIMER_1_IRQ_CHAN_1);
-            break;
-#endif
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            NVIC_DisableIRQ(TIMER_0_IRQ_CHAN_0);
-            NVIC_DisableIRQ(TIMER_0_IRQ_CHAN_1);
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            NVIC_DisableIRQ(TIMER_1_IRQ_CHAN_0);
-            NVIC_DisableIRQ(TIMER_1_IRQ_CHAN_1);
-            break;
-#endif
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-#if TIMER_0_EN
-void TIMER_0_ISR_0(void)
-{
-    DEBUG("\nenter ISR\n");
-    irq_handler(TIMER_0, TIMER_0_DEV_0, TIMER_0_DEV_1);
-    DEBUG("leave ISR\n\n");
-}
-#endif
-
-#if TIMER_1_EN
-void TIMER_1_ISR_0(void)
-{
-    irq_handler(TIMER_1, TIMER_1_DEV_0, TIMER_1_DEV_1);
-}
-#endif
-
-static inline void irq_handler(tim_t timer, TIM_TypeDef *dev0, TIM_TypeDef *dev1)
-{
-    DEBUG("CNT: %08x SR/DIER: %08x\n", ((dev1->CNT<<16) | (0xffff & dev0->CNT)),
-                                       ((dev0->SR<<16) | (0xffff & dev0->DIER)));
-
-    if ((dev0->SR & TIM_SR_CC1IF) && (dev0->DIER & TIM_DIER_CC1IE)) {
-        /* clear interrupt anyway */
-        dev0->SR &= ~TIM_SR_CC1IF;
-        /* if higher 16bit also match */
-        if (dev1->CNT >= dev1->CCR1) {
-            dev0->DIER &= ~TIM_DIER_CC1IE;
-            config[timer].cb(config[timer].arg, 0);
-        }
-        DEBUG("channel 1 CCR: %08x\n", ((dev1->CCR1<<16) | (0xffff & dev0->CCR1)));
-    }
-    else if ((dev0->SR & TIM_SR_CC2IF) && (dev0->DIER & TIM_DIER_CC2IE)) {
-        /* clear interrupt anyway */
-        dev0->SR &= ~TIM_SR_CC2IF;
-        /* if higher 16bit also match */
-        if (dev1->CNT >= dev1->CCR2) {
-            dev0->DIER &= ~TIM_DIER_CC2IE;
-            config[timer].cb(config[timer].arg, 1);
-        }
-        DEBUG("channel 2 CCR: %08x\n", ((dev1->CCR2<<16) | (0xffff & dev0->CCR2)));
-    }
-    else if ((dev0->SR & TIM_SR_CC3IF) && (dev0->DIER & TIM_DIER_CC3IE)) {
-        /* clear interrupt anyway */
-        dev0->SR &= ~TIM_SR_CC3IF;
-        /* if higher 16bit also match */
-        if (dev1->CNT >= dev1->CCR3) {
-            dev0->DIER &= ~TIM_DIER_CC3IE;
-            config[timer].cb(config[timer].arg, 2);
-        }
-        DEBUG("channel 3 CCR: %08x\n", ((dev1->CCR3<<16) | (0xffff & dev0->CCR3)));
-    }
-    else if ((dev0->SR & TIM_SR_CC4IF) && (dev0->DIER & TIM_DIER_CC4IE)) {
-        /* clear interrupt anyway */
-        dev0->SR &= ~TIM_SR_CC4IF;
-        /* if higher 16bit also match */
-        if (dev1->CNT >= dev1->CCR4) {
-            dev0->DIER &= ~TIM_DIER_CC4IE;
-            config[timer].cb(config[timer].arg, 3);
-        }
-        DEBUG("channel 4 CCR: %08x\n", ((dev1->CCR4<<16) | (0xffff & dev0->CCR4)));
+    if (timer_config[tim].bus == APB1) {
+        RCC->APB1ENR |= timer_config[tim].rcc_bit;
     }
     else {
-        dev0->SR = 0;
+        RCC->APB2ENR |= timer_config[tim].rcc_bit;
     }
+}
+
+int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+{
+    /* check if device is valid */
+    if (tim >= TIMER_NUMOF) {
+        return -1;
+    }
+
+    /* remember the interrupt context */
+    isr_ctx[tim].cb = cb;
+    isr_ctx[tim].arg = arg;
+
+    /* enable the peripheral clock */
+    clk_en(tim);
+
+    /* configure the timer as upcounter in continuous mode */
+    dev(tim)->CR1  = 0;
+    dev(tim)->CR2  = 0;
+    dev(tim)->ARR  = TIMER_MAXVAL;
+    /* set prescaler */
+    dev(tim)->PSC = ((CLOCK_CORECLOCK / freq) - 1);
+    /* generate an update event to apply our configuration */
+    dev(tim)->EGR = TIM_EGR_UG;
+
+    /* enable the timer's interrupt */
+    timer_irq_enable(tim);
+    /* reset the counter and start the timer */
+    timer_start(tim);
+
+    return 0;
+}
+
+int timer_set(tim_t tim, int channel, unsigned int timeout)
+{
+    int now = timer_read(tim);
+    return timer_set_absolute(tim, channel, now + timeout);
+}
+
+int timer_set_absolute(tim_t tim, int channel, unsigned int value)
+{
+    if (channel >= TIMER_CHANNELS) {
+        return -1;
+    }
+
+    dev(tim)->CCR[channel] = (value & TIMER_MAXVAL);
+    dev(tim)->SR &= ~(TIM_SR_CC1IF << channel);
+    dev(tim)->DIER |= (TIM_DIER_CC1IE << channel);
+
+    return 0;
+}
+
+int timer_clear(tim_t tim, int channel)
+{
+    if (channel >= TIMER_CHANNELS) {
+        return -1;
+    }
+
+    dev(tim)->DIER &= ~(TIM_DIER_CC1IE << channel);
+    return 0;
+}
+
+unsigned int timer_read(tim_t tim)
+{
+    return (unsigned int)dev(tim)->CNT;
+}
+
+void timer_start(tim_t tim)
+{
+    dev(tim)->CR1 |= TIM_CR1_CEN;
+}
+
+void timer_stop(tim_t tim)
+{
+    dev(tim)->CR1 &= ~(TIM_CR1_CEN);
+}
+
+void timer_irq_enable(tim_t tim)
+{
+    NVIC_EnableIRQ(timer_config[tim].irqn);
+}
+
+void timer_irq_disable(tim_t tim)
+{
+    NVIC_DisableIRQ(timer_config[tim].irqn);
+}
+
+static inline void irq_handler(tim_t tim)
+{
+    uint32_t status = (dev(tim)->SR & dev(tim)->DIER);
+
+    for (unsigned int i = 0; i < TIMER_CHANNELS; i++) {
+        if (status & (TIM_SR_CC1IF << i)) {
+            dev(tim)->DIER &= ~(TIM_DIER_CC1IE << i);
+            isr_ctx[tim].cb(isr_ctx[tim].arg, i);
+        }
+    }
+
     if (sched_context_switch_request) {
         thread_yield();
     }
 }
-#endif /* TIMER_0_EN || TIMER_1_EN */
+
+#ifdef TIMER_0_ISR
+void TIMER_0_ISR(void)
+{
+    irq_handler(0);
+}
+#endif
+
+#ifdef TIMER_1_ISR
+void TIMER_1_ISR(void)
+{
+    irq_handler(1);
+}
+#endif
+
+#ifdef TIMER_2_ISR
+void TIMER_2_ISR(void)
+{
+    irq_handler(2);
+}
+#endif
+
+#ifdef TIMER_3_ISR
+void TIMER_3_ISR(void)
+{
+    irq_handler(3);
+}
+#endif
+
+#ifdef TIMER_4_ISR
+void TIMER_4_ISR(void)
+{
+    irq_handler(4);
+}
+#endif


### PR DESCRIPTION
Cleaned up the timer driver for the stm32f1. The old implementation concatenated two 16-bit timers to force a 32-bit timer. This did not bring many benefits and is not needed anymore, as the xtimer works fine with 16-bit timers. Also this complicated the code quite a bit while still throwing interrupts on every 16-bit timer overflow...

```
tests/periph_timer @ master:
   text	   data	    bss	    dec	    hex	
   9040	    128	   2808	  11976	   2ec8

test/periph_timer @ this PR:
   text	   data	    bss	    dec	    hex	
   8556	    128	   2808	  11492	   2ce4
```
savings in ROM: almost 500byte!