### PR TITLE
sys: make xtimer isr-safe

### DIFF
--- a/examples/timer_periodic_wakeup/main.c
+++ b/examples/timer_periodic_wakeup/main.c
@@ -27,7 +27,7 @@
 
 int main(void)
 {
-    uint32_t last_wakeup = xtimer_now();
+    uint64_t last_wakeup = xtimer_now();
 
     while(1) {
         xtimer_periodic_wakeup(&last_wakeup, INTERVAL);

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -161,7 +161,7 @@ static inline void xtimer_spin(uint32_t microseconds);
  * @param[in] last_wakeup   base time stamp for the wakeup
  * @param[in] period        time in microseconds that will be added to last_wakeup
  */
-void xtimer_periodic_wakeup(uint32_t *last_wakeup, uint32_t period);
+void xtimer_periodic_wakeup(uint64_t *last_wakeup, uint32_t period);
 
 /**
  * @brief Set a timer that sends a message
@@ -407,7 +407,7 @@ int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t us);
 #if XTIMER_WIDTH != 32
 #define XTIMER_MASK ((0xffffffff >> XTIMER_WIDTH) << XTIMER_WIDTH)
 #else
-#define XTIMER_MASK (0)
+#define XTIMER_MASK (0U)
 #endif
 
 #define XTIMER_MASK_SHIFTED XTIMER_TICKS_TO_USEC(XTIMER_MASK)

--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -71,7 +71,7 @@ static inline uint32_t _xtimer_lltimer_mask(uint32_t val)
  * @brief xtimer internal stuff
  * @internal
  */
-int _xtimer_set_absolute(xtimer_t *timer, uint32_t target);
+void _xtimer_set_absolute(xtimer_t *timer);
 void _xtimer_set64(xtimer_t *timer, uint32_t offset, uint32_t long_offset);
 void _xtimer_sleep(uint32_t offset, uint32_t long_offset);
 /** @} */

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -243,7 +243,7 @@ static inline void _lltimer_set(uint32_t target)
     if (_xtimer_lltimer_mask(target - _xtimer_lltimer_now()) > (_xtimer_lltimer_mask(0xFFFFFFFF)>>1) ) {
         target = _xtimer_lltimer_now() + XTIMER_ISR_BACKOFF;
     }
-    timer_set_absolute(XTIMER, XTIMER_CHAN, _xtimer_lltimer_mask(target));
+    timer_set_absolute(XTIMER_DEV, XTIMER_CHAN, _xtimer_lltimer_mask(target));
 }
 
 static void _update_lltimer(void)

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -25,33 +25,48 @@
 #include "irq.h"
 
 /* WARNING! enabling this will have side effects and can lead to timer underflows. */
-#define ENABLE_DEBUG 0
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static volatile int _in_handler = 0;
+static int _in_handler = 0;
 
 static volatile uint32_t _long_cnt = 0;
+
+static uint32_t _safe_long_cnt(uint32_t now)
+{
+    uint32_t long_value = _long_cnt;
+
+    /* _long_cnt counts half 32bit intervals. so to compensate for a possibly
+     * late overflow interrupt, compare if _long_cnt's LSB and the timer's MSB
+     * match. If (_long_cnt & 1) is set but the timer is already in the next
+     * period ((now >> 32) == 0), the overflow interrupt has been missed.
+     */
+
+    return (long_value >> 1) + ((long_value & 1) && (~now >> 31));
+}
+
 #if XTIMER_MASK
 volatile uint32_t _xtimer_high_cnt = 0;
+#define XTIMER_HALFTICK     (_xtimer_high_cnt & XTIMER_MSBMASK)
+#define XTIMER_LL_HALFTICK  (_xtimer_lltimer_now() & XTIMER_MSBMASK)
+#else
+#define XTIMER_HALFTICK     (_long_cnt & 1)
+#define XTIMER_LL_HALFTICK  (_xtimer_lltimer_now() >> 31)
 #endif
 
-static inline void xtimer_spin_until(uint32_t value);
+#define _NEXT_OVERFLOW_TICK (_xtimer_lltimer_mask(0xFFFFFFFF) >> (!XTIMER_HALFTICK))
 
 static xtimer_t *timer_list_head = NULL;
-static xtimer_t *overflow_list_head = NULL;
-static xtimer_t *long_list_head = NULL;
 
 static void _add_timer_to_list(xtimer_t **list_head, xtimer_t *timer);
-static void _add_timer_to_long_list(xtimer_t **list_head, xtimer_t *timer);
 static void _shoot(xtimer_t *timer);
 static void _remove(xtimer_t *timer);
+static uint32_t _time_left(xtimer_t *timer);
 static inline void _lltimer_set(uint32_t target);
-static uint32_t _time_left(uint32_t target, uint32_t reference);
+static void _update_lltimer(void);
 
 static void _timer_callback(void);
 static void _periph_timer_callback(void *arg, int chan);
-
-static inline int _this_high_period(uint32_t target);
 
 static inline int _is_set(xtimer_t *timer)
 {
@@ -72,23 +87,14 @@ void xtimer_init(void)
     timer_init(XTIMER_DEV, XTIMER_USEC_TO_TICKS(1000000ul), _periph_timer_callback, NULL);
 
     /* register initial overflow tick */
-    _lltimer_set(0xFFFFFFFF);
+    _update_lltimer();
 }
 
 static void _xtimer_now64(uint32_t *short_term, uint32_t *long_term)
 {
-    uint32_t before, after, long_value;
-
-    /* loop to cope with possible overflow of xtimer_now() */
-    do {
-        before = xtimer_now();
-        long_value = _long_cnt;
-        after = xtimer_now();
-
-    } while(before > after);
-
-    *short_term = after;
-    *long_term = long_value;
+    uint32_t short_value = xtimer_now();
+    *short_term = short_value;
+    *long_term = _safe_long_cnt(short_value);
 }
 
 uint64_t xtimer_now64(void)
@@ -99,52 +105,50 @@ uint64_t xtimer_now64(void)
     return ((uint64_t)long_term<<32) + short_term;
 }
 
+void xtimer_set(xtimer_t *timer, uint32_t offset)
+{
+    _xtimer_set64(timer, offset, 0);
+}
+
 void _xtimer_set64(xtimer_t *timer, uint32_t offset, uint32_t long_offset)
 {
     DEBUG(" _xtimer_set64() offset=%" PRIu32 " long_offset=%" PRIu32 "\n", offset, long_offset);
-    if (!long_offset) {
-        /* timer fits into the short timer */
-        xtimer_set(timer, (uint32_t) offset);
+    _xtimer_now64(&timer->target, &timer->long_target);
+    timer->target += offset;
+    timer->long_target += long_offset;
+    if (timer->target < offset) {
+        timer->long_target++;
     }
-    else {
-        int state = irq_disable();
-        if (_is_set(timer)) {
-            _remove(timer);
-        }
 
-        _xtimer_now64(&timer->target, &timer->long_target);
-        timer->target += offset;
-        timer->long_target += long_offset;
-        if (timer->target < offset) {
-            timer->long_target++;
-        }
-
-        _add_timer_to_long_list(&long_list_head, timer);
-        irq_restore(state);
-        DEBUG("xtimer_set64(): added longterm timer (long_target=%" PRIu32 " target=%" PRIu32 ")\n",
-                timer->long_target, timer->target);
-    }
+    _xtimer_set_absolute(timer);
 }
 
-void xtimer_set(xtimer_t *timer, uint32_t offset)
+void _xtimer_set_absolute(xtimer_t *timer)
 {
-    DEBUG("timer_set(): offset=%" PRIu32 " now=%" PRIu32 " (%" PRIu32 ")\n", offset, xtimer_now(), _xtimer_lltimer_now());
-    if (!timer->callback) {
-        DEBUG("timer_set(): timer has no callback.\n");
+    DEBUG("timer_set_absolute(): now=%" PRIu32 " target=%" PRIu32 "\n",xtimer_now(), timer->target);
+
+    timer->next = NULL;
+    if (_time_left(timer) < XTIMER_BACKOFF) {
+        while(_time_left(timer));
+        _shoot(timer);
         return;
     }
 
-    xtimer_remove(timer);
+    unsigned state = irq_disable();
+    if (_is_set(timer)) {
+        _remove(timer);
+    }
 
-    if (offset < XTIMER_BACKOFF) {
-        xtimer_spin(offset);
-        _shoot(timer);
+    _add_timer_to_list(&timer_list_head, timer);
+
+    if (timer_list_head == timer) {
+        DEBUG("timer_set_absolute(): timer is new list head. updating lltimer.\n");
+        _update_lltimer();
     }
-    else {
-        uint32_t target = xtimer_now() + offset;
-        _xtimer_set_absolute(timer, target);
-    }
+
+    irq_restore(state);
 }
+
 
 static void _periph_timer_callback(void *arg, int chan)
 {
@@ -158,83 +162,7 @@ static void _shoot(xtimer_t *timer)
     timer->callback(timer->arg);
 }
 
-static inline void _lltimer_set(uint32_t target)
-{
-    if (_in_handler) {
-        return;
-    }
-    DEBUG("_lltimer_set(): setting %" PRIu32 "\n", _xtimer_lltimer_mask(target));
-#ifdef XTIMER_SHIFT
-    target = XTIMER_USEC_TO_TICKS(target);
-    if (!target) {
-        target++;
-    }
-#endif
-    timer_set_absolute(XTIMER_DEV, XTIMER_CHAN, _xtimer_lltimer_mask(target));
-}
-
-int _xtimer_set_absolute(xtimer_t *timer, uint32_t target)
-{
-    uint32_t now = xtimer_now();
-    int res = 0;
-
-    DEBUG("timer_set_absolute(): now=%" PRIu32 " target=%" PRIu32 "\n", now, target);
-
-    timer->next = NULL;
-    if ((target >= now) && ((target - XTIMER_BACKOFF) < now)) {
-        /* backoff */
-        xtimer_spin_until(target + XTIMER_BACKOFF);
-        _shoot(timer);
-        return 0;
-    }
-
-    unsigned state = irq_disable();
-    if (_is_set(timer)) {
-        _remove(timer);
-    }
-
-    timer->target = target;
-    timer->long_target = _long_cnt;
-    if (target < now) {
-        timer->long_target++;
-    }
-
-    if ( (timer->long_target > _long_cnt) || !_this_high_period(target) ) {
-        DEBUG("xtimer_set_absolute(): the timer doesn't fit into the low-level timer's mask.\n");
-        _add_timer_to_long_list(&long_list_head, timer);
-    }
-    else {
-        if (_xtimer_lltimer_mask(now) >= target) {
-            DEBUG("xtimer_set_absolute(): the timer will expire in the next timer period\n");
-            _add_timer_to_list(&overflow_list_head, timer);
-        }
-        else {
-            DEBUG("timer_set_absolute(): timer will expire in this timer period.\n");
-            _add_timer_to_list(&timer_list_head, timer);
-
-            if (timer_list_head == timer) {
-                DEBUG("timer_set_absolute(): timer is new list head. updating lltimer.\n");
-                _lltimer_set(target - XTIMER_OVERHEAD);
-            }
-        }
-    }
-
-    irq_restore(state);
-
-    return res;
-}
-
 static void _add_timer_to_list(xtimer_t **list_head, xtimer_t *timer)
-{
-    while (*list_head && (*list_head)->target <= timer->target) {
-        list_head = &((*list_head)->next);
-    }
-
-    timer->next = *list_head;
-    *list_head = timer;
-}
-
-static void _add_timer_to_long_list(xtimer_t **list_head, xtimer_t *timer)
 {
     while (*list_head
         && (((*list_head)->long_target < timer->long_target)
@@ -262,23 +190,11 @@ static int _remove_timer_from_list(xtimer_t **list_head, xtimer_t *timer)
 static void _remove(xtimer_t *timer)
 {
     if (timer_list_head == timer) {
-        uint32_t next;
         timer_list_head = timer->next;
-        if (timer_list_head) {
-            /* schedule callback on next timer target time */
-            next = timer_list_head->target - XTIMER_OVERHEAD;
-        }
-        else {
-            next = _xtimer_lltimer_mask(0xFFFFFFFF);
-        }
-        _lltimer_set(next);
+        _update_lltimer();
     }
     else {
-        if (!_remove_timer_from_list(&timer_list_head, timer)) {
-            if (!_remove_timer_from_list(&overflow_list_head, timer)) {
-                _remove_timer_from_list(&long_list_head, timer);
-            }
-        }
+        _remove_timer_from_list(&timer_list_head, timer);
     }
 }
 
@@ -291,143 +207,83 @@ void xtimer_remove(xtimer_t *timer)
     irq_restore(state);
 }
 
-static uint32_t _time_left(uint32_t target, uint32_t reference)
+static uint32_t _time_left(xtimer_t *timer)
 {
-    uint32_t now = _xtimer_lltimer_now();
+    uint32_t short_now, long_now, result;
+    _xtimer_now64(&short_now, &long_now);
 
-    if (now < reference) {
+    if (timer->long_target < long_now) {
         return 0;
     }
 
-    if (target > now) {
-        return target - now;
+    if (timer->long_target > long_now) {
+        return 0xffffffff;
+    }
+
+    result = timer->target - short_now;
+    if (result > timer->target) {
+        return 0;
     }
     else {
-        return 0;
+        return result;
     }
 }
 
-static inline int _this_high_period(uint32_t target) {
-#if XTIMER_MASK
-    return (target & XTIMER_MASK_SHIFTED) == _xtimer_high_cnt;
-#else
-    (void)target;
-    return 1;
+static inline void _lltimer_set(uint32_t target)
+{
+    if (_in_handler) {
+        return;
+    }
+#ifdef XTIMER_SHIFT
+    target = XTIMER_USEC_TO_TICKS(target);
+    if (!target) {
+        target++;
+    }
 #endif
+    if (_xtimer_lltimer_mask(target - _xtimer_lltimer_now()) > (_xtimer_lltimer_mask(0xFFFFFFFF)>>1) ) {
+        target = _xtimer_lltimer_now() + XTIMER_ISR_BACKOFF;
+    }
+    timer_set_absolute(XTIMER, XTIMER_CHAN, _xtimer_lltimer_mask(target));
 }
 
-/**
- * @brief compare two timers' target values, return the one with lower value.
- *
- * if either is NULL, return the other.
- * if both are NULL, return NULL.
- */
-static inline xtimer_t *_compare(xtimer_t *a, xtimer_t *b)
+static void _update_lltimer(void)
 {
-    if (a && b) {
-        return ((a->target <= b->target) ? a : b);
-    }
-    else {
-        return (a ? a : b);
-    }
-}
+    uint32_t next_target = _NEXT_OVERFLOW_TICK;
 
-/**
- * @brief merge two timer lists, return head of new list
- */
-static xtimer_t *_merge_lists(xtimer_t *head_a, xtimer_t *head_b)
-{
-    xtimer_t *result_head = _compare(head_a, head_b);
-    xtimer_t *pos = result_head;
-
-    while(1) {
-        head_a = head_a->next;
-        head_b = head_b->next;
-        if (!head_a) {
-            pos->next = head_b;
-            break;
-        }
-        if (!head_b) {
-            pos->next = head_a;
-            break;
-        }
-
-        pos->next = _compare(head_a, head_b);
-        pos = pos->next;
-    }
-
-    return result_head;
-}
-
-/**
- * @brief parse long timers list and copy those that will expire in the current
- *        short timer period
- */
-static void _select_long_timers(void)
-{
-    xtimer_t *select_list_start = long_list_head;
-    xtimer_t *select_list_last = NULL;
-
-    /* advance long_list head so it points to the first timer of the next (not
-     * just started) "long timer period" */
-    while (long_list_head) {
-        if ((long_list_head->long_target <= _long_cnt) && _this_high_period(long_list_head->target)) {
-            select_list_last = long_list_head;
-            long_list_head = long_list_head->next;
-        }
-        else {
-            /* remaining long_list timers belong to later long periods */
-            break;
-        }
-    }
-
-    /* cut the "selected long timer list" at the end */
-    if (select_list_last) {
-        select_list_last->next = NULL;
-    }
-
-    /* merge "current timer list" and "selected long timer list" */
     if (timer_list_head) {
-        if (select_list_last) {
-            /* both lists are non-empty. merge. */
-            timer_list_head = _merge_lists(timer_list_head, select_list_start);
-        }
-        else {
-            /* "selected long timer list" is empty, nothing to do */
+        uint32_t left = _time_left(timer_list_head);
+        if (left < (_NEXT_OVERFLOW_TICK - _xtimer_lltimer_now())) {
+            /* schedule callback on next timer target time */
+            next_target = _xtimer_lltimer_mask(_xtimer_lltimer_now() + left - XTIMER_OVERHEAD);
         }
     }
-    else { /* current timer list is empty */
-        if (select_list_last) {
-            /* there's no current timer list, but a non-empty "selected long
-             * timer list".  So just use that list as the new current timer
-             * list.*/
-            timer_list_head = select_list_start;
-        }
-    }
+
+    /* set low level timer */
+    _lltimer_set(next_target);
 }
 
 /**
- * @brief handle low-level timer overflow, advance to next short timer period
+ * @brief handle low-level timer half-period, advance to next half period
  */
-static void _next_period(void)
+static void _next_half_period(void)
 {
 #if XTIMER_MASK
-    /* advance <32bit mask register */
-    _xtimer_high_cnt += ~XTIMER_MASK_SHIFTED + 1;
-    if (_xtimer_high_cnt == 0) {
-        /* high_cnt overflowed, so advance >32bit counter */
+    /*
+     * advance <32bit high count variable.
+     * (XTIMER_PERIOD_LENGTH >> 1) evaluates to 0x8000 for 16bit timers
+     * with XTIMER_MASK==0xFFFF.
+     */
+    _xtimer_high_cnt += (XTIMER_PERIOD_LENGTH >> 1);
+
+    if ((_xtimer_high_cnt == 0) || (_xtimer_high_cnt == (1LU << 31))) {
+        /* high_cnt overflowed or reached half 32bit period,
+         * so advance 32bit half-period counter */
         _long_cnt++;
     }
 #else
-    /* advance >32bit counter */
+    /* advance 32bit half-period counter */
     _long_cnt++;
 #endif
-
-    /* swap overflow list to current timer list */
-    timer_list_head = overflow_list_head;
-    overflow_list_head = NULL;
-
-    _select_long_timers();
 }
 
 /**
@@ -435,103 +291,37 @@ static void _next_period(void)
  */
 static void _timer_callback(void)
 {
-    uint32_t next_target;
-    uint32_t reference;
-
+    DEBUG("T: now=%" PRIu32 " (ll=%" PRIu32 ")\n", xtimer_now(), _xtimer_lltimer_now());
     _in_handler = 1;
 
-    DEBUG("_timer_callback() now=%" PRIu32 " (%" PRIu32 ")pleft=%" PRIu32 "\n", xtimer_now(),
-            _xtimer_lltimer_mask(xtimer_now()), _xtimer_lltimer_mask(0xffffffff - xtimer_now()));
+    do {
+        /* check if next timers are close to expiring */
+        while (timer_list_head && (_time_left(timer_list_head) < XTIMER_ISR_BACKOFF)) {
+            /* make sure we don't fire too early */
+            while (_time_left(timer_list_head));
 
-    if (!timer_list_head) {
-        DEBUG("_timer_callback(): tick\n");
-        /* there's no timer for this timer period,
-         * so this was a timer overflow callback.
-         *
-         * In this case, we advance to the next timer period.
-         */
-        _next_period();
+            /* pick first timer in list */
+            xtimer_t *timer = timer_list_head;
 
-        reference = 0;
+            /* advance list */
+            timer_list_head = timer->next;
 
-        /* make sure the timer counter also arrived
-         * in the next timer period */
-        while (_xtimer_lltimer_now() == _xtimer_lltimer_mask(0xFFFFFFFF));
-    }
-    else {
-        /* we ended up in _timer_callback and there is
-         * a timer waiting.
-         */
-        /* set our period reference to the current time. */
-        reference = _xtimer_lltimer_now();
-    }
+            /* make sure timer is recognized as being already fired */
+            timer->target = 0;
+            timer->long_target = 0;
 
-overflow:
-    /* check if next timers are close to expiring */
-    while (timer_list_head && (_time_left(_xtimer_lltimer_mask(timer_list_head->target), reference) < XTIMER_ISR_BACKOFF)) {
-        /* make sure we don't fire too early */
-        while (_time_left(_xtimer_lltimer_mask(timer_list_head->target), reference));
-
-        /* pick first timer in list */
-        xtimer_t *timer = timer_list_head;
-
-        /* advance list */
-        timer_list_head = timer->next;
-
-        /* make sure timer is recognized as being already fired */
-        timer->target = 0;
-        timer->long_target = 0;
-
-        /* fire timer */
-        _shoot(timer);
-    }
-
-    /* possibly executing all callbacks took enough
-     * time to overflow.  In that case we advance to
-     * next timer period and check again for expired
-     * timers.*/
-    if (reference > _xtimer_lltimer_now()) {
-        DEBUG("_timer_callback: overflowed while executing callbacks. %i\n", timer_list_head != 0);
-        _next_period();
-        reference = 0;
-        goto overflow;
-    }
-
-    if (timer_list_head) {
-        /* schedule callback on next timer target time */
-        next_target = timer_list_head->target - XTIMER_OVERHEAD;
-
-        /* make sure we're not setting a time in the past */
-        if (next_target < (_xtimer_lltimer_now() + XTIMER_ISR_BACKOFF)) {
-            goto overflow;
+            /* fire timer */
+            _shoot(timer);
         }
-    }
-    else {
-        /* there's no timer planned for this timer period */
-        /* schedule callback on next overflow */
-        next_target = _xtimer_lltimer_mask(0xFFFFFFFF);
-        uint32_t now = _xtimer_lltimer_now();
 
-        /* check for overflow again */
-        if (now < reference) {
-            _next_period();
-            reference = 0;
-            goto overflow;
+        /* if the saved half-period tick doesn't match the timer value MSB, we
+         * have to advance into the next half-period */
+        if (XTIMER_HALFTICK != XTIMER_LL_HALFTICK) {
+            _next_half_period();
+            continue;
         }
-        else {
-            /* check if the end of this period is very soon */
-            if (_xtimer_lltimer_mask(now + XTIMER_ISR_BACKOFF) < now) {
-                /* spin until next period, then advance */
-                while (_xtimer_lltimer_now() >= now);
-                _next_period();
-                reference = 0;
-                goto overflow;
-            }
-        }
-    }
+    } while(0);
 
     _in_handler = 0;
-
-    /* set low level timer */
-    _lltimer_set(next_target);
+    _update_lltimer();
 }

--- a/tests/driver_bh1750/main.c
+++ b/tests/driver_bh1750/main.c
@@ -29,7 +29,7 @@
 int main(void)
 {
     bh1750fvi_t dev;
-    uint32_t last = xtimer_now();
+    uint64_t last = xtimer_now();
 
     puts("BH1750FVI ambient light sensor test\n");
 

--- a/tests/driver_srf02/main.c
+++ b/tests/driver_srf02/main.c
@@ -75,7 +75,7 @@ static int cmd_sample(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-    uint32_t wakeup = xtimer_now();
+    uint64_t wakeup = xtimer_now();
 
     while(1) {
         sample();

--- a/tests/periph_adc/main.c
+++ b/tests/periph_adc/main.c
@@ -31,7 +31,7 @@
 
 int main(void)
 {
-    uint32_t last = xtimer_now();
+    uint64_t last = xtimer_now();
     int sample = 0;
 
     puts("\nRIOT ADC peripheral driver test\n");

--- a/tests/periph_dac/main.c
+++ b/tests/periph_dac/main.c
@@ -30,7 +30,7 @@
 
 int main(void)
 {
-    uint32_t last = xtimer_now();
+    uint64_t last = xtimer_now();
     uint16_t val = 0;
     uint16_t step = 0xffff / STEPS;
 

--- a/tests/periph_pwm/main.c
+++ b/tests/periph_pwm/main.c
@@ -42,7 +42,7 @@ int main(void)
 {
     int state = 0;
     int step = STEP;
-    uint32_t last_wakeup = xtimer_now();
+    uint64_t last_wakeup = xtimer_now();
 
     puts("\nRIOT PWM test");
     puts("Connect an LED or scope to PWM pins to see something\n");

--- a/tests/saul/main.c
+++ b/tests/saul/main.c
@@ -32,7 +32,7 @@
 int main(void)
 {
     phydat_t res;
-    uint32_t last = xtimer_now();
+    uint64_t last = xtimer_now();
 
     puts("SAUL test application");
 

--- a/tests/xtimer_drift/main.c
+++ b/tests/xtimer_drift/main.c
@@ -190,7 +190,7 @@ int main(void)
                    NULL,
                    "worker");
 
-    uint32_t last_wakeup = xtimer_now();
+    uint64_t last_wakeup = xtimer_now();
     while (1) {
         xtimer_periodic_wakeup(&last_wakeup, TEST_INTERVAL);
         msg_try_send(&m, pid3);

--- a/tests/xtimer_longterm/main.c
+++ b/tests/xtimer_longterm/main.c
@@ -96,7 +96,7 @@ void *mid_sleep(void *arg)
 void *ticker(void *arg)
 {
     (void)arg;
-    uint32_t base = xtimer_now();
+    uint64_t base = xtimer_now();
 
     while (1) {
         ++short_ticks;

--- a/tests/xtimer_now64_continuity/Makefile
+++ b/tests/xtimer_now64_continuity/Makefile
@@ -1,6 +1,6 @@
 export APPLICATION = xtimer_now64_continuity
 include ../Makefile.tests_common
 
-USEMODULE += xtimer
+USEMODULE += xtimer fmt
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_now64_continuity/main.c
+++ b/tests/xtimer_now64_continuity/main.c
@@ -22,28 +22,30 @@
 #include <stdint.h>
 
 #include "xtimer.h"
-
-#define ITERATIONS (100000LU)
-#define MAXDIFF 1000
+#include "fmt.h"
+#include "irq.h"
 
 int main(void)
 {
-    uint32_t n = ITERATIONS;
-    uint64_t now;
-    uint64_t before = xtimer_now64();
+    uint32_t before = xtimer_now();
+    uint32_t now;
 
-    while(--n) {
-        now = xtimer_now64();
-        if ((now-before) > MAXDIFF) {
+    print_u32_hex(XTIMER_MSBMASK);
+    print_u32_hex(XTIMER_MSBMASK);
+    puts("");
+
+    do {
+        now = xtimer_now();
+        irq_disable();
+        print_u32_hex(now);
+        puts("");
+        if (now < before) {
             puts("TEST FAILED.");
             break;
         }
         before = now;
-    }
-
-    if (!n) {
-        puts("TEST SUCCESSFUL.");
-    }
+        irq_enable();
+    } while(1);
 
     return 0;
 }

--- a/tests/xtimer_periodic_wakeup/main.c
+++ b/tests/xtimer_periodic_wakeup/main.c
@@ -39,7 +39,7 @@ int main(void)
     for (int i = 0; i < NUMOF; i++) {
         uint32_t now = xtimer_now();
         printf("Testing interval %" PRIu32 "... (now=%" PRIu32 ")\n", interval, now);
-        uint32_t last_wakeup = xtimer_now();
+        uint64_t last_wakeup = xtimer_now();
         uint32_t before = last_wakeup;
         xtimer_periodic_wakeup(&last_wakeup, interval);
         now = xtimer_now();


### PR DESCRIPTION
I started making xtimer ISR-safe, ended up refactoring and simplifying a lot.

Changes:
- xtimer now "ticks" twice per timer period instead of once
- _long_cnt and _high_cnt are now based on half periods, share one bit with the actual timer's MSB
- xtimer_now() and xtimer_now64() use bit fiddling to compensate for a missed timer tick
- dropped overflow_list and long_list. all timers end up in the same.
- xtimer_set\* now all use _xtimer_set64()
- now that we're using half-ticks, it is possible to detect underflows previously causing a hang -> timers setting a time in the past (using _xtimer_set_absolute() or by underflows) get triggered right away

Marked as API change as xtimer_usleep_until() now takes a 64bit state argument.
Marked WIP as it has only seen brief testing on native, samr21, msb-430h.

What do you think?

Fixes #4902.
