### PR TITLE
drivers/uart: use uint8_t for data in cb signature

### DIFF
--- a/cpu/ezr32wg/periph/uart.c
+++ b/cpu/ezr32wg/periph/uart.c
@@ -101,7 +101,7 @@ void uart_poweroff(uart_t dev)
 static inline void rx_irq(int dev)
 {
     if (_uart(dev)->IF & USART_IF_RXDATAV) {
-        char data = (char)_uart(dev)->RXDATA;
+        uint8_t data = (uint8_t)_uart(dev)->RXDATA;
         isr_ctx[dev].rx_cb(isr_ctx[dev].arg, data);
     }
     if (sched_context_switch_request) {

--- a/cpu/lm4f120/periph/uart.c
+++ b/cpu/lm4f120/periph/uart.c
@@ -135,11 +135,8 @@ void isr_uart0(void)
     {
         while(ROM_UARTCharsAvail(UART0_BASE))
         {
-            char cChar;
-            long lChar;
-            lChar = ROM_UARTCharGetNonBlocking(UART0_BASE);
-            cChar = (unsigned char)(lChar & 0xFF);
-            config[UART_0].rx_cb(config[UART_0].arg, cChar);
+            long lchar = ROM_UARTCharGetNonBlocking(UART0_BASE);
+            config[UART_0].rx_cb(config[UART_0].arg, (uint8_t)lchar);
         }
     }
     if (sched_context_switch_request) {

--- a/cpu/lpc11u34/periph/uart.c
+++ b/cpu/lpc11u34/periph/uart.c
@@ -133,7 +133,7 @@ void uart_poweroff(uart_t uart)
 void UART_0_ISR(void)
 {
     if (UART_0_DEV->LSR & (1 << 0)) {       /* is RDR flag set? */
-        char data = (char)UART_0_DEV->RBR;
+        uint8_t data = (uint8_t)UART_0_DEV->RBR;
         config[UART_0].rx_cb(config[UART_0].arg, data);
     }
     if (sched_context_switch_request) {

--- a/cpu/lpc1768/periph/uart.c
+++ b/cpu/lpc1768/periph/uart.c
@@ -200,7 +200,7 @@ void uart_poweroff(uart_t uart)
 void UART_0_ISR(void)
 {
     if (UART_0_DEV->LSR & (1 << 0)) {       /* is RDR flag set? */
-        char data = (char)UART_0_DEV->RBR;
+        uint8_t data = (uint8_t)UART_0_DEV->RBR;
         config[UART_0].rx_cb(config[UART_0].arg, data);
     }
     if (sched_context_switch_request) {
@@ -213,7 +213,7 @@ void UART_0_ISR(void)
 void UART_1_ISR(void)
 {
     if (UART_1_DEV->LSR & (1 << 0)) {       /* is RDR flag set? */
-        char data = (char)UART_1_DEV->RBR;
+        uint8_t data = (uint8_t)UART_1_DEV->RBR;
         config[UART_1].rx_cb(config[UART_1].arg, data);
     }
     if (sched_context_switch_request) {

--- a/cpu/lpc2387/periph/uart.c
+++ b/cpu/lpc2387/periph/uart.c
@@ -84,7 +84,7 @@ void UART0_IRQHandler(void)
         case UIIR_CTI_INT:              /* Character Timeout Indicator */
         case UIIR_RDA_INT:              /* Receive Data Available */
                 do {
-                    char c = (char)U0RBR;
+                    uint8_t c = (uint8_t)U0RBR;
                     _rx_cb(_cb_arg, c);
                 } while (U0LSR & ULSR_RDR);
             break;

--- a/cpu/msp430fxyz/periph/uart.c
+++ b/cpu/msp430fxyz/periph/uart.c
@@ -204,7 +204,7 @@ ISR(UART_RX_ISR, isr_uart_0_rx)
     __enter_isr();
 
     uint8_t stat = UART_BASE->ASTAT;
-    char data = (char)UART_BASE->ARXBUF;
+    uint8_t data = (uint8_t)UART_BASE->ARXBUF;
 
     if (stat & (USCI_ASTAT_FE | USCI_ASTAT_OE | USCI_ASTAT_PE | USCI_ASTAT_BRK)) {
         /* some error which we do not handle, just do a pseudo read to reset the

--- a/cpu/nrf5x_common/periph/uart.c
+++ b/cpu/nrf5x_common/periph/uart.c
@@ -167,7 +167,7 @@ void isr_uart0(void)
 {
     if (NRF_UART0->EVENTS_RXDRDY == 1) {
         NRF_UART0->EVENTS_RXDRDY = 0;
-        char byte = (char)(NRF_UART0->RXD & 0xff);
+        uint8_t byte = (uint8_t)(NRF_UART0->RXD & 0xff);
         uart_config.rx_cb(uart_config.arg, byte);
     }
     if (sched_context_switch_request) {

--- a/cpu/sam3/periph/uart.c
+++ b/cpu/sam3/periph/uart.c
@@ -99,7 +99,7 @@ static inline void isr_handler(int num)
     Uart *dev = uart_config[num].dev;
 
     if (dev->UART_SR & UART_SR_RXRDY) {
-        ctx[num].rx_cb(ctx[num].arg, (char)dev->UART_RHR);
+        ctx[num].rx_cb(ctx[num].arg, (uint8_t)dev->UART_RHR);
     }
     if (sched_context_switch_request) {
         thread_yield();

--- a/cpu/samd21/periph/uart.c
+++ b/cpu/samd21/periph/uart.c
@@ -135,7 +135,7 @@ static inline void irq_handler(int dev)
 
     if (uart->INTFLAG.reg & SERCOM_USART_INTFLAG_RXC) {
         /* interrupt flag is cleared by reading the data register */
-        uart_ctx[dev].rx_cb(uart_ctx[dev].arg, (char)(uart->DATA.reg));
+        uart_ctx[dev].rx_cb(uart_ctx[dev].arg, (uint8_t)(uart->DATA.reg));
     }
     else if (uart->INTFLAG.reg & SERCOM_USART_INTFLAG_ERROR) {
         /* clear error flag */

--- a/cpu/saml21/periph/uart.c
+++ b/cpu/saml21/periph/uart.c
@@ -136,7 +136,7 @@ static inline void irq_handler(uint8_t uartnum, SercomUsart *dev)
 {
     if (dev->INTFLAG.bit.RXC) {
         /* cleared by reading DATA regiser */
-        char data = (char)dev->DATA.reg;
+        uint8_t data = (uint8_t)dev->DATA.reg;
         uart_config[uartnum].rx_cb(uart_config[uartnum].arg, data);
     }
     else if (dev->INTFLAG.bit.ERROR) {

--- a/cpu/stm32f0/periph/uart.c
+++ b/cpu/stm32f0/periph/uart.c
@@ -191,7 +191,7 @@ void uart_poweroff(uart_t uart)
 static inline void irq_handler(uint8_t uartnum, USART_TypeDef *dev)
 {
     if (dev->ISR & USART_ISR_RXNE) {
-        char data = (char)dev->RDR;
+        uint8_t data = (uint8_t)dev->RDR;
         uart_config[uartnum].rx_cb(uart_config[uartnum].arg, data);
     }
     else if (dev->ISR & USART_ISR_ORE) {

--- a/cpu/stm32f1/periph/uart.c
+++ b/cpu/stm32f1/periph/uart.c
@@ -147,7 +147,7 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 static inline void irq_handler(uart_t uartnum, USART_TypeDef *dev)
 {
     if (dev->SR & USART_SR_RXNE) {
-        char data = (char)dev->DR;
+        uint8_t data = (uint8_t)dev->DR;
         config[uartnum].rx_cb(config[uartnum].arg, data);
     }
     else if (dev->SR & USART_SR_ORE) {

--- a/cpu/stm32f3/periph/uart.c
+++ b/cpu/stm32f3/periph/uart.c
@@ -187,7 +187,7 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 static inline void irq_handler(uint8_t uartnum, USART_TypeDef *dev)
 {
     if (dev->ISR & USART_ISR_RXNE) {
-        char data = (char)dev->RDR;
+        uint8_t data = (uint8_t)dev->RDR;
         uart_config[uartnum].rx_cb(uart_config[uartnum].arg, data);
     }
     else if (dev->ISR & USART_ISR_ORE) {

--- a/cpu/stm32f4/periph/uart.c
+++ b/cpu/stm32f4/periph/uart.c
@@ -165,7 +165,7 @@ void uart_poweroff(uart_t uart)
 static inline void irq_handler(int uart, USART_TypeDef *dev)
 {
     if (dev->SR & USART_SR_RXNE) {
-        char data = (char)dev->DR;
+        uint8_t data = (uint8_t)dev->DR;
         uart_ctx[uart].rx_cb(uart_ctx[uart].arg, data);
     }
     if (sched_context_switch_request) {

--- a/cpu/stm32l1/periph/uart.c
+++ b/cpu/stm32l1/periph/uart.c
@@ -166,7 +166,7 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 static inline void irq_handler(uint8_t uartnum, USART_TypeDef *dev)
 {
     if (dev->SR & USART_SR_RXNE) {
-        char data = (char)dev->DR;
+        uint8_t data = (uint8_t)dev->DR;
         uart_config[uartnum].rx_cb(uart_config[uartnum].arg, data);
     }
     if (sched_context_switch_request) {

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -40,7 +40,7 @@
 #include "debug.h"
 
 static void _get_mac_addr(netdev2_t *dev, uint8_t* buf);
-static void ethos_isr(void *arg, char c);
+static void ethos_isr(void *arg, uint8_t c);
 const static netdev2_driver_t netdev2_driver_ethos;
 
 static const uint8_t _esc_esc[] = {ETHOS_ESC_CHAR, (ETHOS_ESC_CHAR ^ 0x20)};
@@ -126,7 +126,7 @@ static void _end_of_frame(ethos_t *dev)
     _reset_state(dev);
 }
 
-static void ethos_isr(void *arg, char c)
+static void ethos_isr(void *arg, uint8_t c)
 {
     ethos_t *dev = (ethos_t *) arg;
 

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -98,7 +98,7 @@ typedef unsigned int uart_t;
  * @param[in] arg           context to the callback (optional)
  * @param[in] data          the byte that was received
  */
-typedef void(*uart_rx_cb_t)(void *arg, char data);
+typedef void(*uart_rx_cb_t)(void *arg, uint8_t data);
 
 /**
  * @brief   Interrupt context for a UART device

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -136,9 +136,8 @@ static void _api_at_cmd(xbee_t *dev, uint8_t *cmd, uint8_t size, resp_t *resp)
 /*
  * Interrupt callbacks
  */
-static void _rx_cb(void *arg, char _c)
+static void _rx_cb(void *arg, uint8_t c)
 {
-    unsigned char c = _c;
     xbee_t *dev = (xbee_t *)arg;
     msg_t msg;
 
@@ -154,7 +153,7 @@ static void _rx_cb(void *arg, char _c)
             dev->int_state = XBEE_INT_STATE_SIZE2;
             break;
         case XBEE_INT_STATE_SIZE2:
-            dev->int_size += (uint8_t)c;
+            dev->int_size += c;
             dev->int_state = XBEE_INT_STATE_TYPE;
             break;
         case XBEE_INT_STATE_TYPE:
@@ -165,7 +164,7 @@ static void _rx_cb(void *arg, char _c)
                     return;
                 }
                 dev->rx_limit = dev->int_size + 1;
-                dev->rx_buf[dev->rx_count++] = (uint8_t)c;
+                dev->rx_buf[dev->rx_count++] = c;
                 dev->int_state = XBEE_INT_STATE_RX;
             }
             else if (c == API_ID_AT_RESP) {
@@ -177,7 +176,7 @@ static void _rx_cb(void *arg, char _c)
             }
             break;
         case XBEE_INT_STATE_RESP:
-            dev->resp_buf[dev->resp_count++] = (uint8_t)c;
+            dev->resp_buf[dev->resp_count++] = c;
             if (dev->resp_count == dev->resp_limit) {
                 /* here we ignore the checksum to prevent deadlocks */
                 mutex_unlock(&(dev->resp_lock));
@@ -185,7 +184,7 @@ static void _rx_cb(void *arg, char _c)
             }
             break;
         case XBEE_INT_STATE_RX:
-            dev->rx_buf[dev->rx_count++] = (uint8_t)c;
+            dev->rx_buf[dev->rx_count++] = c;
             if (dev->rx_count == dev->rx_limit) {
                 /* packet is complete */
                 msg.type = GNRC_NETDEV_MSG_TYPE_EVENT;

--- a/sys/arduino/serialport.cpp
+++ b/sys/arduino/serialport.cpp
@@ -27,10 +27,10 @@ extern "C" {
 
 #include "serialport.hpp"
 
-void rx_cb(void *arg, char c)
+void rx_cb(void *arg, uint8_t c)
 {
     ringbuffer_t *buf = (ringbuffer_t *)arg;
-    ringbuffer_add_one(buf, c);
+    ringbuffer_add_one(buf, (char)c);
 }
 
 SerialPort::SerialPort(uart_t dev)

--- a/sys/include/uart_stdio.h
+++ b/sys/include/uart_stdio.h
@@ -81,7 +81,7 @@ int uart_stdio_write(const char* buffer, int len);
  * @param[in]   arg     (unused)
  * @param[in]   data    character that has been received
  */
-void uart_stdio_rx_cb(void *arg, char data);
+void uart_stdio_rx_cb(void *arg, uint8_t data);
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/link_layer/slip/gnrc_slip.c
+++ b/sys/net/gnrc/link_layer/slip/gnrc_slip.c
@@ -50,9 +50,9 @@
 #define _SLIP_DEV(arg)    ((gnrc_slip_dev_t *)arg)
 
 /* UART callbacks */
-static void _slip_rx_cb(void *arg, char data)
+static void _slip_rx_cb(void *arg, uint8_t data)
 {
-    if (data == _SLIP_END) {
+    if (data == (uint8_t)_SLIP_END) {
         msg_t msg;
 
         msg.type = _SLIP_MSG_TYPE;
@@ -66,14 +66,14 @@ static void _slip_rx_cb(void *arg, char data)
         _SLIP_DEV(arg)->in_esc = 0;
 
         switch (data) {
-            case (_SLIP_END_ESC):
+            case ((uint8_t)_SLIP_END_ESC):
                 if (ringbuffer_add_one(&_SLIP_DEV(arg)->in_buf, _SLIP_END) < 0) {
                     _SLIP_DEV(arg)->in_bytes++;
                 }
 
                 break;
 
-            case (_SLIP_ESC_ESC):
+            case ((uint8_t)_SLIP_ESC_ESC):
                 if (ringbuffer_add_one(&_SLIP_DEV(arg)->in_buf, _SLIP_ESC) < 0) {
                     _SLIP_DEV(arg)->in_bytes++;
                 }
@@ -84,7 +84,7 @@ static void _slip_rx_cb(void *arg, char data)
                 break;
         }
     }
-    else if (data == _SLIP_ESC) {
+    else if (data == (uint8_t)_SLIP_ESC) {
         _SLIP_DEV(arg)->in_esc = 1;
     }
     else {

--- a/sys/uart_stdio/uart_stdio.c
+++ b/sys/uart_stdio/uart_stdio.c
@@ -52,10 +52,10 @@ static tsrb_t _rx_buf = TSRB_INIT(_rx_buf_mem);
 /**
  * @brief Receive a new character from the UART and put it into the receive buffer
  */
-void uart_stdio_rx_cb(void *arg, char data)
+void uart_stdio_rx_cb(void *arg, uint8_t data)
 {
     (void)arg;
-    tsrb_add_one(&_rx_buf, data);
+    tsrb_add_one(&_rx_buf, (uint8_t)data);
     mutex_unlock(&_rx_mutex);
 }
 

--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -63,7 +63,7 @@ static int parse_dev(char *arg)
     return dev;
 }
 
-static void rx_cb(void *arg, char data)
+static void rx_cb(void *arg, uint8_t data)
 {
     int dev = (int)arg;
 


### PR DESCRIPTION
found this little inconsistency in the UART interface, as all other peripheral drivers are using `uint8_t` as byte type.

For merging this, I think it a good code review and a happy build test should be fine.