### PR TITLE
gnrc_sixlowpan: enable NHC by default

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -110,8 +110,7 @@ endif
 ifneq (,$(filter gnrc_sixlowpan_iphc,$(USEMODULE)))
   USEMODULE += gnrc_sixlowpan
   USEMODULE += gnrc_sixlowpan_ctx
-  # NHC is broken, so disable it for now. See #4544 and #4462.
-  #USEMODULE += gnrc_sixlowpan_iphc_nhc
+  USEMODULE += gnrc_sixlowpan_iphc_nhc
 endif
 
 ifneq (,$(filter gnrc_sixlowpan,$(USEMODULE)))


### PR DESCRIPTION
Now that #4935 is merged, we can enable NHC again by default.

edit: Depends on: #4544, ~~#5029~~, ~~#5049~~