### PR TITLE
core: thread_flags: optimize thread_flags_wait_one, fix doxygen

### DIFF
--- a/core/include/thread_flags.h
+++ b/core/include/thread_flags.h
@@ -124,7 +124,7 @@ thread_flags_t thread_flags_wait_all(thread_flags_t mask);
  * @brief Wait for any flags in mask to become set (blocking), one at a time
  *
  * This function is like thread_flags_wait_any(), but will only clear and return
- * one flag at a time, most significant set bit first.
+ * one flag at a time, least significant set bit first.
  *
  * @param[in]   mask    mask of flags to wait for
  *

--- a/core/thread_flags.c
+++ b/core/thread_flags.c
@@ -79,8 +79,10 @@ thread_flags_t thread_flags_wait_one(thread_flags_t mask)
 {
     _thread_flags_wait_any(mask);
     thread_t *me = (thread_t*) sched_active_thread;
-    unsigned tmp = me->flags & mask;
-    return _thread_flags_clear_atomic(me, thread_flags_clear(1 << bitarithm_lsb(tmp)));
+    thread_flags_t tmp = me->flags & mask;
+    /* clear all but least significant bit */
+    tmp &= (~tmp + 1);
+    return _thread_flags_clear_atomic(me, tmp);
 }
 
 thread_flags_t thread_flags_wait_all(thread_flags_t mask)

--- a/tests/thread_flags/main.c
+++ b/tests/thread_flags/main.c
@@ -41,6 +41,15 @@ static void *_thread(void *arg)
     flags = thread_flags_wait_all(0x2 | 0x4);
     printf("thread(): received flags: 0x%04x\n", (unsigned)flags & 0xFFFF);
 
+
+    printf("thread(): waiting for any flag, one by one\n");
+    flags = thread_flags_wait_one(0xFFFF);
+    printf("thread(): received flags: 0x%04x\n", (unsigned)flags & 0xFFFF);
+
+    printf("thread(): waiting for any flag, one by one\n");
+    flags = thread_flags_wait_one(0xFFFF);
+    printf("thread(): received flags: 0x%04x\n", (unsigned)flags & 0xFFFF);
+
     return NULL;
 }
 
@@ -66,6 +75,7 @@ int main(void)
     _set(thread, 0x1);
     _set(thread, 0x64);
     _set(thread, 0x1);
+    _set(thread, 0x8);
     _set(thread, 0x2);
     _set(thread, 0x4);
 


### PR DESCRIPTION
No need to call expensive bitarithm_lsb() for just keeping the most significant bit in thread_flags_wait_one(). Also fix doxygen explaining wrong order.