### PR TITLE
doc: xtimer: be a bit more precise

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -97,7 +97,7 @@ void xtimer_now_timex(timex_t *out);
 void xtimer_init(void);
 
 /**
- * @brief Stop execution of a thread for some time
+ * @brief Pause the execution of a thread for some seconds
  *
  * When called from an ISR, this function will spin and thus block the MCU in
  * interrupt context for the specified amount in *seconds*, so don't *ever* use
@@ -108,7 +108,7 @@ void xtimer_init(void);
 static void xtimer_sleep(uint32_t seconds);
 
 /**
- * @brief Stop execution of a thread for some time
+ * @brief Pause the execution of a thread for some microseconds
  *
  * When called from an ISR, this function will spin and thus block the MCU for
  * the specified amount in microseconds, so only use it there for *very* short


### PR DESCRIPTION
Just realized when looking at ~~https://github.com/cn-uofbasel/ccn-lite/blob/master/src/ccnl-core.c#L716~~ http://doc.riot-os.org/group__sys__xtimer.html#details that the description was not really helpful.