### PR TITLE
gnrc_ipv6: Revert #5179

### DIFF
--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -14,10 +14,7 @@
  * The IPv6 control thread understands messages of type
  *
  *  * @ref GNRC_NETAPI_MSG_TYPE_RCV, and
- *  * @ref GNRC_NETAPI_MSG_TYPE_SND.
- *
- * If the message is of type @ref GNRC_NETAPI_MSG_TYPE_RCV the provided @ref
- * gnrc_pktsnip_t must contain a snip of type @ref GNRC_NETTYPE_NETIF.
+ *  * @ref GNRC_NETAPI_MSG_TYPE_SND,
  *
  * @{
  *

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -769,8 +769,9 @@ static void _receive(gnrc_pktsnip_t *pkt)
 
     netif = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
 
-    assert(netif);
-    iface = ((gnrc_netif_hdr_t *)netif->data)->if_pid;
+    if (netif != NULL) {
+        iface = ((gnrc_netif_hdr_t *)netif->data)->if_pid;
+    }
 
     first_ext = pkt;
 


### PR DESCRIPTION
Reverts #5179.

Alternative to #5247. 

Else-case that was discussed #5247 isn't necessary, since `iface` is already initialized with `KERNEL_PID_UNDEF`.