### PR TITLE
pkg: add support for git reference repository

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -51,6 +51,7 @@ buildtest:
 	        BOARD=$${BOARD} \
 	        CCACHE=$${_CCACHE} \
 	        $${CCACHE_DIR:+CCACHE_DIR=$${CCACHE_DIR}} \
+	        $${GIT_REFERENCE:+GIT_REFERENCE="$${GIT_REFERENCE}"} \
 	        CCACHE_BASEDIR=$${CCACHE_BASEDIR} \
 	        RIOTBASE=$${RIOTBASE} \
 	        RIOTBOARD=$${RIOTBOARD} \

--- a/Makefile.vars
+++ b/Makefile.vars
@@ -58,6 +58,7 @@ export RESET_FLAGS           # The parameters to supply to RESET.
 
 export CCACHE_BASEDIR        # ccache basedir, allows multiple riot build
                              # directories to share a ccache directory
+export GIT_REFERENCE         # git cache directory
 
 export DOWNLOAD_TO_FILE      # Use `$(DOWNLOAD_TO_FILE) $(DESTINATION) $(URL)` to download `$(URL)` to `$(DESTINATION)`.
 export DOWNLOAD_TO_STDOUT    # Use `$(DOWNLOAD_TO_STDOUT) $(URL)` to download `$(URL)` output `$(URL)` to stdout, e.g. to be piped into `tar xz`.

--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -20,7 +20,7 @@ all: $(PKG_DIR)/Makefile
 $(PKG_DIR)/Makefile: $(PKG_DIR)/.git/config
 
 $(PKG_DIR)/.git/config:
-	test -d "$(PKG_DIR)" || git clone "$(PKG_URL)" "$(PKG_DIR)"; \
+	test -d "$(PKG_DIR)" || git clone $(GIT_REFERENCE) "$(PKG_URL)" "$(PKG_DIR)"; \
 		cd "$(PKG_DIR)" && \
 		git remote set-url origin "$(PKG_URL)" && \
 		git fetch && git checkout -f "$(PKG_VERSION)"

--- a/pkg/cmsis-dsp/Makefile
+++ b/pkg/cmsis-dsp/Makefile
@@ -16,7 +16,7 @@ $(PKG_DIR)/Makefile: $(PKG_DIR)/.git/config
 	@
 
 $(PKG_DIR)/.git/config:
-	test -d "$(PKG_DIR)" || git clone "$(PKG_URL)" "$(PKG_DIR)"; \
+	test -d "$(PKG_DIR)" || git clone $(GIT_REFERENCE) "$(PKG_URL)" "$(PKG_DIR)"; \
 		cd "$(PKG_DIR)" && git checkout -f "$(PKG_VERSION)"
 
 $(CURDIR)/$(PKG_NAME) $(PKG_NAME):

--- a/pkg/libcoap/Makefile
+++ b/pkg/libcoap/Makefile
@@ -23,7 +23,7 @@ $(PKG_DIR)/Makefile: $(PKG_DIR)/.git/config
 	cd "$(PKG_DIR)" && git am --ignore-whitespace "$(CURDIR)"/*.patch
 
 $(PKG_DIR)/.git/config:
-	test -d "$(PKG_DIR)" || git clone "$(PKG_URL)" "$(PKG_DIR)"; \
+	test -d "$(PKG_DIR)" || git clone $(GIT_REFERENCE) "$(PKG_URL)" "$(PKG_DIR)"; \
 		cd "$(PKG_DIR)" && git checkout -f "$(PKG_VERSION)"
 
 clean::

--- a/pkg/micro-ecc/Makefile
+++ b/pkg/micro-ecc/Makefile
@@ -30,7 +30,7 @@ $(PKG_BUILDDIR)/Makefile: $(PKG_BUILDDIR)
 
 $(PKG_BUILDDIR):
 	mkdir -p $(BINDIR)/pkg && \
-	git clone $(PKG_URL) $@ && \
+	git clone $(GIT_REFERENCE) $(PKG_URL) $@ && \
 		cd $@ && git reset --hard $(PKG_VERSION)
 
 clean::

--- a/pkg/microcoap/Makefile
+++ b/pkg/microcoap/Makefile
@@ -23,7 +23,7 @@ $(PKG_DIR)/Makefile: $(PKG_DIR)/.git/config
 	cd "$(PKG_DIR)" && git am --ignore-whitespace "$(CURDIR)"/*.patch
 
 $(PKG_DIR)/.git/config:
-	test -d "$(PKG_DIR)" || git clone "$(PKG_URL)" "$(PKG_DIR)"; \
+	test -d "$(PKG_DIR)" || git clone $(GIT_REFERENCE) "$(PKG_URL)" "$(PKG_DIR)"; \
 		cd "$(PKG_DIR)" && git checkout -f "$(PKG_VERSION)"
 
 clean::

--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -26,7 +26,7 @@ $(PKG_DIR)/Makefile: $(PKG_DIR)/.git/config
 	cd "$(PKG_DIR)" && git am --ignore-whitespace "$(CURDIR)"/*.patch
 
 $(PKG_DIR)/.git/config:
-	test -d "$(PKG_DIR)" || git clone "$(PKG_URL)" "$(PKG_DIR)"; \
+	test -d "$(PKG_DIR)" || git clone $(GIT_REFERENCE) "$(PKG_URL)" "$(PKG_DIR)"; \
 		cd "$(PKG_DIR)" && git checkout -f "$(PKG_VERSION)"
 
 clean::

--- a/pkg/openwsn/Makefile
+++ b/pkg/openwsn/Makefile
@@ -18,7 +18,7 @@ $(PKG_DIR)/Makefile: $(PKG_DIR)/.git/config
 	cd "$(PKG_DIR)" && git am --ignore-whitespace $(CURDIR)/*.patch
 
 $(PKG_DIR)/.git/config:
-	test -d "$(PKG_DIR)" || git clone "$(PKG_URL)" "$(PKG_DIR)"; \
+	test -d "$(PKG_DIR)" || git clone $(GIT_REFERENCE) "$(PKG_URL)" "$(PKG_DIR)"; \
 		cd "$(PKG_DIR)" && git checkout -f "$(PKG_VERSION)"
 
 clean::

--- a/pkg/relic/Makefile
+++ b/pkg/relic/Makefile
@@ -27,7 +27,7 @@ $(PKG_DIR)/comp-options.cmake: $(PKG_DIR)/.git/config
 $(PKG_DIR)/Makefile: $(PKG_DIR)/comp-options.cmake
 	cd "$(PKG_DIR)" && COMP="$(filter-out -Werror=old-style-definition -Werror=strict-prototypes, $(CFLAGS) ) " cmake -DCMAKE_TOOLCHAIN_FILE=comp-options.cmake -DCHECK=off -DTESTS=0 -DBENCH=0 -DSHLIB=off -Wno-dev $(RELIC_CONFIG_FLAGS) .
 $(PKG_DIR)/.git/config:
-	test -d "$(PKG_DIR)" || git clone "$(PKG_URL)" "$(PKG_DIR)"; \
+	test -d "$(PKG_DIR)" || git clone $(GIT_REFERENCE) "$(PKG_URL)" "$(PKG_DIR)"; \
 		cd "$(PKG_DIR)" && git checkout -f "$(PKG_VERSION)"
 	cd "$(PKG_DIR)" && git am --ignore-whitespace $(CURDIR)/*.patch
 	./fix-util_print_wo_args.sh .

--- a/pkg/wakaama/Makefile
+++ b/pkg/wakaama/Makefile
@@ -15,7 +15,7 @@ $(PKG_DIR)/Makefile: $(PKG_TEMP_DIR)/.git/config
 	echo 'include $$(RIOTBASE)/Makefile.base' > $(PKG_DIR)/Makefile
 
 $(PKG_TEMP_DIR)/.git/config:
-	test -d "$(PKG_TEMP_DIR)" || git clone "$(PKG_URL)" "$(PKG_TEMP_DIR)"; \
+	test -d "$(PKG_TEMP_DIR)" || git clone $(GIT_REFERENCE) "$(PKG_URL)" "$(PKG_TEMP_DIR)"; \
 		cd "$(PKG_TEMP_DIR)" && git checkout -f "$(PKG_VERSION)"; \
 		cd "$(PKG_TEMP_DIR)" && git am --ignore-whitespace "$(CURDIR)"/*.patch; \
 		mkdir -p "$(PKG_DIR)" ; \


### PR DESCRIPTION
Git allows to specify a reference repository to be specified at clone time, causing all objects available there to be taken from there.

Together with a bare git repository somewhere, that enables transparent git object caching.

GIT_REFERENCE is supposed to have the whole parameter, e.g., ```--reference /home/git-cache.git```

This PR exports the variable, passes it on to buildtest and changes the pkg makefiles accordingly.
It should change nothing unless that variable is set.

Murdock will soon cache all git repos locally.