### PR TITLE
make\arm: Fix compiling against newlib nano.specs

### DIFF
--- a/boards/avsextrem/drivers/Makefile
+++ b/boards/avsextrem/drivers/Makefile
@@ -1,4 +1,3 @@
 MODULE = avsextrem-drivers
-include $(RIOTBOARD)/$(BOARD)/Makefile.include
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/msba2-common/Makefile.include
+++ b/boards/msba2-common/Makefile.include
@@ -30,6 +30,7 @@ export LINKFLAGS += -Wl,--gc-sections
 
 # use the nano-specs of Newlib when available
 ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+export CFLAGS += -specs=nano.specs
 export LINKFLAGS += -specs=nano.specs -lc -lnosys
 endif
 

--- a/boards/msba2-common/drivers/Makefile
+++ b/boards/msba2-common/drivers/Makefile
@@ -1,4 +1,3 @@
 MODULE = msba2-common-drivers
-include $(RIOTBOARD)/$(BOARD)/Makefile.include
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/Makefile.include.cortexm_common
+++ b/cpu/Makefile.include.cortexm_common
@@ -95,6 +95,7 @@ include $(RIOTCPU)/cortexm_common/Makefile.include
 
 # use the nano-specs of Newlib when available
 ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+export CFLAGS += -specs=nano.specs
 export LINKFLAGS += -specs=nano.specs -lc -lnosys
 endif
 

--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -3,10 +3,6 @@ PKG_URL=https://github.com/OlegHahm/ccn-lite/
 PKG_VERSION=39b1406c11de9de364220909488eebabe7e81613
 PKG_DIR=$(CURDIR)/$(PKG_NAME)
 
-ifneq ($(RIOTBOARD),)
-include $(RIOTBOARD)/$(BOARD)/Makefile.include
-endif
-
 .PHONY: all clean distclean
 
 export RIOT_CFLAGS = ${CFLAGS} ${INCLUDES}

--- a/pkg/libcoap/Makefile
+++ b/pkg/libcoap/Makefile
@@ -3,10 +3,6 @@ PKG_URL=https://github.com/obgm/libcoap
 PKG_VERSION=ef41ce5d02d64cec0751882ae8fd95f6c32bc018
 PKG_DIR=$(CURDIR)/$(PKG_NAME)
 
-ifneq ($(RIOTBOARD),)
-include $(RIOTBOARD)/$(BOARD)/Makefile.include
-endif
-
 ifneq ($(RIOTBASE),)
 INCLUDES += -I$(RIOTBASE)/sys/include -I$(RIOTBASE)/sys/net/include \
 			-I$(RIOTBASE)/sys/posix/include -I$(RIOTBASE)/sys/posix/pnet/include

--- a/pkg/micro-ecc/Makefile
+++ b/pkg/micro-ecc/Makefile
@@ -4,10 +4,6 @@ PKG_VERSION=b6c0cdbe7d20af48b0c2a909a66ff00b093d1542
 PKG_DIR=$(CURDIR)
 PKG_BUILDDIR=$(BINDIR)/pkg/$(PKG_NAME)
 
-ifneq ($(RIOTBOARD),)
-include $(RIOTBOARD)/$(BOARD)/Makefile.include
-endif
-
 ifneq ($(RIOTBASE),)
 INCLUDES += -I$(RIOTBASE)/sys/include -I$(RIOTBASE)/sys/net/include \
 			-I$(RIOTBASE)/sys/posix/include

--- a/pkg/microcoap/Makefile
+++ b/pkg/microcoap/Makefile
@@ -3,10 +3,6 @@ PKG_URL=git://github.com/1248/microcoap.git
 PKG_VERSION=9cb1dcda2182a8dca8483b230cda8b591a924c82
 PKG_DIR=$(CURDIR)/$(PKG_NAME)
 
-ifneq ($(RIOTBOARD),)
-include $(RIOTBOARD)/$(BOARD)/Makefile.include
-endif
-
 ifneq ($(RIOTBASE),)
 INCLUDES += -I$(RIOTBASE)/sys/include -I$(RIOTBASE)/sys/net/include \
 			-I$(RIOTBASE)/sys/posix/include

--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -3,10 +3,6 @@ PKG_URL=http://olsr.org/git/oonf.git
 PKG_VERSION=v0.3.0
 PKG_DIR=$(CURDIR)/$(PKG_NAME)
 
-ifneq ($(RIOTBOARD),)
-include $(RIOTBOARD)/$(BOARD)/Makefile.include
-endif
-
 ifneq ($(RIOTBASE),)
 INCLUDES += -I$(RIOTBASE)/sys/include -I$(RIOTBASE)/sys/net/include \
 			-I$(RIOTBASE)/sys/posix/include

--- a/pkg/openwsn/Makefile
+++ b/pkg/openwsn/Makefile
@@ -3,10 +3,6 @@ PKG_URL=https://github.com/openwsn-berkeley/openwsn-fw.git
 PKG_VERSION=ff25e5d0ae5d344ed793a724d60532fb917bf1f8
 PKG_DIR=$(CURDIR)/$(PKG_NAME)
 
-ifneq ($(RIOTBOARD),)
-include $(RIOTBOARD)/$(BOARD)/Makefile.include
-endif
-
 .PHONY: all clean patch reset
 
 all: patch

--- a/pkg/relic/Makefile
+++ b/pkg/relic/Makefile
@@ -6,10 +6,6 @@ PKG_URL=$(RELIC_URL)
 PKG_VERSION=$(RELIC_BRANCH)
 PKG_DIR=$(CURDIR)/$(PKG_NAME)
 
-ifneq ($(RIOTBOARD),)
-include $(RIOTBOARD)/$(BOARD)/Makefile.include
-endif
-
 ifneq ($(RIOTBASE),)
 INCLUDES += -I$(RIOTBASE)/sys/include -I$(RIOTBASE)/sys/net/include \
 			-I$(RIOTBASE)/sys/posix/include -I$(RIOTBASE)/sys/posix/pnet/include


### PR DESCRIPTION
When linking against newlib-nano it is a good idea to make the compiler include the proper newlib configuration header.

Needed for: #4529