### PR TITLE
make: moved driver deps to drivers/Makefile.deps

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -10,7 +10,6 @@ ifneq (,$(filter ccn-lite,$(USEPKG)))
     export CFLAGS += -DCCNL_RIOT
 endif
 
-
 ifneq (,$(filter nhdp,$(USEMODULE)))
   USEMODULE += conn_udp
   USEMODULE += xtimer
@@ -20,30 +19,6 @@ endif
 ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
   USEMODULE += gnrc_netif
   USEMODULE += netdev_default
-endif
-
-ifneq (,$(filter cc110x,$(USEMODULE)))
-  ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-    USEMODULE += gnrc_cc110x
-	# XXX: this can be modelled as a dependency for gnrc_netdev_default as soon
-	# as all drivers are ported to netdev2
-	USEMODULE += gnrc_netdev2
-  endif
-endif
-
-ifneq (,$(filter kw2xrf,$(USEMODULE)))
-  ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-    USEMODULE += gnrc_nomac
-  endif
-endif
-
-ifneq (,$(filter at86rf2%,$(USEMODULE)))
-  USEMODULE += netdev2_ieee802154
-  ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-	# XXX: this can be modelled as a dependency for gnrc_netdev_default as soon
-	# as all drivers are ported to netdev2
-    USEMODULE += gnrc_netdev2
-  endif
 endif
 
 ifneq (,$(filter netdev2_ieee802154,$(USEMODULE)))
@@ -559,11 +534,6 @@ endif
 
 ifneq (,$(filter phydat,$(USEMODULE)))
   USEMODULE += fmt
-endif
-
-ifneq (,$(filter ethos,$(USEMODULE)))
-    USEMODULE += netdev2_eth
-    USEMODULE += random
 endif
 
 ifneq (,$(filter random,$(USEMODULE)))

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -6,9 +6,15 @@ endif
 
 ifneq (,$(filter at86rf2%,$(USEMODULE)))
   USEMODULE += at86rf2xx
-  USEMODULE += ieee802154
   USEMODULE += xtimer
   USEMODULE += netif
+  USEMODULE += ieee802154
+  USEMODULE += netdev2_ieee802154
+  ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+	# XXX: this can be modelled as a dependency for gnrc_netdev_default as soon
+	# as all drivers are ported to netdev2
+    USEMODULE += gnrc_netdev2
+  endif
 endif
 
 ifneq (,$(filter bh1750fvi,$(USEMODULE)))
@@ -18,6 +24,12 @@ endif
 
 ifneq (,$(filter cc110x,$(USEMODULE)))
   USEMODULE += ieee802154
+  ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+    USEMODULE += gnrc_cc110x
+	# XXX: this can be modelled as a dependency for gnrc_netdev_default as soon
+	# as all drivers are ported to netdev2
+	USEMODULE += gnrc_netdev2
+  endif
 endif
 
 ifneq (,$(filter dht,$(USEMODULE)))
@@ -35,6 +47,11 @@ ifneq (,$(filter encx24j600,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter ethos,$(USEMODULE)))
+    USEMODULE += netdev2_eth
+    USEMODULE += random
+endif
+
 ifneq (,$(filter hih6130,$(USEMODULE)))
   USEMODULE += xtimer
 endif
@@ -42,6 +59,9 @@ endif
 ifneq (,$(filter kw2xrf,$(USEMODULE)))
   USEMODULE += ieee802154
   USEMODULE += netif
+  ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+    USEMODULE += gnrc_nomac
+  endif
 endif
 
 ifneq (,$(filter lm75a,$(USEMODULE)))


### PR DESCRIPTION
Somehow somebody put device driver dependencies back into the `Makefile.dep` instead of `drivers/Makefile.dep` where they belong... This fixes that.