### PR TITLE
examples: default: don't shrink pktbuf on native

### DIFF
--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -53,8 +53,11 @@ ifneq (,$(filter $(BOARD),$(BOARD_PROVIDES_NETIF)))
   USEMODULE += gnrc_pktdump
 
   # We use only the lower layers of the GNRC network stack, hence, we can
-  # reduce the size of the packet buffer a bit
+  # reduce the size of the packet buffer a bit. Only native needs a little
+  # larger pktbuf.
+ifeq (,$(filter native,$(BOARD)))
   CFLAGS += -DGNRC_PKTBUF_SIZE=512
+endif
 endif
 
 FEATURES_OPTIONAL += config


### PR DESCRIPTION
native needs to allocate a full l2 packet.