### PR TITLE
drivers: si70xx: result bugfixes

### DIFF
--- a/drivers/si70xx/si70xx.c
+++ b/drivers/si70xx/si70xx.c
@@ -84,7 +84,7 @@ int si70xx_init(si70xx_t *dev, i2c_t i2c_dev, uint8_t address)
 uint16_t si70xx_get_relative_humidity(si70xx_t *dev)
 {
     uint32_t raw;
-    uint16_t humidity;
+    int32_t humidity;
 
     /* perform measurement */
     raw = si70xx_measure(dev, SI70XX_MEASURE_RH_HOLD);
@@ -99,7 +99,7 @@ uint16_t si70xx_get_relative_humidity(si70xx_t *dev)
         return 10000;
     }
     else {
-        return humidity;
+        return (uint16_t) humidity;
     }
 }
 
@@ -129,8 +129,8 @@ void si70xx_get_both(si70xx_t *dev, uint16_t *humidity, int16_t *temperature)
 uint64_t si70xx_get_serial(si70xx_t *dev)
 {
     uint8_t out[2];
-    uint8_t in_first[8];
-    uint8_t in_second[8];
+    uint8_t in_first[8] = { 0 };
+    uint8_t in_second[8] = { 0 };
 
     /* read the lower bytes */
     out[0] = SI70XX_READ_ID_FIRST_A;
@@ -165,7 +165,7 @@ uint8_t si70xx_get_id(si70xx_t *dev)
 uint8_t si70xx_get_revision(si70xx_t *dev)
 {
     uint8_t out[2];
-    uint8_t in;
+    uint8_t in = 0;
 
     /* read the revision number */
     out[0] = SI70XX_READ_REVISION_A;

--- a/tests/driver_si70xx/Makefile
+++ b/tests/driver_si70xx/Makefile
@@ -9,8 +9,8 @@ USEMODULE += xtimer
 
 # set default device parameters in case they are undefined
 TEST_I2C ?= 0
-TEST_I2C_ADDR ?= 128
-TEST_PIN_EN ?= 57
+TEST_I2C_ADDR ?= 0x80
+TEST_PIN_EN ?= GPIO_PIN\(0,0\)
 
 # export parameters
 CFLAGS += -DTEST_I2C=$(TEST_I2C)

--- a/tests/driver_si70xx/main.c
+++ b/tests/driver_si70xx/main.c
@@ -103,8 +103,8 @@ int main(void)
         both = !both;
 
         /* display results */
-        printf("relative humidity: %d.%d\n", humidity / 100, humidity % 100);
-        printf("temperature: %d.%d C\n", temperature / 100, temperature % 100);
+        printf("relative humidity: %d.%02d\n", humidity / 100, humidity % 100);
+        printf("temperature: %d.%02d C\n", temperature / 100, temperature % 100);
 
         /* sleep between measurements */
         xtimer_usleep(1000 * MS_IN_USEC);


### PR DESCRIPTION
While testing #5231, I found two bugs that I should have seen earlier.

* The calculations in `si70xx_get_relative_humidity` could wrap around, resulting in humidity 100% where it should be ~0%. ffe3fe3 fixes this.
* `si70xx_get_revision` and `si70xx_get_serial` start with tainted buffers. In case of I2C failures, I noticed that it still passed `si70xx_test` because of exactly the right values in the buffers (possibly uncleared RAM). By clearing them on beforehand, they should return an invalid revision number or serial number. 08e7e3c fixes this.

I also took the liberty of improving the test application.
