### PR TITLE
at86rf2xx_netdev: fix broken pending_tx handling

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -109,8 +109,8 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, int count)
     for (int i = 0; i < count; i++, ptr++) {
         /* current packet data + FCS too long */
         if ((len + ptr->iov_len + 2) > AT86RF2XX_MAX_PKT_LENGTH) {
-            printf("[at86rf2xx] error: packet too large (%u byte) to be send\n",
-                   (unsigned)len + 2);
+            DEBUG("[at86rf2xx] error: packet too large (%u byte) to be send\n",
+                  (unsigned)len + 2);
             return -EOVERFLOW;
         }
 #ifdef MODULE_NETSTATS_L2

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -626,11 +626,9 @@ static void _isr(netdev2_t *netdev)
                  state == AT86RF2XX_STATE_BUSY_TX_ARET) {
             /* check for more pending TX calls and return to idle state if
              * there are none */
-            if (dev->pending_tx == 0) {
+            assert(dev->pending_tx != 0);
+            if ((--dev->pending_tx) == 0) {
                 at86rf2xx_set_state(dev, dev->idle_state);
-            }
-            else {
-                dev->pending_tx--;
             }
 
             DEBUG("[at86rf2xx] EVT - TX_END\n");


### PR DESCRIPTION
Currently, `at86rf2xx_netdev` is broken.
The driver will never go into `idle` state, because `dev->pending_tx` is decreased **after** the decision is made whether the device should go to idle or not.
Result: no outgoing packets anymore. Can be tested on the iotlab testbed. ping doesn't work anymore.

The second commit is just a bonus and transforms a `printf` into a `DEBUG`.