### PR TITLE
make: introduce RIOTPKG variable

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -55,6 +55,7 @@ buildtest:
 	        RIOTBASE=$${RIOTBASE} \
 	        RIOTBOARD=$${RIOTBOARD} \
 	        RIOTCPU=$${RIOTCPU} \
+	        RIOTPKG=$${RIOTPKG} \
 	        BINDIRBASE=$${BINDIRBASE} \
 	        RIOTNOLINK=$${RIOTNOLINK} \
 	        RIOT_VERSION=$${RIOT_VERSION} \
@@ -90,6 +91,7 @@ buildtest:
 	    RIOTBASE=$${RIOTBASE} \
 	    RIOTBOARD=$${RIOTBOARD} \
 	    RIOTCPU=$${RIOTCPU} \
+	    RIOTPKG=$${RIOTPKG} \
 	    BINDIRBASE=$${BINDIRBASE} \
 	    RIOTNOLINK=$${RIOTNOLINK} \
 	    RIOT_VERSION=$${RIOT_VERSION} \
@@ -127,6 +129,7 @@ info-buildsizes:
 	    RIOTBASE=$${RIOTBASE} \
 	    RIOTBOARD=$${RIOTBOARD} \
 	    RIOTCPU=$${RIOTCPU} \
+	    RIOTPKG=$${RIOTPKG} \
 	    BINDIRBASE=$${BINDIRBASE} \
 	    $(MAKE) info-buildsize 2>/dev/null | tail -n-1 | cut -f-4)" "$${BOARD}"; \
 	done;
@@ -143,6 +146,7 @@ info-buildsizes-diff:
 	      RIOTBASE=$${RIOTBASE} \
 	      RIOTBOARD=$${RIOTBOARD} \
 	      RIOTCPU=$${RIOTCPU} \
+	      RIOTPKG=$${RIOTPKG} \
 	      BINDIRBASE=$${BINDIRBASE} \
 	      $(MAKE) info-buildsize 2>/dev/null | tail -n-1 | cut -f-4; \
 	  done | \
@@ -176,6 +180,7 @@ info-build:
 	@echo 'RIOTBASE:  $(RIOTBASE)'
 	@echo 'RIOTBOARD: $(RIOTBOARD)'
 	@echo 'RIOTCPU:   $(RIOTCPU)'
+	@echo 'RIOTPKG:   $(RIOTPKG)'
 	@echo ''
 	@echo 'DEFAULT_MODULE: $(sort $(filter-out $(DISABLE_MODULE), $(DEFAULT_MODULE)))'
 	@echo 'DISABLE_MODULE: $(sort $(DISABLE_MODULE))'
@@ -296,5 +301,5 @@ info-files:
 	    echo "$$CPPSRC" | xargs dirname -- | sort | uniq | xargs -I{} find {} -name "Makefile*"; \
 	    echo "$$CPPSRC" | xargs $(CXX) $(CXXFLAGS) $(INCLUDES) -MM 2> /dev/null | grep -o "[^ ]\+\.h"; \
 	  fi; \
-	  $(foreach pkg,$(USEPKG),find $(RIOTBASE)/pkg/$(pkg) -type f;) \
+	  $(foreach pkg,$(USEPKG),find $(RIOTPKG)/$(pkg) -type f;) \
 	) | sort | uniq | sed 's#$(RIOTBASE)/##'

--- a/Makefile.include
+++ b/Makefile.include
@@ -15,6 +15,8 @@ RIOTCPU := $(abspath $(RIOTCPU))
 RIOTBOARD ?= $(RIOTBASE)/boards
 RIOTBOARD := $(abspath $(RIOTBOARD))
 
+RIOTPKG ?= $(RIOTBASE)/pkg
+
 RIOTPROJECT ?= $(shell git rev-parse --show-toplevel 2>/dev/null || pwd)
 RIOTPROJECT := $(abspath $(RIOTPROJECT))
 
@@ -247,33 +249,33 @@ INCLUDES += $(USEMODULE_INCLUDES_:%=-I%)
 
 # The `clean` needs to be serialized before everything else.
 ifneq (, $(filter clean, $(MAKECMDGOALS)))
-    all $(BASELIBS) $(USEPKG:%=$(RIOTBASE)/pkg/%/Makefile.include): clean
+    all $(BASELIBS) $(USEPKG:%=$(RIOTPKG)/%/Makefile.include): clean
 endif
 
 # include Makefile.includes for packages in $(USEPKG)
-$(RIOTBASE)/pkg/%/Makefile.include::
-	$(AD)"$(MAKE)" -C $(RIOTBASE)/pkg/$* Makefile.include
+$(RIOTPKG)/%/Makefile.include::
+	$(AD)"$(MAKE)" -C $(RIOTPKG)/$* Makefile.include
 
-.PHONY: $(USEPKG:%=$(RIOTBASE)/pkg/%/Makefile.include)
--include $(USEPKG:%=$(RIOTBASE)/pkg/%/Makefile.include)
+.PHONY: $(USEPKG:%=$(RIOTPKG)/%/Makefile.include)
+-include $(USEPKG:%=$(RIOTPKG)/%/Makefile.include)
 
 .PHONY: $(USEPKG:%=${BINDIR}%.a)
 $(USEPKG:%=${BINDIR}%.a):
 	@mkdir -p ${BINDIR}
-	"$(MAKE)" -C $(RIOTBASE)/pkg/$(patsubst ${BINDIR}%.a,%,$@)
+	"$(MAKE)" -C $(RIOTPKG)/$(patsubst ${BINDIR}%.a,%,$@)
 
 clean:
-	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTBASE)/pkg/$$i clean ; done
+	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i clean ; done
 	-@rm -rf $(BINDIR)
 	-@rm -rf $(SCANBUILD_OUTPUTDIR)
 
 # Remove intermediates, but keep the .elf, .hex and .map etc.
 clean-intermediates:
-	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTBASE)/pkg/$$i clean ; done
+	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i clean ; done
 	-@rm -rf $(BINDIR)/*.a $(BINDIR)/*/
 
 distclean:
-	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTBASE)/pkg/$$i distclean ; done
+	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i distclean ; done
 	-@rm -rf $(BINDIRBASE)
 
 flash: all

--- a/Makefile.vars
+++ b/Makefile.vars
@@ -16,6 +16,7 @@ export APPDEPS               # Files / Makefile targets that need to be created 
 export RIOTBASE              # The root folder of RIOT. The folder where this very file lives in.
 export RIOTCPU               # For third party CPUs this folder is the base of the CPUs.
 export RIOTBOARD             # For third party BOARDs this folder is the base of the BOARDs.
+export RIOTPKG               # For overriding RIOT's pkg directory
 export RIOTPROJECT           # Top level git root of the project being built, or PWD if not a git repository
 export BINDIRBASE            # This is the folder where the application should be built in. For each BOARD a different subfolder is used.
 export BINDIR                # This is the folder where the application should be built in.

--- a/pkg/ccn-lite/Makefile.include
+++ b/pkg/ccn-lite/Makefile.include
@@ -1,2 +1,2 @@
-INCLUDES += -I$(RIOTBASE)/pkg/ccn-lite -I$(RIOTBASE)/pkg/ccn-lite/ccn-lite/src
+INCLUDES += -I$(RIOTPKG)/ccn-lite -I$(RIOTPKG)/ccn-lite/ccn-lite/src
 INCLUDES += -I$(RIOTBASE)/sys/posix/include

--- a/pkg/cmsis-dsp/Makefile.include
+++ b/pkg/cmsis-dsp/Makefile.include
@@ -1,1 +1,1 @@
-INCLUDES += -I$(RIOTBASE)/pkg/cmsis-dsp/cmsis-dsp/include
+INCLUDES += -I$(RIOTPKG)/cmsis-dsp/cmsis-dsp/include

--- a/pkg/doc.txt
+++ b/pkg/doc.txt
@@ -11,7 +11,7 @@
  *
  * ~~~~~~~~ {.mk}
  * USEPKG += <pkg_name>
- * INCLUDE += $(RIOTBASE)/pkg/<pkg_name>/...
+ * INCLUDE += $(RIOTPKG)/<pkg_name>/...
  * ~~~~~~~~
  *
  * Porting an external library

--- a/pkg/libcoap/Makefile.include
+++ b/pkg/libcoap/Makefile.include
@@ -1,3 +1,3 @@
-INCLUDES += -I$(RIOTBASE)/pkg/libcoap/libcoap \
+INCLUDES += -I$(RIOTPKG)/libcoap/libcoap \
 			-I$(RIOTBASE)/sys/posix/include \
 			-I$(RIOTBASE)/sys/net/include

--- a/pkg/micro-ecc/Makefile.include
+++ b/pkg/micro-ecc/Makefile.include
@@ -1,1 +1,1 @@
-INCLUDES += -I $(RIOTBASE)/pkg/micro-ecc/micro-ecc
+INCLUDES += -I$(RIOTPKG)/micro-ecc/micro-ecc

--- a/pkg/microcoap/Makefile.include
+++ b/pkg/microcoap/Makefile.include
@@ -1,1 +1,1 @@
-INCLUDES += -I$(RIOTBASE)/pkg/microcoap/microcoap
+INCLUDES += -I$(RIOTPKG)/microcoap/microcoap

--- a/pkg/oonf_api/Makefile.include
+++ b/pkg/oonf_api/Makefile.include
@@ -1,1 +1,1 @@
-INCLUDES += -I $(RIOTBASE)/pkg/oonf_api/oonf_api/src-api
+INCLUDES += -I$(RIOTPKG)/oonf_api/oonf_api/src-api

--- a/pkg/relic/Makefile.include
+++ b/pkg/relic/Makefile.include
@@ -1,1 +1,1 @@
-INCLUDES += -I$(RIOTBASE)/pkg/relic/relic/include
+INCLUDES += -I$(RIOTPKG)/relic/relic/include

--- a/pkg/tlsf/Makefile.include
+++ b/pkg/tlsf/Makefile.include
@@ -1,1 +1,1 @@
-INCLUDES += -I$(RIOTBASE)/pkg/tlsf/tlsf
+INCLUDES += -I$(RIOTPKG)/tlsf/tlsf

--- a/pkg/wakaama/Makefile.include
+++ b/pkg/wakaama/Makefile.include
@@ -1,1 +1,1 @@
-INCLUDES += -I$(RIOTBASE)/pkg/wakaama/wakaama
+INCLUDES += -I$(RIOTPKG)/wakaama/wakaama


### PR DESCRIPTION
Workaround for #4962.

This PR changes all references to pkg/ to use the variable RIOTPKG, which defaults to RIOTBASE/pkg.