### PR TITLE
gnrc_ipv6_netif: remove existing interfaces on INIT

### DIFF
--- a/tests/unittests/tests-ipv6_nc/tests-ipv6_nc.c
+++ b/tests/unittests/tests-ipv6_nc/tests-ipv6_nc.c
@@ -59,6 +59,7 @@ static void tear_down(void)
     /* remove all ncache entries, this is necesaary in case
      * the last test initializes timers. */
     gnrc_ipv6_nc_init();
+    gnrc_ipv6_netif_init();
 }
 
 static void test_ipv6_nc_add__address_registered(void)


### PR DESCRIPTION
In the unittests, interfaces will not be properly cleaned up. This **could** lead to the behaviour that we encounter in #5040.

This PR removes all existing interfaces on initialization. Then I call init in the tear down of all unittests in the ipv6_nc test.