### PR TITLE
pkg/openwsn: prevent build loop

### DIFF
--- a/pkg/openwsn/Makefile
+++ b/pkg/openwsn/Makefile
@@ -5,6 +5,6 @@ PKG_VERSION=ff25e5d0ae5d344ed793a724d60532fb917bf1f8
 .PHONY: all
 
 all: git-download
-	"$(MAKE)" -C $(PKG_DIR)
+	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
When I build the `openwsn` application from the application repository, then I get a build loop.

A smiliar line is in `pkg/Makefile.git`, so I guess it is not needed to repeat that in `pkg/openwsn/Makefile`