### PR TITLE
tools: ethos: allow `start_network.sh` script to run from anywhere

### DIFF
--- a/dist/tools/ethos/start_network.sh
+++ b/dist/tools/ethos/start_network.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+ETHOS_DIR="$(dirname $(readlink -f $0))"
+
 create_tap() {
     ip tuntap add ${TAP} mode tap user ${USER}
     sysctl -w net.ipv6.conf.${TAP}.forwarding=1
@@ -18,7 +20,7 @@ cleanup() {
     echo "Cleaning up..."
     remove_tap
     ip a d fd00:dead:beef::1/128 dev lo
-    kill $UHCPD_PID
+    kill ${UHCPD_PID}
     trap "" INT QUIT TERM EXIT
 }
 
@@ -30,13 +32,14 @@ start_uhcpd() {
 PORT=$1
 TAP=$2
 PREFIX=$3
-UHCPD=../uhcpd/bin/uhcpd
+UHCPD="$(readlink -f "${ETHOS_DIR}/../uhcpd/bin")/uhcpd"
 
-[ -z "$PORT" -o -z "$TAP" -o -z "$PREFIX" ] && {
+[ -z "${PORT}" -o -z "${TAP}" -o -z "${PREFIX}" ] && {
     echo "usage: $0 <serial-port> <tap-device> <prefix>"
     exit 1
 }
 
 trap "cleanup" INT QUIT TERM EXIT
 
-create_tap && start_uhcpd && ./ethos $TAP $PORT
+
+create_tap && start_uhcpd && "${ETHOS_DIR}/ethos" ${TAP} ${PORT}


### PR DESCRIPTION
allows to run `start_network.sh` like this

```bash
dist/tools/ethos/start_network.sh ...
```