### PR TITLE
gnrc_ipv6: Set preferred lifetime infinite on addresses in border router scenario.

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -107,6 +107,7 @@ static ipv6_addr_t *_add_addr_to_entry(gnrc_ipv6_netif_t *entry, const ipv6_addr
         if (!ipv6_addr_is_link_local(addr)) {
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER
             tmp_addr->valid = UINT32_MAX;
+            tmp_addr->preferred = UINT32_MAX;
             gnrc_sixlowpan_nd_router_abr_t *abr = gnrc_sixlowpan_nd_router_abr_get();
             mutex_unlock(&entry->mutex);
             gnrc_ipv6_netif_set_rtr_adv(entry, true);


### PR DESCRIPTION
I noticed that the border router gets its addresses set to infinite valid life time, but the preferred time is set to zero.
I'm not sure this PR is the correct behaviour, but it seem to work like this in Linux and in Contiki.

Another possible solution would be to let the border router application manage the preferred life time of configured addresses.