### PR TITLE
netdev ethernet: deal with too small packet buffer

### DIFF
--- a/cpu/native/include/cpu_conf.h
+++ b/cpu/native/include/cpu_conf.h
@@ -55,6 +55,11 @@ extern "C" {
  */
 #define NATIVE_ETH_PROTO 0x1234
 
+#if (defined(GNRC_PKTBUF_SIZE)) && (GNRC_PKTBUF_SIZE < 2048)
+#   undef  GNRC_PKTBUF_SIZE
+#   define GNRC_PKTBUF_SIZE     (2048)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/examples/gnrc_minimal/Makefile
+++ b/examples/gnrc_minimal/Makefile
@@ -21,15 +21,7 @@ USEMODULE += gnrc_icmpv6_echo
 # Use minimal standard PRNG
 USEMODULE += prng_minstd
 
-CFLAGS += -DGNRC_IPV6_NETIF_ADDR_NUMOF=4
-# Reduce sizes for GNRC's packet buffer and neighbor cache
-# (for native we need a bigger buffer, because the tap driver temporarily
-# allocates ~1500 bytes)
-ifneq (,$(filter native,$(BOARD)))
-    CFLAGS += -DGNRC_PKTBUF_SIZE=2048 -DGNRC_IPV6_NC_SIZE=1
-else
-    CFLAGS += -DGNRC_PKTBUF_SIZE=512 -DGNRC_IPV6_NC_SIZE=0
-endif
+CFLAGS += -DGNRC_PKTBUF_SIZE=512 -DGNRC_IPV6_NETIF_ADDR_NUMOF=4 -DGNRC_IPV6_NC_SIZE=1
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1


### PR DESCRIPTION
~~Rationale: some drivers, e.g. the Ethernet drivers, require a minimum size for the packet buffer. This commit introduces an optional minimal size that can be overwritten from the application.~~

~~I reworked this PR to introduce a temporary buffer inside the Ethernet drivers themselves, instead of reallocating on the packet buffer. IMO that's a cleaner solution as it reduces the lines of code and makes it simpler. It introduces more statically allocated memory, but this memory is necessary with the current implementation anyway (it just moves from pktbuf to the driver), but at least fails at build time if not available.~~

Let the native port check for a too small pktbuf size and adjust it.

Additionally this PR removes the (now not longer needed) hack from `gnrc_minimal_networking`'s Makefile and handle native the same as any other platform.

Without this PR the default example won't work on native (or other boards with an Ethernet device). Thanks for reporting, @LudwigKnuepfer.