### PR TITLE
make debug: start gdb quietly

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -83,7 +83,7 @@ endif
 export TERMFLAGS := $(PORT) $(TERMFLAGS)
 
 export ASFLAGS =
-export DEBUGGER_FLAGS = --args $(ELF) $(TERMFLAGS)
+export DEBUGGER_FLAGS = -q --args $(ELF) $(TERMFLAGS)
 term-valgrind: export VALGRIND_FLAGS ?= \
 	--track-origins=yes \
 	--fullpath-after=$(RIOTBASE)/ \

--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -171,7 +171,7 @@ do_debug() {
     # save PID for terminating the server afterwards
     DBG_PID=$?
     # connect to the GDB server
-    ${DBG} ${TUI} -ex "tar ext :${GDB_PORT}" ${ELFFILE}
+    ${DBG} -q ${TUI} -ex "tar ext :${GDB_PORT}" ${ELFFILE}
     # clean up
     kill ${DBG_PID}
 }

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -211,7 +211,7 @@ do_debug() {
             -l /dev/null & \
             echo \$! > $OCD_PIDFILE" &
     # connect to the GDB server
-    ${DBG} ${TUI} -ex "tar ext :${GDB_PORT}" ${ELFFILE}
+    ${DBG} -q ${TUI} -ex "tar ext :${GDB_PORT}" ${ELFFILE}
     # will be called by trap
     cleanup() {
         OCD_PID="$(cat $OCD_PIDFILE)"


### PR DESCRIPTION
I don't see the need for the gdb copyright info to be printed when running `make debug`. I'm not sure if this is the cleanest way to do it though, any thoughts?