### PR TITLE
make: buildtest: fix parallel builds

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -38,7 +38,6 @@ buildtest:
 	@ \
 	BUILDTESTOK=true; \
 	APP_RETRY=0; \
-	rm -rf "$$BINDIRBASE"; \
 	for BOARD in $$($(MAKE) -s info-boards-supported); do \
 	  RIOTNOLINK=$$(echo $(BOARD_INSUFFICIENT_MEMORY) | grep $${BOARD} 2>&1 >/dev/null && echo 1); \
 	  ${COLOR_ECHO} -n "Building for $${BOARD} "; \
@@ -63,7 +62,7 @@ buildtest:
 	        WERROR=$${WERROR} \
 	        LTO=$${LTO} \
 	        TOOLCHAIN=$${TOOLCHAIN} \
-	        $(MAKE) -j$(NPROC) -B 2>&1) ; \
+	        $(MAKE) -j$(NPROC) clean all 2>&1) ; \
 	    if [ "$${?}" = "0" ]; then \
 	      ${COLOR_ECHO} "${COLOR_GREEN}success${COLOR_RESET}"; \
 	      if [ -n "$${BUILDTEST_VERBOSE}" ]; then \

--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -45,11 +45,12 @@ buildtest:
 	  [ -n "$${RIOTNOLINK}" ] && ${COLOR_ECHO} -n "(no linking) "; \
 	  for NTH_TRY in 1 2 3; do \
 	    ${COLOR_ECHO} -n ".. "; \
+	    if [ "$$NTH_TRY" != "3" ]; then export _CCACHE=$$CCACHE; else export _CCACHE=""; fi ; \
 	    LOG=$$(env -i \
 	        HOME=$${HOME} \
 	        PATH=$${PATH} \
 	        BOARD=$${BOARD} \
-	        CCACHE=$${CCACHE} \
+	        CCACHE=$${_CCACHE} \
 	        $${CCACHE_DIR:+CCACHE_DIR=$${CCACHE_DIR}} \
 	        CCACHE_BASEDIR=$${CCACHE_BASEDIR} \
 	        RIOTBASE=$${RIOTBASE} \

--- a/pkg/micro-ecc/Makefile
+++ b/pkg/micro-ecc/Makefile
@@ -1,6 +1,8 @@
 PKG_NAME=micro-ecc
 PKG_URL=https://github.com/kmackay/micro-ecc.git
 PKG_VERSION=f3d46f0fb77b42535168a17b4b51802beb124a32
+PKG_DIR=$(CURDIR)
+PKG_BUILDDIR=$(BINDIR)/pkg/$(PKG_NAME)
 
 ifneq ($(RIOTBOARD),)
 include $(RIOTBOARD)/$(BOARD)/Makefile.include
@@ -16,28 +18,26 @@ MODULE:=$(shell basename $(CURDIR))
 .PHONY: all clean patch reset
 
 all: patch
-	make -C $(CURDIR)/$(PKG_NAME)
+	make -C $(PKG_BUILDDIR)
 	make $(BINDIR)$(MODULE).a
 
-patch: $(CURDIR)/$(PKG_NAME)/Makefile
+patch: $(PKG_BUILDDIR)/Makefile
 
-$(CURDIR)/$(PKG_NAME)/Makefile: $(CURDIR)/$(PKG_NAME)
-	$(foreach patch,$(shell ls [0-9][0-9][0-9][0-9]*.patch),cd "$<" && git am "../$(patch)" || { git am --abort; exit 1; };)
-	touch $(CURDIR)/$(PKG_NAME)/Makefile
+$(PKG_BUILDDIR)/Makefile: $(PKG_BUILDDIR)
+	cd $(PKG_BUILDDIR) && \
+	    for patch in $(PKG_DIR)/[0-9][0-9][0-9][0-9]*.patch; do git am "$${patch}" || { git am --abort; exit 1; }; done
+	touch $(PKG_BUILDDIR)/Makefile
 
-$(CURDIR)/$(PKG_NAME):
-	test -d $(PKG_NAME) || \
+$(PKG_BUILDDIR):
+	mkdir -p $(BINDIR)/pkg && \
 	git clone $(PKG_URL) $@ && \
 		cd $@ && git reset --hard $(PKG_VERSION)
 
 clean::
-	# Reset package to checkout state.
-	cd $(CURDIR)/$(PKG_NAME) || true && \
-		git clean -x -f && \
-		git reset --hard $(PKG_VERSION)
+	rm -Rf $(PKG_BUILDDIR)
 
 distclean::
-	rm -rf $(CURDIR)/$(PKG_NAME)
+	rm -rf $(PKG_BUILDDIR)
 
 #$(BINDIR)$(MODULE).a: $(BINDIR)micro-ecc_*.a
 #	mkdir -p $(BINDIR)$(MODULE); cd $(BINDIR)$(MODULE); for var in $?; do ar -x $$var; done; ar -r -c -s $(BINDIR)$(MODULE).a *.o

--- a/pkg/micro-ecc/Makefile.include
+++ b/pkg/micro-ecc/Makefile.include
@@ -1,1 +1,1 @@
-INCLUDES += -I$(RIOTPKG)/micro-ecc/micro-ecc
+INCLUDES += -I$(BINDIR)/pkg/micro-ecc


### PR DESCRIPTION
~~(CI test PR, please ignore)~~

I think I found the last parallel build errors.

This PR contains three commits:

cc96de02 makes "make buildtest" skip ccache on the first retry. Not sure it's needed.

91cec4c7 stops "make buildtest" from doing "rmdir $BINDIRBASE", which breaks parallel buildtest runs in the same source checkout

069bbcec make the micro-ecc package build within $BINDIR/pkg/micro-ecc. There was a race before which also broke parallel buildtests in the same source checkout

