### PR TITLE
fib: cs precision

### DIFF
--- a/sys/include/net/fib.h
+++ b/sys/include/net/fib.h
@@ -70,7 +70,7 @@ typedef struct fib_destination_set_entry_t {
 /**
  * @brief indicator of a lifetime that does not expire (2^64 - 1)
  */
-#define FIB_LIFETIME_NO_EXPIRE (0xFFFFFFFFffffffff)
+#define FIB_LIFETIME_NO_EXPIRE (0xFFFFFFFF)
 
 /**
  * @brief flag to identify if a route was set by RPL
@@ -121,7 +121,7 @@ int fib_register_rp(fib_table_t *table, uint8_t *prefix, size_t prefix_addr_type
  * @param[in] next_hop       the next hop address to be updated
  * @param[in] next_hop_size  the next hop address size
  * @param[in] next_hop_flags the next-hop address flags
- * @param[in] lifetime       the lifetime in ms to be updates
+ * @param[in] lifetime       the lifetime in centiseconds to be updates
  *
  * @return 0 on success
  *         -ENOMEM if the entry cannot be created due to insufficient RAM
@@ -141,7 +141,7 @@ int fib_add_entry(fib_table_t *table, kernel_pid_t iface_id, uint8_t *dst,
  * @param[in] next_hop       the next hop address to be updated
  * @param[in] next_hop_size  the next hop address size
  * @param[in] next_hop_flags the next-hop address flags
- * @param[in] lifetime       the lifetime in ms to be updates
+ * @param[in] lifetime       the lifetime in centiseconds to be updates
  *
  * @return 0 on success
  *         -ENOMEM if the entry cannot be updated due to insufficient RAM
@@ -498,7 +498,7 @@ void fib_print_sr(fib_table_t *table, fib_sr_t *sr);
  * @return 0             on success: entry for dst found and lifetime copied
  *         -EHOSTUNREACH if no fitting entry is available
  */
-int fib_devel_get_lifetime(fib_table_t *table, uint64_t *lifetime, uint8_t *dst,
+int fib_devel_get_lifetime(fib_table_t *table, uint32_t *lifetime, uint8_t *dst,
                            size_t dst_size);
 
 #endif

--- a/sys/include/net/fib/table.h
+++ b/sys/include/net/fib/table.h
@@ -42,7 +42,7 @@ typedef struct fib_entry_t {
     /** interface ID */
     kernel_pid_t iface_id;
     /** Lifetime of this entry (an absolute time-point is stored by the FIB) */
-    uint64_t lifetime;
+    uint32_t lifetime;
     /** Unique identifier for the type of the global address */
     uint32_t global_flags;
     /** Pointer to the shared generic address */
@@ -70,7 +70,7 @@ typedef struct fib_sr_t {
     /** interface ID */
     kernel_pid_t sr_iface_id;
     /** Lifetime of this entry (an absolute time-point is stored by the FIB) */
-    uint64_t sr_lifetime;
+    uint32_t sr_lifetime;
     /** Flags for this source route */
     uint32_t sr_flags;
     /** Pointer to the first hop on the source route */

--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -39,6 +39,16 @@ extern "C" {
 #define SEC_IN_MS   (1000U)
 
 /**
+ * @brief The number of centiseconds per second
+ */
+#define SEC_IN_CS   (100U)
+
+/**
+ * @brief The number of microseconds per centisecond
+ */
+#define CS_IN_USEC  (10000U)
+
+/**
  * @brief The number of microseconds per millisecond
  */
 #define MS_IN_USEC  (1000U)

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -462,8 +462,7 @@ bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt_t *opt
                 fib_add_entry(&gnrc_ipv6_fib_table, dodag->iface, target->target.u8,
                               sizeof(ipv6_addr_t), fib_dst_flags, src->u8,
                               sizeof(ipv6_addr_t), FIB_FLAG_RPL_ROUTE,
-                              (dodag->default_lifetime * dodag->lifetime_unit) *
-                              SEC_IN_MS);
+                              dodag->default_lifetime * dodag->lifetime_unit * SEC_IN_CS);
                 break;
 
             case (GNRC_RPL_OPT_TRANSIT):
@@ -487,8 +486,7 @@ bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt_t *opt
                                      sizeof(ipv6_addr_t),
                                      ((transit->e_flags & GNRC_RPL_OPT_TRANSIT_E_FLAG) ?
                                       0x0 : FIB_FLAG_RPL_ROUTE),
-                                     (transit->path_lifetime *
-                                      dodag->lifetime_unit * SEC_IN_MS));
+                                     transit->path_lifetime * dodag->lifetime_unit * SEC_IN_CS);
                     first_target = (gnrc_rpl_opt_target_t *) (((uint8_t *) (first_target)) +
                                    sizeof(gnrc_rpl_opt_t) + first_target->length);
                 }

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -208,7 +208,7 @@ bool gnrc_rpl_parent_remove(gnrc_rpl_parent_t *parent)
                           parent->next->addr.u8,
                           sizeof(ipv6_addr_t),
                           FIB_FLAG_RPL_ROUTE,
-                          (parent->next->lifetime - now) * SEC_IN_MS);
+                          (parent->next->lifetime - now) * SEC_IN_CS);
         }
     }
     LL_DELETE(dodag->parents, parent);
@@ -252,7 +252,7 @@ void gnrc_rpl_parent_update(gnrc_rpl_dodag_t *dodag, gnrc_rpl_parent_t *parent)
                           parent->addr.u8,
                           sizeof(ipv6_addr_t),
                           FIB_FLAG_RPL_ROUTE,
-                          (dodag->default_lifetime * dodag->lifetime_unit) * SEC_IN_MS);
+                          dodag->default_lifetime * dodag->lifetime_unit * SEC_IN_CS);
         }
     }
 
@@ -304,7 +304,7 @@ static gnrc_rpl_parent_t *_gnrc_rpl_find_preferred_parent(gnrc_rpl_dodag_t *doda
                       dodag->parents->addr.u8,
                       sizeof(ipv6_addr_t),
                       FIB_FLAG_RPL_ROUTE,
-                      (dodag->default_lifetime * dodag->lifetime_unit) * SEC_IN_MS);
+                      dodag->default_lifetime * dodag->lifetime_unit * SEC_IN_CS);
     }
 
     dodag->my_rank = dodag->instance->of->calc_rank(dodag->parents, 0);

--- a/tests/unittests/tests-fib/tests-fib.c
+++ b/tests/unittests/tests-fib/tests-fib.c
@@ -46,7 +46,7 @@ static void _fill_FIB_unique(size_t entries)
         fib_add_entry(&test_fib_table, 42,
                       (uint8_t *)addr_dst, add_buf_size - 1, addr_dst_flags,
                       (uint8_t *)addr_nxt, add_buf_size - 1, addr_nxt_flags,
-                      10000);
+                      1000);
     }
 }
 
@@ -69,7 +69,7 @@ static void _fill_FIB_multiple(size_t entries, size_t modulus)
         fib_add_entry(&test_fib_table, 42,
                       (uint8_t *)addr_dst, add_buf_size - 1, addr_dst_flags,
                       (uint8_t *)addr_nxt, add_buf_size - 1, addr_nxt_flags,
-                      10000);
+                      1000);
     }
 }
 
@@ -323,10 +323,10 @@ static void test_fib_09_update_entry(void)
 
     fib_update_entry(&test_fib_table, (uint8_t *)addr_dst13,
                      add_buf_size - 1, (uint8_t *)addr_nxt2, add_buf_size - 1,
-                     0x99, 9999);
+                     0x99, 999);
     fib_update_entry(&test_fib_table, (uint8_t *)addr_dst07,
                      add_buf_size - 1, (uint8_t *)addr_nxt77, add_buf_size - 1,
-                     0x77, 7777);
+                     0x77, 777);
 
 #if (TEST_FIB_SHOW_OUTPUT == 1)
     fib_print_fib_table(&test_fib_table);
@@ -356,7 +356,7 @@ static void test_fib_10_add_exceed(void)
 
     int ret = fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
                             add_buf_size - 1, 0x98, (uint8_t *)addr_nxt,
-                            add_buf_size - 1, 0x99, 9999);
+                            add_buf_size - 1, 0x99, 999);
 
     TEST_ASSERT_EQUAL_INT(-ENOMEM, ret);
     TEST_ASSERT_EQUAL_INT(20, fib_get_num_used_entries(&test_fib_table));
@@ -496,21 +496,21 @@ static void test_fib_14_exact_and_prefix_match(void)
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
                   add_buf_size - 1, (FIB_FLAG_NET_PREFIX | 0x12),
                   (uint8_t *)addr_nxt, add_buf_size - 1,
-                  0x12, 100000);
+                  0x12, 10000);
 
     snprintf(addr_dst, add_buf_size, "Test addr123");
     snprintf(addr_nxt, add_buf_size, "Test address %02d", 23);
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
                   add_buf_size - 1, (FIB_FLAG_NET_PREFIX | 0x123),
                   (uint8_t *)addr_nxt, add_buf_size - 1,
-                  0x23, 100000);
+                  0x23, 10000);
 
     snprintf(addr_dst, add_buf_size, "Test addr1234");
     snprintf(addr_nxt, add_buf_size, "Test address %02d", 34);
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
                   add_buf_size - 1, (FIB_FLAG_NET_PREFIX | 0x1234),
                   (uint8_t *)addr_nxt, add_buf_size - 1,
-                  0x34, 100000);
+                  0x34, 10000);
 
     memset(addr_lookup, 0, add_buf_size);
     /* exact match */
@@ -558,7 +558,7 @@ static void test_fib_14_exact_and_prefix_match(void)
 
 static void test_fib_15_get_lifetime(void)
 {
-    uint64_t lifetime, now;
+    uint32_t lifetime, now;
     kernel_pid_t iface_id = 1;
     char addr_dst[] = "Test address151";
     char addr_nxt[] = "Test address152";
@@ -575,10 +575,10 @@ static void test_fib_15_get_lifetime(void)
                                                     (uint8_t *)addr_dst,
                                                     add_buf_size - 1));
 
-    /* assuming some ms passed during these operations... */
-    now = xtimer_now64();
-    uint64_t cmp_lifetime = now + 900000lU;
-    uint64_t cmp_max_lifetime = now + 1100000lU;
+    /* assuming no centiseconds passed during these operations... */
+    now = (uint32_t) (xtimer_now64() / CS_IN_USEC);
+    uint32_t cmp_lifetime = now + 999;
+    uint32_t cmp_max_lifetime = now + 1111;
 
     TEST_ASSERT_EQUAL_INT(1, (lifetime > cmp_lifetime));
     /* make sure lifetime hasn't grown magically either */
@@ -615,13 +615,13 @@ static void test_fib_16_prefix_match(void)
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
                   add_buf_size - 1, (FIB_FLAG_NET_PREFIX | 0x123),
                   (uint8_t *)addr_nxt, add_buf_size - 1,
-                  0x23, 100000);
+                  0x23, 10000);
 
     addr_dst[14] = (char)0x3c;    /* 0011 1100 */
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
                   add_buf_size - 1, (FIB_FLAG_NET_PREFIX | 0x123),
                   (uint8_t *)addr_nxt, add_buf_size - 1,
-                  0x23, 100000);
+                  0x23, 10000);
 
     memset(addr_nxt, 0, add_buf_size);
 
@@ -639,7 +639,7 @@ static void test_fib_16_prefix_match(void)
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
                   add_buf_size - 1, (FIB_FLAG_NET_PREFIX | 0x123),
                   (uint8_t *)addr_nxt, add_buf_size -
-                  1, 0x23, 100000);
+                  1, 0x23, 100);
 
     memset(addr_nxt, 0, add_buf_size);
 
@@ -687,7 +687,7 @@ static void test_fib_17_get_entry_set(void)
         snprintf(addr_nxt, addr_buf_size, "Test address %02d", (int)(i % 11));
         fib_add_entry(&test_fib_table, 42,
                       (uint8_t *)addr_dst, addr_buf_size - 1, 0x0,
-                      (uint8_t *)addr_nxt, addr_buf_size - 1, 0x0, 100000);
+                      (uint8_t *)addr_nxt, addr_buf_size - 1, 0x0, 10000);
     }
 
     size_t arr_size = 20;
@@ -815,7 +815,7 @@ static void test_fib_19_default_gateway(void)
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
                   add_buf_size, (FIB_FLAG_NET_PREFIX | 0x123),
                   (uint8_t *)addr_nxt, add_buf_size, 0x23,
-                  100000);
+                  10000);
 
     /* check if it matches all */
     int ret = fib_get_next_hop(&test_fib_table, &iface_id,
@@ -836,7 +836,7 @@ static void test_fib_19_default_gateway(void)
     /* change the default gateway entry */
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
                   add_buf_size, 0x123, (uint8_t *)addr_nxt, add_buf_size, 0x24,
-                  100000);
+                  10000);
 
     /* and check again if it matches all */
     ret = fib_get_next_hop(&test_fib_table, &iface_id,
@@ -892,7 +892,7 @@ static void test_fib_20_replace_prefix(void)
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
                   add_buf_size, (FIB_FLAG_NET_PREFIX | 0x123),
                   (uint8_t *)addr_nxt, add_buf_size, 0x23,
-                  100000);
+                  10000);
 
     /* check if it matches */
     int ret = fib_get_next_hop(&test_fib_table, &iface_id,
@@ -922,7 +922,7 @@ static void test_fib_20_replace_prefix(void)
     fib_add_entry(&test_fib_table, 42, (uint8_t *)addr_dst,
                   add_buf_size, (FIB_FLAG_NET_PREFIX | 0x123),
                   (uint8_t *)addr_nxt, add_buf_size, 0x24,
-                  100000);
+                  10000);
 
     /* and check again if it matches  */
     ret = fib_get_next_hop(&test_fib_table, &iface_id,


### PR DESCRIPTION
This is just an exercise to see how reducing the precision of the fib's lifetimes impacts the size. I did no verification besides of compiling `gnrc_networking` and running the unittests. This PR should not be merged and may still be subject to discussion.

This PR basically assumes seconds in absolute time. So I reduced all `uint64_t` to `uint32_t`. I am not sure whether going lower than 32-bit is a good idea, though.

see #4518

Following a size comparison for `gnrc_networking`

```
text    data    bss     dec     BOARD/BINDIRBASE

-60     0       -160    -220    arduino-due
58168   284     17480   75932   master-bin
58108   284     17320   75712   fib-bin

-426    0       -80     -506    arduino-mega2560
81686   11578   11284   104548  master-bin
81260   11578   11204   104042  fib-bin

-152    0       0       -152    avsextrem
86280   220     98077   184577  master-bin
86128   220     98077   184425  fib-bin

-56     0       -160    -216    cc2538dk
58340   220     17432   75992   master-bin
58284   220     17272   75776   fib-bin

-64     0       -160    -224    ek-lm4f120xl
58600   220     17408   76228   master-bin
58536   220     17248   76004   fib-bin

-64     0       -160    -224    f4vi1
60288   224     17544   78056   master-bin
60224   224     17384   77832   fib-bin

-32     0       -160    -192    fox
73436   220     20600   94256   master-bin
73404   220     20440   94064   fib-bin

-64     0       -168    -232    frdm-k64f
58704   1248    17944   77896   master-bin
58640   1248    17776   77664   fib-bin

-32     0       -160    -192    iotlab-m3
73448   220     20600   94268   master-bin
73416   220     20440   94076   fib-bin

-60     0       -160    -220    limifrog-v1
59440   220     17528   77188   master-bin
59380   220     17368   76968   fib-bin

-60     0       -160    -220    mbed_lpc1768
57944   220     17400   75564   master-bin
57884   220     17240   75344   fib-bin

-152    0       0       -152    msba2
108228  220     98077   206525  master-bin
108076  220     98077   206373  fib-bin

-64     0       -160    -224    msbiot
60624   224     17592   78440   master-bin
60560   224     17432   78216   fib-bin

-48     0       -160    -208    mulle
76264   1284    21056   98604   master-bin
76216   1284    20896   98396   fib-bin

-236    0       -96     -332    native
197838  620     103128  301586  master-bin
197602  620     103032  301254  fib-bin

-64     0       -168    -232    nrf52dk
57952   220     17400   75572   master-bin
57888   220     17232   75340   fib-bin

-44     0       -160    -204    nucleo-f091
59768   220     17528   77516   master-bin
59724   220     17368   77312   fib-bin

-64     0       -160    -224    nucleo-f303
58648   220     17536   76404   master-bin
58584   220     17376   76180   fib-bin

-64     0       -160    -224    nucleo-f401
60256   224     17544   78024   master-bin
60192   224     17384   77800   fib-bin

-60     0       -160    -220    nucleo-l1
59320   220     17520   77060   master-bin
59260   220     17360   76840   fib-bin

-56     0       -160    -216    openmote-cc2538
58964   220     17688   76872   master-bin
58908   220     17528   76656   fib-bin

-64     0       -168    -232    pba-d-01-kw2x
75464   1248    21128   97840   master-bin
75400   1248    20960   97608   fib-bin

-152    0       0       -152    pttu
86488   220     98077   184785  master-bin
86336   220     98077   184633  fib-bin

-56     0       -160    -216    remote
58976   220     17632   76828   master-bin
58920   220     17472   76612   fib-bin

-44     0       -160    -204    saml21-xpro
59772   220     17520   77512   master-bin
59728   220     17360   77308   fib-bin

-40     0       -160    -200    samr21-xpro
76224   220     20608   97052   master-bin
76184   220     20448   96852   fib-bin

-32     0       -168    -200    slwstk6220a
58068   220     17528   75816   master-bin
58036   220     17360   75616   fib-bin

-64     0       -160    -224    stm32f3discovery
58728   220     17536   76484   master-bin
58664   220     17376   76260   fib-bin

-64     0       -160    -224    stm32f4discovery
60536   224     17568   78328   master-bin
60472   224     17408   78104   fib-bin

-60     0       -160    -220    udoo
58168   284     17480   75932   master-bin
58108   284     17320   75712   fib-bin
```
