### PR TITLE
irq: enableIRQ() should be allowed in ISR

### DIFF
--- a/core/include/arch/irq_arch.h
+++ b/core/include/arch/irq_arch.h
@@ -47,12 +47,18 @@
 /**
  * @brief Globally enable maskable interrupt sources
  *
+ * @note  This function must behave exactly the same if called from an ISR or
+ *        not.
+ *
  * @return              the IRQ state after enabling interrupts
  */
 unsigned int irq_arch_enable(void);
 
 /**
  * @brief Globally disable all maskable interrupt sources
+ *
+ * @note  This function must behave exactly the same if called from an ISR or
+ *        not.
  *
  * @return              the IRQ state before disabling interrupts
  */
@@ -61,6 +67,9 @@ unsigned int irq_arch_disable(void);
 
 /**
  * @brief Restore a previously recorded IRQ state
+ *
+ * @note  This function must behave exactly the same if called from an ISR or
+ *        not.
  *
  * @param[in] state     the state to set the IRQ flags to
  */

--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -170,11 +170,7 @@ unsigned enableIRQ(void)
     unsigned int prev_state;
 
     if (_native_in_isr == 1) {
-#ifdef DEVELHELP
-        real_write(STDERR_FILENO, "enableIRQ + _native_in_isr\n", 27);
-#else
         DEBUG("enableIRQ + _native_in_isr\n");
-#endif
     }
 
     _native_syscall_enter();


### PR DESCRIPTION
I got confused about the warning in native:
```
enableIRQ + _native_in_isr
```
and was wondering if we need this at all. IMO it should be okay to call these functions from an ISR and the port for a particular platform should assure that it behaves no differently if called from an ISR or not.