### PR TITLE
sys/newlib: Fix function definitions to match newlib prototypes

### DIFF
--- a/sys/newlib/syscalls.c
+++ b/sys/newlib/syscalls.c
@@ -22,6 +22,8 @@
  * @}
  */
 
+#include <unistd.h>
+#include <reent.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -158,9 +160,10 @@ int _kill_r(struct _reent *r, pid_t pid, int sig)
  *
  * @return      TODO
  */
-int _open_r(struct _reent *r, const char *name, int mode)
+int _open_r(struct _reent *r, const char *name, int flags, int mode)
 {
     (void) name;
+    (void) flags;
     (void) mode;
     r->_errno = ENODEV;                     /* not implemented yet */
     return -1;
@@ -272,7 +275,7 @@ int _fstat_r(struct _reent *r, int fd, struct stat *st)
  *
  * @return      TODO
  */
-int _stat_r(struct _reent *r, char *name, struct stat *st)
+int _stat_r(struct _reent *r, const char *name, struct stat *st)
 {
     (void) name;
     (void) st;
@@ -307,7 +310,7 @@ int _isatty_r(struct _reent *r, int fd)
  *
  * @return      TODO
  */
-int _unlink_r(struct _reent *r, char *path)
+int _unlink_r(struct _reent *r, const char *path)
 {
     (void) path;
     r->_errno = ENODEV;                     /* not implemented yet */


### PR DESCRIPTION
Last-minute bugfix

https://cygwin.com/git/gitweb.cgi?p=newlib-cygwin.git;a=blob;f=newlib/libc/include/reent.h;h=861be71d35326ba329ec479587b6df26a68e62b2;hb=HEAD#l151

http://linux.die.net/man/3/open