### PR TITLE
cpu/cortexm_common: Fix cpu_sleep_until_event()

### DIFF
--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -76,7 +76,6 @@ static inline void cpu_print_last_instruction(void)
  */
 static inline void cpu_sleep_until_event(void)
 {
-    __SEV();
     __WFE();
 }
 


### PR DESCRIPTION
Breakdown of the bug:

**What does SEVONPEND do?**
_When enabled, this causes WFE to wake up when an interrupt moves from inactive to
pended. Otherwise, WFE only wakes up from an event signal, external and SEV instruction
generated. The event input, RXEV, is registered even when not waiting for an event, and so
effects the next WFE._ < ARM Reference Manual
This means that when an IRQ get's it pending state set it would toggle the RXEV register from 0 to 1, or keep it at 1 if it already is 1.

**What does SEV do?**
_SEV is a hint instruction that causes an event to be signaled to all processors within a
multiprocessor system. It also sets the local event register to 1, see Power management on
page 42._ < STM32 Programming Manual
The local event register is the RXEV register. So actually SEV sets RXEV to 1 if it was not yet 1.

**The following events are WFE wake-up events:**
- the execution of an SEV instruction on any processor in the multiprocessor system
- any exception entering the Pending state if SEVONPEND in the System Control Register is set
- an asynchronous exception at a priority that pre-empts any currently active exceptions
- a debug event with debug enabled._ < ARMv7 Architecture Reference Manual

However WFE doesn't enter sleep mode if the RXEV register already is 1, then it just clears RXEV so it can be set by the next event. So when you first call SEV you would set RXEV, and then later clear it with the WFE instruction without entering sleep mode.

By removing the SEV you would first clear RXEV which was set due to previous occurred interrupts. Then you would again check if the flag which should be set is set. If it's not the next call would again be WFE until the next interrupt has entered pending state. And it would keep on looping until the required flag is actually set.