### PR TITLE
cpu/stm32_common: added shared periph_clk_en/dis functions

### DIFF
--- a/boards/f4vi1/include/periph_conf.h
+++ b/boards/f4vi1/include/periph_conf.h
@@ -83,16 +83,16 @@ extern "C" {
  * @{
  */
 static const uart_conf_t uart_config[] = {
-    /* device, RCC mask, RX pin, TX pin, pin AF, IRQ channel, DMA stream, DMA  */
     {
-        USART6,                     /* device base register */
-        RCC_APB2ENR_USART6EN,       /* RCC mask */
-        GPIO_PIN(PORT_C,7),         /* RX pin */
-        GPIO_PIN(PORT_C,6),         /* TX pin */
-        GPIO_AF8,                   /* pin AF */
-        USART6_IRQn,                /* IRQ channel */
-        14,                         /* DMA stream */
-        5                           /* DMA channel */
+        .dev        = USART6,
+        .rcc_mask   = RCC_APB2ENR_USART6EN,
+        .rx_pin     = GPIO_PIN(PORT_C,7),
+        .tx_pin     = GPIO_PIN(PORT_C,6),
+        .af         = GPIO_AF8,
+        .bus        = APB2,
+        .irqn       = USART6_IRQn,
+        .dma_stream = 14,
+        .dma_chan   = 5
     },
 };
 

--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -56,16 +56,16 @@ extern "C" {
  */
 static const timer_conf_t timer_config[] = {
     {
-        .dev     = TIM2,
-        .rcc_bit = RCC_APB1ENR_TIM2EN,
-        .bus     = APB1,
-        .irqn    = TIM2_IRQn
+        .dev      = TIM2,
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .bus      = APB1,
+        .irqn     = TIM2_IRQn
     },
     {
-        .dev     = TIM3,
-        .rcc_bit = RCC_APB1ENR_TIM3EN,
-        .bus     = APB1,
-        .irqn    = TIM3_IRQn
+        .dev      = TIM3,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .bus      = APB1,
+        .irqn     = TIM3_IRQn
     }
 };
 

--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -51,13 +51,22 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Timer configuration
+ * @brief   Timer configuration
  * @{
  */
 static const timer_conf_t timer_config[] = {
-    /* device, APB bus, rcc_bit */
-    { TIM2, APB1, RCC_APB1ENR_TIM2EN, TIM2_IRQn },
-    { TIM3, APB1, RCC_APB1ENR_TIM3EN, TIM3_IRQn }
+    {
+        .dev     = TIM2,
+        .rcc_bit = RCC_APB1ENR_TIM2EN,
+        .bus     = APB1,
+        .irqn    = TIM2_IRQn
+    },
+    {
+        .dev     = TIM3,
+        .rcc_bit = RCC_APB1ENR_TIM3EN,
+        .bus     = APB1,
+        .irqn    = TIM3_IRQn
+    }
 };
 
 #define TIMER_0_ISR         isr_tim2

--- a/boards/iotlab-m3/include/periph_conf.h
+++ b/boards/iotlab-m3/include/periph_conf.h
@@ -62,16 +62,16 @@ extern "C" {
  */
 static const timer_conf_t timer_config[] = {
     {
-        .dev     = TIM2,
-        .rcc_bit = RCC_APB1ENR_TIM2EN,
-        .bus     = APB1,
-        .irqn    = TIM2_IRQn
+        .dev      = TIM2,
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .bus      = APB1,
+        .irqn     = TIM2_IRQn
     },
     {
-        .dev     = TIM3,
-        .rcc_bit = RCC_APB1ENR_TIM3EN,
-        .bus     = APB1,
-        .irqn    = TIM3_IRQn
+        .dev      = TIM3,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .bus      = APB1,
+        .irqn     = TIM3_IRQn
     }
 };
 

--- a/boards/iotlab-m3/include/periph_conf.h
+++ b/boards/iotlab-m3/include/periph_conf.h
@@ -57,13 +57,22 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Timer configuration
+ * @brief   Timer configuration
  * @{
  */
 static const timer_conf_t timer_config[] = {
-    /* device, APB bus, rcc_bit */
-    { TIM2, APB1, RCC_APB1ENR_TIM2EN, TIM2_IRQn },
-    { TIM3, APB1, RCC_APB1ENR_TIM3EN, TIM3_IRQn }
+    {
+        .dev     = TIM2,
+        .rcc_bit = RCC_APB1ENR_TIM2EN,
+        .bus     = APB1,
+        .irqn    = TIM2_IRQn
+    },
+    {
+        .dev     = TIM3,
+        .rcc_bit = RCC_APB1ENR_TIM3EN,
+        .bus     = APB1,
+        .irqn    = TIM3_IRQn
+    }
 };
 
 #define TIMER_0_ISR         isr_tim2

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -129,40 +129,42 @@ extern "C" {
 /** @} */
 
 /**
- * @name UART configuration
+ * @brief   UART configuration
  * @{
  */
 static const uart_conf_t uart_config[] = {
-    /* device, RCC mask, RX pin, TX pin, pin AF, IRQ channel, DMA stream, DMA  */
     {
-        USART2,                     /* device base register */
-        RCC_APB1ENR_USART2EN,       /* RCC mask */
-        GPIO_PIN(PORT_A,3),         /* RX pin */
-        GPIO_PIN(PORT_A,2),         /* TX pin */
-        GPIO_AF7,                   /* pin AF */
-        USART2_IRQn,                /* IRQ channel */
-        6,                          /* DMA stream */
-        4                           /* DMA channel */
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_A,3),
+        .tx_pin     = GPIO_PIN(PORT_A,2),
+        .af         = GPIO_AF7,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
+        .dma_stream = 6,
+        .dma_chan   = 4
     },
     {
-        USART1,                     /* device base register */
-        RCC_APB2ENR_USART1EN,       /* RCC mask */
-        GPIO_PIN(PORT_A,10),        /* RX pin */
-        GPIO_PIN(PORT_A,9),         /* TX pin */
-        GPIO_AF7,                   /* pin AF */
-        USART1_IRQn,                /* IRQ channel */
-        15,                         /* DMA stream */
-        4                           /* DMA channel */
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_A,10),
+        .tx_pin     = GPIO_PIN(PORT_A,9),
+        .af         = GPIO_AF7,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn,
+        .dma_stream = 15,
+        .dma_chan   = 4
     },
     {
-        USART3,                     /* device base register */
-        RCC_APB1ENR_USART3EN,       /* RCC mask */
-        GPIO_PIN(PORT_D,9),         /* RX pin */
-        GPIO_PIN(PORT_D,8),         /* TX pin */
-        GPIO_AF7,                   /* pin AF */
-        USART3_IRQn,                /* IRQ channel */
-        3,                          /* DMA stream */
-        4                           /* DMA channel */
+        .dev        = USART3,
+        .rcc_mask   = RCC_APB1ENR_USART3EN,
+        .rx_pin     = GPIO_PIN(PORT_D,9),
+        .tx_pin     = GPIO_PIN(PORT_D,8),
+        .af         = GPIO_AF7,
+        .bus        = APB1,
+        .irqn       = USART3_IRQn,
+        .dma_stream = 3,
+        .dma_chan   = 4
     },
 };
 

--- a/boards/nucleo-f103/include/periph_conf.h
+++ b/boards/nucleo-f103/include/periph_conf.h
@@ -58,16 +58,16 @@ extern "C" {
  */
 static const timer_conf_t timer_config[] = {
     {
-        .dev     = TIM2,
-        .rcc_bit = RCC_APB1ENR_TIM2EN,
-        .bus     = APB1,
-        .irqn    = TIM2_IRQn
+        .dev      = TIM2,
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .bus      = APB1,
+        .irqn     = TIM2_IRQn
     },
     {
-        .dev     = TIM3,
-        .rcc_bit = RCC_APB1ENR_TIM3EN,
-        .bus     = APB1,
-        .irqn    = TIM3_IRQn
+        .dev      = TIM3,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .bus      = APB1,
+        .irqn     = TIM3_IRQn
     }
 };
 

--- a/boards/nucleo-f103/include/periph_conf.h
+++ b/boards/nucleo-f103/include/periph_conf.h
@@ -53,13 +53,22 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Timer configuration
+ * @brief   Timer configuration
  * @{
  */
 static const timer_conf_t timer_config[] = {
-    /* device, APB bus, rcc_bit */
-    { TIM2, APB1, RCC_APB1ENR_TIM2EN, TIM2_IRQn },
-    { TIM3, APB1, RCC_APB1ENR_TIM3EN, TIM3_IRQn }
+    {
+        .dev     = TIM2,
+        .rcc_bit = RCC_APB1ENR_TIM2EN,
+        .bus     = APB1,
+        .irqn    = TIM2_IRQn
+    },
+    {
+        .dev     = TIM3,
+        .rcc_bit = RCC_APB1ENR_TIM3EN,
+        .bus     = APB1,
+        .irqn    = TIM3_IRQn
+    }
 };
 
 #define TIMER_0_ISR         isr_tim2

--- a/boards/nucleo-f401/include/periph_conf.h
+++ b/boards/nucleo-f401/include/periph_conf.h
@@ -77,20 +77,20 @@ extern "C" {
 /** @} */
 
 /**
- * @name UART configuration
+ * @brief   UART configuration
  * @{
  */
 static const uart_conf_t uart_config[] = {
-    /* device, RCC mask, RX pin, TX pin, pin AF, IRQ channel, DMA stream, DMA  */
     {
-        USART2,                     /* device base register */
-        RCC_APB1ENR_USART2EN,       /* RCC mask */
-        GPIO_PIN(PORT_A,3),         /* RX pin */
-        GPIO_PIN(PORT_A,2),         /* TX pin */
-        GPIO_AF7,                   /* pin AF */
-        USART2_IRQn,                /* IRQ channel */
-        6,                          /* DMA stream */
-        4                           /* DMA channel */
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_A,3),
+        .tx_pin     = GPIO_PIN(PORT_A,2),
+        .af         = GPIO_AF7,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
+        .dma_stream = 6,
+        .dma_chan   = 4
     }
 };
 

--- a/boards/spark-core/include/periph_conf.h
+++ b/boards/spark-core/include/periph_conf.h
@@ -51,13 +51,22 @@
 /** @} */
 
 /**
- * @brief Timer configuration
+ * @brief   Timer configuration
  * @{
  */
 static const timer_conf_t timer_config[] = {
-    /* device, APB bus, rcc_bit */
-    { TIM2, APB1, RCC_APB1ENR_TIM2EN, TIM2_IRQn },
-    { TIM3, APB1, RCC_APB1ENR_TIM3EN, TIM3_IRQn }
+    {
+        .dev     = TIM2,
+        .rcc_bit = RCC_APB1ENR_TIM2EN,
+        .bus     = APB1,
+        .irqn    = TIM2_IRQn
+    },
+    {
+        .dev     = TIM3,
+        .rcc_bit = RCC_APB1ENR_TIM3EN,
+        .bus     = APB1,
+        .irqn    = TIM3_IRQn
+    }
 };
 
 #define TIMER_0_ISR         isr_tim2

--- a/boards/spark-core/include/periph_conf.h
+++ b/boards/spark-core/include/periph_conf.h
@@ -56,16 +56,16 @@
  */
 static const timer_conf_t timer_config[] = {
     {
-        .dev     = TIM2,
-        .rcc_bit = RCC_APB1ENR_TIM2EN,
-        .bus     = APB1,
-        .irqn    = TIM2_IRQn
+        .dev      = TIM2,
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .bus      = APB1,
+        .irqn     = TIM2_IRQn
     },
     {
-        .dev     = TIM3,
-        .rcc_bit = RCC_APB1ENR_TIM3EN,
-        .bus     = APB1,
-        .irqn    = TIM3_IRQn
+        .dev      = TIM3,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .bus      = APB1,
+        .irqn     = TIM3_IRQn
     }
 };
 

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -78,30 +78,31 @@ extern "C" {
 /** @} */
 
 /**
- * @name UART configuration
+ * @brief   UART configuration
  * @{
  */
 static const uart_conf_t uart_config[] = {
-    /* device, RCC mask, RX pin, TX pin, pin AF, IRQ channel, DMA stream, DMA  */
     {
-        USART2,                     /* device base register */
-        RCC_APB1ENR_USART2EN,       /* RCC mask */
-        GPIO_PIN(PORT_A,3),         /* RX pin */
-        GPIO_PIN(PORT_A,2),         /* TX pin */
-        GPIO_AF7,                   /* pin AF */
-        USART2_IRQn,                /* IRQ channel */
-        6,                          /* DMA stream */
-        4                           /* DMA channel */
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_A,3),
+        .tx_pin     = GPIO_PIN(PORT_A,2),
+        .af         = GPIO_AF7,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
+        .dma_stream = 6,
+        .dma_chan   = 4
     },
     {
-        USART3,                     /* device base register */
-        RCC_APB1ENR_USART3EN,       /* RCC mask */
-        GPIO_PIN(PORT_D,9),         /* RX pin */
-        GPIO_PIN(PORT_D,8),         /* TX pin */
-        GPIO_AF7,                   /* pin AF */
-        USART3_IRQn,                /* IRQ channel */
-        3,                          /* DMA stream */
-        4                           /* DMA channel */
+        .dev        = USART3,
+        .rcc_mask   = RCC_APB1ENR_USART3EN,
+        .rx_pin     = GPIO_PIN(PORT_D,9),
+        .tx_pin     = GPIO_PIN(PORT_D,8),
+        .af         = GPIO_AF7,
+        .bus        = APB1,
+        .irqn       = USART3_IRQn,
+        .dma_stream = 3,
+        .dma_chan   = 4
     },
 };
 

--- a/cpu/stm32_common/Makefile
+++ b/cpu/stm32_common/Makefile
@@ -1,3 +1,5 @@
+MODULE = stm32_common
+
 DIRS = periph
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/stm32_common/Makefile.include
+++ b/cpu/stm32_common/Makefile.include
@@ -5,8 +5,8 @@ export CFLAGS += -DCPU_FAM_$(FAM)
 # include common periph module
 USEMODULE += periph_common
 
-# include stm32 common periph drivers
-USEMODULE += stm32_common_periph
+# include stm32 common functions and stm32 common periph drivers
+USEMODULE += stm32_common stm32_common_periph
 
 # export the common include directory
 export INCLUDES += -I$(RIOTCPU)/stm32_common/include

--- a/cpu/stm32_common/cpu_common.c
+++ b/cpu/stm32_common/cpu_common.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_cortexm_common
+ * @{
+ *
+ * @file
+ * @brief       Shared CPU specific function for the STM32 CPU family
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "periph_cpu_common.h"
+
+void periph_clk_en(uint8_t bus, uint32_t mask)
+{
+    if (bus == APB1) {
+        RCC->APB1ENR |= mask;
+    } else {
+        RCC->APB2ENR |= mask;
+    }
+}
+
+void periph_clk_dis(uint8_t bus, uint32_t mask)
+{
+    if (bus == APB1) {
+        RCC->APB1ENR &= ~(mask);
+    } else {
+        RCC->APB2ENR &= ~(mask);
+    }
+}

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -43,9 +43,25 @@ extern "C" {
  * @brief   Available peripheral buses
  */
 enum {
-    APB1,
-    APB2
+    APB1,           /**< APB1 bus */
+    APB2            /**< APB2 bus */
 };
+
+/**
+ * @brief   Enable the given peripheral clock
+ *
+ * @param[in] bus       bus the peripheral is connected to
+ * @param[in] mask      bit in the RCC enable register
+ */
+void periph_clk_en(uint8_t bus, uint32_t mask);
+
+/**
+ * @brief   Disable the given peripheral clock
+ *
+ * @param[in] bus       bus the peripheral is connected to
+ * @param[in] mask      bit in the RCC enable register
+ */
+void periph_clk_dis(uint8_t bus, uint32_t mask);
 
 #ifdef __cplusplus
 }

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -120,8 +120,8 @@ typedef struct {
  */
 typedef struct {
     TIM_TypeDef *dev;       /**< timer device */
+    uint32_t rcc_bit;       /**< corresponding bit in the RCC register */
     uint8_t bus;            /**< APBx bus the timer is clock from */
-    uint8_t rcc_bit;        /**< corresponding bit in the RCC register */
     uint8_t irqn;           /**< global IRQ channel */
 } timer_conf_t;
 

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -120,7 +120,7 @@ typedef struct {
  */
 typedef struct {
     TIM_TypeDef *dev;       /**< timer device */
-    uint32_t rcc_bit;       /**< corresponding bit in the RCC register */
+    uint32_t rcc_mask;      /**< corresponding bit in the RCC register */
     uint8_t bus;            /**< APBx bus the timer is clock from */
     uint8_t irqn;           /**< global IRQ channel */
 } timer_conf_t;

--- a/cpu/stm32f1/periph/timer.c
+++ b/cpu/stm32f1/periph/timer.c
@@ -37,19 +37,6 @@ static inline TIM_TypeDef *dev(tim_t tim)
     return timer_config[tim].dev;
 }
 
-/**
- * @brief   Enable the peripheral clock for the given timer
- */
-static void clk_en(tim_t tim)
-{
-    if (timer_config[tim].bus == APB1) {
-        RCC->APB1ENR |= timer_config[tim].rcc_bit;
-    }
-    else {
-        RCC->APB2ENR |= timer_config[tim].rcc_bit;
-    }
-}
-
 int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 {
     /* check if device is valid */
@@ -62,7 +49,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     isr_ctx[tim].arg = arg;
 
     /* enable the peripheral clock */
-    clk_en(tim);
+    periph_clk_en(timer_config[tim].bus, timer_config[tim].rcc_mask);
 
     /* configure the timer as upcounter in continuous mode */
     dev(tim)->CR1  = 0;
@@ -145,7 +132,6 @@ static inline void irq_handler(tim_t tim)
             isr_ctx[tim].cb(isr_ctx[tim].arg, i);
         }
     }
-
     if (sched_context_switch_request) {
         thread_yield();
     }

--- a/cpu/stm32f4/include/periph_cpu.h
+++ b/cpu/stm32f4/include/periph_cpu.h
@@ -122,6 +122,7 @@ typedef struct {
     gpio_t rx_pin;          /**< RX pin */
     gpio_t tx_pin;          /**< TX pin */
     gpio_af_t af;           /**< alternate pin function to use */
+    uint8_t bus;            /**< APB bus */
     uint8_t irqn;           /**< IRQ channel */
     uint8_t dma_stream;     /**< DMA stream used for TX */
     uint8_t dma_chan;       /**< DMA channel used for TX */


### PR DESCRIPTION
follow up on #5086 (and also rebased on it).

When reworking all the STM periph drivers, we always have the situation where we have to multiples between the APB1 and APB2 ENR. So we might just do this in a central place.

Regarding the `rcc_mask` in the periph confguration: I decided to stay with `uint32_t` in the config and against making this `uint8_t` and shifting in the enable function for now, as this allows for directly using the `RCC_APBxENR_yyy` defines provided by the vendor headers. This seems to me less error prone than doing bit-counting for every peripheral...

EDIT:
This PR also contains a bug-fix for the `stm32f1`, as the `rcc_bit` var was previously only 8-bit while assigning 32-bit masks to it...