### PR TITLE
boards: fix board common module names

### DIFF
--- a/boards/msb-430-common/Makefile
+++ b/boards/msb-430-common/Makefile
@@ -1,4 +1,4 @@
-MODULE = board
+MODULE = msb-430-common
 
 DIRS = drivers
 

--- a/boards/msb-430/Makefile.include
+++ b/boards/msb-430/Makefile.include
@@ -1,1 +1,2 @@
+USEMODULE += msb-430-common
 include $(RIOTBOARD)/msb-430-common/Makefile.include

--- a/boards/msb-430h/Makefile.include
+++ b/boards/msb-430h/Makefile.include
@@ -1,1 +1,2 @@
+USEMODULE += msb-430-common
 include $(RIOTBOARD)/msb-430-common/Makefile.include

--- a/boards/qemu-i386/Makefile.include
+++ b/boards/qemu-i386/Makefile.include
@@ -1,4 +1,4 @@
-include $(RIOTBOARD)/x86-multiboot-common/Makefile.include
+USEMODULE += x86-multiboot-common
 
 CFLAGS += -march=i686 -mtune=i686
 
@@ -23,3 +23,5 @@ debug-gdb: debug
 DEBUGGER_FLAGS = "x-terminal-emulator -e gdb -ex 'target remote :1234' --args $(ELFFILE)"
 
 debug:
+
+include $(RIOTBOARD)/x86-multiboot-common/Makefile.include

--- a/boards/wsn430-common/Makefile
+++ b/boards/wsn430-common/Makefile
@@ -1,4 +1,4 @@
-MODULE = board
+MODULE = wsn430-common
 
 DIRS = drivers
 

--- a/boards/wsn430-v1_3b/Makefile.include
+++ b/boards/wsn430-v1_3b/Makefile.include
@@ -1,1 +1,2 @@
+USEMODULE += wsn430-common
 include $(RIOTBOARD)/wsn430-common/Makefile.include

--- a/boards/wsn430-v1_4/Makefile.include
+++ b/boards/wsn430-v1_4/Makefile.include
@@ -1,1 +1,2 @@
+USEMODULE += wsn430-common
 include $(RIOTBOARD)/wsn430-common/Makefile.include

--- a/boards/x86-multiboot-common/Makefile
+++ b/boards/x86-multiboot-common/Makefile
@@ -1,3 +1,3 @@
-MODULE = board
+MODULE = x86-multiboot-common
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/x86-multiboot-common/Makefile.include
+++ b/boards/x86-multiboot-common/Makefile.include
@@ -46,7 +46,7 @@ LINKFLAGS += -m32 -nostdlib -nostdinc -nostartfiles -nodefaultlibs \
              --prefix=$(NEWLIB_BASE) \
              -Wl,-rpath,$(NEWLIB_BASE)/lib \
              -T$(RIOTBASE)/boards/x86-multiboot-common/linker.ld
-UNDEF += $(BINDIR)board/startup.o
+UNDEF += $(BINDIR)x86-multiboot-common/startup.o
 
 BASELIBS += $(NEWLIB_BASE)/lib/libc.a \
             $(NEWLIB_BASE)/lib/libm.a


### PR DESCRIPTION
"Our build system calls "make -C" for every DIRS entry, which contain the modules.
Now, that make call compiles all sources into .o's and then takes all .o's of the module's bindir directory and archives them into module.a.

Now if multiple DIRS define the same module, as long as the "make -C" calls are called sequentially, the second make would just pick up the modules from the first.

If they're called in parallel, the archives might miss some objects.

So unless we fix this, no two DIRS can compile into the same .a."

#4964 but for qemu-i386, msb-430 and wsn-430.