### PR TITLE
dist/ethos: fixed compile warnings  (backport of #5317)

### DIFF
--- a/dist/tools/ethos/ethos.c
+++ b/dist/tools/ethos/ethos.c
@@ -33,6 +33,13 @@ static void usage(void)
     fprintf(stderr, "usage: ethos <tap> <serial>\n");
 }
 
+static void checked_write(int handle, void *buffer, int nbyte)
+{
+    if (write(handle, buffer, nbyte) != nbyte) {
+        fprintf(stderr, "write to fd %i failed: %s\n", handle, strerror(errno));
+    }
+}
+
 int set_serial_attribs (int fd, int speed, int parity)
 {
     struct termios tty;
@@ -227,17 +234,17 @@ static void _write_escaped(int fd, char* buf, ssize_t n)
             case LINE_FRAME_DELIMITER:
                 out[0] = LINE_ESC_CHAR;
                 out[1] = (LINE_FRAME_DELIMITER ^ 0x20);
-                write(fd, out, 2);
+                checked_write(fd, out, 2);
                 escaped++;
                 break;
             case LINE_ESC_CHAR:
                 out[0] = LINE_ESC_CHAR;
                 out[1] = (LINE_ESC_CHAR ^ 0x20);
-                write(fd, out, 2);
+                checked_write(fd, out, 2);
                 escaped++;
                 break;
             default:
-                write(fd, &c, 1);
+                checked_write(fd, &c, 1);
         }
     }
 }
@@ -246,16 +253,18 @@ static void _send_hello(int serial_fd, serial_t *serial, unsigned type)
 {
     char delim = LINE_FRAME_DELIMITER;
     char head[] = { LINE_FRAME_DELIMITER, LINE_ESC_CHAR, (type ^ 0x20) };
-    write(serial_fd, head, sizeof(head));
-    write(serial_fd, serial->local_l2_addr, 6);
-    write(serial_fd, &delim, 1);
+    checked_write(serial_fd, head, sizeof(head));
+    checked_write(serial_fd, serial->local_l2_addr, 6);
+    checked_write(serial_fd, &delim, 1);
 }
 
 static void _clear_neighbor_cache(const char *ifname)
 {
     char tmp[20 + IFNAMSIZ];
     snprintf(tmp, sizeof(tmp), "ip neigh flush dev %s", ifname);
-    system(tmp);
+    if (system(tmp) < 0) {
+        fprintf(stderr, "error while flushing device neighbor cache\n");
+    }
 }
 
 int main(int argc, char *argv[])
@@ -317,10 +326,10 @@ int main(int argc, char *argv[])
                     if (res) {
                         switch (serial.frametype) {
                             case LINE_FRAME_TYPE_DATA:
-                                write(tap_fd, serial.frame, serial.framebytes);
+                                checked_write(tap_fd, serial.frame, serial.framebytes);
                                 break;
                             case LINE_FRAME_TYPE_TEXT:
-                                write(STDOUT_FILENO, serial.frame, serial.framebytes);
+                                checked_write(STDOUT_FILENO, serial.frame, serial.framebytes);
                                 break;
                             case LINE_FRAME_TYPE_HELLO:
                             case LINE_FRAME_TYPE_HELLO_REPLY:
@@ -353,9 +362,9 @@ int main(int argc, char *argv[])
                 continue;
             }
             char delim = LINE_FRAME_DELIMITER;
-            write(serial_fd, &delim, 1);
+            checked_write(serial_fd, &delim, 1);
             _write_escaped(serial_fd, inbuf, res);
-            write(serial_fd, &delim, 1);
+            checked_write(serial_fd, &delim, 1);
         }
 
         if (FD_ISSET(STDIN_FILENO, &readfds)) {
@@ -368,9 +377,9 @@ int main(int argc, char *argv[])
             if (res) {
                 char delim = LINE_FRAME_DELIMITER;
                 char head[] = { LINE_FRAME_DELIMITER, LINE_ESC_CHAR, (LINE_FRAME_TYPE_TEXT ^ 0x20) };
-                write(serial_fd, head, sizeof(head));
+                checked_write(serial_fd, head, sizeof(head));
                 _write_escaped(serial_fd, inbuf, res);
-                write(serial_fd, &delim, 1);
+                checked_write(serial_fd, &delim, 1);
             }
         }
     }


### PR DESCRIPTION
- checking return values of each write() call
- chack return value of system() call

 (backport of #5317)