### PR TITLE
pkg: u8glib: add initial support for graphics library

### DIFF
--- a/pkg/u8glib/Makefile
+++ b/pkg/u8glib/Makefile
@@ -1,0 +1,10 @@
+PKG_NAME=u8glib
+PKG_URL=https://github.com/olikraus/u8glib
+PKG_VERSION=ec0acc2b7a0acc30194e736a4782aa2ad6802452
+
+.PHONY: all
+
+all: git-download
+	"$(MAKE)" -C $(PKG_BUILDDIR)
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/u8glib/Makefile.include
+++ b/pkg/u8glib/Makefile.include
@@ -1,0 +1,1 @@
+INCLUDES += -I$(BINDIRBASE)/pkg/$(BOARD)/u8glib/csrc

--- a/pkg/u8glib/patches/0001-u8glib-add-riot-os-makefiles.patch
+++ b/pkg/u8glib/patches/0001-u8glib-add-riot-os-makefiles.patch
@@ -1,0 +1,405 @@
+From 0900d6d380fca8379ab416107cf87c8c9ac76a5e Mon Sep 17 00:00:00 2001
+From: Bas Stottelaar <basstottelaar@gmail.com>
+Date: Tue, 22 Dec 2015 19:26:23 +0100
+Subject: [PATCH 1/4] u8glib: add riot-os makefiles.
+
+---
+ Makefile        |  12 ++
+ Makefile.am     | 344 --------------------------------------------------------
+ csrc/Makefile   |   3 +
+ fntsrc/Makefile |   3 +
+ 4 files changed, 18 insertions(+), 344 deletions(-)
+ create mode 100644 Makefile
+ delete mode 100644 Makefile.am
+ create mode 100644 csrc/Makefile
+ create mode 100644 fntsrc/Makefile
+
+diff --git a/Makefile b/Makefile
+new file mode 100644
+index 0000000..7adb568
+--- /dev/null
++++ b/Makefile
+@@ -0,0 +1,12 @@
++MODULE=u8glib
++
++DIRS += csrc fntsrc
++
++# Compiling U8glib will generate a lot of compiler warnings, which are treated
++# as errors. For the sake of simplicity, ignore them.
++CFLAGS += -Wno-empty-translation-unit \
++          -Wno-newline-eof \
++          -Wno-unused-parameter \
++          -Wno-unused
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/Makefile.am b/Makefile.am
+deleted file mode 100644
+index 7f204a5..0000000
+--- a/Makefile.am
++++ /dev/null
+@@ -1,344 +0,0 @@
+-
+-AM_LDFLAGS=
+-AM_CFLAGS=
+-
+-DEFS+= \
+-    -Icsrc -Icppsrc -Idogmsrc -Inonarduino \
+-    `getconf LFS_CFLAGS` \
+-    `getconf LFS64_CFLAGS` \
+-    -D_GNU_SOURCE \
+-    -D_FILE_OFFSET_BITS=64 \
+-    $(NULL)
+-
+-AM_CFLAGS+= \
+-    -I$(top_builddir)/include/ \
+-    $(NULL)
+-
+-AM_LDFLAGS += \
+-    -L$(top_builddir)/ \
+-    `getconf LFS_LDFLAGS` \
+-    `getconf LFS64_LDFLAGS` \
+-    $(NULL)
+-
+-if DEBUG
+-# use "valgrind --tool=memcheck --leak-check=yes" to check memory leak, MemWatch will drag the program.
+-#DEFS+=-DMEMWATCH
+-DEFS+= -DDEBUG=1
+-AM_CFLAGS+=-g -Wall
+-
+-else
+-AM_CFLAGS+=-O3 -Wall
+-endif
+-
+-EXT_FLAGS=
+-@MK@GITNUMTMP=$(shell cd "$(top_srcdir)"; A=$$(git show | head -n 1 | awk '{print $$2}'); echo $${A:0:7}; cd - > /dev/null )
+-#@MK@SVNNUMTMP=$(shell cd "$(top_srcdir)"; LC_ALL=C svn info | grep -i Revision | awk '{print $$2}'; cd - > /dev/null )
+-#@MK@ifeq ($(SVNNUMTMP),)
+-#EXT_FLAGS+= -DSVN_VERSION='"${GITNUMTMP}"'
+-#@MK@else
+-#EXT_FLAGS+= -DSVN_VERSION='"${SVNNUMTMP}"'
+-#@MK@endif
+-@MK@ifeq ($(GITNUMTMP),)
+-@MK@else
+-EXT_FLAGS+= -DSVN_VERSION='"${GITNUMTMP}"'
+-@MK@endif
+-DEFS+=$(EXT_FLAGS)
+-
+-SRC_BASE= \
+-    csrc/u8g_page.c \
+-    csrc/u8g_u16toa.c \
+-    csrc/u8g_u8toa.c \
+-    sfntsrc/u8g_font_data.c \
+-    sys/pbm/dev/u8g_dev_pbm.c \
+-    sys/pbm/dev/u8g_dev_pbm_gr_h2.c \
+-    sys/pbm/dev/u8g_dev_pbm_h.c \
+-    $(NULL)
+-
+-SRC_COMMON_ALG= \
+-    csrc/u8g_bitmap.c \
+-    csrc/u8g_circle.c \
+-    csrc/u8g_clip.c \
+-    csrc/u8g_cursor.c \
+-    csrc/u8g_ellipse.c \
+-    csrc/u8g_font.c \
+-    csrc/u8g_line.c \
+-    csrc/u8g_pb14v1.c \
+-    csrc/u8g_pb16h1.c \
+-    csrc/u8g_pb16h2.c \
+-    csrc/u8g_pb16v1.c \
+-    csrc/u8g_pb16v2.c \
+-    csrc/u8g_pb32h1.c \
+-    csrc/u8g_pb8h1.c \
+-    csrc/u8g_pb8h1f.c \
+-    csrc/u8g_pb8h2.c \
+-    csrc/u8g_pb8h8.c \
+-    csrc/u8g_pb8v1.c \
+-    csrc/u8g_pb8v2.c \
+-    csrc/u8g_pb.c \
+-    csrc/u8g_pbxh16.c \
+-    csrc/u8g_pbxh24.c \
+-    csrc/u8g_polygon.c \
+-    csrc/u8g_rect.c \
+-    csrc/u8g_rot.c \
+-    csrc/u8g_scale.c \
+-    csrc/u8g_virtual_screen.c \
+-    $(NULL)
+-
+-SRC_COMMON_DRV= \
+-    csrc/chessengine.c \
+-    csrc/u8g_com_api_16gr.c \
+-    csrc/u8g_com_api.c \
+-    csrc/u8g_com_arduino_attiny85_hw_spi.c \
+-    csrc/u8g_com_arduino_common.c \
+-    csrc/u8g_com_arduino_fast_parallel.c \
+-    csrc/u8g_com_arduino_hw_spi.c \
+-    csrc/u8g_com_arduino_hw_usart_spi.c \
+-    csrc/u8g_com_arduino_no_en_parallel.c \
+-    csrc/u8g_com_arduino_parallel.c \
+-    csrc/u8g_com_arduino_port_d_wr.c \
+-    csrc/u8g_com_arduino_ssd_i2c.c \
+-    csrc/u8g_com_arduino_st7920_custom.c \
+-    csrc/u8g_com_arduino_st7920_hw_spi.c \
+-    csrc/u8g_com_arduino_st7920_spi.c \
+-    csrc/u8g_com_arduino_std_sw_spi.c \
+-    csrc/u8g_com_arduino_sw_spi.c \
+-    csrc/u8g_com_arduino_t6963.c \
+-    csrc/u8g_com_arduino_uc_i2c.c \
+-    csrc/u8g_com_atmega_hw_spi.c \
+-    csrc/u8g_com_atmega_parallel.c \
+-    csrc/u8g_com_atmega_st7920_hw_spi.c \
+-    csrc/u8g_com_atmega_st7920_spi.c \
+-    csrc/u8g_com_atmega_sw_spi.c \
+-    csrc/u8g_com_i2c.c \
+-    csrc/u8g_com_io.c \
+-    csrc/u8g_com_msp430_hw_spi.c \
+-    csrc/u8g_com_null.c \
+-    csrc/u8g_com_std_sw_spi.c \
+-    csrc/u8g_delay.c \
+-    csrc/u8g_dev_a2_micro_printer.c \
+-    csrc/u8g_dev_flipdisc_2x7.c \
+-    csrc/u8g_dev_gprof.c \
+-    csrc/u8g_dev_ht1632.c \
+-    csrc/u8g_dev_ili9325d_320x240.c \
+-    csrc/u8g_dev_ks0108_128x64.c \
+-    csrc/u8g_dev_lc7981_160x80.c \
+-    csrc/u8g_dev_lc7981_240x128.c \
+-    csrc/u8g_dev_lc7981_240x64.c \
+-    csrc/u8g_dev_lc7981_320x64.c \
+-    csrc/u8g_dev_ld7032_60x32.c \
+-    csrc/u8g_dev_null.c \
+-    csrc/u8g_dev_pcd8544_84x48.c \
+-    csrc/u8g_dev_pcf8812_96x65.c \
+-    csrc/u8g_dev_sbn1661_122x32.c \
+-    csrc/u8g_dev_ssd1306_128x32.c \
+-    csrc/u8g_dev_ssd1306_128x64.c \
+-    csrc/u8g_dev_ssd1309_128x64.c \
+-    csrc/u8g_dev_ssd1322_nhd31oled_bw.c \
+-    csrc/u8g_dev_ssd1322_nhd31oled_gr.c \
+-    csrc/u8g_dev_ssd1325_nhd27oled_bw.c \
+-    csrc/u8g_dev_ssd1325_nhd27oled_bw_new.c \
+-    csrc/u8g_dev_ssd1325_nhd27oled_gr.c \
+-    csrc/u8g_dev_ssd1325_nhd27oled_gr_new.c \
+-    csrc/u8g_dev_ssd1327_96x96_gr.c \
+-    csrc/u8g_dev_ssd1351_128x128.c \
+-    csrc/u8g_dev_ssd1353_160x128.c \
+-    csrc/u8g_dev_st7565_64128n.c \
+-    csrc/u8g_dev_st7565_dogm128.c \
+-    csrc/u8g_dev_st7565_dogm132.c \
+-    csrc/u8g_dev_st7565_lm6059.c \
+-    csrc/u8g_dev_st7565_lm6063.c \
+-    csrc/u8g_dev_st7565_nhd_c12832.c \
+-    csrc/u8g_dev_st7565_nhd_c12864.c \
+-    csrc/u8g_dev_st7687_c144mvgd.c \
+-    csrc/u8g_dev_st7920_128x64.c \
+-    csrc/u8g_dev_st7920_192x32.c \
+-    csrc/u8g_dev_st7920_202x32.c \
+-    csrc/u8g_dev_t6963_128x128.c \
+-    csrc/u8g_dev_t6963_128x64.c \
+-    csrc/u8g_dev_t6963_240x128.c \
+-    csrc/u8g_dev_t6963_240x64.c \
+-    csrc/u8g_dev_tls8204_84x48.c \
+-    csrc/u8g_dev_uc1601_c128032.c \
+-    csrc/u8g_dev_uc1608_240x128.c \
+-    csrc/u8g_dev_uc1608_240x64.c \
+-    csrc/u8g_dev_uc1610_dogxl160.c \
+-    csrc/u8g_dev_uc1611_dogm240.c \
+-    csrc/u8g_dev_uc1611_dogxl240.c \
+-    csrc/u8g_dev_uc1701_dogs102.c \
+-    csrc/u8g_dev_uc1701_mini12864.c \
+-    csrc/u8g_ll_api.c \
+-    csrc/u8g_state.c \
+-    dogmsrc/u8g_dogm128_api.c \
+-    dogmsrc/spacetrash.c \
+-    cppsrc/U8glib.cpp \
+-    $(NULL)
+-
+-SRC_WPI= \
+-    $(SRC_COMMON_ALG) \
+-    $(SRC_COMMON_DRV) \
+-    csrc/u8g_com_raspberrypi_hw_spi.c \
+-    csrc/u8g_com_raspberrypi_ssd_i2c.c \
+-    $(NULL)
+-
+-SRC_SDL= \
+-    $(SRC_COMMON_ALG) \
+-    $(SRC_COMMON_DRV) \
+-    sys/sdl/dev/u8g_dev_sdl.c \
+-    $(NULL)
+-
+-include_HEADERS = \
+-    $(top_srcdir)/csrc/u8g.h \
+-    $(top_srcdir)/cppsrc/U8glib.h \
+-    $(top_srcdir)/dogmsrc/u8g_dogm128_api.h \
+-    $(top_srcdir)/nonarduino/Printable.h \
+-    $(top_srcdir)/nonarduino/Print.h \
+-    $(top_srcdir)/nonarduino/WString.h \
+-    $(NULL)
+-
+-noinst_HEADERS=
+-
+-lib_LTLIBRARIES=libu8gbase.la libu8gsdl.la libu8gwpi.la
+-
+-libu8gbase_la_SOURCES=$(SRC_BASE)
+-
+-libu8gsdl_la_SOURCES=$(SRC_SDL)
+-
+-libu8gwpi_la_SOURCES=$(SRC_WPI)
+-
+-libu8gbase_la_CFLAGS=-Icsrc -Icppsrc -Inonarduino -DU8G_16BIT `sdl-config --cflags`
+-libu8gbase_la_CPPFLAGS=$(libu8gbase_la_CFLAGS)
+-libu8gbase_la_LDFLAGS=
+-
+-libu8gsdl_la_CFLAGS=-Icsrc -Icppsrc -Inonarduino -DU8G_16BIT `sdl-config --cflags`
+-libu8gsdl_la_CPPFLAGS=$(libu8gsdl_la_CFLAGS)
+-libu8gsdl_la_LDFLAGS=`sdl-config --libs`
+-libu8gsdl_la_LIBADD=$(top_builddir)/libu8gbase.la
+-
+-libu8gwpi_la_CFLAGS=-Icsrc -Icppsrc -Inonarduino -DU8G_16BIT -DU8G_RASPBERRY_PI -DU8G_WITH_PINLIST
+-libu8gwpi_la_CPPFLAGS=$(libu8gwpi_la_CFLAGS)
+-libu8gwpi_la_LDFLAGS=-lwiringPi
+-libu8gwpi_la_LIBADD=$(top_builddir)/libu8gbase.la
+-
+-BIN_SDL= \
+-    u8gsdl_2bit u8gsdl_8bit u8gsdl_circle u8gsdl_helloworldpp \
+-    u8gsdl_cursor u8gsdl_fonttop u8gsdl_fullcolor u8gsdl_gabc u8gsdl_gah u8gsdl_greek \
+-    u8gsdl_helloworld u8gsdl_hicolor u8gsdl_logo u8gsdl_menu u8gsdl_polygon u8gsdl_xbm \
+-    u8gsdl_chess u8gsdl_spacetrash \
+-    u8gsdl_clip \
+-    $(NULL)
+-
+-BIN_WPI=u8gwpi_chess u8gwpi_chessdogm u8gwpi_gtest u8gwpi_logo u8gwpi_spacetrash
+-
+-BIN_TOOLS=bdf2u8g
+-bdf2u8g_SOURCES= \
+-    tools/font/bdf2u8g/bdf2u8g.c \
+-    $(NULL)
+-test:
+-	./bdf2u8g -f 2 tools/font/bdf/9x18.bdf u8g_aafont_9x18 test_u8g_aafont_9x18.c
+-
+-bin_PROGRAMS=$(BIN_TOOLS) $(BIN_SDL)
+-noinst_PROGRAMS=$(BIN_WPI)
+-
+-u8gsdl_clip_SOURCES=sys/pbm/cliptest/main.c
+-u8gsdl_clip_CFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_clip_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_2bit_SOURCES=sys/sdl/2bit/main.c
+-u8gsdl_2bit_CFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_2bit_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_8bit_SOURCES=sys/sdl/8bit/main.c
+-u8gsdl_8bit_CFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_8bit_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_chess_SOURCES=sys/sdl/chess/main.c
+-u8gsdl_chess_CFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_chess_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_circle_SOURCES=sys/sdl/circle/main.c
+-u8gsdl_circle_CPPFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_circle_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_helloworldpp_SOURCES=sys/sdl/cpp_helloworld/main.cpp
+-u8gsdl_helloworldpp_CPPFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_helloworldpp_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_cursor_SOURCES=sys/sdl/cursor/main.c
+-u8gsdl_cursor_CPPFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_cursor_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_fonttop_SOURCES=sys/sdl/FontPosTop/main.c
+-u8gsdl_fonttop_CPPFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_fonttop_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_fullcolor_SOURCES=sys/sdl/fullcolor/main.c
+-u8gsdl_fullcolor_CPPFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_fullcolor_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_gabc_SOURCES=sys/sdl/gabc/main.c
+-u8gsdl_gabc_CPPFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_gabc_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_gah_SOURCES=sys/sdl/gA_h/main.c
+-u8gsdl_gah_CPPFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_gah_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_greek_SOURCES=sys/sdl/greek/main.c
+-u8gsdl_greek_CPPFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_greek_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_helloworld_SOURCES=sys/sdl/helloworld/main.c
+-u8gsdl_helloworld_CPPFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_helloworld_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_hicolor_SOURCES=sys/sdl/hicolor/main.c
+-u8gsdl_hicolor_CPPFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_hicolor_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_logo_SOURCES=sys/sdl/cpp_logo/main.cpp
+-u8gsdl_logo_CPPFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_logo_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_menu_SOURCES=sys/sdl/menu/main.c
+-u8gsdl_menu_CPPFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_menu_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_polygon_SOURCES=sys/sdl/polygon/main.c
+-u8gsdl_polygon_CPPFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_polygon_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_spacetrash_SOURCES=sys/sdl/spacetrash/spacemain.c
+-u8gsdl_spacetrash_CPPFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_spacetrash_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-u8gsdl_xbm_SOURCES=sys/sdl/xbm/main.c
+-u8gsdl_xbm_CPPFLAGS=$(libu8gsdl_la_CFLAGS)
+-u8gsdl_xbm_LDFLAGS=-lu8gbase -lu8gsdl $(libu8gsdl_la_LDFLAGS)
+-
+-.pde.cpp:
+-	cp $< $@
+-.ino.o:
+-	cp $< $@
+-
+-#u8gwpi_logo_SOURCES=sys/arm/examples/u8g_logo/u8g_logo.c
+-#u8gwpi_logo_SOURCES=sys/atmega/u8g_logo/u8g_logo.c
+-u8gwpi_logo_SOURCES=nonarduino/wpimain.cpp sys/arduino/U8gLogo/U8gLogo.pde
+-u8gwpi_logo_CFLAGS=$(libu8gwpi_la_CFLAGS)
+-u8gwpi_logo_CPPFLAGS=$(libu8gwpi_la_CFLAGS)
+-u8gwpi_logo_LDFLAGS=-lu8gbase -lu8gwpi $(libu8gwpi_la_LDFLAGS)
+-
+-u8gwpi_gtest_SOURCES=nonarduino/wpimain.cpp sys/arduino/GraphicsTest/GraphicsTest.pde
+-u8gwpi_gtest_CPPFLAGS=$(libu8gwpi_la_CFLAGS)
+-u8gwpi_gtest_LDFLAGS=-lu8gbase -lu8gwpi $(libu8gwpi_la_LDFLAGS)
+-
+-u8gwpi_spacetrash_SOURCES=nonarduino/wpimain.cpp sys/arduino/SpaceTrashDogm/SpaceTrash.pde #sys/sdl/spacetrash/spacemain.c
+-u8gwpi_spacetrash_CPPFLAGS=$(libu8gwpi_la_CFLAGS)
+-u8gwpi_spacetrash_LDFLAGS=-lu8gbase -lu8gwpi $(libu8gwpi_la_LDFLAGS)
+-
+-u8gwpi_chess_SOURCES=nonarduino/wpimain.cpp sys/arduino/Chess/Chess.pde
+-u8gwpi_chess_CPPFLAGS=$(libu8gwpi_la_CFLAGS)
+-u8gwpi_chess_LDFLAGS=-lu8gbase -lu8gwpi $(libu8gwpi_la_LDFLAGS)
+-
+-u8gwpi_chessdogm_SOURCES=nonarduino/wpimain.cpp sys/arduino/ChessDogm/Chess.pde
+-u8gwpi_chessdogm_CPPFLAGS=$(libu8gwpi_la_CFLAGS)
+-u8gwpi_chessdogm_LDFLAGS=-lu8gwpi $(libu8gwpi_la_LDFLAGS)
+diff --git a/csrc/Makefile b/csrc/Makefile
+new file mode 100644
+index 0000000..644af09
+--- /dev/null
++++ b/csrc/Makefile
+@@ -0,0 +1,3 @@
++MODULE = u8glib
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/fntsrc/Makefile b/fntsrc/Makefile
+new file mode 100644
+index 0000000..644af09
+--- /dev/null
++++ b/fntsrc/Makefile
+@@ -0,0 +1,3 @@
++MODULE = u8glib
++
++include $(RIOTBASE)/Makefile.base
+-- 
+2.8.1
+

--- a/pkg/u8glib/patches/0002-u8glib-fix-compiler-errors.patch
+++ b/pkg/u8glib/patches/0002-u8glib-fix-compiler-errors.patch
@@ -1,0 +1,55 @@
+From 3638fe6edbd420e7e76bc84bc051aace36160cb5 Mon Sep 17 00:00:00 2001
+From: Bas Stottelaar <basstottelaar@gmail.com>
+Date: Tue, 22 Dec 2015 19:32:17 +0100
+Subject: [PATCH 2/4] u8glib: fix compiler errors.
+
+---
+ csrc/u8g_clip.c                     | 2 +-
+ csrc/u8g_dev_ssd1325_nhd27oled_bw.c | 3 +++
+ csrc/u8g_dev_ssd1325_nhd27oled_gr.c | 3 +++
+ 3 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/csrc/u8g_clip.c b/csrc/u8g_clip.c
+index 5f12097..39c66a2 100644
+--- a/csrc/u8g_clip.c
++++ b/csrc/u8g_clip.c
+@@ -95,7 +95,7 @@ static uint8_t u8g_is_intersection_boolean(u8g_uint_t a0, u8g_uint_t a1, u8g_uin
+ #define U8G_IS_INTERSECTION_MACRO(a0,a1,v0,v1) ((uint8_t)( (v0) <= (a1) ) ? ( ( (v1) >= (a0) ) ? ( 1 ) : ( (v0) > (v1) ) ) : ( ( (v1) >= (a0) ) ? ( (v0) > (v1) ) : ( 0 ) ))
+ 
+ //static uint8_t u8g_is_intersection_decision_tree(u8g_uint_t a0, u8g_uint_t a1, u8g_uint_t v0, u8g_uint_t v1) U8G_ALWAYS_INLINE;
+-static uint8_t U8G_ALWAYS_INLINE u8g_is_intersection_decision_tree(u8g_uint_t a0, u8g_uint_t a1, u8g_uint_t v0, u8g_uint_t v1) 
++static U8G_ALWAYS_INLINE uint8_t u8g_is_intersection_decision_tree(u8g_uint_t a0, u8g_uint_t a1, u8g_uint_t v0, u8g_uint_t v1)
+ {
+   /* surprisingly the macro leads to larger code */
+   /* return U8G_IS_INTERSECTION_MACRO(a0,a1,v0,v1); */
+diff --git a/csrc/u8g_dev_ssd1325_nhd27oled_bw.c b/csrc/u8g_dev_ssd1325_nhd27oled_bw.c
+index d889539..93a01c9 100644
+--- a/csrc/u8g_dev_ssd1325_nhd27oled_bw.c
++++ b/csrc/u8g_dev_ssd1325_nhd27oled_bw.c
+@@ -41,6 +41,9 @@
+ 
+ */
+ 
++/* prevent empty translation unit errors */
++typedef int dummy_type_t;
++
+ #ifdef OBSOLETE_CODE
+ 
+ #include "u8g.h"
+diff --git a/csrc/u8g_dev_ssd1325_nhd27oled_gr.c b/csrc/u8g_dev_ssd1325_nhd27oled_gr.c
+index 6ab4813..0070d09 100644
+--- a/csrc/u8g_dev_ssd1325_nhd27oled_gr.c
++++ b/csrc/u8g_dev_ssd1325_nhd27oled_gr.c
+@@ -41,6 +41,9 @@
+ 
+ */
+ 
++/* prevent empty translation unit errors */
++typedef int dummy_type_t;
++
+ #ifdef OBSOLETE_CODE
+ 
+ #include "u8g.h"
+-- 
+2.8.1
+

--- a/pkg/u8glib/patches/0003-u8glib-remove-unneeded-files-for-other-platforms.patch
+++ b/pkg/u8glib/patches/0003-u8glib-remove-unneeded-files-for-other-platforms.patch
@@ -1,0 +1,10199 @@
+From 02fc2a10852842f0d43619f12d943d94d0755ff0 Mon Sep 17 00:00:00 2001
+From: Bas Stottelaar <basstottelaar@gmail.com>
+Date: Fri, 6 May 2016 00:14:16 +0200
+Subject: [PATCH 3/4] u8glib: remove unneeded files for other platforms.
+
+---
+ csrc/chessengine.c                     | 2392 --------------------------------
+ csrc/u8g_com_arduino_attiny85_hw_spi.c |  160 ---
+ csrc/u8g_com_arduino_common.c          |   75 -
+ csrc/u8g_com_arduino_fast_parallel.c   |  254 ----
+ csrc/u8g_com_arduino_hw_spi.c          |  438 ------
+ csrc/u8g_com_arduino_hw_usart_spi.c    |  159 ---
+ csrc/u8g_com_arduino_no_en_parallel.c  |  234 ----
+ csrc/u8g_com_arduino_parallel.c        |  184 ---
+ csrc/u8g_com_arduino_port_d_wr.c       |  177 ---
+ csrc/u8g_com_arduino_ssd_i2c.c         |  212 ---
+ csrc/u8g_com_arduino_st7920_custom.c   |  330 -----
+ csrc/u8g_com_arduino_st7920_hw_spi.c   |  293 ----
+ csrc/u8g_com_arduino_st7920_spi.c      |  330 -----
+ csrc/u8g_com_arduino_std_sw_spi.c      |  143 --
+ csrc/u8g_com_arduino_sw_spi.c          |  301 ----
+ csrc/u8g_com_arduino_t6963.c           |  403 ------
+ csrc/u8g_com_arduino_uc_i2c.c          |  206 ---
+ csrc/u8g_com_atmega_hw_spi.c           |  188 ---
+ csrc/u8g_com_atmega_parallel.c         |  183 ---
+ csrc/u8g_com_atmega_st7920_hw_spi.c    |  217 ---
+ csrc/u8g_com_atmega_st7920_spi.c       |  170 ---
+ csrc/u8g_com_atmega_sw_spi.c           |  141 --
+ csrc/u8g_com_atxmega_hw_spi.c          |  174 ---
+ csrc/u8g_com_atxmega_st7920_hw_spi.c   |  202 ---
+ csrc/u8g_com_i2c.c                     |  643 ---------
+ csrc/u8g_com_io.c                      |  452 ------
+ csrc/u8g_com_linux_ssd_i2c.c           |  168 ---
+ csrc/u8g_com_msp430_hw_spi.c           |  221 ---
+ csrc/u8g_com_psoc5_ssd_hw_parallel.c   |  107 --
+ csrc/u8g_com_raspberrypi_hw_spi.c      |  124 --
+ csrc/u8g_com_raspberrypi_ssd_i2c.c     |  176 ---
+ csrc/u8g_com_std_sw_spi.c              |  140 --
+ csrc/u8g_delay.c                       |  323 -----
+ 33 files changed, 9920 deletions(-)
+ delete mode 100644 csrc/chessengine.c
+ delete mode 100644 csrc/u8g_com_arduino_attiny85_hw_spi.c
+ delete mode 100644 csrc/u8g_com_arduino_common.c
+ delete mode 100644 csrc/u8g_com_arduino_fast_parallel.c
+ delete mode 100644 csrc/u8g_com_arduino_hw_spi.c
+ delete mode 100644 csrc/u8g_com_arduino_hw_usart_spi.c
+ delete mode 100644 csrc/u8g_com_arduino_no_en_parallel.c
+ delete mode 100644 csrc/u8g_com_arduino_parallel.c
+ delete mode 100644 csrc/u8g_com_arduino_port_d_wr.c
+ delete mode 100644 csrc/u8g_com_arduino_ssd_i2c.c
+ delete mode 100644 csrc/u8g_com_arduino_st7920_custom.c
+ delete mode 100644 csrc/u8g_com_arduino_st7920_hw_spi.c
+ delete mode 100644 csrc/u8g_com_arduino_st7920_spi.c
+ delete mode 100644 csrc/u8g_com_arduino_std_sw_spi.c
+ delete mode 100644 csrc/u8g_com_arduino_sw_spi.c
+ delete mode 100644 csrc/u8g_com_arduino_t6963.c
+ delete mode 100644 csrc/u8g_com_arduino_uc_i2c.c
+ delete mode 100644 csrc/u8g_com_atmega_hw_spi.c
+ delete mode 100644 csrc/u8g_com_atmega_parallel.c
+ delete mode 100644 csrc/u8g_com_atmega_st7920_hw_spi.c
+ delete mode 100644 csrc/u8g_com_atmega_st7920_spi.c
+ delete mode 100644 csrc/u8g_com_atmega_sw_spi.c
+ delete mode 100644 csrc/u8g_com_atxmega_hw_spi.c
+ delete mode 100644 csrc/u8g_com_atxmega_st7920_hw_spi.c
+ delete mode 100644 csrc/u8g_com_i2c.c
+ delete mode 100644 csrc/u8g_com_io.c
+ delete mode 100644 csrc/u8g_com_linux_ssd_i2c.c
+ delete mode 100644 csrc/u8g_com_msp430_hw_spi.c
+ delete mode 100644 csrc/u8g_com_psoc5_ssd_hw_parallel.c
+ delete mode 100644 csrc/u8g_com_raspberrypi_hw_spi.c
+ delete mode 100644 csrc/u8g_com_raspberrypi_ssd_i2c.c
+ delete mode 100644 csrc/u8g_com_std_sw_spi.c
+ delete mode 100644 csrc/u8g_delay.c
+
+diff --git a/csrc/chessengine.c b/csrc/chessengine.c
+deleted file mode 100644
+index f86bf06..0000000
+--- a/csrc/chessengine.c
++++ /dev/null
+@@ -1,2392 +0,0 @@
+-/*
+-  chessengine.c
+-  
+-  "Little Rook Chess" (lrc)
+-
+-  Port to u8g library
+-
+-  chess for embedded 8-Bit controllers
+-
+-  Copyright (c) 2012, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-
+-  Note:
+-    UNIX_MAIN --> unix console executable
+-
+-  Current Rule Limitation
+-    - no minor promotion, only "Queening" of the pawn
+-    - threefold repetition is not detected (same board situation appears three times)
+-	Note: Could be implemented, but requires tracking of the complete game
+-    - Fifty-move rule is not checked (no pawn move, no capture within last 50 moves)
+-	
+-  Words
+-    Ply		a half move
+-    
+-  General Links
+-    http://chessprogramming.wikispaces.com/
+-
+-  Arduino specific
+-    http://www.arduino.cc/cgi-bin/yabb2/YaBB.pl?num=1260055596
+-    
+-  Prefixes  
+-    chess_		Generic Chess Application Interface
+-    ce_		Chess engine, used internally, these function should not be called directly
+-    cu_		Chess utility function
+-    stack_		Internal function for stack handling
+-
+-  Issues
+-    10.01.2011
+-      - castling to the right does not move the rook
+-	  --> done
+-      - castling to the left: King can only move two squares
+-	  --> done
+-      
+-    11.01.2011	
+-      Next Steps:
+-	- replace stack_NextCurrentPos with cu_NextPos, cleanup code according to the loop variable
+-	    --> done
+-	- Castling: Need to check for fields under attack
+-	    --> done
+-	
+-	- Check for WIN / LOOSE situation, perhaps call ce_Eval() once on the top-level board setup
+-	    just after the real move
+-	- cleanup cu_Move
+-	    --> almost done
+-	- add some heuristics to the eval procedure
+-	- add right side menu
+-	  --> done
+-	- clean up chess_ManualMove
+-	  --> done
+-	- finish menu (consider is_game_end, undo move)
+-        - end condition: if KING is under attack and if KING can not move to a field which is under attack...
+-	      then the game is lost. What will be returned by the Eval procedure? is it -INF?
+-	    --> finished
+-	    
+-	- reduce the use of variable color, all should be reduced to board_orientation and ply&1
+-	
+-	- chess_GetNextMarked shoud make use of cu_NextPos
+-	    --> done
+-	- chess_ManualMove: again cleanup, solve draw issue (KING is not in check and no legal moves are available)
+-	    --> done
+-    22.01.2011
+-	- simplify eval_t ce_Eval(void)
+-	- position eval does not work, still moves side pawn :-(
+-	      maybe because all pieces are considered
+-	    --> done
+-
+-*/
+-
+-#include "u8g.h"
+-
+-//#ifndef __unix__
+-//#else
+-//#include <assert.h>
+-//#define U8G_NOINLINE
+-//#endif
+-
+-/*
+-SAN identifies each piece by a single upper case letter.  The standard English
+-values: pawn = "P", knight = "N", bishop = "B", rook = "R", queen = "Q", and
+-king = "K".
+-*/
+-
+-/* numbers for the various pieces */
+-#define PIECE_NONE	0
+-#define PIECE_PAWN 	1
+-#define PIECE_KNIGHT  	2
+-#define PIECE_BISHOP 	3
+-#define PIECE_ROOK	4
+-#define PIECE_QUEEN 	5
+-#define PIECE_KING		6
+-
+-/* color definitions */
+-#define COLOR_WHITE	0
+-#define COLOR_BLACK	1
+-
+-/* a mask, which includes COLOR and PIECE number */
+-#define COLOR_PIECE_MASK 0x01f
+-
+-#define CP_MARK_MASK 0x20
+-
+-#define ILLEGAL_POSITION 255
+-
+-/* This is the build in upper limit of the search stack */
+-/* This value defines the amount of memory allocated for the search stack */
+-/* The search depth of this chess engine can never exceed this value */
+-#define STACK_MAX_SIZE 5
+-
+-/* chess half move stack: twice the number of undo's, a user can do */ 
+-#define CHM_USER_SIZE 6
+-
+-/* the CHM_LIST_SIZE must be larger than the maximum search depth */
+-/* the overall size of ste half move stack */
+-#define CHM_LIST_SIZE (STACK_MAX_SIZE+CHM_USER_SIZE+2)
+-
+-typedef int16_t eval_t;	/* a variable type to store results from the evaluation */ 
+-//#define EVAL_T_LOST -32768
+-#define EVAL_T_MIN -32767
+-#define EVAL_T_MAX 32767
+-//#define EVAL_T_WIN 32767
+-
+-/* for maintainance of our own stack: this is the definition of one element on the stack */
+-struct _stack_element_struct
+-{
+-  /* the current source position which is investigated */
+-  uint8_t current_pos;
+-  uint8_t current_cp;
+-  uint8_t current_color;	/* COLOR_WHITE or COLOR_BLACK: must be predefines */
+-  
+-  /* the move which belongs to that value, both values are game positions */
+-  uint8_t best_from_pos;
+-  uint8_t best_to_pos;
+-  /* the best value, which has been dicovered so far */
+-  eval_t best_eval;
+-};
+-typedef struct _stack_element_struct stack_element_t;
+-typedef struct _stack_element_struct *stack_element_p;
+-
+-/* chess half move history */
+-struct _chm_struct
+-{
+-  uint8_t main_cp;		/* the main piece, which is moved */
+-  uint8_t main_src;		/* the source position of the main piece */
+-  uint8_t main_dest; 	/* the destination of the main piece */
+-  
+-  uint8_t other_cp;		/* another piece: the captured one, the ROOK in case of castling or PIECE_NONE */
+-  uint8_t other_src;		/* the delete position of other_cp. Often identical to main_dest except for e.p. and castling */
+-  uint8_t other_dest;		/* only used for castling: ROOK destination pos */
+-  
+-  /* the position of the last pawn, which did a double move forward */
+-  /* this is required to check en passant conditions */
+-  /* this array can be indexed by the color of the current player */
+-  /* this is the condition BEFORE the move was done */
+-  uint8_t pawn_dbl_move[2];
+-  
+-  /* flags for the movement of rook and king; required for castling */
+-  /* a 1 means: castling is (still) possible */
+-  /* a 0 means: castling not possible */
+-  /*  bit 0 left side white */
+-  /*  bit 1 right side white */
+-  /*  bit 2 left side black */
+-  /*  bit 3 right side black */
+-  /* this is the condition BEFORE the move was done */
+-  uint8_t castling_possible;   
+-};
+-
+-typedef struct _chm_struct chm_t;
+-typedef struct _chm_struct *chm_p;
+-
+-/* little rook chess, main structure */
+-struct _lrc_struct
+-{  
+-  /* half-move (ply) counter: Counts the number of half-moves so far. Starts with 0 */
+-  /* the lowest bit is used to derive the color of the current player */
+-  /* will be set to zero in chess_SetupBoard() */
+-  uint8_t ply_count;
+-  
+-  /* the half move stack position counter, counts the number of elements in chm_list */
+-  uint8_t chm_pos;
+-  
+-  /* each element contains a colored piece, empty fields have value 0 */
+-  /* the field with index 0 is black (lower left) */
+-  uint8_t board[64];	
+-  /* the position of the last pawn, which did a double move forward */
+-  /* this is required to check en passant conditions */
+-  /* this array can be indexed by the color of the current player */
+-  uint8_t pawn_dbl_move[2]; 
+-  
+-  /* flags for the movement of rook and king; required for castling */
+-  /* a 1 means: castling is (still) possible */
+-  /* a 0 means: castling not possible */
+-  /*  bit 0 left side white */
+-  /*  bit 1 right side white */
+-  /*  bit 2 left side black */
+-  /*  bit 3 right side black */
+-  uint8_t castling_possible; 
+-  
+-  /* board orientation */
+-  /* 0: white is below COLOR_WHITE */
+-  /* 1: black is below COLOR_BLACK */
+-  /* bascially, this can be used as a color */
+-  uint8_t orientation;
+-  
+-  /* exchange colors of the pieces */
+-  /* 0: white has an empty body, use this for bright background color */
+-  /* 1: black has an empty body, use this for dark backround color */
+-  uint8_t strike_out_color;
+-  
+-  /* 0, when the game is ongoing */
+-  /* 1, when the game is stopped (lost or draw) */
+-  uint8_t is_game_end;
+-  /* the color of the side which lost the game */
+-  /* this value is only valid, when is_game_end is not 0 */
+-  /* values 0 and 1 represent WHITE and BLACK, 2 means a draw */
+-  uint8_t lost_side_color;
+-  
+-  
+-  
+-  /* checks are executed in ce_LoopRecur */
+-  /* these checks will put some marks on the board */
+-  /* this will be used by the interface to find out */
+-  /* legal moves */
+-  uint8_t check_src_pos;
+-  uint8_t check_mode;		/* CHECK_MODE_NONE, CHECK_MODE_MOVEABLE, CHECK_MODE_TARGET_MOVE */
+-  
+-  
+-  /* count of the attacking pieces, indexed by color */
+-  uint8_t find_piece_cnt[2];
+-
+-  /* sum of the attacking pieces, indexed by color */
+-  uint8_t find_piece_weight[2];
+-
+-  /* points to the current element of the search stack */
+-  /* this stack is NEVER empty. The value 0 points to the first element of the stack */
+-  /* actually "curr_depth" represent half-moves (plies) */
+-  uint8_t curr_depth;
+-  uint8_t max_depth;
+-  stack_element_p curr_element;
+-  
+-  /* allocated memory for the search stack */
+-  stack_element_t stack_memory[STACK_MAX_SIZE];
+-
+-  /* the half move stack, used for move undo and depth search, size is stored in chm_pos */
+-  chm_t chm_list[CHM_LIST_SIZE];
+-};
+-typedef struct _lrc_struct lrc_t;
+-
+-#define CHECK_MODE_NONE 0
+-#define CHECK_MODE_MOVEABLE 1
+-#define CHECK_MODE_TARGET_MOVE 2
+-
+-
+-
+-/*==============================================================*/
+-/* global variables */
+-/*==============================================================*/
+-
+-u8g_t *lrc_u8g;
+-
+-lrc_t lrc_obj;
+-
+-
+-/*==============================================================*/
+-/* forward declarations */
+-/*==============================================================*/
+-
+-/* 
+-  apply no inline to some of the functions:
+-  avr-gcc very often inlines functions, however not inline saves a lot of program memory!
+-  On the other hand there are some really short procedures which should be inlined (like cp_GetColor)
+-  These procedures are marked static to prevent the generation of the expanded procedure, which
+-  also saves space.
+-*/
+-
+-uint8_t stack_Push(uint8_t color) U8G_NOINLINE;
+-void stack_Pop(void) U8G_NOINLINE;
+-void stack_InitCurrElement(void) U8G_NOINLINE;
+-void stack_Init(uint8_t max) U8G_NOINLINE;
+-void stack_SetMove(eval_t val, uint8_t to_pos) U8G_NOINLINE;
+-uint8_t cu_NextPos(uint8_t pos) U8G_NOINLINE;
+-static uint8_t cu_gpos2bpos(uint8_t gpos);
+-static uint8_t cp_Construct(uint8_t color, uint8_t piece);
+-static uint8_t cp_GetPiece(uint8_t cp);
+-static uint8_t cp_GetColor(uint8_t cp);
+-uint8_t cp_GetFromBoard(uint8_t pos) U8G_NOINLINE;
+-void cp_SetOnBoard(uint8_t pos, uint8_t cp) U8G_NOINLINE;
+-
+-void cu_ClearBoard(void) U8G_NOINLINE;
+-void chess_SetupBoard(void) U8G_NOINLINE;
+-eval_t ce_Eval(void);
+-
+-void cu_ClearMoveHistory(void) U8G_NOINLINE;
+-void cu_ReduceHistoryByFullMove(void) U8G_NOINLINE;
+-void cu_UndoHalfMove(void) U8G_NOINLINE;
+-chm_p cu_PushHalfMove(void) U8G_NOINLINE;
+-
+-
+-void ce_CalculatePositionWeight(uint8_t pos);
+-uint8_t ce_GetPositionAttackWeight(uint8_t pos, uint8_t color);
+-
+-void chess_Thinking(void);
+-void ce_LoopPieces(void);
+-
+-
+-/*==============================================================*/
+-/* search stack */
+-/*==============================================================*/
+-
+-/* get current element from stack */
+-stack_element_p stack_GetCurrElement(void)
+-{
+-  return lrc_obj.curr_element;
+-}
+-
+-uint8_t stack_Push(uint8_t color)
+-{
+-  if ( lrc_obj.curr_depth == lrc_obj.max_depth )
+-    return 0;
+-  lrc_obj.curr_depth++;
+-  lrc_obj.curr_element = lrc_obj.stack_memory+lrc_obj.curr_depth;
+-  
+-  /* change view for the evaluation */
+-  color ^= 1;
+-  stack_GetCurrElement()->current_color = color;
+-
+-  return 1;
+-}
+-
+-void stack_Pop(void)
+-{
+-  lrc_obj.curr_depth--;
+-  lrc_obj.curr_element = lrc_obj.stack_memory+lrc_obj.curr_depth;
+-}
+-
+-/* reset the current element on the stack */
+-void stack_InitCurrElement(void)
+-{
+-  stack_element_p e = stack_GetCurrElement();
+-  e->best_eval = EVAL_T_MIN;
+-  e->best_from_pos = ILLEGAL_POSITION;
+-  e->best_to_pos = ILLEGAL_POSITION;
+-}
+-
+-/* resets the search stack (and the check mode) */
+-void stack_Init(uint8_t max)
+-{
+-  lrc_obj.curr_depth = 0;
+-  lrc_obj.curr_element = lrc_obj.stack_memory;
+-  lrc_obj.max_depth = max;
+-  lrc_obj.check_mode = CHECK_MODE_NONE;
+-  stack_InitCurrElement();
+-  stack_GetCurrElement()->current_color = lrc_obj.ply_count;
+-  stack_GetCurrElement()->current_color &= 1;
+-}
+-
+-/* assign evaluation value and store the move, if this is the best move */
+-/* assumes, that current_pos contains the source position */
+-void stack_SetMove(eval_t val, uint8_t to_pos)
+-{
+-  stack_element_p e = stack_GetCurrElement();
+-  if ( e->best_eval < val )
+-  {
+-    e->best_eval = val;
+-    e->best_from_pos = e->current_pos;
+-    e->best_to_pos = to_pos;
+-  }
+-}
+-
+-/* 
+-  calculate next position on a 0x88 board 
+-  loop is constructed in this way:
+-  i = 0;
+-  do
+-  {
+-    ...
+-    i = cu_NextPos(i);
+-  } while( i != 0 );
+-
+-  next pos might be started with an illegal position like 255
+-*/
+-uint8_t cu_NextPos(uint8_t pos)
+-{
+-  /* calculate next gpos */
+-  pos++;
+-  if ( ( pos & 0x08 ) != 0 )
+-  {
+-    pos+= 0x10;
+-    pos&= 0xf0; 
+-  }
+-  if ( ( pos & 0x80 ) != 0 )
+-    pos = 0;
+-  return pos;
+-}
+-
+-uint8_t cu_PrevPos(uint8_t pos)
+-{
+-  /* calculate prev gpos */
+-  pos--;
+-  if ( ( pos & 0x80 ) != 0 )
+-    pos = 0x077;
+-  else if ( ( pos & 0x08 ) != 0 )
+-  {
+-    pos &= 0xf0; 
+-    pos |= 0x07;
+-  }
+-  return pos;
+-}
+-
+-
+-/*==============================================================*/
+-/* position transltion */
+-/*==============================================================*/
+-/*
+-  there are two positions
+-    1. game position (gpos): BCD encoded x-y values
+-    2. board position (bpos): a number between 0 and 63, only used to access the board.
+-*/
+-/*
+-  gpos:	game position value
+-  returns:	board position
+-  note:	does not do any checks
+-*/
+-static uint8_t cu_gpos2bpos(uint8_t gpos)
+-{
+-  uint8_t bpos = gpos;
+-  bpos &= 0xf0;
+-  bpos >>= 1;
+-  gpos &= 0x0f;
+-  bpos |= gpos;
+-  return bpos;
+-}
+-
+-#define gpos_IsIllegal(gpos) ((gpos) & 0x088)
+-
+-
+-/*==============================================================*/
+-/* colored piece handling */
+-/*==============================================================*/
+-
+-#define cp_IsMarked(cp)  ((cp) & CP_MARK_MASK)
+-
+-
+-/*
+-  piece: one of PIECE_xxx
+-  color: COLOR_WHITE or COLOR_BLACK
+-
+-  returns: A colored piece
+-*/
+-static uint8_t cp_Construct(uint8_t color, uint8_t piece)
+-{
+-  color <<= 4;
+-  color |= piece;
+-  return color;
+-}
+-
+-/* inline is better than a macro */
+-static uint8_t cp_GetPiece(uint8_t cp)
+-{
+-  cp &= 0x0f;
+-  return cp;
+-}
+-
+-/*
+-  we could use a macro:
+-  #define cp_GetColor(cp)	(((cp) >> 4)&1)
+-  however, inlined functions are sometimes much better
+-*/
+-static uint8_t cp_GetColor(uint8_t cp)
+-{
+-  cp >>= 4;
+-  cp &= 1;
+-  return cp;
+-}
+-
+-/*
+-  pos: game position
+-  returns the colored piece at the given position
+-*/
+-uint8_t cp_GetFromBoard(uint8_t pos)
+-{
+-  return lrc_obj.board[cu_gpos2bpos(pos)];
+-}
+-
+-/*
+-  pos: game position
+-  cp: colored piece
+-*/
+-void cp_SetOnBoard(uint8_t pos, uint8_t cp)
+-{
+-  /*printf("cp_SetOnBoard gpos:%02x cp:%02x\n", pos, cp);*/
+-  lrc_obj.board[cu_gpos2bpos(pos)] = cp;
+-}
+-
+-/*==============================================================*/
+-/* global board access */
+-/*==============================================================*/
+-
+-void cu_ClearBoard(void)
+-{
+-  uint8_t i;
+-  /* clear the board */
+-  for( i = 0; i < 64; i++ )
+-    lrc_obj.board[i] = PIECE_NONE;
+-  
+-  lrc_obj.ply_count = 0;
+-  lrc_obj.orientation = COLOR_WHITE;
+-  
+-  lrc_obj.pawn_dbl_move[0] = ILLEGAL_POSITION;
+-  lrc_obj.pawn_dbl_move[1] = ILLEGAL_POSITION;
+-  
+-  lrc_obj.castling_possible = 0x0f;
+-  
+-  lrc_obj.is_game_end = 0;
+-  lrc_obj.lost_side_color = 0;
+-
+-  /* clear half move history */
+-  cu_ClearMoveHistory();
+-
+-}
+-
+-/*
+-  test setup
+-  white wins in one move
+-*/
+-void chess_SetupBoardTest01(void)
+-{
+-  cu_ClearBoard();
+-  lrc_obj.board[7+7*8] = cp_Construct(COLOR_BLACK, PIECE_KING);
+-  lrc_obj.board[7+5*8] = cp_Construct(COLOR_WHITE, PIECE_PAWN);
+-  lrc_obj.board[3] = cp_Construct(COLOR_WHITE, PIECE_KING);
+-  lrc_obj.board[0+7*8] = cp_Construct(COLOR_BLACK, PIECE_ROOK);
+-  lrc_obj.board[6] = cp_Construct(COLOR_WHITE, PIECE_QUEEN);
+-} 
+-
+-/* setup the global board */
+-void chess_SetupBoard(void)
+-{
+-  uint8_t i;
+-  register uint8_t bp, wp;
+-  
+-  /* clear the board */
+-  cu_ClearBoard();
+-  
+-  /* precronstruct pawns */
+-  wp = cp_Construct(COLOR_WHITE, PIECE_PAWN);
+-  bp = cp_Construct(COLOR_BLACK, PIECE_PAWN);
+-  
+-  /* setup pawn */
+-  for( i = 0; i < 8; i++ )
+-  {
+-    lrc_obj.board[i+8] = wp;
+-    lrc_obj.board[i+6*8] = bp;
+-  }
+-  
+-  /* assign remaining pieces */
+-  
+-  lrc_obj.board[0] = cp_Construct(COLOR_WHITE, PIECE_ROOK);
+-  lrc_obj.board[1] = cp_Construct(COLOR_WHITE, PIECE_KNIGHT);
+-  lrc_obj.board[2] = cp_Construct(COLOR_WHITE, PIECE_BISHOP);
+-  lrc_obj.board[3] = cp_Construct(COLOR_WHITE, PIECE_QUEEN);
+-  lrc_obj.board[4] = cp_Construct(COLOR_WHITE, PIECE_KING);
+-  lrc_obj.board[5] = cp_Construct(COLOR_WHITE, PIECE_BISHOP);
+-  lrc_obj.board[6] = cp_Construct(COLOR_WHITE, PIECE_KNIGHT);
+-  lrc_obj.board[7] = cp_Construct(COLOR_WHITE, PIECE_ROOK);
+-
+-  lrc_obj.board[0+7*8] = cp_Construct(COLOR_BLACK, PIECE_ROOK);
+-  lrc_obj.board[1+7*8] = cp_Construct(COLOR_BLACK, PIECE_KNIGHT);
+-  lrc_obj.board[2+7*8] = cp_Construct(COLOR_BLACK, PIECE_BISHOP);
+-  lrc_obj.board[3+7*8] = cp_Construct(COLOR_BLACK, PIECE_QUEEN);
+-  lrc_obj.board[4+7*8] = cp_Construct(COLOR_BLACK, PIECE_KING);
+-  lrc_obj.board[5+7*8] = cp_Construct(COLOR_BLACK, PIECE_BISHOP);
+-  lrc_obj.board[6+7*8] = cp_Construct(COLOR_BLACK, PIECE_KNIGHT);
+-  lrc_obj.board[7+7*8] = cp_Construct(COLOR_BLACK, PIECE_ROOK);
+-
+-  //chess_SetupBoardTest01();
+-
+-}
+-
+-
+-
+-/*==============================================================*/
+-/* checks */
+-/*==============================================================*/
+-
+-/*
+-  checks if the position is somehow illegal
+-*/
+-uint8_t cu_IsIllegalPosition(uint8_t pos, uint8_t my_color)
+-{
+-  uint8_t board_cp;
+-  /* check, if the position is offboard */
+-  if ( gpos_IsIllegal(pos) != 0 )
+-    return 1;
+-  /* get the piece from the board */
+-  board_cp = cp_GetFromBoard(pos);
+-  /* check if hit our own pieces */
+-  if ( board_cp != 0 ) 
+-    if ( cp_GetColor(board_cp) == my_color )
+-      return 1;
+-  /* all ok, we could go to this position */
+-  return 0;
+-}
+-
+-/*==============================================================*/
+-/* evaluation procedure */
+-/*==============================================================*/
+-
+-/*
+-  basic idea is to return a value between EVAL_T_MIN and EVAL_T_MAX
+-*/
+-
+-/*
+-  the weight table uses the PIECE number as index:
+-      #define PIECE_NONE	0
+-      #define PIECE_PAWN 	1
+-      #define PIECE_KNIGHT  	2
+-      #define PIECE_BISHOP 	3
+-      #define PIECE_ROOK	4
+-      #define PIECE_QUEEN 	5
+-      #define PIECE_KING		6
+-  the king itself is not counted
+-*/
+-uint8_t ce_piece_weight[] = { 0, 1, 3, 3, 5, 9, 0 };
+-uint8_t ce_pos_weight[] = { 0, 1, 1, 2, 2, 1, 1, 0};
+-/*
+-  evaluate the current situation on the global board
+-*/
+-eval_t ce_Eval(void)
+-{
+-  uint8_t cp;
+-  uint8_t is_my_king_present = 0;
+-  uint8_t is_opposit_king_present = 0;
+-  eval_t material_my_color = 0;
+-  eval_t material_opposit_color = 0;
+-  eval_t position_my_color = 0;
+-  eval_t position_opposit_color = 0;
+-  eval_t result;
+-  uint8_t pos;
+-  
+-  pos = 0;
+-  do
+-  {
+-    /* get colored piece from the board */
+-    cp = cp_GetFromBoard(pos);
+-    
+-    if ( cp_GetPiece(cp) != PIECE_NONE )
+-    {
+-      if ( stack_GetCurrElement()->current_color == cp_GetColor(cp) )
+-      {
+-	/* this is our color */
+-	/* check if we found our king */
+-	if ( cp_GetPiece(cp) == PIECE_KING  )
+-	  is_my_king_present = 1;
+-	material_my_color += ce_piece_weight[cp_GetPiece(cp)];
+-	if ( cp_GetPiece(cp) == PIECE_PAWN || cp_GetPiece(cp) == PIECE_KNIGHT  )
+-	{
+-	  position_my_color += ce_pos_weight[pos&7]*ce_pos_weight[(pos>>4)&7];
+-	}
+-      }
+-      else
+-      {
+-	/* this is the opposit color */
+-	if ( cp_GetPiece(cp) == PIECE_KING  )
+-	  is_opposit_king_present = 1;
+-	material_opposit_color += ce_piece_weight[cp_GetPiece(cp)];
+-	if ( cp_GetPiece(cp) == PIECE_PAWN || cp_GetPiece(cp) == PIECE_KNIGHT )
+-	{
+-	  position_opposit_color += ce_pos_weight[pos&7]*ce_pos_weight[(pos>>4)&7];
+-	}
+-      }
+-    }
+-    pos = cu_NextPos(pos);
+-  } while( pos != 0 );
+-
+-    
+-  /* decide if we lost or won the game */
+-  if ( is_my_king_present == 0 )
+-    return EVAL_T_MIN;	/*_LOST*/
+-  if ( is_opposit_king_present == 0 )
+-    return EVAL_T_MAX;	/*_WIN*/
+-  
+-  /* here is the evaluation function */
+-  
+-  result = material_my_color - material_opposit_color;
+-  result <<= 3;
+-  result += position_my_color - position_opposit_color;
+-  return result;
+-}
+-
+-/*==============================================================*/
+-/* move backup and restore */
+-/*==============================================================*/
+-
+-
+-/* this procedure must be called to keep the size as low as possible */
+-/* if the chm_list is large enough, it could hold the complete history */
+-/* but for an embedded controler... it is deleted for every engine search */
+-void cu_ClearMoveHistory(void)
+-{
+-  lrc_obj.chm_pos = 0;
+-}
+-
+-void cu_ReduceHistoryByFullMove(void)
+-{
+-  uint8_t i;
+-  while( lrc_obj.chm_pos > CHM_USER_SIZE )
+-  {
+-    i = 0;
+-    for(;;)
+-    {
+-      if ( i+2 >= lrc_obj.chm_pos )
+-	break;
+-      lrc_obj.chm_list[i] = lrc_obj.chm_list[i+2];
+-      i++;
+-    }
+-    lrc_obj.chm_pos -= 2;
+-  }
+-}
+-
+-void cu_UndoHalfMove(void)
+-{
+-  chm_p chm;
+-  
+-  if ( lrc_obj.chm_pos == 0 )
+-    return;
+-  
+-  lrc_obj.chm_pos--;
+-
+-  chm = lrc_obj.chm_list+lrc_obj.chm_pos;
+-  
+-  lrc_obj.pawn_dbl_move[0] = chm->pawn_dbl_move[0];
+-  lrc_obj.pawn_dbl_move[1] = chm->pawn_dbl_move[1];
+-  lrc_obj.castling_possible = chm->castling_possible;
+-  
+-  cp_SetOnBoard(chm->main_src, chm->main_cp);
+-  cp_SetOnBoard(chm->main_dest, PIECE_NONE);
+-  
+-  if ( chm->other_src != ILLEGAL_POSITION )
+-    cp_SetOnBoard(chm->other_src, chm->other_cp);
+-  if ( chm->other_dest != ILLEGAL_POSITION )
+-    cp_SetOnBoard(chm->other_dest, PIECE_NONE);
+-
+-}
+-
+-/*
+-  assumes, that the following members of the returned chm structure are filled 
+-  uint8_t main_cp;		the main piece, which is moved
+-  uint8_t main_src;		the source position of the main piece
+-  uint8_t main_dest; 	the destination of the main piece
+-  
+-  uint8_t other_cp;		another piece: the captured one, the ROOK in case of castling or PIECE_NONE
+-  uint8_t other_src;		the delete position of other_cp. Often identical to main_dest except for e.p. and castling
+-  uint8_t other_dest;		only used for castling: ROOK destination pos
+-
+-*/
+-chm_p cu_PushHalfMove(void)
+-{
+-  chm_p chm;
+-  
+-  chm = lrc_obj.chm_list+lrc_obj.chm_pos;
+-  if ( lrc_obj.chm_pos < CHM_LIST_SIZE-1)
+-    lrc_obj.chm_pos++;
+-
+-  chm->pawn_dbl_move[0] = lrc_obj.pawn_dbl_move[0];
+-  chm->pawn_dbl_move[1] = lrc_obj.pawn_dbl_move[1];
+-  chm->castling_possible = lrc_obj.castling_possible;
+-  return chm;
+-}
+-
+-
+-char chess_piece_to_char[] = "NBRQK";
+-
+-/*
+-  simple moves on empty field: 	Ka1-b2
+-  capture moves:				Ka1xb2
+-  castling:						0-0 or 0-0-0
+-*/
+-
+-static void cu_add_pos(char *s, uint8_t pos) U8G_NOINLINE;
+-
+-static void cu_add_pos(char *s, uint8_t pos)
+-{
+-  *s = pos;
+-  *s >>= 4;
+-  *s += 'a';
+-  s++;
+-  *s = pos;
+-  *s &= 15;
+-  *s += '1';
+-}
+-
+-const char *cu_GetHalfMoveStr(uint8_t idx)
+-{
+-  chm_p chm;
+-  static char buf[7];		/*Ka1-b2*/
+-  char *p = buf;
+-  chm = lrc_obj.chm_list+idx;
+-  
+-  if ( cp_GetPiece(chm->main_cp) != PIECE_NONE )
+-  {
+-    if ( cp_GetPiece(chm->main_cp) > PIECE_PAWN )
+-    {
+-      *p++ = chess_piece_to_char[cp_GetPiece(chm->main_cp)-2];
+-    }
+-    cu_add_pos(p, chm->main_src);
+-    p+=2;
+-    if ( cp_GetPiece(chm->other_cp) == PIECE_NONE )
+-      *p++ = '-';
+-    else
+-      *p++ = 'x';
+-    cu_add_pos(p, chm->main_dest);
+-    p+=2;
+-  }
+-  *p = '\0';
+-  return buf;
+-}
+-
+-
+-
+-
+-
+-/*==============================================================*/
+-/* move */
+-/*==============================================================*/
+-
+-/*
+-  Move a piece from source position to a destination on the board
+-  This function
+-    - does not perform any checking
+-    - however it processes "en passant" and casteling
+-    - backup the move and allow 1x undo
+-  
+-  2011-02-05: 
+-    - fill pawn_dbl_move[] for double pawn moves
+-	--> done
+-    - Implement casteling 
+-	--> done
+-    - en passant
+-	--> done
+-    - pawn conversion/promotion
+-	--> done
+-    - half-move backup 
+-	--> done
+-    - cleanup everything, minimize variables
+-	--> done
+-*/
+-
+-void cu_Move(uint8_t src, uint8_t dest)
+-{  
+-  /* start backup structure */
+-  chm_p chm = cu_PushHalfMove();
+-
+-  /* these are the values from the board at the positions, provided as arguments to this function */
+-  uint8_t cp_src, cp_dest;
+-  
+-  /* Maybe a second position is cleared and one additional location is set */
+-  uint8_t clr_pos2;
+-  uint8_t set_pos2;
+-  uint8_t set_cp2;
+-  
+-  /* get values from board */
+-  cp_src = cp_GetFromBoard(src);
+-  cp_dest = cp_GetFromBoard(dest);
+-
+-  /* fill backup structure */
+-  
+-  chm->main_cp = cp_src;
+-  chm->main_src = src;
+-  chm->main_dest = dest;
+-  
+-  chm->other_cp = cp_dest;		/* prepace capture backup */
+-  chm->other_src = dest;
+-  chm->other_dest = ILLEGAL_POSITION;
+-  
+-  /* setup results as far as possible with some suitable values */
+-  
+-  clr_pos2 = ILLEGAL_POSITION;	/* for en passant and castling, two positions might be cleared */
+-  set_pos2 = ILLEGAL_POSITION;	/* only used for castling */
+-  set_cp2 = PIECE_NONE;			/* ROOK for castling */
+-  
+-  /* check for PAWN */
+-  if ( cp_GetPiece(cp_src) == PIECE_PAWN )
+-  {
+-    
+-    /* double step: is the distance 2 rows */
+-    if ( (src - dest == 32) || ( dest - src == 32 ) )
+-    {
+-      /* remember the destination position */
+-      lrc_obj.pawn_dbl_move[cp_GetColor(cp_src)] = dest;
+-    }
+-    
+-    /* check if the PAWN is able to promote */
+-    else if ( (dest>>4) == 0 || (dest>>4) == 7 )
+-    {
+-      /* do simple "queening" */
+-      cp_src &= ~PIECE_PAWN;
+-      cp_src |= PIECE_QUEEN;
+-    }
+-    
+-    /* is it en passant capture? */
+-    /* check for side move */
+-    else if ( ((src + dest) & 1) != 0 )
+-    {
+-      /* check, if target field is empty */
+-      if (  cp_GetPiece(cp_dest) == PIECE_NONE )
+-      {
+-	/* this is en passant */
+-	/* no further checking required, because legal moves are assumed here */
+-	/* however... the captured pawn position must be valid */
+-	clr_pos2 = lrc_obj.pawn_dbl_move[cp_GetColor(cp_src) ^ 1];
+-	chm->other_src = clr_pos2;
+-	chm->other_cp = cp_GetFromBoard(clr_pos2);
+-      }
+-    }    
+-  }
+-  
+-  /* check for the KING */
+-  else if ( cp_GetPiece(cp_src) == PIECE_KING )
+-  {
+-    /* disallow castling, if the KING has moved */
+-    if ( cp_GetColor(cp_src) == COLOR_WHITE )
+-    {
+-      /* if white KING has moved, disallow castling for white */
+-      lrc_obj.castling_possible &= 0x0c;
+-    }
+-    else
+-    {
+-      /* if black KING has moved, disallow castling for black */
+-      lrc_obj.castling_possible &= 0x03;
+-    }
+-    
+-    /* has it been castling to the left? */
+-    if ( src - dest == 2 )
+-    {
+-      /* let the ROOK move to pos2 */
+-      set_pos2 = src-1;
+-      set_cp2 = cp_GetFromBoard(src-4);
+-      
+-      /* the ROOK must be cleared from the original position */
+-      clr_pos2 = src-4;
+-      
+-      chm->other_cp = set_cp2;
+-      chm->other_src = clr_pos2;
+-      chm->other_dest = set_pos2;
+-    }
+-    
+-    /* has it been castling to the right? */
+-    else if ( dest - src == 2 )
+-    {
+-      /* let the ROOK move to pos2 */
+-      set_pos2 = src+1;
+-      set_cp2 = cp_GetFromBoard(src+3);
+-      
+-      /* the ROOK must be cleared from the original position */
+-      clr_pos2 = src+3;
+-      
+-      chm->other_cp = set_cp2;
+-      chm->other_src = clr_pos2;
+-      chm->other_dest = set_pos2;
+-      
+-    }
+-    
+-  }
+-  
+-  /* check for the ROOK */
+-  else if ( cp_GetPiece(cp_src) == PIECE_ROOK )
+-  {
+-    /* disallow white left castling */
+-    if ( src == 0x00 )
+-      lrc_obj.castling_possible &= ~0x01;
+-    /* disallow white right castling */
+-    if ( src == 0x07 )
+-      lrc_obj.castling_possible &= ~0x02;
+-    /* disallow black left castling */
+-    if ( src == 0x70 )
+-      lrc_obj.castling_possible &= ~0x04;
+-    /* disallow black right castling */
+-    if ( src == 0x77 )
+-      lrc_obj.castling_possible &= ~0x08;
+-  }
+-  
+-  
+-  /* apply new board situation */
+-  
+-  cp_SetOnBoard(dest, cp_src);
+-  
+-  if ( set_pos2 != ILLEGAL_POSITION )
+-    cp_SetOnBoard(set_pos2, set_cp2);
+-  
+-  cp_SetOnBoard(src, PIECE_NONE);
+-  
+-  if ( clr_pos2 != ILLEGAL_POSITION )
+-    cp_SetOnBoard(clr_pos2, PIECE_NONE);
+-  
+-  
+-}
+-
+-/*
+-  this subprocedure decides for evaluation of the current board situation or further (deeper) investigation
+-  Argument pos is the new target position if the current piece 
+-
+-*/
+-uint8_t ce_LoopRecur(uint8_t pos)
+-{
+-  eval_t eval;
+-  
+-  /* 1. check if target position is occupied by the same player (my_color) */
+-  /*     of if pos is somehow illegal or not valid */
+-  if ( cu_IsIllegalPosition(pos, stack_GetCurrElement()->current_color) != 0 )
+-    return 0;
+-
+-  /* 2. move piece to the specified position, capture opponent piece if required */
+-  cu_Move(stack_GetCurrElement()->current_pos, pos);
+-
+-  
+-  /* 3. */
+-  /* if depth reached: evaluate */
+-  /* else: go down next level */
+-  /* no eval if there had been any valid half-moves, so the default value (MIN) will be returned. */
+-  if ( stack_Push(stack_GetCurrElement()->current_color) == 0 )
+-  {
+-    eval = ce_Eval();
+-  }
+-  else
+-  {
+-    /* init the element, which has been pushed */
+-    stack_InitCurrElement();
+-    /* start over with ntext level */
+-    ce_LoopPieces();
+-    /* get the best move from opponents view, so invert the result */
+-    eval = -stack_GetCurrElement()->best_eval;
+-    stack_Pop();
+-  }
+-  
+-  /* 4. store result */
+-  stack_SetMove(eval, pos);
+-  
+-  /* 5. undo the move */
+-  cu_UndoHalfMove();
+-  
+-  /* 6. check special modes */
+-  /* the purpose of these checks is to mark special pieces and positions on the board */
+-  /* these marks can be checked by the user interface to highlight special positions */
+-  if ( lrc_obj.check_mode != 0 )
+-  {
+-    stack_element_p e = stack_GetCurrElement();
+-    if ( lrc_obj.check_mode == CHECK_MODE_MOVEABLE )
+-    {
+-      cp_SetOnBoard(e->current_pos, e->current_cp | CP_MARK_MASK );
+-    }
+-    else if ( lrc_obj.check_mode == CHECK_MODE_TARGET_MOVE )
+-    {
+-      if ( e->current_pos == lrc_obj.check_src_pos )
+-      {
+-	cp_SetOnBoard(pos, cp_GetFromBoard(pos)  | CP_MARK_MASK );
+-      }
+-    }
+-  }
+-  return 1;
+-}
+-
+-/*==============================================================*/
+-/* move pieces which can move one or more steps into a direction */
+-/*==============================================================*/
+-
+-/*
+-  subprocedure to generate various target positions for some pieces
+-  special cases are handled in the piece specific sub-procedure
+-
+-  Arguments:
+-    d: a list of potential directions
+-    is_multi_step: if the piece can only do one step (zero for KING and KNIGHT)
+-*/
+-static const uint8_t ce_dir_offset_rook[] PROGMEM = { 1, 16, -16, -1, 0 };
+-static const uint8_t ce_dir_offset_bishop[] PROGMEM = { 15, 17, -17, -15, 0 };
+-static const uint8_t ce_dir_offset_queen[] PROGMEM = { 1, 16, -16, -1, 15, 17, -17, -15, 0 };
+-static const uint8_t ce_dir_offset_knight[] PROGMEM = {14, -14, 18, -18, 31, -31, 33, -33, 0};
+-
+-void ce_LoopDirsSingleMultiStep(const uint8_t *d, uint8_t is_multi_step)
+-{
+-  uint8_t loop_pos;
+-  
+-  /* with all directions */
+-  for(;;)
+-  {
+-    if ( u8g_pgm_read(d) == 0 )
+-      break;
+-    
+-    /* start again from the initial position */
+-    loop_pos = stack_GetCurrElement()->current_pos;
+-    
+-    /* check direction */
+-    do
+-    {
+-      /* check next position into one direction */
+-      loop_pos += u8g_pgm_read(d);
+-      
+-      /*
+-	go further to ce_LoopRecur()
+-	0 will be returned if the target position is illegal or a piece of the own color
+-	this is used to stop walking into one direction
+-      */
+-      if ( ce_LoopRecur(loop_pos) == 0 )
+-	break;
+-      
+-      /* stop if we had hit another piece */
+-      if ( cp_GetPiece(cp_GetFromBoard(loop_pos)) != PIECE_NONE )
+-	break;
+-    } while( is_multi_step );
+-    d++;
+-  }
+-}
+-
+-void ce_LoopRook(void)
+-{
+-  ce_LoopDirsSingleMultiStep(ce_dir_offset_rook, 1);
+-}
+-
+-void ce_LoopBishop(void)
+-{
+-  ce_LoopDirsSingleMultiStep(ce_dir_offset_bishop, 1);
+-}
+-
+-void ce_LoopQueen(void)
+-{
+-  ce_LoopDirsSingleMultiStep(ce_dir_offset_queen, 1);
+-}
+-
+-void ce_LoopKnight(void)
+-{
+-  ce_LoopDirsSingleMultiStep(ce_dir_offset_knight, 0);
+-}
+-
+-
+-
+-/*==============================================================*/
+-/* move king */
+-/*==============================================================*/
+-
+-uint8_t cu_IsKingCastling(uint8_t mask, int8_t direction, uint8_t cnt) U8G_NOINLINE;
+-
+-/*
+-  checks, if the king can do castling
+-
+-  Arguments:
+-    mask:		the bit-mask for the global "castling possible" flag
+-    direction:	left castling: -1, right castling 1
+-    cnt:		number of fields to be checked: 3 or 2
+-*/
+-uint8_t cu_IsKingCastling(uint8_t mask, int8_t direction, uint8_t cnt)
+-{
+-  uint8_t pos;
+-  uint8_t opponent_color;
+-  
+-  /* check if the current board state allows castling */
+-  if ( (lrc_obj.castling_possible & mask) == 0 )
+-    return 0; 	/* castling not allowed */
+-  
+-  /* get the position of the KING, could be white or black king */
+-  pos = stack_GetCurrElement()->current_pos;
+-  
+-  /* calculate the color of the opponent */
+-  opponent_color = 1;
+-  opponent_color -= stack_GetCurrElement()->current_color;
+-  
+-  /* if the KING itself is given check... */
+-  if ( ce_GetPositionAttackWeight(pos, opponent_color) > 0 )
+-    return 0;
+-
+-  
+-  /* check if fields in the desired direction are emtpy */
+-  for(;;)
+-  {
+-    /* go to the next field */
+-    pos += direction;
+-    /* check for a piece */
+-    if ( cp_GetPiece(cp_GetFromBoard(pos)) != PIECE_NONE )
+-      return 0;		/* castling not allowed */
+-
+-    /* if some of the fields are under attack */
+-    if ( ce_GetPositionAttackWeight(pos, opponent_color) > 0 )
+-      return 0;
+-    
+-    cnt--;
+-    if ( cnt == 0 )
+-      break;
+-  }
+-  return 1; /* castling allowed */
+-}
+-
+-void ce_LoopKing(void)
+-{
+-  /*
+-    there is an interessting timing problem in this procedure
+-    it must be checked for castling first and as second step the normal
+-    KING movement. If we would first check for normal moves, than
+-    any marks might be overwritten by the ROOK in the case of castling.
+-  */
+-  
+-  /* castling (this must be done before checking normal moves (see above) */
+-  if ( stack_GetCurrElement()->current_color == COLOR_WHITE )
+-  {
+-    /* white left castling */
+-    if ( cu_IsKingCastling(1, -1, 3) != 0 )
+-    {
+-      /* check for attacked fields */
+-      ce_LoopRecur(stack_GetCurrElement()->current_pos-2);
+-    }
+-    /* white right castling */
+-    if ( cu_IsKingCastling(2, 1, 2) != 0 )
+-    {
+-      /* check for attacked fields */
+-      ce_LoopRecur(stack_GetCurrElement()->current_pos+2);
+-    }
+-  }
+-  else
+-  {
+-    /* black left castling */
+-    if ( cu_IsKingCastling(4, -1, 3) != 0 )
+-    {
+-      /* check for attacked fields */
+-      ce_LoopRecur(stack_GetCurrElement()->current_pos-2);
+-    }
+-    /* black right castling */
+-    if ( cu_IsKingCastling(8, 1, 2) != 0 )
+-    {
+-      /* check for attacked fields */
+-      ce_LoopRecur(stack_GetCurrElement()->current_pos+2);
+-    }
+-  }
+-  
+-  /* reuse queen directions */
+-  ce_LoopDirsSingleMultiStep(ce_dir_offset_queen, 0);
+-}
+-
+-
+-/*==============================================================*/
+-/* move pawn */
+-/*==============================================================*/
+-
+-/*
+-  doppelschritt: nur von der grundlinie aus, beide (!) felder vor dem bauern müssen frei sein
+-  en passant: nur unmittelbar nachdem ein doppelschritt ausgeführt wurde.
+-*/
+-void ce_LoopPawnSideCapture(uint8_t loop_pos)
+-{
+-  if ( gpos_IsIllegal(loop_pos) == 0 )
+-  {
+-    /* get the piece from the board */
+-    /* if the field is NOT empty */
+-    if ( cp_GetPiece(cp_GetFromBoard(loop_pos)) != PIECE_NONE )
+-    {
+-      /* normal capture */
+-      ce_LoopRecur(loop_pos);
+-      /* TODO: check for pawn conversion/promotion */
+-    }
+-    else
+-    {
+-      /* check conditions for en passant capture */
+-      if ( stack_GetCurrElement()->current_color == COLOR_WHITE )
+-      {
+-	if ( lrc_obj.pawn_dbl_move[COLOR_BLACK]+16 == loop_pos )
+-	{
+-	  ce_LoopRecur(loop_pos);
+-	  /* note: pawn conversion/promotion can not occur */
+-	}
+-      }
+-      else
+-      {
+-	if ( lrc_obj.pawn_dbl_move[COLOR_WHITE] == loop_pos+16 )
+-	{
+-	  ce_LoopRecur(loop_pos);
+-	  /* note: pawn conversion/promotion can not occur */
+-	}
+-      }
+-    }
+-  }
+-}
+-
+-void ce_LoopPawn(void)
+-{
+-  uint8_t initial_pos = stack_GetCurrElement()->current_pos; 
+-  uint8_t my_color = stack_GetCurrElement()->current_color;
+-  
+-  uint8_t loop_pos;
+-  uint8_t line;
+-  
+-  /* one step forward */
+-  
+-  loop_pos = initial_pos;
+-  line = initial_pos;
+-  line >>= 4;
+-  if ( my_color == COLOR_WHITE )
+-    loop_pos += 16;
+-  else
+-    loop_pos -= 16;
+-  if ( gpos_IsIllegal(loop_pos) == 0 )
+-  {
+-    /* if the field is empty */
+-    if ( cp_GetPiece(cp_GetFromBoard(loop_pos)) == PIECE_NONE )
+-    {
+-      /* TODO: check for and loop through piece conversion/promotion */
+-      ce_LoopRecur(loop_pos);      
+-
+-      /* second step forward */
+-      
+-      /* if pawn is on his starting line */
+-      if ( (my_color == COLOR_WHITE && line == 1) || (my_color == COLOR_BLACK && line == 6 ) )
+-      {
+-	/* the place before the pawn is not occupied, so we can do double moves, see above */
+-	
+-	if ( my_color == COLOR_WHITE )
+-	  loop_pos += 16;
+-	else
+-	  loop_pos -= 16;
+-	if ( cp_GetPiece(cp_GetFromBoard(loop_pos)) == PIECE_NONE )
+-	{
+-	  /* this is a special case, other promotions of the pawn can not occur */
+-	  ce_LoopRecur(loop_pos);
+-	}
+-      }
+-    }
+-  }
+-
+-  /* capture */
+-  
+-  loop_pos = initial_pos;
+-  if ( my_color == COLOR_WHITE )
+-    loop_pos += 15;
+-  else
+-    loop_pos -= 15;
+-  ce_LoopPawnSideCapture(loop_pos);
+-
+-
+-  loop_pos = initial_pos;
+-  if ( my_color == COLOR_WHITE )
+-    loop_pos += 17;
+-  else
+-    loop_pos -= 17;
+-  ce_LoopPawnSideCapture(loop_pos);
+-}
+-
+-/*==============================================================*/
+-/* attacked */
+-/*==============================================================*/
+-
+-/*
+-  from a starting position, search for a piece, that might jump to that postion.
+-  return:
+-    the two global variables
+-      lrc_obj.find_piece_weight[0];
+-      lrc_obj.find_piece_weight[1];
+-  will be increased by the weight of the attacked pieces of that color.
+-  it is usually required to reset these global variables to zero, before using
+-  this function.
+-*/
+-
+-void ce_FindPieceByStep(uint8_t start_pos, uint8_t piece, const uint8_t *d, uint8_t is_multi_step)
+-{
+-  uint8_t loop_pos, cp;
+-  
+-  /* with all directions */
+-  for(;;)
+-  {
+-    if ( u8g_pgm_read(d) == 0 )
+-      break;
+-    
+-    /* start again from the initial position */
+-    loop_pos = start_pos;
+-    
+-    /* check direction */
+-    do
+-    {
+-      /* check next position into one direction */
+-      loop_pos += u8g_pgm_read(d);
+-      
+-      /* check if the board boundary has been crossed */
+-      if ( (loop_pos & 0x088) != 0 )
+-	break;
+-      
+-      /* get the colored piece from the board */
+-      cp = cp_GetFromBoard(loop_pos);
+-      
+-      /* stop if we had hit another piece */
+-      if ( cp_GetPiece(cp) != PIECE_NONE )
+-      {
+-	/* if it is the piece we are looking for, then add the weight */
+-	if ( cp_GetPiece(cp) == piece )
+-	{
+-	  lrc_obj.find_piece_weight[cp_GetColor(cp)] += ce_piece_weight[piece];
+-	  lrc_obj.find_piece_cnt[cp_GetColor(cp)]++;
+-	}
+-	/* in any case, break out of the inner loop */
+-	break;
+-      }
+-    } while( is_multi_step );
+-    d++;
+-  }
+-}
+-
+-void ce_FindPawnPiece(uint8_t dest_pos, uint8_t color)
+-{
+-  uint8_t cp;
+-  /* check if the board boundary has been crossed */
+-  if ( (dest_pos & 0x088) == 0 )
+-  {
+-    /* get the colored piece from the board */
+-    cp = cp_GetFromBoard(dest_pos);
+-    /* only if there is a pawn of the matching color */
+-    if ( cp_GetPiece(cp) == PIECE_PAWN )
+-    {
+-      if ( cp_GetColor(cp) == color )
+-      {
+-	/* the weight of the PAWN */
+-	lrc_obj.find_piece_weight[color] += 1;
+-	lrc_obj.find_piece_cnt[color]++;
+-      }
+-    }
+-  }
+-}
+-
+-
+-/*
+-  find out, which pieces do attack a specified field
+-  used to
+-  - check if the KING can do castling
+-  - check if the KING must move
+-
+-  may be used in the eval procedure ... once...
+-
+-  the result is stored in the global array
+-    uint8_t lrc_obj.find_piece_weight[2];
+-  which is indexed with the color.
+-  lrc_obj.find_piece_weight[COLOR_WHITE] is the sum of all white pieces
+-  which can directly move to this field.
+-
+-  example:
+-    if the black KING is at "pos" and lrc_obj.find_piece_weight[COLOR_WHITE] is not zero 
+-    (after executing ce_CalculatePositionWeight(pos)) then the KING must be protected or moveed, because 
+-    the KING was given check.
+-*/
+-
+-void ce_CalculatePositionWeight(uint8_t pos)
+-{
+-  
+-  lrc_obj.find_piece_weight[0] = 0;
+-  lrc_obj.find_piece_weight[1] = 0;
+-  lrc_obj.find_piece_cnt[0] = 0;
+-  lrc_obj.find_piece_cnt[1] = 0;
+-  
+-  if ( (pos & 0x088) != 0 )
+-    return;
+-
+-  ce_FindPieceByStep(pos, PIECE_ROOK, ce_dir_offset_rook, 1);
+-  ce_FindPieceByStep(pos, PIECE_BISHOP, ce_dir_offset_bishop, 1);
+-  ce_FindPieceByStep(pos, PIECE_QUEEN, ce_dir_offset_queen, 1);
+-  ce_FindPieceByStep(pos, PIECE_KNIGHT, ce_dir_offset_knight, 0);
+-  ce_FindPieceByStep(pos, PIECE_KING, ce_dir_offset_queen, 0);
+-
+-  ce_FindPawnPiece(pos+17, COLOR_BLACK);
+-  ce_FindPawnPiece(pos+15, COLOR_BLACK);
+-  ce_FindPawnPiece(pos-17, COLOR_WHITE);
+-  ce_FindPawnPiece(pos-15, COLOR_WHITE);
+-}
+-
+-/*
+-  calculate the summed weight of pieces with specified color which can move to a specified position
+-
+-  argument:
+-    pos: 	the position which should be analysed
+-    color: 	the color of those pieces which should be analysed
+-		e.g. if a black piece is at 'pos' and 'color' is white then this procedure returns the white atting count
+-*/
+-uint8_t ce_GetPositionAttackWeight(uint8_t pos, uint8_t color)
+-{
+-  ce_CalculatePositionWeight(pos);
+-  return lrc_obj.find_piece_weight[color];
+-}
+-
+-uint8_t ce_GetPositionAttackCount(uint8_t pos, uint8_t color)
+-{
+-  ce_CalculatePositionWeight(pos);
+-  return lrc_obj.find_piece_cnt[color];
+-}
+-
+-
+-/*==============================================================*/
+-/* depth search starts here: loop over all pieces of the current color on the board */
+-/*==============================================================*/
+-
+-void ce_LoopPieces(void)
+-{
+-  stack_element_p e = stack_GetCurrElement();
+-  /* start with lower left position (A1) */
+-  e->current_pos = 0;
+-  do
+-  {
+-    e->current_cp = cp_GetFromBoard(e->current_pos);
+-    /* check if the position on the board is empty */
+-    if ( e->current_cp != 0 )
+-    {
+-      /* only generate moves for the current color */
+-      if ( e->current_color == cp_GetColor(e->current_cp) )
+-      {
+-	chess_Thinking();
+-	
+-	/* find out which piece is used */
+-	switch(cp_GetPiece(e->current_cp))
+-	{
+-	  case PIECE_NONE:
+-	    break;
+-	  case PIECE_PAWN:
+-	    ce_LoopPawn();
+-	    break;
+-	  case PIECE_KNIGHT:
+-	    ce_LoopKnight();
+-	    break;
+-	  case PIECE_BISHOP:
+-	    ce_LoopBishop();
+-	    break;
+-	  case PIECE_ROOK:
+-	    ce_LoopRook();
+-	    break;
+-	  case PIECE_QUEEN:
+-	    ce_LoopQueen();
+-	    break;
+-	  case PIECE_KING:
+-	    ce_LoopKing();
+-	    break;
+-	}
+-      }
+-    }    
+-    e->current_pos = cu_NextPos(e->current_pos);
+-  } while( e->current_pos != 0 );
+-}
+-
+-/*==============================================================*/
+-/* user interface */
+-/*==============================================================*/
+-
+-/*
+-eval_t chess_EvalCurrBoard(uint8_t color)
+-{
+-  stack_Init(0);
+-  stack_GetCurrElement()->current_color = color;
+-  ce_LoopPieces();
+-  return stack_GetCurrElement()->best_eval;
+-}
+-*/
+-
+-/* clear any marks on the board */
+-void chess_ClearMarks(void)
+-{
+-  uint8_t i;
+-  for( i = 0; i < 64; i++ )
+-     lrc_obj.board[i] &= ~CP_MARK_MASK;
+-}
+-
+-/*
+-  Mark all pieces which can do moves. This is done by setting flags on the global board
+-*/
+-void chess_MarkMovable(void)
+-{
+-  stack_Init(0);
+-  //stack_GetCurrElement()->current_color = color;
+-  lrc_obj.check_mode = CHECK_MODE_MOVEABLE;
+-  ce_LoopPieces();
+-}
+-
+-/*
+-  Checks, if the piece can move from src_pos to dest_pos
+-
+-  src_pos: The game position of a piece on the chess board
+-*/
+-void chess_MarkTargetMoves(uint8_t src_pos)
+-{
+-  stack_Init(0);
+-  stack_GetCurrElement()->current_color = cp_GetColor(cp_GetFromBoard(src_pos));
+-  lrc_obj.check_src_pos = src_pos;
+-  lrc_obj.check_mode = CHECK_MODE_TARGET_MOVE;  
+-  ce_LoopPieces();
+-}
+-
+-/*
+-  first call should start with 255
+-  this procedure will return 255 if 
+-      - there are no marks at all
+-      - it has looped over all marks once
+-*/
+-uint8_t chess_GetNextMarked(uint8_t arg, uint8_t is_prev)
+-{
+-  uint8_t i;
+-  uint8_t pos = arg;
+-  for(i = 0; i < 64; i++)
+-  {
+-    if ( is_prev != 0 )
+-      pos = cu_PrevPos(pos);
+-    else
+-      pos = cu_NextPos(pos);
+-    if ( arg != 255 && pos == 0 )
+-      return 255;
+-    if ( cp_IsMarked(cp_GetFromBoard(pos)) )
+-      return pos;
+-  }
+-  return 255;
+-}
+-
+-
+-/* make a manual move: this is a little bit more than cu_Move() */
+-void chess_ManualMove(uint8_t src, uint8_t dest)
+-{
+-  uint8_t cp;
+-  
+-  /* printf("chess_ManualMove %02x -> %02x\n", src, dest); */
+-  
+-  /* if all other things fail, this is the place where the game is to be decided: */
+-  /* ... if the KING is captured */
+-  cp = cp_GetFromBoard(dest);
+-  if ( cp_GetPiece(cp) == PIECE_KING )
+-  {
+-    lrc_obj.is_game_end = 1;
+-    lrc_obj.lost_side_color = cp_GetColor(cp);    
+-  }
+-
+-  /* clear ply history here, to avoid memory overflow */
+-  /* may be the last X moves can be kept here */
+-  cu_ReduceHistoryByFullMove();
+-  /* perform the move on the board */
+-  cu_Move(src, dest);
+-  
+-  /* update en passant double move positions: en passant position is removed after two half moves  */
+-  lrc_obj.pawn_dbl_move[lrc_obj.ply_count&1]  = ILLEGAL_POSITION;
+-  
+-  /* update the global half move counter */
+-  lrc_obj.ply_count++;
+-
+-
+-  /* make a small check about the end of the game */
+-  /* use at least depth 1, because we must know if the king can still move */
+-  /* this is: King moves at level 0 and will be captured at level 1 */
+-  /* so we check if the king can move and will not be captured at search level 1 */
+-  
+-  stack_Init(1);
+-  ce_LoopPieces(); 
+-
+-  /* printf("chess_ManualMove/analysis best_from_pos %02x -> best_to_pos %02x\n", stack_GetCurrElement()->best_from_pos, stack_GetCurrElement()->best_to_pos); */
+-
+-  /* analyse the eval result */
+-  
+-  /* check if the other player has any moves left */
+-  if ( stack_GetCurrElement()->best_from_pos == ILLEGAL_POSITION )
+-  {
+-    uint8_t color;
+-    /* conditions: */
+-    /* 1. no King, should never happen, opposite color has won */
+-    /*		this is already checked above at the beginning if this procedure */
+-    /* 2. King is under attack, opposite color has won */
+-    /* 3. King is not under attack, game is a draw */
+-
+-    uint8_t i = 0;
+-    color = lrc_obj.ply_count;
+-    color &= 1;
+-    do
+-    {
+-      cp = cp_GetFromBoard(i);
+-      /* look for the King */
+-      if ( cp_GetPiece(cp) == PIECE_KING )
+-      {
+-	if ( cp_GetColor(cp) == color )
+-	{
+-	  /* check if  KING is attacked */
+-	  if ( ce_GetPositionAttackCount(i, color^1) != 0 )
+-	  {
+-	    /* KING is under attack (check) and can not move: Game is lost */
+-	    lrc_obj.is_game_end = 1;
+-	    lrc_obj.lost_side_color = color; 
+-	  }
+-	  else
+-	  {
+-	    /* KING is NOT under attack (check) but can not move: Game is a draw */
+-	    lrc_obj.is_game_end = 1;
+-	    lrc_obj.lost_side_color = 2; 
+-	  }
+-	  /* break out of the loop */
+-	  break;	  
+-	}
+-      }
+-      i = cu_NextPos(i);
+-    } while( i != 0 );
+-  }
+-}
+-
+-/* let the computer do a move */
+-void chess_ComputerMove(uint8_t depth)
+-{
+-  stack_Init(depth);
+-  
+-  //stack_GetCurrElement()->current_color = lrc_obj.ply_count;
+-  //stack_GetCurrElement()->current_color &= 1;
+-  
+-  cu_ReduceHistoryByFullMove();
+-  ce_LoopPieces();
+-
+-  chess_ManualMove(stack_GetCurrElement()->best_from_pos, stack_GetCurrElement()->best_to_pos);
+-}
+-
+-
+-/*==============================================================*/
+-/* unix code */
+-/*==============================================================*/
+-
+-#ifdef UNIX_MAIN
+-
+-#include <stdio.h>
+-#include <string.h>
+-
+-char *piece_str[] = {
+-  /* 0x00 */
+-  "  ", 
+-  "wP", 
+-  "wN", 
+-  "wB", 
+-  
+-  /* 0x04 */
+-  "wR", 
+-  "wQ", 
+-  "wK", 
+-  "w?", 
+-
+-  /* 0x08 */
+-  "w?", 
+-  "w?", 
+-  "w?", 
+-  "w?", 
+-  
+-  /* 0x0c */
+-  "w?", 
+-  "w?", 
+-  "w?", 
+-  "w?", 
+-
+-  /* 0x10 */
+-  "b ",
+-  "bP", 
+-  "bN", 
+-  "bB", 
+-  "bR", 
+-  "bQ", 
+-  "bK", 
+-  "b?", 
+-
+-  "b?", 
+-  "b?", 
+-  "b?", 
+-  "b?", 
+-  "b?", 
+-  "b?", 
+-  "b?", 
+-  "b?"
+-};
+-
+-void chess_Thinking(void)
+-{
+-  uint8_t i;
+-  uint8_t cp = cp_GetPiece(stack_GetCurrElement()->current_cp);
+-  
+-  printf("Thinking:  ", piece_str[cp], stack_GetCurrElement()->current_pos);
+-  
+-  for( i = 0; i <= lrc_obj.curr_depth; i++ )
+-    printf("%s ", piece_str[(lrc_obj.stack_memory+i)->current_cp]);
+-  
+-  printf("    \r");
+-}
+-
+-void board_Show(void)
+-{
+-  uint8_t i, j, cp;
+-  char buf[10];
+-  for ( i = 0; i < 8; i++ )
+-  {
+-    printf("%1d ", 7-i);
+-    for ( j = 0; j < 8; j++ )
+-    {
+-      /* get piece from global board */
+-      cp = lrc_obj.board[(7-i)*8+j];
+-      strcpy(buf, piece_str[cp&COLOR_PIECE_MASK]);
+-      
+-      if ( (cp & CP_MARK_MASK) != 0 )
+-      {
+-	buf[0] = '#';
+-      }
+-      
+-      /* mask out any bits except color and piece index */
+-      cp &= COLOR_PIECE_MASK;
+-      printf("%s %02x ", buf, cp);
+-      
+-    }
+-    printf("\n");
+-  }
+-}
+-
+-int main(void)
+-{
+-  uint8_t depth = 3;
+-  chess_SetupBoard();
+-  board_Show();
+-  puts("");
+-    
+- 
+- /* 
+-  chess_ClearMarks();
+-  chess_MarkMovable(COLOR_WHITE);
+-  board_Show();
+-  */
+-  
+-  chess_ManualMove(0x006, 0x066);
+-  
+-  printf("lrc_obj.is_game_end: %d\n" , lrc_obj.is_game_end);
+-  printf("lrc_obj.lost_side_color: %d\n" , lrc_obj.lost_side_color);
+-
+-  chess_ComputerMove(2);
+-
+-  printf("lrc_obj.is_game_end: %d\n" , lrc_obj.is_game_end);
+-  printf("lrc_obj.lost_side_color: %d\n" , lrc_obj.lost_side_color);
+-  
+-  board_Show();
+-
+-}
+-
+-
+-
+-#else
+-
+-/*==============================================================*/
+-/* display menu */
+-/*==============================================================*/
+-
+-//#define MNU_FONT font_5x7
+-#define MNU_FONT u8g_font_5x8r
+-//#define MNU_FONT font_6x9
+-#define MNU_ENTRY_HEIGHT 9
+-
+-char *mnu_title = "Little Rook Chess";
+-char *mnu_list[] = { "New Game (White)", "New Game (Black)", "Undo Move", "Return" };
+-uint8_t mnu_pos = 0;
+-uint8_t mnu_max = 4;
+-
+-void mnu_DrawHome(uint8_t is_highlight)
+-{
+-  uint8_t x = lrc_u8g->width - 35;  
+-  uint8_t y = (lrc_u8g->height-1);
+-  uint8_t t;
+-  
+-  u8g_SetFont(lrc_u8g, u8g_font_5x7r);
+-  u8g_SetDefaultForegroundColor(lrc_u8g);
+-  t = u8g_DrawStrP(lrc_u8g, x, y -1, U8G_PSTR("Options"));
+-    
+-  if ( is_highlight )
+-    u8g_DrawFrame(lrc_u8g, x-1, y - MNU_ENTRY_HEIGHT +1, t, MNU_ENTRY_HEIGHT);  
+-}
+-
+-void mnu_DrawEntry(uint8_t y, char *str, uint8_t is_clr_background, uint8_t is_highlight)
+-{
+-  uint8_t t, x;
+-  u8g_SetFont(lrc_u8g, MNU_FONT);
+-  t = u8g_GetStrWidth(lrc_u8g, str);
+-  x = u8g_GetWidth(lrc_u8g);
+-  x -= t;
+-  x >>= 1;
+-  
+-  if ( is_clr_background )
+-  {
+-    u8g_SetDefaultBackgroundColor(lrc_u8g);
+-    u8g_DrawBox(lrc_u8g, x-3, (lrc_u8g->height-1) - (y+MNU_ENTRY_HEIGHT-1+2), t+5, MNU_ENTRY_HEIGHT+4);
+-  }
+-  
+-  u8g_SetDefaultForegroundColor(lrc_u8g);
+-  u8g_DrawStr(lrc_u8g, x, (lrc_u8g->height-1) - y, str);
+-  
+-  if ( is_highlight )
+-  {
+-    u8g_DrawFrame(lrc_u8g, x-1, (lrc_u8g->height-1) - y -MNU_ENTRY_HEIGHT +1, t, MNU_ENTRY_HEIGHT);
+-  }
+-}
+-
+-void mnu_Draw(void)
+-{
+-  uint8_t i;
+-  uint8_t t,y;
+-  /* calculate hight of the complete menu */
+-  y = mnu_max;
+-  y++; 					/* consider also some space for the title */
+-  y++; 					/* consider also some space for the title */
+-  y *= MNU_ENTRY_HEIGHT;
+-  
+-  /* calculate how much space will be left */
+-  t = u8g_GetHeight(lrc_u8g);			
+-  t -= y;
+-  
+-  /* topmost pos start half of that empty space from the top */
+-  t >>= 1;
+-  y = u8g_GetHeight(lrc_u8g);
+-  y -= t;
+-  
+-  y -= MNU_ENTRY_HEIGHT;
+-  mnu_DrawEntry(y, mnu_title, 0, 0);
+-  
+-  y -= MNU_ENTRY_HEIGHT;
+-  
+-  
+-  for( i = 0; i < mnu_max; i++ )
+-  {
+-    y -= MNU_ENTRY_HEIGHT;
+-    mnu_DrawEntry(y, mnu_list[i], 0, i == mnu_pos);
+-  }
+-}
+-
+-void mnu_Step(uint8_t key_cmd)
+-{
+-    if ( key_cmd == CHESS_KEY_NEXT )
+-    {
+-      if ( mnu_pos+1 < mnu_max )
+-	mnu_pos++;
+-    }
+-    else if ( key_cmd == CHESS_KEY_PREV )
+-    {
+-      if ( mnu_pos > 0 )
+-	mnu_pos--;
+-    }
+-}
+-
+-
+-
+-
+-uint8_t chess_key_code = 0;
+-uint8_t chess_key_cmd = 0;
+-#define CHESS_STATE_MENU 0
+-#define CHESS_STATE_SELECT_START 1
+-#define CHESS_STATE_SELECT_PIECE 2
+-#define CHESS_STATE_SELECT_TARGET_POS 3
+-#define CHESS_STATE_THINKING 4
+-#define CHESS_STATE_GAME_END 5
+-uint8_t chess_state = CHESS_STATE_MENU;
+-uint8_t chess_source_pos = 255;
+-uint8_t chess_target_pos = 255;
+-
+-const uint8_t chess_pieces_body_bm[] PROGMEM = 
+-{
+-  /* PAWN */ 		0x00, 0x00, 0x00, 0x18, 0x18, 0x00, 0x00, 0x00, /* 0x00, 0x00, 0x00, 0x0c, 0x0c, 0x00, 0x00, 0x00, */ 
+-  /* KNIGHT */		0x00, 0x00, 0x1c, 0x2c, 0x04, 0x04, 0x0e, 0x00,
+-  /* BISHOP */		0x00, 0x00, 0x1c, 0x1c, 0x1c, 0x08, 0x00, 0x00, /* 0x00, 0x00, 0x08, 0x1c, 0x1c, 0x08, 0x00, 0x00, */
+-  /* ROOK */		0x00, 0x00, 0x00, 0x1c, 0x1c, 0x1c, 0x1c, 0x00,
+-  /* QUEEN */		0x00, 0x00, 0x14, 0x1c, 0x08, 0x1c, 0x08, 0x00,
+-  /* KING */		0x00, 0x00, 0x00, 0x08, 0x3e, 0x1c, 0x08, 0x00,
+-};
+-
+-#ifdef NOT_REQUIRED
+-/* white pieces are constructed by painting black pieces and cutting out the white area */
+-const uint8_t chess_white_pieces_bm[] PROGMEM = 
+-{
+-  /* PAWN */ 		0x00, 0x00, 0x0c, 0x12, 0x12, 0x0c, 0x1e, 0x00, 
+-  /* KNIGHT */		0x00, 0x1c, 0x22, 0x52, 0x6a, 0x0a, 0x11, 0x1f,
+-  /* BISHOP */		0x00, 0x08, 0x14, 0x22, 0x22, 0x14, 0x08, 0x7f,
+-  /* ROOK */		0x00, 0x55, 0x7f, 0x22, 0x22, 0x22, 0x22, 0x7f,
+-  /* QUEEN */		0x00, 0x55, 0x2a, 0x22, 0x14, 0x22, 0x14, 0x7f,
+-  /* KING */		0x08, 0x1c, 0x49, 0x77, 0x41, 0x22, 0x14, 0x7f,
+-};
+-#endif
+-
+-const uint8_t chess_black_pieces_bm[] PROGMEM = 
+-{
+-  /* PAWN */ 		0x00, 0x00, 0x18, 0x3c, 0x3c, 0x18, 0x3c, 0x00, /* 0x00, 0x00, 0x0c, 0x1e, 0x1e, 0x0c, 0x1e, 0x00, */ 
+-  /* KNIGHT */		0x00, 0x1c, 0x3e, 0x7e, 0x6e, 0x0e, 0x1f, 0x1f,
+-  /* BISHOP */		0x00, 0x1c, 0x2e, 0x3e, 0x3e, 0x1c, 0x08, 0x7f,  /*0x00, 0x08, 0x1c, 0x3e, 0x3e, 0x1c, 0x08, 0x7f,*/
+-  /* ROOK */		0x00, 0x55, 0x7f, 0x3e, 0x3e, 0x3e, 0x3e, 0x7f,
+-  /* QUEEN */		0x00, 0x55, 0x3e, 0x3e, 0x1c, 0x3e, 0x1c, 0x7f,
+-  /* KING -*/		0x08, 0x1c, 0x49, 0x7f, 0x7f, 0x3e, 0x1c, 0x7f,
+-};
+-
+-
+-#if defined(DOGXL160_HW_GR)
+-#define BOXSIZE 13
+-#define BOXOFFSET 3
+-#else
+-#define BOXSIZE 8
+-#define BOXOFFSET 1
+-#endif
+-
+-u8g_uint_t chess_low_edge;
+-uint8_t chess_boxsize = 8;
+-uint8_t chess_boxoffset = 1;
+-
+-
+-void chess_DrawFrame(uint8_t pos, uint8_t is_bold)
+-{
+-  u8g_uint_t x0, y0;
+-
+-  x0 = pos;
+-  x0 &= 15;
+-  if ( lrc_obj.orientation != COLOR_WHITE )
+-    x0 ^= 7;
+-
+-  y0 = pos;
+-  y0>>= 4;
+-  if ( lrc_obj.orientation != COLOR_WHITE )
+-    y0 ^= 7;
+-  
+-  x0 *= chess_boxsize;
+-  y0 *= chess_boxsize;
+-  
+-  u8g_SetDefaultForegroundColor(lrc_u8g);
+-  u8g_DrawFrame(lrc_u8g, x0, chess_low_edge - y0 - chess_boxsize+1, chess_boxsize, chess_boxsize);
+-  
+-  
+-  if ( is_bold )
+-  {
+-      x0--;
+-      y0++;
+-  
+-    u8g_DrawFrame(lrc_u8g, x0, chess_low_edge - y0 - chess_boxsize +1, chess_boxsize+2, chess_boxsize+2);
+-  }
+-}
+-
+-
+-void chess_DrawBoard(void)
+-{
+-  uint8_t i, j, cp;
+-  const uint8_t *ptr;  /* pointer into PROGMEM */
+-  
+-  if ( U8G_MODE_GET_BITS_PER_PIXEL(u8g_GetMode(lrc_u8g)) > 1 )
+-  {
+-    for( i = 0; i < 8; i++ )
+-      for( j = 0; j < 8; j++ )
+-      {
+-        uint8_t x,y;
+-        x = i;
+-        x*=chess_boxsize;
+-        y = j;
+-        y*=chess_boxsize;
+-        if ( ((i^j) & 1)  == 0 )
+-          u8g_SetDefaultMidColor(lrc_u8g);  
+-        else
+-          u8g_SetDefaultBackgroundColor(lrc_u8g);  
+-        u8g_DrawBox(lrc_u8g, x,chess_low_edge-y-chess_boxsize+1,chess_boxsize,chess_boxsize);
+-      }
+-    //u8g_SetDefaultForegroundColor(lrc_u8g);  
+-  }
+-  else
+-  {
+-    uint8_t x_offset = 1;
+-    u8g_SetDefaultForegroundColor(lrc_u8g);  
+-    for( i = 0; i < 8*8; i+=8 )
+-    {
+-      for( j = 0; j < 8*8; j+=8 )
+-      {
+-        if ( ((i^j) & 8)  == 0 )
+-        {
+-          u8g_DrawPixel(lrc_u8g, j+0+x_offset, chess_low_edge - i-0);
+-          u8g_DrawPixel(lrc_u8g, j+0+x_offset, chess_low_edge - i-2);
+-          u8g_DrawPixel(lrc_u8g, j+0+x_offset, chess_low_edge - i-4);
+-          u8g_DrawPixel(lrc_u8g, j+0+x_offset, chess_low_edge - i-6);
+-          u8g_DrawPixel(lrc_u8g, j+2+x_offset, chess_low_edge - i-0);
+-          u8g_DrawPixel(lrc_u8g, j+2+x_offset, chess_low_edge - i-6);
+-          u8g_DrawPixel(lrc_u8g, j+4+x_offset, chess_low_edge - i-0);
+-          u8g_DrawPixel(lrc_u8g, j+4+x_offset, chess_low_edge - i-6);
+-          u8g_DrawPixel(lrc_u8g, j+6+x_offset, chess_low_edge - i-0);
+-          u8g_DrawPixel(lrc_u8g, j+6+x_offset, chess_low_edge - i-2);
+-          u8g_DrawPixel(lrc_u8g, j+6+x_offset, chess_low_edge - i-4);
+-          u8g_DrawPixel(lrc_u8g, j+6+x_offset, chess_low_edge - i-6);
+-        }
+-      }
+-    }
+-  }
+-  
+-  for ( i = 0; i < 8; i++ )
+-  {
+-    for ( j = 0; j < 8; j++ )
+-    {
+-      /* get piece from global board */
+-      if ( lrc_obj.orientation == COLOR_WHITE )
+-      {
+-	cp =  lrc_obj.board[i*8+j];
+-      }
+-      else
+-      {
+-	cp =  lrc_obj.board[(7-i)*8+7-j];
+-      }
+-      if ( cp_GetPiece(cp) != PIECE_NONE )
+-      {
+-	ptr = chess_black_pieces_bm;
+-	ptr += (cp_GetPiece(cp)-1)*8;
+-        u8g_SetDefaultForegroundColor(lrc_u8g);
+-        u8g_DrawBitmapP(lrc_u8g, j*chess_boxsize+chess_boxoffset-1, chess_low_edge - (i*chess_boxsize+chess_boxsize-chess_boxoffset), 1, 8, ptr);
+-        
+-	if ( cp_GetColor(cp) == lrc_obj.strike_out_color ) 
+-	{
+-	  ptr = chess_pieces_body_bm;
+-	  ptr += (cp_GetPiece(cp)-1)*8;
+-          u8g_SetDefaultBackgroundColor(lrc_u8g);
+-          u8g_DrawBitmapP(lrc_u8g, j*chess_boxsize+chess_boxoffset-1, chess_low_edge - (i*chess_boxsize+chess_boxsize-chess_boxoffset), 1, 8, ptr);
+-	}
+-      }
+-    }
+-  }
+-  
+-  if ( (chess_source_pos & 0x88) == 0 )
+-  {
+-    chess_DrawFrame(chess_source_pos, 1);
+-  }
+-
+-  if ( (chess_target_pos & 0x88) == 0 )
+-  {
+-    chess_DrawFrame(chess_target_pos, 0);
+-  }
+-  
+-}
+-
+-
+-void chess_Thinking(void)
+-{
+-}
+-
+-void chess_Init(u8g_t *u8g, uint8_t body_color)
+-{
+-  lrc_u8g = u8g;
+-
+-  chess_low_edge = u8g_GetHeight(lrc_u8g);
+-  chess_low_edge--;
+-  
+-
+-  if ( U8G_MODE_GET_BITS_PER_PIXEL(u8g_GetMode(lrc_u8g)) == 1 )
+-  {
+-  
+-    chess_boxsize = 8;
+-    chess_boxoffset = 1;
+-  }
+-  else
+-  {
+-
+-    /*    
+-    if ( u8g_GetHeight(lrc_u8g) >= 12*8 )
+-    {
+-      chess_boxsize = 12;
+-      chess_boxoffset = 3;
+-    }
+-    else */ if ( u8g_GetHeight(lrc_u8g) >= 11*8 )
+-    {
+-      chess_boxsize = 10;
+-      chess_boxoffset = 2;
+-    }
+-    else
+-    {
+-      chess_boxsize = 8;
+-      chess_boxoffset = 1;      
+-    }
+-    
+-    if ( u8g_GetHeight(lrc_u8g) > 64 )
+-      chess_low_edge -= (u8g_GetHeight(lrc_u8g)-chess_boxsize*8) / 2;
+-    
+-  }
+-    
+-  lrc_obj.strike_out_color = body_color;
+-  chess_SetupBoard();
+-}
+-
+-
+-
+-void chess_Draw(void)
+-{
+-  if ( chess_state == CHESS_STATE_MENU )
+-  {
+-    if ( lrc_obj.ply_count == 0)
+-      mnu_max = 2;
+-    else
+-      mnu_max = 4;
+-    mnu_Draw();
+-  }
+-  else
+-  {
+-    chess_DrawBoard();
+-    
+-    {
+-      uint8_t i;
+-      uint8_t entries = lrc_obj.chm_pos;
+-      if ( entries > 4 )
+-	entries = 4;
+-      
+-      u8g_SetFont(lrc_u8g, u8g_font_5x7);
+-      u8g_SetDefaultForegroundColor(lrc_u8g);
+-      for( i = 0; i < entries; i++ )
+-      {
+-        
+-#if defined(DOGXL160_HW_GR) || defined(DOGXL160_HW_BW)
+-	dog_DrawStr(u8g_GetWidth(lrc_u8g)-35, u8g_GetHeight(lrc_u8g)-8*(i+1), font_5x7, cu_GetHalfMoveStr(lrc_obj.chm_pos-entries+i));
+-#else
+-        u8g_DrawStr(lrc_u8g, u8g_GetWidth(lrc_u8g)-35, 8*(i+1), cu_GetHalfMoveStr(lrc_obj.chm_pos-entries+i));
+-#endif
+-
+-      }
+-      
+-    }
+-    
+-    if ( chess_state == CHESS_STATE_SELECT_PIECE )
+-      mnu_DrawHome(chess_source_pos == 255);
+-    else if ( chess_state == CHESS_STATE_SELECT_TARGET_POS )
+-      mnu_DrawHome(chess_target_pos == 255);
+-    else
+-      mnu_DrawHome(0);
+-      
+-    if ( chess_state == CHESS_STATE_GAME_END )
+-    {
+-      switch( lrc_obj.lost_side_color )
+-      {
+-	case COLOR_WHITE:
+-	  mnu_DrawEntry(u8g_GetHeight(lrc_u8g) / 2-2, "Black wins", 1, 1);
+-	  break;
+-	case COLOR_BLACK:
+-	  mnu_DrawEntry(u8g_GetHeight(lrc_u8g) / 2-2, "White wins", 1, 1);
+-	  break;
+-	default:
+-	  mnu_DrawEntry(u8g_GetHeight(lrc_u8g) / 2-2, "Stalemate", 1, 1);
+-	  break;
+-      }  
+-    }
+-  }
+-}
+-
+-
+-void chess_Step(uint8_t keycode)
+-{
+-  if ( keycode == CHESS_KEY_NONE )
+-  {
+-    chess_key_cmd = chess_key_code;
+-    chess_key_code = CHESS_KEY_NONE;
+-  }
+-  else
+-  {
+-    chess_key_cmd = CHESS_KEY_NONE;
+-    chess_key_code = keycode;
+-  }
+-  //chess_ComputerMove(2);
+-  switch(chess_state)
+-  {
+-    case CHESS_STATE_MENU:
+-      mnu_Step(chess_key_cmd);
+-      if ( chess_key_cmd == CHESS_KEY_SELECT )
+-      {
+-	if ( mnu_pos == 0 )
+-	{
+-          chess_SetupBoard();
+-	  lrc_obj.orientation = 0;
+-	  chess_state = CHESS_STATE_SELECT_START;
+-	}
+-	else if ( mnu_pos == 1 )
+-	{
+-          chess_SetupBoard();
+-	  lrc_obj.orientation = 1;
+-	  chess_state = CHESS_STATE_THINKING;
+-	}
+-	else if ( mnu_pos == 2 )
+-	{
+-	  if ( lrc_obj.ply_count >= 2 )
+-	  {
+-	    cu_UndoHalfMove();
+-	    cu_UndoHalfMove();
+-	    lrc_obj.ply_count-=2;
+-	    if ( lrc_obj.ply_count == 0 )
+-	      mnu_pos = 0;
+-	  }
+-	  chess_state = CHESS_STATE_SELECT_START;
+-	}
+-	else if ( mnu_pos == 3 )
+-	{
+-	  chess_state = CHESS_STATE_SELECT_START;
+-	}
+-      }
+-      break;
+-    case CHESS_STATE_SELECT_START:
+-      chess_ClearMarks();
+-      chess_MarkMovable();
+-      chess_source_pos = chess_GetNextMarked(255, 0);
+-      chess_target_pos = ILLEGAL_POSITION;
+-      chess_state = CHESS_STATE_SELECT_PIECE;
+-      break;
+-      
+-    case CHESS_STATE_SELECT_PIECE:
+-      if ( chess_key_cmd == CHESS_KEY_NEXT )
+-      {
+-	chess_source_pos = chess_GetNextMarked(chess_source_pos, 0);
+-      }
+-      else if ( chess_key_cmd == CHESS_KEY_PREV )
+-      {
+-	chess_source_pos = chess_GetNextMarked(chess_source_pos, 1);
+-      }
+-      else if ( chess_key_cmd == CHESS_KEY_SELECT )
+-      {
+-	if ( chess_source_pos == 255 )
+-	{
+-	  chess_state = CHESS_STATE_MENU;
+-	}
+-	else
+-	{
+-	  chess_ClearMarks();
+-	  chess_MarkTargetMoves(chess_source_pos);
+-	  chess_target_pos = chess_GetNextMarked(255, 0);
+-	  chess_state = CHESS_STATE_SELECT_TARGET_POS;      
+-	}
+-      }
+-      break;
+-    case CHESS_STATE_SELECT_TARGET_POS:
+-      if ( chess_key_cmd == CHESS_KEY_NEXT )
+-      {
+-	chess_target_pos = chess_GetNextMarked(chess_target_pos, 0);
+-      }
+-      else if ( chess_key_cmd == CHESS_KEY_PREV )
+-      {
+-	chess_target_pos = chess_GetNextMarked(chess_target_pos, 1);
+-      }
+-      else if ( chess_key_cmd == CHESS_KEY_BACK )
+-      {
+-	chess_ClearMarks();
+-	chess_MarkMovable();
+-	chess_target_pos = ILLEGAL_POSITION;
+-	chess_state = CHESS_STATE_SELECT_PIECE;
+-      }
+-      else if ( chess_key_cmd == CHESS_KEY_SELECT )
+-      {
+-	chess_ManualMove(chess_source_pos, chess_target_pos);
+-	if ( lrc_obj.is_game_end != 0 )
+-	  chess_state = CHESS_STATE_GAME_END;
+-	else
+-	  chess_state = CHESS_STATE_THINKING;
+-	/* clear marks as some kind of feedback to the user... it simply looks better */
+-	chess_source_pos = ILLEGAL_POSITION;
+-	chess_target_pos = ILLEGAL_POSITION;
+-	chess_ClearMarks();
+-      }
+-      break;
+-    case CHESS_STATE_THINKING:
+-      chess_ComputerMove(2);
+-      if ( lrc_obj.is_game_end != 0 )
+-	chess_state = CHESS_STATE_GAME_END;
+-      else
+-	chess_state = CHESS_STATE_SELECT_START;
+-      break;
+-    case CHESS_STATE_GAME_END:
+-      if ( chess_key_cmd != CHESS_KEY_NONE )
+-      {
+-	chess_state = CHESS_STATE_MENU;  
+-	chess_SetupBoard();
+-      }	
+-      break;
+-  }
+-  
+-}
+-
+-#endif
+-
+-
+diff --git a/csrc/u8g_com_arduino_attiny85_hw_spi.c b/csrc/u8g_com_arduino_attiny85_hw_spi.c
+deleted file mode 100644
+index 9d0191e..0000000
+--- a/csrc/u8g_com_arduino_attiny85_hw_spi.c
++++ /dev/null
+@@ -1,160 +0,0 @@
+-/*
+-  
+-  u8g_arduino_ATtiny85_std_hw_spi.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
+-*/
+-
+-// Uses code from tinySPI Written by Nick Gammon
+-// March 2013
+-
+-// ATMEL ATTINY45 / ARDUINO pin mappings
+-//
+-//                         +-\/-+
+-// RESET  Ain0 (D 5) PB5  1|    |8  Vcc
+-// CLK1   Ain3 (D 3) PB3  2|    |7  PB2 (D 2) Ain1  SCK  / USCK / SCL
+-// CLK0   Ain2 (D 4) PB4  3|    |6  PB1 (D 1) pwm1  MISO / DO
+-//                   GND  4|    |5  PB0 (D 0) pwm0  MOSI / DI / SDA
+-//                         +----+
+-
+-
+-#include "u8g.h"
+-
+-
+-#if defined(ARDUINO) && defined(__AVR_ATtiny85__)
+-
+-#if ARDUINO < 100 
+-#include <WProgram.h>
+-#else 
+-#include <Arduino.h> 
+-#endif
+-
+-const byte DI   = 0;  // D0, pin 5  Data In
+-const byte DO   = 1;  // D1, pin 6  Data Out (this is *not* MOSI)
+-const byte USCK = 2;  // D2, pin 7  Universal Serial Interface clock
+-
+-uint8_t u8g_arduino_ATtiny85_spi_out(uint8_t val)
+-{
+-  USIDR = val;  // byte to output
+-  USISR = _BV (USIOIF);  // clear Counter Overflow Interrupt Flag, set count to zero 
+-  do
+-  {
+-    USICR = _BV (USIWM0)   // 3-wire mode
+-          | _BV (USICS1) | _BV (USICLK)  // Software clock strobe
+-          | _BV (USITC);   // Toggle Clock Port Pin
+-  }
+-  while ((USISR & _BV (USIOIF)) == 0);  // until Counter Overflow Interrupt Flag set
+-  
+-  return USIDR;  // return read data
+-}
+-
+-uint8_t u8g_com_arduino_ATtiny85_std_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_CS, HIGH);  // ensure SS stays high until needed
+-      pinMode (USCK, OUTPUT);
+-      pinMode (DO, OUTPUT);
+-      pinMode (u8g->pin_list[U8G_PI_CS], OUTPUT);
+-      pinMode (u8g->pin_list[U8G_PI_A0], OUTPUT);
+-      USICR = _BV (USIWM0);  // 3-wire mode
+-      u8g_MicroDelay();
+-      break;
+-    
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_RESET:
+-      if ( u8g->pin_list[U8G_PI_RESET] != U8G_PIN_NONE )
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-      
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      if ( arg_val == 0 )
+-      {
+-        /* disable */
+-        u8g_MicroDelay();
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, HIGH);
+-        u8g_MicroDelay();
+-      }
+-      else
+-      {
+-        /* enable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, LOW);
+-        u8g_MicroDelay();
+-      }
+-      break;
+-
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_arduino_ATtiny85_spi_out(arg_val);
+-      u8g_MicroDelay();
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_arduino_ATtiny85_spi_out(*ptr++);
+-          arg_val--;
+-        }
+-      }
+-      break;
+-
+-      case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_arduino_ATtiny85_spi_out(u8g_pgm_read(ptr));
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-      
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_A0, arg_val);
+-      u8g_MicroDelay();
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else /* ARDUINO */
+-
+-uint8_t u8g_com_arduino_ATtiny85_std_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif /* ARDUINO */
+\ No newline at end of file
+diff --git a/csrc/u8g_com_arduino_common.c b/csrc/u8g_com_arduino_common.c
+deleted file mode 100644
+index ef0b236..0000000
+--- a/csrc/u8g_com_arduino_common.c
++++ /dev/null
+@@ -1,75 +0,0 @@
+-/*
+-  
+-  u8g_com_arduino_common.c
+-  
+-  shared procedures for the arduino communication procedures
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(ARDUINO)
+-
+-#if ARDUINO < 100 
+-#include <WProgram.h> 
+-#else 
+-#include <Arduino.h> 
+-#endif
+-
+-void u8g_com_arduino_digital_write(u8g_t *u8g, uint8_t pin_index, uint8_t value)
+-{
+-  uint8_t pin;
+-  pin = u8g->pin_list[pin_index];
+-  if ( pin != U8G_PIN_NONE )
+-    digitalWrite(pin, value);
+-}
+-
+-/* this procedure does not set the RW pin */
+-void u8g_com_arduino_assign_pin_output_high(u8g_t *u8g)
+-{
+-  uint8_t i;
+-  /* skip the RW pin, which is the last pin in the list */
+-  for( i = 0; i < U8G_PIN_LIST_LEN-1; i++ )
+-  {
+-    if ( u8g->pin_list[i] != U8G_PIN_NONE )
+-    {
+-      pinMode(u8g->pin_list[i], OUTPUT);	
+-      digitalWrite(u8g->pin_list[i], HIGH);
+-    }
+-  }
+-}
+-
+-
+-#endif
+-
+-
+diff --git a/csrc/u8g_com_arduino_fast_parallel.c b/csrc/u8g_com_arduino_fast_parallel.c
+deleted file mode 100644
+index 57d4410..0000000
+--- a/csrc/u8g_com_arduino_fast_parallel.c
++++ /dev/null
+@@ -1,254 +0,0 @@
+-/*
+-  
+-  u8g_arduino_fast_parallel.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
+-  PIN_D0 8
+-  PIN_D1 9
+-  PIN_D2 10
+-  PIN_D3 11
+-  PIN_D4 4
+-  PIN_D5 5
+-  PIN_D6 6
+-  PIN_D7 7
+-
+-  PIN_CS1 14
+-  PIN_CS2 15
+-  PIN_RW 16
+-  PIN_DI 17
+-  PIN_EN 18
+-  
+-  u8g_Init8Bit(u8g, dev, d0, d1, d2, d3, d4, d5, d6, d7, en, cs1, cs2, di, rw, reset)
+-  u8g_Init8Bit(u8g, dev,  8,    9, 10, 11,   4,   5,   6,   7, 18, 14, 15, 17, 16, U8G_PIN_NONE)
+-
+-  Update for ATOMIC operation done (01 Jun 2013)
+-    U8G_ATOMIC_OR(ptr, val)
+-    U8G_ATOMIC_AND(ptr, val)
+-    U8G_ATOMIC_START();
+-    U8G_ATOMIC_END();
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if  defined(ARDUINO)
+-
+-#if ARDUINO < 100 
+-//#include <WProgram.h> 
+-#include <wiring_private.h> 
+-#include <pins_arduino.h> 
+-#else 
+-#include <Arduino.h> 
+-#endif
+-
+-
+-#define PIN_D0 8
+-#define PIN_D1 9
+-#define PIN_D2 10
+-#define PIN_D3 11
+-#define PIN_D4 4
+-#define PIN_D5 5
+-#define PIN_D6 6
+-#define PIN_D7 7
+-
+-#define PIN_CS1 14
+-#define PIN_CS2 15
+-#define PIN_RW 16
+-#define PIN_DI 17
+-#define PIN_EN 18
+-
+-//#define PIN_RESET
+-
+-
+-#if defined(__PIC32MX)
+-/* CHIPKIT PIC32 */
+-static volatile uint32_t *u8g_data_port[8];
+-static uint32_t u8g_data_mask[8];
+-#else
+-static volatile uint8_t *u8g_data_port[8];
+-static uint8_t u8g_data_mask[8];
+-#endif
+-
+-
+-
+-static void u8g_com_arduino_fast_parallel_init(u8g_t *u8g)
+-{
+-  u8g_data_port[0] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D0]));
+-  u8g_data_mask[0] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D0]);
+-  u8g_data_port[1] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D1]));
+-  u8g_data_mask[1] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D1]);
+-  u8g_data_port[2] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D2]));
+-  u8g_data_mask[2] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D2]);
+-  u8g_data_port[3] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D3]));
+-  u8g_data_mask[3] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D3]);
+-  
+-  u8g_data_port[4] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D4]));
+-  u8g_data_mask[4] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D4]);
+-  u8g_data_port[5] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D5]));
+-  u8g_data_mask[5] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D5]);
+-  u8g_data_port[6] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D6]));
+-  u8g_data_mask[6] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D6]);
+-  u8g_data_port[7] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D7]));
+-  u8g_data_mask[7] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D7]);  
+-}
+-
+-/* atomic protection must be done by calling function */
+-static void u8g_com_arduino_fast_write_data_pin(uint8_t pin, uint8_t val)
+-{
+-  if ( val != 0 )
+-    *u8g_data_port[pin] |= u8g_data_mask[pin];
+-  else
+-    *u8g_data_port[pin] &= ~u8g_data_mask[pin];
+-}
+-
+-
+-void u8g_com_arduino_fast_parallel_write(u8g_t *u8g, uint8_t val)
+-{
+-  U8G_ATOMIC_START();
+-  u8g_com_arduino_fast_write_data_pin( 0, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_fast_write_data_pin( 1, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_fast_write_data_pin( 2, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_fast_write_data_pin( 3, val&1 );
+-  val >>= 1;
+-
+-  u8g_com_arduino_fast_write_data_pin( 4, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_fast_write_data_pin( 5, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_fast_write_data_pin( 6, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_fast_write_data_pin( 7, val&1 );
+-  val >>= 1;
+-  U8G_ATOMIC_END();
+-  
+-  /* EN cycle time must be 1 micro second */
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_EN, HIGH);
+-  u8g_MicroDelay(); /* delay by 1000ns, reference: ST7920: 140ns, SBN1661: 100ns */
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_EN, LOW);
+-  u8g_10MicroDelay(); /* ST7920 commands: 72us */
+-  u8g_10MicroDelay(); /* ST7920 commands: 72us */
+-}
+-
+-
+-uint8_t u8g_com_arduino_fast_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      u8g_com_arduino_fast_parallel_init(u8g);
+-      /* setup the RW pin as output and force it to low */
+-      if ( u8g->pin_list[U8G_PI_RW] != U8G_PIN_NONE )
+-      {
+-        pinMode(u8g->pin_list[U8G_PI_RW], OUTPUT);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_RW, LOW);
+-      }
+-      /* set all pins (except RW pin) */
+-      u8g_com_arduino_assign_pin_output_high(u8g);
+-      break;
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      if ( arg_val == 0 )
+-      {
+-        /* disable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS1, HIGH);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS2, HIGH);
+-      }
+-      else if ( arg_val == 1 )
+-      {
+-        /* enable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS1, LOW);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS2, HIGH);
+-      }
+-      else if ( arg_val == 2 )
+-      {
+-        /* enable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS1, HIGH);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS2, LOW);
+-      }
+-      else
+-      {
+-        /* enable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS1, LOW);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS2, LOW);
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_com_arduino_fast_parallel_write(u8g, arg_val);
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_arduino_fast_parallel_write(u8g, *ptr++);
+-          arg_val--;
+-        }
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_arduino_fast_parallel_write(u8g, u8g_pgm_read(ptr));
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_DI, arg_val);
+-      break;
+-    case U8G_COM_MSG_RESET:
+-      if ( u8g->pin_list[U8G_PI_RESET] != U8G_PIN_NONE )
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-      
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-
+-uint8_t u8g_com_arduino_fast_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-
+-#endif /* ARDUINO */
+-
+diff --git a/csrc/u8g_com_arduino_hw_spi.c b/csrc/u8g_com_arduino_hw_spi.c
+deleted file mode 100644
+index 3c0d34a..0000000
+--- a/csrc/u8g_com_arduino_hw_spi.c
++++ /dev/null
+@@ -1,438 +0,0 @@
+-/*
+-  
+-  u8g_com_arduino_hw_spi.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-
+-  SPI Clock Cycle Type
+-  
+-  SSD1351	  50ns		20 MHz
+-  SSD1322	300ns		  3.3 MHz
+-  SSD1327	300ns
+-  SSD1306	300ns
+-  ST7565		400ns 		  2.5 MHz
+-  ST7920		400ns
+-
+-  Arduino DUE
+-  
+-  PA25	MISO
+-  PA26	MOSI	75
+-  PA27	SCLK	76
+-  
+-  
+-typedef struct {
+-  WoReg SPI_CR;        (Spi Offset: 0x00) Control Register 
+-  RwReg SPI_MR;        (Spi Offset: 0x04) Mode Register 
+-  RoReg SPI_RDR;       (Spi Offset: 0x08) Receive Data Register 
+-  WoReg SPI_TDR;       (Spi Offset: 0x0C) Transmit Data Register 
+-  RoReg SPI_SR;        (Spi Offset: 0x10) Status Register 
+-  WoReg SPI_IER;       (Spi Offset: 0x14) Interrupt Enable Register 
+-  WoReg SPI_IDR;       (Spi Offset: 0x18) Interrupt Disable Register 
+-  RoReg SPI_IMR;       (Spi Offset: 0x1C) Interrupt Mask Register 
+-  RoReg Reserved1[4];
+-  RwReg SPI_CSR[4];    (Spi Offset: 0x30) Chip Select Register 
+-  RoReg Reserved2[41];
+-  RwReg SPI_WPMR;      (Spi Offset: 0xE4) Write Protection Control Register 
+-  RoReg SPI_WPSR;      (Spi Offset: 0xE8) Write Protection Status Register 
+-} Spi;
+-  
+-  Power Management Controller (PMC)
+-  arduino-1.5.2/hardware/arduino/sam/system/CMSIS/Device/ATMEL/sam3xa/include/instance/instance_pmc.h
+-    - enable PIO
+-      
+-      REG_PMC_PCER0 = 1UL << ID_PIOA
+-    - enable SPI
+-      REG_PMC_PCER0 = 1UL << ID_SPI0
+-
+-
+-    - enable PIOA and SPI0
+-      REG_PMC_PCER0 = (1UL << ID_PIOA) | (1UL << ID_SPI0);
+-
+-  Parallel Input/Output Controller (PIO)
+-  arduino-1.5.2/hardware/arduino/sam/system/CMSIS/Device/ATMEL/sam3xa/include/instance/instance_pioa.h
+-    - enable special function of the pin: disable PIO on A26 and A27:
+-	REG_PIOA_PDR = 0x0c000000
+-	PIOA->PIO_PDR = 0x0c000000
+-
+-  SPI
+-    SPI0->SPI_CR = SPI_CR_SPIDIS
+-    SPI0->SPI_CR = SPI_CR_SWRST ;
+-    SPI0->SPI_CR = SPI_CR_SWRST ;
+-    SPI0->SPI_CR = SPI_CR_SPIEN
+-  
+-    Bit 0: Master Mode = 1 (active)
+-    Bit 1: Peripheral Select = 0 (fixed)
+-    Bit 2: Chip Select Decode Mode = 1 (4 to 16)
+-    Bit 4: Mode Fault Detection = 1 (disabled)
+-    Bit 5: Wait Data Read = 0 (disabled) 
+-    Bit 7: Loop Back Mode = 0 (disabled)
+-    Bit 16-19: Peripheral Chip Select = 0 (chip select 0)    
+-    SPI0->SPI_MR = SPI_MR_MSTR | SPI_MR_PCSDEC | SPI_MR_MODFDIS
+-    
+-    Bit 0: Clock Polarity = 0
+-    Bit 1: Clock Phase = 0
+-    Bit 4-7: Bits = 0 (8 Bit)
+-    Bit 8-15: SCBR = 1
+-    SPI0->SPI_CSR[0] = SPI_CSR_SCBR(x)	Serial Baud Rate
+-	SCBR / 84000000 > 50 / 1000000000 
+-	SCBR / 84 > 5 / 100 
+-	SCBR  > 50 *84 / 1000 --> SCBR=5
+-	SCBR  > 300*84 / 1000 --> SCBR=26
+-	SCBR  > 400*84 / 1000 --> SCBR=34
+-
+-  Arduino Due test code:
+-    REG_PMC_PCER0 = (1UL << ID_PIOA) | (1UL << ID_SPI0);
+-    REG_PIOA_PDR = 0x0c000000;
+-    SPI0->SPI_CR = SPI_CR_SPIDIS;
+-    SPI0->SPI_CR = SPI_CR_SWRST;
+-    SPI0->SPI_CR = SPI_CR_SWRST;
+-    SPI0->SPI_CR = SPI_CR_SPIEN;
+-    SPI0->SPI_MR = SPI_MR_MSTR | SPI_MR_PCSDEC | SPI_MR_MODFDIS;
+-    SPI0->SPI_CSR[0] = SPI_CSR_SCBR(30);
+-
+-    for(;;)
+-    {
+-      while( (SPI0->SPI_SR & SPI_SR_TDRE) == 0 )
+-	;
+-      SPI0->SPI_TDR = 0x050;
+-    }
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(ARDUINO)
+-
+-#if defined(__AVR__)
+-#define U8G_ARDUINO_ATMEGA_HW_SPI
+-/* remove the definition for attiny */
+-#if __AVR_ARCH__ == 2
+-#undef U8G_ARDUINO_ATMEGA_HW_SPI
+-#endif
+-#if __AVR_ARCH__ == 25
+-#undef U8G_ARDUINO_ATMEGA_HW_SPI
+-#endif
+-#endif
+-
+-#if defined(U8G_ARDUINO_ATMEGA_HW_SPI)
+-
+-#include <avr/interrupt.h>
+-#include <avr/io.h>
+-
+-#if ARDUINO < 100 
+-#include <WProgram.h> 
+-
+-/* fixed pins */
+-#if defined(__AVR_ATmega644P__) || defined(__AVR_ATmega1284P__) // Sanguino.cc board
+-#define PIN_SCK         7
+-#define PIN_MISO        6
+-#define PIN_MOSI        5
+-#define PIN_CS          4
+-#else                                   // Arduino Board
+-#define PIN_SCK 13
+-#define PIN_MISO  12
+-#define PIN_MOSI 11
+-#define PIN_CS 10
+-#endif // (__AVR_ATmega644P__) || defined(__AVR_ATmega1284P__)
+-
+-#else 
+-
+-#include <Arduino.h> 
+-
+-/* use Arduino pin definitions */
+-#define PIN_SCK SCK
+-#define PIN_MISO  MISO
+-#define PIN_MOSI MOSI
+-#define PIN_CS SS
+-
+-#endif
+-
+-
+-
+-//static uint8_t u8g_spi_out(uint8_t data) U8G_NOINLINE;
+-static uint8_t u8g_spi_out(uint8_t data)
+-{
+-  /* unsigned char x = 100; */
+-  /* send data */
+-  SPDR = data;
+-  /* wait for transmission */
+-  while (!(SPSR & (1<<SPIF))) 
+-    ;
+-  /* clear the SPIF flag by reading SPDR */
+-  return  SPDR;
+-}
+-
+-
+-uint8_t u8g_com_arduino_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_STOP:
+-      break;
+-    
+-    case U8G_COM_MSG_INIT:
+-      u8g_com_arduino_assign_pin_output_high(u8g);
+-      pinMode(PIN_SCK, OUTPUT);
+-      digitalWrite(PIN_SCK, LOW);
+-      pinMode(PIN_MOSI, OUTPUT);
+-      digitalWrite(PIN_MOSI, LOW);
+-      /* pinMode(PIN_MISO, INPUT); */
+-
+-      pinMode(PIN_CS, OUTPUT);			/* system chip select for the atmega board */
+-      digitalWrite(PIN_CS, HIGH);
+-    
+-
+-
+-      /*
+-        SPR1 SPR0
+-            0	0		fclk/4
+-            0	1		fclk/16
+-            1	0		fclk/64
+-            1	1		fclk/128
+-      */
+-      SPCR = 0;
+-      SPCR =  (1<<SPE) | (1<<MSTR)|(0<<SPR1)|(0<<SPR0)|(0<<CPOL)|(0<<CPHA);
+-#ifdef U8G_HW_SPI_2X
+-      SPSR = (1 << SPI2X);  /* double speed, issue 89 */
+-#else
+-      if ( arg_val  <= U8G_SPI_CLK_CYCLE_50NS )
+-      {
+-	SPSR = (1 << SPI2X);  /* double speed, issue 89 */
+-      }
+-#endif
+-      
+-      
+-      break;
+-    
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_A0, arg_val);
+-      break;
+-
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      if ( arg_val == 0 )
+-      {
+-        /* disable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, HIGH);
+-      }
+-      else
+-      {
+-        /* enable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_SCK, LOW);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, LOW);
+-      }
+-      break;
+-      
+-    case U8G_COM_MSG_RESET:
+-      if ( u8g->pin_list[U8G_PI_RESET] != U8G_PIN_NONE )
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_spi_out(arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_spi_out(*ptr++);
+-          arg_val--;
+-        }
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_spi_out(u8g_pgm_read(ptr));
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-  }
+-  return 1;
+-}
+-
+-/* #elif defined(__18CXX) || defined(__PIC32MX) */
+-
+-#elif defined(__SAM3X8E__)		// Arduino Due, maybe we should better check for __SAM3X8E__
+-
+-#include <Arduino.h> 
+-
+-/* use Arduino pin definitions */
+-#define PIN_SCK SCK
+-#define PIN_MISO  MISO
+-#define PIN_MOSI MOSI
+-#define PIN_CS SS
+-
+-
+-static uint8_t u8g_spi_out(uint8_t data)
+-{
+-  /* wait until tx register is empty */
+-  while( (SPI0->SPI_SR & SPI_SR_TDRE) == 0 )
+-    ;
+-  /* send data */
+-  SPI0->SPI_TDR = (uint32_t)data;
+-  return  data;
+-}
+-
+-
+-uint8_t u8g_com_arduino_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_STOP:
+-      break;
+-    
+-    case U8G_COM_MSG_INIT:
+-      u8g_com_arduino_assign_pin_output_high(u8g);
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_CS, HIGH);
+-    
+-      /* Arduino Due specific code */
+-      
+-      /* enable PIOA and SPI0 */
+-      REG_PMC_PCER0 = (1UL << ID_PIOA) | (1UL << ID_SPI0);
+-
+-      /* disable PIO on A26 and A27 */
+-      REG_PIOA_PDR = 0x0c000000;
+-
+-      /* reset SPI0 (from sam lib) */
+-      SPI0->SPI_CR = SPI_CR_SPIDIS;
+-      SPI0->SPI_CR = SPI_CR_SWRST;
+-      SPI0->SPI_CR = SPI_CR_SWRST;
+-      SPI0->SPI_CR = SPI_CR_SPIEN;
+-      u8g_MicroDelay();
+-      
+-      /* master mode, no fault detection, chip select 0 */
+-      SPI0->SPI_MR = SPI_MR_MSTR | SPI_MR_PCSDEC | SPI_MR_MODFDIS;
+-      
+-      /* Polarity, Phase, 8 Bit data transfer, baud rate */
+-      /* x * 1000 / 84 --> clock cycle in ns 
+-        5 * 1000 / 84 = 58 ns       
+-	SCBR  > 50 *84 / 1000 --> SCBR=5
+-	SCBR  > 300*84 / 1000 --> SCBR=26
+-	SCBR  > 400*84 / 1000 --> SCBR=34
+-      */
+-      
+-      if ( arg_val <= U8G_SPI_CLK_CYCLE_50NS )
+-      {
+-	SPI0->SPI_CSR[0] = SPI_CSR_SCBR(5) | 1;
+-      }
+-      else if ( arg_val <= U8G_SPI_CLK_CYCLE_300NS )
+-      {
+-	SPI0->SPI_CSR[0] = SPI_CSR_SCBR(26) | 1;
+-      }
+-      else if ( arg_val <= U8G_SPI_CLK_CYCLE_400NS )
+-      {
+-	SPI0->SPI_CSR[0] = SPI_CSR_SCBR(34) | 1;
+-      }
+-      else
+-      {
+-	SPI0->SPI_CSR[0] = SPI_CSR_SCBR(84) | 1;
+-      }
+-      
+-      u8g_MicroDelay();      
+-      break;
+-    
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_A0, arg_val);
+-      u8g_MicroDelay();
+-      break;
+-
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      if ( arg_val == 0 )
+-      {
+-        /* disable */
+-	u8g_MicroDelay();		/* this delay is required to avoid that the display is switched off too early --> DOGS102 with DUE */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, HIGH);
+-	u8g_MicroDelay();
+-      }
+-      else
+-      {
+-        /* enable */
+-        //u8g_com_arduino_digital_write(u8g, U8G_PI_SCK, LOW);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, LOW);
+-	u8g_MicroDelay();
+-      }
+-      break;
+-      
+-    case U8G_COM_MSG_RESET:
+-      if ( u8g->pin_list[U8G_PI_RESET] != U8G_PIN_NONE )
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_spi_out(arg_val);
+-      u8g_MicroDelay();
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_spi_out(*ptr++);
+-          arg_val--;
+-        }
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_spi_out(u8g_pgm_read(ptr));
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-  }
+-  return 1;
+-}
+-
+-
+-
+-#else /* U8G_ARDUINO_ATMEGA_HW_SPI */
+-
+-#endif /* U8G_ARDUINO_ATMEGA_HW_SPI */
+-
+-#else /* ARDUINO */
+-
+-uint8_t u8g_com_arduino_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif /* ARDUINO */
+-
+diff --git a/csrc/u8g_com_arduino_hw_usart_spi.c b/csrc/u8g_com_arduino_hw_usart_spi.c
+deleted file mode 100644
+index 27fd8d0..0000000
+--- a/csrc/u8g_com_arduino_hw_usart_spi.c
++++ /dev/null
+@@ -1,159 +0,0 @@
+-/*
+-  
+-  u8g_com_arduino_hw_usart_spi.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-
+-  SPI Clock Cycle Type
+-  
+-  SSD1351	  50ns		20 MHz
+-  SSD1322	300ns		  3.3 MHz
+-  SSD1327	300ns
+-  SSD1306	300ns
+-  ST7565		400ns 		  2.5 MHz
+-  ST7920		400ns
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(ARDUINO)
+-
+-#if defined(__AVR_ATmega32U4__ )
+-
+-#include <avr/interrupt.h>
+-#include <avr/io.h>
+-
+-#if ARDUINO < 100 
+-#include <WProgram.h> 
+-#else 
+-#include <Arduino.h> 
+-#endif
+-
+-
+-
+-static uint8_t u8g_usart_spi_out(uint8_t data)
+-{
+-  /* send data */
+-  UDR1 = data;
+-  /* wait for empty transmit buffer */
+-  while(!(UCSR1A & (1 << UDRE1)));
+-
+-  return  UDR1;
+-}
+-
+-
+-uint8_t u8g_com_arduino_hw_usart_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_STOP:
+-      break;
+-    
+-    case U8G_COM_MSG_INIT:
+-      /* SCK is already an output as we overwrite TXLED */
+-      u8g_com_arduino_assign_pin_output_high(u8g);
+-	  u8g_com_arduino_digital_write(u8g, U8G_PI_CS, HIGH);
+-    
+-	  // Init interface at 2MHz
+-	  UBRR1 = 0x00;
+-	  UCSR1C = (1 << UMSEL11) | (1 << UMSEL10);
+-      UCSR1B = (1 << TXEN1);
+-      UBRR1 = 3;
+-           
+-      break;
+-    
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_A0, arg_val);
+-      break;
+-
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      if ( arg_val == 0 )
+-      {
+-        /* disable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, HIGH);
+-      }
+-      else
+-      {
+-        /* enable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, LOW);
+-      }
+-      break;
+-      
+-    case U8G_COM_MSG_RESET:
+-      if ( u8g->pin_list[U8G_PI_RESET] != U8G_PIN_NONE )
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_usart_spi_out(arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_usart_spi_out(*ptr++);
+-          arg_val--;
+-        }
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_usart_spi_out(u8g_pgm_read(ptr));
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-  }
+-  return 1;
+-}
+-
+-/* #elif defined(__18CXX) || defined(__PIC32MX) */
+-/* #elif defined(__arm__)		// Arduino Due, maybe we should better check for __SAM3X8E__ */
+-
+-#else /* __AVR_ATmega32U4__ */
+-
+-#endif /* __AVR_ATmega32U4__ */
+-
+-#else /* ARDUINO */
+-
+-uint8_t u8g_com_arduino_hw_usart_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif /* ARDUINO */
+-
+diff --git a/csrc/u8g_com_arduino_no_en_parallel.c b/csrc/u8g_com_arduino_no_en_parallel.c
+deleted file mode 100644
+index 4edb30a..0000000
+--- a/csrc/u8g_com_arduino_no_en_parallel.c
++++ /dev/null
+@@ -1,234 +0,0 @@
+-/*
+-  
+-  u8g_arduino_no_en_parallel.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2012, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
+-  PIN_D0 8
+-  PIN_D1 9
+-  PIN_D2 10
+-  PIN_D3 11
+-  PIN_D4 4
+-  PIN_D5 5
+-  PIN_D6 6
+-  PIN_D7 7
+-
+-  PIN_CS1 14
+-  PIN_CS2 15
+-  PIN_RW 16
+-  PIN_DI 17
+-  PIN_EN 18
+-  
+-  u8g_Init8Bit(u8g, dev, d0, d1, d2, d3, d4, d5, d6, d7, en, cs1, cs2, di, rw, reset)
+-  u8g_Init8Bit(u8g, dev,  8,    9, 10, 11,   4,   5,   6,   7, 18, 14, 15, 17, 16, U8G_PIN_NONE)
+-  Update for ATOMIC operation done (01 Jun 2013)
+-  
+-    U8G_ATOMIC_OR(ptr, val)
+-    U8G_ATOMIC_AND(ptr, val)
+-    U8G_ATOMIC_START();
+-    U8G_ATOMIC_END();
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if  defined(ARDUINO)
+-
+-#if ARDUINO < 100 
+-//#include <WProgram.h> 
+-#include <wiring_private.h> 
+-#include <pins_arduino.h> 
+-#else 
+-#include <Arduino.h> 
+-#endif
+-
+-//#define PIN_RESET
+-
+-#if defined(__PIC32MX)
+-/* CHIPKIT PIC32 */
+-static volatile uint32_t *u8g_data_port[8];
+-static uint32_t u8g_data_mask[8];
+-#else
+-static volatile uint8_t *u8g_data_port[8];
+-static uint8_t u8g_data_mask[8];
+-#endif
+-
+-
+-
+-static void u8g_com_arduino_no_en_parallel_init(u8g_t *u8g)
+-{
+-  u8g_data_port[0] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D0]));
+-  u8g_data_mask[0] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D0]);
+-  u8g_data_port[1] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D1]));
+-  u8g_data_mask[1] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D1]);
+-  u8g_data_port[2] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D2]));
+-  u8g_data_mask[2] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D2]);
+-  u8g_data_port[3] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D3]));
+-  u8g_data_mask[3] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D3]);
+-  
+-  u8g_data_port[4] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D4]));
+-  u8g_data_mask[4] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D4]);
+-  u8g_data_port[5] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D5]));
+-  u8g_data_mask[5] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D5]);
+-  u8g_data_port[6] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D6]));
+-  u8g_data_mask[6] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D6]);
+-  u8g_data_port[7] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D7]));
+-  u8g_data_mask[7] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D7]);  
+-}
+-
+-/* No atomic protcetion. This is done by caller */
+-static void u8g_com_arduino_no_en_write_data_pin(uint8_t pin, uint8_t val)
+-{
+-  if ( val != 0 )
+-  {
+-   *u8g_data_port[pin] |= u8g_data_mask[pin];
+-  }
+-  else
+-  {
+-    *u8g_data_port[pin] &= ~u8g_data_mask[pin];
+-  }
+-}
+-
+-
+-void u8g_com_arduino_no_en_parallel_write(u8g_t *u8g, uint8_t val)
+-{
+-  U8G_ATOMIC_START();
+-  u8g_com_arduino_no_en_write_data_pin( 0, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_no_en_write_data_pin( 1, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_no_en_write_data_pin( 2, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_no_en_write_data_pin( 3, val&1 );
+-  val >>= 1;
+-
+-  u8g_com_arduino_no_en_write_data_pin( 4, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_no_en_write_data_pin( 5, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_no_en_write_data_pin( 6, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_no_en_write_data_pin( 7, val&1 );
+-  val >>= 1;
+-  U8G_ATOMIC_END();
+-  
+-  /* EN cycle time must be 1 micro second, digitalWrite is slow enough to do this */
+-  if ( u8g->pin_list[U8G_PI_CS_STATE] == 1 )
+-  {
+-    u8g_MicroDelay();
+-    u8g_com_arduino_digital_write(u8g, U8G_PI_CS1, HIGH);
+-    u8g_MicroDelay();
+-    u8g_com_arduino_digital_write(u8g, U8G_PI_CS1, LOW);
+-    u8g_MicroDelay();
+-  }
+-  else if ( u8g->pin_list[U8G_PI_CS_STATE] == 2 )
+-  {
+-    u8g_MicroDelay();
+-    u8g_com_arduino_digital_write(u8g, U8G_PI_CS2, HIGH);
+-    u8g_MicroDelay();
+-    u8g_com_arduino_digital_write(u8g, U8G_PI_CS2, LOW);
+-    u8g_MicroDelay();
+-  }
+-}
+-
+-
+-uint8_t u8g_com_arduino_no_en_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      u8g_com_arduino_no_en_parallel_init(u8g);
+-      /* setup the RW pin as output and force it to low */
+-      if ( u8g->pin_list[U8G_PI_RW] != U8G_PIN_NONE )
+-      {
+-        pinMode(u8g->pin_list[U8G_PI_RW], OUTPUT);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_RW, LOW);
+-      }
+-      /* set all pins (except RW pin) */
+-      u8g_com_arduino_assign_pin_output_high(u8g);
+-      break;
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      /*
+-	0: nothing selected
+-	1: CS1 will be used as enable line
+-        2: CS2 will be used as enable line
+-        this will be used in the u8g_com_arduino_no_en_parallel_write() procedure
+-      */
+-      u8g->pin_list[U8G_PI_CS_STATE] = arg_val;
+-      break;
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_com_arduino_no_en_parallel_write(u8g, arg_val);
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_arduino_no_en_parallel_write(u8g, *ptr++);
+-          arg_val--;
+-        }
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_arduino_no_en_parallel_write(u8g, u8g_pgm_read(ptr));
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_DI, arg_val);
+-      break;
+-    case U8G_COM_MSG_RESET:
+-      if ( u8g->pin_list[U8G_PI_RESET] != U8G_PIN_NONE )
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-
+-uint8_t u8g_com_arduino_no_en_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-
+-#endif /* ARDUINO */
+-
+diff --git a/csrc/u8g_com_arduino_parallel.c b/csrc/u8g_com_arduino_parallel.c
+deleted file mode 100644
+index d5d5dd7..0000000
+--- a/csrc/u8g_com_arduino_parallel.c
++++ /dev/null
+@@ -1,184 +0,0 @@
+-/*
+-  
+-  u8g_com_arduino_parallel.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
+-
+-  PIN_D0 8
+-  PIN_D1 9
+-  PIN_D2 10
+-  PIN_D3 11
+-  PIN_D4 4
+-  PIN_D5 5
+-  PIN_D6 6
+-  PIN_D7 7
+-
+-  PIN_CS1 14
+-  PIN_CS2 15
+-  PIN_RW 16
+-  PIN_DI 17
+-  PIN_EN 18
+-  
+-  u8g_Init8Bit(u8g, dev, d0, d1, d2, d3, d4, d5, d6, d7, en, cs1, cs2, di, rw, reset)
+-  u8g_Init8Bit(u8g, dev,  8,    9, 10, 11,   4,   5,   6,   7, 18, 14, 15, 17, 16, U8G_PIN_NONE)
+-
+-*/
+-
+-#include "u8g.h"
+-
+-
+-#if  defined(ARDUINO)
+-
+-#if ARDUINO < 100 
+-#include <WProgram.h> 
+-#else 
+-#include <Arduino.h> 
+-#endif
+-
+-
+-
+-
+-
+-
+-void u8g_com_arduino_parallel_write(u8g_t *u8g, uint8_t val)
+-{
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_D0, val&1);
+-  val >>= 1;
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_D1, val&1);
+-  val >>= 1;
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_D2, val&1);
+-  val >>= 1;
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_D3, val&1);
+-  val >>= 1;
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_D4, val&1);
+-  val >>= 1;
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_D5, val&1);
+-  val >>= 1;
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_D6, val&1);
+-  val >>= 1;
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_D7, val&1);
+-  
+-  /* EN cycle time must be 1 micro second, digitalWrite is slow enough to do this */
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_EN, HIGH);
+-  u8g_MicroDelay(); /* delay by 1000ns, reference: ST7920: 140ns, SBN1661: 100ns */
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_EN, LOW);
+-  u8g_10MicroDelay(); /* ST7920 commands: 72us */
+-}
+-
+-
+-uint8_t u8g_com_arduino_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      /* setup the RW pin as output and force it to low */
+-      if ( u8g->pin_list[U8G_PI_RW] != U8G_PIN_NONE )
+-      {
+-        pinMode(u8g->pin_list[U8G_PI_RW], OUTPUT);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_RW, LOW);
+-      }
+-      /* set all pins (except RW pin) */
+-      u8g_com_arduino_assign_pin_output_high(u8g);
+-      break;
+-    case U8G_COM_MSG_STOP:
+-      break;
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      if ( arg_val == 0 )
+-      {
+-        /* disable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS1, HIGH);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS2, HIGH);
+-      }
+-      else if ( arg_val == 1 )
+-      {
+-        /* enable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS1, LOW);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS2, HIGH);
+-      }
+-      else if ( arg_val == 2 )
+-      {
+-        /* enable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS1, HIGH);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS2, LOW);
+-      }
+-      else
+-      {
+-        /* enable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS1, LOW);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS2, LOW);
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_com_arduino_parallel_write(u8g, arg_val);
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_arduino_parallel_write(u8g, *ptr++);
+-          arg_val--;
+-        }
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_arduino_parallel_write(u8g, u8g_pgm_read(ptr));
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_DI, arg_val);
+-      break;
+-    case U8G_COM_MSG_RESET:
+-      if ( u8g->pin_list[U8G_PI_RESET] != U8G_PIN_NONE )
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-      
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-
+-uint8_t u8g_com_arduino_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif /* ARDUINO */
+-
+diff --git a/csrc/u8g_com_arduino_port_d_wr.c b/csrc/u8g_com_arduino_port_d_wr.c
+deleted file mode 100644
+index 64a8229..0000000
+--- a/csrc/u8g_com_arduino_port_d_wr.c
++++ /dev/null
+@@ -1,177 +0,0 @@
+-/*
+-  
+-  u8g_arduino_port_d_wr.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
+-
+-  Assumes PORTD for 8 bit data transfer.
+-  EN is assumed to be a low active write signal (WR)
+-
+-  ILI9325D_320x240 from iteadstudio.com
+-  RS=19, WR=18, CS=17, RST=16
+-
+-  
+-  u8g_Init8Bit(u8g, dev, d0, d1, d2, d3, d4, d5, d6, d7, en, cs1, cs2, di, rw, reset)
+-  u8g_Init8Bit(u8g, dev,  8,    9, 10, 11,   4,   5,   6,   7, 18, 14, 15, 17, 16, U8G_PIN_NONE)
+-
+-
+-  Update for ATOMIC operation done (01 Jun 2013)
+-    U8G_ATOMIC_OR(ptr, val)
+-    U8G_ATOMIC_AND(ptr, val)
+-    U8G_ATOMIC_START();
+-    U8G_ATOMIC_END();
+-
+-*/
+-
+-#include "u8g.h"
+-
+-
+-#if  defined(ARDUINO) && defined(PORTD)
+-
+-#if ARDUINO < 100 
+-#include <WProgram.h> 
+-#else 
+-#include <Arduino.h> 
+-#endif
+-
+-
+-
+-
+-
+-
+-static void u8g_com_arduino_port_d_8bit_wr(u8g_t *u8g, uint8_t val)
+-{
+-  PORTD = val;
+-  
+-  /* WR cycle time must be 1 micro second, digitalWrite is slow enough to do this */
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_EN, LOW);
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_EN, HIGH);
+-}
+-
+-
+-uint8_t u8g_com_arduino_port_d_wr_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-
+-#ifdef UCSR0B
+-      UCSR0B = 0;  // disable USART 0
+-#endif
+-      U8G_ATOMIC_START();
+-      DDRD = 0x0ff;
+-      PORTD = 0x0ff;
+-      U8G_ATOMIC_END();
+-
+-      /* setup the RW pin as output and force it to low */
+-      if ( u8g->pin_list[U8G_PI_RW] != U8G_PIN_NONE )
+-      {
+-        pinMode(u8g->pin_list[U8G_PI_RW], OUTPUT);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_RW, HIGH);
+-      }
+-      /* set all pins (except RW pin) */
+-      u8g_com_arduino_assign_pin_output_high(u8g);
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_EN, HIGH);
+-      break;
+-    case U8G_COM_MSG_STOP:
+-      break;
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      if ( arg_val == 0 )
+-      {
+-        /* disable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS1, HIGH);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS2, HIGH);
+-      }
+-      else if ( arg_val == 1 )
+-      {
+-        /* enable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS1, LOW);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS2, HIGH);
+-      }
+-      else if ( arg_val == 2 )
+-      {
+-        /* enable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS1, HIGH);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS2, LOW);
+-      }
+-      else
+-      {
+-        /* enable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS1, LOW);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS2, LOW);
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_com_arduino_port_d_8bit_wr(u8g, arg_val);
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_arduino_port_d_8bit_wr(u8g, *ptr++);
+-          arg_val--;
+-        }
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_arduino_port_d_8bit_wr(u8g, u8g_pgm_read(ptr));
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_DI, arg_val);
+-      break;
+-    case U8G_COM_MSG_RESET:
+-      if ( u8g->pin_list[U8G_PI_RESET] != U8G_PIN_NONE )
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-
+-uint8_t u8g_com_arduino_port_d_wr_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif /* ARDUINO && PORTD */
+-
+diff --git a/csrc/u8g_com_arduino_ssd_i2c.c b/csrc/u8g_com_arduino_ssd_i2c.c
+deleted file mode 100644
+index 84b24da..0000000
+--- a/csrc/u8g_com_arduino_ssd_i2c.c
++++ /dev/null
+@@ -1,212 +0,0 @@
+-/*
+-  
+-  u8g_com_arduino_ssd_i2c.c
+-
+-  com interface for arduino (AND atmega) and the SSDxxxx chip (SOLOMON) variant 
+-  I2C protocol 
+-  
+-  ToDo: Rename this to u8g_com_avr_ssd_i2c.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2012, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
+-  Special pin usage:
+-    U8G_PI_I2C_OPTION	additional options
+-    U8G_PI_A0_STATE	used to store the last value of the command/data register selection
+-    U8G_PI_SET_A0		1: Signal request to update I2C device with new A0_STATE, 0: Do nothing, A0_STATE matches I2C device
+-    U8G_PI_SCL		clock line (NOT USED)
+-    U8G_PI_SDA		data line (NOT USED)
+-    
+-    U8G_PI_RESET		reset line (currently disabled, see below)
+-
+-  Protocol:
+-    SLA, Cmd/Data Selection, Arguments
+-    The command/data register is selected by a special instruction byte, which is sent after SLA
+-    
+-    The continue bit is always 0 so that a (re)start is equired for the change from cmd to/data mode
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(U8G_WITH_PINLIST)
+-
+-
+-#define I2C_SLA         (0x3c*2)
+-//#define I2C_CMD_MODE  0x080
+-#define I2C_CMD_MODE    0x000
+-#define I2C_DATA_MODE   0x040
+-
+-uint8_t u8g_com_arduino_ssd_start_sequence(u8g_t *u8g)
+-{
+-  /* are we requested to set the a0 state? */
+-  if ( u8g->pin_list[U8G_PI_SET_A0] == 0 )
+-    return 1;
+-
+-  /* setup bus, might be a repeated start */
+-  if ( u8g_i2c_start(I2C_SLA) == 0 )
+-    return 0;
+-  if ( u8g->pin_list[U8G_PI_A0_STATE] == 0 )
+-  {
+-    if ( u8g_i2c_send_byte(I2C_CMD_MODE) == 0 )
+-      return 0;
+-  }
+-  else
+-  {
+-    if ( u8g_i2c_send_byte(I2C_DATA_MODE) == 0 )
+-      return 0;
+-  }
+-
+-  u8g->pin_list[U8G_PI_SET_A0] = 0;
+-  return 1;
+-}
+-
+-uint8_t u8g_com_arduino_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      //u8g_com_arduino_digital_write(u8g, U8G_PI_SCL, HIGH);
+-      //u8g_com_arduino_digital_write(u8g, U8G_PI_SDA, HIGH);
+-      //u8g->pin_list[U8G_PI_A0_STATE] = 0;       /* inital RS state: unknown mode */
+-    
+-      u8g_i2c_init(u8g->pin_list[U8G_PI_I2C_OPTION]);
+-
+-      break;
+-    
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_RESET:
+-      /* Currently disabled, but it could be enable. Previous restrictions have been removed */
+-      /* u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val); */
+-      break;
+-      
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      u8g->pin_list[U8G_PI_A0_STATE] = 0;
+-      u8g->pin_list[U8G_PI_SET_A0] = 1;		/* force a0 to set again, also forces start condition */
+-      if ( arg_val == 0 )
+-      {
+-        /* disable chip, send stop condition */
+-	u8g_i2c_stop();
+-     }
+-      else
+-      {
+-        /* enable, do nothing: any byte writing will trigger the i2c start */
+-      }
+-      break;
+-
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      //u8g->pin_list[U8G_PI_SET_A0] = 1;
+-      if ( u8g_com_arduino_ssd_start_sequence(u8g) == 0 )
+-	return u8g_i2c_stop(), 0;
+-      if ( u8g_i2c_send_byte(arg_val) == 0 )
+-	return u8g_i2c_stop(), 0;
+-      // u8g_i2c_stop();
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      //u8g->pin_list[U8G_PI_SET_A0] = 1;
+-      if ( u8g_com_arduino_ssd_start_sequence(u8g) == 0 )
+-	return u8g_i2c_stop(), 0;
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-	  if ( u8g_i2c_send_byte(*ptr++) == 0 )
+-	    return u8g_i2c_stop(), 0;
+-          arg_val--;
+-        }
+-      }
+-      // u8g_i2c_stop();
+-      break;
+-
+-    case U8G_COM_MSG_WRITE_SEQ_P:
+-      //u8g->pin_list[U8G_PI_SET_A0] = 1;
+-      if ( u8g_com_arduino_ssd_start_sequence(u8g) == 0 )
+-	return u8g_i2c_stop(), 0;
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-	  if ( u8g_i2c_send_byte(u8g_pgm_read(ptr)) == 0 )
+-	    return 0;
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      // u8g_i2c_stop();
+-      break;
+-      
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g->pin_list[U8G_PI_A0_STATE] = arg_val;
+-      u8g->pin_list[U8G_PI_SET_A0] = 1;		/* force a0 to set again */
+-    
+-#ifdef OLD_CODE    
+-      if ( i2c_state != 0 )
+-      {
+-	u8g_i2c_stop();
+-	i2c_state = 0;
+-      }
+-
+-      if ( u8g_com_arduino_ssd_start_sequence(arg_val) == 0 )
+-	return 0;
+-    
+-      /* setup bus, might be a repeated start */
+-      /*
+-      if ( u8g_i2c_start(I2C_SLA) == 0 )
+-	return 0;
+-      if ( arg_val == 0 )
+-      {
+-	i2c_state = 1;
+-	
+-	if ( u8g_i2c_send_byte(I2C_CMD_MODE) == 0 )
+-	  return 0;
+-      }
+-      else
+-      {
+-	i2c_state = 2;
+-	if ( u8g_i2c_send_byte(I2C_DATA_MODE) == 0 )
+-	  return 0;
+-      }
+-      */
+-#endif
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else  /* defined(U8G_WITH_PINLIST) */
+-
+-uint8_t u8g_com_arduino_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif /* defined(U8G_WITH_PINLIST) */
+-
+diff --git a/csrc/u8g_com_arduino_st7920_custom.c b/csrc/u8g_com_arduino_st7920_custom.c
+deleted file mode 100644
+index d157b93..0000000
+--- a/csrc/u8g_com_arduino_st7920_custom.c
++++ /dev/null
+@@ -1,330 +0,0 @@
+-/*
+-  
+-  u8g_com_arduino_st7920_custom.c
+-  
+-  Additional COM device, initially introduced for 3D Printer community
+-  Implements a fast SW SPI com subsystem
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-
+-  A special SPI interface for ST7920 controller
+-
+-  Update for ATOMIC operation done (01 Jun 2013)
+-    U8G_ATOMIC_OR(ptr, val)
+-    U8G_ATOMIC_AND(ptr, val)
+-    U8G_ATOMIC_START();
+-    U8G_ATOMIC_END();
+-
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(ARDUINO)
+-
+-#if ARDUINO < 100 
+-#include <WProgram.h>    
+-#include "wiring_private.h"
+-#include "pins_arduino.h"
+-
+-#else 
+-#include <Arduino.h> 
+-#include "wiring_private.h"
+-#endif
+-
+-#if defined(__AVR__)
+-
+-static uint8_t u8g_bitData, u8g_bitNotData;
+-static uint8_t u8g_bitClock, u8g_bitNotClock;
+-static volatile uint8_t *u8g_outData;
+-static volatile uint8_t *u8g_outClock;
+-
+-static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin)
+-{
+-  u8g_outData = portOutputRegister(digitalPinToPort(dataPin));
+-  u8g_outClock = portOutputRegister(digitalPinToPort(clockPin));
+-  u8g_bitData = digitalPinToBitMask(dataPin);
+-  u8g_bitClock = digitalPinToBitMask(clockPin);
+-
+-  u8g_bitNotClock = u8g_bitClock;
+-  u8g_bitNotClock ^= 0x0ff;
+-
+-  u8g_bitNotData = u8g_bitData;
+-  u8g_bitNotData ^= 0x0ff;
+-}
+-
+-static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val) U8G_NOINLINE;
+-static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val)
+-{
+-  uint8_t cnt = 8;
+-  uint8_t bitData = u8g_bitData;
+-  uint8_t bitNotData = u8g_bitNotData;
+-  uint8_t bitClock = u8g_bitClock;
+-  uint8_t bitNotClock = u8g_bitNotClock;
+-  volatile uint8_t *outData = u8g_outData;
+-  volatile uint8_t *outClock = u8g_outClock;
+-  
+-  
+-  U8G_ATOMIC_START();
+-  bitData |= *outData;
+-  bitNotData &= *outData;
+-  do
+-  {
+-    if ( val & 128 )
+-      *outData = bitData;
+-    else
+-      *outData = bitNotData;
+-
+-    /*
+-    *outClock |= bitClock;
+-    val <<= 1;
+-    cnt--;
+-    *outClock &= bitNotClock;
+-    */
+-
+-    val <<= 1;
+-    *outClock &= bitNotClock;
+-    cnt--;
+-    // removed micro delays, because AVRs are too slow and the delay is not required
+-    //u8g_MicroDelay();
+-    *outClock |= bitClock;
+-    //u8g_MicroDelay();
+-  } while( cnt != 0 );
+-  U8G_ATOMIC_END();
+-}
+-
+-#elif defined(__18CXX) || defined(__PIC32MX)
+-
+-uint16_t dog_bitData, dog_bitNotData;
+-uint16_t dog_bitClock, dog_bitNotClock;
+-volatile uint32_t *dog_outData;
+-volatile uint32_t *dog_outClock;
+-volatile uint32_t dog_pic32_spi_tmp;
+-
+-static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin)
+-{
+-  dog_outData = portOutputRegister(digitalPinToPort(dataPin));
+-  dog_outClock = portOutputRegister(digitalPinToPort(clockPin));
+-  dog_bitData = digitalPinToBitMask(dataPin);
+-  dog_bitClock = digitalPinToBitMask(clockPin);
+-
+-  dog_bitNotClock = dog_bitClock;
+-  dog_bitNotClock ^= 0x0ffff;
+-
+-  dog_bitNotData = dog_bitData;
+-  dog_bitNotData ^= 0x0ffff;
+-}
+-
+-static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val)
+-{
+-  uint8_t cnt = 8;
+-  U8G_ATOMIC_START();
+-  do
+-  {
+-    if ( val & 128 )
+-	*dog_outData |= dog_bitData;
+-    else
+-	*dog_outData &= dog_bitNotData;    
+-    val <<= 1;
+-    //u8g_MicroDelay();
+-    //*dog_outClock |= dog_bitClock;
+-    *dog_outClock &= dog_bitNotClock;
+-    cnt--;
+-    u8g_MicroDelay();
+-    //*dog_outClock &= dog_bitNotClock;
+-    *dog_outClock |= dog_bitClock;
+-    u8g_MicroDelay();
+-    
+-  } while( cnt != 0 );
+-  U8G_ATOMIC_END();
+-}
+-
+-#else
+-
+-/* default interface, Arduino DUE (__arm__) */
+-
+-uint8_t u8g_data_custom_pin;
+-uint8_t u8g_clock_custom_pin;
+-
+-static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin)
+-{
+-  u8g_data_custom_pin = dataPin;
+-  u8g_clock_custom_pin = clockPin;
+-}
+-
+-static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val)
+-{
+-  uint8_t cnt = 8;
+-  do
+-  {
+-    if ( val & 128 )
+-	digitalWrite(u8g_data_custom_pin, HIGH);
+-    else
+-	digitalWrite(u8g_data_custom_pin, LOW);
+-    val <<= 1;
+-    //u8g_MicroDelay();
+-    digitalWrite(u8g_clock_custom_pin, LOW);
+-    cnt--;
+-    u8g_MicroDelay();
+-    digitalWrite(u8g_clock_custom_pin, HIGH);
+-    u8g_MicroDelay();    
+-  } while( cnt != 0 );
+-}
+-
+-#endif 
+-
+-
+-static void u8g_com_arduino_st7920_write_byte_seq(uint8_t rs, uint8_t *ptr, uint8_t len)
+-{
+-  uint8_t i;
+-
+-  if ( rs == 0 )
+-  {
+-    /* command */
+-    u8g_com_arduino_do_shift_out_msb_first(0x0f8);
+-  }
+-  else if ( rs == 1 )
+-  {
+-    /* data */
+-    u8g_com_arduino_do_shift_out_msb_first(0x0fa);
+-  }
+-
+-  while( len > 0 )
+-  {
+-    u8g_com_arduino_do_shift_out_msb_first(*ptr & 0x0f0);
+-    u8g_com_arduino_do_shift_out_msb_first(*ptr << 4);
+-    ptr++;
+-    len--;
+-    u8g_10MicroDelay();
+-  }
+-  
+-  for( i = 0; i < 4; i++ )
+-    u8g_10MicroDelay();
+-}
+-
+-static void u8g_com_arduino_st7920_write_byte(uint8_t rs, uint8_t val)
+-{
+-  uint8_t i;
+-
+-  if ( rs == 0 )
+-  {
+-    /* command */
+-    u8g_com_arduino_do_shift_out_msb_first(0x0f8);
+-  }
+-  else if ( rs == 1 )
+-  {
+-    /* data */
+-    u8g_com_arduino_do_shift_out_msb_first(0x0fa);
+-  }
+-  
+-  u8g_com_arduino_do_shift_out_msb_first(val & 0x0f0);
+-  u8g_com_arduino_do_shift_out_msb_first(val << 4);
+-  
+-  for( i = 0; i < 4; i++ )
+-    u8g_10MicroDelay();
+-    
+-}
+-
+-
+-uint8_t u8g_com_arduino_st7920_custom_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      u8g_com_arduino_assign_pin_output_high(u8g);
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_CS, LOW);
+-      // u8g_com_arduino_digital_write(u8g, U8G_PI_SCK, LOW);
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_SCK, HIGH);
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_MOSI, LOW);
+-      u8g_com_arduino_init_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK]);
+-      u8g->pin_list[U8G_PI_A0_STATE] = 0;       /* inital RS state: command mode */
+-      break;
+-    
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_RESET:
+-      if ( u8g->pin_list[U8G_PI_RESET] != U8G_PIN_NONE )
+-	u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-      
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      if ( arg_val == 0 )
+-      {
+-        /* disable, note: the st7920 has an active high chip select */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, LOW);
+-      }
+-      else
+-      {
+-        /* enable */
+-        //u8g_com_arduino_digital_write(u8g, U8G_PI_SCK, HIGH);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, HIGH);
+-      }
+-      break;
+-
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_com_arduino_st7920_write_byte( u8g->pin_list[U8G_PI_A0_STATE], arg_val);
+-      //u8g->pin_list[U8G_PI_A0_STATE] = 2; 
+-      //u8g_arduino_sw_spi_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK], arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      u8g_com_arduino_st7920_write_byte_seq(u8g->pin_list[U8G_PI_A0_STATE], (uint8_t *)arg_ptr, arg_val);
+-      break;
+-
+-      case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_arduino_st7920_write_byte(u8g->pin_list[U8G_PI_A0_STATE], u8g_pgm_read(ptr) );
+-          //u8g->pin_list[U8G_PI_A0_STATE] = 2; 
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-      
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g->pin_list[U8G_PI_A0_STATE] = arg_val;
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else /* ARDUINO */
+-
+-uint8_t u8g_com_arduino_st7920_custom_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif /* ARDUINO */
+-
+diff --git a/csrc/u8g_com_arduino_st7920_hw_spi.c b/csrc/u8g_com_arduino_st7920_hw_spi.c
+deleted file mode 100644
+index af44c7f..0000000
+--- a/csrc/u8g_com_arduino_st7920_hw_spi.c
++++ /dev/null
+@@ -1,293 +0,0 @@
+-/*
+-  
+-  u8g_com_arduino_st7920_hw_spi.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-
+-  A special HW SPI interface for ST7920 controller
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(ARDUINO)
+-
+-#if ARDUINO < 100 
+-#include <WProgram.h>    
+-#include "wiring_private.h"
+-#include "pins_arduino.h"
+-
+-#else 
+-#include <Arduino.h> 
+-#include "wiring_private.h"
+-#endif
+-
+-#if defined(__AVR__)
+-#define U8G_ARDUINO_ATMEGA_HW_SPI
+-
+-/* remove the definition for attiny */
+-#if __AVR_ARCH__ == 2
+-#undef U8G_ARDUINO_ATMEGA_HW_SPI
+-#endif
+-#if __AVR_ARCH__ == 25
+-#undef U8G_ARDUINO_ATMEGA_HW_SPI
+-#endif
+-
+-#endif
+-
+-
+-#if defined(U8G_ARDUINO_ATMEGA_HW_SPI)
+-
+-#include <avr/interrupt.h>
+-#include <avr/io.h>
+-
+-
+-#if ARDUINO < 100 
+-
+-/* fixed pins */
+-#if defined(__AVR_ATmega644P__) || defined(__AVR_ATmega1284P__) // Sanguino.cc board
+-#define PIN_SCK         7
+-#define PIN_MISO        6
+-#define PIN_MOSI        5
+-#define PIN_CS          4
+-#else                                   // Arduino Board
+-#define PIN_SCK 13
+-#define PIN_MISO  12
+-#define PIN_MOSI 11
+-#define PIN_CS 10
+-#endif // (__AVR_ATmega644P__) || defined(__AVR_ATmega1284P__)
+-
+-#else 
+-
+-/* use Arduino pin definitions */
+-#define PIN_SCK SCK
+-#define PIN_MISO  MISO
+-#define PIN_MOSI MOSI
+-#define PIN_CS SS
+-
+-#endif
+-
+-
+-static uint8_t u8g_arduino_st7920_hw_spi_shift_out(u8g_t *u8g, uint8_t val) U8G_NOINLINE;
+-static uint8_t u8g_arduino_st7920_hw_spi_shift_out(u8g_t *u8g, uint8_t val)
+-{
+-  /* send data */
+-  SPDR = val;
+-  /* wait for transmission */
+-  while (!(SPSR & (1<<SPIF))) 
+-    ;
+-  /* clear the SPIF flag by reading SPDR */
+-  return  SPDR;
+-}
+-
+-
+-static void u8g_com_arduino_st7920_write_byte_hw_spi_seq(u8g_t *u8g, uint8_t rs, uint8_t *ptr, uint8_t len)
+-{
+-  uint8_t i;
+-
+-  if ( rs == 0 )
+-  {
+-    /* command */
+-    u8g_arduino_st7920_hw_spi_shift_out(u8g, 0x0f8);
+-  }
+-  else if ( rs == 1 )
+-  {
+-    /* data */
+-    u8g_arduino_st7920_hw_spi_shift_out(u8g, 0x0fa);
+-  }
+-
+-  while( len > 0 )
+-  {
+-    u8g_arduino_st7920_hw_spi_shift_out(u8g, *ptr & 0x0f0);
+-    u8g_arduino_st7920_hw_spi_shift_out(u8g, *ptr << 4);
+-    ptr++;
+-    len--;
+-    u8g_10MicroDelay();
+-  }
+-  
+-  for( i = 0; i < 4; i++ )
+-    u8g_10MicroDelay();
+-}
+-
+-static void u8g_com_arduino_st7920_write_byte_hw_spi(u8g_t *u8g, uint8_t rs, uint8_t val) U8G_NOINLINE;
+-static void u8g_com_arduino_st7920_write_byte_hw_spi(u8g_t *u8g, uint8_t rs, uint8_t val)
+-{
+-  uint8_t i;
+-
+-  if ( rs == 0 )
+-  {
+-    /* command */
+-    u8g_arduino_st7920_hw_spi_shift_out(u8g, 0x0f8);
+-  }
+-  else if ( rs == 1 )
+-  {
+-    /* data */
+-    u8g_arduino_st7920_hw_spi_shift_out(u8g, 0x0fa);
+-  }
+-  else
+-  {
+-    /* do nothing, keep same state */
+-  }
+-  
+-  u8g_arduino_st7920_hw_spi_shift_out(u8g, val & 0x0f0);
+-  u8g_arduino_st7920_hw_spi_shift_out(u8g, val << 4);
+-
+-  for( i = 0; i < 4; i++ )
+-    u8g_10MicroDelay();
+-}
+-
+-
+-uint8_t u8g_com_arduino_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      u8g_com_arduino_assign_pin_output_high(u8g);
+-      
+-      
+-      /* code from u8g_com-arduino_hw_spi.c */
+-      pinMode(PIN_SCK, OUTPUT);
+-      digitalWrite(PIN_SCK, LOW);
+-      pinMode(PIN_MOSI, OUTPUT);
+-      digitalWrite(PIN_MOSI, LOW);
+-      /* pinMode(PIN_MISO, INPUT); */
+-
+-      pinMode(PIN_CS, OUTPUT);			/* system chip select for the atmega board */
+-      digitalWrite(PIN_CS, HIGH);
+-      
+-      
+-      //u8g_com_arduino_digital_write(u8g, U8G_PI_CS, LOW);
+-      
+-#ifdef OBSOLETE      
+-      DDRB |= _BV(3);          /* D0, MOSI */
+-      DDRB |= _BV(5);          /* SCK */
+-      DDRB |= _BV(2);		/* slave select */
+-    
+-      PORTB &= ~_BV(3);        /* D0, MOSI = 0 */
+-      PORTB &= ~_BV(5);        /* SCK = 0 */
+-#endif
+-
+-      /*
+-        SPR1 SPR0
+-            0	0		fclk/4
+-            0	1		fclk/16 
+-            1	0		fclk/64  
+-            1	1		fclk/128
+-      */
+-      SPCR = 0;
+-      
+-      /* 20 Dez 2012: set CPOL and CPHA to 1 !!! */
+-      SPCR =  (1<<SPE) | (1<<MSTR)|(0<<SPR1)|(0<<SPR0)|(1<<CPOL)|(1<<CPHA);
+-#ifdef U8G_HW_SPI_2X
+-      SPSR = (1 << SPI2X);  /* double speed, issue 89 */
+-#endif
+-      u8g->pin_list[U8G_PI_A0_STATE] = 0;       /* inital RS state: command mode */
+-      break;
+-    
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_RESET:
+-      if ( u8g->pin_list[U8G_PI_RESET] != U8G_PIN_NONE )
+-	u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-      
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      if ( arg_val == 0 )
+-      {
+-        /* disable, note: the st7920 has an active high chip select */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, LOW);
+-      }
+-      else
+-      {
+-        /* enable */
+-        //u8g_com_arduino_digital_write(u8g, U8G_PI_SCK, LOW);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, HIGH);
+-      }
+-      break;
+-
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_com_arduino_st7920_write_byte_hw_spi(u8g,  u8g->pin_list[U8G_PI_A0_STATE], arg_val);
+-      // u8g->pin_list[U8G_PI_A0_STATE] = 2; 
+-      //u8g_arduino_sw_spi_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK], arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      u8g_com_arduino_st7920_write_byte_hw_spi_seq(u8g, u8g->pin_list[U8G_PI_A0_STATE], (uint8_t *)arg_ptr, arg_val);
+-      /*
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_arduino_st7920_write_byte_hw_spi(u8g, u8g->pin_list[U8G_PI_A0_STATE], *ptr++);
+-          arg_val--;
+-        }
+-      }
+-      */
+-      
+-      break;
+-
+-      case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_arduino_st7920_write_byte_hw_spi(u8g, u8g->pin_list[U8G_PI_A0_STATE], u8g_pgm_read(ptr) );
+-          // u8g->pin_list[U8G_PI_A0_STATE] = 2; 
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-      
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g->pin_list[U8G_PI_A0_STATE] = arg_val;
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-uint8_t u8g_com_arduino_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-#endif
+-
+-#else /* ARDUINO */
+-
+-uint8_t u8g_com_arduino_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif /* ARDUINO */
+-
+diff --git a/csrc/u8g_com_arduino_st7920_spi.c b/csrc/u8g_com_arduino_st7920_spi.c
+deleted file mode 100644
+index 9a5c2be..0000000
+--- a/csrc/u8g_com_arduino_st7920_spi.c
++++ /dev/null
+@@ -1,330 +0,0 @@
+-/*
+-  
+-  u8g_com_arduino_st7920_spi.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-
+-  A special SPI interface for ST7920 controller
+-
+-  Update for ATOMIC operation done (01 Jun 2013)
+-    U8G_ATOMIC_OR(ptr, val)
+-    U8G_ATOMIC_AND(ptr, val)
+-    U8G_ATOMIC_START();
+-    U8G_ATOMIC_END();
+-
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(ARDUINO)
+-
+-#if ARDUINO < 100 
+-#include <WProgram.h>    
+-#include "wiring_private.h"
+-#include "pins_arduino.h"
+-
+-#else 
+-#include <Arduino.h> 
+-#include "wiring_private.h"
+-#endif
+-
+-#if defined(__AVR__)
+-
+-static uint8_t u8g_bitData, u8g_bitNotData;
+-static uint8_t u8g_bitClock, u8g_bitNotClock;
+-static volatile uint8_t *u8g_outData;
+-static volatile uint8_t *u8g_outClock;
+-
+-static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin)
+-{
+-  u8g_outData = portOutputRegister(digitalPinToPort(dataPin));
+-  u8g_outClock = portOutputRegister(digitalPinToPort(clockPin));
+-  u8g_bitData = digitalPinToBitMask(dataPin);
+-  u8g_bitClock = digitalPinToBitMask(clockPin);
+-
+-  u8g_bitNotClock = u8g_bitClock;
+-  u8g_bitNotClock ^= 0x0ff;
+-
+-  u8g_bitNotData = u8g_bitData;
+-  u8g_bitNotData ^= 0x0ff;
+-}
+-
+-static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val) U8G_NOINLINE;
+-static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val)
+-{
+-  uint8_t cnt = 8;
+-  uint8_t bitData = u8g_bitData;
+-  uint8_t bitNotData = u8g_bitNotData;
+-  uint8_t bitClock = u8g_bitClock;
+-  uint8_t bitNotClock = u8g_bitNotClock;
+-  volatile uint8_t *outData = u8g_outData;
+-  volatile uint8_t *outClock = u8g_outClock;
+-  
+-  
+-  U8G_ATOMIC_START();
+-  bitData |= *outData;
+-  bitNotData &= *outData;
+-  do
+-  {
+-    if ( val & 128 )
+-      *outData = bitData;
+-    else
+-      *outData = bitNotData;
+-
+-    /*
+-    *outClock |= bitClock;
+-    val <<= 1;
+-    cnt--;
+-    *outClock &= bitNotClock;
+-    */
+-
+-    val <<= 1;
+-    *outClock &= bitNotClock;
+-    cnt--;
+-    // removed micro delays, because AVRs are too slow and the delay is not required
+-    //u8g_MicroDelay();
+-    *outClock |= bitClock;
+-    //u8g_MicroDelay();
+-  } while( cnt != 0 );
+-  U8G_ATOMIC_END();
+-}
+-
+-#elif defined(__18CXX) || defined(__PIC32MX)
+-
+-uint16_t dog_bitData, dog_bitNotData;
+-uint16_t dog_bitClock, dog_bitNotClock;
+-volatile uint32_t *dog_outData;
+-volatile uint32_t *dog_outClock;
+-volatile uint32_t dog_pic32_spi_tmp;
+-
+-static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin)
+-{
+-  dog_outData = portOutputRegister(digitalPinToPort(dataPin));
+-  dog_outClock = portOutputRegister(digitalPinToPort(clockPin));
+-  dog_bitData = digitalPinToBitMask(dataPin);
+-  dog_bitClock = digitalPinToBitMask(clockPin);
+-
+-  dog_bitNotClock = dog_bitClock;
+-  dog_bitNotClock ^= 0x0ffff;
+-
+-  dog_bitNotData = dog_bitData;
+-  dog_bitNotData ^= 0x0ffff;
+-}
+-
+-static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val)
+-{
+-  uint8_t cnt = 8;
+-  U8G_ATOMIC_START();
+-  do
+-  {
+-    if ( val & 128 )
+-	*dog_outData |= dog_bitData;
+-    else
+-	*dog_outData &= dog_bitNotData;    
+-    val <<= 1;
+-    //u8g_MicroDelay();
+-    //*dog_outClock |= dog_bitClock;
+-    *dog_outClock &= dog_bitNotClock;
+-    cnt--;
+-    u8g_MicroDelay();
+-    //*dog_outClock &= dog_bitNotClock;
+-    *dog_outClock |= dog_bitClock;
+-    u8g_MicroDelay();
+-    
+-  } while( cnt != 0 );
+-  U8G_ATOMIC_END();
+-}
+-
+-#else
+-
+-/* default interface, Arduino DUE (__arm__) */
+-
+-uint8_t u8g_data_pin;
+-uint8_t u8g_clock_pin;
+-
+-static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin)
+-{
+-  u8g_data_pin = dataPin;
+-  u8g_clock_pin = clockPin;
+-}
+-
+-static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val)
+-{
+-  uint8_t cnt = 8;
+-  do
+-  {
+-    if ( val & 128 )
+-	digitalWrite(u8g_data_pin, HIGH);
+-    else
+-	digitalWrite(u8g_data_pin, LOW);
+-    val <<= 1;
+-    //u8g_MicroDelay();
+-    digitalWrite(u8g_clock_pin, LOW);
+-    cnt--;
+-    u8g_MicroDelay();
+-    digitalWrite(u8g_clock_pin, HIGH);
+-    u8g_MicroDelay();    
+-  } while( cnt != 0 );
+-}
+-
+-#endif 
+-
+-
+-static void u8g_com_arduino_st7920_write_byte_seq(uint8_t rs, uint8_t *ptr, uint8_t len)
+-{
+-  uint8_t i;
+-
+-  if ( rs == 0 )
+-  {
+-    /* command */
+-    u8g_com_arduino_do_shift_out_msb_first(0x0f8);
+-  }
+-  else if ( rs == 1 )
+-  {
+-    /* data */
+-    u8g_com_arduino_do_shift_out_msb_first(0x0fa);
+-  }
+-
+-  while( len > 0 )
+-  {
+-    u8g_com_arduino_do_shift_out_msb_first(*ptr & 0x0f0);
+-    u8g_com_arduino_do_shift_out_msb_first(*ptr << 4);
+-    ptr++;
+-    len--;
+-    u8g_10MicroDelay();
+-  }
+-  
+-  for( i = 0; i < 4; i++ )
+-    u8g_10MicroDelay();
+-}
+-
+-static void u8g_com_arduino_st7920_write_byte(uint8_t rs, uint8_t val)
+-{
+-  uint8_t i;
+-
+-  if ( rs == 0 )
+-  {
+-    /* command */
+-    u8g_com_arduino_do_shift_out_msb_first(0x0f8);
+-  }
+-  else if ( rs == 1 )
+-  {
+-    /* data */
+-    u8g_com_arduino_do_shift_out_msb_first(0x0fa);
+-  }
+-  
+-  u8g_com_arduino_do_shift_out_msb_first(val & 0x0f0);
+-  u8g_com_arduino_do_shift_out_msb_first(val << 4);
+-  
+-  for( i = 0; i < 4; i++ )
+-    u8g_10MicroDelay();
+-    
+-}
+-
+-
+-uint8_t u8g_com_arduino_st7920_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      u8g_com_arduino_assign_pin_output_high(u8g);
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_CS, LOW);
+-      // u8g_com_arduino_digital_write(u8g, U8G_PI_SCK, LOW);
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_SCK, HIGH);
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_MOSI, LOW);
+-      u8g_com_arduino_init_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK]);
+-      u8g->pin_list[U8G_PI_A0_STATE] = 0;       /* inital RS state: command mode */
+-      break;
+-    
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_RESET:
+-      if ( u8g->pin_list[U8G_PI_RESET] != U8G_PIN_NONE )
+-	u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-      
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      if ( arg_val == 0 )
+-      {
+-        /* disable, note: the st7920 has an active high chip select */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, LOW);
+-      }
+-      else
+-      {
+-        /* enable */
+-        //u8g_com_arduino_digital_write(u8g, U8G_PI_SCK, HIGH);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, HIGH);
+-	/* 28 Dec 2013 reassign pins, fixes issue with more than one display */
+-	/* issue 227 */
+-	u8g_com_arduino_init_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK]);
+-      }
+-      break;
+-
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_com_arduino_st7920_write_byte( u8g->pin_list[U8G_PI_A0_STATE], arg_val);
+-      //u8g->pin_list[U8G_PI_A0_STATE] = 2; 
+-      //u8g_arduino_sw_spi_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK], arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      u8g_com_arduino_st7920_write_byte_seq(u8g->pin_list[U8G_PI_A0_STATE], (uint8_t *)arg_ptr, arg_val);
+-      break;
+-
+-      case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_arduino_st7920_write_byte(u8g->pin_list[U8G_PI_A0_STATE], u8g_pgm_read(ptr) );
+-          //u8g->pin_list[U8G_PI_A0_STATE] = 2; 
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-      
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g->pin_list[U8G_PI_A0_STATE] = arg_val;
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else /* ARDUINO */
+-
+-uint8_t u8g_com_arduino_st7920_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif /* ARDUINO */
+-
+diff --git a/csrc/u8g_com_arduino_std_sw_spi.c b/csrc/u8g_com_arduino_std_sw_spi.c
+deleted file mode 100644
+index 048ac1a..0000000
+--- a/csrc/u8g_com_arduino_std_sw_spi.c
++++ /dev/null
+@@ -1,143 +0,0 @@
+-/*
+-  
+-  u8g_arduino_std_sw_spi.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
+-*/
+-
+-#include "u8g.h"
+-
+-
+-#if defined(ARDUINO)
+-
+-#if ARDUINO < 100 
+-#include <WProgram.h>
+-#else 
+-#include <Arduino.h> 
+-#endif
+-
+-void u8g_arduino_sw_spi_shift_out(uint8_t dataPin, uint8_t clockPin, uint8_t val)
+-{
+-  uint8_t i = 8;
+-  do
+-  {
+-    if ( val & 128 )
+-      digitalWrite(dataPin, HIGH);
+-    else
+-      digitalWrite(dataPin, LOW);
+-    val <<= 1;
+-    u8g_MicroDelay();		/* 23 Sep 2012 */
+-    //delay(1);
+-    digitalWrite(clockPin, HIGH);
+-    u8g_MicroDelay();		/* 23 Sep 2012 */
+-    //delay(1);
+-    digitalWrite(clockPin, LOW);		
+-    u8g_MicroDelay();		/* 23 Sep 2012 */
+-    //delay(1);
+-    i--;
+-  } while( i != 0 );
+-}
+-
+-uint8_t u8g_com_arduino_std_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      u8g_com_arduino_assign_pin_output_high(u8g);
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_SCK, LOW);
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_MOSI, LOW);
+-      break;
+-    
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_RESET:
+-      if ( u8g->pin_list[U8G_PI_RESET] != U8G_PIN_NONE )
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-      
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      if ( arg_val == 0 )
+-      {
+-        /* disable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, HIGH);
+-      }
+-      else
+-      {
+-        /* enable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_SCK, LOW);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, LOW);
+-      }
+-      break;
+-
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_arduino_sw_spi_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK], arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_arduino_sw_spi_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK], *ptr++);
+-          arg_val--;
+-        }
+-      }
+-      break;
+-
+-      case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_arduino_sw_spi_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK], u8g_pgm_read(ptr));
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-      
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_A0, arg_val);
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else /* ARDUINO */
+-
+-uint8_t u8g_com_arduino_std_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif /* ARDUINO */
+-
+diff --git a/csrc/u8g_com_arduino_sw_spi.c b/csrc/u8g_com_arduino_sw_spi.c
+deleted file mode 100644
+index 7752adc..0000000
+--- a/csrc/u8g_com_arduino_sw_spi.c
++++ /dev/null
+@@ -1,301 +0,0 @@
+-/*
+-  
+-  u8g_arduino_sw_spi.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
+-  Update for ATOMIC operation done (01 Jun 2013)
+-    U8G_ATOMIC_OR(ptr, val)
+-    U8G_ATOMIC_AND(ptr, val)
+-    U8G_ATOMIC_START();
+-    U8G_ATOMIC_END();
+- 
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(ARDUINO)
+-
+-#if ARDUINO < 100 
+-#include <WProgram.h>    
+-#include "wiring_private.h"
+-#include "pins_arduino.h"
+-
+-#else 
+-#include <Arduino.h> 
+-#include "wiring_private.h"
+-#endif
+-
+-/*=========================================================*/
+-/* Arduino, AVR */
+-
+-#if defined(__AVR__)
+-
+-uint8_t u8g_bitData, u8g_bitNotData;
+-uint8_t u8g_bitClock, u8g_bitNotClock;
+-volatile uint8_t *u8g_outData;
+-volatile uint8_t *u8g_outClock;
+-
+-static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin)
+-{
+-  u8g_outData = portOutputRegister(digitalPinToPort(dataPin));
+-  u8g_outClock = portOutputRegister(digitalPinToPort(clockPin));
+-  u8g_bitData = digitalPinToBitMask(dataPin);
+-  u8g_bitClock = digitalPinToBitMask(clockPin);
+-
+-  u8g_bitNotClock = u8g_bitClock;
+-  u8g_bitNotClock ^= 0x0ff;
+-
+-  u8g_bitNotData = u8g_bitData;
+-  u8g_bitNotData ^= 0x0ff;
+-}
+-
+-static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val) U8G_NOINLINE;
+-static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val)
+-{
+-  uint8_t cnt = 8;
+-  uint8_t bitData = u8g_bitData;
+-  uint8_t bitNotData = u8g_bitNotData;
+-  uint8_t bitClock = u8g_bitClock;
+-  uint8_t bitNotClock = u8g_bitNotClock;
+-  volatile uint8_t *outData = u8g_outData;
+-  volatile uint8_t *outClock = u8g_outClock;
+-  U8G_ATOMIC_START();
+-  do
+-  {
+-    if ( val & 128 )
+-      *outData |= bitData;
+-    else
+-      *outData &= bitNotData;
+-   
+-    *outClock |= bitClock;
+-    val <<= 1;
+-    cnt--;
+-    *outClock &= bitNotClock;
+-  } while( cnt != 0 );
+-  U8G_ATOMIC_END();
+-}
+-
+-/*=========================================================*/
+-/* Arduino, Chipkit */
+-#elif defined(__18CXX) || defined(__PIC32MX)
+-
+-uint16_t dog_bitData, dog_bitNotData;
+-uint16_t dog_bitClock, dog_bitNotClock;
+-volatile uint32_t *dog_outData;
+-volatile uint32_t *dog_outClock;
+-volatile uint32_t dog_pic32_spi_tmp;
+-
+-static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin)
+-{
+-  dog_outData = portOutputRegister(digitalPinToPort(dataPin));
+-  dog_outClock = portOutputRegister(digitalPinToPort(clockPin));
+-  dog_bitData = digitalPinToBitMask(dataPin);
+-  dog_bitClock = digitalPinToBitMask(clockPin);
+-
+-  dog_bitNotClock = dog_bitClock;
+-  dog_bitNotClock ^= 0x0ffff;
+-
+-  dog_bitNotData = dog_bitData;
+-  dog_bitNotData ^= 0x0ffff;
+-}
+-
+-static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val)
+-{
+-  uint8_t cnt = 8;
+-  U8G_ATOMIC_START();
+-  do
+-  {
+-    if ( val & 128 )
+-	*dog_outData |= dog_bitData;
+-    else
+-	*dog_outData &= dog_bitNotData;    
+-    val <<= 1;
+-    /*
+-	There must be some delay here. However
+-	fetching the adress dog_outClock is enough delay, so
+-	do not place dog_outClock in a local variable. This will
+-	break the procedure
+-    */
+-    *dog_outClock |= dog_bitClock;
+-    cnt--;
+-    *dog_outClock &= dog_bitNotClock;
+-    /* 
+-	little additional delay after clk pulse, done by 3x32bit reads 
+-	from I/O. Optimized for PIC32 with 80 MHz.
+-    */
+-    dog_pic32_spi_tmp = *dog_outClock;
+-    dog_pic32_spi_tmp = *dog_outClock;
+-    dog_pic32_spi_tmp = *dog_outClock;
+-  } while( cnt != 0 );
+-  U8G_ATOMIC_END();
+-}
+-
+-/*=========================================================*/
+-/* Arduino Due */
+-#elif defined(__SAM3X8E__)
+-
+-/* Due */
+-
+-void u8g_digital_write_sam_high(uint8_t pin)
+-{
+-    PIO_Set( g_APinDescription[pin].pPort, g_APinDescription[pin].ulPin) ;
+-}
+-
+-void u8g_digital_write_sam_low(uint8_t pin)
+-{
+-    PIO_Clear( g_APinDescription[pin].pPort, g_APinDescription[pin].ulPin) ;
+-}
+-
+-static uint8_t u8g_sam_data_pin;
+-static uint8_t u8g_sam_clock_pin;
+-
+-static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin)
+-{
+-  u8g_sam_data_pin = dataPin;
+-  u8g_sam_clock_pin = clockPin;
+-}
+-
+-static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val)
+-{
+-  uint8_t i = 8;
+-  do
+-  {
+-    if ( val & 128 )
+-      u8g_digital_write_sam_high(u8g_sam_data_pin);
+-    else
+-      u8g_digital_write_sam_low(u8g_sam_data_pin);
+-    val <<= 1;
+-    //u8g_MicroDelay();	
+-    u8g_digital_write_sam_high(u8g_sam_clock_pin);
+-    u8g_MicroDelay();	
+-    u8g_digital_write_sam_low(u8g_sam_clock_pin);
+-    u8g_MicroDelay();	
+-    i--;
+-  } while( i != 0 );
+-}
+-
+-
+-#else
+-/* empty interface */
+-
+-static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin)
+-{
+-}
+-
+-static void u8g_com_arduino_do_shift_out_msb_first(uint8_t val)
+-{
+-}
+-
+-#endif 
+-
+-
+-uint8_t u8g_com_arduino_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      u8g_com_arduino_assign_pin_output_high(u8g);
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_SCK, LOW);
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_MOSI, LOW);
+-      u8g_com_arduino_init_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK]);
+-      break;
+-    
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_RESET:
+-      if ( u8g->pin_list[U8G_PI_RESET] != U8G_PIN_NONE )
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-      
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      if ( arg_val == 0 )
+-      {
+-        /* disable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, HIGH);
+-      }
+-      else
+-      {
+-        /* enable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_SCK, LOW);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, LOW);
+-	/* issue 227 */
+-	u8g_com_arduino_init_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK]);
+-      }
+-      break;
+-
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_com_arduino_do_shift_out_msb_first( arg_val );
+-      //u8g_arduino_sw_spi_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK], arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_arduino_do_shift_out_msb_first(*ptr++);
+-          // u8g_arduino_sw_spi_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK], *ptr++);
+-          arg_val--;
+-        }
+-      }
+-      break;
+-
+-      case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_arduino_do_shift_out_msb_first( u8g_pgm_read(ptr) );
+-          //u8g_arduino_sw_spi_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK], u8g_pgm_read(ptr));
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-      
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g_com_arduino_digital_write(u8g, U8G_PI_A0, arg_val);
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else /* ARDUINO */
+-
+-uint8_t u8g_com_arduino_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif /* ARDUINO */
+-
+diff --git a/csrc/u8g_com_arduino_t6963.c b/csrc/u8g_com_arduino_t6963.c
+deleted file mode 100644
+index 50e5e93..0000000
+--- a/csrc/u8g_com_arduino_t6963.c
++++ /dev/null
+@@ -1,403 +0,0 @@
+-/*
+-  
+-  u8g_com_arduino_t6963.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-
+-
+-  PIN_D0 8
+-  PIN_D1 9
+-  PIN_D2 10
+-  PIN_D3 11
+-  PIN_D4 4
+-  PIN_D5 5
+-  PIN_D6 6
+-  PIN_D7 7
+-
+-  PIN_CS 14
+-  PIN_A0 15
+-  PIN_RESET 16
+-  PIN_WR 17
+-  PIN_RD 18
+-  
+-  u8g_InitRW8Bit(u8g, dev, d0, d1, d2, d3, d4, d5, d6, d7, cs, a0, wr, rd, reset)
+-  u8g_InitRW8Bit(u8g, dev,  8,  9, 10, 11,  4,  5,  6,  7, 14, 15, 17, 18, 16)
+-
+-  Update for ATOMIC operation done (01 Jun 2013)
+-    U8G_ATOMIC_OR(ptr, val)
+-    U8G_ATOMIC_AND(ptr, val)
+-    U8G_ATOMIC_START();
+-    U8G_ATOMIC_END();
+- 
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if  defined(ARDUINO)
+-
+-#if ARDUINO < 100 
+-//#include <WProgram.h> 
+-#include <wiring_private.h> 
+-#include <pins_arduino.h> 
+-#else 
+-#include <Arduino.h> 
+-#endif
+-
+-
+-#if defined(__PIC32MX)
+-/* CHIPKIT PIC32 */
+-static volatile uint32_t *u8g_output_data_port[8];
+-static volatile uint32_t *u8g_input_data_port[8];
+-static volatile uint32_t *u8g_mode_port[8];
+-static uint32_t u8g_data_mask[8];
+-#else
+-static volatile uint8_t *u8g_output_data_port[8];
+-static volatile uint8_t *u8g_input_data_port[8];
+-static volatile uint8_t *u8g_mode_port[8];
+-static uint8_t u8g_data_mask[8];
+-#endif
+-
+-
+-
+-static void u8g_com_arduino_t6963_init(u8g_t *u8g)
+-{
+-  u8g_output_data_port[0] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D0]));
+-  u8g_input_data_port[0] =  portInputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D0]));
+-  u8g_mode_port[0] =  portModeRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D0]));
+-  u8g_data_mask[0] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D0]);
+-  
+-  u8g_output_data_port[1] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D1]));
+-  u8g_input_data_port[1] =  portInputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D1]));
+-  u8g_mode_port[1] =  portModeRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D1]));
+-  u8g_data_mask[1] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D1]);
+-  
+-  u8g_output_data_port[2] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D2]));
+-  u8g_input_data_port[2] =  portInputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D2]));
+-  u8g_mode_port[2] =  portModeRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D2]));
+-  u8g_data_mask[2] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D2]);
+-  
+-  u8g_output_data_port[3] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D3]));
+-  u8g_input_data_port[3] =  portInputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D3]));
+-  u8g_mode_port[3] =  portModeRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D3]));
+-  u8g_data_mask[3] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D3]);
+-  
+-  u8g_output_data_port[4] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D4]));
+-  u8g_input_data_port[4] =  portInputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D4]));
+-  u8g_mode_port[4] =  portModeRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D4]));
+-  u8g_data_mask[4] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D4]);
+-  
+-  u8g_output_data_port[5] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D5]));
+-  u8g_input_data_port[5] =  portInputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D5]));
+-  u8g_mode_port[5] =  portModeRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D5]));
+-  u8g_data_mask[5] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D5]);
+-  
+-  u8g_output_data_port[6] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D6]));
+-  u8g_input_data_port[6] =  portInputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D6]));
+-  u8g_mode_port[6] =  portModeRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D6]));
+-  u8g_data_mask[6] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D6]);
+-  
+-  u8g_output_data_port[7] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D7]));
+-  u8g_input_data_port[7] =  portInputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D7]));
+-  u8g_mode_port[7] =  portModeRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D7]));
+-  u8g_data_mask[7] =  digitalPinToBitMask(u8g->pin_list[U8G_PI_D7]);  
+-}
+-
+-
+-static void u8g_com_arduino_t6963_write_data_pin(uint8_t pin, uint8_t val)
+-{
+-  /* no ATOMIC protection required here, this is done by calling procedure */
+-  if ( val != 0 )
+-    *u8g_output_data_port[pin] |= u8g_data_mask[pin];
+-  else
+-    *u8g_output_data_port[pin] &= ~u8g_data_mask[pin];
+-}
+-
+-static void u8g_com_arduino_t6963_set_port_output(void)
+-{
+-  uint8_t i;
+-  U8G_ATOMIC_START();
+-  for( i = 0; i < 8; i++ )
+-  {
+-#if defined(__PIC32MX)
+-/* CHIPKIT PIC32 */
+-      *u8g_mode_port[i] |= u8g_data_mask[i]; 
+-#elif defined(__AVR__)
+-      *u8g_mode_port[i] |= u8g_data_mask[i]; 
+-#else
+-      /* TODO: use generic Arduino API */
+-      *u8g_mode_port[i] |= u8g_data_mask[i]; 
+-#endif
+-
+-  }
+-  U8G_ATOMIC_END();
+-}
+-
+-static void u8g_com_arduino_t6963_set_port_input(void)
+-{
+-  uint8_t i;
+-  U8G_ATOMIC_START();
+-  for( i = 0; i < 8; i++ )
+-  {
+-#if defined(__PIC32MX)
+-/* CHIPKIT PIC32 */
+-      *u8g_mode_port[i] &= ~u8g_data_mask[i]; 
+-#elif defined(__AVR__)
+-/* avr */
+-      *u8g_mode_port[i] &= ~u8g_data_mask[i]; 
+-      *u8g_output_data_port[i] &= ~u8g_data_mask[i]; 	// no pullup
+-#else
+-      /* TODO: use generic Arduino API */
+-      *u8g_mode_port[i] &= ~u8g_data_mask[i]; 
+-      *u8g_output_data_port[i] &= ~u8g_data_mask[i]; 	// no pullup
+-#endif
+-  }
+-  U8G_ATOMIC_END();
+-}
+-
+-
+-static void u8g_com_arduino_t6963_write(u8g_t *u8g, uint8_t val)
+-{
+-  U8G_ATOMIC_START();
+-
+-  u8g_com_arduino_t6963_write_data_pin( 0, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_t6963_write_data_pin( 1, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_t6963_write_data_pin( 2, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_t6963_write_data_pin( 3, val&1 );
+-  val >>= 1;
+-
+-  u8g_com_arduino_t6963_write_data_pin( 4, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_t6963_write_data_pin( 5, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_t6963_write_data_pin( 6, val&1 );
+-  val >>= 1;
+-  u8g_com_arduino_t6963_write_data_pin( 7, val&1 );
+-  val >>= 1;
+-  U8G_ATOMIC_END();
+-  
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_WR, 0);
+-  u8g_MicroDelay(); /* 80ns, reference: t6963 datasheet */
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_WR, 1);
+-  u8g_MicroDelay(); /* 10ns, reference: t6963 datasheet */
+-}
+-
+-static uint8_t u8g_com_arduino_t6963_read(u8g_t *u8g)
+-{
+-  uint8_t val = 0;
+-  
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_RD, 0);
+-  u8g_MicroDelay(); /* 150ns, reference: t6963 datasheet */
+-  
+-  U8G_ATOMIC_START();
+-  /* only read bits 0, 1 and 3 */
+-  if ( (*u8g_input_data_port[3] & u8g_data_mask[3]) != 0 )
+-    val++;
+-  val <<= 1;
+-  val <<= 1;
+-  if ( (*u8g_input_data_port[1] & u8g_data_mask[1]) != 0 )
+-    val++;
+-  val <<= 1;
+-  if ( (*u8g_input_data_port[0] & u8g_data_mask[0]) != 0 )
+-    val++;
+-  U8G_ATOMIC_END();
+-
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_RD, 1);
+-  u8g_MicroDelay(); /* 10ns, reference: t6963 datasheet */
+-  
+-  return val;
+-}
+-
+-#define U8G_STATUS_TIMEOUT 50
+-
+-static uint8_t u8g_com_arduino_t6963_until_01_ok(u8g_t *u8g)
+-{
+-  long x;
+-  
+-  u8g_com_arduino_t6963_set_port_input();
+-  x = millis();
+-  x += U8G_STATUS_TIMEOUT;
+-
+-  for(;;)
+-  {    
+-    if ( (u8g_com_arduino_t6963_read(u8g) & 3) == 3 )
+-      break;
+-    if ( x < millis() )
+-      return 0;
+-  }
+-  u8g_com_arduino_t6963_set_port_output();
+-  return 1;
+-}
+-
+-static uint8_t u8g_com_arduino_t6963_until_3_ok(u8g_t *u8g)
+-{
+-  long x;
+-  
+-  u8g_com_arduino_t6963_set_port_input();
+-  x = millis();
+-  x += U8G_STATUS_TIMEOUT;
+-
+-  for(;;)
+-  {    
+-    if ( (u8g_com_arduino_t6963_read(u8g) & 8) == 8 )
+-      break;
+-    if ( x < millis() )
+-      return 0;
+-  }
+-  u8g_com_arduino_t6963_set_port_output();
+-  return 1;
+-}
+-
+-static uint8_t u8g_com_arduino_t6963_write_cmd(u8g_t *u8g, uint8_t val)
+-{
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_A0, 1);
+-  if ( u8g_com_arduino_t6963_until_01_ok(u8g) == 0 )
+-    return 0;
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_A0, 1);
+-  u8g_com_arduino_t6963_write(u8g, val);
+-  return 1;  
+-}
+-
+-static uint8_t u8g_com_arduino_t6963_write_data(u8g_t *u8g, uint8_t val)
+-{
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_A0, 1);
+-  if ( u8g_com_arduino_t6963_until_01_ok(u8g) == 0 )
+-    return 0;
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_A0, 0);
+-  u8g_com_arduino_t6963_write(u8g, val);
+-  return 1;  
+-}
+-
+-static uint8_t u8g_com_arduino_t6963_write_auto_data(u8g_t *u8g, uint8_t val)
+-{
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_A0, 1);
+-  if ( u8g_com_arduino_t6963_until_3_ok(u8g) == 0 )
+-    return 0;
+-  u8g_com_arduino_digital_write(u8g, U8G_PI_A0, 0);
+-  u8g_com_arduino_t6963_write(u8g, val);
+-  return 1;  
+-}
+-
+-
+-uint8_t u8g_com_arduino_t6963_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      u8g->pin_list[U8G_PI_A0_STATE] = 0;
+-      u8g_com_arduino_t6963_init(u8g);
+-      /* setup the RW (equal to WR) pin as output and force it to high */
+-      if ( u8g->pin_list[U8G_PI_WR] != U8G_PIN_NONE )
+-      {
+-        pinMode(u8g->pin_list[U8G_PI_WR], OUTPUT);
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_WR, HIGH);
+-      }
+-      /* set all pins (except WR pin) */
+-      u8g_com_arduino_assign_pin_output_high(u8g);
+-      break;
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      if ( arg_val == 0 )
+-      {
+-        /* disable, active low chip select */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, HIGH);
+-      }
+-      else
+-      {
+-        /* enable */
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_CS, LOW);
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      if ( u8g->pin_list[U8G_PI_A0_STATE] == 0 )
+-      {
+-	u8g_com_arduino_t6963_write_data(u8g, arg_val);
+-      }
+-      else
+-      {
+-	u8g_com_arduino_t6963_write_cmd(u8g, arg_val);
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-	u8g_com_arduino_t6963_write_cmd(u8g, 0x0b0);	/* auto write */
+-        while( arg_val > 0 )
+-        {
+-          if ( u8g_com_arduino_t6963_write_auto_data(u8g, *ptr++) == 0 )
+-	    break;
+-          arg_val--;
+-        }
+-	u8g_com_arduino_t6963_write_cmd(u8g, 0x0b2);	/* auto reset */
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-	u8g_com_arduino_t6963_write_cmd(u8g, 0x0b0);	/* auto write */
+-        while( arg_val > 0 )
+-        {
+-          if ( u8g_com_arduino_t6963_write_auto_data(u8g, u8g_pgm_read(ptr)) == 0 )
+-	    break;
+-          ptr++;
+-          arg_val--;
+-        }
+-	u8g_com_arduino_t6963_write_cmd(u8g, 0x0b2);	/* auto reset */
+-      }
+-      break;
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 1) or data mode (arg_val = 0) */
+-      u8g->pin_list[U8G_PI_A0_STATE] = arg_val;
+-      //u8g_com_arduino_digital_write(u8g, U8G_PI_DI, arg_val);
+-      break;
+-    case U8G_COM_MSG_RESET:
+-      if ( u8g->pin_list[U8G_PI_RESET] != U8G_PIN_NONE )
+-        u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-      
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-
+-uint8_t u8g_com_arduino_t6963_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-
+-#endif /* ARDUINO */
+-
+diff --git a/csrc/u8g_com_arduino_uc_i2c.c b/csrc/u8g_com_arduino_uc_i2c.c
+deleted file mode 100644
+index 2637668..0000000
+--- a/csrc/u8g_com_arduino_uc_i2c.c
++++ /dev/null
+@@ -1,206 +0,0 @@
+-/*
+-  
+-  u8g_com_arduino_uc_i2c.c
+-
+-  com interface for arduino (AND atmega) and the SSDxxxx chip (SOLOMON) variant 
+-  I2C protocol 
+-  
+-  ToDo: Rename this to u8g_com_avr_ssd_i2c.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2012, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
+-  Special pin usage:
+-    U8G_PI_I2C_OPTION	additional options
+-    U8G_PI_A0_STATE	used to store the last value of the command/data register selection
+-    U8G_PI_SET_A0		1: Signal request to update I2C device with new A0_STATE, 0: Do nothing, A0_STATE matches I2C device
+-    U8G_PI_SCL		clock line (NOT USED)
+-    U8G_PI_SDA		data line (NOT USED)
+-    
+-    U8G_PI_RESET		reset line (currently disabled, see below)
+-
+-  Protocol:
+-    SLA, Cmd/Data Selection, Arguments
+-    The command/data register is selected by a special instruction byte, which is sent after SLA
+-    
+-    The continue bit is always 0 so that a (re)start is equired for the change from cmd to/data mode
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(U8G_WITH_PINLIST)
+-
+-#define DOGM240_SLA_CMD  (0x38*2)
+-#define DOGM240_SLA_DATA (0x39*2)
+-
+-uint8_t u8g_com_arduino_uc_start_sequence(u8g_t *u8g)
+-{
+-  /* are we requested to set the a0 state? */
+-  if ( u8g->pin_list[U8G_PI_SET_A0] == 0 )
+-    return 1;
+-
+-  if ( u8g->pin_list[U8G_PI_A0_STATE] == 0 )
+-  {
+-    if ( u8g_i2c_start(DOGM240_SLA_CMD) == 0 )
+-      return 0;
+-  }
+-  else
+-  {
+-    if ( u8g_i2c_start(DOGM240_SLA_DATA) == 0 )
+-      return 0;
+-  }
+-
+-  u8g->pin_list[U8G_PI_SET_A0] = 0;
+-  return 1;
+-}
+-
+-uint8_t u8g_com_arduino_uc_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      //u8g_com_arduino_digital_write(u8g, U8G_PI_SCL, HIGH);
+-      //u8g_com_arduino_digital_write(u8g, U8G_PI_SDA, HIGH);
+-      //u8g->pin_list[U8G_PI_A0_STATE] = 0;       /* inital RS state: unknown mode */
+-    
+-      u8g_i2c_init(u8g->pin_list[U8G_PI_I2C_OPTION]);
+-
+-      break;
+-    
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_RESET:
+-      /* Currently disabled, but it could be enable. Previous restrictions have been removed */
+-      /* u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val); */
+-      break;
+-      
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      u8g->pin_list[U8G_PI_A0_STATE] = 0;
+-      u8g->pin_list[U8G_PI_SET_A0] = 1;		/* force a0 to set again, also forces start condition */
+-      if ( arg_val == 0 )
+-      {
+-        /* disable chip, send stop condition */
+-	u8g_i2c_stop();
+-     }
+-      else
+-      {
+-        /* enable, do nothing: any byte writing will trigger the i2c start */
+-      }
+-      break;
+-
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      //u8g->pin_list[U8G_PI_SET_A0] = 1;
+-      if ( u8g_com_arduino_uc_start_sequence(u8g) == 0 )
+-	return u8g_i2c_stop(), 0;
+-      if ( u8g_i2c_send_byte(arg_val) == 0 )
+-	return u8g_i2c_stop(), 0;
+-      // u8g_i2c_stop();
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      //u8g->pin_list[U8G_PI_SET_A0] = 1;
+-      if ( u8g_com_arduino_uc_start_sequence(u8g) == 0 )
+-	return u8g_i2c_stop(), 0;
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-	  if ( u8g_i2c_send_byte(*ptr++) == 0 )
+-	    return u8g_i2c_stop(), 0;
+-          arg_val--;
+-        }
+-      }
+-      // u8g_i2c_stop();
+-      break;
+-
+-    case U8G_COM_MSG_WRITE_SEQ_P:
+-      //u8g->pin_list[U8G_PI_SET_A0] = 1;
+-      if ( u8g_com_arduino_uc_start_sequence(u8g) == 0 )
+-	return u8g_i2c_stop(), 0;
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-	  if ( u8g_i2c_send_byte(u8g_pgm_read(ptr)) == 0 )
+-	    return 0;
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      // u8g_i2c_stop();
+-      break;
+-      
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g->pin_list[U8G_PI_A0_STATE] = arg_val;
+-      u8g->pin_list[U8G_PI_SET_A0] = 1;		/* force a0 to set again */
+-    
+-#ifdef OLD_CODE    
+-      if ( i2c_state != 0 )
+-      {
+-	u8g_i2c_stop();
+-	i2c_state = 0;
+-      }
+-
+-      if ( u8g_com_arduino_uc_start_sequence(arg_val) == 0 )
+-	return 0;
+-    
+-      /* setup bus, might be a repeated start */
+-      /*
+-      if ( u8g_i2c_start(I2C_SLA) == 0 )
+-	return 0;
+-      if ( arg_val == 0 )
+-      {
+-	i2c_state = 1;
+-	
+-	if ( u8g_i2c_send_byte(I2C_CMD_MODE) == 0 )
+-	  return 0;
+-      }
+-      else
+-      {
+-	i2c_state = 2;
+-	if ( u8g_i2c_send_byte(I2C_DATA_MODE) == 0 )
+-	  return 0;
+-      }
+-      */
+-#endif
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else  /* defined(U8G_WITH_PINLIST) */
+-
+-uint8_t u8g_com_arduino_uc_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif /* defined(U8G_WITH_PINLIST) */
+-
+diff --git a/csrc/u8g_com_atmega_hw_spi.c b/csrc/u8g_com_atmega_hw_spi.c
+deleted file mode 100644
+index ca2a063..0000000
+--- a/csrc/u8g_com_atmega_hw_spi.c
++++ /dev/null
+@@ -1,188 +0,0 @@
+-/*
+-  
+-  u8g_com_atmega_hw_spi.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2012, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
+-  
+-  Assumes, that 
+-    MOSI is at PORTB, Pin 3
+-  and
+-    SCK is at PORTB, Pin 5
+-
+-  Update for ATOMIC operation done (01 Jun 2013)
+-    U8G_ATOMIC_OR(ptr, val)
+-    U8G_ATOMIC_AND(ptr, val)
+-    U8G_ATOMIC_START()
+-    U8G_ATOMIC_END()
+- 
+-
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(__AVR_XMEGA__)
+-#elif defined(__AVR__)
+-#define U8G_ATMEGA_HW_SPI
+-
+-/* remove the definition for attiny */
+-#if __AVR_ARCH__ == 2
+-#undef U8G_ATMEGA_HW_SPI
+-#endif
+-#if __AVR_ARCH__ == 25
+-#undef U8G_ATMEGA_HW_SPI
+-#endif
+-#endif
+-
+-
+-#if defined(U8G_ATMEGA_HW_SPI)
+-
+-#include <avr/interrupt.h>
+-#include <avr/io.h>
+-
+-
+-static uint8_t u8g_atmega_spi_out(uint8_t data)
+-{
+-  /* unsigned char x = 100; */
+-  /* send data */
+-  SPDR = data;
+-  /* wait for transmission */
+-  while (!(SPSR & (1<<SPIF))) 
+-    ;
+-  /* clear the SPIF flag by reading SPDR */
+-  return  SPDR;
+-}
+-
+-
+-uint8_t u8g_com_atmega_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_STOP:
+-      break;
+-    
+-    case U8G_COM_MSG_INIT:
+-
+-      u8g_SetPIOutput(u8g, U8G_PI_CS);
+-      u8g_SetPIOutput(u8g, U8G_PI_A0);
+-      u8g_SetPIOutput(u8g, U8G_PI_RESET);
+-      
+-      U8G_ATOMIC_START();
+-      
+-      DDRB |= _BV(3);          /* D0, MOSI */
+-      DDRB |= _BV(5);          /* SCK */
+-      DDRB |= _BV(2);		/* slave select */
+-    
+-      PORTB &= ~_BV(3);        /* D0, MOSI = 0 */
+-      PORTB &= ~_BV(5);        /* SCK = 0 */
+-      
+-      U8G_ATOMIC_END();
+-      
+-      u8g_SetPILevel(u8g, U8G_PI_CS, 1);
+-
+-      /*
+-        SPR1 SPR0
+-            0	0		fclk/4    x
+-            0	1		fclk/16
+-            1	0		fclk/64      
+-            1	1		fclk/128
+-      */
+-      SPCR = 0;
+-      SPCR =  (1<<SPE) | (1<<MSTR)|(0<<SPR1)|(0<<SPR0)|(0<<CPOL)|(0<<CPHA);
+-#ifdef U8G_HW_SPI_2X
+-      SPSR = (1 << SPI2X);  /* double speed, issue 89 */
+-#endif
+-
+-      break;
+-    
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g_SetPILevel(u8g, U8G_PI_A0, arg_val);
+-      break;
+-
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      
+-      if ( arg_val == 0 )
+-      {
+-        /* disable */
+-        u8g_SetPILevel(u8g, U8G_PI_CS, 1);
+-      }
+-      else
+-      {
+-        PORTB &= ~_BV(5);        /* SCK = 0 */
+-        /* enable */
+-        u8g_SetPILevel(u8g, U8G_PI_CS, 0); /* CS = 0 (low active) */
+-      }
+-      
+-      break;
+-      
+-    case U8G_COM_MSG_RESET:
+-      u8g_SetPILevel(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_atmega_spi_out(arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_atmega_spi_out(*ptr++);
+-          arg_val--;
+-        }
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_atmega_spi_out(u8g_pgm_read(ptr));
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-uint8_t u8g_com_atmega_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif
+-
+-
+diff --git a/csrc/u8g_com_atmega_parallel.c b/csrc/u8g_com_atmega_parallel.c
+deleted file mode 100644
+index 2b49b04..0000000
+--- a/csrc/u8g_com_atmega_parallel.c
++++ /dev/null
+@@ -1,183 +0,0 @@
+-/*
+-  
+-  u8g_com_atmega_parallel.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2012, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
+-
+-  PIN_D0 8
+-  PIN_D1 9
+-  PIN_D2 10
+-  PIN_D3 11
+-  PIN_D4 4
+-  PIN_D5 5
+-  PIN_D6 6
+-  PIN_D7 7
+-
+-  PIN_CS1 14
+-  PIN_CS2 15
+-  PIN_RW 16
+-  PIN_DI 17
+-  PIN_EN 18
+-  
+-  u8g_Init8Bit(u8g, dev, d0, d1, d2, d3, d4, d5, d6, d7, en, cs1, cs2, di, rw, reset)
+-  u8g_Init8Bit(u8g, dev,  8,    9, 10, 11,   4,   5,   6,   7, 18, 14, 15, 17, 16, U8G_PIN_NONE)
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(__AVR__)
+-
+-static void u8g_com_atmega_parallel_write(u8g_t *u8g, uint8_t val) U8G_NOINLINE;
+-static void u8g_com_atmega_parallel_write(u8g_t *u8g, uint8_t val)
+-{
+-
+-  u8g_SetPILevel(u8g, U8G_PI_D0, val&1);
+-  val >>= 1;
+-  u8g_SetPILevel(u8g, U8G_PI_D1, val&1);
+-  val >>= 1;
+-  u8g_SetPILevel(u8g, U8G_PI_D2, val&1);
+-  val >>= 1;
+-  u8g_SetPILevel(u8g, U8G_PI_D3, val&1);
+-  val >>= 1;
+-  u8g_SetPILevel(u8g, U8G_PI_D4, val&1);
+-  val >>= 1;
+-  u8g_SetPILevel(u8g, U8G_PI_D5, val&1);
+-  val >>= 1;
+-  u8g_SetPILevel(u8g, U8G_PI_D6, val&1);
+-  val >>= 1;
+-  u8g_SetPILevel(u8g, U8G_PI_D7, val&1);
+-  
+-  /* EN cycle time must be 1 micro second  */
+-  u8g_SetPILevel(u8g, U8G_PI_EN, 1);
+-  u8g_MicroDelay(); /* delay by 1000ns, reference: ST7920: 140ns, SBN1661: 100ns */
+-  u8g_SetPILevel(u8g, U8G_PI_EN, 0);
+-  u8g_10MicroDelay(); /* ST7920 commands: 72us */
+-  u8g_10MicroDelay(); /* ST7920 commands: 72us */
+-}
+-
+-
+-uint8_t u8g_com_atmega_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      /* setup the RW pin as output and force it to low */
+-      u8g_SetPIOutput(u8g, U8G_PI_RW);
+-      u8g_SetPILevel(u8g, U8G_PI_RW, 0);
+-
+-      u8g_SetPIOutput(u8g, U8G_PI_D0);
+-      u8g_SetPIOutput(u8g, U8G_PI_D1);
+-      u8g_SetPIOutput(u8g, U8G_PI_D2);
+-      u8g_SetPIOutput(u8g, U8G_PI_D3);
+-      u8g_SetPIOutput(u8g, U8G_PI_D4);
+-      u8g_SetPIOutput(u8g, U8G_PI_D5);
+-      u8g_SetPIOutput(u8g, U8G_PI_D6);
+-      u8g_SetPIOutput(u8g, U8G_PI_D7);
+-      u8g_SetPIOutput(u8g, U8G_PI_EN);
+-      u8g_SetPIOutput(u8g, U8G_PI_CS1);
+-      u8g_SetPIOutput(u8g, U8G_PI_CS2);
+-      u8g_SetPIOutput(u8g, U8G_PI_DI);
+-      u8g_SetPILevel(u8g, U8G_PI_CS1, 1);
+-      u8g_SetPILevel(u8g, U8G_PI_CS2, 1);
+-
+-      break;
+-    case U8G_COM_MSG_STOP:
+-      break;
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      if ( arg_val == 0 )
+-      {
+-        /* disable */
+-        u8g_SetPILevel(u8g, U8G_PI_CS1, 1);
+-        u8g_SetPILevel(u8g, U8G_PI_CS2, 1);
+-      }
+-      else if ( arg_val == 1 )
+-      {
+-        /* enable */
+-        u8g_SetPILevel(u8g, U8G_PI_CS1, 0);
+-        u8g_SetPILevel(u8g, U8G_PI_CS2, 1);
+-      }
+-      else if ( arg_val == 2 )
+-      {
+-        /* enable */
+-        u8g_SetPILevel(u8g, U8G_PI_CS1, 1);
+-        u8g_SetPILevel(u8g, U8G_PI_CS2, 0);
+-      }
+-      else
+-      {
+-        /* enable */
+-        u8g_SetPILevel(u8g, U8G_PI_CS1, 0);
+-        u8g_SetPILevel(u8g, U8G_PI_CS2, 0);
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_com_atmega_parallel_write(u8g, arg_val);
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_atmega_parallel_write(u8g, *ptr++);
+-          arg_val--;
+-        }
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_atmega_parallel_write(u8g, u8g_pgm_read(ptr));
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g_SetPILevel(u8g, U8G_PI_DI, arg_val);
+-      break;
+-    case U8G_COM_MSG_RESET:
+-      u8g_SetPILevel(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-uint8_t u8g_com_atmega_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif /* ARDUINO */
+-
+diff --git a/csrc/u8g_com_atmega_st7920_hw_spi.c b/csrc/u8g_com_atmega_st7920_hw_spi.c
+deleted file mode 100644
+index 5785792..0000000
+--- a/csrc/u8g_com_atmega_st7920_hw_spi.c
++++ /dev/null
+@@ -1,217 +0,0 @@
+-/*
+-  
+-  u8g_com_atmega_st7920_hw_spi.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-
+-  A special SPI interface for ST7920 controller with HW SPI Support
+-
+-  Assumes, that 
+-    MOSI is at PORTB, Pin 3
+-  and
+-    SCK is at PORTB, Pin 5
+-
+-  Update for ATOMIC operation done (01 Jun 2013)
+-    U8G_ATOMIC_OR(ptr, val)
+-    U8G_ATOMIC_AND(ptr, val)
+-    U8G_ATOMIC_START()
+-    U8G_ATOMIC_END()
+- 
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(__AVR_XMEGA__)
+-#elif defined(__AVR__)
+-#define U8G_ATMEGA_HW_SPI
+-
+-/* remove the definition for attiny */
+-#if __AVR_ARCH__ == 2
+-#undef U8G_ATMEGA_HW_SPI
+-#endif
+-#if __AVR_ARCH__ == 25
+-#undef U8G_ATMEGA_HW_SPI
+-#endif
+-
+-#endif
+-
+-#if defined(U8G_ATMEGA_HW_SPI)
+-
+-#include <avr/interrupt.h>
+-#include <avr/io.h>
+-
+-static uint8_t u8g_atmega_st7920_hw_spi_shift_out(u8g_t *u8g, uint8_t val) U8G_NOINLINE;
+-static uint8_t u8g_atmega_st7920_hw_spi_shift_out(u8g_t *u8g, uint8_t val)
+-{
+-  /* send data */
+-  SPDR = val;
+-  /* wait for transmission */
+-  while (!(SPSR & (1<<SPIF))) 
+-    ;
+-  /* clear the SPIF flag by reading SPDR */
+-  return  SPDR;
+-}
+-
+-
+-static void u8g_com_atmega_st7920_write_byte_hw_spi(u8g_t *u8g, uint8_t rs, uint8_t val) U8G_NOINLINE;
+-static void u8g_com_atmega_st7920_write_byte_hw_spi(u8g_t *u8g, uint8_t rs, uint8_t val)
+-{
+-  uint8_t i;
+-
+-  if ( rs == 0 )
+-  {
+-    /* command */
+-    u8g_atmega_st7920_hw_spi_shift_out(u8g, 0x0f8);
+-  }
+-  else if ( rs == 1 )
+-  {
+-    /* data */
+-    u8g_atmega_st7920_hw_spi_shift_out(u8g, 0x0fa);
+-  }
+-  
+-  u8g_atmega_st7920_hw_spi_shift_out(u8g, val & 0x0f0);
+-  u8g_atmega_st7920_hw_spi_shift_out(u8g, val << 4);
+-
+-  for( i = 0; i < 4; i++ )
+-    u8g_10MicroDelay();
+-}
+-
+-
+-uint8_t u8g_com_atmega_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      u8g_SetPIOutput(u8g, U8G_PI_CS);
+-      //u8g_SetPIOutput(u8g, U8G_PI_A0);
+-      
+-      U8G_ATOMIC_START();
+-      
+-      DDRB |= _BV(3);          /* D0, MOSI */
+-      DDRB |= _BV(5);          /* SCK */
+-      DDRB |= _BV(2);		/* slave select */
+-    
+-      PORTB &= ~_BV(3);        /* D0, MOSI = 0 */
+-      PORTB &= ~_BV(5);        /* SCK = 0 */
+-      U8G_ATOMIC_END();
+-      
+-      u8g_SetPILevel(u8g, U8G_PI_CS, 1);
+-
+-      /*
+-        SPR1 SPR0
+-            0	0		fclk/4
+-            0	1		fclk/16 
+-            1	0		fclk/64  
+-            1	1		fclk/128
+-      */
+-      SPCR = 0;
+-      
+-      /* maybe set CPOL and CPHA to 1 */
+-      /* 20 Dez 2012: did set CPOL and CPHA to 1 in Arduino variant! */
+-      /* 24 Jan 2014: implemented, see also issue 221 */
+-      SPCR =  (1<<SPE) | (1<<MSTR)|(0<<SPR1)|(0<<SPR0)|(1<<CPOL)|(1<<CPHA);
+-#ifdef U8G_HW_SPI_2X
+-      SPSR = (1 << SPI2X);  /* double speed, issue 89 */
+-#endif
+-      u8g->pin_list[U8G_PI_A0_STATE] = 0;       /* inital RS state: command mode */
+-      break;
+-    
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_RESET:
+-      u8g_SetPILevel(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g->pin_list[U8G_PI_A0_STATE] = arg_val;
+-      break;
+-
+-    case U8G_COM_MSG_CHIP_SELECT:      
+-      if ( arg_val == 0 )
+-      {
+-        /* disable, note: the st7920 has an active high chip select */
+-        u8g_SetPILevel(u8g, U8G_PI_CS, 0);
+-      }
+-      else
+-      {
+-        /* u8g_SetPILevel(u8g, U8G_PI_SCK, 0 ); */
+-        /* enable */
+-        u8g_SetPILevel(u8g, U8G_PI_CS, 1); /* CS = 1 (high active) */
+-      }
+-      break;
+-      
+-
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_com_atmega_st7920_write_byte_hw_spi(u8g, u8g->pin_list[U8G_PI_A0_STATE], arg_val);
+-      //u8g->pin_list[U8G_PI_A0_STATE] = 2; 
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_atmega_st7920_write_byte_hw_spi(u8g, u8g->pin_list[U8G_PI_A0_STATE], *ptr++);
+-	  //u8g->pin_list[U8G_PI_A0_STATE] = 2; 
+-          arg_val--;
+-        }
+-      }
+-      break;
+-
+-      case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_atmega_st7920_write_byte_hw_spi(u8g, u8g->pin_list[U8G_PI_A0_STATE], u8g_pgm_read(ptr));
+-	  //u8g->pin_list[U8G_PI_A0_STATE] = 2; 
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-
+-uint8_t u8g_com_atmega_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-
+-#endif
+-
+- 
+\ No newline at end of file
+diff --git a/csrc/u8g_com_atmega_st7920_spi.c b/csrc/u8g_com_atmega_st7920_spi.c
+deleted file mode 100644
+index 24e0602..0000000
+--- a/csrc/u8g_com_atmega_st7920_spi.c
++++ /dev/null
+@@ -1,170 +0,0 @@
+-/*
+-  
+-  u8g_com_atmega_st7920_spi.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-
+-  A special SPI interface for ST7920 controller
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(__AVR__)
+-
+-static void u8g_atmega_st7920_sw_spi_shift_out(u8g_t *u8g, uint8_t val) U8G_NOINLINE;
+-static void u8g_atmega_st7920_sw_spi_shift_out(u8g_t *u8g, uint8_t val)
+-{
+-  uint8_t i = 8;
+-  do
+-  {
+-    u8g_SetPILevel(u8g, U8G_PI_MOSI, val & 128 );
+-    val <<= 1;
+-    u8g_SetPILevel(u8g, U8G_PI_SCK, 1 );
+-    u8g_MicroDelay();		/* 15 Aug 2012: added for high speed uC */
+-    u8g_SetPILevel(u8g, U8G_PI_SCK, 0 );
+-    u8g_MicroDelay();		/* 15 Aug 2012: added for high speed uC */
+-    i--;
+-  } while( i != 0 );
+-}
+-
+-static void u8g_com_atmega_st7920_write_byte(u8g_t *u8g, uint8_t rs, uint8_t val) U8G_NOINLINE;
+-static void u8g_com_atmega_st7920_write_byte(u8g_t *u8g, uint8_t rs, uint8_t val)
+-{
+-  uint8_t i;
+-  
+-  if ( rs == 0 )
+-  {
+-    /* command */
+-    u8g_atmega_st7920_sw_spi_shift_out(u8g, 0x0f8);
+-  }
+-  else if ( rs == 1 )
+-  {
+-    /* data */
+-    u8g_atmega_st7920_sw_spi_shift_out(u8g, 0x0fa);
+-  }
+-  
+-  u8g_atmega_st7920_sw_spi_shift_out(u8g, val & 0x0f0);
+-  u8g_atmega_st7920_sw_spi_shift_out(u8g, val << 4);
+-
+-  for( i = 0; i < 4; i++ )
+-    u8g_10MicroDelay();
+-}
+-
+-
+-uint8_t u8g_com_atmega_st7920_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      u8g_SetPIOutput(u8g, U8G_PI_SCK);
+-      u8g_SetPIOutput(u8g, U8G_PI_MOSI);
+-      /* u8g_SetPIOutput(u8g, U8G_PI_A0); */
+-      u8g_SetPIOutput(u8g, U8G_PI_CS);
+-      u8g_SetPIOutput(u8g, U8G_PI_RESET);
+-      
+-      u8g_SetPILevel(u8g, U8G_PI_SCK, 0 );
+-      u8g_SetPILevel(u8g, U8G_PI_MOSI, 0 );
+-      u8g_SetPILevel(u8g, U8G_PI_CS, 0 );
+-      /* u8g_SetPILevel(u8g, U8G_PI_A0, 0); */
+-    
+-      u8g->pin_list[U8G_PI_A0_STATE] = 0;       /* inital RS state: command mode */
+-      break;
+-    
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_RESET:
+-      u8g_SetPILevel(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g->pin_list[U8G_PI_A0_STATE] = arg_val;
+-      break;
+-
+-    case U8G_COM_MSG_CHIP_SELECT:      
+-      if ( arg_val == 0 )
+-      {
+-        /* disable, note: the st7920 has an active high chip select */
+-        u8g_SetPILevel(u8g, U8G_PI_CS, 0);
+-      }
+-      else
+-      {
+-        /* u8g_SetPILevel(u8g, U8G_PI_SCK, 0 ); */
+-        /* enable */
+-        u8g_SetPILevel(u8g, U8G_PI_CS, 1); /* CS = 1 (high active) */
+-      }
+-      break;
+-      
+-
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_com_atmega_st7920_write_byte(u8g, u8g->pin_list[U8G_PI_A0_STATE], arg_val);
+-      u8g->pin_list[U8G_PI_A0_STATE] = 2; 
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_atmega_st7920_write_byte(u8g, u8g->pin_list[U8G_PI_A0_STATE], *ptr++);
+-	  u8g->pin_list[U8G_PI_A0_STATE] = 2; 
+-          arg_val--;
+-        }
+-      }
+-      break;
+-
+-      case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_atmega_st7920_write_byte(u8g, u8g->pin_list[U8G_PI_A0_STATE], u8g_pgm_read(ptr));
+-	  u8g->pin_list[U8G_PI_A0_STATE] = 2; 
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-
+-uint8_t u8g_com_atmega_st7920_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-
+-#endif
+-
+diff --git a/csrc/u8g_com_atmega_sw_spi.c b/csrc/u8g_com_atmega_sw_spi.c
+deleted file mode 100644
+index fde3153..0000000
+--- a/csrc/u8g_com_atmega_sw_spi.c
++++ /dev/null
+@@ -1,141 +0,0 @@
+-/*
+-  
+-  u8g_com_atmega_sw_spi.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2012, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(__AVR__)
+-
+-static void u8g_atmega_sw_spi_shift_out(u8g_t *u8g, uint8_t val) U8G_NOINLINE;
+-static void u8g_atmega_sw_spi_shift_out(u8g_t *u8g, uint8_t val)
+-{
+-  uint8_t i = 8;
+-  do
+-  {
+-    u8g_SetPILevel(u8g, U8G_PI_MOSI, val & 128 );
+-    val <<= 1;
+-    u8g_SetPILevel(u8g, U8G_PI_SCK, 1 );
+-    u8g_MicroDelay();		/* 15 Aug 2012: added for high speed uC */
+-    u8g_SetPILevel(u8g, U8G_PI_SCK, 0 );
+-    u8g_MicroDelay();		/* 15 Aug 2012: added for high speed uC */
+-    i--;
+-  } while( i != 0 );
+-}
+-
+-uint8_t u8g_com_atmega_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      u8g_SetPIOutput(u8g, U8G_PI_SCK);
+-      u8g_SetPIOutput(u8g, U8G_PI_MOSI);
+-      u8g_SetPIOutput(u8g, U8G_PI_A0);
+-      u8g_SetPIOutput(u8g, U8G_PI_CS);
+-      u8g_SetPIOutput(u8g, U8G_PI_RESET);
+-      
+-      u8g_SetPILevel(u8g, U8G_PI_SCK, 0 );
+-      u8g_SetPILevel(u8g, U8G_PI_MOSI, 0 );
+-      u8g_SetPILevel(u8g, U8G_PI_CS, 1 );
+-      u8g_SetPILevel(u8g, U8G_PI_A0, 0);
+-      break;
+-    
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g_SetPILevel(u8g, U8G_PI_A0, arg_val);
+-      break;
+-
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      
+-      if ( arg_val == 0 )
+-      {
+-        /* disable */
+-        u8g_SetPILevel(u8g, U8G_PI_CS, 1);
+-      }
+-      else
+-      {
+-        u8g_SetPILevel(u8g, U8G_PI_SCK, 0 );
+-        /* enable */
+-        u8g_SetPILevel(u8g, U8G_PI_CS, 0); /* CS = 0 (low active) */
+-      }
+-      break;
+-      
+-    case U8G_COM_MSG_RESET:
+-      u8g_SetPILevel(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-    
+-
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_atmega_sw_spi_shift_out(u8g, arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_atmega_sw_spi_shift_out(u8g, *ptr++);
+-          arg_val--;
+-        }
+-      }
+-      break;
+-
+-      case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_atmega_sw_spi_shift_out(u8g, u8g_pgm_read(ptr));
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-
+-uint8_t u8g_com_atmega_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-
+-#endif
+-
+diff --git a/csrc/u8g_com_atxmega_hw_spi.c b/csrc/u8g_com_atxmega_hw_spi.c
+deleted file mode 100644
+index 4c2dfa2..0000000
+--- a/csrc/u8g_com_atxmega_hw_spi.c
++++ /dev/null
+@@ -1,174 +0,0 @@
+-/*
+-  
+-  u8g_com_atxmega_hw_spi.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  Copyright (c) 2015, florianmenne@t-online.de
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-
+-  A special SPI interface for ST7920 controller with HW SPI Support
+-
+-  Assumes, that 
+-    MOSI is at PORTB, Pin 3
+-  and
+-    SCK is at PORTB, Pin 5
+-
+-  Update for ATOMIC operation done (01 Jun 2013)
+-    U8G_ATOMIC_OR(ptr, val)
+-    U8G_ATOMIC_AND(ptr, val)
+-    U8G_ATOMIC_START()
+-    U8G_ATOMIC_END()
+- 
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(__AVR_XMEGA__)
+-#define U8G_ATXMEGA_HW_SPI
+-#endif
+-
+-
+-#if defined(U8G_ATXMEGA_HW_SPI)
+-
+-#include <avr/interrupt.h>
+-#include <avr/io.h>
+-
+-
+-static uint8_t u8g_atxmega_spi_out(uint8_t data)
+-{
+-  /* send data */
+-  SPIC.DATA = data;
+-  
+-  /* wait for transmission */
+-  while(!(SPIC.STATUS & SPI_IF_bm));
+-  
+-  /* clear the SPIF flag by reading SPDR */
+-  return SPIC.DATA;
+-}
+-
+-
+-uint8_t u8g_com_atxmega_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_STOP:
+-    break;
+-    
+-    case U8G_COM_MSG_INIT:
+-
+-    u8g_SetPIOutput(u8g, U8G_PI_CS);
+-    u8g_SetPIOutput(u8g, U8G_PI_A0);
+-    u8g_SetPIOutput(u8g, U8G_PI_RESET);
+-    
+-    //U8G_ATOMIC_START();
+-    
+-    PORTC.DIR |= PIN4_bm | PIN5_bm | PIN7_bm;
+-    PORTC.DIR &= ~PIN6_bm;
+-
+-    //U8G_ATOMIC_END();
+-    
+-    u8g_SetPILevel(u8g, U8G_PI_CS, 1);
+-
+-    SPIC.CTRL = 0;
+-    SPIC.CTRL     = SPI_PRESCALER_DIV4_gc |		// SPI prescaler.
+-    //SPI_CLK2X_bm |			 //SPI Clock double.
+-    SPI_ENABLE_bm |			 //Enable SPI module.
+-    //SPI_DORD_bm |			 //Data order.
+-    SPI_MASTER_bm |			 //SPI master.
+-    SPI_MODE_0_gc;			// SPI mode.
+-    
+-#ifdef U8G_HW_SPI_2X
+-    SPIC.CTRL |= SPI_CLK2X_bm;  /* double speed, issue 89 */
+-#endif
+-
+-    break;
+-    
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-    u8g_SetPILevel(u8g, U8G_PI_A0, arg_val);
+-    break;
+-
+-    case U8G_COM_MSG_CHIP_SELECT:
+-    
+-    if ( arg_val == 0 )
+-    {
+-      /* disable */
+-      u8g_SetPILevel(u8g, U8G_PI_CS, 1);
+-    }
+-    else
+-    {
+-      //PORTB &= ~_BV(5);        /* SCK = 0 */
+-      PORTC.OUT &= ~PIN7_bm;
+-      /* enable */
+-      u8g_SetPILevel(u8g, U8G_PI_CS, 0); /* CS = 0 (low active) */
+-    }
+-    
+-    break;
+-    
+-    case U8G_COM_MSG_RESET:
+-    u8g_SetPILevel(u8g, U8G_PI_RESET, arg_val);
+-    break;
+-    
+-    case U8G_COM_MSG_WRITE_BYTE:
+-    u8g_atxmega_spi_out(arg_val);
+-    break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-    {
+-      register uint8_t *ptr = arg_ptr;
+-      while( arg_val > 0 )
+-      {
+-        u8g_atxmega_spi_out(*ptr++);
+-        arg_val--;
+-      }
+-    }
+-    break;
+-    case U8G_COM_MSG_WRITE_SEQ_P:
+-    {
+-      register uint8_t *ptr = arg_ptr;
+-      while( arg_val > 0 )
+-      {
+-        u8g_atxmega_spi_out(u8g_pgm_read(ptr));
+-        ptr++;
+-        arg_val--;
+-      }
+-    }
+-    break;
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-uint8_t u8g_com_atxmega_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif
+\ No newline at end of file
+diff --git a/csrc/u8g_com_atxmega_st7920_hw_spi.c b/csrc/u8g_com_atxmega_st7920_hw_spi.c
+deleted file mode 100644
+index 4b82385..0000000
+--- a/csrc/u8g_com_atxmega_st7920_hw_spi.c
++++ /dev/null
+@@ -1,202 +0,0 @@
+-/*
+-  
+-  u8g_com_atxmega_st7920_hw_spi.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  Copyright (c) 2015, florianmenne@t-online.de
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-
+-  A special SPI interface for ST7920 controller with HW SPI Support
+-
+-  Assumes, that 
+-    MOSI is at PORTB, Pin 3
+-  and
+-    SCK is at PORTB, Pin 5
+-
+-  Update for ATOMIC operation done (01 Jun 2013)
+-    U8G_ATOMIC_OR(ptr, val)
+-    U8G_ATOMIC_AND(ptr, val)
+-    U8G_ATOMIC_START()
+-    U8G_ATOMIC_END()
+- 
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(__AVR_XMEGA__)
+-#define U8G_ATXMEGA_HW_SPI
+-#endif
+-
+-#if defined(U8G_ATXMEGA_HW_SPI)
+-
+-#include <avr/interrupt.h>
+-#include <avr/io.h>
+-
+-static uint8_t u8g_atxmega_st7920_hw_spi_shift_out(u8g_t *u8g, uint8_t val) U8G_NOINLINE;
+-static uint8_t u8g_atxmega_st7920_hw_spi_shift_out(u8g_t *u8g, uint8_t val)
+-{
+-  /* send data */
+-  SPIC.DATA = val;
+-  
+-  /* wait for transmission */
+-  while(!(SPIC.STATUS & SPI_IF_bm));
+-  
+-  /* clear the SPIF flag by reading SPDR */
+-  return SPIC.DATA;
+-}
+-
+-
+-static void u8g_com_atxmega_st7920_write_byte_hw_spi(u8g_t *u8g, uint8_t rs, uint8_t val) U8G_NOINLINE;
+-static void u8g_com_atxmega_st7920_write_byte_hw_spi(u8g_t *u8g, uint8_t rs, uint8_t val)
+-{
+-  uint8_t i;
+-
+-  if ( rs == 0 )
+-  {
+-    /* command */
+-    u8g_atxmega_st7920_hw_spi_shift_out(u8g, 0x0f8);
+-  }
+-  else if ( rs == 1 )
+-  {
+-    /* data */
+-    u8g_atxmega_st7920_hw_spi_shift_out(u8g, 0x0fa);
+-  }
+-  
+-  u8g_atxmega_st7920_hw_spi_shift_out(u8g, val & 0x0f0);
+-  u8g_atxmega_st7920_hw_spi_shift_out(u8g, val << 4);
+-
+-  for( i = 0; i < 4; i++ )
+-    u8g_10MicroDelay();
+-}
+-
+-
+-uint8_t u8g_com_atxmega_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      u8g_SetPIOutput(u8g, U8G_PI_CS);
+-      //u8g_SetPIOutput(u8g, U8G_PI_A0);
+-      
+-      //U8G_ATOMIC_START();
+-      
+-      PORTC.DIR |= PIN4_bm | PIN5_bm | PIN7_bm;
+-      PORTC.DIR &= ~PIN6_bm;
+-
+-      //U8G_ATOMIC_END();
+-      
+-      u8g_SetPILevel(u8g, U8G_PI_CS, 1);
+-
+-      SPIC.CTRL = 0;
+-      SPIC.CTRL     = SPI_PRESCALER_DIV4_gc |		// SPI prescaler.
+-      //SPI_CLK2X_bm |			 //SPI Clock double.
+-      SPI_ENABLE_bm |			 //Enable SPI module.
+-      //SPI_DORD_bm |			 //Data order.
+-      SPI_MASTER_bm |			 //SPI master.
+-      SPI_MODE_0_gc;			// SPI mode.
+-
+-#ifdef U8G_HW_SPI_2X
+-      SPIC.CTRL |= SPI_CLK2X_bm;  /* double speed, issue 89 */
+-#endif
+-     
+-      u8g->pin_list[U8G_PI_A0_STATE] = 0;       /* inital RS state: command mode */
+-      break;
+-    
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_RESET:
+-      u8g_SetPILevel(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g->pin_list[U8G_PI_A0_STATE] = arg_val;
+-      break;
+-
+-    case U8G_COM_MSG_CHIP_SELECT:      
+-      if ( arg_val == 0 )
+-      {
+-        /* disable, note: the st7920 has an active high chip select */
+-        u8g_SetPILevel(u8g, U8G_PI_CS, 0);
+-      }
+-      else
+-      {
+-        /* u8g_SetPILevel(u8g, U8G_PI_SCK, 0 ); */
+-        /* enable */
+-        u8g_SetPILevel(u8g, U8G_PI_CS, 1); /* CS = 1 (high active) */
+-      }
+-      break;
+-      
+-
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_com_atxmega_st7920_write_byte_hw_spi(u8g, u8g->pin_list[U8G_PI_A0_STATE], arg_val);
+-      //u8g->pin_list[U8G_PI_A0_STATE] = 2; 
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_atxmega_st7920_write_byte_hw_spi(u8g, u8g->pin_list[U8G_PI_A0_STATE], *ptr++);
+-	  //u8g->pin_list[U8G_PI_A0_STATE] = 2; 
+-          arg_val--;
+-        }
+-      }
+-      break;
+-
+-      case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_com_atxmega_st7920_write_byte_hw_spi(u8g, u8g->pin_list[U8G_PI_A0_STATE], u8g_pgm_read(ptr));
+-	  //u8g->pin_list[U8G_PI_A0_STATE] = 2; 
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-
+-uint8_t u8g_com_atxmega_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-
+-#endif
+-
+- 
+\ No newline at end of file
+diff --git a/csrc/u8g_com_i2c.c b/csrc/u8g_com_i2c.c
+deleted file mode 100644
+index f975952..0000000
+--- a/csrc/u8g_com_i2c.c
++++ /dev/null
+@@ -1,643 +0,0 @@
+-/*
+-  
+-  u8g_com_i2c.c
+-
+-  generic i2c interface
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
+-*/
+-
+-
+-#include "u8g.h"
+-
+-//#define U8G_I2C_WITH_NO_ACK
+-
+-static uint8_t u8g_i2c_err_code;
+-static uint8_t u8g_i2c_opt;		/* U8G_I2C_OPT_NO_ACK, SAM: U8G_I2C_OPT_DEV_1 */
+-/*
+-  position values
+-    1: start condition
+-    2: sla transfer
+-*/
+-static uint8_t u8g_i2c_err_pos;
+-
+-
+-void u8g_i2c_clear_error(void)
+-{
+-  u8g_i2c_err_code = U8G_I2C_ERR_NONE;
+-  u8g_i2c_err_pos = 0;
+-}
+-
+-uint8_t  u8g_i2c_get_error(void)
+-{
+-  return u8g_i2c_err_code;
+-}
+-
+-uint8_t u8g_i2c_get_err_pos(void)
+-{
+-  return u8g_i2c_err_pos;
+-}
+-
+-
+-#if defined(__AVR_XMEGA__)
+-#elif defined(__AVR__)
+-
+-static void u8g_i2c_set_error(uint8_t code, uint8_t pos)
+-{
+-  if ( u8g_i2c_err_code > 0 )
+-    return;
+-  u8g_i2c_err_code |= code;
+-  u8g_i2c_err_pos = pos;
+-}
+-
+-#define U8G_ATMEGA_HW_TWI
+-
+-/* remove the definition for attiny */
+-#if __AVR_ARCH__ == 2
+-#undef U8G_ATMEGA_HW_TWI
+-#endif
+-#if __AVR_ARCH__ == 25
+-#undef U8G_ATMEGA_HW_TWI
+-#endif
+-#endif
+-
+-#if defined(U8G_ATMEGA_HW_TWI)
+-
+-#include <avr/io.h>
+-#include <util/twi.h>
+-
+-
+-
+-void u8g_i2c_init(uint8_t options)
+-{
+-  /*
+-  TWBR: bit rate register
+-  TWSR: status register (contains preselector bits)
+-
+-  prescalar
+-    0		1
+-    1		4
+-    2		16
+-    3		64
+-
+-  f = F_CPU/(16+2*TWBR*prescalar)
+-  
+-  F_CPU = 16MHz
+-    TWBR = 152;
+-    TWSR = 0;
+-	--> 50KHz
+-
+-    TWBR = 72;
+-    TWSR = 0;
+-	--> 100KHz
+-
+-    TWBR = 12;
+-    TWSR = 0;
+-	--> 400KHz
+-
+-    F_CPU/(2*100000)-8  --> calculate TWBR value for 100KHz
+-*/
+-  u8g_i2c_opt = options;
+-  TWSR = 0;
+-  if ( options & U8G_I2C_OPT_FAST )
+-  {
+-    TWBR = F_CPU/(2*400000)-8;
+-  }
+-  else
+-  {  
+-    TWBR = F_CPU/(2*100000)-8;
+-  }
+-  u8g_i2c_clear_error();
+-}
+-
+-uint8_t u8g_i2c_wait(uint8_t mask, uint8_t pos)
+-{
+-  volatile uint16_t cnt = 2000;	/* timout value should be > 280 for 50KHz Bus and 16 Mhz CPU, however the start condition might need longer */
+-  while( !(TWCR & mask) )
+-  {
+-      if ( cnt == 0 )
+-      {
+-	if ( u8g_i2c_opt & U8G_I2C_OPT_NO_ACK )
+-	{
+-	  return 1;	/* all ok */
+-	}
+-	else
+-	{
+-	  u8g_i2c_set_error(U8G_I2C_ERR_TIMEOUT, pos);
+-	  return 0; /* error */
+-	}
+-      }
+-      cnt--;
+-    }
+-  return 1;	/* all ok */
+-}
+-
+-/* sla includes all 8 bits (with r/w bit), assums master transmit */
+-uint8_t u8g_i2c_start(uint8_t sla)
+-{
+-  register uint8_t status;
+-  
+-  /* send start */
+-  TWCR = _BV(TWINT) |  _BV(TWSTA)  |  _BV(TWEN);
+-   
+-  /* wait */
+-  if ( u8g_i2c_wait(_BV(TWINT), 1) == 0 )
+-    return 0;
+-  
+-  status = TW_STATUS;
+- 
+-  /* check status after start */  
+-  if ( status != TW_START && status != TW_REP_START )
+-  {
+-    u8g_i2c_set_error(U8G_I2C_ERR_BUS, 1);
+-    return 0;
+-  }
+-
+-  /* set slave address */  
+-  TWDR = sla;
+-  
+-  /* enable sla transfer */
+-  TWCR = _BV(TWINT)  |  _BV(TWEN);
+-
+-  /* wait */
+-  if ( u8g_i2c_wait(_BV(TWINT), 2) == 0 )
+-    return 0;
+-
+-  if ( u8g_i2c_opt & U8G_I2C_OPT_NO_ACK )
+-  {
+-    /* do not check for ACK */
+-  }
+-  else
+-  {
+-    status = TW_STATUS;
+-    /* check status after sla */  
+-    if ( status != TW_MT_SLA_ACK )
+-    {
+-      u8g_i2c_set_error(U8G_I2C_ERR_BUS, 2);
+-      return 0;
+-    }
+-  }
+-
+-   return 1;
+-}
+-
+-uint8_t u8g_i2c_send_byte(uint8_t data)
+-{
+-  register uint8_t status;
+-  TWDR = data;
+-  TWCR = _BV(TWINT)  |  _BV(TWEN);
+-  if ( u8g_i2c_wait(_BV(TWINT), 3) == 0 )
+-    return 0;
+-    
+-  if ( u8g_i2c_opt & U8G_I2C_OPT_NO_ACK )
+-  {
+-    /* do not check for ACK */
+-  }
+-  else
+-  {
+-    status = TW_STATUS;  
+-    if ( status != TW_MT_DATA_ACK )
+-    {
+-      u8g_i2c_set_error(U8G_I2C_ERR_BUS, 3);
+-      return 0;
+-    }
+-  }
+-
+-  return 1;  
+-}
+-
+-void u8g_i2c_stop(void)
+-{
+-  /* write stop */
+-  TWCR = _BV(TWINT) | _BV(TWEN) | _BV(TWSTO);
+-
+-  /* no error is checked for the stop condition */  
+-  u8g_i2c_wait(_BV(TWSTO), 4);
+-  
+-}
+-
+-/*
+-void twi_send(uint8_t adr, uint8_t data1, uint8_t data2)
+-{
+-  u8g_i2c_start(adr<<1);
+-  u8g_i2c_send_byte(data1);
+-  u8g_i2c_send_byte(data2);
+-  u8g_i2c_stop();
+-}
+-*/
+-
+-#elif defined(ARDUINO) && defined(__SAM3X8E__)
+-/* Arduino Due */
+-#include "Arduino.h"
+-#include "sam.h"
+-
+-/*
+-
+-Controller
+-
+-TWI0 TWCK0 PA18 A			DUE PCB: SCL1
+-TWI0 TWD0 PA17 A			DUE PCB: SDA1 
+-TWI1 TWCK1 PB13 A			DUE PCB: SCL 21
+-TWI1 TWD1 PB12 A			DUE PCB: SDA 20
+-
+-Arduino definitions
+-
+-#define PIN_WIRE_SDA         (20u)
+-#define PIN_WIRE_SCL         (21u)
+-#define WIRE_INTERFACE       TWI1
+-#define WIRE_INTERFACE_ID    ID_TWI1
+-#define WIRE_ISR_HANDLER     TWI1_Handler
+-
+-#define PIN_WIRE1_SDA        (70u)
+-#define PIN_WIRE1_SCL        (71u)
+-#define WIRE1_INTERFACE      TWI0
+-#define WIRE1_INTERFACE_ID   ID_TWI0
+-#define WIRE1_ISR_HANDLER    TWI0_Handler
+-
+-
+-*/
+-
+-static void i2c_400KHz_delay(void)
+-{
+-  /* should be at least 4 */
+-  /* should be 5 for 100KHz transfer speed */
+- 
+-  
+-  /*
+-    Arduino Due
+-    0x NOP: 470KHz
+-    4x NOP: 450KHz
+-    8x NOP: 430KHz
+-    16x NOP: 400KHz
+-  */
+-  
+-  __NOP();
+-  __NOP();
+-  __NOP();
+-  __NOP();
+-  
+-  __NOP();
+-  __NOP();
+-  __NOP();
+-  __NOP();
+-
+-  __NOP();
+-  __NOP();
+-  __NOP();
+-  __NOP();
+-
+-  __NOP();
+-  __NOP();
+-  __NOP();
+-  __NOP();
+-}
+-
+-static void i2c_100KHz_delay(void)
+-{
+-  /* 
+-    1x u8g_MicroDelay()	ca. 130KHz
+-    2x u8g_MicroDelay()	ca. 80KHz 
+-  */
+-  u8g_MicroDelay();
+-  u8g_MicroDelay();  
+-}
+-
+-
+-uint32_t i2c_started = 0;
+-uint32_t i2c_scl_pin = 0;
+-uint32_t i2c_sda_pin = 0;
+-void (*i2c_delay)(void) = i2c_100KHz_delay;
+-
+-const PinDescription *i2c_scl_pin_desc;
+-const PinDescription *i2c_sda_pin_desc;
+-
+-
+-/* maybe this can be optimized */
+-static void i2c_init(void)
+-{
+-  i2c_sda_pin_desc = &(g_APinDescription[i2c_sda_pin]);
+-  i2c_scl_pin_desc = &(g_APinDescription[i2c_scl_pin]);
+-  pinMode(i2c_sda_pin, OUTPUT);
+-  digitalWrite(i2c_sda_pin, HIGH);
+-  pinMode(i2c_scl_pin, OUTPUT);
+-  digitalWrite(i2c_scl_pin, HIGH);
+-  PIO_Configure( i2c_sda_pin_desc->pPort, PIO_OUTPUT_0, i2c_sda_pin_desc->ulPin, PIO_OPENDRAIN );
+-  PIO_Configure( i2c_scl_pin_desc->pPort, PIO_OUTPUT_0, i2c_scl_pin_desc->ulPin, PIO_OPENDRAIN );
+-  PIO_Clear( i2c_sda_pin_desc->pPort, i2c_sda_pin_desc->ulPin) ;
+-  PIO_Clear( i2c_scl_pin_desc->pPort, i2c_scl_pin_desc->ulPin) ;
+-  PIO_Configure( i2c_sda_pin_desc->pPort, PIO_INPUT, i2c_sda_pin_desc->ulPin, PIO_DEFAULT ) ;
+-  PIO_Configure( i2c_scl_pin_desc->pPort, PIO_INPUT, i2c_scl_pin_desc->ulPin, PIO_DEFAULT ) ;
+-  i2c_delay();
+-}
+-
+-/* actually, the scl line is not observed, so this procedure does not return a value */
+-static void i2c_read_scl_and_delay(void)
+-{
+-  uint32_t dwMask = i2c_scl_pin_desc->ulPin;
+-  //PIO_Configure( i2c_scl_pin_desc->pPort, PIO_INPUT, i2c_scl_pin_desc->ulPin, PIO_DEFAULT ) ;
+-  //PIO_SetInput( i2c_scl_pin_desc->pPort, i2c_scl_pin_desc->ulPin, PIO_DEFAULT ) ;
+-
+-  /* set as input */
+-  i2c_scl_pin_desc->pPort->PIO_ODR = dwMask ;
+-  i2c_scl_pin_desc->pPort->PIO_PER = dwMask ;
+-
+-  i2c_delay();
+-}
+-
+-static void i2c_clear_scl(void)
+-{
+-  uint32_t dwMask = i2c_scl_pin_desc->ulPin;
+-  
+-  /* set open collector and drive low */
+-  //PIO_Configure( i2c_scl_pin_desc->pPort, PIO_OUTPUT_0, i2c_scl_pin_desc->ulPin, PIO_OPENDRAIN );
+-  //PIO_SetOutput( i2c_scl_pin_desc->pPort, i2c_scl_pin_desc->ulPin, 0, 1, 0);
+-
+-  /* open drain, zero default output */
+-  i2c_scl_pin_desc->pPort->PIO_MDER = dwMask;
+-  i2c_scl_pin_desc->pPort->PIO_CODR = dwMask;
+-  i2c_scl_pin_desc->pPort->PIO_OER = dwMask;
+-  i2c_scl_pin_desc->pPort->PIO_PER = dwMask;
+-
+-  //PIO_Clear( i2c_scl_pin_desc->pPort, i2c_scl_pin_desc->ulPin) ;
+-}
+-
+-static uint8_t i2c_read_sda(void)
+-{
+-  uint32_t dwMask = i2c_sda_pin_desc->ulPin;
+-  //PIO_Configure( i2c_sda_pin_desc->pPort, PIO_INPUT, i2c_sda_pin_desc->ulPin, PIO_DEFAULT ) ;
+-  //PIO_SetInput( i2c_sda_pin_desc->pPort, i2c_sda_pin_desc->ulPin, PIO_DEFAULT ) ;
+-
+-  /* set as input */
+-  i2c_sda_pin_desc->pPort->PIO_ODR = dwMask ;
+-  i2c_sda_pin_desc->pPort->PIO_PER = dwMask ;
+-
+-
+-  return 1;
+-}
+-
+-static void i2c_clear_sda(void)
+-{
+-  uint32_t dwMask = i2c_sda_pin_desc->ulPin;
+-  
+-  /* set open collector and drive low */
+-  //PIO_Configure( i2c_sda_pin_desc->pPort, PIO_OUTPUT_0, i2c_sda_pin_desc->ulPin, PIO_OPENDRAIN );
+-  //PIO_SetOutput( i2c_sda_pin_desc->pPort, i2c_sda_pin_desc->ulPin, 0, 1, 0);
+-  
+-  /* open drain, zero default output */
+-  i2c_sda_pin_desc->pPort->PIO_MDER = dwMask ;
+-  i2c_sda_pin_desc->pPort->PIO_CODR = dwMask ;
+-  i2c_sda_pin_desc->pPort->PIO_OER = dwMask ;
+-  i2c_sda_pin_desc->pPort->PIO_PER = dwMask ;
+-  
+-  //PIO_Clear( i2c_sda_pin_desc->pPort, i2c_sda_pin_desc->ulPin) ;
+-}
+-
+-static void i2c_start(void)
+-{
+-  if ( i2c_started != 0 )
+-  {
+-    /* if already started: do restart */
+-    i2c_read_sda();     /* SDA = 1 */
+-    i2c_delay();
+-    i2c_read_scl_and_delay();
+-  }
+-  i2c_read_sda();
+-  /*
+-  if (i2c_read_sda() == 0)
+-  {
+-    // do something because arbitration is lost
+-  }
+-  */
+-  /* send the start condition, both lines go from 1 to 0 */
+-  i2c_clear_sda();
+-  i2c_delay();
+-  i2c_clear_scl();
+-  i2c_started = 1;
+-}
+-
+-
+-static void i2c_stop(void)
+-{
+-  /* set SDA to 0 */
+-  i2c_clear_sda();  
+-  i2c_delay();
+- 
+-  /* now release all lines */
+-  i2c_read_scl_and_delay();
+- 
+-  /* set SDA to 1 */
+-  i2c_read_sda();
+-  i2c_delay();
+-  i2c_started = 0;
+-}
+-
+-static void i2c_write_bit(uint8_t val)
+-{
+-  if (val)
+-    i2c_read_sda();
+-  else
+-    i2c_clear_sda();
+- 
+-  i2c_delay();
+-  i2c_read_scl_and_delay();
+-  i2c_clear_scl();
+-}
+-
+-static uint8_t i2c_read_bit(void)
+-{
+-  uint8_t val;
+-  /* do not drive SDA */
+-  i2c_read_sda();
+-  i2c_delay();
+-  i2c_read_scl_and_delay();
+-  val = i2c_read_sda();
+-  i2c_delay();
+-  i2c_clear_scl();
+-  return val;
+-}
+-
+-static uint8_t i2c_write_byte(uint8_t b)
+-{
+-  i2c_write_bit(b & 128);
+-  i2c_write_bit(b & 64);
+-  i2c_write_bit(b & 32);
+-  i2c_write_bit(b & 16);
+-  i2c_write_bit(b & 8);
+-  i2c_write_bit(b & 4);
+-  i2c_write_bit(b & 2);
+-  i2c_write_bit(b & 1);
+-    
+-  /* read ack from client */
+-  /* 0: ack was given by client */
+-  /* 1: nothing happend during ack cycle */  
+-  return i2c_read_bit();
+-}
+-
+-
+-
+-void u8g_i2c_init(uint8_t options)
+-{
+-  u8g_i2c_opt = options;
+-  u8g_i2c_clear_error();
+-
+-  if ( u8g_i2c_opt & U8G_I2C_OPT_FAST )
+-  {
+-    i2c_delay = i2c_400KHz_delay;
+-  }
+-  else
+-  {
+-    i2c_delay = i2c_100KHz_delay;
+-  }
+-
+-
+-  if ( u8g_i2c_opt & U8G_I2C_OPT_DEV_1 )
+-  {
+-    i2c_scl_pin = PIN_WIRE1_SCL;
+-    i2c_sda_pin = PIN_WIRE1_SDA;
+-    
+-    //REG_PIOA_PDR = PIO_PB12A_TWD1 | PIO_PB13A_TWCK1;
+-  }
+-  else
+-  {    
+-    
+-    i2c_scl_pin = PIN_WIRE_SCL;
+-    i2c_sda_pin = PIN_WIRE_SDA;
+-    
+-    //REG_PIOA_PDR = PIO_PA17A_TWD0 | PIO_PA18A_TWCK0;
+-  }
+-  
+-  i2c_init();
+-
+-}
+-
+-/* sla includes also the r/w bit */
+-uint8_t u8g_i2c_start(uint8_t sla)
+-{  
+-  i2c_start();
+-  i2c_write_byte(sla);
+-  return 1;
+-}
+-
+-uint8_t u8g_i2c_send_byte(uint8_t data)
+-{
+-  return i2c_write_byte(data);
+-}
+-
+-void u8g_i2c_stop(void)
+-{
+-  i2c_stop();
+-}
+-
+-
+-#elif defined(U8G_RASPBERRY_PI)
+-
+-#include <wiringPi.h>
+-#include <wiringPiI2C.h>
+-#include <stdio.h>
+-#include <stdlib.h>
+-#include <errno.h>
+-
+-#define I2C_SLA         0x3c
+-
+-static int fd=-1;
+-static uint8_t i2cMode = 0;
+-
+-void u8g_i2c_init(uint8_t options) {
+-   u8g_i2c_clear_error();
+-   u8g_i2c_opt = options;
+-
+-   if (wiringPiSetup() == -1) {
+-      printf("wiringPi-Error\n");
+-      exit(1);
+-   }
+-
+-   fd = wiringPiI2CSetup(I2C_SLA);
+-   if (fd < 0) {
+-      printf ("Unable to open I2C device 0: %s\n", strerror (errno)) ;
+-      exit (1) ;
+-   }
+-   //u8g_SetPIOutput(u8g, U8G_PI_RESET);
+-   //u8g_SetPIOutput(u8g, U8G_PI_A0);
+-}
+-uint8_t u8g_i2c_start(uint8_t sla) {
+-   u8g_i2c_send_mode(0);
+-
+-   return 1;
+-}
+-
+-void u8g_i2c_stop(void) {
+-}
+-
+-uint8_t u8g_i2c_send_mode(uint8_t mode) {
+-   i2cMode = mode;
+-} 
+-
+-uint8_t u8g_i2c_send_byte(uint8_t data) {
+-   wiringPiI2CWriteReg8(fd, i2cMode, data);
+-
+-   return 1;
+-}
+-
+-uint8_t u8g_i2c_wait(uint8_t mask, uint8_t pos)
+-{
+-  return 1;
+-}
+-
+-#else
+-
+-/* empty interface */
+-
+-void u8g_i2c_init(uint8_t options)
+-{
+-  u8g_i2c_clear_error();
+-}
+-
+-uint8_t u8g_i2c_wait(uint8_t mask, uint8_t pos)
+-{
+-  return 1;
+-}
+-
+-uint8_t u8g_i2c_start(uint8_t sla)
+-{
+-  return 1;
+-}
+-uint8_t u8g_i2c_send_byte(uint8_t data)
+-{
+-  return 1;
+-}
+-
+-void u8g_i2c_stop(void)
+-{
+-}
+-
+-
+-#endif
+-
+diff --git a/csrc/u8g_com_io.c b/csrc/u8g_com_io.c
+deleted file mode 100644
+index 1ebd373..0000000
+--- a/csrc/u8g_com_io.c
++++ /dev/null
+@@ -1,452 +0,0 @@
+-/*
+-  
+-  u8g_com_io.c
+-  
+-  abstraction layer for low level i/o 
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2012, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-
+-  Update for ATOMIC operation done (01 Jun 2013)
+-    U8G_ATOMIC_OR(ptr, val)
+-    U8G_ATOMIC_AND(ptr, val)
+-    U8G_ATOMIC_START();
+-    U8G_ATOMIC_END();
+-
+-  uint8_t u8g_Pin(uint8_t port, uint8_t bitpos)						Convert to internal number: AVR: port*8+bitpos, ARM: port*16+bitpos
+-  void u8g_SetPinOutput(uint8_t internal_pin_number)
+-  void u8g_SetPinInput(uint8_t internal_pin_number)
+-  void u8g_SetPinLevel(uint8_t internal_pin_number, uint8_t level)
+-  uint8_t u8g_GetPinLevel(uint8_t internal_pin_number)
+-
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(__AVR__)
+-
+-#include <avr/interrupt.h>
+-#include <avr/io.h>
+-
+-typedef volatile uint8_t * IO_PTR;
+-
+-/* create internal pin number */
+-uint8_t u8g_Pin(uint8_t port, uint8_t bitpos)
+-{
+-  port <<= 3;
+-  port += bitpos;
+-  return port;
+-}
+-
+-#if defined(__AVR_XMEGA__)
+-
+-const IO_PTR u8g_avr_ddr_P[] PROGMEM = {
+-#ifdef PORTA
+-  &PORTA.DIR,
+-#else
+-  0,
+-#endif
+-  &PORTB.DIR,
+-#ifdef PORTC
+-  &PORTC.DIR,
+-#ifdef PORTD
+-  &PORTD.DIR,
+-#ifdef PORTE
+-  &PORTE.DIR,
+-#ifdef PORTF
+-  &PORTF.DIR,
+-#ifdef PORTR
+-  &PORTR.DIR,
+-#endif
+-#endif
+-#endif
+-#endif
+-#endif
+-};
+-
+-
+-const IO_PTR u8g_avr_port_P[] PROGMEM = {
+-#ifdef PORTA
+-  &PORTA.OUT,
+-#else
+-  0,
+-#endif
+-  &PORTB.OUT,
+-#ifdef PORTC
+-  &PORTC.OUT,
+-#ifdef PORTD
+-  &PORTD.OUT,
+-#ifdef PORTE
+-  &PORTE.OUT,
+-#ifdef PORTF
+-  &PORTF.OUT,
+-#ifdef PORTR
+-  &PORTR.OUT,
+-#endif
+-#endif
+-#endif
+-#endif
+-#endif
+-};
+-
+-const IO_PTR u8g_avr_pin_P[] PROGMEM = {
+-#ifdef PORTA
+-  &PORTA.IN,
+-#else
+-  0,
+-#endif
+-  &PORTB.IN,
+-#ifdef PORTC
+-  &PORTC.IN,
+-#ifdef PORTD
+-  &PORTD.IN,
+-#ifdef PORTE
+-  &PORTE.IN,
+-#ifdef PORTF
+-  &PORTF.IN,
+-#ifdef PORTR
+-  &PORTR.IN,
+-#endif
+-#endif
+-#endif
+-#endif
+-#endif
+-};
+-
+-
+-#else
+-const IO_PTR u8g_avr_ddr_P[] PROGMEM = {
+-#ifdef DDRA
+-  &DDRA,
+-#else
+-  0,
+-#endif
+-  &DDRB,
+-#ifdef DDRC
+-  &DDRC,
+-#ifdef DDRD
+-  &DDRD,
+-#ifdef DDRE
+-  &DDRE,
+-#ifdef DDRF
+-  &DDRF,
+-#ifdef DDRG
+-  &DDRG,
+-#ifdef DDRH
+-  &DDRH,
+-#endif
+-#endif
+-#endif
+-#endif
+-#endif
+-#endif
+-};
+-
+-
+-const IO_PTR u8g_avr_port_P[] PROGMEM = {
+-#ifdef PORTA
+-  &PORTA,
+-#else
+-  0,
+-#endif
+-  &PORTB,
+-#ifdef PORTC
+-  &PORTC,
+-#ifdef PORTD
+-  &PORTD,
+-#ifdef PORTE
+-  &PORTE,
+-#ifdef PORTF
+-  &PORTF,
+-#ifdef PORTG
+-  &PORTG,
+-#ifdef PORTH
+-  &PORTH,
+-#endif
+-#endif
+-#endif
+-#endif
+-#endif
+-#endif
+-};
+-
+-const IO_PTR u8g_avr_pin_P[] PROGMEM = {
+-#ifdef PINA
+-  &PINA,
+-#else
+-  0,
+-#endif
+-  &PINB,
+-#ifdef PINC
+-  &PINC,
+-#ifdef PIND
+-  &PIND,
+-#ifdef PINE
+-  &PINE,
+-#ifdef PINF
+-  &PINF,
+-#ifdef PING
+-  &PING,
+-#ifdef PINH
+-  &PINH,
+-#endif
+-#endif
+-#endif
+-#endif
+-#endif
+-#endif
+-};
+-#endif
+-
+-static volatile uint8_t *u8g_get_avr_io_ptr(const IO_PTR *base, uint8_t offset)
+-{
+-  volatile uint8_t * tmp;
+-  base += offset;
+-  memcpy_P(&tmp, base, sizeof(volatile uint8_t * PROGMEM));
+-  return tmp; 
+-}
+-
+-/* set direction to output of the specified pin (internal pin number) */
+-void u8g_SetPinOutput(uint8_t internal_pin_number)
+-{
+-  *u8g_get_avr_io_ptr(u8g_avr_ddr_P, internal_pin_number>>3) |= _BV(internal_pin_number&7);
+-}
+-
+-void u8g_SetPinInput(uint8_t internal_pin_number)
+-{
+-  *u8g_get_avr_io_ptr(u8g_avr_ddr_P, internal_pin_number>>3) &= ~_BV(internal_pin_number&7);
+-}
+-
+-void u8g_SetPinLevel(uint8_t internal_pin_number, uint8_t level)
+-{
+-  volatile uint8_t * tmp = u8g_get_avr_io_ptr(u8g_avr_port_P, internal_pin_number>>3);
+-  
+-  if ( level == 0 )
+-  {
+-    U8G_ATOMIC_AND(tmp, ~_BV(internal_pin_number&7));
+-   // *tmp &= ~_BV(internal_pin_number&7);
+-  }
+-  else
+-  {
+-    U8G_ATOMIC_OR(tmp, _BV(internal_pin_number&7));
+-    //*tmp |= _BV(internal_pin_number&7);
+-  }
+-  
+-}
+-
+-uint8_t u8g_GetPinLevel(uint8_t internal_pin_number)
+-{
+-  volatile uint8_t * tmp = u8g_get_avr_io_ptr(u8g_avr_pin_P, internal_pin_number>>3);
+-  if ( ((*tmp) & _BV(internal_pin_number&7))  != 0 )
+-    return 1;
+-  return 0;
+-}
+-
+-#elif defined (__MSP430__)
+-#include <msp430.h>
+-
+-typedef volatile uint8_t * IO_PTR;
+-
+-// MSP430 F5XXX / F6XXX series. 
+-const IO_PTR u8g_msp_ddr_P[] PROGMEM = {
+-	&P1DIR
+-	,&P2DIR
+-	,&P3DIR
+-	,&P4DIR
+-	,&P5DIR
+-	,&P6DIR
+-	,&P7DIR
+-	,&P8DIR
+-#if defined (__MSP430_HAS_PORT9_R__)
+-	,&P9DIR
+-#if defined (__MSP430_HAS_PORT10_R__)
+-	,&P10DIR
+-#endif
+-#endif
+-};
+-
+-const IO_PTR u8g_msp_port_P[] PROGMEM = {
+-	&P1OUT
+-	,&P2OUT
+-	,&P3OUT
+-	,&P4OUT
+-	,&P5OUT
+-	,&P6OUT
+-	,&P7OUT
+-	,&P8OUT
+-#if defined (__MSP430_HAS_PORT9_R__)
+-	,&P9OUT
+-#if defined (__MSP430_HAS_PORT10_R__)
+-	,&P10OUT
+-#endif
+-#endif
+-};
+-
+-const IO_PTR u8g_msp_pin_P[] PROGMEM = {
+-	&P1IN
+-	,&P2IN
+-	,&P3IN
+-	,&P4IN
+-	,&P5IN
+-	,&P6IN
+-	,&P7IN
+-	,&P8IN
+-#if defined (__MSP430_HAS_PORT9_R__)
+-	,&P9IN
+-#if defined (__MSP430_HAS_PORT10_R__)
+-	,&P10IN
+-#endif
+-#endif
+-};
+-
+-uint8_t u8g_Pin(uint8_t port, uint8_t bitpos)
+-{
+-	port <<= 3;
+-	port += bitpos;
+-	return port;
+-}
+-
+-void u8g_SetPinOutput(uint8_t internal_pin_number)
+-{
+-	uint8_t port = (internal_pin_number >> 3)-1;
+-	uint8_t output = 1 << (internal_pin_number & 0x07);
+-	*u8g_msp_ddr_P[port] |= output;
+-}
+-
+-void u8g_SetPinInput(uint8_t internal_pin_number)
+-{
+-	uint8_t port = (internal_pin_number >> 3)-1;
+-	*u8g_msp_ddr_P[port] &= ~(1 << (internal_pin_number & 0x07));
+-}
+-
+-void u8g_SetPinLevel(uint8_t internal_pin_number, uint8_t level)
+-{
+-	uint8_t port = (internal_pin_number >> 3)-1;
+-	if (level == 0)
+-	{
+-		*u8g_msp_port_P[port] &= ~(1 << (internal_pin_number & 0x07));
+-	}
+-	else
+-	{
+-		*u8g_msp_port_P[port]|= (1 << (internal_pin_number & 0x07));
+-	}
+-}
+-
+-uint8_t u8g_GetPinLevel(uint8_t internal_pin_number)
+-{
+-	uint8_t port = (internal_pin_number >> 3)-1;
+-	uint8_t tmp = *u8g_msp_pin_P[port];
+-	if (tmp & (1 << (internal_pin_number & 0x07)))
+-	{
+-		return 1;
+-	}
+-	return 0;
+-}
+-
+-#elif defined(U8G_RASPBERRY_PI)
+-
+-#include <wiringPi.h>
+-//#include "/usr/local/include/wiringPi.h"
+-
+-void u8g_SetPinOutput(uint8_t internal_pin_number) {
+-   pinMode(internal_pin_number, OUTPUT);
+-}
+-
+-void u8g_SetPinInput(uint8_t internal_pin_number) {
+-   pinMode(internal_pin_number, INPUT);
+-}
+-
+-void u8g_SetPinLevel(uint8_t internal_pin_number, uint8_t level) {
+-   digitalWrite(internal_pin_number, level);
+-}
+-
+-uint8_t u8g_GetPinLevel(uint8_t internal_pin_number) {
+-   return digitalRead(internal_pin_number);
+-}
+-
+-
+-#else
+-
+-/* convert "port" and "bitpos" to internal pin number */
+-uint8_t u8g_Pin(uint8_t port, uint8_t bitpos)
+-{
+-  port <<= 3;
+-  port += bitpos;
+-  return port;
+-}
+-
+-void u8g_SetPinOutput(uint8_t internal_pin_number)
+-{
+-}
+-
+-void u8g_SetPinInput(uint8_t internal_pin_number)
+-{
+-}
+-
+-void u8g_SetPinLevel(uint8_t internal_pin_number, uint8_t level)
+-{
+-}
+-
+-uint8_t u8g_GetPinLevel(uint8_t internal_pin_number)
+-{
+-  return 0;
+-}
+-
+-#endif
+-
+-
+-#if defined(U8G_WITH_PINLIST)
+-
+-void u8g_SetPIOutput(u8g_t *u8g, uint8_t pi)
+-{
+-  uint8_t pin;
+-  pin = u8g->pin_list[pi];
+-  if ( pin != U8G_PIN_NONE )
+-    u8g_SetPinOutput(pin);
+-}
+-
+-void u8g_SetPILevel(u8g_t *u8g, uint8_t pi, uint8_t level)
+-{
+-  uint8_t pin;
+-  pin = u8g->pin_list[pi];
+-  if ( pin != U8G_PIN_NONE )
+-    u8g_SetPinLevel(pin, level);
+-}
+-
+-#else  /* defined(U8G_WITH_PINLIST) */
+-void u8g_SetPIOutput(u8g_t *u8g, uint8_t pi)
+-{
+-}
+-
+-void u8g_SetPILevel(u8g_t *u8g, uint8_t pi, uint8_t level)
+-{
+-}
+-
+-#endif /* defined(U8G_WITH_PINLIST) */
+diff --git a/csrc/u8g_com_linux_ssd_i2c.c b/csrc/u8g_com_linux_ssd_i2c.c
+deleted file mode 100644
+index bd5b735..0000000
+--- a/csrc/u8g_com_linux_ssd_i2c.c
++++ /dev/null
+@@ -1,168 +0,0 @@
+-/*
+-
+-  u8g_com_linux_ssd_i2c.c
+-
+-  com interface for linux i2c-dev and the SSDxxxx chip (SOLOMON) variant
+-  I2C protocol
+-
+-
+-  Universal 8bit Graphics Library
+-
+-  Copyright (c) 2012, olikraus@gmail.com
+-  Copyright (c) 2015, daniel@redfelineninja.org.uk
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification,
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list
+-    of conditions and the following disclaimer.
+-
+-  * Redistributions in binary form must reproduce the above copyright notice, this
+-    list of conditions and the following disclaimer in the documentation and/or other
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(U8G_LINUX)
+-
+-#include <errno.h>
+-#include <stdbool.h>
+-#include <stdio.h>
+-#include <stdlib.h>
+-#include <string.h>
+-
+-#include <sys/types.h>
+-#include <sys/ioctl.h>
+-#include <sys/stat.h>
+-#include <fcntl.h>
+-#include <unistd.h>
+-
+-#include <linux/i2c-dev.h>
+-
+-
+-#define I2C_SLA		0x3c
+-#define I2C_CMD_MODE	0x80
+-#define I2C_DATA_MODE	0x40
+-#define MAX_PACKET      64
+-
+-#ifndef U8G_WITH_PINLIST
+-#error U8G_WITH_PINLIST is mandatory for this driver
+-#endif
+-
+-static void set_cmd_mode(u8g_t *u8g, bool cmd_mode)
+-{
+-  u8g->pin_list[U8G_PI_A0_STATE] = cmd_mode;
+-}
+-
+-static bool get_cmd_mode(u8g_t *u8g)
+-{
+-  return u8g->pin_list[U8G_PI_A0_STATE];
+-}
+-
+-static uint8_t send_data_burst(u8g_t *u8g, int fd, uint8_t *buf, size_t buflen)
+-{
+-  uint8_t i2cbuf[2*MAX_PACKET];
+-  uint8_t i2clen;
+-  int res;
+-
+-  /* ignore bursts when there is no file open */
+-  if (fd < 0)
+-	  return 0;
+-
+-  if (get_cmd_mode(u8g)) {
+-    i2clen = 0;
+-    while (buflen > 0) {
+-      i2cbuf[i2clen++] = I2C_CMD_MODE;
+-      i2cbuf[i2clen++] = *buf++;
+-      buflen--;
+-    }
+-  } else {
+-    i2cbuf[0] = I2C_DATA_MODE;
+-    memcpy(i2cbuf+1, buf, buflen);
+-    i2clen = buflen + 1;
+-  }
+-
+-  res = write(fd, i2cbuf, i2clen);
+-  if (res < 0)
+-    fprintf(stderr, "I2C write failed (%s)\n", strerror(errno));
+-  else if (res != i2clen)
+-    fprintf(stderr, "Incomplete I2C write (%d of %d packet)\n", res, i2clen);
+-
+-  return res == i2clen;
+-}
+-
+-uint8_t u8g_com_linux_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  static int fd = -1;
+-  char dev[24];
+-
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      sprintf(dev, "/dev/i2c-%d", u8g->pin_list[U8G_PI_I2C_OPTION]);
+-      fd = open(dev, O_RDWR);
+-      if (fd < 0) {
+-	fprintf(stderr, "cannot open %s (%s)\n", dev, strerror(errno));
+-	return 0;
+-      }
+-
+-      if (ioctl(fd, I2C_SLAVE, I2C_SLA) < 0) {
+-	fprintf(stderr, "cannot set slave address (%s)\n", strerror(errno));
+-	return 0;
+-      }
+-
+-      break;
+-
+-    case U8G_COM_MSG_STOP:
+-      /* ignored - i2c-dev will automatically stop between writes */
+-      break;
+-
+-    case U8G_COM_MSG_RESET:
+-      /* ignored - no obvious means to reset an SSD via I2C */
+-      break;
+-
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      set_cmd_mode(u8g, true);
+-      break;
+-
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      send_data_burst(u8g, fd, &arg_val, 1);
+-      break;
+-
+-    case U8G_COM_MSG_WRITE_SEQ:
+-    case U8G_COM_MSG_WRITE_SEQ_P:	/* no progmem in Linux */
+-      while (arg_val > MAX_PACKET) {
+-	send_data_burst(u8g, fd, arg_ptr, MAX_PACKET);
+-	arg_ptr += MAX_PACKET;
+-	arg_val -= MAX_PACKET;
+-      }
+-      send_data_burst(u8g, fd, arg_ptr, arg_val);
+-      break;
+-
+-    case U8G_COM_MSG_ADDRESS:
+-      /* choose cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      set_cmd_mode(u8g, !arg_val);
+-      break;
+-  }
+-
+-  return 1;
+-}
+-
+-#endif /* U8G_LINUX */
+diff --git a/csrc/u8g_com_msp430_hw_spi.c b/csrc/u8g_com_msp430_hw_spi.c
+deleted file mode 100644
+index 18c4d77..0000000
+--- a/csrc/u8g_com_msp430_hw_spi.c
++++ /dev/null
+@@ -1,221 +0,0 @@
+-/*
+-  
+-  u8g_com_msp430_hw_spi.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2012, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+- 
+-*/ 
+- 
+-#include "u8g.h"
+-
+-#if defined(__MSP430__)
+-#define U8G_MSP430_HW_SPI
+-#endif
+-
+-#if defined(U8G_MSP430_HW_SPI)
+-
+-#include <msp430.h>
+-
+-#ifndef F_CPU
+-#error "Please specifiy actual master clock using F_CPU in HZ"
+-#endif
+-#ifndef F_SPI
+-#define F_SPI  1000000UL
+-#endif
+-
+-#define U8G_USE_USCIA0	1
+-#define U8G_USE_USCIB0	2
+-#define U8G_USE_USCIA1	3
+-#define U8G_USE_USCIB1	4
+-#define U8G_USE_USCIA2	5
+-#define U8G_USE_USCIB2	6
+-#define U8G_USE_USCIA3	7
+-#define U8G_USE_USCIB3	8
+-
+-#ifndef U8G_USE_USCI
+-#define U8G_USE_USCI	U8G_USE_USCIB0
+-#endif
+-
+-#if U8G_USE_USCI == 1
+-#define UCIFG	UCA0IFG
+-#define UCTXBUF UCA0TXBUF
+-#define UCSTAT  UCA0STAT
+-#define UCCTL0  UCA0CTL0
+-#define UCCTL1  UCA0CTL1
+-#define UCBR0   UCA0BR0
+-#define UCBR1   UCA0BR1
+-#elif U8G_USE_USCI == 2
+-#define UCIFG	UCB0IFG
+-#define UCTXBUF UCB0TXBUF
+-#define UCSTAT  UCB0STAT
+-#define UCCTL0  UCB0CTL0
+-#define UCCTL1  UCB0CTL1
+-#define UCBR0   UCB0BR0
+-#define UCBR1   UCB0BR1
+-#elif U8G_USE_USCI == 3
+-#define UCIFG	UCA1IFG
+-#define UCTXBUF UCA1TXBUF
+-#define UCSTAT  UCA1STAT
+-#define UCCTL0  UCA1CTL0
+-#define UCCTL1  UCA1CTL1
+-#define UCBR0   UCA1BR0
+-#define UCBR1   UCA1BR1
+-#elif U8G_USE_USCI == 4
+-#define UCIFG	UCB1IFG
+-#define UCTXBUF UCB1TXBUF
+-#define UCSTAT  UCB1STAT
+-#define UCCTL0  UCB1CTL0
+-#define UCCTL1  UCB1CTL1
+-#define UCBR0   UCB1BR0
+-#define UCBR1   UCB1BR1
+-#elif U8G_USE_USCI == 5
+-#define UCIFG	UCA2IFG
+-#define UCTXBUF UCA2TXBUF
+-#define UCSTAT  UCA2STAT
+-#define UCCTL0  UCA2CTL0
+-#define UCCTL1  UCA2CTL1
+-#define UCBR0   UCA2BR0
+-#define UCBR1   UCA2BR1
+-#elif U8G_USE_USCI == 6
+-#define UCIFG	UCB2IFG
+-#define UCTXBUF UCB2TXBUF
+-#define UCSTAT  UCB2STAT
+-#define UCCTL0  UCB2CTL0
+-#define UCCTL1  UCB2CTL1
+-#define UCBR0   UCB2BR0
+-#define UCBR1   UCB2BR1
+-#elif U8G_USE_USCI == 7
+-#define UCIFG	UCA3IFG
+-#define UCTXBUF UCA3TXBUF
+-#define UCSTAT  UCA3STAT
+-#define UCCTL0  UCA3CTL0
+-#define UCCTL1  UCA3CTL1
+-#define UCBR0   UCA3BR0
+-#define UCBR1   UCA3BR1
+-#elif U8G_USE_USCI == 8
+-#define UCIFG	UCB3IFG
+-#define UCTXBUF UCB3TXBUF
+-#define UCSTAT  UCB3STAT
+-#define UCCTL0  UCB3CTL0
+-#define UCCTL1  UCB3CTL1
+-#define UCBR0   UCB3BR0
+-#define UCBR1   UCB3BR1
+-#endif
+-
+-inline void u8g_msp430_spi_out(uint8_t data)
+-{
+-  while (!(UCIFG&UCTXIFG));
+-  UCTXBUF = data;
+-}
+-
+-uint8_t u8g_com_msp430_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_STOP:
+-      break;
+-    
+-    case U8G_COM_MSG_INIT:
+-	/*
+- 	 * on MSP430 you need to set PSEL alternative function which
+- 	 * may not be required on other MCU's - should be handled
+- 	 * by a low level u8g_SetPinAlternate(pin_number)...
+- 	 */
+-      UCCTL1 |= UCSWRST;                      // **Put state machine in reset**
+-      UCCTL0 |= UCMST|UCSYNC|UCCKPL|UCMSB;    // 3-pin, 8-bit SPI master Clock polarity high, MSB
+-      UCCTL1 |= UCSSEL_2;                     // SMCLK
+-      UCBR0 = (unsigned char)(F_CPU/F_SPI);   // 
+-      UCBR1 = 0;                              //
+-      UCCTL1 &= ~UCSWRST;                     // **Initialize USCI state machine**
+-      u8g_SetPILevel(u8g, U8G_PI_CS, 1);
+-      u8g_SetPILevel(u8g, U8G_PI_A0, 1);
+-      u8g_SetPILevel(u8g, U8G_PI_RESET, 1);
+-      u8g_SetPIOutput(u8g, U8G_PI_CS);
+-      u8g_SetPIOutput(u8g, U8G_PI_A0);
+-      u8g_SetPIOutput(u8g, U8G_PI_RESET);
+-
+-      break;
+-    
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g_SetPILevel(u8g, U8G_PI_A0, arg_val);
+-      break;
+-
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      
+-       u8g_SetPILevel(u8g, U8G_PI_CS, (arg_val ? 0 : 1));
+-      break;
+-      
+-    case U8G_COM_MSG_RESET:
+-
+-      u8g_SetPILevel(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_msp430_spi_out(arg_val);
+-      while ((UCSTAT&UCBUSY));
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_msp430_spi_out(*ptr++);
+-          arg_val--;
+-        }
+-        while ((UCSTAT&UCBUSY));
+-      }
+-      break;
+-    case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_msp430_spi_out(u8g_pgm_read(ptr));
+-          ptr++;
+-          arg_val--;
+-        }
+-        while ((UCSTAT&UCBUSY));
+-      }
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-uint8_t u8g_com_msp430_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif
+-
+-
+diff --git a/csrc/u8g_com_psoc5_ssd_hw_parallel.c b/csrc/u8g_com_psoc5_ssd_hw_parallel.c
+deleted file mode 100644
+index 668c61b..0000000
+--- a/csrc/u8g_com_psoc5_ssd_hw_parallel.c
++++ /dev/null
+@@ -1,107 +0,0 @@
+-/*
+-  
+-  u8g_com_psoc5_ssd_hw_parallel.c
+-
+-  com interface for Cypress PSoC5 and the SSDxxxx chip variant
+-  I2C protocol
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2015, olikraus@gmail.com, schmidt.ronny@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-   
+-   
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(U8G_CYPRESS_PSOC5)
+-  
+-#include <project.h>   
+-
+-static uint8 dc = 0; // need to store whether next write is data or command
+-  
+-uint8_t u8g_com_psoc5_ssd_hw_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_STOP:
+-      // stop the device
+-      GraphicLCDIntf_Stop();
+-      break;
+-    
+-    case U8G_COM_MSG_INIT:
+-  		// init hardware interfaces, timers, gpios, ...
+-      GraphicLCDIntf_Init();
+-      break;
+-    
+-    case U8G_COM_MSG_ADDRESS:                     
+-      // switch from cmd (arg_val = 0) to data mode (arg_val = 1) or vice versa
+-      dc = arg_val;
+-      break;
+-
+-    case U8G_COM_MSG_CHIP_SELECT:
+-		  /* done by the hardware */
+-      break;
+-      
+-    case U8G_COM_MSG_RESET:
+-      // toggle the reset pin of the display by value in arg_val
+-      nRES_Write(0);
+-      u8g_10MicroDelay();
+-      nRES_Write(1);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      // write byte to the device
+-		  GraphicLCDIntf_Write8(dc, arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-    case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        // write a sequence of bytes to the device
+-        register uint8_t *ptr = arg_ptr;
+-        while (arg_val-- > 0)
+-        {
+-          GraphicLCDIntf_Write8(dc, *ptr++);
+-        }
+-      }
+-      break;
+-      
+-
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-uint8_t u8g_com_psoc5_ssd_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif
+diff --git a/csrc/u8g_com_raspberrypi_hw_spi.c b/csrc/u8g_com_raspberrypi_hw_spi.c
+deleted file mode 100644
+index 611391f..0000000
+--- a/csrc/u8g_com_raspberrypi_hw_spi.c
++++ /dev/null
+@@ -1,124 +0,0 @@
+-/*
+-  
+-  u8g_com_raspberrypi_hw_spi.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2012, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
+-  
+-  Assumes, that 
+-    MOSI is at PORTB, Pin 3
+-  and
+-    SCK is at PORTB, Pin 5
+-
+-  Update for ATOMIC operation done (01 Jun 2013)
+-    U8G_ATOMIC_OR(ptr, val)
+-    U8G_ATOMIC_AND(ptr, val)
+-    U8G_ATOMIC_START()
+-    U8G_ATOMIC_END()
+- 
+-
+-
+-*/
+-
+-#include "u8g.h"
+-
+-
+-
+-#if defined(U8G_RASPBERRY_PI)
+-
+-#include <wiringPiSPI.h>
+-#include <wiringPi.h>
+-#include <stdio.h>
+-#include <stdlib.h>
+-#include <errno.h>
+-
+-uint8_t u8g_com_raspberrypi_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_STOP:
+-      break;
+-    
+-    case U8G_COM_MSG_INIT:
+-		// check wiringPi setup
+-		if (wiringPiSetup() == -1)
+-		{
+-			printf("wiringPi-Error\n");
+-			exit(1);
+-		}
+-
+-		if (wiringPiSPISetup (0, 100000) < 0)
+-		{
+-			printf ("Unable to open SPI device 0: %s\n", strerror (errno)) ;
+-			exit (1) ;
+-		}
+-		
+-		u8g_SetPIOutput(u8g, U8G_PI_RESET);
+-		u8g_SetPIOutput(u8g, U8G_PI_A0);
+-
+-      break;
+-    
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-	  u8g_SetPILevel(u8g, U8G_PI_A0, arg_val);
+-      break;
+-
+-    case U8G_COM_MSG_CHIP_SELECT:
+-		/* Done by the SPI hardware */
+-      break;
+-      
+-    case U8G_COM_MSG_RESET:
+-      u8g_SetPILevel(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_BYTE:
+-		wiringPiSPIDataRW (0, &arg_val, 1) ;
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-		wiringPiSPIDataRW (0, arg_ptr, arg_val);
+-      break;
+-
+-	case U8G_COM_MSG_WRITE_SEQ_P:
+-		wiringPiSPIDataRW (0, arg_ptr, arg_val);		
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-uint8_t u8g_com_raspberrypi_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-#endif
+-
+-
+diff --git a/csrc/u8g_com_raspberrypi_ssd_i2c.c b/csrc/u8g_com_raspberrypi_ssd_i2c.c
+deleted file mode 100644
+index 88d85de..0000000
+--- a/csrc/u8g_com_raspberrypi_ssd_i2c.c
++++ /dev/null
+@@ -1,176 +0,0 @@
+-/*  
+-  Special pin usage:
+-    U8G_PI_I2C_OPTION	additional options
+-    U8G_PI_A0_STATE	used to store the last value of the command/data register selection
+-    U8G_PI_SET_A0		1: Signal request to update I2C device with new A0_STATE, 0: Do nothing, A0_STATE matches I2C device
+-    U8G_PI_SCL		clock line (NOT USED)
+-    U8G_PI_SDA		data line (NOT USED)
+-    
+-    U8G_PI_RESET		reset line (currently disabled, see below)
+-
+-  Protocol:
+-    SLA, Cmd/Data Selection, Arguments
+-    The command/data register is selected by a special instruction byte, which is sent after SLA
+-    
+-    The continue bit is always 0 so that a (re)start is equired for the change from cmd to/data mode
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(U8G_RASPBERRY_PI)
+-
+-#include <wiringPi.h>
+-#include <wiringPiI2C.h>
+-#include <stdio.h>
+-#include <stdlib.h>
+-#include <errno.h>
+-
+-#define I2C_SLA		0x3c
+-#define I2C_CMD_MODE	0x000
+-#define I2C_DATA_MODE	0x040
+-
+-#if defined(U8G_WITH_PINLIST)
+-
+-uint8_t u8g_com_raspberrypi_ssd_start_sequence(u8g_t *u8g)
+-{
+-  /* are we requested to set the a0 state? */
+-  if ( u8g->pin_list[U8G_PI_SET_A0] == 0 )
+-    return 1;	
+-  
+-  /* setup bus, might be a repeated start */
+-  if ( u8g_i2c_start(I2C_SLA) == 0 )
+-    return 0;
+-  if ( u8g->pin_list[U8G_PI_A0_STATE] == 0 )
+-  {
+-    if ( u8g_i2c_send_mode(I2C_CMD_MODE) == 0 )
+-      return 0;
+-  }
+-  else
+-  {
+-    if ( u8g_i2c_send_mode(I2C_DATA_MODE) == 0 )
+-      return 0;
+-  }
+-  
+-  
+-  u8g->pin_list[U8G_PI_SET_A0] = 0;
+-  return 1;
+-}
+-
+-uint8_t u8g_com_raspberrypi_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      u8g_i2c_init(u8g->pin_list[U8G_PI_I2C_OPTION]);
+-      u8g_SetPIOutput(u8g, U8G_PI_RESET);
+-      u8g_SetPIOutput(u8g, U8G_PI_A0);
+-      break;
+-    
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_RESET:
+-      break;
+-      
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      u8g->pin_list[U8G_PI_A0_STATE] = 0;
+-      u8g->pin_list[U8G_PI_SET_A0] = 1;		/* force a0 to set again, also forces start condition */
+-      if ( arg_val == 0 )
+-      {
+-        /* disable chip, send stop condition */
+-	u8g_i2c_stop();
+-     }
+-      else
+-      {
+-        /* enable, do nothing: any byte writing will trigger the i2c start */
+-      }
+-      break;
+-
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      //u8g->pin_list[U8G_PI_SET_A0] = 1;
+-      if ( u8g_com_raspberrypi_ssd_start_sequence(u8g) == 0 )
+-	return u8g_i2c_stop(), 0;
+-      if ( u8g_i2c_send_byte(arg_val) == 0 )
+-	return u8g_i2c_stop(), 0;
+-      // u8g_i2c_stop();
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      //u8g->pin_list[U8G_PI_SET_A0] = 1;
+-      if ( u8g_com_raspberrypi_ssd_start_sequence(u8g) == 0 )
+-	return u8g_i2c_stop(), 0;
+-      {
+-        register uint8_t *ptr = (uint8_t *)arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-	  if ( u8g_i2c_send_byte(*ptr++) == 0 )
+-	    return u8g_i2c_stop(), 0;
+-          arg_val--;
+-        }
+-      }
+-      // u8g_i2c_stop();
+-      break;
+-
+-    case U8G_COM_MSG_WRITE_SEQ_P:
+-      //u8g->pin_list[U8G_PI_SET_A0] = 1;
+-      if ( u8g_com_raspberrypi_ssd_start_sequence(u8g) == 0 )
+-	return u8g_i2c_stop(), 0;
+-      {
+-        register uint8_t *ptr = (uint8_t *)arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-	  if ( u8g_i2c_send_byte(u8g_pgm_read(ptr)) == 0 )
+-	    return 0;
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      // u8g_i2c_stop();
+-      break;
+-      
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g->pin_list[U8G_PI_A0_STATE] = arg_val;
+-      u8g->pin_list[U8G_PI_SET_A0] = 1;		/* force a0 to set again */
+-    
+-#ifdef OLD_CODE    
+-      if ( i2c_state != 0 )
+-      {
+-	u8g_i2c_stop();
+-	i2c_state = 0;
+-      }
+-
+-      if ( u8g_com_raspberrypi_ssd_start_sequence(arg_val) == 0 )
+-	return 0;
+-    
+-      /* setup bus, might be a repeated start */
+-      /*
+-      if ( u8g_i2c_start(I2C_SLA) == 0 )
+-	return 0;
+-      if ( arg_val == 0 )
+-      {
+-	i2c_state = 1;
+-	
+-	if ( u8g_i2c_send_byte(I2C_CMD_MODE) == 0 )
+-	  return 0;
+-      }
+-      else
+-      {
+-	i2c_state = 2;
+-	if ( u8g_i2c_send_byte(I2C_DATA_MODE) == 0 )
+-	  return 0;
+-      }
+-      */
+-#endif
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else	/* defined(U8G_WITH_PINLIST) */
+-
+-uint8_t u8g_com_raspberrypi_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr) {
+-   return 1;
+-}
+-
+-#endif	/* defined(U8G_WITH_PINLIST) */
+-#endif
+diff --git a/csrc/u8g_com_std_sw_spi.c b/csrc/u8g_com_std_sw_spi.c
+deleted file mode 100644
+index 91f58ae..0000000
+--- a/csrc/u8g_com_std_sw_spi.c
++++ /dev/null
+@@ -1,140 +0,0 @@
+-/*
+-  
+-  u8g_com_std_sw_spi.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2015, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
+-*/
+-
+-#include "u8g.h"
+-
+-#if defined(U8G_WITH_PINLIST)
+-
+-static void u8g_sw_spi_shift_out(uint8_t dataPin, uint8_t clockPin, uint8_t val)
+-{
+-  uint8_t i = 8;
+-  do
+-  {
+-    if ( val & 128 )
+-      u8g_SetPinLevel(dataPin, 1);
+-    else
+-      u8g_SetPinLevel(dataPin, 0);
+-    val <<= 1;
+-    u8g_MicroDelay();		/* 23 Sep 2012 */
+-    //delay(1);
+-    u8g_SetPinLevel(clockPin, 1);
+-    u8g_MicroDelay();		/* 23 Sep 2012 */
+-    //delay(1);
+-    u8g_SetPinLevel(clockPin, 0);
+-    u8g_MicroDelay();		/* 23 Sep 2012 */
+-    //delay(1);
+-    i--;
+-  } while( i != 0 );
+-}
+-
+-uint8_t u8g_com_std_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  switch(msg)
+-  {
+-    case U8G_COM_MSG_INIT:
+-      u8g_SetPIOutput(u8g, U8G_PI_SCK);
+-      u8g_SetPIOutput(u8g, U8G_PI_MOSI);
+-      u8g_SetPIOutput(u8g, U8G_PI_RESET);
+-      u8g_SetPIOutput(u8g, U8G_PI_CS);
+-      u8g_SetPIOutput(u8g, U8G_PI_A0);
+-      u8g_SetPILevel(u8g, U8G_PI_SCK, 0);
+-      u8g_SetPILevel(u8g, U8G_PI_MOSI, 0);
+-      break;
+-    
+-    case U8G_COM_MSG_STOP:
+-      break;
+-
+-    case U8G_COM_MSG_RESET:
+-      u8g_SetPILevel(u8g, U8G_PI_RESET, arg_val);
+-      break;
+-      
+-    case U8G_COM_MSG_CHIP_SELECT:
+-      if ( arg_val == 0 )
+-      {
+-        /* disable */
+-	u8g_SetPILevel(u8g, U8G_PI_CS, 1);
+-      }
+-      else
+-      {
+-        /* enable */
+-	u8g_SetPILevel(u8g, U8G_PI_SCK, 0);
+-	u8g_SetPILevel(u8g, U8G_PI_CS, 0);
+-      }
+-      break;
+-
+-    case U8G_COM_MSG_WRITE_BYTE:
+-      u8g_sw_spi_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK], arg_val);
+-      break;
+-    
+-    case U8G_COM_MSG_WRITE_SEQ:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_sw_spi_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK], *ptr++);
+-          arg_val--;
+-        }
+-      }
+-      break;
+-
+-      case U8G_COM_MSG_WRITE_SEQ_P:
+-      {
+-        register uint8_t *ptr = arg_ptr;
+-        while( arg_val > 0 )
+-        {
+-          u8g_sw_spi_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK], u8g_pgm_read(ptr));
+-          ptr++;
+-          arg_val--;
+-        }
+-      }
+-      break;
+-      
+-    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+-      u8g_SetPILevel(u8g, U8G_PI_A0, arg_val);
+-      break;
+-  }
+-  return 1;
+-}
+-
+-#else
+-
+-
+-uint8_t u8g_com_std_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+-{
+-  return 1;
+-}
+-
+-
+-#endif
+diff --git a/csrc/u8g_delay.c b/csrc/u8g_delay.c
+deleted file mode 100644
+index 76137b2..0000000
+--- a/csrc/u8g_delay.c
++++ /dev/null
+@@ -1,323 +0,0 @@
+-/*
+-
+-  u8g_delay.c
+-
+-  Universal 8bit Graphics Library
+-  
+-  Copyright (c) 2011, olikraus@gmail.com
+-  All rights reserved.
+-
+-  Redistribution and use in source and binary forms, with or without modification, 
+-  are permitted provided that the following conditions are met:
+-
+-  * Redistributions of source code must retain the above copyright notice, this list 
+-    of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
+-    materials provided with the distribution.
+-
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-
+-
+-  void u8g_Delay(uint16_t val)		Delay by "val" milliseconds
+-  void u8g_MicroDelay(void)		Delay be one microsecond
+-  void u8g_10MicroDelay(void)	Delay by 10 microseconds
+-
+-  
+-*/
+-
+-
+-#include "u8g.h"
+-
+-/*==== Part 1: Derive suitable delay procedure ====*/
+-
+-#if defined(ARDUINO)
+-
+-#  if ARDUINO < 100 
+-#    include <WProgram.h> 
+-#  else 
+-#    include <Arduino.h> 
+-#  endif
+-
+-/* issue 353 */
+-#if defined(ARDUINO_ARCH_SAMD)
+-#    include <delay.h>
+-#endif
+-
+-#  if defined(__AVR__)
+-#    define USE_AVR_DELAY
+-#  elif defined(__PIC32MX)
+-#    define USE_PIC32_DELAY
+-#  elif defined(__arm__)		/* Arduino Due & Teensy */
+-#    define USE_ARDUINO_DELAY
+-#  else
+-#    define USE_ARDUINO_DELAY
+-#  endif
+-#elif defined(_GNU_SOURCE)
+-#  define USE_LINUX_DELAY
+-#elif defined(__MSP430__)
+-#  define USE_MSP430_DELAY
+-#elif defined(U8G_RASPBERRY_PI)
+-#  define USE_RASPBERRYPI_DELAY
+-#elif defined(__AVR__)
+-#  define USE_AVR_DELAY
+-#elif defined(__18CXX)
+-#  define USE_PIC18_DELAY
+-#elif defined(U8G_CYPRESS_PSOC5)
+-#define USE_PSOC5_DELAY
+-#elif defined(__arm__)
+-/* do not define anything, all procedures are expected to be defined outside u8glib */
+-
+-/*
+-void u8g_Delay(uint16_t val);
+-void u8g_MicroDelay(void);
+-void u8g_10MicroDelay(void);
+-*/
+-
+-#else
+-#  define USE_DUMMY_DELAY
+-#endif
+-
+-
+-
+-/*==== Part 2: Definition of the delay procedures ====*/
+-
+-/*== Raspberry Pi Delay ==*/
+-#if defined (USE_RASPBERRYPI_DELAY)
+-#include <wiringPi.h>
+-//#include "/usr/local/include/wiringPi.h"
+-void u8g_Delay(uint16_t val) {
+-   //delay(val);
+-   //usleep((uint32_t)val*(uint32_t)1000);
+-   delayMicroseconds((uint32_t)val*(uint32_t)1000);
+-}
+-void u8g_MicroDelay(void)
+-{
+-   usleep(1);
+-}
+-void u8g_10MicroDelay(void)
+-{
+-   usleep(10);
+-}
+-#endif
+-
+-#if defined(USE_LINUX_DELAY)
+-void u8g_Delay(uint16_t val) {
+-   //delay(val);
+-   usleep((uint32_t)val*(uint32_t)1000);
+-}
+-void u8g_MicroDelay(void)
+-{
+-   usleep(1);
+-}
+-void u8g_10MicroDelay(void)
+-{
+-   usleep(10);
+-}
+-#endif
+-
+-
+-
+-/*== AVR Delay ==*/
+-
+-#if defined(USE_AVR_DELAY)
+-#include <avr/interrupt.h>
+-#include <avr/io.h>
+-#include <util/delay.h>
+-
+-/*
+-  Delay by the provided number of milliseconds.
+-  Thus, a 16 bit value will allow a delay of 0..65 seconds
+-  Makes use of the _delay_loop_2
+-  
+-  _delay_loop_2 will do a delay of n * 4 prozessor cycles.
+-  with f = F_CPU cycles per second,
+-  n = f / (1000 * 4 )
+-  with f = 16000000 the result is 4000
+-  with f = 1000000 the result is 250
+-  
+-  the millisec loop, gcc requires the following overhead:
+-  - movev 1
+-  - subwi 2x2
+-  - bne i 2
+-  ==> 7 cycles
+-  ==> must be devided by 4, rounded up 7/4 = 2
+-*/
+-void u8g_Delay(uint16_t val)
+-{
+-  /* old version did a call to the arduino lib: delay(val); */
+-  while( val != 0 )
+-  {
+-    _delay_loop_2( (F_CPU / 4000 ) -2);
+-    val--;
+-  }
+-}
+-
+-/* delay by one micro second */
+-void u8g_MicroDelay(void)
+-{
+-#if (F_CPU / 4000000 ) > 0 
+-  _delay_loop_2( (F_CPU / 4000000 ) );
+-#endif
+-}
+-
+-/* delay by 10 micro seconds */
+-void u8g_10MicroDelay(void)
+-{
+-#if (F_CPU / 400000 ) > 0 
+-  _delay_loop_2( (F_CPU / 400000 ) );
+-#endif
+-}
+-
+-#endif 
+-
+-
+-/*== Delay for PIC18 (not tested) ==*/
+-
+-#if defined(USE_PIC18_DELAY)
+-#include <delays.h>
+-#define GetSystemClock()		(64000000ul)      // Hz
+-#define GetInstructionClock()	(GetSystemClock()/4)
+-
+-void u8g_Delay(uint16_t val)
+-{/*
+-	unsigned int _iTemp = (val);
+-	while(_iTemp--)		
+-		Delay1KTCYx((GetInstructionClock()+999999)/1000000);
+-		*/
+-}
+-void u8g_MicroDelay(void)
+-{
+-  /* not implemented */
+-}
+-void u8g_10MicroDelay(void)
+-{
+-  /* not implemented */
+-}
+-#endif
+-
+-
+-/*== Arduino Delay ==*/
+-#if defined(USE_ARDUINO_DELAY)
+-void u8g_Delay(uint16_t val)
+-{
+-#if defined(__arm__)
+-	delayMicroseconds((uint32_t)val*(uint32_t)1000);
+-#else
+-	delay(val);
+-#endif
+-}
+-void u8g_MicroDelay(void)
+-{
+-	delayMicroseconds(1);
+-}
+-void u8g_10MicroDelay(void)
+-{
+-	delayMicroseconds(10);
+-}
+-#endif
+-
+-#if defined(USE_PIC32_DELAY)
+-/* 
+-  Assume chipkit here with F_CPU correctly defined
+-  The problem was, that u8g_Delay() is called within the constructor.
+-  It seems that the chipkit is not fully setup at this time, so a
+-  call to delay() will not work. So here is my own implementation.
+-
+-*/
+-#define CPU_COUNTS_PER_SECOND (F_CPU/2UL)
+-#define TICKS_PER_MILLISECOND  (CPU_COUNTS_PER_SECOND/1000UL)
+-#include "plib.h"
+-void u8g_Delay(uint16_t val)
+-{
+-	uint32_t d;
+-	uint32_t s;
+-	d = val;
+-	d *= TICKS_PER_MILLISECOND;
+-	s = ReadCoreTimer();
+-	while ( (uint32_t)(ReadCoreTimer() - s) < d )
+-		;
+-} 
+-
+-void u8g_MicroDelay(void)
+-{
+-	uint32_t d;
+-	uint32_t s;
+-	d = TICKS_PER_MILLISECOND/1000;
+-	s = ReadCoreTimer();
+-	while ( (uint32_t)(ReadCoreTimer() - s) < d )
+-		;
+-} 
+-
+-void u8g_10MicroDelay(void)
+-{
+-	uint32_t d;
+-	uint32_t s;
+-	d = TICKS_PER_MILLISECOND/100;
+-	s = ReadCoreTimer();
+-	while ( (uint32_t)(ReadCoreTimer() - s) < d )
+-		;
+-} 
+-
+-#endif
+-
+-#if defined(USE_MSP430_DELAY)
+-#include <msp430.h>
+-
+-#ifndef F_CPU
+-#define F_CPU 1000000UL
+-#endif
+-
+-
+-void u8g_Delay(uint16_t val)
+-{
+-  int t;
+-  for (t=0; t < val; t++)
+-  {
+-    __delay_cycles(F_CPU/1000UL);
+-  }
+-}
+-void u8g_MicroDelay(void)
+-{
+-  __delay_cycles(F_CPU/1000000UL);
+-}
+-
+-void u8g_10MicroDelay(void)
+-{
+-  __delay_cycles(F_CPU/100000UL);
+-}
+-#endif
+-#if defined USE_PSOC5_DELAY
+-  #include <project.h>
+-  void u8g_Delay(uint16_t val)  {CyDelay(val);};
+-  void u8g_MicroDelay(void)     {CyDelay(1);};
+-  void u8g_10MicroDelay(void)   {CyDelay(10);};  
+-#endif
+-
+-
+-/*== Any other systems: Dummy Delay ==*/
+-#if defined(USE_DUMMY_DELAY)
+-void u8g_Delay(uint16_t val)
+-{
+-	/* do not know how to delay... */
+-}
+-void u8g_MicroDelay(void)
+-{
+-}
+-void u8g_10MicroDelay(void)
+-{
+-}
+-#endif
+-- 
+2.8.1
+

--- a/pkg/u8glib/patches/0004-u8glib-add-riot-os-interface.patch
+++ b/pkg/u8glib/patches/0004-u8glib-add-riot-os-interface.patch
@@ -1,0 +1,645 @@
+From 831cd1168546fb63afdf01f57a727b52f6470eb2 Mon Sep 17 00:00:00 2001
+From: Bas Stottelaar <basstottelaar@gmail.com>
+Date: Fri, 6 May 2016 01:10:28 +0200
+Subject: [PATCH 4/4] u8glib: add riot-os interface.
+
+---
+ csrc/u8g.h                   | 145 ++++++++++++++++++++++++++-----------------
+ csrc/u8g_com_riotos_hw_spi.c |  75 ++++++++++++++++++++++
+ csrc/u8g_com_riotos_i2c.c    |  67 ++++++++++++++++++++
+ csrc/u8g_delay_riotos.c      |  16 +++++
+ csrc/u8g_dev_riotos_stdout.c |  82 ++++++++++++++++++++++++
+ 5 files changed, 328 insertions(+), 57 deletions(-)
+ create mode 100644 csrc/u8g_com_riotos_hw_spi.c
+ create mode 100644 csrc/u8g_com_riotos_i2c.c
+ create mode 100644 csrc/u8g_delay_riotos.c
+ create mode 100644 csrc/u8g_dev_riotos_stdout.c
+
+diff --git a/csrc/u8g.h b/csrc/u8g.h
+index fc92e51..6a76bfa 100644
+--- a/csrc/u8g.h
++++ b/csrc/u8g.h
+@@ -1,36 +1,36 @@
+ /*
+ 
+   u8g.h
+-  
++
+   Universal 8bit Graphics Library
+-  
++
+   Copyright (c) 2011, olikraus@gmail.com
+   All rights reserved.
+ 
+-  Redistribution and use in source and binary forms, with or without modification, 
++  Redistribution and use in source and binary forms, with or without modification,
+   are permitted provided that the following conditions are met:
+ 
+-  * Redistributions of source code must retain the above copyright notice, this list 
++  * Redistributions of source code must retain the above copyright notice, this list
+     of conditions and the following disclaimer.
+-    
+-  * Redistributions in binary form must reproduce the above copyright notice, this 
+-    list of conditions and the following disclaimer in the documentation and/or other 
++
++  * Redistributions in binary form must reproduce the above copyright notice, this
++    list of conditions and the following disclaimer in the documentation and/or other
+     materials provided with the distribution.
+ 
+-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+-  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+-  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+-  
++  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
++  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
++  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
++  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
++  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
++  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
++  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
++  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
++  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
++  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++
+ */
+ 
+ #ifndef _U8G_H
+@@ -56,10 +56,10 @@ typedef signed short int16_t;
+ 
+ #if defined(__AVR__)
+ #include <avr/pgmspace.h>
+-#endif 
++#endif
+ 
+-/* 
+-  use the com interface directly on any systems which are not AVR or ARDUINO 
++/*
++  use the com interface directly on any systems which are not AVR or ARDUINO
+ */
+ #if defined(__AVR__) || defined(ARDUINO) || defined(__MSP430__)
+ #define U8G_WITH_PINLIST
+@@ -70,7 +70,7 @@ typedef signed short int16_t;
+ extern "C" {
+ #endif
+ 
+-  
++
+ /*===============================================================*/
+ #ifdef __GNUC__
+ #  define U8G_NOINLINE __attribute__((noinline))
+@@ -133,7 +133,7 @@ typedef uint8_t u8g_fntpgm_uint8_t;
+ #  define U8G_PROGMEM PROGMEM
+ typedef uint8_t u8g_pgm_uint8_t;
+ typedef uint8_t u8g_fntpgm_uint8_t;
+-#  define u8g_pgm_read(adr) (*(const u8g_pgm_uint8_t *)(adr)) 
++#  define u8g_pgm_read(adr) (*(const u8g_pgm_uint8_t *)(adr))
+ #  define U8G_PSTR(s) ((u8g_pgm_uint8_t *)(s))
+ #endif
+ 
+@@ -142,10 +142,10 @@ typedef uint8_t u8g_fntpgm_uint8_t;
+ #  define PROGMEM
+ typedef uint8_t u8g_pgm_uint8_t;
+ typedef uint8_t u8g_fntpgm_uint8_t;
+-#  define u8g_pgm_read(adr) (*(const u8g_pgm_uint8_t *)(adr)) 
++#  define u8g_pgm_read(adr) (*(const u8g_pgm_uint8_t *)(adr))
+ #  define U8G_PSTR(s) ((u8g_pgm_uint8_t *)(s))
+ #endif
+-  
++
+ /*===============================================================*/
+ /* interrupt safe code */
+ #if defined(U8G_INTERRUPT_SAFE)
+@@ -167,8 +167,8 @@ extern uint8_t global_SREG_backup;	/* u8g_state.c */
+ #  define U8G_ATOMIC_START()
+ #  define U8G_ATOMIC_END()
+ #endif /* U8G_INTERRUPT_SAFE */
+-  
+-  
++
++
+ /*===============================================================*/
+ /* forward */
+ typedef struct _u8g_t u8g_t;
+@@ -193,7 +193,7 @@ typedef int8_t u8g_int_t;
+ #ifdef OBSOLETE
+ struct _u8g_box_t
+ {
+-  u8g_uint_t x0, y0, x1, y1;  
++  u8g_uint_t x0, y0, x1, y1;
+ };
+ typedef struct _u8g_box_t u8g_box_t;
+ #endif /* OBSOLETE */
+@@ -606,6 +606,37 @@ struct _u8g_dev_arg_irgb_t
+ /* arg: u8g_box_t *, fill structure with current page properties */
+ #define U8G_DEV_MSG_GET_PAGE_BOX 23
+ 
++/* riot-os specific */
++#include "periph/gpio.h"
++#include "periph/i2c.h"
++#include "periph/spi.h"
++
++#if I2C_NUMOF
++typedef struct {
++    i2c_t i2c_dev;
++    uint8_t address;
++    uint8_t mode;
++    gpio_t reset_pin;
++    u8g_t *u8g;
++} u8g_i2c_t;
++
++int u8g_init_i2c(u8g_i2c_t *dev, i2c_t i2c_dev, uint8_t address, gpio_t reset_pin, u8g_t *u8g, u8g_dev_t *display);
++#endif
++
++#if SPI_NUMOF
++typedef struct {
++    spi_t spi_dev;
++    gpio_t csn_pin;
++    gpio_t a0_pin;
++    gpio_t reset_pin;
++    u8g_t *u8g;
++} u8g_spi_t;
++
++int u8g_init_spi(u8g_spi_t *dev, spi_t spi_dev, gpio_t csn_pin, gpio_t a0_pin, gpio_t reset_pin, u8g_t *u8g, u8g_dev_t *display);
++#endif
++
++int u8g_init_stdout(u8g_t *u8g);
++
+ /*
+ #define U8G_DEV_MSG_PRIMITIVE_START             30
+ #define U8G_DEV_MSG_PRIMITIVE_END               31
+@@ -687,7 +718,7 @@ uint8_t u8g_com_arduino_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_va
+ uint8_t u8g_com_arduino_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);           /* u8g_com_arduino_parallel.c */
+ uint8_t u8g_com_arduino_fast_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);      /* u8g_com_arduino_fast_parallel.c */
+ uint8_t u8g_com_arduino_port_d_wr_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);       /* u8g_com_arduino_port_d_wr.c */
+-uint8_t u8g_com_arduino_no_en_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);	/* u8g_com_arduino_no_en_parallel.c */		
++uint8_t u8g_com_arduino_no_en_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);	/* u8g_com_arduino_no_en_parallel.c */
+ uint8_t u8g_com_arduino_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);		/* u8g_com_arduino_ssd_i2c.c */
+ uint8_t u8g_com_arduino_uc_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
+ uint8_t u8g_com_arduino_t6963_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);			/* u8g_com_arduino_t6963.c */
+@@ -712,7 +743,7 @@ uint8_t u8g_com_linux_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void
+ uint8_t u8g_com_psoc5_ssd_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);   /* u8g_com_psoc5_ssd_hw_spi.c */
+ uint8_t u8g_com_psoc5_ssd_hw_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);   /* u8g_com_psoc5_ssd_hw_parallel.c */
+ 
+-/* 
++/*
+   Translation of system specific com drives to generic com names
+   At the moment, the following generic com drives are available
+   U8G_COM_HW_SPI
+@@ -722,8 +753,8 @@ uint8_t u8g_com_psoc5_ssd_hw_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_va
+   U8G_COM_FAST_PARALLEL
+   U8G_COM_SSD_I2C
+   U8G_COM_UC_I2C
+-  
+-defined(__18CXX) || defined(__PIC32MX)  
++
++defined(__18CXX) || defined(__PIC32MX)
+ 
+ */
+ 
+@@ -1118,7 +1149,7 @@ typedef void (*u8g_state_cb)(uint8_t msg);
+ 
+ /* read/write pin, must be the last pin in the list, this means U8G_PIN_LIST_LEN =  U8G_PI_RW + 1*/
+ #define U8G_PI_WR 13
+-#define U8G_PI_RW 13 
++#define U8G_PI_RW 13
+ 
+ #define U8G_PIN_LIST_LEN 14
+ 
+@@ -1134,8 +1165,8 @@ struct _u8g_t
+ {
+   u8g_uint_t width;
+   u8g_uint_t height;
+-  
+-  
++
++
+   u8g_dev_t *dev;               /* first device in the device chain */
+   const u8g_pgm_uint8_t *font;             /* regular font for all text procedures */
+   const u8g_pgm_uint8_t *cursor_font;  /* special font for cursor procedures */
+@@ -1145,31 +1176,32 @@ struct _u8g_t
+   u8g_uint_t cursor_x;
+   u8g_uint_t cursor_y;
+   u8g_draw_cursor_fn cursor_fn;
+-  
++
+   int8_t glyph_dx;
+   int8_t glyph_x;
+   int8_t glyph_y;
+   uint8_t glyph_width;
+   uint8_t glyph_height;
+-  
++
+   u8g_font_calc_vref_fnptr font_calc_vref;
+   uint8_t font_height_mode;
+   int8_t font_ref_ascent;
+   int8_t font_ref_descent;
+   uint8_t font_line_spacing_factor;     /* line_spacing = factor * (ascent - descent) / 64 */
+   uint8_t line_spacing;
+-  
++
+   u8g_dev_arg_pixel_t arg_pixel;
+   /* uint8_t color_index; */
+ 
+ #ifdef U8G_WITH_PINLIST
+   uint8_t pin_list[U8G_PIN_LIST_LEN];
+ #endif
+-  
++
+   u8g_state_cb state_cb;
+-  
++
+   u8g_box_t current_page;		/* current box of the visible page */
+ 
++  void *riot_dev;  /* riot-os device (i2c, spi or stdout) */
+ };
+ 
+ #define u8g_GetFontAscent(u8g) ((u8g)->font_ref_ascent)
+@@ -1199,9 +1231,9 @@ uint8_t u8g_InitSPI(u8g_t *u8g, u8g_dev_t *dev, uint8_t sck, uint8_t mosi, uint8
+ uint8_t u8g_InitHWSPI(u8g_t *u8g, u8g_dev_t *dev, uint8_t cs, uint8_t a0, uint8_t reset);
+ uint8_t u8g_InitI2C(u8g_t *u8g, u8g_dev_t *dev, uint8_t options);	/* use U8G_I2C_OPT_NONE as options */
+ uint8_t u8g_Init8BitFixedPort(u8g_t *u8g, u8g_dev_t *dev, uint8_t en, uint8_t cs, uint8_t di, uint8_t rw, uint8_t reset);
+-uint8_t u8g_Init8Bit(u8g_t *u8g, u8g_dev_t *dev, uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3, uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7, 
++uint8_t u8g_Init8Bit(u8g_t *u8g, u8g_dev_t *dev, uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3, uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7,
+   uint8_t en, uint8_t cs1, uint8_t cs2, uint8_t di, uint8_t rw, uint8_t reset);
+-uint8_t u8g_InitRW8Bit(u8g_t *u8g, u8g_dev_t *dev, uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3, uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7, 
++uint8_t u8g_InitRW8Bit(u8g_t *u8g, u8g_dev_t *dev, uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3, uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7,
+   uint8_t cs, uint8_t a0, uint8_t wr, uint8_t rd, uint8_t reset);
+ #endif
+ 
+@@ -1237,7 +1269,7 @@ void u8g_SetDefaultMidColor(u8g_t *u8g);
+ #define u8g_GetMode(u8g) ((u8g)->mode)
+ /*
+   U8G_MODE_GET_BITS_PER_PIXEL(u8g_GetMode(u8g))
+-  U8G_MODE_IS_COLOR(u8g_GetMode(u8g)) 
++  U8G_MODE_IS_COLOR(u8g_GetMode(u8g))
+ */
+ 
+ /* u8g_state.c */
+@@ -1355,7 +1387,7 @@ u8g_uint_t u8g_DrawAAStr(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, const char *s);
+ 
+ /* u8g_rect.c */
+ 
+-void u8g_draw_box(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w, u8g_uint_t h) U8G_NOINLINE; 
++void u8g_draw_box(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w, u8g_uint_t h) U8G_NOINLINE;
+ 
+ void u8g_DrawHLine(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w) U8G_NOINLINE;
+ void u8g_DrawVLine(u8g_t *u8g, u8g_uint_t x, u8g_uint_t y, u8g_uint_t w) U8G_NOINLINE;
+@@ -1442,7 +1474,7 @@ struct pg_edge_struct
+   pg_word_t height;
+   pg_word_t current_x_offset;
+   pg_word_t error_offset;
+-  
++
+   /* --- line loop --- */
+   pg_word_t current_y;
+   pg_word_t max_y;
+@@ -1637,8 +1669,8 @@ extern const u8g_fntpgm_uint8_t u8g_font_cu12_67_75[] U8G_FONT_SECTION("u8g_font
+ extern const u8g_fntpgm_uint8_t u8g_font_cu12_78_79[] U8G_FONT_SECTION("u8g_font_cu12_78_79");
+ extern const u8g_fntpgm_uint8_t u8g_font_cu12[] U8G_FONT_SECTION("u8g_font_cu12");
+ 
+-/* 
+-  Free-Universal Bold 
++/*
++  Free-Universal Bold
+   r: Reduced char set (codes 32 - 128)
+   n: Numbers (codes 42 - 57)
+   no char: Full set (codes 32 - 255)
+@@ -1666,7 +1698,7 @@ extern const u8g_fntpgm_uint8_t u8g_font_fub35n[] U8G_FONT_SECTION("u8g_font_fub
+ extern const u8g_fntpgm_uint8_t u8g_font_fub42n[] U8G_FONT_SECTION("u8g_font_fub42n");
+ extern const u8g_fntpgm_uint8_t u8g_font_fub49n[] U8G_FONT_SECTION("u8g_font_fub49n");
+ 
+-/* 
++/*
+   Free-Universal Regular
+   r: Reduced char set (codes 32 - 128)
+   n: Numbers (codes 42 - 57)
+@@ -1695,7 +1727,7 @@ extern const u8g_fntpgm_uint8_t u8g_font_fur35n[] U8G_FONT_SECTION("u8g_font_fur
+ extern const u8g_fntpgm_uint8_t u8g_font_fur42n[] U8G_FONT_SECTION("u8g_font_fur42n");
+ extern const u8g_fntpgm_uint8_t u8g_font_fur49n[] U8G_FONT_SECTION("u8g_font_fur49n");
+ 
+-/* 
++/*
+   Gentium Bold
+   r: Reduced char set (codes 32 - 128)
+   n: Numbers (codes 42 - 57)
+@@ -1726,7 +1758,7 @@ extern const u8g_fntpgm_uint8_t u8g_font_gdb20n[] U8G_FONT_SECTION("u8g_font_gdb
+ extern const u8g_fntpgm_uint8_t u8g_font_gdb25n[] U8G_FONT_SECTION("u8g_font_gdb25n");
+ extern const u8g_fntpgm_uint8_t u8g_font_gdb30n[] U8G_FONT_SECTION("u8g_font_gdb30n");
+ 
+-/* 
++/*
+   Gentium Regular
+   r: Reduced char set (codes 32 - 128)
+   n: Numbers (codes 42 - 57)
+@@ -1763,7 +1795,7 @@ extern const u8g_fntpgm_uint8_t u8g_font_gdr20n[] U8G_FONT_SECTION("u8g_font_gdr
+ extern const u8g_fntpgm_uint8_t u8g_font_gdr25n[] U8G_FONT_SECTION("u8g_font_gdr25n");
+ extern const u8g_fntpgm_uint8_t u8g_font_gdr30n[] U8G_FONT_SECTION("u8g_font_gdr30n");
+ 
+-/* 
++/*
+   Old-Standard Bold
+   r: Reduced char set (codes 32 - 128)
+   n: Numbers (codes 42 - 57)
+@@ -1788,7 +1820,7 @@ extern const u8g_fntpgm_uint8_t u8g_font_osb26n[] U8G_FONT_SECTION("u8g_font_osb
+ extern const u8g_fntpgm_uint8_t u8g_font_osb29n[] U8G_FONT_SECTION("u8g_font_osb29n");
+ extern const u8g_fntpgm_uint8_t u8g_font_osb35n[] U8G_FONT_SECTION("u8g_font_osb35n");
+ 
+-/* 
++/*
+   Old-Standard Regular
+   r: Reduced char set (codes 32 - 128)
+   n: Numbers (codes 42 - 57)
+@@ -1835,7 +1867,7 @@ extern const u8g_fntpgm_uint8_t u8g_font_unifont_12_13[] U8G_FONT_SECTION("u8g_f
+ 
+ /* 04b fonts */
+ 
+-extern const u8g_fntpgm_uint8_t u8g_font_04b_03b[] U8G_FONT_SECTION("u8g_font_04b_03b"); 
++extern const u8g_fntpgm_uint8_t u8g_font_04b_03b[] U8G_FONT_SECTION("u8g_font_04b_03b");
+ extern const u8g_fntpgm_uint8_t u8g_font_04b_03bn[] U8G_FONT_SECTION("u8g_font_04b_03bn");
+ extern const u8g_fntpgm_uint8_t u8g_font_04b_03br[] U8G_FONT_SECTION("u8g_font_04b_03br");
+ extern const u8g_fntpgm_uint8_t u8g_font_04b_03[] U8G_FONT_SECTION("u8g_font_04b_03");
+@@ -2061,4 +2093,3 @@ extern const u8g_fntpgm_uint8_t u8g_font_profont29r[] U8G_FONT_SECTION("u8g_font
+ #endif
+ 
+ #endif /* _U8G_H */
+-
+diff --git a/csrc/u8g_com_riotos_hw_spi.c b/csrc/u8g_com_riotos_hw_spi.c
+new file mode 100644
+index 0000000..208cc51
+--- /dev/null
++++ b/csrc/u8g_com_riotos_hw_spi.c
+@@ -0,0 +1,75 @@
++#include "u8g.h"
++
++#if SPI_NUMOF
++
++static uint8_t u8g_com_riotos_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
++{
++    u8g_spi_t *dev = (u8g_spi_t *) u8g->riot_dev;
++
++    spi_acquire(dev->spi_dev);
++
++    switch (msg) {
++    case U8G_COM_MSG_STOP:
++        spi_poweroff(dev->spi_dev);
++        break;
++    case U8G_COM_MSG_INIT:
++        if (dev->csn_pin != GPIO_UNDEF) {
++            gpio_init(dev->csn_pin, GPIO_OUT);
++        }
++        if (dev->a0_pin != GPIO_UNDEF) {
++            gpio_init(dev->a0_pin, GPIO_OUT);
++        }
++        if (dev->reset_pin != GPIO_UNDEF) {
++            gpio_init(dev->reset_pin, GPIO_OUT);
++        }
++
++        spi_init_master(dev->spi_dev, SPI_CONF_SECOND_FALLING, SPI_SPEED_5MHZ);
++
++        break;
++    case U8G_COM_MSG_ADDRESS:
++        if (dev->a0_pin != GPIO_UNDEF) {
++            gpio_write(dev->a0_pin, arg_val);
++        }
++        break;
++    case U8G_COM_MSG_CHIP_SELECT:
++        if (dev->csn_pin != GPIO_UNDEF) {
++            gpio_write(dev->csn_pin, arg_val);
++        }
++        break;
++    case U8G_COM_MSG_RESET:
++        if (dev->reset_pin != GPIO_UNDEF) {
++            gpio_write(dev->reset_pin, arg_val);
++        }
++        break;
++    case U8G_COM_MSG_WRITE_BYTE:
++        spi_transfer_byte(dev->spi_dev, (char) arg_val, NULL);
++        break;
++    case U8G_COM_MSG_WRITE_SEQ:
++    case U8G_COM_MSG_WRITE_SEQ_P:
++        spi_transfer_bytes(dev->spi_dev, (char *) arg_ptr, NULL, arg_val);
++        break;
++    }
++
++    spi_release(dev->spi_dev);
++
++    return 1;
++}
++
++int u8g_init_spi(u8g_spi_t *dev, spi_t spi_dev, gpio_t csn_pin, gpio_t a0_pin, gpio_t reset_pin, u8g_t *u8g, u8g_dev_t *display)
++{
++    /* store reference to u8g_spi_t device to access it in method above */
++    u8g->riot_dev = dev;
++
++    dev->spi_dev = spi_dev;
++    dev->reset_pin = reset_pin;
++    dev->csn_pin = csn_pin;
++    dev->a0_pin = a0_pin;
++    dev->u8g = u8g;
++
++    /* initialize display */
++    u8g_InitComFn(u8g, display, &u8g_com_riotos_hw_spi_fn);
++
++    return 0;
++}
++
++#endif /* SPI_NUMOF */
+diff --git a/csrc/u8g_com_riotos_i2c.c b/csrc/u8g_com_riotos_i2c.c
+new file mode 100644
+index 0000000..6fdb56c
+--- /dev/null
++++ b/csrc/u8g_com_riotos_i2c.c
+@@ -0,0 +1,67 @@
++#include "u8g.h"
++
++#if I2C_NUMOF
++
++static uint8_t u8g_com_riotos_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
++{
++    u8g_i2c_t *dev = (u8g_i2c_t *) u8g->riot_dev;
++
++    i2c_acquire(dev->i2c_dev);
++
++    switch (msg) {
++    case U8G_COM_MSG_STOP:
++        i2c_poweroff(dev->i2c_dev);
++        break;
++    case U8G_COM_MSG_INIT:
++        if (dev->reset_pin != GPIO_UNDEF) {
++            gpio_init(dev->reset_pin, GPIO_OUT);
++        }
++
++        i2c_init_master(dev->i2c_dev, I2C_SPEED_NORMAL);
++        break;
++    case U8G_COM_MSG_ADDRESS:
++        if (arg_val == 0) {
++            dev->mode = 0x00;
++        } else {
++            dev->mode = 0x40;
++        }
++
++        break;
++    case U8G_COM_MSG_RESET:
++        if (dev->reset_pin != GPIO_UNDEF) {
++            gpio_write(dev->reset_pin, arg_val);
++        }
++
++        break;
++    case U8G_COM_MSG_WRITE_BYTE:
++        i2c_write_reg(dev->i2c_dev, dev->address, dev->mode, arg_val);
++        break;
++    case U8G_COM_MSG_WRITE_SEQ:
++    case U8G_COM_MSG_WRITE_SEQ_P:
++        i2c_write_regs(dev->i2c_dev, dev->address,
++                       dev->mode, (char *) arg_ptr, arg_val);
++        break;
++    }
++
++    i2c_release(dev->i2c_dev);
++
++    return 1;
++}
++
++int u8g_init_i2c(u8g_i2c_t *dev, i2c_t i2c_dev, uint8_t address, gpio_t reset_pin, u8g_t *u8g, u8g_dev_t *display)
++{
++    /* store reference to u8g_i2c_t device to access it in method above */
++    u8g->riot_dev = dev;
++
++    dev->i2c_dev = i2c_dev;
++    dev->address = address;
++    dev->reset_pin = reset_pin;
++    dev->u8g = u8g;
++
++    /* initialize display */
++    u8g_InitComFn(dev->u8g, display, &u8g_com_riotos_i2c_fn);
++
++    return 0;
++}
++
++#endif /* I2C_NUMOF */
+diff --git a/csrc/u8g_delay_riotos.c b/csrc/u8g_delay_riotos.c
+new file mode 100644
+index 0000000..0a393f3
+--- /dev/null
++++ b/csrc/u8g_delay_riotos.c
+@@ -0,0 +1,16 @@
++#include "xtimer.h"
++
++void u8g_Delay(uint16_t val)
++{
++    xtimer_usleep((uint32_t)val*(uint32_t)1000);
++}
++
++void u8g_MicroDelay(void)
++{
++    xtimer_usleep(1);
++}
++
++void u8g_10MicroDelay(void)
++{
++    xtimer_usleep(10);
++}
+diff --git a/csrc/u8g_dev_riotos_stdout.c b/csrc/u8g_dev_riotos_stdout.c
+new file mode 100644
+index 0000000..ff4b514
+--- /dev/null
++++ b/csrc/u8g_dev_riotos_stdout.c
+@@ -0,0 +1,82 @@
++#include <stdio.h>
++
++#include "u8g.h"
++
++/* display width */
++#ifndef U8G_STDOUT_WIDTH
++#define U8G_STDOUT_WIDTH 96
++#endif
++
++/* display height */
++#ifndef U8G_STDOUT_HEIGHT
++#define U8G_STDOUT_HEIGHT 32
++#endif
++
++/* height of a single page */
++#ifndef U8G_STDOUT_PAGE_HEIGHT
++#define U8G_STDOUT_PAGE_HEIGHT 8
++#endif
++
++/* use blocks to represent pixels, otherwise normal characters */
++#ifdef U8G_STDOUT_ANSI
++#define U8G_STDOUT_BLACK "\033[40m "
++#define U8G_STDOUT_WHITE "\033[47m "
++#define U8G_STDOUT_RESET "\033[0m"
++#else
++#define U8G_STDOUT_BLACK "#"
++#define U8G_STDOUT_WHITE "."
++#undef U8G_STDOUT_RESET
++#endif
++
++static uint8_t u8g_dev_riotos_stdout_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
++{
++    switch(msg) {
++        case U8G_DEV_MSG_PAGE_FIRST:
++        {
++            /* move cursor up */
++            printf("\033[%dA", U8G_STDOUT_HEIGHT);
++
++            break;
++        }
++        case U8G_DEV_MSG_PAGE_NEXT:
++        {
++            u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
++            uint8_t i, j;
++            uint8_t page_height;
++
++            page_height = pb->p.page_y1;
++            page_height -= pb->p.page_y0;
++            page_height++;
++
++            for (j = 0; j < page_height; j++) {
++                for (i = 0; i < U8G_STDOUT_WIDTH; i++) {
++                    if ((((uint8_t *)(pb->buf))[i] & (1 << j)) != 0) {
++                        printf("%s", U8G_STDOUT_BLACK);
++                    } else {
++                        printf("%s", U8G_STDOUT_WHITE);
++                    }
++                }
++
++                printf("%s", "\n");
++#ifdef U8G_STDOUT_RESET
++                printf("%s", U8G_STDOUT_RESET);
++#endif
++            }
++
++            break;
++        }
++    }
++
++    return u8g_dev_pb8v1_base_fn(u8g, dev, msg, arg);
++}
++
++/* create definition for stdout display */
++U8G_PB_DEV(u8g_dev_riotos_stdout, U8G_STDOUT_WIDTH, U8G_STDOUT_HEIGHT, U8G_STDOUT_PAGE_HEIGHT, u8g_dev_riotos_stdout_fn, NULL);
++
++int u8g_init_stdout(u8g_t *u8g)
++{
++    /* initialize display */
++    u8g_Init(u8g, &u8g_dev_riotos_stdout);
++
++    return 0;
++}
+-- 
+2.8.1
+

--- a/tests/pkg_u8glib/Makefile
+++ b/tests/pkg_u8glib/Makefile
@@ -1,0 +1,43 @@
+APPLICATION = pkg_u8glib
+include ../Makefile.tests_common
+
+USEMODULE += xtimer
+
+USEPKG += u8glib
+
+# set default device parameters in case they are undefined
+TEST_U8GLIB_OUTPUT    ?= 1
+TEST_U8GLIB_DISPLAY   ?= u8g_dev_ssd1306_128x64_hw_spi
+
+TEST_U8GLIB_I2C       ?= 0
+TEST_U8GLIB_SPI       ?= 0
+
+TEST_U8GLIB_ADDR      ?= 0x78
+
+TEST_U8GLIB_PIN_CSN   ?= GPIO_PIN\(0,0\)
+TEST_U8GLIB_PIN_A0    ?= GPIO_PIN\(0,0\)
+TEST_U8GLIB_PIN_RESET ?= GPIO_PIN\(0,0\)
+
+# features depends on output type
+ifeq ($(TEST_U8GLIB_OUTPUT),2)
+FEATURES_REQUIRED += periph_i2c periph_gpio
+endif
+
+ifeq ($(TEST_U8GLIB_OUTPUT),3)
+FEATURES_REQUIRED += periph_spi periph_gpio
+endif
+
+# export parameters
+CFLAGS += -DTEST_U8GLIB_OUTPUT=$(TEST_U8GLIB_OUTPUT)
+CFLAGS += -DTEST_U8GLIB_DISPLAY=$(TEST_U8GLIB_DISPLAY)
+
+CFLAGS += -DTEST_U8GLIB_I2C=$(TEST_U8GLIB_I2C)
+CFLAGS += -DTEST_U8GLIB_SPI=$(TEST_U8GLIB_SPI)
+
+CFLAGS += -DTEST_U8GLIB_ADDR=$(TEST_U8GLIB_ADDR)
+
+CFLAGS += -DTEST_U8GLIB_PIN_CSN=$(TEST_U8GLIB_PIN_CSN)
+CFLAGS += -DTEST_U8GLIB_PIN_A0=$(TEST_U8GLIB_PIN_A0)
+CFLAGS += -DTEST_U8GLIB_PIN_RESET=$(TEST_U8GLIB_PIN_RESET)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_u8glib/README.md
+++ b/tests/pkg_u8glib/README.md
@@ -1,0 +1,36 @@
+# About
+This is a test application for the U8glib package. This package is a graphical display library, including display drivers.
+
+# Usage
+This test application will initialize the U8glib to output on one of the following:
+
+ * output to stdout.
+ * output to I2C graphics screen.
+ * output to SPI graphics screen.
+
+## Output to stdout
+To output to screen, ensure add `TEST_U8GLIB_OUTPUT=1` to the `make` command.
+
+When using a ANSI compatible terminal, one can specify `-DU8G_STDOUT_ANSI` to use ANSI characters to render the screen. Otherwise, normal characters are used.
+
+## Output to I2C
+To output to screen, ensure add `TEST_U8GLIB_OUTPUT=2` to the `make` command.
+
+Furthermore, configure the following:
+
+* `TEST_U8GLIB_I2C` &mdash; The I2C device.
+* `TEST_U8GLIB_ADDR` &mdash; The address to write commands to.
+* `TEST_U8GLIB_PIN_RESET` &mdash; If applicable, the reset pin.
+* `TEST_U8GLIB_DISPLAY` &mdash; The used display driver (see https://github.com/olikraus/u8glib/wiki/device).
+
+## Output to SPI
+To output to screen, ensure add `TEST_U8GLIB_OUTPUT=3` to the `make` command.
+
+* `TEST_U8GLIB_SPI` &mdash; The SPI device.
+* `TEST_U8GLIB_PIN_CSN` &mdash; If applicable, the CSn pin.
+* `TEST_U8GLIB_PIN_A0` &mdash; If applicable, the Command/Data pin.
+* `TEST_U8GLIB_PIN_RESET` &mdash; If applicable, the reset pin.
+* `TEST_U8GLIB_DISPLAY` &mdash; The used display driver (see https://github.com/olikraus/u8glib/wiki/device).
+
+# Expected result
+The output of this test depends on the output mode and used hardware. If it works, the application cycles through three screens with the text: 'This is RIOT-OS'.

--- a/tests/pkg_u8glib/main.c
+++ b/tests/pkg_u8glib/main.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2016 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the U8glib package.
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#define TEST_U8GLIB_OUTPUT_STDOUT 1
+#define TEST_U8GLIB_OUTPUT_I2C 2
+#define TEST_U8GLIB_OUTPUT_SPI 3
+
+#ifndef TEST_U8GLIB_OUTPUT
+#error "TEST_U8GLIB_OUTPUT not defined"
+#endif
+#ifndef TEST_U8GLIB_DISPLAY
+#error "TEST_U8GLIB_DISPLAY not defined"
+#endif
+
+#if TEST_U8GLIB_OUTPUT == TEST_U8GLIB_OUTPUT_I2C
+#ifndef TEST_U8GLIB_I2C
+#error "TEST_U8GLIB_I2C not defined"
+#endif
+#ifndef TEST_U8GLIB_ADDR
+#error "TEST_U8GLIB_ADDR not defined"
+#endif
+#ifndef TEST_U8GLIB_PIN_RESET
+#error "TEST_U8GLIB_PIN_RESET not defined"
+#endif
+#endif
+
+#if TEST_U8GLIB_OUTPUT == TEST_U8GLIB_OUTPUT_SPI
+#ifndef TEST_U8GLIB_SPI
+#error "TEST_U8GLIB_SPI not defined"
+#endif
+#ifndef TEST_U8GLIB_PIN_CSN
+#error "TEST_U8GLIB_PIN_CSN not defined"
+#endif
+#ifndef TEST_U8GLIB_PIN_A0
+#error "TEST_U8GLIB_PIN_A0 not defined"
+#endif
+#ifndef TEST_U8GLIB_PIN_RESET
+#error "TEST_U8GLIB_PIN_RESET not defined"
+#endif
+#endif
+
+#include <stdio.h>
+
+#include "xtimer.h"
+#include "u8g.h"
+
+int main(void)
+{
+    uint32_t screen = 0;
+    u8g_t u8g;
+
+    /* initialize to stdout */
+#if TEST_U8GLIB_OUTPUT == TEST_U8GLIB_OUTPUT_STDOUT
+    if (u8g_init_stdout(&u8g) != 0) {
+        puts("Failed to initialize U8glib to stdout.");
+        return -1;
+    }
+#endif
+
+    /* initialize to I2C */
+#if TEST_U8GLIB_OUTPUT == TEST_U8GLIB_OUTPUT_I2C
+    u8g_i2c_t dev;
+
+    if (u8g_init_i2c(&dev, TEST_U8GLIB_I2C, TEST_U8GLIB_ADDR, TEST_U8GLIB_PIN_RESET, &u8g, &TEST_U8GLIB_DISPLAY)) {
+        puts("Failed to initialize U8glib to I2C device.");
+        return -1;
+    }
+#endif
+
+    /* initialize to SPI */
+#if TEST_U8GLIB_OUTPUT == TEST_U8GLIB_OUTPUT_SPI
+    u8g_spi_t dev;
+
+    if (u8g_init_spi(&dev, TEST_U8GLIB_SPI, TEST_U8GLIB_PIN_CSN, TEST_U8GLIB_PIN_A0, TEST_U8GLIB_PIN_RESET, &u8g, &TEST_U8GLIB_DISPLAY)) {
+        puts("Failed to initialize U8glib to SPI device.");
+        return -1;
+    }
+#endif
+
+    /* draw a text */
+    puts("Drawing on screen.");
+
+    while (true) {
+        u8g_FirstPage(&u8g);
+
+        do {
+            u8g_SetColorIndex(&u8g, 1);
+            u8g_SetFont(&u8g, u8g_font_10x20);
+
+            if (screen == 0) {
+                u8g_DrawStr(&u8g, 0, 20, "THIS");
+            } else if (screen == 1) {
+                u8g_DrawStr(&u8g, 0, 20, "IS");
+            } else if (screen == 2) {
+                u8g_DrawStr(&u8g, 0, 20, "RIOT-OS");
+                u8g_DrawHLine(&u8g, 0, 21, 70);
+            }
+        } while (u8g_NextPage(&u8g));
+
+        /* show next in next iteration */
+        screen = (screen + 1) % 3;
+
+        /* sleep a little */
+        xtimer_sleep(1);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds initial support for [U8glib](https://github.com/olikraus/u8glib) graphics library as an external package. While targeted for Arduino MCUs, it works fine on 32-bit MCUs. The license should be compatible (new-style BSD).

I've tested this with a cheap [SSD1306 OLED display](https://www.youtube.com/watch?v=bG5_EwFTiDc) via SPI, but it also has a stdout (for native) and I2C backend (untested). The included test application cycles through three pages, each second. Several [other](https://github.com/olikraus/u8glib/wiki/device) displays are also supported.

![u8glib](https://cloud.githubusercontent.com/assets/815976/13935668/cf1a3880-efb8-11e5-9698-bc660416f5a4.jpg)

The code size for the test application only (EFM32, STK3600, SPI) is approximately 4.0 kb.