### PR TITLE
core: allow DEBUG in mutex.c to run without DEVELHELP

### DIFF
--- a/core/mutex.c
+++ b/core/mutex.c
@@ -40,18 +40,21 @@
 int _mutex_lock(mutex_t *mutex, int blocking)
 {
     unsigned irqstate = irq_disable();
+
     DEBUG("PID[%" PRIkernel_pid "]: Mutex in use.\n", sched_active_pid);
 
     if (mutex->queue.next == NULL) {
         /* mutex is unlocked. */
         mutex->queue.next = MUTEX_LOCKED;
-        DEBUG("PID[%" PRIkernel_pid "]: mutex_wait early out.\n", sched_active_pid);
+        DEBUG("PID[%" PRIkernel_pid "]: mutex_wait early out.\n",
+              sched_active_pid);
         irq_restore(irqstate);
         return 1;
     }
     else if (blocking) {
-        thread_t *me = (thread_t*) sched_active_thread;
-        DEBUG("PID[%" PRIkernel_pid "]: Adding node to mutex queue: prio: %" PRIu32 "\n", sched_active_pid, (uint32_t)me->priority);
+        thread_t *me = (thread_t*)sched_active_thread;
+        DEBUG("PID[%" PRIkernel_pid "]: Adding node to mutex queue: prio: %"
+              PRIu32 "\n", sched_active_pid, (uint32_t)me->priority);
         sched_set_status(me, STATUS_MUTEX_BLOCKED);
         if (mutex->queue.next == MUTEX_LOCKED) {
             mutex->queue.next = (list_node_t*)&me->rq_entry;
@@ -62,7 +65,8 @@ int _mutex_lock(mutex_t *mutex, int blocking)
         }
         irq_restore(irqstate);
         thread_yield_higher();
-        /* we were woken up by scheduler. waker removed us from queue. we have the mutex now. */
+        /* We were woken up by scheduler. Waker removed us from queue.
+         * We have the mutex now. */
         return 1;
     }
     else {
@@ -74,7 +78,9 @@ int _mutex_lock(mutex_t *mutex, int blocking)
 void mutex_unlock(mutex_t *mutex)
 {
     unsigned irqstate = irq_disable();
-    DEBUG("mutex_unlock(): queue.next: 0x%08x pid: %" PRIkernel_pid "\n", (unsigned)mutex->queue.next, sched_active_pid);
+
+    DEBUG("mutex_unlock(): queue.next: 0x%08x pid: %" PRIkernel_pid "\n",
+          (unsigned)mutex->queue.next, sched_active_pid);
 
     if (mutex->queue.next == NULL) {
         /* the mutex was not locked */
@@ -93,7 +99,8 @@ void mutex_unlock(mutex_t *mutex)
 
     thread_t *process = container_of((clist_node_t*)next, thread_t, rq_entry);
 
-    DEBUG("mutex_unlock: waking up waiting thread %" PRIkernel_pid "\n", process->pid);
+    DEBUG("mutex_unlock: waking up waiting thread %" PRIkernel_pid "\n",
+          process->pid);
     sched_set_status(process, STATUS_PENDING);
 
     if (!mutex->queue.next) {
@@ -117,7 +124,8 @@ void mutex_unlock_and_sleep(mutex_t *mutex)
         }
         else {
             list_node_t *next = list_remove_head(&mutex->queue);
-            thread_t *process = container_of((clist_node_t*)next, thread_t, rq_entry);
+            thread_t *process = container_of((clist_node_t*)next, thread_t,
+                                             rq_entry);
             DEBUG("PID[%" PRIkernel_pid "]: waking up waiter.\n", process->pid);
             sched_set_status(process, STATUS_PENDING);
             if (!mutex->queue.next) {
@@ -127,7 +135,7 @@ void mutex_unlock_and_sleep(mutex_t *mutex)
     }
 
     DEBUG("PID[%" PRIkernel_pid "]: going to sleep.\n", sched_active_pid);
-    sched_set_status((thread_t*) sched_active_thread, STATUS_SLEEPING);
+    sched_set_status((thread_t*)sched_active_thread, STATUS_SLEEPING);
     irq_restore(irqstate);
     thread_yield_higher();
 }


### PR DESCRIPTION
Tried to debug something without DEVELHELP and found that `mutex.c` isn't able to run without it. So I replaced thread names with PIDs.