### PR TITLE
dist: tools: pr_check: adapt to RIOT CI

### DIFF
--- a/dist/tools/pr_check/check_labels.sh
+++ b/dist/tools/pr_check/check_labels.sh
@@ -22,7 +22,11 @@ else
     exit 2
 fi
 
-LABELS_JSON=$(${GET} "${GITHUB_API_HOST}/repos/${GITHUB_REPO}/issues/${TRAVIS_PULL_REQUEST}/labels" 2> /dev/null)
+if [ -n "$TRAVIS_PULL_REQUEST" ]; then
+    LABELS_JSON=$(${GET} "${GITHUB_API_HOST}/repos/${GITHUB_REPO}/issues/${TRAVIS_PULL_REQUEST}/labels" 2> /dev/null)
+elif [ -n "$CI_PULL_LABELS" ]; then
+    LABELS_JSON="$CI_PULL_LABELS"
+fi
 
 check_gh_label() {
     LABEL="${1}"

--- a/dist/tools/pr_check/pr_check.sh
+++ b/dist/tools/pr_check/pr_check.sh
@@ -33,7 +33,7 @@ if [ -n "${SQUASH_COMMITS}" ]; then
     EXIT_CODE=1
 fi
 
-if [ -n "$TRAVIS_PULL_REQUEST" ]; then
+if [ -n "$TRAVIS_PULL_REQUEST" -o -n "$CI_PULL_NR" ]; then
     if check_gh_label "NEEDS SQUASHING"; then
         echo -e "${CERROR}Pull request needs squashing according to its labels set on GitHub${CRESET}"
         EXIT_CODE=1


### PR DESCRIPTION
Adapts the label checks to murdock. Previously, murdock would not fail PR's with "NEEDS SQUASHING" or "Waiting for other PR" set.

Will let it fail with the labels set, then remove them one by one.