### PR TITLE
cpu/cc2538/periph/gpio: fix gpio_init() bugs in cfed0e3

### DIFF
--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -369,10 +369,11 @@ int gpio_init(gpio_t dev, gpio_mode_t mode)
             gpio_dir_input(pin);
             /* configure the pin's pull resistor state */
             IOC_PXX_OVER[pin] = (IOC_OVERRIDE_PUE);
+            break;
         case GPIO_OUT:
             gpio_dir_output(pin);
             /* configure the pin's pull resistor state */
-            IOC_PXX_OVER[pin] = (IOC_OVERRIDE_OE | IOC_OVERRIDE_DIS);
+            IOC_PXX_OVER[pin] = (IOC_OVERRIDE_OE);
             break;
         default:
             return -1;


### PR DESCRIPTION
The `break` statement is the important fix. The other line is just for clarity and has no effect since `IOC_OVERRIDE_DIS` is zero.