### PR TITLE
Implement NETOPT_ACK_REQ configuration option.

### DIFF
--- a/drivers/netdev2_ieee802154/netdev2_ieee802154.c
+++ b/drivers/netdev2_ieee802154/netdev2_ieee802154.c
@@ -84,7 +84,7 @@ int netdev2_ieee802154_get(netdev2_ieee802154_t *dev, netopt_t opt, void *value,
             *((uint16_t *)value) = (uint16_t)dev->chan;
             res = sizeof(dev->chan);
             break;
-        case NETOPT_AUTOACK:
+        case NETOPT_ACK_REQ:
             assert(max_len == sizeof(netopt_enable_t));
             if (dev->flags & NETDEV2_IEEE802154_ACK_REQ) {
                 *((netopt_enable_t *)value) = NETOPT_ENABLE;
@@ -183,7 +183,7 @@ int netdev2_ieee802154_set(netdev2_ieee802154_t *dev, netopt_t opt, void *value,
             dev->pan = *((uint16_t *)value);
             res = sizeof(dev->pan);
             break;
-        case NETOPT_AUTOACK:
+        case NETOPT_ACK_REQ:
             if ((*(bool *)value)) {
                 dev->flags |= NETDEV2_IEEE802154_ACK_REQ;
             }

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -90,6 +90,8 @@ typedef enum {
                                  *   the current state */
     NETOPT_AUTOACK,             /**< en/disable link layer auto ACKs or read
                                  *   the current state */
+    NETOPT_ACK_REQ,             /**< en/disable acknowledgement requests or
+                                 *   read the current state */
     NETOPT_RETRANS,             /**< get/set the maximum number of
                                  *   retransmissions. */
     NETOPT_PROTO,               /**< get/set the protocol for the layer

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -37,6 +37,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_PRELOADING]      = "NETOPT_PRELOADING",
     [NETOPT_PROMISCUOUSMODE] = "NETOPT_PROMISCUOUSMODE",
     [NETOPT_AUTOACK]         = "NETOPT_AUTOACK",
+    [NETOPT_ACK_REQ]         = "NETOPT_ACK_REQ",
     [NETOPT_RETRANS]         = "NETOPT_RETRANS",
     [NETOPT_PROTO]           = "NETOPT_PROTO",
     [NETOPT_STATE]           = "NETOPT_STATE",

--- a/sys/net/link_layer/ieee802154/ieee802154.c
+++ b/sys/net/link_layer/ieee802154/ieee802154.c
@@ -53,7 +53,7 @@ size_t ieee802154_set_frame_hdr(uint8_t *buf, const uint8_t *src, size_t src_len
 
     /* fill in destination address */
     if (bcast) {
-        /* no AUTOACK for broadcast */
+        /* no ACK_REQ for broadcast */
         buf[0] &= ~IEEE802154_FCF_ACK_REQ;
         buf[1] &= ~IEEE802154_FCF_DST_ADDR_MASK;
         buf[1] |= IEEE802154_FCF_DST_ADDR_SHORT;


### PR DESCRIPTION
This fixes #5287 - currently the option `NETOPT_AUTOACK` is incorrectly being used to set the AR (acknowledge request) bit of the 802.15.4 MAC header. This PR introduces a new option for doing this instead, `NETOPT_ACK_REQ`, leaving it up to the driver to set AUTOACK when requested.