### PR TITLE
dist/ethos: make baudrate configurable

### DIFF
--- a/dist/tools/ethos/ethos.c
+++ b/dist/tools/ethos/ethos.c
@@ -28,9 +28,11 @@
 
 #define TRACE(x)
 
+#define BAUDRATE_DEFAULT B115200
+
 static void usage(void)
 {
-    fprintf(stderr, "usage: ethos <tap> <serial>\n");
+    fprintf(stderr, "usage: ethos <tap> <serial> [baudrate]\n");
 }
 
 int set_serial_attribs (int fd, int speed, int parity)
@@ -261,12 +263,22 @@ static void _clear_neighbor_cache(const char *ifname)
 int main(int argc, char *argv[])
 {
     char inbuf[MTU];
+    int speed = BAUDRATE_DEFAULT;
 
     serial_t serial = {0};
 
     if (argc < 3) {
         usage();
         return 1;
+    }
+
+    if (argc >= 4) {
+        speed = atoi(argv[3]);
+        /* baudrates smaller 9600 don't make sense */
+        if (speed < 9600) {
+            fprintf(stderr, "Invalid baudrate specified: %s\n", argv[3]);
+            return 1;
+        }
     }
 
     char ifname[IFNAMSIZ];
@@ -284,7 +296,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    set_serial_attribs(serial_fd, B115200, 0);
+    set_serial_attribs(serial_fd, speed, 0);
     set_blocking(serial_fd, 1);
 
     fd_set readfds;

--- a/dist/tools/ethos/start_network.sh
+++ b/dist/tools/ethos/start_network.sh
@@ -30,13 +30,18 @@ start_uhcpd() {
 PORT=$1
 TAP=$2
 PREFIX=$3
+BAUDRATE=115200
 UHCPD=../uhcpd/bin/uhcpd
 
 [ -z "$PORT" -o -z "$TAP" -o -z "$PREFIX" ] && {
-    echo "usage: $0 <serial-port> <tap-device> <prefix>"
+    echo "usage: $0 <serial-port> <tap-device> <prefix> [baudrate]"
     exit 1
+}
+
+[ ! -z $4 ] && {
+    BAUDRATE=$4
 }
 
 trap "cleanup" INT QUIT TERM EXIT
 
-create_tap && start_uhcpd && ./ethos $TAP $PORT
+create_tap && start_uhcpd && ./ethos $TAP $PORT $BAUDRATE


### PR DESCRIPTION
The baudrate for the serial link was hard-coded - I think it make much sense to make this configurable. Having the UART running at a higher speed than the radio link of a BR node could make sense...

Tested with `iotlab-m3` @ baudrate 500000.