### PR TITLE
Makefile.buildtest: set CCACHE_DIR only if defined

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -50,7 +50,7 @@ buildtest:
 	        PATH=$${PATH} \
 	        BOARD=$${BOARD} \
 	        CCACHE=$${CCACHE} \
-	        CCACHE_DIR=$${CCACHE_DIR} \
+	        $${CCACHE_DIR:+CCACHE_DIR=$${CCACHE_DIR}} \
 	        CCACHE_BASEDIR=$${CCACHE_BASEDIR} \
 	        RIOTBASE=$${RIOTBASE} \
 	        RIOTBOARD=$${RIOTBOARD} \
@@ -85,7 +85,7 @@ buildtest:
 	    PATH=$${PATH} \
 	    BOARD=$${BOARD} \
 	    CCACHE=$${CCACHE} \
-	    CCACHE_DIR=$${CCACHE_DIR} \
+	    $${CCACHE_DIR:+CCACHE_DIR=$${CCACHE_DIR}} \
 	    CCACHE_BASEDIR=$${CCACHE_BASEDIR} \
 	    RIOTBASE=$${RIOTBASE} \
 	    RIOTBOARD=$${RIOTBOARD} \


### PR DESCRIPTION
Everytime when I run `make buildtest` my ccache complains (only for native) that `CCACHE_DIR` must not be the empty string. This patch adds `CCACHE_DIR` to the new env only if it was previously defined.
On my machine I do not export a custom `CCACHE_DIR`, but use the default location.