### PR TITLE
boards/telosb: changed default baudrate to 9600

### DIFF
--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -6,6 +6,7 @@ export CPU_MODEL = msp430f1611
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial-MXV*)))
 # setup serial terminal
+export BAUD ?= 9600
 include $(RIOTBOARD)/Makefile.include.serial
 
 # flash tool configuration

--- a/boards/telosb/include/board.h
+++ b/boards/telosb/include/board.h
@@ -42,6 +42,15 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Override default baudrate for STDIO
+ * @{
+ */
+#ifndef UART_STDIO_BAUDRATE
+#define UART_STDIO_BAUDRATE         (9600)
+#endif
+/** @} */
+
+/**
  * @brief   Xtimer configuration
  * @{
  */


### PR DESCRIPTION
supposedly fixes #4356

I don't have a board to test here, but I assume this should fix the issue of dropped characters on the `telosb`, as the main clock is currently configured with ~2MHz, and this is not enough to process UART interrupts at 115200baud...