### PR TITLE
gnrc_ndp: unset isRouter flag for neighbor sending RS

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -381,6 +381,7 @@ void gnrc_ndp_rtr_sol_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
     gnrc_ipv6_netif_t *if_entry = gnrc_ipv6_netif_get(iface);
 
     if (if_entry->flags & GNRC_IPV6_NETIF_FLAGS_ROUTER) {
+        gnrc_ipv6_nc_t *nc_entry;
         int sicmpv6_size = (int)icmpv6_size, l2src_len = 0;
         uint8_t l2src[GNRC_IPV6_NC_L2_ADDR_MAX];
         uint16_t opt_offset = 0;
@@ -458,11 +459,17 @@ void gnrc_ndp_rtr_sol_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
                 /* or unicast, if source is known */
                 /* XXX: can't just use GNRC_NETAPI_MSG_TYPE_SND, since the next retransmission
                  * must also be set. */
-                gnrc_ipv6_nc_t *nc_entry = gnrc_ipv6_nc_get(iface, &ipv6->src);
+                nc_entry = gnrc_ipv6_nc_get(iface, &ipv6->src);
                 xtimer_set_msg(&nc_entry->rtr_adv_timer, delay, &nc_entry->rtr_adv_msg,
                                gnrc_ipv6_pid);
             }
 #endif
+        }
+        nc_entry = gnrc_ipv6_nc_get(iface, &ipv6->src);
+        if (nc_entry != NULL) {
+            /* unset isRouter flag
+             * (https://tools.ietf.org/html/rfc4861#section-6.2.6) */
+            nc_entry->flags &= ~GNRC_IPV6_NC_IS_ROUTER;
         }
     }
     /* otherwise ignore silently */


### PR DESCRIPTION
After re-reading the RFCs this kept me thinking. When implementing handling of RFCs I disregarded this behavior as not suitable for mesh networks since this would basically take every neighboring router out of the default router list of the node. But I'm not so sure this is the case here: When bootstrapping the network a router only multicasts router solicitations on it's initialization to find its upstream router. Only the upstream router would then disregard the down-stream router as one of its default routers, since it wants to send information out of then network in normal cases (see our confusion at the border router, where it sometimes prefers to send to one of its downstream routers instead out of the network). I did not find any specific information on this in RFC 6775 so I'm getting the feeling I'm on the right track with this.