### PR TITLE
cpu/cortex-m: Enable STKALIGN to make the Cortex-M keep the stack 8 byte aligned

### DIFF
--- a/cpu/cortexm_common/cortexm_init.c
+++ b/cpu/cortexm_common/cortexm_init.c
@@ -52,4 +52,12 @@ void cortexm_init(void)
 
     /* enable wake up on events for __WFE CPU sleep */
     SCB->SCR |= SCB_SCR_SEVONPEND_Msk;
+
+    /* for Cortex-M3 r1p0 and up the STKALIGN option was added, but not automatically
+     * enabled until revision r2p0. For 64bit function arguments to work properly this
+     * needs to be enabled.
+     */
+#ifdef SCB_CCR_STKALIGN_Msk
+    SCB->CCR |= SCB_CCR_STKALIGN_Msk;
+#endif
 }


### PR DESCRIPTION
This was a part of my effort to fix 1891 but this was not the problem.

Anyhow a nice add. :)

     /* for Cortex-M3 r1p0 and up the STKALIGN option was added, but not automatically
      * enabled until revision r2p0. For 64bit function arguments to work properly this
      * needs to be enabled.
      */