### PR TITLE
gnrc_sixlowpan_frag: use IPv6 type for reassembled packet

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -319,7 +319,7 @@ static rbuf_t *_rbuf_get(const void *src, size_t src_len,
 
     /* now we have an empty spot */
 
-    res->pkt = gnrc_pktbuf_add(NULL, NULL, size, GNRC_NETTYPE_SIXLOWPAN);
+    res->pkt = gnrc_pktbuf_add(NULL, NULL, size, GNRC_NETTYPE_IPV6);
     if (res->pkt == NULL) {
         DEBUG("6lo rfrag: can not allocate reassembly buffer space.\n");
         return NULL;


### PR DESCRIPTION
Marks a reassembling packet as IPV6. Marking it as SIXLOWPAN doesn't make much sense since it does not contain a 6LoWPAN frame, but an IPv6 packet. Should fix some of the problems we have with forwarding 6LoWPAN frames.