### PR TITLE
gnrc_sixlowpan_iphc: fix comparison signage

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -566,7 +566,7 @@ inline static size_t iphc_nhc_udp_encode(gnrc_pktsnip_t *udp, ipv6_hdr_t *ipv6_h
     if (udp->type == GNRC_NETTYPE_IPV6) {
         /* forwarded ipv6 packet */
         size_t diff = sizeof(udp_hdr_t) - nhc_len;
-        for (int i = nhc_len; i < (udp->size - diff); i++) {
+        for (size_t i = nhc_len; i < (udp->size - diff); i++) {
             udp_data[i] = udp_data[i + diff];
         }
         /* NOTE: gnrc_pktbuf_realloc_data overflow if (udp->size - diff) < 4 */


### PR DESCRIPTION
Fixes issue pointed out in https://github.com/RIOT-OS/RIOT/pull/5232/files/f405891b688d76be1cdca48a4fcf528ef9ff07e0#r60328519