### PR TITLE
xtimer: return after xtimer_spin() when within an ISR

### DIFF
--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -39,6 +39,7 @@ void _xtimer_sleep(uint32_t offset, uint32_t long_offset)
     if (irq_is_in()) {
         assert(!long_offset);
         xtimer_spin(offset);
+        return;
     }
 
     xtimer_t timer;


### PR DESCRIPTION
Forgive me if I'm missing something but this seems like what the author originally intended. It doesn't make sense to spin and then set a mutex for the same timeout, especially within an ISR.