### PR TITLE
extimer: initial import of an xtimer based event timer

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -516,6 +516,10 @@ ifneq (,$(filter arduino,$(USEMODULE)))
     USEMODULE += xtimer
 endif
 
+ifneq (,$(filter extimer,$(USEMODULE)))
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter xtimer,$(USEMODULE)))
     FEATURES_REQUIRED += periph_timer
 endif

--- a/sys/extimer/Makefile
+++ b/sys/extimer/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/extimer/extimer.c
+++ b/sys/extimer/extimer.c
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include <assert.h>
+
+#include "irq.h"
+#include "utlist.h"
+
+#include "extimer.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+static void _time_next_event(extimer_t *timer);
+static void _callback(void *arg);
+
+uint64_t extimer_get_absolute(uint64_t offset)
+{
+    uint64_t now = xtimer_now64();
+
+    DEBUG("%s(offset=%" PRIu64 ")\n", DEBUG_FUNC, offset);
+
+    DEBUG("%s():%d: entering\n", DEBUG_FUNC, __LINE__);
+    if ((now + offset) < now) { /* handle integer overflow */
+        DEBUG("%s():%d: integer overflow, returning UINT64_MAX\n", DEBUG_FUNC,
+              __LINE__);
+        return UINT64_MAX;
+    }
+    DEBUG("%s():%d: returning %" PRIu64 "\n", DEBUG_FUNC, __LINE__,
+          now + offset);
+    return now + offset;
+}
+
+void extimer_add(extimer_t *timer, extimer_event_t *event, kernel_pid_t pid)
+{
+    DEBUG("%s(timer=%p, event=%p, pid=%" PRIkernel_pid ")\n", DEBUG_FUNC,
+          (void *)timer, (void *)event, pid);
+    assert(timer);
+    assert(event->next == NULL);
+    assert(pid != KERNEL_PID_UNDEF);
+    DEBUG("%s():%d: entering mutex[%p]\n", DEBUG_FUNC, __LINE__,
+          (void *)&timer->mutex);
+    mutex_lock(&timer->mutex);
+    event->msg.sender_pid = pid;    /* use msg_t::sender_pid to store receiver
+                                     * until actual sending */
+    if (timer->events == NULL) {
+        DEBUG("%s():%d: no events in current timer, schedule immediately at %"
+              PRIu64 " usec\n", DEBUG_FUNC, __LINE__, event->time);
+        timer->events = event;
+        _time_next_event(timer);
+    }
+    else {
+        extimer_event_t *ptr = NULL, *tmp = timer->events;
+        while ((tmp != NULL) && (tmp->time <= event->time)) {
+            if (event == tmp) {   /* check rest of the list for identities to event */
+                DEBUG("%s():%d: event already scheduled. Doing nothing\n",
+                      DEBUG_FUNC, __LINE__);
+                mutex_unlock(&timer->mutex);
+                DEBUG("%s():%d: exiting mutex[%p]\n", DEBUG_FUNC, __LINE__,
+                      (void *)&timer->mutex);
+                return;
+            }
+            ptr = tmp;
+            tmp = tmp->next;
+        }
+        if (ptr == NULL) {  /* replace head */
+            DEBUG("%s():%d: schedule immediately at %" PRIu64 " usec\n",
+                  DEBUG_FUNC, __LINE__, event->time);
+            event->next = timer->events;
+            timer->events = event;
+            _time_next_event(timer);
+        }
+        else {
+            DEBUG("%s():%d: schedule later\n", DEBUG_FUNC, __LINE__);
+            list_add((list_node_t *)ptr, (list_node_t *)event);
+        }
+    }
+    mutex_unlock(&timer->mutex);
+    DEBUG("%s():%d: exiting mutex[%p]\n", DEBUG_FUNC, __LINE__,
+          (void *)&timer->mutex);
+}
+
+extimer_event_t *extimer_del(extimer_t *timer, extimer_event_t *event)
+{
+    extimer_event_t *res = NULL;
+    unsigned state;
+
+    DEBUG("%s(timer=%p, event=%p)\n", DEBUG_FUNC, (void *)timer, (void *)event);
+    assert(timer != NULL);
+    assert(event != NULL);
+
+    DEBUG("%s():%d: entering mutex[%p]\n", DEBUG_FUNC, __LINE__,
+          (void *)&timer->mutex);
+    mutex_lock(&timer->mutex);      /* lock mutex to wait for threads that might
+                                     * still use the timer */
+    DEBUG("%s():%d: disabling IRQ\n", DEBUG_FUNC, __LINE__);
+    state = irq_disable();          /* disable IRQ to not fire timer during
+                                     * deletion */
+    if (timer->events == event) {
+        DEBUG("%s():%d: removing currently scheduled event\n", DEBUG_FUNC,
+              __LINE__);
+        xtimer_remove(&timer->timer);
+        timer->events = timer->events->next;    /* remove head */
+        res = event;
+        _time_next_event(timer);
+    }
+    else {
+        extimer_event_t *ptr = timer->events;
+        while ((ptr->next != NULL) && (ptr->next != event)) {
+            ptr = ptr->next;
+        }
+        if (ptr->next) {
+            DEBUG("%s():%d: removing event further down the line\n",
+                  DEBUG_FUNC, __LINE__);
+            res = ptr->next;
+            ptr->next = event->next;
+        }
+#if ENABLE_DEBUG
+        else {
+            DEBUG("%s():%d: event not found\n", DEBUG_FUNC, __LINE__);
+        }
+#endif
+    }
+    irq_restore(state);
+    DEBUG("%s():%d: restoring IRQ 0x%08x\n", DEBUG_FUNC, __LINE__, state);
+    mutex_unlock(&timer->mutex);    /* unlock mutex */
+    DEBUG("%s():%d: exiting mutex[%p]\n", DEBUG_FUNC, __LINE__,
+          (void *)&timer->mutex);
+    return res;
+}
+
+static void _callback(void *arg)
+{
+    extimer_t *timer = (extimer_t *)arg;
+
+    assert(timer);
+    extimer_event_t *event = extimer_del(timer, timer->events);
+    assert(event);
+    msg_send_int(&event->msg, event->msg.sender_pid);
+}
+
+static void _time_next_event(extimer_t *timer)
+{
+    extimer_event_t *event = timer->events;
+    uint64_t offset, now;
+
+    if (event == NULL) {
+        return;
+    }
+    now = xtimer_now(); /* check for past events */
+    if (event->time <= now) {
+        offset = 0;
+    }
+    else {
+        offset = event->time - now;
+    }
+    timer->timer.callback = _callback;
+    timer->timer.arg = (void *)timer;
+    mutex_unlock(&timer->mutex);    /*  in case it fires immediately */
+    DEBUG("%s():%d: exiting mutex[%p]\n", DEBUG_FUNC, __LINE__,
+          (void *)&timer->mutex);
+    DEBUG("%s():%d: Setting timer %p to fire in %" PRIu64 " usec\n", DEBUG_FUNC,
+          __LINE__, (void *)timer, offset);
+    _xtimer_set64(&timer->timer, offset, offset >> 32);
+    DEBUG("%s():%d: entering mutex[%p]\n", DEBUG_FUNC, __LINE__,
+          (void *)&timer->mutex);
+    mutex_lock(&timer->mutex);
+}
+
+
+/** @} */

--- a/sys/extimer/extimer.c
+++ b/sys/extimer/extimer.c
@@ -28,19 +28,20 @@ static void _callback(void *arg);
 
 uint64_t extimer_get_absolute(uint64_t offset)
 {
-    uint64_t now = xtimer_now64();
+    const uint64_t now = xtimer_now64();
+    const uint64_t res = now + offset;
 
     DEBUG("%s(offset=%" PRIu64 ")\n", DEBUG_FUNC, offset);
 
     DEBUG("%s():%d: entering\n", DEBUG_FUNC, __LINE__);
-    if ((now + offset) < now) { /* handle integer overflow */
+    if (res < now) { /* handle integer overflow */
         DEBUG("%s():%d: integer overflow, returning UINT64_MAX\n", DEBUG_FUNC,
               __LINE__);
         return UINT64_MAX;
     }
     DEBUG("%s():%d: returning %" PRIu64 "\n", DEBUG_FUNC, __LINE__,
-          now + offset);
-    return now + offset;
+          res);
+    return res;
 }
 
 void extimer_add(extimer_t *timer, extimer_event_t *event, kernel_pid_t pid)

--- a/sys/include/extimer.h
+++ b/sys/include/extimer.h
@@ -89,10 +89,11 @@ uint64_t extimer_get_absolute(uint64_t offset);
  *
  * Event fires immediately if its time is in the past.
  *
+ * @pre timer != NULL
  * @pre extimer_event_t::next of event needs to be NULL.
  * @pre pid != KERNEL_PID_UNDEF
  *
- * @param[in] timer A timer.
+ * @param[in] timer A timer. Must not be NULL.
  * @param[in] event An event. extimer_event_t::next must be NULL.
  * @param[in] pid   PID of the event handler thread.
  */
@@ -101,8 +102,11 @@ void extimer_add(extimer_t *timer, extimer_event_t *event, kernel_pid_t pid);
 /**
  * @brief   Removes an existing event from a timer
  *
- * @param[in] timer A timer.
- * @param[in] event An event.
+ * @pre timer != NULL
+ * @pre event != NULL
+ *
+ * @param[in] timer A timer. Must not be NULL.
+ * @param[in] event An event. Must not be NULL.
  *
  * @return  The removed event.
  * @return  NULL, if event list of @p timer was empty.

--- a/sys/include/extimer.h
+++ b/sys/include/extimer.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2016 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_extimer Timer for time-based events
+ * @ingroup     sys_xtimer
+ * @brief       Allows for multiple IPC-based events to be handled with one
+ *              @ref xtimer_t
+ *
+ * This timer **is not** to be used for time-*critical* applications.
+ * However, for applications with tolerances from multiple 10 microseconds this
+ * timer is suitable.
+ *
+ * @{
+ *
+ * @file
+ * @brief   extimer definitions.
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+#ifndef EXTIMER_H_
+#define EXTIMER_H_
+
+#include <stdint.h>
+
+#include "kernel_types.h"
+#include "list.h"
+#include "msg.h"
+#include "mutex.h"
+#include "xtimer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Type to represent an event
+ */
+typedef struct extimer_event {
+    struct extimer_event *next; /**< next event for this timer */
+    msg_t msg;                  /**< message to be used for the event */
+    uint64_t time;              /**< absolute time in microseconds */
+} extimer_event_t;
+
+/**
+ * @brief   Event timer
+ */
+typedef struct {
+    extimer_event_t *events;    /**< future events */
+    mutex_t mutex;              /**< mutex */
+    xtimer_t timer;             /**< the timer */
+} extimer_t;
+
+/**
+ * @brief   Initilizes event timer
+ *
+ * @param[in] timer A timer.
+ */
+static inline void extimer_init(extimer_t *timer)
+{
+    timer->events = NULL;
+    mutex_init(&timer->mutex);
+    timer->timer.target = 0;
+    timer->timer.long_target = 0;
+}
+
+/**
+ * @brief   Get's absolute time in @p offset microseconds
+ *
+ * @see @ref xtimer_now64()
+ *
+ * In case of an integer overflow the function returns UINT64_MAX.
+ *
+ * @param[in] offset    The offset from the current absolute time.
+ *
+ * @return  The time in @p offset microseconds.
+ * @return  UINT64_MAX in case of if the time in @p offset microseconds is
+ *          is greater than UINT64_MAX.
+ */
+uint64_t extimer_get_absolute(uint64_t offset);
+
+/**
+ * @brief   Adds a new event to a timer
+ *
+ * Event fires immediately if its time is in the past.
+ *
+ * @pre extimer_event_t::next of event needs to be NULL.
+ * @pre pid != KERNEL_PID_UNDEF
+ *
+ * @param[in] timer A timer.
+ * @param[in] event An event. extimer_event_t::next must be NULL.
+ * @param[in] pid   PID of the event handler thread.
+ */
+void extimer_add(extimer_t *timer, extimer_event_t *event, kernel_pid_t pid);
+
+/**
+ * @brief   Removes an existing event from a timer
+ *
+ * @param[in] timer A timer.
+ * @param[in] event An event.
+ *
+ * @return  The removed event.
+ * @return  NULL, if event list of @p timer was empty.
+ */
+extimer_event_t *extimer_del(extimer_t *timer, extimer_event_t *event);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EXTIMER_H_ */
+/** @} */

--- a/tests/extimer/Makefile
+++ b/tests/extimer/Makefile
@@ -1,0 +1,11 @@
+APPLICATION = extimer
+include ../Makefile.tests_common
+
+USEMODULE += extimer
+
+CFLAGS += -DDEVELHELP
+
+test:
+	tests/01-run.py
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/extimer/main.c
+++ b/tests/extimer/main.c
@@ -37,7 +37,8 @@ static void reset(void)
 static void test_extimer_add(void)
 {
     msg_t msg;
-    uint32_t start;
+    uint32_t start = 0; /* will be overwritten but is here to silence pedantic
+                         * compilers */
     int i;
 
     for (i = 0; i < EVENT_NUM; i++) {
@@ -64,7 +65,8 @@ static void test_extimer_add(void)
 static void test_extimer_del(void)
 {
     msg_t msg;
-    uint32_t start;
+    uint32_t start = 0; /* will be overwritten but is here to silence pedantic
+                         * compilers */
     int i;
 
     for (i = 0; i < EVENT_NUM; i++) {
@@ -90,7 +92,8 @@ static void test_extimer_del(void)
 static void test_extimer_add_reverse(void)
 {
     msg_t msg;
-    uint32_t start;
+    uint32_t start = 0; /* will be overwritten but is here to silence pedantic
+                         * compilers */
     int i;
 
     for (i = (EVENT_NUM - 1); i >= 0; i--) {

--- a/tests/extimer/main.c
+++ b/tests/extimer/main.c
@@ -21,8 +21,9 @@
 #include "sched.h"
 #include "xtimer.h"
 
-#define EVENT_TEST  (0x5555)
-#define EVENT_NUM   (8)
+#define TIME_MULTIPLIER (1000)
+#define EVENT_TEST      (0x5555)
+#define EVENT_NUM       (8)
 
 msg_t msg_queue[EVENT_NUM];
 extimer_event_t events[EVENT_NUM];
@@ -43,7 +44,7 @@ static void test_extimer_add(void)
 
     for (i = 0; i < EVENT_NUM; i++) {
         events[i].msg.type = EVENT_TEST;
-        events[i].time = extimer_get_absolute(1000 * i);
+        events[i].time = extimer_get_absolute(TIME_MULTIPLIER * i);
         if (i == 0) {
             start = xtimer_now();
         }
@@ -54,7 +55,8 @@ static void test_extimer_add(void)
         }
     }
     i = 0;
-    while (xtimer_msg_receive_timeout(&msg, (EVENT_NUM + 1) * 1000) >= 0) {
+    while (xtimer_msg_receive_timeout(&msg,
+                                      (EVENT_NUM + 1) * TIME_MULTIPLIER) >= 0) {
         if ((msg.type == EVENT_TEST)) {
             printf("event %i received after %u us\n", i++,
                    (unsigned)(xtimer_now() - start));
@@ -71,14 +73,15 @@ static void test_extimer_del(void)
 
     for (i = 0; i < EVENT_NUM; i++) {
         events[i].msg.type = EVENT_TEST;
-        events[i].time = extimer_get_absolute(1000 * i);
+        events[i].time = extimer_get_absolute(TIME_MULTIPLIER * i);
         if (i == 0) {
             start = xtimer_now();
         }
         extimer_add(&timer, &events[i], sched_active_pid);
     }
     i = 0;
-    while (xtimer_msg_receive_timeout(&msg, (EVENT_NUM + 1) * 1000) >= 0) {
+    while (xtimer_msg_receive_timeout(&msg,
+                                      (EVENT_NUM + 1) * TIME_MULTIPLIER) >= 0) {
         if (msg.type == EVENT_TEST) {
             printf("event %i received after %u us\n", i++,
                    (unsigned)(xtimer_now() - start));
@@ -98,14 +101,15 @@ static void test_extimer_add_reverse(void)
 
     for (i = (EVENT_NUM - 1); i >= 0; i--) {
         events[i].msg.type = EVENT_TEST;
-        events[i].time = extimer_get_absolute(1000 * i);
+        events[i].time = extimer_get_absolute(TIME_MULTIPLIER * i);
         if (i == 0) {
             start = xtimer_now();
         }
         extimer_add(&timer, &events[i], sched_active_pid);
     }
     i = 0;
-    while (xtimer_msg_receive_timeout(&msg, (EVENT_NUM + 1) * 1000) >= 0) {
+    while (xtimer_msg_receive_timeout(&msg,
+                                      (EVENT_NUM + 1) * TIME_MULTIPLIER) >= 0) {
         if ((msg.type == EVENT_TEST)) {
             printf("event %i received after %u us\n", i++,
                    (unsigned)(xtimer_now() - start));

--- a/tests/extimer/main.c
+++ b/tests/extimer/main.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "extimer.h"
+#include "msg.h"
+#include "sched.h"
+#include "xtimer.h"
+
+#define EVENT_TEST  (0x5555)
+#define EVENT_NUM   (8)
+
+msg_t msg_queue[EVENT_NUM];
+extimer_event_t events[EVENT_NUM];
+extimer_t timer;
+
+static void reset(void)
+{
+    memset(events, 0, sizeof(events));
+    extimer_init(&timer);
+}
+
+static void test_extimer_add(void)
+{
+    msg_t msg;
+    uint32_t start;
+    int i;
+
+    for (i = 0; i < EVENT_NUM; i++) {
+        events[i].msg.type = EVENT_TEST;
+        events[i].time = extimer_get_absolute(1000 * i);
+        if (i == 0) {
+            start = xtimer_now();
+        }
+        extimer_add(&timer, &events[i], sched_active_pid);
+        if (i != 0) {
+            /* test duplicate detection for non-immediate events */
+            extimer_add(&timer, &events[i], sched_active_pid);
+        }
+    }
+    i = 0;
+    while (xtimer_msg_receive_timeout(&msg, (EVENT_NUM + 1) * 1000) >= 0) {
+        if ((msg.type == EVENT_TEST)) {
+            printf("event %i received after %u us\n", i++,
+                   (unsigned)(xtimer_now() - start));
+        }
+    }
+}
+
+static void test_extimer_del(void)
+{
+    msg_t msg;
+    uint32_t start;
+    int i;
+
+    for (i = 0; i < EVENT_NUM; i++) {
+        events[i].msg.type = EVENT_TEST;
+        events[i].time = extimer_get_absolute(1000 * i);
+        if (i == 0) {
+            start = xtimer_now();
+        }
+        extimer_add(&timer, &events[i], sched_active_pid);
+    }
+    i = 0;
+    while (xtimer_msg_receive_timeout(&msg, (EVENT_NUM + 1) * 1000) >= 0) {
+        if (msg.type == EVENT_TEST) {
+            printf("event %i received after %u us\n", i++,
+                   (unsigned)(xtimer_now() - start));
+            if (extimer_del(&timer, timer.events) != NULL) {
+                i++;
+            }
+        }
+    }
+}
+
+static void test_extimer_add_reverse(void)
+{
+    msg_t msg;
+    uint32_t start;
+    int i;
+
+    for (i = (EVENT_NUM - 1); i >= 0; i--) {
+        events[i].msg.type = EVENT_TEST;
+        events[i].time = extimer_get_absolute(1000 * i);
+        if (i == 0) {
+            start = xtimer_now();
+        }
+        extimer_add(&timer, &events[i], sched_active_pid);
+    }
+    i = 0;
+    while (xtimer_msg_receive_timeout(&msg, (EVENT_NUM + 1) * 1000) >= 0) {
+        if ((msg.type == EVENT_TEST)) {
+            printf("event %i received after %u us\n", i++,
+                   (unsigned)(xtimer_now() - start));
+        }
+    }
+}
+
+int main(void)
+{
+    msg_init_queue(msg_queue, EVENT_NUM);
+    reset();
+    puts("Test extimer_add()");
+    test_extimer_add();
+    reset();
+    puts("Test extimer_add() (reversed order)");
+    test_extimer_add_reverse();
+    reset();
+    puts("Test extimer_del()");
+    test_extimer_del();
+    puts("ALL TESTS SUCCESSFUL");
+}
+
+/** @} */

--- a/tests/extimer/tests/01-run.py
+++ b/tests/extimer/tests/01-run.py
@@ -13,12 +13,14 @@ sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
 EVENT_NUM = 8
+TIME_MULTIPLIER = 1000
 
 def check_time(child, i):
     child.expect(r"event %d received after (\d+) us" % i)
     time = int(child.match.groups(1)[0])
 
-    assert((time > (1000 * i) - 250) and (time < (1000 * i) + 200))
+    assert((time > (TIME_MULTIPLIER * i) - 250) and \
+           (time < (TIME_MULTIPLIER * i) + 200))
 
 def testfunc(child):
     child.expect_exact("Test extimer_add()")

--- a/tests/extimer/tests/01-run.py
+++ b/tests/extimer/tests/01-run.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+EVENT_NUM = 8
+
+def check_time(child, i):
+    child.expect(r"event %d received after (\d+) us" % i)
+    time = int(child.match.groups(1)[0])
+
+    assert((time > (1000 * i) - 150) and (time < (1000 * i) + 150))
+
+def testfunc(child):
+    child.expect_exact("Test extimer_add()")
+    for i in range(EVENT_NUM):
+        check_time(child, i)
+    child.expect_exact("Test extimer_add() (reversed order)")
+    for i in range(EVENT_NUM):
+        check_time(child, i)
+    child.expect_exact("Test extimer_del()")
+    for i in range(0, EVENT_NUM, 2):
+        check_time(child, i)
+    child.expect_exact("ALL TESTS SUCCESSFUL")
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/extimer/tests/01-run.py
+++ b/tests/extimer/tests/01-run.py
@@ -18,7 +18,7 @@ def check_time(child, i):
     child.expect(r"event %d received after (\d+) us" % i)
     time = int(child.match.groups(1)[0])
 
-    assert((time > (1000 * i) - 150) and (time < (1000 * i) + 150))
+    assert((time > (1000 * i) - 250) and (time < (1000 * i) + 200))
 
 def testfunc(child):
     child.expect_exact("Test extimer_add()")


### PR DESCRIPTION
First of many new features to clean-up NDP in GNRC.

This PR introduces a new kind of timer that is purely for (IPC-based) event management. I see 3 main advantages to a timer for each event type (which would be the alternative for NDP at least):

1. **Multiple events of one type able to schedule:** allows for better readable implementations of RFC sentences like "[`[…] a host SHOULD transmit up to MAX_RTR_SOLICITATIONS Router Solicitation messages, each separated by at least RTR_SOLICITATION_INTERVAL seconds.`](https://tools.ietf.org/html/rfc4861#section-6.3.7)"
2. **Overall less RAM usage for multiple event types:** compare
  - 1 `xtimer` per event: `sizeof(xtimer_t)` + `sizeof(msg_t)` = 28 bytes for each event type against
  - with `extimer`: `sizeof(extimer)` overhead (28 byte), but only 20 bytes for each event.
  
  So with more then 4 events we start saving RAM. We hit this number easily with NDP, since every message format (RS, RA, NS, NA) would result in at least one event type + things like registration times for addresses, validity times for prefixes etc.
3. **Scheduling decisions based on future events:** allowing for easier rate-limiting of certain packets or prevention of sending out unneeded packets (since another is scheduled already at a very close time interval [i.e. behavior as described in https://tools.ietf.org/html/rfc4861#section-6.2.6]) 

I am aware that this solution isn't suitable for very time-critical applications. But the difference that is observed (up to 150 us) should still be sufficient for NDP.

*edited*