### PR TITLE
gnrc_ipv6_nc: fix compilation error at debug output

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nc/gnrc_ipv6_nc.c
@@ -45,7 +45,7 @@ static void _nc_remove(kernel_pid_t iface, gnrc_ipv6_nc_t *entry)
     }
 
     DEBUG("ipv6_nc: Remove %s for interface %" PRIkernel_pid "\n",
-          ipv6_addr_to_str(addr_str, ipv6_addr, sizeof(addr_str)),
+          ipv6_addr_to_str(addr_str, &(entry->ipv6_addr), sizeof(addr_str)),
           iface);
 
 #ifdef MODULE_GNRC_NDP_NODE


### PR DESCRIPTION
6f6ec3c8a5a96763d4f4f86a879a45a1441904cf refactored `nc_remove` but forgot to update `DEBUG` output. Should we `s/ENABLE_DEBUG (0)/ENABLE_DEBUG (1)/` before CI?