### PR TITLE
cpu/kinetis_common: Use gpio_init_port for PWM pin handling

### DIFF
--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -131,28 +131,22 @@ static const adc_conf_t adc_config[] = {
 #define PWM_0_CLK                    CLOCK_CORECLOCK
 #define PWM_0_CLKEN()                (SIM->SCGC6 |= (SIM_SCGC6_FTM0_MASK))
 #define PWM_0_CLKDIS()               (SIM->SCGC6 &= ~(SIM_SCGC6_FTM0_MASK))
-/* PWM 0 pin configuration */
-#define PWM_0_PORT_CLKEN()           (SIM->SCGC5 |= (SIM_SCGC5_PORTA_MASK | SIM_SCGC5_PORTC_MASK))
 /* Arduino Connector D3 */
-#define PWM_0_PORT_CH0               PORTA
-#define PWM_0_PIN_CH0                1
-#define PWM_0_FTMCHAN_CH0            6
-#define PWM_0_PIN_AF_CH0             3
+#define PWM_0_CH0_GPIO               GPIO_PIN(PORT_A, 1)
+#define PWM_0_CH0_FTMCHAN            6
+#define PWM_0_CH0_AF                 3
 /* Arduino Connector D5 */
-#define PWM_0_PORT_CH1               PORTA
-#define PWM_0_PIN_CH1                2
-#define PWM_0_FTMCHAN_CH1            7
-#define PWM_0_PIN_AF_CH1             3
+#define PWM_0_CH1_GPIO               GPIO_PIN(PORT_A, 2)
+#define PWM_0_CH1_FTMCHAN            7
+#define PWM_0_CH1_AF                 3
 /* Arduino Connector D6 */
-#define PWM_0_PORT_CH2               PORTC
-#define PWM_0_PIN_CH2                2
-#define PWM_0_FTMCHAN_CH2            1
-#define PWM_0_PIN_AF_CH2             4
+#define PWM_0_CH2_GPIO               GPIO_PIN(PORT_C, 2)
+#define PWM_0_CH2_FTMCHAN            1
+#define PWM_0_CH2_AF                 4
 /* Arduino Connector D7 */
-#define PWM_0_PORT_CH3               PORTC
-#define PWM_0_PIN_CH3                3
-#define PWM_0_FTMCHAN_CH3            2
-#define PWM_0_PIN_AF_CH3             4
+#define PWM_0_CH3_GPIO               GPIO_PIN(PORT_C, 3)
+#define PWM_0_CH3_FTMCHAN            2
+#define PWM_0_CH3_AF                 4
 /** @} */
 
 

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -171,17 +171,13 @@ static const adc_conf_t adc_config[] = {
 #define PWM_0_CLKDIS()      (BITBAND_REG32(SIM->SCGC6, SIM_SCGC6_FTM0_SHIFT) = 0)
 
 /* PWM 0 pin configuration */
-#define PWM_0_PORT_CLKEN()  (BITBAND_REG32(SIM->SCGC5, SIM_SCGC5_PORTC_SHIFT) = 1)
+#define PWM_0_CH0_GPIO      GPIO_PIN(PORT_C, 1)
+#define PWM_0_CH0_FTMCHAN   0
+#define PWM_0_CH0_AF        4
 
-#define PWM_0_PIN_CH0       1
-#define PWM_0_FTMCHAN_CH0   0
-#define PWM_0_PORT_CH0      PORTC
-#define PWM_0_PIN_AF_CH0    4
-
-#define PWM_0_PIN_CH1       2
-#define PWM_0_FTMCHAN_CH1   1
-#define PWM_0_PORT_CH1      PORTC
-#define PWM_0_PIN_AF_CH1    4
+#define PWM_0_CH1_GPIO      GPIO_PIN(PORT_C, 2)
+#define PWM_0_CH1_FTMCHAN   1
+#define PWM_0_CH1_AF        4
 
 /* PWM 1 device configuration */
 #define PWM_1_DEV           FTM1
@@ -191,20 +187,15 @@ static const adc_conf_t adc_config[] = {
 #define PWM_1_CLKDIS()      (BITBAND_REG32(SIM->SCGC6, SIM_SCGC6_FTM1_SHIFT) = 0)
 
 /* PWM 1 pin configuration */
-#define PWM_1_PORT_CLKEN()  (BITBAND_REG32(SIM->SCGC5, SIM_SCGC5_PORTA_SHIFT) = 1)
+#define PWM_1_CH0_GPIO      GPIO_PIN(PORT_A, 12)
+#define PWM_1_CH0_FTMCHAN   0
+#define PWM_1_CH0_AF        3
 
-#define PWM_1_PIN_CH0       12
-#define PWM_1_FTMCHAN_CH0   0
-#define PWM_1_PORT_CH0      PORTA
-#define PWM_1_PIN_AF_CH0    3
-
-#define PWM_1_PIN_CH1       13
-#define PWM_1_FTMCHAN_CH1   1
-#define PWM_1_PORT_CH1      PORTA
-#define PWM_1_PIN_AF_CH1    3
+#define PWM_1_CH1_GPIO      GPIO_PIN(PORT_A, 13)
+#define PWM_1_CH1_FTMCHAN   1
+#define PWM_1_CH1_AF        3
 
 /** @} */
-
 
 /**
  * @name SPI configuration

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -149,27 +149,22 @@ static const adc_conf_t adc_config[] = {
 #define PWM_0_CLKEN()       (SIM->SCGC6 |= (SIM_SCGC6_FTM0_MASK))
 #define PWM_0_CLKDIS()      (SIM->SCGC6 &= ~(SIM_SCGC6_FTM0_MASK))
 /* PWM 0 pin configuration */
-#define PWM_0_PORT_CLKEN()  (SIM->SCGC5 |= (SIM_SCGC5_PORTD_MASK | SIM_SCGC5_PORTA_MASK))
 
-#define PWM_0_PIN_CH0       4
-#define PWM_0_FTMCHAN_CH0   1
-#define PWM_0_PORT_CH0      PORTA
-#define PWM_0_PIN_AF_CH0    3
+#define PWM_0_CH0_GPIO      GPIO_PIN(PORT_A, 4)
+#define PWM_0_CH0_FTMCHAN   1
+#define PWM_0_CH0_AF        3
 
-#define PWM_0_PIN_CH1       4
-#define PWM_0_FTMCHAN_CH1   4
-#define PWM_0_PORT_CH1      PORTD
-#define PWM_0_PIN_AF_CH1    4
+#define PWM_0_CH1_GPIO      GPIO_PIN(PORT_D, 4)
+#define PWM_0_CH1_FTMCHAN   4
+#define PWM_0_CH1_AF        4
 
-#define PWM_0_PIN_CH2       6
-#define PWM_0_FTMCHAN_CH2   6
-#define PWM_0_PORT_CH2      PORTD
-#define PWM_0_PIN_AF_CH2    4
+#define PWM_0_CH2_GPIO      GPIO_PIN(PORT_D, 6)
+#define PWM_0_CH2_FTMCHAN   6
+#define PWM_0_CH2_AF        4
 
-#define PWM_0_PIN_CH3       1
-#define PWM_0_FTMCHAN_CH3   1
-#define PWM_0_PORT_CH3      PORTA
-#define PWM_0_PIN_AF_CH3    3
+#define PWM_0_CH3_GPIO      GPIO_PIN(PORT_A, 1)
+#define PWM_0_CH3_FTMCHAN   1
+#define PWM_0_CH3_AF        3
 /** @} */
 
 

--- a/cpu/kinetis_common/periph/pwm.c
+++ b/cpu/kinetis_common/periph/pwm.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin
  * Copyright (C) 2014 PHYTEC Messtechnik GmbH
- * Copyright (C) 2015 Eistec AB
+ * Copyright (C) 2015-2016 Eistec AB
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -35,56 +35,56 @@
 #if PWM_0_EN
 static const uint8_t ftm0chan[] = {
 #if PWM_0_CHANNELS > 0
-    PWM_0_FTMCHAN_CH0,
+    PWM_0_CH0_FTMCHAN,
 #endif
 #if PWM_0_CHANNELS > 1
-    PWM_0_FTMCHAN_CH1,
+    PWM_0_CH1_FTMCHAN,
 #endif
 #if PWM_0_CHANNELS > 2
-    PWM_0_FTMCHAN_CH2,
+    PWM_0_CH2_FTMCHAN,
 #endif
 #if PWM_0_CHANNELS > 3
-    PWM_0_FTMCHAN_CH3,
+    PWM_0_CH3_FTMCHAN,
 #endif
 #if PWM_0_CHANNELS > 4
-    PWM_0_FTMCHAN_CH4,
+    PWM_0_CH4_FTMCHAN,
 #endif
 #if PWM_0_CHANNELS > 5
-    PWM_0_FTMCHAN_CH5,
+    PWM_0_CH5_FTMCHAN,
 #endif
 #if PWM_0_CHANNELS > 6
-    PWM_0_FTMCHAN_CH6,
+    PWM_0_CH6_FTMCHAN,
 #endif
 #if PWM_0_CHANNELS > 7
-    PWM_0_FTMCHAN_CH7,
+    PWM_0_CH7_FTMCHAN,
 #endif
 };
 #endif
 #if PWM_1_EN
 static const uint8_t ftm1chan[] = {
 #if PWM_1_CHANNELS > 0
-    PWM_1_FTMCHAN_CH0,
+    PWM_1_CH0_FTMCHAN,
 #endif
 #if PWM_1_CHANNELS > 1
-    PWM_1_FTMCHAN_CH1,
+    PWM_1_CH1_FTMCHAN,
 #endif
 #if PWM_1_CHANNELS > 2
-    PWM_1_FTMCHAN_CH2,
+    PWM_1_CH2_FTMCHAN,
 #endif
 #if PWM_1_CHANNELS > 3
-    PWM_1_FTMCHAN_CH3,
+    PWM_1_CH3_FTMCHAN,
 #endif
 #if PWM_1_CHANNELS > 4
-    PWM_1_FTMCHAN_CH4,
+    PWM_1_CH4_FTMCHAN,
 #endif
 #if PWM_1_CHANNELS > 5
-    PWM_1_FTMCHAN_CH5,
+    PWM_1_CH5_FTMCHAN,
 #endif
 #if PWM_1_CHANNELS > 6
-    PWM_1_FTMCHAN_CH6,
+    PWM_1_CH6_FTMCHAN,
 #endif
 #if PWM_1_CHANNELS > 7
-    PWM_1_FTMCHAN_CH7,
+    PWM_1_CH7_FTMCHAN,
 #endif
 };
 #endif
@@ -158,60 +158,58 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
 #if PWM_0_EN
 
         case PWM_0:
-            PWM_0_PORT_CLKEN();
             #if PWM_0_CHANNELS > 0
-                PWM_0_PORT_CH0->PCR[PWM_0_PIN_CH0] = PORT_PCR_MUX(PWM_0_PIN_AF_CH0);
+                gpio_init_port(PWM_0_CH0_GPIO, PORT_PCR_MUX(PWM_0_CH0_AF));
             #endif
             #if PWM_0_CHANNELS > 1
-                PWM_0_PORT_CH1->PCR[PWM_0_PIN_CH1] = PORT_PCR_MUX(PWM_0_PIN_AF_CH1);
+                gpio_init_port(PWM_0_CH1_GPIO, PORT_PCR_MUX(PWM_0_CH1_AF));
             #endif
             #if PWM_0_CHANNELS > 2
-                PWM_0_PORT_CH2->PCR[PWM_0_PIN_CH2] = PORT_PCR_MUX(PWM_0_PIN_AF_CH2);
+                gpio_init_port(PWM_0_CH2_GPIO, PORT_PCR_MUX(PWM_0_CH2_AF));
             #endif
             #if PWM_0_CHANNELS > 3
-                PWM_0_PORT_CH3->PCR[PWM_0_PIN_CH3] = PORT_PCR_MUX(PWM_0_PIN_AF_CH3);
+                gpio_init_port(PWM_0_CH3_GPIO, PORT_PCR_MUX(PWM_0_CH3_AF));
             #endif
             #if PWM_0_CHANNELS > 4
-                PWM_0_PORT_CH4->PCR[PWM_0_PIN_CH4] = PORT_PCR_MUX(PWM_0_PIN_AF_CH4);
+                gpio_init_port(PWM_0_CH4_GPIO, PORT_PCR_MUX(PWM_0_CH4_AF));
             #endif
             #if PWM_0_CHANNELS > 5
-                PWM_0_PORT_CH5->PCR[PWM_0_PIN_CH5] = PORT_PCR_MUX(PWM_0_PIN_AF_CH5);
+                gpio_init_port(PWM_0_CH5_GPIO, PORT_PCR_MUX(PWM_0_CH5_AF));
             #endif
             #if PWM_0_CHANNELS > 6
-                PWM_0_PORT_CH6->PCR[PWM_0_PIN_CH6] = PORT_PCR_MUX(PWM_0_PIN_AF_CH6);
+                gpio_init_port(PWM_0_CH6_GPIO, PORT_PCR_MUX(PWM_0_CH6_AF));
             #endif
             #if PWM_0_CHANNELS > 7
-                PWM_0_PORT_CH7->PCR[PWM_0_PIN_CH7] = PORT_PCR_MUX(PWM_0_PIN_AF_CH7);
+                gpio_init_port(PWM_0_CH7_GPIO, PORT_PCR_MUX(PWM_0_CH7_AF));
             #endif
             break;
 #endif
 #if PWM_1_EN
 
         case PWM_1:
-            PWM_1_PORT_CLKEN();
             #if PWM_1_CHANNELS > 0
-                PWM_1_PORT_CH0->PCR[PWM_1_PIN_CH0] = PORT_PCR_MUX(PWM_1_PIN_AF_CH0);
+                gpio_init_port(PWM_1_CH0_GPIO, PORT_PCR_MUX(PWM_1_CH0_AF));
             #endif
             #if PWM_1_CHANNELS > 1
-                PWM_1_PORT_CH1->PCR[PWM_1_PIN_CH1] = PORT_PCR_MUX(PWM_1_PIN_AF_CH1);
+                gpio_init_port(PWM_1_CH1_GPIO, PORT_PCR_MUX(PWM_1_CH1_AF));
             #endif
             #if PWM_1_CHANNELS > 2
-                PWM_1_PORT_CH2->PCR[PWM_1_PIN_CH2] = PORT_PCR_MUX(PWM_1_PIN_AF_CH2);
+                gpio_init_port(PWM_1_CH2_GPIO, PORT_PCR_MUX(PWM_1_CH2_AF));
             #endif
             #if PWM_1_CHANNELS > 3
-                PWM_1_PORT_CH3->PCR[PWM_1_PIN_CH3] = PORT_PCR_MUX(PWM_1_PIN_AF_CH3);
+                gpio_init_port(PWM_1_CH3_GPIO, PORT_PCR_MUX(PWM_1_CH3_AF));
             #endif
             #if PWM_1_CHANNELS > 4
-                PWM_1_PORT_CH4->PCR[PWM_1_PIN_CH4] = PORT_PCR_MUX(PWM_1_PIN_AF_CH4);
+                gpio_init_port(PWM_1_CH4_GPIO, PORT_PCR_MUX(PWM_1_CH4_AF));
             #endif
             #if PWM_1_CHANNELS > 5
-                PWM_1_PORT_CH5->PCR[PWM_1_PIN_CH5] = PORT_PCR_MUX(PWM_1_PIN_AF_CH5);
+                gpio_init_port(PWM_1_CH5_GPIO, PORT_PCR_MUX(PWM_1_CH5_AF));
             #endif
             #if PWM_1_CHANNELS > 6
-                PWM_1_PORT_CH6->PCR[PWM_1_PIN_CH6] = PORT_PCR_MUX(PWM_1_PIN_AF_CH6);
+                gpio_init_port(PWM_1_CH6_GPIO, PORT_PCR_MUX(PWM_1_CH6_AF));
             #endif
             #if PWM_1_CHANNELS > 7
-                PWM_1_PORT_CH7->PCR[PWM_1_PIN_CH7] = PORT_PCR_MUX(PWM_1_PIN_AF_CH7);
+                gpio_init_port(PWM_1_CH7_GPIO, PORT_PCR_MUX(PWM_1_CH7_AF));
             #endif
             break;
 #endif


### PR DESCRIPTION
Updated PWM driver to use gpio_init_port instead of its own pin initialization routine. The periph_conf.h settings are easier to understand now IMO.