### PR TITLE
fib: use return constants for `universal_address_compare()`

### DIFF
--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -132,8 +132,8 @@ static int fib_find_entry(fib_table_t *table, uint8_t *dst, size_t dst_size,
 
             int ret_comp = universal_address_compare(table->data.entries[i].global, dst, &match_size);
             /* If we found an exact match */
-            if ((ret_comp == UNIVERSAL_ADDRESS_EQUAL) 
-                || (is_all_zeros_addr && (match_size == 0) && (ret_comp == UNIVERSAL_ADDRESS_IS_ALL_ZERO_ADDRESS))) {
+            if ((ret_comp == UNIVERSAL_ADDRESS_EQUAL)
+                || (is_all_zeros_addr && (ret_comp == UNIVERSAL_ADDRESS_IS_ALL_ZERO_ADDRESS))) {
                 entry_arr[0] = &(table->data.entries[i]);
                 *entry_arr_size = 1;
                 /* we will not find a better one so we return */


### PR DESCRIPTION
change: Use the introduced return values in 38d5fc24768d6316732d7f5d713c3cb4fb58901f for `universal_address_compare()` across the fib.

fix: notifying routing protocols used the outdated former return value (was previously 1 for successful compare) to consider if the registered prefix of a routing protocol matches the given address.
If the protocol registered the unspecified address as prefix no notification took place since the return value is `UNIVERSAL_ADDRESS_IS_ALL_ZERO_ADDRESS` (2) now.