### PR TITLE
boards/saml21-xpro & boards/samr21-xpro: added dummy ADC and DAC config

### DIFF
--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -101,6 +101,22 @@ extern "C" {
 #define RTT_NUMOF           (1)
 /** @} */
 
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_NUMOF           (0)
+/** @} */
+
+/**
+ * @brief   DAC configuration
+ * @{
+ */
+#define DAC_NUMOF           (0)
+/** @} */
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -211,6 +211,15 @@ static const pwm_conf_t pwm_config[] = {
 #define I2C_0_PINS          (PORT_PA16 | PORT_PA17)
 
 /**
+ * @brief   ADC configuration
+ *
+ * The configuration consists simply of a list of channels that should be used
+ * @{
+ */
+#define ADC_NUMOF          (0)
+/** @} */
+
+/**
  * @name RTC configuration
  * @{
  */
@@ -230,6 +239,20 @@ static const pwm_conf_t pwm_config[] = {
 #define RTT_MAX_VALUE       (0xffffffff)
 #define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
 #define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
+/** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_NUMOF           (0)
+/** @} */
+
+/**
+ * @brief   DAC configuration
+ * @{
+ */
+#define DAC_NUMOF           (0)
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
Signed-off-by: Benjamin Cabé <benjamin@eclipse.org>