### PR TITLE
core: Fix/refactor function naming in core/incude/irq.h

### DIFF
--- a/boards/arduino-mega2560/board.c
+++ b/boards/arduino-mega2560/board.c
@@ -47,7 +47,7 @@ void board_init(void)
     DDRB |= (1 << DDB7);
     PORTB &= ~(1 << 7);
 
-    enableIRQ();
+    irq_enable();
 }
 
 /**

--- a/boards/avsextrem/drivers/avsextrem-smb380.c
+++ b/boards/avsextrem/drivers/avsextrem-smb380.c
@@ -566,7 +566,7 @@ int16_t SMB380_getTemperature(void)
 {
     int16_t t = 0;
 
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_TEMP, 0, SMB380_READ_REGISTER);
 
@@ -574,7 +574,7 @@ int16_t SMB380_getTemperature(void)
     t = (SMB380_ssp_read() & 0xFF);
     t = (t >> 1) + SMB380_TEMP_OFFSET;
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 
     return t;
 }
@@ -588,7 +588,7 @@ void SMB380_getAcceleration(unsigned char axis, int16_t *pAbs, int16_t *pMg)
         settings.range = SMB380_getRange();
     }
 
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
 
     switch (axis) {
@@ -610,7 +610,7 @@ void SMB380_getAcceleration(unsigned char axis, int16_t *pAbs, int16_t *pMg)
     ur = (SMB380_ssp_read() & SMB380_ACC_MSB_MASK) << 2;
     ur |= (SMB380_ssp_read() & SMB380_ACC_LSB_MASK) >> 6;
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 
     if (pAbs != NULL) {
         if (ur & BIT9) {  //ur<0
@@ -635,18 +635,18 @@ void SMB380_getAcceleration(unsigned char axis, int16_t *pAbs, int16_t *pMg)
 unsigned char SMB380_getChipID(void)
 {
     unsigned char ur = 0;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CHIP_ID, 0, 0);
     ur = (unsigned char)(SMB380_ssp_read() & SMB380_CHIP_ID_MASK);
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
     return ur;
 }
 
 void SMB380_setWakeUpPause(unsigned char duration)
 {
     unsigned char utemp;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CONTROL4, 0, SMB380_READ_REGISTER);
     utemp = SMB380_ssp_read();
@@ -655,19 +655,19 @@ void SMB380_setWakeUpPause(unsigned char duration)
     SMB380_ssp_write(SMB380_CONTROL4, utemp, SMB380_WRITE_REGISTER);
     SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 }
 
 unsigned char SMB380_getWakeUpPause(void)
 {
     unsigned char up;
 
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CONTROL4, 0, SMB380_READ_REGISTER);
     up = (unsigned char)SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
     up &= SMB380_CONTROL4_WAKEUP_PAUSE_MASK;
     up = up >> 1;
 
@@ -683,7 +683,7 @@ void SMB380_setBandWidth(unsigned char bandWidth)
             (bandWidth == SMB380_BAND_WIDTH_375HZ) ||
             (bandWidth == SMB380_BAND_WIDTH_50HZ) ||
             (bandWidth == SMB380_BAND_WIDTH_750HZ)) {
-        unsigned long cpsr = disableIRQ();
+        unsigned long cpsr = irq_disable();
         SMB380_Prepare();
         SMB380_ssp_write(SMB380_CONTROL3, 0, SMB380_READ_REGISTER);
         unsigned char utemp = SMB380_ssp_read();
@@ -692,14 +692,14 @@ void SMB380_setBandWidth(unsigned char bandWidth)
         SMB380_ssp_write(SMB380_CONTROL3, utemp, SMB380_WRITE_REGISTER);
         SMB380_ssp_read();
         SMB380_Unprepare();
-        restoreIRQ(cpsr);
+        irq_restore(cpsr);
     }
 }
 
 void SMB380_setRange(unsigned char range)
 {
     if (range != 0x3) {
-        unsigned long cpsr = disableIRQ();
+        unsigned long cpsr = irq_disable();
         SMB380_Prepare();
         SMB380_ssp_write(SMB380_CONTROL3, 0, SMB380_READ_REGISTER);
         unsigned char utemp = (unsigned char)SMB380_ssp_read();
@@ -708,7 +708,7 @@ void SMB380_setRange(unsigned char range)
         SMB380_ssp_write(SMB380_CONTROL3, utemp, SMB380_WRITE_REGISTER);
         SMB380_ssp_read();
         SMB380_Unprepare();
-        restoreIRQ(cpsr);
+        irq_restore(cpsr);
         settings.countRange = 0;
     }
 
@@ -717,12 +717,12 @@ void SMB380_setRange(unsigned char range)
 unsigned char SMB380_getRange(void)
 {
     unsigned char ur;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CONTROL3, 0, SMB380_READ_REGISTER);
     ur = (SMB380_ssp_read() & SMB380_CONTROL3_RANGE_MASK) >> 3;
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 
     switch (ur) {
         case SMB380_RANGE_2G:
@@ -742,12 +742,12 @@ unsigned char SMB380_getRange(void)
 unsigned char SMB380_getBandWidth(void)
 {
     unsigned char uBand;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CONTROL3, 0, SMB380_READ_REGISTER);
     uBand = SMB380_ssp_read() & SMB380_CONTROL3_BANDWITH_MASK;
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
     return uBand;
 }
 
@@ -785,34 +785,34 @@ int16_t SMB380_getBandWidthAbs(void)
 
 void SMB380_softReset(void)
 {
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CONTROL1, SMB380_CONTROL1_SOFT_RESET_MASK,
                      SMB380_WRITE_REGISTER);
     SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 }
 
 void SMB380_setCustomerReg(unsigned char data)
 {
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CUST1, data, SMB380_WRITE_REGISTER);
     SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 }
 
 unsigned char SMB380_getCustomerReg(void)
 {
     unsigned uReg = 0;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CUST1, 0, SMB380_READ_REGISTER);
     uReg = (unsigned char)SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
     return uReg;
 }
 
@@ -820,7 +820,7 @@ unsigned char SMB380_getCustomerReg(void)
 void SMB380_Selftest_1(void)
 {
     unsigned char uReg = 0;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_LG_THRES, 6, SMB380_WRITE_REGISTER);
     //SSP0Init();
@@ -837,7 +837,7 @@ void SMB380_Selftest_1(void)
     //  SSP0Init();
     SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 }
 
 void SMB380_ShowMemory(void)
@@ -846,12 +846,12 @@ void SMB380_ShowMemory(void)
     printf("SMB380 Speicher\n\r");
 
     for (unsigned char regAd = 0x16; regAd > 0; regAd--) {
-        unsigned long cpsr = disableIRQ();
+        unsigned long cpsr = irq_disable();
         SMB380_Prepare();
         SMB380_ssp_write(regAd - 1, 0, SMB380_READ_REGISTER);
         uint16_t uReg = SMB380_ssp_read();
         SMB380_Unprepare();
-        restoreIRQ(cpsr);
+        irq_restore(cpsr);
         printf("Register: = %X: 0x%X = ", regAd - 1, uReg);
 
         for (int pos = 0; pos < 16; pos++) { //uReg != 0)
@@ -874,20 +874,20 @@ void SMB380_ShowMemory(void)
 
 void SMB380_setUpperLimit(void)
 {
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_HG_THRES, 128, SMB380_WRITE_REGISTER); //1g
     SMB380_ssp_read();
     SMB380_ssp_write(SMB380_HG_DUR, 0, SMB380_WRITE_REGISTER);
     SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 }
 
 void SMB380_enableUpperLimit(void)
 {
     unsigned short uReg;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CONTROL2, 0, SMB380_READ_REGISTER);
     uReg = SMB380_ssp_read();
@@ -895,13 +895,13 @@ void SMB380_enableUpperLimit(void)
                      SMB380_WRITE_REGISTER);
     SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 }
 
 void SMB380_disableUpperLimit(void)
 {
     unsigned short uReg;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CONTROL2, 0, SMB380_READ_REGISTER);
     uReg = SMB380_ssp_read();
@@ -909,13 +909,13 @@ void SMB380_disableUpperLimit(void)
                      SMB380_WRITE_REGISTER);
     SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 }
 
 void SMB380_enableLowerLimit(void)
 {
     unsigned short uReg;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CONTROL2, 0, SMB380_READ_REGISTER);
     uReg = SMB380_ssp_read();
@@ -923,13 +923,13 @@ void SMB380_enableLowerLimit(void)
                      SMB380_WRITE_REGISTER);
     SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 }
 
 void SMB380_disableLowerLimit(void)
 {
     unsigned short uReg;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CONTROL2, 0, SMB380_READ_REGISTER);
     uReg = SMB380_ssp_read();
@@ -937,7 +937,7 @@ void SMB380_disableLowerLimit(void)
                      SMB380_WRITE_REGISTER);
     SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 }
 
 /* @param gvaluefloat - value is in mg
@@ -960,7 +960,7 @@ uint8_t SMB380_setAnyMotionLimit(uint16_t mg, uint16_t gvalueint)
         return 0;
     }
 
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     /* 0,3g = 300 / 15,6mg = 19 */
     SMB380_ssp_write(SMB380_ANY_MOTION_THRES, threshold, SMB380_WRITE_REGISTER);
@@ -969,14 +969,14 @@ uint8_t SMB380_setAnyMotionLimit(uint16_t mg, uint16_t gvalueint)
     SMB380_ssp_write(SMB380_ANY_MOTION_DUR_HYST, 0, SMB380_READ_REGISTER);
     SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
     return 1;
 }
 
 void SMB380_enableAnyMotionLimit(void)
 {
     unsigned short uReg;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CONTROL4, 0, SMB380_READ_REGISTER);
     uReg = SMB380_ssp_read();
@@ -989,13 +989,13 @@ void SMB380_enableAnyMotionLimit(void)
                      SMB380_WRITE_REGISTER);
     SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 }
 
 void SMB380_disableAnyMotionLimit(void)
 {
     unsigned short uReg;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CONTROL2, 0, SMB380_READ_REGISTER);
     uReg = SMB380_ssp_read();
@@ -1010,13 +1010,13 @@ void SMB380_disableAnyMotionLimit(void)
                      SMB380_WRITE_REGISTER);
     SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 }
 
 void SMB380_enableNewDataInt(void)
 {
     unsigned short uReg;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     /*
      * prevent deep sleep, reason: 400 µs wake-up time is to long for 3kHz
      * interrupts
@@ -1032,13 +1032,13 @@ void SMB380_enableNewDataInt(void)
     // measuring temperature dependent internal sample rate of SMB380
     tickStart = xtimer_now();
     tickCurrentSamples = 0;
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 }
 
 void SMB380_disableNewDataInt(void)
 {
     unsigned short uReg;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CONTROL4, 0, SMB380_READ_REGISTER);
     uReg = SMB380_ssp_read();
@@ -1051,13 +1051,13 @@ void SMB380_disableNewDataInt(void)
      * interrupts
      */
     CLRBIT(lpm_prevent_sleep, LPM_PREVENT_SLEEP_ACCSENSOR);
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 }
 
 void SMB380_resetInterruptFlags(void)
 {
     unsigned short uReg;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CONTROL1, 0, SMB380_READ_REGISTER);
     uReg = SMB380_ssp_read();
@@ -1065,13 +1065,13 @@ void SMB380_resetInterruptFlags(void)
                      SMB380_WRITE_REGISTER);
     SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 }
 
 void SMB380_enableEEPROM(void)
 {
     unsigned short uReg;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CONTROL1, 0, SMB380_READ_REGISTER);
     uReg = SMB380_ssp_read();
@@ -1079,13 +1079,13 @@ void SMB380_enableEEPROM(void)
                      SMB380_WRITE_REGISTER);
     SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 }
 
 void SMB380_disableEEPROM(void)
 {
     unsigned short uReg;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
     SMB380_ssp_write(SMB380_CONTROL1, 0, SMB380_READ_REGISTER);
     uReg = SMB380_ssp_read();
@@ -1093,7 +1093,7 @@ void SMB380_disableEEPROM(void)
                      SMB380_WRITE_REGISTER);
     SMB380_ssp_read();
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 }
 
 /*
@@ -1107,7 +1107,7 @@ unsigned char SMB380_readOffset(uint16_t *offset)
     }
 
     unsigned short uReg;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
 
     SMB380_ssp_write(SMB380_OFFSET_LSB_GAIN_X, 0, SMB380_READ_REGISTER);
@@ -1136,7 +1136,7 @@ unsigned char SMB380_readOffset(uint16_t *offset)
     printf("Offset Z: %u \r\n", uReg);
 
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 
     return true;
 }
@@ -1144,7 +1144,7 @@ unsigned char SMB380_readOffset(uint16_t *offset)
 unsigned char SMB380_readOffsetTemp(uint16_t *offset)
 {
     unsigned short uReg;
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
 
     SMB380_ssp_write(SMB380_OFFSET_LSB_GAIN_T, 0, SMB380_READ_REGISTER);
@@ -1157,7 +1157,7 @@ unsigned char SMB380_readOffsetTemp(uint16_t *offset)
     printf("Offset T: %u ", uReg);
 
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 
     return true;
 }
@@ -1178,7 +1178,7 @@ void SMB380_writeOffset(uint16_t *offset, uint8_t EEPROM)
         }
 
         unsigned short uReg;
-        unsigned long cpsr = disableIRQ();
+        unsigned long cpsr = irq_disable();
         SMB380_Prepare();
 
         //x-Axis
@@ -1229,7 +1229,7 @@ void SMB380_writeOffset(uint16_t *offset, uint8_t EEPROM)
         xtimer_usleep(50000);
 
         SMB380_Unprepare();
-        restoreIRQ(cpsr);
+        irq_restore(cpsr);
 
     }
 }
@@ -1247,7 +1247,7 @@ void SMB380_writeOffsetTemp(uint16_t *offset, uint8_t EEPROM)
         }
 
         unsigned short uReg;
-        unsigned long cpsr = disableIRQ();
+        unsigned long cpsr = irq_disable();
         SMB380_Prepare();
 
         //T-Axis
@@ -1267,7 +1267,7 @@ void SMB380_writeOffsetTemp(uint16_t *offset, uint8_t EEPROM)
         xtimer_usleep(50000);
 
         SMB380_Unprepare();
-        restoreIRQ(cpsr);
+        irq_restore(cpsr);
     }
 }
 
@@ -1277,7 +1277,7 @@ unsigned char SMB380_readGain(uint16_t *gain)
         return false;
     }
 
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
 
     //x-gain
@@ -1291,7 +1291,7 @@ unsigned char SMB380_readGain(uint16_t *gain)
     gain[2] = (SMB380_ssp_read() & SMB380_OFFSET_GAIN_MASK);
 
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 
     return true;
 }
@@ -1302,7 +1302,7 @@ unsigned char SMB380_readGainTemp(uint16_t *gain)
         return false;
     }
 
-    unsigned long cpsr = disableIRQ();
+    unsigned long cpsr = irq_disable();
     SMB380_Prepare();
 
     //T-gain
@@ -1310,7 +1310,7 @@ unsigned char SMB380_readGainTemp(uint16_t *gain)
     gain[0] = (SMB380_ssp_read() & SMB380_OFFSET_GAIN_MASK);
 
     SMB380_Unprepare();
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
 
     return true;
 }

--- a/boards/chronos/board_init.c
+++ b/boards/chronos/board_init.c
@@ -93,7 +93,7 @@ void cc430_cpu_init(void)
     // Disable write-access to port mapping registers:
     PMAPPWD = 0;
     // Re-enable all interrupts
-    enableIRQ();
+    irq_enable();
 
 }
 

--- a/boards/msb-430-common/board_init.c
+++ b/boards/msb-430-common/board_init.c
@@ -103,10 +103,10 @@ static void msb_ports_init(void)
 
 void msp430_set_cpu_speed(uint32_t speed)
 {
-    disableIRQ();
+    irq_disable();
     __msp430_cpu_speed = speed;
     msp430_init_dco();
-    enableIRQ();
+    irq_enable();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/boards/qemu-i386/x86_board_init.c
+++ b/boards/qemu-i386/x86_board_init.c
@@ -27,7 +27,7 @@
 
 static bool qemu_shutdown(void)
 {
-    unsigned old_state = disableIRQ();
+    unsigned old_state = irq_disable();
 
     DEBUG("SHUTTING DOWN.\n");
 
@@ -35,7 +35,7 @@ static bool qemu_shutdown(void)
     /* Works for qemu and bochs. */
     outw(0xB004, 0x2000);
 
-    restoreIRQ(old_state);
+    irq_restore(old_state);
     return false;
 }
 

--- a/boards/wsn430-common/board_init.c
+++ b/boards/wsn430-common/board_init.c
@@ -63,10 +63,10 @@ static void msb_ports_init(void)
 
 void msp430_set_cpu_speed(uint32_t speed)
 {
-    disableIRQ();
+    irq_disable();
     __msp430_cpu_speed = speed;
     msp430_init_dco();
-    enableIRQ();
+    irq_enable();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/core/atomic.c
+++ b/core/atomic.c
@@ -31,15 +31,15 @@
 
 int atomic_cas(atomic_int_t *var, int old, int now)
 {
-    unsigned int mask = disableIRQ();
+    unsigned int mask = irq_disable();
 
     if (ATOMIC_VALUE(*var) != old) {
-        restoreIRQ(mask);
+        irq_restore(mask);
         return 0;
     }
 
     ATOMIC_VALUE(*var) = now;
-    restoreIRQ(mask);
+    irq_restore(mask);
     return 1;
 }
 

--- a/core/c11_atomic.c
+++ b/core/c11_atomic.c
@@ -53,11 +53,11 @@ typedef uint64_t I8;
 #define TEMPLATE_ATOMIC_FETCH_OP_N(opname, op, n, prefixop) \
     I##n __atomic_fetch_##opname##_##n (volatile void *ptr, I##n val, int memmodel) \
     { \
-        unsigned int mask = disableIRQ();     \
+        unsigned int mask = irq_disable();    \
         (void)memmodel;                       \
         I##n tmp = *((I##n*)ptr);             \
         *((I##n*)ptr) = prefixop(tmp op val); \
-        restoreIRQ(mask);                     \
+        irq_restore(mask);                    \
         return tmp;                           \
     }
 

--- a/core/include/arch/irq_arch.h
+++ b/core/include/arch/irq_arch.h
@@ -37,10 +37,10 @@
  * @{
  */
 #ifdef COREIF_NG
-#define enableIRQ       irq_arch_enable
-#define disableIRQ      irq_arch_disable
-#define restoreIRQ      irq_arch_restore
-#define inISR           irq_arch_in
+#define irq_enable      irq_arch_enable
+#define irq_disable     irq_arch_disable
+#define irq_restore     irq_arch_restore
+#define irq_is_in       irq_arch_in
 #endif
 /** @} */
 

--- a/core/include/irq.h
+++ b/core/include/irq.h
@@ -33,22 +33,22 @@
  *
  * @return  Previous value of status register. The return value should not
  *          interpreted as a boolean value. The actual value is only
- *          significant for restoreIRQ().
+ *          significant for irq_restore().
  *
- * @see     restoreIRQ
+ * @see     irq_restore
  */
-unsigned disableIRQ(void);
+unsigned irq_disable(void);
 
 /**
  * @brief   This function clears the IRQ disable bit in the status register
  *
  * @return  Previous value of status register. The return value should not
  *          interpreted as a boolean value. The actual value is only
- *          significant for restoreIRQ().
+ *          significant for irq_restore().
  *
- * @see     restoreIRQ
+ * @see     irq_restore
  */
-unsigned enableIRQ(void);
+unsigned irq_enable(void);
 
 /**
  * @brief   This function restores the IRQ disable bit in the status register
@@ -56,16 +56,16 @@ unsigned enableIRQ(void);
  *
  * @param[in] state   state to restore
  *
- * @see     enableIRQ
- * @see     disableIRQ
+ * @see     irq_enable
+ * @see     irq_disable
  */
-void restoreIRQ(unsigned state);
+void irq_restore(unsigned state);
 
 /**
  * @brief   Check whether called from interrupt service routine
  * @return  true, if in interrupt service routine, false if not
  */
-int inISR(void);
+int irq_is_in(void);
 
 #ifdef __cplusplus
 }

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -125,7 +125,7 @@ void sched_set_status(thread_t *process, unsigned int status);
  * @details     Either yield if other_prio is higher than the current priority,
  *              or if the current thread is not on the runqueue.
  *
- *              Depending on whether the current execution is in an ISR (inISR()),
+ *              Depending on whether the current execution is in an ISR (irq_is_in()),
  *              thread_yield_higher() is called or @ref sched_context_switch_request is set,
  *              respectively.
  *

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -87,7 +87,7 @@ static char idle_stack[THREAD_STACKSIZE_IDLE];
 
 void kernel_init(void)
 {
-    (void) disableIRQ();
+    (void) irq_disable();
 
     thread_create(idle_stack, sizeof(idle_stack),
             THREAD_PRIORITY_IDLE,

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -53,13 +53,13 @@ void mutex_lock(struct mutex_t *mutex)
 
 static void mutex_wait(struct mutex_t *mutex)
 {
-    unsigned irqstate = disableIRQ();
+    unsigned irqstate = irq_disable();
     DEBUG("%s: Mutex in use. %u\n", sched_active_thread->name, ATOMIC_VALUE(mutex->val));
 
     if (atomic_set_to_one(&mutex->val)) {
         /* somebody released the mutex. return. */
         DEBUG("%s: mutex_wait early out. %u\n", sched_active_thread->name, ATOMIC_VALUE(mutex->val));
-        restoreIRQ(irqstate);
+        irq_restore(irqstate);
         return;
     }
 
@@ -74,7 +74,7 @@ static void mutex_wait(struct mutex_t *mutex)
 
     priority_queue_add(&(mutex->queue), &n);
 
-    restoreIRQ(irqstate);
+    irq_restore(irqstate);
 
     thread_yield_higher();
 
@@ -83,12 +83,12 @@ static void mutex_wait(struct mutex_t *mutex)
 
 void mutex_unlock(struct mutex_t *mutex)
 {
-    unsigned irqstate = disableIRQ();
+    unsigned irqstate = irq_disable();
     DEBUG("mutex_unlock(): val: %u pid: %" PRIkernel_pid "\n", ATOMIC_VALUE(mutex->val), sched_active_pid);
 
     if (ATOMIC_VALUE(mutex->val) == 0) {
         /* the mutex was not locked */
-        restoreIRQ(irqstate);
+        irq_restore(irqstate);
         return;
     }
 
@@ -96,7 +96,7 @@ void mutex_unlock(struct mutex_t *mutex)
     if (!next) {
         /* the mutex was locked and no thread was waiting for it */
         ATOMIC_VALUE(mutex->val) = 0;
-        restoreIRQ(irqstate);
+        irq_restore(irqstate);
         return;
     }
 
@@ -105,14 +105,14 @@ void mutex_unlock(struct mutex_t *mutex)
     sched_set_status(process, STATUS_PENDING);
 
     uint16_t process_priority = process->priority;
-    restoreIRQ(irqstate);
+    irq_restore(irqstate);
     sched_switch(process_priority);
 }
 
 void mutex_unlock_and_sleep(struct mutex_t *mutex)
 {
     DEBUG("%s: unlocking mutex. val: %u pid: %" PRIkernel_pid ", and taking a nap\n", sched_active_thread->name, ATOMIC_VALUE(mutex->val), sched_active_pid);
-    unsigned irqstate = disableIRQ();
+    unsigned irqstate = irq_disable();
 
     if (ATOMIC_VALUE(mutex->val) != 0) {
         priority_queue_node_t *next = priority_queue_remove_head(&(mutex->queue));
@@ -127,6 +127,6 @@ void mutex_unlock_and_sleep(struct mutex_t *mutex)
     }
     DEBUG("%s: going to sleep.\n", sched_active_thread->name);
     sched_set_status((thread_t*) sched_active_thread, STATUS_SLEEPING);
-    restoreIRQ(irqstate);
+    irq_restore(irqstate);
     thread_yield_higher();
 }

--- a/core/panic.c
+++ b/core/panic.c
@@ -69,7 +69,7 @@ NORETURN void core_panic(core_panic_t crash_code, const char *message)
 #endif
     }
     /* disable watchdog and all possible sources of interrupts */
-    disableIRQ();
+    irq_disable();
     panic_arch();
 #ifndef DEVELHELP
     /* DEVELHELP not set => reboot system */

--- a/core/sched.c
+++ b/core/sched.c
@@ -163,7 +163,7 @@ void sched_switch(uint16_t other_prio)
           active_thread->pid, current_prio, on_runqueue, other_prio);
 
     if (!on_runqueue || (current_prio > other_prio)) {
-        if (inISR()) {
+        if (irq_is_in()) {
             DEBUG("sched_switch: setting sched_context_switch_request.\n");
             sched_context_switch_request = 1;
         }
@@ -181,7 +181,7 @@ NORETURN void sched_task_exit(void)
 {
     DEBUG("sched_task_exit: ending thread %" PRIkernel_pid "...\n", sched_active_thread->pid);
 
-    (void) disableIRQ();
+    (void) irq_disable();
     sched_threads[sched_active_pid] = NULL;
     sched_num_threads--;
 

--- a/core/thread.c
+++ b/core/thread.c
@@ -53,13 +53,13 @@ const char *thread_getname(kernel_pid_t pid)
 
 void thread_sleep(void)
 {
-    if (inISR()) {
+    if (irq_is_in()) {
         return;
     }
 
-    unsigned state = disableIRQ();
+    unsigned state = irq_disable();
     sched_set_status((thread_t *)sched_active_thread, STATUS_SLEEPING);
-    restoreIRQ(state);
+    irq_restore(state);
     thread_yield_higher();
 }
 
@@ -67,7 +67,7 @@ int thread_wakeup(kernel_pid_t pid)
 {
     DEBUG("thread_wakeup: Trying to wakeup PID %" PRIkernel_pid "...\n", pid);
 
-    unsigned old_state = disableIRQ();
+    unsigned old_state = irq_disable();
 
     thread_t *other_thread = (thread_t *) thread_get(pid);
 
@@ -79,7 +79,7 @@ int thread_wakeup(kernel_pid_t pid)
 
         sched_set_status(other_thread, STATUS_RUNNING);
 
-        restoreIRQ(old_state);
+        irq_restore(old_state);
         sched_switch(other_thread->priority);
 
         return 1;
@@ -88,18 +88,18 @@ int thread_wakeup(kernel_pid_t pid)
         DEBUG("thread_wakeup: Thread is not sleeping!\n");
     }
 
-    restoreIRQ(old_state);
+    irq_restore(old_state);
     return STATUS_NOT_FOUND;
 }
 
 void thread_yield(void)
 {
-    unsigned old_state = disableIRQ();
+    unsigned old_state = irq_disable();
     thread_t *me = (thread_t *)sched_active_thread;
     if (me->status >= STATUS_ON_RUNQUEUE) {
         clist_advance(&sched_runqueues[me->priority]);
     }
-    restoreIRQ(old_state);
+    irq_restore(old_state);
 
     thread_yield_higher();
 }
@@ -169,7 +169,7 @@ kernel_pid_t thread_create(char *stack, int stacksize, char priority, int flags,
     }
 #endif
 
-    unsigned state = disableIRQ();
+    unsigned state = irq_disable();
 
     kernel_pid_t pid = KERNEL_PID_UNDEF;
     for (kernel_pid_t i = KERNEL_PID_FIRST; i <= KERNEL_PID_LAST; ++i) {
@@ -181,7 +181,7 @@ kernel_pid_t thread_create(char *stack, int stacksize, char priority, int flags,
     if (pid == KERNEL_PID_UNDEF) {
         DEBUG("thread_create(): too many threads!\n");
 
-        restoreIRQ(state);
+        irq_restore(state);
 
         return -EOVERFLOW;
     }
@@ -224,13 +224,13 @@ kernel_pid_t thread_create(char *stack, int stacksize, char priority, int flags,
         sched_set_status(cb, STATUS_PENDING);
 
         if (!(flags & THREAD_CREATE_WOUT_YIELD)) {
-            restoreIRQ(state);
+            irq_restore(state);
             sched_switch(priority);
             return pid;
         }
     }
 
-    restoreIRQ(state);
+    irq_restore(state);
 
     return pid;
 }

--- a/cpu/arm7_common/VIC.c
+++ b/cpu/arm7_common/VIC.c
@@ -18,7 +18,7 @@ static inline unsigned __get_cpsr(void)
     return retval;
 }
 
-int inISR(void)
+int irq_is_in(void)
 {
     int retval;
     asm volatile(" mrs  %0, cpsr" : "=r"(retval) : /* no inputs */);
@@ -30,7 +30,7 @@ static inline void __set_cpsr(unsigned val)
     asm volatile(" msr  cpsr, %0" : /* no outputs */ : "r"(val));
 }
 
-unsigned disableIRQ(void)
+unsigned irq_disable(void)
 {
     unsigned _cpsr;
 
@@ -39,7 +39,7 @@ unsigned disableIRQ(void)
     return _cpsr;
 }
 
-unsigned restoreIRQ(unsigned oldCPSR)
+unsigned irq_restore(unsigned oldCPSR)
 {
     unsigned _cpsr;
 
@@ -56,7 +56,7 @@ unsigned IRQenabled(void)
     return (_cpsr & IRQ_MASK);
 }
 
-unsigned enableIRQ(void)
+unsigned irq_enable(void)
 {
     unsigned _cpsr;
 

--- a/cpu/atmega2560/periph/timer.c
+++ b/cpu/atmega2560/periph/timer.c
@@ -94,7 +94,7 @@ int timer_set(tim_t dev, int channel, unsigned int timeout)
 
 int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 {
-    unsigned state = disableIRQ();
+    unsigned state = irq_disable();
 
     switch (dev) {
 #if TIMER_0_EN
@@ -119,7 +119,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
                     break;
 
                 default:
-                    restoreIRQ(state);
+                    irq_restore(state);
                     return -1;
             }
 
@@ -147,7 +147,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
                     break;
 
                 default:
-                    restoreIRQ(state);
+                    irq_restore(state);
                     return -1;
             }
 
@@ -175,7 +175,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
                     break;
 
                 default:
-                    restoreIRQ(state);
+                    irq_restore(state);
                     return -1;
             }
 
@@ -184,13 +184,13 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 
         case TIMER_UNDEFINED:
         default:
-            restoreIRQ(state);
+            irq_restore(state);
             return -1;
     }
 
     /* enable interrupts for given timer */
     timer_irq_enable(dev);
-    restoreIRQ(state);
+    irq_restore(state);
 
     return 1;
 }
@@ -282,7 +282,7 @@ unsigned int timer_read(tim_t dev)
      * Disabling interrupts globally because read from 16 Bit register can
      * otherwise be messed up
      */
-    unsigned state = disableIRQ();
+    unsigned state = irq_disable();
 
     switch (dev) {
 #if TIMER_0_EN
@@ -319,7 +319,7 @@ unsigned int timer_read(tim_t dev)
             a = 0;
     }
 
-    restoreIRQ(state);
+    irq_restore(state);
     return a;
 }
 

--- a/cpu/atmega_common/thread_arch.c
+++ b/cpu/atmega_common/thread_arch.c
@@ -212,7 +212,7 @@ void thread_arch_start_threading(void)
 void NORETURN __enter_thread_mode(void) __attribute__((naked));
 void NORETURN __enter_thread_mode(void)
 {
-    enableIRQ();
+    irq_enable();
     __context_restore();
     asm volatile("ret");
 
@@ -224,9 +224,9 @@ void thread_arch_yield(void)
 {
     __context_save();
 
-    /* disableIRQ(); */ /* gets already disabled during __context_save() */
+    /* irq_disable(); */ /* gets already disabled during __context_save() */
     sched_run();
-    enableIRQ();
+    irq_enable();
 
     __context_restore();
     asm volatile("ret");

--- a/cpu/cc430/cc430-adc.c
+++ b/cpu/cc430/cc430-adc.c
@@ -72,7 +72,7 @@ uint16_t adc12_single_conversion(uint16_t ref, uint16_t sht, uint16_t channel)
     ADC12CTL1 = ADC12SHP;                       /* Enable sample timer */
     ADC12MCTL0 = ADC12SREF_1 + channel;         /* ADC input channel   */
     ADC12IE = 0x001;                            /* ADC_IFG upon conv result-ADCMEMO */
-    enableIRQ();
+    irq_enable();
 
     /* Wait 66us to allow internal reference to settle */
     xtimer_usleep(66);

--- a/cpu/lpc2387/cpu.c
+++ b/cpu/lpc2387/cpu.c
@@ -87,7 +87,7 @@ bool install_irq(int IntNumber, void (*HandlerAddr)(void), int Priority)
 
 __attribute__((naked,noreturn)) void arm_reset(void)
 {
-    disableIRQ();
+    irq_disable();
     WDTC = 0x0FFFF;
     WDMOD = 0x03;
     WDFEED= 0xAA;

--- a/cpu/lpc2387/i2c/i2c.c
+++ b/cpu/lpc2387/i2c/i2c.c
@@ -466,7 +466,7 @@ void i2c_interface0_master_handler(void) //__irq
     state_value = I20STAT;
 
     //IENABLE;          /* handles nested interrupt */
-    //enableIRQ();
+    //irq_enable();
     switch (state_value) {
         case 0x08: /* A Start condition is issued. */
             //puts("A Start condition is issued\n");
@@ -589,7 +589,7 @@ void i2c_interface0_master_handler(void) //__irq
     }
 
     //IDISABLE;
-    //disableIRQ();
+    //irq_disable();
     //puts("leave I2C handler function\n");
     VICVectAddr = 0; /* Acknowledge Interrupt */
 }
@@ -608,7 +608,7 @@ void i2c_interface1_master_handler(void) //__irq
     state_value = I21STAT;
 
     //IENABLE;    /* handles nested interrupt */
-    //enableIRQ();
+    //irq_enable();
     switch (state_value) {
         case 0x08: /* A Start condition is issued. */
             //puts("A Start condition is issued\n");
@@ -732,7 +732,7 @@ void i2c_interface1_master_handler(void) //__irq
     }
 
     //IDISABLE;
-    //disableIRQ();
+    //irq_disable();
     //puts("leave I2C handler function\n");
     VICVectAddr = 0; /* Acknowledge Interrupt */
 }
@@ -751,7 +751,7 @@ void i2c_interface2_master_handler(void) //__irq
     state_value = I22STAT;
 
     //IENABLE;  /* handles nested interrupt */
-    //enableIRQ();
+    //irq_enable();
     switch (state_value) {
         case 0x08: /* A Start condition is issued. */
             //puts("A Start condition is issued\n");
@@ -875,7 +875,7 @@ void i2c_interface2_master_handler(void) //__irq
     }
 
     //IDISABLE;
-    //disableIRQ();
+    //irq_disable();
     //puts("leave I2C handler function\n");
     VICVectAddr = 0; /* Acknowledge Interrupt */
 }

--- a/cpu/lpc2387/lpc23xx-iap.c
+++ b/cpu/lpc2387/lpc23xx-iap.c
@@ -75,14 +75,14 @@ uint8_t flashrom_write(uint8_t *dst, const uint8_t *src, size_t size)
     }
 
     /*  write flash */
-    unsigned intstate = disableIRQ();
+    unsigned intstate = irq_disable();
     err = copy_ram_to_flash((uint32_t) dst, (uint32_t) src, 256);
-    restoreIRQ(intstate);
+    irq_restore(intstate);
 
     if (err) {
         DEBUG("ERROR: COPY_RAM_TO_FLASH: %u\n", err);
         /* set interrupts back and return */
-        restoreIRQ(intstate);
+        irq_restore(intstate);
         return 0;
     }
     /* check result */
@@ -120,16 +120,16 @@ uint8_t flashrom_erase(uint8_t *addr)
         return 0;
     }
 
-    intstate = disableIRQ();
+    intstate = irq_disable();
 
     /* erase sector */
     if (erase_sectors(sec, sec)) {
         DEBUG("-- ERROR: ERASE SECTOR --\n");
-        restoreIRQ(intstate);
+        irq_restore(intstate);
         return 0;
     }
 
-    restoreIRQ(intstate);
+    irq_restore(intstate);
 
     /* check again */
     if (blank_check_sector(sec, sec)) {

--- a/cpu/lpc2387/periph/gpio.c
+++ b/cpu/lpc2387/periph/gpio.c
@@ -175,7 +175,7 @@ static void _gpio_configure(gpio_t pin, unsigned rising, unsigned falling)
     /* configure irq */
     unsigned int bit = 0x1 << _pin;
 
-    unsigned state = disableIRQ();
+    unsigned state = irq_disable();
 
     *en_clr |= bit;                                         /* clear interrupt */
 
@@ -193,7 +193,7 @@ static void _gpio_configure(gpio_t pin, unsigned rising, unsigned falling)
         *en_r &= ~bit;                                      /* disable rising edge */
     }
 
-    restoreIRQ(state);
+    irq_restore(state);
 }
 
 void gpio_irq_enable(gpio_t pin)

--- a/cpu/msp430-common/include/cpu.h
+++ b/cpu/msp430-common/include/cpu.h
@@ -70,7 +70,7 @@ static inline void __attribute__((always_inline)) __enable_irq(void)
 /**
  * @brief   The current ISR state (inside or not)
  */
-extern volatile int __inISR;
+extern volatile int __irq_is_in;
 
 /**
  * @brief   Memory used as stack for the interrupt context
@@ -127,7 +127,7 @@ static inline void __attribute__((always_inline)) __enter_isr(void)
 {
     __save_context();
     __asm__("mov.w %0,r1" : : "i"(__isr_stack + MSP430_ISR_STACK_SIZE));
-    __inISR = 1;
+    __irq_is_in = 1;
 }
 
 /**
@@ -135,7 +135,7 @@ static inline void __attribute__((always_inline)) __enter_isr(void)
  */
 static inline void __attribute__((always_inline)) __exit_isr(void)
 {
-    __inISR = 0;
+    __irq_is_in = 0;
 
     if (sched_context_switch_request) {
         sched_run();

--- a/cpu/msp430-common/irq.c
+++ b/cpu/msp430-common/irq.c
@@ -22,11 +22,11 @@
 #include "irq.h"
 #include "cpu.h"
 
-volatile int __inISR = 0;
+volatile int __irq_is_in = 0;
 
 char __isr_stack[MSP430_ISR_STACK_SIZE];
 
-unsigned int disableIRQ(void)
+unsigned int irq_disable(void)
 {
     unsigned int state;
     __asm__("mov.w r2,%0" : "=r"(state));
@@ -39,7 +39,7 @@ unsigned int disableIRQ(void)
     return state;
 }
 
-unsigned int enableIRQ(void)
+unsigned int irq_enable(void)
 {
     unsigned int state;
     __asm__("mov.w r2,%0" : "=r"(state));
@@ -52,14 +52,14 @@ unsigned int enableIRQ(void)
     return state;
 }
 
-void restoreIRQ(unsigned int state)
+void irq_restore(unsigned int state)
 {
     if (state) {
         __enable_irq();
     }
 }
 
-int inISR(void)
+int irq_is_in(void)
 {
-    return __inISR;
+    return __irq_is_in;
 }

--- a/cpu/msp430-common/msp430-main.c
+++ b/cpu/msp430-common/msp430-main.c
@@ -110,10 +110,10 @@ static char *cur_break = (char *) &_end;
 
 void msp430_cpu_init(void)
 {
-    disableIRQ();
+    irq_disable();
     init_ports();
     //  lpm_init();
-    enableIRQ();
+    irq_enable();
 
     if ((uintptr_t)cur_break & 1) { /* Workaround for msp430-ld bug!*/
         cur_break++;

--- a/cpu/msp430fxyz/flashrom.c
+++ b/cpu/msp430fxyz/flashrom.c
@@ -83,7 +83,7 @@ static uint8_t prepare(void)
 
     /* disable all interrupts to protect CPU
      during programming from system crash */
-    istate = disableIRQ();
+    istate = irq_disable();
 
     /* disable all NMI-Interrupt sources */
     ie1 = IE1;
@@ -98,7 +98,7 @@ void finish(uint8_t istate)
     /* Enable interrupts. */
     IE1 = ie1;
     IE2 = ie2;
-    restoreIRQ(istate);
+    irq_restore(istate);
 }
 
 static inline void busy_wait(void)

--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -138,25 +138,25 @@ void native_print_signals(void)
 /**
  * block signals
  */
-unsigned disableIRQ(void)
+unsigned irq_disable(void)
 {
     unsigned int prev_state;
 
     _native_syscall_enter();
-    DEBUG("disableIRQ()\n");
+    DEBUG("irq_disable()\n");
 
     if (_native_in_isr == 1) {
-        DEBUG("disableIRQ + _native_in_isr\n");
+        DEBUG("irq_disable + _native_in_isr\n");
     }
 
     if (sigprocmask(SIG_SETMASK, &_native_sig_set_dint, NULL) == -1) {
-        err(EXIT_FAILURE, "disableIRQ: sigprocmask");
+        err(EXIT_FAILURE, "irq_disable: sigprocmask");
     }
 
     prev_state = native_interrupts_enabled;
     native_interrupts_enabled = 0;
 
-    DEBUG("disableIRQ(): return\n");
+    DEBUG("irq_disable(): return\n");
     _native_syscall_leave();
 
     return prev_state;
@@ -165,20 +165,20 @@ unsigned disableIRQ(void)
 /**
  * unblock signals
  */
-unsigned enableIRQ(void)
+unsigned irq_enable(void)
 {
     unsigned int prev_state;
 
     if (_native_in_isr == 1) {
 #ifdef DEVELHELP
-        real_write(STDERR_FILENO, "enableIRQ + _native_in_isr\n", 27);
+        real_write(STDERR_FILENO, "irq_enable + _native_in_isr\n", 27);
 #else
-        DEBUG("enableIRQ + _native_in_isr\n");
+        DEBUG("irq_enable + _native_in_isr\n");
 #endif
     }
 
     _native_syscall_enter();
-    DEBUG("enableIRQ()\n");
+    DEBUG("irq_enable()\n");
 
     /* Mark the IRQ as enabled first since sigprocmask could call the handler
      * before returning to userspace.
@@ -188,33 +188,33 @@ unsigned enableIRQ(void)
     native_interrupts_enabled = 1;
 
     if (sigprocmask(SIG_SETMASK, &_native_sig_set, NULL) == -1) {
-        err(EXIT_FAILURE, "enableIRQ: sigprocmask");
+        err(EXIT_FAILURE, "irq_enable: sigprocmask");
     }
 
     _native_syscall_leave();
 
-    DEBUG("enableIRQ(): return\n");
+    DEBUG("irq_enable(): return\n");
 
     return prev_state;
 }
 
-void restoreIRQ(unsigned state)
+void irq_restore(unsigned state)
 {
-    DEBUG("restoreIRQ()\n");
+    DEBUG("irq_restore()\n");
 
     if (state == 1) {
-        enableIRQ();
+        irq_enable();
     }
     else {
-        disableIRQ();
+        irq_disable();
     }
 
     return;
 }
 
-int inISR(void)
+int irq_is_in(void)
 {
-    DEBUG("inISR: %i\n", _native_in_isr);
+    DEBUG("irq_is_in: %i\n", _native_in_isr);
     return _native_in_isr;
 }
 
@@ -297,7 +297,7 @@ void native_isr_entry(int sig, siginfo_t *info, void *context)
     }
 
     /* XXX: Workaround safety check - whenever this happens it really
-     * indicates a bug in disableIRQ */
+     * indicates a bug in irq_disable */
     if (native_interrupts_enabled == 0) {
         //printf("interrupts are off, but I caught a signal.\n");
         return;
@@ -356,7 +356,7 @@ void set_signal_handler(int sig, bool add)
     struct sigaction sa;
     int ret;
 
-    /* update the signal mask so enableIRQ()/disableIRQ() will be aware */
+    /* update the signal mask so irq_enable()/irq_disable() will be aware */
     if (add) {
         _native_syscall_enter();
         ret = sigdelset(&_native_sig_set, sig);
@@ -404,12 +404,12 @@ int register_interrupt(int sig, _native_callback_t handler)
 {
     DEBUG("register_interrupt\n");
 
-    unsigned state = disableIRQ();
+    unsigned state = irq_disable();
 
     native_irq_handlers[sig] = handler;
     set_signal_handler(sig, true);
 
-    restoreIRQ(state);
+    irq_restore(state);
 
     return 0;
 }
@@ -421,12 +421,12 @@ int unregister_interrupt(int sig)
 {
     DEBUG("unregister_interrupt\n");
 
-    unsigned state = disableIRQ();
+    unsigned state = irq_disable();
 
     set_signal_handler(sig, false);
     native_irq_handlers[sig] = NULL;
 
-    restoreIRQ(state);
+    irq_restore(state);
 
     return 0;
 }

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -140,7 +140,7 @@ void cpu_switch_context_exit(void)
 #endif
 
     if (_native_in_isr == 0) {
-        disableIRQ();
+        irq_disable();
         _native_in_isr = 1;
         native_isr_context.uc_stack.ss_sp = __isr_stack;
         native_isr_context.uc_stack.ss_size = SIGSTKSZ;
@@ -177,7 +177,7 @@ void thread_yield_higher(void)
     ucontext_t *ctx = (ucontext_t *)(sched_active_thread->sp);
     if (_native_in_isr == 0) {
         _native_in_isr = 1;
-        disableIRQ();
+        irq_disable();
         native_isr_context.uc_stack.ss_sp = __isr_stack;
         native_isr_context.uc_stack.ss_size = SIGSTKSZ;
         native_isr_context.uc_stack.ss_flags = 0;
@@ -185,7 +185,7 @@ void thread_yield_higher(void)
         if (swapcontext(ctx, &native_isr_context) == -1) {
             err(EXIT_FAILURE, "thread_yield_higher: swapcontext");
         }
-        enableIRQ();
+        irq_enable();
     }
     else {
         isr_thread_yield();

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -120,7 +120,7 @@ void _native_syscall_leave(void)
        )
     {
         _native_in_isr = 1;
-        unsigned int mask = disableIRQ();
+        unsigned int mask = irq_disable();
         _native_cur_ctx = (ucontext_t *)sched_active_thread->sp;
         native_isr_context.uc_stack.ss_sp = __isr_stack;
         native_isr_context.uc_stack.ss_size = SIGSTKSZ;
@@ -129,7 +129,7 @@ void _native_syscall_leave(void)
         if (swapcontext(_native_cur_ctx, &native_isr_context) == -1) {
             err(EXIT_FAILURE, "_native_syscall_leave: swapcontext");
         }
-        restoreIRQ(mask);
+        irq_restore(mask);
     }
 }
 

--- a/cpu/native/tramp.S
+++ b/cpu/native/tramp.S
@@ -21,7 +21,7 @@ __native_sig_leave_tramp:
     call _swapcontext
     addl $8, %esp
 
-    call _enableIRQ
+    call _enableIRQ /* TODO this call ? */
 
     movl $0x0, __native_in_isr
     popal
@@ -53,7 +53,7 @@ _native_sig_leave_tramp:
     bl      swapcontext
 
     /* reeanble interrupts */
-    bl      enableIRQ
+    bl      irq_enable
 
     /* _native_in_isr = 0 */
     eor     r0, r0, r0
@@ -78,7 +78,7 @@ _native_sig_leave_tramp:
     call swapcontext
     addl $8, %esp
 
-    call enableIRQ
+    call irq_enable
 
     movl $0x0, _native_in_isr
     popal

--- a/cpu/stm32f4/periph/i2c.c
+++ b/cpu/stm32f4/periph/i2c.c
@@ -264,10 +264,10 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
             i2c->CR1 &= ~(I2C_CR1_ACK);
 
             DEBUG("Clear ADDR and set STOP = 1\n");
-            state = disableIRQ();
+            state = irq_disable();
             _clear_addr(i2c);
             i2c->CR1 |= (I2C_CR1_STOP);
-            restoreIRQ(state);
+            irq_restore(state);
 
             DEBUG("Wait for RXNE == 1\n");
 
@@ -289,20 +289,20 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
             DEBUG("Set POS bit\n");
             i2c->CR1 |= (I2C_CR1_POS | I2C_CR1_ACK);
             DEBUG("Crit block: Clear ADDR bit and clear ACK flag\n");
-            state = disableIRQ();
+            state = irq_disable();
             _clear_addr(i2c);
             i2c->CR1 &= ~(I2C_CR1_ACK);
-            restoreIRQ(state);
+            irq_restore(state);
 
             DEBUG("Wait for transfer to be completed\n");
 
             while (!(i2c->SR1 & I2C_SR1_BTF)) {}
 
             DEBUG("Crit block: set STOP and read first byte\n");
-            state = disableIRQ();
+            state = irq_disable();
             i2c->CR1 |= (I2C_CR1_STOP);
             data[0] = (char)i2c->DR;
-            restoreIRQ(state);
+            irq_restore(state);
 
             DEBUG("read second byte\n");
             data[1] = (char)i2c->DR;
@@ -338,10 +338,10 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
             i2c->CR1 &= ~(I2C_CR1_ACK);
 
             DEBUG("Crit block: set STOP and read N-2 byte\n");
-            state = disableIRQ();
+            state = irq_disable();
             data[i++] = (char)i2c->DR;
             i2c->CR1 |= (I2C_CR1_STOP);
-            restoreIRQ(state);
+            irq_restore(state);
 
             DEBUG("Read N-1 byte\n");
             data[i++] = (char)i2c->DR;

--- a/cpu/stm32f4/periph/uart.c
+++ b/cpu/stm32f4/periph/uart.c
@@ -110,7 +110,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 void uart_write(uart_t uart, const uint8_t *data, size_t len)
 {
     /* in case we are inside an ISR, we need to send blocking */
-    if (inISR()) {
+    if (irq_is_in()) {
         /* send data by active waiting on the TXE flag */
         USART_TypeDef *dev = _dev(uart);
         for (int i = 0; i < len; i++) {

--- a/cpu/stm32l1/periph/i2c.c
+++ b/cpu/stm32l1/periph/i2c.c
@@ -164,10 +164,10 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
             i2c->CR1 &= ~(I2C_CR1_ACK);
 
             DEBUG("Clear ADDR and set STOP = 1\n");
-            state = disableIRQ();
+            state = irq_disable();
             _clear_addr(i2c);
             i2c->CR1 |= (I2C_CR1_STOP);
-            restoreIRQ(state);
+            irq_restore(state);
 
             DEBUG("Wait for RXNE == 1\n");
 
@@ -189,20 +189,20 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
             DEBUG("Set POS bit\n");
             i2c->CR1 |= (I2C_CR1_POS | I2C_CR1_ACK);
             DEBUG("Crit block: Clear ADDR bit and clear ACK flag\n");
-            state = disableIRQ();
+            state = irq_disable();
             _clear_addr(i2c);
             i2c->CR1 &= ~(I2C_CR1_ACK);
-            restoreIRQ(state);
+            irq_restore(state);
 
             DEBUG("Wait for transfer to be completed\n");
 
             while (!(i2c->SR1 & I2C_SR1_BTF)) {}
 
             DEBUG("Crit block: set STOP and read first byte\n");
-            state = disableIRQ();
+            state = irq_disable();
             i2c->CR1 |= (I2C_CR1_STOP);
             data[0] = (char)i2c->DR;
-            restoreIRQ(state);
+            irq_restore(state);
 
             DEBUG("read second byte\n");
             data[1] = (char)i2c->DR;
@@ -238,10 +238,10 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
             i2c->CR1 &= ~(I2C_CR1_ACK);
 
             DEBUG("Crit block: set STOP and read N-2 byte\n");
-            state = disableIRQ();
+            state = irq_disable();
             data[i++] = (char)i2c->DR;
             i2c->CR1 |= (I2C_CR1_STOP);
-            restoreIRQ(state);
+            irq_restore(state);
 
             DEBUG("Read N-1 byte\n");
             data[i++] = (char)i2c->DR;

--- a/cpu/x86/include/x86_pci.h
+++ b/cpu/x86/include/x86_pci.h
@@ -318,7 +318,7 @@ struct x86_known_pci_device;
  * @param[in]   d   Device that (might) need attention.
  *
  * Because PCI is multiplexer, there might not be an IRQ for this device.
- * This callback is called out of the interrupt handler (inISR() == true).
+ * This callback is called out of the interrupt handler (irq_is_in() == true).
  * Lengthy operations should be handled in a dedicated thread; use msg_send_int().
  * You must no enable interrupt inside the handler.
  */

--- a/cpu/x86/include/x86_pic.h
+++ b/cpu/x86/include/x86_pic.h
@@ -121,7 +121,7 @@ void x86_init_pic(void);
  * @brief   Callback handler if there was an interrupt on this IRQ line.
  * @param   irq_num   IRQ line in question.
  *
- * This callback is called out of the interrupt handler (inISR() == true).
+ * This callback is called out of the interrupt handler (irq_is_in() == true).
  * Lengthy operations should be handled in a dedicated thread; use msg_send_int().
  * You must no enable interrupt inside the handler.
  */

--- a/cpu/x86/include/x86_threading.h
+++ b/cpu/x86/include/x86_threading.h
@@ -44,7 +44,7 @@ extern "C" {
 void x86_init_threading(void);
 
 /**
- * @brief   The getter/setter for inISR() for the x86 port.
+ * @brief   The getter/setter for irq_is_in() for the x86 port.
  */
 extern bool x86_in_isr;
 

--- a/cpu/x86/x86_pic.c
+++ b/cpu/x86/x86_pic.c
@@ -132,7 +132,7 @@ static void pic_register_handler(void)
 
 void x86_pic_set_enabled_irqs(uint16_t mask)
 {
-    unsigned old_status = disableIRQ();
+    unsigned old_status = irq_disable();
 
     mask |= PIC_MASK_SLAVE;
     mask &= ~PIC_MASK_FPU;
@@ -140,12 +140,12 @@ void x86_pic_set_enabled_irqs(uint16_t mask)
     io_wait();
     outb(PIC_SLAVE + PIC_IMR, ~(uint8_t) (mask >> 8));
 
-    restoreIRQ(old_status);
+    irq_restore(old_status);
 }
 
 void x86_pic_enable_irq(unsigned num)
 {
-    unsigned old_status = disableIRQ();
+    unsigned old_status = irq_disable();
 
     uint16_t port;
     if (num < 8) {
@@ -158,12 +158,12 @@ void x86_pic_enable_irq(unsigned num)
     uint8_t cur = inb(port + PIC_IMR);
     outb(port + PIC_IMR, cur & ~(1 << num));
 
-    restoreIRQ(old_status);
+    irq_restore(old_status);
 }
 
 void x86_pic_disable_irq(unsigned num)
 {
-    unsigned old_status = disableIRQ();
+    unsigned old_status = irq_disable();
 
     uint16_t port;
     if (num < 8) {
@@ -176,7 +176,7 @@ void x86_pic_disable_irq(unsigned num)
     uint8_t cur = inb(port + PIC_IMR);
     outb(port + PIC_IMR, cur | (1 << num));
 
-    restoreIRQ(old_status);
+    irq_restore(old_status);
 }
 
 void x86_init_pic(void)

--- a/cpu/x86/x86_pit.c
+++ b/cpu/x86/x86_pit.c
@@ -43,21 +43,21 @@ void x86_init_pit(void)
 
 uint16_t x86_pit_read(unsigned channel)
 {
-    unsigned old_flags = disableIRQ();
+    unsigned old_flags = irq_disable();
     outb(PIT_COMMAND_PORT, (channel - 1) << 6 | PIT_ACCESS_MODE_LATCH_COUNT);
     uint16_t lohi = inb(PIT_CHANNEL_0_PORT + channel - 1);
     lohi += inb(PIT_CHANNEL_0_PORT + channel - 1) << 8;
-    restoreIRQ(old_flags);
+    irq_restore(old_flags);
     return lohi;
 }
 
 void x86_pit_set2(unsigned channel, unsigned mode, uint16_t max)
 {
-    unsigned old_flags = disableIRQ();
+    unsigned old_flags = irq_disable();
     outb(PIT_COMMAND_PORT, ((channel - 1) << 6) | mode | PIT_ACCESS_MODE_LO_HI);
     outb(PIT_CHANNEL_0_PORT + channel - 1, max && 0xff);
     outb(PIT_CHANNEL_0_PORT + channel - 1, max >> 8);
-    restoreIRQ(old_flags);
+    irq_restore(old_flags);
 }
 
 bool x86_pit_set(unsigned channel, unsigned mode, unsigned hz)

--- a/cpu/x86/x86_rtc.c
+++ b/cpu/x86/x86_rtc.c
@@ -161,7 +161,7 @@ bool x86_rtc_read(x86_rtc_data_t *dest)
         return false;
     }
 
-    unsigned old_status = disableIRQ();
+    unsigned old_status = irq_disable();
 
     while (is_update_in_progress()) {
         asm volatile ("pause");
@@ -193,7 +193,7 @@ bool x86_rtc_read(x86_rtc_data_t *dest)
         dest->hour = ((dest->hour & 0x7F) + 12) % 24;
     }
 
-    restoreIRQ(old_status);
+    irq_restore(old_status);
     return true;
 }
 
@@ -203,7 +203,7 @@ bool x86_rtc_set_alarm(const x86_rtc_data_t *when, uint32_t msg_content, kernel_
         return false;
     }
 
-    unsigned old_status = disableIRQ();
+    unsigned old_status = irq_disable();
     bool result;
     if (target_pid == KERNEL_PID_UNDEF) {
         result = true;
@@ -233,7 +233,7 @@ bool x86_rtc_set_alarm(const x86_rtc_data_t *when, uint32_t msg_content, kernel_
         }
     }
     rtc_irq_handler(0);
-    restoreIRQ(old_status);
+    irq_restore(old_status);
     return result;
 }
 
@@ -243,7 +243,7 @@ bool x86_rtc_set_periodic(uint8_t hz, uint32_t msg_content, kernel_pid_t target_
         return false;
     }
 
-    unsigned old_status = disableIRQ();
+    unsigned old_status = irq_disable();
     bool result;
     if (target_pid == KERNEL_PID_UNDEF || hz == RTC_REG_A_HZ_OFF) {
         result = true;
@@ -265,7 +265,7 @@ bool x86_rtc_set_periodic(uint8_t hz, uint32_t msg_content, kernel_pid_t target_
         }
     }
     rtc_irq_handler(0);
-    restoreIRQ(old_status);
+    irq_restore(old_status);
     return result;
 }
 
@@ -275,7 +275,7 @@ bool x86_rtc_set_update(uint32_t msg_content, kernel_pid_t target_pid, bool allo
         return false;
     }
 
-    unsigned old_status = disableIRQ();
+    unsigned old_status = irq_disable();
     bool result;
     if (target_pid == KERNEL_PID_UNDEF) {
         result = true;
@@ -293,6 +293,6 @@ bool x86_rtc_set_update(uint32_t msg_content, kernel_pid_t target_pid, bool allo
         }
     }
     rtc_irq_handler(0);
-    restoreIRQ(old_status);
+    irq_restore(old_status);
     return result;
 }

--- a/drivers/cc110x/cc110x-spi.c
+++ b/drivers/cc110x/cc110x-spi.c
@@ -76,11 +76,11 @@ void cc110x_writeburst_reg(cc110x_t *dev, uint8_t addr, const char *src, uint8_t
 {
     unsigned int cpsr;
     spi_acquire(dev->params.spi);
-    cpsr = disableIRQ();
+    cpsr = irq_disable();
     cc110x_cs(dev);
     spi_transfer_regs(dev->params.spi, addr | CC110X_WRITE_BURST, (char *)src, 0, count);
     gpio_set(dev->params.cs);
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
     spi_release(dev->params.spi);
 }
 
@@ -89,7 +89,7 @@ void cc110x_readburst_reg(cc110x_t *dev, uint8_t addr, char *buffer, uint8_t cou
     int i = 0;
     unsigned int cpsr;
     spi_acquire(dev->params.spi);
-    cpsr = disableIRQ();
+    cpsr = irq_disable();
     cc110x_cs(dev);
     spi_transfer_byte(dev->params.spi, addr | CC110X_READ_BURST, 0);
     while (i < count) {
@@ -97,7 +97,7 @@ void cc110x_readburst_reg(cc110x_t *dev, uint8_t addr, char *buffer, uint8_t cou
         i++;
     }
     gpio_set(dev->params.cs);
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
     spi_release(dev->params.spi);
 }
 
@@ -105,11 +105,11 @@ void cc110x_write_reg(cc110x_t *dev, uint8_t addr, uint8_t value)
 {
     unsigned int cpsr;
     spi_acquire(dev->params.spi);
-    cpsr = disableIRQ();
+    cpsr = irq_disable();
     cc110x_cs(dev);
     spi_transfer_reg(dev->params.spi, addr, value, 0);
     gpio_set(dev->params.cs);
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
     spi_release(dev->params.spi);
 }
 
@@ -118,11 +118,11 @@ uint8_t cc110x_read_reg(cc110x_t *dev, uint8_t addr)
     char result;
     unsigned int cpsr;
     spi_acquire(dev->params.spi);
-    cpsr = disableIRQ();
+    cpsr = irq_disable();
     cc110x_cs(dev);
     spi_transfer_reg(dev->params.spi, addr | CC110X_READ_SINGLE, CC110X_NOBYTE, &result);
     gpio_set(dev->params.cs);
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
     spi_release(dev->params.spi);
     return (uint8_t) result;
 }
@@ -132,11 +132,11 @@ uint8_t cc110x_read_status(cc110x_t *dev, uint8_t addr)
     char result;
     unsigned int cpsr;
     spi_acquire(dev->params.spi);
-    cpsr = disableIRQ();
+    cpsr = irq_disable();
     cc110x_cs(dev);
     spi_transfer_reg(dev->params.spi, addr | CC110X_READ_BURST, CC110X_NOBYTE, &result);
     gpio_set(dev->params.cs);
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
     spi_release(dev->params.spi);
     return (uint8_t) result;
 }
@@ -146,14 +146,14 @@ uint8_t cc110x_get_reg_robust(cc110x_t *dev, uint8_t addr)
     char result, result2;
     unsigned int cpsr;
     spi_acquire(dev->params.spi);
-    cpsr = disableIRQ();
+    cpsr = irq_disable();
     cc110x_cs(dev);
     do {
         spi_transfer_reg(dev->params.spi, addr | CC110X_READ_BURST, CC110X_NOBYTE, &result);
         spi_transfer_reg(dev->params.spi, addr | CC110X_READ_BURST, CC110X_NOBYTE, &result2);
     } while (result != result2);
     gpio_set(dev->params.cs);
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
     spi_release(dev->params.spi);
     return (uint8_t) result;
 }
@@ -169,11 +169,11 @@ uint8_t cc110x_strobe(cc110x_t *dev, uint8_t c)
     char result;
     unsigned int cpsr;
     spi_acquire(dev->params.spi);
-    cpsr = disableIRQ();
+    cpsr = irq_disable();
     cc110x_cs(dev);
     spi_transfer_byte(dev->params.spi, c, &result);
     gpio_set(dev->params.cs);
-    restoreIRQ(cpsr);
+    irq_restore(cpsr);
     spi_release(dev->params.spi);
     return (uint8_t) result;
 }

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -222,7 +222,7 @@ void ethos_send_frame(ethos_t *dev, const uint8_t *data, size_t len, unsigned fr
 {
     uint8_t frame_delim = ETHOS_FRAME_DELIMITER;
 
-    if (!inISR()) {
+    if (!irq_is_in()) {
         mutex_lock(&dev->out_mutex);
     }
     else {
@@ -248,7 +248,7 @@ void ethos_send_frame(ethos_t *dev, const uint8_t *data, size_t len, unsigned fr
     /* end of frame */
     uart_write(dev->uart, &frame_delim, 1);
 
-    if (!inISR()) {
+    if (!irq_is_in()) {
         mutex_unlock(&dev->out_mutex);
     }
 }

--- a/pkg/openwsn/0002-Add-RIOT-adaption.patch
+++ b/pkg/openwsn/0002-Add-RIOT-adaption.patch
@@ -112,8 +112,8 @@ index 0000000..85f2eb1
 +
 +#define INTERRUPT_DECLARATION(); //no declaration
 +
-+#define DISABLE_INTERRUPTS()    disableIRQ();
-+#define ENABLE_INTERRUPTS()     enableIRQ();
++#define DISABLE_INTERRUPTS()    irq_disable();
++#define ENABLE_INTERRUPTS()     irq_enable();
 +
 +//===== timer
 +

--- a/pkg/tlsf/patch.txt
+++ b/pkg/tlsf/patch.txt
@@ -20,9 +20,9 @@ index 0000000..cb16af8
 +
 +void *TLSF_MALLOC_NAME(malloc)(size_t bytes)
 +{
-+    unsigned old_state = disableIRQ();
++    unsigned old_state = irq_disable();
 +    void *result = tlsf_malloc(bytes);
-+    restoreIRQ(old_state);
++    irq_restore(old_state);
 +    return result;
 +}
 +
@@ -37,25 +37,25 @@ index 0000000..cb16af8
 +
 +void *TLSF_MALLOC_NAME(memalign)(size_t align, size_t bytes)
 +{
-+    unsigned old_state = disableIRQ();
++    unsigned old_state = irq_disable();
 +    void *result = tlsf_memalign(align, bytes);
-+    restoreIRQ(old_state);
++    irq_restore(old_state);
 +    return result;
 +}
 +
 +void *TLSF_MALLOC_NAME(realloc)(void *ptr, size_t size)
 +{
-+    unsigned old_state = disableIRQ();
++    unsigned old_state = irq_disable();
 +    void *result = tlsf_realloc(ptr, size);
-+    restoreIRQ(old_state);
++    irq_restore(old_state);
 +    return result;
 +}
 +
 +void TLSF_MALLOC_NAME(free)(void *ptr)
 +{
-+    unsigned old_state = disableIRQ();
++    unsigned old_state = irq_disable();
 +    tlsf_free(ptr);
-+    restoreIRQ(old_state);
++    irq_restore(old_state);
 +}
 diff --git tlsf-malloc.h tlsf-malloc.h
 new file mode 100644

--- a/sys/arduino/serialport.cpp
+++ b/sys/arduino/serialport.cpp
@@ -153,11 +153,11 @@ int SerialPort::read(void)
 {
     int res = -1;
 
-    disableIRQ();
+    irq_disable();
     if (rx_buf.avail > 0) {
         res = ringbuffer_get_one(&rx_buf);
     }
-    enableIRQ();
+    irq_enable();
 
     return res;
 }

--- a/sys/bitfield/bitfield.c
+++ b/sys/bitfield/bitfield.c
@@ -28,7 +28,7 @@ int bf_get_unset(uint8_t field[], int size)
     int nbytes = (size + 7) / 8;
     int i = 0;
 
-    unsigned state = disableIRQ();
+    unsigned state = irq_disable();
 
     /* skip full bytes */
     for (int j = 0; (j < nbytes) && (field[j] == 255); j++) {
@@ -43,6 +43,6 @@ int bf_get_unset(uint8_t field[], int size)
         }
     }
 
-    restoreIRQ(state);
+    irq_restore(state);
     return(result);
 }

--- a/sys/cpp11-compat/condition_variable.cpp
+++ b/sys/cpp11-compat/condition_variable.cpp
@@ -37,7 +37,7 @@ namespace riot {
 condition_variable::~condition_variable() { m_queue.first = NULL; }
 
 void condition_variable::notify_one() noexcept {
-  unsigned old_state = disableIRQ();
+  unsigned old_state = irq_disable();
   priority_queue_node_t* head = priority_queue_remove_head(&m_queue);
   int other_prio = -1;
   if (head != NULL) {
@@ -48,14 +48,14 @@ void condition_variable::notify_one() noexcept {
     }
     head->data = -1u;
   }
-  restoreIRQ(old_state);
+  irq_restore(old_state);
   if (other_prio >= 0) {
     sched_switch(other_prio);
   }
 }
 
 void condition_variable::notify_all() noexcept {
-  unsigned old_state = disableIRQ();
+  unsigned old_state = irq_disable();
   int other_prio = -1;
   while (true) {
     priority_queue_node_t* head = priority_queue_remove_head(&m_queue);
@@ -71,7 +71,7 @@ void condition_variable::notify_all() noexcept {
     }
     head->data = -1u;
   }
-  restoreIRQ(old_state);
+  irq_restore(old_state);
   if (other_prio >= 0) {
     sched_switch(other_prio);
   }
@@ -88,16 +88,16 @@ void condition_variable::wait(unique_lock<mutex>& lock) noexcept {
   n.data = sched_active_pid;
   n.next = NULL;
   // the signaling thread may not hold the mutex, the queue is not thread safe
-  unsigned old_state = disableIRQ();
+  unsigned old_state = irq_disable();
   priority_queue_add(&m_queue, &n);
-  restoreIRQ(old_state);
+  irq_restore(old_state);
   mutex_unlock_and_sleep(lock.mutex()->native_handle());
   if (n.data != -1u) {
     // on signaling n.data is set to -1u
     // if it isn't set, then the wakeup is either spurious or a timer wakeup
-    old_state = disableIRQ();
+    old_state = irq_disable();
     priority_queue_remove(&m_queue, &n);
-    restoreIRQ(old_state);
+    irq_restore(old_state);
   }
   mutex_lock(lock.mutex()->native_handle());
 }

--- a/sys/include/pipe.h
+++ b/sys/include/pipe.h
@@ -76,7 +76,7 @@ void pipe_init(pipe_t *pipe, ringbuffer_t *rb, void (*free)(void *));
  * @details      Only one thread may access the pipe readingly at once.
  *               If the pipe is empty, then the current thread is send sleeping.
  *               It gets woken up once there is data ready in the pipe.
- *               In an ISR (inISR()) 0 will returned if the pipe is empty.
+ *               In an ISR (irq_is_in()) 0 will returned if the pipe is empty.
  * @param[in]    pipe   Pipe to read from.
  * @param[out]   buf    Buffer to write into
  * @param        n      Size of buffer.
@@ -90,7 +90,7 @@ ssize_t pipe_read(pipe_t *pipe, void *buf, size_t n);
  * @details      Only one thread may access the pipe writingly at once.
  *               If the pipe is full, then the current thread is send sleeping.
  *               It gets woken up once there is room again in the pipe.
- *               In an ISR (inISR()) 0 will returned if the pipe is full.
+ *               In an ISR (irq_is_in()) 0 will returned if the pipe is full.
  * @param[in]    pipe   Pipe to write to.
  * @param[out]   buf    Buffer to read from.
  * @param        n      Size of buffer.

--- a/sys/newlib/syscalls.c
+++ b/sys/newlib/syscalls.c
@@ -95,7 +95,7 @@ void _exit(int n)
  */
 void *_sbrk_r(struct _reent *r, ptrdiff_t incr)
 {
-    unsigned int state = disableIRQ();
+    unsigned int state = irq_disable();
     void *res = heap_top;
 
     if ((heap_top + incr > &_eheap) || (heap_top + incr < &_sheap)) {
@@ -106,7 +106,7 @@ void *_sbrk_r(struct _reent *r, ptrdiff_t incr)
         heap_top += incr;
     }
 
-    restoreIRQ(state);
+    irq_restore(state);
     return res;
 }
 

--- a/sys/pipe/pipe.c
+++ b/sys/pipe/pipe.c
@@ -43,7 +43,7 @@ static ssize_t pipe_rw(ringbuffer_t *rb,
     }
 
     while (1) {
-        unsigned old_state = disableIRQ();
+        unsigned old_state = irq_disable();
 
         unsigned count = ringbuffer_op(rb, buf, n);
 
@@ -56,7 +56,7 @@ static ssize_t pipe_rw(ringbuffer_t *rb,
                 sched_set_status(other_thread, STATUS_PENDING);
             }
 
-            restoreIRQ(old_state);
+            irq_restore(old_state);
 
             if (other_prio >= 0) {
                 sched_switch(other_prio);
@@ -64,15 +64,15 @@ static ssize_t pipe_rw(ringbuffer_t *rb,
 
             return count;
         }
-        else if (*this_op_blocked || inISR()) {
-            restoreIRQ(old_state);
+        else if (*this_op_blocked || irq_is_in()) {
+            irq_restore(old_state);
             return 0;
         }
         else {
             *this_op_blocked = (thread_t *) sched_active_thread;
 
             sched_set_status((thread_t *) sched_active_thread, STATUS_SLEEPING);
-            restoreIRQ(old_state);
+            irq_restore(old_state);
             thread_yield_higher();
         }
     }

--- a/sys/posix/pthread/include/pthread_spin.h
+++ b/sys/posix/pthread/include/pthread_spin.h
@@ -14,7 +14,7 @@
  * @note    Do not include this header file directly, but pthread.h.
  * @warning Spinlocks should be avoided.
  *          They will burn away the battery needlessly, and may not work because RIOT is tickless.
- *          Use disableIRQ() and restoreIRQ() for shortterm locks instead.
+ *          Use irq_disable() and irq_restore() for shortterm locks instead.
  */
 
 #ifndef SYS_POSIX_PTHREAD_SPIN_H_
@@ -30,7 +30,7 @@ extern "C" {
  * @brief           A spinlock.
  * @warning         Spinlocks should be avoided.
  *                  They will burn away the battery needlessly, and may not work because RIOT is tickless.
- *                  Use disableIRQ() and restoreIRQ() for shortterm locks instead.
+ *                  Use irq_disable() and irq_restore() for shortterm locks instead.
  */
 typedef struct {
     atomic_int_t value;

--- a/sys/posix/pthread/pthread.c
+++ b/sys/posix/pthread/pthread.c
@@ -206,7 +206,7 @@ void pthread_exit(void *retval)
             }
         }
 
-        disableIRQ();
+        irq_disable();
         if (self->stack) {
             msg_t m;
             m.content.ptr = self->stack;

--- a/sys/posix/semaphore/posix_semaphore.c
+++ b/sys/posix/semaphore/posix_semaphore.c
@@ -58,7 +58,7 @@ int sem_trywait(sem_t *sem)
         errno = EINVAL;
         return -1;
     }
-    old_state = disableIRQ();
+    old_state = irq_disable();
     value = sem->value;
     if (value == 0) {
         errno = EAGAIN;
@@ -69,7 +69,7 @@ int sem_trywait(sem_t *sem)
         sem->value = value - 1;
     }
 
-    restoreIRQ(old_state);
+    irq_restore(old_state);
     return result;
 }
 

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -36,7 +36,7 @@ static void _callback_unlock_mutex(void* arg)
 
 void _xtimer_sleep(uint32_t offset, uint32_t long_offset)
 {
-    if (inISR()) {
+    if (irq_is_in()) {
         assert(!long_offset);
         xtimer_spin(offset);
     }

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -95,7 +95,7 @@ void _xtimer_set64(xtimer_t *timer, uint32_t offset, uint32_t long_offset)
         xtimer_set(timer, (uint32_t) offset);
     }
     else {
-        int state = disableIRQ();
+        int state = irq_disable();
         if (_is_set(timer)) {
             _remove(timer);
         }
@@ -108,7 +108,7 @@ void _xtimer_set64(xtimer_t *timer, uint32_t offset, uint32_t long_offset)
         }
 
         _add_timer_to_long_list(&long_list_head, timer);
-        restoreIRQ(state);
+        irq_restore(state);
         DEBUG("xtimer_set64(): added longterm timer (long_target=%" PRIu32 " target=%" PRIu32 ")\n",
                 timer->long_target, timer->target);
     }
@@ -176,7 +176,7 @@ int _xtimer_set_absolute(xtimer_t *timer, uint32_t target)
         return 0;
     }
 
-    unsigned state = disableIRQ();
+    unsigned state = irq_disable();
     if (_is_set(timer)) {
         _remove(timer);
     }
@@ -207,7 +207,7 @@ int _xtimer_set_absolute(xtimer_t *timer, uint32_t target)
         }
     }
 
-    restoreIRQ(state);
+    irq_restore(state);
 
     return res;
 }
@@ -272,11 +272,11 @@ static void _remove(xtimer_t *timer)
 
 void xtimer_remove(xtimer_t *timer)
 {
-    int state = disableIRQ();
+    int state = irq_disable();
     if (_is_set(timer)) {
         _remove(timer);
     }
-    restoreIRQ(state);
+    irq_restore(state);
 }
 
 static uint32_t _time_left(uint32_t target, uint32_t reference)

--- a/tests/unittests/tests-ubjson/tests-ubjson.c
+++ b/tests/unittests/tests-ubjson/tests-ubjson.c
@@ -71,7 +71,7 @@ static void *test_ubjson_receiver_trampoline(void *arg)
     mutex_unlock(&data->mutexes[0]);
     mutex_lock(&data->mutexes[1]);
 
-    disableIRQ();
+    irq_disable();
     sched_set_status(data->main_thread, STATUS_PENDING);
     return NULL;
 }


### PR DESCRIPTION
Fixes: #5041

I did the refactor by hand because the code is kind if critical and I don't trust oneliners with with :)