### PR TITLE
cpu: cc2538: add missing include to periph_cpu.h

### DIFF
--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -19,6 +19,8 @@
 #ifndef PERIPH_CPU_H_
 #define PERIPH_CPU_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Weird thing is, I can only reproduce with Docker. my arch toolchains build fine.