### PR TITLE
shell: icmpv6_echo: guard call to *_nc_still_reachable

### DIFF
--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -108,7 +108,9 @@ int _handle_reply(gnrc_pktsnip_t *pkt, uint32_t time)
                ipv6_addr_to_str(ipv6_str, &(ipv6_hdr->src), sizeof(ipv6_str)),
                byteorder_ntohs(icmpv6_hdr->id), seq, (unsigned)ipv6_hdr->hl,
                time / MS_IN_USEC, time % MS_IN_USEC);
+#ifdef MODULE_GNRC_IPV6_NC
         gnrc_ipv6_nc_still_reachable(&ipv6_hdr->src);
+#endif
     }
     else {
         puts("error: unexpected parameters");


### PR DESCRIPTION
`gnrc_ipv6_nc_still_reachable` is not available when `gnrc_ipv6_nc` is not compiled into the binary.