### PR TITLE
cpu: cortex_common: Add entry point in ldscript to tell gdb where to start

### DIFF
--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -31,6 +31,9 @@ OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
 OUTPUT_ARCH(arm)
 SEARCH_DIR(.)
 
+/* This is only used by gdb to understand where to start */
+ENTRY(reset_handler_default)
+
 /* Section Definitions */
 SECTIONS
 {


### PR DESCRIPTION
When using gdb + openocd to load and debug a firmware, gdb sometimes did not know where to start the program as there are no ENTRY point in the ldscripts. This leads to random code execution (only when using openocd + gdb load).

With this ENTRY gdb can now understand where exactly to start. This has no effect on the program itself. 

The same procedure should probably also be added to other architectures, but I don't have a lot of hardware to test the result. 