### PR TITLE
dist: tools: testrunner: increase default timeout to 10 secs

### DIFF
--- a/dist/tools/testrunner/testrunner.py
+++ b/dist/tools/testrunner/testrunner.py
@@ -10,7 +10,7 @@
 import os, signal, sys, subprocess
 from pexpect import spawnu, TIMEOUT, EOF
 
-def run(testfunc, timeout=5, echo=True):
+def run(testfunc, timeout=10, echo=True):
     env = os.environ.copy()
     child = spawnu("make term", env=env, timeout=timeout)
     if echo:


### PR DESCRIPTION
Five seconds sometimes are not enough for the CI to finish the unittests in time.