### PR TITLE
cpu/cc2538/spi: Fix compiler warning of possible uninitialized variable

### DIFF
--- a/cpu/cc2538/periph/spi.c
+++ b/cpu/cc2538/periph/spi.c
@@ -215,7 +215,7 @@ int spi_release(spi_t dev)
 
 static char ssi_flush_input(cc2538_ssi_t *ssi)
 {
-    char tmp;
+    char tmp = 0;
 
     while (ssi->SRbits.RNE) {
         tmp = ssi->DR;


### PR DESCRIPTION
During the build test of #4413 the following errors where shown:

	bindist:openmote-cc2538:
	Building application "bindist" for "openmote-cc2538" with MCU "cc2538".

	/data/riotbuild/cpu/cc2538/periph/spi.c: In function 'ssi_flush_input':
	/data/riotbuild/cpu/cc2538/periph/spi.c:224:12: error: 'tmp' may be used uninitialized in this function [-Werror=maybe-uninitialized]
		 return tmp;
				^
	cc1: all warnings being treated as errors
	

	bindist:remote:
	Building application "bindist" for "remote" with MCU "cc2538".

	/data/riotbuild/cpu/cc2538/periph/spi.c: In function 'ssi_flush_input':
	/data/riotbuild/cpu/cc2538/periph/spi.c:224:12: error: 'tmp' may be used uninitialized in this function [-Werror=maybe-uninitialized]
		 return tmp;
				^
	cc1: all warnings being treated as errors

	bindist:cc2538dk:
	Building application "bindist" for "cc2538dk" with MCU "cc2538".

	/data/riotbuild/cpu/cc2538/periph/spi.c: In function 'ssi_flush_input':
	/data/riotbuild/cpu/cc2538/periph/spi.c:224:12: error: 'tmp' may be used uninitialized in this function [-Werror=maybe-uninitialized]
		 return tmp;
				^
	cc1: all warnings being treated as errors

This fixes that.