### PR TITLE
Arduino mega: change in avrdude argument

### DIFF
--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -43,4 +43,4 @@ export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
 export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -e reset_handler
 export OFLAGS += -j .text -j .data -O ihex
-export FFLAGS += -p m2560 -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -U flash:w:bin/$(BOARD)/$(PROJECT)$(APPLICATION).hex
+export FFLAGS += -p m2560 -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -D -U flash:w:bin/$(BOARD)/$(PROJECT)$(APPLICATION).hex


### PR DESCRIPTION
I was unable to flash the arduino mega with the `make flash` command. Got error message `avrdude: stk500v2_command(): command failed`. However flashing did work using the Arduino IDE, after looking at their avrdude argument i found that the use the `-D` command, adding that to the RIOT makefile made flashing work with `make flash`.