### PR TITLE
debug: fix compilation error for %p formatter

### DIFF
--- a/core/clist.c
+++ b/core/clist.c
@@ -67,7 +67,8 @@ void clist_print(clist_node_t *clist)
     }
 
     do {
-        printf("list entry: %p: prev=%p next=%p\n", clist, clist->prev, clist->next);
+        printf("list entry: %p: prev=%p next=%p\n",
+               (void *)clist, (void *)clist->prev, (void *)clist->next);
         clist = clist->next;
 
         if (clist == start) {

--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -188,9 +188,7 @@ static uint_fast8_t i2c_ctrl_blocking(uint_fast8_t flags)
 
     if (I2CM_STAT & BUSY) {
         /* If the controller is still busy, it probably will be forever */
-#ifdef MODULE_XTIMER
         DEBUG("Master is still BUSY after %u usec. Resetting.\n", xtimer_timeout);
-#endif
         cc2538_i2c_init_master(speed_hz);
     }
 

--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -188,7 +188,9 @@ static uint_fast8_t i2c_ctrl_blocking(uint_fast8_t flags)
 
     if (I2CM_STAT & BUSY) {
         /* If the controller is still busy, it probably will be forever */
+#ifdef MODULE_XTIMER
         DEBUG("Master is still BUSY after %u usec. Resetting.\n", xtimer_timeout);
+#endif
         cc2538_i2c_init_master(speed_hz);
     }
 
@@ -536,7 +538,8 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
     }
 
         if (n < length) {
-            DEBUG("%s(%u, %p, %u): %u/%u bytes delivered.\n", __FUNCTION__, address, data, length, n, length);
+            DEBUG("%s(%u, %p, %u): %u/%u bytes delivered.\n",
+                  __FUNCTION__, address, (void *)data, length, n, length);
         }
 
     return n;
@@ -617,7 +620,7 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int leng
                 dev,
                 address,
                 reg,
-                data,
+                (void *)data,
                 length,
                 n,
                 length

--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -452,7 +452,8 @@ void native_interrupt_init(void)
     DEBUG("native_interrupt_init\n");
 
     VALGRIND_STACK_REGISTER(__isr_stack, __isr_stack + sizeof(__isr_stack));
-    VALGRIND_DEBUG("VALGRIND_STACK_REGISTER(%p, %p)\n", __isr_stack, (void*)((int)__isr_stack + sizeof(__isr_stack)));
+    VALGRIND_DEBUG("VALGRIND_STACK_REGISTER(%p, %p)\n",
+                   (void *)__isr_stack, (void*)((int)__isr_stack + sizeof(__isr_stack)));
 
     native_interrupts_enabled = 1;
     _native_sigpend = 0;

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -80,7 +80,8 @@ char *thread_stack_init(thread_task_func_t task_func, void *arg, void *stack_sta
     ucontext_t *p;
 
     VALGRIND_STACK_REGISTER(stack_start, (char *) stack_start + stacksize);
-    VALGRIND_DEBUG("VALGRIND_STACK_REGISTER(%p, %p)\n", stack_start, (void*)((int)stack_start + stacksize));
+    VALGRIND_DEBUG("VALGRIND_STACK_REGISTER(%p, %p)\n",
+                   stack_start, (void*)((int)stack_start + stacksize));
 
     DEBUG("thread_stack_init\n");
 
@@ -203,7 +204,8 @@ void native_cpu_init(void)
     end_context.uc_stack.ss_flags = 0;
     makecontext(&end_context, sched_task_exit, 0);
     VALGRIND_STACK_REGISTER(__end_stack, __end_stack + sizeof(__end_stack));
-    VALGRIND_DEBUG("VALGRIND_STACK_REGISTER(%p, %p)\n", __end_stack, (void*)((int)__end_stack + sizeof(__end_stack)));
+    VALGRIND_DEBUG("VALGRIND_STACK_REGISTER(%p, %p)\n",
+                   (void*)__end_stack, (void*)((int)__end_stack + sizeof(__end_stack)));
 
     DEBUG("RIOT native cpu initialized.\n");
 }

--- a/cpu/x86/x86_memory.c
+++ b/cpu/x86/x86_memory.c
@@ -283,13 +283,14 @@ static bool add_pages_to_pool(uint64_t start, uint64_t end)
 
 static void init_free_pages(void)
 {
-    printf("Kernel memory: %p - %p\r\n", &_kernel_memory_start, &_kernel_memory_end);
-    printf("  .text:   %p - %p\r\n", &_section_text_start, &_section_text_end);
-    printf("  .rodata: %p - %p\r\n", &_section_rodata_start, &_section_rodata_end);
-    printf("  .data:   %p - %p\r\n", &_section_data_start, &_section_data_end);
-    printf("  .bss:    %p - %p\r\n", &_section_bss_start, &_section_bss_end);
-    printf("Unmapped memory: %p - %p\r\n", &_kernel_memory_end, &_heap_start);
-    printf("Heap start: %p\r\n", &_heap_start);
+    printf("Kernel memory: %p - %p\r\n",
+           (void *)&_kernel_memory_start, (void *)&_kernel_memory_end);
+    printf("  .text:   %p - %p\r\n", (void *)&_section_text_start, (void *)&_section_text_end);
+    printf("  .rodata: %p - %p\r\n", (void *)&_section_rodata_start, (void *)&_section_rodata_end);
+    printf("  .data:   %p - %p\r\n", (void *)&_section_data_start, (void *)&_section_data_end);
+    printf("  .bss:    %p - %p\r\n", (void *)&_section_bss_start, (void *)&_section_bss_end);
+    printf("Unmapped memory: %p - %p\r\n", (void *)&_kernel_memory_end, (void *)&_heap_start);
+    printf("Heap start: %p\r\n", (void *)&_heap_start);
 
     unsigned long cnt = 0;
     uint64_t start, len;

--- a/drivers/pir/pir.c
+++ b/drivers/pir/pir.c
@@ -58,7 +58,7 @@ int pir_register_thread(pir_t *dev)
         }
     }
     else {
-        DEBUG("pir_register_thread: activating interrupt for %p..\n", dev);
+        DEBUG("pir_register_thread: activating interrupt for %p..\n", (void *)dev);
         if (pir_activate_int(dev) != 0) {
             DEBUG("\tfailed\n");
             return -1;

--- a/pkg/openwsn/patches/0005-fixes-to-RIOT-adaption.patch
+++ b/pkg/openwsn/patches/0005-fixes-to-RIOT-adaption.patch
@@ -2318,7 +2318,7 @@ index 367513c..a5589ff 100644
     taskList_item_t** taskListWalker;
     INTERRUPT_DECLARATION();
     
-+   DEBUG("owsn scheduler: push back task %p.\n", cb);
++   DEBUG("owsn scheduler: push back task %p.\n", (void *)cb);
     DISABLE_INTERRUPTS();
     
     // find an empty task container

--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -328,7 +328,7 @@ static int fib_signal_rp(fib_table_t *table, uint16_t type, uint8_t *dat,
     for (size_t i = 0; i < FIB_MAX_REGISTERED_RP; ++i) {
         if (table->notify_rp[i] != KERNEL_PID_UNDEF) {
             DEBUG("[fib_signal_rp] send msg@: %p to pid[%d]: %d\n", \
-                  msg.content.ptr, (int)i, (int)(table->notify_rp[i]));
+                  (void *)msg.content.ptr, (int)i, (int)(table->notify_rp[i]));
 
             /* do only signal a RP if its registered prefix matches */
             if (type != FIB_MSG_RP_SIGNAL_SOURCE_ROUTE_CREATED) {

--- a/sys/posix/pthread/pthread.c
+++ b/sys/posix/pthread/pthread.c
@@ -108,7 +108,7 @@ static void *pthread_reaper(void *arg)
     while (1) {
         msg_t m;
         msg_receive(&m);
-        DEBUG("pthread_reaper(): free(%p)\n", m.content.ptr);
+        DEBUG("pthread_reaper(): free(%p)\n", (void *)m.content.ptr);
         free(m.content.ptr);
     }
 


### PR DESCRIPTION
Passing pointer value other than `void *` to `%p` formatter results in compilation error on Clang 7.3.0 on OS X:
```
RIOT/sys/net/network_layer/fib/fib.c:331:19: error: format specifies type 'void *' but
      the argument has type 'char *' [-Werror,-Wformat-pedantic]
                  msg.content.ptr, (int)i, (int)(table->notify_rp[i]));
                  ^~~~~~~~~~~~~~~
```

```
$ clang --version
Apple LLVM version 7.3.0 (clang-703.0.29)
Target: x86_64-apple-darwin15.4.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

This PR adds casts for pointers.