### PR TITLE
core/thread_flags: remove superfluous bitarithm.h include

### DIFF
--- a/core/thread_flags.c
+++ b/core/thread_flags.c
@@ -19,7 +19,6 @@
  */
 
 
-#include "bitarithm.h"
 #include "thread_flags.h"
 #include "irq.h"
 #include "thread.h"


### PR DESCRIPTION
The only dependency on `bitarithm.h` was removed in #5200.