### PR TITLE
travis: run static tests only if flag is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
 
 before_install:
     - source ./dist/tools/pr_check/check_labels.sh
-    - test -z "$TRAVIS_PULL_REQUEST" || test "$BUILDTEST_MCU_GROUP" = "static-tests" || check_gh_label "Ready for CI build" || exit 1
+    - test -z "$TRAVIS_PULL_REQUEST" || check_gh_label "Ready for CI build" || exit 1
     - sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
     - sudo apt-get update -qq
 


### PR DESCRIPTION
Don't run static tests for PRs that are not marked with the `Ready for CI` flag.