### PR TITLE
board/axavior: Initial import for AxAvior

### DIFF
--- a/boards/axavior/Makefile
+++ b/boards/axavior/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/axavior/Makefile.dep
+++ b/boards/axavior/Makefile.dep
@@ -1,0 +1,12 @@
+ifneq (,$(filter gnrc_netif_default,$(USEMODULE)))
+  USEMODULE += at86rf212b
+  USEMODULE += gnrc_nomac
+endif
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+# The AxAvior uses NVRAM to store persistent variables, such as boot count.
+USEMODULE += nvram_spi
+FEATURES_REQUIRED += periph_spi

--- a/boards/axavior/Makefile.features
+++ b/boards/axavior/Makefile.features
@@ -1,0 +1,17 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_dac
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/axavior/Makefile.include
+++ b/boards/axavior/Makefile.include
@@ -1,0 +1,17 @@
+# the cpu to build for
+export CPU = stm32f1
+export CPU_MODEL = stm32f101rd
+
+# define the default port depending on the host OS
+PORT_LINUX ?= /dev/ttyUSB1
+PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbserial* | head -n 1)
+
+# setup serial terminal
+export BAUD = 115200
+include $(RIOTBOARD)/Makefile.include.serial
+
+# this board uses openocd
+include $(RIOTBOARD)/Makefile.include.openocd
+
+# include board dependencies
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/axavior/board.c
+++ b/boards/axavior/board.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2016 Engineering-Spirit
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_axavior
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the AxAvior board
+ *
+ * @author      Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "cpu.h"
+#include "nvram.h"
+#include "xtimer.h"
+#include "nvram-spi.h"
+
+#include "periph/spi.h"
+
+static void leds_init(void);
+static int nvram_init(void);
+
+static nvram_t axavior_nvram_dev;
+nvram_t *axavior_nvram = &axavior_nvram_dev;
+static nvram_spi_params_t nvram_spi_params = {
+        .spi = EXTFLASH_SPI,
+        .cs = EXTFLASH_CS,
+        .address_count = EXTFLASH_ADDRESS_COUNT,
+};
+
+void board_init(void)
+{
+    /* disable the JTAG interface because we use SWD */
+    RCC->APB2ENR |= RCC_APB2ENR_AFIOEN;
+    AFIO->MAPR |= AFIO_MAPR_SWJ_CFG_JTAGDISABLE;
+
+    /* initialize the CPU */
+    cpu_init();
+
+    /* initialize the boards LEDs */
+    leds_init();
+
+    /* initialize the NVRAM */
+    nvram_init();
+}
+
+/**
+ * @brief Initialize the boards on-board LEDs
+ *
+ * The LEDs initialization is hard-coded in this function. As the LED is soldered
+ * onto the board it is fixed to its CPU pins.
+ *
+ * The LEDs are connected to the following pin:
+ * - Green:     PB3
+ */
+static void leds_init(void)
+{
+    gpio_init(LED_GREEN_GPIO, GPIO_DIR_OUT, GPIO_NOPULL);
+    LED_GREEN_ON;
+}
+
+/**
+ * @brief Initialize the on-module SPI flash chip
+ */
+static int nvram_init(void)
+{
+    union {
+        uint32_t u32;
+        uint8_t  u8[sizeof(uint32_t)];
+    } rec;
+    rec.u32 = 0;
+
+    if (spi_init_master(EXTFLASH_SPI, SPI_CONF_FIRST_RISING, SPI_SPEED_5MHZ) != 0) {
+        return -1;
+    }
+
+    if (nvram_spi_init(axavior_nvram, &nvram_spi_params, EXTFLASH_CAPACITY) != 0) {
+        return -2;
+    }
+
+    if (axavior_nvram->read(axavior_nvram, &rec.u8[0], 0, sizeof(rec.u32)) != sizeof(rec.u32)) {
+        return -3;
+    }
+
+    return 0;
+}

--- a/boards/axavior/dist/openocd.cfg
+++ b/boards/axavior/dist/openocd.cfg
@@ -1,0 +1,8 @@
+interface ftdi
+ftdi_vid_pid 0x0403 0x6010
+
+ftdi_layout_init 0x0c08 0x0c2b
+ftdi_layout_signal nTRST -data 0x0800
+ftdi_layout_signal nSRST -data 0x0400
+
+source [find target/stm32f1x.cfg]

--- a/boards/axavior/include/board.h
+++ b/boards/axavior/include/board.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2016 Engineering-Spirit
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    boards_axavior AxAvior Module
+ * @ingroup     boards
+ * @brief       Board specific files for the AxAvior Module.
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the AxAvior module.
+ *
+ * @author      Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ */
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+#include <stdint.h>
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Tell the xtimer that we use a 16-bit peripheral timer
+ */
+#define XTIMER_MASK         (0xffff0000)
+
+/**
+ * @name Define the interface to the AT86RF231 radio
+ *
+ * {spi bus, spi speed, cs pin, int pin, reset pin, sleep pin}
+ */
+#define AT86RF2XX_PARAMS_BOARD      {.spi = SPI_0, \
+                                     .spi_speed = SPI_SPEED_5MHZ, \
+                                     .cs_pin = GPIO_PIN(PORT_C,8), \
+                                     .int_pin = GPIO_PIN(PORT_C,7), \
+                                     .sleep_pin = GPIO_PIN(PORT_C,11), \
+                                     .reset_pin = GPIO_PIN(PORT_C,10)}
+
+/**
+ * @name Define the interface for the connected flash memory
+ * @{
+ */
+#define EXTFLASH_SPI                SPI_0
+#define EXTFLASH_CS                 GPIO_PIN(PORT_B,12)
+#define EXTFLASH_ADDRESS_COUNT      (3)
+#define EXTFLASH_CAPACITY           (500000)
+/** @} */
+
+/**
+ * @name Define the interface for the joystick
+ * @{
+ */
+#define JOYSTICK_SPI                SPI_1
+#define JOYSTICK_CS                 GPIO_PIN(PORT_B, 0)
+/** @} */
+
+/**
+ * @brief Define the DTR and DSR lines
+ */
+#define COMM_DSR                    GPIO_PIN(PORT_C, 4)
+#define COMM_DTR                    GPIO_PIN(PORT_C, 5)
+
+/**
+ * @name LED pin definitions
+ * @{
+ */
+#define LED_GREEN_PORT      (GPIOB)
+#define LED_GREEN_PIN       (3)
+#define LED_GREEN_GPIO      GPIO_PIN(PORT_B,3)
+/** @} */
+
+/**
+ * @name Macros for controlling the on-board LEDs.
+ * @{
+ */
+#define LED_GREEN_ON        (LED_GREEN_PORT->BSRR = (16+(1<<LED_GREEN_PIN)))
+#define LED_GREEN_OFF       (LED_GREEN_PORT->BSRR = (1<<LED_GREEN_PIN))
+#define LED_GREEN_TOGGLE    (LED_GREEN_PORT->ODR ^= (1<<LED_GREEN_PIN))
+/** @} */
+
+/**
+ * @name xtimer tuning values
+ * @{
+ */
+#define XTIMER_OVERHEAD     6
+#define XTIMER_SHOOT_EARLY  3
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H_ */
+/** @} */

--- a/boards/axavior/include/gpio_params.h
+++ b/boards/axavior/include/gpio_params.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_iotlab-m3
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(green)",
+        .pin = LED_GREEN_GPIO,
+        .dir = GPIO_DIR_OUT,
+        .pull = GPIO_NOPULL,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/axavior/include/periph_conf.h
+++ b/boards/axavior/include/periph_conf.h
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2015 Engineering-Spirit
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_axavior
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the AxAvior module
+ *
+ * @author      Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ */
+
+#ifndef PERIPH_CONF_H_
+#define PERIPH_CONF_H_
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Clock system configuration
+ * @{
+ **/
+#define CLOCK_HSI           (8000000U)              /* frequency of external oscillator */
+#define CLOCK_CORECLOCK     (36000000U)             /* targeted core clock frequency */
+/* configuration of PLL prescaler and multiply values */
+/* CORECLOCK := CLOCK_SOURCE / PLL_DIV * PLL_MUL */
+#define CLOCK_PLL_DIV       (0)
+#define CLOCK_PLL_MUL       RCC_CFGR_PLLMULL9
+/* configuration of peripheral bus clock prescalers */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1      /* AHB clock -> 36MHz */
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* APB2 clock -> 36MHz */
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV1     /* APB1 clock -> 36MHz */
+/* configuration of flash access cycles */
+#define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY_1
+/** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_CONFIG          {       \
+    { GPIO_UNDEF        , 0, 16 },  \
+    { GPIO_UNDEF        , 0, 17 } }
+
+#define ADC_NUMOF           (3)
+/** @} */
+
+/**
+ * @name DAC configuration
+ * @{
+ */
+#define DAC_CONFIG          {       \
+    { GPIO_PIN(PORT_A, 5), 1 } }
+
+#define DAC_NUMOF           (1)
+/** @} */
+
+/**
+ * @brief Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    /* device, APB bus, rcc_bit */
+    { TIM4, APB1, RCC_APB1ENR_TIM4EN, TIM4_IRQn },
+    { TIM5, APB1, RCC_APB1ENR_TIM5EN, TIM5_IRQn }
+};
+
+#define TIMER_0_ISR         isr_tim4
+#define TIMER_1_ISR         isr_tim5
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+ * @brief UART configuration
+ * @{
+ */
+#define UART_NUMOF          (2U)
+#define UART_0_EN           1
+#define UART_1_EN           1
+#define UART_IRQ_PRIO       1
+
+/* UART 0 device configuration */
+#define UART_0_DEV          USART3
+#define UART_0_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART3EN)
+#define UART_0_IRQ          USART3_IRQn
+#define UART_0_ISR          isr_usart3
+#define UART_0_BUS_FREQ     36000000
+/* UART 0 pin configuration */
+#define UART_0_RX_PIN       GPIO_PIN(PORT_B,11)
+#define UART_0_TX_PIN       GPIO_PIN(PORT_B,10)
+
+/* UART 1 device configuration */
+#define UART_1_DEV          USART1
+#define UART_1_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_USART1EN)
+#define UART_1_IRQ          USART1_IRQn
+#define UART_1_ISR          isr_usart1
+#define UART_1_BUS_FREQ     36000000
+/* UART 1 pin configuration */
+#define UART_1_RX_PIN       GPIO_PIN(PORT_A,10)
+#define UART_1_TX_PIN       GPIO_PIN(PORT_A,9)
+#define UART_1_RTS_PIN      GPIO_PIN(PORT_A,12)
+#define UART_1_CTS_PIN      GPIO_PIN(PORT_A,11)
+/** @} */
+
+/**
+ * @brief SPI configuration
+ * @{
+ */
+#define SPI_NUMOF           (2U)
+#define SPI_0_EN            1
+#define SPI_1_EN            1
+
+/* SPI 0 device configuration */
+#define SPI_0_DEV           SPI2
+#define SPI_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_SPI2EN)
+#define SPI_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_SPI2EN))
+#define SPI_0_BUS_DIV       1   /* 1 -> SPI runs with full CPU clock, 0 -> half CPU clock */
+/* SPI 0 pin configuration */
+#define SPI_0_CLK_PIN       GPIO_PIN(PORT_B,13)
+#define SPI_0_MOSI_PIN      GPIO_PIN(PORT_B,15)
+#define SPI_0_MISO_PIN      GPIO_PIN(PORT_B,14)
+
+/* SPI 1 device configuration */
+#define SPI_1_DEV           SPI1
+#define SPI_1_CLKEN()       (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
+#define SPI_1_CLKDIS()      (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI1EN))
+#define SPI_1_BUS_DIV       1   /* 1 -> SPI runs with full CPU clock, 0 -> half CPU clock */
+/* SPI 1 pin configuration */
+#define SPI_1_CLK_PIN       GPIO_PIN(PORT_A,5)
+#define SPI_1_MOSI_PIN      GPIO_PIN(PORT_A,7)
+#define SPI_1_MISO_PIN      GPIO_PIN(PORT_A,6)
+/** @} */
+
+/**
+ * @name Real time counter configuration
+ * @{
+ */
+#define RTT_NUMOF           (1U)
+#define RTT_IRQ_PRIO        1
+
+#define RTT_DEV             RTC
+#define RTT_IRQ             RTC_IRQn
+#define RTT_ISR             isr_rtc
+#define RTT_MAX_VALUE       (0xffffffff)
+#define RTT_FREQUENCY       (1)             /* in Hz */
+#define RTT_PRESCALER       (0x7fff)        /* run with 1 Hz */
+/** @} */
+
+/**
+ * @name I2C configuration
+  * @{
+ */
+#define I2C_NUMOF           (1U)
+#define I2C_0_EN            1
+#define I2C_IRQ_PRIO        1
+#define I2C_APBCLK          (36000000U)
+
+/* I2C 0 device configuration */
+#define I2C_0_DEV           I2C1
+#define I2C_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C1EN)
+#define I2C_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
+#define I2C_0_EVT_IRQ       I2C1_EV_IRQn
+#define I2C_0_EVT_ISR       isr_i2c1_ev
+#define I2C_0_ERR_IRQ       I2C1_ER_IRQn
+#define I2C_0_ERR_ISR       isr_i2c1_er
+/* I2C 0 pin configuration */
+#define I2C_0_SCL_PIN       GPIO_PIN(PORT_B,6)
+#define I2C_0_SDA_PIN       GPIO_PIN(PORT_B,7)
+/** @} */
+
+/**
+ * @brief PWM configuration
+ * @{
+ */
+#define PWM_EN              1
+
+static const pwm_conf_t pwm_config[] =
+{
+    { TIM3, AFIO_MAPR_TIM3_REMAP_PARTIALREMAP, 1, 1, {
+            { GPIO_PIN(PORT_B, 4), 0 },
+            { GPIO_PIN(PORT_B, 5), 1 },
+            { GPIO_PIN(PORT_B, 0), 2 },
+            { GPIO_PIN(PORT_B, 1), 3 },
+    } }
+};
+#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H_ */
+/** @} */

--- a/boards/axavior/include/periph_conf.h
+++ b/boards/axavior/include/periph_conf.h
@@ -39,6 +39,9 @@ extern "C" {
 #define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1      /* AHB clock -> 36MHz */
 #define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* APB2 clock -> 36MHz */
 #define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV1     /* APB1 clock -> 36MHz */
+/* resulting bus clocks */
+#define CLOCK_APB1          (CLOCK_CORECLOCK)
+#define CLOCK_APB2          (CLOCK_CORECLOCK)
 /* configuration of flash access cycles */
 #define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY_1
 /** @} */
@@ -81,35 +84,35 @@ static const timer_conf_t timer_config[] = {
 /** @} */
 
 /**
- * @brief UART configuration
+ * @brief   UART configuration
  * @{
  */
-#define UART_NUMOF          (2U)
-#define UART_0_EN           1
-#define UART_1_EN           1
-#define UART_IRQ_PRIO       1
+static const uart_conf_t uart_config[] = {
+    {
+        .dev     = USART3,
+        .rx_pin  = GPIO_PIN(PORT_B,11),
+        .tx_pin  = GPIO_PIN(PORT_B,10),
+        .rcc_pin = RCC_APB1ENR_USART3EN,
+        .bus     = APB1,
+        .irqn    = USART3_IRQn
+    },
+    {
+        .dev     = USART1,
+        .rx_pin  = GPIO_PIN(PORT_A,10),
+        .tx_pin  = GPIO_PIN(PORT_A,9),
+        .rcc_pin = RCC_APB2ENR_USART1EN,
+        .bus     = APB2,
+        .irqn    = USART1_IRQn
+    }
+};
 
-/* UART 0 device configuration */
-#define UART_0_DEV          USART3
-#define UART_0_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART3EN)
-#define UART_0_IRQ          USART3_IRQn
 #define UART_0_ISR          isr_usart3
-#define UART_0_BUS_FREQ     36000000
-/* UART 0 pin configuration */
-#define UART_0_RX_PIN       GPIO_PIN(PORT_B,11)
-#define UART_0_TX_PIN       GPIO_PIN(PORT_B,10)
-
-/* UART 1 device configuration */
-#define UART_1_DEV          USART1
-#define UART_1_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_USART1EN)
-#define UART_1_IRQ          USART1_IRQn
 #define UART_1_ISR          isr_usart1
-#define UART_1_BUS_FREQ     36000000
-/* UART 1 pin configuration */
-#define UART_1_RX_PIN       GPIO_PIN(PORT_A,10)
-#define UART_1_TX_PIN       GPIO_PIN(PORT_A,9)
+
 #define UART_1_RTS_PIN      GPIO_PIN(PORT_A,12)
 #define UART_1_CTS_PIN      GPIO_PIN(PORT_A,11)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */
 
 /**

--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -51,6 +51,12 @@ extern "C" {
  * @{
  */
 #define ADC_NUMOF           (0)
+
+/**
+ * @brief   DAC configuration
+ * @{
+ */
+#define DAC_NUMOF           (0)
 /** @} */
 
 /**

--- a/boards/iotlab-m3/Makefile.features
+++ b/boards/iotlab-m3/Makefile.features
@@ -2,6 +2,7 @@
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/iotlab-m3/include/periph_conf.h
+++ b/boards/iotlab-m3/include/periph_conf.h
@@ -159,6 +159,30 @@ static const uart_conf_t uart_config[] = {
 #define I2C_0_SDA_PIN       GPIO_PIN(PORT_B,7)
 /** @} */
 
+/**
+ * @brief PWM configuration
+ * @{
+ */
+#define PWM_NUMOF           (1U)
+#define PWM_0_EN            1
+
+#define PWM_MAX_CHANNELS    4
+
+/* PWM 0 device configuration */
+#define PWM_0_DEV           TIM4
+#define PWM_0_CHANNELS      4
+#define PWM_0_CLK           (36000000U)
+#define PWM_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_TIM4EN)
+#define PWM_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM4EN))
+/* PWM 0 pin configuration */
+#define PWM_0_PORT          GPIOB
+#define PWM_0_PORT_CLKEN()  (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
+#define PWM_0_PIN_CH0       6
+#define PWM_0_PIN_CH1       7
+#define PWM_0_PIN_CH2       8
+#define PWM_0_PIN_CH3       9
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/iotlab-m3/include/periph_conf.h
+++ b/boards/iotlab-m3/include/periph_conf.h
@@ -163,24 +163,15 @@ static const uart_conf_t uart_config[] = {
  * @brief PWM configuration
  * @{
  */
-#define PWM_NUMOF           (1U)
-#define PWM_0_EN            1
+#define PWM_EN              1
 
-#define PWM_MAX_CHANNELS    4
-
-/* PWM 0 device configuration */
-#define PWM_0_DEV           TIM4
-#define PWM_0_CHANNELS      4
-#define PWM_0_CLK           (36000000U)
-#define PWM_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_TIM4EN)
-#define PWM_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM4EN))
-/* PWM 0 pin configuration */
-#define PWM_0_PORT          GPIOB
-#define PWM_0_PORT_CLKEN()  (RCC->APB2ENR |= RCC_APB2ENR_IOPBEN)
-#define PWM_0_PIN_CH0       6
-#define PWM_0_PIN_CH1       7
-#define PWM_0_PIN_CH2       8
-#define PWM_0_PIN_CH3       9
+static const pwm_conf_t pwm_config[] =
+{
+    { TIM4, AFIO_MAPR_TIM4_REMAP_NOREMAP, 2, 1, {
+            { GPIO_PIN(PORT_B, 9), 3 },
+    } }
+};
+#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/iotlab-m3/include/periph_conf.h
+++ b/boards/iotlab-m3/include/periph_conf.h
@@ -123,6 +123,13 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
+ * @brief   DAC configuration
+ * @{
+ */
+#define DAC_NUMOF           (0)
+/** @} */
+
+/**
  * @name Real time counter configuration
  * @{
  */

--- a/boards/nucleo-f103/include/periph_conf.h
+++ b/boards/nucleo-f103/include/periph_conf.h
@@ -54,6 +54,12 @@ extern "C" {
  * @{
  */
 #define ADC_NUMOF           (0)
+
+/**
+ * @brief   DAC configuration
+ * @{
+ */
+#define DAC_NUMOF           (0)
 /** @} */
 
 /**

--- a/boards/spark-core/include/periph_conf.h
+++ b/boards/spark-core/include/periph_conf.h
@@ -46,6 +46,13 @@
 #define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY_2
 /** @} */
 
+ /**
+  * @brief   DAC configuration
+  * @{
+  */
+ #define DAC_NUMOF           (0)
+ /** @} */
+
 /**
  * @name ADC configuration
  * @{

--- a/cpu/stm32f1/cpu.c
+++ b/cpu/stm32f1/cpu.c
@@ -32,11 +32,19 @@
 #elif CLOCK_HSI
 #define CLOCK_CR_SOURCE            RCC_CR_HSION
 #define CLOCK_CR_SOURCE_RDY        RCC_CR_HSIRDY
+<<<<<<< 0290a1813c6b0b7b8d0831a621408c9d71f7315d
 #define CLOCK_PLL_SOURCE           (0)
 #elif CLOCK_HSE
 #define CLOCK_CR_SOURCE            RCC_CR_HSEON
 #define CLOCK_CR_SOURCE_RDY        RCC_CR_HSERDY
 #define CLOCK_PLL_SOURCE           RCC_CFGR_PLLSRC
+=======
+#define CLOCK_PLL_SOURCE           RCC_CFGR_PLLSRC_HSI_Div2
+#elif CLOCK_HSE
+#define CLOCK_CR_SOURCE            RCC_CR_HSEON
+#define CLOCK_CR_SOURCE_RDY        RCC_CR_HSERDY
+#define CLOCK_PLL_SOURCE           RCC_CFGR_PLLSRC_HSE
+>>>>>>> cpu: Add clock source selection based on CLOCK_HSE or CLOCK_HSI for STM32F1
 #else
 #error "Please provide CLOCK_HSI or CLOCK_HSE in boards/NAME/includes/perhip_cpu.h"
 #endif

--- a/cpu/stm32f1/cpu.c
+++ b/cpu/stm32f1/cpu.c
@@ -32,19 +32,11 @@
 #elif CLOCK_HSI
 #define CLOCK_CR_SOURCE            RCC_CR_HSION
 #define CLOCK_CR_SOURCE_RDY        RCC_CR_HSIRDY
-<<<<<<< 0290a1813c6b0b7b8d0831a621408c9d71f7315d
 #define CLOCK_PLL_SOURCE           (0)
 #elif CLOCK_HSE
 #define CLOCK_CR_SOURCE            RCC_CR_HSEON
 #define CLOCK_CR_SOURCE_RDY        RCC_CR_HSERDY
 #define CLOCK_PLL_SOURCE           RCC_CFGR_PLLSRC
-=======
-#define CLOCK_PLL_SOURCE           RCC_CFGR_PLLSRC_HSI_Div2
-#elif CLOCK_HSE
-#define CLOCK_CR_SOURCE            RCC_CR_HSEON
-#define CLOCK_CR_SOURCE_RDY        RCC_CR_HSERDY
-#define CLOCK_PLL_SOURCE           RCC_CFGR_PLLSRC_HSE
->>>>>>> cpu: Add clock source selection based on CLOCK_HSE or CLOCK_HSI for STM32F1
 #else
 #error "Please provide CLOCK_HSI or CLOCK_HSE in boards/NAME/includes/perhip_cpu.h"
 #endif

--- a/cpu/stm32f1/include/cpu_conf.h
+++ b/cpu/stm32f1/include/cpu_conf.h
@@ -27,7 +27,7 @@
 
 #if defined(CPU_MODEL_STM32F103CB) || defined(CPU_MODEL_STM32F103RB)
 #include "stm32f103xb.h"
-#elif defined(CPU_MODEL_STM32F103RE)
+#elif defined(CPU_MODEL_STM32F101RD) || defined(CPU_MODEL_STM32F103RE)
 #include "stm32f103xe.h"
 #endif
 

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -96,6 +96,25 @@ enum {
 };
 
 /**
+ * @brief   PWM channel configuration data structure
+ */
+typedef struct {
+    gpio_t pin;                 /**< GPIO pin */
+    uint8_t chan;               /**< timer channel to use */
+} pwm_conf_chan_t;
+
+/**
+ * @brief   PWM device configuration data structure
+ */
+typedef struct {
+    TIM_TypeDef *dev;           /**< timer device to use */
+    uint32_t remap;             /**< timer remapping to use */
+    uint8_t apb;                /**< the RCC clock line to use */
+    uint8_t rcc;                /**< RCC bit to enable the timer */
+    pwm_conf_chan_t chan[4];    /**< channel configuration */
+} pwm_conf_t;
+
+/**
  * @brief   Define alternate function modes
  *
  * On this CPU, only the output pins have alternate function modes. The input

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -157,6 +157,14 @@ typedef struct {
 } uart_conf_t;
 
 /**
+ *  * @brief   DAC line configuration data
+ */
+typedef struct {
+    gpio_t pin;             /**< pin connected to the line */
+    uint8_t chan;           /**< DAC device used for this line */
+} dac_conf_t;
+
+/**
  * @brief   Configure the alternate function for the given pin
  *
  * @note    This is meant for internal use in STM32F1 peripheral drivers only

--- a/cpu/stm32f1/include/stm32f103xe.h
+++ b/cpu/stm32f1/include/stm32f103xe.h
@@ -1767,6 +1767,10 @@ typedef struct
 
 #define AFIO_MAPR_TIM4_REMAP                 ((uint32_t)0x00001000)        /*!< TIM4_REMAP bit (TIM4 remapping) */
 
+/*!< TIM4_REMAP configuration */
+#define AFIO_MAPR_TIM4_REMAP_NOREMAP         ((uint32_t)0x00000000)        /*!< No remap (CH1/PB6, CH2/PB7, CH3/PB8, CH4/PB9) */
+#define AFIO_MAPR_TIM4_REMAP_FULLREMAP       ((uint32_t)0x00001000)        /*!< Full remap (CH1/PD12, CH2/PD13, CH3/PD14, CH4/PD15) */
+
 #define AFIO_MAPR_CAN_REMAP                  ((uint32_t)0x00006000)        /*!< CAN_REMAP[1:0] bits (CAN Alternate function remapping) */
 #define AFIO_MAPR_CAN_REMAP_0                ((uint32_t)0x00002000)        /*!< Bit 0 */
 #define AFIO_MAPR_CAN_REMAP_1                ((uint32_t)0x00004000)        /*!< Bit 1 */

--- a/cpu/stm32f1/ldscripts/stm32f101rd.ld
+++ b/cpu/stm32f1/ldscripts/stm32f101rd.ld
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2015 Engineering-Spirit
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup      cpu_stm32f1
+ * @{
+ *
+ * @file
+ * @brief           Memory definitions for the STM32F101RD
+ *
+ * @author          Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ *
+ * @}
+ */
+
+MEMORY
+{
+    rom (rx)    : ORIGIN = 0x08000000, LENGTH = 384K
+    ram (xrw)   : ORIGIN = 0x20000000, LENGTH = 48K
+    cpuid (r)   : ORIGIN = 0x1ffff7e8, LENGTH = 12
+}
+
+_cpuid_address = ORIGIN(cpuid);
+
+INCLUDE cortexm_base.ld

--- a/cpu/stm32f1/periph/dac.c
+++ b/cpu/stm32f1/periph/dac.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2016 Engineering-Spirit
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_stm32f1
+ * @{
+ *
+ * @file
+ * @brief       Low-level DAC driver implementation
+ *
+ * @author      Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "periph/dac.h"
+#include "periph_conf.h"
+
+/* only compile this, if the CPU has a DAC */
+#ifdef DAC
+
+/**
+ * @brief   Get the DAC configuration from the board (if configured)
+ * @{
+ */
+#ifdef DAC_CONFIG
+static const dac_conf_t dac_config[] = DAC_CONFIG;
+#else
+static const dac_conf_t dac_config[] = {};
+#endif
+/** @} */
+
+int8_t dac_init(dac_t line)
+{
+    if (line >= DAC_NUMOF) {
+        return -1;
+    }
+
+    /* configure pin */
+    gpio_init_analog(dac_config[line].pin);
+    /* enable the DAC's clock */
+    RCC->APB1ENR |= RCC_APB1ENR_DACEN;
+    /* reset output and enable the line's channel */
+    dac_set(line, 0);
+    dac_poweron(line);
+    return 0;
+}
+
+void dac_set(dac_t line, uint16_t value)
+{
+    value = (value >> 4);       /* scale to 12-bit */
+    if (dac_config[line].chan) {
+        DAC->DHR12R2 = value;
+    }
+    else {
+        DAC->DHR12R1 = value;
+    }
+}
+
+void dac_poweron(dac_t line)
+{
+    DAC->CR |= (1 << (16 * dac_config[line].chan));
+}
+
+void dac_poweroff(dac_t line)
+{
+    DAC->CR &= ~(1 << (16 * dac_config[line].chan));
+}
+
+#endif /* DAC */

--- a/cpu/stm32f1/periph/pwm.c
+++ b/cpu/stm32f1/periph/pwm.c
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) 2015 Engineering-Spirit
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_stm32f1
+ * @{
+ *
+ * @file
+ * @brief       Low-level PWM driver implementation
+ *
+ * @author      Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "cpu.h"
+#include "periph/pwm.h"
+#include "periph_conf.h"
+
+/* ignore file in case no PWM devices are defined */
+#if PWM_0_EN || PWM_1_EN
+
+int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int resolution)
+{
+    TIM_TypeDef *tim = NULL;
+    GPIO_TypeDef *port = NULL;
+    uint32_t pins[PWM_MAX_CHANNELS];
+    uint32_t pwm_clk = 0;
+    int channels = 0;
+
+    pwm_poweron(dev);
+
+    switch (dev) {
+#if PWM_0_EN
+        case PWM_0:
+            tim = PWM_0_DEV;
+            port = PWM_0_PORT;
+            pins[0] = PWM_0_PIN_CH0;
+#if (PWM_0_CHANNELS > 1)
+            pins[1] = PWM_0_PIN_CH1;
+#endif
+#if (PWM_0_CHANNELS > 2)
+            pins[2] = PWM_0_PIN_CH2;
+#endif
+#if (PWM_0_CHANNELS > 3)
+            pins[3] = PWM_0_PIN_CH3;
+#endif
+            channels = PWM_0_CHANNELS;
+            pwm_clk = PWM_0_CLK;
+            PWM_0_PORT_CLKEN();
+            break;
+#endif
+
+#if PWM_1_EN
+        case PWM_1:
+            tim = PWM_1_DEV;
+            port = PWM_1_PORT;
+            pins[0] = PWM_1_PIN_CH0;
+#if (PWM_1_CHANNELS > 1)
+            pins[1] = PWM_1_PIN_CH1;
+#endif
+#if (PWM_1_CHANNELS > 2)
+            pins[2] = PWM_1_PIN_CH2;
+#endif
+#if (PWM_1_CHANNELS > 3)
+            pins[3] = PWM_1_PIN_CH3;
+#endif
+            af = PWM_1_PIN_AF;
+            channels = PWM_1_CHANNELS;
+            pwm_clk = PWM_1_CLK;
+            PWM_1_PORT_CLKEN();
+            break;
+#endif
+    }
+
+    /* setup pins for high speed alternate function */
+    for (int i = 0; i < channels; i++) {
+        /* calculate where the MODE and CNF must be updated */
+        port->CR[pins[i] >= 8] &= ~(0xfl << (4 * (pins[i] - ((pins[i] >= 8) * 8))));
+        port->CR[pins[i] >= 8] |= (0xbl << (4 * (pins[i] - ((pins[i] >= 8) * 8))));
+    }
+
+#if PWM_0_PERIPH_AF
+    /* clear re-mapping of the peripheral and set the new re-mapping */
+    AFIO->MAPR &= ~(PWM_0_AFIO_MAPR_BITMASK << PWM_0_AFIO_MAPR_OFFSET);
+    AFIO->MAPR |= (PWM_0_PERIPH_AF << PWM_0_AFIO_MAPR_OFFSET);
+#endif
+
+#if PWM_1_PERIPH_AF
+#endif
+
+    /* reset the c/c and timer configuration register */
+    switch (channels) {
+        case 4:
+            tim->CCR4 = 0;
+            /* no break */
+        case 3:
+            tim->CCR3 = 0;
+            tim->CR2 = 0;
+            /* no break */
+        case 2:
+            tim->CCR2 = 0;
+            /* no break */
+        case 1:
+            tim->CCR1 = 0;
+            tim->CR1 = 0;
+            break;
+    }
+
+    /* set the prescale and auto-reload register to matching values for resolution and frequency */
+    if (resolution > 0xffff || (resolution * frequency) > pwm_clk) {
+        return -2;
+    }
+    tim->PSC = (pwm_clk / (resolution * frequency)) - 1;
+    tim->ARR = resolution - 1;
+
+    /* set PWM mode */
+    switch (mode) {
+        case PWM_LEFT:
+            tim->CCMR1 = (TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2 |
+                           TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_2);
+            tim->CCMR2 = (TIM_CCMR2_OC3M_1 | TIM_CCMR2_OC3M_2 |
+                           TIM_CCMR2_OC4M_1 | TIM_CCMR2_OC4M_2);
+            break;
+
+        case PWM_RIGHT:
+            tim->CCMR1 = (TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2 |
+                           TIM_CCMR1_OC2M_0 | TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_2);
+            tim->CCMR2 = (TIM_CCMR2_OC3M_0 | TIM_CCMR2_OC3M_1 | TIM_CCMR2_OC3M_2 |
+                           TIM_CCMR2_OC4M_0 | TIM_CCMR2_OC4M_1 | TIM_CCMR2_OC4M_2);
+            break;
+
+        case PWM_CENTER:
+            tim->CCMR1 = 0;
+            tim->CCMR2 = 0;
+            tim->CR1 |= (TIM_CR1_CMS_0 | TIM_CR1_CMS_1);
+            break;
+    }
+
+    /* enable output on PWM pins */
+    tim->CCER = (TIM_CCER_CC1E | TIM_CCER_CC2E | TIM_CCER_CC3E | TIM_CCER_CC4E);
+
+    /* enable PWM outputs */
+    tim->BDTR = TIM_BDTR_MOE;
+
+    /* enable timer ergo the PWM generation */
+    pwm_start(dev);
+
+    return frequency;
+}
+
+int pwm_set(pwm_t dev, int channel, unsigned int value)
+{
+    TIM_TypeDef *tim = NULL;
+
+    switch (dev) {
+#if PWM_0_EN
+        case PWM_0:
+            tim = PWM_0_DEV;
+            if (channel >= PWM_0_CHANNELS) {
+                return -1;
+            }
+            break;
+#endif
+#if PWM_1_EN
+        case PWM_1:
+            tim = PWM_1_DEV;
+            if (channel >= PWM_1_CHANNELS) {
+                return -1;
+            }
+            break;
+#endif
+    }
+
+    /* norm value to maximum possible value */
+    if (value > tim->ARR) {
+        value = (unsigned int) tim->ARR;
+    }
+
+    /* calculate the c/c offset, and set the value */
+    *((&(tim->CCR1)) + (channel * 2)) = value;
+
+    return 0;
+}
+
+void pwm_start(pwm_t dev)
+{
+    switch (dev) {
+#if PWM_0_EN
+        case PWM_0:
+            PWM_0_DEV->CR1 |= TIM_CR1_CEN;
+            break;
+#endif
+#if PWM_1_EN
+        case PWM_1:
+            PWM_1_DEV->CR1 |= TIM_CR1_CEN;
+            break;
+#endif
+    }
+}
+
+void pwm_stop(pwm_t dev)
+{
+    switch (dev) {
+#if PWM_0_EN
+        case PWM_0:
+            PWM_0_DEV->CR1 &= ~(TIM_CR1_CEN);
+            break;
+#endif
+#if PWM_1_EN
+        case PWM_1:
+            PWM_1_DEV->CR1 &= ~(TIM_CR1_CEN);
+            break;
+#endif
+    }
+}
+
+void pwm_poweron(pwm_t dev)
+{
+    switch (dev) {
+#if PWM_0_EN
+        case PWM_0:
+            PWM_0_CLKEN();
+            break;
+#endif
+#if PWM_1_EN
+        case PWM_1:
+            PWM_1_CLKEN();
+            break;
+#endif
+    }
+}
+
+void pwm_poweroff(pwm_t dev)
+{
+    switch (dev) {
+#if PWM_0_EN
+        case PWM_0:
+            PWM_0_CLKDIS();
+            break;
+#endif
+#if PWM_1_EN
+        case PWM_1:
+            PWM_1_CLKDIS();
+            break;
+#endif
+    }
+}
+
+#endif /* PWM_0_EN || PWM_1_EN */

--- a/cpu/stm32f1/periph/pwm.c
+++ b/cpu/stm32f1/periph/pwm.c
@@ -26,7 +26,7 @@
 #include "periph_conf.h"
 
 /* ignore file in case no PWM devices are defined */
-#if PWM_0_EN || PWM_1_EN
+#if PWM_0_EN || PWM_1_EN || 1
 
 int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int resolution)
 {
@@ -88,11 +88,13 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
         port->CR[pins[i] >= 8] |= (0xbl << (4 * (pins[i] - ((pins[i] >= 8) * 8))));
     }
 
+#if PWM_0_PERIPH_AF || PWM_1_PERIPH_AF
     /* timer 12 to 14 and timer 9 to 15 must be re-mapped on MAPR2 register of AFIO */
     __IO uint32_t *MAPR = &(AFIO->MAPR);
-    if ((tim > TIM12_BASE && tim < TIM14_BASE) || (tim > TIM15 && tim < TIM11)) {
+    if ((tim > TIM12 && tim < TIM14) || (tim > TIM15 && tim < TIM11)) {
         MAPR = &(AFIO->MAPR2);
     }
+#endif
 
 #if PWM_0_PERIPH_AF
     /* clear re-mapping of the peripheral and set the new re-mapping */

--- a/cpu/stm32f1/periph/pwm.c
+++ b/cpu/stm32f1/periph/pwm.c
@@ -81,13 +81,21 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
 #endif
     }
 
-    /* setup pins for high speed alternate function */
+    /* setup pins for high speed alternate function
+     *
+     * The pin configuration can be found on page 171:
+     *  http://www.st.com/web/en/resource/technical/document/reference_manual/CD00171190.pdf
+     */
     for (int i = 0; i < channels; i++) {
+
         /* calculate where the MODE and CNF must be updated */
         port->CR[pins[i] >= 8] &= ~(0xfl << (4 * (pins[i] - ((pins[i] >= 8) * 8))));
         port->CR[pins[i] >= 8] |= (0xbl << (4 * (pins[i] - ((pins[i] >= 8) * 8))));
     }
 
+    /* alternative function mapping can be found on page 178
+     * http://www.st.com/web/en/resource/technical/document/reference_manual/CD00171190.pdf
+     */
 #if PWM_0_PERIPH_AF || PWM_1_PERIPH_AF
     /* timer 12 to 14 and timer 9 to 15 must be re-mapped on MAPR2 register of AFIO */
     __IO uint32_t *MAPR = &(AFIO->MAPR);

--- a/cpu/stm32f1/periph/pwm.c
+++ b/cpu/stm32f1/periph/pwm.c
@@ -89,9 +89,10 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
     }
 
     /* timer 12 to 14 and timer 9 to 15 must be re-mapped on MAPR2 register of AFIO */
-    __IO uint32_t* MAPR = &(AFIO->MAPR);
-    if ((tim > TIM12_BASE && tim < TIM14_BASE) || (tim > TIM15 && tim < TIM11))
+    __IO uint32_t *MAPR = &(AFIO->MAPR);
+    if ((tim > TIM12_BASE && tim < TIM14_BASE) || (tim > TIM15 && tim < TIM11)) {
         MAPR = &(AFIO->MAPR2);
+    }
 
 #if PWM_0_PERIPH_AF
     /* clear re-mapping of the peripheral and set the new re-mapping */
@@ -109,14 +110,14 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
     switch (channels) {
         case 4:
             tim->CCR4 = 0;
-            /* no break */
+        /* no break */
         case 3:
             tim->CCR3 = 0;
             tim->CR2 = 0;
-            /* no break */
+        /* no break */
         case 2:
             tim->CCR2 = 0;
-            /* no break */
+        /* no break */
         case 1:
             tim->CCR1 = 0;
             tim->CR1 = 0;
@@ -134,16 +135,16 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
     switch (mode) {
         case PWM_LEFT:
             tim->CCMR1 = (TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2 |
-                           TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_2);
+                          TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_2);
             tim->CCMR2 = (TIM_CCMR2_OC3M_1 | TIM_CCMR2_OC3M_2 |
-                           TIM_CCMR2_OC4M_1 | TIM_CCMR2_OC4M_2);
+                          TIM_CCMR2_OC4M_1 | TIM_CCMR2_OC4M_2);
             break;
 
         case PWM_RIGHT:
             tim->CCMR1 = (TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2 |
-                           TIM_CCMR1_OC2M_0 | TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_2);
+                          TIM_CCMR1_OC2M_0 | TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_2);
             tim->CCMR2 = (TIM_CCMR2_OC3M_0 | TIM_CCMR2_OC3M_1 | TIM_CCMR2_OC3M_2 |
-                           TIM_CCMR2_OC4M_0 | TIM_CCMR2_OC4M_1 | TIM_CCMR2_OC4M_2);
+                          TIM_CCMR2_OC4M_0 | TIM_CCMR2_OC4M_1 | TIM_CCMR2_OC4M_2);
             break;
 
         case PWM_CENTER:
@@ -194,22 +195,21 @@ int pwm_set(pwm_t dev, int channel, unsigned int value)
     }
 
     /* set the PWM value to the channel comperator */
-    switch (channel)
-    {
-    case 0:
-        tim->CCR1 = value;
-        break;
-    case 1:
-        tim->CCR2 = value;
-        break;
-    case 2:
-        tim->CCR3 = value;
-        break;
-    case 3:
-        tim->CCR4 = value;
-        break;
-    default:
-        return -1;
+    switch (channel) {
+        case 0:
+            tim->CCR1 = value;
+            break;
+        case 1:
+            tim->CCR2 = value;
+            break;
+        case 2:
+            tim->CCR3 = value;
+            break;
+        case 3:
+            tim->CCR4 = value;
+            break;
+        default:
+            return -1;
     }
 
     return 0;

--- a/cpu/stm32f1/periph/pwm.c
+++ b/cpu/stm32f1/periph/pwm.c
@@ -26,7 +26,7 @@
 #include "periph_conf.h"
 
 /* ignore file in case no PWM devices are defined */
-#if PWM_0_EN || PWM_1_EN || 1
+#if PWM_0_EN || PWM_1_EN
 
 int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int resolution)
 {

--- a/cpu/stm32f1/periph/pwm.c
+++ b/cpu/stm32f1/periph/pwm.c
@@ -193,8 +193,24 @@ int pwm_set(pwm_t dev, int channel, unsigned int value)
         value = (unsigned int) tim->ARR;
     }
 
-    /* calculate the c/c offset, and set the value */
-    *((&(tim->CCR1)) + (channel * 2)) = value;
+    /* set the PWM value to the channel comperator */
+    switch (channel)
+    {
+    case 0:
+        tim->CCR1 = value;
+        break;
+    case 1:
+        tim->CCR2 = value;
+        break;
+    case 2:
+        tim->CCR3 = value;
+        break;
+    case 3:
+        tim->CCR4 = value;
+        break;
+    default:
+        return -1;
+    }
 
     return 0;
 }

--- a/cpu/stm32f1/periph/pwm.c
+++ b/cpu/stm32f1/periph/pwm.c
@@ -41,7 +41,7 @@ static inline const pwm_conf_chan_t* chan(pwm_t dev, int ch)
 
 static inline volatile uint16_t* ccr(pwm_t dev, int ch)
 {
-    return (&(tim(dev)->CCR1)) + (chan(dev, ch)->chan << 1);
+    return (volatile uint16_t *)&(tim(dev)->CCR[chan(dev, ch)->chan]);
 }
 
 static inline volatile uint32_t* apb(pwm_t dev)
@@ -88,9 +88,11 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
          */
         /* timer 12 to 14 and timer 9 to 15 must be re-mapped on MAPR2 register of AFIO */
         volatile uint32_t *MAPR = &(AFIO->MAPR);
+#if defined(TIM15)
         if ((conf->dev > TIM12 && conf->dev < TIM14) || (conf->dev > TIM15 && conf->dev < TIM11)) {
             MAPR = &(AFIO->MAPR2);
         }
+#endif
 
         /* clear re-mapping of the peripheral and set the new re-mapping */
         // TODO add support for not reset ? *MAPR &= ~(PWM_0_AFIO_MAPR_BITMASK << PWM_0_AFIO_MAPR_OFFSET);

--- a/cpu/stm32f1/periph/pwm.c
+++ b/cpu/stm32f1/periph/pwm.c
@@ -88,13 +88,21 @@ int pwm_init(pwm_t dev, pwm_mode_t mode, unsigned int frequency, unsigned int re
         port->CR[pins[i] >= 8] |= (0xbl << (4 * (pins[i] - ((pins[i] >= 8) * 8))));
     }
 
+    /* timer 12 to 14 and timer 9 to 15 must be re-mapped on MAPR2 register of AFIO */
+    __IO uint32_t* MAPR = &(AFIO->MAPR);
+    if ((tim > TIM12_BASE && tim < TIM14_BASE) || (tim > TIM15 && tim < TIM11))
+        MAPR = &(AFIO->MAPR2);
+
 #if PWM_0_PERIPH_AF
     /* clear re-mapping of the peripheral and set the new re-mapping */
-    AFIO->MAPR &= ~(PWM_0_AFIO_MAPR_BITMASK << PWM_0_AFIO_MAPR_OFFSET);
-    AFIO->MAPR |= (PWM_0_PERIPH_AF << PWM_0_AFIO_MAPR_OFFSET);
+    *MAPR &= ~(PWM_0_AFIO_MAPR_BITMASK << PWM_0_AFIO_MAPR_OFFSET);
+    *MAPR |= (PWM_0_PERIPH_AF << PWM_0_AFIO_MAPR_OFFSET);
 #endif
 
 #if PWM_1_PERIPH_AF
+    /* clear re-mapping of the peripheral and set the new re-mapping */
+    *MAPR &= ~(PWM_1_AFIO_MAPR_BITMASK << PWM_1_AFIO_MAPR_OFFSET);
+    *MAPR |= (PWM_1_PERIPH_AF << PWM_1_AFIO_MAPR_OFFSET);
 #endif
 
     /* reset the c/c and timer configuration register */


### PR DESCRIPTION
I would like to import the module / board our company created.

It is currently available on CrowdSupply: https://www.crowdsupply.com/axtrel/axavior

**Specifications:**
MCU: STM32F101RD (Clock: 36MHz - Flash: 384K - RAM: 48K)
Transceiver: AT86RF212B (868 to 920 MHz)
MicroBus on dev board: http://www.mikroe.com/mikrobus/

Reliable range in and around buildings
Range: > 500 m / 1500 ft (line-of-sight)
Bitrate up to 250 kbits/s
Power supply: 3.3 V
Active power: 60 mW
Inactive power: < 0.3 mW

**Depending on PR:**
 - [x] #4154 - cpu: Add clock source selection based on CLOCK_HSE or CLOCK_HSI for STM32F1 family
 - [ ] #4225 - cpu/stm32f1/periph/dac: DAC implementation for STM32F1
 - [ ] #4227 - cpu/stm32f1/periph/pwm: PWM implementation for STM32F1