### PR TITLE
sys/include: include stdint in uart_stdio.h

### DIFF
--- a/sys/include/uart_stdio.h
+++ b/sys/include/uart_stdio.h
@@ -21,6 +21,7 @@
 #define UART_STDIO_H
 
 /* Boards may override the default STDIO UART device */
+#include <stdint.h>
 #include "board.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
sys/include/uart_stdio.h uses uint8_t, but does not include stdint.h. For most boards this is not a problem, because stdint.h is included in the board.h or some higher level h file.