### PR TITLE
sys: net: crosslayer: fixed inet csum for 16bit platforms

### DIFF
--- a/sys/net/crosslayer/inet_csum/inet_csum.c
+++ b/sys/net/crosslayer/inet_csum/inet_csum.c
@@ -45,12 +45,12 @@ uint16_t inet_csum_slice(uint16_t sum, const uint8_t *buf, uint16_t len, size_t 
     }
 
     for (int i = 0; i < (len >> 1); buf += 2, i++) {
-        csum += (*buf << 8) + *(buf + 1);   /* group bytes by 16-byte words
-                                             * and add them*/
+        csum += (uint16_t)(*buf << 8) + *(buf + 1); /* group bytes by 16-byte words */
+                                                    /* and add them */
     }
 
-    if ((accum_len + len) & 1)      /* if accumulated length is odd */
-        csum += (*buf << 8);        /* add last byte as top half of 16-byte word */
+    if ((accum_len + len) & 1)          /* if accumulated length is odd */
+        csum += (uint16_t)(*buf << 8);  /* add last byte as top half of 16-byte word */
 
     while (csum >> 16) {
         uint16_t carry = csum >> 16;


### PR DESCRIPTION
Hello,

proposing inet_csum fix for 16bit platforms. 
wo explicit type conversion *buff << 8 is treated as signed (checked with gcc-msp430 and TI CGT)

wbr
malo