### PR TITLE
gnrc ipv6: append empty netif hdr for loopback

### DIFF
--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -41,6 +41,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Identifier of the loopback interface
+ */
+#define GNRC_NETIF_LOOPBACK_PID     (-1)
+
+/**
  * @brief   The add/remove operation to set network layer protocol
  *          specific options for an interface.
  *

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -737,6 +737,16 @@ static void _send(gnrc_pktsnip_t *pkt, bool prep_hdr)
         gnrc_pktbuf_release(pkt);
 
         DEBUG("ipv6: packet is addressed to myself => loopback\n");
+        ptr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
+
+        if (ptr == NULL) {
+            DEBUG("ipv6: error on interface header allocation, dropping packet\n");
+            gnrc_pktbuf_release(rcv_pkt);
+            return;
+        }
+
+        /* add netif to front of the pkt list */
+        rcv_pkt->next = ptr;
 
         if (gnrc_netapi_receive(gnrc_ipv6_pid, rcv_pkt) < 1) {
             DEBUG("ipv6: unable to deliver packet\n");

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -745,6 +745,9 @@ static void _send(gnrc_pktsnip_t *pkt, bool prep_hdr)
             return;
         }
 
+        gnrc_netif_hdr_t *netif_hdr = (gnrc_netif_hdr_t*) ptr;
+        netif_hdr->if_pid = GNRC_NETIF_LOOPBACK_PID;
+
         /* add netif to front of the pkt list */
         rcv_pkt->next = ptr;
 


### PR DESCRIPTION
The netif header gets discarded during the reverse procedure.
