### PR TITLE
tests: added xtimer long-term test

### DIFF
--- a/tests/xtimer_longterm/Makefile
+++ b/tests/xtimer_longterm/Makefile
@@ -1,0 +1,6 @@
+APPLICATION = xtimer_longterm
+include ../Makefile.tests_common
+
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_longterm/README.md
+++ b/tests/xtimer_longterm/README.md
@@ -1,0 +1,31 @@
+Expected result
+===============
+You should see a number of different messages, printed out on certain intervals:
+
+`msg   -- 14min -- 14 ticks since` -> timeout by xtimer_msg every 14 minutes
+`sleep -- 18min -- 18 ticks since` -> timeout by xtimer_usleep, every 18 minutes
+`msg   -- 3min  -- 3 ticks since`  -> timeout by xtimer_msg, every 3 minutes
+`sleep -- 5min  -- 5 ticks since`  -> timeout by xtimer_usleep, every 5 minutes
+`TICK  -- 1min`  -> event created by aggregation counter every 1 min
+
+Background
+==========
+This test is supposed to find out, if the `xtimer` behaves correctly when
+scheduling multiple long and short term timers. For this we schedule two 'long'
+and two 'mid'-term timers, while in parallel running one periodic fast timer.
+
+The 'long' term timers are triggering every 14 and 18 min (so in this context
+we consider this long-term...). The mid-term timers are set to 3 and 5 minutes.
+Both kind of timers have one that is using `xtimer_usleep` and one that is
+using `xtimer_set_msg`.
+
+The short-term timer is triggered every 50ms and is using `xtimer_sleep_until`.
+Each time this timer triggers, it increments a software counter, which triggers
+then a message every minute. A 50ms interval should be small enough, to trigger
+also for 16-bit wide timers at least once in every timer period.
+
+On each mid- and long-term timer event, the output shows also the number of
+fast timer (1min timer) ticks, that have been triggered since a timer was
+triggered last. This number should be equal to the timers interval.
+
+For reasonable results, you should run this test at least for some ours...

--- a/tests/xtimer_longterm/main.c
+++ b/tests/xtimer_longterm/main.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       xtimer_msg test application
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @}
+ */
+
+#include <stdio.h>
+#include <time.h>
+
+#include "xtimer.h"
+#include "thread.h"
+#include "msg.h"
+
+
+/* some internally used msg types */
+#define MSG_LONG                (0xcafe)
+#define MSG_MID                 (0xe5e1)
+#define MSG_TICK                (0xaffe)
+
+/* define sleep and timeout intervals */
+#define MIN_TO_TICKS(min)       (XTIMER_USEC_TO_TICKS(60UL * 1000 * 1000 * min))
+#define INT_LONG_MSG            (MIN_TO_TICKS(14))
+#define INT_LONG_SLEEP          (MIN_TO_TICKS(18))
+#define INT_MID_MSG             (MIN_TO_TICKS(3))
+#define INT_MID_SLEEP           (MIN_TO_TICKS(5))
+#define INT_SHORT               (XTIMER_USEC_TO_TICKS(50UL * 1000))
+
+/* and some timeout conditions */
+#define SHORT_MIN_REACHED       (60 * 20)    /* 60 * 20 * 50ms = 1min */
+
+/* configure the print threads message queue */
+#define MSG_Q_SIZE              (8U)
+static msg_t mq[MSG_Q_SIZE];
+
+/* allocate some stacks */
+static char long_stack[THREAD_STACKSIZE_MAIN];
+static char mid_stack[THREAD_STACKSIZE_MAIN];
+static char short_stack[THREAD_STACKSIZE_MAIN];
+
+/* the main threads PID */
+static kernel_pid_t print_pid;
+
+/* allocate timer structs for mid- and long-term timers */
+static xtimer_t long_timer;
+static xtimer_t mid_timer;
+
+/* and some software counters */
+static int long_msg_ticks = 0;
+static int long_sleep_ticks = 0;
+static int mid_msg_ticks = 0;
+static int mid_sleep_ticks = 0;
+static int short_ticks = 0;
+
+
+void *long_sleep(void *arg)
+{
+    (void) arg;
+
+    while (1) {
+        printf("sleep -- 18min -- %i ticks since\n", long_sleep_ticks);
+        long_sleep_ticks = 0;
+
+        xtimer_usleep(INT_LONG_SLEEP);
+    }
+
+    return NULL;
+}
+
+void *mid_sleep(void *arg)
+{
+    (void) arg;
+
+    while (1) {
+        printf("sleep -- 5min  -- %i ticks since\n", mid_sleep_ticks);
+        mid_sleep_ticks = 0;
+
+        xtimer_usleep(INT_MID_SLEEP);
+    }
+
+    return NULL;
+}
+
+void *ticker(void *arg)
+{
+    (void)arg;
+    uint32_t base = xtimer_now();
+
+    while (1) {
+        ++short_ticks;
+
+        if (short_ticks == SHORT_MIN_REACHED) {
+            short_ticks = 0;
+            ++long_msg_ticks;
+            ++long_sleep_ticks;
+            ++mid_msg_ticks;
+            ++mid_sleep_ticks;
+
+            msg_t msg;
+            msg.type = MSG_TICK;
+            msg_send(&msg, print_pid);
+        }
+
+        xtimer_usleep_until(&base, INT_SHORT);
+    }
+
+    return NULL;
+}
+
+int main(void)
+{
+    msg_t msg_mid, msg_long, msg;
+
+    puts("xtimer long-term test");
+    puts("Refer to the README to get information on the expected output.");
+
+    /* save the main threads PID */
+    print_pid = thread_getpid();
+
+    /* initialize the message queue */
+    msg_init_queue(mq, MSG_Q_SIZE);
+
+    /* create the other threads */
+    thread_create(long_stack, sizeof(long_stack), THREAD_PRIORITY_MAIN - 1,
+                  0, long_sleep, NULL, "long_sleep");
+    thread_create(mid_stack, sizeof(mid_stack), THREAD_PRIORITY_MAIN - 2,
+                  0, mid_sleep, NULL, "mid_sleep");
+    thread_create(short_stack, sizeof(short_stack), THREAD_PRIORITY_MAIN - 3,
+                  0, ticker, NULL, "ticks");
+
+    /* initiate the mid- and long-term messages */
+    msg_long.type = MSG_LONG;
+    xtimer_set_msg(&long_timer, INT_LONG_MSG, &msg_long, print_pid);
+    msg_mid.type = MSG_MID;
+    xtimer_set_msg(&mid_timer, INT_MID_MSG, &msg_mid, print_pid);
+
+    /* watch for incoming messages */
+    while (1) {
+        msg_receive(&msg);
+
+        switch (msg.type) {
+            case MSG_LONG:
+                printf("msg   -- 14min -- %i ticks since\n", long_msg_ticks);
+                long_msg_ticks = 0;
+                xtimer_set_msg(&long_timer, INT_LONG_MSG, &msg_long, print_pid);
+                break;
+
+            case MSG_MID:
+                printf("msg   -- 3min  -- %i ticks since\n", mid_msg_ticks);
+                mid_msg_ticks = 0;
+                xtimer_set_msg(&mid_timer, INT_MID_MSG, &msg_mid, print_pid);
+                break;
+
+            case MSG_TICK:
+                puts("TICK  -- 1min");
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
As discussed today, here a test application for testing rather 'long'-term settings of the xtimer. The tested intervals are chosen as they are closed to typical intervals used in the network stack (e.g. NDP).

Here some example output running on the `nrf52dk`:
```
2016-03-21 18:45:22,796 - INFO # main(): This is RIOT! (Version: 2016.03-devel-1283-g05730e-prag-add_test_xtimer_longterm)
2016-03-21 18:45:22,797 - INFO # xtimer long-term test
2016-03-21 18:45:22,798 - INFO # Refer to the README to get information on the expected output.
2016-03-21 18:45:22,799 - INFO # sleep -- 18min -- 0 ticks since
2016-03-21 18:45:22,800 - INFO # sleep -- 5min  -- 0 ticks since
2016-03-21 18:46:21,465 - INFO # TICK  -- 1min
2016-03-21 18:47:21,465 - INFO # TICK  -- 1min
2016-03-21 18:48:21,465 - INFO # TICK  -- 1min
2016-03-21 18:48:21,515 - INFO # msg   -- 3min  -- 3 ticks since
2016-03-21 18:49:21,465 - INFO # TICK  -- 1min
2016-03-21 18:50:21,465 - INFO # TICK  -- 1min
2016-03-21 18:50:21,515 - INFO # sleep -- 5min  -- 5 ticks since
2016-03-21 18:51:21,465 - INFO # TICK  -- 1min
2016-03-21 18:51:21,516 - INFO # msg   -- 3min  -- 3 ticks since
2016-03-21 18:52:21,460 - INFO # TICK  -- 1min
2016-03-21 18:53:21,460 - INFO # TICK  -- 1min
2016-03-21 18:54:21,460 - INFO # TICK  -- 1min
2016-03-21 18:54:21,520 - INFO # msg   -- 3min  -- 3 ticks since
2016-03-21 18:55:21,460 - INFO # TICK  -- 1min
2016-03-21 18:55:21,515 - INFO # sleep -- 5min  -- 5 ticks since
2016-03-21 18:56:21,460 - INFO # TICK  -- 1min
2016-03-21 18:57:21,460 - INFO # TICK  -- 1min
2016-03-21 18:57:21,520 - INFO # msg   -- 3min  -- 3 ticks since
2016-03-21 18:58:21,460 - INFO # TICK  -- 1min
2016-03-21 18:59:21,455 - INFO # TICK  -- 1min
2016-03-21 18:59:21,510 - INFO # msg   -- 14min -- 14 ticks since
2016-03-21 19:00:21,455 - INFO # TICK  -- 1min
2016-03-21 19:00:21,515 - INFO # sleep -- 5min  -- 5 ticks since
2016-03-21 19:00:21,520 - INFO # msg   -- 3min  -- 3 ticks since
2016-03-21 19:01:21,455 - INFO # TICK  -- 1min
2016-03-21 19:02:21,455 - INFO # TICK  -- 1min
2016-03-21 19:03:21,455 - INFO # TICK  -- 1min
2016-03-21 19:03:21,505 - INFO # sleep -- 18min -- 18 ticks since
2016-03-21 19:03:21,520 - INFO # msg   -- 3min  -- 3 ticks since
2016-03-21 19:04:21,455 - INFO # TICK  -- 1min
2016-03-21 19:05:21,455 - INFO # TICK  -- 1min
2016-03-21 19:05:21,520 - INFO # sleep -- 5min  -- 5 ticks since
2016-03-21 19:06:21,455 - INFO # TICK  -- 1min
2016-03-21 19:06:21,521 - INFO # msg   -- 3min  -- 3 ticks since
2016-03-21 19:07:21,450 - INFO # TICK  -- 1min
2016-03-21 19:08:21,450 - INFO # TICK  -- 1min
2016-03-21 19:09:21,450 - INFO # TICK  -- 1min
2016-03-21 19:09:21,521 - INFO # msg   -- 3min  -- 3 ticks since
2016-03-21 19:10:21,450 - INFO # TICK  -- 1min
2016-03-21 19:10:21,515 - INFO # sleep -- 5min  -- 5 ticks since
2016-03-21 19:11:21,450 - INFO # TICK  -- 1min
2016-03-21 19:12:21,450 - INFO # TICK  -- 1min
2016-03-21 19:12:21,525 - INFO # msg   -- 3min  -- 3 ticks since
2016-03-21 19:13:21,450 - INFO # TICK  -- 1min
2016-03-21 19:13:21,505 - INFO # msg   -- 14min -- 14 ticks since
2016-03-21 19:14:21,450 - INFO # TICK  -- 1min
2016-03-21 19:15:21,446 - INFO # TICK  -- 1min
2016-03-21 19:15:21,515 - INFO # sleep -- 5min  -- 5 ticks since
2016-03-21 19:15:21,525 - INFO # msg   -- 3min  -- 3 ticks since
```