### PR TITLE
tests_printf_float: fixed precision in test case

### DIFF
--- a/tests/printf_float/main.c
+++ b/tests/printf_float/main.c
@@ -33,7 +33,7 @@ int main(void)
     const uint8_t str_len = strlen(expected_result);
     char result[str_len];
     snprintf(result, str_len + 1,
-             "%.f", floating_point_value);
+             "%.1f", floating_point_value);
 
     printf("Value displayed: %s\n", result);
 


### PR DESCRIPTION
While testing for Release 2016.04 it turned out that the test always failed. A precision value according to the reference string was missing.