### PR TITLE
gnrc_rpl: shell: rename req_opts to dio_opts

### DIFF
--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -528,8 +528,8 @@ uint8_t gnrc_rpl_gen_instance_id(bool local);
  */
 static inline void gnrc_rpl_config_pio(gnrc_rpl_dodag_t *dodag, bool status)
 {
-    dodag->req_opts = (dodag->req_opts & ~GNRC_RPL_REQ_OPT_PREFIX_INFO) |
-                      (status << GNRC_RPL_REQ_OPT_PREFIX_INFO_SHIFT);
+    dodag->dio_opts = (dodag->dio_opts & ~GNRC_RPL_REQ_DIO_OPT_PREFIX_INFO) |
+                      (status << GNRC_RPL_REQ_DIO_OPT_PREFIX_INFO_SHIFT);
 }
 #endif
 

--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -32,13 +32,14 @@ extern "C" {
 #include "trickle.h"
 
 /**
- * @name Bit positions and shifts for gnrc_rpl_dodag_t::req_opts
+ * @anchor GNRC_RPL_REQ_DIO_OPTS
+ * @name DIO Options for gnrc_rpl_dodag_t::dio_opts
  * @{
  */
-#define GNRC_RPL_REQ_OPT_DODAG_CONF_SHIFT       (0)
-#define GNRC_RPL_REQ_OPT_DODAG_CONF             (1 << GNRC_RPL_REQ_OPT_DODAG_CONF_SHIFT)
-#define GNRC_RPL_REQ_OPT_PREFIX_INFO_SHIFT      (1)
-#define GNRC_RPL_REQ_OPT_PREFIX_INFO            (1 << GNRC_RPL_REQ_OPT_PREFIX_INFO_SHIFT)
+#define GNRC_RPL_REQ_DIO_OPT_DODAG_CONF_SHIFT       (0)
+#define GNRC_RPL_REQ_DIO_OPT_DODAG_CONF             (1 << GNRC_RPL_REQ_DIO_OPT_DODAG_CONF_SHIFT)
+#define GNRC_RPL_REQ_DIO_OPT_PREFIX_INFO_SHIFT      (1)
+#define GNRC_RPL_REQ_DIO_OPT_PREFIX_INFO            (1 << GNRC_RPL_REQ_DIO_OPT_PREFIX_INFO_SHIFT)
 /** @} */
 
 /**
@@ -230,7 +231,8 @@ struct gnrc_rpl_dodag {
     uint8_t dao_seq;                /**< dao sequence number */
     uint8_t dao_counter;            /**< amount of retried DAOs */
     bool dao_ack_received;          /**< flag to check for DAO-ACK */
-    uint8_t req_opts;               /**< flags that represent option requests */
+    uint8_t dio_opts;               /**< options in the next DIO
+                                         (see @ref GNRC_RPL_REQ_DIO_OPTS "DIO Options") */
     uint8_t dao_time;               /**< time to schedule a DAO in seconds */
     trickle_t trickle;              /**< trickle representation */
 };

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -103,9 +103,9 @@ gnrc_rpl_instance_t *gnrc_rpl_root_init(uint8_t instance_id, ipv6_addr_t *dodag_
     dodag->grounded = GNRC_RPL_GROUNDED;
     dodag->node_status = GNRC_RPL_ROOT_NODE;
     dodag->my_rank = GNRC_RPL_ROOT_RANK;
-    dodag->req_opts |= GNRC_RPL_REQ_OPT_DODAG_CONF;
+    dodag->dio_opts |= GNRC_RPL_REQ_DIO_OPT_DODAG_CONF;
 #ifndef GNRC_RPL_WITHOUT_PIO
-    dodag->req_opts |= GNRC_RPL_REQ_OPT_PREFIX_INFO;
+    dodag->dio_opts |= GNRC_RPL_REQ_DIO_OPT_PREFIX_INFO;
 #endif
 
     trickle_start(gnrc_rpl_pid, &dodag->trickle, GNRC_RPL_MSG_TYPE_TRICKLE_INTERVAL,

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -155,18 +155,18 @@ void gnrc_rpl_send_DIO(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination)
     gnrc_rpl_dio_t *dio;
 
 #ifndef GNRC_RPL_WITHOUT_PIO
-    if (dodag->req_opts & GNRC_RPL_REQ_OPT_PREFIX_INFO) {
+    if (dodag->dio_opts & GNRC_RPL_REQ_DIO_OPT_PREFIX_INFO) {
         if ((pkt = _dio_prefix_info_build(pkt, dodag)) == NULL) {
             return;
         }
     }
 #endif
 
-    if (dodag->req_opts & GNRC_RPL_REQ_OPT_DODAG_CONF) {
+    if (dodag->dio_opts & GNRC_RPL_REQ_DIO_OPT_DODAG_CONF) {
         if ((pkt = _dio_dodag_conf_build(pkt, dodag)) == NULL) {
             return;
         }
-        dodag->req_opts &= ~GNRC_RPL_REQ_OPT_DODAG_CONF;
+        dodag->dio_opts &= ~GNRC_RPL_REQ_DIO_OPT_DODAG_CONF;
     }
 
     if ((tmp = gnrc_pktbuf_add(pkt, NULL, sizeof(gnrc_rpl_dio_t), GNRC_NETTYPE_UNDEF)) == NULL) {
@@ -265,7 +265,7 @@ void gnrc_rpl_recv_DIS(gnrc_rpl_dis_t *dis, ipv6_addr_t *src, ipv6_addr_t *dst, 
     else {
         for (uint8_t i = 0; i < GNRC_RPL_INSTANCES_NUMOF; ++i) {
             if (gnrc_rpl_instances[i].state != 0) {
-                gnrc_rpl_instances[i].dodag.req_opts |= GNRC_RPL_REQ_OPT_DODAG_CONF;
+                gnrc_rpl_instances[i].dodag.dio_opts |= GNRC_RPL_REQ_DIO_OPT_DODAG_CONF;
                 gnrc_rpl_send_DIO(&gnrc_rpl_instances[i], src);
             }
         }
@@ -390,7 +390,7 @@ bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt_t *opt
             case (GNRC_RPL_OPT_DODAG_CONF):
                 DEBUG("RPL: DODAG CONF DIO option parsed\n");
                 *included_opts |= ((uint32_t) 1) << GNRC_RPL_OPT_DODAG_CONF;
-                dodag->req_opts |= GNRC_RPL_REQ_OPT_DODAG_CONF;
+                dodag->dio_opts |= GNRC_RPL_REQ_DIO_OPT_DODAG_CONF;
                 gnrc_rpl_opt_dodag_conf_t *dc = (gnrc_rpl_opt_dodag_conf_t *) opt;
                 gnrc_rpl_of_t *of = gnrc_rpl_get_of_for_ocp(byteorder_ntohs(dc->ocp));
                 if (of != NULL) {
@@ -416,7 +416,7 @@ bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt_t *opt
                 DEBUG("RPL: Prefix Information DIO option parsed\n");
                 *included_opts |= ((uint32_t) 1) << GNRC_RPL_OPT_PREFIX_INFO;
 #ifndef GNRC_RPL_WITHOUT_PIO
-                dodag->req_opts |= GNRC_RPL_REQ_OPT_PREFIX_INFO;
+                dodag->dio_opts |= GNRC_RPL_REQ_DIO_OPT_PREFIX_INFO;
 #endif
                 gnrc_rpl_opt_prefix_info_t *pi = (gnrc_rpl_opt_prefix_info_t *) opt;
                 ipv6_addr_t all_RPL_nodes = GNRC_RPL_ALL_NODES_ADDR;

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -206,7 +206,7 @@ int _gnrc_rpl_dodag_show(void)
                "TR(I=[%d,%d], k=%d, c=%d, TC=%" PRIu32 "s, TI=%" PRIu32 "s)]\n",
                ipv6_addr_to_str(addr_str, &dodag->dodag_id, sizeof(addr_str)),
                dodag->my_rank, (dodag->node_status == GNRC_RPL_LEAF_NODE ? "Leaf" : "Router"),
-               ((dodag->req_opts & GNRC_RPL_REQ_OPT_PREFIX_INFO) ? "on" : "off"),
+               ((dodag->dio_opts & GNRC_RPL_REQ_DIO_OPT_PREFIX_INFO) ? "on" : "off"),
                (int) cleanup, (1 << dodag->dio_min), dodag->dio_interval_doubl, dodag->trickle.k,
                dodag->trickle.c, (uint32_t) (tc & 0xFFFFFFFF), (uint32_t) (ti & 0xFFFFFFFF));
 


### PR DESCRIPTION
`dio_opts` is more approriate and descriptive than `req_opts`.