### PR TITLE
gnrc_netdev2: do not override res for for ieee802154

### DIFF
--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
@@ -191,7 +191,6 @@ static int _send(gnrc_netdev2_t *gnrc_netdev2, gnrc_pktsnip_t *pkt)
     }
     /* prepare packet for sending */
     vec_snip = gnrc_pktbuf_get_iovec(pkt, &n);
-    res = -ENOBUFS;
     if (vec_snip != NULL) {
         struct iovec *vector;
 
@@ -200,6 +199,9 @@ static int _send(gnrc_netdev2_t *gnrc_netdev2, gnrc_pktsnip_t *pkt)
         vector[0].iov_base = mhr;
         vector[0].iov_len = (size_t)res;
         res = netdev->driver->send(netdev, vector, n);
+    }
+    else {
+        return -ENOBUFS;
     }
     /* release old data */
     gnrc_pktbuf_release(pkt);


### PR DESCRIPTION
`res` is used to set the frame header iovec's length afterwards so overriding it with a negative number is kind of a bad idea ;-).

Provides fix for https://github.com/RIOT-OS/RIOT/pull/4646#issuecomment-197399581 when merged into #4646.