### PR TITLE
gnrc: Set address valid lifetime to UINT32_MAX for border router scenario

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -106,7 +106,7 @@ static ipv6_addr_t *_add_addr_to_entry(gnrc_ipv6_netif_t *entry, const ipv6_addr
     else {
         if (!ipv6_addr_is_link_local(addr)) {
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER
-            tmp_addr->valid = 0xFFFF;
+            tmp_addr->valid = UINT32_MAX;
             gnrc_sixlowpan_nd_router_abr_t *abr = gnrc_sixlowpan_nd_router_abr_get();
             mutex_unlock(&entry->mutex);
             gnrc_ipv6_netif_set_rtr_adv(entry, true);


### PR DESCRIPTION
http://riot-os.org/api/structgnrc__ipv6__netif__addr__t.html#a54a9cd73d1bb5dfa39b7d79de51bd46a

>If it is UINT32_MAX the lifetime is infinite.
Definition at line 251 of file ipv6/netif.h.

I think the original intention of the 0xFFFF literal was to make it permanent on border router configurations.