### PR TITLE
drivers: msp430: software i2c implementation

### DIFF
--- a/cpu/msp430fxyz/periph/i2c.c
+++ b/cpu/msp430fxyz/periph/i2c.c
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2016 Pavol Malosek <malo@25cmsquare.io>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_msp430fxyz
+ * @{
+ *
+ * @file
+ * @brief       I2C functions implementation.
+ *
+ * @author      Pavol Malosek <malo@25cmsquare.io>
+ *
+ * @}
+ */
+
+#include "periph_conf.h"
+#include "mutex.h"
+#include "periph/i2c.h"
+#include "periph/gpio.h"
+#include "periph/i2c_sw.h"
+
+#if (I2C_NUMOF > 2U)
+#error "Only two sw I2C buses are supported!"
+#endif
+
+#if ((I2C_0_EN == 1) || (I2C_1_EN ==1))
+static mutex_t locks[] =  {
+    [I2C_DEV(0)] = MUTEX_INIT,
+    [I2C_DEV(1)] = MUTEX_INIT,
+};
+#endif
+
+int i2c_acquire(i2c_t dev)
+{
+#if I2C_0_EN
+    if (dev == I2C_DEV(0)) {
+        mutex_lock(&locks[dev]);
+        return 0;
+    }
+#endif
+#if I2C_1_EN
+    if (dev == I2C_DEV(1)) {
+        mutex_lock(&locks[dev]);
+        return 0;
+    }
+#endif
+    return -1;
+}
+
+int i2c_release(i2c_t dev)
+{
+#if I2C_0_EN
+    if (dev == I2C_DEV(0)) {
+        mutex_unlock(&locks[dev]);
+        return 0;
+    }
+#endif
+#if I2C_1_EN
+    if (dev == I2C_DEV(1)) {
+        mutex_unlock(&locks[dev]);
+        return 0;
+    }
+#endif
+    return -1;
+}
+
+#ifdef I2C_SOFTWARE
+
+/* Do not have open drain outputs - config as input */
+void i2c_sw_set_SCL(i2c_t dev)
+{
+    switch (dev) {
+#if I2C_0_EN
+        case I2C_DEV(0):
+            gpio_init(I2C_0_SCL_PIN, GPIO_IN);
+            break;
+#endif
+#if I2C_1_EN
+        case I2C_DEV(1):
+            gpio_init(I2C_1_SCL_PIN, GPIO_IN);
+            break;
+#endif
+        default:
+            break;
+    }
+}
+
+/* Active drive to low */
+void i2c_sw_clear_SCL(i2c_t dev)
+{
+    switch (dev) {
+#if I2C_0_EN
+        case I2C_DEV(0):
+            gpio_init(I2C_0_SCL_PIN, GPIO_OUT);
+            break;
+#endif
+#if I2C_1_EN
+        case I2C_DEV(1):
+            gpio_init(I2C_1_SCL_PIN, GPIO_OUT);
+            break;
+#endif
+        default:
+            break;
+    }
+}
+
+/* Do not have open drain outputs - config as input */
+void i2c_sw_set_SDA(i2c_t dev)
+{
+    switch (dev) {
+#if I2C_0_EN
+        case I2C_DEV(0):
+            gpio_init(I2C_0_SDA_PIN, GPIO_IN);
+            break;
+#endif
+#if I2C_1_EN
+        case I2C_DEV(1):
+            gpio_init(I2C_1_SDA_PIN, GPIO_IN);
+            break;
+#endif
+        default:
+            break;
+    }
+}
+
+/* Active drive to low */
+void i2c_sw_clear_SDA(i2c_t dev)
+{
+    switch (dev) {
+#if I2C_0_EN
+        case I2C_DEV(0):
+            gpio_init(I2C_0_SDA_PIN, GPIO_OUT);
+            break;
+#endif
+#if I2C_1_EN
+        case I2C_DEV(1):
+            gpio_init(I2C_1_SDA_PIN, GPIO_OUT);
+            break;
+#endif
+        default:
+            break;
+    }
+}
+
+int i2c_sw_read_SCL(i2c_t dev)
+{
+    switch (dev) {
+#if I2C_0_EN
+        case I2C_DEV(0):
+            return gpio_read(I2C_0_SCL_PIN) ? 1 : 0;
+#endif
+#if I2C_1_EN
+        case I2C_DEV(1):
+            return gpio_read(I2C_1_SCL_PIN) ? 1 : 0;
+#endif
+        default:
+            break;
+    }
+
+    return -1;
+}
+
+int i2c_sw_read_SDA(i2c_t dev)
+{
+    switch (dev) {
+#if I2C_0_EN
+        case I2C_DEV(0):
+            return gpio_read(I2C_0_SDA_PIN) ? 1 : 0;
+#endif
+#if I2C_1_EN
+        case I2C_DEV(1):
+            return gpio_read(I2C_1_SDA_PIN) ? 1 : 0;
+#endif
+        default:
+            break;
+    }
+
+    return -1;
+}
+
+void i2c_sw_delay_2_35us(void)
+{
+    /* On slow platform there is no need for actual delay
+     * since calling this function takes much longer than 2.35us */
+}
+
+void i2c_sw_delay_4_70us(void)
+{
+    i2c_sw_delay_2_35us();
+    i2c_sw_delay_2_35us();
+}
+
+void i2c_sw_delay_4_00us(void)
+{
+    i2c_sw_delay_2_35us();
+    i2c_sw_delay_2_35us();
+}
+
+int i2c_sw_init_gpio(i2c_t dev)
+{
+    switch (dev) {
+#if I2C_0_EN
+        case I2C_DEV(0):
+            gpio_periph_mode(I2C_0_SCL_PIN, false);
+            gpio_periph_mode(I2C_0_SDA_PIN, false);
+            break;
+#endif
+#if I2C_1_EN
+        case I2C_DEV(1):
+            gpio_periph_mode(I2C_1_SCL_PIN, false);
+            gpio_periph_mode(I2C_1_SDA_PIN, false);
+            break;
+#endif
+        default:
+            return -1;
+    }
+    return 0;
+}
+#else
+/* Here goes hw i2c implementation. */
+ #endif

--- a/drivers/include/periph/i2c_sw.h
+++ b/drivers/include/periph/i2c_sw.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2016 Pavol Malosek <malo@25cmsquare.io>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_periph
+ * @brief       Software I2C functions declarations.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Software I2C functions declarations.
+ *
+ * @author      Pavol Malosek <malo@25cmsquare.io>
+ */
+
+#ifndef I2C_SW_H
+#define I2C_SW_H
+
+#include "periph/i2c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Initialize GPIOs as general purpose pins.
+ *
+ * @param[in] dev           device descriptor
+ * @return                  zero on success
+ * @return                  -1 on unknown device
+ */
+int i2c_sw_init_gpio(i2c_t dev);
+
+/**
+ * @brief   Release SCL line.
+ *
+ * @param[in] dev           device descriptor
+ */
+void i2c_sw_set_SCL(i2c_t dev);
+
+/**
+ * @brief   Drive SCL line to 0.
+ *
+ * @param[in] dev           device descriptor
+ */
+void i2c_sw_clear_SCL(i2c_t dev);
+
+/**
+ * @brief   Release SDA line.
+ *
+ * @param[in] dev           device descriptor
+ */
+void i2c_sw_set_SDA(i2c_t dev);
+
+/**
+ * @brief   Drive SDA line to 0.
+ *
+ * @param[in] dev           device descriptor
+ */
+void i2c_sw_clear_SDA(i2c_t dev);
+
+/**
+ * @brief   Read SCL line.
+ *
+ * @param[in] dev           device descriptor
+ * @return                  1 on SCL HI
+ * @return                  0 on SCL LOW
+ * @return                  -1 on unknown device
+ */
+int i2c_sw_read_SCL(i2c_t dev);
+
+/**
+ * @brief   Read SCL line.
+ *
+ * @param[in] dev           device descriptor
+ * @return                  1 on SDA HI
+ * @return                  0 on SDA LOW
+ * @return                  -1 on unknown device
+ */
+int i2c_sw_read_SDA(i2c_t dev);
+
+/**
+ * @brief   Delay half of the LOW period of the SCL clock.
+ */
+void i2c_sw_delay_2_35us(void);
+/**
+ * @brief   Delay LOW period of the SCL clock.
+ */
+void i2c_sw_delay_4_70us(void);
+/**
+ * @brief   Delay HIGH period of the SCL clock.
+ */
+void i2c_sw_delay_4_00us(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* I2C_SW_H */
+/** @} */

--- a/drivers/periph_common/i2c_sw.c
+++ b/drivers/periph_common/i2c_sw.c
@@ -1,0 +1,274 @@
+/*
+ * Copyright (C) 2016 Pavol Malosek <malo@25cmsquare.io>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_periph
+ * @{
+ *
+ * @file
+ * @brief       Software single master I2C implementation with clock stretch.
+ * @brief       spec: http://www.nxp.com/documents/user_manual/UM10204.pdf
+ *
+ * @author      Pavol Malosek <malo@25cmsquare.io>
+ *
+ * @}
+ */
+
+#include "periph/i2c_sw.h"
+#include "periph_conf.h"
+#include "periph/timer.h"
+#include "log.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#ifdef I2C_SOFTWARE
+
+/* Do not use higher timeouts than 0xFFFF since on some platforms
+ * timer_read returns uint16_t */
+#define CLOCK_STRETCH_TIMEOUT_US (50000U)
+
+static inline int wait_for_SCL(i2c_t dev)
+{
+    unsigned int start_stamp = timer_read(XTIMER);
+    while ((timer_read(XTIMER) - start_stamp) < CLOCK_STRETCH_TIMEOUT_US) {
+        //  Check if SCL is up.
+        if (i2c_sw_read_SCL(dev)) {
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+static inline void _bit_out(i2c_t dev, unsigned int bit)
+{
+    /* put data on SDA */
+    if (bit) {
+        i2c_sw_set_SDA(dev);
+    }
+    else {
+        i2c_sw_clear_SDA(dev);
+    }
+
+    /* wait half of tLOW */
+    i2c_sw_delay_2_35us();
+    /* set SCL */
+    i2c_sw_set_SCL(dev);
+    /* wait tHIGH */
+    i2c_sw_delay_4_00us();
+    /* check for clock stretch */
+    if (wait_for_SCL(dev) != 0) {
+        LOG_ERROR("out: SCL line down too long - clock stretch timeout\n");
+    }
+    i2c_sw_clear_SCL(dev);
+    /* wait half of tLOW */
+    i2c_sw_delay_2_35us();
+}
+
+static inline int _bit_in(i2c_t dev, unsigned int last)
+{
+    unsigned int bit;
+    /* slave is driving the data line */
+    i2c_sw_set_SDA(dev);
+    /* set SCL */
+    i2c_sw_set_SCL(dev);
+    /* wait tHIGH */
+    i2c_sw_delay_4_00us();
+    /* check clock stretch */
+    if (wait_for_SCL(dev) != 0) {
+        LOG_ERROR("in: SCL line down too long - clock stretch timeout\n");
+    }
+    /* read SDA */
+    bit = i2c_sw_read_SDA(dev);
+    /* clear SCL */
+    i2c_sw_clear_SCL(dev);
+    /* wait tLOW */
+    if (!last) {
+        i2c_sw_delay_4_70us();
+    }
+    else {
+        i2c_sw_delay_2_35us();
+    }
+
+    return bit;
+}
+
+static int _byte_out(i2c_t dev, char byte)
+{
+    DEBUG("{0x%x}", byte & 0xFF);
+    unsigned int ack;
+    unsigned int count = 8;
+    do {
+        _bit_out(dev, byte & 0x80);
+        byte <<= 1;
+    } while (--count);
+
+    /* read ACk */
+    ack = _bit_in(dev, 0);
+
+    return ack ? -1 : 0;
+}
+
+static char _byte_in(i2c_t dev, unsigned int ack)
+{
+    unsigned char byte = 0;
+    unsigned int count = 8;
+    unsigned int last  = 0;
+    do {
+        if (count == 1) {
+            last = 1;
+        }
+        /* read the data */
+        byte <<= 1;
+        byte |= _bit_in(dev, last);
+    } while (--count);
+
+    /* send ACK */
+    _bit_out(dev, ack);
+
+    DEBUG("[0x%x]", byte & 0xFF);
+
+    return byte;
+}
+
+static int _start(i2c_t dev)
+{
+    i2c_sw_set_SDA(dev);
+    i2c_sw_set_SCL(dev);
+
+    /* bus is busy */
+    if (i2c_sw_read_SDA(dev) == 0) {
+        LOG_ERROR("SDA line down - bus is busy/no pullup\n");
+        return -1;
+    }
+
+    /* check SCL */
+    if (wait_for_SCL(dev) != 0) {
+        LOG_ERROR("SCL line down - bus is busy/no pullup\n");
+        return -1;
+    }
+
+    /* tBUF */
+    i2c_sw_delay_4_70us();
+    i2c_sw_clear_SDA(dev);
+    /* tHD; STA */
+    i2c_sw_delay_4_00us();
+    i2c_sw_clear_SCL(dev);
+    /* wait half of tLOW */
+    i2c_sw_delay_2_35us();
+
+    return 0;
+}
+
+static void _stop(i2c_t dev)
+{
+    i2c_sw_clear_SDA(dev);
+    /* wait half of tLOW */
+    i2c_sw_delay_2_35us();
+    i2c_sw_set_SCL(dev);
+    /* tSU; STO */
+    i2c_sw_delay_4_00us();
+    i2c_sw_set_SDA(dev);
+}
+
+static int _send_address(i2c_t dev, uint8_t address, uint8_t rw_flag)
+{
+    char byte = address << 1 | rw_flag;
+    if (_start(dev) != 0) {
+        return -1;
+    }
+
+    return _byte_out(dev, byte);
+}
+
+int i2c_init_master(i2c_t dev, i2c_speed_t speed)
+{
+    if (speed != I2C_SPEED_NORMAL) {
+        return -2;
+    }
+
+    if (i2c_sw_init_gpio(dev) != 0) {
+        return -1;
+    }
+
+    i2c_sw_set_SDA(dev);
+    i2c_sw_set_SCL(dev);
+
+    return 0;
+}
+
+int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
+{
+    switch (dev) {
+#if I2C_0_EN
+        case I2C_DEV(0):
+            break;
+#endif
+#if I2C_1_EN
+        case I2C_DEV(1):
+            break;
+#endif
+    default:
+        return -1;
+    }
+
+    int byte_count = length;
+    if (_send_address(dev, address, I2C_FLAG_WRITE) != 0) {
+        return -2;
+    }
+
+    while(byte_count--) {
+        if (_byte_out(dev, *data++) != 0) {
+            _stop(dev);
+            return -1;
+        }
+    }
+    _stop(dev);
+
+    return length;
+}
+
+int i2c_write_byte(i2c_t dev, uint8_t address, char data)
+{
+    return i2c_write_bytes(dev, address, &data, sizeof(data));
+}
+
+int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
+{
+    switch (dev) {
+#if I2C_0_EN
+        case I2C_DEV(0):
+            break;
+#endif
+#if I2C_1_EN
+        case I2C_DEV(1):
+            break;
+#endif
+    default:
+        return -1;
+    }
+
+    int byte_count = length;
+    if (_send_address(dev, address, I2C_FLAG_READ) != 0) {
+        return -2;
+    }
+
+    while(byte_count--) {
+        *data++ = _byte_in(dev, !byte_count);
+    }
+    _stop(dev);
+
+    return length;
+}
+
+int i2c_read_byte(i2c_t dev, uint8_t address, char *data)
+{
+    return i2c_read_bytes(dev, address, data, 1);
+}
+#endif


### PR DESCRIPTION
Hello riots,

proposing software single master i2c implementation with clock stretch feature. 
Wanted to separate the main logic from pin handling to make it more usable across platforms. The cost is speed, where on slower platforms is quite far from minimal spec timings. Supports up to two i2c buses on I2C_SPEED_NORMAL.

To use it, just implement functions from i2c_sw.h for particular platform and add 
```c
# define I2C_SOFTWARE
# define I2C_NUMOF           (1U)
# define I2C_0_EN            1
# define I2C_0_SCL_PIN       GPIO_PIN(P2, 0)
# define I2C_0_SDA_PIN       GPIO_PIN(P2, 1)
```
to the periph_conf.h

feedback is welcome
wbr
malo
