### PR TITLE
cpu/cortexm_common: Fix inline asm for ARMv6-M so that it compiles in Clang as well

### DIFF
--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -141,6 +141,8 @@ static inline int _stack_size_left(uint32_t required)
     return ((int)((uint32_t)sp - (uint32_t)&_sstack) - required);
 }
 
+void hard_fault_handler(uint32_t* sp, uint32_t corrupted, uint32_t exc_return, uint32_t* r4_to_r11_stack);
+
 /* Trampoline function to save stack pointer before calling hard fault handler */
 __attribute__((naked)) void hard_fault_default(void)
 {
@@ -181,7 +183,7 @@ __attribute__((naked)) void hard_fault_default(void)
         "push {r4-r11}                      \n" /* save r4..r11 to the stack  */
 #endif
         "mov r3, sp                         \n" /* r4_to_r11_stack parameter  */
-        "b hard_fault_handler               \n" /* hard_fault_handler(r0)     */
+        "bl hard_fault_handler              \n" /* hard_fault_handler(r0)     */
           :
           : [sram]   "r" (&_sram + HARDFAULT_HANDLER_REQUIRED_STACK_SPACE),
             [eram]   "r" (&_eram),

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -154,12 +154,12 @@ __attribute__((naked)) void hard_fault_default(void)
         "bhi fix_msp                        \n" /*   goto fix_msp }           */
         "cmp r0, %[sram]                    \n" /* if(msp <= &_sram) {        */
         "bls fix_msp                        \n" /*   goto fix_msp }           */
-        "mov r1, #0                         \n" /* else { corrupted = false   */
+        "movs r1, #0                        \n" /* else { corrupted = false   */
         "b   test_sp                        \n" /*   goto test_sp     }       */
         " fix_msp:                          \n" /*                            */
         "mov r1, %[estack]                  \n" /*     r1 = _estack           */
         "mov sp, r1                         \n" /*     sp = r1                */
-        "mov r1, #1                         \n" /*     corrupted = true       */
+        "movs r1, #1                        \n" /*     corrupted = true       */
         " test_sp:                          \n" /*                            */
         "movs r0, #4                        \n" /* r0 = 0x4                   */
         "mov r2, lr                         \n" /* r2 = lr                    */


### PR DESCRIPTION
without this we get the following when building for Cortex-M0 (example output from `make TOOLCHAIN=llvm BOARD=yunjia-nrf51822`):
```
.../riot/cpu/cortexm_common/vectors_cortexm.c:157:10: error: instruction requires: arm-mode
        "mov r1, #0                         \n" /* else { corrupted = false   */
         ^
<inline asm>:6:1: note: instantiated into assembly here
mov r1, #0                         
^
.../riot/cpu/cortexm_common/vectors_cortexm.c:162:10: error: instruction requires: arm-mode
        "mov r1, #1                         \n" /*     corrupted = true       */
         ^
<inline asm>:11:1: note: instantiated into assembly here
mov r1, #1                         
^
```

Clarification of the change:
`mov` only exists in ARMv7, `movs` exist in both ARMv6 and ARMv7. `movs` is a copy affecting flags, in this context it doesn't matter which one we use since the next instruction in `test_sp` is also a `movs`.

The second modification, `bl` instead of `b`: Clang exits with the following message without this change:

```
fatal error: error in backend: unsupported relocation on symbol
x86_64-pc-linux-gnu-clang-3.7: error: clang frontend command failed with exit code 70 (use -v to see invocation)
clang version 3.7.1 (tags/RELEASE_371/final)
Target: arm-none--eabi
Thread model: posix
x86_64-pc-linux-gnu-clang-3.7: note: diagnostic msg: PLEASE submit a bug report to http://llvm.org/bugs/ and include the crash backtrace, preprocessed source, and associated run script.
x86_64-pc-linux-gnu-clang-3.7: note: diagnostic msg: 
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
x86_64-pc-linux-gnu-clang-3.7: note: diagnostic msg: /tmp/vectors_cortexm-54333e.c
x86_64-pc-linux-gnu-clang-3.7: note: diagnostic msg: /tmp/vectors_cortexm-54333e.sh
x86_64-pc-linux-gnu-clang-3.7: note: diagnostic msg: 

********************
```

It's something to do with functions versus assembler labels and Clang being picky, I can't find the discussion thread I read in order to debug this one.