### PR TITLE
dist: testrunner: optionally print traceback

### DIFF
--- a/dist/tools/testrunner/testrunner.py
+++ b/dist/tools/testrunner/testrunner.py
@@ -9,8 +9,9 @@
 
 import os, signal, sys, subprocess
 from pexpect import spawnu, TIMEOUT, EOF
+from traceback import print_tb
 
-def run(testfunc, timeout=10, echo=True):
+def run(testfunc, timeout=10, echo=True, traceback=False):
     env = os.environ.copy()
     child = spawnu("make term", env=env, timeout=timeout)
     if echo:
@@ -26,6 +27,8 @@ def run(testfunc, timeout=10, echo=True):
         testfunc(child)
     except TIMEOUT:
         print("Timeout in expect script")
+        if traceback:
+            print_tb(sys.exc_info()[2])
         return 1
     finally:
         print("")


### PR DESCRIPTION
If the (optional) parameter `traceback` is set to `True`, the traceback will be printed in case of a `TIMEOUT`. This is helpful to find out where the timeout occured.