### PR TITLE
cpu/stm32/gpio_exti: EXTI->PR is of type RW_w1 so don't RMW the pending status register

### DIFF
--- a/cpu/stm32f3/periph/gpio.c
+++ b/cpu/stm32f3/periph/gpio.c
@@ -207,7 +207,7 @@ void isr_exti(void)
     uint32_t pending_isr = (EXTI->PR & EXTI->IMR);
     for (int i = 0; i < EXTI_NUMOF; i++) {
         if (pending_isr & (1 << i)) {
-            EXTI->PR |= (1 << i);               /* clear by writing a 1 */
+            EXTI->PR = (1 << i);                /* clear by writing a 1 */
             exti_chan[i].cb(exti_chan[i].arg);
         }
     }

--- a/cpu/stm32f4/periph/gpio.c
+++ b/cpu/stm32f4/periph/gpio.c
@@ -204,7 +204,7 @@ void isr_exti(void)
     uint32_t pending_isr = (EXTI->PR & EXTI->IMR);
     for (unsigned i = 0; i < GPIO_ISR_CHAN_NUMOF; i++) {
         if (pending_isr & (1 << i)) {
-            EXTI->PR |= (1 << i);               /* clear by writing a 1 */
+            EXTI->PR = (1 << i);                /* clear by writing a 1 */
             exti_chan[i].cb(exti_chan[i].arg);
         }
     }

--- a/cpu/stm32l1/periph/gpio.c
+++ b/cpu/stm32l1/periph/gpio.c
@@ -208,7 +208,7 @@ void isr_exti(void)
     uint32_t pending_isr = (EXTI->PR & EXTI->IMR);
     for (int i = 0; i < GPIO_ISR_CHAN_NUMOF; i++) {
         if (pending_isr & (1 << i)) {
-            EXTI->PR |= (1 << i);               /* clear by writing a 1 */
+            EXTI->PR = (1 << i);                /* clear by writing a 1 */
             exti_chan[i].cb(exti_chan[i].arg);
         }
     }


### PR DESCRIPTION
The pending flags are cleared by writing 1, so clearing them with `|=` means dropping interrupts if they arrive at the same time. :)