### PR TITLE
net ipv6: use full include path

### DIFF
--- a/sys/include/net/ipv6.h
+++ b/sys/include/net/ipv6.h
@@ -24,9 +24,9 @@
 #ifndef IPV6_H_
 #define IPV6_H_
 
-#include "ipv6/addr.h"
-#include "ipv6/ext.h"
-#include "ipv6/hdr.h"
+#include "net/ipv6/addr.h"
+#include "net/ipv6/ext.h"
+#include "net/ipv6/hdr.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Using an "absolute" instead of a relative include path, make the doxygen output less confusing.

A small part of the fix for #4794. Thanks to @A-Paul for the observation.