### PR TITLE
cc2650stk: remove XTIMER_SHIFT_ON_COMPARE definition

### DIFF
--- a/boards/cc2650stk/include/board.h
+++ b/boards/cc2650stk/include/board.h
@@ -32,7 +32,6 @@ extern "C" {
  * @{
  */
 #define XTIMER_MASK                 (0xFFFF0000)
-#define XTIMER_SHIFT_ON_COMPARE     (7)
 /** @} */
 
 /**


### PR DESCRIPTION
only saw this afterwards :-(