### PR TITLE
sys/xtimer: eliminate XTIMER_SHIFT_ON_COMPARE

### DIFF
--- a/boards/airfy-beacon/include/board.h
+++ b/boards/airfy-beacon/include/board.h
@@ -34,7 +34,6 @@
 #define XTIMER                      (0)
 #define XTIMER_CHAN                 (0)
 #define XTIMER_MASK                 (0xff000000)
-#define XTIMER_SHIFT_ON_COMPARE     (2)
 #define XTIMER_BACKOFF              (40)
 /** @} */
 

--- a/boards/arduino-mega2560/include/board.h
+++ b/boards/arduino-mega2560/include/board.h
@@ -53,7 +53,6 @@ extern "C" {
  */
 #define XTIMER_MASK                 (0xffff0000)
 #define XTIMER_SHIFT                (2)
-#define XTIMER_SHIFT_ON_COMPARE     (8)
 #define XTIMER_BACKOFF              (40)
 /** @} */
 

--- a/boards/chronos/include/board.h
+++ b/boards/chronos/include/board.h
@@ -41,7 +41,6 @@ extern "C" {
 #define XTIMER                      (0)
 #define XTIMER_CHAN                 (0)
 #define XTIMER_MASK                 (0xffff0000)
-#define XTIMER_SHIFT_ON_COMPARE     (4)
 /** @} */
 
 /**

--- a/boards/msb-430-common/include/board_common.h
+++ b/boards/msb-430-common/include/board_common.h
@@ -40,7 +40,6 @@ extern "C" {
 #define XTIMER                      (0)
 #define XTIMER_CHAN                 (0)
 #define XTIMER_MASK                 (0xffff0000)
-#define XTIMER_SHIFT_ON_COMPARE     (4)
 #define XTIMER_BACKOFF              (40)
 /** @} */
 

--- a/boards/nrf51dongle/include/board.h
+++ b/boards/nrf51dongle/include/board.h
@@ -35,7 +35,6 @@ extern "C" {
 #define XTIMER                      (0)
 #define XTIMER_CHAN                 (0)
 #define XTIMER_MASK                 (0xff000000)
-#define XTIMER_SHIFT_ON_COMPARE     (2)
 #define XTIMER_BACKOFF              (40)
 /** @} */
 

--- a/boards/pca10000/include/board.h
+++ b/boards/pca10000/include/board.h
@@ -35,7 +35,6 @@ extern "C" {
 #define XTIMER                      (0)
 #define XTIMER_CHAN                 (0)
 #define XTIMER_MASK                 (0xff000000)
-#define XTIMER_SHIFT_ON_COMPARE     (2)
 #define XTIMER_BACKOFF              (40)
 /** @} */
 

--- a/boards/pca10005/include/board.h
+++ b/boards/pca10005/include/board.h
@@ -35,7 +35,6 @@ extern "C" {
 #define XTIMER                      (0)
 #define XTIMER_CHAN                 (0)
 #define XTIMER_MASK                 (0xff000000)
-#define XTIMER_SHIFT_ON_COMPARE     (2)
 #define XTIMER_BACKOFF              (40)
 /** @} */
 

--- a/boards/telosb/include/board.h
+++ b/boards/telosb/include/board.h
@@ -57,7 +57,6 @@ extern "C" {
 #define XTIMER                      (0)
 #define XTIMER_CHAN                 (0)
 #define XTIMER_MASK                 (0xffff0000)
-#define XTIMER_SHIFT_ON_COMPARE     (4)
 #define XTIMER_BACKOFF              (40)
 /** @} */
 

--- a/boards/wsn430-common/include/board_common.h
+++ b/boards/wsn430-common/include/board_common.h
@@ -40,7 +40,6 @@ extern "C" {
 #define XTIMER                      (0)
 #define XTIMER_CHAN                 (0)
 #define XTIMER_MASK                 (0xffff0000)
-#define XTIMER_SHIFT_ON_COMPARE     (4)
 #define XTIMER_BACKOFF              (40)
 /** @} */
 

--- a/boards/yunjia-nrf51822/include/board.h
+++ b/boards/yunjia-nrf51822/include/board.h
@@ -34,7 +34,6 @@ extern "C" {
 #define XTIMER                      (0)
 #define XTIMER_CHAN                 (0)
 #define XTIMER_MASK                 (0xff000000)
-#define XTIMER_SHIFT_ON_COMPARE     (2)
 #define XTIMER_BACKOFF              (40)
 /** @} */
 

--- a/boards/z1/include/board.h
+++ b/boards/z1/include/board.h
@@ -51,7 +51,6 @@ extern "C" {
 #define XTIMER                      (0)
 #define XTIMER_CHAN                 (0)
 #define XTIMER_MASK                 (0xffff0000)
-#define XTIMER_SHIFT_ON_COMPARE     (4)
 #define XTIMER_BACKOFF              (40)
 /** @} */
 


### PR DESCRIPTION
I believe that `xtimer_now()` and `XTIMER_SHIFT_ON_COMPARE` are more complicated than they need to be. The goal is to avoid a race condition in which the value of `_high_cnt` changes during a call to `xtimer_now()` and the wrong high count is applied to the `_lltimer_now()` reading.

In my opinion, it is better/faster/simpler to check the `_high_cnt` value before and after the call to `_lltimer_now()`. If the value hasn't changed then it can be safely applied to the latched low count.

This also reduces the number of board-specific parameters and eliminates the need to run `tests/xtimer_shift_on_compare`.
