### PR TITLE
cbor: bounds checking on read and no_copy string deserialization 

### DIFF
--- a/sys/cbor/cbor.c
+++ b/sys/cbor/cbor.c
@@ -404,8 +404,9 @@ static size_t decode_bytes(const cbor_stream_t *s, size_t offset, char *out, siz
 }
 
 /* A zero copy version of decode_bytes.
-   Will not null termiante input, but tell you the size of what you read.
-   Great for reading byte strings which could contain nulls inside
+   Will not null termiante input, but will tell you the size of what you read.
+   Great for reading byte strings which could contain nulls inside of unknown size
+   without forced copies.
 */
 static size_t decode_bytes_no_copy(const cbor_stream_t *s, size_t offset, unsigned char **out, size_t *length)
 {
@@ -638,6 +639,11 @@ size_t cbor_deserialize_byte_string_no_copy(const cbor_stream_t *stream, size_t 
 size_t cbor_serialize_byte_string(cbor_stream_t *stream, const char *val)
 {
     return encode_bytes(CBOR_BYTES, stream, val, strlen(val));
+}
+
+size_t cbor_serialize_byte_stringl(cbor_stream_t *stream, const char *val, size_t length)
+{
+    return encode_bytes(CBOR_BYTES, stream, val, length);
 }
 
 size_t cbor_deserialize_unicode_string(const cbor_stream_t *stream, size_t offset, char *val,

--- a/sys/cbor/cbor.c
+++ b/sys/cbor/cbor.c
@@ -439,6 +439,10 @@ size_t cbor_deserialize_int(const cbor_stream_t *stream, size_t offset, int *val
     uint64_t buf;
     size_t read_bytes = decode_int(stream, offset, &buf);
 
+    if (!read_bytes) {
+        return 0;
+    }
+
     if (CBOR_TYPE(stream, offset) == CBOR_UINT) {
         *val = buf; /* resolve as CBOR_UINT */
     }

--- a/sys/include/cbor.h
+++ b/sys/include/cbor.h
@@ -397,7 +397,7 @@ size_t cbor_serialize_unicode_string(cbor_stream_t *stream, const char *val);
  * @param[in] stream The stream to deserialize
  * @param[in] offset The offset within the stream where to start deserializing
  * @param[out] val   Pointer to a char *
- * @param[out] length Pointer tp a size_t to store the size of the string
+ * @param[out] length Pointer to a size_t to store the size of the string
  *
  * @return Number of bytes written into @p val
  */

--- a/sys/include/cbor.h
+++ b/sys/include/cbor.h
@@ -365,6 +365,16 @@ size_t cbor_deserialize_double(const cbor_stream_t *stream, size_t offset,
  */
 size_t cbor_serialize_byte_string(cbor_stream_t *stream, const char *val);
 
+/**
+ * @brief Serializes an arbitrary byte string
+ *
+ * @param[out] stream   The destination stream for serializing the byte stream
+ * @param[in] val       The arbitrary byte string which may include null bytes
+ * @param[in] length    The size of the byte string in bytes
+ *
+ * @return Number of bytes written to stream @p stream
+ */
+size_t cbor_serialize_byte_stringl(cbor_stream_t *stream, const char *val, size_t length);
 
 /**
  * @brief Deserialize bytes from @p stream to @p val

--- a/sys/include/cbor.h
+++ b/sys/include/cbor.h
@@ -365,16 +365,6 @@ size_t cbor_deserialize_double(const cbor_stream_t *stream, size_t offset,
  */
 size_t cbor_serialize_byte_string(cbor_stream_t *stream, const char *val);
 
-/**
- * @brief Serializes an arbitrary byte string
- *
- * @param[out] stream   The destination stream for serializing the byte stream
- * @param[in] val       The arbitrary byte string which may include null bytes
- * @param[in] length    The size of the byte string in bytes
- *
- * @return Number of bytes written to stream @p stream
- */
-size_t cbor_serialize_byte_stringl(cbor_stream_t *stream, const char *val, size_t length);
 
 /**
  * @brief Deserialize bytes from @p stream to @p val
@@ -390,6 +380,22 @@ size_t cbor_deserialize_byte_string(const cbor_stream_t *stream, size_t offset,
                                     char *val, size_t length);
 
 size_t cbor_serialize_unicode_string(cbor_stream_t *stream, const char *val);
+
+/**
+ * @brief Deserialize bytes/unicode from @p stream to @p val (without copy)
+ *
+ * @param[in] stream The stream to deserialize
+ * @param[in] offset The offset within the stream where to start deserializing
+ * @param[out] val   Pointer to a char *
+ * @param[out] length Pointer tp a size_t to store the size of the string
+ *
+ * @return Number of bytes written into @p val
+ */
+size_t cbor_deserialize_byte_string_no_copy(const cbor_stream_t *stream, size_t offset,
+                                    unsigned char **val, size_t *length);
+
+size_t cbor_deserialize_unicode_string_no_copy(const cbor_stream_t *stream, size_t offset,
+                                    unsigned char **val, size_t *length);
 
 /**
  * @brief Deserialize unicode string from @p stream to @p val

--- a/tests/unittests/tests-cbor/tests-cbor.c
+++ b/tests/unittests/tests-cbor/tests-cbor.c
@@ -279,6 +279,39 @@ static void test_byte_string(void)
     }
 }
 
+static void test_byte_string_no_copy(void)
+{
+    char buffer[128];
+
+    {
+        const char *input = "";
+        unsigned char data[] = {0x40};
+        unsigned char *out;
+        size_t size;
+        TEST_ASSERT(cbor_serialize_byte_string(&stream, input));
+        CBOR_CHECK_SERIALIZED(stream, data, sizeof(data));
+        TEST_ASSERT(cbor_deserialize_byte_string_no_copy(&stream, 0, &out, &size));
+        memcpy(buffer, out, size);
+        buffer[size] = '\0';
+        CBOR_CHECK_DESERIALIZED(input, buffer, EQUAL_STRING);
+    }
+
+    cbor_clear(&stream);
+
+    {
+        const char *input = "a";
+        unsigned char data[] = {0x41, 0x61};
+        unsigned char *out;
+        size_t size;
+        TEST_ASSERT(cbor_serialize_byte_string(&stream, input));
+        CBOR_CHECK_SERIALIZED(stream, data, sizeof(data));
+        TEST_ASSERT(cbor_deserialize_byte_string_no_copy(&stream, 0, &out, &size));
+        memcpy(buffer, out, size);
+        buffer[size] = '\0';
+        CBOR_CHECK_DESERIALIZED(input, buffer, EQUAL_STRING);
+    }
+}
+
 static void test_byte_string_invalid(void)
 {
     {
@@ -314,6 +347,39 @@ static void test_unicode_string(void)
         TEST_ASSERT(cbor_serialize_unicode_string(&stream, input));
         CBOR_CHECK_SERIALIZED(stream, data, sizeof(data));
         TEST_ASSERT(cbor_deserialize_unicode_string(&stream, 0, buffer, sizeof(buffer)));
+        CBOR_CHECK_DESERIALIZED(input, buffer, EQUAL_STRING);
+    }
+}
+
+static void test_unicode_string_no_copy(void)
+{
+    char buffer[128];
+
+    {
+        const char *input = "";
+        unsigned char data[] = {0x60};
+        unsigned char *out;
+        size_t size;
+        TEST_ASSERT(cbor_serialize_unicode_string(&stream, input));
+        CBOR_CHECK_SERIALIZED(stream, data, sizeof(data));
+        TEST_ASSERT(cbor_deserialize_unicode_string_no_copy(&stream, 0, &out, &size));
+        memcpy(buffer, out, size);
+        buffer[size] = '\0';
+        CBOR_CHECK_DESERIALIZED(input, buffer, EQUAL_STRING);
+    }
+
+    cbor_clear(&stream);
+
+    {
+        const char *input = "a";
+        unsigned char data[] = {0x61, 0x61};
+        unsigned char *out;
+        size_t size;
+        TEST_ASSERT(cbor_serialize_unicode_string(&stream, input));
+        CBOR_CHECK_SERIALIZED(stream, data, sizeof(data));
+        TEST_ASSERT(cbor_deserialize_unicode_string_no_copy(&stream, 0, &out, &size));
+        memcpy(buffer, out, size);
+        buffer[size] = '\0';
         CBOR_CHECK_DESERIALIZED(input, buffer, EQUAL_STRING);
     }
 }
@@ -761,8 +827,10 @@ TestRef tests_cbor_all(void)
                         new_TestFixture(test_int64_t),
                         new_TestFixture(test_int64_t_invalid),
                         new_TestFixture(test_byte_string),
+                        new_TestFixture(test_byte_string_no_copy),
                         new_TestFixture(test_byte_string_invalid),
                         new_TestFixture(test_unicode_string),
+                        new_TestFixture(test_unicode_string_no_copy),
                         new_TestFixture(test_unicode_string_invalid),
                         new_TestFixture(test_array),
                         new_TestFixture(test_array_indefinite),


### PR DESCRIPTION
Since @luciotorre seems to be not working on #3843, I adopted parts of it. I refactored that commits and cut out the parts that I didn't understand or which seem unrelated.

@krf, can you take a brief look?
