### PR TITLE
Makefile: Newlib: Added pattern to NEWLIB_INCLUDE_PATTERN

### DIFF
--- a/sys/newlib/Makefile.include
+++ b/sys/newlib/Makefile.include
@@ -28,11 +28,12 @@ export LINKFLAGS += -lc -lnosys
 # Ubuntu seem to put a copy of the newlib headers in the same place as
 # Gentoo crossdev, but we prefer to look at /etc/alternatives first.
 # On OSX, newlib includes are possibly located in
-# /usr/local/opt/arm-none-eabi*/arm-none-eabi/include
+# /usr/local/opt/arm-none-eabi*/arm-none-eabi/include or /usr/local/opt/gcc-arm/arm-none-eabi/include
 NEWLIB_INCLUDE_PATTERNS ?= \
   /etc/alternatives/gcc-$(TARGET_ARCH)-include \
   /usr/$(TARGET_ARCH)/include \
   /usr/local/opt/$(TARGET_ARCH)*/$(TARGET_ARCH)/include \
+  /usr/local/opt/gcc-*/$(TARGET_ARCH)/include \
   #
 # Use the wildcard Makefile function to search for existing directories matching
 # the patterns above. We use the -isystem gcc/clang argument to add the include


### PR DESCRIPTION
Hi

Some arm toolchains in OSX are installed in /usr/local/opt/gcc-arm/$TARGET_ARCH
When the current Makefile tries to search for the location of include files, it doesn't find them and the variable NEWLIB_INCLUDE_DIR is blank.

In the end, this produces errors like:

_Building application "default" for "samr21-xpro" with MCU "samd21".

/Users/jia200x/Development/RIOT/examples/default/main.c:28:20: fatal error: thread.h: No such file or directory
 #include "thread.h"
                    ^
compilation terminated.
make[1]: *** [/Users/jia200x/Development/RIOT/examples/default/bin/samr21-xpro/default/main.o] Error 1
make: *** [all] Error 2_



I added the /usr/local/opt/gcc-arm/$TARGET_ARCH pattern to Makefile.

Also, do you think there should be an error message or something if newlib dirs are not found? 
Best regards





