### PR TITLE
unittests: add fletcher* tests

### DIFF
--- a/tests/unittests/tests-checksum/tests-checksum-crc16-ccitt.c
+++ b/tests/unittests/tests-checksum/tests-checksum-crc16-ccitt.c
@@ -32,63 +32,72 @@ static int calc_and_compare_crc(const unsigned char *buf, size_t len,
     return result == expected;
 }
 
-static void test_checksum_crc16_ccitt_sequence(void)
+static void test_checksum_crc16_ccitt_sequence_empty(void)
 {
-    /* Reference values according to
-     * http://srecord.sourceforge.net/crc16-ccitt.html */
-    {
-        unsigned char buf[] = "";
-        uint16_t expect = 0x1D0F;
+    unsigned char buf[] = "";
+    uint16_t expect = 0x1D0F;
 
-        TEST_ASSERT(calc_and_compare_crc(buf, sizeof(buf) - 1, expect));
-        TEST_ASSERT(calc_and_compare_crc_with_update(buf, sizeof(buf) - 1,
-                    (sizeof(buf) - 1) / 2, expect)); }
+    TEST_ASSERT(calc_and_compare_crc(buf, sizeof(buf) - 1, expect));
+    TEST_ASSERT(calc_and_compare_crc_with_update(buf, sizeof(buf) - 1,
+                (sizeof(buf) - 1) / 2, expect));
+}
 
-    {
-        unsigned char buf[] = "A";
-        uint16_t expect = 0x9479;
+static void test_checksum_crc16_ccitt_sequence_1a(void)
+{
+    unsigned char buf[] = "A";
+    uint16_t expect = 0x9479;
 
-        TEST_ASSERT(calc_and_compare_crc(buf, sizeof(buf) - 1, expect));
-        TEST_ASSERT(calc_and_compare_crc_with_update(buf, sizeof(buf) - 1,
-                    (sizeof(buf) - 1) / 2, expect)); }
+    TEST_ASSERT(calc_and_compare_crc(buf, sizeof(buf) - 1, expect));
+    TEST_ASSERT(calc_and_compare_crc_with_update(buf, sizeof(buf) - 1,
+                (sizeof(buf) - 1) / 2, expect));
+}
 
-    {
-        unsigned char buf[] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                              "AAAA";
-        uint16_t expect = 0xE938;
+static void test_checksum_crc16_ccitt_sequence_256a(void)
+{
+    unsigned char buf[] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                          "AAAA";
+    uint16_t expect = 0xE938;
 
-        TEST_ASSERT(calc_and_compare_crc(buf, sizeof(buf) - 1, expect));
-        TEST_ASSERT(calc_and_compare_crc_with_update(buf, sizeof(buf) - 1,
-                    (sizeof(buf) - 1) / 2, expect)); }
+    TEST_ASSERT(calc_and_compare_crc(buf, sizeof(buf) - 1, expect));
+    TEST_ASSERT(calc_and_compare_crc_with_update(buf, sizeof(buf) - 1,
+                (sizeof(buf) - 1) / 2, expect));
+}
 
-    {
-        unsigned char buf[] = "123456789";
-        uint16_t expect = 0xE5CC;
+static void test_checksum_crc16_ccitt_sequence_1to9(void)
+{
+    unsigned char buf[] = "123456789";
+    uint16_t expect = 0xE5CC;
 
-        TEST_ASSERT(calc_and_compare_crc(buf, sizeof(buf) - 1, expect));
-        TEST_ASSERT(calc_and_compare_crc_with_update(buf, sizeof(buf)
-                    - 1, (sizeof(buf) - 1) / 2, expect));
-    }
+    TEST_ASSERT(calc_and_compare_crc(buf, sizeof(buf) - 1, expect));
+    TEST_ASSERT(calc_and_compare_crc_with_update(buf, sizeof(buf)
+                - 1, (sizeof(buf) - 1) / 2, expect));
+}
 
-    {
-        unsigned char buf[] = { 0x12, 0x34, 0x56, 0x78 };
-        uint16_t expect = 0xBA3C;
+static void test_checksum_crc16_ccitt_sequence_4bytes(void)
+{
+    unsigned char buf[] = { 0x12, 0x34, 0x56, 0x78 };
+    uint16_t expect = 0xBA3C;
 
-        TEST_ASSERT(calc_and_compare_crc(buf, sizeof(buf), expect));
-        TEST_ASSERT(calc_and_compare_crc_with_update(buf, sizeof(buf),
-                    sizeof(buf) / 2, expect));
-    }
+    TEST_ASSERT(calc_and_compare_crc(buf, sizeof(buf), expect));
+    TEST_ASSERT(calc_and_compare_crc_with_update(buf, sizeof(buf),
+                sizeof(buf) / 2, expect));
 }
 
 Test *tests_checksum_crc16_ccitt_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
-        new_TestFixture(test_checksum_crc16_ccitt_sequence),
+        /* Reference values according to
+         * http://srecord.sourceforge.net/crc16-ccitt.html */
+        new_TestFixture(test_checksum_crc16_ccitt_sequence_empty),
+        new_TestFixture(test_checksum_crc16_ccitt_sequence_1a),
+        new_TestFixture(test_checksum_crc16_ccitt_sequence_256a),
+        new_TestFixture(test_checksum_crc16_ccitt_sequence_1to9),
+        new_TestFixture(test_checksum_crc16_ccitt_sequence_4bytes),
     };
 
     EMB_UNIT_TESTCALLER(checksum_crc16_ccitt_tests, NULL, NULL, fixtures);

--- a/tests/unittests/tests-checksum/tests-checksum-fletcher16.c
+++ b/tests/unittests/tests-checksum/tests-checksum-fletcher16.c
@@ -22,47 +22,49 @@ static int calc_and_compare_checksum(const unsigned char *buf, size_t len,
     return result == expected;
 }
 
-static void test_checksum_fletcher16(void)
+static void test_checksum_fletcher16_empty(void)
 {
-    {
-        unsigned char buf[] = "";
-        uint16_t expect = 0xFFFF;
+    unsigned char buf[] = "";
+    uint16_t expect = 0xFFFF;
 
-        TEST_ASSERT(calc_and_compare_checksum(buf, sizeof(buf) - 1, expect));
-    }
+    TEST_ASSERT(calc_and_compare_checksum(buf, sizeof(buf) - 1, expect));
+}
 
-    {
-        /* fletcher cannot distinguish between all 0 and all 1 segments */
-        unsigned char buf0[16] = {
-            0xA1, 0xA1, 0xA1, 0xA1,
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00,
-            0x1A, 0x1A, 0x1A, 0x1A,
-        };
-        uint32_t expect = fletcher16(buf0, sizeof(buf0));
-        unsigned char buf1[16] = {
-            0xA1, 0xA1, 0xA1, 0xA1,
-            0xFF, 0xFF, 0xFF, 0xFF,
-            0xFF, 0xFF, 0xFF, 0xFF,
-            0x1A, 0x1A, 0x1A, 0x1A,
-        };
+static void test_checksum_fletcher16_0to1_undetected(void)
+{
+    /* fletcher cannot distinguish between all 0 and all 1 segments */
+    unsigned char buf0[16] = {
+        0xA1, 0xA1, 0xA1, 0xA1,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+        0x1A, 0x1A, 0x1A, 0x1A,
+    };
+    uint32_t expect = fletcher16(buf0, sizeof(buf0));
+    unsigned char buf1[16] = {
+        0xA1, 0xA1, 0xA1, 0xA1,
+        0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF,
+        0x1A, 0x1A, 0x1A, 0x1A,
+    };
 
-        TEST_ASSERT(calc_and_compare_checksum(buf1, sizeof(buf1), expect));
-    }
+    TEST_ASSERT(calc_and_compare_checksum(buf1, sizeof(buf1), expect));
+}
 
-    {
-        /* verified with http://www.nitrxgen.net/hashgen/ */
-        unsigned char buf[] = "abcde";
-        uint16_t expect = 0xc8f0;
+static void test_checksum_fletcher16_atoe(void)
+{
+    /* verified with http://www.nitrxgen.net/hashgen/ */
+    unsigned char buf[] = "abcde";
+    uint16_t expect = 0xc8f0;
 
-        TEST_ASSERT(calc_and_compare_checksum(buf, sizeof(buf) - 1, expect));
-    }
+    TEST_ASSERT(calc_and_compare_checksum(buf, sizeof(buf) - 1, expect));
 }
 
 Test *tests_checksum_fletcher16_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
-        new_TestFixture(test_checksum_fletcher16),
+        new_TestFixture(test_checksum_fletcher16_empty),
+        new_TestFixture(test_checksum_fletcher16_0to1_undetected),
+        new_TestFixture(test_checksum_fletcher16_atoe),
     };
 
     EMB_UNIT_TESTCALLER(checksum_fletcher16_tests, NULL, NULL, fixtures);

--- a/tests/unittests/tests-checksum/tests-checksum-fletcher16.c
+++ b/tests/unittests/tests-checksum/tests-checksum-fletcher16.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <stdint.h>
+
+#include "embUnit/embUnit.h"
+
+#include "checksum/fletcher16.h"
+
+#include "tests-checksum.h"
+
+static int calc_and_compare_checksum(const unsigned char *buf, size_t len,
+                                     uint16_t expected)
+{
+    uint16_t result = fletcher16(buf, len);
+
+    return result == expected;
+}
+
+static void test_checksum_fletcher16(void)
+{
+    {
+        unsigned char buf[] = "";
+        uint16_t expect = 0xFFFF;
+
+        TEST_ASSERT(calc_and_compare_checksum(buf, sizeof(buf) - 1, expect));
+    }
+
+    {
+        /* fletcher cannot distinguish between all 0 and all 1 segments */
+        unsigned char buf0[16] = {
+            0xA1, 0xA1, 0xA1, 0xA1,
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+            0x1A, 0x1A, 0x1A, 0x1A,
+        };
+        uint32_t expect = fletcher16(buf0, sizeof(buf0));
+        unsigned char buf1[16] = {
+            0xA1, 0xA1, 0xA1, 0xA1,
+            0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF,
+            0x1A, 0x1A, 0x1A, 0x1A,
+        };
+
+        TEST_ASSERT(calc_and_compare_checksum(buf1, sizeof(buf1), expect));
+    }
+
+    {
+        /* verified with http://www.nitrxgen.net/hashgen/ */
+        unsigned char buf[] = "abcde";
+        uint16_t expect = 0xc8f0;
+
+        TEST_ASSERT(calc_and_compare_checksum(buf, sizeof(buf) - 1, expect));
+    }
+}
+
+Test *tests_checksum_fletcher16_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_checksum_fletcher16),
+    };
+
+    EMB_UNIT_TESTCALLER(checksum_fletcher16_tests, NULL, NULL, fixtures);
+
+    return (Test *)&checksum_fletcher16_tests;
+}

--- a/tests/unittests/tests-checksum/tests-checksum-fletcher32.c
+++ b/tests/unittests/tests-checksum/tests-checksum-fletcher32.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <stdint.h>
+
+#include "embUnit/embUnit.h"
+
+#include "checksum/fletcher32.h"
+
+#include "tests-checksum.h"
+
+static int calc_and_compare_checksum(const unsigned char *buf, size_t len,
+                                     uint32_t expected)
+{
+    const uint16_t *buf16 = (const uint16_t *) buf;
+    size_t len16 = len/2;
+    uint32_t result = fletcher32(buf16, len16);
+
+    return result == expected;
+}
+
+static void test_checksum_fletcher32(void)
+{
+    {
+        /* the initial checksum value is 0xFFFFFFFF */
+        unsigned char buf[] = "";
+        uint32_t expect = 0xFFFFFFFF;
+
+        TEST_ASSERT(calc_and_compare_checksum(buf, sizeof(buf) - 1, expect));
+    }
+
+    {
+        /* fletcher cannot distinguish between all 0 and all 1 segments */
+        unsigned char buf0[16] = {
+            0xA1, 0xA1, 0xA1, 0xA1,
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+            0x1A, 0x1A, 0x1A, 0x1A,
+        };
+        uint32_t expect = fletcher32((const uint16_t *) buf0, sizeof(buf0)/2);
+        unsigned char buf1[16] = {
+            0xA1, 0xA1, 0xA1, 0xA1,
+            0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF,
+            0x1A, 0x1A, 0x1A, 0x1A,
+        };
+
+        TEST_ASSERT(calc_and_compare_checksum(buf1, sizeof(buf1), expect));
+    }
+
+    {
+        /* XXX: not verified with external implementation yet */
+        unsigned char buf[] = "abcdef";
+        uint32_t expect = 0x56502d2a;
+
+        TEST_ASSERT(calc_and_compare_checksum(buf, sizeof(buf) - 1, expect));
+    }
+}
+
+Test *tests_checksum_fletcher32_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_checksum_fletcher32),
+    };
+
+    EMB_UNIT_TESTCALLER(checksum_fletcher32_tests, NULL, NULL, fixtures);
+
+    return (Test *)&checksum_fletcher32_tests;
+}

--- a/tests/unittests/tests-checksum/tests-checksum-fletcher32.c
+++ b/tests/unittests/tests-checksum/tests-checksum-fletcher32.c
@@ -24,48 +24,50 @@ static int calc_and_compare_checksum(const unsigned char *buf, size_t len,
     return result == expected;
 }
 
-static void test_checksum_fletcher32(void)
+static void test_checksum_fletcher32_empty(void)
 {
-    {
-        /* the initial checksum value is 0xFFFFFFFF */
-        unsigned char buf[] = "";
-        uint32_t expect = 0xFFFFFFFF;
+    /* the initial checksum value is 0xFFFFFFFF */
+    unsigned char buf[] = "";
+    uint32_t expect = 0xFFFFFFFF;
 
-        TEST_ASSERT(calc_and_compare_checksum(buf, sizeof(buf) - 1, expect));
-    }
+    TEST_ASSERT(calc_and_compare_checksum(buf, sizeof(buf) - 1, expect));
+}
 
-    {
-        /* fletcher cannot distinguish between all 0 and all 1 segments */
-        unsigned char buf0[16] = {
-            0xA1, 0xA1, 0xA1, 0xA1,
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00,
-            0x1A, 0x1A, 0x1A, 0x1A,
-        };
-        uint32_t expect = fletcher32((const uint16_t *) buf0, sizeof(buf0)/2);
-        unsigned char buf1[16] = {
-            0xA1, 0xA1, 0xA1, 0xA1,
-            0xFF, 0xFF, 0xFF, 0xFF,
-            0xFF, 0xFF, 0xFF, 0xFF,
-            0x1A, 0x1A, 0x1A, 0x1A,
-        };
+static void test_checksum_fletcher32_0to1_undetected(void)
+{
+    /* fletcher cannot distinguish between all 0 and all 1 segments */
+    unsigned char buf0[16] = {
+        0xA1, 0xA1, 0xA1, 0xA1,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+        0x1A, 0x1A, 0x1A, 0x1A,
+    };
+    uint32_t expect = fletcher32((const uint16_t *) buf0, sizeof(buf0)/2);
+    unsigned char buf1[16] = {
+        0xA1, 0xA1, 0xA1, 0xA1,
+        0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF,
+        0x1A, 0x1A, 0x1A, 0x1A,
+    };
 
-        TEST_ASSERT(calc_and_compare_checksum(buf1, sizeof(buf1), expect));
-    }
+    TEST_ASSERT(calc_and_compare_checksum(buf1, sizeof(buf1), expect));
+}
 
-    {
-        /* XXX: not verified with external implementation yet */
-        unsigned char buf[] = "abcdef";
-        uint32_t expect = 0x56502d2a;
+static void test_checksum_fletcher32_atof(void)
+{
+    /* XXX: not verified with external implementation yet */
+    unsigned char buf[] = "abcdef";
+    uint32_t expect = 0x56502d2a;
 
-        TEST_ASSERT(calc_and_compare_checksum(buf, sizeof(buf) - 1, expect));
-    }
+    TEST_ASSERT(calc_and_compare_checksum(buf, sizeof(buf) - 1, expect));
 }
 
 Test *tests_checksum_fletcher32_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
-        new_TestFixture(test_checksum_fletcher32),
+        new_TestFixture(test_checksum_fletcher32_empty),
+        new_TestFixture(test_checksum_fletcher32_0to1_undetected),
+        new_TestFixture(test_checksum_fletcher32_atof),
     };
 
     EMB_UNIT_TESTCALLER(checksum_fletcher32_tests, NULL, NULL, fixtures);

--- a/tests/unittests/tests-checksum/tests-checksum.c
+++ b/tests/unittests/tests-checksum/tests-checksum.c
@@ -11,4 +11,6 @@
 void tests_checksum(void)
 {
     TESTS_RUN(tests_checksum_crc16_ccitt_tests());
+    TESTS_RUN(tests_checksum_fletcher16_tests());
+    TESTS_RUN(tests_checksum_fletcher32_tests());
 }

--- a/tests/unittests/tests-checksum/tests-checksum.h
+++ b/tests/unittests/tests-checksum/tests-checksum.h
@@ -36,6 +36,20 @@ void tests_checksum(void);
  */
 Test *tests_checksum_crc16_ccitt_tests(void);
 
+/**
+ * @brief   Generates tests for checksum/fletcher16.h
+ *
+ * @return  embUnit tests if successful, NULL if not.
+ */
+Test *tests_checksum_fletcher16_tests(void);
+
+/**
+ * @brief   Generates tests for checksum/fletcher32.h
+ *
+ * @return  embUnit tests if successful, NULL if not.
+ */
+Test *tests_checksum_fletcher32_tests(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The fletcher32 checksum does not match what the tool referenced in the fletcher16 test produces. I guess this is due to a common (I looked at various implementations on GitHub et al) implementation deviation where 8 bit words are summed instead of 16 bit words.