### PR TITLE
boards/mulle: Default to programmer version 0.70

### DIFF
--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -56,8 +56,8 @@ ifeq ($(PROGRAMMER_VERSION),)
       endif
     endif
   endif
-  # Default to version 0.60 programmer for now.
-  PROGRAMMER_VERSION ?= 0.60
+  # Default to version 0.70 programmer
+  PROGRAMMER_VERSION ?= 0.70
 endif
 
 export OPENOCD_CONFIG = $(RIOTBOARD)/$(BOARD)/dist/openocd/mulle-programmer-$(PROGRAMMER_VERSION).conf


### PR DESCRIPTION
Only a few v0.60 programmer boards exist, better to default to the 0.70 version which is more widely used.

This should eliminate the need to export `PROGRAMMER_SERIAL` before `make flash` and `make term` if only a single programmer v0.70 board is connected.