### PR TITLE
drivers: ethos: misc fixes

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -464,6 +464,7 @@ endif
 
 ifneq (,$(filter ethos,$(USEMODULE)))
     USEMODULE += netdev2_eth
+    USEMODULE += random
 endif
 
 ifneq (,$(filter random,$(USEMODULE)))

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -297,11 +297,12 @@ static int _recv(netdev2_t *netdev, char* buf, int len, void* info)
     ethos_t * dev = (ethos_t *) netdev;
 
     if (buf) {
-        if (len != dev->last_framesize) {
-            DEBUG("ethos _recv(): unmatched receive buffer size.");
+        if (len < dev->last_framesize) {
+            DEBUG("ethos _recv(): receive buffer too small.");
             return -1;
         }
 
+        len = dev->last_framesize;
         dev->last_framesize = 0;
 
         if ((tsrb_get(&dev->inbuf, buf, len) != len)) {


### PR DESCRIPTION
Two small ethos fixes:

- add previously missing "random" dependency
- allow "recv" to be called with a buffer larger than needed
