### PR TITLE
netstats: several fixes

### DIFF
--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -296,7 +296,9 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, int n)
     }
     netdev->stats.tx_bytes += bytes;
 #endif
-    netdev->event_callback(netdev, NETDEV2_EVENT_TX_COMPLETE, NULL);
+    if (netdev->event_callback) {
+        netdev->event_callback(netdev, NETDEV2_EVENT_TX_COMPLETE, NULL);
+    }
     return res;
 }
 

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -230,6 +230,7 @@ static int nd_send(netdev2_t *netdev, const struct iovec *data, int count)
 #ifdef MODULE_NETSTATS_L2
     netdev->stats.tx_bytes += count;
 #endif
+
     /* set write pointer */
     cmd_w_addr(dev, ADDR_WRITE_PTR, BUF_TX_START);
     /* write control byte and the actual data into the buffer */
@@ -380,6 +381,9 @@ static int nd_init(netdev2_t *netdev)
     /* allow receiving bytes from now on */
     cmd_bfs(dev, REG_ECON1, -1, ECON1_RXEN);
 
+#ifdef MODULE_NETSTATS_L2
+    memset(&netdev->stats, 0, sizeof(netstats_t));
+#endif
     mutex_unlock(&dev->devlock);
     return 0;
 }
@@ -424,9 +428,6 @@ static void nd_isr(netdev2_t *netdev)
         }
         eir = cmd_rcr(dev, REG_EIR, -1);
     }
-#ifdef MODULE_NETSTATS_L2
-    memset(&netdev->stats, 0, sizeof(netstats_t));
-#endif
 }
 
 static int nd_get(netdev2_t *netdev, netopt_t opt, void *value, size_t max_len)


### PR DESCRIPTION
Apparently while merging #4801 some things slipped through:
* for netdev2_tap the existence of the callback was not checked before calling it for `TX_COMPLETE`
* for enc28j60 the initialization of the netstats struct was introduced in the isr function instead of the init function
* encx24j600 was completely missing the netstats