### PR TITLE
net: introduce netstats

### DIFF
--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -199,6 +199,14 @@ typedef enum {
      */
     NETOPT_CCA_THRESHOLD,
 
+    /**
+     * @brief get statistics about sent and received packets and data of the device or protocol
+     *
+     * Expects a pointer to a @ref netstats_t struct that will be pointed to
+     * the corresponding @ref netstats_t of the module.
+     */
+    NETOPT_STATS,
+
     /* add more options if needed */
 
     /**

--- a/sys/include/net/netstats.h
+++ b/sys/include/net/netstats.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016 INRIA
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_netstats Packet statistics per module
+ * @ingroup     net
+ * @brief       Each module may store information about sent and received packets
+ * @{
+ *
+ * @file
+ * @brief       Definition of net statistics
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ */
+
+#ifndef NETSTATS_H
+#define NETSTATS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief       Global statistics struct
+ */
+typedef struct {
+    uint32_t tx_unicast_count;  /**< packets sent via unicast */
+    uint32_t tx_mcast_count;    /**< packets sent via multicast
+                                     (including broadcast) */
+    uint32_t tx_success;        /**< successful sending operations
+                                     (either acknowledged or unconfirmed
+                                     sending operation, e.g. multicast) */
+    uint32_t tx_failed;         /**< failed sending operations */
+    uint32_t tx_bytes;          /**< sent bytes */
+    uint32_t rx_count;          /**< received (data) packets */
+    uint32_t rx_bytes;          /**< received bytes */
+} netstats_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NETSTATS_H */
+/** @} */

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -52,6 +52,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_DEVICE_TYPE]     = "NETOPT_DEVICE_TYPE",
     [NETOPT_CHANNEL_PAGE]    = "NETOPT_CHANNEL_PAGE",
     [NETOPT_CCA_THRESHOLD]   = "NETOPT_CCA_THRESHOLD",
+    [NETOPT_STATS]           = "NETOPT_STATS",
     [NETOPT_NUMOF]           = "NETOPT_NUMOF",
 };
 


### PR DESCRIPTION
This is extracted from #4801 and introduces only the netstats struct and the corresponding netoption.