### PR TITLE
ndp: fix stub parameters

### DIFF
--- a/sys/include/net/gnrc/ndp/internal.h
+++ b/sys/include/net/gnrc/ndp/internal.h
@@ -123,7 +123,7 @@ void gnrc_ndp_internal_send_rtr_adv(kernel_pid_t iface, ipv6_addr_t *src,
  * This macro is primarily an optimization to not go into the function defined
  * above.
  */
-#define gnrc_ndp_internal_send_rtr_adv(iface, dst, fin)
+#define gnrc_ndp_internal_send_rtr_adv(iface, src, dst, fin)
 #endif
 
 /**


### PR DESCRIPTION
Came across this while in this part of the code. Pretty sure the noop stub ought to have the same number of parameters?
