### PR TITLE
pkg/oonf_api: use new repo url

### DIFF
--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME=oonf_api
-PKG_URL=http://olsr.org/git/oonf.git
+PKG_URL=https://github.com/OLSR/OONF.git
 PKG_VERSION=v0.3.0
 PKG_DIR=$(CURDIR)/$(PKG_NAME)
 


### PR DESCRIPTION
fixes #5107
apparently they moved to github [1].

[1] https://lists.olsr.org/pipermail/olsr-dev/2016-March/008182.html