### PR TITLE
driver: assure required buffer size

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -51,7 +51,12 @@ void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params)
 void at86rf2xx_reset(at86rf2xx_t *dev)
 {
 #if CPUID_LEN
+/* make sure that the buffer is always big enough to store a 64bit value */
+#   if CPUID_LEN < IEEE802154_LONG_ADDRESS_LEN
+    uint8_t cpuid[IEEE802154_LONG_ADDRESS_LEN];
+#   else
     uint8_t cpuid[CPUID_LEN];
+#endif
     eui64_t addr_long;
 #endif
 

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -395,7 +395,12 @@ int kw2xrf_init(kw2xrf_t *dev, spi_t spi, spi_speed_t spi_speed,
     uint8_t tmp[2];
     kw2xrf_gpio_int = int_pin;
 #if CPUID_LEN
+/* make sure that the buffer is always big enough to store a 64bit value */
+#   if CPUID_LEN < IEEE802154_LONG_ADDRESS_LEN
+    uint8_t cpuid[IEEE802154_LONG_ADDRESS_LEN];
+#   else
     uint8_t cpuid[CPUID_LEN];
+#endif
     eui64_t addr_long;
 #endif
 


### PR DESCRIPTION
The cpuid buffer is also used as a temporary buffer to store the EUI-64 of the transceiver, so we need to make sure that it is always big enough.
May be padded with zeroes for smaller CPUIDs.