### PR TITLE
dist: make: iotlab: specify exp id in iotlab-term

### DIFF
--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -71,21 +71,12 @@ iotlab-stop: $(IOTLAB_AUTH) iotlab-check-exp
 iotlab-term: iotlab-check-exp
 	$(AD)ssh -t $(IOTLAB_AUTHORITY) "test -f ~/.iotlabrc || auth-cli -u $(IOTLAB_USER)"
 
-    ifndef NODES_PARAM
-	    $(AD)ssh -t $(IOTLAB_AUTHORITY)\
-	    "tmux attach -t riot-$(IOTLAB_EXP_ID) || tmux new -s riot-$(IOTLAB_EXP_ID)\
-	    '$(if $(IOTLAB_LOGGING),\
-	    script -fac "'"'"serial_aggregator -i $(IOTLAB_EXP_ID)"'"'"\
-	    RIOT_LOG-$(IOTLAB_EXP_NAME)-$(IOTLAB_EXP_ID),\
-	    serial_aggregator -i $(IOTLAB_EXP_ID))'"
-    else
-	    $(AD)ssh -t $(IOTLAB_AUTHORITY)\
-	    "tmux attach -t riot-$(IOTLAB_EXP_ID) || tmux new -s riot-$(IOTLAB_EXP_ID)\
-	    '$(if $(IOTLAB_LOGGING),\
-	    script -fac "'"'"serial_aggregator $(NODES_PARAM_BASE)"'"'"\
-	    RIOT_LOG-$(IOTLAB_EXP_NAME)-$(IOTLAB_EXP_ID),\
-	    serial_aggregator $(NODES_PARAM_BASE))'"
-    endif
+	$(AD)ssh -t $(IOTLAB_AUTHORITY) \
+	"tmux attach -t riot-$(IOTLAB_EXP_ID) || tmux new -s riot-$(IOTLAB_EXP_ID) \
+	'$(if $(IOTLAB_LOGGING), \
+	script -fac "'"'"serial_aggregator -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE)"'"'" \
+	RIOT_LOG-$(IOTLAB_EXP_NAME)-$(IOTLAB_EXP_ID), \
+	serial_aggregator -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE))'"
 
 iotlab-check-exp:
 ifndef IOTLAB_SITE


### PR DESCRIPTION
Specify the correct experiment id when starting the `serial_aggregator`.