### PR TITLE
core: debug: rely on optimizer to kick out unused debug code

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -67,7 +67,9 @@ extern "C" {
  * @name Debugging defines
  * @{
  */
-#if ENABLE_DEBUG
+#ifndef ENABLE_DEBUG
+#define ENABLE_DEBUG (0)
+#endif
 
 /**
  * @def DEBUG_FUNC
@@ -92,10 +94,7 @@ extern "C" {
  *
  * @note Another name for ::DEBUG_PRINT
  */
-#define DEBUG(...) DEBUG_PRINT(__VA_ARGS__)
-#else
-#define DEBUG(...)
-#endif
+#define DEBUG(...) if (ENABLE_DEBUG) DEBUG_PRINT(__VA_ARGS__)
 /** @} */
 
 /**

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -447,9 +447,10 @@ char *thread_stack_init(thread_task_func_t task_func, void *arg, void *stack_sta
  */
 void thread_add_to_list(list_node_t *list, thread_t *thread);
 
-#ifdef DEVELHELP
 /**
  * @brief Returns the name of a process
+ *
+ * @note when compiling without DEVELHELP, this *always* returns NULL!
  *
  * @param[in] pid   the PID of the thread to get the name from
  *
@@ -458,6 +459,7 @@ void thread_add_to_list(list_node_t *list, thread_t *thread);
  */
 const char *thread_getname(kernel_pid_t pid);
 
+#ifdef DEVELHELP
 /**
  * @brief Measures the stack usage of a stack
  *

--- a/core/thread.c
+++ b/core/thread.c
@@ -44,13 +44,16 @@ int thread_getstatus(kernel_pid_t pid)
     return t ? (int) t->status : STATUS_NOT_FOUND;
 }
 
-#ifdef DEVELHELP
 const char *thread_getname(kernel_pid_t pid)
 {
+#ifdef DEVELHELP
     volatile thread_t *t = thread_get(pid);
     return t ? t->name : NULL;
-}
+#else
+    (void)pid;
+    return NULL;
 #endif
+}
 
 void thread_sleep(void)
 {

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -132,7 +132,8 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
         }
 
         if (freq != sys_clock_freq()) {
-            DEBUG("In 32-bit mode, the GPTimer frequency must equal the system clock frequency (%u).", sys_clock_freq());
+            DEBUG("In 32-bit mode, the GPTimer frequency must equal the system clock frequency (%u).\n",
+                  (unsigned)sys_clock_freq());
             return -1;
         }
     }

--- a/cpu/native/periph/uart.c
+++ b/cpu/native/periph/uart.c
@@ -164,14 +164,14 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 {
     DEBUG("writing to serial port ");
 
-#if ENABLE_DEBUG
-    for (size_t i = 0; i < len; i++) {
-        DEBUG("%02x ", (unsigned char) data[i]);
+    if (ENABLE_DEBUG) {
+        for (size_t i = 0; i < len; i++) {
+            DEBUG("%02x ", (unsigned char) data[i]);
+        }
+        for (size_t i = 0; i < len; i++) {
+            DEBUG("%c", (char) data[i]);
+        }
     }
-    for (size_t i = 0; i < len; i++) {
-        DEBUG("%c", (char) data[i]);
-    }
-#endif
 
     DEBUG("\n");
 

--- a/drivers/kw2xrf/kw2xrf_spi.c
+++ b/drivers/kw2xrf/kw2xrf_spi.c
@@ -70,8 +70,8 @@ int kw2xrf_spi_init(kw2xrf_t *dev)
 #endif
 
     if (res != SPI_OK) {
-        LOG_ERROR("[kw2xrf_spi] failed to init SPI_%i device (code %i)\n",
-                  SPIDEV, res);
+        LOG_ERROR("[kw2xrf_spi] failed to init SPI_%u device (code %i)\n",
+                  (unsigned)SPIDEV, res);
         return 1;
     }
     /* verify SPI params */
@@ -90,8 +90,8 @@ int kw2xrf_spi_init(kw2xrf_t *dev)
     }
     spi_release(SPIDEV);
 
-    DEBUG("[kw2xrf_spi] SPI_DEV(%i) initialized: mode: %i, clk: %i, cs_pin: %i\n",
-          SPIDEV, SPIMODE, SPICLK, CSPIN);
+    DEBUG("[kw2xrf_spi] SPI_DEV(%u) initialized: mode: %u, clk: %u, cs_pin: %u\n",
+          (unsigned)SPIDEV, (unsigned)SPIMODE, (unsigned)SPICLK, (unsigned)CSPIN);
     return 0;
 }
 

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -689,16 +689,16 @@ static int xbee_recv(netdev_t *dev, void *buf, size_t len, void *info)
     size = (size_t)(xbee->rx_limit - 1);
     if (buf == NULL) {
         if (len > 0) {
-            DEBUG("[xbee] recv: reading size and dropping: %i\n", size);
+            DEBUG("[xbee] recv: reading size and dropping: %u\n", (unsigned)size);
             xbee->rx_count = 0;
         }
         else {
-            DEBUG("[xbee] recv: reading size without dropping: %i\n", size);
+            DEBUG("[xbee] recv: reading size without dropping: %u\n", (unsigned)size);
         }
     }
     else {
         size = (size > len) ? len : size;
-        DEBUG("[xbee] recv: consuming packet: reading %i byte\n", size);
+        DEBUG("[xbee] recv: consuming packet: reading %u byte\n", (unsigned)size);
         memcpy(buf, xbee->rx_buf, size);
         xbee->rx_count = 0;
     }

--- a/pkg/littlefs/fs/littlefs_fs.c
+++ b/pkg/littlefs/fs/littlefs_fs.c
@@ -222,7 +222,7 @@ static int _mkdir(vfs_mount_t *mountp, const char *name, mode_t mode)
     mutex_lock(&fs->lock);
 
     DEBUG("littlefs: mkdir: mountp=%p, name=%s, mode=%" PRIu32 "\n",
-          (void *)mountp, name, mode);
+          (void *)mountp, name, (uint32_t)mode);
 
     int ret = lfs_mkdir(&fs->fs, name);
     mutex_unlock(&fs->lock);

--- a/sys/can/conn/raw.c
+++ b/sys/can/conn/raw.c
@@ -72,10 +72,10 @@ int conn_can_raw_set_filter(conn_can_raw_t *conn, struct can_filter *filter, siz
     assert(conn != NULL);
     assert(filter != NULL || count == 0);
 
-    DEBUG("conn_can_raw_set_filter: conn=%p, filter=%p, count=%d\n",
-          (void *)conn, (void *)filter, count);
-    DEBUG("conn_can_raw_set_filter: conn->filter=%p, conn->count=%d\n",
-          (void *)conn->filter, conn->count);
+    DEBUG("conn_can_raw_set_filter: conn=%p, filter=%p, count=%u\n",
+          (void *)conn, (void *)filter, (unsigned)count);
+    DEBUG("conn_can_raw_set_filter: conn->filter=%p, conn->count=%u\n",
+          (void *)conn->filter, (unsigned)conn->count);
 
     /* unset previous filters */
     if (conn->count) {

--- a/sys/can/isotp/isotp.c
+++ b/sys/can/isotp/isotp.c
@@ -509,7 +509,7 @@ static void _isotp_fill_dataframe(struct isotp *isotp, struct can_frame *frame, 
     frame->can_id = isotp->opt.tx_id;
     frame->can_dlc = num_bytes + pci_len;
 
-    DEBUG("_isotp_fill_dataframe: num_bytes=%d, pci_len=%d\n", num_bytes, pci_len);
+    DEBUG("_isotp_fill_dataframe: num_bytes=%d, pci_len=%d\n", (unsigned)num_bytes, (unsigned)pci_len);
 
     if (num_bytes < space) {
         if (isotp->opt.flags & CAN_ISOTP_TX_PADDING) {

--- a/sys/cbor/cbor.c
+++ b/sys/cbor/cbor.c
@@ -960,7 +960,7 @@ static size_t cbor_stream_decode_at(cbor_stream_t *stream, size_t offset, int in
                 offset += inner_read_bytes = cbor_stream_decode_at(stream, offset, indent + 2);
 
                 if (inner_read_bytes == 0) {
-                    DEBUG("Failed to read array item at position %d\n", i);
+                    DEBUG("Failed to read array item at position %u\n", (unsigned)i);
                     break;
                 }
 
@@ -994,7 +994,7 @@ static size_t cbor_stream_decode_at(cbor_stream_t *stream, size_t offset, int in
                 offset += value_read_bytes = cbor_stream_decode_at(stream, offset, indent + 2); /* value */
 
                 if (key_read_bytes == 0 || value_read_bytes == 0) {
-                    DEBUG("Failed to read key-value pair at position %d\n", i);
+                    DEBUG("Failed to read key-value pair at position %u\n", (unsigned)i);
                     break;
                 }
 
@@ -1073,7 +1073,7 @@ void cbor_stream_decode(cbor_stream_t *stream)
         size_t read_bytes = cbor_stream_decode_at(stream, offset, 0);
 
         if (read_bytes == 0) {
-            DEBUG("Failed to read from stream at offset %d, start byte 0x%02X\n", offset, stream->data[offset]);
+            DEBUG("Failed to read from stream at offset %u, start byte 0x%02X\n", (unsigned)offset, stream->data[offset]);
             cbor_stream_print(stream);
             return;
         }

--- a/sys/fs/constfs/constfs.c
+++ b/sys/fs/constfs/constfs.c
@@ -241,7 +241,7 @@ static ssize_t constfs_read(vfs_file_t *filp, void *dest, size_t nbytes)
         nbytes = fp->size - filp->pos;
     }
     memcpy(dest, fp->data + filp->pos, nbytes);
-    DEBUG("constfs_read: read %d bytes\n", nbytes);
+    DEBUG("constfs_read: read %lu bytes\n", (long unsigned)nbytes);
     filp->pos += nbytes;
     return nbytes;
 }

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -131,7 +131,7 @@ static void _listen(sock_udp_t *sock)
 
     res = coap_parse(&pdu, buf, res);
     if (res < 0) {
-        DEBUG("gcoap: parse failure: %d\n", res);
+        DEBUG("gcoap: parse failure: %d\n", (int)res);
         /* If a response, can't clear memo, but it will timeout later. */
         return;
     }
@@ -723,7 +723,7 @@ size_t gcoap_req_send2(const uint8_t *buf, size_t len,
         }
         else if (!res) {
             memo->state = GCOAP_MEMO_UNUSED;
-            DEBUG("gcoap: sock send failed: %d\n", res);
+            DEBUG("gcoap: sock send failed: %d\n", (int)res);
         }
         return res;
     } else {

--- a/sys/net/gnrc/link_layer/gnrc_mac/internal.c
+++ b/sys/net/gnrc/link_layer/gnrc_mac/internal.c
@@ -229,7 +229,7 @@ bool gnrc_mac_queue_rx_packet(gnrc_mac_rx_t *rx, uint32_t priority, gnrc_pktsnip
         return true;
     }
 
-    DEBUG("[gnrc_mac] Can't push RX packet @ %p, no entries left\n", pkt);
+    DEBUG("[gnrc_mac] Can't push RX packet @ %p, no entries left\n", (void*)pkt);
     return false;
 }
 #endif /* GNRC_MAC_RX_QUEUE_SIZE != 0 */
@@ -268,7 +268,7 @@ void gnrc_mac_dispatch(gnrc_mac_rx_t *rx)
             if (!gnrc_netapi_dispatch_receive(rx->dispatch_buffer[i]->type,
                                               GNRC_NETREG_DEMUX_CTX_ALL,
                                               rx->dispatch_buffer[i])) {
-                DEBUG("Unable to forward packet of type %i\n", buffer[i]->type);
+                DEBUG("Unable to forward packet of type %i\n", rx->dispatch_buffer[i]->type);
                 gnrc_pktbuf_release(rx->dispatch_buffer[i]);
             }
             rx->dispatch_buffer[i] = NULL;

--- a/sys/net/gnrc/link_layer/lwmac/timeout.c
+++ b/sys/net/gnrc/link_layer/lwmac/timeout.c
@@ -26,8 +26,7 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#if ENABLE_DEBUG
-char *lwmac_timeout_names[] = {
+static const char *lwmac_timeout_names[] = {
     [GNRC_LWMAC_TIMEOUT_DISABLED]              = "DISABLED",
     [GNRC_LWMAC_TIMEOUT_WR]                    = "WR",
     [GNRC_LWMAC_TIMEOUT_NO_RESPONSE]           = "NO_RESPONSE",
@@ -35,7 +34,6 @@ char *lwmac_timeout_names[] = {
     [GNRC_LWMAC_TIMEOUT_WAIT_DEST_WAKEUP]      = "WAIT_FOR_DEST_WAKEUP",
     [GNRC_LWMAC_TIMEOUT_WAKEUP_PERIOD]         = "WAKEUP_PERIOD",
 };
-#endif
 
 static inline void _lwmac_clear_timeout(gnrc_lwmac_timeout_t *timeout)
 {

--- a/sys/net/gnrc/netapi/gnrc_netapi.c
+++ b/sys/net/gnrc/netapi/gnrc_netapi.c
@@ -85,7 +85,7 @@ static inline int _snd_rcv_mbox(mbox_t *mbox, uint16_t type, gnrc_pktsnip_t *pkt
     /* send message */
     int ret = mbox_try_put(mbox, &msg);
     if (ret < 1) {
-        DEBUG("gnrc_netapi: dropped message to %p (was full)\n", mbox);
+        DEBUG("gnrc_netapi: dropped message to %p (was full)\n", (void*)mbox);
     }
     return ret;
 }

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -59,9 +59,7 @@ static fib_entry_t _fib_entries[GNRC_IPV6_FIB_TABLE_SIZE];
 fib_table_t gnrc_ipv6_fib_table;
 #endif
 
-#if ENABLE_DEBUG
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
-#endif
 
 kernel_pid_t gnrc_ipv6_pid = KERNEL_PID_UNDEF;
 

--- a/sys/net/gnrc/network_layer/ipv6/hdr/gnrc_ipv6_hdr.c
+++ b/sys/net/gnrc/network_layer/ipv6/hdr/gnrc_ipv6_hdr.c
@@ -21,7 +21,7 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#if ENABLE_DEBUG && defined(MODULE_IPV6_ADDR)
+#if defined(MODULE_IPV6_ADDR)
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 #endif
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -24,9 +24,8 @@
 #include "debug.h"
 
 #if GNRC_IPV6_NIB_CONF_6LN
-#if ENABLE_DEBUG
+
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
-#endif
 
 extern void _handle_search_rtr(gnrc_netif_t *netif);
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.c
@@ -23,9 +23,8 @@
 #include "debug.h"
 
 #if GNRC_IPV6_NIB_CONF_6LR
-#if ENABLE_DEBUG
+
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
-#endif
 
 static uint8_t _update_nce_ar_state(const sixlowpan_nd_opt_ar_t *aro,
                                     _nib_onl_entry_t *nce)
@@ -38,12 +37,12 @@ static uint8_t _update_nce_ar_state(const sixlowpan_nd_opt_ar_t *aro,
         _set_ar_state(nce,
                       GNRC_IPV6_NIB_NC_INFO_AR_STATE_REGISTERED);
         DEBUG("nib: Successfully registered %s\n",
-              ipv6_addr_to_str(addr_str, &ipv6->src, sizeof(addr_str)));
+              ipv6_addr_to_str(addr_str, &nce->ipv6, sizeof(addr_str)));
         return SIXLOWPAN_ND_STATUS_SUCCESS;
     }
     else {
         DEBUG("nib: Could not register %s, neighbor cache was full\n",
-              ipv6_addr_to_str(addr_str, &ipv6->src, sizeof(addr_str)));
+              ipv6_addr_to_str(addr_str, &nce->ipv6, sizeof(addr_str)));
         return SIXLOWPAN_ND_STATUS_NC_FULL;
     }
 }

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -28,9 +28,7 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#if ENABLE_DEBUG
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
-#endif
 
 /**
  * @brief   Determines supposed link-layer address from interface and option

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -42,9 +42,7 @@ static _nib_dr_entry_t _def_routers[GNRC_IPV6_NIB_DEFAULT_ROUTER_NUMOF];
 static _nib_abr_entry_t _abrs[GNRC_IPV6_NIB_ABR_NUMOF];
 #endif  /* GNRC_IPV6_NIB_CONF_MULTIHOP_P6C */
 
-#if ENABLE_DEBUG
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
-#endif
 
 mutex_t _nib_mutex = MUTEX_INIT;
 evtimer_msg_t _nib_evtimer;

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -27,9 +27,7 @@
 #include "debug.h"
 
 #if GNRC_IPV6_NIB_CONF_ROUTER
-#if ENABLE_DEBUG
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
-#endif
 
 static void _snd_ra(gnrc_netif_t *netif, const ipv6_addr_t *dst,
                     bool final, _nib_abr_entry_t *abr);

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -39,9 +39,7 @@
 #include "xtimer.h"
 #endif
 
-#if ENABLE_DEBUG
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
-#endif
 
 #if GNRC_IPV6_NIB_CONF_QUEUE_PKT
 static gnrc_pktqueue_t _queue_pool[GNRC_IPV6_NIB_NUMOF];
@@ -418,8 +416,8 @@ static void _handle_rtr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
               netif->pid);
         DEBUG("     - IP Hop Limit: %u (should be 255)\n", ipv6->hl);
         DEBUG("     - ICMP code: %u (should be 0)\n", rtr_sol->code);
-        DEBUG("     - ICMP length: %u (should > %u)\n", icmpv6_len,
-              sizeof(ndp_rtr_sol_t));
+        DEBUG("     - ICMP length: %u (should > %u)\n", (unsigned)icmpv6_len,
+              (unsigned)sizeof(ndp_rtr_sol_t));
         return;
     }
     /* pre-check option length */
@@ -529,7 +527,7 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
         DEBUG("     - IP Hop Limit: %u (should be 255)\n", ipv6->hl);
         DEBUG("     - ICMP code: %u (should be 0)\n", rtr_adv->code);
         DEBUG("     - ICMP length: %u (should > %u)\n", (unsigned)icmpv6_len,
-              sizeof(ndp_rtr_adv_t));
+              (unsigned)sizeof(ndp_rtr_adv_t));
         DEBUG("     - Source address: %s (should be link-local)\n",
               ipv6_addr_to_str(addr_str, &ipv6->src, sizeof(addr_str)));
         DEBUG("     - Router lifetime: %u (should be <= 9000 on non-6LN)\n",
@@ -793,8 +791,8 @@ static void _handle_nbr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
         DEBUG("nib: Received neighbor solicitation is invalid. Discarding silently\n");
         DEBUG("     - IP Hop Limit: %u (should be 255)\n", ipv6->hl);
         DEBUG("     - ICMP code: %u (should be 0)\n", nbr_sol->code);
-        DEBUG("     - ICMP length: %u (should > %u)\n", icmpv6_len,
-              sizeof(ndp_nbr_sol_t));
+        DEBUG("     - ICMP length: %u (should > %u)\n", (unsigned)icmpv6_len,
+              (unsigned)sizeof(ndp_nbr_sol_t));
         DEBUG("     - Target address: %s (should not be multicast)\n",
               ipv6_addr_to_str(addr_str, &nbr_sol->tgt, sizeof(addr_str)));
         DEBUG("     - Source address: %s\n",
@@ -905,8 +903,8 @@ static void _handle_nbr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
         DEBUG("nib: Received neighbor advertisement is invalid. Discarding silently\n");
         DEBUG("     - IP Hop Limit: %u (should be 255)\n", ipv6->hl);
         DEBUG("     - ICMP code: %u (should be 0)\n", nbr_adv->code);
-        DEBUG("     - ICMP length: %u (should > %u)\n", icmpv6_len,
-              sizeof(ndp_nbr_adv_t));
+        DEBUG("     - ICMP length: %u (should > %u)\n", (unsigned)icmpv6_len,
+              (unsigned)sizeof(ndp_nbr_adv_t));
         DEBUG("     - Target address: %s (should not be multicast)\n",
               ipv6_addr_to_str(addr_str, &nbr_adv->tgt, sizeof(addr_str)));
         DEBUG("     - Destination address: %s\n",

--- a/sys/net/gnrc/network_layer/ipv6/whitelist/gnrc_ipv6_whitelist.c
+++ b/sys/net/gnrc/network_layer/ipv6/whitelist/gnrc_ipv6_whitelist.c
@@ -24,9 +24,7 @@
 ipv6_addr_t gnrc_ipv6_whitelist[GNRC_IPV6_WHITELIST_SIZE];
 BITFIELD(gnrc_ipv6_whitelist_set, GNRC_IPV6_WHITELIST_SIZE);
 
-#if ENABLE_DEBUG
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
-#endif
 
 int gnrc_ipv6_whitelist_add(const ipv6_addr_t *addr)
 {

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -26,9 +26,10 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#if ENABLE_DEBUG
+/* For PRIu8 etc. */
+#include <inttypes.h>
+
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
-#endif
 
 gnrc_pktsnip_t *gnrc_ndp_nbr_sol_build(const ipv6_addr_t *tgt,
                                        gnrc_pktsnip_t *options)

--- a/sys/net/gnrc/network_layer/sixlowpan/ctx/gnrc_sixlowpan_ctx.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/ctx/gnrc_sixlowpan_ctx.c
@@ -29,9 +29,7 @@ static mutex_t _ctx_mutex = MUTEX_INIT;
 static uint32_t _current_minute(void);
 static void _update_lifetime(uint8_t id);
 
-#if ENABLE_DEBUG
 static char ipv6str[IPV6_ADDR_MAX_STR_LEN];
-#endif
 
 static inline bool _valid(uint8_t id)
 {

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -225,7 +225,7 @@ void gnrc_sixlowpan_frag_send(gnrc_sixlowpan_msg_frag_t *fragment_msg)
     size_t payload_len = gnrc_pkt_len(fragment_msg->pkt->next);
     msg_t msg;
 
-#if defined(DEVELHELP) && defined(ENABLE_DEBUG)
+#if defined(DEVELHELP) && ENABLE_DEBUG
     if (iface == NULL) {
         DEBUG("6lo frag: iface == NULL, expect segmentation fault.\n");
         /* remove original packet from packet buffer */

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -46,9 +46,7 @@ static rbuf_int_t rbuf_int[RBUF_INT_SIZE];
 
 static rbuf_t rbuf[RBUF_SIZE];
 
-#if ENABLE_DEBUG
 static char l2addr_str[3 * RBUF_L2ADDR_MAX_LEN];
-#endif
 
 /* ------------------------------------
  * internal function definitions

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -279,7 +279,7 @@ static void _send(gnrc_pktsnip_t *pkt)
     }
     else if (datagram_size <= SIXLOWPAN_FRAG_MAX_LEN) {
         DEBUG("6lo: Send fragmented (%u > %" PRIu16 ")\n",
-              (unsigned int)datagram_size, iface->max_frag_size);
+              (unsigned int)datagram_size, iface->sixlo.max_frag_size);
         msg_t msg;
 
         fragment_msg.pid = hdr->if_pid;
@@ -302,7 +302,7 @@ static void _send(gnrc_pktsnip_t *pkt)
 #else
     (void) datagram_size;
     DEBUG("6lo: packet too big (%u > %" PRIu16 ")\n",
-          (unsigned int)datagram_size, iface->max_frag_size);
+          (unsigned int)datagram_size, iface->sixlo.max_frag_size);
     gnrc_pktbuf_release(pkt2);
 #endif
 }

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -42,9 +42,7 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#if ENABLE_DEBUG
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
-#endif
 
 #define GNRC_RPL_GROUNDED_SHIFT             (7)
 #define GNRC_RPL_MOP_SHIFT                  (3)
@@ -465,8 +463,8 @@ bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt_t *opt
                     first_target = target;
                 }
 
-                DEBUG("RPL: adding FT entry %s/%d 0x%" PRIx32 "\n",
-                      ipv6_addr_to_str(addr_str, &(target->target), sizeof(addr_str)),
+                DEBUG("RPL: adding FT entry %s/%d\n",
+                      ipv6_addr_to_str(addr_str, &(target->target), (unsigned)sizeof(addr_str)),
                       target->prefix_length);
 
                 gnrc_ipv6_nib_ft_add(&(target->target), target->prefix_length, src,

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -32,9 +32,7 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#if ENABLE_DEBUG
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
-#endif
 
 static gnrc_rpl_parent_t *_gnrc_rpl_find_preferred_parent(gnrc_rpl_dodag_t *dodag);
 

--- a/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
+++ b/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
@@ -20,9 +20,7 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#if ENABLE_DEBUG
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
-#endif
 
 #define GNRC_RPL_SRH_PADDING(X)     ((X & 0xF0) >> 4)
 #define GNRC_RPL_SRH_COMPRE(X)      (X & 0x0F)

--- a/sys/posix/pthread/pthread_barrier.c
+++ b/sys/posix/pthread/pthread_barrier.c
@@ -56,7 +56,7 @@ int pthread_barrier_wait(pthread_barrier_t *barrier)
 
     mutex_lock(&barrier->mutex);
     DEBUG("%s: hit a synchronization barrier. pid=%" PRIkernel_pid"\n",
-          sched_active_thread->name, sched_active_pid);
+          thread_getname(sched_active_pid), sched_active_pid);
 
     int switch_prio = -1;
 
@@ -64,7 +64,7 @@ int pthread_barrier_wait(pthread_barrier_t *barrier)
         /* need to wait for further threads */
 
         DEBUG("%s: waiting for %u threads. pid=%" PRIkernel_pid "\n",
-              sched_active_thread->name, barrier->count, sched_active_pid);
+              thread_getname(sched_active_pid), barrier->count, sched_active_pid);
 
         pthread_barrier_waiting_node_t node;
         node.pid = sched_active_pid;
@@ -90,7 +90,7 @@ int pthread_barrier_wait(pthread_barrier_t *barrier)
         /* all threads have arrived, wake everybody up */
 
         DEBUG("%s: waking every other thread up. pid=%" PRIkernel_pid "\n",
-              sched_active_thread->name, sched_active_pid);
+              thread_getname(sched_active_pid), sched_active_pid);
 
         int count = 1; /* Count number of woken up threads.
                         * The first thread is the current thread. */

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -736,7 +736,7 @@ int vfs_normalize_path(char *buf, const char *path, size_t buflen)
     }
 
     while(path <= path_end) {
-        DEBUG("vfs_normalize_path: + %d \"%.*s\" <- \"%s\" (%p)\n", npathcomp, len, buf, path, path);
+        DEBUG("vfs_normalize_path: + %d \"%.*s\" <- \"%s\" (%p)\n", npathcomp, (int)len, buf, path, path);
         if (path[0] == '\0') {
             break;
         }


### PR DESCRIPTION
This PR changes `DEBUG` to be enclosed in `if (ENABLE_DEBUG)` instead of being wiped by the preprocessor if unused. That way, all debug code is always compile-checked. With any optimization enabled, the code will still be eliminated if dead.
