### PR TITLE
gnrc_rpl: add netif_addr to DODAG

### DIFF
--- a/sys/include/net/gnrc/rpl/dodag.h
+++ b/sys/include/net/gnrc/rpl/dodag.h
@@ -103,11 +103,13 @@ gnrc_rpl_instance_t *gnrc_rpl_instance_get(uint8_t instance_id);
  * @param[in]   instance        Pointer to the instance to add the DODAG to
  * @param[in]   dodag_id        The DODAG-ID of the new DODAG
  * @param[in]   iface           Interface PID where the DODAG operates
+ * @param[in]   netif_addr      netif address for this DODAG
  *
  * @return  true, if DODAG could be created.
  * @return  false, if DODAG could not be created or exists already.
  */
-bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, ipv6_addr_t *dodag_id, kernel_pid_t iface);
+bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, ipv6_addr_t *dodag_id, kernel_pid_t iface,
+                         gnrc_ipv6_netif_addr_t *netif_addr);
 
 /**
  * @brief   Remove all parents from the @p dodag.

--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -27,6 +27,7 @@
 extern "C" {
 #endif
 
+#include "net/gnrc/ipv6/netif.h"
 #include "net/ipv6/addr.h"
 #include "xtimer.h"
 #include "trickle.h"
@@ -212,11 +213,9 @@ typedef struct {
  */
 struct gnrc_rpl_dodag {
     ipv6_addr_t dodag_id;           /**< id of the DODAG */
+    gnrc_ipv6_netif_addr_t *netif_addr; /**< netif address for this DODAG */
     gnrc_rpl_parent_t *parents;     /**< pointer to the parents list of this DODAG */
     gnrc_rpl_instance_t *instance;  /**< pointer to the instance that this dodag is part of */
-    uint8_t prefix_len;             /**< length of the prefix for the DODAG id */
-    uint32_t addr_preferred;        /**< time in seconds the DODAG id is preferred */
-    uint32_t addr_valid;            /**< time in seconds the DODAG id is valid */
     uint8_t dtsn;                   /**< DAO Trigger Sequence Number */
     uint8_t prf;                    /**< preferred flag */
     uint8_t dio_interval_doubl;     /**< trickle Imax parameter */

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -84,7 +84,7 @@ gnrc_rpl_instance_t *gnrc_rpl_root_init(uint8_t instance_id, ipv6_addr_t *dodag_
 
     gnrc_rpl_dodag_t *dodag = NULL;
     gnrc_rpl_instance_t *inst = gnrc_rpl_root_instance_init(instance_id, dodag_id,
-                                                         GNRC_RPL_DEFAULT_MOP);
+                                                            GNRC_RPL_DEFAULT_MOP);
 
     if (!inst) {
         return NULL;

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -113,21 +113,16 @@ gnrc_rpl_instance_t *gnrc_rpl_instance_get(uint8_t instance_id)
     return NULL;
 }
 
-bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, ipv6_addr_t *dodag_id, kernel_pid_t iface)
+bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, ipv6_addr_t *dodag_id, kernel_pid_t iface,
+                         gnrc_ipv6_netif_addr_t *netif_addr)
 {
-    gnrc_rpl_dodag_t *dodag = NULL;
+    /* TODO: check if netif_addr belongs to iface */
 
-    if ((instance == NULL) || instance->state == 0) {
-        DEBUG("Instance is NULL or unused\n");
-        return false;
-    }
+    assert(instance && (instance->state > 0));
 
-    dodag = &instance->dodag;
+    gnrc_rpl_dodag_t *dodag = &instance->dodag;
 
     dodag->dodag_id = *dodag_id;
-    dodag->prefix_len = GNRC_RPL_DEFAULT_PREFIX_LEN;
-    dodag->addr_preferred = GNRC_RPL_DEFAULT_PREFIX_LIFETIME;
-    dodag->addr_valid = GNRC_RPL_DEFAULT_PREFIX_LIFETIME;
     dodag->my_rank = GNRC_RPL_INFINITE_RANK;
     dodag->trickle.callback.func = &_rpl_trickle_send_dio;
     dodag->trickle.callback.args = instance;
@@ -143,6 +138,7 @@ bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, ipv6_addr_t *dodag_id, k
     dodag->dao_counter = 0;
     dodag->instance = instance;
     dodag->iface = iface;
+    dodag->netif_addr = netif_addr;
 
     return true;
 }
@@ -360,15 +356,13 @@ gnrc_rpl_instance_t *gnrc_rpl_root_instance_init(uint8_t instance_id, ipv6_addr_
         return NULL;
     }
 
-    if (!gnrc_rpl_dodag_init(inst, dodag_id, iface)) {
+    if (!gnrc_rpl_dodag_init(inst, dodag_id, iface, netif_addr)) {
         DEBUG("RPL: could not initialize DODAG");
+        gnrc_rpl_instance_remove(inst);
         return NULL;
     }
 
     dodag = &inst->dodag;
-    dodag->prefix_len = netif_addr->prefix_len;
-    dodag->addr_preferred = netif_addr->preferred;
-    dodag->addr_valid = netif_addr->valid;
     dodag->instance = inst;
 
     return inst;


### PR DESCRIPTION
By storing the `netif_addr` in the DODAG we can omit values like the `prefix_len`, `preferred_lifetime` and `valid_lifetime` of the IPv6 address configured by RPL PIOs. No need to store the same information at several places.

~~Depends on #5135~~