### PR TITLE
gnrc ipv6: replace check by assert

### DIFF
--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -14,7 +14,10 @@
  * The IPv6 control thread understands messages of type
  *
  *  * @ref GNRC_NETAPI_MSG_TYPE_RCV, and
- *  * @ref GNRC_NETAPI_MSG_TYPE_SND,
+ *  * @ref GNRC_NETAPI_MSG_TYPE_SND.
+ *
+ * If the message is of type @ref GNRC_NETAPI_MSG_TYPE_RCV the provided @ref
+ * gnrc_pktsnip_t must contain a snip of type @ref GNRC_NETTYPE_NETIF.
  *
  * @{
  *

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -764,9 +764,8 @@ static void _receive(gnrc_pktsnip_t *pkt)
 
     netif = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
 
-    if (netif != NULL) {
-        iface = ((gnrc_netif_hdr_t *)netif->data)->if_pid;
-    }
+    assert(netif);
+    iface = ((gnrc_netif_hdr_t *)netif->data)->if_pid;
 
     first_ext = pkt;
 


### PR DESCRIPTION
The existence of netif is mandatory here.

IMO this check doesn't make sense because https://github.com/RIOT-OS/RIOT/blob/master/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c#L855 requires `iface` to be set. @authmillenon, can you verify?