### PR TITLE
Use TARGET_ARCH for more platforms

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -159,6 +159,10 @@ endif
 
 export TOOLCHAIN
 
+# default toolchain prefix, defaults to target triple followed by a dash, you
+# will most likely not need to touch this.
+export PREFIX ?= $(if $(TARGET_ARCH),$(TARGET_ARCH)-)
+
 # Import all toolchain settings
 include $(RIOTCPU)/Makefile.include.$(TOOLCHAIN)
 

--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -1,15 +1,6 @@
 # define the cpu used by the arduino mega2560 board
 export CPU = atmega2560
 
-# define tools used for building the project
-export PREFIX = avr-
-export CC = $(PREFIX)gcc
-export CXX = $(PREFIX)c++
-export AR = $(PREFIX)ar
-export AS = $(PREFIX)as
-export LINK = $(PREFIX)gcc
-export SIZE = $(PREFIX)size
-export OBJCOPY = $(PREFIX)objcopy
 export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm
 export TERMFLAGS = -b 9600 -p $(PORT)
 

--- a/boards/msba2-common/Makefile.include
+++ b/boards/msba2-common/Makefile.include
@@ -1,19 +1,6 @@
 ## the cpu to build for
 export CPU = lpc2387
 
-# Target triple for the build. Use arm-none-eabi if you are unsure.
-export TARGET_ARCH ?= arm-none-eabi
-
-# toolchain config
-export PREFIX = $(if $(TARGET_ARCH),$(TARGET_ARCH)-)
-
-export CC = $(PREFIX)gcc
-export CXX = $(PREFIX)g++
-export AR = $(PREFIX)ar
-export AS = $(PREFIX)as
-export LINK = $(PREFIX)gcc
-export SIZE = $(PREFIX)size
-export OBJCOPY = $(PREFIX)objcopy
 FLASHER = lpc2k_pgm
 TERMPROG ?= $(RIOTBASE)/dist/tools/pyterm/pyterm
 

--- a/cpu/Makefile.include.cortexm_common
+++ b/cpu/Makefile.include.cortexm_common
@@ -1,10 +1,6 @@
 # Target triple for the build. Use arm-none-eabi if you are unsure.
 export TARGET_ARCH ?= arm-none-eabi
 
-# default toolchain prefix, defaults to target triple followed by a dash, you
-# will most likely not need to touch this.
-export PREFIX ?= $(if $(TARGET_ARCH),$(TARGET_ARCH)-)
-
 # define build specific options
 export CFLAGS_CPU   = -mcpu=$(MCPU) -mlittle-endian -mthumb $(CFLAGS_FPU)
 ifneq (llvm,$(TOOLCHAIN))

--- a/cpu/Makefile.include.msp430_common
+++ b/cpu/Makefile.include.msp430_common
@@ -1,5 +1,5 @@
-# default toolchain prefix
-export PREFIX ?= msp430-
+# Target architecture for the build. Use msp430 if you are unsure.
+export TARGET_ARCH ?= msp430
 
 # define build specific options
 CFLAGS_CPU   = -mmcu=$(CPU_MODEL)

--- a/cpu/arm7_common/Makefile.include
+++ b/cpu/arm7_common/Makefile.include
@@ -1,1 +1,4 @@
+# Target architecture for the build. Use arm-none-eabi if you are unsure.
+export TARGET_ARCH ?= arm-none-eabi
+
 INCLUDES += -I$(RIOTBASE)/cpu/arm7_common/include/

--- a/cpu/atmega_common/Makefile.include
+++ b/cpu/atmega_common/Makefile.include
@@ -1,3 +1,5 @@
+# Target architecture for the build. Use avr if you are unsure.
+export TARGET_ARCH ?= avr
 
 # include module specific includes
 export INCLUDES += -I$(RIOTCPU)/atmega_common/include -isystem$(RIOTCPU)/atmega_common/avr-libc-extra


### PR DESCRIPTION
 - Moved PREFIX setting to Makefile.include
 - Set TARGET_ARCH for avr and arm7 targets