### PR TITLE
gnrc_rpl: thread prio greater than gnrc_ipv6

### DIFF
--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -69,6 +69,7 @@
 #include <string.h>
 #include <stdint.h>
 #include "net/gnrc.h"
+#include "net/gnrc/ipv6.h"
 #include "net/ipv6/addr.h"
 #include "net/gnrc/nettype.h"
 #include "net/gnrc/rpl/structs.h"
@@ -93,7 +94,7 @@ extern "C" {
  * @brief   Default priority for the RPL thread
  */
 #ifndef GNRC_RPL_PRIO
-#define GNRC_RPL_PRIO           (THREAD_PRIORITY_MAIN - 4)
+#define GNRC_RPL_PRIO           (GNRC_IPV6_PRIO + 1)
 #endif
 
 /**


### PR DESCRIPTION
IMO, the thread priority of RPL should be greater (worse) than that of `gnrc_ipv6`, because rpl operates more or less on top of `gnrc_ipv6`. Currently, the thread prio is lower (better), although I never encountered problems with that.