### PR TITLE
make: removed obsolete 'sys/net/include'

### DIFF
--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -1,8 +1,4 @@
-ifneq (,$(filter net_help,$(USEMODULE)))
-    USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include
-endif
 ifneq (,$(filter nhdp,$(USEMODULE)))
-    USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include
     USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/routing/nhdp
 endif
 
@@ -12,11 +8,9 @@ endif
 
 ifneq (,$(filter fib,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/sys/posix/include
-    USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include   # remove as soon as deleted
 endif
 ifneq (,$(filter posix,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/sys/posix/include
-    USEMODULE_INCLUDES += $(RIOTBASE)/sys/net/include
 endif
 ifneq (,$(filter posix_semaphore,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/sys/posix/include


### PR DESCRIPTION
The path ``sys/net/include`` in ``sys/Makefile.include`` does not exist anymore and hence is obsolete. The new path is already set correctly in ``Makefile.modules``. 