### PR TITLE
make: add makefile for host tools

### DIFF
--- a/dist/tools/Makefile
+++ b/dist/tools/Makefile
@@ -1,0 +1,8 @@
+HOST_TOOLS=ethos uhcpd
+
+.PHONY: all $(HOST_TOOLS)
+
+all: $(HOST_TOOLS)
+
+$(HOST_TOOLS):
+	make -C $@

--- a/dist/tools/travis-scripts/build_and_test.sh
+++ b/dist/tools/travis-scripts/build_and_test.sh
@@ -69,6 +69,11 @@ then
         exit $RESULT
     fi
 
+    if [ "$BUILDTEST_MCU_GROUP" == "host" ]; then
+        make -C dist/tools
+        exit $?
+    fi
+
     if [ "$BUILDTEST_MCU_GROUP" == "x86" ]
     then
         make -C ./tests/unittests all-debug test BOARD=native TERMPROG='gdb -batch -ex r -ex bt $(ELF)' || exit


### PR DESCRIPTION
Host tools don't get checked by CI. This PR adds a simple Makefile to dist/tools and a corresponding CI buildtest group.