### PR TITLE
sys: xtimer: WIP: xtimer refactoring

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -169,7 +169,7 @@ static inline void xtimer_spin(uint32_t microseconds);
  * @param[in] usecs         time in microseconds that will be added to
  *                          last_wakeup
  */
-void xtimer_usleep_until(uint32_t *last_wakeup, uint32_t usecs);
+void xtimer_usleep_until(uint64_t *last_wakeup, uint32_t usecs);
 
 /**
  * @brief Set a timer that sends a message
@@ -426,7 +426,6 @@ static inline uint32_t _lltimer_mask(uint32_t val)
  * @brief xtimer internal stuff
  * @internal
  */
-int _xtimer_set_absolute(xtimer_t *timer, uint32_t target);
 void _xtimer_set64(xtimer_t *timer, uint32_t offset, uint32_t long_offset);
 void _xtimer_sleep(uint32_t offset, uint32_t long_offset);
 static inline void xtimer_spin_until(uint32_t value);


### PR DESCRIPTION
Hello,

addressing issue reported in #4902. The idea is to get rid of timer_set_absolute with 32bits target.
Now all the magic happens in _xtimer_set64 where there is irq disabled between getting the current absolute time and target calculations.
have had look at xtimer_sleep_until as well - not to duplicate code from _xtimer_sleep and use 64bits last_wakeup arg.

It it still WIP (need to adapt the rest of the sources for new xtimer_sleep_until arg), but would like to get general feedback.

wbr
malo
