### PR TITLE
doc: minor fixes of typos in periph documentation

### DIFF
--- a/drivers/include/periph/hwrng.h
+++ b/drivers/include/periph/hwrng.h
@@ -43,7 +43,7 @@ extern "C" {
  * On some platforms, the random number generator needs some global
  * initialization before it can be used. This should happen in this function
  * if it would impose too much overhead to do this everytime the hwrng_read
- * function is called. The device should however be put into power of mode
+ * function is called. The device should however be put into power-off mode
  * after initialization and will be powered on and of when hwrng_read is called.
  */
 void hwrng_init(void);

--- a/drivers/include/periph/pwm.h
+++ b/drivers/include/periph/pwm.h
@@ -141,7 +141,7 @@ void pwm_stop(pwm_t dev);
 /**
  * @brief   Power on the PWM device
  *
- * When the device is powered on the first time, not configuration is set. If
+ * When the device is powered on the first time, no configuration is set. If
  * the device is powered back on, after having been initialized and powered off
  * before, the PWM device will continue its operation with the previously set
  * configuration. So there is no need in re-initializing then.


### PR DESCRIPTION
Just two minor typos I found.