### PR TITLE
boards/nucleo-f072: Use common serial and openocd defines

### DIFF
--- a/boards/nucleo-f072/Makefile.include
+++ b/boards/nucleo-f072/Makefile.include
@@ -2,14 +2,5 @@
 export CPU = stm32f0
 export CPU_MODEL = stm32f072rb
 
-#define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(shell ls -1 /dev/tty.usbmodem* | head -n 1)
-
-# setup serial terminal
-include $(RIOTBOARD)/Makefile.include.serial
-
-# this board uses openocd
-include $(RIOTBOARD)/Makefile.include.openocd
-
+# load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/nucleo-common/Makefile.include


### PR DESCRIPTION
to match other nucleo boards.
I don't have a board to test with. The OSX device name was different between the nucleo-common and the nucleo-f072 Makefiles, did anyone test a nucleo board connected to an OSX machine?