### PR TITLE
gnrc_pktdump: make pid global

### DIFF
--- a/examples/default/main.c
+++ b/examples/default/main.c
@@ -55,7 +55,7 @@ int main(void)
 #ifdef MODULE_NETIF
     gnrc_netreg_entry_t dump;
 
-    dump.pid = gnrc_pktdump_getpid();
+    dump.pid = gnrc_pktdump_pid;
     dump.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
 #endif

--- a/examples/gnrc_networking/udp.c
+++ b/examples/gnrc_networking/udp.c
@@ -103,7 +103,7 @@ static void start_server(char *port_str)
         return;
     }
     /* start server (which means registering pktdump for the chosen port) */
-    server.pid = gnrc_pktdump_getpid();
+    server.pid = gnrc_pktdump_pid;
     server.demux_ctx = (uint32_t)port;
     gnrc_netreg_register(GNRC_NETTYPE_UDP, &server);
     printf("Success: started UDP server on port %" PRIu16 "\n", port);

--- a/sys/include/net/gnrc/pktdump.h
+++ b/sys/include/net/gnrc/pktdump.h
@@ -50,12 +50,9 @@ extern "C" {
 #endif
 
 /**
- * @brief   Get the PID of the pktdump thread
- *
- * @return  PID of the pktdump thread
- * @return  @ref KERNEL_PID_UNDEF if not initialized
+ * @brief   The PID of the pktdump thread
  */
-kernel_pid_t gnrc_pktdump_getpid(void);
+extern kernel_pid_t gnrc_pktdump_pid;
 
 /**
  * @brief   Start the packet dump thread and listening for incoming packets

--- a/sys/net/gnrc/pktdump/gnrc_pktdump.c
+++ b/sys/net/gnrc/pktdump/gnrc_pktdump.c
@@ -36,7 +36,7 @@
 /**
  * @brief   PID of the pktdump thread
  */
-static kernel_pid_t _pid = KERNEL_PID_UNDEF;
+kernel_pid_t gnrc_pktdump_pid = KERNEL_PID_UNDEF;
 
 /**
  * @brief   Stack for the pktdump thread
@@ -154,17 +154,12 @@ static void *_eventloop(void *arg)
     return NULL;
 }
 
-kernel_pid_t gnrc_pktdump_getpid(void)
-{
-    return _pid;
-}
-
 kernel_pid_t gnrc_pktdump_init(void)
 {
-    if (_pid == KERNEL_PID_UNDEF) {
-        _pid = thread_create(_stack, sizeof(_stack), GNRC_PKTDUMP_PRIO,
+    if (gnrc_pktdump_pid == KERNEL_PID_UNDEF) {
+        gnrc_pktdump_pid = thread_create(_stack, sizeof(_stack), GNRC_PKTDUMP_PRIO,
                              THREAD_CREATE_STACKTEST,
                              _eventloop, NULL, "pktdump");
     }
-    return _pid;
+    return gnrc_pktdump_pid;
 }

--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -36,7 +36,7 @@ int main(void)
 
     /* register the pktdump thread */
     puts("Register the packet dump thread for GNRC_NETTYPE_UNDEF packets");
-    dump.pid = gnrc_pktdump_getpid();
+    dump.pid = gnrc_pktdump_pid;
     dump.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
 

--- a/tests/driver_kw2xrf/main.c
+++ b/tests/driver_kw2xrf/main.c
@@ -32,7 +32,7 @@ int main(void)
 
     /* register the pktdump thread */
     puts("Register the packet dump thread for GNRC_NETTYPE_UNDEF packets");
-    dump.pid = gnrc_pktdump_getpid();
+    dump.pid = gnrc_pktdump_pid;
     dump.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
 

--- a/tests/driver_nrfmin/main.c
+++ b/tests/driver_nrfmin/main.c
@@ -41,7 +41,7 @@ int main(void)
     gnrc_nomac_init(nomac_stack, sizeof(nomac_stack), 5, "nomac", &dev);
 
     /* initialize packet dumper */
-    netobj.pid = gnrc_pktdump_getpid();
+    netobj.pid = gnrc_pktdump_pid;
     netobj.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &netobj);
 

--- a/tests/driver_xbee/main.c
+++ b/tests/driver_xbee/main.c
@@ -35,7 +35,7 @@ int main(void)
     puts("Xbee S1 device driver test");
 
     /* initialize and register pktdump */
-    dump.pid = gnrc_pktdump_getpid();
+    dump.pid = gnrc_pktdump_pid;
     if (dump.pid <= KERNEL_PID_UNDEF) {
         puts("Error starting pktdump thread");
         return -1;

--- a/tests/slip/main.c
+++ b/tests/slip/main.c
@@ -35,7 +35,7 @@ int main(void)
     puts("SLIP test");
 
     /* initialize and register pktdump */
-    dump.pid = gnrc_pktdump_getpid();
+    dump.pid = gnrc_pktdump_pid;
     dump.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
 
     if (dump.pid <= KERNEL_PID_UNDEF) {

--- a/tests/zep/main.c
+++ b/tests/zep/main.c
@@ -35,7 +35,7 @@ int main(void)
     puts("ZEP module test");
 
     /* initialize and register pktdump */
-    dump.pid = gnrc_pktdump_getpid();
+    dump.pid = gnrc_pktdump_pid;
 
     if (dump.pid <= KERNEL_PID_UNDEF) {
         puts("Error starting pktdump thread");


### PR DESCRIPTION
`gnrc_pktdump` uses a getter function for the thread pid. AFAIK, our consensus was to use global variables for such use cases instead.

The size copmarison is not that interesting, but this may be due to the fact, that we have only very few occurences where the pid is actually used in our current examples/tests.

```
text    data    bss     dec     BOARD/BINDIRBASE

-8      0       0       -8      arduino-due
57928   284     17488   75700   master-bin
57920   284     17488   75692   pktdump-bin

-6      0       0       -6      arduino-mega2560
81374   11386   11289   104049  master-bin
81368   11386   11289   104043  pktdump-bin

-8      0       0       -8      avsextrem
85948   220     98077   184245  master-bin
85940   220     98077   184237  pktdump-bin

-8      0       0       -8      cc2538dk
58104   220     17440   75764   master-bin
58096   220     17440   75756   pktdump-bin

0       0       0       0       ek-lm4f120xl
58356   220     17416   75992   master-bin
58356   220     17416   75992   pktdump-bin

0       0       0       0       f4vi1
60056   224     17552   77832   master-bin
60056   224     17552   77832   pktdump-bin

-8      0       0       -8      fox
72968   220     20600   93788   master-bin
72960   220     20600   93780   pktdump-bin

0       0       0       0       frdm-k64f
58076   1248    17408   76732   master-bin
58076   1248    17408   76732   pktdump-bin

-8      0       0       -8      iotlab-m3
72992   220     20600   93812   master-bin
72984   220     20600   93804   pktdump-bin

-8      0       0       -8      limifrog-v1
59236   220     17536   76992   master-bin
59228   220     17536   76984   pktdump-bin

-8      0       0       -8      mbed_lpc1768
57704   220     17408   75332   master-bin
57696   220     17408   75324   pktdump-bin

-8      0       0       -8      msba2
107840  220     98077   206137  master-bin
107832  220     98077   206129  pktdump-bin

0       0       0       0       msbiot
60368   224     17600   78192   master-bin
60368   224     17600   78192   pktdump-bin

0       0       0       0       mulle
75924   1284    21064   98272   master-bin
75924   1284    21064   98272   pktdump-bin

-88     0       0       -88     native
196478  620     103128  300226  master-bin
196390  620     103128  300138  pktdump-bin

0       0       0       0       nrf52dk
57708   220     17408   75336   master-bin
57708   220     17408   75336   pktdump-bin

-8      0       0       -8      nucleo-f091
59332   220     17408   76960   master-bin
59324   220     17408   76952   pktdump-bin

0       0       0       0       nucleo-f303
58244   220     17416   75880   master-bin
58244   220     17416   75880   pktdump-bin

0       0       0       0       nucleo-f401
60056   224     17552   77832   master-bin
60056   224     17552   77832   pktdump-bin

-8      0       0       -8      nucleo-l1
59120   220     17528   76868   master-bin
59112   220     17528   76860   pktdump-bin

-8      0       0       -8      openmote-cc2538
58056   220     17440   75716   master-bin
58048   220     17440   75708   pktdump-bin

-16     0       0       -16     pba-d-01-kw2x
75160   1248    21136   97544   master-bin
75144   1248    21136   97528   pktdump-bin

-8      0       0       -8      pttu
86156   220     98077   184453  master-bin
86148   220     98077   184445  pktdump-bin

-8      0       0       -8      remote
58688   220     17440   76348   master-bin
58680   220     17440   76340   pktdump-bin

-8      0       0       -8      saml21-xpro
59512   220     17528   77260   master-bin
59504   220     17528   77252   pktdump-bin

-8      0       0       -8      samr21-xpro
75836   220     20616   96672   master-bin
75828   220     20616   96664   pktdump-bin

0       0       0       0       slwstk6220a
57856   220     17536   75612   master-bin
57856   220     17536   75612   pktdump-bin

-16     0       0       -16     stm32f3discovery
58260   220     17416   75896   master-bin
58244   220     17416   75880   pktdump-bin

0       0       0       0       stm32f4discovery
60300   224     17576   78100   master-bin
60300   224     17576   78100   pktdump-bin

-8      0       0       -8      udoo
57928   284     17488   75700   master-bin
57920   284     17488   75692   pktdump-bin
```