### PR TITLE
boards/frdm-k64f: fix group typo

### DIFF
--- a/boards/frdm-k64f/Makefile.features
+++ b/boards/frdm-k64f/Makefile.features
@@ -15,4 +15,4 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
-EATURES_MCU_GROUP = cortex_m4_1
+FEATURES_MCU_GROUP = cortex_m4_1


### PR DESCRIPTION
Typo made the frdm-k64f build as part of m3_1 in one build, I guess it just ended up in whatever group the previously analysed board happened to be in..