### PR TITLE
make: buildtest: build with -B

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -61,7 +61,7 @@ buildtest:
 	        WERROR=$${WERROR} \
 	        LTO=$${LTO} \
 	        TOOLCHAIN=$${TOOLCHAIN} \
-	        $(MAKE) -j$(NPROC) 2>&1) ; \
+	        $(MAKE) -j$(NPROC) -B 2>&1) ; \
 	    if [ "$${?}" = "0" ]; then \
 	      ${COLOR_ECHO} "${COLOR_GREEN}success${COLOR_RESET}"; \
 	      if [ -n "$${BUILDTEST_VERBOSE}" ]; then \


### PR DESCRIPTION
```make buildtest``` happily retries failed builds three times, but it compiles without -B. If for some reason an object file got corrupted, make will use that one on every retry, making retries less useful.

This PR adds -B to "make buildtest", causing every file to be recreated.