### PR TITLE
make: fix make output when QUIET=0

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -265,7 +265,7 @@ endif # BUILD_IN_DOCKER
 ..compiler-check:
 	@command -v $(CC) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \
-		'${COLOR_RED} Compiler $(CC) is required but not found in PATH.  Aborting.${COLOR_RESET}'; \
+		'${COLOR_RED}Compiler $(CC) is required but not found in PATH.  Aborting.${COLOR_RESET}'; \
 		exit 1; }
 
 ..build-message:
@@ -319,14 +319,14 @@ distclean:
 flash: all
 	@command -v $(FLASHER) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \
-		'${COLOR_RED} Flash program $(FLASHER) not found. Aborting.${COLOR_RESET}'; \
+		'${COLOR_RED}Flash program $(FLASHER) not found. Aborting.${COLOR_RESET}'; \
 		exit 1; }
 	$(FLASHER) $(FFLAGS)
 
 term: $(filter flash, $(MAKECMDGOALS))
 	@command -v $(TERMPROG) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \
-		'${COLOR_RED} Terminal program $(TERMPROG) not found. Aborting.${COLOR_RESET}'; \
+		'${COLOR_RED}Terminal program $(TERMPROG) not found. Aborting.${COLOR_RESET}'; \
 		exit 1; }
 	$(TERMPROG) $(TERMFLAGS)
 
@@ -339,21 +339,21 @@ doc:
 debug:
 	@command -v $(DEBUGGER) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \
-		'${COLOR_RED} Debug program $(DEBUGGER) not found. Aborting.${COLOR_RESET}'; \
+		'${COLOR_RED}Debug program $(DEBUGGER) not found. Aborting.${COLOR_RESET}'; \
 		exit 1; }
 	$(DEBUGGER) $(DEBUGGER_FLAGS)
 
 debug-server:
 	@command -v $(DEBUGSERVER) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \
-		'${COLOR_RED} Debug server program $(DEBUGSERVER) not found. Aborting.${COLOR_RESET}'; \
+		'${COLOR_RED}Debug server program $(DEBUGSERVER) not found. Aborting.${COLOR_RESET}'; \
 		exit 1; }
 	$(DEBUGSERVER) $(DEBUGSERVER_FLAGS)
 
 reset:
 	@command -v $(RESET) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \
-		'${COLOR_RED} Reset program $(RESET) not found. Aborting.${COLOR_RESET}'; \
+		'${COLOR_RED}Reset program $(RESET) not found. Aborting.${COLOR_RESET}'; \
 		exit 1; }
 	$(RESET) $(RESET_FLAGS)
 
@@ -363,7 +363,7 @@ OBJDUMPFLAGS ?= -S -D -h
 objdump:
 	@command -v $(OBJDUMP) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \
-		'${COLOR_RED} Objdump program $(OBJDUMP) not found. Aborting.${COLOR_RESET}'; \
+		'${COLOR_RED}Objdump program $(OBJDUMP) not found. Aborting.${COLOR_RESET}'; \
 		exit 1; }
 	$(OBJDUMP) $(OBJDUMPFLAGS) $(ELFFILE) | less
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -263,7 +263,7 @@ endif
 endif # BUILD_IN_DOCKER
 
 ..compiler-check:
-	$(AD)command -v $(CC) >/dev/null 2>&1 || \
+	@command -v $(CC) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \
 		'${COLOR_RED} Compiler $(CC) is required but not found in PATH.  Aborting.${COLOR_RESET}'; \
 		exit 1; }
@@ -317,14 +317,14 @@ distclean:
 	-@rm -rf $(BINDIRBASE)
 
 flash: all
-	$(AD)command -v $(FLASHER) >/dev/null 2>&1 || \
+	@command -v $(FLASHER) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \
 		'${COLOR_RED} Flash program $(FLASHER) not found. Aborting.${COLOR_RESET}'; \
 		exit 1; }
 	$(FLASHER) $(FFLAGS)
 
 term: $(filter flash, $(MAKECMDGOALS))
-	$(AD)command -v $(TERMPROG) >/dev/null 2>&1 || \
+	@command -v $(TERMPROG) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \
 		'${COLOR_RED} Terminal program $(TERMPROG) not found. Aborting.${COLOR_RESET}'; \
 		exit 1; }
@@ -337,21 +337,21 @@ doc:
 	make -BC $(RIOTBASE) doc
 
 debug:
-	$(AD)command -v $(DEBUGGER) >/dev/null 2>&1 || \
+	@command -v $(DEBUGGER) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \
 		'${COLOR_RED} Debug program $(DEBUGGER) not found. Aborting.${COLOR_RESET}'; \
 		exit 1; }
 	$(DEBUGGER) $(DEBUGGER_FLAGS)
 
 debug-server:
-	$(AD)command -v $(DEBUGSERVER) >/dev/null 2>&1 || \
+	@command -v $(DEBUGSERVER) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \
 		'${COLOR_RED} Debug server program $(DEBUGSERVER) not found. Aborting.${COLOR_RESET}'; \
 		exit 1; }
 	$(DEBUGSERVER) $(DEBUGSERVER_FLAGS)
 
 reset:
-	$(AD)command -v $(RESET) >/dev/null 2>&1 || \
+	@command -v $(RESET) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \
 		'${COLOR_RED} Reset program $(RESET) not found. Aborting.${COLOR_RESET}'; \
 		exit 1; }
@@ -361,7 +361,7 @@ reset:
 OBJDUMPFLAGS ?= -S -D -h
 
 objdump:
-	$(AD)command -v $(OBJDUMP) >/dev/null 2>&1 || \
+	@command -v $(OBJDUMP) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \
 		'${COLOR_RED} Objdump program $(OBJDUMP) not found. Aborting.${COLOR_RESET}'; \
 		exit 1; }


### PR DESCRIPTION
When running make with QUIET=0, some unnecessary and confusing output is given. This PR hides that output.