### PR TITLE
at86rf2xx: introduce pending TX counter

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -44,6 +44,7 @@ void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params)
     memcpy(&dev->params, params, sizeof(at86rf2xx_params_t));
     dev->idle_state = AT86RF2XX_STATE_TRX_OFF;
     dev->state = AT86RF2XX_STATE_SLEEP;
+    dev->pending_tx = 0;
     /* initialise SPI */
     spi_init_master(dev->params.spi, SPI_CONF_FIRST_RISING, params->spi_speed);
 }
@@ -185,6 +186,7 @@ void at86rf2xx_tx_prepare(at86rf2xx_t *dev)
 {
     uint8_t state;
 
+    dev->pending_tx++;
     /* make sure ongoing transmissions are finished */
     do {
         state = at86rf2xx_get_status(dev);

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -624,7 +624,15 @@ static void _isr(netdev2_t *netdev)
         }
         else if (state == AT86RF2XX_STATE_TX_ARET_ON ||
                  state == AT86RF2XX_STATE_BUSY_TX_ARET) {
-            at86rf2xx_set_state(dev, dev->idle_state);
+            /* check for more pending TX calls and return to idle state if
+             * there are none */
+            if (dev->pending_tx == 0) {
+                at86rf2xx_set_state(dev, dev->idle_state);
+            }
+            else {
+                dev->pending_tx--;
+            }
+
             DEBUG("[at86rf2xx] EVT - TX_END\n");
             DEBUG("[at86rf2xx] return to state 0x%x\n", dev->idle_state);
 

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -163,6 +163,9 @@ typedef struct {
     uint8_t page;                       /**< currently used channel page */
 #endif
     uint8_t idle_state;                 /**< state to return to after sending */
+    uint8_t pending_tx;                 /**< keep track of pending TX calls
+                                             this is required to know when to
+                                             return to @ref at86rf2xx_t::idle_state */
     /** @} */
 } at86rf2xx_t;
 


### PR DESCRIPTION
This is another (better) workaround to solve #5257 compared to #5258.

The problem is that one might want to send several packets back to back. The netdev2 event loop will now queue these sending requests in the message queue. Once the first TX is completed it will queue another event in the queue. Once this is handled it would reset the state to idle (RX) again. Now the next TX completed event is handled and interpret the IRQ as an RX event, because it was received in RX state.

This PR counts the currently pending TX calls to only return to idle (RX) after all TX calls are handled.

A better solution for this would be to modify the driver to use thread_flags instead of msg, but if we cannot find the time to include this for the release, I would propose to take this intermediate solution.