### PR TITLE
drivers: misc fixes for encx24j600

### DIFF
--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -112,15 +112,15 @@ static void _isr(netdev2_t *netdev)
     uint16_t eir;
 
     lock(dev);
-    cmd(dev, CLREIE);
+    cmd(dev, ENC_CLREIE);
 
-    eir = reg_get(dev, EIR);
+    eir = reg_get(dev, ENC_EIR);
 
     /* check & handle link state change */
-    if (eir & LINKIF) {
-        uint16_t estat = reg_get(dev, ESTAT);
+    if (eir & ENC_LINKIF) {
+        uint16_t estat = reg_get(dev, ENC_ESTAT);
 
-        netdev2_event_t event = (estat & PHYLNK) ?
+        netdev2_event_t event = (estat & ENC_PHYLNK) ?
             NETDEV2_EVENT_LINK_DOWN :
             NETDEV2_EVENT_LINK_UP;
 
@@ -128,7 +128,7 @@ static void _isr(netdev2_t *netdev)
     }
 
     /* check & handle available packets */
-    if (eir & PKTIF) {
+    if (eir & ENC_PKTIF) {
         while (_packets_available(dev)) {
             unlock(dev);
             netdev->event_callback(netdev, NETDEV2_EVENT_RX_COMPLETE,
@@ -138,11 +138,11 @@ static void _isr(netdev2_t *netdev)
     }
 
     /* drop all flags */
-    reg_clear_bits(dev, EIR, LINKIF);
+    reg_clear_bits(dev, ENC_EIR, ENC_LINKIF);
 
     /* re-enable interrupt */
     gpio_irq_enable(dev->int_pin);
-    cmd(dev, SETEIE);
+    cmd(dev, ENC_SETEIE);
 
     unlock(dev);
 }
@@ -158,7 +158,7 @@ static inline void enc_spi_transfer(encx24j600_t *dev, char *out, char *in, int 
 
 static inline uint16_t reg_get(encx24j600_t *dev, uint8_t reg)
 {
-    char cmd[4] = { RCRU, reg, 0, 0 };
+    char cmd[4] = { ENC_RCRU, reg, 0, 0 };
     char result[4];
 
     enc_spi_transfer(dev, cmd, result, 4);
@@ -167,8 +167,8 @@ static inline uint16_t reg_get(encx24j600_t *dev, uint8_t reg)
 }
 
 static void phy_reg_set(encx24j600_t *dev, uint8_t reg, uint16_t value) {
-    reg_set(dev, MIREGADR, reg | (1<<8));
-    reg_set(dev, MIWR, value);
+    reg_set(dev, ENC_MIREGADR, reg | (1<<8));
+    reg_set(dev, ENC_MIWR, value);
 }
 
 static void cmd(encx24j600_t *dev, char cmd) {
@@ -190,19 +190,19 @@ static void cmdn(encx24j600_t *dev, uint8_t cmd, char *out, char *in, int len) {
 
 static void reg_set(encx24j600_t *dev, uint8_t reg, uint16_t value)
 {
-    char cmd[4] = { WCRU, reg, value, value >> 8 };
+    char cmd[4] = { ENC_WCRU, reg, value, value >> 8 };
     enc_spi_transfer(dev, cmd, NULL, 4);
 }
 
 static void reg_set_bits(encx24j600_t *dev, uint8_t reg, uint16_t mask)
 {
-    char cmd[4] = { BFSU, reg, mask, mask >> 8 };
+    char cmd[4] = { ENC_BFSU, reg, mask, mask >> 8 };
     enc_spi_transfer(dev, cmd, NULL, 4);
 }
 
 static void reg_clear_bits(encx24j600_t *dev, uint8_t reg, uint16_t mask)
 {
-    char cmd[4] = { BFCU, reg, mask, mask >> 8 };
+    char cmd[4] = { ENC_BFCU, reg, mask, mask >> 8 };
     enc_spi_transfer(dev, cmd, NULL, 4);
 }
 
@@ -210,7 +210,7 @@ static void reg_clear_bits(encx24j600_t *dev, uint8_t reg, uint16_t mask)
  * @brief Read/Write to encx24j600's SRAM
  *
  * @param[in] dev   ptr to encx24j600 device handle
- * @param[in] cmd   either WGPDATA, RGPDATA, WRXDATA, RRXDATA, WUDADATA, RUDADATA
+ * @param[in] cmd   either ENC_WGPDATA, ENC_RGPDATA, ENC_WRXDATA, ENC_RRXDATA, ENC_WUDADATA, ENC_RUDADATA
  * @param[in] addr  SRAM address to start reading. 0xFFFF means continue from old address
  * @param     ptr   pointer to buffer to read from / write to
  * @param[in] len   nr of bytes to read/write
@@ -265,35 +265,35 @@ static int _init(netdev2_t *encdev)
     do {
         do {
             xtimer_usleep(ENCX24J600_INIT_DELAY);
-            reg_set(dev, EUDAST, 0x1234);
+            reg_set(dev, ENC_EUDAST, 0x1234);
             xtimer_usleep(ENCX24J600_INIT_DELAY);
-        } while (reg_get(dev, EUDAST) != 0x1234);
+        } while (reg_get(dev, ENC_EUDAST) != 0x1234);
 
-        while (!(reg_get(dev, ESTAT) & CLKRDY));
+        while (!(reg_get(dev, ENC_ESTAT) & ENC_CLKRDY));
 
         /* issue System Reset */
-        cmd(dev, SETETHRST);
+        cmd(dev, ENC_SETETHRST);
 
         /* make sure initialization finalizes */
         xtimer_usleep(1000);
-    } while (!(reg_get(dev, EUDAST) == 0x0000));
+    } while (!(reg_get(dev, ENC_EUDAST) == 0x0000));
 
     /* configure flow control */
-    phy_reg_set(dev, PHANA, 0x05E1);
-    reg_set_bits(dev, ECON2, AUTOFC);
+    phy_reg_set(dev, ENC_PHANA, 0x05E1);
+    reg_set_bits(dev, ENC_ECON2, ENC_AUTOFC);
 
     /* setup receive buffer */
-    reg_set(dev, ERXST, RX_BUFFER_START);
-    reg_set(dev, ERXTAIL, RX_BUFFER_END);
+    reg_set(dev, ENC_ERXST, RX_BUFFER_START);
+    reg_set(dev, ENC_ERXTAIL, RX_BUFFER_END);
     dev->rx_next_ptr = RX_BUFFER_START;
 
     /* configure receive filter to receive multicast frames */
-    reg_set_bits(dev, ERXFCON, MCEN);
+    reg_set_bits(dev, ENC_ERXFCON, ENC_MCEN);
 
     /* setup interrupts */
-    reg_set_bits(dev, EIE, PKTIE | LINKIE);
-    cmd(dev, ENABLERX);
-    cmd(dev, SETEIE);
+    reg_set_bits(dev, ENC_EIE, ENC_PKTIE | ENC_LINKIE);
+    cmd(dev, ENC_ENABLERX);
+    cmd(dev, ENC_SETEIE);
 
     DEBUG("encx24j600: initialization complete.\n");
 
@@ -314,26 +314,26 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, int count) {
 #endif
 
     /* wait until previous packet has been sent */
-    while ((reg_get(dev, ECON1) & TXRTS));
+    while ((reg_get(dev, ENC_ECON1) & ENC_TXRTS));
 
     /* copy packet to SRAM */
     size_t len = 0;
 
     for (int i = 0; i < count; i++) {
-        sram_op(dev, WGPDATA, (i ? 0xFFFF : TX_BUFFER_START), vector[i].iov_base, vector[i].iov_len);
+        sram_op(dev, ENC_WGPDATA, (i ? 0xFFFF : TX_BUFFER_START), vector[i].iov_base, vector[i].iov_len);
         len += vector[i].iov_len;
     }
 
     /* set start of TX packet and length */
-    reg_set(dev, ETXST, TX_BUFFER_START);
-    reg_set(dev, ETXLEN, len);
+    reg_set(dev, ENC_ETXST, TX_BUFFER_START);
+    reg_set(dev, ENC_ETXLEN, len);
 
     /* initiate sending */
-    cmd(dev, SETTXRTS);
+    cmd(dev, ENC_SETTXRTS);
 
     /* wait for sending to complete */
     /* (not sure if it is needed, keeping the line uncommented) */
-    /*while ((reg_get(dev, ECON1) & TXRTS));*/
+    /*while ((reg_get(dev, ENC_ECON1) & ENC_TXRTS));*/
 
     unlock(dev);
 
@@ -342,8 +342,8 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, int count) {
 
 static inline int _packets_available(encx24j600_t *dev)
 {
-    /* return PKTCNT (low byte of ESTAT) */
-    return reg_get(dev, ESTAT) & ~0xFF00;
+    /* return ENC_PKTCNT (low byte of ENC_ESTAT) */
+    return reg_get(dev, ENC_ESTAT) & ~0xFF00;
 }
 
 static void _get_mac_addr(netdev2_t *encdev, uint8_t* buf)
@@ -353,9 +353,9 @@ static void _get_mac_addr(netdev2_t *encdev, uint8_t* buf)
 
     lock(dev);
 
-    addr[0] = reg_get(dev, MAADR1);
-    addr[1] = reg_get(dev, MAADR2);
-    addr[2] = reg_get(dev, MAADR3);
+    addr[0] = reg_get(dev, ENC_MAADR1);
+    addr[1] = reg_get(dev, ENC_MAADR2);
+    addr[2] = reg_get(dev, ENC_MAADR3);
 
     unlock(dev);
 }
@@ -369,7 +369,7 @@ static int _recv(netdev2_t *netdev, char* buf, int len, void *info)
     lock(dev);
 
     /* read frame header */
-    sram_op(dev, RRXDATA, dev->rx_next_ptr, (char*)&hdr, sizeof(hdr));
+    sram_op(dev, ENC_RRXDATA, dev->rx_next_ptr, (char*)&hdr, sizeof(hdr));
 
     /* hdr.frame_len given by device contains 4 bytes checksum */
     size_t payload_len = hdr.frame_len - 4;
@@ -380,14 +380,14 @@ static int _recv(netdev2_t *netdev, char* buf, int len, void *info)
         netdev2->stats.rx_bytes += len;
 #endif
         /* read packet (without 4 bytes checksum) */
-        sram_op(dev, RRXDATA, 0xFFFF, buf, payload_len);
+        sram_op(dev, ENC_RRXDATA, 0xFFFF, buf, payload_len);
 
         /* decrement available packet count */
-        cmd(dev, SETPKTDEC);
+        cmd(dev, ENC_SETPKTDEC);
 
         dev->rx_next_ptr = hdr.rx_next_ptr;
 
-        reg_set(dev, ERXTAIL, dev->rx_next_ptr - 2);
+        reg_set(dev, ENC_ERXTAIL, dev->rx_next_ptr - 2);
     }
 
     unlock(dev);

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -86,7 +86,7 @@ void encx24j600_setup(encx24j600_t *dev, const encx24j600_params_t *params)
 {
     dev->netdev.driver = &netdev2_driver_encx24j600;
     dev->spi = params->spi;
-    dev->cs = params->cs;
+    dev->cs = params->cs_pin;
     dev->int_pin = params->int_pin;
     dev->rx_next_ptr = RX_BUFFER_START;
 
@@ -96,12 +96,13 @@ void encx24j600_setup(encx24j600_t *dev, const encx24j600_params_t *params)
 static void encx24j600_isr(void *arg)
 {
     encx24j600_t *dev = (encx24j600_t *) arg;
+    netdev2_t *netdev = (netdev2_t *) arg;
 
     /* disable interrupt line */
     gpio_irq_disable(dev->int_pin);
 
     /* call netdev2 hook */
-    dev->netdev.event_callback((netdev2_t*) dev, NETDEV2_EVENT_ISR, dev->isr_arg);
+    dev->netdev.event_callback((netdev2_t*) dev, NETDEV2_EVENT_ISR, netdev->isr_arg);
 }
 
 static void _isr(netdev2_t *netdev)

--- a/drivers/encx24j600/include/encx24j600_defines.h
+++ b/drivers/encx24j600/include/encx24j600_defines.h
@@ -28,80 +28,80 @@ extern "C" {
  * @name SPI instruction set
  * @{
  */
-#define RCR         0x00  /* read control register */
-#define WCR         0x04  /* write control register */
+#define ENC_RCR         0x00  /* read control register */
+#define ENC_WCR         0x04  /* write control register */
 
-#define RCRU        0x20  /* read control register unbanked */
-#define WCRU        0x22  /* write control register unbanked */
+#define ENC_RCRU        0x20  /* read control register unbanked */
+#define ENC_WCRU        0x22  /* write control register unbanked */
 
-#define BFSU        0x24  /* set bits unbanked */
-#define BFCU        0x26  /* clear bits unbanked */
+#define ENC_BFSU        0x24  /* set bits unbanked */
+#define ENC_BFCU        0x26  /* clear bits unbanked */
 
-#define RGPDATA     0x28  /* Read EGPDATA */
-#define WGPDATA     0x2a  /* Write EGPDATA */
+#define ENC_RGPDATA     0x28  /* Read EGPDATA */
+#define ENC_WGPDATA     0x2a  /* Write EGPDATA */
 
-#define RRXDATA     0x2c  /* Read ERXDATA */
-#define WRXDATA     0x2e  /* Write ERXDATA */
+#define ENC_RRXDATA     0x2c  /* Read ERXDATA */
+#define ENC_WRXDATA     0x2e  /* Write ERXDATA */
 
-#define RUDADATA    0x30  /* Read EUDADATA */
-#define WUDADATA    0x32  /* Write EUDADATA */
+#define ENC_RUDADATA    0x30  /* Read EUDADATA */
+#define ENC_WUDADATA    0x32  /* Write EUDADATA */
 
-#define BFS         0x80  /* Bit Field Set */
-#define BFC         0xa0  /* Bit Field Clear */
+#define ENC_BFS         0x80  /* Bit Field Set */
+#define ENC_BFC         0xa0  /* Bit Field Clear */
 
-#define SETETHRST   0xca  /* System Reset */
-#define SETPKTDEC   0xcc  /* Decrements PKTCNT by setting PKTDEC (ECON1<5>) */
-#define ENABLERX    0xe8  /* Enables packet reception by setting RXEN (ECON1<0>) */
-#define DISABLERX   0xea  /* Disable packet reception by clearing RXEN (ECON1<0>) */
-#define SETEIE      0xec  /* Enable Ethernet Interrupts by setting INT (ESTAT<16>) */
-#define CLREIE      0xee  /* Disable Ethernet Interrupts by clearing INT (ESTAT<16>) */
+#define ENC_SETETHRST   0xca  /* System Reset */
+#define ENC_SETPKTDEC   0xcc  /* Decrements PKTCNT by setting PKTDEC (ECON1<5>) */
+#define ENC_ENABLERX    0xe8  /* Enables packet reception by setting RXEN (ECON1<0>) */
+#define ENC_DISABLERX   0xea  /* Disable packet reception by clearing RXEN (ECON1<0>) */
+#define ENC_SETEIE      0xec  /* Enable Ethernet Interrupts by setting INT (ESTAT<16>) */
+#define ENC_CLREIE      0xee  /* Disable Ethernet Interrupts by clearing INT (ESTAT<16>) */
 
-#define B0SEL       0xc0  /* select bank 0 */
-#define B1SEL       0xc2  /* select bank 0 */
-#define B2SEL       0xc4  /* select bank 0 */
-#define B3SEL       0xc6  /* select bank 0 */
-#define RBSEL       0xc8  /* Read Bank Select */
+#define ENC_B0SEL       0xc0  /* select bank 0 */
+#define ENC_B1SEL       0xc2  /* select bank 0 */
+#define ENC_B2SEL       0xc4  /* select bank 0 */
+#define ENC_B3SEL       0xc6  /* select bank 0 */
+#define ENC_RBSEL       0xc8  /* Read Bank Select */
 
-#define SETTXRTS    0xd4  /* Sets TXRTS (ECON1<1>), sends an Ethernet packet */
+#define ENC_SETTXRTS    0xd4  /* Sets TXRTS (ECON1<1>), sends an Ethernet packet */
 /** @} */
 
 /**
  * @name 16bit Registers
  * @{
  */
-#define ETXST       0x00
-#define ETXLEN      0x02
-#define ERXST       0x04
-#define ERXTAIL     0x06
-#define ERXHEAD     0x08
-#define ETXSTAT     0x12
-#define ETXWIRE     0x14
-#define EUDAST      0x16
-#define ESTAT       0x1a
-#define EIR         0x1c    /* Interrupt Flag Register */
-#define ECON1       0x1e
+#define ENC_ETXST       0x00
+#define ENC_ETXLEN      0x02
+#define ENC_ERXST       0x04
+#define ENC_ERXTAIL     0x06
+#define ENC_ERXHEAD     0x08
+#define ENC_ETXSTAT     0x12
+#define ENC_ETXWIRE     0x14
+#define ENC_EUDAST      0x16
+#define ENC_ESTAT       0x1a
+#define ENC_EIR         0x1c    /* Interrupt Flag Register */
+#define ENC_ECON1       0x1e
 
-#define ERXFCON     0x34    /* Receive filter control register */
+#define ENC_ERXFCON     0x34    /* Receive filter control register */
 
-#define MACON2      0x42
-#define MAMXFL      0x4a    /* MAC maximum frame length */
+#define ENC_MACON2      0x42
+#define ENC_MAMXFL      0x4a    /* MAC maximum frame length */
 
-#define MAADR3      0x60    /* MAC address byte 5&6 */
-#define MAADR2      0x62    /* MAC address byte 3&4 */
-#define MAADR1      0x64    /* MAC address byte 1&2 */
+#define ENC_MAADR3      0x60    /* MAC address byte 5&6 */
+#define ENC_MAADR2      0x62    /* MAC address byte 3&4 */
+#define ENC_MAADR1      0x64    /* MAC address byte 1&2 */
 
-#define MIWR        0x66
-#define MIREGADR    0x54
+#define ENC_MIWR        0x66
+#define ENC_MIREGADR    0x54
 
-#define ECON2       0x6e
+#define ENC_ECON2       0x6e
 
-#define EIE         0x72    /* Interrupt Enable Register */
+#define ENC_EIE         0x72    /* Interrupt Enable Register */
 
-#define EGPRDPT     0x86    /* General Purpose SRAM read pointer */
-#define EGPWRPT     0x88    /* General Purpose SRAM write pointer */
+#define ENC_EGPRDPT     0x86    /* General Purpose SRAM read pointer */
+#define ENC_EGPWRPT     0x88    /* General Purpose SRAM write pointer */
 
-#define ERXRDPT     0x8a    /* RX buffer read pointer */
-#define ERXWRPT     0x8c    /* RX buffer write pointer */
+#define ENC_ERXRDPT     0x8a    /* RX buffer read pointer */
+#define ENC_ERXWRPT     0x8c    /* RX buffer write pointer */
 /** @} */
 
 /**
@@ -111,92 +111,92 @@ extern "C" {
  *
  * @{
  */
-#define PHCON1  0x00
-#define PHSTAT1 0x01
-#define PHANA   0x04
-#define PHANLPA 0x05
-#define PHANE   0x06
-#define PHCON2  0x11
-#define PHSTAT2 0x1b
-#define PHSTAT3 0x1f
+#define ENC_PHCON1  0x00
+#define ENC_PHSTAT1 0x01
+#define ENC_PHANA   0x04
+#define ENC_PHANLPA 0x05
+#define ENC_PHANE   0x06
+#define ENC_PHCON2  0x11
+#define ENC_PHSTAT2 0x1b
+#define ENC_PHSTAT3 0x1f
 /** @} */
 
 /**
  * @name ESTAT bits
  * @{
  */
-#define PHYLNK  (1<<8)
-#define CLKRDY  (1<<12)
+#define ENC_PHYLNK  (1<<8)
+#define ENC_CLKRDY  (1<<12)
 /** @} */
 
 /**
  * @name ECON1 bits
  * @{
  */
-#define RXEN    (1<<0)
-#define TXRTS   (1<<1)
-#define DMANOCS (1<<2)
-#define DMACSSD (1<<3)
-#define DMACPY  (1<<4)
-#define DMAST   (1<<5)
-#define FCOP0   (1<<6)
-#define FCOP1   (1<<7)
-#define PKTDEC  (1<<8)
-#define AESOP0  (1<<9)
-#define AESOP1  (1<<10)
-#define AESST   (1<<11)
-#define HASHLST (1<<12)
-#define HASHOP  (1<<13)
-#define HASHEN  (1<<14)
-#define MODEXST (1<<15)
+#define ENC_RXEN    (1<<0)
+#define ENC_TXRTS   (1<<1)
+#define ENC_DMANOCS (1<<2)
+#define ENC_DMACSSD (1<<3)
+#define ENC_DMACPY  (1<<4)
+#define ENC_DMAST   (1<<5)
+#define ENC_FCOP0   (1<<6)
+#define ENC_FCOP1   (1<<7)
+#define ENC_PKTDEC  (1<<8)
+#define ENC_AESOP0  (1<<9)
+#define ENC_AESOP1  (1<<10)
+#define ENC_AESST   (1<<11)
+#define ENC_HASHLST (1<<12)
+#define ENC_HASHOP  (1<<13)
+#define ENC_HASHEN  (1<<14)
+#define ENC_MODEXST (1<<15)
 /** @} */
 
 /**
  * @name ECON2 bits
  * @{
  */
-#define ETHRST    (1<<4)
-#define AUTOFC    (1<<7)    /* automatic flow control enable bit */
+#define ENC_ETHRST    (1<<4)
+#define ENC_AUTOFC    (1<<7)    /* automatic flow control enable bit */
 /** @} */
 
 /**
  * @name EIR bits
  * @{
  */
-#define PCFULIE     (1<<0)
-#define RXABTIE     (1<<1)
-#define TXABTIE     (1<<2)
-#define TXIE        (1<<3)
-#define DMAIE       (1<<5)
-#define PKTIE       (1<<6)
-#define LINKIE      (1<<11)
-#define AESIE       (1<<12)
-#define HASHIE      (1<<13)
-#define MODEXIE     (1<<14)
-#define INTIE       (1<<15)
+#define ENC_PCFULIE     (1<<0)
+#define ENC_RXABTIE     (1<<1)
+#define ENC_TXABTIE     (1<<2)
+#define ENC_TXIE        (1<<3)
+#define ENC_DMAIE       (1<<5)
+#define ENC_PKTIE       (1<<6)
+#define ENC_LINKIE      (1<<11)
+#define ENC_AESIE       (1<<12)
+#define ENC_HASHIE      (1<<13)
+#define ENC_MODEXIE     (1<<14)
+#define ENC_INTIE       (1<<15)
 /** @} */
 
 /**
  * @name EIR bits
  * @{
  */
-#define PCFULIF     (1<<0)
-#define RXABTIF     (1<<1)
-#define TXABTIF     (1<<2)
-#define TXIF        (1<<3)
-#define DMAIF       (1<<5)
-#define PKTIF       (1<<6)
-#define LINKIF      (1<<11)
-#define AESIF       (1<<12)
-#define HASHIF      (1<<13)
-#define MODEXIF     (1<<14)
-#define CRYPTEN     (1<<15)
+#define ENC_PCFULIF     (1<<0)
+#define ENC_RXABTIF     (1<<1)
+#define ENC_TXABTIF     (1<<2)
+#define ENC_TXIF        (1<<3)
+#define ENC_DMAIF       (1<<5)
+#define ENC_PKTIF       (1<<6)
+#define ENC_LINKIF      (1<<11)
+#define ENC_AESIF       (1<<12)
+#define ENC_HASHIF      (1<<13)
+#define ENC_MODEXIF     (1<<14)
+#define ENC_CRYPTEN     (1<<15)
 /** @} */
 
 /**
  * @name ERXFCON bits
  */
-#define MCEN        (1<<1)
+#define ENC_MCEN        (1<<1)
 /** @} */
 
 #ifdef __cplusplus

--- a/tests/driver_encx24j600/Makefile
+++ b/tests/driver_encx24j600/Makefile
@@ -1,0 +1,42 @@
+export APPLICATION = driver_encx24j600
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_spi periph_gpio
+
+BOARD_INSUFFICIENT_MEMORY := msb-430h stm32f0discovery weio z1
+
+USEMODULE += gnrc_netdev2
+USEMODULE += gnrc_netdev_default
+USEMODULE += auto_init_gnrc_netif
+USEMODULE += encx24j600
+USEMODULE += gnrc_ipv6_router_default
+USEMODULE += gnrc_icmpv6_echo
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+
+# lower pktbuf size
+CFLAGS += -DGNRC_PKTBUF_SIZE=2048
+
+# set board specific peripheral configurations
+ifneq (,$(filter nucleo-f334,$(BOARD)))
+# these settings are probably valid for PoEll-i on most nucelo boards, but
+# tested only on nucleo-f334
+  ENC_SPI ?= SPI_0
+  ENC_CS  ?= GPIO_PIN\(PORT_C,10\)
+  ENC_INT ?= GPIO_PIN\(PORT_D,2\)
+endif
+
+# fallback: set SPI bus and pins to default values
+ENC_SPI ?= SPI_0
+ENC_CS  ?= GPIO_PIN\(0,0\)
+ENC_INT ?= GPIO_PIN\(0,1\)
+# export SPI and pins
+CFLAGS += -DENCX24J600_SPI=$(ENC_SPI)
+CFLAGS += -DENCX24J600_CS=$(ENC_CS)
+CFLAGS += -DENCX24J600_INT=$(ENC_INT)
+
+# make sure we read the local encx24j600 params file
+CFLAGS += -I$(CURDIR)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_encx24j600/main.c
+++ b/tests/driver_encx24j600/main.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *               2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the ENCx26J600 Ethernet device driver
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+#include "msg.h"
+
+#define MAIN_QUEUE_SIZE     (8U)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+int main(void)
+{
+    /* we need a message queue for the thread running the shell in order to
+     * receive potentially fast incoming networking packets */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+
+    puts("Test application for the encx24j600 driver\n");
+    puts("This test just pulls in parts of the GNRC network stack, use the\n"
+         "provided shell commands (i.e. ifconfig, ping6) to interact with\n"
+         "your encx24j600 device.\n");
+
+    /* start shell */
+    puts("Starting the shell now...");
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    /* should be never reached */
+    return 0;
+}


### PR DESCRIPTION
The driver didn't compile for a while, so this PR

- fixes the compile issues
- prefixes its constants, fixing compilation for msp430
- adds a test application so compile errors don't show up in the future

The test application is basically a copy of tests/driver_enc28j60.