### PR TITLE
msp430: no optimization fix

### DIFF
--- a/cpu/cc430/cc430-adc.c
+++ b/cpu/cc430/cc430-adc.c
@@ -110,7 +110,8 @@ uint16_t adc12_single_conversion(uint16_t ref, uint16_t sht, uint16_t channel)
  * @param       none
  * @return      none
  *************************************************************************************************/
-interrupt(ADC12_VECTOR) __attribute__((naked)) adc_isr(void)
+interrupt(ADC12_VECTOR) __attribute__((naked, optimize("omit-frame-pointer"),
+                                       no_instrument_function)) adc_isr(void)
 {
     __enter_isr();
 

--- a/cpu/cc430/cc430-gpioint.c
+++ b/cpu/cc430/cc430-gpioint.c
@@ -143,7 +143,7 @@ bool gpioint_set(int port, uint32_t bitmask, int flags, fp_irqcb callback)
     return 1;
 }
 
-interrupt(PORT1_VECTOR) __attribute__((naked)) port1_isr(void)
+interrupt(PORT1_VECTOR) port1_isr(void)
 {
     uint8_t int_enable, ifg_num, p1ifg;
     uint16_t p1iv;
@@ -188,7 +188,7 @@ interrupt(PORT1_VECTOR) __attribute__((naked)) port1_isr(void)
     __exit_isr();
 }
 
-interrupt(PORT2_VECTOR) __attribute__((naked)) port2_isr(void)
+interrupt(PORT2_VECTOR) port2_isr(void)
 {
     uint8_t int_enable, ifg_num, p2ifg;
     uint16_t p2iv;

--- a/cpu/cc430/periph/rtc.c
+++ b/cpu/cc430/periph/rtc.c
@@ -182,7 +182,8 @@ void rtc_clear_alarm(void)
     RTCCTL0 &= ~RTCAIE;
 }
 
-interrupt(RTC_VECTOR) __attribute__((naked)) rtc_isr(void)
+interrupt(RTC_VECTOR) __attribute__((naked, optimize("omit-frame-pointer"),
+                                     no_instrument_function)) rtc_isr(void)
 {
     __enter_isr();
 

--- a/cpu/cc430/periph/timer.c
+++ b/cpu/cc430/periph/timer.c
@@ -125,7 +125,8 @@ void timer_irq_disable(tim_t dev)
     /* TODO: not supported, yet */
 }
 
-ISR(TIMER_ISR_CC0, isr_timer_a_cc0)
+void __attribute__((naked, optimize("omit-frame-pointer"), no_instrument_function,
+                    interrupt (TIMER_ISR_CC0))) isr_timer_a_cc0(void)
 {
     __enter_isr();
 
@@ -135,7 +136,8 @@ ISR(TIMER_ISR_CC0, isr_timer_a_cc0)
     __exit_isr();
 }
 
-ISR(TIMER_ISR_CCX, isr_timer_a_ccx_isr)
+void __attribute__((optimize("omit-frame-pointer"), no_instrument_function,
+                    interrupt (TIMER_ISR_CCX))) isr_timer_a_ccx_isr(void)
 {
     __enter_isr();
 

--- a/cpu/msp430-common/cpu.c
+++ b/cpu/msp430-common/cpu.c
@@ -18,7 +18,8 @@
  * for thread_yield_higher(), since we rely on the RETI instruction at the end
  * of its execution, in the inlined __restore_context() sub-function
  */
-__attribute__((naked)) void thread_yield_higher(void)
+__attribute__((naked, optimize("omit-frame-pointer"),
+               no_instrument_function)) void thread_yield_higher(void)
 {
     __asm__("push r2"); /* save SR */
     __disable_irq();

--- a/cpu/msp430fxyz/periph/gpio.c
+++ b/cpu/msp430fxyz/periph/gpio.c
@@ -211,14 +211,16 @@ static inline void isr_handler(msp_port_isr_t *port, int ctx)
     }
 }
 
-ISR(PORT1_VECTOR, isr_port1)
+void __attribute__((naked, optimize("omit-frame-pointer"), no_instrument_function,
+                    interrupt (PORT1_VECTOR))) isr_port1(void)
 {
     __enter_isr();
     isr_handler((msp_port_isr_t *)PORT_1, 0);
     __exit_isr();
 }
 
-ISR(PORT2_VECTOR, isr_port2)
+void __attribute__((naked, optimize("omit-frame-pointer"), no_instrument_function,
+                    interrupt (PORT2_VECTOR))) isr_port2(void)
 {
     __enter_isr();
     isr_handler((msp_port_isr_t *)PORT_2, 8);

--- a/cpu/msp430fxyz/periph/timer.c
+++ b/cpu/msp430fxyz/periph/timer.c
@@ -125,7 +125,8 @@ void timer_irq_disable(tim_t dev)
     /* TODO: not supported, yet */
 }
 
-ISR(TIMER_ISR_CC0, isr_timer_a_cc0)
+void __attribute__((naked, optimize("omit-frame-pointer"), no_instrument_function,
+                    interrupt (TIMER_ISR_CC0))) isr_timer_a_cc0(void)
 {
     __enter_isr();
 
@@ -135,7 +136,8 @@ ISR(TIMER_ISR_CC0, isr_timer_a_cc0)
     __exit_isr();
 }
 
-ISR(TIMER_ISR_CCX, isr_timer_a_ccx)
+void __attribute__((optimize("omit-frame-pointer"), no_instrument_function,
+                    interrupt (TIMER_ISR_CCX))) isr_timer_a_ccx(void)
 {
     __enter_isr();
 

--- a/cpu/msp430fxyz/periph/uart.c
+++ b/cpu/msp430fxyz/periph/uart.c
@@ -109,7 +109,8 @@ void uart_poweroff(uart_t uart)
     UART_ME &= ~(UART_ME_BITS);
 }
 
-ISR(UART_RX_ISR, isr_uart_0_rx)
+void __attribute__((optimize("omit-frame-pointer"), no_instrument_function,
+                    interrupt (UART_RX_ISR))) isr_uart_0_rx(void)
 {
     __enter_isr();
 


### PR DESCRIPTION
addresses #4954, but does not fix it.
I modified all functions so that the compiler doesn't complain anymore.
However, if I flash the `telosb` board with the `default` example, then I can see RIOT's greeting, but it does not respond to my input. When I flash the `hello-world` example, then I get a boot-loop.

Necessary to test this PR: in `cpu/Makefile.include.msp430_common` change `CFLAGS_OPT` to `O0`.
