### PR TITLE
gnrc_rpl: do not use PRIu8/PRIi8

### DIFF
--- a/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
+++ b/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
@@ -41,7 +41,7 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
     uint8_t *addr_vec = (uint8_t *) (rh + 1);
     bool found = false;
 
-    DEBUG("RPL SRH: %" PRIu8 " addresses in the routing header\n", n);
+    DEBUG("RPL SRH: %u addresses in the routing header\n", (unsigned) n);
 
     if (rh->seg_left > n) {
         DEBUG("RPL SRH: number of segments left > number of addresses - discard\n");

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -202,12 +202,12 @@ int _gnrc_rpl_dodag_show(void)
 
         cleanup = dodag->instance->cleanup < 0 ? 0 : dodag->instance->cleanup;
 
-        printf("\tdodag [%s | R: %d | OP: %s | PIO: %s | CL: %" PRIi8 "s | "
+        printf("\tdodag [%s | R: %d | OP: %s | PIO: %s | CL: %ds | "
                "TR(I=[%d,%d], k=%d, c=%d, TC=%" PRIu32 "s, TI=%" PRIu32 "s)]\n",
                ipv6_addr_to_str(addr_str, &dodag->dodag_id, sizeof(addr_str)),
                dodag->my_rank, (dodag->node_status == GNRC_RPL_LEAF_NODE ? "Leaf" : "Router"),
                ((dodag->req_opts & GNRC_RPL_REQ_OPT_PREFIX_INFO) ? "on" : "off"),
-               cleanup, (1 << dodag->dio_min), dodag->dio_interval_doubl, dodag->trickle.k,
+               (int) cleanup, (1 << dodag->dio_min), dodag->dio_interval_doubl, dodag->trickle.k,
                dodag->trickle.c, (uint32_t) (tc & 0xFFFFFFFF), (uint32_t) (ti & 0xFFFFFFFF));
 
         gnrc_rpl_parent_t *parent;


### PR DESCRIPTION
nano.specs does not support it and prints the format specifiers instead of the proper value.
Can be tested on any cortex based platform. E.g. flash the `gnrc_networking` example on an `iotlab-m3` or `samr21-xpro` board and fire up RPL. Take a look at the `CL: ` value. It should not print `hs`, but an actual value with this PR.