### PR TITLE
cib: check (write > read) explicitly

### DIFF
--- a/core/include/cib.h
+++ b/core/include/cib.h
@@ -79,9 +79,7 @@ static inline unsigned int cib_avail(cib_t *__restrict cib)
  */
 static inline int cib_get(cib_t *__restrict cib)
 {
-    unsigned int avail = cib_avail(cib);
-
-    if (avail > 0) {
+    if (cib->write_count > cib->read_count) {
         return (int) (cib->read_count++ & cib->mask);
     }
 


### PR DESCRIPTION
AFAIC, in the current implementation of `cib_get`, the copmarison of the unsigned value `avail` against `0` makes no sense at all. It will never go below `0`. This should report false positives when the `read_count` is greater than the `write_count`, but I did not test that.

This PR checks directly `write_count > read_count`.

*EDIT:* The code is structured the way that `read_count` can never go below `write_count`, so the original check `avail > 0` is still correct, but IMO less readable then `avail != 0` or `write_count > read_count`.

I will keep this PR open for now until it gets (N)ACKed.