### PR TITLE
dist: make: iotlab: add logging to iotlab-term via tmux

### DIFF
--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -48,6 +48,12 @@ iotlab-exp: $(IOTLAB_AUTH) all
 	$(eval NEW_ID := $(shell experiment-cli submit -d $(IOTLAB_DURATION) $(NODES_PARAM) -n $(IOTLAB_EXP_NAME) | grep -Eo '[[:digit:]]+'))
 	$(AD)experiment-cli wait -i $(NEW_ID)
 
+    ifdef $(IOTLAB_LOGGING)
+	    $(AD)ssh -t $(IOTLAB_AUTHORITY) "tmux new -d -s riot-$(NEW_ID)\
+	    'script -fac "'"'"serial_aggregator -i $(NEW_ID)"'"'"\
+	     RIOT_LOG-$(IOTLAB_EXP_NAME)-$(NEW_ID)'"
+    endif
+
 iotlab-flash: $(IOTLAB_AUTH) iotlab-check-exp all
 	$(AD)node-cli --update $(BINARY) -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE) $(EXCLUDE_PARAM)
 
@@ -66,9 +72,19 @@ iotlab-term: iotlab-check-exp
 	$(AD)ssh -t $(IOTLAB_AUTHORITY) "test -f ~/.iotlabrc || auth-cli -u $(IOTLAB_USER)"
 
     ifndef NODES_PARAM
-	    $(AD)ssh -t $(IOTLAB_AUTHORITY) "serial_aggregator -i $(IOTLAB_EXP_ID)"
+	    $(AD)ssh -t $(IOTLAB_AUTHORITY)\
+	    "tmux attach -t riot-$(IOTLAB_EXP_ID) || tmux new -s riot-$(IOTLAB_EXP_ID)\
+	    '$(if $(IOTLAB_LOGGING),\
+	    script -fac "'"'"serial_aggregator -i $(IOTLAB_EXP_ID)"'"'"\
+	    RIOT_LOG-$(IOTLAB_EXP_NAME)-$(IOTLAB_EXP_ID),\
+	    serial_aggregator -i $(IOTLAB_EXP_ID))'"
     else
-	    $(AD)ssh -t $(IOTLAB_AUTHORITY) "serial_aggregator $(NODES_PARAM_BASE)"
+	    $(AD)ssh -t $(IOTLAB_AUTHORITY)\
+	    "tmux attach -t riot-$(IOTLAB_EXP_ID) || tmux new -s riot-$(IOTLAB_EXP_ID)\
+	    '$(if $(IOTLAB_LOGGING),\
+	    script -fac "'"'"serial_aggregator $(NODES_PARAM_BASE)"'"'"\
+	    RIOT_LOG-$(IOTLAB_EXP_NAME)-$(IOTLAB_EXP_ID),\
+	    serial_aggregator $(NODES_PARAM_BASE))'"
     endif
 
 iotlab-check-exp:

--- a/dist/testbed-support/README.iotlab.md
+++ b/dist/testbed-support/README.iotlab.md
@@ -34,6 +34,7 @@ brackets):
  * IOTLAB_EXP_NAME (RIOT_EXP)
  * IOTLAB_PHY_NODES
  * IOTLAB_EXCLUDE_NODES
+ * IOTLAB_LOGGING
 
 ### Format of a Resource ID
 Both variables `IOTLAB_PHY_NODES` and `IOTLAB_EXCLUDE_NODES` use the resource id
@@ -63,6 +64,8 @@ Note that the usage of `IOTLAB_PHY_NODES` ignores `IOTLAB_NODES`. It will also f
 binary of the current application to all registered nodes. The name of the
 experiment is set to "RIOT_EXP" or "RIOT_EXP_$(IOTLAB_EXP_NAME)"
 if `IOTLAB_EXP_NAME` is defined.
+If `IOTLAB_LOGGING` is set to `1`, then the output of all nodes will be logged on the server
+into a file called "RIOT_LOG-<EXPNAME>-<EXPID>".
 
 #### iotlab-flash
 
@@ -83,3 +86,6 @@ then you must specify the site with `IOTLAB_SITE`.
 
 Uses ssh to login the user on the IoT-LAB server of the specified site and
 start the `serial_aggregator` to communication with all registered nodes.
+If `IOTLAB_LOGGING` is set to `1`, then closing the connection with `CTRL+C/D` will also quit
+the logging process. Detach from the server-side tmux process with `CTRL+A-D`
+(or as defined in your server-side `.tmux.conf` file)


### PR DESCRIPTION
If `IOTLAB_LOGGING` is set to `1`, then `iotlab-exp` will start a logging process with `tmux`. Further invocations of `iotlab-term` will attach to that tmux process, so that the logging still continues, while interacting with `serial_aggregator`.