### PR TITLE
gnrc_rpl: make DODAG_CONF optional when joining DODAG

### DIFF
--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -35,6 +35,10 @@ USEMODULE += ps
 # development process:
 CFLAGS += -DDEVELHELP
 
+# Comment this out to join RPL DODAGs even if DIOs do not contain
+# DODAG Configuration Options (see the doc for more info)
+# CFLAGS += -DGNRC_RPL_DODAG_CONF_OPTIONAL_ON_JOIN
+
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -27,7 +27,7 @@
  * CFLAGS
  * ------
  *
- *  - Exclude Prefix Information Options from DIOs
+ * - Exclude Prefix Information Options from DIOs
  *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
  *   CFLAGS += -DGNRC_RPL_WITHOUT_PIO
  *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -37,6 +37,16 @@
  *   CFLAGS += -DGNRC_RPL_DEFAULT_DIO_INTERVAL_DOUBLINGS=20
  *   CFLAGS += -DGNRC_RPL_DEFAULT_DIO_INTERVAL_MIN=3
  *   CFLAGS += -DGNRC_RPL_DEFAULT_DIO_REDUNDANCY_CONSTANT=10
+ *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * - Make reception of DODAG_CONF optional when joining a DODAG.
+ *   This will use the default trickle parameters until a
+ *   DODAG_CONF is received from the parent. The DODAG_CONF is
+ *   requested once from the parent while joining the DODAG.
+ *   The standard behaviour is to request a DODAG_CONF and join
+ *   only a DODAG once a DODAG_CONF is received.
+ *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
+ *   CFLAGS += -DGNRC_RPL_DODAG_CONF_OPTIONAL_ON_JOIN
  *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * @{

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -567,10 +567,15 @@ void gnrc_rpl_recv_DIO(gnrc_rpl_dio_t *dio, ipv6_addr_t *src, uint16_t len)
         }
 
         if (!(included_opts & (((uint32_t) 1) << GNRC_RPL_OPT_DODAG_CONF))) {
+#ifndef GNRC_RPL_DODAG_CONF_OPTIONAL_ON_JOIN
             DEBUG("RPL: DIO without DODAG_CONF option - remove DODAG and request new DIO\n");
             gnrc_rpl_instance_remove(inst);
             gnrc_rpl_send_DIS(NULL, src);
             return;
+#else
+            DEBUG("RPL: DIO without DODAG_CONF option - use default trickle parameters\n");
+            gnrc_rpl_send_DIS(NULL, src);
+#endif
         }
 
         gnrc_rpl_delay_dao(dodag);


### PR DESCRIPTION
Fixes #4236 (see discussion there).

@OlegHahm 
>@cgundogan, let's discuss next Tuesday.

We never discussed it, but I am fine providing that feature as a compile-time option.