### PR TITLE
gnrc_sixlowpan: Preserve order when replacing 6lowpan header by decoded IPv6 header

### DIFF
--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -204,6 +204,17 @@ gnrc_pktsnip_t *gnrc_pktbuf_get_iovec(gnrc_pktsnip_t *pkt, size_t *len);
  */
 gnrc_pktsnip_t *gnrc_pktbuf_remove_snip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *snip);
 
+/**
+ * @brief   Replace a snip from a packet and the packet buffer by another snip.
+ *
+ * @param[in] pkt   A packet
+ * @param[in] old   snip currently in the packet
+ * @param[in] add   snip which will replace old
+ *
+ * @return  The new reference to @p pkt
+ */
+gnrc_pktsnip_t *gnrc_pktbuf_replace_snip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *old, gnrc_pktsnip_t *add);
+
 #ifdef DEVELHELP
 /**
  * @brief   Prints some statistics about the packet buffer to stdout.

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -130,7 +130,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
 #ifdef MODULE_GNRC_SIXLOWPAN_IPHC
     else if (sixlowpan_iphc_is(dispatch)) {
         size_t dispatch_size, nh_len;
-        gnrc_pktsnip_t *sixlowpan, *tmp;
+        gnrc_pktsnip_t *sixlowpan;
         gnrc_pktsnip_t *dec_hdr = gnrc_pktbuf_add(NULL, NULL, sizeof(ipv6_hdr_t),
                                                   GNRC_NETTYPE_IPV6);
         if ((dec_hdr == NULL) ||
@@ -152,11 +152,8 @@ static void _receive(gnrc_pktsnip_t *pkt)
         }
 
         /* Remove IPHC dispatches */
-        pkt = gnrc_pktbuf_remove_snip(pkt, sixlowpan);
         /* Insert decoded header instead */
-        LL_SEARCH_SCALAR(dec_hdr, tmp, next, NULL); /* search last decoded header */
-        tmp->next = pkt->next;
-        pkt->next = dec_hdr;
+        pkt = gnrc_pktbuf_replace_snip(pkt, sixlowpan, dec_hdr);
         payload->type = GNRC_NETTYPE_UNDEF;
     }
 #endif

--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -503,4 +503,27 @@ gnrc_pktsnip_t *gnrc_pktbuf_remove_snip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *sni
     return pkt;
 }
 
+gnrc_pktsnip_t *gnrc_pktbuf_replace_snip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *old, gnrc_pktsnip_t *add)
+{
+    /* If add is a list we need to preserve its tail */
+    if (add->next != NULL) {
+        gnrc_pktsnip_t *tail = add->next;
+        gnrc_pktsnip_t *back;
+        LL_SEARCH_SCALAR(tail, back, next, NULL); /* find the last snip in add */
+        /* Replace old */
+        LL_REPLACE_ELEM(pkt, old, add);
+        /* and wire in the tail between */
+        back->next = add->next;
+        add->next = tail;
+    }
+    else {
+        /* add is a single element, has no tail, simply replace */
+        LL_REPLACE_ELEM(pkt, old, add);
+    }
+    old->next = NULL;
+    gnrc_pktbuf_release(old);
+
+    return pkt;
+}
+
 /** @} */


### PR DESCRIPTION
This fixes a very difficult to trace hard fault on a 6lbr when forwarding a reassembled fragmented UDP packet from 6lowpan to ethos (or another larger MTU device).
Without this change, the packet snips were arranged in the following order:
netiif->udp->ipv6
After this change the snips are:
udp->ipv6->netif

This caused a hard fault at [gnrc_ipv6.c:826](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c#L826) trying to pktbuf release a NULL pointer.

The cause of the issue was that the 6lo header was the old head of the snip list:
6lo->netif
and in the old code, removing the 6lo header made netif the new head, and the decoded header was appended to the netif snip.

I tested this with #4544 and #4935 applied and IPHC UDP NHC reenabled.

The hard fault is gone but now the UDP checksum on the packet coming out on the ethos pipe is wrong, according to Wireshark.