### PR TITLE
drivers 802154: use memset for eui64 padding

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -74,9 +74,7 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
 
 #if CPUID_LEN < IEEE802154_LONG_ADDRESS_LEN
     /* in case CPUID_LEN < 8, fill missing bytes with zeros */
-    for (int i = CPUID_LEN; i < IEEE802154_LONG_ADDRESS_LEN; i++) {
-        cpuid[i] = 0;
-    }
+    memset(&(cpuid[CPUID_LEN]), 0, (IEEE802154_LONG_ADDRESS_LEN - CPUID_LEN));
 #else
     for (int i = 8; i < CPUID_LEN; i++) {
         cpuid[i & 0x07] ^= cpuid[i];

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -70,16 +70,17 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     dev->netdev.flags = 0;
     /* set short and long address */
 #if CPUID_LEN
+    /* in case CPUID_LEN < 8, fill missing bytes with zeros */
+    memset(cpuid, 0, CPUID_LEN);
+
     cpuid_get(cpuid);
 
-#if CPUID_LEN < IEEE802154_LONG_ADDRESS_LEN
-    /* in case CPUID_LEN < 8, fill missing bytes with zeros */
-    memset(&(cpuid[CPUID_LEN]), 0, (IEEE802154_LONG_ADDRESS_LEN - CPUID_LEN));
-#else
-    for (int i = 8; i < CPUID_LEN; i++) {
+#if CPUID_LEN > IEEE802154_LONG_ADDRESS_LEN
+    for (int i = IEEE802154_LONG_ADDRESS_LEN; i < CPUID_LEN; i++) {
         cpuid[i & 0x07] ^= cpuid[i];
     }
 #endif
+
     /* make sure we mark the address as non-multicast and not globally unique */
     cpuid[0] &= ~(0x01);
     cpuid[0] |= 0x02;

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -430,15 +430,12 @@ int kw2xrf_init(kw2xrf_t *dev, spi_t spi, spi_speed_t spi_speed,
     dev->option = 0;
 
 #if CPUID_LEN
+    /* in case CPUID_LEN < 8, fill missing bytes with zeros */
+    memset(cpuid, 0, CPUID_LEN);
+
     cpuid_get(cpuid);
 
-#if CPUID_LEN < IEEE802154_LONG_ADDRESS_LEN
-
-    /* in case CPUID_LEN < 8, fill missing bytes with zeros */
-    memset(&(cpuid[CPUID_LEN]), 0, (IEEE802154_LONG_ADDRESS_LEN - CPUID_LEN));
-
-#else
-
+#if CPUID_LEN > IEEE802154_LONG_ADDRESS_LEN
     for (int i = IEEE802154_LONG_ADDRESS_LEN; i < CPUID_LEN; i++) {
         cpuid[i & 0x07] ^= cpuid[i];
     }

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -435,9 +435,7 @@ int kw2xrf_init(kw2xrf_t *dev, spi_t spi, spi_speed_t spi_speed,
 #if CPUID_LEN < IEEE802154_LONG_ADDRESS_LEN
 
     /* in case CPUID_LEN < 8, fill missing bytes with zeros */
-    for (int i = CPUID_LEN; i < IEEE802154_LONG_ADDRESS_LEN; i++) {
-        cpuid[i] = 0;
-    }
+    memset(&(cpuid[CPUID_LEN]), 0, (IEEE802154_LONG_ADDRESS_LEN - CPUID_LEN));
 
 #else
 


### PR DESCRIPTION
As proposed by @authmillenon in https://github.com/RIOT-OS/RIOT/pull/5239#discussion_r58342950.