### PR TITLE
gnrc_rpl: proper interface handling

### DIFF
--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -454,37 +454,42 @@ void gnrc_rpl_send_DAO_ACK(gnrc_rpl_instance_t *instance, ipv6_addr_t *destinati
  * @brief   Parse a DIS.
  *
  * @param[in] dis       Pointer to the DIS message.
+ * @param[in] iface     Interface PID of the incoming DIS.
  * @param[in] src       Pointer to the source address of the IPv6 packet.
  * @param[in] dst       Pointer to the destination address of the IPv6 packet.
  * @param[in] len       Length of the IPv6 packet.
  */
-void gnrc_rpl_recv_DIS(gnrc_rpl_dis_t *dis, ipv6_addr_t *src, ipv6_addr_t *dst, uint16_t len);
+void gnrc_rpl_recv_DIS(gnrc_rpl_dis_t *dis, kernel_pid_t iface, ipv6_addr_t *src,
+                       ipv6_addr_t *dst, uint16_t len);
 
 /**
  * @brief   Parse a DIO.
  *
  * @param[in] dio       Pointer to the DIO message.
+ * @param[in] iface     Interface PID of the incoming DIO.
  * @param[in] src       Pointer to the source address of the IPv6 packet.
  * @param[in] len       Length of the IPv6 packet.
  */
-void gnrc_rpl_recv_DIO(gnrc_rpl_dio_t *dio, ipv6_addr_t *src, uint16_t len);
+void gnrc_rpl_recv_DIO(gnrc_rpl_dio_t *dio, kernel_pid_t iface, ipv6_addr_t *src, uint16_t len);
 
 /**
  * @brief   Parse a DAO.
  *
  * @param[in] dao       Pointer to the DAO message.
+ * @param[in] iface     Interface PID of the incoming DIO.
  * @param[in] src       Pointer to the source address of the IPv6 packet.
  * @param[in] len       Length of the IPv6 packet.
  */
-void gnrc_rpl_recv_DAO(gnrc_rpl_dao_t *dao, ipv6_addr_t *src, uint16_t len);
+void gnrc_rpl_recv_DAO(gnrc_rpl_dao_t *dao, kernel_pid_t iface, ipv6_addr_t *src, uint16_t len);
 
 /**
  * @brief   Parse a DAO-ACK.
  *
  * @param[in] dao_ack   Pointer to the DAO-ACK message.
+ * @param[in] iface     Interface PID of the incoming DIO.
  * @param[in] len       Length of the IPv6 packet.
  */
-void gnrc_rpl_recv_DAO_ACK(gnrc_rpl_dao_ack_t *dao_ack, uint16_t len);
+void gnrc_rpl_recv_DAO_ACK(gnrc_rpl_dao_ack_t *dao_ack, kernel_pid_t iface, uint16_t len);
 
 /**
  * @brief   Delay the DAO sending interval
@@ -517,11 +522,13 @@ gnrc_rpl_instance_t *gnrc_rpl_root_instance_init(uint8_t instance_id, ipv6_addr_
  * @brief Send a control message
  *
  * @param[in] pkt               gnrc_pktnsip_t to send
+ * @param[in] iface             Interface PID to send this pkt to
  * @param[in] src               Source address of the packet
  * @param[in] dst               Destination address of the packet
  * @param[in] dodag_id          Id of the DODAG
  */
-void gnrc_rpl_send(gnrc_pktsnip_t *pkt, ipv6_addr_t *src, ipv6_addr_t *dst, ipv6_addr_t *dodag_id);
+void gnrc_rpl_send(gnrc_pktsnip_t *pkt, kernel_pid_t iface, ipv6_addr_t *src, ipv6_addr_t *dst,
+                   ipv6_addr_t *dodag_id);
 
 /**
  * @brief Generate a local or global instance id

--- a/sys/include/net/gnrc/rpl/dodag.h
+++ b/sys/include/net/gnrc/rpl/dodag.h
@@ -102,11 +102,12 @@ gnrc_rpl_instance_t *gnrc_rpl_instance_get(uint8_t instance_id);
  *
  * @param[in]   instance        Pointer to the instance to add the DODAG to
  * @param[in]   dodag_id        The DODAG-ID of the new DODAG
+ * @param[in]   iface           Interface PID where the DODAG operates
  *
  * @return  true, if DODAG could be created.
  * @return  false, if DODAG could not be created or exists already.
  */
-bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, ipv6_addr_t *dodag_id);
+bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, ipv6_addr_t *dodag_id, kernel_pid_t iface);
 
 /**
  * @brief   Remove all parents from the @p dodag.

--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -224,6 +224,7 @@ struct gnrc_rpl_dodag {
     uint8_t dio_redun;              /**< trickle k parameter */
     uint8_t default_lifetime;       /**< lifetime of routes (lifetime * unit) */
     uint16_t lifetime_unit;         /**< unit in seconds of the lifetime */
+    kernel_pid_t iface;             /**< interface PID this DODAG operates on */
     uint8_t version;                /**< version of this DODAG */
     uint8_t grounded;               /**< grounded flag */
     uint16_t my_rank;               /**< rank/position in the DODAG */

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -185,11 +185,13 @@ int _gnrc_rpl_dodag_show(void)
         if (gnrc_rpl_instances[i].state == 0) {
             continue;
         }
-        printf("instance [%d | mop: %d | ocp: %d | mhri: %d | mri %d]\n", gnrc_rpl_instances[i].id,
-                gnrc_rpl_instances[i].mop, gnrc_rpl_instances[i].of->ocp,
-                gnrc_rpl_instances[i].min_hop_rank_inc, gnrc_rpl_instances[i].max_rank_inc);
 
         dodag = &gnrc_rpl_instances[i].dodag;
+
+        printf("instance [%d | Iface: %" PRIkernel_pid " | mop: %d | ocp: %d | mhri: %d | mri %d]\n",
+                gnrc_rpl_instances[i].id, dodag->iface,
+                gnrc_rpl_instances[i].mop, gnrc_rpl_instances[i].of->ocp,
+                gnrc_rpl_instances[i].min_hop_rank_inc, gnrc_rpl_instances[i].max_rank_inc);
 
         tc = (((uint64_t) dodag->trickle.msg_callback_timer.long_target << 32)
                 | dodag->trickle.msg_callback_timer.target) - xnow;


### PR DESCRIPTION
At DODAG creation, the appropriate interface id will be assigned to the DODAG.
This way, it is not necessary to look up the correct interface id at several places. Furthermore, looking up the interface id like it was done before had some flaws when multiple interfaces were present.

fixes #3970