### PR TITLE
cpu/make: added global Makefile.periph

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -381,7 +381,7 @@ endif
 
 ifneq (,$(filter isrpipe,$(USEMODULE)))
   USEMODULE += tsrb
-  FEATURES_REQUIRED += periph_uart
+  USEMODULE += periph_driver_uart
 endif
 
 ifneq (,$(filter posix,$(USEMODULE)))
@@ -559,7 +559,7 @@ ifneq (,$(filter arduino,$(USEMODULE)))
 endif
 
 ifneq (,$(filter xtimer,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_timer
+    USEMODULE += periph_driver_timer
     USEMODULE += div
 endif
 

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -381,6 +381,7 @@ endif
 
 ifneq (,$(filter isrpipe,$(USEMODULE)))
   USEMODULE += tsrb
+  FEATURES_REQUIRED += periph_uart
 endif
 
 ifneq (,$(filter posix,$(USEMODULE)))

--- a/Makefile.include
+++ b/Makefile.include
@@ -188,6 +188,7 @@ INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include
 include $(RIOTBASE)/Makefile.pseudomodules
 include $(RIOTBASE)/Makefile.defaultmodules
 include $(RIOTBOARD)/$(BOARD)/Makefile.include
+-include $(RIOTBOARD)/$(BOARD)/Makefile.features
 include $(RIOTCPU)/$(CPU)/Makefile.include
 
 # Import all toolchain settings
@@ -403,9 +404,6 @@ $(CURDIR)/eclipsesym.xml:
 
 # Extra make goals for testing and comparing changes.
 include $(RIOTBASE)/Makefile.buildtests
-
-# process provided features
-include $(RIOTBASE)/Makefile.features
 
 # Export variables used throughout the whole make system:
 include $(RIOTBASE)/Makefile.vars

--- a/Makefile.periph
+++ b/Makefile.periph
@@ -1,0 +1,20 @@
+MODULE ?= periph
+
+# get a list with the peripherals, that are configured by the board
+OFFER = $(patsubst periph_%,%.c,$(filter periph_%,$(FEATURES_PROVIDED)))
+# conclude a list of existing AND configured peripherals
+HAS = $(filter $(wildcard *.c),$(OFFER))
+
+# get a list of peripherals, that are needed by the application
+NEED = $(sort $(patsubst periph_%,%.c,$(filter periph_%,$(FEATURES_REQUIRED))))
+# only compile the peripheral drivers, that are present and configured
+SRC += $(filter $(HAS),$(NEED))
+
+# HACK: in case no peripheral in this folder is to be build, we build the first
+#       configured driver in the list, so we don't end up with an empty
+#       compilation unit where the linker would be complain
+ifeq (,$(SRC))
+  SRC = $(firstword $(filter $(HAS),$(OFFER)))
+endif
+
+include $(RIOTBASE)/Makefile.base

--- a/Makefile.periph
+++ b/Makefile.periph
@@ -6,7 +6,7 @@ OFFER = $(patsubst periph_%,%.c,$(filter periph_%,$(FEATURES_PROVIDED)))
 HAS = $(filter $(wildcard *.c),$(OFFER))
 
 # get a list of peripherals, that are needed by the application
-NEED = $(sort $(patsubst periph_%,%.c,$(filter periph_%,$(FEATURES_REQUIRED))))
+NEED = $(sort $(patsubst periph_driver_%,%.c,$(filter periph_driver_%,$(USEMODULE))))
 # only compile the peripheral drivers, that are present and configured
 SRC += $(filter $(HAS),$(NEED))
 

--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -58,6 +58,9 @@ PSEUDOMODULES += sock_ip
 PSEUDOMODULES += sock_tcp
 PSEUDOMODULES += sock_udp
 
+# all peripheral drivers are build into the periph module
+PSEUDOMODULES += periph_driver_%
+
 # include variants of the AT86RF2xx drivers as pseudo modules
 PSEUDOMODULES += at86rf23%
 PSEUDOMODULES += at86rf21%

--- a/Makefile.vars
+++ b/Makefile.vars
@@ -8,6 +8,8 @@ export CPU                   # The CPU, set by the board's Makefile.include.
 export CPU_MODEL             # The specific identifier of the used CPU, used for some CPU implementations to differentiate between different memory layouts
 export MCU                   # The MCU, set by the board's Makefile.include, or defaulted to the same value as CPU.
 export INCLUDES              # The extra include paths, set by the various Makefile.include files.
+export FEATURES_PROVIDED     # List of features, that the a board provides
+export FEATURES_REQUIRED     # List of board features, that are required by an application
 
 export USEMODULE             # Sys Module dependencies of the application. Set in the application's Makefile.
 export USEPKG                # Pkg dependencies (third party modules) of the application. Set in the application's Makefile.

--- a/boards/airfy-beacon/Makefile
+++ b/boards/airfy-beacon/Makefile
@@ -1,3 +1,3 @@
 MODULE = board
 
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/boards/airfy-beacon/Makefile
+++ b/boards/airfy-beacon/Makefile
@@ -1,3 +1,3 @@
 MODULE = board
 
-include $(RIOTBASE)/Makefile.periph
+include $(RIOTBASE)/Makefile.base

--- a/boards/arduino-due/Makefile.include
+++ b/boards/arduino-due/Makefile.include
@@ -2,6 +2,9 @@
 export CPU = sam3
 export CPU_MODEL = sam3x8e
 
+# include dependencies
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep
+
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/avsextrem/Makefile.dep
+++ b/boards/avsextrem/Makefile.dep
@@ -1,1 +1,4 @@
 include $(RIOTBOARD)/msba2-common/Makefile.dep
+
+# the board uses the GPIO driver for LED initialization
+FEATURES_REQUIRED += periph_gpio

--- a/boards/avsextrem/Makefile.include
+++ b/boards/avsextrem/Makefile.include
@@ -1,3 +1,6 @@
+# include dependencies
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep
+
 USEMODULE += msba2-common
 
 include $(RIOTBOARD)/msba2-common/Makefile.include

--- a/boards/f4vi1/Makefile.features
+++ b/boards/f4vi1/Makefile.features
@@ -1,4 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/frdm-k64f/Makefile.dep
+++ b/boards/frdm-k64f/Makefile.dep
@@ -1,0 +1,2 @@
+# The GPIO driver is used for board initialization
+FEATURES_REQUIRED += periph_gpio

--- a/boards/msba2/Makefile.dep
+++ b/boards/msba2/Makefile.dep
@@ -1,1 +1,8 @@
 include $(RIOTBOARD)/msba2-common/Makefile.dep
+
+# the board uses the GPIO driver for LED initialization
+FEATURES_REQUIRED += periph_gpio
+
+ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+  USEMODULE += cc110x
+endif

--- a/boards/msba2/Makefile.include
+++ b/boards/msba2/Makefile.include
@@ -1,6 +1,5 @@
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
-	USEMODULE += cc110x
-endif
+# include dependencies
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep
 
 USEMODULE += msba2-common
 

--- a/boards/mulle/Makefile.dep
+++ b/boards/mulle/Makefile.dep
@@ -6,6 +6,11 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += lis3dh
 endif
 
+# The RTT clock drives the core clock in the default configuration
+FEATURES_REQUIRED += periph_rtt
+# The GPIO driver is used for board initialization
+FEATURES_REQUIRED += periph_gpio
+
 # The Mulle uses NVRAM to store persistent variables, such as boot count.
 USEMODULE += nvram_spi
 USEMODULE += nvram

--- a/boards/nrf51dongle/Makefile.dep
+++ b/boards/nrf51dongle/Makefile.dep
@@ -1,3 +1,6 @@
+# the board uses the GPIO driver for LED initialization
+FEATURES_REQUIRED += periph_gpio
+
 ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
   USEMODULE += nrfmin
 endif

--- a/boards/nrf51dongle/Makefile.include
+++ b/boards/nrf51dongle/Makefile.include
@@ -2,6 +2,9 @@
 export CPU = nrf51
 export CPU_MODEL = nrf51x22xxab
 
+# include dependencies
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep
+
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/nucleo-common/Makefile.dep
+++ b/boards/nucleo-common/Makefile.dep
@@ -1,3 +1,6 @@
+# the board uses the GPIO driver for LED initialization
+FEATURES_REQUIRED += periph_gpio
+
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif

--- a/boards/openmote-cc2538/Makefile.dep
+++ b/boards/openmote-cc2538/Makefile.dep
@@ -1,3 +1,6 @@
+# the board uses the GPIO driver for LED initialization
+FEATURES_REQUIRED += periph_gpio
+
 ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
     USEMODULE += netif
     USEMODULE += cc2538_rf

--- a/boards/pba-d-01-kw2x/Makefile.dep
+++ b/boards/pba-d-01-kw2x/Makefile.dep
@@ -1,3 +1,6 @@
+# the board uses the GPIO driver for LED initialization
+FEATURES_REQUIRED += periph_gpio
+
 ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
   USEMODULE += kw2xrf
 endif

--- a/boards/remote-common/Makefile.dep
+++ b/boards/remote-common/Makefile.dep
@@ -1,3 +1,6 @@
+# the board uses the GPIO driver for LED initialization
+FEATURES_REQUIRED += periph_gpio
+
 ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
     USEMODULE += netif
     USEMODULE += cc2538_rf

--- a/boards/saml21-xpro/Makefile.dep
+++ b/boards/saml21-xpro/Makefile.dep
@@ -1,0 +1,2 @@
+# the board uses the GPIO driver to initialize its LED
+FEATURES_REQUIRED += periph_gpio

--- a/boards/samr21-xpro/Makefile.dep
+++ b/boards/samr21-xpro/Makefile.dep
@@ -1,3 +1,6 @@
+# the board uses the GPIO driver for LED initialization
+FEATURES_REQUIRED += periph_gpio
+
 ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
   USEMODULE += at86rf233
 endif

--- a/boards/slwstk6220a/Makefile.dep
+++ b/boards/slwstk6220a/Makefile.dep
@@ -1,0 +1,2 @@
+# the board implementation uses the GPIO driver
+FEATURES_REQUIRED += periph_gpio

--- a/boards/stm32f0discovery/Makefile.dep
+++ b/boards/stm32f0discovery/Makefile.dep
@@ -1,3 +1,6 @@
+# the board uses the GPIO driver for LED initialization
+FEATURES_REQUIRED += periph_gpio
+
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif

--- a/boards/stm32f0discovery/Makefile.include
+++ b/boards/stm32f0discovery/Makefile.include
@@ -2,6 +2,9 @@
 export CPU = stm32f0
 export CPU_MODEL = stm32f051r8
 
+# include dependencies
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep
+
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/stm32f3discovery/Makefile.dep
+++ b/boards/stm32f3discovery/Makefile.dep
@@ -1,3 +1,6 @@
+# the board uses the GPIO driver for LED initialization
+FEATURES_REQUIRED += periph_gpio
+
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif

--- a/boards/stm32f3discovery/Makefile.include
+++ b/boards/stm32f3discovery/Makefile.include
@@ -2,6 +2,9 @@
 export CPU = stm32f3
 export CPU_MODEL = stm32f303vc
 
+# include dependencies
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep
+
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/udoo/Makefile.dep
+++ b/boards/udoo/Makefile.dep
@@ -1,6 +1,2 @@
 # the board uses the GPIO driver for LED initialization
 FEATURES_REQUIRED += periph_gpio
-
-ifneq (,$(filter saul_default,$(USEMODULE)))
-  USEMODULE += saul_gpio
-endif

--- a/boards/udoo/Makefile.include
+++ b/boards/udoo/Makefile.include
@@ -2,6 +2,9 @@
 export CPU = sam3
 export CPU_MODEL = sam3x8e
 
+# include dependencies
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep
+
 #define the flash-tool and default port depending on the host operating system
 OS := $(shell uname)
 ifeq ($(OS),Linux)

--- a/cpu/atmega_common/periph/Makefile
+++ b/cpu/atmega_common/periph/Makefile
@@ -1,3 +1,1 @@
-MODULE = periph
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/cc2538/periph/Makefile
+++ b/cpu/cc2538/periph/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/cc430/periph/Makefile
+++ b/cpu/cc430/periph/Makefile
@@ -1,3 +1,1 @@
-MODULE = periph
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/ezr32wg/Makefile.include
+++ b/cpu/ezr32wg/Makefile.include
@@ -1,3 +1,7 @@
 export CPU_ARCH = cortex-m4f
 
+ifndef (,$(filter periph_uart,$(FEATURES_REQUIRED)))
+  FEATURES_REQUIRED += periph_gpio
+endif
+
 include $(RIOTCPU)/Makefile.include.cortexm_common

--- a/cpu/ezr32wg/periph/Makefile
+++ b/cpu/ezr32wg/periph/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/k60/periph/Makefile
+++ b/cpu/k60/periph/Makefile
@@ -1,3 +1,1 @@
-MODULE = periph
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/k64f/periph/Makefile
+++ b/cpu/k64f/periph/Makefile
@@ -1,3 +1,1 @@
-MODULE = periph
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/kinetis_common/Makefile.include
+++ b/cpu/kinetis_common/Makefile.include
@@ -7,6 +7,11 @@ export LINKFLAGS += -L$(RIOTCPU)/kinetis_common/ldscripts
 # add the CPU specific code for the linker
 export UNDEF += $(BINDIR)/kinetis_common/fcfield.o
 
+# define dependencies between peripheral drivers
+ifndef (,$(filter periph_rtc,$(FEATURES_REQUIRED)))
+  FEATURES_REQUIRED += periph_rtt
+endif
+
 # include kinetis common periph drivers
 export USEMODULE += kinetis_common_periph
 export USEMODULE += periph_common

--- a/cpu/kinetis_common/periph/Makefile
+++ b/cpu/kinetis_common/periph/Makefile
@@ -5,7 +5,7 @@ SRC = mcg.c wdog.c
 
 # hack to get the hwrng in for now, better ideas?
 ifneq (,$(filter periph_hwrng,$(FEATURES_PROVIDED)))
-SRC += hwrng_rnga.c hwrng_rngb.c
+  SRC += hwrng_rnga.c hwrng_rngb.c
 endif
 
 include $(RIOTBASE)/Makefile.periph

--- a/cpu/kinetis_common/periph/Makefile
+++ b/cpu/kinetis_common/periph/Makefile
@@ -1,3 +1,11 @@
 MODULE = kinetis_common_periph
 
-include $(RIOTBASE)/Makefile.base
+# always build the peripheral drivers that are used internally
+SRC = mcg.c wdog.c
+
+# hack to get the hwrng in for now, better ideas?
+ifneq (,$(filter periph_hwrng,$(FEATURES_PROVIDED)))
+SRC += hwrng_rnga.c hwrng_rngb.c
+endif
+
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/kw2x/periph/Makefile
+++ b/cpu/kw2x/periph/Makefile
@@ -1,3 +1,1 @@
-MODULE = periph
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/lm4f120/periph/Makefile
+++ b/cpu/lm4f120/periph/Makefile
@@ -1,3 +1,1 @@
-MODULE = periph
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/lpc11u34/periph/Makefile
+++ b/cpu/lpc11u34/periph/Makefile
@@ -1,3 +1,1 @@
-MODULE = periph
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/lpc1768/periph/Makefile
+++ b/cpu/lpc1768/periph/Makefile
@@ -1,3 +1,1 @@
-MODULE = periph
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/lpc2387/periph/Makefile
+++ b/cpu/lpc2387/periph/Makefile
@@ -1,3 +1,1 @@
-MODULE = periph
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/msp430fxyz/periph/Makefile
+++ b/cpu/msp430fxyz/periph/Makefile
@@ -1,3 +1,1 @@
-MODULE = periph
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -5,6 +5,9 @@ ifeq ($(BUILDOSXNATIVE),1)
     export NATIVEINCLUDES += -I$(RIOTCPU)/native/osx-libc-extra
 endif
 
+# the startup code is using the UART driver
+FEATURES_REQUIRED += periph_uart
+
 export USEMODULE += periph
 
 ifeq ($(shell uname -s),Darwin)

--- a/cpu/native/periph/Makefile
+++ b/cpu/native/periph/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/nrf51/periph/Makefile
+++ b/cpu/nrf51/periph/Makefile
@@ -1,3 +1,1 @@
-MODULE = periph
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/nrf52/periph/Makefile
+++ b/cpu/nrf52/periph/Makefile
@@ -1,3 +1,1 @@
-MODULE = periph
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/nrf5x_common/Makefile.include
+++ b/cpu/nrf5x_common/Makefile.include
@@ -8,5 +8,10 @@ USEMODULE += periph_common
 # include nrf5x common periph drivers
 USEMODULE += nrf5x_common_periph
 
+# the nrfmin driver depends no the CPUID driver
+ifneq (,$(filter nrfmin,$(USEMODULE)))
+  USEMODULE += periph_driver_cpuid
+endif
+
 # export the common include directory
 export INCLUDES += -I$(RIOTCPU)/nrf5x_common/include

--- a/cpu/nrf5x_common/periph/Makefile
+++ b/cpu/nrf5x_common/periph/Makefile
@@ -1,3 +1,3 @@
 MODULE = nrf5x_common_periph
 
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/sam0_common/periph/Makefile
+++ b/cpu/sam0_common/periph/Makefile
@@ -1,3 +1,3 @@
 MODULE = sam0_common_periph
 
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/sam3/periph/Makefile
+++ b/cpu/sam3/periph/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/samd21/periph/Makefile
+++ b/cpu/samd21/periph/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/saml21/periph/Makefile
+++ b/cpu/saml21/periph/Makefile
@@ -1,3 +1,1 @@
-MODULE = periph
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/stm32_common/periph/Makefile
+++ b/cpu/stm32_common/periph/Makefile
@@ -1,3 +1,3 @@
 MODULE = stm32_common_periph
 
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/stm32f0/periph/Makefile
+++ b/cpu/stm32f0/periph/Makefile
@@ -1,3 +1,1 @@
-MODULE = periph
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/stm32f1/Makefile.include
+++ b/cpu/stm32f1/Makefile.include
@@ -3,5 +3,9 @@ export CPU_FAM  = stm32f1
 
 USEMODULE += pm_layered
 
+ifndef (,$(filter periph_uart,$(FEATURES_REQUIRED)))
+  FEATURES_REQUIRED += periph_gpio
+endif
+
 include $(RIOTCPU)/stm32_common/Makefile.include
 include $(RIOTCPU)/Makefile.include.cortexm_common

--- a/cpu/stm32f1/periph/Makefile
+++ b/cpu/stm32f1/periph/Makefile
@@ -1,5 +1,1 @@
-# define the module name
-MODULE = periph
-
-# include RIOTs generic Makefile
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/stm32f3/periph/Makefile
+++ b/cpu/stm32f3/periph/Makefile
@@ -1,3 +1,1 @@
-MODULE = periph
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/stm32f4/Makefile.include
+++ b/cpu/stm32f4/Makefile.include
@@ -3,6 +3,10 @@ export CPU_FAM  = stm32f4
 
 USEMODULE += pm_layered
 
+ifndef (,$(filter periph_uart,$(FEATURES_REQUIRED)))
+  FEATURES_REQUIRED += periph_gpio
+endif
+
 include $(RIOTCPU)/stm32_common/Makefile.include
 
 include $(RIOTCPU)/Makefile.include.cortexm_common

--- a/cpu/stm32f4/periph/Makefile
+++ b/cpu/stm32f4/periph/Makefile
@@ -1,3 +1,1 @@
-MODULE = periph
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/cpu/stm32l1/Makefile.include
+++ b/cpu/stm32l1/Makefile.include
@@ -1,5 +1,9 @@
 export CPU_ARCH = cortex-m3
 export CPU_FAM  = stm32l1
 
+ifndef (,$(filter periph_uart,$(FEATURES_REQUIRED)))
+  FEATURES_REQUIRED += periph_gpio
+endif
+
 include $(RIOTCPU)/stm32_common/Makefile.include
 include $(RIOTCPU)/Makefile.include.cortexm_common

--- a/cpu/stm32l1/periph/Makefile
+++ b/cpu/stm32l1/periph/Makefile
@@ -1,5 +1,1 @@
-# define the module name
-MODULE = periph
-
-# include RIOTs generic Makefile
-include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.periph

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -1,12 +1,12 @@
 # driver dependencies (in alphabetical order)
 
 ifneq (,$(filter adxl345,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_i2c
+    USEMODULE += periph_driver_i2c
 endif
 
 ifneq (,$(filter at30tse75x,$(USEMODULE)))
   USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_i2c
+  USEMODULE += periph_driver_i2c
 endif
 
 ifneq (,$(filter at86rf2%,$(USEMODULE)))
@@ -16,6 +16,8 @@ ifneq (,$(filter at86rf2%,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += ieee802154
   USEMODULE += netdev_ieee802154
+  USEMODULE += periph_driver_gpio
+  USEMODULE += periph_driver_spi
   ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
 	# XXX: this can be modelled as a dependency for gnrc_netdev_default as soon
 	# as all drivers are ported to netdev
@@ -29,27 +31,27 @@ ifneq (,$(filter mrf24j40,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += ieee802154
   USEMODULE += netdev_ieee802154
+  USEMODULE += periph_driver_gpio
+  USEMODULE += periph_driver_spi
   ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
 	# XXX: this can be modelled as a dependency for gnrc_netdev_default as soon
 	# as all drivers are ported to netdev
     USEMODULE += gnrc_netdev
   endif
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_spi
 endif
 
 ifneq (,$(filter bh1750fvi,$(USEMODULE)))
   USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_i2c
+  USEMODULE += periph_driver_i2c
 endif
 
 ifneq (,$(filter bmp180,$(USEMODULE)))
     USEMODULE += xtimer
-    FEATURES_REQUIRED += periph_i2c
+    USEMODULE += periph_driver_i2c
 endif
 
 ifneq (,$(filter bme280,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_i2c
+    USEMODULE += periph_driver_i2c
     USEMODULE += xtimer
 endif
 
@@ -63,8 +65,8 @@ ifneq (,$(filter cc110x,$(USEMODULE)))
 	# as all drivers are ported to netdev
 	USEMODULE += gnrc_netdev
   endif
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_spi
+  USEMODULE += periph_driver_gpio
+  USEMODULE += periph_driver_spi
 endif
 
 ifneq (,$(filter cc2420,$(USEMODULE)))
@@ -78,35 +80,35 @@ ifneq (,$(filter cc2420,$(USEMODULE)))
 	# as all drivers are ported to netdev
     USEMODULE += gnrc_netdev
   endif
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_spi
+  USEMODULE += periph_driver_gpio
+  USEMODULE += periph_driver_spi
 endif
 
 ifneq (,$(filter dht,$(USEMODULE)))
     USEMODULE += xtimer
-    FEATURES_REQUIRED += periph_gpio
+    USEMODULE += periph_driver_gpio
 endif
 
 ifneq (,$(filter enc28j60,$(USEMODULE)))
   USEMODULE += netdev_eth
   USEMODULE += xtimer
   USEMODULE += luid
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_spi
+  USEMODULE += periph_driver_gpio
+  USEMODULE += periph_driver_spi
 endif
 
 ifneq (,$(filter encx24j600,$(USEMODULE)))
   USEMODULE += netdev_eth
   USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_spi
+  USEMODULE += periph_driver_gpio
+  USEMODULE += periph_driver_spi
 endif
 
 ifneq (,$(filter ethos,$(USEMODULE)))
     USEMODULE += netdev_eth
     USEMODULE += random
     USEMODULE += tsrb
-    FEATURES_REQUIRED += periph_uart
+    USEMODULE += periph_driver_uart
 endif
 
 ifneq (,$(filter hdc1000,$(USEMODULE)))
@@ -118,12 +120,12 @@ ifneq (,$(filter hih6130,$(USEMODULE)))
 endif
 
 ifneq (,$(filter io1_xplained,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
+  USEMODULE += periph_driver_gpio
   USEMODULE += at30tse75x
 endif
 
 ifneq (,$(filter jc42,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_i2c
+  USEMODULE += periph_driver_i2c
 endif
 
 ifneq (,$(filter kw2xrf,$(USEMODULE)))
@@ -131,8 +133,8 @@ ifneq (,$(filter kw2xrf,$(USEMODULE)))
     USEMODULE += netif
     USEMODULE += ieee802154
     USEMODULE += netdev_ieee802154
-    FEATURES_REQUIRED += periph_gpio
-    FEATURES_REQUIRED += periph_spi
+    USEMODULE += periph_driver_gpio
+    USEMODULE += periph_driver_spi
     ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
       # XXX: this can be modelled as a dependency for gnrc_netdev_default as soon
       # as all drivers are ported to netdev
@@ -141,12 +143,32 @@ ifneq (,$(filter kw2xrf,$(USEMODULE)))
 endif
 
 ifneq (,$(filter lis3dh,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_gpio
-    FEATURES_REQUIRED += periph_spi
+    USEMODULE += periph_driver_gpio
+    USEMODULE += periph_driver_spi
 endif
 
 ifneq (,$(filter l3g4200d,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
+  USEMODULE += periph_driver_i2c
+  USEMODULE += uuid
+  USEMODULE += netif
+  USEMODULE += ieee802154
+  USEMODULE += netdev2_ieee802154
+  ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+    # XXX: this can be modelled as a dependency for gnrc_netdev_default as soon
+    # as all drivers are ported to netdev2
+    USEMODULE += gnrc_netdev2
+  endif
+  USEMODULE += periph_driver_gpio
+  USEMODULE += periph_driver_spi
+endif
+
+ifneq (,$(filter lis3dh,$(USEMODULE)))
+  USEMODULE += periph_driver_gpio
+  USEMODULE += periph_driver_spi
+endif
+
+ifneq (,$(filter l3g4200d,$(USEMODULE)))
+  USEMODULE += periph_driver_i2c
 endif
 
 ifneq (,$(filter lm75a,$(USEMODULE)))
@@ -155,15 +177,15 @@ endif
 
 ifneq (,$(filter lpd8808,$(USEMODULE)))
     USEMODULE += color
-    FEATURES_REQUIRED += periph_gpio
+    USEMODULE += periph_driver_gpio
 endif
 
 ifneq (,$(filter lps331ap,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
+  USEMODULE += periph_driver_i2c
 endif
 
 ifneq (,$(filter lsm303dlhc,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
+  USEMODULE += periph_driver_i2c
 endif
 
 ifneq (,$(filter ltc4150,$(USEMODULE)))
@@ -171,7 +193,7 @@ ifneq (,$(filter ltc4150,$(USEMODULE)))
 endif
 
 ifneq (,$(filter mma8652,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
+  USEMODULE += periph_driver_i2c
 endif
 
 ifneq (,$(filter mpu9150,$(USEMODULE)))
@@ -180,20 +202,20 @@ endif
 
 ifneq (,$(filter nrfmin,$(USEMODULE)))
     FEATURES_REQUIRED += radio_nrfmin
-    FEATURES_REQUIRED += periph_cpuid
+    USEMODULE += periph_driver_cpuid
     USEMODULE += netif
 endif
 
 ifneq (,$(filter nrf24l01p,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_spi
+  USEMODULE += periph_driver_gpio
+  USEMODULE += periph_driver_spi
 endif
 
 ifneq (,$(filter nvram_spi,$(USEMODULE)))
   USEMODULE += nvram
   USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_spi
-  FEATURES_REQUIRED += periph_gpio
+  USEMODULE += periph_driver_spi
+  USEMODULE += periph_driver_gpio
 endif
 
 ifneq (,$(filter pcd8544,$(USEMODULE)))
@@ -205,17 +227,17 @@ ifneq (,$(filter rgbled,$(USEMODULE)))
 endif
 
 ifneq (,$(filter saul_adc,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_adc
+  USEMODULE += periph_driver_adc
 endif
 
 ifneq (,$(filter saul_gpio,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
+  USEMODULE += periph_driver_gpio
 endif
 
 ifneq (,$(filter sdcard_spi,$(USEMODULE)))
   USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_spi
+  USEMODULE += periph_driver_gpio
+  USEMODULE += periph_driver_spi
 endif
 
 ifneq (,$(filter sht11,$(USEMODULE)))
@@ -224,7 +246,7 @@ endif
 
 ifneq (,$(filter si70xx,$(USEMODULE)))
     USEMODULE += xtimer
-    FEATURES_REQUIRED += periph_i2c
+    USEMODULE += periph_driver_i2c
 endif
 
 ifneq (,$(filter srf02,$(USEMODULE)))
@@ -236,7 +258,7 @@ ifneq (,$(filter srf08,$(USEMODULE)))
 endif
 
 ifneq (,$(filter veml6070,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
+  USEMODULE += periph_driver_i2c
 endif
 
 ifneq (,$(filter w5100,$(USEMODULE)))
@@ -248,6 +270,6 @@ ifneq (,$(filter xbee,$(USEMODULE)))
   USEMODULE += ieee802154
   USEMODULE += xtimer
   USEMODULE += netif
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_uart
+  USEMODULE += periph_driver_gpio
+  USEMODULE += periph_driver_uart
 endif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -34,6 +34,8 @@ ifneq (,$(filter mrf24j40,$(USEMODULE)))
 	# as all drivers are ported to netdev
     USEMODULE += gnrc_netdev
   endif
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_spi
 endif
 
 ifneq (,$(filter bh1750fvi,$(USEMODULE)))
@@ -42,8 +44,8 @@ ifneq (,$(filter bh1750fvi,$(USEMODULE)))
 endif
 
 ifneq (,$(filter bmp180,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_i2c
     USEMODULE += xtimer
+    FEATURES_REQUIRED += periph_i2c
 endif
 
 ifneq (,$(filter bme280,$(USEMODULE)))
@@ -61,6 +63,8 @@ ifneq (,$(filter cc110x,$(USEMODULE)))
 	# as all drivers are ported to netdev
 	USEMODULE += gnrc_netdev
   endif
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_spi
 endif
 
 ifneq (,$(filter cc2420,$(USEMODULE)))
@@ -87,17 +91,22 @@ ifneq (,$(filter enc28j60,$(USEMODULE)))
   USEMODULE += netdev_eth
   USEMODULE += xtimer
   USEMODULE += luid
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_spi
 endif
 
 ifneq (,$(filter encx24j600,$(USEMODULE)))
   USEMODULE += netdev_eth
   USEMODULE += xtimer
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_spi
 endif
 
 ifneq (,$(filter ethos,$(USEMODULE)))
     USEMODULE += netdev_eth
     USEMODULE += random
     USEMODULE += tsrb
+    FEATURES_REQUIRED += periph_uart
 endif
 
 ifneq (,$(filter hdc1000,$(USEMODULE)))
@@ -122,6 +131,8 @@ ifneq (,$(filter kw2xrf,$(USEMODULE)))
     USEMODULE += netif
     USEMODULE += ieee802154
     USEMODULE += netdev_ieee802154
+    FEATURES_REQUIRED += periph_gpio
+    FEATURES_REQUIRED += periph_spi
     ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
       # XXX: this can be modelled as a dependency for gnrc_netdev_default as soon
       # as all drivers are ported to netdev
@@ -134,6 +145,10 @@ ifneq (,$(filter lis3dh,$(USEMODULE)))
     FEATURES_REQUIRED += periph_spi
 endif
 
+ifneq (,$(filter l3g4200d,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
 ifneq (,$(filter lm75a,$(USEMODULE)))
     USEMODULE += xtimer
 endif
@@ -141,6 +156,22 @@ endif
 ifneq (,$(filter lpd8808,$(USEMODULE)))
     USEMODULE += color
     FEATURES_REQUIRED += periph_gpio
+endif
+
+ifneq (,$(filter lps331ap,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
+ifneq (,$(filter lsm303dlhc,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
+ifneq (,$(filter ltc4150,$(USEMODULE)))
+    USEMODULE += xtimer
+endif
+
+ifneq (,$(filter mma8652,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
 endif
 
 ifneq (,$(filter mpu9150,$(USEMODULE)))
@@ -153,9 +184,16 @@ ifneq (,$(filter nrfmin,$(USEMODULE)))
     USEMODULE += netif
 endif
 
+ifneq (,$(filter nrf24l01p,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_spi
+endif
+
 ifneq (,$(filter nvram_spi,$(USEMODULE)))
-    USEMODULE += nvram
-    USEMODULE += xtimer
+  USEMODULE += nvram
+  USEMODULE += xtimer
+  FEATURES_REQUIRED += periph_spi
+  FEATURES_REQUIRED += periph_gpio
 endif
 
 ifneq (,$(filter pcd8544,$(USEMODULE)))
@@ -166,10 +204,18 @@ ifneq (,$(filter rgbled,$(USEMODULE)))
   USEMODULE += color
 endif
 
+ifneq (,$(filter saul_adc,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_adc
+endif
+
+ifneq (,$(filter saul_gpio,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+endif
+
 ifneq (,$(filter sdcard_spi,$(USEMODULE)))
+  USEMODULE += xtimer
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_spi
-  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter sht11,$(USEMODULE)))
@@ -202,4 +248,6 @@ ifneq (,$(filter xbee,$(USEMODULE)))
   USEMODULE += ieee802154
   USEMODULE += xtimer
   USEMODULE += netif
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_uart
 endif

--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -23,7 +23,7 @@
 void periph_init(void)
 {
     /* initialize configured SPI devices */
-#ifdef SPI_NUMOF
+#ifdef MODULE_PERIPH_DRIVER_SPI
     for (unsigned i = 0; i < SPI_NUMOF; i++) {
         spi_init(SPI_DEV(i));
     }


### PR DESCRIPTION
So far, every c file in `RIOTBASE/CPU/periph/*.c` is build. This leads to some not very nice use of file guards around full c files.

This PR improves the situation, as now only the peripherals, that are configured by the board (using the `FEATURES_PROVIDED` var) are actually compiled. This prevents us from having to configure certain peripherals for each board that uses a certain CPU, and from using those anti-pattern file guards.

This PR is a somewhat simplified and limited version of #3420.
