### PR TITLE
gnrc_netdev2_ieee802154.c: increase buffer

### DIFF
--- a/sys/include/net/gnrc/netif/hdr.h
+++ b/sys/include/net/gnrc/netif/hdr.h
@@ -36,6 +36,7 @@ extern "C" {
  *          in bytes.
  */
 #define GNRC_NETIF_HDR_L2ADDR_MAX_LEN   (8)
+#define GNRC_NETIF_HDR_L2ADDR_PRINT_LEN (GNRC_NETIF_HDR_L2ADDR_MAX_LEN * 3)
 
 /**
  * @{

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
@@ -89,7 +89,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netdev2_t *gnrc_netdev2)
             gnrc_pktsnip_t *ieee802154_hdr, *netif_hdr;
             gnrc_netif_hdr_t *hdr;
 #if ENABLE_DEBUG
-            char src_str[GNRC_NETIF_HDR_L2ADDR_MAX_LEN];
+            char src_str[GNRC_NETIF_HDR_L2ADDR_PRINT_LEN];
 #endif
             size_t mhr_len = ieee802154_get_frame_hdr_len(pkt->data);
 

--- a/sys/net/gnrc/netif/hdr/gnrc_netif_hdr_print.c
+++ b/sys/net/gnrc/netif/hdr/gnrc_netif_hdr_print.c
@@ -20,7 +20,7 @@
 
 void gnrc_netif_hdr_print(gnrc_netif_hdr_t *hdr)
 {
-    char addr_str[GNRC_NETIF_HDR_L2ADDR_MAX_LEN * 3];
+    char addr_str[GNRC_NETIF_HDR_L2ADDR_PRINT_LEN];
 
     printf("if_pid: %" PRIkernel_pid "  ", hdr->if_pid);
     printf("rssi: %" PRIu8 "  ", hdr->rssi);


### PR DESCRIPTION
While debugging `gnrc_netdev2_ieee802154`, I found that the buffer for printing L2 addresses is too small.
This only increases the buffer for correct printing while debugging.