### PR TITLE
ndp: change rtr adv src to link local

### DIFF
--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -509,9 +509,10 @@ ipv6_addr_t *gnrc_ipv6_netif_match_prefix(kernel_pid_t pid, const ipv6_addr_t *p
  * @brief   Searches for the best address on an interface usable as a
  *          source address for a given destination address.
  *
- * @param[in] pid   The PID to the interface.
- * @param[in] dest  The destination address you want to find a destination
- *                  address for.
+ * @param[in] pid     The PID to the interface.
+ * @param[in] dest    The destination address you want to find a destination
+ *                    address for.
+ * @param[in] ll_only If only link local addresses qualify
  *
  * @todo Rule 4 from RFC 6724 is currently not implemented. Has to updated as
  *       soon as gnrc supports Mobile IP.
@@ -526,7 +527,7 @@ ipv6_addr_t *gnrc_ipv6_netif_match_prefix(kernel_pid_t pid, const ipv6_addr_t *p
  * @return  NULL, if no matching address can be found on the interface.
  * @return  NULL, if @p pid is no interface.
  */
-ipv6_addr_t *gnrc_ipv6_netif_find_best_src_addr(kernel_pid_t pid, const ipv6_addr_t *dest);
+ipv6_addr_t *gnrc_ipv6_netif_find_best_src_addr(kernel_pid_t pid, const ipv6_addr_t *dest, bool ll_only);
 
 /**
  * @brief   Get interface specific meta-information on an address

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -372,7 +372,7 @@ static int _fill_ipv6_hdr(kernel_pid_t iface, gnrc_pktsnip_t *ipv6,
             ipv6_addr_set_loopback(&hdr->src);
         }
         else {
-            ipv6_addr_t *src = gnrc_ipv6_netif_find_best_src_addr(iface, &hdr->dst);
+            ipv6_addr_t *src = gnrc_ipv6_netif_find_best_src_addr(iface, &hdr->dst, false);
 
             if (src != NULL) {
                 DEBUG("ipv6: set packet source to %s\n",

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -549,7 +549,7 @@ kernel_pid_t gnrc_ipv6_netif_find_by_prefix(ipv6_addr_t **out, const ipv6_addr_t
  *      runtime of this function
  */
 static int _create_candidate_set(gnrc_ipv6_netif_t *iface, const ipv6_addr_t *dst,
-                                 uint8_t *candidate_set)
+                                 uint8_t *candidate_set, bool link_local_only)
 {
     int res = -1;
 
@@ -571,6 +571,11 @@ static int _create_candidate_set(gnrc_ipv6_netif_t *iface, const ipv6_addr_t *ds
          */
         if (ipv6_addr_is_multicast(&(iter->addr)) ||
             ipv6_addr_is_unspecified(&(iter->addr))) {
+            continue;
+        }
+
+        /* Check if we only want link local addresses */
+        if (link_local_only && !ipv6_addr_is_link_local(&(iter->addr))) {
             continue;
         }
 
@@ -760,7 +765,7 @@ static ipv6_addr_t *_source_address_selection(gnrc_ipv6_netif_t *iface, const ip
     return res;
 }
 
-ipv6_addr_t *gnrc_ipv6_netif_find_best_src_addr(kernel_pid_t pid, const ipv6_addr_t *dst)
+ipv6_addr_t *gnrc_ipv6_netif_find_best_src_addr(kernel_pid_t pid, const ipv6_addr_t *dst, bool ll_only)
 {
     gnrc_ipv6_netif_t *iface = gnrc_ipv6_netif_get(pid);
     ipv6_addr_t *best_src = NULL;
@@ -768,7 +773,7 @@ ipv6_addr_t *gnrc_ipv6_netif_find_best_src_addr(kernel_pid_t pid, const ipv6_add
     BITFIELD(candidate_set, GNRC_IPV6_NETIF_ADDR_NUMOF);
     memset(candidate_set, 0, sizeof(candidate_set));
 
-    int first_candidate = _create_candidate_set(iface, dst, candidate_set);
+    int first_candidate = _create_candidate_set(iface, dst, candidate_set, ll_only);
     if (first_candidate >= 0) {
         best_src = _source_address_selection(iface, dst, candidate_set);
         if (best_src == NULL) {

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -246,7 +246,7 @@ void gnrc_ndp_internal_send_nbr_sol(kernel_pid_t iface, ipv6_addr_t *src, ipv6_a
 
     /* check if there is a fitting source address to target */
     if (src == NULL) {
-        src = gnrc_ipv6_netif_find_best_src_addr(iface, tgt);
+        src = gnrc_ipv6_netif_find_best_src_addr(iface, tgt, false);
     }
     if (src != NULL) {
         l2src_len = _get_l2src(iface, l2src, sizeof(l2src));
@@ -315,7 +315,7 @@ void gnrc_ndp_internal_send_rtr_sol(kernel_pid_t iface, ipv6_addr_t *dst)
         dst = (ipv6_addr_t *)&ipv6_addr_all_routers_link_local;
     }
     /* check if there is a fitting source address to target */
-    if ((src = gnrc_ipv6_netif_find_best_src_addr(iface, dst)) != NULL) {
+    if ((src = gnrc_ipv6_netif_find_best_src_addr(iface, dst, false)) != NULL) {
         uint8_t l2src[8];
         size_t l2src_len;
         l2src_len = _get_l2src(iface, l2src, sizeof(l2src));
@@ -522,8 +522,9 @@ void gnrc_ndp_internal_send_rtr_adv(kernel_pid_t iface, ipv6_addr_t *src, ipv6_a
     }
     if (src == NULL) {
         mutex_unlock(&ipv6_iface->mutex);
-        /* get address from source selection algorithm */
-        src = gnrc_ipv6_netif_find_best_src_addr(iface, dst);
+        /* get address from source selection algorithm.
+         * Only link local addresses may be used (RFC 4861 section 4.1) */
+        src = gnrc_ipv6_netif_find_best_src_addr(iface, dst, true);
         mutex_lock(&ipv6_iface->mutex);
     }
     /* add SL2A for source address */

--- a/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
+++ b/tests/unittests/tests-ipv6_netif/tests-ipv6_netif.c
@@ -418,7 +418,7 @@ static void test_ipv6_netif_find_best_src_addr__no_unicast(void)
     TEST_ASSERT_NOT_NULL(gnrc_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &mc_addr2,
                                                   DEFAULT_TEST_PREFIX_LEN, 0));
 
-    TEST_ASSERT_NULL(gnrc_ipv6_netif_find_best_src_addr(DEFAULT_TEST_NETIF, &ll_dst_addr));
+    TEST_ASSERT_NULL(gnrc_ipv6_netif_find_best_src_addr(DEFAULT_TEST_NETIF, &ll_dst_addr, false));
 }
 
 static void test_ipv6_netif_find_best_src_addr__success(void)
@@ -441,7 +441,7 @@ static void test_ipv6_netif_find_best_src_addr__success(void)
     TEST_ASSERT_NOT_NULL(gnrc_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &ll_addr1,
                                                   DEFAULT_TEST_PREFIX_LEN, 0));
 
-    TEST_ASSERT_NOT_NULL((out = gnrc_ipv6_netif_find_best_src_addr(DEFAULT_TEST_NETIF, &ll_addr2)));
+    TEST_ASSERT_NOT_NULL((out = gnrc_ipv6_netif_find_best_src_addr(DEFAULT_TEST_NETIF, &ll_addr2, false)));
     TEST_ASSERT(out != &ll_addr1);
     TEST_ASSERT(out != &ll_addr2);
     TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(out, &ll_addr1));
@@ -455,7 +455,7 @@ static void test_ipv6_netif_find_best_src_addr__multicast_input(void)
     /* Adds DEFAULT_TEST_NETIF as interface and to it fe80::1, fe80::2 and ff02::1 */
     test_ipv6_netif_find_best_src_addr__success();
 
-    TEST_ASSERT_NOT_NULL((out = gnrc_ipv6_netif_find_best_src_addr(DEFAULT_TEST_NETIF, &mc_addr)));
+    TEST_ASSERT_NOT_NULL((out = gnrc_ipv6_netif_find_best_src_addr(DEFAULT_TEST_NETIF, &mc_addr, false)));
     TEST_ASSERT_EQUAL_INT(false, ipv6_addr_equal(&mc_addr, out));
     TEST_ASSERT_EQUAL_INT(false, ipv6_addr_is_unspecified(out));
 }
@@ -471,7 +471,7 @@ static void test_ipv6_netif_find_best_src_addr__other_subnet(void)
     TEST_ASSERT_NOT_NULL(gnrc_ipv6_netif_add_addr(DEFAULT_TEST_NETIF, &addr1, DEFAULT_TEST_PREFIX_LEN,
                          0));
 
-    TEST_ASSERT_NOT_NULL((out = gnrc_ipv6_netif_find_best_src_addr(DEFAULT_TEST_NETIF, &addr2)));
+    TEST_ASSERT_NOT_NULL((out = gnrc_ipv6_netif_find_best_src_addr(DEFAULT_TEST_NETIF, &addr2, false)));
     TEST_ASSERT(out != &addr1);
     TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(out, &addr1));
 }


### PR DESCRIPTION
As reported in #5005, sometimes router advertisements are sent with global addresses. This is a WIP example fix, put here as a request for comments from people more familiar with the code base.

I am running some tests now to verify it fixes the problems described in the issue.