### PR TITLE
cpu/stm32f4/periph/adc: ADC_SR_STRT flag is unused

### DIFF
--- a/cpu/stm32f4/periph/adc.c
+++ b/cpu/stm32f4/periph/adc.c
@@ -110,8 +110,6 @@ int adc_sample(adc_t line, adc_res_t res)
     /* lock and power on the ADC device  */
     prep(line);
 
-    /* wait for any ongoing conversions to finish */
-    while (dev(line)->SR & ADC_SR_STRT) {}
     /* set resolution and conversion channel */
     dev(line)->CR1 = res;
     dev(line)->SQR3 = adc_config[line].chan;
@@ -120,7 +118,6 @@ int adc_sample(adc_t line, adc_res_t res)
     while (!(dev(line)->SR & ADC_SR_EOC)) {}
     /* finally read sample and reset the STRT bit in the status register */
     sample = (int)dev(line)->DR;
-    dev(line)->SR &= ~ADC_SR_STRT;
 
     /* power off and unlock device again */
     done(line);


### PR DESCRIPTION
The ADC_SR_STRT flag was first used as mutex, but it isn't used in the new implementation.
If you would first use a 6bit ADC readout and later want to do a 12bits the resolution bits will never get cleared.

Sorry to only see this now, but I noticed when I was updating the STM32F2 implementation. But since API block any other PR from being able to get merged, I think it's better to quick fix the implementation later instead of dragging the total for ages. :)