### PR TITLE
cpu/stm32f1: fixed bug in rcc_bit config for timers

### DIFF
--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -51,13 +51,22 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Timer configuration
+ * @brief   Timer configuration
  * @{
  */
 static const timer_conf_t timer_config[] = {
-    /* device, APB bus, rcc_bit */
-    { TIM2, APB1, RCC_APB1ENR_TIM2EN, TIM2_IRQn },
-    { TIM3, APB1, RCC_APB1ENR_TIM3EN, TIM3_IRQn }
+    {
+        .dev     = TIM2,
+        .rcc_bit = RCC_APB1ENR_TIM2EN,
+        .bus     = APB1,
+        .irqn    = TIM2_IRQn
+    },
+    {
+        .dev     = TIM3,
+        .rcc_bit = RCC_APB1ENR_TIM3EN,
+        .bus     = APB1,
+        .irqn    = TIM3_IRQn
+    }
 };
 
 #define TIMER_0_ISR         isr_tim2

--- a/boards/iotlab-m3/include/periph_conf.h
+++ b/boards/iotlab-m3/include/periph_conf.h
@@ -57,13 +57,22 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Timer configuration
+ * @brief   Timer configuration
  * @{
  */
 static const timer_conf_t timer_config[] = {
-    /* device, APB bus, rcc_bit */
-    { TIM2, APB1, RCC_APB1ENR_TIM2EN, TIM2_IRQn },
-    { TIM3, APB1, RCC_APB1ENR_TIM3EN, TIM3_IRQn }
+    {
+        .dev     = TIM2,
+        .rcc_bit = RCC_APB1ENR_TIM2EN,
+        .bus     = APB1,
+        .irqn    = TIM2_IRQn
+    },
+    {
+        .dev     = TIM3,
+        .rcc_bit = RCC_APB1ENR_TIM3EN,
+        .bus     = APB1,
+        .irqn    = TIM3_IRQn
+    }
 };
 
 #define TIMER_0_ISR         isr_tim2

--- a/boards/nucleo-f103/include/periph_conf.h
+++ b/boards/nucleo-f103/include/periph_conf.h
@@ -53,13 +53,22 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Timer configuration
+ * @brief   Timer configuration
  * @{
  */
 static const timer_conf_t timer_config[] = {
-    /* device, APB bus, rcc_bit */
-    { TIM2, APB1, RCC_APB1ENR_TIM2EN, TIM2_IRQn },
-    { TIM3, APB1, RCC_APB1ENR_TIM3EN, TIM3_IRQn }
+    {
+        .dev     = TIM2,
+        .rcc_bit = RCC_APB1ENR_TIM2EN,
+        .bus     = APB1,
+        .irqn    = TIM2_IRQn
+    },
+    {
+        .dev     = TIM3,
+        .rcc_bit = RCC_APB1ENR_TIM3EN,
+        .bus     = APB1,
+        .irqn    = TIM3_IRQn
+    }
 };
 
 #define TIMER_0_ISR         isr_tim2

--- a/boards/spark-core/include/periph_conf.h
+++ b/boards/spark-core/include/periph_conf.h
@@ -51,13 +51,22 @@
 /** @} */
 
 /**
- * @brief Timer configuration
+ * @brief   Timer configuration
  * @{
  */
 static const timer_conf_t timer_config[] = {
-    /* device, APB bus, rcc_bit */
-    { TIM2, APB1, RCC_APB1ENR_TIM2EN, TIM2_IRQn },
-    { TIM3, APB1, RCC_APB1ENR_TIM3EN, TIM3_IRQn }
+    {
+        .dev     = TIM2,
+        .rcc_bit = RCC_APB1ENR_TIM2EN,
+        .bus     = APB1,
+        .irqn    = TIM2_IRQn
+    },
+    {
+        .dev     = TIM3,
+        .rcc_bit = RCC_APB1ENR_TIM3EN,
+        .bus     = APB1,
+        .irqn    = TIM3_IRQn
+    }
 };
 
 #define TIMER_0_ISR         isr_tim2

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -120,8 +120,8 @@ typedef struct {
  */
 typedef struct {
     TIM_TypeDef *dev;       /**< timer device */
+    uint32_t rcc_bit;       /**< corresponding bit in the RCC register */
     uint8_t bus;            /**< APBx bus the timer is clock from */
-    uint8_t rcc_bit;        /**< corresponding bit in the RCC register */
     uint8_t irqn;           /**< global IRQ channel */
 } timer_conf_t;
 


### PR DESCRIPTION
The way the `rcc_bit` is used in the timer configuration actually needs a 32-bit wide variable to be stored in, as the `RCC_APB1ENR_TIMxEN` macros are bit-fields and not bit positions...

Also made the timer config a little more readable while at it.