### PR TITLE
board: msba2: fix msba2-common module name

### DIFF
--- a/boards/avsextrem/Makefile.include
+++ b/boards/avsextrem/Makefile.include
@@ -1,1 +1,3 @@
+USEMODULE += msba2-common
+
 include $(RIOTBOARD)/msba2-common/Makefile.include

--- a/boards/msba2-common/Makefile
+++ b/boards/msba2-common/Makefile
@@ -1,4 +1,4 @@
-MODULE = board
+MODULE = msba2-common
 
 DIRS = drivers
 

--- a/boards/msba2/Makefile.include
+++ b/boards/msba2/Makefile.include
@@ -2,4 +2,6 @@ ifneq (,$(filter gnrc_netif_default,$(USEMODULE)))
 	USEMODULE += cc110x gnrc_netdev2 gnrc_cc110x
 endif
 
+USEMODULE += msba2-common
+
 include $(RIOTBOARD)/msba2-common/Makefile.include

--- a/boards/pttu/Makefile.include
+++ b/boards/pttu/Makefile.include
@@ -1,1 +1,3 @@
+USEMODULE += msba2-common
+
 include $(RIOTBOARD)/msba2-common/Makefile.include


### PR DESCRIPTION
This one tricked me:

In boards/msba2-common, the module name was specified as "board", the same as in pttu avsextrem and msba2.

That caused the resulting archives to clash, but only when compiling with "-j" > a high value.