### PR TITLE
Makefile.vars: Document TARGET_TRIPLE

### DIFF
--- a/Makefile.vars
+++ b/Makefile.vars
@@ -22,7 +22,8 @@ export BINDIRBASE            # This is the folder where the application should b
 export BINDIR                # This is the folder where the application should be built in.
 export APPDIR                # The base folder containing the application
 
-export PREFIX                # The prefix of the toolchain commands, e.g. "arm-non-eabi-" or "msp430-".
+export TARGET_TRIPLE         # The target platform name, in GCC triple notation, e.g. "arm-none-eabi", "i686-elf", "avr"
+export PREFIX                # The prefix of the toolchain commands, usually "$(TARGET_TRIPLE)-", e.g. "arm-none-eabi-" or "msp430-".
 export CC                    # The C compiler to use.
 export CXX                   # The CXX compiler to use.
 export CFLAGS                # The compiler flags. Must only ever be used with `+=`.


### PR DESCRIPTION
It was undocumented before.
TARGET_TRIPLE is necessary in order to cross-compile with Clang since it is only installed once, not one compiler per target platform.