### PR TITLE
sys: fmt: add fmt_u64_dec(), print_u64_dec()

### DIFF
--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -102,6 +102,21 @@ size_t fmt_u64_hex(char *out, uint64_t val);
 size_t fmt_u32_dec(char *out, uint32_t val);
 
 /**
+ * @brief Convert a uint64 value to decimal string.
+ *
+ * If @p out is NULL, will only return the number of bytes that would have
+ * been written.
+ *
+ * @note This adds ~400b of code when used.
+ *
+ * @param[out]  out  Pointer to output buffer, or NULL
+ * @param[in]   val  Value to convert
+ *
+ * @return      nr of digits written to (or needed in) @p out
+ */
+size_t fmt_u64_dec(char *out, uint64_t val);
+
+/**
  * @brief Convert a uint16 value to decimal string.
  *
  * If @p out is NULL, will only return the number of bytes that would have
@@ -243,6 +258,15 @@ void print_u32_hex(uint32_t val);
  * @param[in]   val  Value to print
  */
 void print_u64_hex(uint64_t val);
+
+/**
+ * @brief Print uint64 value as decimal to stdout
+ *
+ * @note This used fmt_u64_dec(), which uses ~400b of code.
+ *
+ * @param[in]   val  Value to print
+ */
+void print_u64_dec(uint64_t val);
 
 /**
  * @brief Print null-terminated string to stdout

--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -120,6 +120,42 @@ static void test_fmt_s32_dec(void)
     TEST_ASSERT_EQUAL_STRING("-9876", (char *) out);
 }
 
+static void test_fmt_u64_dec_a(void)
+{
+    char out[21] = "------------------";
+    uint64_t val = 0;
+    uint8_t chars = 0;
+
+    chars = fmt_u64_dec(out, val);
+    TEST_ASSERT_EQUAL_INT(1, chars);
+    out[chars] = '\0';
+    TEST_ASSERT_EQUAL_STRING("0", (char *) out);
+}
+
+static void test_fmt_u64_dec_b(void)
+{
+    char out[21] = "--------------------";
+    uint64_t val = 18446744073709551615LLU;
+    uint8_t chars = 0;
+
+    chars = fmt_u64_dec(out, val);
+    TEST_ASSERT_EQUAL_INT(20, chars);
+    out[chars] = '\0';
+    TEST_ASSERT_EQUAL_STRING("18446744073709551615", (char *) out);
+}
+
+static void test_fmt_u64_dec_c(void)
+{
+    char out[21] = "--------------------";
+    uint64_t val = 1234567890123456789LLU;
+    uint8_t chars = 0;
+
+    chars = fmt_u64_dec(out, val);
+    TEST_ASSERT_EQUAL_INT(19, chars);
+    out[chars] = '\0';
+    TEST_ASSERT_EQUAL_STRING("1234567890123456789", (char *) out);
+}
+
 static void test_rmt_s16_dec(void)
 {
     char out[7] = "-------";
@@ -247,6 +283,9 @@ Test *tests_fmt_tests(void)
         new_TestFixture(test_fmt_u32_hex),
         new_TestFixture(test_fmt_u64_hex),
         new_TestFixture(test_fmt_u32_dec),
+        new_TestFixture(test_fmt_u64_dec_a),
+        new_TestFixture(test_fmt_u64_dec_b),
+        new_TestFixture(test_fmt_u64_dec_c),
         new_TestFixture(test_fmt_u16_dec),
         new_TestFixture(test_fmt_s32_dec),
         new_TestFixture(test_rmt_s16_dec),


### PR DESCRIPTION
This PR adds previously missing uin64_t decimal fmt/print to the fmt module.

It *does* add >400bytes of code to SAM R21 *edit* (when used) *edit*, but that is still a lot less than \*printf with 64bit support will take.
~~And *please* find a less clumsy way to add up the base 10k parts...~~