### PR TITLE
unittests/tests-ipv6_nc: remove nbr_sol timer

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -37,8 +37,54 @@ static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
 static gnrc_ipv6_nc_t ncache[GNRC_IPV6_NC_SIZE];
 
+static void _nc_remove(kernel_pid_t iface, gnrc_ipv6_nc_t *entry)
+{
+    (void) iface;
+    if (entry == NULL) {
+        return;
+    }
+
+    DEBUG("ipv6_nc: Remove %s for interface %" PRIkernel_pid "\n",
+          ipv6_addr_to_str(addr_str, ipv6_addr, sizeof(addr_str)),
+          iface);
+
+#ifdef MODULE_GNRC_NDP_NODE
+    while (entry->pkts != NULL) {
+        gnrc_pktbuf_release(entry->pkts->pkt);
+        entry->pkts->pkt = NULL;
+        gnrc_pktqueue_remove_head(&entry->pkts);
+    }
+#endif
+#ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
+    xtimer_remove(&entry->type_timeout);
+
+    gnrc_ipv6_netif_t *if_entry = gnrc_ipv6_netif_get(iface);
+
+    if ((if_entry != NULL) && (if_entry->rtr_adv_msg.content.ptr == (char *) entry)) {
+        /* cancel timer set by gnrc_ndp_rtr_sol_handle */
+        xtimer_remove(&if_entry->rtr_adv_timer);
+    }
+#endif
+#if defined(MODULE_GNRC_NDP_ROUTER) || defined(MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER)
+    xtimer_remove(&entry->rtr_adv_timer);
+#endif
+
+    xtimer_remove(&entry->rtr_timeout);
+    xtimer_remove(&entry->nbr_sol_timer);
+    xtimer_remove(&entry->nbr_adv_timer);
+
+    ipv6_addr_set_unspecified(&(entry->ipv6_addr));
+    entry->iface = KERNEL_PID_UNDEF;
+    entry->flags = 0;
+}
+
 void gnrc_ipv6_nc_init(void)
 {
+    gnrc_ipv6_nc_t *entry;
+
+    for (entry = ncache; entry < (ncache + GNRC_IPV6_NC_SIZE); entry++) {
+        _nc_remove(entry->iface, entry);
+    }
     memset(ncache, 0, sizeof(ncache));
 }
 
@@ -148,41 +194,7 @@ gnrc_ipv6_nc_t *gnrc_ipv6_nc_add(kernel_pid_t iface, const ipv6_addr_t *ipv6_add
 void gnrc_ipv6_nc_remove(kernel_pid_t iface, const ipv6_addr_t *ipv6_addr)
 {
     gnrc_ipv6_nc_t *entry = gnrc_ipv6_nc_get(iface, ipv6_addr);
-
-    if (entry != NULL) {
-        DEBUG("ipv6_nc: Remove %s for interface %" PRIkernel_pid "\n",
-              ipv6_addr_to_str(addr_str, ipv6_addr, sizeof(addr_str)),
-              iface);
-
-#ifdef MODULE_GNRC_NDP_NODE
-        while (entry->pkts != NULL) {
-            gnrc_pktbuf_release(entry->pkts->pkt);
-            entry->pkts->pkt = NULL;
-            gnrc_pktqueue_remove_head(&entry->pkts);
-        }
-#endif
-#ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
-        xtimer_remove(&entry->type_timeout);
-
-        gnrc_ipv6_netif_t *if_entry = gnrc_ipv6_netif_get(iface);
-
-        if ((if_entry != NULL) && (if_entry->rtr_adv_msg.content.ptr == (char *) entry)) {
-            /* cancel timer set by gnrc_ndp_rtr_sol_handle */
-            xtimer_remove(&if_entry->rtr_adv_timer);
-        }
-#endif
-#if defined(MODULE_GNRC_NDP_ROUTER) || defined(MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER)
-        xtimer_remove(&entry->rtr_adv_timer);
-#endif
-
-        xtimer_remove(&entry->rtr_timeout);
-        xtimer_remove(&entry->nbr_sol_timer);
-        xtimer_remove(&entry->nbr_adv_timer);
-
-        ipv6_addr_set_unspecified(&(entry->ipv6_addr));
-        entry->iface = KERNEL_PID_UNDEF;
-        entry->flags = 0;
-    }
+    _nc_remove(iface, entry);
 }
 
 gnrc_ipv6_nc_t *gnrc_ipv6_nc_get(kernel_pid_t iface, const ipv6_addr_t *ipv6_addr)

--- a/tests/unittests/tests-ipv6_nc/tests-ipv6_nc.c
+++ b/tests/unittests/tests-ipv6_nc/tests-ipv6_nc.c
@@ -54,6 +54,13 @@ static void set_up(void)
     gnrc_ipv6_netif_add(DEFAULT_TEST_NETIF);
 }
 
+static void tear_down(void)
+{
+    /* remove all ncache entries, this is necesaary in case
+     * the last test initializes timers. */
+    gnrc_ipv6_nc_init();
+}
+
 static void test_ipv6_nc_add__address_registered(void)
 {
     ipv6_addr_t addr = DEFAULT_TEST_IPV6_ADDR;
@@ -469,7 +476,7 @@ Test *tests_ipv6_nc_tests(void)
         new_TestFixture(test_ipv6_nc_get_l2_addr__reachable),
     };
 
-    EMB_UNIT_TESTCALLER(ipv6_nc_tests, set_up, NULL, fixtures);
+    EMB_UNIT_TESTCALLER(ipv6_nc_tests, set_up, tear_down, fixtures);
 
     return (Test *)&ipv6_nc_tests;
 }


### PR DESCRIPTION
see discussion in https://github.com/RIOT-OS/RIOT/pull/5040#issuecomment-196238132
The `tests-ipv6_nc` unittests seem to segfault in #5040.

Unsetting the timer before the test ends might work in this case.