### PR TITLE
cc110x: cc110x generates IID from CPUID, not from hardware address

### DIFF
--- a/drivers/cc110x/cc110x-netdev2.c
+++ b/drivers/cc110x/cc110x-netdev2.c
@@ -70,30 +70,18 @@ static int _recv(netdev2_t *dev, char* buf, int len, void *info)
 
 static inline int _get_iid(netdev2_t *netdev, eui64_t *value, size_t max_len)
 {
+    cc110x_t *cc110x = &((netdev2_cc110x_t*) dev)->cc110x;
+    uint8_t *eui64 = (uint8_t*) value;
+
     if (max_len < sizeof(eui64_t)) {
         return -EOVERFLOW;
     }
 
-    uint8_t *eui64 = (uint8_t*) value;
-#ifdef CPUID_LEN
-    int n = (CPUID_LEN < sizeof(eui64_t))
-        ? CPUID_LEN
-        : sizeof(eui64_t);
-
-    char cpuid[CPUID_LEN];
-    cpuid_get(cpuid);
-
-    memcpy(eui64 + 8 - n, cpuid, n);
-
-#else
-    for (int i = 0; i < 8; i++) {
-        eui64[i] = i;
-    }
-#endif
-
-    /* make sure we mark the address as non-multicast and not globally unique */
-    eui64[0] &= ~(0x01);
-    eui64[0] |= 0x02;
+    /* make address compatible to https://tools.ietf.org/html/rfc6282#section-3.2.2*/
+    memset(eui64, 0, sizeof(eui64_t));
+    eui64[3] = 0xff;
+    eui64[4] = 0xfe;
+    eui64[7] = cc110x->radio_address;
 
     return sizeof(eui64_t);
 }

--- a/drivers/cc110x/cc110x.c
+++ b/drivers/cc110x/cc110x.c
@@ -88,10 +88,13 @@ int cc110x_setup(cc110x_t *dev, const cc110x_params_t *params)
 
     /* set default node id */
 #ifdef CPUID_LEN
-    if (CPUID_LEN>0) {
+    if (CPUID_LEN > 0) {
         char cpuid[CPUID_LEN];
         cpuid_get(cpuid);
-        cc110x_set_address(dev, (uint8_t) cpuid[CPUID_LEN-1]);
+        for (int i = 1; i < CPUID_LEN; i++) {
+            cpuid[0] ^= cpuid[i]
+        }
+        cc110x_set_address(dev, (uint8_t) cpuid[0]);
     }
 #endif
 


### PR DESCRIPTION
Fixes #4375 and #4998 and makes cc110x more similar to 2-bit address mode of IEEE 802.15.4 (which means better compression with 6LoWPAN). Cases of duplicate addresses can be fixed in a seperate issue by fixing #208 / #3052