### PR TITLE
cpu/cc2538: fix build errors when UART1 or the 32 kHz crystal is enabled (backport)

### DIFF
--- a/cpu/cc2538/cpu.c
+++ b/cpu/cc2538/cpu.c
@@ -84,7 +84,7 @@ static void cpu_clock_init(void)
 
 #if SYS_CTRL_OSC32K_USE_XTAL
     /* Wait for the 32-kHz crystal oscillator to stabilize: */
-    while ( SYS_CTRL->CLOCK_STAbits.SYNC_32K);
-    while (!SYS_CTRL->CLOCK_STAbits.SYNC_32K);
+    while ( SYS_CTRL->cc2538_sys_ctrl_clk_sta.CLOCK_STAbits.SYNC_32K);
+    while (!SYS_CTRL->cc2538_sys_ctrl_clk_sta.CLOCK_STAbits.SYNC_32K);
 #endif
 }

--- a/cpu/cc2538/periph/uart.c
+++ b/cpu/cc2538/periph/uart.c
@@ -61,10 +61,10 @@ enum {
 #define DIVFRAC_MASK          ( (1 << DIVFRAC_NUM_BITS) - 1 )
 
 /** @brief Indicates if there are bytes available in the UART0 receive FIFO */
-#define uart0_rx_avail() ( UART0->FRbits.RXFE == 0 )
+#define uart0_rx_avail() ( UART0->cc2538_uart_fr.FRbits.RXFE == 0 )
 
 /** @brief Indicates if there are bytes available in the UART1 receive FIFO */
-#define uart1_rx_avail() ( UART1->FRbits.RXFE == 0 )
+#define uart1_rx_avail() ( UART1->cc2538_uart_fr.FRbits.RXFE == 0 )
 
 /** @brief Read one byte from the UART0 receive FIFO */
 #define uart0_read()     ( UART0->DR )
@@ -139,7 +139,7 @@ void UART_1_ISR(void)
     mis = UART_1_DEV->cc2538_uart_mis.MIS;
     UART_1_DEV->ICR = mis;
 
-    while (UART_1_DEV->FRbits.RXFE == 0) {
+    while (UART_1_DEV->cc2538_uart_fr.FRbits.RXFE == 0) {
         uart_config[1].rx_cb(uart_config[1].arg, UART_1_DEV->DR);
     }
 


### PR DESCRIPTION
Backport #5124 