### PR TITLE
Makefile.include: use defined application directory

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -250,7 +250,7 @@ all: ..in-docker-container
 else
 ## make script for your application. Build RIOT-base here!
 all: ..compiler-check ..build-message $(USEPKG:%=${BINDIR}%.a) $(APPDEPS)
-	$(AD)DIRS="$(DIRS)" "$(MAKE)" -C $(CURDIR) -f $(RIOTBASE)/Makefile.application
+	$(AD)DIRS="$(DIRS)" "$(MAKE)" -C $(APPDIR) -f $(RIOTBASE)/Makefile.application
 ifeq (,$(RIOTNOLINK))
 ifeq ($(BUILDOSXNATIVE),1)
 	$(AD)$(if $(CPPMIX),$(CXX),$(LINK)) $(UNDEF) -o $(ELFFILE) $$(find $(BASELIBS) -size +8c) $(LINKFLAGS) $(LINKFLAGPREFIX)-no_pie


### PR DESCRIPTION
Instead of looking in the current directory for the application source
files, look into the defined APPDIR directory.
This makes it possible to place your application Makefile in a different directory if you define 
```
APPDIR ?= path/to/app
```
inside it.