### PR TITLE
cpu/atmega2560: reworked timer implementation

### DIFF
--- a/boards/arduino-mega2560/include/board.h
+++ b/boards/arduino-mega2560/include/board.h
@@ -51,6 +51,7 @@ extern "C" {
  * @brief xtimer configuration values
  * @{
  */
+#define XTIMER_MASK                 (0xffff0000)
 #define XTIMER_SHIFT                (2)
 #define XTIMER_SHIFT_ON_COMPARE     (8)
 #define XTIMER_BACKOFF              (40)

--- a/boards/arduino-mega2560/include/periph_conf.h
+++ b/boards/arduino-mega2560/include/periph_conf.h
@@ -31,109 +31,28 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Timer peripheral configuration
+ * @brief   Timer configuration
  *
- * The ATmega2560 has 6 timers. Timer0 and Timer2 are 8 Bit Timers,
- * Timer0 has special uses too and therefore we'll avoid using it.
- * Timer5 has special uses with certain Arduino Shields, too.
- * Therefore we'll also avoid using Timer5.
- * This results in the following mapping to use the left over 16 Bit
- * timers:
- *
- * Timer1 -> TIMER_0
- * Timer3 -> TIMER_1
- * Timer4 -> TIMER_2
+ * The timer driver only supports the four 16-bit timers (Timer1, Timer3,
+ * Timer4, Timer5), so those are the only onces we can use here.
  *
  * @{
  */
-#define TIMER_NUMOF         (3U)
-#define TIMER_0_EN          1
-#define TIMER_1_EN          0
-#define TIMER_2_EN          0
+#define TIMER_NUMOF         (2U)
 
-/* Timer 0 configuration */
-#define TIMER_0_CHANNELS    3
-#define TIMER_0_MAX_VALUE   (0xffff)
+#define TIMER_0             MEGA_TIMER1
+#define TIMER_0_MASK        &TIMSK1
+#define TIMER_0_FLAG        &TIFR1
+#define TIMER_0_ISRA        TIMER1_COMPA_vect
+#define TIMER_0_ISRB        TIMER1_COMPB_vect
+#define TIMER_0_ISRC        TIMER1_COMPC_vect
 
-/* Timer 0 register and flags */
-#define TIMER0_CONTROL_A    TCCR1A
-#define TIMER0_CONTROL_B    TCCR1B
-#define TIMER0_CONTROL_C    TCCR1C
-#define TIMER0_COUNTER      TCNT1
-#define TIMER0_IRQ_FLAG_REG TIFR1
-#define TIMER0_IRQ_MASK_REG TIMSK1
-#define TIMER0_COMP_A       OCR1A
-#define TIMER0_COMP_B       OCR1B
-#define TIMER0_COMP_C       OCR1C
-#define TIMER0_COMP_A_FLAG  OCF1A
-#define TIMER0_COMP_B_FLAG  OCF1B
-#define TIMER0_COMP_C_FLAG  OCF1C
-#define TIMER0_COMP_A_EN    OCIE1A
-#define TIMER0_COMP_B_EN    OCIE1B
-#define TIMER0_COMP_C_EN    OCIE1C
-#define TIMER0_FREQ_16MHZ   (0 << CS12) | (0 << CS11) | (1 << CS10)
-#define TIMER0_FREQ_2MHZ    (0 << CS12) | (1 << CS11) | (0 << CS10)
-#define TIMER0_FREQ_250KHZ  (0 << CS12) | (1 << CS11) | (1 << CS10)
-#define TIMER0_FREQ_DISABLE (0 << CS12) | (0 << CS11) | (0 << CS10)
-#define TIMER0_COMPA_ISR    TIMER1_COMPA_vect
-#define TIMER0_COMPB_ISR    TIMER1_COMPB_vect
-#define TIMER0_COMPC_ISR    TIMER1_COMPC_vect
-
-/* Timer 1 configuration */
-#define TIMER_1_CHANNELS    3
-#define TIMER_1_MAX_VALUE   (0xffff)
-
-/* Timer 1 register and flags */
-#define TIMER1_CONTROL_A    TCCR3A
-#define TIMER1_CONTROL_B    TCCR3B
-#define TIMER1_CONTROL_C    TCCR3C
-#define TIMER1_COUNTER      TCNT3
-#define TIMER1_IRQ_FLAG_REG TIFR3
-#define TIMER1_IRQ_MASK_REG TIMSK3
-#define TIMER1_COMP_A       OCR3A
-#define TIMER1_COMP_B       OCR3B
-#define TIMER1_COMP_C       OCR3C
-#define TIMER1_COMP_A_FLAG  OCF3A
-#define TIMER1_COMP_B_FLAG  OCF3B
-#define TIMER1_COMP_C_FLAG  OCF3C
-#define TIMER1_COMP_A_EN    OCIE3A
-#define TIMER1_COMP_B_EN    OCIE3B
-#define TIMER1_COMP_C_EN    OCIE3C
-#define TIMER1_FREQ_16MHZ   (0 << CS32) | (0 << CS31) | (1 << CS30)
-#define TIMER1_FREQ_2MHZ    (0 << CS32) | (1 << CS31) | (0 << CS30)
-#define TIMER1_FREQ_250KHZ  (0 << CS32) | (1 << CS31) | (1 << CS30)
-#define TIMER1_FREQ_DISABLE (0 << CS32) | (0 << CS31) | (0 << CS30)
-#define TIMER1_COMPA_ISR    TIMER3_COMPA_vect
-#define TIMER1_COMPB_ISR    TIMER3_COMPB_vect
-#define TIMER1_COMPC_ISR    TIMER3_COMPC_vect
-
-/* Timer 2 configuration */
-#define TIMER_2_CHANNELS    3
-#define TIMER_2_MAX_VALUE   (0xffff)
-
-/* Timer 2 register and flags */
-#define TIMER2_CONTROL_A    TCCR4A
-#define TIMER2_CONTROL_B    TCCR4B
-#define TIMER2_CONTROL_C    TCCR4C
-#define TIMER2_COUNTER      TCNT4
-#define TIMER2_IRQ_FLAG_REG TIFR4
-#define TIMER2_IRQ_MASK_REG TIMSK4
-#define TIMER2_COMP_A       OCR4A
-#define TIMER2_COMP_B       OCR4B
-#define TIMER2_COMP_C       OCR4C
-#define TIMER2_COMP_A_FLAG  OCF4A
-#define TIMER2_COMP_B_FLAG  OCF4B
-#define TIMER2_COMP_C_FLAG  OCF4C
-#define TIMER2_COMP_A_EN    OCIE4A
-#define TIMER2_COMP_B_EN    OCIE4B
-#define TIMER2_COMP_C_EN    OCIE4C
-#define TIMER2_FREQ_16MHZ   (0 << CS42) | (0 << CS41) | (1 << CS40)
-#define TIMER2_FREQ_2MHZ    (0 << CS42) | (1 << CS41) | (0 << CS40)
-#define TIMER2_FREQ_250KHZ  (0 << CS42) | (1 << CS41) | (1 << CS40)
-#define TIMER2_FREQ_DISABLE (0 << CS42) | (0 << CS41) | (0 << CS40)
-#define TIMER2_COMPA_ISR    TIMER4_COMPA_vect
-#define TIMER2_COMPB_ISR    TIMER4_COMPB_vect
-#define TIMER2_COMPC_ISR    TIMER4_COMPC_vect
+#define TIMER_1             MEGA_TIMER4
+#define TIMER_1_MASK        &TIMSK4
+#define TIMER_1_FLAG        &TIFR4
+#define TIMER_1_ISRA        TIMER4_COMPA_vect
+#define TIMER_1_ISRB        TIMER4_COMPB_vect
+#define TIMER_1_ISRC        TIMER4_COMPC_vect
 /** @} */
 
 /**

--- a/cpu/atmega2560/include/atmega2560_regs.h
+++ b/cpu/atmega2560/include/atmega2560_regs.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_atmega2560
+ * @{
+ *
+ * @file
+ * @brief       CMSIS style register definitions for the atmega2560
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef ATMEGA2560_REGS_H
+#define ATMEGA2560_REGS_H
+
+#include <avr/io.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Register types
+ * @{
+ */
+#define REG8                    volatile uint8_t
+#define REG16                   volatile uint16_t
+/** @} */
+
+/**
+ * @brief   Timer register map
+ */
+typedef struct {
+    REG8    CRA;            /**< control A */
+    REG8    CRB;            /**< control B */
+    REG8    CRC;            /**< control C */
+    REG8    reserved;       /**< reserved */
+    REG16   CNT;            /**< counter */
+    REG16   ICR;            /**< input capture */
+    REG16   OCR[3];         /**< output compare */
+} mega_timer_t;
+
+/**
+ * @brief    Base register address definitions
+ * @{
+ */
+#define MEGA_TIMER1_BASE        (uint16_t *)(&TCCR1A)
+#define MEGA_TIMER3_BASE        (uint16_t *)(&TCCR3A)
+#define MEGA_TIMER4_BASE        (uint16_t *)(&TCCR4A)
+#define MEGA_TIMER5_BASE        (uint16_t *)(&TCCR5A)
+/** @} */
+
+/**
+ * @brief    Peripheral instances
+ * @{
+ */
+#define MEGA_TIMER1             ((mega_timer_t *)MEGA_TIMER1_BASE)
+#define MEGA_TIMER3             ((mega_timer_t *)MEGA_TIMER3_BASE)
+#define MEGA_TIMER4             ((mega_timer_t *)MEGA_TIMER4_BASE)
+#define MEGA_TIMER5             ((mega_timer_t *)MEGA_TIMER5_BASE)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ATMEGA2560_REGS_H */
+/** @} */

--- a/cpu/atmega2560/include/cpu_conf.h
+++ b/cpu/atmega2560/include/cpu_conf.h
@@ -7,6 +7,7 @@
  */
 
 /**
+ * @ingroup         cpu_atmega2560
  * @{
  *
  * @file
@@ -19,6 +20,7 @@
 #ifndef __CPU_CONF_H
 #define __CPU_CONF_H
 
+#include "atmega2560_regs.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
fixes also #5252

The timers were kind of broken (at least did not function correctly). This implementation should now work fine.

NOTE: the periph timer is not able to run at 1MHz (missing prescaler for that), so the `tests/periph_timer` test needs to be adjusted to run the timer either with 2MHz or better with 250khz.

Also the xtimer tests will most probably fail, as the xtimer requires the low-level timer to run at 1MHZ.