### PR TITLE
kinetis: periph/timer support for LPTMR and PIT (rewritten)

### DIFF
--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -48,31 +48,31 @@ extern "C"
 #define CLOCK_BUSCLOCK               (CLOCK_CORECLOCK / 2)
 /** @} */
 
-
 /**
  * @name Timer configuration
  * @{
  */
-#define TIMER_NUMOF                  (1U)
-#define TIMER_0_EN                   1
-#define TIMER_1_EN                   0
-#define TIMER_IRQ_PRIO               1
-#define TIMER_BASE                   PIT
-#define TIMER_MAX_VALUE              (0xffffffff)
-#define TIMER_CLOCK                  CLOCK_CORECLOCK
-#define TIMER_CLKEN()                (SIM->SCGC6 |= (SIM_SCGC6_PIT_MASK))
+#define PIT_NUMOF               (2U)
+#define PIT_CONFIG {                 \
+        {                            \
+            .prescaler_ch = 0,       \
+            .count_ch = 1,           \
+        },                           \
+        {                            \
+            .prescaler_ch = 2,       \
+            .count_ch = 3,           \
+        },                           \
+    }
+#define LPTMR_NUMOF             (0U)
+#define LPTMR_CONFIG {}
+#define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))
 
-/* Timer 0 configuration */
-#define TIMER_0_PRESCALER_CH         0
-#define TIMER_0_COUNTER_CH           1
-#define TIMER_0_ISR                  isr_pit1
-#define TIMER_0_IRQ_CHAN             PIT1_IRQn
+#define PIT_BASECLOCK           (CLOCK_BUSCLOCK)
+#define PIT_CLOCKGATE           (BITBAND_REG32(SIM->SCGC6, SIM_SCGC6_PIT_SHIFT))
+#define PIT_ISR_0               isr_pit1
+#define PIT_ISR_1               isr_pit3
+#define LPTMR_ISR_0             isr_lptmr0
 
-/* Timer 1 configuration */
-#define TIMER_1_PRESCALER_CH         2
-#define TIMER_1_COUNTER_CH           3
-#define TIMER_1_ISR                  isr_pit3
-#define TIMER_1_IRQ_CHAN             PIT3_IRQn
 /** @} */
 
 /**

--- a/boards/mulle/include/board.h
+++ b/boards/mulle/include/board.h
@@ -34,6 +34,35 @@
 #define DISABLE_WDOG    1
 
 /**
+ * @brief   xtimer configuration
+ * @{
+ */
+#if 0
+/* LPTMR xtimer configuration */
+/* WIP, Use PIT for now */
+#define XTIMER_DEV                  (TIMER_LPTMR_DEV(0))
+#define XTIMER_CHAN                 (0)
+/* LPTMR is 16 bits wide */
+#define XTIMER_WIDTH                (16)
+#define XTIMER_BACKOFF              (4)
+#define XTIMER_ISR_BACKOFF          (4)
+#define XTIMER_OVERHEAD             (3)
+#define XTIMER_HZ                   (32768ul)
+#define XTIMER_SHIFT                (0)
+#else
+/* PIT xtimer configuration */
+#define XTIMER_DEV                  (TIMER_PIT_DEV(0))
+#define XTIMER_CHAN                 (0)
+#define XTIMER_WIDTH                (32)
+#define XTIMER_BACKOFF              (40)
+#define XTIMER_ISR_BACKOFF          (40)
+#define XTIMER_OVERHEAD             (30)
+#define XTIMER_HZ                   (1000000ul)
+#define XTIMER_SHIFT                (0)
+#endif
+/** @} */
+
+/**
  * @brief   LED pin definitions and handlers
  * @{
  */

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -61,29 +61,34 @@ extern "C"
  * @name Timer configuration
  * @{
  */
-#define TIMER_NUMOF             (1U)
-#define TIMER_0_EN              1
-#define TIMER_1_EN              0
-#define TIMER_IRQ_PRIO          CPU_DEFAULT_IRQ_PRIO
-#define TIMER_BASE              PIT
-#define TIMER_MAX_VALUE         (0xffffffff)
-#define TIMER_CLOCK             SystemBusClock
-#define TIMER_CLKEN()           (BITBAND_REG32(SIM->SCGC6, SIM_SCGC6_PIT_SHIFT) = 1)
+#define PIT_NUMOF               (2U)
+#define PIT_CONFIG {                 \
+        {                            \
+            .prescaler_ch = 0,       \
+            .count_ch = 1,           \
+        },                           \
+        {                            \
+            .prescaler_ch = 2,       \
+            .count_ch = 3,           \
+        },                           \
+    }
+#define LPTMR_NUMOF             (1U)
+#define LPTMR_CONFIG { \
+        { \
+            .dev = LPTMR0, \
+            .clk_gate = (uint32_t volatile *)BITBAND_REGADDR(SIM->SCGC5, SIM_SCGC5_LPTIMER_SHIFT), \
+            .index = 0, \
+        } \
+    }
+#define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))
 
-/* Timer 0 configuration */
-#define TIMER_0_PRESCALER_CH    0
-#define TIMER_0_COUNTER_CH      1
-#define TIMER_0_ISR             isr_pit1
-#define TIMER_0_IRQ_CHAN        PIT1_IRQn
-
-/* Timer 1 configuration */
-#define TIMER_1_PRESCALER_CH    2
-#define TIMER_1_COUNTER_CH      3
-#define TIMER_1_ISR             isr_pit3
-#define TIMER_1_IRQ_CHAN        PIT3_IRQn
+#define PIT_BASECLOCK           (CLOCK_BUSCLOCK)
+#define PIT_CLOCKGATE           (BITBAND_REG32(SIM->SCGC6, SIM_SCGC6_PIT_SHIFT))
+#define PIT_ISR_0               isr_pit1
+#define PIT_ISR_1               isr_pit3
+#define LPTMR_ISR_0             isr_lptmr0
 
 /** @} */
-
 
 /**
  * @name UART configuration

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -50,33 +50,32 @@ extern "C"
 #define CLOCK_BUSCLOCK                    CLOCK_CORECLOCK
 /** @} */
 
-
 /**
  * @name Timer configuration
  * @{
  */
-#define TIMER_NUMOF                       (1U)
-#define TIMER_0_EN                        1
-#define TIMER_1_EN                        0
-#define TIMER_IRQ_PRIO                    1
-#define TIMER_BASE                        PIT
-#define TIMER_MAX_VALUE                   (0xffffffff)
-#define TIMER_CLOCK                       CLOCK_CORECLOCK
-#define TIMER_CLKEN()                     (SIM->SCGC6 |= (SIM_SCGC6_PIT_MASK))
+#define PIT_NUMOF               (2U)
+#define PIT_CONFIG {                 \
+        {                            \
+            .prescaler_ch = 0,       \
+            .count_ch = 1,           \
+        },                           \
+        {                            \
+            .prescaler_ch = 2,       \
+            .count_ch = 3,           \
+        },                           \
+    }
+#define LPTMR_NUMOF             (0U)
+#define LPTMR_CONFIG {}
+#define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))
 
-/* Timer 0 configuration */
-#define TIMER_0_PRESCALER_CH              0
-#define TIMER_0_COUNTER_CH                1
-#define TIMER_0_ISR                       isr_pit1
-#define TIMER_0_IRQ_CHAN                  PIT1_IRQn
+#define PIT_BASECLOCK           (CLOCK_BUSCLOCK)
+#define PIT_CLOCKGATE           (BITBAND_REG32(SIM->SCGC6, SIM_SCGC6_PIT_SHIFT))
+#define PIT_ISR_0               isr_pit1
+#define PIT_ISR_1               isr_pit3
+#define LPTMR_ISR_0             isr_lptmr0
 
-/* Timer 1 configuration */
-#define TIMER_1_PRESCALER_CH              2
-#define TIMER_1_COUNTER_CH                3
-#define TIMER_1_ISR                       isr_pit3
-#define TIMER_1_IRQ_CHAN                  PIT3_IRQn
 /** @} */
-
 
 /**
  * @name UART configuration

--- a/cpu/kinetis_common/include/periph_cpu.h
+++ b/cpu/kinetis_common/include/periph_cpu.h
@@ -165,6 +165,42 @@ typedef struct {
 } dac_conf_t;
 
 /**
+ * @brief   CPU specific timer PIT module configuration
+ */
+typedef struct {
+    /** Prescaler channel */
+    uint8_t prescaler_ch;
+    /** Counting channel, will be linked to the prescaler channel */
+    uint8_t count_ch;
+} pit_conf_t;
+
+/**
+ * @brief   CPU specific timer LPTMR module configuration
+ */
+typedef struct {
+    /** LPTMR device base pointer */
+    LPTMR_Type *dev;
+    /** Pointer to module clock gate bit in bitband region, use BITBAND_REGADDR() */
+    uint32_t volatile *clk_gate;
+    /** LPTMR device index */
+    uint8_t index;
+} lptmr_conf_t;
+
+/**
+ * @brief   Possible timer module types
+ */
+enum {
+    TIMER_PIT,
+    TIMER_LPTMR,
+};
+
+/**
+ * @brief   Hardware timer type-specific device macros
+ */
+#define TIMER_PIT_DEV(x)   (TIMER_DEV(0 + (x)))
+#define TIMER_LPTMR_DEV(x) (TIMER_DEV(PIT_NUMOF + (x)))
+
+/**
  * @brief   CPU internal function for initializing PORTs
  *
  * @param[in] pin       pin to initialize

--- a/cpu/kinetis_common/periph/timer.c
+++ b/cpu/kinetis_common/periph/timer.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2016 Eistec AB
  * Copyright (C) 2014 Freie Universität Berlin
  * Copyright (C) 2014-2015 PHYTEC Messtechnik GmbH
  *
@@ -17,6 +18,7 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Johann Fischer <j.fischer@phytec.de>
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  *
  * @}
  */
@@ -33,167 +35,627 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-#if TIMER_NUMOF
+#define PIT_MAX_VALUE     (PIT_LDVAL_TSV_MASK >> PIT_LDVAL_TSV_SHIFT)
+#define LPTMR_MAX_VALUE   (LPTMR_CNR_COUNTER_MASK >> LPTMR_CNR_COUNTER_SHIFT)
 
-/* Virtual count up timer */
-static uint32_t cu_timer[TIMER_NUMOF];
+#if TIMER_NUMOF != (PIT_NUMOF + LPTMR_NUMOF)
+#error TIMER_NUMOF should be the total of PIT and LPTMR timers in the system
+#endif
 
-/** Timer state memory */
-static timer_isr_ctx_t config[TIMER_NUMOF];
+/*
+ * The RTC prescaler will normally count to 32767 every second unless configured
+ * otherwise through the time compensation register.
+ */
+#define TIMER_RTC_SUBTICK_MAX (0x7fff)
+/*
+ * Number of bits in the ideal RTC prescaler counter
+ */
+#define TIMER_RTC_SUBTICK_BITS (15)
 
-inline static void pit_timer_start(uint8_t ch)
-{
-    TIMER_BASE->CHANNEL[ch].TCTRL |= (PIT_TCTRL_TEN_MASK);
+/**
+ * @brief  The number of ticks that will be lost when setting a new target in the LPTMR
+ *
+ * The counter will otherwise drop ticks when setting new timeouts.
+ */
+#define LPTMR_RELOAD_OVERHEAD 2
+
+/**
+ * @brief  Base clock frequency of the LPTMR module
+ */
+/* The LPTMR implementation is hard-coded to use ER32KCLK */
+#define LPTMR_BASE_FREQ (32768ul)
+
+/* PIT channel state */
+typedef struct {
+    timer_isr_ctx_t isr_ctx;
+    uint32_t count;
+    uint32_t tctrl;
+    uint32_t ldval;
+} pit_t;
+
+/* LPTMR state */
+typedef struct {
+    timer_isr_ctx_t isr_ctx;
+    uint32_t csr;
+    uint32_t cmr;
+    uint32_t running;
+    uint16_t reference;
+    uint16_t rtt_offset;
+} lptmr_t;
+
+static const pit_conf_t pit_config[PIT_NUMOF] = PIT_CONFIG;
+static const lptmr_conf_t lptmr_config[LPTMR_NUMOF] = LPTMR_CONFIG;
+
+static pit_t pit[PIT_NUMOF];
+static lptmr_t lptmr[LPTMR_NUMOF];
+
+/**
+ * @brief  lvalue accessor for PIT channel enable bit in the bitband region
+ */
+#define PIT_BITBAND_TEN(ch) (BITBAND_REG32(PIT->CHANNEL[ch].TCTRL, PIT_TCTRL_TEN_SHIFT))
+
+/**
+ * @brief  Find out whether a given timer is a LPTMR or a PIT timer
+ */
+static inline unsigned int _timer_variant(tim_t dev) {
+    if ((unsigned int) dev >= PIT_NUMOF) {
+        return TIMER_LPTMR;
+    }
+    else {
+        return TIMER_PIT;
+    }
 }
 
-inline static void pit_timer_stop(uint8_t ch)
+/**
+ * @brief  Find device index in the pit_config array
+ */
+static inline unsigned int _pit_index(tim_t dev) {
+    return ((unsigned int)dev) - TIMER_DEV(0);
+}
+
+/**
+ * @brief  Get TIMER_x enum value from PIT device index
+ */
+static inline tim_t _pit_tim_t(uint8_t dev) {
+    return (tim_t)(((unsigned int)TIMER_DEV(0)) + dev);
+}
+
+/**
+ * @brief  Find device index in the lptmr_config array
+ */
+static inline unsigned int _lptmr_index(tim_t dev) {
+    return ((unsigned int)dev) - TIMER_DEV(0) - PIT_NUMOF;
+}
+
+/**
+ * @brief  Get TIMER_x enum value from LPTMR device index
+ */
+static inline tim_t _lptmr_tim_t(uint8_t dev) {
+    return (tim_t)(((unsigned int)TIMER_DEV(0)) + PIT_NUMOF + dev);
+}
+
+/* ****** PIT module functions ****** */
+
+/* Forward declarations */
+inline static int pit_init(uint8_t dev, uint32_t freq, timer_cb_t cb, void *arg);
+inline static int pit_set(uint8_t dev, uint32_t timeout);
+inline static int pit_set_absolute(uint8_t dev, uint32_t target);
+inline static int pit_clear(uint8_t dev);
+inline static uint32_t pit_read(uint8_t dev);
+inline static void pit_start(uint8_t dev);
+inline static void pit_stop(uint8_t dev);
+inline static void pit_irq_handler(tim_t dev);
+
+inline static void _pit_set_cb_config(uint8_t dev, timer_cb_t cb, void *arg)
 {
-    TIMER_BASE->CHANNEL[ch].TCTRL &= ~(PIT_TCTRL_TEN_MASK);
+    /* set callback function */
+    pit[dev].isr_ctx.cb = cb;
+    pit[dev].isr_ctx.arg = arg;
 }
 
 /** use channel n-1 as prescaler */
-inline static void timer_set_prescaler(uint8_t ch, unsigned long freq)
+inline static void _pit_set_prescaler(uint8_t ch, uint32_t freq)
 {
-    TIMER_BASE->CHANNEL[ch].TCTRL = 0x0;
-    TIMER_BASE->CHANNEL[ch].LDVAL = (TIMER_CLOCK / freq) - 1;
-    TIMER_BASE->CHANNEL[ch].TCTRL = (PIT_TCTRL_TEN_MASK);
+    /* Disable channel completely */
+    PIT->CHANNEL[ch].TCTRL = 0x0;
+    PIT->CHANNEL[ch].LDVAL = (PIT_BASECLOCK / freq) - 1;
+    /* Start the prescaler counter immediately */
+    PIT->CHANNEL[ch].TCTRL = (PIT_TCTRL_TEN_MASK);
 }
 
-inline static void timer_set_counter(uint8_t ch)
+inline static void _pit_set_counter(uint8_t dev)
 {
-    TIMER_BASE->CHANNEL[ch].TCTRL = 0x0;
-    TIMER_BASE->CHANNEL[ch].LDVAL = TIMER_MAX_VALUE;
-    TIMER_BASE->CHANNEL[ch].TCTRL = (PIT_TCTRL_TIE_MASK | PIT_TCTRL_CHN_MASK);
+    const uint8_t ch = pit_config[dev].count_ch;
+    /* Disable channel completely */
+    PIT->CHANNEL[ch].TCTRL = 0x0;
+    PIT->CHANNEL[ch].LDVAL = pit[dev].ldval;
+    PIT->CHANNEL[ch].TFLG = PIT_TFLG_TIF_MASK;
+    /* Restore previous timer state */
+    PIT->CHANNEL[ch].TCTRL = pit[dev].tctrl;
 }
 
-inline static uint32_t pit_timer_read(tim_t dev, uint8_t ch)
+inline static int pit_init(uint8_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
-    return cu_timer[dev] + (TIMER_BASE->CHANNEL[ch].LDVAL
-                            - TIMER_BASE->CHANNEL[ch].CVAL);
+    PIT_CLOCKGATE = 1;
+    /* Completely disable the module before messing with the settings */
+    PIT->MCR = PIT_MCR_MDIS_MASK;
+
+    /* Disable IRQs to avoid race with ISR */
+    unsigned int mask = irq_disable();
+
+    /* Clear configuration */
+    PIT->CHANNEL[pit_config[dev].count_ch].TCTRL = 0;
+
+    /* Freeze timers during debug break, resume normal operations (clear MDIS) */
+    PIT->MCR = PIT_MCR_FRZ_MASK;
+
+    _pit_set_cb_config(dev, cb, arg);
+
+    /* Clear IRQ flag */
+    PIT->CHANNEL[pit_config[dev].count_ch].TFLG = PIT_TFLG_TIF_MASK;
+    /* Refactor the below lines if there are any CPUs where the PIT IRQs are not sequential */
+    NVIC_ClearPendingIRQ(PIT0_IRQn + pit_config[dev].count_ch);
+    NVIC_EnableIRQ(PIT0_IRQn + pit_config[dev].count_ch);
+
+    /* Reset up-counter */
+    pit[dev].count = PIT_MAX_VALUE;
+    pit[dev].ldval = PIT_MAX_VALUE;
+    pit[dev].tctrl = PIT_TCTRL_CHN_MASK | PIT_TCTRL_TEN_MASK;
+    _pit_set_prescaler(pit_config[dev].prescaler_ch, freq);
+    _pit_set_counter(dev);
+
+    irq_restore(mask);
+    return 0;
 }
 
-inline static void pit_timer_set_max(uint8_t ch)
+inline static int pit_set(uint8_t dev, uint32_t timeout)
 {
-    pit_timer_stop(ch);
-    TIMER_BASE->CHANNEL[ch].LDVAL = TIMER_MAX_VALUE;
-    pit_timer_start(ch);
+    const uint8_t ch = pit_config[dev].count_ch;
+    /* Disable IRQs to minimize the number of lost ticks */
+    unsigned int mask = irq_disable();
+    pit[dev].ldval = timeout;
+    pit[dev].tctrl = PIT_TCTRL_TIE_MASK | PIT_TCTRL_CHN_MASK | PIT_TCTRL_TEN_MASK;
+    /* Add the new timeout offset to the up-counter */
+    pit[dev].count += timeout;
+    if (PIT_BITBAND_TEN(ch) != 0) {
+        /* Timer is currently running */
+        uint32_t cval = PIT->CHANNEL[ch].CVAL;
+        /* Subtract if there was anything left on the counter */
+        pit[dev].count -= cval;
+        _pit_set_counter(dev);
+    }
+    irq_restore(mask);
+    return 0;
 }
 
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+inline static int pit_set_absolute(uint8_t dev, uint32_t target)
 {
-    /* enable timer peripheral clock */
-    TIMER_CLKEN();
-
-    TIMER_BASE->MCR = 0;
-    TIMER_BASE->MCR = PIT_MCR_FRZ_MASK;
-
-    switch (dev) {
-#if TIMER_0_EN
-
-        case TIMER_0:
-            NVIC_SetPriority(TIMER_0_IRQ_CHAN, TIMER_IRQ_PRIO);
-            timer_set_prescaler(TIMER_0_PRESCALER_CH, freq);
-            timer_set_counter(TIMER_0_COUNTER_CH);
-            break;
-#endif
-#if TIMER_1_EN
-
-        case TIMER_1:
-            NVIC_SetPriority(TIMER_1_IRQ_CHAN, TIMER_IRQ_PRIO);
-            timer_set_prescaler(TIMER_1_PRESCALER_CH, freq);
-            timer_set_counter(TIMER_1_COUNTER_CH);
-            break;
-#endif
-
-        case TIMER_UNDEFINED:
-        default:
-            return -1;
+    uint8_t ch = pit_config[dev].count_ch;
+    /* Disable IRQs to minimize the number of lost ticks */
+    unsigned int mask = irq_disable();
+    uint32_t now = pit_read(dev);
+    uint32_t offset = target - now;
+    pit[dev].ldval = offset;
+    pit[dev].tctrl = PIT_TCTRL_TIE_MASK | PIT_TCTRL_CHN_MASK | PIT_TCTRL_TEN_MASK;
+    /* Set the new target time in the up-counter */
+    pit[dev].count = target;
+    if (PIT_BITBAND_TEN(ch) != 0) {
+        _pit_set_counter(dev);
     }
 
+    irq_restore(mask);
+    return 0;
+}
+
+inline static int pit_clear(uint8_t dev)
+{
+    uint8_t ch = pit_config[dev].count_ch;
+    /* Disable IRQs to minimize the number of lost ticks */
+    unsigned int mask = irq_disable();
+
+    pit[dev].ldval = PIT_MAX_VALUE;
+    pit[dev].tctrl = PIT_TCTRL_CHN_MASK | PIT_TCTRL_TEN_MASK;
+    /* pit[dev].count += PIT_MAX_VALUE + 1; */ /* == 0 (mod 2**32) */
+
+    if (PIT_BITBAND_TEN(ch) != 0) {
+        /* Timer is currently running */
+        uint32_t cval = PIT->CHANNEL[ch].CVAL;
+        /* Subtract if there was anything left on the counter */
+        pit[dev].count -= cval;
+        /* Set a long timeout */
+        _pit_set_counter(ch);
+    }
+
+    irq_restore(mask);
+    return 0;
+}
+
+inline static uint32_t pit_read(uint8_t dev)
+{
+    uint8_t ch = pit_config[dev].count_ch;
+    if (PIT_BITBAND_TEN(ch) != 0) {
+        /* Timer running */
+        return pit[dev].count - PIT->CHANNEL[ch].CVAL;
+    }
+    else {
+        /* Timer stopped */
+        return pit[dev].count;
+    }
+}
+
+inline static void pit_start(uint8_t dev)
+{
+    uint8_t ch = pit_config[dev].count_ch;
+    if (PIT_BITBAND_TEN(ch) != 0) {
+        /* Already running */
+        return;
+    }
+    PIT->CHANNEL[ch].LDVAL = pit[dev].ldval;
+    pit[dev].count += pit[dev].ldval;
+    PIT->CHANNEL[ch].TCTRL = pit[dev].tctrl;
+}
+
+inline static void pit_stop(uint8_t dev)
+{
+    uint8_t ch = pit_config[dev].count_ch;
+    if (PIT_BITBAND_TEN(ch) == 0) {
+        /* Already stopped */
+        return;
+    }
+    uint32_t cval = PIT->CHANNEL[ch].CVAL;
+    pit[dev].tctrl = PIT->CHANNEL[ch].TCTRL;
+    PIT->CHANNEL[ch].TCTRL = 0;
+    pit[dev].count -= cval;
+    pit[dev].ldval = cval;
+}
+
+inline static void pit_irq_handler(tim_t dev)
+{
+    uint8_t ch = pit_config[_pit_index(dev)].count_ch;
+    pit_t *pit_ctx = &pit[_pit_index(dev)];
+    pit_ctx->ldval = PIT_MAX_VALUE;
+    pit_ctx->count += PIT_MAX_VALUE;
+    pit_ctx->tctrl = PIT_TCTRL_CHN_MASK | PIT_TCTRL_TEN_MASK;
+    _pit_set_counter(_pit_index(dev));
+
+    if (pit_ctx->isr_ctx.cb != NULL) {
+        pit_ctx->isr_ctx.cb(pit_ctx->isr_ctx.arg, 0);
+    }
+
+    PIT->CHANNEL[ch].TFLG = PIT_TFLG_TIF_MASK;
+
+    if (sched_context_switch_request) {
+        thread_yield();
+    }
+}
+
+/* ****** LPTMR module functions ****** */
+
+/* Forward declarations */
+inline static int lptmr_init(uint8_t dev, uint32_t freq, timer_cb_t cb, void *arg);
+inline static int lptmr_set(uint8_t dev, uint16_t timeout);
+inline static int lptmr_set_absolute(uint8_t dev, uint16_t target);
+inline static int lptmr_clear(uint8_t dev);
+inline static uint16_t lptmr_read(uint8_t dev);
+inline static void lptmr_start(uint8_t dev);
+inline static void lptmr_stop(uint8_t dev);
+inline static void lptmr_irq_handler(tim_t tim);
+
+/**
+ * @brief Read the prescaler register from the RTC as a reliable 47 bit time counter
+ */
+inline static uint32_t _rtt_get_subtick(void)
+{
+    uint32_t tpr;
+    uint32_t tsr;
+
+    for (int i = 0; i < 5; i++) {
+        /* Read twice to make sure we get a stable reading */
+        tpr = RTC->TPR & RTC_TPR_TPR_MASK;
+        tsr = RTC->TSR & RTC_TSR_TSR_MASK;
+
+        if ((tsr == (RTC->TSR & RTC_TSR_TSR_MASK)) &&
+            (tpr == (RTC->TPR & RTC_TPR_TPR_MASK))) {
+            break;
+        }
+    }
+    if (tpr > TIMER_RTC_SUBTICK_MAX) {
+        /* This only happens if the RTC time compensation value has been
+         * modified to compensate for RTC drift. See Kinetis ref.manual,
+         *  RTC Time Compensation Register (RTC_TCR).
+         */
+        tpr = TIMER_RTC_SUBTICK_MAX;
+    }
+
+    return (tsr << TIMER_RTC_SUBTICK_BITS) | tpr;
+}
+
+inline static void _lptmr_set_cb_config(uint8_t dev, timer_cb_t cb, void *arg)
+{
     /* set callback function */
-    config[dev].cb = cb;
-    config[dev].arg = arg;
-    cu_timer[dev] = 0;
+    lptmr[dev].isr_ctx.cb = cb;
+    lptmr[dev].isr_ctx.arg = arg;
+}
 
-    /* enable the timer's interrupt */
-    timer_irq_enable(dev);
+/**
+ * @brief  Compute the LPTMR prescaler setting, see reference manual for details
+ */
+inline static int32_t _lptmr_compute_prescaler(uint32_t freq) {
+    uint32_t prescale = 0;
+    if ((freq > LPTMR_BASE_FREQ) || (freq == 0)) {
+        /* Frequency out of range */
+        return -1;
+    }
+    while (freq < LPTMR_BASE_FREQ){
+        ++prescale;
+        freq <<= 1;
+    }
+    if (freq != LPTMR_BASE_FREQ) {
+        /* freq was not a power of two division of LPTMR_BASE_FREQ */
+        return -2;
+    }
+    if (prescale > 0) {
+        /* LPTMR_PSR_PRESCALE == 0 yields LPTMR_BASE_FREQ/2,
+         * LPTMR_PSR_PRESCALE == 1 yields LPTMR_BASE_FREQ/4 etc.. */
+        return LPTMR_PSR_PRESCALE(prescale - 1);
+    }
+    else {
+        /* Prescaler bypass enabled */
+        return LPTMR_PSR_PBYP_MASK;
+    }
+}
 
-    /* start the timer */
-    timer_start(dev);
+/**
+ * @brief  Update the offset between RTT and LPTMR
+ */
+inline static void _lptmr_update_rtt_offset(uint8_t dev)
+{
+    lptmr[dev].rtt_offset = _rtt_get_subtick();
+}
+
+/**
+ * @brief  Update the reference time point (CNR=0)
+ */
+inline static void _lptmr_update_reference(uint8_t dev)
+{
+    lptmr[dev].reference = _rtt_get_subtick() + LPTMR_RELOAD_OVERHEAD - lptmr[dev].rtt_offset;
+}
+
+inline static void _lptmr_set_counter(uint8_t dev)
+{
+    _lptmr_update_reference(dev);
+    LPTMR_Type *hw = lptmr_config[dev].dev;
+    hw->CSR = 0;
+    hw->CMR = lptmr[dev].cmr;
+    /* restore saved state */
+    hw->CSR = lptmr[dev].csr;
+}
+
+inline static int lptmr_init(uint8_t dev, uint32_t freq, timer_cb_t cb, void *arg)
+{
+    int32_t prescale = _lptmr_compute_prescaler(freq);
+    if (prescale < 0) {
+        return -1;
+    }
+    LPTMR_Type *hw = lptmr_config[dev].dev;
+    /* Disable IRQs to avoid race with ISR */
+    unsigned int mask = irq_disable();
+
+    /* Turn on module clock */
+    *lptmr_config[dev].clk_gate = 1;
+    /* Completely disable the module before messing with the settings */
+    hw->CSR = 0;
+    /* select ERCLK32K as clock source for LPTMR */
+    hw->PSR = LPTMR_PSR_PCS(2) | ((uint32_t)prescale);
+
+    /* Clear IRQ flag in case it was already set */
+    hw->CSR = LPTMR_CSR_TCF_MASK;
+    /* Enable IRQs on the counting channel */
+    /* Refactor the below lines if there are any CPUs where the LPTMR IRQs are not sequential */
+    NVIC_ClearPendingIRQ(LPTMR0_IRQn + lptmr_config[dev].index);
+    NVIC_EnableIRQ(LPTMR0_IRQn + lptmr_config[dev].index);
+
+    _lptmr_set_cb_config(dev, cb, arg);
+
+    /* Reset state */
+    _lptmr_update_rtt_offset(dev);
+    lptmr[dev].running = 1;
+    lptmr_clear(dev);
+
+    irq_restore(mask);
 
     return 0;
 }
 
-int timer_set(tim_t dev, int channel, unsigned int timeout)
+inline static uint16_t lptmr_read(uint8_t dev)
 {
-    unsigned int now = timer_read(dev);
-
-    return timer_set_absolute(dev, channel, now + timeout);
+    LPTMR_Type *hw = lptmr_config[dev].dev;
+    /* latch the current timer value into CNR */
+    hw->CNR = 0;
+    return lptmr[dev].reference + hw->CNR;
 }
 
-int timer_set_absolute(tim_t dev, int channel, unsigned int value)
+inline static int lptmr_set(uint8_t dev, uint16_t timeout)
 {
-    uint32_t diff = 0;
+    /* Disable IRQs to minimize jitter */
+    unsigned int mask = irq_disable();
+    lptmr[dev].cmr = timeout;
+    /* Enable interrupt, enable timer */
+    lptmr[dev].csr = LPTMR_CSR_TEN_MASK | LPTMR_CSR_TIE_MASK;
+    if (lptmr[dev].running != 0) {
+        /* Timer is currently running */
+        /* Set new target */
+        _lptmr_set_counter(dev);
+    }
+    irq_restore(mask);
+    return 0;
+}
 
-    /* we only support one channel */
-    if (channel != 0) {
+inline static int lptmr_set_absolute(uint8_t dev, uint16_t target)
+{
+    /* Disable IRQs to minimize jitter */
+    unsigned int mask = irq_disable();
+    uint16_t offset = target - lptmr[dev].reference;
+    lptmr[dev].cmr = offset;
+    /* Enable interrupt, enable timer */
+    lptmr[dev].csr = LPTMR_CSR_TEN_MASK | LPTMR_CSR_TIE_MASK;
+    if (lptmr[dev].running != 0) {
+        /* Timer is currently running */
+        /* Set new target */
+        _lptmr_set_counter(dev);
+    }
+    irq_restore(mask);
+    return 0;
+}
+
+inline static int lptmr_clear(uint8_t dev)
+{
+    /* Disable IRQs to minimize jitter */
+    unsigned int mask = irq_disable();
+    lptmr[dev].cmr = LPTMR_MAX_VALUE;
+    /* Disable interrupt, enable timer */
+    lptmr[dev].csr = LPTMR_CSR_TEN_MASK;
+    if (lptmr[dev].running != 0) {
+        /* Timer is currently running */
+        /* Set new target */
+        _lptmr_set_counter(dev);
+    }
+    irq_restore(mask);
+    return 0;
+}
+
+inline static void lptmr_start(uint8_t dev)
+{
+    if (lptmr[dev].running != 0) {
+        /* Timer already running */
+        return;
+    }
+    lptmr[dev].running = 1;
+    _lptmr_set_counter(dev);
+}
+
+inline static void lptmr_stop(uint8_t dev)
+{
+    if (lptmr[dev].running == 0) {
+        /* Timer already stopped */
+        return;
+    }
+    /* Disable IRQs to avoid race with ISR */
+    unsigned int mask = irq_disable();
+    lptmr[dev].running = 0;
+    LPTMR_Type *hw = lptmr_config[dev].dev;
+    /* latch the current timer value into CNR */
+    hw->CNR = 12345;
+    uint16_t cnr = hw->CNR;
+    lptmr[dev].cmr = hw->CMR - cnr;
+    lptmr[dev].csr = hw->CSR;
+    _lptmr_update_reference(dev);
+    /* Disable counter and clear interrupt flag */
+    hw->CSR = LPTMR_CSR_TCF_MASK;
+    /* Clear any pending IRQ */
+    NVIC_ClearPendingIRQ(LPTMR0_IRQn + lptmr_config[dev].index);
+    irq_restore(mask);
+}
+
+inline static void lptmr_irq_handler(tim_t tim)
+{
+    uint8_t dev = _lptmr_index(tim);
+    LPTMR_Type *hw = lptmr_config[dev].dev;
+    lptmr_t *lptmr_ctx = &lptmr[dev];
+    lptmr_ctx->cmr = LPTMR_MAX_VALUE;
+    _lptmr_set_counter(dev);
+
+    if (lptmr_ctx->isr_ctx.cb != NULL) {
+        lptmr_ctx->isr_ctx.cb(lptmr_ctx->isr_ctx.arg, 0);
+    }
+
+    /* Clear interrupt flag */
+    BITBAND_REG32(hw->CSR, LPTMR_CSR_TCF_SHIFT) = 1;
+
+    if (sched_context_switch_request) {
+        thread_yield();
+    }
+}
+
+/* ****** Common timer API functions ****** */
+
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+{
+    if ((unsigned int)dev >= TIMER_NUMOF) {
+        /* invalid timer */
         return -1;
     }
-    switch (dev) {
-#if TIMER_0_EN
-
-        case TIMER_0:
-            cu_timer[dev] = pit_timer_read(dev, TIMER_0_COUNTER_CH);
-            pit_timer_stop(TIMER_0_COUNTER_CH);
-            diff = value - cu_timer[dev];
-            TIMER_BASE->CHANNEL[TIMER_0_COUNTER_CH].LDVAL = diff;
-            pit_timer_start(TIMER_0_COUNTER_CH);
-            break;
-#endif
-#if TIMER_1_EN
-
-        case TIMER_1:
-            cu_timer[dev] = pit_timer_read(dev, TIMER_1_COUNTER_CH);
-            pit_timer_stop(TIMER_1_COUNTER_CH);
-            diff = value - cu_timer[dev];
-            TIMER_BASE->CHANNEL[TIMER_1_COUNTER_CH].LDVAL = diff;
-            pit_timer_start(TIMER_1_COUNTER_CH);
-            break;
-#endif
-
-        case TIMER_UNDEFINED:
+    /* demultiplex to handle two types of hardware timers */
+    switch (_timer_variant(dev)) {
+        case TIMER_PIT:
+            return pit_init(_pit_index(dev), freq, cb, arg);
+        case TIMER_LPTMR:
+            return lptmr_init(_lptmr_index(dev), freq, cb, arg);
         default:
             return -1;
     }
+}
 
-    DEBUG("cntr: %lu, value: %u, diff: %lu\n", cu_timer[dev], value, diff);
+int timer_set(tim_t dev, int channel, unsigned int timeout)
+{
+    if (channel != 0) {
+        /* only one channel is supported */
+        return -1;
+    }
+    if ((unsigned int)dev >= TIMER_NUMOF) {
+        /* invalid timer */
+        return -1;
+    }
+    /* demultiplex to handle two types of hardware timers */
+    switch (_timer_variant(dev)) {
+        case TIMER_PIT:
+            return pit_set(_pit_index(dev), timeout);
+        case TIMER_LPTMR:
+            return lptmr_set(_lptmr_index(dev), timeout);
+        default:
+            return -1;
+    }
+}
+
+int timer_set_absolute(tim_t dev, int channel, unsigned int target)
+{
+    if (channel != 0) {
+        /* only one channel is supported */
+        return -1;
+    }
+    if ((unsigned int)dev >= TIMER_NUMOF) {
+        /* invalid timer */
+        return -1;
+    }
+    /* demultiplex to handle two types of hardware timers */
+    switch (_timer_variant(dev)) {
+        case TIMER_PIT:
+            return pit_set_absolute(_pit_index(dev), target);
+        case TIMER_LPTMR:
+            return lptmr_set_absolute(_lptmr_index(dev), target);;
+        default:
+            return -1;
+    }
 
     return 0;
 }
 
 int timer_clear(tim_t dev, int channel)
 {
-    /* we only support one channel */
     if (channel != 0) {
+        /* only one channel is supported */
         return -1;
     }
-    switch (dev) {
-#if TIMER_0_EN
-
-        case TIMER_0:
-            cu_timer[dev] = timer_read(dev);
-            pit_timer_set_max(TIMER_0_COUNTER_CH);
-            break;
-#endif
-#if TIMER_1_EN
-
-        case TIMER_1:
-            cu_timer[dev] = timer_read(dev);
-            pit_timer_set_max(TIMER_1_COUNTER_CH);
-            break;
-#endif
-
-        case TIMER_UNDEFINED:
+    if ((unsigned int)dev >= TIMER_NUMOF) {
+        /* invalid timer */
+        return -1;
+    }
+    /* demultiplex to handle two types of hardware timers */
+    switch (_timer_variant(dev)) {
+        case TIMER_PIT:
+            return pit_clear(_pit_index(dev));
+        case TIMER_LPTMR:
+            return lptmr_clear(_lptmr_index(dev));
         default:
             return -1;
     }
@@ -203,21 +665,16 @@ int timer_clear(tim_t dev, int channel)
 
 unsigned int timer_read(tim_t dev)
 {
-    switch (dev) {
-#if TIMER_0_EN
-
-        case TIMER_0:
-            return pit_timer_read(dev, TIMER_0_COUNTER_CH);
-            break;
-#endif
-#if TIMER_1_EN
-
-        case TIMER_1:
-            return pit_timer_read(dev, TIMER_1_COUNTER_CH);
-            break;
-#endif
-
-        case TIMER_UNDEFINED:
+    if ((unsigned int)dev >= TIMER_NUMOF) {
+        /* invalid timer */
+        return 0;
+    }
+    /* demultiplex to handle two types of hardware timers */
+    switch (_timer_variant(dev)) {
+        case TIMER_PIT:
+            return pit_read(_pit_index(dev));
+        case TIMER_LPTMR:
+            return lptmr_read(_lptmr_index(dev));
         default:
             return 0;
     }
@@ -225,116 +682,82 @@ unsigned int timer_read(tim_t dev)
 
 void timer_start(tim_t dev)
 {
-    switch (dev) {
-#if TIMER_0_EN
-
-        case TIMER_0:
-            pit_timer_start(TIMER_0_COUNTER_CH);
-            break;
-#endif
-#if TIMER_1_EN
-
-        case TIMER_1:
-            pit_timer_start(TIMER_1_COUNTER_CH);
-            break;
-#endif
-
-        case TIMER_UNDEFINED:
-            break;
+    if ((unsigned int)dev >= TIMER_NUMOF) {
+        /* invalid timer */
+        return;
+    }
+    /* demultiplex to handle two types of hardware timers */
+    switch (_timer_variant(dev)) {
+        case TIMER_PIT:
+            pit_start(_pit_index(dev));
+            return;
+        case TIMER_LPTMR:
+            lptmr_start(_lptmr_index(dev));
+            return;
+        default:
+            return;
     }
 }
 
 void timer_stop(tim_t dev)
 {
-    switch (dev) {
-#if TIMER_0_EN
-
-        case TIMER_0:
-            pit_timer_stop(TIMER_0_COUNTER_CH);
-            break;
-#endif
-#if TIMER_1_EN
-
-        case TIMER_1:
-            pit_timer_stop(TIMER_1_COUNTER_CH);
-            break;
-#endif
-
-        case TIMER_UNDEFINED:
-            break;
+    if ((unsigned int)dev >= TIMER_NUMOF) {
+        /* invalid timer */
+        return;
+    }
+    /* demultiplex to handle two types of hardware timers */
+    switch (_timer_variant(dev)) {
+        case TIMER_PIT:
+            pit_stop(_pit_index(dev));
+            return;
+        case TIMER_LPTMR:
+            lptmr_stop(_lptmr_index(dev));
+            return;
+        default:
+            return;
     }
 }
 
-void timer_irq_enable(tim_t dev)
+/* ****** ISR instances ****** */
+
+#ifdef PIT_ISR_0
+void PIT_ISR_0(void)
 {
-    switch (dev) {
-#if TIMER_0_EN
-
-        case TIMER_0:
-            NVIC_EnableIRQ(TIMER_0_IRQ_CHAN);
-            break;
-#endif
-#if TIMER_1_EN
-
-        case TIMER_1:
-            NVIC_EnableIRQ(TIMER_1_IRQ_CHAN);
-            break;
-#endif
-
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-
-        case TIMER_0:
-            NVIC_DisableIRQ(TIMER_0_IRQ_CHAN);
-            break;
-#endif
-#if TIMER_1_EN
-
-        case TIMER_1:
-            NVIC_DisableIRQ(TIMER_1_IRQ_CHAN);
-            break;
-#endif
-
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-inline static void pit_timer_irq_handler(tim_t dev, uint8_t ch)
-{
-    cu_timer[dev] += TIMER_BASE->CHANNEL[ch].LDVAL + 1;
-    pit_timer_set_max(ch);
-
-    if (config[dev].cb != NULL) {
-        config[dev].cb(config[dev].arg, dev);
-    }
-
-    TIMER_BASE->CHANNEL[ch].TFLG = PIT_TFLG_TIF_MASK;
-
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
-}
-
-#if TIMER_0_EN
-void TIMER_0_ISR(void)
-{
-    pit_timer_irq_handler(TIMER_0, TIMER_0_COUNTER_CH);
+    pit_irq_handler(_pit_tim_t(0));
 }
 #endif
 
-#if TIMER_1_EN
-void TIMER_1_ISR(void)
+#ifdef PIT_ISR_1
+void PIT_ISR_1(void)
 {
-    pit_timer_irq_handler(TIMER_1, TIMER_1_COUNTER_CH);
+    pit_irq_handler(_pit_tim_t(1));
 }
 #endif
 
+#ifdef PIT_ISR_2
+void PIT_ISR_2(void)
+{
+    pit_irq_handler(_pit_tim_t(2));
+}
+#endif
+
+#ifdef PIT_ISR_3
+void PIT_ISR_3(void)
+{
+    pit_irq_handler(_pit_tim_t(3));
+}
+#endif
+
+#ifdef LPTMR_ISR_0
+void LPTMR_ISR_0(void)
+{
+    lptmr_irq_handler(_lptmr_tim_t(0));
+}
+#endif
+
+#ifdef LPTMR_ISR_1
+void LPTMR_ISR_1(void)
+{
+    lptmr_irq_handler(_lptmr_tim_t(1));
+}
 #endif


### PR DESCRIPTION
This is a rewrite of #4065 which cleans up the implementations significantly.

The LPTMR module is a prerequisite in order to keep the xtimer running in low power modes on Kinetis. 
This PR adds support for both PIT and LPTMR hardware modules in the configuration, but keeps the old behaviour of using the PIT module for the underlying timer in xtimer.

A future PR will improve the xtimer to support 32768 Hz timers to let the LPTMR act as underlying timer for xtimer, but I would like to get the hardware device driver support in first.

Based on #5607 