### PR TITLE
lwip: introduce MLD as pseudo-module and deactivate by default

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -365,7 +365,7 @@ ifneq (,$(filter lwip_sixlowpan,$(USEMODULE)))
   USEMODULE += lwip_ipv6_autoconfig
 endif
 
-ifneq (,$(filter lwip_ipv6_autoconfig,$(USEMODULE)))
+ifneq (,$(filter lwip_ipv6_autoconfig lwip_ipv6_mld,$(USEMODULE)))
   USEMODULE += lwip_ipv6
 endif
 

--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -25,6 +25,7 @@ PSEUDOMODULES += lwip_dhcp
 PSEUDOMODULES += lwip_ethernet
 PSEUDOMODULES += lwip_igmp
 PSEUDOMODULES += lwip_ipv6_autoconfig
+PSEUDOMODULES += lwip_ipv6_mld
 PSEUDOMODULES += lwip_raw
 PSEUDOMODULES += lwip_sixlowpan
 PSEUDOMODULES += lwip_stats

--- a/pkg/lwip/include/lwipopts.h
+++ b/pkg/lwip/include/lwipopts.h
@@ -74,6 +74,12 @@ extern "C" {
 #define LWIP_IPV6_AUTOCONFIG    (0)
 #endif /* MODULE_LWIP_IPV6_AUTOCONFIG */
 
+#ifdef MODULE_LWIP_IPV6_MLD
+#define LWIP_IPV6_MLD           (1)
+#else  /* MODULE_LWIP_IPV6 */
+#define LWIP_IPV6_MLD           (0)
+#endif /* MODULE_LWIP_IPV6 */
+
 #ifdef MODULE_LWIP_IPV6
 #define LWIP_IPV6               (1)
 #else  /* MODULE_LWIP_IPV6 */

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-mega2560 msb-430h nrf6310 \
                              nucleo-f334 pca10005 stm32f0discovery weio \
                              yunjia-nrf51822 z1
 
+# including lwip_ipv6_mld would currently break this test on at86rf2xx radios
 USEMODULE += lwip lwip_ipv6_autoconfig lwip_conn_ip lwip_netdev2
 USEMODULE += lwip_udp lwip_conn_udp
 USEMODULE += ipv6_addr


### PR DESCRIPTION
See https://github.com/RIOT-OS/RIOT/issues/5394#issuecomment-215378841

(Fixes #5394 in a not so nice way)