### PR TITLE
dist: make: iotlab: use target specific var assignment

### DIFF
--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -81,7 +81,4 @@ iotlab-term: iotlab-check-exp
 	RIOT_LOG-$(IOTLAB_EXP_NAME)-$(IOTLAB_EXP_ID), \
 	serial_aggregator -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE))'"
 
-iotlab-check-exp:
-ifndef IOTLAB_SITE
-	$(eval IOTLAB_SITE := $(shell experiment-cli get -ri -i $(IOTLAB_EXP_ID) | sed -n 4p | cut -d\" -f2))
-endif
+iotlab-check-exp: IOTLAB_SITE ?= $(shell experiment-cli get -ri -i $(IOTLAB_EXP_ID) | sed -n 4p | cut -d\" -f2)


### PR DESCRIPTION
Using a target specific variable assignment looks better, IMO.
