### PR TITLE
core: assert correct msq queue size on creation

### DIFF
--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -369,11 +369,8 @@ int msg_avail(void);
  *                  not be NULL.
  * @param[in] num   Number of ``msg_t`` structures in array.
  *                  **MUST BE POWER OF TWO!**
- *
- * @return 0, if successful
- * @return -1, on error
  */
-int msg_init_queue(msg_t *array, int num);
+void msg_init_queue(msg_t *array, int num);
 
 /**
  * @brief   Prints the message queue of the current thread.

--- a/core/msg.c
+++ b/core/msg.c
@@ -379,17 +379,11 @@ int msg_avail(void)
     return queue_index;
 }
 
-int msg_init_queue(msg_t *array, int num)
+void msg_init_queue(msg_t *array, int num)
 {
-    /* check if num is a power of two by comparing to its complement */
-    if (num && (num & (num - 1)) == 0) {
-        thread_t *me = (thread_t*) sched_active_thread;
-        me->msg_array = array;
-        cib_init(&(me->msg_queue), num);
-        return 0;
-    }
-
-    return -1;
+    thread_t *me = (thread_t*) sched_active_thread;
+    me->msg_array = array;
+    cib_init(&(me->msg_queue), num);
 }
 
 void msg_queue_print(void)

--- a/sys/net/gnrc/application_layer/zep/gnrc_zep.c
+++ b/sys/net/gnrc/application_layer/zep/gnrc_zep.c
@@ -561,9 +561,7 @@ void *_event_loop(void *args)
                                    KERNEL_PID_UNDEF
                                  };
 
-    if (msg_init_queue(msg_q, GNRC_ZEP_MSG_QUEUE_SIZE)) {
-        return NULL;
-    }
+    msg_init_queue(msg_q, GNRC_ZEP_MSG_QUEUE_SIZE);
 
     my_reg.pid = thread_getpid();
 


### PR DESCRIPTION
The return value was never checked. Hence, this runtime check was rather pointless. Better assert the correct size during development.