### PR TITLE
boards: Use separate module name for drivers directory

### DIFF
--- a/boards/avsextrem/Makefile.include
+++ b/boards/avsextrem/Makefile.include
@@ -1,3 +1,4 @@
 USEMODULE += msba2-common
+USEMODULE += avsextrem-drivers
 
 include $(RIOTBOARD)/msba2-common/Makefile.include

--- a/boards/avsextrem/drivers/Makefile
+++ b/boards/avsextrem/drivers/Makefile
@@ -1,4 +1,4 @@
-MODULE = board
+MODULE = avsextrem-drivers
 include $(RIOTBOARD)/$(BOARD)/Makefile.include
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/chronos/Makefile.include
+++ b/boards/chronos/Makefile.include
@@ -8,3 +8,5 @@ export FLASHER = mspdebug
 export FFLAGS = rf2500 "prog $(HEXFILE)"
 
 INCLUDES += -I$(RIOTBOARD)/$(BOARD)/drivers/include
+
+USEMODULE += chronos-drivers

--- a/boards/chronos/drivers/Makefile
+++ b/boards/chronos/drivers/Makefile
@@ -1,3 +1,3 @@
-MODULE = board
+MODULE = chronos-drivers
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/msb-430-common/Makefile.include
+++ b/boards/msb-430-common/Makefile.include
@@ -27,3 +27,5 @@ export DEBUGGER_FLAGS = --tui --ex="target remote localhost:2000" --ex "monitor 
 # export msb-430-common includes
 export INCLUDES += -I$(RIOTBOARD)/msb-430-common/include
 export INCLUDES += -I$(RIOTBOARD)/msb-430-common/drivers/include
+
+USEMODULE += msb-430-common-drivers

--- a/boards/msb-430-common/drivers/Makefile
+++ b/boards/msb-430-common/drivers/Makefile
@@ -1,4 +1,4 @@
-MODULE = board
+MODULE = msb-430-common-drivers
 
 include $(RIOTBOARD)/$(BOARD)/Makefile.include
 

--- a/boards/msba2-common/Makefile.include
+++ b/boards/msba2-common/Makefile.include
@@ -45,3 +45,5 @@ export INCLUDES += -I$(RIOTBOARD)/msba2-common/include -I$(RIOTBOARD)/msba2-comm
 export OFLAGS = -O ihex
 
 export UNDEF += $(BINDIR)cpu/startup.o
+
+USEMODULE += msba2-common-drivers

--- a/boards/msba2-common/drivers/Makefile
+++ b/boards/msba2-common/drivers/Makefile
@@ -1,4 +1,4 @@
-MODULE = board
+MODULE = msba2-common-drivers
 include $(RIOTBOARD)/$(BOARD)/Makefile.include
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -8,6 +8,8 @@ export NATIVEINCLUDES += -I$(RIOTBASE)/drivers/include/
 export CPU = native
 export ELF = $(BINDIR)$(APPLICATION).elf
 
+USEMODULE += native-drivers
+
 # toolchain:
 export PREFIX =
 export CC ?= $(PREFIX)gcc

--- a/boards/native/drivers/Makefile
+++ b/boards/native/drivers/Makefile
@@ -1,4 +1,4 @@
-MODULE = board
+MODULE = native-drivers
 
 include $(RIOTBASE)/Makefile.base
 

--- a/boards/wsn430-common/Makefile.include
+++ b/boards/wsn430-common/Makefile.include
@@ -15,3 +15,5 @@ export FFLAGS = -d $(PORT) -j uif "prog $(HEXFILE)"
 
 # include wsn430-common includes
 export INCLUDES += -I$(RIOTBOARD)/wsn430-common/include
+
+USEMODULE += wsn430-common-drivers

--- a/boards/wsn430-common/drivers/Makefile
+++ b/boards/wsn430-common/drivers/Makefile
@@ -1,4 +1,4 @@
-MODULE = board
+MODULE = wsn430-common-drivers
 
 include $(RIOTBOARD)/$(BOARD)/Makefile.include
 


### PR DESCRIPTION
Same as #4970 #4797 #4964 but for other directories.

Eliminates a race condition between multiple archives with the same filename. See the other PRs for a longer description.