### PR TITLE
compile_test: blacklist tests

### DIFF
--- a/dist/tools/compile_test/compile_test.py
+++ b/dist/tools/compile_test/compile_test.py
@@ -37,6 +37,11 @@ class Termcolor:
     purple = '\033[1;35m'
     end = '\033[0m'
 
+blacklist = {
+        'examples'  : [ 'default', 'gnrc_minimal', 'hello-world' ],
+        'tests'     : [ 'minimal', 'posix', 'shell', 'sizeof_tcb', 'thread_basic' ]
+        }
+
 def is_tracked(application_folder):
     if not isfile(join(application_folder, 'Makefile')):
         return False
@@ -155,10 +160,11 @@ def is_updated(application_folder, subprocess_env):
 def build_all():
     riotbase = environ.get('RIOTBASE') or abspath(join(dirname(abspath(__file__)), '../' * 3))
     for folder in ('examples', 'tests'):
-        print('Building all applications in: {}'.format(colorize_str(folder, Termcolor.blue)))
+        print('Building applications in: {}'.format(colorize_str(folder, Termcolor.blue)))
 
         applications = listdir(join(riotbase, folder))
         applications = filter(lambda app: is_tracked(join(riotbase, folder, app)), applications)
+        applications = [app for app in applications if app not in blacklist[folder]]
         applications = sorted(applications)
 
         subprocess_env = environ.copy()


### PR DESCRIPTION
A discussion with @kYc0o lead to the conclusion that it's probably better for our travis builds to *not* compile every test that we have in `examples` and `tests`.

A lot of tests include the same functionality and IMO it's not necessary to build them all.

What do you think?

I included a small blacklist which definitely can be extended. So I am open to suggesstions.