### PR TITLE
cpu/stm32f4/dma: Fix some miscalculations in the DMA implemenation

### DIFF
--- a/cpu/stm32f4/include/periph_cpu.h
+++ b/cpu/stm32f4/include/periph_cpu.h
@@ -184,14 +184,14 @@ static inline void dma_isr_enable(int stream)
     if (stream < 7) {
         NVIC_EnableIRQ((IRQn_Type)((int)DMA1_Stream0_IRQn + stream));
     }
-    else if (stream == 8) {
+    else if (stream == 7) {
         NVIC_EnableIRQ(DMA1_Stream7_IRQn);
     }
-    else if (stream < 14) {
-        NVIC_EnableIRQ((IRQn_Type)((int)DMA2_Stream0_IRQn + stream));
+    else if (stream < 13) {
+        NVIC_EnableIRQ((IRQn_Type)((int)DMA2_Stream0_IRQn + (stream - 8)));
     }
-    else if (stream < 17) {
-        NVIC_EnableIRQ((IRQn_Type)((int)DMA2_Stream5_IRQn + stream));
+    else if (stream < 16) {
+        NVIC_EnableIRQ((IRQn_Type)((int)DMA2_Stream5_IRQn + (stream - 13)));
     }
 }
 


### PR DESCRIPTION
The calculation where some what incorrect. This because the Streams per peripheral run from 0 to 7 :)