### PR TITLE
seq: bitwise and instead of mod

### DIFF
--- a/sys/seq/seq.c
+++ b/sys/seq/seq.c
@@ -30,7 +30,7 @@ seq8_t seq8_adds(seq8_t s, uint8_t n, uint8_t space)
         return s;
     }
 
-    return (space == UINT8_MAX) ? (s + n) : (s + n) % (space + 1);
+    return (space == UINT8_MAX) ? (s + n) : ((s + n) & space);
 }
 
 int seq8_compares(seq8_t s1, seq8_t s2, uint8_t space)
@@ -64,7 +64,7 @@ seq16_t seq16_adds(seq16_t s, uint16_t n, uint16_t space)
         return s;
     }
 
-    return (space == UINT16_MAX) ? (s + n) : (s + n) % (space + 1);
+    return (space == UINT16_MAX) ? (s + n) : ((s + n) & space);
 }
 
 int seq16_compares(seq16_t s1, seq16_t s2, uint16_t space)
@@ -98,7 +98,7 @@ seq32_t seq32_adds(seq32_t s, uint32_t n, uint32_t space)
         return s;
     }
 
-    return (space == UINT32_MAX) ? (s + n) : (s + n) % (space + 1);
+    return (space == UINT32_MAX) ? (s + n) : ((s + n) & space);
 }
 
 int seq32_compares(seq32_t s1, seq32_t s2, uint32_t space)
@@ -132,7 +132,7 @@ seq64_t seq64_adds(seq64_t s, uint64_t n, uint64_t space)
         return s;
     }
 
-    return (space == UINT64_MAX) ? (s + n) : (s + n) % (space + 1);
+    return (space == UINT64_MAX) ? (s + n) : ((s + n) & space);
 }
 
 int seq64_compares(seq64_t s1, seq64_t s2, uint64_t space)


### PR DESCRIPTION
`space` is expected to be a power of 2 -1.
`x % y` is the same as `x & (y-1)` if `y` is a power of 2.

This reduces the unittests by about 200 bytes for the samr21-xpro.