### PR TITLE
tests: add compile test for netstats_l2

### DIFF
--- a/tests/netstats_l2/Makefile
+++ b/tests/netstats_l2/Makefile
@@ -1,0 +1,19 @@
+APPLICATION = netstats
+include ../Makefile.tests_common
+
+BOARD_PROVIDES_NETIF := airfy-beacon fox iotlab-m3 mulle native nrf51dongle \
+	nrf6310 pba-d-01-kw2x pca10000 pca10005 saml21-xpro samr21-xpro spark-core \
+	yunjia-nrf51822
+
+BOARDS ?= $(shell find $(RIOTBASE)/boards/* -maxdepth 0 -type d \! -name "*-common" -exec basename {} \;)
+
+BOARD_BLACKLIST := $(filter-out $(BOARD_PROVIDES_NETIF), $(BOARDS))
+
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += gnrc
+USEMODULE += gnrc_netdev_default
+USEMODULE += auto_init_gnrc_netif
+USEMODULE += netstats_l2
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/netstats_l2/README.md
+++ b/tests/netstats_l2/README.md
@@ -1,0 +1,3 @@
+This example is just required to check if the NETSTATS_L2 module builds
+correctly. You can use the `ifconfig` command to check the statistics of an
+interface.

--- a/tests/netstats_l2/main.c
+++ b/tests/netstats_l2/main.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016 INRIA
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Simple application to have a build test for the @ref NETSTATS_L2 pseudomodule
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+#include "shell_commands.h"
+
+int main(void)
+{
+    (void) puts("Welcome to RIOT!");
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}


### PR DESCRIPTION
To avoid further problems like the one fixed #5245.