### PR TITLE
netdev2: moved ethernet header into subdir

### DIFF
--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -50,7 +50,7 @@
 
 #include "net/eui64.h"
 #include "net/netdev2.h"
-#include "net/netdev2_eth.h"
+#include "net/netdev2/eth.h"
 #include "net/ethernet.h"
 #include "net/ethernet/hdr.h"
 #include "netdev2_tap.h"

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -24,7 +24,7 @@
 #include "xtimer.h"
 #include "assert.h"
 #include "net/ethernet.h"
-#include "net/netdev2_eth.h"
+#include "net/netdev2/eth.h"
 
 #include "enc28j60.h"
 #include "enc28j60_regs.h"

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -29,7 +29,7 @@
 #include "xtimer.h"
 
 #include "net/netdev2.h"
-#include "net/netdev2_eth.h"
+#include "net/netdev2/eth.h"
 #include "net/eui64.h"
 #include "net/ethernet.h"
 //#include "net/ethernet/hdr.h"

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -28,7 +28,7 @@
 #include "tsrb.h"
 
 #include "net/netdev2.h"
-#include "net/netdev2_eth.h"
+#include "net/netdev2/eth.h"
 #include "net/eui64.h"
 #include "net/ethernet.h"
 

--- a/drivers/include/net/netdev2/eth.h
+++ b/drivers/include/net/netdev2/eth.h
@@ -21,7 +21,7 @@
 
 #include <stdint.h>
 
-#include "netdev2.h"
+#include "net/netdev2.h"
 #include "net/netopt.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
For consistency with the ieee802154 header.