### PR TITLE
auto_init_slip: fix comparison between signed and unsigned

### DIFF
--- a/sys/auto_init/netif/auto_init_slip.c
+++ b/sys/auto_init/netif/auto_init_slip.c
@@ -47,7 +47,7 @@ static char _slip_stacks[SLIP_STACKSIZE][SLIP_NUM];
 
 void auto_init_slip(void)
 {
-    for (int i = 0; i < SLIP_NUM; i++) {
+    for (unsigned int i = 0; i < SLIP_NUM; i++) {
         const gnrc_slip_params_t *p = &gnrc_slip_params[i];
         DEBUG("Initializing SLIP radio at UART_%d\n", p->uart);
         kernel_pid_t res = gnrc_slip_init(&slip_devs[i], p->uart, p->baudrate,


### PR DESCRIPTION
https://ci.riot-labs.de/RIOT-OS/RIOT/4443/03899a57e920fed00b98ac0866f428243129b252/output.html
```
gnrc_border_router:native:
Building application "gnrc_border_router" for "native" with MCU "native".

/data/riotbuild/sys/auto_init/netif/auto_init_slip.c: In function 'auto_init_slip':
/data/riotbuild/sys/auto_init/netif/auto_init_slip.c:50:23: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
     for (int i = 0; i < SLIP_NUM; i++) {
                       ^
```