### PR TITLE
sys/newlib: Improve robustness in include path search

### DIFF
--- a/sys/newlib/Makefile.include
+++ b/sys/newlib/Makefile.include
@@ -36,4 +36,5 @@ ifeq (,$(NEWLIB_INCLUDES))
   NEWLIB_INCLUDES := $(addprefix -isystem ,$(wildcard $(dir $(shell which $(PREFIX)gcc))../$(TARGET_TRIPLE)/include))
 endif
 
-export INCLUDES += $(NEWLIB_INCLUDES)
+# Newlib includes should go before GCC includes.
+export INCLUDES := $(NEWLIB_INCLUDES) $(INCLUDES)

--- a/sys/newlib/Makefile.include
+++ b/sys/newlib/Makefile.include
@@ -30,4 +30,10 @@ NEWLIB_INCLUDES ?= \
         $(foreach pat, $(NEWLIB_INCLUDE_PATTERNS), $(wildcard $(pat))), \
         -isystem $(dir))
 
+# If nothing was found we will try to fall back to searching for a cross-gcc in
+# the current PATH and use a relative path for the includes
+ifeq (,$(NEWLIB_INCLUDES))
+  NEWLIB_INCLUDES := $(addprefix -isystem ,$(wildcard $(dir $(shell which $(PREFIX)gcc))../$(TARGET_TRIPLE)/include))
+endif
+
 export INCLUDES += $(NEWLIB_INCLUDES)


### PR DESCRIPTION
This improves the robustness of the include path search when using non-standard newlib installation paths.
The fallback looks for the proper cross-gcc in the path of the current user and tries to find includes relative to that directory.

The include order patch is only relevant when building with Clang where we have to search for all the cross toolchain headers.