### PR TITLE
tests/xtimer: remove redundant FEATURE_REQUIRED

### DIFF
--- a/tests/xtimer_drift/Makefile
+++ b/tests/xtimer_drift/Makefile
@@ -1,7 +1,6 @@
 APPLICATION = xtimer_drift
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED += periph_timer
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_hang/Makefile
+++ b/tests/xtimer_hang/Makefile
@@ -1,7 +1,6 @@
 APPLICATION = xtimer_hang
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED += periph_timer
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_msg/Makefile
+++ b/tests/xtimer_msg/Makefile
@@ -1,7 +1,6 @@
 APPLICATION = xtimer_msg
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED += periph_timer
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_msg_receive_timeout/Makefile
+++ b/tests/xtimer_msg_receive_timeout/Makefile
@@ -1,7 +1,6 @@
 APPLICATION = xtimer_msg_receive_timeout
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED += periph_timer
 USEMODULE += xtimer
 
 test:

--- a/tests/xtimer_now64_continuity/Makefile
+++ b/tests/xtimer_now64_continuity/Makefile
@@ -1,8 +1,6 @@
 export APPLICATION = xtimer_now64_continuity
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_timer
-
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_remove/Makefile
+++ b/tests/xtimer_remove/Makefile
@@ -4,7 +4,6 @@ include ../Makefile.tests_common
 BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
-FEATURES_REQUIRED += periph_timer
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_reset/Makefile
+++ b/tests/xtimer_reset/Makefile
@@ -4,7 +4,6 @@ include ../Makefile.tests_common
 BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
-FEATURES_REQUIRED += periph_timer
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_shift_on_compare/Makefile
+++ b/tests/xtimer_shift_on_compare/Makefile
@@ -6,7 +6,6 @@ BOARD_WHITELIST += msb-430h arduino-mega2560
 BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
-FEATURES_REQUIRED += periph_timer
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_usleep_until/Makefile
+++ b/tests/xtimer_usleep_until/Makefile
@@ -6,7 +6,6 @@ RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := chronos
 
-FEATURES_REQUIRED += periph_timer
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
The required feature `periph_timer` is globally defined in `Makefile.dep`, so no need to define this dependency again in the test makefiles...