### PR TITLE
cpu/cc2538: xtimer bug fix

### DIFF
--- a/boards/cc2538dk/include/board.h
+++ b/boards/cc2538dk/include/board.h
@@ -78,7 +78,8 @@ extern "C" {
  */
 #define XTIMER              TIMER_0
 #define XTIMER_CHAN         (0)
-#define XTIMER_SHIFT        (-4)
+#define XTIMER_MASK         (0xf0000000)
+#define XTIMER_SHIFT_ON_COMPARE (5)
 #define XTIMER_BACKOFF      (50)
 #define XTIMER_ISR_BACKOFF  (40)
 /** @} */

--- a/boards/openmote-cc2538/include/board.h
+++ b/boards/openmote-cc2538/include/board.h
@@ -66,7 +66,8 @@
  */
 #define XTIMER              TIMER_0
 #define XTIMER_CHAN         (0)
-#define XTIMER_SHIFT        (-4)
+#define XTIMER_MASK         (0xf0000000)
+#define XTIMER_SHIFT_ON_COMPARE (5)
 #define XTIMER_BACKOFF      (50)
 #define XTIMER_ISR_BACKOFF  (40)
 /** @} */

--- a/boards/remote/include/board.h
+++ b/boards/remote/include/board.h
@@ -83,7 +83,8 @@
  */
 #define XTIMER              TIMER_0
 #define XTIMER_CHAN         (0)
-#define XTIMER_SHIFT        (-4)
+#define XTIMER_MASK         (0xf0000000)
+#define XTIMER_SHIFT_ON_COMPARE (5)
 #define XTIMER_BACKOFF      (50)
 #define XTIMER_ISR_BACKOFF  (40)
 /** @} */


### PR DESCRIPTION
My frequency scaling in `cpu/cc2538/periph/timer` went a long way to getting the xtimer working on this MCU, but there was a critical flaw. The low-level timer was effectively reduced from 32-bits to 28-bits, but this change was not reflected in the `XTIMER` config macros. The end result is that the xtimer would stop working after about 4.5 minutes, long after most `tests/xtimer_*` were already finished.

I admit this is a bit of a "band aid" solution and I look forward to the arbitrary frequency support proposed in PRs like #3990 and #4002. In the meantime, I think this is a good way to get the xtimers working reliably on this MCU. Tested on `cc2538dk`.