### PR TITLE
sys/xtimer: Remove unused XTIMER_USLEEP_UNTIL_OVERHEAD

### DIFF
--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -53,7 +53,6 @@
  * @{
  */
 #define XTIMER_OVERHEAD 14
-#define XTIMER_USLEEP_UNTIL_OVERHEAD 1
 
 /* timer_set_absolute() has a high margin for possible underflow if set with
  * value not far in the future. To prevent this, we set high backoff values

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -382,18 +382,6 @@ int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t us);
 #endif
 #define XTIMER_MASK_SHIFTED XTIMER_TICKS_TO_USEC(XTIMER_MASK)
 
-#ifndef XTIMER_USLEEP_UNTIL_OVERHEAD
-/**
- * @brief xtimer_usleep_until overhead value
- *
- * This value specifies the time a xtimer_usleep_until will be late
- * if uncorrected.
- *
- * This is supposed to be defined per-device in e.g., periph_conf.h.
- */
-#define XTIMER_USLEEP_UNTIL_OVERHEAD 10
-#endif
-
 #if XTIMER_MASK
 extern volatile uint32_t _high_cnt;
 #endif


### PR DESCRIPTION
It was used in a previous iteration of xtimer, but is currently not being used anywhere.