### PR TITLE
driver_pir: fix unused parameter

### DIFF
--- a/tests/driver_pir/main.c
+++ b/tests/driver_pir/main.c
@@ -33,6 +33,7 @@ static pir_t dev;
 
 void* pir_handler(void *arg)
 {
+    (void)arg;
     msg_t msg_q[1];
     msg_init_queue(msg_q, 1);
 


### PR DESCRIPTION
https://ci.riot-labs.de/RIOT-OS/RIOT/4443/03899a57e920fed00b98ac0866f428243129b252/output.html
```
driver_pir:native:
Building application "driver_pir" for "native" with MCU "native".

/data/riotbuild/tests/driver_pir/main.c: In function 'pir_handler':
/data/riotbuild/tests/driver_pir/main.c:34:25: error: unused parameter 'arg' [-Werror=unused-parameter]
 void* pir_handler(void *arg)
                         ^
```