### PR TITLE
make: BUILDRELPATH without call to git

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -39,8 +39,8 @@ endif
 # Use absolute paths in recusive "make" even if overriden on command line.
 MAKEOVERRIDES += $(foreach v,${__DIRECTORY_VARIABLES},${v}=${${v}})
 
-# Path to the current directory relative to the git root
-BUILDRELPATH ?= $(shell git rev-parse --show-prefix)
+# Path to the current directory relative to RIOTPROJECT
+BUILDRELPATH ?= ${PWD:${RIOTPROJECT}/%=%}/
 
 # Include Docker settings near the top because we need to build the environment
 # command line before some of the variable origins are overwritten below when


### PR DESCRIPTION
Currently, if git is not installed on a system, it will fail to assign `$BUILDRELPATH`.
This case may be very rare, but why not save the call to git?
This approach uses ~~`$RIOTBASE`~~ `$RIOTPROJECT` and cuts away the prefix of the `$PWD`

*EDIT:* The current approach requires a git repo even for a custom application folder. Before, I thought this would only affect the RIOT folder, but I was wrong, which makes it more apparent to **not** use git in this case.