### PR TITLE
boards/due|udoo: cleaned up LED handling

### DIFF
--- a/boards/arduino-due/board.c
+++ b/boards/arduino-due/board.c
@@ -18,44 +18,14 @@
  * @}
  */
 
-#include <stdio.h>
-
-#include "board.h"
 #include "cpu.h"
-
-
-void led_init(void);
-
+#include "board.h"
+#include "periph/gpio.h"
 
 void board_init(void)
 {
     /* initialize the CPU */
     cpu_init();
-
-    /* initialize the boards LEDs */
-    led_init();
-}
-
-
-/**
- * @brief Initialize the boards on-board LED (Amber LED "L")
- *
- * The LED initialization is hard-coded in this function. As the LED is soldered
- * onto the board it is fixed to its CPU pins.
- *
- * The LED is connected to the following pin:
- * - LED: PB27
- */
-void led_init(void)
-{
-    /* enable PIO control of pin PD27 */
-    LED_PORT->PIO_PER = LED_PIN;
-    /* set pin as output */
-    LED_PORT->PIO_OER = LED_PIN;
-    /* enable direct write access to the LED pin */
-    LED_PORT->PIO_OWER = LED_PIN;
-    /* disable pull-up */
-    LED_PORT->PIO_PUDR = LED_PIN;
-    /* clear pin */
-    LED_PORT->PIO_CODR = LED_PIN;
+    /* initialize the on-board Amber "L" LED @ pin PB27 */
+    gpio_init(LED_PIN, GPIO_DIR_OUT, GPIO_NOPULL);
 }

--- a/boards/arduino-due/include/board.h
+++ b/boards/arduino-due/include/board.h
@@ -33,24 +33,25 @@ extern "C" {
  * @{
  */
 #define LED_PORT            PIOB
-#define LED_PIN             PIO_PB27
+#define LED_BIT             PIO_PB27
+#define LED_PIN             GPIO_PIN(PB, 27)
 /** @} */
 
 /**
  * @name Macros for controlling the on-board LEDs.
  * @{
  */
-#define LED_ON              (LED_PORT->PIO_ODSR |= LED_PIN)
-#define LED_OFF             (LED_PORT->PIO_ODSR &= ~LED_PIN)
-#define LED_TOGGLE          (LED_PORT->PIO_ODSR ^= LED_PIN)
+#define LED_ON              (LED_PORT->PIO_SODR = LED_BIT)
+#define LED_OFF             (LED_PORT->PIO_CODR = LED_BIT)
+#define LED_TOGGLE          (LED_PORT->PIO_ODSR ^= LED_BIT)
 
 /* for compatability to other boards */
-#define LED_GREEN_ON        /* not available */
-#define LED_GREEN_OFF       /* not available */
-#define LED_GREEN_TOGGLE    /* not available */
-#define LED_RED_ON          LED_ON
-#define LED_RED_OFF         LED_OFF
-#define LED_RED_TOGGLE      LED_TOGGLE
+#define LED_GREEN_ON        LED_ON
+#define LED_GREEN_OFF       LED_OFF
+#define LED_GREEN_TOGGLE    LED_TOGGLE
+#define LED_RED_ON          /* not available */
+#define LED_RED_OFF         /* not available */
+#define LED_RED_TOGGLE      /* not available */
 /** @} */
 
 /**

--- a/boards/udoo/board.c
+++ b/boards/udoo/board.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014-2016 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -18,43 +18,14 @@
  * @}
  */
 
-#include <stdio.h>
-
+#include "cpu.h"
 #include "board.h"
-
-
-void led_init(void);
-
+#include "periph/gpio.h"
 
 void board_init(void)
 {
     /* initialize the CPU */
     cpu_init();
-
-    /* initialize the boards LEDs */
-    led_init();
-}
-
-
-/**
- * @brief Initialize the boards on-board LED (Amber LED "L")
- *
- * The LED initialization is hard-coded in this function. As the LED is soldered
- * onto the board it is fixed to its CPU pins.
- *
- * The LED is connected to the following pin:
- * - LED: PB27
- */
-void led_init(void)
-{
-    /* enable PIO control of pin PD27 */
-    LED_PORT->PIO_PER = LED_PIN;
-    /* set pin as output */
-    LED_PORT->PIO_OER = LED_PIN;
-    /* enable direct write access to the LED pin */
-    LED_PORT->PIO_OWER = LED_PIN;
-    /* disable pull-up */
-    LED_PORT->PIO_PUDR = LED_PIN;
-    /* clear pin */
-    LED_PORT->PIO_CODR = LED_PIN;
+    /* initialize the on-board Amber "L" LED @ pin PB27 */
+    gpio_init(LED_PIN, GPIO_DIR_OUT, GPIO_NOPULL);
 }

--- a/boards/udoo/include/board.h
+++ b/boards/udoo/include/board.h
@@ -33,16 +33,17 @@ extern "C" {
  * @{
  */
 #define LED_PORT            PIOB
-#define LED_PIN             PIO_PB27
+#define LED_BIT             PIO_PB27
+#define LED_PIN             GPIO_PIN(PB, 27)
 /** @} */
 
 /**
  * @name Macros for controlling the on-board LEDs.
  * @{
  */
-#define LED_ON              LED_PORT->PIO_ODSR |= LED_PIN
-#define LED_OFF             LED_PORT->PIO_ODSR &= ~LED_PIN
-#define LED_TOGGLE          LED_PORT->PIO_ODSR ^= LED_PIN;
+#define LED_ON              (LED_PORT->PIO_SODR = LED_BIT)
+#define LED_OFF             (LED_PORT->PIO_CODR = LED_BIT)
+#define LED_TOGGLE          (LED_PORT->PIO_ODSR ^= LED_BIT)
 
 /* for compatability to other boards */
 #define LED_GREEN_ON        LED_ON
@@ -52,7 +53,6 @@ extern "C" {
 #define LED_RED_OFF         /* not available */
 #define LED_RED_TOGGLE      /* not available */
 /** @} */
-
 
 /**
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO


### PR DESCRIPTION
simplyfied initialization, added some missing parens and so on.