### PR TITLE
at86rf2xx: at86rf2xx_get_random to at86rf2xx_internal for supporting boards

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -211,6 +211,25 @@ void at86rf2xx_configure_phy(at86rf2xx_t *dev)
     at86rf2xx_set_state(dev, state);
 }
 
+#if defined(MODULE_AT86RF233) || defined(MODULE_AT86RF231)
+void at86rf2xx_get_random(at86rf2xx_t *dev, uint8_t *data, const size_t len)
+{
+    for (size_t byteCount = 0; byteCount < len; ++byteCount) {
+        uint8_t rnd = 0;
+        for (uint8_t i = 0; i < 4; ++i) {
+            /* bit 5 and 6 of the AT86RF2XX_REG__PHY_RSSI register contain the RND_VALUE */
+            uint8_t regVal = at86rf2xx_reg_read(dev, AT86RF2XX_REG__PHY_RSSI)
+                             & AT86RF2XX_PHY_RSSI_MASK__RND_VALUE;
+            /* shift the two random bits first to the right and then to the correct position of the return byte */
+            regVal = regVal >> 5;
+            regVal = regVal << 2 * i;
+            rnd |= regVal;
+        }
+        data[byteCount] = rnd;
+    }
+}
+#endif
+
 void at86rf2xx_force_trx_off(const at86rf2xx_t *dev)
 {
     at86rf2xx_reg_write(dev,

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -163,6 +163,16 @@ void at86rf2xx_hardware_reset(at86rf2xx_t *dev);
  */
 void at86rf2xx_configure_phy(at86rf2xx_t *dev);
 
+#if defined MODULE_AT86RF233 || defined MODULE_AT86RF231
+/**
+ * @brief   Read random data from the RNG
+ *
+ * @param[in] dev       device to configure
+ * @param[out] data     buffer to copy the random data to
+ * @param[in]  len      number of random bytes to store in data
+ */
+void at86rf2xx_get_random(at86rf2xx_t *dev, uint8_t *data, const size_t len);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
As requested by @haukepetersen  and @authmillenon  in #4925, I extracted part of my hwrng patch.
This commit only implements a function which extracts a number of random bytes at the at86rf2xx_internal level.

It is currently activated only for at86rf233 boards, since I do not know if other chips from the at86rf2xx family have the same rng capabilities.