### PR TITLE
gnrc_sixlowpan: enable NHC by default (backport)

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -132,8 +132,7 @@ endif
 ifneq (,$(filter gnrc_sixlowpan_iphc,$(USEMODULE)))
   USEMODULE += gnrc_sixlowpan
   USEMODULE += gnrc_sixlowpan_ctx
-  # NHC is broken, so disable it for now. See #4544 and #4462.
-  #USEMODULE += gnrc_sixlowpan_iphc_nhc
+  USEMODULE += gnrc_sixlowpan_iphc_nhc
 endif
 
 ifneq (,$(filter gnrc_sixlowpan,$(USEMODULE)))


### PR DESCRIPTION
Backport to #5044 