### PR TITLE
native: workaround for thread_t name collision

### DIFF
--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -27,6 +27,8 @@
 #include <mach/mach_init.h>
 #include <mach/mach_port.h>
 #include <mach/mach_host.h>
+/* Both OS X and RIOT typedef thread_t. timer.c does not use either thread_t. */
+#define thread_t riot_thread_t
 #endif
 
 #include <time.h>


### PR DESCRIPTION
Fixes #4973.
Implements @Kijewski's idea.