### PR TITLE
gnrc: simplify hdr_build functions

### DIFF
--- a/examples/gnrc_networking/udp.c
+++ b/examples/gnrc_networking/udp.c
@@ -65,7 +65,7 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
             return;
         }
         /* allocate IPv6 header */
-        ip = gnrc_ipv6_hdr_build(udp, NULL, (uint8_t *)&addr);
+        ip = gnrc_ipv6_hdr_build(udp, NULL, &addr);
         if (ip == NULL) {
             puts("Error: unable to allocate IPv6 header");
             gnrc_pktbuf_release(udp);

--- a/examples/gnrc_networking/udp.c
+++ b/examples/gnrc_networking/udp.c
@@ -34,8 +34,7 @@ static gnrc_netreg_entry_t server = { NULL, GNRC_NETREG_DEMUX_CTX_ALL, KERNEL_PI
 static void send(char *addr_str, char *port_str, char *data, unsigned int num,
                  unsigned int delay)
 {
-    uint8_t port[2];
-    uint16_t tmp;
+    uint16_t port;
     ipv6_addr_t addr;
 
     /* parse destination address */
@@ -44,13 +43,11 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
         return;
     }
     /* parse port */
-    tmp = (uint16_t)atoi(port_str);
-    if (tmp == 0) {
+    port = (uint16_t)atoi(port_str);
+    if (port == 0) {
         puts("Error: unable to parse destination port");
         return;
     }
-    port[0] = (uint8_t)tmp;
-    port[1] = tmp >> 8;
 
     for (unsigned int i = 0; i < num; i++) {
         gnrc_pktsnip_t *payload, *udp, *ip;
@@ -61,7 +58,7 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
             return;
         }
         /* allocate UDP header, set source port := destination port */
-        udp = gnrc_udp_hdr_build(payload, port, 2, port, 2);
+        udp = gnrc_udp_hdr_build(payload, port, port);
         if (udp == NULL) {
             puts("Error: unable to allocate UDP header");
             gnrc_pktbuf_release(payload);
@@ -81,7 +78,7 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
             return;
         }
         printf("Success: send %u byte to [%s]:%u\n", (unsigned)payload->size,
-               addr_str, tmp);
+               addr_str, port);
         xtimer_usleep(delay);
     }
 }

--- a/examples/gnrc_networking/udp.c
+++ b/examples/gnrc_networking/udp.c
@@ -65,7 +65,7 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
             return;
         }
         /* allocate IPv6 header */
-        ip = gnrc_ipv6_hdr_build(udp, NULL, 0, (uint8_t *)&addr, sizeof(addr));
+        ip = gnrc_ipv6_hdr_build(udp, NULL, (uint8_t *)&addr);
         if (ip == NULL) {
             puts("Error: unable to allocate IPv6 header");
             gnrc_pktbuf_release(udp);

--- a/sys/include/net/gnrc/ipv6/hdr.h
+++ b/sys/include/net/gnrc/ipv6/hdr.h
@@ -43,8 +43,8 @@ extern "C" {
  * @return  The an IPv6 header in packet buffer on success.
  * @return  NULL on error.
  */
-gnrc_pktsnip_t *gnrc_ipv6_hdr_build(gnrc_pktsnip_t *payload, uint8_t *src,
-                                    uint8_t *dst);
+gnrc_pktsnip_t *gnrc_ipv6_hdr_build(gnrc_pktsnip_t *payload, ipv6_addr_t *src,
+                                    ipv6_addr_t *dst);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/ipv6/hdr.h
+++ b/sys/include/net/gnrc/ipv6/hdr.h
@@ -43,8 +43,8 @@ extern "C" {
  * @return  The an IPv6 header in packet buffer on success.
  * @return  NULL on error.
  */
-gnrc_pktsnip_t *gnrc_ipv6_hdr_build(gnrc_pktsnip_t *payload, ipv6_addr_t *src,
-                                    ipv6_addr_t *dst);
+gnrc_pktsnip_t *gnrc_ipv6_hdr_build(gnrc_pktsnip_t *payload, const ipv6_addr_t *src,
+                                    const ipv6_addr_t *dst);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/ipv6/hdr.h
+++ b/sys/include/net/gnrc/ipv6/hdr.h
@@ -37,19 +37,14 @@ extern "C" {
  * @param[in] payload   Payload for the packet.
  * @param[in] src       Source address for the header. Can be NULL if not
  *                      known or required.
- * @param[in] src_len   Length of @p src. Can be 0 if not known or required or
- *                      must be `sizeof(ipv6_addr_t)`.
  * @param[in] dst       Destination address for the header. Can be NULL if not
  *                      known or required.
- * @param[in] dst_len   Length of @p dst. Can be 0 if not known or required or
- *                      must be `sizeof(ipv6_addr_t)`.
  *
  * @return  The an IPv6 header in packet buffer on success.
  * @return  NULL on error.
  */
-gnrc_pktsnip_t *gnrc_ipv6_hdr_build(gnrc_pktsnip_t *payload,
-                                    uint8_t *src, uint8_t src_len,
-                                    uint8_t *dst, uint8_t dst_len);
+gnrc_pktsnip_t *gnrc_ipv6_hdr_build(gnrc_pktsnip_t *payload, uint8_t *src,
+                                    uint8_t *dst);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/netreg.h
+++ b/sys/include/net/gnrc/netreg.h
@@ -149,25 +149,6 @@ gnrc_netreg_entry_t *gnrc_netreg_getnext(gnrc_netreg_entry_t *entry);
 
 int gnrc_netreg_calc_csum(gnrc_pktsnip_t *hdr, gnrc_pktsnip_t *pseudo_hdr);
 
-/**
- * @brief   Builds a header for sending and adds it to the packet buffer.
- *
- * @param[in] type      Type of the header.
- * @param[in] payload   Payload for the packet.
- * @param[in] src       Source address for the header. Can be NULL if not
- *                      known or required.
- * @param[in] src_len   Length of @p src. Can be 0 if not known or required.
- * @param[in] dst       Destination address for the header. Can be NULL if not
- *                      known or required.
- * @param[in] dst_len   Length of @p dst. Can be 0 if not known or required.
- *
- * @return  The header for the protocol on success.
- * @return  NULL on error.
- */
-gnrc_pktsnip_t *gnrc_netreg_hdr_build(gnrc_nettype_t type, gnrc_pktsnip_t *payload,
-                                      uint8_t *src, uint8_t src_len,
-                                      uint8_t *dst, uint8_t dst_len);
-
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/gnrc/udp.h
+++ b/sys/include/net/gnrc/udp.h
@@ -71,17 +71,14 @@ int gnrc_udp_calc_csum(gnrc_pktsnip_t *hdr, gnrc_pktsnip_t *pseudo_hdr);
  *
  * @param[in] payload       Payload contained in the UDP packet
  * @param[in] src           Source port in host byte order
- * @param[in] src_len       Length of @p src, must be 2
  * @param[in] dst           Destination port in host byte order
- * @param[in] dst_len       Length of @p dst, must be 2
  *
  * @return  pointer to the newly created (and allocated) header
  * @return  NULL on `src == NULL`, `dst == NULL`, `src_len != 2`, `dst_len != 2`
  *          or on allocation error
  */
-gnrc_pktsnip_t *gnrc_udp_hdr_build(gnrc_pktsnip_t *payload,
-                                   uint8_t *src, size_t src_len,
-                                   uint8_t *dst, size_t dst_len);
+gnrc_pktsnip_t *gnrc_udp_hdr_build(gnrc_pktsnip_t *payload, uint16_t src,
+                                   uint16_t dst);
 
 /**
  * @brief   Initialize and start UDP

--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -958,8 +958,7 @@ tftp_state _tftp_send(gnrc_pktsnip_t *buf, tftp_context_t *ctxt, size_t len)
     /* allocate UDP header, set source port := destination port */
     src_port.u16 = ctxt->src_port;
     dst_port.u16 = ctxt->dst_port;
-    udp = gnrc_udp_hdr_build(buf, src_port.u8, sizeof(src_port),
-                             dst_port.u8, sizeof(dst_port));
+    udp = gnrc_udp_hdr_build(buf, src_port.u16, dst_port.u16);
     if (udp == NULL) {
         DEBUG("tftp: error unable to allocate UDP header");
         gnrc_pktbuf_release(buf);

--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -971,7 +971,7 @@ tftp_state _tftp_send(gnrc_pktsnip_t *buf, tftp_context_t *ctxt, size_t len)
     }
 
     /* allocate IPv6 header */
-    ip = gnrc_ipv6_hdr_build(udp, NULL, 0, ctxt->peer.u8, sizeof(ipv6_addr_t));
+    ip = gnrc_ipv6_hdr_build(udp, NULL, ctxt->peer.u8);
     if (ip == NULL) {
         DEBUG("tftp: error unable to allocate IPv6 header");
         gnrc_pktbuf_release(udp);

--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -971,7 +971,7 @@ tftp_state _tftp_send(gnrc_pktsnip_t *buf, tftp_context_t *ctxt, size_t len)
     }
 
     /* allocate IPv6 header */
-    ip = gnrc_ipv6_hdr_build(udp, NULL, ctxt->peer.u8);
+    ip = gnrc_ipv6_hdr_build(udp, NULL, &(ctxt->peer));
     if (ip == NULL) {
         DEBUG("tftp: error unable to allocate IPv6 header");
         gnrc_pktbuf_release(udp);

--- a/sys/net/gnrc/application_layer/zep/gnrc_zep.c
+++ b/sys/net/gnrc/application_layer/zep/gnrc_zep.c
@@ -241,8 +241,7 @@ static int _send(gnrc_netdev_t *netdev, gnrc_pktsnip_t *pkt)
 
     new_pkt = hdr;
 
-    hdr = gnrc_ipv6_hdr_build(new_pkt, NULL, 0, (uint8_t *) &(dev->dst),
-                              sizeof(ipv6_addr_t));
+    hdr = gnrc_ipv6_hdr_build(new_pkt, NULL, (uint8_t *) &(dev->dst));
 
     if (hdr == NULL) {
         DEBUG("zep: could not allocate IPv6 header in pktbuf\n");

--- a/sys/net/gnrc/application_layer/zep/gnrc_zep.c
+++ b/sys/net/gnrc/application_layer/zep/gnrc_zep.c
@@ -241,7 +241,7 @@ static int _send(gnrc_netdev_t *netdev, gnrc_pktsnip_t *pkt)
 
     new_pkt = hdr;
 
-    hdr = gnrc_ipv6_hdr_build(new_pkt, NULL, (uint8_t *) &(dev->dst));
+    hdr = gnrc_ipv6_hdr_build(new_pkt, NULL, &(dev->dst));
 
     if (hdr == NULL) {
         DEBUG("zep: could not allocate IPv6 header in pktbuf\n");

--- a/sys/net/gnrc/application_layer/zep/gnrc_zep.c
+++ b/sys/net/gnrc/application_layer/zep/gnrc_zep.c
@@ -230,8 +230,7 @@ static int _send(gnrc_netdev_t *netdev, gnrc_pktsnip_t *pkt)
 
     zep = new_pkt->data;
 
-    hdr = gnrc_udp_hdr_build(new_pkt, (uint8_t *)(&(dev->src_port)), sizeof(uint16_t),
-                             (uint8_t *)(&(dev->dst_port)), sizeof(uint16_t));
+    hdr = gnrc_udp_hdr_build(new_pkt, dev->src_port, dev->dst_port);
 
     if (hdr == NULL) {
         DEBUG("zep: could not allocate UDP header in pktbuf\n");

--- a/sys/net/gnrc/conn/ip/gnrc_conn_ip.c
+++ b/sys/net/gnrc/conn/ip/gnrc_conn_ip.c
@@ -99,7 +99,7 @@ int conn_ip_sendto(const void *data, size_t len, const void *src, size_t src_len
                 return -EINVAL;
             }
             /* addr will only be copied */
-            hdr = gnrc_ipv6_hdr_build(pkt, (uint8_t *)src, src_len, (uint8_t *)dst, dst_len);
+            hdr = gnrc_ipv6_hdr_build(pkt, (uint8_t *)src, (uint8_t *)dst);
             if (hdr == NULL) {
                 gnrc_pktbuf_release(pkt);
                 return -ENOMEM;

--- a/sys/net/gnrc/conn/ip/gnrc_conn_ip.c
+++ b/sys/net/gnrc/conn/ip/gnrc_conn_ip.c
@@ -99,7 +99,7 @@ int conn_ip_sendto(const void *data, size_t len, const void *src, size_t src_len
                 return -EINVAL;
             }
             /* addr will only be copied */
-            hdr = gnrc_ipv6_hdr_build(pkt, (uint8_t *)src, (uint8_t *)dst);
+            hdr = gnrc_ipv6_hdr_build(pkt, src, dst);
             if (hdr == NULL) {
                 gnrc_pktbuf_release(pkt);
                 return -ENOMEM;

--- a/sys/net/gnrc/conn/udp/gnrc_conn_udp.c
+++ b/sys/net/gnrc/conn/udp/gnrc_conn_udp.c
@@ -96,8 +96,7 @@ int conn_udp_sendto(const void *data, size_t len, const void *src, size_t src_le
     gnrc_pktsnip_t *pkt, *hdr = NULL;
 
     pkt = gnrc_pktbuf_add(NULL, (void *)data, len, GNRC_NETTYPE_UNDEF); /* data will only be copied */
-    hdr = gnrc_udp_hdr_build(pkt, (uint8_t *)&sport, sizeof(uint16_t), (uint8_t *)&dport,
-                             sizeof(uint16_t));
+    hdr = gnrc_udp_hdr_build(pkt, sport, dport);
     if (hdr == NULL) {
         gnrc_pktbuf_release(pkt);
         return -ENOMEM;

--- a/sys/net/gnrc/conn/udp/gnrc_conn_udp.c
+++ b/sys/net/gnrc/conn/udp/gnrc_conn_udp.c
@@ -111,7 +111,7 @@ int conn_udp_sendto(const void *data, size_t len, const void *src, size_t src_le
                 return -EINVAL;
             }
             /* addr will only be copied */
-            hdr = gnrc_ipv6_hdr_build(pkt, (uint8_t *)src, (uint8_t *)dst);
+            hdr = gnrc_ipv6_hdr_build(pkt, src, dst);
             if (hdr == NULL) {
                 gnrc_pktbuf_release(pkt);
                 return -ENOMEM;

--- a/sys/net/gnrc/conn/udp/gnrc_conn_udp.c
+++ b/sys/net/gnrc/conn/udp/gnrc_conn_udp.c
@@ -111,7 +111,7 @@ int conn_udp_sendto(const void *data, size_t len, const void *src, size_t src_le
                 return -EINVAL;
             }
             /* addr will only be copied */
-            hdr = gnrc_ipv6_hdr_build(pkt, (uint8_t *)src, src_len, (uint8_t *)dst, dst_len);
+            hdr = gnrc_ipv6_hdr_build(pkt, (uint8_t *)src, (uint8_t *)dst);
             if (hdr == NULL) {
                 gnrc_pktbuf_release(pkt);
                 return -ENOMEM;

--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -136,49 +136,4 @@ int gnrc_netreg_calc_csum(gnrc_pktsnip_t *hdr, gnrc_pktsnip_t *pseudo_hdr)
     }
 }
 
-gnrc_pktsnip_t *gnrc_netreg_hdr_build(gnrc_nettype_t type, gnrc_pktsnip_t *payload,
-                                      uint8_t *src, uint8_t src_len,
-                                      uint8_t *dst, uint8_t dst_len)
-{
-    switch (type) {
-#ifdef MODULE_GNRC_IPV6
-
-        case GNRC_NETTYPE_IPV6:
-            assert(src_len == sizeof(ipv6_addr_t));
-            assert(dst_len == sizeof(ipv6_addr_t));
-            return gnrc_ipv6_hdr_build(payload, (ipv6_addr_t*) src, (ipv6_addr_t*) dst);
-#endif
-#ifdef MODULE_GNRC_TCP
-
-        case GNRC_NETTYPE_TCP:
-            {
-            assert(src_len == sizeof(uint16_t));
-            assert(dst_len == sizeof(uint16_t));
-            uint16_t src_port = *((uint16_t *)src);
-            uint16_t dst_port = *((uint16_t *)dst);
-            return gnrc_tcp_hdr_build(payload, src_port, dst_port);
-            }
-#endif
-#ifdef MODULE_GNRC_UDP
-
-        case GNRC_NETTYPE_UDP:
-            {
-            assert(src_len == sizeof(uint16_t));
-            assert(dst_len == sizeof(uint16_t));
-            uint16_t src_port = *((uint16_t *)src);
-            uint16_t dst_port = *((uint16_t *)dst);
-            return gnrc_udp_hdr_build(payload, src_port, dst_port);
-            }
-#endif
-
-        default:
-            (void)payload;
-            (void)src;
-            (void)src_len;
-            (void)dst;
-            (void)dst_len;
-            return NULL;
-    }
-}
-
 /** @} */

--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -143,7 +143,7 @@ gnrc_pktsnip_t *gnrc_netreg_hdr_build(gnrc_nettype_t type, gnrc_pktsnip_t *paylo
 #ifdef MODULE_GNRC_IPV6
 
         case GNRC_NETTYPE_IPV6:
-            return gnrc_ipv6_hdr_build(payload, src, src_len, dst, dst_len);
+            return gnrc_ipv6_hdr_build(payload, src, dst);
 #endif
 #ifdef MODULE_GNRC_TCP
 

--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -146,7 +146,7 @@ gnrc_pktsnip_t *gnrc_netreg_hdr_build(gnrc_nettype_t type, gnrc_pktsnip_t *paylo
         case GNRC_NETTYPE_IPV6:
             assert(src_len == sizeof(ipv6_addr_t));
             assert(dst_len == sizeof(ipv6_addr_t));
-            return gnrc_ipv6_hdr_build(payload, src, dst);
+            return gnrc_ipv6_hdr_build(payload, (ipv6_addr_t*) src, (ipv6_addr_t*) dst);
 #endif
 #ifdef MODULE_GNRC_TCP
 

--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -148,12 +148,20 @@ gnrc_pktsnip_t *gnrc_netreg_hdr_build(gnrc_nettype_t type, gnrc_pktsnip_t *paylo
 #ifdef MODULE_GNRC_TCP
 
         case GNRC_NETTYPE_TCP:
-            return gnrc_tcp_hdr_build(payload, src, src_len, dst, dst_len);
+            {
+            uint16_t src_port = *((uint16_t *)src);
+            uint16_t dst_port = *((uint16_t *)dst);
+            return gnrc_tcp_hdr_build(payload, src_port, dst_port);
+            }
 #endif
 #ifdef MODULE_GNRC_UDP
 
         case GNRC_NETTYPE_UDP:
-            return gnrc_udp_hdr_build(payload, src, src_len, dst, dst_len);
+            {
+            uint16_t src_port = *((uint16_t *)src);
+            uint16_t dst_port = *((uint16_t *)dst);
+            return gnrc_udp_hdr_build(payload, src_port, dst_port);
+            }
 #endif
 
         default:

--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <string.h>
 
+#include "assert.h"
 #include "clist.h"
 #include "utlist.h"
 #include "net/gnrc/netreg.h"
@@ -143,12 +144,16 @@ gnrc_pktsnip_t *gnrc_netreg_hdr_build(gnrc_nettype_t type, gnrc_pktsnip_t *paylo
 #ifdef MODULE_GNRC_IPV6
 
         case GNRC_NETTYPE_IPV6:
+            assert(src_len == sizeof(ipv6_addr_t));
+            assert(dst_len == sizeof(ipv6_addr_t));
             return gnrc_ipv6_hdr_build(payload, src, dst);
 #endif
 #ifdef MODULE_GNRC_TCP
 
         case GNRC_NETTYPE_TCP:
             {
+            assert(src_len == sizeof(uint16_t));
+            assert(dst_len == sizeof(uint16_t));
             uint16_t src_port = *((uint16_t *)src);
             uint16_t dst_port = *((uint16_t *)dst);
             return gnrc_tcp_hdr_build(payload, src_port, dst_port);
@@ -158,6 +163,8 @@ gnrc_pktsnip_t *gnrc_netreg_hdr_build(gnrc_nettype_t type, gnrc_pktsnip_t *paylo
 
         case GNRC_NETTYPE_UDP:
             {
+            assert(src_len == sizeof(uint16_t));
+            assert(dst_len == sizeof(uint16_t));
             uint16_t src_port = *((uint16_t *)src);
             uint16_t dst_port = *((uint16_t *)dst);
             return gnrc_udp_hdr_build(payload, src_port, dst_port);

--- a/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
+++ b/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
@@ -84,11 +84,10 @@ void gnrc_icmpv6_echo_req_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6_hdr,
     }
 
     if (ipv6_addr_is_multicast(&ipv6_hdr->dst)) {
-        hdr = gnrc_ipv6_hdr_build(pkt, NULL, (uint8_t *)&ipv6_hdr->src);
+        hdr = gnrc_ipv6_hdr_build(pkt, NULL, &ipv6_hdr->src);
     }
     else {
-        hdr = gnrc_ipv6_hdr_build(pkt, (uint8_t *)&ipv6_hdr->dst,
-                                  (uint8_t *)&ipv6_hdr->src);
+        hdr = gnrc_ipv6_hdr_build(pkt, &ipv6_hdr->dst, &ipv6_hdr->src);
     }
 
     if (hdr == NULL) {

--- a/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
+++ b/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
@@ -84,13 +84,11 @@ void gnrc_icmpv6_echo_req_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6_hdr,
     }
 
     if (ipv6_addr_is_multicast(&ipv6_hdr->dst)) {
-        hdr = gnrc_ipv6_hdr_build(pkt, NULL, 0, (uint8_t *)&ipv6_hdr->src,
-                                  sizeof(ipv6_addr_t));
+        hdr = gnrc_ipv6_hdr_build(pkt, NULL, (uint8_t *)&ipv6_hdr->src);
     }
     else {
         hdr = gnrc_ipv6_hdr_build(pkt, (uint8_t *)&ipv6_hdr->dst,
-                                  sizeof(ipv6_addr_t), (uint8_t *)&ipv6_hdr->src,
-                                  sizeof(ipv6_addr_t));
+                                  (uint8_t *)&ipv6_hdr->src);
     }
 
     if (hdr == NULL) {

--- a/sys/net/gnrc/network_layer/ipv6/hdr/gnrc_ipv6_hdr.c
+++ b/sys/net/gnrc/network_layer/ipv6/hdr/gnrc_ipv6_hdr.c
@@ -32,19 +32,11 @@ static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 #define HDR_NETTYPE (GNRC_NETTYPE_UNDEF)
 #endif
 
-gnrc_pktsnip_t *gnrc_ipv6_hdr_build(gnrc_pktsnip_t *payload,
-                                    uint8_t *src, uint8_t src_len,
-                                    uint8_t *dst, uint8_t dst_len)
+gnrc_pktsnip_t *gnrc_ipv6_hdr_build(gnrc_pktsnip_t *payload, uint8_t *src,
+                                    uint8_t *dst)
 {
     gnrc_pktsnip_t *ipv6;
     ipv6_hdr_t *hdr;
-
-    if (((src_len != 0) && (src_len != sizeof(ipv6_addr_t))) ||
-        ((dst_len != 0) && (dst_len != sizeof(ipv6_addr_t)))) {
-        DEBUG("ipv6_hdr: Address length was not 0 or %zu byte.\n",
-              sizeof(ipv6_addr_t));
-        return NULL;
-    }
 
     ipv6 = gnrc_pktbuf_add(payload, NULL, sizeof(ipv6_hdr_t), HDR_NETTYPE);
 
@@ -55,28 +47,26 @@ gnrc_pktsnip_t *gnrc_ipv6_hdr_build(gnrc_pktsnip_t *payload,
 
     hdr = (ipv6_hdr_t *)ipv6->data;
 
-    if ((src != NULL) && (src_len != 0)) {
+    if (src != NULL) {
 #ifdef MODULE_IPV6_ADDR
         DEBUG("ipv6_hdr: set packet source to %s\n",
               ipv6_addr_to_str(addr_str, (ipv6_addr_t *)src,
                                sizeof(addr_str)));
 #endif
-        memcpy(&hdr->src, src, src_len);
+        memcpy(&hdr->src, src, sizeof(ipv6_addr_t));
     }
     else {
         DEBUG("ipv6_hdr: set packet source to ::\n");
         ipv6_addr_set_unspecified(&hdr->src);
     }
 
-    memset(&hdr->dst + dst_len, 0, sizeof(ipv6_addr_t) - dst_len);
-
-    if ((dst != NULL) && (dst_len != 0)) {
+    if (dst != NULL) {
 #ifdef MODULE_IPV6_ADDR
         DEBUG("ipv6_hdr: set packet destination to %s\n",
               ipv6_addr_to_str(addr_str, (ipv6_addr_t *)dst,
                                sizeof(addr_str)));
 #endif
-        memcpy(&hdr->dst, dst, dst_len);
+        memcpy(&hdr->dst, dst, sizeof(ipv6_addr_t));
     }
     else {
         DEBUG("ipv6_hdr: set packet destination to ::1\n");

--- a/sys/net/gnrc/network_layer/ipv6/hdr/gnrc_ipv6_hdr.c
+++ b/sys/net/gnrc/network_layer/ipv6/hdr/gnrc_ipv6_hdr.c
@@ -32,8 +32,8 @@ static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 #define HDR_NETTYPE (GNRC_NETTYPE_UNDEF)
 #endif
 
-gnrc_pktsnip_t *gnrc_ipv6_hdr_build(gnrc_pktsnip_t *payload, ipv6_addr_t *src,
-                                    ipv6_addr_t *dst)
+gnrc_pktsnip_t *gnrc_ipv6_hdr_build(gnrc_pktsnip_t *payload, const ipv6_addr_t *src,
+                                    const ipv6_addr_t *dst)
 {
     gnrc_pktsnip_t *ipv6;
     ipv6_hdr_t *hdr;

--- a/sys/net/gnrc/network_layer/ipv6/hdr/gnrc_ipv6_hdr.c
+++ b/sys/net/gnrc/network_layer/ipv6/hdr/gnrc_ipv6_hdr.c
@@ -32,8 +32,8 @@ static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 #define HDR_NETTYPE (GNRC_NETTYPE_UNDEF)
 #endif
 
-gnrc_pktsnip_t *gnrc_ipv6_hdr_build(gnrc_pktsnip_t *payload, uint8_t *src,
-                                    uint8_t *dst)
+gnrc_pktsnip_t *gnrc_ipv6_hdr_build(gnrc_pktsnip_t *payload, ipv6_addr_t *src,
+                                    ipv6_addr_t *dst)
 {
     gnrc_pktsnip_t *ipv6;
     ipv6_hdr_t *hdr;

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -837,8 +837,7 @@ static gnrc_pktsnip_t *_build_headers(kernel_pid_t iface, gnrc_pktsnip_t *payloa
                                       ipv6_addr_t *dst, ipv6_addr_t *src)
 {
     gnrc_pktsnip_t *l2hdr;
-    gnrc_pktsnip_t *iphdr = gnrc_ipv6_hdr_build(payload, (uint8_t *)src,
-                                                (uint8_t *)dst);
+    gnrc_pktsnip_t *iphdr = gnrc_ipv6_hdr_build(payload, src, dst);
     if (iphdr == NULL) {
         DEBUG("ndp internal: error allocating IPv6 header.\n");
         return NULL;

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -837,8 +837,8 @@ static gnrc_pktsnip_t *_build_headers(kernel_pid_t iface, gnrc_pktsnip_t *payloa
                                       ipv6_addr_t *dst, ipv6_addr_t *src)
 {
     gnrc_pktsnip_t *l2hdr;
-    gnrc_pktsnip_t *iphdr = gnrc_ipv6_hdr_build(payload, (uint8_t *)src, sizeof(ipv6_addr_t),
-                                                (uint8_t *)dst, sizeof(ipv6_addr_t));
+    gnrc_pktsnip_t *iphdr = gnrc_ipv6_hdr_build(payload, (uint8_t *)src,
+                                                (uint8_t *)dst);
     if (iphdr == NULL) {
         DEBUG("ndp internal: error allocating IPv6 header.\n");
         return NULL;

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -77,8 +77,7 @@ void gnrc_rpl_send(gnrc_pktsnip_t *pkt, kernel_pid_t iface, ipv6_addr_t *src, ip
         dst = (ipv6_addr_t *) &ipv6_addr_all_rpl_nodes;
     }
 
-    hdr = gnrc_ipv6_hdr_build(pkt, (uint8_t *)src, sizeof(ipv6_addr_t), (uint8_t *)dst,
-                              sizeof(ipv6_addr_t));
+    hdr = gnrc_ipv6_hdr_build(pkt, (uint8_t *)src, (uint8_t *)dst);
 
     if (hdr == NULL) {
         DEBUG("RPL: Send - no space left in packet buffer\n");

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -77,7 +77,7 @@ void gnrc_rpl_send(gnrc_pktsnip_t *pkt, kernel_pid_t iface, ipv6_addr_t *src, ip
         dst = (ipv6_addr_t *) &ipv6_addr_all_rpl_nodes;
     }
 
-    hdr = gnrc_ipv6_hdr_build(pkt, (uint8_t *)src, (uint8_t *)dst);
+    hdr = gnrc_ipv6_hdr_build(pkt, src, dst);
 
     if (hdr == NULL) {
         DEBUG("RPL: Send - no space left in packet buffer\n");

--- a/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
+++ b/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
@@ -271,18 +271,12 @@ int gnrc_udp_calc_csum(gnrc_pktsnip_t *hdr, gnrc_pktsnip_t *pseudo_hdr)
     return 0;
 }
 
-gnrc_pktsnip_t *gnrc_udp_hdr_build(gnrc_pktsnip_t *payload,
-                                   uint8_t *src, size_t src_len,
-                                   uint8_t *dst, size_t dst_len)
+gnrc_pktsnip_t *gnrc_udp_hdr_build(gnrc_pktsnip_t *payload, uint16_t src,
+                                   uint16_t dst)
 {
     gnrc_pktsnip_t *res;
     udp_hdr_t *hdr;
 
-    /* check parameters */
-    if (src == NULL || dst == NULL ||
-        src_len != sizeof(uint16_t) || dst_len != sizeof(uint16_t)) {
-        return NULL;
-    }
     /* allocate header */
     res = gnrc_pktbuf_add(payload, NULL, sizeof(udp_hdr_t), GNRC_NETTYPE_UDP);
     if (res == NULL) {
@@ -290,8 +284,8 @@ gnrc_pktsnip_t *gnrc_udp_hdr_build(gnrc_pktsnip_t *payload,
     }
     /* initialize header */
     hdr = (udp_hdr_t *)res->data;
-    hdr->src_port = byteorder_htons(*((uint16_t *)src));
-    hdr->dst_port = byteorder_htons(*((uint16_t *)dst));
+    hdr->src_port = byteorder_htons(src);
+    hdr->dst_port = byteorder_htons(dst);
     hdr->checksum = byteorder_htons(0);
     return res;
 }

--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -254,8 +254,7 @@ int _icmpv6_ping(int argc, char **argv)
 
         _set_payload(pkt->data, payload_len);
 
-        pkt = gnrc_netreg_hdr_build(GNRC_NETTYPE_IPV6, pkt, NULL, 0, addr.u8,
-                                    sizeof(ipv6_addr_t));
+        pkt = gnrc_ipv6_hdr_build(pkt, NULL, addr.u8);
 
         if (pkt == NULL) {
             puts("error: packet buffer full");

--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -254,7 +254,7 @@ int _icmpv6_ping(int argc, char **argv)
 
         _set_payload(pkt->data, payload_len);
 
-        pkt = gnrc_ipv6_hdr_build(pkt, NULL, addr.u8);
+        pkt = gnrc_ipv6_hdr_build(pkt, NULL, &addr);
 
         if (pkt == NULL) {
             puts("error: packet buffer full");

--- a/tests/unittests/tests-gnrc_ipv6_hdr/tests-gnrc_ipv6_hdr.c
+++ b/tests/unittests/tests-gnrc_ipv6_hdr/tests-gnrc_ipv6_hdr.c
@@ -35,32 +35,6 @@
         } \
     }
 
-static void test_gnrc_ipv6_hdr_build__wrong_src_len(void)
-{
-    ipv6_addr_t src = DEFAULT_TEST_SRC;
-    ipv6_addr_t dst = DEFAULT_TEST_DST;
-
-    gnrc_pktbuf_init();
-    TEST_ASSERT_NULL(gnrc_ipv6_hdr_build(NULL, (uint8_t *)&src,
-                                         sizeof(ipv6_addr_t) + TEST_UINT8,
-                                         (uint8_t *)&dst,
-                                         sizeof(ipv6_addr_t)));
-    TEST_ASSERT(gnrc_pktbuf_is_empty());
-}
-
-static void test_gnrc_ipv6_hdr_build__wrong_dst_len(void)
-{
-    ipv6_addr_t src = DEFAULT_TEST_SRC;
-    ipv6_addr_t dst = DEFAULT_TEST_DST;
-
-    gnrc_pktbuf_init();
-    TEST_ASSERT_NULL(gnrc_ipv6_hdr_build(NULL, (uint8_t *)&src,
-                                         sizeof(ipv6_addr_t),
-                                         (uint8_t *)&dst,
-                                         sizeof(ipv6_addr_t) + TEST_UINT8));
-    TEST_ASSERT(gnrc_pktbuf_is_empty());
-}
-
 static void test_gnrc_ipv6_hdr_build__src_NULL(void)
 {
     ipv6_addr_t dst = DEFAULT_TEST_DST;
@@ -68,8 +42,7 @@ static void test_gnrc_ipv6_hdr_build__src_NULL(void)
     ipv6_hdr_t *hdr;
 
     gnrc_pktbuf_init();
-    TEST_ASSERT_NOT_NULL((pkt = gnrc_ipv6_hdr_build(NULL, NULL, 0, (uint8_t *)&dst,
-                                sizeof(ipv6_addr_t))));
+    TEST_ASSERT_NOT_NULL(pkt = gnrc_ipv6_hdr_build(NULL, NULL, (uint8_t *)&dst));
     hdr = pkt->data;
     TEST_ASSERT_NOT_NULL(hdr);
     TEST_ASSERT(ipv6_hdr_is(hdr));
@@ -88,9 +61,7 @@ static void test_gnrc_ipv6_hdr_build__dst_NULL(void)
     ipv6_hdr_t *hdr;
 
     gnrc_pktbuf_init();
-    TEST_ASSERT_NOT_NULL((pkt = gnrc_ipv6_hdr_build(NULL, (uint8_t *)&src,
-                                sizeof(ipv6_addr_t),
-                                NULL, 0)));
+    TEST_ASSERT_NOT_NULL(pkt = gnrc_ipv6_hdr_build(NULL, (uint8_t *)&src, NULL));
     hdr = pkt->data;
     TEST_ASSERT_NOT_NULL(hdr);
     TEST_ASSERT(ipv6_hdr_is(hdr));
@@ -110,10 +81,7 @@ static void test_gnrc_ipv6_hdr_build__complete(void)
     ipv6_hdr_t *hdr;
 
     gnrc_pktbuf_init();
-    TEST_ASSERT_NOT_NULL((pkt = gnrc_ipv6_hdr_build(NULL, (uint8_t *)&src,
-                                sizeof(ipv6_addr_t),
-                                (uint8_t *)&dst,
-                                sizeof(ipv6_addr_t))));
+    TEST_ASSERT_NOT_NULL(pkt = gnrc_ipv6_hdr_build(NULL, (uint8_t *)&src, (uint8_t *)&dst));
     hdr = pkt->data;
     TEST_ASSERT_NOT_NULL(hdr);
     TEST_ASSERT(ipv6_hdr_is(hdr));
@@ -129,8 +97,6 @@ static void test_gnrc_ipv6_hdr_build__complete(void)
 Test *tests_gnrc_ipv6_hdr_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
-        new_TestFixture(test_gnrc_ipv6_hdr_build__wrong_src_len),
-        new_TestFixture(test_gnrc_ipv6_hdr_build__wrong_dst_len),
         new_TestFixture(test_gnrc_ipv6_hdr_build__src_NULL),
         new_TestFixture(test_gnrc_ipv6_hdr_build__dst_NULL),
         new_TestFixture(test_gnrc_ipv6_hdr_build__complete),

--- a/tests/unittests/tests-gnrc_ipv6_hdr/tests-gnrc_ipv6_hdr.c
+++ b/tests/unittests/tests-gnrc_ipv6_hdr/tests-gnrc_ipv6_hdr.c
@@ -42,7 +42,7 @@ static void test_gnrc_ipv6_hdr_build__src_NULL(void)
     ipv6_hdr_t *hdr;
 
     gnrc_pktbuf_init();
-    TEST_ASSERT_NOT_NULL(pkt = gnrc_ipv6_hdr_build(NULL, NULL, (uint8_t *)&dst));
+    TEST_ASSERT_NOT_NULL(pkt = gnrc_ipv6_hdr_build(NULL, NULL, &dst));
     hdr = pkt->data;
     TEST_ASSERT_NOT_NULL(hdr);
     TEST_ASSERT(ipv6_hdr_is(hdr));
@@ -61,7 +61,7 @@ static void test_gnrc_ipv6_hdr_build__dst_NULL(void)
     ipv6_hdr_t *hdr;
 
     gnrc_pktbuf_init();
-    TEST_ASSERT_NOT_NULL(pkt = gnrc_ipv6_hdr_build(NULL, (uint8_t *)&src, NULL));
+    TEST_ASSERT_NOT_NULL(pkt = gnrc_ipv6_hdr_build(NULL, &src, NULL));
     hdr = pkt->data;
     TEST_ASSERT_NOT_NULL(hdr);
     TEST_ASSERT(ipv6_hdr_is(hdr));
@@ -81,7 +81,7 @@ static void test_gnrc_ipv6_hdr_build__complete(void)
     ipv6_hdr_t *hdr;
 
     gnrc_pktbuf_init();
-    TEST_ASSERT_NOT_NULL(pkt = gnrc_ipv6_hdr_build(NULL, (uint8_t *)&src, (uint8_t *)&dst));
+    TEST_ASSERT_NOT_NULL(pkt = gnrc_ipv6_hdr_build(NULL, &src, &dst));
     hdr = pkt->data;
     TEST_ASSERT_NOT_NULL(hdr);
     TEST_ASSERT(ipv6_hdr_is(hdr));


### PR DESCRIPTION
Directly using 16 bit port numbers instead of casting uint8_t pointers.