### PR TITLE
cleanup: Remove ambigious _t postfixes in struct names

### DIFF
--- a/core/include/atomic.h
+++ b/core/include/atomic.h
@@ -31,7 +31,7 @@ extern "C" {
  * @note    This type is a struct for hard type checking (let the compiler warn
  *          if int is assigned regularly).
  */
-typedef struct atomic_int {
+typedef struct {
     volatile int value;         /**< the actual value */
 } atomic_int_t;
 

--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -181,7 +181,7 @@ extern "C" {
  * the corresponding fields are never read by the kernel.
  *
  */
-typedef struct msg {
+typedef struct {
     kernel_pid_t sender_pid;    /**< PID of sending thread. Will be filled in
                                      by msg_send. */
     uint16_t type;              /**< Type field. */

--- a/core/include/priority_queue.h
+++ b/core/include/priority_queue.h
@@ -29,8 +29,8 @@
 /**
  * @brief data type for priority queue nodes
  */
-typedef struct priority_queue_node_t {
-    struct priority_queue_node_t *next; /**< next queue node */
+typedef struct priority_queue_node {
+    struct priority_queue_node *next;   /**< next queue node */
     uint32_t priority;                  /**< queue node priority */
     unsigned int data;                  /**< queue node data */
 } priority_queue_node_t;
@@ -38,7 +38,7 @@ typedef struct priority_queue_node_t {
 /**
  * @brief data type for priority queues
  */
-typedef struct queue {
+typedef struct {
     priority_queue_node_t *first;        /**< first queue node */
 } priority_queue_t;
 

--- a/core/include/ringbuffer.h
+++ b/core/include/ringbuffer.h
@@ -27,7 +27,7 @@ extern "C" {
  * @brief     Ringbuffer.
  * @details   Non thread-safe FIFO ringbuffer implementation around a `char` array.
  */
-typedef struct ringbuffer {
+typedef struct {
     char *buf;          /**< Buffer to operate on. */
     unsigned int size;  /**< Size of buf. */
     unsigned int start; /**< Current read position in the ring buffer. */

--- a/sys/include/cbor.h
+++ b/sys/include/cbor.h
@@ -138,7 +138,7 @@ extern "C" {
  * @sa cbor_clear
  * @sa cbor_destroy
  */
-typedef struct cbor_stream_t {
+typedef struct {
     /** Array containing CBOR encoded data */
     unsigned char *data;
     /** Size of the array */

--- a/sys/include/net/fib.h
+++ b/sys/include/net/fib.h
@@ -294,6 +294,7 @@ int fib_sr_set(fib_table_t *table, fib_sr_t *fib_sr, kernel_pid_t *sr_iface_id,
 /**
 * @brief deletes the sr
 *
+* @param[in] table the fib instance to access
 * @param[in, out] fib_sr pointer to the source route to be deleted
 *
 * @return 0 on success
@@ -432,7 +433,7 @@ int fib_sr_entry_get_address(fib_table_t *table, fib_sr_t *fib_sr, fib_sr_entry_
 * @param[out] sr_iface_id pointer to the store the iface_id for this route
 * @param[in, out] sr_flags pointer to store the flags of this route
 * @param[out] addr_list pointer to the location for storing the source route addresses
-* @param[in, out] addr_list_elements the number of elements available in addr_list
+* @param[in, out] addr_list_size the number of elements available in addr_list
 * @param[in, out] element_size the provided size for one element in addr_list
 * @param[in] reverse indicator if the hops should be stored in reverse order
 * @param[in, out] fib_sr pointer for cosecutive receiving matching source routes.

--- a/sys/include/net/fib.h
+++ b/sys/include/net/fib.h
@@ -37,7 +37,7 @@ extern "C" {
 /**
  * @brief Routing Protocol (RP) message content to request/reply notification
  */
-typedef struct rp_address_msg_t {
+typedef struct {
     uint8_t *address;      /**< The pointer to the address */
     uint8_t address_size;  /**< The address size */
     uint32_t address_flags; /**< The flags for the given address */
@@ -62,7 +62,7 @@ typedef struct rp_address_msg_t {
 /**
  * @brief entry used to collect available destinations
  */
-typedef struct fib_destination_set_entry_t {
+typedef struct {
     uint8_t dest[UNIVERSAL_ADDRESS_SIZE]; /**< The destination address */
     size_t dest_size;    /**< The destination address size */
 } fib_destination_set_entry_t;

--- a/sys/include/net/fib/table.h
+++ b/sys/include/net/fib/table.h
@@ -93,12 +93,12 @@ typedef struct {
 } fib_sr_meta_t;
 
 /**
-* @breif FIB table type for single hop entries
+* @brief FIB table type for single hop entries
 */
 #define FIB_TABLE_TYPE_SH (1)
 
 /**
-* @breif FIB table type for source routes
+* @brief FIB table type for source routes
 */
 #define FIB_TABLE_TYPE_SR (FIB_TABLE_TYPE_SH + 1)
 

--- a/sys/include/net/fib/table.h
+++ b/sys/include/net/fib/table.h
@@ -38,7 +38,7 @@ extern "C" {
 /**
  * @brief Container descriptor for a FIB entry
  */
-typedef struct fib_entry_t {
+typedef struct {
     /** interface ID */
     kernel_pid_t iface_id;
     /** Lifetime of this entry (an absolute time-point is stored by the FIB) */
@@ -46,27 +46,27 @@ typedef struct fib_entry_t {
     /** Unique identifier for the type of the global address */
     uint32_t global_flags;
     /** Pointer to the shared generic address */
-    struct universal_address_container_t *global;
+    universal_address_container_t *global;
     /** Unique identifier for the type of the next hop address */
     uint32_t next_hop_flags;
     /** Pointer to the shared generic address */
-    struct universal_address_container_t *next_hop;
+    universal_address_container_t *next_hop;
 } fib_entry_t;
 
 /**
 * @brief Container descriptor for a FIB source route entry
 */
-typedef struct fib_sr_entry_t {
+typedef struct fib_sr_entry {
     /** Pointer to the shared generic address */
-    struct universal_address_container_t *address;
+    universal_address_container_t *address;
     /** Pointer to the next shared generic address on the source route */
-    struct fib_sr_entry_t *next;
+    struct fib_sr_entry *next;
 } fib_sr_entry_t;
 
 /**
 * @brief Container descriptor for a FIB source route
 */
-typedef struct fib_sr_t {
+typedef struct {
     /** interface ID */
     kernel_pid_t sr_iface_id;
     /** Lifetime of this entry (an absolute time-point is stored by the FIB) */
@@ -74,16 +74,16 @@ typedef struct fib_sr_t {
     /** Flags for this source route */
     uint32_t sr_flags;
     /** Pointer to the first hop on the source route */
-    struct fib_sr_entry_t *sr_path;
+    fib_sr_entry_t *sr_path;
     /** Pointer to the destination of the source route */
-    struct fib_sr_entry_t *sr_dest;
+    fib_sr_entry_t *sr_dest;
 } fib_sr_t;
 
 /**
 * @brief Container for one FIB source route table,
 *        combining source routes and an entry pool
 */
-typedef struct fib_sr_meta_t {
+typedef struct {
     /** pointer to source route header array */
     fib_sr_t *headers;
     /** pointer to entry pool array holding all hop entries for this table */

--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -34,8 +34,8 @@ extern "C" {
 /**
  * @brief   SAUL registry entry
  */
-typedef struct saul_reg_t {
-    struct saul_reg_t *next;        /**< pointer to the next device */
+typedef struct saul_reg {
+    struct saul_reg *next;          /**< pointer to the next device */
     void *dev;                      /**< pointer to the device descriptor */
     const char *name;               /**< string identifier for the device */
     saul_driver_t const *driver;    /**< the devices read callback */

--- a/sys/include/universal_address.h
+++ b/sys/include/universal_address.h
@@ -56,7 +56,7 @@ extern "C" {
 /**
  * @brief The container descriptor used to identify a universal address entry
  */
-typedef struct universal_address_container_t {
+typedef struct {
     uint8_t use_count;                       /**< The number of entries link here */
     uint8_t address_size;                    /**< Size in bytes of the used generic address */
     uint8_t address[UNIVERSAL_ADDRESS_SIZE]; /**< The generic address data */

--- a/sys/net/routing/nhdp/iib_table.h
+++ b/sys/net/routing/nhdp/iib_table.h
@@ -33,7 +33,7 @@ extern "C" {
 /**
  * @brief   Possible L_STATUS values of a link tuple
  */
-typedef enum iib_link_tuple_status_t {
+typedef enum {
     IIB_LT_STATUS_PENDING,
     IIB_LT_STATUS_LOST,
     IIB_LT_STATUS_HEARD,
@@ -44,7 +44,7 @@ typedef enum iib_link_tuple_status_t {
 /**
  * @brief   Link Set entry (link tuple)
  */
-typedef struct iib_link_set_entry_t {
+typedef struct iib_link_set_entry {
     nhdp_addr_entry_t *address_list_head;       /**< Pointer to head of this tuple's addresses */
     timex_t heard_time;                         /**< Time at which entry leaves heard status */
     timex_t sym_time;                           /**< Time at which entry leaves symmetry status */
@@ -52,7 +52,7 @@ typedef struct iib_link_set_entry_t {
     uint8_t lost;                               /**< Flag whether link is lost */
     timex_t exp_time;                           /**< Time at which entry expires */
     nib_entry_t *nb_elt;                        /**< Pointer to corresponding nb tuple */
-    enum iib_link_tuple_status_t last_status;   /**< Last processed status of link tuple */
+    iib_link_tuple_status_t last_status;        /**< Last processed status of link tuple */
     uint32_t metric_in;                         /**< Metric value for incoming link */
     uint32_t metric_out;                        /**< Metric value for outgoing link */
 #if (NHDP_METRIC == NHDP_LMT_DAT)
@@ -64,29 +64,29 @@ typedef struct iib_link_set_entry_t {
     uint32_t rx_bitrate;                        /**< Incoming Bitrate for this link in Bit/s */
     uint16_t last_seq_no;                       /**< The last received packet sequence number */
 #endif
-    struct iib_link_set_entry_t *next;          /**< Pointer to next list entry */
+    struct iib_link_set_entry *next;            /**< Pointer to next list entry */
 } iib_link_set_entry_t;
 
 /**
  * @brief   2-Hop Set entry (2-Hop tuple)
  */
-typedef struct iib_two_hop_set_entry_t {
-    struct iib_link_set_entry_t *ls_elt;        /**< Pointer to corresponding link tuple */
+typedef struct iib_two_hop_set_entry {
+    iib_link_set_entry_t *ls_elt;               /**< Pointer to corresponding link tuple */
     nhdp_addr_t *th_nb_addr;                    /**< Address of symmetric 2-hop neighbor */
     timex_t exp_time;                           /**< Time at which entry expires */
     uint32_t metric_in;                         /**< Metric value for incoming link */
     uint32_t metric_out;                        /**< Metric value for outgoing link */
-    struct iib_two_hop_set_entry_t *next;       /**< Pointer to next list entry */
+    struct iib_two_hop_set_entry *next;         /**< Pointer to next list entry */
 } iib_two_hop_set_entry_t;
 
 /**
  * @brief   Link set for a registered interface
  */
-typedef struct iib_base_entry_t {
+typedef struct iib_base_entry {
     kernel_pid_t if_pid;                                /**< PID of the interface */
-    struct iib_link_set_entry_t *link_set_head;         /**< Pointer to this if's link tuples */
-    struct iib_two_hop_set_entry_t *two_hop_set_head;   /**< Pointer to this if's 2-hop tuples */
-    struct iib_base_entry_t *next;                      /**< Pointer to next list entry */
+    iib_link_set_entry_t *link_set_head;                /**< Pointer to this if's link tuples */
+    iib_two_hop_set_entry_t *two_hop_set_head;          /**< Pointer to this if's 2-hop tuples */
+    struct iib_base_entry *next;                        /**< Pointer to next list entry */
 } iib_base_entry_t;
 
 /**

--- a/sys/net/routing/nhdp/lib_table.h
+++ b/sys/net/routing/nhdp/lib_table.h
@@ -32,10 +32,10 @@ extern "C" {
 /**
  * @brief   Local Interface Set entry (local interface tuple)
  */
-typedef struct lib_entry_t {
+typedef struct lib_entry {
     kernel_pid_t if_pid;                    /**< PID of the interface's handling thread */
     nhdp_addr_entry_t *if_addr_list_head;   /**< Pointer to head of this interface's addr list */
-    struct lib_entry_t *next;               /**< Pointer to next list entry */
+    struct lib_entry *next;                 /**< Pointer to next list entry */
 } lib_entry_t;
 
 /**

--- a/sys/net/routing/nhdp/nhdp.h
+++ b/sys/net/routing/nhdp/nhdp.h
@@ -88,7 +88,7 @@ extern "C" {
 /**
  * @brief   MANET interface representation
  */
-typedef struct nhdp_if_entry_t {
+typedef struct {
     kernel_pid_t if_pid;                        /**< PID of the interface's handling thread */
     xtimer_t if_timer;                          /**< xtimer used for the periodic signaling */
     timex_t hello_interval;                     /**< Interval time for periodic HELLOs */

--- a/sys/net/routing/nhdp/nhdp_address.h
+++ b/sys/net/routing/nhdp/nhdp_address.h
@@ -26,22 +26,22 @@ extern "C" {
 /**
  * @brief   NHDP address representation
  */
-typedef struct nhdp_addr_t {
+typedef struct nhdp_addr {
     uint8_t *addr;                      /**< Pointer to the address data */
     size_t addr_size;                   /**< Size in bytes of the address */
     uint8_t addr_type;                  /**< AF type for the address */
     uint8_t usg_count;                  /**< Usage count in information bases */
     uint8_t in_tmp_table;               /**< Signals usage in a writers temp table */
     uint16_t tmp_metric_val;            /**< Encoded metric value used during HELLO processing */
-    struct nhdp_addr_t *next;           /**< Pointer to next address (used in central storage) */
+    struct nhdp_addr *next;             /**< Pointer to next address (used in central storage) */
 } nhdp_addr_t;
 
 /**
  * @brief   Container for NHDP address storage in a list
  */
-typedef struct nhdp_addr_entry_t {
-    struct nhdp_addr_t *address;        /**< Pointer to NHDP address storage entry */
-    struct nhdp_addr_entry_t *next;     /**< Pointer to the next address list element */
+typedef struct nhdp_addr_entry {
+    struct nhdp_addr *address;          /**< Pointer to NHDP address storage entry */
+    struct nhdp_addr_entry *next;       /**< Pointer to the next address list element */
 } nhdp_addr_entry_t;
 
 /**

--- a/sys/net/routing/nhdp/nib_table.h
+++ b/sys/net/routing/nhdp/nib_table.h
@@ -32,21 +32,21 @@ extern "C" {
 /**
  * @brief   Neighbor Set entry (neighbor tuple)
  */
-typedef struct nib_entry_t {
+typedef struct nib_entry {
     nhdp_addr_entry_t *address_list_head;   /**< Pointer to this tuple's addresses*/
     uint8_t symmetric;                      /**< Flag whether sym link to this nb exists */
     uint32_t metric_in;                     /**< Lowest metric value for incoming link */
     uint32_t metric_out;                    /**< Lowest metric value for outgoing link */
-    struct nib_entry_t *next;               /**< Pointer to next list entry */
+    struct nib_entry *next;                 /**< Pointer to next list entry */
 } nib_entry_t;
 
 /**
  * @brief   Lost Neighbor Set entry (lost neighbor tuple, lnt)
  */
-typedef struct nib_lost_address_entry_t {
+typedef struct nib_lost_address_entry {
     nhdp_addr_t *address;                   /**< Pointer to addr represented by this lnt */
     timex_t expiration_time;                /**< Time at which entry expires */
-    struct nib_lost_address_entry_t *next;  /**< Pointer to next list entry */
+    struct nib_lost_address_entry *next;    /**< Pointer to next list entry */
 } nib_lost_address_entry_t;
 
 /**

--- a/sys/posix/pthread/include/pthread_barrier.h
+++ b/sys/posix/pthread/include/pthread_barrier.h
@@ -54,7 +54,7 @@ typedef struct pthread_barrier_waiting_node
  *            For a zeroed out datum you do not need to call the initializer,
  *            it is enough to set pthread_barrier_t::count.
  */
-typedef struct pthread_barrier
+typedef struct
 {
     struct pthread_barrier_waiting_node *next; /**< The first waiting thread. */
     mutex_t mutex; /**< Mutex to unlock to wake the thread up. */
@@ -66,7 +66,7 @@ typedef struct pthread_barrier
  * @details   RIOT does not need this structure, because it is a single process OS.
  *            This is only here to POSIX compatibility.
  */
-typedef struct pthread_barrierattr
+typedef struct
 {
     int pshared; /**< See pthread_barrierattr_setpshared() and pthread_barrierattr_getpshared(). */
 } pthread_barrierattr_t;

--- a/sys/posix/pthread/include/pthread_cond.h
+++ b/sys/posix/pthread/include/pthread_cond.h
@@ -36,7 +36,7 @@ extern "C" {
 /**
  * @note condition attributes are currently NOT USED in RIOT condition variables
  */
-typedef struct pthread_condattr_t {
+typedef struct {
     /** dumdidum */
     int __dummy;
 } pthread_condattr_t;
@@ -46,7 +46,7 @@ typedef struct pthread_condattr_t {
  *
  * @warning fields are managed by cv functions, don't touch
  */
-typedef struct pthread_cond_t {
+typedef struct {
     priority_queue_t queue; /**< Threads currently waiting to be signaled. */
 } pthread_cond_t;
 
@@ -55,14 +55,14 @@ typedef struct pthread_cond_t {
  * @param[in, out] attr pre-allocated condition attribute variable structure.
  * @return returns 0 on success, an errorcode otherwise.
  */
-int pthread_cond_condattr_init(struct pthread_condattr_t *attr);
+int pthread_cond_condattr_init(pthread_condattr_t *attr);
 
 /**
  * @brief Uninitializes a condition attribute variable object
  * @param[in, out] attr pre-allocated condition attribute variable structure.
  * @return returns 0 on success, an errorcode otherwise.
  */
-int pthread_cond_condattr_destroy(struct pthread_condattr_t *attr);
+int pthread_cond_condattr_destroy(pthread_condattr_t *attr);
 
 /**
  * @brief Get the process-shared attribute in an initialised attributes object referenced by attr
@@ -106,14 +106,14 @@ int pthread_condattr_setclock(pthread_condattr_t *attr, clockid_t clock_id);
  * @param[in] attr pre-allocated condition attribute variable structure.
  * @return returns 0 on success, an errorcode otherwise.
  */
-int pthread_cond_init(struct pthread_cond_t *cond, struct pthread_condattr_t *attr);
+int pthread_cond_init(pthread_cond_t *cond, pthread_condattr_t *attr);
 
 /**
  * @brief Destroy the condition variable cond
  * @param[in, out] cond pre-allocated condition variable structure.
  * @return returns 0 on success, an errorcode otherwise.
  */
-int pthread_cond_destroy(struct pthread_cond_t *cond);
+int pthread_cond_destroy(pthread_cond_t *cond);
 
 /**
  * @brief blocks the calling thread until the specified condition cond is signalled
@@ -121,7 +121,7 @@ int pthread_cond_destroy(struct pthread_cond_t *cond);
  * @param[in, out] mutex pre-allocated mutex variable structure.
  * @return returns 0 on success, an errorcode otherwise.
  */
-int pthread_cond_wait(struct pthread_cond_t *cond, mutex_t *mutex);
+int pthread_cond_wait(pthread_cond_t *cond, mutex_t *mutex);
 
 /**
  * @brief blocks the calling thread until the specified condition cond is signalled
@@ -130,21 +130,21 @@ int pthread_cond_wait(struct pthread_cond_t *cond, mutex_t *mutex);
  * @param[in] abstime pre-allocated timeout.
  * @return returns 0 on success, an errorcode otherwise.
  */
-int pthread_cond_timedwait(struct pthread_cond_t *cond, mutex_t *mutex, const struct timespec *abstime);
+int pthread_cond_timedwait(pthread_cond_t *cond, mutex_t *mutex, const struct timespec *abstime);
 
 /**
  * @brief unblock at least one of the threads that are blocked on the specified condition variable cond
  * @param[in, out] cond pre-allocated condition variable structure.
  * @return returns 0 on success, an errorcode otherwise.
  */
-int pthread_cond_signal(struct pthread_cond_t *cond);
+int pthread_cond_signal(pthread_cond_t *cond);
 
 /**
  * @brief unblock all threads that are currently blocked on the specified condition variable cond
  * @param[in, out] cond pre-allocated condition variable structure.
  * @return returns 0 on success, an errorcode otherwise.
  */
-int pthread_cond_broadcast(struct pthread_cond_t *cond);
+int pthread_cond_broadcast(pthread_cond_t *cond);
 
 #ifdef __cplusplus
 }

--- a/sys/posix/pthread/include/pthread_mutex_attr.h
+++ b/sys/posix/pthread/include/pthread_mutex_attr.h
@@ -85,7 +85,7 @@ extern "C" {
 /**
  * @brief           This type is unused right now, and only exists for POSIX compatibility.
  */
-typedef struct pthread_mutexattr
+typedef struct
 {
     int pshared;    /**< Whether to share the mutex with child processes. */
     int kind;       /**< Type of the mutex. */

--- a/sys/posix/pthread/include/pthread_rwlock.h
+++ b/sys/posix/pthread/include/pthread_rwlock.h
@@ -34,7 +34,7 @@ extern "C" {
  *            E.g. no new readers will get into the critical section
  *            if a writer of the same or a higher priority already waits for the lock.
  */
-typedef struct pthread_rwlock
+typedef struct
 {
     /**
      * @brief     The current amount of reader inside the critical section.
@@ -59,7 +59,7 @@ typedef struct pthread_rwlock
 /**
  * @brief     Internal structure that stores one waiting thread.
  */
-typedef struct __pthread_rwlock_waiter_node {
+typedef struct {
     bool is_writer;                 /**< `false`: reader; `true`: writer */
     thread_t *thread;               /**< waiting thread */
     priority_queue_node_t qnode;    /**< Node to store in `pthread_rwlock_t::queue`. */

--- a/sys/posix/pthread/include/pthread_rwlock_attr.h
+++ b/sys/posix/pthread/include/pthread_rwlock_attr.h
@@ -27,7 +27,7 @@ extern "C" {
  * @brief     Attributes for a new reader/writer lock.
  * @details   The options set in this struct will be ignored by pthread_rwlock_init().
  */
-typedef struct pthread_rwlockattr
+typedef struct
 {
     /**
      * @brief     Whether to share lock with child processes.

--- a/sys/posix/pthread/include/pthread_threading_attr.h
+++ b/sys/posix/pthread/include/pthread_threading_attr.h
@@ -26,7 +26,7 @@ extern "C" {
  * @details   A zeroed out datum is default initiliazed.
  * @see       pthread_create() for further information
  */
-typedef struct pthread_attr
+typedef struct
 {
     uint8_t detached; /**< Start in detached state. */
     char *ss_sp; /**< Stack to use for new thread. */

--- a/sys/posix/pthread/pthread.c
+++ b/sys/posix/pthread/pthread.c
@@ -46,16 +46,16 @@
 
 #include "debug.h"
 
-enum pthread_thread_status {
+typedef enum {
     PTS_RUNNING,
     PTS_DETACHED,
     PTS_ZOMBIE,
-};
+} pthread_thread_status_t;
 
-typedef struct pthread_thread {
+typedef struct {
     kernel_pid_t thread_pid;
 
-    enum pthread_thread_status status;
+    pthread_thread_status_t status;
     kernel_pid_t joining_thread;
     void *returnval;
     bool should_cancel;

--- a/sys/posix/pthread/pthread_cond.c
+++ b/sys/posix/pthread/pthread_cond.c
@@ -26,7 +26,7 @@
 #include "irq.h"
 #include "debug.h"
 
-int pthread_cond_condattr_destroy(struct pthread_condattr_t *attr)
+int pthread_cond_condattr_destroy(pthread_condattr_t *attr)
 {
     if (attr != NULL) {
         DEBUG("pthread_cond_condattr_destroy: currently attributes are not supported.\n");
@@ -35,7 +35,7 @@ int pthread_cond_condattr_destroy(struct pthread_condattr_t *attr)
     return 0;
 }
 
-int pthread_cond_condattr_init(struct pthread_condattr_t *attr)
+int pthread_cond_condattr_init(pthread_condattr_t *attr)
 {
     if (attr != NULL) {
         DEBUG("pthread_cond_condattr_init: currently attributes are not supported.\n");
@@ -76,7 +76,7 @@ int pthread_condattr_setclock(pthread_condattr_t *attr, clockid_t clock_id)
     return 0;
 }
 
-int pthread_cond_init(struct pthread_cond_t *cond, struct pthread_condattr_t *attr)
+int pthread_cond_init(pthread_cond_t *cond, pthread_condattr_t *attr)
 {
     if (attr != NULL) {
         DEBUG("pthread_cond_init: currently attributes are not supported.\n");
@@ -86,13 +86,13 @@ int pthread_cond_init(struct pthread_cond_t *cond, struct pthread_condattr_t *at
     return 0;
 }
 
-int pthread_cond_destroy(struct pthread_cond_t *cond)
+int pthread_cond_destroy(pthread_cond_t *cond)
 {
     pthread_cond_init(cond, NULL);
     return 0;
 }
 
-int pthread_cond_wait(struct pthread_cond_t *cond, mutex_t *mutex)
+int pthread_cond_wait(pthread_cond_t *cond, mutex_t *mutex)
 {
     priority_queue_node_t n;
     n.priority = sched_active_thread->priority;
@@ -118,7 +118,7 @@ int pthread_cond_wait(struct pthread_cond_t *cond, mutex_t *mutex)
     return 0;
 }
 
-int pthread_cond_timedwait(struct pthread_cond_t *cond, mutex_t *mutex, const struct timespec *abstime)
+int pthread_cond_timedwait(pthread_cond_t *cond, mutex_t *mutex, const struct timespec *abstime)
 {
     timex_t now, then, reltime;
 
@@ -135,7 +135,7 @@ int pthread_cond_timedwait(struct pthread_cond_t *cond, mutex_t *mutex, const st
     return result;
 }
 
-int pthread_cond_signal(struct pthread_cond_t *cond)
+int pthread_cond_signal(pthread_cond_t *cond)
 {
     unsigned old_state = irq_disable();
 
@@ -164,7 +164,7 @@ static int max_prio(int a, int b)
     return (a < 0) ? b : ((a < b) ? a : b);
 }
 
-int pthread_cond_broadcast(struct pthread_cond_t *cond)
+int pthread_cond_broadcast(pthread_cond_t *cond)
 {
     unsigned old_state = irq_disable();
 

--- a/tests/pthread_condition_variable/main.c
+++ b/tests/pthread_condition_variable/main.c
@@ -23,7 +23,7 @@
 #include "thread.h"
 
 static mutex_t mutex = MUTEX_INIT;
-static struct pthread_cond_t cv;
+static pthread_cond_t cv;
 static volatile int is_finished;
 static volatile long count;
 static volatile long expected_value;


### PR DESCRIPTION
Fixes: #1102

Ready for CI set to give Murdock some work. Local test seemd fine.