### PR TITLE
sys/uart_stdio: Move macro definitions to header file, rename STDIO -> UART_STDIO_DEV

### DIFF
--- a/boards/arduino-mega2560/include/board.h
+++ b/boards/arduino-mega2560/include/board.h
@@ -32,7 +32,7 @@ extern "C" {
 * @brief As the CPU is too slow to handle 115200 baud, we set the default
 *        baudrate to 9600 for this board
 */
-#define STDIO_BAUDRATE      (9600U)
+#define UART_STDIO_BAUDRATE (9600U)
 
 /**
  * @name LED pin definitions

--- a/boards/iotlab-m3/include/board.h
+++ b/boards/iotlab-m3/include/board.h
@@ -37,8 +37,8 @@ extern "C" {
  * @name Set the default baudrate to 500K for this board
  * @{
  */
-#ifndef STDIO_BAUDRATE
-#   define STDIO_BAUDRATE   (500000U)
+#ifndef UART_STDIO_BAUDRATE
+#   define UART_STDIO_BAUDRATE (500000U)
 #endif
 /** @} */
 

--- a/boards/msb-430-common/board_init.c
+++ b/boards/msb-430-common/board_init.c
@@ -203,6 +203,6 @@ void board_init(void)
 
     msp430_set_cpu_speed(CLOCK_CORECLOCK);
 
-    /* finally initialize the STDIO */
+    /* finally initialize STDIO over UART */
     uart_stdio_init();
 }

--- a/boards/nucleo-f103/include/board.h
+++ b/boards/nucleo-f103/include/board.h
@@ -33,7 +33,7 @@ extern "C" {
 /**
  * @brief Use the 2nd UART for STDIO on this board
  */
-#define STDIO               UART_DEV(1)
+#define UART_STDIO_DEV      UART_DEV(1)
 
 /**
  * @name xtimer configuration

--- a/boards/telosb/board.c
+++ b/boards/telosb/board.c
@@ -122,7 +122,7 @@ void board_init(void)
     telosb_ports_init();
     msp430_init_dco();
 
-    /* initialize the STDIO */
+    /* initialize STDIO over UART */
     uart_stdio_init();
 
     /* enable interrupts */

--- a/boards/wsn430-common/board_init.c
+++ b/boards/wsn430-common/board_init.c
@@ -111,6 +111,6 @@ void board_init(void)
 
     msp430_set_cpu_speed(MCLK_8MHZ_SCLK_8MHZ);
 
-    /* initialize the STDIO */
+    /* initialize STDIO over UART */
     uart_stdio_init();
 }

--- a/boards/z1/board.c
+++ b/boards/z1/board.c
@@ -215,7 +215,7 @@ void board_init(void)
     /* initializes DCO */
     msp430_init_dco();
 
-    /* initialize STDIO */
+    /* initialize STDIO over UART */
     uart_stdio_init();
 
     /* enable interrupts */

--- a/boards/z1/include/board.h
+++ b/boards/z1/include/board.h
@@ -54,9 +54,9 @@ extern "C" {
  * @brief   Standard input/output device configuration
  * @{
  */
-#define STDIO                       (0)
-#define STDIO_BAUDRATE              (115200U)
-#define STDIO_RX_BUFSIZE            (64U)
+#define UART_STDIO_DEV              (UART_DEV(0))
+#define UART_STDIO_BAUDRATE         (115200U)
+#define UART_STDIO_RX_BUFSIZE       (64U)
 /** @} */
 
 /*  MSP430 core */

--- a/drivers/include/ethos.h
+++ b/drivers/include/ethos.h
@@ -31,14 +31,14 @@
 extern "C" {
 #endif
 
-/* if using ethos + stdio, use STDIO values unless overridden */
+/* if using ethos + stdio, use UART_STDIO values unless overridden */
 #ifdef USE_ETHOS_FOR_STDIO
-#include "board.h"
+#include "uart_stdio.h"
 #ifndef ETHOS_UART
-#define ETHOS_UART  STDIO
+#define ETHOS_UART     UART_STDIO_DEV
 #endif
 #ifndef ETHOS_BAUDRATE
-#define ETHOS_BAUDRATE STDIO_BAUDRATE
+#define ETHOS_BAUDRATE UART_STDIO_BAUDRATE
 #endif
 #endif
 

--- a/sys/include/uart_stdio.h
+++ b/sys/include/uart_stdio.h
@@ -20,8 +20,32 @@
 #ifndef UART_STDIO_H
 #define UART_STDIO_H
 
+/* Boards may override the default STDIO UART device */
+#include "board.h"
+
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+#ifndef UART_STDIO_DEV
+/**
+ * @brief UART device to use for STDIO
+ */
+#define UART_STDIO_DEV           UART_DEV(0)
+#endif
+
+#ifndef UART_STDIO_BAUDRATE
+/**
+ * @brief Baudrate for STDIO
+ */
+#define UART_STDIO_BAUDRATE      (115200)
+#endif
+
+#ifndef UART_STDIO_RX_BUFSIZE
+/**
+ * @brief Buffer size for STDIO
+ */
+#define UART_STDIO_RX_BUFSIZE    (64)
 #endif
 
 /**

--- a/sys/uart_stdio/uart_stdio.c
+++ b/sys/uart_stdio/uart_stdio.c
@@ -24,6 +24,7 @@
  */
 
 #include <stdio.h>
+#include "uart_stdio.h"
 
 #include "tsrb.h"
 #include "thread.h"
@@ -41,23 +42,11 @@ extern ethos_t ethos;
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-#ifndef STDIO
-#define STDIO               UART_DEV(0)
-#endif
-
-#ifndef STDIO_BAUDRATE
-#define STDIO_BAUDRATE      (115200)
-#endif
-
-#ifndef STDIO_RX_BUFSIZE
-#define STDIO_RX_BUFSIZE    (64)
-#endif
-
 /**
  * @brief use mutex for waiting on incoming UART chars
  */
 static mutex_t _rx_mutex = MUTEX_INIT;
-static char _rx_buf_mem[STDIO_RX_BUFSIZE];
+static char _rx_buf_mem[UART_STDIO_RX_BUFSIZE];
 static tsrb_t _rx_buf = TSRB_INIT(_rx_buf_mem);
 
 /**
@@ -73,7 +62,7 @@ void uart_stdio_rx_cb(void *arg, char data)
 void uart_stdio_init(void)
 {
 #ifndef USE_ETHOS_FOR_STDIO
-    uart_init(STDIO, STDIO_BAUDRATE, uart_stdio_rx_cb, NULL);
+    uart_init(UART_STDIO_DEV, UART_STDIO_BAUDRATE, uart_stdio_rx_cb, NULL);
 #else
     uart_init(ETHOS_UART, ETHOS_BAUDRATE, uart_stdio_rx_cb, NULL);
 #endif
@@ -91,7 +80,7 @@ int uart_stdio_read(char* buffer, int count)
 int uart_stdio_write(const char* buffer, int len)
 {
 #ifndef USE_ETHOS_FOR_STDIO
-    uart_write(STDIO, (uint8_t *)buffer, (size_t)len);
+    uart_write(UART_STDIO_DEV, (uint8_t *)buffer, (size_t)len);
 #else
     ethos_send_frame(&ethos, (uint8_t*)buffer, len, ETHOS_FRAME_TYPE_TEXT);
 #endif

--- a/tests/driver_xbee/README.md
+++ b/tests/driver_xbee/README.md
@@ -9,7 +9,7 @@ module to your board:
 - GND
 
 NOTE: when you use an Arduino Xbee shield, the Xbee module is connected to the
-same UART as RIOTs standard out. In this case you must redefine the STDIO to
+same UART as RIOTs standard out. In this case you must redefine UART_STDIO_DEV to
 another UART interface in the board.h and connect a UART-to-USB adapter to that
 UART.
 

--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -35,8 +35,8 @@
 #define PRINTER_PRIO        (THREAD_PRIORITY_MAIN - 1)
 #define PRINTER_TYPE        (0xabcd)
 
-#ifndef STDIO
-#define STDIO               (UART_UNDEF)
+#ifndef UART_STDIO_DEV
+#define UART_STDIO_DEV      (UART_UNDEF)
 #endif
 
 typedef struct {
@@ -52,7 +52,7 @@ static char printer_stack[THREAD_STACKSIZE_MAIN];
 static int parse_dev(char *arg)
 {
     int dev = atoi(arg);
-    if (dev == STDIO) {
+    if (dev == UART_STDIO_DEV) {
         printf("Error: The selected UART_DEV(%i) is used for the shell!\n", dev);
         return -2;
     }
@@ -176,7 +176,7 @@ int main(void)
 
     puts("UART INFO:");
     printf("Available devices:               %i\n", UART_NUMOF);
-    printf("UART used for STDIO (the shell): UART_DEV(%i)\n\n", STDIO);
+    printf("UART used for STDIO (the shell): UART_DEV(%i)\n\n", UART_STDIO_DEV);
 
     /* initialize ringbuffers */
     for (int i = 0; i < UART_NUMOF; i++) {


### PR DESCRIPTION
This allows ethos to use STDIO as its default port when not specifying `ETHOS_UART` and `ETHOS_BAUDRATE` via CFLAGS or other headers