### PR TITLE
ci: split up cortex_m4 in even more groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
         - NPROC_MAX=8
     matrix:
         - BUILDTEST_MCU_GROUP=static-tests
+        - BUILDTEST_MCU_GROUP=cortex_m4_3
         - BUILDTEST_MCU_GROUP=cortex_m4_2
         - BUILDTEST_MCU_GROUP=cortex_m4_1
         - BUILDTEST_MCU_GROUP=cortex_m0_2

--- a/boards/nrf52dk/Makefile.features
+++ b/boards/nrf52dk/Makefile.features
@@ -10,4 +10,4 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
+FEATURES_MCU_GROUP = cortex_m4_3

--- a/boards/nucleo-f401/Makefile.features
+++ b/boards/nucleo-f401/Makefile.features
@@ -10,4 +10,4 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_2
+FEATURES_MCU_GROUP = cortex_m4_3

--- a/boards/pba-d-01-kw2x/Makefile.features
+++ b/boards/pba-d-01-kw2x/Makefile.features
@@ -14,4 +14,4 @@ FEATURES_PROVIDED += periph_uart
 # Various other features (if any)
 
 # The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_1
+FEATURES_MCU_GROUP = cortex_m4_3

--- a/boards/stm32f3discovery/Makefile.features
+++ b/boards/stm32f3discovery/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m4_1
+FEATURES_MCU_GROUP = cortex_m4_3

--- a/dist/tools/drone-scripts/build_and_test.sh
+++ b/dist/tools/drone-scripts/build_and_test.sh
@@ -67,7 +67,7 @@ if $FULL_CHECK; then
     parallel -k exec_build_func {} "$@"  ::: static-tests avr8 msp430 x86 arm7 \
                                              cortex_m0_2 cortex_m0_1 \
                                              cortex_m3_1 cortex_m3_2 \
-                                             cortex_m4_1 cortex_m4_2 \
+                                             cortex_m4_1 cortex_m4_2 cortex_m4_3 \
     |& tee -a "$MYTMPDIR/output.log"
 else
     echo "PR not ready for CI build. Only static-tests will be executed!"

--- a/dist/tools/travis-scripts/get-pkg-list.py
+++ b/dist/tools/travis-scripts/get-pkg-list.py
@@ -21,7 +21,7 @@
 import os
 
 arm_mcu_groups = ["arm7", "cortex_m0_2", "cortex_m0_1", "cortex_m3_1",
-                  "cortex_m3_2", "cortex_m4_1", "cortex_m4_2"]
+                  "cortex_m3_2", "cortex_m4_1", "cortex_m4_2", "cortex_m4_3"]
 msp_mcu_groups = ["msp430"]
 x86_mcu_groups = ["x86"]
 avr8_mcu_groups = ["avr8"]


### PR DESCRIPTION
https://github.com/RIOT-OS/RIOT/pull/4655 is constantly failing because of timeouts for `cortex_m4_2` CI group.