### PR TITLE
dist: compile_test.py: build everything on changes in pkg/

### DIFF
--- a/dist/tools/compile_test/compile_test.py
+++ b/dist/tools/compile_test/compile_test.py
@@ -119,7 +119,8 @@ def is_updated(application_folder, subprocess_env):
             return True
 
         if '.travis.yml' in diff_files or \
-           any('dist/' in s for s in diff_files):
+           any('dist/' in s for s in diff_files) or \
+           any('pkg/' in s for s in diff_files):
             return True
 
         boards_changes = set()


### PR DESCRIPTION
Currently, changes in pkg/ don't trigger rebuilding of affected applications or tests.
This PR rebuilds everything for changes in pkg/, analog to dist/.

Not the most efficient option, but simple and better than false CI positives.