### PR TITLE
drivers/at86rf2xx: mask frame length according to data sheet

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -215,30 +215,3 @@ void at86rf2xx_tx_exec(at86rf2xx_t *dev)
         netdev->event_callback(netdev, NETDEV2_EVENT_TX_STARTED, NULL);
     }
 }
-
-size_t at86rf2xx_rx_len(at86rf2xx_t *dev)
-{
-    uint8_t phr;
-
-    at86rf2xx_fb_read(dev, &phr, 1);
-
-    /* ignore MSB (refer p.80) and substract length of FCS field */
-    return (size_t)((phr & 0x7f) - 2);
-}
-
-void at86rf2xx_rx_read(at86rf2xx_t *dev, uint8_t *data, size_t len,
-                       size_t offset)
-{
-    /* when reading from SRAM, the different chips from the AT86RF2xx family
-     * behave differently: the AT86F233, the AT86RF232 and the ATRF86212B return
-     * frame length field (PHR) at position 0 and the first data byte at
-     * position 1.
-     * The AT86RF231 does not return the PHR field and return
-     * the first data byte at position 0.
-     */
-#ifndef MODULE_AT86RF231
-    at86rf2xx_sram_read(dev, offset + 1, data, len);
-#else
-    at86rf2xx_sram_read(dev, offset, data, len);
-#endif
-}

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -140,8 +140,8 @@ static int _recv(netdev2_t *netdev, char *buf, int len, void *info)
     /* get the size of the received packet */
     at86rf2xx_fb_read(dev, &phr, 1);
 
-    /* Ignore FCS for packet length */
-    pkt_len = phr - 2;
+    /* ignore MSB (refer p.80) and substract length of FCS field */
+    pkt_len = (phr & 0x7f) - 2;
 
     /* just return length when buf == NULL */
     if (buf == NULL) {

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -450,26 +450,6 @@ size_t at86rf2xx_tx_load(at86rf2xx_t *dev, uint8_t *data, size_t len,
  */
 void at86rf2xx_tx_exec(at86rf2xx_t *dev);
 
-/**
- * @brief   Read the length of a received packet
- *
- * @param dev               device to read from
- *
- * @return                  overall length of a received packet in byte
- */
-size_t at86rf2xx_rx_len(at86rf2xx_t *dev);
-
-/**
- * @brief   Read a chunk of data from the receive buffer of the given device
- *
- * @param[in]  dev          device to read from
- * @param[out] data         buffer to write data to
- * @param[in]  len          number of bytes to read from device
- * @param[in]  offset       offset in the receive buffer
- */
-void at86rf2xx_rx_read(at86rf2xx_t *dev, uint8_t *data, size_t len,
-                       size_t offset);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
After some discussion on the devel mailing list about smuggeling in corrupted frames by e.g. SDRs I'd propose we mask the length field according to the datasheet again. It was done before in at86rf2xx_rx_length but this function did get unused anymore along the way. 

Full credit for this goes to @daniel-k BTW.

Additionally this PR removes two functions not used anymore.