### PR TITLE
dist: build_and_test.sh: support CI_BASE_BRANCH

### DIFF
--- a/dist/tools/travis-scripts/build_and_test.sh
+++ b/dist/tools/travis-scripts/build_and_test.sh
@@ -77,5 +77,6 @@ then
         #   resolved:
         #   - make -C ./tests/unittests all test BOARD=qemu-i386 || exit
     fi
-    ./dist/tools/compile_test/compile_test.py $TRAVIS_BRANCH
+    BASE_BRANCH="${TRAVIS_BRANCH:-${CI_BASE_BRANCH}}"
+    ./dist/tools/compile_test/compile_test.py $BASE_BRANCH
 fi


### PR DESCRIPTION
```build_and_test.sh``` is able to skip unchanged applications, but only if it knows the base branch of a PR. 

This PR adds support for getting that information from Murdock.