### PR TITLE
fib: flush entries

### DIFF
--- a/sys/include/net/fib.h
+++ b/sys/include/net/fib.h
@@ -160,6 +160,17 @@ int fib_update_entry(fib_table_t *table, uint8_t *dst, size_t dst_size,
 void fib_remove_entry(fib_table_t *table, uint8_t *dst, size_t dst_size);
 
 /**
+ * @brief removes all entries from the corresponding FIB table and interface combination
+ *
+ * @note if interface is KERNEL_PID_UNDEF, then all entries regardless of the interface
+ *       will be removed.
+ *
+ * @param[in] table         the fib table to flush
+ * @param[in] interface     entries associated with this interface will be removed
+ */
+void fib_flush(fib_table_t *table, kernel_pid_t interface);
+
+/**
  * @brief provides a next hop for a given destination
  *
  * @param[in] table               the fib table that should be searched

--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -451,6 +451,21 @@ void fib_remove_entry(fib_table_t *table, uint8_t *dst, size_t dst_size)
     mutex_unlock(&(table->mtx_access));
 }
 
+void fib_flush(fib_table_t *table, kernel_pid_t interface)
+{
+    mutex_lock(&(table->mtx_access));
+    DEBUG("[fib_flush]\n");
+
+    for (size_t i = 0; i < table->size; ++i) {
+        if ((interface == KERNEL_PID_UNDEF) ||
+            (interface == table->data.entries[i].iface_id)) {
+            fib_remove(&table->data.entries[i]);
+        }
+    }
+
+    mutex_unlock(&(table->mtx_access));
+}
+
 int fib_get_next_hop(fib_table_t *table, kernel_pid_t *iface_id,
                      uint8_t *next_hop, size_t *next_hop_size,
                      uint32_t *next_hop_flags, uint8_t *dst, size_t dst_size,


### PR DESCRIPTION
This PR introduces a function to flush either all entries from the FIB, or just those that belong to a certain interface. Furthermore, I added a shell command for that.

Rationale:
Playing around with RPL on large networks can accumulate a lot of addresses in the FIB near to the root. For testing purposes I sometimes delete some or all entries in the fib. This shell command is super handy for that.
Otherwise, I would need to call `fibroute del` > 20 times and rebooting is not an option.

Can be used as follows: 
`fibroute flush` to flush all entries. `fibroute flush x` to delete all entries that are associated with interface `x`