### PR TITLE
cortexm_common: print trapped interrupt from ipsr

### DIFF
--- a/cpu/cortexm_common/panic.c
+++ b/cpu/cortexm_common/panic.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 INRIA
  * Copyright (C) 2015 Eistec AB
+ * Copyright (C) 2016 OTA keys
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -16,14 +17,29 @@
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author      Toon Stegen <toon.stegen@altran.com>
  */
 
 #include "cpu.h"
 #include "lpm.h"
+#include "log.h"
+
+#ifdef DEVELHELP
+static void print_ipsr(void)
+{
+    uint32_t ipsr = __get_IPSR() & IPSR_ISR_Msk;
+    if(ipsr) {
+        /* if you get here, you might have forgotten to implement the isr
+         * for the printed interrupt number */
+        LOG_ERROR("Inside isr %d\n", ((int)ipsr) - 16);
+    }
+}
+#endif
 
 void panic_arch(void)
 {
 #ifdef DEVELHELP
+    print_ipsr();
     /* The bkpt instruction will signal to the debugger to break here. */
     __asm__("bkpt #0");
     /* enter infinite loop, into deepest possible sleep mode */


### PR DESCRIPTION
The IPSR (=Interrupt Program Status Register) contains the exception type number of the current Interrupt Service Routine. Printing this out can be useful to detect if a certain interrupt is not implemented.

The IPSR is documented [here](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0552a/CHDBIBGJ.html).

