### PR TITLE
sys/auto_init: cpuid as seed for random_init

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -107,7 +107,7 @@ void auto_init(void)
     cpuid_get(cpuid);
     uint32_t seed = cpuid[0];
     for (unsigned int i = 1; i < CPUID_LEN; ++i) {
-        seed ^= cpuid[i];
+        seed += cpuid[i];
     }
     random_init(seed);
 #else

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -86,6 +86,9 @@
 
 #ifdef MODULE_TINYMT32
 #include "random.h"
+#if CPUID_LEN
+#include "periph/cpuid.h"
+#endif
 #endif
 
 #define ENABLE_DEBUG (0)
@@ -99,7 +102,17 @@ void auto_init(void)
 #endif
 
 #ifdef MODULE_TINYMT32
+#if CPUID_LEN
+    uint8_t cpuid[CPUID_LEN];
+    cpuid_get(cpuid);
+    uint32_t seed = cpuid[0];
+    for (unsigned int i = 1; i < CPUID_LEN; ++i) {
+        seed ^= cpuid[i];
+    }
+    random_init(seed);
+#else
     random_init(0);
+#endif
 #endif
 #ifdef MODULE_XTIMER
     DEBUG("Auto init xtimer module.\n");


### PR DESCRIPTION
Choose a sane seed number instead of defaulting to `0`. This PR utilizes the `cpuid`, if present.

Rationale: Trickle timers rely on random offsets to generate increasing intervals. This way, if a network protocol relies on trickle timers, packets of different nodes will not be sent at the same time, but with a little offset applied.

Currently, in case of RPL, many nodes send out DIO messages at the same time, because the "randomness" is the same for all nodes (same seed, and booted at same time).
