### PR TITLE
drivers/periph: added flashrom driver interface

### DIFF
--- a/boards/airfy-beacon/Makefile.features
+++ b/boards/airfy-beacon/Makefile.features
@@ -1,6 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtt

--- a/boards/iotlab-common/Makefile.features
+++ b/boards/iotlab-common/Makefile.features
@@ -1,5 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt

--- a/boards/microbit/Makefile.features
+++ b/boards/microbit/Makefile.features
@@ -1,5 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtt

--- a/boards/nrf51dongle/Makefile.features
+++ b/boards/nrf51dongle/Makefile.features
@@ -1,5 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtt

--- a/boards/nrf52dk/Makefile.features
+++ b/boards/nrf52dk/Makefile.features
@@ -1,5 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtt

--- a/boards/nrf6310/Makefile.features
+++ b/boards/nrf6310/Makefile.features
@@ -1,5 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtt

--- a/boards/pca10000/Makefile.features
+++ b/boards/pca10000/Makefile.features
@@ -1,5 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtt

--- a/boards/pca10005/Makefile.features
+++ b/boards/pca10005/Makefile.features
@@ -1,6 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtt

--- a/boards/yunjia-nrf51822/Makefile.features
+++ b/boards/yunjia-nrf51822/Makefile.features
@@ -1,6 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtt

--- a/cpu/nrf51/include/cpu_conf.h
+++ b/cpu/nrf51/include/cpu_conf.h
@@ -31,8 +31,22 @@ extern "C" {
  * @brief   ARM Cortex-M specific CPU configuration
  * @{
  */
-#define CPU_DEFAULT_IRQ_PRIO            (1U)
-#define CPU_IRQ_NUMOF                   (26U)
+#define CPU_DEFAULT_IRQ_PRIO    (1U)
+#define CPU_IRQ_NUMOF           (26U)
+#define CPU_FLASH_BASE          (0x00000000)
+/** @} */
+
+/**
+ * @brief   Flash page configuration
+ * @{
+ */
+#define FLASHPAGE_SIZE          (1024U)
+
+#if defined(CPU_MODEL_NRF51X22XXAA)
+#define FLASHPAGE_NUMOF         (256U)
+#elif defined(CPU_MODEL_NRF51X22XXAB)
+#define FLASHPAGE_NUMOF         (128U)
+#endif
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/nrf51/include/nrf51.h
+++ b/cpu/nrf51/include/nrf51.h
@@ -1073,11 +1073,7 @@ typedef struct {                                    /*!< NVMC Structure         
   __I  uint32_t  READY;                             /*!< Ready flag.                                                           */
   __I  uint32_t  RESERVED1[64];
   __IO uint32_t  CONFIG;                            /*!< Configuration register.                                               */
-
-  union {
-    __IO uint32_t  ERASEPCR1;                       /*!< Register for erasing a non-protected non-volatile memory page.        */
-    __IO uint32_t  ERASEPAGE;                       /*!< Register for erasing a non-protected non-volatile memory page.        */
-  } nrf51_unnamed1;
+  __IO uint32_t  ERASEPAGE;                       /*!< Register for erasing a non-protected non-volatile memory page.        */
   __IO uint32_t  ERASEALL;                          /*!< Register for erasing all non-volatile user memory.                    */
   __IO uint32_t  ERASEPCR0;                         /*!< Register for erasing a protected non-volatile memory page.            */
   __IO uint32_t  ERASEUICR;                         /*!< Register for start erasing User Information Congfiguration Registers. */

--- a/cpu/nrf52/include/cpu_conf.h
+++ b/cpu/nrf52/include/cpu_conf.h
@@ -38,6 +38,17 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief   Flash page configuration
+ * @{
+ */
+#define FLASHPAGE_SIZE                  (4096U)
+
+#if defined(CPU_MODEL_NRF52XXAA)
+#define FLASHPAGE_NUMOF                 (128U)
+#endif
+/** @} */
+
+/**
  * @brief   SoftDevice settings
  * @{
  */

--- a/cpu/nrf52/include/nrf52.h
+++ b/cpu/nrf52/include/nrf52.h
@@ -2307,14 +2307,7 @@ typedef struct {                                    /*!< NVMC Structure         
     __I  uint32_t  RESERVED1[64];
     __IO uint32_t
     CONFIG;                            /*!< Configuration register                                                */
-
-    union {
-        __IO uint32_t
-        ERASEPCR1;                       /*!< Deprecated register - Register for erasing a page in Code area.
-                                                         Equivalent to ERASEPAGE.                                              */
-        __IO uint32_t
-        ERASEPAGE;                       /*!< Register for erasing a page in Code area                              */
-    };
+    __IO uint32_t ERASEPAGE;           /*!< Register for erasing a page in Code area                              */
     __IO uint32_t
     ERASEALL;                          /*!< Register for erasing all non-volatile user memory                     */
     __IO uint32_t

--- a/cpu/nrf5x_common/periph/flashpage.c
+++ b/cpu/nrf5x_common/periph/flashpage.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_nrf5x_common
+ * @{
+ *
+ * @file
+ * @brief       Low-level flash page driver implementation
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "assert.h"
+#include "periph/flashpage.h"
+
+void flashpage_write(int page, void *data)
+{
+    assert(page < FLASHPAGE_NUMOF);
+
+    uint32_t *page_addr = (uint32_t *)flashpage_addr(page);
+    uint32_t *data_addr = (uint32_t *)data;
+
+    /* erase given page */
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Een;
+    NRF_NVMC->ERASEPAGE = (uint32_t)page_addr;
+    while (NRF_NVMC->READY == 0) {}
+
+    /* write data to page */
+    if (data != NULL) {
+        NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen;
+        for (unsigned i = 0; i < (FLASHPAGE_SIZE / 4); i++) {
+            *page_addr++ = data_addr[i];
+        }
+    }
+
+    /* finish up */
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren;
+}

--- a/cpu/stm32f1/include/cpu_conf.h
+++ b/cpu/stm32f1/include/cpu_conf.h
@@ -45,6 +45,21 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief   Flash page configuration
+ * @{
+ */
+#define FLASHPAGE_SIZE      (2048U)
+
+#if defined(CPU_MODEL_STM32F103C8)
+#define FLASHPAGE_NUMOF     (32U)
+#elif defined(CPU_MODEL_STM32F103CB) || defined(CPU_MODEL_STM32F103RB)
+#define FLASHPAGE_NUMOF     (64U)
+#elif defined(CPU_MODEL_STM32F103RE)
+#define FLASHPAGE_NUMOF     (256U)
+#endif
+/** @} */
+
+/**
  * @brief Configure the CPU's clock system
  *
  * @param[in] source    source clock frequency

--- a/cpu/stm32f1/periph/flashpage.c
+++ b/cpu/stm32f1/periph/flashpage.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_stm32f1
+ * @{
+ *
+ * @file
+ * @brief       Low-level flash page driver implementation
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "assert.h"
+#include "periph/flashpage.h"
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+void flashpage_write(int page, void *data)
+{
+    assert(page < FLASHPAGE_NUMOF);
+
+    uint16_t *page_addr = flashpage_addr(page);
+    uint16_t *data_addr = (uint16_t *)data;
+    uint32_t hsi_state = (RCC->CR & RCC_CR_HSION);
+
+    /* the internal RC oscillator (HSI) must be enabled */
+    RCC->CR |= (RCC_CR_HSION);
+    while (!(RCC->CR & RCC_CR_HSIRDY)) {}
+
+    /* unlock the flash module */
+    DEBUG("[flashpage] unlocking the flash module\n");
+    if (FLASH->CR & FLASH_CR_LOCK) {
+        FLASH->KEYR = FLASH_KEY1;
+        FLASH->KEYR = FLASH_KEY2;
+    }
+
+    /* ERASE sequence */
+    /* make sure no flash operation is ongoing */
+    DEBUG("[flashpage] erase: waiting for any operation to finish\n");
+    while (FLASH->SR & FLASH_SR_BSY) {}
+    /* set page erase bit and program page address */
+    DEBUG("[flashpage] erase: setting the erase bit and page address\n");
+    FLASH->CR |= FLASH_CR_PER;
+    FLASH->AR = (uint32_t)flashpage_addr(page);
+    DEBUG("address to erase: %p\n", flashpage_addr(page));
+    /* trigger the page erase and wait for it to be finished */
+    DEBUG("[flashpage] erase: trigger the page erase\n");
+    FLASH->CR |= FLASH_CR_STRT;
+    DEBUG("[flashpage] erase: wait as long as device is busy\n");
+    while (FLASH->SR & FLASH_SR_BSY) {}
+    /* reset PER bit */
+    DEBUG("[flashpage] erase: resetting the page erase bit\n");
+    FLASH->CR &= ~(FLASH_CR_PER);
+
+    /* WRITE sequence */
+    if (data != NULL) {
+        DEBUG("[flashpage] write: now writing the data\n");
+        /* set PG bit and program page to flash */
+        FLASH->CR |= FLASH_CR_PG;
+        for (unsigned i = 0; i < (FLASHPAGE_SIZE / 2); i++) {
+            *page_addr++ = data_addr[i];
+            while (FLASH->SR & FLASH_SR_BSY) {}
+        }
+        /* clear program bit again */
+        FLASH->CR &= ~(FLASH_CR_PG);
+        DEBUG("[flashpage] write: done writing data\n");
+    }
+
+    /* finally, lock the flash module again */
+    DEBUG("flashpage] now locking the flash module again\n");
+    FLASH->CR |= FLASH_CR_LOCK;
+
+    /* restore the HSI state */
+    if (hsi_state) {
+        RCC->CR &= ~(RCC_CR_HSION);
+        while (RCC->CR & RCC_CR_HSIRDY) {}
+    }
+}

--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_periph_flashpage Flash page driver
+ * @ingroup     drivers_periph
+ * @brief       Low-level flash page interface
+ *
+ * @{
+ * @file
+ * @brief       Low-level flash page peripheral driver interface
+ *
+ * This interface provides a very simple and straight forward way for writing
+ * a MCU's internal flash. This interface is only capable of reading, verifying,
+ * and writing complete flash pages, it has no support for partial flash access.
+ * This enables for very slim and efficient implementations.
+ *
+ * A module for more fine-grained access of memory locations can easily be
+ * programmed on top of this interface.
+ *
+ * @note        Flash memory has only a limited amount of erase cycles (mostly
+ *              around 10K times), so using this interface in some kind of loops
+ *              can damage you MCU!
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef FLASHPAGE_H
+#define FLASHPAGE_H
+
+#include <stdint.h>
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Per default, we expect the internal flash to start at address 0
+ */
+#ifndef CPU_FLASH_BASE
+#define CPU_FLASH_BASE      (0)
+#endif
+
+/**
+ * @brief   Make sure the page size and the number of pages is defined
+ */
+#ifndef FLASHPAGE_SIZE
+#error "periph/flashpage: FLASHPAGE_SIZE not defined"
+#endif
+#ifndef FLASHPAGE_NUMOF
+#error "periph/flashpage: FLASHPAGE_NUMOF not defined"
+#endif
+
+/**
+ * @brief   Return values used in this interface
+ */
+enum {
+    FLASHPAGE_OK      =  0,     /**< everything succeeded */
+    FLASHPAGE_NOMATCH = -1      /**< page differs from target data */
+};
+
+/**
+ * @brief   Translate the given page number into the page's starting address
+ *
+ * @note    The given page MUST be valid, otherwise the returned address points
+ *          to an undefined memory location!
+ *
+ * @param[in] page      page number to get the address of
+ *
+ * @return              starting memory address of the given page
+ */
+static inline void *flashpage_addr(int page)
+{
+    return (void *)(CPU_FLASH_BASE + (page * FLASHPAGE_SIZE));
+}
+
+/**
+ * @brief   Write the given page with the given data
+ *
+ * @param[in] page      page to write
+ * @param[in] data      data to write to the page, MUST be @p FLASHPAGE_SIZE
+ *                      byte. Set to NULL for page erase only.
+ */
+void flashpage_write(int page, void *data);
+
+/**
+ * @brief   Read the given page into the given memory location
+ *
+ * @param[in]  page     page to read
+ * @param[out] data     memory to write the page to, MUST be @p FLASHPAGE_SIZE
+ *                      byte
+ */
+void flashpage_read(int page, void *data);
+
+/**
+ * @brief   Verify the given page against the given data
+ *
+ * @param[in] page      page to verify
+ * @param[in] data      data to compare page against, MUST be @p FLASHPAGE_SIZE
+ *                      byte of data
+ *
+ * @return              FLASHPAGE_OK if data in the page is identical to @p data
+ * @return              FLASHPAGE_NOMATCH if data and page content diverge
+ */
+int flashpage_verify(int page, void *data);
+
+/**
+ * @brief   Write the given page and verify the results
+ *
+ * This is a convenience function wrapping flashpage_write and flashpage_verify.
+ *
+ * @param[in] page      page to write
+ * @param[in] data      data to write to the page, MUST be @p FLASHPAGE_SIZE
+ *                      byte.
+ *
+ * @return              FLASHPAGE_OK on success
+ * @return              FLASHPAGE_NOMATCH if data and page content diverge
+ */
+int flashpage_write_and_verify(int page, void *data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FLASHPAGE_H */
+/** @} */

--- a/drivers/periph_common/flashpage.c
+++ b/drivers/periph_common/flashpage.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers
+ * @{
+ *
+ * @file
+ * @brief       Common flash page functions
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+#include "cpu.h"
+#include "assert.h"
+
+/* guard this file, must be done before including periph/flashpage.h
+ * TODO: remove as soon as periph drivers can be build selectively */
+#if defined(FLASHPAGE_NUMOF) && defined(FLASHPAGE_SIZE)
+
+#include "periph/flashpage.h"
+
+void flashpage_read(int page, void *data)
+{
+    assert(page < FLASHPAGE_NUMOF);
+
+    memcpy(data, flashpage_addr(page), FLASHPAGE_SIZE);
+}
+
+int flashpage_verify(int page, void *data)
+{
+    assert(page < FLASHPAGE_NUMOF);
+
+    if (memcmp(flashpage_addr(page), data, FLASHPAGE_SIZE) == 0) {
+        return FLASHPAGE_OK;
+    }
+    else {
+        return FLASHPAGE_NOMATCH;
+    }
+}
+
+int flashpage_write_and_verify(int page, void *data)
+{
+    flashpage_write(page, data);
+    return flashpage_verify(page, data);
+}
+
+#endif

--- a/tests/periph_flashpage/Makefile
+++ b/tests/periph_flashpage/Makefile
@@ -1,0 +1,8 @@
+export APPLICATION = periph_flashpage
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_flashpage
+
+USEMODULE += shell
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_flashpage/README.md
+++ b/tests/periph_flashpage/README.md
@@ -1,0 +1,38 @@
+Expected result
+===============
+Use the provided shell commands, to read and write pages from/to the MCU's
+internal flash memory. For altering the data in a flash page, use a sequence
+similar to this:
+- read some page from the flash, this will load this page into a local buffer
+```
+read 100
+```
+- edit the contents of the local buffer, here we write 'Hello_RIOT' to position
+  100
+```
+edit 100 Hello_RIOT
+```
+- write the local buffer to any target page in the flash. CAUTION: if you
+  override any page, that contains program code (or even the interrupt vector),
+  you will most like encounter hard faults and crashes which can only be fixed
+  by re-flashing the node...
+```
+write 100
+```
+- check if the contents were written
+```
+dump 100
+```
+- now power off the node, wait a bit and power it back on. The contents of the
+  page written previously should still be there
+
+What else to check:
+- Erase a page with previously known contents, to make sure the erasing works
+- also check the pages before and after the targeted page, to see if the page
+  size is correct, and that you are only erasing the actual page and not any
+  parts of the neighboring page.
+
+Background
+==========
+This test provides you with tools to test implementations of the `flashpage`
+peripheral driver interface.

--- a/tests/periph_flashpage/main.c
+++ b/tests/periph_flashpage/main.c
@@ -1,0 +1,268 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Manual test application for UART peripheral drivers
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "shell.h"
+#include "periph/flashpage.h"
+
+#define LINE_LEN            (16)
+
+/**
+ * @brief   Allocate space for 1 flash page in RAM
+ */
+static uint8_t page_mem[FLASHPAGE_SIZE];
+
+static int getpage(const char *str)
+{
+    int page = atoi(str);
+    if ((page >= FLASHPAGE_NUMOF) || (page < 0)) {
+        printf("error: page %i is invalid\n", page);
+        return -1;
+    }
+    return page;
+}
+
+static void dumpchar(uint8_t mem)
+{
+    if (mem >= ' ' && mem <= '~') {
+        printf("  %c  ", mem);
+    }
+    else {
+        printf("  ?? ");
+    }
+}
+
+static void memdump(void *addr, size_t len)
+{
+    unsigned pos = 0;
+    uint8_t *mem = (uint8_t *)addr;
+
+    while (pos < (unsigned)len) {
+        for (unsigned i = 0; i < LINE_LEN; i++) {
+            printf("0x%02x ", mem[pos + i]);
+        }
+        puts("");
+        for (unsigned i = 0; i < LINE_LEN; i++) {
+            dumpchar(mem[pos++]);
+        }
+        puts("");
+    }
+}
+
+static void dump_local(void)
+{
+    puts("Local page buffer:");
+    memdump(page_mem, FLASHPAGE_SIZE);
+}
+
+static int cmd_info(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    printf("Flash start addr:\t0x%08x\n", (int)CPU_FLASH_BASE);
+    printf("Page size:\t\t%i\n", (int)FLASHPAGE_SIZE);
+    printf("Number of pages:\t%i\n", (int)FLASHPAGE_NUMOF);
+
+    return 0;
+}
+
+static int cmd_dump(int argc, char **argv)
+{
+    int page;
+    void *addr;
+
+    if (argc < 2) {
+        printf("usage: %s <page>\n", argv[0]);
+        return 1;
+    }
+
+    page = getpage(argv[1]);
+    if (page < 0) {
+        return 1;
+    }
+    addr = flashpage_addr(page);
+
+    printf("Flash page %i at address %p\n", page, addr);
+    memdump(addr, FLASHPAGE_SIZE);
+
+    return 0;
+}
+
+static int cmd_dump_local(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    dump_local();
+
+    return 0;
+}
+
+static int cmd_read(int argc, char **argv)
+{
+    int page;
+
+    if (argc < 2) {
+        printf("usage: %s <page>\n", argv[0]);
+        return 1;
+    }
+
+    page = getpage(argv[1]);
+    if (page < 0) {
+        return 1;
+    }
+
+    flashpage_read(page, page_mem);
+    printf("Read flash page %i into local page buffer\n", page);
+    dump_local();
+
+    return 0;
+}
+
+static int cmd_write(int argc, char **argv)
+{
+    int page;
+
+    if (argc < 2) {
+        printf("usage: %s <page>\n", argv[0]);
+        return 1;
+    }
+
+    page = getpage(argv[1]);
+    if (page < 0) {
+        return 1;
+    }
+
+    if (flashpage_write_and_verify(page, page_mem) != FLASHPAGE_OK) {
+        printf("error: verification for page %i failed\n", page);
+        return 1;
+    }
+
+    printf("wrote local page to flash page %i at addr %p\n",
+           page, flashpage_addr(page));
+    return 0;
+}
+
+static int cmd_erase(int argc, char **argv)
+{
+    int page;
+
+    if (argc < 2) {
+        printf("usage: %s <page>\n", argv[0]);
+        return 1;
+    }
+
+    page = getpage(argv[1]);
+    if (page < 0) {
+        return 1;
+    }
+    flashpage_write(page, NULL);
+
+    printf("successfully erased page %i (addr %p)\n",
+           page, flashpage_addr(page));
+    return 0;
+}
+
+static int cmd_edit(int argc, char **argv)
+{
+    int offset;
+    size_t data_len;
+
+    if (argc < 3) {
+        printf("usage: %s <offset> <data>\n", argv[0]);
+        return 1;
+    }
+
+    offset = atoi(argv[1]);
+    if (offset >= FLASHPAGE_SIZE) {
+        printf("error: given offset is out of bounce\n");
+        return -1;
+    }
+    data_len = strlen(argv[2]);
+    if ((data_len + offset) > FLASHPAGE_SIZE) {
+        data_len = FLASHPAGE_SIZE - offset;
+    }
+
+    memcpy(&page_mem[offset], argv[2], data_len);
+    dump_local();
+
+    return 0;
+}
+
+static int cmd_test(int argc, char **argv)
+{
+    int page;
+    char fill = 'a';
+
+    if (argc < 2) {
+        printf("usage: %s <page>\n", argv[0]);
+        return 1;
+    }
+
+    page = getpage(argv[1]);
+    if (page < 0) {
+        return 1;
+    }
+
+    for (int i = 0; i < sizeof(page_mem); i++) {
+        page_mem[i] = (uint8_t)fill++;
+        if (fill > 'z') {
+            fill = 'a';
+        }
+    }
+
+    if (flashpage_write_and_verify(page, page_mem) != FLASHPAGE_OK) {
+        printf("error verifying the content of page %i: ", page);
+        return 1;
+    }
+
+    printf("wrote local page to flash page %i at addr %p\n",
+           page, flashpage_addr(page));
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "info", "Show information about pages", cmd_info },
+    { "dump", "Dump the selected page to STDOUT", cmd_dump },
+    { "dump_local", "Dump the local page buffer to STDOUT", cmd_dump_local },
+    { "read", "Read and output the given page", cmd_read },
+    { "write", "Write (ASCII) data to the given page", cmd_write },
+    { "erase", "Erase the given page", cmd_erase },
+    { "edit", "Write bytes to the local page", cmd_edit },
+    { "test", "Write and verify test pattern", cmd_test },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("ROM flash read write test\n");
+    puts("Please refer to the README.md for further information\n");
+
+    cmd_info(0, NULL);
+
+    /* run the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    return 0;
+}


### PR DESCRIPTION
Before I leave for parental leave, here something that I did some weeks ago...

The `flashrom` interface provides a very simple and straight forward way, to write (complete) pages in a MCU's internal flash memory. This should be considered as a base for other moduls, e.g. over-the-air-updating, config-stores, etc...

It is implemented so far for the `nrf5x` and `stm32f1` CPUs, and tested on the `airfy-beacon`, `nrf51dongle`,`nrf52dk`, `iotlab-m3`. 
