### PR TITLE
boards/cc2538dk: fix wrong UART CTS and RTS pins

### DIFF
--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -96,14 +96,14 @@ extern "C" {
 /* UART 0 pin configuration */
 #define UART_0_TX_PIN       GPIO_PA1
 #define UART_0_RX_PIN       GPIO_PA0
+#define UART_0_RTS_PIN      GPIO_PD3
+#define UART_0_CTS_PIN      GPIO_PB0
 
 /* UART 1 device configuration */
 #define UART_1_DEV          UART1
 #define UART_1_IRQ          UART1_IRQn
 #define UART_1_ISR          isr_uart1
 /* UART 1 pin configuration */
-#define UART_1_RTS_PIN      GPIO_PD3
-#define UART_1_CTS_PIN      GPIO_PB0
 /** @} */
 
 /**


### PR DESCRIPTION
According to SmartRF06 user's [guide](http://www.ti.com.cn/cn/lit/ug/swru321a/swru321a.pdf) table 4 and 14, UART0 CTS and RTS pins correspond to the previously assigned to UART1.

Since UART1 is not defined for this platform, in case of need the user should choice the needed pins from the available GPIO.