### PR TITLE
sys: net: gnrc: fix IS_WIRED netopt call

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -863,7 +863,7 @@ void gnrc_ipv6_netif_init_by_dev(void)
              * gnrc_ipv6_netif_add() */
         }
 
-        if (gnrc_netapi_get(ifs[i], NETOPT_IS_WIRED, 0, &tmp, sizeof(int)) > 0) {
+        if (gnrc_netapi_get(ifs[i], NETOPT_IS_WIRED, 0, NULL, 0) > 0) {
             ipv6_if->flags |= GNRC_IPV6_NETIF_FLAGS_IS_WIRED;
         }
         else {


### PR DESCRIPTION
The netopt call cupplied a ptr to "tmp" (uint16_t), but "sizeof(int)" as length...

Anyways, NETOPT_IS_WIRED directly returns the result, so no parameter is needed.