### PR TITLE
pkg: clarify that current `download` target is only for git

### DIFF
--- a/pkg/Makefile.git
+++ b/pkg/Makefile.git
@@ -4,7 +4,7 @@ PKG_VERSION=	# version of the package to use e.g. a git commit/ref
 
 .PHONY: all
 
-all: download
+all: git-download
 	$(MAKE) -C $(CURDIR)/$(PKG_NAME)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -6,7 +6,7 @@ PKG_VERSION=39b1406c11de9de364220909488eebabe7e81613
 
 export RIOT_CFLAGS = ${CFLAGS} ${INCLUDES}
 
-all: download
+all: git-download
 	"$(MAKE)" -BC $(PKG_BUILDDIR)/src lib-ccn-lite.a
 	"$(MAKE)" -BC $(PKG_BUILDDIR)/src lib-ccn-lite-utils.a
 	cp $(PKG_BUILDDIR)/src/lib-ccn-lite.a ${BINDIR}/ccn-lite.a

--- a/pkg/cmsis-dsp/Makefile
+++ b/pkg/cmsis-dsp/Makefile
@@ -8,7 +8,7 @@ endif
 
 .PHONY: all
 
-all: download
+all: git-download
 	$(MAKE) -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/libcoap/Makefile
+++ b/pkg/libcoap/Makefile
@@ -9,7 +9,7 @@ endif
 
 .PHONY: all
 
-all: download
+all: git-download
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/micro-ecc/Makefile
+++ b/pkg/micro-ecc/Makefile
@@ -9,7 +9,7 @@ endif
 
 .PHONY: all
 
-all: download
+all: git-download
 	make -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/microcoap/Makefile
+++ b/pkg/microcoap/Makefile
@@ -9,7 +9,7 @@ endif
 
 .PHONY: all
 
-all: download
+all: git-download
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -11,7 +11,7 @@ MODULE:=$(PKG_NAME)
 
 .PHONY: all
 
-all: download
+all: git-download
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 	"$(MAKE)" $(BINDIR)$(MODULE).a
 

--- a/pkg/openwsn/Makefile
+++ b/pkg/openwsn/Makefile
@@ -4,7 +4,7 @@ PKG_VERSION=ff25e5d0ae5d344ed793a724d60532fb917bf1f8
 
 .PHONY: all
 
-all: download
+all: git-download
 	"$(MAKE)" -C $(PKG_DIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -4,15 +4,17 @@
 PKG_DIR?=$(CURDIR)
 PKG_BUILDDIR?=$(BINDIR)/pkg/$(PKG_NAME)
 
-download: $(PKG_BUILDDIR)/.downloaded
+.PHONY: git-download
 
-$(PKG_BUILDDIR)/.downloaded:
+git-download: $(PKG_BUILDDIR)/.git-downloaded
+
+$(PKG_BUILDDIR)/.git-downloaded:
 	mkdir -p $(PKG_BUILDDIR)
 	$(GITCACHE) clone "$(PKG_URL)" "$(PKG_VERSION)" "$(PKG_BUILDDIR)"
 	if test -d "$(PKG_DIR)"/patches; then \
 		git -C "$(PKG_BUILDDIR)" am --ignore-whitespace "$(PKG_DIR)"/patches/*.patch; \
-		fi
-	touch $(PKG_BUILDDIR)/.downloaded
+	fi
+	touch $@
 
 clean::
 	@echo "Cleaning package $(PKG_NAME)..."

--- a/pkg/relic/Makefile
+++ b/pkg/relic/Makefile
@@ -19,7 +19,7 @@ $(PKG_BUILDDIR)/comp-options.cmake: fix_source
 $(PKG_BUILDDIR)/Makefile: $(PKG_BUILDDIR)/comp-options.cmake
 	cd "$(PKG_BUILDDIR)" && COMP="$(filter-out -Werror=old-style-definition -Werror=strict-prototypes, $(CFLAGS) ) " cmake -DCMAKE_TOOLCHAIN_FILE=comp-options.cmake -DCHECK=off -DTESTS=0 -DBENCH=0 -DSHLIB=off -Wno-dev $(RELIC_CONFIG_FLAGS) .
 
-fix_source: download
+fix_source: git-download
 	./fix-util_print_wo_args.sh $(PKG_BUILDDIR)
 	./fix-old-style-definitions.sh $(PKG_BUILDDIR)
 

--- a/pkg/wakaama/Makefile
+++ b/pkg/wakaama/Makefile
@@ -7,7 +7,7 @@ PKG_VERSION=69a32cfae39f66fe4eec4cc8d1cd48ced7ad447c
 all: patch
 	"$(MAKE)" -C $(PKG_BUILDDIR)/riotbuild
 
-patch: download
+patch: git-download
 	mkdir -p "$(PKG_BUILDDIR)/riotbuild"
 	cp $(PKG_BUILDDIR)/core/*.c $(PKG_BUILDDIR)/core/*.h $(PKG_BUILDDIR)/riotbuild
 	cp $(PKG_BUILDDIR)/core/er-coap-13/*.c $(PKG_TEMP_DIR)/core/er-coap-13/*.h $(PKG_BUILDDIR)/riotbuild


### PR DESCRIPTION
Enhancement to #5138. I did not provide a general download method for HTTP since I think it is too diverse. We do not have other sources than git or HTTP yet so I did not provide e.g. SVN either ;-).