### PR TITLE
ndp: fix neighbor advertisement byte ordering

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -181,7 +181,7 @@ void gnrc_ndp_nbr_sol_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
             /* see https://tools.ietf.org/html/rfc6775#section-6.5.2 */
             eui64_t iid;
             ieee802154_get_iid(&iid, ar_opt->eui64.uint8, sizeof(eui64_t));
-            ipv6_addr_set_iid(&nbr_adv_dst, iid.uint64.u64);
+            ipv6_addr_set_aiid(&nbr_adv_dst, iid.uint8);
             ipv6_addr_set_link_local_prefix(&nbr_adv_dst);
         }
     }


### PR DESCRIPTION
This was initially reported on the mailing list, and a fix was suggested by @OlegHahm on February 10th. This is just a quick PR so that this does not get lost.

I have been running this on some nodes for a long time now, and it has fixed the problems I was initially seeing where the L2 address of the recipient of the neighbor advertisement was reversed. In the picture, the address should have been fe80::212:6d03:0:1005.

![weird](https://cloud.githubusercontent.com/assets/4234131/13550244/7149f624-e2ce-11e5-8f1f-e8eb339b8d1e.png)
