### PR TITLE
travis: continue static tests on error

### DIFF
--- a/dist/tools/travis-scripts/build_and_test.sh
+++ b/dist/tools/travis-scripts/build_and_test.sh
@@ -7,20 +7,6 @@
 # directory for more details.
 #
 
-set -e
-
-set_result() {
-    NEW_RESULT=$1
-    LAST_RESULT=$2
-
-    if [ $LAST_RESULT -ne 0 ] && [ $NEW_RESULT -eq 0 ]
-    then
-        NEW_RESULT=$LAST_RESULT
-    fi
-
-    echo $NEW_RESULT
-}
-
 if [[ $BUILDTEST_MCU_GROUP ]]
 then
 
@@ -28,36 +14,32 @@ then
     then
         RESULT=0
 
+        trap "RESULT=1" ERR
+
         git rebase master || git rebase --abort
-        RESULT=$(set_result $? $RESULT)
+        if [ $RESULT -ne 0 ]; then
+            exit $RESULT
+        fi
 
         ./dist/tools/whitespacecheck/check.sh master
-        RESULT=$(set_result $? $RESULT)
 
         ./dist/tools/licenses/check.sh master --diff-filter=MR --error-exitcode=0
-        RESULT=$(set_result $? $RESULT)
 
         ./dist/tools/licenses/check.sh master --diff-filter=AC
-        RESULT=$(set_result $? $RESULT)
 
         ./dist/tools/doccheck/check.sh master
-        RESULT=$(set_result $? $RESULT)
 
         ./dist/tools/externc/check.sh master
-        RESULT=$(set_result $? $RESULT)
 
         # TODO:
         #   Remove all but `master` parameters to cppcheck (and remove second
         #   invocation) once all warnings of cppcheck have been taken care of
         #   in master.
         ./dist/tools/cppcheck/check.sh master --diff-filter=MR --error-exitcode=0
-        RESULT=$(set_result $? $RESULT)
 
         ./dist/tools/cppcheck/check.sh master --diff-filter=AC
-        RESULT=$(set_result $? $RESULT)
 
         ./dist/tools/pr_check/pr_check.sh master
-        RESULT=$(set_result $? $RESULT)
 
         exit $RESULT
     fi


### PR DESCRIPTION
Continue static tests even if one of them fails. This way we might get more feedback in one run, instead of having a running - testing - running - testing loop.

In the current implementation the script exits as soon as one of static tests fail (because of `set -e`).