### PR TITLE
make: use single ticks

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -179,7 +179,7 @@ ifeq ($(origin RIOT_VERSION), undefined)
       RIOT_VERSION := $(GIT_STRING)-$(GIT_BRANCH)
     endif
   else
-    RIOT_VERSION := "UNKNOWN (builddir: $(RIOTBASE))"
+    RIOT_VERSION := 'UNKNOWN (builddir: $(RIOTBASE))'
   endif
 endif
 


### PR DESCRIPTION
Otherwise the shell will try to evaluate the parentheses.