### PR TITLE
examples/gnrc_border_router: Build with RPL support by default

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -38,6 +38,7 @@ USEMODULE += gnrc_sixlowpan_border_router_default
 USEMODULE += fib
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
+USEMODULE += gnrc_rpl
 # Add also the shell, some shell commands
 USEMODULE += shell
 USEMODULE += shell_commands


### PR DESCRIPTION
I think it makes sense to have RPL enabled by default on the border router example.