### PR TITLE
gnrc_ipv6: Strip netif header and nothing else

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -823,8 +823,15 @@ static void _receive(gnrc_pktsnip_t *pkt)
                 gnrc_pktbuf_release(pkt);
                 return;
             }
-            gnrc_pktbuf_remove_snip(pkt, ipv6->next);   /* remove L2 headers around IPV6 */
-            while (ptr != NULL) {                       /* reverse packet order */
+
+            /* remove L2 headers around IPV6 */
+            netif = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
+            if (netif != NULL) {
+                gnrc_pktbuf_remove_snip(pkt, netif);
+            }
+
+            /* reverse packet snip list order */
+            while (ptr != NULL) {
                 gnrc_pktsnip_t *next;
                 ptr = gnrc_pktbuf_start_write(ptr);     /* duplicate if not already done */
                 if (ptr == NULL) {


### PR DESCRIPTION
This adds an extra safety to remove only the netif header and nothing else when forwarding IPv6 packets.

This PR makes the hard fault described in #5029 impossible because we check for a NULL pointer before releasing.

Is this too much overhead?